### PR TITLE
Workaround for USB ethernet tx-offload bug in Rockchip64

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -254,7 +254,7 @@ family_tweaks()
 
 		# rename USB based network to lan0
 		mkdir -p $SDCARD/etc/udev/rules.d/
-		echo 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="r8152", KERNEL=="eth1", NAME="lan0"' > $SDCARD/etc/udev/rules.d/70-rename-lan.rules
+		echo 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="r8152", KERNEL=="eth1", NAME="lan0"', RUN+="/usr/sbin/ethtool -K lan0 tx off" > $SDCARD/etc/udev/rules.d/70-rename-lan.rules
 
 		# workaround - create old school initial network config since network manager have issues
 		echo "auto eth0" >> $SDCARD/etc/network/interfaces


### PR DESCRIPTION
The problem has been detected on NanoPi R2S,  see https://forum.armbian.com/topic/15165-nanopi-r2s-lan0-goes-offline-with-high-traffic/

Tested only on my already installed armbian.
