### PR TITLE
Allwinner H6 - Remove CPU soft-cap

### DIFF
--- a/config/sources/families/sun50iw6.conf
+++ b/config/sources/families/sun50iw6.conf
@@ -6,7 +6,7 @@ OVERLAY_PREFIX='sun50i-h6'
 BOOTENV_FILE='sun50iw2-next.txt'
 
 [[ -z $CPUMIN ]] && CPUMIN=480000
-[[ -z $CPUMAX ]] && CPUMAX=1488000
+[[ -z $CPUMAX ]] && CPUMAX=1810000
 GOVERNOR=ondemand
 
 ASOUND_STATE='asound.state.sun50iw2-dev'


### PR DESCRIPTION
No longer necessary due to the recently added thermal trips
