### PR TITLE
Helios4: Add SPI bootloader install feature

### DIFF
--- a/config/bootenv/helios4-default.txt
+++ b/config/bootenv/helios4-default.txt
@@ -1,3 +1,3 @@
 verbosity=1
 eth1addr=00:50:43:25:fb:84
-spi_workaround="on"
+spi_workaround=off

--- a/config/bootenv/helios4-default.txt
+++ b/config/bootenv/helios4-default.txt
@@ -1,3 +1,3 @@
 verbosity=1
 eth1addr=00:50:43:25:fb:84
-
+spi_workaround="on"

--- a/config/bootscripts/boot-marvell.cmd
+++ b/config/bootscripts/boot-marvell.cmd
@@ -8,6 +8,7 @@ setenv rootdev "/dev/mmcblk0p1"
 setenv rootfstype "ext4"
 setenv verbosity "1"
 setenv emmc_fix "off"
+setenv spi_workaround "off"
 setenv ethaddr "00:50:43:84:fb:2f"
 setenv eth1addr "00:50:43:25:fb:84"
 setenv eth2addr "00:50:43:84:25:2f"
@@ -42,6 +43,17 @@ if test "${emmc_fix}" = "on"; then
 	fdt resize
 	fdt rm /soc/internal-regs/sdhci@d8000/ cd-gpios
 	fdt set /soc/internal-regs/sdhci@d8000/ non-removable
+fi
+
+# SPI - SATA workaround
+if test "${spi_workaround}" = "on"; then
+	echo "Applying SPI workaround to the DT"
+	fdt addr ${fdt_addr}
+	fdt resize
+	fdt set /soc/internal-regs/sata@e0000 status "disabled"
+	fdt set /soc/internal-regs/sata@a8000 status "disabled"
+	fdt set /soc/spi@10680 status "okay"
+	fdt set /soc/spi@10680/spi-flash@0 status "okay"
 fi
 
 bootz ${kernel_addr_r} ${ramdisk_addr_r} ${fdt_addr}

--- a/config/sources/mvebu-helios4.inc
+++ b/config/sources/mvebu-helios4.inc
@@ -5,7 +5,8 @@ case $BRANCH in
 	BOOTDIR='u-boot-armada'
 	BOOTSCRIPT='boot-marvell.cmd:boot.cmd'
 
-	UBOOT_TARGET_MAP="u-boot.mmc;;u-boot.mmc"
+	UBOOT_TARGET_MAP="u-boot.mmc;;u-boot.mmc
+		u-boot.flash;spi;u-boot.flash u-boot-uart.flash"
 
 	UBOOT_USE_GCC='== 4.9'
 	UBOOT_COMPILER='arm-linux-gnueabi-'

--- a/config/sources/mvebu.conf
+++ b/config/sources/mvebu.conf
@@ -54,6 +54,11 @@ write_uboot_platform()
 	dd if=$1/u-boot.mmc of=$2 bs=512 seek=1 status=noxfer > /dev/null 2>&1
 }
 
+write_uboot_platform_mtd ()
+{
+	dd if=$1/u-boot.flash of=$2 status=noxfer > /dev/null 2>&1
+}
+
 family_tweaks()
 {
 	# execute specific tweaks function if present

--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -214,6 +214,7 @@ compile_uboot()
 	cat <<-EOF > $SRC/.tmp/$uboot_name/usr/lib/u-boot/platform_install.sh
 	DIR=/usr/lib/$uboot_name
 	$(declare -f write_uboot_platform)
+	$(declare -f write_uboot_platform_mtd)
 	$(declare -f setup_write_uboot_platform)
 	EOF
 

--- a/packages/bsp/common/usr/sbin/nand-sata-install
+++ b/packages/bsp/common/usr/sbin/nand-sata-install
@@ -309,7 +309,8 @@ create_armbian()
 	cat $logfile >${TempDir}/rootfs${logfile}
 	sync
 
-	umountdevice "/dev/sda"
+	umount ${TempDir}/rootfs
+	[[ $1 != "spi" ]] && unmount ${TempDir}/bootfs
 } # create_armbian
 
 
@@ -598,8 +599,6 @@ main()
 					formatnand
 				fi
 				create_armbian "$dest_boot" "$dest_root"
-				umount ${TempDir}/rootfs
-				umount ${TempDir}/bootfs
 				;;
 			2)
 				title="$ichip boot | USB/SATA/NVMe root install"
