### PR TITLE
Fix rockchip-default mali patch

### DIFF
--- a/patch/kernel/rockchip-default/04-patch-4.4.167-168_mali.patch
+++ b/patch/kernel/rockchip-default/04-patch-4.4.167-168_mali.patch
@@ -31,24 +31,19 @@ index 4a223e8ee..42e0df5db 100644
  
  	if (pinned_pages <= 0)
 diff --git a/drivers/gpu/arm/midgard/mali_kbase_mem_linux.c b/drivers/gpu/arm/midgard/mali_kbase_mem_linux.c
-index eea429a8d..23152f076 100644
+index eea429a8..76610fda 100644
 --- a/drivers/gpu/arm/midgard/mali_kbase_mem_linux.c
 +++ b/drivers/gpu/arm/midgard/mali_kbase_mem_linux.c
-@@ -1161,14 +1161,13 @@ static struct kbase_va_region *kbase_mem_from_user_buffer(
+@@ -1161,10 +1161,8 @@ static struct kbase_va_region *kbase_mem_from_user_buffer(
  
  #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 6, 0)
  	faulted_pages = get_user_pages(current, current->mm, address, *va_pages,
 -			reg->flags & KBASE_REG_GPU_WR, 0, pages, NULL);
-+			reg->flags & KBASE_REG_GPU_WR, NULL, NULL);
- #elif LINUX_VERSION_CODE < KERNEL_VERSION(4, 9, 0)
- 	faulted_pages = get_user_pages(address, *va_pages,
+-#elif LINUX_VERSION_CODE < KERNEL_VERSION(4, 9, 0)
+-	faulted_pages = get_user_pages(address, *va_pages,
 -			reg->flags & KBASE_REG_GPU_WR, 0, pages, NULL);
-+			reg->flags & KBASE_REG_GPU_WR, NULL, NULL);
++			reg->flags & KBASE_REG_GPU_WR ? FOLL_WRITE : 0,
++			pages, NULL);
  #else
  	faulted_pages = get_user_pages(address, *va_pages,
--			reg->flags & KBASE_REG_GPU_WR ? FOLL_WRITE : 0,
--			pages, NULL);
-+			reg->flags & KBASE_REG_GPU_WR ? FOLL_WRITE : 0,	NULL);
- #endif
- 
- 	up_read(&current->mm->mmap_sem);
+ 			reg->flags & KBASE_REG_GPU_WR ? FOLL_WRITE : 0,


### PR DESCRIPTION
Now correct for versions >= 4.9 as well
I'll touch up the rk3399 that I touched before, because my assumption for kernel versions > 4.9 is wrong. More on that commit. When it comes to 4.4, all good.