### PR TITLE
fix shell script execute after su

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -76,7 +76,7 @@ echo update_src >> $TMPFILE
 #due to in docker/VM, we can't su to a normal user, so do not update/checkout git.
 if [[ `systemd-detect-virt` == 'none' ]]; then
 	if [[ $EUID == 0 ]]; then
-		su `stat --format=%U $SRC/.git` -c bash $TMPFILE
+		su `stat --format=%U $SRC/.git` -c "bash $TMPFILE"
 	else
 		bash $TMPFILE
 	fi


### PR DESCRIPTION
`su xxx -c bash a.sh`
it will execute like `su xxx -c bash` and ignore a.sh

in order to do right way

`su xxx -c "bash a.sh"`

Signed-off-by: Zhang Ning <832666+zhangn1985@users.noreply.github.com>

