### PR TITLE
updated nanopi-duo patches w/o nanopi.dtsi

### DIFF
--- a/patch/kernel/sunxi-next/add-nanopi-duo.patch
+++ b/patch/kernel/sunxi-next/add-nanopi-duo.patch
@@ -1,5 +1,5 @@
 diff --git a/arch/arm/boot/dts/Makefile b/arch/arm/boot/dts/Makefile
-index 3e9e4c0..3697ca9 100644
+index c236ae6..6c2ba91 100644
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
 @@ -906,6 +906,7 @@ dtb-$(CONFIG_MACH_SUN8I) += \
@@ -12,10 +12,10 @@ index 3e9e4c0..3697ca9 100644
  	sun8i-h3-nanopi-m1.dtb	\
 diff --git a/arch/arm/boot/dts/sun8i-h2-plus-nanopi-duo.dts b/arch/arm/boot/dts/sun8i-h2-plus-nanopi-duo.dts
 new file mode 100644
-index 0000000..7f3a9c8
+index 0000000..5ab58f0
 --- /dev/null
 +++ b/arch/arm/boot/dts/sun8i-h2-plus-nanopi-duo.dts
-@@ -0,0 +1,156 @@
+@@ -0,0 +1,218 @@
 +/*
 + * adapted by <github.com/karabek>, based on
 + *   Copyright (C) 2016 James Pettigrew <james@innovum.com.au>
@@ -62,7 +62,11 @@ index 0000000..7f3a9c8
 + */
 +
 +/dts-v1/;
