### PR TITLE
Enabling IGNORE_UPDATES back

### DIFF
--- a/lib/build-all-ng.sh
+++ b/lib/build-all-ng.sh
@@ -307,7 +307,7 @@ function build_all()
 		if [[ "${BUILD_STABILITY}" == "${STABILITY}" ]]; then
 
 			# check if currnt hash is the same as upstream
-			if [[ $(check_hash) != idential ]]; then
+			if [[ $(check_hash) != idential || "$IGNORE_HASH" == yes ]]; then
 
 			((n+=1))
 
@@ -341,7 +341,11 @@ function build_all()
 					for RELEASE in "${RELTARGETS[@]}"
 					do
 						display_alert "BSP for ${BOARD} ${BRANCH} ${RELEASE}."
-						build_main
+						if [[ $IGNORE_HASH == yes ]]; then
+							build_main &
+							else
+							build_main
+						fi
 						# unset non board related stuff
 						unset_all
 					done

--- a/lib/main.sh
+++ b/lib/main.sh
@@ -401,6 +401,9 @@ prepare_host
 [[ $CLEAN_LEVEL == *sources* ]] && cleaning "sources"
 
 # fetch_from_repo <url> <dir> <ref> <subdir_flag>
+
+# ignore updates help on building all images - for internal purposes
+if [[ $IGNORE_UPDATES != yes ]]; then
 display_alert "Downloading sources" "" "info"
 
 fetch_from_repo "$BOOTSOURCE" "$BOOTDIR" "$BOOTBRANCH" "yes"
@@ -423,6 +426,8 @@ install_rkbin_tools
 for option in $(tr ',' ' ' <<< "$CLEAN_LEVEL"); do
 	[[ $option != sources ]] && cleaning "$option"
 done
+
+fi
 
 # Compile u-boot if packed .deb does not exist or use the one from repository
 if [[ ! -f "${DEB_STORAGE}"/${CHOSEN_UBOOT}_${REVISION}_${ARCH}.deb ]]; then


### PR DESCRIPTION
This switch is used when we build all bsp packages in parallel. We don't want to slow things down https://ibb.co/YPYn9hR by checking external sources at this process. I overlooked at https://github.com/armbian/build/pull/2019 @The-going