### PR TITLE
Ignore BCM4345 and derivatives (all are UART based) in btsdio

### DIFF
--- a/patch/kernel/rockchip64-current/general-btsdio-ignore-uart-devs.patch
+++ b/patch/kernel/rockchip64-current/general-btsdio-ignore-uart-devs.patch
@@ -1,0 +1,18 @@
+Some UART BT devices wrongly present themselves as SDIO - probably
+because their WiFi counterparts are SDIO based.
+This leads to creating a non functional fantom hci0 device.
+
+This happens with AP6256 seen on both ROCK Pi 4 and OrangePi 4.
+
+diff --git a/drivers/bluetooth/btsdio.c b/drivers/bluetooth/btsdio.c
+index fd9571d5f..26b16dd11 100644
+--- a/drivers/bluetooth/btsdio.c
++++ b/drivers/bluetooth/btsdio.c
+@@ -286,6 +286,7 @@ static int btsdio_probe(struct sdio_func *func,
+ 		switch (func->device) {
+ 		case SDIO_DEVICE_ID_BROADCOM_43341:
+ 		case SDIO_DEVICE_ID_BROADCOM_43430:
++		case SDIO_DEVICE_ID_BROADCOM_4345:
+ 		case SDIO_DEVICE_ID_BROADCOM_4356:
+ 			return -ENODEV;
+ 		}

--- a/patch/kernel/rockchip64-dev/general-btsdio-ignore-uart-devs.patch
+++ b/patch/kernel/rockchip64-dev/general-btsdio-ignore-uart-devs.patch
@@ -1,0 +1,18 @@
+Some UART BT devices wrongly present themselves as SDIO - probably
+because their WiFi counterparts are SDIO based.
+This leads to creating a non functional fantom hci0 device.
+
+This happens with AP6256 seen on both ROCK Pi 4 and OrangePi 4.
+
+diff --git a/drivers/bluetooth/btsdio.c b/drivers/bluetooth/btsdio.c
+index 199e8f7d4..2edb53bfe 100644
+--- a/drivers/bluetooth/btsdio.c
++++ b/drivers/bluetooth/btsdio.c
+@@ -295,6 +295,7 @@ static int btsdio_probe(struct sdio_func *func,
+ 		switch (func->device) {
+ 		case SDIO_DEVICE_ID_BROADCOM_43341:
+ 		case SDIO_DEVICE_ID_BROADCOM_43430:
++		case SDIO_DEVICE_ID_BROADCOM_4345:
+ 		case SDIO_DEVICE_ID_BROADCOM_4356:
+ 			return -ENODEV;
+ 		}


### PR DESCRIPTION
Some UART BT devices wrongly present themselves as SDIO - their WiFi counterparts are SDIO based.
This leads to creating a non functional fantom hci0 device alongside hci1.

This happens with AP6256 seen on both ROCK Pi 4b and OrangePi 4b.