### PR TITLE
Enable vcc_sd regulator on boot for NanoPi R2S

### DIFF
--- a/patch/kernel/rockchip64-current/add-board-nanopi-r2s.patch
+++ b/patch/kernel/rockchip64-current/add-board-nanopi-r2s.patch
@@ -333,7 +333,7 @@ new file mode 100644
 index 000000000..36890bb7f
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-nanopi-r2-common.dtsi
-@@ -0,0 +1,624 @@
+@@ -0,0 +1,625 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2018 FriendlyElec Computer Tech. Co., Ltd.
@@ -423,6 +423,7 @@ index 000000000..36890bb7f
 +		gpio = <&gpio0 30 GPIO_ACTIVE_LOW>;
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&sdmmc0m1_gpio>;
++		regulator-boot-on;
 +		regulator-name = "vcc_sd";
 +		regulator-min-microvolt = <3300000>;
 +		regulator-max-microvolt = <3300000>;

--- a/patch/kernel/rockchip64-dev/add-board-nanopi-r2s.patch
+++ b/patch/kernel/rockchip64-dev/add-board-nanopi-r2s.patch
@@ -333,7 +333,7 @@ new file mode 100644
 index 000000000..36890bb7f
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-nanopi-r2-common.dtsi
-@@ -0,0 +1,624 @@
+@@ -0,0 +1,625 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2018 FriendlyElec Computer Tech. Co., Ltd.
@@ -423,6 +423,7 @@ index 000000000..36890bb7f
 +		gpio = <&gpio0 30 GPIO_ACTIVE_LOW>;
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&sdmmc0m1_gpio>;
++		regulator-boot-on;
 +		regulator-name = "vcc_sd";
 +		regulator-min-microvolt = <3300000>;
 +		regulator-max-microvolt = <3300000>;


### PR DESCRIPTION
NanoPi R2S has the same issue as ROC-RK3328-CC.

With working GPIO, during init the GPIO state's reset.
This causes the sdmmc regulator to shut down, preventing detection.
Removing and replacing the card will allow it to be detected, but that should not be necessary.
Fix this by setting the regulator on at boot.

Signed-off-by: Peter Geis <pgwipeout@gmail.com>
Link: https://github.com/torvalds/linux/commit/75aa567803b15e679432655badf95cd30b66b930
Signed-off-by: Jayantajit Gogoi <jayanta.gogoi525@gmail.com>