### PR TITLE
Improve boot stability

### DIFF
--- a/patch/u-boot/u-boot-sunxi/add-sunvell-r69.patch
+++ b/patch/u-boot/u-boot-sunxi/add-sunvell-r69.patch
@@ -1,13 +1,13 @@
 diff --git a/configs/sunvell_r69_defconfig b/configs/sunvell_r69_defconfig
 new file mode 100644
-index 0000000..d37f4f4
+index 0000000..f4947ab
 --- /dev/null
 +++ b/configs/sunvell_r69_defconfig
 @@ -0,0 +1,21 @@
 +CONFIG_ARM=y
 +CONFIG_ARCH_SUNXI=y
 +CONFIG_MACH_SUN8I_H3=y
-+CONFIG_DRAM_CLK=576
++CONFIG_DRAM_CLK=408
 +CONFIG_DRAM_ZQ=3881979
 +CONFIG_DRAM_ODT_EN=y
 +# CONFIG_VIDEO_DE2 is not set
@@ -26,7 +26,7 @@ index 0000000..d37f4f4
 +CONFIG_SYS_USB_EVENT_POLL_VIA_INT_QUEUE=y
 +
 diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
-index 9dd0e11..da06402 100755
+index 7202541..1af2005 100644
 --- a/arch/arm/dts/Makefile
 +++ b/arch/arm/dts/Makefile
 @@ -320,6 +320,7 @@ dtb-$(CONFIG_MACH_SUN8I_A83T) += \


### PR DESCRIPTION
Reduced DRAM clock from 576MHz to 408MHz since users reported boot issues with some R69s.
See https://forum.armbian.com/topic/4877-h2-sunvell-r69-android-tv-box-aliexpress/?page=6&tab=comments#comment-48779

