### PR TITLE
Removed NanoPi M4V2 firmware tweaks (not needed anymore)

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -262,12 +262,6 @@ family_tweaks()
 
 	fi
 
-	if [[ $BOARD == nanopim4v2 ]]; then
-		mv $SDCARD/lib/firmware/brcm/brcmfmac4356-sdio.bin{,.bak}
-		ln -s brcmfmac4356-sdio-nanopi-m4v2.bin $SDCARD/lib/firmware/brcm/brcmfmac4356-sdio.bin
-		ln -s brcmfmac4356-sdio-nanopi-m4v2.txt $SDCARD/lib/firmware/brcm/brcmfmac4356-sdio.friendlyarm,nanopi-m4.txt
-	fi
-
 }
 
 


### PR DESCRIPTION
The tweaks are not needed since a bit of cleanup done in https://github.com/armbian/firmware/pull/15

They were not surviving armbian-firmware* package upgrades anyway...

Closes: [AR-340]

[AR-340]: https://armbian.atlassian.net/browse/AR-340