### PR TITLE
The directive After=graphical.target at wrong location

### DIFF
--- a/lib/distributions.sh
+++ b/lib/distributions.sh
@@ -130,11 +130,12 @@ install_common()
 	mkdir -p "${SDCARD}"/etc/systemd/system/getty@.service.d/
 	mkdir -p "${SDCARD}"/etc/systemd/system/serial-getty@.service.d/
 	cat <<-EOF > "${SDCARD}"/etc/systemd/system/serial-getty@.service.d/override.conf
+	[Unit]
+	After=graphical.target
 	[Service]
 	ExecStartPre=/bin/sh -c 'exec /bin/sleep 10'
 	ExecStart=
 	ExecStart=-/sbin/agetty --noissue --autologin root %I $TERM
-	After=graphical.target
 	Type=idle
 	EOF
 	cp "${SDCARD}"/etc/systemd/system/serial-getty@.service.d/override.conf "${SDCARD}"/etc/systemd/system/getty@.service.d/override.conf


### PR DESCRIPTION
It needs to be in the [Unit] section instead of the [Service]section.

[AR-570]

Closing https://github.com/armbian/build/issues/2434

[AR-570]: https://armbian.atlassian.net/browse/AR-570