### PR TITLE
Updated pine64.conf with beta stretch mainline

### DIFF
--- a/config/boards/pine64.conf
+++ b/config/boards/pine64.conf
@@ -11,7 +11,7 @@ KERNEL_TARGET="default,next,dev"
 CLI_TARGET="jessie,xenial:default"
 DESKTOP_TARGET="xenial:default"
 
-CLI_BETA_TARGET=""
+CLI_BETA_TARGET="stretch:next"
 DESKTOP_BETA_TARGET=""
 #
 RECOMMENDED="Ubuntu_xenial_default_desktop:90,Ubuntu_xenial_default:90"


### PR DESCRIPTION
Adds `jessie:next` to `pine64` beta automatic build config