### PR TITLE
T/upstream roc rk3399 pc

### DIFF
--- a/config/boards/roc-rk3399-pc.csc
+++ b/config/boards/roc-rk3399-pc.csc
@@ -1,0 +1,14 @@
+# RK3399 hexa core 4GB DDR4 SoC eMMC GBE USB3
+BOARD_NAME="ROC-RK3399-PC"
+BOARDFAMILY="rk3399"
+BOOTCONFIG="roc-rk3399-pc_defconfig"
+#
+MODULES=""
+MODULES_NEXT=""
+#
+KERNEL_TARGET="default,dev"
+CLI_TARGET="buster,bionic:default"
+DESKTOP_TARGET="buster,bionic:default"
+#
+CLI_BETA_TARGET="buster,bionic:dev"
+DESKTOP_BETA_TARGET=""

--- a/config/sources/rk3399.conf
+++ b/config/sources/rk3399.conf
@@ -5,7 +5,17 @@ OFFSET=16
 BOOTSCRIPT='boot-rockchip64.cmd:boot.cmd'
 BOOTENV_FILE='rockchip-default.txt'
 
-UBOOT_TARGET_MAP="BL31=$SRC/cache/sources/rkbin-tools/rk33/rk3399_bl31_v1.30.elf idbloader.img u-boot.itb;;idbloader.img u-boot.itb"
+if [[ $BOARD == roc-rk3399-pc ]]; then
+	ATF_USE_MAINLINE=yes
+fi
+
+if [[ $ATF_USE_MAINLINE == yes ]]; then
+	BL31=bl31.bin
+else
+	BL31=$SRC/cache/sources/rkbin-tools/rk33/rk3399_bl31_v1.30.elf
+fi
+
+UBOOT_TARGET_MAP="BL31=$BL31 idbloader.img u-boot.itb;;idbloader.img u-boot.itb"
 UBOOT_USE_GCC='> 7.0'
 
 BOOTSOURCE='https://github.com/u-boot/u-boot.git'
@@ -17,6 +27,15 @@ BOOTDELAY=0
 
 OVERLAY_PREFIX='rockchip'
 SERIALCON='ttyFIQ0:1500000'
+
+if [[ $ATF_USE_MAINLINE == yes ]]; then
+	ATFSOURCE='https://github.com/ARM-software/arm-trusted-firmware'
+	ATFDIR='arm-trusted-firmware'
+	ATFBRANCH='branch:master'
+	ATF_USE_GCC='> 6.3'
+	ATF_TARGET_MAP='M0_CROSS_COMPILE=arm-linux-gnueabi- PLAT=rk3399 bl31;;build/rk3399/release/bl31/bl31.elf:bl31.bin'
+	ATF_TOOLCHAIN2="arm-linux-gnueabi-:> 5.0"
+fi
 
 CPUMIN="600000"
 CPUMAX="2016000"

--- a/config/sources/rk3399.conf
+++ b/config/sources/rk3399.conf
@@ -95,6 +95,7 @@ family_tweaks()
 	[[ $BOARD == nanopineo4 ]] && echo "fdtfile=rockchip/rk3399-nanopi4-rev04.dtb" >> $SDCARD/boot/armbianEnv.txt
 	[[ $BOARD == orangepi-rk3399 ]] && echo "fdtfile=rockchip/rk3399-orangepi.dtb" >> $SDCARD/boot/armbianEnv.txt
 	[[ $BOARD == firefly-rk3399 ]] && echo "fdtfile=rockchip/rk3399-firefly.dtb" >> $SDCARD/boot/armbianEnv.txt
+	[[ $BOARD == roc-rk3399-pc ]] && echo "fdtfile=rockchip/rk3399-roc-pc.dtb" >> $SDCARD/boot/armbianEnv.txt
 	# install and enable Bluetooth
 	chroot $SDCARD /bin/bash -c "apt-get -y -qq install rfkill bluetooth bluez bluez-tools"
 	chroot $SDCARD /bin/bash -c "systemctl --no-reload enable rk3399-bluetooth.service >/dev/null 2>&1"

--- a/config/templates/customize-image.sh.template
+++ b/config/templates/customize-image.sh.template
@@ -187,7 +187,7 @@ InstallOpenMediaVault() {
 		bananapim3|nanopifire3|nanopct3plus|nanopim3)
 			HMP_Fix='; taskset -c -p 4-7 $i '
 			;;
-		edge*|ficus|firefly-rk3399|nanopct4|nanopim4|nanopineo4|renegade-elite|rockpro64)
+		edge*|ficus|firefly-rk3399|nanopct4|nanopim4|nanopineo4|renegade-elite|roc-rk3399-pc|rockpro64)
 			HMP_Fix='; taskset -c -p 4-5 $i '
 			;;
 	esac

--- a/patch/kernel/rk3399-default/firefly-dts.patch
+++ b/patch/kernel/rk3399-default/firefly-dts.patch
@@ -2,17 +2,16 @@ diff --git a/arch/arm64/boot/dts/rockchip/Makefile b/arch/arm64/boot/dts/rockchi
 index 244272a3..8da63ea9 100644
 --- a/arch/arm64/boot/dts/rockchip/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/Makefile
-@@ -4,8 +4,8 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += \
- 	rk3399-nanopi4-rev01.dtb \
- 	rk3399-nanopi4-rev04.dtb \
+@@ -7,7 +7,8 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += \
  	rk3399-nanopi4-rev06.dtb \
--	rk3399-nanopi4-rev21.dtb
--
-+	rk3399-nanopi4-rev21.dtb \
+ 	rk3399-nanopi4-rev07.dtb \
+ 	rk3399-nanopi4-rev21.dtb \
+-	rk3399-nanopi4-rev22.dtb
++	rk3399-nanopi4-rev22.dtb \
 +	rk3399-firefly.dtb
+
  else
- 
- dtb-$(CONFIG_ARCH_ROCKCHIP) += px30-evb-ddr3-v10.dtb
+
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-firefly-linux.dts b/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts
 similarity index 85%
 rename from arch/arm64/boot/dts/rockchip/rk3399-firefly-linux.dts

