### PR TITLE
meson64-dev: build modpost in linux-header postinst script

### DIFF
--- a/patch/kernel/meson64-dev/general-packaging-4.17-dev.patch
+++ b/patch/kernel/meson64-dev/general-packaging-4.17-dev.patch
@@ -22,7 +22,7 @@ index 90c9a8a..3c79b90 100755
 +
 +	# Create postinstall script for headers
 +	if [[ "$1" == *headers* ]]; then
-+		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts >/dev/null 2>&1" >> $pdir/DEBIAN/postinst
++		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts >/dev/null 2>&1; make -s M=scripts/mod/ >/dev/null 2>&1" >> $pdir/DEBIAN/postinst
 +		echo "exit 0" >> $pdir/DEBIAN/postinst
 +		chmod 775 $pdir/DEBIAN/postinst
 +	fi


### PR DESCRIPTION
due to modpost is used by dkms or out-of-tree kernel modules, eg mali
so add this tool to linux-header's postinst script

for #1552

Signed-off-by: Zhang Ning <832666+zhangn1985@users.noreply.github.com>
