### PR TITLE
Disable hs400 modes of Helios64's emmc

### DIFF
--- a/patch/kernel/rk3399-legacy/helios64-add-board.patch
+++ b/patch/kernel/rk3399-legacy/helios64-add-board.patch
@@ -27,7 +27,7 @@ new file mode 100644
 index 00000000..d4248a01
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-helios64.dts
-@@ -0,0 +1,1260 @@
+@@ -0,0 +1,1258 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * Copyright (c) 2020 Aditya Prayoga (aditya@kobol.io)
@@ -1102,9 +1102,7 @@ index 00000000..d4248a01
 +
 +&sdhci {
 +	bus-width = <8>;
-+	mmc-hs400-1_8v;
 +	mmc-hs200-1_8v;
-+	mmc-hs400-enhanced-strobe;
 +	//keep-power-in-suspend;
 +	supports-emmc;
 +	non-removable;

--- a/patch/kernel/rockchip64-current/add-board-helios64.patch
+++ b/patch/kernel/rockchip64-current/add-board-helios64.patch
@@ -27,7 +27,7 @@ new file mode 100644
 index 000000000..342589131
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-helios64.dts
-@@ -0,0 +1,1080 @@
+@@ -0,0 +1,1078 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2020 Aditya Prayoga (aditya@kobol.io)
@@ -944,9 +944,7 @@ index 000000000..342589131
 +
 +&sdhci {
 +	bus-width = <8>;
-+	mmc-hs400-1_8v;
 +	mmc-hs200-1_8v;
-+	mmc-hs400-enhanced-strobe;
 +	supports-emmc;
 +	non-removable;
 +	disable-wp;


### PR DESCRIPTION
Closes: [AR-413]

Helios64 uses eMMC module (`KLMAG1JETD-B041` identified as `AJTD4R`) that apparently cannot run in hs400{,es} modes.
The same module [had to be disabled for roc-rk3399-pc](https://github.com/armbian/build/pull/1666) some time ago.

Symptoms - no way to finish moving Armbian from SD to eMMC by means of `nand-sata-install` with `mmc1: "running CQE recovery"` flooding kernel message log and leading to remounting filesystem in read-only mode.

As discussed with @aprayoga I am limiting the supported high speed modes for eMMC to hs200.
Most of the other rk3399 boards has the same limitation anyway.

[AR-413]: https://armbian.atlassian.net/browse/AR-413