### PR TITLE
[pine64lts] - add board PINE A64-LTS

### DIFF
--- a/config/boards/pine64lts.conf
+++ b/config/boards/pine64lts.conf
@@ -1,0 +1,9 @@
+# A64 quad core 2GB RAM SoC GBE
+BOARD_NAME="PINE A64-LTS"
+BOARDFAMILY="sun50iw1"
+BOOTCONFIG_DEFAULT="sun50iw1p1_config"
+BOOTCONFIG="pine64-lts_defconfig"
+MODULES="sunxi_codec sunxi_i2s sunxi_sndcodec 8723bs"
+MODULES_NEXT=""
+KERNEL_TARGET="default,next,dev"
+FULL_DESKTOP="yes"


### PR DESCRIPTION
Hi,

The purpose of the pull request is to add the board PINE A64-LTS.
PINE A64-LTS and SoPine A64 (`config/boards/pine64so.conf`) are somehow the same.

I've been able to build and test the following image:

- Armbian_5.98_Pine64lts_Debian_stretch_next_4.19.79_desktop.img
- Armbian_5.98_Pine64lts_Debian_stretch_next_4.19.79_minimal.img
- Armbian_5.98_Pine64lts_Ubuntu_bionic_next_4.19.80.img
- Armbian_5.98_Pine64lts_Ubuntu_bionic_next_4.19.80_desktop.img
- Armbian_5.98_Pine64lts_Ubuntu_bionic_next_4.19.80_minimal.img

The tests are covering:
- boot on emmc
- Ethernet
- HDMI (audio+video)

Best regards