### PR TITLE
Update npi-a64-only-audio-usb.patch

### DIFF
--- a/patch/kernel/sunxi-dev/npi-a64-only-audio-usb.patch
+++ b/patch/kernel/sunxi-dev/npi-a64-only-audio-usb.patch
@@ -2,7 +2,7 @@ diff --git a/arch/arm64/boot/dts/allwinner/sun50i-a64-nanopi-a64.dts b/arch/arm6
 index ec0296a85..ad2c64d51 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-a64-nanopi-a64.dts
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-a64-nanopi-a64.dts
-@@ -293,3 +293,36 @@ &uart0 {
+@@ -293,3 +293,32 @@ &uart0 {
  &usbphy {
  	status = "okay";
  };


### PR DESCRIPTION
https://github.com/armbian/build/commit/7107eed3faf72db90348e1674b0ed782db370a19#diff-b855842906d9352d559c9a0b69eb30ed broke this patch.
This fixes it.
