### PR TITLE
remove redundant cleanup

### DIFF
--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -688,9 +688,6 @@ process_patch_file()
 	local patch=$1
 	local status=$2
 
-	# detect and remove files which patch will create
-	lsdiff -s --strip=1 $patch | grep '^+' | awk '{print $2}' | xargs -I % sh -c 'rm -f %'
-
 	echo "Processing file $patch" >> $DEST/debug/patching.log
 	patch --batch --silent -p1 -N < $patch >> $DEST/debug/patching.log 2>&1
 


### PR DESCRIPTION
source code cleanup should be done in source update/checkout step.
thus no need redundant cleanup in apply patch step.

Signed-off-by: Zhang Ning <832666+zhangn1985@users.noreply.github.com>