### PR TITLE
delete additional modules-line in nanopia64.csc

### DIFF
--- a/config/boards/nanopia64.csc
+++ b/config/boards/nanopia64.csc
@@ -2,6 +2,5 @@
 BOARD_NAME="NanoPi A64"
 BOARDFAMILY="sun50iw1"
 BOOTCONFIG="nanopi_a64_defconfig"
-MODULES="sunxi_codec sunxi_i2s sunxi_sndcodec 8723bs"
 KERNEL_TARGET="current,dev"
 FULL_DESKTOP="yes"


### PR DESCRIPTION
these modules arent in the image and also wouldnt be used for sound & network, because other modules are doing this work.
This - now deleted - module-line does generate a error-message in the onscreen-boot-log (not in dmesg) and can be read via :
systemctl status systemd-modules-load.service

result of this command:
Jun 04 13:07:49 npi-a64 systemd-modules-load[531]: Failed to find module 'sunxi_codec'
Jun 04 13:07:49 npi-a64 systemd-modules-load[531]: Failed to find module 'sunxi_i2s'
Jun 04 13:07:49 npi-a64 systemd-modules-load[531]: Failed to find module 'sunxi_sndcodec'
Jun 04 13:07:49 npi-a64 systemd-modules-load[531]: Failed to find module '8723bs'

without this module-line /etc/modules should be empty and the error-message is gone away
the 8723bs seems to be a artifact of teh former PineA64 image where the NanoPi A64 was forrmerly build of.
Maybe also the other 3 modules.