### PR TITLE
Small desktop packages rfc

### DIFF
--- a/config/desktop/bullseye/appgroups/internet-tools
+++ b/config/desktop/bullseye/appgroups/internet-tools
@@ -1,1 +1,0 @@
-../../buster/appgroups/internet-tools

--- a/config/desktop/buster/appgroups/internet-tools/packages
+++ b/config/desktop/buster/appgroups/internet-tools/packages
@@ -1,1 +1,0 @@
-filezilla putty

--- a/config/desktop/buster/appgroups/internet/packages
+++ b/config/desktop/buster/appgroups/internet/packages
@@ -1,1 +1,1 @@
-qbittorrent transmission
+qbittorrent transmission transmission-remote-gtk filezilla putty

--- a/config/desktop/focal/appgroups/languages/packages
+++ b/config/desktop/focal/appgroups/languages/packages
@@ -1,2 +1,0 @@
-language-pack-gnome-sl language-pack-gnome-de language-pack-gnome-fr language-pack-gnome-it 
-language-pack-gnome-es language-pack-gnome-pt language-pack-gnome-ru

--- a/config/desktop/focal/environments/budgie/config_base/packages
+++ b/config/desktop/focal/environments/budgie/config_base/packages
@@ -15,4 +15,5 @@ ghostscript-x inputattach kerneloops language-pack-en libatk-adaptor libgail-com
 spice-vdagent zip lightdm lightdm-gtk-greeter lightdm-settings lightdm-gtk-greeter-settings numix-gtk-theme terminator gnome-terminal bubblewrap 
 dbus-x11 dictionaries-common hunspell-en-us nautilus nautilus-data tracker tracker-extract tracker-miner-fs update-manager update-manager-core 
 update-notifier update-notifier-common libgl1-mesa-dri policykit-1 profile-sync-daemon system-config-printer system-config-printer-common 
-printer-driver-all software-properties-common samba smbclient cifs-utils pulseaudio-module-bluetooth gdebi
+printer-driver-all software-properties-common samba smbclient cifs-utils pulseaudio-module-bluetooth gdebi language-pack-gnome-sl 
+language-pack-gnome-de language-pack-gnome-fr language-pack-gnome-it language-pack-gnome-es language-pack-gnome-pt language-pack-gnome-ru 

--- a/config/desktop/focal/environments/cinnamon/config_base/packages
+++ b/config/desktop/focal/environments/cinnamon/config_base/packages
@@ -13,4 +13,5 @@ libatk-adaptor libgail-common libnotify-bin software-properties-gtk speech-dispa
 dictionaries-common hunspell-en-us tracker tracker-extract tracker-miner-fs update-manager update-manager-core update-notifier 
 update-notifier-common libgl1-mesa-dri policykit-1 profile-sync-daemon system-config-printer system-config-printer-common printer-driver-all 
 software-properties-common samba smbclient cifs-utils gnome-power-manager powermgmt-base libupower-glib3 ruby-power-assert plank 
-libplank-common libplank1 gdebi
+libplank-common libplank1 gdebi language-pack-gnome-sl language-pack-gnome-de language-pack-gnome-fr language-pack-gnome-it language-pack-gnome-es 
+language-pack-gnome-pt language-pack-gnome-ru

--- a/config/desktop/focal/environments/cinnamon/config_meta/packages
+++ b/config/desktop/focal/environments/cinnamon/config_meta/packages
@@ -13,4 +13,5 @@ libatk-adaptor libgail-common libnotify-bin software-properties-gtk speech-dispa
 dictionaries-common hunspell-en-us tracker tracker-extract tracker-miner-fs update-manager update-manager-core update-notifier 
 update-notifier-common libgl1-mesa-dri policykit-1 profile-sync-daemon system-config-printer system-config-printer-common printer-driver-all 
 software-properties-common samba smbclient cifs-utils gnome-power-manager powermgmt-base libupower-glib3 ruby-power-assert plank 
-libplank-common libplank1 
+libplank-common libplank1 language-pack-gnome-sl language-pack-gnome-de language-pack-gnome-fr language-pack-gnome-it language-pack-gnome-es 
+language-pack-gnome-pt language-pack-gnome-ru

--- a/config/desktop/focal/environments/deepin/config_base/packages
+++ b/config/desktop/focal/environments/deepin/config_base/packages
@@ -15,4 +15,6 @@ p7zip-full policykit-desktop-privileges anacron doc-base foomatic-db-compressed-
 libatk-adaptor libgail-common libnotify-bin software-properties-gtk speech-dispatcher spice-vdagent zip orca bubblewrap dbus-x11 
 dictionaries-common hunspell-en-us tracker tracker-extract tracker-miner-fs update-manager update-manager-core update-notifier 
 update-notifier-common libgl1-mesa-dri policykit-1 profile-sync-daemon system-config-printer system-config-printer-common printer-driver-all 
