### PR TITLE
update overlay compile patch for 4.20.17

### DIFF
--- a/patch/kernel/meson64-dev/general-add-overlay-compilation-support.patch
+++ b/patch/kernel/meson64-dev/general-add-overlay-compilation-support.patch
@@ -1,22 +1,22 @@
-diff --git a/arch/arm/Makefile b/arch/arm/Makefile
-index 65f4e2a4..9eb2043c 100644
---- a/arch/arm/Makefile
-+++ b/arch/arm/Makefile
-@@ -339,6 +339,12 @@ $(INSTALL_TARGETS):
- %.dtb: | scripts
- 	$(Q)$(MAKE) $(build)=$(boot)/dts MACHINE=$(MACHINE) $(boot)/dts/$@
-
-+%.dtbo: | scripts
-+	$(Q)$(MAKE) $(build)=$(boot)/dts MACHINE=$(MACHINE) $(boot)/dts/$@
+diff --git a/Makefile b/Makefile
+index b15adbe428d9..d0b426549603 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1232,6 +1232,12 @@ ifneq ($(dtstree),)
+ %.dtb: prepare3 scripts_dtc
+ 	$(Q)$(MAKE) $(build)=$(dtstree) $(dtstree)/$@
+ 
++%.dtbo: | scripts_dtc
++	$(Q)$(MAKE) $(build)=$(dtstree) $(dtstree)/$@
 +
-+%.scr: | scripts
-+	$(Q)$(MAKE) $(build)=$(boot)/dts ARCH=$(ARCH) $(boot)/dts/$@
++%.scr: | scripts_dtc
++	$(Q)$(MAKE) $(build)=$(dtstree) $(dtstree)/$@
 +
  PHONY += dtbs dtbs_install
-
- dtbs: prepare scripts
+ dtbs: prepare3 scripts_dtc
+ 	$(Q)$(MAKE) $(build)=$(dtstree)
 diff --git a/arch/arm/boot/.gitignore b/arch/arm/boot/.gitignore
-index 3c79f859..4e5c1d59 100644
+index ce1c5ff746e7..13237c538390 100644
 --- a/arch/arm/boot/.gitignore
 +++ b/arch/arm/boot/.gitignore
 @@ -3,3 +3,5 @@ zImage
@@ -26,41 +26,24 @@ index 3c79f859..4e5c1d59 100644
 +*.dtb*
 +*.scr
 \ No newline at end of file
-diff --git a/arch/arm64/Makefile b/arch/arm64/Makefile
-index f839ecd9..9788f16d 100644
---- a/arch/arm64/Makefile
-+++ b/arch/arm64/Makefile
-@@ -121,6 +121,12 @@ zinstall install:
- %.dtb: scripts
- 	$(Q)$(MAKE) $(build)=$(boot)/dts $(boot)/dts/$@
-
-+%.dtbo: | scripts
-+	$(Q)$(MAKE) $(build)=$(boot)/dts MACHINE=$(MACHINE) $(boot)/dts/$@
-+
-+%.scr: | scripts
-+	$(Q)$(MAKE) $(build)=$(boot)/dts ARCH=$(ARCH) $(boot)/dts/$@
-+
- PHONY += dtbs dtbs_install
-
- dtbs: prepare scripts
 diff --git a/scripts/Makefile.dtbinst b/scripts/Makefile.dtbinst
-index 34614a48..8a8313d6 100644
+index 7301ab5e2e06..a08f9bee3e55 100644
 --- a/scripts/Makefile.dtbinst
 +++ b/scripts/Makefile.dtbinst
 @@ -20,6 +20,9 @@ include scripts/Kbuild.include
  include $(src)/Makefile
-
+ 
  dtbinst-files	:= $(sort $(dtb-y) $(if $(CONFIG_OF_ALL_DTBS), $(dtb-)))
 +dtboinst-files	:= $(dtbo-y)
 +script-files	:= $(scr-y)
 +readme-files	:= $(dtbotxt-y)
  dtbinst-dirs	:= $(subdir-y) $(subdir-m)
-
+ 
  # Helper targets for Installing DTBs into the boot directory
-@@ -32,10 +35,19 @@ install-dir = $(patsubst $(dtbinst-root)%,$(INSTALL_DTBS_PATH)%,$(obj))
+@@ -31,10 +34,19 @@ install-dir = $(patsubst $(dtbinst_root)%,$(INSTALL_DTBS_PATH)%,$(obj))
  $(dtbinst-files): %.dtb: $(obj)/%.dtb
  	$(call cmd,dtb_install,$(install-dir))
