### PR TITLE
Update BSP for olinuxino-lime2 and a20-som

### DIFF
--- a/patch/u-boot/u-boot-sunxi/board_lime2/GMAC_TX_DELAY_autocorrection.patch
+++ b/patch/u-boot/u-boot-sunxi/board_lime2/GMAC_TX_DELAY_autocorrection.patch
@@ -1,19 +1,22 @@
 diff --git a/configs/A20-OLinuXino-Lime2-eMMC_defconfig b/configs/A20-OLinuXino-Lime2-eMMC_defconfig
-index cba7d7d..1509562 100755
+index cd1fa64..f817b8c 100644
 --- a/configs/A20-OLinuXino-Lime2-eMMC_defconfig
 +++ b/configs/A20-OLinuXino-Lime2-eMMC_defconfig
-@@ -37,3 +37,5 @@ CONFIG_USB_GADGET_DOWNLOAD=y
- CONFIG_G_DNL_MANUFACTURER="Allwinner Technology"
- CONFIG_G_DNL_VENDOR_NUM=0x1f3a
- CONFIG_G_DNL_PRODUCT_NUM=0x1010
+@@ -25,6 +25,8 @@ CONFIG_DFU_RAM=y
+ CONFIG_ETH_DESIGNWARE=y
+ CONFIG_RGMII=y
+ CONFIG_SUN7I_GMAC=y
 +CONFIG_PHY_MICREL=y
 +CONFIG_PHY_MICREL_KSZ90X1=y
+ CONFIG_AXP_ALDO3_VOLT=2800
+ CONFIG_AXP_ALDO4_VOLT=2800
+ CONFIG_SCSI=y
 diff --git a/drivers/net/phy/micrel_ksz90x1.c b/drivers/net/phy/micrel_ksz90x1.c
-index 0bb99e6..ce35daf 100644
+index b350a61..701a3d1 100644
 --- a/drivers/net/phy/micrel_ksz90x1.c
 +++ b/drivers/net/phy/micrel_ksz90x1.c
 @@ -16,6 +16,8 @@
- #include <fdtdec.h>
+ #include <errno.h>
  #include <micrel.h>
  #include <phy.h>
 +#include <asm/io.h>
@@ -21,7 +24,7 @@ index 0bb99e6..ce35daf 100644
  
  DECLARE_GLOBAL_DATA_PTR;
  
-@@ -335,6 +337,10 @@ static int ksz9031_phy_extwrite(struct phy_device *phydev, int addr,
+@@ -334,6 +336,10 @@ static int ksz9031_phy_extwrite(struct phy_device *phydev, int addr,
  static int ksz9031_config(struct phy_device *phydev)
  {
  	int ret;

--- a/patch/u-boot/u-boot-sunxi/board_olimex-som-a20/GMAC_TX_DELAY_autocorrection.patch
+++ b/patch/u-boot/u-boot-sunxi/board_olimex-som-a20/GMAC_TX_DELAY_autocorrection.patch
@@ -1,19 +1,19 @@
 diff --git a/configs/A20-Olimex-SOM-EVB_defconfig b/configs/A20-Olimex-SOM-EVB_defconfig
-index 6f57c3a..a4a8b32 100644
+index ee94155..0ff93b8 100644
 --- a/configs/A20-Olimex-SOM-EVB_defconfig
 +++ b/configs/A20-Olimex-SOM-EVB_defconfig
-@@ -28,3 +28,5 @@ CONFIG_AXP_ALDO4_VOLT=2800
+@@ -27,3 +27,5 @@ CONFIG_AXP_ALDO4_VOLT=2800
  CONFIG_SCSI=y
  CONFIG_USB_EHCI_HCD=y
  CONFIG_SYS_USB_EVENT_POLL_VIA_INT_QUEUE=y
 +CONFIG_PHY_MICREL=y
 +CONFIG_PHY_MICREL_KSZ90X1=y
 diff --git a/drivers/net/phy/micrel_ksz90x1.c b/drivers/net/phy/micrel_ksz90x1.c
-index 0bb99e6..ce35daf 100644
+index b350a61..701a3d1 100644
 --- a/drivers/net/phy/micrel_ksz90x1.c
 +++ b/drivers/net/phy/micrel_ksz90x1.c
 @@ -16,6 +16,8 @@
- #include <fdtdec.h>
+ #include <errno.h>
  #include <micrel.h>
  #include <phy.h>
 +#include <asm/io.h>
@@ -21,7 +21,7 @@ index 0bb99e6..ce35daf 100644
  
  DECLARE_GLOBAL_DATA_PTR;
  
-@@ -335,6 +337,10 @@ static int ksz9031_phy_extwrite(struct phy_device *phydev, int addr,
+@@ -334,6 +336,10 @@ static int ksz9031_phy_extwrite(struct phy_device *phydev, int addr,
  static int ksz9031_config(struct phy_device *phydev)
  {
  	int ret;


### PR DESCRIPTION
Update GMAC timing patches for lime2 and a20-som.

With u-boot v2017.11 these patches need minor rework.
