### PR TITLE
kernel: mvebu-next: Reduce performance impact on libata led trigger

### DIFF
--- a/patch/kernel/mvebu-next/91-01-libata-add-ledtrig-support.patch
+++ b/patch/kernel/mvebu-next/91-01-libata-add-ledtrig-support.patch
@@ -1,7 +1,7 @@
-From 5843af891d0dabf9bb80039cfe807d01e9495154 Mon Sep 17 00:00:00 2001
-From: Daniel Golle <daniel at makrotopia.org>
-Date: Fri, 12 Dec 2014 13:38:33 +0100
-Subject: libata: add ledtrig support
+From 3065579b76f738dd56960a8871d5d15b9f5a7a24 Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Sat, 13 Dec 2014 01:07:20 +0100
+Subject: [PATCH 1/2] libata: add ledtrig support
 
 This adds a LED trigger for each ATA port indicating disk activity.
 
@@ -13,7 +13,33 @@ In that way, if not selected, LED trigger support not will be
 included in libata-core and both, codepaths and structures remain
 untouched.
 
-Signed-off-by: Daniel Golle <daniel at makrotopia.org>
+I'm currently deploying this for the oxnas target in OpenWrt
+https://dev.openwrt.org/changeset/43675/
+
+v2: rebased to kernel/git/tj/libata.git
+    plus small corrections and comments added
+
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+URL: https://patchwork.ozlabs.org/patch/420733/
+[Aditya Prayoga:
+* Port forward
+* Change ATA_LEDS default to no
+* Reduce performance impact by moving ata_led_act() call from
+    ata_qc_new() to ata_qc_complete()]
+Signed-off-by: Aditya Prayoga <aditya@kobol.io>
+
+---
+
+If there is anything fundamentally wrong with that approach, I'd be
+glad for some advise on how to do it better.
+I conciously choose an #ifdev approach to make sure performance will
+not be affected for non-users of that code.
+
+Thanks
+
+Daniel
+
+---
 ---
  drivers/ata/Kconfig       | 16 ++++++++++++++
  drivers/ata/libata-core.c | 56 +++++++++++++++++++++++++++++++++++++++++++++++
@@ -21,7 +47,7 @@ Signed-off-by: Daniel Golle <daniel at makrotopia.org>
  3 files changed, 79 insertions(+)
 
 diff --git a/drivers/ata/Kconfig b/drivers/ata/Kconfig
-index 6aaa3f8..4e24b64 100644
+index 39b181d..a2c64ce 100644
 --- a/drivers/ata/Kconfig
 +++ b/drivers/ata/Kconfig
 @@ -46,6 +46,22 @@ config ATA_VERBOSE_ERROR
@@ -37,7 +63,7 @@ index 6aaa3f8..4e24b64 100644
 +	select NEW_LEDS
 +	select LEDS_CLASS
 +	select LEDS_TRIGGERS
-+	default y
++	default n
 +	help
 +	  This option adds a LED trigger for each registered ATA port.
 +	  It is used to drive disk activity leds connected via GPIO.
@@ -48,18 +74,10 @@ index 6aaa3f8..4e24b64 100644
  	bool "ATA ACPI Support"
  	depends on ACPI
 diff --git a/drivers/ata/libata-core.c b/drivers/ata/libata-core.c
-index b0b77b6..1400f4d 100644
+index 599e01b..65228f5 100644
 --- a/drivers/ata/libata-core.c
 +++ b/drivers/ata/libata-core.c
