### PR TITLE
ASUS Tinkerboard: Added gpio & i2c groups with udev rules to devices

### DIFF
--- a/config/sources/rockchip.conf
+++ b/config/sources/rockchip.conf
@@ -82,10 +82,18 @@ family_tweaks_bsp()
 		cp $SRC/packages/bsp/rockchip/60-media.rules $destination/etc/udev/rules.d
 		cp $SRC/packages/bsp/rockchip/pulseaudio.txt $destination/usr/local/bin
 		install -m 755 $SRC/packages/bsp/rockchip/hdmi-hotplug $destination/usr/local/bin
+
+		# Peripheral access for specific groups
+		addgroup --system --quiet --gid 997 gpio
+		addgroup --system --quiet --gid 998 i2c
+		cp $SRC/packages/bsp/rockchip/70-gpio.rules $destination/etc/udev/rules.d
+		cp $SRC/packages/bsp/rockchip/71-i2c.rules $destination/etc/udev/rules.d
+
 		# Bluetooth
 		install -m 755 $SRC/packages/bsp/rockchip/rtk_hciattach $destination/usr/bin
 		install -m 755 $SRC/packages/bsp/rockchip/start_bt.sh $destination/usr/local/bin
 		cp $SRC/packages/bsp/rockchip/tinker-bluetooth.service $destination/lib/systemd/system/
+
 		# Sound
 		cp $SRC/packages/bsp/rockchip/asound.conf $destination/etc/
 }

--- a/packages/bsp/rockchip/70-gpio.rules
+++ b/packages/bsp/rockchip/70-gpio.rules
@@ -1,2 +1,9 @@
 # Allow group gpio to access gpiomem device
 SUBSYSTEM=="rk3288-gpiomem", GROUP="gpio", MODE="0660"
+
+# To allow additional features like edge detection
+SUBSYSTEM=="gpio*", PROGRAM="/bin/sh -c '\
+  chown -R root:gpio /sys/class/gpio && chmod -R 770 /sys/class/gpio;\
+  chown -R root:gpio /sys/devices/virtual/gpio && chmod -R 770 /sys/devices/virtual/gpio;\
+  chown -R root:gpio /sys$devpath && chmod -R 770 /sys$devpath\
+'"

--- a/packages/bsp/rockchip/70-gpio.rules
+++ b/packages/bsp/rockchip/70-gpio.rules
@@ -1,0 +1,2 @@
+# Allow group gpio to access gpiomem device
+SUBSYSTEM=="rk3288-gpiomem", GROUP="gpio", MODE="0660"

--- a/packages/bsp/rockchip/71-i2c.rules
+++ b/packages/bsp/rockchip/71-i2c.rules
@@ -1,0 +1,2 @@
+# Allow i2c group to access i2c devices
+SUBSYSTEM=="i2c-dev", GROUP="i2c", MODE="0660"

--- a/patch/kernel/rockchip-default/261_gpiomem_driver.patch
+++ b/patch/kernel/rockchip-default/261_gpiomem_driver.patch
@@ -228,7 +228,7 @@ index 0000000..984471c
 +
 +static int rk3288_gpiomem_dev_uevent(struct device *dev, struct kobj_uevent_env *env)
 +{
-+    add_uevent_var(env, "DEVMODE=%#o", 0666);
++    add_uevent_var(env, "DEVMODE=%#o", 0660);
 +    return 0;
 +}
 +

--- a/patch/kernel/rockchip-next/261_gpiomem_driver.patch
+++ b/patch/kernel/rockchip-next/261_gpiomem_driver.patch
@@ -227,7 +227,7 @@ index 0000000..c289041
 +
 +static int rk3288_gpiomem_dev_uevent(struct device *dev, struct kobj_uevent_env *env)
 +{
-+    add_uevent_var(env, "DEVMODE=%#o", 0666);
++    add_uevent_var(env, "DEVMODE=%#o", 0660);
 +    return 0;
 +}
 +


### PR DESCRIPTION
Simple change to add some restrictions & usability to the gpiomem & i2c devices.

Probably it will be better to put groups gpio & i2c to some general groups creation and leave udev rules per board, but I didn't find a place for such groups.