### PR TITLE
[ mvebu-helios4 ] Fix helios4 module includes

### DIFF
--- a/config/sources/families/include/mvebu-helios4.inc
+++ b/config/sources/families/include/mvebu-helios4.inc
@@ -81,13 +81,13 @@ family_tweaks_bsp()
 	# add custom motd default conf file
         install -m 644 $SRC/packages/bsp/helios4/armbian-motd $destination/etc/default/
 
-        # create modules file
+    # create modules file
 	if [[ $BRANCH == dev && -n $MODULES_DEV ]]; then
 		tr ' ' '\n' <<< "$MODULES_DEV" > "${destination}"/etc/modules
-	elif [[ $BRANCH == next || $BRANCH == dev ]]; then
-		tr ' ' '\n' <<< "$MODULES_NEXT" > "${destination}"/etc/modules
+	elif [[ $BRANCH == current || $BRANCH == dev ]]; then
+		tr ' ' '\n' <<< "$MODULES_CURRENT" > "${destination}"/etc/modules
 	else
-		tr ' ' '\n' <<< "$MODULES" > "${destination}"/etc/modules
+		tr ' ' '\n' <<< "$MODULES_LEGACY" > "${destination}"/etc/modules
 	fi
 
 	## Postinst


### PR DESCRIPTION
Hi,

@aprayoga noticed that since changing the kernel naming from "legacy, next, dev" to "legacy, current, dev" the modules did not get included anymore.

Compare these:
https://github.com/armbian/build/blob/b09c61a011a3d0cf1d23059f1524e4fb14640bc6/config/sources/families/include/mvebu-helios4.inc#L84-L91

To:
https://github.com/armbian/build/blob/b09c61a011a3d0cf1d23059f1524e4fb14640bc6/config/boards/helios4.conf#L6-L7

I updated the mvebu-helios4.inc file to include the new naming. This should only affect helios4 so is safe to be included. 

Only thing I am unsure about is how to include this into 20.02. Can you cherry-pick this over @lanefu ?

Cheers,
count-doku