### PR TITLE
Sunvell R69: Remove deprecated sections from board config file (CSC)

### DIFF
--- a/config/boards/sunvell-r69.csc
+++ b/config/boards/sunvell-r69.csc
@@ -14,11 +14,5 @@ KERNEL_TARGET="default,next,dev"
 CLI_TARGET="stretch,xenial:next"
 DESKTOP_TARGET="stretch:next"
 #
-CLI_BETA_TARGET=""
+CLI_BETA_TARGET="bionic:dev"
 DESKTOP_BETA_TARGET=""
-#
-BOARDRATING=""
-CHIP="http://docs.armbian.com/Hardware_Allwinner-H3/"
-HARDWARE="http://linux-sunxi.org/Sunvell_R69"
-FORUMS="http://forum.armbian.com/index.php/forum/13-allwinner-h3/"
-


### PR DESCRIPTION
Deprecated and unused meta-info removed. 
bionic:dev added as server beta image in line with supported boards.

