### PR TITLE
Enable DMC for Station M1 in current and dev

### DIFF
--- a/patch/kernel/rockchip64-current/board-rk3328-roc-pc-dts-enable-dmc.patch
+++ b/patch/kernel/rockchip64-current/board-rk3328-roc-pc-dts-enable-dmc.patch
@@ -2,7 +2,7 @@ diff --git a/arch/arm64/boot/dts/rockchip/rk3328-roc-pc.dts b/arch/arm64/boot/dt
 index 3cbbcfc37..4e23a25f9 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3328-roc-pc.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-roc-pc.dts
-@@ -4,12 +4,80 @@
+@@ -4,12 +4,81 @@
   */
  
  /dts-v1/;
@@ -73,6 +73,7 @@ index 3cbbcfc37..4e23a25f9 100644
 +			opp-microvolt-L1 = <1050000>;
 +		};
 +		opp-924000000 {
++			status = "disabled"; // unstable
 +			opp-hz = /bits/ 64 <924000000>;
 +			opp-microvolt = <1100000>;
 +			opp-microvolt-L0 = <1100000>;

--- a/patch/kernel/rockchip64-current/board-rk3328-roc-pc-dts-enable-dmc.patch
+++ b/patch/kernel/rockchip64-current/board-rk3328-roc-pc-dts-enable-dmc.patch
@@ -1,0 +1,85 @@
+diff --git a/arch/arm64/boot/dts/rockchip/rk3328-roc-pc.dts b/arch/arm64/boot/dts/rockchip/rk3328-roc-pc.dts
+index 3cbbcfc37..4e23a25f9 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3328-roc-pc.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3328-roc-pc.dts
+@@ -4,12 +4,80 @@
+  */
+ 
+ /dts-v1/;
++#include "rk3328-roc-pc-dram-timing.dtsi"
+ #include "rk3328.dtsi"
+ 
+ / {
+ 	model = "Firefly roc-rk3328-pc";
+ 	compatible = "firefly,roc-rk3328-pc", "rockchip,rk3328";
+ 
++	dfi: dfi@ff790000 {
++		reg = <0x00 0xff790000 0x00 0x400>;
++		compatible = "rockchip,rk3328-dfi";
++		rockchip,grf = <&grf>;
++		status = "okay";
++	};
++
++	dmc: dmc {
++		compatible = "rockchip,rk3328-dmc";
++		center-supply = <&vdd_logic>;
++		devfreq-events = <&dfi>;
++		clocks = <&cru SCLK_DDRCLK>;
++		clock-names = "dmc_clk";
++		operating-points-v2 = <&dmc_opp_table>;
++		ddr_timing = <&ddr_timing>;
++		upthreshold = <40>;
++		downdifferential = <20>;
++		auto-min-freq = <786000>;
++		auto-freq-en = <0>;
++		#cooling-cells = <2>;
++		status = "okay";
++
++		ddr_power_model: ddr_power_model {
++			compatible = "ddr_power_model";
++			dynamic-power-coefficient = <120>;
++			static-power-coefficient = <200>;
++			ts = <32000 4700 (-80) 2>;
++			thermal-zone = "soc-thermal";
++		};
++	};
++
++	dmc_opp_table: dmc-opp-table {
++		compatible = "operating-points-v2";
++
++		rockchip,leakage-voltage-sel = <
++			1   10    0
++			11  254   1
++		>;
++		nvmem-cells = <&logic_leakage>;
++		nvmem-cell-names = "ddr_leakage";
++
++		opp-786000000 {
++			opp-hz = /bits/ 64 <786000000>;
++			opp-microvolt = <1075000>;
++			opp-microvolt-L0 = <1075000>;
++			opp-microvolt-L1 = <1050000>;
++		};
++		opp-798000000 {
++			opp-hz = /bits/ 64 <798000000>;
++			opp-microvolt = <1075000>;
++			opp-microvolt-L0 = <1075000>;
++			opp-microvolt-L1 = <1050000>;
++		};
++		opp-840000000 {
++			opp-hz = /bits/ 64 <840000000>;
++			opp-microvolt = <1075000>;
++			opp-microvolt-L0 = <1075000>;
++			opp-microvolt-L1 = <1050000>;
++		};
++		opp-924000000 {
++			opp-hz = /bits/ 64 <924000000>;
++			opp-microvolt = <1100000>;
++			opp-microvolt-L0 = <1100000>;
++			opp-microvolt-L1 = <1075000>;
++		};
++	};
++
+ 	gmac_clkin: external-gmac-clock {
+ 		compatible = "fixed-clock";
+ 		clock-frequency = <125000000>;

--- a/patch/kernel/rockchip64-current/board-rk3328-roc-pc-dts-ram-profile.patch
+++ b/patch/kernel/rockchip64-current/board-rk3328-roc-pc-dts-ram-profile.patch
@@ -1,0 +1,229 @@
+diff --git a/arch/arm64/boot/dts/rockchip/rk3328-roc-pc-dram-timing.dtsi b/arch/arm64/boot/dts/rockchip/rk3328-roc-pc-dram-timing.dtsi
+new file mode 100644
+index 000000000000..0ea270539a23
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3328-roc-pc-dram-timing.dtsi
+@@ -0,0 +1,223 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2018 Fuzhou Rockchip Electronics Co., Ltd
++ *
++ */
++#include <dt-bindings/clock/rockchip-ddr.h>
++#include <dt-bindings/memory/rk3328-dram.h>
++
++/ {
++	ddr_timing: ddr_timing {
++		/* CA de-skew, one step is 47.8ps, range 0-15 */
++		ddr3a1_ddr4a9_de-skew = <0>;
++		ddr3a0_ddr4a10_de-skew = <0>;
++		ddr3a3_ddr4a6_de-skew = <1>;
++		ddr3a2_ddr4a4_de-skew = <1>;
++		ddr3a5_ddr4a8_de-skew = <0>;
++		ddr3a4_ddr4a5_de-skew = <2>;
++		ddr3a7_ddr4a11_de-skew = <0>;
++		ddr3a6_ddr4a7_de-skew = <2>;
++		ddr3a9_ddr4a0_de-skew = <1>;
++		ddr3a8_ddr4a13_de-skew = <0>;
++		ddr3a11_ddr4a3_de-skew = <2>;
++		ddr3a10_ddr4cs0_de-skew = <0>;
++		ddr3a13_ddr4a2_de-skew = <1>;
++		ddr3a12_ddr4ba1_de-skew = <0>;
++		ddr3a15_ddr4odt0_de-skew = <0>;
++		ddr3a14_ddr4a1_de-skew = <1>;
++		ddr3ba1_ddr4a15_de-skew = <0>;
++		ddr3ba0_ddr4bg0_de-skew = <0>;
++		ddr3ras_ddr4cke_de-skew = <0>;
++		ddr3ba2_ddr4ba0_de-skew = <1>;
++		ddr3we_ddr4bg1_de-skew = <1>;
++		ddr3cas_ddr4a12_de-skew = <0>;
++		ddr3ckn_ddr4ckn_de-skew = <5>;
++		ddr3ckp_ddr4ckp_de-skew = <5>;
++		ddr3cke_ddr4a16_de-skew = <1>;
++		ddr3odt0_ddr4a14_de-skew = <0>;
++		ddr3cs0_ddr4act_de-skew = <1>;
++		ddr3reset_ddr4reset_de-skew = <0>;
++		ddr3cs1_ddr4cs1_de-skew = <0>;
++		ddr3odt1_ddr4odt1_de-skew = <0>;
++
++		/* DATA de-skew
++		 * RX one step is 25.1ps, range 0-15
++		 * TX one step is 47.8ps, range 0-15
++		 */
++		cs0_dm0_rx_de-skew = <7>;
++		cs0_dm0_tx_de-skew = <8>;
++		cs0_dq0_rx_de-skew = <7>;
++		cs0_dq0_tx_de-skew = <8>;
++		cs0_dq1_rx_de-skew = <7>;
++		cs0_dq1_tx_de-skew = <8>;
++		cs0_dq2_rx_de-skew = <7>;
++		cs0_dq2_tx_de-skew = <8>;
++		cs0_dq3_rx_de-skew = <7>;
++		cs0_dq3_tx_de-skew = <8>;
++		cs0_dq4_rx_de-skew = <7>;
++		cs0_dq4_tx_de-skew = <8>;
++		cs0_dq5_rx_de-skew = <7>;
++		cs0_dq5_tx_de-skew = <8>;
++		cs0_dq6_rx_de-skew = <7>;
++		cs0_dq6_tx_de-skew = <8>;
++		cs0_dq7_rx_de-skew = <7>;
++		cs0_dq7_tx_de-skew = <8>;
++		cs0_dqs0_rx_de-skew = <6>;
++		cs0_dqs0p_tx_de-skew = <9>;
++		cs0_dqs0n_tx_de-skew = <9>;
++
++		cs0_dm1_rx_de-skew = <7>;
++		cs0_dm1_tx_de-skew = <7>;
++		cs0_dq8_rx_de-skew = <7>;
++		cs0_dq8_tx_de-skew = <8>;
++		cs0_dq9_rx_de-skew = <7>;
++		cs0_dq9_tx_de-skew = <7>;
++		cs0_dq10_rx_de-skew = <7>;
++		cs0_dq10_tx_de-skew = <8>;
++		cs0_dq11_rx_de-skew = <7>;
++		cs0_dq11_tx_de-skew = <7>;
++		cs0_dq12_rx_de-skew = <7>;
++		cs0_dq12_tx_de-skew = <8>;
++		cs0_dq13_rx_de-skew = <7>;
++		cs0_dq13_tx_de-skew = <7>;
++		cs0_dq14_rx_de-skew = <7>;
++		cs0_dq14_tx_de-skew = <8>;
++		cs0_dq15_rx_de-skew = <7>;
++		cs0_dq15_tx_de-skew = <7>;
++		cs0_dqs1_rx_de-skew = <7>;
++		cs0_dqs1p_tx_de-skew = <9>;
++		cs0_dqs1n_tx_de-skew = <9>;
++
++		cs0_dm2_rx_de-skew = <7>;
++		cs0_dm2_tx_de-skew = <8>;
++		cs0_dq16_rx_de-skew = <7>;
++		cs0_dq16_tx_de-skew = <8>;
++		cs0_dq17_rx_de-skew = <7>;
++		cs0_dq17_tx_de-skew = <8>;
++		cs0_dq18_rx_de-skew = <7>;
++		cs0_dq18_tx_de-skew = <8>;
++		cs0_dq19_rx_de-skew = <7>;
++		cs0_dq19_tx_de-skew = <8>;
++		cs0_dq20_rx_de-skew = <7>;
++		cs0_dq20_tx_de-skew = <8>;
++		cs0_dq21_rx_de-skew = <7>;
++		cs0_dq21_tx_de-skew = <8>;
++		cs0_dq22_rx_de-skew = <7>;
++		cs0_dq22_tx_de-skew = <8>;
++		cs0_dq23_rx_de-skew = <7>;
++		cs0_dq23_tx_de-skew = <8>;
++		cs0_dqs2_rx_de-skew = <6>;
++		cs0_dqs2p_tx_de-skew = <9>;
++		cs0_dqs2n_tx_de-skew = <9>;
++
++		cs0_dm3_rx_de-skew = <7>;
++		cs0_dm3_tx_de-skew = <7>;
++		cs0_dq24_rx_de-skew = <7>;
++		cs0_dq24_tx_de-skew = <8>;
++		cs0_dq25_rx_de-skew = <7>;
++		cs0_dq25_tx_de-skew = <7>;
++		cs0_dq26_rx_de-skew = <7>;
++		cs0_dq26_tx_de-skew = <7>;
++		cs0_dq27_rx_de-skew = <7>;
++		cs0_dq27_tx_de-skew = <7>;
++		cs0_dq28_rx_de-skew = <7>;
++		cs0_dq28_tx_de-skew = <7>;
++		cs0_dq29_rx_de-skew = <7>;
++		cs0_dq29_tx_de-skew = <7>;
++		cs0_dq30_rx_de-skew = <7>;
++		cs0_dq30_tx_de-skew = <7>;
++		cs0_dq31_rx_de-skew = <7>;
++		cs0_dq31_tx_de-skew = <7>;
++		cs0_dqs3_rx_de-skew = <7>;
++		cs0_dqs3p_tx_de-skew = <9>;
++		cs0_dqs3n_tx_de-skew = <9>;
++
++		cs1_dm0_rx_de-skew = <7>;
++		cs1_dm0_tx_de-skew = <8>;
++		cs1_dq0_rx_de-skew = <7>;
++		cs1_dq0_tx_de-skew = <8>;
++		cs1_dq1_rx_de-skew = <7>;
++		cs1_dq1_tx_de-skew = <8>;
++		cs1_dq2_rx_de-skew = <7>;
++		cs1_dq2_tx_de-skew = <8>;
++		cs1_dq3_rx_de-skew = <7>;
++		cs1_dq3_tx_de-skew = <8>;
++		cs1_dq4_rx_de-skew = <7>;
++		cs1_dq4_tx_de-skew = <8>;
++		cs1_dq5_rx_de-skew = <7>;
++		cs1_dq5_tx_de-skew = <8>;
++		cs1_dq6_rx_de-skew = <7>;
++		cs1_dq6_tx_de-skew = <8>;
++		cs1_dq7_rx_de-skew = <7>;
++		cs1_dq7_tx_de-skew = <8>;
++		cs1_dqs0_rx_de-skew = <6>;
++		cs1_dqs0p_tx_de-skew = <9>;
++		cs1_dqs0n_tx_de-skew = <9>;
++
++		cs1_dm1_rx_de-skew = <7>;
++		cs1_dm1_tx_de-skew = <7>;
++		cs1_dq8_rx_de-skew = <7>;
++		cs1_dq8_tx_de-skew = <8>;
++		cs1_dq9_rx_de-skew = <7>;
++		cs1_dq9_tx_de-skew = <7>;
++		cs1_dq10_rx_de-skew = <7>;
++		cs1_dq10_tx_de-skew = <8>;
++		cs1_dq11_rx_de-skew = <7>;
++		cs1_dq11_tx_de-skew = <7>;
++		cs1_dq12_rx_de-skew = <7>;
++		cs1_dq12_tx_de-skew = <8>;
++		cs1_dq13_rx_de-skew = <7>;
++		cs1_dq13_tx_de-skew = <7>;
++		cs1_dq14_rx_de-skew = <7>;
++		cs1_dq14_tx_de-skew = <8>;
++		cs1_dq15_rx_de-skew = <7>;
++		cs1_dq15_tx_de-skew = <7>;
++		cs1_dqs1_rx_de-skew = <7>;
++		cs1_dqs1p_tx_de-skew = <9>;
++		cs1_dqs1n_tx_de-skew = <9>;
++
++		cs1_dm2_rx_de-skew = <7>;
++		cs1_dm2_tx_de-skew = <8>;
++		cs1_dq16_rx_de-skew = <7>;
++		cs1_dq16_tx_de-skew = <8>;
++		cs1_dq17_rx_de-skew = <7>;
++		cs1_dq17_tx_de-skew = <8>;
++		cs1_dq18_rx_de-skew = <7>;
++		cs1_dq18_tx_de-skew = <8>;
++		cs1_dq19_rx_de-skew = <7>;
++		cs1_dq19_tx_de-skew = <8>;
++		cs1_dq20_rx_de-skew = <7>;
++		cs1_dq20_tx_de-skew = <8>;
++		cs1_dq21_rx_de-skew = <7>;
++		cs1_dq21_tx_de-skew = <8>;
++		cs1_dq22_rx_de-skew = <7>;
++		cs1_dq22_tx_de-skew = <8>;
++		cs1_dq23_rx_de-skew = <7>;
++		cs1_dq23_tx_de-skew = <8>;
++		cs1_dqs2_rx_de-skew = <6>;
++		cs1_dqs2p_tx_de-skew = <9>;
++		cs1_dqs2n_tx_de-skew = <9>;
++
++		cs1_dm3_rx_de-skew = <7>;
++		cs1_dm3_tx_de-skew = <7>;
++		cs1_dq24_rx_de-skew = <7>;
++		cs1_dq24_tx_de-skew = <8>;
++		cs1_dq25_rx_de-skew = <7>;
++		cs1_dq25_tx_de-skew = <7>;
++		cs1_dq26_rx_de-skew = <7>;
++		cs1_dq26_tx_de-skew = <7>;
++		cs1_dq27_rx_de-skew = <7>;
++		cs1_dq27_tx_de-skew = <7>;
++		cs1_dq28_rx_de-skew = <7>;
++		cs1_dq28_tx_de-skew = <7>;
++		cs1_dq29_rx_de-skew = <7>;
++		cs1_dq29_tx_de-skew = <7>;
++		cs1_dq30_rx_de-skew = <7>;
++		cs1_dq30_tx_de-skew = <7>;
++		cs1_dq31_rx_de-skew = <7>;
++		cs1_dq31_tx_de-skew = <7>;
++		cs1_dqs3_rx_de-skew = <7>;
++		cs1_dqs3p_tx_de-skew = <9>;
++		cs1_dqs3n_tx_de-skew = <9>;
++	};
++};

--- a/patch/kernel/rockchip64-dev/board-rk3328-roc-pc-dts-enable-dmc.patch
+++ b/patch/kernel/rockchip64-dev/board-rk3328-roc-pc-dts-enable-dmc.patch
@@ -1,0 +1,85 @@
+diff --git a/arch/arm64/boot/dts/rockchip/rk3328-roc-pc.dts b/arch/arm64/boot/dts/rockchip/rk3328-roc-pc.dts
+index 3cbbcfc37..4e23a25f9 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3328-roc-pc.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3328-roc-pc.dts
+@@ -4,12 +4,80 @@
+  */
+ 
+ /dts-v1/;
++#include "rk3328-roc-pc-dram-timing.dtsi"
+ #include "rk3328.dtsi"
+ 
+ / {
+ 	model = "Firefly roc-rk3328-pc";
+ 	compatible = "firefly,roc-rk3328-pc", "rockchip,rk3328";
+ 
++	dfi: dfi@ff790000 {
++		reg = <0x00 0xff790000 0x00 0x400>;
++		compatible = "rockchip,rk3328-dfi";
++		rockchip,grf = <&grf>;
++		status = "okay";
++	};
++
++	dmc: dmc {
++		compatible = "rockchip,rk3328-dmc";
++		center-supply = <&vdd_logic>;
++		devfreq-events = <&dfi>;
++		clocks = <&cru SCLK_DDRCLK>;
++		clock-names = "dmc_clk";
++		operating-points-v2 = <&dmc_opp_table>;
++		ddr_timing = <&ddr_timing>;
++		upthreshold = <40>;
++		downdifferential = <20>;
++		auto-min-freq = <786000>;
++		auto-freq-en = <0>;
++		#cooling-cells = <2>;
++		status = "okay";
++
++		ddr_power_model: ddr_power_model {
++			compatible = "ddr_power_model";
++			dynamic-power-coefficient = <120>;
++			static-power-coefficient = <200>;
++			ts = <32000 4700 (-80) 2>;
++			thermal-zone = "soc-thermal";
++		};
++	};
++
++	dmc_opp_table: dmc-opp-table {
++		compatible = "operating-points-v2";
++
++		rockchip,leakage-voltage-sel = <
++			1   10    0
++			11  254   1
++		>;
++		nvmem-cells = <&logic_leakage>;
++		nvmem-cell-names = "ddr_leakage";
++
++		opp-786000000 {
++			opp-hz = /bits/ 64 <786000000>;
++			opp-microvolt = <1075000>;
++			opp-microvolt-L0 = <1075000>;
++			opp-microvolt-L1 = <1050000>;
++		};
++		opp-798000000 {
++			opp-hz = /bits/ 64 <798000000>;
++			opp-microvolt = <1075000>;
++			opp-microvolt-L0 = <1075000>;
++			opp-microvolt-L1 = <1050000>;
++		};
++		opp-840000000 {
++			opp-hz = /bits/ 64 <840000000>;
++			opp-microvolt = <1075000>;
++			opp-microvolt-L0 = <1075000>;
++			opp-microvolt-L1 = <1050000>;
++		};
++		opp-924000000 {
++			opp-hz = /bits/ 64 <924000000>;
++			opp-microvolt = <1100000>;
++			opp-microvolt-L0 = <1100000>;
++			opp-microvolt-L1 = <1075000>;
++		};
++	};
++
+ 	gmac_clkin: external-gmac-clock {
+ 		compatible = "fixed-clock";
+ 		clock-frequency = <125000000>;

--- a/patch/kernel/rockchip64-dev/board-rk3328-roc-pc-dts-enable-dmc.patch
+++ b/patch/kernel/rockchip64-dev/board-rk3328-roc-pc-dts-enable-dmc.patch
@@ -73,6 +73,7 @@ index 3cbbcfc37..4e23a25f9 100644
 +			opp-microvolt-L1 = <1050000>;
 +		};
 +		opp-924000000 {
++			status = "disabled"; // unstable
 +			opp-hz = /bits/ 64 <924000000>;
 +			opp-microvolt = <1100000>;
 +			opp-microvolt-L0 = <1100000>;

--- a/patch/kernel/rockchip64-dev/board-rk3328-roc-pc-dts-ram-profile.patch
+++ b/patch/kernel/rockchip64-dev/board-rk3328-roc-pc-dts-ram-profile.patch
@@ -1,0 +1,229 @@
+diff --git a/arch/arm64/boot/dts/rockchip/rk3328-roc-pc-dram-timing.dtsi b/arch/arm64/boot/dts/rockchip/rk3328-roc-pc-dram-timing.dtsi
+new file mode 100644
+index 000000000000..0ea270539a23
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3328-roc-pc-dram-timing.dtsi
+@@ -0,0 +1,223 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2018 Fuzhou Rockchip Electronics Co., Ltd
++ *
++ */
++#include <dt-bindings/clock/rockchip-ddr.h>
++#include <dt-bindings/memory/rk3328-dram.h>
++
++/ {
++	ddr_timing: ddr_timing {
++		/* CA de-skew, one step is 47.8ps, range 0-15 */
++		ddr3a1_ddr4a9_de-skew = <0>;
++		ddr3a0_ddr4a10_de-skew = <0>;
++		ddr3a3_ddr4a6_de-skew = <1>;
++		ddr3a2_ddr4a4_de-skew = <1>;
++		ddr3a5_ddr4a8_de-skew = <0>;
++		ddr3a4_ddr4a5_de-skew = <2>;
++		ddr3a7_ddr4a11_de-skew = <0>;
++		ddr3a6_ddr4a7_de-skew = <2>;
++		ddr3a9_ddr4a0_de-skew = <1>;
++		ddr3a8_ddr4a13_de-skew = <0>;
++		ddr3a11_ddr4a3_de-skew = <2>;
++		ddr3a10_ddr4cs0_de-skew = <0>;
++		ddr3a13_ddr4a2_de-skew = <1>;
++		ddr3a12_ddr4ba1_de-skew = <0>;
++		ddr3a15_ddr4odt0_de-skew = <0>;
++		ddr3a14_ddr4a1_de-skew = <1>;
++		ddr3ba1_ddr4a15_de-skew = <0>;
++		ddr3ba0_ddr4bg0_de-skew = <0>;
++		ddr3ras_ddr4cke_de-skew = <0>;
++		ddr3ba2_ddr4ba0_de-skew = <1>;
++		ddr3we_ddr4bg1_de-skew = <1>;
++		ddr3cas_ddr4a12_de-skew = <0>;
++		ddr3ckn_ddr4ckn_de-skew = <5>;
++		ddr3ckp_ddr4ckp_de-skew = <5>;
++		ddr3cke_ddr4a16_de-skew = <1>;
++		ddr3odt0_ddr4a14_de-skew = <0>;
++		ddr3cs0_ddr4act_de-skew = <1>;
++		ddr3reset_ddr4reset_de-skew = <0>;
++		ddr3cs1_ddr4cs1_de-skew = <0>;
++		ddr3odt1_ddr4odt1_de-skew = <0>;
++
++		/* DATA de-skew
++		 * RX one step is 25.1ps, range 0-15
++		 * TX one step is 47.8ps, range 0-15
++		 */
++		cs0_dm0_rx_de-skew = <7>;
++		cs0_dm0_tx_de-skew = <8>;
++		cs0_dq0_rx_de-skew = <7>;
++		cs0_dq0_tx_de-skew = <8>;
++		cs0_dq1_rx_de-skew = <7>;
++		cs0_dq1_tx_de-skew = <8>;
++		cs0_dq2_rx_de-skew = <7>;
++		cs0_dq2_tx_de-skew = <8>;
++		cs0_dq3_rx_de-skew = <7>;
++		cs0_dq3_tx_de-skew = <8>;
++		cs0_dq4_rx_de-skew = <7>;
++		cs0_dq4_tx_de-skew = <8>;
++		cs0_dq5_rx_de-skew = <7>;
++		cs0_dq5_tx_de-skew = <8>;
++		cs0_dq6_rx_de-skew = <7>;
++		cs0_dq6_tx_de-skew = <8>;
++		cs0_dq7_rx_de-skew = <7>;
++		cs0_dq7_tx_de-skew = <8>;
++		cs0_dqs0_rx_de-skew = <6>;
++		cs0_dqs0p_tx_de-skew = <9>;
++		cs0_dqs0n_tx_de-skew = <9>;
++
++		cs0_dm1_rx_de-skew = <7>;
++		cs0_dm1_tx_de-skew = <7>;
++		cs0_dq8_rx_de-skew = <7>;
++		cs0_dq8_tx_de-skew = <8>;
++		cs0_dq9_rx_de-skew = <7>;
++		cs0_dq9_tx_de-skew = <7>;
++		cs0_dq10_rx_de-skew = <7>;
++		cs0_dq10_tx_de-skew = <8>;
++		cs0_dq11_rx_de-skew = <7>;
++		cs0_dq11_tx_de-skew = <7>;
++		cs0_dq12_rx_de-skew = <7>;
++		cs0_dq12_tx_de-skew = <8>;
++		cs0_dq13_rx_de-skew = <7>;
++		cs0_dq13_tx_de-skew = <7>;
++		cs0_dq14_rx_de-skew = <7>;
++		cs0_dq14_tx_de-skew = <8>;
++		cs0_dq15_rx_de-skew = <7>;
++		cs0_dq15_tx_de-skew = <7>;
++		cs0_dqs1_rx_de-skew = <7>;
++		cs0_dqs1p_tx_de-skew = <9>;
++		cs0_dqs1n_tx_de-skew = <9>;
++
++		cs0_dm2_rx_de-skew = <7>;
++		cs0_dm2_tx_de-skew = <8>;
++		cs0_dq16_rx_de-skew = <7>;
++		cs0_dq16_tx_de-skew = <8>;
++		cs0_dq17_rx_de-skew = <7>;
++		cs0_dq17_tx_de-skew = <8>;
++		cs0_dq18_rx_de-skew = <7>;
++		cs0_dq18_tx_de-skew = <8>;
++		cs0_dq19_rx_de-skew = <7>;
++		cs0_dq19_tx_de-skew = <8>;
++		cs0_dq20_rx_de-skew = <7>;
++		cs0_dq20_tx_de-skew = <8>;
++		cs0_dq21_rx_de-skew = <7>;
++		cs0_dq21_tx_de-skew = <8>;
++		cs0_dq22_rx_de-skew = <7>;
++		cs0_dq22_tx_de-skew = <8>;
++		cs0_dq23_rx_de-skew = <7>;
++		cs0_dq23_tx_de-skew = <8>;
++		cs0_dqs2_rx_de-skew = <6>;
++		cs0_dqs2p_tx_de-skew = <9>;
++		cs0_dqs2n_tx_de-skew = <9>;
++
++		cs0_dm3_rx_de-skew = <7>;
++		cs0_dm3_tx_de-skew = <7>;
++		cs0_dq24_rx_de-skew = <7>;
++		cs0_dq24_tx_de-skew = <8>;
++		cs0_dq25_rx_de-skew = <7>;
++		cs0_dq25_tx_de-skew = <7>;
++		cs0_dq26_rx_de-skew = <7>;
++		cs0_dq26_tx_de-skew = <7>;
++		cs0_dq27_rx_de-skew = <7>;
++		cs0_dq27_tx_de-skew = <7>;
++		cs0_dq28_rx_de-skew = <7>;
++		cs0_dq28_tx_de-skew = <7>;
++		cs0_dq29_rx_de-skew = <7>;
++		cs0_dq29_tx_de-skew = <7>;
++		cs0_dq30_rx_de-skew = <7>;
++		cs0_dq30_tx_de-skew = <7>;
++		cs0_dq31_rx_de-skew = <7>;
++		cs0_dq31_tx_de-skew = <7>;
++		cs0_dqs3_rx_de-skew = <7>;
++		cs0_dqs3p_tx_de-skew = <9>;
++		cs0_dqs3n_tx_de-skew = <9>;
++
++		cs1_dm0_rx_de-skew = <7>;
++		cs1_dm0_tx_de-skew = <8>;
++		cs1_dq0_rx_de-skew = <7>;
++		cs1_dq0_tx_de-skew = <8>;
++		cs1_dq1_rx_de-skew = <7>;
++		cs1_dq1_tx_de-skew = <8>;
++		cs1_dq2_rx_de-skew = <7>;
++		cs1_dq2_tx_de-skew = <8>;
++		cs1_dq3_rx_de-skew = <7>;
++		cs1_dq3_tx_de-skew = <8>;
++		cs1_dq4_rx_de-skew = <7>;
++		cs1_dq4_tx_de-skew = <8>;
++		cs1_dq5_rx_de-skew = <7>;
++		cs1_dq5_tx_de-skew = <8>;
++		cs1_dq6_rx_de-skew = <7>;
++		cs1_dq6_tx_de-skew = <8>;
++		cs1_dq7_rx_de-skew = <7>;
++		cs1_dq7_tx_de-skew = <8>;
++		cs1_dqs0_rx_de-skew = <6>;
++		cs1_dqs0p_tx_de-skew = <9>;
++		cs1_dqs0n_tx_de-skew = <9>;
++
++		cs1_dm1_rx_de-skew = <7>;
++		cs1_dm1_tx_de-skew = <7>;
++		cs1_dq8_rx_de-skew = <7>;
++		cs1_dq8_tx_de-skew = <8>;
++		cs1_dq9_rx_de-skew = <7>;
++		cs1_dq9_tx_de-skew = <7>;
++		cs1_dq10_rx_de-skew = <7>;
++		cs1_dq10_tx_de-skew = <8>;
++		cs1_dq11_rx_de-skew = <7>;
++		cs1_dq11_tx_de-skew = <7>;
++		cs1_dq12_rx_de-skew = <7>;
++		cs1_dq12_tx_de-skew = <8>;
++		cs1_dq13_rx_de-skew = <7>;
++		cs1_dq13_tx_de-skew = <7>;
++		cs1_dq14_rx_de-skew = <7>;
++		cs1_dq14_tx_de-skew = <8>;
++		cs1_dq15_rx_de-skew = <7>;
++		cs1_dq15_tx_de-skew = <7>;
++		cs1_dqs1_rx_de-skew = <7>;
++		cs1_dqs1p_tx_de-skew = <9>;
++		cs1_dqs1n_tx_de-skew = <9>;
++
++		cs1_dm2_rx_de-skew = <7>;
++		cs1_dm2_tx_de-skew = <8>;
++		cs1_dq16_rx_de-skew = <7>;
++		cs1_dq16_tx_de-skew = <8>;
++		cs1_dq17_rx_de-skew = <7>;
++		cs1_dq17_tx_de-skew = <8>;
++		cs1_dq18_rx_de-skew = <7>;
++		cs1_dq18_tx_de-skew = <8>;
++		cs1_dq19_rx_de-skew = <7>;
++		cs1_dq19_tx_de-skew = <8>;
++		cs1_dq20_rx_de-skew = <7>;
++		cs1_dq20_tx_de-skew = <8>;
++		cs1_dq21_rx_de-skew = <7>;
++		cs1_dq21_tx_de-skew = <8>;
++		cs1_dq22_rx_de-skew = <7>;
++		cs1_dq22_tx_de-skew = <8>;
++		cs1_dq23_rx_de-skew = <7>;
++		cs1_dq23_tx_de-skew = <8>;
++		cs1_dqs2_rx_de-skew = <6>;
++		cs1_dqs2p_tx_de-skew = <9>;
++		cs1_dqs2n_tx_de-skew = <9>;
++
++		cs1_dm3_rx_de-skew = <7>;
++		cs1_dm3_tx_de-skew = <7>;
++		cs1_dq24_rx_de-skew = <7>;
++		cs1_dq24_tx_de-skew = <8>;
++		cs1_dq25_rx_de-skew = <7>;
++		cs1_dq25_tx_de-skew = <7>;
++		cs1_dq26_rx_de-skew = <7>;
++		cs1_dq26_tx_de-skew = <7>;
++		cs1_dq27_rx_de-skew = <7>;
++		cs1_dq27_tx_de-skew = <7>;
++		cs1_dq28_rx_de-skew = <7>;
++		cs1_dq28_tx_de-skew = <7>;
++		cs1_dq29_rx_de-skew = <7>;
++		cs1_dq29_tx_de-skew = <7>;
++		cs1_dq30_rx_de-skew = <7>;
++		cs1_dq30_tx_de-skew = <7>;
++		cs1_dq31_rx_de-skew = <7>;
++		cs1_dq31_tx_de-skew = <7>;
++		cs1_dqs3_rx_de-skew = <7>;
++		cs1_dqs3p_tx_de-skew = <9>;
++		cs1_dqs3n_tx_de-skew = <9>;
++	};
++};


### PR DESCRIPTION
# Description

The board boots with RAM configured to minimal frequency which results in slow memory operations.
With this PR there are following frequencies enabled: 786, 798, 840 and ~924~ (disabled for being unstable).

Jira reference number [AR-622]

# How Has This Been Tested?

- [x] sbc-bench, DMC disabled - http://ix.io/2N4J
- [x] sbc-bench, DMC enabled @ 924MHz (unstable) - http://ix.io/2N4Y
- [x] sbc-bench, DMC enabled @ 840MHz - http://ix.io/2N5P 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

[AR-622]: https://armbian.atlassian.net/browse/AR-622