### PR TITLE
Fix up bootsplash patches

### DIFF
--- a/patch/misc/0001-bootsplash.patch
+++ b/patch/misc/0001-bootsplash.patch
@@ -2,10 +2,10 @@ diff --git a/MAINTAINERS b/MAINTAINERS
 index a74227ad082e..b5633b56391e 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
-@@ -2705,6 +2705,14 @@ S:	Supported
+@@ -2277,6 +2277,14 @@ S:	Supported
  F:	drivers/net/bonding/
  F:	include/uapi/linux/if_bonding.h
- 
+
 +BOOTSPLASH
 +M:	Max Staudt <mstaudt@suse.de>
 +L:	linux-fbdev@vger.kernel.org
@@ -16,15 +16,15 @@ index a74227ad082e..b5633b56391e 100644
 +
  BPF (Safe dynamic programs and tools)
  M:	Alexei Starovoitov <ast@kernel.org>
- M:	Daniel Borkmann <daniel@iogearbox.net>
+ L:	netdev@vger.kernel.org
 diff --git a/drivers/video/console/Kconfig b/drivers/video/console/Kconfig
 index 7f1f1fbcef9e..f3ff976266fe 100644
 --- a/drivers/video/console/Kconfig
 +++ b/drivers/video/console/Kconfig
-@@ -151,6 +151,30 @@ config FRAMEBUFFER_CONSOLE_ROTATION
+@@ -133,6 +133,30 @@ config FRAMEBUFFER_CONSOLE_ROTATION
           such that other users of the framebuffer will remain normally
           oriented.
- 
+
 +config BOOTSPLASH
 +	bool "Bootup splash screen"
 +	depends on FRAMEBUFFER_CONSOLE
@@ -553,7 +553,7 @@ index 000000000000..8c22ff92ce24
 +#include <linux/vt_kern.h>
 +#include <linux/console.h>
 +#include <asm/types.h>
-+#include "fbcon.h"
++#include "../../console/fbcon.h"
 +
 +static void dummy_bmove(struct vc_data *vc, struct fb_info *info, int sy,
 +			int sx, int dy, int dx, int height, int width)
@@ -618,28 +618,28 @@ index 000000000000..8c22ff92ce24
 +MODULE_AUTHOR("Max Staudt <mstaudt@suse.de>");
 +MODULE_DESCRIPTION("Dummy Blitting Operation");
 +MODULE_LICENSE("GPL");
-diff --git a/drivers/video/fbdev/core/fbcon.c b/drivers/video/fbdev/core/fbcon.c
+diff --git a/drivers/video/console/fbcon.c b/drivers/video/console/fbcon.c
 index 04612f938bab..9a39a6fcfe98 100644
---- a/drivers/video/fbdev/core/fbcon.c
-+++ b/drivers/video/fbdev/core/fbcon.c
+--- a/drivers/video/console/fbcon.c
++++ b/drivers/video/console/fbcon.c
 @@ -80,6 +80,7 @@
  #include <asm/irq.h>
- 
+
  #include "fbcon.h"
 +#include <linux/bootsplash.h>
- 
+
  #ifdef FBCONDEBUG
  #  define DPRINTK(fmt, args...) printk(KERN_DEBUG "%s: " fmt, __func__ , ## args)
-@@ -542,6 +543,8 @@ static int do_fbcon_takeover(int show_logo)
+@@ -540,6 +540,8 @@ static int do_fbcon_takeover(int show_logo)
  	for (i = first_fb_vc; i <= last_fb_vc; i++)
  		con2fb_map[i] = info_idx;
- 
+
 +	bootsplash_init();
 +
  	err = do_take_over_console(&fb_con, first_fb_vc, last_fb_vc,
  				fbcon_is_default);
- 
-@@ -661,6 +664,9 @@ static void set_blitting_type(struct vc_data *vc, struct fb_info *info)
+
+@@ -659,6 +659,9 @@ static void set_blitting_type(struct vc_data *vc, struct fb_info *info)
  	else {
  		fbcon_set_rotation(info);
  		fbcon_set_bitops(ops);
@@ -648,8 +648,8 @@ index 04612f938bab..9a39a6fcfe98 100644
 +			fbcon_set_dummyops(ops);
  	}
  }
- 
-@@ -683,6 +689,19 @@ static void set_blitting_type(struct vc_data *vc, struct fb_info *info)
+
+@@ -659,6 +659,19 @@ static void set_blitting_type(struct vc_data *vc, struct fb_info *info)
  	ops->p = &fb_display[vc->vc_num];
  	fbcon_set_rotation(info);
  	fbcon_set_bitops(ops);
@@ -667,26 +667,26 @@ index 04612f938bab..9a39a6fcfe98 100644
 +	if (bootsplash_would_render_now())
 +		fbcon_set_dummyops(ops);
  }
- 
+
  static int fbcon_invalid_charcount(struct fb_info *info, unsigned charcount)
 @@ -2184,6 +2203,9 @@ static int fbcon_switch(struct vc_data *vc)
  	info = registered_fb[con2fb_map[vc->vc_num]];
  	ops = info->fbcon_par;
