### PR TITLE
Workaround for kernel bug

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-resize-filesystem
+++ b/packages/bsp/common/usr/lib/armbian/armbian-resize-filesystem
@@ -118,6 +118,16 @@ do_expand_partition()
 		((echo n; echo p; echo ; echo $(( $lastsector + 1 )); echo $secondpartition ; echo w;) | fdisk $rootdevicepath) >>${Log} 2>&1
 	local s=0
 	partprobe $rootdevicepath >>${Log} 2>&1 || s=$?
+
+	#
+	# Workaround for 5.8>
+	#
+	KERNELID=$(uname -r |  awk -F'.' '{print ($1 * 100) + $2}')
+	[[ ${KERNELID} -le 517 ]] && s=0
+	#
+	#
+	#
+
 	echo -e "New partition table:\n" >>${Log}
 	cat /proc/partitions >>${Log}
 	echo -e "\nNow trying to resize $1 filesystem on $rootsource to the limits:\n" >>${Log}


### PR DESCRIPTION
Until we don't find a solution to this problem, disabling partition checking and it will not bother to resize resized fs again. Most likely the bug is related to the ext4 filesystem changes in the upstream 5.8.y kernel.

Addressing [AR-425]

[AR-425]: https://armbian.atlassian.net/browse/AR-425