### PR TITLE
Check also previous rootfs version

### DIFF
--- a/lib/general.sh
+++ b/lib/general.sh
@@ -119,7 +119,7 @@ exit_with_error()
 
 get_package_list_hash()
 {
-	( printf '%s\n' $PACKAGE_LIST | sort -u; printf '%s\n' $PACKAGE_LIST_EXCLUDE | sort -u; echo "$ROOTFSCACHE_VERSION" ) \
+	( printf '%s\n' $PACKAGE_LIST | sort -u; printf '%s\n' $PACKAGE_LIST_EXCLUDE | sort -u; echo "$1" ) \
 		| md5sum | cut -d' ' -f 1
 }
 


### PR DESCRIPTION
In the image creation process we use cached rootfs instead of slow debootstrap and when seeking for cache files we shall also checks previous version. This solves problem described in [AR-166]

[AR-166]: https://armbian.atlassian.net/browse/AR-166

@lanefu 