### PR TITLE
Fix spidev patch rockchip

### DIFF
--- a/patch/kernel/rockchip-next/9002_dts_rk3288_updates.patch
+++ b/patch/kernel/rockchip-next/9002_dts_rk3288_updates.patch
@@ -120,7 +120,7 @@ index 9e2e099..3a0f0a7 100644
  	{ .compatible = "rohm,dh2228fv" },
  	{ .compatible = "lineartechnology,ltc2488" },
  	{ .compatible = "ge,achc" },
-  { .compatible = "semtech,sx1301" },
+ 	{ .compatible = "semtech,sx1301" },
 +	{ .compatible = "rockchip,spi_tinker" },
  	{},
  };

--- a/patch/kernel/rockchip-next/9002_dts_rk3288_updates.patch
+++ b/patch/kernel/rockchip-next/9002_dts_rk3288_updates.patch
@@ -116,10 +116,11 @@ diff --git a/drivers/spi/spidev.c b/drivers/spi/spidev.c
 index 9e2e099..3a0f0a7 100644
 --- a/drivers/spi/spidev.c
 +++ b/drivers/spi/spidev.c
-@@ -697,6 +697,7 @@ static const struct of_device_id spidev_dt_ids[] = {
+@@ -697,7 +697,8 @@ static const struct of_device_id spidev_dt_ids[] = {
  	{ .compatible = "rohm,dh2228fv" },
  	{ .compatible = "lineartechnology,ltc2488" },
  	{ .compatible = "ge,achc" },
+  { .compatible = "semtech,sx1301" },
 +	{ .compatible = "rockchip,spi_tinker" },
  	{},
  };


### PR DESCRIPTION
kernel 4.12 has another device in the spidev compatibility list, added and patch modified.