### PR TITLE
Increase number of inodes during FS creation

### DIFF
--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -391,10 +391,11 @@ prepare_partitions()
 	# parttype[nfs] is empty
 
 	# metadata_csum and 64bit may need to be disabled explicitly when migrating to newer supported host OS releases
+	# add -N number of inodes to keep mount from running out
 	if [[ $(lsb_release -sc) =~ bionic|buster|bullseye|cosmic|groovy|focal|hirsute|sid ]]; then
-		mkopts[ext4]='-q -m 2 -O ^64bit,^metadata_csum'
+		mkopts[ext4]="-q -m 2 -O ^64bit,^metadata_csum -N $((128*1024))"
 	elif [[ $(lsb_release -sc) == xenial ]]; then
-		mkopts[ext4]='-q -m 2'
+		mkopts[ext4]="-q -m 2 -N $((128*1024))"
 	fi
 	mkopts[fat]='-n BOOT'
 	mkopts[ext2]='-q'


### PR DESCRIPTION
# Description

This fixes #2664 , where the rootfs runs out of inodes during building and hangs indefinitely.

If there's a better way, please comment down below.

Jira reference number [AR-659]

# How Has This Been Tested?

Used the steps given in the issue to reproduce the issue and then used the suggested fixes. Build a image to test them.
See issue for more (full) details. 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Need to test building a few more images


[AR-659]: https://armbian.atlassian.net/browse/AR-659