### PR TITLE
Rock Pi 4 explicitly refer device tree binary in /boot/armbianEnv.txt

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -113,6 +113,7 @@ family_tweaks()
 	[[ $BOARD == nanopineo4 ]] && echo "fdtfile=rockchip/rk3399-nanopi-neo4.dtb" >> $SDCARD/boot/armbianEnv.txt
 	[[ $BOARD == orangepi-rk3399 ]] && echo "fdtfile=rockchip/rk3399-orangepi.dtb" >> $SDCARD/boot/armbianEnv.txt
 	[[ $BOARD == roc-rk3399-pc ]] && echo "fdtfile=rockchip/rk3399-roc-pc.dtb" >> $SDCARD/boot/armbianEnv.txt
+	[[ $BOARD == rockpi-4* ]] && echo "fdtfile=rockchip/rk3399-rock-pi-4.dtb" >> $SDCARD/boot/armbianEnv.txt
 
 	if [[ $BOARD == z28pro ]]; then
 

--- a/patch/kernel/rockchip64-legacy/board-rockpi4-modern-dts-link.patch
+++ b/patch/kernel/rockchip64-legacy/board-rockpi4-modern-dts-link.patch
@@ -1,0 +1,29 @@
+diff --git a/arch/arm64/boot/dts/rockchip/Makefile b/arch/arm64/boot/dts/rockchip/Makefile
+index 4906fd0a..48731f52 100644
+--- a/arch/arm64/boot/dts/rockchip/Makefile
++++ b/arch/arm64/boot/dts/rockchip/Makefile
+@@ -92,6 +92,8 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-mid-818-android.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-pinebook-pro-v1.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-pinebook-pro.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-rock960-ab.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-rockpi4b.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-rock-pi-4.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-rockpro64.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-rv1-android.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-sapphire-excavator-box-android-6.0.dtb
+@@ -102,7 +104,6 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-sapphire-excavator-edp.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-sapphire-excavator-edp-avb.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-sapphire-excavator-linux.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-sapphire-excavator-linux-for-rk1808-cascade.dtb
+-dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-rockpi4b.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-tve1030g.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-tve1030g-avb.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-tve1205g.dtb
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts
+new file mode 120000
+index 00000000..d365c482
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts
+@@ -0,0 +1 @@
++rk3399-rockpi4b.dts
+\ No newline at end of file


### PR DESCRIPTION
This should help the folks running Armbian off NVMe with Radxa's u-boot in SPI.
https://forum.radxa.com/t/kernel-5-x-and-nvme/2120/5

Tested with both `dev` and `legacy`.

BTW. I am thinking about introducing a variable (eg. `$KERNEL_FDTFILE`) for board config files and a support for it in `lib/distributions.sh`.
That would reduce the need for conditional calls in `family_twaeks()` but that's for another PR