### PR TITLE
rework of the BPi-M2-Zero patches

### DIFF
--- a/patch/kernel/sunxi-dev/47-06-enable-dvfs-bpi-m2-zero.patch
+++ b/patch/kernel/sunxi-dev/47-06-enable-dvfs-bpi-m2-zero.patch
@@ -1,0 +1,39 @@
+diff --git a/arch/arm/boot/dts/sun8i-h2-plus-bananapi-m2-zero.dts b/arch/arm/boot/dts/sun8i-h2-plus-bananapi-m2-zero.dts
+index 7d01f93..401cbd9 100644
+--- a/arch/arm/boot/dts/sun8i-h2-plus-bananapi-m2-zero.dts
++++ b/arch/arm/boot/dts/sun8i-h2-plus-bananapi-m2-zero.dts
+@@ -48,6 +48,23 @@
+ 		};
+ 	};
+ 
++	reg_sy8113b: gpio-regulator {
++		compatible = "regulator-gpio";
++		regulator-name = "vdd-cpux";
++		regulator-type = "voltage";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <1100000>;
++		regulator-max-microvolt = <1300000>;
++		regulator-ramp-delay = <50>; /* 4ms */
++
++		gpios = <&r_pio 0 1 GPIO_ACTIVE_HIGH>; /* PL1 */
++		enable-active-high;
++		gpios-states = <0x1>;
++		states = <1100000 0x0
++			  1300000 0x1>;
++	};
++
+ 	wifi_pwrseq: wifi_pwrseq {
+ 		compatible = "mmc-pwrseq-simple";
+ 		pinctrl-names = "default";
+@@ -55,6 +72,10 @@
+ 	};
+ };
+ 
++&cpu0 {
++	cpu-supply = <&reg_sy8113b>;
++};
++
+ &ehci0 {
+ 	status = "okay";
+ };

--- a/patch/kernel/sunxi-next/add-bananapi-m2-zero.patch
+++ b/patch/kernel/sunxi-next/add-bananapi-m2-zero.patch
@@ -1,32 +1,5 @@
-From 9270c2efc5e63e8c69338c0cf6c5128fb6808c15 Mon Sep 17 00:00:00 2001
-From: Icenowy Zheng <icenowy@aosc.io>
-Date: Thu, 8 Feb 2018 18:06:13 +0800
-Subject: [PATCH] ARM: sun8i: h2+: add support for Banana Pi M2 Zero board
-
-Banana Pi M2 Zero board is a H2+-based board by Sinovoip, with a form
-factor and GPIO holes similar to Raspberry Pi Zero.
-
-It features:
-- Allwinner H2+ SoC
-- Single-chip (16-bit) 512MiB DDR3 DRAM
-- Ampak AP6212 Wi-Fi/Bluetooth module
-- MicroSD slot
-- Two MicroUSB Type-B ports (one can only be used to power the board and
-  the other features OTG functionality)
-- Two keys, a reset and a GPIO-connected key.
-- HDMI Type-C (miniHDMI) connector connected to the HDMI part of H2+.
-- CSI connector to connect the camera sensor provided by Sinovoip.
-
-Signed-off-by: Icenowy Zheng <icenowy@aosc.io>
-Signed-off-by: Maxime Ripard <maxime.ripard@bootlin.com>
----
- arch/arm/boot/dts/Makefile                         |   1 +
- .../boot/dts/sun8i-h2-plus-bananapi-m2-zero.dts    | 125 +++++++++++++++++++++
- 2 files changed, 126 insertions(+)
- create mode 100644 arch/arm/boot/dts/sun8i-h2-plus-bananapi-m2-zero.dts
-
 diff --git a/arch/arm/boot/dts/Makefile b/arch/arm/boot/dts/Makefile
-index ade7a38543dc9..d5a17e6e8b0f4 100644
+index e2d218d..88fa9f7 100644
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
 @@ -917,6 +917,7 @@ dtb-$(CONFIG_MACH_SUN8I) += \
