### PR TITLE
Working Docker Swarm Overlay Network

### DIFF
--- a/config/kernel/linux-rockchip-next.config
+++ b/config/kernel/linux-rockchip-next.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 4.14.53 Kernel Configuration
+# Linux/arm 4.14.69 Kernel Configuration
 #
 CONFIG_ARM=y
 CONFIG_ARM_HAS_SG_CHAIN=y
@@ -1020,8 +1020,8 @@ CONFIG_IP_VS_TAB_BITS=12
 #
 # IPVS transport protocol load balancing support
 #
-# CONFIG_IP_VS_PROTO_TCP is not set
-# CONFIG_IP_VS_PROTO_UDP is not set
+CONFIG_IP_VS_PROTO_TCP=y
+CONFIG_IP_VS_PROTO_UDP=y
 # CONFIG_IP_VS_PROTO_AH_ESP is not set
 # CONFIG_IP_VS_PROTO_ESP is not set
 # CONFIG_IP_VS_PROTO_AH is not set
@@ -1051,7 +1051,9 @@ CONFIG_IP_VS_SH_TAB_BITS=8
 #
 # IPVS application helper
 #
+# CONFIG_IP_VS_FTP is not set
 CONFIG_IP_VS_NFCT=y
+# CONFIG_IP_VS_PE_SIP is not set
 
 #
 # IP: Netfilter Configuration
@@ -1171,7 +1173,7 @@ CONFIG_BRIDGE_NF_EBTABLES=m
 CONFIG_STP=y
 CONFIG_BRIDGE=y
 CONFIG_BRIDGE_IGMP_SNOOPING=y
-# CONFIG_BRIDGE_VLAN_FILTERING is not set
+CONFIG_BRIDGE_VLAN_FILTERING=y
 CONFIG_HAVE_NET_DSA=y
 # CONFIG_NET_DSA is not set
 CONFIG_VLAN_8021Q=y
@@ -1283,7 +1285,7 @@ CONFIG_DNS_RESOLVER=y
 # CONFIG_NET_NSH is not set
 # CONFIG_HSR is not set
 # CONFIG_NET_SWITCHDEV is not set
-# CONFIG_NET_L3_MASTER_DEV is not set
+CONFIG_NET_L3_MASTER_DEV=y
 # CONFIG_NET_NCSI is not set
 CONFIG_RPS=y
 CONFIG_RFS_ACCEL=y
@@ -1401,6 +1403,8 @@ CONFIG_RFKILL_LEDS=y
 # CONFIG_NET_9P is not set
 # CONFIG_CAIF is not set
 # CONFIG_CEPH_LIB is not set
+# CONFIG_CEPH_LIB_PRETTYDEBUG is not set
+# CONFIG_CEPH_LIB_USE_DNS_RESOLVER is not set
 # CONFIG_NFC is not set
 CONFIG_PSAMPLE=m
 CONFIG_NET_IFE=m
@@ -1664,6 +1668,8 @@ CONFIG_DUMMY=y
 # CONFIG_NET_TEAM is not set
 CONFIG_MACVLAN=y
 CONFIG_MACVTAP=m
+CONFIG_IPVLAN=y
+# CONFIG_IPVTAP is not set
 CONFIG_VXLAN=y
 CONFIG_GENEVE=m
 CONFIG_GTP=m
@@ -1676,6 +1682,7 @@ CONFIG_TAP=m
 # CONFIG_TUN_VNET_CROSS_LE is not set
 CONFIG_VETH=y
 # CONFIG_NLMON is not set
+# CONFIG_NET_VRF is not set
 
 #
 # CAIF transport drivers


### PR DESCRIPTION
Let me just preface this with -- This is my only experience compiling a new kernel for the Tinkerboard. The overlay network **didn't** work before these changes, and it **does** work after these changes.

This is the minimal amount of changes (aside from new 'is not set' kernel vars) that I could come up with that allows the Docker Swarm overlay network to function on the Tinkerboard. 

Changes are based on the [settings](https://github.com/moby/moby/pull/37147) described on a Moby PR.