### PR TITLE
Module 'nls_utf8'

### DIFF
--- a/config/kernel/linux-sunxi64-dev.config
+++ b/config/kernel/linux-sunxi64-dev.config
@@ -5832,7 +5832,7 @@ CONFIG_NLS_ISO8859_1=y
 # CONFIG_NLS_MAC_INUIT is not set
 # CONFIG_NLS_MAC_ROMANIAN is not set
 # CONFIG_NLS_MAC_TURKISH is not set
-# CONFIG_NLS_UTF8 is not set
+# CONFIG_NLS_UTF8=y
 # CONFIG_DLM is not set
 
 #

--- a/config/kernel/linux-sunxi64-next.config
+++ b/config/kernel/linux-sunxi64-next.config
@@ -5887,7 +5887,7 @@ CONFIG_NLS_ISO8859_1=y
 # CONFIG_NLS_MAC_INUIT is not set
 # CONFIG_NLS_MAC_ROMANIAN is not set
 # CONFIG_NLS_MAC_TURKISH is not set
-# CONFIG_NLS_UTF8 is not set
+# CONFIG_NLS_UTF8=y
 # CONFIG_DLM is not set
 
 #


### PR DESCRIPTION
Please include nls_utf8.ko module into next build.
https://forum.armbian.com/topic/9479-module-nls_utf8-was-missing-in-armbian-570-41913-sunxi64/