### PR TITLE
change bootorder in u-boot for z28pro

### DIFF
--- a/patch/u-boot/u-boot-rk3328-default/board_z28pro/switch_bootorder_mmc0_mmc1.patch
+++ b/patch/u-boot/u-boot-rk3328-default/board_z28pro/switch_bootorder_mmc0_mmc1.patch
@@ -1,0 +1,15 @@
+diff --git a/include/configs/rockchip-common.h b/include/configs/rockchip-common.h
+index 1b00ef4..335b214 100644
+--- a/include/configs/rockchip-common.h
++++ b/include/configs/rockchip-common.h
+@@ -14,9 +14,9 @@
+ /* First try to boot from SD (index 0), then eMMC (index 1 */
+ #ifdef CONFIG_CMD_USB
+ #define BOOT_TARGET_DEVICES(func) \
+-	func(MMC, mmc, 0) \
+ 	func(MMC, mmc, 1) \
+ 	func(USB, usb, 0) \
++        func(MMC, mmc, 0) \
+ 	func(PXE, pxe, na) \
+ 	func(DHCP, dchp, na)
+ #else


### PR DESCRIPTION
The lack of real multi boot capability is IMO the biggest disadvantage of this TV-box (and a real PITA while developing).

At least at the stage of u-boot we can boot from external SD, but the default boot order does the opposite of its original intention. It prefers eMMC over SD. 
One place to change this, is the definition in rockchip-common.h. 
My initial attempts to ‚setenv boot_targets=„mmc1 usb0 mmc0“‘ in armbianEnv.txt  (and recompile this) were not successful.

So now we have „some-sort-of“ mulitboot and can for instance check new armbian builds on SD with less risk of pseudo-bricking the box (and avoiding the flashing procedure with maskrom mode and so on) without cumbersome keyboard actions on the serial console.