### PR TITLE
Disable USB power down on rockchip devices

### DIFF
--- a/patch/kernel/rockchip-dev/usb-dwc2-disable-power_down-on-rockchip-devices.patch
+++ b/patch/kernel/rockchip-dev/usb-dwc2-disable-power_down-on-rockchip-devices.patch
@@ -1,0 +1,21 @@
+Disables the power down feature to make USB host and OTG ports work
+again on rockchip device due to some rework done in kernel >= 4.18.
+This patch is based upon the one from Hal Emmerich available at
+<https://patchwork.kernel.org/patch/10535905/>, but the original patch
+had some minor issues:
+
+- whitespaces instead of tabs triggers an error when patch is used
+- power_down attribute is set to 0 and not *false* like sorrounding code
+
+diff --git a/drivers/usb/dwc2/params.c b/drivers/usb/dwc2/params.c
+index f03e41879224..492607adc506 100644
+--- a/drivers/usb/dwc2/params.c
++++ b/drivers/usb/dwc2/params.c
+@@ -82,6 +82,7 @@ static void dwc2_set_rk_params(struct dwc2_hsotg *hsotg)
+	p->host_perio_tx_fifo_size = 256;
+	p->ahbcfg = GAHBCFG_HBSTLEN_INCR16 <<
+		GAHBCFG_HBSTLEN_SHIFT;
++	p->power_down = 0;
+ }
+
+ static void dwc2_set_ltq_params(struct dwc2_hsotg *hsotg)

--- a/patch/kernel/rockchip-dev/usb-dwc2-disable-power_down-on-rockchip-devices.patch
+++ b/patch/kernel/rockchip-dev/usb-dwc2-disable-power_down-on-rockchip-devices.patch
@@ -15,7 +15,7 @@ index f03e41879224..492607adc506 100644
 	p->host_perio_tx_fifo_size = 256;
 	p->ahbcfg = GAHBCFG_HBSTLEN_INCR16 <<
 		GAHBCFG_HBSTLEN_SHIFT;
-+	p->power_down = 0;
++	p->power_down = false;
  }
 
  static void dwc2_set_ltq_params(struct dwc2_hsotg *hsotg)


### PR DESCRIPTION
Disables the power down feature to make USB host and OTG ports work
again on rockchip devices due to some rework done in kernel >= 4.18