### PR TITLE
set Btrfs compression creation time only

### DIFF
--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -43,7 +43,7 @@ ROOT_MAPPER="armbian-root"
 [[ -z $ROOTFS_TYPE ]] && ROOTFS_TYPE=ext4 # default rootfs type is ext4
 [[ "ext4 f2fs btrfs nfs fel" != *$ROOTFS_TYPE* ]] && exit_with_error "Unknown rootfs type" "$ROOTFS_TYPE"
 
-[[ -z $BTRFS_COMPRESSION ]] && BTRFS_COMPRESSION=lzo # default btrfs filesystem compression method is lzo
+[[ -z $BTRFS_COMPRESSION ]] && BTRFS_COMPRESSION=zlib # default btrfs filesystem compression method is lzo
 [[ ! $BTRFS_COMPRESSION =~ zlib|lzo|zstd|none ]] && exit_with_error "Unknown btrfs compression method" "$BTRFS_COMPRESSION"
 
 # Fixed image size is in 1M dd blocks (MiB)

--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -43,7 +43,7 @@ ROOT_MAPPER="armbian-root"
 [[ -z $ROOTFS_TYPE ]] && ROOTFS_TYPE=ext4 # default rootfs type is ext4
 [[ "ext4 f2fs btrfs nfs fel" != *$ROOTFS_TYPE* ]] && exit_with_error "Unknown rootfs type" "$ROOTFS_TYPE"
 
-[[ -z $BTRFS_COMPRESSION ]] && BTRFS_COMPRESSION=zlib # default btrfs filesystem compression method is lzo
+[[ -z $BTRFS_COMPRESSION ]] && BTRFS_COMPRESSION=zlib # default btrfs filesystem compression method is zlib
 [[ ! $BTRFS_COMPRESSION =~ zlib|lzo|zstd|none ]] && exit_with_error "Unknown btrfs compression method" "$BTRFS_COMPRESSION"
 
 # Fixed image size is in 1M dd blocks (MiB)

--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -338,11 +338,7 @@ prepare_partitions()
 	# mountopts[ext2] is empty
 	# mountopts[fat] is empty
 	# mountopts[f2fs] is empty
-	if [[ $BTRFS_COMPRESSION == none ]]; then
-		mountopts[btrfs]=',commit=600'
-	else
-		mountopts[btrfs]=",commit=600,compress=${BTRFS_COMPRESSION}"
-	fi
+	mountopts[btrfs]=',commit=600'
 	# mountopts[nfs] is empty
 
 	# default BOOTSIZE to use if not specified


### PR DESCRIPTION
By https://github.com/armbian/build/pull/2163#issuecomment-683444245
Set BTRFS_COMPRESSION means image creation-only, no compression in /etc/fstab at all.
make zlib as default
@ThomasKaiser @lanefu @igorpecovnik 