### PR TITLE
Add Opi R1+

### DIFF
--- a/config/boards/orangepi-r1plus.conf
+++ b/config/boards/orangepi-r1plus.conf
@@ -1,0 +1,11 @@
+# Rockchip RK3328 quad core 1GB 2xGBE USB2
+BOARD_NAME="Orange Pi R1 Plus"
+BOARDFAMILY="rockchip64"
+BOOTCONFIG="orangepi_r1_plus_rk3328_defconfig"
+KERNEL_TARGET="current"
+DEFAULT_CONSOLE="serial"
+MODULES="g_serial"
+MODULES_BLACKLIST="rockchipdrm analogix_dp dw_mipi_dsi dw_hdmi gpu_sched lima hantro_vpu"
+SERIALCON="ttyS2:1500000,ttyGS0"
+BUILD_DESKTOP="no"
+BOOT_FDT_FILE="rockchip/rk3328-orangepi-r1plus.dtb"

--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -25,7 +25,7 @@ else # rk3308, rk3328
 
 fi
 
-if [[ $BOARD == nanopi-r2s || $BOARD == rockpi-e || $BOARD == nanopineo3 || $BOARD == renegade || $BOARD == station-m1 || $BOARD == z28pro ]]; then
+if [[ $BOARD == nanopi-r2s || $BOARD == rockpi-e || $BOARD == nanopineo3 || $BOARD == renegade || $BOARD == station-m1 || $BOARD == z28pro || $BOARD == orangepi-r1plus ]]; then
 
 	BOOT_USE_BLOBS=yes
 	BOOT_SOC=rk3328

