### PR TITLE
Enable overlays for rockchip64-legacy

### DIFF
--- a/patch/kernel/rockchip64-legacy/general-add-overlay-compilation-support.patch
+++ b/patch/kernel/rockchip64-legacy/general-add-overlay-compilation-support.patch
@@ -1,0 +1,92 @@
+diff --git a/arch/arm/boot/.gitignore b/arch/arm/boot/.gitignore
+index 3c79f859..4e5c1d59 100644
+--- a/arch/arm/boot/.gitignore
++++ b/arch/arm/boot/.gitignore
+@@ -3,5 +3,6 @@ zImage
+ xipImage
+ bootpImage
+ uImage
+-*.dtb
+-zImage-dtb
+\ No newline at end of file
++*.dtb*
++*.scr
++zImage-dtb
+diff --git a/scripts/Makefile.dtbinst b/scripts/Makefile.dtbinst
+index 50d580d77..94bd15617 100644
+--- a/scripts/Makefile.dtbinst
++++ b/scripts/Makefile.dtbinst
+@@ -28,8 +28,11 @@ ifeq ("$(dtbinst-root)", "$(obj)")
+ 	$(Q)mkdir -p $(INSTALL_DTBS_PATH)
+ endif
+ 
+-dtbinst-files	:= $(dtb-y)
+-dtbinst-dirs	:= $(dts-dirs)
++dtbinst-files	:= $(sort $(dtb-y) $(if $(CONFIG_OF_ALL_DTBS), $(dtb-)))
++dtboinst-files	:= $(dtbo-y)
++script-files	:= $(scr-y)
++readme-files	:= $(dtbotxt-y)
++dtbinst-dirs	:= $(subdir-y) $(subdir-m)
+ 
+ # Helper targets for Installing DTBs into the boot directory
+ quiet_cmd_dtb_install =	INSTALL $<
+@@ -42,10 +45,19 @@ $(dtbinst-files) $(dtbinst-dirs): | __dtbs_install_prep
+ $(dtbinst-files): %.dtb: $(obj)/%.dtb
+ 	$(call cmd,dtb_install,$(install-dir))
+ 
++$(dtboinst-files): %.dtbo: $(obj)/%.dtbo
++	$(call cmd,dtb_install,$(install-dir))
++
++$(script-files): %.scr: $(obj)/%.scr
++	$(call cmd,dtb_install,$(install-dir))
++
++$(readme-files): %: $(src)/%
++	$(call cmd,dtb_install,$(install-dir))
++
+ $(dtbinst-dirs):
+ 	$(Q)$(MAKE) $(dtbinst)=$(obj)/$@
+ 
+-PHONY += $(dtbinst-files) $(dtbinst-dirs)
+-__dtbs_install: $(dtbinst-files) $(dtbinst-dirs)
++PHONY += $(dtbinst-files) $(dtboinst-files) $(script-files) $(readme-files) $(dtbinst-dirs)
++__dtbs_install: $(dtbinst-files) $(dtboinst-files) $(script-files) $(readme-files) $(dtbinst-dirs)
+ 
+ .PHONY: $(PHONY)
+diff --git a/scripts/Makefile.lib b/scripts/Makefile.lib
+index 58c05e5d..2b95dda9 100644
+--- a/scripts/Makefile.lib
++++ b/scripts/Makefile.lib
+@@ -278,6 +278,9 @@ cmd_gzip = (cat $(filter-out FORCE,$^) | gzip -n -f -9 > $@) || \
+ # ---------------------------------------------------------------------------
+ DTC ?= $(objtree)/scripts/dtc/dtc
+
++# Overlay support
++DTC_FLAGS += -@ -Wno-unit_address_format -Wno-simple_bus_reg
++
+ # Disable noisy checks by default
+ ifeq ($(KBUILD_ENABLE_EXTRA_GCC_CHECKS),)
+ DTC_FLAGS += -Wno-unit_address_vs_reg \
+@@ -324,6 +327,23 @@ cmd_dtc = mkdir -p $(dir ${dtc-tmp}) ; \
+ $(obj)/%.dtb: $(src)/%.dts FORCE
+ 	$(call if_changed_dep,dtc)
+
++quiet_cmd_dtco = DTCO    $@
++cmd_dtco = mkdir -p $(dir ${dtc-tmp}) ; \
++	$(CPP) $(dtc_cpp_flags) -x assembler-with-cpp -o $(dtc-tmp) $< ; \
++	$(DTC) -O dtb -o $@ -b 0 \
++		-i $(dir $<) $(DTC_FLAGS) \
++		-d $(depfile).dtc.tmp $(dtc-tmp) ; \
++	cat $(depfile).pre.tmp $(depfile).dtc.tmp > $(depfile)
++
++$(obj)/%.dtbo: $(src)/%.dts FORCE
++	$(call if_changed_dep,dtco)
++
++quiet_cmd_scr = MKIMAGE $@
++cmd_scr = mkimage -C none -A $(ARCH) -T script -d $< $@
++
++$(obj)/%.scr: $(src)/%.scr-cmd FORCE
++	$(call if_changed,scr)
++
+ dtc-tmp = $(subst $(comma),_,$(dot-target).dts.tmp)
+
+ # Bzip2

