### PR TITLE
Fix DKMS in Armbian

### DIFF
--- a/lib/distributions.sh
+++ b/lib/distributions.sh
@@ -31,8 +31,6 @@ install_common()
 		fi
 
 	fi
-	# define ARCH within global environment variables
-	[[ -f $SDCARD/etc/environment ]] && echo -e "ARCH=${ARCH//hf}" >> "${SDCARD}"/etc/environment
 
 	# add dummy fstab entry to make mkinitramfs happy
 	echo "/dev/mmcblk0p1 / $ROOTFS_TYPE defaults 0 1" >> "${SDCARD}"/etc/fstab

--- a/patch/misc/general-packaging-4.14.y.patch
+++ b/patch/misc/general-packaging-4.14.y.patch
@@ -1,8 +1,8 @@
 diff --git a/arch/arm64/Makefile b/arch/arm64/Makefile
-index f839ecd9..cd276162 100644
+index 8c4bc5a2..30bc0cff 100644
 --- a/arch/arm64/Makefile
 +++ b/arch/arm64/Makefile
-@@ -103,7 +103,7 @@ core-$(CONFIG_EFI_STUB) += $(objtree)/drivers/firmware/efi/libstub/lib.a
+@@ -114,7 +114,7 @@ core-$(CONFIG_EFI_STUB) += $(objtree)/drivers/firmware/efi/libstub/lib.a
  
  # Default target when executing plain make
  boot		:= arch/arm64/boot
@@ -12,6 +12,7 @@ index f839ecd9..cd276162 100644
  
  all:	Image.gz $(KBUILD_DTBS)
 diff --git a/scripts/package/builddeb b/scripts/package/builddeb
