### PR TITLE
Add video related patches to Rockchip64-legacy kernel.

### DIFF
--- a/patch/kernel/rockchip64-legacy/vcodec-fixes.patch
+++ b/patch/kernel/rockchip64-legacy/vcodec-fixes.patch
@@ -1,0 +1,945 @@
+From e222e9913d3c70967bae92f1aed46de726974dc7 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Thu, 5 Jul 2018 00:14:14 +0200
+Subject: [PATCH] Revert "drm/drm-prime: cache dma_buf import context"
+
+This reverts commit 5a90381e5acc2cf32be03099a14d05d4362b3348.
+---
+ drivers/gpu/drm/drm_prime.c                 | 46 ++---------------------------
+ drivers/gpu/drm/rockchip/rockchip_drm_gem.c |  1 +
+ 2 files changed, 3 insertions(+), 44 deletions(-)
+
+diff --git a/drivers/gpu/drm/drm_prime.c b/drivers/gpu/drm/drm_prime.c
+index 6f207d5946dc..6b7417a194a3 100644
+--- a/drivers/gpu/drm/drm_prime.c
++++ b/drivers/gpu/drm/drm_prime.c
+@@ -71,11 +71,6 @@ struct drm_prime_attachment {
+ 	enum dma_data_direction dir;
+ };
+ 
+-struct drm_prime_callback_data {
+-	struct drm_gem_object *obj;
+-	struct sg_table *sgt;
+-};
+-
+ static int drm_prime_add_buf_handle(struct drm_prime_file_private *prime_fpriv,
+ 				    struct dma_buf *dma_buf, uint32_t handle)
+ {
+@@ -524,23 +519,6 @@ out_unlock:
+ }
+ EXPORT_SYMBOL(drm_gem_prime_handle_to_fd);
+ 
+-static void drm_gem_prime_dmabuf_release_callback(void *data)
+-{
+-	struct drm_prime_callback_data *cb_data = data;
+-
+-	if (cb_data && cb_data->obj && cb_data->obj->import_attach) {
+-		struct dma_buf_attachment *attach = cb_data->obj->import_attach;
+-		struct sg_table *sgt = cb_data->sgt;
+-
+-		if (sgt)
+-			dma_buf_unmap_attachment(attach, sgt,
+-						 DMA_BIDIRECTIONAL);
+-		dma_buf_detach(attach->dmabuf, attach);
+-		drm_gem_object_unreference_unlocked(cb_data->obj);
+-		kfree(cb_data);
+-	}
+-}
+-
+ /**
+  * drm_gem_prime_import - helper library implementation of the import callback
+  * @dev: drm_device to import into
+@@ -555,7 +533,6 @@ struct drm_gem_object *drm_gem_prime_import(struct drm_device *dev,
+ 	struct dma_buf_attachment *attach;
+ 	struct sg_table *sgt;
+ 	struct drm_gem_object *obj;
+-	struct drm_prime_callback_data *cb_data;
+ 	int ret;
+ 
+ 	if (dma_buf->ops == &drm_gem_prime_dmabuf_ops) {
+@@ -570,13 +547,6 @@ struct drm_gem_object *drm_gem_prime_import(struct drm_device *dev,
+ 		}
+ 	}
+ 
+-	cb_data = dma_buf_get_release_callback_data(dma_buf,
+-					drm_gem_prime_dmabuf_release_callback);
+-	if (cb_data && cb_data->obj && cb_data->obj->dev == dev) {
+-		drm_gem_object_reference(cb_data->obj);
+-		return cb_data->obj;
+-	}
+-
+ 	if (!dev->driver->gem_prime_import_sg_table)
+ 		return ERR_PTR(-EINVAL);
+ 
+@@ -585,16 +555,11 @@ struct drm_gem_object *drm_gem_prime_import(struct drm_device *dev,
+ 		return ERR_CAST(attach);
+ 
+ 	get_dma_buf(dma_buf);
+-	cb_data = kmalloc(sizeof(*cb_data), GFP_KERNEL);
+-	if (!cb_data) {
+-		ret = -ENOMEM;
+-		goto fail_detach;
+-	}
+ 
+ 	sgt = dma_buf_map_attachment(attach, DMA_BIDIRECTIONAL);
+ 	if (IS_ERR(sgt)) {
+ 		ret = PTR_ERR(sgt);
+-		goto fail_free;
++		goto fail_detach;
+ 	}
+ 
+ 	obj = dev->driver->gem_prime_import_sg_table(dev, attach, sgt);
+@@ -602,20 +567,13 @@ struct drm_gem_object *drm_gem_prime_import(struct drm_device *dev,
+ 		ret = PTR_ERR(obj);
+ 		goto fail_unmap;
+ 	}
++
+ 	obj->import_attach = attach;
+-	cb_data->obj = obj;
+-	cb_data->sgt = sgt;
+-	dma_buf_set_release_callback(dma_buf,
+-			drm_gem_prime_dmabuf_release_callback, cb_data);
+-	dma_buf_put(dma_buf);
+-	drm_gem_object_reference(obj);
+ 
+ 	return obj;
+ 
+ fail_unmap:
+ 	dma_buf_unmap_attachment(attach, sgt, DMA_BIDIRECTIONAL);
+-fail_free:
+-	kfree(cb_data);
+ fail_detach:
+ 	dma_buf_detach(dma_buf, attach);
+ 	dma_buf_put(dma_buf);
+diff --git a/drivers/gpu/drm/rockchip/rockchip_drm_gem.c b/drivers/gpu/drm/rockchip/rockchip_drm_gem.c
+index 273a52b5eb66..85bbd19c87b0 100644
+--- a/drivers/gpu/drm/rockchip/rockchip_drm_gem.c
++++ b/drivers/gpu/drm/rockchip/rockchip_drm_gem.c
+@@ -649,6 +649,7 @@ void rockchip_gem_free_object(struct drm_gem_object *obj)
+ 			dma_unmap_sg(drm->dev, rk_obj->sgt->sgl,
+ 				     rk_obj->sgt->nents, DMA_BIDIRECTIONAL);
+ 		}
++		drm_prime_gem_destroy(obj, rk_obj->sgt);
+ 	} else {
+ 		rockchip_gem_free_buf(rk_obj);
+ 	}
+
+From 0868438e92b0e9a44d6c6e711ef3be0a429ab4af Mon Sep 17 00:00:00 2001
+From: Rob Clark <robdclark@gmail.com>
+Date: Thu, 9 Jun 2016 15:29:19 -0400
+Subject: [PATCH] UPSTREAM: drm/prime: fix error path deadlock fail
+
+There were a couple messed up things about this fail path.
+(1) it would drop object_name_lock twice
+(2) drm_gem_handle_delete() (in drm_gem_remove_prime_handles())
+    needs to grab prime_lock
+
+Reported-by: Alex Deucher <alexdeucher@gmail.com>
+Signed-off-by: Rob Clark <robdclark@gmail.com>
+Reviewed-by: Alex Deucher <alexander.deucher@amd.com>
+Signed-off-by: Daniel Vetter <daniel.vetter@ffwll.ch>
+Link: http://patchwork.freedesktop.org/patch/msgid/1465500559-17873-1-git-send-email-robdclark@gmail.com
+(cherry picked from commit bd6e2732f0e2894ce792f344c41fc32591436fe3)
+---
+ drivers/gpu/drm/drm_prime.c | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/gpu/drm/drm_prime.c b/drivers/gpu/drm/drm_prime.c
+index 6b7417a194a3..d8d85286764d 100644
+--- a/drivers/gpu/drm/drm_prime.c
++++ b/drivers/gpu/drm/drm_prime.c
+@@ -628,7 +628,7 @@ int drm_gem_prime_fd_to_handle(struct drm_device *dev,
+ 		get_dma_buf(dma_buf);
+ 	}
+ 
+-	/* drm_gem_handle_create_tail unlocks dev->object_name_lock. */
++	/* _handle_create_tail unconditionally unlocks dev->object_name_lock. */
+ 	ret = drm_gem_handle_create_tail(file_priv, obj, handle);
+ 	drm_gem_object_unreference_unlocked(obj);
+ 	if (ret)
+@@ -636,11 +636,10 @@ int drm_gem_prime_fd_to_handle(struct drm_device *dev,
+ 
+ 	ret = drm_prime_add_buf_handle(&file_priv->prime,
+ 			dma_buf, *handle);
++	mutex_unlock(&file_priv->prime.lock);
+ 	if (ret)
+ 		goto fail;
+ 
+-	mutex_unlock(&file_priv->prime.lock);
+-
+ 	dma_buf_put(dma_buf);
+ 
+ 	return 0;
+@@ -650,11 +649,14 @@ fail:
+ 	 * to detach.. which seems ok..
+ 	 */
+ 	drm_gem_handle_delete(file_priv, *handle);
++	dma_buf_put(dma_buf);
++	return ret;
++
+ out_unlock:
+ 	mutex_unlock(&dev->object_name_lock);
+ out_put:
+-	dma_buf_put(dma_buf);
+ 	mutex_unlock(&file_priv->prime.lock);
++	dma_buf_put(dma_buf);
+ 	return ret;
+ }
+ EXPORT_SYMBOL(drm_gem_prime_fd_to_handle);
+
+From 8e4ac090d0a814f73d719887f96f7dc44112e03e Mon Sep 17 00:00:00 2001
+From: Chris Wilson <chris@chris-wilson.co.uk>
+Date: Mon, 26 Sep 2016 21:44:14 +0100
+Subject: [PATCH] UPSTREAM: drm: Convert prime dma-buf <-> handle to rbtree
+
+Currently we use a linear walk to lookup a handle and return a dma-buf,
+and vice versa. A long overdue TODO task is to convert that to a
+hashtable. Since the initial implementation of dma-buf/prime, we now
+have resizeable hashtables we can use (and now a future task is to RCU
+enable the lookup!). However, this patch opts to use an rbtree instead
+to provide O(lgN) lookups (and insertion, deletion). rbtrees were chosen
+over using the RCU backed resizable hashtable to firstly avoid the
+reallocations (rbtrees can be embedded entirely within the parent
+struct) and to favour simpler code with predictable worst case
+behaviour. In simple testing, the difference between using the constant
+lookup and insertion of the rhashtable and the rbtree was less than 10%
+of the wall time (igt/benchmarks/prime_lookup) - both are dramatic
+improvements over the existing linear lists.
+
+v2: Favour rbtree over rhashtable
+
+Bugzilla: https://bugs.freedesktop.org/show_bug.cgi?id=94631
+Signed-off-by: Chris Wilson <chris@chris-wilson.co.uk>
+Cc: Sean Paul <seanpaul@chromium.org>
+Cc: David Herrmann <dh.herrmann@gmail.com>
+Reviewed-by: David Herrmann <dh.herrmann@gmail.com>
+Reviewed-by: Sean Paul <seanpaul@chromium.org>
+Signed-off-by: Daniel Vetter <daniel.vetter@ffwll.ch>
+Link: http://patchwork.freedesktop.org/patch/msgid/20160926204414.23222-1-chris@chris-wilson.co.uk
+(cherry picked from commit 077675c1e8a193a6355d4a7c8c7bf63be310b472)
+---
+ drivers/gpu/drm/drm_prime.c | 85 +++++++++++++++++++++++++++++++++++++++------
+ include/drm/drmP.h          |  5 +--
+ 2 files changed, 77 insertions(+), 13 deletions(-)
+
+diff --git a/drivers/gpu/drm/drm_prime.c b/drivers/gpu/drm/drm_prime.c
+index d8d85286764d..4c49e736bc9c 100644
+--- a/drivers/gpu/drm/drm_prime.c
++++ b/drivers/gpu/drm/drm_prime.c
+@@ -28,6 +28,7 @@
+ 
+ #include <linux/export.h>
+ #include <linux/dma-buf.h>
++#include <linux/rbtree.h>
+ #include <drm/drmP.h>
+ #include <drm/drm_gem.h>
+ 
+@@ -61,9 +62,11 @@
+  */
+ 
+ struct drm_prime_member {
+-	struct list_head entry;
+ 	struct dma_buf *dma_buf;
+ 	uint32_t handle;
++
++	struct rb_node dmabuf_rb;
++	struct rb_node handle_rb;
+ };
+ 
+ struct drm_prime_attachment {
+@@ -75,6 +78,7 @@ static int drm_prime_add_buf_handle(struct drm_prime_file_private *prime_fpriv,
+ 				    struct dma_buf *dma_buf, uint32_t handle)
+ {
+ 	struct drm_prime_member *member;
++	struct rb_node **p, *rb;
+ 
+ 	member = kmalloc(sizeof(*member), GFP_KERNEL);
+ 	if (!member)
+@@ -83,18 +87,56 @@ static int drm_prime_add_buf_handle(struct drm_prime_file_private *prime_fpriv,
+ 	get_dma_buf(dma_buf);
+ 	member->dma_buf = dma_buf;
+ 	member->handle = handle;
+-	list_add(&member->entry, &prime_fpriv->head);
++
++	rb = NULL;
++	p = &prime_fpriv->dmabufs.rb_node;
++	while (*p) {
++		struct drm_prime_member *pos;
++
++		rb = *p;
++		pos = rb_entry(rb, struct drm_prime_member, dmabuf_rb);
++		if (dma_buf > pos->dma_buf)
++			p = &rb->rb_right;
++		else
++			p = &rb->rb_left;
++	}
++	rb_link_node(&member->dmabuf_rb, rb, p);
++	rb_insert_color(&member->dmabuf_rb, &prime_fpriv->dmabufs);
++
++	rb = NULL;
++	p = &prime_fpriv->handles.rb_node;
++	while (*p) {
++		struct drm_prime_member *pos;
++
++		rb = *p;
++		pos = rb_entry(rb, struct drm_prime_member, handle_rb);
++		if (handle > pos->handle)
++			p = &rb->rb_right;
++		else
++			p = &rb->rb_left;
++	}
++	rb_link_node(&member->handle_rb, rb, p);
++	rb_insert_color(&member->handle_rb, &prime_fpriv->handles);
++
+ 	return 0;
+ }
+ 
+ static struct dma_buf *drm_prime_lookup_buf_by_handle(struct drm_prime_file_private *prime_fpriv,
+ 						      uint32_t handle)
+ {
+-	struct drm_prime_member *member;
++	struct rb_node *rb;
++
++	rb = prime_fpriv->handles.rb_node;
++	while (rb) {
++		struct drm_prime_member *member;
+ 
+-	list_for_each_entry(member, &prime_fpriv->head, entry) {
++		member = rb_entry(rb, struct drm_prime_member, handle_rb);
+ 		if (member->handle == handle)
+ 			return member->dma_buf;
++		else if (member->handle < handle)
++			rb = rb->rb_right;
++		else
++			rb = rb->rb_left;
+ 	}
+ 
+ 	return NULL;
+@@ -104,14 +146,23 @@ static int drm_prime_lookup_buf_handle(struct drm_prime_file_private *prime_fpri
+ 				       struct dma_buf *dma_buf,
+ 				       uint32_t *handle)
+ {
+-	struct drm_prime_member *member;
++	struct rb_node *rb;
++
++	rb = prime_fpriv->dmabufs.rb_node;
++	while (rb) {
++		struct drm_prime_member *member;
+ 
+-	list_for_each_entry(member, &prime_fpriv->head, entry) {
++		member = rb_entry(rb, struct drm_prime_member, dmabuf_rb);
+ 		if (member->dma_buf == dma_buf) {
+ 			*handle = member->handle;
+ 			return 0;
++		} else if (member->dma_buf < dma_buf) {
++			rb = rb->rb_right;
++		} else {
++			rb = rb->rb_left;
+ 		}
+ 	}
++
+ 	return -ENOENT;
+ }
+ 
+@@ -166,13 +217,24 @@ static void drm_gem_map_detach(struct dma_buf *dma_buf,
+ void drm_prime_remove_buf_handle_locked(struct drm_prime_file_private *prime_fpriv,
+ 					struct dma_buf *dma_buf)
+ {
+-	struct drm_prime_member *member, *safe;
++	struct rb_node *rb;
+ 
+-	list_for_each_entry_safe(member, safe, &prime_fpriv->head, entry) {
++	rb = prime_fpriv->dmabufs.rb_node;
++	while (rb) {
++		struct drm_prime_member *member;
++
++		member = rb_entry(rb, struct drm_prime_member, dmabuf_rb);
+ 		if (member->dma_buf == dma_buf) {
++			rb_erase(&member->handle_rb, &prime_fpriv->handles);
++			rb_erase(&member->dmabuf_rb, &prime_fpriv->dmabufs);
++
+ 			dma_buf_put(dma_buf);
+-			list_del(&member->entry);
+ 			kfree(member);
++			return;
++		} else if (member->dma_buf < dma_buf) {
++			rb = rb->rb_right;
++		} else {
++			rb = rb->rb_left;
+ 		}
+ 	}
+ }
+@@ -794,12 +856,13 @@ EXPORT_SYMBOL(drm_prime_gem_destroy);
+ 
+ void drm_prime_init_file_private(struct drm_prime_file_private *prime_fpriv)
+ {
+-	INIT_LIST_HEAD(&prime_fpriv->head);
+ 	mutex_init(&prime_fpriv->lock);
++	prime_fpriv->dmabufs = RB_ROOT;
++	prime_fpriv->handles = RB_ROOT;
+ }
+ 
+ void drm_prime_destroy_file_private(struct drm_prime_file_private *prime_fpriv)
+ {
+ 	/* by now drm_gem_release should've made sure the list is empty */
+-	WARN_ON(!list_empty(&prime_fpriv->head));
++	WARN_ON(!RB_EMPTY_ROOT(&prime_fpriv->dmabufs));
+ }
+diff --git a/include/drm/drmP.h b/include/drm/drmP.h
+index 04edcd32b409..93da65df2e7e 100644
+--- a/include/drm/drmP.h
++++ b/include/drm/drmP.h
+@@ -51,6 +51,7 @@
+ #include <linux/platform_device.h>
+ #include <linux/poll.h>
+ #include <linux/ratelimit.h>
++#include <linux/rbtree.h>
+ #include <linux/sched.h>
+ #include <linux/slab.h>
+ #include <linux/types.h>
+@@ -365,10 +366,10 @@ struct drm_pending_event {
+ 	void (*destroy)(struct drm_pending_event *event);
+ };
+ 
+-/* initial implementaton using a linked list - todo hashtab */
+ struct drm_prime_file_private {
+-	struct list_head head;
+ 	struct mutex lock;
++	struct rb_root dmabufs;
++	struct rb_root handles;
+ };
+ 
+ /** File private data */
+
+From fcb8af30f524cd437434ec6ddea0231cc37529bc Mon Sep 17 00:00:00 2001
+From: Chris Wilson <chris@chris-wilson.co.uk>
+Date: Wed, 5 Oct 2016 13:21:44 +0100
+Subject: [PATCH] UPSTREAM: drm/prime: Take a ref on the drm_dev when exporting
+ a dma_buf
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+dma_buf may live a long time, longer than the last direct user of the
+driver. We already hold a reference to the owner module (that prevents
+the object code from disappearing), but there is no reference to the
+drm_dev - so the pointers to the driver backend themselves may vanish.
+
+v2: Resist temptation to fix the bug in armada_gem.c not setting the
+correct flags on the exported dma-buf (it should pass the flags through
+and not be arbitrarily setting O_RDWR).
+
+Use a common wrapper for exporting the dmabuf and acquiring the
+reference to the drm_device.
+
+Testcase: igt/vgem_basic/unload
+Suggested-by: Daniel Vetter <daniel.vetter@ffwll.ch>
+Signed-off-by: Chris Wilson <chris@chris-wilson.co.uk>
+Cc: Petri Latvala <petri.latvala@intel.com>
+Cc: Daniel Vetter <daniel.vetter@ffwll.ch>
+Cc: stable@vger.kernel.org
+Tested-by: Petri Latvala <petri.latvala@intel.com>
+Reviewed-by: Christian König <christian.koenig@amd.com>
+Signed-off-by: Daniel Vetter <daniel.vetter@ffwll.ch>
+Link: http://patchwork.freedesktop.org/patch/msgid/20161005122145.1507-2-chris@chris-wilson.co.uk
+(cherry picked from commit a4fce9cb782ad340ee5576a38e934e5e75832dc6)
+---
+ drivers/gpu/drm/armada/armada_gem.c    |  2 +-
+ drivers/gpu/drm/drm_prime.c            | 30 +++++++++++++++++++++++++++++-
+ drivers/gpu/drm/i915/i915_gem_dmabuf.c |  2 +-
+ drivers/gpu/drm/tegra/gem.c            |  2 +-
+ drivers/gpu/drm/udl/udl_dmabuf.c       |  2 +-
+ include/drm/drmP.h                     |  4 ++++
+ 6 files changed, 37 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/gpu/drm/armada/armada_gem.c b/drivers/gpu/drm/armada/armada_gem.c
+index 60a688ef81c7..cd5bb991f49a 100644
+--- a/drivers/gpu/drm/armada/armada_gem.c
++++ b/drivers/gpu/drm/armada/armada_gem.c
+@@ -546,7 +546,7 @@ armada_gem_prime_export(struct drm_device *dev, struct drm_gem_object *obj,
+ 	exp_info.flags = O_RDWR;
+ 	exp_info.priv = obj;
+ 
+-	return dma_buf_export(&exp_info);
++	return drm_gem_dmabuf_export(dev, &exp_info);
+ }
+ 
+ struct drm_gem_object *
+diff --git a/drivers/gpu/drm/drm_prime.c b/drivers/gpu/drm/drm_prime.c
+index 4c49e736bc9c..94b4872255c8 100644
+--- a/drivers/gpu/drm/drm_prime.c
++++ b/drivers/gpu/drm/drm_prime.c
+@@ -283,19 +283,47 @@ static void drm_gem_unmap_dma_buf(struct dma_buf_attachment *attach,
+ 	/* nothing to be done here */
+ }
+ 
++/**
++ * drm_gem_dmabuf_export - dma_buf export implementation for GEM
++ * @dma_buf: buffer to be exported
++ *
++ * This wraps dma_buf_export() for use by generic GEM drivers that are using
++ * drm_gem_dmabuf_release(). In addition to calling dma_buf_export(), we take
++ * a reference to the drm_device which is released by drm_gem_dmabuf_release().
++ *
++ * Returns the new dmabuf.
++ */
++struct dma_buf *drm_gem_dmabuf_export(struct drm_device *dev,
++				      struct dma_buf_export_info *exp_info)
++{
++	struct dma_buf *dma_buf;
++
++	dma_buf = dma_buf_export(exp_info);
++	if (!IS_ERR(dma_buf))
++		drm_dev_ref(dev);
++
++	return dma_buf;
++}
++EXPORT_SYMBOL(drm_gem_dmabuf_export);
++
+ /**
+  * drm_gem_dmabuf_release - dma_buf release implementation for GEM
+  * @dma_buf: buffer to be released
+  *
+  * Generic release function for dma_bufs exported as PRIME buffers. GEM drivers
+  * must use this in their dma_buf ops structure as the release callback.
++ * drm_gem_dmabuf_release() should be used in conjunction with
++ * drm_gem_dmabuf_export().
+  */
+ void drm_gem_dmabuf_release(struct dma_buf *dma_buf)
+ {
+ 	struct drm_gem_object *obj = dma_buf->priv;
++	struct drm_device *dev = obj->dev;
+ 
+ 	/* drop the reference on the export fd holds */
+ 	drm_gem_object_unreference_unlocked(obj);
++
++	drm_dev_unref(dev);
+ }
+ EXPORT_SYMBOL(drm_gem_dmabuf_release);
+ 
+@@ -444,7 +472,7 @@ struct dma_buf *drm_gem_prime_export(struct drm_device *dev,
+ 	if (dev->driver->gem_prime_res_obj)
+ 		exp_info.resv = dev->driver->gem_prime_res_obj(obj);
+ 
+-	return dma_buf_export(&exp_info);
++	return drm_gem_dmabuf_export(dev, &exp_info);
+ }
+ EXPORT_SYMBOL(drm_gem_prime_export);
+ 
+diff --git a/drivers/gpu/drm/i915/i915_gem_dmabuf.c b/drivers/gpu/drm/i915/i915_gem_dmabuf.c
+index e9c2bfd85b52..d4a021629bd6 100644
+--- a/drivers/gpu/drm/i915/i915_gem_dmabuf.c
++++ b/drivers/gpu/drm/i915/i915_gem_dmabuf.c
+@@ -244,7 +244,7 @@ struct dma_buf *i915_gem_prime_export(struct drm_device *dev,
+ 			return ERR_PTR(ret);
+ 	}
+ 
+-	return dma_buf_export(&exp_info);
++	return drm_gem_dmabuf_export(dev, &exp_info);
+ }
+ 
+ static int i915_gem_object_get_pages_dmabuf(struct drm_i915_gem_object *obj)
+diff --git a/drivers/gpu/drm/tegra/gem.c b/drivers/gpu/drm/tegra/gem.c
+index 01e16e146bfe..da06f1c1ee0f 100644
+--- a/drivers/gpu/drm/tegra/gem.c
++++ b/drivers/gpu/drm/tegra/gem.c
+@@ -625,7 +625,7 @@ struct dma_buf *tegra_gem_prime_export(struct drm_device *drm,
+ 	exp_info.flags = flags;
+ 	exp_info.priv = gem;
+ 
+-	return dma_buf_export(&exp_info);
++	return drm_gem_dmabuf_export(drm, &exp_info);
+ }
+ 
+ struct drm_gem_object *tegra_gem_prime_import(struct drm_device *drm,
+diff --git a/drivers/gpu/drm/udl/udl_dmabuf.c b/drivers/gpu/drm/udl/udl_dmabuf.c
+index e2243edd1ce3..ac90ffdb5912 100644
+--- a/drivers/gpu/drm/udl/udl_dmabuf.c
++++ b/drivers/gpu/drm/udl/udl_dmabuf.c
+@@ -209,7 +209,7 @@ struct dma_buf *udl_gem_prime_export(struct drm_device *dev,
+ 	exp_info.flags = flags;
+ 	exp_info.priv = obj;
+ 
+-	return dma_buf_export(&exp_info);
++	return drm_gem_dmabuf_export(dev, &exp_info);
+ }
+ 
+ static int udl_prime_create(struct drm_device *dev,
+diff --git a/include/drm/drmP.h b/include/drm/drmP.h
+index 93da65df2e7e..4aba6478d718 100644
+--- a/include/drm/drmP.h
++++ b/include/drm/drmP.h
+@@ -1124,6 +1124,8 @@ static inline int drm_debugfs_remove_files(const struct drm_info_list *files,
+ }
+ #endif
+ 
++struct dma_buf_export_info;
++
+ extern struct dma_buf *drm_gem_prime_export(struct drm_device *dev,
+ 					    struct drm_gem_object *obj,
+ 					    int flags);
+@@ -1134,6 +1136,8 @@ extern struct drm_gem_object *drm_gem_prime_import(struct drm_device *dev,
+ 		struct dma_buf *dma_buf);
+ extern int drm_gem_prime_fd_to_handle(struct drm_device *dev,
+ 		struct drm_file *file_priv, int prime_fd, uint32_t *handle);
++struct dma_buf *drm_gem_dmabuf_export(struct drm_device *dev,
++				      struct dma_buf_export_info *exp_info);
+ extern void drm_gem_dmabuf_release(struct dma_buf *dma_buf);
+ 
+ extern int drm_prime_sg_to_page_addr_arrays(struct sg_table *sgt, struct page **pages,
+
+From 2c0a8737dd35ba259d3bbbf1b956fb43da32f117 Mon Sep 17 00:00:00 2001
+From: Chris Wilson <chris@chris-wilson.co.uk>
+Date: Wed, 7 Dec 2016 21:45:27 +0000
+Subject: [PATCH] UPSTREAM: drm: Take ownership of the dmabuf->obj when
+ exporting
+
+Currently the reference for the dmabuf->obj is incremented for the
+dmabuf in drm_gem_prime_handle_to_fd() (at the high level userspace
+interface), but is released in drm_gem_dmabuf_release() (the lowlevel
+handler). Improve the symmetry of the dmabuf->obj ownership by acquiring
+the reference in drm_gem_dmabuf_export(). This makes it easier to use
+the prime functions directly.
+
+Signed-off-by: Chris Wilson <chris@chris-wilson.co.uk>
+[danvet: Update kerneldoc.]
+Signed-off-by: Daniel Vetter <daniel.vetter@ffwll.ch>
+Link: http://patchwork.freedesktop.org/patch/msgid/20161207214527.22533-1-chris@chris-wilson.co.uk
+(cherry picked from commit 72a93e8dd52c9feea42f1258d555e6070680a347)
+---
+ drivers/gpu/drm/drm_prime.c | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/gpu/drm/drm_prime.c b/drivers/gpu/drm/drm_prime.c
+index 94b4872255c8..dbd34fa7f71c 100644
+--- a/drivers/gpu/drm/drm_prime.c
++++ b/drivers/gpu/drm/drm_prime.c
+@@ -289,7 +289,8 @@ static void drm_gem_unmap_dma_buf(struct dma_buf_attachment *attach,
+  *
+  * This wraps dma_buf_export() for use by generic GEM drivers that are using
+  * drm_gem_dmabuf_release(). In addition to calling dma_buf_export(), we take
+- * a reference to the drm_device which is released by drm_gem_dmabuf_release().
++ * a reference to the &drm_device and the exported &drm_gem_object (stored in
++ * exp_info->priv) which is released by drm_gem_dmabuf_release().
+  *
+  * Returns the new dmabuf.
+  */
+@@ -299,8 +300,11 @@ struct dma_buf *drm_gem_dmabuf_export(struct drm_device *dev,
+ 	struct dma_buf *dma_buf;
+ 
+ 	dma_buf = dma_buf_export(exp_info);
+-	if (!IS_ERR(dma_buf))
+-		drm_dev_ref(dev);
++	if (IS_ERR(dma_buf))
++		return dma_buf;
++
++	drm_dev_ref(dev);
++	drm_gem_object_reference(exp_info->priv);
+ 
+ 	return dma_buf;
+ }
+@@ -503,8 +507,6 @@ static struct dma_buf *export_and_register_object(struct drm_device *dev,
+ 	 */
+ 	obj->dma_buf = dmabuf;
+ 	get_dma_buf(obj->dma_buf);
+-	/* Grab a new ref since the callers is now used by the dma-buf */
+-	drm_gem_object_reference(obj);
+ 
+ 	return dmabuf;
+ }
+
+From 595e921b1e908458bd1ee022c9a7ee08cf203ad9 Mon Sep 17 00:00:00 2001
+From: Lucas Stach <l.stach@pengutronix.de>
+Date: Thu, 30 Nov 2017 18:34:28 +0100
+Subject: [PATCH] UPSTREAM: drm/prime: skip CPU sync in map/unmap dma_buf
+
+Dma-bufs should already be device coherent, as they are only pulled in the
+CPU domain via the begin/end cpu_access calls. As we cache the mapping set
+up by dma_map_sg a CPU sync at this point will not actually guarantee proper
+coherency on non-coherent architectures, so we can as well stop pretending.
+
+This is an important performance fix for architectures which need explicit
+cache synchronization and userspace doing lots of dma-buf imports.
+Improves Weston on Etnaviv performance 5x, where before this patch > 90%
+of Weston CPU time was spent synchronizing caches for buffers which are
+already device coherent.
+
+Signed-off-by: Lucas Stach <l.stach@pengutronix.de>
+Reviewed-by: Chris Wilson <chris@chris-wilson.co.uk>
+Signed-off-by: Daniel Vetter <daniel.vetter@ffwll.ch>
+Link: https://patchwork.freedesktop.org/patch/msgid/20171130173428.8666-1-l.stach@pengutronix.de
+(cherry picked from commit ca0e68e21aae10220eff71a297e7d794425add77)
+---
+ drivers/gpu/drm/drm_prime.c | 11 ++++++++---
+ 1 file changed, 8 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/gpu/drm/drm_prime.c b/drivers/gpu/drm/drm_prime.c
+index dbd34fa7f71c..133362279591 100644
+--- a/drivers/gpu/drm/drm_prime.c
++++ b/drivers/gpu/drm/drm_prime.c
+@@ -203,9 +203,12 @@ static void drm_gem_map_detach(struct dma_buf *dma_buf,
+ 
+ 	sgt = prime_attach->sgt;
+ 	if (sgt) {
++		DEFINE_DMA_ATTRS(attrs);
++		dma_set_attr(DMA_ATTR_SKIP_CPU_SYNC, &attrs);
+ 		if (prime_attach->dir != DMA_NONE)
+-			dma_unmap_sg(attach->dev, sgt->sgl, sgt->nents,
+-					prime_attach->dir);
++			dma_unmap_sg_attrs(attach->dev, sgt->sgl, sgt->nents,
++					   prime_attach->dir,
++					   &attrs);
+ 		sg_free_table(sgt);
+ 	}
+ 
+@@ -263,7 +266,9 @@ static struct sg_table *drm_gem_map_dma_buf(struct dma_buf_attachment *attach,
+ 	sgt = obj->dev->driver->gem_prime_get_sg_table(obj);
+ 
+ 	if (!IS_ERR(sgt)) {
+-		if (!dma_map_sg(attach->dev, sgt->sgl, sgt->nents, dir)) {
++		DEFINE_DMA_ATTRS(attrs);
++		dma_set_attr(DMA_ATTR_SKIP_CPU_SYNC, &attrs);
++		if (!dma_map_sg_attrs(attach->dev, sgt->sgl, sgt->nents, dir, &attrs)) {
+ 			sg_free_table(sgt);
+ 			kfree(sgt);
+ 			sgt = ERR_PTR(-ENOMEM);
+
+From d314fd1a48e930d034eccd49342a23340c3f1c27 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Christian=20K=C3=B6nig?= <ckoenig.leichtzumerken@gmail.com>
+Date: Tue, 27 Feb 2018 12:49:56 +0100
+Subject: [PATCH] UPSTREAM: drm/prime: fix potential race in drm_gem_map_detach
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Unpin the GEM object only after freeing the sg table.
+
+Signed-off-by: Christian König <christian.koenig@amd.com>
+Reviewed-by: Daniel Vetter <daniel.vetter@ffwll.ch>
+Acked-by: Roger He <Hongbo.He@amd.com>
+Signed-off-by: Alex Deucher <alexander.deucher@amd.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20180227115000.4105-1-christian.koenig@amd.com
+(cherry picked from commit 681066ec1d41e4b299146bada52cef846b323c04)
+---
+ drivers/gpu/drm/drm_prime.c | 36 ++++++++++++++++++------------------
+ 1 file changed, 18 insertions(+), 18 deletions(-)
+
+diff --git a/drivers/gpu/drm/drm_prime.c b/drivers/gpu/drm/drm_prime.c
+index 133362279591..95ecc69d03a0 100644
+--- a/drivers/gpu/drm/drm_prime.c
++++ b/drivers/gpu/drm/drm_prime.c
+@@ -193,28 +193,28 @@ static void drm_gem_map_detach(struct dma_buf *dma_buf,
+ 	struct drm_prime_attachment *prime_attach = attach->priv;
+ 	struct drm_gem_object *obj = dma_buf->priv;
+ 	struct drm_device *dev = obj->dev;
+-	struct sg_table *sgt;
+-
+-	if (dev->driver->gem_prime_unpin)
+-		dev->driver->gem_prime_unpin(obj);
+ 
+-	if (!prime_attach)
+-		return;
++	if (prime_attach) {
++		struct sg_table *sgt = prime_attach->sgt;
++
++		if (sgt) {
++			DEFINE_DMA_ATTRS(attrs);
++			dma_set_attr(DMA_ATTR_SKIP_CPU_SYNC, &attrs);
++			if (prime_attach->dir != DMA_NONE)
++				dma_unmap_sg_attrs(attach->dev, sgt->sgl,
++						   sgt->nents,
++						   prime_attach->dir,
++						   &attrs);
++			sg_free_table(sgt);
++		}
+ 
+-	sgt = prime_attach->sgt;
+-	if (sgt) {
+-		DEFINE_DMA_ATTRS(attrs);
+-		dma_set_attr(DMA_ATTR_SKIP_CPU_SYNC, &attrs);
+-		if (prime_attach->dir != DMA_NONE)
+-			dma_unmap_sg_attrs(attach->dev, sgt->sgl, sgt->nents,
+-					   prime_attach->dir,
+-					   &attrs);
+-		sg_free_table(sgt);
++		kfree(sgt);
++		kfree(prime_attach);
++		attach->priv = NULL;
+ 	}
+ 
+-	kfree(sgt);
+-	kfree(prime_attach);
+-	attach->priv = NULL;
++	if (dev->driver->gem_prime_unpin)
++		dev->driver->gem_prime_unpin(obj);
+ }
+ 
+ void drm_prime_remove_buf_handle_locked(struct drm_prime_file_private *prime_fpriv,
+
+From c74449bbd7e3ee3f3195ac9da48271c83c56f101 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Christian=20K=C3=B6nig?= <ckoenig.leichtzumerken@gmail.com>
+Date: Tue, 27 Feb 2018 12:49:57 +0100
+Subject: [PATCH] UPSTREAM: drm/prime: make the pages array optional for
+ drm_prime_sg_to_page_addr_arrays
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Most of the time we only need the dma addresses.
+
+Signed-off-by: Christian König <christian.koenig@amd.com>
+Reviewed-by: Roger He <Hongbo.He@amd.com>
+Signed-off-by: Alex Deucher <alexander.deucher@amd.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20180227115000.4105-2-christian.koenig@amd.com
+Link: https://patchwork.freedesktop.org/patch/msgid/20180227115000.4105-3-christian.koenig@amd.com
+Link: https://patchwork.freedesktop.org/patch/msgid/20180227115000.4105-4-christian.koenig@amd.com
+Link: https://patchwork.freedesktop.org/patch/msgid/20180227115000.4105-5-christian.koenig@amd.com
+Link: https://patchwork.freedesktop.org/patch/msgid/BN6PR12MB18262C0DE9B5F07B9A42EAE7F2C60@BN6PR12MB1826.namprd12.prod.outlook.com
+(cherry picked from commit 186ca446aea19e49d2e1433dd170c6e1c211a52a)
+---
+ drivers/gpu/drm/drm_prime.c | 20 ++++++++++----------
+ 1 file changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/gpu/drm/drm_prime.c b/drivers/gpu/drm/drm_prime.c
+index 95ecc69d03a0..7ea65c4105c1 100644
+--- a/drivers/gpu/drm/drm_prime.c
++++ b/drivers/gpu/drm/drm_prime.c
+@@ -827,40 +827,40 @@ EXPORT_SYMBOL(drm_prime_pages_to_sg);
+ /**
+  * drm_prime_sg_to_page_addr_arrays - convert an sg table into a page array
+  * @sgt: scatter-gather table to convert
+- * @pages: array of page pointers to store the page array in
++ * @pages: optional array of page pointers to store the page array in
+  * @addrs: optional array to store the dma bus address of each page
+- * @max_pages: size of both the passed-in arrays
++ * @max_entries: size of both the passed-in arrays
+  *
+  * Exports an sg table into an array of pages and addresses. This is currently
+  * required by the TTM driver in order to do correct fault handling.
+  */
+ int drm_prime_sg_to_page_addr_arrays(struct sg_table *sgt, struct page **pages,
+-				     dma_addr_t *addrs, int max_pages)
++				     dma_addr_t *addrs, int max_entries)
+ {
+ 	unsigned count;
+ 	struct scatterlist *sg;
+ 	struct page *page;
+-	u32 len;
+-	int pg_index;
++	u32 len, index;
+ 	dma_addr_t addr;
+ 
+-	pg_index = 0;
++	index = 0;
+ 	for_each_sg(sgt->sgl, sg, sgt->nents, count) {
+ 		len = sg->length;
+ 		page = sg_page(sg);
+ 		addr = sg_dma_address(sg);
+ 
+ 		while (len > 0) {
+-			if (WARN_ON(pg_index >= max_pages))
++			if (WARN_ON(index >= max_entries))
+ 				return -1;
+-			pages[pg_index] = page;
++			if (pages)
++				pages[index] = page;
+ 			if (addrs)
+-				addrs[pg_index] = addr;
++				addrs[index] = addr;
+ 
+ 			page++;
+ 			addr += PAGE_SIZE;
+ 			len -= PAGE_SIZE;
+-			pg_index++;
++			index++;
+ 		}
+ 	}
+ 	return 0;
+
+From 2fc969d64eb928db78c9fd99fb68d9d2442a8919 Mon Sep 17 00:00:00 2001
+From: Chris Wilson <chris@chris-wilson.co.uk>
+Date: Sat, 19 Aug 2017 13:05:58 +0100
+Subject: [PATCH] UPSTREAM: drm: Release driver tracking before making the
+ object available again
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This is the same bug as we fixed in commit f6cd7daecff5 ("drm: Release
+driver references to handle before making it available again"), but now
+the exposure is via the PRIME lookup tables. If we remove the
+object/handle from the PRIME lut, then a new request for the same
+object/fd will generate a new handle, thus for a short window that
+object is known to userspace by two different handles. Fix this by
+releasing the driver tracking before PRIME.
+
+Fixes: 0ff926c7d4f0 ("drm/prime: add exported buffers to current fprivs
+imported buffer list (v2)")
+Signed-off-by: Chris Wilson <chris@chris-wilson.co.uk>
+Cc: David Airlie <airlied@linux.ie>
+Cc: Daniel Vetter <daniel.vetter@intel.com>
+Cc: Rob Clark <robdclark@gmail.com>
+Cc: Ville Syrjälä <ville.syrjala@linux.intel.com>
+Cc: Thierry Reding <treding@nvidia.com>
+Cc: stable@vger.kernel.org
+Reviewed-by: Daniel Vetter <daniel.vetter@ffwll.ch>
+Signed-off-by: Joonas Lahtinen <joonas.lahtinen@linux.intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20170819120558.6465-1-chris@chris-wilson.co.uk
+(cherry picked from commit d0a133f7f5bc3583e460ba6bb54474a50ada5201)
+---
+ drivers/gpu/drm/drm_gem.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/gpu/drm/drm_gem.c b/drivers/gpu/drm/drm_gem.c
+index d7f39a03c2c9..966ea63581b1 100644
+--- a/drivers/gpu/drm/drm_gem.c
++++ b/drivers/gpu/drm/drm_gem.c
+@@ -255,13 +255,13 @@ drm_gem_object_release_handle(int id, void *ptr, void *data)
+ 	struct drm_gem_object *obj = ptr;
+ 	struct drm_device *dev = obj->dev;
+ 
++	if (dev->driver->gem_close_object)
++		dev->driver->gem_close_object(obj, file_priv);
++
+ 	if (drm_core_check_feature(dev, DRIVER_PRIME))
+ 		drm_gem_remove_prime_handles(obj, file_priv);
+ 	drm_vma_node_revoke(&obj->vma_node, file_priv->filp);
+ 
+-	if (dev->driver->gem_close_object)
+-		dev->driver->gem_close_object(obj, file_priv);
+-
+ 	drm_gem_object_handle_unreference_unlocked(obj);
+ 
+ 	return 0;
+
+From 1d9b65acb4e776f43408afed2b0fd7b86fdb95ce Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sat, 17 Feb 2018 05:30:36 +0100
+Subject: [PATCH] vcodec: skip reduce freq
+
+---
+ drivers/video/rockchip/vcodec/vcodec_service.c | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/drivers/video/rockchip/vcodec/vcodec_service.c b/drivers/video/rockchip/vcodec/vcodec_service.c
+index c4ee73be92d3..9d5ee5c8b1f9 100644
+--- a/drivers/video/rockchip/vcodec/vcodec_service.c
++++ b/drivers/video/rockchip/vcodec/vcodec_service.c
+@@ -1630,9 +1630,6 @@ static void try_set_reg(struct vpu_subdev_data *data)
+ 			reg_from_wait_to_run(pservice, reg);
+ 			reg_copy_to_hw(reg->data, reg);
+ 		}
+-	} else {
+-		if (pservice->hw_ops->reduce_freq)
+-			pservice->hw_ops->reduce_freq(pservice);
+ 	}
+ 
+ 	mutex_unlock(&pservice->shutdown_lock);
+@@ -2385,6 +2382,7 @@ static void vcodec_set_freq_rk3328(struct vpu_service_info *pservice,
+ 	if (curr == reg->freq)
+ 		return;
+ 
++	atomic_set(&pservice->freq_status, reg->freq);
+ 	if (pservice->dev_id == VCODEC_DEVICE_ID_RKVDEC) {
+ 		if (reg->reg[1] & 0x00800000) {
+ 			if (rkv_dec_get_fmt(reg->reg) == FMT_H264D)

--- a/patch/kernel/rockchip64-legacy/video-fixes.patch
+++ b/patch/kernel/rockchip64-legacy/video-fixes.patch
@@ -1,0 +1,840 @@
+From 61382c4e328df487f69b2095865c2e9e2c9e4121 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sun, 28 May 2017 09:08:50 +0200
+Subject: [PATCH] gpu/arm/mali400: default to performance gpu governor
+
+---
+ drivers/gpu/arm/mali400/mali/linux/mali_devfreq.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/arm/mali400/mali/linux/mali_devfreq.c b/drivers/gpu/arm/mali400/mali/linux/mali_devfreq.c
+index c9b8652f100d..6c97c530a2ae 100644
+--- a/drivers/gpu/arm/mali400/mali/linux/mali_devfreq.c
++++ b/drivers/gpu/arm/mali400/mali/linux/mali_devfreq.c
+@@ -259,7 +259,7 @@ int mali_devfreq_init(struct mali_device *mdev)
+ 		return -EFAULT;
+ 
+ 	mdev->devfreq = devfreq_add_device(mdev->dev, dp,
+-					   "simple_ondemand", NULL);
++					   "performance", NULL);
+ 	if (IS_ERR(mdev->devfreq)) {
+ 		mali_devfreq_term_freq_table(mdev);
+ 		return PTR_ERR(mdev->devfreq);
+
+diff --git a/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c b/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c
+index a58edabe600c..7273561fe6b1 100644
+--- a/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c
++++ b/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c
+@@ -510,9 +510,15 @@ dw_hdmi_rockchip_mode_valid(struct drm_connector *connector,
+ 		return MODE_BAD;
+ 
+ 	hdmi = to_rockchip_hdmi(encoder);
+-	if (hdmi->dev_type == RK3368_HDMI && mode->clock > 340000 &&
++	if ((hdmi->dev_type == RK3368_HDMI || hdmi->dev_type == RK3328_HDMI) &&
++	    mode->clock > 340000 &&
+ 	    !drm_mode_is_420(&connector->display_info, mode))
+ 		return MODE_BAD;
++
++	/* Skip bad clocks for RK3288 */
++	if (hdmi->dev_type == RK3288_HDMI && (mode->clock < 27500 || mode->clock > 340000))
++		return MODE_CLOCK_RANGE;
++
+ 	/*
+ 	 * ensure all drm display mode can work, if someone want support more
+ 	 * resolutions, please limit the possible_crtc, only connect to
+
+From 28e3e0508d53dd697fc3dd75588bba08adee1bb0 Mon Sep 17 00:00:00 2001
+From: xuhuicong <xhc@rock-chips.com>
+Date: Fri, 23 Jun 2017 18:56:17 +0800
+Subject: [PATCH] drm/rockchip: hdmi: fix no sound some time
+
+Change-Id: Ic9f931d9a5b7bca954363293a20ca242eb0bfa6f
+Signed-off-by: xuhuicong <xhc@rock-chips.com>
+---
+ drivers/gpu/drm/bridge/synopsys/dw-hdmi.c | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
+index 8cb2cb4e61a6..30b6bd979eb8 100644
+--- a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
++++ b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
+@@ -1991,10 +1991,6 @@ static void hdmi_av_composer(struct dw_hdmi *hdmi,
+ 		HDMI_FC_INVIDCONF_IN_I_P_INTERLACED :
+ 		HDMI_FC_INVIDCONF_IN_I_P_PROGRESSIVE;
+ 
+-	inv_val |= hdmi->sink_is_hdmi ?
+-		HDMI_FC_INVIDCONF_DVI_MODEZ_HDMI_MODE :
+-		HDMI_FC_INVIDCONF_DVI_MODEZ_DVI_MODE;
+-
+ 	hdmi_writeb(hdmi, inv_val, HDMI_FC_INVIDCONF);
+ 
+ 	hdisplay = mode->hdisplay;
+@@ -2292,6 +2288,9 @@ static int dw_hdmi_setup(struct dw_hdmi *hdmi, struct drm_display_mode *mode)
+ 	/* not for DVI mode */
+ 	if (hdmi->sink_is_hdmi) {
+ 		dev_dbg(hdmi->dev, "%s HDMI mode\n", __func__);
++		hdmi_modb(hdmi, HDMI_FC_INVIDCONF_DVI_MODEZ_HDMI_MODE,
++			  HDMI_FC_INVIDCONF_DVI_MODEZ_HDMI_MODE,
++			  HDMI_FC_INVIDCONF);
+ 
+ 		/* HDMI Initialization Step F - Configure AVI InfoFrame */
+ 		hdmi_config_AVI(hdmi, mode);
+
+From 16f51adab10ab06bfecbd0ed9e444329debb426d Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sat, 18 Nov 2017 11:09:39 +0100
+Subject: [PATCH] rockchip: vop: force skip lines if image too big
+
+---
+ drivers/gpu/drm/rockchip/rockchip_drm_vop.c | 13 ++++++++++---
+ 1 file changed, 10 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/gpu/drm/rockchip/rockchip_drm_vop.c b/drivers/gpu/drm/rockchip/rockchip_drm_vop.c
+index 76610608c723..1418402c2668 100644
+--- a/drivers/gpu/drm/rockchip/rockchip_drm_vop.c
++++ b/drivers/gpu/drm/rockchip/rockchip_drm_vop.c
+@@ -1653,6 +1653,7 @@ static void vop_plane_atomic_update(struct drm_plane *plane,
+ 	int ymirror, xmirror;
+ 	uint32_t val;
+ 	bool rb_swap, global_alpha_en;
++	int skip_lines = 0;
+ 
+ #if defined(CONFIG_ROCKCHIP_DRM_DEBUG)
+ 	bool AFBC_flag = false;
+@@ -1689,8 +1690,14 @@ static void vop_plane_atomic_update(struct drm_plane *plane,
+ 	}
+ 
+ 	mode = &crtc->state->adjusted_mode;
++
++	/*
++	 * force skip lines if image too big.
++	 */
+ 	actual_w = drm_rect_width(src) >> 16;
+-	actual_h = drm_rect_height(src) >> 16;
++	if (actual_w == 3840 && is_yuv_support(fb->pixel_format))
++		skip_lines = 1;
++	actual_h = drm_rect_height(src) >> (16 + skip_lines);
+ 	act_info = (actual_h - 1) << 16 | ((actual_w - 1) & 0xffff);
+ 
+ 	dsp_info = (drm_rect_height(dest) - 1) << 16;
+@@ -1727,12 +1734,12 @@ static void vop_plane_atomic_update(struct drm_plane *plane,
+ 	VOP_WIN_SET(vop, win, xmirror, xmirror);
+ 	VOP_WIN_SET(vop, win, ymirror, ymirror);
+ 	VOP_WIN_SET(vop, win, format, vop_plane_state->format);
+-	VOP_WIN_SET(vop, win, yrgb_vir, fb->pitches[0] >> 2);
++	VOP_WIN_SET(vop, win, yrgb_vir, fb->pitches[0] >> (2 - skip_lines));
+ 	VOP_WIN_SET(vop, win, yrgb_mst, vop_plane_state->yrgb_mst);
+ 	VOP_WIN_SET(vop, win, yrgb_mst1, vop_plane_state->yrgb_mst);
+ 
+ 	if (is_yuv_support(fb->pixel_format)) {
+-		VOP_WIN_SET(vop, win, uv_vir, fb->pitches[1] >> 2);
++		VOP_WIN_SET(vop, win, uv_vir, fb->pitches[1] >> (2 - skip_lines));
+ 		VOP_WIN_SET(vop, win, uv_mst, vop_plane_state->uv_mst);
+ 	}
+ 	VOP_WIN_SET(vop, win, fmt_10, is_yuv_10bit(fb->pixel_format));
+
+From d56d2c8dcd6dc828693bed0cf965d68e90431019 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sat, 18 Nov 2017 23:17:24 +0100
+Subject: [PATCH] gpu/arm/midgard: default to performance gpu governor
+
+---
+ drivers/gpu/arm/midgard/backend/gpu/mali_kbase_devfreq.c | 5 ++---
+ drivers/gpu/arm/midgard/mali_kbase_config_defaults.h     | 3 +--
+ 2 files changed, 3 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/gpu/arm/midgard/backend/gpu/mali_kbase_devfreq.c b/drivers/gpu/arm/midgard/backend/gpu/mali_kbase_devfreq.c
+index 1495f06cd9b9..a6d2e0121015 100644
+--- a/drivers/gpu/arm/midgard/backend/gpu/mali_kbase_devfreq.c
++++ b/drivers/gpu/arm/midgard/backend/gpu/mali_kbase_devfreq.c
+@@ -348,8 +348,7 @@ int kbase_devfreq_init(struct kbase_device *kbdev)
+ 	dp = &kbdev->devfreq_profile;
+ 
+ 	dp->initial_freq = kbdev->current_freq;
+-	/* .KP : set devfreq_dvfs_interval_in_ms */
+-	dp->polling_ms = 20;
++	dp->polling_ms = 100;
+ 	dp->target = kbase_devfreq_target;
+ 	dp->get_dev_status = kbase_devfreq_status;
+ 	dp->get_cur_freq = kbase_devfreq_cur_freq;
+@@ -363,7 +362,7 @@ int kbase_devfreq_init(struct kbase_device *kbdev)
+ 		return err;
+ 
+ 	kbdev->devfreq = devfreq_add_device(kbdev->dev, dp,
+-				"simple_ondemand", NULL);
++				"performance", NULL);
+ 	if (IS_ERR(kbdev->devfreq)) {
+ 		kbase_devfreq_term_freq_table(kbdev);
+ 		return PTR_ERR(kbdev->devfreq);
+diff --git a/drivers/gpu/arm/midgard/mali_kbase_config_defaults.h b/drivers/gpu/arm/midgard/mali_kbase_config_defaults.h
+index 1cf44b3500cf..a6a1a52f0463 100644
+--- a/drivers/gpu/arm/midgard/mali_kbase_config_defaults.h
++++ b/drivers/gpu/arm/midgard/mali_kbase_config_defaults.h
+@@ -109,8 +109,7 @@ enum {
+ /*
+  * Default period for DVFS sampling
+  */
+-// #define DEFAULT_PM_DVFS_PERIOD 100 /* 100ms */
+-#define DEFAULT_PM_DVFS_PERIOD 20 /* 20 ms */
++#define DEFAULT_PM_DVFS_PERIOD 100 /* 100ms */
+ 
+ /*
+  * Power Management poweroff tick granuality. This is in nanoseconds to
+
+From 955a2a87c8fa737d78c022afef1ed32fd6f06760 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sun, 10 Dec 2017 14:16:09 +0100
+Subject: [PATCH] uapi: install rockchip_drm header
+
+---
+ include/uapi/drm/Kbuild | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/include/uapi/drm/Kbuild b/include/uapi/drm/Kbuild
+index 38d437096c35..b7ae9969d41e 100644
+--- a/include/uapi/drm/Kbuild
++++ b/include/uapi/drm/Kbuild
+@@ -11,6 +11,7 @@ header-y += nouveau_drm.h
+ header-y += qxl_drm.h
+ header-y += r128_drm.h
+ header-y += radeon_drm.h
++header-y += rockchip_drm.h
+ header-y += savage_drm.h
+ header-y += sis_drm.h
+ header-y += tegra_drm.h
+
+From f3f9dc1c2c697f0c9fefd501731a07ef64a026b1 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Tue, 12 Dec 2017 00:37:27 +0100
+Subject: [PATCH] clk: rockchip: fix round rate
+
+---
+ drivers/clk/rockchip/clk-pll.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/drivers/clk/rockchip/clk-pll.c b/drivers/clk/rockchip/clk-pll.c
+index 0a9f31f2dd27..183114d824a7 100644
+--- a/drivers/clk/rockchip/clk-pll.c
++++ b/drivers/clk/rockchip/clk-pll.c
+@@ -364,6 +364,17 @@ static const struct rockchip_pll_rate_table *rockchip_get_pll_settings(
+ static long rockchip_pll_round_rate(struct clk_hw *hw,
+ 			    unsigned long drate, unsigned long *prate)
+ {
++	struct rockchip_clk_pll *pll = to_rockchip_clk_pll(hw);
++	const struct rockchip_pll_rate_table *rate;
++
++	/* Get required rate settings from table */
++	rate = rockchip_get_pll_settings(pll, drate);
++	if (!rate) {
++		pr_debug("%s: Invalid rate : %lu for pll clk %s\n", __func__,
++			drate, __clk_get_name(hw->clk));
++		return -EINVAL;
++	}
++
+ 	return drate;
+ }
+ 
+
+From 5a5f5ea8edcc75ca49961a458ac0380e60f30a4d Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sun, 21 Jan 2018 17:20:00 +0100
+Subject: [PATCH] drm: fix HDR metadata infoframe length
+
+HDR metadata infoframe length is 26 bytes (not 30) according to [1]
+(CTA-861-G: 6.9 Dynamic Range and Mastering InfoFrame)
+
+Fixes activation of HDR mode on my LG OLED
+
+[1] https://standards.cta.tech/kwspub/published_docs/CTA-861-G_FINAL_revised_2017.pdf
+---
+ drivers/gpu/drm/bridge/synopsys/dw-hdmi.c | 2 +-
+ drivers/gpu/drm/drm_edid.c                | 4 ++--
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
+index 30b6bd979eb8..ec002a4a7a7d 100644
+--- a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
++++ b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
+@@ -1857,7 +1857,7 @@ static void hdmi_config_hdr_infoframe(struct dw_hdmi *hdmi)
+ 		return;
+ 	}
+ 
+-	hdmi_writeb(hdmi, 1, HDMI_FC_DRM_HB0);
++	hdmi_writeb(hdmi, frame.version, HDMI_FC_DRM_HB0);
+ 	hdmi_writeb(hdmi, frame.length, HDMI_FC_DRM_HB1);
+ 	hdmi_writeb(hdmi, frame.eotf, HDMI_FC_DRM_PB0);
+ 	hdmi_writeb(hdmi, frame.metadata_type, HDMI_FC_DRM_PB1);
+diff --git a/drivers/gpu/drm/drm_edid.c b/drivers/gpu/drm/drm_edid.c
+index bfe671071d9f..e3a0f561e8f0 100644
+--- a/drivers/gpu/drm/drm_edid.c
++++ b/drivers/gpu/drm/drm_edid.c
+@@ -4735,10 +4735,10 @@ drm_hdmi_infoframe_set_hdr_metadata(struct hdmi_drm_infoframe *frame,
+ 
+ 	hdr_source_metadata = (struct hdr_static_metadata *)hdr_metadata;
+ 
+-	frame->length = sizeof(struct hdr_static_metadata);
++	frame->length = 26;
+ 
+ 	frame->eotf = hdr_source_metadata->eotf;
+-	frame->type = hdr_source_metadata->type;
++	frame->metadata_type = hdr_source_metadata->type;
+ 
+ 	for (i = 0; i < 3; i++) {
+ 		frame->display_primaries_x[i] =
+
+From 19e9d690fe47e5e4b47760d060b11707bb44194b Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sun, 11 Feb 2018 19:21:41 +0100
+Subject: [PATCH] drm: bridge: dw-hdmi: default to underscan mode
+
+---
+ drivers/gpu/drm/bridge/synopsys/dw-hdmi.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
+index ec002a4a7a7d..393bd5b28f07 100644
+--- a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
++++ b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
+@@ -1691,7 +1691,7 @@ static void hdmi_config_AVI(struct dw_hdmi *hdmi, struct drm_display_mode *mode)
+ 		break;
+ 	}
+ 
+-	frame.scan_mode = HDMI_SCAN_MODE_NONE;
++	frame.scan_mode = HDMI_SCAN_MODE_UNDERSCAN;
+ 
+ 	/*
+ 	 * The Designware IP uses a different byte format from standard
+
+From 922cc477bd191cbfddae005b27a2c89cb9c9623a Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sun, 1 Jul 2018 23:17:47 +0200
+Subject: [PATCH] drm/rockchip: clip yuv
+
+---
+ drivers/gpu/drm/rockchip/rockchip_drm_vop.c | 2 ++
+ drivers/gpu/drm/rockchip/rockchip_drm_vop.h | 2 ++
+ drivers/gpu/drm/rockchip/rockchip_vop_reg.c | 3 +++
+ 3 files changed, 7 insertions(+)
+
+diff --git a/drivers/gpu/drm/rockchip/rockchip_drm_vop.c b/drivers/gpu/drm/rockchip/rockchip_drm_vop.c
+index 1418402c2668..0916b4284f88 100644
+--- a/drivers/gpu/drm/rockchip/rockchip_drm_vop.c
++++ b/drivers/gpu/drm/rockchip/rockchip_drm_vop.c
+@@ -1731,6 +1731,7 @@ static void vop_plane_atomic_update(struct drm_plane *plane,
+ 	s = to_rockchip_crtc_state(crtc->state);
+ 
+ 	spin_lock(&vop->reg_lock);
++	VOP_WIN_SET(vop, win, yuv_clip, 0);
+ 	VOP_WIN_SET(vop, win, xmirror, xmirror);
+ 	VOP_WIN_SET(vop, win, ymirror, ymirror);
+ 	VOP_WIN_SET(vop, win, format, vop_plane_state->format);
+@@ -2544,6 +2545,7 @@ static void vop_update_csc(struct drm_crtc *crtc)
+ 		VOP_CTRL_SET(vop, dsp_data_swap, 0);
+ 
+ 	VOP_CTRL_SET(vop, out_mode, s->output_mode);
++	VOP_CTRL_SET(vop, yuv_clip, 0);
+ 
+ 	switch (s->bus_format) {
+ 	case MEDIA_BUS_FMT_RGB565_1X16:
+diff --git a/drivers/gpu/drm/rockchip/rockchip_drm_vop.h b/drivers/gpu/drm/rockchip/rockchip_drm_vop.h
+index 618de17e608a..391998c7aa50 100644
+--- a/drivers/gpu/drm/rockchip/rockchip_drm_vop.h
++++ b/drivers/gpu/drm/rockchip/rockchip_drm_vop.h
+@@ -178,6 +178,7 @@ struct vop_ctrl {
+ 	struct vop_reg dsp_lut_en;
+ 
+ 	struct vop_reg out_mode;
++	struct vop_reg yuv_clip;
+ 
+ 	struct vop_reg xmirror;
+ 	struct vop_reg ymirror;
+@@ -409,6 +410,7 @@ struct vop_win_phy {
+ 	struct vop_reg format;
+ 	struct vop_reg fmt_10;
+ 	struct vop_reg csc_mode;
++	struct vop_reg yuv_clip;
+ 	struct vop_reg xmirror;
+ 	struct vop_reg ymirror;
+ 	struct vop_reg rb_swap;
+diff --git a/drivers/gpu/drm/rockchip/rockchip_vop_reg.c b/drivers/gpu/drm/rockchip/rockchip_vop_reg.c
+index 9c96d5614e54..aeb1c7644bc9 100644
+--- a/drivers/gpu/drm/rockchip/rockchip_vop_reg.c
++++ b/drivers/gpu/drm/rockchip/rockchip_vop_reg.c
+@@ -119,6 +119,7 @@ static const struct vop_win_phy rk3288_win01_data = {
+ 	.fmt_10 = VOP_REG(RK3288_WIN0_CTRL0, 0x7, 4),
+ 	.csc_mode = VOP_REG_VER(RK3288_WIN0_CTRL0, 0x3, 10, 3, 2, -1),
+ 	.rb_swap = VOP_REG(RK3288_WIN0_CTRL0, 0x1, 12),
++	.yuv_clip = VOP_REG(RK3288_WIN0_CTRL0, 0x1, 20),
+ 	.xmirror = VOP_REG_VER(RK3368_WIN0_CTRL0, 0x1, 21, 3, 2, -1),
+ 	.ymirror = VOP_REG_VER(RK3368_WIN0_CTRL0, 0x1, 22, 3, 2, -1),
+ 	.act_info = VOP_REG(RK3288_WIN0_ACT_INFO, 0x1fff1fff, 0),
+@@ -286,6 +287,7 @@ static const struct vop_ctrl rk3288_ctrl_data = {
+ 	.bcsh_color_bar = VOP_REG(RK3288_BCSH_COLOR_BAR, 0xffffff, 8),
+ 	.bcsh_en = VOP_REG(RK3288_BCSH_COLOR_BAR, 0x1, 0),
+ 
++	.yuv_clip = VOP_REG(RK3288_DSP_CTRL0, 0x1, 21),
+ 	.xmirror = VOP_REG(RK3288_DSP_CTRL0, 0x1, 22),
+ 	.ymirror = VOP_REG(RK3288_DSP_CTRL0, 0x1, 23),
+ 
+@@ -964,6 +966,7 @@ static const struct vop_ctrl rk3328_ctrl_data = {
+ 	.dsp_lut_en = VOP_REG(RK3328_DSP_CTRL1, 0x1, 0),
+ 	.out_mode = VOP_REG(RK3328_DSP_CTRL0, 0xf, 0),
+ 
++	.yuv_clip = VOP_REG(RK3328_DSP_CTRL0, 0x1, 21),
+ 	.xmirror = VOP_REG(RK3328_DSP_CTRL0, 0x1, 22),
+ 	.ymirror = VOP_REG(RK3328_DSP_CTRL0, 0x1, 23),
+ 
+
+From 991811443d72d7915afdee23c30843669a347d7c Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sun, 8 Jul 2018 12:38:00 +0200
+Subject: [PATCH] drm/atomic: use active_only flag for connector atomic
+ begin/flush
+
+---
+ drivers/gpu/drm/drm_atomic_helper.c | 20 ++++++++++----------
+ 1 file changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/gpu/drm/drm_atomic_helper.c b/drivers/gpu/drm/drm_atomic_helper.c
+index f77d4aa1e58b..4da489b54dc5 100644
+--- a/drivers/gpu/drm/drm_atomic_helper.c
++++ b/drivers/gpu/drm/drm_atomic_helper.c
+@@ -1563,15 +1563,15 @@ void drm_atomic_helper_commit_planes(struct drm_device *dev,
+ 	for_each_connector_in_state(old_state, connector, old_conn_state, i) {
+ 		const struct drm_connector_helper_funcs *funcs;
+ 
+-		if (!connector->state->crtc)
+-			continue;
++		funcs = connector->helper_private;
+ 
+-		if (!connector->state->crtc->state->active)
++		if (!funcs || !funcs->atomic_begin)
+ 			continue;
+ 
+-		funcs = connector->helper_private;
++		if (!connector->state->crtc)
++			continue;
+ 
+-		if (!funcs || !funcs->atomic_begin)
++		if (active_only && !connector->state->crtc->state->active)
+ 			continue;
+ 
+ 		DRM_DEBUG_ATOMIC("flush beginning [CONNECTOR:%d:%s]\n",
+@@ -1645,15 +1645,15 @@ void drm_atomic_helper_commit_planes(struct drm_device *dev,
+ 	for_each_connector_in_state(old_state, connector, old_conn_state, i) {
+ 		const struct drm_connector_helper_funcs *funcs;
+ 
+-		if (!connector->state->crtc)
+-			continue;
++		funcs = connector->helper_private;
+ 
+-		if (!connector->state->crtc->state->active)
++		if (!funcs || !funcs->atomic_flush)
+ 			continue;
+ 
+-		funcs = connector->helper_private;
++		if (!connector->state->crtc)
++			continue;
+ 
+-		if (!funcs || !funcs->atomic_flush)
++		if (active_only && !connector->state->crtc->state->active)
+ 			continue;
+ 
+ 		DRM_DEBUG_ATOMIC("flushing [CONNECTOR:%d:%s]\n",
+
+From 8d514d5127fbb4d49247f893ac6b803cbdd3304d Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sun, 22 Jul 2018 14:51:58 +0200
+Subject: [PATCH] drm: rockchip: dw-hdmi: only force YCbCr422 when max tmds is
+ up to 340Mhz
+
+---
+ drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c b/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c
+index 7273561fe6b1..e2aad6e2149b 100644
+--- a/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c
++++ b/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c
+@@ -728,7 +728,9 @@ dw_hdmi_rockchip_select_output(struct drm_connector_state *conn_state,
+ 		/* BT2020 require color depth at lest 10bit */
+ 		*color_depth = 10;
+ 		/* We prefer use YCbCr422 to send 10bit */
+-		if (info->color_formats & DRM_COLOR_FORMAT_YCRCB422)
++		if (info->color_formats & DRM_COLOR_FORMAT_YCRCB422 &&
++		    info->max_tmds_clock <= 340000 &&
++		    hdmi->dev_type != RK3288_HDMI)
+ 			*color_format = DRM_HDMI_OUTPUT_YCBCR422;
+ 	}
+ 
+
+From 9d6de32c2e992b71e6634a284dc99ab1b3bd43e2 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sun, 22 Jul 2018 15:09:16 +0200
+Subject: [PATCH] drm: bridge: dw-hdmi: signal full range for rgb output
+
+---
+ drivers/gpu/drm/bridge/synopsys/dw-hdmi.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
+index 393bd5b28f07..91c5b8fc8fa0 100644
+--- a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
++++ b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
+@@ -1693,6 +1693,14 @@ static void hdmi_config_AVI(struct dw_hdmi *hdmi, struct drm_display_mode *mode)
+ 
+ 	frame.scan_mode = HDMI_SCAN_MODE_UNDERSCAN;
+ 
++	if (hdmi_bus_fmt_is_rgb(hdmi->hdmi_data.enc_out_bus_format)) {
++		frame.quantization_range = HDMI_QUANTIZATION_RANGE_FULL;
++		frame.ycc_quantization_range = HDMI_YCC_QUANTIZATION_RANGE_FULL;
++	} else {
++		frame.quantization_range = HDMI_QUANTIZATION_RANGE_LIMITED;
++		frame.ycc_quantization_range = HDMI_YCC_QUANTIZATION_RANGE_LIMITED;
++	}
++
+ 	/*
+ 	 * The Designware IP uses a different byte format from standard
+ 	 * AVI info frames, though generally the bits are in the correct
+
+From 24a070f21767a8d381b81ab5fc5f39c2b9729b24 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sat, 4 Aug 2018 15:19:39 +0200
+Subject: [PATCH] drm: add picture_aspect_ratio to hdmi 1.4 4k modes
+
+---
+ drivers/gpu/drm/drm_edid.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/gpu/drm/drm_edid.c b/drivers/gpu/drm/drm_edid.c
+index f7d41950614e..69a1eb4ee382 100644
+--- a/drivers/gpu/drm/drm_edid.c
++++ b/drivers/gpu/drm/drm_edid.c
+@@ -1233,25 +1233,25 @@ static const struct drm_display_mode edid_4k_modes[] = {
+ 		   3840, 4016, 4104, 4400, 0,
+ 		   2160, 2168, 2178, 2250, 0,
+ 		   DRM_MODE_FLAG_PHSYNC | DRM_MODE_FLAG_PVSYNC),
+-	  .vrefresh = 30, },
++	  .vrefresh = 30, .picture_aspect_ratio = HDMI_PICTURE_ASPECT_16_9, },
+ 	/* 2 - 3840x2160@25Hz */
+ 	{ DRM_MODE("3840x2160", DRM_MODE_TYPE_DRIVER, 297000,
+ 		   3840, 4896, 4984, 5280, 0,
+ 		   2160, 2168, 2178, 2250, 0,
+ 		   DRM_MODE_FLAG_PHSYNC | DRM_MODE_FLAG_PVSYNC),
+-	  .vrefresh = 25, },
++	  .vrefresh = 25, .picture_aspect_ratio = HDMI_PICTURE_ASPECT_16_9, },
+ 	/* 3 - 3840x2160@24Hz */
+ 	{ DRM_MODE("3840x2160", DRM_MODE_TYPE_DRIVER, 297000,
+ 		   3840, 5116, 5204, 5500, 0,
+ 		   2160, 2168, 2178, 2250, 0,
+ 		   DRM_MODE_FLAG_PHSYNC | DRM_MODE_FLAG_PVSYNC),
+-	  .vrefresh = 24, },
++	  .vrefresh = 24, .picture_aspect_ratio = HDMI_PICTURE_ASPECT_16_9, },
+ 	/* 4 - 4096x2160@24Hz (SMPTE) */
+ 	{ DRM_MODE("4096x2160", DRM_MODE_TYPE_DRIVER, 297000,
+ 		   4096, 5116, 5204, 5500, 0,
+ 		   2160, 2168, 2178, 2250, 0,
+ 		   DRM_MODE_FLAG_PHSYNC | DRM_MODE_FLAG_PVSYNC),
+-	  .vrefresh = 24, },
++	  .vrefresh = 24, .picture_aspect_ratio = HDMI_PICTURE_ASPECT_256_135, },
+ };
+ 
+ /*** DDC fetch and block validation ***/
+
+From daadd2b2e1bf5419694ebae5243e61e462885b03 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sat, 4 Aug 2018 16:26:47 +0200
+Subject: [PATCH] drm: bridge: dw-hdmi: signal none colorimetry for rgb output
+
+---
+ drivers/gpu/drm/bridge/synopsys/dw-hdmi.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
+index 91c5b8fc8fa0..8261ba15f98e 100644
+--- a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
++++ b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
+@@ -1694,6 +1694,8 @@ static void hdmi_config_AVI(struct dw_hdmi *hdmi, struct drm_display_mode *mode)
+ 	frame.scan_mode = HDMI_SCAN_MODE_UNDERSCAN;
+ 
+ 	if (hdmi_bus_fmt_is_rgb(hdmi->hdmi_data.enc_out_bus_format)) {
++		frame.colorimetry = HDMI_COLORIMETRY_NONE;
++		frame.extended_colorimetry = 0;
+ 		frame.quantization_range = HDMI_QUANTIZATION_RANGE_FULL;
+ 		frame.ycc_quantization_range = HDMI_YCC_QUANTIZATION_RANGE_FULL;
+ 	} else {
+
+From 88c6dbd7a37b01d4029102c6fdad2b1fc24098e0 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sat, 4 Aug 2018 16:27:08 +0200
+Subject: [PATCH] drm: bridge: dw-hdmi: signal it content and content type
+
+---
+ drivers/gpu/drm/bridge/synopsys/dw-hdmi.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
+index 8261ba15f98e..cdfa295fc323 100644
+--- a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
++++ b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
+@@ -1692,6 +1692,8 @@ static void hdmi_config_AVI(struct dw_hdmi *hdmi, struct drm_display_mode *mode)
+ 	}
+ 
+ 	frame.scan_mode = HDMI_SCAN_MODE_UNDERSCAN;
++	frame.content_type = HDMI_CONTENT_TYPE_GRAPHICS;
++	frame.itc = true;
+ 
+ 	if (hdmi_bus_fmt_is_rgb(hdmi->hdmi_data.enc_out_bus_format)) {
+ 		frame.colorimetry = HDMI_COLORIMETRY_NONE;
+
+From 7405c1596ae36388bc2d32dd8b72f0b1f22ffb41 Mon Sep 17 00:00:00 2001
+From: Randy Li <randy.li@rock-chips.com>
+Date: Thu, 20 Sep 2018 10:59:11 +0800
+Subject: [PATCH] Mali: midgard: fix the memory translation for aarch32
+
+When the clients are 32 bits while the kernel is 64 bits,
+we need to translate the memory address before accessing.
+
+Change-Id: I7f47ab94da258e9d170613252aae9b396623cf48
+Signed-off-by: Randy Li <randy.li@rock-chips.com>
+---
+ drivers/gpu/arm/midgard/mali_kbase_core_linux.c | 88 +++++++++++++++++++------
+ 1 file changed, 69 insertions(+), 19 deletions(-)
+
+diff --git a/drivers/gpu/arm/midgard/mali_kbase_core_linux.c b/drivers/gpu/arm/midgard/mali_kbase_core_linux.c
+index 24bafe2bf32c..65bc5ad2a7c2 100644
+--- a/drivers/gpu/arm/midgard/mali_kbase_core_linux.c
++++ b/drivers/gpu/arm/midgard/mali_kbase_core_linux.c
+@@ -515,14 +515,20 @@ copy_failed:
+ 	case KBASE_FUNC_JOB_SUBMIT:
+ 		{
+ 			struct kbase_uk_job_submit *job = args;
++			void __user *user_addr = NULL;
+ 
+ 			if (sizeof(*job) != args_size)
+ 				goto bad_size;
+ 
+-			if (kbase_jd_submit(kctx, job->addr.value,
+-						job->nr_atoms,
+-						job->stride,
+-						false) != 0)
++#ifdef CONFIG_COMPAT
++			if (kbase_ctx_flag(kctx, KCTX_COMPAT))
++				user_addr = compat_ptr(job->addr.compat_value);
++			else
++#endif
++				user_addr = job->addr.value;
++
++			if (kbase_jd_submit(kctx, user_addr, job->nr_atoms,
++					    job->stride, false) != 0)
+ 				ukh->ret = MALI_ERROR_FUNCTION_FAILED;
+ 			break;
+ 		}
+@@ -531,14 +537,20 @@ copy_failed:
+ 	case KBASE_FUNC_JOB_SUBMIT_UK6:
+ 		{
+ 			struct kbase_uk_job_submit *job = args;
++			void __user *user_addr = NULL;
+ 
+ 			if (sizeof(*job) != args_size)
+ 				goto bad_size;
+ 
+-			if (kbase_jd_submit(kctx, job->addr.value,
+-						job->nr_atoms,
+-						job->stride,
+-						true) != 0)
++#ifdef CONFIG_COMPAT
++			if (kbase_ctx_flag(kctx, KCTX_COMPAT))
++				user_addr = compat_ptr(job->addr.compat_value);
++			else
++#endif
++				user_addr = job->addr.value;
++
++			if (kbase_jd_submit(kctx, user_addr, job->nr_atoms,
++					    job->stride, true) != 0)
+ 				ukh->ret = MALI_ERROR_FUNCTION_FAILED;
+ 			break;
+ 		}
+@@ -646,7 +658,8 @@ copy_failed:
+ 				goto bad_size;
+ 
+ 			if (find->gpu_addr & ~PAGE_MASK) {
+-				dev_warn(kbdev->dev, "kbase_legacy_dispatch case KBASE_FUNC_FIND_CPU_OFFSET: find->gpu_addr: passed parameter is invalid");
++				dev_warn(kbdev->dev,
++					"kbase_legacy_dispatch case KBASE_FUNC_FIND_CPU_OFFSET: find->gpu_addr: passed parameter is invalid");
+ 				goto out_bad;
+ 			}
+ 
+@@ -674,8 +687,11 @@ copy_failed:
+ 				goto bad_size;
+ 
+ 			/* version buffer size check is made in compile time assert */
+-			memcpy(get_version->version_buffer, KERNEL_SIDE_DDK_VERSION_STRING, sizeof(KERNEL_SIDE_DDK_VERSION_STRING));
+-			get_version->version_string_size = sizeof(KERNEL_SIDE_DDK_VERSION_STRING);
++			memcpy(get_version->version_buffer,
++			       KERNEL_SIDE_DDK_VERSION_STRING,
++			       sizeof(KERNEL_SIDE_DDK_VERSION_STRING));
++			get_version->version_string_size =
++				sizeof(KERNEL_SIDE_DDK_VERSION_STRING);
+ 			get_version->rk_version = ROCKCHIP_VERSION;
+ 			break;
+ 		}
+@@ -828,7 +844,8 @@ copy_failed:
+ 
+ #ifdef CONFIG_COMPAT
+ 			if (kbase_ctx_flag(kctx, KCTX_COMPAT))
+-				user_buf = compat_ptr(add_data->buf.compat_value);
++				user_buf =
++					compat_ptr(add_data->buf.compat_value);
+ 			else
+ #endif
+ 				user_buf = add_data->buf.value;
+@@ -977,9 +994,9 @@ copy_failed:
+ 
+ 	return ret;
+ 
+- bad_size:
++bad_size:
+ 	dev_err(kbdev->dev, "Wrong syscall size (%d) for %08x\n", args_size, id);
+- out_bad:
++out_bad:
+ 	return -EINVAL;
+ }
+ 
+@@ -1317,7 +1334,16 @@ static int kbase_api_set_flags(struct kbase_context *kctx,
+ static int kbase_api_job_submit(struct kbase_context *kctx,
+ 		struct kbase_ioctl_job_submit *submit)
+ {
+-	return kbase_jd_submit(kctx, submit->addr.value, submit->nr_atoms,
++	void __user *user_addr = NULL;
++
++#ifdef CONFIG_COMPAT
++	if (kbase_ctx_flag(kctx, KCTX_COMPAT))
++		user_addr = compat_ptr(submit->addr.compat_value);
++	else
++#endif
++		user_addr = submit->addr.value;
++
++	return kbase_jd_submit(kctx, user_addr, submit->nr_atoms,
+ 			submit->stride, false);
+ }
+ 
+@@ -1548,6 +1574,7 @@ static int kbase_api_mem_alias(struct kbase_context *kctx,
+ 		union kbase_ioctl_mem_alias *alias)
+ {
+ 	struct base_mem_aliasing_info *ai;
++	void __user *user_addr = NULL;
+ 	u64 flags;
+ 	int err;
+ 
+@@ -1558,8 +1585,15 @@ static int kbase_api_mem_alias(struct kbase_context *kctx,
+ 	if (!ai)
+ 		return -ENOMEM;
+ 
+-	err = copy_from_user(ai, alias->in.aliasing_info.value,
+-			sizeof(*ai) * alias->in.nents);
++#ifdef CONFIG_COMPAT
++	if (kbase_ctx_flag(kctx, KCTX_COMPAT))
++		user_addr =
++			compat_ptr(alias->in.aliasing_info.compat_value);
++	else
++#endif
++		user_addr = alias->in.aliasing_info.value;
++
++	err = copy_from_user(ai, user_addr, sizeof(*ai) * alias->in.nents);
+ 	if (err) {
+ 		vfree(ai);
+ 		return err;
+@@ -1586,10 +1620,18 @@ static int kbase_api_mem_import(struct kbase_context *kctx,
+ {
+ 	int ret;
+ 	u64 flags = import->in.flags;
++	void __user *phandle;
++
++#ifdef CONFIG_COMPAT
++	if (kbase_ctx_flag(kctx, KCTX_COMPAT))
++		phandle = compat_ptr(import->in.phandle.compat_value);
++	else
++#endif
++		phandle = import->in.phandle.value;
+ 
+ 	ret = kbase_mem_import(kctx,
+ 			import->in.type,
+-			import->in.phandle.value,
++			phandle,
+ 			import->in.padding,
+ 			&import->out.gpu_va,
+ 			&import->out.va_pages,
+@@ -1654,6 +1696,7 @@ static int kbase_api_get_profiling_controls(struct kbase_context *kctx,
+ static int kbase_api_mem_profile_add(struct kbase_context *kctx,
+ 		struct kbase_ioctl_mem_profile_add *data)
+ {
++	char __user *user_buf;
+ 	char *buf;
+ 	int err;
+ 
+@@ -1666,7 +1709,14 @@ static int kbase_api_mem_profile_add(struct kbase_context *kctx,
+ 	if (ZERO_OR_NULL_PTR(buf))
+ 		return -ENOMEM;
+ 
+-	err = copy_from_user(buf, data->buffer.value, data->len);
++#ifdef CONFIG_COMPAT
++	if (kbase_ctx_flag(kctx, KCTX_COMPAT))
++		user_buf = compat_ptr(data->buffer.compat_value);
++	else
++#endif
++		user_buf = data->buffer.value;
++
++	err = copy_from_user(buf, user_buf, data->len);
+ 	if (err) {
+ 		kfree(buf);
+ 		return err;
+
+From 309a27eaf2f4e429ef102e3eef70a2f908360c44 Mon Sep 17 00:00:00 2001
+From: Nick <nick@khadas.com>
+Date: Wed, 19 Sep 2018 22:14:58 +0800
+Subject: [PATCH] bump PD voltage & current for board without charge IC
+
+---
+ drivers/mfd/fusb302.c | 28 ++++++++++++++++++++++++++--
+ 1 file changed, 26 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/mfd/fusb302.c b/drivers/mfd/fusb302.c
+index 240cecac65b5..8fe4163214e0 100644
+--- a/drivers/mfd/fusb302.c
++++ b/drivers/mfd/fusb302.c
+@@ -217,8 +217,32 @@ static int fusb302_set_pos_power_by_charge_ic(struct fusb30x_chip *chip)
+ 	max_vol = 0;
+ 	max_cur = 0;
+ 	psy = power_supply_get_by_phandle(chip->dev->of_node, "charge-dev");
+-	if (!psy || IS_ERR(psy))
+-		return -1;
++	if (!psy || IS_ERR(psy)) {
++		int ret;
++		u32 value;
++
++		ret = of_property_read_u32(chip->dev->of_node, "max-input-voltage", &value);
++		if (ret) {
++			dev_err(chip->dev, "'max-input-voltage' not found!\n");
++			return -1;
++		}
++
++		max_vol = value / 1000;
++
++		ret = of_property_read_u32(chip->dev->of_node, "max-input-current", &value);
++
++		if (ret) {
++			dev_err(chip->dev, "'max-input-current' not found!\n");
++			return -1;
++		}
++
++		max_cur = value / 1000;
++
++		if (max_vol > 0 && max_cur > 0)
++			fusb_set_pos_power(chip, max_vol, max_cur);
++
++		return 0;
++	}
+ 
+ 	psp = POWER_SUPPLY_PROP_CHARGE_CONTROL_LIMIT_MAX;
+ 	if (power_supply_get_property(psy, psp, &val) == 0)


### PR DESCRIPTION
# Description

These patches were lifted from the Rockchip port of libreelec 9.2, specifically from [this](https://github.com/LibreELEC/LibreELEC.tv/blob/libreelec-9.2/projects/Rockchip/patches/linux/rockchip-4.4/linux-0001-rockchip.patch) and [this](https://github.com/LibreELEC/LibreELEC.tv/blob/libreelec-9.2/projects/Rockchip/patches/linux/rockchip-4.4/linux-1000-vcodec.patch) file.  My main aim was to get HDR output working with the RK3399 Legacy Media Framework, of which more details can be found in the discussion [here](https://forum.armbian.com/topic/16516-rk3399-legacy-multimedia-framework/page/3/).

I'm fairly sure (although I haven't tested it) that I could get HDR output working by applying a single patch, but as the Armbian kernel seemed to suffer from other problems, compared to the kernel in the libreelec image (most prominently, it was unable to connect via HDMI at 3840x2160@60 9 times out of 10), I decided to pick any video-related patches that seemed desirable (and hadn't been applied already), based on the commit message and cursory perusal of the code.

Most of these are fixes and should therefore be desirable in a general-purpose kernel.  Some may not be though, so please let me know if you'd like me to remove some of them and retest the result.  The ones I have my doubts about are listed below:

[PATCH] gpu/arm/mali400: default to performance gpu governor
[PATCH] gpu/arm/midgard: default to performance gpu governor
[PATCH] drm: bridge: dw-hdmi: default to underscan mode
[PATCH] bump PD voltage & current for board without charge IC

The patch filenames are probably not very good;  please advise on whether you'd like me to bundle all patches in a single file and what good filenames would be.

# How Has This Been Tested?

I've tested this on my Rock Pi 4B board, which I mostly use with KODI for media playback.  I've been using the patched kernel for about a week now and have noticed no adverse effects, either crashes etc., or suspicious kernel messages (that weren't there before).  On the other hand, I can now connect in 3840x2160@60 every time, the display is properly switched to HDR mode and I think a crash in the VOP driver may also have been fixed (I say "think" because this happened rarely before, and resulted in video mode switching being impossible until reboot).