-
+ 
 +$(dtboinst-files): %.dtbo: $(obj)/%.dtbo
 +	$(call cmd,dtb_install,$(install-dir))
 +
@@ -72,31 +55,31 @@ index 34614a48..8a8313d6 100644
 +
  $(dtbinst-dirs):
  	$(Q)$(MAKE) $(dtbinst)=$(obj)/$@
-
+ 
 -PHONY += $(dtbinst-files) $(dtbinst-dirs)
 -__dtbs_install: $(dtbinst-files) $(dtbinst-dirs)
 +PHONY += $(dtbinst-files) $(dtboinst-files) $(script-files) $(readme-files) $(dtbinst-dirs)
 +__dtbs_install: $(dtbinst-files) $(dtboinst-files) $(script-files) $(readme-files) $(dtbinst-dirs)
-
+ 
  .PHONY: $(PHONY)
 diff --git a/scripts/Makefile.lib b/scripts/Makefile.lib
-index 58c05e5d..2b95dda9 100644
+index 8fe4468f9bda..efccf940d653 100644
 --- a/scripts/Makefile.lib
 +++ b/scripts/Makefile.lib
-@@ -278,6 +278,9 @@ cmd_gzip = (cat $(filter-out FORCE,$^) | gzip -n -f -9 > $@) || \
+@@ -244,6 +244,9 @@ cmd_gzip = (cat $(filter-out FORCE,$^) | gzip -n -f -9 > $@) || \
  # ---------------------------------------------------------------------------
  DTC ?= $(objtree)/scripts/dtc/dtc
-
+ 
 +# Overlay support
 +DTC_FLAGS += -@ -Wno-unit_address_format -Wno-simple_bus_reg
 +
  # Disable noisy checks by default
- ifeq ($(KBUILD_ENABLE_EXTRA_GCC_CHECKS),)
+ ifeq ($(findstring 1,$(KBUILD_ENABLE_EXTRA_GCC_CHECKS)),)
  DTC_FLAGS += -Wno-unit_address_vs_reg \
-@@ -324,6 +327,23 @@ cmd_dtc = mkdir -p $(dir ${dtc-tmp}) ; \
- $(obj)/%.dtb: $(src)/%.dts FORCE
+@@ -292,6 +295,23 @@ cmd_dtc = mkdir -p $(dir ${dtc-tmp}) ; \
+ $(obj)/%.dtb: $(src)/%.dts $(DTC) FORCE
  	$(call if_changed_dep,dtc)
-
+ 
 +quiet_cmd_dtco = DTCO    $@
 +cmd_dtco = mkdir -p $(dir ${dtc-tmp}) ; \
 +	$(CPP) $(dtc_cpp_flags) -x assembler-with-cpp -o $(dtc-tmp) $< ; \
@@ -115,5 +98,5 @@ index 58c05e5d..2b95dda9 100644
 +	$(call if_changed,scr)
 +
  dtc-tmp = $(subst $(comma),_,$(dot-target).dts.tmp)
-
+ 
  # Bzip2


### PR DESCRIPTION
Signed-off-by: Zhang Ning <832666+zhangn1985@users.noreply.github.com>

I'm trying to fix kernel patch conflict: general-add-overlay-compilation-support.patch

but I'm not quite understand this patch, so upload it to new branch for review.

