### PR TITLE
opp fix stability issue

### DIFF
--- a/patch/kernel/sunxi-dev/0012-general-h6-new-opp-table.patch
+++ b/patch/kernel/sunxi-dev/0012-general-h6-new-opp-table.patch
@@ -1,41 +1,48 @@
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h6.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h6.dtsi
-index 141fd186b..5356ca6f6 100644
+index 141fd186b..4ab42048d 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h6.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h6.dtsi
-@@ -73,55 +73,55 @@
+@@ -67,61 +67,62 @@
+ 		};
+ 	};
+ 
++	/* 0.6~1.1V, 10mV/Step, 51 steps */
+ 	cpu_opp_table: opp_table {
+ 		compatible = "operating-points-v2";
+ 		opp-shared;
  
  		opp@480000000 {
  			opp-hz = /bits/ 64 <480000000>;
 -			opp-microvolt = <880000 880000 880000>;
-+			opp-microvolt = <800000 800000 880000>;
++			opp-microvolt = <880000 870000 900000>;
  			clock-latency-ns = <244144>; /* 8 32k periods */
  		};
  
  		opp@720000000 {
  			opp-hz = /bits/ 64 <720000000>;
 -			opp-microvolt = <880000 880000 880000>;
-+			opp-microvolt = <800000 800000 880000>;
++			opp-microvolt = <880000 870000 900000>;
  			clock-latency-ns = <244144>; /* 8 32k periods */
  		};
  
  		opp@816000000 {
  			opp-hz = /bits/ 64 <816000000>;
 -			opp-microvolt = <880000 880000 880000>;
-+			opp-microvolt = <800000 800000 880000>;
++			opp-microvolt = <880000 870000 900000>;
  			clock-latency-ns = <244144>; /* 8 32k periods */
  		};
  
  		opp@888000000 {
  			opp-hz = /bits/ 64 <888000000>;
 -			opp-microvolt = <880000 880000 880000>;
-+			opp-microvolt = <800000 800000 900000>;
++			opp-microvolt = <880000 870000 900000>;
  			clock-latency-ns = <244144>; /* 8 32k periods */
  		};
  
  		opp@1080000000 {
  			opp-hz = /bits/ 64 <1080000000>;
 -			opp-microvolt = <940000 940000 940000>;
-+			opp-microvolt = <840000 840000 900000>;
++			opp-microvolt = <880000 880000 900000>;
  			clock-latency-ns = <244144>; /* 8 32k periods */
  		};
  
@@ -49,21 +56,21 @@ index 141fd186b..5356ca6f6 100644
  		opp@1488000000 {
  			opp-hz = /bits/ 64 <1488000000>;
 -			opp-microvolt = <1060000 1060000 1060000>;
-+			opp-microvolt = <900000 900000 910000>;
++			opp-microvolt = <900000 900000 920000>;
  			clock-latency-ns = <244144>; /* 8 32k periods */
  		};
  
  		opp@1640000000 {
  			opp-hz = /bits/ 64 <1640000000>;
 -			opp-microvolt = <1160000 1160000 1160000>;
-+			opp-microvolt = <910000 910000 920000>;
++			opp-microvolt = <910000 910000 930000>;
  			clock-latency-ns = <244144>; /* 8 32k periods */
  		};
  
  		opp@1800000000 {
  			opp-hz = /bits/ 64 <1800000000>;
 -			opp-microvolt = <1160000 1160000 1160000>;
-+			opp-microvolt = <950000 930000 950000>;
++			opp-microvolt = <950000 930000 960000>;
  			clock-latency-ns = <244144>; /* 8 32k periods */
  		};
  	};

--- a/patch/kernel/sunxi-dev/0012-general-h6-new-opp-table.patch
+++ b/patch/kernel/sunxi-dev/0012-general-h6-new-opp-table.patch
@@ -1,12 +1,12 @@
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h6.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h6.dtsi
-index 141fd186b..4ab42048d 100644
+index 141fd186b..4d4dcf8eb 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h6.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h6.dtsi
 @@ -67,61 +67,62 @@
  		};
  	};
  
