### PR TITLE
add H5 support for optional 1.4GHz operation

### DIFF
--- a/patch/kernel/sunxi-next/sunxi-h5-add-gpio-regulator-overclock.patch
+++ b/patch/kernel/sunxi-next/sunxi-h5-add-gpio-regulator-overclock.patch
@@ -1,12 +1,13 @@
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/Makefile b/arch/arm64/boot/dts/allwinner/overlay/Makefile
-index 379d852..2ace5f9 100644
+index 4c945d8..2833b86 100644
 --- a/arch/arm64/boot/dts/allwinner/overlay/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/overlay/Makefile
-@@ -12,6 +12,8 @@ dtbo-$(CONFIG_ARCH_SUNXI) += \
+@@ -12,6 +12,9 @@ dtbo-$(CONFIG_ARCH_SUNXI) += \
  	sun50i-a64-w1-gpio.dtbo \
  	sun50i-h5-analog-codec.dtbo \
  	sun50i-h5-cir.dtbo \
 +	sun50i-h5-cpu-clock-1.3GHz.dtbo \
++	sun50i-h5-cpu-clock-1.4GHz.dtbo \
 +	sun50i-h5-gpio-regulator-1.3v.dtbo \
  	sun50i-h5-i2c0.dtbo \
  	sun50i-h5-i2c1.dtbo \
@@ -51,6 +52,68 @@ index 0000000..4ab2633
 +			opp@1152000000 {
 +				opp-hz = /bits/ 64 <1296000000>;
 +				opp-microvolt = <1300000 1300000 1300000>;
++				clock-latency-ns = <244144>; /* 8 32k periods */
++			};
++		};
++	};
++};
++
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-cpu-clock-1.4GHz.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-cpu-clock-1.4GHz.dts
+new file mode 100644
+index 0000000..6994432
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-cpu-clock-1.4GHz.dts
+@@ -0,0 +1,56 @@
++// DT overlay for operating points to 1.4GHz
++
++/dts-v1/;
++/plugin/;
++
++/ {
++	fragment@0 {
++		target = <&cpu_opp_table>;
++
++		__overlay__ {
++			compatible = "operating-points-v2";
++			opp-shared;
++
++			// in order to match the H5 DT cooling-maps, replace the latter
++			// part of the OP table with the new frequencies...
++
++			// override the "960MHz" opp definition with the 1.008GHz clock definition
++			opp@960000000 {
++				opp-hz = /bits/ 64 <1008000000>;
++				opp-microvolt = <1200000 1200000 1300000>;
++				clock-latency-ns = <244144>; /* 8 32k periods */
++			};
++
++
++			// override the "1.008GHz" opp definition with the 1.104GHz clock definition
++			opp@1008000000 {
++				opp-hz = /bits/ 64 <1104000000>;
++				opp-microvolt = <1240000 1240000 1400000>;
++				clock-latency-ns = <244144>; /* 8 32k periods */
++			};
++
++			// override the "1.056GHz" opp definition with the 1.200GHz clock definition
++			opp@1056000000 {
++				opp-hz = /bits/ 64 <1200000000>;
++				opp-microvolt = <1290000 1290000 1400000>;
++				clock-latency-ns = <244144>; /* 8 32k periods */
++			};
++
++
++			// override the "1.104GHz" opp definition with the 1.296GHz clock definition
++			opp@1104000000 {
++                                opp-hz = /bits/ 64 <1296000000>;
++                                opp-microvolt = <1340000 1340000 1400000>;
++                                clock-latency-ns = <244144>; /* 8 32k periods */
++                        };
++
++			// override the "1.152GHz" opp definition with the 1.392GHz clock definition
++			opp@1152000000 {
++				opp-hz = /bits/ 64 <1392000000>;
++				opp-microvolt = <1400000 1400000 1400000>;
 +				clock-latency-ns = <244144>; /* 8 32k periods */
 +			};
 +		};


### PR DESCRIPTION
This change introduces an optional overlay that can be used to modify
the default CPU clock operating table to support a maximum core clock
of 1.4GHz.  These higher clock rates will only be allowed if the
board's CPU VDD regulator can support operation at 1.4v (or greater),
e.g., SY8106A.

Tested 1.4GHz operation on a NanoPi NEO Core2 (including thermal throttling), and that the higher clocks are limited on an OrangePi Zero Plus2.