### PR TITLE
Fix USB FEL, and working inside docker

### DIFF
--- a/config/templates/Dockerfile
+++ b/config/templates/Dockerfile
@@ -18,6 +18,11 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive apt -y upgrade && \
 	libc6-i386 lib32ncurses5 lib32tinfo5 locales ncurses-base zlib1g:i386 pixz bison libbison-dev flex libfl-dev \
 	pigz aptly aria2 cryptsetup cryptsetup-bin python3-distutils --no-install-recommends
 RUN locale-gen en_US.UTF-8
+
+# Static port for NFSv3 server used for USB FEL boot
+RUN sed -i 's/\(^STATDOPTS=\).*/\1"--port 32765 --outgoing-port 32766"/' /etc/default/nfs-common && \
+  sed -i 's/\(^RPCMOUNTDOPTS=\).*/\1"--port 32767"/' /etc/default/nfs-kernel-server
+
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8' TERM=screen
 WORKDIR /root/armbian
 ENTRYPOINT [ "/bin/bash", "/root/armbian/compile.sh" ]

--- a/config/templates/config-docker.conf
+++ b/config/templates/config-docker.conf
@@ -30,6 +30,7 @@ fi
 DOCKER_FLAGS=()
 
 # Running this container in privileged mode is a simple way to solve loop device access issues
+# Required for USB FEL
 #DOCKER_FLAGS+=(--privileged)
 
 # add only required capabilities instead (though MKNOD should be already present)
@@ -69,6 +70,11 @@ else
   display_alert "Your Docker version does not support device-cgroup-rule" "" "wrn"
   display_alert "and will be able to create only Kernel and u-boot packages (KERNEL_ONLY=yes)" "" "wrn"
 fi
+
+# Expose ports for NFS server inside docker container, required for USB FEL
+#DOCKER_FLAGS+=(-p 0.0.0.0:2049:2049 -p 0.0.0.0:2049:2049/udp -p 0.0.0.0:111:111 -p 0.0.0.0:111:111/udp -p 0.0.0.0:32765:32765 -p 0.0.0.0:32765:32765/udp -p 0.0.0.0:32767:32767 -p 0.0.0.0:32767:32767/udp)
+# Export usb device for FEL, required for USB FEL
+#DOCKER_FLAGS+=(-v /dev/bus/usb:/dev/bus/usb:ro)
 
 # map source to Docker Working dir.
 DOCKER_FLAGS+=(-v=$SRC/:/root/armbian/)


### PR DESCRIPTION
Fixing weird `sunxi-fel` failed with `Invalid command -p`
* I remove `""` fixing this problem, I don't know if there is a issue inside the parsing options in sunxi-fel command or in the bach script itself.

For docker
* Add static port configuration for NFSv3 server used for USB FEL boot
* Add needed flags in docker template