-@@ -728,6 +728,7 @@ u64 ata_tf_read_block(struct ata_taskfile *tf, struct ata_device *dev)
- 	return block;
- }
- 
-+
- /**
-  *	ata_build_rw_tf - Build ATA taskfile for given read/write request
-  *	@tf: Target ATA taskfile
-@@ -4757,6 +4758,30 @@ void swap_buf_le16(u16 *buf, unsigned int buf_words)
+@@ -5105,6 +5105,30 @@ void swap_buf_le16(u16 *buf, unsigned int buf_words)
  }
  
  /**
@@ -75,7 +93,7 @@ index b0b77b6..1400f4d 100644
 + */
 +static inline void ata_led_act(struct ata_port *ap)
 +{
-+#if CONFIG_ATA_LEDS
++#ifdef CONFIG_ATA_LEDS
 +#define LIBATA_BLINK_DELAY 20 /* ms */
 +	unsigned long led_delay = LIBATA_BLINK_DELAY;
 +
@@ -90,31 +108,32 @@ index b0b77b6..1400f4d 100644
   *	ata_qc_new_init - Request an available ATA command, and initialize it
   *	@dev: Device from whom we request an available command structure
   *	@tag: tag
-@@ -4780,6 +4805,9 @@ struct ata_queued_cmd *ata_qc_new_init(struct ata_device *dev, int tag)
- 		if (tag < 0)
- 			return NULL;
- 	}
-+#if CONFIG_ATA_LEDS
+@@ -5249,6 +5273,10 @@ void ata_qc_complete(struct ata_queued_cmd *qc)
+ 	/* Trigger the LED (if available) */
+ 	ledtrig_disk_activity(!!(qc->tf.flags & ATA_TFLAG_WRITE));
+ 
++#ifdef CONFIG_ATA_LEDS
 +	ata_led_act(ap);
 +#endif
