### PR TITLE
Docker: override stty size in container

### DIFF
--- a/config-docker.conf
+++ b/config-docker.conf
@@ -77,6 +77,8 @@ DOCKER_FLAGS+=(-v=$SRC/:/root/armbian/)
 # mount 2 named volumes - for cacheable data and compiler cache
 DOCKER_FLAGS+=(-v=armbian-cache:/root/armbian/cache -v=armbian-ccache:/root/.ccache)
 
+DOCKER_FLAGS+=(-e COLUMNS="`tput cols`" -e LINES="`tput lines`")
+
 # pass other command line arguments like KERNEL_ONLY=yes, KERNEL_CONFIGURE=yes, etc.
 # pass "docker-guest" as an additional config name that will be sourced in the container if exists
 display_alert "Running the container" "" "info"

--- a/lib/main.sh
+++ b/lib/main.sh
@@ -26,6 +26,10 @@ umask 002
 # destination
 DEST=$SRC/output
 
+# override stty size
+[[ -n $COLUMNS ]] && stty cols $COLUMNS
+[[ -n $LINES ]] && stty rows $LINES
+
 TTY_X=$(($(stty size | awk '{print $2}')-6)) 			# determine terminal width
 TTY_Y=$(($(stty size | awk '{print $1}')-6)) 			# determine terminal height
 


### PR DESCRIPTION
With some docker CLI version, `stty size` in the container will return `0 0`,
which causes `dialog` to fail. This commit fixes that by setting the actual
terminal size.

For more infor, see:

  https://github.com/docker/for-linux/issues/314
