### PR TITLE
Change Cloudflare DNS for Google's

### DIFF
--- a/lib/chroot-buildpackages.sh
+++ b/lib/chroot-buildpackages.sh
@@ -59,7 +59,7 @@ create_chroot()
 	printf '#!/bin/sh\nexit 101' > $target_dir/usr/sbin/policy-rc.d
 	chmod 755 $target_dir/usr/sbin/policy-rc.d
 	rm $target_dir/etc/resolv.conf 2>/dev/null
-	echo "1.1.1.1" > $target_dir/etc/resolv.conf
+	echo "8.8.8.8" > $target_dir/etc/resolv.conf
 	rm $target_dir/etc/hosts 2>/dev/null
 	echo "127.0.0.1 localhost" > $target_dir/etc/hosts
 	mkdir -p $target_dir/root/{build,overlay,sources} $target_dir/selinux

--- a/lib/debootstrap-ng.sh
+++ b/lib/debootstrap-ng.sh
@@ -224,7 +224,7 @@ create_rootfs_cache()
 
 		# this is needed for the build process later since resolvconf generated file in /run is not saved
 		rm $SDCARD/etc/resolv.conf
-		echo 'nameserver 1.1.1.1' >> $SDCARD/etc/resolv.conf
+		echo 'nameserver 8.8.8.8' >> $SDCARD/etc/resolv.conf
 
 		# stage: make rootfs cache archive
 		display_alert "Ending debootstrap process and preparing cache" "$RELEASE" "info"

--- a/lib/distributions.sh
+++ b/lib/distributions.sh
@@ -259,7 +259,7 @@ install_common()
 
 	# DNS fix. package resolvconf is not available everywhere
 	if [ -d /etc/resolvconf/resolv.conf.d ]; then
-		echo 'nameserver 1.1.1.1' > $SDCARD/etc/resolvconf/resolv.conf.d/head
+		echo 'nameserver 8.8.8.8' > $SDCARD/etc/resolvconf/resolv.conf.d/head
 	fi
 
 	# premit root login via SSH for the first boot
@@ -361,7 +361,7 @@ install_distribution_specific()
 		  renderer: NetworkManager
 		EOF
 		# DNS fix
-		sed -i "s/#DNS=.*/DNS=1.1.1.1/g" $SDCARD/etc/systemd/resolved.conf
+		sed -i "s/#DNS=.*/DNS=8.8.8.8/g" $SDCARD/etc/systemd/resolved.conf
 		# Journal service adjustements
 		sed -i "s/#Storage=.*/Storage=volatile/g" $SDCARD/etc/systemd/journald.conf
 		sed -i "s/#Compress=.*/Compress=yes/g" $SDCARD/etc/systemd/journald.conf


### PR DESCRIPTION
Some routers have problems with routing DNS request to 1.1.1.1, leading build script to fail at certain stages. It's been happening to me for a long time, and I wasn't able to figure out the cause until recently. My router was distributed by one of the major ISP's in my country and there are reports of many people experiencing the same problem (not in the Armbian forums, but with the use of 1.1.1.1 in general).

Google's DNS (8.8.8.8) are still used in other parts of Armbian. I understand that Cloudflare gives better privacy protection, but in that stage of the build script, DNS is only used a few times to resolve the upstream Debian/Ubuntu repo. So I don't think it will pose a big privacy risk to restore 8.8.8.8.