### PR TITLE
Fixed update-initramfs optimisation for ubuntu targets

### DIFF
--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -572,7 +572,7 @@ update_initramfs()
 	display_alert "Updated initramfs." "for details see: $DEST/debug/install.log" "info"
 
 	display_alert "Re-enabling" "initramfs-tools hook for kernel"
-	chroot "${SDCARD}" /bin/bash -c "chmod +x /etc/kernel/postinst.d/initramfs-tools" >> "${DEST}"/debug/install.log 2>&1
+	chroot $chroot_target /bin/bash -c "chmod -v +x /etc/kernel/postinst.d/initramfs-tools" >> "${DEST}"/debug/install.log 2>&1
 
 	umount_chroot "$chroot_target/"
 	rm $chroot_target/usr/bin/$QEMU_BINARY

--- a/lib/distributions.sh
+++ b/lib/distributions.sh
@@ -83,7 +83,7 @@ install_common()
 	fi
 
 	# configure MIN / MAX speed for cpufrequtils
-	cat <<-EOF > "${SDCARD}"/etc/default/cpufrequtils	
+	cat <<-EOF > "${SDCARD}"/etc/default/cpufrequtils
 	ENABLE=true
 	MIN_SPEED=$CPUMIN
 	MAX_SPEED=$CPUMAX
@@ -215,8 +215,8 @@ install_common()
 	display_alert "Updating" "package lists"
 	chroot "${SDCARD}" /bin/bash -c "apt-get update" >> "${DEST}"/debug/install.log 2>&1
 
-#	display_alert "Temporarily disabling" "initramfs-tools hook for kernel"
-#	chroot "${SDCARD}" /bin/bash -c "chmod -x /etc/kernel/postinst.d/initramfs-tools" >> "${DEST}"/debug/install.log 2>&1
+	display_alert "Temporarily disabling" "initramfs-tools hook for kernel"
+	chroot "${SDCARD}" /bin/bash -c "chmod -v -x /etc/kernel/postinst.d/initramfs-tools" >> "${DEST}"/debug/install.log 2>&1
 
 	# install family packages
 	if [[ -n ${PACKAGE_LIST_FAMILY} ]]; then


### PR DESCRIPTION
Closes: [AR-531]

It seems it was once again a copy-paste issue...
When re-enabling intramfs-tools postinst hook it needs to be done in $MOUNT (with $chroot_target) and not $SDCARD.
The verbosity (-v) is simply added to chmod for better traceability in the install.log.

Reproduced with focal and tested with both buster and focal.
The quickest way to verify that it works is to check if initramfs-tools hook in the output image has execute permission:

```
root@nanopim4v2:~# ll /etc/kernel/postinst.d/initramfs-tools
-rwxr-xr-x 1 root root 893 Feb 15  2020 /etc/kernel/postinst.d/initramfs-tools
```

[AR-531]: https://armbian.atlassian.net/browse/AR-531