### PR TITLE
Fix "mmc2: unrecognised EXT_CSD revision 8" on Sunvell R69

### DIFF
--- a/patch/kernel/sun8i-default/0099-eMMC-fix-sunvellR69.patch
+++ b/patch/kernel/sun8i-default/0099-eMMC-fix-sunvellR69.patch
@@ -1,0 +1,12 @@
+diff -Naur a/drivers/mmc/core/mmc.c b/drivers/mmc/core/mmc.c
+--- a/drivers/mmc/core/mmc.c	2017-12-11 18:37:58.908013000 +0100
++++ b/drivers/mmc/core/mmc.c	2018-01-18 11:55:47.942244701 +0100
+@@ -262,7 +262,7 @@
+ 	}
+ 
+ 	card->ext_csd.rev = ext_csd[EXT_CSD_REV];
+-	if (card->ext_csd.rev > 7) {
++	if (card->ext_csd.rev > 8) {
+ 		pr_err("%s: unrecognised EXT_CSD revision %d\n",
+ 			mmc_hostname(card->host), card->ext_csd.rev);
+ 		err = -EINVAL;


### PR DESCRIPTION
Sunvell R69 report this error on kernel boot:

[    1.622884] mmc2: unrecognised EXT_CSD revision 8
[    1.622900] mmc2: error -22 whilst initialising MMC card

This patch fix this issue and make internal eMMC accesible via  /dev/mmcblk1

Note that old version of Sunvell R69 dosen't have this issue that come with probably new version