### PR TITLE
Update nanopct4 and nanopim4 dtb names

### DIFF
--- a/config/sources/rk3399.conf
+++ b/config/sources/rk3399.conf
@@ -86,8 +86,8 @@ atf_custom_postprocess()
 
 family_tweaks()
 {
-	[[ $BOARD == nanopct4 ]] && echo "fdtfile=rockchip/rk3399-nanopi4-rev00.dtb" >> $SDCARD/boot/armbianEnv.txt
-	[[ $BOARD == nanopim4 ]] && echo "fdtfile=rockchip/rk3399-nanopi4-rev01.dtb" >> $SDCARD/boot/armbianEnv.txt
+	[[ $BOARD == nanopct4 ]] && echo "fdtfile=rockchip/rk3399-nanopc-t4" >> $SDCARD/boot/armbianEnv.txt
+	[[ $BOARD == nanopim4 ]] && echo "fdtfile=rockchip/rk3399-nanopi-m4.dtb" >> $SDCARD/boot/armbianEnv.txt
 	[[ $BOARD == nanopineo4 ]] && echo "fdtfile=rockchip/rk3399-nanopi4-rev04.dtb" >> $SDCARD/boot/armbianEnv.txt
 	[[ $BOARD == orangepi-rk3399 ]] && echo "fdtfile=rockchip/rk3399-orangepi.dtb" >> $SDCARD/boot/armbianEnv.txt
 	[[ $BOARD == firefly-rk3399 ]] && echo "fdtfile=rockchip/rk3399-firefly.dtb" >> $SDCARD/boot/armbianEnv.txt


### PR DESCRIPTION
The 5.1 kernel seems to have the dtb filenames as rk3399-nanopc-t4 and rk3399-nanopi-m4 instead of rk3399-nanopi4-rev0X.dtb.