### PR TITLE
Restore eMMC HS400 on Helios64

### DIFF
--- a/patch/kernel/rockchip64-current/add-board-helios64.patch
+++ b/patch/kernel/rockchip64-current/add-board-helios64.patch
@@ -14,7 +14,7 @@ new file mode 100644
 index 000000000..fae17f416
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts
-@@ -0,0 +1,1151 @@
+@@ -0,0 +1,1153 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2020 Aditya Prayoga (aditya@kobol.io)
@@ -984,6 +984,8 @@ index 000000000..fae17f416
 +	assigned-clock-rates = <150000000>;
 +	bus-width = <8>;
 +	mmc-hs200-1_8v;
++	mmc-hs400-1_8v;
++	mmc-hs400-enhanced-strobe;
 +	supports-emmc;
 +	non-removable;
 +	disable-wp;

--- a/patch/kernel/rockchip64-current/add-board-helios64.patch
+++ b/patch/kernel/rockchip64-current/add-board-helios64.patch
@@ -14,7 +14,7 @@ new file mode 100644
 index 000000000..fae17f416
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts
-@@ -0,0 +1,1150 @@
+@@ -0,0 +1,1151 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2020 Aditya Prayoga (aditya@kobol.io)
@@ -981,6 +981,7 @@ index 000000000..fae17f416
 +};
 +
 +&sdhci {
++	assigned-clock-rates = <150000000>;
 +	bus-width = <8>;
 +	mmc-hs200-1_8v;
 +	supports-emmc;

--- a/patch/u-boot/u-boot-rockchip64-mainline/add-board-helios64.patch
+++ b/patch/u-boot/u-boot-rockchip64-mainline/add-board-helios64.patch
@@ -188,7 +188,7 @@ new file mode 100644
 index 00000000..9d067505
 --- /dev/null
 +++ b/arch/arm/dts/rk3399-kobol-helios64.dts
-@@ -0,0 +1,1146 @@
+@@ -0,0 +1,1147 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2020 Aditya Prayoga (aditya@kobol.io)
@@ -1158,6 +1158,7 @@ index 00000000..9d067505
 +};
 +
 +&sdhci {
++	assigned-clock-rates = <150000000>;
 +	bus-width = <8>;
 +	mmc-hs200-1_8v;
 +	supports-emmc;

--- a/patch/u-boot/u-boot-rockchip64-mainline/add-board-helios64.patch
+++ b/patch/u-boot/u-boot-rockchip64-mainline/add-board-helios64.patch
@@ -188,7 +188,7 @@ new file mode 100644
 index 00000000..9d067505
 --- /dev/null
 +++ b/arch/arm/dts/rk3399-kobol-helios64.dts
-@@ -0,0 +1,1147 @@
+@@ -0,0 +1,1149 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2020 Aditya Prayoga (aditya@kobol.io)
@@ -1161,6 +1161,8 @@ index 00000000..9d067505
 +	assigned-clock-rates = <150000000>;
 +	bus-width = <8>;
 +	mmc-hs200-1_8v;
++	mmc-hs400-1_8v;
++	mmc-hs400-enhanced-strobe;
 +	supports-emmc;
 +	non-removable;
 +	status = "okay";


### PR DESCRIPTION
# Description

Some user reported issue (sometimes failed to initialized) with their eMMC.
Signal integrity at 200 MHz might not great, similar like 
https://github.com/torvalds/linux/blob/v5.10/arch/arm64/boot/dts/rockchip/rk3399-gru.dtsi#L493-L498

Slightly reduce the clock and enable HS400 to compensate the lower clock.

Jira reference number [AR-658]

# How Has This Been Tested?

Image written to internal eMMC and system boot from internal eMMC. Test conducted 10 times with reboot on each loop. Tested on three helios64 boards.

- [x] System boot and no corrupted filesystem
- [x] Simple dd read from eMMC
- [x] Simple dd write to eMMC

Test result: https://gist.github.com/aprayoga/6db2d7f8bf6b17c94cf47788c09e1a41

No _mmc1: "running CQE recovery"_
as described at https://lkml.org/lkml/2019/11/11/203 

Additional test, kernel compilation

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-658]: https://armbian.atlassian.net/browse/AR-658