### PR TITLE
Install vagrant-disksize automatically

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,12 +18,8 @@ Vagrant.configure(2) do |config|
     config.vm.box = "ubuntu/bionic64"
     config.vm.box_version = ">= 20180719.0.0"
 
-    #######################################################################
-    # THIS REQUIRES YOU TO INSTALL A PLUGIN. RUN THE COMMAND BELOW...
-    #
-    #   $ vagrant plugin install vagrant-disksize
-    #
     # Default images are not big enough to build Armbian.
+    config.vagrant.plugins = "vagrant-disksize"
     config.disksize.size = "40GB"
 
     # provisioning: install dependencies, download the repository copy

--- a/config-vagrant.conf
+++ b/config-vagrant.conf
@@ -6,14 +6,8 @@
 # remove "vagrant" from the command line since "vagrant-guest" will be passed instead
 shift
 
-# check and install vagrant-disksize
-if ! grep -q '^vagrant-disksize' <(vagrant plugin list); then
-	display_alert "Trying to install vargant-disksize plugin"
-	vagrant plugin install vagrant-disksize
-fi
-
 display_alert "Building and running the Vagrant box"
-vagrant up
+VAGRANT_INSTALL_LOCAL_PLUGINS=1 vagrant up || vagrant up
 
 display_alert "SSH config for the Vagrant box"
 vagrant ssh-config


### PR DESCRIPTION
People will get the following error if they never installed `vagrant-disksize` before.
> Unknown configuration section 'disksize'

By setting `config.vagrant.plugins`<sup>[1]</sup> and `VAGRANT_INSTALL_LOCAL_PLUGINS`<sup>[2]</sup>, Vagrant will install `vagrant-disksize` automatically.

1. https://www.vagrantup.com/docs/vagrantfile/vagrant_settings.html#config-vagrant-plugins
2. https://www.vagrantup.com/docs/other/environmental-variables.html#vagrant_install_local_plugins