### PR TITLE
Docker config: Now safely builds in other distros

### DIFF
--- a/config-docker.conf
+++ b/config-docker.conf
@@ -16,7 +16,13 @@ chmod --quiet g+w,g+s $SRC/{output,userpatches}
 
 # build a new container based on provided Dockerfile
 display_alert "Building a Docker container"
-docker build -t armbian .
+if ! docker build -t armbian . ; then
+  STATUS=$?
+  # Adding a newline, so the alert won't be shown in the same line as the error
+  echo 
+  display_alert "Docker container build exited with code: " "$STATUS" "err"
+  exit 1
+fi
 
 DOCKER_FLAGS=()
 
@@ -45,10 +51,15 @@ done
 # https://github.com/moby/moby/issues/27886
 # --device-cgroup-rule requires new Docker version
 
-# allow loop devices (not required)
-DOCKER_FLAGS+=(--device-cgroup-rule='b 7:* rmw')
-# allow loop device partitions
-DOCKER_FLAGS+=(--device-cgroup-rule='b 259:* rmw')
+# Test for --device-cgroup-rule support. If supported, appends it
+if docker run --help | grep device-cgroup-rule > /dev/null 2>&1; then
+  # allow loop devices (not required)
+  DOCKER_FLAGS+=(--device-cgroup-rule='b 7:* rmw')
+  # allow loop device partitions
+  DOCKER_FLAGS+=(--device-cgroup-rule='b 259:* rmw')
+else
+  display_alert "Your Docker version does not support dynamically created devices" "" "info"
+fi
 
 # this is an ugly hack, but it is required to get /dev/loopXpY minor number
 # for mknod inside the container, and container itself still uses private /dev internally
@@ -63,15 +74,14 @@ DOCKER_FLAGS+=(-v=$SRC/output:/root/armbian/output -v=$SRC/userpatches:/root/arm
 # pass other command line arguments like KERNEL_ONLY=yes, KERNEL_CONFIGURE=yes, etc.
 # pass "docker-guest" as an additional config name that will be sourced in the container if exists
 display_alert "Running the container"
-docker run "${DOCKER_FLAGS[@]}" -it armbian docker-guest "$@"
-
-STATUS=$?
-
-if [[ $STATUS -ge 125 && $STATUS -le 127 ]]; then
-	display_alert "Docker error" "$STATUS" "wrn"
-	display_alert "please make sure you are using the latest version (17.06 CE or newer)" "" "wrn"
-	display_alert "please check the Armbian documentation for the Docker setup procedure" "" "wrn"
-	docker version
+if ! docker run "${DOCKER_FLAGS[@]}" -it armbian docker-guest "$@" ; then
+  STATUS=$?
+  if [ $STATUS != "0" ] ; then
+    # Adding a newline, so the alert won't be shown in the same line as the error
+    echo 
+    display_alert "Docker exited with code: " "$STATUS" "wrn"
+    exit 1
+  fi
 fi
 
 # don't need to proceed further on the host

--- a/config-docker.conf
+++ b/config-docker.conf
@@ -52,13 +52,15 @@ done
 # --device-cgroup-rule requires new Docker version
 
 # Test for --device-cgroup-rule support. If supported, appends it
+# Otherwise, let it go and let user know that only kernel and uBoot for you
 if docker run --help | grep device-cgroup-rule > /dev/null 2>&1; then
   # allow loop devices (not required)
   DOCKER_FLAGS+=(--device-cgroup-rule='b 7:* rmw')
   # allow loop device partitions
   DOCKER_FLAGS+=(--device-cgroup-rule='b 259:* rmw')
 else
-  display_alert "Your Docker version does not support dynamically created devices" "" "info"
+  display_alert "Your Docker version does not support device-cgroup-rule" "" "wrn"
+  display_alert "and will be able to create only Kernel and uBoot images." "" "wrn"
 fi
 
 # this is an ugly hack, but it is required to get /dev/loopXpY minor number
@@ -73,15 +75,26 @@ DOCKER_FLAGS+=(-v=$SRC/output:/root/armbian/output -v=$SRC/userpatches:/root/arm
 
 # pass other command line arguments like KERNEL_ONLY=yes, KERNEL_CONFIGURE=yes, etc.
 # pass "docker-guest" as an additional config name that will be sourced in the container if exists
-display_alert "Running the container"
-if ! docker run "${DOCKER_FLAGS[@]}" -it armbian docker-guest "$@" ; then
-  STATUS=$?
-  if [ $STATUS != "0" ] ; then
-    # Adding a newline, so the alert won't be shown in the same line as the error
-    echo 
-    display_alert "Docker exited with code: " "$STATUS" "wrn"
-    exit 1
+display_alert "Running the container" "" "info"
+docker run "${DOCKER_FLAGS[@]}" -it armbian docker-guest "$@"
+
+# Docker error treatment
+STATUS=$?
+if [ $STATUS != "0" ] ; then
+  # Adding a newline, so the alert won't be shown in the same line as the error
+  echo 
+  if [ $STATUS == "125" ] ; then
+    display_alert "Docker command failed, check syntax or version support. Error code:  " "$STATUS" "err"
+  elif [ $STATUS == "126" ] ; then
+    display_alert "Failure when running containerd command. Error code:  " "$STATUS" "err"
+  elif [ $STATUS == "127" ] ; then
+    display_alert "containerd command not found. Error code:  " "$STATUS" "err"
+  elif [ $STATUS == "137" ] ; then
+    display_alert "Container exit from docker stop. Error code:  " "$STATUS" "info"
+  else
+    display_alert "Container exited with code: " "$STATUS" "wrn"
   fi
+  exit 1
 fi
 
 # don't need to proceed further on the host


### PR DESCRIPTION
Hi @zador-blood-stained @igorpecovnik 

Played a bit with your Docker build recipe. This is really damn good, a shame it was not documented previously! Works nicely with RHEL/Fedora/CentOS and might work smoothly cross-distros as well.

Changeset:

- Added a fail trap in docker build
- Test for --device-cgroup-rule. Adds flag only if supported
- Add display exit errorlevel case != 0

Thanks a bunch-o! Have a great Sunday.