### PR TITLE
Attempt to improve stability on Helios64

### DIFF
--- a/patch/kernel/rockchip64-current/board-helios64-dts-fix-stability-issues.patch
+++ b/patch/kernel/rockchip64-current/board-helios64-dts-fix-stability-issues.patch
@@ -1,0 +1,12 @@
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts b/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts
+index e666bd5ae..df1fc943b 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts
+@@ -478,6 +478,7 @@ rk808: pmic@1b {
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&pmic_int_l>;
+ 		rockchip,system-power-controller;
++		max-buck-steps-per-change = <4>;
+ 		wakeup-source;
+ 
+ 		vcc1-supply = <&vcc5v0_sys>;

--- a/patch/u-boot/u-boot-rockchip64-mainline/add-board-helios64.patch
+++ b/patch/u-boot/u-boot-rockchip64-mainline/add-board-helios64.patch
@@ -181,7 +181,7 @@ index 00000000..2988a209
 +};
 +
 +&vdd_log {
-+	regulator-init-microvolt = <900000>;
++	regulator-init-microvolt = <930000>;
 +};
 diff --git a/arch/arm/dts/rk3399-kobol-helios64.dts b/arch/arm/dts/rk3399-kobol-helios64.dts
 new file mode 100644
@@ -1342,7 +1342,7 @@ index 254b9c5b..5f89bf6e 100644
 @@ -26,6 +26,22 @@ config TARGET_PINEBOOK_PRO_RK3399
  	  with 4Gb RAM, onboard eMMC, USB-C, a USB3 and USB2 port,
  	  1920*1080 screen and all the usual laptop features.
- 
+
 +config TARGET_HELIOS64
 +	bool "Kobol Innovations Helios64"
 +	select BOARD_LATE_INIT
@@ -1362,7 +1362,7 @@ index 254b9c5b..5f89bf6e 100644
  config TARGET_PUMA_RK3399
  	bool "Theobroma Systems RK3399-Q7 (Puma)"
  	help
-@@ -151,6 +167,7 @@ endif # BOOTCOUNT_LIMIT
+@@ -153,6 +169,7 @@ endif # BOOTCOUNT_LIMIT
  
  source "board/firefly/roc-pc-rk3399/Kconfig"
  source "board/google/gru/Kconfig"
@@ -1428,7 +1428,7 @@ new file mode 100644
 index 00000000..c7a0efa4
 --- /dev/null
 +++ b/board/kobol/helios64/helios64.c
-@@ -0,0 +1,304 @@
+@@ -0,0 +1,321 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * (C) Copyright 2020 Aditya Prayoga (aditya@kobol.io)
@@ -1511,6 +1511,22 @@ index 00000000..c7a0efa4
 +	/* Set GPIO1 1.8v/3.0v source select to PMU1830_VOL */
 +	rk_setreg(&pmugrf->soc_con0, 1 << PMUGRF_CON0_VSEL_SHIFT);
 +	rk_setreg(&pmugrf->soc_con0, 0 << PMUGRF_CON0_PMU1830_VOL_SHIFT);
++}
++
++static void init_vdd_center(void)
++{
++	struct udevice *regulator;
++	struct dm_regulator_uclass_platdata *uc_pdata;
++	int ret;
++
++	ret = regulator_get_by_platname("vdd_center", &regulator);
++	if (ret)
++		return;
++
++	uc_pdata = dev_get_uclass_platdata(regulator);
++	ret = regulator_set_value(regulator, uc_pdata->init_uV);
++	if (ret)
++		debug("%s vdd_center init fail! ret %d\n", __func__, ret);
 +}
 +
 +/*
@@ -1604,6 +1620,7 @@ index 00000000..c7a0efa4
 +	int ret;
 +
 +	setup_iodomain();
++	init_vdd_center();
 +	set_board_info();
 +
 +	ret = rockchip_cpuid_from_efuse(cpuid_offset, cpuid_length, cpuid);
@@ -2207,6 +2224,6 @@ index 00000000..6fca9a6b
 +#endif
 +
 +#endif
--- 
+--
 Created with Armbian build tools https://github.com/armbian/build
 


### PR DESCRIPTION
# Description

Number of Helios64 users suffer stability issue which seem caused by DVFS. Initial test of #2663 on Helios64 improve the stability but it needs to be tested on more user.
Part of this changes depend on _general-rk808-configrable-switch-voltage-steps.patch_ of PR #2663 

Jira reference number [AR-660]

# How Has This Been Tested?

Difficult to test since we don't really have the board that have issue with DVFS. The changes tested on a board that always crash after several reboot.

- [x] Voltage measured on the board
- [x] Reboot test

With the changes, the board can survive more reboots.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-660]: https://armbian.atlassian.net/browse/AR-660