### PR TITLE
Cleanup dns config 1096

### DIFF
--- a/lib/chroot-buildpackages.sh
+++ b/lib/chroot-buildpackages.sh
@@ -59,6 +59,7 @@ create_chroot()
 	printf '#!/bin/sh\nexit 101' > $target_dir/usr/sbin/policy-rc.d
 	chmod 755 $target_dir/usr/sbin/policy-rc.d
 	rm $target_dir/etc/resolv.conf 2>/dev/null
+	echo "1.1.1.1" > $target_dir/etc/resolv.conf
 	rm $target_dir/etc/hosts 2>/dev/null
 	echo "127.0.0.1 localhost" > $target_dir/etc/hosts
 	mkdir -p $target_dir/root/{build,overlay,sources} $target_dir/selinux

--- a/lib/distributions.sh
+++ b/lib/distributions.sh
@@ -235,8 +235,7 @@ install_common()
 
 	# DNS fix. package resolvconf is not available everywhere
 	if [ -d /etc/resolvconf/resolv.conf.d ]; then
-		echo -e "# In case of DNS problems, try uncommenting this and reboot for debugging\n# nameserver 1.1.1.1" \
-		> $SDCARD/etc/resolvconf/resolv.conf.d/head
+		echo 'nameserver 1.1.1.1' > $SDCARD/etc/resolvconf/resolv.conf.d/head
 	fi
 
 	# premit root login via SSH for the first boot
@@ -302,6 +301,8 @@ install_distribution_specific()
 		exit 0
 		EOF
 		chmod +x $SDCARD/etc/rc.local
+		# DNS fix
+		sed -i "s/#DNS=.*/DNS=1.1.1.1/g" $SDCARD/etc/systemd/resolved.conf
 		;;
 	bionic)
 		# remove doubled uname from motd
@@ -332,6 +333,8 @@ install_distribution_specific()
 		  version: 2
 		  renderer: NetworkManager
 		EOF
+		# DNS fix
+		sed -i "s/#DNS=.*/DNS=1.1.1.1/g" $SDCARD/etc/systemd/resolved.conf
 		# Journal service adjustements
 		sed -i "s/#Storage=.*/Storage=volatile/g" $SDCARD/etc/systemd/journald.conf
 		sed -i "s/#Compress=.*/Compress=yes/g" $SDCARD/etc/systemd/journald.conf

--- a/lib/distributions.sh
+++ b/lib/distributions.sh
@@ -27,7 +27,7 @@ install_common()
 
 	fi
 	# define ARCH within global environment variables
-	[[ -f $SDCARD/etc/environment ]] && echo "ARCH=${ARCH}" >> $SDCARD/etc/environment
+	[[ -f $SDCARD/etc/environment ]] && echo "ARCH=${ARCH//hf}" >> $SDCARD/etc/environment
 
 	# add dummy fstab entry to make mkinitramfs happy
 	echo "/dev/mmcblk0p1 / $ROOTFS_TYPE defaults 0 1" >> $SDCARD/etc/fstab

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstrun
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstrun
@@ -56,13 +56,6 @@ case "$1" in
 		/etc/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xfwm4.xml
 	fi
 
-	# check whether DNS resolution works, if not switch to Cloudflare DNS
-	fping cloudflare.com >/dev/null 2>&1
-	if [ $? -ne 0 ]; then
-		sed -i "s/#DNS=.*/DNS=1.1.1.1/" /etc/systemd/resolved.conf
-		sed -i "s/# nameserver.*/nameserver 1.1.1.1/" /etc/resolvconf/resolv.conf.d/head
-	fi
-
 	# some hardware workarounds
 	case $LINUXFAMILY in
 		sun7i|sun8i)


### PR DESCRIPTION
Provides sane DNS defaults regarding #1096 

- NetworkManager maintains traditional /etc/resolv.conf file
- nsswitch.conf prioritizes dns

Tested on dev kernel on opioneplus on:

- xenial
- bionic
- stretch

I couldn't test jessie because the debian security mirrors were messing things up.