### PR TITLE
Support eval bash statement in ./compile.sh

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -169,6 +169,7 @@ fi
 
 if [[ -z "$CONFIG" && -n "$1" && -f "${SRC}/userpatches/config-$1.conf" ]]; then
 	CONFIG="userpatches/config-$1.conf"
+	shift
 fi
 
 # usind default if custom not found
@@ -195,13 +196,12 @@ popd > /dev/null
 [[ -z "${USERPATCHES_PATH}" ]] && USERPATCHES_PATH="$CONFIG_PATH"
 
 # Script parameters handling
-for i in "$@"; do
-	if [[ $i == *=* ]]; then
-		parameter=${i%%=*}
-		value=${i##*=}
-		display_alert "Command line: setting $parameter to" "${value:-(empty)}" "info"
-		eval "$parameter=\"$value\""
-	fi
+while [[ $1 == *=* ]]; do
+    parameter=${1%%=*}
+    value=${1##*=}
+    shift
+    display_alert "Command line: setting $parameter to" "${value:-(empty)}" "info"
+    eval "$parameter=\"$value\""
 done
 
 if [[ $BUILD_ALL == yes || $BUILD_ALL == demo ]]; then

--- a/lib/main.sh
+++ b/lib/main.sh
@@ -102,33 +102,6 @@ else
 
 fi
 
-# Check and install dependencies, directory structure and settings
-prepare_host
-
-if [[ -n $REPOSITORY_UPDATE ]]; then
-
-	# select stable/beta configuration
-	if [[ $BETA == yes ]]; then
-		DEB_STORAGE=$DEST/debs-beta
-		REPO_STORAGE=$DEST/repository-beta
-		REPO_CONFIG="aptly-beta.conf"
-	else
-		DEB_STORAGE=$DEST/debs
-		REPO_STORAGE=$DEST/repository
-		REPO_CONFIG="aptly.conf"
-	fi
-
-	# For user override
-	if [[ -f $USERPATCHES_PATH/lib.config ]]; then
-		display_alert "Using user configuration override" "userpatches/lib.config" "info"
-	        source "$USERPATCHES_PATH"/lib.config
-	fi
-
-	repo-manipulate "$REPOSITORY_UPDATE"
-	exit
-
-fi
-
 # if KERNEL_ONLY, KERNEL_CONFIGURE, BOARD, BRANCH or RELEASE are not set, display selection menu
 
 if [[ -z $KERNEL_ONLY ]]; then
@@ -356,7 +329,62 @@ else
 
 fi
 
+if [[ $BETA == yes ]]; then
+	IMAGE_TYPE=nightly
+elif [[ $BETA != "yes" && $BUILD_ALL == yes && -n $GPG_PASS ]]; then
+	IMAGE_TYPE=stable
+else
+	IMAGE_TYPE=user-built
+fi
+
+branch2dir() {
+	[[ $1 == head ]] && echo HEAD || echo ${1##*:}
+}
+
+BOOTSOURCEDIR=$BOOTDIR/$(branch2dir ${BOOTBRANCH})
+LINUXSOURCEDIR=$KERNELDIR/$(branch2dir ${KERNELBRANCH})
+[[ -n $ATFSOURCE ]] && ATFSOURCEDIR=$ATFDIR/$(branch2dir ${ATFBRANCH})
+
+# define package names
+DEB_BRANCH=${BRANCH//default}
+# if not empty, append hyphen
+DEB_BRANCH=${DEB_BRANCH:+${DEB_BRANCH}-}
+CHOSEN_UBOOT=linux-u-boot-${DEB_BRANCH}${BOARD}
+CHOSEN_KERNEL=linux-image-${DEB_BRANCH}${LINUXFAMILY}
+CHOSEN_ROOTFS=linux-${RELEASE}-root-${DEB_BRANCH}${BOARD}
+CHOSEN_DESKTOP=armbian-${RELEASE}-desktop
+CHOSEN_KSRC=linux-source-${BRANCH}-${LINUXFAMILY}
+
+do_default() {
+
 start=$(date +%s)
+
+# Check and install dependencies, directory structure and settings
+prepare_host
+
+if [[ -n $REPOSITORY_UPDATE ]]; then
+
+	# select stable/beta configuration
+	if [[ $BETA == yes ]]; then
+		DEB_STORAGE=$DEST/debs-beta
+		REPO_STORAGE=$DEST/repository-beta
+		REPO_CONFIG="aptly-beta.conf"
+	else
+		DEB_STORAGE=$DEST/debs
+		REPO_STORAGE=$DEST/repository
+		REPO_CONFIG="aptly.conf"
+	fi
+
+	# For user override
+	if [[ -f $USERPATCHES_PATH/lib.config ]]; then
+		display_alert "Using user configuration override" "userpatches/lib.config" "info"
+	    source "$USERPATCHES_PATH"/lib.config
+	fi
+
+	repo-manipulate "$REPOSITORY_UPDATE"
+	exit
+
+fi
 
 [[ $CLEAN_LEVEL == *sources* ]] && cleaning "sources"
 
@@ -378,34 +406,8 @@ if [[ $IGNORE_UPDATES != yes ]]; then
 	fetch_from_repo "https://github.com/armbian/testings" "testing-reports" "branch:master"
 fi
 
-if [[ $BETA == yes ]]; then
-	IMAGE_TYPE=nightly
-elif [[ $BETA != "yes" && $BUILD_ALL == yes && -n $GPG_PASS ]]; then
-	IMAGE_TYPE=stable
-else
-	IMAGE_TYPE=user-built
-fi
-
 compile_sunxi_tools
 install_rkbin_tools
-
-branch2dir() {
-	[[ $1 == head ]] && echo HEAD || echo ${1##*:}
-}
-
-BOOTSOURCEDIR=$BOOTDIR/$(branch2dir ${BOOTBRANCH})
-LINUXSOURCEDIR=$KERNELDIR/$(branch2dir ${KERNELBRANCH})
-[[ -n $ATFSOURCE ]] && ATFSOURCEDIR=$ATFDIR/$(branch2dir ${ATFBRANCH})
-
-# define package names
-DEB_BRANCH=${BRANCH//default}
-# if not empty, append hyphen
-DEB_BRANCH=${DEB_BRANCH:+${DEB_BRANCH}-}
-CHOSEN_UBOOT=linux-u-boot-${DEB_BRANCH}${BOARD}
-CHOSEN_KERNEL=linux-image-${DEB_BRANCH}${LINUXFAMILY}
-CHOSEN_ROOTFS=linux-${RELEASE}-root-${DEB_BRANCH}${BOARD}
-CHOSEN_DESKTOP=armbian-${RELEASE}-desktop
-CHOSEN_KSRC=linux-source-${BRANCH}-${LINUXFAMILY}
 
 for option in $(tr ',' ' ' <<< "$CLEAN_LEVEL"); do
 	[[ $option != sources ]] && cleaning "$option"
@@ -480,3 +482,11 @@ $([[ -n $KERNEL_ONLY ]] && echo "KERNEL_ONLY=${KERNEL_ONLY} ")\
 $([[ -n $KERNEL_CONFIGURE ]] && echo "KERNEL_CONFIGURE=${KERNEL_CONFIGURE} ")\
 $([[ -n $COMPRESS_OUTPUTIMAGE ]] && echo "COMPRESS_OUTPUTIMAGE=${COMPRESS_OUTPUTIMAGE} ")\
 " "info"
+
+} # end of do_default()
+
+if [[ -z $1 ]]; then
+	do_default
+else
+	eval "$@"
+fi


### PR DESCRIPTION
Currently, invoking compile.sh will run its mono task of building all the
source codes and components into a final image.

In some situation, especially when developing with Kernel or U-Boot, it is
handy to run a portion of that great task like:

    export BOARD=firefly-rk3399
    export BRANCH=default
    ... # more to avoid the popup of dialog
    ./compile.sh 'fetch_from_repo "$BOOTSOURCE" "$BOOTDIR" "$BOOTBRANCH" "yes"'
    ./compile.sh 'compile_uboot'

or use a profile to keep things simple:

    ./compile.sh default BRANCH=dev 'compile_uboot'
