### PR TITLE
nand-sata-install increase DEFAULT_BOOTSIZE to 200

### DIFF
--- a/packages/bsp/common/usr/sbin/nand-sata-install
+++ b/packages/bsp/common/usr/sbin/nand-sata-install
@@ -462,7 +462,7 @@ format_emmc()
 		fi
 
 		# default boot partition size, in MiB
-		DEFAULT_BOOTSIZE=96
+		DEFAULT_BOOTSIZE=200
 
 		# (convert to sectors for partitioning)
 		DEFAULT_BOOTSIZE_SECTORS=$(((${DEFAULT_BOOTSIZE} * 1024 * 1024) / 512))


### PR DESCRIPTION
As 96mb does not leave enough space to upgrade the kernel

