### PR TITLE
Update nanopi-duo and sunvell-r69 board add to 4.18

### DIFF
--- a/patch/kernel/sunxi-dev/board-nanopi-duo-add-device.patch
+++ b/patch/kernel/sunxi-dev/board-nanopi-duo-add-device.patch
@@ -1,15 +1,15 @@
 diff --git a/arch/arm/boot/dts/Makefile b/arch/arm/boot/dts/Makefile
-index e3d5a6c..7cd0b4e 100644
+index 64b9c63..4fe104b 100644
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -992,6 +992,7 @@ dtb-$(CONFIG_MACH_SUN8I) += \
- 	sun8i-a83t-bananapi-m3.dtb \
- 	sun8i-a83t-cubietruck-plus.dtb \
+@@ -1008,6 +1008,7 @@ dtb-$(CONFIG_MACH_SUN8I) += \
  	sun8i-a83t-tbs-a711.dtb \
+ 	sun8i-h2-plus-bananapi-m2-zero.dtb \
+ 	sun8i-h2-plus-libretech-all-h3-cc.dtb \
 +	sun8i-h2-plus-nanopi-duo.dtb \
  	sun8i-h2-plus-orangepi-r1.dtb \
- 	sun8i-h2-plus-bananapi-m2-zero.dtb \
  	sun8i-h2-plus-orangepi-zero.dtb \
+ 	sun8i-h3-bananapi-m2-plus.dtb \
 diff --git a/arch/arm/boot/dts/sun8i-h2-plus-nanopi-duo.dts b/arch/arm/boot/dts/sun8i-h2-plus-nanopi-duo.dts
 new file mode 100644
 index 0000000..040f99f

--- a/patch/kernel/sunxi-dev/board-sunvell-r69-add-device.patch
+++ b/patch/kernel/sunxi-dev/board-sunvell-r69-add-device.patch
@@ -1,10 +1,10 @@
 diff --git a/arch/arm/boot/dts/Makefile b/arch/arm/boot/dts/Makefile
-index e3d5a6c..0d3eef6 100644
+index 4fe104b..47f4946 100644
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -995,6 +995,7 @@ dtb-$(CONFIG_MACH_SUN8I) += \
+@@ -1011,6 +1011,7 @@ dtb-$(CONFIG_MACH_SUN8I) += \
+ 	sun8i-h2-plus-nanopi-duo.dtb \
  	sun8i-h2-plus-orangepi-r1.dtb \
- 	sun8i-h2-plus-bananapi-m2-zero.dtb \
  	sun8i-h2-plus-orangepi-zero.dtb \
 +	sun8i-h2-plus-sunvell-r69.dtb \
  	sun8i-h3-bananapi-m2-plus.dtb \


### PR DESCRIPTION
update board-add patches to 4.18 for:
   nanopi-duo
   sunvell r69
Reason: both patches fail with 4.18 due to kernel-dts Makefile updates

