### PR TITLE
Update boot-odroid-c4.ini

### DIFF
--- a/config/bootscripts/boot-odroid-c4.ini
+++ b/config/bootscripts/boot-odroid-c4.ini
@@ -81,8 +81,9 @@ setenv cec "false"
 setenv disable_vu7 "true"
 # setenv disable_vu7 "false"
 
-# max cpu frequency for little core, A55 in MHz unit
-# setenv max_freq_a55 "2016"  # 2.016 Ghz
+# max cpu frequency for A55 core in MHz unit
+# setenv max_freq_a55 "2100"  # 2.1 Ghz, 10% overclock
+# setenv max_freq_a55 "2016"  # 2.016 Ghz, mild overclock
 setenv max_freq_a55 "1908"    # 1.908 GHz, default value
 # setenv max_freq_a55 "1800"  # 1.8 Ghz
 # setenv max_freq_a55 "1704"  # 1.704 GHz
@@ -108,7 +109,7 @@ if test "${disable_vu7}" = "false"; then setenv hid_quirks "usbhid.quirks=0x0eef
 if ext4load mmc ${devno}:1 0x44000000 /boot/armbianEnv.txt || fatload mmc ${devno}:1 0x44000000 armbianEnv.txt || ext4load mmc ${devno}:1 0x44000000 armbianEnv.txt; then env import -t 0x44000000 ${filesize}; fi
 
 # Boot Args
-setenv bootargs "root=${rootdev} rootwait rootflags=data=writeback rw rootfstype=${rootfstype} ${condev} ${amlogic} no_console_suspend fsck.repair=yes net.ifnames=0 elevator=noop hdmimode=${hdmimode} cvbsmode=576cvbs maxcpus=${maxcpus} voutmode=${voutmode} ${cmode} disablehpd=${disablehpd} cvbscable=${cvbscable} overscan=${overscan} ${hid_quirks} monitor_onoff=${monitor_onoff} logo=osd0,loaded ${cec_enable} ${bootsplash} sdrmode=${sdrmode} consoleblank=0"
+setenv bootargs "root=${rootdev} rootwait rootflags=data=writeback rw rootfstype=${rootfstype} ${condev} ${amlogic} no_console_suspend fsck.repair=yes net.ifnames=0 elevator=noop hdmimode=${hdmimode} cvbsmode=576cvbs max_freq_a55=${max_freq_a55} maxcpus=${maxcpus} voutmode=${voutmode} ${cmode} disablehpd=${disablehpd} cvbscable=${cvbscable} overscan=${overscan} ${hid_quirks} monitor_onoff=${monitor_onoff} logo=osd0,loaded ${cec_enable} ${bootsplash} sdrmode=${sdrmode} consoleblank=0"
 
 # Set load addresses
 setenv dtb_loadaddr "0x1000000"


### PR DESCRIPTION
Fix a bug that prevents user from choosing any CPU frequency > 1.8 GHz.  Also increase the offered overclocking range.

Please use the "Preview" tab above to view this message if you are seeing this in the new pull request text box.

Please make sure that:

 - pull request is opened to the `master` branch unless you are working on a specfic feature which is developed in a separate branch
 - any changes to kernel configuration files were made by Kconfig menu (build script option `KERNEL_CONFIGURE=yes`) and not by editing configuration files by hand,
 - patch file names don't contain spaces and have less than 40 characters (not counting the `.patch` extension),
 - changes are properly described - what was done exactly and why.

Thanks for contributing! Please remove the text above before opening a pull request.
