### PR TITLE
helios64: Enable Advanced U-Boot recovery

### DIFF
--- a/patch/u-boot/u-boot-rockchip64-mainline/add-board-helios64.patch
+++ b/patch/u-boot/u-boot-rockchip64-mainline/add-board-helios64.patch
@@ -5,19 +5,19 @@ Subject: [PATCH] Patching something
 
 Signed-off-by: Aditya Prayoga <aditya@kobol.io>
 ---
- arch/arm/dts/Makefile                    |    1 +
- arch/arm/dts/rk3399-kobol-helios64-u-boot.dtsi |  140 +++
- arch/arm/dts/rk3399-kobol-helios64.dts         | 1152 ++++++++++++++++++++++
- arch/arm/mach-rockchip/rk3399/Kconfig    |   17 +
- board/kobol/helios64/Kconfig             |   24 +
- board/kobol/helios64/MAINTAINERS         |    6 +
- board/kobol/helios64/Makefile            |    5 +
- board/kobol/helios64/helios64.c          |  262 +++++
- board/kobol/helios64/sys_otp.c           |  248 +++++
- board/kobol/helios64/sys_otp.h           |   10 +
- configs/helios64-rk3399_defconfig        |  149 +++
- include/configs/helios64.h               |   47 +
- 12 files changed, 2061 insertions(+)
+ arch/arm/dts/Makefile                         |    1 +
+ arch/arm/dts/rk3399-kobol-helios64-u-boot.dtsi |  136 ++
+ arch/arm/dts/rk3399-kobol-helios64.dts        | 1146 +++++++++++++++++
+ arch/arm/mach-rockchip/rk3399/Kconfig         |   17 +
+ board/kobol/helios64/Kconfig                  |   24 +
+ board/kobol/helios64/MAINTAINERS              |    6 +
+ board/kobol/helios64/Makefile                 |    5 +
+ board/kobol/helios64/helios64.c               |  304 +++++
+ board/kobol/helios64/sys_otp.c                |  248 ++++
+ board/kobol/helios64/sys_otp.h                |   10 +
+ configs/helios64-rk3399_defconfig             |  145 +++
+ include/configs/helios64.h                    |   47 +
+ 12 files changed, 2089 insertions(+)
  create mode 100644 arch/arm/dts/rk3399-kobol-helios64-u-boot.dtsi
  create mode 100644 arch/arm/dts/rk3399-kobol-helios64.dts
  create mode 100644 board/kobol/helios64/Kconfig
@@ -46,7 +46,7 @@ new file mode 100644
 index 00000000..2988a209
 --- /dev/null
 +++ b/arch/arm/dts/rk3399-kobol-helios64-u-boot.dtsi
-@@ -0,0 +1,140 @@
+@@ -0,0 +1,136 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * Copyright (c) 2020 Aditya Prayoga (aditya@kobol.io)
@@ -163,10 +163,6 @@ index 00000000..2988a209
 +	};
 +};
 +
-+&power_hdd_a {
-+	startup-delay-us = <10000000>;
-+};
-+
 +&spi1 {
 +	spiflash: flash@0 {
 +		compatible = "jedec,spi-nor";
@@ -192,7 +188,7 @@ new file mode 100644
 index 00000000..9d067505
 --- /dev/null
 +++ b/arch/arm/dts/rk3399-kobol-helios64.dts
-@@ -0,0 +1,1150 @@
+@@ -0,0 +1,1146 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2020 Aditya Prayoga (aditya@kobol.io)
@@ -417,8 +413,6 @@ index 00000000..9d067505
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&hdd_a_power>;
 +		regulator-name = "power_hdd_a";
-+		regulator-always-on;
-+		regulator-boot-on;
 +	};
 +
 +	power_hdd_b: power-hdd-b {
@@ -428,8 +422,6 @@ index 00000000..9d067505
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&hdd_b_power>;
 +		regulator-name = "power_hdd_b";
-+		regulator-always-on;
-+		regulator-boot-on;
 +	};
 +
 +	usblan_power: usblan-power {
@@ -1436,7 +1428,7 @@ new file mode 100644
 index 00000000..c7a0efa4
 --- /dev/null
 +++ b/board/kobol/helios64/helios64.c
-@@ -0,0 +1,262 @@
+@@ -0,0 +1,304 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * (C) Copyright 2020 Aditya Prayoga (aditya@kobol.io)
@@ -1632,6 +1624,29 @@ index 00000000..c7a0efa4
 +}
 +#endif
 +
++#ifdef CONFIG_ROCKCHIP_ADVANCED_RECOVERY
++void rockchip_prepare_download_mode(void)
++{
++	struct gpio_desc *enable, *mux;
++
++	if (gpio_hog_lookup_name("USB_MUX_OE#", &enable)) {
++		debug("Fail to get USB_MUX_OE\n");
++		return;
++	}
++
++	if (gpio_hog_lookup_name("USB_MUX_HS", &mux)) {
++		debug("Fail to get USB_MUX_HS\n");
++		return;
++	}
++
++	dm_gpio_set_value(enable, 0);
++	mdelay(100);
++	dm_gpio_set_value(mux, 1);
++	mdelay(100);
++	dm_gpio_set_value(enable, 1);
++}
++#endif
++
 +#ifdef CONFIG_LAST_STAGE_INIT
 +static void auto_power_enable(void)
 +{
@@ -1653,9 +1668,28 @@ index 00000000..c7a0efa4
 +	dm_gpio_set_value(clock, 0);
 +}
 +
++static void sata_power_enable(void)
++{
++	struct udevice *rail_a, *rail_b;
++	int ret;
++
++	ret = regulator_get_by_platname("power_hdd_a", &rail_a);
++	if (!ret) {
++		ret = regulator_set_enable(rail_a, true);
++		if (!ret)
++			mdelay(10000);
++	}
++
++	ret = regulator_get_by_platname("power_hdd_b", &rail_b);
++	if (!ret)
++		ret = regulator_set_enable(rail_b, true);
++
++}
++
 +int last_stage_init(void)
 +{
 +	auto_power_enable();
++	sata_power_enable();
 +
 +#ifdef CONFIG_PCI
 +	scsi_scan(true);
@@ -1974,13 +2008,16 @@ new file mode 100644
 index 00000000..62210055
 --- /dev/null
 +++ b/configs/helios64-rk3399_defconfig
-@@ -0,0 +1,142 @@
+@@ -0,0 +1,145 @@
 +CONFIG_ARM=y
 +CONFIG_ARCH_ROCKCHIP=y
 +CONFIG_SYS_TEXT_BASE=0x00200000
 +CONFIG_SPL_GPIO_SUPPORT=y
 +CONFIG_ENV_OFFSET=0x3F8000
 +CONFIG_ROCKCHIP_RK3399=y
++CONFIG_ROCKCHIP_ADVANCED_RECOVERY=y
++CONFIG_ROCKCHIP_ADVANCED_RECOVERY_LED="helios64::status"
++# CONFIG_ROCKCHIP_ADVANCED_RECOVERY_ROCKUSB is not set
 +CONFIG_TARGET_HELIOS64=y
 +CONFIG_NR_DRAM_BANKS=1
 +CONFIG_DEBUG_UART_BASE=0xFF1A0000


### PR DESCRIPTION
* Enable ums and maskrom u-boot recovery button
* Configure USB MUX before starting download mode
* Blink system status led to notify user the download mode
* Move HDD power staggering to board function

Closes: [AR-466]
[AR-466]: https://armbian.atlassian.net/browse/AR-466
