### PR TITLE
[ mvebu ] Disable debian stretch image creation for Helios4 and Clearfog

### DIFF
--- a/config/targets.conf
+++ b/config/targets.conf
@@ -53,13 +53,11 @@ bananapipro			current			buster		minimal			stable	yes
 
 # Clearfog Base
 clearfogbase			legacy			buster		cli			stable	yes
-clearfogbase			legacy			stretch		cli			stable	yes
 clearfogbase			current			buster		cli			stable	yes
 clearfogbase			current			bionic		cli			stable	yes
 
 # Clearfog Pro
 clearfogpro			legacy			buster		cli			stable	yes
-clearfogpro			legacy			stretch		cli			stable	yes
 clearfogpro			current			buster		cli			stable	yes
 clearfogpro			current			bionic		cli			stable	yes
 
@@ -93,10 +91,8 @@ udoo				current			buster		minimal			stable	yes
 udoo				current			bullseye	cli			stable	yes
 
 # Helios4
-helios4				legacy			stretch		cli			stable	yes
 helios4				current			buster		cli			stable	yes
 helios4				current			bionic		cli			stable	yes
-helios4				current			stretch		cli			stable	no
 
 # Khadas Vim1
 kvim1				current			buster		desktop			stable	yes


### PR DESCRIPTION
Hi,

this PR disables the automatic building of debian stretch images for Helios4 and Clearfog. 
As I understand both boards have full support in Buster & Bionic so we should not need another "base os version" which might introduce unknown problems.

Is this the right way to disable stretch images @igorpecovnik ?

Do you need stretch for anything I missed @g-provost ?

If we can not clarify this before freeze date, I would move it to next release.

Cheers