### PR TITLE
Fix filesystem resize for small media

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-resize-filesystem
+++ b/packages/bsp/common/usr/lib/armbian/armbian-resize-filesystem
@@ -62,7 +62,7 @@ do_expand_partition()
 				[[ $lastsector -lt $partend ]] && unset lastsector
 				;;
 		esac
-		# if SD card is larger than 4GB then create another partition behind first one(s)
+		# if SD card is larger than 4GiB then create another partition behind first one(s)
 		if [[ $capacity -ge 5 ]]; then
 			local secondpartition=$(( 32 * $(parted $rootdevicepath unit s print -sm | grep "^$rootdevicepath" | awk -F":" "{printf (\"%0d\", ( \$2 * 99 / 3200))}") -1 ))
 			if [[ $secondpartition -lt $partend ]]; then
@@ -70,17 +70,17 @@ do_expand_partition()
 			fi
 		fi
 	else
-		# check device capacity. If 4GB or below do not use whole card but leave a 5% spare area
+		# check device capacity. If 4GiB or below do not use whole card but leave a 5% spare area
 		# to help older cards with wear leveling and garbage collection. In case this reduced card
 		# capacity is less than the actual image capacity this is a clear sign that someone wants
 		# to use Armbian on a card of inappropriate size so he gets what he deserves (at least he
 		# should know what he's doing)
 		if [[ $capacity -lt 5 ]]; then # 4 GiB or less
-			local lastsector=$(parted $rootdevicepath unit s print -sm | grep "^$rootdevicepath" | awk -F":" "{print \$2 - (200 * 1024 * ( 1024 / \$4 ))}")
+			local lastsector=$(( 32 * $(parted $rootdevicepath unit s print -sm | grep "^$rootdevicepath" | awk -F":" "{printf (\"%0d\", ( \$2 * 95 / 3200))}") -1 ))
 			if [[ $lastsector -lt $partend ]]; then
 				unset lastsector
 			else
-				ResizeLog="4GB media so leaving 200MB spare area"
+				ResizeLog="4GiB or smaller media - leaving 5% spare area"
 			fi
 		elif [[ $capacity -lt 9 ]]; then # 8 GiB or less
 			# Leave 2 percent unpartitioned
@@ -88,7 +88,7 @@ do_expand_partition()
 			if [[ $lastsector -lt $partend ]]; then
 				unset lastsector
 			else
-				ResizeLog="8GB media so leaving 2 percent spare area"
+				ResizeLog="8GiB or smaller media - leaving 2% spare area"
 			fi
 		else
 			# Leave 1 percent unpartitioned
@@ -96,7 +96,7 @@ do_expand_partition()
 			if [[ $lastsector -lt $partend ]]; then
 				unset lastsector
 			else
-				ResizeLog="Leaving 1 percent spare area"
+				ResizeLog="Leaving 1% spare area"
 			fi
 		fi
 	fi

--- a/packages/bsp/common/usr/lib/armbian/armbian-resize-filesystem
+++ b/packages/bsp/common/usr/lib/armbian/armbian-resize-filesystem
@@ -131,8 +131,8 @@ do_expand_partition()
 		ext4)
 			resize2fs $rootsource >>${Log} 2>&1
 			# check whether reboot is necessary for resize2fs to take effect
-			local freesize=$(( $(findmnt --target / -n -o AVAIL -b) / 1048576 )) # MiB
-			if [[ $s != 0 || $freesize -lt 512 ]]; then
+			local usedpercent=$(findmnt --target / -n -o USE% -b) # images before resize have 70-75%
+			if [[ $s != 0 || $usedpercent -gt 70 ]]; then
 				touch /var/run/resize2fs-reboot
 				echo -e "\n### [resize2fs] Automated reboot needed to finish the resize procedure" >>${Log}
 			fi


### PR DESCRIPTION
Before the change filesystem resize reserved 200MiB for all media sizes below 4GiB.
For 1GiB it's almost 20%. According to the comment in code it should reserve 5% - let's do so.

Successfully resized filesystem was assessed by the available space size - 512MiB+ meant it was resized. For small media (1GiB) it was problematic.
Let's assess the success by used percent. Images before resize have 70(Desktop) to 75% used space.
Let's assume that if percent used is below 70% this means the filesystem was resized successfully.