### PR TITLE
Attach wireless driver back to master branch

### DIFF
--- a/lib/compilation-prepare.sh
+++ b/lib/compilation-prepare.sh
@@ -323,7 +323,7 @@ compilation_prepare()
 	if linux-version compare "${version}" ge 3.14 && [ "$EXTRAWIFI" == yes ]; then
 
 		# attach to specifics tag or branch
-		local rtl8812auver="commit:ad351bd0afeb47d2fb197aff8cde4d7fb5fead9e"
+		local rtl8812auver="branch:v5.6.4.2"
 
 		display_alert "Adding" "Wireless drivers for Realtek 8811, 8812, 8814 and 8821 chipsets ${rtl8812auver}" "info"
 


### PR DESCRIPTION
# Description

When upstream driver is broken and we don't have time to fix problem, we usually attach code to some known to working commit id. It seems problems were fixed, so we are switching back to master. But driver compilation needs to be tested on all kernels.

Jira reference number [AR-645]

# How Has This Been Tested?

- [x] Compiled kernel 5.10.y
- [x] Compiled kernel 5.11.y

Others are not affected.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings

[AR-645]: https://armbian.atlassian.net/browse/AR-645