### PR TITLE
rk3399: Adapt helios64 devicetree name to match upstream linux

### DIFF
--- a/patch/kernel/rk3399-legacy/helios64-add-board.patch
+++ b/patch/kernel/rk3399-legacy/helios64-add-board.patch
@@ -6,9 +6,9 @@ Subject: [PATCH] Add Helios64 board device tree
 Signed-off-by: Aditya Prayoga <aditya@kobol.io>
 ---
  arch/arm64/boot/dts/rockchip/Makefile         |    1 +
- .../boot/dts/rockchip/rk3399-helios64.dts     | 1263 +++++++++++++++++
+ .../boot/dts/rockchip/rk3399-kobol-helios64.dts     | 1263 +++++++++++++++++
  2 files changed, 1264 insertions(+)
- create mode 100644 arch/arm64/boot/dts/rockchip/rk3399-helios64.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts
 
 diff --git a/arch/arm64/boot/dts/rockchip/Makefile b/arch/arm64/boot/dts/rockchip/Makefile
 index dbebbf9fe..2b1e29649 100644
@@ -18,15 +18,15 @@ index dbebbf9fe..2b1e29649 100644
  	rk3399-nanopi4-rev21.dtb \
  	rk3399-nanopi-m4v2.dtb \
  	rk3399-nanopi4-rev22.dtb \
-+	rk3399-helios64.dtb \
++	rk3399-kobol-helios64.dtb \
  	rk3399-firefly.dtb
  
  dtb-$(CONFIG_ARCH_ROCKCHIP) += \
-diff --git a/arch/arm64/boot/dts/rockchip/rk3399-helios64.dts b/arch/arm64/boot/dts/rockchip/rk3399-helios64.dts
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts b/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts
 new file mode 100644
 index 000000000..ef95aa489
 --- /dev/null
-+++ b/arch/arm64/boot/dts/rockchip/rk3399-helios64.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts
 @@ -0,0 +1,1263 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*

--- a/patch/kernel/rk3399-legacy/roc-rk3399-pc-add-board.patch
+++ b/patch/kernel/rk3399-legacy/roc-rk3399-pc-add-board.patch
@@ -5,7 +5,7 @@ index adfa8211..2c3a023a 100644
 @@ -15,7 +15,8 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += \
  	rk3399-nanopi-m4v2.dtb \
  	rk3399-nanopi4-rev22.dtb \
- 	rk3399-helios64.dtb \
+ 	rk3399-kobol-helios64.dtb \
 -	rk3399-firefly.dtb
 +	rk3399-firefly.dtb \
 +	rk3399-roc-pc.dtb

--- a/patch/kernel/rockchip64-current/add-board-helios64.patch
+++ b/patch/kernel/rockchip64-current/add-board-helios64.patch
@@ -6,9 +6,9 @@ Subject: [PATCH] Add board Helios64
 Signed-off-by: Aditya Prayoga <aditya@kobol.io>
 ---
  arch/arm64/boot/dts/rockchip/Makefile         |    1 +
- .../boot/dts/rockchip/rk3399-helios64.dts     | 1084 +++++++++++++++++
+ .../boot/dts/rockchip/rk3399-kobol-helios64.dts     | 1084 +++++++++++++++++
  2 files changed, 1085 insertions(+)
- create mode 100644 arch/arm64/boot/dts/rockchip/rk3399-helios64.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts
 
 diff --git a/arch/arm64/boot/dts/rockchip/Makefile b/arch/arm64/boot/dts/rockchip/Makefile
 index 473e14e12..b8e6e86e0 100644
@@ -18,15 +18,15 @@ index 473e14e12..b8e6e86e0 100644
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-gru-kevin.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-gru-scarlet-inx.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-gru-scarlet-kd.dtb
-+dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-helios64.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-kobol-helios64.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-hugsun-x99.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-khadas-edge.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-khadas-edge-captain.dtb
-diff --git a/arch/arm64/boot/dts/rockchip/rk3399-helios64.dts b/arch/arm64/boot/dts/rockchip/rk3399-helios64.dts
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts b/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts
 new file mode 100644
 index 000000000..fae17f416
 --- /dev/null
-+++ b/arch/arm64/boot/dts/rockchip/rk3399-helios64.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts
 @@ -0,0 +1,1084 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*

--- a/patch/kernel/rockchip64-current/zzz-0005-remove-overclock-from-helios64.patch
+++ b/patch/kernel/rockchip64-current/zzz-0005-remove-overclock-from-helios64.patch
@@ -5,13 +5,13 @@ Subject: [PATCH] Remove overclock from helios64
 
 Signed-off-by: Aditya Prayoga <aditya@kobol.io>
 ---
- arch/arm64/boot/dts/rockchip/rk3399-helios64.dts | 10 +++++++++-
+ arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts | 10 +++++++++-
  1 file changed, 9 insertions(+), 1 deletion(-)
 
-diff --git a/arch/arm64/boot/dts/rockchip/rk3399-helios64.dts b/arch/arm64/boot/dts/rockchip/rk3399-helios64.dts
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts b/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts
 index ba8ff5d4c..c065ba82d 100644
