### PR TITLE
repair wifi on nanopi duo

### DIFF
--- a/patch/kernel/sunxi-next/board-h2plus-nanopi-duo-add-device.patch
+++ b/patch/kernel/sunxi-next/board-h2plus-nanopi-duo-add-device.patch
@@ -1,8 +1,8 @@
 diff --git a/arch/arm/boot/dts/Makefile b/arch/arm/boot/dts/Makefile
-index 27440439..47f4946d 100644
+index 99cf49a..977b6ff 100644
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -1008,6 +1008,7 @@ dtb-$(CONFIG_MACH_SUN8I) += \
+@@ -1030,6 +1030,7 @@ dtb-$(CONFIG_MACH_SUN8I) += \
  	sun8i-a83t-tbs-a711.dtb \
  	sun8i-h2-plus-bananapi-m2-zero.dtb \
  	sun8i-h2-plus-libretech-all-h3-cc.dtb \
@@ -12,7 +12,7 @@ index 27440439..47f4946d 100644
  	sun8i-h2-plus-sunvell-r69.dtb \
 diff --git a/arch/arm/boot/dts/sun8i-h2-plus-nanopi-duo.dts b/arch/arm/boot/dts/sun8i-h2-plus-nanopi-duo.dts
 new file mode 100644
-index 0000000..040f99f
+index 0000000..2b31b8f
 --- /dev/null
 +++ b/arch/arm/boot/dts/sun8i-h2-plus-nanopi-duo.dts
 @@ -0,0 +1,164 @@
@@ -106,7 +106,7 @@ index 0000000..040f99f
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&wifi_en_npi>;
 +		reset-gpios = <&pio 6 13 GPIO_ACTIVE_LOW>;  // PG13 WL_RESTN
-+		post-power-on-delay-ms = <50>;
++		post-power-on-delay-ms = <200>;
 +	};
 +};
 +


### PR DESCRIPTION
this board lost wifi (see https://forum.armbian.com/topic/8101-nanopi-duo-no-wifi-with-lastest-ubuntu/) a year ago.
Increasing the post-power-on-delay-ms from 50ms to 200ms (in line with other xradio boards) fixes this issue.

