### PR TITLE
check the return code of customize_image.sh for errors

### DIFF
--- a/lib/image-helpers.sh
+++ b/lib/image-helpers.sh
@@ -113,8 +113,12 @@ customize_image()
 	mount -o bind,ro $SRC/userpatches/overlay $SDCARD/tmp/overlay
 	display_alert "Calling image customization script" "customize-image.sh" "info"
 	chroot $SDCARD /bin/bash -c "/tmp/customize-image.sh $RELEASE $LINUXFAMILY $BOARD $BUILD_DESKTOP"
+	CUSTOMIZE_IMAGE_RC=$?
 	umount $SDCARD/tmp/overlay
 	mountpoint -q $SDCARD/tmp/overlay || rm -r $SDCARD/tmp/overlay
+	if [[ $CUSTOMIZE_IMAGE_RC != 0 ]]; then
+		exit_with_error "customize-image.sh exited with error (rc: $CUSTOMIZE_IMAGE_RC)"
+	fi
 } #############################################################################
 
 install_deb_chroot()


### PR DESCRIPTION
This is a fairly simple change that we use together with `set -e` when running our customize_image.sh

Failing commands in the script could otherwise lead to unexpected errors in the resulting image.