### PR TITLE
fix arithmetic to align filesystem sizes to 16MiB (not 16KiB)

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-resize-filesystem
+++ b/packages/bsp/common/usr/lib/armbian/armbian-resize-filesystem
@@ -50,10 +50,10 @@ do_expand_partition()
 		case $RESIZE_VALUE in
 			*%)
 				# percentage value, we try to use 16MiB to align partitions since this is
-				# the erase block size of more recent SD cards (512 byte sectors, so we use 32
+				# the erase block size of more recent SD cards (512 byte sectors, so we use 32768
 				# as divider and substract 1)
 				local percentage=$(echo $RESIZE_VALUE | tr -c -d '[:digit:]')
-				local lastsector=$(( 32 * $(parted $rootdevicepath unit s print -sm | grep "^$rootdevicepath" | awk -F":" "{printf (\"%0d\", ( \$2 * $percentage / 3200))}") - 1 ))
+				local lastsector=$(( 32768 * $(parted $rootdevicepath unit s print -sm | grep "^$rootdevicepath" | awk -F":" "{printf (\"%0d\", ( \$2 * $percentage / 3276800))}") - 1 ))
 				[[ $lastsector -lt $partend ]] && unset lastsector
 				;;
 			*s)
@@ -64,7 +64,7 @@ do_expand_partition()
 		esac
 		# if SD card is larger than 4GiB then create another partition behind first one(s)
 		if [[ $capacity -ge 5 ]]; then
-			local secondpartition=$(( 32 * $(parted $rootdevicepath unit s print -sm | grep "^$rootdevicepath" | awk -F":" "{printf (\"%0d\", ( \$2 * 99 / 3200))}") -1 ))
+			local secondpartition=$(( 32768 * $(parted $rootdevicepath unit s print -sm | grep "^$rootdevicepath" | awk -F":" "{printf (\"%0d\", ( \$2 * 99 / 3276800))}") -1 ))
 			if [[ $secondpartition -lt $partend ]]; then
 				unset secondpartition
 			fi
@@ -76,7 +76,7 @@ do_expand_partition()
 		# to use Armbian on a card of inappropriate size so he gets what he deserves (at least he
 		# should know what he's doing)
 		if [[ $capacity -lt 5 ]]; then # 4 GiB or less
-			local lastsector=$(( 32 * $(parted $rootdevicepath unit s print -sm | grep "^$rootdevicepath" | awk -F":" "{printf (\"%0d\", ( \$2 * 95 / 3200))}") -1 ))
+			local lastsector=$(( 32768 * $(parted $rootdevicepath unit s print -sm | grep "^$rootdevicepath" | awk -F":" "{printf (\"%0d\", ( \$2 * 95 / 3276800))}") -1 ))
 			if [[ $lastsector -lt $partend ]]; then
 				unset lastsector
 			else
@@ -84,7 +84,7 @@ do_expand_partition()
 			fi
 		elif [[ $capacity -lt 9 ]]; then # 8 GiB or less
 			# Leave 2 percent unpartitioned
-			local lastsector=$(( 32 * $(parted $rootdevicepath unit s print -sm | grep "^$rootdevicepath" | awk -F":" "{printf (\"%0d\", ( \$2 * 98 / 3200))}") -1 ))
+			local lastsector=$(( 32768 * $(parted $rootdevicepath unit s print -sm | grep "^$rootdevicepath" | awk -F":" "{printf (\"%0d\", ( \$2 * 98 / 3276800))}") -1 ))
 			if [[ $lastsector -lt $partend ]]; then
 				unset lastsector
 			else
@@ -92,7 +92,7 @@ do_expand_partition()
 			fi
 		else
 			# Leave 1 percent unpartitioned
-			local lastsector=$(( 32 * $(parted $rootdevicepath unit s print -sm | grep "^$rootdevicepath" | awk -F":" "{printf (\"%0d\", ( \$2 * 99 / 3200))}") -1 ))
+			local lastsector=$(( 32768 * $(parted $rootdevicepath unit s print -sm | grep "^$rootdevicepath" | awk -F":" "{printf (\"%0d\", ( \$2 * 99 / 3276800))}") -1 ))
 			if [[ $lastsector -lt $partend ]]; then
 				unset lastsector
 			else

--- a/packages/bsp/common/usr/sbin/nand-sata-install
+++ b/packages/bsp/common/usr/sbin/nand-sata-install
@@ -444,12 +444,15 @@ format_emmc()
 	QUOTED_DEVICE=$(echo "$1" | sed 's:/:\\\/:g')
 	CAPACITY=$(parted "$1" unit s print -sm | awk -F":" "/^${QUOTED_DEVICE}/ {printf (\"%0d\", \$2 / ( 1024 / \$4 ))}")
 
+	# We use 16MiB to align partitions which may overestimate the erase block
+	# size of a NAND device. Overestimating is harmless. (512 byte
+	# sectors, so we use 32768 as divider and substract 1)
 	if [[ $CAPACITY -lt 4000000 ]]; then
 		# Leave 2 percent unpartitioned when eMMC size is less than 4GB (unlikely)
-		LASTSECTOR=$(( 32 * $(parted "$1" unit s print -sm | awk -F":" "/^${QUOTED_DEVICE}/ {printf (\"%0d\", ( \$2 * 98 / 3200))}") -1 ))
+		LASTSECTOR=$(( 32768 * $(parted "$1" unit s print -sm | awk -F":" "/^${QUOTED_DEVICE}/ {printf (\"%0d\", ( \$2 * 98 / 3276800))}") -1 ))
 	else
 		# Leave 1 percent unpartitioned
-		LASTSECTOR=$(( 32 * $(parted "$1" unit s print -sm | awk -F":" "/^${QUOTED_DEVICE}/ {printf (\"%0d\", ( \$2 * 99 / 3200))}") -1 ))
+		LASTSECTOR=$(( 32768 * $(parted "$1" unit s print -sm | awk -F":" "/^${QUOTED_DEVICE}/ {printf (\"%0d\", ( \$2 * 99 / 3276800))}") -1 ))
 	fi
 
 	parted -s "$1" -- mklabel msdos


### PR DESCRIPTION
# Description

The arithmetic to produce 16MiB-aligned filesystem sizes was actually producing a 16KiB-alignments. The same calculation was corrected in five places.

# How Has This Been Tested?

I created a test version of armbian-resize-filesystem to enable setting a fake size of the  SD card and "kneecapping" it so that no writes were done. I then created another script that iterated the test script over a range of SD card sizes and noted that the writes would have been on 16MiB boundaries.

# Checklist:

- [ ✔️  ] My code follows the style guidelines of this project
- [ ✔️ ] I have performed a self-review of my own code
- [ ✔️ ] I have updated comments in code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
