### PR TITLE
allow untar to a samba share

### DIFF
--- a/lib/general.sh
+++ b/lib/general.sh
@@ -656,7 +656,7 @@ download_toolchain()
 	fi
 	if [[ $verified == true ]]; then
 		display_alert "Extracting"
-		tar --overwrite -xf $filename && touch $SRC/cache/toolchains/$dirname/.download-complete
+		tar --no-same-owner --overwrite -xf $filename && touch $SRC/cache/toolchains/$dirname/.download-complete
 		display_alert "Download complete" "" "info"
 	else
 		display_alert "Verification failed" "" "wrn"


### PR DESCRIPTION
Currently there is no way to untar to a samba share, always getting permission error.