### PR TITLE
Fixes makefiles of rockchip headers

### DIFF
--- a/patch/kernel/rockchip-legacy/arm64_makefile_fix_build_of_i-file_in_external_module_case.patch
+++ b/patch/kernel/rockchip-legacy/arm64_makefile_fix_build_of_i-file_in_external_module_case.patch
@@ -1,0 +1,20 @@
+diff --git a/arch/arm64/Makefile b/arch/arm64/Makefile
+index 605f6cf4..08b797df 100644
+--- a/arch/arm64/Makefile
++++ b/arch/arm64/Makefile
+@@ -141,6 +141,7 @@ archclean:
+ 	$(Q)$(MAKE) $(clean)=$(boot)
+ 	$(Q)$(MAKE) $(clean)=$(boot)/dts
+ 
++ifeq ($(KBUILD_EXTMOD),)
+ # We need to generate vdso-offsets.h before compiling certain files in kernel/.
+ # In order to do that, we should use the archprepare target, but we can't since
+ # asm-offsets.h is included in some files used to generate vdso-offsets.h, and
+@@ -150,6 +151,7 @@ archclean:
+ prepare: vdso_prepare
+ vdso_prepare: prepare0
+ 	$(Q)$(MAKE) $(build)=arch/arm64/kernel/vdso include/generated/vdso-offsets.h
++endif
+ 
+ define archhelp
+   echo  '* Image.gz      - Compressed kernel image (arch/$(ARCH)/boot/Image.gz)'

--- a/patch/kernel/rockchip64-legacy/arm64_makefile_fix_build_of_i-file_in_external_module_case.patch
+++ b/patch/kernel/rockchip64-legacy/arm64_makefile_fix_build_of_i-file_in_external_module_case.patch
@@ -1,0 +1,20 @@
+diff --git a/arch/arm64/Makefile b/arch/arm64/Makefile
+index 605f6cf4..08b797df 100644
+--- a/arch/arm64/Makefile
++++ b/arch/arm64/Makefile
+@@ -141,6 +141,7 @@ archclean:
+ 	$(Q)$(MAKE) $(clean)=$(boot)
+ 	$(Q)$(MAKE) $(clean)=$(boot)/dts
+ 
++ifeq ($(KBUILD_EXTMOD),)
+ # We need to generate vdso-offsets.h before compiling certain files in kernel/.
+ # In order to do that, we should use the archprepare target, but we can't since
+ # asm-offsets.h is included in some files used to generate vdso-offsets.h, and
+@@ -150,6 +151,7 @@ archclean:
+ prepare: vdso_prepare
+ vdso_prepare: prepare0
+ 	$(Q)$(MAKE) $(build)=arch/arm64/kernel/vdso include/generated/vdso-offsets.h
++endif
+ 
+ define archhelp
+   echo  '* Image.gz      - Compressed kernel image (arch/$(ARCH)/boot/Image.gz)'


### PR DESCRIPTION
This fix is the same as the one already applied successfully by PR #1753 for the rk3399-kernel. In this case the kernels for rockchip and rockchip64 are fixed as they suffer from the same issue.