### PR TITLE
Place Armbian wallpaper also on monitor 1

### DIFF
--- a/packages/blobs/desktop/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-desktop.xml
+++ b/packages/blobs/desktop/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-desktop.xml
@@ -4,12 +4,24 @@
   <property name="backdrop" type="empty">
     <property name="screen0" type="empty">
       <property name="monitor0" type="empty">
-		<property name="image-path" type="string" value="/usr/share/backgrounds/xfce/armbian03-Dre0x-Minum-dark-3840x2160.jpg"/>
-        <property name="last-single-image" type="string" value="/usr/share/backgrounds/xfce/armbian03-Dre0x-Minum-dark-3840x2160.jpg"/>
         <property name="workspace0" type="empty">
           <property name="color-style" type="int" value="0"/>
           <property name="image-style" type="int" value="5"/>
-		  <property name="image-path" type="string" value="/usr/share/backgrounds/xfce/armbian03-Dre0x-Minum-dark-3840x2160.jpg"/>
+          <property name="image-path" type="string" value="/usr/share/backgrounds/xfce/armbian03-Dre0x-Minum-dark-3840x2160.jpg"/>
+          <property name="last-image" type="string" value="/usr/share/backgrounds/xfce/armbian03-Dre0x-Minum-dark-3840x2160.jpg"/>
+        </property>
+        <property name="workspace1" type="empty">
+          <property name="color-style" type="int" value="0"/>
+          <property name="image-style" type="int" value="5"/>
+          <property name="image-path" type="string" value="/usr/share/backgrounds/xfce/armbian06-1430-very-dark-3840x2160.jpg"/>
+          <property name="last-image" type="string" value="/usr/share/backgrounds/xfce/armbian06-1430-very-dark-3840x2160.jpg"/>
+        </property>
+      </property>
+      <property name="monitor1" type="empty">
+        <property name="workspace0" type="empty">
+          <property name="color-style" type="int" value="0"/>
+          <property name="image-style" type="int" value="5"/>
+          <property name="image-path" type="string" value="/usr/share/backgrounds/xfce/armbian03-Dre0x-Minum-dark-3840x2160.jpg"/>
           <property name="last-image" type="string" value="/usr/share/backgrounds/xfce/armbian03-Dre0x-Minum-dark-3840x2160.jpg"/>
         </property>
         <property name="workspace1" type="empty">


### PR DESCRIPTION
If display output is dual (e.g. HDMI and LCD), on monitor1 the default XFCE logo is placed. The patch replace it with armbian wallpaper. Also some styling is fixed.

Tested on A64-OLinuXino.