### PR TITLE
AR 206: Improve memory performance roc-rk3328-cc

### DIFF
--- a/patch/kernel/rockchip64-current/board-rk3328-roc-cc-dts-enable-dmc.patch
+++ b/patch/kernel/rockchip64-current/board-rk3328-roc-cc-dts-enable-dmc.patch
@@ -6,7 +6,7 @@ index a1041ec3e..cc5855eda 100644
   */
  
  /dts-v1/;
-+#include "rk3328-dram-default-timing.dtsi"
++#include "rk3328-dram-renegade-timing.dtsi"
  #include "rk3328.dtsi"
  
  / {
@@ -31,7 +31,7 @@ index a1041ec3e..cc5855eda 100644
 +		ddr_timing = <&ddr_timing>;
 +		upthreshold = <40>;
 +		downdifferential = <20>;
-+		auto-min-freq = <786000>;
++		auto-min-freq = <840000>;
 +		auto-freq-en = <0>;
 +		#cooling-cells = <2>;
 +		status = "okay";
@@ -79,8 +79,8 @@ index a1041ec3e..cc5855eda 100644
 +			opp-microvolt-L0 = <1100000>;
 +			opp-microvolt-L1 = <1075000>;
 +		};
-+		opp-1056000000 {
-+			opp-hz = /bits/ 64 <1056000000>;
++		opp-1068000000 {
++			opp-hz = /bits/ 64 <1068000000>;
 +			opp-microvolt = <1175000>;
 +			opp-microvolt-L0 = <1175000>;
 +			opp-microvolt-L1 = <1150000>;

--- a/patch/kernel/rockchip64-current/board-rk3328-roc-cc-dts-ram-profile.patch
+++ b/patch/kernel/rockchip64-current/board-rk3328-roc-cc-dts-ram-profile.patch
@@ -1,0 +1,331 @@
+From 036c59ebd2265236880bb156e995af55249726b1 Mon Sep 17 00:00:00 2001
+From: tonymac32 <tonymckahan@gmail.com>
+Date: Wed, 7 Oct 2020 23:39:54 -0400
+Subject: [PATCH] board-rk3328-roc-cc-adjust-DMC-opps
+
+Signed-off-by: tonymac32 <tonymckahan@gmail.com>
+---
+ .../rockchip/rk3328-dram-renegade-timing.dtsi | 311 ++++++++++++++++++
+ 1 file changed, 311 insertions(+), 0 deletion(-)
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3328-dram-renegade-timing.dtsi
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3328-dram-renegade-timing.dtsi b/arch/arm64/boot/dts/rockchip/rk3328-dram-renegade-timing.dtsi
+new file mode 100644
+index 000000000..303428153
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3328-dram-renegade-timing.dtsi
+@@ -0,0 +1,311 @@
++/*
++ * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd
++ *
++ * This file is dual-licensed: you can use it either under the terms
++ * of the GPL or the X11 license, at your option. Note that this dual
++ * licensing only applies to this file, and not this project as a
++ * whole.
++ *
++ *  a) This library is free software; you can redistribute it and/or
++ *     modify it under the terms of the GNU General Public License as
++ *     published by the Free Software Foundation; either version 2 of the
++ *     License, or (at your option) any later version.
++ *
++ *     This library is distributed in the hope that it will be useful,
++ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *     GNU General Public License for more details.
++ *
++ * Or, alternatively,
++ *
++ *  b) Permission is hereby granted, free of charge, to any person
++ *     obtaining a copy of this software and associated documentation
++ *     files (the "Software"), to deal in the Software without
++ *     restriction, including without limitation the rights to use,
++ *     copy, modify, merge, publish, distribute, sublicense, and/or
++ *     sell copies of the Software, and to permit persons to whom the
++ *     Software is furnished to do so, subject to the following
++ *     conditions:
++ *
++ *     The above copyright notice and this permission notice shall be
++ *     included in all copies or substantial portions of the Software.
++ *
++ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
++ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
++ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
++ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
++ *     OTHER DEALINGS IN THE SOFTWARE.
++ */
++#include <dt-bindings/clock/rockchip-ddr.h>
++#include <dt-bindings/memory/rk3328-dram.h>
++
++/ {
++	ddr_timing: ddr_timing {
++		compatible = "rockchip,ddr-timing";
++		ddr3_speed_bin = <DDR3_DEFAULT>;
++		ddr4_speed_bin = <DDR4_DEFAULT>;
++		pd_idle = <0>;
++		sr_idle = <0>;
++		sr_mc_gate_idle = <0>;
++		srpd_lite_idle	= <0>;
++		standby_idle = <0>;
++
++		auto_pd_dis_freq = <1066>;
++		auto_sr_dis_freq = <800>;
++		ddr3_dll_dis_freq = <300>;
++		ddr4_dll_dis_freq = <625>;
++		phy_dll_dis_freq = <400>;
++
++		ddr3_odt_dis_freq = <100>;
++		phy_ddr3_odt_dis_freq = <100>;
++		ddr3_drv = <DDR3_DS_40ohm>;
++		ddr3_odt = <DDR3_ODT_120ohm>;
++		phy_ddr3_ca_drv = <PHY_DDR3_RON_RTT_34ohm>;
++		phy_ddr3_ck_drv = <PHY_DDR3_RON_RTT_45ohm>;
++		phy_ddr3_dq_drv = <PHY_DDR3_RON_RTT_34ohm>;
++		phy_ddr3_odt = <PHY_DDR3_RON_RTT_225ohm>;
++
++		lpddr3_odt_dis_freq = <666>;
++		phy_lpddr3_odt_dis_freq = <666>;
++		lpddr3_drv = <LP3_DS_40ohm>;
++		lpddr3_odt = <LP3_ODT_240ohm>;
++		phy_lpddr3_ca_drv = <PHY_DDR4_LPDDR3_RON_RTT_34ohm>;
++		phy_lpddr3_ck_drv = <PHY_DDR4_LPDDR3_RON_RTT_43ohm>;
++		phy_lpddr3_dq_drv = <PHY_DDR4_LPDDR3_RON_RTT_34ohm>;
++		phy_lpddr3_odt = <PHY_DDR4_LPDDR3_RON_RTT_240ohm>;
++
++		lpddr4_odt_dis_freq = <800>;
++		phy_lpddr4_odt_dis_freq = <800>;
++		lpddr4_drv = <LP4_PDDS_60ohm>;
++		lpddr4_dq_odt = <LP4_DQ_ODT_40ohm>;
++		lpddr4_ca_odt = <LP4_CA_ODT_40ohm>;
++		phy_lpddr4_ca_drv = <PHY_DDR4_LPDDR3_RON_RTT_40ohm>;
++		phy_lpddr4_ck_cs_drv = <PHY_DDR4_LPDDR3_RON_RTT_80ohm>;
++		phy_lpddr4_dq_drv = <PHY_DDR4_LPDDR3_RON_RTT_80ohm>;
++		phy_lpddr4_odt = <PHY_DDR4_LPDDR3_RON_RTT_60ohm>;
++
++		ddr4_odt_dis_freq = <666>;
++		phy_ddr4_odt_dis_freq = <666>;
++		ddr4_drv = <DDR4_DS_34ohm>;
++		ddr4_odt = <DDR4_RTT_NOM_240ohm>;
++		phy_ddr4_ca_drv = <PHY_DDR4_LPDDR3_RON_RTT_34ohm>;
++		phy_ddr4_ck_drv = <PHY_DDR4_LPDDR3_RON_RTT_43ohm>;
++		phy_ddr4_dq_drv = <PHY_DDR4_LPDDR3_RON_RTT_34ohm>;
++		phy_ddr4_odt = <PHY_DDR4_LPDDR3_RON_RTT_240ohm>;
++
++		/* CA de-skew, one step is 47.8ps, range 0-15 */
++		ddr3a1_ddr4a9_de-skew = <0>;
++		ddr3a0_ddr4a10_de-skew = <0>;
++		ddr3a3_ddr4a6_de-skew = <1>;
++		ddr3a2_ddr4a4_de-skew = <1>;
++		ddr3a5_ddr4a8_de-skew = <0>;
++		ddr3a4_ddr4a5_de-skew = <2>;
++		ddr3a7_ddr4a11_de-skew = <0>;
++		ddr3a6_ddr4a7_de-skew = <2>;
++		ddr3a9_ddr4a0_de-skew = <1>;
++		ddr3a8_ddr4a13_de-skew = <0>;
++		ddr3a11_ddr4a3_de-skew = <2>;
++		ddr3a10_ddr4cs0_de-skew = <0>;
++		ddr3a13_ddr4a2_de-skew = <1>;
++		ddr3a12_ddr4ba1_de-skew = <0>;
++		ddr3a15_ddr4odt0_de-skew = <0>;
++		ddr3a14_ddr4a1_de-skew = <1>;
++		ddr3ba1_ddr4a15_de-skew = <0>;
++		ddr3ba0_ddr4bg0_de-skew = <0>;
++		ddr3ras_ddr4cke_de-skew = <0>;
++		ddr3ba2_ddr4ba0_de-skew = <1>;
++		ddr3we_ddr4bg1_de-skew = <1>;
++		ddr3cas_ddr4a12_de-skew = <0>;
++		ddr3ckn_ddr4ckn_de-skew = <5>;
++		ddr3ckp_ddr4ckp_de-skew = <5>;
++		ddr3cke_ddr4a16_de-skew = <1>;
++		ddr3odt0_ddr4a14_de-skew = <0>;
++		ddr3cs0_ddr4act_de-skew = <1>;
++		ddr3reset_ddr4reset_de-skew = <0>;
++		ddr3cs1_ddr4cs1_de-skew = <0>;
++		ddr3odt1_ddr4odt1_de-skew = <0>;
++
++		/* DATA de-skew
++		 * RX one step is 25.1ps, range 0-15
++		 * TX one step is 47.8ps, range 0-15
++		 */
++		cs0_dm0_rx_de-skew = <7>;
++		cs0_dm0_tx_de-skew = <8>;
++		cs0_dq0_rx_de-skew = <7>;
++		cs0_dq0_tx_de-skew = <8>;
++		cs0_dq1_rx_de-skew = <7>;
++		cs0_dq1_tx_de-skew = <8>;
++		cs0_dq2_rx_de-skew = <7>;
++		cs0_dq2_tx_de-skew = <8>;
++		cs0_dq3_rx_de-skew = <7>;
++		cs0_dq3_tx_de-skew = <8>;
++		cs0_dq4_rx_de-skew = <7>;
++		cs0_dq4_tx_de-skew = <8>;
++		cs0_dq5_rx_de-skew = <7>;
++		cs0_dq5_tx_de-skew = <8>;
++		cs0_dq6_rx_de-skew = <7>;
++		cs0_dq6_tx_de-skew = <8>;
++		cs0_dq7_rx_de-skew = <7>;
++		cs0_dq7_tx_de-skew = <8>;
++		cs0_dqs0_rx_de-skew = <6>;
++		cs0_dqs0p_tx_de-skew = <9>;
++		cs0_dqs0n_tx_de-skew = <9>;
++
++		cs0_dm1_rx_de-skew = <7>;
++		cs0_dm1_tx_de-skew = <7>;
++		cs0_dq8_rx_de-skew = <7>;
++		cs0_dq8_tx_de-skew = <8>;
++		cs0_dq9_rx_de-skew = <7>;
++		cs0_dq9_tx_de-skew = <7>;
++		cs0_dq10_rx_de-skew = <7>;
++		cs0_dq10_tx_de-skew = <8>;
++		cs0_dq11_rx_de-skew = <7>;
++		cs0_dq11_tx_de-skew = <7>;
++		cs0_dq12_rx_de-skew = <7>;
++		cs0_dq12_tx_de-skew = <8>;
++		cs0_dq13_rx_de-skew = <7>;
++		cs0_dq13_tx_de-skew = <7>;
++		cs0_dq14_rx_de-skew = <7>;
++		cs0_dq14_tx_de-skew = <8>;
++		cs0_dq15_rx_de-skew = <7>;
++		cs0_dq15_tx_de-skew = <7>;
++		cs0_dqs1_rx_de-skew = <7>;
++		cs0_dqs1p_tx_de-skew = <9>;
++		cs0_dqs1n_tx_de-skew = <9>;
++
++		cs0_dm2_rx_de-skew = <7>;
++		cs0_dm2_tx_de-skew = <8>;
++		cs0_dq16_rx_de-skew = <7>;
++		cs0_dq16_tx_de-skew = <8>;
++		cs0_dq17_rx_de-skew = <7>;
++		cs0_dq17_tx_de-skew = <8>;
++		cs0_dq18_rx_de-skew = <7>;
++		cs0_dq18_tx_de-skew = <8>;
++		cs0_dq19_rx_de-skew = <7>;
++		cs0_dq19_tx_de-skew = <8>;
++		cs0_dq20_rx_de-skew = <7>;
++		cs0_dq20_tx_de-skew = <8>;
++		cs0_dq21_rx_de-skew = <7>;
++		cs0_dq21_tx_de-skew = <8>;
++		cs0_dq22_rx_de-skew = <7>;
++		cs0_dq22_tx_de-skew = <8>;
++		cs0_dq23_rx_de-skew = <7>;
++		cs0_dq23_tx_de-skew = <8>;
++		cs0_dqs2_rx_de-skew = <6>;
++		cs0_dqs2p_tx_de-skew = <9>;
++		cs0_dqs2n_tx_de-skew = <9>;
++
++		cs0_dm3_rx_de-skew = <7>;
++		cs0_dm3_tx_de-skew = <7>;
++		cs0_dq24_rx_de-skew = <7>;
++		cs0_dq24_tx_de-skew = <8>;
++		cs0_dq25_rx_de-skew = <7>;
++		cs0_dq25_tx_de-skew = <7>;
++		cs0_dq26_rx_de-skew = <7>;
++		cs0_dq26_tx_de-skew = <7>;
++		cs0_dq27_rx_de-skew = <7>;
++		cs0_dq27_tx_de-skew = <7>;
++		cs0_dq28_rx_de-skew = <7>;
++		cs0_dq28_tx_de-skew = <7>;
++		cs0_dq29_rx_de-skew = <7>;
++		cs0_dq29_tx_de-skew = <7>;
++		cs0_dq30_rx_de-skew = <7>;
++		cs0_dq30_tx_de-skew = <7>;
++		cs0_dq31_rx_de-skew = <7>;
++		cs0_dq31_tx_de-skew = <7>;
++		cs0_dqs3_rx_de-skew = <7>;
++		cs0_dqs3p_tx_de-skew = <9>;
++		cs0_dqs3n_tx_de-skew = <9>;
++
++		cs1_dm0_rx_de-skew = <7>;
++		cs1_dm0_tx_de-skew = <8>;
++		cs1_dq0_rx_de-skew = <7>;
++		cs1_dq0_tx_de-skew = <8>;
++		cs1_dq1_rx_de-skew = <7>;
++		cs1_dq1_tx_de-skew = <8>;
++		cs1_dq2_rx_de-skew = <7>;
++		cs1_dq2_tx_de-skew = <8>;
++		cs1_dq3_rx_de-skew = <7>;
++		cs1_dq3_tx_de-skew = <8>;
++		cs1_dq4_rx_de-skew = <7>;
++		cs1_dq4_tx_de-skew = <8>;
++		cs1_dq5_rx_de-skew = <7>;
++		cs1_dq5_tx_de-skew = <8>;
++		cs1_dq6_rx_de-skew = <7>;
++		cs1_dq6_tx_de-skew = <8>;
++		cs1_dq7_rx_de-skew = <7>;
++		cs1_dq7_tx_de-skew = <8>;
++		cs1_dqs0_rx_de-skew = <6>;
++		cs1_dqs0p_tx_de-skew = <9>;
++		cs1_dqs0n_tx_de-skew = <9>;
++
++		cs1_dm1_rx_de-skew = <7>;
++		cs1_dm1_tx_de-skew = <7>;
++		cs1_dq8_rx_de-skew = <7>;
++		cs1_dq8_tx_de-skew = <8>;
++		cs1_dq9_rx_de-skew = <7>;
++		cs1_dq9_tx_de-skew = <7>;
++		cs1_dq10_rx_de-skew = <7>;
++		cs1_dq10_tx_de-skew = <8>;
++		cs1_dq11_rx_de-skew = <7>;
++		cs1_dq11_tx_de-skew = <7>;
++		cs1_dq12_rx_de-skew = <7>;
++		cs1_dq12_tx_de-skew = <8>;
++		cs1_dq13_rx_de-skew = <7>;
++		cs1_dq13_tx_de-skew = <7>;
++		cs1_dq14_rx_de-skew = <7>;
++		cs1_dq14_tx_de-skew = <8>;
++		cs1_dq15_rx_de-skew = <7>;
++		cs1_dq15_tx_de-skew = <7>;
++		cs1_dqs1_rx_de-skew = <7>;
++		cs1_dqs1p_tx_de-skew = <9>;
++		cs1_dqs1n_tx_de-skew = <9>;
++
++		cs1_dm2_rx_de-skew = <7>;
++		cs1_dm2_tx_de-skew = <8>;
++		cs1_dq16_rx_de-skew = <7>;
++		cs1_dq16_tx_de-skew = <8>;
++		cs1_dq17_rx_de-skew = <7>;
++		cs1_dq17_tx_de-skew = <8>;
++		cs1_dq18_rx_de-skew = <7>;
++		cs1_dq18_tx_de-skew = <8>;
++		cs1_dq19_rx_de-skew = <7>;
++		cs1_dq19_tx_de-skew = <8>;
++		cs1_dq20_rx_de-skew = <7>;
++		cs1_dq20_tx_de-skew = <8>;
++		cs1_dq21_rx_de-skew = <7>;
++		cs1_dq21_tx_de-skew = <8>;
++		cs1_dq22_rx_de-skew = <7>;
++		cs1_dq22_tx_de-skew = <8>;
++		cs1_dq23_rx_de-skew = <7>;
++		cs1_dq23_tx_de-skew = <8>;
++		cs1_dqs2_rx_de-skew = <6>;
++		cs1_dqs2p_tx_de-skew = <9>;
++		cs1_dqs2n_tx_de-skew = <9>;
++
++		cs1_dm3_rx_de-skew = <7>;
++		cs1_dm3_tx_de-skew = <7>;
++		cs1_dq24_rx_de-skew = <7>;
++		cs1_dq24_tx_de-skew = <8>;
++		cs1_dq25_rx_de-skew = <7>;
++		cs1_dq25_tx_de-skew = <7>;
++		cs1_dq26_rx_de-skew = <7>;
++		cs1_dq26_tx_de-skew = <7>;
++		cs1_dq27_rx_de-skew = <7>;
++		cs1_dq27_tx_de-skew = <7>;
++		cs1_dq28_rx_de-skew = <7>;
++		cs1_dq28_tx_de-skew = <7>;
++		cs1_dq29_rx_de-skew = <7>;
++		cs1_dq29_tx_de-skew = <7>;
++		cs1_dq30_rx_de-skew = <7>;
++		cs1_dq30_tx_de-skew = <7>;
++		cs1_dq31_rx_de-skew = <7>;
++		cs1_dq31_tx_de-skew = <7>;
++		cs1_dqs3_rx_de-skew = <7>;
++		cs1_dqs3p_tx_de-skew = <9>;
++		cs1_dqs3n_tx_de-skew = <9>;
++	};
++};
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/kernel/rockchip64-current/rk3328-audio-and-renegade-supplies.patch
+++ b/patch/kernel/rockchip64-current/rk3328-audio-and-renegade-supplies.patch
@@ -114,7 +114,7 @@ index f4b6799a8..a1041ec3e 100644
 -				regulator-min-microvolt = <712500>;
 -				regulator-max-microvolt = <1450000>;
 +				regulator-min-microvolt = <900000>;
-+				regulator-max-microvolt = <1150000>;
++				regulator-max-microvolt = <11750000>;
 +				regulator-ramp-delay = <12500>;
  				regulator-always-on;
  				regulator-boot-on;
@@ -126,7 +126,7 @@ index f4b6799a8..a1041ec3e 100644
 -				regulator-min-microvolt = <712500>;
 -				regulator-max-microvolt = <1450000>;
 +				regulator-min-microvolt = <950000>;
-+				regulator-max-microvolt = <1350000>;
++				regulator-max-microvolt = <1450000>;
 +				regulator-ramp-delay = <12500>;
  				regulator-always-on;
  				regulator-boot-on;

--- a/patch/kernel/rockchip64-current/rk3328-audio-and-renegade-supplies.patch
+++ b/patch/kernel/rockchip64-current/rk3328-audio-and-renegade-supplies.patch
@@ -114,7 +114,7 @@ index f4b6799a8..a1041ec3e 100644
 -				regulator-min-microvolt = <712500>;
 -				regulator-max-microvolt = <1450000>;
 +				regulator-min-microvolt = <900000>;
-+				regulator-max-microvolt = <11750000>;
++				regulator-max-microvolt = <1175000>;
 +				regulator-ramp-delay = <12500>;
  				regulator-always-on;
  				regulator-boot-on;


### PR DESCRIPTION
addresses instability and poor memory performance of rk3328-roc-cc with "Current" kernel (5.8.y)

Changes:
 - added board-specific dram profile using vendor profile as reference
 - increased vdd_log to support 1068 MHz opp (RAM is DDR4-2400, so an approx DDR4-2133 speed is within specs)
 - increased vdd_arm to support 1.5 GHz opp 
 **(discuss:  this an overclock, recommend out of box max is 1.3 with user ability to select 1.5)**

The current opps are a bit confusing, with irregular spacing.  I may make a second pass and choose more regularly spaced points.  The only reason to have more than 2 is for the user to select a minimum, the devfreq driver goes from min to max only.

Testing:

 - @ThomasKaiser 's sbc-bench, output: http://ix.io/2A3F
 - 12 hours running BOINC (Rosetta @ home, 4 threads)
 - 3 hours full screen YouTube video (seemed to have the most immediate effect of hitting maximum RAM speed.

Recommend more people test this before merge.

SBC bench result with 1.4 GHz opp K4.4: 
```
 standard memcpy                                      :   1565.3 MB/s (0.5%)
 standard memset                                      :   7435.8 MB/s
```

SBC bench result with 1.3 GHz opp K5.8:

```
 standard memcpy                                      :   1690.2 MB/s (2.9%)
 standard memset                                      :   6203.7 MB/s (3.6%)

```

NOTE: that this was on a desktop image with monitoring.  I will comment with more scientific results as I take them, I wanted to get more eyes on this.