### PR TITLE
npi-a64-only-audio-usb.patch

### DIFF
--- a/patch/kernel/sunxi-current/npi-a64-only-audio-usb.patch
+++ b/patch/kernel/sunxi-current/npi-a64-only-audio-usb.patch
@@ -1,0 +1,41 @@
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-a64-nanopi-a64.dts b/arch/arm64/boot/dts/allwinner/sun50i-a64-nanopi-a64.dts
+index ec0296a85..ad2c64d51 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-a64-nanopi-a64.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-a64-nanopi-a64.dts
+@@ -293,3 +293,36 @@ &uart0 {
+ &usbphy {
+ 	status = "okay";
+ };
++
++&sound {
++status = "okay";
++};
++
++&sound_hdmi {
++status = "okay";
++};
++
++&usb_otg {
++dr_mode = "host";
++status = "okay";
++};
++
++&i2s1 {
++status = "okay";
++};
++
++&i2s2 {
++status = "okay";
++};
++
++&dai {
++status = "okay";
++};
++
++&codec {
++status = "okay";
++};
++
++&codec_analog {
++status = "okay";
++};

--- a/patch/kernel/sunxi-dev/npi-a64-only-audio-usb.patch
+++ b/patch/kernel/sunxi-dev/npi-a64-only-audio-usb.patch
@@ -1,0 +1,41 @@
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-a64-nanopi-a64.dts b/arch/arm64/boot/dts/allwinner/sun50i-a64-nanopi-a64.dts
+index ec0296a85..ad2c64d51 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-a64-nanopi-a64.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-a64-nanopi-a64.dts
+@@ -293,3 +293,36 @@ &uart0 {
+ &usbphy {
+ 	status = "okay";
+ };
++
++&sound {
++status = "okay";
++};
++
++&sound_hdmi {
++status = "okay";
++};
++
++&usb_otg {
++dr_mode = "host";
++status = "okay";
++};
++
++&i2s1 {
++status = "okay";
++};
++
++&i2s2 {
++status = "okay";
++};
++
++&dai {
++status = "okay";
++};
++
++&codec {
++status = "okay";
++};
++
++&codec_analog {
++status = "okay";
++};


### PR DESCRIPTION
This is a follow-up to the PR #1927 where the complete sun50i-a64.dtsi was changed.
This is a patch ONLY for the NanoPi A64 .dts to activate Audio & Upper USB-port
Has been build/compiled and works with focal 5.6.5

Address = Alias:
sound=sound
sound_hdmi = sound_hdmi
1c19000 = usb_otg
1c22400 = i2s1
1c22c00 = dai
1c22e00 = codec
1c22800 = i2s2
1f015c0 = codec_analog
[npi-a64-only-audio-usb_.patch.txt](https://github.com/armbian/build/files/4547811/npi-a64-only-audio-usb_.patch.txt)
