### PR TITLE
[meson64-dev] Fix to clock properties in sound node for various meson64-dev boards,…

### DIFF
--- a/patch/kernel/meson64-dev/4-0009-ARM64-dts-meson-activate-hdmi-audio-HDMI-enabled-boa.patch
+++ b/patch/kernel/meson64-dev/4-0009-ARM64-dts-meson-activate-hdmi-audio-HDMI-enabled-boa.patch
@@ -12,26 +12,12 @@ the audio I expect to see merged
 
 Signed-off-by: Jerome Brunet <jbrunet@baylibre.com>
 Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>
----
- .../boot/dts/amlogic/meson-gx-p23x-q20x.dtsi  | 37 +++++++++++++++++++
- .../boot/dts/amlogic/meson-gxbb-nanopi-k2.dts | 37 +++++++++++++++++++
- .../dts/amlogic/meson-gxbb-nexbox-a95x.dts    | 37 +++++++++++++++++++
- .../boot/dts/amlogic/meson-gxbb-odroidc2.dts  | 37 +++++++++++++++++++
- .../boot/dts/amlogic/meson-gxbb-p20x.dtsi     | 37 +++++++++++++++++++
- .../boot/dts/amlogic/meson-gxbb-wetek.dtsi    | 37 +++++++++++++++++++
- .../amlogic/meson-gxl-s905x-khadas-vim.dts    | 37 +++++++++++++++++++
- .../amlogic/meson-gxl-s905x-libretech-cc.dts  | 37 +++++++++++++++++++
- .../amlogic/meson-gxl-s905x-nexbox-a95x.dts   | 37 +++++++++++++++++++
- .../boot/dts/amlogic/meson-gxl-s905x-p212.dts | 37 +++++++++++++++++++
- .../dts/amlogic/meson-gxm-khadas-vim2.dts     | 37 +++++++++++++++++++
- .../boot/dts/amlogic/meson-gxm-nexbox-a1.dts  | 37 +++++++++++++++++++
- 12 files changed, 444 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-gx-p23x-q20x.dtsi b/arch/arm64/boot/dts/amlogic/meson-gx-p23x-q20x.dtsi
-index a9b778571cf5..2b5af81c1be0 100644
+index a9b778571..332ac5627 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-gx-p23x-q20x.dtsi
 +++ b/arch/arm64/boot/dts/amlogic/meson-gx-p23x-q20x.dtsi
-@@ -102,6 +102,35 @@
+@@ -102,6 +102,34 @@
  			};
  		};
  	};
