### PR TITLE
Gnome - add missing packages which made terminal look ugly

### DIFF
--- a/config/desktop/focal/environments/gnome/config_base/packages
+++ b/config/desktop/focal/environments/gnome/config_base/packages
@@ -23,4 +23,4 @@ spice-vdagent tracker tracker-extract tracker-miner-fs update-manager update-man
 x11-session-utils x11-utils xdg-desktop-portal xdg-user-dirs xdg-user-dirs-gtk xinput xorg xorg-docs-core yaru-theme-gnome-shell yelp yelp-xsl 
 pulseaudio-module-bluetooth pavucontrol gnome-shell-extension-trash cups system-config-printer-gnome ubuntu-desktop-minimal ubuntu-session 
 ubuntu-settings gnome-terminal synaptic gnome-packagekit gnome-system-tools gnome-tweak-tool gedit gpaste gnome-tweaks gnome-system-log 
-gnome-power-manager gnome-screensaver gnome-screenshot gnome-todo gnome-photos gpaint lightdm lightdm-gtk-greeter lightdm-gtk-greeter-settings gdebi gnome-screenshot
+gnome-power-manager gnome-screensaver gnome-screenshot gnome-todo gnome-photos gpaint lightdm lightdm-gtk-greeter lightdm-gtk-greeter-settings gdebi gnome-screenshot fonts-ubuntu network-manager-openvpn-gnome eject


### PR DESCRIPTION
# Description

Fixing problem with fonts:

![Screenshot from 2021-02-22 21-30-09](https://user-images.githubusercontent.com/6281704/109280990-039d7400-781c-11eb-9cd6-db546847a3ad.png)

Added two unrelated packages (network-manager-openvpn-gnome eject)

Jira reference number [AR-653]

# How Has This Been Tested?

Installed those files on top of previously made image. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings

[AR-653]: https://armbian.atlassian.net/browse/AR-653