### PR TITLE
create simlink to boot in /boot on separate partition

### DIFF
--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -490,6 +490,9 @@ prepare_partitions()
 		mkdir -p $MOUNT/boot/
 		mount ${LOOP}p${bootpart} $MOUNT/boot/
 		echo "UUID=$(blkid -s UUID -o value ${LOOP}p${bootpart}) /boot ${mkfs[$bootfs]} defaults${mountopts[$bootfs]} 0 2" >> $SDCARD/etc/fstab
+		# workaround allows to use /boot/filename naming when
+		# /boot partition mounted as "/" on first boot stage (before initrd)
+		ln -s -T . $MOUNT/boot/boot
 	fi
 	[[ $ROOTFS_TYPE == nfs ]] && echo "/dev/nfs / nfs defaults 0 0" >> $SDCARD/etc/fstab
 	echo "tmpfs /tmp tmpfs defaults,nosuid 0 0" >> $SDCARD/etc/fstab


### PR DESCRIPTION
create simlink to boot in /boot on separate partition
to let all paths like /boot/file1.bin good in boot.ini
when /boot partition mounted as / on first boot stage
Then not need to use constructions like
ext4load mmc 0:1 0x44000000 /boot/dtb/${fdtfile} || ext4load mmc 0:1 0x44000000 dtb/${fdtfile}
just to handle "is boot a /boot directory on large root
or just / for a while"
