### PR TITLE
Fixed sd card detection for Helios64

### DIFF
--- a/patch/kernel/rk3399-legacy/helios64-add-board.patch
+++ b/patch/kernel/rk3399-legacy/helios64-add-board.patch
@@ -27,7 +27,7 @@ new file mode 100644
 index 00000000..d4248a01
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-helios64.dts
-@@ -0,0 +1,1258 @@
+@@ -0,0 +1,1259 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * Copyright (c) 2020 Aditya Prayoga (aditya@kobol.io)
@@ -1116,6 +1116,7 @@ index 00000000..d4248a01
 +	bus-width = <4>;
 +	cap-sd-highspeed;
 +	card-detect-delay = <800>;
++	cd-gpios = <&gpio0 RK_PA7 GPIO_ACTIVE_LOW>;
 +	disable-wp;
 +	num-slots = <1>;
 +	pinctrl-names = "default";

--- a/patch/kernel/rk3399-legacy/helios64-add-board.patch
+++ b/patch/kernel/rk3399-legacy/helios64-add-board.patch
@@ -20,7 +20,7 @@ index 270c0c62..adfa8211 100644
  	rk3399-nanopi4-rev22.dtb \
 +	rk3399-helios64.dtb \
  	rk3399-firefly.dtb
- 
+
  dtb-$(CONFIG_ARCH_ROCKCHIP) += \
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-helios64.dts b/arch/arm64/boot/dts/rockchip/rk3399-helios64.dts
 new file mode 100644
@@ -1116,7 +1116,7 @@ index 00000000..d4248a01
 +	bus-width = <4>;
 +	cap-sd-highspeed;
 +	card-detect-delay = <800>;
-+	cd-gpios = <&gpio0 RK_PA7 GPIO_ACTIVE_LOW>;
++	cd-gpios = <&gpio0 RK_PA7 GPIO_ACTIVE_LOW>; // TODO: verify what needs to be done to use implicit CD definition
 +	disable-wp;
 +	num-slots = <1>;
 +	pinctrl-names = "default";
@@ -1287,6 +1287,5 @@ index 00000000..d4248a01
 +&vopl_mmu {
 +	status = "okay";
 +};
--- 
+--
 Created with Armbian build tools https://github.com/armbian/build
-

--- a/patch/kernel/rk3399-legacy/helios64-add-board.patch
+++ b/patch/kernel/rk3399-legacy/helios64-add-board.patch
@@ -20,7 +20,7 @@ index 270c0c62..adfa8211 100644
  	rk3399-nanopi4-rev22.dtb \
 +	rk3399-helios64.dtb \
  	rk3399-firefly.dtb
-
+ 
  dtb-$(CONFIG_ARCH_ROCKCHIP) += \
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-helios64.dts b/arch/arm64/boot/dts/rockchip/rk3399-helios64.dts
 new file mode 100644
@@ -1287,5 +1287,6 @@ index 00000000..d4248a01
 +&vopl_mmu {
 +	status = "okay";
 +};
---
+-- 
 Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/kernel/rockchip64-current/add-board-helios64.patch
+++ b/patch/kernel/rockchip64-current/add-board-helios64.patch
@@ -27,7 +27,7 @@ new file mode 100644
 index 000000000..342589131
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-helios64.dts
-@@ -0,0 +1,1080 @@
+@@ -0,0 +1,1081 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2020 Aditya Prayoga (aditya@kobol.io)
@@ -957,6 +957,7 @@ index 000000000..342589131
 +&sdmmc {
 +	bus-width = <4>;
 +	cap-sd-highspeed;
++	cd-gpios = <&gpio0 RK_PA7 GPIO_ACTIVE_LOW>;
 +	disable-wp;
 +	// sd-uhs-sdr104;
 +	pinctrl-names = "default";

--- a/patch/kernel/rockchip64-current/add-board-helios64.patch
+++ b/patch/kernel/rockchip64-current/add-board-helios64.patch
@@ -875,7 +875,7 @@ index 000000000..342589131
 +
 +	pmic {
 +		pmic_int_l: pmic-int-l {
-+			rockchip,pins =
++			rockchip,pins = 
 +				<0 RK_PB2 RK_FUNC_GPIO &pcfg_pull_up>;
 +		};
 +
@@ -1110,5 +1110,6 @@ index 000000000..342589131
 +	status = "okay";
 +};
 \ No newline at end of file
---
+-- 
 Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/kernel/rockchip64-current/add-board-helios64.patch
+++ b/patch/kernel/rockchip64-current/add-board-helios64.patch
@@ -875,7 +875,7 @@ index 000000000..342589131
 +
 +	pmic {
 +		pmic_int_l: pmic-int-l {
-+			rockchip,pins = 
++			rockchip,pins =
 +				<0 RK_PB2 RK_FUNC_GPIO &pcfg_pull_up>;
 +		};
 +
@@ -957,7 +957,7 @@ index 000000000..342589131
 +&sdmmc {
 +	bus-width = <4>;
 +	cap-sd-highspeed;
-+	cd-gpios = <&gpio0 RK_PA7 GPIO_ACTIVE_LOW>;
++	cd-gpios = <&gpio0 RK_PA7 GPIO_ACTIVE_LOW>; // TODO: verify what needs to be done to use implicit CD definition
 +	disable-wp;
 +	// sd-uhs-sdr104;
 +	pinctrl-names = "default";
@@ -1110,6 +1110,5 @@ index 000000000..342589131
 +	status = "okay";
 +};
 \ No newline at end of file
--- 
+--
 Created with Armbian build tools https://github.com/armbian/build
-


### PR DESCRIPTION
Missing `cd-gpios` in `sdmmc` node prevents the board detecting sd card insertion / removal events.