### PR TITLE
add H5 support for optional 1.3v regulator and 1.3GHz operation

### DIFF
--- a/patch/kernel/sunxi-next/sunxi-h5-add-gpio-regulator-overclock.patch
+++ b/patch/kernel/sunxi-next/sunxi-h5-add-gpio-regulator-overclock.patch
@@ -1,0 +1,103 @@
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/Makefile b/arch/arm64/boot/dts/allwinner/overlay/Makefile
+index 379d852..2ace5f9 100644
+--- a/arch/arm64/boot/dts/allwinner/overlay/Makefile
++++ b/arch/arm64/boot/dts/allwinner/overlay/Makefile
+@@ -12,6 +12,8 @@ dtbo-$(CONFIG_ARCH_SUNXI) += \
+ 	sun50i-a64-w1-gpio.dtbo \
+ 	sun50i-h5-analog-codec.dtbo \
+ 	sun50i-h5-cir.dtbo \
++	sun50i-h5-cpu-clock-1.3GHz.dtbo \
++	sun50i-h5-gpio-regulator-1.3v.dtbo \
+ 	sun50i-h5-i2c0.dtbo \
+ 	sun50i-h5-i2c1.dtbo \
+ 	sun50i-h5-i2c2.dtbo \
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-cpu-clock-1.3GHz.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-cpu-clock-1.3GHz.dts
+new file mode 100644
+index 0000000..4ab2633
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-cpu-clock-1.3GHz.dts
+@@ -0,0 +1,40 @@
++// DT overlay for operating points to 1.3GHz
++
++/dts-v1/;
++/plugin/;
++
++/ {
++	fragment@0 {
++		target = <&cpu_opp_table>;
++
++		__overlay__ {
++			compatible = "operating-points-v2";
++			opp-shared;
++
++			// in order to match the H5 DT cooling-maps, replace the latter
++			// part of the OP table with the new frequencies...
++
++			// override the "1.056GHz" opp definition with the 1.104GHz clock definition
++			opp@1056000000 {
++				opp-hz = /bits/ 64 <1104000000>;
++				opp-microvolt = <1300000 1300000 1300000>;
++				clock-latency-ns = <244144>; /* 8 32k periods */
++			};
++
++			// override the "1.104GHz" opp definition with the 1.200GHz clock definition
++			opp@1104000000 {
++                                opp-hz = /bits/ 64 <1200000000>;
++                                opp-microvolt = <1300000 1300000 1300000>;
++                                clock-latency-ns = <244144>; /* 8 32k periods */
++                        };
++
++			// override the "1.152GHz" opp definition with the 1.296GHz clock definition
++			opp@1152000000 {
++				opp-hz = /bits/ 64 <1296000000>;
++				opp-microvolt = <1300000 1300000 1300000>;
++				clock-latency-ns = <244144>; /* 8 32k periods */
++			};
++		};
++	};
++};
++
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-gpio-regulator-1.3v.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-gpio-regulator-1.3v.dts
+new file mode 100644
+index 0000000..8d2755c
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-gpio-regulator-1.3v.dts
+@@ -0,0 +1,38 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "allwinner,sun50i-h5";
++
++	fragment@0 {
++		target-path = "/";
++
++		__overlay__ {
++			reg_vdd_cpux: gpio-regulator {
++				compatible = "regulator-gpio";
++				regulator-name = "vdd-cpux";
++				regulator-type = "voltage";
++				regulator-boot-on;
++				regulator-always-on;
++				regulator-min-microvolt = <1100000>;
++				regulator-max-microvolt = <1300000>;
++				regulator-ramp-delay = <50>; /* 4ms */
++
++				gpios = <&r_pio 0 6 0>; /* PL6 */
++				enable-active-high;
++				gpios-states = <0x1>;
++				states = <1100000 0x0
++					  1300000 0x1>;
++			};
++		};
++	};
++
++	fragment@1 {
++		target = <&cpu0>;
++
++		__overlay__ {
++			cpu-supply = <&reg_vdd_cpux>;
++		};
++	};
++};
++


### PR DESCRIPTION
This patch adds two optional overlays that can be used to:

1) enable the 1.1v/1.3v regulator on boards that provide the necessary compatible H/W support
2) modify the default CPU clock operating table to add new 1.2GHz and 1.3GHz clocks

Note that the generated regulator overlay will only support boards whose 1.1v/1.3v regulator
is controlled by GPIO PL6.

I have tested this new support on the sunxi-4.18 branch (current 4.17.6-sunxi64 kernel) using both a Nano Pi Neo Plus2 as well as a Orange Pi Zero Plus2 (with MOSFET modification to enable access to the GPIO voltage regulator on PL6).  If only the regulator overlay is enabled, then the maximum CPU clock is 1.152GHz (per the Armbian H5 DT configuration), and if both overlays are enabled, then the new CPU clocks are enabled (upper clock range provided is 1.0GHz, 1.1GHz, 1.2GHz, and 1.3GHz).
