### PR TITLE
Updated DTS for z28pro

### DIFF
--- a/patch/kernel/rk3328-default/z28pro_8822bs.patch
+++ b/patch/kernel/rk3328-default/z28pro_8822bs.patch
@@ -1,8 +1,8 @@
 diff --git a/arch/arm64/boot/dts/rockchip/Makefile b/arch/arm64/boot/dts/rockchip/Makefile
-index f610d40..8f70f90 100644
+index 92981d8..1dbe50c 100644
 --- a/arch/arm64/boot/dts/rockchip/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/Makefile
-@@ -11,6 +11,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-evb.dtb
+@@ -17,6 +17,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-evb.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-evb-android.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-rock64.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-rock64-android.dtb
@@ -12,10 +12,10 @@ index f610d40..8f70f90 100644
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3368-evb-act8846.dtb
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328-z28pro.dts b/arch/arm64/boot/dts/rockchip/rk3328-z28pro.dts
 new file mode 100644
-index 0000000..f7e45a5
+index 0000000..7b82b78
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-z28pro.dts
-@@ -0,0 +1,801 @@
+@@ -0,0 +1,779 @@
 +/*
 + * Copyright (c) 2016 Fuzhou Rockchip Electronics Co., Ltd
 + *
@@ -74,21 +74,17 @@ index 0000000..f7e45a5
 +		compatible = "gpio-leds";
 +
 +		standby-led {
-+			linux,default-trigger = "disk-activity";
++			linux,default-trigger = "heartbeat";
 +			gpios = <&rk805 0 GPIO_ACTIVE_LOW>;
 +			default-state = "on";
 +		};
 +
 +		power-led {
++			linux,default-trigger = "mmc0";
 +			gpios = <&rk805 1 GPIO_ACTIVE_LOW>;
 +			default-state = "on";
 +		};
 +
-+		ir {
-+			linux,default-trigger = "ir";
-+			default-state = "off";
-+			mode = <0x0>;
-+		};
 +	};
 +
 +	gmac_clkin: external-gmac-clock {
@@ -148,11 +144,6 @@ index 0000000..f7e45a5
 +		#sound-dai-cells = <0>;
 +	};
 +
-+	dummy_codec: dummy-codec {
-+		compatible = "rockchip,dummy-codec";
-+		status = "disabled";
-+	};
-+
 +	vcc_phy: vcc-phy-regulator {
 +		compatible = "regulator-fixed";
 +		regulator-name = "vcc_phy";
@@ -176,9 +167,6 @@ index 0000000..f7e45a5
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&usb30_host_drv>;
 +		regulator-name = "vcc_host_5v";
-+		regulator-always-on;
-+		regulator-min-microvolt = <5000000>;
-+		regulator-max-microvolt = <5000000>;
 +		vin-supply = <&vcc_sys>;
 +	};
 +
@@ -189,33 +177,27 @@ index 0000000..f7e45a5
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&usb20_host_drv>;
 +		regulator-name = "vcc_host1_5v";
-+		regulator-always-on;
-+		regulator-min-microvolt = <5000000>;
-+		regulator-max-microvolt = <5000000>;
 +		vin-supply = <&vcc_sys>;
++	};
++
++	xin32k: xin32k {
++		compatible = "fixed-clock";
++		clock-frequency = <32768>;
++		clock-output-names = "xin32k";
++		#clock-cells = <0>;
 +	};
 +
 +
 +        vcc_sd: sdmmc-ext-regulator {
 +                compatible = "regulator-fixed";
-+                gpio = <&gpio2 RK_PA7 GPIO_ACTIVE_LOW>;
++                gpio = <&gpio2 RK_PA7 GPIO_ACTIVE_HIGH>;
 +                pinctrl-names = "default";
-+                pinctrl-0 = <&sdmmc0m1_gpio>;
++                pinctrl-0 = <&sdmmc0m0_gpio>;
 +                regulator-name = "vcc_sd";
 +                regulator-min-microvolt = <3300000>;
 +                regulator-max-microvolt = <3300000>;
 +                vin-supply = <&vcc_io>;
 +        };
-+
-+	vcc_sdio: sdmmc-regulator {
-+		compatible = "regulator-fixed";
-+		gpio = <&gpio0 RK_PD6 GPIO_ACTIVE_HIGH>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&sdmmc0m1_gpio>;
-+		regulator-name = "vcc_sdio";
-+		regulator-always-on;
-+		vin-supply = <&vcc_io>;
-+	};
 +
 +	ir-receiver {
 +		compatible = "gpio-ir-receiver";
@@ -229,12 +211,12 @@ index 0000000..f7e45a5
 +		compatible = "bluetooth-platdata";
 +		uart_rts_gpios = <&gpio1 RK_PB2 GPIO_ACTIVE_LOW>;
 +		pinctrl-names = "default", "rts_gpio";
-+		pinctrl-0 = <&uart0_rts>;
-+		pinctrl-1 = <&uart0_gpios>;
++		pinctrl-0 = <&uart2m1_xfer>;
++		pinctrl-1;
++		BT,wake_gpio;
 +		BT,power_gpio = <&gpio1 0x18 GPIO_ACTIVE_HIGH>;
 +		BT,wake_host_irq = <&gpio1 0x1a GPIO_ACTIVE_HIGH>;
-+		BT,wake_gpio;
-+		status = "okay";  /* not ready yet*/
++		status = "okay";  
 +	};
 +
 +	wireless-wlan {
@@ -242,7 +224,7 @@ index 0000000..f7e45a5
 +		rockchip,grf = <&grf>;
 +		wifi_chip_type = "rtl8822bs";
 +		WIFI,host_wake_irq = <&gpio1 RK_PA5 GPIO_ACTIVE_HIGH>;
-+		WIFI,poweren_gpio = <&gpio1 RK_PC2 GPIO_ACTIVE_HIGH>;
++		/*WIFI,poweren_gpio = <&gpio1 RK_PC2 GPIO_ACTIVE_HIGH>;*/
 +		status = "okay"; 
 +		sdio_vref = <1800>;
 +	};
