### PR TITLE
Added getfacl because not present in 20.04 ootb

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -89,6 +89,10 @@ if [[ -z "$(which dialog)" ]]; then
 	sudo apt-get update
 	sudo apt-get install -y dialog
 fi
+if [[ -z "$(which getfacl)" ]]; then
+	sudo apt-get update
+	sudo apt-get install -y acl
+fi
 
 # Check for Vagrant
 if [[ "$1" == vagrant && -z "$(which vagrant)" ]]; then


### PR DESCRIPTION
At least in the 20.04 cloud image is not included ootb and it is required in
https://github.com/armbian/build/blob/master/lib/configuration.sh#L321