@@ -616,8 +615,6 @@ main()
 				umountdevice "${DISK_ROOT_PART//[0-9]*/}"
 				formatdisk "$DISK_ROOT_PART"
 				create_armbian "$dest_boot" "$DISK_ROOT_PART"
-				umount ${TempDir}/rootfs
-				umount ${TempDir}/bootfs
 				;;
 			3)
 				title="MMC (SD/eMMC) boot | USB/SATA/NVMe root install"

--- a/packages/bsp/common/usr/sbin/nand-sata-install
+++ b/packages/bsp/common/usr/sbin/nand-sata-install
@@ -48,12 +48,20 @@ root_partition_device="${root_partition::-2}"
 [[ -b /dev/nand ]] && nandcheck=$(ls -d -1 /dev/nand* | grep -w 'nand' | awk '{print $NF}');
 emmccheck=$(ls -d -1 /dev/mmcblk* | grep -w 'mmcblk[0-9]' | grep -v "$root_partition_device");
 diskcheck=$(lsblk -l | awk -F" " '/ disk / {print $1}' | egrep '^sd|^nvme')
+spicheck=$(grep 'mtd' /proc/partitions | awk '{print $NF}')
 
 # define makefs and mount options
 declare -A mkopts mountopts
-mkopts[ext2]='-qF'
-mkopts[ext3]='-qF'
-mkopts[ext4]='-qF'
+# for ARMv7 remove 64bit feature from default mke2fs format features
+if [[ $LINUXFAMILY == mvebu ]]; then
+	mkopts[ext2]='-O ^64bit -qF'
+	mkopts[ext3]='-O ^64bit -qF'
+	mkopts[ext4]='-O ^64bit -qF'
+else
+	mkopts[ext2]='-qF'
+	mkopts[ext3]='-qF'
+	mkopts[ext4]='-qF'
+fi
 mkopts[btrfs]='-f'
 mkopts[f2fs]=''
 
@@ -567,7 +575,7 @@ main()
 	[[ ( -n $nandcheck || -n $emmccheck ) && -n $diskcheck ]] && options+=(2 "Boot from $ichip - system on SATA, USB or NVMe")
 	[[ -n $diskcheck ]] && options+=(3 "Boot from SD   - system on SATA, USB or NVMe")
 	[[ ( $LINUXFAMILY == odroidxu4 || $LINUXFAMILY == mvebu* ) && ( -b /dev/mmcblk0boot0 || -b /dev/mmcblk1boot0 ) ]] && options+=(4 "Update the bootloader on a special eMMC partition")
