### PR TITLE
Disabled hs400 mode of roc-rk3399-pc's emmc

### DIFF
--- a/patch/kernel/rk3399-legacy/roc-rk3399-pc-fix-disable-hs400.patch
+++ b/patch/kernel/rk3399-legacy/roc-rk3399-pc-fix-disable-hs400.patch
@@ -1,0 +1,21 @@
+Some eMMC moduled that come with ROC-RK3399-PC don't cope well with HS400/HS400ES.
+The modules that have issues are mentioned below DJNB4R and mine AJTD4R.
+
+See:
+https://lkml.org/lkml/2019/11/11/203
+https://lkml.org/lkml/2019/11/15/444
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-roc-pc.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-roc-pc.dtsi
+index f871f0c5..8cfd38f7 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-roc-pc.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3399-roc-pc.dtsi
+@@ -1082,8 +1082,7 @@
+ &sdhci {
+ 	bus-width = <8>;
+ 	keep-power-in-suspend;
+-	mmc-hs400-1_8v;
+-	mmc-hs400-enhanced-strobe;
++	mmc-hs200-1_8v;
+ 	non-removable;
+ 	status = "okay";
+ 	supports-emmc;

--- a/patch/kernel/rockchip64-current/board-roc-rk3399-pc-fix-disable-hs400.patch
+++ b/patch/kernel/rockchip64-current/board-roc-rk3399-pc-fix-disable-hs400.patch
@@ -1,0 +1,22 @@
+Some eMMC moduled that come with ROC-RK3399-PC don't cope well with HS400/HS400ES.
+The modules that have issues are mentioned below DJNB4R and mine AJTD4R.
+
+See:
+https://lkml.org/lkml/2019/11/11/203
+https://lkml.org/lkml/2019/11/15/444
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-roc-pc.dts b/arch/arm64/boot/dts/rockchip/rk3399-roc-pc.dts
+index 19f7732d7..bef364a09 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-roc-pc.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3399-roc-pc.dts
+@@ -646,8 +646,7 @@
+ 
+ &sdhci {
+ 	bus-width = <8>;
++	mmc-hs200-1_8v;
+-	mmc-hs400-1_8v;
+-	mmc-hs400-enhanced-strobe;
+ 	non-removable;
+ 	status = "okay";
+ };
+ 

--- a/patch/kernel/rockchip64-dev/board-roc-rk3399-pc-fix-disable-hs400.patch
+++ b/patch/kernel/rockchip64-dev/board-roc-rk3399-pc-fix-disable-hs400.patch
@@ -1,0 +1,22 @@
+Some eMMC moduled that come with ROC-RK3399-PC don't cope well with HS400/HS400ES.
+The modules that have issues are mentioned below DJNB4R and mine AJTD4R.
+
+See:
+https://lkml.org/lkml/2019/11/11/203
+https://lkml.org/lkml/2019/11/15/444
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-roc-pc.dts b/arch/arm64/boot/dts/rockchip/rk3399-roc-pc.dts
+index 19f7732d7..bef364a09 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-roc-pc.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3399-roc-pc.dts
+@@ -646,8 +646,7 @@
+ 
+ &sdhci {
+ 	bus-width = <8>;
++	mmc-hs200-1_8v;
+-	mmc-hs400-1_8v;
+-	mmc-hs400-enhanced-strobe;
+ 	non-removable;
+ 	status = "okay";
+ };
+ 


### PR DESCRIPTION
I observed similar behaviour as [described by Markus Reichl](https://lkml.org/lkml/2019/11/11/203) with the 16GB eMMC module named `AJTD4R` (KLMAG1JETD-B041).

The easiest way to reproduce is to run `nand-sata-install` in Armbian and try to move os to eMMC which results in lots of errors including filesystem being switched to read-only mode.
With HS400 mode disabled it works perfectly well.

@levindu I think it's reasonable to disable HS400 on roc-rk3399-pc for now unless there is some workaround that could make all modules work at HS400 spec.