### PR TITLE
Return some changes from 01-linux-0001-rockchip (HDMI 1366x768 fix)

### DIFF
--- a/patch/kernel/rockchip-default/01-linux-0001-rockchip.patch
+++ b/patch/kernel/rockchip-default/01-linux-0001-rockchip.patch
@@ -1,0 +1,94 @@
+diff --git a/arch/arm/boot/dts/rk3288.dtsi b/arch/arm/boot/dts/rk3288.dtsi
+index ee8ca48b..d5e11b69 100644
+--- a/arch/arm/boot/dts/rk3288.dtsi
++++ b/arch/arm/boot/dts/rk3288.dtsi
+@@ -1064,7 +1064,7 @@
+                                   <&cru PCLK_PERI>;
+ 		assigned-clock-rates = <594000000>,
+ 				       <1250000000>, <300000000>,
+-				       <150000000>, <75000000>,
++				       <0>, <75000000>,
+ 				       <300000000>, <150000000>,
+ 				       <75000000>;
+ 	};
+@@ -1315,6 +1315,8 @@
+ 		resets = <&cru SRST_LCDC0_AXI>, <&cru SRST_LCDC0_AHB>, <&cru SRST_LCDC0_DCLK>;
+ 		reset-names = "axi", "ahb", "dclk";
+ 		iommus = <&vopb_mmu>;
++		assigned-clocks = <&cru DCLK_VOP0>;
++		assigned-clock-parents = <&cru PLL_NPLL>;
+ 		status = "disabled";
+ 
+ 		vopb_out: port {
+diff --git a/drivers/clk/rockchip/clk-pll.c b/drivers/clk/rockchip/clk-pll.c
+index 0a9f31f2..183114d8 100644
+--- a/drivers/clk/rockchip/clk-pll.c
++++ b/drivers/clk/rockchip/clk-pll.c
+@@ -364,6 +364,17 @@ static const struct rockchip_pll_rate_table *rockchip_get_pll_settings(
+ static long rockchip_pll_round_rate(struct clk_hw *hw,
+ 			    unsigned long drate, unsigned long *prate)
+ {
++	struct rockchip_clk_pll *pll = to_rockchip_clk_pll(hw);
++	const struct rockchip_pll_rate_table *rate;
++
++	/* Get required rate settings from table */
++	rate = rockchip_get_pll_settings(pll, drate);
++	if (!rate) {
++		pr_debug("%s: Invalid rate : %lu for pll clk %s\n", __func__,
++			drate, __clk_get_name(hw->clk));
++		return -EINVAL;
++	}
++
+ 	return drate;
+ }
+ 
+diff --git a/drivers/clk/rockchip/clk-rk3288.c b/drivers/clk/rockchip/clk-rk3288.c
+index ca6c2ad3..f748a292 100644
+--- a/drivers/clk/rockchip/clk-rk3288.c
++++ b/drivers/clk/rockchip/clk-rk3288.c
+@@ -105,6 +105,27 @@ static struct rockchip_pll_rate_table rk3288_pll_rates[] = {
+ 	{ /* sentinel */ },
+ };
+ 
++static struct rockchip_pll_rate_table rk3288_npll_rates[] = {
++	RK3066_PLL_RATE_NB(594000000, 1, 99, 4, 32),
++	RK3066_PLL_RATE_NB(585000000, 6, 585, 4, 32),
++	RK3066_PLL_RATE_NB(432000000, 3, 216, 4, 32),
++	RK3066_PLL_RATE_NB(426000000, 3, 213, 4, 32),
++	RK3066_PLL_RATE_NB(400000000, 1, 100, 6, 32),
++	RK3066_PLL_RATE_NB(342000000, 3, 171, 4, 32),
++	RK3066_PLL_RATE_NB(297000000, 2, 198, 8, 16),
++	RK3066_PLL_RATE_NB(270000000, 1, 135, 12, 32),
++	RK3066_PLL_RATE_NB(260000000, 1, 130, 12, 32),
++	RK3066_PLL_RATE_NB(148500000, 1, 99, 16, 32),
++	RK3066_PLL_RATE(148352000, 13, 1125, 14),
++	RK3066_PLL_RATE_NB(146250000, 6, 585, 16, 32),
++	RK3066_PLL_RATE_NB(108000000, 1, 54, 12, 32),
++	RK3066_PLL_RATE_NB(106500000, 4, 213, 12, 32),
++	RK3066_PLL_RATE_NB(85500000, 4, 171, 12, 32),
++	RK3066_PLL_RATE_NB(74250000, 4, 198, 16, 32),
++	RK3066_PLL_RATE(74176000, 26, 1125, 14),
++	{ /* sentinel */ },
++};
++
+ #define RK3288_DIV_ACLK_CORE_M0_MASK	0xf
+ #define RK3288_DIV_ACLK_CORE_M0_SHIFT	0
+ #define RK3288_DIV_ACLK_CORE_MP_MASK	0xf
+@@ -214,7 +235,7 @@ static struct rockchip_pll_clock rk3288_pll_clks[] __initdata = {
+ 	[gpll] = PLL(pll_rk3066, PLL_GPLL, "gpll", mux_pll_p, 0, RK3288_PLL_CON(12),
+ 		     RK3288_MODE_CON, 12, 8, 0, rk3288_pll_rates),
+ 	[npll] = PLL(pll_rk3066, PLL_NPLL, "npll",  mux_pll_p, 0, RK3288_PLL_CON(16),
+-		     RK3288_MODE_CON, 14, 9, ROCKCHIP_PLL_SYNC_RATE, rk3288_pll_rates),
++		     RK3288_MODE_CON, 14, 9, 0, rk3288_npll_rates),
+ };
+ 
+ static struct clk_div_table div_hclk_cpu_t[] = {
+@@ -429,7 +450,7 @@ static struct rockchip_clk_branch rk3288_clk_branches[] __initdata = {
+ 			RK3288_CLKSEL_CON(30), 14, 2, MFLAGS, 8, 5, DFLAGS,
+ 			RK3288_CLKGATE_CON(3), 4, GFLAGS),
+ 
+-	COMPOSITE(DCLK_VOP0, "dclk_vop0", mux_pll_src_cpll_gpll_npll_p, 0,
++	COMPOSITE(DCLK_VOP0, "dclk_vop0", mux_pll_src_cpll_gpll_npll_p, CLK_SET_RATE_NO_REPARENT | CLK_SET_RATE_PARENT,
+ 			RK3288_CLKSEL_CON(27), 0, 2, MFLAGS, 8, 8, DFLAGS,
+ 			RK3288_CLKGATE_CON(3), 1, GFLAGS),
+ 	COMPOSITE(DCLK_VOP1, "dclk_vop1", mux_pll_src_cpll_gpll_npll_p, 0,


### PR DESCRIPTION
I connect 1366x768 monitor to Tinkerboard (bionic, 4.4 kernel)
But not all resolutions are determined:
```
root@tinkerboard:~# cat /sys/devices/platform/display-subsystem/drm/card0/card0-HDMI-A-1/modes
1920x1080p60
1280x720p60
720x400p70
```

I tried use manual modeline for my monitor (from edid):
```Modeline "Mode 0" 85.50 1366 1436 1579 1792 768 771 774 798 +hsync +vsync ```

But after applying this modeline:
* monitor detects 1280x720 resolution instead of 1366x768
* crops image as 1024x768
* have many noises and waves on screen... very unstable image
(pixel clock 84.857 mhz, but expected 85.5 mhz)

I tried cvt/gtf and others modelines, but result is one - not working. 

Finally i tested in TinkerOS and all resolutions works fine!

After few days of debugging i found problem. 
@igorpecovnik in this commit https://github.com/armbian/build/commit/93ae28f78dce6c747f0616dced591af7edf31377 disables important changes for HDMI. 

After backporting this patch all resolutions determined and works same as in TinkerOS. 
```
root@tinkerboard:~# cat /sys/devices/platform/display-subsystem/drm/card0/card0-HDMI-A-1/modes
1366x768p60
1920x1080p60
1920x1080p60
1152x864p75
1280x720p60
1280x720p60
1024x768p75
1024x768p60
800x600p75
800x600p60
640x480p75
720x400p70
```

Thread in forum: https://forum.armbian.com/topic/9944-solution-armbian-kernel-44-has-broken-hdmi-dont-work-some-resolutions/