### PR TITLE
Update index for pin bank 'H' in sun50i-a64-fixup.scr-cmd

### DIFF
--- a/patch/kernel/sunxi-dev/general-sunxi-overlays.patch
+++ b/patch/kernel/sunxi-dev/general-sunxi-overlays.patch
@@ -5068,7 +5068,7 @@ index 0000000..6e192b5
 +test "${tmp_bank}" = "B" && setenv tmp_bank 1;
 +test "${tmp_bank}" = "C" && setenv tmp_bank 2;
 +test "${tmp_bank}" = "D" && setenv tmp_bank 3;
-+test "${tmp_bank}" = "H" && setenv tmp_bank 6'
++test "${tmp_bank}" = "H" && setenv tmp_bank 7'
 +
 +if test -n "${param_spinor_spi_bus}"; then
 +	test "${param_spinor_spi_bus}" = "0" && setenv tmp_spi_path "spi@1c68000"

--- a/patch/kernel/sunxi-next/general-sunxi-overlays.patch
+++ b/patch/kernel/sunxi-next/general-sunxi-overlays.patch
@@ -5068,7 +5068,7 @@ index 0000000..6e192b5
 +test "${tmp_bank}" = "B" && setenv tmp_bank 1;
 +test "${tmp_bank}" = "C" && setenv tmp_bank 2;
 +test "${tmp_bank}" = "D" && setenv tmp_bank 3;
-+test "${tmp_bank}" = "H" && setenv tmp_bank 6'
++test "${tmp_bank}" = "H" && setenv tmp_bank 7'
 +
 +if test -n "${param_spinor_spi_bus}"; then
 +	test "${param_spinor_spi_bus}" = "0" && setenv tmp_spi_path "spi@1c68000"


### PR DESCRIPTION
Fix off-by-one numeric index for pin bank ‘H’ in sun50i-a64-fixup.scr-cmd

This was also previously corrected via [PR#6](https://github.com/armbian/sunxi-DT-overlays/pull/6) to the sunxi-DT-overlays repository
