### PR TITLE
Use ATF for rk322xh

### DIFF
--- a/config/sources/rk3328.conf
+++ b/config/sources/rk3328.conf
@@ -16,11 +16,11 @@ HAS_UUID_SUPPORT=yes
 BOOTDELAY=0
 OVERLAY_PREFIX='rk3328'
 
-ATFSOURCE='https://github.com/rockchip-linux/arm-trusted-firmware'
+ATFSOURCE='https://github.com/ayufan-rock64/arm-trusted-firmware'
 ATFDIR='arm-trusted-firmware-rk3328'
-ATFBRANCH='branch:master'
+ATFBRANCH='branch:rockchip'
 ATF_USE_GCC='> 6.3'
-ATF_TARGET_MAP='PLAT=rk3328 DEBUG=1 bl31;;trust.bin'
+ATF_TARGET_MAP='PLAT=rk322xh DEBUG=1 bl31;;trust.bin'
 
 case $BRANCH in
 	default)


### PR DESCRIPTION
This makes to use ATF for rk322xh (is a code product for rk3328) which allows the efuse to work correctly. It seems that rk3328 PLAT misses a lot of needed configuration options today.
