### PR TITLE
[ mvebu ] Put back Armada temperature tweak in motd

### DIFF
--- a/config/sources/mvebu-helios4.inc
+++ b/config/sources/mvebu-helios4.inc
@@ -66,4 +66,10 @@ family_tweaks_s()
 	# copy and enable helios4-wol.service
 	cp $SRC/packages/bsp/helios4/helios4-wol.service $SDCARD/lib/systemd/system/
 	chroot $SDCARD /bin/bash -c "systemctl --no-reload enable helios4-wol.service >/dev/null 2>&1"
+
+	### Other tweaks
+
+	# add custom motd default conf file
+        cp $SRC/packages/bsp/helios4/armbian-motd $SDCARD/etc/default/
+
 }

--- a/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
+++ b/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
@@ -17,6 +17,9 @@ MOTD_DISABLE=""
 STORAGE=/dev/sda1
 SHOW_IP_PATTERN="^[ewr].*|^br.*|^lt.*|^umts.*"
 
+CPU_TEMP_LIMIT=45
+AMB_TEMP_LIMIT=40
+
 [[ -f /etc/default/armbian-motd ]] && . /etc/default/armbian-motd
 
 for f in $MOTD_DISABLE; do
@@ -200,8 +203,8 @@ printf "IP:            "
 printf "\x1B[92m%s\x1B[0m" "$ip_address"
 echo "" # fixed newline
 a=0;b=0;c=0
-display "CPU temp" "$board_temp" "45" "0" "°C" "" ; a=$?
-display "Ambient temp" "$amb_temp" "40" "0" "°C" "" ; b=$?
+display "CPU temp" "$board_temp" $CPU_TEMP_LIMIT "0" "°C" "" ; a=$?
+display "Ambient temp" "$amb_temp" $AMB_TEMP_LIMIT "0" "°C" "" ; b=$?
 (( ($a+$b) >0 )) && echo "" # new line only if some value is displayed
 display "Usage of /" "$root_usage" "90" "1" "%" " of $root_total"
 display "storage/" "$storage_usage" "90" "1" "%" " of $storage_total"

--- a/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
+++ b/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
@@ -45,7 +45,10 @@ function getboardtemp() {
 			# Allwinner legacy kernels output degree C
 			board_temp=${raw_temp}
 		else
-			board_temp=$(awk '{printf("%d",$1/1000)}' <<<${raw_temp})
+			# Tweak for Marvell Armada error in the default value of Tc trim (Errata #132698)
+			grep -qi Armada /proc/cpuinfo && \
+				board_temp=$(( $(awk '{printf("%d",$1/1000)}' <<<${raw_temp}) - 20 )) || \
+				board_temp=$(awk '{printf("%d",$1/1000)}' <<<${raw_temp})
 		fi
 	elif [ -f /etc/armbianmonitor/datasources/pmictemp ]; then
 		# fallback to PMIC temperature

--- a/packages/bsp/helios4/armbian-motd
+++ b/packages/bsp/helios4/armbian-motd
@@ -1,0 +1,10 @@
+# add space-separated list of MOTD script names (without number) to exclude them from MOTD
+# Example:
+# MOTD_DISABLE="header tips updates"
+
+MOTD_DISABLE=""
+ONE_WIRE="" # yes = show 1-wire temperature sensor if attached 
+
+# Helios4 temperature display warning threshold
+CPU_TEMP_LIMIT=65
+AMB_TEMP_LIMIT=50


### PR DESCRIPTION
As discussed [here](https://forum.armbian.com/topic/10214-clearfogpro-possible-change-in-temperature-reporting-between-414next-and-419dev) the -20C tweak on Armada wasn't supposed to be removed https://github.com/armbian/build/issues/1135

This tweak is to address Armada Marvell errata 132698 which is now fixed in kernel 4.19
https://github.com/torvalds/linux/commit/8c0b888f6610d0ebbc4bdfb52d2fef9f4a11adfc

So once we switch _next_ branch to 4.19 then we will need to add a condition to only do the -20C display tweak when it's _default_ branch which will be 4.14