### PR TITLE
Fix RTC initialize patch for mvebu current

### DIFF
--- a/patch/kernel/mvebu-current/421-rtc-initialize.patch
+++ b/patch/kernel/mvebu-current/421-rtc-initialize.patch
@@ -55,12 +55,11 @@ bootloader hacks that write special register values.
  };
  
  static const struct armada38x_rtc_data armada8k_data = {
-@@ -558,6 +580,17 @@ static __init int armada38x_rtc_probe(st
+@@ -603,6 +603,16 @@ static __init int armada38x_rtc_probe(struct platform_device *pdev)
+ 	if (ret)
  		dev_err(&pdev->dev, "Failed to register RTC device: %d\n", ret);
- 		return ret;
- 	}
-+
-+	/*
+ 
++    /*
 +	 * Try to detect if RTC is in uninitialized state.
 +	 * It is not definitive to know if the RTC is in an uninialized state or not,
 +	 * but the following call will read some bits in the RTC unit and guess if
@@ -70,6 +69,6 @@ bootloader hacks that write special register values.
 +		rtc->data->init_rtc(rtc);
 +	}
 +
- 	return 0;
+ 	return ret;
  }
  

--- a/patch/kernel/mvebu-legacy/421-rtc-initialize.patch
+++ b/patch/kernel/mvebu-legacy/421-rtc-initialize.patch
@@ -54,12 +54,11 @@ bootloader hacks that write special register values.
  };
  
  static const struct armada38x_rtc_data armada8k_data = {
-@@ -558,6 +580,17 @@ static __init int armada38x_rtc_probe(st
+@@ -603,6 +603,16 @@ static __init int armada38x_rtc_probe(struct platform_device *pdev)
+ 	if (ret)
  		dev_err(&pdev->dev, "Failed to register RTC device: %d\n", ret);
- 		return ret;
- 	}
-+
-+	/*
+ 
++    /*
 +	 * Try to detect if RTC is in uninitialized state.
 +	 * It is not definitive to know if the RTC is in an uninialized state or not,
 +	 * but the following call will read some bits in the RTC unit and guess if
@@ -69,6 +68,6 @@ bootloader hacks that write special register values.
 +		rtc->data->init_rtc(rtc);
 +	}
 +
- 	return 0;
+ 	return ret;
  }
  


### PR DESCRIPTION
Hi,

the old rtc-initialize patch for mvebu-current was not applying correctly anymore, because the patched function has been changed upstream. I corrected the patch (only minor change).

Please check and merge if ok for helios4. Tested on clearfogpro.
