### PR TITLE
Patching general packaging patches, remove postinst code dealing with NAND

### DIFF
--- a/patch/misc/general-packaging-4.14.y.patch
+++ b/patch/misc/general-packaging-4.14.y.patch
@@ -111,7 +111,7 @@ index 8c4bc5a2c..30bc0cffb 100644
  
  set -e
  
-@@ -212,6 +246,53 @@ EOF
+@@ -212,6 +246,44 @@ EOF
  	chmod 755 "$tmpdir/DEBIAN/$script"
  done
  
@@ -120,16 +120,7 @@ index 8c4bc5a2c..30bc0cffb 100644
 +##
 +sed -e "s/exit 0//g" -i $tmpdir/DEBIAN/postinst
 +cat >> $tmpdir/DEBIAN/postinst <<EOT
-+if [ "\$(grep nand /proc/partitions)" != "" ] && [ "\$(grep mmc /proc/partitions)" = "" ]; then
-+mkimage -A arm -O linux -T kernel -C none -a "0x40008000" -e "0x40008000" -n "Linux kernel" -d /$installed_image_path /boot/uImage  > /dev/null 2>&1
-+cp /boot/uImage /tmp/uImage
-+sync
-+mountpoint -q /boot || mount /boot
-+cp /tmp/uImage /boot/uImage
-+rm -f /$installed_image_path
-+else
 +ln -sf $(basename $installed_image_path) /boot/$image_name 2> /dev/null || mv /$installed_image_path /boot/$image_name
-+fi
 +touch /boot/.next
 +exit 0
 +EOT

--- a/patch/misc/general-packaging-4.19.y.patch
+++ b/patch/misc/general-packaging-4.19.y.patch
@@ -134,7 +134,7 @@ index 0b31f4f1f92c..f6b96d8507f4 100755
  
  set -e
  
-@@ -153,9 +209,58 @@ EOF
+@@ -153,9 +209,49 @@ EOF
  	chmod 755 "$tmpdir/DEBIAN/$script"
  done
  
@@ -143,16 +143,7 @@ index 0b31f4f1f92c..f6b96d8507f4 100755
 +##
 +sed -e "s/exit 0//g" -i $tmpdir/DEBIAN/postinst
 +cat >> $tmpdir/DEBIAN/postinst <<EOT
-+if [ "\$(grep nand /proc/partitions)" != "" ] && [ "\$(grep mmc /proc/partitions)" = "" ]; then
-+	mkimage -A arm -O linux -T kernel -C none -a "0x40008000" -e "0x40008000" -n "Linux kernel" -d /$installed_image_path /boot/uImage  > /dev/null 2>&1
-+	cp /boot/uImage /tmp/uImage
-+	sync
-+	mountpoint -q /boot || mount /boot
-+	cp /tmp/uImage /boot/uImage
-+	rm -f /$installed_image_path
-+else
-+	ln -sf $(basename $installed_image_path) /boot/$image_name 2> /dev/null || mv /$installed_image_path /boot/$image_name
-+fi
++ln -sf $(basename $installed_image_path) /boot/$image_name 2> /dev/null || mv /$installed_image_path /boot/$image_name
 +touch /boot/.next
 +exit 0
 +EOT

--- a/patch/misc/general-packaging-4.4.y-rk3399.patch
+++ b/patch/misc/general-packaging-4.4.y-rk3399.patch
@@ -115,7 +115,7 @@ index 6c3b038e..f4166fbe 100755
  export INITRD=$want_initrd
  
  test -d $debhookdir/$script.d && run-parts --arg="$version" --arg="/$installed_image_path" $debhookdir/$script.d
-@@ -218,6 +252,56 @@ EOF
+@@ -218,6 +252,44 @@ EOF
  	chmod 755 "$tmpdir/DEBIAN/$script"
  done
  
@@ -124,19 +124,7 @@ index 6c3b038e..f4166fbe 100755
 +##
 +sed -e "s/exit 0//g" -i $tmpdir/DEBIAN/postinst
 +cat >> $tmpdir/DEBIAN/postinst <<EOT 
-+if [ "\$(grep nand /proc/partitions)" != "" ] && [ "\$(grep mmc /proc/partitions)" = "" ]; then
-+mkimage -A arm -O linux -T kernel -C gzip -a "0x40008000" -e "0x40008000" -n "Linux kernel" -d /$installed_image_path /boot/uImage  > /dev/null 2>&1
-+cp /boot/uImage /tmp/uImage
-+##copy uncompressed Kernel Image w/o Uboot for espressobin--gzip compressed forced above for mkimage
-+cp $installed_image_path /tmp/Image
-+sync
-+mountpoint -q /boot || mount /boot
-+cp /tmp/uImage /boot/uImage
-+cp /tmp/Image /boot/Image
-+rm -f /$installed_image_path
-+else
 +ln -sf $(basename $installed_image_path) /boot/Image > /dev/null 2>&1 || mv /$installed_image_path /boot/Image
