### PR TITLE
correct previous kernel config path

### DIFF
--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -283,9 +283,9 @@ compile_kernel()
 	display_alert "Compiler version" "${KERNEL_COMPILER}gcc $(eval env PATH=$toolchain:$PATH ${KERNEL_COMPILER}gcc -dumpversion)" "info"
 
 	# copy kernel config
-	if [[ $KERNEL_KEEP_CONFIG == yes && -f $DEST/$LINUXCONFIG.config ]]; then
-		display_alert "Using previous kernel config" "$DEST/$LINUXCONFIG.config" "info"
-		cp $DEST/$LINUXCONFIG.config .config
+	if [[ $KERNEL_KEEP_CONFIG == yes && -f $DEST/config/$LINUXCONFIG.config ]]; then
+		display_alert "Using previous kernel config" "$DEST/config/$LINUXCONFIG.config" "info"
+		cp $DEST/config/$LINUXCONFIG.config .config
 	else
 		if [[ -f $SRC/userpatches/$LINUXCONFIG.config ]]; then
 			display_alert "Using kernel config provided by user" "userpatches/$LINUXCONFIG.config" "info"


### PR DESCRIPTION
Please use the "Preview" tab above to view this message if you are seeing this in the new pull request text box.

Please make sure that:

 - any changes to kernel configuration files were made by Kconfig menu (build script option `KERNEL_CONFIGURE=yes`) and not by editing configuration files by hand,
 - patch file names don't contain spaces and have less than 40 characters (not counting the `.patch` extension),
 - changes are properly described - what was done exactly and why.

Thanks for contributing! Please remove the text above before opening a pull request.
