### PR TITLE
Enable Network on SoPine Clusterboard

### DIFF
--- a/patch/kernel/sunxi-next/00-readd-dwmac-sun8i-DT-bindings-arm64.patch
+++ b/patch/kernel/sunxi-next/00-readd-dwmac-sun8i-DT-bindings-arm64.patch
@@ -142,7 +142,7 @@ index d891a1a27f6c5..216e3a5dafaef 100644
 +&emac {
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&rgmii_pins>;
-+	phy-mode = "rgmii";
++	phy-mode = "rgmii-txid";
 +	phy-handle = <&ext_rgmii_phy>;
 +	status = "okay";
 +};


### PR DESCRIPTION
When using the recently released SoPine clusterboard, networking fails if this is not set to rgmii-txid. Various delays we tested with manually overriding with `allwinner,tx-delay-ps = <500>;` but that seemed to cause issues with the baseboard. 

Using rgmii-txid works both on the clusterboards and the baseboard. I think this works as a side affect of changes introduced to get the pine64 boards working with realtek drivers. 