@@ -39,10 +12,10 @@ index ade7a38543dc9..d5a17e6e8b0f4 100644
  	sun8i-h2-plus-sunvell-r69.dtb \
 diff --git a/arch/arm/boot/dts/sun8i-h2-plus-bananapi-m2-zero.dts b/arch/arm/boot/dts/sun8i-h2-plus-bananapi-m2-zero.dts
 new file mode 100644
-index 0000000000000..1cdbd9a3ef578
+index 0000000..1e58d7c
 --- /dev/null
 +++ b/arch/arm/boot/dts/sun8i-h2-plus-bananapi-m2-zero.dts
-@@ -0,0 +1,125 @@
+@@ -0,0 +1,146 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (C) 2017 Icenowy Zheng <icenowy@aosc.io>
@@ -93,11 +66,32 @@ index 0000000000000..1cdbd9a3ef578
 +		};
 +	};
 +
++	reg_sy8113b: gpio-regulator {
++		compatible = "regulator-gpio";
++		regulator-name = "vdd-cpux";
++		regulator-type = "voltage";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <1100000>;
++		regulator-max-microvolt = <1300000>;
++		regulator-ramp-delay = <50>; /* 4ms */
++
++		gpios = <&r_pio 0 1 GPIO_ACTIVE_HIGH>; /* PL1 */
++		enable-active-high;
++		gpios-states = <0x1>;
++		states = <1100000 0x0
++			  1300000 0x1>;
++	};	
++	
 +	wifi_pwrseq: wifi_pwrseq {
 +		compatible = "mmc-pwrseq-simple";
 +		pinctrl-names = "default";
 +		reset-gpios = <&r_pio 0 7 GPIO_ACTIVE_LOW>; /* PL7 */
 +	};
++};
++
++&cpu0 {
++	cpu-supply = <&reg_sy8113b>;
 +};
 +
 +&ehci0 {

--- a/patch/u-boot/u-boot-sunxi-dev/add-bananapi-bpi-zero.patch
+++ b/patch/u-boot/u-boot-sunxi-dev/add-bananapi-bpi-zero.patch
@@ -1,18 +1,21 @@
-diff -Naur v2017.11.org/arch/arm/dts/Makefile v2017.11-bpi-m2z/arch/arm/dts/Makefile
---- v2017.11.org/arch/arm/dts/Makefile	2017-12-02 18:16:32.755513258 +0800
-+++ v2017.11-bpi-m2z/arch/arm/dts/Makefile	2017-12-02 21:00:39.727635880 +0800
-@@ -318,6 +318,7 @@
- 	sun8i-a83t-bananapi-m3.dtb \
- 	sun8i-a83t-cubietruck-plus.dtb
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index aaaa9d8..b6eebe8 100644
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -341,6 +341,7 @@ dtb-$(CONFIG_MACH_SUN8I_A83T) += \
+ 	sun8i-a83t-cubietruck-plus.dtb \
+ 	sun8i-a83t-tbs-a711.dts
  dtb-$(CONFIG_MACH_SUN8I_H3) += \
-+	sun8i-h2-plus-bananapi-m2-zero.dts \
++	sun8i-h2-plus-bananapi-m2-zero.dtb \
  	sun8i-h2-plus-orangepi-zero.dtb \
  	sun8i-h2-plus-nanopi-duo.dtb \
- 	sun8i-h3-bananapi-m2-plus.dtb \
-diff -Naur v2017.11.org/arch/arm/dts/sun8i-h2-plus-bananapi-m2-zero.dts v2017.11-bpi-m2z/arch/arm/dts/sun8i-h2-plus-bananapi-m2-zero.dts
---- v2017.11.org/arch/arm/dts/sun8i-h2-plus-bananapi-m2-zero.dts	1970-01-01 08:00:00.000000000 +0800
-+++ v2017.11-bpi-m2z/arch/arm/dts/sun8i-h2-plus-bananapi-m2-zero.dts	2017-11-23 15:57:53.000000000 +0800
-@@ -0,0 +1,154 @@
+ 	sun8i-h2-plus-sunvell-r69.dtb \
+diff --git a/arch/arm/dts/sun8i-h2-plus-bananapi-m2-zero.dts b/arch/arm/dts/sun8i-h2-plus-bananapi-m2-zero.dts
+new file mode 100644
+index 0000000..61de91d
+--- /dev/null
++++ b/arch/arm/dts/sun8i-h2-plus-bananapi-m2-zero.dts
+@@ -0,0 +1,141 @@
 +/*
 + * Copyright (C) 2017 Icenowy Zheng <icenowy@aosc.io>
 + *
@@ -100,23 +103,6 @@ diff -Naur v2017.11.org/arch/arm/dts/sun8i-h2-plus-bananapi-m2-zero.dts v2017.11
 +		};
 +	};
 +
-+	reg_sy8113b: gpio-regulator {
-+		compatible = "regulator-gpio";
-+		regulator-name = "vdd-cpux";
-+		regulator-type = "voltage";
-+		regulator-boot-on;
-+		regulator-always-on;
-+		regulator-min-microvolt = <1100000>;
-+		regulator-max-microvolt = <1300000>;
-+		regulator-ramp-delay = <50>; /* 4ms */
-+
-+		gpios = <&r_pio 0 1 GPIO_ACTIVE_HIGH>; /* PL1 */
-+		enable-active-high;
-+		gpios-states = <0x1>;
-+		states = <1100000 0x0
-+			  1300000 0x1>;
-+	};
-+
 +	wifi_pwrseq: wifi_pwrseq {
 +		compatible = "mmc-pwrseq-simple";
 +		pinctrl-names = "default";
@@ -125,15 +111,14 @@ diff -Naur v2017.11.org/arch/arm/dts/sun8i-h2-plus-bananapi-m2-zero.dts v2017.11
 +};
 +
 +&mmc0 {
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&mmc0_pins_a>;
 +	vmmc-supply = <&reg_vcc3v3>;
 +	bus-width = <4>;
 +	/*
-+	 * In different revisions the board have different card detect
-+	 * configuration.
++	 * On the production batch of this board the card detect GPIO is
++	 * high active (card inserted), although on the early samples it's
++	 * low active.
 +	 */
-+	broken-cd;
++	cd-gpios = <&pio 5 6 GPIO_ACTIVE_HIGH>; /* PF6 */
 +	status = "okay";
 +};
 +
