### PR TITLE
fixed LED in rockpis device tree

### DIFF
--- a/patch/kernel/rockchip64-dev/fix-rockpi4b-led.patch
+++ b/patch/kernel/rockchip64-dev/fix-rockpi4b-led.patch
@@ -1,0 +1,46 @@
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rockpi4b.dts b/arch/arm64/boot/dts/rockchip/rk3399-rockpi4b.dts
+index 7f10da2a8..1d4721dcc 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-rockpi4b.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3399-rockpi4b.dts
+@@ -140,20 +140,15 @@
+ 	};
+ 
+ 	leds {
++		status = "okay";
+ 		compatible = "gpio-leds";
+ 		pinctrl-names = "default";
+-		pinctrl-0 = <&work_led_gpio>, <&diy_led_gpio>;
+-
+-		work-led {
+-			label = "work";
+-			default-state = "on";
+-			gpios = <&gpio0 RK_PB3 GPIO_ACTIVE_HIGH>;
+-		};
++		pinctrl-0 = <&status_led_gpio>;
+ 
+-		diy-led {
+-			label = "diy";
+-			default-state = "off";
+-			gpios = <&gpio0 RK_PA2 GPIO_ACTIVE_HIGH>;
++		system-status {
++			label = "status";
++			gpios = <&gpio3 29 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "heartbeat";
+ 		};
+ 	};
+ 
+@@ -643,12 +638,8 @@
+ 	};
+ 
+ 	leds {
+-		work_led_gpio: work_led-gpio {
+-			rockchip,pins = <0 RK_PB3 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-
+-		diy_led_gpio: diy_led-gpio {
+-			rockchip,pins = <0 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
++		status_led_gpio: status_led_gpio {
++			rockchip,pins = <3 28 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 	};
+ 

--- a/patch/u-boot/u-boot-rockchip64-dev/fix-rockpi4b-led.patch
+++ b/patch/u-boot/u-boot-rockchip64-dev/fix-rockpi4b-led.patch
@@ -1,0 +1,22 @@
+diff --git a/arch/arm/dts/rk3399-rockpi4b.dts b/arch/arm/dts/rk3399-rockpi4b.dts
+index 5d73ce5..5574e9b 100644
+--- a/arch/arm/dts/rk3399-rockpi4b.dts
++++ b/arch/arm/dts/rk3399-rockpi4b.dts
+@@ -65,14 +65,9 @@
+ 		status = "okay";
+ 		compatible = "gpio-leds";
+ 
+-		power-led {
+-			label = "power";
+-			gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
+-		};
+-
+-		standby-led {
+-			label = "standby";
+-			gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
++		system-status {
++			label = "status";
++			gpios = <&gpio3 28 GPIO_ACTIVE_HIGH>;
+ 		};
+ 	};
+ 


### PR DESCRIPTION
This patch sets the red LED of the RockPi 4b to heatbeat, according to DT informations from the BSP kernel. The green LED couldn't be triggered. Currently it's not known where they got the second LED in  [their DT](https://github.com/radxa/kernel/blob/c26d93d001494bbeec86d62e9954b932f254776c/arch/arm64/boot/dts/rockchip/rockpi-4b-linux.dts#L274-L278)

In the future, this patch should be merged with add-rockpi once we sorted out all faults we have in the DT. :) 

Edit: this patch was generated in the mini-series how to contribute to armbian, currently placed in:
https://forum.armbian.com/topic/9226-rockpi-4b-board-bring-up/?tab=comments#comment-70220
