### PR TITLE
Crude fix for multiple interfaces

### DIFF
--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -1023,7 +1023,7 @@ NetworkMonitorMode() {
 	trap "echo ; exit 0" 0 1 2 3 15
 	timerStart
 	kickAllStatsDown
-	iface=$(route -n | egrep UG | egrep -o "[a-zA-Z0-9]*$")
+	iface=$(route -n | egrep UG | egrep -o "[a-zA-Z0-9]*$" | head -n 1)
 	
 	printf "\nruntime network statistics: $(uname -n)\n"
 	printf "[tap 'd' to display column headings]\n"


### PR DESCRIPTION
I ran into an issue that `armbianmonitor -N` and `-n` spit out an `sed` error message and noticed this is caused when multiple network interfaces (like additional `tun`) are detected.

This is a quick and dirty fix and just grabs the first result ~~(which for me at least is eth0)~~ to make it work.

Edit: It is using `tun0` as first result, but I think on classic VPN usage this should be this way, shouldn't it? 
 ¯\\_(ツ)_/¯

