### PR TITLE
Update support for A20-OLinuXino-MICRO board

### DIFF
--- a/config/boards/micro-emmc.conf
+++ b/config/boards/micro-emmc.conf
@@ -1,0 +1,17 @@
+# A20 dual core 1Gb SoC
+BOARD_NAME="Micro eMMC"
+LINUXFAMILY="sun7i"
+BOOTCONFIG="A20-OLinuXino_MICRO_eMMC_config"
+MODULES="hci_uart gpio_sunxi rfcomm hidp bonding spi_sun7i 8021q a20_tp"
+MODULES_NEXT="bonding"
+#
+KERNEL_TARGET="default,next,dev"
+CLI_TARGET=""
+DESKTOP_TARGET=""
+#
+RECOMMENDED="Ubuntu_xenial_default_desktop:90,Debian_jessie_next:100"
+#
+BOARDRATING=""
+CHIP="http://docs.armbian.com/Hardware_Allwinner-A20/"
+HARDWARE="https://linux-sunxi.org/Olimex_A20-OLinuXino-Micro"
+FORUMS="http://forum.armbian.com/index.php/forum/7-allwinner-a10a20/"

--- a/config/fex/micro-emmc.fex
+++ b/config/fex/micro-emmc.fex
@@ -1,0 +1,1088 @@
+[product]
+version = "100"
+machine = "Olimex A20-Olinuxino Micro"
+
+[platform]
+eraseflag = 0
+
+[target]
+boot_clock = 912
+dcdc2_vol = 1400
+dcdc3_vol = 1250
+ldo2_vol = 3000
+ldo3_vol = 2800
+ldo4_vol = 2800
+power_start = 1
+storage_type = 1
+
+[clock]
+pll3 = 297
+pll4 = 300
+pll6 = 600
+pll7 = 297
+pll8 = 336
+
+[card_boot]
+logical_start = 40960
+sprite_gpio0 =
+
+[card0_boot_para]
+card_ctrl = 0
+card_high_speed = 1
+card_line = 4
+sdc_d1 = port:PF00<2><1><default><default>
+sdc_d0 = port:PF01<2><1><default><default>
+sdc_clk = port:PF02<2><1><default><default>
+sdc_cmd = port:PF03<2><1><default><default>
+sdc_d3 = port:PF04<2><1><default><default>
+sdc_d2 = port:PF05<2><1><default><default>
+
+[card2_boot_para]
+card_ctrl = 2
+card_high_speed = 1
+card_line = 4
+sdc_cmd = port:PC06<3><1><default><default>
+sdc_clk = port:PC07<3><1><default><default>
+sdc_d0 = port:PC08<3><1><default><default>
+sdc_d1 = port:PC09<3><1><default><default>
+sdc_d2 = port:PC10<3><1><default><default>
+sdc_d3 = port:PC11<3><1><default><default>
+
+[twi_para]
+twi_port = 0
+twi_scl = port:PB00<2><default><default><default>
+twi_sda = port:PB01<2><default><default><default>
+
+[uart_para]
+uart_debug_port = 0
+uart_debug_tx = port:PB22<2><1><default><default>
+uart_debug_rx = port:PB23<2><1><default><default>
+
+[uart_force_debug]
+uart_debug_port = 0
+uart_debug_tx = port:PB22<2><1><default><default>
+uart_debug_rx = port:PB23<2><1><default><default>
+
+[jtag_para]
+jtag_enable = 0
+jtag_ms = port:PB14<3><default><default><default>
+jtag_ck = port:PB15<3><default><default><default>
+jtag_do = port:PB16<3><default><default><default>
+jtag_di = port:PB17<3><default><default><default>
+
+[pm_para]
+standby_mode = 0
+
+[dram_para]
+dram_baseaddr = 0x40000000
+dram_clk = 384
+dram_type = 3
+dram_rank_num = 1
+dram_chip_density = 4096
+dram_io_width = 16
+dram_bus_width = 32
+dram_cas = 9
+dram_zq = 0x7f
+dram_odt_en = 0
+dram_size = 1024
+dram_tpr0 = 0x42d899b7
+dram_tpr1 = 0xa090
+dram_tpr2 = 0x22a00
+dram_tpr3 = 0x0
+dram_tpr4 = 0x0
+dram_tpr5 = 0x0
+dram_emr1 = 0x4
+dram_emr2 = 0x10
+dram_emr3 = 0x0
+
+[mali_para]
+mali_used = 1
+mali_clkdiv = 1
+
+[emac_para]
+emac_used = 1
+emac_rxd3 = port:PA00<2><default><default><default>
+emac_rxd2 = port:PA01<2><default><default><default>
+emac_rxd1 = port:PA02<2><default><default><default>
+emac_rxd0 = port:PA03<2><default><default><default>
+emac_txd3 = port:PA04<2><default><default><default>
+emac_txd2 = port:PA05<2><default><default><default>
+emac_txd1 = port:PA06<2><default><default><default>
+emac_txd0 = port:PA07<2><default><default><default>
+emac_rxclk = port:PA08<2><default><default><default>
+emac_rxerr = port:PA09<2><default><default><default>
+emac_rxdV = port:PA10<2><default><default><default>
+emac_mdc = port:PA11<2><default><default><default>
+emac_mdio = port:PA12<2><default><default><default>
+emac_txen = port:PA13<2><default><default><default>
+emac_txclk = port:PA14<2><default><default><default>
+emac_crs = port:PA15<2><default><default><default>
+emac_col = port:PA16<2><default><default><default>
+emac_reset = port:PA17<1><default><default><default>
+
+[twi0_para]
+twi0_used = 1
+twi0_scl = port:PB00<2><default><default><default>
+twi0_sda = port:PB01<2><default><default><default>
+
+[twi1_para]
+twi1_used = 1
+twi1_scl = port:PB18<2><default><default><default>
+twi1_sda = port:PB19<2><default><default><default>
+
+[twi2_para]
+twi2_used = 1
+twi2_scl = port:PB20<2><default><default><default>
+twi2_sda = port:PB21<2><default><default><default>
+
+[twi3_para]
+twi3_used = 0
+twi3_scl = port:PI00<3><default><default><default>
+twi3_sda = port:PI01<3><default><default><default>
+
+[twi4_para]
+twi4_used = 0
+twi4_scl = port:PI02<3><default><default><default>
+twi4_sda = port:PI03<3><default><default><default>
+
+[uart_para0]
+uart_used = 1
+uart_port = 0
+uart_type = 2
+uart_tx = port:PB22<2><1><default><default>
+uart_rx = port:PB23<2><1><default><default>
+
+[uart_para1]
+uart_used = 0
+uart_port = 1
+uart_type = 8
+uart_tx = port:PA10<4><1><default><default>
+uart_rx = port:PA11<4><1><default><default>
+uart_rts = port:PA12<4><1><default><default>
+uart_cts = port:PA13<4><1><default><default>
+uart_dtr = port:PA14<4><1><default><default>
+uart_dsr = port:PA15<4><1><default><default>
+uart_dcd = port:PA16<4><1><default><default>
+uart_ring = port:PA17<4><1><default><default>
+
+[uart_para2]
+uart_used = 0
+uart_port = 2
+uart_type = 4
+uart_tx = port:PI18<3><1><default><default>
+uart_rx = port:PI19<3><1><default><default>
+uart_rts = port:PI16<3><1><default><default>
+uart_cts = port:PI17<3><1><default><default>
+
+[uart_para3]
+uart_used = 0
+uart_port = 3
+uart_type = 4
+uart_tx = port:PH00<4><1><default><default>
+uart_rx = port:PH01<4><1><default><default>
+uart_rts = port:PH02<4><1><default><default>
+uart_cts = port:PH03<4><1><default><default>
+
+[uart_para4]
+uart_used = 0
+uart_port = 4
+uart_type = 2
+uart_tx = port:PG10<4><1><default><default>
+uart_rx = port:PG11<4><1><default><default>
+
+[uart_para5]
+uart_used = 0
+uart_port = 5
+uart_type = 2
+uart_tx = port:PH06<4><1><default><default>
+uart_rx = port:PH07<4><1><default><default>
+
+[uart_para6]
+uart_used = 1
+uart_port = 6
+uart_type = 2
+uart_tx = port:PI12<3><1><default><default>
+uart_rx = port:PI13<3><1><default><default>
+
+[uart_para7]
+uart_used = 1
+uart_port = 7
+uart_type = 2
+uart_tx = port:PI20<3><1><default><default>
+uart_rx = port:PI21<3><1><default><default>
+
+[spi0_para]
+spi_used = 0
+spi_cs_bitmap = 1
+spi_cs0 = port:PI10<2><default><default><default>
+spi_cs1 = port:PI14<2><default><default><default>
+spi_sclk = port:PI11<2><default><default><default>
+spi_mosi = port:PI12<2><default><default><default>
+spi_miso = port:PI13<2><default><default><default>
+
+[spi1_para]
+spi_used = 1
+spi_cs_bitmap = 1
+spi_cs0 = port:PI16<3><default><default><default>
+spi_sclk = port:PI17<3><default><default><default>
+spi_mosi = port:PI18<3><default><default><default>
+spi_miso = port:PI19<3><default><default><default>
+
+[spi2_para]
+spi_used = 1
+spi_cs_bitmap = 1
+spi_cs0 = port:PC19<3><default><default><default>
+spi_sclk = port:PC20<3><default><default><default>
+spi_mosi = port:PC21<3><default><default><default>
+spi_miso = port:PC22<3><default><default><default>
+
+[spi3_para]
+spi_used = 0
+spi_cs_bitmap = 1
+spi_cs0 = port:PA05<3><default><default><default>
+spi_cs1 = port:PA09<3><default><default><default>
+spi_sclk = port:PA06<3><default><default><default>
+spi_mosi = port:PA07<3><default><default><default>
+spi_miso = port:PA08<3><default><default><default>
+
+[spi_devices]
+spi_dev_num = 2
+
+[spi_board0]
+modalias = "spidev"
+max_speed_hz = 1000000
+bus_num = 2
+chip_select = 0
+mode = 3
+full_duplex = 0
+manual_cs = 0
+
+[spi_board1]
+modalias = "spidev"
+max_speed_hz = 1000000
+bus_num = 1
+chip_select = 0
+mode = 3
+full_duplex = 0
+manual_cs = 0
+
+
+[rtp_para]
+rtp_used = 1
+rtp_screen_size = 5
+rtp_regidity_level = 5
+rtp_press_threshold_enable = 0
+rtp_press_threshold = 0x1f40
+rtp_sensitive_level = 0xf
+rtp_exchange_x_y_flag = 0
+
+[ctp_para]
+ctp_used = 1
+ctp_twi_id = 2
+ctp_twi_name =
+ctp_screen_max_x = 800
+ctp_screen_max_y = 480
+ctp_revert_x_flag = 0
+ctp_revert_y_flag = 0
+ctp_exchange_x_y_flag = 0
+ctp_int_port = port:PH21<6><default><default><default>
+ctp_wakeup = port:PB13<1><default><default><1>
+
+[tkey_para]
+tkey_used = 0
+tkey_twi_id = 2
+tkey_twi_addr = 0x62
+tkey_int = port:PI13<6><default><default><default>
+
+[motor_para]
+motor_used = 0
+motor_shake = port:PB03<1><default><default><1>
+
+[leds_para]
+leds_used = 1
+leds_num = 1
+leds_pin_1 = port:PH02<1><default><default><0>
+leds_name_1 = "green:ph02:led1"
+leds_default_1 = 0
+leds_trigger_1 = "heartbeat"
+
+[nand_para]
+nand_used = 1
+nand_we = port:PC00<2><default><default><default>
+nand_ale = port:PC01<2><default><default><default>
+nand_cle = port:PC02<2><default><default><default>
+nand_ce0 = port:PC04<2><default><default><default>
+nand_nre = port:PC05<2><default><default><default>
+nand_rb0 = port:PC06<2><default><default><default>
+nand_rb1 = port:PC07<2><default><default><default>
+nand_d0 = port:PC08<2><default><default><default>
+nand_d1 = port:PC09<2><default><default><default>
+nand_d2 = port:PC10<2><default><default><default>
+nand_d3 = port:PC11<2><default><default><default>
+nand_d4 = port:PC12<2><default><default><default>
+nand_d5 = port:PC13<2><default><default><default>
+nand_d6 = port:PC14<2><default><default><default>
+nand_d7 = port:PC15<2><default><default><default>
+nand_ce4 =
+nand_ce5 =
+nand_ce6 =
+nand_ce7 =
+good_block_ratio = 0
+
+[disp_init]
+disp_init_enable = 1
+disp_mode = 0
+screen0_output_type = 1
+screen0_output_mode = 5
+screen1_output_type = 1
+screen1_output_mode = 5
+fb0_framebuffer_num = 2
+fb0_format = 9
+fb0_pixel_sequence = 2
+fb0_scaler_mode_enable = 0
+fb1_framebuffer_num = 2
+fb1_format = 9
+fb1_pixel_sequence = 2
+fb1_scaler_mode_enable = 0
+lcd0_backlight = 197
+lcd1_backlight = 197
+lcd0_bright = 50
+lcd0_contrast = 50
+lcd0_saturation = 57
+lcd0_hue = 50
+lcd1_bright = 50
+lcd1_contrast = 50
+lcd1_saturation = 57
+lcd1_hue = 50
+
+[lcd0_para]
+lcd_used = 1
+lcd_x = 800
+lcd_y = 480
+lcd_dclk_freq = 33
+lcd_pwm_not_used = 0
+lcd_pwm_ch = 0
+lcd_pwm_freq = 10000
+lcd_pwm_pol = 1
+lcd_if = 0
+lcd_hbp = 46
+lcd_ht = 1055
+lcd_vbp = 23
+lcd_vt = 1050
+lcd_hv_if = 0
+lcd_hv_smode = 0
+lcd_hv_s888_if = 0
+lcd_hv_syuv_if = 0
+lcd_hv_vspw = 1
+lcd_hv_hspw = 30
+lcd_lvds_ch = 0
+lcd_lvds_mode = 0
+lcd_lvds_bitwidth = 0
+lcd_lvds_io_cross = 0
+lcd_cpu_if = 0
+lcd_frm = 1
+lcd_io_cfg0 = 268435456
+lcd_gamma_correction_en = 0
+lcd_gamma_tbl_0 = 0x0
+lcd_gamma_tbl_1 = 0x10101
+lcd_gamma_tbl_255 = 0xffffff
+lcd_bl_en_used = 1
+lcd_bl_en = port:PH07<1><0><default><1>
+lcd_power_used = 1
+lcd_power = port:PH08<1><0><default><1>
+lcd_pwm_used = 1
+lcd_pwm = port:PB02<2><0><default><default>
+lcdd0 = port:PD00<2><0><default><default>
+lcdd1 = port:PD01<2><0><default><default>
+lcdd2 = port:PD02<2><0><default><default>
+lcdd3 = port:PD03<2><0><default><default>
+lcdd4 = port:PD04<2><0><default><default>
+lcdd5 = port:PD05<2><0><default><default>
+lcdd6 = port:PD06<2><0><default><default>
+lcdd7 = port:PD07<2><0><default><default>
+lcdd8 = port:PD08<2><0><default><default>
+lcdd9 = port:PD09<2><0><default><default>
+lcdd10 = port:PD10<2><0><default><default>
+lcdd11 = port:PD11<2><0><default><default>
+lcdd12 = port:PD12<2><0><default><default>
+lcdd13 = port:PD13<2><0><default><default>
+lcdd14 = port:PD14<2><0><default><default>
+lcdd15 = port:PD15<2><0><default><default>
+lcdd16 = port:PD16<2><0><default><default>
+lcdd17 = port:PD17<2><0><default><default>
+lcdd18 = port:PD18<2><0><default><default>
+lcdd19 = port:PD19<2><0><default><default>
+lcdd20 = port:PD20<2><0><default><default>
+lcdd21 = port:PD21<2><0><default><default>
+lcdd22 = port:PD22<2><0><default><default>
+lcdd23 = port:PD23<2><0><default><default>
+lcdclk = port:PD24<2><0><default><default>
+lcdde = port:PD25<2><0><default><default>
+lcdhsync = port:PD26<2><0><default><default>
+lcdvsync = port:PD27<2><0><default><default>
+
+[lcd1_para]
+lcd_used = 0
+lcd_x = 0
+lcd_y = 0
+lcd_dclk_freq = 0
+lcd_pwm_not_used = 0
+lcd_pwm_ch = 1
+lcd_pwm_freq = 0
+lcd_pwm_pol = 0
+lcd_if = 0
+lcd_hbp = 0
+lcd_ht = 0
+lcd_vbp = 0
+lcd_vt = 0
+lcd_vspw = 0
+lcd_hspw = 0
+lcd_hv_if = 0
+lcd_hv_smode = 0
+lcd_hv_s888_if = 0
+lcd_hv_syuv_if = 0
+lcd_lvds_ch = 0
+lcd_lvds_mode = 0
+lcd_lvds_bitwidth = 0
+lcd_lvds_io_cross = 0
+lcd_cpu_if = 0
+lcd_frm = 0
+lcd_io_cfg0 = 0
+lcd_gamma_correction_en = 0
+lcd_gamma_tbl_0 = 0x0
+lcd_gamma_tbl_1 = 0x10101
+lcd_gamma_tbl_255 = 0xffffff
+lcd_bl_en_used = 0
+lcd_bl_en =
+lcd_power_used = 0
+lcd_power =
+lcd_pwm_used = 1
+lcd_pwm = port:PI03<2><0><default><default>
+lcd_gpio_0 =
+lcd_gpio_1 =
+lcd_gpio_2 =
+lcd_gpio_3 =
+lcdd0 = port:PH00<2><0><default><default>
+lcdd1 = port:PH01<2><0><default><default>
+lcdd2 = port:PH02<2><0><default><default>
+lcdd3 = port:PH03<2><0><default><default>
+lcdd4 = port:PH04<2><0><default><default>
+lcdd5 = port:PH05<2><0><default><default>
+lcdd6 = port:PH06<2><0><default><default>
+lcdd7 = port:PH07<2><0><default><default>
+lcdd8 = port:PH08<2><0><default><default>
+lcdd9 = port:PH09<2><0><default><default>
+lcdd10 = port:PH10<2><0><default><default>
+lcdd11 = port:PH11<2><0><default><default>
+lcdd12 = port:PH12<2><0><default><default>
+lcdd13 = port:PH13<2><0><default><default>
+lcdd14 = port:PH14<2><0><default><default>
+lcdd15 = port:PH15<2><0><default><default>
+lcdd16 = port:PH16<2><0><default><default>
+lcdd17 = port:PH17<2><0><default><default>
+lcdd18 = port:PH18<2><0><default><default>
+lcdd19 = port:PH19<2><0><default><default>
+lcdd20 = port:PH20<2><0><default><default>
+lcdd21 = port:PH21<2><0><default><default>
+lcdd22 = port:PH22<2><0><default><default>
+lcdd23 = port:PH23<2><0><default><default>
+lcdclk = port:PH24<2><0><default><default>
+lcdde = port:PH25<2><0><default><default>
+lcdhsync = port:PH26<2><0><default><default>
+lcdvsync = port:PH27<2><0><default><default>
+
+[tv_out_dac_para]
+dac_used = 1
+dac0_src = 4
+dac1_src = 5
+dac2_src = 6
+dac3_src = 0
+
+[hdmi_para]
+hdmi_used = 1
+
+[camera_list_para]
+camera_list_para_used = 0
+ov7670 = 0
+gc0308 = 1
+gt2005 = 0
+hi704 = 0
+sp0838 = 0
+mt9m112 = 0
+mt9m113 = 0
+ov2655 = 0
+hi253 = 0
+gc0307 = 0
+mt9d112 = 0
+ov5640 = 1
+gc2015 = 0
+ov2643 = 0
+gc0329 = 0
+gc0309 = 0
+tvp5150 = 0
+s5k4ec = 0
+ov5650_mv9335 = 0
+siv121d = 0
+
+[csi0_para]
+csi_used = 0
+csi_dev_qty = 1
+csi_stby_mode = 0
+csi_mname = "gc0308"
+csi_if = 0
+csi_iovdd = ""
+csi_avdd = ""
+csi_dvdd = ""
+csi_vol_iovdd =
+csi_vol_dvdd =
+csi_vol_avdd =
+csi_vflip = 0
+csi_hflip = 0
+csi_flash_pol = 0
+csi_facing = 0
+csi_twi_id = 1
+csi_twi_addr = 0x42
+csi_pck = port:PE00<3><default><default><default>
+csi_ck = port:PE01<3><default><default><default>
+csi_hsync = port:PE02<3><default><default><default>
+csi_vsync = port:PE03<3><default><default><default>
+csi_d0 = port:PE04<3><default><default><default>
+csi_d1 = port:PE05<3><default><default><default>
+csi_d2 = port:PE06<3><default><default><default>
+csi_d3 = port:PE07<3><default><default><default>
+csi_d4 = port:PE08<3><default><default><default>
+csi_d5 = port:PE09<3><default><default><default>
+csi_d6 = port:PE10<3><default><default><default>
+csi_d7 = port:PE11<3><default><default><default>
+csi_reset = port:PH13<1><default><default><0>
+csi_power_en =
+csi_stby = port:PH16<1><default><default><0>
+
+[csi1_para]
+csi_used = 0
+csi_dev_qty = 1
+csi_stby_mode = 0
+csi_mname = "gc0308"
+csi_if = 0
+csi_iovdd = ""
+csi_avdd = ""
+csi_dvdd = ""
+csi_vol_iovdd =
+csi_vol_dvdd =
+csi_vol_avdd =
+csi_vflip = 0
+csi_hflip = 0
+csi_flash_pol = 0
+csi_facing = 1
+csi_twi_id = 1
+csi_twi_addr = 0x42
+csi_pck = port:PG00<3><default><default><default>
+csi_ck = port:PG01<3><default><default><default>
+csi_hsync = port:PG02<3><default><default><default>
+csi_vsync = port:PG03<3><default><default><default>
+csi_d0 = port:PG04<3><default><default><default>
+csi_d1 = port:PG05<3><default><default><default>
+csi_d2 = port:PG06<3><default><default><default>
+csi_d3 = port:PG07<3><default><default><default>
+csi_d4 = port:PG08<3><default><default><default>
+csi_d5 = port:PG09<3><default><default><default>
+csi_d6 = port:PG10<3><default><default><default>
+csi_d7 = port:PG11<3><default><default><default>
+csi_reset = port:PH14<1><default><default><0>
+csi_power_en =
+csi_stby = port:PH17<1><default><default><0>
+
+[tvout_para]
+tvout_used = 1
+tvout_channel_num = 1
+
+[tvin_para]
+tvin_used = 0
+tvin_channel_num = 4
+
+[sata_para]
+sata_used = 1
+sata_power_en = port:PB08<1><default><default><0>
+
+[mmc0_para]
+sdc_used = 1
+sdc_detmode = 1
+sdc_buswidth = 4
+sdc_clk = port:PF02<2><1><2><default>
+sdc_cmd = port:PF03<2><1><2><default>
+sdc_d0 = port:PF01<2><1><2><default>
+sdc_d1 = port:PF00<2><1><2><default>
+sdc_d2 = port:PF05<2><1><2><default>
+sdc_d3 = port:PF04<2><1><2><default>
+sdc_det = port:PH01<0><1><default><default>
+sdc_use_wp = 0
+sdc_wp =
+sdc_isio = 0
+sdc_regulator = "none"
+
+[mmc1_para]
+sdc_used = 0
+sdc_detmode = 1
+sdc_buswidth = 4
+sdc_clk = port:PG04<2><1><2><default>
+sdc_cmd = port:PG03<2><1><2><default>
+sdc_d0 = port:PG05<2><1><2><default>
+sdc_d1 = port:PG06<2><1><2><default>
+sdc_d2 = port:PG07<2><1><2><default>
+sdc_d3 = port:PG08<2><1><2><default>
+sdc_det = port:PG13<0><1><default><default>
+sdc_use_wp = 0
+sdc_wp =
+sdc_isio = 0
+sdc_regulator = "none"
+
+[mmc2_para]
+sdc_used = 1
+sdc_detmode = 3
+sdc_buswidth = 4
+sdc_cmd = port:PC06<3><1><2><default>
+sdc_clk = port:PC07<3><1><2><default>
+sdc_d0 = port:PC08<3><1><2><default>
+sdc_d1 = port:PC09<3><1><2><default>
+sdc_d2 = port:PC10<3><1><2><default>
+sdc_d3 = port:PC11<3><1><2><default>
+sdc_det =
+sdc_use_wp = 0
+sdc_wp =
+sdc_isio = 0
+sdc_regulator = "none"
+
+[mmc3_para]
+sdc_used = 1
+sdc_detmode = 1
+sdc_buswidth = 4
+sdc_cmd = port:PI04<2><1><2><default>
+sdc_clk = port:PI05<2><1><2><default>
+sdc_d0 = port:PI06<2><1><2><default>
+sdc_d1 = port:PI07<2><1><2><default>
+sdc_d2 = port:PI08<2><1><2><default>
+sdc_d3 = port:PI09<2><1><2><default>
+sdc_det = port:PH11<0><1><default><default>
+sdc_use_wp = 0
+sdc_wp =
+sdc_isio = 1
+sdc_regulator = "none"
+
+[ms_para]
+ms_used = 0
+ms_bs = port:PH06<5><default><default><default>
+ms_clk = port:PH07<5><default><default><default>
+ms_d0 = port:PH08<5><default><default><default>
+ms_d1 = port:PH09<5><default><default><default>
+ms_d2 = port:PH10<5><default><default><default>
+ms_d3 = port:PH11<5><default><default><default>
+ms_det =
+
+[smc_para]
+smc_used = 0
+smc_rst = port:PH13<5><default><default><default>
+smc_vppen = port:PH14<5><default><default><default>
+smc_vppp = port:PH15<5><default><default><default>
+smc_det = port:PH16<5><default><default><default>
+smc_vccen = port:PH17<5><default><default><default>
+smc_sck = port:PH18<5><default><default><default>
+smc_sda = port:PH19<5><default><default><default>
+
+[ps2_0_para]
+ps2_used = 0
+ps2_scl = port:PI20<2><1><default><default>
+ps2_sda = port:PI21<2><1><default><default>
+
+[ps2_1_para]
+ps2_used = 0
+ps2_scl = port:PI14<3><1><default><default>
+ps2_sda = port:PI15<3><1><default><default>
+
+[can_para]
+can_used = 0
+can_tx = port:PA16<3><default><default><default>
+can_rx = port:PA17<3><default><default><default>
+
+[keypad_para]
+kp_used = 0
+kp_in_size = 8
+kp_out_size = 8
+kp_in0 = port:PH08<4><1><default><default>
+kp_in1 = port:PH09<4><1><default><default>
+kp_in2 = port:PH10<4><1><default><default>
+kp_in3 = port:PH11<4><1><default><default>
+kp_in4 = port:PH14<4><1><default><default>
+kp_in5 = port:PH15<4><1><default><default>
+kp_in6 = port:PH16<4><1><default><default>
+kp_in7 = port:PH17<4><1><default><default>
+kp_out0 = port:PH18<4><1><default><default>
+kp_out1 = port:PH19<4><1><default><default>
+kp_out2 = port:PH22<4><1><default><default>
+kp_out3 = port:PH23<4><1><default><default>
+kp_out4 = port:PH24<4><1><default><default>
+kp_out5 = port:PH25<4><1><default><default>
+kp_out6 = port:PH26<4><1><default><default>
+kp_out7 = port:PH27<4><1><default><default>
+
+[usbc0]
+usb_used = 1
+usb_port_type = 2
+usb_detect_type = 1
+usb_id_gpio = port:PH04<0><1><default><default>
+usb_det_vbus_gpio = port:PH05<0><0><default><default>
+usb_drv_vbus_gpio = port:PB09<1><0><default><0>
+usb_host_init_state = 0
+usb_restric_flag = 0
+usb_restric_voltage = 3550000
+usb_restric_capacity = 5
+
+[usbc1]
+usb_used = 1
+usb_port_type = 1
+usb_detect_type = 0
+usb_drv_vbus_gpio = port:PH06<1><0><default><0>
+usb_restrict_gpio =
+usb_host_init_state = 1
+usb_restric_flag = 0
+
+[usbc2]
+usb_used = 1
+usb_port_type = 1
+usb_detect_type = 0
+usb_drv_vbus_gpio = port:PH03<1><0><default><0>
+usb_restrict_gpio =
+usb_host_init_state = 1
+usb_restric_flag = 0
+
+[usb_feature]
+vendor_id = 6353
+mass_storage_id = 1
+adb_id = 2
+manufacturer_name = "USB Developer"
+product_name = "Android"
+serial_number = "20080411"
+
+[msc_feature]
+vendor_name = "USB 2.0"
+product_name = "USB Flash Driver"
+release = 100
+luns = 3
+
+[gsensor_para]
+gsensor_used = 1
+gsensor_twi_id = 1
+gsensor_int1 =
+gsensor_int2 =
+
+[gps_para]
+gps_used = 0
+gps_spi_id = 2
+gps_spi_cs_num = 0
+gps_lradc = 1
+gps_clk = port:PI00<2><default><default><default>
+gps_sign = port:PI01<2><default><default><default>
+gps_mag = port:PI02<2><default><default><default>
+gps_vcc_en = port:PC22<1><default><default><0>
+gps_osc_en = port:PI14<1><default><default><0>
+gps_rx_en = port:PI15<1><default><default><0>
+
+[wifi_para]
+wifi_used = 0
+wifi_sdc_id = 3
+wifi_usbc_id = 2
+wifi_usbc_type = 1
+wifi_mod_sel = 7
+wifi_power = ""
+rtk_rtl8723as_wl_dis = port:PH09<1><default><default><0>
+rtk_rtl8723as_bt_dis = port:PB05<1><default><default><0>
+rtk_rtl8723as_wl_host_wake = port:PH10<0><default><default><0>
+rtk_rtl8723as_bt_host_wake = port:PI21<0><default><default><0>
+ap6xxx_wl_regon = port:PH09<1><default><default><0>
+ap6xxx_wl_host_wake = port:PH10<0><default><default><0>
+ap6xxx_bt_regon = port:PB05<1><default><default><0>
+ap6xxx_bt_wake = port:PI20<1><default><default><0>
+ap6xxx_bt_host_wake = port:PI21<0><default><default><0>
+
+[3g_para]
+3g_used = 0
+3g_usbc_num = 2
+3g_uart_num = 0
+3g_pwr =
+3g_wakeup =
+3g_int =
+
+[gy_para]
+gy_used = 0
+gy_twi_id = 1
+gy_twi_addr = 0
+gy_int1 = port:PH18<6><1><default><default>
+gy_int2 = port:PH19<6><1><default><default>
+
+[ls_para]
+ls_used = 0
+ls_twi_id = 1
+ls_twi_addr = 0
+ls_int = port:PH20<6><1><default><default>
+
+[compass_para]
+compass_used = 0
+compass_twi_id = 1
+compass_twi_addr = 0
+compass_int = port:PI13<6><1><default><default>
+
+[bt_para]
+bt_used = 0
+bt_uart_id = 2
+bt_wakeup = port:PI20<1><default><default><default>
+bt_gpio = port:PI21<1><default><default><default>
+bt_rst = port:PB05<1><default><default><default>
+
+[i2s_para]
+i2s_used = 0
+i2s_channel = 2
+i2s_mclk = port:PB05<2><1><default><default>
+i2s_bclk = port:PB06<2><1><default><default>
+i2s_lrclk = port:PB07<2><1><default><default>
+i2s_dout0 = port:PB08<2><1><default><default>
+i2s_dout1 =
+i2s_dout2 =
+i2s_dout3 =
+i2s_din = port:PB12<2><1><default><default>
+
+[spdif_para]
+spdif_used = 0
+spdif_mclk =
+spdif_dout = port:PB13<4><1><default><default>
+spdif_din =
+
+[audio_para]
+audio_used = 1
+capture_used = 1
+playback_used = 1
+audio_lr_change = 0
+
+[switch_para]
+switch_used = 1
+
+[ir_para]
+ir_used = 0
+ir0_rx = port:PB04<2><default><default><default>
+
+[pmu_para]
+pmu_used = 1
+pmu_twi_addr = 52
+pmu_twi_id = 0
+pmu_irq_id = 32
+pmu_battery_rdc = 100
+pmu_battery_cap = 3200
+pmu_init_chgcur = 300
+pmu_earlysuspend_chgcur = 600
+pmu_suspend_chgcur = 1000
+pmu_resume_chgcur = 300
+pmu_shutdown_chgcur = 1000
+pmu_init_chgvol = 4200
+pmu_init_chgend_rate = 15
+pmu_init_chg_enabled = 1
+pmu_init_adc_freq = 100
+pmu_init_adc_freqc = 100
+pmu_init_chg_pretime = 50
+pmu_init_chg_csttime = 720
+pmu_bat_para1 = 0
+pmu_bat_para2 = 0
+pmu_bat_para3 = 0
+pmu_bat_para4 = 0
+pmu_bat_para5 = 5
+pmu_bat_para6 = 8
+pmu_bat_para7 = 11
+pmu_bat_para8 = 22
+pmu_bat_para9 = 33
+pmu_bat_para10 = 43
+pmu_bat_para11 = 50
+pmu_bat_para12 = 59
+pmu_bat_para13 = 71
+pmu_bat_para14 = 83
+pmu_bat_para15 = 92
+pmu_bat_para16 = 100
+pmu_usbvol_limit = 1
+pmu_usbcur_limit = 0
+pmu_usbvol = 4000
+pmu_usbcur = 0
+pmu_usbvol_pc = 4000
+pmu_usbcur_pc = 0
+pmu_pwroff_vol = 3300
+pmu_pwron_vol = 2900
+pmu_pekoff_time = 6000
+pmu_pekoff_en = 1
+pmu_peklong_time = 1500
+pmu_pekon_time = 1000
+pmu_pwrok_time = 64
+pmu_pwrnoe_time = 2000
+pmu_intotp_en = 1
+pmu_used2 = 0
+pmu_adpdet = port:PH02<0><default><default><default>
+pmu_init_chgcur2 = 400
+pmu_earlysuspend_chgcur2 = 600
+pmu_suspend_chgcur2 = 1200
+pmu_resume_chgcur2 = 400
+pmu_shutdown_chgcur2 = 1200
+pmu_suspendpwroff_vol = 3500
+pmu_batdeten = 1
+
+[recovery_key]
+key_min = 4
+key_max = 6
+
+[dvfs_table]
+max_freq = 1008000000
+min_freq = 408000000
+LV_count = 7
+LV1_freq = 1008000000
+LV1_volt = 1450
+LV2_freq = 912000000
+LV2_volt = 1400
+LV3_freq = 864000000
+LV3_volt = 1300
+LV4_freq = 720000000
+LV4_volt = 1200
+LV5_freq = 528000000
+LV5_volt = 1100
+LV6_freq = 312000000
+LV6_volt = 1000
+LV7_freq = 144000000
+LV7_volt = 1000
+[gpio_para]
+gpio_used = 1
+gpio_num = 61
+gpio_pin_1 = port:PG00<0><default><default><default>
+gpio_pin_2 = port:PG01<0><default><default><default>
+gpio_pin_3 = port:PG02<0><default><default><default>
+gpio_pin_4 = port:PG03<0><default><default><default>
+gpio_pin_5 = port:PG04<0><default><default><default>
+gpio_pin_6 = port:PG05<0><default><default><default>
+gpio_pin_7 = port:PG06<0><default><default><default>
+gpio_pin_8 = port:PG07<0><default><default><default>
+gpio_pin_9 = port:PG08<0><default><default><default>
+gpio_pin_10 = port:PG09<0><default><default><default>
+gpio_pin_11 = port:PC07<0><default><default><default>
+gpio_pin_12 = port:PC17<0><default><default><default>
+gpio_pin_13 = port:PC18<0><default><default><default>
+gpio_pin_14 = port:PC23<0><default><default><default>
+gpio_pin_15 = port:PC24<0><default><default><default>
+gpio_pin_16 = port:PH00<0><default><default><default>
+gpio_pin_17 = port:PH02<0><default><default><default>
+gpio_pin_18 = port:PH09<0><default><default><default>
+gpio_pin_19 = port:PH10<0><default><default><default>
+gpio_pin_20 = port:PH11<0><default><default><default>
+gpio_pin_21 = port:PH14<0><default><default><default>
+gpio_pin_22 = port:PH15<0><default><default><default>
+gpio_pin_23 = port:PH16<0><default><default><default>
+gpio_pin_24 = port:PH17<0><default><default><default>
+gpio_pin_25 = port:PH18<0><default><default><default>
+gpio_pin_26 = port:PH19<0><default><default><default>
+gpio_pin_27 = port:PH20<0><default><default><default>
+gpio_pin_28 = port:PH21<0><default><default><default>
+gpio_pin_29 = port:PH22<0><default><default><default>
+gpio_pin_30 = port:PH23<0><default><default><default>
+gpio_pin_31 = port:PH24<0><default><default><default>
+gpio_pin_32 = port:PH25<0><default><default><default>
+gpio_pin_33 = port:PH26<0><default><default><default>
+gpio_pin_34 = port:PH27<0><default><default><default>
+gpio_pin_35 = port:PB03<0><default><default><default>
+gpio_pin_36 = port:PB04<0><default><default><default>
+gpio_pin_37 = port:PB05<0><default><default><default>
+gpio_pin_38 = port:PB06<0><default><default><default>
+gpio_pin_39 = port:PB07<0><default><default><default>
+gpio_pin_40 = port:PB10<0><default><default><default>
+gpio_pin_41 = port:PB11<0><default><default><default>
+gpio_pin_42 = port:PB12<0><default><default><default>
+gpio_pin_43 = port:PB13<0><default><default><default>
+gpio_pin_44 = port:PB14<0><default><default><default>
+gpio_pin_45 = port:PB15<0><default><default><default>
+gpio_pin_46 = port:PB16<0><default><default><default>
+gpio_pin_47 = port:PB17<0><default><default><default>
+gpio_pin_48 = port:PI00<0><default><default><default>
+gpio_pin_49 = port:PI01<0><default><default><default>
+gpio_pin_50 = port:PI02<0><default><default><default>
+gpio_pin_51 = port:PI03<0><default><default><default>
+gpio_pin_52 = port:PI04<0><default><default><default>
+gpio_pin_53 = port:PI05<0><default><default><default>
+gpio_pin_54 = port:PI06<0><default><default><default>
+gpio_pin_55 = port:PI07<0><default><default><default>
+gpio_pin_56 = port:PI08<0><default><default><default>
+gpio_pin_57 = port:PI09<0><default><default><default>
+gpio_pin_58 = port:PI10<0><default><default><default>
+gpio_pin_59 = port:PI11<0><default><default><default>
+gpio_pin_60 = port:PI14<0><default><default><default>
+gpio_pin_61 = port:PI15<0><default><default><default>
+
+[gpio_init]
+pin_1 = port:PG00<0><default><default><default>
+pin_2 = port:PG01<0><default><default><default>
+pin_3 = port:PG02<0><default><default><default>
+pin_4 = port:PG03<0><default><default><default>
+pin_5 = port:PG04<0><default><default><default>
+pin_6 = port:PG05<0><default><default><default>
+pin_7 = port:PG06<0><default><default><default>
+pin_8 = port:PG07<0><default><default><default>
+pin_9 = port:PG08<0><default><default><default>
+pin_10 = port:PG09<0><default><default><default>
+pin_11 = port:PC07<0><default><default><default>
+pin_12 = port:PC17<0><default><default><default>
+pin_13 = port:PC18<0><default><default><default>
+pin_14 = port:PC23<0><default><default><default>
+pin_15 = port:PC24<0><default><default><default>
+pin_16 = port:PH00<0><default><default><default>
+pin_17 = port:PH02<0><default><default><default>
+pin_18 = port:PH09<0><default><default><default>
+pin_19 = port:PH10<0><default><default><default>
+pin_20 = port:PH11<0><default><default><default>
+pin_21 = port:PH14<0><default><default><default>
+pin_22 = port:PH15<0><default><default><default>
+pin_23 = port:PH16<0><default><default><default>
+pin_24 = port:PH17<0><default><default><default>
+pin_25 = port:PH18<0><default><default><default>
+pin_26 = port:PH19<0><default><default><default>
+pin_27 = port:PH20<0><default><default><default>
+pin_28 = port:PH21<0><default><default><default>
+pin_29 = port:PH22<0><default><default><default>
+pin_30 = port:PH23<0><default><default><default>
+pin_31 = port:PH24<0><default><default><default>
+pin_32 = port:PH25<0><default><default><default>
+pin_33 = port:PH26<0><default><default><default>
+pin_34 = port:PH27<0><default><default><default>
+pin_35 = port:PB03<0><default><default><default>
+pin_36 = port:PB04<0><default><default><default>
+pin_37 = port:PB05<0><default><default><default>
+pin_38 = port:PB06<0><default><default><default>
+pin_39 = port:PB07<0><default><default><default>
+pin_40 = port:PB10<0><default><default><default>
+pin_41 = port:PB11<0><default><default><default>
+pin_42 = port:PB12<0><default><default><default>
+pin_43 = port:PB13<0><default><default><default>
+pin_44 = port:PB14<0><default><default><default>
+pin_45 = port:PB15<0><default><default><default>
+pin_46 = port:PB16<0><default><default><default>
+pin_47 = port:PB17<0><default><default><default>
+pin_48 = port:PI00<0><default><default><default>
+pin_49 = port:PI01<0><default><default><default>
+pin_50 = port:PI02<0><default><default><default>
+pin_51 = port:PI03<0><default><default><default>
+pin_52 = port:PI04<0><default><default><default>
+pin_53 = port:PI05<0><default><default><default>
+pin_54 = port:PI06<0><default><default><default>
+pin_55 = port:PI07<0><default><default><default>
+pin_56 = port:PI08<0><default><default><default>
+pin_57 = port:PI09<0><default><default><default>
+pin_58 = port:PI10<0><default><default><default>
+pin_59 = port:PI11<0><default><default><default>
+pin_60 = port:PI14<0><default><default><default>
+pin_61 = port:PI15<0><default><default><default>
+
+[softpwm_para]
+softpwm_used = 1
+pwm_pin = port:PD23<0><default><default><default>
+dcr_pin = port:PD24<0><default><default><default>
+
+
+[tabletkeys_para]
+tabletkeys_used = 1

