### PR TITLE
Adjusted txpbl for rk3399 to fix network issues with MTU 1500

### DIFF
--- a/patch/kernel/rockchip64-current/rk3399-adjust-txpbl-for-mtu-1500.patch
+++ b/patch/kernel/rockchip64-current/rk3399-adjust-txpbl-for-mtu-1500.patch
@@ -1,0 +1,19 @@
+Default Programmable Buffer Length for TX in rk3399's gmac is not suitable
+for MTUs higher than 1498. The easiest solution would be to disable
+TX offloading but it is not ideal as it disables hardware checksumming.
+
+This patch sets txpbl to 0x4 which is good for the most popular MTU
+value of 1500.
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399.dtsi b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
+index cede1ad81..02674bbf0 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
+@@ -288,6 +288,7 @@
+ 		resets = <&cru SRST_A_GMAC>;
+ 		reset-names = "stmmaceth";
+ 		rockchip,grf = <&grf>;
++		snps,txpbl = <0x4>;
+ 		status = "disabled";
+ 	};
+ 

--- a/patch/kernel/rockchip64-dev/rk3399-adjust-txpbl-for-mtu-1500.patch
+++ b/patch/kernel/rockchip64-dev/rk3399-adjust-txpbl-for-mtu-1500.patch
@@ -1,0 +1,19 @@
+Default Programmable Buffer Length for TX in rk3399's gmac is not suitable
+for MTUs higher than 1498. The easiest solution would be to disable
+TX offloading but it is not ideal as it disables hardware checksumming.
+
+This patch sets txpbl to 0x4 which is good for the most popular MTU
+value of 1500.
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399.dtsi b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
+index cede1ad81..02674bbf0 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
+@@ -288,6 +288,7 @@
+ 		resets = <&cru SRST_A_GMAC>;
+ 		reset-names = "stmmaceth";
+ 		rockchip,grf = <&grf>;
++		snps,txpbl = <0x4>;
+ 		status = "disabled";
+ 	};
+ 


### PR DESCRIPTION
Default Programmable Buffer Length for TX in rk3399's gmac is not suitable for MTUs higher than 1498. The easiest solution would be to disable TX offloading with `ethtool -K eth0 tx off rx off` but it is not ideal as it disables hardware checksumming.

This patch sets txpbl to 0x4 which is good for the most popular MTU value of 1500.
It is inspired by [this thread on Armbian forum](https://forum.armbian.com/topic/12622-solved-downloading-files-from-samba-shares-on-nanopi-m4v2-stalls/?tab=comments#comment-92772) and based on the discussion [from this thread on LKML](https://lkml.org/lkml/2019/4/5/148).

The value was tested empirically with NanoPi M4V2 by trying to download a large file from SMB share configured on affected rk3399 host. With txpbl = 0x4 it still works, with 0x8 it stalls after ~1GiB.

Below is the log from iperf3 transmitting from affected host after applying the patch.

```
Connecting to host 192.168.2.2, port 5001
[  5] local 192.168.2.16 port 36312 connected to 192.168.2.2 port 5001
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-5.00   sec   563 MBytes   944 Mbits/sec    0    440 KBytes
[  5]   5.00-10.00  sec   561 MBytes   941 Mbits/sec    0    440 KBytes
[  5]  10.00-15.00  sec   561 MBytes   942 Mbits/sec    0    440 KBytes
[  5]  15.00-20.00  sec   562 MBytes   944 Mbits/sec    0    646 KBytes
[  5]  20.00-25.00  sec   561 MBytes   942 Mbits/sec    0    646 KBytes
[  5]  25.00-30.00  sec   561 MBytes   942 Mbits/sec    0    646 KBytes
[  5]  30.00-35.00  sec   561 MBytes   942 Mbits/sec    0    646 KBytes
[  5]  35.00-40.00  sec   561 MBytes   942 Mbits/sec    0    646 KBytes
[  5]  40.00-45.00  sec   561 MBytes   942 Mbits/sec    0    646 KBytes
[  5]  45.00-50.00  sec   561 MBytes   942 Mbits/sec    0    646 KBytes
[  5]  50.00-55.00  sec   561 MBytes   942 Mbits/sec    0    646 KBytes
[  5]  55.00-60.00  sec   561 MBytes   942 Mbits/sec    0    646 KBytes
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-60.00  sec  6.58 GBytes   942 Mbits/sec    0             sender
[  5]   0.00-60.00  sec  6.58 GBytes   942 Mbits/sec                  receiver
```
