### PR TITLE
Orange Pi R1 - set BOOTCONFIG to orangepi_r1_defconfig in board configuration

### DIFF
--- a/config/boards/orangepi-r1.conf
+++ b/config/boards/orangepi-r1.conf
@@ -1,7 +1,7 @@
 # H2+ quad core 256MB Wi-Fi + dual Ethernet
 BOARD_NAME="Orange Pi R1"
 BOARDFAMILY="sun8i"
-BOOTCONFIG="orangepi_zero_defconfig"
+BOOTCONFIG="orangepi_r1_defconfig"
 #
 MODULES="#w1-sunxi #w1-gpio #w1-therm #sunxi-cir g_serial r8152 8189es"
 MODULES_NEXT="g_serial r8152 8189es"


### PR DESCRIPTION
board configuration file for Orange Pi R1 was referring to Pi Zero as
BOOTCONFIG - As a result wrong device tree file was used which
made some of the hardware features unavailable or configured
incorrectly


