### PR TITLE
Improve patch making

### DIFF
--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -758,7 +758,14 @@ userpatch_create()
 	local patch="$DEST/patch/$1-$LINUXFAMILY-$BRANCH.patch"
 
 	# apply previous user debug mode created patches
-	[[ -f $patch ]] && display_alert "Applying existing $1 patch" "$patch" "wrn" && patch --batch --silent -p1 -N < "${patch}"
+	if [[ -f $patch ]]; then
+		display_alert "Applying existing $1 patch" "$patch" "wrn" && patch --batch --silent -p1 -N < "${patch}"
+		# read title of a patch in case Git is configured
+		if [[ -n $(git config user.email) ]]; then
+			COMMIT_MESSAGE=$(cat "${patch}" | grep Subject | sed -n -e '0,/PATCH/s/.*PATCH]//p' | xargs)
+			display_alert "Patch name extracted" "$COMMIT_MESSAGE" "wrn"
+		fi
+	fi
 
 	# prompt to alter source
 	display_alert "Make your changes in this directory:" "$(pwd)" "wrn"
@@ -768,7 +775,20 @@ userpatch_create()
 	git add .
 	# create patch out of changes
 	if ! git diff-index --quiet --cached HEAD; then
-		git diff --staged > "${patch}"
+		# If Git is configured, create proper patch and ask for a name
+		if [[ -n $(git config user.email) ]]; then
+			display_alert "Add / change patch name" "$COMMIT_MESSAGE" "wrn"
+			read -e -p "Patch description: " -i "$COMMIT_MESSAGE" COMMIT_MESSAGE
+			[[ -z "$COMMIT_MESSAGE" ]] && COMMIT_MESSAGE="Patch made with https://github.com/armbian/build"
+			git commit -s -m "$COMMIT_MESSAGE"
+			git format-patch -1 HEAD --stdout --signature="Created with Armbian build tools https://github.com/armbian/build" > "${patch}"
+			PATCHFILE=$(git format-patch -1 HEAD)
+			# create a symlink to have a nice name ready
+			find $DEST/patch/ -type l -delete # delete any existing
+			ln -sf $patch $DEST/patch/$PATCHFILE
+		else
+			git diff --staged > "${patch}"
+		fi
 		display_alert "You will find your patch here:" "$patch" "info"
 	else
 		display_alert "No changes found, skipping patch creation" "" "wrn"

--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -783,6 +783,7 @@ userpatch_create()
 			git commit -s -m "$COMMIT_MESSAGE"
 			git format-patch -1 HEAD --stdout --signature="Created with Armbian build tools https://github.com/armbian/build" > "${patch}"
 			PATCHFILE=$(git format-patch -1 HEAD)
+			rm $PATCHFILE # delete the actual file
 			# create a symlink to have a nice name ready
 			find $DEST/patch/ -type l -delete # delete any existing
 			ln -sf $patch $DEST/patch/$PATCHFILE

--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -779,7 +779,7 @@ userpatch_create()
 		if [[ -n $(git config user.email) ]]; then
 			display_alert "Add / change patch name" "$COMMIT_MESSAGE" "wrn"
 			read -e -p "Patch description: " -i "$COMMIT_MESSAGE" COMMIT_MESSAGE
-			[[ -z "$COMMIT_MESSAGE" ]] && COMMIT_MESSAGE="Patch made with https://github.com/armbian/build"
+			[[ -z "$COMMIT_MESSAGE" ]] && COMMIT_MESSAGE="Patching something"
 			git commit -s -m "$COMMIT_MESSAGE"
 			git format-patch -1 HEAD --stdout --signature="Created with Armbian build tools https://github.com/armbian/build" > "${patch}"
 			PATCHFILE=$(git format-patch -1 HEAD)


### PR DESCRIPTION
When we are making a patch from a source code change with a help of CREATE_PATCHES="yes" we actually only get a diff from the code. But to make use of this patch, one has be named and signed. 

* [x] recognize if Git credentials are defined
* [x] make a signed patch with use of git format-patch
* [x] prompt for name
* [x] provide named patch as a temporally link

Before:

    diff --git a/arch/arm64/boot/dts/allwinner/sun50i-a64-teres-i.dts b/arch/arm64/boot/dts/allwinner/sun50i-a64-teres-i.dts
    index 0356608ce..5ec3e95ac 100644
    --- a/arch/arm64/boot/dts/allwinner/sun50i-a64-teres-i.dts
    +++ b/arch/arm64/boot/dts/allwinner/sun50i-a64-teres-i.dts
    @@ -28,7 +28,7 @@
     		power-supply = <&reg_dcdc1>;
     		brightness-levels = <0 5 7 10 14 20 28 40 56 80 112>;
     		default-brightness-level = <5>;
    -		enable-gpios = <&pio 3 23 GPIO_ACTIVE_HIGH>; /* PD23 */
    +		enable-gpios = <&pio 3 21 GPIO_ACTIVE_HIGH>; /* PD21 */
     	};
     
     	chosen {`
After:

    From b854307531204eb43354aecfde987fbf18ec5787 Mon Sep 17 00:00:00 2001
    From: Igor Pecovnik <igor.pecovnik@gmail.com>
    Date: Sun, 28 Jun 2020 11:41:43 +0200
    Subject: [PATCH] This is a very important change
    
    Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
    ---
     arch/arm64/boot/dts/allwinner/sun50i-a64-teres-i.dts | 2 +-
     1 file changed, 1 insertion(+), 1 deletion(-)
    
    diff --git a/arch/arm64/boot/dts/allwinner/sun50i-a64-teres-i.dts b/arch/arm64/boot/dts/allwinner/sun50i-a64-teres-i.dts
    index 0356608ce..5ec3e95ac 100644
    --- a/arch/arm64/boot/dts/allwinner/sun50i-a64-teres-i.dts
    +++ b/arch/arm64/boot/dts/allwinner/sun50i-a64-teres-i.dts
    @@ -28,7 +28,7 @@
     		power-supply = <&reg_dcdc1>;
     		brightness-levels = <0 5 7 10 14 20 28 40 56 80 112>;
     		default-brightness-level = <5>;
    -		enable-gpios = <&pio 3 23 GPIO_ACTIVE_HIGH>; /* PD23 */
    +		enable-gpios = <&pio 3 21 GPIO_ACTIVE_HIGH>; /* PD21 */
     	};
     
     	chosen {
    -- 
    Created with Armbian build tools https://github.com/armbian/build
Closes [AR-335]

[AR-335]: https://armbian.atlassian.net/browse/AR-335