### PR TITLE
Add mali GPU supply for OrangePi Lite2

### DIFF
--- a/patch/kernel/sunxi-dev/board-h6-orangepi-lite2-fix-missing-all.patch
+++ b/patch/kernel/sunxi-dev/board-h6-orangepi-lite2-fix-missing-all.patch
@@ -98,6 +98,11 @@ index e098a2475..6c481b547 100644
 +	status = "okay";
 +};
 +
++&gpu {
++	mali-supply = <&reg_dcdcc>;
++	status = "okay";
++};
++
 +&hdmi {
 +	status = "okay";
 +};
@@ -244,6 +249,7 @@ index e098a2475..6c481b547 100644
 +			};
 +
 +			reg_dcdcc: dcdcc {
++				regulator-enable-ramp-delay = <32000>;
 +				regulator-min-microvolt = <810000>;
 +				regulator-max-microvolt = <1080000>;
 +				regulator-name = "vdd-gpu";


### PR DESCRIPTION
Based on https://github.com/torvalds/linux/commit/8abc4c4a154f658ac1f928eb5ccd9cb4706b2f3d

and the discussion: https://forum.armbian.com/topic/12516-unable-to-make-panfrost-work-on-h6/?do=findComment&comment=100244
