### PR TITLE
Rework of image signing. 

### DIFF
--- a/lib/build-all-ng.sh
+++ b/lib/build-all-ng.sh
@@ -83,6 +83,7 @@ pack_upload ()
 	if [[ $COMPRESS_OUTPUTIMAGE == *gz* ]]; then
 		display_alert "Compressing" "$DEST/images/${version}.img.gz" "info"
 		pigz $DESTIMG/${version}.img
+		rm ${DESTIMG}/${version}.img
 		compression_type=".gz"
 	fi
 


### PR DESCRIPTION
Now we compress the image first, then sign that archive. Old way - 7z - remains the same.

Based on @belfastraven work 
https://github.com/belfastraven/build/blob/pre-new-doc/lib/debootstrap.sh

Tested all variant, except automated build_all which is an internal function anyway.

Closing [AR-213]

[AR-213]: https://armbian.atlassian.net/browse/AR-213