### PR TITLE
[ General ] Move bootscript update to nand-sata-install

### DIFF
--- a/lib/makeboarddeb.sh
+++ b/lib/makeboarddeb.sh
@@ -214,17 +214,7 @@ create_board_package()
 			echo "Updating bootscript"
 
 			# copy new bootscript
-			cp /usr/share/armbian/$bootscript_dst /boot  >/dev/null 2>&1
-
-			# build new bootscript
-			if [ -f /boot/boot.cmd ]; then
-				mkimage -C none -A arm -T script -d /boot/boot.cmd /boot/boot.scr  >/dev/null 2>&1
-			elif [ -f /boot/boot.ini ]; then
-				rootdev=\$(sed -e 's/^.*root=//' -e 's/ .*\$//' < /proc/cmdline)
-				rootfstype=\$(sed -e 's/^.*rootfstype=//' -e 's/ .*$//' < /proc/cmdline)
-				sed -i "s/setenv rootfstype.*/setenv rootfstype \\"\$rootfstype\\"/" /boot/boot.ini
-				sed -i "s/setenv rootdev.*/setenv rootdev \\"\$rootdev\\"/" /boot/boot.ini
-			fi
+			cp -f /usr/share/armbian/$bootscript_dst /boot/${bootscript_dst}.new  >/dev/null 2>&1
 
 			# cleanup old bootscript backup
 			[ -f /usr/share/armbian/boot.cmd ] && ls /usr/share/armbian/boot.cmd-* | head -n -5 | xargs rm -f --

--- a/packages/bsp/common/usr/sbin/nand-sata-install
+++ b/packages/bsp/common/usr/sbin/nand-sata-install
@@ -521,6 +521,21 @@ check_nvme_target()
 	DISK_ROOT_PART=${NVMeOptions[(2*$NVMeChoices)-1]}
 }
 
+# build and update new bootscript
+update_bootscript()
+{
+	if [ -f /boot/boot.cmd.new ]; then
+		mv -f /boot/boot.cmd.new /boot/boot.cmd >/dev/null 2>&1
+		mkimage -C none -A arm -T script -d /boot/boot.cmd /boot/boot.scr  >/dev/null 2>&1
+	elif [ -f /boot/boot.ini.new ]; then
+		mv -f /boot/boot.ini.new /boot/boot.ini >/dev/null 2>&1
+		rootdev=$(sed -e 's/^.*root=//' -e 's/ .*$//' < /proc/cmdline)
+		rootfstype=$(sed -e 's/^.*rootfstype=//' -e 's/ .*$//' < /proc/cmdline)
+		sed -i "s/setenv rootfstype.*/setenv rootfstype \"$rootfstype\"/" /boot/boot.ini
+		sed -i "s/setenv rootdev.*/setenv rootdev \"$rootdev\"/" /boot/boot.ini
+	fi
+}
+
 # show warning [TEXT]
 show_warning()
 {
@@ -646,6 +661,7 @@ main()
 			5)
 				show_warning "This script will update the bootloader on SD/eMMC. Continue?"
 				write_uboot_platform $DIR ${root_partition_device}
+				update_bootscript
 				dialog --backtitle "$backtitle" --title "Writing bootloader" --msgbox "\n          Done." 7 30
 				return
 				;;
@@ -664,6 +680,7 @@ main()
 				MTD_BLK="/dev/${spicheck}"
 				show_warning "This script will update the bootloader on SPI Flash $MTD_BLK. Continue?"
 				write_uboot_platform_mtd $DIR $MTD_BLK
+				update_bootscript
 				echo "Done"
 				return
 				;;


### PR DESCRIPTION
As recently surfaced on Helios4 Support forum, upgrading system from 5.67 image would break the system. This is due to during upgrade, bootscript updated into other version that is not compatible with the U-Boot included in Armbian 5.67.

This PR, move the bootscript update function into nand-sata-install altogether with bootloader update.
The intention is to make bootloader upgrade and bootscript update in one process to avoid incompatibility problem between these two.

The bootloader upgrade and bootscript update must be invoke by user by running nand-sata-install and select appropriate menu.

---

Upgrade log can be access on

- Armbian 5.67 (Initial version of U-Boot 2018.11) to Armbian 5.72
https://pastebin.com/raw/igqj0yPd

- Armbian 5.64 (Marvell U-Boot) to Armbian 5.72
https://pastebin.com/raw/jnVZ2YdE

Notes:
Generated debs uploaded and published into local network repository at 192.168.0.126:8080. The system under test configured to add that local repo during 1st boot.
