### PR TITLE
Compatibility issue for Debian Buster

### DIFF
--- a/config/sources/arm64.conf
+++ b/config/sources/arm64.conf
@@ -17,8 +17,10 @@ CAN_BUILD_STRETCH=yes
 [[ -z $BOOTDIR ]]		&& BOOTDIR=$MAINLINE_UBOOT_DIR
 [[ -z $BOOTBRANCH ]]		&& BOOTBRANCH='tag:v2020.04'
 
-[[ -z $KERNEL_COMPILER ]]	&& KERNEL_COMPILER="aarch64-none-linux-gnu-"
-[[ -z $KERNEL_USE_GCC ]]	&& KERNEL_USE_GCC='> 8.0'
+# > 9.2 https://armbian.atlassian.net/browse/AR-557
+# [[ -z $KERNEL_COMPILER ]]	&& KERNEL_COMPILER="aarch64-none-linux-gnu-"
+[[ -z $KERNEL_COMPILER ]]	&& KERNEL_COMPILER="aarch64-linux-gnu-"
+[[ -z $KERNEL_USE_GCC ]]	&& KERNEL_USE_GCC='< 9.2'
 [[ -z $KERNELDIR ]]		&& KERNELDIR=$MAINLINE_KERNEL_DIR
 [[ -z $KERNELSOURCE ]]		&& KERNELSOURCE=$MAINLINE_KERNEL_SOURCE
 [[ -z $KERNELBRANCH ]]		&& KERNELBRANCH='branch:linux-5.4.y'

--- a/config/sources/armhf.conf
+++ b/config/sources/armhf.conf
@@ -10,8 +10,10 @@ CAN_BUILD_STRETCH=yes
 [[ -z $BOOTDIR ]]		&& BOOTDIR=$MAINLINE_UBOOT_DIR
 [[ -z $BOOTBRANCH ]]		&& BOOTBRANCH='tag:v2020.04'
 
-[[ -z $KERNEL_COMPILER ]]	&& KERNEL_COMPILER="arm-none-linux-gnueabihf-"
-[[ -z $KERNEL_USE_GCC ]]	&& KERNEL_USE_GCC='> 8.0'
+# > 9.2 https://armbian.atlassian.net/browse/AR-557
+#[[ -z $KERNEL_COMPILER ]]	&& KERNEL_COMPILER="arm-none-linux-gnueabihf-"
+[[ -z $KERNEL_COMPILER ]]	&& KERNEL_COMPILER="arm-linux-gnueabihf-"
+[[ -z $KERNEL_USE_GCC ]]	&& KERNEL_USE_GCC='< 9.2'
 [[ -z $KERNELDIR ]]		&& KERNELDIR=$MAINLINE_KERNEL_DIR
 [[ -z $KERNELSOURCE ]]		&& KERNELSOURCE=$MAINLINE_KERNEL_SOURCE
 [[ -z $KERNELBRANCH ]]		&& KERNELBRANCH='branch:linux-5.4.y'

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1097,6 +1097,8 @@ prepare_host()
 		"${ARMBIAN_MIRROR}/_toolchain/gcc-linaro-arm-linux-gnueabihf-4.8-2014.04_linux.tar.xz"
 		"${ARMBIAN_MIRROR}/_toolchain/gcc-linaro-7.4.1-2019.02-x86_64_arm-linux-gnueabi.tar.xz"
 		"${ARMBIAN_MIRROR}/_toolchain/gcc-linaro-7.4.1-2019.02-x86_64_aarch64-linux-gnu.tar.xz"
+		"${ARMBIAN_MIRROR}/_toolchains/gcc-arm-8.3-2019.03-x86_64-arm-linux-gnueabihf.tar.xz"
+		"${ARMBIAN_MIRROR}/_toolchains/gcc-arm-8.3-2019.03-x86_64-aarch64-linux-gnu.tar.xz"
 		"${ARMBIAN_MIRROR}/_toolchain/gcc-arm-9.2-2019.12-x86_64-arm-none-linux-gnueabihf.tar.xz"
 		"${ARMBIAN_MIRROR}/_toolchain/gcc-arm-9.2-2019.12-x86_64-aarch64-none-linux-gnu.tar.xz"
 		)


### PR DESCRIPTION
If kernel is built with GCC 9.2 we can't compile modules with DKMS on Debian Buster. Reverting compiler to 8.3 until better solution emerges. No known side effects. Tested - working.

Closing https://github.com/armbian/build/issues/2245

[AR-557]

This is one way to solve the problem @jbergler

[AR-557]: https://armbian.atlassian.net/browse/AR-557