### PR TITLE
backport Linux v5.8 fbtft/fb_st7789v invert colors, proper gamma

### DIFF
--- a/lib/compilation-prepare.sh
+++ b/lib/compilation-prepare.sh
@@ -498,4 +498,10 @@ compilation_prepare()
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723du.patch" "applying"
 	fi
 
+
+	if linux-version compare $version ge 4.4 && linux-version compare $version lt 5.8; then
+		display_alert "Adjustin" "Framebuffer driver for ST7789 IPS display" "info"
+		process_patch_file "${SRC}/patch/misc/fbtft-st7789v-invert-color.patch" "applying"
+	fi
+
 }

--- a/patch/misc/fbtft-st7789v-invert-color.patch
+++ b/patch/misc/fbtft-st7789v-invert-color.patch
@@ -1,0 +1,82 @@
+diff --git a/drivers/staging/fbtft/fb_st7789v.c b/drivers/staging/fbtft/fb_st7789v.c
+index 3c3f38793..3a280cc18 100644
+--- a/drivers/staging/fbtft/fb_st7789v.c
++++ b/drivers/staging/fbtft/fb_st7789v.c
+@@ -20,6 +20,12 @@
+ 	"70 2C 2E 15 10 09 48 33 53 0B 19 18 20 25\n" \
+ 	"70 2C 2E 15 10 09 48 33 53 0B 19 18 20 25"
+ 
++#define HSD20_IPS_GAMMA \
++	"D0 05 0A 09 08 05 2E 44 45 0F 17 16 2B 33\n" \
++	"D0 05 0A 09 08 05 2E 43 45 0F 16 16 2B 33"
++
++#define HSD20_IPS 1
++
+ /**
+  * enum st7789v_command - ST7789V display controller commands
+  *
+@@ -82,14 +88,20 @@ static int init_display(struct fbtft_par *par)
+ 
+ 	/* set pixel format to RGB-565 */
+ 	write_reg(par, MIPI_DCS_SET_PIXEL_FORMAT, MIPI_DCS_PIXEL_FMT_16BIT);
++	if (HSD20_IPS)
++		write_reg(par, PORCTRL, 0x05, 0x05, 0x00, 0x33, 0x33);
+ 
+-	write_reg(par, PORCTRL, 0x08, 0x08, 0x00, 0x22, 0x22);
++	else
++		write_reg(par, PORCTRL, 0x08, 0x08, 0x00, 0x22, 0x22);
+ 
+ 	/*
+ 	 * VGH = 13.26V
+ 	 * VGL = -10.43V
+ 	 */
+-	write_reg(par, GCTRL, 0x35);
++	if (HSD20_IPS)
++		write_reg(par, GCTRL, 0x75);
++	else
++		write_reg(par, GCTRL, 0x35);
+ 
+ 	/*
+ 	 * VDV and VRH register values come from command write
+@@ -101,13 +113,19 @@ static int init_display(struct fbtft_par *par)
+ 	 * VAP =  4.1V + (VCOM + VCOM offset + 0.5 * VDV)
+ 	 * VAN = -4.1V + (VCOM + VCOM offset + 0.5 * VDV)
+ 	 */
+-	write_reg(par, VRHS, 0x0B);
++	if (HSD20_IPS)
++		write_reg(par, VRHS, 0x13);
++	else
++		write_reg(par, VRHS, 0x0B);
+ 
+ 	/* VDV = 0V */
+ 	write_reg(par, VDVS, 0x20);
+ 
+ 	/* VCOM = 0.9V */
+-	write_reg(par, VCOMS, 0x20);
++	if (HSD20_IPS)
++		write_reg(par, VCOMS, 0x22);
++	else
++		write_reg(par, VCOMS, 0x20);
+ 
+ 	/* VCOM offset = 0V */
+ 	write_reg(par, VCMOFSET, 0x20);
+@@ -120,6 +138,10 @@ static int init_display(struct fbtft_par *par)
+ 	write_reg(par, PWCTRL1, 0xA4, 0xA1);
+ 
+ 	write_reg(par, MIPI_DCS_SET_DISPLAY_ON);
++
++	if (HSD20_IPS)
++		write_reg(par, MIPI_DCS_ENTER_INVERT_MODE);
++
+ 	return 0;
+ }
+ 
+@@ -234,7 +256,7 @@ static struct fbtft_display display = {
+ 	.height = 320,
+ 	.gamma_num = 2,
+ 	.gamma_len = 14,
+-	.gamma = DEFAULT_GAMMA,
++	.gamma = HSD20_IPS_GAMMA,
+ 	.fbtftops = {
+ 		.init_display = init_display,
+ 		.set_var = set_var,


### PR DESCRIPTION
https://github.com/torvalds/linux/commit/f03c9b7884720973d1673fbb64f808897ca88a12

Without this patch, st7789 LCD is black/white inverted.

Patch was created as following:
```
# armbian/build
git checkout v20.05
./compile.sh ... # to populate kernel sources
# copy fb_st7789v.c from github/torvalds/linux/master to cache/sources/...
cd cache/sources/.../fbtft/
git diff >/root/armbian/userpatches/kernel/sunxi-current/fbtft-st7789v-invert-color.patch
```
Patch was tested on real hardware in userpatches/kernel/sunxi-current/ directory. I just copied .patch file as is to patch/misc/.

This patch is obsolete when Armbian moves to Linux 5.8.