### PR TITLE
PR for changing the phy mode for nanoPi A64 from rgmii to rgmii-id

### DIFF
--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -20,7 +20,7 @@ TZDATA=$(cat /etc/timezone) # Timezone for target is taken from host or defined 
 USEALLCORES=yes # Use all CPU cores for compiling
 EXIT_PATCHING_ERROR="" # exit patching if failed
 [[ -z $HOST ]] && HOST="$(echo "$BOARD" | cut -f1 -d-)" # set hostname to the board
-ROOTFSCACHE_VERSION=11
+ROOTFSCACHE_VERSION=12
 CHROOT_CACHE_VERSION=6
 BUILD_REPOSITORY_URL=$(git remote get-url $(git remote 2>/dev/null) 2>/dev/null)
 BUILD_REPOSITORY_COMMIT=$(git describe --match=d_e_a_d_b_e_e_f --always --dirty 2>/dev/null)
@@ -147,7 +147,7 @@ fi
 DEBOOTSTRAP_LIST="locales gnupg ifupdown apt-utils apt-transport-https ca-certificates bzip2 console-setup cpio cron \
 	dbus init initramfs-tools iputils-ping isc-dhcp-client kmod less libpam-systemd \
 	linux-base logrotate netbase netcat-openbsd rsyslog systemd sudo ucf udev whiptail \
-	wireless-regdb crda dmsetup rsync"
+	wireless-regdb crda dmsetup rsync rng-tools"
 
 [[ $BUILD_DESKTOP == yes ]] && DEBOOTSTRAP_LIST+=" libgtk2.0-bin"
 

--- a/patch/kernel/sunxi-dev/board-a64-nanopi-a64-ethernet-phy-mode.patch
+++ b/patch/kernel/sunxi-dev/board-a64-nanopi-a64-ethernet-phy-mode.patch
@@ -1,0 +1,27 @@
+From 9fa7f92966d8b0e689171ddcd708c4f249012e3f Mon Sep 17 00:00:00 2001
+From: root <guido.lehwalder@gmail.com>
+Date: Tue, 26 Jan 2021 18:17:33 +0300
+Subject: [PATCH] set right phy-mode for NPI A64 to rgmii-id for working
+ onboard-ethernet
+
+Signed-off-by: root <guido.lehwalder@gmail.com>
+---
+ arch/arm64/boot/dts/allwinner/sun50i-a64-nanopi-a64.dts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-a64-nanopi-a64.dts b/arch/arm64/boot/dts/allwinner/sun50i-a64-nanopi-a64.dts
+index 0cf3d2e61..25f07cf89 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-a64-nanopi-a64.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-a64-nanopi-a64.dts
+@@ -94,7 +94,7 @@ &ehci1 {
+ &emac {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&rgmii_pins>;
+-	phy-mode = "rgmii";
++	phy-mode = "rgmii-id";
+ 	phy-handle = <&ext_rgmii_phy>;
+ 	phy-supply = <&reg_dcdc1>;
+ 	status = "okay";
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+


### PR DESCRIPTION
This PR is for changing the phy-mod efor the onboard ethernet from rgmii to rgmii-id because only with rgmii-id the onboard ethernet can be used and connect to the network.

This has been tested with fresh compiled armbian buster current/dev images (build with armbian-build-system)

Please ignore the old also attached change from 2019 for the configuration.sh - only the 2nd change/patch is needed :)
But I dont know how to delete/disable it

Kind regard 
Guido