### PR TITLE
Update 30-armbian-sysinfo

### DIFF
--- a/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
+++ b/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
@@ -138,9 +138,9 @@ function get_ip_addresses() {
 		if [[ $intf =~ $SHOW_IP_PATTERN ]]; then
 			local tmp=$(ip -4 addr show dev $intf | awk '/inet/ {print $2}' | cut -d'/' -f1)
 			# add both name and IP - can be informative but becomes ugly with long persistent/predictable device names
-			#[[ -n $tmp ]] && ips+=("$intf: $tmp")
+			[[ -n $tmp ]] && ips+=("$intf: $tmp")
 			# add IP only
-			[[ -n $tmp ]] && ips+=("$tmp")
+			#[[ -n $tmp ]] && ips+=("$tmp")
 		fi
 	done
 	echo "${ips[@]}"
@@ -196,7 +196,7 @@ display "Local users" "${users##* }" "3" "2" ""
 echo "" # fixed newline
 display "Memory usage" "$memory_usage" "70" "0" " %" " of ${memory_total}MB"
 display "Zram usage" "$swap_usage" "75" "0" " %" " of $swap_total""Mb"
-printf "IP:            "
+printf "\nIP:            "
 printf "\x1B[92m%s\x1B[0m" "$ip_address"
 echo "" # fixed newline
 a=0;b=0;c=0

--- a/packages/bsp/helios4/armbian-motd
+++ b/packages/bsp/helios4/armbian-motd
@@ -1,9 +1,13 @@
 # add space-separated list of MOTD script names (without number) to exclude them from MOTD
 # Example:
 # MOTD_DISABLE="header tips updates"
+# configure display of Interfaces/IP addresses in 30-armbian-sysinfo
+# Example:
+# IP_AND_INTERFACE_NAMES="none one list table"
 
 MOTD_DISABLE=""
 ONE_WIRE="" # yes = show 1-wire temperature sensor if attached 
+IP_AND_INTERFACE_NAMES="none"
 
 # Helios4 temperature display warning threshold
 CPU_TEMP_LIMIT=70


### PR DESCRIPTION
This change enables the option for IP **and** interface, and adds an additional line feed, to start  the IP report on a new line.
As noted in the comment, this may not give an optimal layout with "predictable" interface names, possibly mitigated by the extra linefeed.
example output:
netadmin@probe3:~$ ./30-armbian-sysinfo 
System load:   0.01 0.01 0.00  	Up time:       5:18 hours		
Memory usage:  29 % of 238MB  	Zram usage:    17 % of 119Mb  	
IP:            eth0: 192.168.1.5
CPU temp:      44°C           	
Usage of /:    5% of 29G    	

Without this change, the IP address is to the far right of the display. With the changes, the display is more compact horizontally at just less than 60 chars. If the additional line taken by the IP display gives problems with other motd displays, one of the two empty lines at the foot of this display culd be sacrificed.

Please use the "Preview" tab above to view this message if you are seeing this in the new pull request text box.

Please make sure that:

 - pull request is opened to the `master` branch unless you are working on a specfic feature which is developed in a separate branch
 - any changes to kernel configuration files were made by Kconfig menu (build script option `KERNEL_CONFIGURE=yes`) and not by editing configuration files by hand,
 - patch file names don't contain spaces and have less than 40 characters (not counting the `.patch` extension),
 - changes are properly described - what was done exactly and why.

Thanks for contributing! Please remove the text above before opening a pull request.
