### PR TITLE
Docker: add docker shell support

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -31,7 +31,7 @@ fi
 
 if [[ $EUID == 0 ]] || [[ "$1" == vagrant ]]; then
 	:
-elif [[ "$1" == docker || "$1" == dockerpurge ]] && grep -q `whoami` <(getent group docker); then
+elif [[ "$1" == docker || "$1" == dockerpurge || "$1" == docker-shell ]] && grep -q `whoami` <(getent group docker); then
 	:
 else
 	display_alert "This script requires root privileges, trying to use sudo" "" "wrn"
@@ -91,6 +91,20 @@ if [[ "$1" == vagrant && -z "$(which vagrant)" ]]; then
 	sudo apt-get install -y vagrant virtualbox
 fi
 
+if [[ "$1" == dockerpurge && -f /etc/debian_version ]]; then
+	display_alert "Purging Armbian Docker containers" "" "wrn"
+	docker container ls -a | grep armbian | awk '{print $1}' | xargs docker container rm &> /dev/null
+	docker image ls | grep armbian | awk '{print $3}' | xargs docker image rm &> /dev/null
+	shift
+	set -- "docker" "$@"
+fi
+
+if [[ "$1" == docker-shell ]]; then
+	shift
+	SHELL_ONLY=yes
+	set -- "docker" "$@"
+fi
+
 # Install Docker if not there but wanted. We cover only Debian based distro install. Else, manual Docker install is needed
 if [[ "$1" == docker && -f /etc/debian_version && -z "$(which docker)" ]]; then
 	display_alert "Docker not installed." "Installing" "Info"
@@ -110,16 +124,6 @@ if [[ "$1" == docker && -f /etc/debian_version && -z "$(which docker)" ]]; then
 	apt-get install -y -qq --no-install-recommends docker-ce
 	display_alert "Add yourself to docker group to avoid root privileges" "" "wrn"
 	"$SRC/compile.sh" "$@"
-	exit $?
-fi
-
-if [[ "$1" == dockerpurge && -f /etc/debian_version ]]; then
-	display_alert "Purging Armbian Docker containers" "" "wrn"
-	docker container ls -a | grep armbian | awk '{print $1}' | xargs docker container rm &> /dev/null
-	docker image ls | grep armbian | awk '{print $3}' | xargs docker image rm &> /dev/null
-	shift
-	arr=("docker" "$@")
-	"$SRC/compile.sh" ${arr[@]}
 	exit $?
 fi
 

--- a/config/templates/config-docker.conf
+++ b/config/templates/config-docker.conf
@@ -5,13 +5,7 @@
 
 [[ ! -c /dev/loop-control ]] && display_alert "/dev/loop-control does not exist, image building may not work" "" "wrn"
 
-# remove "docker" from the command line since "docker-guest" will be passed instead
-shift
-
 # second argument can be a build parameter or a config file
-unset DOCKER_CONF
-[[ $1 != *=* ]] && DOCKER_CONF=$1
-
 # create user accessible directories and set their owner group and permissions
 # if they are created from Docker they will be owned by root and require root permissions to change/delete
 mkdir -p $SRC/{output,userpatches}
@@ -27,7 +21,7 @@ else
   if ! docker build -t armbian:$VERSION . ; then
     STATUS=$?
     # Adding a newline, so the alert won't be shown in the same line as the error
-    echo 
+    echo
     display_alert "Docker container build exited with code: " "$STATUS" "err"
     exit 1
   fi
@@ -86,8 +80,31 @@ DOCKER_FLAGS+=(-e COLUMNS="`tput cols`" -e LINES="`tput lines`")
 
 # pass other command line arguments like KERNEL_ONLY=yes, KERNEL_CONFIGURE=yes, etc.
 # pass "docker-guest" as an additional config name that will be sourced in the container if exists
-display_alert "Running the container" "" "info"
-docker run "${DOCKER_FLAGS[@]}" -it armbian:$VERSION $DOCKER_CONF "$@"
+if [[ $SHELL_ONLY == yes ]]; then
+  display_alert "Running the container in shell mode" "" "info"
+  cat <<\EOF
+Welcome to the docker shell of Armbian.
+
+To build the whole thing using default profile, run:
+    ./compile.sh
+
+To build the U-Boot only, run:
+    # Optional: prepare the environment first if you had not run `./compile.sh`
+    ./compile.sh 'prepare_host && compile_sunxi_tools && install_rkbin_tools'
+
+    # build the U-Boot only
+    ./compile.sh compile_uboot
+
+If you prefer to use profile, for example, `userpatches/config-my.conf`,  try:
+    ./compile.sh my 'prepare_host && compile_sunxi_tools && install_rkbin_tools'
+    ./compile.sh my compile_uboot
+
+EOF
+  docker run "${DOCKER_FLAGS[@]}" -it --rm --entrypoint /usr/bin/env armbian:$VERSION "$@" /bin/bash
+else
+  display_alert "Running the container" "" "info"
+  docker run "${DOCKER_FLAGS[@]}" -it --rm armbian:$VERSION "$@"
+fi
 
 # Docker error treatment
 STATUS=$?


### PR DESCRIPTION
This allows to enter the docker container in a shell by:

     ./compile.sh docker-shell \
         BOARD=firefly-rk3399 BRANCH=dev RELEASE=bionic BUILD_DESKTOP=no

Then one can run any function defined in the compile.sh script.

For example, to compile the `U-Boot`, prepare the environment first with:

    ./compile.sh default prepare_host compile_sunxi_tools install_rkbin_tools

Then build U-Boot for example:

    ./compile.sh default compile_uboot

To compile only the source code as it is without patching, run:

    ./compile.sh default COMPILE_ONLY=yes compile_uboot

Note that you must enter docker-shell after a docker build, which will
download all the required toolchains and sourcecodes first.
