### PR TITLE
sunxi64: current/dev: add pine64-7inch-lcd overlay

### DIFF
--- a/patch/kernel/sunxi-current/drm-panel-fix-feiyang-panel.patch
+++ b/patch/kernel/sunxi-current/drm-panel-fix-feiyang-panel.patch
@@ -1,0 +1,39 @@
+From c1f367a69854abc4c359c98645ce47d550285344 Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <icenowy@aosc.io>
+Date: Sat, 28 Nov 2020 20:49:38 +0800
+Subject: [PATCH] drm/panel: feiyang-fy07024di26a30d: cleanup if panel
+ attaching failed
+
+Attaching the panel can fail, so cleanup work is necessary, otherwise
+a pointer to freed struct drm_panel* will remain in drm_panel code.
+
+Do the cleanup if panel attaching failed.
+
+Fixes: 69dc678abc2b ("drm/panel: Add Feiyang FY07024DI26A30-D MIPI-DSI LCD panel")
+Signed-off-by: Icenowy Zheng <icenowy@aosc.io>
+---
+ drivers/gpu/drm/panel/panel-feiyang-fy07024di26a30d.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/panel/panel-feiyang-fy07024di26a30d.c b/drivers/gpu/drm/panel/panel-feiyang-fy07024di26a30d.c
+index 581661b506f8..f9c1f7bc8218 100644
+--- a/drivers/gpu/drm/panel/panel-feiyang-fy07024di26a30d.c
++++ b/drivers/gpu/drm/panel/panel-feiyang-fy07024di26a30d.c
+@@ -227,7 +227,13 @@ static int feiyang_dsi_probe(struct mipi_dsi_device *dsi)
+ 	dsi->format = MIPI_DSI_FMT_RGB888;
+ 	dsi->lanes = 4;
+ 
+-	return mipi_dsi_attach(dsi);
++	ret = mipi_dsi_attach(dsi);
++	if (ret < 0) {
++		drm_panel_remove(&ctx->panel);
++		return ret;
++	}
++
++	return 0;
+ }
+ 
+ static int feiyang_dsi_remove(struct mipi_dsi_device *dsi)
+-- 
+2.28.0
+

