### PR TITLE
[fix] Add a patch made to fix ethernet for pine64+with dev kernel (5.3.X)

### DIFF
--- a/patch/kernel/sunxi-dev/0001-arm64-pine64-plus-add-PHY-regulator-delay.patch
+++ b/patch/kernel/sunxi-dev/0001-arm64-pine64-plus-add-PHY-regulator-delay.patch
@@ -1,0 +1,33 @@
+From bb0516f4d03ffe9bcc06f840e477ea665af94e9d Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@siol.net>
+Date: Sun, 25 Aug 2019 14:40:10 +0200
+Subject: [PATCH] arm64: dts: allwinner: a64: pine64-plus: Add PHY regulator
+ delay
+
+Depending on kernel and bootloader configuration, it's possible that
+Realtek ethernet PHY isn't powered on properly. It needs some time
+before it can be used.
+
+Fix that by adding 100ms ramp delay to regulator responsible for
+powering PHY.
+
+Fixes: 94dcfdc77fc5 ("arm64: allwinner: pine64-plus: Enable dwmac-sun8i")
+Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>
+---
+ arch/arm64/boot/dts/allwinner/sun50i-a64-pine64-plus.dts | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-a64-pine64-plus.dts b/arch/arm64/boot/dts/allwinner/sun50i-a64-pine64-plus.dts
+index 24f1aac366d6..9612a34c1762 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-a64-pine64-plus.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-a64-pine64-plus.dts
+@@ -63,3 +63,7 @@
+                reg = <1>;
+        };
+ };
++
++&reg_dc1sw {
++       regulator-enable-ramp-delay = <100000>;
++};
+--
+2.23.0


### PR DESCRIPTION
This PR fix a PHY detection problem with 5.3.X kernel with pine64+

This patch is not mine, it comes from https://github.com/LibreELEC/LibreELEC.tv/blob/9d68e4ba191d7b0bd319e1e254610917e69526e0/projects/Allwinner/devices/A64/patches/linux/03_pine64_plus_ethernet_fixes.patch and is written by Jernej Skrabec.

The patch filename has a length > 40 characters, I can rename it if needed but we'll lose important information IMHO.

I can attach a build log showing that it work if needed.
  