### PR TITLE
NanoPi M4V2 ethernet fix for legacy kernel

### DIFF
--- a/patch/kernel/rk3399-legacy/friendly-arm-nanopim4v2-ethernet-fix.patch
+++ b/patch/kernel/rk3399-legacy/friendly-arm-nanopim4v2-ethernet-fix.patch
@@ -1,0 +1,15 @@
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-nanopi4-rev21.dts b/arch/arm64/boot/dts/rockchip/rk3399-nanopi4-rev21.dts
+index 6104cac5..ce2fe96d 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-nanopi4-rev21.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi4-rev21.dts
+@@ -29,6 +29,10 @@
+ 	model = "NanoPi M4";
+ };
+ 
++&gmac {
++	tx_delay = <0x20>;
++};
++
+ &sdhci {
+ 	mmc-hs200-1_8v;
+ 	/delete-property/ mmc-hs400-1_8v;


### PR DESCRIPTION
Changing `tx_delay` from 0x28 to 0x20 in ethernet node effectively fixes ethernet issues experienced with the board using legacy kernel.

The value has been chosen empirically - anything between 0x1E and 0x24 works correctly.
With the change both sending and receiving are sound at gigabit level and putting in an USB drive does not bork the ethernet connection:

```
root@nanopim4v2:~# iperf3 -c 192.168.2.2 -p 5001 -t 30
Connecting to host 192.168.2.2, port 5001
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-30.00  sec  3.29 GBytes   942 Mbits/sec    0             sender
[  5]   0.00-30.00  sec  3.29 GBytes   941 Mbits/sec                  receiver

root@nanopim4v2:~# iperf3 -R -c 192.168.2.2 -p 5001 -t 30
Connecting to host 192.168.2.2, port 5001
Reverse mode, remote host 192.168.2.2 is sending
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-30.00  sec  3.26 GBytes   935 Mbits/sec    0             sender
[  5]   0.00-30.00  sec  3.26 GBytes   934 Mbits/sec                  receiver
```

