### PR TITLE
Update support for A20-OLinuXino-MICRO on next branch

### DIFF
--- a/config/boards/micro-emmc.conf
+++ b/config/boards/micro-emmc.conf
@@ -1,0 +1,17 @@
+# A20 dual core 1Gb SoC
+BOARD_NAME="Micro eMMC"
+LINUXFAMILY="sun7i"
+BOOTCONFIG="A20-OLinuXino_MICRO_eMMC_config"
+MODULES="hci_uart gpio_sunxi rfcomm hidp bonding spi_sun7i 8021q a20_tp"
+MODULES_NEXT="bonding"
+#
+KERNEL_TARGET="default,next,dev"
+CLI_TARGET=""
+DESKTOP_TARGET=""
+#
+RECOMMENDED="Ubuntu_xenial_default_desktop:90,Debian_jessie_next:100"
+#
+BOARDRATING=""
+CHIP="http://docs.armbian.com/Hardware_Allwinner-A20/"
+HARDWARE="https://linux-sunxi.org/Olimex_A20-OLinuXino-Micro"
+FORUMS="http://forum.armbian.com/index.php/forum/7-allwinner-a10a20/"

--- a/patch/kernel/sunxi-next/add-a20-olinuxino-micro-emmc-support.patch
+++ b/patch/kernel/sunxi-next/add-a20-olinuxino-micro-emmc-support.patch
@@ -1,0 +1,88 @@
+diff --git a/arch/arm/boot/dts/Makefile b/arch/arm/boot/dts/Makefile
+index 4b17f35..e1d1e93 100644
+--- a/arch/arm/boot/dts/Makefile
++++ b/arch/arm/boot/dts/Makefile
+@@ -880,6 +880,7 @@ dtb-$(CONFIG_MACH_SUN7I) += \
+ 	sun7i-a20-olinuxino-lime2.dtb \
+ 	sun7i-a20-olinuxino-lime2-emmc.dtb \
+ 	sun7i-a20-olinuxino-micro.dtb \
++	sun7i-a20-olinuxino-micro-emmc.dtb \
+ 	sun7i-a20-orangepi.dtb \
+ 	sun7i-a20-orangepi-mini.dtb \
+ 	sun7i-a20-pcduino3.dtb \
+diff --git a/arch/arm/boot/dts/sun7i-a20-olinuxino-micro-emmc.dts b/arch/arm/boot/dts/sun7i-a20-olinuxino-micro-emmc.dts
+new file mode 100644
+index 0000000..d99e7b1
+--- /dev/null
++++ b/arch/arm/boot/dts/sun7i-a20-olinuxino-micro-emmc.dts
+@@ -0,0 +1,70 @@
++ /*
++ * Copyright 2017 Olimex Ltd.
++ * Stefan Mavrodiev <stefan@olimex.com>
++ *
++ * This file is dual-licensed: you can use it either under the terms
++ * of the GPL or the X11 license, at your option. Note that this dual
++ * licensing only applies to this file, and not this project as a
++ * whole.
++ *
++ *  a) This file is free software; you can redistribute it and/or
++ *     modify it under the terms of the GNU General Public License as
++ *     published by the Free Software Foundation; either version 2 of the
++ *     License, or (at your option) any later version.
++ *
++ *     This file is distributed in the hope that it will be useful,
++ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *     GNU General Public License for more details.
++ *
++ * Or, alternatively,
++ *
++ *  b) Permission is hereby granted, free of charge, to any person
++ *     obtaining a copy of this software and associated documentation
++ *     files (the "Software"), to deal in the Software without
++ *     restriction, including without limitation the rights to use,
++ *     copy, modify, merge, publish, distribute, sublicense, and/or
++ *     sell copies of the Software, and to permit persons to whom the
++ *     Software is furnished to do so, subject to the following
++ *     conditions:
++ *
++ *     The above copyright notice and this permission notice shall be
++ *     included in all copies or substantial portions of the Software.
++ *
++ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
++ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
++ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
++ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
++ *     OTHER DEALINGS IN THE SOFTWARE.
++ */
++
++#include "sun7i-a20-olinuxino-micro.dts"
++
++/ {
++	model = "Olimex A20-OLinuXino-MICRO-eMMC";
++	compatible = "olimex,a20-olinuxino-micro-emmc", "allwinner,sun7i-a20";
++
++	mmc2_pwrseq: pwrseq {
++		compatible = "mmc-pwrseq-emmc";
++		reset-gpios = <&pio 2 16 GPIO_ACTIVE_LOW>;
++	};
++};
++
++&mmc2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mmc2_pins_a>;
++	vmmc-supply = <&reg_vcc3v3>;
++	bus-width = <4>;
++	non-removable;
++	mmc-pwrseq = <&mmc2_pwrseq>;
++	status = "okay";
++
++	emmc: emmc@0 {
++		reg = <0>;
++		compatible = "mmc-card";
++		broken-hpi;
++	};
++};

