### PR TITLE
Fixed the boot of 256M version of Rock Pi S

### DIFF
--- a/config/bootscripts/boot-rockpis.cmd
+++ b/config/bootscripts/boot-rockpis.cmd
@@ -3,7 +3,7 @@
 # Please edit /boot/armbianEnv.txt to set supported parameters
 #
 
-setenv load_addr "0x19000000"
+setenv load_addr "0x9000000"
 setenv overlay_error "false"
 # default values
 setenv rootdev "/dev/mmcblk0p1"


### PR DESCRIPTION
Original PR already merged into master: https://github.com/armbian/build/pull/1762
Tested with 512MB by me and [256MB version](https://forum.armbian.com/topic/12788-rk3308-rock-pi-s-256/?tab=comments#comment-94096).