### PR TITLE
Fix kernel headers generation

### DIFF
--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -118,7 +118,7 @@ PACKAGE_LIST="bc bridge-utils build-essential cpufrequtils device-tree-compiler 
 	ca-certificates resolvconf expect rcconf iptables"
 
 # development related packages. remove when they are not needed for building packages in chroot
-PACKAGE_LIST="$PACKAGE_LIST automake libwrap0-dev libssl-dev libnl-3-dev libnl-genl-3-dev"
+PACKAGE_LIST="$PACKAGE_LIST automake bison flex libwrap0-dev libssl-dev libnl-3-dev libnl-genl-3-dev"
 
 # Non-essential packages
 PACKAGE_LIST_ADDITIONAL="alsa-utils btrfs-tools dosfstools hddtemp iotop iozone3 stress sysbench screen ntfs-3g vim pciutils \

--- a/patch/kernel/sunxi-dev/packaging-4.x-dev.patch
+++ b/patch/kernel/sunxi-dev/packaging-4.x-dev.patch
@@ -1,8 +1,8 @@
 diff --git a/scripts/package/builddeb b/scripts/package/builddeb
-index 0bc8747..9dab810 100755
+index b4f0f2b..062ccf5 100755
 --- a/scripts/package/builddeb
 +++ b/scripts/package/builddeb
-@@ -29,6 +29,28 @@ create_package() {
+@@ -29,6 +29,27 @@ create_package() {
  	# in case we are in a restrictive umask environment like 0077
  	chmod -R a+rX "$pdir"
  
@@ -10,7 +10,6 @@ index 0bc8747..9dab810 100755
 +	if [[ "$1" == *dtb* ]]; then
 +		echo "if [ -d /boot/dtb-$version ]; then mv /boot/dtb-$version /boot/dtb-$version.old; fi" >> $pdir/DEBIAN/preinst
 +		echo "if [ -d /boot/dtb.old ]; then rm -rf /boot/dtb.old; fi" >> $pdir/DEBIAN/preinst
-+		echo "if [ -d /dtb ]; then mv /dtb /dtb.old; fi" >> $pdir/DEBIAN/preinst
 +		echo "if [ -d /boot/dtb ]; then mv /boot/dtb /boot/dtb.old; fi" >> $pdir/DEBIAN/preinst
 +		echo "exit 0" >> $pdir/DEBIAN/preinst
 +		chmod 775 $pdir/DEBIAN/preinst
@@ -20,46 +19,67 @@ index 0bc8747..9dab810 100755
 +		echo "exit 0" >> $pdir/DEBIAN/postinst
 +		chmod 775 $pdir/DEBIAN/postinst
 +	fi
-+	
++
 +	# Create postinstall script for headers
 +	if [[ "$1" == *headers* ]]; then
 +		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; make -s scripts >/dev/null 2>&1" >> $pdir/DEBIAN/postinst
 +		echo "exit 0" >> $pdir/DEBIAN/postinst
 +		chmod 775 $pdir/DEBIAN/postinst
 +	fi
-+	
++
  	# Create the package
  	dpkg-gencontrol $forcearch -Vkernel:debarch="${debarch}" -p$pname -P"$pdir"
  	dpkg --build "$pdir" ..
-@@ -94,10 +116,13 @@ sourcename=$KDEB_SOURCENAME
- tmpdir="$objtree/debian/tmp"
+@@ -52,7 +73,9 @@ set_debarch() {
+ 	mips*)
+ 		debarch=mips$(grep -q CPU_LITTLE_ENDIAN=y $KCONFIG_CONFIG && echo el || true) ;;
+ 	aarch64|arm64)
+-		debarch=arm64 ;;
++		debarch=arm64
++		image_name=Image
++		;;
+ 	arm*)
+ 		if grep -q CONFIG_AEABI=y $KCONFIG_CONFIG; then
+ 		    if grep -q CONFIG_VFP=y $KCONFIG_CONFIG; then
+@@ -63,6 +86,7 @@ set_debarch() {
+ 		else
+ 		    debarch=arm
+ 		fi
++		image_name=zImage
+ 		;;
+ 	*)
+ 		debarch=$(dpkg --print-architecture)
+@@ -95,12 +119,15 @@ tmpdir="$objtree/debian/tmp"
  kernel_headers_dir="$objtree/debian/hdrtmp"
  libc_headers_dir="$objtree/debian/headertmp"
-+dtb_dir="$objtree/debian/dtbtmp"
  dbg_dir="$objtree/debian/dbgtmp"
 -packagename=linux-image-$version
 -kernel_headers_packagename=linux-headers-$version
 -libc_headers_packagename=linux-libc-dev
++dtb_dir="$objtree/debian/dtbtmp"
 +packagename=linux-image-dev"$LOCALVERSION"
