### PR TITLE
Added psmisc package as a requirement for fuser

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -118,6 +118,10 @@ if [[ -z "$(command -v dialog)" ]]; then
 	sudo apt-get update
 	sudo apt-get install -y dialog
 fi
+if [[ -z "$(command -v fuser)" ]]; then
+	sudo apt-get update
+	sudo apt-get install -y psmisc
+fi
 if [[ -z "$(command -v getfacl)" ]]; then
 	sudo apt-get update
 	sudo apt-get install -y acl


### PR DESCRIPTION
./compile.sh checks the availability of certain tools before doing its job.

The fuser utility is used later on, but this utility was missing on my freshly installed Ubuntu Server (running @Hetzner).  