--- a/patch/kernel/rockchip64-current/add-board-orangepi-r1plus.patch
+++ b/patch/kernel/rockchip64-current/add-board-orangepi-r1plus.patch
@@ -1,0 +1,401 @@
+From 683299eb47db3f70cc86248ad93b84da2fcff229 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor.pecovnik@gmail.com>
+Date: Mon, 8 Feb 2021 12:13:55 +0100
+Subject: [PATCH] Add Orangepi R1plus
+
+Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
+---
+ arch/arm64/boot/dts/rockchip/Makefile         |   1 +
+ .../dts/rockchip/rk3328-orangepi-r1plus.dts   | 368 ++++++++++++++++++
+ 2 files changed, 369 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3328-orangepi-r1plus.dts
+
+diff --git a/arch/arm64/boot/dts/rockchip/Makefile b/arch/arm64/boot/dts/rockchip/Makefile
+index 3fb6d6e9f..ced7badb8 100644
+--- a/arch/arm64/boot/dts/rockchip/Makefile
++++ b/arch/arm64/boot/dts/rockchip/Makefile
+@@ -20,6 +20,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3326-odroid-go2.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-a1.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-evb.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-nanopi-r2s.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-orangepi-r1plus.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-rock64.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-roc-cc.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3368-evb-act8846.dtb
+diff --git a/arch/arm64/boot/dts/rockchip/rk3328-orangepi-r1plus.dts b/arch/arm64/boot/dts/rockchip/rk3328-orangepi-r1plus.dts
+new file mode 100644
+index 000000000..2ee07d15a
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3328-orangepi-r1plus.dts
+@@ -0,0 +1,368 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Based on Nanopi R2S
++ */
++
++/dts-v1/;
++
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/gpio/gpio.h>
++#include "rk3328.dtsi"
++
++/ {
++	model = "Xunlong Orange Pi R1 Plus";
++	compatible = "rockchip,rk3328";
++
++	chosen {
++		stdout-path = "serial2:1500000n8";
++	};
++
++	gmac_clk: gmac-clock {
++		compatible = "fixed-clock";
++		clock-frequency = <125000000>;
++		clock-output-names = "gmac_clkin";
++		#clock-cells = <0>;
++	};
++
++	keys {
++		compatible = "gpio-keys";
++		pinctrl-0 = <&reset_button_pin>;
++		pinctrl-names = "default";
++
++		reset {
++			label = "reset";
++			gpios = <&gpio0 RK_PA0 GPIO_ACTIVE_LOW>;
++			linux,code = <KEY_RESTART>;
++			debounce-interval = <50>;
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++		pinctrl-0 = <&lan_led_pin>,  <&sys_led_pin>, <&wan_led_pin>;
++		pinctrl-names = "default";
++
++		lan_led: led-0 {
++			gpios = <&gpio2 RK_PB7 GPIO_ACTIVE_HIGH>;
++			label = "nanopi-r2s:green:lan";
++		};
++
++		sys_led: led-1 {
++			gpios = <&gpio0 RK_PA2 GPIO_ACTIVE_HIGH>;
++			label = "nanopi-r2s:red:sys";
++		};
++
++		wan_led: led-2 {
++			gpios = <&gpio2 RK_PC2 GPIO_ACTIVE_HIGH>;
++			label = "nanopi-r2s:green:wan";
++		};
++	};
++
++	vcc_io_sdio: sdmmcio-regulator {
++		compatible = "regulator-gpio";
++		enable-active-high;
++		gpios = <&gpio1 RK_PD4 GPIO_ACTIVE_HIGH>;
++		pinctrl-0 = <&sdio_vcc_pin>;
++		pinctrl-names = "default";
++		regulator-name = "vcc_io_sdio";
++		regulator-always-on;
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <3300000>;
++		regulator-settling-time-us = <5000>;
++		regulator-type = "voltage";
++		startup-delay-us = <2000>;
++		states = <1800000 0x1
++			  3300000 0x0>;
++		vin-supply = <&vcc_io_33>;
++	};
++
++	vcc_sd: sdmmc-regulator {
++		compatible = "regulator-fixed";
++		gpio = <&gpio0 RK_PD6 GPIO_ACTIVE_LOW>;
++		pinctrl-0 = <&sdmmc0m1_pin>;
++		pinctrl-names = "default";
++		regulator-name = "vcc_sd";
++		regulator-boot-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc_io_33>;
++	};
++
++	vdd_5v: vdd-5v {
++		compatible = "regulator-fixed";
++		regulator-name = "vdd_5v";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++	};
++};
++
++&cpu0 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&cpu1 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&cpu2 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&cpu3 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&gmac2io {
++	assigned-clocks = <&cru SCLK_MAC2IO>, <&cru SCLK_MAC2IO_EXT>;
++	assigned-clock-parents = <&gmac_clk>, <&gmac_clk>;
++	clock_in_out = "input";
++	phy-handle = <&rtl8211e>;
++	phy-mode = "rgmii";
++	phy-supply = <&vcc_io_33>;
++	pinctrl-0 = <&rgmiim1_pins>;
++	pinctrl-names = "default";
++	rx_delay = <0x18>;
++	snps,aal;
++	tx_delay = <0x24>;
++	status = "okay";
++
++	mdio {
++		compatible = "snps,dwmac-mdio";
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		rtl8211e: ethernet-phy@1 {
++			reg = <1>;
++			pinctrl-0 = <&eth_phy_reset_pin>;
++			pinctrl-names = "default";
++			reset-assert-us = <10000>;
++			reset-deassert-us = <50000>;
++			reset-gpios = <&gpio1 RK_PC2 GPIO_ACTIVE_LOW>;
++		};
++	};
++};
++
++&i2c1 {
++	status = "okay";
++
++	rk805: pmic@18 {
++		compatible = "rockchip,rk805";
++		reg = <0x18>;
++		interrupt-parent = <&gpio1>;
++		interrupts = <24 IRQ_TYPE_LEVEL_LOW>;
++		#clock-cells = <1>;
++		clock-output-names = "xin32k", "rk805-clkout2";
++		gpio-controller;
++		#gpio-cells = <2>;
++		pinctrl-0 = <&pmic_int_l>;
++		pinctrl-names = "default";
++		rockchip,system-power-controller;
++		wakeup-source;
++
++		vcc1-supply = <&vdd_5v>;
++		vcc2-supply = <&vdd_5v>;
++		vcc3-supply = <&vdd_5v>;
++		vcc4-supply = <&vdd_5v>;
++		vcc5-supply = <&vcc_io_33>;
++		vcc6-supply = <&vdd_5v>;
++
++		regulators {
++			vdd_log: DCDC_REG1 {
++				regulator-name = "vdd_log";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <712500>;
++				regulator-max-microvolt = <1450000>;
++				regulator-ramp-delay = <12500>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1000000>;
++				};
++			};
++
++			vdd_arm: DCDC_REG2 {
++				regulator-name = "vdd_arm";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <712500>;
++				regulator-max-microvolt = <1450000>;
++				regulator-ramp-delay = <12500>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <950000>;
++				};
++			};
++
++			vcc_ddr: DCDC_REG3 {
++				regulator-name = "vcc_ddr";
++				regulator-always-on;
++				regulator-boot-on;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++				};
++			};
++
++			vcc_io_33: DCDC_REG4 {
++				regulator-name = "vcc_io_33";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++				};
++			};
++
++			vcc_18: LDO_REG1 {
++				regulator-name = "vcc_18";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vcc18_emmc: LDO_REG2 {
++				regulator-name = "vcc18_emmc";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vdd_10: LDO_REG3 {
++				regulator-name = "vdd_10";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1000000>;
++				regulator-max-microvolt = <1000000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1000000>;
++				};
++			};
++		};
++	};
++};
++
++&io_domains {
++	pmuio-supply = <&vcc_io_33>;
++	vccio1-supply = <&vcc_io_33>;
++	vccio2-supply = <&vcc18_emmc>;
++	vccio3-supply = <&vcc_io_sdio>;
++	vccio4-supply = <&vcc_18>;
++	vccio5-supply = <&vcc_io_33>;
++	vccio6-supply = <&vcc_io_33>;
++	status = "okay";
++};
++
++&pinctrl {
++	button {
++		reset_button_pin: reset-button-pin {
++			rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	ethernet-phy {
++		eth_phy_reset_pin: eth-phy-reset-pin {
++			rockchip,pins = <1 RK_PC2 RK_FUNC_GPIO &pcfg_pull_down>;
++		};
++	};
++
++	leds {
++		lan_led_pin: lan-led-pin {
++			rockchip,pins = <2 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		sys_led_pin: sys-led-pin {
++			rockchip,pins = <0 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		wan_led_pin: wan-led-pin {
++			rockchip,pins = <2 RK_PC2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	pmic {
++		pmic_int_l: pmic-int-l {
++			rockchip,pins = <1 RK_PD0 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	sd {
++		sdio_vcc_pin: sdio-vcc-pin {
++			rockchip,pins = <1 RK_PD4 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++};
++
++&pwm2 {
++	status = "okay";
++};
++
++&sdmmc {
++	bus-width = <4>;
++	cap-sd-highspeed;
++	disable-wp;
++	pinctrl-0 = <&sdmmc0_clk>, <&sdmmc0_cmd>, <&sdmmc0_dectn>, <&sdmmc0_bus4>;
++	pinctrl-names = "default";
++	sd-uhs-sdr12;
++	sd-uhs-sdr25;
++	sd-uhs-sdr50;
++	sd-uhs-sdr104;
++	vmmc-supply = <&vcc_sd>;
++	vqmmc-supply = <&vcc_io_sdio>;
++	status = "okay";
++};
++
++&tsadc {
++	rockchip,hw-tshut-mode = <0>;
++	rockchip,hw-tshut-polarity = <0>;
++	status = "okay";
++};
++
++&u2phy {
++	status = "okay";
++};
++
++&u2phy_host {
++	status = "okay";
++};
++
++&u2phy_otg {
++	status = "okay";
++};
++
++&uart2 {
++	status = "okay";
++};
++
++&usb20_otg {
++	status = "okay";
++	dr_mode = "host";
++};
++
++&usb_host0_ehci {
++	status = "okay";
++};
++
++&usb_host0_ohci {
++	status = "okay";
++};
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/kernel/rockchip64-dev/add-board-orangepi-r1plus.patch
+++ b/patch/kernel/rockchip64-dev/add-board-orangepi-r1plus.patch
@@ -1,0 +1,401 @@
+From 683299eb47db3f70cc86248ad93b84da2fcff229 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor.pecovnik@gmail.com>
+Date: Mon, 8 Feb 2021 12:13:55 +0100
+Subject: [PATCH] Add Orangepi R1plus
+
+Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
+---
+ arch/arm64/boot/dts/rockchip/Makefile         |   1 +
+ .../dts/rockchip/rk3328-orangepi-r1plus.dts   | 368 ++++++++++++++++++
+ 2 files changed, 369 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3328-orangepi-r1plus.dts
+
+diff --git a/arch/arm64/boot/dts/rockchip/Makefile b/arch/arm64/boot/dts/rockchip/Makefile
+index 3fb6d6e9f..ced7badb8 100644
+--- a/arch/arm64/boot/dts/rockchip/Makefile
++++ b/arch/arm64/boot/dts/rockchip/Makefile
+@@ -20,6 +20,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3326-odroid-go2.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-a1.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-evb.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-nanopi-r2s.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-orangepi-r1plus.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-rock64.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-roc-cc.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3368-evb-act8846.dtb
+diff --git a/arch/arm64/boot/dts/rockchip/rk3328-orangepi-r1plus.dts b/arch/arm64/boot/dts/rockchip/rk3328-orangepi-r1plus.dts
+new file mode 100644
+index 000000000..2ee07d15a
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3328-orangepi-r1plus.dts
+@@ -0,0 +1,368 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Based on Nanopi R2S
++ */
++
++/dts-v1/;
++
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/gpio/gpio.h>
++#include "rk3328.dtsi"
++
++/ {
++	model = "Xunlong Orange Pi R1 Plus";
++	compatible = "rockchip,rk3328";
++
++	chosen {
++		stdout-path = "serial2:1500000n8";
++	};
++
++	gmac_clk: gmac-clock {
++		compatible = "fixed-clock";
++		clock-frequency = <125000000>;
++		clock-output-names = "gmac_clkin";
++		#clock-cells = <0>;
++	};
++
++	keys {
++		compatible = "gpio-keys";
++		pinctrl-0 = <&reset_button_pin>;
++		pinctrl-names = "default";
++
++		reset {
++			label = "reset";
++			gpios = <&gpio0 RK_PA0 GPIO_ACTIVE_LOW>;
++			linux,code = <KEY_RESTART>;
++			debounce-interval = <50>;
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++		pinctrl-0 = <&lan_led_pin>,  <&sys_led_pin>, <&wan_led_pin>;
++		pinctrl-names = "default";
++
++		lan_led: led-0 {
++			gpios = <&gpio2 RK_PB7 GPIO_ACTIVE_HIGH>;
++			label = "nanopi-r2s:green:lan";
++		};
++
++		sys_led: led-1 {
++			gpios = <&gpio0 RK_PA2 GPIO_ACTIVE_HIGH>;
++			label = "nanopi-r2s:red:sys";
++		};
++
++		wan_led: led-2 {
++			gpios = <&gpio2 RK_PC2 GPIO_ACTIVE_HIGH>;
++			label = "nanopi-r2s:green:wan";
++		};
++	};
++
++	vcc_io_sdio: sdmmcio-regulator {
++		compatible = "regulator-gpio";
++		enable-active-high;
++		gpios = <&gpio1 RK_PD4 GPIO_ACTIVE_HIGH>;
++		pinctrl-0 = <&sdio_vcc_pin>;
++		pinctrl-names = "default";
++		regulator-name = "vcc_io_sdio";
++		regulator-always-on;
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <3300000>;
++		regulator-settling-time-us = <5000>;
++		regulator-type = "voltage";
++		startup-delay-us = <2000>;
++		states = <1800000 0x1
++			  3300000 0x0>;
++		vin-supply = <&vcc_io_33>;
++	};
++
++	vcc_sd: sdmmc-regulator {
++		compatible = "regulator-fixed";
++		gpio = <&gpio0 RK_PD6 GPIO_ACTIVE_LOW>;
++		pinctrl-0 = <&sdmmc0m1_pin>;
++		pinctrl-names = "default";
++		regulator-name = "vcc_sd";
++		regulator-boot-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc_io_33>;
++	};
++
++	vdd_5v: vdd-5v {
++		compatible = "regulator-fixed";
++		regulator-name = "vdd_5v";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++	};
++};
++
++&cpu0 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&cpu1 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&cpu2 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&cpu3 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&gmac2io {
++	assigned-clocks = <&cru SCLK_MAC2IO>, <&cru SCLK_MAC2IO_EXT>;
++	assigned-clock-parents = <&gmac_clk>, <&gmac_clk>;
++	clock_in_out = "input";
++	phy-handle = <&rtl8211e>;
++	phy-mode = "rgmii";
++	phy-supply = <&vcc_io_33>;
++	pinctrl-0 = <&rgmiim1_pins>;
++	pinctrl-names = "default";
++	rx_delay = <0x18>;
++	snps,aal;
++	tx_delay = <0x24>;
++	status = "okay";
++
++	mdio {
++		compatible = "snps,dwmac-mdio";
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		rtl8211e: ethernet-phy@1 {
++			reg = <1>;
++			pinctrl-0 = <&eth_phy_reset_pin>;
++			pinctrl-names = "default";
++			reset-assert-us = <10000>;
++			reset-deassert-us = <50000>;
++			reset-gpios = <&gpio1 RK_PC2 GPIO_ACTIVE_LOW>;
++		};
++	};
++};
++
++&i2c1 {
++	status = "okay";
++
++	rk805: pmic@18 {
++		compatible = "rockchip,rk805";
++		reg = <0x18>;
++		interrupt-parent = <&gpio1>;
++		interrupts = <24 IRQ_TYPE_LEVEL_LOW>;
++		#clock-cells = <1>;
++		clock-output-names = "xin32k", "rk805-clkout2";
++		gpio-controller;
++		#gpio-cells = <2>;
++		pinctrl-0 = <&pmic_int_l>;
++		pinctrl-names = "default";
++		rockchip,system-power-controller;
++		wakeup-source;
++
++		vcc1-supply = <&vdd_5v>;
++		vcc2-supply = <&vdd_5v>;
++		vcc3-supply = <&vdd_5v>;
++		vcc4-supply = <&vdd_5v>;
++		vcc5-supply = <&vcc_io_33>;
++		vcc6-supply = <&vdd_5v>;
++
++		regulators {
++			vdd_log: DCDC_REG1 {
++				regulator-name = "vdd_log";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <712500>;
++				regulator-max-microvolt = <1450000>;
++				regulator-ramp-delay = <12500>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1000000>;
++				};
++			};
++
++			vdd_arm: DCDC_REG2 {
++				regulator-name = "vdd_arm";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <712500>;
++				regulator-max-microvolt = <1450000>;
++				regulator-ramp-delay = <12500>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <950000>;
++				};
++			};
++
++			vcc_ddr: DCDC_REG3 {
++				regulator-name = "vcc_ddr";
++				regulator-always-on;
++				regulator-boot-on;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++				};
++			};
++
++			vcc_io_33: DCDC_REG4 {
++				regulator-name = "vcc_io_33";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++				};
++			};
++
++			vcc_18: LDO_REG1 {
++				regulator-name = "vcc_18";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vcc18_emmc: LDO_REG2 {
++				regulator-name = "vcc18_emmc";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vdd_10: LDO_REG3 {
++				regulator-name = "vdd_10";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1000000>;
++				regulator-max-microvolt = <1000000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1000000>;
++				};
++			};
++		};
++	};
++};
++
++&io_domains {
++	pmuio-supply = <&vcc_io_33>;
++	vccio1-supply = <&vcc_io_33>;
++	vccio2-supply = <&vcc18_emmc>;
++	vccio3-supply = <&vcc_io_sdio>;
++	vccio4-supply = <&vcc_18>;
++	vccio5-supply = <&vcc_io_33>;
++	vccio6-supply = <&vcc_io_33>;
++	status = "okay";
++};
++
++&pinctrl {
++	button {
++		reset_button_pin: reset-button-pin {
++			rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	ethernet-phy {
++		eth_phy_reset_pin: eth-phy-reset-pin {
++			rockchip,pins = <1 RK_PC2 RK_FUNC_GPIO &pcfg_pull_down>;
++		};
++	};
++
++	leds {
++		lan_led_pin: lan-led-pin {
++			rockchip,pins = <2 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		sys_led_pin: sys-led-pin {
++			rockchip,pins = <0 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		wan_led_pin: wan-led-pin {
++			rockchip,pins = <2 RK_PC2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	pmic {
++		pmic_int_l: pmic-int-l {
++			rockchip,pins = <1 RK_PD0 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	sd {
++		sdio_vcc_pin: sdio-vcc-pin {
++			rockchip,pins = <1 RK_PD4 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++};
++
++&pwm2 {
++	status = "okay";
++};
++
++&sdmmc {
++	bus-width = <4>;
++	cap-sd-highspeed;
++	disable-wp;
++	pinctrl-0 = <&sdmmc0_clk>, <&sdmmc0_cmd>, <&sdmmc0_dectn>, <&sdmmc0_bus4>;
++	pinctrl-names = "default";
++	sd-uhs-sdr12;
++	sd-uhs-sdr25;
++	sd-uhs-sdr50;
++	sd-uhs-sdr104;
++	vmmc-supply = <&vcc_sd>;
++	vqmmc-supply = <&vcc_io_sdio>;
++	status = "okay";
++};
++
++&tsadc {
++	rockchip,hw-tshut-mode = <0>;
++	rockchip,hw-tshut-polarity = <0>;
++	status = "okay";
++};
++
++&u2phy {
++	status = "okay";
++};
++
++&u2phy_host {
++	status = "okay";
++};
++
++&u2phy_otg {
++	status = "okay";
++};
++
++&uart2 {
++	status = "okay";
++};
++
++&usb20_otg {
++	status = "okay";
++	dr_mode = "host";
++};
++
++&usb_host0_ehci {
++	status = "okay";
++};
++
++&usb_host0_ohci {
++	status = "okay";
++};
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/u-boot/u-boot-rockchip64-mainline/add-orangepi-r1plus.patch
+++ b/patch/u-boot/u-boot-rockchip64-mainline/add-orangepi-r1plus.patch
@@ -1,0 +1,936 @@
+From 378c8c45d4e4ae19c81d2c7ea178428ccdd97b5b Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor.pecovnik@gmail.com>
+Date: Mon, 8 Feb 2021 11:55:27 +0100
+Subject: [PATCH] Patching something
+
+Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
+---
+ arch/arm/dts/Makefile                         |   1 +
+ .../dts/rk3328-orangepi-r1plus-common.dtsi    | 623 ++++++++++++++++++
+ .../dts/rk3328-orangepi-r1plus-u-boot.dtsi    |  16 +
+ arch/arm/dts/rk3328-orangepi-r1plus.dts       | 145 ++++
+ configs/orangepi_r1_plus_rk3328_defconfig     |  95 +++
+ 5 files changed, 880 insertions(+)
+ create mode 100644 arch/arm/dts/rk3328-orangepi-r1plus-common.dtsi
+ create mode 100644 arch/arm/dts/rk3328-orangepi-r1plus-u-boot.dtsi
+ create mode 100644 arch/arm/dts/rk3328-orangepi-r1plus.dts
+ create mode 100644 configs/orangepi_r1_plus_rk3328_defconfig
+
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index 06ccc03e..a2657ebe 100644
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -109,6 +109,7 @@ dtb-$(CONFIG_ROCKCHIP_RK3308) += \
+ dtb-$(CONFIG_ROCKCHIP_RK3328) += \
+ 	rk3328-evb.dtb \
+ 	rk3328-nanopi-r2-rev00.dtb \
++	rk3328-orangepi-r1plus.dtb \
+ 	rk3328-roc-cc.dtb \
+ 	rk3328-rock64.dtb \
+ 	rk3328-rock-pi-e.dtb
+diff --git a/arch/arm/dts/rk3328-orangepi-r1plus-common.dtsi b/arch/arm/dts/rk3328-orangepi-r1plus-common.dtsi
+new file mode 100644
+index 00000000..5574cb7c
+--- /dev/null
++++ b/arch/arm/dts/rk3328-orangepi-r1plus-common.dtsi
+@@ -0,0 +1,623 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2018 FriendlyElec Computer Tech. Co., Ltd.
++ * (http://www.friendlyarm.com)
++ *
++ * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd
++ */
++
++/dts-v1/;
++/*#include "rk3328-dram-default-timing.dtsi"*/
++#include "rk3328.dtsi"
++
++/ {
++	model = "OrangePi boards based on Rockchip RK3328";
++	compatible = "rockchip,rk3328";
++
++	aliases {
++/*		ethernet1 = &r8153;*/
++	};
++
++	chosen {
++		bootargs = "swiotlb=1 coherent_pool=1m consoleblank=0";
++		stdout-path = "serial2:1500000n8";
++	};
++
++	gmac_clkin: external-gmac-clock {
++		compatible = "fixed-clock";
++		clock-frequency = <125000000>;
++		clock-output-names = "gmac_clkin";
++		#clock-cells = <0>;
++	};
++
++	mach: board {
++		compatible = "orangepi,board";
++		machine = "ORANGEPI-R1PLUS";
++		hwrev = <255>;
++		model = "Orange Pi R1 Plus Series";
++		nvmem-cells = <&efuse_id>, <&efuse_cpu_version>;
++		nvmem-cell-names = "id", "cpu-version";
++	};
++
++	leds: gpio-leds {
++		compatible = "gpio-leds";
++		pinctrl-names = "default";
++		pinctrl-0 =<&leds_gpio>;
++		status = "disabled";
++
++		led@1 {
++			gpios = <&gpio0 RK_PA2 GPIO_ACTIVE_HIGH>;
++			label = "status_led";
++			linux,default-trigger = "heartbeat";
++			linux,default-trigger-delay-ms = <0>;
++		};
++	};
++
++	sdio_pwrseq: sdio-pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		clocks = <&rk805 1>;
++		clock-names = "ext_clock";
++		pinctrl-names = "default";
++		pinctrl-0 = <&wifi_enable_h>;
++
++		/*
++		 * On the module itself this is one of these (depending
++		 * on the actual card populated):
++		 * - SDIO_RESET_L_WL_REG_ON
++		 * - PDN (power down when low)
++		 */
++		reset-gpios = <&gpio3 RK_PB0 GPIO_ACTIVE_LOW>;
++	};
++
++/*	sdmmc_ext: dwmmc@ff5f0000 {
++		compatible = "rockchip,rk3328-dw-mshc", "rockchip,rk3288-dw-mshc";
++		reg = <0x0 0xff5f0000 0x0 0x4000>;
++		clock-freq-min-max = <400000 150000000>;
++		clocks = <&cru HCLK_SDMMC_EXT>, <&cru SCLK_SDMMC_EXT>,
++			 <&cru SCLK_SDMMC_EXT_DRV>, <&cru SCLK_SDMMC_EXT_SAMPLE>;
++		clock-names = "biu", "ciu", "ciu-drv", "ciu-sample";
++		fifo-depth = <0x100>;
++		interrupts = <GIC_SPI 4 IRQ_TYPE_LEVEL_HIGH>;
++		status = "disabled";
++	};*/
++
++	vcc_sd: sdmmc-regulator {
++		compatible = "regulator-fixed";
++		gpio = <&gpio0 30 GPIO_ACTIVE_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&sdmmc0m1_gpio>;
++		regulator-name = "vcc_sd";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc_io>;
++	};
++
++	vccio_sd: sdmmcio-regulator {
++		compatible = "regulator-gpio";
++		gpios = <&gpio1 RK_PD4 GPIO_ACTIVE_HIGH>;
++		states = <1800000 0x1
++			  3300000 0x0>;
++		regulator-name = "vccio_sd";
++		regulator-type = "voltage";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <3300000>;
++		regulator-always-on;
++		vin-supply = <&vcc_io>;
++		startup-delay-us = <2000>;
++		regulator-settling-time-us = <5000>;
++		enable-active-high;
++		status = "disabled";
++	};
++
++	vcc_sys: vcc-sys {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++	};
++
++	vcc_phy: vcc-phy-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_phy";
++		regulator-always-on;
++		regulator-boot-on;
++	};
++
++	vcc_host_vbus: host-vbus-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_host_vbus";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++	};
++
++	dfi: dfi@ff790000 {
++		reg = <0x00 0xff790000 0x00 0x400>;
++		compatible = "rockchip,rk3328-dfi";
++		rockchip,grf = <&grf>;
++		status = "disabled";
++	};
++
++/*	dmc: dmc {
++		compatible = "rockchip,rk3328-dmc";
++		devfreq-events = <&dfi>;
++		clocks = <&cru SCLK_DDRCLK>;
++		clock-names = "dmc_clk";
++		operating-points-v2 = <&dmc_opp_table>;
++		ddr_timing = <&ddr_timing>;
++		upthreshold = <40>;
++		downdifferential = <20>;
++		auto-min-freq = <786000>;
++		auto-freq-en = <0>;
++		#cooling-cells = <2>;
++		status = "disabled";
++
++		ddr_power_model: ddr_power_model {
++			compatible = "ddr_power_model";
++			dynamic-power-coefficient = <120>;
++			static-power-coefficient = <200>;
++			ts = <32000 4700 (-80) 2>;
++			thermal-zone = "soc-thermal";
++		};
++	};
++
++	dmc_opp_table: dmc-opp-table {
++		compatible = "operating-points-v2";
++
++		rockchip,leakage-voltage-sel = <
++			1   10    0
++			11  254   1
++		>;
++		nvmem-cells = <&logic_leakage>;
++		nvmem-cell-names = "ddr_leakage";
++
++		opp-786000000 {
++			opp-hz = /bits/ 64 <786000000>;
++			opp-microvolt = <1075000>;
++			opp-microvolt-L0 = <1075000>;
++			opp-microvolt-L1 = <1050000>;
++		};
++		opp-798000000 {
++			opp-hz = /bits/ 64 <798000000>;
++			opp-microvolt = <1075000>;
++			opp-microvolt-L0 = <1075000>;
++			opp-microvolt-L1 = <1050000>;
++		};
++		opp-840000000 {
++			opp-hz = /bits/ 64 <840000000>;
++			opp-microvolt = <1075000>;
++			opp-microvolt-L0 = <1075000>;
++			opp-microvolt-L1 = <1050000>;
++		};
++		opp-924000000 {
++			opp-hz = /bits/ 64 <924000000>;
++			opp-microvolt = <1100000>;
++			opp-microvolt-L0 = <1100000>;
++			opp-microvolt-L1 = <1075000>;
++		};
++		opp-1056000000 {
++			opp-hz = /bits/ 64 <1056000000>;
++			opp-microvolt = <1175000>;
++			opp-microvolt-L0 = <1175000>;
++			opp-microvolt-L1 = <1150000>;
++		};
++	};
++*/};
++
++&cpu0 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&dfi {
++	status = "okay";
++};
++
++/*&dmc {
++	center-supply = <&vdd_logic>;
++	status = "okay";
++};*/
++
++&emmc {
++	bus-width = <8>;
++	cap-mmc-highspeed;
++	max-frequency = <150000000>;
++	mmc-hs200-1_8v;
++	no-sd;
++	non-removable;
++	pinctrl-names = "default";
++	pinctrl-0 = <&emmc_clk &emmc_cmd &emmc_bus8>;
++	vmmc-supply = <&vcc_io>;
++	vqmmc-supply = <&vcc18_emmc>;
++	status = "okay";
++};
++
++&gmac2phy {
++	phy-supply = <&vcc_phy>;
++	clock_in_out = "output";
++	assigned-clocks = <&cru SCLK_MAC2PHY_SRC>;
++	assigned-clock-rate = <50000000>;
++	assigned-clocks = <&cru SCLK_MAC2PHY>;
++	assigned-clock-parents = <&cru SCLK_MAC2PHY_SRC>;
++	status = "disabled";
++};
++
++&gmac2io {
++	assigned-clocks = <&cru SCLK_MAC2IO>, <&cru SCLK_MAC2IO_EXT>;
++	assigned-clock-parents = <&gmac_clkin>, <&gmac_clkin>;
++	clock_in_out = "input";
++	pinctrl-names = "default";
++	pinctrl-0 = <&rgmiim1_pins>;
++	phy-handle = <&rtl8211e>;
++	phy-mode = "rgmii";
++	phy-supply = <&vcc_phy>;
++	snps,reset-active-low;
++	snps,reset-delays-us = <0 10000 30000>;
++	snps,reset-gpio = <&gpio1 RK_PC2 GPIO_ACTIVE_LOW>;
++	snps,aal;
++	snps,rxpbl = <0x4>;
++	snps,txpbl = <0x4>;
++	tx_delay = <0x24>;
++	rx_delay = <0x18>;
++	status = "okay";
++
++	mdio {
++		compatible = "snps,dwmac-mdio";
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		rtl8211e: phy@0 {
++			reg = <0>;
++			reset-assert-us = <10000>;
++			reset-deassert-us = <30000>;
++			/* reset-gpios = <&gpio1 RK_PC2 GPIO_ACTIVE_LOW>; */
++		};
++	};
++};
++
++&i2c1 {
++	status = "okay";
++
++	rk805: rk805@18 {
++		compatible = "rockchip,rk805";
++		reg = <0x18>;
++		interrupt-parent = <&gpio2>;
++		interrupts = <6 IRQ_TYPE_LEVEL_LOW>;
++		#clock-cells = <1>;
++		clock-output-names = "xin32k", "rk805-clkout2";
++		gpio-controller;
++		#gpio-cells = <2>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pmic_int_l>;
++		rockchip,system-power-controller;
++		wakeup-source;
++
++		vcc1-supply = <&vcc_sys>;
++		vcc2-supply = <&vcc_sys>;
++		vcc3-supply = <&vcc_sys>;
++		vcc4-supply = <&vcc_sys>;
++		vcc5-supply = <&vcc_io>;
++		vcc6-supply = <&vcc_io>;
++
++		regulators {
++			vdd_logic: DCDC_REG1 {
++				regulator-name = "vdd_logic";
++				regulator-init-microvolt = <1075000>;
++				regulator-min-microvolt = <712500>;
++				regulator-max-microvolt = <1450000>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1000000>;
++				};
++			};
++
++			vdd_arm: DCDC_REG2 {
++				regulator-name = "vdd_arm";
++				regulator-init-microvolt = <1225000>;
++				regulator-min-microvolt = <712500>;
++				regulator-max-microvolt = <1450000>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <950000>;
++				};
++			};
++
++			vcc_ddr: DCDC_REG3 {
++				regulator-name = "vcc_ddr";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++				};
++			};
++
++			vcc_io: DCDC_REG4 {
++				regulator-name = "vcc_io";
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++				};
++			};
++
++			vcc_18: LDO_REG1 {
++				regulator-name = "vcc_18";
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vcc18_emmc: LDO_REG2 {
++				regulator-name = "vcc18_emmc";
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vdd_10: LDO_REG3 {
++				regulator-name = "vdd_10";
++				regulator-min-microvolt = <1000000>;
++				regulator-max-microvolt = <1000000>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1000000>;
++				};
++			};
++		};
++	};
++};
++
++&io_domains {
++	status = "okay";
++
++	vccio1-supply = <&vcc_io>;
++	vccio2-supply = <&vcc18_emmc>;
++	vccio3-supply = <&vcc_io>;
++	vccio4-supply = <&vcc_io>;
++	vccio5-supply = <&vcc_io>;
++	vccio6-supply = <&vcc_18>;
++	pmuio-supply = <&vcc_io>;
++};
++
++&pinctrl {
++	pmic {
++		pmic_int_l: pmic-int-l {
++			rockchip,pins = <2 RK_PA6 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	sdio-pwrseq {
++		wifi_enable_h: wifi-enable-h {
++			rockchip,pins = <3 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	sdmmc0 {
++		sdmmc0_clk: sdmmc0-clk {
++			rockchip,pins = <1 RK_PA6 1 &pcfg_pull_none_4ma>;
++		};
++
++		sdmmc0_cmd: sdmmc0-cmd {
++			rockchip,pins = <1 RK_PA4 1 &pcfg_pull_up_4ma>;
++		};
++
++		sdmmc0_dectn: sdmmc0-dectn {
++			rockchip,pins = <1 RK_PA5 1 &pcfg_pull_up_4ma>;
++		};
++
++		sdmmc0_bus4: sdmmc0-bus4 {
++			rockchip,pins =
++				<1 RK_PA0 1 &pcfg_pull_up_4ma>,
++				<1 RK_PA1 1 &pcfg_pull_up_4ma>,
++				<1 RK_PA2 1 &pcfg_pull_up_4ma>,
++				<1 RK_PA3 1 &pcfg_pull_up_4ma>;
++		};
++	};
++
++	sdmmc0ext {
++		sdmmc0ext_clk: sdmmc0ext-clk {
++			rockchip,pins = <3 RK_PA2 3 &pcfg_pull_none_2ma>;
++		};
++
++		sdmmc0ext_cmd: sdmmc0ext-cmd {
++			rockchip,pins = <3 RK_PA0 3 &pcfg_pull_up_2ma>;
++		};
++
++		sdmmc0ext_bus4: sdmmc0ext-bus4 {
++			rockchip,pins =
++				<3 RK_PA4 3 &pcfg_pull_up_2ma>,
++				<3 RK_PA5 3 &pcfg_pull_up_2ma>,
++				<3 RK_PA6 3 &pcfg_pull_up_2ma>,
++				<3 RK_PA7 3 &pcfg_pull_up_2ma>;
++		};
++	};
++
++	gmac-1 {
++		rgmiim1_pins: rgmiim1-pins {
++			rockchip,pins =
++				/* mac_txclk */
++				<1 RK_PB4 2 &pcfg_pull_none_4ma>,
++				/* mac_rxclk */
++				<1 RK_PB5 2 &pcfg_pull_none>,
++				/* mac_mdio */
++				<1 RK_PC3 2 &pcfg_pull_none_2ma>,
++				/* mac_txen */
++				<1 RK_PD1 2 &pcfg_pull_none_4ma>,
++				/* mac_clk */
++				<1 RK_PC5 2 &pcfg_pull_none_2ma>,
++				/* mac_rxdv */
++				<1 RK_PC6 2 &pcfg_pull_none>,
++				/* mac_mdc */
++				<1 RK_PC7 2 &pcfg_pull_none_2ma>,
++				/* mac_rxd1 */
++				<1 RK_PB2 2 &pcfg_pull_none>,
++				/* mac_rxd0 */
++				<1 RK_PB3 2 &pcfg_pull_none>,
++				/* mac_txd1 */
++				<1 RK_PB0 2 &pcfg_pull_none_4ma>,
++				/* mac_txd0 */
++				<1 RK_PB1 2 &pcfg_pull_none_4ma>,
++				/* mac_rxd3 */
++				<1 RK_PB6 2 &pcfg_pull_none>,
++				/* mac_rxd2 */
++				<1 RK_PB7 2 &pcfg_pull_none>,
++				/* mac_txd3 */
++				<1 RK_PC0 2 &pcfg_pull_none_4ma>,
++				/* mac_txd2 */
++				<1 RK_PC1 2 &pcfg_pull_none_4ma>,
++
++				/* mac_txclk */
++				<0 RK_PB0 1 &pcfg_pull_none>,
++				/* mac_txen */
++				<0 RK_PB4 1 &pcfg_pull_none>,
++				/* mac_clk */
++				<0 RK_PD0 1 &pcfg_pull_none>,
++				/* mac_txd1 */
++				<0 RK_PC0 1 &pcfg_pull_none>,
++				/* mac_txd0 */
++				<0 RK_PC1 1 &pcfg_pull_none>,
++				/* mac_txd3 */
++				<0 RK_PC7 1 &pcfg_pull_none>,
++				/* mac_txd2 */
++				<0 RK_PC6 1 &pcfg_pull_none>;
++		};
++	};
++
++	usb {
++		host_vbus_drv: host-vbus-drv {
++			rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		otg_vbus_drv: otg-vbus-drv {
++			rockchip,pins = <3 RK_PA1 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	gpio-leds {
++		leds_gpio: leds-gpio {
++			rockchip,pins = <0 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++};
++
++&sdmmc {
++	bus-width = <4>;
++	cap-mmc-highspeed;
++	cap-sd-highspeed;
++	disable-wp;
++	max-frequency = <150000000>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdmmc0_clk &sdmmc0_cmd &sdmmc0_dectn &sdmmc0_bus4>;
++	vmmc-supply = <&vcc_sd>;
++	status = "okay";
++};
++
++/*&sdmmc_ext {
++	bus-width = <4>;
++	cap-sd-highspeed;
++	cap-sdio-irq;
++	disable-wp;
++	keep-power-in-suspend;
++	max-frequency = <100000000>;
++	mmc-pwrseq = <&sdio_pwrseq>;
++	non-removable;
++	num-slots = <1>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdmmc0ext_clk &sdmmc0ext_cmd &sdmmc0ext_bus4>;
++	rockchip,default-sample-phase = <120>;
++	supports-sdio;
++	sd-uhs-sdr104;
++	#address-cells = <1>;
++	#size-cells = <0>;
++	status = "okay";
++
++	brcmf: bcrmf@1 {
++		reg = <1>;
++		compatible = "brcm,bcm4329-fmac";
++		interrupt-parent = <&gpio1>;
++		interrupts = <RK_PD2 IRQ_TYPE_LEVEL_HIGH>;
++		interrupt-names = "host-wake";
++	};
++};*/
++
++/*&tsadc {
++	status = "okay";
++};*/
++
++&uart2 {
++	status = "okay";
++};
++
++/*&u2phy {
++	status = "okay";
++};
++
++&u2phy_host {
++	status = "okay";
++};
++
++&u2phy_otg {
++	status = "okay";
++};
++
++&u3phy {
++	vbus-supply = <&vcc_host_vbus>;
++	status = "okay";
++};
++
++&u3phy_utmi {
++	status = "okay";
++};
++
++&u3phy_pipe {
++	status = "okay";
++};
++
++&usb20_otg {
++	status = "okay";
++};
++
++&usb_host0_ehci {
++	status = "okay";
++};
++
++&usb_host0_ohci {
++	status = "okay";
++};
++
++&usbdrd3 {
++	status = "okay";
++};
++
++&usbdrd_dwc3 {
++	status = "okay";
++	#address-cells = <1>;
++	#size-cells = <0>;
++
++	r8153: device@2 {
++		compatible = "usbbda:8153";
++		reg = <2>;
++		local-mac-address = [00 00 00 00 00 00];
++	};
++};*/
+diff --git a/arch/arm/dts/rk3328-orangepi-r1plus-u-boot.dtsi b/arch/arm/dts/rk3328-orangepi-r1plus-u-boot.dtsi
+new file mode 100644
+index 00000000..cf3452ea
+--- /dev/null
++++ b/arch/arm/dts/rk3328-orangepi-r1plus-u-boot.dtsi
+@@ -0,0 +1,16 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * (C) Copyright 2018-2019 Rockchip Electronics Co., Ltd
++ */
++
++#include "rk3328-u-boot.dtsi"
++#include "rk3328-sdram-ddr4-666.dtsi"
++/ {
++	chosen {
++		u-boot,spl-boot-order = "same-as-spl", &sdmmc, &emmc;
++	};
++};
++
++&usb_host0_xhci {
++	status = "okay";
++};
+diff --git a/arch/arm/dts/rk3328-orangepi-r1plus.dts b/arch/arm/dts/rk3328-orangepi-r1plus.dts
+new file mode 100644
+index 00000000..23023ad0
+--- /dev/null
++++ b/arch/arm/dts/rk3328-orangepi-r1plus.dts
+@@ -0,0 +1,145 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2019 FriendlyElec Computer Tech. Co., Ltd.
++ * (http://www.friendlyarm.com)
++ */
++
++/dts-v1/;
++#include <dt-bindings/input/linux-event-codes.h>
++#include "rk3328-orangepi-r1plus-common.dtsi"
++
++/ {
++	model = "Xunlong Orange Pi R1 Plus";
++	compatible = "rockchip,rk3328";
++
++	gpio-keys {
++		compatible = "gpio-keys";
++		#address-cells = <1>;
++		#size-cells = <0>;
++		autorepeat;
++
++		pinctrl-names = "default";
++		pinctrl-0 = <&gpio_key1>;
++
++		button@0 {
++			gpios = <&gpio0 RK_PA0 GPIO_ACTIVE_LOW>;
++			label = "reset";
++			linux,code = <BTN_1>;
++			linux,input-type = <1>;
++			gpio-key,wakeup = <1>;
++			debounce-interval = <100>;
++		};
++	};
++
++	vcc_rtl8153: vcc-rtl8153-regulator {
++		compatible = "regulator-fixed";
++		gpio = <&gpio2 RK_PC6 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&usb30_en_drv>;
++		regulator-always-on;
++		regulator-name = "vcc_rtl8153";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		off-on-delay-us = <5000>;
++		enable-active-high;
++	};
++};
++
++&mach {
++	hwrev = <0>;
++	model = "OrangePi R1Plus";
++};
++
++&emmc {
++	status = "disabled";
++};
++
++&i2c0 {
++	status = "okay";
++};
++
++&leds {
++	status = "okay";
++
++	led@2 {
++		gpios = <&gpio2 RK_PB7 GPIO_ACTIVE_HIGH>;
++		label = "lan_led";
++	};
++
++	led@3 {
++		gpios = <&gpio2 RK_PC2 GPIO_ACTIVE_HIGH>;
++		label = "wan_led";
++	};
++};
++
++&leds_gpio {
++	rockchip,pins =
++		<0 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>,
++		<2 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>,
++		<2 RK_PC2 RK_FUNC_GPIO &pcfg_pull_none>;
++};
++
++/*&pwm2 {
++	pinctrl-names = "default", "sleep";
++	pinctrl-1 = <&pwm2_sleep_pin>;
++	status = "okay";
++};*/
++
++&rk805 {
++	interrupt-parent = <&gpio1>;
++	interrupts = <RK_PD0 IRQ_TYPE_LEVEL_LOW>;
++};
++
++&vccio_sd {
++	status = "okay";
++};
++
++&io_domains {
++	vccio3-supply = <&vccio_sd>;
++};
++
++&sdmmc {
++	vqmmc-supply = <&vccio_sd>;
++	max-frequency = <150000000>;
++	sd-uhs-sdr50;
++	sd-uhs-sdr104;
++	status = "okay";
++};
++
++/*&sdmmc_ext {
++	status = "disabled";
++};*/
++
++&sdio_pwrseq {
++	status = "disabled";
++};
++
++&pinctrl {
++	pmic {
++		pmic_int_l: pmic-int-l {
++			rockchip,pins = <1 RK_PD0 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	pwm {
++		pwm2_sleep_pin: pwm2-sleep-pin {
++			rockchip,pins = <2 RK_PA6 RK_FUNC_GPIO &pcfg_output_low>;
++		};
++	};
++
++	rockchip-key {
++		gpio_key1: gpio-key1 {
++			rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	usb {
++		otg_vbus_drv: otg-vbus-drv {
++			rockchip,pins = <1 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		usb30_en_drv: usb30-en-drv {
++			rockchip,pins = <2 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++};
+diff --git a/configs/orangepi_r1_plus_rk3328_defconfig b/configs/orangepi_r1_plus_rk3328_defconfig
+new file mode 100644
+index 00000000..ddbe9715
+--- /dev/null
++++ b/configs/orangepi_r1_plus_rk3328_defconfig
+@@ -0,0 +1,95 @@
++CONFIG_ARM=y
++CONFIG_ARCH_ROCKCHIP=y
++CONFIG_SYS_TEXT_BASE=0x00200000
++CONFIG_ROCKCHIP_RK3328=y
++CONFIG_TPL_ROCKCHIP_COMMON_BOARD=y
++CONFIG_TPL_LIBCOMMON_SUPPORT=y
++CONFIG_TPL_LIBGENERIC_SUPPORT=y
++CONFIG_SPL_DRIVERS_MISC_SUPPORT=y
++CONFIG_ENV_OFFSET=0x3F8000
++CONFIG_SPL_STACK_R_ADDR=0x600000
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_DEBUG_UART_BASE=0xFF130000
++CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_SMBIOS_PRODUCT_NAME="rock64_rk3328"
++CONFIG_DEBUG_UART=y
++CONFIG_TPL_SYS_MALLOC_F_LEN=0x800
++# CONFIG_ANDROID_BOOT_IMAGE is not set
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y
++CONFIG_SPL_LOAD_FIT=y
++CONFIG_DEFAULT_FDT_FILE="rockchip/rk3328-orangepi-r1plus.dtb"
++CONFIG_MISC_INIT_R=y
++# CONFIG_DISPLAY_CPUINFO is not set
++CONFIG_DISPLAY_BOARDINFO_LATE=y
++# CONFIG_SPL_RAW_IMAGE_SUPPORT is not set
++CONFIG_TPL_SYS_MALLOC_SIMPLE=y
++CONFIG_SPL_STACK_R=y
++CONFIG_SPL_ATF=y
++CONFIG_SPL_ATF_NO_PLATFORM_PARAM=y
++CONFIG_CMD_BOOTZ=y
++CONFIG_CMD_GPT=y
++CONFIG_CMD_MMC=y
++CONFIG_CMD_USB=y
++# CONFIG_CMD_SETEXPR is not set
++CONFIG_CMD_TIME=y
++CONFIG_SPL_OF_CONTROL=y
++CONFIG_TPL_OF_CONTROL=y
++CONFIG_DEFAULT_DEVICE_TREE="rk3328-orangepi-r1plus"
++CONFIG_OF_SPL_REMOVE_PROPS="pinctrl-0 pinctrl-names clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
++CONFIG_TPL_OF_PLATDATA=y
++CONFIG_ENV_IS_IN_MMC=y
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_NET_RANDOM_ETHADDR=y
++CONFIG_TPL_DM=y
++CONFIG_REGMAP=y
++CONFIG_SPL_REGMAP=y
++CONFIG_TPL_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_SPL_SYSCON=y
++CONFIG_TPL_SYSCON=y
++CONFIG_CLK=y
++CONFIG_SPL_CLK=y
++CONFIG_FASTBOOT_BUF_ADDR=0x800800
++CONFIG_FASTBOOT_CMD_OEM_FORMAT=y
++CONFIG_ROCKCHIP_GPIO=y
++CONFIG_SYS_I2C_ROCKCHIP=y
++CONFIG_MMC_DW=y
++CONFIG_MMC_DW_ROCKCHIP=y
++CONFIG_SF_DEFAULT_SPEED=20000000
++CONFIG_DM_ETH=y
++CONFIG_ETH_DESIGNWARE=y
++CONFIG_GMAC_ROCKCHIP=y
++CONFIG_PHY=y
++CONFIG_PINCTRL=y
++CONFIG_SPL_PINCTRL=y
++CONFIG_DM_PMIC=y
++CONFIG_PMIC_RK8XX=y
++CONFIG_REGULATOR_PWM=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_REGULATOR_RK8XX=y
++CONFIG_PWM_ROCKCHIP=y
++CONFIG_RAM=y
++CONFIG_SPL_RAM=y
++CONFIG_TPL_RAM=y
++CONFIG_DM_RESET=y
++CONFIG_BAUDRATE=1500000
++CONFIG_DEBUG_UART_SHIFT=2
++CONFIG_SYSRESET=y
++# CONFIG_TPL_SYSRESET is not set
++CONFIG_USB=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_XHCI_DWC3=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_EHCI_GENERIC=y
++CONFIG_USB_OHCI_HCD=y
++CONFIG_USB_OHCI_GENERIC=y
++CONFIG_USB_DWC2=y
++CONFIG_USB_DWC3=y
++# CONFIG_USB_DWC3_GADGET is not set
++CONFIG_USB_GADGET=y
++CONFIG_USB_GADGET_DWC2_OTG=y
++CONFIG_SPL_TINY_MEMSET=y
++CONFIG_TPL_TINY_MEMSET=y
++CONFIG_ERRNO_STR=y
++CONFIG_SMBIOS_MANUFACTURER="pine64"
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+


### PR DESCRIPTION
# Description

Added u-boot config, dt for u-boot, kernel dt. Unchanged from Nanopi R2S.

Jira reference number [AR-634]

# How Has This Been Tested?

Untested. No hardware.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-634]: https://armbian.atlassian.net/browse/AR-634