### PR TITLE
Sunvell R69: enable eMMC boot

### DIFF
--- a/patch/u-boot/u-boot-sunxi/add-sunvell-r69.patch
+++ b/patch/u-boot/u-boot-sunxi/add-sunvell-r69.patch
@@ -1,9 +1,9 @@
 diff --git a/configs/sunvell_r69_defconfig b/configs/sunvell_r69_defconfig
 new file mode 100644
-index 0000000..afbeb08
+index 0000000..d03dcec
 --- /dev/null
 +++ b/configs/sunvell_r69_defconfig
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,20 @@
 +CONFIG_ARM=y
 +CONFIG_ARCH_SUNXI=y
 +CONFIG_SPL=y
@@ -21,6 +21,9 @@ index 0000000..afbeb08
 +CONFIG_USB_EHCI_HCD=y
 +CONFIG_USB_OHCI_HCD=y
 +CONFIG_SYS_USB_EVENT_POLL_VIA_INT_QUEUE=y
++CONFIG_MMC_SUNXI_SLOT_EXTRA=2
++CONFIG_SYS_CLK_FREQ=480000000
++
 diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
 index 81fb8be..73de6f6 100755
 --- a/arch/arm/dts/Makefile


### PR DESCRIPTION
Added CONFIG_MMC_SUNXI_SLOT_EXTRA=2 to defconfig to enable booting from eMMC. Works.
