### PR TITLE
fix path issue for cron.d script

### DIFF
--- a/packages/bsp/common/etc/cron.d/armbian-truncate-logs
+++ b/packages/bsp/common/etc/cron.d/armbian-truncate-logs
@@ -1,4 +1,4 @@
-PATH=/usr/bin:/bin:/usr/sbin:/sbin
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
 */15 * * * * root /usr/lib/armbian/armbian-truncate-logs
 

--- a/packages/bsp/common/etc/cron.d/armbian-truncate-logs
+++ b/packages/bsp/common/etc/cron.d/armbian-truncate-logs
@@ -1,2 +1,4 @@
+PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
 */15 * * * * root /usr/lib/armbian/armbian-truncate-logs
 


### PR DESCRIPTION
Fix for Issue (https://github.com/armbian/build/issues/1298)

The default path for cron is "/usr/bin:/bin"

The armbian-truncate-logs script refers to items in /usr/sbin

