### PR TITLE
Vagrant-based setup: do not clone Armbian again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,10 @@ ubuntu-*-cloudimg-console.log
 
 ### output directories
 /.tmp/
+.tmp
 /output/
 /cache/
+cache
 /userpatches/
 
 ### General annoyances ###

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,12 +4,9 @@
 Vagrant.require_version ">= 1.5"
 
 $provisioning_script = <<SCRIPT
-# use remote git version instead of sharing a copy from host to preserve proper file permissions
-# and prevent permission related issues for the temp directory
-git clone https://github.com/armbian/build /home/ubuntu/armbian
-mkdir -p /vagrant/output /vagrant/userpatches
-ln -sf /vagrant/output /home/ubuntu/armbian/output
-ln -sf /vagrant/userpatches /home/ubuntu/armbian/userpatches
+mkdir -p /vagrant/output /vagrant/userpatches /home/ubuntu/cache /home/ubuntu/.tmp
+ln -sf /home/ubuntu/cache /vagrant/cache
+ln -sf /home/ubuntu/.tmp /vagrant/.tmp
 SCRIPT
 
 Vagrant.configure(2) do |config|


### PR DESCRIPTION
The current Vagrantfile provisioning will clone the "build" repository a second time into a new directory in the VM's filesystem and build Armbian in there rather than in the /vagrant tree mounted from the host. This is apparently done because the mounted /vagrant directory doesn't support things like hardlinks, which would prevent the build from succeeding. But obviously, cloning the whole thing again from upstream is a hack, and any local changes made by developers (even committed ones that just happen to not have been reintegrated into upstream) will be silently ignored.

On closer inspection, it turns out that you can get a successful build if only the cache/ and .tmp/ subdirectories support hardlinks (i.e. are located in the VM's filesystem). Thus, this PR does away with the upstream clone and instead builds the project in the host-mounted /vagrant directory (so all local changes will be incorporated), with only cache/ and .tmp/ symlinked out to directories in the VM. I'm getting a successful Vagrant-based build with these changes.