### PR TITLE
Update linux-sunxi-dev.config

### DIFF
--- a/config/kernel/linux-sunxi-dev.config
+++ b/config/kernel/linux-sunxi-dev.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 5.6.3 Kernel Configuration
+# Linux/arm 5.6.8 Kernel Configuration
 #
 
 #


### PR DESCRIPTION
megi updated the 5.6 orangepi repo. No config changes since 5.6.3 detected. Still update version at least.