### PR TITLE
Bring back the LEDs to Rock Pi 4

### DIFF
--- a/patch/kernel/rockchip64-dev/board-rockpi4-dts-leds.patch
+++ b/patch/kernel/rockchip64-dev/board-rockpi4-dts-leds.patch
@@ -1,12 +1,16 @@
 While mainlining Rock Pi 4 its leds were probably overlooked in the dts.
-Power led is not usable by default but could possibly be made controllable
-by its gpio with the help of soldering iron, good hands and patience (SMD0402).
+Power led is not usable in currently available board revisions <= 1.4
+and is disabled in dts to not confuse users who would like to fiddle with it.
+
+It could possibly be made controllable by its gpio with the help
+of soldering iron, steady hands, patience (SMD0402) and additional overlay
+to enable the led and its gpio pin in device tree.
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts
 index e03062715..a97e02bc0 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts
-@@ -111,6 +111,24 @@
+@@ -111,6 +111,25 @@
  		regulator-max-microvolt = <1400000>;
  		vin-supply = <&vcc5v0_sys>;
  	};
@@ -20,6 +24,7 @@ index e03062715..a97e02bc0 100644
 +			label = "power";
 +			gpios = <&gpio3 RK_PD4 GPIO_ACTIVE_HIGH>;
 +			linux,default-trigger = "default-on";
++			status = "disabled";
 +		};
 +
 +		system-status {

--- a/patch/kernel/rockchip64-dev/board-rockpi4-dts-leds.patch
+++ b/patch/kernel/rockchip64-dev/board-rockpi4-dts-leds.patch
@@ -1,0 +1,50 @@
+While mainlining Rock Pi 4 its leds were probably overlooked in the dts.
+Power led is not usable by default but could possibly be made controllable
+by its gpio with the help of soldering iron, good hands and patience (SMD0402).
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts
+index e03062715..a97e02bc0 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts
+@@ -111,6 +111,24 @@
+ 		regulator-max-microvolt = <1400000>;
+ 		vin-supply = <&vcc5v0_sys>;
+ 	};
++
++	leds {
++		compatible = "gpio-leds";
++		pinctrl-names = "default";
++		pinctrl-0 = <&power_led_gpio>, <&status_led_gpio>;
++
++		power-status {
++			label = "power";
++			gpios = <&gpio3 RK_PD4 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "default-on";
++		};
++
++		system-status {
++			label = "status";
++			gpios = <&gpio3 RK_PD5 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "heartbeat";
++		};
++	};
+ };
+
+ &cpu_l0 {
+@@ -457,6 +476,16 @@
+ 		};
+ 	};
+
++	leds {
++		power_led_gpio: power_led_gpio {
++			rockchip,pins = <3 RK_PD4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		status_led_gpio: status_led_gpio {
++			rockchip,pins = <3 RK_PD5 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
+ 	pmic {
+ 		pmic_int_l: pmic-int-l {
+ 			rockchip,pins = <1 RK_PC5 RK_FUNC_GPIO &pcfg_pull_up>;


### PR DESCRIPTION
While mainlining Rock Pi 4 its leds were probably overlooked in the dts.

Power led is not usable by default but could possibly be made controllable
by its gpio with the help of soldering iron, good hands and patience (SMD0402).

The patch introduces 1 warning in dmesg:
```
[   46.138466] rockchip-pinctrl pinctrl: pin gpio3-28 already requested by leds; cannot claim for ff880000.i2s
[   46.138508] rockchip-i2s: probe of ff880000.i2s failed with error -22
```
Its cause is lack of customisation of i2s in Rock Pi 4's dts and usage of default rk3399 i2s but that's for another PR.

Tested on Rock Pi 4B with latest master.