### PR TITLE
Fix block iosched for kernel 4.20

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
+++ b/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
@@ -20,18 +20,23 @@
 
 set_io_scheduler() {
 
+	# Convert kernel version to integer
+	KERNELID=$(uname -r |  awk -F'.' '{print ($1 * 100) + $2}')
 	for i in $( lsblk -idn -o NAME | grep -v zram ); do
 		read ROTATE </sys/block/$i/queue/rotational
 		case ${ROTATE} in
 			1) # mechanical drives
-				echo cfq >/sys/block/$i/queue/scheduler
-				echo -e "[\e[0;32m ok \x1B[0m] Setting cfg I/O scheduler for $i"
+				[[ $KERNELID -lt 420 ]] && sched=cfq || sched=bfq
 				;;
 			0) # flash based
-				echo noop >/sys/block/$i/queue/scheduler
-				echo -e "[\e[0;32m ok \x1B[0m] Setting noop I/O scheduler for $i"
+				[[ $KERNELID -lt 420 ]] && sched=noop || sched=none
+				;;
+			*)
+				continue
 				;;
 		esac
+		echo $sched >/sys/block/$i/queue/scheduler
+		echo -e "[\e[0;32m ok \x1B[0m] Setting $sched I/O scheduler for $i"
 	done
 
 } # set_io_scheduler


### PR DESCRIPTION
Legacy IO schedulers are removed in 4.20. Series can be found [here](https://patchwork.kernel.org/cover/10663021/).

In armbian-hardware-optimization check kernel version and write either noop/cfq or none/bfq.