### PR TITLE
Add ZeroPi IRQ balancing

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
+++ b/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
@@ -251,9 +251,9 @@ prepare_board() {
 						echo 8 >/proc/irq/$i/smp_affinity
 					done
 					;;
-				"Beelink X2"|"Orange Pi R1")
+				"Beelink X2"|"Orange Pi R1"|"ZeroPi")
 					# Wifi module reload workaround / fix
-					[[ -n $(lsmod | grep 8189es) ]] && rmmod 8189es && modprobe 8189es
+					[[ -n $(lsmod | grep 8189es) && "${BOARD_NAME}" != "ZeroPi" ]] && rmmod 8189es && modprobe 8189es
 					# Send SDIO to cpu1, USB to cpu2, Ethernet to cpu3
 					for i in $(awk -F':' '/sunxi-mmc/{print $1}' </proc/interrupts | sed 's/\ //g'); do
 						echo 2 >/proc/irq/$i/smp_affinity


### PR DESCRIPTION
IRQ distribution over cpu's, SD, USB, eth0.
ZeroPi has 4 root hubs (USB0/1/2/3) of which only USB3 is in use (2.0 type A port).

Disable reloading of 8189es kmod for this board to prevent unexpected behavior in case an 8189es based USB dongle should ever be attached.
