### PR TITLE
Fix issue with audio quality on NanoPi M4, see: https://forum.armbian.com/topic/9605-sound-problems-with-nanopi-m4/

### DIFF
--- a/patch/kernel/rk3399-default/friendly-arm-hangs-without.patch
+++ b/patch/kernel/rk3399-default/friendly-arm-hangs-without.patch
@@ -1,9 +1,9 @@
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-nanopi4-common.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-nanopi4-common.dtsi
-index c2a6bedb..cdfcf0a5 100644
+index c2918c3f..dcf79320 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-nanopi4-common.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi4-common.dtsi
-@@ -67,24 +67,6 @@
- 		model = "NanoPi 4 Series";
+@@ -74,24 +74,6 @@
+ 		spi1 = &spi1;
  	};
  
 -	fiq_debugger: fiq-debugger {
@@ -27,7 +27,7 @@ index c2a6bedb..cdfcf0a5 100644
  	clkin_gmac: external-gmac-clock {
  		compatible = "fixed-clock";
  		clock-frequency = <125000000>;
-@@ -507,16 +489,12 @@
+@@ -526,16 +508,12 @@
  	//allocator = <0>;
  };
  
@@ -45,7 +45,7 @@ index c2a6bedb..cdfcf0a5 100644
  	force-hpd;
  	/delete-property/ pinctrl-0;
  
-@@ -537,29 +515,22 @@
+@@ -556,29 +534,22 @@
  
  &route_edp {
  	status = "okay";
@@ -77,20 +77,8 @@ index c2a6bedb..cdfcf0a5 100644
 -	logo,mode = "center";
  };
  
- &cif_isp0 {
-@@ -932,11 +903,6 @@
- 	#sound-dai-cells = <0>;
- };
- 
--&i2s1 {
--	assigned-clocks = <&cru SCLK_I2S_8CH>;
--	assigned-clock-parents = <&cru SCLK_I2S1_8CH>;
--};
--
- &i2s2 {
- 	#sound-dai-cells = <0>;
- 	status = "okay";
-@@ -946,10 +946,16 @@
+ &i2c0 {
+@@ -931,10 +902,16 @@
  };
  
  &pcie0 {
@@ -108,7 +96,7 @@ index c2a6bedb..cdfcf0a5 100644
  };
  
  &pwm_bl {
-@@ -1147,14 +1120,6 @@
+@@ -1118,14 +1095,6 @@
  };
  
  &pinctrl {


### PR DESCRIPTION
Reinstate &i2s1 entry from FriendlyElec rk3399-nanopi4-common.dtsi to assigns i2s1 master clock (SCLK_I2S1_8CH) to i2s_8ch_mclk output pin clock source (SCLK_I2S_8CH) when i2s1 node is enabled.

Impact: Only impacts NanoPi M4. By default the i2s1 DT node is disabled, therefore this clock assignment is not applied unless either (1) the user modifies the DT, or (2) i2s1 is enabled in a specific nanopi board .dts -- at this time the only such board is NanoPi M4. 

On NanoPi M4 this change will cause the i2s1 mclk to be sent to the rt5651 codec, which results in the audio codec receiving the correct (i2s1) master clock -- this is what fixes the audio quality issue. Prior to this change, the codec was getting the default i2s0 mclk, which was the cause of the bad audio. 

On all nanopis if i2s1 is enabled in DT (e.g. if the user enables it), this change will route i2s1 mclk to the mclk line on the 40 pin header. 

As-is this change leaves NanoPC T4 unaffected. However, if the user edits the DT to enable i2s1 there is a behavior change: On NanoPC T4, the onboard codec is connected to i2s0 bus and also to the i2s_8ch_mclk line. The T4 onboard codec needs to receive i2s0 clock and will not work correctly if it receives i2s1 mclk. Hence user-enabling i2s1 on the T4 (with this merge request applied) will break audio quality (in essence, create the reverse of the situation of the current problem with the M4). Anyone enabling i2s1 to use the 40 pin header on the T4 will need to chose whether to route i2s0 or i2s1 mclk to the i2s_8ch_mclk line.

NOTE: the other context line changes in this patch reflect the fact that the source file rk3399-nanopi4-common.dtsi has changed since the original friendly-arm-hangs-without.patch was created.

The generated device trees have been tested on:

- NanoPC T4 (by user s_frit) where the system boots and the change has no other detected effect, as expected.
- NanoPi M4 (by user Exie) where the system boots, and the change switches clk_i2sout_src and improves audio quality (once audio output is enabled with amixer). (Exie confirmed this in linked forum thread.)