### PR TITLE
fix xradio driver & nanopi-duo for dev-branch (5.3.7)

### DIFF
--- a/patch/kernel/sunxi-dev/board-h2plus-nanopi-duo-add-device.patch
+++ b/patch/kernel/sunxi-dev/board-h2plus-nanopi-duo-add-device.patch
@@ -1,8 +1,8 @@
 diff --git a/arch/arm/boot/dts/Makefile b/arch/arm/boot/dts/Makefile
-index 27440439..47f4946d 100644
+index 99cf49a..977b6ff 100644
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -1008,6 +1008,7 @@ dtb-$(CONFIG_MACH_SUN8I) += \
+@@ -1030,6 +1030,7 @@ dtb-$(CONFIG_MACH_SUN8I) += \
  	sun8i-a83t-tbs-a711.dtb \
  	sun8i-h2-plus-bananapi-m2-zero.dtb \
  	sun8i-h2-plus-libretech-all-h3-cc.dtb \
@@ -12,7 +12,7 @@ index 27440439..47f4946d 100644
  	sun8i-h2-plus-sunvell-r69.dtb \
 diff --git a/arch/arm/boot/dts/sun8i-h2-plus-nanopi-duo.dts b/arch/arm/boot/dts/sun8i-h2-plus-nanopi-duo.dts
 new file mode 100644
-index 0000000..040f99f
+index 0000000..2b31b8f
 --- /dev/null
 +++ b/arch/arm/boot/dts/sun8i-h2-plus-nanopi-duo.dts
 @@ -0,0 +1,164 @@
@@ -106,7 +106,7 @@ index 0000000..040f99f
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&wifi_en_npi>;
 +		reset-gpios = <&pio 6 13 GPIO_ACTIVE_LOW>;  // PG13 WL_RESTN
-+		post-power-on-delay-ms = <50>;
++		post-power-on-delay-ms = <200>;
 +	};
 +};
 +

--- a/patch/kernel/sunxi-dev/wifi-add-xradio.patch
+++ b/patch/kernel/sunxi-dev/wifi-add-xradio.patch
@@ -1,18 +1,20 @@
 diff --git a/drivers/net/wireless/Kconfig b/drivers/net/wireless/Kconfig
-index 3d1ffcb..bed2537 100644
+index b84d8a3..7779c1d 100644
 --- a/drivers/net/wireless/Kconfig
 +++ b/drivers/net/wireless/Kconfig
-@@ -49,4 +49,5 @@ source "drivers/net/wireless/realtek/Kconfig"
- source "drivers/net/wireless/rtl8188eu/Kconfig"
- source "drivers/net/wireless/rtl8812au/Kconfig"
+@@ -48,6 +48,7 @@ source "drivers/net/wireless/realtek/Kconfig"
+ source "drivers/net/wireless/rsi/Kconfig"
+ source "drivers/net/wireless/st/Kconfig"
+ source "drivers/net/wireless/ti/Kconfig"
 +source "drivers/net/wireless/xradio/Kconfig"
  source "drivers/net/wireless/zydas/Kconfig"
  source "drivers/net/wireless/quantenna/Kconfig"
+ 
 diff --git a/drivers/net/wireless/Makefile b/drivers/net/wireless/Makefile
-index d0fbe9c..2442af0 100644
+index 1681dbc..ab14e53 100644
 --- a/drivers/net/wireless/Makefile
 +++ b/drivers/net/wireless/Makefile
-@@ -18,6 +18,7 @@ obj-$(CONFIG_WLAN_VENDOR_REALTEK) += realtek/
+@@ -21,6 +21,7 @@ obj-$(CONFIG_WLAN_VENDOR_REALTEK) += realtek/
  obj-$(CONFIG_WLAN_VENDOR_RSI) += rsi/
  obj-$(CONFIG_WLAN_VENDOR_ST) += st/
  obj-$(CONFIG_WLAN_VENDOR_TI) += ti/
@@ -26,20 +28,23 @@ index 0000000..4f8fc9c
 Binary files /dev/null and b/drivers/net/wireless/xradio/.7z differ
 diff --git a/drivers/net/wireless/xradio/Kconfig b/drivers/net/wireless/xradio/Kconfig
 new file mode 100644
