### PR TITLE
correct sunxi H3 DT overlays for latest kernel

### DIFF
--- a/patch/kernel/sunxi-next/general-sunxi-overlays.patch
+++ b/patch/kernel/sunxi-next/general-sunxi-overlays.patch
@@ -3829,8 +3829,8 @@ index 0000000..744889c
 +test "${tmp_bank}" = "G" && setenv tmp_bank 6'
 +
 +if test -n "${param_spinor_spi_bus}"; then
-+	test "${param_spinor_spi_bus}" = "0" && setenv tmp_spi_path "spi@01c68000"
-+	test "${param_spinor_spi_bus}" = "1" && setenv tmp_spi_path "spi@01c69000"
++	test "${param_spinor_spi_bus}" = "0" && setenv tmp_spi_path "spi@1c68000"
++	test "${param_spinor_spi_bus}" = "1" && setenv tmp_spi_path "spi@1c69000"
 +	fdt set /soc/${tmp_spi_path} status "okay"
 +	fdt set /soc/${tmp_spi_path}/spiflash status "okay"
 +	if test -n "${param_spinor_max_freq}"; then
@@ -3843,8 +3843,8 @@ index 0000000..744889c
 +fi
 +
 +if test -n "${param_spidev_spi_bus}"; then
-+	test "${param_spidev_spi_bus}" = "0" && setenv tmp_spi_path "spi@01c68000"
-+	test "${param_spidev_spi_bus}" = "1" && setenv tmp_spi_path "spi@01c69000"
++	test "${param_spidev_spi_bus}" = "0" && setenv tmp_spi_path "spi@1c68000"
++	test "${param_spidev_spi_bus}" = "1" && setenv tmp_spi_path "spi@1c69000"
 +	fdt set /soc/${tmp_spi_path} status "okay"
 +	fdt set /soc/${tmp_spi_path}/spidev status "okay"
 +	if test -n "${param_spidev_max_freq}"; then
@@ -3860,8 +3860,8 @@ index 0000000..744889c
 +	setenv tmp_bank "${param_pps_pin}"
 +	setenv tmp_pin "${param_pps_pin}"
 +	run decompose_pin
-+	fdt set /soc/pinctrl@01c20800/pps_pins pins "${param_pps_pin}"
-+	fdt get value tmp_phandle /soc/pinctrl@01c20800 phandle
++	fdt set /soc/pinctrl@1c20800/pps_pins pins "${param_pps_pin}"
++	fdt get value tmp_phandle /soc/pinctrl@1c20800 phandle
 +	fdt set /pps@0 gpios "<${tmp_phandle} ${tmp_bank} ${tmp_pin} 0>"
 +	env delete tmp_pin tmp_bank tmp_phandle
 +fi
@@ -3888,40 +3888,40 @@ index 0000000..744889c
 +	setenv tmp_bank "${param_w1_pin}"
 +	setenv tmp_pin "${param_w1_pin}"
 +	run decompose_pin
-+	fdt set /soc/pinctrl@01c20800/w1_pins pins "${param_w1_pin}"
-+	fdt get value tmp_phandle /soc/pinctrl@01c20800 phandle
++	fdt set /soc/pinctrl@1c20800/w1_pins pins "${param_w1_pin}"
++	fdt get value tmp_phandle /soc/pinctrl@1c20800 phandle
 +	fdt set /onewire@0 gpios "<${tmp_phandle} ${tmp_bank} ${tmp_pin} 0>"
 +	env delete tmp_pin tmp_bank tmp_phandle
 +fi
 +
 +if test "${param_w1_pin_int_pullup}" = "1"; then
-+	fdt set /soc/pinctrl@01c20800/w1_pins bias-pull-up
++	fdt set /soc/pinctrl@1c20800/w1_pins bias-pull-up
 +fi
 +
 +if test "${param_uart1_rtscts}" = "1"; then
-+	fdt get value tmp_phandle1 /soc/pinctrl@01c20800/uart1 phandle
-+	fdt get value tmp_phandle2 /soc/pinctrl@01c20800/uart1_rts_cts phandle
-+	fdt set /soc/serial@01c28400 pinctrl-names "default" "default"
-+	fdt set /soc/serial@01c28400 pinctrl-0 "<${tmp_phandle1}>"
-+	fdt set /soc/serial@01c28400 pinctrl-1 "<${tmp_phandle2}>"
++	fdt get value tmp_phandle1 /soc/pinctrl@1c20800/uart1 phandle
++	fdt get value tmp_phandle2 /soc/pinctrl@1c20800/uart1_rts_cts phandle
++	fdt set /soc/serial@1c28400 pinctrl-names "default" "default"
++	fdt set /soc/serial@1c28400 pinctrl-0 "<${tmp_phandle1}>"
++	fdt set /soc/serial@1c28400 pinctrl-1 "<${tmp_phandle2}>"
 +	env delete tmp_phandle1 tmp_phandle2
 +fi
 +
 +if test "${param_uart2_rtscts}" = "1"; then
