### PR TITLE
Make ethernet on BananaPi M3 working with 4.17.y

### DIFF
--- a/patch/kernel/sunxi-next/board-bpi-m3-make-ethernet-working.patch
+++ b/patch/kernel/sunxi-next/board-bpi-m3-make-ethernet-working.patch
@@ -1,0 +1,15 @@
+diff --git a/arch/arm/boot/dts/sun8i-a83t-bananapi-m3.dts b/arch/arm/boot/dts/sun8i-a83t-bananapi-m3.dts
+index 3b579d7..679a9aa 100644
+--- a/arch/arm/boot/dts/sun8i-a83t-bananapi-m3.dts
++++ b/arch/arm/boot/dts/sun8i-a83t-bananapi-m3.dts
+@@ -301,8 +301,8 @@
+ 
+ &reg_dldo3 {
+ 	regulator-always-on;
+-	regulator-min-microvolt = <2500000>;
+-	regulator-max-microvolt = <2500000>;
++	regulator-min-microvolt = <3300000>;
++	regulator-max-microvolt = <3300000>;
+ 	regulator-name = "vcc-pd";
+ };
+ 


### PR DESCRIPTION
based on https://patchwork.kernel.org/patch/10515589/ this patch makes (wired GBit) ethernet working on BananaPi M3 again.
