### PR TITLE
Workaround MTU setting issues for dwmac interfaces on rockchip64

### DIFF
--- a/patch/kernel/rockchip64-current/general-disable-mtu-validation.patch
+++ b/patch/kernel/rockchip64-current/general-disable-mtu-validation.patch
@@ -1,0 +1,37 @@
+This patch reverts: https://github.com/torvalds/linux/commit/eaf4fac478077d4ed57cbca2c044c4b58a96bd98
+
+It works around following issues:
+ - no way to change MTU (tx_fifo_size is reported as 0 for Rockchip's dwmac)
+ - no way to set MTU of 1500 (it is aligned to 1536)
+
+Signed-off-by: Piotr Szczepanik <piter75@gmail.com>
+
+diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
+index 122a06972..951d2281f 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
++++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
+@@ -3961,24 +3961,12 @@ static void stmmac_set_rx_mode(struct net_device *dev)
+ static int stmmac_change_mtu(struct net_device *dev, int new_mtu)
+ {
+ 	struct stmmac_priv *priv = netdev_priv(dev);
+-	int txfifosz = priv->plat->tx_fifo_size;
+-
+-	if (txfifosz == 0)
+-		txfifosz = priv->dma_cap.tx_fifo_size;
+-
+-	txfifosz /= priv->plat->tx_queues_to_use;
+ 
+ 	if (netif_running(dev)) {
+ 		netdev_err(priv->dev, "must be stopped to change its MTU\n");
+ 		return -EBUSY;
+ 	}
+ 
+-	new_mtu = STMMAC_ALIGN(new_mtu);
+-
+-	/* If condition true, FIFO is too small or MTU too large */
+-	if ((txfifosz < new_mtu) || (new_mtu > BUF_SIZE_16KiB))
+-		return -EINVAL;
+-
+ 	dev->mtu = new_mtu;
+ 
+ 	netdev_update_features(dev);


### PR DESCRIPTION
Closes: [AR-522]

This reverts: https://github.com/torvalds/linux/commit/eaf4fac478077d4ed57cbca2c044c4b58a96bd98

It works around following issues:
 - no way to change MTU (tx_fifo_size is reported as 0 for Rockchip's dwmac)
 - no way to set MTU of 1500 (it is aligned to 1536)

The issue was discovered by [one of the Helios64 owners](https://forum.armbian.com/topic/15431-helios64-support/?do=findComment&comment=111854).

[AR-522]: https://armbian.atlassian.net/browse/AR-522