### PR TITLE
Docker: install more host dep packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade && 
 	ncurses-term p7zip-full kmod dosfstools libc6-dev-armhf-cross fakeroot xxd \
 	curl patchutils python liblz4-tool libpython2.7-dev linux-base swig libpython-dev \
 	systemd-container udev g++-5-arm-linux-gnueabihf lib32stdc++6 cpio tzdata psmisc acl \
-	libc6-i386 lib32ncurses5 lib32tinfo5 locales ncurses-base zlib1g:i386 pixz bison libbison-dev flex libfl-dev
+	libc6-i386 lib32ncurses5 lib32tinfo5 locales ncurses-base zlib1g:i386 pixz bison libbison-dev flex libfl-dev \
+        aptly aria2 cryptsetup cryptsetup-bin gnupg1 gpgv1
 RUN locale-gen en_US.UTF-8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8' TERM=screen
 WORKDIR /root/armbian


### PR DESCRIPTION
This avoids installing the host-dep packages again everytime running the docker container.
