### PR TITLE
Docker: do not rebuild docker image everytime.

### DIFF
--- a/config-docker.conf
+++ b/config-docker.conf
@@ -14,14 +14,18 @@ mkdir -p $SRC/{output,userpatches}
 grep -q '^docker:' /etc/group && chgrp --quiet docker $SRC/{output,userpatches}
 chmod --quiet g+w,g+s $SRC/{output,userpatches}
 
-# build a new container based on provided Dockerfile
-display_alert "Building a Docker container"
-if ! docker build -t armbian . ; then
-  STATUS=$?
-  # Adding a newline, so the alert won't be shown in the same line as the error
-  echo 
-  display_alert "Docker container build exited with code: " "$STATUS" "err"
-  exit 1
+if grep -q armbian <(docker images); then
+  display_alert "Using existed a armbian Docker container"
+else
+  # build a new container based on provided Dockerfile
+  display_alert "Building a Docker container"
+  if ! docker build -t armbian . ; then
+    STATUS=$?
+    # Adding a newline, so the alert won't be shown in the same line as the error
+    echo 
+    display_alert "Docker container build exited with code: " "$STATUS" "err"
+    exit 1
+  fi
 fi
 
 DOCKER_FLAGS=()


### PR DESCRIPTION
when start build in docker, it will rebuild docker image everytime.
it will waste of time and disk space.

check if there is a armbian docker image before build docker image.

Signed-off-by: Zhang Ning <832666+zhangn1985@users.noreply.github.com>