```patch
diff --git a/Makefile b/Makefile
index b15adbe428d9..d0b426549603 100644
--- a/Makefile
+++ b/Makefile
@@ -1232,6 +1232,12 @@ ifneq ($(dtstree),)
 %.dtb: prepare3 scripts_dtc
 	$(Q)$(MAKE) $(build)=$(dtstree) $(dtstree)/$@
 
+%.dtbo: | scripts_dtc
+	$(Q)$(MAKE) $(build)=$(dtstree) $(dtstree)/$@
+
+%.scr: | scripts_dtc
+	$(Q)$(MAKE) $(build)=$(dtstree) $(dtstree)/$@
+
 PHONY += dtbs dtbs_install
 dtbs: prepare3 scripts_dtc
 	$(Q)$(MAKE) $(build)=$(dtstree)
diff --git a/arch/arm/boot/.gitignore b/arch/arm/boot/.gitignore
index ce1c5ff746e7..13237c538390 100644
--- a/arch/arm/boot/.gitignore
+++ b/arch/arm/boot/.gitignore
@@ -3,3 +3,5 @@ zImage
 xipImage
 bootpImage
 uImage
+*.dtb*
+*.scr
\ No newline at end of file
diff --git a/scripts/Makefile.dtbinst b/scripts/Makefile.dtbinst
index 7301ab5e2e06..a08f9bee3e55 100644
--- a/scripts/Makefile.dtbinst
+++ b/scripts/Makefile.dtbinst
@@ -20,6 +20,9 @@ include scripts/Kbuild.include
 include $(src)/Makefile
 
 dtbinst-files	:= $(sort $(dtb-y) $(if $(CONFIG_OF_ALL_DTBS), $(dtb-)))
+dtboinst-files	:= $(dtbo-y)
+script-files	:= $(scr-y)
+readme-files	:= $(dtbotxt-y)
 dtbinst-dirs	:= $(subdir-y) $(subdir-m)
 
 # Helper targets for Installing DTBs into the boot directory
@@ -31,10 +34,19 @@ install-dir = $(patsubst $(dtbinst_root)%,$(INSTALL_DTBS_PATH)%,$(obj))
 $(dtbinst-files): %.dtb: $(obj)/%.dtb
 	$(call cmd,dtb_install,$(install-dir))
 
+$(dtboinst-files): %.dtbo: $(obj)/%.dtbo
+	$(call cmd,dtb_install,$(install-dir))
+
+$(script-files): %.scr: $(obj)/%.scr
+	$(call cmd,dtb_install,$(install-dir))
+
+$(readme-files): %: $(src)/%
+	$(call cmd,dtb_install,$(install-dir))
+
 $(dtbinst-dirs):
 	$(Q)$(MAKE) $(dtbinst)=$(obj)/$@
 
-PHONY += $(dtbinst-files) $(dtbinst-dirs)
-__dtbs_install: $(dtbinst-files) $(dtbinst-dirs)
+PHONY += $(dtbinst-files) $(dtboinst-files) $(script-files) $(readme-files) $(dtbinst-dirs)
+__dtbs_install: $(dtbinst-files) $(dtboinst-files) $(script-files) $(readme-files) $(dtbinst-dirs)
 
 .PHONY: $(PHONY)
diff --git a/scripts/Makefile.lib b/scripts/Makefile.lib
index 8fe4468f9bda..efccf940d653 100644
--- a/scripts/Makefile.lib
+++ b/scripts/Makefile.lib
@@ -244,6 +244,9 @@ cmd_gzip = (cat $(filter-out FORCE,$^) | gzip -n -f -9 > $@) || \
 # ---------------------------------------------------------------------------
 DTC ?= $(objtree)/scripts/dtc/dtc
 
+# Overlay support
+DTC_FLAGS += -@ -Wno-unit_address_format -Wno-simple_bus_reg
+
 # Disable noisy checks by default
 ifeq ($(findstring 1,$(KBUILD_ENABLE_EXTRA_GCC_CHECKS)),)
 DTC_FLAGS += -Wno-unit_address_vs_reg \
@@ -292,6 +295,23 @@ cmd_dtc = mkdir -p $(dir ${dtc-tmp}) ; \
 $(obj)/%.dtb: $(src)/%.dts $(DTC) FORCE
 	$(call if_changed_dep,dtc)
 
+quiet_cmd_dtco = DTCO    $@
+cmd_dtco = mkdir -p $(dir ${dtc-tmp}) ; \
+	$(CPP) $(dtc_cpp_flags) -x assembler-with-cpp -o $(dtc-tmp) $< ; \
+	$(DTC) -O dtb -o $@ -b 0 \
+		-i $(dir $<) $(DTC_FLAGS) \
+		-d $(depfile).dtc.tmp $(dtc-tmp) ; \
+	cat $(depfile).pre.tmp $(depfile).dtc.tmp > $(depfile)
+
+$(obj)/%.dtbo: $(src)/%.dts FORCE
+	$(call if_changed_dep,dtco)
+
+quiet_cmd_scr = MKIMAGE $@
+cmd_scr = mkimage -C none -A $(ARCH) -T script -d $< $@
+
+$(obj)/%.scr: $(src)/%.scr-cmd FORCE
+	$(call if_changed,scr)
+
 dtc-tmp = $(subst $(comma),_,$(dot-target).dts.tmp)
 
 # Bzip2
```