- 
- 	qc = __ata_qc_from_tag(ap, tag);
- 	qc->tag = tag;
-@@ -5677,6 +5705,9 @@ struct ata_port *ata_port_alloc(struct ata_host *host)
++
+ 	/* XXX: New EH and old EH use different mechanisms to
+ 	 * synchronize EH with regular execution path.
+ 	 *
+@@ -6028,6 +6056,9 @@ struct ata_port *ata_port_alloc(struct ata_host *host)
  	ap->stats.unhandled_irq = 1;
  	ap->stats.idle_irq = 1;
  #endif
-+#if CONFIG_ATA_LEDS
++#ifdef CONFIG_ATA_LEDS
 +	ap->ledtrig = kzalloc(sizeof(struct led_trigger), GFP_KERNEL);
 +#endif
  	ata_sff_port_init(ap);
  
  	return ap;
-@@ -5698,6 +5729,12 @@ static void ata_host_release(struct device *gendev, void *res)
+@@ -6063,6 +6094,12 @@ static void ata_host_release(struct kref *kref)
  
  		kfree(ap->pmp_link);
  		kfree(ap->slave_link);
-+#if CONFIG_ATA_LEDS
++#ifdef CONFIG_ATA_LEDS
 +		if (ap->ledtrig) {
 +			led_trigger_unregister(ap->ledtrig);
 +			kfree(ap->ledtrig);
@@ -123,11 +142,11 @@ index b0b77b6..1400f4d 100644
  		kfree(ap);
  		host->ports[i] = NULL;
  	}
-@@ -6145,6 +6182,25 @@ int ata_host_register(struct ata_host *host, struct scsi_host_template *sht)
+@@ -6527,6 +6564,25 @@ int ata_host_register(struct ata_host *host, struct scsi_host_template *sht)
  		host->ports[i]->local_port_no = i + 1;
  	}
  
-+#if CONFIG_ATA_LEDS
++#ifdef CONFIG_ATA_LEDS
 +	/* register LED triggers for all ports */
 +	for (i = 0; i < host->n_ports; i++) {
 +		if (unlikely(!host->ports[i]->ledtrig))
@@ -150,7 +169,7 @@ index b0b77b6..1400f4d 100644
  	for (i = 0; i < host->n_ports; i++) {
  		rc = ata_tport_add(host->dev,host->ports[i]);
 diff --git a/include/linux/libata.h b/include/linux/libata.h
-index b20a275..50eeee3 100644
+index 38c95d6..3cc5f63 100644
 --- a/include/linux/libata.h
 +++ b/include/linux/libata.h
 @@ -38,6 +38,7 @@
@@ -161,7 +180,7 @@ index b20a275..50eeee3 100644
  
  /*
   * Define if arch has non-standard setup.  This is a _PCI_ standard
-@@ -877,6 +878,12 @@ struct ata_port {
+@@ -893,6 +894,12 @@ struct ata_port {
  #ifdef CONFIG_ATA_ACPI
  	struct ata_acpi_gtm	__acpi_init_gtm; /* use ata_acpi_init_gtm() */
  #endif

--- a/patch/kernel/mvebu-next/91-02-Enable-ATA-port-LED-trigger.patch
+++ b/patch/kernel/mvebu-next/91-02-Enable-ATA-port-LED-trigger.patch
@@ -1,37 +1,31 @@
-From 9ee6345ef82f7af5f98e17a40e667f8ad6b2fa1b Mon Sep 17 00:00:00 2001
-From: aprayoga <adit.prayoga@gmail.com>
-Date: Sun, 3 Sep 2017 18:10:12 +0800
-Subject: Enable ATA port LED trigger
+From 092da520a40e0fc68e10ef92f9a94687720ebcad Mon Sep 17 00:00:00 2001
+From: Aditya Prayoga <aditya@kobol.io>
+Date: Thu, 13 Sep 2018 15:08:05 +0800
+Subject: [PATCH 2/2] ARM: mvebu: Enable ARCH_WANT_LIBATA_LEDS in Armada 38x
 
+Enable hidden symbol ARCH_WANT_LIBATA_LEDS so CONFIG_ATA_LEDS can be
+used in kernel configuration.
+
+URL: https://lists.openwrt.org/pipermail/openwrt-
+devel/2017-March/006582.html
+
+Signed-off-by: Aditya Prayoga <aditya@kobol.io>
 ---
- arch/arm/configs/mvebu_v7_defconfig | 1 +
- arch/arm/mach-mvebu/Kconfig         | 1 +
- 2 files changed, 2 insertions(+)
+ arch/arm/mach-mvebu/Kconfig | 1 +
+ 1 file changed, 1 insertion(+)
 
-diff --git a/arch/arm/configs/mvebu_v7_defconfig b/arch/arm/configs/mvebu_v7_defconfig
-index cf363ab..19449d3 100644
---- a/arch/arm/configs/mvebu_v7_defconfig
-+++ b/arch/arm/configs/mvebu_v7_defconfig
-@@ -61,6 +61,7 @@ CONFIG_MTD_SPI_NOR=y
- CONFIG_EEPROM_AT24=y
- CONFIG_BLK_DEV_SD=y
- CONFIG_ATA=y
-+CONFIG_ATA_LEDS=y
- CONFIG_SATA_AHCI=y
- CONFIG_AHCI_MVEBU=y
- CONFIG_SATA_MV=y
 diff --git a/arch/arm/mach-mvebu/Kconfig b/arch/arm/mach-mvebu/Kconfig
-index 053ea9d..aa1f389 100644
+index 2c20599..51f3256 100644
 --- a/arch/arm/mach-mvebu/Kconfig
 +++ b/arch/arm/mach-mvebu/Kconfig
-@@ -57,6 +57,7 @@ config MACH_ARMADA_375
- config MACH_ARMADA_38X
- 	bool "Marvell Armada 380/385 boards"
- 	depends on ARCH_MULTI_V7
+@@ -68,6 +68,7 @@ config MACH_ARMADA_38X
+ 	select HAVE_SMP
+ 	select MACH_MVEBU_V7
+ 	select PINCTRL_ARMADA_38X
 +	select ARCH_WANT_LIBATA_LEDS
- 	select ARM_ERRATA_720789
- 	select ARM_ERRATA_753970
- 	select ARM_GIC
+ 	help
+ 	  Say 'Y' here if you want your kernel to support boards based
+ 	  on the Marvell Armada 380/385 SoC with device tree.
 -- 
 2.7.4
 


### PR DESCRIPTION
previous version of the patch has slightly higher performance impact
compared to disk activity trigger.
This updated patch should have similar impact as disk activity trigger.
It also set the Kconfig default as No so it should not accidentally enabled on other board that use mvebu-next