### PR TITLE
Enable network link triggers for NanoPi R4S leds

### DIFF
--- a/patch/kernel/rockchip64-current/add-board-nanopi-r4s.patch
+++ b/patch/kernel/rockchip64-current/add-board-nanopi-r4s.patch
@@ -11,7 +11,7 @@ new file mode 100644
 index 000000000000..7b136d4707c8
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts
-@@ -0,0 +1,148 @@
+@@ -0,0 +1,156 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2020 FriendlyElec Computer Tech. Co., Ltd.
@@ -77,7 +77,7 @@ index 000000000000..7b136d4707c8
 +		label = "lan_led";
 +	};
 +
-+	wan_len: led-3 {
++	wan_led: led-3 {
 +		gpios = <&gpio1 RK_PA0 GPIO_ACTIVE_HIGH>;
 +		label = "wan_led";
 +	};
@@ -147,6 +147,14 @@ index 000000000000..7b136d4707c8
 +};
 +
 +// Armbian tweaks
++&lan_led {
++	linux,default-trigger = "stmmac-0:01:link";
++};
++
++&wan_led {
++	linux,default-trigger = "r8169-100:00:link";
++};
++
 +&uart0 {
 +	bluetooth {
 +		status = "disabled";

--- a/patch/kernel/rockchip64-dev/add-board-nanopi-r4s.patch
+++ b/patch/kernel/rockchip64-dev/add-board-nanopi-r4s.patch
@@ -11,7 +11,7 @@ new file mode 100644
 index 000000000000..7b136d4707c8
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts
-@@ -0,0 +1,148 @@
+@@ -0,0 +1,156 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2020 FriendlyElec Computer Tech. Co., Ltd.
@@ -77,7 +77,7 @@ index 000000000000..7b136d4707c8
 +		label = "lan_led";
 +	};
 +
-+	wan_len: led-3 {
++	wan_led: led-3 {
 +		gpios = <&gpio1 RK_PA0 GPIO_ACTIVE_HIGH>;
 +		label = "wan_led";
 +	};
@@ -147,6 +147,14 @@ index 000000000000..7b136d4707c8
 +};
 +
 +// Armbian tweaks
++&lan_led {
++	linux,default-trigger = "stmmac-0:01:link";
++};
++
++&wan_led {
++	linux,default-trigger = "r8169-100:00:link";
++};
++
 +&uart0 {
 +	bluetooth {
 +		status = "disabled";


### PR DESCRIPTION
# Description

NanoPi R4S has two network dedicated leds.
Let's enable the link triggers for them by default.

Jira reference number [AR-620]

# How Has This Been Tested?

- [x] boot with Current Buster Current

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


[AR-620]: https://armbian.atlassian.net/browse/AR-620