### PR TITLE
Reworked and enabled usb phy reset patch when waking up for rk3288 devices

### DIFF
--- a/patch/kernel/rockchip-default/xt-q8l-v10-add-device-tree.patch
+++ b/patch/kernel/rockchip-default/xt-q8l-v10-add-device-tree.patch
@@ -1,5 +1,5 @@
---- a/arch/arm/boot/dts/rk3288-xt-q8l-v10.dts	1970-01-01 01:00:00.000000000 +0100
-+++ b/arch/arm/boot/dts/rk3288-xt-q8l-v10.dts	2018-09-23 15:07:34.436815846 +0200
+--- /dev/null	2018-11-29 17:19:47.960000000 +0000
++++ b/arch/arm/boot/dts/rk3288-xt-q8l-v10.dts	2018-09-23 13:07:34.000000000 +0000
 @@ -0,0 +1,1120 @@
 +/*
 + * Copyright (c) 2014, 2015 FUKAUMI Naoki <naobsd@gmail.com>

--- a/patch/kernel/rockchip-dev/ARM-DTSI-rk3288-add-usbphy-reset.patch
+++ b/patch/kernel/rockchip-dev/ARM-DTSI-rk3288-add-usbphy-reset.patch
@@ -1,0 +1,31 @@
+diff --git a/arch/arm/boot/dts/rk3288.dtsi b/arch/arm/boot/dts/rk3288.dtsi
+index 0840ffb3..5393f2cd 100644
+--- a/arch/arm/boot/dts/rk3288.dtsi
++++ b/arch/arm/boot/dts/rk3288.dtsi
+@@ -894,6 +894,8 @@
+ 				reg = <0x320>;
+ 				clocks = <&cru SCLK_OTGPHY0>;
+ 				clock-names = "phyclk";
++				resets = <&cru SRST_USBOTG_PHY>;
++				reset-names = "phy-reset";
+ 				#clock-cells = <0>;
+ 			};
+ 
+@@ -902,6 +904,8 @@
+ 				reg = <0x334>;
+ 				clocks = <&cru SCLK_OTGPHY1>;
+ 				clock-names = "phyclk";
++				resets = <&cru SRST_USBHOST0_PHY>;
++				reset-names = "phy-reset";
+ 				#clock-cells = <0>;
+ 			};
+ 
+@@ -910,6 +914,8 @@
+ 				reg = <0x348>;
+ 				clocks = <&cru SCLK_OTGPHY2>;
+ 				clock-names = "phyclk";
++				resets = <&cru SRST_USBHOST1_PHY>;
++				reset-names = "phy-reset";
+ 				#clock-cells = <0>;
+ 			};
+ 		};

--- a/patch/kernel/rockchip-dev/assert-phy-reset-when-waking-up-in-rk3288-platform.patch
+++ b/patch/kernel/rockchip-dev/assert-phy-reset-when-waking-up-in-rk3288-platform.patch
@@ -1,38 +1,38 @@
 diff --git a/drivers/usb/dwc2/core.h b/drivers/usb/dwc2/core.h
-index 9548d3e..0cd5896 100644
+index cc9c93af..3ff41d87 100644
 --- a/drivers/usb/dwc2/core.h
 +++ b/drivers/usb/dwc2/core.h
-@@ -919,6 +919,7 @@  struct dwc2_hsotg {
- 	unsigned int ll_hw_enabled:1;
+@@ -1021,6 +1021,7 @@ struct dwc2_hsotg {
+ 	u16 frame_number;
  
  	struct phy *phy;
 +	struct work_struct phy_rst_work;
  	struct usb_phy *uphy;
  	struct dwc2_hsotg_plat *plat;
- 	struct regulator_bulk_data supplies[ARRAY_SIZE(dwc2_hsotg_supply_names)];
+ 	struct regulator_bulk_data supplies[DWC2_NUM_SUPPLIES];
 diff --git a/drivers/usb/dwc2/core_intr.c b/drivers/usb/dwc2/core_intr.c
-index 5b228ba..bf1c029 100644
+index 19ae2595..f1270bf1 100644
 --- a/drivers/usb/dwc2/core_intr.c
 +++ b/drivers/usb/dwc2/core_intr.c
-@@ -345,6 +345,7 @@  static void dwc2_handle_session_req_intr(struct dwc2_hsotg *hsotg)
+@@ -396,6 +396,7 @@ static void dwc2_wakeup_from_lpm_l1(struct dwc2_hsotg *hsotg)
  static void dwc2_handle_wakeup_detected_intr(struct dwc2_hsotg *hsotg)
  {
  	int ret;
 +	struct device_node *np = hsotg->dev->of_node;
  
  	/* Clear interrupt */