-+#include "sun8i-h3-nanopi.dtsi"
++#include "sun8i-h3.dtsi"
++#include "sunxi-common-regulators.dtsi"
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
 +#include <dt-bindings/pinctrl/sun4i-a10.h>
 +
 +/ {
@@ -71,16 +75,52 @@ index 0000000..7f3a9c8
 +
 +	aliases {
 +		ethernet1 = &xr819;
++		serial0 = &uart0;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	leds {
++		compatible = "gpio-leds";
++		pinctrl-names = "default";
++		pinctrl-0 = <&leds_npi>, <&leds_r_npi>;
++
++		status {
++			label = "nanopi:blue:status";
++			gpios = <&pio 0 10 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "heartbeat";
++		};
++
++		pwr {
++			label = "nanopi:green:pwr";
++			gpios = <&r_pio 0 10 GPIO_ACTIVE_HIGH>;
++			default-state = "on";
++		};
++	};
++
++	r_gpio_keys {
++		compatible = "gpio-keys";
++		input-name = "k1";
++		pinctrl-names = "default";
++		pinctrl-0 = <&sw_r_npi>;
++
++		k1@0 {
++			label = "k1";
++			linux,code = <KEY_POWER>;
++			gpios = <&r_pio 0 3 GPIO_ACTIVE_LOW>;
++		};
 +	};
 +
 +	reg_vcc_wifi: reg_vcc_wifi {
 +		compatible = "regulator-fixed";
-+		regulator-min-microvolt = <1800000>;	// npi 1.8M, OPi 3.3M
-+		regulator-max-microvolt = <1800000>;	// npi 1.8M, OPi 3.3M
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
 +		regulator-name = "vcc-wifi";
 +		gpio = <&r_pio 0 7 GPIO_ACTIVE_HIGH>;	// PL7 WIFI_POWER_EN
-+	        startup-delay-us = <70000>;		// npi added
-+        	enable-active-high;			// npi added
++	        startup-delay-us = <70000>;
++        	enable-active-high;
 +	};
 +
 +	reg_sy8113b: gpio-regulator {
@@ -102,10 +142,10 @@ index 0000000..7f3a9c8
 +
 +	wifi_pwrseq: wifi_pwrseq {
 +		compatible = "mmc-pwrseq-simple";
-+		pinctrl-names = "default";		// from npi 
-+		pinctrl-0 = <&wifi_en_npi>;		// from npi 
++		pinctrl-names = "default"; 
++		pinctrl-0 = <&wifi_en_npi>; 
 +		reset-gpios = <&pio 6 13 GPIO_ACTIVE_LOW>;  // PG13 WL_RESTN 
-+		post-power-on-delay-ms = <50>;		// OPiZ: 200=16ms
++		post-power-on-delay-ms = <50>;
 +	};
 +};
 +
@@ -120,6 +160,16 @@ index 0000000..7f3a9c8
 +	status = "okay";
 +};
 +
++&mmc0 {
++	bus-width = <4>;
++	cd-gpios = <&pio 5 6 GPIO_ACTIVE_HIGH>;
++	cd-inverted;
++	pinctrl-names = "default";
++	pinctrl-0 = <&mmc0_pins_a>, <&mmc0_cd_pin>;
++	status = "okay";
++	vmmc-supply = <&reg_vcc3v3>;
++};
++
 +&mmc1 {
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&mmc1_pins_a>;
@@ -130,26 +180,26 @@ index 0000000..7f3a9c8
 +	non-removable;
 +	status = "okay";
 +
-+	/*
-+	 * Explicitly define the sdio device, so that we can add an ethernet
-+	 * alias for it (which e.g. makes u-boot set a mac-address).
-+	 */
 +	xr819: sdio_wifi@1 {
 +		reg = <1>;
 +		compatible = "xradio,xr819";
-+		pinctrl-names = "default";		// from nano
-+		pinctrl-0 = <&wifi_wake>;		// from nano
++		pinctrl-names = "default";
++		pinctrl-0 = <&wifi_wake>;
 +		interrupt-parent = <&pio>;
-+		interrupts = <6 10 IRQ_TYPE_EDGE_RISING>;    // nano check
++		interrupts = <6 10 IRQ_TYPE_EDGE_RISING>;
 +		interrupt-names = "host-wake";
 +	};
 +};
 +
 +&mmc1_pins_a {
-+	bias-pull-up;					// from OPiZ, npi-orig
++	bias-pull-up;
 +};
 +
 +&pio {
++	leds_npi: led_pins@0 {
++		pins = "PA10";
++		function = "gpio_out";
++	};
 +	wifi_en_npi: wifi_en_pin {
 +		pins = "PG13";
 +		function = "gpio_out";
@@ -161,14 +211,26 @@ index 0000000..7f3a9c8
 +	};
 +};
 +
-+&spi1 {
-+	status = "okay";
-+	spidev1: spi@1 {
-+		compatible = "nanopi,spidev";
-+		reg = <0>;
-+		spi-max-frequency = <10000000>;
++&r_pio {
++	leds_r_npi: led_pins@0 {
++		pins = "PL10";
++		function = "gpio_out";
++	};
++
++	sw_r_npi: key_pins@0 {
++		pins = "PL3";
++		function = "gpio_in";
 +	};
 +};
 +
++&uart0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart0_pins_a>;
++	status = "okay";
++};
++
++&usbphy {
++	status = "okay";
++};
 +
 +

--- a/patch/u-boot/u-boot-sunxi/add-nanopi-duo.patch
+++ b/patch/u-boot/u-boot-sunxi/add-nanopi-duo.patch
@@ -38,15 +38,13 @@ index 4f8ca34..019ac0b 100644
  	sun8i-h3-orangepi-lite.dtb \
 diff --git a/arch/arm/dts/sun8i-h2-plus-nanopi-duo.dts b/arch/arm/dts/sun8i-h2-plus-nanopi-duo.dts
 new file mode 100644
-index 0000000..476d72e
+index 0000000..b6afe20
 --- /dev/null
 +++ b/arch/arm/dts/sun8i-h2-plus-nanopi-duo.dts
-@@ -0,0 +1,150 @@
+@@ -0,0 +1,98 @@
 +/*
 + * adapted by <github.com/karabek>, based on
-+ *   Copyright (C) 2016 James Pettigrew <james@innovum.com.au>
-+ *   Copyright (C) 2016 Milo Kim <woogyom.kim@gmail.com>
-+ *
++ * Copyright (C) 2017 Jelle van der Waa <jelle@vdwaa.nl>
 + *
 + * This file is dual-licensed: you can use it either under the terms
 + * of the GPL or the X11 license, at your option. Note that this dual
@@ -87,108 +85,58 @@ index 0000000..476d72e
 + *     OTHER DEALINGS IN THE SOFTWARE.
 + */
 +
-+#include "sun8i-h3-nanopi.dtsi"
++/dts-v1/;
++#include "sun8i-h3.dtsi"
++#include "sunxi-common-regulators.dtsi"
++
++#include <dt-bindings/gpio/gpio.h>
 +#include <dt-bindings/pinctrl/sun4i-a10.h>
 +
 +/ {
-+	model = "FriendlyARM NanoPi DUO";
-+	compatible = "friendlyarm,nanopi-duo", "allwinner,sun8i-h3";
++	model = "FriendlyARM NanoPi DUO Air";
++	compatible = "friendlyarm,nanopi-duo-air", "allwinner,sun8i-h3";
 +
 +	aliases {
-+		ethernet1 = &xr819;
++		serial0 = &uart0;
 +	};
 +
-+	reg_vcc_wifi: reg_vcc_wifi {
-+		compatible = "regulator-fixed";
-+		regulator-min-microvolt = <1800000>;	// npi 1.8M, OPi 3.3M
-+		regulator-max-microvolt = <1800000>;	// npi 1.8M, OPi 3.3M
-+		regulator-name = "vcc-wifi";
-+		gpio = <&r_pio 0 7 GPIO_ACTIVE_HIGH>;	// PL7 WIFI_POWER_EN
-+	        startup-delay-us = <70000>;		// npi added
-+        	enable-active-high;			// npi added
++	chosen {
++		stdout-path = "serial0:115200n8";
 +	};
 +
-+	reg_sy8113b: gpio-regulator {
-+		compatible = "regulator-gpio";
-+		regulator-name = "vdd-cpux";
-+		regulator-type = "voltage";
-+		regulator-boot-on;
-+		regulator-always-on;
-+		regulator-min-microvolt = <1100000>;
-+		regulator-max-microvolt = <1300000>;
-+		regulator-ramp-delay = <50>; 		// 50=4ms check
++	leds {
++		compatible = "gpio-leds";
 +
-+		gpios = <&r_pio 0 6 GPIO_ACTIVE_HIGH>; 	// PL6 check
-+		enable-active-high;
-+		gpios-states = <0x1>;
-+		states = <1100000 0x0
-+			  1300000 0x1>;
-+	};
++		pwr {
++			label = "nanopi:green:pwr";
++			gpios = <&r_pio 0 10 GPIO_ACTIVE_HIGH>; /* PL10 */
++			default-state = "on";
++		};
 +
-+	wifi_pwrseq: wifi_pwrseq {
-+		compatible = "mmc-pwrseq-simple";
-+		pinctrl-names = "default";		// from npi
-+		pinctrl-0 = <&wifi_en_npi>;		// from npi
-+		reset-gpios = <&pio 6 13 GPIO_ACTIVE_LOW>;  // PG13 WL_RESTN
-+		post-power-on-delay-ms = <50>;		// OpiZ 200=16ms
++		status {
++			label = "nanopi:blue:status";
++			gpios = <&pio 0 10 GPIO_ACTIVE_HIGH>; /* PA10 */
++		};
 +	};
 +};
 +
-+// &cpu0 {
-+// 	cpu-supply = <&reg_sy8113b>;
-+// };
-+
-+&emac {
-+	phy = <&phy1>;
-+	phy-mode = "mii";
-+	allwinner,use-internal-phy;
-+	allwinner,leds-active-low;
-+	status = "okay";
-+	phy1: ethernet-phy@1 {
-+		reg = <1>;
-+	};
-+};
-+
-+&mmc1 {
++&mmc0 {
 +	pinctrl-names = "default";
-+	pinctrl-0 = <&mmc1_pins_a>;
-+	vqmmc-supply = <&reg_vcc_wifi>;
++	pinctrl-0 = <&mmc0_pins_a>, <&mmc0_cd_pin>;
 +	vmmc-supply = <&reg_vcc3v3>;
-+	mmc-pwrseq = <&wifi_pwrseq>;
 +	bus-width = <4>;
-+	non-removable;
++	cd-gpios = <&pio 5 6 GPIO_ACTIVE_HIGH>; /* PF6 */
++	cd-inverted;
 +	status = "okay";
-+
-+	/*
-+	 * Explicitly define the sdio device, so that we can add an ethernet
-+	 * alias for it (which e.g. makes u-boot set a mac-address).
-+	 */
-+	xr819: sdio_wifi@1 {
-+		reg = <1>;
-+		compatible = "xradio,xr819";
-+		pinctrl-names = "default";		// from nano-orig
-+		pinctrl-0 = <&wifi_wake>;		// from nano-orig
-+		interrupt-parent = <&pio>;
-+		interrupts = <6 10 IRQ_TYPE_EDGE_RISING>;    // nano-orig
-+		interrupt-names = "host-wake";
-+	};
 +};
 +
-+&mmc1_pins_a {
-+	bias-pull-up;
++&uart0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart0_pins_a>;
++	status = "okay";
 +};
 +
-+&pio {
-+	wifi_wake: wifi_wake@0 {
-+		pins = "PG10";
-+		function = "irq";
-+		pull = <SUN4I_PINCTRL_NO_PULL>;
-+	};
-+	wifi_en_npi: wifi_en_pin {
-+		pins = "PG13";
-+		function = "gpio_out";
-+	};
++&usbphy {
++	/* USB VBUS is always on */
++	status = "okay";
 +};
-+
-+
-+


### PR DESCRIPTION
nanopi-duo kernel and u-boot patch
- nanopi.dtsi include removed, adapted tree accordingly 
- spi-entry removed