### PR TITLE
Odroidn2 - prefix uboot boot_scripts with /boot/ path

### DIFF
--- a/config/boards/odroidn2.csc
+++ b/config/boards/odroidn2.csc
@@ -3,7 +3,11 @@ BOARD_NAME="Odroid N2"
 BOARDFAMILY="odroidn2"
 BOOTCONFIG="odroidn2_config"
 #
-MODULES=""
+MODULES="media_clock firmware"
+if [[ $BUILD_DESKTOP == 'yes' ]]; then
+  MODULES+=" decoder_common stream_input amvdec_avs amvdec_h264 amvdec_h264_4k2k amvdec_mh264 amvdec_h264mvc amvdec_h265 amvdec_mjpeg amvdec_mmjpeg amvdec_mpeg12 amvdec_mpeg4 amvdec_mmpeg4 amvdec_real amvdec_vc1 amvdec_vp9"
+fi
+
 MODULES_NEXT=""
 #
 KERNEL_TARGET="default,dev"

--- a/patch/u-boot/u-boot-odroidn2/fix-boot-scripts-path.patch
+++ b/patch/u-boot/u-boot-odroidn2/fix-boot-scripts-path.patch
@@ -1,0 +1,13 @@
+diff --git a/include/configs/odroid-g12-common.h b/include/configs/odroid-g12-common.h
+index 1539e68..3828642 100644
+--- a/include/configs/odroid-g12-common.h
++++ b/include/configs/odroid-g12-common.h
+@@ -96,7 +96,7 @@
+ 
+ #define ENV_BOOT_ORDER_DEFAULT			"boot_order=mmc rawimage usb pxe spi\0"
+ 
+-#define ENV_BOOTSCRIPTS_DEFAULT			"boot_scripts=boot.ini boot.scr\0"
++#define ENV_BOOTSCRIPTS_DEFAULT			"boot_scripts=boot.ini boot.scr /boot/boot.ini /boot/boot.scr\0"
+ 
+ #define ENV_BOOT_ATTEMPT_DEFAULT			\
+ 	"boot_attempt="					\


### PR DESCRIPTION
Odroidn2 was failing to boot because `boot.ini` was not found

needed u-boot to look for `/boot/boot.ini` rather than `boot.ini`

Fix is backward compatbile with original config of `boot-scripts=boot.ini boot.scr`

working build results:
http://ix.io/1Qrr
