### PR TITLE
Possible issue with fping test

### DIFF
--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -148,7 +148,7 @@ ParseOptions() {
 		u)
 			# Upload /var/log/armhwinfo.log with additional support info
 			fping ix.io 2>/dev/null | grep -q alive || \
-				(echo -e "\nNetwork/firewall problem detected. Not able to upload debug info.\nPlease fix this or use \"-U\" instead and upload ${BOLD}whole output${NC} manually\n" >&2 ; exit 1)
+				{ echo -e "\nNetwork/firewall problem detected. Not able to upload debug info.\nPlease fix this or use \"-U\" instead and upload ${BOLD}whole output${NC} manually\n" >&2 ; exit 1; }
 			which curl >/dev/null 2>&1 || apt-get -f -qq -y install curl
 			echo -e "System diagnosis information will now be uploaded to \c"
 			# we obfuscate IPv4 addresses somehow but not too much, MAC addresses have to remain
@@ -172,7 +172,7 @@ ParseOptions() {
 		r|R)
 			# Installs RPi-Monitor and patches config on sun8i
 			fping armbian.com 2>/dev/null | grep -q alive || \
-				(echo "Network/firewall problem detected. Please fix this prior to installing RPi-Monitor." >&2 ; exit 1)
+				{ echo "Network/firewall problem detected. Please fix this prior to installing RPi-Monitor." >&2 ; exit 1; }
 			InstallRPiMonitor
 			case $(awk '/Hardware/ {print $3$4}' </proc/cpuinfo) in
 				*sun8i*)
@@ -192,7 +192,7 @@ ParseOptions() {
 			# Installs cpuminer on 32-bit platforms
 			dpkg --print-architecture | grep -q armhf || (echo -e "Functionality currently not supported on 64-bit platforms. Exiting\n" >&2 ; exit 1)
 			fping armbian.com 2>/dev/null | grep -q alive || \
-				(echo "Network/firewall problem detected. Please fix this prior to installing cpuminer." >&2 ; exit 1)
+				{ echo "Network/firewall problem detected. Please fix this prior to installing cpuminer." >&2 ; exit 1; }
 			cd /usr/local/src/
 			wget http://downloads.sourceforge.net/project/cpuminer/pooler-cpuminer-2.4.5.tar.gz
 			tar xf pooler-cpuminer-2.4.5.tar.gz && rm pooler-cpuminer-2.4.5.tar.gz


### PR DESCRIPTION
I was using the fping test in another script to check if a webcam was online, and realised that the exit 1 never fired and the script continued after reporting the camera non-responsive. Using braces instead of parenthesis for the command grouping, and adding the semi-colon seems to have resolved it. I don't have a test box handy with serial AND armbian so can't test it atm.
