### PR TITLE
Odroid HC4: add red led to DTS

### DIFF
--- a/patch/kernel/meson64-current/board_odroidhc4_red_led_kernel_support.patch
+++ b/patch/kernel/meson64-current/board_odroidhc4_red_led_kernel_support.patch
@@ -1,0 +1,33 @@
+From 7eec2f3bf6266eac5d1b4bb5b60c0ce470ec9a8a Mon Sep 17 00:00:00 2001
+From: Ricardo Pardini <ricardo@pardini.net>
+Date: Sun, 17 Jan 2021 00:14:18 +0100
+Subject: [PATCH] ODROID-HC4 add red power led this is in addition to the blue
+ led in the C4. defaults to always-on, but can be changed, example: # echo
+ rc-feedback > /sys/class/leds/red:power/trigger
+
+Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
+---
+ arch/arm64/boot/dts/amlogic/meson-sm1-odroid-hc4.dts | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-hc4.dts b/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-hc4.dts
+index 92987fece80e0..28631fd2d9f18 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-hc4.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-hc4.dts
+@@ -22,6 +22,16 @@
+ 		interrupts = <84 IRQ_TYPE_EDGE_FALLING>;
+ 		pulses-per-revolutions = <2>;
+ 	};
++
++	leds {
++		compatible = "gpio-leds";
++		led-red {
++			color = <LED_COLOR_ID_RED>;
++			function = LED_FUNCTION_POWER;
++			gpios = <&gpio_ao GPIOAO_7 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "default-on";
++		};
++	};
+ };
+
+ &cpu_thermal {


### PR DESCRIPTION
The HC4 can control the red/power LED on the board, just like the blue/heartbeat LED.
- make the red led accessible in /sys/class/leds/ (so it can be eg turned off, just like the blue led)

This has been split off from #2552 

Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
