### PR TITLE
Update 0000-0012-ARM-dts-sunxi-h3-h5-Move-CPU-OPP-table-to-dtsi-share…

### DIFF
--- a/patch/kernel/sunxi-legacy/0000-0012-ARM-dts-sunxi-h3-h5-Move-CPU-OPP-table-to-dtsi-share.patch
+++ b/patch/kernel/sunxi-legacy/0000-0012-ARM-dts-sunxi-h3-h5-Move-CPU-OPP-table-to-dtsi-share.patch
@@ -24,19 +24,19 @@ index cb19ff797606..261ca0356358 100644
 -		compatible = "operating-points-v2";
 -		opp-shared;
 -
--		opp@648000000 {
+-		opp-648000000 {
 -			opp-hz = /bits/ 64 <648000000>;
 -			opp-microvolt = <1040000 1040000 1300000>;
 -			clock-latency-ns = <244144>; /* 8 32k periods */
 -		};
 -
--		opp@816000000 {
+-		opp-816000000 {
 -			opp-hz = /bits/ 64 <816000000>;
 -			opp-microvolt = <1100000 1100000 1300000>;
 -			clock-latency-ns = <244144>; /* 8 32k periods */
 -		};
 -
--		opp@1008000000 {
+-		opp-1008000000 {
 -			opp-hz = /bits/ 64 <1008000000>;
 -			opp-microvolt = <1200000 1200000 1300000>;
 -			clock-latency-ns = <244144>; /* 8 32k periods */


### PR DESCRIPTION
First hunk failed to apply. This fixes it.

Kernel package building for an OPi One was successful. Not tested on a SBC....yet 😄 

Almost forgot: Happy Holidays!!