### PR TITLE
Helios4: Add support for Wake-On-LAN and update fancontrol configuration

### DIFF
--- a/packages/bsp/helios4/fancontrol_pwm-fan-mvebu-next.conf
+++ b/packages/bsp/helios4/fancontrol_pwm-fan-mvebu-next.conf
@@ -2,8 +2,8 @@
 # Temp source : /dev/thermal-cpu
 INTERVAL=10
 FCTEMPS=/dev/fan-j10/pwm1=/dev/thermal-cpu/temp1_input /dev/fan-j17/pwm1=/dev/thermal-cpu/temp1_input
-MINTEMP=/dev/fan-j10/pwm1=70 /dev/fan-j17/pwm1=70
-MAXTEMP=/dev/fan-j10/pwm1=90 /dev/fan-j17/pwm1=90
+MINTEMP=/dev/fan-j10/pwm1=60 /dev/fan-j17/pwm1=60
+MAXTEMP=/dev/fan-j10/pwm1=80 /dev/fan-j17/pwm1=80
 MINSTART=/dev/fan-j10/pwm1=20 /dev/fan-j17/pwm1=20
 MINSTOP=/dev/fan-j10/pwm1=29 /dev/fan-j17/pwm1=29
-MINPWM=0
+MINPWM=20

--- a/patch/kernel/mvebu-next/92-mvebu-gpio-add_wake_on_gpio_support.patch
+++ b/patch/kernel/mvebu-next/92-mvebu-gpio-add_wake_on_gpio_support.patch
@@ -1,0 +1,90 @@
+diff --git a/drivers/gpio/gpio-mvebu.c b/drivers/gpio/gpio-mvebu.c
+index 661c5a38f..a25d61d54 100644
+--- a/drivers/gpio/gpio-mvebu.c
++++ b/drivers/gpio/gpio-mvebu.c
+@@ -38,6 +38,7 @@
+ #include <linux/err.h>
+ #include <linux/gpio.h>
+ #include <linux/init.h>
++#include <linux/interrupt.h>
+ #include <linux/io.h>
+ #include <linux/irq.h>
+ #include <linux/irqchip/chained_irq.h>
+@@ -133,7 +134,7 @@ struct mvebu_gpio_chip {
+ 	struct regmap     *regs;
+ 	u32		   offset;
+ 	struct regmap     *percpu_regs;
+-	int		   irqbase;
++	int		   bank_irq[4];
+ 	struct irq_domain *domain;
+ 	int		   soc_variant;
+ 
+@@ -608,6 +609,33 @@ static void mvebu_gpio_irq_handler(struct irq_desc *desc)
+ 	chained_irq_exit(chip, desc);
+ }
+ 
++/*
++ * Set interrupt number "irq" in the GPIO as a wake-up source.
++ * While system is running, all registered GPIO interrupts need to have
++ * wake-up enabled. When system is suspended, only selected GPIO interrupts
++ * need to have wake-up enabled.
++ * @param  irq          interrupt source number
++ * @param  enable       enable as wake-up if equal to non-zero
++ * @return       This function returns 0 on success.
++ */
++static int mvebu_gpio_set_wake_irq(struct irq_data *d, unsigned int enable)
++{
++	struct irq_chip_generic *gc = irq_data_get_irq_chip_data(d);
++	struct mvebu_gpio_chip *mvchip = gc->private;
++	int irq;
++	int bank;
++
++	bank = d->hwirq % 8;
++	irq = mvchip->bank_irq[bank];
++
++	if (enable)
++		enable_irq_wake(irq);
++	else
++		disable_irq_wake(irq);
++
++	return 0;
++}
++
+ /*
+  * Functions implementing the pwm_chip methods
+  */
+@@ -1277,7 +1305,7 @@ static int mvebu_gpio_probe(struct platform_device *pdev)
+ 
+ 	err = irq_alloc_domain_generic_chips(
+ 	    mvchip->domain, ngpios, 2, np->name, handle_level_irq,
+-	    IRQ_NOREQUEST | IRQ_NOPROBE | IRQ_LEVEL, 0, 0);
++	    IRQ_NOREQUEST | IRQ_NOPROBE | IRQ_LEVEL, 0, IRQ_GC_INIT_NESTED_LOCK);
+ 	if (err) {
+ 		dev_err(&pdev->dev, "couldn't allocate irq chips %s (DT).\n",
+ 			mvchip->chip.label);
+@@ -1295,6 +1323,8 @@ static int mvebu_gpio_probe(struct platform_device *pdev)
+ 	ct->chip.irq_mask = mvebu_gpio_level_irq_mask;
+ 	ct->chip.irq_unmask = mvebu_gpio_level_irq_unmask;
+ 	ct->chip.irq_set_type = mvebu_gpio_irq_set_type;
++	ct->chip.irq_set_wake = mvebu_gpio_set_wake_irq;
++	ct->chip.flags = IRQCHIP_SET_TYPE_MASKED | IRQCHIP_MASK_ON_SUSPEND;
+ 	ct->chip.name = mvchip->chip.label;
+ 
+ 	ct = &gc->chip_types[1];
+@@ -1303,6 +1333,8 @@ static int mvebu_gpio_probe(struct platform_device *pdev)
+ 	ct->chip.irq_mask = mvebu_gpio_edge_irq_mask;
+ 	ct->chip.irq_unmask = mvebu_gpio_edge_irq_unmask;
+ 	ct->chip.irq_set_type = mvebu_gpio_irq_set_type;
++	ct->chip.irq_set_wake = mvebu_gpio_set_wake_irq;
++	ct->chip.flags = IRQCHIP_SET_TYPE_MASKED | IRQCHIP_MASK_ON_SUSPEND;
+ 	ct->handler = handle_edge_irq;
+ 	ct->chip.name = mvchip->chip.label;
+ 
+@@ -1318,6 +1350,7 @@ static int mvebu_gpio_probe(struct platform_device *pdev)
+ 			continue;
+ 		irq_set_chained_handler_and_data(irq, mvebu_gpio_irq_handler,
+ 						 mvchip);
++		mvchip->bank_irq[i] = irq;
+ 	}
+ 
+ 	/* Some MVEBU SoCs have simple PWM support for GPIO lines */

