### PR TITLE
Moved `${LOOP}p${rootpart}` in it's own variable `$rootdevice`

### DIFF
--- a/lib/debootstrap-ng.sh
+++ b/lib/debootstrap-ng.sh
@@ -383,13 +383,14 @@ prepare_partitions()
 	# stage: create fs, mount partitions, create fstab
 	rm -f $SDCARD/etc/fstab
 	if [[ -n $rootpart ]]; then
+		local rootdevice="${LOOP}p${rootpart}"
+		local rootfs="UUID=$(blkid -s UUID -o value $rootdevice)"
+		check_loop_device "$rootdevice"
 		display_alert "Creating rootfs" "$ROOTFS_TYPE"
-		check_loop_device "${LOOP}p${rootpart}"
-		mkfs.${mkfs[$ROOTFS_TYPE]} ${mkopts[$ROOTFS_TYPE]} ${LOOP}p${rootpart}
-		[[ $ROOTFS_TYPE == ext4 ]] && tune2fs -o journal_data_writeback ${LOOP}p${rootpart} > /dev/null
+		mkfs.${mkfs[$ROOTFS_TYPE]} ${mkopts[$ROOTFS_TYPE]} $rootdevice
+		[[ $ROOTFS_TYPE == ext4 ]] && tune2fs -o journal_data_writeback $rootdevice > /dev/null
 		[[ $ROOTFS_TYPE == btrfs ]] && local fscreateopt="-o compress-force=zlib"
-		mount ${fscreateopt} ${LOOP}p${rootpart} $MOUNT/
-		local rootfs="UUID=$(blkid -s UUID -o value ${LOOP}p${rootpart})"
+		mount ${fscreateopt} $rootdevice $MOUNT/
 		echo "$rootfs / ${mkfs[$ROOTFS_TYPE]} defaults,noatime,nodiratime${mountopts[$ROOTFS_TYPE]} 0 1" >> $SDCARD/etc/fstab
 	fi
 	if [[ -n $bootpart ]]; then


### PR DESCRIPTION
Replaced all (5) occurences of `${LOOP}p${rootpart}` with `$rootdevice`. This minor refactoring makes further additions easier to merge. For example using a LUKS mapper device `/dev/mapper/cryptroot` instead of `/dev/loop0p2` as the actual root device can now be handled by just re-assigning the `$rootdevice` variable, while all other related code lines (mkfs, mount, ...) won't need to change.