### PR TITLE
Disable VirtualBox GUI by default.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,8 +38,8 @@ Vagrant.configure(2) do |config|
     config.vm.provider "virtualbox" do |vb|
         vb.name = "Armbian Builder"
 
-        # comment this to disable the VirtualBox GUI
-        vb.gui = true
+        # Uncomment this to enable the VirtualBox GUI
+        #vb.gui = true
 
         # Tweak these to fit your needs.
         #vb.memory = "8192"


### PR DESCRIPTION
Enabling the GUI prevents build from running on headless servers (automated build systems, etc.). Disabling the GUI by default allows clean tracking of the repository.

The VirtualBox GUI nearly never provides any useful information on desktops anyway. `vagrant up` doesn't return until the box is booted, so the GUI doesn't serve as a status indicator.