### PR TITLE
Add missing closing backslash

### DIFF
--- a/lib/desktop.sh
+++ b/lib/desktop.sh
@@ -87,7 +87,7 @@ create_desktop_package ()
 
 	# using different icon pack. Workaround due to this bug https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=867779
 	if [[ ${RELEASE} == bionic || ${RELEASE} == stretch || ${RELEASE} == buster || ${RELEASE} == disco ]]; then
-	sed -i 's/<property name="IconThemeName" type="string" value=".*$/<property name="IconThemeName" type="string" value="Humanity-Dark">/g' \
+	sed -i 's/<property name="IconThemeName" type="string" value=".*$/<property name="IconThemeName" type="string" value="Humanity-Dark"\/>/g' \
 	$destination/etc/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml
 	fi
 


### PR DESCRIPTION

After modification of xsettings.xml, the IconThemeName property is missing closing backslash. This throws an error.

`Error parsing xfconf config file "/home/olimex/.config/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml": Error on line 37 char 11: Element 'channel' was closed, but the currently open element is 'property'`