### PR TITLE
armbian-add-overlay: fixed for non-dev-branches

### DIFF
--- a/packages/bsp/common/usr/sbin/armbian-add-overlay
+++ b/packages/bsp/common/usr/sbin/armbian-add-overlay
@@ -40,11 +40,6 @@ if [[ $LINUXFAMILY != sunxi && $LINUXFAMILY != sunxi64 ]]; then
 	exit -1
 fi
 
-if [[ $BRANCH != next && $BRANCH != dev ]]; then
-	echo >&2 "Overlays are supported only on mainline kernel based images"
-	exit -1
-fi
-
 if [[ -d /lib/modules/$(uname -r)/build/scripts/dtc ]]; then
 	if [[ ! -x /lib/modules/$(uname -r)/build/scripts/dtc/dtc ]]; then
 		# Can't use distribution provided (i.e. Bionic) dtc yet


### PR DESCRIPTION
Current version only allows user-added overlays for 'dev' kernels. Excluding 'legacy' kernels should not be necessary anymore since <4 kernels are not supported anymore.
