### PR TITLE
Workaround Helios64 SD reboot issues by disabling sdr104 mode

### DIFF
--- a/patch/kernel/rk3399-legacy/helios64-add-board.patch
+++ b/patch/kernel/rk3399-legacy/helios64-add-board.patch
@@ -1120,7 +1120,7 @@ index 00000000..d4248a01
 +	num-slots = <1>;
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&sdmmc_clk &sdmmc_cmd &sdmmc_cd &sdmmc_bus4>;
-+	sd-uhs-sdr104;
++	// sd-uhs-sdr104;
 +	supports-sd;
 +	vmmc-supply = <&vcc3v0_sd>;
 +	vqmmc-supply = <&vcc_sdio_s0>;

--- a/patch/kernel/rockchip64-current/add-board-helios64.patch
+++ b/patch/kernel/rockchip64-current/add-board-helios64.patch
@@ -27,7 +27,7 @@ new file mode 100644
 index 000000000..342589131
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-helios64.dts
-@@ -0,0 +1,1078 @@
+@@ -0,0 +1,1080 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2020 Aditya Prayoga (aditya@kobol.io)
@@ -581,6 +581,8 @@ index 000000000..342589131
 +
 +			vcc_sdio_s0: LDO_REG4 {
 +				regulator-name = "vcc_sdio_s0";
++				regulator-always-on;
++				regulator-boot-on;
 +				regulator-min-microvolt = <1800000>;
 +				regulator-max-microvolt = <3000000>;
 +				regulator-state-mem {
@@ -956,7 +958,7 @@ index 000000000..342589131
 +	bus-width = <4>;
 +	cap-sd-highspeed;
 +	disable-wp;
-+	sd-uhs-sdr104;
++	// sd-uhs-sdr104;
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&sdmmc_clk &sdmmc_cmd &sdmmc_cd &sdmmc_bus4>;
 +	vmmc-supply = <&vcc3v0_sd>;


### PR DESCRIPTION
Closes: [AR-415]

As discussed with @aprayoga we are disabling sdr104 mode on Helios64 for now to fix reboot issues.
It also requires `vcc_sdio_s0` tweaks in current.

I have another workaround in mind but it would also affect other rockchip64 boards and needs to be thoroughly tested.

[AR-415]: https://armbian.atlassian.net/browse/AR-415