### PR TITLE
Remove superfluous newline in shell prompt

### DIFF
--- a/packages/bsp/common/etc/profile.d/armbian-check-first-login-reboot.sh
+++ b/packages/bsp/common/etc/profile.d/armbian-check-first-login-reboot.sh
@@ -8,8 +8,7 @@
 
 # only do this for interactive shells
 if [ "$-" != "${-#*i}" ]; then
-	printf "\n"
 	if [ -f "/var/run/.reboot_required" ]; then
-		printf "[\e[0;91m Kernel was updated, please reboot\x1B[0m ]\n\n"
+		printf "\n[\e[0;91m Kernel was updated, please reboot\x1B[0m ]\n\n"
 	fi
 fi


### PR DESCRIPTION
Fixed a bug in armbian-check-first-login-reboot.sh which caused a
newline character to be prepended to the shell prompt even when a reboot
required warning was not shown to the user.