### PR TITLE
Update 30-armbian-sysinfo for uptime/users/load + add bonding devices IP

### DIFF
--- a/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
+++ b/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
@@ -15,7 +15,7 @@ export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 THIS_SCRIPT="sysinfo"
 MOTD_DISABLE=""
 STORAGE=/dev/sda1
-SHOW_IP_PATTERN="^[ewr].*|^br.*|^lt.*|^umts.*"
+SHOW_IP_PATTERN="^bond.*|^[ewr].*|^br.*|^lt.*|^umts.*"
 
 CPU_TEMP_LIMIT=45
 AMB_TEMP_LIMIT=40
@@ -168,18 +168,15 @@ getboardtemp
 critical_load=$(( 1 + $(grep -c processor /proc/cpuinfo) / 2 ))
 
 # get uptime, logged in users and load in one take
-UptimeString=$(uptime | tr -d ',')
-time=$(awk -F" " '{print $3" "$4}' <<<"${UptimeString}")
-load="$(awk -F"average: " '{print $2}'<<<"${UptimeString}")"
-users="$(awk -F" user" '{print $1}'<<<"${UptimeString}")"
-case ${time} in
-	1:*) # 1-2 hours
-		time=$(awk -F" " '{print $3" hour"}' <<<"${UptimeString}")
-		;;
-	*:*) # 2-24 hours
-		time=$(awk -F" " '{print $3" hours"}' <<<"${UptimeString}")
-		;;
-esac
+UPTIME=$(uptime)
+UPT1=${UPTIME#*'up '}
+UPT2=${UPT1%'user'*}
+users=${UPT2//*','}
+users=${users//' '}
+time=${UPT2%','*}
+time=${time//','}
+load=${UPTIME#*'load average: '}
+load=${load//','}
 
 # memory and swap
 mem_info=$(LC_ALL=C free -w 2>/dev/null | grep "^Mem" || LC_ALL=C free | grep "^Mem")


### PR DESCRIPTION
change 1:
fix for uptime from procps-ng 3.3.15: reports uptime less then a day as "hh:mm," but uptime larger than a day as "nn days, hh:mm," or "nn days, mm min", and less than 1 hour as "mm min," which mixes up the assignments for user count and load in the original script due to the various differing uptime value formats we'll cut out the components for uptime / user(s) / load by bash string substitutions

change 2:
fix for including bonding device(s) in SHOW_IP_PATTERN