### PR TITLE
add postrotate to ramlog

### DIFF
--- a/packages/bsp/common/etc/systemd/system/logrotate.service
+++ b/packages/bsp/common/etc/systemd/system/logrotate.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=Rotate log files
+Documentation=man:logrotate(8) man:logrotate.conf(5)
+ConditionACPower=true
+
+[Service]
+Type=oneshot
+ExecStartPre=/usr/lib/armbian/armbian-ramlog write
+ExecStart=/usr/sbin/logrotate /etc/logrotate.conf
+ExecStartPost=/usr/lib/armbian/armbian-ramlog postrotate
+
+# performance options
+Nice=19
+IOSchedulingClass=best-effort
+IOSchedulingPriority=7
+
+# hardening options
+#  details: https://www.freedesktop.org/software/systemd/man/systemd.exec.html
+#  no ProtectHome for userdir logs
+#  no PrivateNetwork for mail deliviery
+#  no ProtectKernelTunables for working SELinux with systemd older than 235
+#  no MemoryDenyWriteExecute for gzip on i686
+PrivateDevices=true
+PrivateTmp=true
+ProtectControlGroups=true
+ProtectKernelModules=true
+ProtectSystem=full
+RestrictRealtime=true

--- a/packages/bsp/common/usr/lib/armbian/armbian-ramlog
+++ b/packages/bsp/common/usr/lib/armbian/armbian-ramlog
@@ -46,7 +46,7 @@ syncToDisk () {
 	echo -e "\n\n$(date): Syncing logs to storage\n" | $LOG_OUTPUT
 
 	if [ "$USE_RSYNC" = true ]; then
-		${NoCache} rsync -aXWv --delete --exclude "lost+found" --exclude armbian-ramlog.log --links $RAM_LOG $HDD_LOG 2>&1 | $LOG_OUTPUT
+		${NoCache} rsync -aXWv --exclude "lost+found" --exclude armbian-ramlog.log --links $RAM_LOG $HDD_LOG 2>&1 | $LOG_OUTPUT
 	else
 		${NoCache} cp -rfup $RAM_LOG -T $HDD_LOG 2>&1 | $LOG_OUTPUT
 	fi

--- a/packages/bsp/common/usr/lib/armbian/armbian-ramlog
+++ b/packages/bsp/common/usr/lib/armbian/armbian-ramlog
@@ -112,6 +112,14 @@ case "$1" in
 	write)
 		syncToDisk
 		;;
+	postrotate)
+		cd /var/log.hdd/
+		find . -type f -print | grep -E -v "(\.gz|\.xz|\.[0-9]|armbian-ramlog)" | while IFS= read -r  file
+		do
+	    		dest="/var/log/$file"
+	    		cat $file > $dest	    
+		done
+		;;
 	*)
 		echo "Usage: ${0##*/} {start|stop|write}" >&2
 		exit 1

--- a/packages/bsp/common/usr/lib/armbian/armbian-ramlog
+++ b/packages/bsp/common/usr/lib/armbian/armbian-ramlog
@@ -60,7 +60,7 @@ syncFromDisk () {
 	echo -e "\n\n$(date): Loading logs from storage\n" | $LOG_OUTPUT
 
 	if [ "$USE_RSYNC" = true ]; then
-		${NoCache} rsync -aXWv --delete --exclude "lost+found" --exclude armbian-ramlog.log --exclude *.gz --exclude='*.[0-9]' --links $HDD_LOG $RAM_LOG 2>&1 | $LOG_OUTPUT
+		${NoCache} rsync -aXWv --delete --exclude "lost+found" --exclude armbian-ramlog.log --exclude *.gz --exclude *.xz --exclude='*.[0-9]' --links $HDD_LOG $RAM_LOG 2>&1 | $LOG_OUTPUT
 	else
 		${NoCache} find $HDD_LOG* -maxdepth 1 -type f -not \( -name '*.[0-9]' -or -name '*.xz*' -or -name '*.gz' \) | xargs cp -ut $RAM_LOG
 	fi


### PR DESCRIPTION
Improve armbian-ramlog. See discussion here :
https://github.com/armbian/build/issues/1582

The edit of armbian-ramlog adds the postrotate action to sync back /var/log/ after rotating /var/log.hdd
The new logrotate.service in /etc/systemd/system will get precedence over the standard file in /lib/systemd/system. 
The new lines will synchronize log and log.hdd before and after rotation. 