### PR TITLE
enable kernel MTD SPI flash configuration

### DIFF
--- a/config/kernel/linux-sunxi-next.config
+++ b/config/kernel/linux-sunxi-next.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 4.17.5 Kernel Configuration
+# Linux/arm 4.17.8 Kernel Configuration
 #
 CONFIG_ARM=y
 CONFIG_ARM_HAS_SG_CHAIN=y
@@ -1646,6 +1646,7 @@ CONFIG_MTD_CFI_I2=y
 # Self-contained MTD device drivers
 #
 # CONFIG_MTD_DATAFLASH is not set
+CONFIG_MTD_M25P80=y
 # CONFIG_MTD_MCHP23K256 is not set
 # CONFIG_MTD_SST25L is not set
 # CONFIG_MTD_SLRAM is not set
@@ -1683,7 +1684,16 @@ CONFIG_MTD_NAND_SUNXI=y
 #
 # CONFIG_MTD_LPDDR is not set
 # CONFIG_MTD_LPDDR2_NVM is not set
-# CONFIG_MTD_SPI_NOR is not set
+CONFIG_MTD_SPI_NOR=y
+# CONFIG_MTD_MT81xx_NOR is not set
+CONFIG_MTD_SPI_NOR_USE_4K_SECTORS=y
+# CONFIG_SPI_ASPEED_SMC is not set
+# CONFIG_SPI_ATMEL_QUADSPI is not set
+# CONFIG_SPI_CADENCE_QUADSPI is not set
+# CONFIG_SPI_FSL_QUADSPI is not set
+# CONFIG_SPI_HISI_SFC is not set
+# CONFIG_SPI_NXP_SPIFI is not set
+# CONFIG_SPI_STM32_QUADSPI is not set
 CONFIG_MTD_UBI=y
 CONFIG_MTD_UBI_WL_THRESHOLD=4096
 CONFIG_MTD_UBI_BEB_LIMIT=20


### PR DESCRIPTION
This change enables the MTD SPI flash configuration in the sunxi-next kernel; this allows on-board SPI flash to be accessible via MTD by default when enabling the "spi-jedec-nor" overlay in the boot configuration.

This option originally was enabled in the Armbian kernel and somewhere along the way it was disabled.  Enabling this allows access to the SPI NOR flash present in many of the Orange Pi Zero boards (e.g., H3 and H5).

Tested on an Orange Pi Zero R1 and an Orange Pi Zero Plus H5.
