### PR TITLE
Revert UHS SD card voltage to 3.3V before power off on rockchip64

### DIFF
--- a/patch/kernel/rockchip64-current/add-board-helios64.patch
+++ b/patch/kernel/rockchip64-current/add-board-helios64.patch
@@ -1008,7 +1008,7 @@ index 000000000..fae17f416
 +	cap-sd-highspeed;
 +	cd-gpios = <&gpio0 RK_PA7 GPIO_ACTIVE_LOW>; // TODO: verify what needs to be done to use implicit CD definition
 +	disable-wp;
-+	// sd-uhs-sdr104;
++	sd-uhs-sdr104;
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&sdmmc_clk &sdmmc_cmd &sdmmc_cd &sdmmc_bus4>;
 +	vmmc-supply = <&vcc3v0_sd>;

--- a/patch/kernel/rockchip64-current/board-roc-rk3399-pc-fix-reboot.patch
+++ b/patch/kernel/rockchip64-current/board-roc-rk3399-pc-fix-reboot.patch
@@ -1,5 +1,4 @@
 This fixes reboot issues coused by vcc_sdio being disabled on reboot.
-Additionaly there are kernel panics when rebooting with sd-uhs-sdr104.
 
 Signed-off-by: Piotr Szczepanik <piter75@gmail.com>
 
@@ -15,16 +14,6 @@ index 9f225e9c3..f060fc0c5 100644
  				regulator-boot-on;
  				regulator-min-microvolt = <1800000>;
  				regulator-max-microvolt = <3000000>;
-@@ -688,7 +688,8 @@
- 	max-frequency = <150000000>;
- 	pinctrl-names = "default";
- 	pinctrl-0 = <&sdmmc_clk &sdmmc_cmd &sdmmc_bus4>;
--	sd-uhs-sdr104;
-+	// the board does not boot after reset with sd-uhs-sdr104 enabled
-+	// sd-uhs-sdr104;
- 	vmmc-supply = <&vcc3v0_sd>;
- 	vqmmc-supply = <&vcc_sdio>;
- 	status = "okay";
 -- 
 2.17.1
 

--- a/patch/kernel/rockchip64-current/general-fix-mmc-signal-voltage-before-reboot.patch
+++ b/patch/kernel/rockchip64-current/general-fix-mmc-signal-voltage-before-reboot.patch
@@ -1,0 +1,43 @@
+From ae85f92289509b44f291d2a95b858a36f7444aaa Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sun, 17 Feb 2019 22:14:38 +0000
+Subject: [PATCH] mmc: core: set initial signal voltage on power off
+
+Some boards have SD card connectors where the power rail cannot be switched
+off by the driver. If the card has not been power cycled, it may still be
+using 1.8V signaling after a warm re-boot. Bootroms expecting 3.3V signaling
+will fail to boot from a UHS card that continue to use 1.8V signaling.
+
+Set initial signal voltage in mmc_power_off() to allow re-boot to function.
+
+This fixes re-boot with UHS cards on Asus Tinker Board (Rockchip RK3288),
+same issue have been seen on some Rockchip RK3399 boards.
+
+I am sending this as a RFC because I have no insights into SD/MMC subsystem,
+this change fix a re-boot issue on my boards and does not break emmc/sdio.
+Is this an acceptable workaround? Any advice is appreciated.
+
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+---
+ drivers/mmc/core/core.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/drivers/mmc/core/core.c b/drivers/mmc/core/core.c
+index 8ccae6452..3d0494bdb 100644
+--- a/drivers/mmc/core/core.c
++++ b/drivers/mmc/core/core.c
+@@ -1349,6 +1349,14 @@ void mmc_power_off(struct mmc_host *host)
+ 	if (host->ios.power_mode == MMC_POWER_OFF)
+ 		return;
+ 
++	mmc_set_initial_signal_voltage(host);
++
++	/*
++	 * This delay should be sufficient to allow the power supply
++	 * to reach the minimum voltage.
++	 */
++	mmc_delay(host->ios.power_delay_ms);
++
+ 	mmc_pwrseq_power_off(host);
+ 
+ 	host->ios.clock = 0;

