### PR TITLE
[ helios4 ] fix helios4-wol.service copy target path

### DIFF
--- a/config/sources/mvebu-helios4.inc
+++ b/config/sources/mvebu-helios4.inc
@@ -64,6 +64,6 @@ family_tweaks_s()
 	### Ethernet tweaks
 
 	# copy and enable helios4-wol.service
-	cp $SRC/packages/bsp/helios4/helios4-wol.service $SDCARD/usr/lib/systemd/system/
+	cp $SRC/packages/bsp/helios4/helios4-wol.service $SDCARD/lib/systemd/system/
 	chroot $SDCARD /bin/bash -c "systemctl --no-reload enable helios4-wol.service >/dev/null 2>&1"
 }


### PR DESCRIPTION
Board specific service file should go to /lib/systemd/system/