### PR TITLE
bootscript: remove panic=10 from bootargs

### DIFF
--- a/config/bootscripts/boot-meson64.cmd
+++ b/config/bootscripts/boot-meson64.cmd
@@ -28,7 +28,7 @@ if test "${console}" = "serial"; then setenv consoleargs "console=ttyAML0,115200
 if test "${console}" = "display" || test "${console}" = "both"; then setenv consoleargs "console=ttyAML0,115200 console=tty1"; fi
 if test "${console}" = "serial"; then setenv consoleargs "console=ttyAML0,115200"; fi
 
-setenv bootargs "root=${rootdev} rootwait rootfstype=${rootfstype} panic=10 ${consoleargs} consoleblank=0 coherent_pool=2M loglevel=${verbosity} ubootpart=${partuuid} usb-storage.quirks=${usbstoragequirks} ${extraargs} ${extraboardargs}"
+setenv bootargs "root=${rootdev} rootwait rootfstype=${rootfstype} ${consoleargs} consoleblank=0 coherent_pool=2M loglevel=${verbosity} ubootpart=${partuuid} usb-storage.quirks=${usbstoragequirks} ${extraargs} ${extraboardargs}"
 
 if test "${docker_optimizations}" = "on"; then setenv bootargs "${bootargs} cgroup_enable=memory swapaccount=1"; fi
 

--- a/config/bootscripts/boot-odroid-xu4-default.ini
+++ b/config/bootscripts/boot-odroid-xu4-default.ini
@@ -24,7 +24,7 @@ if ext4load mmc 0:1 0x44000000 /boot/armbianEnv.txt || fatload mmc 0:1 0x4400000
 if test "${console}" = "display" || test "${console}" = "both"; then setenv consoleargs "console=tty1"; fi
 if test "${console}" = "serial" || test "${console}" = "both"; then setenv consoleargs "console=ttySAC2,115200n8 ${consoleargs}"; fi
 
-setenv bootrootfs "${consoleargs} consoleblank=0 loglevel=${verbosity} panic=10 root=${rootdev} rootfstype=${rootfstype} rootwait rw"
+setenv bootrootfs "${consoleargs} consoleblank=0 loglevel=${verbosity} root=${rootdev} rootfstype=${rootfstype} rootwait rw"
 
 # --- Screen Configuration for HDMI --- #
 # ---------------------------------------

--- a/config/bootscripts/boot-pine64-default.cmd
+++ b/config/bootscripts/boot-pine64-default.cmd
@@ -22,7 +22,7 @@ fi
 if test "${console}" = "display" || test "${console}" = "both"; then setenv consoleargs "console=tty1"; fi
 if test "${console}" = "serial" || test "${console}" = "both"; then setenv consoleargs "${consoleargs} console=ttyS0,115200n8"; fi
 
-setenv bootargs "root=${rootdev} rootfstype=${rootfstype} rootwait ${consoleargs} no_console_suspend earlycon=uart,mmio32,0x01c28000 mac_addr=${ethaddr} panic=10 consoleblank=0 loglevel=${verbosity} ${extraargs} ${extraboardargs}"
+setenv bootargs "root=${rootdev} rootfstype=${rootfstype} rootwait ${consoleargs} no_console_suspend earlycon=uart,mmio32,0x01c28000 mac_addr=${ethaddr} consoleblank=0 loglevel=${verbosity} ${extraargs} ${extraboardargs}"
 
 # determine board type from DT compiled into u-boot binary, currently SoPine is not autodetected
 fdt get value dt_name / dt-name

--- a/config/bootscripts/boot-rockchip.cmd
+++ b/config/bootscripts/boot-rockchip.cmd
@@ -30,7 +30,7 @@ if test "${console}" = "serial" || test "${console}" = "both"; then setenv conso
 # get PARTUUID of first partition on SD/eMMC the boot script was loaded from
 if test "${devtype}" = "mmc"; then part uuid mmc ${devnum}:1 partuuid; fi
 
-setenv bootargs "earlyprintk root=${rootdev} rootwait rootfstype=${rootfstype} ${consoleargs} panic=10 consoleblank=0 loglevel=${verbosity} ubootpart=${partuuid} usb-storage.quirks=${usbstoragequirks} ${extraargs} ${extraboardargs}"
+setenv bootargs "earlyprintk root=${rootdev} rootwait rootfstype=${rootfstype} ${consoleargs} consoleblank=0 loglevel=${verbosity} ubootpart=${partuuid} usb-storage.quirks=${usbstoragequirks} ${extraargs} ${extraboardargs}"
 
 if test "${docker_optimizations}" = "on"; then setenv bootargs "${bootargs} cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory swapaccount=1"; fi
 

--- a/config/bootscripts/boot-rockchip64.cmd
+++ b/config/bootscripts/boot-rockchip64.cmd
@@ -27,7 +27,7 @@ if test "${console}" = "serial" || test "${console}" = "both"; then setenv conso
 # get PARTUUID of first partition on SD/eMMC the boot script was loaded from
 if test "${devtype}" = "mmc"; then part uuid mmc ${devnum}:1 partuuid; fi
 
