### PR TITLE
bugfix: gc2035 accepts a wrong format in sensor_try_fmt_internal function.

### DIFF
--- a/patch/kernel/sun8i-default/0001-gc2035-camera-improvements.patch
+++ b/patch/kernel/sun8i-default/0001-gc2035-camera-improvements.patch
@@ -1,21 +1,26 @@
-From fa377b234d6bb8216805bd34cdef2d60a9eabcf2 Mon Sep 17 00:00:00 2001
+From 03225f6dd86073fcef4ebbc764e4c57ecfcbed62 Mon Sep 17 00:00:00 2001
 From: lhelontra <lhe.lontra@gmail.com>
-Date: Wed, 28 Jun 2017 12:22:07 -0300
-Subject: [PATCH] gc2035 camera improvements * resolution 1280x720 in hres0
- mode, of 5fps to 8fps. * resolution 1600x1200 in hres0 mode, quality
- improvements. * resolution 1600x1200 in hres1, runs at 10fps and fixed
- darkness frames. * fixes cropped cif resolution in hres3. * change hres name,
- 3 to 2 and 2 to 3. * added auto choose of hres based on fps or/and
- resolution. * new hres modes:   - hres=0 (640x480|1280x720|1600x1200 - 8 FPS)
-   - hres=1 (800x600|1600x1200 - 10 FPS)   - hres=2 (320x240|352x288|640x480 -
- 15 FPS)   - hres=3 (320x240|640x480|800x600|1600x1200 - 20 FPS)
+Date: Sat, 1 Jul 2017 01:33:01 -0300
+Subject: [PATCH] gc2035 camera improvements
 
+resolution 1280x720 in hres0 mode, of 5fps to 8fps.
+resolution 1600x1200 in hres0 mode, quality improvements.
+resolution 1600x1200 in hres1, runs at 10fps and fixed darkness frames.
+fixes cropped cif resolution in hres3.
+change hres name, 3 to 2 and 2 to 3.
+added auto choose of hres based on fps or/and resolution.
+new hres modes:
+ - hres=0 (640x480|1280x720|1600x1200 - 8 FPS)
+ - hres=1 (800x600|1600x1200 - 10 FPS)
+ - hres=2 (320x240|352x288|640x480 - 15 FPS)
+ - hres=3 (320x240|640x480|800x600|1600x1200 - 20 FPS)
+when trying set fmt, like V4L2_PIX_FMT_{BGR24,SGBRG8}, driver sets BGGR 8bits format and causes segmentation fault. The raw bayer format was disable.
 ---
  drivers/media/video/sunxi-vfe/device/gc2035.c | 5780 ++++++++++++++++++-------
  1 file changed, 4161 insertions(+), 1619 deletions(-)
 
 diff --git a/drivers/media/video/sunxi-vfe/device/gc2035.c b/drivers/media/video/sunxi-vfe/device/gc2035.c
-index 1d3eb0e77..ddffa83ab 100755
+index 1d3eb0e77..b1c2b1f33 100755
 --- a/drivers/media/video/sunxi-vfe/device/gc2035.c
 +++ b/drivers/media/video/sunxi-vfe/device/gc2035.c
 @@ -14,22 +14,30 @@
@@ -4882,14 +4887,14 @@ index 1d3eb0e77..ddffa83ab 100755
 +		.regs_size = ARRAY_SIZE(sensor_fmt_yuv422_vyuy),
 +		.bpp		= 2,
 +	},
-+  // when try set format as bgr24 for example, this format was returned
-+	{
-+		.desc		= "Raw RGB Bayer",
-+		.mbus_code	= V4L2_MBUS_FMT_SBGGR8_1X8,//linux-3.0
-+		.regs 		= sensor_fmt_raw,
-+		.regs_size = ARRAY_SIZE(sensor_fmt_raw),
-+		.bpp		= 1
-+	},
++  // NOTE: when trying set fmt, like V4L2_PIX_FMT_{BGR24,SGBRG8}, driver sets BGGR 8bits format and causes segmentation fault
++	// {
++	// 	.desc		= "RAW Bayer BGGR 8bit",
++	// 	.mbus_code	= V4L2_MBUS_FMT_SBGGR8_1X8,//linux-3.0
++	// 	.regs 		= sensor_fmt_raw,
++	// 	.regs_size = ARRAY_SIZE(sensor_fmt_raw),
++	// 	.bpp		= 1
++	// },
 +};
 +#define N_FMTS ARRAY_SIZE(sensor_formats)
 +


### PR DESCRIPTION
When trying set a format, like V4L2_PIX_FMT_{BGR24,SGBRG8}, driver sets BGGR 8bits format and causes segmentation fault, depending of your resolution. 
The raw bayer format was disable.