### PR TITLE
fix armbian overlays (part 2) - refactor pinctrl names for older SoCs (A10, A13)

### DIFF
--- a/patch/kernel/sunxi-current/general-sunxi-overlays.patch
+++ b/patch/kernel/sunxi-current/general-sunxi-overlays.patch
@@ -1196,7 +1196,7 @@ index 0000000..9254e22
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-can.dts b/arch/arm/boot/dts/overlay/sun4i-a10-can.dts
 new file mode 100644
-index 0000000..4be3a38
+index 0000000..1a9511d
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-can.dts
 @@ -0,0 +1,15 @@
@@ -1210,7 +1210,7 @@ index 0000000..4be3a38
 +		target = <&can0>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&can0_pins_a>;
++			pinctrl-0 = <&can0_ph_pins>;
 +			status = "okay";
 +		};
 +	};
@@ -1347,7 +1347,7 @@ index 0000000..d80f2fc
 +fi
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-i2c1.dts b/arch/arm/boot/dts/overlay/sun4i-a10-i2c1.dts
 new file mode 100644
-index 0000000..0b31052
+index 0000000..4c104bf
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-i2c1.dts
 @@ -0,0 +1,22 @@
@@ -1368,14 +1368,14 @@ index 0000000..0b31052
 +		target = <&i2c1>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&i2c1_pins_a>;
++			pinctrl-0 = <&i2c1_pins>;
 +			status = "okay";
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-i2c2.dts b/arch/arm/boot/dts/overlay/sun4i-a10-i2c2.dts
 new file mode 100644
-index 0000000..04b489f
+index 0000000..1c2c3e9
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-i2c2.dts
 @@ -0,0 +1,22 @@
@@ -1396,7 +1396,7 @@ index 0000000..04b489f
 +		target = <&i2c2>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&i2c2_pins_a>;
++			pinctrl-0 = <&i2c2_pins>;
 +			status = "okay";
 +		};
 +	};
@@ -1547,7 +1547,7 @@ index 0000000..6031fc5
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-pwm.dts b/arch/arm/boot/dts/overlay/sun4i-a10-pwm.dts
 new file mode 100644
-index 0000000..1927fc5
+index 0000000..ba88500
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-pwm.dts
 @@ -0,0 +1,15 @@
@@ -1561,7 +1561,7 @@ index 0000000..1927fc5
 +		target = <&pwm>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&pwm0_pins_a>, <&pwm1_pins_a>;
++			pinctrl-0 = <&pwm0_pin>, <&pwm1_pin>;
 +			status = "okay";
 +		};
 +	};
@@ -1738,7 +1738,7 @@ index 0000000..a570c86
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-spi0.dts b/arch/arm/boot/dts/overlay/sun4i-a10-spi0.dts
 new file mode 100644
-index 0000000..132f780
+index 0000000..cad50d8
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-spi0.dts
 @@ -0,0 +1,23 @@
@@ -1760,14 +1760,14 @@ index 0000000..132f780
 +		__overlay__ {
 +			status = "okay";
 +			pinctrl-names = "default", "default";
-+			pinctrl-0 = <&spi0_pins_a>;
-+			pinctrl-1 = <&spi0_cs0_pins_a>;
++			pinctrl-0 = <&spi0_pi_pins>;
++			pinctrl-1 = <&spi0_cs0_pi_pin>;
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-spi1.dts b/arch/arm/boot/dts/overlay/sun4i-a10-spi1.dts
 new file mode 100644
-index 0000000..1d5c9df
+index 0000000..8c606d6
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-spi1.dts
 @@ -0,0 +1,22 @@
@@ -1789,7 +1789,7 @@ index 0000000..1d5c9df
 +		__overlay__ {
 +			status = "okay";
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&spi1_pins_a>, <&spi1_cs0_pins_a>;
++			pinctrl-0 = <&spi1_pins>, <&spi1_cs0_pin>;
 +		};
 +	};
 +};
@@ -2185,7 +2185,7 @@ index 0000000..9589767
 +fi
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-i2c1.dts b/arch/arm/boot/dts/overlay/sun5i-a13-i2c1.dts
 new file mode 100644
-index 0000000..e674962
+index 0000000..444c32c
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-i2c1.dts
 @@ -0,0 +1,22 @@
@@ -2206,14 +2206,14 @@ index 0000000..e674962
 +		target = <&i2c1>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&i2c1_pins_a>;
++			pinctrl-0 = <&i2c1_pins>;
 +			status = "okay";
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-i2c2.dts b/arch/arm/boot/dts/overlay/sun5i-a13-i2c2.dts
 new file mode 100644
