### PR TITLE
update sunvell-r69 board config

### DIFF
--- a/config/boards/sunvell-r69.csc
+++ b/config/boards/sunvell-r69.csc
@@ -4,16 +4,21 @@ BOARDFAMILY="sun8i"
 BOOTCONFIG="sunvell_r69_defconfig"
 #
 MODULES="xradio_wlan xradio_wlan"
-MODULES_NEXT="xradio_wlan"
+MODULES_NEXT=""
 MODULES_BLACKLIST="dhd"
+DEFAULT_OVERLAYS="cir analog-codec"
 CPUMIN=240000
 CPUMAX=1008000
 #
-KERNEL_TARGET="default next"
-CLI_TARGET="jessie,xenial:default"
+KERNEL_TARGET="default,next,dev"
+CLI_TARGET="stretch,xenial:next"
+DESKTOP_TARGET="stretch:next"
+#
+CLI_BETA_TARGET=""
+DESKTOP_BETA_TARGET=""
+#
+BOARDRATING=""
+CHIP="http://docs.armbian.com/Hardware_Allwinner-H3/"
+HARDWARE="http://linux-sunxi.org/Sunvell_R69"
+FORUMS="http://forum.armbian.com/index.php/forum/13-allwinner-h3/"
 
-CLI_BETA_TARGET="xenial,stretch:next"
-DESKTOP_TARGET="xenial:default"
-
-CLI_BETA_TARGET="jessie:default"
-DESKTOP_BETA_TARGET="xenial:default"


### PR DESCRIPTION
brings sunvell-r79.csc in line with other board configs (adding dev as target, remove duplicate lines, syntax cleanup, ...)

