### PR TITLE
Fix sed: no input files when all logrotate.d items contain compress o…

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
+++ b/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
@@ -67,7 +67,7 @@ prepare_board() {
 	[[ -f $prefix/cpuinfo_cur_freq ]] && chmod +r $prefix/cpuinfo_cur_freq 2> /dev/null
 
 	# enable compression where not exists
-	find /etc/logrotate.d/. -type f | xargs grep -H -c 'compress' | grep 0$ | cut -d':' -f1 | xargs -L1 sed -i '/{/ a compress'
+	find /etc/logrotate.d/. -type f | xargs grep -H -c 'compress' | grep 0$ | cut -d':' -f1 | xargs -r -L1 sed -i '/{/ a compress'
 	sed -i "s/#compress/compress/" /etc/logrotate.conf
 
 	# tweak ondemand cpufreq governor settings to increase cpufreq with IO load


### PR DESCRIPTION
When all /etc/logrotate.d/* files contain compress sed: no input is dumped to /var/log/daemon.log 
