### PR TITLE
Modify rk3328-roc-cc.dts according to last Firefly

### DIFF
--- a/patch/kernel/rk3328-default/Add_dts_rk3328-roc-cc.patch
+++ b/patch/kernel/rk3328-default/Add_dts_rk3328-roc-cc.patch
@@ -329,10 +329,10 @@ index 0000000..59cae37
 +};
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts b/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts
 new file mode 100644
-index 0000000..ac747a6
+index 0000000..457359c
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts
-@@ -0,0 +1,833 @@
+@@ -0,0 +1,864 @@
 +/*
 + * Copyright (c) 2016 Fuzhou Rockchip Electronics Co., Ltd
 + *
@@ -392,6 +392,7 @@ index 0000000..ac747a6
 +		compatible = "rockchip,fiq-debugger";
 +		rockchip,serial-id = <2>;
 +		rockchip,signal-irq = <159>;
++		rockchip,wake-irq = <0>;
 +		/* If enable uart uses irq instead of fiq */
 +		rockchip,irq-mode-enable = <0>;
 +		rockchip,baudrate = <1500000>;  /* Only 115200 and 1500000 */
@@ -493,15 +494,36 @@ index 0000000..ac747a6
 +		regulator-type = "voltage";
 +		regulator-min-microvolt = <1800000>;
 +		regulator-max-microvolt = <3300000>;
++		status="disabled";
 +	};
-+	vcc5v0_host: vcc5v0-host-regulator {
++	vcc_host1_5v: vcc_otg_5v: vcc5v0-host-regulator {
 +		compatible = "regulator-fixed";
 +		enable-active-high;
 +		gpio = <&gpio1 26 GPIO_ACTIVE_HIGH>;
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&host_vbus_drv>;
-+		regulator-name = "vcc5v0_host";
++		regulator-name = "vcc_host1_5v";
 +		regulator-always-on;
++	};
++
++	vcc_host_5v: vcc-host-5v-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio0 0 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&usb30_host_drv>;
++		regulator-name = "vcc_host_5v";
++		regulator-always-on;
++		vin-supply = <&vcc_sys>;
++	};
++
++	vcc_sys: vcc-sys {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
 +	};
 +
 +	wireless-wlan {
@@ -572,14 +594,14 @@ index 0000000..ac747a6
 +
 +	system-status-freq = <
 +		/*system status         freq(KHz)*/
-+		SYS_STATUS_NORMAL       1066000
-+		SYS_STATUS_REBOOT       1066000
-+		SYS_STATUS_SUSPEND      1066000
-+		SYS_STATUS_VIDEO_1080P  1066000
-+		SYS_STATUS_VIDEO_4K     1066000
-+		SYS_STATUS_VIDEO_4K_10B 1066000
-+		SYS_STATUS_PERFORMANCE  1066000
-+		SYS_STATUS_BOOST        1066000
++		SYS_STATUS_NORMAL       1024000
++		SYS_STATUS_REBOOT       1024000
++		SYS_STATUS_SUSPEND      1024000
++		SYS_STATUS_VIDEO_1080P  1024000
++		SYS_STATUS_VIDEO_4K     1024000
++		SYS_STATUS_VIDEO_4K_10B 1024000
++		SYS_STATUS_PERFORMANCE  1024000
++		SYS_STATUS_BOOST        1024000
 +	>;
 +};
 +
@@ -604,8 +626,8 @@ index 0000000..ac747a6
 +		opp-microvolt-L0 = <1150000>;
 +		opp-microvolt-L1 = <1100000>;
 +	};
