### PR TITLE
update Nano Pi Neo Plus 2(nanopineoplus2) DT

### DIFF
--- a/patch/kernel/sun50i-dev/badd-nanopineoplus2.patch
+++ b/patch/kernel/sun50i-dev/badd-nanopineoplus2.patch
@@ -8,15 +8,14 @@ index b296f10..f361a2a 100644
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo2.dtb
 +dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo-plus2.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopim1plus2.dtb
-
- always		:= $(dtb-y)
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-neo-plus2.dts b/arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-neo-plus2.dts
 new file mode 100644
-index 0000000..93df9fd
+index 0000000..f86db28
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-neo-plus2.dts
-@@ -0,0 +1,256 @@
+@@ -0,0 +1,260 @@
 +/*
++ * Copyright (C) 2017 Antony Antony <antony@phenome.org>
 + * Copyright (C) 2016 ARM Ltd.
 + *
 + * This file is dual-licensed: you can use it either under the terms
@@ -67,7 +66,7 @@ index 0000000..93df9fd
 +
 +/ {
 +	model = "FriendlyARM NanoPi NEO Plus2";
-+	compatible = "friendlyarm,nanopi-neo-pus2", "allwinner,sun50i-h5";
++	compatible = "friendlyarm,nanopi-neo-plus2", "allwinner,sun50i-h5";
 +
 +	reg_vcc3v3: vcc3v3 {
 +		compatible = "regulator-fixed";
@@ -89,29 +88,21 @@ index 0000000..93df9fd
 +		compatible = "gpio-leds";
 +
 +		pwr {
-+			label = "orangepi:green:pwr";
++			label = "nanopi:green:pwr";
 +			gpios = <&r_pio 0 10 GPIO_ACTIVE_HIGH>;
 +			default-state = "on";
 +		};
 +
 +		status {
-+			label = "orangepi:red:status";
++			label = "nanopi:red:status";
 +			gpios = <&pio 0 20 GPIO_ACTIVE_HIGH>;
-+		};
-+	};
-+
-+	r-gpio-keys {
-+		compatible = "gpio-keys";
-+
-+		sw4 {
-+			label = "sw4";
-+			linux,code = <BTN_0>;
-+			gpios = <&r_pio 0 3 GPIO_ACTIVE_LOW>;
 +		};
 +	};
 +
 +	reg_gmac_3v3: gmac-3v3 {
 +		compatible = "regulator-fixed";
++		pinctrl-names = "default";
++		pinctrl-0 = <&gmac_power_pin_nanopi>;
 +		regulator-name = "gmac-3v3";
 +		regulator-min-microvolt = <3300000>;
 +		regulator-max-microvolt = <3300000>;
@@ -120,14 +111,32 @@ index 0000000..93df9fd
 +		gpio = <&pio 3 6 GPIO_ACTIVE_HIGH>;
 +	};
 +
-+	reg_usb0_vbus: usb0-vbus {
-+		compatible = "regulator-fixed";
-+		regulator-name = "usb0-vbus";
-+		regulator-min-microvolt = <5000000>;
-+		regulator-max-microvolt = <5000000>;
-+		enable-active-high;
-+		gpio = <&r_pio 0 2 GPIO_ACTIVE_HIGH>; /* PL2 */
-+		status = "okay";
++	vdd_cpux: gpio-regulator {
++		compatible = "regulator-gpio";
++
++		pinctrl-names = "default";
++		pinctrl-0 = <&vdd_cpux_r_npi>;
++
++		regulator-name = "vdd-cpux";
++		regulator-type = "voltage";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <1100000>;
++		regulator-max-microvolt = <1300000>;
++		regulator-ramp-delay = <50>; /* 4ms */
++
++		gpios = <&r_pio 0 6 GPIO_ACTIVE_HIGH>;
++		gpios-states = <0x1>;
++		states = <1100000 0x0
++			  1300000 0x1>;
++	};
++
++	wifi_pwrseq: wifi_pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		pinctrl-names = "default";
++		pinctrl-0 = <&wifi_en_npi>;
++		reset-gpios = <&r_pio 0 7 GPIO_ACTIVE_LOW>; /* PL7 */
++		post-power-on-delay-ms = <200>;
 +	};
 +};
 +
@@ -139,19 +148,7 @@ index 0000000..93df9fd
 +	status = "okay";
 +};
 +
-+&de {
-+	status = "okay";
-+};
-+
 +&ehci0 {
-+	status = "okay";
-+};
-+
-+&ehci1 {
-+	status = "okay";
-+};
-+
-+&ehci2 {
 +	status = "okay";
 +};
 +
@@ -168,25 +165,11 @@ index 0000000..93df9fd
 +	status = "okay";
 +};
 +
