### PR TITLE
Revert removal of armbianEnv.txt load on odroid-xu4

### DIFF
--- a/config/bootscripts/boot-odroid-xu4.ini
+++ b/config/bootscripts/boot-odroid-xu4.ini
@@ -20,6 +20,8 @@ setenv verbosity "1"
 # To update boot loader on your eMMC use the nand-sata-install tool
 # run copy_uboot_sd2emmc
 
+if ext4load mmc 0:1 0x44000000 /boot/armbianEnv.txt || fatload mmc 0:1 0x44000000 armbianEnv.txt || ext4load mmc 0:1 0x44000000 armbianEnv.txt; then env import -t 0x44000000 ${filesize}; fi
+
 if test "${console}" = "display" || test "${console}" = "both"; then setenv consoleargs "console=tty1"; fi
 if test "${console}" = "serial" || test "${console}" = "both"; then setenv consoleargs "console=ttySAC2,115200n8 ${consoleargs}"; fi
 if test "${bootlogo}" = "true"; then setenv consoleargs "bootsplash.bootfile=bootsplash.armbian ${consoleargs}"; fi


### PR DESCRIPTION
Fixes breakage of setting board_name, usbstoragequirks, and extraargs on odroid-xu4 via armbianEnv.txt
(introduced in 7d758026b57380b17b6337e23b053db01c7e0b3d)