### PR TITLE
add nanopi-duo as community supported board

### DIFF
--- a/config/boards/nanopiduo.csc
+++ b/config/boards/nanopiduo.csc
@@ -1,0 +1,24 @@
+# H2+ quad core 256/512MB SoC Wi-Fi/Ethernet
+BOARD_NAME="NanoPi Duo"
+LINUXFAMILY="sun8i"
+BOOTCONFIG="nanopi_duo_defconfig"
+# nanopi_duo_defconfig
+MODULES="#w1-sunxi #w1-gpio #w1-therm #sunxi-cir xradio_wlan g_serial xradio_wlan"
+MODULES_NEXT="g_serial"
+MODULES_BLACKLIST="dhd"
+CPUMIN=240000
+CPUMAX=1200000
+BUILD_DESKTOP="no"
+#
+KERNEL_TARGET="next"
+CLI_TARGET=""
+
+CLI_BETA_TARGET=""
+#
+RECOMMENDED="Ubuntu_xenial_next_nightly:60"
+#
+BOARDRATING=""
+CHIP="http://docs.armbian.com/Hardware_Allwinner-H3/"
+HARDWARE="http://linux-sunxi.org/FriendlyARM_NanoPi_Duo"
+FORUMS="http://forum.armbian.com/index.php/forum/13-allwinner-h3/"
+

