### PR TITLE
Added Buster current CLI for Orange P i4

### DIFF
--- a/config/targets.conf
+++ b/config/targets.conf
@@ -511,6 +511,7 @@ orangepi4			legacy			buster		cli			stable	yes
 orangepi4			legacy			bullseye	cli			stable	yes
 orangepi4			legacy			bionic		desktop			stable	yes
 orangepi4			current			buster		desktop			stable	yes
+orangepi4			current			buster		cli			stable	yes
 orangepi4			current			bionic		minimal			stable	yes
 orangepi4			current			focal		cli			stable	yes
 orangepi4			current			focal		desktop			stable	yes


### PR DESCRIPTION
Added a configuration for the Orange Pi 4 and OnePlus for build Armbian Buster with current kernel.
