### PR TITLE
Add eMMC to mainline u-boot device tree for NanoPi Neo Air

### DIFF
--- a/patch/u-boot/u-boot-sunxi/add-nanopi-air-emmc.patch
+++ b/patch/u-boot/u-boot-sunxi/add-nanopi-air-emmc.patch
@@ -1,3 +1,31 @@
+diff --git a/arch/arm/dts/sun8i-h3-nanopi-neo-air.dts b/arch/arm/dts/sun8i-h3-nanopi-neo-air.dts
+index 6246d3e..4f213e1 100644
+--- a/arch/arm/dts/sun8i-h3-nanopi-neo-air.dts
++++ b/arch/arm/dts/sun8i-h3-nanopi-neo-air.dts
+@@ -103,6 +103,23 @@
+ 	};
+ };
+ 
++&mmc2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mmc2_8bit_pins>;
++	vmmc-supply = <&reg_vcc3v3>;
++	bus-width = <8>;
++	non-removable;
++	cap-mmc-hw-reset;
++	status = "okay";
++};
++
++&mmc2_8bit_pins {
++	/* Increase drive strength for DDR modes */
++	drive-strength = <40>;
++	/* eMMC is missing pull-ups */
++	bias-pull-up;
++};
++
+ &uart0 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&uart0_pins_a>;
 diff --git a/configs/nanopi_neo_air_defconfig b/configs/nanopi_neo_air_defconfig
 index 11eb3ab13b..9f83068dd7 100644
 --- a/configs/nanopi_neo_air_defconfig


### PR DESCRIPTION
I noticed that the NanoPi Neo Air does not currently boot when Armbian is installed to the eMMC, because the mainline U-Boot device tree does not include it. I assume this was an oversight when adding the device tree to the u-boot mainline, as it's also not present in the mainline Linux device tree and there is already a similar patch for it in Armbian.

I've added it to the existing patch which currently only modifies the U-Boot device config. I have tested on two of my own devices and booting from the eMMC finally works.