### PR TITLE
updates for the NanoPi NEO Plus2

### DIFF
--- a/patch/kernel/sunxi-next/update-nanopi-neo-plus2-enable-regulator-fix-leds.patch
+++ b/patch/kernel/sunxi-next/update-nanopi-neo-plus2-enable-regulator-fix-leds.patch
@@ -1,0 +1,45 @@
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-neo-plus2.dts b/arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-neo-plus2.dts
+index 506e25b..bc42210 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-neo-plus2.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-neo-plus2.dts
+@@ -65,14 +65,15 @@
+ 		compatible = "gpio-leds";
+ 
+ 		pwr {
+-			label = "nanopi:green:pwr";
+-			gpios = <&r_pio 0 10 GPIO_ACTIVE_HIGH>;
+-			default-state = "on";
++			label = "nanopi:red:pwr";
++			gpios = <&r_pio 0 10 GPIO_ACTIVE_HIGH>; /* PL10 */
++			linux,default-trigger = "default-on";
+ 		};
+ 
+ 		status {
+-			label = "nanopi:red:status";
+-			gpios = <&pio 0 20 GPIO_ACTIVE_HIGH>;
++			label = "nanopi:green:status";
++			gpios = <&pio 0 10 GPIO_ACTIVE_HIGH>; /* PA10 */
++			linux,default-trigger = "heartbeat";
+ 		};
+ 	};
+ 
+@@ -104,7 +105,7 @@
+ 		regulator-min-microvolt = <1100000>;
+ 		regulator-max-microvolt = <1300000>;
+ 		regulator-ramp-delay = <50>; /* 4ms */
+-		gpios = <&r_pio 0 6 GPIO_ACTIVE_HIGH>;
++		gpios = <&r_pio 0 6 GPIO_ACTIVE_HIGH>; /* PL6 */
+ 		gpios-states = <0x1>;
+ 		states = <1100000 0x0
+ 			  1300000 0x1>;
+@@ -118,6 +119,10 @@
+ 	};
+ };
+ 
++&cpu0 {
++	cpu-supply = <&vdd_cpux>;
++};
++
+ &codec {
+ 	allwinner,audio-routing =
+ 		"Line Out", "LINEOUT",


### PR DESCRIPTION
This change introduces a patch that provides two changes for the NanoPi NEO Plus2:

* Configure the "cpu0" to use the "vdd_cpux" regulator; this enables the ability to use higher CPU clocks

* Correct the configurations of the on-board power and status LEDs

Note that the FriendlyELEC schematic for the NEO Plus2 (v1.0-1704) is actually incorrect in terms of the status LEDs.  The actual NEO Plus2 board has the red LED physically connected to GPIO PL10 (PWR-LED), and the green LED phyically connected to GPIO PA10 (STATUS-LED).  This physical wiring is consistent with other later-version NanoPi boards, such as the NEO2 v1.1-1711, and the NEO Core2 (v1.0-1707).  This patch configures the LEDs to be consistent with these other FriendlyELEC boards.

These changes were tested and verified on a NanoPi NEO Plus2 board running a full kernel build from the "sunxi-4.18" Armbian branch (kernel 4.17.6-sunxi64).
