### PR TITLE
HDMI support for (community supported) mainline kernel for Sunvell R69

### DIFF
--- a/config/boards/sunvell-r69.csc
+++ b/config/boards/sunvell-r69.csc
@@ -7,7 +7,7 @@ MODULES="xradio_wlan xradio_wlan"
 MODULES_NEXT="xradio_wlan"
 MODULES_BLACKLIST="dhd"
 CPUMIN=240000
-CPUMAX=1104000
+CPUMAX=1008000
 #
 KERNEL_TARGET="default next"
 CLI_TARGET="jessie,xenial:default"

--- a/patch/kernel/sunxi-next/add-sunvell-r69.patch
+++ b/patch/kernel/sunxi-next/add-sunvell-r69.patch
@@ -12,13 +12,12 @@ index 357ad60..6817198 100644
  	sun8i-h3-nanopi-m1.dtb	\
 diff --git a/arch/arm/boot/dts/sun8i-h2-plus-sunvell-r69.dts b/arch/arm/boot/dts/sun8i-h2-plus-sunvell-r69.dts
 new file mode 100644
-index 0000000..2c525b8
+index 0000000..3dd5c81
 --- /dev/null
 +++ b/arch/arm/boot/dts/sun8i-h2-plus-sunvell-r69.dts
-@@ -0,0 +1,182 @@
+@@ -0,0 +1,221 @@
 +/*
-+ * Based original Sunvell R69 FEX file
-+ *   Copyright (C) 2017 M. R. Karabek <github.com/karabek>
++ * Based original Sunvell R69 FEX file (2017 <github.com/karabek>)
 + *
 + * This file is dual-licensed: you can use it either under the terms
 + * of the GPL or the X11 license, at your option. Note that this dual
@@ -81,6 +80,17 @@ index 0000000..2c525b8
 +		stdout-path = "serial0:115200n8";
 +	};
 +
++	connector {
++		compatible = "hdmi-connector";
++		type = "a";
++
++		port {
++			hdmi_con_in: endpoint {
++				remote-endpoint = <&hdmi_out_con>;
++			};
++		};
++	};
++
 +	leds {
 +		compatible = "gpio-leds";
 +
@@ -93,7 +103,6 @@ index 0000000..2c525b8
 +		status_led {
 +			label = "sunvell-r69:red:status";
 +			gpios = <&r_pio 0 10 GPIO_ACTIVE_HIGH>;
-+			linux,default-trigger = "cpu";
 +		};
 +	};
 +
@@ -114,6 +123,10 @@ index 0000000..2c525b8
 +	};
 +};
 +
++&de {
++	status = "okay";
++};
++
 +&ehci0 {
 +	status = "okay";
 +};
@@ -126,6 +139,24 @@ index 0000000..2c525b8
 +	phy-handle = <&int_mii_phy>;
 +	phy-mode = "mii";
 +	allwinner,leds-active-low;
++	status = "okay";
++};
++
++&hdmi {
++	status = "okay";
++};
++
++&hdmi_out {
++	hdmi_out_con: endpoint {
++		remote-endpoint = <&hdmi_con_in>;
++	};
++};
++
++&i2s2 {
++	status = "okay";
++};
++
++&mixer0 {
 +	status = "okay";
 +};
 +
@@ -180,6 +211,14 @@ index 0000000..2c525b8
 +};
 +
 +&ohci1 {
++	status = "okay";
++};
++
++&sound_hdmi {
++	status = "okay";
++};
++
++&tcon0 {
 +	status = "okay";
 +};
 +

--- a/patch/u-boot/u-boot-sunxi/add-sunvell-r69.patch
+++ b/patch/u-boot/u-boot-sunxi/add-sunvell-r69.patch
@@ -1,27 +1,28 @@
 diff --git a/configs/sunvell_r69_defconfig b/configs/sunvell_r69_defconfig
 new file mode 100644
-index 0000000..f738392
+index 0000000..d37f4f4
 --- /dev/null
 +++ b/configs/sunvell_r69_defconfig
-@@ -0,0 +1,20 @@
+@@ -0,0 +1,21 @@
 +CONFIG_ARM=y
 +CONFIG_ARCH_SUNXI=y
 +CONFIG_MACH_SUN8I_H3=y
-+CONFIG_DRAM_CLK=408
++CONFIG_DRAM_CLK=576
 +CONFIG_DRAM_ZQ=3881979
 +CONFIG_DRAM_ODT_EN=y
-+# CONFIG_VIDEO_DE2
++# CONFIG_VIDEO_DE2 is not set
++# CONFIG_VIDEO_COMPOSITE is not set
 +CONFIG_DEFAULT_DEVICE_TREE="sun8i-h2-plus-sunvell-r69"
-+# CONFIG_MMC_SUNXI_SLOT_EXTRA=2
++CONFIG_MMC_SUNXI_SLOT_EXTRA=2
 +# CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
-+CONFIG_CONSOLE_MUX=y
++# CONFIG_CONSOLE_MUX is not set
 +CONFIG_SPL=y
-+CONFIG_SYS_CLK_FREQ=480000000
 +# CONFIG_CMD_FLASH is not set
 +# CONFIG_CMD_FPGA is not set
-+CONFIG_SPL_SPI_SUNXI=y
++# CONFIG_SPL_SPI_SUNXI is not set
 +CONFIG_SUN8I_EMAC=y
 +CONFIG_USB_EHCI_HCD=y
++CONFIG_SYS_CLK_FREQ=480000000
 +CONFIG_SYS_USB_EVENT_POLL_VIA_INT_QUEUE=y
 +
 diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
@@ -38,13 +39,12 @@ index 9dd0e11..da06402 100755
  	sun8i-h3-orangepi-lite.dtb \
 diff --git a/arch/arm/dts/sun8i-h2-plus-sunvell-r69.dts b/arch/arm/dts/sun8i-h2-plus-sunvell-r69.dts
 new file mode 100644
-index 0000000..1d3d495
+index 0000000..4b41116
 --- /dev/null
 +++ b/arch/arm/dts/sun8i-h2-plus-sunvell-r69.dts
-@@ -0,0 +1,167 @@
+@@ -0,0 +1,166 @@
 +/*
-+ * Based original Sunvell R69 FEX file
-+ *   Copyright (C) 2017 M. R. Karabek <github.com/karabek>
++ * Based original Sunvell R69 FEX file (2017 <github.com/karabek>)
 + *
 + * This file is dual-licensed: you can use it either under the terms
 + * of the GPL or the X11 license, at your option. Note that this dual


### PR DESCRIPTION
The current (community supported) Sunvell R69 mainline kernel lacked HDMI support.
- HDMI now works 
- eMMC boot tested/works
- IrDA tested/works (activated via overlay)
- audio tested/works (activated via overlay)
Further changes:
- Vcore measured @ 1.2V fixed
- max. CPU-freq reduced to 1008 MHz accordingly, in line with armbian recommendations
- DRAM clock set to 576 MHz
Unchanged:
- USB-Port 1 and 2 configured as hosts

This patch replaces the previous "add-sunvell-r69" patches, instead of "patching the patches".

Peace!