### PR TITLE
Truncate logs: keep log files ownership

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-truncate-logs
+++ b/packages/bsp/common/usr/lib/armbian/armbian-truncate-logs
@@ -20,7 +20,6 @@ if [ $logusage -ge $treshold ]; then
     # write to SD
     /usr/lib/armbian/armbian-ramlog write >/dev/null 2>&1
     # rotate logs on "disk"
-    chown root.root -R /var/log.hdd
     /usr/sbin/logrotate --force /etc/logrotate.conf
     # truncate
     /usr/bin/find /var/log -name '*.log' -or -name '*.xz' -or -name 'lastlog' -or -name 'messages' -or -name 'debug' -or -name 'syslog' | xargs truncate --size 0


### PR DESCRIPTION
Keep file ownership in `/var/log.hdd/` directory same as in `/var/log/` directory. 
Fixes https://forum.armbian.com/topic/12001-logs/.