### PR TITLE
Disabled HDMI in mainline u-boot for rk3399 boards

### DIFF
--- a/patch/u-boot/u-boot-rockchip64-mainline/rk3399-disable-hdmi.patch
+++ b/patch/u-boot/u-boot-rockchip64-mainline/rk3399-disable-hdmi.patch
@@ -1,0 +1,124 @@
+diff --git a/configs/nanopc-t4-rk3399_defconfig b/configs/nanopc-t4-rk3399_defconfig
+index 607a00db..9ea9b115 100644
+--- a/configs/nanopc-t4-rk3399_defconfig
++++ b/configs/nanopc-t4-rk3399_defconfig
+@@ -52,12 +52,5 @@ CONFIG_USB_ETHER_ASIX88179=y
+ CONFIG_USB_ETHER_MCS7830=y
+ CONFIG_USB_ETHER_RTL8152=y
+ CONFIG_USB_ETHER_SMSC95XX=y
+-CONFIG_USB_KEYBOARD=y
+ CONFIG_SPL_TINY_MEMSET=y
+ CONFIG_ERRNO_STR=y
+-CONFIG_DM_VIDEO=y
+-CONFIG_VIDEO_BPP16=y
+-CONFIG_VIDEO_BPP32=y
+-CONFIG_DISPLAY=y
+-CONFIG_VIDEO_ROCKCHIP=y
+-CONFIG_DISPLAY_ROCKCHIP_HDMI=y
+diff --git a/configs/nanopi-m4-rk3399_defconfig b/configs/nanopi-m4-rk3399_defconfig
+index 3fcb7ac2..ad0e808b 100644
+--- a/configs/nanopi-m4-rk3399_defconfig
++++ b/configs/nanopi-m4-rk3399_defconfig
+@@ -52,12 +52,5 @@ CONFIG_USB_ETHER_ASIX88179=y
+ CONFIG_USB_ETHER_MCS7830=y
+ CONFIG_USB_ETHER_RTL8152=y
+ CONFIG_USB_ETHER_SMSC95XX=y
+-CONFIG_USB_KEYBOARD=y
+ CONFIG_SPL_TINY_MEMSET=y
+ CONFIG_ERRNO_STR=y
+-CONFIG_DM_VIDEO=y
+-CONFIG_VIDEO_BPP16=y
+-CONFIG_VIDEO_BPP32=y
+-CONFIG_DISPLAY=y
+-CONFIG_VIDEO_ROCKCHIP=y
+-CONFIG_DISPLAY_ROCKCHIP_HDMI=y
+diff --git a/configs/nanopi-m4v2-rk3399_defconfig b/configs/nanopi-m4v2-rk3399_defconfig
+index 0b7077ca..45d05078 100644
+--- a/configs/nanopi-m4v2-rk3399_defconfig
++++ b/configs/nanopi-m4v2-rk3399_defconfig
+@@ -55,15 +55,8 @@ CONFIG_USB_ETHER_ASIX88179=y
+ CONFIG_USB_ETHER_MCS7830=y
+ CONFIG_USB_ETHER_RTL8152=y
+ CONFIG_USB_ETHER_SMSC95XX=y
+-CONFIG_USB_KEYBOARD=y
+ CONFIG_SPL_TINY_MEMSET=y
+ CONFIG_ERRNO_STR=y
+-CONFIG_DM_VIDEO=y
+-CONFIG_VIDEO_BPP16=y
+-CONFIG_VIDEO_BPP32=y
+-CONFIG_DISPLAY=y
+-CONFIG_VIDEO_ROCKCHIP=y
+-CONFIG_DISPLAY_ROCKCHIP_HDMI=y
+ CONFIG_LOG=y
+ CONFIG_LOG_CONSOLE=y
+ CONFIG_SPL_LOG=y
+diff --git a/configs/nanopi-neo4-rk3399_defconfig b/configs/nanopi-neo4-rk3399_defconfig
+index b9ea535e..d038a8ca 100644
+--- a/configs/nanopi-neo4-rk3399_defconfig
++++ b/configs/nanopi-neo4-rk3399_defconfig
+@@ -52,12 +52,5 @@ CONFIG_USB_ETHER_ASIX88179=y
+ CONFIG_USB_ETHER_MCS7830=y
+ CONFIG_USB_ETHER_RTL8152=y
+ CONFIG_USB_ETHER_SMSC95XX=y
+-CONFIG_USB_KEYBOARD=y
+ CONFIG_SPL_TINY_MEMSET=y
+ CONFIG_ERRNO_STR=y
+-CONFIG_DM_VIDEO=y
+-CONFIG_VIDEO_BPP16=y
+-CONFIG_VIDEO_BPP32=y
+-CONFIG_DISPLAY=y
+-CONFIG_VIDEO_ROCKCHIP=y
+-CONFIG_DISPLAY_ROCKCHIP_HDMI=y
+diff --git a/configs/orangepi-4-rk3399_defconfig b/configs/orangepi-4-rk3399_defconfig
+index 18ec369f..a0cb7628 100644
+--- a/configs/orangepi-4-rk3399_defconfig
++++ b/configs/orangepi-4-rk3399_defconfig
+@@ -55,15 +55,8 @@ CONFIG_USB_ETHER_ASIX88179=y
+ CONFIG_USB_ETHER_MCS7830=y
+ CONFIG_USB_ETHER_RTL8152=y
+ CONFIG_USB_ETHER_SMSC95XX=y
+-CONFIG_USB_KEYBOARD=y
+ CONFIG_SPL_TINY_MEMSET=y
+ CONFIG_ERRNO_STR=y
+-CONFIG_DM_VIDEO=y
+-CONFIG_VIDEO_BPP16=y
+-CONFIG_VIDEO_BPP32=y
+-CONFIG_DISPLAY=y
+-CONFIG_VIDEO_ROCKCHIP=y
+-CONFIG_DISPLAY_ROCKCHIP_HDMI=y
+ CONFIG_LOG=y
+ CONFIG_LOG_CONSOLE=y
+ CONFIG_SPL_LOG=y
+diff --git a/configs/roc-pc-rk3399_defconfig b/configs/roc-pc-rk3399_defconfig
+index be76524c..659c67a0 100644
+--- a/configs/roc-pc-rk3399_defconfig
++++ b/configs/roc-pc-rk3399_defconfig
+@@ -56,12 +56,5 @@ CONFIG_USB_ETHER_ASIX88179=y
+ CONFIG_USB_ETHER_MCS7830=y
+ CONFIG_USB_ETHER_RTL8152=y
+ CONFIG_USB_ETHER_SMSC95XX=y
+-CONFIG_USB_KEYBOARD=y
+ CONFIG_SPL_TINY_MEMSET=y
+ CONFIG_ERRNO_STR=y
+-CONFIG_DM_VIDEO=y
+-CONFIG_VIDEO_BPP16=y
+-CONFIG_VIDEO_BPP32=y
+-CONFIG_DISPLAY=y
+-CONFIG_VIDEO_ROCKCHIP=y
+-CONFIG_DISPLAY_ROCKCHIP_HDMI=y
+diff --git a/include/configs/evb_rk3399.h b/include/configs/evb_rk3399.h
+index 2d3db228..c0b03588 100644
+--- a/include/configs/evb_rk3399.h
++++ b/include/configs/evb_rk3399.h
+@@ -6,11 +6,6 @@
+ #ifndef __EVB_RK3399_H
+ #define __EVB_RK3399_H
+ 
+-#define ROCKCHIP_DEVICE_SETTINGS \
+-		"stdin=serial,usbkbd\0" \
+-		"stdout=serial,vidconsole\0" \
+-		"stderr=serial,vidconsole\0"
+-
+ #include <configs/rk3399_common.h>
+ 
+ #if defined(CONFIG_ENV_IS_IN_MMC)


### PR DESCRIPTION
AR-308

One of the change in u-boot v2020.04 was the enablement of HDMI in u-boot.
I tested this scenario while upgrading u-boot with WQHD Dell u2719d which I have access to and it was working.

However since the switch to u-boot v2020.04 there are already two reported cases that users cannot boot with monitor connected to HDMI during boot.
* https://forum.armbian.com/topic/14289-nanopi-m4-v1-wont-boot-latest-versions/
* https://forum.armbian.com/topic/13865-nanopc-t4-will-not-boot-image-made-with-current-build-script-bug/

Let's disable HDMI in u-boot for rk3399 for now as it does not seem to be prime time ready yet.