### PR TITLE
(partially) fix armbian overlays - refactor pinctrl names

### DIFF
--- a/patch/kernel/sunxi-current/general-sunxi-overlays.patch
+++ b/patch/kernel/sunxi-current/general-sunxi-overlays.patch
@@ -1,10 +1,10 @@
 diff --git a/arch/arm/boot/dts/Makefile b/arch/arm/boot/dts/Makefile
-index a48dc14..68da8fc 100644
+index 965a7c0..71a672e 100644
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -1136,3 +1136,5 @@ dtb-$(CONFIG_ARCH_ASPEED) += \
- 	aspeed-bmc-opp-witherspoon.dtb \
+@@ -1213,3 +1213,5 @@ dtb-$(CONFIG_ARCH_ASPEED) += \
  	aspeed-bmc-opp-zaius.dtb \
+ 	aspeed-bmc-portwell-neptune.dtb \
  	aspeed-bmc-quanta-q71l.dtb
 +
 +subdir-y	:= overlay
@@ -1217,7 +1217,7 @@ index 0000000..4be3a38
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-fixup.scr-cmd b/arch/arm/boot/dts/overlay/sun4i-a10-fixup.scr-cmd
 new file mode 100644
-index 0000000..8dd3eeb
+index 0000000..d80f2fc
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-fixup.scr-cmd
 @@ -0,0 +1,124 @@
@@ -1347,7 +1347,7 @@ index 0000000..8dd3eeb
 +fi
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-i2c1.dts b/arch/arm/boot/dts/overlay/sun4i-a10-i2c1.dts
 new file mode 100644
-index 0000000..44a7ce9
+index 0000000..0b31052
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-i2c1.dts
 @@ -0,0 +1,22 @@
@@ -1375,7 +1375,7 @@ index 0000000..44a7ce9
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-i2c2.dts b/arch/arm/boot/dts/overlay/sun4i-a10-i2c2.dts
 new file mode 100644
-index 0000000..ab3c00f
+index 0000000..04b489f
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-i2c2.dts
 @@ -0,0 +1,22 @@
@@ -1568,7 +1568,7 @@ index 0000000..1927fc5
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-spdif-out.dts b/arch/arm/boot/dts/overlay/sun4i-a10-spdif-out.dts
 new file mode 100644
-index 0000000..5811e47
+index 0000000..234dfc8
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-spdif-out.dts
 @@ -0,0 +1,38 @@
@@ -1582,7 +1582,7 @@ index 0000000..5811e47
 +		target = <&spdif>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&spdif_tx_pins_a>;
++			pinctrl-0 = <&spdif_tx_pin>;
 +			status = "okay";
 +		};
 +	};
@@ -1612,7 +1612,7 @@ index 0000000..5811e47
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-spi-jedec-nor.dts b/arch/arm/boot/dts/overlay/sun4i-a10-spi-jedec-nor.dts
 new file mode 100644
-index 0000000..9cf640f
+index 0000000..617bf75
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-spi-jedec-nor.dts
 @@ -0,0 +1,57 @@
@@ -1675,7 +1675,7 @@ index 0000000..9cf640f
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-spi-spidev.dts b/arch/arm/boot/dts/overlay/sun4i-a10-spi-spidev.dts
 new file mode 100644
-index 0000000..f603d6d
+index 0000000..a570c86
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-spi-spidev.dts
 @@ -0,0 +1,57 @@
@@ -1738,7 +1738,7 @@ index 0000000..f603d6d
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-spi0.dts b/arch/arm/boot/dts/overlay/sun4i-a10-spi0.dts
 new file mode 100644
-index 0000000..0444262
+index 0000000..132f780
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-spi0.dts
 @@ -0,0 +1,23 @@
@@ -1767,7 +1767,7 @@ index 0000000..0444262
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-spi1.dts b/arch/arm/boot/dts/overlay/sun4i-a10-spi1.dts
 new file mode 100644
-index 0000000..3c3fcb8
+index 0000000..1d5c9df
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-spi1.dts
 @@ -0,0 +1,22 @@
@@ -1795,7 +1795,7 @@ index 0000000..3c3fcb8
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-spi2.dts b/arch/arm/boot/dts/overlay/sun4i-a10-spi2.dts
 new file mode 100644
-index 0000000..b38e04c
+index 0000000..145f285
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-spi2.dts
 @@ -0,0 +1,23 @@
@@ -1824,7 +1824,7 @@ index 0000000..b38e04c
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-uart2.dts b/arch/arm/boot/dts/overlay/sun4i-a10-uart2.dts
 new file mode 100644
-index 0000000..41ce3e6
+index 0000000..89bb44d
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-uart2.dts
 @@ -0,0 +1,37 @@
@@ -1867,7 +1867,7 @@ index 0000000..41ce3e6
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-uart3.dts b/arch/arm/boot/dts/overlay/sun4i-a10-uart3.dts
 new file mode 100644
-index 0000000..0b70a65
+index 0000000..f599d92
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-uart3.dts
 @@ -0,0 +1,47 @@
@@ -1920,7 +1920,7 @@ index 0000000..0b70a65
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-uart4.dts b/arch/arm/boot/dts/overlay/sun4i-a10-uart4.dts
 new file mode 100644
-index 0000000..0677c63
+index 0000000..b5e562a
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-uart4.dts
 @@ -0,0 +1,37 @@
@@ -1963,7 +1963,7 @@ index 0000000..0677c63
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-uart5.dts b/arch/arm/boot/dts/overlay/sun4i-a10-uart5.dts
 new file mode 100644
-index 0000000..0a3ed9b
+index 0000000..12c3f96
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-uart5.dts
 @@ -0,0 +1,32 @@
@@ -2001,7 +2001,7 @@ index 0000000..0a3ed9b
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-uart6.dts b/arch/arm/boot/dts/overlay/sun4i-a10-uart6.dts
 new file mode 100644
-index 0000000..f58b411
+index 0000000..6be41d5
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-uart6.dts
 @@ -0,0 +1,32 @@
@@ -2039,7 +2039,7 @@ index 0000000..f58b411
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-uart7.dts b/arch/arm/boot/dts/overlay/sun4i-a10-uart7.dts
 new file mode 100644
-index 0000000..65d8c68
+index 0000000..967f6af
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-uart7.dts
 @@ -0,0 +1,32 @@
@@ -2131,7 +2131,7 @@ index 0000000..60e2717
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-fixup.scr-cmd b/arch/arm/boot/dts/overlay/sun5i-a13-fixup.scr-cmd
 new file mode 100644
-index 0000000..db03a70
+index 0000000..9589767
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-fixup.scr-cmd
 @@ -0,0 +1,48 @@
@@ -2185,7 +2185,7 @@ index 0000000..db03a70
 +fi
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-i2c1.dts b/arch/arm/boot/dts/overlay/sun5i-a13-i2c1.dts
 new file mode 100644
-index 0000000..8d7aaff
+index 0000000..e674962
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-i2c1.dts
 @@ -0,0 +1,22 @@
@@ -2213,7 +2213,7 @@ index 0000000..8d7aaff
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-i2c2.dts b/arch/arm/boot/dts/overlay/sun5i-a13-i2c2.dts
 new file mode 100644
-index 0000000..c933d05
+index 0000000..497f618
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-i2c2.dts
 @@ -0,0 +1,22 @@
@@ -2328,7 +2328,7 @@ index 0000000..711ff9c
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-spi-jedec-nor.dts b/arch/arm/boot/dts/overlay/sun5i-a13-spi-jedec-nor.dts
 new file mode 100644
-index 0000000..168d208
+index 0000000..cece796
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-spi-jedec-nor.dts
 @@ -0,0 +1,57 @@
@@ -2391,7 +2391,7 @@ index 0000000..168d208
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-spi-spidev.dts b/arch/arm/boot/dts/overlay/sun5i-a13-spi-spidev.dts
 new file mode 100644
-index 0000000..d2329c7
+index 0000000..6294ee3
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-spi-spidev.dts
 @@ -0,0 +1,57 @@
@@ -2454,7 +2454,7 @@ index 0000000..d2329c7
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-spi0.dts b/arch/arm/boot/dts/overlay/sun5i-a13-spi0.dts
 new file mode 100644
-index 0000000..0a73644
+index 0000000..b23a754
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-spi0.dts
 @@ -0,0 +1,38 @@
@@ -2498,7 +2498,7 @@ index 0000000..0a73644
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-spi1.dts b/arch/arm/boot/dts/overlay/sun5i-a13-spi1.dts
 new file mode 100644
-index 0000000..2dc3e24
+index 0000000..cc0af5d
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-spi1.dts
 @@ -0,0 +1,39 @@
@@ -2543,7 +2543,7 @@ index 0000000..2dc3e24
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-spi2.dts b/arch/arm/boot/dts/overlay/sun5i-a13-spi2.dts
 new file mode 100644
-index 0000000..54ea7f9
+index 0000000..e8535be
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-spi2.dts
 @@ -0,0 +1,22 @@
@@ -2571,7 +2571,7 @@ index 0000000..54ea7f9
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-uart0.dts b/arch/arm/boot/dts/overlay/sun5i-a13-uart0.dts
 new file mode 100644
-index 0000000..726514f
+index 0000000..6edad42
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-uart0.dts
 @@ -0,0 +1,32 @@
@@ -2591,7 +2591,7 @@ index 0000000..726514f
 +	fragment@1 {
 +		target = <&pio>;
 +		__overlay__ {
-+			uart0_pins_a: uart0@0 {
++			uart0_pa_pins: uart0@0 {
 +				pins = "PF2", "PF4";
 +				function = "uart0";
 +			};
@@ -2602,14 +2602,14 @@ index 0000000..726514f
 +		target = <&uart0>;
 +		 __overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&uart0_pins_a>;
++			pinctrl-0 = <&uart0_pa_pins>;
 +			status = "okay";
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-uart1.dts b/arch/arm/boot/dts/overlay/sun5i-a13-uart1.dts
 new file mode 100644
-index 0000000..53d745e
+index 0000000..b165d5e
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-uart1.dts
 @@ -0,0 +1,22 @@
@@ -2637,7 +2637,7 @@ index 0000000..53d745e
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-uart2.dts b/arch/arm/boot/dts/overlay/sun5i-a13-uart2.dts
 new file mode 100644
-index 0000000..89b9fc4
+index 0000000..fa2d0f1
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-uart2.dts
 @@ -0,0 +1,22 @@
@@ -2665,7 +2665,7 @@ index 0000000..89b9fc4
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-uart3.dts b/arch/arm/boot/dts/overlay/sun5i-a13-uart3.dts
 new file mode 100644
-index 0000000..028ea08
+index 0000000..d474544
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-uart3.dts
 @@ -0,0 +1,22 @@
@@ -2733,7 +2733,7 @@ index 0000000..65aebcd
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-fixup.scr-cmd b/arch/arm/boot/dts/overlay/sun7i-a20-fixup.scr-cmd
 new file mode 100644
-index 0000000..5a320b8
+index 0000000..db3cec8
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-fixup.scr-cmd
 @@ -0,0 +1,143 @@
@@ -2882,7 +2882,7 @@ index 0000000..5a320b8
 +fi
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-i2c1.dts b/arch/arm/boot/dts/overlay/sun7i-a20-i2c1.dts
 new file mode 100644
-index 0000000..d1146ee
+index 0000000..c5f6e97
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-i2c1.dts
 @@ -0,0 +1,22 @@
@@ -2903,14 +2903,14 @@ index 0000000..d1146ee
 +		target = <&i2c1>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&i2c1_pins_a>;
++			pinctrl-0 = <&i2c1_pins>;
 +			status = "okay";
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-i2c2.dts b/arch/arm/boot/dts/overlay/sun7i-a20-i2c2.dts
 new file mode 100644
-index 0000000..e6b32de
+index 0000000..fa93d1e
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-i2c2.dts
 @@ -0,0 +1,22 @@
@@ -2931,14 +2931,14 @@ index 0000000..e6b32de
 +		target = <&i2c2>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&i2c2_pins_a>;
++			pinctrl-0 = <&i2c2_pins>;
 +			status = "okay";
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-i2c3.dts b/arch/arm/boot/dts/overlay/sun7i-a20-i2c3.dts
 new file mode 100644
-index 0000000..5273d06
+index 0000000..945795c
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-i2c3.dts
 @@ -0,0 +1,22 @@
@@ -2959,14 +2959,14 @@ index 0000000..5273d06
 +		target = <&i2c3>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&i2c3_pins_a>;
++			pinctrl-0 = <&i2c3_pins>;
 +			status = "okay";
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-i2c4.dts b/arch/arm/boot/dts/overlay/sun7i-a20-i2c4.dts
 new file mode 100644
-index 0000000..113a220
+index 0000000..4fcf08c
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-i2c4.dts
 @@ -0,0 +1,32 @@
@@ -2997,7 +2997,7 @@ index 0000000..113a220
 +		target = <&i2c4>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&i2c4_pins_a>;
++			pinctrl-0 = <&i2c4_pins>;
 +			status = "okay";
 +		};
 +	};
@@ -3066,7 +3066,7 @@ index 0000000..e6f0a22
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-mmc2.dts b/arch/arm/boot/dts/overlay/sun7i-a20-mmc2.dts
 new file mode 100644
-index 0000000..f1ddbaa
+index 0000000..ede92f2
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-mmc2.dts
 @@ -0,0 +1,18 @@
@@ -3080,7 +3080,7 @@ index 0000000..f1ddbaa
 +		target = <&mmc2>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&mmc2_pins_a>;
++			pinctrl-0 = <&mmc2_pins>;
 +			vmmc-supply = <&reg_vcc3v3>;
 +			bus-width = <4>;
 +			cd-gpios = <&pio 7 0 1>; /* PH0, active low */
@@ -3234,7 +3234,7 @@ index 0000000..fe3e2bd
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-pwm.dts b/arch/arm/boot/dts/overlay/sun7i-a20-pwm.dts
 new file mode 100644
-index 0000000..a0cc469
+index 0000000..b9978c6
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-pwm.dts
 @@ -0,0 +1,15 @@
@@ -3248,14 +3248,14 @@ index 0000000..a0cc469
 +		target = <&pwm>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&pwm0_pins_a>, <&pwm1_pins_a>;
++			pinctrl-0 = <&pwm0_pins>, <&pwm1_pins>;
 +			status = "okay";
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-spdif-out.dts b/arch/arm/boot/dts/overlay/sun7i-a20-spdif-out.dts
 new file mode 100644
-index 0000000..7983ad0
+index 0000000..11a0939
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-spdif-out.dts
 @@ -0,0 +1,38 @@
@@ -3269,7 +3269,7 @@ index 0000000..7983ad0
 +		target = <&spdif>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&spdif_tx_pins_a>;
++			pinctrl-0 = <&spdif_tx_pin>;
 +			status = "okay";
 +		};
 +	};
