### PR TITLE
Fixed mali error on boot for rk3399-legacy

### DIFF
--- a/patch/kernel/rk3399-legacy/general-fix-mali-error-on-boot.patch
+++ b/patch/kernel/rk3399-legacy/general-fix-mali-error-on-boot.patch
@@ -1,0 +1,14 @@
+diff --git a/drivers/gpu/arm/midgard/ipa/mali_kbase_ipa.c b/drivers/gpu/arm/midgard/ipa/mali_kbase_ipa.c
+index 01bdbb4e..c6ecee65 100644
+--- a/drivers/gpu/arm/midgard/ipa/mali_kbase_ipa.c
++++ b/drivers/gpu/arm/midgard/ipa/mali_kbase_ipa.c
+@@ -107,7 +107,8 @@ static struct device_node *get_model_dt_node(struct kbase_ipa_model *model)
+ 	snprintf(compat_string, sizeof(compat_string), "arm,%s",
+ 		 model->ops->name);
+ 
+-	model_dt_node = of_find_compatible_node(model->kbdev->dev->of_node,
++
++	model_dt_node = of_find_compatible_node(of_node_get(model->kbdev->dev->of_node),
+ 						NULL, compat_string);
+ 	if (!model_dt_node && !model->missing_dt_node_warning) {
+ 		dev_warn(model->kbdev->dev,


### PR DESCRIPTION
This fixes long standing but rather harmless bug exhibiting itself with mali originating error message on boot:
```
ERROR: Bad of_node_put() on /gpu@ffa30000
```
`of_find_compatible_node` in `get_model_dt_node` frees the gpu node with `of_node_put` but it was never acquired with `of_node_get`.