### PR TITLE
Change regex match from 'log/' to '/log/' in armbian-hardware-optimization

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
+++ b/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
@@ -44,11 +44,11 @@ prepare_board() {
 	CheckDevice=$(for i in /var/log /var / ; do findmnt -n -o SOURCE $i && break ; done)
 	# adjust logrotate configs
 	if [[ "${CheckDevice}" == "/dev/zram0" || "${CheckDevice}" == "armbian-ramlog" ]]; then
-		for ConfigFile in /etc/logrotate.d/* ; do sed -i -e "s/log\//log.hdd\//" "${ConfigFile}"; done
-		sed -i "s/log\//log.hdd\//" /etc/logrotate.conf
+		for ConfigFile in /etc/logrotate.d/* ; do sed -i -e "s/\/log\//\/log.hdd\//g" "${ConfigFile}"; done
+		sed -i "s/\/log\//\/log.hdd\//g" /etc/logrotate.conf
 	else
-		for ConfigFile in /etc/logrotate.d/* ; do sed -i -e "s/\/log.hdd\//\/log\//" "${ConfigFile}"; done
-		sed -i "s/\/log.hdd\//\/log\//" /etc/logrotate.conf
+		for ConfigFile in /etc/logrotate.d/* ; do sed -i -e "s/\/log.hdd\//\/log\//g" "${ConfigFile}"; done
+		sed -i "s/\/log.hdd\//\/log\//g" /etc/logrotate.conf
 	fi
 
 	# unlock cpuinfo_cur_freq to be accesible by a normal user


### PR DESCRIPTION
The sed command in `armbian-hardware-optimization` script was wrongly replacing every folder whose name ends in `log/` with `log.hdd/`, so i.e. `/var/log/ulog/*.log` became `/var/log.hdd/ulog.hdd/*.log`. Subsequent logrotate exections would fail due to non existent folders.

In addition, some logrotate config files may have more than one path per line, so a _"g"_ option in the sed replacement regex is required to replace all `/log/` entries at once.
