### PR TITLE
Replace gpgv1

### DIFF
--- a/lib/general.sh
+++ b/lib/general.sh
@@ -849,7 +849,7 @@ prepare_host()
 	nfs-kernel-server btrfs-progs ncurses-term p7zip-full kmod dosfstools libc6-dev-armhf-cross \
 	curl patchutils liblz4-tool libpython2.7-dev linux-base swig aptly acl python3-dev python3-distutils \
 	locales ncurses-base pixz dialog systemd-container udev lib32stdc++6 libc6-i386 lib32ncurses5 lib32tinfo5 \
-	bison libbison-dev flex libfl-dev cryptsetup gpgv1 gnupg1 cpio aria2 pigz dirmngr python3-distutils"
+	bison libbison-dev flex libfl-dev cryptsetup gpg gnupg1 cpio aria2 pigz dirmngr python3-distutils"
 
 	local codename=$(lsb_release -sc)
 


### PR DESCRIPTION
Not haven the common gpg package leads into verification error (https://forum.armbian.com/topic/14455-error-verifying-gcc-linaro-2013/) but is also marked as deprecated (https://packages.ubuntu.com/focal/gpgv1)
