### PR TITLE
Read distro data from our files

### DIFF
--- a/packages/bsp/common/etc/update-motd.d/10-armbian-header
+++ b/packages/bsp/common/etc/update-motd.d/10-armbian-header
@@ -18,7 +18,6 @@ for f in $MOTD_DISABLE; do
 	[[ $f == $THIS_SCRIPT ]] && exit 0
 done
 
-. /etc/os-release
 . /etc/armbian-release
 
 KERNELID=$(uname -r)
@@ -27,7 +26,7 @@ KERNELID=$(uname -r)
 [[ -n $(cat /proc/device-tree/model | tr -d '\000' | grep ODROID | grep Plus) ]] && BOARD_NAME+="+"
 
 TERM=linux toilet -f standard -F metal $(echo $BOARD_NAME | sed 's/Orange Pi/OPi/' | sed 's/NanoPi/NPi/' | sed 's/Banana Pi/BPi/')
-echo -e "Welcome to \e[0;91m${PRETTY_NAME}\x1B[0m with \e[0;91mLinux $KERNELID\x1B[0m\n"
+echo -e "Welcome to \e[0;91mArmbian ${VERSION} ${DISTRIBUTION_CODENAME^}\x1B[0m with \e[0;91mLinux $KERNELID\x1B[0m\n"
 
 # displaying status warnings
 


### PR DESCRIPTION
# Description

When Ubuntu pushes out update it also recreate /etc/os-release file and /etc/issues /etc/issues.net ... Let welcome screen read from our data in any case.

Jira reference number [AR-627]

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-627]: https://armbian.atlassian.net/browse/AR-627