### PR TITLE
[ mvebu ] Fix clearfog pci to msata switching

### DIFF
--- a/patch/u-boot/u-boot-mvebu/clearfog-pci0=msata.patch.disabled
+++ b/patch/u-boot/u-boot-mvebu/clearfog-pci0=msata.patch.disabled
@@ -1,0 +1,10 @@
+This turns pci0 (on clearfogpro the farthest from the cpu) into mSATA
+On clearfogbase this is the only mSATA/mPCIe
+---
+diff --git a/configs/clearfog_defconfig b/configs/clearfog_defconfig
+index 6b3e196..4400c71 100644
+--- a/configs/clearfog_defconfig
++++ b/configs/clearfog_defconfig
+@@ -47,0 +47,1 @@ CONFIG_DEBUG_UART_BASE=0xd0012000
++CONFIG_CLEARFOG_CON3_SATA=y
+

--- a/patch/u-boot/u-boot-mvebu/clearfog-pci1=msata.patch.disabled
+++ b/patch/u-boot/u-boot-mvebu/clearfog-pci1=msata.patch.disabled
@@ -1,0 +1,9 @@
+This turns the pci1 (on clearfogpro the closest from the cpu) into mSATA
+---
+diff --git a/configs/clearfog_defconfig b/configs/clearfog_defconfig
+index 6b3e196..4400c71 100644
+--- a/configs/clearfog_defconfig
++++ b/configs/clearfog_defconfig
+@@ -47,0 +47,1 @@ CONFIG_DEBUG_UART_BASE=0xd0012000
++CONFIG_CLEARFOG_CON2_SATA=y
+

--- a/patch/u-boot/u-boot-mvebu/swap-sata-serdes-rx.patch
+++ b/patch/u-boot/u-boot-mvebu/swap-sata-serdes-rx.patch
@@ -1,0 +1,44 @@
+From f95ec9a3e97c9e1be4b444f776e47201e03d9783 Mon Sep 17 00:00:00 2001
+From: Baruch Siach <baruch@tkos.co.il>
+Date: Wed, 13 Jun 2018 16:25:20 +0300
+Subject: [PATCH] clearfog: sata serdes needs Rx swap
+
+Both SATA serdes configurations need to enable the swap_rx field in
+serdes_map to allow proper communication with SATA devices.
+
+Apply the fix to Pro and Base.
+
+Signed-off-by: Baruch Siach <baruch@tkos.co.il>
+---
+ board/solidrun/clearfog/clearfog.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/board/solidrun/clearfog/clearfog.c b/board/solidrun/clearfog/clearfog.c
+index 34dc50d94b2..cec9c764a89 100644
+--- a/board/solidrun/clearfog/clearfog.c
++++ b/board/solidrun/clearfog/clearfog.c
+@@ -41,13 +41,13 @@ static struct serdes_map board_serdes_map[] = {
+ 	{SATA0, SERDES_SPEED_3_GBPS, SERDES_DEFAULT_MODE, 0, 0},
+ 	{SGMII1, SERDES_SPEED_1_25_GBPS, SERDES_DEFAULT_MODE, 0, 0},
+ #ifdef CONFIG_CLEARFOG_CON3_SATA
+-	{SATA1, SERDES_SPEED_3_GBPS, SERDES_DEFAULT_MODE, 0, 0},
++	{SATA1, SERDES_SPEED_3_GBPS, SERDES_DEFAULT_MODE, 1, 0},
+ #else
+ 	{PEX1, SERDES_SPEED_5_GBPS, PEX_ROOT_COMPLEX_X1, 0, 0},
+ #endif
+ 	{USB3_HOST1, SERDES_SPEED_5_GBPS, SERDES_DEFAULT_MODE, 0, 0},
+ #ifdef CONFIG_CLEARFOG_CON2_SATA
+-	{SATA2, SERDES_SPEED_3_GBPS, SERDES_DEFAULT_MODE, 0, 0},
++	{SATA2, SERDES_SPEED_3_GBPS, SERDES_DEFAULT_MODE, 1, 0},
+ #else
+ 	{PEX2, SERDES_SPEED_5_GBPS, PEX_ROOT_COMPLEX_X1, 0, 0},
+ #endif
+@@ -64,7 +64,7 @@ static struct serdes_map board_serdes_map[] = {
+ 	{SATA0, SERDES_SPEED_3_GBPS, SERDES_DEFAULT_MODE, 0, 0},
+ 	{SGMII1, SERDES_SPEED_1_25_GBPS, SERDES_DEFAULT_MODE, 0, 0},
+ #ifdef CONFIG_CLEARFOG_CON3_SATA
+-	{SATA1, SERDES_SPEED_3_GBPS, SERDES_DEFAULT_MODE, 0, 0},
++	{SATA1, SERDES_SPEED_3_GBPS, SERDES_DEFAULT_MODE, 1, 0},
+ #else
+ 	{PEX1, SERDES_SPEED_5_GBPS, PEX_ROOT_COMPLEX_X1, 0, 0},
+ #endif


### PR DESCRIPTION
Hi,

This adds two disabled patches which allow users to switch the pci ports on clearfog to msata. Also fixes the then occuring sata serdes config error (needs rx swap). (See also: https://github.com/SolidRun/u-boot/pull/3)
We had this included once, it got lost somewhere...

I tested this on clearfogpro. It should not influence any other board.

This does not need to be included in current release as switching pci to sata requires users to build their own uboot anyways.