### PR TITLE
Change source path of Vagrant synced folder

### DIFF
--- a/config/templates/Vagrantfile
+++ b/config/templates/Vagrantfile
@@ -43,4 +43,11 @@ Vagrant.configure(2) do |config|
         #vb.memory = "8192"
         #vb.cpus = "4"
     end
+
+    case File.basename(Dir.getwd)
+    when "templates"
+        config.vm.synced_folder "../..", "/vagrant"
+    when "userpatches"
+        config.vm.synced_folder "..", "/vagrant"
+    end
 end


### PR DESCRIPTION
Change `config.vm.synced_folder`<sup>[1]</sup> due to changed Vagrantfile location.

1. https://www.vagrantup.com/docs/vagrantfile/machine_settings.html#config-vm-synced_folder