### PR TITLE
Added rk3328 efuse driver to mainline u-boot and stable secondary mac address

### DIFF
--- a/patch/u-boot/u-boot-rockchip64-mainline/general-set-eth1addr.patch
+++ b/patch/u-boot/u-boot-rockchip64-mainline/general-set-eth1addr.patch
@@ -1,0 +1,16 @@
+diff --git a/arch/arm/mach-rockchip/misc.c b/arch/arm/mach-rockchip/misc.c
+index 6dbb9bde..89f3a918 100644
+--- a/arch/arm/mach-rockchip/misc.c
++++ b/arch/arm/mach-rockchip/misc.c
+@@ -50,6 +50,11 @@ int rockchip_setup_macaddr(void)
+ 	mac_addr[0] &= 0xfe;  /* clear multicast bit */
+ 	mac_addr[0] |= 0x02;  /* set local assignment bit (IEEE802) */
+ 	eth_env_set_enetaddr("ethaddr", mac_addr);
++
++	/* Make a valid MAC address for eth1 too */
++	mac_addr[5] += 0x20;
++	mac_addr[5] &= 0xff;
++	eth_env_set_enetaddr("eth1addr", mac_addr);
+ #endif
+ 	return 0;
+ }

--- a/patch/u-boot/u-boot-rockchip64-mainline/rk3328-efuse-driver.patch
+++ b/patch/u-boot/u-boot-rockchip64-mainline/rk3328-efuse-driver.patch
@@ -1,0 +1,184 @@
+diff --git a/drivers/misc/rockchip-efuse.c b/drivers/misc/rockchip-efuse.c
+index 2520c6a3..c3e58188 100644
+--- a/drivers/misc/rockchip-efuse.c
++++ b/drivers/misc/rockchip-efuse.c
+@@ -13,8 +13,18 @@
+ #include <dm.h>
+ #include <linux/bitops.h>
+ #include <linux/delay.h>
++#include <malloc.h>
+ #include <misc.h>
+ 
++#define RK3328_INT_STATUS	0x0018
++#define RK3328_DOUT		0x0020
++#define RK3328_AUTO_CTRL	0x0024
++#define RK3328_INT_FINISH	BIT(0)
++#define RK3328_AUTO_ENB		BIT(0)
++#define RK3328_AUTO_RD		BIT(1)
++#define RK3328_NO_SECURE_BYTES	32
++#define RK3328_SECURE_BYTES	96
++
+ #define RK3399_A_SHIFT          16
+ #define RK3399_A_MASK           0x3ff
+ #define RK3399_NFUSES           32
+@@ -27,6 +37,9 @@
+ #define RK3399_STROBE           BIT(1)
+ #define RK3399_CSB              BIT(0)
+ 
++typedef int (*EFUSE_READ)(struct udevice *dev, int offset, void *buf,
++			  int size);
++
+ struct rockchip_efuse_regs {
+ 	u32 ctrl;      /* 0x00  efuse control register */
+ 	u32 dout;      /* 0x04  efuse data out register */
+@@ -35,6 +48,10 @@ struct rockchip_efuse_regs {
+ 	u32 jtag_pass; /* 0x10  JTAG password */
+ 	u32 strobe_finish_ctrl;
+ 		       /* 0x14	efuse strobe finish control register */
++	u32 int_status;/* 0x18 */
++	u32 reserved;  /* 0x1c */
++	u32 dout2;     /* 0x20 */
++	u32 auto_ctrl; /* 0x24 */
+ };
+ 
+ struct rockchip_efuse_platdata {
+@@ -83,6 +100,57 @@ U_BOOT_CMD(
+ );
+ #endif
+ 
++static int rockchip_rk3328_efuse_read(struct udevice *dev, int offset,
++				      void *buf, int size)
++{
++	struct rockchip_efuse_platdata *plat = dev_get_platdata(dev);
++	struct rockchip_efuse_regs *efuse =
++		(struct rockchip_efuse_regs *)plat->base;
++	unsigned int addr_start, addr_end, addr_offset, addr_len;
++	u32 out_value, status;
++	u8 *buffer;
++	int ret = 0, i = 0, j = 0;
++
++	/* Max non-secure Byte */
++	if (size > RK3328_NO_SECURE_BYTES)
++		size = RK3328_NO_SECURE_BYTES;
++
++	/* 128 Byte efuse, 96 Byte for secure, 32 Byte for non-secure */
++	offset += RK3328_SECURE_BYTES;
++	addr_start = rounddown(offset, RK3399_BYTES_PER_FUSE) /
++			       RK3399_BYTES_PER_FUSE;
++	addr_end = roundup(offset + size, RK3399_BYTES_PER_FUSE) /
++			   RK3399_BYTES_PER_FUSE;
++	addr_offset = offset % RK3399_BYTES_PER_FUSE;
++	addr_len = addr_end - addr_start;
++
++	buffer = calloc(1, sizeof(*buffer) * addr_len * RK3399_BYTES_PER_FUSE);
++	if (!buffer)
++		return -ENOMEM;
++
++	for (j = 0; j < addr_len; j++) {
++		writel(RK3328_AUTO_RD | RK3328_AUTO_ENB |
++		       ((addr_start++ & RK3399_A_MASK) << RK3399_A_SHIFT),
++		       &efuse->auto_ctrl);
++		udelay(5);
++		status = readl(&efuse->int_status);
++		if (!(status & RK3328_INT_FINISH)) {
++			ret = -EIO;
++			goto err;
++		}
++		out_value = readl(&efuse->dout2);
++		writel(RK3328_INT_FINISH, &efuse->int_status);
++
++		memcpy(&buffer[i], &out_value, RK3399_BYTES_PER_FUSE);
++		i += RK3399_BYTES_PER_FUSE;
++	}
++	memcpy(buf, buffer + addr_offset, size);
++err:
++	free(buffer);
++
++	return ret;
++}
++
+ static int rockchip_rk3399_efuse_read(struct udevice *dev, int offset,
+ 				      void *buf, int size)
+ {
+@@ -130,7 +198,13 @@ static int rockchip_rk3399_efuse_read(struct udevice *dev, int offset,
+ static int rockchip_efuse_read(struct udevice *dev, int offset,
+ 			       void *buf, int size)
+ {
+-	return rockchip_rk3399_efuse_read(dev, offset, buf, size);
++	EFUSE_READ efuse_read = NULL;
++
++	efuse_read = (EFUSE_READ)dev_get_driver_data(dev);
++	if (!efuse_read)
++		return -EINVAL;
++
++	return (*efuse_read)(dev, offset, buf, size);
+ }
+ 
+ static const struct misc_ops rockchip_efuse_ops = {
+@@ -146,7 +220,14 @@ static int rockchip_efuse_ofdata_to_platdata(struct udevice *dev)
+ }
+ 
+ static const struct udevice_id rockchip_efuse_ids[] = {
+-	{ .compatible = "rockchip,rk3399-efuse" },
++	{
++		.compatible = "rockchip,rk3328-efuse",
++		.data = (ulong)&rockchip_rk3328_efuse_read,
++	},
++	{
++		.compatible = "rockchip,rk3399-efuse",
++		.data = (ulong)&rockchip_rk3399_efuse_read,
++	},
+ 	{}
+ };
+ 
+diff --git a/include/configs/rk3328_common.h b/include/configs/rk3328_common.h
+index 407e5d29..0552e476 100644
+--- a/include/configs/rk3328_common.h
++++ b/include/configs/rk3328_common.h
+@@ -23,6 +23,10 @@
+ #define CONFIG_SPL_BSS_START_ADDR	0x2000000
+ #define CONFIG_SPL_BSS_MAX_SIZE		0x2000
+ 
++#define CONFIG_MISC 1
++#define CONFIG_MISC_INIT_R 1
++#define CONFIG_ROCKCHIP_EFUSE 1
++
+ #define CONFIG_SYS_BOOTM_LEN	(64 << 20)	/* 64M */
+ 
+ /* FAT sd card locations. */
+diff --git a/arch/arm/dts/rk3328.dtsi b/arch/arm/dts/rk3328.dtsi
+index eac257b0..3e04a823 100644
+--- a/arch/arm/dts/rk3328.dtsi
++++ b/arch/arm/dts/rk3328.dtsi
+@@ -337,6 +337,31 @@
+ 		};
+ 	};
+ 
++	efuse: efuse@ff260000 {
++		compatible = "rockchip,rk3328-efuse";
++		reg = <0x0 0xff260000 0x0 0x50>;
++		#address-cells = <1>;
++		#size-cells = <1>;
++		clocks = <&cru SCLK_EFUSE>;
++		clock-names = "pclk_efuse";
++		rockchip,efuse-size = <0x20>;
++
++		/* Data cells */
++		efuse_id: id@7 {
++			reg = <0x07 0x10>;
++		};
++		cpu_leakage: cpu-leakage@17 {
++			reg = <0x17 0x1>;
++		};
++		logic_leakage: logic-leakage@19 {
++			reg = <0x19 0x1>;
++		};
++		efuse_cpu_version: cpu-version@1a {
++			reg = <0x1a 0x1>;
++			bits = <3 3>;
++		};
++	};
++
+ 	saradc: saradc@ff280000 {
+ 		compatible = "rockchip,rk3328-saradc", "rockchip,saradc";
+ 		reg = <0x0 0xff280000 0x0 0x100>;


### PR DESCRIPTION
Secondary mac address is based on [ayufan's work](https://github.com/ayufan-rock64/linux-u-boot/commit/0360b8cf6066034134e505b7b3359675f10c14db).

Efuse driver is enforced for all rk3328 devices (none enabled yet in mainline u-boot) to enable stable mac addresses based in cpu id.