### PR TITLE
Update 0001-bootsplash.patch

### DIFF
--- a/patch/misc/0001-bootsplash.patch
+++ b/patch/misc/0001-bootsplash.patch
@@ -581,7 +581,7 @@ index 000000000000..8c22ff92ce24
 +}
 +
 +static void dummy_cursor(struct vc_data *vc, struct fb_info *info, int mode,
-+			int softback_lines, int fg, int bg)
++			 int fg, int bg)
 +{
 +	;
 +}


### PR DESCRIPTION
dummyblit.c from patch/misc-001 will not compile with 5.8.10--

Change dummy_cursor  declaration in dummyblit.c in misc-001 to match changes in fbcon.h  
see
https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/drivers/video/fbdev/core/fbcon.h?h=v5.8.10&id=ffa74c8e58b8f42b2d95b29443befba2e28fb260


