### PR TITLE
Rock Pi 4 enable PCIe in device tree for "dev" target

### DIFF
--- a/patch/kernel/rockchip64-dev/board-rockpi4-dts-pcie.patch
+++ b/patch/kernel/rockchip64-dev/board-rockpi4-dts-pcie.patch
@@ -1,0 +1,35 @@
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts
+index 1ae1ebd4e..2f84397d5 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts
+@@ -62,6 +62,8 @@
+ 		regulator-name = "vcc3v3_pcie";
+ 		regulator-always-on;
+ 		regulator-boot-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
+ 		vin-supply = <&vcc5v0_sys>;
+ 	};
+ 
+@@ -434,6 +459,21 @@
+ 	gpio1830-supply = <&vcc_3v0>;
+ };
+ 
++&pcie0 {
++	ep-gpios = <&gpio4 RK_PD3 GPIO_ACTIVE_HIGH>;
++	num-lanes = <4>;
++	max-link-speed = <1>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie_clkreqnb_cpm>;
++	vpcie12v-supply = <&vcc12v_dcin>;
++	vpcie3v3-supply = <&vcc3v3_pcie>;
++	status = "okay";
++};
++
++&pcie_phy {
++	status = "okay";
++};
++
+ &pmu_io_domains {
+ 	status = "okay";
+ 

--- a/patch/kernel/rockchip64-dev/general-rockchip-overlays.patch
+++ b/patch/kernel/rockchip64-dev/general-rockchip-overlays.patch
@@ -12,11 +12,12 @@ diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts
 index e69de29..576e190 100644
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
-@@ -0,0 +1,21 @@
+@@ -0,0 +1,22 @@
 +# SPDX-License-Identifier: GPL-2.0
 +dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 +	rockchip-i2c7.dtbo \
 +	rockchip-i2c8.dtbo \
++	rockchip-pcie-gen2.dtbo \
 +	rockchip-spi-jedec-nor.dtbo \
 +	rockchip-spi-spidev.dtbo \
 +	rockchip-uart4.dtbo \
@@ -38,7 +39,7 @@ diff --git a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays b/arc
 index e69de29..9512445 100644
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
-@@ -0,0 +1,101 @@
+@@ -0,0 +1,106 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
 +https://docs.armbian.com/User-Guide_Allwinner_overlays/
@@ -49,7 +50,7 @@ index e69de29..9512445 100644
 +
 +### Provided overlays:
 +
-+- i2c7, i2c8, spi-spidev, uart4, w1-gpio
++- i2c7, i2c8, pcie-gen2, spi-spidev, uart4, w1-gpio
 +
 +### Overlay details:
 +
@@ -64,6 +65,11 @@ index e69de29..9512445 100644
 +Activates TWI/I2C bus 8
 +
 +I2C8 pins (SCL, SDA): GPIO1-C5, GPIO1-C4
++
++### pcie-gen2
++
++Enables PCIe Gen2 link speed on RK3399.
++WARNING! Not officially supported by Rockchip!!!
 +
 +### spi-jedec-nor
 +
@@ -239,6 +245,24 @@ index 0000000..54bc844
 +        target-path = "/i2c@ff3e0000";
 +        __overlay__ {
 +            status = "okay";
++        };
++    };
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-pcie-gen2.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-pcie-gen2.dts
+new file mode 100644
+index 0000000..54bc844
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-pcie-gen2.dts
+@@ -0,0 +1,12 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++    compatible = "rockchip,rk3399";
++    fragment@0 {
++        target = <&pcie0>;
++        __overlay__ {
++            max-link-speed = <2>;
 +        };
 +    };
 +};


### PR DESCRIPTION
PCIe enabled with default (officially supported by Rockchip) link speed of Gen1.
Added an overlay to change the link speed to Gen2 if one wants to take the risk.

[Tested with NVMe](https://forum.radxa.com/t/kernel-5-x-and-nvme/2120/8) by @darinpp