### PR TITLE
Prevent multiple update-initramfs runs while building image

### DIFF
--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -565,6 +565,9 @@ update_initramfs()
 	chroot $chroot_target /bin/bash -c "$update_initramfs_cmd" >> $DEST/debug/install.log 2>&1
 	display_alert "Updated initramfs." "for details see: $DEST/debug/install.log" "ext"
 
+	display_alert "Re-enabling" "initramfs-tools hook for kernel"
+	chroot "${SDCARD}" /bin/bash -c "chmod +x /etc/kernel/postinst.d/initramfs-tools" "${DEST}"/debug/install.log 2>&1
+
 	umount_chroot "$chroot_target/"
 	rm $chroot_target/usr/bin/$QEMU_BINARY
 

--- a/lib/distributions.sh
+++ b/lib/distributions.sh
@@ -214,6 +214,9 @@ install_common()
 	display_alert "Updating" "package lists"
 	chroot "${SDCARD}" /bin/bash -c "apt-get update" "${DEST}"/debug/install.log 2>&1
 
+	display_alert "Temporarily disabling" "initramfs-tools hook for kernel"
+	chroot "${SDCARD}" /bin/bash -c "chmod -x /etc/kernel/postinst.d/initramfs-tools" "${DEST}"/debug/install.log 2>&1
+
 	# install family packages
 	if [[ -n ${PACKAGE_LIST_FAMILY} ]]; then
 		chroot "${SDCARD}" /bin/bash -c "DEBIAN_FRONTEND=noninteractive  apt-get -yqq --no-install-recommends install $PACKAGE_LIST_FAMILY" >> "${DEST}"/debug/install.log


### PR DESCRIPTION
This is the follow-up to #2290 in my pursuit of faster builds ;-)

Currently during image build process `update-initramfs` is called (in qemu arm64 chroot) three times:

- postinst for kernel package
- trigger for board package
- explicit run at the end of build

Each of this runs takes approx. 1min with my hardware (Ryzen 3700x) but only a single run at the end of the build is actually needed.
This PR disables unnecessary `update-initramfs` runs and leaves the last - explicit one - by means of temporarily disabling the kernel postinst `initramfs-tools` hook.

This change shaves of 2m of build time with my hardware.
On top of #2290, with the ccache populated, the build time (Helios64 / current / minimal image) went down from 8m0s to 6m0s.

Tested with buster and focal.