### PR TITLE
Change-load-address-for-boot.cmd

### DIFF
--- a/config/bootscripts/boot-rk3328.cmd
+++ b/config/bootscripts/boot-rk3328.cmd
@@ -3,7 +3,7 @@
 # Please edit /boot/armbianEnv.txt to set supported parameters
 #
 
-setenv load_addr "0x44000000"
+setenv load_addr "0x39000000"
 setenv overlay_error "false"
 # default values
 setenv rootdev "/dev/mmcblk0p1"


### PR DESCRIPTION
Change load address for boot.cmd

Address 0x44000000 is not available for boards with 1Gb RAM, so it was causing a boot error as described here:
https://forum.armbian.com/topic/5771-rock64-nightly-image/?do=findComment&comment=53150

A lower address 0x39000000 works and doesn't seem to cause any other problem.
I cannot test it in boards with more than 1Gb RAM so, even though I see no reason why it should not be compatible, it is safer to test just in case.

