### PR TITLE
mvebu64 switch to systemd-networkd

### DIFF
--- a/config/sources/mvebu64.conf
+++ b/config/sources/mvebu64.conf
@@ -54,6 +54,8 @@ family_tweaks()
 {
 	chroot $SDCARD /bin/bash -c "apt-get -y -qq remove --auto-remove lirc linux-sound-base alsa-base alsa-utils bluez>/dev/null 2>&1"
 	ln -sf interfaces.espressobin $SDCARD/etc/network/interfaces
- 	echo "#Marvell Espressobin Console" >> $SDCARD/etc/securetty
+	cp $SRC/packages/bsp/mvebu64/10*  $SDCARD/etc/systemd/network/
+	cp $SRC/packages/bsp/mvebu64/NetworkManager.conf  $SDCARD/etc/NetworkManager/
+	echo "#Marvell Espressobin Console" >> $SDCARD/etc/securetty
 	echo "ttyMV0" >> $SDCARD/etc/securetty
 }

--- a/packages/bsp/common/etc/init.d/firstrun
+++ b/packages/bsp/common/etc/init.d/firstrun
@@ -252,6 +252,21 @@ case "$1" in
 			sed -i "s/^\#[^ tab]\+hwaddress ether/\thwaddress ether $MACADDR/" /etc/network/interfaces
 			;;
 
+                mvebu64)
+			# configure/enable/start systemd-networkd
+                        rm /etc/resolv.conf
+                        systemctl start systemd-networkd.service
+                        systemctl start systemd-resolved.service
+                        systemctl enable systemd-networkd.service
+                        systemctl enable systemd-resolved.service
+                        ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf
+                        systemctl restart systemd-networkd
+                        #stop syslog spam
+                        systemctl stop  serial-getty@ttyS0.service
+                        systemctl disable serial-getty@ttyS0.service
+                        systemctl mask  serial-getty@ttyS0.service
+                        ;;
+
 	esac
 
 	systemctl disable firstrun

--- a/packages/bsp/common/etc/network/interfaces.espressobin
+++ b/packages/bsp/common/etc/network/interfaces.espressobin
@@ -1,16 +1,3 @@
-# All thre interfaces are bridged - to get IP via DHCP in any port
-
-auto lo br0
+# interfaces(5) file used by ifup(8) and ifdown(8)
+auto lo
 iface lo inet loopback
-
-allow-hotplug eth0
-iface eth0 inet manual
-
-allow-hotplug lan0
-iface lan0 inet manual
-
-allow-hotplug lan1
-iface lan1 inet manual
-
-iface br0 inet dhcp
-bridge_ports lan0 lan1 wan

--- a/packages/bsp/mvebu64/10-br0.netdev
+++ b/packages/bsp/mvebu64/10-br0.netdev
@@ -1,0 +1,3 @@
+[NetDev]
+Name=br0
+Kind=bridge

--- a/packages/bsp/mvebu64/10-br0.network
+++ b/packages/bsp/mvebu64/10-br0.network
@@ -1,0 +1,5 @@
+[Match]
+Name=br0
+
+[Network]
+DHCP=ipv4

--- a/packages/bsp/mvebu64/10-eth0.network
+++ b/packages/bsp/mvebu64/10-eth0.network
@@ -1,0 +1,5 @@
+[Match]
+Name=eth0
+
+[Network]
+DHCP=ipv4 

--- a/packages/bsp/mvebu64/10-lan0.network
+++ b/packages/bsp/mvebu64/10-lan0.network
@@ -1,0 +1,5 @@
+[Match]
+Name=lan0
+
+[Network]
+Bridge=br0

--- a/packages/bsp/mvebu64/10-lan1.network
+++ b/packages/bsp/mvebu64/10-lan1.network
@@ -1,0 +1,5 @@
+[Match]
+Name=lan1
+
+[Network]
+Bridge=br0

--- a/packages/bsp/mvebu64/10-wan.network
+++ b/packages/bsp/mvebu64/10-wan.network
@@ -1,0 +1,5 @@
+[Match]
+Name=wan 
+
+[Network]
+Bridge=br0

--- a/packages/bsp/mvebu64/NetworkManager.conf
+++ b/packages/bsp/mvebu64/NetworkManager.conf
@@ -1,0 +1,9 @@
+[main]
+plugins=ifupdown,keyfile,ofono
+dns=dnsmasq
+
+[ifupdown]
+managed=false
+
+[keyfile]
+unmanaged-devices=interface-name:eth*,interface-name:wan*,interface-name:lan*,interface-name:wlan*,interface-name:br*,interface-name:lo


### PR DESCRIPTION
fix of 'job for raising network interfaces' interrupting the boot sequence:
systemd-networkd is configured as a switch (with bridged interfaces)
NetworkManager is configured not to manage any interface

Espressobin now boots reliable and faster (tested)

This PR implements the suggestions related to PR #778