### PR TITLE
Dockerfile: Create cache directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade && 
 	systemd-container udev distcc g++-5-arm-linux-gnueabihf lib32stdc++6 \
 	libc6-i386 lib32ncurses5 lib32tinfo5 locales ncurses-base zlib1g:i386 aptly pixz
 RUN locale-gen en_US.UTF-8
+RUN mkdir -p /root/armbian/cache
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8' TERM=screen
 WORKDIR /root/armbian
 COPY . /root/armbian


### PR DESCRIPTION
@igorpecovnik @zador-blood-stained,

A Docker build in RHEL / CentOS typically takes more than the default 20
GB that is provisioned in the Docker container. This commit aims to
create beforehand /root/armbian/cache, so this directory can be
bind-mounted with some other host filesystem with enough space.

Please consider moving it to Master ASAP, as it is very important to Docker builds.

Sample use case:

$ docker run -v /mnt:/root/armbian/cache armbian_dev

Signed-off-by: Rodrigo Freire <rbs@brasilia.br>