### PR TITLE
Helios64: Switch fusb302 driver to mainline and enable DP over TypeC

### DIFF
--- a/patch/kernel/rockchip64-current/add-board-helios64.patch
+++ b/patch/kernel/rockchip64-current/add-board-helios64.patch
@@ -27,7 +27,7 @@ new file mode 100644
 index 000000000..fae17f416
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts
-@@ -0,0 +1,1084 @@
+@@ -0,0 +1,1150 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2020 Aditya Prayoga (aditya@kobol.io)
@@ -188,6 +188,16 @@ index 000000000..fae17f416
 +		regulator-min-microvolt = <5000000>;
 +		regulator-max-microvolt = <5000000>;
 +		vin-supply = <&vcc5v0_perdev>;
++	};
++
++	vcc5v0_typec: vcc5v0-typec-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio1 RK_PA3 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&fusb0_vbus_en>;
++		regulator-name = "vcc5v0_typec";
++		vin-supply = <&vcc5v0_usb>;
 +	};
 +
 +	vcc5v0_perdev: vcc5v0-perdev {
@@ -718,15 +728,51 @@ index 000000000..fae17f416
 +	status = "okay";
 +
 +	fusb0: typec-portc@22 {
-+		compatible = "fairchild,fusb302";
++		compatible = "fcs,fusb302";
 +		reg = <0x22>;
-+		status = "okay";
++		interrupt-parent = <&gpio1>;
++		interrupts = <RK_PA2 IRQ_TYPE_LEVEL_LOW>;
 +		pinctrl-names = "default";
-+		pinctrl-0 = <&fusb0_int>, <&fusb0_vbus_en>;
-+		vbus-5v-gpios = <&gpio1 RK_PA3 GPIO_ACTIVE_HIGH>;
-+		int-n-gpios = <&gpio1 RK_PA2 GPIO_ACTIVE_LOW>;
-+		fusb302,role = "ROLE_MODE_DRP";
-+		fusb302,try_role = "ROLE_MODE_UFP";
++		pinctrl-0 = <&fusb0_int>;
++		vbus-supply = <&vcc5v0_typec>;
++
++		connector {
++			compatible = "usb-c-connector";
++			label = "USB-C";
++			power-role = "dual";
++			data-role = "dual";
++			try-power-role = "sink";
++			source-pdos = <PDO_FIXED(5000, 1200, PDO_FIXED_USB_COMM)>;
++			sink-pdos = <PDO_FIXED(5000, 500, PDO_FIXED_USB_COMM)>;
++			op-sink-microwatt = <5000000>;
++
++			extcon-cables = <1 2 5 6 9 10 12 44>;
++			typec-altmodes = <0xff01 1 0x001c0000 1>;
++
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				port@0 {
++					reg = <0>;
++					usb_con_hs: endpoint {
++						remote-endpoint = <&u2phy0_typec_hs>;
++					};
++				};
++				port@1 {
++					reg = <1>;
++					usb_con_ss: endpoint {
++						remote-endpoint = <&tcphy0_typec_ss>;
++					};
++				};
++				port@2 {
++					reg = <2>;
++					usb_con_sbu: endpoint {
++						remote-endpoint = <&tcphy0_typec_dp>;
++					};
++				};
++			};
++		};
 +	};
 +};
 +
@@ -988,6 +1034,22 @@ index 000000000..fae17f416
 +	status = "okay";
 +};
 +
++&tcphy0_dp {
++	port {
++		tcphy0_typec_dp: endpoint {
++			remote-endpoint = <&usb_con_sbu>;
++		};
++	};
++};
++
++&tcphy0_usb3 {
++	port {
++		tcphy0_typec_ss: endpoint {
++			remote-endpoint = <&usb_con_ss>;
++		};
++	};
++};
++
 +&tcphy1 {
 +	status = "okay";
 +};
@@ -1002,7 +1064,6 @@ index 000000000..fae17f416
 +
 +&u2phy0 {
 +	status = "okay";
-+	extcon = <&fusb0>;
 +
 +	u2phy0_otg: otg-port {
 +		status = "okay";
@@ -1011,6 +1072,12 @@ index 000000000..fae17f416
 +	u2phy0_host: host-port {
 +		phy-supply = <&vcc5v0_usb>;
 +		status = "okay";
++	};
++
++	port {
++		u2phy0_typec_hs: endpoint {
++			remote-endpoint = <&usb_con_hs>;
++		};
 +	};
 +};
 +
@@ -1041,7 +1108,6 @@ index 000000000..fae17f416
 +};
 +
 +&usbdrd3_0 {
-+	extcon = <&fusb0>;
 +	status = "okay";
 +};
 +

