### PR TITLE
Fixed the boot of 256M version of Rock Pi S (hopefully)

### DIFF
--- a/config/bootscripts/boot-rockpis.cmd
+++ b/config/bootscripts/boot-rockpis.cmd
@@ -3,7 +3,7 @@
 # Please edit /boot/armbianEnv.txt to set supported parameters
 #
 
-setenv load_addr "0x19000000"
+setenv load_addr "0x9000000"
 setenv overlay_error "false"
 # default values
 setenv rootdev "/dev/mmcblk0p1"


### PR DESCRIPTION
Boot script was loaded to a memory region that is out of memory for a 256M model.
No 256M unit to test but at least 512M one still boots ;p