### PR TITLE
modified anx6345 patch to log errno from read edid from device tree

### DIFF
--- a/patch/kernel/sunxi-current/0130-drm-bridge-Add-Analogix-anx6345-support.patch
+++ b/patch/kernel/sunxi-current/0130-drm-bridge-Add-Analogix-anx6345-support.patch
@@ -604,7 +604,7 @@ index 000000000000..81676407aa6d
 +	if (!anx6345->edid) {
 +		err = anx6345_probe_edid_from_of(anx6345);
 +		if (err) {
-+			DRM_ERROR("Failed to probe EDID from device tree\n");
++			DRM_ERROR("Failed to probe EDID from device tree: %d\n", err);
 +			goto unlock;
 +		}
 +	}

--- a/patch/kernel/sunxi-dev/0130-drm-bridge-Add-Analogix-anx6345-support.patch-disabled
+++ b/patch/kernel/sunxi-dev/0130-drm-bridge-Add-Analogix-anx6345-support.patch-disabled
@@ -604,7 +604,7 @@ index 000000000000..81676407aa6d
 +	if (!anx6345->edid) {
 +		err = anx6345_probe_edid_from_of(anx6345);
 +		if (err) {
-+			DRM_ERROR("Failed to probe EDID from device tree\n");
++			DRM_ERROR("Failed to probe EDID from device tree: &d\n", err);
 +			goto unlock;
 +		}
 +	}

--- a/patch/kernel/sunxi-legacy/0130-drm-bridge-Add-Analogix-anx6345-support.patch
+++ b/patch/kernel/sunxi-legacy/0130-drm-bridge-Add-Analogix-anx6345-support.patch
@@ -603,7 +603,7 @@ index 000000000000..81676407aa6d
 +	if (!anx6345->edid) {
 +		err = anx6345_probe_edid_from_of(anx6345);
 +		if (err) {
-+			DRM_ERROR("Failed to probe EDID from device tree\n");
++			DRM_ERROR("Failed to probe EDID from device tree: %d\n", err);
 +			goto unlock;
 +		}
 +	}


### PR DESCRIPTION
modified the existing sunxi-current and sunxi-legacy anx6345 patch to log the errno returned from a failure to read EDID from the device tree