### PR TITLE
Fix file encoding of the locale generator

### DIFF
--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -189,9 +189,8 @@ create_rootfs_cache()
 		# stage: configure language and locales
 		display_alert "Configuring locales" "$DEST_LANG" "info"
 
-		[[ -f $SDCARD/etc/locale.gen ]] && sed -i "s/^# $DEST_LANG/$DEST_LANG/" $SDCARD/etc/locale.gen
-		eval 'LC_ALL=C LANG=C chroot $SDCARD /bin/bash -c "locale-gen $DEST_LANG"' ${OUTPUT_VERYSILENT:+' >/dev/null 2>/dev/null'}
-		eval 'LC_ALL=C LANG=C chroot $SDCARD /bin/bash -c "update-locale LANG=$DEST_LANG LANGUAGE=$DEST_LANG LC_MESSAGES=$DEST_LANG"' \
+		eval 'chroot $SDCARD /bin/bash -c "locale-gen en_US.UTF-8 $DEST_LANG"' ${OUTPUT_VERYSILENT:+' >/dev/null 2>/dev/null'}
+		eval 'chroot $SDCARD /bin/bash -c "update-locale LANG=$DEST_LANG LANGUAGE=$DEST_LANG LC_MESSAGES=$DEST_LANG"' \
 			${OUTPUT_VERYSILENT:+' >/dev/null 2>/dev/null'}
 
 		if [[ -f $SDCARD/etc/default/console-setup ]]; then


### PR DESCRIPTION
This is a minimal fix for the correct display
of characters in the applications, especially the console.

For example, if the locale-gen command is only for one locale
locale-gen ru_RU.UTF-8
Then the console application MC instead of a line in the frame outputs:

@
@@@@@@@@@@@@@@@@@@
@   README.md
@@@@@@@@@@@@@@@@@@
@
@

Setting variables to LC_ALL=C LANG=C is not necessary in this construction.
The line with the editor is not needed.
The 'locale-gen en_US.UTF-8 xx_XX.UTF-8' command
will fix this file itself.