### PR TITLE
Introducing CRYPTROOT_PARAMETERS variable

### DIFF
--- a/config/templates/config-example.conf
+++ b/config/templates/config-example.conf
@@ -25,3 +25,12 @@ BSPFREEZE=""				# freeze armbian packages (u-boot, kernel, dtb)
 INSTALL_HEADERS=""			# install kernel headers package
 LIB_TAG="master"			# change to "branchname" to use any branch currently available.
 CARD_DEVICE=""				# device name /dev/sdx of your SD card to burn directly to the card when done
+
+
+CRYPTROOT_ENABLE=no			# enable root filesystem encryption using LUKS
+CRYPTROOT_PARAMETERS=""			# optionally: change cryptsetup's defaults like cipher, hash etc.
+CRYPTROOT_PASSPHRASE="MYSECRETPASS"	# enter the encryption passphrase (can also be changed later on the CLI)
+CRYPTROOT_SSH_UNLOCK=no			# enable dropbear to unlock your device via SSH
+					# if you have an SSH public key store it in userpatches/dropbear_authorized_keys
+					# otherwise a new SSH key will be created and stored beside the OS image
+CRYPTROOT_SSH_UNLOCK_PORT=2022		# dropbear SSH port

--- a/config/templates/config-example.conf
+++ b/config/templates/config-example.conf
@@ -29,6 +29,7 @@ CARD_DEVICE=""				# device name /dev/sdx of your SD card to burn directly to the
 
 CRYPTROOT_ENABLE=no			# enable root filesystem encryption using LUKS
 CRYPTROOT_PARAMETERS=""			# optionally: change cryptsetup's defaults like cipher, hash etc.
+					# Currently only LUKS1 is supported, so don't use --type luks2
 CRYPTROOT_PASSPHRASE="MYSECRETPASS"	# enter the encryption passphrase (can also be changed later on the CLI)
 CRYPTROOT_SSH_UNLOCK=no			# enable dropbear to unlock your device via SSH
 					# if you have an SSH public key store it in userpatches/dropbear_authorized_keys

--- a/lib/debootstrap-ng.sh
+++ b/lib/debootstrap-ng.sh
@@ -419,7 +419,7 @@ prepare_partitions()
 
 		if [[ $CRYPTROOT_ENABLE == yes ]]; then
 			display_alert "Encrypting root partition with LUKS..." "cryptsetup luksFormat $rootdevice" ""
-			echo -n $CRYPTROOT_PASSPHRASE | cryptsetup luksFormat $rootdevice -
+			echo -n $CRYPTROOT_PASSPHRASE | cryptsetup luksFormat $CRYPTROOT_PARAMETERS $rootdevice -
 			echo -n $CRYPTROOT_PASSPHRASE | cryptsetup luksOpen $rootdevice $ROOT_MAPPER -
 			display_alert "Root partition encryption complete." "" "ext"
 			# TODO: pass /dev/mapper to Docker


### PR DESCRIPTION
As written in my comments I added an additional CRYPTROOT variable to be able to set the cipher, hash etc. for the cryptsetup luksFormat command.