### PR TITLE
Update meson-g12b.conf

### DIFF
--- a/config/sources/families/meson-g12b.conf
+++ b/config/sources/families/meson-g12b.conf
@@ -1,7 +1,7 @@
 source "${BASH_SOURCE%/*}/include/meson64_common.inc"
 ASOUND_STATE="asound.state.meson64"
 UBOOT_TARGET_MAP=';;sd_fuse/u-boot.bin'
-SERIALCON=ttyS0
+[[ $BRANCH == legacy ]] && SERIALCON=ttyS0
 UBOOT_USE_GCC='< 4.9'
 UBOOT_TOOLCHAIN2="arm-none-eabi-:< 5.0"
 UBOOT_COMPILER="aarch64-none-elf-"

--- a/config/sources/families/meson-g12b.conf
+++ b/config/sources/families/meson-g12b.conf
@@ -1,7 +1,7 @@
 source "${BASH_SOURCE%/*}/include/meson64_common.inc"
 ASOUND_STATE="asound.state.meson64"
 UBOOT_TARGET_MAP=';;sd_fuse/u-boot.bin'
-[[ $BRANCH == legacy ]] && SERIALCON=ttyS0
+[[ ${BRANCH} == legacy ]] && SERIALCON=ttyS0
 UBOOT_USE_GCC='< 4.9'
 UBOOT_TOOLCHAIN2="arm-none-eabi-:< 5.0"
 UBOOT_COMPILER="aarch64-none-elf-"

--- a/config/sources/families/meson-sm1.conf
+++ b/config/sources/families/meson-sm1.conf
@@ -4,7 +4,7 @@ CPUMIN=667000
 CPUMAX=2100000
 GOVERNOR=ondemand
 
-[[ $BRANCH == legacy ]] && SERIALCON=ttyS0
+[[ ${BRANCH} == legacy ]] && SERIALCON=ttyS0
 
 family_tweaks()
 {


### PR DESCRIPTION
The mainline kernel is filling up logs about the ttyS0, it should be ttyaml0 on mainline as is inherited from meson64_common.inc, only overridden in case of legacy kernel.

This matches the logic in the sm1 configuration.

