### PR TITLE
Support eMMC boot on HummingBoard2

### DIFF
--- a/patch/u-boot/u-boot-cubox-next/U-Boot-mx6cuboxi-support-for-emmc-boot.patch
+++ b/patch/u-boot/u-boot-cubox-next/U-Boot-mx6cuboxi-support-for-emmc-boot.patch
@@ -1,0 +1,123 @@
+--- a/board/solidrun/mx6cuboxi/mx6cuboxi.c
++++ b/board/solidrun/mx6cuboxi/mx6cuboxi.c
+@@ -78,6 +78,20 @@
+ 	IOMUX_PADS(PAD_SD2_DAT3__SD2_DATA3	| MUX_PAD_CTRL(USDHC_PAD_CTRL)),
+ };
+ 
++static iomux_v3_cfg_t const usdhc3_pads[] = {
++        IOMUX_PADS(PAD_SD3_CLK__SD3_CLK     | MUX_PAD_CTRL(USDHC_PAD_CTRL)),
++        IOMUX_PADS(PAD_SD3_CMD__SD3_CMD     | MUX_PAD_CTRL(USDHC_PAD_CTRL)),
++        IOMUX_PADS(PAD_SD3_DAT0__SD3_DATA0   | MUX_PAD_CTRL(USDHC_PAD_CTRL)),
++        IOMUX_PADS(PAD_SD3_DAT1__SD3_DATA1   | MUX_PAD_CTRL(USDHC_PAD_CTRL)),
++        IOMUX_PADS(PAD_SD3_DAT2__SD3_DATA2   | MUX_PAD_CTRL(USDHC_PAD_CTRL)),
++        IOMUX_PADS(PAD_SD3_DAT3__SD3_DATA3   | MUX_PAD_CTRL(USDHC_PAD_CTRL)),
++        IOMUX_PADS(PAD_SD3_DAT4__SD3_DATA4   | MUX_PAD_CTRL(USDHC_PAD_CTRL)),
++        IOMUX_PADS(PAD_SD3_DAT5__SD3_DATA5   | MUX_PAD_CTRL(USDHC_PAD_CTRL)),
++        IOMUX_PADS(PAD_SD3_DAT6__SD3_DATA6   | MUX_PAD_CTRL(USDHC_PAD_CTRL)),
++        IOMUX_PADS(PAD_SD3_DAT7__SD3_DATA7   | MUX_PAD_CTRL(USDHC_PAD_CTRL)),
++        IOMUX_PADS(PAD_SD3_RST__SD3_RESET     | MUX_PAD_CTRL(USDHC_PAD_CTRL)),
++};
++
+ static iomux_v3_cfg_t const hb_cbi_sense[] = {
+ 	/* These pins are for sensing if it is a CuBox-i, HummingBoard(2) and SoM rev */
+ 	IOMUX_PADS(PAD_KEY_ROW1__GPIO4_IO09   | MUX_PAD_CTRL(UART_PAD_CTRL)),
+@@ -95,8 +109,9 @@
+ 	SETUP_IOMUX_PADS(uart1_pads);
+ }
+ 
+-static struct fsl_esdhc_cfg usdhc_cfg[1] = {
++static struct fsl_esdhc_cfg usdhc_cfg[2] = {
+ 	{USDHC2_BASE_ADDR},
++	{USDHC3_BASE_ADDR},
+ };
+ 
+ int board_mmc_getcd(struct mmc *mmc)
+@@ -104,14 +119,52 @@
+ 	return 1; /* uSDHC2 is always present */
+ }
+ 
++static bool is_hummingboard2(void)
++{
++	int val1;
++
++	SETUP_IOMUX_PADS(hb_cbi_sense);
++
++	gpio_direction_input(IMX_GPIO_NR(2, 8));
++
++        val1 = gpio_get_value(IMX_GPIO_NR(2, 8));
++
++	/*
++	 * Machine selection -
++	 * Machine        val1
++	 * -------------------
++	 * HB2            0
++	 * HB rev 3.x     x
++	 * CBi            x
++	 * HB             x
++	 */
++
++	if (val1 == 0)
++		return true;
++	else
++		return false;
++}
++
+ int board_mmc_init(bd_t *bis)
+ {
++	if (is_hummingboard2()) {
++		int ret;
++		
++		SETUP_IOMUX_PADS(usdhc3_pads);
++		usdhc_cfg[0].esdhc_base = USDHC3_BASE_ADDR;
++		usdhc_cfg[0].sdhc_clk = mxc_get_clock(MXC_ESDHC3_CLK);
++		usdhc_cfg[0].max_bus_width = 8;
++		ret = fsl_esdhc_initialize(bis, &usdhc_cfg[0]);
++		if (ret < 0)
++			puts("Warning: Couldn't init eMMC\n");
++	}
++
+ 	SETUP_IOMUX_PADS(usdhc2_pads);
+-	usdhc_cfg[0].esdhc_base = USDHC2_BASE_ADDR;
+-	usdhc_cfg[0].sdhc_clk = mxc_get_clock(MXC_ESDHC2_CLK);
+-	gd->arch.sdhc_clk = usdhc_cfg[0].sdhc_clk;
++	usdhc_cfg[1].esdhc_base = USDHC2_BASE_ADDR;
++	usdhc_cfg[1].sdhc_clk = mxc_get_clock(MXC_ESDHC2_CLK);
++	gd->arch.sdhc_clk = usdhc_cfg[1].sdhc_clk;
+ 
+-	return fsl_esdhc_initialize(bis, &usdhc_cfg[0]);
++	return fsl_esdhc_initialize(bis, &usdhc_cfg[1]);
+ }
+ 
+ static iomux_v3_cfg_t const enet_pads[] = {
+@@ -366,31 +419,6 @@
+ 		return true;
+ }
+ 
+-static bool is_hummingboard2(void)
+-{
+-	int val1;
+-
+-	SETUP_IOMUX_PADS(hb_cbi_sense);
+-
+-	gpio_direction_input(IMX_GPIO_NR(2, 8));
+-
+-        val1 = gpio_get_value(IMX_GPIO_NR(2, 8));
+-
+-	/*
+-	 * Machine selection -
+-	 * Machine        val1
+-	 * -------------------
+-	 * HB2            0
+-	 * HB rev 3.x     x
+-	 * CBi            x
+-	 * HB             x
+-	 */
+-
+-	if (val1 == 0)
+-		return true;
+-	else
+-		return false;
+-}
+ 
+ static bool is_som_rev15(void)
+ {


### PR DESCRIPTION
This add the patch to enable USDHC3 pads for eMMC boot on HummingBoard2, tested with eMMC and SD booting.

Cannot PR to development because it don't contain a previous patch 3d9ea39a680ba7665d7d579d0255ba78edfe5df7 required which provide HB2 detection function and other stuff