### PR TITLE
Bugfix: check LOG_TYPE only at script start

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-ramlog
+++ b/packages/bsp/common/usr/lib/armbian/armbian-ramlog
@@ -43,7 +43,7 @@ RecreateLogs (){
 syncToDisk () {
 	isSafe
 
-	echo -e "\n\n$(date): Syncing logs from $LOG_TYPE to storage\n" | $LOG_OUTPUT
+	echo -e "\n\n$(date): Syncing logs to storage\n" | $LOG_OUTPUT
 
 	if [ "$USE_RSYNC" = true ]; then
 		${NoCache} rsync -aXWv --delete --exclude "lost+found" --exclude armbian-ramlog.log --links $RAM_LOG $HDD_LOG 2>&1 | $LOG_OUTPUT
@@ -57,7 +57,7 @@ syncToDisk () {
 syncFromDisk () {
 	isSafe
 
-	echo -e "\n\n$(date): Loading logs from storage to $LOG_TYPE\n" | $LOG_OUTPUT
+	echo -e "\n\n$(date): Loading logs from storage\n" | $LOG_OUTPUT
 
 	if [ "$USE_RSYNC" = true ]; then
 		${NoCache} rsync -aXWv --delete --exclude "lost+found" --exclude armbian-ramlog.log --exclude *.gz --exclude='*.[0-9]' --links $HDD_LOG $RAM_LOG 2>&1 | $LOG_OUTPUT
@@ -77,18 +77,18 @@ check_if_installed () {
 	fi
 }
 
-# Check whether zram device is available or we need to use tmpfs
-if [ "$(blkid -s TYPE /dev/zram0 | awk ' { print $2 } ' | grep ext4)" ]; then
-	LOG_TYPE="zram"
-else
-	LOG_TYPE="tmpfs"
-fi
-
 case "$1" in
 	start)
 		[ -d $HDD_LOG ] || mkdir -p $HDD_LOG
 		mount --bind $RAM_LOG $HDD_LOG
 		mount --make-private $HDD_LOG
+		
+		# Check whether zram device is available or we need to use tmpfs
+		if [ "$(blkid -s TYPE /dev/zram0 | awk ' { print $2 } ' | grep ext4)" ]; then
+			LOG_TYPE="zram"
+		else
+			LOG_TYPE="tmpfs"
+		fi
 
 		case $LOG_TYPE in
 			zram)


### PR DESCRIPTION
Only at start of the service since checking spins up attached mechanical drives and we don't want that. As a side product, this will remove info about the type which goes to logs.