### PR TITLE
remove rootfs debs depends on python-apt

### DIFF
--- a/lib/makeboarddeb.sh
+++ b/lib/makeboarddeb.sh
@@ -49,7 +49,7 @@ create_board_package()
 	Installed-Size: 1
 	Section: kernel
 	Priority: optional
-	Depends: bash, linux-base, u-boot-tools, initramfs-tools, python-apt, lsb-release
+	Depends: bash, linux-base, u-boot-tools, initramfs-tools, lsb-release
 	Provides: armbian-bsp
 	Conflicts: armbian-bsp
 	Suggests: armbian-config


### PR DESCRIPTION
Signed-off-by: Zhang Ning <832666+zhangn1985@users.noreply.github.com>


due to prebuild rootfs do not have `python-apt` installed, so it will failed to install rootfs deb when build cli image.

just remove python-apt from depends list.

```
 linux-buster-root-dev-kedge-v depends on python-apt; however:
  Package python-apt is not installed.

```
