### PR TITLE
Helios4: Add mdadm script and config to display raid error on Fault LED

### DIFF
--- a/config/sources/mvebu-helios4.inc
+++ b/config/sources/mvebu-helios4.inc
@@ -31,20 +31,37 @@ case $BRANCH in
 esac
 
 
-# Helios4 tweak : install and configure fancontrol
+# Helios4 tweak
 family_tweaks_s()
 {
-	chroot $SDCARD /bin/bash -c "apt-get -y -qq install fancontrol >/dev/null 2>&1"
+	# install fancontrol and mdadm
+	chroot $SDCARD /bin/bash -c "apt-get -y -qq install fancontrol mdadm >/dev/null 2>&1"
+
+	### Fancontrol tweaks
+
+	# copy hwmon rules to fix device mapping
+	cp $SRC/packages/bsp/helios4/90-helios4-hwmon.rules $SDCARD/etc/udev/rules.d/
+
+	# patch fancontrol
 	patch $SDCARD/usr/sbin/fancontrol $SRC/packages/bsp/helios4/fancontrol.patch
-	cp -R $SRC/packages/bsp/helios4/90-helios4-hwmon.rules $SDCARD/etc/udev/rules.d/
+
+	# copy fancontrol config
 	case $BRANCH in
 	default)
-		cp -R $SRC/packages/bsp/helios4/fancontrol_pwm-fan-mvebu-default.conf $SDCARD/etc/fancontrol
+		cp $SRC/packages/bsp/helios4/fancontrol_pwm-fan-mvebu-default.conf $SDCARD/etc/fancontrol
 		;;
-
 	next)
-		cp -R $SRC/packages/bsp/helios4/fancontrol_pwm-fan-mvebu-next.conf $SDCARD/etc/fancontrol
+		cp $SRC/packages/bsp/helios4/fancontrol_pwm-fan-mvebu-next.conf $SDCARD/etc/fancontrol
 		;;
 	esac
-}
 
+	### Mdadm tweaks
+
+	# copy mdadm-fault-led script and set right permission
+	cp $SRC/packages/bsp/helios4/mdadm-fault-led.sh $SDCARD/usr/sbin/
+	chmod a+x $SDCARD/usr/sbin/mdadm-fault-led.sh
+
+	# modify mdadm configuration
+	echo -e "\n # Trigger Fault Led script when an event is detected" >> $SDCARD/etc/mdadm/mdadm.conf
+	echo -e "PROGRAM /usr/sbin/mdadm-fault-led.sh" >> $SDCARD/etc/mdadm/mdadm.conf
+}

--- a/packages/bsp/helios4/mdadm-fault-led.sh
+++ b/packages/bsp/helios4/mdadm-fault-led.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Make Red Fault LED (LED2) reports mdadm error events.
+#
+EVENT=$1
+
+# RED Fault LED trigger
+# trigger none = LED not-blinking if LED on
+# trigger timer = LED blinking if LED on
+TRIGGER=/sys/class/leds/helios4\:red\:fault/trigger
+
+# RED Fault LED brightness
+# britghness 0 = LED off
+# britghness 1 = LED on
+BRIGHTNESS=/sys/class/leds/helios4\:red\:fault/brightness
+
+# Active component device of an array has been marked as faulty OR A newly noticed array appears to be degraded.
+if [[ $EVENT == "Fail" || $EVENT == "DegradedArray" ]]; then
+    echo none > $TRIGGER
+    echo 1 > $BRIGHTNESS
+fi
+
+# An md array started reconstruction
+if [ $EVENT == "RebuildStarted" ]; then
+    echo timer > $TRIGGER
+    echo 1 > $BRIGHTNESS
+fi
+
+# A spare component device which was being rebuilt to replace a faulty device has been successfully rebuilt and has been made active
+if [ $EVENT == "SpareActive" ]; then
+    echo none > $TRIGGER
+    echo 0 > $BRIGHTNESS
+fi
+
+# Test RED Fault LED
+if [ $EVENT == "TestMessage" ]; then
+    echo timer > $TRIGGER
+    echo 1 > $BRIGHTNESS
+    sleep 5
+    echo 0 > $BRIGHTNESS
+fi


### PR DESCRIPTION
Install mdadm and add script in order to make use of Helios4 fault led to display array error events. Refer to https://wiki.kobol.io/mdadm/#configure-fault-led