-+	/* 0.6~1.1V, 10mV/Step, 51 steps */
++	/* axp80,DCDC-A: 0.6~1.1V, 10mV/Step, 51 steps; 1.12~1.52V, 20mV/Step, 21 Steps */
  	cpu_opp_table: opp_table {
  		compatible = "operating-points-v2";
  		opp-shared;
@@ -42,35 +42,35 @@ index 141fd186b..4ab42048d 100644
  		opp@1080000000 {
  			opp-hz = /bits/ 64 <1080000000>;
 -			opp-microvolt = <940000 940000 940000>;
-+			opp-microvolt = <880000 880000 900000>;
++			opp-microvolt = <880000 880000 940000>;
  			clock-latency-ns = <244144>; /* 8 32k periods */
  		};
  
  		opp@1320000000 {
  			opp-hz = /bits/ 64 <1320000000>;
 -			opp-microvolt = <1000000 1000000 1000000>;
-+			opp-microvolt = <880000 880000 900000>;
++			opp-microvolt = <880000 880000 960000>;
  			clock-latency-ns = <244144>; /* 8 32k periods */
  		};
  
  		opp@1488000000 {
  			opp-hz = /bits/ 64 <1488000000>;
 -			opp-microvolt = <1060000 1060000 1060000>;
-+			opp-microvolt = <900000 900000 920000>;
++			opp-microvolt = <910000 900000 980000>;
  			clock-latency-ns = <244144>; /* 8 32k periods */
  		};
  
  		opp@1640000000 {
  			opp-hz = /bits/ 64 <1640000000>;
 -			opp-microvolt = <1160000 1160000 1160000>;
-+			opp-microvolt = <910000 910000 930000>;
++			opp-microvolt = <950000 910000 1100000>;
  			clock-latency-ns = <244144>; /* 8 32k periods */
  		};
  
  		opp@1800000000 {
  			opp-hz = /bits/ 64 <1800000000>;
 -			opp-microvolt = <1160000 1160000 1160000>;
-+			opp-microvolt = <950000 930000 960000>;
++			opp-microvolt = <1010000 930000 1160000>;
  			clock-latency-ns = <244144>; /* 8 32k periods */
  		};
  	};


### PR DESCRIPTION
use [StabilityTester](https://github.com/mzhboy/StabilityTester) to test system stability.
the original [ehoutsma/StabilityTester](https://github.com/ehoutsma/StabilityTester) does not works on armbian-dev.
the orangepi boards have very small input MLCC Capacitor 10uF which is not enough and cause stability issue on system powersupply, small modification is needed.
A low ESR, high capacitance, high ripple current [electric capacitor](https://www.google.com/search?newwindow=1&q=CONDUCTIVE+POLYMER+SOLID+ELECTROLYTIC+CAPACITOR) is recommended. 
I'm using a 6.8v 330uF solid electric capacitor.

![cap](https://user-images.githubusercontent.com/5281193/59106032-f2397780-8967-11e9-819c-c333b9da235d.png)
![mod](https://user-images.githubusercontent.com/5281193/59106182-552b0e80-8968-11e9-9ae6-299730f93f30.png)

---------
The best solution is adding a dc-dc converter that generate 5.1v directly connect to sbc board with short wire. The low ESR Capacitor is still needed.
power(12v) ---> buck converter(5.1v) -> sbc board

---------

This pr have been tested **without hardware modification** by running 200 times `stabilityTester.sh`.
Others configuration had been tested to find out the best solution.

|1.08|1.32|1.48|1.64|1.8|GHz|
|----|----|----|----|---|---|
|880|880|910|940|1000|mV|
|900|910|920|930|990|mV|
|900|920|940|960|1000|mV|
|880|880|910|950|1000|mV|
|900|910|920|940|990|mV|
|900|920|950|1000|1100|mV|
|880|880|910|950|1010|mV|
|900|920|930|940|990|mV|
|900|920|950|990|1050|mV|
|890|900|910|940|990|mV|
|900|920|930|950|1000|mV|
|900|920|950|990|1060|mV|
|900|900|910|940|990|mV|
|900|920|940|950|1000|mV|
|900|920|950|990|1080|mV|

