### PR TITLE
Espressobin/mvebu64 console is "/dev/ttyMV0", set SERIALCON accordingly

### DIFF
--- a/config/sources/mvebu64.conf
+++ b/config/sources/mvebu64.conf
@@ -48,6 +48,8 @@ CPUMIN=250000
 CPUMAX=1000000
 GOVERNOR=ondemand
 
+SERIALCON='ttyMV0'
+
 NM_IGNORE_DEVICES="interface-name:eth*,interface-name:wan*,interface-name:lan*,interface-name:br*"
 
 write_uboot_platform()


### PR DESCRIPTION
This is replacing pull request #1052, setting SERIALCON has been moved outside case as requested.

See [https://forum.armbian.com/topic/7687-espressobin-serial-getty-on-ttys0-spamming-syslog/](https://forum.armbian.com/topic/7687-espressobin-serial-getty-on-ttys0-spamming-syslog/): On Espressobin armbian is bringing up both `/dev/ttyMV0` and `/dev/ttyS0`:
```
[  OK  ] Found device /dev/ttyS0.
[  OK  ] Found device /dev/ttyMV0.
```

Espressobin only has `/dev/ttyMV0` and as a result systemd is constantly starting/stopping Serial Getty on ttyS0 which spams the log file `/var/log/sy﻿slo﻿g` and fills up the file system:
```
Jul 11 00:37:04 localhost systemd[1]: serial-getty@ttyS0.service: Service hold-off time over, scheduling restart.
Jul 11 00:37:04 localhost systemd[1]: Stopped Serial Getty on ttyS0.
Jul 11 00:37:04 localhost systemd[1]: Started Serial Getty on ttyS0.
Jul 11 00:37:14 localhost systemd[1]: serial-getty@ttyS0.service: Service hold-off time over, scheduling restart.
Jul 11 00:37:14 localhost systemd[1]: Stopped Serial Getty on ttyS0﻿.
Jul 11 00:37:14 localhost systemd[1]: Started Serial Getty on ttyS0.
Jul 11 00:37:25 localhost systemd[1]: serial-getty@ttyS0.service: Service hold-off time over, scheduling restart.
Jul 11 00:37:25 localhost systemd[1]: Stopped Serial Getty on ttyS0.
Jul 11 00:37:25 localhost systemd[1]: Started Serial Getty on ttyS0.
```

Setting `SERIALCON='ttyMV0'` in `mvebu64.conf` only brings up `/dev/ttyMV0` and resolves this issue. This has been tested on `ARMBIAN 5.52 user-built Debian GNU/Linux 9 (stretch) 4.17.8-mvebu64`.