### PR TITLE
Adding MOTD support for vnstat and ZFS and fix minor bugs

### DIFF
--- a/packages/bsp/common/etc/default/armbian-motd.dpkg-dist
+++ b/packages/bsp/common/etc/default/armbian-motd.dpkg-dist
@@ -6,6 +6,8 @@
 MOTD_DISABLE=""
 ONE_WIRE=""
 SHOW_IP_PATTERN="^bond.*|^[ewr].*|^br.*|^lt.*|^umts.*|^lan.*"
+PRIMARY_INTERFACE="$(ls -1 /sys/class/net/ | grep -v lo | sed -n -e 'H;${x;s/\n/+/g;s/^+//;p;}')"
+PRIMARY_DIRECTION="rx"
 CPU_TEMP_LIMIT=60
 HDD_TEMP_LIMIT=60
 AMB_TEMP_LIMIT=40

--- a/packages/bsp/common/etc/default/armbian-motd.dpkg-dist
+++ b/packages/bsp/common/etc/default/armbian-motd.dpkg-dist
@@ -1,6 +1,11 @@
 # add space-separated list of MOTD script names (without number) to exclude them from MOTD
 # Example:
 # MOTD_DISABLE="header tips updates"
+# ONE_WIRE="yes" show 1-wire temperature sensor if attached
 
 MOTD_DISABLE=""
-ONE_WIRE="" # yes = show 1-wire temperature sensor if attached 
+ONE_WIRE=""
+SHOW_IP_PATTERN="^bond.*|^[ewr].*|^br.*|^lt.*|^umts.*|^lan.*"
+CPU_TEMP_LIMIT=60
+HDD_TEMP_LIMIT=60
+AMB_TEMP_LIMIT=40

--- a/packages/bsp/common/etc/default/armbian-motd.dpkg-dist
+++ b/packages/bsp/common/etc/default/armbian-motd.dpkg-dist
@@ -8,6 +8,7 @@ ONE_WIRE=""
 SHOW_IP_PATTERN="^bond.*|^[ewr].*|^br.*|^lt.*|^umts.*|^lan.*"
 PRIMARY_INTERFACE="$(ls -1 /sys/class/net/ | grep -v lo | sed -n -e 'H;${x;s/\n/+/g;s/^+//;p;}')"
 PRIMARY_DIRECTION="rx"
+STORAGE=/dev/sda1
 CPU_TEMP_LIMIT=60
 HDD_TEMP_LIMIT=60
 AMB_TEMP_LIMIT=40

--- a/packages/bsp/common/etc/profile.d/armbian-check-first-login-reboot.sh
+++ b/packages/bsp/common/etc/profile.d/armbian-check-first-login-reboot.sh
@@ -8,7 +8,17 @@
 
 # only do this for interactive shells
 if [ "$-" != "${-#*i}" ]; then
+	OutstandingPackages="$(egrep -v "linux-base|linux-image" /var/run/reboot-required.pkgs 2>/dev/null)"
 	if [ -f "/var/run/.reboot_required" ]; then
 		printf "\n[\e[0;91m Kernel was updated, please reboot\x1B[0m ]\n\n"
+	elif [ "X${OutstandingPackages}" != "X" ]; then
+		# No kernel update involved, just regular packages like e.g. dbus require a reboot
+		Packages="$(egrep -v "linux-base|linux-image" /var/run/reboot-required.pkgs | sort | uniq | tr '\n' ',' | sed -e 's/,/, /g' -e 's/,\ $//')"
+		OlderThanOneDay=$(find /var/run/reboot-required -mtime +1)
+	        if [ "X${OlderThanOneDay}" = "X" ]; then
+			printf "\n[\e[0;92m some packages require a reboot (${Packages})\x1B[0m ]\n\n"
+	        else
+			printf "\n[\e[0;91m some packages require a reboot since more than 1 day (${Packages})\x1B[0m ]\n\n"
+	        fi
 	fi
 fi

--- a/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
+++ b/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
@@ -11,16 +11,9 @@
 # generate system information
 
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-
 THIS_SCRIPT="sysinfo"