@@ -3299,7 +3299,7 @@ index 0000000..7983ad0
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-spi-add-cs1.dts b/arch/arm/boot/dts/overlay/sun7i-a20-spi-add-cs1.dts
 new file mode 100644
-index 0000000..2de39a2
+index 0000000..c0a4ba2
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-spi-add-cs1.dts
 @@ -0,0 +1,16 @@
@@ -3313,15 +3313,15 @@ index 0000000..2de39a2
 +		target = <&spi0>;
 +		__overlay__ {
 +			pinctrl-names = "default", "default", "default";
-+			pinctrl-0 = <&spi0_pins_a>;
-+			pinctrl-1 = <&spi0_cs0_pins_a>;
-+			pinctrl-2 = <&spi0_cs1_pins_a>;
++			pinctrl-0 = <&spi0_pi_pins>;
++			pinctrl-1 = <&spi0_cs0_pi_pin>;
++			pinctrl-2 = <&spi0_cs1_pi_pin>;
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-spi-jedec-nor.dts b/arch/arm/boot/dts/overlay/sun7i-a20-spi-jedec-nor.dts
 new file mode 100644
-index 0000000..baf59df
+index 0000000..efd147c
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-spi-jedec-nor.dts
 @@ -0,0 +1,57 @@
@@ -3384,7 +3384,7 @@ index 0000000..baf59df
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-spi-spidev.dts b/arch/arm/boot/dts/overlay/sun7i-a20-spi-spidev.dts
 new file mode 100644
-index 0000000..8d0f6ac
+index 0000000..f8faa97
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-spi-spidev.dts
 @@ -0,0 +1,57 @@
@@ -3447,7 +3447,7 @@ index 0000000..8d0f6ac
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-spi0.dts b/arch/arm/boot/dts/overlay/sun7i-a20-spi0.dts
 new file mode 100644
-index 0000000..0444262
+index 0000000..cad50d8
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-spi0.dts
 @@ -0,0 +1,23 @@
@@ -3469,14 +3469,14 @@ index 0000000..0444262
 +		__overlay__ {
 +			status = "okay";
 +			pinctrl-names = "default", "default";
-+			pinctrl-0 = <&spi0_pins_a>;
-+			pinctrl-1 = <&spi0_cs0_pins_a>;
++			pinctrl-0 = <&spi0_pi_pins>;
++			pinctrl-1 = <&spi0_cs0_pi_pin>;
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-spi1.dts b/arch/arm/boot/dts/overlay/sun7i-a20-spi1.dts
 new file mode 100644
-index 0000000..3c3fcb8
+index 0000000..f0218eb
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-spi1.dts
 @@ -0,0 +1,22 @@
@@ -3498,13 +3498,13 @@ index 0000000..3c3fcb8
 +		__overlay__ {
 +			status = "okay";
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&spi1_pins_a>, <&spi1_cs0_pins_a>;
++			pinctrl-0 = <&spi1_pi_pins>, <&spi1_cs0_pi_pin>;
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-spi2.dts b/arch/arm/boot/dts/overlay/sun7i-a20-spi2.dts
 new file mode 100644
-index 0000000..b38e04c
+index 0000000..effba42
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-spi2.dts
 @@ -0,0 +1,23 @@
@@ -3526,14 +3526,14 @@ index 0000000..b38e04c
 +		__overlay__ {
 +			status = "okay";
 +			pinctrl-names = "default", "default";
-+			pinctrl-0 = <&spi2_pins_a>;
-+			pinctrl-1 = <&spi2_cs0_pins_a>;
++			pinctrl-0 = <&spi2_pb_pins>;
++			pinctrl-1 = <&spi2_pb_cs0_pin>;
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-uart2.dts b/arch/arm/boot/dts/overlay/sun7i-a20-uart2.dts
 new file mode 100644
-index 0000000..b4f7230
+index 0000000..79d1dca
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-uart2.dts
 @@ -0,0 +1,32 @@
@@ -3571,7 +3571,7 @@ index 0000000..b4f7230
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-uart3.dts b/arch/arm/boot/dts/overlay/sun7i-a20-uart3.dts
 new file mode 100644
-index 0000000..75e79ea
+index 0000000..703acbc
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-uart3.dts
 @@ -0,0 +1,42 @@
@@ -3619,7 +3619,7 @@ index 0000000..75e79ea
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-uart4.dts b/arch/arm/boot/dts/overlay/sun7i-a20-uart4.dts
 new file mode 100644
-index 0000000..008cf83
+index 0000000..1918034
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-uart4.dts
 @@ -0,0 +1,22 @@
@@ -3640,14 +3640,14 @@ index 0000000..008cf83
 +		target = <&uart4>;
 +		 __overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&uart4_pins_a>;
++			pinctrl-0 = <&uart4_pg_pins>;
 +			status = "okay";
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-uart5.dts b/arch/arm/boot/dts/overlay/sun7i-a20-uart5.dts
 new file mode 100644
-index 0000000..3236710
+index 0000000..a1369ee
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-uart5.dts
 @@ -0,0 +1,22 @@
@@ -3668,14 +3668,14 @@ index 0000000..3236710
 +		target = <&uart5>;
 +		 __overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&uart5_pins_a>;
++			pinctrl-0 = <&uart5_pi_pins>;
 +			status = "okay";
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-uart6.dts b/arch/arm/boot/dts/overlay/sun7i-a20-uart6.dts
 new file mode 100644
-index 0000000..1243538
+index 0000000..fb9efe2
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-uart6.dts
 @@ -0,0 +1,22 @@
@@ -3696,14 +3696,14 @@ index 0000000..1243538
 +		target = <&uart6>;
 +		 __overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&uart6_pins_a>;
++			pinctrl-0 = <&uart6_pi_pins>;
 +			status = "okay";
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-uart7.dts b/arch/arm/boot/dts/overlay/sun7i-a20-uart7.dts
 new file mode 100644
-index 0000000..3087271
+index 0000000..bbdca3e
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-uart7.dts
 @@ -0,0 +1,22 @@
@@ -3724,7 +3724,7 @@ index 0000000..3087271
 +		target = <&uart7>;
 +		 __overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&uart7_pins_a>;
++			pinctrl-0 = <&uart7_pi_pins>;
 +			status = "okay";
 +		};
 +	};
@@ -3789,7 +3789,7 @@ index 0000000..36dbc31
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun8i-h3-cir.dts b/arch/arm/boot/dts/overlay/sun8i-h3-cir.dts
 new file mode 100644
-index 0000000..9b62fd2
+index 0000000..bf4a0ea
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun8i-h3-cir.dts
 @@ -0,0 +1,15 @@
@@ -3803,14 +3803,14 @@ index 0000000..9b62fd2
 +		target = <&ir>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&ir_pins_a>;
++			pinctrl-0 = <&r_ir_rx_pin>;
 +			status = "okay";
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun8i-h3-fixup.scr-cmd b/arch/arm/boot/dts/overlay/sun8i-h3-fixup.scr-cmd
 new file mode 100644
-index 0000000..744889c
+index 0000000..142b7e5
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun8i-h3-fixup.scr-cmd
 @@ -0,0 +1,110 @@
@@ -3926,7 +3926,7 @@ index 0000000..744889c
 +fi
 diff --git a/arch/arm/boot/dts/overlay/sun8i-h3-i2c0.dts b/arch/arm/boot/dts/overlay/sun8i-h3-i2c0.dts
 new file mode 100644
-index 0000000..b457ac7
+index 0000000..a36ac86
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun8i-h3-i2c0.dts
 @@ -0,0 +1,20 @@
@@ -3952,7 +3952,7 @@ index 0000000..b457ac7
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun8i-h3-i2c1.dts b/arch/arm/boot/dts/overlay/sun8i-h3-i2c1.dts
 new file mode 100644
-index 0000000..fd0928a
+index 0000000..258c86d
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun8i-h3-i2c1.dts
 @@ -0,0 +1,20 @@
@@ -3978,7 +3978,7 @@ index 0000000..fd0928a
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun8i-h3-i2c2.dts b/arch/arm/boot/dts/overlay/sun8i-h3-i2c2.dts
 new file mode 100644
-index 0000000..25b75b7
+index 0000000..a1e3284
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun8i-h3-i2c2.dts
 @@ -0,0 +1,20 @@
@@ -4084,7 +4084,7 @@ index 0000000..ed3b8e6
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun8i-h3-spdif-out.dts b/arch/arm/boot/dts/overlay/sun8i-h3-spdif-out.dts
 new file mode 100644
-index 0000000..c7c0141
+index 0000000..35b2d56
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun8i-h3-spdif-out.dts
 @@ -0,0 +1,38 @@
@@ -4098,7 +4098,7 @@ index 0000000..c7c0141
 +		target = <&spdif>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&spdif_tx_pins_a>;
++			pinctrl-0 = <&spdif_tx_pin>;
 +			status = "okay";
 +		};
 +	};
@@ -4175,7 +4175,7 @@ index 0000000..bd8e256
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun8i-h3-spi-jedec-nor.dts b/arch/arm/boot/dts/overlay/sun8i-h3-spi-jedec-nor.dts
 new file mode 100644
-index 0000000..ad22a71
+index 0000000..6e53bbb
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun8i-h3-spi-jedec-nor.dts
 @@ -0,0 +1,42 @@
@@ -4223,7 +4223,7 @@ index 0000000..ad22a71
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun8i-h3-spi-spidev.dts b/arch/arm/boot/dts/overlay/sun8i-h3-spi-spidev.dts
 new file mode 100644
-index 0000000..180979e
+index 0000000..9c4c907
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun8i-h3-spi-spidev.dts
 @@ -0,0 +1,42 @@
@@ -4271,7 +4271,7 @@ index 0000000..180979e
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun8i-h3-uart1.dts b/arch/arm/boot/dts/overlay/sun8i-h3-uart1.dts
 new file mode 100644
-index 0000000..8a4f7e4
+index 0000000..3c10d4d
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun8i-h3-uart1.dts
 @@ -0,0 +1,22 @@
@@ -4299,7 +4299,7 @@ index 0000000..8a4f7e4
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun8i-h3-uart2.dts b/arch/arm/boot/dts/overlay/sun8i-h3-uart2.dts
 new file mode 100644
-index 0000000..499a1b4
+index 0000000..f16e618
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun8i-h3-uart2.dts
 @@ -0,0 +1,22 @@
@@ -4327,7 +4327,7 @@ index 0000000..499a1b4
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun8i-h3-uart3.dts b/arch/arm/boot/dts/overlay/sun8i-h3-uart3.dts
 new file mode 100644
-index 0000000..b5734c5
+index 0000000..b1aef57
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun8i-h3-uart3.dts
 @@ -0,0 +1,22 @@
@@ -4521,18 +4521,18 @@ index 0000000..f4ccb7f
 +	};
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
-index 94de6044..1e85fd7c 100644
+index fa35163..89df4ff 100644
 --- a/arch/arm64/boot/dts/allwinner/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/Makefile