-+	fdt get value tmp_phandle1 /soc/pinctrl@01c20800/uart2 phandle
-+	fdt get value tmp_phandle2 /soc/pinctrl@01c20800/uart2_rts_cts phandle
-+	fdt set /soc/serial@01c28800 pinctrl-names "default" "default"
-+	fdt set /soc/serial@01c28800 pinctrl-0 "<${tmp_phandle1}>"
-+	fdt set /soc/serial@01c28800 pinctrl-1 "<${tmp_phandle2}>"
++	fdt get value tmp_phandle1 /soc/pinctrl@1c20800/uart2 phandle
++	fdt get value tmp_phandle2 /soc/pinctrl@1c20800/uart2_rts_cts phandle
++	fdt set /soc/serial@1c28800 pinctrl-names "default" "default"
++	fdt set /soc/serial@1c28800 pinctrl-0 "<${tmp_phandle1}>"
++	fdt set /soc/serial@1c28800 pinctrl-1 "<${tmp_phandle2}>"
 +	env delete tmp_phandle1 tmp_phandle2
 +fi
 +
 +if test "${param_uart3_rtscts}" = "1"; then
-+	fdt get value tmp_phandle1 /soc/pinctrl@01c20800/uart3 phandle
-+	fdt get value tmp_phandle2 /soc/pinctrl@01c20800/uart3_rts_cts phandle
-+	fdt set /soc/serial@01c28c00 pinctrl-names "default" "default"
-+	fdt set /soc/serial@01c28c00 pinctrl-0 "<${tmp_phandle1}>"
-+	fdt set /soc/serial@01c28c00 pinctrl-1 "<${tmp_phandle2}>"
++	fdt get value tmp_phandle1 /soc/pinctrl@1c20800/uart3 phandle
++	fdt get value tmp_phandle2 /soc/pinctrl@1c20800/uart3_rts_cts phandle
++	fdt set /soc/serial@1c28c00 pinctrl-names "default" "default"
++	fdt set /soc/serial@1c28c00 pinctrl-0 "<${tmp_phandle1}>"
++	fdt set /soc/serial@1c28c00 pinctrl-1 "<${tmp_phandle2}>"
 +	env delete tmp_phandle1 tmp_phandle2
 +fi
 diff --git a/arch/arm/boot/dts/overlay/sun8i-h3-i2c0.dts b/arch/arm/boot/dts/overlay/sun8i-h3-i2c0.dts
@@ -3939,7 +3939,7 @@ index 0000000..b457ac7
 +	fragment@0 {
 +		target-path = "/aliases";
 +		__overlay__ {
-+			i2c0 = "/soc/i2c@01c2ac00";
++			i2c0 = "/soc/i2c@1c2ac00";
 +		};
 +	};
 +
@@ -3965,7 +3965,7 @@ index 0000000..fd0928a
 +	fragment@0 {
 +		target-path = "/aliases";
 +		__overlay__ {
-+			i2c1 = "/soc/i2c@01c2b000";
++			i2c1 = "/soc/i2c@1c2b000";
 +		};
 +	};
 +
@@ -3991,7 +3991,7 @@ index 0000000..25b75b7
 +	fragment@0 {
 +		target-path = "/aliases";
 +		__overlay__ {
-+			i2c2 = "/soc/i2c@01c2b400";
++			i2c2 = "/soc/i2c@1c2b400";
 +		};
 +	};
 +
@@ -4188,8 +4188,8 @@ index 0000000..ad22a71
 +	fragment@0 {
 +		target-path = "/aliases";
 +		__overlay__ {
-+			spi0 = "/soc/spi@01c68000";
-+			spi1 = "/soc/spi@01c69000";
++			spi0 = "/soc/spi@1c68000";
++			spi1 = "/soc/spi@1c69000";
 +		};
 +	};
 +
@@ -4236,8 +4236,8 @@ index 0000000..180979e
 +	fragment@0 {
 +		target-path = "/aliases";
 +		__overlay__ {
-+			spi0 = "/soc/spi@01c68000";
-+			spi1 = "/soc/spi@01c69000";
++			spi0 = "/soc/spi@1c68000";
++			spi1 = "/soc/spi@1c69000";
 +		};
 +	};
 +
@@ -4284,7 +4284,7 @@ index 0000000..8a4f7e4
 +	fragment@0 {
 +		target-path = "/aliases";
 +		__overlay__ {
-+			serial1 = "/soc/serial@01c28400";
++			serial1 = "/soc/serial@1c28400";
 +		};
 +	};
 +
@@ -4312,7 +4312,7 @@ index 0000000..499a1b4
 +	fragment@0 {
 +		target-path = "/aliases";
 +		__overlay__ {
-+			serial2 = "/soc/serial@01c28800";
++			serial2 = "/soc/serial@1c28800";
 +		};
 +	};
 +
@@ -4340,7 +4340,7 @@ index 0000000..b5734c5
 +	fragment@0 {
 +		target-path = "/aliases";
 +		__overlay__ {
-+			serial3 = "/soc/serial@01c28c00";
++			serial3 = "/soc/serial@1c28c00";
 +		};
 +	};
 +


### PR DESCRIPTION
In order to enable compatibility with the new 4.17.y kernel, this change removes the leading zeros from the unit addresses in the sun8i-h3-* DT overlays, and the sun8i-h3-fixup script has been updated as well.
