### PR TITLE
Fix "No signal" issue with DVB-T/T2 tuner MyGica T230C v2

### DIFF
--- a/patch/kernel/sunxi-dev/0147-si2168-fix-cmd-timeout.patch
+++ b/patch/kernel/sunxi-dev/0147-si2168-fix-cmd-timeout.patch
@@ -1,0 +1,28 @@
+From 2e01cc074cc426da4b390af025a736eda9aef80c Mon Sep 17 00:00:00 2001
+From: Koumes <koumes@centrum.cz>
+Date: Sat, 1 Jun 2019 21:20:26 +0000
+Subject: [PATCH] si2168: fix cmd timeout
+
+Some demuxer si2168 commands may take 130-140 ms.
+(DVB-T/T2 tuner MyGica T230C v2).
+Details: https://github.com/CoreELEC/CoreELEC/pull/208
+---
+ drivers/media/dvb-frontends/si2168.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/media/dvb-frontends/si2168.c b/drivers/media/dvb-frontends/si2168.c
+index b05e6772c..ffaba6f81 100644
+--- a/drivers/media/dvb-frontends/si2168.c
++++ b/drivers/media/dvb-frontends/si2168.c
+@@ -42,7 +42,7 @@ static int si2168_cmd_execute(struct i2c_client *client, struct si2168_cmd *cmd)
+ 
+ 	if (cmd->rlen) {
+ 		/* wait cmd execution terminate */
+-		#define TIMEOUT 70
++		#define TIMEOUT 200
+ 		timeout = jiffies + msecs_to_jiffies(TIMEOUT);
+ 		while (!time_after(jiffies, timeout)) {
+ 			ret = i2c_master_recv(client, cmd->args, cmd->rlen);
+-- 
+2.17.1
+

--- a/patch/kernel/sunxi-next/0147-si2168-fix-cmd-timeout.patch
+++ b/patch/kernel/sunxi-next/0147-si2168-fix-cmd-timeout.patch
@@ -1,0 +1,28 @@
+From 2e01cc074cc426da4b390af025a736eda9aef80c Mon Sep 17 00:00:00 2001
+From: Koumes <koumes@centrum.cz>
+Date: Sat, 1 Jun 2019 21:20:26 +0000
+Subject: [PATCH] si2168: fix cmd timeout
+
+Some demuxer si2168 commands may take 130-140 ms.
+(DVB-T/T2 tuner MyGica T230C v2).
+Details: https://github.com/CoreELEC/CoreELEC/pull/208
+---
+ drivers/media/dvb-frontends/si2168.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/media/dvb-frontends/si2168.c b/drivers/media/dvb-frontends/si2168.c
+index b05e6772c..ffaba6f81 100644
+--- a/drivers/media/dvb-frontends/si2168.c
++++ b/drivers/media/dvb-frontends/si2168.c
+@@ -42,7 +42,7 @@ static int si2168_cmd_execute(struct i2c_client *client, struct si2168_cmd *cmd)
+ 
+ 	if (cmd->rlen) {
+ 		/* wait cmd execution terminate */
+-		#define TIMEOUT 70
++		#define TIMEOUT 200
+ 		timeout = jiffies + msecs_to_jiffies(TIMEOUT);
+ 		while (!time_after(jiffies, timeout)) {
+ 			ret = i2c_master_recv(client, cmd->args, cmd->rlen);
+-- 
+2.17.1
+


### PR DESCRIPTION
Some demuxer si2168 commands may take 130-140 ms. (DVB-T/T2 tuner MyGica T230C v2).

Details: https://github.com/CoreELEC/CoreELEC/pull/208

Patch was successfully tested with some Armbian kernels sunxi-next 4.14.70, 4.19.20 and 4.19.38 on the Allwinner H3 (OrangePI PC).