### PR TITLE
Fix broken ATF compile

### DIFF
--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -58,7 +58,7 @@ compile_atf()
 	[[ $CREATE_PATCHES == yes ]] && userpatch_create "atf"
 
 	eval CCACHE_BASEDIR="$(pwd)" env PATH=$toolchain:$toolchain2:$PATH \
-		'make $target_make $CTHREADS CROSS_COMPILE="$CCACHE $ATF_COMPILER"' 2>&1 \
+		'make ENABLE_BACKTRACE="0" $target_make $CTHREADS CROSS_COMPILE="$CCACHE $ATF_COMPILER"' 2>&1 \
 		${PROGRESS_LOG_TO_FILE:+' | tee -a $DEST/debug/compilation.log'} \
 		${OUTPUT_DIALOG:+' | dialog --backtitle "$backtitle" --progressbox "Compiling ATF..." $TTY_Y $TTY_X'} \
 		${OUTPUT_VERYSILENT:+' >/dev/null 2>/dev/null'}


### PR DESCRIPTION
Crude fix to make it work again. For H6 at least. Others untested.

```
[...]
[ o.k. ] Cleaning output/debs for [ orangepioneplus dev ]
[ o.k. ] Cleaning [ arm-trusted-firmware-sunxi-mainline/master ]
[ o.k. ] Compiling ATF
[ o.k. ] Compiler version [ aarch64-linux-gnu-gcc 6.4.1 ]
[ o.k. ] Started patching process for [ atf sunxi64-orangepioneplus-dev ]
[ o.k. ] Looking for user patches in [ userpatches/atf/atf-sunxi64 ]
[ warn ] * [l][c] enable-additional-regulators.patch [ failed ]
[ warn ] * [l][c] set-rsb-to-nonsec.patch [ failed ]
  CC      drivers/arm/gic/common/gic_common.c
  CC      drivers/arm/gic/v2/gicv2_helpers.c
  CC      drivers/arm/gic/v2/gicv2_main.c
  CC      drivers/delay_timer/delay_timer.c
  CC      drivers/delay_timer/generic_delay_timer.c
  CC      plat/common/plat_gicv2.c
  CC      plat/common/plat_psci_common.c
  CC      plat/allwinner/common/sunxi_bl31_setup.c
  CC      plat/allwinner/common/sunxi_cpu_ops.c
  CC      plat/allwinner/common/sunxi_pm.c
  CC      plat/allwinner/sun50i_h6/sunxi_power.c
  CC      plat/allwinner/common/sunxi_security.c
  CC      plat/allwinner/common/sunxi_topology.c
  CC      bl31/bl31_main.c
  CC      bl31/interrupt_mgmt.c
  CC      bl31/bl31_context_mgmt.c
  CC      common/runtime_svc.c
  CC      services/arm_arch_svc/arm_arch_svc_setup.c
  CC      services/std_svc/std_svc_setup.c
  CC      lib/el3_runtime/cpu_data_array.c
  CC      lib/el3_runtime/aarch64/context_mgmt.c
  CC      lib/cpus/errata_report.c
  CC      lib/psci/psci_off.c
  CC      lib/psci/psci_on.c
  CC      lib/psci/psci_suspend.c
  CC      lib/psci/psci_common.c
  CC      lib/psci/psci_main.c
  CC      lib/psci/psci_setup.c
  CC      lib/psci/psci_system_off.c
  CC      lib/psci/psci_mem_protect.c
  CC      lib/locks/bakery/bakery_lock_normal.c
  CC      lib/extensions/spe/spe.c
  CC      lib/extensions/sve/sve.c
  CC      common/bl_common.c
  CC      common/tf_log.c
  CC      plat/common/plat_bl_common.c
  CC      plat/common/plat_log_common.c
  CC      plat/common/aarch64/plat_common.c
  CC      lib/xlat_tables_v2/aarch64/xlat_tables_arch.c
  CC      lib/xlat_tables_v2/xlat_tables_context.c
  CC      lib/xlat_tables_v2/xlat_tables_core.c
  CC      lib/xlat_tables_v2/xlat_tables_utils.c
  CC      plat/allwinner/common/sunxi_common.c
  CC      drivers/mentor/i2c/mi2cv.c
  AS      lib/cpus/aarch64/cortex_a53.S
  AS      bl31/aarch64/bl31_entrypoint.S
  AS      bl31/aarch64/crash_reporting.S
  AS      bl31/aarch64/ea_delegate.S
  AS      bl31/aarch64/runtime_exceptions.S
  AS      lib/aarch64/setjmp.S
  AS      lib/cpus/aarch64/dsu_helpers.S
  AS      plat/common/aarch64/platform_mp_stack.S
  AS      lib/el3_runtime/aarch64/cpu_data.S
  AS      lib/cpus/aarch64/cpu_helpers.S
  AS      lib/locks/exclusive/aarch64/spinlock.S
  AS      lib/psci/aarch64/psci_helpers.S
  AS      lib/el3_runtime/aarch64/context.S
  AS      lib/cpus/aarch64/wa_cve_2017_5715_bpiall.S
  AS      lib/cpus/aarch64/wa_cve_2017_5715_mmu.S
  AS      common/aarch64/debug.S
  AS      lib/aarch64/cache_helpers.S
  AS      lib/aarch64/misc_helpers.S
  AS      plat/common/aarch64/platform_helpers.S
  AS      drivers/console/aarch64/console.S
  AS      drivers/ti/uart/aarch64/16550_console.S
  AS      lib/xlat_tables_v2/aarch64/enable_mmu.S
  AS      plat/allwinner/common/plat_helpers.S
  PP      bl31/bl31.ld.S
  CC      lib/libfdt/fdt.c
  CC      lib/libfdt/fdt_empty_tree.c
  CC      lib/libfdt/fdt_ro.c
  CC      lib/libfdt/fdt_addresses.c
  CC      lib/libfdt/fdt_rw.c
  CC      lib/libfdt/fdt_sw.c
  CC      lib/libfdt/fdt_wip.c
  CC      lib/libfdt/fdt_strerror.c
  CC      lib/libc/abort.c
  CC      lib/libc/memchr.c
  CC      lib/libc/assert.c
  CC      lib/libc/exit.c
  CC      lib/libc/memcmp.c
  CC      lib/libc/memcpy.c
  CC      lib/libc/memmove.c
  CC      lib/libc/memset.c
  CC      lib/libc/printf.c
  CC      lib/libc/putchar.c
  CC      lib/libc/puts.c
  CC      lib/libc/strchr.c
  CC      lib/libc/strcmp.c
  CC      lib/libc/snprintf.c
  CC      lib/libc/strlcpy.c
  CC      lib/libc/strlen.c
  CC      lib/libc/strncmp.c
  CC      lib/libc/strnlen.c
  CC      lib/libc/strrchr.c
  AR      build/sun50i_h6/debug/lib/libc.a
  AR      build/sun50i_h6/debug/lib/libfdt.a
  LD      build/sun50i_h6/debug/bl31/bl31.elf
  BIN     build/sun50i_h6/debug/bl31.bin
  OD      build/sun50i_h6/debug/bl31/bl31.dump

Built build/sun50i_h6/debug/bl31.bin successfully

[ o.k. ] Cleaning [ u-boot/h6-hdmi-rebased-1 ]
[ o.k. ] Compiling u-boot [ 2018.09-rc1 ]
[ o.k. ] Compiler version [ aarch64-linux-gnu-gcc 7.2.1 ]
[ .... ] Checking out sources
[ o.k. ] Cleaning [ u-boot/h6-hdmi-rebased-1 ]
[ o.k. ] Started patching process for [ u-boot sunxi64-orangepioneplus-dev ]
[ o.k. ] Looking for user patches in [ userpatches/u-boot/u-boot-sun50iw6 ]
[ o.k. ] * [l][c] add-orangepilite_2.patch
'/home/build/build/.tmp/atf-sunxi64-orangepioneplus-dev/bl31.bin' -> './bl31.bin'
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o

[...]
```