@@ -164,13 +149,20 @@ diff -Naur v2017.11.org/arch/arm/dts/sun8i-h2-plus-bananapi-m2-zero.dts v2017.11
 +
 +&usbphy {
 +	usb0_id_det-gpios = <&r_pio 0 6 GPIO_ACTIVE_HIGH>; /* PL6 */
-+	/* USB OTG VBUS is directly connected to 5V without any regulators */
++	/*
++	 * There're two micro-USB connectors, one is power-only and another is
++	 * OTG. The Vbus of these two connectors are connected together, so
++	 * the external USB device will be powered just by the power input
++	 * from the power-only USB port.
++	 */
 +	status = "okay";
 +};
-diff -Naur v2017.11.org/configs/Sinovoip_BPI_M2_Zero_defconfig v2017.11-bpi-m2z/configs/Sinovoip_BPI_M2_Zero_defconfig
---- v2017.11.org/configs/Sinovoip_BPI_M2_Zero_defconfig	1970-01-01 08:00:00.000000000 +0800
-+++ v2017.11-bpi-m2z/configs/Sinovoip_BPI_M2_Zero_defconfig	2017-12-02 20:56:15.000000000 +0800
-@@ -0,0 +1,18 @@
+diff --git a/configs/Sinovoip_BPI_M2_Zero_defconfig b/configs/Sinovoip_BPI_M2_Zero_defconfig
+new file mode 100644
+index 0000000..8f96ac1
+--- /dev/null
++++ b/configs/Sinovoip_BPI_M2_Zero_defconfig
+@@ -0,0 +1,19 @@
 +CONFIG_ARM=y
 +CONFIG_ARCH_SUNXI=y
 +CONFIG_SYS_TEXT_BASE=0x4a000000
@@ -189,3 +181,4 @@ diff -Naur v2017.11.org/configs/Sinovoip_BPI_M2_Zero_defconfig v2017.11-bpi-m2z/
 +# CONFIG_SPL_EFI_PARTITION is not set
 +CONFIG_SUN8I_EMAC=y
 +CONFIG_USB_EHCI_HCD=y
