### PR TITLE
Move A20-SOM204 from dev branch to default/next

### DIFF
--- a/config/boards/olimex-som204-a20.csc
+++ b/config/boards/olimex-som204-a20.csc
@@ -2,16 +2,16 @@
 BOARD_NAME="SOM204-A20"
 BOARDFAMILY="sun7i"
 BOOTCONFIG="A20-Olimex-SOM204-EVB-eMMC_defconfig"
-MODULES=""
-MODULES_NEXT=""
-MODULES_DEV="g_serial r8723bs gpio-ir-tx"
+MODULES="8021q a20_tp bonding g_serial gpio_sunxi m25p80 spi_sun7i sunxi_lirc_new sunxi_can"
+MODULES_NEXT="bonding g_serial gpio-ir-tx r8723bs"
+MODULES_DEV="bonding g_serial gpio-ir-tx r8723bs "
 #
-KERNEL_TARGET="dev"
-CLI_TARGET="stretch"
-DESKTOP_TARGET=""
+KERNEL_TARGET="default,next,dev"
+CLI_TARGET="stretch,xenial:next"
+DESKTOP_TARGET="xenial:default,next"
 #
-CLI_BETA_TARGET=""
-DESKTOP_BETA_TARGET=""
+CLI_BETA_TARGET="stretch:next"
+DESKTOP_BETA_TARGET="xenial:default"
 #
 RECOMMENDED="Ubuntu_xenial_default_desktop:90,Debian_jessie_next:100"
 #

