### PR TITLE
MIQI-DTS-enable-sound-node

### DIFF
--- a/patch/kernel/rockchip-dev/2027-ARM-DTS-rk3288-miqi-enable-sound.patch
+++ b/patch/kernel/rockchip-dev/2027-ARM-DTS-rk3288-miqi-enable-sound.patch
@@ -1,0 +1,30 @@
+diff --git a/arch/arm/boot/dts/rk3288-miqi.dts b/arch/arm/boot/dts/rk3288-miqi.dts
+index dd785c7..5824ee7 100644
+--- a/arch/arm/boot/dts/rk3288-miqi.dts
++++ b/arch/arm/boot/dts/rk3288-miqi.dts
+@@ -57,6 +57,23 @@
+ 		reg = <0x0 0x0 0x0 0x80000000>;
+ 	};
+ 
++	sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,name = "DW-HDMI";
++		simple-audio-card,mclk-fs = <512>;
++
++		simple-audio-card,dai-link@0 {  /* I2S - S/PDIF */
++			format = "i2s";
++			cpu {
++				sound-dai = <&i2s>;
++			};
++			codec {
++				sound-dai = <&hdmi>;
++			};
++		};
++	};
++
+ 	ext_gmac: external-gmac-clock {
+ 		compatible = "fixed-clock";
+ 		#clock-cells = <0>;
+--
+2.14.1


### PR DESCRIPTION
Add missing sound node in rk3288-miqi.dts. Compile and run-tested on miqi device with kernel 4.16.0-rc5.