### PR TITLE
Replace Etcher with dd + verify, tested under Docker

### DIFF
--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -645,12 +645,6 @@ create_image()
 	# call custom post build hook
 	[[ $(type -t post_build_image) == function ]] && post_build_image "$DEST/images/${version}.img"
 
-	# display warning when we want to write sd card under Docker
-	if [[ `systemd-detect-virt` == 'docker' && -n $CARD_DEVICE ]]; then
-		dd if=/dev/zero of=$CARD_DEVICE count=1 status=none  >/dev/null 2>&1
-		[[ $? -ne 0 ]] && display_alert "Can't write to $CARD_DEVICE" "Enable docker privileged mode in config-docker.conf" "wrn"
-	fi
-
 	# write image to SD card
 	if [[ $(lsblk "$CARD_DEVICE" 2>/dev/null) && -f $DEST/images/${version}.img ]]; then
 
@@ -674,6 +668,9 @@ create_image()
 		else
 			display_alert "Writing failed" "${version}.img" "err"
 		fi
+	elif [[ `systemd-detect-virt` == 'docker' && -n $CARD_DEVICE ]]; then
+		# display warning when we want to write sd card under Docker
+		display_alert "Can't write to $CARD_DEVICE" "Enable docker privileged mode in config-docker.conf" "wrn"
 	fi
 
 } #############################################################################

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -19,7 +19,6 @@
 # prepare_host
 # webseed
 # download_and_verify
-# download_etcher_cli
 
 # cleaning <target>
 #
@@ -723,9 +722,6 @@ prepare_host()
 		fi
 	done
 
-	# download etcher CLI utility
-	download_etcher_cli
-
 	[[ ! -f $USERPATCHES_PATH/customize-image.sh ]] && cp $SRC/config/templates/customize-image.sh.template $USERPATCHES_PATH/customize-image.sh
 
 	if [[ ! -f $USERPATCHES_PATH/README ]]; then
@@ -900,41 +896,6 @@ download_and_verify()
 	fi
 }
 
-
-download_etcher_cli()
-{
-        local url="https://github.com/balena-io/etcher/releases/download/v1.4.8/balena-etcher-cli-1.4.8-linux-x64.tar.gz"
-	local hash="9befa06b68bb5846bcf5a9516785d48d6aaa9364d80a5802deb5b6a968bf5404"
-
-        local filename=${url##*/}
-        local dirname=${filename/.tar.gz/-dist}
-
-	export PATH="$PATH:$SRC/cache/utility/$dirname"
-
-        if [[ -f $SRC/cache/utility/$dirname/.download-complete ]]; then
-                return
-        fi
-
-        cd $SRC/cache/utility/
-
-        display_alert "Downloading" "$dirname"
-        curl -Lf --progress-bar $url -o $filename
-
-        local verified=false
-	local b=$(sha256sum $filename)
-
-        display_alert "Verifying"
-
-        [[ "$hash" == "$(sha256sum $filename | cut -d ' ' -f 1)" ]] && verified=true
-
-        if [[ $verified == true ]]; then
-                display_alert "Extracting"
-                tar --no-same-owner --overwrite -xf $filename && touch $SRC/cache/utility/$dirname/.download-complete && rm $filename
-                display_alert "Download complete" "" "info"
-        else
-                display_alert "Verification failed" "" "wrn"
-        fi
-}
 
 
 


### PR DESCRIPTION
I believe this compare method is good enough to ditch etcher. Under Docker, one have to enable privilege mode. I could not write even exposing devices like we do for loop.