### PR TITLE
Add `lighttpd` entries to `armbian-ramlog`

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-ramlog
+++ b/packages/bsp/common/usr/lib/armbian/armbian-ramlog
@@ -35,6 +35,8 @@ RecreateLogs (){
 		(mkdir -p /var/log/proftpd ; touch /var/log/proftpd/controls.log)
 	check_if_installed nginx && [ ! -d /var/log/nginx ] && \
 		(mkdir -p /var/log/nginx ; touch /var/log/nginx/access.log ; touch /var/log/nginx/error.log)
+	check_if_installed lighttpd && [ ! -d /var/log/lighttpd ] && \
+		(mkdir -p /var/log/lighttpd ; touch /var/log/lighttpd/access.log ; touch /var/log/lighttpd/error.log)
 	check_if_installed samba && [ ! -d /var/log/samba ] && mkdir -p /var/log/samba
 	check_if_installed unattended-upgrades && [ ! -d /var/log/unattended-upgrades ] && mkdir -p /var/log/unattended-upgrades
 	return 0


### PR DESCRIPTION
Adds entries for `lighthttpd` similar to `nginx`. This ***should*** solve boot issues with things like pihole's web interface.