-index 0000000..18d1e2b
+index 0000000..d3925ec
 --- /dev/null
 +++ b/drivers/net/wireless/xradio/Kconfig
-@@ -0,0 +1,46 @@
+@@ -0,0 +1,49 @@
++# SPDX-License-Identifier: GPL-2.0-only
++
 +config WLAN_VENDOR_XRADIO
 +       tristate "XRADIO WLAN support"
 +       depends on MAC80211
-+       default m
-+       help
++       default y
++	---help---
++	  If you have a wireless card belonging to this class, say Y.
 +
-+         This is an experimental driver for the XRADIO chip-set.
-+         Enabling this option enables the generic driver without
-+         any platform support.
-+         Please select the appropriate platform below.
++	  Note that the answer to this question doesn't directly affect the
++	  kernel: saying N will just cause the configurator to skip all
++	  the questions about cards. If you say Y, you will be asked for
++	  your specific card in the following questions.
 +
 +if WLAN_VENDOR_XRADIO
 +
@@ -75,7 +80,7 @@ index 0000000..18d1e2b
 +	  Say Y if you want to include XR extensions
 +	  If unsure, say Y.
 +
-+endif
++endif # WLAN_VENDOR_XRADIO
 diff --git a/drivers/net/wireless/xradio/LICENSE b/drivers/net/wireless/xradio/LICENSE
 new file mode 100644
 index 0000000..23cb790
@@ -423,10 +428,12 @@ index 0000000..23cb790
 +Public License instead of this License.
 diff --git a/drivers/net/wireless/xradio/Makefile b/drivers/net/wireless/xradio/Makefile
 new file mode 100644
-index 0000000..80a9a14
+index 0000000..3e7e5ed
 --- /dev/null
 +++ b/drivers/net/wireless/xradio/Makefile
-@@ -0,0 +1,54 @@
+@@ -0,0 +1,57 @@
++# SPDX-License-Identifier: GPL-2.0-only
++
 +# Standalone Makefile - uncomment for out-of-tree compilation
 +#CONFIG_WLAN_VENDOR_XRADIO := m
 +#CONFIG_XRADIO_USE_EXTENSIONS := y
@@ -479,7 +486,8 @@ index 0000000..80a9a14
 +#ccflags-$(CONFIG_WLAN_VENDOR_XRADIO) += -DDEBUG
 +#ccflags-$(CONFIG_WLAN_VENDOR_XRADIO) += -DXRADIO_DISABLE_HW_CRYPTO
 +
-+ldflags-$(CONFIG_WLAN_VENDOR_XRADIO) += --strip-debug
++# <5.3>
++#ldflags-$(CONFIG_WLAN_VENDOR_XRADIO) += --strip-debug
 +
 diff --git a/drivers/net/wireless/xradio/ap.c b/drivers/net/wireless/xradio/ap.c
 new file mode 100644
@@ -2182,7 +2190,7 @@ index 0000000..9d55fb8
 +#endif
 diff --git a/drivers/net/wireless/xradio/bh.c b/drivers/net/wireless/xradio/bh.c
 new file mode 100644
-index 0000000..5b53778
+index 0000000..7666329
 --- /dev/null
 +++ b/drivers/net/wireless/xradio/bh.c
 @@ -0,0 +1,836 @@
