### PR TITLE
Possible workaround for NanoPi M4V2 stability issues

### DIFF
--- a/config/sources/families/rk3399.conf
+++ b/config/sources/families/rk3399.conf
@@ -20,7 +20,14 @@ if [[ $BOARD == roc-rk3399-pc ]]; then
 
 	BOOT_USE_MAINLINE_ATF=yes
 
-elif [[ $BOARD == nanopim4v2 || $BOARD == orangepi4 ]]; then
+elif [[ $BOARD == nanopim4v2 ]]; then
+
+	BOOT_USE_BLOBS=yes
+	DDR_BLOB='rk33/rk3399_ddr_800MHz_v1.20.bin'
+	MINILOADER_BLOB='rk33/rk3399_miniloader_v1.19.bin'
+	BL31_BLOB='rk33/rk3399_bl31_v1.30.elf'
+
+elif [[ $BOARD == orangepi4 ]]; then
 
 	BOOT_USE_BLOBS=yes
 	DDR_BLOB='rk33/rk3399_ddr_933MHz_v1.24.bin'


### PR DESCRIPTION
This changes LPDDR4 frequency to 800MHz instead of 856MHz.
Needs time for further verification.