### PR TITLE
Where a board config uses a modern kernel and is already using either stretch or bionic, enable both distributions.

### DIFF
--- a/config/boards/bananapim3.csc
+++ b/config/boards/bananapim3.csc
@@ -8,7 +8,7 @@ MODULES_NEXT=""
 OVERLAY_PREFIX="sun8i-a83t"
 #
 KERNEL_TARGET="dev"
-CLI_TARGET="stretch:dev"
-DESKTOP_TARGET="stretch:dev"
+CLI_TARGET="stretch,bionic:dev"
+DESKTOP_TARGET="stretch,bionic:dev"
 #
 CLI_BETA_TARGET=""

--- a/config/boards/cubox-i.conf
+++ b/config/boards/cubox-i.conf
@@ -8,4 +8,4 @@ MODULES_NEXT="bonding"
 #
 KERNEL_TARGET="default,next"
 CLI_TARGET="stretch,bionic:default,next"
-DESKTOP_TARGET="bionic:default,next"
+DESKTOP_TARGET="stretch,bionic:default,next"

--- a/config/boards/firefly-rk3399.csc
+++ b/config/boards/firefly-rk3399.csc
@@ -7,8 +7,8 @@ MODULES=""
 MODULES_NEXT=""
 #
 KERNEL_TARGET="default,dev"
-CLI_TARGET="stretch:default"
-DESKTOP_TARGET="bionic:default"
+CLI_TARGET="stretch,bionic:default"
+DESKTOP_TARGET="stretch,bionic:default"
 #
 CLI_BETA_TARGET="stretch,bionic:dev"
 DESKTOP_BETA_TARGET=""

--- a/config/boards/helios4.conf
+++ b/config/boards/helios4.conf
@@ -6,6 +6,6 @@ MODULES="mv_cesa"
 BUILD_DESKTOP="no"
 
 KERNEL_TARGET="default,next"
-CLI_TARGET="bionic,stretch:next"
+CLI_TARGET="stretch,bionic:next"
 
 CLI_BETA_TARGET=""

--- a/config/boards/lepotato.conf
+++ b/config/boards/lepotato.conf
@@ -7,8 +7,8 @@ MODULES=""
 MODULES_NEXT=""
 #
 KERNEL_TARGET="default,next,dev"
-CLI_TARGET="stretch:default,next"
-DESKTOP_TARGET="stretch:default,next"
+CLI_TARGET="stretch,bionic:default,next"
+DESKTOP_TARGET="stretch,bionic:default,next"
 #
 CLI_BETA_TARGET=""
 DESKTOP_BETA_TARGET=""

--- a/config/boards/miqi.eos
+++ b/config/boards/miqi.eos
@@ -7,8 +7,8 @@ MODULES=""
 MODULES_NEXT=""
 #
 KERNEL_TARGET="default,next,dev"
-CLI_TARGET="stretch:default,next"
-DESKTOP_TARGET="bionic:default,next"
+CLI_TARGET="stretch,bionic:default,next"
+DESKTOP_TARGET="stretch,bionic:default,next"
 #
 CLI_BETA_TARGET=""
 DESKTOP_BETA_TARGET=""

--- a/config/boards/nanopct3.conf
+++ b/config/boards/nanopct3.conf
@@ -9,7 +9,7 @@ CPUMIN="400000"
 CPUMAX="1400000"
 #
 KERNEL_TARGET="next"
-CLI_TARGET="stretch:next"
-DESKTOP_TARGET="bionic:next"
+CLI_TARGET="stretch,bionic:next"
+DESKTOP_TARGET="stretch,bionic:next"
 #
 CLI_BETA_TARGET=""

--- a/config/boards/nanopct3plus.conf
+++ b/config/boards/nanopct3plus.conf
@@ -9,7 +9,7 @@ CPUMIN="400000"
 CPUMAX="1400000"
 #
 KERNEL_TARGET="next"
-CLI_TARGET="stretch:next"
-DESKTOP_TARGET="bionic:next"
+CLI_TARGET="stretch,bionic:next"
+DESKTOP_TARGET="stretch,bionic:next"
 #
 CLI_BETA_TARGET=""

--- a/config/boards/nanopct4.conf
+++ b/config/boards/nanopct4.conf
@@ -7,8 +7,8 @@ MODULES=""
 MODULES_NEXT=""
 #
 KERNEL_TARGET="default,dev"
