### PR TITLE
[rockchip64-default rockchip64-dev] Update compatibility for Radxa Ro…

### DIFF
--- a/patch/kernel/rockchip64-default/add-rockpi4b.patch
+++ b/patch/kernel/rockchip64-default/add-rockpi4b.patch
@@ -6,7 +6,7 @@ index 02a344399..ad91dd192 100644
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-sapphire-excavator-edp.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-sapphire-excavator-linux.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-sapphire-excavator-linux-for-rk1808-cascade.dtb
-+dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-rockpi4b.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-rock-pi-4.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-tve1030g.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-tve1205g.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-videostrong-linux.dtb
@@ -30,11 +30,11 @@ index 2851cd529..77801340b 100644
  		route_edp: route-edp {
  			status = "disabled";
  			logo,uboot = "logo.bmp";
-diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rockpi4b.dts b/arch/arm64/boot/dts/rockchip/rk3399-rockpi4b.dts
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts
 new file mode 100644
 index 000000000..59ed95952
 --- /dev/null
-+++ b/arch/arm64/boot/dts/rockchip/rk3399-rockpi4b.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts
 @@ -0,0 +1,1311 @@
 +/*
 + * Copyright (c) 2016 Fuzhou Rockchip Electronics Co., Ltd
@@ -89,8 +89,8 @@ index 000000000..59ed95952
 +
 +/ {
 +
-+	model = "ROCK PI 4B";
-+	compatible = "rockchip,rockpi","rockchip,rk3399";
++	model = "Radxa ROCK Pi 4";
++	compatible = "radxa,rockpi4","rockchip,rk3399";
 +
 +	fiq_debugger: fiq-debugger {
 +		compatible = "rockchip,fiq-debugger";

--- a/patch/kernel/rockchip64-dev/add-board-rockpi4b.patch
+++ b/patch/kernel/rockchip64-dev/add-board-rockpi4b.patch
@@ -6,15 +6,15 @@ index 49042c4..191829b 100644
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-puma-haikou.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-roc-pc.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-rock960.dtb
-+dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-rockpi4b.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-rock-pi-4.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-rockpro64.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-sapphire.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-sapphire-excavator.dtb
-diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rockpi4b.dts b/arch/arm64/boot/dts/rockchip/rk3399-rockpi4b.dts
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts
 new file mode 100644
 index 000000000..c3c38266f
 --- /dev/null
-+++ b/arch/arm64/boot/dts/rockchip/rk3399-rockpi4b.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts
 @@ -0,0 +1,928 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
@@ -29,8 +29,8 @@ index 000000000..c3c38266f
 +#include "rk3399-opp.dtsi"
 +
 +/ {
-+	model = "RockPi-4B";
-+	compatible = "radxa,rockpi-4b", "rockchip,rk3399";
++	model = "Radxa ROCK Pi 4";
++	compatible = "radxa,rockpi4", "rockchip,rk3399";
 +
 +	chosen {
 +		bootargs = "mmc_cmdqueue=0 earlycon=uart8250,mmio32,0xff1a0000";


### PR DESCRIPTION
…ckPi4

This matches upstreams compatibility as in
https://github.com/torvalds/linux/blob/788a024921c48985939f8241c1ff862a7374d8f9/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts#L15