### PR TITLE
Switch ROCK Pi 4 to all blobs u-boot for Radxa's SPI compatibility

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -48,7 +48,16 @@ elif [[ $BOARD == pinebook-pro ]]; then
 	BOOT_SOC=rk3399
 	ATFPATCHDIR='atf-rk3399'
 
-elif [[ $BOARD == rockpi-4* || $BOARD == rockpro64 ]]; then
+elif [[ $BOARD == rockpi-4* ]]; then
+
+	BOOT_USE_BLOBS=yes
+	BOOT_SUPPORT_SPI=yes
+	BOOT_SOC=rk3399
+	DDR_BLOB='rk33/rk3399_ddr_933MHz_v1.24.bin'
+	MINILOADER_BLOB='rk33/rk3399_miniloader_v1.19.bin'
+	BL31_BLOB='rk33/rk3399_bl31_v1.30.elf'
+
+elif [[ $BOARD == rockpro64 ]]; then
 
 	BOOT_USE_TPL_SPL_BLOB=yes
 	BOOT_SUPPORT_SPI=yes
@@ -142,7 +151,7 @@ prepare_boot_configuration()
 
 	if [[ $BOOT_SUPPORT_SPI == yes ]]; then
 
-		UBOOT_TARGET_MAP+=" rkspi_loader.img"
+		UBOOT_TARGET_MAP="BL31=$RKBIN_DIR/$BL31_BLOB tpl/u-boot-tpl.bin spl/u-boot-spl.bin u-boot.itb ${UBOOT_TARGET_MAP} rkspi_loader.img"
 
 	fi
 }
@@ -165,14 +174,7 @@ legacy_uboot_locations()
 uboot_custom_postprocess()
 {
 	if [[ $BOOT_USE_MAINLINE_ATF == yes || $BOOT_USE_TPL_SPL_BLOB == yes ]]; then
-
-		if [[ $BOOT_SUPPORT_SPI == yes ]]; then
-			tools/mkimage -n rk3399 -T rkspi -d tpl/u-boot-tpl.bin:spl/u-boot-spl.bin rkspi_tpl_spl.img
-			dd if=/dev/zero of=rkspi_loader.img count=8128 status=none
-			dd if=rkspi_tpl_spl.img of=rkspi_loader.img conv=notrunc status=none
-			dd if=u-boot.itb of=rkspi_loader.img seek=768 conv=notrunc status=none
-		fi
-
+		:
 	elif [[ $BOOT_USE_BLOBS == yes ]]; then
 
 		local tempfile=$(mktemp)
@@ -206,6 +208,13 @@ uboot_custom_postprocess()
 		echo "Unsupported u-boot processing configuration!"
 		exit 1
 	fi
+
+	if [[ $BOOT_SUPPORT_SPI == yes ]]; then
+		tools/mkimage -n $BOOT_SOC -T rkspi -d tpl/u-boot-tpl.bin:spl/u-boot-spl.bin rkspi_tpl_spl.img
+		dd if=/dev/zero of=rkspi_loader.img count=8128 status=none
+		dd if=rkspi_tpl_spl.img of=rkspi_loader.img conv=notrunc status=none
+		dd if=u-boot.itb of=rkspi_loader.img seek=768 conv=notrunc status=none
+	fi
 }
 
 write_uboot_platform()
@@ -237,7 +246,7 @@ write_uboot_platform_mtd()
 	if [[ -f $1/rkspi_loader.img ]]; then
 
 		dd if=$1/rkspi_loader.img of=$2 conv=notrunc status=none >/dev/null 2>&1
-	
+
 	else
 
 		echo "SPI u-boot image not found!"
@@ -311,7 +320,7 @@ family_tweaks()
 family_tweaks_bsp()
 {
 
-	if [[ $BOOTCONFIG == *3328* ]] && [[ $BRANCH != legacy ]]; then	
+	if [[ $BOOTCONFIG == *3328* ]] && [[ $BRANCH != legacy ]]; then
 		mkdir -p "$destination"/etc/X11/xorg.conf.d
 		cat <<-EOF > "$destination"/etc/X11/xorg.conf.d/02-driver.conf
 		# set fbdev as default driver.
@@ -349,7 +358,7 @@ family_tweaks_bsp()
 		mkdir -p $destination/etc/udev/hwdb.d/
 		cp $SRC/packages/bsp/pinebook-pro/10-usb-kbd.hwdb $destination/etc/udev/hwdb.d/
 		## brightness and power management defaults
-		mkdir -p $destination/usr/local/share/xdg/xfce4/xfconf/xfce-perchannel-xml/		
+		mkdir -p $destination/usr/local/share/xdg/xfce4/xfconf/xfce-perchannel-xml/
 		cp $SRC/packages/bsp/pinebook-pro/xfce4-power-manager.xml $destination/usr/local/share/xdg/xfce4/xfconf/xfce-perchannel-xml/
 		## additional keyboard configs in lib/desktop.sh
 


### PR DESCRIPTION
Closes: [AR-561]

Current u-boot scenario used with ROCK Pi 4 is incompatible with Radxa's SPI bootloader.
While we provide our own SPI bootloader image it may be desirable for one to continue using Radxa's one, eg. it supports USB booting.

[AR-561]: https://armbian.atlassian.net/browse/AR-561