### PR TITLE
drm: workaround for crash when trying to open render node

### DIFF
--- a/patch/kernel/rk3399-default/50-fix_drm.patch
+++ b/patch/kernel/rk3399-default/50-fix_drm.patch
@@ -1,0 +1,23 @@
+From 06d1099d7f4cece7af7793ff68fabc08eb55935d Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Wed, 14 Nov 2018 06:08:01 +0100
+Subject: [PATCH] drm: workaround for crash when trying to open render node
+
+---
+ drivers/gpu/drm/drm_ioctl.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/drivers/gpu/drm/drm_ioctl.c b/drivers/gpu/drm/drm_ioctl.c
+index 34757168ffaa..0914c886277f 100644
+--- a/drivers/gpu/drm/drm_ioctl.c
++++ b/drivers/gpu/drm/drm_ioctl.c
+@@ -57,6 +57,9 @@ static int drm_getunique(struct drm_device *dev, void *data,
+ 	struct drm_unique *u = data;
+ 	struct drm_master *master = file_priv->master;
+ 
++	if (!master)
++		return -EINVAL;
++
+ 	if (u->unique_len >= master->unique_len) {
+ 		if (copy_to_user(u->unique, master->unique, master->unique_len))
+ 			return -EFAULT;


### PR DESCRIPTION
Certain DRM calls were causing system crash when using 64-bit userspace binaries. The most outstanding example of an app creating this problem is kodi-gbm. The fix is taken from Libreelec.