### PR TITLE
Improve DSD-direct support in kernel 4.14.y

### DIFF
--- a/patch/kernel/cubox-default/Linux4.14-001-ALSA:_usb-audio:_Add_native_DSD_support_for_Mytek_DACs.patch
+++ b/patch/kernel/cubox-default/Linux4.14-001-ALSA:_usb-audio:_Add_native_DSD_support_for_Mytek_DACs.patch
@@ -1,0 +1,72 @@
+From 165a0d29ca8bae890e2f2767af83b09d61f33553 Mon Sep 17 00:00:00 2001
+From: Jussi Laako <jussi@sonarnerd.net>
+Date: Wed, 13 Jun 2018 01:43:01 +0300
+Subject: [PATCH] ALSA: usb-audio: Add native DSD support for Mytek DACs
+
+commit 3a572d94bcff98a14c94fe686881a169a26f3fca upstream.
+
+Add new mostly generic code with Mytek VID to support native DSD mode.
+
+This implementation should be easier to maintain when manufacturers
+release new products.
+
+Signed-off-by: Jussi Laako <jussi@sonarnerd.net>
+Signed-off-by: Takashi Iwai <tiwai@suse.de>
+---
+ sound/usb/card.h   |  1 +
+ sound/usb/format.c |  5 ++++-
+ sound/usb/quirks.c | 13 +++++++++++++
+ 3 files changed, 18 insertions(+), 1 deletion(-)
+
+diff --git a/sound/usb/card.h b/sound/usb/card.h
+index ed87cc83eb47d..2f4801cdc01d4 100644
+--- a/sound/usb/card.h
++++ b/sound/usb/card.h
+@@ -32,6 +32,7 @@ struct audioformat {
+ 	struct snd_pcm_chmap_elem *chmap; /* (optional) channel map */
+ 	bool dsd_dop;			/* add DOP headers in case of DSD samples */
+ 	bool dsd_bitrev;		/* reverse the bits of each DSD sample */
++	bool dsd_raw;			/* altsetting is raw DSD */
+ };
+ 
+ struct snd_usb_substream;
+diff --git a/sound/usb/format.c b/sound/usb/format.c
+index 2c44386e5569f..916ff842c4375 100644
+--- a/sound/usb/format.c
++++ b/sound/usb/format.c
+@@ -63,8 +63,11 @@ static u64 parse_audio_format_i_type(struct snd_usb_audio *chip,
+ 		sample_width = fmt->bBitResolution;
+ 		sample_bytes = fmt->bSubslotSize;
+ 
+-		if (format & UAC2_FORMAT_TYPE_I_RAW_DATA)
++		if (format & UAC2_FORMAT_TYPE_I_RAW_DATA) {
+ 			pcm_formats |= SNDRV_PCM_FMTBIT_SPECIAL;
++			/* flag potentially raw DSD capable altsettings */
++			fp->dsd_raw = true;
++		}
+ 
+ 		format <<= 1;
+ 		break;
+diff --git a/sound/usb/quirks.c b/sound/usb/quirks.c
+index ad14d6b78bdcf..da6fd90360a8a 100644
+--- a/sound/usb/quirks.c
++++ b/sound/usb/quirks.c
+@@ -1411,5 +1411,18 @@ u64 snd_usb_interface_dsd_format_quirks(struct snd_usb_audio *chip,
+ 			return SNDRV_PCM_FMTBIT_DSD_U32_BE;
+ 	}
+ 
++	/* Mostly generic method to detect many DSD-capable implementations -
++	 * from XMOS/Thesycon
++	 */
++	switch (USB_ID_VENDOR(chip->usb_id)) {
++	case 0x25ce:  /* Mytek devices */
++		if (fp->dsd_raw)
++			return SNDRV_PCM_FMTBIT_DSD_U32_BE;
++		break;
++	default:
++		break;
++
++	}
++
+ 	return 0;
+ }

