### PR TITLE
Several DT tweaks for Renegade

### DIFF
--- a/patch/kernel/rockchip64-default/Add_dts_rk3328-roc-cc.patch
+++ b/patch/kernel/rockchip64-default/Add_dts_rk3328-roc-cc.patch
@@ -539,7 +539,7 @@ index 0000000..457359c
 +		compatible = "gpio-leds";
 +		power {
 +			label = "firefly:blue:power";
-+			linux,default-trigger = "ir-power-click";
++			linux,default-trigger = "heartbeat";
 +			gpios = <&rk805 1 GPIO_ACTIVE_LOW>;
 +			default-state = "on";
 +			mode = <0x23>;
@@ -547,7 +547,7 @@ index 0000000..457359c
 +
 +		user {
 +			label = "firefly:yellow:user";
-+            linux,default-trigger = "ir-user-click";
++            linux,default-trigger = "mmc1";
 +			gpios = <&rk805 0 GPIO_ACTIVE_LOW>;
 +			default-state = "off";
 +			mode = <0x05>;

--- a/patch/kernel/rockchip64-default/enable-1512mhz-opp.patch
+++ b/patch/kernel/rockchip64-default/enable-1512mhz-opp.patch
@@ -16,3 +16,25 @@ index b7c84b52..9f11025a 100644
  	};
  
  	arm-pmu {
+
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts b/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts
+index dee5a395..bfacc080 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts
+@@ -360,11 +360,10 @@
+ 		clock-latency-ns = <40000>;
+ 	};
+ 	opp-1512000000 {
+-		status = "disabled";
+ 		opp-hz = /bits/ 64 <1512000000>;
+-		opp-microvolt = <1350000>;
+-		opp-microvolt-L0 = <1350000>;
+-		opp-microvolt-L1 = <1325000>;
++		opp-microvolt = <1450000>;
++		opp-microvolt-L0 = <1450000>;
++		opp-microvolt-L1 = <1425000>;
+ 		clock-latency-ns = <40000>;
+ 	};
+ };
+


### PR DESCRIPTION
A couple tweaks for the Renegade:
- Fixing 1512MHz OPP. Renegade's dts has its own OPP definitions, which were overwriting the common RK3328 dtsi.
- Assign the LED's to heartbeat and sdcard io, as in other RK boards.