### PR TITLE
Allow interface selection on NetworkMonitorMode

### DIFF
--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -1031,16 +1031,16 @@ NetworkMonitorMode() {
 	timerStart
 	kickAllStatsDown
 	
-	# Count interfaces
-	ifacecount=$(route -n | egrep UG | egrep -o "[a-zA-Z0-9]*$")
+	# Count interfaces - multiple routes causing interfaces to show up more than once, filtering...
+	ifacecount=$(route -n | egrep UG | egrep -o "[a-zA-Z0-9]*$" | sort | uniq)
 	# If there are two ore more interfaces detected open a dynamic dialog box to select which to monitor
-	if [ "$(echo -e $ifacecount |tr ' ' '\n'|wc -l)" -gt 1 ]; then
-		ifacemenu=$(route -n | egrep UG | egrep -o "[a-zA-Z0-9]*$" | sort | uniq| awk '{a[$1]=$1}END{for(i in a)printf i" "a[i]" "}')
+	if [ "$(echo -e $ifacecount | tr ' ' '\n' | wc -l)" -gt 1 ]; then
+		ifacemenu=$(route -n | egrep UG | egrep -o "[a-zA-Z0-9]*$" | sort | uniq | awk '{a[$1]=$1}END{for(i in a)printf i" "a[i]" "}')
 		ifacefunc() {
 			dialog --backtitle "Interface selector" \
 			--title "Multiple network interfaces detected" \
 			--menu "Choose which interface to monitor:" \
-			15 50 $(route -n | egrep UG | egrep -o "[a-zA-Z0-9]*$" | sort | uniq|wc -l) \
+			15 50 $(route -n | egrep UG | egrep -o "[a-zA-Z0-9]*$" | sort | uniq | wc -l) \
 			$(echo $ifacemenu) 2>&1 >$(tty)
 		}
 		iface=$(ifacefunc)

--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -1025,14 +1025,32 @@ VerifyInstallation() {
 } # VerifyInstallation
 
 NetworkMonitorMode() {
-	
+
 	# Allow armbianmonitor to return back to armbian-config
 	trap "echo ; exit 0" 0 1 2 3 15
 	timerStart
 	kickAllStatsDown
-	iface=$(route -n | egrep UG | egrep -o "[a-zA-Z0-9]*$" | head -n 1)
+	
+	# Find interfaces
+	ifacecount=$(route -n | egrep UG | egrep -o "[a-zA-Z0-9]*$")
+	# If there are two ore more interfaces detected open dialog box to select which to monitor
+	if [ "$(echo -e $ifacecount |tr ' ' '\n'|wc -l)" -gt 1 ]; then
+		ifacemenu=$(route -n | egrep UG | egrep -o "[a-zA-Z0-9]*$" | sort | uniq| awk '{a[$1]=$1}END{for(i in a)printf i" "a[i]" "}')
+		ifacefunc() {
+			dialog --backtitle "Interface selector" \
+			--title "Multiple network interfaces were detected" \
+			--menu "Choose one of the following options:" \
+			15 49 $(route -n | egrep UG | egrep -o "[a-zA-Z0-9]*$" | sort | uniq|wc -l) \
+			$(echo $ifacemenu) 2>&1 >$(tty)
+		}
+		iface=$(ifacefunc)
+	else
+	# Use default behavior if one interface is found only
+		iface=$(route -n | egrep UG | egrep -o "[a-zA-Z0-9]*$")
+	fi
 	
 	printf "\nruntime network statistics: $(uname -n)\n"
+	printf "network interface: $(echo $iface)\n"
 	printf "[tap 'd' to display column headings]\n"
 	printf "[tap 'z' to reset counters]\n"
 	printf "[use <ctrl-c> to exit]\n"

--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -1031,16 +1031,16 @@ NetworkMonitorMode() {
 	timerStart
 	kickAllStatsDown
 	
-	# Find interfaces
+	# Count interfaces
 	ifacecount=$(route -n | egrep UG | egrep -o "[a-zA-Z0-9]*$")
-	# If there are two ore more interfaces detected open dialog box to select which to monitor
+	# If there are two ore more interfaces detected open a dynamic dialog box to select which to monitor
 	if [ "$(echo -e $ifacecount |tr ' ' '\n'|wc -l)" -gt 1 ]; then
 		ifacemenu=$(route -n | egrep UG | egrep -o "[a-zA-Z0-9]*$" | sort | uniq| awk '{a[$1]=$1}END{for(i in a)printf i" "a[i]" "}')
 		ifacefunc() {
 			dialog --backtitle "Interface selector" \
-			--title "Multiple network interfaces were detected" \
-			--menu "Choose one of the following options:" \
-			15 49 $(route -n | egrep UG | egrep -o "[a-zA-Z0-9]*$" | sort | uniq|wc -l) \
+			--title "Multiple network interfaces detected" \
+			--menu "Choose which interface to monitor:" \
+			15 50 $(route -n | egrep UG | egrep -o "[a-zA-Z0-9]*$" | sort | uniq|wc -l) \
 			$(echo $ifacemenu) 2>&1 >$(tty)
 		}
 		iface=$(ifacefunc)


### PR DESCRIPTION
When running `armbianmonitor -N/n` and two or more network interfaces are detected create a dynamic dialog box to select which interface should be monitored. Otherwise proceed as usual.

This also reverts the crude fix https://github.com/armbian/build/pull/1106

I could test this with `eth0` and `tun0` as interfaces only. If somebody gets a chance to test this with further interface names and types please go ahead.