### PR TITLE
overlay for pinebook's boe hb140wx-501 lcd panel

### DIFF
--- a/patch/kernel/sunxi-current/x-board-pinebook-boe-hb140wx-501-overlay.patch
+++ b/patch/kernel/sunxi-current/x-board-pinebook-boe-hb140wx-501-overlay.patch
@@ -1,0 +1,111 @@
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/Makefile b/arch/arm64/boot/dts/allwinner/overlay/Makefile
+index fbd2daaa4..7f55788e8 100644
+--- a/arch/arm64/boot/dts/allwinner/overlay/Makefile
++++ b/arch/arm64/boot/dts/allwinner/overlay/Makefile
+@@ -1,5 +1,6 @@
+ # SPDX-License-Identifier: GPL-2.0
+ dtbo-$(CONFIG_ARCH_SUNXI) += \
++	sun50i-a64-boe-hb140wx1-501.dtbo \
+ 	sun50i-a64-i2c0.dtbo \
+ 	sun50i-a64-i2c1.dtbo \
+ 	sun50i-a64-pps-gpio.dtbo \
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/README.sun50i-a64-overlays b/arch/arm64/boot/dts/allwinner/overlay/README.sun50i-a64-overlays
+index cd9dbc686..672ebd5bd 100644
+--- a/arch/arm64/boot/dts/allwinner/overlay/README.sun50i-a64-overlays
++++ b/arch/arm64/boot/dts/allwinner/overlay/README.sun50i-a64-overlays
+@@ -18,6 +18,7 @@ on supported boards, so this controller is not supported in provided overlays
+ 
+ ### Provided overlays:
+ 
++- boe-hb140wx1-501
+ - i2c0
+ - i2c1
+ - pps-gpio
+@@ -32,6 +33,10 @@ on supported boards, so this controller is not supported in provided overlays
+ 
+ ### Overlay details:
+ 
++### boe-hb140wx1-501
++
++Provides EDID for BOE HB140WX1-501 LCD panel for early 14" pinebook models.
++
+ ### i2c0
+ 
+ Activates TWI/I2C bus 0
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-boe-hb140wx1-501.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-boe-hb140wx1-501.dts
+new file mode 100644
+index 000000000..217a1290d
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-boe-hb140wx1-501.dts
+@@ -0,0 +1,71 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++    fragment {
++        target = <&anx6345>;
++        __overlay__ {
++            edid = [
++                /* Header */
++                00 ff ff ff ff ff ff 00
++                /* ID Manufacturer Name */
++                09 e5
++                /* ID Product Code */
++                37 00
++                /* 32-bit serial No. */
++                00 00 00 00
++                /* Week of manufacture */
++                01
++                /* Year of manufacture */
++                16
++                /* EDID Structure Ver. */
++                01
++                /* EDID revision # */
++                04
++                /* Video input definition */
++                80
++                /* Max H image size */
++                1f
++                /* Max V image size */
++                11
++                /* Display Gamma */
++                78
++                /* Feature support */
++                0a
++                /* Color bits */
++                b0 90 97 58 54 92 26 1d 50 54
++                /* Established timings */
++                00 00 00
++                /* Standard timings */
++                01 01
++                01 01
++                01 01
++                01 01
++                01 01
++                01 01
++                01 01
++                01 01
++                /* Detailed timing/monitor descriptor #1 */
++                3e 1c 56 a0 50 00 16 30
++                30 20 36 00 35 ad 10 00
++                00 1a
++                /* Detailed timing/monitor descriptor #2 */
++                3e 1c 56 a0 50 00 16 30
++                30 20 36 00 35 ad 10 00
++                00 1a
++                /* Detailed timing/monitor descriptor #3 */
++                00 00 00 fe 00 42 4f 45
++                20 48 46 0a 20 20 20 20
++                20 20
++                /* Detailed timing/monitor descriptor #4 */
++                00 00 00 fe 00 48 42 31
++                34 30 57 58 31 2d 35 30
++                31 0a
++                /* Extension flag */
++                00
++                /* Checksum */
++                81
++            ];
++        };
++    };
++};