--- a/patch/kernel/rk3399-default/roc-rk3399-pc.patch
+++ b/patch/kernel/rk3399-default/roc-rk3399-pc.patch
@@ -1,0 +1,1567 @@
+--- a/arch/arm64/boot/dts/rockchip/Makefile
++++ b/arch/arm64/boot/dts/rockchip/Makefile
+@@ -8,7 +8,8 @@
+ 	rk3399-nanopi4-rev07.dtb \
+ 	rk3399-nanopi4-rev21.dtb \
+ 	rk3399-nanopi4-rev22.dtb \
+-	rk3399-firefly.dtb
++	rk3399-firefly.dtb \
++	rk3399-roc-pc.dtb
+ 
+ else
+ 
+@@ -109,6 +110,7 @@
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-gru-kevin-r1.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-mid-818-android-6.0.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-mid-818-android.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-roc-pc.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-rock960-ab.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-rockpro64.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-rv1-android.dtb
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3399-roc-pc-exp.dts
+@@ -0,0 +1,20 @@
++/dts-v1/;
++#include "rk3399-roc-pc.dtsi"
++
++/ {
++	model = "Firefly roc-rk3399-pc";
++	compatible = "firefly,roc-rk3399-pc", "rockchip,rk3399";
++};
++
++&wireless_wlan {
++	status = "okay";
++};
++
++&wireless_bluetooth {
++	status = "okay";
++};
++
++&usb_charge {
++	status = "okay";
++};
++
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3399-roc-pc-mipi.dts
+@@ -0,0 +1,78 @@
++/dts-v1/;
++#include "rk3399-roc-pc.dtsi"
++
++/ {
++	model = "Firefly roc-rk3399-pc";
++	compatible = "firefly,roc-rk3399-pc", "rockchip,rk3399";
++
++};
++
++&pinctrl {
++	vcc_dis {
++		vcc_dis_en0: vcc-dis-en0 {
++			rockchip,pins =
++				<2 6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++};
++
++//mipi
++&dsi {
++	status = "okay";
++	//status = "okay";
++	dsi_panel: panel {
++		compatible ="simple-panel-dsi";
++		reg = <0>;
++		backlight = <&backlight>;
++		power-supply = <&vcc_lcd>;
++		dsi,flags = <(MIPI_DSI_MODE_VIDEO | MIPI_DSI_MODE_VIDEO_BURST)>;
++		dsi,format = <MIPI_DSI_FMT_RGB888>;
++		bus-format = <MEDIA_BUS_FMT_RGB666_1X18>;
++		dsi,lanes = <4>;
++		reset-delay-ms = <20>;
++		init-delay-ms = <20>;
++		enable-delay-ms = <120>;
++		prepare-delay-ms = <120>;
++		status = "okay";
++
++		panel-init-sequence = [
++			05 20 01 29
++			05 96 01 11
++		];
++
++		panel-exit-sequence = [
++			05 05 01 28
++			05 78 01 10
++		];
++
++		disp_timings: display-timings {
++			native-mode = <&timing0>;
++
++			timing0: timing0 {
++				clock-frequency = <80000000>;
++				hactive = <768>;
++				vactive = <1024>;
++				hsync-len = <20>;
++				hback-porch = <110>;
++				hfront-porch = <170>;
++				vsync-len = <40>;
++				vback-porch = <130>;
++				vfront-porch = <136>;
++				hsync-active = <0>;
++				vsync-active = <0>;
++				de-active = <0>;
++				pixelclk-active = <0>;
++			};
++		};
++	};
++};
++
++//TF
++&gsl3680 {
++	status = "okay";
++};
++
++//boot logo for MIPI screen
++&route_dsi {
++	status = "disabled";
++};
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3399-roc-pc.dts
+@@ -0,0 +1,7 @@
++/dts-v1/;
++#include "rk3399-roc-pc.dtsi"
++
++/ {
++	model = "Firefly roc-rk3399-pc";
++	compatible = "firefly,roc-rk3399-pc", "rockchip,rk3399";
++};
+\ No newline at end of file
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3399-roc-pc.dtsi
+@@ -0,0 +1,1419 @@
++#include "dt-bindings/pwm/pwm.h"
++#include "rk3399.dtsi"
++#include "rk3399-opp.dtsi"
++#include "rk3399-linux.dtsi"
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/display/media-bus-format.h>
++//#include "include/uapi/drm/drm_mode.h"
++
++/ {
++	compatible = "firefly,roc-rk3399-pc", "rockchip,rk3399";
++
++	backlight: backlight {
++		status = "okay";
++		compatible = "pwm-backlight";
++		pwms = <&pwm1 0 25000 0>;
++		brightness-levels = <
++			  0   1   2   3   4   5   6   7
++			  8   9  10  11  12  13  14  15
++			 16  17  18  19  20  21  22  23
++			 24  25  26  27  28  29  30  31
++			 32  33  34  35  36  37  38  39
++			 40  41  42  43  44  45  46  47
++			 48  49  50  51  52  53  54  55
++			 56  57  58  59  60  61  62  63
++			 64  65  66  67  68  69  70  71
++			 72  73  74  75  76  77  78  79
++			 80  81  82  83  84  85  86  87
++			 88  89  90  91  92  93  94  95
++			 96  97  98  99 100 101 102 103
++			104 105 106 107 108 109 110 111
++			112 113 114 115 116 117 118 119
++			120 121 122 123 124 125 126 127
++			128 129 130 131 132 133 134 135
++			136 137 138 139 140 141 142 143
++			144 145 146 147 148 149 150 151
++			152 153 154 155 156 157 158 159
++			160 161 162 163 164 165 166 167
++			168 169 170 171 172 173 174 175
++			176 177 178 179 180 181 182 183
++			184 185 186 187 188 189 190 191
++			192 193 194 195 196 197 198 199
++			200 201 202 203 204 205 206 207
++			208 209 210 211 212 213 214 215
++			216 217 218 219 220 221 222 223
++			224 225 226 227 228 229 230 231
++			232 233 234 235 236 237 238 239
++			240 241 242 243 244 245 246 247
++			248 249 250 251 252 253 254 255>;
++		default-brightness-level = <200>;
++	};
++
++	/* first 64k(0xff8c0000~0xff8d0000) for ddr and suspend */
++
++	iram: sram@ff8d0000 {
++		compatible = "mmio-sram";
++		reg = <0x0 0xff8d0000 0x0 0x20000>; /* 128k */
++	};
++
++	clkin_gmac: external-gmac-clock {
++		compatible = "fixed-clock";
++		clock-frequency = <125000000>;
++		clock-output-names = "clkin_gmac";
++		#clock-cells = <0>;
++	};
++
++	hdmi_sound: hdmi-sound {
++		status = "disabled";
++		compatible = "simple-audio-card";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,mclk-fs = <256>;
++		simple-audio-card,name = "rockchip,hdmi";
++
++		simple-audio-card,cpu {
++			sound-dai = <&i2s2>;
++		};
++		simple-audio-card,codec {
++			sound-dai = <&hdmi>;
++		};
++	};
++
++	vccadc_ref: vccadc-ref {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc1v8_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++	};
++
++	vcc3v3_sys: vcc3v3-sys {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc3v3_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++	};
++
++	vcc5v0_host: vcc5v0-host-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio1 0 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&host_vbus_drv>;
++		regulator-name = "vcc5v0_host";
++		regulator-always-on;
++	};
++
++	vcc_hub_en: vcc_hub_en-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio2 4 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&hub_rst_en>;
++		regulator-name = "vcc_hub_en";
++		regulator-always-on;
++	};
++
++	vcc_wifi: vcc-wifi {
++		status = "okay";
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_wifi";
++		enable-active-high;
++		gpio = <&gpio4 27 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc_wifi_h>;
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++	};
++
++	vcc_pcie: vcc-pcie {
++		status = "okay";
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_pcie";
++		enable-active-high;
++		gpio = <&gpio1 17 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc_pcie_h>;
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++	};
++
++	vcc_chargen: vcc-chargen {
++		status = "disabled";
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_chargen";
++		enable-active-high;
++		gpio = <&gpio2 28 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc_chargen_h>;
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++	};
++
++	vcc_sd: vcc-sd {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio4 30 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc_sd_h>;
++		regulator-name = "vcc_sd";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++	};
++
++	vcc5v0_sys: vcc5v0-sys {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++	};
++
++	vcc_phy: vcc-phy-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_phy";
++		regulator-always-on;
++		regulator-boot-on;
++	};
++
++	vdd_log: vdd-log {
++		compatible = "pwm-regulator";
++		pwms = <&pwm2 0 25000 1>;
++		regulator-name = "vdd_log";
++		regulator-min-microvolt = <800000>;
++		regulator-max-microvolt = <1100000>;
++		regulator-always-on;
++		regulator-boot-on;
++
++		/* for rockchip boot on */
++		rockchip,pwm_id= <2>;
++		rockchip,pwm_voltage = <1000000>;
++	};
++
++	vcc_lcd: vcc-lcd-regulator {
++		compatible = "regulator-fixed";
++		regulator-always-on;
++		regulator-boot-on;
++		enable-active-high;
++		gpio = <&gpio1 24 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&lcd_en>;
++		regulator-name = "vcc_lcd";
++	};
++
++	sdio_pwrseq: sdio-pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		clocks = <&rk808 1>;
++		clock-names = "ext_clock";
++		pinctrl-names = "default";
++		pinctrl-0 = <&wifi_enable_h>;
++
++		/*
++		 * On the module itself this is one of these (depending
++		 * on the actual card populated):
++		 * - SDIO_RESET_L_WL_REG_ON
++		 * - PDN (power down when low)
++		 */
++		reset-gpios = <&gpio0 10 GPIO_ACTIVE_LOW>; /* GPIO0_B2 */
++	};
++
++	wireless_wlan: wireless-wlan {
++		compatible = "wlan-platdata";
++		rockchip,grf = <&grf>;
++		wifi_chip_type = "ap6354";
++		sdio_vref = <1800>;
++		WIFI,host_wake_irq = <&gpio0 3 GPIO_ACTIVE_HIGH>; /* GPIO0_a3 */
++		status = "disabled";
++	};
++
++	wireless_bluetooth: wireless-bluetooth {
++		compatible = "bluetooth-platdata";
++		//wifi-bt-power-toggle;
++		clocks = <&rk808 1>;
++		clock-name = "ext_clock";
++		uart_rts_gpios = <&gpio2 19 GPIO_ACTIVE_LOW>; /* GPIO2_C3 */
++		pinctrl-names = "default", "rts_gpio";
++		pinctrl-0 = <&uart0_rts>;
++		pinctrl-1 = <&uart0_gpios>;
++		//BT,power_gpio  = <&gpio3 19 GPIO_ACTIVE_HIGH>; /* GPIOx_xx */
++		BT,reset_gpio    = <&gpio0 9 GPIO_ACTIVE_HIGH>; /* GPIO0_B1 */
++		BT,wake_gpio     = <&gpio2 26 GPIO_ACTIVE_HIGH>; /* GPIO2_D2 */
++		BT,wake_host_irq = <&gpio0 4 GPIO_ACTIVE_HIGH>; /* GPIO0_A4 */
++		status = "disabled";
++	};
++
++	leds {
++		compatible = "gpio-leds";
++		power {
++			label = "firefly:blue:power";
++			linux,default-trigger = "ir-power-click";
++			default-state = "on";
++			gpios = <&gpio2 27 GPIO_ACTIVE_HIGH>;
++			pinctrl-names = "default";pinctrl-0 = <&led_power>;
++		};
++		user {
++			label = "firefly:yellow:user";
++			linux,default-trigger = "ir-user-click";
++			default-state = "off";
++			gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
++			pinctrl-names = "default";
++			pinctrl-0 = <&led_user>;
++		};
++	};
++
++	adc-keys {
++		compatible = "adc-keys";
++		io-channels = <&saradc 1>;
++		io-channel-names = "buttons";
++		poll-interval = <300>;
++		keyup-threshold-microvolt = <1800000>;
++
++		esc-key {
++			linux,code = <KEY_ESC>;
++			label = "esc";
++			press-threshold-microvolt = <0>;
++		};
++	};
++
++	gpio-keys {
++		compatible = "gpio-keys";
++		#address-cells = <1>;
++		#size-cells = <0>;
++		autorepeat;
++
++		pinctrl-names = "default";
++		pinctrl-0 = <&pwrbtn>;
++
++		button@0 {
++			gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
++			linux,code = <KEY_POWER>;
++			label = "GPIO Key Power";
++			linux,input-type = <1>;
++			gpio-key,wakeup = <1>;
++			debounce-interval = <100>;
++		};
++	};
++
++	usb_charge: usb-charge {
++		compatible = "usb-ext-charge";
++		status = "disabled";
++		io-channels = <&saradc 0>;
++		extcon = <&fusb0>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc_chargen_h &bat_int_h &cur_ctl_h &poe_det_h>;
++	    bat-int = <&gpio2 28 IRQ_TYPE_EDGE_RISING>;
++		charge-en-gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>;
++		cur-ctl-gpios = <&gpio3 26 GPIO_ACTIVE_HIGH>;
++		poe-state-gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
++		//cap-led-gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
++	};
++
++	dp_sound: dp-sound {
++		status = "disabled";
++		compatible = "rockchip,cdndp-sound";
++		rockchip,cpu = <&spdif>;
++		rockchip,codec = <&cdn_dp 1>;
++	};
++
++	vcc_mipi: vcc_mipi {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio1 22 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&dvp_pwr>;
++		regulator-name = "vcc_mipi";
++		status = "disabled";
++    };
++
++	dvdd_1v2: dvdd-1v2 {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio1 23 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&cif_pwr>;
++		regulator-name = "dvdd_1v2";
++		status = "disabled";
++    };
++};
++
++&cpu_l0 {
++	cpu-supply = <&vdd_cpu_l>;
++};
++
++&cpu_l1 {
++	cpu-supply = <&vdd_cpu_l>;
++};
++
++&cpu_l2 {
++	cpu-supply = <&vdd_cpu_l>;
++};
++
++&cpu_l3 {
++	cpu-supply = <&vdd_cpu_l>;
++};
++
++&cpu_b0 {
++	cpu-supply = <&vdd_cpu_b>;
++};
++
++&cpu_b1 {
++	cpu-supply = <&vdd_cpu_b>;
++};
++
++&display_subsystem {
++	status = "okay";
++};
++
++&emmc_phy {
++	status = "okay";
++};
++
++&gmac {
++	phy-supply = <&vcc_phy>;
++	phy-mode = "rgmii";
++	clock_in_out = "input";
++	snps,reset-gpio = <&gpio3 15 GPIO_ACTIVE_LOW>;
++	snps,reset-active-low;
++	snps,reset-delays-us = <0 10000 50000>;
++	assigned-clocks = <&cru SCLK_RMII_SRC>;
++	assigned-clock-parents = <&clkin_gmac>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&rgmii_pins>;
++	tx_delay = <0x2e>;
++	rx_delay = <0x13>;
++	status = "okay";
++};
++
++&gpu {
++	status = "okay";
++	mali-supply = <&vdd_gpu>;
++};
++
++&hdmi {
++	#address-cells = <1>;
++	#size-cells = <0>;
++	#sound-dai-cells = <0>;
++	status = "okay";
++};
++
++&i2c0 {
++	status = "okay";
++	i2c-scl-rising-time-ns = <168>;
++	i2c-scl-falling-time-ns = <4>;
++	clock-frequency = <400000>;
++
++	vdd_cpu_b: syr827@40 {
++		compatible = "silergy,syr827";
++		reg = <0x40>;
++		vin-supply = <&vcc5v0_sys>;
++		regulator-compatible = "fan53555-reg";
++		regulator-name = "vdd_cpu_b";
++		regulator-min-microvolt = <712500>;
++		regulator-max-microvolt = <1500000>;
++		regulator-ramp-delay = <1000>;
++		pinctrl-0 = <&vsel1_gpio>;
++		vsel-gpios = <&gpio1 18 GPIO_ACTIVE_HIGH>;
++		fcs,suspend-voltage-selector = <1>;
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-initial-state = <3>;
++			regulator-state-mem {
++				regulator-off-in-suspend;
++			};
++	};
++
++	vdd_gpu: syr828@41 {
++		compatible = "silergy,syr828";
++		reg = <0x41>;
++		vin-supply = <&vcc5v0_sys>;
++		pinctrl-0 = <&vsel2_gpio>;
++		vsel-gpios = <&gpio1 14 GPIO_ACTIVE_HIGH>;
++		regulator-compatible = "fan53555-reg";
++		regulator-name = "vdd_gpu";
++		regulator-min-microvolt = <712500>;
++		regulator-max-microvolt = <1500000>;
++		regulator-ramp-delay = <1000>;
++		fcs,suspend-voltage-selector = <1>;
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-initial-state = <3>;
++			regulator-state-mem {
++				regulator-off-in-suspend;
++			};
++	};
++
++	rk808: pmic@1b {
++		compatible = "rockchip,rk808";
++		reg = <0x1b>;
++		interrupt-parent = <&gpio1>;
++		interrupts = <21 IRQ_TYPE_LEVEL_LOW>;
++		pinctrl-names = "default";
++		//pinctrl-0 = <&pmic_int_l &pmic_dvs2>;
++		pinctrl-0 = <&pmic_int_l &pmic_dvs2 &vcc_5v0_h>;
++		rockchip,system-power-controller;
++		wakeup-source;
++		#clock-cells = <1>;
++		clock-output-names = "xin32k", "rk808-clkout2";
++
++		pmic,hold-gpio = <&gpio2 6 GPIO_ACTIVE_HIGH>;
++
++		//vin-supply = <&sys_12v>;
++
++		vcc1-supply = <&vcc3v3_sys>;
++		vcc2-supply = <&vcc3v3_sys>;
++		vcc3-supply = <&vcc3v3_sys>;
++		vcc4-supply = <&vcc3v3_sys>;
++		vcc6-supply = <&vcc3v3_sys>;
++		vcc7-supply = <&vcc3v3_sys>;
++		vcc8-supply = <&vcc3v3_sys>;
++		vcc9-supply = <&vcc3v3_sys>;
++		vcc10-supply = <&vcc3v3_sys>;
++		vcc11-supply = <&vcc3v3_sys>;
++		vcc12-supply = <&vcc3v3_sys>;
++		vddio-supply = <&vcc1v8_pmu>;
++
++		regulators {
++			vdd_center: DCDC_REG1 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <750000>;
++				regulator-max-microvolt = <1350000>;
++				regulator-ramp-delay = <6001>;
++				regulator-name = "vdd_center";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_cpu_l: DCDC_REG2 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <750000>;
++				regulator-max-microvolt = <1350000>;
++				regulator-ramp-delay = <6001>;
++				regulator-name = "vdd_cpu_l";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc_ddr: DCDC_REG3 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-name = "vcc_ddr";
++				regulator-state-mem {
++					regulator-on-in-suspend;
++				};
++			};
++
++			vcc_1v8: DCDC_REG4 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "vcc_1v8";
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vcca1v8_codec: LDO_REG1 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "vcca1v8_codec";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc1v8_hdmi: LDO_REG2 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "vcc1v8_hdmi";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc1v8_pmu: LDO_REG3 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "vcc1v8_pmu";
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vccio_sd: LDO_REG4 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <3000000>;
++				regulator-name = "vccio_sd";
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3000000>;
++				};
++			};
++
++			vcca3v0_codec: LDO_REG5 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <3000000>;
++				regulator-max-microvolt = <3000000>;
++				regulator-name = "vcca3v0_codec";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc_1v5: LDO_REG6 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1500000>;
++				regulator-max-microvolt = <1500000>;
++				regulator-name = "vcc_1v5";
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1500000>;
++				};
++			};
++
++			vcca0v9_hdmi: LDO_REG7 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <900000>;
++				regulator-max-microvolt = <900000>;
++				regulator-name = "vcca0v9_hdmi";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc_3v0: LDO_REG8 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <3000000>;
++				regulator-max-microvolt = <3000000>;
++				regulator-name = "vcc_3v0";
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3000000>;
++				};
++			};
++
++			vcc3v3_s3: SWITCH_REG1 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-name = "vcc3v3_s3";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc3v3_s0: SWITCH_REG2 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-name = "vcc3v3_s0";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++		};
++	};
++};
++
++&i2c1 {
++	status = "okay";
++	i2c-scl-rising-time-ns = <300>;
++	i2c-scl-falling-time-ns = <15>;
++	clock-frequency = <100000>;
++
++	ov13850: ov13850@36 {
++		compatible = "ovti,ov13850";
++		status = "disabled";
++		reg = <0x36>;
++		clocks = <&cru SCLK_CIF_OUT>;
++		clock-names = "xvclk";
++
++		/* conflict with csi-ctl-gpios */
++		reset-gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;	/*GPIO0_B0 MIP_RST*/
++		pwdn-gpios = <&gpio2 2 GPIO_ACTIVE_HIGH>;	/*GPIO2_A2 DVP_PDN0*/
++		pinctrl-names = "rockchip,camera_default", "rockchip,camera_sleep";
++		//pinctrl-0 = <&cif_clkout>;
++		pinctrl-0 = <&pwdn_cam0 &mipi_rst>;
++		pinctrl-1 = <&cam0_default_pins>;
++		pinctrl-2 = <&cam0_sleep_pins>;
++		rockchip,camera-module-index = <0>;
++		rockchip,camera-module-facing = "back";
++		rockchip,camera-module-name = "CMK-CT0116";
++		rockchip,camera-module-lens-name = "Largan-50013A1";
++
++		avdd-supply = <&vcc_mipi>; /* GPIO1_C6 CIF_PWR  AGND*/
++		dovdd-supply = <&vcc_mipi>; /* GPIO1_C6 CIF_PWR  AGND */
++		dvdd-supply = <&dvdd_1v2>; /* GPIO1_C7 DVP_PWR DVDD_1V2 */
++
++		port {
++			ucam_out0: endpoint {
++				remote-endpoint = <&mipi_in_ucam0>;
++				data-lanes = <1 2>;
++			};
++		};
++	};
++
++	ov13850_1: ov13850@46 {
++		compatible = "ovti,ov13850";
++		status = "disabled";
++		reg = <0x46>;
++		clocks = <&cru SCLK_CIF_OUT>;
++		clock-names = "xvclk";
++
++		/* conflict with csi-ctl-gpios */
++		reset-gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>; /*GPIO0_B0 MIP_RST*/
++		pwdn-gpios = <&gpio2 3 GPIO_ACTIVE_HIGH>;	/*GPIO2_A3 DVP_PDN0*/
++		pinctrl-names = "rockchip,camera_default", "rockchip,camera_sleep";
++		//pinctrl-0 = <&cif_clkout>;
++		pinctrl-0 = <&pwdn_cam1>;
++		pinctrl-1 = <&cam0_default_pins>;
++		pinctrl-2 = <&cam0_sleep_pins>;
++		rockchip,camera-module-index = <1>;
++		rockchip,camera-module-facing = "back";
++		rockchip,camera-module-name = "CMK-CT0116";
++		rockchip,camera-module-lens-name = "Largan-50013A1";
++
++		avdd-supply = <&vcc_mipi>; /* VCC28_MIPI */
++		dovdd-supply = <&vcc_mipi>; /* VCC18_MIPI */
++		dvdd-supply = <&dvdd_1v2>; /* DVDD_1V2 */
++
++		port {
++			ucam_out1: endpoint {
++				remote-endpoint = <&mipi_in_ucam1>;
++				data-lanes = <1 2>;
++			};
++		};
++	};
++};
++
++&i2c2 {
++	status = "okay";
++	cw2015@62 {
++		status = "okay";
++		compatible = "cw201x";
++		reg = <0x62>;
++		bat_config_info = <0x15 0x42 0x60 0x59 0x52 0x58 0x4D 0x48
++				   0x48 0x44 0x44 0x46 0x49 0x48 0x32 0x24
++				   0x20 0x17 0x13 0x0F 0x19 0x3E 0x51 0x45
++				   0x08 0x76 0x0B 0x85 0x0E 0x1C 0x2E 0x3E
++				   0x4D 0x52 0x52 0x57 0x3D 0x1B 0x6A 0x2D
++				   0x25 0x43 0x52 0x87 0x8F 0x91 0x94 0x52
++				   0x82 0x8C 0x92 0x96 0xFF 0x7B 0xBB 0xCB
++				   0x2F 0x7D 0x72 0xA5 0xB5 0xC1 0x46 0xAE>;
++		monitor_sec = <5>;
++		virtual_power = <0>;
++	};
++};
++
++&i2c4 {
++	status = "okay";
++	i2c-scl-rising-time-ns = <475>;
++	i2c-scl-falling-time-ns = <26>;
++
++	gsl3680: gsl3680@40 {
++		status = "disabled";
++		compatible = "gslX680";
++		reg = <0x40>;
++		screen_max_x = <1536>;
++		screen_max_y = <2048>;
++		revert_xy = <0>;
++		revert_x = <0>;
++		revert_y = <0>;
++		touch-gpio = <&gpio4 28 IRQ_TYPE_LEVEL_LOW>;
++		reset-gpio = <&gpio4 21 GPIO_ACTIVE_HIGH>;
++	};
++
++	fusb1: fusb30x@22 {
++		compatible = "fairchild,fusb302";
++		reg = <0x22>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&fusb1_int &typec1_vbus_drv>;
++		int-n-gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;
++		vbus-5v-gpios = <&gpio1 13 GPIO_ACTIVE_HIGH>;
++		status = "okay";
++	};
++
++};
++
++&i2c7 {
++	status = "okay";
++	i2c-scl-rising-time-ns = <345>;
++	i2c-scl-falling-time-ns = <11>;
++	clock-frequency = <400000>;
++
++	fusb0: fusb30x@22 {
++		compatible = "fairchild,fusb302";
++		reg = <0x22>;
++		//charge-dev = <&mp8859>;
++		power-dev = <&mp8859>;
++		pinctrl-names = "default";
++		//pinctrl-0 = <&fusb0_int &vcc_chargen_h>;
++		pinctrl-0 = <&fusb0_int>;
++		int-n-gpios = <&gpio1 2 GPIO_ACTIVE_HIGH>;
++		//charge-en-gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>;
++		status = "okay";
++	};
++
++	mp8859: mp8859@66 {
++		compatible = "mps,mp8859";
++		reg = <0x66>;
++		status = "okay";
++        extcon = <&fusb0>;
++		max-input-voltage = <15000000>;
++		max-input-current = <3000000>;
++		//charge-en-gpios =<&gpio0 1 GPIO_ACTIVE_HIGH>;
++		//pinctrl-names = "default";
++		//pinctrl-0 = <&vcc_chargen_h>;
++		//mp,register-power-supply;
++
++		regulators {
++			sys_12v: mp8859_dcdc1 {
++				regulator-name = "sys_12v";
++				regulator-min-microvolt = <12300000>;
++				regulator-max-microvolt = <12300000>;
++				regulator-ramp-delay = <8000>;
++				//regulator-always-on;
++				//regulator-boot-on;
++			};
++		};
++	};
++};
++
++&i2s1 {
++	status = "okay";
++	rockchip,i2s-broken-burst-len;
++	rockchip,playback-channels = <2>;
++	rockchip,capture-channels = <2>;
++	#sound-dai-cells = <0>;
++	assigned-clocks = <&cru SCLK_I2S1_DIV>, <&cru SCLK_I2S_8CH>;
++	assigned-clock-parents = <&cru PLL_GPLL>, <&cru SCLK_I2S1_8CH>;
++};
++
++&i2s2 {
++	#sound-dai-cells = <0>;
++	dmas = <&dmac_bus 4>;
++	dma-names = "tx";
++	status = "okay";
++};
++
++&io_domains {
++	status = "okay";
++	bt656-supply = <&vcc_3v0>;		/* bt656_gpio2ab_ms */
++	audio-supply = <&vcca1v8_codec>;	/* audio_gpio3d4a_ms */
++	sdmmc-supply = <&vccio_sd>;		/* sdmmc_gpio4b_ms */
++	gpio1830-supply = <&vcc_3v0>;		/* gpio1833_gpio4cd_ms */
++};
++
++&pcie_phy {
++	status = "okay";
++};
++
++
++&pcie0 {
++	ep-gpios = <&gpio4 25 GPIO_ACTIVE_HIGH>;
++	num-lanes = <4>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie_clkreqn_cpm>;
++	status = "okay";
++};
++
++&pmu_io_domains {
++	status = "okay";
++	pmu1830-supply = <&vcc_3v0>;
++};
++
++&pinctrl {
++	cam0 {
++                cif_pwr: cif-pwr {
++                        rockchip,pins = <1 23 RK_FUNC_GPIO &pcfg_pull_down>;
++                };
++
++                dvp_pwr: dvp-pwr {
++                        rockchip,pins = <1 22 RK_FUNC_GPIO &pcfg_pull_down>;
++                };
++    };
++
++	lcd-panel {
++		lcd_panel_reset: lcd-panel-reset {
++			rockchip,pins = <4 29 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++
++		lcd_en: lcd-en {
++			rockchip,pins = <1 24 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	pmic {
++		vsel1_gpio: vsel1-gpio {
++			rockchip,pins =
++				<1 18 RK_FUNC_GPIO &pcfg_pull_down>;
++		};
++
++		vsel2_gpio: vsel2-gpio {
++			rockchip,pins =
++			<1 14 RK_FUNC_GPIO &pcfg_pull_down>;
++		};
++	};
++
++	leds {
++	       led_power: led-power {
++		       rockchip,pins =
++		       <2 27 RK_FUNC_GPIO &pcfg_pull_none>;
++		       };
++	       led_user: led-user {
++		       rockchip,pins =
++		       <0 13 RK_FUNC_GPIO &pcfg_pull_none>;
++		       };
++	};
++
++	pmic {
++		pmic_int_l: pmic-int-l {
++			rockchip,pins =
++				<1 21 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++
++		pmic_dvs2: pmic-dvs2 {
++			rockchip,pins =
++				<1 18 RK_FUNC_GPIO &pcfg_pull_down>;
++		};
++
++	};
++
++	sdio-pwrseq {
++		wifi_enable_h: wifi-enable-h {
++			rockchip,pins =
++				<0 10 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	wireless-bluetooth {
++		uart0_gpios: uart0-gpios {
++			rockchip,pins =
++				<2 19 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++
++
++	usb2 {
++		host_vbus_drv: host-vbus-drv {
++			rockchip,pins =
++				<1 0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		hub_rst_en: hub-rst-en {
++			rockchip,pins =
++				<2 4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	fusb30x {
++		fusb1_int: fusb1-int {
++			rockchip,pins = <1 1 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++
++		fusb0_int: fusb0-int {
++			rockchip,pins = <1 2 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++
++		typec1_vbus_drv: typec1-vbus-drv {
++			rockchip,pins = <1 13 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	vcc5v0_sys {
++		vcc_5v0_h: vcc-5v0-h {
++			rockchip,pins = <2 6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	vcc_sd {
++		vcc_sd_h: vcc-sd-h {
++			rockchip,pins = <4 30 RK_FUNC_GPIO &pcfg_pull_none>;
++			};
++		};
++	wifi {
++		vcc_wifi_h: vcc-wifi-h {
++			rockchip,pins = <4 27 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	pcie {
++		vcc_pcie_h: vcc-pcie-h {
++			rockchip,pins = <1 17 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	buttons {
++		pwrbtn: pwrbtn {
++			rockchip,pins = <0 5 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	chargen {
++		vcc_chargen_h: vcc-chargen-h {
++			rockchip,pins = <0 1 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++		bat_int_h: bat-int-h {
++			rockchip,pins = <2 28 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++		cur_ctl_h: cur-ctl-h {
++			rockchip,pins = <3 26 RK_FUNC_GPIO &pcfg_pull_none_20ma>;
++		};
++		poe_det_h: poe-det-h {
++			rockchip,pins = <0 12 RK_FUNC_GPIO &pcfg_pull_down>;
++		};
++	};
++
++	cam_pins {
++		cam0_default_pins: cam0-default-pins {
++			rockchip,pins =
++		//		<4 27 RK_FUNC_GPIO &pcfg_pull_none>,
++				<2 11 RK_FUNC_3 &pcfg_pull_none>;
++		};
++
++		cam0_sleep_pins: cam0-sleep-pins {
++			rockchip,pins =
++				<4 27 RK_FUNC_3 &pcfg_pull_none>,
++				<2 11 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		pwdn_cam0: pwdn-cma0 {
++			rockchip,pins =
++				<2 2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		pwdn_cam1: pwdn-cma1 {
++			rockchip,pins =
++				<2 3 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		mipi_rst: mipi-rst {
++			rockchip,pins =
++            			<0 8 RK_FUNC_GPIO &pcfg_pull_none>;
++        };
++	};
++};
++
++&pwm0 {
++	status = "okay";
++};
++
++&pwm1 {
++	status = "okay";
++};
++
++&pwm2 {
++	status = "okay";
++	pinctrl-names = "active";
++	pinctrl-0 = <&pwm2_pin_pull_down>;
++};
++
++&rkvdec {
++	status = "okay";
++};
++
++&rockchip_suspend {
++	rockchip,power-ctrl =
++		<&gpio1 18 GPIO_ACTIVE_LOW>,
++		<&gpio1 14 GPIO_ACTIVE_HIGH>;
++};
++
++&route_hdmi {
++	status = "okay";
++};
++
++&dp_sound {
++	status = "okay";
++};
++
++&hdmi_sound {
++	status = "okay";
++};
++
++&cdn_dp {
++	status = "okay";
++	extcon = <&fusb0 &fusb1>;
++	phys = <&tcphy0_dp &tcphy1_dp>;
++};
++
++&hdmi_in_vopl {
++	status = "disabled";
++};
++
++&dp_in_vopb {
++	status = "okay";
++};
++
++&dp_in_vopl {
++	status = "disabled";
++};
++
++&saradc {
++	status = "okay";
++	vref-supply = <&vccadc_ref>;
++};
++
++&sdhci {
++	bus-width = <8>;
++	keep-power-in-suspend;
++	mmc-hs400-1_8v;
++	mmc-hs400-enhanced-strobe;
++	non-removable;
++	status = "okay";
++	supports-emmc;
++};
++
++&sdmmc {
++	//max-frequncy = <150000000>;
++	clock-frequency = <150000000>;
++	clock-freq-min-max = <100000 150000000>;
++	supports-sd;
++	bus-width = <4>;
++	cap-mmc-highspeed;
++	cap-sd-highspeed;
++	disable-wp;
++	num-slots = <1>;
++	sd-uhs-sdr104;
++	vmmc-supply = <&vcc_sd>;
++	vqmmc-supply = <&vccio_sd>;
++	//vqmmc-supply = <&vcc_sd>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdmmc_clk &sdmmc_cmd &sdmmc_cd &sdmmc_bus4>;
++	status = "okay";
++};
++
++&sdio0 {
++	max-frequency = <100000000>;
++	supports-sdio;
++	bus-width = <4>;
++	disable-wp;
++	cap-sd-highspeed;
++	keep-power-in-suspend;
++	mmc-pwrseq = <&sdio_pwrseq>;
++	non-removable;
++	num-slots = <1>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdio0_bus4 &sdio0_cmd &sdio0_clk>;
++	sd-uhs-sdr104;
++	status = "okay";
++};
++
++&tcphy0 {
++	extcon = <&fusb0>;
++	status = "okay";
++};
++
++&tcphy1 {
++	extcon = <&fusb1>;
++	status = "okay";
++};
++
++&tsadc {
++	/* tshut mode 0:CRU 1:GPIO */
++	rockchip,hw-tshut-mode = <1>;
++	/* tshut polarity 0:LOW 1:HIGH */
++	rockchip,hw-tshut-polarity = <1>;
++	status = "okay";
++};
++
++&u2phy0 {
++	status = "okay";
++	extcon = <&fusb0>;
++
++	u2phy0_otg: otg-port {
++		status = "okay";
++	};
++
++	u2phy0_host: host-port {
++		phy-supply = <&vcc5v0_host>;
++		status = "okay";
++	};
++};
++
++&u2phy1 {
++	status = "okay";
++	extcon = <&fusb1>;
++
++	u2phy1_otg: otg-port {
++		status = "okay";
++	};
++
++	u2phy1_host: host-port {
++		phy-supply = <&vcc5v0_host>;
++		status = "okay";
++	};
++};
++
++&uart0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart0_xfer &uart0_cts>;
++	status = "okay";
++};
++
++&uart2 {
++	status = "disabled";
++};
++
++&usbdrd3_0 {
++	status = "okay";
++	extcon = <&fusb0>;
++};
++
++&usbdrd3_1 {
++	status = "okay";
++	extcon = <&fusb1>;
++};
++
++&usbdrd_dwc3_0 {
++	status = "okay";
++};
++
++&usbdrd_dwc3_1 {
++	status = "okay";
++	dr_mode = "host";
++};
++
++&usb_host0_ehci {
++	status = "okay";
++};
++
++&usb_host0_ohci {
++	status = "okay";
++};
++
++&usb_host1_ehci {
++	status = "okay";
++};
++
++&usb_host1_ohci {
++	status = "okay";
++	pinctrl-names = "default";
++};
++
++&spi1 {
++	status = "okay";
++	max-freq = <48000000>;
++	dev-port = <0>;
++
++	spidev0: spidev@00 {
++		status = "okay";
++		//compatible = "linux,spidev";
++		compatible = "jedec,spi-nor";
++		reg = <0x00>;
++		spi-max-frequency = <48000000>;
++	};
++};
++
++&pwm3 {
++	status = "okay";
++	interrupts = <GIC_SPI 61 IRQ_TYPE_LEVEL_HIGH 0>;
++	compatible = "rockchip,remotectl-pwm";
++	pinctrl-names = "default";
++	remote_pwm_id = <3>;
++	handle_cpu_id = <0>;
++	remote_support_psci = <1>;
++
++	ir_key1{
++        rockchip,usercode = <0xff00>;
++        rockchip,key_table =
++            <0xeb   KEY_POWER>,
++            <0xec   KEY_MENU>,
++            <0xfe   KEY_BACK>,
++            <0xb7   KEY_HOME>,
++            <0xa3   KEY_WWW>,
++            <0xf4   KEY_VOLUMEUP>,
++            <0xa7   KEY_VOLUMEDOWN>,
++            <0xf8   KEY_REPLY>,
++            <0xfc   KEY_UP>,
++            <0xfd   KEY_DOWN>,
++            <0xf1   KEY_LEFT>,
++            <0xe5   KEY_RIGHT>;
++    };
++};
++
++&vopb {
++	status = "okay";
++};
++&vopb_mmu {
++	status = "okay";
++};
++&vopl {
++	status = "okay";
++};
++&vopl_mmu {
++	status = "okay";
++};
++&vpu {
++	status = "okay";
++};
++
++&spdif {
++	status = "okay";
++	pinctrl-0 = <&spdif_bus_1>;
++	i2c-scl-rising-time-ns = <450>;
++	i2c-scl-falling-time-ns = <15>;
++	#sound-dai-cells = <0>;
++};
++
++&mipi_dphy_rx0 {
++	status = "okay";
++	ports {
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		port@0 {
++			reg = <0>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			mipi_in_ucam0: endpoint@1 {
++				reg = <1>;
++				remote-endpoint = <&ucam_out0>;
++				data-lanes = <1 2>;
++			};
++		};
++
++		port@1 {
++			reg = <1>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			dphy_rx0_out: endpoint@0 {
++				reg = <0>;
++				remote-endpoint = <&isp0_mipi_in>;
++			};
++		};
++	};
++};
++
++&mipi_dphy_tx1rx1 {
++	status = "disabled";
++
++	ports {
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		port@0 {
++			reg = <0>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			mipi_in_ucam1: endpoint@1 {
++				reg = <1>;
++				remote-endpoint = <&ucam_out1>;
++				data-lanes = <1 2>;
++			};
++		};
++
++		port@1 {
++			reg = <1>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			dphy_tx1rx1_out: endpoint@0 {
++				reg = <0>;
++				remote-endpoint = <&isp1_mipi_in>;
++			};
++		};
++	};
++};
++
++
++&rkisp1_0 {
++	status = "disabled";
++
++	port {
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		isp0_mipi_in: endpoint@0 {
++			reg = <0>;
++			remote-endpoint = <&dphy_rx0_out>;
++		};
++	};
++};
++
++&rkisp1_1 {
++	status = "disabled";
++
++	port {
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		isp1_mipi_in: endpoint@0 {
++			reg = <0>;
++			remote-endpoint = <&dphy_tx1rx1_out>;
++		};
++	};
++};
++
++&cam0_default_pins {
++	rockchip,pins =
++				<2 11 RK_FUNC_3 &pcfg_pull_none>;
++};
++
++&vcc_mipi {
++	status = "okay";
++};
++
++&dvdd_1v2 {
++	status = "okay";
++};
++
++&ov13850 {
++	status = "okay";
++};
++
++&ov13850_1 {
++	status = "okay";
++};
++
++&rkisp1_0 {
++	status = "okay";
++};
++
++&mipi_dphy_rx0 {
++	status = "okay";
++};
++
++&isp0_mmu {
++	status = "okay";
++};
++
++&rkisp1_1 {
++	status = "okay";
++};
++
++&mipi_dphy_tx1rx1 {
++	status = "okay";
++};
++
++&isp1_mmu {
++	status = "okay";
++};
+--- a/include/dt-bindings/clock/rk3399-cru.h
++++ b/include/dt-bindings/clock/rk3399-cru.h
+@@ -31,6 +31,7 @@
+ 
+ /* sclk gates (special clocks) */
+ #define SCLK_I2SOUT_SRC			64
++#define SCLK_I2S_8CH            SCLK_I2SOUT_SRC
+ #define SCLK_I2C1			65
+ #define SCLK_I2C2			66
+ #define SCLK_I2C3			67

--- a/patch/kernel/rockchip64-dev/board-roc-rk3399-pc-fix-regulator.patch
+++ b/patch/kernel/rockchip64-dev/board-roc-rk3399-pc-fix-regulator.patch
@@ -1,0 +1,24 @@
+--- a/arch/arm64/boot/dts/rockchip/rk3399-roc-pc.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3399-roc-pc.dts
+@@ -113,6 +113,10 @@
+ 
+ 	vcc_sys: vcc-sys {
+ 		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio2 RK_PA6 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc_sys_en>;
+ 		regulator-name = "vcc_sys";
+ 		regulator-always-on;
+ 		regulator-boot-on;
+@@ -521,6 +525,10 @@
+ 			rockchip,pins = <1 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 
++		vcc_sys_en: vcc-sys-en {
++			rockchip,pins = <2 RK_PA6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
+ 		hub_rst: hub-rst {
+ 			rockchip,pins = <2 RK_PA4 RK_FUNC_GPIO &pcfg_output_high>;
+ 		};


### PR DESCRIPTION
This is an attempt to make csc support of `roc-rk3399-pc' to Armbian .

Currently, the default and dev branch is tested.

The mainline ATF has to be used, otherwise, it hangs at U-Boot.