### PR TITLE
Fix set locale

### DIFF
--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -190,6 +190,7 @@ create_rootfs_cache()
 		# DEFAULT LANGUAGE = 'en_US.UTF-8 UTF-8'
 		local lng='en_US.UTF-8'
 		if [ "$DEST_LANG" == "" ]; then
+			display_alert "The variable DEST_LANG is empty" "[$DEST_LANG]" "info"
 			display_alert "Configuring default locale" "$lng" "info"
 			DEST_LANG=$lng
 		elif [ "$DEST_LANG" == "en_US.UTF-8" ]; then
@@ -200,7 +201,7 @@ create_rootfs_cache()
 		fi
 
 		eval 'chroot $SDCARD /bin/bash -c "locale-gen $lng"' ${OUTPUT_VERYSILENT:+' >/dev/null 2>/dev/null'}
-		eval 'chroot $SDCARD /bin/bash -c "update-locale LANG=$DEST_LANG LC_MESSAGES=$DEST_LANG"' \
+		eval 'chroot $SDCARD /bin/bash -c "update-locale LANG=$DEST_LANG LANGUAGE=$DEST_LANG LC_MESSAGES=$DEST_LANG"' \
 			${OUTPUT_VERYSILENT:+' >/dev/null 2>/dev/null'}
 
 		if [[ -f $SDCARD/etc/default/console-setup ]]; then

--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -187,11 +187,20 @@ create_rootfs_cache()
 		chmod 755 $SDCARD/sbin/start-stop-daemon
 
 		# stage: configure language and locales
-		display_alert "Configuring locales" "$DEST_LANG" "info"
+		# DEFAULT LANGUAGE = 'en_US.UTF-8 UTF-8'
+		local lng='en_US.UTF-8'
+		if [ "$DEST_LANG" == "" ]; then
+			display_alert "Configuring default locale" "$lng" "info"
+			DEST_LANG=$lng
+		elif [ "$DEST_LANG" == "en_US.UTF-8" ]; then
+			display_alert "Configuring default locale" "$lng" "info"
+		else
+			lng="$lng $DEST_LANG"
+			display_alert "Configuring locales" "$lng" "info"
+		fi
 
-		[[ -f $SDCARD/etc/locale.gen ]] && sed -i "s/^# $DEST_LANG/$DEST_LANG/" $SDCARD/etc/locale.gen
-		eval 'LC_ALL=C LANG=C chroot $SDCARD /bin/bash -c "locale-gen $DEST_LANG"' ${OUTPUT_VERYSILENT:+' >/dev/null 2>/dev/null'}
-		eval 'LC_ALL=C LANG=C chroot $SDCARD /bin/bash -c "update-locale LANG=$DEST_LANG LANGUAGE=$DEST_LANG LC_MESSAGES=$DEST_LANG"' \
+		eval 'chroot $SDCARD /bin/bash -c "locale-gen $lng"' ${OUTPUT_VERYSILENT:+' >/dev/null 2>/dev/null'}
+		eval 'chroot $SDCARD /bin/bash -c "update-locale LANG=$DEST_LANG LC_MESSAGES=$DEST_LANG"' \
 			${OUTPUT_VERYSILENT:+' >/dev/null 2>/dev/null'}
 
 		if [[ -f $SDCARD/etc/default/console-setup ]]; then


### PR DESCRIPTION
If the DEST_LANG variable is empty,
then the 'create_rootfs_cache ()' function installs all existing locales.
If the DEST_LANG variable is set to the native language,
then the default language, en_US.UTF-8, is not set.
Messages:
/bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
....
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings
....
are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
/bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
And many more lines.

The line with the editor is not needed.
sed -i "s/^# $DEST_LANG/$DEST_LANG/" $SDCARD/etc/locale.gen
The 'locale-gen en_US.UTF-8 native.UTF-8' command
will fix this file itself.

Checked for ubuntu bionic.