- 
+
 +	if (bootsplash_would_render_now())
 +		bootsplash_render_full(info);
 +
  	if (softback_top) {
  		if (softback_lines)
  			fbcon_set_origin(vc);
-diff --git a/drivers/video/fbdev/core/fbcon.h b/drivers/video/fbdev/core/fbcon.h
+diff --git a/drivers/video/console/fbcon.h b/drivers/video/console/fbcon.h
 index 18f3ac144237..45f94347fe5e 100644
---- a/drivers/video/fbdev/core/fbcon.h
-+++ b/drivers/video/fbdev/core/fbcon.h
+--- a/drivers/video/console/fbcon.h
++++ b/drivers/video/console/fbcon.h
 @@ -214,6 +214,11 @@ static inline int attr_col_ec(int shift, struct vc_data *vc,
  #define SCROLL_REDRAW	   0x004
  #define SCROLL_PAN_REDRAW  0x005
- 
+
 +#ifdef CONFIG_BOOTSPLASH
 +extern void fbcon_set_dummyops(struct fbcon_ops *ops);
 +#else /* CONFIG_BOOTSPLASH */

--- a/patch/misc/0002-bootsplash.patch
+++ b/patch/misc/0002-bootsplash.patch
@@ -1,20 +1,8 @@
-diff --git a/MAINTAINERS b/MAINTAINERS
-index b5633b56391e..5c237445761e 100644
---- a/MAINTAINERS
-+++ b/MAINTAINERS
-@@ -2712,6 +2712,7 @@ S:	Maintained
- F:	drivers/video/fbdev/core/bootsplash*.*
- F:	drivers/video/fbdev/core/dummycon.c
- F:	include/linux/bootsplash.h
-+F:	include/uapi/linux/bootsplash_file.h
- 
- BPF (Safe dynamic programs and tools)
- M:	Alexei Starovoitov <ast@kernel.org>
 diff --git a/drivers/video/fbdev/core/Makefile b/drivers/video/fbdev/core/Makefile
 index 66895321928e..6a8d1bab8a01 100644
 --- a/drivers/video/fbdev/core/Makefile
 +++ b/drivers/video/fbdev/core/Makefile
-@@ -31,4 +31,4 @@ obj-$(CONFIG_FB_SVGALIB)       += svgalib.o
+@@ -20,4 +20,4 @@ obj-$(CONFIG_FB_SVGALIB)       += svgalib.o
  obj-$(CONFIG_FB_DDC)           += fb_ddc.o
  
  obj-$(CONFIG_BOOTSPLASH)       += bootsplash.o bootsplash_render.o \

--- a/patch/misc/0006-bootsplash.patch
+++ b/patch/misc/0006-bootsplash.patch
@@ -2,22 +2,22 @@ diff --git a/drivers/tty/vt/vt.c b/drivers/tty/vt/vt.c
 index 2ebaba16f785..416735ab6dc1 100644
 --- a/drivers/tty/vt/vt.c
 +++ b/drivers/tty/vt/vt.c
-@@ -105,6 +105,7 @@
+@@ -102,6 +102,7 @@
+ #include <linux/uaccess.h>
+ #include <linux/kdb.h>
  #include <linux/ctype.h>
- #include <linux/bsearch.h>
- #include <linux/gcd.h>
 +#include <linux/bootsplash.h>
  
  #define MAX_NR_CON_DRIVER 16
  
-@@ -4235,6 +4236,7 @@ void do_unblank_screen(int leaving_gfx)
- 	}
- 
+@@ -3505,6 +3505,7 @@ void do_unblank_screen(int leaving_gfx)
+ 	saved_console_blanked = console_blanked;
+ 	vc->vc_mode = KD_TEXT;
  	console_blanked = 0;
 +	bootsplash_mark_dirty();
- 	if (vc->vc_sw->con_blank(vc, 0, leaving_gfx))
- 		/* Low-level driver cannot restore -> do it ourselves */
- 		update_screen(vc);
+ 	if (vc->vc_sw->con_debug_enter)
+ 		ret = vc->vc_sw->con_debug_enter(vc);
+ #ifdef CONFIG_KGDB_KDB
 diff --git a/drivers/video/fbdev/core/bootsplash.c b/drivers/video/fbdev/core/bootsplash.c
 index c8642142cfea..13fcaabbc2ca 100644
 --- a/drivers/video/fbdev/core/bootsplash.c

--- a/patch/misc/0009-bootsplash.patch
+++ b/patch/misc/0009-bootsplash.patch
@@ -1,8 +1,8 @@
-diff --git a/drivers/video/fbdev/core/fbcon.c b/drivers/video/fbdev/core/fbcon.c
+diff --git a/drivers/video/console/fbcon.c b/drivers/video/console/fbcon.c
 index 9a39a6fcfe98..8a9c67e1c5d8 100644
---- a/drivers/video/fbdev/core/fbcon.c
-+++ b/drivers/video/fbdev/core/fbcon.c
-@@ -1343,6 +1343,16 @@ static void fbcon_cursor(struct vc_data *vc, int mode)
+--- a/drivers/video/console/fbcon.c
++++ b/drivers/video/console/fbcon.c
+@@ -1333,6 +1333,16 @@ static void fbcon_cursor(struct vc_data *vc, int mode)
  	int y;
   	int c = scr_readw((u16 *) vc->vc_pos);
  


### PR DESCRIPTION
The patches do apply and build successfully as opposed to before. I still do not see any boot splash on my SPI display.