### PR TITLE
remove mount option "nodiratime" where "noatime" is given

### DIFF
--- a/config/templates/fel-boot.cmd.template
+++ b/config/templates/fel-boot.cmd.template
@@ -1,7 +1,7 @@
 setenv nfs_ip FEL_LOCAL_IP
 setenv nfs_root FEL_ROOTFS
 setenv branch BRANCH
-setenv bootargs "console=tty1 console=ttyS0,115200 root=/dev/nfs nfsroot=${nfs_ip}:${nfs_root} ip=dhcp rw panic=10 consoleblank=0 enforcing=0 loglevel=6 rootflags=noatime,nodiratime"
+setenv bootargs "console=tty1 console=ttyS0,115200 root=/dev/nfs nfsroot=${nfs_ip}:${nfs_root} ip=dhcp rw panic=10 consoleblank=0 enforcing=0 loglevel=6 rootflags=noatime"
 # uncomment to disable initrd
 # setenv ramdisk_addr_r "-"
 if test ${branch} != default; then

--- a/config/templates/nfs-boot.cmd.template
+++ b/config/templates/nfs-boot.cmd.template
@@ -11,7 +11,7 @@ setenv net_setup "ip=dhcp"
 # setenv net_setup "ip=<client-ip>:<server-ip>:<gw-ip>:<netmask>:<hostname>:<device>:<autoconf>:<dns0-ip>:<dns1-ip>"
 
 # you may need to add extra kernel arguments specific to your device
-setenv bootargs "console=tty1 console=ttyS0,115200 root=/dev/nfs ${net_setup} rw rootflags=noatime,nodiratime disp.screen0_output_mode=1920x1080p60 panic=10 consoleblank=0 enforcing=0 loglevel=6"
+setenv bootargs "console=tty1 console=ttyS0,115200 root=/dev/nfs ${net_setup} rw rootflags=noatime disp.screen0_output_mode=1920x1080p60 panic=10 consoleblank=0 enforcing=0 loglevel=6"
 
 if test -n ${nfs_root}; then
 	setenv bootargs "${bootargs} nfsroot=${nfs_root}"

--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -493,7 +493,7 @@ prepare_partitions()
 		else
 			local rootfs="UUID=$(blkid -s UUID -o value $rootdevice)"
 		fi
-		echo "$rootfs / ${mkfs[$ROOTFS_TYPE]} defaults,noatime,nodiratime${mountopts[$ROOTFS_TYPE]} 0 1" >> $SDCARD/etc/fstab
+		echo "$rootfs / ${mkfs[$ROOTFS_TYPE]} defaults,noatime${mountopts[$ROOTFS_TYPE]} 0 1" >> $SDCARD/etc/fstab
 	fi
 	if [[ -n $bootpart ]]; then
 		display_alert "Creating /boot" "$bootfs on ${LOOP}p${bootpart}"

--- a/packages/bsp/common/usr/sbin/nand-sata-install
+++ b/packages/bsp/common/usr/sbin/nand-sata-install
@@ -65,11 +65,11 @@ fi
 mkopts[btrfs]='-f'
 mkopts[f2fs]='-f'
 
-mountopts[ext2]='defaults,noatime,nodiratime,commit=600,errors=remount-ro,x-gvfs-hide	0	1'
-mountopts[ext3]='defaults,noatime,nodiratime,commit=600,errors=remount-ro,x-gvfs-hide	0	1'
-mountopts[ext4]='defaults,noatime,nodiratime,commit=600,errors=remount-ro,x-gvfs-hide	0	1'
-mountopts[btrfs]='defaults,noatime,nodiratime,commit=600,compress=lzo,x-gvfs-hide			0	2'
-mountopts[f2fs]='defaults,noatime,nodiratime,x-gvfs-hide	0	2'
+mountopts[ext2]='defaults,noatime,commit=600,errors=remount-ro,x-gvfs-hide	0	1'
+mountopts[ext3]='defaults,noatime,commit=600,errors=remount-ro,x-gvfs-hide	0	1'
+mountopts[ext4]='defaults,noatime,commit=600,errors=remount-ro,x-gvfs-hide	0	1'
+mountopts[btrfs]='defaults,noatime,commit=600,compress=lzo,x-gvfs-hide			0	2'
+mountopts[f2fs]='defaults,noatime,x-gvfs-hide	0	2'
 
 # Create boot and root file system "$1" = boot, "$2" = root (Example: create_armbian "/dev/nand1" "/dev/sda3")
 create_armbian()
@@ -212,7 +212,7 @@ create_armbian()
 		echo "Finishing installation to NAND." >> $logfile
 		REMOVESDTXT="and remove SD to boot from NAND"
 		echo "$1 /boot vfat	defaults 0 0" >> "${TempDir}"/rootfs/etc/fstab
-		echo "$2 / ext4 defaults,noatime,nodiratime,commit=600,errors=remount-ro 0 1" >> "${TempDir}"/rootfs/etc/fstab
+		echo "$2 / ext4 defaults,noatime,commit=600,errors=remount-ro 0 1" >> "${TempDir}"/rootfs/etc/fstab
 		dialog --title "$title" --backtitle "$backtitle" --infobox "\nConverting kernel ... few seconds." 5 60
 		mkimage -A arm -O linux -T kernel -C none -a "0x40008000" -e "0x40008000" -n "Linux kernel" -d \
 			/boot/zImage "${TempDir}"/bootfs/uImage >/dev/null 2>&1


### PR DESCRIPTION
Dear Armbian team/community,

thanks for this great project.

I think the mount option "noatime" implies "nodiratime".
See, e.g., [this code section in the source code of Linux 5.11](https://github.com/torvalds/linux/blob/v5.11/fs/inode.c#L1807-L1808).

In order to keep the configurations clean, this PR removes the mount option "nodiratime" where "noatime" is given.