### PR TITLE
Add USERPATCHES_PATH optional setting to config file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ ubuntu-*-cloudimg-console.log
 /.tmp/
 /output/
 /cache/
-/userpatches/
+/*userpatches*/
 
 ### General annoyances ###
 .DS_Store

--- a/compile.sh
+++ b/compile.sh
@@ -50,6 +50,7 @@ else
 	# shellcheck source=/dev/null
 	source "${SRC}"/config-default.conf
 fi
+[[ -z "${USERPATCHES_PATH}" ]] && USERPATCHES_PATH="$SRC/userpatches"
 
 if [[ $EUID != 0 ]]; then
 	display_alert "This script requires root privileges, trying to use sudo" "" "wrn"

--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -316,9 +316,9 @@ compile_kernel()
 		display_alert "Using previous kernel config" "$DEST/config/$LINUXCONFIG.config" "info"
 		cp $DEST/config/$LINUXCONFIG.config .config
 	else
-		if [[ -f $SRC/userpatches/$LINUXCONFIG.config ]]; then
+		if [[ -f $USERPATCHES_PATH/$LINUXCONFIG.config ]]; then
 			display_alert "Using kernel config provided by user" "userpatches/$LINUXCONFIG.config" "info"
-			cp $SRC/userpatches/$LINUXCONFIG.config .config
+			cp $USERPATCHES_PATH/$LINUXCONFIG.config .config
 		else
 			display_alert "Using kernel config file" "config/kernel/$LINUXCONFIG.config" "info"
 			cp $SRC/config/kernel/$LINUXCONFIG.config .config
@@ -515,10 +515,10 @@ find_toolchain()
 # <description>: additional description text
 #
 # priority:
-# $SRC/userpatches/<dest>/<family>/target_<target>
-# $SRC/userpatches/<dest>/<family>/board_<board>
-# $SRC/userpatches/<dest>/<family>/branch_<branch>
-# $SRC/userpatches/<dest>/<family>
+# $USERPATCHES_PATH/<dest>/<family>/target_<target>
+# $USERPATCHES_PATH/<dest>/<family>/board_<board>
+# $USERPATCHES_PATH/<dest>/<family>/branch_<branch>
+# $USERPATCHES_PATH/<dest>/<family>
 # $SRC/patch/<dest>/<family>/target_<target>
 # $SRC/patch/<dest>/<family>/board_<board>
 # $SRC/patch/<dest>/<family>/branch_<branch>
