### PR TITLE
Add tvbox Z28 pro to the mainline kernel as a link to rock64

### DIFF
--- a/config/targets.conf
+++ b/config/targets.conf
@@ -879,5 +879,6 @@ xt-q8l-v10			current			focal		cli			stable	yes
 # Z28 pro
 
 z28pro				legacy			buster		cli			stable	yes
-z28pro				legacy			bionic		desktop			stable	yes
+z28pro				legacy			focal		desktop			stable	yes
+z28pro				legacy			focal		cli			stable	yes
 z28pro				legacy			focal		desktop			stable	yes

--- a/patch/kernel/rockchip64-current/zzz-0006-Add-Z28-PRO-as-link-to-Rock64.patch
+++ b/patch/kernel/rockchip64-current/zzz-0006-Add-Z28-PRO-as-link-to-Rock64.patch
@@ -1,0 +1,34 @@
+From d1fb54e1292f2896fc7e485ee13ef2a8a7e87bb5 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor.pecovnik@gmail.com>
+Date: Sat, 14 Nov 2020 18:47:08 +0100
+Subject: [PATCH] Add Z28 PRO as link to Rock64
+
+Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
+---
+ arch/arm64/boot/dts/rockchip/rk3328-z28pro.dts | 1 +
+ 1 file changed, 1 insertion(+)
+ create mode 120000 arch/arm64/boot/dts/rockchip/rk3328-z28pro.dts
+
+diff --git a/arch/arm64/boot/dts/rockchip/Makefile b/arch/arm64/boot/dts/rockchip/Makefile
+index 92981d8..1dbe50c 100644
+--- a/arch/arm64/boot/dts/rockchip/Makefile
++++ b/arch/arm64/boot/dts/rockchip/Makefile
+@@ -17,6 +17,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-evb.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-nanopi-neo3-rev02.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-rock-pi-e.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-rock64.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-z28pro.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-roc-cc.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3368-evb-act8846.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3368-geekbox.dtb
+diff --git a/arch/arm64/boot/dts/rockchip/rk3328-z28pro.dts b/arch/arm64/boot/dts/rockchip/rk3328-z28pro.dts
+new file mode 120000
+index 000000000..69752a370
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3328-z28pro.dts
+@@ -0,0 +1 @@
++rk3328-rock64.dts
+\ No newline at end of file
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+


### PR DESCRIPTION
Working good enough.

- no wireless / BT support and probably not all variants work.

Closing [AR-529]

[AR-529]: https://armbian.atlassian.net/browse/AR-529