### PR TITLE
nand-sata-install: egrep -> grep, fix error cases, supply exit codes

### DIFF
--- a/packages/bsp/common/usr/sbin/nand-sata-install
+++ b/packages/bsp/common/usr/sbin/nand-sata-install
@@ -303,7 +303,7 @@ create_armbian()
 
 		if [[ $(type -t write_uboot_platform) != function ]]; then
 			echo "Error: no u-boot package found, exiting"
-			exit -1
+			exit 1
 		fi
 		write_uboot_platform "$DIR" $emmccheck
 

--- a/packages/bsp/common/usr/sbin/nand-sata-install
+++ b/packages/bsp/common/usr/sbin/nand-sata-install
@@ -278,7 +278,7 @@ create_armbian()
 			[[ -f "${TempDir}"/bootfs/boot/boot.ini ]] && sed -e 's,^setenv rootdev.*$,setenv rootdev "'"$targetuuid"'",' -i "${TempDir}"/bootfs/boot/boot.ini
 			[[ -f "${TempDir}"/rootfs/boot/boot.ini ]] && sed -e 's,^setenv rootdev.*$,setenv rootdev "'"$targetuuid"'",' -i "${TempDir}"/rootfs/boot/boot.ini
 		fi
-		mkimage -C none -A arm -T script -d "${TempDir}"/bootfs/boot/boot.cmd "${TempDir}"/bootfs/boot/boot.scr	>/dev/null 2>&1 || (echo "Error"; exit 0)
+		mkimage -C none -A arm -T script -d "${TempDir}"/bootfs/boot/boot.cmd "${TempDir}"/bootfs/boot/boot.scr	>/dev/null 2>&1 || (echo "Error"; exit 1)
 
 		# fstab adj
 		if [[ "$1" != "$2" ]]; then
@@ -327,7 +327,7 @@ create_armbian()
 			sed -e 's,setenv rootfstype.*,setenv rootfstype '"$FilesystemChoosen"',' -i /boot/boot.cmd
 			sed -e 's,setenv rootfstype.*,setenv rootfstype '"$FilesystemChoosen"',' -i /boot/boot.ini
 		fi
-		[[ -f /boot/boot.cmd ]] && mkimage -C none -A arm -T script -d /boot/boot.cmd /boot/boot.scr >/dev/null 2>&1 || (echo "Error"; exit 0)
+		[[ -f /boot/boot.cmd ]] && mkimage -C none -A arm -T script -d /boot/boot.cmd /boot/boot.scr >/dev/null 2>&1 || (echo "Error"; exit 1)
 		mkdir -p "${TempDir}"/rootfs/media/mmc/boot
 		echo "${sduuid}	/media/mmcboot	ext4    ${mountopts[ext4]}" >> "${TempDir}"/rootfs/etc/fstab
 		echo "/media/mmcboot/boot  				/boot		none	bind								0       0" >> "${TempDir}"/rootfs/etc/fstab
