### PR TITLE
fix gpu power on firefly rk3399

### DIFF
--- a/patch/kernel/rockchip64-current/board-firefly-rk3399-fix-gpu-power.patch
+++ b/patch/kernel/rockchip64-current/board-firefly-rk3399-fix-gpu-power.patch
@@ -1,0 +1,25 @@
+From 2345073b11f6bfa5faa2e514b9d4ca03157e5149 Mon Sep 17 00:00:00 2001
+From: Michal Lazo <michal.lazo@memsource.com>
+Date: Mon, 6 Jan 2020 14:52:00 -0800
+Subject: [PATCH 1/1] mali power fix
+
+---
+ arch/arm64/boot/dts/rockchip/rk3399-firefly.dts | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts b/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts
+index c706db0ee..0fd8ef955 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts
+@@ -803,3 +803,8 @@
+ &vopl_mmu {
+ 	status = "okay";
+ };
++
++&gpu {
++	mali-supply = <&vdd_gpu>;
++	status = "okay";
++};
+-- 
+2.17.1
+

--- a/patch/kernel/rockchip64-dev/board-firefly-rk3399-fix-gpu-power.patch
+++ b/patch/kernel/rockchip64-dev/board-firefly-rk3399-fix-gpu-power.patch
@@ -1,0 +1,25 @@
+From 2345073b11f6bfa5faa2e514b9d4ca03157e5149 Mon Sep 17 00:00:00 2001
+From: Michal Lazo <michal.lazo@memsource.com>
+Date: Mon, 6 Jan 2020 14:52:00 -0800
+Subject: [PATCH 1/1] mali power fix
+
+---
+ arch/arm64/boot/dts/rockchip/rk3399-firefly.dts | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts b/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts
+index c706db0ee..0fd8ef955 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts
+@@ -803,3 +803,8 @@
+ &vopl_mmu {
+ 	status = "okay";
+ };
++
++&gpu {
++	mali-supply = <&vdd_gpu>;
++	status = "okay";
++};
+-- 
+2.17.1
+


### PR DESCRIPTION
Add missing gpu power on firefly rk3399 boards
mali or panfronst kernel modules don't work without this
