### PR TITLE
fix problems with mmc modules on rockpi 4b

### DIFF
--- a/patch/kernel/rockchip64-current/board-rockpi4-FixMMCFreq.patch
+++ b/patch/kernel/rockchip64-current/board-rockpi4-FixMMCFreq.patch
@@ -1,0 +1,10 @@
+--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi	2021-01-21 12:54:16.967891868 +0800
++++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi	2021-01-21 13:04:10.214771523 +0800
+@@ -697,6 +697,7 @@
+ };
+ 
+ &sdhci {
++	max-frequency = <150000000>;
+ 	bus-width = <8>;
+ 	mmc-hs400-1_8v;
+ 	mmc-hs400-enhanced-strobe;


### PR DESCRIPTION
# Description
Fix the problem of kernel panic when booting from emmc.

previous problem:
Booting from emmc fails because the emmc freq is not set properly.
log:
`[    3.356575] mmc1: Got data interrupt 0x00000002 even though no data operation was in progress.`
`[    3.359693] mmcblk1: error -110 sending stop command, original cmd response 0x900, card status 0x400900`
`[    3.360531] mmcblk1: error -84 transferring data, sector 1507464, nr 32, cmd response 0x900, card status 0x0`
`[    3.361416] mmcblk1: retrying using single block read`
`[    3.365976] mmcblk1: error -84 transferring data, sector 1507474, nr 22, cmd response 0x900, card status 0x0`
`[    3.366852] blk_update_request: I/O error, dev mmcblk1, sector 1507474`
`[    3.383062] mmc1: Got data interrupt 0x00000002 even though no data operation was in progress.`
`[    3.385984] mmcblk1: error -110 sending stop command, original cmd response 0x900, card status 0x400900`
`[    3.386822] mmcblk1: error -84 transferring data, sector 1097896, nr 56, cmd response 0x900, card status 0x0`
`[    3.387717] mmcblk1: retrying using single block read`

It's solved by adding proper frequency limit to the device tree.

# How Has This Been Tested?
It's built and tested with current&dev on rockpi 4b with a 64GByte emmc module, not yet tested with legacy.
Not sure whether the problem exists with legacy kernel.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