++CONFIG_MMC0_CD_PIN=""

--- a/patch/u-boot/u-boot-sunxi/add-bananapi-m2-zero.patch
+++ b/patch/u-boot/u-boot-sunxi/add-bananapi-m2-zero.patch
@@ -1,18 +1,21 @@
-diff -Naur v2017.11.org/arch/arm/dts/Makefile v2017.11-bpi-m2z/arch/arm/dts/Makefile
---- v2017.11.org/arch/arm/dts/Makefile	2017-12-02 18:16:32.755513258 +0800
-+++ v2017.11-bpi-m2z/arch/arm/dts/Makefile	2017-12-02 21:00:39.727635880 +0800
-@@ -318,6 +318,7 @@
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index 6ea9805..6826001 100644
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -320,6 +320,7 @@ dtb-$(CONFIG_MACH_SUN8I_A83T) += \
  	sun8i-a83t-bananapi-m3.dtb \
  	sun8i-a83t-cubietruck-plus.dtb
  dtb-$(CONFIG_MACH_SUN8I_H3) += \
-+	sun8i-h2-plus-bananapi-m2-zero.dts \
++	sun8i-h2-plus-bananapi-m2-zero.dtb \
  	sun8i-h2-plus-orangepi-zero.dtb \
  	sun8i-h2-plus-nanopi-duo.dtb \
- 	sun8i-h3-bananapi-m2-plus.dtb \
-diff -Naur v2017.11.org/arch/arm/dts/sun8i-h2-plus-bananapi-m2-zero.dts v2017.11-bpi-m2z/arch/arm/dts/sun8i-h2-plus-bananapi-m2-zero.dts
---- v2017.11.org/arch/arm/dts/sun8i-h2-plus-bananapi-m2-zero.dts	1970-01-01 08:00:00.000000000 +0800
-+++ v2017.11-bpi-m2z/arch/arm/dts/sun8i-h2-plus-bananapi-m2-zero.dts	2017-11-23 15:57:53.000000000 +0800
-@@ -0,0 +1,154 @@
+ 	sun8i-h2-plus-sunvell-r69.dtb \
+diff --git a/arch/arm/dts/sun8i-h2-plus-bananapi-m2-zero.dts b/arch/arm/dts/sun8i-h2-plus-bananapi-m2-zero.dts
+new file mode 100644
+index 0000000..61de91d
+--- /dev/null
++++ b/arch/arm/dts/sun8i-h2-plus-bananapi-m2-zero.dts
+@@ -0,0 +1,141 @@
 +/*
 + * Copyright (C) 2017 Icenowy Zheng <icenowy@aosc.io>
 + *
@@ -100,23 +103,6 @@ diff -Naur v2017.11.org/arch/arm/dts/sun8i-h2-plus-bananapi-m2-zero.dts v2017.11
 +		};
 +	};
 +
-+	reg_sy8113b: gpio-regulator {
-+		compatible = "regulator-gpio";
-+		regulator-name = "vdd-cpux";
-+		regulator-type = "voltage";
-+		regulator-boot-on;
-+		regulator-always-on;
-+		regulator-min-microvolt = <1100000>;
-+		regulator-max-microvolt = <1300000>;
-+		regulator-ramp-delay = <50>; /* 4ms */
-+
-+		gpios = <&r_pio 0 1 GPIO_ACTIVE_HIGH>; /* PL1 */
-+		enable-active-high;
-+		gpios-states = <0x1>;
-+		states = <1100000 0x0
-+			  1300000 0x1>;
-+	};
-+
 +	wifi_pwrseq: wifi_pwrseq {
 +		compatible = "mmc-pwrseq-simple";
 +		pinctrl-names = "default";
@@ -125,15 +111,14 @@ diff -Naur v2017.11.org/arch/arm/dts/sun8i-h2-plus-bananapi-m2-zero.dts v2017.11
 +};
 +
 +&mmc0 {
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&mmc0_pins_a>;
 +	vmmc-supply = <&reg_vcc3v3>;
 +	bus-width = <4>;
 +	/*
-+	 * In different revisions the board have different card detect
-+	 * configuration.
++	 * On the production batch of this board the card detect GPIO is
++	 * high active (card inserted), although on the early samples it's
++	 * low active.
 +	 */
-+	broken-cd;
++	cd-gpios = <&pio 5 6 GPIO_ACTIVE_HIGH>; /* PF6 */
 +	status = "okay";
 +};
 +
