### PR TITLE
Change links and references to armbian/build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,5 @@ FROM ubuntu:16.04
 RUN apt-get update
 RUN apt-get install -y git build-essential binutils
 WORKDIR /root
-RUN git clone https://github.com/igorpecovnik/lib/
-RUN cp lib/compile.sh .
+RUN git clone https://github.com/armbian/build/
+RUN cp build/compile.sh .

--- a/README-Vagrant.md
+++ b/README-Vagrant.md
@@ -17,7 +17,7 @@ First, you'll need to [install Vagrant](https://www.vagrantup.com/downloads.html
 Now we'll need to [install git](https://git-scm.com/downloads) and clone the Armbian repo. While this might seem obvious, we rely on it being there when we use Vagrant to bring up our guest-build box.
 
 	# Clone the project.
-	git clone --depth 1 https://github.com/igorpecovnik/lib.git lib
+	git clone --depth 1 https://github.com/armbian/build.git build
 
 	# Make the Vagrant box available. This might take a while but only needs to be done once.
 	vagrant box add ubuntu/xenial64
@@ -34,7 +34,7 @@ Before we bring up the box, take note of the [directory structure]( https://docs
 Let's bring the box up. This might take a minute or two depending on your bandwidth and hardware.
 
 	# We have to be in the same directory as the Vagrant file.
-	cd lib
+	cd build
 
 	# And now we simply let vagrant create our box and bring it up. 
 	vagrant up
@@ -50,7 +50,7 @@ The following steps are all run on the *guest* Vagrant created for us.
 Once it's finally up and you're logged in, it works much like any of the other install methods (NOTE: again, these commands are run on the *guest* box).
 
 	# Copy the compile script out of the lib directory to your new home directory.
-	cp lib/compile.sh .
+	cp build/compile.sh .
 
 	# Let's get building!
 	sudo ./compile.sh

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ https://www.armbian.com
 Supported build environments:
 
 - [Ubuntu Xenial 16.04 x64](http://archive.ubuntu.com/ubuntu/dists/xenial-updates/main/installer-amd64/current/images/netboot/mini.iso) guest inside a [VirtualBox](https://www.virtualbox.org/wiki/Downloads) or other virtualization software,
-- [Ubuntu Xenial 16.04 x64](http://archive.ubuntu.com/ubuntu/dists/xenial-updates/main/installer-amd64/current/images/netboot/mini.iso) guest managed by [Vagrant](https://www.vagrantup.com/). This uses Virtualbox (as above) but does so in an easily repeatable way. Please check the [Armbian with Vagrant README](https://github.com/igorpecovnik/lib/blob/master/README-Vagrant.md) for a quick start HOWTO,
-- [Ubuntu Xenial 16.04 x64](http://archive.ubuntu.com/ubuntu/dists/xenial-updates/main/installer-amd64/current/images/netboot/mini.iso) inside a [Docker](https://www.docker.com/), [systemd-nspawn](https://www.freedesktop.org/software/systemd/man/systemd-nspawn.html) or other container environment [(example)](https://github.com/igorpecovnik/lib/pull/255#issuecomment-205045273). Building full OS images inside containers may not work, so this option is mostly for the kernel compilation,
+- [Ubuntu Xenial 16.04 x64](http://archive.ubuntu.com/ubuntu/dists/xenial-updates/main/installer-amd64/current/images/netboot/mini.iso) guest managed by [Vagrant](https://www.vagrantup.com/). This uses Virtualbox (as above) but does so in an easily repeatable way. Please check the [Armbian with Vagrant README](https://github.com/armbian/build/blob/master/README-Vagrant.md) for a quick start HOWTO,
+- [Ubuntu Xenial 16.04 x64](http://archive.ubuntu.com/ubuntu/dists/xenial-updates/main/installer-amd64/current/images/netboot/mini.iso) inside a [Docker](https://www.docker.com/), [systemd-nspawn](https://www.freedesktop.org/software/systemd/man/systemd-nspawn.html) or other container environment [(example)](https://github.com/armbian/build/pull/255#issuecomment-205045273). Building full OS images inside containers may not work, so this option is mostly for the kernel compilation,
 - [Ubuntu Xenial 16.04 x64](http://archive.ubuntu.com/ubuntu/dists/xenial-updates/main/installer-amd64/current/images/netboot/mini.iso) running natively on a dedicated PC or a server,
 - [Ubuntu Trusty 14.04 x64](http://archive.ubuntu.com/ubuntu/dists/trusty-updates/main/installer-amd64/current/images/netboot/mini.iso) may still be used for the kernel compilation but it is not recommended,
 - **20GB disk space** or more and **2GB RAM** or more available for the VM, container or native OS,
@@ -18,8 +18,8 @@ Supported build environments:
 **Execution**
 
 	apt-get -y install git
-	git clone https://github.com/igorpecovnik/lib --depth 1
-	cp lib/compile.sh .
+	git clone https://github.com/armbian/build --depth 1
+	cp build/compile.sh .
 	./compile.sh
 
 You will be prompted with a selection menu for a build option, a board name, a kernel branch and an OS release. Please check the documentation for [advanced options](https://docs.armbian.com/Developer-Guide_Build-Options/) and [additional customization](https://docs.armbian.com/Developer-Guide_User-Configurations/).
@@ -40,11 +40,11 @@ to display the kernel configuration menu during the compilation process
 
 ## Reporting issues
 
-Please read [this](https://github.com/igorpecovnik/lib/blob/master/.github/ISSUE_TEMPLATE.md) notice first before opening an issue.
+Please read [this](https://github.com/armbian/build/blob/master/.github/ISSUE_TEMPLATE.md) notice first before opening an issue.
 
 ## More info:
 
 - [Documentation](https://docs.armbian.com/Developer-Guide_Build-Preparation/)
 - [Prebuilt images](https://www.armbian.com/download/)
 - [Support forums](https://forum.armbian.com/ "Armbian support forum")
-- [Project at Github](https://github.com/igorpecovnik/lib)
+- [Project at Github](https://github.com/armbian/build)

--- a/build-all.sh
+++ b/build-all.sh
@@ -6,11 +6,11 @@
 # License version 2. This program is licensed "as is" without any
 # warranty of any kind, whether express or implied.
 #
-# This file is a part of tool chain https://github.com/igorpecovnik/lib
+# This file is a part of tool chain https://github.com/armbian/build
 #
 
 # Include here to make "display_alert" and "prepare_host" available
-source $SRC/lib/general.sh
+source $SRC/build/general.sh
 
 # Script parameters handling
 for i in "$@"; do
@@ -69,7 +69,7 @@ rm -r $CACHEDIR/$DESTIMG" &
 build_main ()
 {
 touch "/run/armbian/Armbian_${BOARD^}_${BRANCH}_${RELEASE}_${BUILD_DESKTOP}.pid";
-source $SRC/lib/main.sh;
+source $SRC/build/main.sh;
 [[ $KERNEL_ONLY != yes ]] && pack_upload
 rm "/run/armbian/Armbian_${BOARD^}_${BRANCH}_${RELEASE}_${BUILD_DESKTOP}.pid"
 }
@@ -80,9 +80,9 @@ create_images_list()
 	#
 	# if parameter is true, than we build beta list
 	#
-	for board in $SRC/lib/config/boards/*.conf; do
+	for board in $SRC/build/config/boards/*.conf; do
 		BOARD=$(basename $board | cut -d'.' -f1)
-		source $SRC/lib/config/boards/$BOARD.conf
+		source $SRC/build/config/boards/$BOARD.conf
 		if [[ -n $CLI_TARGET && -z $1 ]]; then
 
 			# RELEASES : BRANCHES
@@ -161,9 +161,9 @@ create_images_list()
 
 create_kernels_list()
 {
-	for board in $SRC/lib/config/boards/*.conf; do
+	for board in $SRC/build/config/boards/*.conf; do
 		BOARD=$(basename $board | cut -d'.' -f1)
-		source $SRC/lib/config/boards/$BOARD.conf
+		source $SRC/build/config/boards/$BOARD.conf
 		if [[ -n $KERNEL_TARGET ]]; then
 			for kernel in $(tr ',' ' ' <<< $KERNEL_TARGET); do
 				buildlist+=("$BOARD $kernel")

--- a/chroot-buildpackages.sh
+++ b/chroot-buildpackages.sh
@@ -6,7 +6,7 @@
 # License version 2. This program is licensed "as is" without any
 # warranty of any kind, whether express or implied.
 #
-# This file is a part of tool chain https://github.com/igorpecovnik/lib
+# This file is a part of tool chain https://github.com/armbian/build
 #
 # Functions:
 # create_chroot
@@ -131,7 +131,7 @@ chroot_build_packages()
 				date +%s > $t
 			fi
 
-			for plugin in $SRC/lib/extras-buildpkgs/*.conf; do
+			for plugin in $SRC/build/extras-buildpkgs/*.conf; do
 				unset package_name package_repo package_ref package_builddeps package_install_chroot package_install_target \
 					package_upstream_version needs_building plugin_target_dir package_component package_builddeps_${release}
 				source $plugin
@@ -227,7 +227,7 @@ chroot_build_packages()
 
 				fetch_from_repo "$package_repo" "extra/$package_name" "$package_ref"
 
-				eval systemd-nspawn -a -q -D $target_dir --tmpfs=/root/build --tmpfs=/tmp:mode=777 --bind-ro $SRC/lib/extras-buildpkgs/:/root/overlay \
+				eval systemd-nspawn -a -q -D $target_dir --tmpfs=/root/build --tmpfs=/tmp:mode=777 --bind-ro $SRC/build/extras-buildpkgs/:/root/overlay \
 					--bind-ro $SRC/sources/extra/:/root/sources /bin/bash -c "/root/build.sh" 2>&1 \
 					${PROGRESS_LOG_TO_FILE:+' | tee -a $DEST/debug/buildpkg.log'}
 				[[ ${PIPESTATUS[0]} -eq 2 ]] && failed+=("$package_name:$release:$arch")
@@ -249,7 +249,7 @@ chroot_build_packages()
 #
 chroot_installpackages_local()
 {
-	local conf=$SRC/lib/config/aptly-temp.conf
+	local conf=$SRC/build/config/aptly-temp.conf
 	rm -rf /tmp/aptly-temp/
 	mkdir -p /tmp/aptly-temp/
 	aptly -config=$conf repo create temp
@@ -257,11 +257,11 @@ chroot_installpackages_local()
 	aptly -config=$conf repo add temp $DEST/debs/extra/${RELEASE}-desktop/
 	aptly -config=$conf repo add temp $DEST/debs/extra/utils/
 	# -gpg-key="925644A6"
-	aptly -keyring="$SRC/lib/extras-buildpkgs/buildpkg-public.gpg" -secret-keyring="$SRC/lib/extras-buildpkgs/buildpkg.gpg" -batch=true -config=$conf \
+	aptly -keyring="$SRC/build/extras-buildpkgs/buildpkg-public.gpg" -secret-keyring="$SRC/build/extras-buildpkgs/buildpkg.gpg" -batch=true -config=$conf \
 		 -gpg-key="925644A6" -passphrase="testkey1234" -component=temp -distribution=$RELEASE publish repo temp
 	aptly -config=$conf -listen=":8189" serve &
 	local aptly_pid=$!
-	cp $SRC/lib/extras-buildpkgs/buildpkg.key $CACHEDIR/$SDCARD/tmp/buildpkg.key
+	cp $SRC/build/extras-buildpkgs/buildpkg.key $CACHEDIR/$SDCARD/tmp/buildpkg.key
 	cat <<-'EOF' > $CACHEDIR/$SDCARD/etc/apt/preferences.d/90-armbian-temp.pref
 	Package: *
 	Pin: origin "localhost"
@@ -281,7 +281,7 @@ chroot_installpackages()
 	local remote_only=$1
 	local install_list=""
 	display_alert "Installing additional packages" "EXTERNAL_NEW"
-	for plugin in $SRC/lib/extras-buildpkgs/*.conf; do
+	for plugin in $SRC/build/extras-buildpkgs/*.conf; do
 		source $plugin
 		if [[ $(type -t package_checkinstall) == function ]] && package_checkinstall; then
 			install_list="$install_list $package_install_target"

--- a/common.sh
+++ b/common.sh
@@ -6,7 +6,7 @@
 # License version 2. This program is licensed "as is" without any
 # warranty of any kind, whether express or implied.
 #
-# This file is a part of tool chain https://github.com/igorpecovnik/lib
+# This file is a part of tool chain https://github.com/armbian/build
 #
 
 # Functions:
@@ -81,7 +81,7 @@ compile_uboot()
 
 		[[ -f .config ]] && sed -i 's/CONFIG_LOCALVERSION=""/CONFIG_LOCALVERSION="-armbian"/g' .config
 		[[ -f .config ]] && sed -i 's/CONFIG_LOCALVERSION_AUTO=.*/# CONFIG_LOCALVERSION_AUTO is not set/g' .config
-		[[ -f tools/logos/udoo.bmp ]] && cp $SRC/lib/bin/splash/udoo.bmp tools/logos/udoo.bmp
+		[[ -f tools/logos/udoo.bmp ]] && cp $SRC/build/bin/splash/udoo.bmp tools/logos/udoo.bmp
 		touch .scmversion
 
 		# $BOOTDELAY can be set in board family config, ensure autoboot can be stopped even if set to 0
@@ -174,9 +174,9 @@ compile_kernel()
 
 	# this is a patch that Ubuntu Trusty compiler works
 	# TODO: Check if still required
-	if [[ $(patch --dry-run -t -p1 < $SRC/lib/patch/kernel/compiler.patch | grep Reversed) != "" ]]; then
+	if [[ $(patch --dry-run -t -p1 < $SRC/build/patch/kernel/compiler.patch | grep Reversed) != "" ]]; then
 		display_alert "Patching kernel for compiler support"
-		[[ $FORCE_CHECKOUT == yes ]] && patch --batch --silent -t -p1 < $SRC/lib/patch/kernel/compiler.patch >> $DEST/debug/output.log 2>&1
+		[[ $FORCE_CHECKOUT == yes ]] && patch --batch --silent -t -p1 < $SRC/build/patch/kernel/compiler.patch >> $DEST/debug/output.log 2>&1
 	fi
 
 	[[ $FORCE_CHECKOUT == yes ]] && advanced_patch "kernel" "$KERNELPATCHDIR" "$BOARD" "" "$BRANCH" "$LINUXFAMILY-$BRANCH"
@@ -204,12 +204,12 @@ compile_kernel()
 			cp $SRC/userpatches/$LINUXCONFIG.config .config
 		else
 			display_alert "Using kernel config file" "lib/config/kernel/$LINUXCONFIG.config" "info"
-			cp $SRC/lib/config/kernel/$LINUXCONFIG.config .config
+			cp $SRC/build/config/kernel/$LINUXCONFIG.config .config
 		fi
 	fi
 
 	# hack for deb builder. To pack what's missing in headers pack.
-	cp $SRC/lib/patch/misc/headers-debian-byteshift.patch /tmp
+	cp $SRC/build/patch/misc/headers-debian-byteshift.patch /tmp
 
 	export LOCALVERSION="-$LINUXFAMILY"
 
@@ -315,10 +315,10 @@ find_toolchain()
 # $SRC/userpatches/<dest>/<family>/board_<board>
 # $SRC/userpatches/<dest>/<family>/branch_<branch>
 # $SRC/userpatches/<dest>/<family>
-# $SRC/lib/patch/<dest>/<family>/target_<target>
-# $SRC/lib/patch/<dest>/<family>/board_<board>
-# $SRC/lib/patch/<dest>/<family>/branch_<branch>
-# $SRC/lib/patch/<dest>/<family>
+# $SRC/build/patch/<dest>/<family>/target_<target>
+# $SRC/build/patch/<dest>/<family>/board_<board>
+# $SRC/build/patch/<dest>/<family>/branch_<branch>
+# $SRC/build/patch/<dest>/<family>
 #
 advanced_patch()
 {
@@ -338,10 +338,10 @@ advanced_patch()
 		"$SRC/userpatches/$dest/$family/board_${board}:[\e[33mu\e[0m][\e[35mb\e[0m]"
 		"$SRC/userpatches/$dest/$family/branch_${branch}:[\e[33mu\e[0m][\e[33mb\e[0m]"
 		"$SRC/userpatches/$dest/$family:[\e[33mu\e[0m][\e[32mc\e[0m]"
-		"$SRC/lib/patch/$dest/$family/target_${target}:[\e[32ml\e[0m][\e[34mt\e[0m]"
-		"$SRC/lib/patch/$dest/$family/board_${board}:[\e[32ml\e[0m][\e[35mb\e[0m]"
-		"$SRC/lib/patch/$dest/$family/branch_${branch}:[\e[32ml\e[0m][\e[33mb\e[0m]"
-		"$SRC/lib/patch/$dest/$family:[\e[32ml\e[0m][\e[32mc\e[0m]"
+		"$SRC/build/patch/$dest/$family/target_${target}:[\e[32ml\e[0m][\e[34mt\e[0m]"
+		"$SRC/build/patch/$dest/$family/board_${board}:[\e[32ml\e[0m][\e[35mb\e[0m]"
+		"$SRC/build/patch/$dest/$family/branch_${branch}:[\e[32ml\e[0m][\e[33mb\e[0m]"
+		"$SRC/build/patch/$dest/$family:[\e[32ml\e[0m][\e[32mc\e[0m]"
 		)
 
 	# required for "for" command
@@ -402,7 +402,7 @@ install_external_applications()
 #--------------------------------------------------------------------------------------------------------------------------------
 	display_alert "Installing extra applications and drivers" "" "info"
 
-	for plugin in $SRC/lib/extras/*.sh; do
+	for plugin in $SRC/build/extras/*.sh; do
 		source $plugin
 	done
 }

--- a/compile.sh
+++ b/compile.sh
@@ -6,7 +6,7 @@
 # License version 2. This program is licensed "as is" without any
 # warranty of any kind, whether express or implied.
 #
-# This file is a part of tool chain https://github.com/igorpecovnik/lib
+# This file is a part of tool chain https://github.com/armbian/bulid
 #
 #--------------------------------------------------------------------------------------------------------------------------------
 
@@ -37,7 +37,7 @@ MULTITHREAD=""				# build n images at once. For internal use.
 
 # build script version to use
 LIB_TAG=""				# empty for latest version,
-					# one of listed here: https://github.com/igorpecovnik/lib/tags for stable versions,
+					# one of listed here: https://github.com/armbian/build/tags for stable versions,
 					# or commit hash
 #--------------------------------------------------------------------------------------------------------------------------------
 
@@ -64,10 +64,10 @@ fi
 [[ $(dpkg-query -W -f='${db:Status-Abbrev}\n' git 2>/dev/null) != *ii* ]] && \
 	apt-get -qq -y --no-install-recommends install git
 
-if [[ ! -d $SRC/lib ]]; then
-	git clone https://github.com/igorpecovnik/lib
+if [[ ! -d $SRC/build ]]; then
+	git clone https://github.com/armbian/build
 fi
-cd $SRC/lib
+cd $SRC/build
 if [[ ! -f $SRC/.ignore_changes ]]; then
 	echo -e "[\e[0;32m o.k. \x1B[0m] This script will try to update"
 	git pull
@@ -88,9 +88,9 @@ fi
 if [[ $BETA == yes ]]; then SUBREVISION="."$(date --date="tomorrow" +"%y%m%d"); fi
 
 if [[ $BUILD_ALL == yes || $BUILD_ALL == demo ]]; then
-	source $SRC/lib/build-all.sh
+	source $SRC/build/build-all.sh
 else
-	source $SRC/lib/main.sh
+	source $SRC/build/main.sh
 fi
 
 # hook for function to run after build, i.e. to change owner of $SRC

--- a/config/sources/cubox.conf
+++ b/config/sources/cubox.conf
@@ -63,10 +63,10 @@ family_tweaks()
 	# default lirc configuration
 	sed -e 's/DEVICE=""/DEVICE="\/dev\/lirc0"/g' -i $CACHEDIR/$SDCARD/etc/lirc/hardware.conf
 	sed -e 's/DRIVER="UNCONFIGURED"/DRIVER="default"/g' -i $CACHEDIR/$SDCARD/etc/lirc/hardware.conf
-	cp $SRC/lib/config/lirc.conf.cubox-i $CACHEDIR/$SDCARD/etc/lirc/lircd.conf
-	install -m 755 $SRC/lib/bin/brcm_patchram_plus_cubox $CACHEDIR/$SDCARD/usr/local/bin/brcm_patchram_plus
-	cp $SRC/lib/scripts/brcm4330 $CACHEDIR/$SDCARD/etc/default
-	install -m 755 $SRC/lib/scripts/brcm4330-patch $CACHEDIR/$SDCARD/etc/init.d/brcm4330-patch
+	cp $SRC/build/config/lirc.conf.cubox-i $CACHEDIR/$SDCARD/etc/lirc/lircd.conf
+	install -m 755 $SRC/build/bin/brcm_patchram_plus_cubox $CACHEDIR/$SDCARD/usr/local/bin/brcm_patchram_plus
+	cp $SRC/build/scripts/brcm4330 $CACHEDIR/$SDCARD/etc/default
+	install -m 755 $SRC/build/scripts/brcm4330-patch $CACHEDIR/$SDCARD/etc/init.d/brcm4330-patch
 	#chroot $CACHEDIR/$SDCARD /bin/bash -c "LC_ALL=C LANG=C update-rc.d brcm4330-patch defaults>> /dev/null"
 	if [[ $BRANCH == next && -f $CACHEDIR/$SDCARD/boot/boot.cmd ]]; then
 		sed -e 's/console=tty1 //g' -i $CACHEDIR/$SDCARD/boot/boot.cmd

--- a/config/sources/meson.conf
+++ b/config/sources/meson.conf
@@ -40,7 +40,7 @@ write_uboot_platform()
 
 family_tweaks()
 {
-	install -m 755 $SRC/lib/scripts/c1_init.sh $CACHEDIR/$SDCARD/etc/
+	install -m 755 $SRC/build/scripts/c1_init.sh $CACHEDIR/$SDCARD/etc/
 	sed -e 's/exit 0//g' -i $CACHEDIR/$SDCARD/etc/rc.local
 	echo "/etc/c1_init.sh" >> $CACHEDIR/$SDCARD/etc/rc.local
 	echo "exit 0" >> $CACHEDIR/$SDCARD/etc/rc.local

--- a/config/sources/meson64.conf
+++ b/config/sources/meson64.conf
@@ -37,9 +37,9 @@ family_tweaks()
 	sed -i 's/LOAD_MODULES=.*/LOAD_MODULES="true"/' $CACHEDIR/$SDCARD/etc/lirc/hardware.conf
 	sed -i 's/DEVICE=.*/DEVICE="\/dev\/lirc0"/' $CACHEDIR/$SDCARD/etc/lirc/hardware.conf
 	sed -i 's/LIRCD_ARGS=.*/LIRCD_ARGS="--uinput"/' $CACHEDIR/$SDCARD/etc/lirc/hardware.conf
-	cp $SRC/lib/config/lirc.conf.odroidc2 $CACHEDIR/$SDCARD/etc/lirc/lircd.conf
+	cp $SRC/build/config/lirc.conf.odroidc2 $CACHEDIR/$SDCARD/etc/lirc/lircd.conf
 
-	install -m 755 $SRC/lib/scripts/c2_init.sh $CACHEDIR/$SDCARD/etc/
+	install -m 755 $SRC/build/scripts/c2_init.sh $CACHEDIR/$SDCARD/etc/
 	sed -e 's/exit 0//g' -i $CACHEDIR/$SDCARD/etc/rc.local
 	echo "/etc/c2_init.sh" >> $CACHEDIR/$SDCARD/etc/rc.local
 	echo "exit 0" >> $CACHEDIR/$SDCARD/etc/rc.local

--- a/config/sources/odroidc1.conf
+++ b/config/sources/odroidc1.conf
@@ -39,7 +39,7 @@ write_uboot_platform()
 
 family_tweaks()
 {
-	install -m 755 $SRC/lib/scripts/c1_init.sh $CACHEDIR/$SDCARD/usr/local/bin
+	install -m 755 $SRC/build/scripts/c1_init.sh $CACHEDIR/$SDCARD/usr/local/bin
 	# systemd service for c1_init.sh
 	cat <<-EOF > $CACHEDIR/$SDCARD/etc/systemd/system/odroid-c1-hdmi.service
 	[Unit]

--- a/config/sources/odroidc2.conf
+++ b/config/sources/odroidc2.conf
@@ -36,9 +36,9 @@ family_tweaks()
 	sed -i 's/LOAD_MODULES=.*/LOAD_MODULES="true"/' $CACHEDIR/$SDCARD/etc/lirc/hardware.conf
 	sed -i 's/DEVICE=.*/DEVICE="\/dev\/lirc0"/' $CACHEDIR/$SDCARD/etc/lirc/hardware.conf
 	sed -i 's/LIRCD_ARGS=.*/LIRCD_ARGS="--uinput"/' $CACHEDIR/$SDCARD/etc/lirc/hardware.conf
-	cp $SRC/lib/config/lirc.conf.odroidc2 $CACHEDIR/$SDCARD/etc/lirc/lircd.conf
+	cp $SRC/build/config/lirc.conf.odroidc2 $CACHEDIR/$SDCARD/etc/lirc/lircd.conf
 
-	install -m 755 $SRC/lib/scripts/c2_init.sh $CACHEDIR/$SDCARD/usr/local/bin
+	install -m 755 $SRC/build/scripts/c2_init.sh $CACHEDIR/$SDCARD/usr/local/bin
 	# systemd service for c1_init.sh
 	cat <<-EOF > $CACHEDIR/$SDCARD/etc/systemd/system/odroid-c2-hdmi.service
 	[Unit]

--- a/config/sources/rda8810.conf
+++ b/config/sources/rda8810.conf
@@ -32,5 +32,5 @@ write_uboot_platform()
 
 family_tweaks()
 {
-	cp $SRC/lib/bin/rda8810_modem.bin $CACHEDIR/$SDCARD/boot/modem.bin
+	cp $SRC/build/bin/rda8810_modem.bin $CACHEDIR/$SDCARD/boot/modem.bin
 }

--- a/config/sources/rockchip.conf
+++ b/config/sources/rockchip.conf
@@ -1,6 +1,6 @@
 BOOTSCRIPT="boot-rockchip.cmd:boot.cmd"
 BOOTENV_FILE='rockchip-default.txt'
-UBOOT_TARGET_MAP=";;$SRC/lib/bin/rk3288_boot.bin u-boot-dtb.bin spl/u-boot-spl-dtb.bin"
+UBOOT_TARGET_MAP=";;$SRC/build/bin/rk3288_boot.bin u-boot-dtb.bin spl/u-boot-spl-dtb.bin"
 
 UBOOT_USE_GCC='> 6.0'
 

--- a/config/sources/s500.conf
+++ b/config/sources/s500.conf
@@ -14,7 +14,7 @@ case $BOARD in
 	BOOTSOURCE='https://github.com/LeMaker/u-boot-actions'
 	BOOTBRANCH='branch:s500-master'
 	BOOTDIR='u-boot-s500'
-	UBOOT_TARGET_MAP="u-boot-dtb.img;;$SRC/lib/bin/s500-bootloader-guitar.bin u-boot-dtb.img"
+	UBOOT_TARGET_MAP="u-boot-dtb.img;;$SRC/build/bin/s500-bootloader-guitar.bin u-boot-dtb.img"
 	SERIALCON=ttyS3
 	;;
 
@@ -23,7 +23,7 @@ case $BOARD in
 	BOOTBRANCH='branch:merge-20160113'
 	BOOTDIR='u-boot-roseapple'
 	BOOTPATCHDIR='u-boot-roseapple'
-	UBOOT_TARGET_MAP="u-boot-dtb.img;;$SRC/lib/bin/s500-bootloader-roseapple.bin u-boot-dtb.img"
+	UBOOT_TARGET_MAP="u-boot-dtb.img;;$SRC/build/bin/s500-bootloader-roseapple.bin u-boot-dtb.img"
 	SERIALCON=ttyS2
 	;;
 esac
@@ -39,5 +39,5 @@ family_tweaks()
 {
 	printf "blacklist wlan_8723bs_vq0\nblacklist ctp_gslX680\nblacklist ctp_gsl3680\n" > $CACHEDIR/$SDCARD/etc/modprobe.d/blacklist-guitar.conf
 	printf "blacklist gsensor_mir3da\nblacklist gsensor_stk8313\nblacklist gsensor_bma222\nblacklist lightsensor_ltr301\n" >> $CACHEDIR/$SDCARD/etc/modprobe.d/blacklist-guitar.conf
-	gzip < $SRC/lib/bin/udoo.bmp > $CACHEDIR/$SDCARD/boot/boot_logo.bmp.gz
+	gzip < $SRC/build/bin/udoo.bmp > $CACHEDIR/$SDCARD/boot/boot_logo.bmp.gz
 }

--- a/config/sources/sun4i.conf
+++ b/config/sources/sun4i.conf
@@ -31,5 +31,5 @@ family_tweaks()
 	sed -i '1i # Cubietruck automatic lirc device detection by Igor Pecovnik' $CACHEDIR/$SDCARD/etc/lirc/hardware.conf
 	sed -e 's/DEVICE=""/DEVICE="\/dev\/input\/event1"/g' -i $CACHEDIR/$SDCARD/etc/lirc/hardware.conf
 	sed -e 's/DRIVER="UNCONFIGURED"/DRIVER="devinput"/g' -i $CACHEDIR/$SDCARD/etc/lirc/hardware.conf
-	cp $SRC/lib/config/lirc.conf.cubietruck $CACHEDIR/$SDCARD/etc/lirc/lircd.conf
+	cp $SRC/build/config/lirc.conf.cubietruck $CACHEDIR/$SDCARD/etc/lirc/lircd.conf
 }

--- a/config/sources/sun50iw1.conf
+++ b/config/sources/sun50iw1.conf
@@ -45,9 +45,9 @@ family_tweaks()
 	if [[ $BRANCH == default ]]; then
 		mkdir -p $CACHEDIR/$SDCARD/var/lib/alsa/
 		if [[ $BOARD == pinebook-a64 ]]; then
-			cp $SRC/lib/config/asound.state.pinebooka64-default $CACHEDIR/$SDCARD/var/lib/alsa/asound.state
+			cp $SRC/build/config/asound.state.pinebooka64-default $CACHEDIR/$SDCARD/var/lib/alsa/asound.state
 		else
-			cp $SRC/lib/config/asound.state.pine64-default $CACHEDIR/$SDCARD/var/lib/alsa/asound.state
+			cp $SRC/build/config/asound.state.pine64-default $CACHEDIR/$SDCARD/var/lib/alsa/asound.state
 		fi
 	fi
 	if [[ $BRANCH == dev && $BOARD == pine64so ]]; then

--- a/config/sources/sun50iw2.conf
+++ b/config/sources/sun50iw2.conf
@@ -17,5 +17,5 @@ write_uboot_platform()
 family_tweaks()
 {
 	mkdir -p $CACHEDIR/$SDCARD/var/lib/alsa/
-	cp $SRC/lib/config/asound.state.sun50iw2-dev $CACHEDIR/$SDCARD/var/lib/alsa/asound.state
+	cp $SRC/build/config/asound.state.sun50iw2-dev $CACHEDIR/$SDCARD/var/lib/alsa/asound.state
 }

--- a/config/sources/sun7i.conf
+++ b/config/sources/sun7i.conf
@@ -38,9 +38,9 @@ family_tweaks()
 	sed -i '1i # Cubietruck automatic lirc device detection by Igor Pecovnik' $CACHEDIR/$SDCARD/etc/lirc/hardware.conf
 	sed -e 's/DEVICE=""/DEVICE="\/dev\/input\/event1"/g' -i $CACHEDIR/$SDCARD/etc/lirc/hardware.conf
 	sed -e 's/DRIVER="UNCONFIGURED"/DRIVER="devinput"/g' -i $CACHEDIR/$SDCARD/etc/lirc/hardware.conf
-	cp $SRC/lib/config/lirc.conf.cubietruck $CACHEDIR/$SDCARD/etc/lirc/lircd.conf
+	cp $SRC/build/config/lirc.conf.cubietruck $CACHEDIR/$SDCARD/etc/lirc/lircd.conf
 	if [[ $BRANCH == next ]]; then
 		mkdir -p $CACHEDIR/$SDCARD/var/lib/alsa/
-		cp $SRC/lib/config/asound.state.sunxi-next $CACHEDIR/$SDCARD/var/lib/alsa/asound.state
+		cp $SRC/build/config/asound.state.sunxi-next $CACHEDIR/$SDCARD/var/lib/alsa/asound.state
 	fi
 }

--- a/config/sources/sun8i-r40.conf
+++ b/config/sources/sun8i-r40.conf
@@ -25,12 +25,12 @@ family_tweaks()
 	sed -e 's/DEVICE=""/DEVICE="\/dev\/lirc0"/g' -i $CACHEDIR/$SDCARD/etc/lirc/hardware.conf
 	sed -e 's/MODULES=""/MODULES="sunxi_cir"/g' -i $CACHEDIR/$SDCARD/etc/lirc/hardware.conf
 	sed -e 's/DRIVER="UNCONFIGURED"/DRIVER="default"/g' -i $CACHEDIR/$SDCARD/etc/lirc/hardware.conf
-	cp $SRC/lib/config/lirc.conf.cubietruck $CACHEDIR/$SDCARD/etc/lirc/lircd.conf
+	cp $SRC/build/config/lirc.conf.cubietruck $CACHEDIR/$SDCARD/etc/lirc/lircd.conf
 	mkdir -p $CACHEDIR/$SDCARD/var/lib/alsa/
 	if [[ $BRANCH == default ]]; then
-		cp $SRC/lib/config/asound.state.sun8i-default $CACHEDIR/$SDCARD/var/lib/alsa/asound.state
+		cp $SRC/build/config/asound.state.sun8i-default $CACHEDIR/$SDCARD/var/lib/alsa/asound.state
 	else
-		cp $SRC/lib/config/asound.state.sun8i-dev $CACHEDIR/$SDCARD/var/lib/alsa/asound.state
+		cp $SRC/build/config/asound.state.sun8i-dev $CACHEDIR/$SDCARD/var/lib/alsa/asound.state
 	fi
 	# enable serial gadget on OTG port since the board doesn't have Ethernet
 	case ${BOARD} in

--- a/config/sources/sun8i.conf
+++ b/config/sources/sun8i.conf
@@ -7,7 +7,7 @@ case $BRANCH in
 	default)
 	BOOTENV_FILE='sun8i-default.txt'
 
-	KERNELSOURCE='https://github.com/igorpecovnik/linux'
+	KERNELSOURCE='https://github.com/armbian/linux'
 	KERNELBRANCH='branch:sun8i'
 	KERNELDIR='linux-sun8i'
 	;;
@@ -30,12 +30,12 @@ family_tweaks()
 	sed -e 's/DEVICE=""/DEVICE="\/dev\/lirc0"/g' -i $CACHEDIR/$SDCARD/etc/lirc/hardware.conf
 	sed -e 's/MODULES=""/MODULES="sunxi_cir"/g' -i $CACHEDIR/$SDCARD/etc/lirc/hardware.conf
 	sed -e 's/DRIVER="UNCONFIGURED"/DRIVER="default"/g' -i $CACHEDIR/$SDCARD/etc/lirc/hardware.conf
-	cp $SRC/lib/config/lirc.conf.cubietruck $CACHEDIR/$SDCARD/etc/lirc/lircd.conf
+	cp $SRC/build/config/lirc.conf.cubietruck $CACHEDIR/$SDCARD/etc/lirc/lircd.conf
 	mkdir -p $CACHEDIR/$SDCARD/var/lib/alsa/
 	if [[ $BRANCH == default ]]; then
-		cp $SRC/lib/config/asound.state.sun8i-default $CACHEDIR/$SDCARD/var/lib/alsa/asound.state
+		cp $SRC/build/config/asound.state.sun8i-default $CACHEDIR/$SDCARD/var/lib/alsa/asound.state
 	else
-		cp $SRC/lib/config/asound.state.sun8i-dev $CACHEDIR/$SDCARD/var/lib/alsa/asound.state
+		cp $SRC/build/config/asound.state.sun8i-dev $CACHEDIR/$SDCARD/var/lib/alsa/asound.state
 	fi
 	# enable serial gadget on OTG port since the board doesn't have Ethernet
 	case ${BOARD} in

--- a/config/sources/udoo-neo.conf
+++ b/config/sources/udoo-neo.conf
@@ -52,9 +52,9 @@ family_tweaks()
 		sed 's/mmcblk0p1/mmcblk1p1/' -i $CACHEDIR/$SDCARD/etc/fstab
 		# firmware for M4
 		mkdir -p $CACHEDIR/$SDCARD/boot/bin/
-		cp $SRC/lib/bin/m4startup.fw* $CACHEDIR/$SDCARD/boot/bin/
+		cp $SRC/build/bin/m4startup.fw* $CACHEDIR/$SDCARD/boot/bin/
 		# fix for BT
-		cp $SRC/lib/bin/udoo-neo-debs/udooneo-bluetooth_1.2-1_armhf.deb $CACHEDIR/$SDCARD/tmp
+		cp $SRC/build/bin/udoo-neo-debs/udooneo-bluetooth_1.2-1_armhf.deb $CACHEDIR/$SDCARD/tmp
 		chroot $CACHEDIR/$SDCARD /bin/bash -c "dpkg -i /tmp/udooneo-bluetooth_1.2-1_armhf.deb >/dev/null 2>&1"
 	fi
 }

--- a/config/sources/udoo.conf
+++ b/config/sources/udoo.conf
@@ -51,9 +51,9 @@ family_tweaks()
 		sed 's/mmcblk0p1/mmcblk1p1/' -i $CACHEDIR/$SDCARD/etc/fstab
 		# firmware for M4
 		mkdir -p $CACHEDIR/$SDCARD/boot/bin/
-		cp $SRC/lib/bin/m4startup.fw* $CACHEDIR/$SDCARD/boot/bin/
+		cp $SRC/build/bin/m4startup.fw* $CACHEDIR/$SDCARD/boot/bin/
 		# fix for BT
-		cp $SRC/lib/bin/udoo-neo-debs/udooneo-bluetooth_1.2-1_armhf.deb $CACHEDIR/$SDCARD/tmp
+		cp $SRC/build/bin/udoo-neo-debs/udooneo-bluetooth_1.2-1_armhf.deb $CACHEDIR/$SDCARD/tmp
 		chroot $CACHEDIR/$SDCARD /bin/bash -c "dpkg -i /tmp/udooneo-bluetooth_1.2-1_armhf.deb >/dev/null 2>&1"
 	fi
 }

--- a/configuration.sh
+++ b/configuration.sh
@@ -6,7 +6,7 @@
 # License version 2. This program is licensed "as is" without any
 # warranty of any kind, whether express or implied.
 #
-# This file is a part of tool chain https://github.com/igorpecovnik/lib
+# This file is a part of tool chain https://github.com/armbian/build
 #
 
 # common options
@@ -65,10 +65,10 @@ SDCARD="sdcard-${BRANCH}-${BOARD}-${RELEASE}-${BUILD_DESKTOP}"
 MOUNT="mount-${BRANCH}-${BOARD}-${RELEASE}-${BUILD_DESKTOP}"
 DESTIMG="image-${BRANCH}-${BOARD}-${RELEASE}-${BUILD_DESKTOP}"
 
-[[ ! -f $SRC/lib/config/sources/$LINUXFAMILY.conf ]] && \
+[[ ! -f $SRC/build/config/sources/$LINUXFAMILY.conf ]] && \
 	exit_with_error "Sources configuration not found" "$LINUXFAMILY"
 
-source $SRC/lib/config/sources/$LINUXFAMILY.conf
+source $SRC/build/config/sources/$LINUXFAMILY.conf
 
 if [[ -f $SRC/userpatches/sources/$LINUXFAMILY.conf ]]; then
 	display_alert "Adding user provided $LINUXFAMILY overrides"
@@ -169,7 +169,7 @@ fi
 cat <<-EOF >> $DEST/debug/output.log
 ## BUILD SCRIPT ENVIRONMENT
 
-Version: $(cd $SRC/lib; git rev-parse @)
+Version: $(cd $SRC/build; git rev-parse @)
 
 ## BUILD CONFIGURATION
 

--- a/debootstrap-ng.sh
+++ b/debootstrap-ng.sh
@@ -4,7 +4,7 @@
 # License version 2. This program is licensed "as is" without any
 # warranty of any kind, whether express or implied.
 #
-# This file is a part of tool chain https://github.com/igorpecovnik/lib
+# This file is a part of tool chain https://github.com/armbian/build
 #
 
 # Functions:
@@ -84,7 +84,7 @@ debootstrap_ng()
 	if [[ $ROOTFS_TYPE == fel ]]; then
 		FEL_ROOTFS=$CACHEDIR/$SDCARD/
 		display_alert "Starting FEL boot" "$BOARD" "info"
-		source $SRC/lib/fel-load.sh
+		source $SRC/build/fel-load.sh
 	else
 		prepare_partitions
 		create_image
@@ -181,7 +181,7 @@ create_rootfs_cache()
 		# stage: add armbian repository and install key
 		echo "deb http://apt.armbian.com $RELEASE main utils ${RELEASE}-desktop" > $CACHEDIR/$SDCARD/etc/apt/sources.list.d/armbian.list
 
-		cp $SRC/lib/bin/armbian.key $CACHEDIR/$SDCARD
+		cp $SRC/build/bin/armbian.key $CACHEDIR/$SDCARD
 		eval 'chroot $CACHEDIR/$SDCARD /bin/bash -c "cat armbian.key | apt-key add -"' \
 			${OUTPUT_VERYSILENT:+' >/dev/null 2>/dev/null'}
 		rm $CACHEDIR/$SDCARD/armbian.key

--- a/desktop.sh
+++ b/desktop.sh
@@ -6,7 +6,7 @@
 # License version 2. This program is licensed "as is" without any
 # warranty of any kind, whether express or implied.
 #
-# This file is a part of tool chain https://github.com/igorpecovnik/lib
+# This file is a part of tool chain https://github.com/armbian/build
 #
 
 install_desktop ()
@@ -14,27 +14,27 @@ install_desktop ()
 	display_alert "Installing desktop" "XFCE" "info"
 
 	mkdir -p $CACHEDIR/$SDCARD/tmp/bin
-	mount --bind $SRC/lib/bin/ $CACHEDIR/$SDCARD/tmp/bin
+	mount --bind $SRC/build/bin/ $CACHEDIR/$SDCARD/tmp/bin
 
 	# add loading desktop splash service
-	cp $SRC/lib/scripts/desktop-splash/desktop-splash.service $CACHEDIR/$SDCARD/etc/systemd/system/desktop-splash.service
+	cp $SRC/build/scripts/desktop-splash/desktop-splash.service $CACHEDIR/$SDCARD/etc/systemd/system/desktop-splash.service
 
 	if [[ $RELEASE == xenial ]]; then
 		# install optimized firefox configuration
-		cp $SRC/lib/config/firefox.conf $CACHEDIR/$SDCARD/etc/firefox/syspref.js
+		cp $SRC/build/config/firefox.conf $CACHEDIR/$SDCARD/etc/firefox/syspref.js
 	fi
 	# install dedicated startup icons
-	cp $SRC/lib/bin/icons/${RELEASE}.png $CACHEDIR/$SDCARD/usr/share/pixmaps
+	cp $SRC/build/bin/icons/${RELEASE}.png $CACHEDIR/$SDCARD/usr/share/pixmaps
 
 	# install default desktop settings
-	cp -R $SRC/lib/config/desktop/. $CACHEDIR/$SDCARD/etc/skel
-	cp -R $SRC/lib/config/desktop/. $CACHEDIR/$SDCARD/root
+	cp -R $SRC/build/config/desktop/. $CACHEDIR/$SDCARD/etc/skel
+	cp -R $SRC/build/config/desktop/. $CACHEDIR/$SDCARD/root
 
 	# install wallpapers
 	d=$CACHEDIR/$SDCARD/usr/share/backgrounds/xfce/
-	test -d "$d" || mkdir -p "$d" && cp $SRC/lib/bin/wallpapers/armbian*.jpg "$d"
+	test -d "$d" || mkdir -p "$d" && cp $SRC/build/bin/wallpapers/armbian*.jpg "$d"
 	mkdir -p $CACHEDIR/$SDCARD/etc/polkit-1/localauthority/50-local.d
-	cp $SRC/lib/config/polkit-jessie/*.pkla $CACHEDIR/$SDCARD/etc/polkit-1/localauthority/50-local.d/
+	cp $SRC/build/config/polkit-jessie/*.pkla $CACHEDIR/$SDCARD/etc/polkit-1/localauthority/50-local.d/
 
 	# Install custom icons and theme
 	chroot $CACHEDIR/$SDCARD /bin/bash -c "dpkg -i /tmp/bin/vibrancy-colors_2.4-trusty-Noobslab.com_all.deb >/dev/null 2>&1"

--- a/distributions.sh
+++ b/distributions.sh
@@ -6,7 +6,7 @@
 # License version 2. This program is licensed "as is" without any
 # warranty of any kind, whether express or implied.
 #
-# This file is a part of tool chain https://github.com/igorpecovnik/lib
+# This file is a part of tool chain https://github.com/armbian/build
 #
 # Functions:
 # install_common
@@ -62,10 +62,10 @@ install_common()
 	# NOTE: this needs to be executed before family_tweaks
 	local bootscript_src=${BOOTSCRIPT%%:*}
 	local bootscript_dst=${BOOTSCRIPT##*:}
-	cp $SRC/lib/config/bootscripts/$bootscript_src $CACHEDIR/$SDCARD/boot/$bootscript_dst
+	cp $SRC/build/config/bootscripts/$bootscript_src $CACHEDIR/$SDCARD/boot/$bootscript_dst
 
-	[[ -n $BOOTENV_FILE && -f $SRC/lib/config/bootenv/$BOOTENV_FILE ]] && \
-		cp $SRC/lib/config/bootenv/$BOOTENV_FILE $CACHEDIR/$SDCARD/boot/armbianEnv.txt
+	[[ -n $BOOTENV_FILE && -f $SRC/build/config/bootenv/$BOOTENV_FILE ]] && \
+		cp $SRC/build/config/bootenv/$BOOTENV_FILE $CACHEDIR/$SDCARD/boot/armbianEnv.txt
 
 	# TODO: modify $bootscript_dst or armbianEnv.txt to make NFS boot universal
 	# instead of copying sunxi-specific template
@@ -74,7 +74,7 @@ install_common()
 		if [[ -f $SRC/userpatches/nfs-boot.cmd ]]; then
 			cp $SRC/userpatches/nfs-boot.cmd $CACHEDIR/$SDCARD/boot/boot.cmd
 		else
-			cp $SRC/lib/scripts/nfs-boot.cmd.template $CACHEDIR/$SDCARD/boot/boot.cmd
+			cp $SRC/build/scripts/nfs-boot.cmd.template $CACHEDIR/$SDCARD/boot/boot.cmd
 		fi
 	fi
 
@@ -126,22 +126,22 @@ install_common()
 	chroot $CACHEDIR/$SDCARD /bin/bash -c "dpkg -i /tmp/debs/$RELEASE/${CHOSEN_ROOTFS}_${REVISION}_${ARCH}.deb" >> $DEST/debug/install.log 2>&1
 
 	# copy boot splash images
-	cp $SRC/lib/bin/splash/armbian-u-boot.bmp $CACHEDIR/$SDCARD/boot/boot.bmp
-	cp $SRC/lib/bin/splash/armbian-desktop.png $CACHEDIR/$SDCARD/boot/boot-desktop.png
+	cp $SRC/build/bin/splash/armbian-u-boot.bmp $CACHEDIR/$SDCARD/boot/boot.bmp
+	cp $SRC/build/bin/splash/armbian-desktop.png $CACHEDIR/$SDCARD/boot/boot-desktop.png
 
 	# execute $LINUXFAMILY-specific tweaks from $BOARD.conf
 	[[ $(type -t family_tweaks) == function ]] && family_tweaks
 
-	install -m 755 $SRC/lib/scripts/resize2fs $CACHEDIR/$SDCARD/etc/init.d/
-	install -m 755 $SRC/lib/scripts/firstrun  $CACHEDIR/$SDCARD/etc/init.d/
-	install -m 644 $SRC/lib/scripts/resize2fs.service $CACHEDIR/$SDCARD/etc/systemd/system/
-	install -m 644 $SRC/lib/scripts/firstrun.service $CACHEDIR/$SDCARD/etc/systemd/system/
+	install -m 755 $SRC/build/scripts/resize2fs $CACHEDIR/$SDCARD/etc/init.d/
+	install -m 755 $SRC/build/scripts/firstrun  $CACHEDIR/$SDCARD/etc/init.d/
+	install -m 644 $SRC/build/scripts/resize2fs.service $CACHEDIR/$SDCARD/etc/systemd/system/
+	install -m 644 $SRC/build/scripts/firstrun.service $CACHEDIR/$SDCARD/etc/systemd/system/
 
 	# enable additional services
 	chroot $CACHEDIR/$SDCARD /bin/bash -c "systemctl --no-reload enable firstrun.service resize2fs.service armhwinfo.service log2ram.service >/dev/null 2>&1"
 
 	# copy "first run automated config, optional user configured"
- 	cp $SRC/lib/config/armbian_first_run.txt $CACHEDIR/$SDCARD/boot/armbian_first_run.txt
+ 	cp $SRC/build/config/armbian_first_run.txt $CACHEDIR/$SDCARD/boot/armbian_first_run.txt
 
 	# switch to beta repository at this stage if building nightly images
 	[[ $IMAGE_TYPE == nightly ]] && echo "deb http://beta.armbian.com $RELEASE main utils ${RELEASE}-desktop" > $CACHEDIR/$SDCARD/etc/apt/sources.list.d/armbian.list
@@ -164,7 +164,7 @@ install_common()
 
 	# handle PMU power button
 	mkdir -p $CACHEDIR/$SDCARD/etc/udev/rules.d/
-	cp $SRC/lib/config/71-axp-power-button.rules $CACHEDIR/$SDCARD/etc/udev/rules.d/
+	cp $SRC/build/config/71-axp-power-button.rules $CACHEDIR/$SDCARD/etc/udev/rules.d/
 
 	[[ $LINUXFAMILY == sun*i ]] && mkdir -p $CACHEDIR/$SDCARD/boot/overlay-user
 

--- a/extras-buildpkgs/SOURCES
+++ b/extras-buildpkgs/SOURCES
@@ -8,4 +8,4 @@ libump: https://github.com/rellla/libump (http://ppa.launchpad.net/longsleep/ubu
 libvdpau-sunxi: http://ppa.launchpad.net/longsleep/ubuntu-pine64-flavour-makers/ubuntu/pool/main/libv/libvdpau-sunxi/
 sunxi-tools: http://packages.ubuntu.com/ru/xenial/sunxi-tools / http://archive.ubuntu.com/ubuntu/pool/universe/s/sunxi-tools/
 swconfig: https://github.com/jekader/swconfig
-xf86-video-fbturbo: https://github.com/igorpecovnik/lib/pull/384
+xf86-video-fbturbo: https://github.com/armbian/build/pull/384

--- a/extras/firmware.sh
+++ b/extras/firmware.sh
@@ -4,7 +4,7 @@
 # License version 2. This program is licensed "as is" without any
 # warranty of any kind, whether express or implied.
 #
-# This file is a part of tool chain https://github.com/igorpecovnik/lib
+# This file is a part of tool chain https://github.com/armbian/build
 #
 
 build_firmware()
@@ -20,7 +20,7 @@ build_firmware()
 	fi
 	mkdir -p $SOURCES/$plugin_dir/lib/firmware
 	# overlay our firmware
-	cp -R $SRC/lib/bin/firmware-overlay/* $SOURCES/$plugin_dir/lib/firmware
+	cp -R $SRC/build/bin/firmware-overlay/* $SOURCES/$plugin_dir/lib/firmware
 
 	# cleanup what's not needed for sure
 	rm -rf $SOURCES/$plugin_dir/lib/firmware/{amdgpu,amd-ucode,radeon,nvidia,matrox,.git}

--- a/extras/mt7601.sh
+++ b/extras/mt7601.sh
@@ -4,7 +4,7 @@
 # License version 2. This program is licensed "as is" without any
 # warranty of any kind, whether express or implied.
 #
-# This file is a part of tool chain https://github.com/igorpecovnik/lib
+# This file is a part of tool chain https://github.com/armbian/build
 #
 
 install_mt7601()

--- a/extras/rtl8192cu.sh
+++ b/extras/rtl8192cu.sh
@@ -4,7 +4,7 @@
 # License version 2. This program is licensed "as is" without any
 # warranty of any kind, whether express or implied.
 #
-# This file is a part of tool chain https://github.com/igorpecovnik/lib
+# This file is a part of tool chain https://github.com/armbian/build
 #
 
 # NOTE: NEeds gcc5 specific fixes like other wireless drivers

--- a/extras/tools.sh
+++ b/extras/tools.sh
@@ -6,7 +6,7 @@
 # License version 2. This program is licensed "as is" without any
 # warranty of any kind, whether express or implied.
 #
-# This file is a part of tool chain https://github.com/igorpecovnik/lib
+# This file is a part of tool chain https://github.com/armbian/build
 #
 
 compile_tools()
@@ -47,12 +47,12 @@ compile_tools()
 		# brcm
 		cp $tmpdir/brcm/{brcm_bt_reset,brcm_patchram_plus} $tmpdir/armbian-tools-${RELEASE}_${REVISION}_${ARCH}/usr/bin
 		# brcm configs and service
-		install -m 644 $SRC/lib/scripts/brcm40183					$tmpdir/armbian-tools-${RELEASE}_${REVISION}_${ARCH}/etc/default
-		install -m 755	$SRC/lib/scripts/brcm40183-patch			$tmpdir/armbian-tools-${RELEASE}_${REVISION}_${ARCH}/etc/init.d
+		install -m 644 $SRC/build/scripts/brcm40183					$tmpdir/armbian-tools-${RELEASE}_${REVISION}_${ARCH}/etc/default
+		install -m 755	$SRC/build/scripts/brcm40183-patch			$tmpdir/armbian-tools-${RELEASE}_${REVISION}_${ARCH}/etc/init.d
 		
 		# ap6212 configs and service
-		install -m 644 $SRC/lib/scripts/ap6212						$tmpdir/armbian-tools-${RELEASE}_${REVISION}_${ARCH}/etc/default
-		install -m 755 $SRC/lib/scripts/ap6212-bluetooth			$tmpdir/armbian-tools-${RELEASE}_${REVISION}_${ARCH}/etc/init.d
+		install -m 644 $SRC/build/scripts/ap6212						$tmpdir/armbian-tools-${RELEASE}_${REVISION}_${ARCH}/etc/default
+		install -m 755 $SRC/build/scripts/ap6212-bluetooth			$tmpdir/armbian-tools-${RELEASE}_${REVISION}_${ARCH}/etc/init.d
 		
 		cd $tmpdir/armbian-tools-${RELEASE}_${REVISION}_${ARCH}
 		find . -type f ! -regex '.*.hg.*' ! -regex '.*?debian-binary.*' ! -regex '.*?DEBIAN.*' -printf '%P ' | xargs md5sum > DEBIAN/md5sums

--- a/extras/usb-redirector.sh
+++ b/extras/usb-redirector.sh
@@ -4,7 +4,7 @@
 # License version 2. This program is licensed "as is" without any
 # warranty of any kind, whether express or implied.
 #
-# This file is a part of tool chain https://github.com/igorpecovnik/lib
+# This file is a part of tool chain https://github.com/armbian/build
 #
 
 # USB redirector tools http://www.incentivespro.com
@@ -22,7 +22,7 @@ install_usb_redirector()
 			EXTRA_BUILD_FLAGS=""
 		fi
 	else
-		cp $SRC/lib/bin/usb-redirector-old.tgz usb-redirector-linux-arm-eabi.tar.gz
+		cp $SRC/build/bin/usb-redirector-old.tgz usb-redirector-linux-arm-eabi.tar.gz
 	fi
 	
 	tar xfz usb-redirector-linux-arm-eabi.tar.gz

--- a/fel-load.sh
+++ b/fel-load.sh
@@ -6,7 +6,7 @@
 # License version 2. This program is licensed "as is" without any
 # warranty of any kind, whether express or implied.
 #
-# This file is a part of tool chain https://github.com/igorpecovnik/lib
+# This file is a part of tool chain https://github.com/armbian/build
 #
 
 # FEL_ROOTFS should be set to path to debootstrapped root filesystem
@@ -28,7 +28,7 @@ fel_prepare_target()
 		display_alert "Using custom boot script" "userpatches/fel-boot.cmd" "info"
 		cp $SRC/userpatches/fel-boot.cmd $FEL_ROOTFS/boot/boot.cmd
 	else
-		cp $SRC/lib/scripts/fel-boot.cmd.template $FEL_ROOTFS/boot/boot.cmd
+		cp $SRC/build/scripts/fel-boot.cmd.template $FEL_ROOTFS/boot/boot.cmd
 	fi
 	if [[ -z $FEL_LOCAL_IP ]]; then
 		FEL_LOCAL_IP=$(ifconfig $FEL_NET_IFNAME | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p')

--- a/general.sh
+++ b/general.sh
@@ -6,7 +6,7 @@
 # License version 2. This program is licensed "as is" without any
 # warranty of any kind, whether express or implied.
 #
-# This file is a part of tool chain https://github.com/igorpecovnik/lib
+# This file is a part of tool chain https://github.com/armbian/build
 #
 
 # Functions:
@@ -345,12 +345,12 @@ fingerprint_image()
 	Kernel:			Linux $VER
 	Build date:		$(date +'%d.%m.%Y')
 	Authors:		http://www.armbian.com/authors
-	Sources: 		http://github.com/igorpecovnik/lib
+	Sources: 		http://github.com/armbian/build
 	Support: 		http://forum.armbian.com/
 	Changelog: 		http://www.armbian.com/logbook/
 	Documantation:		http://docs.armbian.com/
 	--------------------------------------------------------------------------------
-	$(cat $SRC/lib/LICENSE)
+	$(cat $SRC/build/LICENSE)
 	--------------------------------------------------------------------------------
 	EOF
 }
@@ -541,7 +541,7 @@ prepare_host()
 
 	# create directory structure
 	mkdir -p $SOURCES $DEST/debs/extra $DEST/debug $CACHEDIR/rootfs $SRC/userpatches/{overlay,CREATE_PATCHES} $SRC/toolchains
-	find $SRC/lib/patch -type d ! -name . | sed "s%lib/patch%userpatches%" | xargs mkdir -p
+	find $SRC/build/patch -type d ! -name . | sed "s%lib/patch%userpatches%" | xargs mkdir -p
 
 	# download external Linaro compiler and missing special dependencies since they are needed for certain sources
 	local toolchains=(
@@ -572,7 +572,7 @@ prepare_host()
 		fi
 	done
 
-	[[ ! -f $SRC/userpatches/customize-image.sh ]] && cp $SRC/lib/scripts/customize-image.sh.template $SRC/userpatches/customize-image.sh
+	[[ ! -f $SRC/userpatches/customize-image.sh ]] && cp $SRC/build/scripts/customize-image.sh.template $SRC/userpatches/customize-image.sh
 
 	if [[ ! -f $SRC/userpatches/README ]]; then
 		rm $SRC/userpatches/readme.txt
@@ -605,8 +605,8 @@ download_toolchain()
 	cd $SRC/toolchains/
 
 	display_alert "Downloading" "$dirname"
-	curl -Lf --progress-bar $url -o $filename
-	curl -Lf --progress-bar ${url}.asc -o ${filename}.asc
+	curl -C - -Lf --progress-bar $url -o $filename
+	curl -C - -Lf --progress-bar ${url}.asc -o ${filename}.asc
 
 	local verified=false
 

--- a/main.sh
+++ b/main.sh
@@ -6,7 +6,7 @@
 # License version 2. This program is licensed "as is" without any
 # warranty of any kind, whether express or implied.
 #
-# This file is a part of tool chain https://github.com/igorpecovnik/lib
+# This file is a part of tool chain https://github.com/armbian/build
 #
 #
 # Main program
@@ -30,13 +30,13 @@ backtitle="Armbian building script, http://www.armbian.com | Author: Igor Pecovn
 [[ -z $CONSOLE_CHAR ]] && export CONSOLE_CHAR="UTF-8"
 
 # Load libraries
-source $SRC/lib/debootstrap-ng.sh 			# System specific install
-source $SRC/lib/distributions.sh 			# System specific install
-source $SRC/lib/desktop.sh 				# Desktop specific install
-source $SRC/lib/common.sh 				# Functions
-source $SRC/lib/makeboarddeb.sh 			# Create board support package
-source $SRC/lib/general.sh				# General functions
-source $SRC/lib/chroot-buildpackages.sh			# Building packages in chroot
+source $SRC/build/debootstrap-ng.sh 			# System specific install
+source $SRC/build/distributions.sh 			# System specific install
+source $SRC/build/desktop.sh 				# Desktop specific install
+source $SRC/build/common.sh 				# Functions
+source $SRC/build/makeboarddeb.sh 			# Create board support package
+source $SRC/build/general.sh				# General functions
+source $SRC/build/chroot-buildpackages.sh			# Building packages in chroot
 
 # compress and remove old logs
 mkdir -p $DEST/debug
@@ -48,9 +48,9 @@ date +"%d_%m_%Y-%H_%M_%S" > $DEST/debug/timestamp
 
 # compile.sh version checking
 ver1=$(awk -F"=" '/^# VERSION/ {print $2}' <$SRC/compile.sh )
-ver2=$(awk -F"=" '/^# VERSION/ {print $2}' <$SRC/lib/compile.sh 2>/dev/null) || ver2=0
+ver2=$(awk -F"=" '/^# VERSION/ {print $2}' <$SRC/build/compile.sh 2>/dev/null) || ver2=0
 if [[ $BETA != yes && ( -z $ver1 || $ver1 -lt $ver2 ) ]]; then
-	display_alert "File $0 is outdated. Please overwrite it with an updated version from" "$SRC/lib" "wrn"
+	display_alert "File $0 is outdated. Please overwrite it with an updated version from" "$SRC/build" "wrn"
 	echo -e "Press \e[0;33m<Ctrl-C>\x1B[0m to abort compilation, \e[0;33m<Enter>\x1B[0m to ignore and continue"
 	read
 fi
@@ -114,10 +114,10 @@ EXT='conf'
 if [[ -z $BOARD ]]; then
 	WIP_STATE='supported'
 	WIP_BUTTON='WIP'
-	[[ -n $(find $SRC/lib/config/boards/ -name '*.wip' -print -quit) ]] && DIALOG_EXTRA="--extra-button"
+	[[ -n $(find $SRC/build/config/boards/ -name '*.wip' -print -quit) ]] && DIALOG_EXTRA="--extra-button"
 	while true; do
 		options=()
-		for board in $SRC/lib/config/boards/*.${EXT}; do
+		for board in $SRC/build/config/boards/*.${EXT}; do
 			options+=("$(basename $board | cut -d'.' -f1)" "$(head -1 $board | cut -d'#' -f2)")
 		done
 		BOARD=$(dialog --stdout --title "Choose a board" --backtitle "$backtitle" --scrollbar --extra-label "Show $WIP_BUTTON" $DIALOG_EXTRA \
@@ -142,11 +142,11 @@ if [[ -z $BOARD ]]; then
 	done
 fi
 
-if [[ -f $SRC/lib/config/boards/${BOARD}.${EXT} ]]; then
-	source $SRC/lib/config/boards/${BOARD}.${EXT}
-elif [[ -f $SRC/lib/config/boards/${BOARD}.wip ]]; then
+if [[ -f $SRC/build/config/boards/${BOARD}.${EXT} ]]; then
+	source $SRC/build/config/boards/${BOARD}.${EXT}
+elif [[ -f $SRC/build/config/boards/${BOARD}.wip ]]; then
 	# when launching build for WIP board from command line
-	source $SRC/lib/config/boards/${BOARD}.wip
+	source $SRC/build/config/boards/${BOARD}.wip
 fi
 
 [[ -z $KERNEL_TARGET ]] && exit_with_error "Board configuration does not define valid kernel config"
@@ -190,7 +190,7 @@ if [[ $KERNEL_ONLY != yes && -z $BUILD_DESKTOP ]]; then
 	[[ -z $BUILD_DESKTOP ]] && exit_with_error "No option selected"
 fi
 
-source $SRC/lib/configuration.sh
+source $SRC/build/configuration.sh
 
 # sync clock
 if [[ $SYNC_CLOCK != no ]]; then

--- a/makeboarddeb.sh
+++ b/makeboarddeb.sh
@@ -6,7 +6,7 @@
 # License version 2. This program is licensed "as is" without any
 # warranty of any kind, whether express or implied.
 #
-# This file is a part of tool chain https://github.com/igorpecovnik/lib
+# This file is a part of tool chain https://github.com/armbian/build
 #
 #
 # Create board support packages
@@ -113,7 +113,7 @@ create_board_package()
 	mkdir -p $destination/etc/X11/xorg.conf.d/
 	mkdir -p $destination/lib/systemd/system/
 
-	install -m 755 $SRC/lib/scripts/armhwinfo $destination/etc/init.d/
+	install -m 755 $SRC/build/scripts/armhwinfo $destination/etc/init.d/
 
 	# configure MIN / MAX speed for cpufrequtils
 	cat <<-EOF > $destination/etc/default/cpufrequtils
@@ -136,10 +136,10 @@ create_board_package()
 	EOF
 
 	# add USB OTG port mode switcher
-	install -m 755 $SRC/lib/scripts/sunxi-musb $destination/usr/bin
+	install -m 755 $SRC/build/scripts/sunxi-musb $destination/usr/bin
 
 	# armbianmonitor (currently only to toggle boot verbosity and log upload)
-	install -m 755 $SRC/lib/scripts/armbianmonitor/armbianmonitor $destination/usr/bin
+	install -m 755 $SRC/build/scripts/armbianmonitor/armbianmonitor $destination/usr/bin
 
 	# updating uInitrd image in update-initramfs trigger
 	cat <<-EOF > $destination/etc/initramfs/post-update.d/99-uboot
@@ -185,7 +185,7 @@ create_board_package()
 	chmod +x $destination/etc/kernel/preinst.d/initramfs-cleanup
 
 	# network interfaces configuration
-	cp $SRC/lib/config/network/interfaces.* $destination/etc/network/
+	cp $SRC/build/config/network/interfaces.* $destination/etc/network/
 	[[ $RELEASE = xenial ]] && sed -i 's/#no-auto-down/no-auto-down/g' $destination/etc/network/interfaces.default
 
 	# apt configuration
@@ -209,7 +209,7 @@ create_board_package()
 	EOF
 
 	# configure the system for unattended upgrades
-	cp $SRC/lib/scripts/02periodic $destination/etc/apt/apt.conf.d/02periodic
+	cp $SRC/build/scripts/02periodic $destination/etc/apt/apt.conf.d/02periodic
 
 	# pin priority for armbian repo
 	# reference: man apt_preferences
@@ -221,7 +221,7 @@ create_board_package()
 	EOF
 
 	# script to install to SATA
-	cp -R $SRC/lib/scripts/nand-sata-install/usr $destination/
+	cp -R $SRC/build/scripts/nand-sata-install/usr $destination/
 	chmod +x $destination/usr/lib/nand-sata-install/nand-sata-install.sh
 	ln -s ../lib/nand-sata-install/nand-sata-install.sh $destination/usr/sbin/nand-sata-install
 
@@ -238,11 +238,11 @@ create_board_package()
 	install -m 755 $SRC/sources/Debian-micro-home-server/softy $destination/usr/bin/softy
 
 	# install custom motd with reboot and upgrade checking
-	install -m 755 $SRC/lib/scripts/update-motd.d/* $destination/etc/update-motd.d/
-	cp $SRC/lib/scripts/check_first_login_reboot.sh $destination/etc/profile.d
-	cp $SRC/lib/scripts/check_first_login.sh $destination/etc/profile.d
+	install -m 755 $SRC/build/scripts/update-motd.d/* $destination/etc/update-motd.d/
+	cp $SRC/build/scripts/check_first_login_reboot.sh $destination/etc/profile.d
+	cp $SRC/build/scripts/check_first_login.sh $destination/etc/profile.d
 
-	install -m 755 $SRC/lib/scripts/apt-updates $destination/usr/lib/armbian/apt-updates
+	install -m 755 $SRC/build/scripts/apt-updates $destination/usr/lib/armbian/apt-updates
 
 	cat <<-EOF > $destination/usr/lib/armbian/armbian-motd.default
 	# add space-separated list of MOTD script names (without number) to exclude them from MOTD
@@ -257,19 +257,19 @@ create_board_package()
 	EOF
 
 	# setting window title for remote sessions
-	install -m 755 $SRC/lib/scripts/ssh-title.sh $destination/etc/profile.d/ssh-title.sh
+	install -m 755 $SRC/build/scripts/ssh-title.sh $destination/etc/profile.d/ssh-title.sh
 
 	# install copy of boot script & environment file
 	local bootscript_src=${BOOTSCRIPT%%:*}
 	local bootscript_dst=${BOOTSCRIPT##*:}
-	cp $SRC/lib/config/bootscripts/$bootscript_src $destination/usr/share/armbian/$bootscript_dst
-	[[ -n $BOOTENV_FILE && -f $SRC/lib/config/bootenv/$BOOTENV_FILE ]] && \
-		cp $SRC/lib/config/bootenv/$BOOTENV_FILE $destination/usr/share/armbian/armbianEnv.txt
+	cp $SRC/build/config/bootscripts/$bootscript_src $destination/usr/share/armbian/$bootscript_dst
+	[[ -n $BOOTENV_FILE && -f $SRC/build/config/bootenv/$BOOTENV_FILE ]] && \
+		cp $SRC/build/config/bootenv/$BOOTENV_FILE $destination/usr/share/armbian/armbianEnv.txt
 
 	# h3disp for sun8i/3.4.x
 	if [[ $LINUXFAMILY == sun8i && $BRANCH == default ]]; then
-		install -m 755 $SRC/lib/scripts/h3disp $destination/usr/bin
-		install -m 755 $SRC/lib/scripts/h3consumption $destination/usr/bin
+		install -m 755 $SRC/build/scripts/h3disp $destination/usr/bin
+		install -m 755 $SRC/build/scripts/h3consumption $destination/usr/bin
 	fi
 
 	# add configuration for setting uboot environment from userspace with: fw_setenv fw_printenv
@@ -280,35 +280,35 @@ create_board_package()
 	fi
 
 	# log2ram - systemd compatible ramlog alternative
-	cp $SRC/lib/scripts/log2ram/LICENSE.log2ram $destination/usr/share/log2ram/LICENSE
-	cp $SRC/lib/scripts/log2ram/log2ram.service $destination/lib/systemd/system/log2ram.service
-	install -m 755 $SRC/lib/scripts/log2ram/log2ram $destination/usr/sbin/log2ram
-	install -m 755 $SRC/lib/scripts/log2ram/log2ram.hourly $destination/etc/cron.daily/log2ram
-	cp $SRC/lib/scripts/log2ram/log2ram.default $destination/etc/default/log2ram.dpkg-dist
+	cp $SRC/build/scripts/log2ram/LICENSE.log2ram $destination/usr/share/log2ram/LICENSE
+	cp $SRC/build/scripts/log2ram/log2ram.service $destination/lib/systemd/system/log2ram.service
+	install -m 755 $SRC/build/scripts/log2ram/log2ram $destination/usr/sbin/log2ram
+	install -m 755 $SRC/build/scripts/log2ram/log2ram.hourly $destination/etc/cron.daily/log2ram
+	cp $SRC/build/scripts/log2ram/log2ram.default $destination/etc/default/log2ram.dpkg-dist
 
 	if [[ $LINUXFAMILY == sun*i ]]; then
-		install -m 755 $SRC/lib/scripts/armbian-add-overlay $destination/usr/sbin
+		install -m 755 $SRC/build/scripts/armbian-add-overlay $destination/usr/sbin
 		if [[ $BRANCH == default ]]; then
 			# add soc temperature app
 			local codename=$(lsb_release -sc)
 			if [[ -z $codename || "sid" == *"$codename"* ]]; then
-				arm-linux-gnueabihf-gcc-5 $SRC/lib/scripts/sunxi-temp/sunxi_tp_temp.c -o $destination/usr/bin/sunxi_tp_temp
+				arm-linux-gnueabihf-gcc-5 $SRC/build/scripts/sunxi-temp/sunxi_tp_temp.c -o $destination/usr/bin/sunxi_tp_temp
 			else
-				arm-linux-gnueabihf-gcc $SRC/lib/scripts/sunxi-temp/sunxi_tp_temp.c -o $destination/usr/bin/sunxi_tp_temp
+				arm-linux-gnueabihf-gcc $SRC/build/scripts/sunxi-temp/sunxi_tp_temp.c -o $destination/usr/bin/sunxi_tp_temp
 			fi
 		fi
 
 		# convert and add fex files
 		mkdir -p $destination/boot/bin
-		for i in $(ls -w1 $SRC/lib/config/fex/*.fex | xargs -n1 basename); do
-			fex2bin $SRC/lib/config/fex/${i%*.fex}.fex $destination/boot/bin/${i%*.fex}.bin
+		for i in $(ls -w1 $SRC/build/config/fex/*.fex | xargs -n1 basename); do
+			fex2bin $SRC/build/config/fex/${i%*.fex}.fex $destination/boot/bin/${i%*.fex}.bin
 		done
 	fi
 
 	if [[ ( $LINUXFAMILY == sun*i || $LINUXFAMILY == pine64 ) && $BRANCH == default ]]; then
 		# add mpv config for vdpau_sunxi
 		mkdir -p $destination/etc/mpv/
-		cp $SRC/lib/config/mpv_sunxi.conf $destination/etc/mpv/mpv.conf
+		cp $SRC/build/config/mpv_sunxi.conf $destination/etc/mpv/mpv.conf
 		echo "export VDPAU_OSD=1" > $destination/etc/profile.d/90-vdpau.sh
 		chmod 755 $destination/etc/profile.d/90-vdpau.sh
 	fi

--- a/repo-show.sh
+++ b/repo-show.sh
@@ -6,7 +6,7 @@
 # License version 2. This program is licensed "as is" without any
 # warranty of any kind, whether express or implied.
 #
-# This file is a part of tool chain https://github.com/igorpecovnik/lib
+# This file is a part of tool chain https://github.com/armbian/build
 #
 
 # This script shows packages in local repository

--- a/repo-update.sh
+++ b/repo-update.sh
@@ -6,7 +6,7 @@
 # License version 2. This program is licensed "as is" without any
 # warranty of any kind, whether express or implied.
 #
-# This file is a part of tool chain https://github.com/igorpecovnik/lib
+# This file is a part of tool chain https://github.com/armbian/build
 #
 
 # This script recreates deb repository from files in directory POT

--- a/scripts/resize2fs
+++ b/scripts/resize2fs
@@ -97,7 +97,7 @@ do_expand_partition()
 	if [[ $partitions == 1 ]] && awk "BEGIN{exit ! ($fdisk_version >= 2.27 )}"; then
 		# if dealing with fdisk from util-linux 2.27+ we need a workaround for just 1 partition
 		# though it does not break anything - just prevents an "unexpected command" to fdisk
-		# https://github.com/igorpecovnik/lib/issues/353#issuecomment-224728506
+		# https://github.com/armbian/build/issues/353#issuecomment-224728506
 		((echo d; echo n; echo p; echo ; echo $startfrom; echo $lastsector ; echo w;) | fdisk $rootdevicepath) >>${Log} 2>&1
 	else
 		((echo d; echo $partitions; echo n; echo p; echo ; echo $startfrom; echo $lastsector ; echo w;) | fdisk $rootdevicepath) >>${Log} 2>&1


### PR DESCRIPTION
The build and kernel repos are no longer hosted on Igor's GitHub,
so GitHub (currently) redirects the old links to the correct places.
However we should really use the correct links as GitHub may one
day decide to stop redirecting.

This was motivated by navigating manually to Igor's GitHub and not
finding the source files.
