### PR TITLE
Workaround for Snap-less Chromium on Focal

### DIFF
--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -241,10 +241,10 @@ case $RELEASE in
 
 	focal)
 		DEBOOTSTRAP_COMPONENTS="main,universe"
-		DEBOOTSTRAP_LIST+=" rng-tools"
+		DEBOOTSTRAP_LIST+=" rng-tools debian-archive-keyring"
 		[[ -z $BUILD_MINIMAL || $BUILD_MINIMAL == no ]] && PACKAGE_LIST_RELEASE="man-db kbd net-tools gnupg2 dirmngr networkd-dispatcher"
 		PACKAGE_LIST_DESKTOP+=" xserver-xorg-input-all paprefs dbus-x11 pulseaudio-module-gsettings onboard"
-		PACKAGE_LIST_DESKTOP_RECOMMENDS+=" firefox system-config-printer-common system-config-printer \
+		PACKAGE_LIST_DESKTOP_RECOMMENDS+=" chromium system-config-printer-common system-config-printer \
 								language-selector-gnome viewnior"
 		PACKAGE_LIST_DESKTOP_FULL+=" thunderbird"
 		PACKAGE_LIST_PREDEPENDS="policykit-1-gnome notification-daemon"
@@ -255,7 +255,7 @@ case $RELEASE in
 		DEBOOTSTRAP_LIST+=" rng-tools"
 		[[ -z $BUILD_MINIMAL || $BUILD_MINIMAL == no ]] && PACKAGE_LIST_RELEASE="man-db kbd net-tools gnupg2 dirmngr networkd-dispatcher"
 		PACKAGE_LIST_DESKTOP+=" xserver-xorg-input-all paprefs dbus-x11 pulseaudio-module-gsettings onboard"
-		PACKAGE_LIST_DESKTOP_RECOMMENDS+=" firefox system-config-printer-common system-config-printer \
+		PACKAGE_LIST_DESKTOP_RECOMMENDS+=" chromium system-config-printer-common system-config-printer \
 								language-selector-gnome mirage"
 		PACKAGE_LIST_DESKTOP_FULL+=" thunderbird"
 		PACKAGE_LIST_PREDEPENDS="policykit-1-gnome notification-daemon"

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -168,6 +168,36 @@ create_sources_list()
 	;;
 	esac
 
+	# workaround for Chromium by downloading it from Debian
+	if [[ $release == focal || $release == eoan ]]; then
+
+		cat <<-EOF > $basedir/etc/apt/preferences.d/chromium.pref
+		# Note: 2 blank lines are required between entries
+		Package: *
+		Pin: release a=${release}
+		Pin-Priority: 500
+
+		Package: *
+		Pin: origin "${DEBIAN_MIRROR//\/debian}"
+		Pin-Priority: 300
+
+		# Pattern includes 'chromium', 'chromium-browser' and similarly
+		# named dependencies:
+		Package: chromium*
+		Pin: origin "${DEBIAN_MIRROR//\/debian}"
+		Pin-Priority: 700
+		EOF
+
+		cat <<-EOF > $basedir/etc/apt/sources.list.d/debian.list
+		deb http://${DEBIAN_MIRROR} stable main
+		deb http://${DEBIAN_MIRROR} stable-updates main
+		deb http://${DEBIAN_MIRROR}-security stable/updates main
+		EOF
+
+		chroot "${SDCARD}" /bin/bash -c "apt-key add /usr/share/keyrings/debian-archive-keyring.gpg >/dev/null 2>&1"
+
+	fi
+
 	# stage: add armbian repository and install key
 	if [[ $DOWNLOAD_MIRROR == "china" ]]; then
 		echo "deb http://mirrors.tuna.tsinghua.edu.cn/armbian $RELEASE main ${RELEASE}-utils ${RELEASE}-desktop" > $SDCARD/etc/apt/sources.list.d/armbian.list


### PR DESCRIPTION
Ubuntu only provides snap packed Chromium since 19.10 while Armbian comes without snapd. It is optional.

A workaround is by adding Debian stable repository and use pinning magic.

Closes [AR-278]

[AR-278]: https://armbian.atlassian.net/browse/AR-278