@@ -538,10 +538,10 @@ advanced_patch()
 
 	local names=()
 	local dirs=(
-		"$SRC/userpatches/$dest/$family/target_${target}:[\e[33mu\e[0m][\e[34mt\e[0m]"
-		"$SRC/userpatches/$dest/$family/board_${board}:[\e[33mu\e[0m][\e[35mb\e[0m]"
-		"$SRC/userpatches/$dest/$family/branch_${branch}:[\e[33mu\e[0m][\e[33mb\e[0m]"
-		"$SRC/userpatches/$dest/$family:[\e[33mu\e[0m][\e[32mc\e[0m]"
+		"$USERPATCHES_PATH/$dest/$family/target_${target}:[\e[33mu\e[0m][\e[34mt\e[0m]"
+		"$USERPATCHES_PATH/$dest/$family/board_${board}:[\e[33mu\e[0m][\e[35mb\e[0m]"
+		"$USERPATCHES_PATH/$dest/$family/branch_${branch}:[\e[33mu\e[0m][\e[33mb\e[0m]"
+		"$USERPATCHES_PATH/$dest/$family:[\e[33mu\e[0m][\e[32mc\e[0m]"
 		"$SRC/patch/$dest/$family/target_${target}:[\e[32ml\e[0m][\e[34mt\e[0m]"
 		"$SRC/patch/$dest/$family/board_${board}:[\e[32ml\e[0m][\e[35mb\e[0m]"
 		"$SRC/patch/$dest/$family/branch_${branch}:[\e[32ml\e[0m][\e[33mb\e[0m]"

--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -85,9 +85,9 @@ DESTIMG="${SRC}/.tmp/image-${BRANCH}-${BOARD}-${RELEASE}-${BUILD_DESKTOP}"
 
 source "${SRC}/config/sources/${LINUXFAMILY}.conf"
 
-if [[ -f ${SRC}/userpatches/sources/$LINUXFAMILY.conf ]]; then
+if [[ -f $USERPATCHES_PATH/sources/$LINUXFAMILY.conf ]]; then
 	display_alert "Adding user provided $LINUXFAMILY overrides"
-	source "${SRC}/userpatches/sources/${LINUXFAMILY}.conf"
+	source "$USERPATCHES_PATH/sources/${LINUXFAMILY}.conf"
 fi
 
 # dropbear needs to be configured differently
@@ -220,9 +220,9 @@ if [[ $DOWNLOAD_MIRROR == china ]] ; then
 fi
 
 # For user override
-if [[ -f ${SRC}/userpatches/lib.config ]]; then
+if [[ -f $USERPATCHES_PATH/lib.config ]]; then
 	display_alert "Using user configuration override" "userpatches/lib.config" "info"
-	source "${SRC}"/userpatches/lib.config
+	source "$USERPATCHES_PATH"/lib.config
 fi
 
 # apt-cacher-ng mirror configurarion

--- a/lib/distributions.sh
+++ b/lib/distributions.sh
@@ -44,8 +44,8 @@ install_common()
 		[[ -f $SDCARD/etc/dropbear-initramfs/config ]] && sed -i 's/^#DROPBEAR_OPTIONS=/DROPBEAR_OPTIONS="-p '"${CRYPTROOT_SSH_UNLOCK_PORT}"'"/' "${SDCARD}"/etc/dropbear-initramfs/config
 
 		# setup dropbear authorized_keys, either provided by userpatches or generated
-		if [[ -f $SRC/userpatches/dropbear_authorized_keys ]]; then
-			cp "${SRC}"/userpatches/dropbear_authorized_keys "${SDCARD}"/etc/dropbear-initramfs/authorized_keys
+		if [[ -f $USERPATCHES_PATH/dropbear_authorized_keys ]]; then
+			cp "$USERPATCHES_PATH"/dropbear_authorized_keys "${SDCARD}"/etc/dropbear-initramfs/authorized_keys
 		else
 			# generate a default ssh key for login on dropbear in initramfs
 			# this key should be changed by the user on first login
@@ -139,8 +139,8 @@ install_common()
 	# instead of copying sunxi-specific template
 	if [[ $ROOTFS_TYPE == nfs ]]; then
 		display_alert "Copying NFS boot script template"
-		if [[ -f $SRC/userpatches/nfs-boot.cmd ]]; then
-			cp "${SRC}"/userpatches/nfs-boot.cmd "${SDCARD}"/boot/boot.cmd
+		if [[ -f $USERPATCHES_PATH/nfs-boot.cmd ]]; then
+			cp "$USERPATCHES_PATH"/nfs-boot.cmd "${SDCARD}"/boot/boot.cmd
 		else
 			cp "${SRC}"/config/templates/nfs-boot.cmd.template "${SDCARD}"/boot/boot.cmd
 		fi

--- a/lib/fel-load.sh
+++ b/lib/fel-load.sh
@@ -24,9 +24,9 @@ fel_prepare_host()
 
 fel_prepare_target()
 {
-	if [[ -f $SRC/userpatches/fel-boot.cmd ]]; then
+	if [[ -f $USERPATCHES_PATH/fel-boot.cmd ]]; then
 		display_alert "Using custom boot script" "userpatches/fel-boot.cmd" "info"
-		cp "${SRC}"/userpatches/fel-boot.cmd "${FEL_ROOTFS}"/boot/boot.cmd
+		cp "$USERPATCHES_PATH"/fel-boot.cmd "${FEL_ROOTFS}"/boot/boot.cmd
 	else
 		cp "${SRC}"/config/templates/fel-boot.cmd.template "${FEL_ROOTFS}"/boot/boot.cmd
 	fi
@@ -72,10 +72,10 @@ fel_load()
 		write 0x43100000 "${FEL_ROOTFS}"/boot/boot.scr
 }
 
-if [[ -f $SRC/userpatches/fel-hooks.sh ]]; then
+if [[ -f $USERPATCHES_PATH/fel-hooks.sh ]]; then
 	display_alert "Using additional FEL hooks in" "userpatches/fel-hooks.sh" "info"
 	# shellcheck source=/dev/null
-	source "${SRC}"/userpatches/fel-hooks.sh
+	source "$USERPATCHES_PATH"/fel-hooks.sh
 fi
 
 # basic sanity check

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -642,18 +642,16 @@ prepare_host()
 	fi
 
 	# create directory structure
-	mkdir -p $SRC/{cache,output,userpatches}
+	mkdir -p $SRC/{cache,output} $USERPATCHES_PATH
 	if [[ -n $SUDO_USER ]]; then
-		chgrp --quiet sudo cache output userpatches
+		chgrp --quiet sudo cache output $USERPATCHES_PATH
 		# SGID bit on cache/sources breaks kernel dpkg packaging
-		chmod --quiet g+w,g+s output userpatches
+		chmod --quiet g+w,g+s output $USERPATCHES_PATH
 		# fix existing permissions
-		find $SRC/output $SRC/userpatches -type d ! -group sudo -exec chgrp --quiet sudo {} \;
-		find $SRC/output $SRC/userpatches -type d ! -perm -g+w,g+s -exec chmod --quiet g+w,g+s {} \;
+		find $SRC/output $USERPATCHES_PATH -type d ! -group sudo -exec chgrp --quiet sudo {} \;
+		find $SRC/output $USERPATCHES_PATH -type d ! -perm -g+w,g+s -exec chmod --quiet g+w,g+s {} \;
 	fi
-	mkdir -p $DEST/debs/extra $DEST/{config,debug,patch} $SRC/userpatches/overlay $SRC/cache/{sources,toolchains,utility,rootfs} $SRC/.tmp
-
-	find $SRC/patch -type d ! -name . | sed "s%/patch%/userpatches%" | xargs mkdir -p
+	mkdir -p $DEST/debs/extra $DEST/{config,debug,patch} $USERPATCHES_PATH/overlay $SRC/cache/{sources,toolchains,utility,rootfs} $SRC/.tmp
 
 	display_alert "Checking for external GCC compilers" "" "info"
 	# download external Linaro compiler and missing special dependencies since they are needed for certain sources
@@ -698,12 +696,12 @@ prepare_host()
 	# download etcher CLI utility
 	download_etcher_cli
 
-	[[ ! -f $SRC/userpatches/customize-image.sh ]] && cp $SRC/config/templates/customize-image.sh.template $SRC/userpatches/customize-image.sh
+	[[ ! -f $USERPATCHES_PATH/customize-image.sh ]] && cp $SRC/config/templates/customize-image.sh.template $USERPATCHES_PATH/customize-image.sh
 
-	if [[ ! -f $SRC/userpatches/README ]]; then
-		rm -f $SRC/userpatches/readme.txt
-		echo 'Please read documentation about customizing build configuration' > $SRC/userpatches/README
-		echo 'http://www.armbian.com/using-armbian-tools/' >> $SRC/userpatches/README
+	if [[ ! -f $USERPATCHES_PATH/README ]]; then
+		rm -f $USERPATCHES_PATH/readme.txt
+		echo 'Please read documentation about customizing build configuration' > $USERPATCHES_PATH/README
+		echo 'http://www.armbian.com/using-armbian-tools/' >> $USERPATCHES_PATH/README
 	fi
 
 	# check free space (basic)

--- a/lib/image-helpers.sh
+++ b/lib/image-helpers.sh
@@ -107,12 +107,12 @@ write_uboot()
 customize_image()
 {
 	# for users that need to prepare files at host
-	[[ -f $SRC/userpatches/customize-image-host.sh ]] && source "${SRC}"/userpatches/customize-image-host.sh
-	cp "${SRC}"/userpatches/customize-image.sh "${SDCARD}"/tmp/customize-image.sh
+	[[ -f $USERPATCHES_PATH/customize-image-host.sh ]] && source "$USERPATCHES_PATH"/customize-image-host.sh
+	cp "$USERPATCHES_PATH"/customize-image.sh "${SDCARD}"/tmp/customize-image.sh
 	chmod +x "${SDCARD}"/tmp/customize-image.sh
 	mkdir -p "${SDCARD}"/tmp/overlay
 	# util-linux >= 2.27 required
-	mount -o bind,ro "${SRC}"/userpatches/overlay "${SDCARD}"/tmp/overlay
+	mount -o bind,ro "$USERPATCHES_PATH"/overlay "${SDCARD}"/tmp/overlay
 	display_alert "Calling image customization script" "customize-image.sh" "info"
 	chroot "${SDCARD}" /bin/bash -c "/tmp/customize-image.sh $RELEASE $LINUXFAMILY $BOARD $BUILD_DESKTOP"
 	CUSTOMIZE_IMAGE_RC=$?


### PR DESCRIPTION
Required if userpatrched folder is conflicted between two different configs.
This is frequent and today requires maintaining two copies of the builder.
