### PR TITLE
Disable ext4 options that don't work with u-boot

### DIFF
--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -302,8 +302,7 @@ prepare_partitions()
 	# parttype[nfs] is empty
 
 	# metadata_csum and 64bit may need to be disabled explicitly when migrating to newer supported host OS releases
-	# TODO: Disable metadata_csum only for older releases (jessie)?
-	if [[ $(lsb_release -sc) == bionic ]]; then
+	if [[ $(lsb_release -sc) =~ bionic|buster|cosmic|disco ]]; then
 		mkopts[ext4]='-q -m 2 -O ^64bit,^metadata_csum'
 	elif [[ $(lsb_release -sc) == xenial ]]; then
 		mkopts[ext4]='-q -m 2'


### PR DESCRIPTION
Disable these mkfs options for all new distros.

Building on Ubuntu 19.04, the board wouldn't boot.
The `64bit` and the `metadata_csum` are enabled by default since Ubuntu 18.04.

Buster and Cosmic are safe guesses, i think these options are default on those systems as well.