-MOTD_DISABLE=""
-STORAGE=/dev/sda1
-SHOW_IP_PATTERN="^bond.*|^[ewr].*|^br.*|^lt.*|^umts.*|^lan.*"
 
-CPU_TEMP_LIMIT=60
-HDD_TEMP_LIMIT=60
-AMB_TEMP_LIMIT=40
-
+# load user defined overrides
 [[ -f /etc/default/armbian-motd ]] && . /etc/default/armbian-motd
 
 for f in $MOTD_DISABLE; do

--- a/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
+++ b/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
@@ -17,6 +17,7 @@ THIS_SCRIPT="sysinfo"
 
 MOTD_DISABLE=""
 PRIMARY_INTERFACE="eth0"
+PRIMARY_DIRECTION="rx"
 STORAGE=/dev/sda1
 SHOW_IP_PATTERN="^bond.*|^[ewr].*|^br.*|^lt.*|^umts.*|^lan.*"
 CPU_TEMP_LIMIT=60
@@ -231,9 +232,9 @@ line=0
 if [[ $(command -v vnstat) ]]; then
 	line=$((line+1))
 	traffic=$(vnstat -d 1 -i $PRIMARY_INTERFACE --oneline | cut -d";" -f4,5)
-	traffic_rx=$(echo $traffic | cut -d";" -f1,1)
-	traffic_tx=$(echo $traffic | cut -d";" -f2,2)
-	printf "Traffic ($PRIMARY_DIRECTION):  "
+	traffic_rx=$(echo $traffic | cut -d";" -f1,1 | sed -r 's/([0-9]+\.[0-9]{1})[0-9]*/\1/')
+	traffic_tx=$(echo $traffic | cut -d";" -f2,2 | sed -r 's/([0-9]+\.[0-9]{1})[0-9]*/\1/')
+	printf "${PRIMARY_DIRECTION^^} yesterday:  "
 	if [[ $PRIMARY_DIRECTION == tx ]]; then
 		printf "\x1B[92m%s\x1B[0m" "$traffic_tx"
 	else

--- a/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
+++ b/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
@@ -218,7 +218,9 @@ display "storage/" "$storage_usage" "90" "1" "%" " of $storage_total"
 display "storage temp" "$storage_temp" $HDD_TEMP_LIMIT "0" "°C" "" ; a=$?
 display "Battery" "$battery_percent" "20" "1" "%" "$status_battery_text"
 echo ""
+line=0
 if [[ $(command -v vnstat) ]]; then
+	line=$((line+1))
 	traffic=$(vnstat -d 1 -i $PRIMARY_INTERFACE --oneline | cut -d";" -f4,5)
 	traffic_rx=$(echo $traffic | cut -d";" -f1,1)
 	traffic_tx=$(echo $traffic | cut -d";" -f2,2)
@@ -237,10 +239,13 @@ if [[ $(command -v zpool) ]]; then
 	:
 	elif [[ -n $(echo $zpoolstatus | grep 'degraded\|OFFLINE') ]]; then
 		printf "ZFS pool:      "
-		echo -ne "\e[0;91mDegraded"
+		echo -ne "\e[0;91mDegraded\x1B[0m"
+		line=$((line+1))
 	else
 		printf "ZFS pool:      "
-		echo -ne "\e[0;92mOnline"
+		echo -ne "\e[0;92mOnline\x1B[0m"
+		line=$((line+1))
 	fi
 fi
+[[ $line -ne 0 ]] && echo ""
 echo ""

--- a/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
+++ b/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
@@ -13,7 +13,16 @@
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 THIS_SCRIPT="sysinfo"
 
-# load user defined overrides
+# don't change default values - they are lost on upgrades. Use /etc/default/armbian-motd for your values
+
+MOTD_DISABLE=""
+PRIMARY_INTERFACE="eth0"
+STORAGE=/dev/sda1
+SHOW_IP_PATTERN="^bond.*|^[ewr].*|^br.*|^lt.*|^umts.*|^lan.*"
+CPU_TEMP_LIMIT=60
+HDD_TEMP_LIMIT=60
+AMB_TEMP_LIMIT=40
+
 [[ -f /etc/default/armbian-motd ]] && . /etc/default/armbian-motd
 
 for f in $MOTD_DISABLE; do

