### PR TITLE
fix directly run pyc error

### DIFF
--- a/config/sources/meson64.conf
+++ b/config/sources/meson64.conf
@@ -85,7 +85,7 @@ uboot_custom_postprocess()
 				$t/gxl/bl301_zero.bin \
 				$t/gxl/bl30_new.bin bl30
 
-		$t/acs_tool.pyc $t/gxl/bl2.bin \
+		python $t/acs_tool.pyc $t/gxl/bl2.bin \
 				$t/gxl/bl2_acs.bin \
 				$t/gxl/acs.bin 0
 
@@ -130,7 +130,7 @@ uboot_custom_postprocess()
 
 		$t/k2/fip_create --dump $t/k2/fip.bin
 
-		$t/acs_tool.pyc $t/k2/bl2.bin \
+		python $t/acs_tool.pyc $t/k2/bl2.bin \
 				$t/k2/bl2_acs.bin \
 				$t/k2/acs.bin 0
 


### PR DESCRIPTION
for #1309 issue 1

due to error when directly run pyc, change to python *.pyc, then no error.

Signed-off-by: Zhang Ning <832666+zhangn1985@users.noreply.github.com>

Please use the "Preview" tab above to view this message if you are seeing this in the new pull request text box.

Please make sure that:

 - pull request is opened to the `master` branch unless you are working on a specfic feature which is developed in a separate branch
 - any changes to kernel configuration files were made by Kconfig menu (build script option `KERNEL_CONFIGURE=yes`) and not by editing configuration files by hand,
 - patch file names don't contain spaces and have less than 40 characters (not counting the `.patch` extension),
 - changes are properly described - what was done exactly and why.

Thanks for contributing! Please remove the text above before opening a pull request.
