### PR TITLE
Temporary workaround for ethernet in rockchip64-current

### DIFF
--- a/patch/kernel/rockchip64-current/general-temporary-ethernet-fixup.patch
+++ b/patch/kernel/rockchip64-current/general-temporary-ethernet-fixup.patch
@@ -1,0 +1,23 @@
+This is a temporary fix for ethernet with kernels 5.4.7+
+
+It reverts the following change: https://patchwork.ozlabs.org/patch/1213121/
+which disabled mdio init for most of the boards except NanoPi M4(V2)
+or NanoPC T4 which have proper device tree definition for mdio/phy.
+
+The proper fix will be to add phy device tree node for boards that miss
+it.
+
+---
+diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
+index 170c3a052b14..1f230bd854c4 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
++++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
+@@ -320,7 +320,7 @@ out:
+ static int stmmac_dt_phy(struct plat_stmmacenet_data *plat,
+ 			 struct device_node *np, struct device *dev)
+ {
+-	bool mdio = false;
++	bool mdio = true;
+ 	static const struct of_device_id need_mdio_ids[] = {
+ 		{ .compatible = "snps,dwc-qos-ethernet-4.10" },
+ 		{},


### PR DESCRIPTION
With the introduction of the following [commit](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=v5.4.7&id=bfdbfd28f76028b960458d107dc4ae9240c928b3) in kernel 5.4.7 most of the rockchip64 boards lost their ethernet interfaces (except from FriendlyARM's which have proper mdio nodes defined in their device trees).

Symptoms are described here: https://forum.armbian.com/topic/12573-armbian-buster-current-with-linux-54y-on-the-rock-pi-4/?do=findComment&comment=92245

The fix is temporary as the proper one would and probably will be to add missing mdio/phy nodes to `&gmac` nodes per board.
This is however enough to keep ethernet working for now.