### PR TITLE
Fixed makefile of kernel headers 4.4.210 for rk3399

### DIFF
--- a/patch/kernel/rk3399-legacy/arm64_makefile_fix_build_of_i-file_in_external_module_case.patch
+++ b/patch/kernel/rk3399-legacy/arm64_makefile_fix_build_of_i-file_in_external_module_case.patch
@@ -1,0 +1,20 @@
+diff --git a/arch/arm64/Makefile b/arch/arm64/Makefile
+index 605f6cf4..08b797df 100644
+--- a/arch/arm64/Makefile
++++ b/arch/arm64/Makefile
+@@ -141,6 +141,7 @@ archclean:
+ 	$(Q)$(MAKE) $(clean)=$(boot)
+ 	$(Q)$(MAKE) $(clean)=$(boot)/dts
+ 
++ifeq ($(KBUILD_EXTMOD),)
+ # We need to generate vdso-offsets.h before compiling certain files in kernel/.
+ # In order to do that, we should use the archprepare target, but we can't since
+ # asm-offsets.h is included in some files used to generate vdso-offsets.h, and
+@@ -150,6 +151,7 @@ archclean:
+ prepare: vdso_prepare
+ vdso_prepare: prepare0
+ 	$(Q)$(MAKE) $(build)=arch/arm64/kernel/vdso include/generated/vdso-offsets.h
++endif
+ 
+ define archhelp
+   echo  '* Image.gz      - Compressed kernel image (arch/$(ARCH)/boot/Image.gz)'


### PR DESCRIPTION
Motivated by Issue https://github.com/armbian/build/issues/1751

Problem: Installing kernel headers 4.4.210 for rk3399 (discovered for NanoPi M4V2) shows:
`make: *** No rule to make target 'prepare0', needed by 'vdso_prepare'.  Stop.`
Solution: Add dependency to KBUILD_EXTMOD to Makefile (see https://patchwork.kernel.org/patch/10661821/ for details)
Note: This PR does not fix the general problem of postinst of kernel headers failing silently

Test that was executed to confirm solution:
* Built image for NanoPi M4V2 with legacy kernel 4.4.210, kernel-headers to be installed
* output/debug/install.log does not show `make: *** No rule to make target 'prepare0', needed by 'vdso_prepare'.  Stop.` anymore
* Build of image is completed without errors

Open questions:
* Problem seems to be a general issue for arm64, but I don't know which builds for other boards are affected. How can we identify other afftected builds?