### PR TITLE
Disable offloading on RK3399 network devices

### DIFF
--- a/packages/bsp/common/etc/NetworkManager/dispatcher.d/30-offload
+++ b/packages/bsp/common/etc/NetworkManager/dispatcher.d/30-offload
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# With offloading enabled, Samba becomes completely useless - transfers to a Windows PC freezes randomly
+# Disabling offloading should solve this - all RK3399
+
+IFACE=$1
+EVENT=$2
+
+if [[ "$EVENT" != "up" ]]; then
+        exit 1
+fi
+
+ETHTOOL=/sbin/ethtool
+
+[ -f $ETHTOOL ] || exit 2
+[ -d /sys/devices/platform/fe300000.ethernet/net/$IFACE ] || exit 3
+
+$ETHTOOL -K $IFACE rx off tx off
+exit 0

--- a/packages/bsp/common/etc/NetworkManager/dispatcher.d/30-offload
+++ b/packages/bsp/common/etc/NetworkManager/dispatcher.d/30-offload
@@ -9,7 +9,7 @@ if [[ "$EVENT" != "up" ]]; then
         exit 1
 fi
 
-if linux-version compare $(uname -r | cut -d '.' -f1,2) le 5.4; then
+if linux-version compare $(uname -r | cut -d '.' -f1,2) gt 4.4; then
 	exit 1
 fi
 

--- a/packages/bsp/common/etc/NetworkManager/dispatcher.d/30-offload
+++ b/packages/bsp/common/etc/NetworkManager/dispatcher.d/30-offload
@@ -9,6 +9,11 @@ if [[ "$EVENT" != "up" ]]; then
         exit 1
 fi
 
+if linux-version compare $(uname -r | cut -d '.' -f1,2) le 5.4; then
+	exit 1
+fi
+
+
 ETHTOOL=/sbin/ethtool
 
 [ -f $ETHTOOL ] || exit 2


### PR DESCRIPTION
Not sure if we can add this script for all? Is /sys/devices/platform/fe300000.ethernet/net/ goot enough id?

* [x] Add kernel version checking since we only need this for legacy

Closes [AR-348]

[AR-348]: https://armbian.atlassian.net/browse/AR-348