### PR TITLE
Enable user overlays on rockchip64 based boards

### DIFF
--- a/packages/bsp/common/usr/sbin/armbian-add-overlay
+++ b/packages/bsp/common/usr/sbin/armbian-add-overlay
@@ -35,10 +35,14 @@ fi
 
 . /etc/armbian-release
 
-if [[ $LINUXFAMILY != sunxi && $LINUXFAMILY != sunxi64 ]]; then
-	echo >&2 "Overlays are supported only on A10, A20, H3, H5 and A64 based boards"
-	exit -1
-fi
+case "${LINUXFAMILY}" in
+	sunxi|sunxi64|rockchip64)
+		:;;
+	*)
+		echo >&2 "Overlays are not supported on ${LINUXFAMILY^} based boards."
+		exit -1
+		;;
+esac
 
 if [[ -d /lib/modules/$(uname -r)/build/scripts/dtc ]]; then
 	if [[ ! -x /lib/modules/$(uname -r)/build/scripts/dtc/dtc ]]; then


### PR DESCRIPTION
User overlays are working fine on this boards (I have already tested on rock64).
Added the possibility to use on rockchip64 based boards.
Changed "if" to "case" to facilitate adding more supported boards.