### PR TITLE
Downgraded DDR blob for RockPi 4 to fix 1GB model boot issue

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -30,7 +30,7 @@ elif [[ $BOARD == rockpi-4* ]]; then
 
 	BOOT_USE_BLOBS=yes
 	BOOT_SOC=rk3399
-	DDR_BLOB='rk33/rk3399_ddr_933MHz_v1.24.bin'
+	DDR_BLOB='rk33/rk3399_ddr_933MHz_v1.20.bin' # 1GB model does not boot with later versions
 	MINILOADER_BLOB='rk33/rk3399_miniloader_v1.19.bin'
 	BL31_BLOB='rk33/rk3399_bl31_v1.30.elf'
 


### PR DESCRIPTION
Closes: AR-282

[Tested by forum user `foo`](https://forum.armbian.com/topic/14277-rock-pi-4a-1g/?do=findComment&comment=103229).