### PR TITLE
Randomize mac address for eth1addr in armbianEnv.txt

### DIFF
--- a/config/bootenv/helios4-default.txt
+++ b/config/bootenv/helios4-default.txt
@@ -1,3 +1,3 @@
 verbosity=1
-ethaddr=00:50:43:84:fb:2f
+eth1addr=00:50:43:25:fb:84
 

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstrun
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstrun
@@ -57,8 +57,12 @@ case "$1" in
 	fi
 
 	# randomize mac in armbianEnv.txt
-	get_random_mac
-	[[ -f /boot/armbianEnv.txt ]] && sed  -i "s/^ethaddr=.*/ethaddr=$MACADDR/" /boot/armbianEnv.txt
+	if [[ -f /boot/armbianEnv.txt ]]; then
+		get_random_mac
+		sed  -i "s/^ethaddr=.*/ethaddr=$MACADDR/" /boot/armbianEnv.txt
+		get_random_mac
+		sed  -i "s/^eth1addr=.*/eth1addr=$MACADDR/" /boot/armbianEnv.txt
+	fi
 
 	# hardware workarounds per family
 	case $LINUXFAMILY in


### PR DESCRIPTION
For Helios4, Linux use eth1addr variable form U-boot as eth0 mac addres
Make armbian-firstrun script also randomizes mac address for eth1addr in armbianEnv.txt
