### PR TITLE
[rockchip] Fixed xt-q8l-v10 DTS, reworked ath9k driver patch for 5.8.y

### DIFF
--- a/patch/kernel/rockchip-current/2007-drivers-wifi-ath9k-reverse-do-not-use-bulk-on-EP3-and-EP4.patch
+++ b/patch/kernel/rockchip-current/2007-drivers-wifi-ath9k-reverse-do-not-use-bulk-on-EP3-and-EP4.patch
@@ -10,65 +10,67 @@ This commit fixes that issue.
 This is only a temporary work around while a permenant fix is found, as this commit seems to only cause issues
 with dwc2
 
+
 diff --git a/drivers/net/wireless/ath/ath9k/hif_usb.c b/drivers/net/wireless/ath/ath9k/hif_usb.c
---- b/drivers/net/wireless/ath/ath9k/hif_usb.c
-+++ a/drivers/net/wireless/ath/ath9k/hif_usb.c
-@@ -115,10 +115,10 @@
+index 3f563e02d..903851481 100644
+--- a/drivers/net/wireless/ath/ath9k/hif_usb.c
++++ b/drivers/net/wireless/ath/ath9k/hif_usb.c
+@@ -118,10 +118,10 @@ static int hif_usb_send_regout(struct hif_device_usb *hif_dev,
  	cmd->skb = skb;
  	cmd->hif_dev = hif_dev;
  
-+	usb_fill_bulk_urb(urb, hif_dev->udev,
-+			 usb_sndbulkpipe(hif_dev->udev, USB_REG_OUT_PIPE),
 -	usb_fill_int_urb(urb, hif_dev->udev,
 -			 usb_sndintpipe(hif_dev->udev, USB_REG_OUT_PIPE),
++	usb_fill_bulk_urb(urb, hif_dev->udev,
++			 usb_sndbulkpipe(hif_dev->udev, USB_REG_OUT_PIPE),
  			 skb->data, skb->len,
-+			 hif_usb_regout_cb, cmd);
 -			 hif_usb_regout_cb, cmd, 1);
++			 hif_usb_regout_cb, cmd);
  
  	usb_anchor_urb(urb, &hif_dev->regout_submitted);
  	ret = usb_submit_urb(urb, GFP_KERNEL);
-@@ -723,11 +723,11 @@
- 			return;
- 		}
+@@ -735,11 +735,11 @@ static void ath9k_hif_usb_reg_in_cb(struct urb *urb)
  
-+		usb_fill_bulk_urb(urb, hif_dev->udev,
-+				 usb_rcvbulkpipe(hif_dev->udev,
+ 		rx_buf->skb = nskb;
+ 
 -		usb_fill_int_urb(urb, hif_dev->udev,
 -				 usb_rcvintpipe(hif_dev->udev,
++		usb_fill_bulk_urb(urb, hif_dev->udev,
++				 usb_rcvbulkpipe(hif_dev->udev,
  						 USB_REG_IN_PIPE),
  				 nskb->data, MAX_REG_IN_BUF_SIZE,
-+				 ath9k_hif_usb_reg_in_cb, nskb);
--				 ath9k_hif_usb_reg_in_cb, nskb, 1);
+-				 ath9k_hif_usb_reg_in_cb, rx_buf, 1);
++				 ath9k_hif_usb_reg_in_cb, rx_buf);
  	}
  
  resubmit:
-@@ -909,11 +909,11 @@
+@@ -944,11 +944,11 @@ static int ath9k_hif_usb_alloc_reg_in_urbs(struct hif_device_usb *hif_dev)
  		rx_buf->hif_dev = hif_dev;
  		rx_buf->skb = skb;
  
