### PR TITLE
Enable the i2c-tiny-usb and bmp280 kernel modules

### DIFF
--- a/config/kernel/linux-odroidxu4-default.config
+++ b/config/kernel/linux-odroidxu4-default.config
@@ -2533,7 +2533,7 @@ CONFIG_I2C_S3C2410=y
 # CONFIG_I2C_PARPORT_LIGHT is not set
 # CONFIG_I2C_ROBOTFUZZ_OSIF is not set
 # CONFIG_I2C_TAOS_EVM is not set
-# CONFIG_I2C_TINY_USB is not set
+CONFIG_I2C_TINY_USB=m
 
 #
 # Other I2C/SMBus bus drivers
@@ -5252,7 +5252,9 @@ CONFIG_AK8975=y
 # Pressure sensors
 #
 # CONFIG_ABP060MG is not set
-# CONFIG_BMP280 is not set
+CONFIG_BMP280=m
+CONFIG_BMP280_I2C=m
+CONFIG_BMP280_SPI=m
 # CONFIG_HP03 is not set
 # CONFIG_MPL115_I2C is not set
 # CONFIG_MPL115_SPI is not set

--- a/config/kernel/linux-odroidxu4-dev.config
+++ b/config/kernel/linux-odroidxu4-dev.config
@@ -2575,7 +2575,7 @@ CONFIG_I2C_S3C2410=y
 # CONFIG_I2C_PARPORT_LIGHT is not set
 # CONFIG_I2C_ROBOTFUZZ_OSIF is not set
 # CONFIG_I2C_TAOS_EVM is not set
-# CONFIG_I2C_TINY_USB is not set
+CONFIG_I2C_TINY_USB=m
 
 #
 # Other I2C/SMBus bus drivers
@@ -5351,7 +5351,9 @@ CONFIG_MCP41010=m
 # Pressure sensors
 #
 # CONFIG_ABP060MG is not set
-# CONFIG_BMP280 is not set
+CONFIG_BMP280=m
+CONFIG_BMP280_I2C=m
+CONFIG_BMP280_SPI=m
 # CONFIG_HP03 is not set
 # CONFIG_MPL115_I2C is not set
 # CONFIG_MPL115_SPI is not set

--- a/config/kernel/linux-odroidxu4-next.config
+++ b/config/kernel/linux-odroidxu4-next.config
@@ -2532,7 +2532,7 @@ CONFIG_I2C_S3C2410=y
 # CONFIG_I2C_PARPORT_LIGHT is not set
 # CONFIG_I2C_ROBOTFUZZ_OSIF is not set
 # CONFIG_I2C_TAOS_EVM is not set
-# CONFIG_I2C_TINY_USB is not set
+CONFIG_I2C_TINY_USB=m
 
 #
 # Other I2C/SMBus bus drivers
@@ -5245,7 +5245,9 @@ CONFIG_AK8975=y
 # Pressure sensors
 #
 # CONFIG_ABP060MG is not set
-# CONFIG_BMP280 is not set
+CONFIG_BMP280=m
+CONFIG_BMP280_I2C=m
+CONFIG_BMP280_SPI=m
 # CONFIG_HP03 is not set
 # CONFIG_MPL115_I2C is not set
 # CONFIG_MPL115_SPI is not set


### PR DESCRIPTION
CONFIG_I2C_TINY_USB=m enables to use I2C on boards without GPIO header like Odroid HC1/HC2 with USB to I2C converters like Digistump. 

The CONFIG_BMP280=m is useful for using the Bosch BMP280 sensors for temperature/humidity/pressure monitoring.