### PR TITLE
Flush armbianEnv.txt to disk to avoid corruption

### DIFF
--- a/packages/bsp/common/etc/init.d/armhwinfo
+++ b/packages/bsp/common/etc/init.d/armhwinfo
@@ -371,6 +371,10 @@ add_usb_storage_quirks() {
 	read USBQUIRKS <${TMPFILE}
 	sed -i '/^usbstoragequirks/d' /boot/armbianEnv.txt
 	echo "usbstoragequirks=${USBQUIRKS}" >>/boot/armbianEnv.txt
+	# Make sure /boot/armbianEnv.txt is completely written to disk given
+	# we flush to disk infrequently and corruption of this file can have
+	# nasty side-effects
+	sync
 	if [ -f /sys/module/usb_storage/parameters/quirks ]; then
 		echo ${USBQUIRKS} >/sys/module/usb_storage/parameters/quirks
 	fi


### PR DESCRIPTION
Corruption of this file affects the ability to boot properly
and this can easily happen with an unclean shutdown given the
long commit interval in /etc/fstab.

As seen in https://github.com/ConnectBox/connectbox-pi/issues/220