### PR TITLE
Use armbian mirrors for downloads

### DIFF
--- a/config/templates/Dockerfile
+++ b/config/templates/Dockerfile
@@ -45,6 +45,7 @@ RUN apt-get update \
        gcc-arm-linux-gnueabihf \
        git \
        imagemagick \
+       jq \
        kmod \
        lib32ncurses6 \
        lib32stdc++6 \

--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -283,6 +283,8 @@ if [[ $DOWNLOAD_MIRROR == china ]] ; then
 	UBUNTU_MIRROR='mirrors.tuna.tsinghua.edu.cn/ubuntu-ports/'
 fi
 
+ARMBIAN_MIRROR='https://redirect.armbian.com'
+
 # For user override
 if [[ -f $USERPATCHES_PATH/lib.config ]]; then
 	display_alert "Using user configuration override" "$USERPATCHES_PATH/lib.config" "info"

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1210,7 +1210,7 @@ download_and_verify()
 	# use local control file
 	if [[ -f "${SRC}"/config/torrents/${filename}.asc ]]; then
 		local torrent="${SRC}"/config/torrents/${filename}.torrent
-		ln -s "${SRC}/config/torrents/${filename}.asc" "${localdir}/${filename}.asc"
+		ln -sf "${SRC}/config/torrents/${filename}.asc" "${localdir}/${filename}.asc"
 	elif [[ ! $(wget -S --spider "${server}${remotedir}/${filename}.asc" 2>&1 >/dev/null | grep 'HTTP/1.1 200 OK') ]]; then
 		return
 	else

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -974,7 +974,7 @@ prepare_host()
 	nfs-kernel-server btrfs-progs ncurses-term p7zip-full kmod dosfstools libc6-dev-armhf-cross imagemagick \
 	curl patchutils liblz4-tool libpython2.7-dev linux-base swig aptly acl python3-dev python3-distutils \
 	locales ncurses-base pixz dialog systemd-container udev lib32stdc++6 libc6-i386 lib32ncurses5 lib32tinfo5 \
-	bison libbison-dev flex libfl-dev cryptsetup gpg gnupg1 cpio aria2 pigz dirmngr python3-distutils"
+	bison libbison-dev flex libfl-dev cryptsetup gpg gnupg1 cpio aria2 pigz dirmngr python3-distutils jq"
 
 	local codename=$(lsb_release -sc)
 
@@ -1088,17 +1088,18 @@ prepare_host()
 	fi
 	mkdir -p "${DEST}"/debs-beta/extra "${DEST}"/debs/extra "${DEST}"/{config,debug,patch} "${USERPATCHES_PATH}"/overlay "${SRC}"/cache/{sources,hash,hash-beta,toolchain,utility,rootfs} "${SRC}"/.tmp
 
+	display_alert "Armbian mirror" "${ARMBIAN_MIRROR}" "info"
 	display_alert "Checking for external GCC compilers" "" "info"
 	# download external Linaro compiler and missing special dependencies since they are needed for certain sources
 
 	local toolchains=(
-		"https://dl.armbian.com/_toolchain/gcc-linaro-aarch64-none-elf-4.8-2013.11_linux.tar.xz"
-		"https://dl.armbian.com/_toolchain/gcc-linaro-arm-none-eabi-4.8-2014.04_linux.tar.xz"
-		"https://dl.armbian.com/_toolchain/gcc-linaro-arm-linux-gnueabihf-4.8-2014.04_linux.tar.xz"
-		"https://dl.armbian.com/_toolchain/gcc-linaro-7.4.1-2019.02-x86_64_arm-linux-gnueabi.tar.xz"
-		"https://dl.armbian.com/_toolchain/gcc-linaro-7.4.1-2019.02-x86_64_aarch64-linux-gnu.tar.xz"
-		"https://dl.armbian.com/_toolchain/gcc-arm-9.2-2019.12-x86_64-arm-none-linux-gnueabihf.tar.xz"
-		"https://dl.armbian.com/_toolchain/gcc-arm-9.2-2019.12-x86_64-aarch64-none-linux-gnu.tar.xz"
+		"${ARMBIAN_MIRROR}/_toolchain/gcc-linaro-aarch64-none-elf-4.8-2013.11_linux.tar.xz"
+		"${ARMBIAN_MIRROR}/_toolchain/gcc-linaro-arm-none-eabi-4.8-2014.04_linux.tar.xz"
+		"${ARMBIAN_MIRROR}/_toolchain/gcc-linaro-arm-linux-gnueabihf-4.8-2014.04_linux.tar.xz"
+		"${ARMBIAN_MIRROR}/_toolchain/gcc-linaro-7.4.1-2019.02-x86_64_arm-linux-gnueabi.tar.xz"
+		"${ARMBIAN_MIRROR}/_toolchain/gcc-linaro-7.4.1-2019.02-x86_64_aarch64-linux-gnu.tar.xz"
+		"${ARMBIAN_MIRROR}/_toolchain/gcc-arm-9.2-2019.12-x86_64-arm-none-linux-gnueabihf.tar.xz"
+		"${ARMBIAN_MIRROR}/_toolchain/gcc-arm-9.2-2019.12-x86_64-aarch64-none-linux-gnu.tar.xz"
 		)
 
 	USE_TORRENT_STATUS=${USE_TORRENT}
