### PR TITLE
Add overlay_error env on sunxi64 to enable overlays support

### DIFF
--- a/config/bootscripts/boot-mvebu.cmd
+++ b/config/bootscripts/boot-mvebu.cmd
@@ -5,6 +5,7 @@
 
 setenv load_addr "0x300000"
 # default values
+setenv overlay_error "false"
 setenv rootdev "/dev/mmcblk0p1"
 setenv rootfstype "ext4"
 setenv verbosity "1"

--- a/config/bootscripts/boot-sun50i-next.cmd
+++ b/config/bootscripts/boot-sun50i-next.cmd
@@ -5,6 +5,7 @@
 
 # default values
 setenv load_addr "0x45000000"
+setenv overlay_error "false"
 setenv rootdev "/dev/mmcblk0p1"
 setenv verbosity "1"
 setenv rootfstype "ext4"


### PR DESCRIPTION
Hi @igorpecovnik ,

Commit 37c324975fa51f2b824da7c053674547189fdcd4 breaks overlays support for sunxi64 based boards.
Indeed, it checks if there is a `setenv overlay_error` line in the boot cmd file.
That's why I added it to **config/bootscripts/boot-sun50i-next.cmd**.

Note: I work with an Orange Pi Zero Plus so that i was able to check for this board type but there might be the very same issue for **config/bootscripts/boot-mvebu.cmd**.

Regards,
Orel