### PR TITLE
Add a DTS-file for the z28pro

### DIFF
--- a/patch/kernel/rk3328-default/z28pro.ptach
+++ b/patch/kernel/rk3328-default/z28pro.ptach
@@ -1,0 +1,810 @@
+diff --git a/arch/arm64/boot/dts/rockchip/Makefile b/arch/arm64/boot/dts/rockchip/Makefile
+index f610d40..8f70f90 100644
+--- a/arch/arm64/boot/dts/rockchip/Makefile
++++ b/arch/arm64/boot/dts/rockchip/Makefile
+@@ -11,6 +11,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-evb.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-evb-android.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-rock64.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-rock64-android.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-z28pro.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3366-fpga.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3366-sheep.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3368-evb-act8846.dtb
+diff --git a/arch/arm64/boot/dts/rockchip/rk3328-z28pro.dts b/arch/arm64/boot/dts/rockchip/rk3328-z28pro.dts
+new file mode 100644
+index 0000000..b140134
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3328-z28pro.dts
+@@ -0,0 +1,792 @@
++/*
++ * Copyright (c) 2016 Fuzhou Rockchip Electronics Co., Ltd
++ *
++ * This file is dual-licensed: you can use it either under the terms
++ * of the GPL or the X11 license, at your option. Note that this dual
++ * licensing only applies to this file, and not this project as a
++ * whole.
++ *
++ *  a) This library is free software; you can redistribute it and/or
++ *     modify it under the terms of the GNU General Public License as
++ *     published by the Free Software Foundation; either version 2 of the
++ *     License, or (at your option) any later version.
++ *
++ *     This library is distributed in the hope that it will be useful,
++ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *     GNU General Public License for more details.
++ *
++ * Or, alternatively,
++ *
++ *  b) Permission is hereby granted, free of charge, to any person
++ *     obtaining a copy of this software and associated documentation
++ *     files (the "Software"), to deal in the Software without
++ *     restriction, including without limitation the rights to use,
++ *     copy, modify, merge, publish, distribute, sublicense, and/or
++ *     sell copies of the Software, and to permit persons to whom the
++ *     Software is furnished to do so, subject to the following
++ *     conditions:
++ *
++ *     The above copyright notice and this permission notice shall be
++ *     included in all copies or substantial portions of the Software.
++ *
++ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
++ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
++ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
++ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
++ *     OTHER DEALINGS IN THE SOFTWARE.
++ */
++
++/dts-v1/;
++#include "rk3328.dtsi"
++#include <dt-bindings/input/input.h>
++
++/ {
++	model = "Z28pro";
++	compatible = "rockchip,rk3328-z28pro", "rockchip,rk3328";
++
++	chosen {
++		bootargs = "earlyprintk=uart8250-32bit,0xff130000";
++		stdout-path = "serial2:115200n8";	
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		standby-led {
++			linux,default-trigger = "disk-activity";
++			gpios = <&rk805 0 GPIO_ACTIVE_LOW>;
++			default-state = "on";
++		};
++
++		power-led {
++			gpios = <&rk805 1 GPIO_ACTIVE_LOW>;
++			default-state = "on";
++		};
++
++		ir {
++			linux,default-trigger = "ir";
++			default-state = "off";
++			mode = <0x0>;
++		};
++	};
++
++	switches {
++		compatible = "gpio-leds";
++
++		usb-switch {
++			linux,default-trigger = "none";
++			gpios = <&gpio0 2 1>;
++			mode = <0x23>;
++			default-state = "on";
++		};
++	};
++
++	gmac_clkin: external-gmac-clock {
++		compatible = "fixed-clock";
++		clock-frequency = <125000000>;
++		clock-output-names = "gmac_clkin";
++		#clock-cells = <0>;
++	};
++
++	sdio_pwrseq: sdio-pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		pinctrl-names = "default";
++		pinctrl-0 = <&wifi_enable_h>;
++
++		/*
++		 * On the module itself this is one of these (depending
++		 * on the actual card populated):
++		 * - SDIO_RESET_L_WL_REG_ON
++		 * - PDN (power down when low)
++		 */
++		reset-gpios = <&gpio1 18 GPIO_ACTIVE_LOW>;
++	};
++
++	sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,mclk-fs = <256>;
++		simple-audio-card,name = "rockchip,rk3328";
++		simple-audio-card,cpu {
++			sound-dai = <&i2s1>;
++		};
++		simple-audio-card,codec {
++			sound-dai = <&codec>;
++		};
++	};
++
++	hdmi-sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,mclk-fs = <128>;
++		simple-audio-card,name = "rockchip,hdmi";
++		simple-audio-card,cpu {
++			sound-dai = <&i2s0>;
++		};
++		simple-audio-card,codec {
++			sound-dai = <&hdmi>;
++		};
++	};
++
++	spdif-sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,name = "rockchip,spdif";
++		simple-audio-card,cpu {
++			sound-dai = <&spdif>;
++		};
++		simple-audio-card,codec {
++			sound-dai = <&spdif_out>;
++		};
++	};
++
++	spdif_out: spdif-out {
++		compatible = "linux,spdif-dit";
++		#sound-dai-cells = <0>;
++	};
++
++	dummy_codec: dummy-codec {
++		compatible = "rockchip,dummy-codec";
++		status = "disabled";
++	};
++
++	vcc_phy: vcc-phy-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_phy";
++		regulator-always-on;
++		regulator-boot-on;
++	};
++
++	vcc_sys: vcc-sys {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++	};
++
++	vcc_host_5v: vcc-host-5v-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio0 RK_PA0 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&usb30_host_drv>;
++		regulator-name = "vcc_host_5v";
++		regulator-always-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc_sys>;
++	};
++
++	vcc_host1_5v: vcc_otg_5v: vcc-host1-5v-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio0 RK_PA2 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&usb20_host_drv>;
++		regulator-name = "vcc_host1_5v";
++		regulator-always-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc_sys>;
++	};
++
++
++        vcc_sd: sdmmc-regulator {
++                compatible = "regulator-fixed";
++                gpio = <&gpio2 RK_PA7 GPIO_ACTIVE_LOW>;
++                pinctrl-names = "default";
++                pinctrl-0 = <&sdmmc0m1_gpio>;
++                regulator-name = "vcc_sd";
++                regulator-min-microvolt = <3300000>;
++                regulator-max-microvolt = <3300000>;
++                vin-supply = <&vcc_io>;
++        };
++
++	ir-receiver {
++		compatible = "gpio-ir-receiver";
++		gpios = <&gpio2 RK_PA2 GPIO_ACTIVE_LOW>;
++		pinctrl-0 = <&ir_int>;
++		pinctrl-names = "default";
++		status = "okay";
++	};
++
++	wireless-bluetooth {
++		compatible = "bluetooth-platdata";
++		uart_rts_gpios = <&gpio1 RK_PB2 GPIO_ACTIVE_LOW>;
++		pinctrl-names = "default", "rts_gpio";
++		pinctrl-0 = <&uart0_rts>;
++		pinctrl-1 = <&uart0_gpios>;
++		BT,power_gpio = <&gpio1 RK_PC5 GPIO_ACTIVE_HIGH>;
++		BT,wake_host_irq = <&gpio1 RK_PD2 GPIO_ACTIVE_HIGH>;
++		status = "disabled";  /* not ready yet*/
++	};
++
++	wireless-wlan {
++		compatible = "wlan-platdata";
++		rockchip,grf = <&grf>;
++		wifi_chip_type = "rtl8189es";
++		WIFI,host_wake_irq = <&gpio1 RK_PC3 GPIO_ACTIVE_HIGH>;
++		WIFI,poweren_gpio = <&gpio1 RK_PC2 RK_FUNC_GPIO GPIO_ACTIVE_HIGH>;
++		WIFI,reset_gpio = <&gpio1 18 GPIO_ACTIVE_LOW>;
++		status = "okay"; /* not ready yet*/
++	};
++};
++
++&codec {
++	#sound-dai-cells = <0>;
++	status = "okay";
++};
++
++&cpu0 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&cpu1 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&cpu2 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&cpu3 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&display_subsystem {
++	status = "okay";
++};
++
++&dfi {
++	status = "okay";
++};
++
++&dmc {
++	center-supply = <&vdd_logic>;
++	status = "okay";
++};
++
++&emmc {
++	/delete-property/ clock-freq-min-max;
++	bus-width = <8>;
++	cap-mmc-highspeed;
++	non-removable;
++	supports-emmc;
++	clocks = <&cru HCLK_EMMC>, <&cru SCLK_EMMC>,
++		<&cru SCLK_EMMC_DRV>, <&cru SCLK_EMMC_SAMPLE>;	
++	clock-names = "biu", "ciu", "ciu-drv", "ciu-sample";
++	disable-wp;
++	max-frequency = <200000000>;
++	mmc-hs200-1_8v;
++	num-slots = <1>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&emmc_clk &emmc_cmd &emmc_bus8>;
++	vmmc-supply = <&vcc_io>;
++	vqmmc-supply = <&vcc_18emmc>;
++	status = "okay";
++};
++
++
++&gmac2io {
++	phy-supply = <&vcc_phy>;
++	phy-mode = "rgmii";
++	clock_in_out = "input";
++	snps,reset-gpio = <&gpio1 RK_PC2 GPIO_ACTIVE_LOW>;
++	snps,reset-active-low;
++	snps,reset-delays-us = <0 10000 50000>;
++	assigned-clocks = <&cru SCLK_MAC2IO>, <&cru SCLK_MAC2IO_EXT>;
++	assigned-clock-parents = <&gmac_clkin>, <&gmac_clkin>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&rgmiim1_pins>;
++	tx_delay = <0x26>;
++	rx_delay = <0x11>;
++	status = "okay";
++};
++
++&gpu {
++	status = "okay";
++	mali-supply = <&vdd_logic>;
++};
++
++&hdmi {
++	#sound-dai-cells = <0>;
++	ddc-i2c-scl-high-time-ns = <9625>;
++	ddc-i2c-scl-low-time-ns = <10000>;
++	status = "okay";
++};
++
++&hdmiphy {
++	status = "okay";
++};
++
++&i2c1 {
++	status = "okay";
++
++	rk805: rk805@18 {
++		compatible = "rockchip,rk805";
++		status = "okay";
++		reg = <0x18>;
++		interrupt-parent = <&gpio2>;
++		interrupts = <6 IRQ_TYPE_LEVEL_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pmic_int_l>;
++		rockchip,system-power-controller;
++		wakeup-source;
++		gpio-controller;
++		#gpio-cells = <2>;
++		#clock-cells = <1>;
++		clock-output-names = "xin32k", "rk805-clkout2";
++
++		vcc1-supply = <&vcc_sys>;
++		vcc2-supply = <&vcc_sys>;
++		vcc3-supply = <&vcc_sys>;
++		vcc4-supply = <&vcc_sys>;
++		vcc5-supply = <&vcc_io>;
++		vcc6-supply = <&vcc_sys>;
++		
++
++		rtc {
++			status = "disabled";
++		};
++
++		pwrkey {
++			status = "okay";
++		};
++
++		gpio {
++			status = "okay";
++		};
++
++		regulators {
++			compatible = "rk805-regulator";
++			status = "okay";
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			vdd_logic: RK805_DCDC1@0 {
++				regulator-compatible = "RK805_DCDC1";
++				regulator-name = "vdd_logic";
++				regulator-min-microvolt = <712500>;
++				regulator-max-microvolt = <1450000>;
++				regulator-initial-mode = <0x1>;
++				regulator-ramp-delay = <12500>;
++				regulator-boot-on;
++				regulator-always-on;
++				regulator-state-mem {
++					regulator-mode = <0x2>;
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1000000>;
++				};
++			};
++
++			vdd_arm: RK805_DCDC2@1 {
++				regulator-compatible = "RK805_DCDC2";
++				regulator-name = "vdd_arm";
++				regulator-min-microvolt = <712500>;
++				regulator-max-microvolt = <1450000>;
++				regulator-initial-mode = <0x1>;
++				regulator-ramp-delay = <12500>;
++				regulator-boot-on;
++				regulator-always-on;
++				regulator-state-mem {
++					regulator-mode = <0x2>;
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <950000>;
++				};
++			};
++
++			vcc_ddr: RK805_DCDC3@2 {
++				regulator-compatible = "RK805_DCDC3";
++				regulator-name = "vcc_ddr";
++				regulator-initial-mode = <0x1>;
++				regulator-boot-on;
++				regulator-always-on;
++				regulator-state-mem {
++					regulator-mode = <0x2>;
++					regulator-on-in-suspend;
++				};
++			};
++
++			vcc_io: RK805_DCDC4@3 {
++				regulator-compatible = "RK805_DCDC4";
++				regulator-name = "vcc_io";
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-initial-mode = <0x1>;
++				regulator-boot-on;
++				regulator-always-on;
++				regulator-state-mem {
++					regulator-mode = <0x2>;
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++				};
++			};
++
++			vdd_18: RK805_LDO1@4 {
++				regulator-compatible = "RK805_LDO1";
++				regulator-name = "vdd_18";
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-boot-on;
++				regulator-always-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vcc_18emmc: RK805_LDO2@5 {
++				regulator-compatible = "RK805_LDO2";
++				regulator-name = "vcc_18emmc";
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-boot-on;
++				regulator-always-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vdd_11: RK805_LDO3@6 {
++				regulator-compatible = "RK805_LDO3";
++				regulator-name = "vdd_11";
++				regulator-min-microvolt = <1100000>;
++				regulator-max-microvolt = <1100000>;
++				regulator-boot-on;
++				regulator-always-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1100000>;
++				};
++			};
++		};
++	};
++};
++
++&h265e {
++	status = "okay";
++};
++
++&i2s0 {
++	#sound-dai-cells = <0>;
++	rockchip,bclk-fs = <128>;
++	status = "okay";
++};
++
++&i2s1 {
++	#sound-dai-cells = <0>;
++	status = "okay";
++};
++
++
++&io_domains {
++	status = "okay";
++
++	vccio1-supply = <&vcc_io>;
++	vccio2-supply = <&vcc_18emmc>;
++	vccio3-supply = <&vcc_io>;
++	vccio4-supply = <&vdd_18>;
++	vccio5-supply = <&vcc_io>;
++	vccio6-supply = <&vcc_io>;
++	pmuio-supply = <&vcc_io>;
++};
++
++&pinctrl {
++	pmic {
++		pmic_int_l: pmic-int-l {
++		rockchip,pins =
++			<2 RK_PA6 RK_FUNC_GPIO &pcfg_pull_up>;	/* gpio2_a6 */
++		};
++	};
++
++	sdio-pwrseq {
++		wifi_enable_h: wifi-enable-h {
++		rockchip,pins =
++			<1 RK_PC2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	clk_32k {
++		clk_32k_out: clk-32k-out {
++			rockchip,pins = <1 RK_PD4 RK_FUNC_1 &pcfg_pull_none>;
++		};
++	};
++	
++	usb2 {
++		usb20_host_drv: usb20-host-drv {
++			rockchip,pins = <0 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	usb3 {
++		usb30_host_drv: usb30-host-drv {
++			rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++	
++	ir {
++		ir_int: ir-int {
++			rockchip,pins = <2 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	wireless-bluetooth {
++		uart0_gpios: uart0-gpios {
++			rockchip,pins = <1 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++	
++};
++
++&rga {
++	status = "okay";
++};
++
++
++&pwm3 {
++	status = "okay";
++	compatible = "rockchip,remotectl-pwm";
++	remote_pwm_id = <3>;
++	handle_cpu_id = <1>;
++	remote_support_psci = <1>;
++
++	ir_key1 {
++		rockchip,usercode = <0x4040>;
++		rockchip,key_table =
++			<0xf2	KEY_REPLY>,
++			<0xba	KEY_BACK>,
++			<0xf4	KEY_UP>,
++			<0xf1	KEY_DOWN>,
++			<0xef	KEY_LEFT>,
++			<0xee	KEY_RIGHT>,
++			<0xbd	KEY_HOME>,
++			<0xea	KEY_VOLUMEUP>,
++			<0xe3	KEY_VOLUMEDOWN>,
++			<0xe2	KEY_SEARCH>,
++			<0xb2	KEY_POWER>,
++			<0xbc	KEY_MUTE>,
++			<0xec	KEY_MENU>,
++			<0xbf	0x190>,
++			<0xe0	0x191>,
++			<0xe1	0x192>,
++			<0xe9	183>,
++			<0xe6	248>,
++			<0xe8	185>,
++			<0xe7	186>,
++			<0xf0	388>,
++			<0xbe	0x175>;
++	};
++
++	ir_key2 {
++		rockchip,usercode = <0xff00>;
++		rockchip,key_table =
++			<0x39	KEY_POWER>,
++			<0x73	KEY_MUTE>,
++			<0xa4	KEY_PLAYPAUSE>,
++			<0x75	KEY_VOLUMEDOWN>,
++			<0x77	KEY_VOLUMEUP>,
++			<0x7d	KEY_MENU>,
++			<0xf9	KEY_HOME>,
++			<0x5f	KEY_BACK>,
++			<0xb9	KEY_UP>,
++			<0xe9	KEY_DOWN>,
++			<0xb8	KEY_LEFT>,
++			<0xea	KEY_RIGHT>,
++			<0xaa	KEY_REPLY>,
++			<0x55	KEY_1>,
++			<0x5b	KEY_2>,
++			<0xf8	KEY_3>,
++			<0x57	KEY_4>,
++			<0xed	KEY_5>,
++			<0xee	KEY_6>,
++			<0x59	KEY_7>,
++			<0xf1	KEY_8>,
++			<0xf2	KEY_9>,
++			<0xe0	KEY_BACKSPACE>,
++			<0x79	KEY_0>,
++			<0xa4	KEY_SETUP>;
++	};
++
++	ir_key3 {
++		rockchip,usercode = <0x1dcc>;
++		rockchip,key_table =
++			<0xee	KEY_REPLY>,
++			<0xf0	KEY_BACK>,
++			<0xf8	KEY_UP>,
++			<0xbb	KEY_DOWN>,
++			<0xef	KEY_LEFT>,
++			<0xed	KEY_RIGHT>,
++			<0xfc	KEY_HOME>,
++			<0xf1	KEY_VOLUMEUP>,
++			<0xfd	KEY_VOLUMEDOWN>,
++			<0xb7	KEY_SEARCH>,
++			<0xff	KEY_POWER>,
++			<0xf3	KEY_MUTE>,
++			<0xbf	KEY_MENU>,
++			<0xf9	0x191>,
++			<0xf5	0x192>,
++			<0xb3	388>,
++			<0xbe	KEY_1>,
++			<0xba	KEY_2>,
++			<0xb2	KEY_3>,
++			<0xbd	KEY_4>,
++			<0xf9	KEY_5>,
++			<0xb1	KEY_6>,
++			<0xfc	KEY_7>,
++			<0xf8	KEY_8>,
++			<0xb0	KEY_9>,
++			<0xb6	KEY_0>,
++			<0xb5	KEY_BACKSPACE>;
++	};
++};
++
++&rkvdec {
++	status = "okay";
++};
++
++&rkvdec_mmu {
++	status = "okay";
++};
++
++&sdmmc_ext {
++		/delete-property/ clock-freq-min-max;
++                reg = <0x0 0xff5f0000 0x0 0x4000>;
++                clocks = <0x2 0x140 0x2 0x1f 0x2 0x4d 0x2 0x51>;
++                clock-names = "biu", "ciu", "ciu-drive", "ciu-sample";
++                fifo-depth = <0x100>;
++                interrupts = <0x0 0x4 0x4>;
++                status = "okay";
++                cd-gpios = <&gpio3 RK_PA1 GPIO_ACTIVE_LOW>;
++                bus-width = <0x4>;
++                cap-sd-highspeed;
++                disable-wp;
++                max-frequency = <0x8f0d180>;
++                num-slots = <0x1>;
++                pinctrl-names = "default";
++                pinctrl-0 = <&sdmmc0ext_clk &sdmmc0ext_cmd &sdmmc0ext_dectn &sdmmc0ext_bus4>;
++                supports-sd;
++                card-detect-delay = <0x320>;
++		vmmc-supply = <&vcc_sd>;
++                vqmmc-supply = <&vcc_sd>;
++
++		supports-sdio;
++                ignore-pm-notify;
++                keep-power-in-suspend;
++                cap-sdio-irq;
++                supports-UHS_SDR104;
++        };
++
++&spdif {
++	#sound-dai-cells = <0>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&spdifm0_tx>;
++	status = "okay";
++};
++
++&threshold {
++	temperature = <90000>; /* millicelsius */
++};
++
++&target {
++	temperature = <105000>; /* millicelsius */
++};
++
++&soc_crit {
++	temperature = <110000>; /* millicelsius */
++};
++
++&tsadc {
++	rockchip,hw-tshut-mode = <0>;
++	rockchip,hw-tshut-polarity = <0>;
++	rockchip,hw-tshut-temp = <120000>;
++	status = "okay";
++};
++
++&uart0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart0_xfer &uart0_cts>;
++	status = "disabled";   /* not ready yet*/
++};
++
++&uart2 {
++	status = "okay";
++};
++
++&u2phy {
++	status = "okay";
++};
++
++&u2phy_host {
++	phy-supply = <&vcc_host1_5v>;
++	status = "okay";
++};
++
++&u2phy_otg {
++	phy-supply = <&vcc_otg_5v>;
++	status = "okay";
++};
++
++&u3phy {
++	status = "okay";
++};
++
++&u3phy_utmi {
++	phy-supply = <&vcc_host_5v>;
++	status = "okay";
++};
++
++&u3phy_pipe {
++	phy-supply = <&vcc_host_5v>;
++	status = "okay";
++};
++
++&usb20_otg {
++	dr_mode = "host";
++	status = "okay";
++};
++
++&usb_host0_ehci {
++	status = "okay";
++};
++
++&usb_host0_ohci {
++	status = "okay";
++};
++
++&usbdrd3 {
++	status = "okay";
++};
++
++&usbdrd_dwc3 {
++	status = "okay";
++};
++
++&vepu {
++	status = "okay";
++};
++
++&vepu_mmu {
++	status = "okay";
++};
++
++&venc_srv {
++	status = "okay";
++};
++
++&vop {
++	status = "okay";
++};
++
++&vop_mmu {
++	status = "okay";
++};
++
++&vpu_service {
++	status = "okay";
++};


### PR DESCRIPTION
This adds a dts-file for the alphawise z28pro (v11).

It is far from perfect and atm only for testing. Hopefully someone can find the missing pieces.

Usage: Compile what you like for the rock64-board and install on the z28pro (yes, via usb-cable, maskrom-mode and so on ...) , then login via serial and just overwrite  rk3328-rock64.dtb in /boot/dtb-.../rockchip with rk3328-z28pro.dtb (or rename rk3328-z28pro.dtb to rk3328-rock64.dtb).
The reboot.

What should work:
Gigabit-Ethernet, All USB-Ports, the SD-Card.

What does not work:
WLAN and Bluetooth. I kept the non-working parts in the DTS, which at least very close to the entries on the original Android-installation (including the incorrect name for the WLAN-chip which should be rtl8822be or bs). 

Tested with default-kernel (4.4.124) and Stretch.
Expect glitches (f.i. reboot problems). Most of the time you have to do a cold reset for restart.