@@ -39,6 +25,13 @@ index a9b778571cf5..2b5af81c1be0 100644
 +	sound {
 +		compatible = "simple-audio-card";
 +		simple-audio-card,name = "meson-gx-audio";
++		assigned-clocks = <&clkc CLKID_MPLL2>,
++						<&clkc CLKID_MPLL0>,
++						<&clkc CLKID_MPLL1>;
++		assigned-clock-parents = <0>, <0>, <0>;
++		assigned-clock-rates = <294912000>,
++					   <270950400>,
++					   <393216000>;
 +
 +		simple-audio-card,dai-link@0 {
 +			/* HDMI Output */
@@ -46,14 +39,6 @@ index a9b778571cf5..2b5af81c1be0 100644
 +			mclk-fs = <256>;
 +			bitclock-master = <&aiu_i2s>;
 +			frame-master = <&aiu_i2s>;
-+
-+			assigned-clocks = <&clkc CLKID_MPLL2>,
-+					  <&clkc CLKID_MPLL0>,
-+					  <&clkc CLKID_MPLL1>;
-+			assigned-clock-parents = <0>, <0>, <0>;
-+			assigned-clock-rates = <294912000>,
-+					       <270950400>,
-+					       <393216000>;
 +
 +			cpu {
 +				sound-dai = <&aiu_i2s>;
@@ -67,7 +52,7 @@ index a9b778571cf5..2b5af81c1be0 100644
  };
  
  &cec_AO {
-@@ -111,6 +140,14 @@
+@@ -111,6 +139,14 @@
  	hdmi-phandle = <&hdmi_tx>;
  };
  
@@ -83,16 +68,23 @@ index a9b778571cf5..2b5af81c1be0 100644
  	cvbs_vdac_out: endpoint {
  		remote-endpoint = <&cvbs_connector_in>;
 diff --git a/arch/arm64/boot/dts/amlogic/meson-gxbb-nanopi-k2.dts b/arch/arm64/boot/dts/amlogic/meson-gxbb-nanopi-k2.dts
-index c34c1c90ccb6..319e3433b0c5 100644
+index c34c1c90c..99ca661da 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-gxbb-nanopi-k2.dts
 +++ b/arch/arm64/boot/dts/amlogic/meson-gxbb-nanopi-k2.dts
-@@ -88,6 +88,35 @@
+@@ -88,6 +88,34 @@
  		clock-names = "ext_clock";
  	};
  
 +	sound {
 +		compatible = "simple-audio-card";
 +		simple-audio-card,name = "meson-gx-audio";
++		assigned-clocks = <&clkc CLKID_MPLL2>,
++					  <&clkc CLKID_MPLL0>,
++					  <&clkc CLKID_MPLL1>;
++		assigned-clock-parents = <0>, <0>, <0>;
++		assigned-clock-rates = <294912000>,
++					   <270950400>,
++					   <393216000>;
 +
 +		simple-audio-card,dai-link@0 {
 +			/* HDMI Output */
@@ -100,14 +92,6 @@ index c34c1c90ccb6..319e3433b0c5 100644
 +			mclk-fs = <256>;
 +			bitclock-master = <&aiu_i2s>;
 +			frame-master = <&aiu_i2s>;
-+
-+			assigned-clocks = <&clkc CLKID_MPLL2>,
-+					  <&clkc CLKID_MPLL0>,
-+					  <&clkc CLKID_MPLL1>;
-+			assigned-clock-parents = <0>, <0>, <0>;
-+			assigned-clock-rates = <294912000>,
-+					       <270950400>,
-+					       <393216000>;
 +
 +			cpu {
 +				sound-dai = <&aiu_i2s>;
@@ -122,7 +106,7 @@ index c34c1c90ccb6..319e3433b0c5 100644
  	vcc1v8: regulator-vcc1v8 {
  		compatible = "regulator-fixed";
  		regulator-name = "VCC1.8V";
-@@ -131,6 +160,14 @@
+@@ -131,6 +159,14 @@
  	};
  };
  
@@ -138,16 +122,23 @@ index c34c1c90ccb6..319e3433b0c5 100644
  	status = "okay";
  	pinctrl-0 = <&ao_cec_pins>;
 diff --git a/arch/arm64/boot/dts/amlogic/meson-gxbb-nexbox-a95x.dts b/arch/arm64/boot/dts/amlogic/meson-gxbb-nexbox-a95x.dts
-index b636912a2715..df8bd01a58b2 100644
+index b636912a2..61307f72a 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-gxbb-nexbox-a95x.dts
 +++ b/arch/arm64/boot/dts/amlogic/meson-gxbb-nexbox-a95x.dts
-@@ -119,6 +119,35 @@
+@@ -119,6 +119,34 @@
  		clock-names = "ext_clock";
  	};
  
 +	sound {
 +		compatible = "simple-audio-card";
 +		simple-audio-card,name = "meson-gx-audio";
++		assigned-clocks = <&clkc CLKID_MPLL2>,
++					  <&clkc CLKID_MPLL0>,
++					  <&clkc CLKID_MPLL1>;
++		assigned-clock-parents = <0>, <0>, <0>;
++		assigned-clock-rates = <294912000>,
++					   <270950400>,
++					   <393216000>;
 +
 +		simple-audio-card,dai-link@0 {
 +			/* HDMI Output */
@@ -155,14 +146,6 @@ index b636912a2715..df8bd01a58b2 100644
 +			mclk-fs = <256>;
 +			bitclock-master = <&aiu_i2s>;
 +			frame-master = <&aiu_i2s>;
-+
-+			assigned-clocks = <&clkc CLKID_MPLL2>,
-+					  <&clkc CLKID_MPLL0>,
-+					  <&clkc CLKID_MPLL1>;
-+			assigned-clock-parents = <0>, <0>, <0>;
-+			assigned-clock-rates = <294912000>,
-+					       <270950400>,
-+					       <393216000>;
 +
 +			cpu {
 +				sound-dai = <&aiu_i2s>;
@@ -177,7 +160,7 @@ index b636912a2715..df8bd01a58b2 100644
  	cvbs-connector {
  		compatible = "composite-video-connector";
  
-@@ -154,6 +183,14 @@
+@@ -154,6 +182,14 @@
  	hdmi-phandle = <&hdmi_tx>;
  };
  
@@ -193,10 +176,10 @@ index b636912a2715..df8bd01a58b2 100644
  	status = "okay";
  	pinctrl-0 = <&eth_rmii_pins>;
 diff --git a/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts b/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts
-index 9972b1515da6..ba39856497ba 100644
+index 9972b1515..68fc42bf5 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts
 +++ b/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts
-@@ -110,6 +110,35 @@
+@@ -110,6 +110,34 @@
  			};
  		};
  	};
@@ -204,6 +187,13 @@ index 9972b1515da6..ba39856497ba 100644
 +	sound {
 +		compatible = "simple-audio-card";
 +		simple-audio-card,name = "meson-gx-audio";
++		assigned-clocks = <&clkc CLKID_MPLL2>,
++					  <&clkc CLKID_MPLL0>,
++					  <&clkc CLKID_MPLL1>;
++		assigned-clock-parents = <0>, <0>, <0>;
++		assigned-clock-rates = <294912000>,
++					   <270950400>,
++					   <393216000>;
 +
 +		simple-audio-card,dai-link@0 {
 +			/* HDMI Output */
@@ -211,14 +201,6 @@ index 9972b1515da6..ba39856497ba 100644
 +			mclk-fs = <256>;
 +			bitclock-master = <&aiu_i2s>;
 +			frame-master = <&aiu_i2s>;
-+
-+			assigned-clocks = <&clkc CLKID_MPLL2>,
-+					  <&clkc CLKID_MPLL0>,
-+					  <&clkc CLKID_MPLL1>;
-+			assigned-clock-parents = <0>, <0>, <0>;
-+			assigned-clock-rates = <294912000>,
-+					       <270950400>,
-+					       <393216000>;
 +
 +			cpu {
 +				sound-dai = <&aiu_i2s>;
@@ -232,7 +214,7 @@ index 9972b1515da6..ba39856497ba 100644
  };
  
  &cec_AO {
-@@ -119,6 +148,14 @@
+@@ -119,6 +147,14 @@
  	hdmi-phandle = <&hdmi_tx>;
  };
  
@@ -248,10 +230,10 @@ index 9972b1515da6..ba39856497ba 100644
  	status = "okay";
  	pinctrl-0 = <&eth_rgmii_pins>;
 diff --git a/arch/arm64/boot/dts/amlogic/meson-gxbb-p20x.dtsi b/arch/arm64/boot/dts/amlogic/meson-gxbb-p20x.dtsi
-index e8f925871edf..44af6eb34095 100644
+index e8f925871..830efebb2 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-gxbb-p20x.dtsi
 +++ b/arch/arm64/boot/dts/amlogic/meson-gxbb-p20x.dtsi
-@@ -113,6 +113,35 @@
+@@ -113,6 +113,34 @@
  			};
  		};
  	};
@@ -259,6 +241,13 @@ index e8f925871edf..44af6eb34095 100644
 +	sound {
 +		compatible = "simple-audio-card";
 +		simple-audio-card,name = "meson-gx-audio";
++		assigned-clocks = <&clkc CLKID_MPLL2>,
++				  <&clkc CLKID_MPLL0>,
++				  <&clkc CLKID_MPLL1>;
++		assigned-clock-parents = <0>, <0>, <0>;
++		assigned-clock-rates = <294912000>,
++				   <270950400>,
++				   <393216000>;
 +
 +		simple-audio-card,dai-link@0 {
 +			/* HDMI Output */
@@ -266,14 +255,6 @@ index e8f925871edf..44af6eb34095 100644
 +			mclk-fs = <256>;
 +			bitclock-master = <&aiu_i2s>;
 +			frame-master = <&aiu_i2s>;
-+
-+			assigned-clocks = <&clkc CLKID_MPLL2>,
-+					  <&clkc CLKID_MPLL0>,
-+					  <&clkc CLKID_MPLL1>;
-+			assigned-clock-parents = <0>, <0>, <0>;
-+			assigned-clock-rates = <294912000>,
-+					       <270950400>,
-+					       <393216000>;
 +
 +			cpu {
 +				sound-dai = <&aiu_i2s>;
@@ -287,7 +268,7 @@ index e8f925871edf..44af6eb34095 100644
  };
  
  &cec_AO {
-@@ -122,6 +151,14 @@
+@@ -122,6 +150,14 @@
  	hdmi-phandle = <&hdmi_tx>;
  };
  
@@ -303,10 +284,10 @@ index e8f925871edf..44af6eb34095 100644
  	cvbs_vdac_out: endpoint {
  		remote-endpoint = <&cvbs_connector_in>;
 diff --git a/arch/arm64/boot/dts/amlogic/meson-gxbb-wetek.dtsi b/arch/arm64/boot/dts/amlogic/meson-gxbb-wetek.dtsi
-index 4c539881fbb7..71fa43425e4e 100644
+index 4c539881f..dfe26b589 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-gxbb-wetek.dtsi
 +++ b/arch/arm64/boot/dts/amlogic/meson-gxbb-wetek.dtsi
-@@ -112,6 +112,43 @@
+@@ -112,6 +112,42 @@
  			};
  		};
  	};
@@ -314,6 +295,13 @@ index 4c539881fbb7..71fa43425e4e 100644
 +	sound {
 +		compatible = "simple-audio-card";
 +		simple-audio-card,name = "meson-gx-audio";
++		assigned-clocks = <&clkc CLKID_MPLL2>,
++					  <&clkc CLKID_MPLL0>,
++					  <&clkc CLKID_MPLL1>;
++		assigned-clock-parents = <0>, <0>, <0>;
++		assigned-clock-rates = <294912000>,
++					   <270950400>,
++					   <393216000>;
 +
 +		simple-audio-card,dai-link@0 {
 +			/* HDMI Output */
@@ -321,14 +309,6 @@ index 4c539881fbb7..71fa43425e4e 100644
 +			mclk-fs = <256>;
 +			bitclock-master = <&aiu_i2s>;
 +			frame-master = <&aiu_i2s>;
-+
-+			assigned-clocks = <&clkc CLKID_MPLL2>,
-+					  <&clkc CLKID_MPLL0>,
-+					  <&clkc CLKID_MPLL1>;
-+			assigned-clock-parents = <0>, <0>, <0>;
-+			assigned-clock-rates = <294912000>,
-+					       <270950400>,
-+					       <393216000>;
 +
 +			cpu {
 +				sound-dai = <&aiu_i2s>;
@@ -351,10 +331,10 @@ index 4c539881fbb7..71fa43425e4e 100644
  
  &cec_AO {
 diff --git a/arch/arm64/boot/dts/amlogic/meson-gxl-s905x-khadas-vim.dts b/arch/arm64/boot/dts/amlogic/meson-gxl-s905x-khadas-vim.dts
-index 5499e8de5c74..dad31d67dabc 100644
+index 5499e8de5..ced95e86d 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-gxl-s905x-khadas-vim.dts
 +++ b/arch/arm64/boot/dts/amlogic/meson-gxl-s905x-khadas-vim.dts
-@@ -65,6 +65,35 @@
+@@ -65,6 +65,34 @@
  			};
  		};
  	};
@@ -362,6 +342,13 @@ index 5499e8de5c74..dad31d67dabc 100644
 +	sound {
 +		compatible = "simple-audio-card";
 +		simple-audio-card,name = "meson-gx-audio";
++		assigned-clocks = <&clkc CLKID_MPLL2>,
++				  <&clkc CLKID_MPLL0>,
++				  <&clkc CLKID_MPLL1>;
++		assigned-clock-parents = <0>, <0>, <0>;
++		assigned-clock-rates = <294912000>,
++				   <270950400>,
++				   <393216000>;
 +
 +		simple-audio-card,dai-link@0 {
 +			/* HDMI Output */
@@ -369,14 +356,6 @@ index 5499e8de5c74..dad31d67dabc 100644
 +			mclk-fs = <256>;
 +			bitclock-master = <&aiu_i2s>;
 +			frame-master = <&aiu_i2s>;
-+
-+			assigned-clocks = <&clkc CLKID_MPLL2>,
-+					  <&clkc CLKID_MPLL0>,
-+					  <&clkc CLKID_MPLL1>;
-+			assigned-clock-parents = <0>, <0>, <0>;
-+			assigned-clock-rates = <294912000>,
-+					       <270950400>,
-+					       <393216000>;
 +
 +			cpu {
 +				sound-dai = <&aiu_i2s>;
@@ -390,7 +369,7 @@ index 5499e8de5c74..dad31d67dabc 100644
  };
  
  &cec_AO {
-@@ -74,6 +103,14 @@
+@@ -74,6 +102,14 @@
  	hdmi-phandle = <&hdmi_tx>;
  };
  
@@ -406,16 +385,23 @@ index 5499e8de5c74..dad31d67dabc 100644
  	status = "okay";
  	pinctrl-0 = <&hdmi_hpd_pins>, <&hdmi_i2c_pins>;
 diff --git a/arch/arm64/boot/dts/amlogic/meson-gxl-s905x-libretech-cc.dts b/arch/arm64/boot/dts/amlogic/meson-gxl-s905x-libretech-cc.dts
-index 4b8ce738e213..36a4fa76b528 100644
+index 4b8ce738e..f18b22b64 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-gxl-s905x-libretech-cc.dts
 +++ b/arch/arm64/boot/dts/amlogic/meson-gxl-s905x-libretech-cc.dts
-@@ -84,6 +84,35 @@
+@@ -84,6 +84,34 @@
  		regulator-always-on;
  	};
  
 +	sound {
 +		compatible = "simple-audio-card";
 +		simple-audio-card,name = "meson-gx-audio";
++		assigned-clocks = <&clkc CLKID_MPLL2>,
++					  <&clkc CLKID_MPLL0>,
++					  <&clkc CLKID_MPLL1>;
++		assigned-clock-parents = <0>, <0>, <0>;
++		assigned-clock-rates = <294912000>,
++					   <270950400>,
++					   <393216000>;
 +
 +		simple-audio-card,dai-link@0 {
 +			/* HDMI Output */
@@ -423,14 +409,6 @@ index 4b8ce738e213..36a4fa76b528 100644
 +			mclk-fs = <256>;
 +			bitclock-master = <&aiu_i2s>;
 +			frame-master = <&aiu_i2s>;
-+
-+			assigned-clocks = <&clkc CLKID_MPLL2>,
-+					  <&clkc CLKID_MPLL0>,
-+					  <&clkc CLKID_MPLL1>;
-+			assigned-clock-parents = <0>, <0>, <0>;
-+			assigned-clock-rates = <294912000>,
-+					       <270950400>,
-+					       <393216000>;
 +
 +			cpu {
 +				sound-dai = <&aiu_i2s>;
@@ -445,7 +423,7 @@ index 4b8ce738e213..36a4fa76b528 100644
  	vcc_3v3: regulator-vcc_3v3 {
  		compatible = "regulator-fixed";
  		regulator-name = "VCC_3V3";
-@@ -132,6 +161,14 @@
+@@ -132,6 +160,14 @@
  	hdmi-phandle = <&hdmi_tx>;
  };
  
@@ -461,10 +439,10 @@ index 4b8ce738e213..36a4fa76b528 100644
  	cvbs_vdac_out: endpoint {
  		remote-endpoint = <&cvbs_connector_in>;
 diff --git a/arch/arm64/boot/dts/amlogic/meson-gxl-s905x-nexbox-a95x.dts b/arch/arm64/boot/dts/amlogic/meson-gxl-s905x-nexbox-a95x.dts
-index 26907ac82930..68a2d896bddd 100644
+index 26907ac82..3c779e33a 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-gxl-s905x-nexbox-a95x.dts
 +++ b/arch/arm64/boot/dts/amlogic/meson-gxl-s905x-nexbox-a95x.dts
-@@ -102,6 +102,35 @@
+@@ -102,6 +102,34 @@
  			};
  		};
  	};
@@ -472,6 +450,13 @@ index 26907ac82930..68a2d896bddd 100644
 +	sound {
 +		compatible = "simple-audio-card";
 +		simple-audio-card,name = "meson-gx-audio";
++		assigned-clocks = <&clkc CLKID_MPLL2>,
++					  <&clkc CLKID_MPLL0>,
++					  <&clkc CLKID_MPLL1>;
++		assigned-clock-parents = <0>, <0>, <0>;
++		assigned-clock-rates = <294912000>,
++					   <270950400>,
++					   <393216000>;
 +
 +		simple-audio-card,dai-link@0 {
 +			/* HDMI Output */
@@ -479,14 +464,6 @@ index 26907ac82930..68a2d896bddd 100644
 +			mclk-fs = <256>;
 +			bitclock-master = <&aiu_i2s>;
 +			frame-master = <&aiu_i2s>;
-+
-+			assigned-clocks = <&clkc CLKID_MPLL2>,
-+					  <&clkc CLKID_MPLL0>,
-+					  <&clkc CLKID_MPLL1>;
-+			assigned-clock-parents = <0>, <0>, <0>;
-+			assigned-clock-rates = <294912000>,
-+					       <270950400>,
-+					       <393216000>;
 +
 +			cpu {
 +				sound-dai = <&aiu_i2s>;
@@ -500,7 +477,7 @@ index 26907ac82930..68a2d896bddd 100644
  };
  
  &cec_AO {
-@@ -111,6 +140,14 @@
+@@ -111,6 +139,14 @@
  	hdmi-phandle = <&hdmi_tx>;
  };
  
@@ -516,10 +493,10 @@ index 26907ac82930..68a2d896bddd 100644
  	cvbs_vdac_out: endpoint {
  		remote-endpoint = <&cvbs_connector_in>;
 diff --git a/arch/arm64/boot/dts/amlogic/meson-gxl-s905x-p212.dts b/arch/arm64/boot/dts/amlogic/meson-gxl-s905x-p212.dts
-index 2602940c2077..1b0ee78d29bd 100644
+index 2602940c2..23336f2f2 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-gxl-s905x-p212.dts
 +++ b/arch/arm64/boot/dts/amlogic/meson-gxl-s905x-p212.dts
-@@ -32,6 +32,35 @@
+@@ -32,6 +32,34 @@
  			};
  		};
  	};
@@ -527,6 +504,13 @@ index 2602940c2077..1b0ee78d29bd 100644
 +	sound {
 +		compatible = "simple-audio-card";
 +		simple-audio-card,name = "meson-gx-audio";
++		assigned-clocks = <&clkc CLKID_MPLL2>,
++					  <&clkc CLKID_MPLL0>,
++					  <&clkc CLKID_MPLL1>;
++		assigned-clock-parents = <0>, <0>, <0>;
++		assigned-clock-rates = <294912000>,
++					   <270950400>,
++					   <393216000>;
 +
 +		simple-audio-card,dai-link@0 {
 +			/* HDMI Output */
@@ -534,14 +518,6 @@ index 2602940c2077..1b0ee78d29bd 100644
 +			mclk-fs = <256>;
 +			bitclock-master = <&aiu_i2s>;
 +			frame-master = <&aiu_i2s>;
-+
-+			assigned-clocks = <&clkc CLKID_MPLL2>,
-+					  <&clkc CLKID_MPLL0>,
-+					  <&clkc CLKID_MPLL1>;
-+			assigned-clock-parents = <0>, <0>, <0>;
-+			assigned-clock-rates = <294912000>,
-+					       <270950400>,
-+					       <393216000>;
 +
 +			cpu {
 +				sound-dai = <&aiu_i2s>;
@@ -555,7 +531,7 @@ index 2602940c2077..1b0ee78d29bd 100644
  };
  
  &cec_AO {
-@@ -41,6 +70,14 @@
+@@ -41,6 +69,14 @@
  	hdmi-phandle = <&hdmi_tx>;
  };
  
@@ -571,16 +547,23 @@ index 2602940c2077..1b0ee78d29bd 100644
  	cvbs_vdac_out: endpoint {
  		remote-endpoint = <&cvbs_connector_in>;
 diff --git a/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts b/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts
-index 989d33ac6eae..0fbac2df77e6 100644
+index 989d33ac6..1610d5872 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts
 +++ b/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts
-@@ -82,6 +82,35 @@
+@@ -82,6 +82,34 @@
  		};
  	};
  
 +	sound {
 +		compatible = "simple-audio-card";
 +		simple-audio-card,name = "meson-gx-audio";
++		assigned-clocks = <&clkc CLKID_MPLL2>,
++					  <&clkc CLKID_MPLL0>,
++					  <&clkc CLKID_MPLL1>;
++		assigned-clock-parents = <0>, <0>, <0>;
++		assigned-clock-rates = <294912000>,
++					   <270950400>,
++					   <393216000>;
 +
 +		simple-audio-card,dai-link@0 {
 +			/* HDMI Output */
@@ -588,14 +571,6 @@ index 989d33ac6eae..0fbac2df77e6 100644
 +			mclk-fs = <256>;
 +			bitclock-master = <&aiu_i2s>;
 +			frame-master = <&aiu_i2s>;
-+
-+			assigned-clocks = <&clkc CLKID_MPLL2>,
-+					  <&clkc CLKID_MPLL0>,
-+					  <&clkc CLKID_MPLL1>;
-+			assigned-clock-parents = <0>, <0>, <0>;
-+			assigned-clock-rates = <294912000>,
-+					       <270950400>,
-+					       <393216000>;
 +
 +			cpu {
 +				sound-dai = <&aiu_i2s>;
@@ -610,7 +585,7 @@ index 989d33ac6eae..0fbac2df77e6 100644
  	pwmleds {
  		compatible = "pwm-leds";
  
-@@ -198,6 +227,14 @@
+@@ -198,6 +226,14 @@
  	hdmi-phandle = <&hdmi_tx>;
  };
  
@@ -626,10 +601,10 @@ index 989d33ac6eae..0fbac2df77e6 100644
  	#cooling-cells = <2>;
  };
 diff --git a/arch/arm64/boot/dts/amlogic/meson-gxm-nexbox-a1.dts b/arch/arm64/boot/dts/amlogic/meson-gxm-nexbox-a1.dts
-index c2bd4dbbf38c..e708247ee77b 100644
+index c2bd4dbbf..1cfba0cc2 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-gxm-nexbox-a1.dts
 +++ b/arch/arm64/boot/dts/amlogic/meson-gxm-nexbox-a1.dts
-@@ -75,6 +75,35 @@
+@@ -75,6 +75,34 @@
  			};
  		};
  	};
@@ -637,6 +612,13 @@ index c2bd4dbbf38c..e708247ee77b 100644
 +	sound {
 +		compatible = "simple-audio-card";
 +		simple-audio-card,name = "meson-gx-audio";
++		assigned-clocks = <&clkc CLKID_MPLL2>,
++					  <&clkc CLKID_MPLL0>,
++					  <&clkc CLKID_MPLL1>;
++		assigned-clock-parents = <0>, <0>, <0>;
++		assigned-clock-rates = <294912000>,
++					   <270950400>,
++					   <393216000>;
 +
 +		simple-audio-card,dai-link@0 {
 +			/* HDMI Output */
@@ -644,14 +626,6 @@ index c2bd4dbbf38c..e708247ee77b 100644
 +			mclk-fs = <256>;
 +			bitclock-master = <&aiu_i2s>;
 +			frame-master = <&aiu_i2s>;
-+
-+			assigned-clocks = <&clkc CLKID_MPLL2>,
-+					  <&clkc CLKID_MPLL0>,
-+					  <&clkc CLKID_MPLL1>;
-+			assigned-clock-parents = <0>, <0>, <0>;
-+			assigned-clock-rates = <294912000>,
-+					       <270950400>,
-+					       <393216000>;
 +
 +			cpu {
 +				sound-dai = <&aiu_i2s>;
@@ -665,7 +639,7 @@ index c2bd4dbbf38c..e708247ee77b 100644
  };
  
  &cec_AO {
-@@ -84,6 +113,14 @@
+@@ -84,6 +112,14 @@
  	hdmi-phandle = <&hdmi_tx>;
  };
  
@@ -680,6 +654,3 @@ index c2bd4dbbf38c..e708247ee77b 100644
  &cvbs_vdac_port {
  	cvbs_vdac_out: endpoint {
  		remote-endpoint = <&cvbs_connector_in>;
--- 
-2.20.1
-


### PR DESCRIPTION
… thus enabling sound

Changed patch 4-0009... because some clock nodes were in the wrong place. 
HDMI sound should now work on those boards.