### PR TITLE
Downgraded DDR blob for RockPi 4 to fix 1GB model boot issue (again)

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -53,7 +53,7 @@ elif [[ $BOARD == rockpi-4* ]]; then
 	BOOT_USE_BLOBS=yes
 	BOOT_SUPPORT_SPI=yes
 	BOOT_SOC=rk3399
-	DDR_BLOB='rk33/rk3399_ddr_933MHz_v1.24.bin'
+	DDR_BLOB='rk33/rk3399_ddr_933MHz_v1.20.bin' # 1GB model does not boot with later versions
 	MINILOADER_BLOB='rk33/rk3399_miniloader_v1.19.bin'
 	BL31_BLOB='rk33/rk3399_bl31_v1.30.elf'
 


### PR DESCRIPTION
Closes: [AR-595]

Reintroduce the fix from https://github.com/armbian/build/pull/2010 that got lost between u-boot scenario transitions for ROCK Pi 4

[AR-595]: https://armbian.atlassian.net/browse/AR-595