### PR TITLE
Corrected the order of WAN and LAN LEDs to correspond to the tag on the  R4S official metal case.

### DIFF
--- a/patch/kernel/rockchip64-current/add-board-nanopi-r4s.patch
+++ b/patch/kernel/rockchip64-current/add-board-nanopi-r4s.patch
@@ -148,11 +148,11 @@ index 000000000000..7b136d4707c8
 +
 +// Armbian tweaks
 +&lan_led {
-+	linux,default-trigger = "stmmac-0:01:link";
++	linux,default-trigger = "r8169-100:00:link";
 +};
 +
 +&wan_led {
-+	linux,default-trigger = "r8169-100:00:link";
++	linux,default-trigger = "stmmac-0:01:link";
 +};
 +
 +&uart0 {

--- a/patch/kernel/rockchip64-dev/add-board-nanopi-r4s.patch
+++ b/patch/kernel/rockchip64-dev/add-board-nanopi-r4s.patch
@@ -148,11 +148,11 @@ index 000000000000..7b136d4707c8
 +
 +// Armbian tweaks
 +&lan_led {
-+	linux,default-trigger = "stmmac-0:01:link";
++	linux,default-trigger = "r8169-100:00:link";
 +};
 +
 +&wan_led {
-+	linux,default-trigger = "r8169-100:00:link";
++	linux,default-trigger = "stmmac-0:01:link";
 +};
 +
 +&uart0 {


### PR DESCRIPTION
# Description

Corrected the order of WAN and LAN LEDs to correspond to the tag on the R4S official metal case.

# How Has This Been Tested?

use official metal case, LED tag is correct.