### PR TITLE
Delayed $SERIALCON config default value setup until use

### DIFF
--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -75,7 +75,6 @@ MAINLINE_UBOOT_DIR='u-boot'
 [[ -z $OFFSET ]] && OFFSET=4 # offset to 1st partition (we use 4MiB boundaries by default)
 ARCH=armhf
 KERNEL_IMAGE_TYPE=zImage
-[[ -z $SERIALCON ]] && SERIALCON=ttyS0
 CAN_BUILD_STRETCH=yes
 ATF_COMPILE=yes
 [[ -z $CRYPTROOT_SSH_UNLOCK ]] && CRYPTROOT_SSH_UNLOCK=yes

--- a/lib/distributions.sh
+++ b/lib/distributions.sh
@@ -295,7 +295,7 @@ install_common()
 	# example: SERIALCON="ttyS0:15000000,ttyGS1"
 	#
 	ifs=$IFS
-	for i in $(echo ${SERIALCON} | sed "s/,/ /g")
+	for i in $(echo ${SERIALCON:-'ttyS0'} | sed "s/,/ /g")
 	do
 		IFS=':' read -r -a array <<< "$i"
 		# add serial console to secure tty list


### PR DESCRIPTION
With https://github.com/armbian/build/pull/1793/commits/5b12e406f67b901aee194bdb4c5d95ab7f6fb882 I broke login on serial console in rockchip64 family.

With proposed change it is possible to set default serial console for family, override it per board if needed and evantually use default value if none was set for family or board.