### PR TITLE
nand-sata-install: rm unused nanddevice variable

### DIFF
--- a/packages/bsp/common/usr/sbin/nand-sata-install
+++ b/packages/bsp/common/usr/sbin/nand-sata-install
@@ -17,7 +17,6 @@
 CWD="/usr/lib/nand-sata-install"
 EX_LIST="${CWD}/exclude.txt"
 [ -f /etc/default/openmediavault ] && echo '/srv/*' >>"${EX_LIST}"
-nanddevice="/dev/nand"
 logfile="/var/log/nand-sata-install.log"
 
 # read in board info


### PR DESCRIPTION
I would do a bunch of PRs doind a basic clean up of the the `nand-sata-install`.
Would open a bunch of small PRs.
And also probably would do some improving of a shell code.