### PR TITLE
rockchip-current: Add GPU 500MHZ OPP

### DIFF
--- a/patch/kernel/rockchip-current/1026-arm-dtsi-rk3288-add-GPU-500-Mhz-OPP.patch
+++ b/patch/kernel/rockchip-current/1026-arm-dtsi-rk3288-add-GPU-500-Mhz-OPP.patch
@@ -1,0 +1,42 @@
+From 73258d32daf3a661281bb5c77c5e2e06c7ff714e Mon Sep 17 00:00:00 2001
+From: "Miouyouyou (Myy)" <myy@miouyouyou.fr>
+Date: Fri, 3 Jul 2020 02:02:18 +0200
+Subject: [PATCH] arm: dtsi: rk3288: add GPU 500 Mhz OPP again
+
+Undoing the very bizarre mainline kernel patch,
+75481833c6dbab4c29d15452f6b4337c16f5407b
+which main purpose is to sync some 3.14 kernels hacks to
+mainline kernels, for reasons that only matter for a few Chromebooks,
+and shove it down the throat of every RK3288 user.
+
+If you need to avoid the GPU going to 500 Mhz on Chromebooks,
+remove the OPP entry inside the DTS that actually matters to RK3288
+Chromebooks.
+
+Meanwhile, the 600 Mhz operating point can prove to be unstable on
+some RK3288 boards, while 500 Mhz works fine.
+https://forum.armbian.com/topic/13515-panfrost-on-rk3288-and-gpu-on-600mhz-problems/
+
+Signed-off-by: Miouyouyou (Myy) <myy@miouyouyou.fr>
+---
+ arch/arm/boot/dts/rk3288.dtsi | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/arch/arm/boot/dts/rk3288.dtsi b/arch/arm/boot/dts/rk3288.dtsi
+index a66412547..ef7457f79 100644
+--- a/arch/arm/boot/dts/rk3288.dtsi
++++ b/arch/arm/boot/dts/rk3288.dtsi
+@@ -1312,6 +1312,10 @@ opp-400000000 {
+ 			opp-hz = /bits/ 64 <400000000>;
+ 			opp-microvolt = <1100000>;
+ 		};
++		opp-500000000 {
++			opp-hz = /bits/ 64 <500000000>;
++			opp-microvolt = <1200000>;
++		};
+ 		opp-600000000 {
+ 			opp-hz = /bits/ 64 <600000000>;
+ 			opp-microvolt = <1250000>;
+-- 
+2.27.0
+


### PR DESCRIPTION
Those were removed from mainline kernels by Chromebook devs,
wanting to protect their broken babies at all cost.

This patch was dully tested here :
https://forum.armbian.com/topic/13515-panfrost-on-rk3288-and-gpu-on-600mhz-problems/

But you're welcome to test it again !

I did it, with a whole glmark2 round and it worked flawlessly.

To test the GPU at that frequency, locate the **devfreq** folder of your GPU unit on your system (For tinkerboards, it's in **/sys/devices/platform/ffa30000.gpu/devfreq/ffa30000.gpu**) and then :

* Check the available frequencies by doing `sudo cat available_frequencies` .
That should output something like this : `100000000 200000000 300000000 400000000 500000000 600000000`
Be sure that `500000000` is in the list.

* Setup the minimum GPU frequency to 500Mhz like this : `sudo echo 500000000 > min_freq`

You can also set up the GPU to not go over 500Mhz like this : `sudo echo 500000000 > max_freq`

Signed-off-by: Miouyouyou (Myy) <myy@miouyouyou.fr>
