### PR TITLE
Update armbian-zram-config

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-zram-config
+++ b/packages/bsp/common/usr/lib/armbian/armbian-zram-config
@@ -101,7 +101,7 @@ activate_ramlog_partition() {
 
 activate_compressed_tmp() {
 	# create /tmp not as tmpfs but zram compressed if no fstab entry exists
-	grep -q ' /tmp ' /etc/fstab && return
+	grep -q '^tmpfs /tmp ' /etc/fstab && return
 
 	tmp_device=$(( ${zram_devices} + 1 ))
 	if [[ -f /sys/block/zram${tmp_device}/comp_algorithm ]]; then

--- a/packages/bsp/common/usr/lib/armbian/armbian-zram-config
+++ b/packages/bsp/common/usr/lib/armbian/armbian-zram-config
@@ -101,7 +101,7 @@ activate_ramlog_partition() {
 
 activate_compressed_tmp() {
 	# create /tmp not as tmpfs but zram compressed if no fstab entry exists
-	grep -q '/tmp' /etc/fstab && return
+	grep -q ' /tmp ' /etc/fstab && return
 
 	tmp_device=$(( ${zram_devices} + 1 ))
 	if [[ -f /sys/block/zram${tmp_device}/comp_algorithm ]]; then


### PR DESCRIPTION
I have a mount /media/tmpfs which is picked by  

> grep -q '/tmp' /etc/fstab && return

This prevents it.
Also, it prevents an commented out /tmp from being picked by grep.