### PR TITLE
Detect overlay capability from uboot boot.cmd

### DIFF
--- a/packages/bsp/common/usr/sbin/armbian-add-overlay
+++ b/packages/bsp/common/usr/sbin/armbian-add-overlay
@@ -35,14 +35,10 @@ fi
 
 . /etc/armbian-release
 
-case "${LINUXFAMILY}" in
-	sunxi|sunxi64|rk3399|rockchip64|rockpis)
-		:;;
-	*)
-		echo >&2 "Overlays are not supported on ${LINUXFAMILY^} based boards."
-		exit -1
-		;;
-esac
+if ! grep -q '^setenv overlay_error' /boot/boot.cmd; then
+	echo >&2 "Overlays are not supported on ${LINUXFAMILY^} based boards."
+	exit -1
+fi
 
 if [[ -d /lib/modules/$(uname -r)/build/scripts/dtc ]]; then
 	if [[ ! -x /lib/modules/$(uname -r)/build/scripts/dtc/dtc ]]; then


### PR DESCRIPTION
# Description

Addresses an apparent issue where the armbian-add-overlay script fails on meson64 boards, even though the uboot configuration appears to contain support for them.

Modifies the script from checking chip family against a static list to directly checking the uboot script for a hint of support. Ideally, as overlays are supported on more families on the future, and those boot environments are updated to match other board's configuration, this script should pick up that support automatically.

[Original forum thread](https://forum.armbian.com/topic/16967-odroid-hc4-enable-rtc-clock/)

# How Has This Been Tested?

Tested on NanoPi M4V2 running Armbian release 21.02.1, mostly with a slightly modified version of the script to exit immediately after this check.

- [x] Verified that the check passes for M4V2 build
- [x] Verified that check fails when that checked line is changed/removed in /boot/boot.cmd
- [x] Verified that same line exists in build for ODroid C4 (release 20.11.7)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
