### PR TITLE
Update Nano Pi Neo Plus 2(nanopineoplus2) DT

### DIFF
--- a/patch/kernel/sunxi64-dev/badd-nanopineoplus2.patch
+++ b/patch/kernel/sunxi64-dev/badd-nanopineoplus2.patch
@@ -12,10 +12,10 @@ index b296f10..f361a2a 100644
  always		:= $(dtb-y)
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-neo-plus2.dts b/arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-neo-plus2.dts
 new file mode 100644
-index 0000000..f86db28
+index 0000000..b11c72d
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-neo-plus2.dts
-@@ -0,0 +1,260 @@
+@@ -0,0 +1,225 @@
 +/*
 + * Copyright (C) 2017 Antony Antony <antony@phenome.org>
 + * Copyright (C) 2016 ARM Ltd.
@@ -70,16 +70,10 @@ index 0000000..f86db28
 +	model = "FriendlyARM NanoPi NEO Plus2";
 +	compatible = "friendlyarm,nanopi-neo-plus2", "allwinner,sun50i-h5";
 +
-+	reg_vcc3v3: vcc3v3 {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc3v3";
-+		regulator-min-microvolt = <3300000>;
-+		regulator-max-microvolt = <3300000>;
-+	};
-+
 +	aliases {
 +		ethernet0 = &emac;
 +		serial0 = &uart0;
++		serial1 = &uart3;
 +	};
 +
 +	chosen {
@@ -104,7 +98,6 @@ index 0000000..f86db28
 +	reg_gmac_3v3: gmac-3v3 {
 +		compatible = "regulator-fixed";
 +		pinctrl-names = "default";
-+		pinctrl-0 = <&gmac_power_pin_nanopi>;
 +		regulator-name = "gmac-3v3";
 +		regulator-min-microvolt = <3300000>;
 +		regulator-max-microvolt = <3300000>;
@@ -113,12 +106,16 @@ index 0000000..f86db28
 +		gpio = <&pio 3 6 GPIO_ACTIVE_HIGH>;
 +	};
 +
++	reg_vcc3v3: vcc3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc3v3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++	};
++
 +	vdd_cpux: gpio-regulator {
 +		compatible = "regulator-gpio";
-+
 +		pinctrl-names = "default";
-+		pinctrl-0 = <&vdd_cpux_r_npi>;
-+
 +		regulator-name = "vdd-cpux";
 +		regulator-type = "voltage";
 +		regulator-boot-on;
@@ -126,7 +123,6 @@ index 0000000..f86db28
 +		regulator-min-microvolt = <1100000>;
 +		regulator-max-microvolt = <1300000>;
 +		regulator-ramp-delay = <50>; /* 4ms */
-+
 +		gpios = <&r_pio 0 6 GPIO_ACTIVE_HIGH>;
 +		gpios-states = <0x1>;
 +		states = <1100000 0x0
@@ -136,7 +132,6 @@ index 0000000..f86db28
 +	wifi_pwrseq: wifi_pwrseq {
 +		compatible = "mmc-pwrseq-simple";
 +		pinctrl-names = "default";
-+		pinctrl-0 = <&wifi_en_npi>;
 +		reset-gpios = <&r_pio 0 7 GPIO_ACTIVE_LOW>; /* PL7 */
 +		post-power-on-delay-ms = <200>;
 +	};
@@ -191,13 +186,8 @@ index 0000000..f86db28
 +	mmc-pwrseq = <&wifi_pwrseq>;
 +	bus-width = <4>;
 +	non-removable;
-+	boot_device = <0>;
 +	status = "okay";
 +
-+	/*
-+	 * WiFi driver support could be incomplete,
-+	 * wlan0 is able to see Base Stations, however not able to join.
-+	 */
 +	brcmf: wifi@1 {
 +		reg = <1>;
 +		compatible = "brcm,bcm4329-fmac";
@@ -211,58 +201,34 @@ index 0000000..f86db28
 +	bus-width = <8>;
 +	non-removable;
 +	cap-mmc-hw-reset;
-+	boot_device = <0>;
 +	status = "okay";
-+};
-+
-+&mmc2_8bit_pins {
-+	/* Increase drive strength for DDR modes */
-+	drive-strength = <40>;
-+	/* eMMC is missing pull-ups */
-+	bias-pull-up;
 +};
 +
 +&ohci0 {
 +	status = "okay";
 +};
 +
++&pio {
++	uart3_rts_cts_pins: uart3_rts_cts {
++		pins = "PA15", "PA16";
++		function = "uart3";
++	};
++
++};
++
 +&ohci3 {
 +	status = "okay";
-+};
-+
-+&pio {
-+	leds_npi: led_pins@0 {
-+		pins = "PA10";
-+		function = "gpio_out";
-+	};
-+	gmac_power_pin_nanopi: gmac_power_pin@0 {
-+			pins = "PD6";
-+			function = "gpio_out";
-+	};
-+};
-+
-+&r_pio {
-+	leds_r_npi: led_pins@0 {
-+		pins = "PL10";
-+		function = "gpio_out";
-+	};
-+
-+	vdd_cpux_r_npi: regulator_pins@0 {
-+		allwinner,pins = "PL6";
-+		allwinner,function = "gpio_out";
-+		allwinner,drive = <SUN4I_PINCTRL_10_MA>;
-+		allwinner,pull = <SUN4I_PINCTRL_NO_PULL>;
-+	};
-+
-+	wifi_en_npi: wifi_en_pin {
-+		pins = "PL7";
-+		function = "gpio_out";
-+	};
 +};
 +
 +&uart0 {
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&uart0_pins_a>;
++	status = "okay";
++};
++
++&uart3 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart3_pins>, <&uart3_rts_cts_pins>;
 +	status = "okay";
 +};
 +
@@ -273,6 +239,5 @@ index 0000000..f86db28
 +
 +&usbphy {
 +	/* USB Type-A ports' VBUS is always on */
-+	usb0_id_det-gpios = <&pio 6 12 GPIO_ACTIVE_HIGH>; /* PG12 */
 +	status = "okay";
 +};


### PR DESCRIPTION
updated DT with changes accepted in sunxi-next
+ enable uart3 to AP6212A Bluetooh

keep emac(stmmc) supported in icenowy/sunxi64-4.13.y