--- a/patch/kernel/sunxi-next/add-nanopi-duo.patch
+++ b/patch/kernel/sunxi-next/add-nanopi-duo.patch
@@ -1,0 +1,174 @@
+diff --git a/arch/arm/boot/dts/Makefile b/arch/arm/boot/dts/Makefile
+index 3e9e4c0..3697ca9 100644
+--- a/arch/arm/boot/dts/Makefile
++++ b/arch/arm/boot/dts/Makefile
+@@ -906,6 +906,7 @@ dtb-$(CONFIG_MACH_SUN8I) += \
+ 	sun8i-a83t-allwinner-h8homlet-v2.dtb \
+ 	sun8i-a83t-cubietruck-plus.dtb \
+ 	sun8i-h2-plus-orangepi-zero.dtb \
++	sun8i-h2-plus-nanopi-duo.dtb \
+ 	sun8i-h3-bananapi-m2-plus.dtb \
+ 	sun8i-h3-beelink-x2.dtb \
+ 	sun8i-h3-nanopi-m1.dtb	\
+diff --git a/arch/arm/boot/dts/sun8i-h2-plus-nanopi-duo.dts b/arch/arm/boot/dts/sun8i-h2-plus-nanopi-duo.dts
+new file mode 100644
+index 0000000..7f3a9c8
+--- /dev/null
++++ b/arch/arm/boot/dts/sun8i-h2-plus-nanopi-duo.dts
+@@ -0,0 +1,156 @@
++/*
++ * adapted by <github.com/karabek>, based on
++ *   Copyright (C) 2016 James Pettigrew <james@innovum.com.au>
++ *   Copyright (C) 2016 Milo Kim <woogyom.kim@gmail.com>
++ *
++ *
++ * This file is dual-licensed: you can use it either under the terms
++ * of the GPL or the X11 license, at your option. Note that this dual
++ * licensing only applies to this file, and not this project as a
++ * whole.
++ *
++ *  a) This file is free software; you can redistribute it and/or
++ *     modify it under the terms of the GNU General Public License as
++ *     published by the Free Software Foundation; either version 2 of the
++ *     License, or (at your option) any later version.
++ *
++ *     This file is distributed in the hope that it will be useful,
++ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *     GNU General Public License for more details.
++ *
++ * Or, alternatively,
++ *
++ *  b) Permission is hereby granted, free of charge, to any person
++ *     obtaining a copy of this software and associated documentation
++ *     files (the "Software"), to deal in the Software without
++ *     restriction, including without limitation the rights to use,
++ *     copy, modify, merge, publish, distribute, sublicense, and/or
++ *     sell copies of the Software, and to permit persons to whom the
++ *     Software is furnished to do so, subject to the following
++ *     conditions:
++ *
++ *     The above copyright notice and this permission notice shall be
++ *     included in all copies or substantial portions of the Software.
++ *
++ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
++ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
++ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
++ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
++ *     OTHER DEALINGS IN THE SOFTWARE.
++ */
++
++/dts-v1/;
++#include "sun8i-h3-nanopi.dtsi"
++#include <dt-bindings/pinctrl/sun4i-a10.h>
++
++/ {
++	model = "FriendlyARM NanoPi DUO";
++	compatible = "friendlyarm,nanopi-duo", "allwinner,sun8i-h3";
++
++	aliases {
++		ethernet1 = &xr819;
++	};
++
++	reg_vcc_wifi: reg_vcc_wifi {
++		compatible = "regulator-fixed";
++		regulator-min-microvolt = <1800000>;	// npi 1.8M, OPi 3.3M
++		regulator-max-microvolt = <1800000>;	// npi 1.8M, OPi 3.3M
++		regulator-name = "vcc-wifi";
++		gpio = <&r_pio 0 7 GPIO_ACTIVE_HIGH>;	// PL7 WIFI_POWER_EN
++	        startup-delay-us = <70000>;		// npi added
++        	enable-active-high;			// npi added
++	};
++
++	reg_sy8113b: gpio-regulator {
++		compatible = "regulator-gpio";
++		regulator-name = "vdd-cpux";
++		regulator-type = "voltage";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <1100000>;
++		regulator-max-microvolt = <1300000>;
++		regulator-ramp-delay = <50>; 		// 50=4ms check
++
++		gpios = <&r_pio 0 6 GPIO_ACTIVE_HIGH>; 	// PL6 check
++		enable-active-high;
++		gpios-states = <0x1>;
++		states = <1100000 0x0
++			  1300000 0x1>;
++	};
++
++	wifi_pwrseq: wifi_pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		pinctrl-names = "default";		// from npi 
++		pinctrl-0 = <&wifi_en_npi>;		// from npi 
++		reset-gpios = <&pio 6 13 GPIO_ACTIVE_LOW>;  // PG13 WL_RESTN 
++		post-power-on-delay-ms = <50>;		// OPiZ: 200=16ms
++	};
++};
++
++&cpu0 {
++	cpu-supply = <&reg_sy8113b>;
++};
++
++&emac {
++	phy-handle = <&int_mii_phy>;
++	phy-mode = "mii";
++	allwinner,leds-active-low;
++	status = "okay";
++};
++
++&mmc1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mmc1_pins_a>;
++	vqmmc-supply = <&reg_vcc_wifi>;
++	vmmc-supply = <&reg_vcc3v3>;
++	mmc-pwrseq = <&wifi_pwrseq>;
++	bus-width = <4>;
++	non-removable;
++	status = "okay";
++
++	/*
++	 * Explicitly define the sdio device, so that we can add an ethernet
++	 * alias for it (which e.g. makes u-boot set a mac-address).
++	 */
++	xr819: sdio_wifi@1 {
++		reg = <1>;
++		compatible = "xradio,xr819";
++		pinctrl-names = "default";		// from nano
++		pinctrl-0 = <&wifi_wake>;		// from nano
++		interrupt-parent = <&pio>;
++		interrupts = <6 10 IRQ_TYPE_EDGE_RISING>;    // nano check
++		interrupt-names = "host-wake";
++	};
++};
++
++&mmc1_pins_a {
++	bias-pull-up;					// from OPiZ, npi-orig
++};
++
++&pio {
++	wifi_en_npi: wifi_en_pin {
++		pins = "PG13";
++		function = "gpio_out";
++	};
++	wifi_wake: wifi_wake@0 {
++		pins = "PG10";
++		function = "irq";
++		pull = <SUN4I_PINCTRL_NO_PULL>;
++	};
++};
++
++&spi1 {
++	status = "okay";
++	spidev1: spi@1 {
++		compatible = "nanopi,spidev";
++		reg = <0>;
++		spi-max-frequency = <10000000>;
++	};
++};
++
++
++

