### PR TITLE
Set image compression levels to maximum

### DIFF
--- a/lib/build-all-ng.sh
+++ b/lib/build-all-ng.sh
@@ -92,7 +92,7 @@ pack_upload ()
 
 	if [[ $COMPRESS_OUTPUTIMAGE == *xz* ]]; then
 		display_alert "Compressing" "$DEST/images/${version}.img.xz" "info"
-		pixz -3 < "$DESTIMG/${version}.img" > "${DESTIMG}/${version}.img.xz"
+		pixz -9 < "$DESTIMG/${version}.img" > "${DESTIMG}/${version}.img.xz"
 		rm "${DESTIMG}/${version}.img"
 		compression_type=".xz"
 	fi

--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -665,7 +665,7 @@ create_image()
 
 		if [[ $COMPRESS_OUTPUTIMAGE == *xz* ]]; then
 			display_alert "Compressing" "$DEST/images/${version}.img.xz" "info"
-			pixz -3 < $DESTIMG/${version}.img > $DEST/images/${version}.img.xz
+			pixz -9 < $DESTIMG/${version}.img > $DEST/images/${version}.img.xz
 			compression_type=".xz"
 		fi
 

--- a/lib/image-helpers.sh
+++ b/lib/image-helpers.sh
@@ -144,7 +144,7 @@ install_deb_chroot()
 	display_alert "Installing${desc}" "${name/\/root\//}"
 	[[ $NO_APT_CACHER != yes ]] && local apt_extra="-o Acquire::http::Proxy=\"http://${APT_PROXY_ADDR:-localhost:3142}\" -o Acquire::http::Proxy::localhost=\"DIRECT\""
 	# when building in bulk from remote, lets make sure we have up2date index
-	[[ $BUILD_ALL == yes ${variant} == remote ]] && chroot "${SDCARD}" /bin/bash -c "DEBIAN_FRONTEND=noninteractive apt-get $apt_extra -yqq update"
+	[[ $BUILD_ALL == yes && ${variant} == remote ]] && chroot "${SDCARD}" /bin/bash -c "DEBIAN_FRONTEND=noninteractive apt-get $apt_extra -yqq update"
 	chroot "${SDCARD}" /bin/bash -c "DEBIAN_FRONTEND=noninteractive apt-get -yqq \
 		$apt_extra --no-install-recommends install $name" >> "${DEST}"/debug/install.log 2>&1
 	[[ ${variant} == remote && ${transfer} == yes ]] && rsync -rq "${SDCARD}"/var/cache/apt/archives/*.deb ${DEB_STORAGE}/

--- a/lib/image-helpers.sh
+++ b/lib/image-helpers.sh
@@ -143,7 +143,9 @@ install_deb_chroot()
 
 	display_alert "Installing${desc}" "${name/\/root\//}"
 	[[ $NO_APT_CACHER != yes ]] && local apt_extra="-o Acquire::http::Proxy=\"http://${APT_PROXY_ADDR:-localhost:3142}\" -o Acquire::http::Proxy::localhost=\"DIRECT\""
-	LC_ALL=C LANG=C chroot "${SDCARD}" /bin/bash -c "DEBIAN_FRONTEND=noninteractive apt-get -yqq \
+	# when building in bulk from remote, lets make sure we have up2date index
+	[[ $BUILD_ALL == yes ${variant} == remote ]] && chroot "${SDCARD}" /bin/bash -c "DEBIAN_FRONTEND=noninteractive apt-get $apt_extra -yqq update"
+	chroot "${SDCARD}" /bin/bash -c "DEBIAN_FRONTEND=noninteractive apt-get -yqq \
 		$apt_extra --no-install-recommends install $name" >> "${DEST}"/debug/install.log 2>&1
 	[[ ${variant} == remote && ${transfer} == yes ]] && rsync -rq "${SDCARD}"/var/cache/apt/archives/*.deb ${DEB_STORAGE}/
 }


### PR DESCRIPTION
This feature is used mainly by us or other distributors / internal function. Compression time and CPU usage for this process is significantly increased but the size of the daily batch was decreased from 80Gb -> 50Gb. Mitigate upload speed bottleneck.