### PR TITLE
Enable GPIO_SYSFS on mvebu64

### DIFF
--- a/config/kernel/linux-mvebu64-next.config
+++ b/config/kernel/linux-mvebu64-next.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 4.14.0 Kernel Configuration
+# Linux/arm64 4.14.14 Kernel Configuration
 #
 CONFIG_ARM64=y
 CONFIG_64BIT=y
@@ -3076,7 +3076,7 @@ CONFIG_OF_GPIO=y
 CONFIG_GPIO_ACPI=y
 CONFIG_GPIOLIB_IRQCHIP=y
 # CONFIG_DEBUG_GPIO is not set
-# CONFIG_GPIO_SYSFS is not set
+CONFIG_GPIO_SYSFS=y
 CONFIG_GPIO_GENERIC=y
 
 #
@@ -3694,7 +3694,6 @@ CONFIG_HID_CHERRY=y
 CONFIG_HID_CHICONY=y
 # CONFIG_HID_CORSAIR is not set
 # CONFIG_HID_CMEDIA is not set
-# CONFIG_HID_CP2112 is not set
 CONFIG_HID_CYPRESS=y
 # CONFIG_HID_DRAGONRISE is not set
 # CONFIG_HID_EMS_FF is not set


### PR DESCRIPTION
As per issue #863 enabling GPIO_SYSFS

Note: File is as generated automatically (and not edited manually) as required by PR message. However I see new Kconfig deleted CONFIG_HID_CP2112 option. Please suggest if better just submit manually edited config over automatically generated.