### PR TITLE
Espressobin: Activation of HIDDEV

### DIFF
--- a/config/kernel/linux-mvebu64-dev.config
+++ b/config/kernel/linux-mvebu64-dev.config
@@ -4542,7 +4542,7 @@ CONFIG_HID_U2FZERO=m
 #
 CONFIG_USB_HID=y
 # CONFIG_HID_PID is not set
-# CONFIG_USB_HIDDEV is not set
+CONFIG_USB_HIDDEV=y
 # end of USB HID support
 
 #


### PR DESCRIPTION
Some UPS (eaton, APS, ...) use usb generic  HID to communicate and send informations.
This pull request add the modification so that espressobin is capable of using them.
Without it, the kernel send the following message "hid-generic 0003:0463:FFFF.000B: device has no listeners, quitting"

I did a simple test with a "-dev" kernel (BRANCH="dev" with compile.sh).
I'm not really sure what is the "-next" kernel configuration and how to recompile against.

The configuration was already present in the legacy kernel, and is also present in many other armbian platform. So I think it's relatively safe to add it to the dev kernel, and to other configurations if the need arise.

