### PR TITLE
[ rockchip ]add overlay to force RK3399 DW3 USB-C port to host mode

### DIFF
--- a/patch/kernel/rockchip64-dev/general-rockchip-overlays.patch
+++ b/patch/kernel/rockchip64-dev/general-rockchip-overlays.patch
@@ -21,6 +21,7 @@ index e69de29..576e190 100644
 +	rockchip-spi-jedec-nor.dtbo \
 +	rockchip-spi-spidev.dtbo \
 +	rockchip-uart4.dtbo \
++	rockchip-usb-c-host.dtbo \
 +	rockchip-w1-gpio.dtbo
 +
 +scr-$(CONFIG_ARCH_ROCKCHIP) += \
@@ -132,6 +133,10 @@ index e69de29..9512445 100644
 +
 +Notice: UART4 cannot be activated together with SPI1 - they share the sam pins.
 +Enabling this overlay disables SPI1.
++
++### usb-c-host
++
++Sets the DesignWare USB-C port (port 0) to host mode.
 +
 +### w1-gpio
 +
@@ -445,6 +450,25 @@ index 0000000..fe8fb14
 +		target = <&uart4>;
 +		__overlay__ {
 +			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-usb-c-host.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-usb-c-host.dts
+new file mode 100644
+index 0000000..abcd123
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-usb-c-host.dts
+@@ -0,0 +1,13 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "rockchip,rk3399";
++
++	fragment@0 {
++		target = <&usbdrd_dwc3_0>;
++		__overlay__ {
++			dr_mode = "host";
 +		};
 +	};
 +};

--- a/patch/kernel/rockchip64-dev/general-rockchip-overlays.patch
+++ b/patch/kernel/rockchip64-dev/general-rockchip-overlays.patch
@@ -21,7 +21,7 @@ index e69de29..576e190 100644
 +	rockchip-spi-jedec-nor.dtbo \
 +	rockchip-spi-spidev.dtbo \
 +	rockchip-uart4.dtbo \
-+	rockchip-usb-c-host.dtbo \
++	rockchip-dwc3-0-host.dtbo \
 +	rockchip-w1-gpio.dtbo
 +
 +scr-$(CONFIG_ARCH_ROCKCHIP) += \
@@ -134,9 +134,12 @@ index e69de29..9512445 100644
 +Notice: UART4 cannot be activated together with SPI1 - they share the sam pins.
 +Enabling this overlay disables SPI1.
 +
-+### usb-c-host
++### dwc3-0-host
 +
-+Sets the DesignWare USB-C port (port 0) to host mode.
++Forces port 0 of the DesignWare xHCI controller to host mode.
++
++This can be used on plaforms such as NanoPC-T4, where devices plugged into the
++USB-C port may not be detected otherwise.
 +
 +### w1-gpio
 +
@@ -453,11 +456,11 @@ index 0000000..fe8fb14
 +		};
 +	};
 +};
-diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-usb-c-host.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-usb-c-host.dts
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-dwc3-0-host.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-dwc3-0-host.dts
 new file mode 100644
 index 0000000..abcd123
 --- /dev/null
-+++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-usb-c-host.dts
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-dwc3-0-host.dts
 @@ -0,0 +1,13 @@
 +/dts-v1/;
 +/plugin/;


### PR DESCRIPTION
* Per https://forum.armbian.com/topic/13721-nanopc-t4-usb-type-c-port-doesnt-work-with-buster-current-5431/
  this is for the NanoPC-T4 as the default from the Device Tree is to set port 0 (USB-C port) to OTG mode,
  and the current kernel fusb302 driver is unable to perform autonegotiation to switch the port to host
  mode when required.
* As a result, and since most users will want to use this port in host mode, Armbian should provide a new
  overlay to do just that.