### PR TITLE
Update board-h6-orangepi-lite2-fix-missing-all.patch

### DIFF
--- a/patch/kernel/sunxi-dev/board-h6-orangepi-lite2-fix-missing-all.patch
+++ b/patch/kernel/sunxi-dev/board-h6-orangepi-lite2-fix-missing-all.patch
@@ -2,7 +2,7 @@ diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-lite2.dts b/arch/a
 index e098a2475..6c481b547 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-lite2.dts
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-lite2.dts
-@@ -3,9 +3,344 @@
+@@ -3,9 +3,350 @@
   * Copyright (C) 2018 Jagan Teki <jagan@openedev.com>
   */
  


### PR DESCRIPTION
https://github.com/armbian/build/commit/89b5e5f782a4f70c3b0588c9f8040a965d158bc8#diff-986c134d2455444b5a9ffd6941aa50ef broke the patch.
This fixes it.

Build processing....