### PR TITLE
disable strict mode for A64 pinctrl

### DIFF
--- a/patch/kernel/sunxi-next/0001-pinctrl-sunxi-Disable-strict-mode-for-A64-pinctrl-dr.patch
+++ b/patch/kernel/sunxi-next/0001-pinctrl-sunxi-Disable-strict-mode-for-A64-pinctrl-dr.patch
@@ -1,0 +1,30 @@
+From 4aa7894de903660f5c8d5155f2590d00022ca95e Mon Sep 17 00:00:00 2001
+From: WaterByWind <WaterByWind@users.noreply.github.com>
+Date: Sun, 14 Apr 2019 16:16:09 -0400
+Subject: [PATCH] pinctrl: sunxi: Disable strict mode for A64 pinctrl driver
+
+With kernel 4.15.y (and later):
+*  Strict mode was enabled by default via commit 1396007286b1e2fd5dd10ae6a5ccaaaed51ab762 which can/will cause breakage with existing implementations.
+* The ability to configure strict mode was added via commit aae842a3ff3385f27f1df8a9ee1494a416ec032d to allow older drivers to maintain existing behavior and avoid breakage.
+* Commit cd70387f892205bcd7b8093b0837269b0739cbe0 had then explicitly disabled strict mode for most other existing SoCs but did not include A64.
+
+This change is to update the A64 pinctrl driver similar to the other pre-existing SoC pinctrl drivers.
+---
+ drivers/pinctrl/sunxi/pinctrl-sun50i-a64.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/pinctrl/sunxi/pinctrl-sun50i-a64.c b/drivers/pinctrl/sunxi/pinctrl-sun50i-a64.c
+index 7b83d3755a0e..bea52c5a9afa 100644
+--- a/drivers/pinctrl/sunxi/pinctrl-sun50i-a64.c
++++ b/drivers/pinctrl/sunxi/pinctrl-sun50i-a64.c
+@@ -578,6 +578,7 @@ static const struct sunxi_pinctrl_desc a64_pinctrl_data = {
+ 	.pins = a64_pins,
+ 	.npins = ARRAY_SIZE(a64_pins),
+ 	.irq_banks = 3,
++	.disable_strict_mode = true,
+ };
+ 
+ static int a64_pinctrl_probe(struct platform_device *pdev)
+-- 
+2.20.1 (Apple Git-117)
+


### PR DESCRIPTION
this pull request is to solve pinctrl conflict for PPS GPIO device (described in https://forum.armbian.com/topic/9901-pps-gpio-no-longer-default-kernel-configuration/ ) and has been solved in -DEV.

I just copied the missing kernel patch file into sunxi-next from sunxi-dev.
the patch was copied from patch/kernel/sunxi-dev, and kept the name as is, contains more than 40 characters.