-+fwpackagename=linux-firmware-image-dev"$LOCALVERSION"
 +kernel_headers_packagename=linux-headers-dev"$LOCALVERSION"
 +dtb_packagename=linux-dtb-dev"$LOCALVERSION"
 +libc_headers_packagename=linux-libc-dev-dev"$LOCALVERSION"
  dbg_packagename=$packagename-dbg
  debarch=
  forcearch=
-@@ -124,7 +149,9 @@ esac
++image_name=
+ set_debarch
+ 
+ if [ "$ARCH" = "um" ] ; then
+@@ -124,7 +151,9 @@ esac
  BUILD_DEBUG="$(grep -s '^CONFIG_DEBUG_INFO=y' $KCONFIG_CONFIG || true)"
  
  # Setup the directory structure
 -rm -rf "$tmpdir" "$kernel_headers_dir" "$libc_headers_dir" "$dbg_dir" $objtree/debian/files
-+rm -rf "$tmpdir" "$fwdir" "$kernel_headers_dir" "$libc_headers_dir" "$dbg_dir" "$dtb_dir" $objtree/debian/files
++rm -rf "$tmpdir" "$kernel_headers_dir" "$libc_headers_dir" "$dbg_dir" "$dtb_dir" $objtree/debian/files
 +mkdir -m 755 -p "$dtb_dir/DEBIAN"
 +mkdir -p "$dtb_dir/boot/dtb-$version" "$dtb_dir/usr/share/doc/$dtb_packagename"
  mkdir -m 755 -p "$tmpdir/DEBIAN"
  mkdir -p "$tmpdir/lib" "$tmpdir/boot"
  mkdir -p "$kernel_headers_dir/lib/modules/$version/"
-@@ -177,6 +204,11 @@ if grep -q '^CONFIG_MODULES=y' $KCONFIG_CONFIG ; then
+@@ -177,6 +206,11 @@ if grep -q '^CONFIG_MODULES=y' $KCONFIG_CONFIG ; then
  	fi
  fi
  
@@ -71,32 +91,6 @@ index 0bc8747..9dab810 100755
  if [ "$ARCH" != "um" ]; then
  	$MAKE headers_check KBUILD_SRC=
  	$MAKE headers_install KBUILD_SRC= INSTALL_HDR_PATH="$libc_headers_dir/usr"
-@@ -189,21 +221,23 @@ fi
- # so do we; recent versions of dracut and initramfs-tools will obey this.
- debhookdir=${KDEB_HOOKDIR:-/etc/kernel}
- if grep -q '^CONFIG_BLK_DEV_INITRD=y' $KCONFIG_CONFIG; then
--	want_initrd=Yes
-+	want_initrd=Yes 
- else
- 	want_initrd=No
- fi
- for script in postinst postrm preinst prerm ; do
- 	mkdir -p "$tmpdir$debhookdir/$script.d"
- 	cat <<EOF > "$tmpdir/DEBIAN/$script"
--#!/bin/sh
-+#!/bin/bash
- 
- set -e
- 
- # Pass maintainer script parameters to hook scripts
-+
- export DEB_MAINT_PARAMS="\$*"
- 
- # Tell initramfs builder whether it's wanted
-+
- export INITRD=$want_initrd
- 
- test -d $debhookdir/$script.d && run-parts --arg="$version" --arg="/$installed_image_path" $debhookdir/$script.d
 @@ -212,6 +246,55 @@ EOF
  	chmod 755 "$tmpdir/DEBIAN/$script"
  done
@@ -106,7 +100,7 @@ index 0bc8747..9dab810 100755
 +##
 +sed -e "s/set -e//g" -i $tmpdir/DEBIAN/postinst
 +sed -e "s/exit 0//g" -i $tmpdir/DEBIAN/postinst
-+cat >> $tmpdir/DEBIAN/postinst <<EOT 
++cat >> $tmpdir/DEBIAN/postinst <<EOT
 +if [ "\$(grep nand /proc/partitions)" != "" ] && [ "\$(grep mmc /proc/partitions)" = "" ]; then
 +mkimage -A arm -O linux -T kernel -C none -a "0x40008000" -e "0x40008000" -n "Linux kernel" -d /$installed_image_path /boot/uImage  > /dev/null 2>&1
 +cp /boot/uImage /tmp/uImage
@@ -115,7 +109,7 @@ index 0bc8747..9dab810 100755
 +cp /tmp/uImage /boot/uImage
 +rm -f /$installed_image_path
 +else
-+ln -sf $(basename $installed_image_path) /boot/zImage > /dev/null 2>&1 || mv /$installed_image_path /boot/zImage
++ln -sf $(basename $installed_image_path) /boot/$image_name || mv /$installed_image_path /boot/$image_name
 +fi
 +touch /boot/.next
 +exit 0
@@ -125,7 +119,7 @@ index 0bc8747..9dab810 100755
 +##
 +sed -e "s/set -e//g" -i $tmpdir/DEBIAN/preinst
 +sed -e "s/exit 0//g" -i $tmpdir/DEBIAN/preinst
