### PR TITLE
Softlimit H6 clock

### DIFF
--- a/config/sources/families/sun50iw6.conf
+++ b/config/sources/families/sun50iw6.conf
@@ -6,7 +6,7 @@ OVERLAY_PREFIX='sun50i-h6'
 BOOTENV_FILE='sun50iw2-next.txt'
 
 [[ -z $CPUMIN ]] && CPUMIN=480000
-[[ -z $CPUMAX ]] && CPUMAX=1810000
+[[ -z $CPUMAX ]] && CPUMAX=1488000
 GOVERNOR=ondemand
 
 ASOUND_STATE='asound.state.sun50iw2-dev'


### PR DESCRIPTION
Relating to Igors post here: https://forum.armbian.com/topic/12660-opi-one-h6-18-ghz-on-54x/?do=findComment&comment=92600

Since some users reported unstable behavior with the H6 SoC when running in full speed (never had any issues with my two boards though) soft-limit the max CPU freq at dispatch. If users want to give it a try to check if their board is capable to run at full speed they now can simply edit a file and get what they want.

Just an idea I had while being on the road. Need to test this.