-software-properties-common samba smbclient cifs-utils gnome-power-manager powermgmt-base libupower-glib3 ruby-power-assert gdebi
+software-properties-common samba smbclient cifs-utils gnome-power-manager powermgmt-base libupower-glib3 ruby-power-assert gdebi 
+language-pack-gnome-sl language-pack-gnome-de language-pack-gnome-fr language-pack-gnome-it language-pack-gnome-es language-pack-gnome-pt 
+language-pack-gnome-ru

--- a/config/desktop/focal/environments/gnome/config_base/packages
+++ b/config/desktop/focal/environments/gnome/config_base/packages
@@ -23,4 +23,6 @@ spice-vdagent tracker tracker-extract tracker-miner-fs update-manager update-man
 x11-session-utils x11-utils xdg-desktop-portal xdg-user-dirs xdg-user-dirs-gtk xinput xorg xorg-docs-core yaru-theme-gnome-shell yelp yelp-xsl 
 pulseaudio-module-bluetooth pavucontrol gnome-shell-extension-trash cups system-config-printer-gnome ubuntu-desktop-minimal ubuntu-session 
 ubuntu-settings gnome-terminal synaptic gnome-packagekit gnome-system-tools gnome-tweak-tool gedit gpaste gnome-tweaks gnome-system-log 
-gnome-power-manager gnome-screensaver gnome-screenshot gnome-todo gnome-photos gpaint lightdm lightdm-gtk-greeter lightdm-gtk-greeter-settings gdebi gnome-screenshot fonts-ubuntu network-manager-openvpn-gnome eject
+gnome-power-manager gnome-screensaver gnome-screenshot gnome-todo gnome-photos gpaint lightdm lightdm-gtk-greeter lightdm-gtk-greeter-settings 
+gdebi gnome-screenshot fonts-ubuntu network-manager-openvpn-gnome eject language-pack-gnome-sl language-pack-gnome-de language-pack-gnome-fr 
+language-pack-gnome-it language-pack-gnome-es language-pack-gnome-pt language-pack-gnome-ru

--- a/config/desktop/focal/environments/mate/config_base/packages
+++ b/config/desktop/focal/environments/mate/config_base/packages
@@ -13,5 +13,6 @@ libgck-1-0 p11-kit pasystray pavucontrol pulseaudio pavumeter bluez bluez-tools 
 libgl1-mesa-dri profile-sync-daemon gnome-orca numix-gtk-theme synaptic apt-xapian-index lightdm lightdm-gtk-greeter lightdm-settings 
 lightdm-gtk-greeter-settings numix-gtk-theme dbus-x11 dictionaries-common hunspell-en-us tracker tracker-extract tracker-miner-fs 
 update-manager update-manager-core update-notifier update-notifier-common policykit-1 profile-sync-daemon software-properties-common 
-system-config-printer system-config-printer-common printer-driver-all smbclient cifs-utils gdebi
+system-config-printer system-config-printer-common printer-driver-all smbclient cifs-utils gdebi language-pack-gnome-sl 
+language-pack-gnome-de language-pack-gnome-fr language-pack-gnome-it language-pack-gnome-es language-pack-gnome-pt language-pack-gnome-ru
 

--- a/config/desktop/focal/environments/xfce/config_base/packages
+++ b/config/desktop/focal/environments/xfce/config_base/packages
@@ -4,5 +4,6 @@ pasystray pavucontrol pulseaudio pavumeter bluez bluez-tools pulseaudio-module-b
 profile-sync-daemon gnome-orca numix-gtk-theme synaptic apt-xapian-index lightdm lightdm-gtk-greeter lightdm-settings lightdm-gtk-greeter-settings 
 numix-gtk-theme system-config-printer system-config-printer-common printer-driver-all dbus-x11 dbus-x11 dictionaries-common hunspell-en-us tracker 
 tracker-extract tracker-miner-fs update-manager update-manager-core update-notifier update-notifier-common policykit-1 profile-sync-daemon 
-software-properties-common samba smbclient cifs-utils xfce4-screenshooter gdebi
+software-properties-common samba smbclient cifs-utils xfce4-screenshooter gdebi language-pack-gnome-sl language-pack-gnome-de language-pack-gnome-fr 
+language-pack-gnome-it language-pack-gnome-es language-pack-gnome-pt language-pack-gnome-ru
 

--- a/config/desktop/sid/appgroups/chat
+++ b/config/desktop/sid/appgroups/chat
@@ -1,0 +1,1 @@
+../../buster/appgroups/chat

--- a/config/desktop/sid/appgroups/chat/packages
+++ b/config/desktop/sid/appgroups/chat/packages
@@ -1,1 +1,0 @@
-hexchat telegram-desktop

--- a/config/desktop/sid/appgroups/desktop_tools
+++ b/config/desktop/sid/appgroups/desktop_tools
@@ -1,0 +1,1 @@
+../../buster/appgroups/desktop_tools

--- a/config/desktop/sid/appgroups/desktop_tools/packages
+++ b/config/desktop/sid/appgroups/desktop_tools/packages
@@ -1,1 +1,0 @@
-bleachbit fbi kazam

