### PR TITLE
ODROID XU4: Improve IRQ detection regex

### DIFF
--- a/packages/bsp/common/etc/init.d/armhwinfo
+++ b/packages/bsp/common/etc/init.d/armhwinfo
@@ -126,9 +126,9 @@ prepare_board() {
 			echo 7 >/sys/class/net/eth0/queues/rx-0/rps_cpus
 			;;
 		odroidxu4) # ODROID XU3/XU4/HC1/MC1/HC2
-			echo 2 >/proc/irq/$(awk -F":" "/usb2/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
-			echo 4 >/proc/irq/$(awk -F":" "/usb3/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
-			echo 7 >/proc/irq/$(awk -F":" "/usb5/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity_list
+			echo 2 >/proc/irq/$(awk -F":" "/:usb2/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
+			echo 4 >/proc/irq/$(awk -F":" "/:usb3/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
+			echo 7 >/proc/irq/$(awk -F":" "/:usb5/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity_list
 			echo 16 >/proc/irq/$(awk -F":" "/dw-mci/ {print \$1}" </proc/interrupts | sed 's/\ //g' | tail -1)/smp_affinity
 			echo 32 >/proc/irq/$(awk -F":" "/dw-mci/ {print \$1}" </proc/interrupts | sed 's/\ //g' | head -1)/smp_affinity
 			for i in $(awk -F':' '/11800000.mali/{print $1}' </proc/interrupts | sed 's/\ //g'); do


### PR DESCRIPTION
Some kernels might have additional interrupts like ```extcon_usb3_0```. The previous regex matches this as well, so usb3 smp_affinity was never set correctly.
```
 80:       1465         54          0          0          0          0          0          0     GICv2 103 Edge      ehci_hcd:usb1, ohci_hcd:usb2
150:       3915          0     132611          0          0          0          0          0     GICv2 104 Edge      xhci-hcd:usb3
151:        334          0          0          0          0          0          0    7406300     GICv2 105 Edge      xhci-hcd:usb5
152:          0          0          0          0          0          0          0          0  exynos4210_wkup_irq_chip   5 Edge      extcon_usb3_0
153:          1          0          0          0          0          0          0          0  exynos4210_wkup_irq_chip   1 Edge      extcon_usb3_1
154:          0          0          0          0          0          0          0          0  exynos4210_wkup_irq_chip   4 Edge      extcon_usb3_1
```
_Note: The armbian kernel doesn't have these additional interrupts, but it can't hurt to improve it anyways ;)_