### PR TITLE
fix linux 5.7 package building

### DIFF
--- a/patch/misc/general-packaging-5.6.y.patch
+++ b/patch/misc/general-packaging-5.6.y.patch
@@ -254,23 +254,18 @@ index 6df3c9f..d33e1f3 100755
  set_debarch
  
  if [ "$ARCH" = "um" ] ; then
-@@ -185,6 +187,7 @@ Description: Linux kernel, version $version
+@@ -183,8 +185,14 @@ Description: Linux kernel, version $version
+  This package contains the Linux kernel, modules and corresponding other
+  files, version: $version.
  
++Package: $dtb_packagename
++Architecture: $debarch
++Description: Linux DTB, version $version
++ This package contains device blobs from the Linux kernel, version $version
++
  Package: $kernel_headers_packagename
  Architecture: $debarch
 +Depends: make, gcc, libc6-dev, bison, flex, libssl-dev
  Description: Linux kernel headers for $version on $debarch
   This package provides kernel header files for $version on $debarch
   .
-@@ -205,6 +208,11 @@ Architecture: $debarch
- Description: Linux kernel debugging symbols for $version
-  This package will come in handy if you need to debug the kernel. It provides
-  all the necessary debug symbols for the kernel and its modules.
-+
-+Package: $dtb_packagename
-+Architecture: $debarch
-+Description: Linux DTB, version $version
-+ This package contains device blobs from the Linux kernel, version $version
- EOF
- 
- cat <<EOF > debian/rules


### PR DESCRIPTION
Fixing general-packaging-5.6.y.patch so we can build packages for linux kernel 5.7

Problem was in patch for mkdebian
as new version from 5.7 kernel add if condition
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/scripts/package/mkdebian?h=v5.7-rc2#n203
so git merge it to condition part
and whole description about dtb package missing 

I moved package description so we have same patch 5.6 and 5.7

tested on 5.6 and 5.7 linux kernel