### PR TITLE
Use serialcon from u-boot-environment

### DIFF
--- a/config/bootscripts/boot-rk3328.cmd
+++ b/config/bootscripts/boot-rk3328.cmd
@@ -22,7 +22,7 @@ fi
 if test "${logo}" = "disabled"; then setenv logo "logo.nologo"; fi
 
 if test "${console}" = "display" || test "${console}" = "both"; then setenv consoleargs "console=tty1"; fi
-if test "${console}" = "serial" || test "${console}" = "both"; then setenv consoleargs "${consoleargs} console=ttyFIQ0,1500000"; fi
+if test "${console}" = "serial" || test "${console}" = "both"; then setenv consoleargs "${consoleargs} console=${serialcon},1500000"; fi
 
 # get PARTUUID of first partition on SD/eMMC the boot script was loaded from
 if test "${devtype}" = "mmc"; then part uuid mmc ${devnum}:1 partuuid; fi


### PR DESCRIPTION
Only useful with other patch, that writes SERIALCON to /boot/armbianEnv.txt at compile time.

Please use the "Preview" tab above to view this message if you are seeing this in the new pull request text box.

Please make sure that:

 - any changes to kernel configuration files were made by Kconfig menu (build script option `KERNEL_CONFIGURE=yes`) and not by editing configuration files by hand,
 - patch file names don't contain spaces and have less than 40 characters (not counting the `.patch` extension),
 - changes are properly described - what was done exactly and why.

Thanks for contributing! Please remove the text above before opening a pull request.
