### PR TITLE
Fix for broken overlays (fdt apply) on rockchip

### DIFF
--- a/patch/u-boot/u-boot-rockchip64-dev/enable-DT-overlays-support.patch
+++ b/patch/u-boot/u-boot-rockchip64-dev/enable-DT-overlays-support.patch
@@ -2,10 +2,10 @@ diff --git a/arch/arm/Kconfig b/arch/arm/Kconfig
 index 0e8dc01..22170d2 100644
 --- a/arch/arm/Kconfig
 +++ b/arch/arm/Kconfig
-@@ -1082,6 +1082,8 @@ config ARCH_ROCKCHIP
- 	select DM_PWM
- 	select DM_REGULATOR
- 	imply FAT_WRITE
+@@ -1125,6 +1125,8 @@ config ARCH_ROCKCHIP
+	imply TPL_SYSRESET
+	imply ADC
+	imply SARADC_ROCKCHIP
 +	select OF_LIBFDT
 +	select OF_LIBFDT_OVERLAY
  


### PR DESCRIPTION
Repaired broken Rock patch for current Kconfig
Current version of u-boot patch is not synchronized with current codebase,
Then changes are applied to wrong part of code and u-boot fdt apply is not working on rockchip64.