@@ -1161,18 +1162,10 @@ function webseed ()
 {
 # list of mirrors that host our files
 unset text
-WEBSEED=(
-	"https://dl.armbian.com/"
-	"https://imola.armbian.com/dl/"
-	"https://mirrors.netix.net/armbian/dl/"
-	"https://mirrors.dotsrc.org/armbian-dl/"
-	"https://us.mirrors.fossho.st/armbian/dl/"
-	"https://uk.mirrors.fossho.st/armbian/dl/"
-	"https://armbian.systemonachip.net/dl/"
-	)
+WEBSEED=($(curl -s https://redirect.armbian.com/mirrors | jq '.[] |.[] | values' | grep https | awk '!a[$0]++'))
 	if [[ -z $DOWNLOAD_MIRROR ]]; then
 		WEBSEED=(
-                "https://dl.armbian.com/"
+                "${ARMBIAN_MIRROR}/"
                 )
 	fi
 	# aria2 simply split chunks based on sources count not depending on download speed
@@ -1206,7 +1199,7 @@ download_and_verify()
         if [[ $DOWNLOAD_MIRROR == china ]]; then
 		local server="https://mirrors.tuna.tsinghua.edu.cn/armbian-releases/"
 			else
-		local server="https://dl.armbian.com/"
+		local server="${ARMBIAN_MIRROR}/"
         fi
 
 	if [[ -f ${localdir}/${dirname}/.download-complete ]]; then

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1088,7 +1088,6 @@ prepare_host()
 	fi
 	mkdir -p "${DEST}"/debs-beta/extra "${DEST}"/debs/extra "${DEST}"/{config,debug,patch} "${USERPATCHES_PATH}"/overlay "${SRC}"/cache/{sources,hash,hash-beta,toolchain,utility,rootfs} "${SRC}"/.tmp
 
-	display_alert "Armbian mirror" "${ARMBIAN_MIRROR}" "info"
 	display_alert "Checking for external GCC compilers" "" "info"
 	# download external Linaro compiler and missing special dependencies since they are needed for certain sources
 
@@ -1160,9 +1159,9 @@ prepare_host()
 
 function webseed ()
 {
-# list of mirrors that host our files
-unset text
-WEBSEED=($(curl -s https://redirect.armbian.com/mirrors | jq '.[] |.[] | values' | grep https | awk '!a[$0]++'))
+	# list of mirrors that host our files
+	unset text
+	WEBSEED=($(curl -s https://redirect.armbian.com/mirrors | jq '.[] |.[] | values' | grep https | awk '!a[$0]++'))
 	if [[ -z $DOWNLOAD_MIRROR ]]; then
 		WEBSEED=(
                 "${ARMBIAN_MIRROR}/"
@@ -1249,7 +1248,7 @@ download_and_verify()
 	if [[ ! -f "${localdir}/${filename}.complete" ]]; then
 		if [[ $(wget -S --spider "${server}${remotedir}/${filename}" 2>&1 >/dev/null \
 			| grep 'HTTP/1.1 200 OK') ]]; then
-			display_alert "downloading using http(s) network" "$filename"
+			display_alert "downloading from $(echo $server | cut -d'/' -f3 | cut -d':' -f1) using http(s) network" "$filename"
 			aria2c --download-result=hide --rpc-save-upload-metadata=false --console-log-level=error \
 			--dht-file-path="${SRC}"/cache/.aria2/dht.dat --disable-ipv6=true --summary-interval=0 --auto-file-renaming=false --dir="${localdir}" "$(webseed "${remotedir}/${filename}")" -o "${filename}"
 			# mark complete


### PR DESCRIPTION
[AR-553]

tool chains etc now default to downloading via https://redirect.armbian.com

can be overriden in `userpatches/lib.config`

ex:
`ARMBIAN_MIRROR='https://redirect.armbian.com/region/NA'`

[AR-553]: https://armbian.atlassian.net/browse/AR-553