### PR TITLE
Add missing overclocking opp for N2+

### DIFF
--- a/config/kernel/linux-meson64-current.config
+++ b/config/kernel/linux-meson64-current.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.10.6 Kernel Configuration
+# Linux/arm64 5.10.10 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (GNU Toolchain for the A-profile Architecture 8.3-2019.03 (arm-rel-8.36)) 8.3.0"
 CONFIG_CC_IS_GCC=y

--- a/patch/kernel/meson64-current/0001-Add-missing-CPU-opp-values-for-clocking-g12b-N2-high.patch
+++ b/patch/kernel/meson64-current/0001-Add-missing-CPU-opp-values-for-clocking-g12b-N2-high.patch
@@ -1,0 +1,46 @@
+From 712b399ed54f49e0ac7ae92c57ed775604eaaed9 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor.pecovnik@gmail.com>
+Date: Wed, 10 Feb 2021 18:07:08 +0100
+Subject: [PATCH] Add missing CPU opp values for clocking g12b / N2+ higher
+
+Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
+---
+ .../arm64/boot/dts/amlogic/meson-g12b-a311d.dtsi | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-a311d.dtsi b/arch/arm64/boot/dts/amlogic/meson-g12b-a311d.dtsi
+index d61f43052..75030d197 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-g12b-a311d.dtsi
++++ b/arch/arm64/boot/dts/amlogic/meson-g12b-a311d.dtsi
+@@ -65,6 +65,14 @@ opp-1800000000 {
+ 			opp-hz = /bits/ 64 <1800000000>;
+ 			opp-microvolt = <1001000>;
+ 		};
++		opp-1908000000 {
++			opp-hz = /bits/ 64 <1908000000>;
++			opp-microvolt = <1030000>;
++		};
++		opp-2016000000 {
++			opp-hz = /bits/ 64 <2016000000>;
++			opp-microvolt = <1040000>;
++		};
+ 	};
+ 
+ 	cpub_opp_table_1: opp-table-1 {
+@@ -145,5 +153,13 @@ opp-2208000000 {
+                         opp-hz = /bits/ 64 <2208000000>;
+                         opp-microvolt = <1011000>;
+                 };
++		opp-2304000000 {
++			opp-hz = /bits/ 64 <2304000000>;
++			opp-microvolt = <1030000>;
++		};
++		opp-2400000000 {
++			opp-hz = /bits/ 64 <2400000000>;
++			opp-microvolt = <1040000>;
++		};
+ 	};
+ };
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/kernel/meson64-dev/0001-Add-missing-CPU-opp-values-for-clocking-g12b-N2-high.patch
+++ b/patch/kernel/meson64-dev/0001-Add-missing-CPU-opp-values-for-clocking-g12b-N2-high.patch
@@ -1,0 +1,46 @@
+From 712b399ed54f49e0ac7ae92c57ed775604eaaed9 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor.pecovnik@gmail.com>
+Date: Wed, 10 Feb 2021 18:07:08 +0100
+Subject: [PATCH] Add missing CPU opp values for clocking g12b / N2+ higher
+
+Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
+---
+ .../arm64/boot/dts/amlogic/meson-g12b-a311d.dtsi | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-a311d.dtsi b/arch/arm64/boot/dts/amlogic/meson-g12b-a311d.dtsi
+index d61f43052..75030d197 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-g12b-a311d.dtsi
++++ b/arch/arm64/boot/dts/amlogic/meson-g12b-a311d.dtsi
+@@ -65,6 +65,14 @@ opp-1800000000 {
+ 			opp-hz = /bits/ 64 <1800000000>;
+ 			opp-microvolt = <1001000>;
+ 		};
++		opp-1908000000 {
++			opp-hz = /bits/ 64 <1908000000>;
++			opp-microvolt = <1030000>;
++		};
++		opp-2016000000 {
++			opp-hz = /bits/ 64 <2016000000>;
++			opp-microvolt = <1040000>;
++		};
+ 	};
+ 
+ 	cpub_opp_table_1: opp-table-1 {
+@@ -145,5 +153,13 @@ opp-2208000000 {
+                         opp-hz = /bits/ 64 <2208000000>;
+                         opp-microvolt = <1011000>;
+                 };
++		opp-2304000000 {
++			opp-hz = /bits/ 64 <2304000000>;
++			opp-microvolt = <1030000>;
++		};
++		opp-2400000000 {
++			opp-hz = /bits/ 64 <2400000000>;
++			opp-microvolt = <1040000>;
++		};
+ 	};
+ };
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+


### PR DESCRIPTION
# Description

When upgrading to 5.10.y we changed to the DT that comes with the upstream kernel. But it appears that mainline sources lack support for overclocking values.

Jira reference number [AR-636]

# How Has This Been Tested?

- [x] [Upgraded kernel on test machine](https://forum.armbian.com/topic/14774-odroid-n2-n2-plus/page/2/?tab=comments#comment-119132)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-636]: https://armbian.atlassian.net/browse/AR-636