### PR TITLE
Fix broken usbip

### DIFF
--- a/patch/kernel/sunxi-current/xxx-fix_broken_usbip.patch
+++ b/patch/kernel/sunxi-current/xxx-fix_broken_usbip.patch
@@ -1,0 +1,70 @@
+From 7a2f2974f26542b4e7b9b4321edb3cbbf3eeb91a Mon Sep 17 00:00:00 2001
+From: "M. Vefa Bicakci" <m.v.b@runbox.com>
+Date: Mon, 10 Aug 2020 19:00:17 +0300
+Subject: usbip: Implement a match function to fix usbip
+
+Commit 88b7381a939d ("USB: Select better matching USB drivers when
+available") introduced the use of a "match" function to select a
+non-generic/better driver for a particular USB device. This
+unfortunately breaks the operation of usbip in general, as reported in
+the kernel bugzilla with bug 208267 (linked below).
+
+Upon inspecting the aforementioned commit, one can observe that the
+original code in the usb_device_match function used to return 1
+unconditionally, but the aforementioned commit makes the usb_device_match
+function use identifier tables and "match" virtual functions, if either of
+them are available.
+
+Hence, this commit implements a match function for usbip that
+unconditionally returns true to ensure that usbip is functional again.
+
+This change has been verified to restore usbip functionality, with a
+v5.7.y kernel on an up-to-date version of Qubes OS 4.0, which uses
+usbip to redirect USB devices between VMs.
+
+Thanks to Jonathan Dieter for the effort in bisecting this issue down
+to the aforementioned commit.
+
+Fixes: 88b7381a939d ("USB: Select better matching USB drivers when available")
+Link: https://bugzilla.kernel.org/show_bug.cgi?id=208267
+Link: https://bugzilla.redhat.com/show_bug.cgi?id=1856443
+Link: https://github.com/QubesOS/qubes-issues/issues/5905
+Signed-off-by: M. Vefa Bicakci <m.v.b@runbox.com>
+Cc: <stable@vger.kernel.org> # 5.7
+Cc: Valentina Manea <valentina.manea.m@gmail.com>
+Cc: Alan Stern <stern@rowland.harvard.edu>
+Reviewed-by: Bastien Nocera <hadess@hadess.net>
+Reviewed-by: Shuah Khan <skhan@linuxfoundation.org>
+Link: https://lore.kernel.org/r/20200810160017.46002-1-m.v.b@runbox.com
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/usb/usbip/stub_dev.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/usb/usbip/stub_dev.c b/drivers/usb/usbip/stub_dev.c
+index 2305d425e6c9a..9d7d642022d1f 100644
+--- a/drivers/usb/usbip/stub_dev.c
++++ b/drivers/usb/usbip/stub_dev.c
+@@ -461,6 +461,11 @@ static void stub_disconnect(struct usb_device *udev)
+ 	return;
+ }
+ 
++static bool usbip_match(struct usb_device *udev)
++{
++	return true;
++}
++
+ #ifdef CONFIG_PM
+ 
+ /* These functions need usb_port_suspend and usb_port_resume,
+@@ -486,6 +491,7 @@ struct usb_device_driver stub_driver = {
+ 	.name		= "usbip-host",
+ 	.probe		= stub_probe,
+ 	.disconnect	= stub_disconnect,
++	.match		= usbip_match,
+ #ifdef CONFIG_PM
+ 	.suspend	= stub_suspend,
+ 	.resume		= stub_resume,
+-- 
+cgit 1.2.3-1.el7
+


### PR DESCRIPTION
Fixes https://forum.armbian.com/topic/15069-usbip-not-working-with-zeropi-buster-image-device-disconnect-as-soon-as-i-try-to-bind/?tab=comments#comment-107847
Needs to be removed most likely with next upstream version.