-setenv bootargs "root=${rootdev} rootwait rootfstype=${rootfstype} ${consoleargs} panic=10 consoleblank=0 loglevel=${verbosity} ubootpart=${partuuid} usb-storage.quirks=${usbstoragequirks} ${extraargs} ${extraboardargs}"
+setenv bootargs "root=${rootdev} rootwait rootfstype=${rootfstype} ${consoleargs} consoleblank=0 loglevel=${verbosity} ubootpart=${partuuid} usb-storage.quirks=${usbstoragequirks} ${extraargs} ${extraboardargs}"
 
 if test "${docker_optimizations}" = "on"; then setenv bootargs "${bootargs} cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory swapaccount=1"; fi
 

--- a/config/bootscripts/boot-rockpis.cmd
+++ b/config/bootscripts/boot-rockpis.cmd
@@ -27,7 +27,7 @@ if test "${console}" = "serial" || test "${console}" = "both"; then setenv conso
 # get PARTUUID of first partition on SD/eMMC the boot script was loaded from
 if test "${devtype}" = "mmc"; then part uuid mmc ${devnum}:1 partuuid; fi
 
-setenv bootargs "root=${rootdev} rootwait rootfstype=${rootfstype} ${consoleargs} panic=10 consoleblank=0 loglevel=${verbosity} ubootpart=${partuuid} usb-storage.quirks=${usbstoragequirks} ${extraargs} ${extraboardargs}"
+setenv bootargs "root=${rootdev} rootwait rootfstype=${rootfstype} ${consoleargs} consoleblank=0 loglevel=${verbosity} ubootpart=${partuuid} usb-storage.quirks=${usbstoragequirks} ${extraargs} ${extraboardargs}"
 
 if test "${docker_optimizations}" = "on"; then setenv bootargs "${bootargs} cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory swapaccount=1"; fi
 

--- a/config/bootscripts/boot-sun50i-next.cmd
+++ b/config/bootscripts/boot-sun50i-next.cmd
@@ -30,7 +30,7 @@ if test "${console}" = "serial"; then setenv consoleargs "console=ttyS0,115200";
 # mmc 0 is always mapped to device u-boot (2016.09+) was loaded from
 if test "${devtype}" = "mmc"; then part uuid mmc 0:1 partuuid; fi
 
-setenv bootargs "root=${rootdev} rootwait rootfstype=${rootfstype} ${consoleargs} panic=10 consoleblank=0 loglevel=${verbosity} ubootpart=${partuuid} usb-storage.quirks=${usbstoragequirks} ${extraargs} ${extraboardargs}"
+setenv bootargs "root=${rootdev} rootwait rootfstype=${rootfstype} ${consoleargs} consoleblank=0 loglevel=${verbosity} ubootpart=${partuuid} usb-storage.quirks=${usbstoragequirks} ${extraargs} ${extraboardargs}"
 
 if test "${docker_optimizations}" = "on"; then setenv bootargs "${bootargs} cgroup_enable=memory swapaccount=1"; fi
 

--- a/config/bootscripts/boot-sunxi.cmd
+++ b/config/bootscripts/boot-sunxi.cmd
@@ -40,7 +40,7 @@ if test "${logo}" = "disabled"; then setenv logo "logo.nologo"; fi
 if test "${console}" = "display" || test "${console}" = "both"; then setenv consoleargs "console=ttyS0,115200 console=tty1"; fi
 if test "${console}" = "serial"; then setenv consoleargs "console=ttyS0,115200"; fi
 
-setenv bootargs "root=${rootdev} rootwait rootfstype=${rootfstype} ${consoleargs} hdmi.audio=EDID:0 disp.screen0_output_mode=${disp_mode} panic=10 consoleblank=0 loglevel=${verbosity} ubootpart=${partuuid} ubootsource=${devtype} usb-storage.quirks=${usbstoragequirks} ${extraargs} ${extraboardargs}"
+setenv bootargs "root=${rootdev} rootwait rootfstype=${rootfstype} ${consoleargs} hdmi.audio=EDID:0 disp.screen0_output_mode=${disp_mode} consoleblank=0 loglevel=${verbosity} ubootpart=${partuuid} ubootsource=${devtype} usb-storage.quirks=${usbstoragequirks} ${extraargs} ${extraboardargs}"
 
 if test "${disp_mem_reserves}" = "off"; then setenv bootargs "${bootargs} sunxi_ve_mem_reserve=0 sunxi_g2d_mem_reserve=0 sunxi_fb_mem_reserve=16"; fi
 if test "${docker_optimizations}" = "on"; then setenv bootargs "${bootargs} cgroup_enable=memory swapaccount=1"; fi


### PR DESCRIPTION
when there are some reasons which board failed to boot, eg rootfs crashes.
/init will fail to panic().

panic()
{
	local console rest IFS

	if command -v chvt >/dev/null 2>&1; then
		chvt 1
	fi

	echo "$@"
	# Disallow console access
	if [ -n "${panic?}" ]; then
		echo "Rebooting automatically due to panic= boot argument"
		sleep "${panic}"
		reboot
		exit  # in case reboot fails, force kernel panic
	fi
...
}

when panic is set, there is no chance to fail into a shell, to debug what happens.
and device just keep reboot.

remove panic from bootargs to make it possible for users to find out why their boards fail to boot.

Signed-off-by: Zhang Ning <832666+zhangn1985@users.noreply.github.com>