-index 0000000..497f618
+index 0000000..7a30681
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-i2c2.dts
 @@ -0,0 +1,22 @@
@@ -2234,14 +2234,14 @@ index 0000000..497f618
 +		target = <&i2c2>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&i2c2_pins_a>;
++			pinctrl-0 = <&i2c2_pins>;
 +			status = "okay";
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-nand.dts b/arch/arm/boot/dts/overlay/sun5i-a13-nand.dts
 new file mode 100644
-index 0000000..669527a
+index 0000000..0c5fc89
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-nand.dts
 @@ -0,0 +1,60 @@
@@ -2257,7 +2257,7 @@ index 0000000..669527a
 +			#address-cells = <1>;
 +			#size-cells = <0>;
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&nand_pins_a>, <&nand_cs0_pins_a>, <&nand_rb0_pins_a>;
++			pinctrl-0 = <&nand_pins>, <&nand_cs0_pin>, <&nand_rb0_pin>;
 +			status = "okay";
 +
 +			nand@0 {
@@ -2307,7 +2307,7 @@ index 0000000..669527a
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-pwm.dts b/arch/arm/boot/dts/overlay/sun5i-a13-pwm.dts
 new file mode 100644
-index 0000000..711ff9c
+index 0000000..54f5d51
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-pwm.dts
 @@ -0,0 +1,15 @@
@@ -2321,7 +2321,7 @@ index 0000000..711ff9c
 +		target = <&pwm>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&pwm0_pins>;
++			pinctrl-0 = <&pwm0_pin>;
 +			status = "okay";
 +		};
 +	};
@@ -2543,7 +2543,7 @@ index 0000000..cc0af5d
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-spi2.dts b/arch/arm/boot/dts/overlay/sun5i-a13-spi2.dts
 new file mode 100644
-index 0000000..e8535be
+index 0000000..6cf5c41
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-spi2.dts
 @@ -0,0 +1,22 @@
@@ -2565,7 +2565,7 @@ index 0000000..e8535be
 +		__overlay__ {
 +			status = "okay";
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&spi2_pins_a>, <&spi2_cs0_pins_a>;
++			pinctrl-0 = <&spi2_pe_pins>, <&spi2_cs0_pe_pin>;
 +		};
 +	};
 +};
@@ -2609,7 +2609,7 @@ index 0000000..6edad42
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-uart1.dts b/arch/arm/boot/dts/overlay/sun5i-a13-uart1.dts
 new file mode 100644
-index 0000000..b165d5e
+index 0000000..675b701
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-uart1.dts
 @@ -0,0 +1,22 @@
@@ -2630,14 +2630,14 @@ index 0000000..b165d5e
 +		target = <&uart1>;
 +		 __overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&uart1_pins_a>;
++			pinctrl-0 = <&uart1_pe_pins>;
 +			status = "okay";
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-uart2.dts b/arch/arm/boot/dts/overlay/sun5i-a13-uart2.dts
 new file mode 100644
-index 0000000..fa2d0f1
+index 0000000..b3c4e3d
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-uart2.dts
 @@ -0,0 +1,22 @@
@@ -2658,14 +2658,14 @@ index 0000000..fa2d0f1
 +		target = <&uart2>;
 +		 __overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&uart2_pins_a>;
++			pinctrl-0 = <&uart2_pd_pins>;
 +			status = "okay";
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-uart3.dts b/arch/arm/boot/dts/overlay/sun5i-a13-uart3.dts
 new file mode 100644
-index 0000000..d474544
+index 0000000..15c25d0
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-uart3.dts
 @@ -0,0 +1,22 @@
@@ -2686,7 +2686,7 @@ index 0000000..d474544
 +		target = <&uart3>;
 +		 __overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&uart3_pins_a>;
++			pinctrl-0 = <&uart3_pg_pins>;
 +			status = "okay";
 +		};
 +	};
@@ -3234,7 +3234,7 @@ index 0000000..fe3e2bd
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-pwm.dts b/arch/arm/boot/dts/overlay/sun7i-a20-pwm.dts
 new file mode 100644
-index 0000000..b9978c6
+index 0000000..b0cfe4d
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-pwm.dts
 @@ -0,0 +1,15 @@
@@ -3248,7 +3248,7 @@ index 0000000..b9978c6
 +		target = <&pwm>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&pwm0_pins>, <&pwm1_pins>;
++			pinctrl-0 = <&pwm0_pin>, <&pwm1_pin>;
 +			status = "okay";
 +		};
 +	};

--- a/patch/kernel/sunxi-dev/general-sunxi-overlays.patch
+++ b/patch/kernel/sunxi-dev/general-sunxi-overlays.patch
@@ -1196,7 +1196,7 @@ index 0000000..9254e22
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-can.dts b/arch/arm/boot/dts/overlay/sun4i-a10-can.dts
 new file mode 100644