--- a/patch/kernel/sunxi-dev/board-pinebook-boe-hb140wx-501-overlay.patch
+++ b/patch/kernel/sunxi-dev/board-pinebook-boe-hb140wx-501-overlay.patch
@@ -1,0 +1,111 @@
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/Makefile b/arch/arm64/boot/dts/allwinner/overlay/Makefile
+index fbd2daaa4..7f55788e8 100644
+--- a/arch/arm64/boot/dts/allwinner/overlay/Makefile
++++ b/arch/arm64/boot/dts/allwinner/overlay/Makefile
+@@ -1,5 +1,6 @@
+ # SPDX-License-Identifier: GPL-2.0
+ dtbo-$(CONFIG_ARCH_SUNXI) += \
++	sun50i-a64-boe-hb140wx1-501.dtbo \
+ 	sun50i-a64-i2c0.dtbo \
+ 	sun50i-a64-i2c1.dtbo \
+ 	sun50i-a64-pps-gpio.dtbo \
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/README.sun50i-a64-overlays b/arch/arm64/boot/dts/allwinner/overlay/README.sun50i-a64-overlays
+index cd9dbc686..672ebd5bd 100644
+--- a/arch/arm64/boot/dts/allwinner/overlay/README.sun50i-a64-overlays
++++ b/arch/arm64/boot/dts/allwinner/overlay/README.sun50i-a64-overlays
+@@ -18,6 +18,7 @@ on supported boards, so this controller is not supported in provided overlays
+ 
+ ### Provided overlays:
+ 
++- boe-hb140wx1-501
+ - i2c0
+ - i2c1
+ - pps-gpio
+@@ -32,6 +33,10 @@ on supported boards, so this controller is not supported in provided overlays
+ 
+ ### Overlay details:
+ 
++### boe-hb140wx1-501
++
++Provides EDID for BOE HB140WX1-501 LCD panel for early 14" pinebook models.
++
+ ### i2c0
+ 
+ Activates TWI/I2C bus 0
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-boe-hb140wx1-501.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-boe-hb140wx1-501.dts
+new file mode 100644
+index 000000000..217a1290d
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-boe-hb140wx1-501.dts
+@@ -0,0 +1,71 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++    fragment {
++        target = <&anx6345>;
++        __overlay__ {
++            edid = [
++                /* Header */
++                00 ff ff ff ff ff ff 00
++                /* ID Manufacturer Name */
++                09 e5
++                /* ID Product Code */
++                37 00
++                /* 32-bit serial No. */
++                00 00 00 00
++                /* Week of manufacture */
++                01
++                /* Year of manufacture */
++                16
++                /* EDID Structure Ver. */
++                01
++                /* EDID revision # */
++                04
++                /* Video input definition */
++                80
++                /* Max H image size */
++                1f
++                /* Max V image size */
++                11
++                /* Display Gamma */
++                78
++                /* Feature support */
++                0a
++                /* Color bits */
++                b0 90 97 58 54 92 26 1d 50 54
++                /* Established timings */
++                00 00 00
++                /* Standard timings */
++                01 01
++                01 01
++                01 01
++                01 01
++                01 01
++                01 01
++                01 01
++                01 01
++                /* Detailed timing/monitor descriptor #1 */
++                3e 1c 56 a0 50 00 16 30
++                30 20 36 00 35 ad 10 00
++                00 1a
++                /* Detailed timing/monitor descriptor #2 */
++                3e 1c 56 a0 50 00 16 30
++                30 20 36 00 35 ad 10 00
++                00 1a
++                /* Detailed timing/monitor descriptor #3 */
++                00 00 00 fe 00 42 4f 45
++                20 48 46 0a 20 20 20 20
++                20 20
++                /* Detailed timing/monitor descriptor #4 */
++                00 00 00 fe 00 48 42 31
++                34 30 57 58 31 2d 35 30
++                31 0a
++                /* Extension flag */
++                00
++                /* Checksum */
++                81
++            ];
++        };
++    };
++};

