### PR TITLE
update bl31 from v1.42 to v1.44

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -31,7 +31,7 @@ if [[ $BOARD == nanopi-r2s || $BOARD == rockpi-e || $BOARD == nanopineo3 || $BOA
 	BOOT_SOC=rk3328
 	DDR_BLOB='rk33/rk3328_ddr_333MHz_v1.16.bin'
 	MINILOADER_BLOB='rk33/rk322xh_miniloader_v2.50.bin'
-	BL31_BLOB='rk33/rk322xh_bl31_v1.42.elf'
+	BL31_BLOB='rk33/rk322xh_bl31_v1.44.elf'
 
 elif [[ $BOARD == rock64 ]]; then
 


### PR DESCRIPTION
From Rockchip repo https://github.com/rockchip-linux/rkbin/commit/d671d47b5674acb930d6e180c049a50a8e932259

Build from ATF commit:
    403e0b816 plat: rk322xh: support atags
update feature:
    403e0b816 plat: rk322xh: support atags
    2daf5cc66 plat: rk322xh: ddr: fix the error about DDR4 DLL
    23e4d2483 rockchip: commit_elf.sh: select elf manually
    2041b46d8 BACKPORT: Prevent speculative execution past ERET
    af49f6714 UPSTREAM: runtime_exceptions: Save x4-x29 unconditionally
    7c114f10c plat: rockchip: common: fix the error about lpddr4 tccd

Tested on Renegade