---- a/arch/arm64/boot/dts/rockchip/rk3399-helios64.dts
-+++ b/arch/arm64/boot/dts/rockchip/rk3399-helios64.dts
+--- a/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts
 @@ -1078,4 +1078,12 @@
  
  &vopl_mmu {

--- a/patch/u-boot/u-boot-rockchip64-mainline/add-board-helios64.patch
+++ b/patch/u-boot/u-boot-rockchip64-mainline/add-board-helios64.patch
@@ -6,8 +6,8 @@ Subject: [PATCH] Patching something
 Signed-off-by: Aditya Prayoga <aditya@kobol.io>
 ---
  arch/arm/dts/Makefile                    |    1 +
- arch/arm/dts/rk3399-helios64-u-boot.dtsi |  140 +++
- arch/arm/dts/rk3399-helios64.dts         | 1152 ++++++++++++++++++++++
+ arch/arm/dts/rk3399-kobol-helios64-u-boot.dtsi |  140 +++
+ arch/arm/dts/rk3399-kobol-helios64.dts         | 1152 ++++++++++++++++++++++
  arch/arm/mach-rockchip/rk3399/Kconfig    |   17 +
  board/kobol/helios64/Kconfig             |   24 +
  board/kobol/helios64/MAINTAINERS         |    6 +
@@ -18,8 +18,8 @@ Signed-off-by: Aditya Prayoga <aditya@kobol.io>
  configs/helios64-rk3399_defconfig        |  149 +++
  include/configs/helios64.h               |   47 +
  12 files changed, 2061 insertions(+)
- create mode 100644 arch/arm/dts/rk3399-helios64-u-boot.dtsi
- create mode 100644 arch/arm/dts/rk3399-helios64.dts
+ create mode 100644 arch/arm/dts/rk3399-kobol-helios64-u-boot.dtsi
+ create mode 100644 arch/arm/dts/rk3399-kobol-helios64.dts
  create mode 100644 board/kobol/helios64/Kconfig
  create mode 100644 board/kobol/helios64/MAINTAINERS
  create mode 100644 board/kobol/helios64/Makefile
@@ -37,15 +37,15 @@ index 530d60bf..d9fd6cf1 100644
  	rk3399-ficus.dtb \
  	rk3399-firefly.dtb \
  	rk3399-gru-bob.dtb \
-+	rk3399-helios64.dtb \
++	rk3399-kobol-helios64.dtb \
  	rk3399-khadas-edge.dtb \
  	rk3399-khadas-edge-captain.dtb \
  	rk3399-khadas-edge-v.dtb \
-diff --git a/arch/arm/dts/rk3399-helios64-u-boot.dtsi b/arch/arm/dts/rk3399-helios64-u-boot.dtsi
+diff --git a/arch/arm/dts/rk3399-kobol-helios64-u-boot.dtsi b/arch/arm/dts/rk3399-kobol-helios64-u-boot.dtsi
 new file mode 100644
 index 00000000..2988a209
 --- /dev/null
-+++ b/arch/arm/dts/rk3399-helios64-u-boot.dtsi
++++ b/arch/arm/dts/rk3399-kobol-helios64-u-boot.dtsi
 @@ -0,0 +1,140 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
@@ -187,11 +187,11 @@ index 00000000..2988a209
 +&vdd_log {
 +	regulator-init-microvolt = <900000>;
 +};
-diff --git a/arch/arm/dts/rk3399-helios64.dts b/arch/arm/dts/rk3399-helios64.dts
+diff --git a/arch/arm/dts/rk3399-kobol-helios64.dts b/arch/arm/dts/rk3399-kobol-helios64.dts
 new file mode 100644
 index 00000000..9d067505
 --- /dev/null
-+++ b/arch/arm/dts/rk3399-helios64.dts
++++ b/arch/arm/dts/rk3399-kobol-helios64.dts
 @@ -0,0 +1,1152 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
@@ -1996,7 +1996,7 @@ index 00000000..62210055
 +CONFIG_USE_PREBOOT=y
 +CONFIG_CONSOLE_MUX=y
 +CONFIG_SYS_CONSOLE_ENV_OVERWRITE=y
-+CONFIG_DEFAULT_FDT_FILE="rockchip/rk3399-helios64.dtb"
++CONFIG_DEFAULT_FDT_FILE="rockchip/rk3399-kobol-helios64.dtb"
 +CONFIG_MISC_INIT_R=y
 +CONFIG_VERSION_VARIABLE=y
 +# CONFIG_DISPLAY_BOARDINFO is not set
@@ -2048,7 +2048,7 @@ index 00000000..62210055
 +CONFIG_PARTITION_TYPE_GUID=y
 +CONFIG_SPL_OF_CONTROL=y
 +CONFIG_OF_LIVE=y
-+CONFIG_DEFAULT_DEVICE_TREE="rk3399-helios64"
++CONFIG_DEFAULT_DEVICE_TREE="rk3399-kobol-helios64"
 +CONFIG_OF_SPL_REMOVE_PROPS="pinctrl-0 pinctrl-names clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
 +CONFIG_ENV_IS_IN_MMC=y
 +CONFIG_SYS_RELOC_GD_ENV_ADDR=y


### PR DESCRIPTION
The helios64 devicetree was submitted for inclusion in the mainline kernel.
The name used there is rk3399-kobol-helios64, so use the same here
for consistency, to be easily able to boot a mainline kernel without
changing the U-Boot environment and simplify further development.