--- a/patch/u-boot/u-boot-sunxi/add-nanopi-duo.patch
+++ b/patch/u-boot/u-boot-sunxi/add-nanopi-duo.patch
@@ -1,0 +1,194 @@
+diff --git a/configs/nanopi_duo_defconfig b/configs/nanopi_duo_defconfig
+new file mode 100644
+index 0000000..1e51018
+--- /dev/null
++++ b/configs/nanopi_duo_defconfig
+@@ -0,0 +1,20 @@
++CONFIG_ARM=y
++CONFIG_ARCH_SUNXI=y
++CONFIG_SPL_SPI_FLASH_SUPPORT=y
++CONFIG_MACH_SUN8I_H3=y
++CONFIG_DRAM_CLK=408
++CONFIG_DRAM_ZQ=3881979
++CONFIG_DRAM_ODT_EN=y
++# CONFIG_VIDEO_DE2 is not set
++CONFIG_DEFAULT_DEVICE_TREE="sun8i-h2-plus-nanopi-duo"
++# CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
++CONFIG_CONSOLE_MUX=y
++CONFIG_SPL=y
++CONFIG_SYS_CLK_FREQ=480000000
++# CONFIG_CMD_IMLS is not set
++# CONFIG_CMD_FLASH is not set
++# CONFIG_CMD_FPGA is not set
++CONFIG_SPL_SPI_SUNXI=y
++CONFIG_SUN8I_EMAC=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_SYS_USB_EVENT_POLL_VIA_INT_QUEUE=y
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index 4f8ca34..019ac0b 100644
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -312,6 +312,7 @@ dtb-$(CONFIG_MACH_SUN8I_A83T) += \
+ 	sun8i-a83t-sinovoip-bpi-m3.dtb
+ dtb-$(CONFIG_MACH_SUN8I_H3) += \
+ 	sun8i-h2-plus-orangepi-zero.dtb \
++	sun8i-h2-plus-nanopi-duo.dtb \
+ 	sun8i-h3-bananapi-m2-plus.dtb \
+ 	sun8i-h3-orangepi-2.dtb \
+ 	sun8i-h3-orangepi-lite.dtb \
+diff --git a/arch/arm/dts/sun8i-h2-plus-nanopi-duo.dts b/arch/arm/dts/sun8i-h2-plus-nanopi-duo.dts
+new file mode 100644
+index 0000000..476d72e
+--- /dev/null
++++ b/arch/arm/dts/sun8i-h2-plus-nanopi-duo.dts
+@@ -0,0 +1,150 @@
++/*
++ * adapted by <github.com/karabek>, based on
++ *   Copyright (C) 2016 James Pettigrew <james@innovum.com.au>
++ *   Copyright (C) 2016 Milo Kim <woogyom.kim@gmail.com>
++ *
++ *
++ * This file is dual-licensed: you can use it either under the terms
++ * of the GPL or the X11 license, at your option. Note that this dual
++ * licensing only applies to this file, and not this project as a
++ * whole.
++ *
++ *  a) This file is free software; you can redistribute it and/or
++ *     modify it under the terms of the GNU General Public License as
++ *     published by the Free Software Foundation; either version 2 of the
++ *     License, or (at your option) any later version.
++ *
++ *     This file is distributed in the hope that it will be useful,
++ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *     GNU General Public License for more details.
++ *
++ * Or, alternatively,
++ *
++ *  b) Permission is hereby granted, free of charge, to any person
++ *     obtaining a copy of this software and associated documentation
++ *     files (the "Software"), to deal in the Software without
++ *     restriction, including without limitation the rights to use,
++ *     copy, modify, merge, publish, distribute, sublicense, and/or
++ *     sell copies of the Software, and to permit persons to whom the
++ *     Software is furnished to do so, subject to the following
++ *     conditions:
++ *
++ *     The above copyright notice and this permission notice shall be
++ *     included in all copies or substantial portions of the Software.
++ *
++ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
++ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
++ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
++ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
++ *     OTHER DEALINGS IN THE SOFTWARE.
++ */
++
++#include "sun8i-h3-nanopi.dtsi"
++#include <dt-bindings/pinctrl/sun4i-a10.h>
++
++/ {
++	model = "FriendlyARM NanoPi DUO";
++	compatible = "friendlyarm,nanopi-duo", "allwinner,sun8i-h3";
++
++	aliases {
++		ethernet1 = &xr819;
++	};
++
++	reg_vcc_wifi: reg_vcc_wifi {
++		compatible = "regulator-fixed";
++		regulator-min-microvolt = <1800000>;	// npi 1.8M, OPi 3.3M
++		regulator-max-microvolt = <1800000>;	// npi 1.8M, OPi 3.3M
++		regulator-name = "vcc-wifi";
++		gpio = <&r_pio 0 7 GPIO_ACTIVE_HIGH>;	// PL7 WIFI_POWER_EN
++	        startup-delay-us = <70000>;		// npi added
++        	enable-active-high;			// npi added
++	};
++
++	reg_sy8113b: gpio-regulator {
++		compatible = "regulator-gpio";
++		regulator-name = "vdd-cpux";
++		regulator-type = "voltage";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <1100000>;
++		regulator-max-microvolt = <1300000>;
++		regulator-ramp-delay = <50>; 		// 50=4ms check
++
++		gpios = <&r_pio 0 6 GPIO_ACTIVE_HIGH>; 	// PL6 check
++		enable-active-high;
++		gpios-states = <0x1>;
++		states = <1100000 0x0
++			  1300000 0x1>;
++	};
++
++	wifi_pwrseq: wifi_pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		pinctrl-names = "default";		// from npi
++		pinctrl-0 = <&wifi_en_npi>;		// from npi
++		reset-gpios = <&pio 6 13 GPIO_ACTIVE_LOW>;  // PG13 WL_RESTN
++		post-power-on-delay-ms = <50>;		// OpiZ 200=16ms
++	};
++};
++
++// &cpu0 {
++// 	cpu-supply = <&reg_sy8113b>;
++// };
++
++&emac {
++	phy = <&phy1>;
++	phy-mode = "mii";
++	allwinner,use-internal-phy;
++	allwinner,leds-active-low;
++	status = "okay";
++	phy1: ethernet-phy@1 {
++		reg = <1>;
++	};
++};
++
++&mmc1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mmc1_pins_a>;
++	vqmmc-supply = <&reg_vcc_wifi>;
++	vmmc-supply = <&reg_vcc3v3>;
++	mmc-pwrseq = <&wifi_pwrseq>;
++	bus-width = <4>;
++	non-removable;
++	status = "okay";
++
++	/*
++	 * Explicitly define the sdio device, so that we can add an ethernet
++	 * alias for it (which e.g. makes u-boot set a mac-address).
++	 */
++	xr819: sdio_wifi@1 {
++		reg = <1>;
++		compatible = "xradio,xr819";
++		pinctrl-names = "default";		// from nano-orig
++		pinctrl-0 = <&wifi_wake>;		// from nano-orig
++		interrupt-parent = <&pio>;
++		interrupts = <6 10 IRQ_TYPE_EDGE_RISING>;    // nano-orig
++		interrupt-names = "host-wake";
++	};
++};
++
++&mmc1_pins_a {
++	bias-pull-up;
++};
++
++&pio {
++	wifi_wake: wifi_wake@0 {
++		pins = "PG10";
++		function = "irq";
++		pull = <SUN4I_PINCTRL_NO_PULL>;
++	};
++	wifi_en_npi: wifi_en_pin {
++		pins = "PG13";
++		function = "gpio_out";
++	};
++};
++
++
++


### PR DESCRIPTION
This adds the NanoPi Du board as community supported board.
- config: nanopiduo.csc
- u-boot and kernel patch

WLAN, USB, I2C, ... works.

WLAN uses armbians xradio driver.