### PR TITLE
Install Vagrant when not installed

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -37,8 +37,9 @@ fi
 
 # Check for Vagrant
 if [[ "$1" == vagrant && -z "$(which vagrant)" ]]; then
-        display_alert "Vagrant not installed." "Install manually!" "err"
-        exit $?
+	display_alert "Vagrant not installed." "Installing"
+	sudo apt-get update
+	sudo apt-get install -y vagrant virtualbox
 fi
 
 # Install Docker if not there but wanted


### PR DESCRIPTION
Install Vagrant on Ubuntu 18.04. It could be tested with the following steps.

```
$ sudo docker run --privileged --device /dev/vboxdrv -it ubuntu:bionic

# apt update
# apt install vagrant virtualbox
# vagrant init ubuntu/bionic64
# vagrant up
# vagrant ssh
```