-CLI_TARGET="stretch:default"
-DESKTOP_TARGET="bionic:default"
+CLI_TARGET="stretch,bionic:default"
+DESKTOP_TARGET="stretch,bionic:default"
 
 CLI_BETA_TARGET="stretch,bionic:dev"
 DESKTOP_BETA_TARGET=""

--- a/config/boards/nanopifire3.conf
+++ b/config/boards/nanopifire3.conf
@@ -9,8 +9,8 @@ CPUMIN="400000"
 CPUMAX="1400000"
 #
 KERNEL_TARGET="next"
-CLI_TARGET="stretch:next"
-DESKTOP_TARGET="bionic:next"
+CLI_TARGET="stretch,bionic:next"
+DESKTOP_TARGET="stretch,bionic:next"
 #
 CLI_BETA_TARGET=""
 

--- a/config/boards/nanopik1plus.conf
+++ b/config/boards/nanopik1plus.conf
@@ -8,7 +8,7 @@ CPUMIN="408000"
 CPUMAX="1296000"
 #
 KERNEL_TARGET="next,dev"
-CLI_TARGET="bionic,stretch:next"
+CLI_TARGET="stretch,bionic:next"
 DESKTOP_TARGET=""
 #
 CLI_BETA_TARGET=""

--- a/config/boards/nanopik2-s905.conf
+++ b/config/boards/nanopik2-s905.conf
@@ -7,8 +7,8 @@ MODULES=""
 MODULES_NEXT=""
 #
 KERNEL_TARGET="default,next,dev"
-CLI_TARGET="stretch:default,next"
-DESKTOP_TARGET="stretch:default,next"
+CLI_TARGET="stretch,bionic:default,next"
+DESKTOP_TARGET="stretch,bionic:default,next"
 CLI_BETA_TARGET=""
 DESKTOP_BETA_TARGET=""
 

--- a/config/boards/nanopim3.eos
+++ b/config/boards/nanopim3.eos
@@ -9,7 +9,7 @@ CPUMIN="400000"
 CPUMAX="1400000"
 #
 KERNEL_TARGET="next"
-CLI_TARGET="stretch:next"
-DESKTOP_TARGET="bionic:next"
+CLI_TARGET="stretch,bionic:next"
+DESKTOP_TARGET="stretch,bionic:next"
 #
 CLI_BETA_TARGET=""

--- a/config/boards/nanopim4.conf
+++ b/config/boards/nanopim4.conf
@@ -7,8 +7,8 @@ MODULES=""
 MODULES_NEXT=""
 #
 KERNEL_TARGET="default,dev"
-CLI_TARGET="stretch:default"
-DESKTOP_TARGET="bionic:default"
+CLI_TARGET="stretch,bionic:default"
+DESKTOP_TARGET="stretch,bionic:default"
 
 CLI_BETA_TARGET="stretch,bionic:dev"
 DESKTOP_BETA_TARGET=""

--- a/config/boards/nanopineo4.conf
+++ b/config/boards/nanopineo4.conf
@@ -7,8 +7,8 @@ MODULES=""
 MODULES_NEXT=""
 #
 KERNEL_TARGET="default,dev"
-CLI_TARGET="stretch:default"
-DESKTOP_TARGET="bionic:default"
+CLI_TARGET="stretch,bionic:default"
+DESKTOP_TARGET="stretch,bionic:default"
 
 CLI_BETA_TARGET="stretch,bionic:dev"
 DESKTOP_BETA_TARGET=""

--- a/config/boards/nanopineocore2.conf
+++ b/config/boards/nanopineocore2.conf
@@ -12,6 +12,6 @@ CPUMAX="1392000"
 BUILD_DESKTOP="no"
 #
 KERNEL_TARGET="next,dev"
-CLI_TARGET="bionic,stretch:next"
+CLI_TARGET="stretch,bionic:next"
 #
 CLI_BETA_TARGET=""

--- a/config/boards/orangepiprime.conf
+++ b/config/boards/orangepiprime.conf
@@ -8,8 +8,8 @@ CPUMIN="120000"
 CPUMAX="1400000"
 #
 KERNEL_TARGET="next,dev"
