### PR TITLE
Make USB3 support of ROCK Pi E on par with other rk3328 boards

### DIFF
--- a/patch/kernel/rockchip64-current/add-board-rockpi-e.patch
+++ b/patch/kernel/rockchip64-current/add-board-rockpi-e.patch
@@ -15,7 +15,7 @@ new file mode 100644
 index 000000000..52732643f
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-rock-pi-e.dts
-@@ -0,0 +1,467 @@
+@@ -0,0 +1,470 @@
 +/*
 + * SPDX-License-Identifier: (GPL-2.0+ or MIT)
 + * Copyright (c) 2016 Fuzhou Rockchip Electronics Co., Ltd
@@ -79,6 +79,8 @@ index 000000000..52732643f
 +		gpio = <&gpio3 RK_PA7 GPIO_ACTIVE_HIGH>;
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&host_vbus_drv>;
++		regulator-always-on;
++		regulator-boot-on;
 +		regulator-name = "vcc_host_vbus";
 +		regulator-min-microvolt = <5000000>;
 +		regulator-max-microvolt = <5000000>;
@@ -466,6 +468,7 @@ index 000000000..52732643f
 +};
 +
 +&usbdrd_dwc3 {
++	dr_mode = "host";
 +	status = "okay";
 +};
 +

--- a/patch/kernel/rockchip64-dev/add-board-rockpi-e.patch
+++ b/patch/kernel/rockchip64-dev/add-board-rockpi-e.patch
@@ -15,7 +15,7 @@ new file mode 100644
 index 000000000..52732643f
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-rock-pi-e.dts
-@@ -0,0 +1,467 @@
+@@ -0,0 +1,470 @@
 +/*
 + * SPDX-License-Identifier: (GPL-2.0+ or MIT)
 + * Copyright (c) 2016 Fuzhou Rockchip Electronics Co., Ltd
@@ -79,6 +79,8 @@ index 000000000..52732643f
 +		gpio = <&gpio3 RK_PA7 GPIO_ACTIVE_HIGH>;
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&host_vbus_drv>;
++		regulator-always-on;
++		regulator-boot-on;
 +		regulator-name = "vcc_host_vbus";
 +		regulator-min-microvolt = <5000000>;
 +		regulator-max-microvolt = <5000000>;
@@ -466,6 +468,7 @@ index 000000000..52732643f
 +};
 +
 +&usbdrd_dwc3 {
++	dr_mode = "host";
 +	status = "okay";
 +};
 +


### PR DESCRIPTION
It is not complete and for sure not fully stable but at least on the same level as other rk3328 boards.

Closes: AR-326