### PR TITLE
Don't delete /boot/armbianEnv.txt file at least for meson64

### DIFF
--- a/config/bootenv/meson.txt
+++ b/config/bootenv/meson.txt
@@ -1,3 +1,2 @@
 verbosity=1
 console=both
-ethaddr=00:50:43:84:fb:2f

--- a/config/bootscripts/boot-odroid-n2.ini
+++ b/config/bootscripts/boot-odroid-n2.ini
@@ -1,10 +1,5 @@
 ODROIDN2-UBOOT-CONFIG
 
-setenv rootdev "/dev/mmcblk0p1"
-setenv rootfstype "ext4"
-
-ODROIDN2-UBOOT-CONFIG
-
 # Display splash logo
 setenv bootlogo "false"
 

--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -518,7 +518,9 @@ prepare_partitions()
 		else
 			sed -i 's/^setenv rootdev .*/setenv rootdev "'$rootfs'"/' $SDCARD/boot/boot.ini
 		fi
-		[[ -f $SDCARD/boot/armbianEnv.txt ]] && rm $SDCARD/boot/armbianEnv.txt
+		if [[  $LINUXFAMILY != meson64 ]]; then
+			[[ -f $SDCARD/boot/armbianEnv.txt ]] && rm $SDCARD/boot/armbianEnv.txt
+		fi
 	fi
 
 	# if we have a headless device, set console to DEFAULT_CONSOLE


### PR DESCRIPTION
fix for #2249 ODroid-N2 armbian-config-->hardware menu not work

Will be better to check for platform that need to remove env file.