--- a/config/fex/olimex-som204-a20.fex
+++ b/config/fex/olimex-som204-a20.fex
@@ -1,0 +1,1027 @@
+[product]
+version = "100"
+machine = "Olimex A20-Olimex-SOM204"
+
+[platform]
+eraseflag = 0
+
+[target]
+boot_clock = 912
+dcdc2_vol = 1425
+dcdc3_vol = 1300
+ldo2_vol = 3000
+ldo3_vol = 2800
+ldo4_vol = 2800
+power_start = 1
+storage_type = 0
+
+[clock]
+pll4 = 300
+pll6 = 600
+pll7 = 297
+pll8 = 336
+
+[card_boot]
+logical_start = 40960
+sprite_gpio0 =
+
+[card0_boot_para]
+card_ctrl = 0
+card_high_speed = 1
+card_line = 4
+sdc_d1 = port:PF00<2><1><default><default>
+sdc_d0 = port:PF01<2><1><default><default>
+sdc_clk = port:PF02<2><1><default><default>
+sdc_cmd = port:PF03<2><1><default><default>
+sdc_d3 = port:PF04<2><1><default><default>
+sdc_d2 = port:PF05<2><1><default><default>
+
+[card2_boot_para]
+card_ctrl = 2
+card_high_speed = 1
+card_line = 4
+sdc_cmd = port:PC06<3><1><default><default>
+sdc_clk = port:PC07<3><1><default><default>
+sdc_d0 = port:PC08<3><1><default><default>
+sdc_d1 = port:PC09<3><1><default><default>
+sdc_d2 = port:PC10<3><1><default><default>
+sdc_d3 = port:PC11<3><1><default><default>
+
+[twi_para]
+twi_port = 0
+twi_scl = port:PB00<2><default><default><default>
+twi_sda = port:PB01<2><default><default><default>
+
+[uart_para]
+uart_debug_port = 0
+uart_debug_tx = port:PB22<2><1><default><default>
+uart_debug_rx = port:PB23<2><1><default><default>
+
+[uart_force_debug]
+uart_debug_port = 0
+uart_debug_tx = port:PB22<2><1><default><default>
+uart_debug_rx = port:PB23<2><1><default><default>
+
+[jtag_para]
+jtag_enable = 1
+jtag_ms = port:PB14<3><default><default><default>
+jtag_ck = port:PB15<3><default><default><default>
+jtag_do = port:PB16<3><default><default><default>
+jtag_di = port:PB17<3><default><default><default>
+
+[pm_para]
+standby_mode = 0
+
+[dram_para]
+dram_baseaddr = 0x40000000
+dram_clk = 384
+dram_type = 3
+dram_rank_num = 1
+dram_chip_density = 4096
+dram_io_width = 16
+dram_bus_width = 32
+dram_cas = 9
+dram_zq = 0x7f
+dram_odt_en = 0
+dram_size = 1024
+dram_tpr0 = 0x42d899b7
+dram_tpr1 = 0xa090
+dram_tpr2 = 0x22a00
+dram_tpr3 = 0x0
+dram_tpr4 = 0x1
+dram_tpr5 = 0x0
+dram_emr1 = 0x4
+dram_emr2 = 0x10
+dram_emr3 = 0x0
+
+[mali_para]
+mali_used = 1
+mali_clkdiv = 1
+
+[gmac_para]
+gmac_used = 1
+gmac_rxd3 = port:PA00<5><default><3><default>
+gmac_rxd2 = port:PA01<5><default><3><default>
+gmac_rxd1 = port:PA02<5><default><3><default>
+gmac_rxd0 = port:PA03<5><default><3><default>
+gmac_txd3 = port:PA04<5><default><3><default>
+gmac_txd2 = port:PA05<5><default><3><default>
+gmac_txd1 = port:PA06<5><default><3><default>
+gmac_txd0 = port:PA07<5><default><3><default>
+gmac_rxclk = port:PA08<5><default><3><default>
+gmac_rxerr = port:PA09<0><default><3><default>
+gmac_rxctl = port:PA10<5><default><3><default>
+gmac_mdc = port:PA11<5><default><3><default>
+gmac_mdio = port:PA12<5><default><3><default>
+gmac_txctl = port:PA13<5><default><3><default>
+gmac_txclk = port:PA14<0><default><3><default>
+gmac_txck = port:PA15<5><default><3><default>
+gmac_clkin = port:PA16<5><default><3><default>
+gmac_txerr = port:PA17<0><default><3><default>
+
+[twi0_para]
+twi0_used = 1
+twi0_scl = port:PB00<2><default><default><default>
+twi0_sda = port:PB01<2><default><default><default>
+
+[twi1_para]
+twi1_used = 1
+twi1_scl = port:PB18<2><default><default><default>
+twi1_sda = port:PB19<2><default><default><default>
+
+[twi2_para]
+twi2_used = 1
+twi2_scl = port:PB20<2><default><default><default>
+twi2_sda = port:PB21<2><default><default><default>
+
+[twi3_para]
+twi3_used = 0
+twi3_scl = port:PI00<3><default><default><default>
+twi3_sda = port:PI01<3><default><default><default>
+
+[twi4_para]
+twi4_used = 0
+twi4_scl = port:PI02<3><default><default><default>
+twi4_sda = port:PI03<3><default><default><default>
+
+[uart_para0]
+uart_used = 1
+uart_port = 0
+uart_type = 2
+uart_tx = port:PB22<2><1><default><default>
+uart_rx = port:PB23<2><1><default><default>
+
+[uart_para1]
+uart_used = 0
+uart_port = 1
+uart_type = 8
+uart_tx = port:PA10<4><1><default><default>
+uart_rx = port:PA11<4><1><default><default>
+uart_rts = port:PA12<4><1><default><default>
+uart_cts = port:PA13<4><1><default><default>
+uart_dtr = port:PA14<4><1><default><default>
+uart_dsr = port:PA15<4><1><default><default>
+uart_dcd = port:PA16<4><1><default><default>
+uart_ring = port:PA17<4><1><default><default>
+
+[uart_para2]
+uart_used = 0
+uart_port = 2
+uart_type = 4
+uart_tx = port:PI18<3><1><default><default>
+uart_rx = port:PI19<3><1><default><default>
+uart_rts = port:PI16<3><1><default><default>
+uart_cts = port:PI17<3><1><default><default>
+
+[uart_para3]
+uart_used = 0
+uart_port = 3
+uart_type = 4
+uart_tx = port:PH00<4><1><default><default>
+uart_rx = port:PH01<4><1><default><default>
+uart_rts = port:PH02<4><1><default><default>
+uart_cts = port:PH03<4><1><default><default>
+
+[uart_para4]
+uart_used = 1
+uart_port = 4
+uart_type = 2
+uart_tx = port:PG10<4><1><default><default>
+uart_rx = port:PG11<4><1><default><default>
+
+[uart_para5]
+uart_used = 0
+uart_port = 5
+uart_type = 2
+uart_tx = port:PH06<4><1><default><default>
+uart_rx = port:PH07<4><1><default><default>
+
+[uart_para6]
+uart_used = 0
+uart_port = 6
+uart_type = 2
+uart_tx = port:PI12<3><1><default><default>
+uart_rx = port:PI13<3><1><default><default>
+
+[uart_para7]
+uart_used = 1
+uart_port = 7
+uart_type = 2
+uart_tx = port:PI20<3><1><default><default>
+uart_rx = port:PI21<3><1><default><default>
+
+[spi0_para]
+spi_used = 1
+spi_cs_bitmap = 1
+spi_cs0 = port:PC23<3><default><default><default>
+spi_cs1 = port:PI14<2><default><default><default>
+spi_sclk = port:PC02<3><default><default><default>
+spi_mosi = port:PC00<3><default><default><default>
+spi_miso = port:PC01<3><default><default><default>
+
+[spi1_para]
+spi_used = 1
+spi_cs_bitmap = 1
+spi_cs0 = port:PI16<2><default><default><default>
+spi_sclk = port:PI17<2><default><default><default>
+spi_mosi = port:PI18<2><default><default><default>
+spi_miso = port:PI19<2><default><default><default>
+
+[spi2_para]
+spi_used = 1
+spi_cs_bitmap = 1
+spi_cs0 = port:PC19<3><default><default><default>
+spi_sclk = port:PC20<3><default><default><default>
+spi_mosi = port:PC21<3><default><default><default>
+spi_miso = port:PC22<3><default><default><default>
+
+[spi3_para]
+spi_used = 0
+spi_cs_bitmap = 1
+spi_cs0 = port:PA05<3><default><default><default>
+spi_cs1 = port:PA09<3><default><default><default>
+spi_sclk = port:PA06<3><default><default><default>
+spi_mosi = port:PA07<3><default><default><default>
+spi_miso = port:PA08<3><default><default><default>
+
+[spi_devices]
+spi_dev_num = 3
+
+[spi_board0]
+modalias = "w25q128"
+max_speed_hz = 10000000
+bus_num = 0
+chip_select = 0
+mode = 3
+full_duplex = 0
+manual_cs = 0
+
+[spi_board1]
+modalias = "spidev"
+max_speed_hz = 1000000
+bus_num = 1
+chip_select = 0
+mode = 3
+full_duplex = 0
+manual_cs = 0
+
+[spi_board2]
+modalias = "spidev"
+max_speed_hz = 1000000
+bus_num = 2
+chip_select = 0
+mode = 3
+full_duplex = 0
+manual_cs = 0
+
+[rtp_para]
+rtp_used = 1
+rtp_screen_size = 5
+rtp_regidity_level = 5
+rtp_press_threshold_enable = 0
+rtp_press_threshold = 0x1f40
+rtp_sensitive_level = 0xf
+rtp_exchange_x_y_flag = 0
+
+[ctp_para]
+ctp_used = 1
+ctp_name = "ft5x_ts"
+ctp_twi_id = 2
+ctp_twi_addr = 0x38
+ctp_screen_max_x = 1024
+ctp_screen_max_y = 600
+ctp_revert_x_flag = 0
+ctp_revert_y_flag = 0
+ctp_exchange_x_y_flag = 1
+ctp_firm = 1
+ctp_int_port = port:PH02<6><default><default><default>
+ctp_wakeup = port:PI01<1><default><default><1>
+
+[ctp_list_para]
+ctp_det_used = 1
+ft5x_ts = 1
+gt82x = 0
+gslX680 = 0
+gt9xx_ts = 0
+gt811 = 0
+
+[tkey_para]
+tkey_used = 0
+tkey_twi_id = 2
+tkey_twi_addr = 0x62
+tkey_int = port:PI13<6><default><default><default>
+
+[motor_para]
+motor_used = 0
+motor_shake = port:PB03<1><default><default><1>
+
+[leds_para]
+leds_used = 1
+leds_num = 3
+leds_pin_1 = port:PI00<1><default><default><0>
+leds_name_1 = "green:pi00:led1"
+leds_default_1 = 0
+leds_trigger_1 = "heartbeat"
+leds_pin_2 = port:PI10<1><default><default><0>
+leds_name_2 = "green:pi10:led2"
+leds_default_2 = 0
+leds_trigger_2 = "cpu0"
+leds_pin_3 = port:PI11<1><default><default><0>
+leds_name_3 = "yellow:pi11:led2"
+leds_default_3 = 0
+leds_trigger_3 = "mmc0"
+
+[nand_para]
+nand_used = 0
+nand_we = port:PC00<2><default><default><default>
+nand_ale = port:PC01<2><default><default><default>
+nand_cle = port:PC02<2><default><default><default>
+nand_ce0 = port:PC04<2><default><default><default>
+nand_nre = port:PC05<2><default><default><default>
+nand_rb0 = port:PC06<2><default><default><default>
+nand_d0 = port:PC08<2><default><default><default>
+nand_d1 = port:PC09<2><default><default><default>
+nand_d2 = port:PC10<2><default><default><default>
+nand_d3 = port:PC11<2><default><default><default>
+nand_d4 = port:PC12<2><default><default><default>
+nand_d5 = port:PC13<2><default><default><default>
+nand_d6 = port:PC14<2><default><default><default>
+nand_d7 = port:PC15<2><default><default><default>
+nand_wp = port:PC16<2><default><default><default>
+good_block_ratio = 0
+
+[disp_init]
+disp_init_enable = 1
+disp_mode = 0
+screen0_output_type = 3
+screen0_output_mode = 4
+screen1_output_type = 1
+screen1_output_mode = 4
+fb0_width = 0
+fb0_height = 0
+fb0_framebuffer_num = 2
+fb0_format = 10
+fb0_pixel_sequence = 0
+fb0_scaler_mode_enable = 0
+fb1_width = 1024
+fb1_height = 600
+fb1_framebuffer_num = 2
+fb1_format = 10
+fb1_pixel_sequence = 0
+fb1_scaler_mode_enable = 0
+lcd0_backlight = 197
+lcd1_backlight = 197
+lcd0_bright = 50
+lcd0_contrast = 50
+lcd0_saturation = 57
+lcd0_hue = 50
+lcd1_bright = 239
+lcd1_contrast = 50
+lcd1_saturation = 57
+lcd1_hue = 50
+
+[lcd0_para]
+lcd_used = 0
+lcd_x = 800
+lcd_y = 480
+lcd_dclk_freq = 33
+lcd_pwm_not_used = 0
+lcd_pwm_ch = 0
+lcd_pwm_freq = 10000
+lcd_pwm_pol = 1
+lcd_if = 0
+lcd_hbp = 46
+lcd_ht = 1055
+lcd_vbp = 23
+lcd_vt = 1050
+lcd_hv_if = 0
+lcd_hv_smode = 0
+lcd_hv_s888_if = 0
+lcd_hv_syuv_if = 0
+lcd_hv_vspw = 1
+lcd_hv_hspw = 30
+lcd_lvds_ch = 0
+lcd_lvds_mode = 0
+lcd_lvds_bitwidth = 0
+lcd_lvds_io_cross = 0
+lcd_cpu_if = 0
+lcd_frm = 1
+lcd_io_cfg0 = 0
+lcd_gamma_correction_en = 0
+lcd_gamma_tbl_0 = 0x0
+lcd_gamma_tbl_1 = 0x10101
+lcd_gamma_tbl_255 = 0xffffff
+lcd_power_used = 1
+lcd_power = port:PC24<1><0><default><1>
+lcd_pwm_used = 1
+lcd_pwm = port:PB02<2><0><default><default>
+lcdd0 = port:PD00<2><0><default><default>
+lcdd1 = port:PD01<2><0><default><default>
+lcdd2 = port:PD02<2><0><default><default>
+lcdd3 = port:PD03<2><0><default><default>
+lcdd4 = port:PD04<2><0><default><default>
+lcdd5 = port:PD05<2><0><default><default>
+lcdd6 = port:PD06<2><0><default><default>
+lcdd7 = port:PD07<2><0><default><default>
+lcdd8 = port:PD08<2><0><default><default>
+lcdd9 = port:PD09<2><0><default><default>
+lcdd10 = port:PD10<2><0><default><default>
+lcdd11 = port:PD11<2><0><default><default>
+lcdd12 = port:PD12<2><0><default><default>
+lcdd13 = port:PD13<2><0><default><default>
+lcdd14 = port:PD14<2><0><default><default>
+lcdd15 = port:PD15<2><0><default><default>
+lcdd16 = port:PD16<2><0><default><default>
+lcdd17 = port:PD17<2><0><default><default>
+lcdd18 = port:PD18<2><0><default><default>
+lcdd19 = port:PD19<2><0><default><default>
+lcdd20 = port:PD20<2><0><default><default>
+lcdd21 = port:PD21<2><0><default><default>
+lcdd22 = port:PD22<2><0><default><default>
+lcdd23 = port:PD23<2><0><default><default>
+lcdclk = port:PD24<2><0><default><default>
+lcdde = port:PD25<2><0><default><default>
+lcdhsync = port:PD26<2><0><default><default>
+lcdvsync = port:PD27<2><0><default><default>
+
+[lcd1_para]
+lcd_used = 0
+lcd_x = 0
+lcd_y = 0
+lcd_dclk_freq = 0
+lcd_pwm_not_used = 0
+lcd_pwm_ch = 1
+lcd_pwm_freq = 0
+lcd_pwm_pol = 0
+lcd_max_bright = 240
+lcd_min_bright = 64
+lcd_if = 0
+lcd_hbp = 0
+lcd_ht = 0
+lcd_vbp = 0
+lcd_vt = 0
+lcd_vspw = 0
+lcd_hspw = 0
+lcd_hv_if = 0
+lcd_hv_smode = 0
+lcd_hv_s888_if = 0
+lcd_hv_syuv_if = 0
+lcd_lvds_ch = 0
+lcd_lvds_mode = 0
+lcd_lvds_bitwidth = 0
+lcd_lvds_io_cross = 0
+lcd_cpu_if = 0
+lcd_frm = 0
+lcd_io_cfg0 = 0
+lcd_gamma_correction_en = 0
+lcd_gamma_tbl_0 = 0x0
+lcd_gamma_tbl_1 = 0x10101
+lcd_gamma_tbl_255 = 0xffffff
+lcd_bl_en_used = 1
+lcd_bl_en =
+lcd_power_used = 0
+lcd_power =
+lcd_pwm_used = 1
+lcd_pwm = port:PI03<2><0><default><default>
+lcd_gpio_0 =
+lcd_gpio_1 =
+lcd_gpio_2 =
+lcd_gpio_3 =
+lcdd0 = port:PH00<2><0><default><default>
+lcdd1 = port:PH01<2><0><default><default>
+lcdd2 = port:PH02<2><0><default><default>
+lcdd3 = port:PH03<2><0><default><default>
+lcdd4 = port:PH04<2><0><default><default>
+lcdd5 = port:PH05<2><0><default><default>
+lcdd6 = port:PH06<2><0><default><default>
+lcdd7 = port:PH07<2><0><default><default>
+lcdd8 = port:PH08<2><0><default><default>
+lcdd9 = port:PH09<2><0><default><default>
+lcdd10 = port:PH10<2><0><default><default>
+lcdd11 = port:PH11<2><0><default><default>
+lcdd12 = port:PH12<2><0><default><default>
+lcdd13 = port:PH13<2><0><default><default>
+lcdd14 = port:PH14<2><0><default><default>
+lcdd15 = port:PH15<2><0><default><default>
+lcdd16 = port:PH16<2><0><default><default>
+lcdd17 = port:PH17<2><0><default><default>
+lcdd18 = port:PH18<2><0><default><default>
+lcdd19 = port:PH19<2><0><default><default>
+lcdd20 = port:PH20<2><0><default><default>
+lcdd21 = port:PH21<2><0><default><default>
+
+[tv_out_dac_para]
+dac_used = 0
+dac0_src = 4
+dac1_src = 5
+dac2_src = 6
+dac3_src = 0
+
+[hdmi_para]
+hdmi_used = 1
+
+[camera_list_para]
+camera_list_para_used = 1
+ov7670 = 0
+gc0308 = 0
+gt2005 = 1
+hi704 = 0
+sp0838 = 0
+mt9m112 = 0
+mt9m113 = 0
+ov2655 = 0
+hi253 = 0
+gc0307 = 0
+mt9d112 = 0
+ov5640 = 0
+gc2015 = 0
+ov2643 = 0
+gc0329 = 0
+gc0309 = 0
+tvp5150 = 0
+s5k4ec = 0
+ov5650_mv9335 = 0
+siv121d = 0
+gc2035 = 0
+
+[csi0_para]
+csi_used = 1
+csi_dev_qty = 1
+csi_stby_mode = 0
+csi_mname = "gt2005"
+csi_twi_id = 1
+csi_twi_addr = 0x78
+csi_if = 0
+csi_vflip = 0
+csi_hflip = 0
+csi_iovdd = "axp20_pll"
+csi_avdd = ""
+csi_dvdd = ""
+csi_vol_iovdd = 2800
+csi_vol_dvdd =
+csi_vol_avdd =
+csi_flash_pol = 0
+csi_pck = port:PE00<3><default><default><default>
+csi_ck = port:PE01<3><default><default><default>
+csi_hsync = port:PE02<3><default><default><default>
+csi_vsync = port:PE03<3><default><default><default>
+csi_d0 = port:PE04<3><default><default><default>
+csi_d1 = port:PE05<3><default><default><default>
+csi_d2 = port:PE06<3><default><default><default>
+csi_d3 = port:PE07<3><default><default><default>
+csi_d4 = port:PE08<3><default><default><default>
+csi_d5 = port:PE09<3><default><default><default>
+csi_d6 = port:PE10<3><default><default><default>
+csi_d7 = port:PE11<3><default><default><default>
+csi_reset = port:PH13<1><default><default><0>
+csi_power_en = port:PC16<1><default><default><0>
+csi_stby = port:PH12<1><default><default><0>
+csi_flash =
+csi_af_en =
+
+[csi1_para]
+csi_used = 0
+csi_dev_qty = 1
+csi_stby_mode = 0
+csi_mname = "gc0308"
+csi_if = 0
+csi_iovdd = "axp20_pll"
+csi_avdd = ""
+csi_dvdd = ""
+csi_vol_iovdd = 2800
+csi_vol_dvdd =
+csi_vol_avdd =
+csi_vflip = 0
+csi_hflip = 0
+csi_flash_pol = 0
+csi_facing = 1
+csi_twi_id = 1
+csi_twi_addr = 0x42
+csi_pck = port:PG00<3><default><default><default>
+csi_ck = port:PG01<3><default><default><default>
+csi_hsync = port:PG02<3><default><default><default>
+csi_vsync = port:PG03<3><default><default><default>
+csi_d0 = port:PG04<3><default><default><default>
+csi_d1 = port:PG05<3><default><default><default>
+csi_d2 = port:PG06<3><default><default><default>
+csi_d3 = port:PG07<3><default><default><default>
+csi_d4 = port:PG08<3><default><default><default>
+csi_d5 = port:PG09<3><default><default><default>
+csi_d6 = port:PG10<3><default><default><default>
+csi_d7 = port:PG11<3><default><default><default>
+csi_reset = port:PH13<1><default><default><0>
+csi_power_en = port:PH16<1><default><default><0>
+csi_stby = port:PH19<1><default><default><0>
+
+[tvout_para]
+tvout_used = 0
+tvout_channel_num = 1
+
+[tvin_para]
+tvin_used = 0
+tvin_channel_num = 4
+
+[pwm0_para]
+pwm_used = 1
+pwm_period = 20
+pwm_duty_percent = 50
+
+[sata_para]
+sata_used = 1
+sata_power_en = port:PC03<1><default><default><0>
+
+[mmc0_para]
+sdc_used = 1
+sdc_detmode = 1
+sdc_buswidth = 4
+sdc_clk = port:PF02<2><1><2><default>
+sdc_cmd = port:PF03<2><1><2><default>
+sdc_d0 = port:PF01<2><1><2><default>
+sdc_d1 = port:PF00<2><1><2><default>
+sdc_d2 = port:PF05<2><1><2><default>
+sdc_d3 = port:PF04<2><1><2><default>
+sdc_det = port:PH01<0><1><default><default>
+sdc_use_wp = 0
+sdc_wp =
+sdc_isio = 0
+sdc_regulator = "none"
+
+[mmc1_para]
+sdc_used = 0
+sdc_detmode = 4
+sdc_buswidth = 4
+sdc_clk = port:PG00<2><1><2><default>
+sdc_cmd = port:PG01<2><1><2><default>
+sdc_d0 = port:PG02<2><1><2><default>
+sdc_d1 = port:PG03<2><1><2><default>
+sdc_d2 = port:PG04<2><1><2><default>
+sdc_d3 = port:PG05<2><1><2><default>
+sdc_det =
+sdc_use_wp = 0
+sdc_wp =
+sdc_isio = 0
+sdc_regulator = "none"
+
+[mmc2_para]
+sdc_used = 0
+sdc_detmode = 3
+sdc_buswidth = 4
+sdc_cmd = port:PC06<3><1><2><default>
+sdc_clk = port:PC07<3><1><2><default>
+sdc_d0 = port:PC08<3><1><2><default>
+sdc_d1 = port:PC09<3><1><2><default>
+sdc_d2 = port:PC10<3><1><2><default>
+sdc_d3 = port:PC11<3><1><2><default>
+sdc_det =
+sdc_use_wp = 0
+sdc_wp =
+sdc_isio = 0
+sdc_regulator = "none"
+
+[mmc3_para]
+sdc_used = 0
+sdc_detmode = 1
+sdc_buswidth = 4
+sdc_cmd = port:PI04<2><1><2><default>
+sdc_clk = port:PI05<2><1><2><default>
+sdc_d0 = port:PI06<2><1><2><default>
+sdc_d1 = port:PI07<2><1><2><default>
+sdc_d2 = port:PI08<2><1><2><default>
+sdc_d3 = port:PI09<2><1><2><default>
+sdc_det = port:PH00<0><1><default><default>
+sdc_use_wp = 0
+sdc_wp =
+sdc_isio = 1
+sdc_regulator = "none"
+
+[ms_para]
+ms_used = 0
+ms_bs = port:PH06<5><default><default><default>
+ms_clk = port:PH07<5><default><default><default>
+ms_d0 = port:PH08<5><default><default><default>
+ms_d1 = port:PH09<5><default><default><default>
+ms_d2 = port:PH10<5><default><default><default>
+ms_d3 = port:PH11<5><default><default><default>
+ms_det =
+
+[smc_para]
+smc_used = 0
+smc_rst = port:PH13<5><default><default><default>
+smc_vppen = port:PH14<5><default><default><default>
+smc_vppp = port:PH15<5><default><default><default>
+smc_det = port:PH16<5><default><default><default>
+smc_vccen = port:PH17<5><default><default><default>
+smc_sck = port:PH18<5><default><default><default>
+smc_sda = port:PH19<5><default><default><default>
+
+[ps2_0_para]
+ps2_used = 0
+ps2_scl = port:PI20<2><1><default><default>
+ps2_sda = port:PI21<2><1><default><default>
+
+[ps2_1_para]
+ps2_used = 0
+ps2_scl = port:PI14<3><1><default><default>
+ps2_sda = port:PI15<3><1><default><default>
+
+[can_para]
+can_used = 1
+can_tx = port:PH20<4><default><default><default>
+can_rx = port:PH21<4><default><default><default>
+
+[keypad_para]
+kp_used = 0
+kp_in_size = 8
+kp_out_size = 8
+kp_in0 = port:PH08<4><1><default><default>
+kp_in1 = port:PH09<4><1><default><default>
+kp_in2 = port:PH10<4><1><default><default>
+kp_in3 = port:PH11<4><1><default><default>
+kp_in4 = port:PH14<4><1><default><default>
+kp_in5 = port:PH15<4><1><default><default>
+kp_in6 = port:PH16<4><1><default><default>
+kp_in7 = port:PH17<4><1><default><default>
+kp_out0 = port:PH18<4><1><default><default>
+kp_out1 = port:PH19<4><1><default><default>
+kp_out2 = port:PH22<4><1><default><default>
+kp_out3 = port:PH23<4><1><default><default>
+kp_out4 = port:PH24<4><1><default><default>
+kp_out5 = port:PH25<4><1><default><default>
+kp_out6 = port:PH26<4><1><default><default>
+kp_out7 = port:PH27<4><1><default><default>
+
+[usbc0]
+usb_used = 1
+usb_port_type = 2
+usb_detect_type = 1
+usb_id_gpio = port:PH04<0><1><default><default>
+usb_det_vbus_gpio = port:PH05<1><0><default><0>
+usb_drv_vbus_gpio = port:PC17<1><0><default><0>
+usb_host_init_state = 1
+usb_restric_flag = 0
+usb_restric_voltage = 3550000
+usb_restric_capacity = 5
+
+[usbc1]
+usb_used = 1
+usb_port_type = 1
+usb_detect_type = 0
+usb_drv_vbus_gpio = port:PH06<1><0><default><0>
+usb_restrict_gpio =
+usb_host_init_state = 1
+usb_restric_flag = 0
+
+[usbc2]
+usb_used = 1
+usb_port_type = 1
+usb_detect_type = 0
+usb_drv_vbus_gpio = port:PH03<1><0><default><0>
+usb_restrict_gpio =
+usb_host_init_state = 1
+usb_restric_flag = 0
+
+[usb_feature]
+vendor_id = 6353
+mass_storage_id = 1
+adb_id = 2
+manufacturer_name = "USB Developer"
+product_name = "Android"
+serial_number = "20080411"
+
+[msc_feature]
+vendor_name = "USB 2.0"
+product_name = "USB Flash Driver"
+release = 100
+luns = 3
+
+[gsensor_para]
+gsensor_used = 0
+gsensor_twi_id = 1
+gsensor_int1 =
+gsensor_int2 =
+
+[gsensor_list_para]
+gsensor_det_used = 0
+bma250 = 1
+mma8452 = 1
+mma7660 = 1
+mma865x = 1
+afa750 = 1
+lis3de_acc = 1
+lis3dh_acc = 1
+kxtik = 1
+dmard10 = 0
+dmard06 = 1
+mxc622x = 1
+fxos8700 = 1
+lsm303d = 1
+
+[gps_para]
+gps_used = 0
+gps_spi_id = 2
+gps_spi_cs_num = 0
+gps_lradc = 1
+gps_clk = port:PI00<2><default><default><default>
+gps_sign = port:PI01<2><default><default><default>
+gps_mag = port:PI02<2><default><default><default>
+gps_vcc_en = port:PC22<1><default><default><0>
+gps_osc_en = port:PI14<1><default><default><0>
+gps_rx_en = port:PI15<1><default><default><0>
+
+[wifi_para]
+wifi_used = 0
+wifi_sdc_id = 3
+wifi_usbc_id = 2
+wifi_usbc_type = 1
+wifi_mod_sel = 7
+wifi_power = ""
+ap6xxx_wl_regon = port:PH09<1><default><default><0>
+ap6xxx_bt_regon = port:PH18<1><default><default><0>
+ap6xxx_bt_wake = port:PH24<1><default><default><0>
+ap6xxx_bt_host_wake = port:PH25<0><default><default><0>
+ap6xxx_lpo = port:PI12<4><1><default><1>
+
+[usb_wifi_para]
+usb_wifi_used = 1
+usb_wifi_usbc_num = 2
+
+[3g_para]
+3g_used = 0
+3g_usbc_num = 2
+3g_uart_num = 0
+3g_pwr =
+3g_wakeup =
+3g_int =
+
+[gy_para]
+gy_used = 0
+gy_twi_id = 1
+gy_twi_addr = 0
+gy_int1 = port:PH18<6><1><default><default>
+gy_int2 = port:PH19<6><1><default><default>
+
+[ls_para]
+ls_used = 0
+ls_twi_id = 1
+ls_twi_addr = 0
+ls_int = port:PH20<6><1><default><default>
+
+[compass_para]
+compass_used = 0
+compass_twi_id = 1
+compass_twi_addr = 0
+compass_int = port:PI13<6><1><default><default>
+
+[bt_para]
+bt_used = 0
+bt_uart_id = 2
+
+[i2s_para]
+i2s_used = 0
+i2s_channel = 2
+i2s_mclk = port:PB05<2><1><default><default>
+i2s_bclk = port:PB06<2><1><default><default>
+i2s_lrclk = port:PB07<2><1><default><default>
+i2s_dout0 = port:PB08<2><1><default><default>
+i2s_dout1 =
+i2s_dout2 =
+i2s_dout3 =
+i2s_din = port:PB12<2><1><default><default>
+
+[spdif_para]
+spdif_used = 0
+spdif_mclk =
+spdif_dout = port:PB13<4><1><default><default>
+spdif_din =
+
+[audio_para]
+audio_used = 1
+capture_used = 1
+playback_used = 1
+audio_lr_change = 0
+
+[switch_para]
+switch_used = 1
+
+[ir_para]
+ir_used = 1
+ir0_rx = port:PB04<2><default><default><default>
+
+[pmu_para]
+pmu_used = 1
+pmu_twi_addr = 52
+pmu_twi_id = 0
+pmu_irq_id = 32
+pmu_battery_rdc = 120
+pmu_battery_cap = 2100
+pmu_init_chgcur = 300
+pmu_earlysuspend_chgcur = 600
+pmu_suspend_chgcur = 1000
+pmu_resume_chgcur = 300
+pmu_shutdown_chgcur = 1000
+pmu_init_chgvol = 4200
+pmu_init_chgend_rate = 15
+pmu_init_chg_enabled = 1
+pmu_init_adc_freq = 100
+pmu_init_adc_freqc = 100
+pmu_init_chg_pretime = 50
+pmu_init_chg_csttime = 720
+pmu_bat_para1 = 0
+pmu_bat_para2 = 0
+pmu_bat_para3 = 0
+pmu_bat_para4 = 0
+pmu_bat_para5 = 5
+pmu_bat_para6 = 11
+pmu_bat_para7 = 13
+pmu_bat_para8 = 15
+pmu_bat_para9 = 19
+pmu_bat_para10 = 32
+pmu_bat_para11 = 50
+pmu_bat_para12 = 58
+pmu_bat_para13 = 71
+pmu_bat_para14 = 81
+pmu_bat_para15 = 89
+pmu_bat_para16 = 100
+pmu_usbvol_limit = 1
+pmu_usbcur_limit = 0
+pmu_usbvol = 4000
+pmu_usbcur = 0
+pmu_usbvol_pc = 4200
+pmu_usbcur_pc = 0
+pmu_pwroff_vol = 3300
+pmu_pwron_vol = 2900
+pmu_pekoff_time = 6000
+pmu_pekoff_en = 1
+pmu_peklong_time = 1500
+pmu_pekon_time = 1000
+pmu_pwrok_time = 64
+pmu_pwrnoe_time = 2000
+pmu_intotp_en = 1
+pmu_used2 = 0
+pmu_adpdet = port:PH02<0><default><default><default>
+pmu_init_chgcur2 = 400
+pmu_earlysuspend_chgcur2 = 600
+pmu_suspend_chgcur2 = 1200
+pmu_resume_chgcur2 = 400
+pmu_shutdown_chgcur2 = 1200
+pmu_suspendpwroff_vol = 3500
+pmu_batdeten = 1
+pmu_backupen = 1
+
+[recovery_key]
+key_min = 4
+key_max = 40
+
+[dvfs_table]
+max_freq = 1008000000
+min_freq = 720000000
+normal_freq = 720000000
+LV_count = 7
+LV1_freq = 1008000000
+LV1_volt = 1450
+LV2_freq = 912000000
+LV2_volt = 1425
+LV3_freq = 864000000
+LV3_volt = 1350
+LV4_freq = 720000000
+LV4_volt = 1250
+LV5_freq = 528000000
+LV5_volt = 1150
+LV6_freq = 312000000
+LV6_volt = 1100
+LV7_freq = 144000000
+LV7_volt = 1050
+
+[gpio_para]
+gpio_used = 1
+gpio_num = 14
+gpio_pin_1 = port:PH00<0><default><default><default>
+gpio_pin_2 = port:PI02<0><default><default><default>
+gpio_pin_3 = port:PG00<0><default><default><default>
+gpio_pin_4 = port:PG01<0><default><default><default>
+gpio_pin_5 = port:PG02<0><default><default><default>
+gpio_pin_6 = port:PG03<0><default><default><default>
+gpio_pin_7 = port:PG04<0><default><default><default>
+gpio_pin_8 = port:PG05<0><default><default><default>
+gpio_pin_9 = port:PI10<0><default><default><default>
+gpio_pin_10 = port:PI11<0><default><default><default>
+gpio_pin_11 = port:PI12<0><default><default><default>
+gpio_pin_12 = port:PI13<0><default><default><default>
+gpio_pin_13 = port:PB05<0><default><default><default>
+gpio_pin_14 = port:PB10<0><default><default><default>
+
+[gpio_init]
+gpio_pin_1 = port:PH00<0><default><default><default>
+gpio_pin_2 = port:PI02<0><default><default><default>
+gpio_pin_3 = port:PG00<0><default><default><default>
+gpio_pin_4 = port:PG01<0><default><default><default>
+gpio_pin_5 = port:PG02<0><default><default><default>
+gpio_pin_6 = port:PG03<0><default><default><default>
+gpio_pin_7 = port:PG04<0><default><default><default>
+gpio_pin_8 = port:PG05<0><default><default><default>
+gpio_pin_9 = port:PI10<0><default><default><default>
+gpio_pin_10 = port:PI11<0><default><default><default>
+gpio_pin_11 = port:PI12<0><default><default><default>
+gpio_pin_12 = port:PI13<0><default><default><default>
+gpio_pin_13 = port:PB05<0><default><default><default>
+gpio_pin_14 = port:PB10<0><default><default><default>

