### PR TITLE
Enabled current kernel for roc-rk3399-pc (and fixed legacy build)

### DIFF
--- a/config/boards/roc-rk3399-pc.csc
+++ b/config/boards/roc-rk3399-pc.csc
@@ -6,7 +6,7 @@ BOOTCONFIG="roc-rk3399-pc_defconfig"
 MODULES=""
 MODULES_NEXT=""
 #
-KERNEL_TARGET="default,dev"
+KERNEL_TARGET="legacy,current,dev"
 CLI_TARGET="buster,bionic:default"
 DESKTOP_TARGET="buster,bionic:default"
 #

--- a/patch/kernel/rockchip64-current/board-roc-rk3399-pc-fix-regulator.patch
+++ b/patch/kernel/rockchip64-current/board-roc-rk3399-pc-fix-regulator.patch
@@ -1,0 +1,24 @@
+--- a/arch/arm64/boot/dts/rockchip/rk3399-roc-pc.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3399-roc-pc.dts
+@@ -113,6 +113,10 @@
+ 
+ 	vcc_sys: vcc-sys {
+ 		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio2 RK_PA6 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc_sys_en>;
+ 		regulator-name = "vcc_sys";
+ 		regulator-always-on;
+ 		regulator-boot-on;
+@@ -521,6 +525,10 @@
+ 			rockchip,pins = <1 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 
++		vcc_sys_en: vcc-sys-en {
++			rockchip,pins = <2 RK_PA6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
+ 		hub_rst: hub-rst {
+ 			rockchip,pins = <2 RK_PA4 RK_FUNC_GPIO &pcfg_output_high>;
+ 		};


### PR DESCRIPTION
Tested with minimal image:

```
U-Boot TPL 2019.10-armbian (Nov 29 2019 - 22:20:16)
Trying to boot from BOOTROM
Returning to boot ROM...

U-Boot SPL 2019.10-armbian (Nov 29 2019 - 22:20:16 +0000)
Trying to boot from MMC1
NOTICE:  BL31: v2.2(release):a04808c-dirty
NOTICE:  BL31: Built : 22:20:11, Nov 29 2019


U-Boot 2019.10-armbian (Nov 29 2019 - 22:20:16 +0000)

Model: Firefly ROC-RK3399-PC Board
DRAM:  3.9 GiB
MMC:   dwmmc@fe320000: 1, sdhci@fe330000: 0
Loading Environment from EXT4... Card did not respond to voltage select!
In:    serial@ff1a0000
Out:   serial@ff1a0000
Err:   serial@ff1a0000
Model: Firefly ROC-RK3399-PC Board
rockchip_dnl_key_pressed: adc_channel_single_shot fail!
Net:
Error: ethernet@fe300000 address not set.
eth-1: ethernet@fe300000
Hit any key to stop autoboot:  0
switch to partitions #0, OK
mmc1 is current device
Scanning mmc 1:1...
Found U-Boot script /boot/boot.scr
2949 bytes read in 5 ms (575.2 KiB/s)
## Executing script at 00500000
Boot script loaded from mmc 1
186 bytes read in 5 ms (36.1 KiB/s)
5931885 bytes read in 255 ms (22.2 MiB/s)
20447744 bytes read in 870 ms (22.4 MiB/s)
71941 bytes read in 12 ms (5.7 MiB/s)
2698 bytes read in 9 ms (292 KiB/s)
Applying kernel provided DT fixup script (rockchip-fixup.scr)
## Executing script at 39000000
## Loading init Ramdisk from Legacy Image at 04000000 ...
   Image Name:   uInitrd
   Image Type:   AArch64 Linux RAMDisk Image (gzip compressed)
   Data Size:    5931821 Bytes = 5.7 MiB
   Load Address: 00000000
   Entry Point:  00000000
   Verifying Checksum ... OK
## Flattened Device Tree blob at 01f00000
   Booting using the fdt blob at 0x1f00000
   Loading Ramdisk to f5976000, end f5f1e32d ... OK
   Loading Device Tree to 00000000f58fc000, end 00000000f5975fff ... OK

Starting kernel ...


Armbian 19.11.3 Buster ttyS2

roc login: root
Password:
Last login: Fri Nov 29 22:49:27 UTC 2019 on ttyS2
 ____   ___   ____      ____  _  ____________ ___   ___        ____   ____
|  _ \ / _ \ / ___|    |  _ \| |/ /___ /___ // _ \ / _ \      |  _ \ / ___|
| |_) | | | | |   _____| |_) | ' /  |_ \ |_ \ (_) | (_) |_____| |_) | |
|  _ <| |_| | |__|_____|  _ <| . \ ___) |__) \__, |\__, |_____|  __/| |___
|_| \_\\___/ \____|    |_| \_\_|\_\____/____/  /_/   /_/      |_|    \____|

Welcome to Armbian Buster with Linux 5.4.1-rockchip64

System load:   0.04 0.12 0.07  	Up time:       3 min
Memory usage:  2 % of 3868MB 	IP:
CPU temp:      46°C
Usage of /:    2% of 29G

[ Menu-driven system configuration (beta): sudo apt update && sudo apt install armbian-config ]


root@roc:~# uname -a
Linux roc 5.4.1-rockchip64 #19.11.3 SMP PREEMPT Fri Nov 29 22:44:11 UTC 2019 aarch64 GNU/Linux
root@roc:~#
```

cc: @levindu @Tonymac32 