### PR TITLE
Remove hardcoded rootfstype for rockchip and udoo

### DIFF
--- a/config/bootscripts/boot-rockchip.cmd
+++ b/config/bootscripts/boot-rockchip.cmd
@@ -4,6 +4,7 @@
 #
 
 setenv rootdev "/dev/mmcblk0p1"
+setenv rootfstype "ext4"
 setenv fdt_file "rk3288-miqi.dtb"
 setenv ramdisk_addr_r "0x21000000"
 setenv console "ttyS2,115200n8 console=tty1"
@@ -16,7 +17,7 @@ if load ${devtype} ${devnum}:1 ${ramdisk_addr_r} /boot/armbianEnv.txt || load ${
 	env import -t ${ramdisk_addr_r} ${filesize}
 fi
 
-setenv bootargs "consoleblank=0 scandelay root=${rootdev} rw console=${console} rootfstype=ext4 loglevel=${verbosity} rootwait usb-storage.quirks=${usbstoragequirks} ${extraargs}"
+setenv bootargs "consoleblank=0 scandelay root=${rootdev} rw console=${console} rootfstype=${rootfstype} loglevel=${verbosity} rootwait usb-storage.quirks=${usbstoragequirks} ${extraargs}"
 ext4load ${devtype} ${devnum}:1 ${fdt_addr_r} /boot/dtb/${fdt_file} || fatload ${devtype} ${devnum}:1 ${fdt_addr_r} dtb/${fdt_file} || ext4load ${devtype} ${devnum}:1 ${fdt_addr_r} dtb/${fdt_file}
 ext4load ${devtype} ${devnum}:1 ${ramdisk_addr_r} /boot/uInitrd || fatload ${devtype} ${devnum}:1 ${ramdisk_addr_r} uInitrd || ext4load ${devtype} ${devnum}:1 ${ramdisk_addr_r} uInitrd
 ext4load ${devtype} ${devnum}:1 ${kernel_addr_r} /boot/zImage || fatload ${devtype} ${devnum}:1 ${kernel_addr_r} zImage || ext4load ${devtype} ${devnum}:1 ${kernel_addr_r} zImage

--- a/config/bootscripts/boot-udoo-neo.cmd
+++ b/config/bootscripts/boot-udoo-neo.cmd
@@ -24,7 +24,7 @@ fi
 if test "${console}" = "display" || test "${console}" = "both"; then setenv consoleargs "console=tty1"; fi
 if test "${console}" = "serial" || test "${console}" = "both"; then setenv consoleargs "${consoleargs} console=ttymxc0,115200"; fi
 
-setenv bootargs "root=${rootdev} rootfstype=ext4 rootwait ${consoleargs} rd.dm=0 rd.luks=0 rd.lvm=0 rw uart_from_osc loglevel=${verbosity} usb-storage.quirks=${usbstoragequirks} ${extraargs}"
+setenv bootargs "root=${rootdev} rootfstype=${rootfstype} rootwait ${consoleargs} rd.dm=0 rd.luks=0 rd.lvm=0 rw uart_from_osc loglevel=${verbosity} usb-storage.quirks=${usbstoragequirks} ${extraargs}"
 
 ext2load mmc ${mmcdev}:${mmcpart} ${fw_load_addr} /boot/bin/m4startup.fw
 ext2load mmc ${mmcdev}:${mmcpart} ${loadaddr} /boot/zImage

--- a/config/bootscripts/boot-udoo.cmd
+++ b/config/bootscripts/boot-udoo.cmd
@@ -24,7 +24,7 @@ if test "${console}" = "display" || test "${console}" = "both"; then setenv cons
 if test "${console}" = "serial" || test "${console}" = "both"; then setenv consoleargs "${consoleargs} console=ttymxc1,115200"; fi
 
 
-setenv bootargs "root=${rootdev} rootfstype=ext4 rootwait ${consoleargs} video=mxcfb0:dev=hdmi,${disp_mode},if=RGB24,bpp=32 rd.dm=0 rd.luks=0 rd.lvm=0 raid=noautodetect pci=nomsi ahci_imx.hotplug=1 vt.global_cursor_default=0 loglevel=${verbosity} usb-storage.quirks=${usbstoragequirks} ${extraargs}"
+setenv bootargs "root=${rootdev} rootfstype=${rootfstype} rootwait ${consoleargs} video=mxcfb0:dev=hdmi,${disp_mode},if=RGB24,bpp=32 rd.dm=0 rd.luks=0 rd.lvm=0 raid=noautodetect pci=nomsi ahci_imx.hotplug=1 vt.global_cursor_default=0 loglevel=${verbosity} usb-storage.quirks=${usbstoragequirks} ${extraargs}"
 
 ext4load mmc 0 ${ramdisk_addr} /boot/uInitrd || fatload mmc 0 ${ramdisk_addr} uInitrd || ext4load mmc 0 ${ramdisk_addr} uInitrd
 ext4load mmc 0 ${loadaddr} /boot/zImage || fatload mmc 0 ${loadaddr} zImage


### PR DESCRIPTION
The rockchip and udoo bootscripts were forcing etx4 as rootfstype, which made btrfs install through nand-sata-install a bit awkward 😅

For boot-rockchip.cmd, a default rootfstype environment value is provided and bootargs updated to use the environment value.
For boot-udoo*.cmd, the default environment value was already defined, so only bootargs required update.