### PR TITLE
Fixing out of the tree wireless driver compilation

### DIFF
--- a/lib/compilation-prepare.sh
+++ b/lib/compilation-prepare.sh
@@ -323,7 +323,9 @@ compilation_prepare()
 	if linux-version compare "${version}" ge 3.14 && [ "$EXTRAWIFI" == yes ]; then
 
 		# attach to specifics tag or branch
-		local rtl8812auver="commit:ad351bd0afeb47d2fb197aff8cde4d7fb5fead9e"
+		# local rtl8812auver="commit:ad351bd0afeb47d2fb197aff8cde4d7fb5fead9e"
+		local rtl8812auver="branch:v5.6.4.2"
+
 
 		display_alert "Adding" "Wireless drivers for Realtek 8811, 8812, 8814 and 8821 chipsets ${rtl8812auver}" "info"
 
@@ -429,7 +431,7 @@ compilation_prepare()
 
 	# Wireless drivers for Realtek 8188EU 8188EUS and 8188ETV chipsets
 
-	if linux-version compare "${version}" ge 3.14 && linux-version compare "${version}" le 5.9 && [ "$EXTRAWIFI" == yes ]; then
+	if linux-version compare "${version}" ge 3.14 && linux-version compare "${version}" le 5.12 && [ "$EXTRAWIFI" == yes ]; then
 
 		# attach to specifics tag or branch
 		local rtl8188euver="branch:v5.7.6.1"
@@ -460,6 +462,8 @@ compilation_prepare()
 		echo "obj-\$(CONFIG_RTL8188EU) += rtl8188eu/" >> "$kerneldir/drivers/net/wireless/Makefile"
 		sed -i '/source "drivers\/net\/wireless\/ti\/Kconfig"/a source "drivers\/net\/wireless\/rtl8188eu\/Kconfig"' \
 		"$kerneldir/drivers/net/wireless/Kconfig"
+
+		process_patch_file "${SRC}/patch/misc/wireless-rtl8188eu.patch" "applying"
 
 	fi
 

--- a/lib/compilation-prepare.sh
+++ b/lib/compilation-prepare.sh
@@ -323,9 +323,7 @@ compilation_prepare()
 	if linux-version compare "${version}" ge 3.14 && [ "$EXTRAWIFI" == yes ]; then
 
 		# attach to specifics tag or branch
-		# local rtl8812auver="commit:ad351bd0afeb47d2fb197aff8cde4d7fb5fead9e"
-		local rtl8812auver="branch:v5.6.4.2"
-
+		local rtl8812auver="commit:ad351bd0afeb47d2fb197aff8cde4d7fb5fead9e"
 
 		display_alert "Adding" "Wireless drivers for Realtek 8811, 8812, 8814 and 8821 chipsets ${rtl8812auver}" "info"
 
@@ -431,7 +429,7 @@ compilation_prepare()
 
 	# Wireless drivers for Realtek 8188EU 8188EUS and 8188ETV chipsets
 
-	if linux-version compare "${version}" ge 3.14 && linux-version compare "${version}" le 5.12 && [ "$EXTRAWIFI" == yes ]; then
+	if linux-version compare "${version}" ge 3.14 && [ "$EXTRAWIFI" == yes ]; then
 
 		# attach to specifics tag or branch
 		local rtl8188euver="branch:v5.7.6.1"

--- a/patch/misc/wireless-rtl8188eu.patch
+++ b/patch/misc/wireless-rtl8188eu.patch
@@ -1,0 +1,48 @@
+From 64cd5169be2f2da24b0949a93aef2b3e40c4e4ec Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor.pecovnik@gmail.com>
+Date: Mon, 15 Feb 2021 12:28:44 +0100
+Subject: [PATCH] wifi
+
+Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
+---
+ .../net/wireless/rtl8188eu/os_dep/osdep_service.c   | 13 +++++--------
+ 1 files changed, 6 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/net/wireless/rtl8188eu/os_dep/osdep_service.c b/drivers/net/wireless/rtl8188eu/os_dep/osdep_service.c
+index 27366fa09..c6b3f65bb 100644
+--- a/drivers/net/wireless/rtl8188eu/os_dep/osdep_service.c
++++ b/drivers/net/wireless/rtl8188eu/os_dep/osdep_service.c
+@@ -2276,7 +2276,7 @@ static int retriveFromFile(const char *path, u8 *buf, u32 sz)
+ static int storeToFile(const char *path, u8 *buf, u32 sz)
+ {
+ 	int ret = 0;
+-	#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
++	#ifdef set_fs
+ 	mm_segment_t oldfs;
+ 	#endif
+ 	struct file *fp;
+@@ -2285,17 +2285,14 @@ static int storeToFile(const char *path, u8 *buf, u32 sz)
+ 		ret = openFile(&fp, path, O_CREAT | O_WRONLY, 0666);
+ 		if (0 == ret) {
+ 			RTW_INFO("%s openFile path:%s fp=%p\n", __FUNCTION__, path , fp);
+-
+-			#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
++#ifdef set_fs
+ 			oldfs = get_fs();
+ 			set_fs(KERNEL_DS);
+-			#else
+-			set_fs(get_ds());
+-			#endif
+ 			ret = writeFile(fp, buf, sz);
+-			#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 10, 0))
+ 			set_fs(oldfs);
+-			#endif
++#else
++			ret = writeFile(fp, buf, sz);
++#endif
+ 			closeFile(fp);
+ 
+ 			RTW_INFO("%s writeFile, ret:%d\n", __FUNCTION__, ret);
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+


### PR DESCRIPTION
# Description

Realtek 8188EU was broken and disabled since 5.9.y due to wrong code adjustment. This fix allow driver compilation on 5.10.y and 5.11.y

Jira reference number [AR-644]

# How Has This Been Tested?

- [x] Compiled on 5.10.y
- [x] Compiled on 5.11.y

# Checklist:

- [x] My changes generate no new warnings

[AR-644]: https://armbian.atlassian.net/browse/AR-644