--- a/config/kernel/linux-sun7i-default.config
+++ b/config/kernel/linux-sun7i-default.config
@@ -1206,7 +1206,78 @@ CONFIG_CMA_ALIGNMENT=8
 CONFIG_CMA_AREAS=7
 CONFIG_CONNECTOR=y
 CONFIG_PROC_EVENTS=y
-# CONFIG_MTD is not set
+CONFIG_MTD=m
+# CONFIG_MTD_TESTS is not set
+# CONFIG_MTD_REDBOOT_PARTS is not set
+# CONFIG_MTD_AFS_PARTS is not set
+# CONFIG_MTD_AR7_PARTS is not set
+
+#
+# User Modules And Translation Layers
+#
+# CONFIG_MTD_CHAR is not set
+# CONFIG_MTD_BLKDEVS is not set
+# CONFIG_MTD_BLOCK is not set
+# CONFIG_MTD_BLOCK_RO is not set
+# CONFIG_FTL is not set
+# CONFIG_NFTL is not set
+# CONFIG_INFTL is not set
+# CONFIG_RFD_FTL is not set
+# CONFIG_SSFDC is not set
+# CONFIG_SM_FTL is not set
+# CONFIG_MTD_OOPS is not set
+# CONFIG_MTD_SWAP is not set
+
+#
+# RAM/ROM/Flash chip drivers
+#
+# CONFIG_MTD_CFI is not set
+# CONFIG_MTD_JEDECPROBE is not set
+CONFIG_MTD_MAP_BANK_WIDTH_1=y
+CONFIG_MTD_MAP_BANK_WIDTH_2=y
+CONFIG_MTD_MAP_BANK_WIDTH_4=y
+# CONFIG_MTD_MAP_BANK_WIDTH_8 is not set
+# CONFIG_MTD_MAP_BANK_WIDTH_16 is not set
+# CONFIG_MTD_MAP_BANK_WIDTH_32 is not set
+CONFIG_MTD_CFI_I1=y
+CONFIG_MTD_CFI_I2=y
+# CONFIG_MTD_CFI_I4 is not set
+# CONFIG_MTD_CFI_I8 is not set
+# CONFIG_MTD_RAM is not set
+# CONFIG_MTD_ROM is not set
+# CONFIG_MTD_ABSENT is not set
+
+#
+# Mapping drivers for chip access
+#
+# CONFIG_MTD_COMPLEX_MAPPINGS is not set
+# CONFIG_MTD_PLATRAM is not set
+
+#
+# Self-contained MTD device drivers
+#
+# CONFIG_MTD_DATAFLASH is not set
+CONFIG_MTD_M25P80=m
+CONFIG_M25PXX_USE_FAST_READ=y
+# CONFIG_MTD_SST25L is not set
+# CONFIG_MTD_SLRAM is not set
+# CONFIG_MTD_PHRAM is not set
+# CONFIG_MTD_MTDRAM is not set
+# CONFIG_MTD_BLOCK2MTD is not set
+
+#
+# Disk-On-Chip Device Drivers
+#
+# CONFIG_MTD_DOCG3 is not set
+# CONFIG_MTD_NAND_IDS is not set
+# CONFIG_MTD_NAND is not set
+# CONFIG_MTD_ONENAND is not set
+
+#
+# LPDDR flash memory drivers
+#
+# CONFIG_MTD_LPDDR is not set
+# CONFIG_MTD_UBI is not set
 CONFIG_PARPORT=m
 # CONFIG_PARPORT_PC is not set
 # CONFIG_PARPORT_GSC is not set