--- a/config/desktop/sid/appgroups/editors
+++ b/config/desktop/sid/appgroups/editors
@@ -1,0 +1,1 @@
+../../buster/appgroups/editors

--- a/config/desktop/sid/appgroups/editors/packages
+++ b/config/desktop/sid/appgroups/editors/packages
@@ -1,1 +1,0 @@
-vim emacs geany code

--- a/config/desktop/sid/appgroups/internet
+++ b/config/desktop/sid/appgroups/internet
@@ -1,0 +1,1 @@
+../../buster/appgroups/internet

--- a/config/desktop/sid/appgroups/internet-tools/packages
+++ b/config/desktop/sid/appgroups/internet-tools/packages
@@ -1,1 +1,0 @@
-filezilla putty

--- a/config/desktop/sid/appgroups/internet/packages
+++ b/config/desktop/sid/appgroups/internet/packages
@@ -1,1 +1,0 @@
-qbittorrent transmission

--- a/config/desktop/sid/appgroups/multimedia
+++ b/config/desktop/sid/appgroups/multimedia
@@ -1,0 +1,1 @@
+../../buster/appgroups/multimedia

--- a/config/desktop/sid/appgroups/multimedia/packages
+++ b/config/desktop/sid/appgroups/multimedia/packages
@@ -1,1 +1,0 @@
-mpv pithos gimp

--- a/config/desktop/sid/appgroups/programming
+++ b/config/desktop/sid/appgroups/programming
@@ -1,0 +1,1 @@
+../../buster/appgroups/programming

--- a/config/desktop/sid/appgroups/programming/packages
+++ b/config/desktop/sid/appgroups/programming/packages
@@ -1,1 +1,0 @@
-build-essential clang meld

--- a/config/desktop/sid/appgroups/remote_desktop
+++ b/config/desktop/sid/appgroups/remote_desktop
@@ -1,0 +1,1 @@
+../../buster/appgroups/remote_desktop

--- a/config/desktop/sid/appgroups/remote_desktop/packages
+++ b/config/desktop/sid/appgroups/remote_desktop/packages
@@ -1,1 +1,0 @@
-remmina

--- a/config/targets-desktop-beta.conf
+++ b/config/targets-desktop-beta.conf
@@ -1,73 +1,73 @@
-#########################################################################################################################################################
-# board             branch          release     desktop|cli|minimal      stable|beta    create images  DE      DE config     Comma delimited app groups #
-#########################################################################################################################################################
+###########################################################################################################################################################
+# board             branch          release     desktop|cli|minimal      stable|beta    create images  DE        DE config     Comma delimited app groups #
+###########################################################################################################################################################
 
 #Friendlyelec FE-SOM-RK3399
-fe-som-rk3399       current         focal       desktop                  beta            yes           budgie  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+fe-som-rk3399       current         focal       desktop                  beta            yes           budgie    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
 fe-som-rk3399       current         focal       desktop                  beta            yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-fe-som-rk3399       current         focal       desktop                  beta            yes           gnome   config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-fe-som-rk3399       current         focal       desktop                  beta            yes           mate    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-fe-som-rk3399       current         focal       desktop                  beta            yes           xfce    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+fe-som-rk3399       current         focal       desktop                  beta            yes           gnome     config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+fe-som-rk3399       current         focal       desktop                  beta            yes           mate      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+fe-som-rk3399       current         focal       desktop                  beta            yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
 
 
 # Khadas Vim1
-kvim1               current         focal       desktop                  beta            yes           gnome   config_base
+kvim1               current         focal       desktop                  beta            yes           gnome     config_base
 
 
 # La frite
-lafrite             current         focal       desktop                  beta            yes           gnome   config_base
+lafrite             current         focal       desktop                  beta            yes           gnome     config_base
 
 
 # Lepotato
-lepotato            current         focal       desktop                  beta            yes           gnome   config_base
+lepotato            current         focal       desktop                  beta            yes           gnome     config_base
 
 
 # Olimex Lime A64
-lime-a64            current         focal       desktop                  beta            yes           gnome   config_base
+lime-a64            current         focal       desktop                  beta            yes           gnome     config_base
 
 
 # nanopct4
-nanopct4            current         focal       desktop                  beta            yes           budgie  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+nanopct4            current         focal       desktop                  beta            yes           budgie    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
 nanopct4            current         focal       desktop                  beta            yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-nanopct4            current         focal       desktop                  beta            yes           gnome   config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-nanopct4            current         focal       desktop                  beta            yes           mate    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-nanopct4            current         focal       desktop                  beta            yes           xfce    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+nanopct4            current         focal       desktop                  beta            yes           gnome     config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+nanopct4            current         focal       desktop                  beta            yes           mate      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+nanopct4            current         focal       desktop                  beta            yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
 
 
 # nanopik1plus
-nanopik1plus        current         focal       desktop                  beta            yes           gnome   config_base
+nanopik1plus        current         focal       desktop                  beta            yes           gnome     config_base
 
 
 # nanopik2-905
-nanopik2-s905       current         focal       desktop                  beta            yes           gnome   config_base
+nanopik2-s905       current         focal       desktop                  beta            yes           gnome     config_base
 
 
 # nanopim4
