### PR TITLE
Most recent git client returns protocol in get-url origin

### DIFF
--- a/lib/general.sh
+++ b/lib/general.sh
@@ -272,7 +272,7 @@ fetch_from_repo()
 	#  Then the target URL matches the local URL.
 
 	if [[ "$(improved_git rev-parse --git-dir 2>/dev/null)" == ".git" && \
-		  "$url" != "$(improved_git remote get-url origin 2>/dev/null)" ]]; then
+		  "$url" != *"$(improved_git remote get-url origin | sed 's/^.*@//' | sed 's/^.*\/\///' 2>/dev/null)" ]]; then
 		display_alert "Remote URL does not match, removing existing local copy"
 		rm -rf .git ./*
 	fi


### PR DESCRIPTION
# Description

Most recent UBUNTU host comes with a Git client that displays protocol type in get-url. This breaks our implementation of checking if code URL was changed. In that case we have to download the code ... but different protocol leads to constant re-downloading of sources in case your access to Github is done via ssh protocol, while url is not written that way.

# How Has This Been Tested?

It properly detect change when once URL of vanilla kernels comes from kernel.org / google.com

./compile.sh USE_MAINLINE_GOOGLE_MIRROR="yes" 
./compile.sh USE_MAINLINE_GOOGLE_MIRROR="no" 

while it works normally if there is no change in URL.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