@@ -3750,6 +3821,7 @@ CONFIG_HFSPLUS_FS=y
 # CONFIG_BEFS_FS is not set
 # CONFIG_BFS_FS is not set
 # CONFIG_EFS_FS is not set
+# CONFIG_JFFS2_FS is not set
 # CONFIG_LOGFS is not set
 # CONFIG_CRAMFS is not set
 CONFIG_SQUASHFS=y

--- a/config/kernel/linux-sun7i-default.config
+++ b/config/kernel/linux-sun7i-default.config
@@ -1024,7 +1024,32 @@ CONFIG_HAVE_BPF_JIT=y
 #
 CONFIG_NET_PKTGEN=m
 # CONFIG_HAMRADIO is not set
-# CONFIG_CAN is not set
+CONFIG_CAN=m
+# CONFIG_CAN_RAW is not set
+# CONFIG_CAN_BCM is not set
+# CONFIG_CAN_GW is not set
+
+#
+# CAN Device Drivers
+#
+# CONFIG_CAN_VCAN is not set
+# CONFIG_CAN_SLCAN is not set
+CONFIG_CAN_DEV=m
+CONFIG_CAN_CALC_BITTIMING=y
+# CONFIG_CAN_MCP251X is not set
+CONFIG_CAN_SUNXI=m
+# CONFIG_CAN_SJA1000 is not set
+# CONFIG_CAN_C_CAN is not set
+# CONFIG_CAN_CC770 is not set
+
+#
+# CAN USB interfaces
+#
+# CONFIG_CAN_EMS_USB is not set
+# CONFIG_CAN_ESD_USB2 is not set
+# CONFIG_CAN_PEAK_USB is not set
+# CONFIG_CAN_SOFTING is not set
+# CONFIG_CAN_DEBUG_DEVICES is not set
 CONFIG_IRDA=m
 
 #

--- a/config/sources/sun7i.conf
+++ b/config/sources/sun7i.conf
@@ -32,27 +32,31 @@ CPUMIN=480000
 
 family_tweaks_s()
 {
-	if [[ $BRANCH == dev && $BOARD == olimex-som204-a20 ]]; then
+	if [[ $BOARD == olimex-som204-a20 ]]; then
 
 		# Enable serial login on USB-OTG
 		mkdir -p $SDCARD/etc/systemd/system/serial-getty@ttyGS0.service.d
 		chroot $SDCARD /bin/bash -c "systemctl --no-reload enable serial-getty@ttyGS0.service > /dev/null 2>&1"
 		echo "ttyGS0" >> $SDCARD/etc/securetty
 
-		# Enable bluetooth
-		chroot $SDCARD /bin/bash -c "systemctl --no-reload enable olinuxino-bluetooth.service >/dev/null 2>&1"
+		if [[ $BRANCH != default ]]; then
+			# Enable bluetooth
+			chroot $SDCARD /bin/bash -c "systemctl --no-reload enable olinuxino-bluetooth.service >/dev/null 2>&1"
+		fi
 	fi
 }
 
 family_tweaks_bsp_s()
 {
-	if [[ $BRANCH == dev && $BOARD == olimex-som204-a20 ]]; then
+	if [[ $BRANCH != default && $BOARD == olimex-som204-a20 ]]; then
 
 		# Copy bluetooth service
 		install -m 755 $SRC/packages/bsp/olinuxino/rtk_hciattach $destination/usr/bin
 		cp $SRC/packages/bsp/olinuxino/olinuxino-bluetooth.service $destination/lib/systemd/system
 
-		# Copy fbdev configuration
-		cp $SRC/packages/bsp/olinuxino/02-olinuxino-hdmi-fbdev.conf $destination/etc/X11/xorg.conf.d/
+		if [[ $BRANCH == dev ]]; then
+			# Copy fbdev configuration
+			cp $SRC/packages/bsp/olinuxino/02-olinuxino-hdmi-fbdev.conf $destination/etc/X11/xorg.conf.d/
+		fi
 	fi
 }

