### PR TITLE
meson-64: Expose Amlogic thermal as HWMON devices

### DIFF
--- a/patch/kernel/meson64-current/thermal_amlogic_thermal_add_hwmon_support.patch
+++ b/patch/kernel/meson64-current/thermal_amlogic_thermal_add_hwmon_support.patch
@@ -1,0 +1,44 @@
+From 719854edeb7c2c85901031f3062e89fafa66ea1b Mon Sep 17 00:00:00 2001
+From: Dongjin Kim <tobetter@gmail.com>
+Date: Wed, 25 Nov 2020 03:43:28 +0900
+Subject: [PATCH] thermal: amlogic_thermal: Add hwmon support
+
+Expose Amlogic thermal as HWMON devices.
+
+	$ sensors
+	cpu_thermal-virtual-0
+	Adapter: Virtual device
+	temp1:        +32.2 C  (crit = +110.0 C)
+
+	ddr_thermal-virtual-0
+	Adapter: Virtual device
+	temp1:        +33.4 C  (crit = +110.0 C)
+
+Signed-off-by: Dongjin Kim <tobetter@gmail.com>
+Change-Id: Icb1bf7cd7e4462f9923af5bcd72fa7c0c8e14cc9
+---
+ drivers/thermal/amlogic_thermal.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/drivers/thermal/amlogic_thermal.c b/drivers/thermal/amlogic_thermal.c
+index ccb1fe18e9931..2fce96c32586f 100644
+--- a/drivers/thermal/amlogic_thermal.c
++++ b/drivers/thermal/amlogic_thermal.c
+@@ -29,6 +29,7 @@
+ #include <linux/thermal.h>
+
+ #include "thermal_core.h"
++#include "thermal_hwmon.h"
+
+ #define TSENSOR_CFG_REG1			0x4
+ 	#define TSENSOR_CFG_REG1_RSET_VBG	BIT(12)
+@@ -291,6 +292,9 @@ static int amlogic_thermal_probe(struct platform_device *pdev)
+ 	if (ret)
+ 		return ret;
+
++	if (devm_thermal_add_hwmon_sysfs(pdata->tzd))
++		dev_warn(&pdev->dev, "failed to add hwmon sysfs attributes\n");
++
+ 	ret = amlogic_thermal_enable(pdata);
+
+ 	return ret;


### PR DESCRIPTION
Exposes amlogic's thermal info via hwmon. It allows lm-sensors to read temperatures.
Should be useful and safe on all of meson64.
It is specially relevant for the ODROID HC4 and other boards with fans, since this allows userspace to query temps in a more standard way (eg: fancontrol/pwmconfig).
This does NOT include any PWM changes.

This has been split off from #2552 