### PR TITLE
Update npi-a64-only-audio-usb.patch

### DIFF
--- a/patch/kernel/sunxi-dev/npi-a64-only-audio-usb.patch
+++ b/patch/kernel/sunxi-dev/npi-a64-only-audio-usb.patch
@@ -20,10 +20,6 @@ index ec0296a85..ad2c64d51 100644
 +status = "okay";
 +};
 +
-+&i2s1 {
-+status = "okay";
-+};
-+
 +&i2s2 {
 +status = "okay";
 +};


### PR DESCRIPTION
deleted activation of i2s1 - 1c2240, because it isnt necessary for the correct operation of 
audio-analog (dai) and sound_hdmi
upper USB-port isnt affected.
i2s2 is right as OK, because its needed for sound_hdmi 1c22800