### PR TITLE
Add /userpatches to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ ubuntu-*-cloudimg-console.log
 /output/
 /cache/
 /*userpatches*/
+/userpatches
 
 ### General annoyances ###
 .DS_Store


### PR DESCRIPTION
If userpatches is a symlink, then it will not be ignored. This adds /userpatches to .gitignore so it is properly ignored.
