### PR TITLE
[ odroid xu4 ] use udev rules to set ethernet rps

### DIFF
--- a/config/sources/odroidxu4.conf
+++ b/config/sources/odroidxu4.conf
@@ -13,7 +13,7 @@ case $BRANCH in
 	KERNELSOURCE='https://github.com/hardkernel/linux'
 	KERNELBRANCH='branch:odroidxu4-4.14.y'
 	KERNELDIR='linux-odroidxu4'
-	
+
 
 	KERNEL_USE_GCC='> 6.3'
 	;;
@@ -116,8 +116,9 @@ family_tweaks()
 
 family_tweaks_bsp()
 {
+	mkdir -p $destination/etc/udev/rules.d
+	cp $SRC/packages/bsp/odroid/90-builtin-net-rps.rules $destination/etc/udev/rules.d
 	if [[ $BRANCH != default ]]; then
-		mkdir -p $destination/etc/udev/rules.d
 		mkdir -p $destination/usr/local/bin
 		cp $SRC/packages/bsp/rockchip/hdmi.rules $destination/etc/udev/rules.d
 		install -m 755 $SRC/packages/bsp/rockchip/hdmi-hotplug $destination/usr/local/bin

--- a/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
+++ b/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
@@ -123,9 +123,7 @@ prepare_board() {
 			for i in $(awk -F':' '/11800000.mali/{print $1}' </proc/interrupts | sed 's/\ //g'); do
 				echo 64 >/proc/irq/$i/smp_affinity
 			done
-			echo 7 >/sys/class/net/eth0/queues/rx-0/rps_cpus
 			echo 32768 >/proc/sys/net/core/rps_sock_flow_entries
-			echo 32768 >/sys/class/net/eth0/queues/rx-0/rps_flow_cnt
 			;;
 		rockchip) # RK3288: usb1 on cpu1, usb3 (EHCI) on cpu2, eth0 and GPU on cpu3
 			echo 2 >/proc/irq/$(awk -F":" "/usb1/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity

--- a/packages/bsp/odroid/90-builtin-net-rps.rules
+++ b/packages/bsp/odroid/90-builtin-net-rps.rules
@@ -1,0 +1,5 @@
+# Set up receive packet steering for builtin ethernet
+ACTION=="add", SUBSYSTEMS=="usb", SUBSYSTEM=="net", \
+  ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="8153", \
+  ATTR{queues/rx-0/rps_cpus}="7", ATTR{queues/rx-0/rps_flow_cnt}="32768"
+


### PR DESCRIPTION
In Armbian Stretch, it seems udev's "predictable interface naming" scheme has been adopted, meaning the onboard ethernet on the ODROID-HC2 is no longer named eth0, it's named similar to "enx001e06436e92" (derived from the MAC address) and so the commands in armbian-hardware-optimization to set receive packet steering to CPU7 on /sys/class/net/eth0/... no longer work.

Using a udev rule to apply the RPS settings is an alternative that works for my HC2 board and will apply the settings no matter what the interface name is.

The other boards in armbian-hardware-optimization probably need similar changes, but I'm afraid I don't have access to any to work out what the udev rules should be, or to test that they work.