-nanopim4            current         focal       desktop                  beta            yes           gnome   config_base
+nanopim4            current         focal       desktop                  beta            yes           gnome     config_base
 
 
 # nanopim4v2
-nanopim4v2          current         focal       desktop                  beta            yes           gnome   config_base	
-nanopim4v2          current         focal       desktop                  beta            yes           xfce    config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+nanopim4v2          current         focal       desktop                  beta            yes           gnome     config_base	
+nanopim4v2          current         focal       desktop                  beta            yes           xfce      config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
 
 # Odroid C2
-odroidc2            current         focal       desktop                  beta            yes           gnome   config_base
-odroidc2            current         focal       desktop                  beta            yes           mate    config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+odroidc2            current         focal       desktop                  beta            yes           gnome     config_base
+odroidc2            current         focal       desktop                  beta            yes           mate      config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
 
 
 # Odroid N2
-odroidn2            current         focal       desktop                  beta            yes           budgie  config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+odroidn2            current         focal       desktop                  beta            yes           budgie    config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
 odroidn2            current         focal       desktop                  beta            yes           cinnamon  config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-odroidn2            current         focal       desktop                  beta            yes           gnome   config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-odroidn2            current         focal       desktop                  beta            yes           mate    config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-odroidn2            current         focal       desktop                  beta            yes           xfce    config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+odroidn2            current         focal       desktop                  beta            yes           gnome     config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+odroidn2            current         focal       desktop                  beta            yes           mate      config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+odroidn2            current         focal       desktop                  beta            yes           xfce      config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
 
 # Odroid C4
-odroidc4            current         focal       desktop                  beta            yes           budgie  config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+odroidc4            current         focal       desktop                  beta            yes           budgie    config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
 odroidc4            current         focal       desktop                  beta            yes           cinnamon  config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-odroidc4            current         focal       desktop                  beta            yes           gnome   config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-odroidc4            current         focal       desktop                  beta            yes           mate    config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-odroidc4            current         focal       desktop                  beta            yes           xfce    config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+odroidc4            current         focal       desktop                  beta            yes           gnome     config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+odroidc4            current         focal       desktop                  beta            yes           mate      config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+odroidc4            current         focal       desktop                  beta            yes           xfce      config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
 
 
 # Odroid HC4
@@ -75,86 +75,86 @@ odroidhc4           current         focal       desktop                  beta   
 
 
 # Odroid XU4
-odroidxu4           current         focal       desktop                  beta            yes           xfce    config_base
+odroidxu4           current         focal       desktop                  beta            yes           xfce      config_base
 
 
 # orangepi 3
-orangepi3           current         focal       desktop                  beta            yes           gnome   config_base
+orangepi3           current         focal       desktop                  beta            yes           gnome     config_base
 
 
 # Orangepi 4
-orangepi4           current         focal       desktop                  beta            yes           gnome   config_base
+orangepi4           current         focal       desktop                  beta            yes           gnome     config_base
 
 
 # orangepilite2
-orangepilite2       current         focal       desktop                  beta            yes           gnome   config_base
+orangepilite2       current         focal       desktop                  beta            yes           gnome     config_base
 
 
 # orangepipc2
-orangepipc2         current         focal       desktop                  beta            yes           gnome   config_base
+orangepipc2         current         focal       desktop                  beta            yes           gnome     config_base
 
 
 # Orangepi Prime
-orangepiprime       current         focal       desktop                  beta            yes           gnome   config_base
+orangepiprime       current         focal       desktop                  beta            yes           gnome     config_base
 
 
 # Orangepi Win
-orangepiwin         current         focal       desktop                  beta            yes           gnome   config_base
+orangepiwin         current         focal       desktop                  beta            yes           gnome     config_base
 
 
 # Pine64
-pine64              current         focal       desktop                  beta            yes           gnome   config_base
+pine64              current         focal       desktop                  beta            yes           gnome     config_base
 
 # Pinebook A64
-pinebook-a64        current         focal       desktop                  beta            yes           gnome   config_base
+pinebook-a64        current         focal       desktop                  beta            yes           gnome     config_base
 
 
 # Pinebook PRO
-pinebook-pro        current         focal       desktop                  beta            yes           budgie  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-pinebook-pro        current         focal       desktop                  beta            yes           cinnamon  config_base  3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop 
-pinebook-pro        current         focal       desktop                  beta            yes           gnome   config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-pinebook-pro        current         focal       desktop                  beta            yes           mate    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-pinebook-pro        current         focal       desktop                  beta            yes           xfce    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+pinebook-pro        current         focal       desktop                  beta            yes           budgie    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+pinebook-pro        current         focal       desktop                  beta            yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop 
+pinebook-pro        current         focal       desktop                  beta            yes           gnome     config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+pinebook-pro        current         focal       desktop                  beta            yes           mate      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+pinebook-pro        current         focal       desktop                  beta            yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
 
 
 # Pine H64