-+cat >> $tmpdir/DEBIAN/preinst <<EOT 
++cat >> $tmpdir/DEBIAN/preinst <<EOT
 +# exit if we are running chroot
 +if [ "\$(stat -c %d:%i /)" != "\$(stat -c %d:%i /proc/1/root/.)" ]; then exit 0; fi
 +
@@ -141,40 +135,43 @@ index 0bc8747..9dab810 100755
 +done
 +
 +bootfstype=\$(blkid -s TYPE -o value \$boot_partition)
-+if [ "\$bootfstype" = "vfat" ]; then 
-+umount /boot; 
-+rm -f /boot/System.map* /boot/config* /boot/vmlinuz* /boot/zImage /boot/uImage
++if [ "\$bootfstype" = "vfat" ]; then
++umount /boot
++rm -f /boot/System.map* /boot/config* /boot/vmlinuz* /boot/$image_name /boot/uImage
 +fi
 +}
 +mountpoint -q /boot && check_and_unmount
 +EOT
-+echo "exit 0" >> $tmpdir/DEBIAN/preinst 
++echo "exit 0" >> $tmpdir/DEBIAN/preinst
 +
  # Try to determine maintainer and email values
  if [ -n "$DEBEMAIL" ]; then
         email=$DEBEMAIL
-@@ -325,12 +408,20 @@ if grep -q '^CONFIG_GCC_PLUGINS=y' $KCONFIG_CONFIG ; then
+@@ -314,6 +397,7 @@ fi
+ # Build kernel header package
+ (cd $srctree; find . -name Makefile\* -o -name Kconfig\* -o -name \*.pl) > "$objtree/debian/hdrsrcfiles"
+ (cd $srctree; find arch/*/include include scripts -type f) >> "$objtree/debian/hdrsrcfiles"
++(cd $srctree; find security/*/include -type f) >> "$objtree/debian/hdrsrcfiles"
+ (cd $srctree; find arch/$SRCARCH -name module.lds -o -name Kbuild.platforms -o -name Platform) >> "$objtree/debian/hdrsrcfiles"
+ (cd $srctree; find $(find arch/$SRCARCH -name include -o -name scripts -type d) -type f) >> "$objtree/debian/hdrsrcfiles"
+ if grep -q '^CONFIG_STACK_VALIDATION=y' $KCONFIG_CONFIG ; then
+@@ -325,12 +409,15 @@ if grep -q '^CONFIG_GCC_PLUGINS=y' $KCONFIG_CONFIG ; then
  fi
  destdir=$kernel_headers_dir/usr/src/linux-headers-$version
  mkdir -p "$destdir"
-+######################## headers patch
-+ZACNI=$(pwd)
-+cd $destdir
-+patch -p1 < /tmp/headers-debian-byteshift.patch
-+cd $ZACNI
-+######################## headers patch
++(cd $destdir; patch -p1 < /tmp/headers-debian-byteshift.patch)
  (cd $srctree; tar -c -f - -T -) < "$objtree/debian/hdrsrcfiles" | (cd $destdir; tar -xf -)
  (cd $objtree; tar -c -f - -T -) < "$objtree/debian/hdrobjfiles" | (cd $destdir; tar -xf -)
  (cd $objtree; cp $KCONFIG_CONFIG $destdir/.config) # copy .config manually to be where it's expected to be
  ln -sf "/usr/src/linux-headers-$version" "$kernel_headers_dir/lib/modules/$version/build"
  rm -f "$objtree/debian/hdrsrcfiles" "$objtree/debian/hdrobjfiles"
  
-+(cd "$destdir"; make M=scripts clean)
++(cd $destdir; make M=scripts clean)
 +
  cat <<EOF >> debian/control
  
  Package: $kernel_headers_packagename
-@@ -343,6 +434,16 @@ EOF
+@@ -343,6 +430,16 @@ EOF
  
  cat <<EOF >> debian/control
  
@@ -191,7 +188,7 @@ index 0bc8747..9dab810 100755
  Package: $libc_headers_packagename
  Section: devel
  Provides: linux-kernel-headers
-@@ -354,7 +455,7 @@ EOF
+@@ -354,7 +451,7 @@ EOF
  
  if [ "$ARCH" != "um" ]; then
  	create_package "$kernel_headers_packagename" "$kernel_headers_dir"


### PR DESCRIPTION
This pull request syncs the packaging patch with sunxi-next branch. Basically this is copy/paste from sunxi-next with different name and changed packages names. Also the patch is renamed.

There was some issue with this patch, which can relate to this #830.

Since post-install script doesn't generate errors, the package installs successfully, but there were missing binary files. It turns out, on recent kernels, you need bison and flex to build scripts target.

The second commit adds them to PACKAGE_LIST variable.

 