-@@ -14,3 +14,4 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-zero-plus.dtb
- dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo2.dtb
- dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo-plus2.dtb
+@@ -31,3 +31,5 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-orangepi-lite2.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-orangepi-one-plus.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-pine-h64.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6.dtb
++
 +subdir-y	:= $(dts-dirs) overlay
-\ No newline at end of file
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/Makefile b/arch/arm64/boot/dts/allwinner/overlay/Makefile
 new file mode 100644
-index 0000000..5cad268
+index 0000000..128d32c
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/Makefile
 @@ -0,0 +1,53 @@
@@ -4589,11 +4589,6 @@ index 0000000..5cad268
 +dtbotxt-$(CONFIG_ARCH_SUNXI) += \
 +	README.sun50i-a64-overlays \
 +	README.sun50i-h5-overlays
-+
-+targets += $(dtbo-y) $(scr-y) $(dtbotxt-y)
-+
-+always		:= $(dtbo-y) $(scr-y) $(dtbotxt-y)
-+clean-files	:= *.dtbo *.scr
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/README.sun50i-a64-overlays b/arch/arm64/boot/dts/allwinner/overlay/README.sun50i-a64-overlays
 new file mode 100644
 index 0000000..cd9dbc6
@@ -5054,7 +5049,7 @@ index 0000000..1ac7fbc
 +		or long wires -	please use external pull-up resistor instead
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-fixup.scr-cmd b/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-fixup.scr-cmd
 new file mode 100644
-index 0000000..6e192b5
+index 0000000..36df83c
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-fixup.scr-cmd
 @@ -0,0 +1,95 @@
@@ -5303,7 +5298,7 @@ index 0000000..4432aac
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-spi-jedec-nor.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-spi-jedec-nor.dts
 new file mode 100644
-index 0000000..d67a4f6
+index 0000000..31d73e5
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-spi-jedec-nor.dts
 @@ -0,0 +1,34 @@
@@ -5500,7 +5495,7 @@ index 0000000..a103a75
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-uart4.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-uart4.dts
 new file mode 100644
-index 0000000..f84333c
+index 0000000..6e4702b
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-uart4.dts
 @@ -0,0 +1,37 @@
@@ -5601,7 +5596,7 @@ index 0000000..aaa66d5
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-cir.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-cir.dts
 new file mode 100644
-index 0000000..74569cb
+index 0000000..90c264a
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-cir.dts
 @@ -0,0 +1,15 @@
@@ -5615,14 +5610,14 @@ index 0000000..74569cb
 +		target = <&ir>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&ir_pins_a>;
++			pinctrl-0 = <&r_ir_rx_pin>;
 +			status = "okay";
 +		};
 +	};
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-fixup.scr-cmd b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-fixup.scr-cmd
 new file mode 100644
-index 0000000..744889c
+index 0000000..f7b89ae
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-fixup.scr-cmd
 @@ -0,0 +1,110 @@
@@ -5738,7 +5733,7 @@ index 0000000..744889c
 +fi
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-i2c0.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-i2c0.dts
 new file mode 100644
-index 0000000..55d249d
+index 0000000..87fbd7e
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-i2c0.dts
 @@ -0,0 +1,20 @@
@@ -5764,7 +5759,7 @@ index 0000000..55d249d
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-i2c1.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-i2c1.dts
 new file mode 100644
-index 0000000..2528870
+index 0000000..6008b9a
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-i2c1.dts
 @@ -0,0 +1,20 @@
@@ -5790,7 +5785,7 @@ index 0000000..2528870
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-i2c2.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-i2c2.dts
 new file mode 100644
-index 0000000..ff42f01
+index 0000000..2980dbf
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-i2c2.dts
 @@ -0,0 +1,20 @@
@@ -5896,7 +5891,7 @@ index 0000000..6d12e84
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-spdif-out.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-spdif-out.dts
 new file mode 100644
-index 0000000..2bb301f
+index 0000000..65bc51b
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-spdif-out.dts
 @@ -0,0 +1,38 @@
@@ -5910,7 +5905,7 @@ index 0000000..2bb301f
 +		target = <&spdif>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&spdif_tx_pins_a>;
++			pinctrl-0 = <&spdif_tx_pin>;
 +			status = "okay";
 +		};
 +	};
@@ -5987,7 +5982,7 @@ index 0000000..8e3eab2
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-spi-jedec-nor.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-spi-jedec-nor.dts
 new file mode 100644
-index 0000000..d4accd9
+index 0000000..5a45808
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-spi-jedec-nor.dts
 @@ -0,0 +1,42 @@
@@ -6035,7 +6030,7 @@ index 0000000..d4accd9
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-spi-spidev.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-spi-spidev.dts
 new file mode 100644
-index 0000000..d8a008d
+index 0000000..70f435b
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-spi-spidev.dts
 @@ -0,0 +1,42 @@
@@ -6083,7 +6078,7 @@ index 0000000..d8a008d
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-uart1.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-uart1.dts
 new file mode 100644
-index 0000000..0ce76ef
+index 0000000..92e3eb4
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-uart1.dts
 @@ -0,0 +1,22 @@
@@ -6111,7 +6106,7 @@ index 0000000..0ce76ef
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-uart2.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-uart2.dts
 new file mode 100644
-index 0000000..88cc0cd
+index 0000000..521a01d
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-uart2.dts
 @@ -0,0 +1,32 @@
@@ -6149,7 +6144,7 @@ index 0000000..88cc0cd
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-uart3.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-uart3.dts
 new file mode 100644
-index 0000000..3ad6cc9
+index 0000000..639e15d
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-uart3.dts
 @@ -0,0 +1,32 @@
@@ -6352,417 +6347,9 @@ index 0000000..6e99626
 +		};
 +	};
 +};
-diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c0.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c0.dts
-index e69de29..7e7ee8c 100644
---- /dev/null
-+++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c0.dts
-@@ -0,0 +1,20 @@
-+/dts-v1/;
-+/plugin/;
-+
-+/ {
-+	compatible = "allwinner,sun50i-h6";
-+
-+	fragment@0 {
-+		target-path = "/aliases";
-+		__overlay__ {
-+			i2c0 = "/soc/i2c@5002000";
-+		};
-+	};
-+
-+	fragment@1 {
-+		target = <&i2c0>;
-+		__overlay__ {
-+			status = "okay";
-+		};
-+	};
-+};
-diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c1.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c1.dts
-index e69de29..1117698 100644
---- /dev/null
-+++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c1.dts
-@@ -0,0 +1,20 @@
-+/dts-v1/;
-+/plugin/;
-+
-+/ {
-+	compatible = "allwinner,sun50i-h6";
-+
-+	fragment@0 {
-+		target-path = "/aliases";
-+		__overlay__ {
-+			i2c1 = "/soc/i2c@5002400";
-+		};
-+	};
-+
-+	fragment@1 {
-+		target = <&i2c1>;
-+		__overlay__ {
-+			status = "okay";
-+		};
-+	};
-+};
-diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c2.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c2.dts
-index e69de29..b627529 100644
---- /dev/null
-+++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c2.dts
-@@ -0,0 +1,20 @@
-+/dts-v1/;
-+/plugin/;
-+
-+/ {
-+	compatible = "allwinner,sun50i-h6";
-+
-+	fragment@0 {
-+		target-path = "/aliases";
-+		__overlay__ {
-+			i2c2 = "/soc/i2c@5002800";
-+		};
-+	};
-+
-+	fragment@1 {
-+		target = <&i2c2>;
-+		__overlay__ {
-+			status = "okay";
-+		};
-+	};
-+};
-diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-add-cs1.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-add-cs1.dts
-new file mode 100644
-index 0000000..0fa060f
---- /dev/null
-+++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-add-cs1.dts
-@@ -0,0 +1,41 @@
-+/dts-v1/;
-+/plugin/;
-+
-+/ {
-+	compatible = "allwinner,sun50i-h6";
-+
-+	fragment@0 {
-+		target = <&pio>;
-+		__overlay__ {
-+			spi0_cs1: spi0_cs1 {
-+				pins = "PA10";
-+				function = "gpio_out";
-+				output-high;
-+			};
-+
-+			spi1_cs1: spi1_cs1 {
-+				pins = "PA21";
-+				function = "gpio_out";
-+				output-high;
-+			};
-+		};
-+	};
-+
-+	fragment@1 {
-+		target = <&spi0>;
-+		__overlay__ {
-+			pinctrl-names = "default", "default";
-+			pinctrl-1 = <&spi0_cs1>;
-+			cs-gpios = <0>, <&pio 0 10 0>; /* PA10 */
-+		};
-+	};
-+
-+	fragment@2 {
-+		target = <&spi1>;
-+		__overlay__ {
-+			pinctrl-names = "default", "default";
-+			pinctrl-1 = <&spi1_cs1>;
-+			cs-gpios = <0>, <&pio 0 21 0>; /* PA21 */
-+		};
-+	};
-+};
-diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-jedec-nor.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-jedec-nor.dts
-new file mode 100644
-index 0000000..3a2be38
---- /dev/null
-+++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-jedec-nor.dts
-@@ -0,0 +1,42 @@
-+/dts-v1/;
-+/plugin/;
-+
-+/ {
-+	compatible = "allwinner,sun50i-h6";
-+
-+	fragment@0 {
-+		target-path = "/aliases";
-+		__overlay__ {
-+			spi0 = "/soc/spi@5010000";
-+			spi1 = "/soc/spi@5011000";
-+		};
-+	};
-+
-+	fragment@1 {
-+		target = <&spi0>;
-+		__overlay__ {
-+			#address-cells = <1>;
-+			#size-cells = <0>;
-+			spiflash@0 {
-+				compatible = "jedec,spi-nor";
-+				reg = <0>;
-+				spi-max-frequency = <1000000>;
-+				status = "disabled";
-+			};
-+		};
-+	};
-+
-+	fragment@2 {
-+		target = <&spi1>;
-+		__overlay__ {
-+			#address-cells = <1>;
-+			#size-cells = <0>;
-+			spiflash@0 {
-+				compatible = "jedec,spi-nor";
-+				reg = <0>;
-+				spi-max-frequency = <1000000>;
-+				status = "disabled";
-+			};
-+		};
-+	};
-+};
-diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-spidev.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-spidev.dts
-new file mode 100644
-index 0000000..fd807d6
---- /dev/null
-+++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-spidev.dts
-@@ -0,0 +1,42 @@
-+/dts-v1/;
-+/plugin/;
-+
-+/ {
-+	compatible = "allwinner,sun50i-h6";
-+
-+	fragment@0 {
-+		target-path = "/aliases";
-+		__overlay__ {
-+			spi0 = "/soc/spi@5010000";
-+			spi1 = "/soc/spi@5011000";
-+		};
-+	};
-+
-+	fragment@1 {
-+		target = <&spi0>;
-+		__overlay__ {
-+			#address-cells = <1>;
-+			#size-cells = <0>;
-+			spidev {
-+				compatible = "spidev";
-+				status = "disabled";
-+				reg = <0>;
-+				spi-max-frequency = <1000000>;
-+			};
-+		};
-+	};
-+
-+	fragment@2 {
-+		target = <&spi1>;
-+		__overlay__ {
-+			#address-cells = <1>;
-+			#size-cells = <0>;
-+			spidev {
-+				compatible = "spidev";
-+				status = "disabled";
-+				reg = <0>;
-+				spi-max-frequency = <1000000>;
-+			};
-+		};
-+	};
-+};
-diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-spidev1.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-spidev1.dts
-new file mode 100644
-index 0000000..fd807d6
---- /dev/null
-+++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-spidev1.dts
-@@ -0,0 +1,30 @@
-+// Enable the spidev interface
-+/dts-v1/;
-+/plugin/;
-+
-+/ {
-+    compatible = "allwinner,sun8i-h6";
-+
-+    fragment@0 {
-+	target-path = "/aliases";
-+	__overlay__ {
-+            /* Path to the SPI controller nodes */
-+            spi1 = "/soc/spi@5011000";
-+        };
-+    };
-+    fragment@1 {
-+        target = <&spi1>;
-+        __overlay__ {
-+            pinctrl-names = "default";
-+            pinctrl-0 = <&spi1_pins>;
-+            status = "okay";
-+            #address-cells = <1>;
-+            #size-cells = <0>;
-+            spidev@0 {
-+                compatible = "spidev";
-+                reg = <0x0>;
-+                spi-max-frequency = <1000000>;
-+            };
-+        };
-+    };
-+};
-diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart1.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart1.dts
-index e69de29..44aa94e 100644
---- /dev/null
-+++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart1.dts
-@@ -0,0 +1,22 @@
-+/dts-v1/;
-+/plugin/;
-+
-+/ {
-+	compatible = "allwinner,sun50i-h6";
-+
-+	fragment@0 {
-+		target-path = "/aliases";
-+		__overlay__ {
-+			serial1 = "/soc/serial@5000400";
-+		};
-+	};
-+
-+	fragment@1 {
-+		target = <&uart1>;
-+		 __overlay__ {
-+			pinctrl-names = "default";
-+			pinctrl-0 = <&uart1_pins>;
-+			status = "okay";
-+		};
-+	};
-+};
-diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart2.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart2.dts
-index e69de29..7a1860e 100644
---- /dev/null
-+++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart2.dts
-@@ -0,0 +1,32 @@
-+/dts-v1/;
-+/plugin/;
-+
-+/ {
-+	compatible = "allwinner,sun50i-h6";
-+
-+	fragment@0 {
-+		target-path = "/aliases";
-+		__overlay__ {
-+			serial2 = "/soc/serial@5000800";
-+		};
-+	};
-+
-+	fragment@1 {
-+		target = <&pio>;
-+		__overlay__ {
-+			uart2_rts_cts: uart2_rts_cts {
-+				pins = "PD21", "PD22";
-+				function = "uart2";
-+			};
-+		};
-+	};
-+
-+	fragment@2 {
-+		target = <&uart2>;
-+		 __overlay__ {
-+			pinctrl-names = "default";
-+			pinctrl-0 = <&uart2_pins>;
-+			status = "okay";
-+		};
-+	};
-+};
-diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart3.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart3.dts
-index e69de29..38a59ac 100644
---- /dev/null
-+++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart3.dts
-@@ -0,0 +1,32 @@
-+/dts-v1/;
-+/plugin/;
-+
-+/ {
-+	compatible = "allwinner,sun50i-h6";
-+
-+	fragment@0 {
-+		target-path = "/aliases";
-+		__overlay__ {
-+			serial3 = "/soc/serial@5000c00";
-+		};
-+	};
-+
-+	fragment@1 {
-+		target = <&pio>;
-+		__overlay__ {
-+			uart3_rts_cts: uart3_rts_cts {
-+				pins = "PD25", "PD26";
-+				function = "uart3";
-+			};
-+		};
-+	};
-+
-+	fragment@2 {
-+		target = <&uart3>;
-+		 __overlay__ {
-+			pinctrl-names = "default";
-+			pinctrl-0 = <&uart3_pins>;
-+			status = "okay";
-+		};
-+	};
-+};
-diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-ruart.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-ruart.dts
-index e69de29..38a59ac 100644
---- /dev/null
-+++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-ruart.dts
-@@ -0,0 +1,13 @@
-+/dts-v1/;
-+/plugin/;
-+
-+/ {
-+	compatible = "allwinner,sun50i-h6";
-+
-+	fragment@0 {
-+		target = <&r_uart>;
-+		 __overlay__ {
-+			status = "okay";
-+		};
-+	};
-+};
-diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-w1-gpio.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-w1-gpio.dts
-new file mode 100644
-index 0000000..a4cd713
---- /dev/null
-+++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-w1-gpio.dts
-@@ -0,0 +1,29 @@
-+/dts-v1/;
-+/plugin/;
-+
-+/ {
-+	compatible = "allwinner,sun50i-h6";
-+
-+	fragment@0 {
-+		target = <&pio>;
-+		__overlay__ {
-+			w1_pins: w1_pins {
-+				pins = "PC9";
-+				function = "gpio_in";
-+			};
-+		};
-+	};
-+
-+	fragment@1 {
-+		target-path = "/";
-+		__overlay__ {
-+			onewire@0 {
-+				compatible = "w1-gpio";
-+				pinctrl-names = "default";
-+				pinctrl-0 = <&w1_pins>;
-+				gpios = <&pio 2 9 0>; /* PC9 */
-+				status = "okay";
-+			};
-+		};
-+	};
-+};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-fixup.scr-cmd b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-fixup.scr-cmd
 new file mode 100644
