### PR TITLE
Wireguard: bump tag to most recent since it breaks building on 5.4.y

### DIFF
--- a/lib/compilation-prepare.sh
+++ b/lib/compilation-prepare.sh
@@ -95,7 +95,7 @@ compilation_prepare()
 
 		# attach to specifics tag or branch
 		#local wirever="branch:master"
-		local wirever="tag:0.0.20190702"
+		local wirever="tag:0.0.20191219"
 
 		display_alert "Adding" "WireGuard ${wirever} " "info"
 


### PR DESCRIPTION
[AR-106]

[AR-106]: https://armbian.atlassian.net/browse/AR-106