@@ -164,13 +149,20 @@ diff -Naur v2017.11.org/arch/arm/dts/sun8i-h2-plus-bananapi-m2-zero.dts v2017.11
 +
 +&usbphy {
 +	usb0_id_det-gpios = <&r_pio 0 6 GPIO_ACTIVE_HIGH>; /* PL6 */
-+	/* USB OTG VBUS is directly connected to 5V without any regulators */
++	/*
++	 * There're two micro-USB connectors, one is power-only and another is
++	 * OTG. The Vbus of these two connectors are connected together, so
++	 * the external USB device will be powered just by the power input
++	 * from the power-only USB port.
++	 */
 +	status = "okay";
 +};
-diff -Naur v2017.11.org/configs/Sinovoip_BPI_M2_Zero_defconfig v2017.11-bpi-m2z/configs/Sinovoip_BPI_M2_Zero_defconfig
---- v2017.11.org/configs/Sinovoip_BPI_M2_Zero_defconfig	1970-01-01 08:00:00.000000000 +0800
-+++ v2017.11-bpi-m2z/configs/Sinovoip_BPI_M2_Zero_defconfig	2017-12-02 20:56:15.000000000 +0800
-@@ -0,0 +1,17 @@
+diff --git a/configs/Sinovoip_BPI_M2_Zero_defconfig b/configs/Sinovoip_BPI_M2_Zero_defconfig
+new file mode 100644
+index 0000000..6458c60
+--- /dev/null
++++ b/configs/Sinovoip_BPI_M2_Zero_defconfig
+@@ -0,0 +1,18 @@
 +CONFIG_ARM=y
 +CONFIG_ARCH_SUNXI=y
 +CONFIG_MACH_SUN8I_H3=y
@@ -188,3 +180,4 @@ diff -Naur v2017.11.org/configs/Sinovoip_BPI_M2_Zero_defconfig v2017.11-bpi-m2z/
 +# CONFIG_SPL_EFI_PARTITION is not set
 +CONFIG_SUN8I_EMAC=y
 +CONFIG_USB_EHCI_HCD=y
++CONFIG_MMC0_CD_PIN=""

--- a/patch/u-boot/u-boot-sunxi/add-nanopi-m1-plus2-emmc.patch
+++ b/patch/u-boot/u-boot-sunxi/add-nanopi-m1-plus2-emmc.patch
@@ -1,3 +1,15 @@
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index 916435c..5891be2 100644
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -345,6 +345,7 @@ dtb-$(CONFIG_MACH_SUN8I_V3S) += \
+ 	sun8i-v3s-licheepi-zero.dtb
+ dtb-$(CONFIG_MACH_SUN50I_H5) += \
+ 	sun50i-h5-nanopi-neo2.dtb \
++	sun50i-h5-nanopi-m1-plus2.dtb \
+ 	sun50i-h5-orangepi-pc2.dtb \
+ 	sun50i-h5-orangepi-prime.dtb \
+ 	sun50i-h5-orangepi-zero-plus2.dtb
 diff --git a/arch/arm/dts/sun50i-h5-nanopi-m1-plus2.dts b/arch/arm/dts/sun50i-h5-nanopi-m1-plus2.dts
 new file mode 100644
 index 0000000..fdf2c87
@@ -132,7 +144,7 @@ index 0000000..fdf2c87
 +};
 diff --git a/configs/nanopi_m1_plus2_defconfig b/configs/nanopi_m1_plus2_defconfig
 new file mode 100644
-index 0000000..f710366
+index 0000000..d088b3b
 --- /dev/null
 +++ b/configs/nanopi_m1_plus2_defconfig
 @@ -0,0 +1,21 @@
