### PR TITLE
removed obsolete config (e39757)

### DIFF
--- a/config/sources/udoo-neo.conf
+++ b/config/sources/udoo-neo.conf
@@ -50,8 +50,6 @@ write_uboot_platform()
 family_tweaks()
 {
 	sed 's/wlan0/wlan2/' -i $SDCARD/etc/network/interfaces.default
-	sed 's/wlan0/wlan2/' -i $SDCARD/etc/network/interfaces.bonding
-	sed 's/wlan0/wlan2/' -i $SDCARD/etc/network/interfaces.hostapd
 	if [[ $BOARD == udoo-neo ]]; then
 		# SD card is elsewhere
 		sed 's/mmcblk0p1/mmcblk1p1/' -i $SDCARD/etc/fstab

--- a/config/sources/udoo.conf
+++ b/config/sources/udoo.conf
@@ -58,8 +58,6 @@ write_uboot_platform()
 family_tweaks()
 {
 	sed 's/wlan0/wlan2/' -i $SDCARD/etc/network/interfaces.default
-	sed 's/wlan0/wlan2/' -i $SDCARD/etc/network/interfaces.bonding
-	sed 's/wlan0/wlan2/' -i $SDCARD/etc/network/interfaces.hostapd
 	if [[ $BOARD == udoo-neo ]]; then
 		# SD card is elsewhere
 		sed 's/mmcblk0p1/mmcblk1p1/' -i $SDCARD/etc/fstab


### PR DESCRIPTION
With https://github.com/armbian/build/commit/e39757e142c8f510a0b013aba33a8555075ddf16 interfaces.bonding & interfaces.hostapd got obsolete, therefore this should be removed from the config (same count's IMO for the master branch).

chwe