--- a/patch/kernel/rockchip64-legacy/general-rockchip-overlays.patch
+++ b/patch/kernel/rockchip64-legacy/general-rockchip-overlays.patch
@@ -1,0 +1,491 @@
+diff --git a/arch/arm64/boot/dts/rockchip/Makefile b/arch/arm64/boot/dts/rockchip/Makefile
+index 6a33eff..60fc91a 100644
+--- a/arch/arm64/boot/dts/rockchip/Makefile
++++ b/arch/arm64/boot/dts/rockchip/Makefile
+@@ -115,5 +118,5 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399pro-evb-v11-linux.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399pro-npu-evb-v10.dtb
+ 
+ always		:= $(dtb-y)
+-subdir-y	:= $(dts-dirs)
++subdir-y        := $(dts-dirs) overlay
+ clean-files	:= *.dtb
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts/rockchip/overlay/Makefile
+index e69de29..576e190 100644
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
+@@ -0,0 +1,22 @@
++# SPDX-License-Identifier: GPL-2.0
++dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
++	rockchip-i2c7.dtbo \
++	rockchip-i2c8.dtbo \
++	rockchip-pcie-gen2.dtbo \
++	rockchip-spi-jedec-nor.dtbo \
++	rockchip-spi-spidev.dtbo \
++	rockchip-uart4.dtbo \
++	rockchip-w1-gpio.dtbo
++
++scr-$(CONFIG_ARCH_ROCKCHIP) += \
++       rockchip-fixup.scr
++
++dtbotxt-$(CONFIG_ARCH_ROCKCHIP) += \
++       README.rockchip-overlays
++
++targets += $(dtbo-y) $(scr-y) $(dtbotxt-y)
++
++always         := $(dtbo-y) $(scr-y) $(dtbotxt-y)
++clean-files    := *.dtbo *.scr
++
++
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
+index e69de29..9512445 100644
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
+@@ -0,0 +1,106 @@
++This document describes overlays provided in the kernel packages
++For generic Armbian overlays documentation please see
++https://docs.armbian.com/User-Guide_Allwinner_overlays/
++
++### Platform:
++
++rockchip (Rockchip)
++
++### Provided overlays:
++
++- i2c7, i2c8, pcie-gen2, spi-spidev, uart4, w1-gpio
++
++### Overlay details:
++
++### i2c7
++
++Activates TWI/I2C bus 7
++
++I2C7 pins (SCL, SDA): GPIO2-B0, GPIO2-A7 GPIO1-C5, GPIO1-C4
++
++### i2c8
++
++Activates TWI/I2C bus 8
++
++I2C8 pins (SCL, SDA): GPIO1-C5, GPIO1-C4
++
++### pcie-gen2
++
++Enables PCIe Gen2 link speed on RK3399.
++WARNING! Not officially supported by Rockchip!!!
++
++### spi-jedec-nor
++
++Activates MTD support for JEDEC compatible SPI NOR flash chips on SPI bus
++supported by the kernel SPI NOR driver
++
++SPI 0 pins (MOSI, MISO, SCK, CS): GPIO3_A5, GPIO3_A4, GPIO3_A6, GPIO3_A7
++SPI 1 pins (MOSI, MISO, SCK, CS): GPIO1_A7, GPIO1_B0, GPIO1_B1, GPIO1_B2
++SPI 2 pins (MOSI, MISO, SCK, CS): GPIO1_C0, GPIO1_B7, GPIO1_C1, GPIO1_C2
++SPI 3 pins (MOSI, MISO, SCK, CS): GPIO2_B2, GPIO2_B1, GPIO2_B3, GPIO2_B4
++
++Parameters:
++
++param_spinor_spi_bus (int)
++	SPI bus to activate SPI NOR flash support on
++	Required
++	Supported values: 0, 1, 2
++
++param_spinor_max_freq (int)
++	Maximum SPI frequency
++	Optional
++	Default: 1000000
++	Range: 3000 - 100000000
++
++### spi-spidev
++
++Activates SPIdev device node (/dev/spidevX.Y) for userspace SPI access,
++where X is the bus number and Y is the CS number
++
++SPI 0 pins (MOSI, MISO, SCK, CS): GPIO3_A5, GPIO3_A4, GPIO3_A6, GPIO3_A7
++SPI 1 pins (MOSI, MISO, SCK, CS): GPIO1_A7, GPIO1_B0, GPIO1_B1, GPIO1_B2
++SPI 2 pins (MOSI, MISO, SCK, CS): GPIO1_C0, GPIO1_B7, GPIO1_C1, GPIO1_C2
++SPI 3 pins (MOSI, MISO, SCK, CS): GPIO2_B2, GPIO2_B1, GPIO2_B3, GPIO2_B4
++
++Parameters:
++
++param_spidev_spi_bus (int)
++	SPI bus to activate SPIdev support on
++	Required
++	Supported values: 0, 1
++
++param_spidev_spi_cs (int)
++	SPI chip select number
++	Optional
++	Default: 0
++	Supported values: 0, 1
++	Using chip select 1 requires using "spi-add-cs1" overlay
++
++param_spidev_max_freq (int)
++	Maximum SPIdev frequency
++	Optional
++	Default: 1000000
++	Range: 3000 - 100000000
++
++### uart4
++
++Activates UART4
++
++UART4 pins (RX, TX): GPIO1_A7, GPIO1_B0
++
++Notice: UART4 cannot be activated together with SPI1 - they share the sam pins.
++Enabling this overlay disables SPI1.
++
++### w1-gpio
++
++Activates 1-Wire GPIO master
++Requires an external pull-up resistor on the data pin
++or enabling the internal pull-up
++
++Parameters:
++
++param_w1_pin (pin)
++	Data pin for 1-Wire master
++	Optional
++	Default: PD14
++
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-fixup.scr-cmd b/arch/arm64/boot/dts/rockchip/overlay/rockchip-fixup.scr-cmd
+new file mode 100644
+index 0000000..d4c39e2
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-fixup.scr-cmd
+@@ -0,0 +1,62 @@
++# overlays fixup script
++# implements (or rather substitutes) overlay arguments functionality
++# using u-boot scripting, environment variables and "fdt" command
++
++setenv decompose_pin 'setexpr tmp_pinctrl sub "GPIO(0|1|2|3|4)_\\S\\d+" "\\1";
++setexpr tmp_bank sub "GPIO\\d_(\\S)\\d+" "\\1";
++test "${tmp_bank}" = "A" && setenv tmp_bank 0;
++test "${tmp_bank}" = "B" && setenv tmp_bank 1;
++test "${tmp_bank}" = "C" && setenv tmp_bank 2;
++test "${tmp_bank}" = "D" && setenv tmp_bank 3;
++setexpr tmp_pin sub "GPIO\\d_\\S(\\d+)" "\\1";
++setexpr tmp_bank ${tmp_bank} * 8;
++setexpr tmp_pin ${tmp_bank} + ${tmp_pin}'
++
++
++if test -n "${param_spinor_spi_bus}"; then
++	test "${param_spinor_spi_bus}" = "0" && setenv tmp_spi_path "spi@ff1c0000"
++	test "${param_spinor_spi_bus}" = "1" && setenv tmp_spi_path "spi@ff1d0000"
++	test "${param_spinor_spi_bus}" = "2" && setenv tmp_spi_path "spi@ff1e0000"
++	test "${param_spinor_spi_bus}" = "3" && setenv tmp_spi_path "spi@ff1f0000"
++	fdt set /${tmp_spi_path} status "okay"
++	fdt set /${tmp_spi_path}/spiflash@0 status "okay"
++	if test -n "${param_spinor_max_freq}"; then
++		fdt set /${tmp_spi_path}/spiflash@0 spi-max-frequency "<${param_spinor_max_freq}>"
++	fi
++	if test "${param_spinor_spi_cs}" = "1"; then
++		fdt set /${tmp_spi_path}/spiflash@0 reg "<1>"
++	fi
++	env delete tmp_spi_path
++fi
++
++if test -n "${param_spidev_spi_bus}"; then
++	test "${param_spidev_spi_bus}" = "0" && setenv tmp_spi_path "spi@ff1c0000"
++	test "${param_spidev_spi_bus}" = "1" && setenv tmp_spi_path "spi@ff1d0000"
++	test "${param_spidev_spi_bus}" = "2" && setenv tmp_spi_path "spi@ff1e0000"
++	test "${param_spidev_spi_bus}" = "3" && setenv tmp_spi_path "spi@ff1f0000"
++	fdt set /${tmp_spi_path} status "okay"
++	fdt set /${tmp_spi_path}/spidev status "okay"
++	if test -n "${param_spidev_max_freq}"; then
++		fdt set /${tmp_spi_path}/spidev spi-max-frequency "<${param_spidev_max_freq}>"
++	fi
++	if test "${param_spidev_spi_cs}" = "1"; then
++		fdt set /${tmp_spi_path}/spidev reg "<1>";
++	fi
++fi
++
++if test -n "${param_w1_pin}"; then
++	setenv tmp_pinctrl "${param_w1_pin}"
++	setenv tmp_bank "${param_w1_pin}"
++	setenv tmp_pin "${param_w1_pin}"
++	run decompose_pin
++	#echo "${param_w1_pin} ---> pinctrl = ${tmp_pinctrl}"
++	#echo "${param_w1_pin} ---> bank = ${tmp_bank}"
++	#echo "${param_w1_pin} ---> pin = ${tmp_pin}"
++	fdt get value tmp_pinctrl /__symbols__	gpio${tmp_pinctrl}
++	#echo "${param_w1_pin} ---> tmp_pinctrl = ${tmp_pinctrl}"
++	fdt get value tmp_phandle ${tmp_pinctrl} phandle
++	#echo "${param_w1_pin} ---> tmp_phandle = ${tmp_phandle}"
++	fdt set /onewire@0 gpios "<${tmp_phandle} 0x000000${tmp_pin} 0 0>"
++	env delete tmp_pinctrl tmp_bank tmp_pin tmp_phandle
++fi
++
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-i2c7.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-i2c7.dts
+new file mode 100644
+index 0000000..54bc844
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-i2c7.dts
+@@ -0,0 +1,11 @@
++/dts-v1/;
++
++/ {
++    compatible = "rockchip,rk3399";
++    fragment@0 {
++        target-path = "/i2c@ff160000";
++        __overlay__ {
++            status = "okay";
++        };
++    };
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-i2c8.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-i2c8.dts
+new file mode 100644
+index 0000000..54bc844
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-i2c8.dts
+@@ -0,0 +1,11 @@
++/dts-v1/;
++
++/ {
++    compatible = "rockchip,rk3399";
++    fragment@0 {
++        target-path = "/i2c@ff3e0000";
++        __overlay__ {
++            status = "okay";
++        };
++    };
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-pcie-gen2.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-pcie-gen2.dts
+new file mode 100644
+index 0000000..54bc844
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-pcie-gen2.dts
+@@ -0,0 +1,12 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++    compatible = "rockchip,rk3399";
++    fragment@0 {
++        target = <&pcie0>;
++        __overlay__ {
++            max-link-speed = <2>;
++        };
++    };
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-spi-jedec-nor.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-spi-jedec-nor.dts
+new file mode 100644
+index 0000000..3a2be38
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-spi-jedec-nor.dts
+@@ -0,0 +1,72 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "rockchip,rk3399";
++
++	fragment@0 {
++		target-path = "/aliases";
++		__overlay__ {
++			spi0 = "/spi@ff1c0000";
++			spi1 = "/spi@ff1d0000";
++			spi2 = "/spi@ff1e0000";
++			spi3 = "/spi@ff1f0000";
++		};
++	};
++
++	fragment@1 {
++		target = <&spi0>;
++		__overlay__ {
++			#address-cells = <1>;
++			#size-cells = <0>;
++			spiflash@0 {
++				compatible = "jedec,spi-nor";
++				reg = <0>;
++				spi-max-frequency = <10000000>;
++				status = "disabled";
++			};
++		};
++	};
++
++	fragment@2 {
++		target = <&spi1>;
++		__overlay__ {
++			#address-cells = <1>;
++			#size-cells = <0>;
++			spiflash@0 {
++				compatible = "jedec,spi-nor";
++				reg = <0>;
++				spi-max-frequency = <10000000>;
++				status = "disabled";
++			};
++		};
++	};
++
++	fragment@3 {
++		target = <&spi2>;
++		__overlay__ {
++			#address-cells = <1>;
++			#size-cells = <0>;
++			spiflash@0 {
++				compatible = "jedec,spi-nor";
++				reg = <0>;
++				spi-max-frequency = <10000000>;
++				status = "disabled";
++			};
++		};
++	};
++
++	fragment@4 {
++		target = <&spi3>;
++		__overlay__ {
++			#address-cells = <1>;
++			#size-cells = <0>;
++			spiflash@0 {
++				compatible = "jedec,spi-nor";
++				reg = <0>;
++				spi-max-frequency = <10000000>;
++				status = "disabled";
++			};
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-spi-spidev.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-spi-spidev.dts
+new file mode 100644
+index 0000000..fe8fb14
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-spi-spidev.dts
+@@ -0,0 +1,72 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "rockchip,rk3399";
++
++	fragment@0 {
++		target-path = "/aliases";
++		__overlay__ {
++			spi0 = "/spi@ff1c0000";
++			spi1 = "/spi@ff1d0000";
++			spi2 = "/spi@ff1e0000";
++			spi3 = "/spi@ff1f0000";
++		};
++	};
++
++	fragment@1 {
++		target = <&spi0>;
++		__overlay__ {
++			#address-cells = <1>;
++			#size-cells = <0>;
++			spidev {
++				compatible = "spidev";
++				status = "disabled";
++				reg = <0>;
++				spi-max-frequency = <10000000>;
++			};
++		};
++	};
++
++	fragment@2 {
++		target = <&spi1>;
++		__overlay__ {
++			#address-cells = <1>;
++			#size-cells = <0>;
++			spidev {
++				compatible = "spidev";
++				status = "disabled";
++				reg = <0>;
++				spi-max-frequency = <10000000>;
++			};
++		};
++	};
++
++	fragment@3 {
++		target = <&spi2>;
++		__overlay__ {
++			#address-cells = <1>;
++			#size-cells = <0>;
++			spidev {
++				compatible = "spidev";
++				status = "disabled";
++				reg = <0>;
++				spi-max-frequency = <10000000>;
++			};
++		};
++	};
++
++	fragment@4 {
++		target = <&spi3>;
++		__overlay__ {
++			#address-cells = <1>;
++			#size-cells = <0>;
++			spidev {
++				compatible = "spidev";
++				status = "disabled";
++				reg = <0>;
++				spi-max-frequency = <10000000>;
++			};
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-uart4.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-uart4.dts
+new file mode 100644
+index 0000000..fe8fb14
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-uart4.dts
+@@ -0,0 +1,20 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "rockchip,rk3399";
++
++	fragment@0 {
++		target = <&spi1>;
++		__overlay__ {
++			status = "disabled";
++		};
++	};
++
++	fragment@1 {
++		target = <&uart4>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-w1-gpio.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-w1-gpio.dts
+new file mode 100644
+index 0000000..bfbc16a
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-w1-gpio.dts
+@@ -0,0 +1,20 @@
++// Definitions for w1-gpio module (without external pullup)
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "rockchip,rk3399";
++
++	fragment@0 {
++		target-path = "/";
++		__overlay__ {
++
++			w1: onewire@0 {
++				compatible = "w1-gpio";
++				pinctrl-names = "default";
++				gpios = <&gpio1 4 0 0xae>; // GPIO1_A4
++				status = "okay";
++			};
++		};
++	};
++};
+diff --git a/scripts/Makefile.lib b/scripts/Makefile.lib
+index 26e6af4..65b9435 100644
+--- a/scripts/Makefile.lib
++++ b/scripts/Makefile.lib
+@@ -65,6 +65,9 @@ real-objs-m := $(foreach m, $(obj-m), $(if $(strip $($(m:.o=-objs)) $($(m:.o=-y)
+ extra-y				+= $(dtb-y)
+ extra-$(CONFIG_OF_ALL_DTBS)	+= $(dtb-)
+ 
++# Overlay targets
++extra-y				+= $(dtbo-y) $(scr-y) $(dtbotxt-y)
++
+ # Add subdir path
+ 
+ extra-y		:= $(addprefix $(obj)/,$(extra-y))


### PR DESCRIPTION
This makes overlays support in rockchip64 legacy on par with both dev and current.

Closes: [AR-400]

[AR-400]: https://armbian.atlassian.net/browse/AR-400