### PR TITLE
[ helios4 ] Enable WoL for eth0

### DIFF
--- a/config/sources/mvebu-helios4.inc
+++ b/config/sources/mvebu-helios4.inc
@@ -60,4 +60,10 @@ family_tweaks_s()
 	# modify mdadm configuration
 	echo -e "\n # Trigger Fault Led script when an event is detected" >> $SDCARD/etc/mdadm/mdadm.conf
 	echo -e "PROGRAM /usr/sbin/mdadm-fault-led.sh" >> $SDCARD/etc/mdadm/mdadm.conf
+
+	### Ethernet tweaks
+
+	# copy and enable helios4-wol.service
+	cp $SRC/packages/bsp/helios4/helios4-wol.service $SDCARD/usr/lib/systemd/system/
+	chroot $SDCARD /bin/bash -c "systemctl --no-reload enable helios4-wol.service >/dev/null 2>&1"
 }

--- a/packages/bsp/helios4/helios4-wol.service
+++ b/packages/bsp/helios4/helios4-wol.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Enable Wake-on-LAN for Helios4 eth0
+Requires=network.target
+After=network.target
+
+[Service]
+ExecStart=/sbin/ethtool -s eth0 wol g
+Type=oneshot
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Since now WoL is supported by Helios4 since #1284 then let's enable magic packet wake up on eth0 interface by default. 