### PR TITLE
delete Checking out sources from compile_uboot()

### DIFF
--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -140,9 +140,6 @@ compile_uboot()
 		local target_patchdir=$(cut -d';' -f2 <<< $target)
 		local target_files=$(cut -d';' -f3 <<< $target)
 
-		display_alert "Checking out sources"
-		git checkout -f -q HEAD
-
 		if [[ $CLEAN_LEVEL == *make* ]]; then
 			display_alert "Cleaning" "$BOOTSOURCEDIR" "info"
 			(cd $SRC/cache/sources/$BOOTSOURCEDIR; make clean > /dev/null 2>&1)


### PR DESCRIPTION
At this point the repository is already clean,
and the next line is not needed.

Fix issues armbian#1952