### PR TITLE
fix build deb version legacy

### DIFF
--- a/patch/kernel/rockchip64-legacy/ayufan-packagin-version.patch
+++ b/patch/kernel/rockchip64-legacy/ayufan-packagin-version.patch
@@ -1,0 +1,16 @@
+--- a/scripts/package/builddeb
++++ b/scripts/package/builddeb
+@@ -94,9 +94,9 @@
+ kernel_headers_dir="$objtree/debian/hdrtmp"
+ libc_headers_dir="$objtree/debian/headertmp"
+ dbg_dir="$objtree/debian/dbgtmp"
+-packagename=linux-image-$version
+-fwpackagename=linux-firmware-image-$version
+-kernel_headers_packagename=linux-headers-$version
++packagename=linux-image-"$BRANCH$LOCALVERSION"
++fwpackagename=linux-firmware-image-"$BRANCH$LOCALVERSION"
++kernel_headers_packagename=linux-headers-"$BRANCH$LOCALVERSION"
+ libc_headers_packagename=linux-libc-dev
+ dbg_packagename=$packagename-dbg
+ debarch=
+


### PR DESCRIPTION
This fixes the deb package build when using the LINUXFAMILY variable