### PR TITLE
Add debconf to dependencies

### DIFF
--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -665,7 +665,7 @@ compile_armbian-config()
 	Maintainer: $MAINTAINER <$MAINTAINERMAIL>
 	Replaces: armbian-bsp
 	Depends: bash, iperf3, psmisc, curl, bc, expect, dialog, pv, \
-	debconf-utils, unzip, build-essential, html2text, apt-transport-https, html2text, dirmngr, software-properties-common
+	debconf-utils, unzip, build-essential, html2text, apt-transport-https, html2text, dirmngr, software-properties-common, debconf
 	Recommends: armbian-bsp
 	Suggests: libpam-google-authenticator, qrencode, network-manager, sunxi-tools
 	Section: utils


### PR DESCRIPTION
# Description

Fixes https://forum.armbian.com/topic/17200-tinkerboard-buster-minimal-dpkg-reconfigure-command-not-found/

Jira reference number [AR-none]

# How Has This Been Tested?

It hasn't. At least by me though. Maybe Technicavolous steps in


# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
