### PR TITLE
odroidc1: fix invalid extent boot bug

### DIFF
--- a/patch/u-boot/u-boot-meson/ext4fs-fix-invalid-extent-block-error.patch
+++ b/patch/u-boot/u-boot-meson/ext4fs-fix-invalid-extent-block-error.patch
@@ -1,0 +1,44 @@
+From b33e6fa8e4217bbfc41e6af266049f86b198156e Mon Sep 17 00:00:00 2001
+From: Ionut Nicu <ioan.nicu.ext@nsn.com>
+Date: Mon, 13 Jan 2014 12:00:08 +0100
+Subject: [PATCH 2/2] ext4fs: fix "invalid extent block" error
+
+For files where we actually have extent indexes following
+an extent header (ext_block->eh_depth != 0), the do/while
+loop from ext4fs_get_extent_block() does not select the
+proper extent index structure.
+
+For example, if we have:
+
+ext_block->eh_depth = 1
+ext_block->eh_entries = 1
+fileblock = 0
+index[0].ei_block = 0
+
+the do/while loop will exit with i set to 0 and the
+ext4fs_get_extent_block() function will return 0, even if
+there was a valid extent index structure following the
+header.
+
+Signed-off-by: Ionut Nicu <ioan.nicu.ext@nsn.com>
+Signed-off-by: Mathias Rulf <mathias.rulf@nsn.com>
+---
+ fs/ext4/ext4_common.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/fs/ext4/ext4_common.c b/fs/ext4/ext4_common.c
+index 16b58ca1a6..50b904661d 100644
+--- a/fs/ext4/ext4_common.c
++++ b/fs/ext4/ext4_common.c
+@@ -1430,7 +1430,7 @@ static struct ext4_extent_header *ext4fs_get_extent_block
+ 			i++;
+ 			if (i >= le16_to_cpu(ext_block->eh_entries))
+ 				break;
+-		} while (fileblock > le32_to_cpu(index[i].ei_block));
++		} while (fileblock >= le32_to_cpu(index[i].ei_block));
+ 
+ 		if (--i < 0)
+ 			return 0;
+-- 
+2.26.2
+


### PR DESCRIPTION
odroidc1 can fail to boot probably depending
on features of the ext4 rootfs that is created
during the build process : extent feature

serial log error:
Loading file "/boot/uInitrd" from mmc device 0:1 xxa1
invalid extent block

this happens with buildbot / downloaded images but
I cannot replicate it with local building using docker

since there is no support for that board in upstream u-boot
backport the patch from
upstream commit:b5bbac1a9b07016602559ff483df265fef6c1f83
see also [1]

[1] https://lists.denx.de/pipermail/u-boot/2014-January/170802.html

Signed-off-by: Dirk Neukirchen <plntyk.arm@plntyk.name>