-pineh64             current         focal       desktop                  beta            yes           gnome   config_base
+pineh64             current         focal       desktop                  beta            yes           gnome     config_base
 
 
 # Pine H64 B
-pineh64-b           current         focal       desktop                  beta            yes           gnome   config_base
+pineh64-b           current         focal       desktop                  beta            yes           gnome     config_base
 
 
 # Renegade
-renegade            current         focal       desktop                  beta            yes           gnome   config_base
+renegade            current         focal       desktop                  beta            yes           gnome     config_base
 
 
 # Rockpi 4a
-rockpi-4a           current         focal       desktop                  beta            yes           gnome   config_base
+rockpi-4a           current         focal       desktop                  beta            yes           gnome     config_base
 
 # Rockpi 4b
-rockpi-4b           current         focal       desktop                  beta            yes           gnome   config_base
+rockpi-4b           current         focal       desktop                  beta            yes           gnome     config_base
 
 
 # Rockpi 4c
-rockpi-4c           current         focal       desktop                  beta            yes           gnome   config_base
+rockpi-4c           current         focal       desktop                  beta            yes           gnome     config_base
 
 
 # Rock64pro
 
-rockpro64           current         focal       desktop                  beta            yes           budgie  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+rockpro64           current         focal       desktop                  beta            yes           budgie    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
 rockpro64           current         focal       desktop                  beta            yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-rockpro64           current         focal       desktop                  beta            yes           gnome   config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-rockpro64           current         focal       desktop                  beta            yes           mate    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-rockpro64           current         focal       desktop                  beta            yes           xfce    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+rockpro64           current         focal       desktop                  beta            yes           gnome     config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+rockpro64           current         focal       desktop                  beta            yes           mate      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+rockpro64           current         focal       desktop                  beta            yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
 
 # Teres A64
-teres-a64           current         focal       desktop                  beta            yes           gnome   config_base
+teres-a64           current         focal       desktop                  beta            yes           gnome     config_base
 
 
 # Tinkerboard
-tinkerboard         current         focal       desktop                  beta            yes           xfce    config_base
+tinkerboard         current         focal       desktop                  beta            yes           xfce      config_base
 
 
 # tritium-h5        
-tritium-h5          current         focal       desktop                  beta            yes           gnome   config_base
+tritium-h5          current         focal       desktop                  beta            yes           gnome     config_base

--- a/config/targets-desktop-beta.conf
+++ b/config/targets-desktop-beta.conf
@@ -3,11 +3,11 @@
 ###########################################################################################################################################################
 
 #Friendlyelec FE-SOM-RK3399
-fe-som-rk3399       current         focal       desktop                  beta            yes           budgie    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-fe-som-rk3399       current         focal       desktop                  beta            yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-fe-som-rk3399       current         focal       desktop                  beta            yes           gnome     config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-fe-som-rk3399       current         focal       desktop                  beta            yes           mate      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-fe-som-rk3399       current         focal       desktop                  beta            yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+fe-som-rk3399       current         focal       desktop                  beta            yes           budgie    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+fe-som-rk3399       current         focal       desktop                  beta            yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+fe-som-rk3399       current         focal       desktop                  beta            yes           gnome     config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+fe-som-rk3399       current         focal       desktop                  beta            yes           mate      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+fe-som-rk3399       current         focal       desktop                  beta            yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 
 # Khadas Vim1
@@ -27,11 +27,11 @@ lime-a64            current         focal       desktop                  beta   
 
 
 # nanopct4
-nanopct4            current         focal       desktop                  beta            yes           budgie    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-nanopct4            current         focal       desktop                  beta            yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-nanopct4            current         focal       desktop                  beta            yes           gnome     config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-nanopct4            current         focal       desktop                  beta            yes           mate      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-nanopct4            current         focal       desktop                  beta            yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+nanopct4            current         focal       desktop                  beta            yes           budgie    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+nanopct4            current         focal       desktop                  beta            yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+nanopct4            current         focal       desktop                  beta            yes           gnome     config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+nanopct4            current         focal       desktop                  beta            yes           mate      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+nanopct4            current         focal       desktop                  beta            yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 
 # nanopik1plus
@@ -48,26 +48,26 @@ nanopim4            current         focal       desktop                  beta   
 
 # nanopim4v2
 nanopim4v2          current         focal       desktop                  beta            yes           gnome     config_base	
-nanopim4v2          current         focal       desktop                  beta            yes           xfce      config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+nanopim4v2          current         focal       desktop                  beta            yes           xfce      config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 # Odroid C2
 odroidc2            current         focal       desktop                  beta            yes           gnome     config_base
-odroidc2            current         focal       desktop                  beta            yes           mate      config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+odroidc2            current         focal       desktop                  beta            yes           mate      config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 
 # Odroid N2
