### PR TITLE
Adds example fex file for enabling tv out on the OrangePi Zero Plus2 …

### DIFF
--- a/config/fex/orangepizeroplus2-h3-tvout.fex
+++ b/config/fex/orangepizeroplus2-h3-tvout.fex
@@ -1,0 +1,816 @@
+[product]
+version = "100"
+machine = "Xunlong Orange Pi Zero Plus 2 H3"
+
+[platform]
+debug_mode = 1
+eraseflag = 1
+next_work = 3
+secure_without_OS = 1
+
+[target]
+boot_clock = 1008
+storage_type = -1
+burn_key = 1
+
+[key_detect_en]
+keyen_flag = 0
+
+[fel_key]
+fel_key_max = 7
+fel_key_min = 2
+
+[card_boot]
+logical_start = 40960
+sprite_work_delay = 500
+sprite_err_delay = 200
+sprite_gpio0 = port:PA17<1><default><default><default>
+next_work = 3
+
+[box_start_os]
+used = 1
+start_type = 1
+irkey_used = 1
+pmukey_used = 0
+pmukey_num = 0
+led_power = 0
+led_state = 0
+
+[boot_init_gpio]
+used = 1
+gpio0 = port:PL10<1><default><default><1>
+gpio1 = port:PA17<1><default><default><0>
+
+[recovery_para]
+used = 1
+mode = 2
+recovery_key = port:PL04<0><default><default><default>
+
+[pm_para]
+standby_mode = 1
+
+[card0_boot_para]
+card_ctrl = 0
+card_high_speed = 1
+card_line = 4
+sdc_d1 = port:PF00<2><1><2><default>
+sdc_d0 = port:PF01<2><1><2><default>
+sdc_clk = port:PF02<2><1><2><default>
+sdc_cmd = port:PF03<2><1><2><default>
+sdc_d3 = port:PF04<2><1><2><default>
+sdc_d2 = port:PF05<2><1><2><default>
+
+[card2_boot_para]
+card_ctrl = 2
+card_high_speed = 1
+card_line = 8
+sdc_cmd = port:PC06<3><1><2><default>
+sdc_clk = port:PC05<3><1><2><default>
+sdc_d0 = port:PC08<3><1><2><default>
+sdc_d1 = port:PC09<3><1><2><default>
+sdc_d2 = port:PC10<3><1><2><default>
+sdc_d3 = port:PC11<3><1><2><default>
+sdc_d4 = port:PC12<3><1><2><default>
+sdc_d5 = port:PC13<3><1><2><default>
+sdc_d6 = port:PC14<3><1><2><default>
+sdc_d7 = port:PC15<3><1><2><default>
+sdc_2xmode = 1
+sdc_ddrmode = 1
+
+[twi_para]
+twi_port = 0
+twi_scl = port:PA11<2><default><default><default>
+twi_sda = port:PA12<2><default><default><default>
+
+[uart_para]
+uart_debug_port = 0
+uart_debug_tx = port:PA04<2><1><default><default>
+uart_debug_rx = port:PA05<2><1><default><default>
+
+[force_uart_para]
+force_uart_port = 0
+force_uart_tx =
+force_uart_rx =
+
+[jtag_para]
+jtag_enable = 0
+jtag_ms = port:PA00<3><default><default><default>
+jtag_ck = port:PA01<3><default><default><default>
+jtag_do = port:PA02<3><default><default><default>
+jtag_di = port:PA03<3><default><default><default>
+
+[clock]
+pll_video = 297
+pll_ve = 402
+pll_periph0 = 600
+pll_gpu = 576
+pll_periph1 = 600
+pll_de = 864
+
+[dram_para]
+dram_clk = 408
+dram_type = 3
+dram_zq = 0x3b3bf9
+dram_odt_en = 1
+dram_para1 = 284430580
+dram_para2 = 0
+dram_mr0 = 6208
+dram_mr1 = 64
+dram_mr2 = 24
+dram_mr3 = 2
+dram_tpr0 = 0x48a192
+dram_tpr1 = 0x1b1a94b
+dram_tpr2 = 0x61043
+dram_tpr3 = 0xb4787896
+dram_tpr4 = 0x0
+dram_tpr5 = 0x0
+dram_tpr6 = 0x64
+dram_tpr7 = 0x1e08a1e0
+dram_tpr8 = 0x0
+dram_tpr9 = 0x0
+dram_tpr10 = 0x2535
+dram_tpr11 = 0x23330000
+dram_tpr12 = 0x8897
+dram_tpr13 = 0x4002910
+
+[wakeup_src_para]
+cpu_en = 0
+cpu_freq = 48
+pll_ratio = 273
+dram_selfresh_en = 1
+dram_freq = 36
+wakeup_src0 =
+wakeup_src_wl = port:PG10<4><default><default><0>
+wakeup_src_bt = port:PL03<6><default><default><0>
+
+[twi0]
+twi_used = 1
+twi_scl = port:PA11<2><default><default><default>
+twi_sda = port:PA12<2><default><default><default>
+
+[twi1]
+twi_used = 1
+twi_scl = port:PA18<3><default><default><default>
+twi_sda = port:PA19<3><default><default><default>
+
+[twi2]
+twi_used = 0
+twi_scl = port:PE12<3><default><default><default>
+twi_sda = port:PE13<3><default><default><default>
+
+[uart0]
+uart_used = 1
+uart_port = 0
+uart_type = 2
+uart_tx = port:PA04<2><1><default><default>
+uart_rx = port:PA05<2><1><default><default>
+
+[uart1]
+uart_used = 1
+uart_port = 1
+uart_type = 4
+uart_tx = port:PG06<2><1><default><default>
+uart_rx = port:PG07<2><1><default><default>
+uart1_rts = port:PG08<2><1><default><default>
+uart1_cts = port:PG09<2><1><default><default>
+
+[uart2]
+uart_used = 1
+uart_port = 2
+uart_type = 4
+uart_tx = port:PA00<2><1><default><default>
+uart_rx = port:PA01<2><1><default><default>
+uart2_rts = port:PA02<2><1><default><default>
+uart2_cts = port:PA03<2><1><default><default>
+
+[uart3]
+uart_used = 0
+uart_port = 3
+uart_type = 2
+uart_tx = port:PA13<3><1><default><default>
+uart_rx = port:PA14<3><1><default><default>
+
+[spi0]
+spi_used = 1
+spi_cs_bitmap = 1
+spi_mosi = port:PC00<3><default><default><default>
+spi_miso = port:PC01<3><default><default><default>
+spi_sclk = port:PC02<3><default><default><default>
+spi_cs0 = port:PC03<3><1><default><default>
+
+[spi1]
+spi_used = 1
+spi_cs_bitmap = 1
+spi_cs0 = port:PA13<2><1><default><default>
+spi_sclk = port:PA14<2><default><default><default>
+spi_mosi = port:PA15<2><default><default><default>
+spi_miso = port:PA16<2><default><default><default>
+
+[spi_devices]
+spi_dev_num = 2
+
+[spi_board0]
+modalias = "spidev"
+max_speed_hz = 33000000
+bus_num = 0
+chip_select = 0
+mode = 0
+full_duplex = 1
+manual_cs = 0
+
+[spi_board1]
+modalias = "spidev"
+max_speed_hz = 33000000
+bus_num = 1
+chip_select = 0
+mode = 0
+full_duplex = 1
+manual_cs = 0
+
+[gpio_para]
+gpio_used = 0
+gpio_num = 0
+
+[leds_para]
+leds_used = 1
+green_led = port:PL10<1><default><default><1>
+green_led_active_low = 0
+red_led = port:PA17<1><default><default><0>
+red_led_active_low = 0
+
+[ths_para]
+ths_used = 1
+ths_trip1_count = 8
+ths_trip1_0 = 65
+ths_trip1_1 = 70
+ths_trip1_2 = 75
+ths_trip1_3 = 80
+ths_trip1_4 = 85
+ths_trip1_5 = 90
+ths_trip1_6 = 95
+ths_trip1_7 = 100
+ths_trip1_0_min = 0
+ths_trip1_0_max = 1
+ths_trip1_1_min = 1
+ths_trip1_1_max = 2
+ths_trip1_2_min = 2
+ths_trip1_2_max = 3
+ths_trip1_3_min = 3
+ths_trip1_3_max = 4
+ths_trip1_4_min = 4
+ths_trip1_4_max = 5
+ths_trip1_5_min = 5
+ths_trip1_5_max = 6
+ths_trip1_6_min = 6
+ths_trip1_6_max = 7
+ths_trip2_count = 1
+ths_trip2_0 = 105
+
+[cooler_table]
+cooler_count = 8
+cooler0 = "1200000 4 4294967295 0"
+cooler1 = "912000 4 4294967295 0"
+cooler2 = "768000 4 4294967295 0"
+cooler3 = "648000 4 4294967295 0"
+cooler4 = "480000 4 4294967295 0"
+cooler5 = "480000 3 4294967295 0"
+cooler6 = "240000 2 4294967295 0"
+cooler7 = "240000 1 4294967295 0"
+
+[nand0_para]
+nand_support_2ch = 0
+nand0_used = 0
+nand0_we = port:PC00<2><default><default><default>
+nand0_ale = port:PC01<2><default><default><default>
+nand0_cle = port:PC02<2><default><default><default>
+nand0_ce1 = port:PC03<2><default><default><default>
+nand0_ce0 = port:PC04<2><default><default><default>
+nand0_nre = port:PC05<2><default><default><default>
+nand0_rb0 = port:PC06<2><default><default><default>
+nand0_rb1 = port:PC07<2><default><default><default>
+nand0_d0 = port:PC08<2><default><default><default>
+nand0_d1 = port:PC09<2><default><default><default>
+nand0_d2 = port:PC10<2><default><default><default>
+nand0_d3 = port:PC11<2><default><default><default>
+nand0_d4 = port:PC12<2><default><default><default>
+nand0_d5 = port:PC13<2><default><default><default>
+nand0_d6 = port:PC14<2><default><default><default>
+nand0_d7 = port:PC15<2><default><default><default>
+nand0_ndqs = port:PC16<2><default><default><default>
+
+[boot_disp]
+advert_disp = 0
+auto_hpd = 1
+output_type = 4
+hdmi_channel = 0
+hdmi_mode = 4
+cvbs_channel = 1
+cvbs_mode = 11
+output_full = 1
+hdmi_mode_check = 1
+
+[disp_init]
+disp_init_enable = 1
+disp_mode = 1
+screen0_output_type = 3
+screen0_output_mode = 5
+screen1_output_type = 2
+screen1_output_mode = 14
+fb0_format = 0
+fb0_width = 0
+fb0_height = 0
+fb1_format = 0
+fb1_width = 0
+fb1_height = 0
+
+[hdmi_para]
+hdmi_used = 0
+hdmi_power = "vcc-hdmi-18"
+
+[tv_para]
+tv_used = 1
+tv_dac_used = 1
+tv_dac_src0 = 0
+
+[pwm0_para]
+pwm_used = 0
+pwm_positive = port:PA05<3><0><default><default>
+
+[pwm1_para]
+pwm_used = 0
+pwm_positive = port:PA06<3><0><default><default>
+
+[gmac0]
+gmac_used = 0
+gmac_power1 =
+
+[csi0]
+vip_used = 1
+vip_mode = 0
+vip_dev_qty = 1
+vip_define_sensor_list = 0
+vip_csi_pck = port:PE00<2><default><default><default>
+vip_csi_mck = port:PE01<2><default><default><default>
+vip_csi_hsync = port:PE02<2><default><default><default>
+vip_csi_vsync = port:PE03<2><default><default><default>
+vip_csi_d0 = port:PE04<2><default><default><default>
+vip_csi_d1 = port:PE05<2><default><default><default>
+vip_csi_d2 = port:PE06<2><default><default><default>
+vip_csi_d3 = port:PE07<2><default><default><default>
+vip_csi_d4 = port:PE08<2><default><default><default>
+vip_csi_d5 = port:PE09<2><default><default><default>
+vip_csi_d6 = port:PE10<2><default><default><default>
+vip_csi_d7 = port:PE11<2><default><default><default>
+vip_csi_sck = port:PE12<2><default><default><default>
+vip_csi_sda = port:PE13<2><default><default><default>
+vip_dev0_mname = "gc2035"
+vip_dev0_pos = "front"
+vip_dev0_lane = 1
+vip_dev0_twi_id = 2
+vip_dev0_twi_addr = 120
+vip_dev0_isp_used = 0
+vip_dev0_fmt = 0
+vip_dev0_stby_mode = 0
+vip_dev0_vflip = 1
+vip_dev0_hflip = 1
+vip_dev0_iovdd = ""
+vip_dev0_iovdd_vol = 2800000
+vip_dev0_avdd = ""
+vip_dev0_avdd_vol = 2800000
+vip_dev0_dvdd = ""
+vip_dev0_dvdd_vol = 1800000
+vip_dev0_afvdd = ""
+vip_dev0_afvdd_vol = 2800000
+vip_dev0_power_en = port:PD14<1><default><default><default>
+vip_dev0_reset = port:PE14<1><default><default><default>
+vip_dev0_pwdn = port:PE15<1><default><default><default>
+vip_dev0_flash_en =
+vip_dev0_flash_mode =
+vip_dev0_af_pwdn =
+vip_dev0_act_used = 0
+vip_dev0_act_name = "ad5820_act"
+vip_dev0_act_slave = 24
+vip_dev1_mname = ""
+vip_dev1_pos = "front"
+vip_dev1_lane = 1
+vip_dev1_twi_id = 0
+vip_dev1_twi_addr =
+vip_dev1_isp_used = 0
+vip_dev1_fmt = 1
+vip_dev1_stby_mode = 0
+vip_dev1_vflip = 0
+vip_dev1_hflip = 0
+vip_dev1_iovdd = ""
+vip_dev1_iovdd_vol = 2800000
+vip_dev1_avdd = ""
+vip_dev1_avdd_vol = 2800000
+vip_dev1_dvdd = ""
+vip_dev1_dvdd_vol = 1500000
+vip_dev1_afvdd = ""
+vip_dev1_afvdd_vol = 2800000
+vip_dev1_power_en =
+vip_dev1_reset =
+vip_dev1_pwdn =
+vip_dev1_flash_en =
+vip_dev1_flash_mode =
+vip_dev1_af_pwdn =
+
+[tvout_para]
+tvout_used = 1
+tvout_channel_num = 1
+tv_en =
+
+[tvin_para]
+tvin_used = 0
+tvin_channel_num =
+
+[di_para]
+di_used = 1
+
+[mmc0_para]
+sdc_used = 1
+sdc_detmode = 3
+sdc_buswidth = 4
+sdc_clk = port:PF02<2><1><2><default>
+sdc_cmd = port:PF03<2><1><2><default>
+sdc_d0 = port:PF01<2><1><2><default>
+sdc_d1 = port:PF00<2><1><2><default>
+sdc_d2 = port:PF05<2><1><2><default>
+sdc_d3 = port:PF04<2><1><2><default>
+sdc_det = port:PF06<0><1><2><default>
+sdc_use_wp = 0
+sdc_wp =
+sdc_isio = 0
+sdc_regulator = "none"
+sdc_power_supply = "none"
+
+[mmc1_para]
+sdc_used = 1
+sdc_detmode = 4
+sdc_buswidth = 4
+sdc_clk = port:PG00<2><1><2><default>
+sdc_cmd = port:PG01<2><1><2><default>
+sdc_d0 = port:PG02<2><1><2><default>
+sdc_d1 = port:PG03<2><1><2><default>
+sdc_d2 = port:PG04<2><1><2><default>
+sdc_d3 = port:PG05<2><1><2><default>
+sdc_det =
+sdc_use_wp = 0
+sdc_wp =
+sdc_isio = 1
+sdc_regulator = "none"
+sdc_power_supply = "none"
+sdc_2xmode = 1
+sdc_ddrmode = 1
+
+[mmc2_para]
+sdc_used = 1
+sdc_detmode = 3
+sdc_buswidth = 8
+sdc_clk = port:PC05<3><1><2><default>
+sdc_cmd = port:PC06<3><1><2><default>
+sdc_d0 = port:PC08<3><1><2><default>
+sdc_d1 = port:PC09<3><1><2><default>
+sdc_d2 = port:PC10<3><1><2><default>
+sdc_d3 = port:PC11<3><1><2><default>
+sdc_d4 = port:PC12<3><1><2><default>
+sdc_d5 = port:PC13<3><1><2><default>
+sdc_d6 = port:PC14<3><1><2><default>
+sdc_d7 = port:PC15<3><1><2><default>
+emmc_rst = port:PC16<3><1><2><default>
+sdc_det =
+sdc_use_wp = 0
+sdc_wp =
+sdc_isio = 0
+sdc_regulator = "none"
+sdc_power_supply = "none"
+sdc_2xmode = 1
+sdc_ddrmode = 1
+
+[smc_para]
+smc_used =
+smc_rst = port:PA09<2><default><default><default>
+smc_vppen = port:PA20<3><default><default><default>
+smc_vppp = port:PA21<3><default><default><default>
+smc_det = port:PA10<2><default><default><default>
+smc_vccen = port:PA06<2><default><default><default>
+smc_sck = port:PA07<2><default><default><default>
+smc_sda = port:PA08<2><default><default><default>
+
+[usbc0]
+usb_used = 1
+usb_port_type = 2
+usb_detect_type = 0
+usb_id_gpio = port:PG12<0><1><default><default>
+usb_det_vbus_gpio = port:PG12<0><1><default><default>
+usb_drv_vbus_gpio = port:PL02<1><0><default><0>
+usb_host_init_state = 1
+usb_restrict_gpio =
+usb_restric_flag = 0
+usb_restric_voltage = 3550000
+usb_restric_capacity = 5
+usb_regulator_io = "nocare"
+usb_regulator_vol = 0
+usb_not_suspend = 0
+
+[usbc1]
+usb_used = 0
+usb_drv_vbus_gpio =
+usb_restrict_gpio =
+usb_host_init_state = 1
+usb_restric_flag = 0
+usb_regulator_io = "nocare"
+usb_regulator_vol = 0
+usb_not_suspend = 0
+
+[usbc2]
+usb_used = 1
+usb_drv_vbus_gpio =
+usb_restrict_gpio =
+usb_host_init_state = 1
+usb_restric_flag = 0
+usb_regulator_io = "nocare"
+usb_regulator_vol = 0
+usb_not_suspend = 0
+
+[usbc3]
+usb_used = 1
+usb_drv_vbus_gpio =
+usb_restrict_gpio =
+usb_host_init_state = 1
+usb_restric_flag = 0
+usb_regulator_io = "nocare"
+usb_regulator_vol = 0
+usb_not_suspend = 0
+
+[usb_feature]
+vendor_id = 6353
+mass_storage_id = 1
+adb_id = 2
+manufacturer_name = "USB Developer"
+product_name = "Android"
+serial_number = "20080411"
+
+[msc_feature]
+vendor_name = "USB 2.0"
+product_name = "USB Flash Driver"
+release = 100
+luns = 3
+
+[serial_feature]
+serial_unique = 0
+
+[module_para]
+module_power0 = port:PA20<1><default><default><0>
+module_power0_vol = 1
+module_power1 =
+module_power1_vol =
+module_power2 =
+module_power2_vol =
+module_power3 =
+module_power3_vol =
+module_select_pin0 =
+module_select_pin1 =
+chip_en =
+lpo_use_apclk = "losc_out"
+
+[wifi_para]
+wifi_used = 1
+wifi_sdc_id = 1
+wifi_usbc_id =
+wifi_usbc_type =
+wl_reg_on = port:PA09<1><default><default><0>
+wl_host_wake = port:PL07<0><default><default><0>
+wl_host_wake_invert = 0
+
+[bt_para]
+bt_used = 1
+bt_uart_id = 1
+bt_uart_baud = 115200
+bt_rst_n = port:PA10<1><default><default><0>
+bt_wake = port:PA20<1><default><default><1>
+bt_host_wake = port:PL02<6><default><default><0>
+bt_host_wake_invert = 0
+
+[pcm0]
+daudio_used = 0
+daudio_master = 4
+daudio_select = 1
+audio_format = 1
+signal_inversion = 1
+mclk_fs = 128
+sample_resolution = 16
+slot_width_select = 32
+pcm_lrck_period = 32
+pcm_lrckr_period = 1
+msb_lsb_first = 0
+sign_extend = 0
+slot_index = 0
+slot_width = 32
+frame_width = 0
+tx_data_mode = 0
+rx_data_mode = 0
+i2s_mclk = port:PA18<2><1><default><default>
+i2s_bclk = port:PA19<2><1><default><default>
+i2s_dout0 = port:PA20<2><1><default><default>
+i2s_din = port:PA21<2><1><default><default>
+
+[pcm1]
+daudio_used = 0
+daudio_master = 4
+daudio_select = 1
+audio_format = 1
+signal_inversion = 1
+mclk_fs = 128
+sample_resolution = 16
+slot_width_select = 32
+pcm_lrck_period = 32
+pcm_lrckr_period = 1
+msb_lsb_first = 0
+sign_extend = 0
+slot_index = 0
+slot_width = 32
+frame_width = 0
+tx_data_mode = 0
+rx_data_mode = 0
+i2s_mclk = port:PG10<2><1><default><default>
+i2s_bclk = port:PG11<2><1><default><default>
+i2s_dout0 = port:PG12<2><1><default><default>
+i2s_din = port:PG13<2><1><default><default>
+
+[audio0]
+audio_used = 1
+lineout_vol = 31
+cap_vol = 5
+audio_hp_ldo = "none"
+adcagc_used = 0
+adcdrc_used = 0
+dacdrc_used = 0
+adchpf_used = 0
+dachpf_used = 0
+
+[spdif0]
+spdif_used = 0
+spdif_dout = port:PA17<2><1><default><default>
+
+[audiohub]
+hub_used = 0
+codec_used = 1
+spdif_used = 1
+hdmi_used = 0
+
+[s_cir0]
+ir_used = 1
+ir_rx = port:PL11<2><1><default><default>
+ir_power_key_code0 = 0
+ir_addr_code0 = 50235
+ir_power_key_code1 = 8
+ir_addr_code1 = 50235
+ir_power_key_code2 = 26
+ir_addr_code2 = 50235
+ir_power_key_code3 = 10
+ir_addr_code3 = 50235
+ir_power_key_code4 = 13
+ir_addr_code4 = 50235
+ir_power_key_code5 = 16
+ir_addr_code5 = 50235
+ir_power_key_code6 = 17
+ir_addr_code6 = 50235
+ir_power_key_code7 = 18
+ir_addr_code7 = 50235
+ir_power_key_code8 = 21
+ir_addr_code8 = 50235
+ir_power_key_code9 = 14
+ir_addr_code9 = 50235
+ir_power_key_code10 = 22
+ir_addr_code10 = 50235
+ir_power_key_code11 = 12
+ir_addr_code11 = 50235
+ir_power_key_code12 = 81
+ir_addr_code12 = 50235
+ir_power_key_code13 = 20
+ir_addr_code13 = 50235
+ir_power_key_code14 = 80
+ir_addr_code15 = 50235
+
+[cir]
+ir_used = 0
+ir_tx = port:PH07<2><default><default><default>
+
+[ls_para]
+ls_used = 0
+
+[dvfs_table]
+pmuic_type = 1
+pmu_gpio0 = port:PL06<1><1><2><1>
+pmu_level0 = 11300
+pmu_level1 = 1100
+max_freq = 1200000000
+min_freq = 240000000
+LV_count = 6
+LV1_freq = 1200000000
+LV1_volt = 1300
+LV2_freq = 1008000000
+LV2_volt = 1300
+LV3_freq = 912000000
+LV3_volt = 1100
+LV4_freq = 648000000
+LV4_volt = 1100
+LV5_freq = 480000000
+LV5_volt = 1100
+LV6_freq = 240000000
+LV6_volt = 1100
+
+[gpu_dvfs_table]
+G_LV_count = 3
+G_LV0_freq = 312000000
+G_LV0_volt = 1200000
+G_LV1_freq = 384000000
+G_LV1_volt = 1200000
+G_LV2_freq = 456000000
+G_LV2_volt = 1200000
+
+[board_vendor]
+vid_used = 0
+vid_count = 6
+vid_bit_0 = port:PD16<0><1><default><default>
+vid_bit_1 = port:PD15<0><1><default><default>
+vid_bit_2 = port:PD14<0><1><default><default>
+vid_bit_3 = port:PD13<0><1><default><default>
+vid_bit_4 = port:PD12<0><1><default><default>
+vid_bit_5 = port:PD17<0><1><default><default>
+
+[Vdevice]
+Vdevice_used = 0
+Vdevice_0 = port:PH10<5><1><2><default>
+Vdevice_1 = port:PH11<5><1><2><default>
+
+[s_uart0]
+s_uart_used = 0
+s_uart_tx = port:PL02<2><default><default><default>
+s_uart_rx = port:PL03<2><default><default><default>
+
+[s_rsb0]
+s_rsb_used = 1
+s_rsb_sck = port:PL00<2><1><2><default>
+s_rsb_sda = port:PL01<2><1><2><default>
+
+[s_jtag0]
+s_jtag_used = 0
+s_jtag_tms = port:PL04<2><1><2><default>
+s_jtag_tck = port:PL05<2><1><2><default>
+s_jtag_tdo = port:PL06<2><1><2><default>
+s_jtag_tdi = port:PL07<2><1><2><default>
+
+[s_powchk]
+s_powchk_used = -2147483648
+s_power_reg = 0
+s_system_power = 50
+
+[ts0]
+tsc_used = 0
+tsc_clk = port:PE00<3><default><default><default>
+tsc_err = port:PE01<3><default><default><default>
+tsc_sync = port:PE02<3><default><default><default>
+tsc_dvld = port:PE03<3><default><default><default>
+tsc_d0 = port:PE04<3><default><default><default>
+tsc_d1 = port:PE05<3><default><default><default>
+tsc_d2 = port:PE06<3><default><default><default>
+tsc_d3 = port:PE07<3><default><default><default>
+tsc_d4 = port:PE08<3><default><default><default>
+tsc_d5 = port:PE09<3><default><default><default>
+tsc_d6 = port:PE10<3><default><default><default>
+tsc_d7 = port:PE11<3><default><default><default>
+
+[gpio_power_key]
+key_used = 0
+key_io = port:PL03<6><default><default><0>
+
+[key_para]
+key_used = 0
+key_cnt = 5
+key1_vol = 222
+key2_vol = 444
+key3_vol = 666
+key4_vol = 857
+key5_vol = 2000
+
+[d7s_para]
+d7s_used = 0
+din_gpio = port:PD00<1><default><default><1>
+clk_gpio = port:PD01<1><default><default><1>
+stb_gpio = port:PD02<1><default><default><1>
+
+[mali_para]
+mali_used = 1
+mali_clkdiv = 1
+mali_extreme_freq = 600
+mali_extreme_vol = 1400
+
+[w1_para]
+w1_used = 0
+gpio = 10
+
+[corekeeper]
+corekeeper_enabled = 1
+


### PR DESCRIPTION
…H3 using the legacy kernel. See this thread for details: https://forum.armbian.com/topic/10216-composite-video-framebuffer-on-opi-02
