### PR TITLE
fix building scripts mod when installing header package on device

### DIFF
--- a/patch/kernel/cubox-next/general-packaging-4.19-next.patch
+++ b/patch/kernel/cubox-next/general-packaging-4.19-next.patch
@@ -22,7 +22,7 @@ index 90c9a8a..3c79b90 100755
 +
 +	# Create postinstall script for headers
 +	if [[ "$1" == *headers* ]]; then
-+		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts >/dev/null 2>&1" >> $pdir/DEBIAN/postinst
++		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts -s prepare0 >/dev/null 2>&1" >> $pdir/DEBIAN/postinst
 +		echo "exit 0" >> $pdir/DEBIAN/postinst
 +		chmod 775 $pdir/DEBIAN/postinst
 +	fi

--- a/patch/kernel/meson64-dev/general-packaging-4.17-dev.patch
+++ b/patch/kernel/meson64-dev/general-packaging-4.17-dev.patch
@@ -22,7 +22,7 @@ index 90c9a8a..3c79b90 100755
 +
 +	# Create postinstall script for headers
 +	if [[ "$1" == *headers* ]]; then
-+		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts >/dev/null 2>&1" >> $pdir/DEBIAN/postinst
++		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts -s prepare0 >/dev/null 2>&1" >> $pdir/DEBIAN/postinst
 +		echo "exit 0" >> $pdir/DEBIAN/postinst
 +		chmod 775 $pdir/DEBIAN/postinst
 +	fi

--- a/patch/kernel/meson64-next/general-packaging-4.17-next.patch
+++ b/patch/kernel/meson64-next/general-packaging-4.17-next.patch
@@ -22,7 +22,7 @@ index 90c9a8a..3c79b90 100755
 +
 +	# Create postinstall script for headers
 +	if [[ "$1" == *headers* ]]; then
-+		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts >/dev/null 2>&1" >> $pdir/DEBIAN/postinst
++		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts prepare0 >/dev/null 2>&1" >> $pdir/DEBIAN/postinst
 +		echo "exit 0" >> $pdir/DEBIAN/postinst
 +		chmod 775 $pdir/DEBIAN/postinst
 +	fi

--- a/patch/kernel/odroidxu4-dev/general-packaging-4.18-dev.patch
+++ b/patch/kernel/odroidxu4-dev/general-packaging-4.18-dev.patch
@@ -22,7 +22,7 @@ index 90c9a8a..3c79b90 100755
 +
 +	# Create postinstall script for headers
 +	if [[ "$1" == *headers* ]]; then
-+		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts >/dev/null 2>&1" >> $pdir/DEBIAN/postinst
++		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts -s prepare0 >/dev/null 2>&1" >> $pdir/DEBIAN/postinst
 +		echo "exit 0" >> $pdir/DEBIAN/postinst
 +		chmod 775 $pdir/DEBIAN/postinst
 +	fi

--- a/patch/kernel/odroidxu4-next/packaging-4.x-NEXT-with-postinstall-scripts.patch
+++ b/patch/kernel/odroidxu4-next/packaging-4.x-NEXT-with-postinstall-scripts.patch
@@ -23,7 +23,7 @@ index 0bc8747..9dab810 100755
 +
 +	# Create postinstall script for headers
 +	if [[ "$1" == *headers* ]]; then
-+		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts >/dev/null 2>&1" >> $pdir/DEBIAN/postinst
++		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts -s prepare0 >/dev/null 2>&1" >> $pdir/DEBIAN/postinst
 +		echo "exit 0" >> $pdir/DEBIAN/postinst
 +		chmod 775 $pdir/DEBIAN/postinst
 +	fi

--- a/patch/kernel/rockchip-dev/general-packaging-4.20-dev.patch
+++ b/patch/kernel/rockchip-dev/general-packaging-4.20-dev.patch
@@ -22,7 +22,7 @@ index 90c9a8a..3c79b90 100755
 +
 +	# Create postinstall script for headers
 +	if [[ "$1" == *headers* ]]; then
-+		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts >/dev/null 2>&1" >> $pdir/DEBIAN/postinst
++		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts -s prepare0 >/dev/null 2>&1" >> $pdir/DEBIAN/postinst
 +		echo "exit 0" >> $pdir/DEBIAN/postinst
 +		chmod 775 $pdir/DEBIAN/postinst
 +	fi

--- a/patch/kernel/rockchip-next/general-packaging-4.17-dev.patch
+++ b/patch/kernel/rockchip-next/general-packaging-4.17-dev.patch
@@ -22,7 +22,7 @@ index 90c9a8a..3c79b90 100755
 +
 +	# Create postinstall script for headers
 +	if [[ "$1" == *headers* ]]; then
-+		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts >/dev/null 2>&1" >> $pdir/DEBIAN/postinst
++		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts -s prepare0 >/dev/null 2>&1" >> $pdir/DEBIAN/postinst
 +		echo "exit 0" >> $pdir/DEBIAN/postinst
 +		chmod 775 $pdir/DEBIAN/postinst
 +	fi

--- a/patch/kernel/sunxi-dev/general-packaging-4.20-dev.patch
+++ b/patch/kernel/sunxi-dev/general-packaging-4.20-dev.patch
@@ -22,7 +22,7 @@ index 90c9a8a..3c79b90 100755
 +
 +	# Create postinstall script for headers
 +	if [[ "$1" == *headers* ]]; then
-+		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts >/dev/null 2>&1" >> $pdir/DEBIAN/postinst
++		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts prepare0 >/dev/null 2>&1" >> $pdir/DEBIAN/postinst
 +		echo "exit 0" >> $pdir/DEBIAN/postinst
 +		chmod 775 $pdir/DEBIAN/postinst
 +	fi

--- a/patch/kernel/sunxi-next/general-packaging-4.17-next.patch
+++ b/patch/kernel/sunxi-next/general-packaging-4.17-next.patch
@@ -22,7 +22,7 @@ index 90c9a8a..3c79b90 100755
 +
 +	# Create postinstall script for headers
 +	if [[ "$1" == *headers* ]]; then
-+		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts >/dev/null 2>&1" >> $pdir/DEBIAN/postinst
++		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts -s prepare0 >/dev/null 2>&1" >> $pdir/DEBIAN/postinst
 +		echo "exit 0" >> $pdir/DEBIAN/postinst
 +		chmod 775 $pdir/DEBIAN/postinst
 +	fi


### PR DESCRIPTION
Fixing problem in linux headers dev package postinstall when script don't build scripts/mod tool
on linux kernel 5+