### PR TITLE
Check the return code from 'make menuconfig' and abort compilation wi…

### DIFF
--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -354,6 +354,9 @@ compile_kernel()
 			'make $CTHREADS ARCH=$ARCHITECTURE CROSS_COMPILE="$CCACHE $KERNEL_COMPILER" oldconfig'
 		eval CCACHE_BASEDIR="$(pwd)" env PATH=$toolchain:$PATH \
 			'make $CTHREADS ARCH=$ARCHITECTURE CROSS_COMPILE="$CCACHE $KERNEL_COMPILER" ${KERNEL_MENUCONFIG:-menuconfig}'
+
+		[[ ${PIPESTATUS[0]} -ne 0 ]] && exit_with_error "Error kernel menuconfig failed"
+
 		# store kernel config in easily reachable place
 		display_alert "Exporting new kernel config" "$DEST/config/$LINUXCONFIG.config" "info"
 		cp .config $DEST/config/$LINUXCONFIG.config


### PR DESCRIPTION
…th a suitable message.

With reference to issue #2035 

I noticed that if my terminal window was too small, menuconfig would throw the error "Your display is too small to run Menuconfig! It must be at least 19 lines by 80 columns."
The kernel compilation would then proceed with default config. This I feel should not happen because of the fact that you wanted to configure the kernel through menuconfig then the default config is probably unsuitable, making the compilation that then takes place a waste of time, etc.
This PR adds a check on the return code from menuconfig which aborts compilation if 0 is not returned, this only affects the build when KERNEL_CONFIGURE="yes" either on the command line or set through the menu prompt.