### PR TITLE
Add bfsu mirror as another mirror of tuna

### DIFF
--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -492,13 +492,13 @@ DEBIAN_MIRROR='deb.debian.org/debian'
 DEBIAN_SECURTY='security.debian.org/'
 UBUNTU_MIRROR='ports.ubuntu.com/'
 
-if [[ $DOWNLOAD_MIRROR == tuna ]] ; then
+if [[ $DOWNLOAD_MIRROR == "china" ]] ; then
 	DEBIAN_MIRROR='mirrors.tuna.tsinghua.edu.cn/debian'
 	DEBIAN_SECURTY='mirrors.tuna.tsinghua.edu.cn/debian-security'
 	UBUNTU_MIRROR='mirrors.tuna.tsinghua.edu.cn/ubuntu-ports/'
 fi
 
-if [[ $DOWNLOAD_MIRROR == bfsu ]] ; then
+if [[ $DOWNLOAD_MIRROR == "bfsu" ]] ; then
 	DEBIAN_MIRROR='mirrors.bfsu.edu.cn/debian'
 	DEBIAN_SECURTY='mirrors.bfsu.edu.cn/debian-security'
 	UBUNTU_MIRROR='mirrors.bfsu.edu.cn/ubuntu-ports/'

--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -64,6 +64,7 @@ fi
 case $MAINLINE_MIRROR in
 	google) MAINLINE_KERNEL_SOURCE='https://kernel.googlesource.com/pub/scm/linux/kernel/git/stable/linux-stable' ;;
 	tuna) MAINLINE_KERNEL_SOURCE='https://mirrors.tuna.tsinghua.edu.cn/git/linux-stable.git' ;;
+	bfsu) MAINLINE_KERNEL_SOURCE='https://mirrors.bfsu.edu.cn/git/linux-stable.git' ;;
 	*) MAINLINE_KERNEL_SOURCE='git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git' ;;
 esac
 MAINLINE_KERNEL_DIR='linux-mainline'
@@ -491,10 +492,16 @@ DEBIAN_MIRROR='deb.debian.org/debian'
 DEBIAN_SECURTY='security.debian.org/'
 UBUNTU_MIRROR='ports.ubuntu.com/'
 
-if [[ $DOWNLOAD_MIRROR == china ]] ; then
+if [[ $DOWNLOAD_MIRROR == tuna ]] ; then
 	DEBIAN_MIRROR='mirrors.tuna.tsinghua.edu.cn/debian'
 	DEBIAN_SECURTY='mirrors.tuna.tsinghua.edu.cn/debian-security'
 	UBUNTU_MIRROR='mirrors.tuna.tsinghua.edu.cn/ubuntu-ports/'
+fi
+
+if [[ $DOWNLOAD_MIRROR == bfsu ]] ; then
+	DEBIAN_MIRROR='mirrors.bfsu.edu.cn/debian'
+	DEBIAN_SECURTY='mirrors.bfsu.edu.cn/debian-security'
+	UBUNTU_MIRROR='mirrors.bfsu.edu.cn/ubuntu-ports/'
 fi
 
 # don't use mirrors that throws garbage on 404

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1235,6 +1235,10 @@ function webseed ()
 		WEBSEED=(
 		"https://mirrors.tuna.tsinghua.edu.cn/armbian-releases/"
 		)
+	elif [[ $DOWNLOAD_MIRROR == bfsu ]]; then
+		WEBSEED=(
+		"https://mirrors.bfsu.edu.cn/armbian-releases/"
+		)
 	fi
 	for toolchain in ${WEBSEED[@]}; do
 		# use only live, tnahosting return ok also when file is absent
