### PR TITLE
more clean up for source code

### DIFF
--- a/lib/general.sh
+++ b/lib/general.sh
@@ -259,6 +259,7 @@ fetch_from_repo()
 		esac
 		display_alert "Checking out"
 		git checkout -f -q FETCH_HEAD
+		git clean -qdf
 	elif [[ -n $(git status -uno --porcelain --ignore-submodules=all) ]]; then
 		# working directory is not clean
 		if [[ $FORCE_CHECKOUT == yes ]]; then


### PR DESCRIPTION
some patches will create new files, they can be removed by `git clean -qdf`

but when repo has update, git clean is forgot, thus leave new files still in repo.

add git clean back.

Signed-off-by: Zhang Ning <832666+zhangn1985@users.noreply.github.com>

