### PR TITLE
fix broken 8822bs-patch

### DIFF
--- a/patch/kernel/rk3328-default/wifi-realtek-8822BS-kconfig-makefile-4.4.patch
+++ b/patch/kernel/rk3328-default/wifi-realtek-8822BS-kconfig-makefile-4.4.patch
@@ -1,0 +1,40 @@
+diff --git a/drivers/net/wireless/rockchip_wlan/Kconfig b/drivers/net/wireless/rockchip_wlan/Kconfig
+index 9df827f..1d77b96 100644
+--- a/drivers/net/wireless/rockchip_wlan/Kconfig
++++ b/drivers/net/wireless/rockchip_wlan/Kconfig
+@@ -41,6 +41,7 @@ source "drivers/net/wireless/rockchip_wlan/rtl8723cs/Kconfig"
+ source "drivers/net/wireless/rockchip_wlan/rtl8723ds/Kconfig"
+ source "drivers/net/wireless/rockchip_wlan/rtl8812au/Kconfig"
+ source "drivers/net/wireless/rockchip_wlan/rtl8822be/Kconfig"
++source "drivers/net/wireless/rockchip_wlan/rtl8822bs/Kconfig"
+ source "drivers/net/wireless/rockchip_wlan/mvl88w8977/Kconfig"
+ 
+ endif # WL_ROCKCHIP
+diff --git a/drivers/net/wireless/rockchip_wlan/Makefile b/drivers/net/wireless/rockchip_wlan/Makefile
+index d1aebf7..93e3658 100644
+--- a/drivers/net/wireless/rockchip_wlan/Makefile
++++ b/drivers/net/wireless/rockchip_wlan/Makefile
+@@ -9,6 +9,7 @@ obj-$(CONFIG_RTL8723BU) += rtl8723bu/
+ obj-$(CONFIG_RTL8723CS)	+= rtl8723cs/
+ obj-$(CONFIG_RTL8723DS) += rtl8723ds/
+ obj-$(CONFIG_RTL8822BE)	+= rtl8822be/
++obj-$(CONFIG_RTL8822BS) += rtl8822bs/
+ obj-$(CONFIG_MVL88W8977)	+= mvl88w8977/
+ obj-$(CONFIG_WL_ROCKCHIP)	+= wifi_sys/rkwifi_sys_iface.o
+ obj-$(CONFIG_WL_ROCKCHIP)	+= rkwifi/rk_wifi_config.o
+diff --git a/drivers/net/wireless/rockchip_wlan/Makefile.rej b/drivers/net/wireless/rockchip_wlan/Makefile.rej
+new file mode 100644
+index 0000000..a275c66
+--- /dev/null
++++ b/drivers/net/wireless/rockchip_wlan/Makefile.rej
+@@ -0,0 +1,10 @@
++--- drivers/net/wireless/rockchip_wlan/Makefile
+++++ drivers/net/wireless/rockchip_wlan/Makefile
++@@ -9,6 +9,7 @@ obj-$(CONFIG_RTL8723BU) += rtl8723bu/
++ obj-$(CONFIG_RTL8723CS)        += rtl8723cs/
++ obj-$(CONFIG_RTL8723DS) += rtl8723ds/
++ obj-$(CONFIG_RTL8822BE)        += rtl8822be/
+++obj-$(CONFIG_RTL8822BS) += rtl8822bs/
++ obj-$(CONFIG_MVL88W8977)       += mvl88w8977/
++ obj-$(CONFIG_WL_ROCKCHIP)      += wifi_sys/rkwifi_sys_iface.o
++ obj-$(CONFIG_WL_ROCKCHIP)      += rkwifi/rk_wifi_config.o


### PR DESCRIPTION
After updates to ayufan's repo the patches for Kconfig and Makefile were broken.
It should work again and I made an extra-patch for both as You did before with other patches for easier maintenance in the future.
No changes beside that (hopefully no new errors).

Bluetooth is still completely broken, but I'll try to fix it, when I find the time (and the idea;).