### PR TITLE
Fix race condition on armbian-hardware-optimization

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
+++ b/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
@@ -186,9 +186,15 @@ prepare_board() {
 			for i in $(awk -F':' '/Mali/{print $1}' </proc/interrupts | sed 's/\ //g'); do
 				echo 2 >/proc/irq/$i/smp_affinity
 			done
-			echo 2 >/proc/irq/$(awk -F":" "/ehci/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
-			echo 2 >/proc/irq/$(awk -F":" "/ohci/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
-			echo 4 >/proc/irq/$(awk -F":" "/xhci/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
+			for i in $(awk -F":" "/ehci/ {print \$1}" </proc/interrupts | sed 's/\ //g'); do
+				echo 2 >/proc/irq/$i/smp_affinity
+			done
+			for i in $(awk -F":" "/ohci/ {print \$1}" </proc/interrupts | sed 's/\ //g'); do
+				echo 2 >/proc/irq/$i/smp_affinity
+			done
+			for i in $(awk -F":" "/xhci/ {print \$1}" </proc/interrupts | sed 's/\ //g'); do
+				echo 4 >/proc/irq/$i/smp_affinity
+			done
 
 			# Wait (up to 5s) until eth0 brought up
 			for i in {1..5}; do

--- a/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
+++ b/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
@@ -211,6 +211,13 @@ prepare_board() {
 			for i in $(awk -F":" "/xhci/ {print \$1}" </proc/interrupts | sed 's/\ //g'); do
 				echo 4 >/proc/irq/$i/smp_affinity
 			done
+
+			# Wait (up to 5s) until eth0 brought up
+			for i in {1..5}; do
+				grep -q "eth0" /proc/interrupts && break
+				sleep 1
+			done
+
 			echo 8 >/proc/irq/$(awk -F":" "/eth0/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
 			echo 7 >/sys/class/net/eth0/queues/rx-0/rps_cpus
 			echo 32768 >/proc/sys/net/core/rps_sock_flow_entries

--- a/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
+++ b/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
@@ -189,6 +189,13 @@ prepare_board() {
 			echo 2 >/proc/irq/$(awk -F":" "/ehci/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
 			echo 2 >/proc/irq/$(awk -F":" "/ohci/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
 			echo 4 >/proc/irq/$(awk -F":" "/xhci/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
+
+			# Wait (up to 5s) until eth0 brought up
+			for i in {1..5}; do
+				grep -q "eth0" /proc/interrupts && break
+				sleep 1
+			done
+
 			echo 8 >/proc/irq/$(awk -F":" "/eth0/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
 			echo 7 >/sys/class/net/eth0/queues/rx-0/rps_cpus
 			echo 32768 >/proc/sys/net/core/rps_sock_flow_entries


### PR DESCRIPTION
Closes [AR-505]

Observed and applied to rockchip64 and rk3399 family.
eth0 only appear in /proc/interrupts after brought up by NetworkManager. The tweak executed before NetworkManager running.

Also applied #2121 fixes to rockchip64 family.

[AR-505]: https://armbian.atlassian.net/browse/AR-505