### PR TITLE
Vagrant provision create output and userpatches directory.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,6 +7,7 @@ $provisioning_script = <<SCRIPT
 # use remote git version instead of sharing a copy from host to preserve proper file permissions
 # and prevent permission related issues for the temp directory
 git clone https://github.com/armbian/build /home/ubuntu/armbian
+mkdir -p /vagrant/output /vagrant/userpatches
 ln -sf /vagrant/output /home/ubuntu/armbian/output
 ln -sf /vagrant/userpatches /home/ubuntu/armbian/userpatches
 SCRIPT


### PR DESCRIPTION
Without the output directory, builds will fail.

Docker also creates these directories: https://github.com/armbian/build/blob/master/config-docker.conf#L13

This PR replaces https://github.com/armbian/build/pull/749