-index 0000000..fba1c4f
+index 0000000..5f00458
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-fixup.scr-cmd
 @@ -0,0 +1,110 @@
@@ -6876,6 +6463,421 @@ index 0000000..fba1c4f
 +	fdt set /soc/serial@5000c00 pinctrl-1 "<${tmp_phandle2}>"
 +	env delete tmp_phandle1 tmp_phandle2
 +fi
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c0.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c0.dts
+new file mode 100644
+index 0000000..7e7ee8c
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c0.dts
+@@ -0,0 +1,20 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "allwinner,sun50i-h6";
++
++	fragment@0 {
++		target-path = "/aliases";
++		__overlay__ {
++			i2c0 = "/soc/i2c@5002000";
++		};
++	};
++
++	fragment@1 {
++		target = <&i2c0>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c1.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c1.dts
+new file mode 100644
+index 0000000..1117698
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c1.dts
+@@ -0,0 +1,20 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "allwinner,sun50i-h6";
++
++	fragment@0 {
++		target-path = "/aliases";
++		__overlay__ {
++			i2c1 = "/soc/i2c@5002400";
++		};
++	};
++
++	fragment@1 {
++		target = <&i2c1>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c2.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c2.dts
+new file mode 100644
+index 0000000..b627529
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c2.dts
+@@ -0,0 +1,20 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "allwinner,sun50i-h6";
++
++	fragment@0 {
++		target-path = "/aliases";
++		__overlay__ {
++			i2c2 = "/soc/i2c@5002800";
++		};
++	};
++
++	fragment@1 {
++		target = <&i2c2>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-ruart.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-ruart.dts
+new file mode 100644
+index 0000000..6430cb0
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-ruart.dts
+@@ -0,0 +1,13 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "allwinner,sun50i-h6";
++
++	fragment@0 {
++		target = <&r_uart>;
++		 __overlay__ {
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-add-cs1.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-add-cs1.dts
+new file mode 100644
+index 0000000..0fa060f
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-add-cs1.dts
+@@ -0,0 +1,41 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "allwinner,sun50i-h6";
++
++	fragment@0 {
++		target = <&pio>;
++		__overlay__ {
++			spi0_cs1: spi0_cs1 {
++				pins = "PA10";
++				function = "gpio_out";
++				output-high;
++			};
++
++			spi1_cs1: spi1_cs1 {
++				pins = "PA21";
++				function = "gpio_out";
++				output-high;
++			};
++		};
++	};
++
++	fragment@1 {
++		target = <&spi0>;
++		__overlay__ {
++			pinctrl-names = "default", "default";
++			pinctrl-1 = <&spi0_cs1>;
++			cs-gpios = <0>, <&pio 0 10 0>; /* PA10 */
++		};
++	};
++
++	fragment@2 {
++		target = <&spi1>;
++		__overlay__ {
++			pinctrl-names = "default", "default";
++			pinctrl-1 = <&spi1_cs1>;
++			cs-gpios = <0>, <&pio 0 21 0>; /* PA21 */
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-jedec-nor.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-jedec-nor.dts
+new file mode 100644
+index 0000000..4f81dbb
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-jedec-nor.dts
+@@ -0,0 +1,42 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "allwinner,sun50i-h6";
++
++	fragment@0 {
++		target-path = "/aliases";
++		__overlay__ {
++			spi0 = "/soc/spi@5010000";
++			spi1 = "/soc/spi@5011000";
++		};
++	};
++
++	fragment@1 {
++		target = <&spi0>;
++		__overlay__ {
++			#address-cells = <1>;
++			#size-cells = <0>;
++			spiflash@0 {
++				compatible = "jedec,spi-nor";
++				reg = <0>;
++				spi-max-frequency = <1000000>;
++				status = "disabled";
++			};
++		};
++	};
++
++	fragment@2 {
++		target = <&spi1>;
++		__overlay__ {
++			#address-cells = <1>;
++			#size-cells = <0>;
++			spiflash@0 {
++				compatible = "jedec,spi-nor";
++				reg = <0>;
++				spi-max-frequency = <1000000>;
++				status = "disabled";
++			};
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-spidev.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-spidev.dts
+new file mode 100644
+index 0000000..fd807d6
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-spidev.dts
+@@ -0,0 +1,42 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "allwinner,sun50i-h6";
++
++	fragment@0 {
++		target-path = "/aliases";
++		__overlay__ {
++			spi0 = "/soc/spi@5010000";
++			spi1 = "/soc/spi@5011000";
++		};
++	};
++
++	fragment@1 {
++		target = <&spi0>;
++		__overlay__ {
++			#address-cells = <1>;
++			#size-cells = <0>;
++			spidev {
++				compatible = "spidev";
++				status = "disabled";
++				reg = <0>;
++				spi-max-frequency = <1000000>;
++			};
++		};
++	};
++
++	fragment@2 {
++		target = <&spi1>;
++		__overlay__ {
++			#address-cells = <1>;
++			#size-cells = <0>;
++			spidev {
++				compatible = "spidev";
++				status = "disabled";
++				reg = <0>;
++				spi-max-frequency = <1000000>;
++			};
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-spidev1.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-spidev1.dts
+new file mode 100644
+index 0000000..e194484
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-spidev1.dts
+@@ -0,0 +1,30 @@
++// Enable the spidev interface
++/dts-v1/;
++/plugin/;
++
++/ {
++    compatible = "allwinner,sun8i-h6";
++
++    fragment@0 {
++	target-path = "/aliases";
++	__overlay__ {
++            /* Path to the SPI controller nodes */
++            spi1 = "/soc/spi@5011000";
++        };
++    };
++    fragment@1 {
++        target = <&spi1>;
++        __overlay__ {
++            pinctrl-names = "default";
++            pinctrl-0 = <&spi1_pins>;
++            status = "okay";
++            #address-cells = <1>;
++            #size-cells = <0>;
++            spidev@0 {
++                compatible = "spidev";
++                reg = <0x0>;
++                spi-max-frequency = <1000000>;
++            };
++        };
++    };
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart1.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart1.dts
+new file mode 100644
+index 0000000..44aa94e
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart1.dts
+@@ -0,0 +1,22 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "allwinner,sun50i-h6";
++
++	fragment@0 {
++		target-path = "/aliases";
++		__overlay__ {
++			serial1 = "/soc/serial@5000400";
++		};
++	};
++
++	fragment@1 {
++		target = <&uart1>;
++		 __overlay__ {
++			pinctrl-names = "default";
++			pinctrl-0 = <&uart1_pins>;
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart2.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart2.dts
+new file mode 100644
+index 0000000..7a1860e
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart2.dts
+@@ -0,0 +1,32 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "allwinner,sun50i-h6";
++
++	fragment@0 {
++		target-path = "/aliases";
++		__overlay__ {
++			serial2 = "/soc/serial@5000800";
++		};
++	};
++
++	fragment@1 {
++		target = <&pio>;
++		__overlay__ {
++			uart2_rts_cts: uart2_rts_cts {
++				pins = "PD21", "PD22";
++				function = "uart2";
++			};
++		};
++	};
++
++	fragment@2 {
++		target = <&uart2>;
++		 __overlay__ {
++			pinctrl-names = "default";
++			pinctrl-0 = <&uart2_pins>;
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart3.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart3.dts
+new file mode 100644
+index 0000000..770219a
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart3.dts
+@@ -0,0 +1,32 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "allwinner,sun50i-h6";
++
++	fragment@0 {
++		target-path = "/aliases";
++		__overlay__ {
++			serial3 = "/soc/serial@5000c00";
++		};
++	};
++
++	fragment@1 {
++		target = <&pio>;
++		__overlay__ {
++			uart3_rts_cts: uart3_rts_cts {
++				pins = "PD25", "PD26";
++				function = "uart3";
++			};
++		};
++	};
++
++	fragment@2 {
++		target = <&uart3>;
++		 __overlay__ {
++			pinctrl-names = "default";
++			pinctrl-0 = <&uart3_pins>;
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-w1-gpio.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-w1-gpio.dts
+new file mode 100644
+index 0000000..3043c87
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-w1-gpio.dts
+@@ -0,0 +1,29 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "allwinner,sun50i-h6";
++
++	fragment@0 {
++		target = <&pio>;
++		__overlay__ {
++			w1_pins: w1_pins {
++				pins = "PC9";
++				function = "gpio_in";
++			};
++		};
++	};
++
++	fragment@1 {
++		target-path = "/";
++		__overlay__ {
++			onewire@0 {
++				compatible = "w1-gpio";
++				pinctrl-names = "default";
++				pinctrl-0 = <&w1_pins>;
++				gpios = <&pio 2 9 0>; /* PC9 */
++				status = "okay";
++			};
++		};
++	};
++};
 diff --git a/scripts/Makefile.lib b/scripts/Makefile.lib
 index 26e6af4..65b9435 100644
 --- a/scripts/Makefile.lib
@@ -6890,3 +6892,4 @@ index 26e6af4..65b9435 100644
  # Add subdir path
  
  extra-y		:= $(addprefix $(obj)/,$(extra-y))
+

--- a/patch/kernel/sunxi-dev/general-sunxi-overlays.patch
+++ b/patch/kernel/sunxi-dev/general-sunxi-overlays.patch
@@ -1,10 +1,10 @@
 diff --git a/arch/arm/boot/dts/Makefile b/arch/arm/boot/dts/Makefile
-index a48dc14..68da8fc 100644
+index 965a7c0..71a672e 100644
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -1136,3 +1136,5 @@ dtb-$(CONFIG_ARCH_ASPEED) += \
- 	aspeed-bmc-opp-witherspoon.dtb \
+@@ -1213,3 +1213,5 @@ dtb-$(CONFIG_ARCH_ASPEED) += \
  	aspeed-bmc-opp-zaius.dtb \
+ 	aspeed-bmc-portwell-neptune.dtb \
  	aspeed-bmc-quanta-q71l.dtb
 +
 +subdir-y	:= overlay
@@ -1217,7 +1217,7 @@ index 0000000..4be3a38
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-fixup.scr-cmd b/arch/arm/boot/dts/overlay/sun4i-a10-fixup.scr-cmd
 new file mode 100644
-index 0000000..8dd3eeb
+index 0000000..d80f2fc
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-fixup.scr-cmd
 @@ -0,0 +1,124 @@
@@ -1347,7 +1347,7 @@ index 0000000..8dd3eeb
 +fi
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-i2c1.dts b/arch/arm/boot/dts/overlay/sun4i-a10-i2c1.dts
 new file mode 100644
-index 0000000..44a7ce9
+index 0000000..0b31052
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-i2c1.dts
 @@ -0,0 +1,22 @@
@@ -1375,7 +1375,7 @@ index 0000000..44a7ce9
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-i2c2.dts b/arch/arm/boot/dts/overlay/sun4i-a10-i2c2.dts
 new file mode 100644
-index 0000000..ab3c00f
+index 0000000..04b489f
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-i2c2.dts
 @@ -0,0 +1,22 @@
@@ -1568,7 +1568,7 @@ index 0000000..1927fc5
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-spdif-out.dts b/arch/arm/boot/dts/overlay/sun4i-a10-spdif-out.dts
 new file mode 100644
-index 0000000..5811e47
+index 0000000..234dfc8
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-spdif-out.dts
 @@ -0,0 +1,38 @@
@@ -1582,7 +1582,7 @@ index 0000000..5811e47
 +		target = <&spdif>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&spdif_tx_pins_a>;
++			pinctrl-0 = <&spdif_tx_pin>;
 +			status = "okay";
 +		};
 +	};
@@ -1612,7 +1612,7 @@ index 0000000..5811e47
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-spi-jedec-nor.dts b/arch/arm/boot/dts/overlay/sun4i-a10-spi-jedec-nor.dts
 new file mode 100644
-index 0000000..9cf640f
+index 0000000..617bf75
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-spi-jedec-nor.dts
 @@ -0,0 +1,57 @@
@@ -1675,7 +1675,7 @@ index 0000000..9cf640f
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-spi-spidev.dts b/arch/arm/boot/dts/overlay/sun4i-a10-spi-spidev.dts
 new file mode 100644
-index 0000000..f603d6d
+index 0000000..a570c86
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-spi-spidev.dts
 @@ -0,0 +1,57 @@
@@ -1738,7 +1738,7 @@ index 0000000..f603d6d
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-spi0.dts b/arch/arm/boot/dts/overlay/sun4i-a10-spi0.dts
 new file mode 100644
-index 0000000..0444262
+index 0000000..132f780
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-spi0.dts
 @@ -0,0 +1,23 @@
@@ -1767,7 +1767,7 @@ index 0000000..0444262
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-spi1.dts b/arch/arm/boot/dts/overlay/sun4i-a10-spi1.dts
 new file mode 100644
-index 0000000..3c3fcb8
+index 0000000..1d5c9df
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-spi1.dts
 @@ -0,0 +1,22 @@
@@ -1795,7 +1795,7 @@ index 0000000..3c3fcb8
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-spi2.dts b/arch/arm/boot/dts/overlay/sun4i-a10-spi2.dts
 new file mode 100644
-index 0000000..b38e04c
+index 0000000..145f285
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-spi2.dts
 @@ -0,0 +1,23 @@
@@ -1824,7 +1824,7 @@ index 0000000..b38e04c
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-uart2.dts b/arch/arm/boot/dts/overlay/sun4i-a10-uart2.dts
 new file mode 100644
-index 0000000..41ce3e6
+index 0000000..89bb44d
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-uart2.dts
 @@ -0,0 +1,37 @@
@@ -1867,7 +1867,7 @@ index 0000000..41ce3e6
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-uart3.dts b/arch/arm/boot/dts/overlay/sun4i-a10-uart3.dts
 new file mode 100644
-index 0000000..0b70a65
+index 0000000..f599d92
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-uart3.dts
 @@ -0,0 +1,47 @@
@@ -1920,7 +1920,7 @@ index 0000000..0b70a65
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-uart4.dts b/arch/arm/boot/dts/overlay/sun4i-a10-uart4.dts
 new file mode 100644
-index 0000000..0677c63
+index 0000000..b5e562a
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-uart4.dts
 @@ -0,0 +1,37 @@
@@ -1963,7 +1963,7 @@ index 0000000..0677c63
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-uart5.dts b/arch/arm/boot/dts/overlay/sun4i-a10-uart5.dts
 new file mode 100644
-index 0000000..0a3ed9b
+index 0000000..12c3f96
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-uart5.dts
 @@ -0,0 +1,32 @@
@@ -2001,7 +2001,7 @@ index 0000000..0a3ed9b
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-uart6.dts b/arch/arm/boot/dts/overlay/sun4i-a10-uart6.dts
 new file mode 100644
-index 0000000..f58b411
+index 0000000..6be41d5
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-uart6.dts
 @@ -0,0 +1,32 @@
@@ -2039,7 +2039,7 @@ index 0000000..f58b411
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-uart7.dts b/arch/arm/boot/dts/overlay/sun4i-a10-uart7.dts
 new file mode 100644
-index 0000000..65d8c68
+index 0000000..967f6af
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-uart7.dts
 @@ -0,0 +1,32 @@
@@ -2131,7 +2131,7 @@ index 0000000..60e2717
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-fixup.scr-cmd b/arch/arm/boot/dts/overlay/sun5i-a13-fixup.scr-cmd
 new file mode 100644
-index 0000000..db03a70
+index 0000000..9589767
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-fixup.scr-cmd
 @@ -0,0 +1,48 @@
@@ -2185,7 +2185,7 @@ index 0000000..db03a70
 +fi
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-i2c1.dts b/arch/arm/boot/dts/overlay/sun5i-a13-i2c1.dts
 new file mode 100644
-index 0000000..8d7aaff
+index 0000000..e674962
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-i2c1.dts
 @@ -0,0 +1,22 @@
@@ -2213,7 +2213,7 @@ index 0000000..8d7aaff
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-i2c2.dts b/arch/arm/boot/dts/overlay/sun5i-a13-i2c2.dts
 new file mode 100644
-index 0000000..c933d05
+index 0000000..497f618
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-i2c2.dts
 @@ -0,0 +1,22 @@
@@ -2328,7 +2328,7 @@ index 0000000..711ff9c
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-spi-jedec-nor.dts b/arch/arm/boot/dts/overlay/sun5i-a13-spi-jedec-nor.dts
 new file mode 100644
-index 0000000..168d208
+index 0000000..cece796
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-spi-jedec-nor.dts
 @@ -0,0 +1,57 @@
@@ -2391,7 +2391,7 @@ index 0000000..168d208
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-spi-spidev.dts b/arch/arm/boot/dts/overlay/sun5i-a13-spi-spidev.dts
 new file mode 100644
-index 0000000..d2329c7
+index 0000000..6294ee3
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-spi-spidev.dts
 @@ -0,0 +1,57 @@
@@ -2454,7 +2454,7 @@ index 0000000..d2329c7
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-spi0.dts b/arch/arm/boot/dts/overlay/sun5i-a13-spi0.dts
 new file mode 100644
-index 0000000..0a73644
+index 0000000..b23a754
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-spi0.dts
 @@ -0,0 +1,38 @@
@@ -2498,7 +2498,7 @@ index 0000000..0a73644
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-spi1.dts b/arch/arm/boot/dts/overlay/sun5i-a13-spi1.dts
 new file mode 100644
-index 0000000..2dc3e24
+index 0000000..cc0af5d
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-spi1.dts
 @@ -0,0 +1,39 @@
@@ -2543,7 +2543,7 @@ index 0000000..2dc3e24
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-spi2.dts b/arch/arm/boot/dts/overlay/sun5i-a13-spi2.dts
 new file mode 100644
-index 0000000..54ea7f9
+index 0000000..e8535be
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-spi2.dts
 @@ -0,0 +1,22 @@
@@ -2571,7 +2571,7 @@ index 0000000..54ea7f9
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-uart0.dts b/arch/arm/boot/dts/overlay/sun5i-a13-uart0.dts
 new file mode 100644
-index 0000000..726514f
+index 0000000..6edad42
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-uart0.dts
 @@ -0,0 +1,32 @@
@@ -2591,7 +2591,7 @@ index 0000000..726514f
 +	fragment@1 {
 +		target = <&pio>;
 +		__overlay__ {
-+			uart0_pins_a: uart0@0 {
++			uart0_pa_pins: uart0@0 {
 +				pins = "PF2", "PF4";
 +				function = "uart0";
 +			};
@@ -2602,14 +2602,14 @@ index 0000000..726514f
 +		target = <&uart0>;
 +		 __overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&uart0_pins_a>;
++			pinctrl-0 = <&uart0_pa_pins>;
 +			status = "okay";
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-uart1.dts b/arch/arm/boot/dts/overlay/sun5i-a13-uart1.dts
 new file mode 100644
-index 0000000..53d745e
+index 0000000..b165d5e
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-uart1.dts
 @@ -0,0 +1,22 @@
@@ -2637,7 +2637,7 @@ index 0000000..53d745e
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-uart2.dts b/arch/arm/boot/dts/overlay/sun5i-a13-uart2.dts
 new file mode 100644
-index 0000000..89b9fc4
+index 0000000..fa2d0f1
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-uart2.dts
 @@ -0,0 +1,22 @@
@@ -2665,7 +2665,7 @@ index 0000000..89b9fc4
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-uart3.dts b/arch/arm/boot/dts/overlay/sun5i-a13-uart3.dts
 new file mode 100644
-index 0000000..028ea08
+index 0000000..d474544
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-uart3.dts
 @@ -0,0 +1,22 @@
@@ -2733,7 +2733,7 @@ index 0000000..65aebcd
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-fixup.scr-cmd b/arch/arm/boot/dts/overlay/sun7i-a20-fixup.scr-cmd
 new file mode 100644
-index 0000000..5a320b8
+index 0000000..db3cec8
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-fixup.scr-cmd
 @@ -0,0 +1,143 @@
@@ -2882,7 +2882,7 @@ index 0000000..5a320b8
 +fi
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-i2c1.dts b/arch/arm/boot/dts/overlay/sun7i-a20-i2c1.dts
 new file mode 100644
-index 0000000..d1146ee
+index 0000000..c5f6e97
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-i2c1.dts
 @@ -0,0 +1,22 @@
@@ -2903,14 +2903,14 @@ index 0000000..d1146ee
 +		target = <&i2c1>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&i2c1_pins_a>;
++			pinctrl-0 = <&i2c1_pins>;
 +			status = "okay";
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-i2c2.dts b/arch/arm/boot/dts/overlay/sun7i-a20-i2c2.dts
 new file mode 100644
-index 0000000..e6b32de
+index 0000000..fa93d1e
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-i2c2.dts
 @@ -0,0 +1,22 @@
@@ -2931,14 +2931,14 @@ index 0000000..e6b32de
 +		target = <&i2c2>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&i2c2_pins_a>;
++			pinctrl-0 = <&i2c2_pins>;
 +			status = "okay";
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-i2c3.dts b/arch/arm/boot/dts/overlay/sun7i-a20-i2c3.dts
 new file mode 100644
-index 0000000..5273d06
+index 0000000..945795c
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-i2c3.dts
 @@ -0,0 +1,22 @@
@@ -2959,14 +2959,14 @@ index 0000000..5273d06
 +		target = <&i2c3>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&i2c3_pins_a>;
++			pinctrl-0 = <&i2c3_pins>;
 +			status = "okay";
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-i2c4.dts b/arch/arm/boot/dts/overlay/sun7i-a20-i2c4.dts
 new file mode 100644
-index 0000000..113a220
+index 0000000..4fcf08c
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-i2c4.dts
 @@ -0,0 +1,32 @@
@@ -2997,7 +2997,7 @@ index 0000000..113a220
 +		target = <&i2c4>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&i2c4_pins_a>;
++			pinctrl-0 = <&i2c4_pins>;
 +			status = "okay";
 +		};
 +	};
@@ -3066,7 +3066,7 @@ index 0000000..e6f0a22
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-mmc2.dts b/arch/arm/boot/dts/overlay/sun7i-a20-mmc2.dts
 new file mode 100644
-index 0000000..f1ddbaa
+index 0000000..ede92f2
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-mmc2.dts
 @@ -0,0 +1,18 @@
@@ -3080,7 +3080,7 @@ index 0000000..f1ddbaa
 +		target = <&mmc2>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&mmc2_pins_a>;
++			pinctrl-0 = <&mmc2_pins>;
 +			vmmc-supply = <&reg_vcc3v3>;
 +			bus-width = <4>;
 +			cd-gpios = <&pio 7 0 1>; /* PH0, active low */
@@ -3234,7 +3234,7 @@ index 0000000..fe3e2bd
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-pwm.dts b/arch/arm/boot/dts/overlay/sun7i-a20-pwm.dts
 new file mode 100644
-index 0000000..a0cc469
+index 0000000..b9978c6
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-pwm.dts
 @@ -0,0 +1,15 @@
@@ -3248,14 +3248,14 @@ index 0000000..a0cc469
 +		target = <&pwm>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&pwm0_pins_a>, <&pwm1_pins_a>;
++			pinctrl-0 = <&pwm0_pins>, <&pwm1_pins>;
 +			status = "okay";
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-spdif-out.dts b/arch/arm/boot/dts/overlay/sun7i-a20-spdif-out.dts
 new file mode 100644
-index 0000000..7983ad0
+index 0000000..11a0939
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-spdif-out.dts
 @@ -0,0 +1,38 @@
@@ -3269,7 +3269,7 @@ index 0000000..7983ad0
 +		target = <&spdif>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&spdif_tx_pins_a>;
++			pinctrl-0 = <&spdif_tx_pin>;
 +			status = "okay";
 +		};
 +	};
@@ -3299,7 +3299,7 @@ index 0000000..7983ad0
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-spi-add-cs1.dts b/arch/arm/boot/dts/overlay/sun7i-a20-spi-add-cs1.dts
 new file mode 100644
-index 0000000..2de39a2
+index 0000000..c0a4ba2
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-spi-add-cs1.dts
 @@ -0,0 +1,16 @@
@@ -3313,15 +3313,15 @@ index 0000000..2de39a2
 +		target = <&spi0>;
 +		__overlay__ {
 +			pinctrl-names = "default", "default", "default";
-+			pinctrl-0 = <&spi0_pins_a>;
-+			pinctrl-1 = <&spi0_cs0_pins_a>;
-+			pinctrl-2 = <&spi0_cs1_pins_a>;
++			pinctrl-0 = <&spi0_pi_pins>;
++			pinctrl-1 = <&spi0_cs0_pi_pin>;
++			pinctrl-2 = <&spi0_cs1_pi_pin>;
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-spi-jedec-nor.dts b/arch/arm/boot/dts/overlay/sun7i-a20-spi-jedec-nor.dts
 new file mode 100644
-index 0000000..baf59df
+index 0000000..efd147c
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-spi-jedec-nor.dts
 @@ -0,0 +1,57 @@
@@ -3384,7 +3384,7 @@ index 0000000..baf59df
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-spi-spidev.dts b/arch/arm/boot/dts/overlay/sun7i-a20-spi-spidev.dts
 new file mode 100644
-index 0000000..8d0f6ac
+index 0000000..f8faa97
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-spi-spidev.dts
 @@ -0,0 +1,57 @@
@@ -3447,7 +3447,7 @@ index 0000000..8d0f6ac
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-spi0.dts b/arch/arm/boot/dts/overlay/sun7i-a20-spi0.dts
 new file mode 100644
-index 0000000..0444262
+index 0000000..cad50d8
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-spi0.dts
 @@ -0,0 +1,23 @@
@@ -3469,14 +3469,14 @@ index 0000000..0444262
 +		__overlay__ {
 +			status = "okay";
 +			pinctrl-names = "default", "default";
-+			pinctrl-0 = <&spi0_pins_a>;
-+			pinctrl-1 = <&spi0_cs0_pins_a>;
++			pinctrl-0 = <&spi0_pi_pins>;
++			pinctrl-1 = <&spi0_cs0_pi_pin>;
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-spi1.dts b/arch/arm/boot/dts/overlay/sun7i-a20-spi1.dts
 new file mode 100644
-index 0000000..3c3fcb8
+index 0000000..f0218eb
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-spi1.dts
 @@ -0,0 +1,22 @@
@@ -3498,13 +3498,13 @@ index 0000000..3c3fcb8
 +		__overlay__ {
 +			status = "okay";
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&spi1_pins_a>, <&spi1_cs0_pins_a>;
++			pinctrl-0 = <&spi1_pi_pins>, <&spi1_cs0_pi_pin>;
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-spi2.dts b/arch/arm/boot/dts/overlay/sun7i-a20-spi2.dts
 new file mode 100644
-index 0000000..b38e04c
+index 0000000..effba42
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-spi2.dts
 @@ -0,0 +1,23 @@
@@ -3526,14 +3526,14 @@ index 0000000..b38e04c
 +		__overlay__ {
 +			status = "okay";
 +			pinctrl-names = "default", "default";
-+			pinctrl-0 = <&spi2_pins_a>;
-+			pinctrl-1 = <&spi2_cs0_pins_a>;
++			pinctrl-0 = <&spi2_pb_pins>;
++			pinctrl-1 = <&spi2_pb_cs0_pin>;
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-uart2.dts b/arch/arm/boot/dts/overlay/sun7i-a20-uart2.dts
 new file mode 100644
-index 0000000..b4f7230
+index 0000000..79d1dca
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-uart2.dts
 @@ -0,0 +1,32 @@
@@ -3571,7 +3571,7 @@ index 0000000..b4f7230
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-uart3.dts b/arch/arm/boot/dts/overlay/sun7i-a20-uart3.dts
 new file mode 100644
-index 0000000..75e79ea
+index 0000000..703acbc
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-uart3.dts
 @@ -0,0 +1,42 @@
@@ -3619,7 +3619,7 @@ index 0000000..75e79ea
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-uart4.dts b/arch/arm/boot/dts/overlay/sun7i-a20-uart4.dts
 new file mode 100644
-index 0000000..008cf83
+index 0000000..1918034
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-uart4.dts
 @@ -0,0 +1,22 @@
@@ -3640,14 +3640,14 @@ index 0000000..008cf83
 +		target = <&uart4>;
 +		 __overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&uart4_pins_a>;
++			pinctrl-0 = <&uart4_pg_pins>;
 +			status = "okay";
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-uart5.dts b/arch/arm/boot/dts/overlay/sun7i-a20-uart5.dts
 new file mode 100644
-index 0000000..3236710
+index 0000000..a1369ee
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-uart5.dts
 @@ -0,0 +1,22 @@
@@ -3668,14 +3668,14 @@ index 0000000..3236710
 +		target = <&uart5>;
 +		 __overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&uart5_pins_a>;
++			pinctrl-0 = <&uart5_pi_pins>;
 +			status = "okay";
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-uart6.dts b/arch/arm/boot/dts/overlay/sun7i-a20-uart6.dts
 new file mode 100644
-index 0000000..1243538
+index 0000000..fb9efe2
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-uart6.dts
 @@ -0,0 +1,22 @@
@@ -3696,14 +3696,14 @@ index 0000000..1243538
 +		target = <&uart6>;
 +		 __overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&uart6_pins_a>;
++			pinctrl-0 = <&uart6_pi_pins>;
 +			status = "okay";
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-uart7.dts b/arch/arm/boot/dts/overlay/sun7i-a20-uart7.dts
 new file mode 100644
-index 0000000..3087271
+index 0000000..bbdca3e
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-uart7.dts
 @@ -0,0 +1,22 @@
@@ -3724,7 +3724,7 @@ index 0000000..3087271
 +		target = <&uart7>;
 +		 __overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&uart7_pins_a>;
++			pinctrl-0 = <&uart7_pi_pins>;
 +			status = "okay";
 +		};
 +	};
@@ -3789,7 +3789,7 @@ index 0000000..36dbc31
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun8i-h3-cir.dts b/arch/arm/boot/dts/overlay/sun8i-h3-cir.dts
 new file mode 100644
-index 0000000..9b62fd2
+index 0000000..bf4a0ea
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun8i-h3-cir.dts
 @@ -0,0 +1,15 @@
@@ -3803,14 +3803,14 @@ index 0000000..9b62fd2
 +		target = <&ir>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&ir_pins_a>;
++			pinctrl-0 = <&r_ir_rx_pin>;
 +			status = "okay";
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun8i-h3-fixup.scr-cmd b/arch/arm/boot/dts/overlay/sun8i-h3-fixup.scr-cmd
 new file mode 100644
-index 0000000..744889c
+index 0000000..142b7e5
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun8i-h3-fixup.scr-cmd
 @@ -0,0 +1,110 @@
@@ -3926,7 +3926,7 @@ index 0000000..744889c
 +fi
 diff --git a/arch/arm/boot/dts/overlay/sun8i-h3-i2c0.dts b/arch/arm/boot/dts/overlay/sun8i-h3-i2c0.dts
 new file mode 100644
-index 0000000..b457ac7
+index 0000000..a36ac86
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun8i-h3-i2c0.dts
 @@ -0,0 +1,20 @@
@@ -3952,7 +3952,7 @@ index 0000000..b457ac7
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun8i-h3-i2c1.dts b/arch/arm/boot/dts/overlay/sun8i-h3-i2c1.dts
 new file mode 100644
-index 0000000..fd0928a
+index 0000000..258c86d
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun8i-h3-i2c1.dts
 @@ -0,0 +1,20 @@
@@ -3978,7 +3978,7 @@ index 0000000..fd0928a
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun8i-h3-i2c2.dts b/arch/arm/boot/dts/overlay/sun8i-h3-i2c2.dts
 new file mode 100644
-index 0000000..25b75b7
+index 0000000..a1e3284
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun8i-h3-i2c2.dts
 @@ -0,0 +1,20 @@
@@ -4084,7 +4084,7 @@ index 0000000..ed3b8e6
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun8i-h3-spdif-out.dts b/arch/arm/boot/dts/overlay/sun8i-h3-spdif-out.dts
 new file mode 100644
-index 0000000..c7c0141
+index 0000000..35b2d56
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun8i-h3-spdif-out.dts
 @@ -0,0 +1,38 @@
@@ -4098,7 +4098,7 @@ index 0000000..c7c0141
 +		target = <&spdif>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&spdif_tx_pins_a>;
++			pinctrl-0 = <&spdif_tx_pin>;
 +			status = "okay";
 +		};
 +	};
@@ -4175,7 +4175,7 @@ index 0000000..bd8e256
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun8i-h3-spi-jedec-nor.dts b/arch/arm/boot/dts/overlay/sun8i-h3-spi-jedec-nor.dts
 new file mode 100644
-index 0000000..ad22a71
+index 0000000..6e53bbb
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun8i-h3-spi-jedec-nor.dts
 @@ -0,0 +1,42 @@
@@ -4223,7 +4223,7 @@ index 0000000..ad22a71
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun8i-h3-spi-spidev.dts b/arch/arm/boot/dts/overlay/sun8i-h3-spi-spidev.dts
 new file mode 100644
-index 0000000..180979e
+index 0000000..9c4c907
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun8i-h3-spi-spidev.dts
 @@ -0,0 +1,42 @@
@@ -4271,7 +4271,7 @@ index 0000000..180979e
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun8i-h3-uart1.dts b/arch/arm/boot/dts/overlay/sun8i-h3-uart1.dts
 new file mode 100644
-index 0000000..8a4f7e4
+index 0000000..3c10d4d
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun8i-h3-uart1.dts
 @@ -0,0 +1,22 @@
@@ -4299,7 +4299,7 @@ index 0000000..8a4f7e4
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun8i-h3-uart2.dts b/arch/arm/boot/dts/overlay/sun8i-h3-uart2.dts
 new file mode 100644
-index 0000000..499a1b4
+index 0000000..f16e618
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun8i-h3-uart2.dts
 @@ -0,0 +1,22 @@
@@ -4327,7 +4327,7 @@ index 0000000..499a1b4
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun8i-h3-uart3.dts b/arch/arm/boot/dts/overlay/sun8i-h3-uart3.dts
 new file mode 100644
-index 0000000..b5734c5
+index 0000000..b1aef57
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun8i-h3-uart3.dts
 @@ -0,0 +1,22 @@
@@ -4521,19 +4521,18 @@ index 0000000..f4ccb7f
 +	};
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
-index 94de6044..1e85fd7c 100644
+index fa35163..89df4ff 100644
 --- a/arch/arm64/boot/dts/allwinner/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/Makefile
-@@ -14,4 +14,6 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-zero-plus.dtb
- dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo2.dtb
- dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo-plus2.dtb
+@@ -31,3 +31,5 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-orangepi-lite2.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-orangepi-one-plus.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-pine-h64.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6.dtb
 +
 +subdir-y	:= $(dts-dirs) overlay
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/Makefile b/arch/arm64/boot/dts/allwinner/overlay/Makefile
 new file mode 100644
-index 0000000..5cad268
+index 0000000..128d32c
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/Makefile
 @@ -0,0 +1,53 @@
@@ -4590,11 +4589,6 @@ index 0000000..5cad268
 +dtbotxt-$(CONFIG_ARCH_SUNXI) += \
 +	README.sun50i-a64-overlays \
 +	README.sun50i-h5-overlays
-+
-+targets += $(dtbo-y) $(scr-y) $(dtbotxt-y)
-+
-+always		:= $(dtbo-y) $(scr-y) $(dtbotxt-y)
-+clean-files	:= *.dtbo *.scr
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/README.sun50i-a64-overlays b/arch/arm64/boot/dts/allwinner/overlay/README.sun50i-a64-overlays
 new file mode 100644
 index 0000000..cd9dbc6
@@ -5055,7 +5049,7 @@ index 0000000..1ac7fbc
 +		or long wires -	please use external pull-up resistor instead
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-fixup.scr-cmd b/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-fixup.scr-cmd
 new file mode 100644
-index 0000000..6e192b5
+index 0000000..36df83c
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-fixup.scr-cmd
 @@ -0,0 +1,95 @@
@@ -5304,7 +5298,7 @@ index 0000000..4432aac
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-spi-jedec-nor.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-spi-jedec-nor.dts
 new file mode 100644
-index 0000000..d67a4f6
+index 0000000..31d73e5
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-spi-jedec-nor.dts
 @@ -0,0 +1,34 @@
@@ -5501,7 +5495,7 @@ index 0000000..a103a75
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-uart4.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-uart4.dts
 new file mode 100644
-index 0000000..f84333c
+index 0000000..6e4702b
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-uart4.dts
 @@ -0,0 +1,37 @@
@@ -5602,7 +5596,7 @@ index 0000000..aaa66d5
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-cir.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-cir.dts
 new file mode 100644
-index 0000000..74569cb
+index 0000000..90c264a
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-cir.dts
 @@ -0,0 +1,15 @@
@@ -5616,14 +5610,14 @@ index 0000000..74569cb
 +		target = <&ir>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&ir_pins_a>;
++			pinctrl-0 = <&r_ir_rx_pin>;
 +			status = "okay";
 +		};
 +	};
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-fixup.scr-cmd b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-fixup.scr-cmd
 new file mode 100644
-index 0000000..744889c
+index 0000000..f7b89ae
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-fixup.scr-cmd
 @@ -0,0 +1,110 @@
@@ -5739,7 +5733,7 @@ index 0000000..744889c
 +fi
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-i2c0.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-i2c0.dts
 new file mode 100644
-index 0000000..55d249d
+index 0000000..87fbd7e
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-i2c0.dts
 @@ -0,0 +1,20 @@
@@ -5765,7 +5759,7 @@ index 0000000..55d249d
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-i2c1.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-i2c1.dts
 new file mode 100644
-index 0000000..2528870
+index 0000000..6008b9a
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-i2c1.dts
 @@ -0,0 +1,20 @@
@@ -5791,7 +5785,7 @@ index 0000000..2528870
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-i2c2.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-i2c2.dts
 new file mode 100644
-index 0000000..ff42f01
+index 0000000..2980dbf
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-i2c2.dts
 @@ -0,0 +1,20 @@
@@ -5897,7 +5891,7 @@ index 0000000..6d12e84
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-spdif-out.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-spdif-out.dts
 new file mode 100644
-index 0000000..2bb301f
+index 0000000..65bc51b
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-spdif-out.dts
 @@ -0,0 +1,38 @@
@@ -5911,7 +5905,7 @@ index 0000000..2bb301f
 +		target = <&spdif>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&spdif_tx_pins_a>;
++			pinctrl-0 = <&spdif_tx_pin>;
 +			status = "okay";
 +		};
 +	};
@@ -5988,7 +5982,7 @@ index 0000000..8e3eab2
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-spi-jedec-nor.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-spi-jedec-nor.dts
 new file mode 100644
-index 0000000..d4accd9
+index 0000000..5a45808
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-spi-jedec-nor.dts
 @@ -0,0 +1,42 @@
@@ -6036,7 +6030,7 @@ index 0000000..d4accd9
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-spi-spidev.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-spi-spidev.dts
 new file mode 100644
-index 0000000..d8a008d
+index 0000000..70f435b
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-spi-spidev.dts
 @@ -0,0 +1,42 @@
@@ -6084,7 +6078,7 @@ index 0000000..d8a008d
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-uart1.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-uart1.dts
 new file mode 100644
-index 0000000..0ce76ef
+index 0000000..92e3eb4
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-uart1.dts
 @@ -0,0 +1,22 @@
@@ -6112,7 +6106,7 @@ index 0000000..0ce76ef
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-uart2.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-uart2.dts
 new file mode 100644
-index 0000000..88cc0cd
+index 0000000..521a01d
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-uart2.dts
 @@ -0,0 +1,32 @@
@@ -6150,7 +6144,7 @@ index 0000000..88cc0cd
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-uart3.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-uart3.dts
 new file mode 100644
-index 0000000..3ad6cc9
+index 0000000..639e15d
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-uart3.dts
 @@ -0,0 +1,32 @@
@@ -6353,417 +6347,9 @@ index 0000000..6e99626
 +		};
 +	};
 +};
-diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c0.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c0.dts
-index e69de29..7e7ee8c 100644
---- /dev/null
-+++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c0.dts
-@@ -0,0 +1,20 @@
-+/dts-v1/;
-+/plugin/;
-+
-+/ {
-+	compatible = "allwinner,sun50i-h6";
-+
-+	fragment@0 {
-+		target-path = "/aliases";
-+		__overlay__ {
-+			i2c0 = "/soc/i2c@5002000";
-+		};
-+	};
-+
-+	fragment@1 {
-+		target = <&i2c0>;
-+		__overlay__ {
-+			status = "okay";
-+		};
-+	};
-+};
-diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c1.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c1.dts
-index e69de29..1117698 100644
---- /dev/null
-+++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c1.dts
-@@ -0,0 +1,20 @@
-+/dts-v1/;
-+/plugin/;
-+
-+/ {
-+	compatible = "allwinner,sun50i-h6";
-+
-+	fragment@0 {
-+		target-path = "/aliases";
-+		__overlay__ {
-+			i2c1 = "/soc/i2c@5002400";
-+		};
-+	};
-+
-+	fragment@1 {
-+		target = <&i2c1>;
-+		__overlay__ {
-+			status = "okay";
-+		};
-+	};
-+};
-diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c2.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c2.dts
-index e69de29..b627529 100644
---- /dev/null
-+++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c2.dts
-@@ -0,0 +1,20 @@
-+/dts-v1/;
-+/plugin/;
-+
-+/ {
-+	compatible = "allwinner,sun50i-h6";
-+
-+	fragment@0 {
-+		target-path = "/aliases";
-+		__overlay__ {
-+			i2c2 = "/soc/i2c@5002800";
-+		};
-+	};
-+
-+	fragment@1 {
-+		target = <&i2c2>;
-+		__overlay__ {
-+			status = "okay";
-+		};
-+	};
-+};
-diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-add-cs1.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-add-cs1.dts
-new file mode 100644
-index 0000000..0fa060f
---- /dev/null
-+++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-add-cs1.dts
-@@ -0,0 +1,41 @@
-+/dts-v1/;
-+/plugin/;
-+
-+/ {
-+	compatible = "allwinner,sun50i-h6";
-+
-+	fragment@0 {
-+		target = <&pio>;
-+		__overlay__ {
-+			spi0_cs1: spi0_cs1 {
-+				pins = "PA10";
-+				function = "gpio_out";
-+				output-high;
-+			};
-+
-+			spi1_cs1: spi1_cs1 {
-+				pins = "PA21";
-+				function = "gpio_out";
-+				output-high;
-+			};
-+		};
-+	};
-+
-+	fragment@1 {
-+		target = <&spi0>;
-+		__overlay__ {
-+			pinctrl-names = "default", "default";
-+			pinctrl-1 = <&spi0_cs1>;
-+			cs-gpios = <0>, <&pio 0 10 0>; /* PA10 */
-+		};
-+	};
-+
-+	fragment@2 {
-+		target = <&spi1>;
-+		__overlay__ {
-+			pinctrl-names = "default", "default";
-+			pinctrl-1 = <&spi1_cs1>;
-+			cs-gpios = <0>, <&pio 0 21 0>; /* PA21 */
-+		};
-+	};
-+};
-diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-jedec-nor.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-jedec-nor.dts
-new file mode 100644
-index 0000000..3a2be38
---- /dev/null
-+++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-jedec-nor.dts
-@@ -0,0 +1,42 @@
-+/dts-v1/;
-+/plugin/;
-+
-+/ {
-+	compatible = "allwinner,sun50i-h6";
-+
-+	fragment@0 {
-+		target-path = "/aliases";
-+		__overlay__ {
-+			spi0 = "/soc/spi@5010000";
-+			spi1 = "/soc/spi@5011000";
-+		};
-+	};
-+
-+	fragment@1 {
-+		target = <&spi0>;
-+		__overlay__ {
-+			#address-cells = <1>;
-+			#size-cells = <0>;
-+			spiflash@0 {
-+				compatible = "jedec,spi-nor";
-+				reg = <0>;
-+				spi-max-frequency = <1000000>;
-+				status = "disabled";
-+			};
-+		};
-+	};
-+
-+	fragment@2 {
-+		target = <&spi1>;
-+		__overlay__ {
-+			#address-cells = <1>;
-+			#size-cells = <0>;
-+			spiflash@0 {
-+				compatible = "jedec,spi-nor";
-+				reg = <0>;
-+				spi-max-frequency = <1000000>;
-+				status = "disabled";
-+			};
-+		};
-+	};
-+};
-diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-spidev.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-spidev.dts
-new file mode 100644
-index 0000000..fd807d6
---- /dev/null
-+++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-spidev.dts
-@@ -0,0 +1,42 @@
-+/dts-v1/;
-+/plugin/;
-+
-+/ {
-+	compatible = "allwinner,sun50i-h6";
-+
-+	fragment@0 {
-+		target-path = "/aliases";
-+		__overlay__ {
-+			spi0 = "/soc/spi@5010000";
-+			spi1 = "/soc/spi@5011000";
-+		};
-+	};
-+
-+	fragment@1 {
-+		target = <&spi0>;
-+		__overlay__ {
-+			#address-cells = <1>;
-+			#size-cells = <0>;
-+			spidev {
-+				compatible = "spidev";
-+				status = "disabled";
-+				reg = <0>;
-+				spi-max-frequency = <1000000>;
-+			};
-+		};
-+	};
-+
-+	fragment@2 {
-+		target = <&spi1>;
-+		__overlay__ {
-+			#address-cells = <1>;
-+			#size-cells = <0>;
-+			spidev {
-+				compatible = "spidev";
-+				status = "disabled";
-+				reg = <0>;
-+				spi-max-frequency = <1000000>;
-+			};
-+		};
-+	};
-+};
-diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-spidev1.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-spidev1.dts
-new file mode 100644
-index 0000000..fd807d6
---- /dev/null
-+++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-spidev1.dts
-@@ -0,0 +1,30 @@
-+// Enable the spidev interface
-+/dts-v1/;
-+/plugin/;
-+
-+/ {
-+    compatible = "allwinner,sun8i-h6";
-+
-+    fragment@0 {
-+	target-path = "/aliases";
-+	__overlay__ {
-+            /* Path to the SPI controller nodes */
-+            spi1 = "/soc/spi@5011000";
-+        };
-+    };
-+    fragment@1 {
-+        target = <&spi1>;
-+        __overlay__ {
-+            pinctrl-names = "default";
-+            pinctrl-0 = <&spi1_pins>;
-+            status = "okay";
-+            #address-cells = <1>;
-+            #size-cells = <0>;
-+            spidev@0 {
-+                compatible = "spidev";
-+                reg = <0x0>;
-+                spi-max-frequency = <1000000>;
-+            };
-+        };
-+    };
-+};
-diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart1.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart1.dts
-index e69de29..44aa94e 100644
---- /dev/null
-+++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart1.dts
-@@ -0,0 +1,22 @@
-+/dts-v1/;
-+/plugin/;
-+
-+/ {
-+	compatible = "allwinner,sun50i-h6";
-+
-+	fragment@0 {
-+		target-path = "/aliases";
-+		__overlay__ {
-+			serial1 = "/soc/serial@5000400";
-+		};
-+	};
-+
-+	fragment@1 {
-+		target = <&uart1>;
-+		 __overlay__ {
-+			pinctrl-names = "default";
-+			pinctrl-0 = <&uart1_pins>;
-+			status = "okay";
-+		};
-+	};
-+};
-diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart2.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart2.dts
-index e69de29..7a1860e 100644
---- /dev/null
-+++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart2.dts
-@@ -0,0 +1,32 @@
-+/dts-v1/;
-+/plugin/;
-+
-+/ {
-+	compatible = "allwinner,sun50i-h6";
-+
-+	fragment@0 {
-+		target-path = "/aliases";
-+		__overlay__ {
-+			serial2 = "/soc/serial@5000800";
-+		};
-+	};
-+
-+	fragment@1 {
-+		target = <&pio>;
-+		__overlay__ {
-+			uart2_rts_cts: uart2_rts_cts {
-+				pins = "PD21", "PD22";
-+				function = "uart2";
-+			};
-+		};
-+	};
-+
-+	fragment@2 {
-+		target = <&uart2>;
-+		 __overlay__ {
-+			pinctrl-names = "default";
-+			pinctrl-0 = <&uart2_pins>;
-+			status = "okay";
-+		};
-+	};
-+};
-diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart3.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart3.dts
-index e69de29..38a59ac 100644
---- /dev/null
-+++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart3.dts
-@@ -0,0 +1,32 @@
-+/dts-v1/;
-+/plugin/;
-+
-+/ {
-+	compatible = "allwinner,sun50i-h6";
-+
-+	fragment@0 {
-+		target-path = "/aliases";
-+		__overlay__ {
-+			serial3 = "/soc/serial@5000c00";
-+		};
-+	};
-+
-+	fragment@1 {
-+		target = <&pio>;
-+		__overlay__ {
-+			uart3_rts_cts: uart3_rts_cts {
-+				pins = "PD25", "PD26";
-+				function = "uart3";
-+			};
-+		};
-+	};
-+
-+	fragment@2 {
-+		target = <&uart3>;
-+		 __overlay__ {
-+			pinctrl-names = "default";
-+			pinctrl-0 = <&uart3_pins>;
-+			status = "okay";
-+		};
-+	};
-+};
-diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-ruart.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-ruart.dts
-index e69de29..38a59ac 100644
---- /dev/null
-+++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-ruart.dts
-@@ -0,0 +1,13 @@
-+/dts-v1/;
-+/plugin/;
-+
-+/ {
-+	compatible = "allwinner,sun50i-h6";
-+
-+	fragment@0 {
-+		target = <&r_uart>;
-+		 __overlay__ {
-+			status = "okay";
-+		};
-+	};
-+};
-diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-w1-gpio.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-w1-gpio.dts
-new file mode 100644
-index 0000000..a4cd713
---- /dev/null
-+++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-w1-gpio.dts
-@@ -0,0 +1,29 @@
-+/dts-v1/;
-+/plugin/;
-+
-+/ {
-+	compatible = "allwinner,sun50i-h6";
-+
-+	fragment@0 {
-+		target = <&pio>;
-+		__overlay__ {
-+			w1_pins: w1_pins {
-+				pins = "PC9";
-+				function = "gpio_in";
-+			};
-+		};
-+	};
-+
-+	fragment@1 {
-+		target-path = "/";
-+		__overlay__ {
-+			onewire@0 {
-+				compatible = "w1-gpio";
-+				pinctrl-names = "default";
-+				pinctrl-0 = <&w1_pins>;
-+				gpios = <&pio 2 9 0>; /* PC9 */
-+				status = "okay";
-+			};
-+		};
-+	};
-+};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-fixup.scr-cmd b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-fixup.scr-cmd
 new file mode 100644
-index 0000000..fba1c4f
+index 0000000..5f00458
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-fixup.scr-cmd
 @@ -0,0 +1,110 @@
@@ -6877,6 +6463,421 @@ index 0000000..fba1c4f
 +	fdt set /soc/serial@5000c00 pinctrl-1 "<${tmp_phandle2}>"
 +	env delete tmp_phandle1 tmp_phandle2
 +fi
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c0.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c0.dts
+new file mode 100644
+index 0000000..7e7ee8c
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c0.dts
+@@ -0,0 +1,20 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "allwinner,sun50i-h6";
++
++	fragment@0 {
++		target-path = "/aliases";
++		__overlay__ {
++			i2c0 = "/soc/i2c@5002000";
++		};
++	};
++
++	fragment@1 {
++		target = <&i2c0>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c1.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c1.dts
+new file mode 100644
+index 0000000..1117698
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c1.dts
+@@ -0,0 +1,20 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "allwinner,sun50i-h6";
++
++	fragment@0 {
++		target-path = "/aliases";
++		__overlay__ {
++			i2c1 = "/soc/i2c@5002400";
++		};
++	};
++
++	fragment@1 {
++		target = <&i2c1>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c2.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c2.dts
+new file mode 100644
+index 0000000..b627529
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-i2c2.dts
+@@ -0,0 +1,20 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "allwinner,sun50i-h6";
++
++	fragment@0 {
++		target-path = "/aliases";
++		__overlay__ {
++			i2c2 = "/soc/i2c@5002800";
++		};
++	};
++
++	fragment@1 {
++		target = <&i2c2>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-ruart.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-ruart.dts
+new file mode 100644
+index 0000000..6430cb0
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-ruart.dts
+@@ -0,0 +1,13 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "allwinner,sun50i-h6";
++
++	fragment@0 {
++		target = <&r_uart>;
++		 __overlay__ {
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-add-cs1.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-add-cs1.dts
+new file mode 100644
+index 0000000..0fa060f
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-add-cs1.dts
+@@ -0,0 +1,41 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "allwinner,sun50i-h6";
++
++	fragment@0 {
++		target = <&pio>;
++		__overlay__ {
++			spi0_cs1: spi0_cs1 {
++				pins = "PA10";
++				function = "gpio_out";
++				output-high;
++			};
++
++			spi1_cs1: spi1_cs1 {
++				pins = "PA21";
++				function = "gpio_out";
++				output-high;
++			};
++		};
++	};
++
++	fragment@1 {
++		target = <&spi0>;
++		__overlay__ {
++			pinctrl-names = "default", "default";
++			pinctrl-1 = <&spi0_cs1>;
++			cs-gpios = <0>, <&pio 0 10 0>; /* PA10 */
++		};
++	};
++
++	fragment@2 {
++		target = <&spi1>;
++		__overlay__ {
++			pinctrl-names = "default", "default";
++			pinctrl-1 = <&spi1_cs1>;
++			cs-gpios = <0>, <&pio 0 21 0>; /* PA21 */
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-jedec-nor.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-jedec-nor.dts
+new file mode 100644
+index 0000000..4f81dbb
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-jedec-nor.dts
+@@ -0,0 +1,42 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "allwinner,sun50i-h6";
++
++	fragment@0 {
++		target-path = "/aliases";
++		__overlay__ {
++			spi0 = "/soc/spi@5010000";
++			spi1 = "/soc/spi@5011000";
++		};
++	};
++
++	fragment@1 {
++		target = <&spi0>;
++		__overlay__ {
++			#address-cells = <1>;
++			#size-cells = <0>;
++			spiflash@0 {
++				compatible = "jedec,spi-nor";
++				reg = <0>;
++				spi-max-frequency = <1000000>;
++				status = "disabled";
++			};
++		};
++	};
++
++	fragment@2 {
++		target = <&spi1>;
++		__overlay__ {
++			#address-cells = <1>;
++			#size-cells = <0>;
++			spiflash@0 {
++				compatible = "jedec,spi-nor";
++				reg = <0>;
++				spi-max-frequency = <1000000>;
++				status = "disabled";
++			};
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-spidev.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-spidev.dts
+new file mode 100644
+index 0000000..fd807d6
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-spidev.dts
+@@ -0,0 +1,42 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "allwinner,sun50i-h6";
++
++	fragment@0 {
++		target-path = "/aliases";
++		__overlay__ {
++			spi0 = "/soc/spi@5010000";
++			spi1 = "/soc/spi@5011000";
++		};
++	};
++
++	fragment@1 {
++		target = <&spi0>;
++		__overlay__ {
++			#address-cells = <1>;
++			#size-cells = <0>;
++			spidev {
++				compatible = "spidev";
++				status = "disabled";
++				reg = <0>;
++				spi-max-frequency = <1000000>;
++			};
++		};
++	};
++
++	fragment@2 {
++		target = <&spi1>;
++		__overlay__ {
++			#address-cells = <1>;
++			#size-cells = <0>;
++			spidev {
++				compatible = "spidev";
++				status = "disabled";
++				reg = <0>;
++				spi-max-frequency = <1000000>;
++			};
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-spidev1.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-spidev1.dts
+new file mode 100644
+index 0000000..e194484
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-spidev1.dts
+@@ -0,0 +1,30 @@
++// Enable the spidev interface
++/dts-v1/;
++/plugin/;
++
++/ {
++    compatible = "allwinner,sun8i-h6";
++
++    fragment@0 {
++	target-path = "/aliases";
++	__overlay__ {
++            /* Path to the SPI controller nodes */
++            spi1 = "/soc/spi@5011000";
++        };
++    };
++    fragment@1 {
++        target = <&spi1>;
++        __overlay__ {
++            pinctrl-names = "default";
++            pinctrl-0 = <&spi1_pins>;
++            status = "okay";
++            #address-cells = <1>;
++            #size-cells = <0>;
++            spidev@0 {
++                compatible = "spidev";
++                reg = <0x0>;
++                spi-max-frequency = <1000000>;
++            };
++        };
++    };
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart1.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart1.dts
+new file mode 100644
+index 0000000..44aa94e
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart1.dts
+@@ -0,0 +1,22 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "allwinner,sun50i-h6";
++
++	fragment@0 {
++		target-path = "/aliases";
++		__overlay__ {
++			serial1 = "/soc/serial@5000400";
++		};
++	};
++
++	fragment@1 {
++		target = <&uart1>;
++		 __overlay__ {
++			pinctrl-names = "default";
++			pinctrl-0 = <&uart1_pins>;
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart2.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart2.dts
+new file mode 100644
+index 0000000..7a1860e
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart2.dts
+@@ -0,0 +1,32 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "allwinner,sun50i-h6";
++
++	fragment@0 {
++		target-path = "/aliases";
++		__overlay__ {
++			serial2 = "/soc/serial@5000800";
++		};
++	};
++
++	fragment@1 {
++		target = <&pio>;
++		__overlay__ {
++			uart2_rts_cts: uart2_rts_cts {
++				pins = "PD21", "PD22";
++				function = "uart2";
++			};
++		};
++	};
++
++	fragment@2 {
++		target = <&uart2>;
++		 __overlay__ {
++			pinctrl-names = "default";
++			pinctrl-0 = <&uart2_pins>;
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart3.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart3.dts
+new file mode 100644
+index 0000000..770219a
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-uart3.dts
+@@ -0,0 +1,32 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "allwinner,sun50i-h6";
++
++	fragment@0 {
++		target-path = "/aliases";
++		__overlay__ {
++			serial3 = "/soc/serial@5000c00";
++		};
++	};
++
++	fragment@1 {
++		target = <&pio>;
++		__overlay__ {
++			uart3_rts_cts: uart3_rts_cts {
++				pins = "PD25", "PD26";
++				function = "uart3";
++			};
++		};
++	};
++
++	fragment@2 {
++		target = <&uart3>;
++		 __overlay__ {
++			pinctrl-names = "default";
++			pinctrl-0 = <&uart3_pins>;
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-w1-gpio.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-w1-gpio.dts
+new file mode 100644
+index 0000000..3043c87
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-w1-gpio.dts
+@@ -0,0 +1,29 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "allwinner,sun50i-h6";
++
++	fragment@0 {
++		target = <&pio>;
++		__overlay__ {
++			w1_pins: w1_pins {
++				pins = "PC9";
++				function = "gpio_in";
++			};
++		};
++	};
++
++	fragment@1 {
++		target-path = "/";
++		__overlay__ {
++			onewire@0 {
++				compatible = "w1-gpio";
++				pinctrl-names = "default";
++				pinctrl-0 = <&w1_pins>;
++				gpios = <&pio 2 9 0>; /* PC9 */
++				status = "okay";
++			};
++		};
++	};
++};
 diff --git a/scripts/Makefile.lib b/scripts/Makefile.lib
 index 26e6af4..65b9435 100644
 --- a/scripts/Makefile.lib
@@ -6891,3 +6892,4 @@ index 26e6af4..65b9435 100644
  # Add subdir path
  
  extra-y		:= $(addprefix $(obj)/,$(extra-y))
+


### PR DESCRIPTION
some armbian dts overlays currently do not work in current and dev branches since pinctrl names have not been adapted to renaming in 5.0 and 5.2.

this patch modifies the following overlays:
sun50i-h5:	cir, spdif-out
sun8i-h3:	cir, spdif-out
sun7i-a20:	i2c1..4, mmc2, pwm, spdif-out, spi0..2, spi-add-cs1, uart4..7
sun5i-a13:	uart0
sun4i-a10:	spdif-out

A20/H3/H5 should be pretty complete. 
A10/A13 are NOT complete - but currently armbian only supports these SoCs on CSC or EOS boards.

Tests:
- patch compiles ok on current and dev.
- selected functional tests: h3-cir, a20-uart2, a20-uart7, a20-i2c2 ok.
- h5 not tested (no device)
	
Next:
- refactor A13 & A10 overlays (will take some time)
- update armbian/sunxi-DT-overlays via pull requests