--- a/patch/kernel/mvebu-next/94-helios4-dts-add-wake-on-lan-support.patch
+++ b/patch/kernel/mvebu-next/94-helios4-dts-add-wake-on-lan-support.patch
@@ -1,0 +1,23 @@
+diff --git a/arch/arm/boot/dts/armada-388-helios4.dts b/arch/arm/boot/dts/armada-388-helios4.dts
+index 705adfa8c..d5afbfc53 100644
+--- a/arch/arm/boot/dts/armada-388-helios4.dts
++++ b/arch/arm/boot/dts/armada-388-helios4.dts
+@@ -84,6 +84,18 @@
+ 		};
+ 	};
+ 
++	gpio-keys {
++		compatible = "gpio-keys";
++		pinctrl-0 = <&microsom_phy0_int_pins>;
++
++		wol {
++			label = "Wake-On-LAN";
++			linux,code = <KEY_WAKEUP>;
++			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
++			wakeup-source;
++		};
++	};
++
+ 	io-leds {
+ 		compatible = "gpio-leds";
+ 		sata1-led {


### PR DESCRIPTION
This PR add Wake on GPIO support on mvebu-next kernel.
without the patch, kernel crash on wakeup from **standby** with following message:

```
------------[ cut here ]------------
WARNING: CPU: 0 PID: 1535 at kernel/irq/manage.c:623 irq_set_irq_wake+0xe4/0x11c
Unbalanced IRQ 50 wake disable
Modules linked in: lz4hc lz4hc_compress marvell_cesa zram zsmalloc lm75 pwm_fan ip_tables x_tables
CPU: 0 PID: 1535 Comm: bash Not tainted 4.14.94-mvebu+ #14
Hardware name: Marvell Armada 380/385 (Device Tree)
[<c01118d0>] (unwind_backtrace) from [<c010c7cc>] (show_stack+0x10/0x14)
[<c010c7cc>] (show_stack) from [<c095091c>] (dump_stack+0x88/0x9c)
[<c095091c>] (dump_stack) from [<c012ab9c>] (__warn+0xe8/0x100)
[<c012ab9c>] (__warn) from [<c012abfc>] (warn_slowpath_fmt+0x48/0x6c)
[<c012abfc>] (warn_slowpath_fmt) from [<c017bb64>] (irq_set_irq_wake+0xe4/0x11c)
[<c017bb64>] (irq_set_irq_wake) from [<c0747594>] (gpio_keys_resume+0xb0/0x11c)
[<c0747594>] (gpio_keys_resume) from [<c0654b34>] (dpm_run_callback+0x54/0xec)
[<c0654b34>] (dpm_run_callback) from [<c0655180>] (device_resume+0xcc/0x270)
[<c0655180>] (device_resume) from [<c0656660>] (dpm_resume+0x100/0x230)
[<c0656660>] (dpm_resume) from [<c06569e4>] (dpm_resume_end+0xc/0x18)
[<c06569e4>] (dpm_resume_end) from [<c0175af8>] (suspend_devices_and_enter+0x210/0x5e0)
[<c0175af8>] (suspend_devices_and_enter) from [<c01761c0>] (pm_suspend+0x2f8/0x380)
[<c01761c0>] (pm_suspend) from [<c0174a30>] (state_store+0x70/0xcc)
[<c0174a30>] (state_store) from [<c02c80e4>] (kernfs_fop_write+0xe8/0x1c4)
[<c02c80e4>] (kernfs_fop_write) from [<c024ce78>] (vfs_write+0xa4/0x1b4)
[<c024ce78>] (vfs_write) from [<c024d0b4>] (SyS_write+0x4c/0xac)
[<c024d0b4>] (SyS_write) from [<c0108620>] (ret_fast_syscall+0x0/0x54)
---[ end trace c725de247edb5ce9 ]---
```

and the system also unable to wakeup from **Suspend to RAM**.

Then make use of this wake on GPIO event to wake up the system when WoL magic packet received. There is a catch however, between enabling WoL on magic packet and sleep/suspend the system must not received any magic packet. Otherwise the system would not able to wake up.
The reason of this limitation is because when PHY received magic packet it would raised interrupt and have to be ack by ethernet MAC. but since no interrupt handler for PHY interrupt in mvneta, it would not ACK the INT so the INT pin still active and won't generate other interrupt.


Also included in PR, another fancontrol tweak. User reported that HDDs have high temp during idle, due to fan stop spinning. Adjust the fancontrol configuration to always run in low speed during idle.