### PR TITLE
Set Rock Pi S dev targets as stable

### DIFF
--- a/config/targets.conf
+++ b/config/targets.conf
@@ -799,8 +799,8 @@ rockpi-s			legacy			buster		cli			stable	yes
 rockpi-s			legacy			bionic		minimal			stable	yes
 rockpi-s			legacy			bullseye	minimal			stable	yes
 rockpi-s			legacy			focal		cli			stable	yes
-rockpi-s			dev			focal		cli			beta	yes
-rockpi-s			dev			buster		cli			beta	yes
+rockpi-s			dev			focal		cli			stable	yes
+rockpi-s			dev			buster		cli			stable	yes
 
 # Rock64pro
 


### PR DESCRIPTION
So that we get some 5.x kernel images automagically at [armbian.com/rockpi-s/](https://www.armbian.com/rockpi-s/)