### PR TITLE
Change rx delay for rockpro64

### DIFF
--- a/patch/kernel/rockchip64-current/ayufan-dts-rockpro64-change-rx_delay-for-gmac.patch
+++ b/patch/kernel/rockchip64-current/ayufan-dts-rockpro64-change-rx_delay-for-gmac.patch
@@ -1,0 +1,26 @@
+From 57825a7190ac09a1e273cab12e797010fcb7a1c9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Kamil=20Trzci=C5=84ski?= <ayufan@ayufan.eu>
+Date: Sun, 30 Dec 2018 13:32:47 +0100
+Subject: [PATCH] ayufan: dts: rockpro64: change rx_delay for gmac
+
+Change-Id: Ib3899f684188aa1ed1545717af004bba53fe0e07
+---
+ arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts
+index cdab3089046c..0db9de46ff16 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts
+@@ -249,7 +249,7 @@
+ 	snps,reset-active-low;
+ 	snps,reset-delays-us = <0 10000 50000>;
+ 	tx_delay = <0x28>;
+-	rx_delay = <0x11>;
++	rx_delay = <0x20>;
+ 	status = "okay";
+ };
+ 
+-- 
+2.20.1
+


### PR DESCRIPTION
This patch is retrieved from ayufan-rock64 repository and fixes the ethernet issues for rockpro64 in the rockchip64-current branch. 