### PR TITLE
Switched OrangePi 4 to SPL/TPL + bl31 u-boot scenario

### DIFF
--- a/config/sources/families/rk3399.conf
+++ b/config/sources/families/rk3399.conf
@@ -22,12 +22,12 @@ if [[ $BOARD == roc-rk3399-pc ]]; then
 
 	BOOT_USE_MAINLINE_ATF=yes
 
-elif [[ $BOARD == rockpi-4* ]]; then
+elif [[ $BOARD == rockpi-4* || $BOARD == orangepi4 ]]; then
 
 	BOOT_USE_TPL_SPL_BLOB=yes
 	BL31_BLOB='rk33/rk3399_bl31_v1.30.elf'
 
-elif [[ $BOARD == nanopim4v2 || $BOARD == orangepi4 ]]; then
+elif [[ $BOARD == nanopim4v2 ]]; then
 
 	BOOT_USE_BLOBS=yes
 	DDR_BLOB='rk33/rk3399_ddr_933MHz_v1.24.bin'


### PR DESCRIPTION
Fixes issue with booting Armbian after using GPT based image on the same card.

@igorpecovnik could you please try to boot it from SD in the meantime?
IIRC you still have Xunlong's distro on eMMC - this is the scenario most new users will face.