--- a/patch/kernel/cubox-default/Linux4.14-002-ALSA:_usb-audio:_generic_DSD_detection_for_XMOS-based_implementations.patch
+++ b/patch/kernel/cubox-default/Linux4.14-002-ALSA:_usb-audio:_generic_DSD_detection_for_XMOS-based_implementations.patch
@@ -1,0 +1,72 @@
+From: Gé Koerkamp <ge.koerkamp@gmail.com>
+Date: Thu, 27 Dec 2018 20:30:08 +0000
+Subject: [PATCH] ALSA: usb-audio: generic DSD detection for XMOS-based implementations
+
+This is the second half of the USB Audio patch for 4.14.90
+See the preceding back-port "ALSA:_usb-audio:_Add_native_DSD_support_for_Mytek_DACs"
+
+This patch adds support for a range of popular USB DAc's with DSD-direct (native DSD) capabilities.
+
+Signed-off-by: Gé Koerkamp <ge.koerkamp@gmail.com>
+---
+ sound/usb/quirks.c | 27 +++++++++++++++++++++++++++
+ 1 file changed, 27 insertions(+)
+
+diff --git a/sound/usb/quirks.c b/sound/usb/quirks.c
+index da6fd90360a8a..1c990a3e8fa9c 100644
+--- a/sound/usb/quirks.c
++++ b/sound/usb/quirks.c
+@@ -1356,19 +1356,44 @@ u64 snd_usb_interface_dsd_format_quirks(struct snd_usb_audio *chip,
+ 	/* XMOS based USB DACs */
+ 	switch (chip->usb_id) {
+ 	case USB_ID(0x20b1, 0x3008): /* iFi Audio micro/nano iDSD */
++	case USB_ID(0x1511, 0x0037): /* AURALiC VEGA */
++	case USB_ID(0x20b1, 0x0002): /* Wyred 4 Sound DAC-2 DSD */
++	case USB_ID(0x20b1, 0x2004): /* Matrix Audio X-SPDIF 2 */
+ 	case USB_ID(0x20b1, 0x2008): /* Matrix Audio X-Sabre */
+ 	case USB_ID(0x20b1, 0x300a): /* Matrix Audio Mini-i Pro */
+ 	case USB_ID(0x22d9, 0x0416): /* OPPO HA-1 */
++	case USB_ID(0x22d9, 0x0436): /* OPPO Sonica */
++	case USB_ID(0x22d9, 0x0461): /* OPPO UDP-205 */
++	case USB_ID(0x2522, 0x0012): /* LH Labs VI DAC Infinity */
+ 	case USB_ID(0x2772, 0x0230): /* Pro-Ject Pre Box S2 Digital */
+ 		if (fp->altsetting == 2)
+ 			return SNDRV_PCM_FMTBIT_DSD_U32_BE;
+ 		break;
+ 
++	case USB_ID(0x152a, 0x85de): /* SMSL D1 DAC */
++	case USB_ID(0x16d0, 0x09dd): /* Encore mDSD */
++	case USB_ID(0x0d8c, 0x0316): /* Hegel HD12 DSD */
++	case USB_ID(0x16b0, 0x06b2): /* NuPrime DAC-10 */
++	case USB_ID(0x16d0, 0x0733): /* Furutech ADL Stratos */
++	case USB_ID(0x16d0, 0x09db): /* NuPrime Audio DAC-9 */
++	case USB_ID(0x1db5, 0x0003): /* Bryston BDA3 */
+ 	case USB_ID(0x20b1, 0x000a): /* Gustard DAC-X20U */
++	case USB_ID(0x20b1, 0x2005): /* Denafrips Ares DAC */
+ 	case USB_ID(0x20b1, 0x2009): /* DIYINHK DSD DXD 384kHz USB to I2S/DSD */
+ 	case USB_ID(0x20b1, 0x2023): /* JLsounds I2SoverUSB */
++	case USB_ID(0x20b1, 0x3021): /* Eastern El. MiniMax Tube DAC Supreme */
+ 	case USB_ID(0x20b1, 0x3023): /* Aune X1S 32BIT/384 DSD DAC */
++	case USB_ID(0x20b1, 0x302d): /* Unison Research Unico CD Due */
++	case USB_ID(0x20b1, 0x307b): /* CH Precision C1 DAC */
++	case USB_ID(0x20b1, 0x3086): /* Singxer F-1 converter board */
++	case USB_ID(0x22d9, 0x0426): /* OPPO HA-2 */
++	case USB_ID(0x22e1, 0xca01): /* HDTA Serenade DSD */
++	case USB_ID(0x249c, 0x9326): /* M2Tech Young MkIII */
+ 	case USB_ID(0x2616, 0x0106): /* PS Audio NuWave DAC */
++	case USB_ID(0x2622, 0x0041): /* Audiolab M-DAC+ */
++	case USB_ID(0x27f7, 0x3002): /* W4S DAC-2v2SE */
++	case USB_ID(0x29a2, 0x0086): /* Mutec MC3+ USB */
++	case USB_ID(0x6b42, 0x0042): /* MSB Technology */
+ 		if (fp->altsetting == 3)
+ 			return SNDRV_PCM_FMTBIT_DSD_U32_BE;
+ 		break;
+@@ -1415,6 +1440,8 @@ u64 snd_usb_interface_dsd_format_quirks(struct snd_usb_audio *chip,
+ 	 * from XMOS/Thesycon
+ 	 */
+ 	switch (USB_ID_VENDOR(chip->usb_id)) {
++	case 0x20b1:  /* XMOS based devices */
++	case 0x152a:  /* Thesycon devices */
+ 	case 0x25ce:  /* Mytek devices */
+ 		if (fp->dsd_raw)
+ 			return SNDRV_PCM_FMTBIT_DSD_U32_BE;


### PR DESCRIPTION
This pull request contains 2 patches and must be applied in order.

The first patch is a back-port from upstream and introduces a more generic way to detect DSD-direct (native DSD) capabilities for Mytek USB Audio devices 
The second patch is assembled from the current 4.19 sound/usb/quirks.c module.
It adds XMOS and Thesycon devices to the generic DSD-direct detection and adds support for a wide range of other DSD capable DACs.

These patches would also apply to other boards with the same kernel, but I only tested cubox with it.
cuboxi-next does not need this as kernel 4.19 is up-to-date.
  