@@ -403,7 +403,7 @@ show_nand_warning()
 #
 format_nand()
 {
-	[[ ! -e /dev/nand ]] && echo "NAND error" && exit 0
+	[[ ! -e /dev/nand ]] && echo "NAND error" && exit 1
 
 	show_nand_warning
 

--- a/packages/bsp/common/usr/sbin/nand-sata-install
+++ b/packages/bsp/common/usr/sbin/nand-sata-install
@@ -74,7 +74,7 @@ mountopts[f2fs]='defaults,noatime,nodiratime,x-gvfs-hide	0	2'
 create_armbian()
 {
 	# create mount points, mount and clean
-	TempDir=$(mktemp -d /mnt/${0##*/}.XXXXXX || exit 1)
+	TempDir=$(mktemp -d /mnt/${0##*/}.XXXXXX || exit 2)
 	sync &&	mkdir -p "${TempDir}"/bootfs "${TempDir}"/rootfs
 	if [[ $eMMCFilesystemChoosen =~ ^(btrfs|f2fs)$ ]]; then
 		[[ -n $1 ]] && mount ${1::-1}"1" "${TempDir}"/bootfs
@@ -108,7 +108,7 @@ create_armbian()
 		dialog --title "$title" --backtitle "$backtitle" --colors --infobox\
 		"\n\Z1Partition too small.\Zn Needed: $USAGE MB Avaliable: $DEST MB" 5 60
 		umount_device "$1"; umount_device "$2"
-		exit 1
+		exit 3
 	fi
 
 	if [[ $1 == *nand* ]]; then
@@ -183,7 +183,7 @@ create_armbian()
 			else
 				# if rsync return error
 				echo "Error: could not copy rootfs files, exiting"
-				exit 1
+				exit 4
 			fi
 		else
 			sleep 0.5
@@ -278,7 +278,7 @@ create_armbian()
 			[[ -f "${TempDir}"/bootfs/boot/boot.ini ]] && sed -e 's,^setenv rootdev.*$,setenv rootdev "'"$targetuuid"'",' -i "${TempDir}"/bootfs/boot/boot.ini
 			[[ -f "${TempDir}"/rootfs/boot/boot.ini ]] && sed -e 's,^setenv rootdev.*$,setenv rootdev "'"$targetuuid"'",' -i "${TempDir}"/rootfs/boot/boot.ini
 		fi
-		mkimage -C none -A arm -T script -d "${TempDir}"/bootfs/boot/boot.cmd "${TempDir}"/bootfs/boot/boot.scr	>/dev/null 2>&1 || (echo 'Error while creating U-Boot loader image with mkimage' >&2 ; exit 1)
+		mkimage -C none -A arm -T script -d "${TempDir}"/bootfs/boot/boot.cmd "${TempDir}"/bootfs/boot/boot.scr	>/dev/null 2>&1 || (echo 'Error while creating U-Boot loader image with mkimage' >&2 ; exit 5)
 
 		# fstab adj
 		if [[ "$1" != "$2" ]]; then
@@ -303,7 +303,7 @@ create_armbian()
 
 		if [[ $(type -t write_uboot_platform) != function ]]; then
 			echo "Error: no u-boot package found, exiting"
-			exit 1
+			exit 6
 		fi
 		write_uboot_platform "$DIR" $emmccheck
 
@@ -327,7 +327,7 @@ create_armbian()
 			sed -e 's,setenv rootfstype.*,setenv rootfstype '"$FilesystemChoosen"',' -i /boot/boot.cmd
 			sed -e 's,setenv rootfstype.*,setenv rootfstype '"$FilesystemChoosen"',' -i /boot/boot.ini
 		fi
-		[[ -f /boot/boot.cmd ]] && mkimage -C none -A arm -T script -d /boot/boot.cmd /boot/boot.scr >/dev/null 2>&1 || (echo 'Error while creating U-Boot loader image with mkimage' >&2 ; exit 1)
+		[[ -f /boot/boot.cmd ]] && mkimage -C none -A arm -T script -d /boot/boot.cmd /boot/boot.scr >/dev/null 2>&1 || (echo 'Error while creating U-Boot loader image with mkimage' >&2 ; exit 7)
 		mkdir -p "${TempDir}"/rootfs/media/mmc/boot
 		echo "${sduuid}	/media/mmcboot	ext4    ${mountopts[ext4]}" >> "${TempDir}"/rootfs/etc/fstab
 		echo "/media/mmcboot/boot  				/boot		none	bind								0       0" >> "${TempDir}"/rootfs/etc/fstab
@@ -403,7 +403,7 @@ show_nand_warning()
 #
 format_nand()
 {
-	[[ ! -e /dev/nand ]] && echo '/dev/nand does not exist' >&2 && exit 1
+	[[ ! -e /dev/nand ]] && echo '/dev/nand does not exist' >&2 && exit 8
 
 	show_nand_warning
 
@@ -433,7 +433,7 @@ format_emmc()
 	FilesystemCmd=(dialog --title "Select filesystem type for eMMC $1" --backtitle "$backtitle" --menu "\n$infos" 10 60 16)
 	FilesystemChoices=$("${FilesystemCmd[@]}" "${FilesystemOptions[@]}" 2>&1 >/dev/tty)
 
-	[[ $? -ne 0 ]] && exit 1
+	[[ $? -ne 0 ]] && exit 9
 	eMMCFilesystemChoosen=${FilesystemOptions[(2*$FilesystemChoices)-1]}
 
 	# deletes all partitions on eMMC drive
@@ -518,7 +518,7 @@ format_disk()
 	FilesystemCmd=(dialog --title "Select filesystem type for $1" --backtitle "$backtitle" --menu "\n$infos" 10 60 16)
 	FilesystemChoices=$("${FilesystemCmd[@]}" "${FilesystemOptions[@]}" 2>&1 >/dev/tty)
 
-	[[ $? -ne 0 ]] && exit 1
+	[[ $? -ne 0 ]] && exit 10
 	FilesystemChoosen=${FilesystemOptions[(2*$FilesystemChoices)-1]}
 
 	dialog --title "$title" --backtitle "$backtitle" --infobox "\nFormating $1 to $FilesystemChoosen ... please wait." 5 60
@@ -544,7 +544,7 @@ check_partitions()
 	PartitionCmd=(dialog --title 'Select destination:' --backtitle "$backtitle" --menu "\n$infos" 10 60 16)
 	PartitionChoices=$("${PartitionCmd[@]}" "${PartitionOptions[@]}" 2>&1 >/dev/tty)
 
-	[[ $? -ne 0 ]] && exit 1
+	[[ $? -ne 0 ]] && exit 11
 	DISK_ROOT_PART=${PartitionOptions[(2*$PartitionChoices)-1]}
 }
 
@@ -566,7 +566,7 @@ check_nvme_target()
 	NVMeCmd=(dialog --title 'Select destination:' --backtitle "$backtitle" --menu "\n$infos" 10 60 16)
 	NVMeChoices=$("${NVMeCmd[@]}" "${NVMeOptions[@]}" 2>&1 >/dev/tty)
 
-	[[ $? -ne 0 ]] && exit 1
+	[[ $? -ne 0 ]] && exit 12
 	DISK_ROOT_PART=${NVMeOptions[(2*$NVMeChoices)-1]}
 }
 
@@ -589,7 +589,7 @@ update_bootscript()
 show_warning()
 {
 	dialog --title "$title" --backtitle "$backtitle" --cr-wrap --colors --yesno " \Z1$(toilet -f mono12 WARNING)\Zn\n$1" 17 74
-	[[ $? -ne 0 ]] && exit 1
+	[[ $? -ne 0 ]] && exit 13
 }
 
 # try to stop running services
@@ -609,7 +609,7 @@ main()
 	# This tool must run under root
 	if [[ $EUID -ne 0 ]]; then
 		echo 'This tool must run as root. Exiting ...' >&2
-		exit 1
+		exit 14
 	fi
 
 	# Check if we run it from SD card
@@ -620,7 +620,7 @@ main()
 			;;
 		*)
 			dialog --title "$title" --backtitle "$backtitle" --colors --infobox '\n\Z1This tool must run from SD-card! \Zn' 5 37
-			exit 1
+			exit 15
 			;;
 	esac
 
@@ -654,7 +654,7 @@ main()
 	dialog --ok-label 'Cancel' --title ' Warning ' --backtitle "$backtitle" --colors --no-collapse --msgbox '\n\Z1There are no targets. Please check your drives.\Zn' 7 52
 	cmd=(dialog --title 'Choose an option:' --backtitle "$backtitle" --menu "\nCurrent root: $root_uuid \n \n" 14 60 7)
 	choices=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
-	[[ $? -ne 0 ]] && exit 1
+	[[ $? -ne 0 ]] && exit 16
 
 	for choice in $choices
 	do

--- a/packages/bsp/common/usr/sbin/nand-sata-install
+++ b/packages/bsp/common/usr/sbin/nand-sata-install
@@ -278,7 +278,7 @@ create_armbian()
 			[[ -f "${TempDir}"/bootfs/boot/boot.ini ]] && sed -e 's,^setenv rootdev.*$,setenv rootdev "'"$targetuuid"'",' -i "${TempDir}"/bootfs/boot/boot.ini
 			[[ -f "${TempDir}"/rootfs/boot/boot.ini ]] && sed -e 's,^setenv rootdev.*$,setenv rootdev "'"$targetuuid"'",' -i "${TempDir}"/rootfs/boot/boot.ini
 		fi
-		mkimage -C none -A arm -T script -d "${TempDir}"/bootfs/boot/boot.cmd "${TempDir}"/bootfs/boot/boot.scr	>/dev/null 2>&1 || (echo "Error"; exit 1)
+		mkimage -C none -A arm -T script -d "${TempDir}"/bootfs/boot/boot.cmd "${TempDir}"/bootfs/boot/boot.scr	>/dev/null 2>&1 || (echo 'Error while creating U-Boot loader image with mkimage' >&2 ; exit 1)
 
 		# fstab adj
 		if [[ "$1" != "$2" ]]; then
@@ -327,7 +327,7 @@ create_armbian()
 			sed -e 's,setenv rootfstype.*,setenv rootfstype '"$FilesystemChoosen"',' -i /boot/boot.cmd
 			sed -e 's,setenv rootfstype.*,setenv rootfstype '"$FilesystemChoosen"',' -i /boot/boot.ini
 		fi
-		[[ -f /boot/boot.cmd ]] && mkimage -C none -A arm -T script -d /boot/boot.cmd /boot/boot.scr >/dev/null 2>&1 || (echo "Error"; exit 1)
+		[[ -f /boot/boot.cmd ]] && mkimage -C none -A arm -T script -d /boot/boot.cmd /boot/boot.scr >/dev/null 2>&1 || (echo 'Error while creating U-Boot loader image with mkimage' >&2 ; exit 1)
 		mkdir -p "${TempDir}"/rootfs/media/mmc/boot
 		echo "${sduuid}	/media/mmcboot	ext4    ${mountopts[ext4]}" >> "${TempDir}"/rootfs/etc/fstab
 		echo "/media/mmcboot/boot  				/boot		none	bind								0       0" >> "${TempDir}"/rootfs/etc/fstab
@@ -403,7 +403,7 @@ show_nand_warning()
 #
 format_nand()
 {
-	[[ ! -e /dev/nand ]] && echo "NAND error" && exit 1
+	[[ ! -e /dev/nand ]] && echo '/dev/nand does not exist' >&2 && exit 1
 
 	show_nand_warning
 

--- a/packages/bsp/common/usr/sbin/nand-sata-install
+++ b/packages/bsp/common/usr/sbin/nand-sata-install
@@ -16,7 +16,7 @@
 # script configuration
 CWD="/usr/lib/nand-sata-install"
 EX_LIST="${CWD}/exclude.txt"
-[ -f /etc/default/openmediavault ] && echo '/srv/*' >>"${EX_LIST}"
+[ -f /etc/default/openmediavault ] && echo '/srv/*' >> "${EX_LIST}"
 logfile="/var/log/nand-sata-install.log"
 
 # read in board info
@@ -46,7 +46,7 @@ root_partition_device="${root_partition::-2}"
 # find targets: NAND, EMMC, SATA, SPI flash, NVMe
 [[ -b /dev/nand ]] && nandcheck=$(ls -d -1 /dev/nand* | grep -w 'nand' | awk '{print $NF}');
 emmccheck=$(ls -d -1 /dev/mmcblk* | grep -w 'mmcblk[0-9]' | grep -v "$root_partition_device");
-diskcheck=$(lsblk -l | awk -F" " '/ disk / {print $1}' | egrep '^sd|^nvme')
+diskcheck=$(lsblk -l | awk -F" " '/ disk / {print $1}' | grep -E '^sd|^nvme')
 spicheck=$(grep 'mtd' /proc/partitions | awk '{print $NF}')
 
 # define makefs and mount options
@@ -121,7 +121,7 @@ create_armbian()
 	echo -e "Dest: $DEST\n\n/etc/fstab:" >> $logfile
 	cat /etc/fstab >> $logfile
 	echo -e "\n/etc/mtab:" >> $logfile
-	grep '^/dev/' /etc/mtab | egrep -v "log2ram|folder2ram" | sort >> $logfile
+	grep '^/dev/' /etc/mtab | grep -E -v "log2ram|folder2ram" | sort >> $logfile
 
 	# stop running services
 	echo -e "\nFiles currently open for writing:" >> $logfile
@@ -530,7 +530,7 @@ format_disk()
 check_partitions()
 {
 	IFS=" "
-	AvailablePartitions=$(lsblk -l | awk -F" " '/ part | raid..? / {print $1}' | egrep '^sd|^nvme|^md')
+	AvailablePartitions=$(lsblk -l | awk -F" " '/ part | raid..? / {print $1}' | grep -E '^sd|^nvme|^md')
 	if [[ -z $AvailablePartitions ]]; then
 		dialog --title "$title" --backtitle "$backtitle" --colors --msgbox \
 		"\n\Z1There are no avaliable partitions. Please create them.\Zn" 7 60
@@ -538,7 +538,7 @@ check_partitions()
 		apt-get -y -q install gdisk >/dev/null 2>&1
 		gdisk /dev/$diskcheck
 	fi
-	AvailablePartitions=$(lsblk -l | awk -F" " '/ part | raid..? / {print $1}' | egrep '^sd|^nvme|^md' | uniq | sed 's|^|/dev/|' | nl | xargs echo -n)
+	AvailablePartitions=$(lsblk -l | awk -F" " '/ part | raid..? / {print $1}' | grep -E '^sd|^nvme|^md' | uniq | sed 's|^|/dev/|' | nl | xargs echo -n)
 	PartitionOptions=($AvailablePartitions)
 
 	PartitionCmd=(dialog --title 'Select destination:' --backtitle "$backtitle" --menu "\n$infos" 10 60 16)
@@ -596,7 +596,7 @@ show_warning()
 stop_running_services()
 {
 	systemctl --state=running | awk -F" " '/.service/ {print $1}' | sort -r | \
-		egrep -e "$1" | while read ; do
+		grep -E -e "$1" | while read ; do
 		echo -e "\nStopping ${REPLY} \c"
 		systemctl stop ${REPLY} 2>&1
 	done


### PR DESCRIPTION
1. `egrep` now is a deprecated tool, now it just launches `grep` with a `-E` key. But real `egrep` can still be on some OS.
    - Streamlining on `grep`.
    - Usage of `egrep` is deprecated.
    - Remove unneeded dependency on `egrep`.

2. Fixed impossible `exit -1` code, changed to proper one - in range of [1-255].
3. In three cases lines essentially were:
    
    ```bash
    echo "Error" && exit 0
    ```
    That code contradicted itself.
  
    Turned those severe error cases (which seems for me they are - like creating U-boot loader image with `mkimage`) - into proper cases with error exit codes. And with more informative messages now properly sent to `stderr`, as they should.
  
4. Went through solidified (in paragraphs 2-3) list of `exit 1` codes and made for errors the different exit codes.
  
    It is strange for all errors to have one error code. We have a [1-255] range.
    Different error codes allow for anyone without reading through the script or knowing `bash -x` debug key - to jump right to and see the lines that brought error, this one is obvious.