### PR TITLE
add journalctl vacuum to armbian-truncate-logs

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-truncate-logs
+++ b/packages/bsp/common/usr/lib/armbian/armbian-truncate-logs
@@ -27,4 +27,6 @@ if [ $logusage -ge $treshold ]; then
     /usr/bin/find /var/log -name 'mail.err' -or -name 'mail.info' -or -name 'mail.warning' | xargs -r truncate --size 0
     # remove
     /usr/bin/find /var/log -name '*.[0-9]' -or -name '*.gz' | xargs -r rm -f
+    # rotate and vacuum systemd-journal
+    /usr/bin/journalctl --vacuum-size=5M --rotate
 fi


### PR DESCRIPTION
[AR-445]

will help clean /var/log when full


[AR-445]: https://armbian.atlassian.net/browse/AR-445