### PR TITLE
- Corrected the f2fs and btrfs emmc write, due to a missing rootfstyp…

### DIFF
--- a/packages/bsp/common/usr/sbin/nand-sata-install
+++ b/packages/bsp/common/usr/sbin/nand-sata-install
@@ -236,6 +236,11 @@ create_armbian()
 			echo "$emmcbootuuid	/media/mmcboot	ext4    ${mountopts[ext4]}" >> ${TempDir}/rootfs/etc/fstab
 			echo "/media/mmcboot/boot   				/boot		none	bind								0       0" >> ${TempDir}/rootfs/etc/fstab
 		fi
+		# if the rootfstype is not defined as cmdline argument on armbianEnv.txt
+		if grep -qE '^rootfstype=.*' ${TempDir}/bootfs/boot/armbianEnv.txt; then
+			# Add the line of type of the selected rootfstype to the file armbianEnv.txt
+			echo "rootfstype=$choosen_fs" >> ${TempDir}/bootfs/boot/armbianEnv.txt
+		fi
 
 		if [[ $eMMCFilesystemChoosen =~ ^(btrfs|f2fs)$ ]]; then
 			echo "$targetuuid	/		$choosen_fs	${mountopts[$choosen_fs]}" >> ${TempDir}/rootfs/etc/fstab


### PR DESCRIPTION
- Corrected the f2fs and btrfs emmc write, due to a missing rootfstype key missing on the armbianEnv.txt

Please use the "Preview" tab above to view this message if you are seeing this in the new pull request text box.

Please make sure that:

 - pull request is opened to the `master` branch unless you are working on a specfic feature which is developed in a separate branch
 - any changes to kernel configuration files were made by Kconfig menu (build script option `KERNEL_CONFIGURE=yes`) and not by editing configuration files by hand,
 - patch file names don't contain spaces and have less than 40 characters (not counting the `.patch` extension),
 - changes are properly described - what was done exactly and why.

Thanks for contributing! Please remove the text above before opening a pull request.
