### PR TITLE
Helios64 UPS. System shutdown when battery reach 7.0V.

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -410,6 +410,7 @@ family_tweaks_bsp()
 		# UPS service
 		cp $SRC/packages/bsp/helios64/helios64-ups.service $destination/lib/systemd/system/
 		cp $SRC/packages/bsp/helios64/helios64-ups.timer $destination/lib/systemd/system/
+		install -m 755 $SRC/packages/bsp/helios64/helios64-ups.sh $destination/usr/bin/helios64-ups.sh
 
 	fi
 

--- a/packages/bsp/helios64/helios64-ups.service
+++ b/packages/bsp/helios64/helios64-ups.service
@@ -3,4 +3,4 @@ Description=Helios64 UPS Action
 
 [Service]
 Type=oneshot
-ExecStart=/usr/sbin/poweroff
+ExecStart=/usr/bin/helios64-ups.sh

--- a/packages/bsp/helios64/helios64-ups.sh
+++ b/packages/bsp/helios64/helios64-ups.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+#7.0V 	916 	Recommended threshold to force shutdown system
+TH=916
+
+val=$(cat /sys/bus/iio/devices/iio\:device0/in_voltage2_raw)
+sca=$(cat /sys/bus/iio/devices/iio\:device0/in_voltage_scale)
+adc=$(echo "$val * $sca / 1" | bc)
+
+if [[ $adc -le $TH ]]; then
+	echo "Shutdown"
+	/usr/sbin/poweroff
+fi

--- a/packages/bsp/helios64/helios64-ups.sh
+++ b/packages/bsp/helios64/helios64-ups.sh
@@ -3,11 +3,10 @@
 #7.0V 	916 	Recommended threshold to force shutdown system
 TH=916
 
-val=$(cat /sys/bus/iio/devices/iio\:device0/in_voltage2_raw)
-sca=$(cat /sys/bus/iio/devices/iio\:device0/in_voltage_scale)
+val=$(cat '/sys/bus/iio/devices/iio:device0/in_voltage2_raw')
+sca=$(cat '/sys/bus/iio/devices/iio:device0/in_voltage_scale')
 adc=$(echo "$val * $sca / 1" | bc)
 
-if [[ $adc -le $TH ]]; then
-	echo "Shutdown"
+if [ "$adc" -le $TH ]; then
 	/usr/sbin/poweroff
 fi

--- a/packages/bsp/helios64/helios64-ups.timer
+++ b/packages/bsp/helios64/helios64-ups.timer
@@ -2,8 +2,9 @@
 Description=Helios64 UPS Shutdown timer on power loss
 
 [Timer]
-OnActiveSec=10m
+OnActiveSec=20
 AccuracySec=1s
+OnUnitActiveSec=10
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
Updated Helios64 ups service. Timer fires every 10s and reads battery voltage. System shutdown when voltage drops below ~7.0V. 