### PR TITLE
add gparted and mc for DE

### DIFF
--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -183,7 +183,7 @@ PACKAGE_LIST_DESKTOP="xserver-xorg xserver-xorg-video-fbdev gvfs-backends gvfs-f
 	x11-xserver-utils xfce4 lxtask xfce4-terminal thunar-volman gtk2-engines gtk2-engines-murrine gtk2-engines-pixbuf \
 	libgtk2.0-bin network-manager-gnome xfce4-notifyd gnome-keyring gcr libgck-1-0 p11-kit pasystray pavucontrol \
 	pulseaudio pavumeter bluez bluez-tools pulseaudio-module-bluetooth blueman libpam-gnome-keyring \
-	libgl1-mesa-dri policykit-1 profile-sync-daemon gnome-orca numix-gtk-theme synaptic apt-xapian-index lightdm lightdm-gtk-greeter"
+	libgl1-mesa-dri policykit-1 profile-sync-daemon gnome-orca numix-gtk-theme synaptic apt-xapian-index lightdm lightdm-gtk-greeter gparted mc"
 
 
 # Recommended desktop packages


### PR DESCRIPTION

For a system with a GUI, it is desirable to have a tool for managing the disk also via the GUI (gparted). The MC utility is small in size , but it greatly facilitates editing and visual management of configuration files.