### PR TITLE
Update armbian-ramlog

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-ramlog
+++ b/packages/bsp/common/usr/lib/armbian/armbian-ramlog
@@ -51,7 +51,7 @@ syncToDisk () {
 		${NoCache} cp -rfup $RAM_LOG -T $HDD_LOG 2>&1 | $LOG_OUTPUT
 	fi
 
-	sync
+	sync /
 }
 
 syncFromDisk () {
@@ -65,7 +65,7 @@ syncFromDisk () {
 		${NoCache} find $HDD_LOG* -maxdepth 1 -type f -not \( -name '*.[0-9]' -or -name '*.xz*' -or -name '*.gz' \) | xargs cp -ut $RAM_LOG
 	fi
 
-	sync
+	sync /
 }
 
 check_if_installed () {


### PR DESCRIPTION
Prevent hard disk drive spin-up by using `sync /` instead of `sync`. Using `sync /var` is another option which also prevent hard disk drive spin-up.