--- a/patch/kernel/sun7i-default/add-w25q128-spi-nor.patch
+++ b/patch/kernel/sun7i-default/add-w25q128-spi-nor.patch
@@ -1,0 +1,12 @@
+diff --git a/drivers/mtd/devices/m25p80.c b/drivers/mtd/devices/m25p80.c
+index 797860e..225fdab 100644
+--- a/drivers/mtd/devices/m25p80.c
++++ b/drivers/mtd/devices/m25p80.c
+@@ -728,6 +728,7 @@ static const struct spi_device_id m25p_ids[] = {
+ 	{ "w25q32", INFO(0xef4016, 0, 64 * 1024,  64, SECT_4K) },
+ 	{ "w25x64", INFO(0xef3017, 0, 64 * 1024, 128, SECT_4K) },
+ 	{ "w25q64", INFO(0xef4017, 0, 64 * 1024, 128, SECT_4K) },
++	{ "w25q128", INFO(0xef4018, 0, 64 * 1024, 256, SECT_4K) },
+ 
+ 	/* Catalyst / On Semiconductor -- non-JEDEC */
+ 	{ "cat25c11", CAT25_INFO(  16, 8, 16, 1) },

--- a/patch/kernel/sun7i-default/sunxi-can.patch
+++ b/patch/kernel/sun7i-default/sunxi-can.patch
@@ -1,0 +1,914 @@
+diff --git a/drivers/net/can/Kconfig b/drivers/net/can/Kconfig
+index bb709fd..671be9d 100644
+--- a/drivers/net/can/Kconfig
++++ b/drivers/net/can/Kconfig
+@@ -110,6 +110,13 @@ config PCH_CAN
+ 	  is an IOH for x86 embedded processor (Intel Atom E6xx series).
+ 	  This driver can access CAN bus.
+ 
++config CAN_SUNXI
++	tristate "Sun7i, Sun4i CAN bus controller"
++	depends on ARCH_SUN4I || ARCH_SUN7I
++	default n
++	---help---
++	  This is the Sun7i, Sun4i Allwinner CAN BUS driver.
++
+ source "drivers/net/can/mscan/Kconfig"
+ 
+ source "drivers/net/can/sja1000/Kconfig"
+diff --git a/drivers/net/can/Makefile b/drivers/net/can/Makefile
+index 938be37..02123c4 100644
+--- a/drivers/net/can/Makefile
++++ b/drivers/net/can/Makefile
+@@ -22,5 +22,6 @@ obj-$(CONFIG_CAN_BFIN)		+= bfin_can.o
+ obj-$(CONFIG_CAN_JANZ_ICAN3)	+= janz-ican3.o
+ obj-$(CONFIG_CAN_FLEXCAN)	+= flexcan.o
+ obj-$(CONFIG_PCH_CAN)		+= pch_can.o
++obj-$(CONFIG_CAN_SUNXI)		+= sunxi_can.o
+ 
+ ccflags-$(CONFIG_CAN_DEBUG_DEVICES) := -DDEBUG
+diff --git a/drivers/net/can/sunxi_can.c b/drivers/net/can/sunxi_can.c
+new file mode 100644
+index 0000000..57631fa
+--- /dev/null
++++ b/drivers/net/can/sunxi_can.c
+@@ -0,0 +1,695 @@
++/*
++* sunxi_can.c - CAN bus controller driver for sun7i and sun4i
++*
++* Copyright (c) 2013 Peter Chen
++*  - driver for sun7i
++* Copyright (c) 2017 Oleg Strelkov <o.strelkov@gmail.com>
++*  - modifications for sun4i
++*
++* Copyright (c) 2013 Inmotion Co,. LTD
++* All right reserved.
++*
++*/
++
++#include <linux/module.h>
++#include <linux/init.h>
++#include <linux/kernel.h>
++#include <linux/sched.h>
++#include <linux/types.h>
++#include <linux/fcntl.h>
++#include <linux/interrupt.h>
++#include <linux/ptrace.h>
++#include <linux/string.h>
++#include <linux/errno.h>
++#include <linux/netdevice.h>
++#include <linux/if_arp.h>
++#include <linux/if_ether.h>
++#include <linux/skbuff.h>
++#include <linux/delay.h>
++#include <linux/clk.h>
++
++#include <linux/can/dev.h>
++#include <linux/can/error.h>
++
++#include <plat/sys_config.h>
++#include <mach/irqs.h>
++
++#include "sunxi_can.h"
++
++#define DRV_NAME "sunxi_can"
++
++MODULE_AUTHOR("Peter Chen <xingkongcp@gmail.com>");
++MODULE_LICENSE("Dual BSD/GPL");
++MODULE_DESCRIPTION(DRV_NAME "CAN netdevice driver");
++
++static struct net_device *sunxican_dev;
++static struct can_bittiming_const sunxi_can_bittiming_const = {
++        .name = DRV_NAME,
++        .tseg1_min = 1,
++        .tseg1_max = 16,
++        .tseg2_min = 1,
++        .tseg2_max = 8,
++        .sjw_max = 4,
++        .brp_min = 1,
++        .brp_max = 64,
++        .brp_inc = 1,
++};
++
++static void sunxi_can_write_cmdreg(struct sunxi_can_priv *priv, u8 val)
++{
++        unsigned long flags;
++
++        /*
++         * The command register needs some locking and time to settle
++         * the write_reg() operation - especially on SMP systems.
++         */
++        spin_lock_irqsave(&priv->cmdreg_lock, flags);
++        writel(val, CAN_CMD_ADDR);
++        spin_unlock_irqrestore(&priv->cmdreg_lock, flags);
++}
++
++static int sunxi_can_is_absent(struct sunxi_can_priv *priv)
++{
++        return ((readl(CAN_MSEL_ADDR) & 0xFF) == 0xFF);
++}
++
++static int sunxi_can_probe(struct net_device *dev)
++{
++        struct sunxi_can_priv *priv = netdev_priv(dev);
++
++        if (sunxi_can_is_absent(priv)) {
++                printk(KERN_INFO "%s: probing @0x%lX failed\n",
++                 DRV_NAME, dev->base_addr);
++                return 0;
++        }
++        return -1;
++}
++
++static void set_reset_mode(struct net_device *dev)
++{
++        struct sunxi_can_priv *priv = netdev_priv(dev);
++        uint32_t status = readl(CAN_MSEL_ADDR);
++        int i;
++
++        for (i = 0; i < 100; i++) {
++                /* check reset bit */
++                if (status & RESET_MODE) {
++                        priv->can.state = CAN_STATE_STOPPED;
++                        return;
++                }
++
++                writel(readl(CAN_MSEL_ADDR) | RESET_MODE, CAN_MSEL_ADDR);        /* select reset mode */
++                //writel(RESET_MODE, CAN_MSEL_ADDR);        /* select reset mode */
++                udelay(10);
++                status = readl(CAN_MSEL_ADDR);
++        }
++
++        netdev_err(dev, "setting SUNXI_CAN into reset mode failed!\n");
++}
++
++static void set_normal_mode(struct net_device *dev)
++{
++        struct sunxi_can_priv *priv = netdev_priv(dev);
++        unsigned char status = readl(CAN_MSEL_ADDR);
++        int i;
++
++        for (i = 0; i < 100; i++) {
++                /* check reset bit */
++                if ((status & RESET_MODE) == 0) {
++                        priv->can.state = CAN_STATE_ERROR_ACTIVE;												
++						
++						/* enable interrupts */
++                        if (priv->can.ctrlmode & CAN_CTRLMODE_BERR_REPORTING) {
++								writel(0xFFFF, CAN_INTEN_ADDR);
++						} else {
++								writel(0xFFFF & ~BERR_IRQ_EN, CAN_INTEN_ADDR);
++						}
++											
++						if (priv->can.ctrlmode & CAN_CTRLMODE_LOOPBACK) {
++							/* Put device into loopback mode */
++							writel(readl(CAN_MSEL_ADDR) | LOOPBACK_MODE, CAN_MSEL_ADDR);
++						} else if (priv->can.ctrlmode & CAN_CTRLMODE_LISTENONLY) {
++							/* Put device into listen-only mode */
++							writel(readl(CAN_MSEL_ADDR) | LISTEN_ONLY_MODE, CAN_MSEL_ADDR);
++						}
++                        return;
++                }
++
++                /* set chip to normal mode */
++                writel(readl(CAN_MSEL_ADDR) & (~RESET_MODE), CAN_MSEL_ADDR);
++                udelay(10);
++                status = readl(CAN_MSEL_ADDR);
++        }
++
++        netdev_err(dev, "setting SUNXI_CAN into normal mode failed!\n");
++}
++
++
++static void sunxi_can_start(struct net_device *dev)
++{
++        struct sunxi_can_priv *priv = netdev_priv(dev);
++
++        /* leave reset mode */
++        if (priv->can.state != CAN_STATE_STOPPED)
++                set_reset_mode(dev);
++
++        /* Clear error counters and error code capture */
++        writel(0x0, CAN_ERRC_ADDR);
++
++        /* leave reset mode */
++        set_normal_mode(dev);
++}
++
++static int sunxi_can_set_mode(struct net_device *dev, enum can_mode mode)
++{
++        struct sunxi_can_priv *priv = netdev_priv(dev);
++
++        if (!priv->open_time)
++                return -EINVAL;
++
++        switch (mode) {
++        case CAN_MODE_START:
++                sunxi_can_start(dev);
++                if (netif_queue_stopped(dev))
++                        netif_wake_queue(dev);
++                break;
++
++        default:
++                return -EOPNOTSUPP;
++        }
++
++        return 0;
++}
++
++static int sunxi_can_set_bittiming(struct net_device *dev)
++{
++        struct sunxi_can_priv *priv = netdev_priv(dev);
++        struct can_bittiming *bt = &priv->can.bittiming;
++        u32 cfg;
++
++        cfg = ((bt->brp - 1) & 0x3FF)
++                | (((bt->sjw - 1) & 0x3) << 14)
++                | (((bt->prop_seg + bt->phase_seg1 - 1) & 0xf) << 16)
++                | (((bt->phase_seg2 - 1) & 0x7) << 20);
++        if (priv->can.ctrlmode & CAN_CTRLMODE_3_SAMPLES)
++                cfg |= 0x800000;
++
++        netdev_info(dev, "setting BITTIMING=0x%08x\n", cfg);
++
++        set_reset_mode(dev);                //CAN_BTIME_ADDR only writable in reset mode
++        writel(cfg, CAN_BTIME_ADDR);
++        set_normal_mode(dev);
++
++        return 0;
++}
++
++static int sunxi_can_get_berr_counter(const struct net_device *dev,
++                                 struct can_berr_counter *bec)
++{
++        bec->txerr = readl(CAN_ERRC_ADDR) & 0x000F;
++        bec->rxerr = (readl(CAN_ERRC_ADDR) & 0x0F00) >> 16;
++
++        return 0;
++}
++
++/*
++* initialize sunxi_can:
++* - reset chip
++* - set output mode
++* - set baudrate
++* - enable interrupts
++* - start operating mode
++*/
++static void chipset_init(struct net_device *dev)
++{
++        u32 temp_irqen;
++		
++        /* config pins
++         * PH20-TX, PH21-RX :4 */
++
++		if (gpio_request_ex("can_para", "can_tx") == 0 || gpio_request_ex("can_para", "can_rx") == 0 ) {
++			pr_info("can request gpio fail!\n");
++        }
++
++        //enable clock
++        writel(readl(0xF1C20000 + 0x6C) | (1 << 4), 0xF1C20000 + 0x6C);
++
++        //set can controller in reset mode
++        set_reset_mode(dev);
++
++        //enable interrupt
++        temp_irqen = BERR_IRQ_EN | ERR_PASSIVE_IRQ_EN
++                        | OR_IRQ_EN | RX_IRQ_EN;
++        writel(readl(CAN_INTEN_ADDR) | temp_irqen, CAN_INTEN_ADDR);
++
++        //return to transfer mode
++        set_normal_mode(dev);
++}
++
++/*
++* transmit a CAN message
++* message layout in the sk_buff should be like this:
++* xx xx xx xx         ff         ll 00 11 22 33 44 55 66 77
++* [ can_id ] [flags] [len] [can data (up to 8 bytes]
++*/
++static netdev_tx_t sunxi_can_start_xmit(struct sk_buff *skb,
++                                         struct net_device *dev)
++{
++        struct sunxi_can_priv *priv = netdev_priv(dev);
++        struct can_frame *cf = (struct can_frame *)skb->data;
++        uint8_t dlc;
++        canid_t id;
++        uint32_t temp = 0;
++        uint8_t i;
++        
++        //wait buff ready
++        while (!(readl(CAN_STA_ADDR) & TBUF_RDY));
++
++        set_reset_mode(dev);
++
++        writel(0xffffffff, CAN_ACPM_ADDR);
++
++        //enter transfer mode
++        set_normal_mode(dev);
++
++        if (can_dropped_invalid_skb(dev, skb))
++                return NETDEV_TX_OK;
++
++        netif_stop_queue(dev);
++
++        dlc = cf->can_dlc;
++        id = cf->can_id;
++
++        temp = ((id >> 30) << 6) | dlc;
++        writel(temp, CAN_BUF0_ADDR);
++        if (id & CAN_EFF_FLAG) {/* extern frame */
++                writel(0xFF & (id >> 21), CAN_BUF1_ADDR);        //id28~21
++                writel(0xFF & (id >> 13), CAN_BUF2_ADDR);         //id20~13
++                writel(0xFF & (id >> 5), CAN_BUF3_ADDR);         //id12~5
++                writel((id & 0x1F) << 3, CAN_BUF4_ADDR);         //id4~0
++                
++                for (i = 0; i < dlc; i++) {
++                        writel(cf->data[i], CAN_BUF5_ADDR + i * 4);
++                }
++        } else {                /* standard frame*/        
++                writel(0xFF & (id >> 3), CAN_BUF1_ADDR);         //id28~21
++                writel((id & 0x7) << 5, CAN_BUF2_ADDR);                //id20~13
++                
++                for (i = 0; i < dlc; i++) {
++                        writel(cf->data[i], CAN_BUF3_ADDR + i * 4);
++                }
++        }
++
++        can_put_echo_skb(skb, dev, 0);
++
++        while (!(readl(CAN_STA_ADDR) & TBUF_RDY));
++        sunxi_can_write_cmdreg(priv, TRANS_REQ);
++
++        return NETDEV_TX_OK;
++}
++
++static void sunxi_can_rx(struct net_device *dev)
++{
++        struct sunxi_can_priv *priv = netdev_priv(dev);
++        struct net_device_stats *stats = &dev->stats;
++        struct can_frame *cf;
++        struct sk_buff *skb;
++        uint8_t fi;
++        canid_t id;
++        int i;
++
++        /* create zero'ed CAN frame buffer */
++        skb = alloc_can_skb(dev, &cf);
++        if (skb == NULL)
++                return;
++
++        fi = readl(CAN_BUF0_ADDR);
++        cf->can_dlc = get_can_dlc(fi & 0x0F);
++        if (fi >> 7) {
++                /* extended frame format (EFF) */
++                id = (readl(CAN_BUF1_ADDR) << 21)        //id28~21
++                 | (readl(CAN_BUF2_ADDR) << 13)        //id20~13
++                 | (readl(CAN_BUF3_ADDR) << 5)        //id12~5
++                 | ((readl(CAN_BUF4_ADDR) >> 3) & 0x1f);        //id4~0
++                id |= CAN_EFF_FLAG;
++
++                if ((fi >> 6) & 0x1) {        /* remote transmission request */
++                id |= CAN_RTR_FLAG;
++                } else {
++                        for (i = 0; i < cf->can_dlc; i++)
++                                cf->data[i] = readl(CAN_BUF5_ADDR + i * 4);
++                }
++        } else {
++                /* standard frame format (SFF) */
++                id = (readl(CAN_BUF1_ADDR) << 3)        //id28~21
++                 | ((readl(CAN_BUF2_ADDR) >> 5) & 0x7);        //id20~18
++
++                if ((fi >> 6) & 0x1) {        /* remote transmission request */
++                id |= CAN_RTR_FLAG;
++                } else {
++                        for (i = 0; i < cf->can_dlc; i++)
++                                cf->data[i] = readl(CAN_BUF3_ADDR + i * 4);
++                }
++        }
++
++        cf->can_id = id;
++
++        /* release receive buffer */
++        sunxi_can_write_cmdreg(priv, RELEASE_RBUF);
++
++        netif_rx(skb);
++
++        stats->rx_packets++;
++        stats->rx_bytes += cf->can_dlc;
++}
++
++static int sunxi_can_err(struct net_device *dev, uint8_t isrc, uint8_t status)
++{
++        struct sunxi_can_priv *priv = netdev_priv(dev);
++        struct net_device_stats *stats = &dev->stats;
++        struct can_frame *cf;
++        struct sk_buff *skb;
++        enum can_state state = priv->can.state;
++        uint32_t ecc, alc;
++
++        skb = alloc_can_err_skb(dev, &cf);
++        if (skb == NULL)
++                return -ENOMEM;
++
++        if (isrc & DATA_ORUNI) {
++                /* data overrun interrupt */
++                netdev_dbg(dev, "data overrun interrupt\n");
++                cf->can_id |= CAN_ERR_CRTL;
++                cf->data[1] = CAN_ERR_CRTL_RX_OVERFLOW;
++                stats->rx_over_errors++;
++                stats->rx_errors++;
++                sunxi_can_write_cmdreg(priv, CLEAR_DOVERRUN);        /* clear bit */
++        }
++
++        if (isrc & ERR_WRN) {
++                /* error warning interrupt */
++                netdev_dbg(dev, "error warning interrupt\n");
++
++                if (status & BUS_OFF) {
++                        state = CAN_STATE_BUS_OFF;
++                        cf->can_id |= CAN_ERR_BUSOFF;
++                        can_bus_off(dev);
++                } else if (status & ERR_STA) {
++                        state = CAN_STATE_ERROR_WARNING;
++                } else
++                        state = CAN_STATE_ERROR_ACTIVE;
++        }
++        if (isrc & BUS_ERR) {
++                /* bus error interrupt */
++                priv->can.can_stats.bus_error++;
++                stats->rx_errors++;
++
++                ecc = readl(CAN_STA_ADDR);
++
++                cf->can_id |= CAN_ERR_PROT | CAN_ERR_BUSERROR;
++
++                if(ecc & BIT_ERR)
++                        cf->data[2] |= CAN_ERR_PROT_BIT;
++                else if (ecc & FORM_ERR)
++                        cf->data[2] |= CAN_ERR_PROT_FORM;
++                else if (ecc & STUFF_ERR)
++                        cf->data[2] |= CAN_ERR_PROT_STUFF;
++                else {
++                        cf->data[2] |= CAN_ERR_PROT_UNSPEC;
++                        cf->data[3] = (ecc & ERR_SEG_CODE) >> 16;
++                }
++                /* Error occurred during transmission? */
++                if ((ecc & ERR_DIR) == 0)
++                        cf->data[2] |= CAN_ERR_PROT_TX;
++        }
++        if (isrc & ERR_PASSIVE) {
++                /* error passive interrupt */
++                netdev_dbg(dev, "error passive interrupt\n");
++                if (status & ERR_STA)
++                        state = CAN_STATE_ERROR_PASSIVE;
++                else
++                        state = CAN_STATE_ERROR_ACTIVE;
++        }
++        if (isrc & ARB_LOST) {
++                /* arbitration lost interrupt */
++                netdev_dbg(dev, "arbitration lost interrupt\n");
++                alc = readl(CAN_STA_ADDR);
++                priv->can.can_stats.arbitration_lost++;
++                stats->tx_errors++;
++                cf->can_id |= CAN_ERR_LOSTARB;
++                cf->data[0] = (alc & 0x1f) >> 8;
++        }
++
++        if (state != priv->can.state && (state == CAN_STATE_ERROR_WARNING ||
++                                         state == CAN_STATE_ERROR_PASSIVE)) {
++                uint8_t rxerr = (readl(CAN_ERRC_ADDR) >> 16) & 0xFF;
++                uint8_t txerr = readl(CAN_ERRC_ADDR) & 0xFF;
++                cf->can_id |= CAN_ERR_CRTL;
++                if (state == CAN_STATE_ERROR_WARNING) {
++                        priv->can.can_stats.error_warning++;
++                        cf->data[1] = (txerr > rxerr) ?
++                                CAN_ERR_CRTL_TX_WARNING :
++                                CAN_ERR_CRTL_RX_WARNING;
++                } else {
++                        priv->can.can_stats.error_passive++;
++                        cf->data[1] = (txerr > rxerr) ?
++                                CAN_ERR_CRTL_TX_PASSIVE :
++                                CAN_ERR_CRTL_RX_PASSIVE;
++                }
++                cf->data[6] = txerr;
++                cf->data[7] = rxerr;
++        }
++
++        priv->can.state = state;
++
++        netif_rx(skb);
++
++        stats->rx_packets++;
++        stats->rx_bytes += cf->can_dlc;
++
++        return 0;
++}
++
++irqreturn_t sunxi_can_interrupt(int irq, void *dev_id)
++{
++        struct net_device *dev = (struct net_device *)dev_id;
++        struct sunxi_can_priv *priv = netdev_priv(dev);
++        struct net_device_stats *stats = &dev->stats;
++        uint8_t isrc, status;
++        int n = 0;
++
++        while ((isrc = readl(CAN_INT_ADDR)) && (n < SUNXI_CAN_MAX_IRQ)) {
++                n++;
++                status = readl(CAN_STA_ADDR);
++                /* check for absent controller due to hw unplug */
++                if (sunxi_can_is_absent(priv))
++                        return IRQ_NONE;
++
++                if (isrc & WAKEUP)
++                        netdev_warn(dev, "wakeup interrupt\n");
++
++                if (isrc & TBUF_VLD) {
++			pr_debug("sunxicanirq: Tx irq, reg=0x%X\n", isrc);
++                        /* transmission complete interrupt */
++                        stats->tx_bytes += readl(CAN_RBUF_RBACK_START_ADDR) & 0xf;
++                        stats->tx_packets++;
++                        can_get_echo_skb(dev, 0);
++                        netif_wake_queue(dev);
++                }
++                if (isrc & RBUF_VLD) {
++			pr_debug("sunxicanirq: Rx irq, reg=0x%X\n", isrc);
++                        /* receive interrupt */
++                        while (status & RBUF_RDY) {        //RX buffer is not empty
++                                sunxi_can_rx(dev);
++                                status = readl(CAN_STA_ADDR);
++                                /* check for absent controller */
++                                if (sunxi_can_is_absent(priv))
++                                        return IRQ_NONE;
++                        }
++                }
++                if (isrc & (DATA_ORUNI | ERR_WRN | BUS_ERR | ERR_PASSIVE | ARB_LOST)) {
++			pr_debug("sunxicanirq: error, reg=0x%X\n", isrc);
++                        /* error interrupt */
++                        if (sunxi_can_err(dev, isrc, status))
++                                break;
++                }
++
++                //clear the interrupt
++                writel(isrc, CAN_INT_ADDR);
++                readl(CAN_INT_ADDR);
++        }
++
++        if (n >= SUNXI_CAN_MAX_IRQ)
++                netdev_dbg(dev, "%d messages handled in ISR", n);
++
++        return (n) ? IRQ_HANDLED : IRQ_NONE;
++}
++EXPORT_SYMBOL_GPL(sunxi_can_interrupt);
++
++static int sunxi_can_open(struct net_device *dev)
++{
++        struct sunxi_can_priv *priv = netdev_priv(dev);
++        int err;
++
++        /* set chip into reset mode */
++        set_reset_mode(dev);
++
++        writel(0xffffffff, CAN_ACPM_ADDR);
++
++        /* common open */
++        err = open_candev(dev);
++        if (err)
++                return err;
++
++        /* register interrupt handler, if not done by the device driver */
++        if (!(priv->flags & SUNXI_CAN_CUSTOM_IRQ_HANDLER)) {
++                err = request_irq(dev->irq, sunxi_can_interrupt, priv->irq_flags,
++                                 dev->name, (void *)dev);
++                if (err) {
++                        close_candev(dev);
++                        pr_info("request_irq err:%d\n", err);
++                        return -EAGAIN;
++                }
++        }
++
++        /* init and start chi */
++        sunxi_can_start(dev);
++        priv->open_time = jiffies;
++
++        netif_start_queue(dev);
++
++        return 0;
++}
++
++static int sunxi_can_close(struct net_device *dev)
++{
++        struct sunxi_can_priv *priv = netdev_priv(dev);
++
++        netif_stop_queue(dev);
++        set_reset_mode(dev);
++
++        if (!(priv->flags & SUNXI_CAN_CUSTOM_IRQ_HANDLER))
++                free_irq(dev->irq, (void *)dev);
++
++        close_candev(dev);
++
++        priv->open_time = 0;
++
++        return 0;
++}
++
++struct net_device *alloc_sunxicandev(int sizeof_priv)
++{
++        struct net_device *dev;
++        struct sunxi_can_priv *priv;
++
++        dev = alloc_candev(sizeof(struct sunxi_can_priv) + sizeof_priv,
++                SUNXI_CAN_ECHO_SKB_MAX);
++        if (!dev)
++                return NULL;
++
++        priv = netdev_priv(dev);
++
++        priv->dev = dev;
++        priv->can.bittiming_const = &sunxi_can_bittiming_const;
++        priv->can.do_set_bittiming = sunxi_can_set_bittiming;
++        priv->can.do_set_mode = sunxi_can_set_mode;
++        priv->can.do_get_berr_counter = sunxi_can_get_berr_counter;
++        priv->can.ctrlmode_supported = CAN_CTRLMODE_LOOPBACK |
++                CAN_CTRLMODE_LISTENONLY |
++                CAN_CTRLMODE_3_SAMPLES |
++                CAN_CTRLMODE_BERR_REPORTING;
++
++        spin_lock_init(&priv->cmdreg_lock);
++
++        if (sizeof_priv)
++                priv->priv = (void *)priv + sizeof(struct sunxi_can_priv);
++
++        return dev;
++}
++EXPORT_SYMBOL_GPL(alloc_sunxicandev);
++
++void free_sunxicandev(struct net_device *dev)
++{
++        free_candev(dev);
++}
++EXPORT_SYMBOL_GPL(free_sunxicandev);
++
++static const struct net_device_ops sunxican_netdev_ops = {
++       .ndo_open = sunxi_can_open,
++       .ndo_stop = sunxi_can_close,
++       .ndo_start_xmit = sunxi_can_start_xmit,
++};
++
++int register_sunxicandev(struct net_device *dev)
++{
++        if (!sunxi_can_probe(dev))
++                return -ENODEV;
++
++        dev->flags |= IFF_ECHO;        /* support local echo */
++        dev->netdev_ops = &sunxican_netdev_ops;
++
++        set_reset_mode(dev);
++        
++        return register_candev(dev);
++}
++EXPORT_SYMBOL_GPL(register_sunxicandev);
++
++void unregister_sunxicandev(struct net_device *dev)
++{
++        set_reset_mode(dev);
++        unregister_candev(dev);
++}
++EXPORT_SYMBOL_GPL(unregister_sunxicandev);
++
++static __init int sunxi_can_init(void)
++{
++        struct sunxi_can_priv *priv;
++        int err = 0;
++		int ret = 0;
++		int used = 0;
++		
++        sunxican_dev = alloc_sunxicandev(0);
++        if(!sunxican_dev) {
++                pr_info("alloc sunxicandev fail\n");
++        }
++	
++		ret = script_parser_fetch("can_para", "can_used", &used, sizeof (used));
++		if ( ret || used == 0) {
++			pr_info("[sunxi-can] Cannot setup CANBus driver, maybe not configured in script.bin?");
++			goto exit_free;
++		}
++		
++        priv = netdev_priv(sunxican_dev);
++        sunxican_dev->irq = SW_INT_IRQNO_CAN;
++        priv->irq_flags = 0;
++        priv->can.clock.freq = clk_get_rate(clk_get(NULL, "can"));
++        chipset_init(sunxican_dev);
++        err = register_sunxicandev(sunxican_dev);
++        if(err) {
++                dev_err(&sunxican_dev->dev, "registering %s failed (err=%d)\n", DRV_NAME, err);
++                goto exit_free;
++        }
++
++        dev_info(&sunxican_dev->dev, "%s device registered (reg_base=0x%08x, irq=%d)\n",
++                 DRV_NAME, CAN_BASE0, sunxican_dev->irq);
++
++        pr_info("%s CAN netdevice driver\n", DRV_NAME);
++
++        return 0;
++
++exit_free:
++        free_sunxicandev(sunxican_dev);
++
++        return err;
++}
++module_init(sunxi_can_init);
++
++static __exit void sunxi_can_exit(void)
++{
++        unregister_sunxicandev(sunxican_dev);
++        free_sunxicandev(sunxican_dev);
++
++        pr_info("%s: driver removed\n", DRV_NAME);
++}
++module_exit(sunxi_can_exit);
+diff --git a/drivers/net/can/sunxi_can.h b/drivers/net/can/sunxi_can.h
+new file mode 100644
+index 0000000..9e84307
+--- /dev/null
++++ b/drivers/net/can/sunxi_can.h
+@@ -0,0 +1,178 @@
++/*
++* sun7i_can.h - CAN bus controller driver for sun7i
++*
++* Copyright (c) 2013 Peter Chen
++*
++* Copyright (c) 2013 Inmotion Co., Ltd.
++* All right reserved.
++*
++*/
++
++#ifndef SUNXI_CAN_H
++#define SUNXI_CAN_H
++
++#include <linux/irqreturn.h>
++#include <linux/can/dev.h>
++
++#define SUNXI_CAN_ECHO_SKB_MAX        1 /* the SUN7I, SUN4I CAN has one TX buffer object */
++
++/* Registers' address */
++#define CAN_BASE0                        0xF1C2BC00
++#define CAN_MSEL_ADDR                        (CAN_BASE0 + 0x0000)         //Can Mode Select Register
++#define CAN_CMD_ADDR                        (CAN_BASE0 + 0x0004)         //Can Command Register
++#define CAN_STA_ADDR         (CAN_BASE0 + 0x0008)         //Can Status Register
++#define CAN_INT_ADDR         (CAN_BASE0 + 0x000c)         //Can Interrupt Flag Register
++#define CAN_INTEN_ADDR         (CAN_BASE0 + 0x0010)         //Can Interrupt Enable Register
++#define CAN_BTIME_ADDR         (CAN_BASE0 + 0x0014)         //Can Bus Timing 0 Register
++#define CAN_TEWL_ADDR         (CAN_BASE0 + 0x0018)         //Can Tx Error Warning Limit Register
++#define CAN_ERRC_ADDR         (CAN_BASE0 + 0x001c)         //Can Error Counter Register
++#define CAN_RMCNT_ADDR         (CAN_BASE0 + 0x0020)         //Can Receive Message Counter Register
++#define CAN_RBUFSA_ADDR         (CAN_BASE0 + 0x0024)         //Can Receive Buffer Start Address Register
++#define CAN_BUF0_ADDR         (CAN_BASE0 + 0x0040)         //Can Tx/Rx Buffer 0 Register
++#define CAN_BUF1_ADDR         (CAN_BASE0 + 0x0044)         //Can Tx/Rx Buffer 1 Register
++#define CAN_BUF2_ADDR         (CAN_BASE0 + 0x0048)         //Can Tx/Rx Buffer 2 Register
++#define CAN_BUF3_ADDR         (CAN_BASE0 + 0x004c)         //Can Tx/Rx Buffer 3 Register
++#define CAN_BUF4_ADDR         (CAN_BASE0 + 0x0050)         //Can Tx/Rx Buffer 4 Register
++#define CAN_BUF5_ADDR         (CAN_BASE0 + 0x0054)         //Can Tx/Rx Buffer 5 Register
++#define CAN_BUF6_ADDR         (CAN_BASE0 + 0x0058)         //Can Tx/Rx Buffer 6 Register
++#define CAN_BUF7_ADDR         (CAN_BASE0 + 0x005c)         //Can Tx/Rx Buffer 7 Register
++#define CAN_BUF8_ADDR         (CAN_BASE0 + 0x0060)         //Can Tx/Rx Buffer 8 Register
++#define CAN_BUF9_ADDR         (CAN_BASE0 + 0x0064)         //Can Tx/Rx Buffer 9 Register
++#define CAN_BUF10_ADDR         (CAN_BASE0 + 0x0068)         //Can Tx/Rx Buffer 10 Register
++#define CAN_BUF11_ADDR         (CAN_BASE0 + 0x006c)         //Can Tx/Rx Buffer 11 Register
++#define CAN_BUF12_ADDR         (CAN_BASE0 + 0x0070)         //Can Tx/Rx Buffer 12 Register
++#define CAN_ACPC_ADDR         (CAN_BASE0 + 0x0040)         //Can Acceptance Code 0 Register
++#define CAN_ACPM_ADDR         (CAN_BASE0 + 0x0044)         //Can Acceptance Mask 0 Register
++#define CAN_RBUF_RBACK_START_ADDR        (CAN_BASE0 + 0x0180)        //CAN transmit buffer for read back register
++#define CAN_RBUF_RBACK_END_ADDR                (CAN_BASE0 + 0x01b0)        //CAN transmit buffer for read back register
++
++/* Controller Register Description */
++
++/* mode select register (r/w)
++* offset:0x0000 default:0x0000_0001 */
++#define SLEEP_MODE         (1<<4)        //This bit can only be written in Reset Mode
++#define WAKE_UP                        (0<<4)        //This bit can only be written in Reset Mode
++#define SINGLE_FILTER         (1<<3)
++#define DUAL_FILTERS         (0<<3)
++#define LOOPBACK_MODE         (1<<2)
++#define LISTEN_ONLY_MODE         (1<<1)
++#define RESET_MODE         (1<<0)
++/* command register (w)
++* offset:0x0004 default:0x0000_0000 */
++#define BUS_OFF_REQ                (1<<5)
++#define SELF_RCV_REQ         (1<<4)
++#define CLEAR_DOVERRUN         (1<<3)
++#define RELEASE_RBUF         (1<<2)
++#define ABORT_REQ         (1<<1)
++#define TRANS_REQ         (1<<0)
++/* status register (r)
++* offset:0x0008 default:0x0000_003c */
++#define BIT_ERR                        (0<<22)
++#define FORM_ERR         (1<<22)
++#define STUFF_ERR         (2<<22)
++#define OTHER_ERR         (3<<22)
++#define ERR_DIR                 (1<<21)
++#define ERR_SEG_CODE                (0x1f<<16)
++#define START                         (0x03<<16)
++#define ID28_21                        (0x02<<16)
++#define ID20_18                        (0x06<<16)
++#define SRTR                         (0x04<<16)
++#define IDE                         (0x05<<16)
++#define ID17_13                        (0x07<<16)
++#define ID12_5                        (0x0f<<16)
++#define ID4_0                        (0x0e<<16)
++#define RTR                         (0x0c<<16)
++#define RB1                        (0x0d<<16)
++#define RB0                        (0x09<<16)
++#define DLEN                        (0x0b<<16)
++#define DATA_FIELD                (0x0a<<16)
++#define CRC_SEQUENCE                (0x08<<16)
++#define CRC_DELIMITER                (0x18<<16)
++#define ACK                        (0x19<<16)
++#define ACK_DELIMITER                (0x1b<<16)
++#define END                         (0x1a<<16)
++#define INTERMISSION                (0x12<<16)
++#define ACTIVE_ERROR                (0x11<<16)
++#define PASSIVE_ERROR                (0x16<<16)
++#define TOLERATE_DOMINANT_BITS        (0x13<<16)
++#define ERROR_DELIMITER                (0x17<<16)
++#define OVERLOAD                (0x1c<<16)
++#define BUS_OFF         (1<<7)
++#define ERR_STA         (1<<6)
++#define TRANS_BUSY         (1<<5)
++#define RCV_BUSY         (1<<4)
++#define TRANS_OVER         (1<<3)
++#define TBUF_RDY         (1<<2)
++#define DATA_ORUN         (1<<1)
++#define RBUF_RDY         (1<<0)
++/* interrupt register (r)
++* offset:0x000c default:0x0000_0000 */
++#define BUS_ERR         (1<<7)        //write 1 to clear
++#define ARB_LOST         (1<<6)        //write 1 to clear
++#define ERR_PASSIVE         (1<<5)        //write 1 to clear
++#define WAKEUP         (1<<4)        //write 1 to clear
++#define DATA_ORUNI         (1<<3)        //write 1 to clear
++#define ERR_WRN         (1<<2)        //write 1 to clear
++#define TBUF_VLD         (1<<1)        //write 1 to clear
++#define RBUF_VLD         (1<<0)        //write 1 to clear
++/* interrupt enable register (r/w)
++* offset:0x0010 default:0x0000_0000 */
++#define BERR_IRQ_EN                (1<<7)
++#define BERR_IRQ_DIS                (0<<7)
++#define ARB_LOST_IRQ_EN                (1<<6)
++#define ARB_LOST_IRQ_DIS        (0<<6)
++#define ERR_PASSIVE_IRQ_EN        (1<<5)
++#define ERR_PASSIVE_IRQ_DIS        (0<<5)
++#define WAKEUP_IRQ_EN                (1<<4)
++#define WAKEUP_IRQ_DIS                (0<<4)
++#define OR_IRQ_EN                (1<<3)
++#define OR_IRQ_DIS                (0<<3)
++#define ERR_WRN_IRQ_EN                (1<<2)
++#define ERR_WRN_IRQ_DIS                (0<<2)
++#define TX_IRQ_EN                (1<<1)
++#define TX_IRQ_DIS                (0<<1)
++#define RX_IRQ_EN                (1<<0)
++#define RX_IRQ_DIS                (0<<0)
++/* timing register (r/w)
++* offset:0x0014 default:0x0000_0000 */
++//...
++
++/* output control */
++#define NOR_OMODE         (2)
++#define CLK_OMODE         (3)
++/* arbitration lost flag*/
++
++/* error code */
++#define ERR_INRCV         (1<<5)
++#define ERR_INTRANS         (0<<5)
++
++/* filter mode */
++#define FILTER_CLOSE         0
++#define SINGLE_FLTER_MODE         1
++#define DUAL_FILTER_MODE         2
++
++/*
++* Flags for sun7icanpriv.flags
++*/
++#define SUNXI_CAN_CUSTOM_IRQ_HANDLER 0x1
++
++#define SUNXI_CAN_MAX_IRQ 20        /* max. number of interrupts handled in ISR */
++
++/*
++* sun7i_can private data structure
++*/
++struct sunxi_can_priv {
++        struct can_priv can;        /* must be the first member */
++        int open_time;
++        struct sk_buff *echo_skb;
++
++        void *priv;                /* for board-specific data */
++        struct net_device *dev;
++
++        unsigned long irq_flags; /* for request_irq() */
++        spinlock_t cmdreg_lock; /* lock for concurrent cmd register writes */
++
++        u16 flags;                /* custom mode flags */
++};
++
++#endif

--- a/patch/kernel/sunxi-next/add-a20-olimex-som204-evb-emmc.patch
+++ b/patch/kernel/sunxi-next/add-a20-olimex-som204-evb-emmc.patch
@@ -1,0 +1,371 @@
+diff --git a/arch/arm/boot/dts/Makefile b/arch/arm/boot/dts/Makefile
+index 88fa9f7..ce7b25c 100644
+--- a/arch/arm/boot/dts/Makefile
++++ b/arch/arm/boot/dts/Makefile
+@@ -886,6 +886,8 @@ dtb-$(CONFIG_MACH_SUN7I) += \
+ 	sun7i-a20-lamobo-r1.dtb \
+ 	sun7i-a20-m3.dtb \
+ 	sun7i-a20-mk808c.dtb \
++	sun7i-a20-olimex-som204-evb.dtb \
++	sun7i-a20-olimex-som204-evb-emmc.dtb \
+ 	sun7i-a20-olimex-som-evb.dtb \
+ 	sun7i-a20-olinuxino-lime.dtb \
+ 	sun7i-a20-olinuxino-lime2.dtb \
+diff --git a/arch/arm/boot/dts/sun7i-a20-olimex-som204-evb-emmc.dts b/arch/arm/boot/dts/sun7i-a20-olimex-som204-evb-emmc.dts
+new file mode 100644
+index 0000000..c56620a
+--- /dev/null
++++ b/arch/arm/boot/dts/sun7i-a20-olimex-som204-evb-emmc.dts
+@@ -0,0 +1,36 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Device Tree Source for A20-SOM204-EVB-eMMC Board
++ *
++ * Copyright (C) 2018 Olimex Ltd.
++ *   Author: Stefan Mavrodiev <stefan@olimex.com>
++ */
++
++/dts-v1/;
++#include "sun7i-a20-olimex-som204-evb.dts"
++
++/ {
++	model = "Olimex A20-SOM204-EVB-eMMC";
++	compatible = "olimex,a20-olimex-som204-evb-emmc", "allwinner,sun7i-a20";
++
++	mmc2_pwrseq: mmc2_pwrseq {
++		compatible = "mmc-pwrseq-emmc";
++		reset-gpios = <&pio 2 16 GPIO_ACTIVE_LOW>;
++	};
++};
++
++&mmc2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mmc2_pins_a>;
++	vmmc-supply = <&reg_vcc3v3>;
++	mmc-pwrseq = <&mmc2_pwrseq>;
++	bus-width = <4>;
++	non-removable;
++	status = "okay";
++
++	emmc: emmc@0 {
++		reg = <0>;
++		compatible = "mmc-card";
++		broken-hpi;
++	};
++};
+diff --git a/arch/arm/boot/dts/sun7i-a20-olimex-som204-evb.dts b/arch/arm/boot/dts/sun7i-a20-olimex-som204-evb.dts
+new file mode 100644
+index 0000000..3d904f1
+--- /dev/null
++++ b/arch/arm/boot/dts/sun7i-a20-olimex-som204-evb.dts
+@@ -0,0 +1,310 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Device Tree Source for A20-SOM204-EVB Board
++ *
++ * Copyright (C) 2018 Olimex Ltd.
++ *   Author: Stefan Mavrodiev <stefan@olimex.com>
++ */
++
++/dts-v1/;
++#include "sun7i-a20.dtsi"
++#include "sunxi-common-regulators.dtsi"
++
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/interrupt-controller/irq.h>
++#include <dt-bindings/pwm/pwm.h>
++
++/ {
++	model = "Olimex A20-SOM204-EVB";
++	compatible = "olimex,a20-olimex-som204-evb", "allwinner,sun7i-a20";
++
++	aliases {
++		serial0 = &uart0;
++		serial1 = &uart4;
++		serial2 = &uart7;
++		spi0 = &spi1;
++		spi1 = &spi2;
++		ethernet1 = &rtl8723bs;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		stat {
++			label = "a20-som204-evb:green:stat";
++			gpios = <&pio 8 0 GPIO_ACTIVE_HIGH>;
++			default-state = "on";
++		};
++
++		led1 {
++			label = "a20-som204-evb:green:led1";
++			gpios = <&pio 8 10 GPIO_ACTIVE_HIGH>;
++			default-state = "on";
++		};
++
++		led2 {
++			label = "a20-som204-evb:yellow:led2";
++			gpios = <&pio 8 11 GPIO_ACTIVE_HIGH>;
++			default-state = "on";
++		};
++	};
++
++	rtl_pwrseq: rtl_pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		reset-gpios = <&pio 6 9 GPIO_ACTIVE_LOW>;
++	};
++};
++
++&ahci {
++	target-supply = <&reg_ahci_5v>;
++	status = "okay";
++};
++
++&can0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&can0_pins_a>;
++	status = "okay";
++};
++
++&codec {
++	status = "okay";
++};
++
++&cpu0 {
++	cpu-supply = <&reg_dcdc2>;
++};
++
++&ehci0 {
++	status = "okay";
++};
++
++&ehci1 {
++	status = "okay";
++};
++
++&gmac {
++	pinctrl-names = "default";
++	pinctrl-0 = <&gmac_pins_rgmii_a>;
++	phy = <&phy3>;
++	phy-mode = "rgmii";
++	phy-supply = <&reg_vcc3v3>;
++
++	snps,reset-gpio = <&pio 0 17 GPIO_ACTIVE_HIGH>;
++	snps,reset-active-low;
++	snps,reset-delays-us = <0 10000 1000000>;
++	status = "okay";
++
++	phy3: ethernet-phy@3 {
++		reg = <3>;
++	};
++};
++
++&i2c0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c0_pins_a>;
++	status = "okay";
++
++	axp209: pmic@34 {
++		reg = <0x34>;
++		interrupt-parent = <&nmi_intc>;
++		interrupts = <0 IRQ_TYPE_LEVEL_LOW>;
++	};
++};
++
++/* Exposed to UEXT1 */
++&i2c1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c1_pins_a>;
++	status = "okay";
++
++	eeprom: eeprom@50 {
++		compatible = "atmel,24c16";
++		reg = <0x50>;
++		pagesize = <16>;
++	};
++};
++
++/* Exposed to UEXT2 */
++&i2c2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c2_pins_a>;
++	status = "okay";
++};
++
++&ir0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&ir0_rx_pins_a>;
++	status = "okay";
++};
++
++&mmc0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mmc0_pins_a>;
++	vmmc-supply = <&reg_vcc3v3>;
++	bus-width = <4>;
++	cd-gpios = <&pio 7 1 GPIO_ACTIVE_HIGH>;
++	cd-inverted;
++	status = "okay";
++};
++
++&mmc3 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mmc3_pins_a>;
++	vmmc-supply = <&reg_vcc3v3>;
++	mmc-pwrseq = <&rtl_pwrseq>;
++	bus-width = <4>;
++	non-removable;
++	status = "okay";
++
++	rtl8723bs: sdio_wifi@1 {
++		reg = <1>;
++	};
++};
++
++&ohci0 {
++	status = "okay";
++};
++
++&ohci1 {
++	status = "okay";
++};
++
++&otg_sram {
++	status = "okay";
++};
++
++&pio {
++	bt_uart_pins: bt_uart_pins@0 {
++		pins = "PG6", "PG7", "PG8";
++		function = "uart3";
++	};
++};
++
++#include "axp209.dtsi"
++
++&ac_power_supply {
++	status = "okay";
++};
++
++&battery_power_supply {
++	status = "okay";
++};
++
++&reg_ahci_5v {
++	gpio = <&pio 2 3 GPIO_ACTIVE_HIGH>;
++	status = "okay";
++};
++
++&reg_dcdc2 {
++	regulator-always-on;
++	regulator-min-microvolt = <1000000>;
++	regulator-max-microvolt = <1400000>;
++	regulator-name = "vdd-cpu";
++};
++
++&reg_dcdc3 {
++	regulator-always-on;
++	regulator-min-microvolt = <1000000>;
++	regulator-max-microvolt = <1400000>;
++	regulator-name = "vdd-int-dll";
++};
++
++&reg_ldo1 {
++	regulator-always-on;
++	regulator-min-microvolt = <1300000>;
++	regulator-max-microvolt = <1300000>;
++	regulator-name = "vdd-rtc";
++};
++
++&reg_ldo2 {
++	regulator-always-on;
++	regulator-min-microvolt = <3000000>;
++	regulator-max-microvolt = <3000000>;
++	regulator-name = "avcc";
++};
++
++&reg_ldo4 {
++	regulator-min-microvolt = <3300000>;
++	regulator-max-microvolt = <3300000>;
++	regulator-name = "vcc-pg";
++};
++
++&reg_usb0_vbus {
++	gpio = <&pio 2 17 GPIO_ACTIVE_HIGH>;
++	status = "okay";
++};
++
++&reg_usb1_vbus {
++	status = "okay";
++};
++
++&reg_usb2_vbus {
++	status = "okay";
++};
++
++/* Exposed to UEXT1 */
++&spi1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi1_pins_a>,
++		    <&spi1_cs0_pins_a>;
++	status = "okay";
++};
++
++/* Exposed to UEXT2 */
++&spi2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi2_pins_a>,
++		    <&spi2_cs0_pins_a>;
++	status = "okay";
++};
++
++&uart0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart0_pins_a>;
++	status = "okay";
++};
++
++/* Used for RTL8723BS bluetooth */
++&uart3 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&bt_uart_pins>;
++	status = "okay";
++};
++
++/* Exposed to UEXT1 */
++&uart4 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart4_pins_a>;
++	status = "okay";
++};
++
++/* Exposed to UEXT2 */
++&uart7 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart7_pins_a>;
++	status = "okay";
++};
++
++&usb_otg {
++	dr_mode = "otg";
++	status = "okay";
++};
++
++&usb_power_supply {
++	status = "okay";
++};
++
++&usbphy {
++	usb0_id_det-gpio = <&pio 7 4 GPIO_ACTIVE_HIGH>; /* PH4 */
++	usb0_vbus_det-gpio = <&pio 7 5 GPIO_ACTIVE_HIGH>; /* PH5 */
++	usb0_vbus_power-supply = <&usb_power_supply>;
++	usb0_vbus-supply = <&reg_usb0_vbus>;
++	usb1_vbus-supply = <&reg_usb1_vbus>;
++	usb2_vbus-supply = <&reg_usb2_vbus>;
++	status = "okay";
++};