-index 0000000..4be3a38
+index 0000000..1a9511d
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-can.dts
 @@ -0,0 +1,15 @@
@@ -1210,7 +1210,7 @@ index 0000000..4be3a38
 +		target = <&can0>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&can0_pins_a>;
++			pinctrl-0 = <&can0_ph_pins>;
 +			status = "okay";
 +		};
 +	};
@@ -1347,7 +1347,7 @@ index 0000000..d80f2fc
 +fi
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-i2c1.dts b/arch/arm/boot/dts/overlay/sun4i-a10-i2c1.dts
 new file mode 100644
-index 0000000..0b31052
+index 0000000..4c104bf
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-i2c1.dts
 @@ -0,0 +1,22 @@
@@ -1368,14 +1368,14 @@ index 0000000..0b31052
 +		target = <&i2c1>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&i2c1_pins_a>;
++			pinctrl-0 = <&i2c1_pins>;
 +			status = "okay";
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-i2c2.dts b/arch/arm/boot/dts/overlay/sun4i-a10-i2c2.dts
 new file mode 100644
-index 0000000..04b489f
+index 0000000..1c2c3e9
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-i2c2.dts
 @@ -0,0 +1,22 @@
@@ -1396,7 +1396,7 @@ index 0000000..04b489f
 +		target = <&i2c2>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&i2c2_pins_a>;
++			pinctrl-0 = <&i2c2_pins>;
 +			status = "okay";
 +		};
 +	};
@@ -1547,7 +1547,7 @@ index 0000000..6031fc5
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-pwm.dts b/arch/arm/boot/dts/overlay/sun4i-a10-pwm.dts
 new file mode 100644
-index 0000000..1927fc5
+index 0000000..ba88500
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-pwm.dts
 @@ -0,0 +1,15 @@
@@ -1561,7 +1561,7 @@ index 0000000..1927fc5
 +		target = <&pwm>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&pwm0_pins_a>, <&pwm1_pins_a>;
++			pinctrl-0 = <&pwm0_pin>, <&pwm1_pin>;
 +			status = "okay";
 +		};
 +	};
@@ -1738,7 +1738,7 @@ index 0000000..a570c86
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-spi0.dts b/arch/arm/boot/dts/overlay/sun4i-a10-spi0.dts
 new file mode 100644
-index 0000000..132f780
+index 0000000..cad50d8
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-spi0.dts
 @@ -0,0 +1,23 @@
@@ -1760,14 +1760,14 @@ index 0000000..132f780
 +		__overlay__ {
 +			status = "okay";
 +			pinctrl-names = "default", "default";
-+			pinctrl-0 = <&spi0_pins_a>;
-+			pinctrl-1 = <&spi0_cs0_pins_a>;
++			pinctrl-0 = <&spi0_pi_pins>;
++			pinctrl-1 = <&spi0_cs0_pi_pin>;
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-spi1.dts b/arch/arm/boot/dts/overlay/sun4i-a10-spi1.dts
 new file mode 100644
-index 0000000..1d5c9df
+index 0000000..8c606d6
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-spi1.dts
 @@ -0,0 +1,22 @@
@@ -1789,7 +1789,7 @@ index 0000000..1d5c9df
 +		__overlay__ {
 +			status = "okay";
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&spi1_pins_a>, <&spi1_cs0_pins_a>;
++			pinctrl-0 = <&spi1_pins>, <&spi1_cs0_pin>;
 +		};
 +	};
 +};
@@ -2185,7 +2185,7 @@ index 0000000..9589767
 +fi
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-i2c1.dts b/arch/arm/boot/dts/overlay/sun5i-a13-i2c1.dts
 new file mode 100644
-index 0000000..e674962
+index 0000000..444c32c
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-i2c1.dts
 @@ -0,0 +1,22 @@
@@ -2206,14 +2206,14 @@ index 0000000..e674962
 +		target = <&i2c1>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&i2c1_pins_a>;
++			pinctrl-0 = <&i2c1_pins>;
 +			status = "okay";
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-i2c2.dts b/arch/arm/boot/dts/overlay/sun5i-a13-i2c2.dts
 new file mode 100644
-index 0000000..497f618
+index 0000000..7a30681
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-i2c2.dts
 @@ -0,0 +1,22 @@
@@ -2234,14 +2234,14 @@ index 0000000..497f618
 +		target = <&i2c2>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&i2c2_pins_a>;
++			pinctrl-0 = <&i2c2_pins>;
 +			status = "okay";
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-nand.dts b/arch/arm/boot/dts/overlay/sun5i-a13-nand.dts
 new file mode 100644
