### PR TITLE
Enabled SPI boot option for roc-rk3399-pc

### DIFF
--- a/config/sources/families/rk3399.conf
+++ b/config/sources/families/rk3399.conf
@@ -19,6 +19,7 @@ esac
 if [[ $BOARD == roc-rk3399-pc ]]; then
 
 	BOOT_USE_MAINLINE_ATF=yes
+	BOOT_SUPPORT_SPI=yes
 
 elif [[ $BOARD == helios64 ]]; then
 

--- a/patch/u-boot/u-boot-rockchip64-mainline/board-roc-rk3399-pc-fix-boot-from-spi-flash.patch
+++ b/patch/u-boot/u-boot-rockchip64-mainline/board-roc-rk3399-pc-fix-boot-from-spi-flash.patch
@@ -1,0 +1,42 @@
+From 0ad85609017068d93c0311c34438db4e43588090 Mon Sep 17 00:00:00 2001
+From: Markus Reichl <m.reichl@fivetechno.de>
+Date: Thu, 17 Dec 2020 15:32:56 +0100
+Subject: [PATCH] rockchip: roc-pc-rk3399: fix boot from SPI flash on spi1
+
+Set the default bus for the onboard SPI flash to 1.
+This fixes booting from U-Boot in SPI flash on the
+roc-pc-rk3399 board and it's mezzanine variant.
+
+Signed-off-by: Markus Reichl <m.reichl@fivetechno.de>
+---
+ configs/roc-pc-mezzanine-rk3399_defconfig | 1 +
+ configs/roc-pc-rk3399_defconfig           | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/configs/roc-pc-mezzanine-rk3399_defconfig b/configs/roc-pc-mezzanine-rk3399_defconfig
+index ae16f3558a..8aa5a15518 100644
+--- a/configs/roc-pc-mezzanine-rk3399_defconfig
++++ b/configs/roc-pc-mezzanine-rk3399_defconfig
+@@ -42,6 +42,7 @@ CONFIG_MMC_DW=y
+ CONFIG_MMC_DW_ROCKCHIP=y
+ CONFIG_MMC_SDHCI=y
+ CONFIG_MMC_SDHCI_ROCKCHIP=y
++CONFIG_SF_DEFAULT_BUS=1
+ CONFIG_SPI_FLASH_WINBOND=y
+ CONFIG_DM_ETH=y
+ CONFIG_ETH_DESIGNWARE=y
+diff --git a/configs/roc-pc-rk3399_defconfig b/configs/roc-pc-rk3399_defconfig
+index 774707b115..927b57685d 100644
+--- a/configs/roc-pc-rk3399_defconfig
++++ b/configs/roc-pc-rk3399_defconfig
+@@ -41,6 +41,7 @@ CONFIG_MMC_DW=y
+ CONFIG_MMC_DW_ROCKCHIP=y
+ CONFIG_MMC_SDHCI=y
+ CONFIG_MMC_SDHCI_ROCKCHIP=y
++CONFIG_SF_DEFAULT_BUS=1
+ CONFIG_SPI_FLASH_WINBOND=y
+ CONFIG_DM_ETH=y
+ CONFIG_ETH_DESIGNWARE=y
+-- 
+2.29.2
+


### PR DESCRIPTION
# Description

Enable the building of SPI u-boot image for roc-rk3399-pc / Renegade Elite.
It allows booting to NVMe without SD/eMMC - configurable with `nand-sata-install`.

Jira reference number [AR-603]

# How Has This Been Tested?

- [x] [boot with SPI / NVMe](https://gist.github.com/piter75/80f51adfc3ab75c7daa10db3d90c69cd)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


[AR-603]: https://armbian.atlassian.net/browse/AR-603