### PR TITLE
add prerm script for heders

### DIFF
--- a/patch/misc/general-packaging-4.19.y.patch
+++ b/patch/misc/general-packaging-4.19.y.patch
@@ -1,3 +1,14 @@
+From 2b73935784b88ef50fc4be16254a4962b5f70383 Mon Sep 17 00:00:00 2001
+From: The-going <48602507+The-going@users.noreply.github.com>
+Date: Tue, 10 Mar 2020 16:44:18 +0300
+Subject: [PATCH] general packaging 4.19.y
+
+---
+ arch/arm64/Makefile      |   2 +-
+ scripts/package/builddeb | 121 ++++++++++++++++++++++++++++++++++++++++++++---
+ scripts/package/mkdebian |  12 ++++-
+ 3 files changed, 126 insertions(+), 9 deletions(-)
+
 diff --git a/arch/arm64/Makefile b/arch/arm64/Makefile
 index 9a5e28141211..851e646169ba 100644
 --- a/arch/arm64/Makefile
@@ -11,37 +22,56 @@ index 9a5e28141211..851e646169ba 100644
  KBUILD_DTBS	:= dtbs
  
  all:	Image.gz $(KBUILD_DTBS)
+diff --git a/scripts/package/builddeb b/scripts/package/builddeb
+index 0b31f4f1f92c..f6b96d8507f4 100755
 --- a/scripts/package/builddeb
 +++ b/scripts/package/builddeb