--- a/patch/u-boot/u-boot-sunxi/board_olimex-som204-a20/Change-GMAC-phy-address.patch
+++ b/patch/u-boot/u-boot-sunxi/board_olimex-som204-a20/Change-GMAC-phy-address.patch
@@ -1,0 +1,13 @@
+diff --git a/include/configs/sunxi-common.h b/include/configs/sunxi-common.h
+index 6b0ad5e..310e9bb 100644
+--- a/include/configs/sunxi-common.h
++++ b/include/configs/sunxi-common.h
+@@ -292,7 +292,7 @@ extern int soft_i2c_gpio_scl;
+ #endif
+ 
+ #ifdef CONFIG_SUN7I_GMAC
+-#define CONFIG_PHY_ADDR		1
++#define CONFIG_PHY_ADDR		3
+ #define CONFIG_MII			/* MII PHY management		*/
+ #define CONFIG_PHY_REALTEK
+ #endif

--- a/patch/u-boot/u-boot-sunxi/board_olimex-som204-a20/fix-mmc-phases.patch
+++ b/patch/u-boot/u-boot-sunxi/board_olimex-som204-a20/fix-mmc-phases.patch
@@ -1,0 +1,28 @@
+diff --git a/drivers/mmc/sunxi_mmc.c b/drivers/mmc/sunxi_mmc.c
+index 4edb4be..be55dc4 100644
+--- a/drivers/mmc/sunxi_mmc.c
++++ b/drivers/mmc/sunxi_mmc.c
+@@ -146,19 +146,19 @@ static int mmc_set_mod_clk(struct sunxi_mmc_priv *priv, unsigned int hz)
+ 		oclk_dly = 0;
+ 		sclk_dly = 5;
+ #ifdef CONFIG_MACH_SUN9I
+-	} else if (hz <= 50000000) {
++	} else if (hz <= 52000000) {
+ 		oclk_dly = 5;
+ 		sclk_dly = 4;
+ 	} else {
+-		/* hz > 50000000 */
++		/* hz > 52000000 */
+ 		oclk_dly = 2;
+ 		sclk_dly = 4;
+ #else
+-	} else if (hz <= 50000000) {
++	} else if (hz <= 52000000) {
+ 		oclk_dly = 3;
+ 		sclk_dly = 4;
+ 	} else {
+-		/* hz > 50000000 */
++		/* hz > 52000000 */
+ 		oclk_dly = 1;
+ 		sclk_dly = 4;
+ #endif


### PR DESCRIPTION
A20-SOM204 is currently supported only for dev branch, which is big drawback. After some second thoughts support for DEFAULT and NEXT branch added. This includes:

- For u-boot:
  - The board has phy address 3, so patch is needed to get is working
  - As described in #935 the board needs some phase tunning for the mmc controller

- For the default branch:
  - Add fex for the board
  - Add can driver for linux-sunxi3.4 kernel branch
  - Update sun7i kernel config, enabling m25p80 (spi-nor) driver and sunxi-can.

- For the next branch:
  - Add dts files

Not working peripherals are:
- In the default branch:
  - WIFI/BT combo (rtl8723bs)
  - eMMC
  - ATECC508A crypto engine

- In the next branch:
  - CSI camera


