### PR TITLE
Fixed htop cpufreq meter for non-root users

### DIFF
--- a/packages/extras-buildpkgs/htop/debian/patches/fix-cpufreq-meter-for-non-root.patch
+++ b/packages/extras-buildpkgs/htop/debian/patches/fix-cpufreq-meter-for-non-root.patch
@@ -1,0 +1,56 @@
+diff --git a/linux/Platform.c b/linux/Platform.c
+index cd95463..f9e644e 100644
+--- a/linux/Platform.c
++++ b/linux/Platform.c
+@@ -287,7 +287,7 @@ int Platform_getCpuTemp(Meter* this) {
+        }
+    } else {
+       // sleep_ms(30);
+-      // xSnprintf(szbuf, sizeof(szbuf), "/sys/devices/system/cpu/cpufreq/policy%d/cpuinfo_cur_freq", cpu);
++      // xSnprintf(szbuf, sizeof(szbuf), "/sys/devices/system/cpu/cpufreq/policy%d/scaling_cur_freq", cpu);
+       xSnprintf(szbuf, sizeof(szbuf), "%s", "/sys/class/thermal/thermal_zone0/temp");
+    }
+    FILE *fd = fopen(szbuf, "r");
+@@ -304,7 +304,6 @@ int Platform_getCpuTemp(Meter* this) {
+ 
+ int Platform_getCpuFreq(Meter* this, int cpu) {
+    int Freq = 0;
+-   FILE* fd;
+    char szbuf[256];
+    Settings* settings = this->pl->settings;
+    char *handler;
+@@ -318,18 +317,28 @@ int Platform_getCpuFreq(Meter* this, int cpu) {
+        } else {
+            xSnprintf(szbuf, sizeof(szbuf), "%s", handler);
+        }
++       ReadIntFromFile(szbuf, &Freq);
+    } else {
+-      // sleep_ms(30);
+-      xSnprintf(szbuf, sizeof(szbuf), "/sys/devices/system/cpu/cpufreq/policy%d/cpuinfo_cur_freq", cpu);
++       // sleep_ms(30);
++       xSnprintf(szbuf, sizeof(szbuf), "/sys/devices/system/cpu/cpufreq/policy%d/scaling_cur_freq", cpu);
++       if (ReadIntFromFile(szbuf, &Freq) < 0) {
++           xSnprintf(szbuf, sizeof(szbuf), "/sys/devices/system/cpu/cpufreq/policy%d/cpuinfo_cur_freq", cpu);
++           ReadIntFromFile(szbuf, &Freq);
++       }
+    }
+-   fd = fopen(szbuf, "r");
++   return Freq;
++}
++
++int ReadIntFromFile(char *file_name, int *out) {
++   FILE *fd;
++   fd = fopen(file_name, "r");
+    if (fd) {
+       int n;
+-      n = fscanf(fd, "%d", &Freq);
++      n = fscanf(fd, "%d", out);
+       fclose(fd);
+-      if (n <= 0) return 0;
++      return n;
+    }
+-   return Freq;
++   return 0;
+ }
+ 
+ int Platform_getCpuVcore(Meter* this) {

--- a/packages/extras-buildpkgs/htop/debian/patches/series
+++ b/packages/extras-buildpkgs/htop/debian/patches/series
@@ -3,5 +3,6 @@ fix-linux-process.patch
 avafinger-cpu-monitor.patch
 remove-fancy-flashing.patch
 fix-cpufreq-meter-on-biglittle.patch
+fix-cpufreq-meter-for-non-root.patch
 cpu-temperatute-from-hwmon.patch
 


### PR DESCRIPTION
Closes: [AR-482]

Switched reading current cpu frequency from:
`/sys/devices/system/cpu/cpufreq/policy%d/cpuinfo_cur_freq`
to:
`/sys/devices/system/cpu/cpufreq/policy%d/scaling_cur_freq`

Retained the former one as fallback.

[AR-482]: https://armbian.atlassian.net/browse/AR-482