### PR TITLE
[ sunxi ] Enable additional iio sensors

### DIFF
--- a/config/kernel/linux-sunxi-dev.config
+++ b/config/kernel/linux-sunxi-dev.config
@@ -5673,7 +5673,7 @@ CONFIG_HID_SENSOR_HUMIDITY=m
 # CONFIG_HTS221 is not set
 # CONFIG_HTU21 is not set
 # CONFIG_SI7005 is not set
-# CONFIG_SI7020 is not set
+CONFIG_SI7020=m
 
 #
 # Inertial measurement units
@@ -5791,7 +5791,9 @@ CONFIG_MCP41010=m
 # Pressure sensors
 #
 # CONFIG_ABP060MG is not set
-# CONFIG_BMP280 is not set
+CONFIG_BMP280=m
+CONFIG_BMP280_I2C=m
+CONFIG_BMP280_SPI=m
 # CONFIG_HID_SENSOR_PRESS is not set
 # CONFIG_HP03 is not set
 # CONFIG_MPL115_I2C is not set

--- a/config/kernel/linux-sunxi-next.config
+++ b/config/kernel/linux-sunxi-next.config
@@ -5599,7 +5599,7 @@ CONFIG_HID_SENSOR_HUMIDITY=m
 # CONFIG_HTS221 is not set
 # CONFIG_HTU21 is not set
 # CONFIG_SI7005 is not set
-# CONFIG_SI7020 is not set
+CONFIG_SI7020=m
 
 #
 # Inertial measurement units
@@ -5711,7 +5711,9 @@ CONFIG_MAX5481=m
 # Pressure sensors
 #
 # CONFIG_ABP060MG is not set
-# CONFIG_BMP280 is not set
++CONFIG_BMP280=m
++CONFIG_BMP280_I2C=m
++CONFIG_BMP280_SPI=m
 # CONFIG_HID_SENSOR_PRESS is not set
 # CONFIG_HP03 is not set
 # CONFIG_MPL115_I2C is not set


### PR DESCRIPTION
This patch enables the `si7020` and `bmp280` i2c iio sensors on `sunxi-dev` and `sunxi-next`. I want to start using Armbian on my boards instead of rolling my own kernels, and I need these to modules.

I've created this patch using Kconfig menu, and tested that the build does not break, which it doesn't for me.