### PR TITLE
Removed export of variable ARCH

### DIFF
--- a/lib/distributions.sh
+++ b/lib/distributions.sh
@@ -31,8 +31,6 @@ install_common()
 		fi
 
 	fi
-	# define ARCH within global environment variables
-	[[ -f $SDCARD/etc/environment ]] && echo -e "ARCH=${ARCH//hf}" >> "${SDCARD}"/etc/environment
 
 	# add dummy fstab entry to make mkinitramfs happy
 	echo "/dev/mmcblk0p1 / $ROOTFS_TYPE defaults 0 1" >> "${SDCARD}"/etc/fstab


### PR DESCRIPTION
This change has been motivated by this post in the forum: https://forum.armbian.com/topic/10344-postinst-of-dkms-package-is-broken-on-armbian/?do=findComment&comment=89779

**Background:** The postinst-scripts of DKMS are currently broken because they use a variable "ARCH" which conflicts with a exported variable of the same name (which basically contains the same values). Two fixes are possible: Modify the postinst-script (would be an upstream-change for a Debian package) or remove the export of the variable within Armbian (which is under full control of the Armbian project).

This PR follows the second approach, as proposed in the post in the forum mentioned above. Tests have been successful (package zfs-dkms can be built and installed with legacy kernel on NanoPi M4V2).

**Please note:** This change does not fix all problems concerning DKMS in Armbian. There are still other issues but those seem to be related to the kernel headers.

**Important:** Most likely there will be side effects: I expect an exported variable, that has been available for several years, is being used. Removing it will break those dependencies. But I'm not familar enough with the code base to find such problems. Extensive review recommended. Required further changes can be added to this PR.