### PR TITLE
VFAT boot partition bugfix

### DIFF
--- a/patch/misc/general-packaging-4.14.y.patch
+++ b/patch/misc/general-packaging-4.14.y.patch
@@ -128,7 +128,7 @@ index 8c4bc5a2c..30bc0cffb 100644
 +cp /tmp/uImage /boot/uImage
 +rm -f /$installed_image_path
 +else
-+ln -sf $(basename $installed_image_path) /boot/$image_name || mv /$installed_image_path /boot/$image_name
++ln -sf $(basename $installed_image_path) /boot/$image_name 2> /dev/null || mv /$installed_image_path /boot/$image_name
 +fi
 +touch /boot/.next
 +exit 0
@@ -154,7 +154,7 @@ index 8c4bc5a2c..30bc0cffb 100644
 +
 +bootfstype=\$(blkid -s TYPE -o value \$boot_partition)
 +if [ "\$bootfstype" = "vfat" ]; then
-+umount /boot
++# we have to keep it mounted! umount /boot
 +rm -f /boot/System.map* /boot/config* /boot/vmlinuz* /boot/$image_name /boot/uImage
 +fi
 +}

--- a/patch/misc/general-packaging-4.19.y.patch
+++ b/patch/misc/general-packaging-4.19.y.patch
@@ -151,7 +151,7 @@ index 0b31f4f1f92c..f6b96d8507f4 100755
 +	cp /tmp/uImage /boot/uImage
 +	rm -f /$installed_image_path
 +else
-+	ln -sf $(basename $installed_image_path) /boot/$image_name || mv /$installed_image_path /boot/$image_name
++	ln -sf $(basename $installed_image_path) /boot/$image_name 2> /dev/null || mv /$installed_image_path /boot/$image_name
 +fi
 +touch /boot/.next
 +exit 0
@@ -178,7 +178,7 @@ index 0b31f4f1f92c..f6b96d8507f4 100755
 +
 +	bootfstype=\$(blkid -s TYPE -o value \$boot_partition)
 +	if [ "\$bootfstype" = "vfat" ]; then
-+		umount /boot
++		# we have to keep it mounted! umount /boot
 +		rm -f /boot/System.map* /boot/config* /boot/vmlinuz* /boot/$image_name /boot/uImage
 +	fi
 +}

--- a/patch/misc/general-packaging-4.4.y-rk3399.patch
+++ b/patch/misc/general-packaging-4.4.y-rk3399.patch
@@ -161,7 +161,7 @@ index 6c3b038e..f4166fbe 100755
 +
 +bootfstype=\$(blkid -s TYPE -o value \$boot_partition)
 +if [ "\$bootfstype" = "vfat" ]; then 
-+umount /boot; 
++# we have to keep it mounted! umount /boot
 +rm -f /boot/System.map* /boot/config* /boot/vmlinuz* /boot/zImage /boot/uImage /boot/Image
 +fi
 +}

--- a/patch/misc/general-packaging-4.4.y-rockchip64.patch
+++ b/patch/misc/general-packaging-4.4.y-rockchip64.patch
@@ -161,7 +161,7 @@ index 6c3b038e..f4166fbe 100755
 +
 +bootfstype=\$(blkid -s TYPE -o value \$boot_partition)
 +if [ "\$bootfstype" = "vfat" ]; then 
-+umount /boot; 
++# we have to keep it mounted! umount /boot
 +rm -f /boot/System.map* /boot/config* /boot/vmlinuz* /boot/zImage /boot/uImage /boot/Image
 +fi
 +}

--- a/patch/misc/general-packaging-4.4.y.patch
+++ b/patch/misc/general-packaging-4.4.y.patch
@@ -154,7 +154,7 @@ index 6c3b038e..977a0624 100755
 +
 +bootfstype=\$(blkid -s TYPE -o value \$boot_partition)
 +if [ "\$bootfstype" = "vfat" ]; then 
-+umount /boot; 
++# we have to keep it mounted! umount /boot
 +rm -f /boot/System.map* /boot/config* /boot/vmlinuz* /boot/$image_name /boot/uImage
 +fi
 +}

--- a/patch/misc/general-packaging-4.9.y.patch
+++ b/patch/misc/general-packaging-4.9.y.patch
@@ -141,7 +141,7 @@ index 0a2a7372..87edac65 100755
 +
 +bootfstype=\$(blkid -s TYPE -o value \$boot_partition)
 +if [ "\$bootfstype" = "vfat" ]; then 
-+umount /boot; 
++# we have to keep it mounted! umount /boot
 +rm -f /boot/System.map* /boot/config* /boot/vmlinuz* /boot/zImage /boot/uImage
 +fi
 +}

--- a/patch/misc/general-packaging-5.3.y.patch
+++ b/patch/misc/general-packaging-5.3.y.patch
@@ -177,7 +177,7 @@ index c4c580f547ef..2be8a687f878 100755
 +
 +	bootfstype=\$(blkid -s TYPE -o value \$boot_partition)
 +	if [ "\$bootfstype" = "vfat" ]; then
-+		umount /boot
++		# we have to keep it mounted! umount /boot
 +		rm -f /boot/System.map* /boot/config* /boot/vmlinuz* /boot/$image_name /boot/uImage
 +	fi
 +}

--- a/patch/misc/general-packaging-5.6.y.patch
+++ b/patch/misc/general-packaging-5.6.y.patch
@@ -170,7 +170,7 @@ index 6df3c9f..d33e1f3 100755
 +	cp /tmp/uImage /boot/uImage
 +	rm -f /$installed_image_path
 +else
-+	ln -sf $(basename $installed_image_path) /boot/$image_name || mv /$installed_image_path /boot/$image_name
++	ln -sf $(basename $installed_image_path) /boot/$image_name 2> /dev/null || mv /$installed_image_path /boot/$image_name
 +fi
 +touch /boot/.next
 +exit 0
@@ -199,7 +199,7 @@ index 6df3c9f..d33e1f3 100755
 -	create_package linux-libc-dev debian/linux-libc-dev
 +	bootfstype=\$(blkid -s TYPE -o value \$boot_partition)
 +	if [ "\$bootfstype" = "vfat" ]; then
-+		umount /boot
++		# we have to keep it mounted! umount /boot
 +		rm -f /boot/System.map* /boot/config* /boot/vmlinuz* /boot/$image_name /boot/uImage
 +	fi
 +}


### PR DESCRIPTION
Kernel install image is broken on VFAT images since it unmounts /boot directory in preinstall script and doesn't mount back. We used to have this for NAND / FAT install which fixes this in the postinst script. Removing since we have no more support for NAND anyway. Tested on Odroid C1. 

Closes [AR-240]
Related [AR-241]

@the-going
Perhaps relevant for new packaging?

[AR-240]: https://armbian.atlassian.net/browse/AR-240
[AR-241]: https://armbian.atlassian.net/browse/AR-241