--- a/patch/kernel/sunxi-next/fix-a20-olinux-micro-phy-support.patch
+++ b/patch/kernel/sunxi-next/fix-a20-olinux-micro-phy-support.patch
@@ -1,0 +1,53 @@
+diff --git a/arch/arm/boot/dts/sun7i-a20-olinuxino-micro.dts b/arch/arm/boot/dts/sun7i-a20-olinuxino-micro.dts
+index 0b7403e..ed88c76 100644
+--- a/arch/arm/boot/dts/sun7i-a20-olinuxino-micro.dts
++++ b/arch/arm/boot/dts/sun7i-a20-olinuxino-micro.dts
+@@ -100,16 +100,15 @@
+ 	status = "okay";
+ };
+ 
+-&gmac {
++&emac {
+ 	pinctrl-names = "default";
+-	pinctrl-0 = <&gmac_pins_mii_a>;
++	pinctrl-0 = <&emac_pins_a>,<&emac_txerr_pin>;
+ 	phy = <&phy1>;
+-	phy-mode = "mii";
+ 	status = "okay";
++};
+ 
+-	phy1: ethernet-phy@1 {
+-		reg = <1>;
+-	};
++&emac_sram {
++	status = "okay";
+ };
+ 
+ &i2c0 {
+@@ -196,6 +195,14 @@
+ 	};
+ };
+ 
++&mdio {
++	status = "okay";
++
++	phy1: ethernet-phy@1 {
++		reg = <1>;
++	};
++};
++
+ &mmc0 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&mmc0_pins_a>;
+@@ -229,6 +236,11 @@
+ };
+ 
+ &pio {
++	emac_txerr_pin: emac_txerr_pin@0 {
++		pins = "PA17";
++		function = "emac";
++	};
++
+ 	mmc3_cd_pin_olinuxinom: mmc3_cd_pin@0 {
+ 		pins = "PH11";
+ 		function = "gpio_in";

--- a/patch/u-boot/u-boot-sunxi/add-a20-olinuxino-micro-emmc-support.patch
+++ b/patch/u-boot/u-boot-sunxi/add-a20-olinuxino-micro-emmc-support.patch
@@ -1,0 +1,278 @@
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index a3ef685..14677fe 100644
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -281,6 +281,7 @@ dtb-$(CONFIG_MACH_SUN7I) += \
+ 	sun7i-a20-olinuxino-lime2.dtb \
+ 	sun7i-a20-olinuxino-lime2-emmc.dtb \
+ 	sun7i-a20-olinuxino-micro.dtb \
++	sun7i-a20-olinuxino-micro-emmc.dtb \
+ 	sun7i-a20-orangepi.dtb \
+ 	sun7i-a20-orangepi-mini.dtb \
+ 	sun7i-a20-pcduino3.dtb \
+diff --git a/arch/arm/dts/sun7i-a20-olinuxino-micro-emmc.dts b/arch/arm/dts/sun7i-a20-olinuxino-micro-emmc.dts
+new file mode 100644
+index 0000000..d99e7b1
+--- /dev/null
++++ b/arch/arm/dts/sun7i-a20-olinuxino-micro-emmc.dts
+@@ -0,0 +1,70 @@
++ /*
++ * Copyright 2017 Olimex Ltd.
++ * Stefan Mavrodiev <stefan@olimex.com>
++ *
++ * This file is dual-licensed: you can use it either under the terms
++ * of the GPL or the X11 license, at your option. Note that this dual
++ * licensing only applies to this file, and not this project as a
++ * whole.
++ *
++ *  a) This file is free software; you can redistribute it and/or
++ *     modify it under the terms of the GNU General Public License as
++ *     published by the Free Software Foundation; either version 2 of the
++ *     License, or (at your option) any later version.
++ *
++ *     This file is distributed in the hope that it will be useful,
++ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *     GNU General Public License for more details.
++ *
++ * Or, alternatively,
++ *
++ *  b) Permission is hereby granted, free of charge, to any person
++ *     obtaining a copy of this software and associated documentation
++ *     files (the "Software"), to deal in the Software without
++ *     restriction, including without limitation the rights to use,
++ *     copy, modify, merge, publish, distribute, sublicense, and/or
++ *     sell copies of the Software, and to permit persons to whom the
++ *     Software is furnished to do so, subject to the following
++ *     conditions:
++ *
++ *     The above copyright notice and this permission notice shall be
++ *     included in all copies or substantial portions of the Software.
++ *
++ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
++ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
++ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
++ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
++ *     OTHER DEALINGS IN THE SOFTWARE.
++ */
++
++#include "sun7i-a20-olinuxino-micro.dts"
++
++/ {
++	model = "Olimex A20-OLinuXino-MICRO-eMMC";
++	compatible = "olimex,a20-olinuxino-micro-emmc", "allwinner,sun7i-a20";
++
++	mmc2_pwrseq: pwrseq {
++		compatible = "mmc-pwrseq-emmc";
++		reset-gpios = <&pio 2 16 GPIO_ACTIVE_LOW>;
++	};
++};
++
++&mmc2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mmc2_pins_a>;
++	vmmc-supply = <&reg_vcc3v3>;
++	bus-width = <4>;
++	non-removable;
++	mmc-pwrseq = <&mmc2_pwrseq>;
++	status = "okay";
++
++	emmc: emmc@0 {
++		reg = <0>;
++		compatible = "mmc-card";
++		broken-hpi;
++	};
++};
+diff --git a/arch/arm/dts/sun7i-a20-olinuxino-micro.dts b/arch/arm/dts/sun7i-a20-olinuxino-micro.dts
+index 7e3006f..ed88c76 100644
+--- a/arch/arm/dts/sun7i-a20-olinuxino-micro.dts
++++ b/arch/arm/dts/sun7i-a20-olinuxino-micro.dts
+@@ -49,7 +49,6 @@
+ #include <dt-bindings/gpio/gpio.h>
+ #include <dt-bindings/input/input.h>
+ #include <dt-bindings/interrupt-controller/irq.h>
+-#include <dt-bindings/pinctrl/sun4i-a10.h>
+ 
+ / {
+ 	model = "Olimex A20-Olinuxino Micro";
+@@ -85,6 +84,14 @@
+ 	status = "okay";
+ };
+ 
++&codec {
++	status = "okay";
++};
++
++&cpu0 {
++	cpu-supply = <&reg_dcdc2>;
++};
++
+ &ehci0 {
+ 	status = "okay";
+ };
+@@ -93,16 +100,15 @@
+ 	status = "okay";
+ };
+ 
+-&gmac {
++&emac {
+ 	pinctrl-names = "default";
+-	pinctrl-0 = <&gmac_pins_mii_a>;
++	pinctrl-0 = <&emac_pins_a>,<&emac_txerr_pin>;
+ 	phy = <&phy1>;
+-	phy-mode = "mii";
+ 	status = "okay";
++};
+ 
+-	phy1: ethernet-phy@1 {
+-		reg = <1>;
+-	};
++&emac_sram {
++	status = "okay";
+ };
+ 
+ &i2c0 {
+@@ -111,13 +117,9 @@
+ 	status = "okay";
+ 
+ 	axp209: pmic@34 {
+-		compatible = "x-powers,axp209";
+ 		reg = <0x34>;
+ 		interrupt-parent = <&nmi_intc>;
+ 		interrupts = <0 IRQ_TYPE_LEVEL_LOW>;
+-
+-		interrupt-controller;
+-		#interrupt-cells = <1>;
+ 	};
+ };
+ 
+@@ -193,9 +195,17 @@
+ 	};
+ };
+ 
++&mdio {
++	status = "okay";
++
++	phy1: ethernet-phy@1 {
++		reg = <1>;
++	};
++};
++
+ &mmc0 {
+ 	pinctrl-names = "default";
+-	pinctrl-0 = <&mmc0_pins_a>, <&mmc0_cd_pin_reference_design>;
++	pinctrl-0 = <&mmc0_pins_a>;
+ 	vmmc-supply = <&reg_vcc3v3>;
+ 	bus-width = <4>;
+ 	cd-gpios = <&pio 7 1 GPIO_ACTIVE_HIGH>; /* PH1 */
+@@ -226,35 +236,59 @@
+ };
+ 
+ &pio {
++	emac_txerr_pin: emac_txerr_pin@0 {
++		pins = "PA17";
++		function = "emac";
++	};
++
+ 	mmc3_cd_pin_olinuxinom: mmc3_cd_pin@0 {
+-		allwinner,pins = "PH11";
+-		allwinner,function = "gpio_in";
+-		allwinner,drive = <SUN4I_PINCTRL_10_MA>;
+-		allwinner,pull = <SUN4I_PINCTRL_PULL_UP>;
++		pins = "PH11";
++		function = "gpio_in";
++		bias-pull-up;
+ 	};
+ 
+ 	led_pins_olinuxino: led_pins@0 {
+-		allwinner,pins = "PH2";
+-		allwinner,function = "gpio_out";
+-		allwinner,drive = <SUN4I_PINCTRL_20_MA>;
+-		allwinner,pull = <SUN4I_PINCTRL_NO_PULL>;
++		pins = "PH2";
++		function = "gpio_out";
++		drive-strength = <20>;
+ 	};
+ 
+ 	usb0_id_detect_pin: usb0_id_detect_pin@0 {
+-		allwinner,pins = "PH4";
+-		allwinner,function = "gpio_in";
+-		allwinner,drive = <SUN4I_PINCTRL_10_MA>;
+-		allwinner,pull = <SUN4I_PINCTRL_PULL_UP>;
++		pins = "PH4";
++		function = "gpio_in";
++		bias-pull-up;
+ 	};
+ 
+ 	usb0_vbus_detect_pin: usb0_vbus_detect_pin@0 {
+-		allwinner,pins = "PH5";
+-		allwinner,function = "gpio_in";
+-		allwinner,drive = <SUN4I_PINCTRL_10_MA>;
+-		allwinner,pull = <SUN4I_PINCTRL_PULL_DOWN>;
++		pins = "PH5";
++		function = "gpio_in";
++		bias-pull-down;
+ 	};
+ };
+ 
++#include "axp209.dtsi"
++
++&reg_dcdc2 {
++	regulator-always-on;
++	regulator-min-microvolt = <1000000>;
++	regulator-max-microvolt = <1400000>;
++	regulator-name = "vdd-cpu";
++};
++
++&reg_dcdc3 {
++	regulator-always-on;
++	regulator-min-microvolt = <1000000>;
++	regulator-max-microvolt = <1400000>;
++	regulator-name = "vdd-int-dll";
++};
++
++&reg_ldo2 {
++	regulator-always-on;
++	regulator-min-microvolt = <3000000>;
++	regulator-max-microvolt = <3000000>;
++	regulator-name = "avcc";
++};
++
+ &reg_ahci_5v {
+ 	status = "okay";
+ };
+diff --git a/configs/A20-OLinuXino_MICRO_eMMC_defconfig b/configs/A20-OLinuXino_MICRO_eMMC_defconfig
+new file mode 100644
+index 0000000..1ec93e4
+--- /dev/null
++++ b/configs/A20-OLinuXino_MICRO_eMMC_defconfig
+@@ -0,0 +1,26 @@
++CONFIG_ARM=y
++CONFIG_ARCH_SUNXI=y
++CONFIG_MACH_SUN7I=y
++CONFIG_DRAM_CLK=384
++CONFIG_MMC0_CD_PIN="PH1"
++CONFIG_MMC3_CD_PIN="PH11"
++CONFIG_MMC_SUNXI_SLOT_EXTRA=2
++CONFIG_I2C1_ENABLE=y
++CONFIG_VIDEO_VGA=y
++CONFIG_SATAPWR="PB8"
++CONFIG_DEFAULT_DEVICE_TREE="sun7i-a20-olinuxino-micro-emmc"
++CONFIG_AHCI=y
++# CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
++CONFIG_SPL=y
++CONFIG_SPL_I2C_SUPPORT=y
++# CONFIG_CMD_IMLS is not set
++# CONFIG_CMD_FLASH is not set
++# CONFIG_CMD_FPGA is not set
++# CONFIG_SPL_DOS_PARTITION is not set
++# CONFIG_SPL_ISO_PARTITION is not set
++# CONFIG_SPL_EFI_PARTITION is not set
++CONFIG_ETH_DESIGNWARE=y
++CONFIG_SUN7I_GMAC=y
++CONFIG_AXP_ALDO3_VOLT=2800
++CONFIG_AXP_ALDO4_VOLT=2800
++CONFIG_USB_EHCI_HCD=y


### PR DESCRIPTION
The new rev.J board has new phy chip - LAN8710, which request additional pin - PA17. Therefore GMAC node in the dts is replaced with EMAC.

Along with new phy, there is option for eMMC.

Currently we are pushing these changes to mainline kernel and soon they will be available in the dev branch.
