### PR TITLE
don't set LC_ALL=C

### DIFF
--- a/lib/distributions.sh
+++ b/lib/distributions.sh
@@ -29,7 +29,7 @@ install_common()
 
 	fi
 	# define ARCH within global environment variables
-	[[ -f $SDCARD/etc/environment ]] && echo -e "ARCH=${ARCH//hf}\nLC_ALL=\"C\"" >> "${SDCARD}"/etc/environment
+	[[ -f $SDCARD/etc/environment ]] && echo -e "ARCH=${ARCH//hf}" >> "${SDCARD}"/etc/environment
 
 	# add dummy fstab entry to make mkinitramfs happy
 	echo "/dev/mmcblk0p1 / $ROOTFS_TYPE defaults 0 1" >> "${SDCARD}"/etc/fstab


### PR DESCRIPTION
This breaks UTF-8 in console and in general it just should not be there.

See https://forum.armbian.com/topic/10054-locale-config-issue-stretch/
