### PR TITLE
Several improvements to support meson-gxm

### DIFF
--- a/config/boards/kvim2.csc
+++ b/config/boards/kvim2.csc
@@ -1,0 +1,7 @@
+# Amlogic S912 octa core 3Gb RAM SoC eMMC
+BOARD_NAME="Khadas VIM2"
+BOARDFAMILY="meson-gxl"
+BOOTCONFIG="khadas-vim2_defconfig"
+KERNEL_TARGET="current,dev"
+FULL_DESKTOP="yes"
+BOOT_LOGO="desktop"

--- a/config/sources/families/include/meson64_common.inc
+++ b/config/sources/families/include/meson64_common.inc
@@ -152,7 +152,44 @@ uboot_g12_postprocess()
 			--ddrfw8 $1/aml_ddr.fw \
 			--level v3
 	fi
+
 }
+
+# this helper function includes postprocess for meson gxl and gxm.
+# $1 PATH for uboot blob repo
+uboot_gxl_postprocess_ng()
+{
+    mv u-boot.bin bl33.bin
+
+    $1/blx_fix.sh $1/bl30.bin \
+                       $1/zero_tmp \
+                       $1/bl30_zero.bin \
+                       $1/bl301.bin \
+                       $1/bl301_zero.bin \
+                       $1/bl30_new.bin bl30
+
+    python3 $1/acs_tool.py $1/bl2.bin $1/bl2_acs.bin $1/acs.bin 0
+
+    $1/blx_fix.sh $1/bl2_acs.bin \
+                       $1/zero_tmp \
+                       $1/bl2_zero.bin \
+                       $1/bl21.bin \
+                       $1/bl21_zero.bin \
+                       $1/bl2_new.bin bl2
+
+    $1/aml_encrypt_gxl --bl3enc --input $1/bl30_new.bin
+    $1/aml_encrypt_gxl --bl3enc --input $1/bl31.img
+    $1/aml_encrypt_gxl --bl3enc --input bl33.bin
+    $1/aml_encrypt_gxl --bl2sig --input $1/bl2_new.bin \
+			--output bl2.n.bin.sig
+
+    $1/aml_encrypt_gxl --bootmk --output u-boot.bin \
+			--bl2 $1/bl2.n.bin.sig \
+			--bl30 $1/bl30_new.bin.enc \
+			--bl31 $1/bl31.img.enc \
+			--bl33 bl33.bin.enc
+}
+
 
 write_uboot_platform()
 {

--- a/config/sources/families/meson-gxl.conf
+++ b/config/sources/families/meson-gxl.conf
@@ -20,5 +20,8 @@ uboot_custom_postprocess()
 	if [[ $BOARD == kvim1 ]]; then
 		uboot_gxl_postprocess $SRC/cache/sources/odroidc2-blobs/ vim1
 	fi
-	
+
+	if [[ $BOARD == kvim2 ]]; then
+		uboot_gxl_postprocess_ng $SRC/cache/sources/amlogic-boot-fip/khadas-vim2
+	fi
 }

--- a/patch/kernel/meson64-current/0101-fix-mesongxm-cpu-scheduling.patch
+++ b/patch/kernel/meson64-current/0101-fix-mesongxm-cpu-scheduling.patch
@@ -1,0 +1,64 @@
+[0] https://github.com/torvalds/linux/commit/6eeaf4d2452ec8b1ece58776812140734fc2e088
+
+Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
+---
+ arch/arm64/boot/dts/amlogic/meson-gxm.dtsi | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-gxm.dtsi b/arch/arm64/boot/dts/amlogic/meson-gxm.dtsi
+index fe4145112295c..411cc312fc62b 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-gxm.dtsi
++++ b/arch/arm64/boot/dts/amlogic/meson-gxm.dtsi
+@@ -42,11 +42,28 @@
+ 			};
+ 		};
+ 
++		cpu0: cpu@0 {
++			capacity-dmips-mhz = <1024>;
++		};
++
++		cpu1: cpu@1 {
++			capacity-dmips-mhz = <1024>;
++		};
++
++		cpu2: cpu@2 {
++			capacity-dmips-mhz = <1024>;
++		};
++
++		cpu3: cpu@3 {
++			capacity-dmips-mhz = <1024>;
++		};
++
+ 		cpu4: cpu@100 {
+ 			device_type = "cpu";
+ 			compatible = "arm,cortex-a53";
+ 			reg = <0x0 0x100>;
+ 			enable-method = "psci";
++			capacity-dmips-mhz = <1024>;
+ 			next-level-cache = <&l2>;
+ 			clocks = <&scpi_dvfs 1>;
+ 			#cooling-cells = <2>;
+@@ -57,6 +74,7 @@
+ 			compatible = "arm,cortex-a53";
+ 			reg = <0x0 0x101>;
+ 			enable-method = "psci";
++			capacity-dmips-mhz = <1024>;
+ 			next-level-cache = <&l2>;
+ 			clocks = <&scpi_dvfs 1>;
+ 			#cooling-cells = <2>;
+@@ -67,6 +85,7 @@
+ 			compatible = "arm,cortex-a53";
+ 			reg = <0x0 0x102>;
+ 			enable-method = "psci";
++			capacity-dmips-mhz = <1024>;
+ 			next-level-cache = <&l2>;
+ 			clocks = <&scpi_dvfs 1>;
+ 			#cooling-cells = <2>;
+@@ -77,6 +96,7 @@
+ 			compatible = "arm,cortex-a53";
+ 			reg = <0x0 0x103>;
+ 			enable-method = "psci";
++			capacity-dmips-mhz = <1024>;
+ 			next-level-cache = <&l2>;
+ 			clocks = <&scpi_dvfs 1>;
+ 			#cooling-cells = <2>;


### PR DESCRIPTION
This started as a test for adding Khadas VIM2 as a csc, but I developed a few items that can be useful for any meson-gxm board that we want to add (like Tartiflette), and even for current gxl boards:

- Added the function `uboot_gxl_postprocess_ng()` to `meson64_common.inc`. It processes the Amlogic boot blobs based on the source repo amlogic-boot-fip. It can be used directly for new meson-gxm boards, but also for our current gxl boards, therefore getting rid of the duplicate odroidc2-blobs repo.
- Added a patch that finally fixes the S912 CPU scheduling problems, making it perform much better ([reference](https://forum.khadas.com/t/s912-limited-to-1200-mhz-with-multithreaded-loads/2311/82?u=huantxo)).