### PR TITLE
Netplan folder check & armbian-tools dependency on expect (and tcl) solved

### DIFF
--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -172,7 +172,7 @@ if [[ $BUILD_MINIMAL == yes  ]]; then
 		ca-certificates nocache debconf-utils"
 
 	# Non-essential packages for minimal build
-	PACKAGE_LIST_ADDITIONAL="network-manager cron lsof htop vim mmc-utils"
+	PACKAGE_LIST_ADDITIONAL="network-manager cron lsof htop vim mmc-utils python3-apt rsyslog"
 
 fi
 

--- a/lib/distributions.sh
+++ b/lib/distributions.sh
@@ -377,7 +377,7 @@ install_distribution_specific()
 		EOF
 		chmod +x "${SDCARD}"/etc/rc.local
 		# Basic Netplan config. Let NetworkManager manage all devices on this system
-		cat <<-EOF > "${SDCARD}"/etc/netplan/armbian-default.yaml
+		[[ -d "${SDCARD}"/etc/netplan ]] && cat <<-EOF > "${SDCARD}"/etc/netplan/armbian-default.yaml
 		network:
 		  version: 2
 		  renderer: NetworkManager

--- a/packages/extras/armbian-config.sh
+++ b/packages/extras/armbian-config.sh
@@ -54,5 +54,5 @@ if [[ ! -f $DEST/debs/armbian-config_${REVISION}_all.deb ]]; then
 fi
 
 # installing additional dependencies here so they are installed only with armbian-config
-chroot $SDCARD /bin/bash -c "apt install -q -y iperf3 debconf-utils html2text dirmngr expect libassuan0 libnpth0 libksba8"
+chroot $SDCARD /bin/bash -c "apt install -q -y iperf3 debconf-utils html2text dirmngr expect libassuan0 libnpth0 libksba8 expect libiperf0"
 install_deb_chroot "$DEST/debs/armbian-config_${REVISION}_all.deb"

--- a/packages/extras/armbian-config.sh
+++ b/packages/extras/armbian-config.sh
@@ -54,5 +54,5 @@ if [[ ! -f $DEST/debs/armbian-config_${REVISION}_all.deb ]]; then
 fi
 
 # installing additional dependencies here so they are installed only with armbian-config
-chroot $SDCARD /bin/bash -c "apt install -q -y iperf3 debconf-utils html2text dirmngr expect libassuan0 libnpth0 libksba8 expect libiperf0"
+chroot $SDCARD /bin/bash -c "apt install -q -y iperf3 libiperf0 debconf-utils html2text dirmngr expect libassuan0 libnpth0 libksba8 expect tcl8.6 libtcl8.6 tcl-expect"
 install_deb_chroot "$DEST/debs/armbian-config_${REVISION}_all.deb"


### PR DESCRIPTION
Simple update:
- creation of file only if folder exists
- Arabian-tools dependency installation extended with expect & libiperf0 
- Python3-apt & rsyslog added