### PR TITLE
Enable multithreading for kernel packaging

### DIFF
--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -419,7 +419,7 @@ compile_kernel()
 	# produce deb packages: image, headers, firmware, dtb
 	echo -e "\n\t== deb packages: image, headers, firmware, dtb ==\n" >> "${DEST}"/debug/compilation.log
 	eval CCACHE_BASEDIR="$(pwd)" env PATH="${toolchain}:${PATH}" \
-		'make -j1 $kernel_packing \
+		'make $CTHREADS $kernel_packing \
 		KDEB_PKGVERSION=$REVISION \
 		BRANCH=$BRANCH \
 		LOCALVERSION="-${LINUXFAMILY}" \


### PR DESCRIPTION
Kernel packaging has been single threaded [since like forever](https://github.com/armbian/build/blob/5365760e0213683741486a1e4e24941fe51597cc/common.sh#L196).
There must definitely have been a reason for that 5 years ago but maybe it is obsolete now?

Currently both Debian and Ubuntu wikis suggest that the packaging could be done utilising multiple threads:

[Debian](https://wiki.debian.org/BuildADebianKernelPackage):
> Use make bindeb-pkg target to build the kernel. the -j`nproc` argument sets the build to use as many cpu's as you have.
> make -j`nproc` bindeb-pkg

[Ubuntu](https://wiki.ubuntu.com/KernelTeam/GitKernelBuild)
> Build the linux-image and linux-header .deb files using a thread per core + 1. This process takes a lot of time:
> make -j `getconf _NPROCESSORS_ONLN` deb-pkg LOCALVERSION=-custom

IMHO we could consider switching to multithreaded kernel packaging - definitely after the v20.11 is released.

As a sidenote:
With the ccache populated the build time (Helios64 / current / minimal image) went down from 9m20s to 8m0s using Ryzen 3700x. With larger images or unpopulated ccache this 1m20s will be less noticeable but it's still more than nothing.