### PR TITLE
Odroid XU4 kernel, enable CONFIG_USB_HID as module, enable CONFIG_USB_HIDDEV

### DIFF
--- a/config/kernel/linux-odroidxu4-default.config
+++ b/config/kernel/linux-odroidxu4-default.config
@@ -4109,9 +4109,9 @@ CONFIG_HID_WIIMOTE=m
 #
 # USB HID support
 #
-CONFIG_USB_HID=y
+CONFIG_USB_HID=m
 # CONFIG_HID_PID is not set
-# CONFIG_USB_HIDDEV is not set
+CONFIG_USB_HIDDEV=y
 
 #
 # I2C HID support

--- a/config/kernel/linux-odroidxu4-dev.config
+++ b/config/kernel/linux-odroidxu4-dev.config
@@ -4191,9 +4191,9 @@ CONFIG_HID_WIIMOTE=m
 #
 # USB HID support
 #
-CONFIG_USB_HID=y
+CONFIG_USB_HID=m
 # CONFIG_HID_PID is not set
-# CONFIG_USB_HIDDEV is not set
+CONFIG_USB_HIDDEV=y
 
 #
 # I2C HID support

--- a/config/kernel/linux-odroidxu4-next.config
+++ b/config/kernel/linux-odroidxu4-next.config
@@ -4108,9 +4108,9 @@ CONFIG_HID_WIIMOTE=m
 #
 # USB HID support
 #
-CONFIG_USB_HID=y
+CONFIG_USB_HID=m
 # CONFIG_HID_PID is not set
-# CONFIG_USB_HIDDEV is not set
+CONFIG_USB_HIDDEV=y
 
 #
 # I2C HID support


### PR DESCRIPTION
for Odroid XU4 enables CONFIG_USB_HID as a module instead of being compiled in. Enables CONFIG_USB_HIDDEV 
