### PR TITLE
Do not overwrite `EXIT_PATCHING_ERROR` if already defined

### DIFF
--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -18,7 +18,7 @@ REVISION=$(cat "${SRC}"/VERSION)"$SUBREVISION" # all boards have same revision
 [[ -z $MAINTAINERMAIL ]] && MAINTAINERMAIL="igor.pecovnik@****l.com" # deb signature
 TZDATA=$(cat /etc/timezone) # Timezone for target is taken from host or defined here.
 USEALLCORES=yes # Use all CPU cores for compiling
-EXIT_PATCHING_ERROR="" # exit patching if failed
+[[ -z $EXIT_PATCHING_ERROR ]] && EXIT_PATCHING_ERROR="" # exit patching if failed
 [[ -z $HOST ]] && HOST="$BOARD" # set hostname to the board
 cd "${SRC}" || exit
 ROOTFSCACHE_VERSION=2


### PR DESCRIPTION
# Description

Passing in `EXIT_PATCHING_ERROR=yes` doesn't seem to be working currently. 
```
<snip>
[ o.k. ] Command line: setting BRANCH to [ current ]
[ o.k. ] Command line: setting RELEASE to [ buster ]
[ o.k. ] Command line: setting KERNEL_CONFIGURE to [ no ]
[ o.k. ] Command line: setting EXTERNAL to [ yes ]
[ o.k. ] Command line: setting BUILD_KSRC to [ no ]
[ o.k. ] Command line: setting BUILD_DESKTOP to [ no ]
[ o.k. ] Command line: setting EXIT_PATCHING_ERROR to [ yes ]
```
It is read correctly, but later overwritten here: 
https://github.com/armbian/build/blob/4713ab23b982c78b4979957b51995ceb79455c97/lib/configuration.sh#L21

So we just check before clearing it. 

# How Has This Been Tested?

NA

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

