### PR TITLE
rockchip64-dev: Add back original names of nanopim4 and nanopct4 dtb …

### DIFF
--- a/patch/kernel/rockchip64-dev/xxx-add-symlink-to-old-dtb-names-for-nanopim4-and-nanopct4.patch
+++ b/patch/kernel/rockchip64-dev/xxx-add-symlink-to-old-dtb-names-for-nanopim4-and-nanopct4.patch
@@ -1,0 +1,46 @@
+From 5791ab558033d85ed6433e66df4671810eea1d1b Mon Sep 17 00:00:00 2001
+From: Steev Klimaszewski <steev@kali.org>
+Date: Tue, 11 Jun 2019 12:21:18 -0500
+Subject: [PATCH] arm64: dts: rockchip: Add symlinks to older bootloader names
+
+---
+ arch/arm64/boot/dts/rockchip/Makefile                 | 2 ++
+ arch/arm64/boot/dts/rockchip/rk3399-nanopi4-rev00.dts | 1 +
+ arch/arm64/boot/dts/rockchip/rk3399-nanopi4-rev01.dts | 1 +
+ 3 files changed, 4 insertions(+)
+ create mode 120000 arch/arm64/boot/dts/rockchip/rk3399-nanopi4-rev00.dts
+ create mode 120000 arch/arm64/boot/dts/rockchip/rk3399-nanopi4-rev01.dts
+
+diff --git a/arch/arm64/boot/dts/rockchip/Makefile b/arch/arm64/boot/dts/rockchip/Makefile
+index 83f38b8de5b5..3f2911dd853c 100644
+--- a/arch/arm64/boot/dts/rockchip/Makefile
++++ b/arch/arm64/boot/dts/rockchip/Makefile
+@@ -17,7 +17,9 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-gru-kevin.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-gru-scarlet-inx.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-gru-scarlet-kd.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-nanopc-t4.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-nanopi4-rev00.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-nanopi-m4.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-nanopi4-rev01.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-pinebook-pro.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-puma-haikou.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-roc-pc.dtb
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-nanopi4-rev00.dts b/arch/arm64/boot/dts/rockchip/rk3399-nanopi4-rev00.dts
+new file mode 120000
+index 000000000000..123de3c9ba4f
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi4-rev00.dts
+@@ -0,0 +1 @@
++rk3399-nanopc-t4.dts
+\ No newline at end of file
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-nanopi4-rev01.dts b/arch/arm64/boot/dts/rockchip/rk3399-nanopi4-rev01.dts
+new file mode 120000
+index 000000000000..5c27e6fc3f38
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi4-rev01.dts
+@@ -0,0 +1 @@
++rk3399-nanopi-m4.dts
+\ No newline at end of file
+-- 
+2.20.1 (Apple Git-117)
+


### PR DESCRIPTION
…files

The bootloader seems to expect the downstream names of the dtb files, so create
a symlink to them from the new names that mainline has.
