### PR TITLE
user newer shellcheck, with less aggress coverage

### DIFF
--- a/.github/workflows/testpr.yml
+++ b/.github/workflows/testpr.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   shellcheck:
     name: shellcheck
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
        - name: Checkout repository
          uses: actions/checkout@v2
@@ -14,7 +14,7 @@ jobs:
        - name: Install required packages
          run: sudo apt-get install shellcheck
        - name: "lint libraries via shellcheck"
-         run: shellcheck --color -x -s bash lib/*.sh && echo "shellcheck lib/*.sh - OK";
+         run: shellcheck --color -x -s bash -S warning -e SC2034,SC1090,SC2154,SC2153 lib/*.sh && echo "shellcheck lib/*.sh - OK";
   build_sbc_kernel:
     name: Compile changed kernel
     # This job runs on self hosted Linux machine, with public label


### PR DESCRIPTION
newer shell check lets severity levels be specified..

using warning level.  eliminating a few checks that will be unlikely to be solved