### PR TITLE
fallback to a working nameserver if dns does not work in the chroot env

### DIFF
--- a/lib/chroot-buildpackages.sh
+++ b/lib/chroot-buildpackages.sh
@@ -330,8 +330,19 @@ chroot_installpackages()
 		unset package_install_target package_checkinstall
 	done
 	[[ $NO_APT_CACHER != yes ]] && local apt_extra="-o Acquire::http::Proxy=\"http://${APT_PROXY_ADDR:-localhost:3142}\" -o Acquire::http::Proxy::localhost=\"DIRECT\""
+	# add the local resolver config as a potential fallback
+	cp /etc/resolv.conf "${SDCARD}"/tmp
 	cat <<-EOF > "${SDCARD}"/tmp/install.sh
 	#!/bin/bash
+	# check dns connectiivity (1.0.0.1 might not be available)
+	cd /tmp
+	wget http://apt.armbian.com
+	if [ -f index.html ]; then
+		rm /tmp/index.html
+	else
+		# fallback to your working dns config
+		mv /tmp/resolv.conf /etc
+	fi
 	[[ "$remote_only" != yes ]] && apt-key add /tmp/buildpkg.key
 	apt $apt_extra -q update
 	# uncomment to debug


### PR DESCRIPTION
i was running a build in a corporate intranet and found out that a nameserver 1.0.0.1 does not work here. So when
chroot "${SDCARD}" /bin/bash -c "/tmp/install.sh"
was run, all the apt-commands in the install.sh script ended in a timout. So i try to resolve apt.armbian.com first and if that fails, use the resolv.conf from the build environment.