### PR TITLE
Set performance GPU devfreq governor for RK3399

### DIFF
--- a/config/sources/rk3399.conf
+++ b/config/sources/rk3399.conf
@@ -97,6 +97,8 @@ family_tweaks_bsp()
 {
 		# Graphics and media
 		mkdir -p $destination/etc/udev/rules.d
-		cp $SRC/packages/bsp/rk3399/50-mali.rules $destination/etc/udev/rules.d
-		cp $SRC/packages/bsp/rk3399/50-rk3399-vpu.rules $destination/etc/udev/rules.d
+		cp $SRC/packages/bsp/rk3399/50-mali.rules $destination/etc/udev/rules.d/
+		cp $SRC/packages/bsp/rk3399/50-rk3399-vpu.rules $destination/etc/udev/rules.d/
+		mkdir -p $destination/etc/sysfs.d
+		cp $SRC/packages/bsp/rk3399/20-gpu-governor.conf $destination/etc/sysfs.d/
 }

--- a/packages/bsp/rk3399/20-gpu-governor.conf
+++ b/packages/bsp/rk3399/20-gpu-governor.conf
@@ -1,0 +1,2 @@
+# Set "performance" GPU devfreq governor, "simple_ondemand" works bad in recent kernels
+devices/platform/ff9a0000.gpu/devfreq/ff9a0000.gpu/governor = performance


### PR DESCRIPTION
GPU freqdev governor is by default simple_ondemand. It used to work well in other kernels, but on this one and also in recent RK3288, it is terribly lazy to clock up, leading to significant performance loss. Therefore, I'm setting "performance" as default.