### PR TITLE
[mvebu] Disable debian stretch image creation

### DIFF
--- a/config/targets.conf
+++ b/config/targets.conf
@@ -67,20 +67,20 @@ bananapipro			current			focal		cli			stable	yes
 bananapipro			current			buster		minimal			stable	yes
 
 # Helios4
-helios4				legacy			stretch		cli			stable	yes
+helios4				legacy			stretch		cli			stable	no
 helios4				current			buster		cli			stable	yes
 helios4				current			bionic		cli			stable	yes
-helios4				dev				stretch		cli			stable	no
+helios4				dev				buster		cli			stable	no
 
 # Clearfog Base
 clearfogbase			legacy			buster		cli			stable	yes
-clearfogbase			legacy			stretch		cli			stable	yes
+clearfogbase			legacy			stretch		cli			stable	no
 clearfogbase			current			buster		cli			stable	yes
 clearfogbase			current			bionic		cli			stable	yes
 
 # Clearfog Pro
 clearfogpro			legacy			buster		cli			stable	yes
-clearfogpro			legacy			stretch		cli			stable	yes
+clearfogpro			legacy			stretch		cli			stable	no
 clearfogpro			current			buster		cli			stable	yes
 clearfogpro			current			bionic		cli			stable	yes
 

--- a/config/targets.conf
+++ b/config/targets.conf
@@ -67,22 +67,25 @@ bananapipro			current			focal		cli			stable	yes
 bananapipro			current			buster		minimal			stable	yes
 
 # Helios4
-helios4				legacy			stretch		cli			stable	no
 helios4				current			buster		cli			stable	yes
 helios4				current			bionic		cli			stable	yes
+helios4				current			focal		cli			stable	yes
+helios4				current			bullseye	cli			stable	yes
 helios4				dev				buster		cli			stable	no
 
 # Clearfog Base
 clearfogbase			legacy			buster		cli			stable	yes
-clearfogbase			legacy			stretch		cli			stable	no
 clearfogbase			current			buster		cli			stable	yes
 clearfogbase			current			bionic		cli			stable	yes
+clearfogbase			current			focal		cli			stable	yes
+clearfogbase			current			bullseye	cli			stable	yes
 
 # Clearfog Pro
 clearfogpro			legacy			buster		cli			stable	yes
-clearfogpro			legacy			stretch		cli			stable	no
 clearfogpro			current			buster		cli			stable	yes
 clearfogpro			current			bionic		cli			stable	yes
+clearfogpro			current			focal		cli			stable	yes
+clearfogpro			current			bullseye	cli			stable	yes
 
 # Cubieboard1
 


### PR DESCRIPTION
Hi,

this changes targets.conf to disable build of debian stretch images for mvebu family.

https://armbian.atlassian.net/browse/AR-150

Should we also disable legacy in general? In my opinion lk4.19 (which will be legacy with 20.05) has no advantage over 5.4 (which will be current with 20.05)