### PR TITLE
Transfer 'serialcon' to u-boot-environment

### DIFF
--- a/lib/debootstrap-ng.sh
+++ b/lib/debootstrap-ng.sh
@@ -426,6 +426,9 @@ prepare_partitions()
 		[[ $HAS_UUID_SUPPORT == yes ]] && sed -i 's/^setenv rootdev .*/setenv rootdev "'$rootfs'"/' $SDCARD/boot/boot.ini
 		[[ -f $SDCARD/boot/armbianEnv.txt ]] && rm $SDCARD/boot/armbianEnv.txt
 	fi
+	
+	# transfer serialcon to u-boot-environment for later use in boot.cmd (at the moment only used for rk3328)
+	echo "serialcon=$SERIALCON" >> $SDCARD/boot/armbianEnv.txt
 
 	# recompile .cmd to .scr if boot.cmd exists
 	[[ -f $SDCARD/boot/boot.cmd ]] && \


### PR DESCRIPTION
At the moment the boards with rk3328 need different settings in bootargs for kernel 4.4 vs. 4.15 (and later). Otherwise we have a speed bump in the serial console from 1500000 to 9600 baud after u-boot, which is inconvenient.
One possible way is to inject the needed value in armbianEnv.txt at build-time and use that in an updated boot.cmd.
Of course there are other (and maybe smarter) ways to achieve this, but it should be flexible, if we need new settings in later kernel releases. We only need to declare the correct SERIALCON in config/sources/rk3328.conf.

Please use the "Preview" tab above to view this message if you are seeing this in the new pull request text box.

Please make sure that:

 - any changes to kernel configuration files were made by Kconfig menu (build script option `KERNEL_CONFIGURE=yes`) and not by editing configuration files by hand,
 - patch file names don't contain spaces and have less than 40 characters (not counting the `.patch` extension),
 - changes are properly described - what was done exactly and why.

Thanks for contributing! Please remove the text above before opening a pull request.