--- a/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
+++ b/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
@@ -218,4 +218,29 @@ display "storage/" "$storage_usage" "90" "1" "%" " of $storage_total"
 display "storage temp" "$storage_temp" $HDD_TEMP_LIMIT "0" "°C" "" ; a=$?
 display "Battery" "$battery_percent" "20" "1" "%" "$status_battery_text"
 echo ""
+if [[ $(command -v vnstat) ]]; then
+	traffic=$(vnstat -d 1 -i $PRIMARY_INTERFACE --oneline | cut -d";" -f4,5)
+	traffic_rx=$(echo $traffic | cut -d";" -f1,1)
+	traffic_tx=$(echo $traffic | cut -d";" -f2,2)
+	printf "Traffic ($PRIMARY_DIRECTION):  "
+	if [[ $PRIMARY_DIRECTION == tx ]]; then
+		printf "\x1B[92m%s\x1B[0m" "$traffic_tx"
+	else
+		printf "\x1B[92m%s\x1B[0m" "$traffic_rx"
+	fi
+	printf "\t"
+fi
+
+if [[ $(command -v zpool) ]]; then
+	zpoolstatus="$(zpool status </dev/stdin 2>&1 )"
+	if [[ -n $(echo $zpoolstatus | grep 'not loaded') ]]; then
+	:
+	elif [[ -n $(echo $zpoolstatus | grep 'degraded\|OFFLINE') ]]; then
+		printf "ZFS pool:      "
+		echo -ne "\e[0;91mDegraded"
+	else
+		printf "ZFS pool:      "
+		echo -ne "\e[0;92mOnline"
+	fi
+fi
 echo ""

--- a/packages/bsp/common/usr/lib/armbian/armbian-apt-updates
+++ b/packages/bsp/common/usr/lib/armbian/armbian-apt-updates
@@ -30,6 +30,9 @@ fi
 # give up if packages are broken
 [[ $(dpkg -l | grep ^..r) ]] && exit 0
 
+# give up if there is a dependency problem
+[[ "$((apt-get upgrade -s -qq) 2>&1)" == *"Unmet dependencies"* ]] && exit 0
+
 myfile="/var/cache/apt/archives/updates.number"
 
 # update procedure

--- a/packages/bsp/common/usr/lib/armbian/armbian-apt-updates
+++ b/packages/bsp/common/usr/lib/armbian/armbian-apt-updates
@@ -28,7 +28,7 @@ else
 fi
 
 # give up if packages are broken
-[[ ! $(dpkg -l | grep ^..r) ]] && exit 0
+[[ $(dpkg -l | grep ^..r) ]] && exit 0
 
 myfile="/var/cache/apt/archives/updates.number"
 


### PR DESCRIPTION
    root@10.0.30.117's password: 
      ___      _           _     _   _   _ ____       
     / _ \  __| |_ __ ___ (_) __| | | \ | |___ \  _   
    | | | |/ _` | '__/ _ \| |/ _` | |  \| | __) || |_ 
    | |_| | (_| | | | (_) | | (_| | | |\  |/ __/_   _|
     \___/ \__,_|_|  \___/|_|\__,_| |_| \_|_____||_|  
                                                      
    Welcome to Armbian 21.02.0-trunk.5 Focal with Linux 5.9.11-meson64
    
    No end-user support: untested automated build
    
    System load:   2%           	Up time:       23:06		Local users:   2            	
    Memory usage:  16% of 3.55G  	Zram usage:    6% of 1.77G  	IP:            10.0.30.117
    CPU temp:      37°C           	Usage of /:    51% of 29G    	storage/:      84% of 29G    	
    Traffic (rx):  529.01 MiB	ZFS pool:      Online
    
    [ 3 security updates available, 3 updates total: apt upgrade ]
    Last check: 2020-12-01 18:55

    Last login: Tue Dec  1 18:51:10 2020 from 10.0.30.3
    
    [ Kernel was updated, please reboot ]

Closing [AR-556]

[AR-556]: https://armbian.atlassian.net/browse/AR-556