### PR TITLE
Orange Pi One: Enable ethernet interface for 4.17

### DIFF
--- a/patch/kernel/sunxi-dev/emac-orangepi-one-fix.patch
+++ b/patch/kernel/sunxi-dev/emac-orangepi-one-fix.patch
@@ -1,0 +1,12 @@
+diff --git a/arch/arm/boot/dts/sun8i-h3-orangepi-one.dts b/arch/arm/boot/dts/sun8i-h3-orangepi-one.dts
+index 3328fe5..232f124 100644
+--- a/arch/arm/boot/dts/sun8i-h3-orangepi-one.dts
++++ b/arch/arm/boot/dts/sun8i-h3-orangepi-one.dts
+@@ -117,6 +117,7 @@
+ 	phy-handle = <&int_mii_phy>;
+ 	phy-mode = "mii";
+ 	allwinner,leds-active-low;
++	status = "okay";
+ };
+ 
+ &hdmi {


### PR DESCRIPTION
This patch (re-)enables emac-support for the Orange Pi One
