### PR TITLE
Disable developer warning for non-supported boards

### DIFF
--- a/lib/main.sh
+++ b/lib/main.sh
@@ -196,7 +196,7 @@ if [[ -z $BRANCH ]]; then
 	fi
 	unset options
 	[[ -z $BRANCH ]] && exit_with_error "No kernel branch selected"
-	[[ $BRANCH == dev && $SHOW_WARNING == yes ]] && show_developer_warning
+	[[ $BOARD_TYPE == 'conf' && $BRANCH == dev && $SHOW_WARNING == yes ]] && show_developer_warning
 else
 	[[ $KERNEL_TARGET != *$BRANCH* ]] && exit_with_error "Kernel branch not defined for this board" "$BRANCH"
 fi


### PR DESCRIPTION
When you pass BOARD for not officially supported board, and you select dev branch, developer warning appears. 

This is useless, since the user should be aware of this. After all the warning for dev branch and non .conf boards is the same.