@@ -157,15 +169,3 @@ index 0000000..f710366
 +CONFIG_SUN8I_EMAC=y
 +CONFIG_USB_EHCI_HCD=y
 +CONFIG_SYS_USB_EVENT_POLL_VIA_INT_QUEUE=y
-diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
-index c9ace9f..d1bd78c
---- a/arch/arm/dts/Makefile
-+++ b/arch/arm/dts/Makefile
-@@ -332,6 +332,7 @@ dtb-$(CONFIG_MACH_SUN8I_V3S) += \
- 	sun8i-v3s-licheepi-zero.dtb
- dtb-$(CONFIG_MACH_SUN50I_H5) += \
- 	sun50i-h5-nanopi-neo2.dtb \
-+	sun50i-h5-nanopi-m1-plus2.dts \
- 	sun50i-h5-orangepi-pc2.dtb \
- 	sun50i-h5-orangepi-prime.dtb \
- 	sun50i-h5-orangepi-zero-plus2.dtb


### PR DESCRIPTION
Next attempt. :) @zador-blood-stained hint did the trick. The new patches should satisfy you hopefully more. 

Changes:
- Kernel dts was adjusted to Icenowy v5 patch for this board and sy8113b-node was added
- Kernel patch was renamed to have them both consistent 
- U-Boot dts was adjusted similar and cleaned a bit (removal of sy8113b node)
- `CONFIG_MMC0_CD_PIN=""` was added to defconfig to allow the board boot without an ugly hack
- Makefile for u-boot dts was fixed (dtb instead of dts)

**Why it isn't perfect?**

This patch will need a rework as soon as we move to 4.17 kernel for the following reasons:
- pinctrl part is removed from board-specific dts e.g.
```
+	pinctrl-names = "default";
+	pinctrl-0 = <&mmc0_pins_a>;
```
(this trolled me when I tried to use the 4.17 dts directly cause wifi will not work without them and it tooks me some builds to figure that out)
- due to Armbians naming scheme of patches, sy8113b for CPU voltage switch couldn't be separated properly (47-06-enable-dvfs-bpi-m2-zero.patch will fail due to add-bananapi-m2-zero.patch comes later and therefore it has to be renamed to something like bpi-47-06-enable-dvfs-bpi-m2-zero.patch which messes up the naming scheme more than having it inside the patch). It would also need a third patch which adds the pinctrl stuff so that only two patches have to be removed as soon as we switch to >4.17 with sunxi-next. I prefer to rework this patch rather than reworking (probably) three patches when we reach 4.17. 

**Why it satisfy me**

The patches touching only BPi-M2-Zero files (+ Makefiles):
- sun8i-h2-plus-bananapi-m2-zero.dts (kernel and u-boot)
- Sinovoip_BPI_M2_Zero_defconfig
therefore, chances are low that this will ever break boards we officially support.
- patches apply without issues with cleaned cache: 
uboot:
```
[ o.k. ] * [l][c] add-a20-optional-eMMC.patch
[ o.k. ] * [l][c] add-bananapi-m2-zero.patch
[ o.k. ] * [l][c] add-beelink-x2.patch
```
kernel:
```
[ o.k. ] * [l][c] add-axp803-DT.patch
[ o.k. ] * [l][c] add-bananapi-m2-zero.patch
[ o.k. ] * [l][c] add-configfs-overlay-for-v4.10.x.patch
```
- the board boots without issues (or at least none I can see) and is surprisingly cold (~40°C Idle and my thumb thinks this could be accurate).
- armbianmonitor -u: http://ix.io/1a2Y
- bootlog from serial console: http://ix.io/1a31 (boardname looks ugly on the 'welcome screen' but wasn't my decision to have such a long name... :P )

**Why the second commit?**
During this clean-up I found a small mistake in the u-boot dts makefile which is related to the add-nanopi-m1-plus2-emmc.patch (dts instead of dtb), I fixed this one too, but have no chance to test if this makes a difference (doesn't have the board). Armbians 'create patch' rearranged this patch so that it looks ugly on the github changes but the only change (to my knowledge) is replacing a dt**s** to a dt**b** in the makefile. :P 

