### PR TITLE
Restart systemd-journald after starting armbian-ramlog

### DIFF
--- a/packages/bsp/common/lib/systemd/system/systemd-journald.service.d/override.conf
+++ b/packages/bsp/common/lib/systemd/system/systemd-journald.service.d/override.conf
@@ -1,0 +1,2 @@
+[Unit]
+After=armian-ramlog.service


### PR DESCRIPTION
While using Ubuntu 18 I have found out that `journald` would write all log entries to `/var/log/syslog` and corresponding `journalctl -u xxx` commands would show no log entries for individual services/units.

I am not really sure why this is happening (and could not find under which conditions `journald` decides to do that) but I suspect it is related to `armian-ramlog`; restarting `systemd-journald` allows to see back log entries with `journalctl`.

In this PR I added a command to restart `systemd-journald` right after `armbian-ramlog` is started and verified experimentally that it fixed the issue for me.

Please comment if you can reproduce the issue and have better ideas about why the original issue is happening, and/or better ways to fix it.