### PR TITLE
Adjust bootsplash patch. Tested for compilation on 5.10.y and 5.11.y

### DIFF
--- a/patch/misc/0007-bootsplash.patch
+++ b/patch/misc/0007-bootsplash.patch
@@ -2,15 +2,14 @@ diff --git a/drivers/tty/vt/keyboard.c b/drivers/tty/vt/keyboard.c
 index f4166263bb3a..a248429194bb 100644
 --- a/drivers/tty/vt/keyboard.c
 +++ b/drivers/tty/vt/keyboard.c
-@@ -47,6 +47,8 @@
- 
- #include <asm/irq_regs.h>
+@@ -28,6 +28,7 @@
+  * 21-08-02: Converted to input API, major cleanup. (Vojtech Pavlik)
+  */
  
 +#include <linux/bootsplash.h>
-+
- extern void ctrl_alt_del(void);
+ #define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
  
- /*
+ #include <linux/consolemap.h>
 @@ -1353,6 +1355,28 @@ static void kbd_keycode(unsigned int keycode, int down, int hw_raw)
  	}
  #endif


### PR DESCRIPTION
# Description

Due small code changes, we need to adjust our patch.

Jira reference number [AR-646]

# How Has This Been Tested?

- [x] Compiled kernel 5.10.y
- [x] Compiled kernel 5.11.y

Others are not affected.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings

[AR-646]: https://armbian.atlassian.net/browse/AR-646