--- a/patch/kernel/sun7i-default/board_micro-emmc/fix_emmc_hpi.patch
+++ b/patch/kernel/sun7i-default/board_micro-emmc/fix_emmc_hpi.patch
@@ -1,0 +1,35 @@
+diff --git a/drivers/mmc/core/mmc.c b/drivers/mmc/core/mmc.c
+index 5352cd7..0004b8f 100644
+--- a/drivers/mmc/core/mmc.c
++++ b/drivers/mmc/core/mmc.c
+@@ -480,21 +480,6 @@ static int mmc_read_ext_csd(struct mmc_card *card, u8 *ext_csd)
+ 	}
+ 
+ 	if (card->ext_csd.rev >= 5) {
+-		/* check whether the eMMC card supports HPI */
+-		if (ext_csd[EXT_CSD_HPI_FEATURES] & 0x1) {
+-			card->ext_csd.hpi = 1;
+-			if (ext_csd[EXT_CSD_HPI_FEATURES] & 0x2)
+-				card->ext_csd.hpi_cmd =	MMC_STOP_TRANSMISSION;
+-			else
+-				card->ext_csd.hpi_cmd = MMC_SEND_STATUS;
+-			/*
+-			 * Indicate the maximum timeout to close
+-			 * a command interrupted by HPI
+-			 */
+-			card->ext_csd.out_of_int_time =
+-				ext_csd[EXT_CSD_OUT_OF_INTERRUPT_TIME] * 10;
+-		}
+-
+ 		card->ext_csd.rel_param = ext_csd[EXT_CSD_WR_REL_PARAM];
+ 		card->ext_csd.rst_n_function = ext_csd[EXT_CSD_RST_N_FUNCTION];
+ 	}
+@@ -1026,7 +1011,7 @@ static int mmc_init_card(struct mmc_host *host, u32 ocr,
+ 		err = 0;
+ 		if (card->ext_csd.hs_max_dtr > 52000000 &&
+ 		    host->caps2 & MMC_CAP2_HS200)
+-			err = mmc_select_hs200(card);
++			err = -EBADMSG;
+ 		else if	(host->caps & MMC_CAP_MMC_HIGHSPEED)
+ 			err = mmc_switch(card, EXT_CSD_CMD_SET_NORMAL,
+ 					 EXT_CSD_HS_TIMING, 1,

--- a/patch/kernel/sunxi-next/add-a20-olinuxino-micro-emmc-support.patch
+++ b/patch/kernel/sunxi-next/add-a20-olinuxino-micro-emmc-support.patch
@@ -1,0 +1,98 @@
+diff --git a/arch/arm/boot/dts/Makefile b/arch/arm/boot/dts/Makefile
+index 175523f..4b024d2 100644
+--- a/arch/arm/boot/dts/Makefile
++++ b/arch/arm/boot/dts/Makefile
+@@ -867,6 +867,7 @@ dtb-$(CONFIG_MACH_SUN7I) += \
+ 	sun7i-a20-olinuxino-lime2.dtb \
+ 	sun7i-a20-olinuxino-lime2-emmc.dtb \
+ 	sun7i-a20-olinuxino-micro.dtb \
++	sun7i-a20-olinuxino-micro-emmc.dtb \
+ 	sun7i-a20-orangepi.dtb \
+ 	sun7i-a20-orangepi-mini.dtb \
+ 	sun7i-a20-pcduino3.dtb \
+diff --git a/arch/arm/boot/dts/sun7i-a20-olinuxino-micro-emmc.dts b/arch/arm/boot/dts/sun7i-a20-olinuxino-micro-emmc.dts
+new file mode 100644
+index 0000000..9ee2800
+--- /dev/null
++++ b/arch/arm/boot/dts/sun7i-a20-olinuxino-micro-emmc.dts
+@@ -0,0 +1,80 @@
++ /*
++ * Copyright 2017 Olimex Ltd.
++ * Stefan Mavrodiev <stefan@olimex.com>
++ *
++ * This file is dual-licensed: you can use it either under the terms
++ * of the GPL or the X11 license, at your option. Note that this dual
++ * licensing only applies to this file, and not this project as a
++ * whole.
++ *
++ *  a) This file is free software; you can redistribute it and/or
++ *     modify it under the terms of the GNU General Public License as
++ *     published by the Free Software Foundation; either version 2 of the
++ *     License, or (at your option) any later version.
++ *
++ *     This file is distributed in the hope that it will be useful,
++ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *     GNU General Public License for more details.
++ *
++ * Or, alternatively,
++ *
++ *  b) Permission is hereby granted, free of charge, to any person
++ *     obtaining a copy of this software and associated documentation
++ *     files (the "Software"), to deal in the Software without
++ *     restriction, including without limitation the rights to use,
++ *     copy, modify, merge, publish, distribute, sublicense, and/or
++ *     sell copies of the Software, and to permit persons to whom the
++ *     Software is furnished to do so, subject to the following
++ *     conditions:
++ *
++ *     The above copyright notice and this permission notice shall be
++ *     included in all copies or substantial portions of the Software.
++ *
++ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
++ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
++ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
++ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
++ *     OTHER DEALINGS IN THE SOFTWARE.
++ */
++
++#include "sun7i-a20-olinuxino-micro.dts"
++
++/ {
++	model = "Olimex A20-OLinuXino-MICRO-eMMC";
++	compatible = "olimex,a20-olinuxino-micro-emmc", "allwinner,sun7i-a20";
++
++	mmc2_pwrseq: pwrseq {
++		pinctrl-0 = <&mmc2_pins_nrst>;
++		pinctrl-names = "default";
++		compatible = "mmc-pwrseq-emmc";
++		reset-gpios = <&pio 2 16 GPIO_ACTIVE_LOW>;
++	};
++};
++
++&pio {
++	mmc2_pins_nrst: mmc2-rst-pin {
++		pins = "PC16";
++		function = "gpio_out";
++	};
++};
++
++&mmc2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mmc2_pins_a>;
++	vmmc-supply = <&reg_vcc3v3>;
++	vqmmc-supply = <&reg_vcc3v3>;
++	bus-width = <4>;
++	non-removable;
++	mmc-pwrseq = <&mmc2_pwrseq>;
++	status = "okay";
++
++	emmc: emmc@0 {
++		reg = <0>;
++		compatible = "mmc-card";
++		broken-hpi;
++	};
++};

--- a/patch/kernel/sunxi-next/fix-a20-olinuxino-micro-lan8710-support.patch
+++ b/patch/kernel/sunxi-next/fix-a20-olinuxino-micro-lan8710-support.patch
@@ -1,0 +1,25 @@
+diff --git a/arch/arm/boot/dts/sun7i-a20-olinuxino-micro.dts b/arch/arm/boot/dts/sun7i-a20-olinuxino-micro.dts
+index def0ad8..3843b69 100644
+--- a/arch/arm/boot/dts/sun7i-a20-olinuxino-micro.dts
++++ b/arch/arm/boot/dts/sun7i-a20-olinuxino-micro.dts
+@@ -102,7 +102,7 @@
+ 
+ &gmac {
+ 	pinctrl-names = "default";
+-	pinctrl-0 = <&gmac_pins_mii_a>;
++	pinctrl-0 = <&gmac_pins_mii_a>,<&gmac_txerr>;
+ 	phy = <&phy1>;
+ 	phy-mode = "mii";
+ 	status = "okay";
+@@ -229,6 +229,11 @@
+ };
+ 
+ &pio {
++	gmac_txerr: gmac_txerr@0 {
++		pins = "PA17";
++		function = "gmac";
++	};
++
+ 	mmc3_cd_pin_olinuxinom: mmc3_cd_pin@0 {
+ 		pins = "PH11";
+ 		function = "gpio_in";

--- a/patch/u-boot/u-boot-sunxi/add-a20-olinuxino-micro-emmc-support.patch
+++ b/patch/u-boot/u-boot-sunxi/add-a20-olinuxino-micro-emmc-support.patch
@@ -1,0 +1,160 @@
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index 9cc5c1e..7ed687e 100644
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -281,6 +281,7 @@ dtb-$(CONFIG_MACH_SUN7I) += \
+ 	sun7i-a20-olinuxino-lime2.dtb \
+ 	sun7i-a20-olinuxino-lime2-emmc.dtb \
+ 	sun7i-a20-olinuxino-micro.dtb \
++	sun7i-a20-olinuxino-micro-emmc.dtb \
+ 	sun7i-a20-orangepi.dtb \
+ 	sun7i-a20-orangepi-mini.dtb \
+ 	sun7i-a20-pcduino3.dtb \
+diff --git a/arch/arm/dts/sun7i-a20-olinuxino-micro-emmc.dts b/arch/arm/dts/sun7i-a20-olinuxino-micro-emmc.dts
+new file mode 100644
+index 0000000..a39247a
+--- /dev/null
++++ b/arch/arm/dts/sun7i-a20-olinuxino-micro-emmc.dts
+@@ -0,0 +1,83 @@
++ /*
++ * Copyright 2017 Olimex Ltd.
++ * Stefan Mavrodiev <stefan@olimex.com>
++ *
++ * This file is dual-licensed: you can use it either under the terms
++ * of the GPL or the X11 license, at your option. Note that this dual
++ * licensing only applies to this file, and not this project as a
++ * whole.
++ *
++ *  a) This file is free software; you can redistribute it and/or
++ *     modify it under the terms of the GNU General Public License as
++ *     published by the Free Software Foundation; either version 2 of the
++ *     License, or (at your option) any later version.
++ *
++ *     This file is distributed in the hope that it will be useful,
++ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *     GNU General Public License for more details.
++ *
++ * Or, alternatively,
++ *
++ *  b) Permission is hereby granted, free of charge, to any person
++ *     obtaining a copy of this software and associated documentation
++ *     files (the "Software"), to deal in the Software without
++ *     restriction, including without limitation the rights to use,
++ *     copy, modify, merge, publish, distribute, sublicense, and/or
++ *     sell copies of the Software, and to permit persons to whom the
++ *     Software is furnished to do so, subject to the following
++ *     conditions:
++ *
++ *     The above copyright notice and this permission notice shall be
++ *     included in all copies or substantial portions of the Software.
++ *
++ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
++ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
++ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
++ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
++ *     OTHER DEALINGS IN THE SOFTWARE.
++ */
++
++#include "sun7i-a20-olinuxino-micro.dts"
++
++/ {
++	model = "Olimex A20-OLinuXino-MICRO-eMMC";
++	compatible = "olimex,a20-olinuxino-micro-emmc", "allwinner,sun7i-a20";
++
++	mmc2_pwrseq: pwrseq {
++                pinctrl-0 = <&mmc2_pins_nrst>;
++                pinctrl-names = "default";
++                compatible = "mmc-pwrseq-emmc";
++                reset-gpios = <&pio 2 16 GPIO_ACTIVE_LOW>;
++        };
++};
++
++&pio {
++        mmc2_pins_nrst: mmc2@0 {
++                allwinner,pins = "PC16";
++                allwinner,function = "gpio_out";
++                allwinner,drive = <SUN4I_PINCTRL_10_MA>;
++                allwinner,pull = <SUN4I_PINCTRL_NO_PULL>;
++        };
++};
++
++&mmc2 {
++        pinctrl-names = "default";
++        pinctrl-0 = <&mmc2_pins_a>;
++        vmmc-supply = <&reg_vcc3v3>;
++        vqmmc-supply = <&reg_vcc3v3>;
++        bus-width = <4>;
++        non-removable;
++        mmc-pwrseq = <&mmc2_pwrseq>;
++        status = "okay";
++
++        emmc: emmc@0 {
++                reg = <0>;
++                compatible = "mmc-card";
++                broken-hpi;
++        };
++};
++
+diff --git a/arch/arm/dts/sun7i-a20-olinuxino-micro.dts b/arch/arm/dts/sun7i-a20-olinuxino-micro.dts
+index 7e3006f..eb701e3 100644
+--- a/arch/arm/dts/sun7i-a20-olinuxino-micro.dts
++++ b/arch/arm/dts/sun7i-a20-olinuxino-micro.dts
+@@ -95,7 +95,7 @@
+ 
+ &gmac {
+ 	pinctrl-names = "default";
+-	pinctrl-0 = <&gmac_pins_mii_a>;
++	pinctrl-0 = <&gmac_pins_mii_a>,<&gmac_txerr>;
+ 	phy = <&phy1>;
+ 	phy-mode = "mii";
+ 	status = "okay";
+@@ -226,6 +226,13 @@
+ };
+ 
+ &pio {
++	gmac_txerr: gmac_txerr@0 {
++		allwinner,pins = "PA17";
++		allwinner,function = "gmac";
++		allwinner,drive = <SUN4I_PINCTRL_10_MA>;
++		allwinner,pull = <SUN4I_PINCTRL_NO_PULL>;
++	};
++
+ 	mmc3_cd_pin_olinuxinom: mmc3_cd_pin@0 {
+ 		allwinner,pins = "PH11";
+ 		allwinner,function = "gpio_in";
+diff --git a/configs/A20-OLinuXino_MICRO_eMMC_defconfig b/configs/A20-OLinuXino_MICRO_eMMC_defconfig
+new file mode 100644
+index 0000000..1ec93e4
+--- /dev/null
++++ b/configs/A20-OLinuXino_MICRO_eMMC_defconfig
+@@ -0,0 +1,26 @@
++CONFIG_ARM=y
++CONFIG_ARCH_SUNXI=y
++CONFIG_MACH_SUN7I=y
++CONFIG_DRAM_CLK=384
++CONFIG_MMC0_CD_PIN="PH1"
++CONFIG_MMC3_CD_PIN="PH11"
++CONFIG_MMC_SUNXI_SLOT_EXTRA=2
++CONFIG_I2C1_ENABLE=y
++CONFIG_VIDEO_VGA=y
++CONFIG_SATAPWR="PB8"
++CONFIG_DEFAULT_DEVICE_TREE="sun7i-a20-olinuxino-micro-emmc"
++CONFIG_AHCI=y
++# CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
++CONFIG_SPL=y
++CONFIG_SPL_I2C_SUPPORT=y
++# CONFIG_CMD_IMLS is not set
++# CONFIG_CMD_FLASH is not set
++# CONFIG_CMD_FPGA is not set
++# CONFIG_SPL_DOS_PARTITION is not set
++# CONFIG_SPL_ISO_PARTITION is not set
++# CONFIG_SPL_EFI_PARTITION is not set
++CONFIG_ETH_DESIGNWARE=y
++CONFIG_SUN7I_GMAC=y
++CONFIG_AXP_ALDO3_VOLT=2800
++CONFIG_AXP_ALDO4_VOLT=2800
++CONFIG_USB_EHCI_HCD=y


### PR DESCRIPTION
### About A20-OLinuXino-MICRO
From revision J the board has new PHY - LAN8710 which replace RTL8201. Because of that
pin PA17 needs to be additionally muxed to "gmac" function. Otherwise the phy will not work.
This is back compatible with older boards.

### About A20-OLinuXino-MICRO-eMMC
Apart from new PHY, there is new option -4GB eMMC. The support includes

- configuration for Armbian build script
- u-boot defconfig and .dts file
- kernel .dts file and .fex file for the legacy one

To work HPI must be disabled in the kernel driver. 