### PR TITLE
Install compile dependency dialog if missing

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -84,6 +84,12 @@ fi
 
 rm $TMPFILE
 
+# Check for required packages for compiling
+if [[ -z "$(which dialog)" ]]; then
+	sudo apt update
+	sudo apt install -y dialog
+fi
+
 # Check for Vagrant
 if [[ "$1" == vagrant && -z "$(which vagrant)" ]]; then
 	display_alert "Vagrant not installed." "Installing"


### PR DESCRIPTION
When following tutorial on https://docs.armbian.com/Developer-Guide_Using-Vagrant/, `./compile.sh` does not work due to `dialog` missing (even after `apt update && apt upgrade`). 
