### PR TITLE
swap wan and lan1 ports

### DIFF
--- a/patch/kernel/mvebu64-next/add-board-espressobinv7.patch
+++ b/patch/kernel/mvebu64-next/add-board-espressobinv7.patch
@@ -1,0 +1,219 @@
+diff --git a/arch/arm64/boot/dts/marvell/Makefile b/arch/arm64/boot/dts/marvell/Makefile
+index ea9d49f2a911..d80da8f5d82d 100644
+--- a/arch/arm64/boot/dts/marvell/Makefile
++++ b/arch/arm64/boot/dts/marvell/Makefile
+@@ -2,6 +2,7 @@
+ # Mvebu SoC Family
+ dtb-$(CONFIG_ARCH_MVEBU) += armada-3720-db.dtb
+ dtb-$(CONFIG_ARCH_MVEBU) += armada-3720-espressobin.dtb
++dtb-$(CONFIG_ARCH_MVEBU) += armada-3720-espressobinv7.dtb
+ dtb-$(CONFIG_ARCH_MVEBU) += armada-7040-db.dtb
+ dtb-$(CONFIG_ARCH_MVEBU) += armada-8040-db.dtb
+ dtb-$(CONFIG_ARCH_MVEBU) += armada-8040-mcbin.dtb
+diff --git a/arch/arm64/boot/dts/marvell/armada-3720-espressobinv7.dts b/arch/arm64/boot/dts/marvell/armada-3720-espressobinv7.dts
+new file mode 100644
+index 000000000000..6385b2488e45
+--- /dev/null
++++ b/arch/arm64/boot/dts/marvell/armada-3720-espressobinv7.dts
+@@ -0,0 +1,201 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Device Tree file for Globalscale Marvell ESPRESSOBin Board
++ * Copyright (C) 2016 Marvell
++ *
++ * Romain Perier <romain.perier@free-electrons.com>
++ *
++ */
++/*
++ * Schematic available at http://espressobin.net/wp-content/uploads/2017/08/ESPRESSObin_V5_Schematics.pdf
++ */
++
++/dts-v1/;
++
++#include <dt-bindings/gpio/gpio.h>
++#include "armada-372x.dtsi"
++
++/ {
++	model = "Globalscale Marvell ESPRESSOBin Board";
++	compatible = "globalscale,espressobin", "marvell,armada3720", "marvell,armada3710";
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	memory@0 {
++		device_type = "memory";
++		reg = <0x00000000 0x00000000 0x00000000 0x20000000>;
++	};
++
++	vcc_sd_reg1: regulator {
++		compatible = "regulator-gpio";
++		regulator-name = "vcc_sd1";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <3300000>;
++		regulator-boot-on;
++
++		gpios = <&gpionb 4 GPIO_ACTIVE_HIGH>;
++		gpios-states = <0>;
++		states = <1800000 0x1
++			  3300000 0x0>;
++		enable-active-high;
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		red {
++			label = "espressobin:red:usr";
++			gpios = <&gpionb 2 GPIO_ACTIVE_LOW>;
++		};
++	};
++};
++
++/* J9 */
++&pcie0 {
++	status = "okay";
++};
++
++/* J6 */
++&sata {
++	status = "okay";
++};
++
++/* J1 */
++&sdhci1 {
++	wp-inverted;
++	bus-width = <4>;
++	cd-gpios = <&gpionb 3 GPIO_ACTIVE_LOW>;
++	marvell,pad-type = "sd";
++	vqmmc-supply = <&vcc_sd_reg1>;
++	status = "okay";
++};
++
++&spi0 {
++	status = "okay";
++
++	flash@0 {
++		reg = <0>;
++		/*
++		 * Originally "winbond,w25q32dw", but since the manufacturer is known
++		 * to have replaced the part with "macronix,mx25u3235f" in some board
++		 * batches, just use the generic "jedec,spi-nor" and let the actual
++		 * chip type be probed. The partition table still depends on the chip
++		 * being 4 MiB in size.
++		 */
++		compatible = "jedec,spi-nor";
++		spi-max-frequency = <104000000>;
++		m25p,fast-read;
++		status = "okay";
++
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			partition@0 {
++				label = "uboot";
++				reg = <0 0x3f0000>;
++			};
++
++			partition@3f0000 {
++				label = "ubootenv";
++				reg = <0x3f0000 0x10000>;
++			};
++		};
++	};
++};
++
++/* Exported on the micro USB connector J5 through an FTDI */
++&uart0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart1_pins>;
++	status = "okay";
++};
++
++/*
++ * Connector J17 and J18 expose a number of different features. Some pins are
++ * multiplexed. This is the case for instance for the following features:
++ * - UART1 (pin 24 = RX, pin 26 = TX). See armada-3720-db.dts for an example of
++ *   how to enable it. Beware that the signals are 1.8V TTL.
++ * - I2C
++ * - SPI
++ * - MMC
++ */
++
++/* J7 */
++&usb3 {
++	status = "okay";
++};
++
++/* J8 */
++&usb2 {
++	status = "okay";
++};
++
++&mdio {
++	switch0: switch0@1 {
++		compatible = "marvell,mv88e6085";
++		#address-cells = <1>;
++		#size-cells = <0>;
++		reg = <1>;
++
++		dsa,member = <0 0>;
++
++		ports {
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			port@0 {
++				reg = <0>;
++				label = "cpu";
++				ethernet = <&eth0>;
++			};
++
++			port@1 {
++				reg = <1>;
++				label = "lan1";
++				phy-handle = <&switch0phy0>;
++			};
++
++			port@2 {
++				reg = <2>;
++				label = "lan0";
++				phy-handle = <&switch0phy1>;
++			};
++
++			port@3 {
++				reg = <3>;
++				label = "wan";
++				phy-handle = <&switch0phy2>;
++			};
++
++		};
++
++		mdio {
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			switch0phy0: switch0phy0@11 {
++				reg = <0x11>;
++			};
++			switch0phy1: switch0phy1@12 {
++				reg = <0x12>;
++			};
++			switch0phy2: switch0phy2@13 {
++				reg = <0x13>;
++			};
++		};
++	};
++};
++
++&eth0 {
++	phy-mode = "rgmii-id";
++	status = "okay";
++
++	fixed-link {
++		speed = <1000>;
++		full-duplex;
++	};
++};


### PR DESCRIPTION
Existing espressobin.dts.patch has been amended to swap the labels on the wan and lan1 ports, as described in #1243
This will BREAK existing users of all Espressobin in preference for allowing expected behavior for future users of v7 boards.