### PR TITLE
Script does not properly stop on network issue

### DIFF
--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -147,8 +147,11 @@ ParseOptions() {
 			;;
 		u)
 			# Upload /var/log/armbian-hardware-monitor.log with additional support info
-			fping ix.io 2>/dev/null | grep -q alive || \
-				(echo -e "\nNetwork/firewall problem detected. Not able to upload debug info.\nPlease fix this or use \"-U\" instead and upload ${BOLD}whole output${NC} manually\n" >&2 ; exit 1)
+			fping ix.io 2>/dev/null | grep -q alive
+			if [ $? != 0 ]; then
+				echo -e "\nNetwork/firewall problem detected. Not able to upload debug info.\nPlease fix this or use \"-U\" instead and upload ${BOLD}whole output${NC} manually\n" >&2
+				exit 1
+			fi
 			which curl >/dev/null 2>&1 || apt-get -f -qq -y install curl
 			echo -e "System diagnosis information will now be uploaded to \c"
 			# we obfuscate IPv4 addresses somehow but not too much, MAC addresses have to remain


### PR DESCRIPTION
Fixes https://forum.armbian.com/topic/12579-opi-stuck-after-restart-cant-connect-to-network/?do=findComment&comment=92034

For some reason the sript does not properly exit on network issues like it should. TBH I cannot find a reason for that behavior, though this way it works as it is intended.