### PR TITLE
Disabling GPIO reset to fix broken ethernet on Odroid C4

### DIFF
--- a/patch/kernel/meson64-current/0002-arm64-dts-meson-sm1-add-support-for-Hardkernel-ODROI.patch
+++ b/patch/kernel/meson64-current/0002-arm64-dts-meson-sm1-add-support-for-Hardkernel-ODROI.patch
@@ -30,7 +30,7 @@ new file mode 100755
 index 000000000..221572a77
 --- /dev/null
 +++ b/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-c4.dts
-@@ -0,0 +1,399 @@
+@@ -0,0 +1,398 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2020 Dongjin Kim <tobetter@gmail.com>
@@ -257,7 +257,6 @@ index 000000000..221572a77
 +
 +		reset-assert-us = <10000>;
 +		reset-deassert-us = <30000>;
-+		reset-gpios = <&gpio GPIOZ_15 (GPIO_ACTIVE_LOW | GPIO_OPEN_DRAIN)>;
 +
 +		interrupt-parent = <&gpio_intc>;
 +		/* MAC_INTR on GPIOZ_14 */


### PR DESCRIPTION
Close [AR-231]

[AR-231]: https://armbian.atlassian.net/browse/AR-231