-odroidn2            current         focal       desktop                  beta            yes           budgie    config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-odroidn2            current         focal       desktop                  beta            yes           cinnamon  config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-odroidn2            current         focal       desktop                  beta            yes           gnome     config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-odroidn2            current         focal       desktop                  beta            yes           mate      config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-odroidn2            current         focal       desktop                  beta            yes           xfce      config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+odroidn2            current         focal       desktop                  beta            yes           budgie    config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+odroidn2            current         focal       desktop                  beta            yes           cinnamon  config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+odroidn2            current         focal       desktop                  beta            yes           gnome     config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+odroidn2            current         focal       desktop                  beta            yes           mate      config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+odroidn2            current         focal       desktop                  beta            yes           xfce      config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 # Odroid C4
-odroidc4            current         focal       desktop                  beta            yes           budgie    config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-odroidc4            current         focal       desktop                  beta            yes           cinnamon  config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-odroidc4            current         focal       desktop                  beta            yes           gnome     config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-odroidc4            current         focal       desktop                  beta            yes           mate      config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-odroidc4            current         focal       desktop                  beta            yes           xfce      config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+odroidc4            current         focal       desktop                  beta            yes           budgie    config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+odroidc4            current         focal       desktop                  beta            yes           cinnamon  config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+odroidc4            current         focal       desktop                  beta            yes           gnome     config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+odroidc4            current         focal       desktop                  beta            yes           mate      config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+odroidc4            current         focal       desktop                  beta            yes           xfce      config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 
 # Odroid HC4
@@ -110,11 +110,11 @@ pinebook-a64        current         focal       desktop                  beta   
 
 
 # Pinebook PRO
-pinebook-pro        current         focal       desktop                  beta            yes           budgie    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-pinebook-pro        current         focal       desktop                  beta            yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop 
-pinebook-pro        current         focal       desktop                  beta            yes           gnome     config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-pinebook-pro        current         focal       desktop                  beta            yes           mate      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-pinebook-pro        current         focal       desktop                  beta            yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+pinebook-pro        current         focal       desktop                  beta            yes           budgie    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+pinebook-pro        current         focal       desktop                  beta            yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop 
+pinebook-pro        current         focal       desktop                  beta            yes           gnome     config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+pinebook-pro        current         focal       desktop                  beta            yes           mate      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+pinebook-pro        current         focal       desktop                  beta            yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 
 # Pine H64
@@ -142,11 +142,11 @@ rockpi-4c           current         focal       desktop                  beta   
 
 # Rock64pro
 
-rockpro64           current         focal       desktop                  beta            yes           budgie    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-rockpro64           current         focal       desktop                  beta            yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-rockpro64           current         focal       desktop                  beta            yes           gnome     config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-rockpro64           current         focal       desktop                  beta            yes           mate      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-rockpro64           current         focal       desktop                  beta            yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+rockpro64           current         focal       desktop                  beta            yes           budgie    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+rockpro64           current         focal       desktop                  beta            yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+rockpro64           current         focal       desktop                  beta            yes           gnome     config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+rockpro64           current         focal       desktop                  beta            yes           mate      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+rockpro64           current         focal       desktop                  beta            yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 # Teres A64
 teres-a64           current         focal       desktop                  beta            yes           gnome     config_base

--- a/config/targets.conf
+++ b/config/targets.conf
@@ -116,18 +116,18 @@ espressobin         dev             hirsute     cli                      stable 
 firefly-rk3399      current         buster      cli                      stable         yes
 firefly-rk3399      legacy          buster      desktop                  stable         yes            xfce    config_base   browsers,chat
 firefly-rk3399      current         focal       cli                      stable         yes
-#firefly-rk3399       current         focal       desktop                  stable         yes           budgie  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-#firefly-rk3399       current         focal       desktop                  stable         yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-firefly-rk3399       current         focal       desktop                  stable         yes           gnome   config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-#firefly-rk3399       current         focal       desktop                  stable         yes           mate    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-firefly-rk3399       current         focal       desktop                  stable         yes           xfce    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+#firefly-rk3399       current         focal       desktop                  stable         yes           budgie  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+#firefly-rk3399       current         focal       desktop                  stable         yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+firefly-rk3399       current         focal       desktop                  stable         yes           gnome   config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+#firefly-rk3399       current         focal       desktop                  stable         yes           mate    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+firefly-rk3399       current         focal       desktop                  stable         yes           xfce    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 #Friendlyelec FE-SOM-RK3399
-#fe-som-rk3399       current         focal       desktop                  stable         yes           budgie  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-#fe-som-rk3399       current         focal       desktop                  stable         yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-fe-som-rk3399       current         focal       desktop                  stable         yes           gnome   config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-#fe-som-rk3399       current         focal       desktop                  stable         yes           mate    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-fe-som-rk3399       current         focal       desktop                  stable         yes           xfce    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+#fe-som-rk3399       current         focal       desktop                  stable         yes           budgie  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+#fe-som-rk3399       current         focal       desktop                  stable         yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+fe-som-rk3399       current         focal       desktop                  stable         yes           gnome   config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+#fe-som-rk3399       current         focal       desktop                  stable         yes           mate    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+fe-som-rk3399       current         focal       desktop                  stable         yes           xfce    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 # Khadas Vim1
 kvim1               current         buster      cli                      stable         yes
