### PR TITLE
add x64 into library path

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -175,9 +175,9 @@ uboot_custom_postprocess()
 {
 	if [ "$(uname -m)" = "aarch64" ]; then
 		if [ "$(lsb_release -sc)" = "focal" ]; then
-			PKG_PREFIX="qemu-x86_64-static "
+			PKG_PREFIX="qemu-x86_64-static -L /usr/x86_64-linux-gnu "
 		else
-			PKG_PREFIX="qemu-x86_64 "
+			PKG_PREFIX="qemu-x86_64 -L /usr/x86_64-linux-gnu "
 		fi
 	else
 		PKG_PREFIX=""


### PR DESCRIPTION
Allow to use dynamic-linked x64 binaries

I run test 
`./compile.sh BOARD=rockpi-4a REPOSITORY_INSTALL="kernel,bsp,armbian-config,armbian-firmware"` on odroid-N2 with armbian 20.11 focal
It can form uboot with my propose and can't without.