### PR TITLE
added missing mail logs, and firewalld log

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-truncate-logs
+++ b/packages/bsp/common/usr/lib/armbian/armbian-truncate-logs
@@ -17,15 +17,15 @@ treshold=75 # %
 
 logusage=$(df /var/log/ --output=pcent | tail -1 |cut -d "%" -f 1)
 if [ $logusage -ge $treshold ]; then
-		# write to SD
-                /usr/lib/armbian/armbian-ramlog write >/dev/null 2>&1
-                # rotate logs on "disk"
-                chown root.root -R /var/log.hdd
-                /usr/sbin/logrotate --force /etc/logrotate.conf
-		# truncate
-	        /usr/bin/find /var/log -name '*.log' -or -name '*.xz' -or -name 'lastlog' -or -name 'messages' -or -name 'debug' -or -name 'syslog' | xargs truncate --size 0
-		/usr/bin/find /var/log -name 'btmp' -or -name 'wtmp' -or -name 'faillog' | xargs truncate --size 0
-		# remove
-		/usr/bin/find /var/log -name '*.[0-9]' -or -name '*.gz' | xargs rm >/dev/null 2>&1
-
+    # write to SD
+    /usr/lib/armbian/armbian-ramlog write >/dev/null 2>&1
+    # rotate logs on "disk"
+    chown root.root -R /var/log.hdd
+    /usr/sbin/logrotate --force /etc/logrotate.conf
+    # truncate
+    /usr/bin/find /var/log -name '*.log' -or -name '*.xz' -or -name 'lastlog' -or -name 'messages' -or -name 'debug' -or -name 'syslog' | xargs truncate --size 0
+    /usr/bin/find /var/log -name 'btmp' -or -name 'wtmp' -or -name 'faillog' -or -name 'firewalld' | xargs truncate --size 0
+    /usr/bin/find /var/log -name 'mail.err' -or -name 'mail.info' -or -name 'mail.warning' | xargs truncate --size 0
+    # remove
+    /usr/bin/find /var/log -name '*.[0-9]' -or -name '*.gz' | xargs rm >/dev/null 2>&1
 fi


### PR DESCRIPTION
my armbian system recently ran out of log space due to a large mail.info log. The mail.info, mail.err and mail.warning logs are specified in the default /etc/rsyslog.conf file, therefore IMHO should be handled in the armbian-truncate-logs script.

I also added the firewalld log which is used / created if you enable the firewalld service and specify logging, and I found no configurable option to rename it.

I toyed with the idea of adding an ADDITIONAL_LOGS variable to the /etc/default/armbian-ramlog file for firewalld, and would not argue if that were the preferred solution.

I additionally changed the mixture of tabs/spaces to all space. 
