### PR TITLE
opp fix stability issue

### DIFF
--- a/patch/kernel/sunxi-dev/0012-general-h6-new-opp-table.patch
+++ b/patch/kernel/sunxi-dev/0012-general-h6-new-opp-table.patch
@@ -13,29 +13,25 @@ index 141fd186b..4d4dcf8eb 100644
  
  		opp@480000000 {
  			opp-hz = /bits/ 64 <480000000>;
--			opp-microvolt = <880000 880000 880000>;
-+			opp-microvolt = <880000 870000 900000>;
+ 			opp-microvolt = <880000 880000 880000>;
  			clock-latency-ns = <244144>; /* 8 32k periods */
  		};
  
  		opp@720000000 {
  			opp-hz = /bits/ 64 <720000000>;
--			opp-microvolt = <880000 880000 880000>;
-+			opp-microvolt = <880000 870000 900000>;
+ 			opp-microvolt = <880000 880000 880000>;
  			clock-latency-ns = <244144>; /* 8 32k periods */
  		};
  
  		opp@816000000 {
  			opp-hz = /bits/ 64 <816000000>;
--			opp-microvolt = <880000 880000 880000>;
-+			opp-microvolt = <880000 870000 900000>;
+ 			opp-microvolt = <880000 880000 880000>;
  			clock-latency-ns = <244144>; /* 8 32k periods */
  		};
  
  		opp@888000000 {
  			opp-hz = /bits/ 64 <888000000>;
--			opp-microvolt = <880000 880000 880000>;
-+			opp-microvolt = <880000 870000 900000>;
+ 			opp-microvolt = <880000 880000 880000>;
  			clock-latency-ns = <244144>; /* 8 32k periods */
  		};
  
@@ -49,28 +45,28 @@ index 141fd186b..4d4dcf8eb 100644
  		opp@1320000000 {
  			opp-hz = /bits/ 64 <1320000000>;
 -			opp-microvolt = <1000000 1000000 1000000>;
-+			opp-microvolt = <880000 880000 960000>;
++			opp-microvolt = <880000 880000 1000000>;
  			clock-latency-ns = <244144>; /* 8 32k periods */
  		};
  
  		opp@1488000000 {
  			opp-hz = /bits/ 64 <1488000000>;
 -			opp-microvolt = <1060000 1060000 1060000>;
-+			opp-microvolt = <910000 900000 980000>;
++			opp-microvolt = <940000 940000 1060000>;
  			clock-latency-ns = <244144>; /* 8 32k periods */
  		};
  
  		opp@1640000000 {
  			opp-hz = /bits/ 64 <1640000000>;
 -			opp-microvolt = <1160000 1160000 1160000>;
-+			opp-microvolt = <950000 910000 1100000>;
++			opp-microvolt = <990000 990000 1160000>;
  			clock-latency-ns = <244144>; /* 8 32k periods */
  		};
  
  		opp@1800000000 {
  			opp-hz = /bits/ 64 <1800000000>;
 -			opp-microvolt = <1160000 1160000 1160000>;
-+			opp-microvolt = <1010000 930000 1160000>;
++			opp-microvolt = <1050000 1050000 1160000>;
  			clock-latency-ns = <244144>; /* 8 32k periods */
  		};
  	};


### PR DESCRIPTION
I've tested my OPi3 for best voltage numbers (for resolving stability problem after first patch), using StabilityTester and increasing slowly mV by 10 after every crash. Finaly, this values gives no error by running StabilityTester 100 times.

I've set same values for target and min mV, max set to default.