### PR TITLE
change `bionic64`to `focal64`

### DIFF
--- a/config/templates/Vagrantfile
+++ b/config/templates/Vagrantfile
@@ -15,7 +15,7 @@ SCRIPT
 Vagrant.configure(2) do |config|
 
     # What box should we base this build on?
-    config.vm.box = "ubuntu/bionic64"
+    config.vm.box = "ubuntu/focal64"
     config.vm.box_version = ">= 20180719.0.0"
 
     # Default images are not big enough to build Armbian.


### PR DESCRIPTION
Not sure if this is necessary for making it work but since a focal64 Vagrant box is required it's more consistent.