-+fi
 +touch /boot/.next
 +exit 0
 +EOT

--- a/patch/misc/general-packaging-4.4.y-rockchip64.patch
+++ b/patch/misc/general-packaging-4.4.y-rockchip64.patch
@@ -115,7 +115,7 @@ index 6c3b038e..f4166fbe 100755
  export INITRD=$want_initrd
  
  test -d $debhookdir/$script.d && run-parts --arg="$version" --arg="/$installed_image_path" $debhookdir/$script.d
-@@ -218,6 +252,56 @@ EOF
+@@ -218,6 +252,44 @@ EOF
  	chmod 755 "$tmpdir/DEBIAN/$script"
  done
  
@@ -124,19 +124,7 @@ index 6c3b038e..f4166fbe 100755
 +##
 +sed -e "s/exit 0//g" -i $tmpdir/DEBIAN/postinst
 +cat >> $tmpdir/DEBIAN/postinst <<EOT 
-+if [ "\$(grep nand /proc/partitions)" != "" ] && [ "\$(grep mmc /proc/partitions)" = "" ]; then
-+mkimage -A arm -O linux -T kernel -C gzip -a "0x40008000" -e "0x40008000" -n "Linux kernel" -d /$installed_image_path /boot/uImage  > /dev/null 2>&1
-+cp /boot/uImage /tmp/uImage
-+##copy uncompressed Kernel Image w/o Uboot for espressobin--gzip compressed forced above for mkimage
-+cp $installed_image_path /tmp/Image
-+sync
-+mountpoint -q /boot || mount /boot
-+cp /tmp/uImage /boot/uImage
-+cp /tmp/Image /boot/Image
-+rm -f /$installed_image_path
-+else
 +ln -sf $(basename $installed_image_path) /boot/Image > /dev/null 2>&1 || mv /$installed_image_path /boot/Image
-+fi
 +touch /boot/.next
 +exit 0
 +EOT

--- a/patch/misc/general-packaging-4.4.y.patch
+++ b/patch/misc/general-packaging-4.4.y.patch
@@ -111,7 +111,7 @@ index 6c3b038e..977a0624 100755
  export INITRD=$want_initrd
  
  test -d $debhookdir/$script.d && run-parts --arg="$version" --arg="/$installed_image_path" $debhookdir/$script.d
-@@ -218,6 +254,53 @@
+@@ -218,6 +254,44 @@
  	chmod 755 "$tmpdir/DEBIAN/$script"
  done
  
@@ -120,16 +120,7 @@ index 6c3b038e..977a0624 100755
 +##
 +sed -e "s/exit 0//g" -i $tmpdir/DEBIAN/postinst
 +cat >> $tmpdir/DEBIAN/postinst <<EOT 
-+if [ "\$(grep nand /proc/partitions)" != "" ] && [ "\$(grep mmc /proc/partitions)" = "" ]; then
-+mkimage -A arm -O linux -T kernel -C none -a "0x40008000" -e "0x40008000" -n "Linux kernel" -d /$installed_image_path /boot/uImage  > /dev/null 2>&1
-+cp /boot/uImage /tmp/uImage
-+sync
-+mountpoint -q /boot || mount /boot
-+cp /tmp/uImage /boot/uImage
-+rm -f /$installed_image_path
-+else
 +ln -sf $(basename $installed_image_path) /boot/$image_name > /dev/null 2>&1 || mv /$installed_image_path /boot/$image_name
-+fi
 +touch /boot/.next
 +exit 0
 +EOT

--- a/patch/misc/general-packaging-4.9.y.patch
+++ b/patch/misc/general-packaging-4.9.y.patch
@@ -98,7 +98,7 @@ index 0a2a7372..87edac65 100755
  export INITRD=$want_initrd
  
  test -d $debhookdir/$script.d && run-parts --arg="$version" --arg="/$installed_image_path" $debhookdir/$script.d
-@@ -220,6 +253,53 @@ EOF
+@@ -220,6 +253,44 @@ EOF
  	chmod 755 "$tmpdir/DEBIAN/$script"
  done
  
