### PR TITLE
Fixed running compile_uboot directly - broken since bce24a2

### DIFF
--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -155,12 +155,9 @@ compile_uboot()
 		target_patchdir=$(cut -d';' -f2 <<< "${target}")
 		target_files=$(cut -d';' -f3 <<< "${target}")
 
-		# only checkout when we go several times over the source
-		if [[ $target_cycles -ge 1 ]]; then
-			display_alert "Checking out to clean sources"
-			git checkout -f -q HEAD
-		fi
-		target_cycles=$((target_cycles+1))
+		# needed for multiple targets and for calling compile_uboot directly
+		display_alert "Checking out to clean sources"
+		git checkout -f -q HEAD
 
 		if [[ $CLEAN_LEVEL == *make* ]]; then
 			display_alert "Cleaning" "$BOOTSOURCEDIR" "info"


### PR DESCRIPTION
Let's revert the changes made in bce24a2 completely.

The cost of running checkout in case of already clean working copy is negligible and removing it broke running compile_uboot() directly from command line (`./compile.sh .... compile_uboot`) - direct runs do not involve fetching from repository.