### PR TITLE
Fix mmc phase timings

### DIFF
--- a/patch/u-boot/u-boot-sunxi/fix-mmc-phase-timings.patch
+++ b/patch/u-boot/u-boot-sunxi/fix-mmc-phase-timings.patch
@@ -1,0 +1,28 @@
+diff --git a/drivers/mmc/sunxi_mmc.c b/drivers/mmc/sunxi_mmc.c
+index 4edb4be..be55dc4 100644
+--- a/drivers/mmc/sunxi_mmc.c
++++ b/drivers/mmc/sunxi_mmc.c
+@@ -146,19 +146,19 @@ static int mmc_set_mod_clk(struct sunxi_mmc_priv *priv, unsigned int hz)
+ 		oclk_dly = 0;
+ 		sclk_dly = 5;
+ #ifdef CONFIG_MACH_SUN9I
+-	} else if (hz <= 50000000) {
++	} else if (hz <= 52000000) {
+ 		oclk_dly = 5;
+ 		sclk_dly = 4;
+ 	} else {
+-		/* hz > 50000000 */
++		/* hz > 52000000 */
+ 		oclk_dly = 2;
+ 		sclk_dly = 4;
+ #else
+-	} else if (hz <= 50000000) {
++	} else if (hz <= 52000000) {
+ 		oclk_dly = 3;
+ 		sclk_dly = 4;
+ 	} else {
+-		/* hz > 50000000 */
++		/* hz > 52000000 */
+ 		oclk_dly = 1;
+ 		sclk_dly = 4;
+ #endif


### PR DESCRIPTION
SUNXI-MMC driver needs some clock phase corrections according to this patch:
https://patchwork.ozlabs.org/patch/891576/

This affects writing/erasing eMMC on A20-SOM204 ( and others ?) from u-boot shell.