### PR TITLE
Truncate logs: add -r to xargs to suppress calling with no arguments

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-truncate-logs
+++ b/packages/bsp/common/usr/lib/armbian/armbian-truncate-logs
@@ -22,9 +22,9 @@ if [ $logusage -ge $treshold ]; then
     # rotate logs on "disk"
     /usr/sbin/logrotate --force /etc/logrotate.conf
     # truncate
-    /usr/bin/find /var/log -name '*.log' -or -name '*.xz' -or -name 'lastlog' -or -name 'messages' -or -name 'debug' -or -name 'syslog' | xargs truncate --size 0 >/dev/null 2>&1
-    /usr/bin/find /var/log -name 'btmp' -or -name 'wtmp' -or -name 'faillog' -or -name 'firewalld' | xargs truncate --size 0 >/dev/null 2>&1
-    /usr/bin/find /var/log -name 'mail.err' -or -name 'mail.info' -or -name 'mail.warning' | xargs truncate --size 0 >/dev/null 2>&1
+    /usr/bin/find /var/log -name '*.log' -or -name '*.xz' -or -name 'lastlog' -or -name 'messages' -or -name 'debug' -or -name 'syslog' | xargs -r truncate --size 0
+    /usr/bin/find /var/log -name 'btmp' -or -name 'wtmp' -or -name 'faillog' -or -name 'firewalld' | xargs -r truncate --size 0
+    /usr/bin/find /var/log -name 'mail.err' -or -name 'mail.info' -or -name 'mail.warning' | xargs -r truncate --size 0
     # remove
-    /usr/bin/find /var/log -name '*.[0-9]' -or -name '*.gz' | xargs rm >/dev/null 2>&1
+    /usr/bin/find /var/log -name '*.[0-9]' -or -name '*.gz' | xargs -r rm -f
 fi


### PR DESCRIPTION
When using xargs, the default behaviour is to call the argument command even when no input is received on std in of xargs. This tends to generate error messages because command like truncate or xargs do not like being called without any argument.

Previously this has been suppressed by redirecting evertything into /dev/null, I think using xargs -r is much better way of doing it, and still allowing one to see real errors.
