### PR TITLE
auto-select board DT for the NanoPi NEO2 based on board hardware revision

### DIFF
--- a/patch/u-boot/u-boot-sunxi/add-xx-boot-auto-dt-select-neo2.patch
+++ b/patch/u-boot/u-boot-sunxi/add-xx-boot-auto-dt-select-neo2.patch
@@ -1,0 +1,119 @@
+diff --git a/board/sunxi/board.c b/board/sunxi/board.c
+index 818d2a0..a3ee6ed 100644
+--- a/board/sunxi/board.c
++++ b/board/sunxi/board.c
+@@ -725,6 +725,74 @@ static void setup_environment(const void *fdt)
+ 	}
+ }
+ 
++#if defined(CONFIG_BOOT_PROCESS_MULTI_DTB) && !defined(CONFIG_SPL_BUILD)
++
++#define NP_NEO2_DT_SS			"nanopi-neo2."
++
++#define NP_NEO2_DT_EXT_V1_1		"-v1.1.dtb"
++
++#define NP_NEO2_BOARD_ID_GPIO		"PL3"
++#define NP_NEO2_BOARD_ID_1_0		1
++#define NP_NEO2_BOARD_ID_1_1		0
++
++void boot_process_multi_dtb(void)
++{
++	const char *fdtfile = env_get("fdtfile");
++	if (fdtfile == NULL) {
++		return;
++	}
++
++	/* check for a NanoPi NEO2 */
++	if (strstr(fdtfile, NP_NEO2_DT_SS) != NULL) {
++		int board_id_pin, prev_cfg, ret, rev_1_1;
++
++		/* NEO2 DT found; process board revision and select corresponding DT */
++
++		board_id_pin = sunxi_name_to_gpio(NP_NEO2_BOARD_ID_GPIO);
++		if (board_id_pin < 0) {
++			return;
++		}
++
++		ret = gpio_request(board_id_pin, "board_id_pin");
++		if (ret) {
++			return;
++		}
++
++		prev_cfg = sunxi_gpio_get_cfgpin(board_id_pin);
++
++		gpio_direction_input(board_id_pin);
++		sunxi_gpio_set_pull(board_id_pin, SUNXI_GPIO_PULL_DISABLE);
++
++		mdelay(2);
++
++		rev_1_1 = gpio_get_value(board_id_pin) == NP_NEO2_BOARD_ID_1_1;
++
++		sunxi_gpio_set_cfgpin(board_id_pin, prev_cfg);
++		gpio_free(board_id_pin);
++
++		printf("NanoPi NEO2 v1.%d detected\n", rev_1_1);
++
++		if (rev_1_1) {
++			int ddt_len = sizeof(CONFIG_DEFAULT_DEVICE_TREE);
++			int fdt_len = strlen(fdtfile);
++
++			char *n_fdtfile = (char *)malloc(max(fdt_len, ddt_len) + sizeof(NP_NEO2_DT_EXT_V1_1) + 1);
++			if (n_fdtfile != NULL) {
++				char *cp = strstr(strcpy(n_fdtfile, fdtfile), CONFIG_DEFAULT_DEVICE_TREE);
++				if (cp != NULL) {
++					cp[ddt_len - 1] = '\0';
++					strcat(cp, NP_NEO2_DT_EXT_V1_1);
++
++					env_set("fdtfile", n_fdtfile);
++				}
++
++				free(n_fdtfile);
++			}
++		}
++	}
++}
++#endif
++
+ int misc_init_r(void)
+ {
+ 	__maybe_unused int ret;
+@@ -758,6 +826,10 @@ int misc_init_r(void)
+ 	usb_ether_init();
+ #endif
+ 
++#if defined(CONFIG_BOOT_PROCESS_MULTI_DTB) && !defined(CONFIG_SPL_BUILD)
++	boot_process_multi_dtb();
++#endif
++
+ 	return 0;
+ }
+ 
+diff --git a/configs/nanopi_neo2_defconfig b/configs/nanopi_neo2_defconfig
+index 78d587f..ca8a842 100755
+--- a/configs/nanopi_neo2_defconfig
++++ b/configs/nanopi_neo2_defconfig
+@@ -12,4 +12,5 @@ CONFIG_DEFAULT_DEVICE_TREE="sun50i-h5-nanopi-neo2"
+ CONFIG_SUN8I_EMAC=y
+ CONFIG_USB_EHCI_HCD=y
+ CONFIG_SYS_USB_EVENT_POLL_VIA_INT_QUEUE=y
+-CONFIG_MMC_SUNXI_SLOT_EXTRA=2
+\ No newline at end of file
++CONFIG_MMC_SUNXI_SLOT_EXTRA=2
++CONFIG_BOOT_PROCESS_MULTI_DTB=y
+diff --git a/dts/Kconfig b/dts/Kconfig
+index 0cef225..cd4d101 100644
+--- a/dts/Kconfig
++++ b/dts/Kconfig
+@@ -166,6 +166,12 @@ config SPL_OF_LIST
+ 	  device tree files (without the directory or .dtb suffix)
+ 	  separated by <space>.
+ 
++if ARCH_SUNXI
++config BOOT_PROCESS_MULTI_DTB
++	bool "Adjust default board DT as necessary at boot"
++	default n
++endif
++
+ choice
+ 	prompt "SPL OF LIST compression"
+ 	depends on SPL_MULTI_DTB_FIT


### PR DESCRIPTION
This change introduces a method for U-Boot to perform board version detection at boot and update the required board DT to load.  This process is used to detect the NEO2 board revision and load the v1.1 NEO2 DT for v1.1 NEO2 boards.

Note that this change is dependent on the changes  made in both [PR #1064](https://github.com/armbian/build/pull/1064) and [PR #1065](https://github.com/armbian/build/pull/1065).  This PR should not be merged until after these two prior PRs are merged.

This change has been tested on both NanoPi NEO2 v1.0 and v1.1 boards.