### PR TITLE
Config files moved to userpatches

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -31,26 +31,39 @@ else
 	exit 255
 fi
 
-# source build configuration file
-if [[ -n $1 && -f "${SRC}/config-$1.conf" ]]; then
-	display_alert "Using config file" "config-$1.conf" "info"
-	# shellcheck source=/dev/null
-	source "${SRC}/config-$1.conf"
-else
-	# copy default config from the template
-	if [[ ! -f "${SRC}"/config-default.conf ]]; then
-		display_alert "Create example config file using template" "config-default.conf" "info"
-		if [[ ! -f "${SRC}"/config-example.conf ]]; then
-			cp "${SRC}"/config/templates/config-example.conf "${SRC}"/config-example.conf || exit 1
-		fi
-		ln -s config-example.conf "${SRC}"/config-default.conf || exit 1
-	fi
-
-	display_alert "Using config file" "config-default.conf" "info"
-	# shellcheck source=/dev/null
-	source "${SRC}"/config-default.conf
+if [[ -z "$CONFIG" && -n "$1" && -f "${SRC}/userpatches/config-$1.conf" ]]; then
+	CONFIG="userpatches/config-$1.conf"
 fi
-[[ -z "${USERPATCHES_PATH}" ]] && USERPATCHES_PATH="$SRC/userpatches"
+
+if [[ -z "$CONFIG" && -z "$1" && ! -f "${SRC}/userpatches/config-default.conf" ]]; then
+	display_alert "Create example config file using template" "config-default.conf" "info"
+	mkdir -p $SRC/userpatches
+	if [[ ! -f "${SRC}"/userpatches/config-example.conf ]]; then
+		cp "${SRC}"/config/templates/config-example.conf "${SRC}"/userpatches/config-example.conf || exit 1
+	fi
+	ln -s config-example.conf "${SRC}"/userpatches/config-default.conf || exit 1
+fi
+
+if [[ -z "$CONFIG" && -f "${SRC}/userpatches/config-default.conf" ]]; then
+	CONFIG="userpatches/config-default.conf"
+fi
+
+# source build configuration file
+CONFIG_FILE="$(realpath "$CONFIG")"
+if [[ ! -f $CONFIG_FILE ]]; then
+	display_alert "Config file does not exist" "$CONFIG" "error"
+	exit 254
+fi
+
+CONFIG_PATH=$(dirname "$CONFIG_FILE")
+
+display_alert "Using config file" "$CONFIG_FILE" "info"
+pushd $CONFIG_PATH > /dev/null
+# shellcheck source=/dev/null
+source "$CONFIG_FILE"
+popd > /dev/null
+
+[[ -z "${USERPATCHES_PATH}" ]] && USERPATCHES_PATH="$CONFIG_PATH"
 
 if [[ $EUID != 0 ]]; then
 	display_alert "This script requires root privileges, trying to use sudo" "" "wrn"

--- a/compile.sh
+++ b/compile.sh
@@ -36,12 +36,17 @@ if [[ -z "$CONFIG" && -n "$1" && -f "${SRC}/userpatches/config-$1.conf" ]]; then
 fi
 
 if [[ -z "$CONFIG" && -z "$1" && ! -f "${SRC}/userpatches/config-default.conf" ]]; then
-	display_alert "Create example config file using template" "config-default.conf" "info"
 	mkdir -p $SRC/userpatches
-	if [[ ! -f "${SRC}"/userpatches/config-example.conf ]]; then
-		cp "${SRC}"/config/templates/config-example.conf "${SRC}"/userpatches/config-example.conf || exit 1
+	if [[ -f "${SRC}/config-default.conf" ]]; then
+		display_alert "Migrate config file to userpatches directory" "config-default.conf" "info"
+		mv "${SRC}/config-default.conf" "${SRC}/userpatches" || exit 1
+	else
+		display_alert "Create example config file using template" "config-default.conf" "info"
+		if [[ ! -f "${SRC}"/userpatches/config-example.conf ]]; then
+			cp "${SRC}"/config/templates/config-example.conf "${SRC}"/userpatches/config-example.conf || exit 1
+		fi
+		ln -s config-example.conf "${SRC}"/userpatches/config-default.conf || exit 1
 	fi
-	ln -s config-example.conf "${SRC}"/userpatches/config-default.conf || exit 1
 fi
 
 if [[ -z "$CONFIG" && -f "${SRC}/userpatches/config-default.conf" ]]; then


### PR DESCRIPTION
Causes of change:
Config files and userpatches folder are very important information for custom builders.
These files should be put in separated git repository.

1. USERPATCHES folder is detected using CONFIG file location.
You can checkout a few separated userpatches folders (in example: two different repositories or two branches...):
compile.sh CONFIG=userpatches-master/config-default.conf
compile.sh CONFIG=userpatches-dev/config-default.conf
compile.sh CONFIG=/home/mike/blackbox-armbian/config-blackbox.conf

And userpatches will be established based on config folder.

2. Default config file (config-default.conf) is generated in userpatches folder.