### PR TITLE
switch to https for apt.armbian.com and beta.armbian.com

### DIFF
--- a/lib/debootstrap-ng.sh
+++ b/lib/debootstrap-ng.sh
@@ -169,7 +169,7 @@ create_rootfs_cache()
 		create_sources_list "$RELEASE" "$SDCARD/"
 
 		# stage: add armbian repository and install key
-		echo "deb http://apt.armbian.com $RELEASE main ${RELEASE}-utils ${RELEASE}-desktop" > $SDCARD/etc/apt/sources.list.d/armbian.list
+		echo "deb https://apt.armbian.com $RELEASE main ${RELEASE}-utils ${RELEASE}-desktop" > $SDCARD/etc/apt/sources.list.d/armbian.list
 
 		cp $SRC/config/armbian.key $SDCARD
 		eval 'chroot $SDCARD /bin/bash -c "cat armbian.key | apt-key add -"' \

--- a/lib/distributions.sh
+++ b/lib/distributions.sh
@@ -199,7 +199,7 @@ install_common()
  	cp $SRC/packages/bsp/armbian_first_run.txt.template $SDCARD/boot/armbian_first_run.txt.template
 
 	# switch to beta repository at this stage if building nightly images
-	[[ $IMAGE_TYPE == nightly ]] && echo "deb http://beta.armbian.com $RELEASE main ${RELEASE}-utils ${RELEASE}-desktop" > $SDCARD/etc/apt/sources.list.d/armbian.list
+	[[ $IMAGE_TYPE == nightly ]] && echo "deb https://beta.armbian.com $RELEASE main ${RELEASE}-utils ${RELEASE}-desktop" > $SDCARD/etc/apt/sources.list.d/armbian.list
 
 	# Cosmetic fix [FAILED] Failed to start Set console font and keymap at first boot
 	[[ -f $SDCARD/etc/console-setup/cached_setup_font.sh ]] && sed -i "s/^printf '.*/printf '\\\033\%\%G'/g" $SDCARD/etc/console-setup/cached_setup_font.sh


### PR DESCRIPTION
Cause apt.armbian.com and beta.armbian.com are now reachable via https we should IMO use https by default.

as far as I see: https://github.com/armbian/config/blob/398c0b018e303afdbd3860aed64121551fa5d118/debian-config-jobs#L1184
is not affected due to sed command is properly set. 