-CLI_TARGET="stretch:next"
-DESKTOP_TARGET="stretch:next"
+CLI_TARGET="stretch,bionic:next"
+DESKTOP_TARGET="stretch,bionic:next"
 #
 CLI_BETA_TARGET=""
 DESKTOP_BETA_TARGET=""

--- a/config/boards/renegade.conf
+++ b/config/boards/renegade.conf
@@ -7,8 +7,8 @@ MODULES=""
 MODULES_NEXT=""
 #
 KERNEL_TARGET="default,dev"
-CLI_TARGET="bionic:default"
-DESKTOP_TARGET="bionic:default"
+CLI_TARGET="stretch,bionic:default"
+DESKTOP_TARGET="stretch,bionic:default"
 #
 CLI_BETA_TARGET=""
 DESKTOP_BETA_TARGET=""

--- a/config/boards/rock64.conf
+++ b/config/boards/rock64.conf
@@ -7,8 +7,8 @@ MODULES=""
 MODULES_NEXT=""
 #
 KERNEL_TARGET="default,dev"
-CLI_TARGET="bionic:default"
-DESKTOP_TARGET="stretch:default"
+CLI_TARGET="stretch,bionic:default"
+DESKTOP_TARGET="stretch,bionic:default"
 #
 CLI_BETA_TARGET=""
 DESKTOP_BETA_TARGET=""

--- a/config/boards/rockpro64.wip
+++ b/config/boards/rockpro64.wip
@@ -7,8 +7,8 @@ MODULES=""
 MODULES_NEXT=""
 #
 KERNEL_TARGET="default,dev"
-CLI_TARGET="stretch:default"
-DESKTOP_TARGET="bionic:default"
+CLI_TARGET="stretch,bionic:default"
+DESKTOP_TARGET="stretch,bionic:default"
 
 CLI_BETA_TARGET=""
 DESKTOP_BETA_TARGET=""

--- a/config/boards/tinkerboard.conf
+++ b/config/boards/tinkerboard.conf
@@ -7,8 +7,8 @@ MODULES="hci_uart rfcomm hidp 8723bs"
 MODULES_NEXT=""
 #
 KERNEL_TARGET="default,next,dev"
-CLI_TARGET="stretch:default,next"
-DESKTOP_TARGET="bionic:default,next"
+CLI_TARGET="stretch,bionic:default,next"
+DESKTOP_TARGET="stretch,bionic:default,next"
 #
 CLI_BETA_TARGET=""
 DESKTOP_BETA_TARGET=""

--- a/config/boards/tritium-h3.csc
+++ b/config/boards/tritium-h3.csc
@@ -10,5 +10,5 @@ CPUMIN="240000"
 CPUMAX="912000"
 #
 KERNEL_TARGET="next,dev"
-CLI_TARGET="bionic,stretch:next"
+CLI_TARGET="stretch,bionic:next"
 DESKTOP_TARGET=""

--- a/config/boards/tritium-h5.csc
+++ b/config/boards/tritium-h5.csc
@@ -11,7 +11,7 @@ CPUMAX="1200000"
 #
 KERNEL_TARGET="next,dev"
 CLI_TARGET="stretch,bionic:next"
-DESKTOP_TARGET="bionic:next"
+DESKTOP_TARGET="stretch,bionic:next"
 #
 CLI_BETA_TARGET=""
 #

--- a/config/boards/udoo.eos
+++ b/config/boards/udoo.eos
@@ -6,5 +6,5 @@ MODULES=""
 MODULES_NEXT=""
 #
 KERNEL_TARGET="next"
-CLI_TARGET="bionic,stretch:next"
+CLI_TARGET="stretch,bionic:next"
 DESKTOP_TARGET=""

--- a/config/boards/z28pro.csc
+++ b/config/boards/z28pro.csc
@@ -7,8 +7,8 @@ MODULES=""
 MODULES_NEXT=""
 #
 KERNEL_TARGET="default"
-CLI_TARGET="stretch:default"
-DESKTOP_TARGET="bionic:default"
+CLI_TARGET="stretch,bionic:default"
+DESKTOP_TARGET="stretch,bionic:default"
 #
 CLI_BETA_TARGET=""
 DESKTOP_BETA_TARGET=""


### PR DESCRIPTION
Some platforms are missing either Bionic or Stretch distributions.

When a platform is using a kernel >= 3.10, we can use both.

This PR also lists the 2 distros in a consistent order.