### PR TITLE
Add onboard led support fo Orange Pi zero 2+

### DIFF
--- a/patch/kernel/sunxi-next/sun50i-h5-orangepi0+2-led-fix.patch
+++ b/patch/kernel/sunxi-next/sun50i-h5-orangepi0+2-led-fix.patch
@@ -1,0 +1,33 @@
+--- sun50i-h5-orangepi-zero-plus2.dts	2018-06-12 21:44:33.735864264 +0500
++++ sun50i-h5-orangepi0+2-led-fix.dts	2018-06-13 08:53:24.345843418 +0500
+@@ -72,6 +72,23 @@
+                 reset-gpios = <&pio 0 9 GPIO_ACTIVE_LOW>; /* PA9 */
+                 post-power-on-delay-ms = <50>;
+         };
++
++        leds {
++                compatible = "gpio-leds";
++
++                pwr {
++                        label = "orangepi:green:pwr";
++                        gpios = <&r_pio 0 10 GPIO_ACTIVE_HIGH>; /* PL10 */
++                        default-state = "on";
++                };
++
++                status {
++                        label = "orangepi:red:status";
++                        linux,default-trigger = "mmc0";
++                        gpios = <&pio 0 17 GPIO_ACTIVE_HIGH>; /* PA17 */
++			default-state = "on";
++                };
++        };
+ };
+ 
+ &mmc0 {
+@@ -186,4 +203,4 @@
+ 	 */
+ 	usb0_id_det-gpios = <&pio 6 12 GPIO_ACTIVE_HIGH>; /* PG12 */
+ 	status = "okay";
+-};
+\ No newline at end of file
++};


### PR DESCRIPTION
This patch enabling onboard leds:
green for power on
red for mmc0 activities