### PR TITLE
Orange Pi 4 refactor to mainline

### DIFF
--- a/config/boards/orangepi4.conf
+++ b/config/boards/orangepi4.conf
@@ -1,8 +1,9 @@
 # Rockchip RK3399 hexa core 4GB RAM SoC GBE eMMC USB3 USB-C WiFi/BT
 BOARD_NAME="OrangePi 4"
-BOARDFAMILY="rk3399"
+BOARDFAMILY="rockchip64"
 BOOTCONFIG="orangepi-4-rk3399_defconfig"
 KERNEL_TARGET="legacy,current,dev"
 FULL_DESKTOP="yes"
 ASOUND_STATE="asound.state.rt5651"
 BOOT_LOGO="desktop"
+BOOT_FDT_FILE="rockchip/rk3399-orangepi-4.dtb"

--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -56,6 +56,16 @@ elif [[ $BOARD == rockpi-4* ]]; then
 	DDR_BLOB='rk33/rk3399_ddr_933MHz_v1.20.bin' # 1GB model does not boot with later versions
 	MINILOADER_BLOB='rk33/rk3399_miniloader_v1.19.bin'
 	BL31_BLOB='rk33/rk3399_bl31_v1.30.elf'
+	
+elif [[ $BOARD == orangepi4 ]]; then
+
+	BOOT_USE_BLOBS=yes
+	BOOT_SUPPORT_SPI=yes
+	BOOT_SOC=rk3399
+	DDR_BLOB='rk33/rk3399_ddr_933MHz_v1.24.bin' # Orange Pi 4 does it has 4gb standard and is cheaper and b has also a ai  :)
+	MINILOADER_BLOB='rk33/rk3399_miniloader_v1.19.bin'
+	BL31_BLOB='rk33/rk3399_bl31_v1.30.elf'
+
 
 elif [[ $BOARD == station-p1 ]]; then
 

--- a/config/sources/families/rk3399.conf
+++ b/config/sources/families/rk3399.conf
@@ -32,7 +32,7 @@ elif [[ $BOARD == helios64 ]]; then
 		BOOT_USE_MAINLINE_ATF=yes
 	fi
 
-elif [[ $BOARD == nanopim4v2 || $BOARD == orangepi4 ]]; then
+elif [[ $BOARD == nanopim4v2 ]]; then
 
 	BOOT_USE_BLOBS=yes
 	DDR_BLOB='rk33/rk3399_ddr_933MHz_v1.24.bin'

--- a/patch/kernel/rockchip64-dev/add-board-orangepi-4.patch
+++ b/patch/kernel/rockchip64-dev/add-board-orangepi-4.patch
@@ -1,9 +1,9 @@
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4.dts b/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4.dts
 new file mode 100644
-index 000000000..1e1747ceb
+index 000000000..715d6d677
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4.dts
-@@ -0,0 +1,1123 @@
+@@ -0,0 +1,1177 @@
 +/*
 + * SPDX-License-Identifier: (GPL-2.0+ or MIT)
 + * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd.
@@ -37,6 +37,15 @@ index 000000000..1e1747ceb
 +		clock-frequency = <125000000>;
 +		clock-output-names = "clkin_gmac";
 +		#clock-cells = <0>;
++	};
++	
++		sdio_pwrseq: sdio-pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		clocks = <&rk808 1>;
++		clock-names = "ext_clock";
++		pinctrl-names = "default";
++		pinctrl-0 = <&wifi_enable_h>;
++		reset-gpios = <&gpio0 10 GPIO_ACTIVE_LOW>; /* GPIO0_B2 */
 +	};
 +
 +	usb_vbus: usb-vbus {
@@ -80,7 +89,7 @@ index 000000000..1e1747ceb
 +		vin-supply = <&vcc5v0_sys>;
 +
 +		regulator-state-mem {
-+			regulator-off-in-suspend;
++			regulator-on-in-suspend;
 +		};
 +	};
 +
@@ -325,22 +334,10 @@ index 000000000..1e1747ceb
 +			linux,default-trigger-delay-ms = <0>;
 +		};
 +	};
++};
 +
-+	sdio_pwrseq: sdio-pwrseq {
-+		compatible = "mmc-pwrseq-simple";
-+		clocks = <&rk808 1>;
-+		clock-names = "ext_clock";
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&wifi_enable_h>;
-+
-+		/*
-+		 * On the module itself this is one of these (depending
-+		 * on the actual card populated):
-+		 * - SDIO_RESET_L_WL_REG_ON
-+		 * - PDN (power down when low)
-+		 */
-+		reset-gpios = <&gpio0 10 GPIO_ACTIVE_LOW>; /* GPIO0_B2 */
-+	};
++&cdn_dp {
++	status = "disabled";
 +};
 +
 +&cpu_l0 {
@@ -367,9 +364,15 @@ index 000000000..1e1747ceb
 +	cpu-supply = <&vdd_cpu_b>;
 +};
 +