@@ -1258,9 +1262,11 @@ download_and_verify()
 	local dirname=${filename//.tar.xz}
 
         if [[ $DOWNLOAD_MIRROR == china ]]; then
-		local server="https://mirrors.tuna.tsinghua.edu.cn/armbian-releases/"
-	else
-		local server=${ARMBIAN_MIRROR}
+			local server="https://mirrors.tuna.tsinghua.edu.cn/armbian-releases/"
+		elif [[ $DOWNLOAD_MIRROR == bfsu ]]; then
+			local server="https://mirrors.bfsu.edu.cn/armbian-releases/"
+		else
+			local server=${ARMBIAN_MIRROR}
         fi
 
 	if [[ -f ${localdir}/${dirname}/.download-complete ]]; then
@@ -1272,6 +1278,13 @@ download_and_verify()
 	if [[ $? -ne 7 && $? -ne 22 && $? -ne 0 ]]; then
 		display_alert "Timeout from $server" "retrying" "info"
 		server="https://mirrors.tuna.tsinghua.edu.cn/armbian-releases/"
+	fi
+	
+	# switch to another china mirror if US timeouts
+	timeout 10 curl --head --fail --silent ${server}${remotedir}/${filename} 2>&1 >/dev/null
+	if [[ $? -ne 7 && $? -ne 22 && $? -ne 0 ]]; then
+		display_alert "Timeout from $server" "retrying" "info"
+		server="https://mirrors.bfsu.edu.cn/armbian-releases/"
 	fi
 
 	# check if file exists on remote server before running aria2 downloader

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1278,14 +1278,15 @@ download_and_verify()
 	if [[ $? -ne 7 && $? -ne 22 && $? -ne 0 ]]; then
 		display_alert "Timeout from $server" "retrying" "info"
 		server="https://mirrors.tuna.tsinghua.edu.cn/armbian-releases/"
+		
+		# switch to another china mirror if tuna timeouts
+		timeout 10 curl --head --fail --silent ${server}${remotedir}/${filename} 2>&1 >/dev/null
+		if [[ $? -ne 7 && $? -ne 22 && $? -ne 0 ]]; then
+			display_alert "Timeout from $server" "retrying" "info"
+			server="https://mirrors.bfsu.edu.cn/armbian-releases/"
+		fi
 	fi
 	
-	# switch to another china mirror if US timeouts
-	timeout 10 curl --head --fail --silent ${server}${remotedir}/${filename} 2>&1 >/dev/null
-	if [[ $? -ne 7 && $? -ne 22 && $? -ne 0 ]]; then
-		display_alert "Timeout from $server" "retrying" "info"
-		server="https://mirrors.bfsu.edu.cn/armbian-releases/"
-	fi
 
 	# check if file exists on remote server before running aria2 downloader
 	[[ ! `timeout 10 curl --head --fail --silent ${server}${remotedir}/${filename}` ]] && return

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -175,6 +175,8 @@ create_sources_list()
 	# stage: add armbian repository and install key
 	if [[ $DOWNLOAD_MIRROR == "china" ]]; then
 		echo "deb http://mirrors.tuna.tsinghua.edu.cn/armbian $RELEASE main ${RELEASE}-utils ${RELEASE}-desktop" > "${SDCARD}"/etc/apt/sources.list.d/armbian.list
+	elif [[ $DOWNLOAD_MIRROR == "bfsu" ]]; then
+	    echo "deb http://mirrors.bfsu.edu.cn/armbian $RELEASE main ${RELEASE}-utils ${RELEASE}-desktop" > "${SDCARD}"/etc/apt/sources.list.d/armbian.list
 	else
 		echo "deb http://"$([[ $BETA == yes ]] && echo "beta" || echo "apt" )".armbian.com $RELEASE main ${RELEASE}-utils ${RELEASE}-desktop" > "${SDCARD}"/etc/apt/sources.list.d/armbian.list
 	fi


### PR DESCRIPTION
# Description
Add bfsu mirror as another mirror of tuna. Reduce tuna source stress. Increase download speed.

```
./compile.sh DOWNLOAD_MIRROR=bfsu MAINLINE_MIRROR=bfsu
```

# How Has This Been Tested?
- [x] tested in common build case.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
