### PR TITLE
Fixed rt5651 sound output on OrangePi 4

### DIFF
--- a/patch/kernel/rockchip64-current/add-board-orangepi-4.patch
+++ b/patch/kernel/rockchip64-current/add-board-orangepi-4.patch
@@ -15,7 +15,7 @@ new file mode 100644
 index 00000000..17010305
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4.dts
-@@ -0,0 +1,1121 @@
+@@ -0,0 +1,1130 @@
 +/*
 + * SPDX-License-Identifier: (GPL-2.0+ or MIT)
 + * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd.
@@ -813,11 +813,14 @@ index 00000000..17010305
 +};
 +
 +&i2s1 {
-+	status = "okay";
-+	rockchip,i2s-broken-burst-len;
-+	rockchip,playback-channels = <8>;
-+	rockchip,capture-channels = <8>;
++	assigned-clocks = <&cru SCLK_I2SOUT_SRC>;
++	assigned-clock-parents = <&cru SCLK_I2S1_8CH>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2s_8ch_mclk>,<&i2s1_2ch_bus>;
++	rockchip,playback-channels = <2>;
++	rockchip,capture-channels = <2>;
 +	#sound-dai-cells = <0>;
++	status = "okay";
 +};
 +/*
 +&i2s0 {
@@ -1016,6 +1019,12 @@ index 00000000..17010305
 +
 +	hdmi {
 +		/delete-node/ hdmi-i2c-xfer;
++	};
++
++	i2s1 {
++		i2s_8ch_mclk: i2s-8ch-mclk {
++			rockchip,pins = <4 RK_PA0 RK_FUNC_1 &pcfg_pull_none>;
++		};
 +	};
 +
 +	pmic {

--- a/patch/kernel/rockchip64-current/general-rt5651-add-mclk.patch
+++ b/patch/kernel/rockchip64-current/general-rt5651-add-mclk.patch
@@ -1,0 +1,60 @@
+diff --git a/sound/soc/codecs/rt5651.c b/sound/soc/codecs/rt5651.c
+index c506c9305..41a08b320 100644
+--- a/sound/soc/codecs/rt5651.c
++++ b/sound/soc/codecs/rt5651.c
+@@ -24,6 +24,7 @@
+ #include <sound/initval.h>
+ #include <sound/tlv.h>
+ #include <sound/jack.h>
++#include <linux/clk.h>
+ 
+ #include "rl6231.h"
+ #include "rt5651.h"
+@@ -1511,6 +1512,7 @@ static int rt5651_set_dai_pll(struct snd_soc_dai *dai, int pll_id, int source,
+ static int rt5651_set_bias_level(struct snd_soc_component *component,
+ 			enum snd_soc_bias_level level)
+ {
++	struct rt5651_priv *rt5651 = snd_soc_component_get_drvdata(component);
+ 	switch (level) {
+ 	case SND_SOC_BIAS_PREPARE:
+ 		if (SND_SOC_BIAS_STANDBY == snd_soc_component_get_bias_level(component)) {
+@@ -1518,6 +1520,13 @@ static int rt5651_set_bias_level(struct snd_soc_component *component,
+ 				snd_soc_component_update_bits(component, RT5651_D_MISC,
+ 						    0xc00, 0xc00);
+ 		}
++		if (!IS_ERR(rt5651->mclk)){
++			if (snd_soc_component_get_bias_level(component) == SND_SOC_BIAS_ON) {
++				clk_disable_unprepare(rt5651->mclk);
++			} else {
++				clk_prepare_enable(rt5651->mclk);
++			}
++		}
+ 		break;
+ 	case SND_SOC_BIAS_STANDBY:
+ 		if (SND_SOC_BIAS_OFF == snd_soc_component_get_bias_level(component)) {
+@@ -2059,6 +2068,13 @@ static int rt5651_probe(struct snd_soc_component *component)
+ {
+ 	struct rt5651_priv *rt5651 = snd_soc_component_get_drvdata(component);
+ 
++	/* Check if MCLK provided */
++	rt5651->mclk = devm_clk_get(component->dev, "mclk");
++	if (PTR_ERR(rt5651->mclk) == -EPROBE_DEFER){
++		dev_err(component->dev, "unable to get mclk\n");
++		return -EPROBE_DEFER;
++	}
++
+ 	rt5651->component = component;
+ 
+ 	snd_soc_component_update_bits(component, RT5651_PWR_ANLG1,
+diff --git a/sound/soc/codecs/rt5651.h b/sound/soc/codecs/rt5651.h
+index 20c33a3ec..17524fa9f 100644
+--- a/sound/soc/codecs/rt5651.h
++++ b/sound/soc/codecs/rt5651.h
+@@ -2097,6 +2097,7 @@ struct rt5651_priv {
+ 
+ 	int dmic_en;
+ 	bool hp_mute;
++	struct clk *mclk;
+ };
+ 
+ #endif /* __RT5651_H__ */

--- a/patch/kernel/rockchip64-current/rk3399-add-sclk-i2sout-src-clock.patch
+++ b/patch/kernel/rockchip64-current/rk3399-add-sclk-i2sout-src-clock.patch
@@ -1,0 +1,25 @@
+diff --git a/drivers/clk/rockchip/clk-rk3399.c b/drivers/clk/rockchip/clk-rk3399.c
+index ce1d2446f..38447441b 100644
+--- a/drivers/clk/rockchip/clk-rk3399.c
++++ b/drivers/clk/rockchip/clk-rk3399.c
+@@ -620,7 +620,7 @@ static struct rockchip_clk_branch rk3399_clk_branches[] __initdata = {
+ 	GATE(SCLK_I2S2_8CH, "clk_i2s2", "clk_i2s2_mux", CLK_SET_RATE_PARENT,
+ 			RK3399_CLKGATE_CON(8), 11, GFLAGS),
+ 
+-	MUX(0, "clk_i2sout_src", mux_i2sch_p, CLK_SET_RATE_PARENT,
++	MUX(SCLK_I2SOUT_SRC, "clk_i2sout_src", mux_i2sch_p, CLK_SET_RATE_PARENT,
+ 			RK3399_CLKSEL_CON(31), 0, 2, MFLAGS),
+ 	COMPOSITE_NODIV(SCLK_I2S_8CH_OUT, "clk_i2sout", mux_i2sout_p, CLK_SET_RATE_PARENT,
+ 			RK3399_CLKSEL_CON(31), 2, 1, MFLAGS,
+diff --git a/include/dt-bindings/clock/rk3399-cru.h b/include/dt-bindings/clock/rk3399-cru.h
+index 44e0a319f..b7b07dfda 100644
+--- a/include/dt-bindings/clock/rk3399-cru.h
++++ b/include/dt-bindings/clock/rk3399-cru.h
+@@ -19,6 +19,7 @@
+ #define ARMCLKB				9
+ 
+ /* sclk gates (special clocks) */
++#define SCLK_I2SOUT_SRC			64
+ #define SCLK_I2C1			65
+ #define SCLK_I2C2			66
+ #define SCLK_I2C3			67

--- a/patch/kernel/rockchip64-dev/add-board-orangepi-4.patch
+++ b/patch/kernel/rockchip64-dev/add-board-orangepi-4.patch
@@ -15,7 +15,7 @@ new file mode 100644
 index 00000000..17010305
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4.dts
-@@ -0,0 +1,1121 @@
+@@ -0,0 +1,1130 @@
 +/*
 + * SPDX-License-Identifier: (GPL-2.0+ or MIT)
 + * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd.
@@ -813,11 +813,14 @@ index 00000000..17010305
 +};
 +
 +&i2s1 {
-+	status = "okay";
-+	rockchip,i2s-broken-burst-len;
-+	rockchip,playback-channels = <8>;
-+	rockchip,capture-channels = <8>;
++	assigned-clocks = <&cru SCLK_I2SOUT_SRC>;
++	assigned-clock-parents = <&cru SCLK_I2S1_8CH>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2s_8ch_mclk>,<&i2s1_2ch_bus>;
++	rockchip,playback-channels = <2>;
++	rockchip,capture-channels = <2>;
 +	#sound-dai-cells = <0>;
++	status = "okay";
 +};
 +/*
 +&i2s0 {
@@ -1016,6 +1019,12 @@ index 00000000..17010305
 +
 +	hdmi {
 +		/delete-node/ hdmi-i2c-xfer;
++	};
++
++	i2s1 {
++		i2s_8ch_mclk: i2s-8ch-mclk {
++			rockchip,pins = <4 RK_PA0 RK_FUNC_1 &pcfg_pull_none>;
++		};
 +	};
 +
 +	pmic {

--- a/patch/kernel/rockchip64-dev/general-rt5651-add-mclk.patch
+++ b/patch/kernel/rockchip64-dev/general-rt5651-add-mclk.patch
@@ -1,0 +1,60 @@
+diff --git a/sound/soc/codecs/rt5651.c b/sound/soc/codecs/rt5651.c
+index c506c9305..41a08b320 100644
+--- a/sound/soc/codecs/rt5651.c
++++ b/sound/soc/codecs/rt5651.c
+@@ -24,6 +24,7 @@
+ #include <sound/initval.h>
+ #include <sound/tlv.h>
+ #include <sound/jack.h>
++#include <linux/clk.h>
+ 
+ #include "rl6231.h"
+ #include "rt5651.h"
+@@ -1511,6 +1512,7 @@ static int rt5651_set_dai_pll(struct snd_soc_dai *dai, int pll_id, int source,
+ static int rt5651_set_bias_level(struct snd_soc_component *component,
+ 			enum snd_soc_bias_level level)
+ {
++	struct rt5651_priv *rt5651 = snd_soc_component_get_drvdata(component);
+ 	switch (level) {
+ 	case SND_SOC_BIAS_PREPARE:
+ 		if (SND_SOC_BIAS_STANDBY == snd_soc_component_get_bias_level(component)) {
+@@ -1518,6 +1520,13 @@ static int rt5651_set_bias_level(struct snd_soc_component *component,
+ 				snd_soc_component_update_bits(component, RT5651_D_MISC,
+ 						    0xc00, 0xc00);
+ 		}
++		if (!IS_ERR(rt5651->mclk)){
++			if (snd_soc_component_get_bias_level(component) == SND_SOC_BIAS_ON) {
++				clk_disable_unprepare(rt5651->mclk);
++			} else {
++				clk_prepare_enable(rt5651->mclk);
++			}
++		}
+ 		break;
+ 	case SND_SOC_BIAS_STANDBY:
+ 		if (SND_SOC_BIAS_OFF == snd_soc_component_get_bias_level(component)) {
+@@ -2059,6 +2068,13 @@ static int rt5651_probe(struct snd_soc_component *component)
+ {
+ 	struct rt5651_priv *rt5651 = snd_soc_component_get_drvdata(component);
+ 
++	/* Check if MCLK provided */
++	rt5651->mclk = devm_clk_get(component->dev, "mclk");
++	if (PTR_ERR(rt5651->mclk) == -EPROBE_DEFER){
++		dev_err(component->dev, "unable to get mclk\n");
++		return -EPROBE_DEFER;
++	}
++
+ 	rt5651->component = component;
+ 
+ 	snd_soc_component_update_bits(component, RT5651_PWR_ANLG1,
+diff --git a/sound/soc/codecs/rt5651.h b/sound/soc/codecs/rt5651.h
+index 20c33a3ec..17524fa9f 100644
+--- a/sound/soc/codecs/rt5651.h
++++ b/sound/soc/codecs/rt5651.h
+@@ -2097,6 +2097,7 @@ struct rt5651_priv {
+ 
+ 	int dmic_en;
+ 	bool hp_mute;
++	struct clk *mclk;
+ };
+ 
+ #endif /* __RT5651_H__ */

--- a/patch/kernel/rockchip64-dev/rk3399-add-sclk-i2sout-src-clock.patch
+++ b/patch/kernel/rockchip64-dev/rk3399-add-sclk-i2sout-src-clock.patch
@@ -1,0 +1,25 @@
+diff --git a/drivers/clk/rockchip/clk-rk3399.c b/drivers/clk/rockchip/clk-rk3399.c
+index ce1d2446f..38447441b 100644
+--- a/drivers/clk/rockchip/clk-rk3399.c
++++ b/drivers/clk/rockchip/clk-rk3399.c
+@@ -620,7 +620,7 @@ static struct rockchip_clk_branch rk3399_clk_branches[] __initdata = {
+ 	GATE(SCLK_I2S2_8CH, "clk_i2s2", "clk_i2s2_mux", CLK_SET_RATE_PARENT,
+ 			RK3399_CLKGATE_CON(8), 11, GFLAGS),
+ 
+-	MUX(0, "clk_i2sout_src", mux_i2sch_p, CLK_SET_RATE_PARENT,
++	MUX(SCLK_I2SOUT_SRC, "clk_i2sout_src", mux_i2sch_p, CLK_SET_RATE_PARENT,
+ 			RK3399_CLKSEL_CON(31), 0, 2, MFLAGS),
+ 	COMPOSITE_NODIV(SCLK_I2S_8CH_OUT, "clk_i2sout", mux_i2sout_p, CLK_SET_RATE_PARENT,
+ 			RK3399_CLKSEL_CON(31), 2, 1, MFLAGS,
+diff --git a/include/dt-bindings/clock/rk3399-cru.h b/include/dt-bindings/clock/rk3399-cru.h
+index 44e0a319f..b7b07dfda 100644
+--- a/include/dt-bindings/clock/rk3399-cru.h
++++ b/include/dt-bindings/clock/rk3399-cru.h
+@@ -19,6 +19,7 @@
+ #define ARMCLKB				9
+ 
+ /* sclk gates (special clocks) */
++#define SCLK_I2SOUT_SRC			64
+ #define SCLK_I2C1			65
+ #define SCLK_I2C2			66
+ #define SCLK_I2C3			67


### PR DESCRIPTION
[AR-205]

Based on the research of `iamdrq` in the [Armbian forums](https://forum.armbian.com/topic/13601-orange-pi-4-kernel-5xx-rt5651-sound-and-bluetooth-fixed/).

Tested with `dev` and `current`.

[AR-205]: https://armbian.atlassian.net/browse/AR-205