-@@ -29,6 +29,27 @@ create_package() {
+@@ -29,6 +29,44 @@ create_package() {
  	# in case we are in a restrictive umask environment like 0077
  	chmod -R a+rX "$pdir"
  
 +	# Create preinstall and post install script to remove dtb
 +	if [[ "$1" == *dtb* ]]; then
-+		echo "if [ -d /boot/dtb-$version ]; then mv /boot/dtb-$version /boot/dtb-$version.old; fi" >> $pdir/DEBIAN/preinst
-+		echo "if [ -d /boot/dtb.old ]; then rm -rf /boot/dtb.old; fi" >> $pdir/DEBIAN/preinst
-+		echo "if [ -d /boot/dtb ]; then mv /boot/dtb /boot/dtb.old; fi" >> $pdir/DEBIAN/preinst
-+		echo "exit 0" >> $pdir/DEBIAN/preinst
-+		chmod 775 $pdir/DEBIAN/preinst
 +
-+		echo "if [ -d /boot/dtb-$version.old ]; then rm -rf /boot/dtb-$version.old; fi" >> $pdir/DEBIAN/postinst
-+		echo "ln -sf dtb-$version /boot/dtb > /dev/null 2>&1 || mv /boot/dtb-$version /boot/dtb" >> $pdir/DEBIAN/postinst
-+		echo "exit 0" >> $pdir/DEBIAN/postinst
-+		chmod 775 $pdir/DEBIAN/postinst
++	cat >> $pdir/DEBIAN/preinst <<EOT
++rm -rf /boot/{dtb,dtb-$version}
++exit 0
++EOT
++
++	cat >> $pdir/DEBIAN/postinst <<EOT
++cd /boot
++ln -sfT dtb-$version dtb 2> /dev/null || mv dtb-$version dtb
++exit 0
++EOT
++
++	chmod 775 $pdir/DEBIAN/{preinst,postinst}
 +	fi
 +
-+	# Create postinstall script for headers
++	# Create postinst prerm scripts for headers
 +	if [[ "$1" == *headers* ]]; then
-+		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts >/dev/null; make -s M=scripts/mod/ >/dev/null" >> $pdir/DEBIAN/postinst
-+		echo "exit 0" >> $pdir/DEBIAN/postinst
-+		chmod 775 $pdir/DEBIAN/postinst
++
++cat >> $pdir/DEBIAN/postinst << EOT
++cd /usr/src/linux-headers-$version
++echo "Compiling headers - please wait ..."
++find -type f -exec touch {} +
++make -s scripts >/dev/null
++make -s M=scripts/mod/ >/dev/null
++exit 0
++EOT
++
++cat >> $pdir/DEBIAN/prerm << EOT
++cd /usr/src/linux-headers-$version
++rm -rf scripts .config.old
++exit 0
++EOT
++
++	chmod 775 $pdir/DEBIAN/{postinst,prerm}
 +	fi
 +
  	# Create the package
  	dpkg-gencontrol -p$pname -P"$pdir"
  	dpkg --build "$pdir" ..
-@@ -39,9 +60,11 @@ tmpdir="$objtree/debian/tmp"
+@@ -39,9 +77,11 @@ tmpdir="$objtree/debian/tmp"
  kernel_headers_dir="$objtree/debian/hdrtmp"
  libc_headers_dir="$objtree/debian/headertmp"
  dbg_dir="$objtree/debian/dbgtmp"
@@ -56,7 +86,7 @@ index 9a5e28141211..851e646169ba 100644
  dbg_packagename=$packagename-dbg
  
  if [ "$ARCH" = "um" ] ; then
-@@ -52,6 +75,15 @@ fi
+@@ -52,6 +92,15 @@ fi
  # XXX: have each arch Makefile export a variable of the canonical image install
  # path instead
  case $ARCH in
@@ -72,7 +102,7 @@ index 9a5e28141211..851e646169ba 100644
  um)
  	installed_image_path="usr/bin/linux-$version"
  	;;
-@@ -65,7 +97,9 @@ esac
+@@ -65,7 +114,9 @@ esac
  BUILD_DEBUG="$(grep -s '^CONFIG_DEBUG_INFO=y' $KCONFIG_CONFIG || true)"
  
  # Setup the directory structure
@@ -83,7 +113,7 @@ index 9a5e28141211..851e646169ba 100644
  mkdir -m 755 -p "$tmpdir/DEBIAN"
  mkdir -p "$tmpdir/lib" "$tmpdir/boot"
  mkdir -p "$kernel_headers_dir/lib/modules/$version/"
-@@ -118,6 +152,11 @@ if grep -q '^CONFIG_MODULES=y' $KCONFIG_CONFIG ; then
+@@ -118,6 +169,11 @@ if grep -q '^CONFIG_MODULES=y' $KCONFIG_CONFIG ; then
  	fi
  fi
  
@@ -95,7 +125,7 @@ index 9a5e28141211..851e646169ba 100644
  if [ "$ARCH" != "um" ]; then
  	$MAKE headers_check KBUILD_SRC=
  	$MAKE headers_install KBUILD_SRC= INSTALL_HDR_PATH="$libc_headers_dir/usr"
-@@ -137,7 +176,7 @@ fi
+@@ -137,7 +193,7 @@ fi
  for script in postinst postrm preinst prerm ; do
  	mkdir -p "$tmpdir$debhookdir/$script.d"
  	cat <<EOF > "$tmpdir/DEBIAN/$script"
@@ -104,7 +134,7 @@ index 9a5e28141211..851e646169ba 100644
  
  set -e
  
-@@ -153,9 +192,58 @@ EOF
+@@ -153,9 +209,58 @@ EOF
  	chmod 755 "$tmpdir/DEBIAN/$script"
  done
  
@@ -163,7 +193,7 @@ index 9a5e28141211..851e646169ba 100644
  (cd $srctree; find arch/$SRCARCH -name module.lds -o -name Kbuild.platforms -o -name Platform) >> "$objtree/debian/hdrsrcfiles"
  (cd $srctree; find $(find arch/$SRCARCH -name include -o -name scripts -type d) -type f) >> "$objtree/debian/hdrsrcfiles"
  if grep -q '^CONFIG_STACK_VALIDATION=y' $KCONFIG_CONFIG ; then
-@@ -167,15 +255,19 @@ if grep -q '^CONFIG_GCC_PLUGINS=y' $KCONFIG_CONFIG ; then
+@@ -167,15 +272,19 @@ if grep -q '^CONFIG_GCC_PLUGINS=y' $KCONFIG_CONFIG ; then
  fi
  destdir=$kernel_headers_dir/usr/src/linux-headers-$version
  mkdir -p "$destdir"
@@ -184,6 +214,8 @@ index 9a5e28141211..851e646169ba 100644
  fi
  
  create_package "$packagename" "$tmpdir"
+diff --git a/scripts/package/mkdebian b/scripts/package/mkdebian
+index edcad61fe3cd..8a49f432921f 100755
 --- a/scripts/package/mkdebian
 +++ b/scripts/package/mkdebian
 @@ -94,10 +94,12 @@ else
@@ -221,3 +253,6 @@ index 9a5e28141211..851e646169ba 100644
  EOF
  
  cat <<EOF > debian/rules
+-- 
+2.16.4
+

--- a/patch/misc/general-packaging-5.3.y.patch
+++ b/patch/misc/general-packaging-5.3.y.patch
@@ -1,5 +1,16 @@
+From f0c6ececf4ecf8407c96af709dc96f959299ee56 Mon Sep 17 00:00:00 2001
+From: The-going <48602507+The-going@users.noreply.github.com>
+Date: Tue, 10 Mar 2020 17:16:41 +0300
+Subject: [PATCH] general packaging 5.3.y
+
+---
+ arch/arm64/Makefile      |   2 +-
+ scripts/package/builddeb | 122 ++++++++++++++++++++++++++++++++++++++++++++---
+ scripts/package/mkdebian |  15 ++++--
+ 3 files changed, 128 insertions(+), 11 deletions(-)
+
 diff --git a/arch/arm64/Makefile b/arch/arm64/Makefile
-index 5858d6e44..e81b8a6fc 100644
+index 5858d6e44926..e81b8a6fcc21 100644
 --- a/arch/arm64/Makefile
 +++ b/arch/arm64/Makefile
 @@ -142,7 +142,7 @@ core-$(CONFIG_EFI_STUB) += $(objtree)/drivers/firmware/efi/libstub/lib.a
@@ -11,37 +22,55 @@ index 5858d6e44..e81b8a6fc 100644
  
  all:	Image.gz
  
+diff --git a/scripts/package/builddeb b/scripts/package/builddeb
+index c4c580f547ef..2be8a687f878 100755
 --- a/scripts/package/builddeb
 +++ b/scripts/package/builddeb
-@@ -41,6 +41,27 @@ create_package() {
+@@ -41,6 +41,43 @@ create_package() {
  	# in case we are in a restrictive umask environment like 0077
  	chmod -R a+rX "$pdir"
  
 +	# Create preinstall and post install script to remove dtb
 +	if [ "$3" = "dtb" ]; then
-+		echo "if [ -d /boot/dtb-$version ]; then mv /boot/dtb-$version /boot/dtb-$version.old; fi" >> $pdir/DEBIAN/preinst
-+		echo "if [ -d /boot/dtb.old ]; then rm -rf /boot/dtb.old; fi" >> $pdir/DEBIAN/preinst
-+		echo "if [ -d /boot/dtb ]; then mv /boot/dtb /boot/dtb.old; fi" >> $pdir/DEBIAN/preinst
-+		echo "exit 0" >> $pdir/DEBIAN/preinst
-+		chmod 775 $pdir/DEBIAN/preinst
 +
-+		echo "if [ -d /boot/dtb-$version.old ]; then rm -rf /boot/dtb-$version.old; fi" >> $pdir/DEBIAN/postinst
-+		echo "ln -sf dtb-$version /boot/dtb > /dev/null 2>&1 || mv /boot/dtb-$version /boot/dtb" >> $pdir/DEBIAN/postinst
-+		echo "exit 0" >> $pdir/DEBIAN/postinst
-+		chmod 775 $pdir/DEBIAN/postinst
++	cat >> $pdir/DEBIAN/preinst <<EOT
++rm -rf /boot/{dtb,dtb-$version}
++exit 0
++EOT
++
++	cat >> $pdir/DEBIAN/postinst <<EOT
++cd /boot
++ln -sfT dtb-$version dtb 2> /dev/null || mv dtb-$version dtb
++exit 0
++EOT
++
++	chmod 775 $pdir/DEBIAN/{preinst,postinst}
 +	fi
 +
-+	# Create postinstall script for headers
++	# Create postinst prerm scripts for headers
 +	if [ "$3" = "headers" ]; then
-+		echo "cd /usr/src/linux-headers-$version; echo \"Compiling headers - please wait ...\"; find -type f -exec touch {} +;make -s scripts >/dev/null; make -s M=scripts/mod/ >/dev/null" >> $pdir/DEBIAN/postinst
-+		echo "exit 0" >> $pdir/DEBIAN/postinst
-+		chmod 775 $pdir/DEBIAN/postinst
++
++cat >> $pdir/DEBIAN/postinst << EOT
++cd /usr/src/linux-headers-$version
++echo "Compiling headers - please wait ..."
++find -type f -exec touch {} +
++make -s scripts >/dev/null
++make -s M=scripts/mod/ >/dev/null
++exit 0
++EOT
++
++cat >> $pdir/DEBIAN/prerm << EOT
++cd /usr/src/linux-headers-$version
++rm -rf scripts .config.old
++EOT
++
++	chmod 775 $pdir/DEBIAN/{postinst,prerm}
 +	fi
 +
  	# Create the package
  	dpkg-gencontrol -p$pname -P"$pdir"
  	dpkg --build "$pdir" ..
-@@ -51,9 +72,11 @@ tmpdir="$objtree/debian/tmp"
+@@ -51,9 +88,11 @@ tmpdir="$objtree/debian/tmp"
  kernel_headers_dir="$objtree/debian/hdrtmp"
  libc_headers_dir="$objtree/debian/headertmp"
  dbg_dir="$objtree/debian/dbgtmp"
@@ -56,7 +85,7 @@ index 5858d6e44..e81b8a6fc 100644
  dbg_packagename=$packagename-dbg
  
  if [ "$ARCH" = "um" ] ; then
-@@ -64,6 +87,15 @@ fi
+@@ -64,6 +103,15 @@ fi
  # XXX: have each arch Makefile export a variable of the canonical image install
  # path instead
  case $ARCH in
@@ -72,7 +101,7 @@ index 5858d6e44..e81b8a6fc 100644
  um)
  	installed_image_path="usr/bin/linux-$version"
  	;;
-@@ -77,7 +109,9 @@ esac
+@@ -77,7 +125,9 @@ esac
  BUILD_DEBUG=$(if_enabled_echo CONFIG_DEBUG_INFO Yes)
  
  # Setup the directory structure
@@ -83,7 +112,7 @@ index 5858d6e44..e81b8a6fc 100644
  mkdir -m 755 -p "$tmpdir/DEBIAN"
  mkdir -p "$tmpdir/lib" "$tmpdir/boot"
  mkdir -p "$kernel_headers_dir/lib/modules/$version/"
-@@ -129,6 +163,11 @@ if is_enabled CONFIG_MODULES; then
+@@ -129,6 +179,11 @@ if is_enabled CONFIG_MODULES; then
  	fi
  fi
  
@@ -95,7 +124,7 @@ index 5858d6e44..e81b8a6fc 100644
  if [ "$ARCH" != "um" ]; then
  	$MAKE -f $srctree/Makefile headers
  	$MAKE -f $srctree/Makefile headers_install INSTALL_HDR_PATH="$libc_headers_dir/usr"
-@@ -148,7 +187,7 @@ debhookdir=${KDEB_HOOKDIR:-/etc/kernel}
+@@ -148,7 +203,7 @@ debhookdir=${KDEB_HOOKDIR:-/etc/kernel}
  for script in postinst postrm preinst prerm ; do
  	mkdir -p "$tmpdir$debhookdir/$script.d"
  	cat <<EOF > "$tmpdir/DEBIAN/$script"
@@ -104,7 +133,7 @@ index 5858d6e44..e81b8a6fc 100644
  
  set -e
  
-@@ -164,9 +203,58 @@ EOF
+@@ -164,9 +219,58 @@ EOF
  	chmod 755 "$tmpdir/DEBIAN/$script"
  done
  
@@ -163,7 +192,7 @@ index 5858d6e44..e81b8a6fc 100644
  (cd $srctree; find arch/$SRCARCH -name module.lds -o -name Kbuild.platforms -o -name Platform) >> "$objtree/debian/hdrsrcfiles"
  (cd $srctree; find $(find arch/$SRCARCH -name include -o -name scripts -type d) -type f) >> "$objtree/debian/hdrsrcfiles"
  if is_enabled CONFIG_STACK_VALIDATION; then
-@@ -178,15 +266,18 @@ if is_enabled CONFIG_GCC_PLUGINS; then
+@@ -178,15 +282,19 @@ if is_enabled CONFIG_GCC_PLUGINS; then
  fi
  destdir=$kernel_headers_dir/usr/src/linux-headers-$version
  mkdir -p "$destdir"
@@ -180,13 +209,16 @@ index 5858d6e44..e81b8a6fc 100644
 -	create_package "$kernel_headers_packagename" "$kernel_headers_dir"
 -	create_package "$libc_headers_packagename" "$libc_headers_dir"
 +	create_package "$kernel_headers_packagename" "$kernel_headers_dir" "headers"
++#UNCOMENT	create_package "$libc_headers_packagename" "$libc_headers_dir"
 +	create_package "$dtb_packagename" "$dtb_dir" "dtb"
  fi
  
  create_package "$packagename" "$tmpdir"
+diff --git a/scripts/package/mkdebian b/scripts/package/mkdebian
+index e0750b70453f..f6f1a7c09ce7 100755
 --- a/scripts/package/mkdebian
 +++ b/scripts/package/mkdebian
-@@ -94,10 +94,12 @@ else
+@@ -94,10 +94,13 @@ else
  	packageversion=$version-$revision
  fi
  sourcename=$KDEB_SOURCENAME
@@ -194,6 +226,7 @@ index 5858d6e44..e81b8a6fc 100644
 -kernel_headers_packagename=linux-headers-$version
 +packagename=linux-image-$BRANCH$LOCALVERSION
 +kernel_headers_packagename=linux-headers-$BRANCH$LOCALVERSION
++libc_headers_packagename=linux-libc-dev-$BRANCH$LOCALVERSION
 +dtb_packagename=linux-dtb-$BRANCH$LOCALVERSION
  dbg_packagename=$packagename-dbg
  debarch=
@@ -201,7 +234,7 @@ index 5858d6e44..e81b8a6fc 100644
  set_debarch
  
  if [ "$ARCH" = "um" ] ; then
-@@ -185,6 +187,7 @@ Description: Linux kernel, version $version
+@@ -185,12 +188,13 @@ Description: Linux kernel, version $version
  
  Package: $kernel_headers_packagename
  Architecture: $debarch
@@ -209,7 +242,14 @@ index 5858d6e44..e81b8a6fc 100644
  Description: Linux kernel headers for $version on $debarch
   This package provides kernel header files for $version on $debarch
   .
-@@ -205,6 +208,11 @@ Architecture: $debarch
+  This is useful for people who need to build external modules
+ 
+-Package: linux-libc-dev
++Package: $libc_headers_packagename
+ Section: devel
+ Provides: linux-kernel-headers
+ Architecture: $debarch
+@@ -205,6 +209,11 @@ Architecture: $debarch
  Description: Linux kernel debugging symbols for $version
   This package will come in handy if you need to debug the kernel. It provides
   all the necessary debug symbols for the kernel and its modules.
@@ -221,3 +261,6 @@ index 5858d6e44..e81b8a6fc 100644
  EOF
  
  cat <<EOF > debian/rules
+-- 
+2.16.4
+


### PR DESCRIPTION
After the 'linux-headers' package is installed,
the 'postinst' script makes changes to the target directory.
This behavior makes it impossible to delete the package
in the standard 'dpkg-r' way.
The 'dpkg-r' command fails and some directories and files remain.

This fix solves this problem.

This is tested for kernel 4.19.y 5.4.y