### PR TITLE
Update 30-armbian-sysinfo

### DIFF
--- a/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
+++ b/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
@@ -168,7 +168,7 @@ getboardtemp
 critical_load=$(( 1 + $(grep -c processor /proc/cpuinfo) / 2 ))
 
 # get uptime, logged in users and load in one take
-UPTIME=$(uptime)
+UPTIME=$(LC_ALL=C uptime)
 UPT1=${UPTIME#*'up '}
 UPT2=${UPT1%'user'*}
 users=${UPT2//*','}


### PR DESCRIPTION
Fix for locales where the decimal separator is a 'comma'. For these systems `uptime` would output `load average: 0,06, 0,08, 0,07`. And then it would be possible for `006` to be above `critical_load`. Forcing the dot separator with `LC_ALL=C uptime` fixes this issue.
