### PR TITLE
Enable derivation of stable MAC address from cpuid on rk3399

### DIFF
--- a/patch/u-boot/u-boot-rk3399/rk3399-enable-stable-mac.patch
+++ b/patch/u-boot/u-boot-rk3399/rk3399-enable-stable-mac.patch
@@ -1,0 +1,15 @@
+diff --git a/include/configs/rk3399_common.h b/include/configs/rk3399_common.h
+index 126c3476..c6dccf4f 100644
+--- a/include/configs/rk3399_common.h
++++ b/include/configs/rk3399_common.h
+@@ -19,6 +19,10 @@
+ #define CONFIG_SYS_INIT_SP_ADDR		0x00300000
+ #define CONFIG_SYS_LOAD_ADDR		0x00800800
+ 
++#define CONFIG_MISC 1
++#define CONFIG_MISC_INIT_R 1
++#define CONFIG_ROCKCHIP_EFUSE 1
++
+ #if defined(CONFIG_SPL_BUILD) && defined(CONFIG_TPL_BOOTROM_SUPPORT)
+ #define CONFIG_SPL_STACK		0x00400000
+ #define CONFIG_SPL_MAX_SIZE             0x40000


### PR DESCRIPTION
u-boot v2019.10 introduced support for deriving a stable MAC address based on cpuid stored in efuse subsystem of rk3399.

By default it is only enabled on a few devices. Let's enable it on all boards in rk3399 family.