### PR TITLE
Removed the graphical.target dependency from getty services

### DIFF
--- a/lib/distributions.sh
+++ b/lib/distributions.sh
@@ -130,8 +130,6 @@ install_common()
 	mkdir -p "${SDCARD}"/etc/systemd/system/getty@.service.d/
 	mkdir -p "${SDCARD}"/etc/systemd/system/serial-getty@.service.d/
 	cat <<-EOF > "${SDCARD}"/etc/systemd/system/serial-getty@.service.d/override.conf
-	[Unit]
-	After=graphical.target
 	[Service]
 	ExecStartPre=/bin/sh -c 'exec /bin/sleep 10'
 	ExecStart=


### PR DESCRIPTION
Reverts the effects of #2436 which effectively disabled serial console because of the units cycle:
serial-getty@.service -> graphical.target -> multi-user.target -> basic.target -> getty.target -> serial-getty@.service