-index 0000000..669527a
+index 0000000..0c5fc89
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-nand.dts
 @@ -0,0 +1,60 @@
@@ -2257,7 +2257,7 @@ index 0000000..669527a
 +			#address-cells = <1>;
 +			#size-cells = <0>;
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&nand_pins_a>, <&nand_cs0_pins_a>, <&nand_rb0_pins_a>;
++			pinctrl-0 = <&nand_pins>, <&nand_cs0_pin>, <&nand_rb0_pin>;
 +			status = "okay";
 +
 +			nand@0 {
@@ -2307,7 +2307,7 @@ index 0000000..669527a
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-pwm.dts b/arch/arm/boot/dts/overlay/sun5i-a13-pwm.dts
 new file mode 100644
-index 0000000..711ff9c
+index 0000000..54f5d51
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-pwm.dts
 @@ -0,0 +1,15 @@
@@ -2321,7 +2321,7 @@ index 0000000..711ff9c
 +		target = <&pwm>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&pwm0_pins>;
++			pinctrl-0 = <&pwm0_pin>;
 +			status = "okay";
 +		};
 +	};
@@ -2543,7 +2543,7 @@ index 0000000..cc0af5d
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-spi2.dts b/arch/arm/boot/dts/overlay/sun5i-a13-spi2.dts
 new file mode 100644
-index 0000000..e8535be
+index 0000000..6cf5c41
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-spi2.dts
 @@ -0,0 +1,22 @@
@@ -2565,7 +2565,7 @@ index 0000000..e8535be
 +		__overlay__ {
 +			status = "okay";
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&spi2_pins_a>, <&spi2_cs0_pins_a>;
++			pinctrl-0 = <&spi2_pe_pins>, <&spi2_cs0_pe_pin>;
 +		};
 +	};
 +};
@@ -2609,7 +2609,7 @@ index 0000000..6edad42
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-uart1.dts b/arch/arm/boot/dts/overlay/sun5i-a13-uart1.dts
 new file mode 100644
-index 0000000..b165d5e
+index 0000000..675b701
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-uart1.dts
 @@ -0,0 +1,22 @@
@@ -2630,14 +2630,14 @@ index 0000000..b165d5e
 +		target = <&uart1>;
 +		 __overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&uart1_pins_a>;
++			pinctrl-0 = <&uart1_pe_pins>;
 +			status = "okay";
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-uart2.dts b/arch/arm/boot/dts/overlay/sun5i-a13-uart2.dts
 new file mode 100644
-index 0000000..fa2d0f1
+index 0000000..b3c4e3d
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-uart2.dts
 @@ -0,0 +1,22 @@
@@ -2658,14 +2658,14 @@ index 0000000..fa2d0f1
 +		target = <&uart2>;
 +		 __overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&uart2_pins_a>;
++			pinctrl-0 = <&uart2_pd_pins>;
 +			status = "okay";
 +		};
 +	};
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-uart3.dts b/arch/arm/boot/dts/overlay/sun5i-a13-uart3.dts
 new file mode 100644
-index 0000000..d474544
+index 0000000..15c25d0
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-uart3.dts
 @@ -0,0 +1,22 @@
@@ -2686,7 +2686,7 @@ index 0000000..d474544
 +		target = <&uart3>;
 +		 __overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&uart3_pins_a>;
++			pinctrl-0 = <&uart3_pg_pins>;
 +			status = "okay";
 +		};
 +	};
@@ -3234,7 +3234,7 @@ index 0000000..fe3e2bd
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-pwm.dts b/arch/arm/boot/dts/overlay/sun7i-a20-pwm.dts
 new file mode 100644
-index 0000000..b9978c6
+index 0000000..b0cfe4d
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-pwm.dts
 @@ -0,0 +1,15 @@
@@ -3248,7 +3248,7 @@ index 0000000..b9978c6
 +		target = <&pwm>;
 +		__overlay__ {
 +			pinctrl-names = "default";
-+			pinctrl-0 = <&pwm0_pins>, <&pwm1_pins>;
++			pinctrl-0 = <&pwm0_pin>, <&pwm1_pin>;
 +			status = "okay";
 +		};
 +	};


### PR DESCRIPTION
fix armbian overlays (part 2) - refactor pinctrl names for older SoCs (A10, A13)

this update of the previous patch (#1663) additionally fixes the following overlays:
sun5i-a13:	i2c1..2, nand, pwm, spi2, uart0..3
sun4i-a10:	can, i2c1..2, pwm, spdif-out, spi0..2
(sun7i-a20:	fixed typo in pwm overlay)

Next:
- update armbian/sunxi-DT-overlays via pull requests