### PR TITLE
Fix: do not overwrite user's custom htoprc settings on each boot

### DIFF
--- a/packages/bsp/common/etc/NetworkManager/dispatcher.d/80-update-htop-and-offload-tx
+++ b/packages/bsp/common/etc/NetworkManager/dispatcher.d/80-update-htop-and-offload-tx
@@ -9,39 +9,42 @@ for homedir in $(awk -F'[:]' '{if ($3 >= 1000 && $3 != 65534 || $3 == 0) print $
 
 	unset FIELDS FIELD_PARA
 
-	# start with a clean copy
-	cp /etc/skel/.config/htop/htoprc "${homedir}"/.config/htop/htoprc
+	if [ ! -f "${homedir}"/.config/htop/htoprc ]; then
+		# start with a clean copy
+		mkdir "${homedir}"/.config/htop 2>/dev/null
+		cp /etc/skel/.config/htop/htoprc "${homedir}"/.config/htop/htoprc
 
-	for TYPE in ethernet wifi; do
+		for TYPE in ethernet wifi; do
 
-		i=0
-		for INTERFAC in $(LC_ALL=C nmcli device status | grep $TYPE | grep -w connected | awk '{ print $1 }' | grep -v lo | grep -v p2p | head -2); do
+			i=0
+			for INTERFAC in $(LC_ALL=C nmcli device status | grep $TYPE | grep -w connected | awk '{ print $1 }' | grep -v lo | grep -v p2p | head -2); do
 
-			[[ $TYPE == ethernet ]] && type="eth"; [[ $TYPE == wifi ]] && type="wlan"
+				[[ $TYPE == ethernet ]] && type="eth"; [[ $TYPE == wifi ]] && type="wlan"
 
-			# offload tx if conditions are met
-			[[ $TYPE == ethernet && $LINUXFAMILY == rockchip64 ]] && ethtool -K ${INTERFAC} tx off
+				# offload tx if conditions are met
+				[[ $TYPE == ethernet && $LINUXFAMILY == rockchip64 ]] && ethtool -K ${INTERFAC} tx off
 
-			FIELDS+="${type^}$i ${type^}${i}stat "
-			FIELD_PARA+="2 2 "
-			sed -i "s/^${type}${i}_alias=.*/${type}${i}_alias=$INTERFAC/" "${homedir}"/.config/htop/htoprc
+				FIELDS+="${type^}$i ${type^}${i}stat "
+				FIELD_PARA+="2 2 "
+				sed -i "s/^${type}${i}_alias=.*/${type}${i}_alias=$INTERFAC/" "${homedir}"/.config/htop/htoprc
 
-			((i=i+1))
+				((i=i+1))
+			done
 		done
-	done
 
-	FIELDS=$(echo $FIELDS | xargs)
-	FIELD_PARA=$(echo $FIELD_PARA | xargs)
+		FIELDS=$(echo $FIELDS | xargs)
+		FIELD_PARA=$(echo $FIELD_PARA | xargs)
 
-	echo "$FIELDS $FIELD_PARA"
+		echo "$FIELDS $FIELD_PARA"
 
-	sed -i "s/right_meters.*$/& $FIELDS/" "${homedir}"/.config/htop/htoprc
-	sed -i "s/right_meter_modes.*$/& $FIELD_PARA/" "${homedir}"/.config/htop/htoprc
+		sed -i "s/right_meters.*$/& $FIELDS/" "${homedir}"/.config/htop/htoprc
+		sed -i "s/right_meter_modes.*$/& $FIELD_PARA/" "${homedir}"/.config/htop/htoprc
 
-	# enable GPU where this works
-	if [[ $LINUXFAMILY == meson64 || $LINUXFAMILY == odroidxu4 ]]; then
-	        sed -i "s/left_meters.*$/& GpuTemp/" "${homedir}"/.config/htop/htoprc
-        	sed -i "s/left_meter_modes.*$/& 2/" "${homedir}"/.config/htop/htoprc
+		# enable GPU where this works
+		if [[ $LINUXFAMILY == meson64 || $LINUXFAMILY == odroidxu4 ]]; then
+			sed -i "s/left_meters.*$/& GpuTemp/" "${homedir}"/.config/htop/htoprc
+			sed -i "s/left_meter_modes.*$/& 2/" "${homedir}"/.config/htop/htoprc
+		fi
 	fi
 
 done


### PR DESCRIPTION
Recently this script was added to add some default settings for htop. But, if the user set their own settings (e.g. sort order, hide userland threads) that would get overwritten on next boot.

This commit only installs the skeleton htoprc if it doesn't already exist. Also fixes bug where htoprc would not be created if ~/.config/htop didn't already exist.