### PR TITLE
Create xxx-sun50i-h6-enable-higher-clock.patch

### DIFF
--- a/patch/kernel/sunxi-current/xxx-sun50i-h6-enable-higher-clock.patch
+++ b/patch/kernel/sunxi-current/xxx-sun50i-h6-enable-higher-clock.patch
@@ -1,0 +1,12 @@
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi.dtsi
+index fe8c57876..0ed487311 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi.dtsi
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi.dtsi
+@@ -177,7 +177,7 @@
+                        reg_dcdca: dcdca {
+                                regulator-always-on;
+                                regulator-min-microvolt = <810000>;
+-                               regulator-max-microvolt = <1080000>;
++                               regulator-max-microvolt = <1160000>;
+                                regulator-name = "vdd-cpu";
+                        };


### PR DESCRIPTION
Adjusted the dcdca voltage to allow H6 to clock to its designed clock of 1800MHz

https://forum.armbian.com/topic/9368-orangepi-3-h6-allwiner-chip/?do=findComment&comment=95721