### PR TITLE
[rockchip64-dev] UART4 activating overlay

### DIFF
--- a/patch/kernel/rockchip64-dev/general-rockchip-overlays.patch
+++ b/patch/kernel/rockchip64-dev/general-rockchip-overlays.patch
@@ -12,12 +12,13 @@ diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts
 index e69de29..576e190 100644
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
-@@ -0,0 +1,19 @@
+@@ -0,0 +1,20 @@
 +# SPDX-License-Identifier: GPL-2.0
 +dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 +	rockchip-i2c7.dtbo \
 +	rockchip-i2c8.dtbo \
 +	rockchip-spi-spidev.dtbo \
++	rockchip-uart4.dtbo \
 +	rockchip-w1-gpio.dtbo
 +
 +scr-$(CONFIG_ARCH_ROCKCHIP) += \
@@ -36,7 +37,7 @@ diff --git a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays b/arc
 index e69de29..9512445 100644
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
-@@ -0,0 +1,67 @@
+@@ -0,0 +1,76 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
 +https://docs.armbian.com/User-Guide_Allwinner_overlays/
@@ -47,7 +48,7 @@ index e69de29..9512445 100644
 +
 +### Provided overlays:
 +
-+- i2c7, i2c8
++- i2c7, i2c8, spi-spidev, uart4, w1-gpio
 +
 +### Overlay details:
 +
@@ -90,6 +91,15 @@ index e69de29..9512445 100644
 +	Optional
 +	Default: 1000000
 +	Range: 3000 - 100000000
++
++### uart4
++
++Activates UART4
++
++UART4 pins (RX, TX): GPIO1_A7, GPIO1_B0
++
++Notice: UART4 cannot be activated together with SPI1 - they share the sam pins.
++Enabling this overlay disables SPI1.
 +
 +### w1-gpio
 +
@@ -233,6 +243,32 @@ index 0000000..fe8fb14
 +				reg = <0>;
 +				spi-max-frequency = <1000000>;
 +			};
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-uart4.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-uart4.dts
+new file mode 100644
+index 0000000..fe8fb14
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-uart4.dts
+@@ -0,0 +1,20 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "rockchip,rk3399";
++
++	fragment@0 {
++		target = <&uart4>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++
++	fragmenet@1 {
++		target = <&spi1>;
++		__overlay__ {
++			status = "disabled";
 +		};
 +	};
 +};


### PR DESCRIPTION
This adds general overlay for activating UART4 on rockchip64-dev.

I have done it because I could not find a way to successfully "disconnect" kernel from UART2 which is used as serial console during boot and decided I could use UART4 leaving console on UART2.

The change is pretty straightforward except for one thing. I have decided to disable SPI1 when activating UART4 - they use the same GPIOs and using them both at the same time can give unpredictable results.

Now I am thinking that maybe it is a bit over-caring and the user should responsibly choose one or another with a bit of help in README?