### PR TITLE
Disable autologin on pinebook pro.

### DIFF
--- a/config/boards/pinebook-pro.wip
+++ b/config/boards/pinebook-pro.wip
@@ -2,5 +2,6 @@
 BOARD_NAME="Pinebook Pro"
 BOARDFAMILY="rockchip64"
 BOOTCONFIG="pinebook_pro-rk3399_defconfig"
+DESKTOP_AUTOLOGIN="no"
 KERNEL_TARGET="legacy,current,dev"
 FULL_DESKTOP="yes"


### PR DESCRIPTION
This change follow the [pinebook-a64](https://github.com/armbian/build/blob/909be0239d8f3a9d6e2dae9da94d18b65e350320/config/boards/pinebook-a64.conf#L5) and is just a need on any laptop.