### PR TITLE
Fixing desktop install on Ubuntu Focal / Eean

### DIFF
--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -184,7 +184,7 @@ PACKAGE_LIST_DESKTOP_RECOMMENDS="galculator hexchat xfce4-screenshooter network-
 # Full desktop packages
 PACKAGE_LIST_DESKTOP_FULL="libreoffice libreoffice-style-tango meld remmina kazam avahi-daemon transmission"
 
-# Packages installed before deskop.
+# Packages installed before desktop.
 PACKAGE_LIST_PREDEPENDS=""
 
 # Release specific packages

--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -184,6 +184,9 @@ PACKAGE_LIST_DESKTOP_RECOMMENDS="galculator hexchat xfce4-screenshooter network-
 # Full desktop packages
 PACKAGE_LIST_DESKTOP_FULL="libreoffice libreoffice-style-tango meld remmina kazam avahi-daemon transmission"
 
+# Packages installed before deskop.
+PACKAGE_LIST_PREDEPENDS=""
+
 # Release specific packages
 case $RELEASE in
 
@@ -244,6 +247,7 @@ case $RELEASE in
 		PACKAGE_LIST_DESKTOP_RECOMMENDS+=" firefox system-config-printer-common system-config-printer \
 								language-selector-gnome viewnior"
 		PACKAGE_LIST_DESKTOP_FULL+=" thunderbird"
+		PACKAGE_LIST_PREDEPENDS="policykit-1-gnome notification-daemon"
 	;;
 
 	eoan)
@@ -254,6 +258,7 @@ case $RELEASE in
 		PACKAGE_LIST_DESKTOP_RECOMMENDS+=" firefox system-config-printer-common system-config-printer \
 								language-selector-gnome mirage"
 		PACKAGE_LIST_DESKTOP_FULL+=" thunderbird"
+		PACKAGE_LIST_PREDEPENDS="policykit-1-gnome notification-daemon"
 	;;
 
 esac

--- a/lib/desktop.sh
+++ b/lib/desktop.sh
@@ -16,6 +16,9 @@ create_desktop_package ()
 	PACKAGE_LIST_DESKTOP=${PACKAGE_LIST_DESKTOP// /,};
 	PACKAGE_LIST_DESKTOP=${PACKAGE_LIST_DESKTOP//[[:space:]]/}
 
+	PACKAGE_LIST_PREDEPENDS=${PACKAGE_LIST_PREDEPENDS// /,};
+	PACKAGE_LIST_PREDEPENDS=${PACKAGE_LIST_PREDEPENDS//[[:space:]]/}
+
 	local destination=${SRC}/.tmp/${RELEASE}/${BOARD}/${CHOSEN_DESKTOP}_${REVISION}_all
 	rm -rf "${destination}"
 	mkdir -p "${destination}"/DEBIAN
@@ -31,6 +34,7 @@ create_desktop_package ()
 	Priority: optional
 	Recommends: ${PACKAGE_LIST_DESKTOP//[:space:]+/,}
 	Provides: ${CHOSEN_DESKTOP}
+	Pre-Depends: ${PACKAGE_LIST_PREDEPENDS//[:space:]+/,}
 	Description: Armbian desktop for ${DISTRIBUTION} ${RELEASE}
 	EOF
 


### PR DESCRIPTION
Changed dependencies for Network manager automatically install Gnome3 desktop unless certain packages are installed first. Fixing with pre-depends package feature. Tested on arm64, desktop install on top of CLI image

Tested on Rock64 CLI Focal -> upgrade to desktop via armbian-config ... from local repository. This will work once desktop packages are updated at apt / beta.armbian.com

Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>