### PR TITLE
set sizeimage and default channel in VFE

### DIFF
--- a/patch/kernel/sun8i-default/vfe-set-channel-sizeimage.patch
+++ b/patch/kernel/sun8i-default/vfe-set-channel-sizeimage.patch
@@ -1,0 +1,37 @@
+diff --git a/drivers/media/video/sunxi-vfe/vfe.c b/drivers/media/video/sunxi-vfe/vfe.c
+index 1d518924..a3a8ab33 100755
+--- a/drivers/media/video/sunxi-vfe/vfe.c
++++ b/drivers/media/video/sunxi-vfe/vfe.c
+@@ -2047,10 +2047,12 @@ static enum v4l2_mbus_pixelcode *try_fmt_internal(struct vfe_dev *dev,struct v4l
+ 
+   f->fmt.pix.width = ccm_fmt.width;
+   f->fmt.pix.height = ccm_fmt.height;
++  f->fmt.pix.sizeimage = ccm_fmt.height * f->fmt.pix.bytesperline;
+ 
+   vfe_dbg(0,"bus pixel code = %x at %s\n",*bus_pix_code,__func__);
+   vfe_dbg(0,"pix->width = %d at %s\n",f->fmt.pix.width,__func__);
+   vfe_dbg(0,"pix->height = %d at %s\n",f->fmt.pix.height,__func__);
++  vfe_dbg(0,"pix->sizeimage = %d at %s\n",f->fmt.pix.sizeimage,__func__);
+ 
+   return bus_pix_code;
+ }
+@@ -2108,6 +2110,8 @@ static int vidioc_try_fmt_vid_cap(struct file *file, void *priv,
+ 	return 0;
+ }
+ 
++static int vidioc_s_input(struct file *file, void *priv, unsigned int i);
++
+ static int vidioc_s_fmt_vid_cap(struct file *file, void *priv,
+           struct v4l2_format *f)
+ {
+@@ -2135,6 +2139,10 @@ static int vidioc_s_fmt_vid_cap(struct file *file, void *priv,
+     return -EBUSY;
+   }
+ 
++  if (!dev->vfe_s_input_flag) {
++    vidioc_s_input(file, NULL, 0);
++  }
++
+   mutex_lock(&q->vb_lock);
+ 
+   bus_pix_code = try_fmt_internal(dev,f);


### PR DESCRIPTION
I'm attempting to get gstreamer-1.0 working with a Nano Pi NEO Air and FA's CAM500B.  GStreamer's V4L2 plugin will call S_FMT with `bytesperline` set and expects `sizeimage` to be set accordingly by the driver on return.  

This patch will set sizeimage so that the V4L2 plugin will operate correctly.  The following pipeline lets me stream video with this patch applied:

```
gst-launch-1.0 v4l2src ! 'video/x-raw,format=NV12,width=1280,height=720,framerate=30/1' ! fakesink
```
The patch will also force the V4L channel input to 0 if it hasn't yet been set when S_FMT is called.  This is necessary since not all V4L2 applications will set the channel input if it's not a tuner.