### PR TITLE
RK3328: Do not force fbdev Xorg driver on legacy

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -310,7 +310,7 @@ family_tweaks()
 family_tweaks_bsp()
 {
 
-	if [[ $BOOTCONFIG == *3328* ]]; then	
+	if [[ $BOOTCONFIG == *3328* ]] && [[ $BRANCH != legacy ]]; then	
 		mkdir -p "$destination"/etc/X11/xorg.conf.d
 		cat <<-EOF > "$destination"/etc/X11/xorg.conf.d/02-driver.conf
 		# set fbdev as default driver.


### PR DESCRIPTION
Currently, we are forcing fbdev Xorg driver in all RK3288 images, in order to avoid some Lima-related bug. But this bug does not affect legacy, only current and dev. On top of that, it breaks legacy desktop acceleration.
This commit simply corrects that.