### PR TITLE
Fix LIB_TAG parameter not working from command line.

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -48,6 +48,16 @@ if [[ $EUID != 0 ]]; then
 	exit $?
 fi
 
+# Script parameters handling
+for i in "$@"; do
+	if [[ $i == *=* ]]; then
+		parameter=${i%%=*}
+		value=${i##*=}
+		display_alert "Command line: setting $parameter to" "${value:-(empty)}" "info"
+		eval $parameter=$value
+	fi
+done
+
 if [[ ! -f $SRC/.ignore_changes ]]; then
 	echo -e "[\e[0;32m o.k. \x1B[0m] This script will try to update"
 	git pull

--- a/lib/build-all.sh
+++ b/lib/build-all.sh
@@ -7,19 +7,6 @@
 # This file is a part of the Armbian build script
 # https://github.com/armbian/build/
 
-# Include here to make "display_alert" and "prepare_host" available
-source $SRC/lib/general.sh
-
-# Script parameters handling
-for i in "$@"; do
-	if [[ $i == *=* ]]; then
-		parameter=${i%%=*}
-		value=${i##*=}
-		display_alert "Command line: setting $parameter to" "${value:-(empty)}" "info"
-		eval $parameter=$value
-	fi
-done
-
 FORCEDRELEASE=$RELEASE
 
 # when we want to build from certain start

--- a/lib/main.sh
+++ b/lib/main.sh
@@ -54,16 +54,6 @@ date +"%d_%m_%Y-%H_%M_%S" > $DEST/debug/timestamp
 # delete compressed logs older than 7 days
 (cd $DEST/debug && find . -name '*.tgz' -mtime +7 -delete) > /dev/null
 
-# Script parameters handling
-for i in "$@"; do
-	if [[ $i == *=* ]]; then
-		parameter=${i%%=*}
-		value=${i##*=}
-		display_alert "Command line: setting $parameter to" "${value:-(empty)}" "info"
-		eval $parameter=$value
-	fi
-done
-
 if [[ $PROGRESS_DISPLAY == none ]]; then
 	OUTPUT_VERYSILENT=yes
 elif [[ $PROGRESS_DISPLAY == dialog ]]; then


### PR DESCRIPTION
Command line arguments were being parsed after `git pull`.
Also, it makes sense to reduce some code duplication.
Now this works

```
./compile.sh docker \
  BOARD=rock64\  
  BRANCH=default\
  KERNEL_ONLY=no\     
  KERNEL_CONFIGURE=no\
  RELEASE=stretch\ 
  BUILD_DESKTOP=no\
  EXPERT=yes \           
  LIB_TAG="development"\ 
```
