### PR TITLE
Add LIB_TAG "master"

### DIFF
--- a/config/templates/config-example.conf
+++ b/config/templates/config-example.conf
@@ -21,3 +21,4 @@ BUILD_ALL="no"				# cycle through available boards and make images or kernel/u-b
 
 BSPFREEZE=""				# freeze armbian packages (u-boot, kernel, dtb)
 INSTALL_HEADERS=""			# install kernel headers package
+LIB_TAG="master"			# change to "development" if you want use Armbians developmen branch


### PR DESCRIPTION
Explain how people not familiar with the build-script can switch to development branch often needs multiple posts until they get it as it can be seen [here](https://forum.armbian.com/topic/6956-rock64-debian-building-a-replica-of-current-testing-image/?do=findComment&comment=52920), [here](https://forum.armbian.com/topic/6926-tinkerboard-build-44-119-fail-questions/?do=findComment&comment=52540) or [here](https://forum.armbian.com/topic/6754-fails-to-get-allwinner-stable-branch-of-atf/?do=findComment&comment=51218). Adding the LIB_TAG to config-example.conf should make this easier (documentation is also updated with [this PR](https://github.com/armbian/documentation/pull/19)). Tested with a freshly cloned build script and it looks that the behavior is as expected (default master):

```
[ o.k. ] Using config file [ config-default.conf ]
[ o.k. ] This script will try to update
Already up-to-date.
Already on 'master'
Your branch is up-to-date with 'origin/master'.
```
and development when changes are made in config-default.conf
```
[ o.k. ] Using config file [ config-default.conf ]
[ o.k. ] This script will try to update
Already up-to-date.
Switched to branch 'development'
Your branch is up-to-date with 'origin/development'.
```
