### PR TITLE
enable R_PIO GPIO access in the SPL (H3 and H5)

### DIFF
--- a/patch/u-boot/u-boot-sunxi/enable-r_pio-access-in-spl-h3-h5.patch
+++ b/patch/u-boot/u-boot-sunxi/enable-r_pio-access-in-spl-h3-h5.patch
@@ -1,0 +1,17 @@
+diff --git a/arch/arm/mach-sunxi/clock_sun6i.c b/arch/arm/mach-sunxi/clock_sun6i.c
+index 6bfda31..59d556f 100644
+--- a/arch/arm/mach-sunxi/clock_sun6i.c
++++ b/arch/arm/mach-sunxi/clock_sun6i.c
+@@ -76,6 +76,12 @@ void clock_init_sec(void)
+ 		     PRCM_SEC_SWITCH_APB0_CLK_NONSEC |
+ 		     PRCM_SEC_SWITCH_PLL_CFG_NONSEC |
+ 		     PRCM_SEC_SWITCH_PWR_GATE_NONSEC);
++
++#if defined(CONFIG_SPL_BUILD) && (CONFIG_CONS_INDEX < 5)
++	/* enable R_PIO access within the SPL */
++	prcm_apb0_enable(PRCM_APB0_GATE_PIO);
++#endif
++
+ #endif
+ }
+ 


### PR DESCRIPTION
This patch enables access to the R_PIO GPIO bank within the U-Boot SPL for the Allwinner H3 and H5.  This secondary GPIO bank should be available in the SPL just as the PIO bank is, as there can be need to access these GPIOs during initial board startup.

I've tested this change on both Orange Pi H3 and H5 devices, as well as several different NanoPi H5 devices.
