### PR TITLE
Enable the i2c-tiny-usb kernel module

### DIFF
--- a/config/kernel/linux-sunxi-dev.config
+++ b/config/kernel/linux-sunxi-dev.config
@@ -2734,7 +2734,7 @@ CONFIG_I2C_SUN6I_P2WI=m
 # CONFIG_I2C_PARPORT_LIGHT is not set
 # CONFIG_I2C_ROBOTFUZZ_OSIF is not set
 # CONFIG_I2C_TAOS_EVM is not set
-# CONFIG_I2C_TINY_USB is not set
+CONFIG_I2C_TINY_USB=m
 
 #
 # Other I2C/SMBus bus drivers

--- a/config/kernel/linux-sunxi-next.config
+++ b/config/kernel/linux-sunxi-next.config
@@ -2741,7 +2741,7 @@ CONFIG_I2C_SUN6I_P2WI=m
 # CONFIG_I2C_PARPORT_LIGHT is not set
 # CONFIG_I2C_ROBOTFUZZ_OSIF is not set
 # CONFIG_I2C_TAOS_EVM is not set
-# CONFIG_I2C_TINY_USB is not set
+CONFIG_I2C_TINY_USB=m
 
 #
 # Other I2C/SMBus bus drivers


### PR DESCRIPTION
It is neccessary to enable this module to run an external USB-I2C adapter (i2c-tiny-usb, https://github.com/harbaum/I2C-Tiny-USB).