### PR TITLE
Fix argument parsing

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -54,7 +54,7 @@ for i in "$@"; do
 		parameter=${i%%=*}
 		value=${i##*=}
 		display_alert "Command line: setting $parameter to" "${value:-(empty)}" "info"
-		eval $parameter=$value
+		eval $parameter=\"$value\"
 	fi
 done
 


### PR DESCRIPTION
When passing parameter with white space to ./compile, eval doesn't handles it properly.
For example to change maintainer you what to pass your name as "John Doe". The eval makes MAINTAINER=John and then the script throw error that there is no Doe command.

The fix is to make the quotes as escape characters. 