-+		usb_fill_bulk_urb(urb, hif_dev->udev,
-+				  usb_rcvbulkpipe(hif_dev->udev,
 -		usb_fill_int_urb(urb, hif_dev->udev,
 -				  usb_rcvintpipe(hif_dev->udev,
++		usb_fill_bulk_urb(urb, hif_dev->udev,
++				  usb_rcvbulkpipe(hif_dev->udev,
  						  USB_REG_IN_PIPE),
  				  skb->data, MAX_REG_IN_BUF_SIZE,
-+				  ath9k_hif_usb_reg_in_cb, skb);
 -				  ath9k_hif_usb_reg_in_cb, rx_buf, 1);
++				  ath9k_hif_usb_reg_in_cb, skb);
  
  		/* Anchor URB */
  		usb_anchor_urb(urb, &hif_dev->reg_in_submitted);
-@@ -1031,7 +1031,9 @@
+@@ -1069,7 +1069,9 @@ static int ath9k_hif_usb_download_fw(struct hif_device_usb *hif_dev)
  
  static int ath9k_hif_usb_dev_init(struct hif_device_usb *hif_dev)
  {
+-	int ret;
 +	struct usb_host_interface *alt = &hif_dev->interface->altsetting[0];
 +	struct usb_endpoint_descriptor *endp;
 +	int ret, idx;
--	int ret;
  
  	ret = ath9k_hif_usb_download_fw(hif_dev);
  	if (ret) {
-@@ -1041,6 +1043,20 @@
+@@ -1079,6 +1081,20 @@ static int ath9k_hif_usb_dev_init(struct hif_device_usb *hif_dev)
  		return ret;
  	}
  
@@ -89,13 +91,12 @@ diff --git a/drivers/net/wireless/ath/ath9k/hif_usb.c b/drivers/net/wireless/ath
  	/* Alloc URBs */
  	ret = ath9k_hif_usb_alloc_urbs(hif_dev);
  	if (ret) {
-@@ -1252,7 +1268,7 @@
+@@ -1353,7 +1369,7 @@ static void ath9k_hif_usb_reboot(struct usb_device *udev)
  	if (!buf)
  		return;
  
-+	ret = usb_bulk_msg(udev, usb_sndbulkpipe(udev, USB_REG_OUT_PIPE),
 -	ret = usb_interrupt_msg(udev, usb_sndintpipe(udev, USB_REG_OUT_PIPE),
++	ret = usb_bulk_msg(udev, usb_sndbulkpipe(udev, USB_REG_OUT_PIPE),
  			   buf, 4, NULL, USB_MSG_TIMEOUT);
  	if (ret)
  		dev_err(&udev->dev, "ath9k_htc: USB reboot failed\n");
-

--- a/patch/kernel/rockchip-current/xt-q8l-v10-add-device-tree.patch
+++ b/patch/kernel/rockchip-current/xt-q8l-v10-add-device-tree.patch
@@ -718,18 +718,18 @@ index 000000000..784528f6d
 +		 * to the gpio pins
 +		 */
 +		sdmmc_bus4: sdmmc-bus4 {
-+			rockchip,pins = <6 16 RK_FUNC_1 &pcfg_pull_up_drv_8ma>,
-+					<6 17 RK_FUNC_1 &pcfg_pull_up_drv_8ma>,
-+					<6 18 RK_FUNC_1 &pcfg_pull_up_drv_8ma>,
-+					<6 19 RK_FUNC_1 &pcfg_pull_up_drv_8ma>;
++			rockchip,pins = <6 16 1 &pcfg_pull_up_drv_8ma>,
++					<6 17 1 &pcfg_pull_up_drv_8ma>,
++					<6 18 1 &pcfg_pull_up_drv_8ma>,
++					<6 19 1 &pcfg_pull_up_drv_8ma>;
 +		};
 +
 +		sdmmc_clk: sdmmc-clk {
-+			rockchip,pins = <6 20 RK_FUNC_1 &pcfg_pull_none_8ma>;
++			rockchip,pins = <6 20 1 &pcfg_pull_none_8ma>;
 +		};
 +
 +		sdmmc_cmd: sdmmc-cmd {
-+			rockchip,pins = <6 21 RK_FUNC_1 &pcfg_pull_up_drv_8ma>;
++			rockchip,pins = <6 21 1 &pcfg_pull_up_drv_8ma>;
 +		};
 +
 +		sdmmc_pwr: sdmmc-pwr {

--- a/patch/kernel/rockchip-dev/2007-drivers-wifi-ath9k-reverse-do-not-use-bulk-on-EP3-and-EP4.patch
+++ b/patch/kernel/rockchip-dev/2007-drivers-wifi-ath9k-reverse-do-not-use-bulk-on-EP3-and-EP4.patch
@@ -10,65 +10,67 @@ This commit fixes that issue.
 This is only a temporary work around while a permenant fix is found, as this commit seems to only cause issues
 with dwc2
 
+
 diff --git a/drivers/net/wireless/ath/ath9k/hif_usb.c b/drivers/net/wireless/ath/ath9k/hif_usb.c
---- b/drivers/net/wireless/ath/ath9k/hif_usb.c
-+++ a/drivers/net/wireless/ath/ath9k/hif_usb.c
-@@ -115,10 +115,10 @@
+index 3f563e02d..903851481 100644
+--- a/drivers/net/wireless/ath/ath9k/hif_usb.c
++++ b/drivers/net/wireless/ath/ath9k/hif_usb.c
+@@ -118,10 +118,10 @@ static int hif_usb_send_regout(struct hif_device_usb *hif_dev,
  	cmd->skb = skb;
  	cmd->hif_dev = hif_dev;
  
-+	usb_fill_bulk_urb(urb, hif_dev->udev,
-+			 usb_sndbulkpipe(hif_dev->udev, USB_REG_OUT_PIPE),
 -	usb_fill_int_urb(urb, hif_dev->udev,
 -			 usb_sndintpipe(hif_dev->udev, USB_REG_OUT_PIPE),
++	usb_fill_bulk_urb(urb, hif_dev->udev,
++			 usb_sndbulkpipe(hif_dev->udev, USB_REG_OUT_PIPE),
  			 skb->data, skb->len,
-+			 hif_usb_regout_cb, cmd);
 -			 hif_usb_regout_cb, cmd, 1);
++			 hif_usb_regout_cb, cmd);
  
  	usb_anchor_urb(urb, &hif_dev->regout_submitted);
  	ret = usb_submit_urb(urb, GFP_KERNEL);
-@@ -723,11 +723,11 @@
- 			return;
- 		}
+@@ -735,11 +735,11 @@ static void ath9k_hif_usb_reg_in_cb(struct urb *urb)
  
-+		usb_fill_bulk_urb(urb, hif_dev->udev,
-+				 usb_rcvbulkpipe(hif_dev->udev,
+ 		rx_buf->skb = nskb;
+ 
 -		usb_fill_int_urb(urb, hif_dev->udev,
 -				 usb_rcvintpipe(hif_dev->udev,
++		usb_fill_bulk_urb(urb, hif_dev->udev,
++				 usb_rcvbulkpipe(hif_dev->udev,
  						 USB_REG_IN_PIPE),
  				 nskb->data, MAX_REG_IN_BUF_SIZE,
-+				 ath9k_hif_usb_reg_in_cb, nskb);
--				 ath9k_hif_usb_reg_in_cb, nskb, 1);
+-				 ath9k_hif_usb_reg_in_cb, rx_buf, 1);
++				 ath9k_hif_usb_reg_in_cb, rx_buf);
  	}
  
  resubmit:
-@@ -909,11 +909,11 @@
+@@ -944,11 +944,11 @@ static int ath9k_hif_usb_alloc_reg_in_urbs(struct hif_device_usb *hif_dev)
  		rx_buf->hif_dev = hif_dev;
  		rx_buf->skb = skb;
  
-+		usb_fill_bulk_urb(urb, hif_dev->udev,
-+				  usb_rcvbulkpipe(hif_dev->udev,
 -		usb_fill_int_urb(urb, hif_dev->udev,
 -				  usb_rcvintpipe(hif_dev->udev,
++		usb_fill_bulk_urb(urb, hif_dev->udev,
++				  usb_rcvbulkpipe(hif_dev->udev,
  						  USB_REG_IN_PIPE),
  				  skb->data, MAX_REG_IN_BUF_SIZE,
-+				  ath9k_hif_usb_reg_in_cb, skb);
 -				  ath9k_hif_usb_reg_in_cb, rx_buf, 1);
++				  ath9k_hif_usb_reg_in_cb, skb);
  
  		/* Anchor URB */
  		usb_anchor_urb(urb, &hif_dev->reg_in_submitted);
-@@ -1031,7 +1031,9 @@
+@@ -1069,7 +1069,9 @@ static int ath9k_hif_usb_download_fw(struct hif_device_usb *hif_dev)
  
  static int ath9k_hif_usb_dev_init(struct hif_device_usb *hif_dev)
  {
+-	int ret;
 +	struct usb_host_interface *alt = &hif_dev->interface->altsetting[0];
 +	struct usb_endpoint_descriptor *endp;
 +	int ret, idx;
--	int ret;
  
  	ret = ath9k_hif_usb_download_fw(hif_dev);
  	if (ret) {
-@@ -1041,6 +1043,20 @@
+@@ -1079,6 +1081,20 @@ static int ath9k_hif_usb_dev_init(struct hif_device_usb *hif_dev)
  		return ret;
  	}
  
@@ -89,13 +91,12 @@ diff --git a/drivers/net/wireless/ath/ath9k/hif_usb.c b/drivers/net/wireless/ath
  	/* Alloc URBs */
  	ret = ath9k_hif_usb_alloc_urbs(hif_dev);
  	if (ret) {
-@@ -1252,7 +1268,7 @@
+@@ -1353,7 +1369,7 @@ static void ath9k_hif_usb_reboot(struct usb_device *udev)
  	if (!buf)
  		return;
  
-+	ret = usb_bulk_msg(udev, usb_sndbulkpipe(udev, USB_REG_OUT_PIPE),
 -	ret = usb_interrupt_msg(udev, usb_sndintpipe(udev, USB_REG_OUT_PIPE),
++	ret = usb_bulk_msg(udev, usb_sndbulkpipe(udev, USB_REG_OUT_PIPE),
  			   buf, 4, NULL, USB_MSG_TIMEOUT);
  	if (ret)
  		dev_err(&udev->dev, "ath9k_htc: USB reboot failed\n");
-

--- a/patch/kernel/rockchip-dev/xt-q8l-v10-add-device-tree.patch
+++ b/patch/kernel/rockchip-dev/xt-q8l-v10-add-device-tree.patch
@@ -718,18 +718,18 @@ index 000000000..784528f6d
 +		 * to the gpio pins
 +		 */
 +		sdmmc_bus4: sdmmc-bus4 {
-+			rockchip,pins = <6 16 RK_FUNC_1 &pcfg_pull_up_drv_8ma>,
-+					<6 17 RK_FUNC_1 &pcfg_pull_up_drv_8ma>,
-+					<6 18 RK_FUNC_1 &pcfg_pull_up_drv_8ma>,
-+					<6 19 RK_FUNC_1 &pcfg_pull_up_drv_8ma>;
++			rockchip,pins = <6 16 1 &pcfg_pull_up_drv_8ma>,
++					<6 17 1 &pcfg_pull_up_drv_8ma>,
++					<6 18 1 &pcfg_pull_up_drv_8ma>,
++					<6 19 1 &pcfg_pull_up_drv_8ma>;
 +		};
 +
 +		sdmmc_clk: sdmmc-clk {
-+			rockchip,pins = <6 20 RK_FUNC_1 &pcfg_pull_none_8ma>;
++			rockchip,pins = <6 20 1 &pcfg_pull_none_8ma>;
 +		};
 +
 +		sdmmc_cmd: sdmmc-cmd {
-+			rockchip,pins = <6 21 RK_FUNC_1 &pcfg_pull_up_drv_8ma>;
++			rockchip,pins = <6 21 1 &pcfg_pull_up_drv_8ma>;
 +		};
 +
 +		sdmmc_pwr: sdmmc-pwr {


### PR DESCRIPTION
For both rockchip-current and rockchip-dev:

* Fixed the xt-q8l-v10 device tree to work on kernel 5.8.y
* Reworked and enabled back the ath9k driver patch. Had that in the pipe and don't remember if I did it myself or I stole it from someone else... :unamused: no chance to test it though but should compile