@@ -107,16 +107,7 @@ index 0a2a7372..87edac65 100755
 +##
 +sed -e "s/exit 0//g" -i $tmpdir/DEBIAN/postinst
 +cat >> $tmpdir/DEBIAN/postinst <<EOT 
-+if [ "\$(grep nand /proc/partitions)" != "" ] && [ "\$(grep mmc /proc/partitions)" = "" ]; then
-+mkimage -A arm -O linux -T kernel -C none -a "0x40008000" -e "0x40008000" -n "Linux kernel" -d /$installed_image_path /boot/uImage  > /dev/null 2>&1
-+cp /boot/uImage /tmp/uImage
-+sync
-+mountpoint -q /boot || mount /boot
-+cp /tmp/uImage /boot/uImage
-+rm -f /$installed_image_path
-+else
 +ln -sf $(basename $installed_image_path) /boot/zImage > /dev/null 2>&1 || mv /$installed_image_path /boot/zImage
-+fi
 +touch /boot/.next
 +exit 0
 +EOT

--- a/patch/misc/general-packaging-5.3.y.patch
+++ b/patch/misc/general-packaging-5.3.y.patch
@@ -133,7 +133,7 @@ index c4c580f547ef..2be8a687f878 100755
  
  set -e
  
-@@ -164,9 +219,58 @@ EOF
+@@ -164,9 +219,49 @@ EOF
  	chmod 755 "$tmpdir/DEBIAN/$script"
  done
  
@@ -142,16 +142,7 @@ index c4c580f547ef..2be8a687f878 100755
 +##
 +sed -e "s/exit 0//g" -i $tmpdir/DEBIAN/postinst
 +cat >> $tmpdir/DEBIAN/postinst <<EOT
-+if [ "\$(grep nand /proc/partitions)" != "" ] && [ "\$(grep mmc /proc/partitions)" = "" ]; then
-+	mkimage -A arm -O linux -T kernel -C none -a "0x40008000" -e "0x40008000" -n "Linux kernel" -d /$installed_image_path /boot/uImage  > /dev/null 2>&1
-+	cp /boot/uImage /tmp/uImage
-+	sync
-+	mountpoint -q /boot || mount /boot
-+	cp /tmp/uImage /boot/uImage
-+	rm -f /$installed_image_path
-+else
-+	ln -sf $(basename $installed_image_path) /boot/$image_name || mv /$installed_image_path /boot/$image_name
-+fi
++ln -sf $(basename $installed_image_path) /boot/$image_name || mv /$installed_image_path /boot/$image_name
 +touch /boot/.next
 +exit 0
 +EOT

--- a/patch/misc/general-packaging-5.6.y.patch
+++ b/patch/misc/general-packaging-5.6.y.patch
@@ -150,7 +150,7 @@ index 6df3c9f..d33e1f3 100755
  
  set -e
  
-@@ -201,12 +257,81 @@ EOF
+@@ -201,12 +257,72 @@ EOF
  	chmod 755 "$tmpdir/DEBIAN/$script"
  done
  
@@ -162,16 +162,7 @@ index 6df3c9f..d33e1f3 100755
 +##
 +sed -e "s/exit 0//g" -i $tmpdir/DEBIAN/postinst
 +cat >> $tmpdir/DEBIAN/postinst <<EOT
-+if [ "\$(grep nand /proc/partitions)" != "" ] && [ "\$(grep mmc /proc/partitions)" = "" ]; then
-+	mkimage -A arm -O linux -T kernel -C none -a "0x40008000" -e "0x40008000" -n "Linux kernel" -d /$installed_image_path /boot/uImage  > /dev/null 2>&1
-+	cp /boot/uImage /tmp/uImage
-+	sync
-+	mountpoint -q /boot || mount /boot
-+	cp /tmp/uImage /boot/uImage
-+	rm -f /$installed_image_path
-+else
-+	ln -sf $(basename $installed_image_path) /boot/$image_name 2> /dev/null || mv /$installed_image_path /boot/$image_name
-+fi
++ln -sf $(basename $installed_image_path) /boot/$image_name 2> /dev/null || mv /$installed_image_path /boot/$image_name
 +touch /boot/.next
 +exit 0
 +EOT


### PR DESCRIPTION
Some shell code in some general packaging patches seems to be a leftover. It was dealing with some NAND board configurations and seems unnecessary nowadays.

In particular, in the rk3399 4.4.y patch there is a comment about the espressobin board, so I bring in marvell people for further inspection. @igorpecovnik suggested it may be a leftover for old allwinner boards, so allwinner people may confirm if this is safe.

The discussion on IRC starts here: https://freenode.irclog.whitequark.org/armbian/2020-10-09#28103698
