### PR TITLE
Do not exit the armbian-hardware-optimisation in armbian-audio-config

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-audio-config
+++ b/packages/bsp/common/usr/lib/armbian/armbian-audio-config
@@ -162,5 +162,3 @@ done
 
 fi
 
-exit 0
-


### PR DESCRIPTION
Closes: [AR-494]
This fixes the issue with hardware optimisations being not run after: https://github.com/armbian/build/commit/a9005dc2c4dff8ac0872307f4a1fc24e31e4962f which leads to Helios64 instability with v20.08.13.


[AR-494]: https://armbian.atlassian.net/browse/AR-494