### PR TITLE
Allow install to SD NAND for ROCK Pi S

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -44,7 +44,7 @@ elif [[ $BOARD == rockpi-s ]]; then
 	BOOT_USE_BLOBS=yes
 	BOOT_SOC=rk3308
 	DDR_BLOB='rk33/rk3308_ddr_589MHz_uart0_m0_v1.26.bin'
-	MINILOADER_BLOB='rk33/rk3308_miniloader_v1.13.bin'
+	MINILOADER_BLOB='rk33/rk3308_miniloader_sd_nand_v1.13.bin'
 	BL31_BLOB='rk33/rk3308_bl31_v2.10.elf'
 	CPUMAX="1296000"
 

--- a/packages/bsp/common/usr/sbin/nand-sata-install
+++ b/packages/bsp/common/usr/sbin/nand-sata-install
@@ -30,7 +30,7 @@ elif grep -q 'sun5i' /proc/cpuinfo; then DEVICE_TYPE="a13";
 else DEVICE_TYPE="a20"; fi
 BOOTLOADER="${CWD}/${DEVICE_TYPE}/bootloader"
 case ${LINUXFAMILY} in
-	rk3328|rk3399|rockchip64)
+	rk3328|rk3399|rockchip64|rockpis)
 		FIRSTSECTOR=32768
 		;;
 	*)


### PR DESCRIPTION
It can be used in one of these ways:

- writing an image straight to SD NAND (with `rkdeveloptool`)
- using `nand-sata-install` and choose install to `eMMC`

SD NAND is 1GiB max. so minimal is the only viable option.

Closes: AR-323