### PR TITLE
Use current branches from Marvell Repo

### DIFF
--- a/lib/main.sh
+++ b/lib/main.sh
@@ -416,8 +416,8 @@ if [[ -n $ATFSOURCE ]]; then
 fi
 fetch_from_repo "https://github.com/linux-sunxi/sunxi-tools" "sunxi-tools" "branch:master"
 fetch_from_repo "https://github.com/armbian/rkbin" "rkbin-tools" "branch:master"
-fetch_from_repo "https://github.com/MarvellEmbeddedProcessors/A3700-utils-marvell" "marvell-tools" "branch:A3700_utils-armada-18.12"
-fetch_from_repo "https://github.com/MarvellEmbeddedProcessors/mv-ddr-marvell.git" "marvell-ddr" "branch:mv_ddr-armada-18.12"
+fetch_from_repo "https://github.com/MarvellEmbeddedProcessors/A3700-utils-marvell" "marvell-tools" "branch:A3700_utils-armada-18.12-fixed"
+fetch_from_repo "https://github.com/MarvellEmbeddedProcessors/mv-ddr-marvell.git" "marvell-ddr" "branch:mv-ddr-devel"
 fetch_from_repo "https://github.com/MarvellEmbeddedProcessors/binaries-marvell" "marvell-binaries" "branch:binaries-marvell-armada-18.12"
 fetch_from_repo "https://github.com/armbian/odroidc2-blobs" "odroidc2-blobs" "branch:master"
 fetch_from_repo "https://github.com/armbian/testings" "testing-reports" "branch:master"


### PR DESCRIPTION
Unfortunately, most Marvell repos have old state as default branch. The current branches for Utilities is _18.12-fixed_ and for mv-ddr _mv-ddr-devel_ . The U-Boot produced with these branches runs perfectly on my EspressoBin v7 1GB boards, without any patches.