### PR TITLE
ODROID-HC4 extras (LED control, DDR/CPU thermal in hwmon, PWM control)

### DIFF
--- a/patch/kernel/meson64-current/board_odroidhc4/hwmon__pwm_fan_add_fan_pwm1_enable_attribute.patch
+++ b/patch/kernel/meson64-current/board_odroidhc4/hwmon__pwm_fan_add_fan_pwm1_enable_attribute.patch
@@ -1,0 +1,124 @@
+From 8a63de9e2aef4e073d91385c5992886e0ea6368e Mon Sep 17 00:00:00 2001
+From: Dongjin Kim <tobetter@gmail.com>
+Date: Wed, 25 Nov 2020 05:01:49 +0900
+Subject: [PATCH] hwmon: (pwm-fan) add fan pwm1_enable attribute
+
+This patch adds to new attribute 'pwm1_enable' to change the fan speed
+control method as documented in 'Documentation/hwmon/sysfs-interface'.
+
+Signed-off-by: Dongjin Kim <tobetter@gmail.com>
+Change-Id: I19094d60e928d6c3ce226d319e75a35ecbd3ae52
+---
+ drivers/hwmon/pwm-fan.c | 52 ++++++++++++++++++++++++++++++++++++-----
+ 1 file changed, 46 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/hwmon/pwm-fan.c b/drivers/hwmon/pwm-fan.c
+index 1f63807c0399e..834275309421d 100644
+--- a/drivers/hwmon/pwm-fan.c
++++ b/drivers/hwmon/pwm-fan.c
+@@ -39,6 +39,7 @@ struct pwm_fan_ctx {
+ 	unsigned int pwm_fan_max_state;
+ 	unsigned int *pwm_fan_cooling_levels;
+ 	struct thermal_cooling_device *cdev;
++	int enable;
+ };
+
+ /* This handler assumes self resetting edge triggered interrupt. */
+@@ -76,6 +77,10 @@ static int  __set_pwm(struct pwm_fan_ctx *ctx, unsigned long pwm)
+ 	struct pwm_state state = { };
+
+ 	mutex_lock(&ctx->lock);
++
++	if (ctx->enable == 0)
++		pwm = MAX_PWM;
++
+ 	if (ctx->pwm_value == pwm)
+ 		goto exit_set_pwm_err;
+
+@@ -137,11 +142,42 @@ static ssize_t rpm_show(struct device *dev,
+ 	return sprintf(buf, "%u\n", ctx->rpm);
+ }
+
++static ssize_t enable_store(struct device *dev,
++		struct device_attribute *attr,
++		const char *buf, size_t count)
++{
++	struct pwm_fan_ctx *ctx = dev_get_drvdata(dev);
++	int err;
++	unsigned long val;
++
++	err = kstrtoul(buf, 10, &val);
++	if (err)
++		return err;
++
++	mutex_lock(&ctx->lock);
++	ctx->enable = val;
++	mutex_unlock(&ctx->lock);
++
++	err = __set_pwm(ctx, ctx->pwm_fan_cooling_levels[ctx->pwm_fan_state]);
++
++	return err ? err : count;
++}
++
++static ssize_t enable_show(struct device *dev, struct device_attribute *attr,
++			   char *buf)
++{
++	struct pwm_fan_ctx *ctx = dev_get_drvdata(dev);
++
++	return sprintf(buf, "%u\n", ctx->enable);
++}
++
+ static SENSOR_DEVICE_ATTR_RW(pwm1, pwm, 0);
++static SENSOR_DEVICE_ATTR_RW(pwm1_enable, enable, 0);
+ static SENSOR_DEVICE_ATTR_RO(fan1_input, rpm, 0);
+
+ static struct attribute *pwm_fan_attrs[] = {
+ 	&sensor_dev_attr_pwm1.dev_attr.attr,
++	&sensor_dev_attr_pwm1_enable.dev_attr.attr,
+ 	&sensor_dev_attr_fan1_input.dev_attr.attr,
+ 	NULL,
+ };
+@@ -153,7 +189,7 @@ static umode_t pwm_fan_attrs_visible(struct kobject *kobj, struct attribute *a,
+ 	struct pwm_fan_ctx *ctx = dev_get_drvdata(dev);
+
+ 	/* Hide fan_input in case no interrupt is available  */
+-	if (n == 1 && ctx->irq <= 0)
++	if (n == 2 && ctx->irq <= 0)
+ 		return 0;
+
+ 	return a->mode;
+@@ -200,7 +236,7 @@ static int
+ pwm_fan_set_cur_state(struct thermal_cooling_device *cdev, unsigned long state)
+ {
+ 	struct pwm_fan_ctx *ctx = cdev->devdata;
+-	int ret;
++	int ret = 0;
+
+ 	if (!ctx || (state > ctx->pwm_fan_max_state))
+ 		return -EINVAL;
+@@ -208,10 +244,12 @@ pwm_fan_set_cur_state(struct thermal_cooling_device *cdev, unsigned long state)
+ 	if (state == ctx->pwm_fan_state)
+ 		return 0;
+
+-	ret = __set_pwm(ctx, ctx->pwm_fan_cooling_levels[state]);
+-	if (ret) {
+-		dev_err(&cdev->device, "Cannot set pwm!\n");
+-		return ret;
++	if (ctx->enable >= 2) {
++		ret = __set_pwm(ctx, ctx->pwm_fan_cooling_levels[state]);
++		if (ret) {
++			dev_err(&cdev->device, "Cannot set pwm!\n");
++			return ret;
++		}
+ 	}
+
+ 	ctx->pwm_fan_state = state;
+@@ -298,6 +336,8 @@ static int pwm_fan_probe(struct platform_device *pdev)
+ 	if (IS_ERR(ctx->pwm))
+ 		return dev_err_probe(dev, PTR_ERR(ctx->pwm), "Could not get PWM\n");
+
++	ctx->enable = 2;
++
+ 	platform_set_drvdata(pdev, ctx);
+
+ 	ctx->irq = platform_get_irq_optional(pdev, 0);

--- a/patch/kernel/meson64-current/board_odroidhc4_red_led_kernel_support.patch
+++ b/patch/kernel/meson64-current/board_odroidhc4_red_led_kernel_support.patch
@@ -1,0 +1,33 @@
+From 7eec2f3bf6266eac5d1b4bb5b60c0ce470ec9a8a Mon Sep 17 00:00:00 2001
+From: Ricardo Pardini <ricardo@pardini.net>
+Date: Sun, 17 Jan 2021 00:14:18 +0100
+Subject: [PATCH] ODROID-HC4 add red power led this is in addition to the blue
+ led in the C4. defaults to always-on, but can be changed, example: # echo
+ rc-feedback > /sys/class/leds/red:power/trigger
+
+Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
+---
+ arch/arm64/boot/dts/amlogic/meson-sm1-odroid-hc4.dts | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-hc4.dts b/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-hc4.dts
+index 92987fece80e0..28631fd2d9f18 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-hc4.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-hc4.dts
+@@ -22,6 +22,16 @@
+ 		interrupts = <84 IRQ_TYPE_EDGE_FALLING>;
+ 		pulses-per-revolutions = <2>;
+ 	};
++
++	leds {
++		compatible = "gpio-leds";
++		led-red {
++			color = <LED_COLOR_ID_RED>;
++			function = LED_FUNCTION_POWER;
++			gpios = <&gpio_ao GPIOAO_7 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "default-on";
++		};
++	};
+ };
+
+ &cpu_thermal {

--- a/patch/kernel/meson64-current/thermal_amlogic_thermal_add_hwmon_support.patch
+++ b/patch/kernel/meson64-current/thermal_amlogic_thermal_add_hwmon_support.patch
@@ -1,0 +1,44 @@
+From 719854edeb7c2c85901031f3062e89fafa66ea1b Mon Sep 17 00:00:00 2001
+From: Dongjin Kim <tobetter@gmail.com>
+Date: Wed, 25 Nov 2020 03:43:28 +0900
+Subject: [PATCH] thermal: amlogic_thermal: Add hwmon support
+
+Expose Amlogic thermal as HWMON devices.
+
+	$ sensors
+	cpu_thermal-virtual-0
+	Adapter: Virtual device
+	temp1:        +32.2 C  (crit = +110.0 C)
+
+	ddr_thermal-virtual-0
+	Adapter: Virtual device
+	temp1:        +33.4 C  (crit = +110.0 C)
+
+Signed-off-by: Dongjin Kim <tobetter@gmail.com>
+Change-Id: Icb1bf7cd7e4462f9923af5bcd72fa7c0c8e14cc9
+---
+ drivers/thermal/amlogic_thermal.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/drivers/thermal/amlogic_thermal.c b/drivers/thermal/amlogic_thermal.c
+index ccb1fe18e9931..2fce96c32586f 100644
+--- a/drivers/thermal/amlogic_thermal.c
++++ b/drivers/thermal/amlogic_thermal.c
+@@ -29,6 +29,7 @@
+ #include <linux/thermal.h>
+
+ #include "thermal_core.h"
++#include "thermal_hwmon.h"
+
+ #define TSENSOR_CFG_REG1			0x4
+ 	#define TSENSOR_CFG_REG1_RSET_VBG	BIT(12)
+@@ -291,6 +292,9 @@ static int amlogic_thermal_probe(struct platform_device *pdev)
+ 	if (ret)
+ 		return ret;
+
++	if (devm_thermal_add_hwmon_sysfs(pdata->tzd))
++		dev_warn(&pdev->dev, "failed to add hwmon sysfs attributes\n");
++
+ 	ret = amlogic_thermal_enable(pdata);
+
+ 	return ret;


### PR DESCRIPTION
Some patches for the ODROID-HC4.

- make the red led accessible in /sys/class/leds/ (so it can be eg turned off, just like the blue led)
  - this is just added to the device tree, very simple, low risk, my own patch
- add thermal support for cpu/ddr, in the hopes of getting the fan in HC4 going according to temps
  - this is for all meson64, @tobetter's patch - seems useful for all meson, low risk
- another @tobetter patch for changing the manual/auto control of pwm1 via pwm1_enable in hwmon
  - I'd rather a cooling map in the DTS, but this works for now
  - totally HC4-specific, but patch affects pwm everywhere, so I used separate board-folder patch
  - upstream does not seem super-happy about it (see commit, there's links)
  

- still missing / much wanted:
  - SATA power control (GPIO?) -- so we can reset the SATA drives when things go wrong
  - MTD-style SPI flash, so we can write u-boot to SPI (16mb) and be done with SD cards