### PR TITLE
Create nanopc-t4-fix_emmc.patch

### DIFF
--- a/patch/kernel/rockchip64-current/nanopc-t4-fix_emmc.patch
+++ b/patch/kernel/rockchip64-current/nanopc-t4-fix_emmc.patch
@@ -1,0 +1,12 @@
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-nanopc-t4.dts b/arch/arm64/boot/dts/rockchip/rk3399-nanopc-t4.dts
+index d3ed8e5e7..d60c22dc1 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-nanopc-t4.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopc-t4.dts
+@@ -105,7 +105,6 @@
+ 
+ &sdhci {
+ 	mmc-hs400-1_8v;
+-	mmc-hs400-enhanced-strobe;
+ };
+ 
+ &u2phy0_host {


### PR DESCRIPTION
As discussed earlier https://forum.armbian.com/topic/7498-nanopc-t4/page/3/
the dtsi settings of the board
`mmc-hs400-1_8v;`
`mmc-hs400-enhanced-strobe;`
won't work since moving away from legacy 4.4, resulting in unexpected boot behaviours or mmc simply just not showing up, but this is not 100% reproducible. I had no answers regarding anyone using these settings with success.

simple solution: only remove 
`mmc-hs400-enhanced-strobe;`
but keep 
`mmc-hs400-1_8v`

I had some spare time testing many build options, and this seems to be the most or always  consistent solution.

Long explanation (imho, could be totally wrong)
mmc-hs400-enhanced-strobe sets any voltage, see

/*
	 * eMMC cards can support 3.3V to 1.2V i/o (vccq)
	 * signaling.
	 *
	 * EXT_CSD_CARD_TYPE_DDR_1_8V means 3.3V or 1.8V vccq.
	 *
	 * 1.8V vccq at 3.3V core voltage (vcc) is not required
	 * in the JEDEC spec for DDR.
	 *
	 * Even (e)MMC card can support 3.3v to 1.2v vccq, but not all
	 * host controller can support this, like some of the SDHCI
	 * controller which connect to an eMMC device. Some of these
	 * host controller still needs to use 1.8v vccq for supporting
	 * DDR mode.
	 *
	 * So the sequence will be:
	 * if (host and device can both support 1.2v IO)
	 *	use 1.2v IO;
	 * else if (host and device can both support 1.8v IO)
	 *	use 1.8v IO;
	 * so if host and device can only support 3.3v IO, this is the
	 * last choice.
	 *
	 * WARNING: eMMC rules are NOT the same as SD DDR
	 */

... and following 
[source](https://github.com/torvalds/linux/blob/master/drivers/mmc/core/mmc.c)

There seems to be some hickups one this board with voltage regulators, therefore you can get different results if rebooting/cold starting/remove power complete.
In my opinion this is a good workaround, till someone finds the real culprit, but board seems not that popular - i love it.

Performance hit is barely noticable.