### PR TITLE
lib/main.sh: allow correctly use of 'head' in BRANCH reference.

### DIFF
--- a/lib/main.sh
+++ b/lib/main.sh
@@ -366,9 +366,13 @@ fi
 compile_sunxi_tools
 install_rkbin_tools
 
-BOOTSOURCEDIR=$BOOTDIR/${BOOTBRANCH##*:}
-LINUXSOURCEDIR=$KERNELDIR/${KERNELBRANCH##*:}
-[[ -n $ATFSOURCE ]] && ATFSOURCEDIR=$ATFDIR/${ATFBRANCH##*:}
+branch2dir() {
+	[[ $1 == head ]] && echo HEAD || echo ${1##*:}
+}
+
+BOOTSOURCEDIR=$BOOTDIR/$(branch2dir ${BOOTBRANCH})
+LINUXSOURCEDIR=$KERNELDIR/$(branch2dir ${KERNELBRANCH})
+[[ -n $ATFSOURCE ]] && ATFSOURCEDIR=$ATFDIR/$(branch2dir ${ATFBRANCH})
 
 # define package names
 DEB_BRANCH=${BRANCH//default}


### PR DESCRIPTION
In fetch_from_repo() from general.sh, when ref uses `head` as value, the ref_name
will be set to `HEAD`, which is later used as a subdir:

    local workdir=$dir/$ref_name

This commit makes the directories consistent with the workdir above.