-+&gpu {
++&dp_in_vopb {
++	status = "disable";
++};
++&dp_in_vopl {
 +	status = "okay";
-+	mali-supply = <&vdd_gpu>;
++};
++
++&emmc_phy {
++	status = "okay";
 +};
 +
 +&gmac {
@@ -388,83 +391,9 @@ index 000000000..1e1747ceb
 +	status = "okay";
 +};
 +
-+&spi1 {
-+	status = "disable";
-+	pinctrl-names = "default", "sleep";
-+	pinctrl-1 = <&spi1_gpio>;
-+
-+	spidev0: spidev@0 {
-+		compatible = "rockchip,spidev";
-+		reg = <0>;
-+		spi-max-frequency = <10000000>;
-+		status = "okay";
-+	};
-+};
-+/*
-+&spi1 {
-+    status = "okay";
-+    max-freq = <48000000>;
-+    spidev@00 {
-+        compatible = "linux,spidev";
-+        reg = <0x00>;
-+        spi-max-frequency = <48000000>;
-+    };
-+};
-+*/
-+
-+&uart0 {
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&uart0_xfer &uart0_cts &uart0_rts>;
++&gpu {
++	mali-supply = <&vdd_gpu>;
 +	status = "okay";
-+
-+	bluetooth {
-+		compatible = "brcm,bcm4345c5";
-+		clocks = <&rk808 1>;
-+		clock-names = "lpo";
-+		device-wakeup-gpios = <&gpio2 RK_PD2 GPIO_ACTIVE_HIGH>;
-+		host-wakeup-gpios = <&gpio0 RK_PA4 GPIO_ACTIVE_HIGH>;
-+		shutdown-gpios = <&gpio0 RK_PB1 GPIO_ACTIVE_HIGH>;
-+		max-speed = <1500000>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&bt_host_wake &bt_wake &bt_reset>;
-+	};
-+
-+};
-+
-+&uart2 {
-+	status = "okay";
-+};
-+
-+&vopb {
-+	status = "okay";
-+};
-+
-+&vopb_mmu {
-+	status = "okay";
-+};
-+
-+&vopl {
-+	status = "okay";
-+};
-+
-+&vopl_mmu {
-+	status = "okay";
-+};
-+
-+&vpu {
-+	status = "okay";
-+	/* 0 means ion, 1 means drm */
-+	//allocator = <0>;
-+};
-+
-+&rga {
-+	status = "disabled";
-+};
-+
-+&cdn_dp {
-+	status = "okay";
-+	extcon = <&fusb0>;
-+	phys = <&tcphy0_dp>;
 +};
 +
 +&hdmi {
@@ -476,6 +405,14 @@ index 000000000..1e1747ceb
 +	status = "okay";
 +	ddc-i2c-bus = <&i2c7>;
 +	rockchip,defaultmode = <16>; /* CEA 1920x1080@60Hz */
++};
++
++&hdmi_in_vopb {
++	status = "okay";
++};
++
++&hdmi_in_vopl {
++	status = "disable";
 +};
 +
 +&i2c0 {
@@ -735,18 +672,64 @@ index 000000000..1e1747ceb
 +
 +&i2c4 {
 +	status = "okay";
-+	i2c-scl-rising-time-ns = <160>;
-+	i2c-scl-falling-time-ns = <30>;
-+	clock-frequency = <400000>;
++	i2c-scl-falling-time-ns = <20>;
++	i2c-scl-rising-time-ns = <600>;
 +
 +	fusb0: fusb30x@22 {
-+		compatible = "fairchild,fusb302";
++		compatible = "fcs,fusb302";
 +		reg = <0x22>;
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&fusb0_int>;
-+		int-n-gpios = <&gpio1 RK_PA2 GPIO_ACTIVE_HIGH>;
++		interrupt-parent = <&gpio1>;
++		interrupts = <RK_PA2 IRQ_TYPE_LEVEL_LOW>;
 +		vbus-5v-gpios = <&gpio2 RK_PB4 GPIO_ACTIVE_HIGH>;
++		vbus-supply = <&vbus_typec>;
 +		status = "okay";
++		
++		connector {
++			compatible = "usb-c-connector";
++			data-role = "host";
++			label = "USB-C";
++			op-sink-microwatt = <1000000>;
++			power-role = "dual";
++			sink-pdos =
++				<PDO_FIXED(5000, 2500, PDO_FIXED_USB_COMM)>;
++			source-pdos =
++				<PDO_FIXED(5000, 1400, PDO_FIXED_USB_COMM)>;
++			try-power-role = "source";
++
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				port@0 {
++					reg = <0>;
++
++					usbc_hs: endpoint {
++						remote-endpoint =
++							<&u2phy0_typec_hs>;
++					};
++				};
++
++				port@1 {
++					reg = <1>;
++
++					usbc_ss: endpoint {
++						remote-endpoint =
++							<&tcphy0_typec_ss>;
++					};
++				};
++
++				port@2 {
++					reg = <2>;
++
++					usbc_dp: endpoint {
++						remote-endpoint =
++							<&tcphy0_typec_dp>;
++					};
++				};
++			};
++		};
 +	};
 +
 +	ft5x06_ts@38 {
@@ -770,13 +753,11 @@ index 000000000..1e1747ceb
 +	status = "okay";
 +};
 +
-+&spdif {
-+	status = "disable";
-+	pinctrl-0 = <&spdif_bus>;
-+	i2c-scl-rising-time-ns = <450>;
-+	i2c-scl-falling-time-ns = <15>;
-+	#sound-dai-cells = <0>;
-+};
++/*
++&i2s0 {
++	assigned-clocks = <&cru SCLK_I2S1_DIV>;
++	assigned-clock-parents = <&cru PLL_GPLL>;
++};*/
 +
 +&i2s1 {
 +	assigned-clocks = <&cru SCLK_I2SOUT_SRC>;
@@ -788,11 +769,7 @@ index 000000000..1e1747ceb
 +	#sound-dai-cells = <0>;
 +	status = "okay";
 +};
-+/*
-+&i2s0 {
-+	assigned-clocks = <&cru SCLK_I2S1_DIV>;
-+	assigned-clock-parents = <&cru PLL_GPLL>;
-+};*/
++
 +
 +&i2s2 {
 +	#sound-dai-cells = <0>;
@@ -806,11 +783,6 @@ index 000000000..1e1747ceb
 +	audio-supply = <&vcca1v8_codec>;	/* audio_gpio3d4a_ms */
 +	sdmmc-supply = <&vcc_sdio>;		/* sdmmc_gpio4b_ms */
 +	gpio1830-supply = <&vcc_3v0>;		/* gpio1833_gpio4cd_ms */
-+};
-+
-+&pmu_io_domains {
-+	status = "okay";
-+	pmu1830-supply = <&vcc_3v0>;
 +};
 +
 +&pcie_phy {
@@ -827,154 +799,6 @@ index 000000000..1e1747ceb
 +	max-link-speed = <1>;
 +};
 +
-+&pwm_bl {
-+	status = "okay";
-+};
-+
-+&pwm0 {
-+	status = "okay";
-+};
-+
-+&pwm1 {
-+	status = "okay";
-+};
-+
-+&pwm2 {
-+	status = "okay";
-+	pinctrl-names = "active";
-+	pinctrl-0 = <&pwm2_pin_pull_down>;
-+};
-+
-+&saradc {
-+	status = "okay";
-+	vref-supply = <&vcca1v8_s3>; /* TBD */
-+};
-+
-+&sdhci {
-+	bus-width = <8>;
-+	mmc-hs400-1_8v;
-+	supports-emmc;
-+	non-removable;
-+	keep-power-in-suspend;
-+	mmc-hs400-enhanced-strobe;
-+	status = "okay";
-+};
-+
-+&emmc_phy {
-+	status = "okay";
-+};
-+
-+&sdio0 {
-+	clock-frequency = <50000000>;
-+	clock-freq-min-max = <200000 50000000>;
-+	supports-sdio;
-+	bus-width = <4>;
-+	disable-wp;
-+	cap-sd-highspeed;
-+	cap-sdio-irq;
-+	keep-power-in-suspend;
-+	mmc-pwrseq = <&sdio_pwrseq>;
-+	non-removable;
-+	num-slots = <1>;
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&sdio0_bus4 &sdio0_cmd &sdio0_clk>;
-+	sd-uhs-sdr104;
-+	status = "okay";
-+};
-+
-+&sdmmc {
-+	bus-width = <4>;
-+	cap-sd-highspeed;
-+	cap-mmc-highspeed;
-+	cd-gpios = <&gpio0 RK_PA7 GPIO_ACTIVE_LOW>;
-+	disable-wp;
-+	max-frequency = <150000000>;
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&sdmmc_bus4 &sdmmc_clk &sdmmc_cmd &sdmmc0_det_l>;
-+//	sd-uhs-sdr104;
-+	vmmc-supply = <&vcc3v0_sd>;
-+	vqmmc-supply = <&vcc_sdio>;
-+	status = "okay";
-+};
-+
-+&tsadc {
-+	/* tshut mode 0:CRU 1:GPIO */
-+	rockchip,hw-tshut-mode = <1>;
-+	/* tshut polarity 0:LOW 1:HIGH */
-+	rockchip,hw-tshut-polarity = <1>;
-+	status = "okay";
-+};
-+
-+&tcphy0 {
-+	extcon = <&fusb0>;
-+	status = "okay";
-+};
-+
-+&tcphy1 {
-+	status = "okay";
-+};
-+
-+&u2phy0 {
-+	status = "okay";
-+	extcon = <&fusb0>;
-+
-+	u2phy0_otg: otg-port {
-+		status = "okay";
-+	};
-+
-+	u2phy0_host: host-port {
-+		phy-supply = <&usb3_vbus>;
-+		status = "okay";
-+	};
-+};
-+
-+&u2phy1 {
-+	status = "okay";
-+
-+	u2phy1_otg: otg-port {
-+		status = "okay";
-+	};
-+
-+	u2phy1_host: host-port {
-+		phy-supply = <&usb_vbus>;
-+		status = "okay";
-+	};
-+};
-+
-+&usbdrd3_0 {
-+	status = "okay";
-+	extcon = <&fusb0>;
-+};
-+
-+&usbdrd3_1 {
-+	status = "okay";
-+};
-+
-+&usbdrd_dwc3_0 {
-+	status = "okay";
-+};
-+
-+&usbdrd_dwc3_1 {
-+	status = "okay";
-+	dr_mode = "host";
-+};
-+
-+&usb_host0_ehci {
-+	status = "okay";
-+};
-+
-+&usb_host0_ohci {
-+	status = "okay";
-+};
-+
-+&usb_host1_ehci {
-+	status = "okay";
-+};
-+
-+&usb_host1_ohci {
-+	status = "okay";
-+};
-+
 +&pinctrl {
 +	pcie {
 +		pcie_drv: pcie-drv {
@@ -982,11 +806,7 @@ index 000000000..1e1747ceb
 +				<1 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
 +		};
 +	};
-+
-+	hdmi {
-+		/delete-node/ hdmi-i2c-xfer;
-+	};
-+
++	
 +	i2s1 {
 +		i2s_8ch_mclk: i2s-8ch-mclk {
 +			rockchip,pins = <4 RK_PA0 1 &pcfg_pull_none>;
@@ -1112,18 +932,252 @@ index 000000000..1e1747ceb
 +
 +};
 +
-+&hdmi_in_vopb {
++&pmu_io_domains {
++	status = "okay";
++	pmu1830-supply = <&vcc_3v0>;
++};
++
++&pwm_bl {
 +	status = "okay";
 +};
 +
-+&hdmi_in_vopl {
-+	status = "disable";
-+};
-+
-+&dp_in_vopb {
-+	status = "disable";
-+};
-+&dp_in_vopl {
++&pwm0 {
 +	status = "okay";
 +};
 +
++&pwm1 {
++	status = "okay";
++};
++
++&pwm2 {
++	status = "okay";
++	pinctrl-names = "active";
++	pinctrl-0 = <&pwm2_pin_pull_down>;
++};
++
++&rga {
++	status = "disabled";
++};
++
++&saradc {
++	status = "okay";
++	vref-supply = <&vcca1v8_s3>; /* TBD */
++};
++
++&sdio0 {
++	clock-frequency = <50000000>;
++	clock-freq-min-max = <200000 50000000>;
++	supports-sdio;
++	bus-width = <4>;
++	disable-wp;
++	cap-sd-highspeed;
++	cap-sdio-irq;
++	keep-power-in-suspend;
++	mmc-pwrseq = <&sdio_pwrseq>;
++	non-removable;
++	num-slots = <1>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdio0_bus4 &sdio0_cmd &sdio0_clk>;
++	sd-uhs-sdr104;
++	status = "okay";
++};
++
++&sdmmc {
++	bus-width = <4>;
++	cap-sd-highspeed;
++	cap-mmc-highspeed;
++	cd-gpios = <&gpio0 RK_PA7 GPIO_ACTIVE_LOW>;
++	disable-wp;
++	max-frequency = <150000000>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdmmc_bus4 &sdmmc_clk &sdmmc_cmd &sdmmc0_det_l>;
++//	sd-uhs-sdr104;
++	vmmc-supply = <&vcc3v0_sd>;
++	vqmmc-supply = <&vcc_sdio>;
++	status = "okay";
++};
++
++&sdhci {
++	bus-width = <8>;
++	mmc-hs400-1_8v;
++	supports-emmc;
++	non-removable;
++	keep-power-in-suspend;
++	mmc-hs400-enhanced-strobe;
++	status = "okay";
++};
++
++&spdif {
++	status = "disable";
++	pinctrl-0 = <&spdif_bus>;
++	i2c-scl-rising-time-ns = <450>;
++	i2c-scl-falling-time-ns = <15>;
++	#sound-dai-cells = <0>;
++};
++
++&spi1 {
++	status = "disable";
++	pinctrl-names = "default", "sleep";
++	pinctrl-1 = <&spi1_gpio>;
++
++	spidev0: spidev@0 {
++		compatible = "rockchip,spidev";
++		reg = <0>;
++		spi-max-frequency = <10000000>;
++		status = "okay";
++	};
++}; 
++/*
++&spi1 {
++    status = "okay";
++    max-freq = <48000000>;
++    spidev@00 {
++        compatible = "linux,spidev";
++        reg = <0x00>;
++        spi-max-frequency = <48000000>;
++    };
++};
++*/
++
++&tcphy0 {
++	status = "okay";
++};
++
++&tcphy0_dp {
++	port {
++		tcphy0_typec_dp: endpoint {
++			remote-endpoint = <&usbc_dp>;
++		};
++	};
++};
++
++&tcphy0_usb3 {
++	port {
++		tcphy0_typec_ss: endpoint {
++			remote-endpoint = <&usbc_ss>;
++		};
++	};
++};
++
++&tcphy1 {
++	status = "okay";
++};
++
++&tsadc {
++	/* tshut mode 0:CRU 1:GPIO */
++	rockchip,hw-tshut-mode = <1>;
++	/* tshut polarity 0:LOW 1:HIGH */
++	rockchip,hw-tshut-polarity = <1>;
++	status = "okay";
++};
++
++&u2phy0 {
++	status = "okay";
++
++	u2phy0_otg: otg-port {
++		status = "okay";
++	};
++
++	u2phy0_host: host-port {
++		phy-supply = <&vbus_typec>;
++		status = "okay";
++	};
++	
++	port {
++		u2phy0_typec_hs: endpoint {
++			remote-endpoint = <&usbc_hs>;
++		};
++	};
++};
++
++&u2phy1 {
++	status = "okay";
++
++	u2phy1_otg: otg-port {
++		status = "okay";
++	};
++
++	u2phy1_host: host-port {
++		phy-supply = <&usb_vbus>;
++		status = "okay";
++	};
++};
++
++&uart0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart0_xfer &uart0_cts &uart0_rts>;
++	status = "okay";
++
++	bluetooth {
++		compatible = "brcm,bcm4345c5";
++		clocks = <&rk808 1>;
++		clock-names = "lpo";
++		device-wakeup-gpios = <&gpio2 RK_PD2 GPIO_ACTIVE_HIGH>;
++		host-wakeup-gpios = <&gpio0 RK_PA4 GPIO_ACTIVE_HIGH>;
++		shutdown-gpios = <&gpio0 RK_PB1 GPIO_ACTIVE_HIGH>;
++		max-speed = <1500000>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&bt_host_wake &bt_wake &bt_reset>;
++	};
++
++};
++
++&uart2 {
++	status = "okay";
++};
++
++&usb_host0_ehci {
++	status = "okay";
++};
++
++&usb_host0_ohci {
++	status = "okay";
++};
++
++&usb_host1_ehci {
++	status = "okay";
++};
++
++&usb_host1_ohci {
++	status = "okay";
++};
++
++&usbdrd3_0 {
++	status = "okay";
++};
++
++&usbdrd3_1 {
++	status = "okay";
++};
++
++&usbdrd_dwc3_0 {
++        dr_mode = "host";
++	status = "okay";
++};
++
++&usbdrd_dwc3_1 {
++	dr_mode = "host";
++	status = "okay";
++};
++
++&vopb {
++	status = "okay";
++};
++
++&vopb_mmu {
++	status = "okay";
++};
++
++&vopl {
++	status = "okay";
++};
++
++&vopl_mmu {
++	status = "okay";
++};
++
++&vpu {
++	status = "okay";
++	/* 0 means ion, 1 means drm */
++	//allocator = <0>;
++};

--- a/patch/u-boot/u-boot-rockchip64-mainline/add-board-orangepi-4.patch
+++ b/patch/u-boot/u-boot-rockchip64-mainline/add-board-orangepi-4.patch
@@ -1,8 +1,8 @@
 diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
-index 0ba45ff7..530d60bf 100644
+index 8d89f9c1..1f35ea31 100644
 --- a/arch/arm/dts/Makefile
 +++ b/arch/arm/dts/Makefile
-@@ -132,6 +132,7 @@ dtb-$(CONFIG_ROCKCHIP_RK3399) += \
+@@ -137,6 +137,7 @@ dtb-$(CONFIG_ROCKCHIP_RK3399) += \
  	rk3399-nanopi-m4v2.dtb \
  	rk3399-nanopi-neo4.dtb \
  	rk3399-orangepi.dtb \
@@ -12,10 +12,10 @@ index 0ba45ff7..530d60bf 100644
  	rk3399-roc-pc.dtb \
 diff --git a/arch/arm/dts/rk3399-orangepi-4-u-boot.dtsi b/arch/arm/dts/rk3399-orangepi-4-u-boot.dtsi
 new file mode 100644
-index 00000000..5bd86966
+index 00000000..36a24503
 --- /dev/null
 +++ b/arch/arm/dts/rk3399-orangepi-4-u-boot.dtsi
-@@ -0,0 +1,13 @@
+@@ -0,0 +1,50 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * Copyright (C) 2019 Jagan Teki <jagan@amarulasolutions.com>
@@ -26,52 +26,176 @@ index 00000000..5bd86966
 +
 +/ {
 +	chosen {
-+		u-boot,spl-boot-order = "same-as-spl", &sdhci, &sdmmc;
++		u-boot,spl-boot-order = "same-as-spl", &spi_flash, &sdmmc, &sdhci;
++	};
++	
++	config {
++		u-boot,spl-payload-offset = <0x60000>; /* @ 384KB */
 +	};
 +};
++
++&i2c0 {
++	u-boot,dm-pre-reloc;
++};
++
++&rk808 {
++	u-boot,dm-pre-reloc;
++};
++
++&rng {
++	status = "okay";
++};
++
++&vdd_log {
++	regulator-init-microvolt = <950000>;
++};
++
++&spi1 {
++	status = "okay";
++
++	flash@0 {
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <10000000>;
++	};
++};
++
++&spi1 {
++	spi_flash: flash@0 {
++		u-boot,dm-pre-reloc;
++	};
++};
++
 diff --git a/arch/arm/dts/rk3399-orangepi-4.dts b/arch/arm/dts/rk3399-orangepi-4.dts
 new file mode 100644
-index 00000000..65e9c44b
+index 00000000..cee7c634
 --- /dev/null
 +++ b/arch/arm/dts/rk3399-orangepi-4.dts
-@@ -0,0 +1,206 @@
+@@ -0,0 +1,1175 @@
 +/*
 + * (C) Copyright 2016 Rockchip Electronics Co., Ltd
++ * Copyright (c) 2020 Armbian (thc013)
 + *
 + * SPDX-License-Identifier:     GPL-2.0+
 + */
 +
 +/dts-v1/;
++#include <dt-bindings/input/linux-event-codes.h>
 +#include <dt-bindings/pwm/pwm.h>
-+#include <dt-bindings/pinctrl/rockchip.h>
++#include <dt-bindings/usb/pd.h>
++
 +#include "rk3399.dtsi"
 +#include "rk3399-opp.dtsi"
 +
 +/ {
-+	model = "OrangePi 4 AI board";
++	model = "OrangePi 4 board";
 +	compatible = "rockchip,rk3399";
 +
 +	chosen {
 +		stdout-path = "serial2:1500000n8";
 +	};
 +
-+	vdd_center: vdd-center {
-+		compatible = "pwm-regulator";
-+		pwms = <&pwm3 0 25000 1>;
-+		regulator-name = "vdd_center";
-+		regulator-min-microvolt = <800000>;
-+		regulator-max-microvolt = <1400000>;
-+		regulator-init-microvolt = <950000>;
-+		regulator-always-on;
-+		regulator-boot-on;
-+		status = "okay";
++
++
++	clkin_gmac: external-gmac-clock {
++		compatible = "fixed-clock";
++		clock-frequency = <125000000>;
++		clock-output-names = "clkin_gmac";
++		#clock-cells = <0>;
++	};
++	
++	sdio_pwrseq: sdio-pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		clocks = <&rk808 1>;
++		clock-names = "ext_clock";
++		pinctrl-names = "default";
++		pinctrl-0 = <&wifi_enable_h>;
++		reset-gpios = <&gpio0 RK_PB2 GPIO_ACTIVE_LOW>;
 +	};
 +
-+	vccsys: vccsys {
++	usb_vbus: usb-vbus {
 +		compatible = "regulator-fixed";
-+		regulator-name = "vccsys";
-+		regulator-boot-on;
++		regulator-name = "usb_vbus";
 +		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc5v0_sys>;
++
++		regulator-state-mem {
++			regulator-on-in-suspend;
++		};
++	};
++
++	usb3_vbus: usb3-vbus {
++		compatible = "regulator-fixed";
++		regulator-name = "usb3_vbus";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc5v0_sys>;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++
++	vbus_typec: vbus-typec {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio2 RK_PB4 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc5v0_typec_en>;
++		regulator-name = "vbus_typec";
++		regulator-always-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc5v0_sys>;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++
++	/* 0.9 V supply, over PMIC
++	vcc_0v9: vcc-0v9 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_0v9";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <900000>;
++		regulator-max-microvolt = <900000>;
++		vin-supply = <&vcc3v3_sys>;
++	}
++	*/
++
++	vcc3v0_sd: vcc3v0-sd {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio0 RK_PA1 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&sdmmc0_pwr_h>;
++		regulator-name = "vcc3v0_sd";
++		regulator-always-on;
++		regulator-min-microvolt = <3000000>;
++		regulator-max-microvolt = <3000000>;
++		vin-supply = <&vcc3v3_sys>;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++
++	vcc3v3_pcie: vcc3v3-pcie-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio1 RK_PA0 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pcie_drv>;
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-name = "vcc3v3_pcie";
 +	};
 +
 +	vcc3v3_sys: vcc3v3-sys {
@@ -81,43 +205,800 @@ index 00000000..65e9c44b
 +		regulator-boot-on;
 +		regulator-min-microvolt = <3300000>;
 +		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc_sys>;
++
++		regulator-state-mem {
++			regulator-on-in-suspend;
++		};
 +	};
 +
-+	vcc_phy: vcc-phy-regulator {
++	vcc5v0_sys: vcc5v0-sys {
 +		compatible = "regulator-fixed";
-+		regulator-name = "vcc_phy";
++		regulator-name = "vcc5v0_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc_sys>;
++
++		regulator-state-mem {
++			regulator-on-in-suspend;
++		};
++	};
++
++	vcc_sys: vcc-sys {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_sys";
 +		regulator-always-on;
 +		regulator-boot-on;
 +	};
 +
-+	vcc5v0_host: vcc5v0-host-en {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc5v0_host";
-+		gpio = <&gpio4 25 GPIO_ACTIVE_HIGH>;
++	vdd_log: vdd-log {
++		compatible = "pwm-regulator";
++		pwms = <&pwm2 0 25000 1>;
++		regulator-name = "vdd_log";
++		regulator-min-microvolt = <800000>;
++		regulator-max-microvolt = <1400000>;
++		regulator-always-on;
++		regulator-boot-on;
++		vin-supply = <&vcc3v3_sys>;
 +	};
 +
-+	vcc5v0_typec0: vcc5v0-typec0-en {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc5v0_typec0";
-+		gpio = <&gpio1 3 GPIO_ACTIVE_HIGH>;
++/*	rt5651_card: rt5651-sound {
++		status = "okay";
++		compatible = "simple-audio-card";
++		pinctrl-names = "default";
++		pinctrl-0 = <&hp_det>;
++
++		simple-audio-card,name = "realtek,rt5651-codec";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,mclk-fs = <256>;
++		simple-audio-card,hp-det-gpio = <&gpio4 28 GPIO_ACTIVE_HIGH>;
++
++		simple-audio-card,widgets =
++			"Microphone", "Mic Jack",
++			"Headphone", "Headphone Jack";
++		simple-audio-card,routing =
++			"Mic Jack", "micbias1",
++			"IN2P", "Mic Jack",
++			"IN3P", "Mic Jack",
++			"Headphone Jack", "HPOL",
++			"Headphone Jack", "HPOR";
++
++		simple-audio-card,cpu {
++			sound-dai = <&i2s1>;
++		};
++		simple-audio-card,codec {
++			sound-dai = <&rt5651>;
++		};
++	}; */
++
++	dw_hdmi_audio: dw-hdmi-audio {
++		status = "disable";
++		compatible = "rockchip,dw-hdmi-audio";
++		#sound-dai-cells = <0>;
 +	};
 +
-+	vcc5v0_typec1: vcc5v0-typec1-en {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc5v0_typec1";
-+		gpio = <&gpio1 4 GPIO_ACTIVE_HIGH>;
++	hdmi_sound: hdmi-sound {
++		status = "okay";
 +	};
 +
-+	clkin_gmac: external-gmac-clock {
-+		compatible = "fixed-clock";
-+		clock-frequency = <125000000>;
-+		clock-output-names = "clkin_gmac";
-+		#clock-cells = <0>;
++        hdmi_dp_sound: hdmi-dp-sound {
++                status = "okay";
++                compatible = "rockchip,rk3399-hdmi-dp";
++                rockchip,cpu = <&i2s2>;
++                rockchip,codec = <&hdmi>, <&cdn_dp>;
++        };
++
++	spdif-sound {
++		status = "disable";
++		compatible = "simple-audio-card";
++		simple-audio-card,name = "ROCKCHIP,SPDIF";
++		simple-audio-card,cpu {
++			sound-dai = <&spdif>;
++		};
++		simple-audio-card,codec {
++			sound-dai = <&spdif_out>;
++		};
++	};
++
++	spdif_out: spdif-out {
++		status = "disable";
++		compatible = "linux,spdif-dit";
++		#sound-dai-cells = <0>;
++	};
++
++	pwm_bl: backlight {
++		status = "disable";
++		compatible = "pwm-backlight";
++		pwms = <&pwm0 0 25000 0>;
++		brightness-levels = <
++			  0   1   2   3   4   5   6   7
++			  8   9  10  11  12  13  14  15
++			 16  17  18  19  20  21  22  23
++			 24  25  26  27  28  29  30  31
++			 32  33  34  35  36  37  38  39
++			 40  41  42  43  44  45  46  47
++			 48  49  50  51  52  53  54  55
++			 56  57  58  59  60  61  62  63
++			 64  65  66  67  68  69  70  71
++			 72  73  74  75  76  77  78  79
++			 80  81  82  83  84  85  86  87
++			 88  89  90  91  92  93  94  95
++			 96  97  98  99 100 101 102 103
++			104 105 106 107 108 109 110 111
++			112 113 114 115 116 117 118 119
++			120 121 122 123 124 125 126 127
++			128 129 130 131 132 133 134 135
++			136 137 138 139 140 141 142 143
++			144 145 146 147 148 149 150 151
++			152 153 154 155 156 157 158 159
++			160 161 162 163 164 165 166 167
++			168 169 170 171 172 173 174 175
++			176 177 178 179 180 181 182 183
++			184 185 186 187 188 189 190 191
++			192 193 194 195 196 197 198 199
++			200 201 202 203 204 205 206 207
++			208 209 210 211 212 213 214 215
++			216 217 218 219 220 221 222 223
++			224 225 226 227 228 229 230 231
++			232 233 234 235 236 237 238 239
++			240 241 242 243 244 245 246 247
++			248 249 250 251 252 253 254 255>;
++		default-brightness-level = <200>;
++	};
++
++/*	gpio-keys {
++		compatible = "gpio-keys";
++		#address-cells = <1>;
++		#size-cells = <0>;
++		autorepeat;
++
++		pinctrl-names = "default";
++		pinctrl-0 = <&power_key>;
++
++		button@0 {
++			gpios = <&gpio0 RK_PA5 GPIO_ACTIVE_LOW>;
++			linux,code = <KEY_POWER>;
++			label = "GPIO Key Power";
++			linux,input-type = <1>;
++			gpio-key,wakeup = <1>;
++			debounce-interval = <100>;
++		};
++	};
++
++	adc-keys {
++		compatible = "adc-keys";
++		io-channels = <&saradc 1>;
++		io-channel-names = "buttons";
++		poll-interval = <100>;
++		keyup-threshold-microvolt = <1800000>;
++
++		button-up {
++			label = "Volume Up";
++			linux,code = <KEY_VOLUMEUP>;
++			press-threshold-microvolt = <100000>;
++		};
++
++		button-down {
++			label = "Volume Down";
++			linux,code = <KEY_VOLUMEDOWN>;
++			press-threshold-microvolt = <300000>;
++		};
++	};
++
++	leds: gpio-leds {
++		compatible = "gpio-leds";
++		pinctrl-names = "default";
++		pinctrl-0 =<&leds_gpio>;
++
++		led@1 {
++			gpios = <&gpio0 RK_PB3 GPIO_ACTIVE_HIGH>;
++			label = "status_led";
++			linux,default-trigger = "heartbeat";
++			linux,default-trigger-delay-ms = <0>;
++		};
++	}; */
++};
++
++&cdn_dp {
++	status = "disabled";
++};
++
++&cpu_l0 {
++	cpu-supply = <&vdd_cpu_l>;
++};
++
++&cpu_l1 {
++	cpu-supply = <&vdd_cpu_l>;
++};
++
++&cpu_l2 {
++	cpu-supply = <&vdd_cpu_l>;
++};
++
++&cpu_l3 {
++	cpu-supply = <&vdd_cpu_l>;
++};
++
++&cpu_b0 {
++	cpu-supply = <&vdd_cpu_b>;
++};
++
++&cpu_b1 {
++	cpu-supply = <&vdd_cpu_b>;
++};
++
++&dp_in_vopb {
++	status = "disable";
++};
++&dp_in_vopl {
++	status = "okay";
++};
++
++&emmc_phy {
++	status = "okay";
++};
++
++&gmac {
++	assigned-clocks = <&cru SCLK_RMII_SRC>;
++	assigned-clock-parents = <&clkin_gmac>;
++	clock_in_out = "input";
++	phy-supply = <&vcc3v3_s3>;
++	phy-mode = "rgmii";
++	pinctrl-names = "default";
++	pinctrl-0 = <&rgmii_pins>;
++	snps,reset-gpio = <&gpio3 RK_PB7 GPIO_ACTIVE_LOW>;
++	snps,reset-active-low;
++	snps,reset-delays-us = <0 10000 50000>;
++	tx_delay = <0x28>;
++	rx_delay = <0x11>;
++	status = "okay";
++};
++
++&gpu {
++	mali-supply = <&vdd_gpu>;
++	status = "okay";
++};
++
++&hdmi {
++	ddc-i2c-bus = <&i2c7>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&hdmi_cec>;
++	status = "okay";
++};
++
++&hdmi_in_vopb {
++	status = "okay";
++};
++
++&hdmi_in_vopl {
++	status = "disable";
++};
++
++&i2c0 {
++	clock-frequency = <400000>;
++	i2c-scl-rising-time-ns = <160>;
++	i2c-scl-falling-time-ns = <30>;
++	status = "okay";
++	u-boot,dm-pre-reloc;
++
++	rk808: pmic@1b {
++		compatible = "rockchip,rk808";
++		reg = <0x1b>;
++		interrupt-parent = <&gpio1>;
++		interrupts = <21 IRQ_TYPE_LEVEL_LOW>;
++		#clock-cells = <1>;
++		clock-output-names = "xin32k", "rk808-clkout2";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pmic_int_l>;
++		rockchip,system-power-controller;
++		wakeup-source;
++		u-boot,dm-pre-reloc;
++		status = "okay";
++
++		vcc1-supply = <&vcc3v3_sys>;
++		vcc2-supply = <&vcc3v3_sys>;
++		vcc3-supply = <&vcc3v3_sys>;
++		vcc4-supply = <&vcc3v3_sys>;
++		vcc6-supply = <&vcc3v3_sys>;
++		vcc7-supply = <&vcc3v3_sys>;
++		vcc8-supply = <&vcc3v3_sys>;
++		vcc9-supply = <&vcc3v3_sys>;
++		vcc10-supply = <&vcc3v3_sys>;
++		vcc11-supply = <&vcc3v3_sys>;
++		vcc12-supply = <&vcc3v3_sys>;
++		vcc13-supply = <&vcc3v3_sys>;
++		vcc14-supply = <&vcc3v3_sys>;
++		vddio-supply = <&vcc_3v0>;
++
++		regulators {
++			vdd_center: DCDC_REG1 {
++				regulator-name = "vdd_center";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <750000>;
++				regulator-max-microvolt = <1350000>;
++				regulator-ramp-delay = <6001>;
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_cpu_l: DCDC_REG2 {
++				regulator-name = "vdd_cpu_l";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <750000>;
++				regulator-max-microvolt = <1350000>;
++				regulator-ramp-delay = <6001>;
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc_ddr: DCDC_REG3 {
++				regulator-name = "vcc_ddr";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++				};
++			};
++
++			vcc1v8: vcc1v8_s3: vcca1v8_s3: DCDC_REG4 {
++				regulator-name = "vcc1v8";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vcc1v8_dvp: LDO_REG1 {
++				regulator-name = "vcc1v8_dvp";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc3v0_touch: LDO_REG2 {
++				regulator-name = "vcc3v0_touch";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <3000000>;
++				regulator-max-microvolt = <3000000>;
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc1v8_pmu: LDO_REG3 {
++				regulator-name = "vcc1v8_pmu";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vcc_sdio: LDO_REG4 {
++				regulator-name = "vcc_sdio";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <3000000>;
++				regulator-init-microvolt = <3000000>;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3000000>;
++				};
++			};
++
++			vcca3v0_codec: LDO_REG5 {
++				regulator-name = "vcca3v0_codec";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <3000000>;
++				regulator-max-microvolt = <3000000>;
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc_1v5: LDO_REG6 {
++				regulator-name = "vcc_1v5";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1500000>;
++				regulator-max-microvolt = <1500000>;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1500000>;
++				};
++			};
++
++			vcca1v8_codec: LDO_REG7 {
++				regulator-name = "vcca1v8_codec";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc_3v0: LDO_REG8 {
++				regulator-name = "vcc_3v0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <3000000>;
++				regulator-max-microvolt = <3000000>;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3000000>;
++				};
++			};
++
++			vcc3v3_s3: vcc_lan: SWITCH_REG1 {
++				regulator-name = "vcc3v3_s3";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc3v3_s0: SWITCH_REG2 {
++				regulator-name = "vcc3v3_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++		};
++	};
++
++	vdd_cpu_b: regulator@40 {
++		compatible = "silergy,syr827";
++		reg = <0x40>;
++		fcs,suspend-voltage-selector = <1>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vsel1_gpio>;
++		regulator-name = "vdd_cpu_b";
++		regulator-min-microvolt = <712500>;
++		regulator-max-microvolt = <1500000>;
++		regulator-ramp-delay = <1000>;
++		regulator-always-on;
++		regulator-boot-on;
++		vin-supply = <&vcc3v3_sys>;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++
++	vdd_gpu: regulator@41 {
++		compatible = "silergy,syr828";
++		reg = <0x41>;
++		fcs,suspend-voltage-selector = <1>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vsel2_gpio>;
++		regulator-name = "vdd_gpu";
++		regulator-min-microvolt = <712500>;
++		regulator-max-microvolt = <1500000>;
++		regulator-ramp-delay = <1000>;
++		regulator-always-on;
++		regulator-boot-on;
++		vin-supply = <&vcc3v3_sys>;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++};
++
++&i2c1 {
++	
++	i2c-scl-rising-time-ns = <300>;
++	i2c-scl-falling-time-ns = <15>;
++	status = "okay";
++	clock-frequency = <200000>;
++
++	rt5651: rt5651@1a {
++		#sound-dai-cells = <0>;
++		compatible = "realtek,rt5651";
++		reg = <0x1a>;
++		clocks = <&cru SCLK_I2S_8CH_OUT>;
++		clock-names = "mclk";
++		status = "okay";
++	};
++};
++
++&i2c3 {
++	status = "okay";
++};
++
++&i2c4 {
++	status = "okay";
++	i2c-scl-falling-time-ns = <20>;
++	i2c-scl-rising-time-ns = <600>;
++
++	fusb0: fusb30x@22 {
++		compatible = "fcs,fusb302";
++		reg = <0x22>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&fusb0_int>;
++		interrupt-parent = <&gpio1>;
++		interrupts = <RK_PA2 IRQ_TYPE_LEVEL_LOW>;
++		vbus-5v-gpios = <&gpio2 RK_PB4 GPIO_ACTIVE_HIGH>;
++		vbus-supply = <&vbus_typec>;
++		status = "okay";
++		
++		connector {
++			compatible = "usb-c-connector";
++			data-role = "host";
++			label = "USB-C";
++			op-sink-microwatt = <1000000>;
++			power-role = "dual";
++			sink-pdos =
++				<PDO_FIXED(5000, 2500, PDO_FIXED_USB_COMM)>;
++			source-pdos =
++				<PDO_FIXED(5000, 1400, PDO_FIXED_USB_COMM)>;
++			try-power-role = "sink";
++
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				port@0 {
++					reg = <0>;
++
++					usbc_hs: endpoint {
++						remote-endpoint =
++							<&u2phy0_typec_hs>;
++					};
++				};
++
++				port@1 {
++					reg = <1>;
++
++					usbc_ss: endpoint {
++						remote-endpoint =
++							<&tcphy0_typec_ss>;
++					};
++				};
++
++				port@2 {
++					reg = <2>;
++
++					usbc_dp: endpoint {
++						remote-endpoint =
++							<&tcphy0_typec_dp>;
++					};
++				};
++			};
++		};
++	};
++
++	ft5x06_ts@38 {
++		compatible = "edt,edt-ft5x06", "ft5x06";
++		reg = <0x38>;
++		interrupt-parent = <&gpio1>;
++		interrupts = <20 IRQ_TYPE_EDGE_FALLING>;
++		status = "okay";
++	};
++
++	/*
++	onewire_ts@2f {
++		compatible = "onewire";
++		reg = <0x2f>;
++		interrupt-parent = <&gpio1>;
++		interrupts = <20 IRQ_TYPE_EDGE_FALLING>;
++	}; */
++};
++
++&i2c7 {
++	status = "okay";
++};
++
++/*
++&i2s0 {
++	assigned-clocks = <&cru SCLK_I2S1_DIV>;
++	assigned-clock-parents = <&cru PLL_GPLL>;
++};*/
++
++/* &i2s1 {
++	assigned-clocks = <&cru SCLK_I2SOUT_SRC>;
++	assigned-clock-parents = <&cru SCLK_I2S1_8CH>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2s_8ch_mclk>,<&i2s1_2ch_bus>;
++	rockchip,playback-channels = <2>;
++	rockchip,capture-channels = <2>;
++	#sound-dai-cells = <0>;
++	status = "okay";
++};*/
++
++
++&i2s2 {
++	#sound-dai-cells = <0>;
++	status = "okay";
++};
++
++&io_domains {
++	status = "okay";
++
++	bt656-supply = <&vcc1v8_dvp>;		/* bt656_gpio2ab_ms */
++	audio-supply = <&vcca1v8_codec>;	/* audio_gpio3d4a_ms */
++	sdmmc-supply = <&vcc_sdio>;		/* sdmmc_gpio4b_ms */
++	gpio1830-supply = <&vcc_3v0>;		/* gpio1833_gpio4cd_ms */
++};
++
++&pcie_phy {
++	status = "okay";
++};
++
++&pcie0 {
++	ep-gpios = <&gpio1 RK_PA1 GPIO_ACTIVE_HIGH>;
++	max-link-speed = <2>;
++	num-lanes = <4>;
++	pinctrl-0 = <&pcie_clkreqnb_cpm>;
++	pinctrl-names = "default";
++	vpcie3v3-supply = <&vcc5v0_sys>;
++	status = "okay";
++};
++
++&pinctrl {
++	pcie {
++		pcie_drv: pcie-drv {
++			rockchip,pins =
++				<1 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++	
++	i2s1 {
++		i2s_8ch_mclk: i2s-8ch-mclk {
++			rockchip,pins = <4 RK_PA0 1 &pcfg_pull_none>;
++		};
++	};
++
++	pmic {
++		pmic_int_l: pmic-int-l {
++			rockchip,pins = <1 RK_PC5 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++
++		vsel1_gpio: vsel1-gpio {
++			rockchip,pins = <1 RK_PC1 RK_FUNC_GPIO &pcfg_pull_down>;
++		};
++
++		vsel2_gpio: vsel2-gpio {
++			rockchip,pins = <1 RK_PB6 RK_FUNC_GPIO &pcfg_pull_down>;
++		};
++	};
++
++	sdmmc {
++		sdmmc0_det_l: sdmmc0-det-l {
++			rockchip,pins = <0 RK_PA7 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++
++		sdmmc0_pwr_h: sdmmc0-pwr-h {
++			rockchip,pins = <0 RK_PA1 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	usb-typec {
++		vcc5v0_typec_en: vcc5v0_typec_en {
++			rockchip,pins = <2 RK_PB4 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	fusb30x {
++		fusb0_int: fusb0-int {
++			rockchip,pins = <1 RK_PA2 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	sdio-pwrseq {
++		wifi_enable_h: wifi-enable-h {
++			rockchip,pins = <0 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	wireless-bluetooth {
++		uart0_gpios: uart0-gpios {
++			rockchip,pins = <2 RK_PC3 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	rockchip-key {
++		power_key: power-key {
++			rockchip,pins = <0 RK_PA5 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	headphone {
++		hp_det: hp-det {
++			rockchip,pins = <4 RK_PD4 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	gpio-leds {
++		leds_gpio: leds-gpio {
++			rockchip,pins = <0 RK_PB3 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	cam_pins {
++		cif_clkout_a: cif-clkout-a {
++			rockchip,pins = <2 11 3 &pcfg_pull_none>;
++		};
++
++		cif_clkout_a_sleep: cif-clkout-a-sleep {
++			rockchip,pins = <2 RK_PB3 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		cam0_default_pins: cam0-default-pins {
++			rockchip,pins =
++				<4 27 0 &pcfg_pull_down>,
++				<2 11 3 &pcfg_pull_none>;
++		};
++		cam0_sleep_pins: cam0-sleep-pins {
++   			rockchip,pins =
++    			<4 27 3 &pcfg_pull_none>,
++		    	<2 11 0 &pcfg_pull_none>;
++ 		 };
++
++		cam1_default_pins: cam1-default-pins {
++			rockchip,pins =
++				<0 12 RK_FUNC_GPIO &pcfg_pull_down>,
++				<0  8 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++	
++	spi1 {
++		spi1_gpio: spi1-gpio {
++			rockchip,pins =
++				<1 RK_PA7 RK_FUNC_GPIO &pcfg_output_low>,
++				<1 RK_PB0 RK_FUNC_GPIO &pcfg_output_low>,
++				<1 RK_PB1 RK_FUNC_GPIO &pcfg_output_low>,
++				<1 RK_PB2 RK_FUNC_GPIO &pcfg_output_low>;
++		};
++	};
++
++	bt {
++		bt_host_wake: bt-host-wake {
++			rockchip,pins = <0 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		bt_reset: bt-reset {
++			rockchip,pins = <0 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		bt_wake: bt-wake {
++			rockchip,pins = <2 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
 +	};
 +
 +};
 +
-+&emmc_phy {
++&pmu_io_domains {
++	status = "okay";
++	pmu1830-supply = <&vcc_3v0>;
++};	
++	
++&pwm_bl {
 +	status = "okay";
 +};
 +
@@ -125,20 +1006,55 @@ index 00000000..65e9c44b
 +	status = "okay";
 +};
 +
-+&pwm2 {
++&pwm1 {
 +	status = "okay";
 +};
 +
-+&pwm3 {
++&pwm2 {
 +	status = "okay";
++	pinctrl-names = "active";
++	pinctrl-0 = <&pwm2_pin_pull_down>;
++};
++
++&rga {
++	status = "disabled";
 +};
 +
 +&saradc {
 +	status = "okay";
++	vref-supply = <&vcca1v8_s3>; /* TBD */
++};	
++
++&sdio0 {
++	clock-frequency = <50000000>;
++	clock-freq-min-max = <200000 50000000>;
++	supports-sdio;
++	bus-width = <4>;
++	disable-wp;
++	cap-sd-highspeed;
++	cap-sdio-irq;
++	keep-power-in-suspend;
++	mmc-pwrseq = <&sdio_pwrseq>;
++	non-removable;
++	num-slots = <1>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdio0_bus4 &sdio0_cmd &sdio0_clk>;
++	sd-uhs-sdr104;
++
 +};
 +
 +&sdmmc {
 +	bus-width = <4>;
++	cap-mmc-highspeed;
++	cap-sd-highspeed;
++	cd-gpios = <&gpio0 RK_PA7 GPIO_ACTIVE_LOW>;
++	disable-wp;
++	max-frequency = <150000000>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdmmc_clk &sdmmc_cd &sdmmc_cmd &sdmmc_bus4>;
++//	sd-uhs-sdr104;
++	vmmc-supply = <&vcc3v0_sd>;
++	vqmmc-supply = <&vcc_sdio>;
 +	status = "okay";
 +};
 +
@@ -147,7 +1063,125 @@ index 00000000..65e9c44b
 +	mmc-hs400-1_8v;
 +	mmc-hs400-enhanced-strobe;
 +	non-removable;
++	keep-power-in-suspend;
++	supports-emmc;
 +	status = "okay";
++};
++
++&spdif {
++	status = "disable";
++	pinctrl-0 = <&spdif_bus>;
++	i2c-scl-rising-time-ns = <450>;
++	i2c-scl-falling-time-ns = <15>;
++	#sound-dai-cells = <0>;
++};
++
++/* &spi1 {
++	status = "disable";
++	pinctrl-names = "default", "sleep";
++	pinctrl-1 = <&spi1_gpio>;
++
++	spidev0: spidev@0 {
++		compatible = "rockchip,spidev";
++		reg = <0>;
++		spi-max-frequency = <10000000>;
++		status = "okay";
++	};
++};*/
++/*
++&spi1 {
++    status = "okay";
++    max-freq = <48000000>;
++    spidev@00 {
++        compatible = "linux,spidev";
++        reg = <0x00>;
++        spi-max-frequency = <48000000>;
++    };
++};
++*/
++
++&tcphy0 {
++	status = "okay";
++};
++
++&tcphy0_dp {
++	port {
++		tcphy0_typec_dp: endpoint {
++			remote-endpoint = <&usbc_dp>;
++		};
++	};
++};
++
++&tcphy0_usb3 {
++	port {
++		tcphy0_typec_ss: endpoint {
++			remote-endpoint = <&usbc_ss>;
++		};
++	};
++};
++
++&tcphy1 {
++	status = "okay";
++};
++
++&tsadc {
++	status = "okay";
++
++	/* tshut mode 0:CRU 1:GPIO */
++	rockchip,hw-tshut-mode = <1>;
++	/* tshut polarity 0:LOW 1:HIGH */
++	rockchip,hw-tshut-polarity = <1>;
++};
++
++&u2phy0 {
++	status = "okay";
++
++	u2phy0_otg: otg-port {
++		status = "okay";
++	};
++
++	u2phy0_host: host-port {
++		phy-supply = <&vbus_typec>;
++		status = "okay";
++	};
++	
++	port {
++		u2phy0_typec_hs: endpoint {
++			remote-endpoint = <&usbc_hs>;
++		};
++	};
++};
++
++&u2phy1 {
++	status = "okay";
++
++	u2phy1_otg: otg-port {
++		status = "okay";
++	};
++
++	u2phy1_host: host-port {
++		phy-supply = <&usb_vbus>;
++		status = "okay";
++	};
++};
++
++&uart0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart0_xfer &uart0_cts &uart0_rts>;
++	status = "okay";
++
++	bluetooth {
++		compatible = "brcm,bcm4345c5";
++		clocks = <&rk808 1>;
++		clock-names = "lpo";
++		device-wakeup-gpios = <&gpio2 RK_PD2 GPIO_ACTIVE_HIGH>;
++		host-wakeup-gpios = <&gpio0 RK_PA4 GPIO_ACTIVE_HIGH>;
++		shutdown-gpios = <&gpio0 RK_PB1 GPIO_ACTIVE_HIGH>;
++		max-speed = <1500000>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&bt_host_wake &bt_wake &bt_reset>;
++	};
++
 +};
 +
 +&uart2 {
@@ -155,6 +1189,7 @@ index 00000000..65e9c44b
 +};
 +
 +&usb_host0_ehci {
++        phy-supply = <&vcc3v3_sys>;
 +	status = "okay";
 +};
 +
@@ -162,12 +1197,8 @@ index 00000000..65e9c44b
 +	status = "okay";
 +};
 +
-+&usbdrd3_0 {
-+	vbus-supply = <&vcc5v0_typec0>;
-+	status = "okay";
-+};
-+
 +&usb_host1_ehci {
++        phy-supply = <&vcc3v3_sys>;
 +	status = "okay";
 +};
 +
@@ -175,89 +1206,70 @@ index 00000000..65e9c44b
 +	status = "okay";
 +};
 +
++&usbdrd3_0 {
++	phy-supply = <&vbus_typec>;
++	status = "okay";
++};
++
 +&usbdrd3_1 {
-+	vbus-supply = <&vcc5v0_typec1>;
++	phy-supply = <&vbus_typec>;
 +	status = "okay";
 +};
 +
-+&i2c0 {
++&usbdrd_dwc3_0 {
++        dr_mode = "host";
 +	status = "okay";
-+	clock-frequency = <400000>;
-+	i2c-scl-falling-time-ns = <50>;
-+	i2c-scl-rising-time-ns = <100>;
-+	u-boot,dm-pre-reloc;
-+
-+	rk808: pmic@1b {
-+		compatible = "rockchip,rk808";
-+		clock-output-names = "xin32k", "wifibt_32kin";
-+		interrupt-parent = <&gpio0>;
-+		interrupts = <4 IRQ_TYPE_LEVEL_LOW>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&pmic_int_l>;
-+		reg = <0x1b>;
-+		rockchip,system-power-controller;
-+		#clock-cells = <1>;
-+		u-boot,dm-pre-reloc;
-+		status = "okay";
-+
-+		vcc12-supply = <&vcc3v3_sys>;
-+
-+		regulators {
-+			vcc33_lcd: SWITCH_REG2 {
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-name = "vcc33_lcd";
-+			};
-+		};
-+	};
 +};
 +
-+&pinctrl {
-+	pmic {
-+		pmic_int_l: pmic-int-l {
-+			rockchip,pins =
-+				<1 21 RK_FUNC_GPIO &pcfg_pull_up>;
-+		};
-+
-+		pmic_dvs2: pmic-dvs2 {
-+			rockchip,pins =
-+				<1 18 RK_FUNC_GPIO &pcfg_pull_down>;
-+		};
-+	};
++&usbdrd_dwc3_1 {
++	dr_mode = "host";
++	status = "okay";
 +};
 +
-+&gmac {
-+	phy-supply = <&vcc_phy>;
-+	phy-mode = "rgmii";
-+	clock_in_out = "input";
-+	snps,reset-gpio = <&gpio3 RK_PB7 GPIO_ACTIVE_LOW>;
-+	snps,reset-active-low;
-+	snps,reset-delays-us = <0 10000 50000>;
-+	assigned-clocks = <&cru SCLK_RMII_SRC>;
-+	assigned-clock-parents = <&clkin_gmac>;
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&rgmii_pins>;
-+	tx_delay = <0x28>;
-+	rx_delay = <0x11>;
++&vopb {
 +	status = "okay";
++};
++
++&vopb_mmu {
++	status = "okay";
++};
++
++&vopl {
++	status = "okay";
++};
++
++&vopl_mmu {
++	status = "okay";
++};
++
++&vpu {
++	status = "okay";
++	/* 0 means ion, 1 means drm */
++	//allocator = <0>;
 +};
 diff --git a/configs/orangepi-4-rk3399_defconfig b/configs/orangepi-4-rk3399_defconfig
 new file mode 100644
-index 00000000..18ec369f
+index 00000000..26301706
 --- /dev/null
 +++ b/configs/orangepi-4-rk3399_defconfig
-@@ -0,0 +1,64 @@
+@@ -0,0 +1,97 @@
 +CONFIG_ARM=y
 +CONFIG_ARCH_ROCKCHIP=y
 +CONFIG_SYS_TEXT_BASE=0x00200000
++CONFIG_SPL_GPIO_SUPPORT=y
 +CONFIG_NR_DRAM_BANKS=1
++CONFIG_ENV_SIZE=0x6000
 +CONFIG_ENV_OFFSET=0x3F8000
++CONFIG_ENV_SECT_SIZE=0x1000
 +CONFIG_ROCKCHIP_RK3399=y
 +CONFIG_TARGET_EVB_RK3399=y
 +CONFIG_DEBUG_UART_BASE=0xFF1A0000
 +CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_SPL_SPI_FLASH_SUPPORT=y
++CONFIG_SPL_SPI_SUPPORT=y
 +CONFIG_DEFAULT_DEVICE_TREE="rk3399-orangepi-4"
 +CONFIG_DEBUG_UART=y
++CONFIG_BOOTDELAY=3
 +CONFIG_DEFAULT_FDT_FILE="rockchip/rk3399-orangepi-4.dtb"
 +CONFIG_MISC_INIT_R=y
 +# CONFIG_DISPLAY_CPUINFO is not set
@@ -265,39 +1277,64 @@ index 00000000..18ec369f
 +# CONFIG_SPL_RAW_IMAGE_SUPPORT is not set
 +CONFIG_SPL_STACK_R=y
 +CONFIG_SPL_STACK_R_MALLOC_SIMPLE_LEN=0x10000
++CONFIG_SPL_MTD_SUPPORT=y
++CONFIG_SPL_ENV_SUPPORT=y
++CONFIG_SPL_SPI_LOAD=y
 +CONFIG_TPL=y
 +CONFIG_CMD_BOOTZ=y
++CONFIG_CMD_GPIO=y
 +CONFIG_CMD_GPT=y
++CONFIG_CMD_I2C=y
 +CONFIG_CMD_MMC=y
++CONFIG_CMD_PCI=y
 +CONFIG_CMD_USB=y
 +# CONFIG_CMD_SETEXPR is not set
 +CONFIG_CMD_TIME=y
 +CONFIG_SPL_OF_CONTROL=y
 +CONFIG_OF_SPL_REMOVE_PROPS="pinctrl-0 pinctrl-names clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
-+CONFIG_ENV_IS_IN_MMC=y
++CONFIG_ENV_IS_IN_SPI_FLASH=y
 +CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_SPL_DM_SEQ_ALIAS=y
 +CONFIG_ROCKCHIP_GPIO=y
 +CONFIG_SYS_I2C_ROCKCHIP=y
++CONFIG_MISC=y
 +CONFIG_MMC_DW=y
 +CONFIG_MMC_DW_ROCKCHIP=y
 +CONFIG_MMC_SDHCI=y
 +CONFIG_MMC_SDHCI_ROCKCHIP=y
++CONFIG_SF_DEFAULT_BUS=1
++CONFIG_SPI_FLASH_GIGADEVICE=y
++CONFIG_SPI_FLASH_WINBOND=y
++CONFIG_SPI_FLASH_XTX=y
++CONFIG_SPI_FLASH_STMICRO=y
 +CONFIG_DM_ETH=y
 +CONFIG_ETH_DESIGNWARE=y
 +CONFIG_GMAC_ROCKCHIP=y
++CONFIG_NVME=y
++CONFIG_PCI=y
++CONFIG_PHY_ROCKCHIP_INNO_USB2=y
++CONFIG_PHY_ROCKCHIP_TYPEC=y
 +CONFIG_PMIC_RK8XX=y
 +CONFIG_REGULATOR_PWM=y
 +CONFIG_REGULATOR_RK8XX=y
 +CONFIG_PWM_ROCKCHIP=y
 +CONFIG_RAM_RK3399_LPDDR4=y
++CONFIG_DM_RESET=y
++CONFIG_DM_RNG=y
++CONFIG_RNG_ROCKCHIP=y
 +CONFIG_BAUDRATE=1500000
 +CONFIG_DEBUG_UART_SHIFT=2
++CONFIG_ROCKCHIP_SPI=y
 +CONFIG_SYSRESET=y
 +CONFIG_USB=y
 +CONFIG_USB_XHCI_HCD=y
 +CONFIG_USB_XHCI_DWC3=y
 +CONFIG_USB_EHCI_HCD=y
 +CONFIG_USB_EHCI_GENERIC=y
++CONFIG_USB_DWC3=y
++CONFIG_USB_DWC3_GENERIC=y
++CONFIG_USB_STORAGE=y
++CONFIG_USB_GADGET=y
 +CONFIG_USB_KEYBOARD=y
 +CONFIG_USB_HOST_ETHER=y
 +CONFIG_USB_ETHER_ASIX=y
@@ -311,3 +1348,5 @@ index 00000000..18ec369f
 +CONFIG_DISPLAY_ROCKCHIP_HDMI=y
 +CONFIG_SPL_TINY_MEMSET=y
 +CONFIG_ERRNO_STR=y
++CONFIG_MTD=y
++CONFIG_DM_MTD=y


### PR DESCRIPTION
Orange Pi4 updates to make the dts more common to mainline and added some features

like spi boot
hdmi outpit in uboot
type c fix  (@tonymac this is new dp fix )

refactor kernel dts dot make it same as the rest of the boards.

# Description

Changes the dts of uboot and kernel to be more mainline 
can be build with blobs or atf bot work 

added spi boot
Usb3 is seen with uboot  
Hdmi output on uboot
old uboot has lot of wrong pin , a mipi switch is not a usbc switch etc 
only problem is how to switch fusb on but that have all boards


and kernel side it 

fixed type-c (@tonymac this is the replacement of extcon)
and refactor to mainline and alphabet 



# How Has This Been Tested?

Tested on Orange Pi 4 
on sd and spi 

with uboot debug 
and comapring dmesg of kernel 

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
