### PR TITLE
Added resolvconf package for correct work of NetworkManager with stat…

### DIFF
--- a/configuration.sh
+++ b/configuration.sh
@@ -105,7 +105,7 @@ PACKAGE_LIST="bc bridge-utils build-essential cpufrequtils device-tree-compiler 
 	iw fake-hwclock wpasupplicant psmisc ntp parted rsync sudo curl linux-base dialog crda \
 	wireless-regdb ncurses-term python3-apt sysfsutils toilet u-boot-tools unattended-upgrades \
 	usbutils wireless-tools console-setup console-common unicode-data openssh-server initramfs-tools \
-	ca-certificates"
+	ca-certificates resolvconf"
 
 # development related packages. remove when they are not needed for building packages in chroot
 PACKAGE_LIST="$PACKAGE_LIST automake libwrap0-dev libssl-dev libusb-dev libusb-1.0-0-dev libnl-3-dev libnl-genl-3-dev"


### PR DESCRIPTION
…ic IP

If I use static IP for eth interfaces, the file /run/resolvconf/resolv.conf does not exist without installing resolvconf package so resolves does not work. I tested this on Debian Jessie. Not sure if resolvconf package would be installed automatically for Ubuntu.

