### PR TITLE
Set permissions for multimedia nodes in RK3288 & RK3399

### DIFF
--- a/config/sources/rk3399.conf
+++ b/config/sources/rk3399.conf
@@ -92,3 +92,11 @@ family_tweaks()
 	[[ $BOARD == orangepi-rk3399 ]] && echo "fdtfile=rockchip/rk3399-orangepi.dtb" >> $SDCARD/boot/armbianEnv.txt
 	[[ $BOARD == firefly-rk3399 ]] && echo "fdtfile=rockchip/rk3399-firefly.dtb" >> $SDCARD/boot/armbianEnv.txt
 }
+
+family_tweaks_bsp()
+{
+		# Graphics and media
+		mkdir -p $destination/etc/udev/rules.d
+		cp $SRC/packages/bsp/rk3399/50-mali.rules $destination/etc/udev/rules.d
+		cp $SRC/packages/bsp/rk3399/50-rk3399-vpu.rules $destination/etc/udev/rules.d
+}

--- a/packages/bsp/rk3399/50-mali.rules
+++ b/packages/bsp/rk3399/50-mali.rules
@@ -1,0 +1,2 @@
+KERNEL=="mali0", MODE="0660", GROUP="video"
+

--- a/packages/bsp/rk3399/50-rk3399-vpu.rules
+++ b/packages/bsp/rk3399/50-rk3399-vpu.rules
@@ -1,0 +1,3 @@
+KERNEL=="vpu_service", MODE="0660", GROUP="video"
+KERNEL=="rkvdec", MODE="0660", GROUP="video"
+

--- a/packages/bsp/rockchip/50-hevc.rules
+++ b/packages/bsp/rockchip/50-hevc.rules
@@ -1,1 +1,1 @@
-KERNEL=="hevc-service", MODE="0666", GROUP="video"
+KERNEL=="hevc-service", MODE="0660", GROUP="video"

--- a/packages/bsp/rockchip/50-mali.rules
+++ b/packages/bsp/rockchip/50-mali.rules
@@ -1,1 +1,1 @@
-KERNEL=="mali0", MODE="0666", GROUP="video"
+KERNEL=="mali0", MODE="0660", GROUP="video"

--- a/packages/bsp/rockchip/50-vpu.rules
+++ b/packages/bsp/rockchip/50-vpu.rules
@@ -1,1 +1,1 @@
-KERNEL=="vpu-service", MODE="0666", GROUP="video"
+KERNEL=="vpu-service", MODE="0660", GROUP="video"

--- a/packages/bsp/rockchip/60-media.rules
+++ b/packages/bsp/rockchip/60-media.rules
@@ -1,1 +1,1 @@
-KERNEL=="media*", MODE="0666", GROUP="video"
+KERNEL=="media*", MODE="0660", GROUP="video"


### PR DESCRIPTION
First step towards full multimedia support on Rockchips.