### PR TITLE
Desktop fails to start if auto login is disabled - lightdm-gtk-greeter bug

### DIFF
--- a/lib/makeboarddeb.sh
+++ b/lib/makeboarddeb.sh
@@ -118,6 +118,8 @@ create_board_package()
 	[ -f "/lib/systemd/system/resize2fs.service" ] && rm /lib/systemd/system/resize2fs.service
 	[ -f "/usr/lib/armbian/apt-updates" ] && rm /usr/lib/armbian/apt-updates
 	[ -f "/usr/lib/armbian/firstrun-config.sh" ] && rm /usr/lib/armbian/firstrun-config.sh
+	# fix for https://bugs.launchpad.net/ubuntu/+source/lightdm-gtk-greeter/+bug/1897491
+	[ -d "/var/lib/lightdm" ] && (chown -R lightdm:lightdm /var/lib/lightdm ; chmod 0750 /var/lib/lightdm)
 	dpkg-divert --quiet --package linux-${RELEASE}-root-${DEB_BRANCH}${BOARD} --add --rename --divert /etc/mpv/mpv-dist.conf /etc/mpv/mpv.conf
 	exit 0
 	EOF

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -336,6 +336,8 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 		elif [ -z "$ConfigureDisplay" ] || [ "$ConfigureDisplay" = "n" ] || [ "$ConfigureDisplay" = "N" ]; then
 			echo -e "\n\e[1m\e[39mNow starting desktop environment...\x1B[0m\n"
 			sleep 1
+			# fix for https://bugs.launchpad.net/ubuntu/+source/lightdm-gtk-greeter/+bug/1897491
+			chown -R lightdm:lightdm /var/lib/lightdm ; chmod 0750 /var/lib/lightdm
 			service lightdm start 2>/dev/null
 			if [ -f /root/.desktop_autologin ]; then
 				rm /root/.desktop_autologin

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -336,8 +336,6 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 		elif [ -z "$ConfigureDisplay" ] || [ "$ConfigureDisplay" = "n" ] || [ "$ConfigureDisplay" = "N" ]; then
 			echo -e "\n\e[1m\e[39mNow starting desktop environment...\x1B[0m\n"
 			sleep 1
-			# fix for https://bugs.launchpad.net/ubuntu/+source/lightdm-gtk-greeter/+bug/1897491
-			chown -R lightdm:lightdm /var/lib/lightdm ; chmod 0750 /var/lib/lightdm
 			service lightdm start 2>/dev/null
 			if [ -f /root/.desktop_autologin ]; then
 				rm /root/.desktop_autologin


### PR DESCRIPTION
# Description

As described here:
https://bugs.launchpad.net/ubuntu/+source/lightdm-gtk-greeter/+bug/1897491

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Jira reference number [AR-632]

# How Has This Been Tested?

- [x] fixing permissions and restarting lightdm
- [x] build Focal xfce desktop with fix present
- [x] build Buster xfce desktop with fix present

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

[AR-632]: https://armbian.atlassian.net/browse/AR-632