### PR TITLE
Fixed eMMC hs400es mode init on some rockchip64 boards in current and dev

### DIFF
--- a/patch/kernel/rockchip64-current/general-emmc-hs400es-init-tweak.patch
+++ b/patch/kernel/rockchip64-current/general-emmc-hs400es-init-tweak.patch
@@ -1,0 +1,22 @@
+This patch is required to boot some Rock Pi 4 and NanoPC T4 units
+with kernel 5.3+ and is on par with how it is done in Rockchip's BSP.
+
+diff --git a/drivers/mmc/core/mmc.c b/drivers/mmc/core/mmc.c
+index de8fbc396..95858e554 100644
+--- a/drivers/mmc/core/mmc.c
++++ b/drivers/mmc/core/mmc.c
+@@ -1371,12 +1371,12 @@ static int mmc_select_hs400es(struct mmc_card *card)
+ 	}
+ 
+ 	mmc_set_timing(host, MMC_TIMING_MMC_HS);
++	mmc_set_clock(host, card->ext_csd.hs_max_dtr);
++
+ 	err = mmc_switch_status(card);
+ 	if (err)
+ 		goto out_err;
+ 
+-	mmc_set_clock(host, card->ext_csd.hs_max_dtr);
+-
+ 	/* Switch card to DDR with strobe bit */
+ 	val = EXT_CSD_DDR_BUS_WIDTH_8 | EXT_CSD_BUS_WIDTH_STROBE;
+ 	err = mmc_switch(card, EXT_CSD_CMD_SET_NORMAL,

--- a/patch/kernel/rockchip64-dev/general-emmc-hs400es-init-tweak.patch
+++ b/patch/kernel/rockchip64-dev/general-emmc-hs400es-init-tweak.patch
@@ -1,0 +1,22 @@
+This patch is required to boot some Rock Pi 4 and NanoPC T4 units
+with kernel 5.3+ and is on par with how it is done in Rockchip's BSP.
+
+diff --git a/drivers/mmc/core/mmc.c b/drivers/mmc/core/mmc.c
+index de8fbc396..95858e554 100644
+--- a/drivers/mmc/core/mmc.c
++++ b/drivers/mmc/core/mmc.c
+@@ -1371,12 +1371,12 @@ static int mmc_select_hs400es(struct mmc_card *card)
+ 	}
+ 
+ 	mmc_set_timing(host, MMC_TIMING_MMC_HS);
++	mmc_set_clock(host, card->ext_csd.hs_max_dtr);
++
+ 	err = mmc_switch_status(card);
+ 	if (err)
+ 		goto out_err;
+ 
+-	mmc_set_clock(host, card->ext_csd.hs_max_dtr);
+-
+ 	/* Switch card to DDR with strobe bit */
+ 	val = EXT_CSD_DDR_BUS_WIDTH_8 | EXT_CSD_BUS_WIDTH_STROBE;
+ 	err = mmc_switch(card, EXT_CSD_CMD_SET_NORMAL,


### PR DESCRIPTION
The patch brings hs400es initialisation in current / dev on par with Rockchip's BSP.
There are few rk3399 based SBC units that were known to cause problems without the patch and are booting fine with it:

- my once owned RockPi 4A
- @fraz0815's NanoPi T4: https://github.com/armbian/build/pull/1820#issuecomment-593125830
- (at)diginet's RockPi 4: https://forum.armbian.com/topic/12573-armbian-buster-current-with-linux-54y-on-the-rock-pi-4/?do=findComment&comment=92245

This is fairly safe change as there are not many boards left with hs400es mode enabled - namely Rock Pi 4 and NanoPC T4 - others max out at hs200 mode.