--- a/patch/kernel/sunxi-current/sun50i-a64-pine64-lcd-overlays.patch
+++ b/patch/kernel/sunxi-current/sun50i-a64-pine64-lcd-overlays.patch
@@ -1,0 +1,124 @@
+diff -Naur orange-pi-5.9.old/arch/arm64/boot/dts/allwinner/overlay/Makefile orange-pi-5.9/arch/arm64/boot/dts/allwinner/overlay/Makefile
+--- orange-pi-5.9.old/arch/arm64/boot/dts/allwinner/overlay/Makefile	2020-11-30 00:11:27.929355656 +0800
++++ orange-pi-5.9/arch/arm64/boot/dts/allwinner/overlay/Makefile	2020-11-30 00:11:53.461207971 +0800
+@@ -2,6 +2,7 @@
+ dtbo-$(CONFIG_ARCH_SUNXI) += \
+ 	sun50i-a64-i2c0.dtbo \
+ 	sun50i-a64-i2c1.dtbo \
++	sun50i-a64-pine64-7inch-lcd.dtbo \
+ 	sun50i-a64-pps-gpio.dtbo \
+ 	sun50i-a64-spi-add-cs1.dtbo \
+ 	sun50i-a64-spi-jedec-nor.dtbo \
+diff -Naur orange-pi-5.9.old/arch/arm64/boot/dts/allwinner/overlay/README.sun50i-a64-overlays orange-pi-5.9/arch/arm64/boot/dts/allwinner/overlay/README.sun50i-a64-overlays
+--- orange-pi-5.9.old/arch/arm64/boot/dts/allwinner/overlay/README.sun50i-a64-overlays	2020-11-30 00:11:09.346195021 +0800
++++ orange-pi-5.9/arch/arm64/boot/dts/allwinner/overlay/README.sun50i-a64-overlays	2020-11-30 00:13:37.504591349 +0800
+@@ -20,6 +20,7 @@
+ 
+ - i2c0
+ - i2c1
++- pine64-7inch-lcd
+ - pps-gpio
+ - spi-add-cs1
+ - spi-jedec-nor
+@@ -44,6 +45,10 @@
+ 
+ I2C1 pins (SCL, SDA): PH2, PH3
+ 
++### pine64-7inch-lcd
++
++Activates the Pine64 7" LCD on pine64/pine64so boards
++
+ ### pps-gpio
+ 
+ Activates pulse-per-second GPIO client
+diff -Naur orange-pi-5.9.old/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-pine64-7inch-lcd.dts orange-pi-5.9/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-pine64-7inch-lcd.dts
+--- orange-pi-5.9.old/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-pine64-7inch-lcd.dts	1970-01-01 08:00:00.000000000 +0800
++++ orange-pi-5.9/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-pine64-7inch-lcd.dts	2020-11-30 00:07:22.417773606 +0800
+@@ -0,0 +1,87 @@
++/dts-v1/;
++/plugin/;
++
++#include <dt-bindings/interrupt-controller/irq.h>
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/pwm/pwm.h>
++
++/ {
++	compatible = "allwinner,sun50i-a64";
++
++	fragment@0 {
++		target = <&reg_ldo_io0>;
++
++		__overlay__ {
++			regulator-min-microvolt = <3300000>;
++			regulator-max-microvolt = <3300000>;
++			regulator-name = "vcc-ctp";
++			status = "okay";
++		};
++	};
++
++	fragment@1 {
++		target = <&i2c0>;
++
++		__overlay__ {
++			status = "okay";
++
++			gt911: touchscreen@5d {
++				compatible = "goodix,gt911";
++				reg = <0x5d>;
++		
++				interrupt-parent = <&pio>;
++				interrupts = <7 4 IRQ_TYPE_EDGE_RISING>; /* PH4 */
++				reset-gpios = <&pio 7 11 GPIO_ACTIVE_HIGH>; /* PH11 */
++				AVDD28-supply = <&reg_ldo_io0>;
++			};
++		};
++	};
++
++	fragment@2 {
++		target = <&r_pwm>;
++
++		__overlay__ {
++			status = "okay";
++		};
++	};
++
++	fragment@3 {
++		target-path = "/";
++
++		__overlay__ {
++			backlight: backlight {
++				compatible = "pwm-backlight";
++				pwms = <&r_pwm 0 50000 PWM_POLARITY_INVERTED>;
++				brightness-levels = <1 2 4 8 16 32 64 128 512>;
++				default-brightness-level = <8>;
++				enable-gpios = <&pio 7 10 GPIO_ACTIVE_HIGH>; /* PH10 */
++			};
++		};
++	};
++
++	fragment@4 {
++		target = <&dsi>;
++
++		__overlay__ {
++			vcc-dsi-supply = <&reg_dldo1>;
++			status = "okay";
++		
++			panel@0 {
++				compatible = "feiyang,fy07024di26a30d";
++				reg = <0>;
++				avdd-supply = <&reg_dc1sw>;
++				dvdd-supply = <&reg_dldo2>;
++				reset-gpios = <&pio 3 24 GPIO_ACTIVE_HIGH>; /* PD24 */
++				backlight = <&backlight>;
++			};
++		};
++	};
++
++	fragment@5 {
++		target = <&dphy>;
++
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};

--- a/patch/kernel/sunxi-current/sun6i-dsi-fix-burst-panel.patch
+++ b/patch/kernel/sunxi-current/sun6i-dsi-fix-burst-panel.patch
@@ -1,0 +1,141 @@
+From 227b7b8d1fad466fc8ef9ec16d35a935bac39325 Mon Sep 17 00:00:00 2001
+From: Ondrej Jirman <megous@megous.com>
+Date: Wed, 25 Nov 2020 20:28:40 +0100
+Subject: [PATCH 1/2] Revert "drm/sun4i: Fix mipi-dsi panel framerate being 2/3
+ of the expected value"
+
+This reverts commit ad763c88b662f9d5da50cc86db387f6ee01311f2.
+---
+ drivers/gpu/drm/sun4i/sun4i_tcon.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/sun4i/sun4i_tcon.c b/drivers/gpu/drm/sun4i/sun4i_tcon.c
+index 1c56b4fb9ac8..ab06f5e1fc95 100644
+--- a/drivers/gpu/drm/sun4i/sun4i_tcon.c
++++ b/drivers/gpu/drm/sun4i/sun4i_tcon.c
+@@ -398,8 +398,8 @@ static void sun4i_tcon0_mode_set_cpu(struct sun4i_tcon *tcon,
+ 	u32 block_space, start_delay;
+ 	u32 tcon_div;
+ 
+-	tcon->dclk_min_div = 6;
+-	tcon->dclk_max_div = 6;
++	tcon->dclk_min_div = SUN6I_DSI_TCON_DIV;
++	tcon->dclk_max_div = SUN6I_DSI_TCON_DIV;
+ 
+ 	sun4i_tcon0_mode_set_common(tcon, mode);
+ 
+-- 
+2.28.0
+
+From 57fc64d7504dba9eb323b490e762d17fc0d15ffb Mon Sep 17 00:00:00 2001
+From: Roman Beranek <roman.beranek@prusa3d.com>
+Date: Wed, 25 Nov 2020 13:07:35 +0100
+Subject: [PATCH 2/2] drm: sun4i: decouple TCON_DCLK_DIV value from
+ pll_mipi/dotclock ratio
+
+Observations showed that an actual refresh rate differs from the intended.
+Specifically, in case of 4-lane panels it was reduced by 1/3, and in case of
+2-lane panels by 2/3.
+
+BSP code apparently distinguishes between a `dsi_div` and a 'tcon inner div'.
+While this 'inner' divider is under DSI always 4, the `dsi_div` is defined
+as a number of bits per pixel over a number of DSI lanes. This value is then
+involved in setting the rate of PLL_MIPI.
+
+I couldn't really figure out how to fit this into the dotclock driver,
+so I opted for this hack where the requested rate is adjusted in such a way
+that the sun4i_dotclock driver can remain untouched.
+---
+ drivers/gpu/drm/sun4i/sun4i_tcon.c | 44 +++++++++++++++++-------------
+ 1 file changed, 25 insertions(+), 19 deletions(-)
+
+diff --git a/drivers/gpu/drm/sun4i/sun4i_tcon.c b/drivers/gpu/drm/sun4i/sun4i_tcon.c
+index ab06f5e1fc95..958734ab5007 100644
+--- a/drivers/gpu/drm/sun4i/sun4i_tcon.c
++++ b/drivers/gpu/drm/sun4i/sun4i_tcon.c
+@@ -322,18 +322,6 @@ static int sun4i_tcon_get_clk_delay(const struct drm_display_mode *mode,
+ 	return delay;
+ }
+ 
+-static void sun4i_tcon0_mode_set_common(struct sun4i_tcon *tcon,
+-					const struct drm_display_mode *mode)
+-{
+-	/* Configure the dot clock */
+-	clk_set_rate(tcon->dclk, mode->crtc_clock * 1000);
+-
+-	/* Set the resolution */
+-	regmap_write(tcon->regs, SUN4I_TCON0_BASIC0_REG,
+-		     SUN4I_TCON0_BASIC0_X(mode->crtc_hdisplay) |
+-		     SUN4I_TCON0_BASIC0_Y(mode->crtc_vdisplay));
+-}
+-
+ static void sun4i_tcon0_mode_set_dithering(struct sun4i_tcon *tcon,
+ 					   const struct drm_connector *connector)
+ {
+@@ -396,12 +384,18 @@ static void sun4i_tcon0_mode_set_cpu(struct sun4i_tcon *tcon,
+ 	u8 bpp = mipi_dsi_pixel_format_to_bpp(device->format);
+ 	u8 lanes = device->lanes;
+ 	u32 block_space, start_delay;
+-	u32 tcon_div;
+ 
+ 	tcon->dclk_min_div = SUN6I_DSI_TCON_DIV;
+ 	tcon->dclk_max_div = SUN6I_DSI_TCON_DIV;
+ 
+-	sun4i_tcon0_mode_set_common(tcon, mode);
++	/* Configure the dot clock */
++	clk_set_rate(tcon->dclk, mode->crtc_clock * 1000
++				 * bpp / (lanes * SUN6I_DSI_TCON_DIV));
++
++        /* Set the resolution */
++	regmap_write(tcon->regs, SUN4I_TCON0_BASIC0_REG,
++		     SUN4I_TCON0_BASIC0_X(mode->crtc_hdisplay) |
++		     SUN4I_TCON0_BASIC0_Y(mode->crtc_vdisplay));
+ 
+ 	/* Set dithering if needed */
+ 	sun4i_tcon0_mode_set_dithering(tcon, sun4i_tcon_get_connector(encoder));
+@@ -425,9 +419,7 @@ static void sun4i_tcon0_mode_set_cpu(struct sun4i_tcon *tcon,
+ 	 * The datasheet says that this should be set higher than 20 *
+ 	 * pixel cycle, but it's not clear what a pixel cycle is.
+ 	 */
+-	regmap_read(tcon->regs, SUN4I_TCON0_DCLK_REG, &tcon_div);
+-	tcon_div &= GENMASK(6, 0);
+-	block_space = mode->htotal * bpp / (tcon_div * lanes);
++	block_space = mode->htotal * bpp / (SUN6I_DSI_TCON_DIV * lanes);
+ 	block_space -= mode->hdisplay + 40;
+ 
+ 	regmap_write(tcon->regs, SUN4I_TCON0_CPU_TRI0_REG,
+@@ -469,7 +461,14 @@ static void sun4i_tcon0_mode_set_lvds(struct sun4i_tcon *tcon,
+ 
+ 	tcon->dclk_min_div = 7;
+ 	tcon->dclk_max_div = 7;
+-	sun4i_tcon0_mode_set_common(tcon, mode);
++
++	/* Configure the dot clock */
++	clk_set_rate(tcon->dclk, mode->crtc_clock * 1000);
++
++        /* Set the resolution */
++	regmap_write(tcon->regs, SUN4I_TCON0_BASIC0_REG,
++		     SUN4I_TCON0_BASIC0_X(mode->crtc_hdisplay) |
++		     SUN4I_TCON0_BASIC0_Y(mode->crtc_vdisplay));
+ 
+ 	/* Set dithering if needed */
+ 	sun4i_tcon0_mode_set_dithering(tcon, sun4i_tcon_get_connector(encoder));
+@@ -546,7 +545,14 @@ static void sun4i_tcon0_mode_set_rgb(struct sun4i_tcon *tcon,
+ 
+ 	tcon->dclk_min_div = tcon->quirks->dclk_min_div;
+ 	tcon->dclk_max_div = 127;
+-	sun4i_tcon0_mode_set_common(tcon, mode);
++
++	/* Configure the dot clock */
++	clk_set_rate(tcon->dclk, mode->crtc_clock * 1000);
++
++	/* Set the resolution */
++	regmap_write(tcon->regs, SUN4I_TCON0_BASIC0_REG,
++		     SUN4I_TCON0_BASIC0_X(mode->crtc_hdisplay) |
++		     SUN4I_TCON0_BASIC0_Y(mode->crtc_vdisplay));
+ 
+ 	/* Set dithering if needed */
+ 	sun4i_tcon0_mode_set_dithering(tcon, connector);
+-- 
+2.28.0
+

--- a/patch/kernel/sunxi-dev/drm-panel-fix-feiyang-panel.patch
+++ b/patch/kernel/sunxi-dev/drm-panel-fix-feiyang-panel.patch
@@ -1,0 +1,39 @@
+From c1f367a69854abc4c359c98645ce47d550285344 Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <icenowy@aosc.io>
+Date: Sat, 28 Nov 2020 20:49:38 +0800
+Subject: [PATCH] drm/panel: feiyang-fy07024di26a30d: cleanup if panel
+ attaching failed
+
+Attaching the panel can fail, so cleanup work is necessary, otherwise
+a pointer to freed struct drm_panel* will remain in drm_panel code.
+
+Do the cleanup if panel attaching failed.
+
+Fixes: 69dc678abc2b ("drm/panel: Add Feiyang FY07024DI26A30-D MIPI-DSI LCD panel")
+Signed-off-by: Icenowy Zheng <icenowy@aosc.io>
+---
+ drivers/gpu/drm/panel/panel-feiyang-fy07024di26a30d.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/panel/panel-feiyang-fy07024di26a30d.c b/drivers/gpu/drm/panel/panel-feiyang-fy07024di26a30d.c
+index 581661b506f8..f9c1f7bc8218 100644
+--- a/drivers/gpu/drm/panel/panel-feiyang-fy07024di26a30d.c
++++ b/drivers/gpu/drm/panel/panel-feiyang-fy07024di26a30d.c
+@@ -227,7 +227,13 @@ static int feiyang_dsi_probe(struct mipi_dsi_device *dsi)
+ 	dsi->format = MIPI_DSI_FMT_RGB888;
+ 	dsi->lanes = 4;
+ 
+-	return mipi_dsi_attach(dsi);
++	ret = mipi_dsi_attach(dsi);
++	if (ret < 0) {
++		drm_panel_remove(&ctx->panel);
++		return ret;
++	}
++
++	return 0;
+ }
+ 
+ static int feiyang_dsi_remove(struct mipi_dsi_device *dsi)
+-- 
+2.28.0
+

--- a/patch/kernel/sunxi-dev/sun50i-a64-pine64-lcd-overlays.patch
+++ b/patch/kernel/sunxi-dev/sun50i-a64-pine64-lcd-overlays.patch
@@ -1,0 +1,124 @@
+diff -Naur orange-pi-5.9.old/arch/arm64/boot/dts/allwinner/overlay/Makefile orange-pi-5.9/arch/arm64/boot/dts/allwinner/overlay/Makefile
+--- orange-pi-5.9.old/arch/arm64/boot/dts/allwinner/overlay/Makefile	2020-11-30 00:11:27.929355656 +0800
++++ orange-pi-5.9/arch/arm64/boot/dts/allwinner/overlay/Makefile	2020-11-30 00:11:53.461207971 +0800
+@@ -2,6 +2,7 @@
+ dtbo-$(CONFIG_ARCH_SUNXI) += \
+ 	sun50i-a64-i2c0.dtbo \
+ 	sun50i-a64-i2c1.dtbo \
++	sun50i-a64-pine64-7inch-lcd.dtbo \
+ 	sun50i-a64-pps-gpio.dtbo \
+ 	sun50i-a64-spi-add-cs1.dtbo \
+ 	sun50i-a64-spi-jedec-nor.dtbo \
+diff -Naur orange-pi-5.9.old/arch/arm64/boot/dts/allwinner/overlay/README.sun50i-a64-overlays orange-pi-5.9/arch/arm64/boot/dts/allwinner/overlay/README.sun50i-a64-overlays
+--- orange-pi-5.9.old/arch/arm64/boot/dts/allwinner/overlay/README.sun50i-a64-overlays	2020-11-30 00:11:09.346195021 +0800
++++ orange-pi-5.9/arch/arm64/boot/dts/allwinner/overlay/README.sun50i-a64-overlays	2020-11-30 00:13:37.504591349 +0800
+@@ -20,6 +20,7 @@
+ 
+ - i2c0
+ - i2c1
++- pine64-7inch-lcd
+ - pps-gpio
+ - spi-add-cs1
+ - spi-jedec-nor
+@@ -44,6 +45,10 @@
+ 
+ I2C1 pins (SCL, SDA): PH2, PH3
+ 
++### pine64-7inch-lcd
++
++Activates the Pine64 7" LCD on pine64/pine64so boards
++
+ ### pps-gpio
+ 
+ Activates pulse-per-second GPIO client
+diff -Naur orange-pi-5.9.old/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-pine64-7inch-lcd.dts orange-pi-5.9/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-pine64-7inch-lcd.dts
+--- orange-pi-5.9.old/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-pine64-7inch-lcd.dts	1970-01-01 08:00:00.000000000 +0800
++++ orange-pi-5.9/arch/arm64/boot/dts/allwinner/overlay/sun50i-a64-pine64-7inch-lcd.dts	2020-11-30 00:07:22.417773606 +0800
+@@ -0,0 +1,87 @@
++/dts-v1/;
++/plugin/;
++
++#include <dt-bindings/interrupt-controller/irq.h>
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/pwm/pwm.h>
++
++/ {
++	compatible = "allwinner,sun50i-a64";
++
++	fragment@0 {
++		target = <&reg_ldo_io0>;
++
++		__overlay__ {
++			regulator-min-microvolt = <3300000>;
++			regulator-max-microvolt = <3300000>;
++			regulator-name = "vcc-ctp";
++			status = "okay";
++		};
++	};
++
++	fragment@1 {
++		target = <&i2c0>;
++
++		__overlay__ {
++			status = "okay";
++
++			gt911: touchscreen@5d {
++				compatible = "goodix,gt911";
++				reg = <0x5d>;
++		
++				interrupt-parent = <&pio>;
++				interrupts = <7 4 IRQ_TYPE_EDGE_RISING>; /* PH4 */
++				reset-gpios = <&pio 7 11 GPIO_ACTIVE_HIGH>; /* PH11 */
++				AVDD28-supply = <&reg_ldo_io0>;
++			};
++		};
++	};
++
++	fragment@2 {
++		target = <&r_pwm>;
++
++		__overlay__ {
++			status = "okay";
++		};
++	};
++
++	fragment@3 {
++		target-path = "/";
++
++		__overlay__ {
++			backlight: backlight {
++				compatible = "pwm-backlight";
++				pwms = <&r_pwm 0 50000 PWM_POLARITY_INVERTED>;
++				brightness-levels = <1 2 4 8 16 32 64 128 512>;
++				default-brightness-level = <8>;
++				enable-gpios = <&pio 7 10 GPIO_ACTIVE_HIGH>; /* PH10 */
++			};
++		};
++	};
++
++	fragment@4 {
++		target = <&dsi>;
++
++		__overlay__ {
++			vcc-dsi-supply = <&reg_dldo1>;
++			status = "okay";
++		
++			panel@0 {
++				compatible = "feiyang,fy07024di26a30d";
++				reg = <0>;
++				avdd-supply = <&reg_dc1sw>;
++				dvdd-supply = <&reg_dldo2>;
++				reset-gpios = <&pio 3 24 GPIO_ACTIVE_HIGH>; /* PD24 */
++				backlight = <&backlight>;
++			};
++		};
++	};
++
++	fragment@5 {
++		target = <&dphy>;
++
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};


### PR DESCRIPTION
Add overlay for the 1024x600 7" LCD from Pine64 to use it on
pine64/pine64so boards.

Signed-off-by: Icenowy Zheng <icenowy@aosc.io>