### PR TITLE
Fix NanoPi NEO random eth0 mac

### DIFF
--- a/patch/kernel/sunxi-next/fix-nanopi-neo-random-eth-mac.patch
+++ b/patch/kernel/sunxi-next/fix-nanopi-neo-random-eth-mac.patch
@@ -1,0 +1,12 @@
+diff --git a/arch/arm/boot/dts/sun8i-h3-nanopi.dtsi b/arch/arm/boot/dts/sun8i-h3-nanopi.dtsi
+index c6decee..642a43b 100644
+--- a/arch/arm/boot/dts/sun8i-h3-nanopi.dtsi
++++ b/arch/arm/boot/dts/sun8i-h3-nanopi.dtsi
+@@ -51,6 +51,7 @@
+ / {
+ 	aliases {
+ 		serial0 = &uart0;
++		ethernet0 = &emac;
+ 	};
+ 
+ 	chosen {


### PR DESCRIPTION
Adds missing eth0 alias that didn’t come across for the Neo in the move from sun8i-dev to sunxi-next.