### PR TITLE
Fix monitormode run unprivileged

### DIFF
--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -310,10 +310,10 @@ MonitorMode() {
 		CPUs=notavailable
 	fi
 	# Set freq output to --- if non-privileged. Overwrites settings above.
-        if [ "$(id -u)" != "0" ]; then
-                echo "Running unprivileged. CPU frequency will not be displayed."
-                CPUs=notavailable
-        fi
+	if [ "$(id -u)" != "0" ]; then
+		echo "Running unprivileged. CPU frequency will not be displayed."
+		CPUs=notavailable
+	fi
 
 	[ -f "${Sensors}/soctemp" ] && DisplayHeader="${DisplayHeader}   CPU" || SocTemp='n/a'
 	[ -f "${Sensors}/pmictemp" ] && DisplayHeader="${DisplayHeader}   PMIC" || PMICTemp='n/a'

--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -309,6 +309,12 @@ MonitorMode() {
 		DisplayHeader="Time      CPU n/a    load %cpu %sys %usr %nice %io %irq"
 		CPUs=notavailable
 	fi
+	# Set freq output to --- if non-privileged. Overwrites settings above.
+        if [ "$(id -u)" != "0" ]; then
+                echo "Running unprivileged. CPU frequency will not be displayed."
+                CPUs=notavailable
+        fi
+
 	[ -f "${Sensors}/soctemp" ] && DisplayHeader="${DisplayHeader}   CPU" || SocTemp='n/a'
 	[ -f "${Sensors}/pmictemp" ] && DisplayHeader="${DisplayHeader}   PMIC" || PMICTemp='n/a'
 	DCIN=$(CheckDCINVoltage)


### PR DESCRIPTION
Running `armbianmonitor -m/M` non-privileged leading into an no permission error as user do not have permission to read `cpuinfo_cur_freq`.
This will prevent the error and adds a warning if people trying to run as user.

Credits to @ThomasKaiser for providing the initial code snipped used.