- 	dwc2_writel(GINTSTS_WKUPINT, hsotg->regs + GINTSTS);
-@@ -379,6 +380,16 @@  static void dwc2_handle_wakeup_detected_intr(struct dwc2_hsotg *hsotg)
+ 	dwc2_writel(hsotg, GINTSTS_WKUPINT, GINTSTS);
+@@ -435,6 +436,16 @@ static void dwc2_handle_wakeup_detected_intr(struct dwc2_hsotg *hsotg)
  			/* Restart the Phy Clock */
  			pcgcctl &= ~PCGCTL_STOPPCLK;
- 			dwc2_writel(pcgcctl, hsotg->regs + PCGCTL);
+ 			dwc2_writel(hsotg, pcgcctl, PCGCTL);
 +
 +			/*
 +			 * It is a quirk in Rockchip RK3288, causing by
 +			 * a hardware bug. This will propagate out and
 +			 * eventually we'll re-enumerate the device.
 +			 * Not great but the best we can do.
-+			 */
++			*/
 +			if (of_device_is_compatible(np, "rockchip,rk3288-usb"))
 +				schedule_work(&hsotg->phy_rst_work);
 +
@@ -40,10 +40,10 @@ index 5b228ba..bf1c029 100644
  				  jiffies + msecs_to_jiffies(71));
  		} else {
 diff --git a/drivers/usb/dwc2/platform.c b/drivers/usb/dwc2/platform.c
-index 4fc8c60..8ef278e 100644
+index 57764289..748763bd 100644
 --- a/drivers/usb/dwc2/platform.c
 +++ b/drivers/usb/dwc2/platform.c
-@@ -207,6 +207,14 @@  int dwc2_lowlevel_hw_disable(struct dwc2_hsotg *hsotg)
+@@ -208,6 +208,14 @@ int dwc2_lowlevel_hw_disable(struct dwc2_hsotg *hsotg)
  	return ret;
  }
  
@@ -58,7 +58,7 @@ index 4fc8c60..8ef278e 100644
  static int dwc2_lowlevel_hw_init(struct dwc2_hsotg *hsotg)
  {
  	int i, ret;
-@@ -251,6 +259,7 @@  static int dwc2_lowlevel_hw_init(struct dwc2_hsotg *hsotg)
+@@ -252,6 +260,7 @@ static int dwc2_lowlevel_hw_init(struct dwc2_hsotg *hsotg)
  			return ret;
  		}
  	}
@@ -66,4 +66,3 @@ index 4fc8c60..8ef278e 100644
  
  	if (!hsotg->phy) {
  		hsotg->uphy = devm_usb_get_phy(hsotg->dev, USB_PHY_TYPE_USB2);
-

--- a/patch/kernel/rockchip-dev/xt-q8l-v10-add-device-tree.patch
+++ b/patch/kernel/rockchip-dev/xt-q8l-v10-add-device-tree.patch
@@ -1,6 +1,6 @@
---- a/arch/arm/boot/dts/rk3288-xt-q8l-v10.dts	1970-01-01 01:00:00.000000000 +0100
-+++ b/arch/arm/boot/dts/rk3288-xt-q8l-v10.dts	2018-09-23 15:07:23.816787921 +0200
-@@ -0,0 +1,969 @@
+--- /dev/null	2018-11-29 17:19:47.960000000 +0000
++++ b/arch/arm/boot/dts/rk3288-xt-q8l-v10.dts	2018-11-29 21:12:34.069256135 +0000
+@@ -0,0 +1,951 @@
 +/*
 + * Copyright (c) 2014, 2015 FUKAUMI Naoki <naobsd@gmail.com>
 + * 					   2018 Paolo Sabatino <paolo.sabatino@gm**l.com>
@@ -880,19 +880,10 @@
 +};
 + 
 +&usbphy0 {
-+    resets = <&cru SRST_USBOTG_PHY>;
-+    reset-names = "phy-reset";
 +    vbus-supply = <&vcc_otg_5v>;
 +};
 +
-+&usbphy1 {
-+    resets = <&cru SRST_USBHOST0_PHY>;
-+    reset-names = "phy-reset";
-+};
-+
 +&usbphy2 {
-+    resets = <&cru SRST_USBHOST1_PHY>;
-+    reset-names = "phy-reset";
 +    vbus-supply = <&vcc_host_5v>;
 +};
 +
@@ -950,15 +941,6 @@
 +&wdt {
 +	status = "okay";
 +};
-+
-+/* q8 device tree specifies that pwm0 is enabled on the device and
-+ * this is the device which listens for IR remote control
-+ */
-+/*
-+&pwm0 {
-+	status = "okay";
-+};
-+*/
 +
 +// i2s bus is present on q8 device, enable it
 +&i2s {

--- a/patch/kernel/rockchip-next/ARM-DTSI-rk3288-add-usbphy-reset.patch
+++ b/patch/kernel/rockchip-next/ARM-DTSI-rk3288-add-usbphy-reset.patch
@@ -1,0 +1,31 @@
+diff --git a/arch/arm/boot/dts/rk3288.dtsi b/arch/arm/boot/dts/rk3288.dtsi
+index f7a951afd..b32106332 100644
+--- a/arch/arm/boot/dts/rk3288.dtsi
++++ b/arch/arm/boot/dts/rk3288.dtsi
+@@ -880,6 +880,8 @@
+ 				reg = <0x320>;
+ 				clocks = <&cru SCLK_OTGPHY0>;
+ 				clock-names = "phyclk";
++				resets = <&cru SRST_USBOTG_PHY>;
++				reset-names = "phy-reset";
+ 				#clock-cells = <0>;
+ 			};
+ 
+@@ -888,6 +890,8 @@
+ 				reg = <0x334>;
+ 				clocks = <&cru SCLK_OTGPHY1>;
+ 				clock-names = "phyclk";
++				resets = <&cru SRST_USBHOST0_PHY>;
++				reset-names = "phy-reset";
+ 				#clock-cells = <0>;
+ 			};
+ 
+@@ -896,6 +900,8 @@
+ 				reg = <0x348>;
+ 				clocks = <&cru SCLK_OTGPHY2>;
+ 				clock-names = "phyclk";
++				resets = <&cru SRST_USBHOST1_PHY>;
++				reset-names = "phy-reset";
+ 				#clock-cells = <0>;
+ 			};
+ 		};

