### PR TITLE
OrangePi Zero Plus Add PXE boot support

### DIFF
--- a/patch/u-boot/u-boot-sunxi/add-orangepi-zero-plus-pxe-support.patch
+++ b/patch/u-boot/u-boot-sunxi/add-orangepi-zero-plus-pxe-support.patch
@@ -1,0 +1,13 @@
+diff --git a/configs/orangepi_zero_plus_defconfig b/configs/orangepi_zero_plus_defconfig
+index 2c4c4900..c2d18e98 100644
+--- a/configs/orangepi_zero_plus_defconfig
++++ b/configs/orangepi_zero_plus_defconfig
+@@ -7,6 +7,8 @@ CONFIG_DRAM_ZQ=3881977
+ # CONFIG_DRAM_ODT_EN is not set
+ CONFIG_DEFAULT_DEVICE_TREE="sun50i-h5-orangepi-zero-plus"
+ # CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
++CONFIG_MACPWR="PD6"
++CONFIG_SPL_SPI_SUNXI=y
+ CONFIG_SUN8I_EMAC=y
+ CONFIG_USB_EHCI_HCD=y
+ CONFIG_USB_OHCI_HCD=y


### PR DESCRIPTION
# Description

Add new U-boot patch allowing an OrangePi Zero Plus to boot from PXE and boot from SPI Flash.

# How Has This Been Tested?

Test 1 : with SD Card :
-Boot without SD card
-Stop boot by pressing a key
-Insert SD card
-Type boot
-Armbian boot OK

Test 2 : PXE boot (with dhcp, tftp, nfs correctly configured)
-Boot without SD card
-Armbian boot OK

- [x] Test A
- [x] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