@@ -2962,7 +2970,7 @@ index 0000000..5b53778
 +		} else if (!status) {
 +			/* check if there is data waiting but we missed the interrupt*/
 +			if (xradio_bh_rx_availlen(hw_priv) > 0) {
-+				dev_warn(hw_priv->pdev, "missed interrupt\n");
++				dev_warn(hw_priv->pdev, "missed interrupt!\n");
 +				if(xradio_bh_exchange(hw_priv) < 0){
 +					break;
 +				}
@@ -7278,7 +7286,7 @@ index 0000000..d6b64ce
 +#endif /* XRADIO_QUEUE_H_INCLUDED */
 diff --git a/drivers/net/wireless/xradio/rx.c b/drivers/net/wireless/xradio/rx.c
 new file mode 100644
-index 0000000..fb8be92
+index 0000000..5a1ce60
 --- /dev/null
 +++ b/drivers/net/wireless/xradio/rx.c
 @@ -0,0 +1,414 @@
@@ -7469,7 +7477,7 @@ index 0000000..fb8be92
 +			hdr->flag |= RX_FLAG_MMIC_ERROR;
 +		} else if (arg->status == WSM_STATUS_NO_KEY_FOUND) {
 +			dev_warn(priv->hw_priv->pdev, "received frame has no key status\n");
-+			//goto drop;
++			goto drop;
 +		} else {
 +			dev_err(priv->hw_priv->pdev, "[RX] IF=%d, Receive failure: %d.\n",
 +				priv->if_id, arg->status);

--- a/patch/u-boot/u-boot-sunxi/add-nanopi-duo.patch
+++ b/patch/u-boot/u-boot-sunxi/add-nanopi-duo.patch
@@ -1,6 +1,6 @@
 diff --git a/configs/nanopi_duo_defconfig b/configs/nanopi_duo_defconfig
 new file mode 100644
-index 0000000..1e51018
+index 0000000..7917596
 --- /dev/null
 +++ b/configs/nanopi_duo_defconfig
 @@ -0,0 +1,21 @@
@@ -26,12 +26,12 @@ index 0000000..1e51018
 +CONFIG_USB_EHCI_HCD=y
 +CONFIG_SYS_USB_EVENT_POLL_VIA_INT_QUEUE=y
 diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
-index 4f8ca34..019ac0b 100644
+index b6091f3..112cdfc 100755
 --- a/arch/arm/dts/Makefile
 +++ b/arch/arm/dts/Makefile
-@@ -312,6 +312,7 @@ dtb-$(CONFIG_MACH_SUN8I_A83T) += \
- 	sun8i-a83t-sinovoip-bpi-m3.dtb
- dtb-$(CONFIG_MACH_SUN8I_H3) += \
+@@ -438,6 +438,7 @@ dtb-$(CONFIG_MACH_SUN8I_H3) += \
+ 	sun8i-h2-plus-libretech-all-h3-cc.dtb \
+ 	sun8i-h2-plus-orangepi-r1.dtb \
  	sun8i-h2-plus-orangepi-zero.dtb \
 +	sun8i-h2-plus-nanopi-duo.dtb \
  	sun8i-h3-bananapi-m2-plus.dtb \
@@ -39,7 +39,7 @@ index 4f8ca34..019ac0b 100644
  	sun8i-h3-orangepi-lite.dtb \
 diff --git a/arch/arm/dts/sun8i-h2-plus-nanopi-duo.dts b/arch/arm/dts/sun8i-h2-plus-nanopi-duo.dts
 new file mode 100644
-index 0000000..b6afe20
+index 0000000..6280346
 --- /dev/null
 +++ b/arch/arm/dts/sun8i-h2-plus-nanopi-duo.dts
 @@ -0,0 +1,98 @@
@@ -94,8 +94,8 @@ index 0000000..b6afe20
 +#include <dt-bindings/pinctrl/sun4i-a10.h>
 +
 +/ {
-+	model = "FriendlyARM NanoPi DUO Air";
-+	compatible = "friendlyarm,nanopi-duo-air", "allwinner,sun8i-h3";
++	model = "FriendlyARM NanoPi DUO";
++	compatible = "friendlyarm,nanopi-duo", "allwinner,sun8i-h3";
 +
 +	aliases {
 +		serial0 = &uart0;


### PR DESCRIPTION
a) patch "wifi-add-xradio.patch": fix KConfig to 5.x [dev-branch]
	WLAN_VENDOR-flag set to "y" in line with other drivers.
b) patch "board-h2plus-nanopi-duo-add-device.patch": increase post-power-on-delay-ms 
	from 50ms to 200ms in wifi_pwrseq node in nanopi-duo dts [dev-branch]
	Change in line with other XRADIO device trees (orange pi zero, sunvell).
	See also Pull Request #1605
c) patch "add-nanopi-duo.patch": change nodes "model" and "compatible" to correct
	device name (from "NanoPi Duo AIR" to "NanoPi Duo") [dev-branch]
	Not functionally necessary, but more correct.