### PR TITLE
[ rockchip64-dev ] add opp clock latencies

### DIFF
--- a/patch/kernel/rockchip64-dev/rk3399-dtsi-add-opp-clock-latency.patch
+++ b/patch/kernel/rockchip64-dev/rk3399-dtsi-add-opp-clock-latency.patch
@@ -1,0 +1,83 @@
+From 973697eb8a8f1f4bab39b1ecee8721b8624cd2f1 Mon Sep 17 00:00:00 2001
+From: tonymac32 <tonymckahan@gmail.com>
+Date: Sat, 19 Dec 2020 23:46:41 -0500
+Subject: [PATCH] add clock latency
+
+Signed-off-by: tonymac32 <tonymckahan@gmail.com>
+---
+ arch/arm64/boot/dts/rockchip/rk3399-opp.dtsi | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-opp.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-opp.dtsi
+index b6d86f681..59fb06495 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-opp.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3399-opp.dtsi
+@@ -16,22 +16,27 @@ opp00 {
+ 		opp01 {
+ 			opp-hz = /bits/ 64 <600000000>;
+ 			opp-microvolt = <825000>;
++			clock-latency-ns = <40000>;
+ 		};
+ 		opp02 {
+ 			opp-hz = /bits/ 64 <816000000>;
+ 			opp-microvolt = <850000>;
++			clock-latency-ns = <40000>;
+ 		};
+ 		opp03 {
+ 			opp-hz = /bits/ 64 <1008000000>;
+ 			opp-microvolt = <925000>;
++			clock-latency-ns = <40000>;
+ 		};
+ 		opp04 {
+ 			opp-hz = /bits/ 64 <1200000000>;
+ 			opp-microvolt = <1000000>;
++			clock-latency-ns = <40000>;
+ 		};
+ 		opp05 {
+ 			opp-hz = /bits/ 64 <1416000000>;
+ 			opp-microvolt = <1125000>;
++			clock-latency-ns = <40000>;
+ 		};
+ 	};
+ 
+@@ -47,30 +52,37 @@ opp00 {
+ 		opp01 {
+ 			opp-hz = /bits/ 64 <600000000>;
+ 			opp-microvolt = <825000>;
++			clock-latency-ns = <40000>;
+ 		};
+ 		opp02 {
+ 			opp-hz = /bits/ 64 <816000000>;
+ 			opp-microvolt = <825000>;
++			clock-latency-ns = <40000>;
+ 		};
+ 		opp03 {
+ 			opp-hz = /bits/ 64 <1008000000>;
+ 			opp-microvolt = <875000>;
++			clock-latency-ns = <40000>;
+ 		};
+ 		opp04 {
+ 			opp-hz = /bits/ 64 <1200000000>;
+ 			opp-microvolt = <950000>;
++			clock-latency-ns = <40000>;
+ 		};
+ 		opp05 {
+ 			opp-hz = /bits/ 64 <1416000000>;
+ 			opp-microvolt = <1025000>;
++			clock-latency-ns = <40000>;
+ 		};
+ 		opp06 {
+ 			opp-hz = /bits/ 64 <1608000000>;
+ 			opp-microvolt = <1100000>;
++			clock-latency-ns = <40000>;
+ 		};
+ 		opp07 {
+ 			opp-hz = /bits/ 64 <1800000000>;
+ 			opp-microvolt = <1200000>;
++			clock-latency-ns = <40000>;
+ 		};
+ 	};
+ 
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+


### PR DESCRIPTION
Vendor kernel has latency per opp for big and little cluster.  Mainline does not for
RK3399, however does for RK3328.  Given the phantom lockup issues observed randomly
by users, I am adding them in the hope it helps reduce this occurrence.

