### PR TITLE
Append rootdev to armbianEnv when transferring to eMMC

### DIFF
--- a/packages/bsp/common/usr/sbin/nand-sata-install
+++ b/packages/bsp/common/usr/sbin/nand-sata-install
@@ -272,6 +272,7 @@ create_armbian()
 		# new boot scripts
 		if [[ -f "${TempDir}"/bootfs/boot/armbianEnv.txt ]]; then
 			sed -e 's,rootdev=.*,rootdev='"$targetuuid"',g' -i "${TempDir}"/bootfs/boot/armbianEnv.txt
+			grep -q '^rootdev' "${TempDir}"/bootfs/boot/armbianEnv.txt || echo "rootdev=$targetuuid" >> "${TempDir}"/bootfs/boot/armbianEnv.txt
 		else
 			sed -e 's,setenv rootdev.*,setenv rootdev '"$targetuuid"',g' -i "${TempDir}"/bootfs/boot/boot.cmd
 			[[ -f "${TempDir}"/bootfs/boot/boot.ini ]] && sed -e 's,^setenv rootdev.*$,setenv rootdev "'"$targetuuid"'",' -i "${TempDir}"/bootfs/boot/boot.ini


### PR DESCRIPTION
Some boot environment files doesn't have rootdev variable by default (e.g. sun50iw1-next, sun50iw1-next). When running nand-sata-install, rootdev points to the one defined in boot.cmd (mmcblk0p1).

In result, when booting from eMMC, the kernel hangs waiting for root device.

Simple fix is to check if rootdev exist and append it if not.