### PR TITLE
Remove [ ] to enable sh compatibility in preinst kernel script

### DIFF
--- a/patch/misc/general-packaging-4.4.y-rk3399.patch
+++ b/patch/misc/general-packaging-4.4.y-rk3399.patch
@@ -141,7 +141,7 @@ index 6c3b038e..f4166fbe 100755
 +
 +for file in /dev/* ; do
 +	CURRENT_DEVICE=\$(printf "%d:%d" \$(stat --printf="0x%t 0x%T" \$file))
-+	if [[ "\$CURRENT_DEVICE" = "\$boot_device" ]]; then
++	if [ "\$CURRENT_DEVICE" = "\$boot_device" ]; then
 +		boot_partition=\$file
 +		break;
 +	fi


### PR DESCRIPTION
This fixes throwing out errors on kernel package upgrade.

Closes [AR-436]

[AR-436]: https://armbian.atlassian.net/browse/AR-436