### PR TITLE
automatic 4-byte-skip (or not)

### DIFF
--- a/config/sources/rk3328.conf
+++ b/config/sources/rk3328.conf
@@ -68,18 +68,24 @@ setup_write_uboot_platform()
 uboot_custom_postprocess()
 {
 	# bootloader image
-	local tempfile=$(mktemp)
 	#
-	#Below is what works with BOOTBRANCH='branch:rockchip-master'
-	#
-	dd if=$SRC/cache/sources/rkbin-tools/rk33/rk3328_ddr_786MHz_v1.06.bin of=$tempfile bs=4 skip=1
-	tools/mkimage -n rk3328 -T rksd -d $tempfile idbloader.bin
+	case $BRANCH in
+        default)
+                #Below is what works with BOOTBRANCH='branch:rockchip-master'
+                #
+                local tempfile=$(mktemp)
+                dd if=$SRC/cache/sources/rkbin-tools/rk33/rk3328_ddr_786MHz_v1.06.bin of=$tempfile bs=4 skip=1
+                tools/mkimage -n rk3328 -T rksd -d $tempfile idbloader.bin
+                ;;
 
-	# Below is the way it is supposed to work according to Rockchip documentation,
-	# and how it does work with the mainline-master branch.  No 4-byte skip.
-	#
-	# tools/mkimage -n rk3328 -T rksd -d $SRC/cache/sources/rkbin-tools/rk33/rk3328_ddr_786MHz_v1.06.bin idbloader.bin
-	#
+        dev)
+                # Below is the way it is supposed to work according to Rockchip documentation,
+                # and how it does work with the mainline-master branch.  No 4-byte skip.
+                #
+                tools/mkimage -n rk3328 -T rksd -d $SRC/cache/sources/rkbin-tools/rk33/rk3328_ddr_786MHz_v1.06.bin idbloader.bin
+                ;;
+        esac
+
 
 	cat $SRC/cache/sources/rkbin-tools/rk33/rk3328_miniloader_v2.43.bin >> idbloader.bin
 


### PR DESCRIPTION
4-byte-skip for branch:rockchip-master
and 
no-skip for branch:mainline-master

Please use the "Preview" tab above to view this message if you are seeing this in the new pull request text box.

Please make sure that:

 - any changes to kernel configuration files were made by Kconfig menu (build script option `KERNEL_CONFIGURE=yes`) and not by editing configuration files by hand,
 - patch file names don't contain spaces and have less than 40 characters (not counting the `.patch` extension),
 - changes are properly described - what was done exactly and why.

Thanks for contributing! Please remove the text above before opening a pull request.
