### PR TITLE
removed device specific "powersave disable"

### DIFF
--- a/packages/bsp/common/etc/NetworkManager/conf.d/default-wifi-powersave-on.conf
+++ b/packages/bsp/common/etc/NetworkManager/conf.d/default-wifi-powersave-on.conf
@@ -1,0 +1,3 @@
+[connection]
+# Values are 0 (use default), 1 (ignore/don't touch), 2 (disable) or 3 (enable).
+wifi.powersave = 2

--- a/packages/bsp/common/etc/modprobe.d/r8723bs.conf
+++ b/packages/bsp/common/etc/modprobe.d/r8723bs.conf
@@ -1,1 +1,1 @@
-options r8723bs rtw_power_mgnt=0 rtw_enusbss=0
+options r8723bs rtw_enusbss=0

--- a/packages/bsp/common/etc/udev/rules.d/10-wifi-disable-powermanagement.rules
+++ b/packages/bsp/common/etc/udev/rules.d/10-wifi-disable-powermanagement.rules
@@ -1,0 +1,1 @@
+KERNEL=="wlan*", ACTION=="add", RUN+="/sbin/iwconfig wlan0 power off"


### PR DESCRIPTION
Powersave is now permanently disabled via NetworkManager and a specific udev rule