### PR TITLE
Fix armbianmonitor -n for vlan interfaces

### DIFF
--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -1055,26 +1055,26 @@ NetworkMonitorMode() {
 
 	# Allow armbianmonitor to return back to armbian-config
 	trap "echo ; exit 0" 0 1 2 3 15
-	timerStart
-	kickAllStatsDown
 	
 	# Count interfaces - multiple routes causing interfaces to show up more than once, filtering...
-	ifacecount=$(route -n | egrep UG | egrep -o "[a-zA-Z0-9]*$" | sort | uniq)
+	ifacecount=$(route -n | egrep UG | egrep -o '[^ ]*$' | sort | uniq)
 	# If there are two ore more interfaces detected open a dynamic dialog box to select which to monitor
 	if [ "$(echo -e $ifacecount | tr ' ' '\n' | wc -l)" -gt 1 ]; then
-		ifacemenu=$(route -n | egrep UG | egrep -o "[a-zA-Z0-9]*$" | sort | uniq | awk '{a[$1]=$1}END{for(i in a)printf i" "a[i]" "}')
+		ifacemenu=$(route -n | egrep UG | egrep -o '[^ ]*$' | sort | uniq | awk '{a[$1]=$1}END{for(i in a)printf i" "a[i]" "}')
 		ifacefunc() {
 			dialog --backtitle "Interface selector" \
 			--title "Multiple network interfaces detected" \
 			--menu "Choose which interface to monitor:" \
-			15 50 $(route -n | egrep UG | egrep -o "[a-zA-Z0-9]*$" | sort | uniq | wc -l) \
+			15 50 $(route -n | egrep UG | egrep -o '[^ ]*$' | sort | uniq | wc -l) \
 			$(echo $ifacemenu) 2>&1 >$(tty)
 		}
 		iface=$(ifacefunc)
 	else
 	# Use default behavior if one interface is found only
-		iface=$(route -n | egrep UG | egrep -o "[a-zA-Z0-9]*$")
+		iface=$(route -n | egrep UG | egrep -o '[^ ]*$')
 	fi
+	timerStart
+	kickAllStatsDown
 	
 	printf "\nruntime network statistics: $(uname -n)\n"
 	printf "network interface: $(echo $iface)\n"


### PR DESCRIPTION
Currently armbianmonitor -n does not detect vlan interfaces correctly.
This is because of an incorrect egrep -o which filters out the parent interface name:
network interface: 100
instead of
network interface: eth0.100

Cascading into:
armbianmonitor: line 1095: eth0. - 0 : syntax error: invalid arithmetic operator (error token is ". - 0 ")

Fixed by changing the egrep logic to filter out the last field of route -n output.

Also fixes a timer issue by moving the timer start to after the interface selection.
time controller adjustment: -2.43
/usr/bin/armbianmonitor: line 1128: read: -2.43: invalid timeout specification