-	[[ $(type -t write_uboot_platform_mtd) == function && -b /dev/mtd0 && -f /usr/sbin/flashcp ]] && options+=(5 "Install the bootloader to SPI Flash")
+	[[ -n $spicheck && $(type -t write_uboot_platform_mtd) == function ]] && options+=(5 "Install the bootloader to SPI Flash")
 	[[ -n $spicheck ]] && options+=(6 "Boot from SPI  - system on SATA, USB or NVMe")
 	[[ ${#options[@]} -eq 0 || "$root_uuid" == "$emmcuuid" || "$root_uuid" == "/dev/nand2" ]] && \
 	dialog --ok-label "Cancel" --title " Warning " --backtitle "$backtitle" --colors --no-collapse --msgbox "\n\Z1There are no targets. Please check your drives.\Zn" 7 52
@@ -631,8 +639,9 @@ main()
 				return
 				;;
 			5)
-				# TODO: Add warning dialogs with MTD device info
-				write_uboot_platform_mtd $DIR /dev/mtd0
+				MTD_BLK="/dev/${spicheck}"
+				ShowWarning "This script will update the bootloader on SPI Flash $MTD_BLK. Continue?"
+				write_uboot_platform_mtd $DIR $MTD_BLK
 				echo "Done"
 				return
 				;;

--- a/patch/u-boot/u-boot-helios4/add-spinor-targets.patch
+++ b/patch/u-boot/u-boot-helios4/add-spinor-targets.patch
@@ -1,0 +1,30 @@
+diff --git a/Makefile b/Makefile
+index 55380d7..2fd3440 100755
+--- a/Makefile
++++ b/Makefile
+@@ -482,6 +482,10 @@ endif
+ $(obj)u-boot.mmc: $(obj)u-boot.bin
+ 	echo y | $(obj)tools/marvell/doimage -T mmc -D 0x0 -E 0x0 -G $(obj)tools/marvell/bin_hdr/bin_hdr.bin u-boot.bin u-boot.mmc
+ 
++$(obj)u-boot.flash: $(obj)u-boot.bin
++	echo y | $(obj)tools/marvell/doimage -T flash -D 0x0 -E 0x0 -G $(obj)tools/marvell/bin_hdr/bin_hdr.bin u-boot.bin u-boot.flash
++	echo y | $(obj)tools/marvell/doimage -T uart -D 0x0 -E 0x0 -G $(obj)tools/marvell/bin_hdr/bin_hdr.uart.bin u-boot.bin u-boot-uart.flash
++
+ $(obj)u-boot.img:	$(obj)u-boot.bin
+ 		$(obj)tools/mkimage -A $(ARCH) -T firmware -C none \
+ 		-O u-boot -a $(CONFIG_SYS_TEXT_BASE) \
+diff --git a/include/configs/armada_38x.h b/include/configs/armada_38x.h
+index c38122c..cb59ea8 100644
+--- a/include/configs/armada_38x.h
++++ b/include/configs/armada_38x.h
+@@ -325,6 +325,10 @@ extern unsigned int mvUartPortGet(void);
+ #endif
+ 
+ /* Boot from SPI settings */
++#if defined(CONFIG_MV_SPI_BOOT)
++	#define MV_SPI_BOOT
++#endif
++
+ 	#if defined(MV_SPI_BOOT)
+ 		#define CONFIG_ENV_IS_IN_SPI_FLASH
+ 

--- a/patch/u-boot/u-boot-helios4/loading-boot-scr.patch
+++ b/patch/u-boot/u-boot-helios4/loading-boot-scr.patch
@@ -42,7 +42,7 @@ index 0dce7f6..6d69879 100755
 +		"echo Trying to boot from MMC; run mmcboot;"
 +#elif defined (MV_SATA_BOOT)
 +		"echo Trying to boot from SATA; run sataboot;"
-+#elif defined (MV_NOR_BOOT)
++#elif defined (MV_SPI_BOOT)
 +		"echo Please store the boot environment on the NOR SPI flash to override the default boot sequence;"
 +#endif /* MV_NOR_BOOT */
 +		"echo Trying to boot from USB; run usbboot;"

--- a/patch/u-boot/u-boot-helios4/target_spi/config-set-boot-device-spinor.patch
+++ b/patch/u-boot/u-boot-helios4/target_spi/config-set-boot-device-spinor.patch
@@ -1,0 +1,13 @@
+diff --git a/boards.cfg b/boards.cfg
+index 4d9f810..fb2d487 100644
+--- a/boards.cfg
++++ b/boards.cfg
+@@ -55,7 +55,7 @@ armada_38x                   arm         armv7       a38x                mv_ebu
+ armada_38x_customer0         arm         armv7       a38x                mv_ebu         mvca9        armada_38x:CUSTOMER_BOARD_0,ARMADA_38X
+ armada_38x_customer1         arm         armv7       a38x                mv_ebu         mvca9        armada_38x:CUSTOMER_BOARD_1,ARMADA_38X
+ armada_38x_clearfog          arm         armv7       a38x                mv_ebu         mvca9        armada_38x:CLEARFOG_BOARD,ARMADA_38X
+-armada_38x_helios4           arm         armv7       a38x                mv_ebu         mvca9        armada_38x:HELIOS4_BOARD,ARMADA_38X,MV_MMC_BOOT,MV_INCLUDE_SPI,DDR3
++armada_38x_helios4           arm         armv7       a38x                mv_ebu         mvca9        armada_38x:HELIOS4_BOARD,ARMADA_38X,MV_SPI_BOOT,MV_INCLUDE_SPI,DDR3
+ armada_39x                   arm         armv7       a38x                mv_ebu         mvca9        armada_38x:ARMADA_39X
+ armada_39x_customer0         arm         armv7       a38x                mv_ebu         mvca9        armada_38x:CUSTOMER_BOARD_0,ARMADA_39X
+ armada_39x_customer1         arm         armv7       a38x                mv_ebu         mvca9        armada_38x:CUSTOMER_BOARD_1,ARMADA_39X


### PR DESCRIPTION
This will allow to use nand-sata-install to perform the following operations on Helios4 :
- Install bootloader to SPI NOR Flash (Option 5 in Menu).
- Copy RootFS to USB storage in order to boot from SPI with RootFS on USB (Option 6 in Menu).

Note: To make the above install functions available, user will need to be enable temporarily spi_workaround in armbianEnv.txt

You can refer to our wiki page for instruction : https://wiki.kobol.io/spi/