+index e15159d0..d3bfac05 100755
 --- a/scripts/package/builddeb
 +++ b/scripts/package/builddeb
 @@ -29,6 +29,27 @@ create_package() {
@@ -103,7 +104,7 @@ diff --git a/scripts/package/builddeb b/scripts/package/builddeb
  if [ "$ARCH" != "um" ]; then
  	$MAKE headers_check KBUILD_SRC=
  	$MAKE headers_install KBUILD_SRC= INSTALL_HDR_PATH="$libc_headers_dir/usr"
-@@ -218,7 +218,7 @@
+@@ -196,7 +230,7 @@ fi
  for script in postinst postrm preinst prerm ; do
  	mkdir -p "$tmpdir$debhookdir/$script.d"
  	cat <<EOF > "$tmpdir/DEBIAN/$script"
@@ -168,7 +169,7 @@ diff --git a/scripts/package/builddeb b/scripts/package/builddeb
  # Try to determine maintainer and email values
  if [ -n "$DEBEMAIL" ]; then
         email=$DEBEMAIL
-@@ -397,6 +397,7 @@ fi
+@@ -314,6 +397,7 @@ fi
  # Build kernel header package
  (cd $srctree; find . -name Makefile\* -o -name Kconfig\* -o -name \*.pl) > "$objtree/debian/hdrsrcfiles"
  (cd $srctree; find arch/*/include include scripts -type f -o -type l) >> "$objtree/debian/hdrsrcfiles"
@@ -192,7 +193,7 @@ diff --git a/scripts/package/builddeb b/scripts/package/builddeb
  cat <<EOF >> debian/control
  
  Package: $kernel_headers_packagename
-@@ -343,6 +430,16 @@ EOF
+@@ -343,10 +430,21 @@ EOF
  
  cat <<EOF >> debian/control
  
@@ -209,7 +210,12 @@ diff --git a/scripts/package/builddeb b/scripts/package/builddeb
  Package: $libc_headers_packagename
  Section: devel
  Provides: linux-kernel-headers
-@@ -354,7 +451,7 @@ EOF
+ Architecture: any
++Depends: make, flex, bison, libssl-dev
+ Description: Linux support headers for userspace development
+  This package provides userspaces headers from the Linux kernel.  These headers
+  are used by the installed headers for GNU glibc and other system libraries.
+@@ -354,7 +452,7 @@ EOF
  
  if [ "$ARCH" != "um" ]; then
  	create_package "$kernel_headers_packagename" "$kernel_headers_dir"

--- a/patch/misc/general-packaging-4.14.y.patch
+++ b/patch/misc/general-packaging-4.14.y.patch
@@ -1,5 +1,5 @@
 diff --git a/arch/arm64/Makefile b/arch/arm64/Makefile
-index 8c4bc5a2..30bc0cff 100644
+index 8c4bc5a2c..30bc0cffb 100644
 --- a/arch/arm64/Makefile
 +++ b/arch/arm64/Makefile
 @@ -114,7 +114,7 @@ core-$(CONFIG_EFI_STUB) += $(objtree)/drivers/firmware/efi/libstub/lib.a
@@ -12,7 +12,7 @@ index 8c4bc5a2..30bc0cff 100644
  
  all:	Image.gz $(KBUILD_DTBS)
 diff --git a/scripts/package/builddeb b/scripts/package/builddeb
-index e15159d0..d3bfac05 100755
+index e15159d0a..009332700 100755
 --- a/scripts/package/builddeb
 +++ b/scripts/package/builddeb
 @@ -29,6 +29,27 @@ create_package() {
@@ -177,7 +177,7 @@ index e15159d0..d3bfac05 100755
  (cd $srctree; find arch/$SRCARCH -name module.lds -o -name Kbuild.platforms -o -name Platform) >> "$objtree/debian/hdrsrcfiles"
  (cd $srctree; find $(find arch/$SRCARCH -name include -o -name scripts -type d) -type f) >> "$objtree/debian/hdrsrcfiles"
  if grep -q '^CONFIG_STACK_VALIDATION=y' $KCONFIG_CONFIG ; then
-@@ -325,12 +409,15 @@ if grep -q '^CONFIG_GCC_PLUGINS=y' $KCONFIG_CONFIG ; then
+@@ -325,16 +409,20 @@ if grep -q '^CONFIG_GCC_PLUGINS=y' $KCONFIG_CONFIG ; then
  fi
  destdir=$kernel_headers_dir/usr/src/linux-headers-$version
  mkdir -p "$destdir"
@@ -193,7 +193,12 @@ index e15159d0..d3bfac05 100755
  cat <<EOF >> debian/control
  
  Package: $kernel_headers_packagename
-@@ -343,10 +430,21 @@ EOF
+ Architecture: any
++Depends: make, gcc, libc6-dev, libssl-dev
+ Description: Linux kernel headers for $KERNELRELEASE on \${kernel:debarch}
+  This package provides kernel header files for $KERNELRELEASE on \${kernel:debarch}
+  .
+@@ -343,6 +431,16 @@ EOF
  
  cat <<EOF >> debian/control
  
@@ -210,11 +215,6 @@ index e15159d0..d3bfac05 100755
  Package: $libc_headers_packagename
  Section: devel
  Provides: linux-kernel-headers
- Architecture: any
-+Depends: make, flex, bison, libssl-dev
- Description: Linux support headers for userspace development
-  This package provides userspaces headers from the Linux kernel.  These headers
-  are used by the installed headers for GNU glibc and other system libraries.
 @@ -354,7 +452,7 @@ EOF
  
  if [ "$ARCH" != "um" ]; then

--- a/patch/misc/general-packaging-4.14.y.patch
+++ b/patch/misc/general-packaging-4.14.y.patch
@@ -12,7 +12,6 @@ index f839ecd9..cd276162 100644
  
  all:	Image.gz $(KBUILD_DTBS)
 diff --git a/scripts/package/builddeb b/scripts/package/builddeb
-index 0bc87473..cf26d2c7 100755
 --- a/scripts/package/builddeb
 +++ b/scripts/package/builddeb
 @@ -29,6 +29,27 @@ create_package() {
@@ -35,7 +34,7 @@ index 0bc87473..cf26d2c7 100755
 +
 +	# Create postinstall script for headers
 +	if [[ "$1" == *headers* ]]; then
-+		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts >/dev/null 2>&1; make -s M=scripts/mod/ >/dev/null 2>&1" >> $pdir/DEBIAN/postinst
++		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts >/dev/null; make -s M=scripts/mod/ >/dev/null" >> $pdir/DEBIAN/postinst
 +		echo "exit 0" >> $pdir/DEBIAN/postinst
 +		chmod 775 $pdir/DEBIAN/postinst
 +	fi

--- a/patch/misc/general-packaging-4.19.y.patch
+++ b/patch/misc/general-packaging-4.19.y.patch
@@ -22,7 +22,7 @@ index 90c9a8a..3c79b90 100755
 +
 +	# Create postinstall script for headers
 +	if [[ "$1" == *headers* ]]; then
-+		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts >/dev/null 2>&1; make -s M=scripts/mod/ >/dev/null 2>&1" >> $pdir/DEBIAN/postinst
++		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts >/dev/null; make -s M=scripts/mod/ >/dev/null" >> $pdir/DEBIAN/postinst
 +		echo "exit 0" >> $pdir/DEBIAN/postinst
 +		chmod 775 $pdir/DEBIAN/postinst
 +	fi

--- a/patch/misc/general-packaging-4.19.y.patch
+++ b/patch/misc/general-packaging-4.19.y.patch
@@ -1,5 +1,5 @@
 diff --git a/arch/arm64/Makefile b/arch/arm64/Makefile
-index 9a5e28141..851e64616 100644
+index 9a5e28141211..851e646169ba 100644
 --- a/arch/arm64/Makefile
 +++ b/arch/arm64/Makefile
 @@ -113,7 +113,7 @@ core-$(CONFIG_EFI_STUB) += $(objtree)/drivers/firmware/efi/libstub/lib.a
@@ -12,7 +12,7 @@ index 9a5e28141..851e64616 100644
  
  all:	Image.gz $(KBUILD_DTBS)
 diff --git a/scripts/package/builddeb b/scripts/package/builddeb
-index 0b31f4f1f..4f605fe82 100755
+index 0b31f4f1f92c..4f605fe82fd4 100755
 --- a/scripts/package/builddeb
 +++ b/scripts/package/builddeb
 @@ -29,6 +29,27 @@ create_package() {
@@ -189,7 +189,7 @@ index 0b31f4f1f..4f605fe82 100755
  
  create_package "$packagename" "$tmpdir"
 diff --git a/scripts/package/mkdebian b/scripts/package/mkdebian
-index edcad61fe..7a0ce28ca 100755
+index edcad61fe3cd..8a49f432921f 100755
 --- a/scripts/package/mkdebian
 +++ b/scripts/package/mkdebian
 @@ -94,10 +94,12 @@ else
@@ -207,14 +207,14 @@ index edcad61fe..7a0ce28ca 100755
  set_debarch
  
  if [ "$ARCH" = "um" ] ; then
-@@ -190,6 +192,7 @@ Package: linux-libc-dev
- Section: devel
- Provides: linux-kernel-headers
+@@ -181,6 +183,7 @@ Description: Linux kernel, version $version
+ 
+ Package: $kernel_headers_packagename
  Architecture: $debarch
-+Depends: make, flex, bison, libssl-dev
- Description: Linux support headers for userspace development
-  This package provides userspaces headers from the Linux kernel.  These headers
-  are used by the installed headers for GNU glibc and other system libraries.
++Depends: make, gcc, libc6-dev, flex, bison, libssl-dev
+ Description: Linux kernel headers for $version on $debarch
+  This package provides kernel header files for $version on $debarch
+  .
 @@ -200,6 +203,11 @@ Architecture: $debarch
  Description: Linux kernel debugging symbols for $version
   This package will come in handy if you need to debug the kernel. It provides

--- a/patch/misc/general-packaging-4.19.y.patch
+++ b/patch/misc/general-packaging-4.19.y.patch
@@ -1,11 +1,24 @@
+diff --git a/arch/arm64/Makefile b/arch/arm64/Makefile
+index 9a5e28141..851e64616 100644
+--- a/arch/arm64/Makefile
++++ b/arch/arm64/Makefile
+@@ -113,7 +113,7 @@ core-$(CONFIG_EFI_STUB) += $(objtree)/drivers/firmware/efi/libstub/lib.a
+ 
+ # Default target when executing plain make
+ boot		:= arch/arm64/boot
+-KBUILD_IMAGE	:= $(boot)/Image.gz
++KBUILD_IMAGE	:= $(boot)/Image
+ KBUILD_DTBS	:= dtbs
+ 
+ all:	Image.gz $(KBUILD_DTBS)
 diff --git a/scripts/package/builddeb b/scripts/package/builddeb
-index 90c9a8a..3c79b90 100755
+index 0b31f4f1f..4f605fe82 100755
 --- a/scripts/package/builddeb
 +++ b/scripts/package/builddeb
 @@ -29,6 +29,27 @@ create_package() {
  	# in case we are in a restrictive umask environment like 0077
  	chmod -R a+rX "$pdir"
-
+ 
 +	# Create preinstall and post install script to remove dtb
 +	if [[ "$1" == *dtb* ]]; then
 +		echo "if [ -d /boot/dtb-$version ]; then mv /boot/dtb-$version /boot/dtb-$version.old; fi" >> $pdir/DEBIAN/preinst
@@ -43,7 +56,7 @@ index 90c9a8a..3c79b90 100755
 +dtb_packagename=linux-dtb-"$BRANCH$LOCALVERSION"
 +libc_headers_packagename=linux-libc-dev-"$BRANCH$LOCALVERSION"
  dbg_packagename=$packagename-dbg
-
+ 
  if [ "$ARCH" = "um" ] ; then
 @@ -52,6 +75,15 @@ fi
  # XXX: have each arch Makefile export a variable of the canonical image install
@@ -63,7 +76,7 @@ index 90c9a8a..3c79b90 100755
  	;;
 @@ -65,7 +97,9 @@ esac
  BUILD_DEBUG="$(grep -s '^CONFIG_DEBUG_INFO=y' $KCONFIG_CONFIG || true)"
-
+ 
  # Setup the directory structure
 -rm -rf "$tmpdir" "$kernel_headers_dir" "$libc_headers_dir" "$dbg_dir" $objtree/debian/files
 +rm -rf "$tmpdir" "$kernel_headers_dir" "$libc_headers_dir" "$dbg_dir" "$dtb_dir" $objtree/debian/files
@@ -75,7 +88,7 @@ index 90c9a8a..3c79b90 100755
 @@ -118,6 +152,11 @@ if grep -q '^CONFIG_MODULES=y' $KCONFIG_CONFIG ; then
  	fi
  fi
-
+ 
 +if grep -q '^CONFIG_OF=y' $KCONFIG_CONFIG ; then
 +	#mkdir -p "$tmpdir/boot/dtb"
 +	INSTALL_DTBS_PATH="$dtb_dir/boot/dtb-$version" $MAKE KBUILD_SRC= dtbs_install
@@ -90,13 +103,13 @@ index 90c9a8a..3c79b90 100755
  	cat <<EOF > "$tmpdir/DEBIAN/$script"
 -#!/bin/sh
 +#!/bin/bash
-
+ 
  set -e
-
+ 
 @@ -153,9 +192,60 @@ EOF
  	chmod 755 "$tmpdir/DEBIAN/$script"
  done
-
+ 
 +##
 +## Create sym link to kernel image
 +##
@@ -164,7 +177,7 @@ index 90c9a8a..3c79b90 100755
  (cd $objtree; cp $KCONFIG_CONFIG $destdir/.config) # copy .config manually to be where it's expected to be
  ln -sf "/usr/src/linux-headers-$version" "$kernel_headers_dir/lib/modules/$version/build"
  rm -f "$objtree/debian/hdrsrcfiles" "$objtree/debian/hdrobjfiles"
-
+ 
 +(cd $destdir; make M=scripts clean)
 +
  if [ "$ARCH" != "um" ]; then
@@ -173,13 +186,13 @@ index 90c9a8a..3c79b90 100755
 +	# create_package "$libc_headers_packagename" "$libc_headers_dir"
 +	create_package "$dtb_packagename" "$dtb_dir"
  fi
-
+ 
  create_package "$packagename" "$tmpdir"
 diff --git a/scripts/package/mkdebian b/scripts/package/mkdebian
-index 6adb3a1..00e12eb 100755
+index edcad61fe..7a0ce28ca 100755
 --- a/scripts/package/mkdebian
 +++ b/scripts/package/mkdebian
-@@ -61,10 +61,12 @@ else
+@@ -94,10 +94,12 @@ else
  	packageversion=$version-$revision
  fi
  sourcename=$KDEB_SOURCENAME
@@ -192,9 +205,17 @@ index 6adb3a1..00e12eb 100755
  debarch=
 +image_name=
  set_debarch
-
+ 
  if [ "$ARCH" = "um" ] ; then
-@@ -168,6 +170,11 @@ Architecture: $debarch
+@@ -190,6 +192,7 @@ Package: linux-libc-dev
+ Section: devel
+ Provides: linux-kernel-headers
+ Architecture: $debarch
++Depends: make, flex, bison, libssl-dev
+ Description: Linux support headers for userspace development
+  This package provides userspaces headers from the Linux kernel.  These headers
+  are used by the installed headers for GNU glibc and other system libraries.
+@@ -200,6 +203,11 @@ Architecture: $debarch
  Description: Linux kernel debugging symbols for $version
   This package will come in handy if you need to debug the kernel. It provides
   all the necessary debug symbols for the kernel and its modules.
@@ -204,18 +225,5 @@ index 6adb3a1..00e12eb 100755
 +Description: Linux DTB, version $version
 + This package contains device blobs from the Linux kernel, version $version
  EOF
-
+ 
  cat <<EOF > debian/rules
-diff --git a/arch/arm64/Makefile b/arch/arm64/Makefile
-index f839ecd9..cd276162 100644
---- a/arch/arm64/Makefile
-+++ b/arch/arm64/Makefile
-@@ -103,7 +103,7 @@ core-$(CONFIG_EFI_STUB) += $(objtree)/drivers/firmware/efi/libstub/lib.a
-
- # Default target when executing plain make
- boot		:= arch/arm64/boot
--KBUILD_IMAGE	:= $(boot)/Image.gz
-+KBUILD_IMAGE	:= $(boot)/Image
- KBUILD_DTBS	:= dtbs
-
- all:	Image.gz $(KBUILD_DTBS)

--- a/patch/misc/general-packaging-4.4.y-rk3399.patch
+++ b/patch/misc/general-packaging-4.4.y-rk3399.patch
@@ -23,7 +23,7 @@ index 6c3b038..34c4006 100755
 +
 +	# Create postinstall script for headers
 +	if [[ "$1" == *headers* ]]; then
-+		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts >/dev/null 2>&1; make -s M=scripts/mod/ >/dev/null 2>&1" >> $pdir/DEBIAN/postinst
++		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts >/dev/null; make -s M=scripts/mod/ >/dev/null" >> $pdir/DEBIAN/postinst
 +		echo "exit 0" >> $pdir/DEBIAN/postinst
 +		chmod 775 $pdir/DEBIAN/postinst
 +	fi

--- a/patch/misc/general-packaging-4.4.y-rk3399.patch
+++ b/patch/misc/general-packaging-4.4.y-rk3399.patch
@@ -198,7 +198,7 @@ index 6c3b038e..f4166fbe 100755
 -Provides: linux-headers, linux-headers-2.6
 +Provides: linux-headers
  Architecture: any
-+Depends: make, flex, bison, libssl-dev
++Depends: make, gcc, libc6-dev, libssl-dev
  Description: Linux kernel headers for $KERNELRELEASE on \${kernel:debarch}
   This package provides kernel header files for $KERNELRELEASE on \${kernel:debarch}
   .

--- a/patch/misc/general-packaging-4.4.y-rk3399.patch
+++ b/patch/misc/general-packaging-4.4.y-rk3399.patch
@@ -1,5 +1,5 @@
 diff --git a/scripts/package/builddeb b/scripts/package/builddeb
-index 6c3b038..34c4006 100755
+index 6c3b038e..f4166fbe 100755
 --- a/scripts/package/builddeb
 +++ b/scripts/package/builddeb
 @@ -27,6 +27,28 @@ create_package() {
@@ -174,7 +174,7 @@ index 6c3b038..34c4006 100755
  # Try to determine maintainer and email values
  if [ -n "$DEBEMAIL" ]; then
         email=$DEBEMAIL
-@@ -328,16 +414,24 @@ fi
+@@ -328,17 +414,26 @@ fi
  (cd $objtree; find arch/$SRCARCH/include Module.symvers include scripts -type f) >> "$objtree/debian/hdrobjfiles"
  destdir=$kernel_headers_dir/usr/src/linux-headers-$version
  mkdir -p "$destdir"
@@ -198,9 +198,11 @@ index 6c3b038..34c4006 100755
 -Provides: linux-headers, linux-headers-2.6
 +Provides: linux-headers
  Architecture: any
++Depends: make, flex, bison, libssl-dev
  Description: Linux kernel headers for $KERNELRELEASE on \${kernel:debarch}
   This package provides kernel header files for $KERNELRELEASE on \${kernel:debarch}
-@@ -363,6 +457,16 @@ fi
+  .
+@@ -363,6 +458,16 @@ fi
  
  cat <<EOF >> debian/control
  
@@ -217,7 +219,7 @@ index 6c3b038..34c4006 100755
  Package: $libc_headers_packagename
  Section: devel
  Provides: linux-kernel-headers
-@@ -374,7 +478,7 @@ EOF
+@@ -374,7 +479,7 @@ EOF
  
  if [ "$ARCH" != "um" ]; then
  	create_package "$kernel_headers_packagename" "$kernel_headers_dir"

--- a/patch/misc/general-packaging-4.4.y.patch
+++ b/patch/misc/general-packaging-4.4.y.patch
@@ -23,7 +23,7 @@ index 6c3b038e..060ed240 100755
 +
 +	# Create postinstall script for headers
 +	if [[ "$1" == *headers* ]]; then
-+		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts >/dev/null 2>&1; make -s M=scripts/mod/ >/dev/null 2>&1" >> $pdir/DEBIAN/postinst
++		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts >/dev/null; make -s M=scripts/mod/ >/dev/null" >> $pdir/DEBIAN/postinst
 +		echo "exit 0" >> $pdir/DEBIAN/postinst
 +		chmod 775 $pdir/DEBIAN/postinst
 +	fi

--- a/patch/misc/general-packaging-4.4.y.patch
+++ b/patch/misc/general-packaging-4.4.y.patch
@@ -211,7 +211,7 @@ index 6c3b038e..977a0624 100755
  Section: devel
  Provides: linux-kernel-headers
  Architecture: any
-+Depends: make, flex, bison, libssl-dev
++Depends: make, gcc, libc6-dev, libssl-dev
  Description: Linux support headers for userspace development
   This package provides userspaces headers from the Linux kernel.  These headers
   are used by the installed headers for GNU glibc and other system libraries.

--- a/patch/misc/general-packaging-4.4.y.patch
+++ b/patch/misc/general-packaging-4.4.y.patch
@@ -1,5 +1,5 @@
 diff --git a/scripts/package/builddeb b/scripts/package/builddeb
-index 6c3b038e..060ed240 100755
+index 6c3b038e..977a0624 100755
 --- a/scripts/package/builddeb
 +++ b/scripts/package/builddeb
 @@ -27,6 +27,28 @@ create_package() {
@@ -31,7 +31,7 @@ index 6c3b038e..060ed240 100755
  	# Create the package
  	dpkg-gencontrol $forcearch -Vkernel:debarch="${debarch}" -p$pname -P"$pdir"
  	dpkg --build "$pdir" ..
-@@ -72,8 +72,11 @@ set_debarch() {
+@@ -50,8 +72,11 @@ set_debarch() {
  	mips*)
  		debarch=mips$(grep -q CPU_LITTLE_ENDIAN=y $KCONFIG_CONFIG && echo el || true) ;;
  	arm64)
@@ -44,7 +44,7 @@ index 6c3b038e..060ed240 100755
  		if grep -q CONFIG_AEABI=y $KCONFIG_CONFIG; then
  		    if grep -q CONFIG_VFP=y $KCONFIG_CONFIG; then
  			debarch=armhf
-@@ -93,11 +115,13 @@ tmpdir="$objtree/debian/tmp"
+@@ -93,11 +118,13 @@ tmpdir="$objtree/debian/tmp"
  fwdir="$objtree/debian/fwtmp"
  kernel_headers_dir="$objtree/debian/hdrtmp"
  libc_headers_dir="$objtree/debian/headertmp"
@@ -62,7 +62,7 @@ index 6c3b038e..060ed240 100755
  dbg_packagename=$packagename-dbg
  debarch=
  forcearch=
-@@ -124,7 +148,9 @@ esac
+@@ -124,7 +151,9 @@ esac
  BUILD_DEBUG="$(grep -s '^CONFIG_DEBUG_INFO=y' $KCONFIG_CONFIG || true)"
  
  # Setup the directory structure
@@ -73,7 +73,7 @@ index 6c3b038e..060ed240 100755
  mkdir -m 755 -p "$tmpdir/DEBIAN"
  mkdir -p "$tmpdir/lib" "$tmpdir/boot"
  mkdir -p "$fwdir/lib/firmware/$version/"
-@@ -183,6 +209,11 @@ if grep -q '^CONFIG_MODULES=y' $KCONFIG_CONFIG ; then
+@@ -183,6 +212,11 @@ if grep -q '^CONFIG_MODULES=y' $KCONFIG_CONFIG ; then
  	fi
  fi
  
@@ -85,7 +85,7 @@ index 6c3b038e..060ed240 100755
  if [ "$ARCH" != "um" ]; then
  	$MAKE headers_check KBUILD_SRC=
  	$MAKE headers_install KBUILD_SRC= INSTALL_HDR_PATH="$libc_headers_dir/usr"
-@@ -195,21 +226,23 @@ fi
+@@ -195,21 +229,23 @@ fi
  # so do we; recent versions of dracut and initramfs-tools will obey this.
  debhookdir=${KDEB_HOOKDIR:-/etc/kernel}
  if grep -q '^CONFIG_BLK_DEV_INITRD=y' $KCONFIG_CONFIG; then
@@ -111,7 +111,7 @@ index 6c3b038e..060ed240 100755
  export INITRD=$want_initrd
  
  test -d $debhookdir/$script.d && run-parts --arg="$version" --arg="/$installed_image_path" $debhookdir/$script.d
-@@ -218,6 +251,55 @@ EOF
+@@ -218,6 +254,55 @@ EOF
  	chmod 755 "$tmpdir/DEBIAN/$script"
  done
  
@@ -167,7 +167,7 @@ index 6c3b038e..060ed240 100755
  # Try to determine maintainer and email values
  if [ -n "$DEBEMAIL" ]; then
         email=$DEBEMAIL
-@@ -328,16 +410,24 @@ fi
+@@ -328,16 +413,24 @@ fi
  (cd $objtree; find arch/$SRCARCH/include Module.symvers include scripts -type f) >> "$objtree/debian/hdrobjfiles"
  destdir=$kernel_headers_dir/usr/src/linux-headers-$version
  mkdir -p "$destdir"
@@ -193,7 +193,7 @@ index 6c3b038e..060ed240 100755
  Architecture: any
  Description: Linux kernel headers for $KERNELRELEASE on \${kernel:debarch}
   This package provides kernel header files for $KERNELRELEASE on \${kernel:debarch}
-@@ -363,6 +453,16 @@ fi
+@@ -363,10 +456,21 @@ fi
  
  cat <<EOF >> debian/control
  
@@ -210,7 +210,12 @@ index 6c3b038e..060ed240 100755
  Package: $libc_headers_packagename
  Section: devel
  Provides: linux-kernel-headers
-@@ -374,7 +474,7 @@ EOF
+ Architecture: any
++Depends: make, flex, bison, libssl-dev
+ Description: Linux support headers for userspace development
+  This package provides userspaces headers from the Linux kernel.  These headers
+  are used by the installed headers for GNU glibc and other system libraries.
+@@ -374,7 +478,7 @@ EOF
  
  if [ "$ARCH" != "um" ]; then
  	create_package "$kernel_headers_packagename" "$kernel_headers_dir"

--- a/patch/misc/general-packaging-4.9.y.patch
+++ b/patch/misc/general-packaging-4.9.y.patch
@@ -23,7 +23,7 @@ index 0a2a7372..fa26c0c6 100755
 +
 +	# Create postinstall script for headers
 +	if [[ "$1" == *headers* ]]; then
-+		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts >/dev/null 2>&1; make -s M=scripts/mod/ >/dev/null 2>&1" >> $pdir/DEBIAN/postinst
++		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts >/dev/null; make -s M=scripts/mod/ >/dev/null" >> $pdir/DEBIAN/postinst
 +		echo "exit 0" >> $pdir/DEBIAN/postinst
 +		chmod 775 $pdir/DEBIAN/postinst
 +	fi

--- a/patch/misc/general-packaging-4.9.y.patch
+++ b/patch/misc/general-packaging-4.9.y.patch
@@ -1,5 +1,5 @@
 diff --git a/scripts/package/builddeb b/scripts/package/builddeb
-index 0a2a7372..fa26c0c6 100755
+index 0a2a7372..c709fc8b 100755
 --- a/scripts/package/builddeb
 +++ b/scripts/package/builddeb
 @@ -29,6 +29,28 @@ create_package() {
@@ -180,7 +180,7 @@ index 0a2a7372..fa26c0c6 100755
  Architecture: any
  Description: Linux kernel headers for $KERNELRELEASE on \${kernel:debarch}
   This package provides kernel header files for $KERNELRELEASE on \${kernel:debarch}
-@@ -372,6 +462,16 @@ fi
+@@ -372,10 +462,21 @@ fi
  
  cat <<EOF >> debian/control
  
@@ -197,7 +197,12 @@ index 0a2a7372..fa26c0c6 100755
  Package: $libc_headers_packagename
  Section: devel
  Provides: linux-kernel-headers
-@@ -383,7 +483,7 @@ EOF
+ Architecture: any
++Depends: make, flex, bison, libssl-dev
+ Description: Linux support headers for userspace development
+  This package provides userspaces headers from the Linux kernel.  These headers
+  are used by the installed headers for GNU glibc and other system libraries.
+@@ -383,7 +484,7 @@ EOF
  
  if [ "$ARCH" != "um" ]; then
  	create_package "$kernel_headers_packagename" "$kernel_headers_dir"

--- a/patch/misc/general-packaging-4.9.y.patch
+++ b/patch/misc/general-packaging-4.9.y.patch
@@ -1,5 +1,5 @@
 diff --git a/scripts/package/builddeb b/scripts/package/builddeb
-index 0a2a7372..c709fc8b 100755
+index 0a2a7372..87edac65 100755
 --- a/scripts/package/builddeb
 +++ b/scripts/package/builddeb
 @@ -29,6 +29,28 @@ create_package() {
@@ -154,7 +154,7 @@ index 0a2a7372..c709fc8b 100755
  # Try to determine maintainer and email values
  if [ -n "$DEBEMAIL" ]; then
         email=$DEBEMAIL
-@@ -337,16 +419,24 @@ if grep -q '^CONFIG_GCC_PLUGINS=y' $KCONFIG_CONFIG ; then
+@@ -337,17 +419,26 @@ if grep -q '^CONFIG_GCC_PLUGINS=y' $KCONFIG_CONFIG ; then
  fi
  destdir=$kernel_headers_dir/usr/src/linux-headers-$version
  mkdir -p "$destdir"
@@ -178,9 +178,11 @@ index 0a2a7372..c709fc8b 100755
 -Provides: linux-headers, linux-headers-2.6
 +Provides: linux-headers
  Architecture: any
++Depends: make, gcc, libc6-dev, libssl-dev
  Description: Linux kernel headers for $KERNELRELEASE on \${kernel:debarch}
   This package provides kernel header files for $KERNELRELEASE on \${kernel:debarch}
-@@ -372,10 +462,21 @@ fi
+  .
+@@ -372,6 +463,16 @@ fi
  
  cat <<EOF >> debian/control
  
@@ -197,11 +199,6 @@ index 0a2a7372..c709fc8b 100755
  Package: $libc_headers_packagename
  Section: devel
  Provides: linux-kernel-headers
- Architecture: any
-+Depends: make, flex, bison, libssl-dev
- Description: Linux support headers for userspace development
-  This package provides userspaces headers from the Linux kernel.  These headers
-  are used by the installed headers for GNU glibc and other system libraries.
 @@ -383,7 +484,7 @@ EOF
  
  if [ "$ARCH" != "um" ]; then

--- a/patch/misc/general-packaging-5.3.y.patch
+++ b/patch/misc/general-packaging-5.3.y.patch
@@ -211,7 +211,7 @@ index e0750b704..ac1409748 100755
  
  Package: $kernel_headers_packagename
  Architecture: $debarch
-+Depends: make, bison, flex, libssl-dev
++Depends: make, gcc, libc6-dev, bison, flex, libssl-dev
  Description: Linux kernel headers for $version on $debarch
   This package provides kernel header files for $version on $debarch
   .

--- a/patch/misc/general-packaging-5.3.y.patch
+++ b/patch/misc/general-packaging-5.3.y.patch
@@ -1,8 +1,8 @@
 diff --git a/arch/arm64/Makefile b/arch/arm64/Makefile
-index 2c0238ce0..1b55633a9 100644
+index 5858d6e44..e81b8a6fc 100644
 --- a/arch/arm64/Makefile
 +++ b/arch/arm64/Makefile
-@@ -125,7 +125,7 @@ core-$(CONFIG_EFI_STUB) += $(objtree)/drivers/firmware/efi/libstub/lib.a
+@@ -142,7 +142,7 @@ core-$(CONFIG_EFI_STUB) += $(objtree)/drivers/firmware/efi/libstub/lib.a
  
  # Default target when executing plain make
  boot		:= arch/arm64/boot
@@ -12,6 +12,7 @@ index 2c0238ce0..1b55633a9 100644
  all:	Image.gz
  
 diff --git a/scripts/package/builddeb b/scripts/package/builddeb
+index c4c580f54..58243c628 100755
 --- a/scripts/package/builddeb
 +++ b/scripts/package/builddeb
 @@ -41,6 +41,27 @@ create_package() {
@@ -188,6 +189,7 @@ diff --git a/scripts/package/builddeb b/scripts/package/builddeb
  
  create_package "$packagename" "$tmpdir"
 diff --git a/scripts/package/mkdebian b/scripts/package/mkdebian
+index e0750b704..ac1409748 100755
 --- a/scripts/package/mkdebian
 +++ b/scripts/package/mkdebian
 @@ -94,10 +94,12 @@ else
@@ -205,7 +207,15 @@ diff --git a/scripts/package/mkdebian b/scripts/package/mkdebian
  set_debarch
  
  if [ "$ARCH" = "um" ] ; then
-@@ -205,6 +207,11 @@ Architecture: $debarch
+@@ -185,6 +187,7 @@ Description: Linux kernel, version $version
+ 
+ Package: $kernel_headers_packagename
+ Architecture: $debarch
++Depends: make, bison, flex, libssl-dev
+ Description: Linux kernel headers for $version on $debarch
+  This package provides kernel header files for $version on $debarch
+  .
+@@ -205,6 +208,11 @@ Architecture: $debarch
  Description: Linux kernel debugging symbols for $version
   This package will come in handy if you need to debug the kernel. It provides
   all the necessary debug symbols for the kernel and its modules.

--- a/patch/misc/general-packaging-5.3.y.patch
+++ b/patch/misc/general-packaging-5.3.y.patch
@@ -12,7 +12,6 @@ index 2c0238ce0..1b55633a9 100644
  all:	Image.gz
  
 diff --git a/scripts/package/builddeb b/scripts/package/builddeb
-index c4c580f54..351a33958 100755
 --- a/scripts/package/builddeb
 +++ b/scripts/package/builddeb
 @@ -41,6 +41,27 @@ create_package() {
@@ -35,7 +34,7 @@ index c4c580f54..351a33958 100755
 +
 +	# Create postinstall script for headers
 +	if [ "$3" = "headers" ]; then
-+		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts >/dev/null 2>&1; make -s M=scripts/mod/ >/dev/null 2>&1" >> $pdir/DEBIAN/postinst
++		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts >/dev/null; make -s M=scripts/mod/ >/dev/null" >> $pdir/DEBIAN/postinst
 +		echo "exit 0" >> $pdir/DEBIAN/postinst
 +		chmod 775 $pdir/DEBIAN/postinst
 +	fi
@@ -189,7 +188,6 @@ index c4c580f54..351a33958 100755
  
  create_package "$packagename" "$tmpdir"
 diff --git a/scripts/package/mkdebian b/scripts/package/mkdebian
-index e0750b704..6ac0114c0 100755
 --- a/scripts/package/mkdebian
 +++ b/scripts/package/mkdebian
 @@ -94,10 +94,12 @@ else


### PR DESCRIPTION
The issue that is going to be fixed in this PR has already been discussed in the forum: https://forum.armbian.com/topic/10344-postinst-of-dkms-package-is-broken-on-armbian

Summary: DKMS does not work in Armbian due to two reasons:

1. Environment variable `ARCH` is exported and interferes with the build of kernel modules within DKMS
2. The postinst-script of the kernel-headers faild due to missing packages like make, gcc, etc. Those are not automatically installed as the kernel-headers don't have any dependencies to them.

The proposed solution does the following:

1.  _/etc/environment_ has been modified: The export of the variable `ARCH` has been removed.
2. The dependencies required to run the postinst-script have been added to the kernel headers. This has been done in the general kernel patches located in _/patches/misc_ by modifying the scripts `builddeb` and `mkdebian` (depending on kernel version).
3. In addition to that those kernel patches have also been modified to output stderr to the console in the postinst-script of the kernel-headers. This was required for debugging and seems to be valuable for the future as well.

Concerning testing: I was able to successfully generate Armbian images for all kernel versions (4.4, 4.4-rk3399, 4.9, 4.14, 4.19, **5.4**). I installed images for kernel 4.4-rk3399 and 5.4 on a NanoPi M4V2. For both kernels I was able to install DKMS-packages (see thread in forums for details).

So I assume the problems around DKMS have been fixed in Armbian. My main concern is now that the changes have unexpected sideeffects.