### PR TITLE
Fix a bunch of small cryptroot image builds issues

### DIFF
--- a/config/templates/Dockerfile
+++ b/config/templates/Dockerfile
@@ -68,6 +68,7 @@ RUN apt-get update \
        ncurses-term \
        nfs-kernel-server \
        ntpdate \
+       openssh-client \
        p7zip-full \
        parted \
        patchutils \

--- a/lib/chroot-buildpackages.sh
+++ b/lib/chroot-buildpackages.sh
@@ -336,7 +336,7 @@ chroot_installpackages()
 	cat <<-EOF > "${SDCARD}"/tmp/install.sh
 	#!/bin/bash
 	[[ "$remote_only" != yes ]] && apt-key add /tmp/buildpkg.key
-	apt-get "${apt_extra}" -q update
+	apt-get ${apt_extra} -q update
 	# uncomment to debug
 	# /bin/bash
 	# TODO: check if package exists in case new config was added
@@ -345,7 +345,7 @@ chroot_installpackages()
 	#		if grep -qE "apt.armbian.com|localhost" <(apt-cache madison \$p); then
 	#		if apt-get -s -qq install \$p; then
 	#fi
-	apt-get -q "${apt_extra}" --show-progress -o DPKG::Progress-Fancy=1 install -y ${install_list}
+	apt-get -q ${apt_extra} --show-progress -o DPKG::Progress-Fancy=1 install -y ${install_list}
 	apt-get clean
 	[[ "${remote_only}" != yes ]] && apt-key del "925644A6"
 	rm /etc/apt/sources.list.d/armbian-temp.list 2>/dev/null

--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -83,6 +83,11 @@ CAN_BUILD_STRETCH=yes
 ATF_COMPILE=yes
 [[ -z $CRYPTROOT_SSH_UNLOCK ]] && CRYPTROOT_SSH_UNLOCK=yes
 [[ -z $CRYPTROOT_SSH_UNLOCK_PORT ]] && CRYPTROOT_SSH_UNLOCK_PORT=2022
+# Default to pdkdf2, this used to be the default with cryptroot <= 2.0, however
+# cryptroot 2.1 changed that to Argon2i. Argon2i is a memory intensive
+# algorithm which doesn't play well with SBCs (need 1GiB RAM by default !)
+# https://gitlab.com/cryptsetup/cryptsetup/-/issues/372
+[[ -z $CRYPTROOT_PARAMETERS ]] && CRYPTROOT_PARAMETERS="--pbkdf pbkdf2"
 [[ -z $WIREGUARD ]] && WIREGUARD="yes"
 [[ -z $EXTRAWIFI ]] && EXTRAWIFI="yes"
 [[ -z $AUFS ]] && AUFS="yes"


### PR DESCRIPTION
This fixes a few issues I ran into while trying to build a CRYPTROOT enabled image using docker.

With these changes and the docker workaround mentioned here : https://github.com/armbian/build/issues/495#issuecomment-253085570

I'm able to successfully build and run a cryptroot image on the lime2 target.

By the way is there a trick I missed that would have docker work without a workaround ? I noticed the following comment in the config-docker.conf file, but it doesn't seem to work for me and I couldn't see the /tmp/dev path actually used in build scripts ?
```
    # this is an ugly hack, but it is required to get /dev/loopXpY minor number
    # for mknod inside the container, and container itself still uses private /dev internally
    DOCKER_FLAGS+=(-v /dev:/tmp/dev:ro)
```