@@ -213,10 +213,10 @@ nanopct4            current         buster      cli                      stable 
 nanopct4            current         buster      desktop                  stable         yes            xfce    config_base   browsers,chat
 nanopct4            current         focal       cli                      stable         yes
 nanopct4            current         focal       desktop                  stable         yes           xfce      config_base   browsers,chat
-nanopct4            current         focal       desktop                  stable         yes           budgie    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-nanopct4            current         focal       desktop                  stable         yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-nanopct4            current         focal       desktop                  stable         yes           gnome     config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-nanopct4            current         focal       desktop                  stable         yes           mate      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+nanopct4            current         focal       desktop                  stable         yes           budgie    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+nanopct4            current         focal       desktop                  stable         yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+nanopct4            current         focal       desktop                  stable         yes           gnome     config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+nanopct4            current         focal       desktop                  stable         yes           mate      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 
 # nanopi-r1
@@ -291,11 +291,11 @@ nanopim4v2          current         buster      cli                      stable 
 nanopim4v2          current         buster      desktop                  stable         yes            xfce    config_base   browsers,chat
 nanopim4v2          current         focal       cli                      stable         yes
 nanopim4v2          current         focal       desktop                  stable         yes            xfce    config_base   browsers,chat
-nanopim4v2          current         focal       desktop                  stable         yes           budgie  config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-nanopim4v2          current         focal       desktop                  stable         yes           cinnamon  config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-nanopim4v2          current         focal       desktop                  stable         yes           gnome   config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-nanopim4v2          current         focal       desktop                  stable         yes           mate    config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-nanopim4v2          current         focal       desktop                  stable         yes           xfce    config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+nanopim4v2          current         focal       desktop                  stable         yes           budgie  config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+nanopim4v2          current         focal       desktop                  stable         yes           cinnamon  config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+nanopim4v2          current         focal       desktop                  stable         yes           gnome   config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+nanopim4v2          current         focal       desktop                  stable         yes           mate    config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+nanopim4v2          current         focal       desktop                  stable         yes           xfce    config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 # nanopineo
 nanopineo           current         buster      cli                      stable         yes
@@ -358,21 +358,21 @@ odroidn2            current         buster      cli                      stable 
 odroidn2            current         buster      desktop                  stable         yes            xfce    config_base   browsers,chat
 odroidn2            current         focal       cli                      stable         yes
 odroidn2            dev             hirsute     cli                      stable         no
-odroidn2            current         focal       desktop                  stable         yes           budgie  config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-odroidn2            current         focal       desktop                  stable         yes           cinnamon  config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-odroidn2            current         focal       desktop                  stable         yes           gnome   config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-odroidn2            current         focal       desktop                  stable         yes           mate    config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-odroidn2            current         focal       desktop                  stable         yes           xfce    config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+odroidn2            current         focal       desktop                  stable         yes           budgie  config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+odroidn2            current         focal       desktop                  stable         yes           cinnamon  config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+odroidn2            current         focal       desktop                  stable         yes           gnome   config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+odroidn2            current         focal       desktop                  stable         yes           mate    config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+odroidn2            current         focal       desktop                  stable         yes           xfce    config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 # Odroid C4
 odroidc4            legacy          focal       desktop                  stable         yes           xfce    config_base   browsers,chat
 odroidc4            legacy          buster      cli                      stable         yes
 odroidc4            current         buster      cli                      stable         yes
 odroidc4            current         focal       cli                      stable         yes
-#odroidc4            current         focal       desktop                  stable         yes           budgie  config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-#odroidc4            current         focal       desktop                  stable         yes           cinnamon  config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-#odroidc4            current         focal       desktop                  stable         yes           gnome   config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-#odroidc4            current         focal       desktop                  stable         yes           mate    config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-odroidc4            current         focal       desktop                  stable         yes           xfce    config_base   browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+#odroidc4            current         focal       desktop                  stable         yes           budgie  config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+#odroidc4            current         focal       desktop                  stable         yes           cinnamon  config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+#odroidc4            current         focal       desktop                  stable         yes           gnome   config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+#odroidc4            current         focal       desktop                  stable         yes           mate    config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+odroidc4            current         focal       desktop                  stable         yes           xfce    config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 # Odroid HC4
 odroidhc4           legacy          focal       cli                      stable         yes
@@ -411,11 +411,11 @@ orangepi4           legacy          buster      desktop                  stable 
 orangepi4           current         buster      cli                      stable         yes
 orangepi4           current         focal       cli                      stable         yes
 orangepi4           current         focal       desktop                  stable         yes           xfce      config_base   browsers,chat
-orangepi4           current         focal       desktop                  stable         yes           budgie    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-orangepi4           current         focal       desktop                  stable         yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-orangepi4           current         focal       desktop                  stable         yes           gnome     config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-orangepi4           current         focal       desktop                  stable         yes           mate      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-orangepi4           current         focal       desktop                  stable         yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+orangepi4           current         focal       desktop                  stable         yes           budgie    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+orangepi4           current         focal       desktop                  stable         yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+orangepi4           current         focal       desktop                  stable         yes           gnome     config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+orangepi4           current         focal       desktop                  stable         yes           mate      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+orangepi4           current         focal       desktop                  stable         yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 
 # orangepi-r1
