### PR TITLE
rootfs: update DNS for prebuilt rootfs

### DIFF
--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -115,6 +115,8 @@ create_rootfs_cache()
 		display_alert "Extracting $display_name" "$date_diff days old" "info"
 		pv -p -b -r -c -N "[ .... ] $display_name" "$cache_fname" | lz4 -dc | tar xp --xattrs -C $SDCARD/
 		[[ $? -ne 0 ]] && rm $cache_fname && exit_with_error "Cache $cache_fname is corrupted and was deleted. Restart."
+		rm $SDCARD/etc/resolv.conf
+		echo "nameserver $NAMESERVER" >> $SDCARD/etc/resolv.conf
 	else
 		display_alert "... remote not found" "Creating new rootfs cache for $RELEASE" "info"
 


### PR DESCRIPTION
defualt DNS for prebuilt rootfs is 1.0.0.1
when this DNS is not accessable, eg. due to proxy.

network operation in chroot will not available.

use alternative DNS in variable NAMESERVER.

Signed-off-by: Zhang Ning <832666+zhangn1985@users.noreply.github.com>