--- a/patch/kernel/rockchip-next/xt-q8l-v10-add-device-tree.patch
+++ b/patch/kernel/rockchip-next/xt-q8l-v10-add-device-tree.patch
@@ -1,6 +1,6 @@
---- a/arch/arm/boot/dts/rk3288-xt-q8l-v10.dts	1970-01-01 01:00:00.000000000 +0100
-+++ b/arch/arm/boot/dts/rk3288-xt-q8l-v10.dts	2018-09-23 15:07:44.968843202 +0200
-@@ -0,0 +1,960 @@
+--- /dev/null	2018-11-29 17:19:47.960000000 +0000
++++ b/arch/arm/boot/dts/rk3288-xt-q8l-v10.dts	2018-11-29 21:02:56.636665164 +0000
+@@ -0,0 +1,951 @@
 +/*
 + * Copyright (c) 2014, 2015 FUKAUMI Naoki <naobsd@gmail.com>
 + * 					   2018 Paolo Sabatino <paolo.sabatino@gm**l.com>
@@ -875,19 +875,10 @@
 +};
 + 
 +&usbphy0 {
-+    resets = <&cru SRST_USBOTG_PHY>;
-+    reset-names = "phy-reset";
 +    vbus-supply = <&vcc_otg_5v>;
 +};
 +
-+&usbphy1 {
-+    resets = <&cru SRST_USBHOST0_PHY>;
-+    reset-names = "phy-reset";
-+};
-+
 +&usbphy2 {
-+    resets = <&cru SRST_USBHOST1_PHY>;
-+    reset-names = "phy-reset";
 +    vbus-supply = <&vcc_host_5v>;
 +};
 +

--- a/patch/u-boot/u-boot-rockchip/board_xt-q8l-v10/xt-q8l-v10-device-tree.patch
+++ b/patch/u-boot/u-boot-rockchip/board_xt-q8l-v10/xt-q8l-v10-device-tree.patch
@@ -1,5 +1,5 @@
---- a/arch/arm/dts/rk3288-xt-q8l-v10.dts	1970-01-01 01:00:00.000000000 +0100
-+++ b/arch/arm/dts/rk3288-xt-q8l-v10.dts	2018-09-23 14:59:27.243013399 +0200
+--- /dev/null	2018-11-29 17:19:47.960000000 +0000
++++ b/arch/arm/dts/rk3288-xt-q8l-v10.dts	2018-09-23 12:59:27.000000000 +0000
 @@ -0,0 +1,740 @@
 +/*
 + * Copyright (c) 2014, 2015 FUKAUMI Naoki <naobsd@gmail.com>


### PR DESCRIPTION
Reworked assert-phy-reset-when-waking-up patch to fit into 4.19 kernel DWC2 USB driver
Adding usbphy reset lines patch for rk3288.dtsi in both rockchip next and dev kernels
Removed same reset lines from xt-q8l-v10 next and dev device trees

@Tonymac32 FYI, this also re-enables assert-phy-reset-when-waking-up.patch for rockchip-dev 