@@ -493,11 +493,11 @@ orangepiplus2e      current         focal       desktop                  stable 
 orangepiprime       current         buster      cli                      stable         yes
 orangepiprime       current         buster      desktop                  stable         yes            xfce    config_base   browsers,chat
 orangepiprime       current         focal       cli                      stable         yes
-#orangepiprime       current         focal       desktop                  stable         yes           budgie  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-#orangepiprime       current         focal       desktop                  stable         yes           cinnamon  config_base  3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-orangepiprime       current         focal       desktop                  stable         yes           gnome   config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-#orangepiprime       current         focal       desktop                  stable         yes           mate    config_base  3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-orangepiprime       current         focal       desktop                  stable         yes           xfce    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+#orangepiprime       current         focal       desktop                  stable         yes           budgie  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+#orangepiprime       current         focal       desktop                  stable         yes           cinnamon  config_base  3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+orangepiprime       current         focal       desktop                  stable         yes           gnome   config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+#orangepiprime       current         focal       desktop                  stable         yes           mate    config_base  3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+orangepiprime       current         focal       desktop                  stable         yes           xfce    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 # Orangepi Win
 orangepiwin         current         buster      cli                      stable         yes
@@ -562,11 +562,11 @@ pinebook-pro        legacy          buster      desktop                  stable 
 pinebook-pro        legacy          focal       desktop                  stable         yes            xfce    config_base   browsers,chat
 pinebook-pro        current         buster      desktop                  stable         yes            xfce    config_base   browsers,chat
 pinebook-pro        current         focal       desktop                  stable         yes            xfce    config_base   browsers,chat
-#pinebook-pro        current         focal       desktop                  stable         yes           budgie  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-#pinebook-pro        current         focal       desktop                  stable         yes           cinnamon  config_base  3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop 
-pinebook-pro        current         focal       desktop                  stable         yes           gnome   config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-pinebook-pro        current         focal       desktop                  stable         yes           mate    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-pinebook-pro        current         focal       desktop                  stable         yes           xfce    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+#pinebook-pro        current         focal       desktop                  stable         yes           budgie  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+#pinebook-pro        current         focal       desktop                  stable         yes           cinnamon  config_base  3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop 
+pinebook-pro        current         focal       desktop                  stable         yes           gnome   config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+pinebook-pro        current         focal       desktop                  stable         yes           mate    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+pinebook-pro        current         focal       desktop                  stable         yes           xfce    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 # Pine H64
 pineh64             current         buster      cli                      stable         yes
@@ -649,11 +649,11 @@ rockpro64           legacy          buster      desktop                  stable 
 rockpro64           current         buster      cli                      stable         yes
 rockpro64           current         buster      desktop                  stable         yes            xfce    config_base   browsers,chat
 rockpro64           current         focal       cli                      stable         yes
-#rockpro64           current         focal       desktop                  stable         yes           budgie  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-#rockpro64           current         focal       desktop                  stable         yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-#ockpro64           current         focal       desktop                  stable         yes           gnome   config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-#rockpro64           current         focal       desktop                  stable         yes           mate    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
-rockpro64           current         focal       desktop                  stable         yes           xfce    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,internet-tools,multimedia,office,programming,remote_desktop
+#rockpro64           current         focal       desktop                  stable         yes           budgie  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+#rockpro64           current         focal       desktop                  stable         yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+#ockpro64           current         focal       desktop                  stable         yes           gnome   config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+#rockpro64           current         focal       desktop                  stable         yes           mate    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+rockpro64           current         focal       desktop                  stable         yes           xfce    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 # Teres A64
 teres-a64           current         buster      desktop                  stable         yes            xfce    config_base   browsers,chat

--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -21,7 +21,7 @@ USEALLCORES=yes # Use all CPU cores for compiling
 [[ -z $EXIT_PATCHING_ERROR ]] && EXIT_PATCHING_ERROR="" # exit patching if failed
 [[ -z $HOST ]] && HOST="$BOARD" # set hostname to the board
 cd "${SRC}" || exit
-ROOTFSCACHE_VERSION=3
+ROOTFSCACHE_VERSION=4
 CHROOT_CACHE_VERSION=7
 BUILD_REPOSITORY_URL=$(improved_git remote get-url $(improved_git remote 2>/dev/null | grep origin) 2>/dev/null)
 BUILD_REPOSITORY_COMMIT=$(improved_git describe --match=d_e_a_d_b_e_e_f --always --dirty 2>/dev/null)


### PR DESCRIPTION
# Description

- merging app group internet-tools into internet for Debian targets. On Ubuntu it was already done
- merging language group into desktop base packages sets
- link application groups on Debian SID
- cosmetic cleaning of build targets
- bump with rootfs version to force packages recreation

# How Has This Been Tested?

- [x] Rebuild all stable cache on aarch build host
- [x] ... on Hirsute x86 build host

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