-+	opp-1066000000 {
-+		opp-hz = /bits/ 64 <1066000000>;
++	opp-1024000000 {
++		opp-hz = /bits/ 64 <1024000000>;
 +		opp-microvolt = <1200000>;
 +		opp-microvolt-L0 = <1200000>;
 +		opp-microvolt-L1 = <1175000>;
@@ -704,13 +726,14 @@ index 0000000..ac747a6
 +	clock_in_out = "input";
 +	snps,reset-gpio = <&gpio1 RK_PC2 GPIO_ACTIVE_LOW>;
 +	snps,reset-active-low;
++	snps,force_thresh_dma_mode;
 +	snps,reset-delays-us = <0 10000 50000>;
 +	assigned-clocks = <&cru SCLK_MAC2IO>, <&cru SCLK_MAC2IO_EXT>;
 +	assigned-clock-parents = <&gmac_clkin>, <&gmac_clkin>;
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&rgmiim1_pins>;
-+	tx_delay = <0x25>;
-+	rx_delay = <0x11>;
++	tx_delay = <0x28>;
++	rx_delay = <0x16>;
 +	status = "okay";
 +};
 +
@@ -932,7 +955,8 @@ index 0000000..ac747a6
 +
 +	vccio1-supply = <&vcc_io>;
 +	vccio2-supply = <&vcc_18emmc>;
-+	vccio3-supply = <&vccio_sd>;
++	//vccio3-supply = <&vccio_sd>;
++	vccio3-supply = <&vcc_io>;
 +	vccio4-supply = <&vdd_18>;
 +	vccio5-supply = <&vcc_io>;
 +	vccio6-supply = <&vcc_io>;
@@ -958,6 +982,12 @@ index 0000000..ac747a6
 +		host_vbus_drv: host-vbus-drv {
 +		rockchip,pins =
 +			<1 26 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	usb3 {
++		usb30_host_drv: usb30-host-drv {
++			rockchip,pins = <0 0 RK_FUNC_GPIO &pcfg_pull_none>;
 +		};
 +	};
 +
@@ -996,9 +1026,9 @@ index 0000000..ac747a6
 +	bus-width = <4>;
 +	cap-mmc-highspeed;
 +	cap-sd-highspeed;
-+	sd-uhs-sdr104;
++	//sd-uhs-sdr104;
 +	disable-wp;
-+	clock-freq-min-max = <400000 150000000>;
++	clock-freq-min-max = <400000 80000000>;
 +	clocks = <&cru HCLK_SDMMC>, <&cru SCLK_SDMMC>,
 +			 <&cru SCLK_SDMMC_DRV>, <&cru SCLK_SDMMC_SAMPLE>;
 +	clock-names = "biu", "ciu", "ciu-drive", "ciu-sample";
@@ -1008,7 +1038,7 @@ index 0000000..ac747a6
 +	supports-sd;
 +	status = "okay";
 +	vmmc-supply = <&vcc_sd>;
-+	vqmmc-supply = <&vccio_sd>;
++	//vqmmc-supply = <&vccio_sd>;
 +};
 +
 +&spdif {
@@ -1021,20 +1051,21 @@ index 0000000..ac747a6
 +};
 +
 +&u2phy {
-+	otg-vbus-gpios = <&gpio0 RK_PD3 GPIO_ACTIVE_HIGH>;
-+	status = "okay";
++    status = "okay";
 +
-+	u2phy_host: host-port {
-+		status = "okay";
-+	};
++    u2phy_host: host-port {
++        phy-supply = <&vcc_otg_5v>;
++        status = "okay";
++    };
 +
-+	u2phy_otg: otg-port {
-+		status = "okay";
-+	};
++    u2phy_otg: otg-port {
++        phy-supply = <&vcc_host1_5v>;
++        status = "okay";
++    };
 +};
 +
 +&u3phy {
-+	vbus-drv-gpios = <&gpio0 RK_PA0 GPIO_ACTIVE_HIGH>;
++    phy-supply = <&vcc_host_5v>;
 +	status = "okay";
 +};
 +


### PR DESCRIPTION
With the former dts, board failed to initialize sd card, and was unable to boot. Using the dtb from firefly's default kernel fixes the issue.