### PR TITLE
fix /etc/hosts for full qualified hostname

### DIFF
--- a/lib/distributions.sh
+++ b/lib/distributions.sh
@@ -203,7 +203,8 @@ install_common()
 
 	# set hostname in hosts file
 	cat <<-EOF > "${SDCARD}"/etc/hosts
-	127.0.0.1   localhost $HOST
+	127.0.0.1   localhost
+	127.0.1.1   $HOST
 	::1         localhost $HOST ip6-localhost ip6-loopback
 	fe00::0     ip6-localnet
 	ff00::0     ip6-mcastprefix


### PR DESCRIPTION
Fix /etc/hosts to use 127.0.**1**.1 instead of 127.0.**0**.1 for the hostname to support full qualified hostname resulution.

Prior to this change `hostname --fqdn` will resolve to `localhost`, instead of the hostname. This is also the case for pythons `socket.getfqdn()` which is used by `unattended-upgrade` for mail delivery. If you have more than 1 armbian host running is quite hard to get the origin of that mail if the mail subject states only 'result of localhost'

See also [Debian Reference Manual](https://www.debian.org/doc/manuals/debian-reference/ch05.en.html#_the_hostname_resolution) and [Debian Bug Report #719621](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=719621)