### PR TITLE
Fix shell selection bug in Bionic version

### DIFF
--- a/lib/distributions.sh
+++ b/lib/distributions.sh
@@ -320,9 +320,6 @@ install_common()
 		fi
 	fi
 
-	#  set default shell back to BASH and prompt for selection at first login
-	chroot "${SDCARD}" /bin/bash -c "chsh -s $(grep /bash$ /etc/shells | tail -1)"
-
 	# install kernel sources
 	if [[ -f ${DEB_STORAGE}/${CHOSEN_KSRC}_${REVISION}_all.deb && $INSTALL_KSRC == yes ]]; then
 		install_deb_chroot "${DEB_STORAGE}/${CHOSEN_KSRC}_${REVISION}_all.deb"

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -55,12 +55,14 @@ set_shell()
 				esac
 			done
 	fi
+	SHELL_PATH=$(grep /$USER_SHELL$ /etc/shells | tail -1)
+
 	chsh -s $(grep -iF "/$USER_SHELL" /etc/shells | tail -1)
 	echo -e "\nShell: \x1B[92m${USER_SHELL^^}\x1B[0m"
 
 	# change shell for future users
-	sed -i "s/^SHELL=.*/SHELL=\/usr\/bin\/${USER_SHELL}/" /etc/default/useradd
-	sed -i "s/^DSHELL=.*/DSHELL=\/usr\/bin\/${USER_SHELL}/" /etc/adduser.conf
+	sed -i "s|^SHELL=.*|SHELL=${SHELL_PATH}|" /etc/default/useradd
+	sed -i "s|^DSHELL=.*|DSHELL=${SHELL_PATH}|" /etc/adduser.conf
 
 }
 


### PR DESCRIPTION
# Description

Choosing BASH shell on Bionic leads to error.

Jira reference number [AR-616]

# How Has This Been Tested?

Created CLI image and choose BASH as default shell. Once from console, once via SSH.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


[AR-616]: https://armbian.atlassian.net/browse/AR-616