### PR TITLE
sunxi-overlays: updated child node syntax to 5.x 

### DIFF
--- a/patch/kernel/sunxi-current/general-sunxi-overlays.patch
+++ b/patch/kernel/sunxi-current/general-sunxi-overlays.patch
@@ -1612,7 +1612,7 @@ index 0000000..234dfc8
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-spi-jedec-nor.dts b/arch/arm/boot/dts/overlay/sun4i-a10-spi-jedec-nor.dts
 new file mode 100644
-index 0000000..617bf75
+index 0000000..ee4ff6f
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-spi-jedec-nor.dts
 @@ -0,0 +1,57 @@
@@ -1636,7 +1636,7 @@ index 0000000..617bf75
 +		__overlay__ {
 +			#address-cells = <1>;
 +			#size-cells = <0>;
-+			spiflash {
++			spiflash@0 {
 +				compatible = "jedec,spi-nor";
 +				status = "disabled";
 +				reg = <0>;
@@ -1650,7 +1650,7 @@ index 0000000..617bf75
 +		__overlay__ {
 +			#address-cells = <1>;
 +			#size-cells = <0>;
-+			spiflash {
++			spiflash@0 {
 +				compatible = "jedec,spi-nor";
 +				status = "disabled";
 +				reg = <0>;
@@ -1664,7 +1664,7 @@ index 0000000..617bf75
 +		__overlay__ {
 +			#address-cells = <1>;
 +			#size-cells = <0>;
-+			spiflash {
++			spiflash@0 {
 +				compatible = "jedec,spi-nor";
 +				status = "disabled";
 +				reg = <0>;
@@ -1675,7 +1675,7 @@ index 0000000..617bf75
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun4i-a10-spi-spidev.dts b/arch/arm/boot/dts/overlay/sun4i-a10-spi-spidev.dts
 new file mode 100644
-index 0000000..a570c86
+index 0000000..5667aec
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun4i-a10-spi-spidev.dts
 @@ -0,0 +1,57 @@
@@ -1699,7 +1699,7 @@ index 0000000..a570c86
 +		__overlay__ {
 +			#address-cells = <1>;
 +			#size-cells = <0>;
-+			spidev {
++			spidev@0 {
 +				compatible = "spidev";
 +				status = "disabled";
 +				reg = <0>;
@@ -1713,7 +1713,7 @@ index 0000000..a570c86
 +		__overlay__ {
 +			#address-cells = <1>;
 +			#size-cells = <0>;
-+			spidev {
++			spidev@0 {
 +				compatible = "spidev";
 +				status = "disabled";
 +				reg = <0>;
@@ -1727,7 +1727,7 @@ index 0000000..a570c86
 +		__overlay__ {
 +			#address-cells = <1>;
 +			#size-cells = <0>;
-+			spidev {
++			spidev@0 {
 +				compatible = "spidev";
 +				status = "disabled";
 +				reg = <0>;
@@ -2328,7 +2328,7 @@ index 0000000..54f5d51
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-spi-jedec-nor.dts b/arch/arm/boot/dts/overlay/sun5i-a13-spi-jedec-nor.dts
 new file mode 100644
-index 0000000..cece796
+index 0000000..8cebb0b
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-spi-jedec-nor.dts
 @@ -0,0 +1,57 @@
@@ -2352,7 +2352,7 @@ index 0000000..cece796
 +		__overlay__ {
 +			#address-cells = <1>;
 +			#size-cells = <0>;
-+			spiflash {
++			spiflash@0 {
 +				compatible = "jedec,spi-nor";
 +				status = "disabled";
 +				reg = <0>;
@@ -2366,7 +2366,7 @@ index 0000000..cece796
 +		__overlay__ {
 +			#address-cells = <1>;
 +			#size-cells = <0>;
-+			spiflash {
++			spiflash@0 {
 +				compatible = "jedec,spi-nor";
 +				status = "disabled";
 +				reg = <0>;
@@ -2380,7 +2380,7 @@ index 0000000..cece796
 +		__overlay__ {
 +			#address-cells = <1>;
 +			#size-cells = <0>;
-+			spiflash {
++			spiflash@0 {
 +				compatible = "jedec,spi-nor";
 +				status = "disabled";
 +				reg = <0>;
@@ -2391,7 +2391,7 @@ index 0000000..cece796
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun5i-a13-spi-spidev.dts b/arch/arm/boot/dts/overlay/sun5i-a13-spi-spidev.dts
 new file mode 100644
-index 0000000..6294ee3
+index 0000000..ced1a0e
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun5i-a13-spi-spidev.dts
 @@ -0,0 +1,57 @@
@@ -2415,7 +2415,7 @@ index 0000000..6294ee3
 +		__overlay__ {
 +			#address-cells = <1>;
 +			#size-cells = <0>;
-+			spidev {
++			spidev@0 {
 +				compatible = "spidev";
 +				status = "disabled";
 +				reg = <0>;
@@ -2429,7 +2429,7 @@ index 0000000..6294ee3
 +		__overlay__ {
 +			#address-cells = <1>;
 +			#size-cells = <0>;
-+			spidev {
++			spidev@0 {
 +				compatible = "spidev";
 +				status = "disabled";
 +				reg = <0>;
@@ -2443,7 +2443,7 @@ index 0000000..6294ee3
 +		__overlay__ {
 +			#address-cells = <1>;
 +			#size-cells = <0>;
-+			spidev {
++			spidev@0 {
 +				compatible = "spidev";
 +				status = "disabled";
 +				reg = <0>;
@@ -3321,7 +3321,7 @@ index 0000000..c0a4ba2
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-spi-jedec-nor.dts b/arch/arm/boot/dts/overlay/sun7i-a20-spi-jedec-nor.dts
 new file mode 100644
-index 0000000..efd147c
+index 0000000..b91097e
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-spi-jedec-nor.dts
 @@ -0,0 +1,57 @@
@@ -3345,7 +3345,7 @@ index 0000000..efd147c
 +		__overlay__ {
 +			#address-cells = <1>;
 +			#size-cells = <0>;
-+			spiflash {
++			spiflash@0 {
 +				compatible = "jedec,spi-nor";
 +				status = "disabled";
 +				reg = <0>;
@@ -3359,7 +3359,7 @@ index 0000000..efd147c
 +		__overlay__ {
 +			#address-cells = <1>;
 +			#size-cells = <0>;
-+			spiflash {
++			spiflash@0 {
 +				compatible = "jedec,spi-nor";
 +				status = "disabled";
 +				reg = <0>;
@@ -3373,7 +3373,7 @@ index 0000000..efd147c
 +		__overlay__ {
 +			#address-cells = <1>;
 +			#size-cells = <0>;
-+			spiflash {
++			spiflash@0 {
 +				compatible = "jedec,spi-nor";
 +				status = "disabled";
 +				reg = <0>;
@@ -3384,7 +3384,7 @@ index 0000000..efd147c
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun7i-a20-spi-spidev.dts b/arch/arm/boot/dts/overlay/sun7i-a20-spi-spidev.dts
 new file mode 100644
-index 0000000..f8faa97
+index 0000000..a3073b2
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun7i-a20-spi-spidev.dts
 @@ -0,0 +1,57 @@
@@ -3408,7 +3408,7 @@ index 0000000..f8faa97
 +		__overlay__ {
 +			#address-cells = <1>;
 +			#size-cells = <0>;
-+			spidev {
++			spidev@0 {
 +				compatible = "spidev";
 +				status = "disabled";
 +				reg = <0>;
@@ -3422,7 +3422,7 @@ index 0000000..f8faa97
 +		__overlay__ {
 +			#address-cells = <1>;
 +			#size-cells = <0>;
-+			spidev {
++			spidev@0 {
 +				compatible = "spidev";
 +				status = "disabled";
 +				reg = <0>;
@@ -3436,7 +3436,7 @@ index 0000000..f8faa97
 +		__overlay__ {
 +			#address-cells = <1>;
 +			#size-cells = <0>;
-+			spidev {
++			spidev@0 {
 +				compatible = "spidev";
 +				status = "disabled";
 +				reg = <0>;
@@ -4175,7 +4175,7 @@ index 0000000..bd8e256
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun8i-h3-spi-jedec-nor.dts b/arch/arm/boot/dts/overlay/sun8i-h3-spi-jedec-nor.dts
 new file mode 100644
-index 0000000..6e53bbb
+index 0000000..95fa5f2
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun8i-h3-spi-jedec-nor.dts
 @@ -0,0 +1,42 @@
@@ -4198,7 +4198,7 @@ index 0000000..6e53bbb
 +		__overlay__ {
 +			#address-cells = <1>;
 +			#size-cells = <0>;
-+			spiflash {
++			spiflash@0 {
 +				compatible = "jedec,spi-nor";
 +				reg = <0>;
 +				spi-max-frequency = <1000000>;
@@ -4212,7 +4212,7 @@ index 0000000..6e53bbb
 +		__overlay__ {
 +			#address-cells = <1>;
 +			#size-cells = <0>;
-+			spiflash {
++			spiflash@0 {
 +				compatible = "jedec,spi-nor";
 +				reg = <0>;
 +				spi-max-frequency = <1000000>;
@@ -4223,7 +4223,7 @@ index 0000000..6e53bbb
 +};
 diff --git a/arch/arm/boot/dts/overlay/sun8i-h3-spi-spidev.dts b/arch/arm/boot/dts/overlay/sun8i-h3-spi-spidev.dts
 new file mode 100644
-index 0000000..9c4c907
+index 0000000..575c970
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/sun8i-h3-spi-spidev.dts
 @@ -0,0 +1,42 @@
@@ -4246,7 +4246,7 @@ index 0000000..9c4c907
 +		__overlay__ {
 +			#address-cells = <1>;
 +			#size-cells = <0>;
-+			spidev {
++			spidev@0 {
 +				compatible = "spidev";
 +				status = "disabled";
 +				reg = <0>;
@@ -4260,7 +4260,7 @@ index 0000000..9c4c907
 +		__overlay__ {
 +			#address-cells = <1>;
 +			#size-cells = <0>;
-+			spidev {
++			spidev@0 {
 +				compatible = "spidev";
 +				status = "disabled";
 +				reg = <0>;
@@ -5343,7 +5343,7 @@ index 0000000..31d73e5
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-spi-spidev.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-spi-spidev.dts
 new file mode 100644
-index 0000000..fe8fb14
+index 0000000..70d90a2
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-spi-spidev.dts
 @@ -0,0 +1,42 @@
@@ -5366,7 +5366,7 @@ index 0000000..fe8fb14
 +		__overlay__ {
 +			#address-cells = <1>;
 +			#size-cells = <0>;
-+			spidev {
++			spidev@0 {
 +				compatible = "spidev";
 +				status = "disabled";
 +				reg = <0>;
@@ -5380,7 +5380,7 @@ index 0000000..fe8fb14
 +		__overlay__ {
 +			#address-cells = <1>;
 +			#size-cells = <0>;
-+			spidev {
++			spidev@0 {
 +				compatible = "spidev";
 +				status = "disabled";
 +				reg = <0>;
@@ -6035,7 +6035,7 @@ index 0000000..5a45808
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-spi-spidev.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-spi-spidev.dts
 new file mode 100644
-index 0000000..70f435b
+index 0000000..9b5b0f2
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-spi-spidev.dts
 @@ -0,0 +1,42 @@
@@ -6058,7 +6058,7 @@ index 0000000..70f435b
 +		__overlay__ {
 +			#address-cells = <1>;
 +			#size-cells = <0>;
-+			spidev {
++			spidev@0 {
 +				compatible = "spidev";
 +				status = "disabled";
 +				reg = <0>;
@@ -6072,7 +6072,7 @@ index 0000000..70f435b
 +		__overlay__ {
 +			#address-cells = <1>;
 +			#size-cells = <0>;
-+			spidev {
++			spidev@0 {
 +				compatible = "spidev";
 +				status = "disabled";
 +				reg = <0>;
@@ -6662,7 +6662,7 @@ index 0000000..4f81dbb
 +};
 diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-spidev.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-spidev.dts
 new file mode 100644
-index 0000000..fd807d6
+index 0000000..bac3adc
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-spi-spidev.dts
 @@ -0,0 +1,42 @@
@@ -6685,7 +6685,7 @@ index 0000000..fd807d6
 +		__overlay__ {
 +			#address-cells = <1>;
 +			#size-cells = <0>;
-+			spidev {
++			spidev@0 {
 +				compatible = "spidev";
 +				status = "disabled";
 +				reg = <0>;
@@ -6699,7 +6699,7 @@ index 0000000..fd807d6
 +		__overlay__ {
 +			#address-cells = <1>;
 +			#size-cells = <0>;
-+			spidev {
++			spidev@0 {
 +				compatible = "spidev";
 +				status = "disabled";
 +				reg = <0>;


### PR DESCRIPTION
updated child node syntax to 5.x for arm/spi-spidev and arm/spi-jedec-nor as well as  arm64/spi-spidev.