@@ -307,9 +289,9 @@ index 0000000..f7e45a5
 +	phy-supply = <&vcc_phy>;
 +	phy-mode = "rgmii";
 +	clock_in_out = "input";
-+/*	snps,reset-gpio = <&gpio1 RK_PC2 GPIO_ACTIVE_LOW>;
++	snps,reset-gpio = <&gpio2 0x11 GPIO_ACTIVE_LOW>;
 +	snps,reset-active-low;
-+	snps,reset-delays-us = <0 10000 50000>;*/
++	snps,reset-delays-us = <0 10000 50000>;
 +	assigned-clocks = <&cru SCLK_MAC2IO>, <&cru SCLK_MAC2IO_EXT>;
 +	assigned-clock-parents = <&gmac_clkin>, <&gmac_clkin>;
 +	pinctrl-names = "default";
@@ -351,7 +333,7 @@ index 0000000..f7e45a5
 +		gpio-controller;
 +		#gpio-cells = <2>;
 +		#clock-cells = <1>;
-+		clock-output-names = "xin32k", "rk805-clkout2";
++		clock-output-names = "rk805-clkout1", "rk805-clkout2";
 +
 +		vcc1-supply = <&vcc_sys>;
 +		vcc2-supply = <&vcc_sys>;
@@ -362,7 +344,7 @@ index 0000000..f7e45a5
 +		
 +
 +		rtc {
-+			status = "disabled";
++			status = "okay";
 +		};
 +
 +		pwrkey {
@@ -379,7 +361,7 @@ index 0000000..f7e45a5
 +			#address-cells = <1>;
 +			#size-cells = <0>;
 +
-+			vdd_logic: RK805_DCDC1@0 {
++			vdd_logic: RK805_DCDC1 {
 +				regulator-compatible = "RK805_DCDC1";
 +				regulator-name = "vdd_logic";
 +				regulator-min-microvolt = <712500>;
@@ -395,7 +377,7 @@ index 0000000..f7e45a5
 +				};
 +			};
 +
-+			vdd_arm: RK805_DCDC2@1 {
++			vdd_arm: RK805_DCDC2 {
 +				regulator-compatible = "RK805_DCDC2";
 +				regulator-name = "vdd_arm";
 +				regulator-min-microvolt = <712500>;
@@ -411,7 +393,7 @@ index 0000000..f7e45a5
 +				};
 +			};
 +
-+			vcc_ddr: RK805_DCDC3@2 {
++			vcc_ddr: RK805_DCDC3 {
 +				regulator-compatible = "RK805_DCDC3";
 +				regulator-name = "vcc_ddr";
 +				regulator-initial-mode = <0x1>;
@@ -423,7 +405,7 @@ index 0000000..f7e45a5
 +				};
 +			};
 +
-+			vcc_io: RK805_DCDC4@3 {
++			vcc_io: RK805_DCDC4 {
 +				regulator-compatible = "RK805_DCDC4";
 +				regulator-name = "vcc_io";
 +				regulator-min-microvolt = <3300000>;
@@ -438,7 +420,7 @@ index 0000000..f7e45a5
 +				};
 +			};
 +
-+			vdd_18: RK805_LDO1@4 {
++			vdd_18: RK805_LDO1 {
 +				regulator-compatible = "RK805_LDO1";
 +				regulator-name = "vdd_18";
 +				regulator-min-microvolt = <1800000>;
@@ -451,7 +433,7 @@ index 0000000..f7e45a5
 +				};
 +			};
 +
-+			vcc_18emmc: RK805_LDO2@5 {
++			vcc_18emmc: RK805_LDO2 {
 +				regulator-compatible = "RK805_LDO2";
 +				regulator-name = "vcc_18emmc";
 +				regulator-min-microvolt = <1800000>;
@@ -464,7 +446,7 @@ index 0000000..f7e45a5
 +				};
 +			};
 +
-+			vdd_11: RK805_LDO3@6 {
++			vdd_11: RK805_LDO3 {
 +				regulator-compatible = "RK805_LDO3";
 +				regulator-name = "vdd_11";
 +				regulator-min-microvolt = <1100000>;
@@ -509,6 +491,10 @@ index 0000000..f7e45a5
 +};
 +
 +&pinctrl {
++	
++	pinctrl-names = "default";
++	pinctrl-0 = <&clk_32k_out>;
++	
 +	pmic {
 +		pmic_int_l: pmic-int-l {
 +		rockchip,pins =
@@ -546,13 +532,6 @@ index 0000000..f7e45a5
 +			rockchip,pins = <2 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
 +		};
 +	};
-+
-+	wireless-bluetooth {
-+		uart0_gpios: uart0-gpios {
-+			rockchip,pins = <1 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+	
 +};
 +
 +&rga {
@@ -680,8 +659,8 @@ index 0000000..f7e45a5
 +        num-slots = <1>;
 +        pinctrl-names = "default";
 +        pinctrl-0 = <&sdmmc0_bus4 &sdmmc0_cmd &sdmmc0_clk>;
-+	vmmc-supply = <&vcc_sdio>;
-+	vqmmc-supply = <&vdd_18>;
++	/*vmmc-supply = <&vcc_sdio>;
++	vqmmc-supply = <&vdd_18>;*/
 +	status = "okay";
 +};
 +
@@ -707,6 +686,9 @@ index 0000000..f7e45a5
 +	card-detect-delay = <0x320>;
 +	vmmc-supply = <&vcc_sd>;
 +	vqmmc-supply = <&vcc_sd>;
++        ignore-pm-notify;
++        keep-power-in-suspend;
++        power-inverted;
 +        };
 +
 +&spdif {
@@ -735,14 +717,10 @@ index 0000000..f7e45a5
 +	status = "okay";
 +};
 +
-+&uart0 {
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&uart0_xfer &uart0_cts>;
-+	status = "disabled";   /* not ready yet*/
-+};
 +
 +&uart2 {
 +	status = "okay";
++	dma-names = "tx", "rx";
 +};
 +
 +&u2phy {


### PR DESCRIPTION
Updated DTS including:

1. Removed some bogus.
2. Enabled RTC.
3. Changes snps,reset-gpio for /ethernet@ff540000 according to the reset-gpio in the corresponding DTS-node of the Android-vendor-image. This might be wrong, but it does not obviously break anything and when I use the GPIO-pin from the rock64-DTS the WLAN-card turns off.
4. -changed some settings in the wireless- and bluetooth-section as seen in the Android-vendor-image. I'm aware of the error regarding pin-64 due to the claiming-conflict between serial 2 and wireless-bluetooth, but I still have some fundamental lack of understanding, how RFKILL expects the things to be set up.


Side notes:
Reboot and the raw HID events driver work now, which should be unrelated to the DTS-changes.

ATM the external SD-card is lost, which surely is not a problem of the DTS. You can check, if you change to the latest linux kernel from ayufan (branch:release-4.4 - tested today) and then build with deactivating MIDGARD in the device-driver-section of the kernel config, because to my knowledge that is the only current reason, why we use the older kernel version (....0.6.45) in Armbian due to the compiling errors. But that is another cup of tea.

Please consider the WLAN-driver as unstable. 

GBit-Lan shows the same problems as on all other platforms and kernel versions, which seems to be a never-ending story :(

Things to do:
I will try to activate Bluetooth, which accidentally appeared (not worked!!) once, but this will require changes to the software stack, because wether btrtl.c nor rtk_hciattach contain code for the rtl8822bs (at kernel version 4.4.138!), but this second step seems to be manageable.