--- a/patch/kernel/rockchip64-dev/add-board-helios64.patch
+++ b/patch/kernel/rockchip64-dev/add-board-helios64.patch
@@ -1008,7 +1008,7 @@ index 000000000..fae17f416
 +	cap-sd-highspeed;
 +	cd-gpios = <&gpio0 RK_PA7 GPIO_ACTIVE_LOW>; // TODO: verify what needs to be done to use implicit CD definition
 +	disable-wp;
-+	// sd-uhs-sdr104;
++	sd-uhs-sdr104;
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&sdmmc_clk &sdmmc_cmd &sdmmc_cd &sdmmc_bus4>;
 +	vmmc-supply = <&vcc3v0_sd>;

--- a/patch/kernel/rockchip64-dev/board-roc-rk3399-pc-fix-reboot.patch
+++ b/patch/kernel/rockchip64-dev/board-roc-rk3399-pc-fix-reboot.patch
@@ -15,16 +15,6 @@ index 9f225e9c3..f060fc0c5 100644
  				regulator-boot-on;
  				regulator-min-microvolt = <1800000>;
  				regulator-max-microvolt = <3000000>;
-@@ -688,7 +688,8 @@
- 	max-frequency = <150000000>;
- 	pinctrl-names = "default";
- 	pinctrl-0 = <&sdmmc_clk &sdmmc_cmd &sdmmc_bus4>;
--	sd-uhs-sdr104;
-+	// the board does not boot after reset with sd-uhs-sdr104 enabled
-+	// sd-uhs-sdr104;
- 	vmmc-supply = <&vcc3v0_sd>;
- 	vqmmc-supply = <&vcc_sdio>;
- 	status = "okay";
 -- 
 2.17.1
 

--- a/patch/kernel/rockchip64-dev/general-fix-mmc-signal-voltage-before-reboot.patch
+++ b/patch/kernel/rockchip64-dev/general-fix-mmc-signal-voltage-before-reboot.patch
@@ -1,0 +1,43 @@
+From ae85f92289509b44f291d2a95b858a36f7444aaa Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sun, 17 Feb 2019 22:14:38 +0000
+Subject: [PATCH] mmc: core: set initial signal voltage on power off
+
+Some boards have SD card connectors where the power rail cannot be switched
+off by the driver. If the card has not been power cycled, it may still be
+using 1.8V signaling after a warm re-boot. Bootroms expecting 3.3V signaling
+will fail to boot from a UHS card that continue to use 1.8V signaling.
+
+Set initial signal voltage in mmc_power_off() to allow re-boot to function.
+
+This fixes re-boot with UHS cards on Asus Tinker Board (Rockchip RK3288),
+same issue have been seen on some Rockchip RK3399 boards.
+
+I am sending this as a RFC because I have no insights into SD/MMC subsystem,
+this change fix a re-boot issue on my boards and does not break emmc/sdio.
+Is this an acceptable workaround? Any advice is appreciated.
+
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+---
+ drivers/mmc/core/core.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/drivers/mmc/core/core.c b/drivers/mmc/core/core.c
+index d42037f0f..019dc3555 100644
+--- a/drivers/mmc/core/core.c
++++ b/drivers/mmc/core/core.c
+@@ -1349,6 +1349,14 @@ void mmc_power_off(struct mmc_host *host)
+ 	if (host->ios.power_mode == MMC_POWER_OFF)
+ 		return;
+ 
++	mmc_set_initial_signal_voltage(host);
++
++	/*
++	 * This delay should be sufficient to allow the power supply
++	 * to reach the minimum voltage.
++	 */
++	mmc_delay(host->ios.power_delay_ms);
++
+ 	mmc_pwrseq_power_off(host);
+ 
+ 	host->ios.clock = 0;


### PR DESCRIPTION
Closes: [AR-552]

Added Kwiboo's patch to revert mmc signal voltage to 3.3V before power off.
The same patch is used in rockchip (32-bit) family already.

Re-enabled UHS SDR104 for `Helios64` and `roc-rk3399-pc` sdmmc controllers in current and dev.
Tested with both boards and they both reboot fine with SDR104 enabled.
I did not notice any issues after the change on both boards.

[AR-552]: https://armbian.atlassian.net/browse/AR-552