### PR TITLE
ODROIDN2 disable eth0 reset line in dts

### DIFF
--- a/patch/kernel/meson64-current/board-odroidn2-eth0-disable-reset.patch
+++ b/patch/kernel/meson64-current/board-odroidn2-eth0-disable-reset.patch
@@ -1,0 +1,11 @@
+--- a/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dts	2020/08/26 03:53:22	1.1
++++ b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dts	2020/08/26 03:54:20
+@@ -403,7 +403,7 @@
+ 
+ 		reset-assert-us = <10000>;
+ 		reset-deassert-us = <30000>;
+-		reset-gpios = <&gpio GPIOZ_15 (GPIO_ACTIVE_LOW | GPIO_OPEN_DRAIN)>;
++		/* reset-gpios = <&gpio GPIOZ_15 (GPIO_ACTIVE_LOW | GPIO_OPEN_DRAIN)>; */
+ 
+ 		interrupt-parent = <&gpio_intc>;
+ 		/* MAC_INTR on GPIOZ_14 */


### PR DESCRIPTION
This is the corresponding PR to the fix mentioned [here](https://forum.armbian.com/topic/15013-odroid-n2-recent-kernel-update-5715-meson64-breaks-eth0/?do=findComment&comment=107491).
