### PR TITLE
Fix Firefly-RK3399 default kernel dts issues

### DIFF
--- a/config/sources/rk3399.conf
+++ b/config/sources/rk3399.conf
@@ -90,14 +90,5 @@ family_tweaks()
 	[[ $BOARD == nanopct4 ]] && echo "fdtfile=rockchip/rk3399-nanopi4-rev00.dtb" >> $SDCARD/boot/armbianEnv.txt
 	[[ $BOARD == nanopim4 ]] && echo "fdtfile=rockchip/rk3399-nanopi4-rev01.dtb" >> $SDCARD/boot/armbianEnv.txt
 	[[ $BOARD == nanopineo4 ]] && echo "fdtfile=rockchip/rk3399-nanopi4-rev04.dtb" >> $SDCARD/boot/armbianEnv.txt
-
-	case $BRANCH in
-		default)
-		[[ $BOARD == firefly-rk3399 ]] && echo "fdtfile=rockchip/rk3399-firefly-linux.dtb" >> $SDCARD/boot/armbianEnv.txt
-		;;
-
-		dev)
-		[[ $BOARD == firefly-rk3399 ]] && echo "fdtfile=rockchip/rk3399-firefly.dtb" >> $SDCARD/boot/armbianEnv.txt
-		;;
-	esac
+	[[ $BOARD == firefly-rk3399 ]] && echo "fdtfile=rockchip/rk3399-firefly.dtb" >> $SDCARD/boot/armbianEnv.txt
 }

--- a/patch/kernel/rk3399-default/firefly-dts.patch
+++ b/patch/kernel/rk3399-default/firefly-dts.patch
@@ -1,7 +1,24 @@
-diff --git a/arch/arm64/boot/dts/rockchip/rk3399-firefly-linux.dts b/arch/arm64/boot/dts/rockchip/rk3399-firefly-linux.dts
-index 243eef88..7d2ee03d 100644
+diff --git a/arch/arm64/boot/dts/rockchip/Makefile b/arch/arm64/boot/dts/rockchip/Makefile
+index 244272a3..8da63ea9 100644
+--- a/arch/arm64/boot/dts/rockchip/Makefile
++++ b/arch/arm64/boot/dts/rockchip/Makefile
+@@ -3,7 +3,8 @@ ifeq ($(CONFIG_MACH_NANOPI4),y)
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += \
+ 	rk3399-nanopi4-rev00.dtb \
+ 	rk3399-nanopi4-rev01.dtb \
+-	rk3399-nanopi4-rev04.dtb
++	rk3399-nanopi4-rev04.dtb \
++	rk3399-firefly.dtb
+ 
+ else
+ 
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-firefly-linux.dts b/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts
+similarity index 85%
+rename from arch/arm64/boot/dts/rockchip/rk3399-firefly-linux.dts
+rename to arch/arm64/boot/dts/rockchip/rk3399-firefly.dts
+index c3e076f7..5e31d9df 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-firefly-linux.dts
-+++ b/arch/arm64/boot/dts/rockchip/rk3399-firefly-linux.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts
 @@ -121,17 +121,6 @@
  		};
  	};
@@ -164,7 +181,7 @@ index 243eef88..7d2ee03d 100644
  		rockchip,system-power-controller;
  		wakeup-source;
  		#clock-cells = <1>;
-@@ -801,7 +908,17 @@
+@@ -838,7 +945,17 @@
  
  		vsel2_gpio: vsel2-gpio {
  			rockchip,pins =
@@ -183,7 +200,7 @@ index 243eef88..7d2ee03d 100644
  		};
  	};
  
-@@ -819,6 +936,15 @@
+@@ -856,6 +973,15 @@
  		};
  	};
  
@@ -199,7 +216,7 @@ index 243eef88..7d2ee03d 100644
  	rt5640 {
  		rt5640_hpcon: rt5640-hpcon {
  			rockchip,pins = <4 21 RK_FUNC_GPIO &pcfg_pull_none>;
-@@ -875,6 +1001,29 @@
+@@ -912,6 +1038,29 @@
  	status = "disabled";
  };
  
@@ -229,7 +246,7 @@ index 243eef88..7d2ee03d 100644
  &saradc {
  	status = "okay";
  	vref-supply = <&vccadc_ref>;
-@@ -972,6 +1121,31 @@
+@@ -1009,6 +1158,31 @@
  	};
  };
  
@@ -261,7 +278,7 @@ index 243eef88..7d2ee03d 100644
  &uart0 {
  	pinctrl-names = "default";
  	pinctrl-0 = <&uart0_xfer &uart0_cts>;
-@@ -982,6 +1156,12 @@
+@@ -1019,6 +1193,12 @@
  	status = "okay";
  };
  


### PR DESCRIPTION
1. Rename rk3399-firefly-linux.dts to rk3399-firefly.dts to be consistent with mainline kernel, so that users don't need to edit armbianEnv.txt when switching kernel.
2. Add rk3399-firefly.dtb to CONFIG_ARCH_ROCKCHIP