### PR TITLE
[rockchip64-dev] Bring back power off fix for boards using RK808

### DIFF
--- a/patch/kernel/rockchip64-dev/RK808-use-syscore-for-poweroff.patch
+++ b/patch/kernel/rockchip64-dev/RK808-use-syscore-for-poweroff.patch
@@ -1,0 +1,50 @@
+This patch fixes shutdown power off issues on Rock Pi 4 and probably
+all other boards using RK808 PMIC combined with PSCI.
+
+diff --git a/drivers/mfd/rk808.c b/drivers/mfd/rk808.c
+index 601cefb5c..a57e4bb86 100644
+--- a/drivers/mfd/rk808.c
++++ b/drivers/mfd/rk808.c
+@@ -526,15 +526,24 @@ static void rk8xx_syscore_shutdown(void)
+ 	struct rk808 *rk808 = i2c_get_clientdata(rk808_i2c_client);
+ 	int ret;
+
+-	if (system_state == SYSTEM_POWER_OFF &&
+-	    (rk808->variant == RK809_ID || rk808->variant == RK817_ID)) {
+-		ret = regmap_update_bits(rk808->regmap,
+-					 RK817_SYS_CFG(3),
+-					 RK817_SLPPIN_FUNC_MSK,
+-					 SLPPIN_DN_FUN);
+-		if (ret) {
+-			dev_warn(&rk808_i2c_client->dev,
+-				 "Cannot switch to power down function\n");
++	if (system_state == SYSTEM_POWER_OFF) {
++		switch(rk808->variant) {
++			case RK809_ID:
++			case RK817_ID:
++				ret = regmap_update_bits(rk808->regmap,
++							 RK817_SYS_CFG(3),
++							 RK817_SLPPIN_FUNC_MSK,
++							 SLPPIN_DN_FUN);
++				if (ret) {
++					dev_warn(&rk808_i2c_client->dev,
++						 "Cannot switch to power down function\n");
++				}
++				break;
++			case RK808_ID:
++				rk808_device_shutdown();
++				break;
++			default:
++				break;
+ 		}
+ 	}
+ }
+@@ -616,7 +625,7 @@ static int rk808_probe(struct i2c_client *client,
+ 		nr_pre_init_regs = ARRAY_SIZE(rk808_pre_init_reg);
+ 		cells = rk808s;
+ 		nr_cells = ARRAY_SIZE(rk808s);
+-		rk808->pm_pwroff_fn = rk808_device_shutdown;
++		register_syscore_ops(&rk808_syscore_ops);
+ 		break;
+ 	case RK818_ID:
+ 		rk808->regmap_cfg = &rk818_regmap_config;


### PR DESCRIPTION
Original patch got lost in the commit switching rockchip64's kernel from 5.2 to 5.3-rc4.
It had to be reworked for 5.3 anyway.