### PR TITLE
[sunxi-dev][h6] update opp table

### DIFF
--- a/patch/kernel/sunxi-dev/0012-general-h6-new-opp-table.patch
+++ b/patch/kernel/sunxi-dev/0012-general-h6-new-opp-table.patch
@@ -56,14 +56,14 @@ index 141fd186b..5356ca6f6 100644
  		opp@1640000000 {
  			opp-hz = /bits/ 64 <1640000000>;
 -			opp-microvolt = <1160000 1160000 1160000>;
-+			opp-microvolt = <910000 900000 920000>;
++			opp-microvolt = <910000 910000 920000>;
  			clock-latency-ns = <244144>; /* 8 32k periods */
  		};
  
  		opp@1800000000 {
  			opp-hz = /bits/ 64 <1800000000>;
 -			opp-microvolt = <1160000 1160000 1160000>;
-+			opp-microvolt = <930000 920000 940000>;
++			opp-microvolt = <950000 930000 950000>;
  			clock-latency-ns = <244144>; /* 8 32k periods */
  		};
  	};


### PR DESCRIPTION
use more powerfull 'cpuburn-a53' to do pressure test.
power meter shows that 'cpuburn-a53' consumes much more power than
'stress -c 4' in the same condition. 930mV is not enough when running
'cpuburn-a53' meanwhile 950mV is the minimum  required voltage.
When running 'cpuburn-a53' at 1.8G, h6 consumes lots of power and generate
such amount of heat that an active cooling is necessary otherwise h6
gets overheat and system crashes. Even with active cooling and heatsink
is in low temperature the junction temperature is still quit high that
it reaches about 88~90 ℃ . Maybe the high thermal resistance of plastic
package causes the problem.

-----

![stress2-detail](https://user-images.githubusercontent.com/5281193/58750946-df87f400-84ca-11e9-89a7-f8ffe0493ffe.png)
