### PR TITLE
Bumped voltages for low OPPs for rk3399 in current/dev

### DIFF
--- a/patch/kernel/rockchip64-current/rk3399-bump-voltages-for-low-opps.patch
+++ b/patch/kernel/rockchip64-current/rk3399-bump-voltages-for-low-opps.patch
@@ -1,0 +1,40 @@
+The change is in line with the following commit from Rockchip's BSP:
+https://github.com/rockchip-linux/kernel/commit/7a8a38540302b746cdb1238023d807190c1ee485
+
+"It is better to make the voltage greater than 810mV
+and it will be more stable."
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-opp.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-opp.dtsi
+index 30f353c10..996fe66a5 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-opp.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3399-opp.dtsi
+@@ -10,12 +10,12 @@
+ 
+ 		opp00 {
+ 			opp-hz = /bits/ 64 <408000000>;
+-			opp-microvolt = <800000>;
++			opp-microvolt = <825000>;
+ 			clock-latency-ns = <40000>;
+ 		};
+ 		opp01 {
+ 			opp-hz = /bits/ 64 <600000000>;
+-			opp-microvolt = <800000>;
++			opp-microvolt = <825000>;
+ 		};
+ 		opp02 {
+ 			opp-hz = /bits/ 64 <816000000>;
+@@ -45,12 +45,12 @@
+ 
+ 		opp00 {
+ 			opp-hz = /bits/ 64 <408000000>;
+-			opp-microvolt = <800000>;
++			opp-microvolt = <825000>;
+ 			clock-latency-ns = <40000>;
+ 		};
+ 		opp01 {
+ 			opp-hz = /bits/ 64 <600000000>;
+-			opp-microvolt = <800000>;
++			opp-microvolt = <825000>;
+ 		};
+ 		opp02 {
+ 			opp-hz = /bits/ 64 <816000000>;

--- a/patch/kernel/rockchip64-dev/rk3399-bump-voltages-for-low-opps.patch
+++ b/patch/kernel/rockchip64-dev/rk3399-bump-voltages-for-low-opps.patch
@@ -1,0 +1,40 @@
+The change is in line with the following commit from Rockchip's BSP:
+https://github.com/rockchip-linux/kernel/commit/7a8a38540302b746cdb1238023d807190c1ee485
+
+"It is better to make the voltage greater than 810mV
+and it will be more stable."
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-opp.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-opp.dtsi
+index 30f353c10..996fe66a5 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-opp.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3399-opp.dtsi
+@@ -10,12 +10,12 @@
+ 
+ 		opp00 {
+ 			opp-hz = /bits/ 64 <408000000>;
+-			opp-microvolt = <800000>;
++			opp-microvolt = <825000>;
+ 			clock-latency-ns = <40000>;
+ 		};
+ 		opp01 {
+ 			opp-hz = /bits/ 64 <600000000>;
+-			opp-microvolt = <800000>;
++			opp-microvolt = <825000>;
+ 		};
+ 		opp02 {
+ 			opp-hz = /bits/ 64 <816000000>;
+@@ -45,12 +45,12 @@
+ 
+ 		opp00 {
+ 			opp-hz = /bits/ 64 <408000000>;
+-			opp-microvolt = <800000>;
++			opp-microvolt = <825000>;
+ 			clock-latency-ns = <40000>;
+ 		};
+ 		opp01 {
+ 			opp-hz = /bits/ 64 <600000000>;
+-			opp-microvolt = <800000>;
++			opp-microvolt = <825000>;
+ 		};
+ 		opp02 {
+ 			opp-hz = /bits/ 64 <816000000>;


### PR DESCRIPTION
Closes: [AR-423]

The change is in line with the following commit from Rockchip's BSP:
https://github.com/rockchip-linux/kernel/commit/7a8a38540302b746cdb1238023d807190c1ee485

> It is better to make the voltage greater than 810mV and it will be more stable.

[AR-423]: https://armbian.atlassian.net/browse/AR-423