### PR TITLE
Resolve network issue on Clusterboard

### DIFF
--- a/packages/blobs/sunxi/a64/pine64so.dts
+++ b/packages/blobs/sunxi/a64/pine64so.dts
@@ -2833,6 +2833,8 @@
 			pinctrl-0 = <0x9e>;
 			gmac_power2;
 			gmac_power3;
+			allwinner,tx-delay-ps = <500>;
+			allwinner,rx-delay-ps = <500>;
 		};
 
 		product {

--- a/packages/blobs/sunxi/a64/pine64so.dts
+++ b/packages/blobs/sunxi/a64/pine64so.dts
@@ -2824,7 +2824,7 @@
 			interrupt-names = "gmacirq";
 			clocks = <0x8f>;
 			clock-names = "gmac";
-			phy-mode = "rgmii";
+			phy-mode = "rgmii-txid";
 			tx-delay = <0x3>;
 			rx-delay = <0x0>;
 			gmac_power1 = "axp81x_dc1sw:0";
@@ -2833,8 +2833,6 @@
 			pinctrl-0 = <0x9e>;
 			gmac_power2;
 			gmac_power3;
-			allwinner,tx-delay-ps = <500>;
-			allwinner,rx-delay-ps = <500>;
 		};
 
 		product {


### PR DESCRIPTION
A long-known issue with Clusterboard is that SOpine does see network interface but no traffic is getting through. This solution has been described in many forum discussions and has proven to work:

https://forum.armbian.com/topic/9402-ethernet-not-working-on-sopine-module/

Please use the "Preview" tab above to view this message if you are seeing this in the new pull request text box.

Please make sure that:

 - pull request is opened to the `master` branch unless you are working on a specfic feature which is developed in a separate branch
 - any changes to kernel configuration files were made by Kconfig menu (build script option `KERNEL_CONFIGURE=yes`) and not by editing configuration files by hand,
 - patch file names don't contain spaces and have less than 40 characters (not counting the `.patch` extension),
 - changes are properly described - what was done exactly and why.

Thanks for contributing! Please remove the text above before opening a pull request.
