### PR TITLE
Docker: do not copy source code to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,4 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade && 
 RUN locale-gen en_US.UTF-8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8' TERM=screen
 WORKDIR /root/armbian
-COPY . /root/armbian
 ENTRYPOINT [ "/bin/bash", "/root/armbian/compile.sh" ]

--- a/config-docker.conf
+++ b/config-docker.conf
@@ -71,11 +71,11 @@ else
   display_alert "and will be able to create only Kernel and u-boot packages (KERNEL_ONLY=yes)" "" "wrn"
 fi
 
+# map source to Docker Working dir.
+DOCKER_FLAGS+=(-v=$SRC/:/root/armbian/)
+
 # mount 2 named volumes - for cacheable data and compiler cache
 DOCKER_FLAGS+=(-v=armbian-cache:/root/armbian/cache -v=armbian-ccache:/root/.ccache)
-
-# mount 2 local directories - output and userpatches
-DOCKER_FLAGS+=(-v=$SRC/output:/root/armbian/output -v=$SRC/userpatches:/root/armbian/userpatches)
 
 # pass other command line arguments like KERNEL_ONLY=yes, KERNEL_CONFIGURE=yes, etc.
 # pass "docker-guest" as an additional config name that will be sourced in the container if exists


### PR DESCRIPTION
map it to container, so userpatch/output no need map from container

Signed-off-by: Zhang Ning <832666+zhangn1985@users.noreply.github.com>

@igorpecovnik due to my last patch has merged, and then it will not build armbian docker image every time. due  to source code is copy to docker image, when run in docker, docker will not get updated source code. so need to map it to container.

I should send them in one PR, sorry.