### PR TITLE
Fix boad-deb dependencies

### DIFF
--- a/lib/makeboarddeb.sh
+++ b/lib/makeboarddeb.sh
@@ -49,12 +49,12 @@ create_board_package()
 	Installed-Size: 1
 	Section: kernel
 	Priority: optional
-	Depends: bash, linux-base, u-boot-tools, initramfs-tools
+	Depends: bash, linux-base, u-boot-tools, initramfs-tools, python3-apt
 	Provides: armbian-bsp
 	Conflicts: armbian-bsp
 	Suggests: armbian-config
 	Replaces: zram-config, base-files, armbian-tools-$RELEASE
-	Recommends: bsdutils, parted, python3-apt, util-linux, toilet
+	Recommends: bsdutils, parted, util-linux, toilet
 	Description: Armbian tweaks for $RELEASE on $BOARD ($BRANCH branch)
 	EOF
 


### PR DESCRIPTION
The packages 'recommend' python3-apt, while it simply does not work without this package. This patch moves python3-apt from recommends to depends.

```
  Traceback (most recent call last):
    File "/usr/lib/armbian/armbian-apt-updates", line 25, in <module>
      import apt_pkg
  ModuleNotFoundError: No module named 'apt_pkg'
```