-+&hdmi {
-+	status = "okay";
-+};
-+
-+&ir {
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&ir_pins_a>;
-+	status = "okay";
-+};
-+
 +&mdio {
 +	ext_rgmii_phy: ethernet-phy@7 {
 +		compatible = "ethernet-phy-ieee802.3-c22";
 +		reg = <7>;
 +	};
-+};
-+
-+&mixer0 {
-+	status = "okay";
 +};
 +
 +&mmc0 {
@@ -198,15 +181,46 @@ index 0000000..93df9fd
 +	status = "okay";
 +};
 +
++&mmc1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mmc1_pins_a>;
++	vmmc-supply = <&reg_vcc3v3>;
++	vqmmc-supply = <&reg_vcc3v3>;
++	mmc-pwrseq = <&wifi_pwrseq>;
++	bus-width = <4>;
++	non-removable;
++	boot_device = <0>;
++	status = "okay";
++
++	/*
++	 * WiFi driver support could be incomplete,
++	 * wlan0 is able to see Base Stations, however not able to join.
++	 */
++	brcmf: wifi@1 {
++		reg = <1>;
++		compatible = "brcm,bcm4329-fmac";
++	};
++};
++
++&mmc2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mmc2_8bit_pins>;
++	vmmc-supply = <&reg_vcc3v3>;
++	bus-width = <8>;
++	non-removable;
++	cap-mmc-hw-reset;
++	boot_device = <0>;
++	status = "okay";
++};
++
++&mmc2_8bit_pins {
++	/* Increase drive strength for DDR modes */
++	drive-strength = <40>;
++	/* eMMC is missing pull-ups */
++	bias-pull-up;
++};
++
 +&ohci0 {
-+	status = "okay";
-+};
-+
-+&ohci1 {
-+	status = "okay";
-+};
-+
-+&ohci2 {
 +	status = "okay";
 +};
 +
@@ -214,33 +228,34 @@ index 0000000..93df9fd
 +	status = "okay";
 +};
 +
-+&tcon0 {
-+	status = "okay";
++&pio {
++	leds_npi: led_pins@0 {
++		pins = "PA10";
++		function = "gpio_out";
++	};
++	gmac_power_pin_nanopi: gmac_power_pin@0 {
++			pins = "PD6";
++			function = "gpio_out";
++	};
 +};
 +
-+&spi0 {
-+	status = "okay";
-+        spi-flash@0 {
-+                #address-cells = <1>;
-+                #size-cells = <0>;
-+                compatible = "jedec,spi-nor";
-+                reg = <0>; /* Chip select 0 */
-+                spi-max-frequency = <10000000>;
-+                status = "okay";
-+                partitions {
-+                        compatible = "fixed-partitions";
-+                        #address-cells = <1>;
-+                        #size-cells = <1>;
-+                        partition@0 {
-+                                label = "uboot";
-+                                reg = <0x0 0x100000>;
-+                        };
-+                        partition@100000 {
-+                                label = "env";
-+                                reg = <0x100000 0x100000>;
-+                        };
-+                };
-+        };
++&r_pio {
++	leds_r_npi: led_pins@0 {
++		pins = "PL10";
++		function = "gpio_out";
++	};
++
++	vdd_cpux_r_npi: regulator_pins@0 {
++		allwinner,pins = "PL6";
++		allwinner,function = "gpio_out";
++		allwinner,drive = <SUN4I_PINCTRL_10_MA>;
++		allwinner,pull = <SUN4I_PINCTRL_NO_PULL>;
++	};
++
++	wifi_en_npi: wifi_en_pin {
++		pins = "PL7";
++		function = "gpio_out";
++	};
 +};
 +
 +&uart0 {
@@ -249,26 +264,15 @@ index 0000000..93df9fd
 +	status = "okay";
 +};
 +
-+&uart1 {
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&uart1_pins>;
-+	status = "disabled";
-+};
-+
-+&uart2 {
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&uart2_pins>;
-+	status = "disabled";
-+};
-+
 +&usb_otg {
-+	dr_mode = "otg";
++	dr_mode = "host";
 +	status = "okay";
 +};
 +
 +&usbphy {
 +	/* USB Type-A ports' VBUS is always on */
 +	usb0_id_det-gpios = <&pio 6 12 GPIO_ACTIVE_HIGH>; /* PG12 */
-+	usb0_vbus-supply = <&reg_usb0_vbus>;
 +	status = "okay";
 +};
+--
+2.9.3


### PR DESCRIPTION
incorporate feed back from ThomasKaiser, arm-kernel list, and
Kernel commit 442e1f7e

Remove stuff that was incorrectly copied from Orange Pi PC2
Change white speces to tabs in the dts file

 add wifi power controller,  mmc1, mmc2
 fix typo s/orangepi/nanopi/, s/pus/plus/
 usb_otg set to host mode
 wifi fix from brcm,bcm43xx-fmac.txt
 remove functions on header pins: spi, ir, ehci 1&2, ohci 1&2, uart 1&2
 remove hdmi, de2, r-gpio-keys, mixer - not supported the board, reg_usb0_vbus
