### PR TITLE
Call prepare_host in the DockerFile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade && 
 RUN locale-gen en_US.UTF-8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8' TERM=screen
 WORKDIR /root/armbian
+ENV SRC=/root/armbian
+RUN bash -c ". ${SRC}/lib/general.sh && prepare_host"
 ENTRYPOINT [ "/bin/bash", "/root/armbian/compile.sh" ]


### PR DESCRIPTION
Rationale:

1. It means we don't have to keep up to date this dockerfile with [general.sh](https://github.com/armbian/build/blob/master/lib/general.sh#L540) anymore.
2. We also download the deps `gcc-linaro-*`.
3. People building more complete dockerfile based on this one can make efficient use of docker cached images by not having to download `gcc-linaro` the first time they build their custom image.

What we can do in a follow up PR is to remove the dependencies in this apt-get install, as they should be installed in `prepare_host`.
