### PR TITLE
Enable UART for ATF logging on rk3399

### DIFF
--- a/patch/atf/atf-rk3399/enable-logging.patch
+++ b/patch/atf/atf-rk3399/enable-logging.patch
@@ -1,0 +1,31 @@
+diff --git a/plat/rockchip/rk3399/rk3399_def.h b/plat/rockchip/rk3399/rk3399_def.h
+index ba83242..8d6ecfb 100644
+--- a/plat/rockchip/rk3399/rk3399_def.h
++++ b/plat/rockchip/rk3399/rk3399_def.h
+@@ -17,7 +17,7 @@
+ /**************************************************************************
+  * UART related constants
+  **************************************************************************/
+-#define RK3399_BAUDRATE			115200
++#define RK3399_BAUDRATE			1500000
+ #define RK3399_UART_CLOCK		24000000
+
+ /******************************************************************************
+diff --git a/plat/rockchip/common/bl31_plat_setup.c b/plat/rockchip/common/bl31_plat_setup.c
+index c4a0359..22d07e0 100644
+--- a/plat/rockchip/common/bl31_plat_setup.c
++++ b/plat/rockchip/common/bl31_plat_setup.c
+@@ -61,10 +61,13 @@ void bl31_early_platform_setup2(u_register_t arg0, u_register_t arg1,
+
+ 	params_early_setup(arg1);
+
+-	if (rockchip_get_uart_base() != 0)
++	if (rockchip_get_uart_base() != 0) {
+ 		console_16550_register(rockchip_get_uart_base(),
+ 				       rockchip_get_uart_clock(),
+ 				       rockchip_get_uart_baudrate(), &console);
++		console_set_scope(&console.console,
++				  CONSOLE_FLAG_BOOT | CONSOLE_FLAG_RUNTIME | CONSOLE_FLAG_CRASH);
++	}
+
+ 	VERBOSE("bl31_setup\n");


### PR DESCRIPTION
This changes the UART baudrate in ATF to rk3399 defaut 1500000 and enables console for logging.

IMHO it is valuable to see the info about compiled ATF version during boot - lines starting with `NOTICE:` below.

```
U-Boot TPL 2019.10-armbian (Dec 01 2019 - 22:22:46)
Trying to boot from BOOTROM
Returning to boot ROM...

U-Boot SPL 2019.10-armbian (Dec 01 2019 - 22:22:46 +0100)
Trying to boot from MMC1
NOTICE:  BL31: v2.2(release):a04808c-dirty
NOTICE:  BL31: Built : 22:22:42, Dec  1 2019

U-Boot 2019.10-armbian (Dec 01 2019 - 22:22:46 +0100)
```