### PR TITLE
Remove transition package apt-transport-https.

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -162,7 +162,7 @@ if [[ "${1}" == docker && -f /etc/debian_version && -z "$(command -v docker)" ]]
 	echo "deb [arch=amd64] https://download.docker.com/linux/${codeid} ${codename} edge" > /etc/apt/sources.list.d/docker.list
 
 	# minimal set of utilities that are needed for prep
-	packages=("curl" "gnupg" "apt-transport-https")
+	packages=("curl" "gnupg")
 	for i in "${packages[@]}"
 	do
 	[[ ! $(command -v "${i}") ]] && install_packages+=${i}" "

--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -644,7 +644,7 @@ compile_armbian-config()
 	Maintainer: $MAINTAINER <$MAINTAINERMAIL>
 	Replaces: armbian-bsp
 	Depends: bash, iperf3, psmisc, curl, bc, expect, dialog, pv, \
-	debconf-utils, unzip, build-essential, html2text, apt-transport-https, html2text, dirmngr, software-properties-common
+	debconf-utils, unzip, build-essential, html2text, html2text, dirmngr, software-properties-common
 	Recommends: armbian-bsp
 	Suggests: libpam-google-authenticator, qrencode, network-manager, sunxi-tools
 	Section: utils

--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -138,7 +138,7 @@ if [[ $RELEASE == xenial || $RELEASE == bionic || $RELEASE == focal || $RELEASE 
 fi
 
 # Base system dependencies. Since adding MINIMAL_IMAGE we rely on "variant=minbase" which has very basic package set
-DEBOOTSTRAP_LIST="locales gnupg ifupdown apt-utils apt-transport-https ca-certificates bzip2 console-setup cpio cron \
+DEBOOTSTRAP_LIST="locales gnupg ifupdown apt-utils ca-certificates bzip2 console-setup cpio cron \
 	dbus init initramfs-tools iputils-ping isc-dhcp-client kmod less libpam-systemd \
 	linux-base logrotate netbase netcat-openbsd rsyslog systemd sudo ucf udev whiptail \
 	wireless-regdb crda dmsetup rsync tzdata"


### PR DESCRIPTION
Support for https has been build into apt version 1.5 and both Debian
Buster and Ubuntu Bionic have that version and therefor
apt-transport-https has become a transitional package and there is no
need for it, assuming Buster/Bionic are the oldest targets.
