### PR TITLE
Prioritize booting from SD for OrangePi 4

### DIFF
--- a/patch/u-boot/u-boot-rk3399/board_orangepi4/board-orangepi-4-prioritize-sd.patch
+++ b/patch/u-boot/u-boot-rk3399/board_orangepi4/board-orangepi-4-prioritize-sd.patch
@@ -1,0 +1,15 @@
+diff --git a/include/configs/rockchip-common.h b/include/configs/rockchip-common.h
+index 68e1105a..906c22ed 100644
+--- a/include/configs/rockchip-common.h
++++ b/include/configs/rockchip-common.h
+@@ -14,8 +14,8 @@
+ /* First try to boot from SD (index 0), then eMMC (index 1) */
+ #if CONFIG_IS_ENABLED(CMD_MMC)
+ 	#define BOOT_TARGET_MMC(func) \
+-		func(MMC, mmc, 0) \
+-		func(MMC, mmc, 1)
++		func(MMC, mmc, 1) \
++		func(MMC, mmc, 0)
+ #else
+ 	#define BOOT_TARGET_MMC(func)
+ #endif


### PR DESCRIPTION
The change allows to boot from SD which has a proper u-boot installed even though eMMC contains bootable installation.

Tested following scenarios:

- BSP in eMMC / Armbian in SD - booting from SD
- Armbian in eMMC / Armbian in SD - booting from SD
- Armbian in eMMC / BSP in SD - booting from SD
- Armbian in eMMC / emptied SD (zeroed u-boot) - booting from eMMC