### PR TITLE
extra firmware: check USE_MAINLINE_GOOGLE_MIRROR

### DIFF
--- a/packages/extras/firmware.sh
+++ b/packages/extras/firmware.sh
@@ -10,8 +10,11 @@
 build_firmware()
 {
 	display_alert "Merging and packaging linux firmware" "@host" "info"
-
-	local plugin_repo="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git"
+	if [[ $USE_MAINLINE_GOOGLE_MIRROR == yes ]]; then
+		plugin_repo="https://kernel.googlesource.com/pub/scm/linux/kernel/git/firmware/linux-firmware.git"
+	else
+		plugin_repo="https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git"
+	fi
 	local plugin_dir="armbian-firmware${FULL}"
 	[[ -d $SRC/cache/sources/$plugin_dir ]] && rm -rf $SRC/cache/sources/$plugin_dir
 	mkdir -p $SRC/cache/sources/$plugin_dir/lib/firmware


### PR DESCRIPTION
if users want to use google mirror for mainline linux, then he/she has
same reason to use google miiror for linux firmware.

Signed-off-by: Zhang Ning <832666+zhangn1985@users.noreply.github.com>

Please use the "Preview" tab above to view this message if you are seeing this in the new pull request text box.

Please make sure that:

 - pull request is opened to the `master` branch unless you are working on a specfic feature which is developed in a separate branch
 - any changes to kernel configuration files were made by Kconfig menu (build script option `KERNEL_CONFIGURE=yes`) and not by editing configuration files by hand,
 - patch file names don't contain spaces and have less than 40 characters (not counting the `.patch` extension),
 - changes are properly described - what was done exactly and why.

Thanks for contributing! Please remove the text above before opening a pull request.
