### PR TITLE
Stop also service "fail2ban"

### DIFF
--- a/packages/bsp/common/usr/sbin/nand-sata-install
+++ b/packages/bsp/common/usr/sbin/nand-sata-install
@@ -122,7 +122,7 @@ create_armbian()
 	lsof / | awk 'NR==1 || $4~/[0-9][uw]/' | grep -v "^COMMAND" >> $logfile
 	echo -e "\nTrying to stop running services to minimize open files:\c" >> $logfile
 	StopRunningServices "nfs-|smbd|nmbd|winbind|ftpd|netatalk|monit|cron|webmin|rrdcached" >> $logfile
-	StopRunningServices "log2ram|folder2ram|postgres|mariadb|mysql|postfix|mail|nginx|apache|snmpd" >> $logfile
+	StopRunningServices "fail2ban|log2ram|folder2ram|postgres|mariadb|mysql|postfix|mail|nginx|apache|snmpd" >> $logfile
 	pkill dhclient 2>/dev/null
 	LANG=C echo -e "\n\nChecking again for open files:" >> $logfile
 	lsof / | awk 'NR==1 || $4~/[0-9][uw]/' | grep -v "^COMMAND" >> $logfile


### PR DESCRIPTION
Apache service is stopped. Why not stopping also the service fail2ban, which is often installed beside apache
