### PR TITLE
espressobin enable emmc

### DIFF
--- a/patch/kernel/mvebu64-next/0011-espressobin-enable-emmc.patch
+++ b/patch/kernel/mvebu64-next/0011-espressobin-enable-emmc.patch
@@ -1,0 +1,20 @@
+diff --git a/arch/arm64/boot/dts/marvell/armada-3720-espressobin.dts b/arch/arm64/boot/dts/marvell/armada-3720-espressobin.dts
+index 2ce52ba..a759fd1 100644
+--- a/arch/arm64/boot/dts/marvell/armada-3720-espressobin.dts
++++ b/arch/arm64/boot/dts/marvell/armada-3720-espressobin.dts
+@@ -96,6 +96,15 @@
+ 	status = "okay";
+ };
+ 
++&sdhci0 {
++	non-removable;
++	bus-width = <8>;
++	mmc-ddr-1_8v;
++	mmc-hs400-1_8v;
++	marvell,pad-type = "fixed-1-8v";
++	status = "okay";
++};
++
+ /* Exported on the micro USB connector J5 through an FTDI */
+ &uart0 {
+ 	status = "okay";

--- a/patch/u-boot/u-boot-mvebu64/0001-espressobin-enable-emmc.patch
+++ b/patch/u-boot/u-boot-mvebu64/0001-espressobin-enable-emmc.patch
@@ -1,0 +1,29 @@
+diff --git a/arch/arm/dts/armada-3720-espressobin.dts b/arch/arm/dts/armada-3720-espressobin.dts
+index d2ca3b9..b25f40e 100644
+--- a/arch/arm/dts/armada-3720-espressobin.dts
++++ b/arch/arm/dts/armada-3720-espressobin.dts
+@@ -140,6 +140,24 @@
+ 	status = "okay";
+ };
+ 
++&sdhci1 {
++	non-removable;
++	bus-width = <8>;
++	mmc-ddr-1_8v;
++	mmc-hs400-1_8v;
++	marvell,pad-type = "fixed-1-8v";
++	pinctrl-names = "default";
++	pinctrl-0 = <&mmc_pins>;
++	status = "okay";
++
++	#address-cells = <1>;
++	#size-cells = <0>;
++	mmccard: mmccard@0 {
++		compatible = "mmc-card";
++		reg = <0>;
++	};
++};
++
+ &spi0 {
+ 	status = "okay";
+ 	pinctrl-names = "default";


### PR DESCRIPTION
These patches are according to issue #851 and enable eMMC on board of ESPRESSObin board for linux-next and u-boot. Unfortunately linux-default produces image that gets stuck during boot on networking, need to look deeper into that, which might go as separate patch set.