### PR TITLE
Further stabilize ethernet of rockpi-4b

### DIFF
--- a/patch/kernel/rockchip64-current/rockpi-4b_increase_rx_delay.patch
+++ b/patch/kernel/rockchip64-current/rockpi-4b_increase_rx_delay.patch
@@ -1,0 +1,13 @@
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-nanopi4.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-nanopi4.dtsi
+index 5ecaf63ea..b71336f96 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-nanopi4.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi4.dtsi
+@@ -177,7 +177,7 @@
+ 	snps,reset-delays-us = <0 10000 30000>;
+ 	snps,reset-gpio = <&gpio3 RK_PB7 GPIO_ACTIVE_LOW>;
+ 	tx_delay = <0x28>;
+-	rx_delay = <0x11>;
++	rx_delay = <0x20>;
+ 	status = "okay";
+ 
+ 	mdio {


### PR DESCRIPTION
This [pull 1736](https://github.com/armbian/build/pull/1736) was a good start for improving network stability. 
`snps,txpbl = <0x4>;`

But in my case, or I guess with a typical german ISP with DS-lite (Native IPv6 + IPv4 tunneling through IPv6 - it is a nightmare in general). I did not use the board much because it was only usuable with
`ethtool -K eth0 tx off rx off`. Turns out the above pull request improved situation, but I was still unable to complete a simple apt update. After checking some other fixes around I also increased `rx_delay = <0x20>; `and all my problems are gone for the first time and I am actually using this board. The setting could possibly use some fine tuning, maybe 16 is already enough.