### PR TITLE
Fix error message in rk3399 builds with mainline ATF

### DIFF
--- a/config/sources/families/rk3399.conf
+++ b/config/sources/families/rk3399.conf
@@ -106,3 +106,8 @@ uboot_custom_postprocess()
 		exit 1
 	fi
 }
+
+atf_custom_postprocess()
+{
+	:
+}


### PR DESCRIPTION
Fixes: #1651 

I am overwriting `atf_custom_postprocess` in rk3399 family as it has no use there.