### PR TITLE
Update lime2 lan support

### DIFF
--- a/patch/u-boot/u-boot-sunxi/board_lime2/GMAC_TX_DELAY_autocorrection.patch
+++ b/patch/u-boot/u-boot-sunxi/board_lime2/GMAC_TX_DELAY_autocorrection.patch
@@ -1,0 +1,72 @@
+diff --git a/configs/A20-OLinuXino-Lime2-eMMC_defconfig b/configs/A20-OLinuXino-Lime2-eMMC_defconfig
+index cba7d7d..1509562 100755
+--- a/configs/A20-OLinuXino-Lime2-eMMC_defconfig
++++ b/configs/A20-OLinuXino-Lime2-eMMC_defconfig
+@@ -37,3 +37,5 @@ CONFIG_USB_GADGET_DOWNLOAD=y
+ CONFIG_G_DNL_MANUFACTURER="Allwinner Technology"
+ CONFIG_G_DNL_VENDOR_NUM=0x1f3a
+ CONFIG_G_DNL_PRODUCT_NUM=0x1010
++CONFIG_PHY_MICREL=y
++CONFIG_PHY_MICREL_KSZ90X1=y
+diff --git a/drivers/net/phy/micrel_ksz90x1.c b/drivers/net/phy/micrel_ksz90x1.c
+index 0bb99e6..ce35daf 100644
+--- a/drivers/net/phy/micrel_ksz90x1.c
++++ b/drivers/net/phy/micrel_ksz90x1.c
+@@ -16,6 +16,8 @@
+ #include <fdtdec.h>
+ #include <micrel.h>
+ #include <phy.h>
++#include <asm/io.h>
++#include <asm/arch/clock.h>
+ 
+ DECLARE_GLOBAL_DATA_PTR;
+ 
+@@ -335,6 +337,10 @@ static int ksz9031_phy_extwrite(struct phy_device *phydev, int addr,
+ static int ksz9031_config(struct phy_device *phydev)
+ {
+ 	int ret;
++	struct sunxi_ccm_reg *const ccm =
++		(struct sunxi_ccm_reg *)SUNXI_CCM_BASE;
++
++	setbits_le32(&ccm->gmac_clk_cfg, CCM_GMAC_CTRL_TX_CLK_DELAY(4));
+ 
+ 	ret = ksz9031_of_config(phydev);
+ 	if (ret)
+diff --git a/drivers/net/phy/realtek.c b/drivers/net/phy/realtek.c
+index 6d917f8..87956c0 100644
+--- a/drivers/net/phy/realtek.c
++++ b/drivers/net/phy/realtek.c
+@@ -11,6 +11,8 @@
+ #include <common.h>
+ #include <linux/bitops.h>
+ #include <phy.h>
++#include <asm/io.h>
++#include <asm/arch/clock.h>
+ 
+ #define PHY_RTL8211x_FORCE_MASTER BIT(1)
+ 
+@@ -63,6 +65,9 @@ static int rtl8211b_probe(struct phy_device *phydev)
+ /* RealTek RTL8211x */
+ static int rtl8211x_config(struct phy_device *phydev)
+ {
++	struct sunxi_ccm_reg *const ccm =
++		(struct sunxi_ccm_reg *)SUNXI_CCM_BASE;
++
+ 	phy_write(phydev, MDIO_DEVAD_NONE, MII_BMCR, BMCR_RESET);
+ 
+ 	/* mask interrupt at init; if the interrupt is
+@@ -71,6 +76,14 @@ static int rtl8211x_config(struct phy_device *phydev)
+ 	phy_write(phydev, MDIO_DEVAD_NONE, MIIM_RTL8211x_PHY_INER,
+ 		  MIIM_RTL8211x_PHY_INTR_DIS);
+ 
++	if(phydev->drv->uid == 0x1cc912) {
++		/* With RTL8211C Force Master must be enabled */
++		phydev->flags |= PHY_RTL8211x_FORCE_MASTER;
++	} else if(phydev->drv->uid == 0x1cc915) {
++		/* RTL8211E has different GMAC_TX_DELAY requirements */
++		setbits_le32(&ccm->gmac_clk_cfg, CCM_GMAC_CTRL_TX_CLK_DELAY(2));
++	}
++
+ 	if (phydev->flags & PHY_RTL8211x_FORCE_MASTER) {
+ 		unsigned int reg;
+ 


### PR DESCRIPTION
Update LAN support for all A20-OLinuXino-Lime2 versions:

-  With **RTL8211C** - Using this chip require FORCE_MASTER flag to be set and GMAC_TX_DELAY to be 0, which is default.
-  With **RTL8211E** - This fixes need of forced master mode, but GMAC_TX_DELAY need to be set to 2.
-  With **KSZ9031** - GMAC_TX_DELAY has to be set as 4.