### PR TITLE
Update to use dev kernel 5.3.0-rc4

### DIFF
--- a/config/sources/rk3399.conf
+++ b/config/sources/rk3399.conf
@@ -40,7 +40,7 @@ case $BRANCH in
 
 	dev)
 	KERNELSOURCE='https://github.com/ayufan-rock64/linux-mainline-kernel'
-	KERNELBRANCH='tag:5.2.0-1116-ayufan'
+	KERNELBRANCH='tag:5.3.0-rc4-1118-ayufan'
 	KERNELDIR='linux-rockchip64'
 	KERNELPATCHDIR='rockchip64-dev'
 	LINUXCONFIG='linux-rockchip64-dev'


### PR DESCRIPTION
Tested on NanoPi M4. Boots with the same issues as 5.2.0 (slow initial boot, does not support all video modes, no wi-fi). Doesn't seem any better than 5.2.0 but also doesn't seem any worse.

Corrects build failure referenced in issue #1516.