--- a/patch/kernel/sunxi-legacy/board-pinebook-boe-hb140wx-501-overlay.patch-disabled
+++ b/patch/kernel/sunxi-legacy/board-pinebook-boe-hb140wx-501-overlay.patch-disabled
@@ -1,0 +1,111 @@
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/Makefile b/arch/arm64/boot/dts/allwinner/overlay/Makefile
+index fbd2daaa4..7f55788e8 100644
+--- a/arch/arm64/boot/dts/allwinner/overlay/Makefile
++++ b/arch/arm64/boot/dts/allwinner/overlay/Makefile
+@@ -1,5 +1,6 @@
+ # SPDX-License-Identifier: GPL-2.0
+ dtbo-$(CONFIG_ARCH_SUNXI) += \
++	sun50i-a64-boe-hb140wx1-501.dtbo \
+ 	sun50i-a64-i2c0.dtbo \
+ 	sun50i-a64-i2c1.dtbo \
+ 	sun50i-a64-pps-gpio.dtbo \
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/README.sun50i-a64-overlays b/arch/arm64/boot/dts/allwinner/overlay/README.sun50i-a64-overlays
+index cd9dbc686..672ebd5bd 100644
+--- a/arch/arm64/boot/dts/allwinner/overlay/README.sun50i-a64-overlays
++++ b/arch/arm64/boot/dts/allwinner/overlay/README.sun50i-a64-overlays
+@@ -18,6 +18,7 @@ on supported boards, so this controller is not supported in provided overlays
+ 
+ ### Provided overlays:
+ 
++- boe-hb140wx1-501
+ - i2c0
+ - i2c1
+ - pps-gpio
+@@ -32,6 +33,10 @@ on supported boards, so this controller is not supported in provided overlays
+ 
+ ### Overlay details:
+ 
++### boe-hb140wx1-501
++
++Provides EDID for BOE HB140WX1-501 LCD panel for early 14" pinebook models.
++
+ ### i2c0
+ 
+ Activates TWI/I2C bus 0
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-boe-hb140wx1-501.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-boe-hb140wx1-501.dts
+new file mode 100644
+index 000000000..217a1290d
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-boe-hb140wx1-501.dts
+@@ -0,0 +1,71 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++    fragment {
++        target = <&anx6345>;
++        __overlay__ {
++            edid = [
++                /* Header */
++                00 ff ff ff ff ff ff 00
++                /* ID Manufacturer Name */
++                09 e5
++                /* ID Product Code */
++                37 00
++                /* 32-bit serial No. */
++                00 00 00 00
++                /* Week of manufacture */
++                01
++                /* Year of manufacture */
++                16
++                /* EDID Structure Ver. */
++                01
++                /* EDID revision # */
++                04
++                /* Video input definition */
++                80
++                /* Max H image size */
++                1f
++                /* Max V image size */
++                11
++                /* Display Gamma */
++                78
++                /* Feature support */
++                0a
++                /* Color bits */
++                b0 90 97 58 54 92 26 1d 50 54
++                /* Established timings */
++                00 00 00
++                /* Standard timings */
++                01 01
++                01 01
++                01 01
++                01 01
++                01 01
++                01 01
++                01 01
++                01 01
++                /* Detailed timing/monitor descriptor #1 */
++                3e 1c 56 a0 50 00 16 30
++                30 20 36 00 35 ad 10 00
++                00 1a
++                /* Detailed timing/monitor descriptor #2 */
++                3e 1c 56 a0 50 00 16 30
++                30 20 36 00 35 ad 10 00
++                00 1a
++                /* Detailed timing/monitor descriptor #3 */
++                00 00 00 fe 00 42 4f 45
++                20 48 46 0a 20 20 20 20
++                20 20
++                /* Detailed timing/monitor descriptor #4 */
++                00 00 00 fe 00 48 42 31
++                34 30 57 58 31 2d 35 30
++                31 0a
++                /* Extension flag */
++                00
++                /* Checksum */
++                81
++            ];
++        };
++    };
++};


### PR DESCRIPTION
Patch adds a boe-hb140wx-501 overlay for the sunxi-a64 pinebook.

The early 14" pinebook models shipped with a BOE HB140WX-501 LCD panel with no EDID support.

This overlay adds the `edid` property to the `anx6345` drm bridge to specify an EDID to fallback to if the driver is unable to interrogate an EDID from the actual device.

Tested with BRANCH=dev (5.5.y) kernel on RELEASE=bionic and RELEASE=eoan.

Compiles with BRANCH=current (5.4.y) on RELEASE=eoan.

Disabled under sunxi-legacy.