### PR TITLE
Add support for Odroid c4

### DIFF
--- a/config/boards/odroidc4.conf
+++ b/config/boards/odroidc4.conf
@@ -1,0 +1,7 @@
+# S905X3 quad core 4GB RAM SoC eMMC GBE USB3 SPI
+BOARD_NAME="Odroid C4"
+BOARDFAMILY="meson-sm1"
+BOOTCONFIG="odroid-c4_defconfig"
+KERNEL_TARGET="current,dev"
+FULL_DESKTOP="yes"
+SERIALCON="ttyAML0"

--- a/config/sources/families/include/meson64_common.inc
+++ b/config/sources/families/include/meson64_common.inc
@@ -68,6 +68,82 @@ uboot_gxl_postprocess()
 				--bl33 bl33.bin.enc
 }
 
+# this helper function includes postprocess for u200 and its variants.
+# $1 PATH for uboot blob repo
+# $2 family g12a or g12b
+uboot_g12_postprocess()
+{
+	mv u-boot.bin bl33.bin
+
+	$1/blx_fix.sh $1/bl30.bin \
+		      zero_tmp \
+		      bl30_zero.bin \
+		      $1/bl301.bin \
+		      bl301_zero.bin \
+		      bl30_new.bin bl30
+
+	$1/blx_fix.sh $1/bl2.bin \
+		      zero_tmp \
+		      bl2_zero.bin \
+		      $1/acs.bin \
+		      bl21_zero.bin \
+		      bl2_new.bin bl2
+
+	$1/aml_encrypt_$2 --bl30sig \
+			    --input bl30_new.bin \
+			    --output bl30_new.bin.g12.enc \
+			    --level v3
+	$1/aml_encrypt_$2 --bl3sig \
+			    --input bl30_new.bin.g12.enc \
+			    --output bl30_new.bin.enc \
+			    --level v3 --type bl30
+	$1/aml_encrypt_$2 --bl3sig \
+			    --input $1/bl31.img \
+			    --output bl31.img.enc \
+			    --level v3 --type bl31
+	$1/aml_encrypt_$2 --bl3sig \
+			    --input bl33.bin \
+			    --compress lz4 \
+			    --output bl33.bin.enc \
+			    --level v3 --type bl33
+	$1/aml_encrypt_$2 --bl2sig \
+			    --input bl2_new.bin \
+			    --output bl2.n.bin.sig
+	if [ -e $1/lpddr3_1d.fw ]
+		then
+			$1/aml_encrypt_g12a --bootmk --output u-boot.bin \
+			--bl2 bl2.n.bin.sig \
+			--bl30 bl30_new.bin.enc \
+			--bl31 bl31.img.enc \
+			--bl33 bl33.bin.enc \
+			--ddrfw1 $1/ddr4_1d.fw \
+			--ddrfw2 $1/ddr4_2d.fw \
+			--ddrfw3 $1/ddr3_1d.fw \
+			--ddrfw4 $1/piei.fw \
+			--ddrfw5 $1/lpddr4_1d.fw \
+			--ddrfw6 $1/lpddr4_2d.fw \
+			--ddrfw7 $1/diag_lpddr4.fw \
+			--ddrfw8 $1/aml_ddr.fw \
+			--ddrfw9 $1/lpddr3_1d.fw \
+			--level v3
+	else
+		$1/aml_encrypt_g12a --bootmk  --output u-boot.bin \
+			--bl2 bl2.n.bin.sig \
+			--bl30 bl30_new.bin.enc \
+			--bl31 bl31.img.enc \
+			--bl33 bl33.bin.enc \
+			--ddrfw1 $1/ddr4_1d.fw \
+			--ddrfw2 $1/ddr4_2d.fw \
+			--ddrfw3 $1/ddr3_1d.fw \
+			--ddrfw4 $1/piei.fw \
+			--ddrfw5 $1/lpddr4_1d.fw \
+			--ddrfw6 $1/lpddr4_2d.fw \
+			--ddrfw7 $1/diag_lpddr4.fw \
+			--ddrfw8 $1/aml_ddr.fw \
+			--level v3
+	fi
+}
+
 write_uboot_platform()
 {
 	dd if=$1/u-boot.bin of=$2 bs=1 count=442 conv=fsync > /dev/null 2>&1

--- a/config/sources/families/meson-sm1.conf
+++ b/config/sources/families/meson-sm1.conf
@@ -1,0 +1,13 @@
+source "${BASH_SOURCE%/*}/include/meson64_common.inc"
+
+family_tweaks()
+{
+	:
+}
+
+uboot_custom_postprocess()
+{
+	if [[ $BOARD == odroidc4 ]]; then
+		uboot_g12_postprocess $SRC/cache/sources/amlogic-boot-fip/odroid-c4 g12a
+	fi
+}

--- a/config/targets.conf
+++ b/config/targets.conf
@@ -457,6 +457,16 @@ odroidn2			current			bullseye		cli			stable	yes
 odroidn2			current			focal		cli			stable	yes
 odroidn2			dev			focal	minimal			beta	yes
 
+# Odroid C4
+
+odroidc4			current			buster		cli			stable	yes
+odroidc4			current			buster		desktop			stable	yes
+odroidc4			current			stretch		cli			stable	yes
+odroidc4			current			bionic		desktop			stable	yes
+odroidc4			current			bullseye		cli			stable	yes
+odroidc4			current			focal		cli			stable	yes
+odroidc4			dev			focal	minimal			beta	yes
+
 # Odroid XU4
 
 odroidxu4			legacy			buster		cli			stable	yes

--- a/lib/main.sh
+++ b/lib/main.sh
@@ -410,6 +410,7 @@ if [[ $IGNORE_UPDATES != yes ]]; then
 	fetch_from_repo "https://github.com/MarvellEmbeddedProcessors/binaries-marvell" "marvell-binaries" "branch:binaries-marvell-armada-18.12"
 	fetch_from_repo "https://github.com/armbian/odroidc2-blobs" "odroidc2-blobs" "branch:master"
 	fetch_from_repo "https://github.com/armbian/testings" "testing-reports" "branch:master"
+	fetch_from_repo "https://gitlab.com/superna9999/amlogic-boot-fip" "amlogic-boot-fip" "branch:master"
 fi
 
 compile_sunxi_tools

--- a/patch/kernel/meson64-current/0002-arm64-dts-meson-sm1-add-support-for-Hardkernel-ODROI.patch
+++ b/patch/kernel/meson64-current/0002-arm64-dts-meson-sm1-add-support-for-Hardkernel-ODROI.patch
@@ -1,0 +1,435 @@
+From e2ee8474ca020935d2dee7cf3493a5d5084dc975 Mon Sep 17 00:00:00 2001
+From: Dongjin Kim <tobetter@gmail.com>
+Date: Sun, 15 Mar 2020 02:15:06 +0900
+Subject: [PATCH] arm64: dts: meson-sm1: add support for Hardkernel ODROID-C4
+
+Add the board support for the Hardkernel Odroid-C4 single board computer.
+
+The Odroid-C4 is the Odroid-C2 successor with same form factor, but using
+a modern Amlogic S905X3 (SM1) SoC and 4x USB3 ports.
+
+Signed-off-by: Dongjin Kim <tobetter@gmail.com>
+Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>
+---
+ arch/arm64/boot/dts/amlogic/Makefile          |   1 +
+ .../boot/dts/amlogic/meson-sm1-odroid-c4.dts  | 399 ++++++++++++++++++
+ 2 files changed, 400 insertions(+)
+ create mode 100755 arch/arm64/boot/dts/amlogic/meson-sm1-odroid-c4.dts
+
+diff --git a/arch/arm64/boot/dts/amlogic/Makefile b/arch/arm64/boot/dts/amlogic/Makefile
+index 84afecba9..1d2fe850e 100644
+--- a/arch/arm64/boot/dts/amlogic/Makefile
++++ b/arch/arm64/boot/dts/amlogic/Makefile
+@@ -36,3 +36,4 @@ dtb-$(CONFIG_ARCH_MESON) += meson-gxm-rbox-pro.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-gxm-vega-s96.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-sm1-sei610.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-sm1-khadas-vim3l.dtb
++dtb-$(CONFIG_ARCH_MESON) += meson-sm1-odroid-c4.dtb
+diff --git a/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-c4.dts b/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-c4.dts
+new file mode 100755
+index 000000000..221572a77
+--- /dev/null
++++ b/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-c4.dts
+@@ -0,0 +1,399 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2020 Dongjin Kim <tobetter@gmail.com>
++ */
++
++/dts-v1/;
++
++#include "meson-sm1.dtsi"
++#include <dt-bindings/gpio/meson-g12a-gpio.h>
++#include <dt-bindings/leds/common.h>
++
++/ {
++	compatible = "hardkernel,odroid-c4", "amlogic,sm1";
++	model = "Hardkernel ODROID-C4";
++
++	aliases {
++		serial0 = &uart_AO;
++		ethernet0 = &ethmac;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	memory@0 {
++		device_type = "memory";
++		reg = <0x0 0x0 0x0 0x40000000>;
++	};
++
++	emmc_pwrseq: emmc-pwrseq {
++		compatible = "mmc-pwrseq-emmc";
++		reset-gpios = <&gpio BOOT_12 GPIO_ACTIVE_LOW>;
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led-blue {
++			color = <LED_COLOR_ID_BLUE>;
++			function = LED_FUNCTION_STATUS;
++			gpios = <&gpio_ao GPIOAO_11 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "heartbeat";
++			panic-indicator;
++		};
++	};
++
++	tflash_vdd: regulator-tflash_vdd {
++		compatible = "regulator-fixed";
++
++		regulator-name = "TFLASH_VDD";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++
++		gpio = <&gpio_ao GPIOAO_3 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++		regulator-always-on;
++	};
++
++	tf_io: gpio-regulator-tf_io {
++		compatible = "regulator-gpio";
++
++		regulator-name = "TF_IO";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <3300000>;
++
++		gpios = <&gpio_ao GPIOAO_6 GPIO_ACTIVE_HIGH>;
++		gpios-states = <0>;
++
++		states = <3300000 0>,
++			 <1800000 1>;
++	};
++
++	flash_1v8: regulator-flash_1v8 {
++		compatible = "regulator-fixed";
++		regulator-name = "FLASH_1V8";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vcc_3v3>;
++		regulator-always-on;
++	};
++
++	main_12v: regulator-main_12v {
++		compatible = "regulator-fixed";
++		regulator-name = "12V";
++		regulator-min-microvolt = <12000000>;
++		regulator-max-microvolt = <12000000>;
++		regulator-always-on;
++	};
++
++	vcc_5v: regulator-vcc_5v {
++		compatible = "regulator-fixed";
++		regulator-name = "5V";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		regulator-always-on;
++		vin-supply = <&main_12v>;
++	};
++
++	vcc_1v8: regulator-vcc_1v8 {
++		compatible = "regulator-fixed";
++		regulator-name = "VCC_1V8";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vcc_3v3>;
++		regulator-always-on;
++	};
++
++	vcc_3v3: regulator-vcc_3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "VCC_3V3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vddao_3v3>;
++		regulator-always-on;
++		/* FIXME: actually controlled by VDDCPU_B_EN */
++	};
++
++	vddcpu: regulator-vddcpu {
++		/*
++		 * MP8756GD Regulator.
++		 */
++		compatible = "pwm-regulator";
++
++		regulator-name = "VDDCPU";
++		regulator-min-microvolt = <721000>;
++		regulator-max-microvolt = <1022000>;
++
++		vin-supply = <&main_12v>;
++
++		pwms = <&pwm_AO_cd 1 1250 0>;
++		pwm-dutycycle-range = <100 0>;
++
++		regulator-boot-on;
++		regulator-always-on;
++	};
++
++	hub_5v: regulator-hub_5v {
++		compatible = "regulator-fixed";
++		regulator-name = "HUB_5V";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc_5v>;
++
++		/* Connected to the Hub CHIPENABLE, LOW sets low power state */
++		gpio = <&gpio GPIOH_4 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++	};
++
++	usb_pwr_en: regulator-usb_pwr_en {
++		compatible = "regulator-fixed";
++		regulator-name = "USB_PWR_EN";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc_5v>;
++
++		/* Connected to the microUSB port power enable */
++		gpio = <&gpio_ao GPIOAO_2 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++	};
++
++	vddao_1v8: regulator-vddao_1v8 {
++		compatible = "regulator-fixed";
++		regulator-name = "VDDAO_1V8";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vddao_3v3>;
++		regulator-always-on;
++	};
++
++	vddao_3v3: regulator-vddao_3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "VDDAO_3V3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&main_12v>;
++		regulator-always-on;
++	};
++
++	hdmi-connector {
++		compatible = "hdmi-connector";
++		type = "a";
++
++		port {
++			hdmi_connector_in: endpoint {
++				remote-endpoint = <&hdmi_tx_tmds_out>;
++			};
++		};
++	};
++};
++
++&cpu0 {
++	cpu-supply = <&vddcpu>;
++	operating-points-v2 = <&cpu_opp_table>;
++	clocks = <&clkc CLKID_CPU_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu1 {
++	cpu-supply = <&vddcpu>;
++	operating-points-v2 = <&cpu_opp_table>;
++	clocks = <&clkc CLKID_CPU1_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu2 {
++	cpu-supply = <&vddcpu>;
++	operating-points-v2 = <&cpu_opp_table>;
++	clocks = <&clkc CLKID_CPU2_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu3 {
++	cpu-supply = <&vddcpu>;
++	operating-points-v2 = <&cpu_opp_table>;
++	clocks = <&clkc CLKID_CPU3_CLK>;
++	clock-latency = <50000>;
++};
++
++&ext_mdio {
++	external_phy: ethernet-phy@0 {
++		/* Realtek RTL8211F (0x001cc916) */
++		reg = <0>;
++		max-speed = <1000>;
++
++		reset-assert-us = <10000>;
++		reset-deassert-us = <30000>;
++		reset-gpios = <&gpio GPIOZ_15 (GPIO_ACTIVE_LOW | GPIO_OPEN_DRAIN)>;
++
++		interrupt-parent = <&gpio_intc>;
++		/* MAC_INTR on GPIOZ_14 */
++		interrupts = <26 IRQ_TYPE_LEVEL_LOW>;
++	};
++};
++
++&ethmac {
++	pinctrl-0 = <&eth_pins>, <&eth_rgmii_pins>;
++	pinctrl-names = "default";
++	status = "okay";
++	phy-mode = "rgmii";
++	phy-handle = <&external_phy>;
++	amlogic,tx-delay-ns = <2>;
++};
++
++&gpio {
++	gpio-line-names =
++		/* GPIOZ */
++		"", "", "", "", "", "", "", "",
++		"", "", "", "", "", "", "", "",
++		/* GPIOH */
++		"", "", "", "", "",
++		"PIN_36", /* GPIOH_5 */
++		"PIN_26", /* GPIOH_6 */
++		"PIN_32", /* GPIOH_7 */
++		"",
++		/* BOOT */
++		"", "", "", "", "", "", "", "",
++		"", "", "", "", "", "", "", "",
++		/* GPIOC */
++		"", "", "", "", "", "", "", "",
++		/* GPIOA */
++		"", "", "", "", "", "", "", "",
++		"", "", "", "", "", "",
++		"PIN_27", /* GPIOA_14 */
++		"PIN_28", /* GPIOA_15 */
++		/* GPIOX */
++		"PIN_16", /* GPIOX_0 */
++		"PIN_18", /* GPIOX_1 */
++		"PIN_22", /* GPIOX_2 */
++		"PIN_11", /* GPIOX_3 */
++		"PIN_13", /* GPIOX_4 */
++		"PIN_7",  /* GPIOX_5 */
++		"PIN_33", /* GPIOX_6 */
++		"PIN_15", /* GPIOX_7 */
++		"PIN_19", /* GPIOX_8 */
++		"PIN_21", /* GPIOX_9 */
++		"PIN_24", /* GPIOX_10 */
++		"PIN_23", /* GPIOX_11 */
++		"PIN_8",  /* GPIOX_12 */
++		"PIN_10", /* GPIOX_13 */
++		"PIN_29", /* GPIOX_14 */
++		"PIN_31", /* GPIOX_15 */
++		"PIN_12", /* GPIOX_16 */
++		"PIN_3",  /* GPIOX_17 */
++		"PIN_5",  /* GPIOX_18 */
++		"PIN_35"; /* GPIOX_19 */
++
++	/*
++	 * WARNING: The USB Hub on the Odroid-C4 needs a reset signal
++	 * to be turned high in order to be detected by the USB Controller
++	 * This signal should be handled by a USB specific power sequence
++	 * in order to reset the Hub when USB bus is powered down.
++	 */
++	usb-hub {
++		gpio-hog;
++		gpios = <GPIOH_4 GPIO_ACTIVE_HIGH>;
++		output-high;
++		line-name = "usb-hub-reset";
++	};
++};
++
++&gpio_ao {
++	gpio-line-names =
++		/* GPIOAO */
++		"", "", "", "",
++		"PIN_47", /* GPIOAO_4 */
++		"", "",
++		"PIN_45", /* GPIOAO_7 */
++		"PIN_46", /* GPIOAO_8 */
++		"PIN_44", /* GPIOAO_9 */
++		"PIN_42", /* GPIOAO_10 */
++		"",
++		/* GPIOE */
++		"", "", "";
++};
++
++&hdmi_tx {
++	status = "okay";
++	pinctrl-0 = <&hdmitx_hpd_pins>, <&hdmitx_ddc_pins>;
++	pinctrl-names = "default";
++	hdmi-supply = <&vcc_5v>;
++};
++
++&hdmi_tx_tmds_port {
++	hdmi_tx_tmds_out: endpoint {
++		remote-endpoint = <&hdmi_connector_in>;
++	};
++};
++
++&pwm_AO_cd {
++	pinctrl-0 = <&pwm_ao_d_e_pins>;
++	pinctrl-names = "default";
++	clocks = <&xtal>;
++	clock-names = "clkin1";
++	status = "okay";
++};
++
++&saradc {
++	status = "okay";
++};
++
++/* SD card */
++&sd_emmc_b {
++	status = "okay";
++	pinctrl-0 = <&sdcard_c_pins>;
++	pinctrl-1 = <&sdcard_clk_gate_c_pins>;
++	pinctrl-names = "default", "clk-gate";
++
++	bus-width = <4>;
++	cap-sd-highspeed;
++	max-frequency = <200000000>;
++	sd-uhs-sdr12;
++	sd-uhs-sdr25;
++	sd-uhs-sdr50;
++	sd-uhs-sdr104;
++	disable-wp;
++
++	cd-gpios = <&gpio GPIOC_6 GPIO_ACTIVE_LOW>;
++	vmmc-supply = <&tflash_vdd>;
++	vqmmc-supply = <&tf_io>;
++};
++
++/* eMMC */
++&sd_emmc_c {
++	status = "okay";
++	pinctrl-0 = <&emmc_pins>, <&emmc_ds_pins>;
++	pinctrl-1 = <&emmc_clk_gate_pins>;
++	pinctrl-names = "default", "clk-gate";
++
++	bus-width = <8>;
++	cap-mmc-highspeed;
++	mmc-ddr-1_8v;
++	mmc-hs200-1_8v;
++	max-frequency = <200000000>;
++	disable-wp;
++
++	mmc-pwrseq = <&emmc_pwrseq>;
++	vmmc-supply = <&vcc_3v3>;
++	vqmmc-supply = <&flash_1v8>;
++};
++
++&uart_AO {
++	status = "okay";
++	pinctrl-0 = <&uart_ao_a_pins>;
++	pinctrl-names = "default";
++};
++
++&usb {
++	status = "okay";
++	vbus-supply = <&usb_pwr_en>;
++};
++
++&usb2_phy0 {
++	phy-supply = <&vcc_5v>;
++};
++
++&usb2_phy1 {
++	/* Enable the hub which is connected to this port */
++	phy-supply = <&hub_5v>;
++};
+-- 
+2.22.0
+

--- a/patch/kernel/meson64-dev/0002-arm64-dts-meson-sm1-add-support-for-Hardkernel-ODROI.patch
+++ b/patch/kernel/meson64-dev/0002-arm64-dts-meson-sm1-add-support-for-Hardkernel-ODROI.patch
@@ -1,0 +1,437 @@
+From db954006ffe8ce711f43ed562b7fe93ad26bef7d Mon Sep 17 00:00:00 2001
+From: Dongjin Kim <tobetter@gmail.com>
+Date: Sun, 15 Mar 2020 02:15:06 +0900
+Subject: [PATCH 2/2] arm64: dts: meson-sm1: add support for Hardkernel
+ ODROID-C4
+
+Add the board support for the Hardkernel Odroid-C4 single board computer.
+
+The Odroid-C4 is the Odroid-C2 successor with same form factor, but using
+a modern Amlogic S905X3 (SM1) SoC and 4x USB3 ports.
+
+Signed-off-by: Dongjin Kim <tobetter@gmail.com>
+Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>
+---
+ arch/arm64/boot/dts/amlogic/Makefile          |   1 +
+ .../boot/dts/amlogic/meson-sm1-odroid-c4.dts  | 399 ++++++++++++++++++
+ 2 files changed, 400 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/amlogic/meson-sm1-odroid-c4.dts
+
+diff --git a/arch/arm64/boot/dts/amlogic/Makefile b/arch/arm64/boot/dts/amlogic/Makefile
+index eef0045320f2..5daab72f5639 100644
+--- a/arch/arm64/boot/dts/amlogic/Makefile
++++ b/arch/arm64/boot/dts/amlogic/Makefile
+@@ -40,4 +40,5 @@ dtb-$(CONFIG_ARCH_MESON) += meson-gxm-s912-libretech-pc.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-gxm-vega-s96.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-sm1-sei610.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-sm1-khadas-vim3l.dtb
++dtb-$(CONFIG_ARCH_MESON) += meson-sm1-odroid-c4.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-a1-ad401.dtb
+diff --git a/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-c4.dts b/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-c4.dts
+new file mode 100644
+index 000000000000..4882c604a7e0
+--- /dev/null
++++ b/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-c4.dts
+@@ -0,0 +1,399 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2020 Dongjin Kim <tobetter@gmail.com>
++ */
++
++/dts-v1/;
++
++#include "meson-sm1.dtsi"
++#include <dt-bindings/gpio/meson-g12a-gpio.h>
++#include <dt-bindings/leds/common.h>
++
++/ {
++	compatible = "hardkernel,odroid-c4", "amlogic,sm1";
++	model = "Hardkernel ODROID-C4";
++
++	aliases {
++		serial0 = &uart_AO;
++		ethernet0 = &ethmac;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	memory@0 {
++		device_type = "memory";
++		reg = <0x0 0x0 0x0 0x40000000>;
++	};
++
++	emmc_pwrseq: emmc-pwrseq {
++		compatible = "mmc-pwrseq-emmc";
++		reset-gpios = <&gpio BOOT_12 GPIO_ACTIVE_LOW>;
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led-blue {
++			color = <LED_COLOR_ID_BLUE>;
++			function = LED_FUNCTION_STATUS;
++			gpios = <&gpio_ao GPIOAO_11 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "heartbeat";
++			panic-indicator;
++		};
++	};
++
++	tflash_vdd: regulator-tflash_vdd {
++		compatible = "regulator-fixed";
++
++		regulator-name = "TFLASH_VDD";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++
++		gpio = <&gpio_ao GPIOAO_3 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++		regulator-always-on;
++	};
++
++	tf_io: gpio-regulator-tf_io {
++		compatible = "regulator-gpio";
++
++		regulator-name = "TF_IO";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <3300000>;
++
++		gpios = <&gpio_ao GPIOAO_6 GPIO_ACTIVE_HIGH>;
++		gpios-states = <0>;
++
++		states = <3300000 0>,
++			 <1800000 1>;
++	};
++
++	flash_1v8: regulator-flash_1v8 {
++		compatible = "regulator-fixed";
++		regulator-name = "FLASH_1V8";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vcc_3v3>;
++		regulator-always-on;
++	};
++
++	main_12v: regulator-main_12v {
++		compatible = "regulator-fixed";
++		regulator-name = "12V";
++		regulator-min-microvolt = <12000000>;
++		regulator-max-microvolt = <12000000>;
++		regulator-always-on;
++	};
++
++	vcc_5v: regulator-vcc_5v {
++		compatible = "regulator-fixed";
++		regulator-name = "5V";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		regulator-always-on;
++		vin-supply = <&main_12v>;
++	};
++
++	vcc_1v8: regulator-vcc_1v8 {
++		compatible = "regulator-fixed";
++		regulator-name = "VCC_1V8";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vcc_3v3>;
++		regulator-always-on;
++	};
++
++	vcc_3v3: regulator-vcc_3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "VCC_3V3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vddao_3v3>;
++		regulator-always-on;
++		/* FIXME: actually controlled by VDDCPU_B_EN */
++	};
++
++	vddcpu: regulator-vddcpu {
++		/*
++		 * MP8756GD Regulator.
++		 */
++		compatible = "pwm-regulator";
++
++		regulator-name = "VDDCPU";
++		regulator-min-microvolt = <721000>;
++		regulator-max-microvolt = <1022000>;
++
++		vin-supply = <&main_12v>;
++
++		pwms = <&pwm_AO_cd 1 1250 0>;
++		pwm-dutycycle-range = <100 0>;
++
++		regulator-boot-on;
++		regulator-always-on;
++	};
++
++	hub_5v: regulator-hub_5v {
++		compatible = "regulator-fixed";
++		regulator-name = "HUB_5V";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc_5v>;
++
++		/* Connected to the Hub CHIPENABLE, LOW sets low power state */
++		gpio = <&gpio GPIOH_4 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++	};
++
++	usb_pwr_en: regulator-usb_pwr_en {
++		compatible = "regulator-fixed";
++		regulator-name = "USB_PWR_EN";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc_5v>;
++
++		/* Connected to the microUSB port power enable */
++		gpio = <&gpio_ao GPIOAO_2 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++	};
++
++	vddao_1v8: regulator-vddao_1v8 {
++		compatible = "regulator-fixed";
++		regulator-name = "VDDAO_1V8";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vddao_3v3>;
++		regulator-always-on;
++	};
++
++	vddao_3v3: regulator-vddao_3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "VDDAO_3V3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&main_12v>;
++		regulator-always-on;
++	};
++
++	hdmi-connector {
++		compatible = "hdmi-connector";
++		type = "a";
++
++		port {
++			hdmi_connector_in: endpoint {
++				remote-endpoint = <&hdmi_tx_tmds_out>;
++			};
++		};
++	};
++};
++
++&cpu0 {
++	cpu-supply = <&vddcpu>;
++	operating-points-v2 = <&cpu_opp_table>;
++	clocks = <&clkc CLKID_CPU_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu1 {
++	cpu-supply = <&vddcpu>;
++	operating-points-v2 = <&cpu_opp_table>;
++	clocks = <&clkc CLKID_CPU1_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu2 {
++	cpu-supply = <&vddcpu>;
++	operating-points-v2 = <&cpu_opp_table>;
++	clocks = <&clkc CLKID_CPU2_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu3 {
++	cpu-supply = <&vddcpu>;
++	operating-points-v2 = <&cpu_opp_table>;
++	clocks = <&clkc CLKID_CPU3_CLK>;
++	clock-latency = <50000>;
++};
++
++&ext_mdio {
++	external_phy: ethernet-phy@0 {
++		/* Realtek RTL8211F (0x001cc916) */
++		reg = <0>;
++		max-speed = <1000>;
++
++		reset-assert-us = <10000>;
++		reset-deassert-us = <30000>;
++		reset-gpios = <&gpio GPIOZ_15 (GPIO_ACTIVE_LOW | GPIO_OPEN_DRAIN)>;
++
++		interrupt-parent = <&gpio_intc>;
++		/* MAC_INTR on GPIOZ_14 */
++		interrupts = <26 IRQ_TYPE_LEVEL_LOW>;
++	};
++};
++
++&ethmac {
++	pinctrl-0 = <&eth_pins>, <&eth_rgmii_pins>;
++	pinctrl-names = "default";
++	status = "okay";
++	phy-mode = "rgmii";
++	phy-handle = <&external_phy>;
++	amlogic,tx-delay-ns = <2>;
++};
++
++&gpio {
++	gpio-line-names =
++		/* GPIOZ */
++		"", "", "", "", "", "", "", "",
++		"", "", "", "", "", "", "", "",
++		/* GPIOH */
++		"", "", "", "", "",
++		"PIN_36", /* GPIOH_5 */
++		"PIN_26", /* GPIOH_6 */
++		"PIN_32", /* GPIOH_7 */
++		"",
++		/* BOOT */
++		"", "", "", "", "", "", "", "",
++		"", "", "", "", "", "", "", "",
++		/* GPIOC */
++		"", "", "", "", "", "", "", "",
++		/* GPIOA */
++		"", "", "", "", "", "", "", "",
++		"", "", "", "", "", "",
++		"PIN_27", /* GPIOA_14 */
++		"PIN_28", /* GPIOA_15 */
++		/* GPIOX */
++		"PIN_16", /* GPIOX_0 */
++		"PIN_18", /* GPIOX_1 */
++		"PIN_22", /* GPIOX_2 */
++		"PIN_11", /* GPIOX_3 */
++		"PIN_13", /* GPIOX_4 */
++		"PIN_7",  /* GPIOX_5 */
++		"PIN_33", /* GPIOX_6 */
++		"PIN_15", /* GPIOX_7 */
++		"PIN_19", /* GPIOX_8 */
++		"PIN_21", /* GPIOX_9 */
++		"PIN_24", /* GPIOX_10 */
++		"PIN_23", /* GPIOX_11 */
++		"PIN_8",  /* GPIOX_12 */
++		"PIN_10", /* GPIOX_13 */
++		"PIN_29", /* GPIOX_14 */
++		"PIN_31", /* GPIOX_15 */
++		"PIN_12", /* GPIOX_16 */
++		"PIN_3",  /* GPIOX_17 */
++		"PIN_5",  /* GPIOX_18 */
++		"PIN_35"; /* GPIOX_19 */
++
++	/*
++	 * WARNING: The USB Hub on the Odroid-C4 needs a reset signal
++	 * to be turned high in order to be detected by the USB Controller
++	 * This signal should be handled by a USB specific power sequence
++	 * in order to reset the Hub when USB bus is powered down.
++	 */
++	usb-hub {
++		gpio-hog;
++		gpios = <GPIOH_4 GPIO_ACTIVE_HIGH>;
++		output-high;
++		line-name = "usb-hub-reset";
++	};
++};
++
++&gpio_ao {
++	gpio-line-names =
++		/* GPIOAO */
++		"", "", "", "",
++		"PIN_47", /* GPIOAO_4 */
++		"", "",
++		"PIN_45", /* GPIOAO_7 */
++		"PIN_46", /* GPIOAO_8 */
++		"PIN_44", /* GPIOAO_9 */
++		"PIN_42", /* GPIOAO_10 */
++		"",
++		/* GPIOE */
++		"", "", "";
++};
++
++&hdmi_tx {
++	status = "okay";
++	pinctrl-0 = <&hdmitx_hpd_pins>, <&hdmitx_ddc_pins>;
++	pinctrl-names = "default";
++	hdmi-supply = <&vcc_5v>;
++};
++
++&hdmi_tx_tmds_port {
++	hdmi_tx_tmds_out: endpoint {
++		remote-endpoint = <&hdmi_connector_in>;
++	};
++};
++
++&pwm_AO_cd {
++	pinctrl-0 = <&pwm_ao_d_e_pins>;
++	pinctrl-names = "default";
++	clocks = <&xtal>;
++	clock-names = "clkin1";
++	status = "okay";
++};
++
++&saradc {
++	status = "okay";
++};
++
++/* SD card */
++&sd_emmc_b {
++	status = "okay";
++	pinctrl-0 = <&sdcard_c_pins>;
++	pinctrl-1 = <&sdcard_clk_gate_c_pins>;
++	pinctrl-names = "default", "clk-gate";
++
++	bus-width = <4>;
++	cap-sd-highspeed;
++	max-frequency = <200000000>;
++	sd-uhs-sdr12;
++	sd-uhs-sdr25;
++	sd-uhs-sdr50;
++	sd-uhs-sdr104;
++	disable-wp;
++
++	cd-gpios = <&gpio GPIOC_6 GPIO_ACTIVE_LOW>;
++	vmmc-supply = <&tflash_vdd>;
++	vqmmc-supply = <&tf_io>;
++};
++
++/* eMMC */
++&sd_emmc_c {
++	status = "okay";
++	pinctrl-0 = <&emmc_ctrl_pins>, <&emmc_data_8b_pins>, <&emmc_ds_pins>;
++	pinctrl-1 = <&emmc_clk_gate_pins>;
++	pinctrl-names = "default", "clk-gate";
++
++	bus-width = <8>;
++	cap-mmc-highspeed;
++	mmc-ddr-1_8v;
++	mmc-hs200-1_8v;
++	max-frequency = <200000000>;
++	disable-wp;
++
++	mmc-pwrseq = <&emmc_pwrseq>;
++	vmmc-supply = <&vcc_3v3>;
++	vqmmc-supply = <&flash_1v8>;
++};
++
++&uart_AO {
++	status = "okay";
++	pinctrl-0 = <&uart_ao_a_pins>;
++	pinctrl-names = "default";
++};
++
++&usb {
++	status = "okay";
++	vbus-supply = <&usb_pwr_en>;
++};
++
++&usb2_phy0 {
++	phy-supply = <&vcc_5v>;
++};
++
++&usb2_phy1 {
++	/* Enable the hub which is connected to this port */
++	phy-supply = <&hub_5v>;
++};
+-- 
+2.22.0
+

--- a/patch/u-boot/u-boot-meson64/0001-ARM-dts-Import-Odroid-C4-DT-from-Linux-5.X.patch
+++ b/patch/u-boot/u-boot-meson64/0001-ARM-dts-Import-Odroid-C4-DT-from-Linux-5.X.patch
@@ -1,0 +1,419 @@
+From e59c5fca47c82b85f232fc9e182df387d6c34dfd Mon Sep 17 00:00:00 2001
+From: Christian Hewitt <christianshewitt@gmail.com>
+Date: Fri, 24 Apr 2020 02:58:30 +0000
+Subject: [PATCH 1/3] ARM: dts: Import Odroid C4 DT from Linux 5.X
+
+Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>
+---
+ arch/arm/dts/Makefile                |   1 +
+ arch/arm/dts/meson-sm1-odroid-c4.dts | 386 +++++++++++++++++++++++++++
+ 2 files changed, 387 insertions(+)
+ create mode 100755 arch/arm/dts/meson-sm1-odroid-c4.dts
+
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index 820ee973..7dee4c51 100644
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -154,6 +154,7 @@ dtb-$(CONFIG_ARCH_MESON) += \
+ 	meson-g12b-odroid-n2.dtb \
+ 	meson-g12b-a311d-khadas-vim3.dtb \
+ 	meson-sm1-khadas-vim3l.dtb \
++	meson-sm1-odroid-c4.dtb \
+ 	meson-sm1-sei610.dtb
+ dtb-$(CONFIG_TEGRA) += tegra20-harmony.dtb \
+ 	tegra20-medcom-wide.dtb \
+diff --git a/arch/arm/dts/meson-sm1-odroid-c4.dts b/arch/arm/dts/meson-sm1-odroid-c4.dts
+new file mode 100755
+index 00000000..f4e19710
+--- /dev/null
++++ b/arch/arm/dts/meson-sm1-odroid-c4.dts
+@@ -0,0 +1,386 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2020 Dongjin Kim <tobetter@gmail.com>
++ */
++
++/dts-v1/;
++
++#include "meson-sm1.dtsi"
++#include <dt-bindings/gpio/meson-g12a-gpio.h>
++
++/ {
++	compatible = "hardkernel,odroid-c4", "amlogic,sm1";
++	model = "Hardkernel ODROID-C4";
++
++	aliases {
++		serial0 = &uart_AO;
++		ethernet0 = &ethmac;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	memory@0 {
++		device_type = "memory";
++		reg = <0x0 0x0 0x0 0x40000000>;
++	};
++
++	emmc_pwrseq: emmc-pwrseq {
++		compatible = "mmc-pwrseq-emmc";
++		reset-gpios = <&gpio BOOT_12 GPIO_ACTIVE_LOW>;
++	};
++
++	tflash_vdd: regulator-tflash_vdd {
++		compatible = "regulator-fixed";
++
++		regulator-name = "TFLASH_VDD";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++
++		gpio = <&gpio_ao GPIOAO_3 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++		regulator-always-on;
++	};
++
++	tf_io: gpio-regulator-tf_io {
++		compatible = "regulator-gpio";
++
++		regulator-name = "TF_IO";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <3300000>;
++
++		gpios = <&gpio_ao GPIOAO_6 GPIO_ACTIVE_HIGH>;
++		gpios-states = <0>;
++
++		states = <3300000 0>,
++			 <1800000 1>;
++	};
++
++	flash_1v8: regulator-flash_1v8 {
++		compatible = "regulator-fixed";
++		regulator-name = "FLASH_1V8";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vcc_3v3>;
++		regulator-always-on;
++	};
++
++	main_12v: regulator-main_12v {
++		compatible = "regulator-fixed";
++		regulator-name = "12V";
++		regulator-min-microvolt = <12000000>;
++		regulator-max-microvolt = <12000000>;
++		regulator-always-on;
++	};
++
++	vcc_5v: regulator-vcc_5v {
++		compatible = "regulator-fixed";
++		regulator-name = "5V";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		regulator-always-on;
++		vin-supply = <&main_12v>;
++	};
++
++	vcc_1v8: regulator-vcc_1v8 {
++		compatible = "regulator-fixed";
++		regulator-name = "VCC_1V8";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vcc_3v3>;
++		regulator-always-on;
++	};
++
++	vcc_3v3: regulator-vcc_3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "VCC_3V3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vddao_3v3>;
++		regulator-always-on;
++		/* FIXME: actually controlled by VDDCPU_B_EN */
++	};
++
++	vddcpu: regulator-vddcpu {
++		/*
++		 * MP8756GD Regulator.
++		 */
++		compatible = "pwm-regulator";
++
++		regulator-name = "VDDCPU";
++		regulator-min-microvolt = <721000>;
++		regulator-max-microvolt = <1022000>;
++
++		vin-supply = <&main_12v>;
++
++		pwms = <&pwm_AO_cd 1 1250 0>;
++		pwm-dutycycle-range = <100 0>;
++
++		regulator-boot-on;
++		regulator-always-on;
++	};
++
++	hub_5v: regulator-hub_5v {
++		compatible = "regulator-fixed";
++		regulator-name = "HUB_5V";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc_5v>;
++
++		/* Connected to the Hub CHIPENABLE, LOW sets low power state */
++		gpio = <&gpio GPIOH_4 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++	};
++
++	usb_pwr_en: regulator-usb_pwr_en {
++		compatible = "regulator-fixed";
++		regulator-name = "USB_PWR_EN";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc_5v>;
++
++		/* Connected to the microUSB port power enable */
++		gpio = <&gpio_ao GPIOAO_2 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++	};
++
++	vddao_1v8: regulator-vddao_1v8 {
++		compatible = "regulator-fixed";
++		regulator-name = "VDDAO_1V8";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vddao_3v3>;
++		regulator-always-on;
++	};
++
++	vddao_3v3: regulator-vddao_3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "VDDAO_3V3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&main_12v>;
++		regulator-always-on;
++	};
++
++	hdmi-connector {
++		compatible = "hdmi-connector";
++		type = "a";
++
++		port {
++			hdmi_connector_in: endpoint {
++				remote-endpoint = <&hdmi_tx_tmds_out>;
++			};
++		};
++	};
++};
++
++&cpu0 {
++	cpu-supply = <&vddcpu>;
++	operating-points-v2 = <&cpu_opp_table>;
++	clocks = <&clkc CLKID_CPU_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu1 {
++	cpu-supply = <&vddcpu>;
++	operating-points-v2 = <&cpu_opp_table>;
++	clocks = <&clkc CLKID_CPU1_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu2 {
++	cpu-supply = <&vddcpu>;
++	operating-points-v2 = <&cpu_opp_table>;
++	clocks = <&clkc CLKID_CPU2_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu3 {
++	cpu-supply = <&vddcpu>;
++	operating-points-v2 = <&cpu_opp_table>;
++	clocks = <&clkc CLKID_CPU3_CLK>;
++	clock-latency = <50000>;
++};
++
++&ext_mdio {
++	external_phy: ethernet-phy@0 {
++		/* Realtek RTL8211F (0x001cc916) */
++		reg = <0>;
++		max-speed = <1000>;
++
++		reset-assert-us = <10000>;
++		reset-deassert-us = <30000>;
++		reset-gpios = <&gpio GPIOZ_15 (GPIO_ACTIVE_LOW | GPIO_OPEN_DRAIN)>;
++
++		interrupt-parent = <&gpio_intc>;
++		/* MAC_INTR on GPIOZ_14 */
++		interrupts = <26 IRQ_TYPE_LEVEL_LOW>;
++	};
++};
++
++&ethmac {
++	pinctrl-0 = <&eth_pins>, <&eth_rgmii_pins>;
++	pinctrl-names = "default";
++	status = "okay";
++	phy-mode = "rgmii";
++	phy-handle = <&external_phy>;
++	amlogic,tx-delay-ns = <2>;
++};
++
++&gpio {
++	gpio-line-names =
++		/* GPIOZ */
++		"", "", "", "", "", "", "", "",
++		"", "", "", "", "", "", "", "",
++		/* GPIOH */
++		"", "", "", "", "",
++		"PIN_36", /* GPIOH_5 */
++		"PIN_26", /* GPIOH_6 */
++		"PIN_32", /* GPIOH_7 */
++		"",
++		/* BOOT */
++		"", "", "", "", "", "", "", "",
++		"", "", "", "", "", "", "", "",
++		/* GPIOC */
++		"", "", "", "", "", "", "", "",
++		/* GPIOA */
++		"", "", "", "", "", "", "", "",
++		"", "", "", "", "", "",
++		"PIN_27", /* GPIOA_14 */
++		"PIN_28", /* GPIOA_15 */
++		/* GPIOX */
++		"PIN_16", /* GPIOX_0 */
++		"PIN_18", /* GPIOX_1 */
++		"PIN_22", /* GPIOX_2 */
++		"PIN_11", /* GPIOX_3 */
++		"PIN_13", /* GPIOX_4 */
++		"PIN_7",  /* GPIOX_5 */
++		"PIN_33", /* GPIOX_6 */
++		"PIN_15", /* GPIOX_7 */
++		"PIN_19", /* GPIOX_8 */
++		"PIN_21", /* GPIOX_9 */
++		"PIN_24", /* GPIOX_10 */
++		"PIN_23", /* GPIOX_11 */
++		"PIN_8",  /* GPIOX_12 */
++		"PIN_10", /* GPIOX_13 */
++		"PIN_29", /* GPIOX_14 */
++		"PIN_31", /* GPIOX_15 */
++		"PIN_12", /* GPIOX_16 */
++		"PIN_3",  /* GPIOX_17 */
++		"PIN_5",  /* GPIOX_18 */
++		"PIN_35"; /* GPIOX_19 */
++
++	/*
++	 * WARNING: The USB Hub on the Odroid-C4 needs a reset signal
++	 * to be turned high in order to be detected by the USB Controller
++	 * This signal should be handled by a USB specific power sequence
++	 * in order to reset the Hub when USB bus is powered down.
++	 */
++	usb-hub {
++		gpio-hog;
++		gpios = <GPIOH_4 GPIO_ACTIVE_HIGH>;
++		output-high;
++		line-name = "usb-hub-reset";
++	};
++};
++
++&gpio_ao {
++	gpio-line-names =
++		/* GPIOAO */
++		"", "", "", "",
++		"PIN_47", /* GPIOAO_4 */
++		"", "",
++		"PIN_45", /* GPIOAO_7 */
++		"PIN_46", /* GPIOAO_8 */
++		"PIN_44", /* GPIOAO_9 */
++		"PIN_42", /* GPIOAO_10 */
++		"",
++		/* GPIOE */
++		"", "", "";
++};
++
++&hdmi_tx {
++	status = "okay";
++	pinctrl-0 = <&hdmitx_hpd_pins>, <&hdmitx_ddc_pins>;
++	pinctrl-names = "default";
++	hdmi-supply = <&vcc_5v>;
++};
++
++&hdmi_tx_tmds_port {
++	hdmi_tx_tmds_out: endpoint {
++		remote-endpoint = <&hdmi_connector_in>;
++	};
++};
++
++&pwm_AO_cd {
++	pinctrl-0 = <&pwm_ao_d_e_pins>;
++	pinctrl-names = "default";
++	clocks = <&xtal>;
++	clock-names = "clkin1";
++	status = "okay";
++};
++
++&saradc {
++	status = "okay";
++};
++
++/* SD card */
++&sd_emmc_b {
++	status = "okay";
++	pinctrl-0 = <&sdcard_c_pins>;
++	pinctrl-1 = <&sdcard_clk_gate_c_pins>;
++	pinctrl-names = "default", "clk-gate";
++
++	bus-width = <4>;
++	cap-sd-highspeed;
++	max-frequency = <200000000>;
++	sd-uhs-sdr12;
++	sd-uhs-sdr25;
++	sd-uhs-sdr50;
++	sd-uhs-sdr104;
++	disable-wp;
++
++	cd-gpios = <&gpio GPIOC_6 GPIO_ACTIVE_LOW>;
++	vmmc-supply = <&tflash_vdd>;
++	vqmmc-supply = <&tf_io>;
++};
++
++/* eMMC */
++&sd_emmc_c {
++	status = "okay";
++	pinctrl-0 = <&emmc_pins>, <&emmc_ds_pins>;
++	pinctrl-1 = <&emmc_clk_gate_pins>;
++	pinctrl-names = "default", "clk-gate";
++
++	bus-width = <8>;
++	cap-mmc-highspeed;
++	mmc-ddr-1_8v;
++	mmc-hs200-1_8v;
++	max-frequency = <200000000>;
++	disable-wp;
++
++	mmc-pwrseq = <&emmc_pwrseq>;
++	vmmc-supply = <&vcc_3v3>;
++	vqmmc-supply = <&flash_1v8>;
++};
++
++&uart_AO {
++	status = "okay";
++	pinctrl-0 = <&uart_ao_a_pins>;
++	pinctrl-names = "default";
++};
++
++&usb {
++	status = "okay";
++	vbus-supply = <&usb_pwr_en>;
++};
++
++&usb2_phy0 {
++	phy-supply = <&vcc_5v>;
++};
++
++&usb2_phy1 {
++	/* Enable the hub which is connected to this port */
++	phy-supply = <&hub_5v>;
++};
+-- 
+2.22.0
+

--- a/patch/u-boot/u-boot-meson64/0002-boards-amlogic-add-Odroid-C4-support.patch
+++ b/patch/u-boot/u-boot-meson64/0002-boards-amlogic-add-Odroid-C4-support.patch
@@ -1,0 +1,238 @@
+From 9af545e2824df54e8cef7f3a62d96c37360cb0a0 Mon Sep 17 00:00:00 2001
+From: Christian Hewitt <christianshewitt@gmail.com>
+Date: Fri, 24 Apr 2020 03:09:12 +0000
+Subject: [PATCH 2/3] boards: amlogic: add Odroid C4 support
+
+Odroid C4 is an SM1 device, the board config is adapted from VIM3L and
+README is based on the README.odroid-n2 from the same vendor.
+
+Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
+Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>
+---
+ board/amlogic/w400/MAINTAINERS      |   1 +
+ board/amlogic/w400/README.odroid-c4 | 134 ++++++++++++++++++++++++++++
+ configs/odroid-c4_defconfig         |  62 +++++++++++++
+ 3 files changed, 197 insertions(+)
+ create mode 100644 board/amlogic/w400/README.odroid-c4
+ create mode 100644 configs/odroid-c4_defconfig
+
+diff --git a/board/amlogic/w400/MAINTAINERS b/board/amlogic/w400/MAINTAINERS
+index 2ff90039..b28dd7f0 100644
+--- a/board/amlogic/w400/MAINTAINERS
++++ b/board/amlogic/w400/MAINTAINERS
+@@ -6,3 +6,4 @@ F:	board/amlogic/w400/
+ F:	configs/khadas-vim3_defconfig
+ F:	configs/khadas-vim3l_defconfig
+ F:	configs/odroid-n2_defconfig
++F:	configs/odroid-c4_defconfig
+diff --git a/board/amlogic/w400/README.odroid-c4 b/board/amlogic/w400/README.odroid-c4
+new file mode 100644
+index 00000000..b1bca758
+--- /dev/null
++++ b/board/amlogic/w400/README.odroid-c4
+@@ -0,0 +1,134 @@
++U-Boot for ODROID-C4
++====================
++
++ODROID-N2 is a single board computer manufactured by Hardkernel
++Co. Ltd with the following specifications:
++
++ - Amlogic S905X3 Arm Cortex-A55 quad-core SoC
++ - 2GB or 4GB LPDDR4 SDRAM
++ - Gigabit Ethernet
++ - HDMI 2.1 display
++ - 40-pin GPIO header
++ - 7-pin GPIO expansion header
++ - 4x USB 3.0 Host
++ - 1x USB 2.0 Host/OTG (micro)
++ - eMMC, microSD
++ - UART serial
++ - Infrared receiver
++
++Schematics are available on the manufacturer website.
++
++Currently the U-Boot port supports the following devices:
++ - serial
++ - eMMC, microSD
++ - Ethernet
++ - I2C
++ - Regulators
++ - Reset controller
++ - Clock controller
++ - ADC
++
++u-boot compilation
++==================
++
++ > export ARCH=arm
++ > export CROSS_COMPILE=aarch64-none-elf-
++ > make odroid-c4_defconfig
++ > make
++
++Image creation
++==============
++
++Amlogic doesn't provide sources for the firmware and for tools needed
++to create the bootloader image, so it is necessary to obtain them from
++the git tree published by the board vendor:
++
++ > wget https://releases.linaro.org/archive/13.11/components/toolchain/binaries/gcc-linaro-aarch64-none-elf-4.8-2013.11_linux.tar.xz
++ > wget https://releases.linaro.org/archive/14.04/components/toolchain/binaries/gcc-linaro-arm-none-eabi-4.8-2014.04_linux.tar.xz
++ > tar xvfJ gcc-linaro-aarch64-none-elf-4.8-2013.11_linux.tar.xz
++ > tar xvf gcc-linaro-arm-none-eabi-4.8-2014.04_linux.tar.xz
++ > export PATH=$PWD/gcc-linaro-aarch64-none-elf-4.8-2013.11_linux/bin:$PWD/gcc-linaro-arm-none-eabi-4.8-2014.04_linux/bin:$PATH
++
++ > DIR=odroidc4-u-boot
++ > git clone --depth 1 \
++       https://github.com/hardkernel/u-boot.git -b odroidg12-v2015.01 \
++       $DIR
++
++ > cd odroidc4-u-boot
++ > make odroidc4_defconfig
++ > make
++ > export UBOOTDIR=$PWD
++
++ Go back to mainline U-Boot source tree then :
++ > mkdir fip
++
++ > cp $UBOOTDIR/build/scp_task/bl301.bin fip/
++ > cp $UBOOTDIR/build/board/hardkernel/odroidc4/firmware/acs.bin fip/
++ > cp $UBOOTDIR/fip/g12a/bl2.bin fip/
++ > cp $UBOOTDIR/fip/g12a/bl30.bin fip/
++ > cp $UBOOTDIR/fip/g12a/bl31.img fip/
++ > cp $UBOOTDIR/fip/g12a/ddr3_1d.fw fip/
++ > cp $UBOOTDIR/fip/g12a/ddr4_1d.fw fip/
++ > cp $UBOOTDIR/fip/g12a/ddr4_2d.fw fip/
++ > cp $UBOOTDIR/fip/g12a/diag_lpddr4.fw fip/
++ > cp $UBOOTDIR/fip/g12a/lpddr3_1d.fw fip/
++ > cp $UBOOTDIR/fip/g12a/lpddr4_1d.fw fip/
++ > cp $UBOOTDIR/fip/g12a/lpddr4_2d.fw fip/
++ > cp $UBOOTDIR/fip/g12a/piei.fw fip/
++ > cp $UBOOTDIR/fip/g12a/aml_ddr.fw fip/
++ > cp u-boot.bin fip/bl33.bin
++
++ > sh fip/blx_fix.sh \
++	fip/bl30.bin \
++	fip/zero_tmp \
++	fip/bl30_zero.bin \
++	fip/bl301.bin \
++	fip/bl301_zero.bin \
++	fip/bl30_new.bin \
++	bl30
++
++ > sh fip/blx_fix.sh \
++	fip/bl2.bin \
++	fip/zero_tmp \
++	fip/bl2_zero.bin \
++	fip/acs.bin \
++	fip/bl21_zero.bin \
++	fip/bl2_new.bin \
++	bl2
++
++ > $UBOOTDIR/fip/g12a/aml_encrypt_g12a --bl30sig --input fip/bl30_new.bin \
++					--output fip/bl30_new.bin.g12a.enc \
++					--level v3
++ > $UBOOTDIR/fip/g12a/aml_encrypt_g12a --bl3sig --input fip/bl30_new.bin.g12a.enc \
++					--output fip/bl30_new.bin.enc \
++					--level v3 --type bl30
++ > $UBOOTDIR/fip/g12a/aml_encrypt_g12a --bl3sig --input fip/bl31.img \
++					--output fip/bl31.img.enc \
++					--level v3 --type bl31
++ > $UBOOTDIR/fip/g12a/aml_encrypt_g12a --bl3sig --input fip/bl33.bin --compress lz4 \
++					--output fip/bl33.bin.enc \
++					--level v3 --type bl33 --compress lz4
++ > $UBOOTDIR/fip/g12a/aml_encrypt_g12a --bl2sig --input fip/bl2_new.bin \
++					--output fip/bl2.n.bin.sig
++ > $UBOOTDIR/fip/g12a/aml_encrypt_g12a --bootmk \
++		--output fip/u-boot.bin \
++		--bl2 fip/bl2.n.bin.sig \
++		--bl30 fip/bl30_new.bin.enc \
++		--bl31 fip/bl31.img.enc \
++		--bl33 fip/bl33.bin.enc \
++		--ddrfw1 fip/ddr4_1d.fw \
++		--ddrfw2 fip/ddr4_2d.fw \
++		--ddrfw3 fip/ddr3_1d.fw \
++		--ddrfw4 fip/piei.fw \
++		--ddrfw5 fip/lpddr4_1d.fw \
++		--ddrfw6 fip/lpddr4_2d.fw \
++		--ddrfw7 fip/diag_lpddr4.fw \
++		--ddrfw8 fip/aml_ddr.fw \
++		--ddrfw9 fip/lpddr3_1d.fw \
++		--level v3
++
++and then write the image to SD with:
++
++ > DEV=/dev/your_sd_device
++ > dd if=fip/u-boot.bin.sd.bin of=$DEV conv=fsync,notrunc bs=512 skip=1 seek=1
++ > dd if=fip/u-boot.bin.sd.bin of=$DEV conv=fsync,notrunc bs=1 count=444
+diff --git a/configs/odroid-c4_defconfig b/configs/odroid-c4_defconfig
+new file mode 100644
+index 00000000..ab7d588e
+--- /dev/null
++++ b/configs/odroid-c4_defconfig
+@@ -0,0 +1,62 @@
++CONFIG_ARM=y
++CONFIG_SYS_BOARD="w400"
++CONFIG_ARCH_MESON=y
++CONFIG_SYS_TEXT_BASE=0x01000000
++CONFIG_ENV_SIZE=0x2000
++CONFIG_DM_GPIO=y
++CONFIG_MESON_G12A=y
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_DEBUG_UART_BASE=0xff803000
++CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_IDENT_STRING=" odroid-c4"
++CONFIG_DEBUG_UART=y
++CONFIG_OF_BOARD_SETUP=y
++CONFIG_MISC_INIT_R=y
++# CONFIG_DISPLAY_CPUINFO is not set
++# CONFIG_CMD_BDI is not set
++# CONFIG_CMD_IMI is not set
++CONFIG_CMD_GPIO=y
++# CONFIG_CMD_LOADS is not set
++CONFIG_CMD_MMC=y
++CONFIG_CMD_USB=y
++CONFIG_CMD_USB_MASS_STORAGE=y
++# CONFIG_CMD_SETEXPR is not set
++CONFIG_CMD_REGULATOR=y
++CONFIG_OF_CONTROL=y
++CONFIG_DEFAULT_DEVICE_TREE="meson-sm1-odroid-c4"
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_NET_RANDOM_ETHADDR=y
++CONFIG_DM_MMC=y
++CONFIG_MMC_MESON_GX=y
++CONFIG_PHY_REALTEK=y
++CONFIG_DM_ETH=y
++CONFIG_ETH_DESIGNWARE=y
++CONFIG_MESON_G12A_USB_PHY=y
++CONFIG_PINCTRL=y
++CONFIG_PINCTRL_MESON_G12A=y
++CONFIG_POWER_DOMAIN=y
++CONFIG_MESON_EE_POWER_DOMAIN=y
++CONFIG_DM_REGULATOR=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_DM_RESET=y
++CONFIG_DEBUG_UART_MESON=y
++CONFIG_DEBUG_UART_ANNOUNCE=y
++CONFIG_DEBUG_UART_SKIP_INIT=y
++CONFIG_MESON_SERIAL=y
++CONFIG_USB=y
++CONFIG_DM_USB=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_XHCI_DWC3=y
++CONFIG_USB_DWC3=y
++# CONFIG_USB_DWC3_GADGET is not set
++CONFIG_USB_DWC3_MESON_G12A=y
++CONFIG_USB_GADGET=y
++CONFIG_USB_GADGET_VENDOR_NUM=0x1b8e
++CONFIG_USB_GADGET_PRODUCT_NUM=0xfada
++CONFIG_USB_GADGET_DWC2_OTG=y
++CONFIG_USB_GADGET_DWC2_OTG_PHY_BUS_WIDTH_8=y
++CONFIG_USB_GADGET_DOWNLOAD=y
++CONFIG_DM_VIDEO=y
++CONFIG_VIDEO_MESON=y
++CONFIG_VIDEO_DT_SIMPLEFB=y
++CONFIG_OF_LIBFDT_OVERLAY=y
+-- 
+2.22.0
+

--- a/patch/u-boot/u-boot-meson64/0003-HACK-mmc-meson-gx-limit-to-24MHz.patch
+++ b/patch/u-boot/u-boot-meson64/0003-HACK-mmc-meson-gx-limit-to-24MHz.patch
@@ -1,0 +1,26 @@
+From 64017a2cc9e501329016d50b701c5e9a9488991d Mon Sep 17 00:00:00 2001
+From: Neil Armstrong <narmstrong@baylibre.com>
+Date: Mon, 2 Sep 2019 15:42:04 +0200
+Subject: [PATCH 3/3] HACK: mmc: meson-gx: limit to 24MHz
+
+Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>
+---
+ drivers/mmc/meson_gx_mmc.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/mmc/meson_gx_mmc.c b/drivers/mmc/meson_gx_mmc.c
+index b5f5122b..00bfa324 100644
+--- a/drivers/mmc/meson_gx_mmc.c
++++ b/drivers/mmc/meson_gx_mmc.c
+@@ -252,7 +252,7 @@ static int meson_mmc_probe(struct udevice *dev)
+ 	cfg->host_caps = MMC_MODE_8BIT | MMC_MODE_4BIT |
+ 			MMC_MODE_HS_52MHz | MMC_MODE_HS;
+ 	cfg->f_min = DIV_ROUND_UP(SD_EMMC_CLKSRC_24M, CLK_MAX_DIV);
+-	cfg->f_max = 100000000; /* 100 MHz */
++	cfg->f_max = SD_EMMC_CLKSRC_24M;
+ 	cfg->b_max = 511; /* max 512 - 1 blocks */
+ 	cfg->name = dev->name;
+ 
+-- 
+2.22.0
+


### PR DESCRIPTION
This adds support for Hardkernel Odroid-C4

It uses recently pushed patch backported for Linux 5.4, and sync'ed to U-boot 2020.04.

To generate the boot binary, the amlogic-boot-fip I maintain on gitlab is used, with introduction of script to generate a g12a/g12b/sm1 binary.

It has been tested on focal/server.
