### PR TITLE
Fix boot (and bluetooth) for NanoPi M4*, NanoPC T4 and Firefly RK3399 in legacy

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -345,6 +345,9 @@ family_tweaks_bsp()
 		install -m 755 $SRC/packages/bsp/rk3399/brcm_patchram_plus_rk3399 $destination/usr/bin
 		cp $SRC/packages/bsp/rk3399/rk3399-bluetooth.service $destination/lib/systemd/system/
 
+		if [[ $BOARD == nanop*4* || $BOARD == firefly* ]]; then
+			sed -i s%BCM4345C5%BCM4356A2%g $destination/lib/systemd/system/rk3399-bluetooth.service
+		fi
 	fi
 
 	if [[ $BOARD == pinebook-pro ]]; then

--- a/packages/bsp/rk3399/rk3399-bluetooth.service
+++ b/packages/bsp/rk3399/rk3399-bluetooth.service
@@ -3,7 +3,7 @@ Description=Bluetooth Rockpi
 After=bluetooth.target
 
 [Service]
-Type=forking
+Type=exec
 ExecStartPre=/usr/sbin/rfkill unblock all
 ExecStart=/usr/bin/brcm_patchram_plus_rk3399 -d --enable_hci --no2bytes --use_baudrate_for_download --tosleep 200000 --baudrate 1500000 --patchram /lib/firmware/brcm/BCM4345C5.hcd /dev/ttyS0
 TimeoutSec=0

--- a/packages/bsp/rk3399/rk3399-bluetooth.service
+++ b/packages/bsp/rk3399/rk3399-bluetooth.service
@@ -5,7 +5,7 @@ After=bluetooth.target
 [Service]
 Type=forking
 ExecStartPre=/usr/sbin/rfkill unblock all
-ExecStart=/usr/bin/brcm_patchram_plus_rk3399 -d --enable_hci --no2bytes --use_baudrate_for_downloade --tosleep 200000 --baudrate 1500000 --patchram /lib/firmware/brcm/BCM4345C5.hcd /dev/ttyS0
+ExecStart=/usr/bin/brcm_patchram_plus_rk3399 -d --enable_hci --no2bytes --use_baudrate_for_download --tosleep 200000 --baudrate 1500000 --patchram /lib/firmware/brcm/BCM4345C5.hcd /dev/ttyS0
 TimeoutSec=0
 RemainAfterExit=yes
 SysVStartPriority=99


### PR DESCRIPTION
Closes: [AR-584]

NanoPi M4*, NanoPC T4 and Firefly RK3399 need different bluetooth patchrom file.
Also corrected spelling mistake in `use_baudrate_for_download` option.

https://forum.armbian.com/topic/16525-unable-to-boot-buster-legacy-on-nanopi-m4v2

[AR-584]: https://armbian.atlassian.net/browse/AR-584