### PR TITLE
Add libata.force=noncq to the meson64 kernel command line

### DIFF
--- a/config/bootscripts/boot-meson64.cmd
+++ b/config/bootscripts/boot-meson64.cmd
@@ -112,7 +112,7 @@ else
 	if test "${console}" = "display" || test "${console}" = "both"; then setenv consoleargs "console=ttyAML0,115200 console=tty1"; fi
 	if test "${console}" = "serial"; then setenv consoleargs "console=ttyAML0,115200"; fi
 	if test "${bootlogo}" = "true"; then setenv consoleargs "bootsplash.bootfile=bootsplash.armbian ${consoleargs}"; fi
-	setenv bootargs "root=${rootdev} rootwait rootfstype=${rootfstype} ${consoleargs} consoleblank=0 coherent_pool=2M loglevel=${verbosity} ubootpart=${partuuid} usb-storage.quirks=${usbstoragequirks} ${extraargs} ${extraboardargs}"
+	setenv bootargs "root=${rootdev} rootwait rootfstype=${rootfstype} ${consoleargs} consoleblank=0 coherent_pool=2M loglevel=${verbosity} ubootpart=${partuuid} libata.force=noncq usb-storage.quirks=${usbstoragequirks} ${extraargs} ${extraboardargs}"
 
 	if test "${docker_optimizations}" = "on"; then setenv bootargs "${bootargs} cgroup_enable=memory swapaccount=1"; fi
 


### PR DESCRIPTION
# Description

There seems to be a problem between some kernel versions ans some SATA controllers and disabling NCQ seems to be the best workaround for users having this problem. https://askubuntu.com/questions/133946/are-these-sata-errors-dangerous

Jira reference number [AR-629]

# How Has This Been Tested?

User reported testing - don't have hardware.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] Any dependent changes have been merged and published in downstream modules


[AR-629]: https://armbian.atlassian.net/browse/AR-629