### PR TITLE
ODroid-N2 enable RTC clock on dev branch

### DIFF
--- a/patch/kernel/meson64-dev/odroid-n2-rtc0.patch
+++ b/patch/kernel/meson64-dev/odroid-n2-rtc0.patch
@@ -1,0 +1,24 @@
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dts b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dts
+index 93ba39044eb3..e2f727ffb731 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dts
+@@ -24,6 +24,7 @@ aliases {
+ 		i2c1 = &i2c3;
+ 		serial0 = &uart_AO;
+ 		serial1 = &uart_A;
++		rtc1 = &vrtc;
+ 	};
+ 
+ 	dioo2133: audio-amplifier-0 {
+@@ -632,6 +633,11 @@ &i2c3 {
+ 
+ 	/* default 100k */
+ 	clock-frequency = <100000>;
++	
++	rtc@51 {
++		compatible = "nxp,pcf8563";
++		reg = <0x51>;
++	};
+ };
+ 
+ &ir {


### PR DESCRIPTION
Same as on "current".