### PR TITLE
Enable HDMI sound for Miqi & Miqi clones

### DIFF
--- a/patch/kernel/rockchip-dev/2027-ARM-DTS-rk3288-miqi-enable-sound.patch
+++ b/patch/kernel/rockchip-dev/2027-ARM-DTS-rk3288-miqi-enable-sound.patch
@@ -1,0 +1,61 @@
+Sound node recovered from Pull Request #408
+Node name changed in line with tinkerboard & xt-q8l, cf. issue #1367
+Also added missing i2s node, cf. http://rockchip.wikidot.com/hdmi-audio
+
+From b5d066aba887ebd5963da588d0229d356f1ae79a Mon Sep 17 00:00:00 2001
+From: Sebastian <nitroshift@yahoo.com>
+Date: Wed, 14 Mar 2018 12:49:45 +0200
+Subject: [PATCH] MIQI-DTS-enable-sound-node
+
+Add missing sound node in rk3288-miqi.dts. Compile and run-tested on miqi device with kernel 4.16.0-rc5.
+
+---
+diff --git a/arch/arm/boot/dts/rk3288-miqi.dts b/arch/arm/boot/dts/rk3288-miqi.dts
+index dd785c7..5824ee7 100644
+--- a/arch/arm/boot/dts/rk3288-miqi.dts
++++ b/arch/arm/boot/dts/rk3288-miqi.dts
+@@ -57,6 +57,23 @@
+ 		reg = <0x0 0x0 0x0 0x80000000>;
+ 	};
+ 
++	sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,name = "DW-I2S-HDMI";
++		simple-audio-card,mclk-fs = <512>;
++
++		simple-audio-card,dai-link@0 {  /* I2S - S/PDIF */
++			format = "i2s";
++			cpu {
++				sound-dai = <&i2s>;
++			};
++			codec {
++				sound-dai = <&hdmi>;
++			};
++		};
++	};
++
+ 	ext_gmac: external-gmac-clock {
+ 		compatible = "fixed-clock";
+ 		#clock-cells = <0>;
+@@ -136,10 +153,18 @@
+ };
+ 
+ &hdmi {
++	#address-cells = <1>;
++	#size-cells = <0>;
++	#sound-dai-cells = <0>;
+ 	ddc-i2c-bus = <&i2c5>;
+ 	status = "okay";
+ };
+ 
++&i2s {
++	#sound-dai-cells = <0>;
++	status = "okay";
++};
++
+ &i2c0 {
+ 	clock-frequency = <400000>;
+ 	status = "okay";
+--
+2.14.1


### PR DESCRIPTION
1. Sound node for Miqi recovered from Pull Request #908
2. Sound node name changed in line with tinkerboard & xt-q8l, cf. issue #1367
3. Also added missing i2s node, cf. http://rockchip.wikidot.com/hdmi-audio
HDMI audio now confirmed working on Miqi clone, Openhour Chameleon