--- a/patch/kernel/rockchip64-dev/add-board-helios64.patch
+++ b/patch/kernel/rockchip64-dev/add-board-helios64.patch
@@ -27,7 +27,7 @@ new file mode 100644
 index 000000000..fae17f416
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts
-@@ -0,0 +1,1084 @@
+@@ -0,0 +1,1150 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2020 Aditya Prayoga (aditya@kobol.io)
@@ -188,6 +188,16 @@ index 000000000..fae17f416
 +		regulator-min-microvolt = <5000000>;
 +		regulator-max-microvolt = <5000000>;
 +		vin-supply = <&vcc5v0_perdev>;
++	};
++
++	vcc5v0_typec: vcc5v0-typec-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio1 RK_PA3 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&fusb0_vbus_en>;
++		regulator-name = "vcc5v0_typec";
++		vin-supply = <&vcc5v0_usb>;
 +	};
 +
 +	vcc5v0_perdev: vcc5v0-perdev {
@@ -718,15 +728,51 @@ index 000000000..fae17f416
 +	status = "okay";
 +
 +	fusb0: typec-portc@22 {
-+		compatible = "fairchild,fusb302";
++		compatible = "fcs,fusb302";
 +		reg = <0x22>;
-+		status = "okay";
++		interrupt-parent = <&gpio1>;
++		interrupts = <RK_PA2 IRQ_TYPE_LEVEL_LOW>;
 +		pinctrl-names = "default";
-+		pinctrl-0 = <&fusb0_int>, <&fusb0_vbus_en>;
-+		vbus-5v-gpios = <&gpio1 RK_PA3 GPIO_ACTIVE_HIGH>;
-+		int-n-gpios = <&gpio1 RK_PA2 GPIO_ACTIVE_LOW>;
-+		fusb302,role = "ROLE_MODE_DRP";
-+		fusb302,try_role = "ROLE_MODE_UFP";
++		pinctrl-0 = <&fusb0_int>;
++		vbus-supply = <&vcc5v0_typec>;
++
++		connector {
++			compatible = "usb-c-connector";
++			label = "USB-C";
++			power-role = "dual";
++			data-role = "dual";
++			try-power-role = "sink";
++			source-pdos = <PDO_FIXED(5000, 1200, PDO_FIXED_USB_COMM)>;
++			sink-pdos = <PDO_FIXED(5000, 500, PDO_FIXED_USB_COMM)>;
++			op-sink-microwatt = <5000000>;
++
++			extcon-cables = <1 2 5 6 9 10 12 44>;
++			typec-altmodes = <0xff01 1 0x001c0000 1>;
++
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				port@0 {
++					reg = <0>;
++					usb_con_hs: endpoint {
++						remote-endpoint = <&u2phy0_typec_hs>;
++					};
++				};
++				port@1 {
++					reg = <1>;
++					usb_con_ss: endpoint {
++						remote-endpoint = <&tcphy0_typec_ss>;
++					};
++				};
++				port@2 {
++					reg = <2>;
++					usb_con_sbu: endpoint {
++						remote-endpoint = <&tcphy0_typec_dp>;
++					};
++				};
++			};
++		};
 +	};
 +};
 +
@@ -988,6 +1034,22 @@ index 000000000..fae17f416
 +	status = "okay";
 +};
 +
++&tcphy0_dp {
++	port {
++		tcphy0_typec_dp: endpoint {
++			remote-endpoint = <&usb_con_sbu>;
++		};
++	};
++};
++
++&tcphy0_usb3 {
++	port {
++		tcphy0_typec_ss: endpoint {
++			remote-endpoint = <&usb_con_ss>;
++		};
++	};
++};
++
 +&tcphy1 {
 +	status = "okay";
 +};
@@ -1002,7 +1064,6 @@ index 000000000..fae17f416
 +
 +&u2phy0 {
 +	status = "okay";
-+	extcon = <&fusb0>;
 +
 +	u2phy0_otg: otg-port {
 +		status = "okay";
@@ -1011,6 +1072,12 @@ index 000000000..fae17f416
 +	u2phy0_host: host-port {
 +		phy-supply = <&vcc5v0_usb>;
 +		status = "okay";
++	};
++
++	port {
++		u2phy0_typec_hs: endpoint {
++			remote-endpoint = <&usb_con_hs>;
++		};
 +	};
 +};
 +
@@ -1041,7 +1108,6 @@ index 000000000..fae17f416
 +};
 +
 +&usbdrd3_0 {
-+	extcon = <&fusb0>;
 +	status = "okay";
 +};
 +


### PR DESCRIPTION
Closes [AR-504]

Switch fusb302 driver to the one with compatible string "fcs,fusb302".
This driver also support DisplayPort over USB Type-C with [this patch](https://github.com/armbian/build/blob/master/patch/kernel/rockchip64-current/0015-add-dp-alt-mode-to-PBP.patch) so enable it on Helios64

[AR-504]: https://armbian.atlassian.net/browse/AR-504