### PR TITLE
Add earlycon for early verbose boot messages.

### DIFF
--- a/config/bootscripts/boot-rockchip64.cmd
+++ b/config/bootscripts/boot-rockchip64.cmd
@@ -11,6 +11,7 @@ setenv verbosity "1"
 setenv console "both"
 setenv rootfstype "ext4"
 setenv docker_optimizations "on"
+setenv earlycon "off"
 
 echo "Boot script loaded from ${devtype} ${devnum}"
 
@@ -23,6 +24,7 @@ if test "${logo}" = "disabled"; then setenv logo "logo.nologo"; fi
 
 if test "${console}" = "display" || test "${console}" = "both"; then setenv consoleargs "console=tty1"; fi
 if test "${console}" = "serial" || test "${console}" = "both"; then setenv consoleargs "console=ttyS2,1500000 ${consoleargs}"; fi
+if test "${earlycon}" = "on"; then setenv consoleargs "earlycon ${consoleargs}"; fi
 
 # get PARTUUID of first partition on SD/eMMC the boot script was loaded from
 if test "${devtype}" = "mmc"; then part uuid mmc ${devnum}:1 partuuid; fi


### PR DESCRIPTION
This adds a disabled "earlycon" parameter to the boot config, so that it is obvous how to enable extra boot information when debugging bootup problems.

Note that I don't expect that this PR is in a mergable state as is. I expect you have other required quality gates or documentation that needs updating. I create this PR to illustrate my suggested change.

See my comments on the forum thread:
https://forum.armbian.com/topic/13435-rockpro64-boot-fails-if-fstab-has-volumes-on-pcie-ssd/?do=findComment&comment=98625
