### PR TITLE
Bugfix for ZSH on upgrades

### DIFF
--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -596,18 +596,6 @@ compile_armbian-zsh()
 	exit 0
 	END
 
-	# set up post remove script
-	cat <<-END > "${tmp_dir}/${armbian_zsh_dir}"/DEBIAN/postrm
-	#!/bin/sh
-	# change shell back to bash for future users
-	BASHLOCATION=\$(grep /bash\$ /etc/shells | tail -1)
-	sed -i "s|^SHELL=.*|SHELL=\${BASHLOCATION}|" /etc/default/useradd
-	sed -i "s|^DSHELL=.*|DSHELL=\${BASHLOCATION}|" /etc/adduser.conf
-	# change to BASH shell for root and all normal users
-	awk -F'[/:]' '{if (\$3 >= 1000 && \$3 != 65534 || \$3 == 0) print \$1}' /etc/passwd | xargs -L1 chsh -s \$(grep /bash\$ /etc/shells | tail -1)
-	exit 0
-	END
-
 	cp -R "${SRC}"/cache/sources/oh-my-zsh "${tmp_dir}/${armbian_zsh_dir}"/etc/
 	cp -R "${SRC}"/cache/sources/evalcache "${tmp_dir}/${armbian_zsh_dir}"/etc/oh-my-zsh/plugins
 	cp "${tmp_dir}/${armbian_zsh_dir}"/etc/oh-my-zsh/templates/zshrc.zsh-template "${tmp_dir}/${armbian_zsh_dir}"/etc/skel/.zshrc


### PR DESCRIPTION
# Description

Move changing to BASH to armbian-config. This prevents unwanted automated switching back to bash on upgrade
Jira reference number [AR-666]

# How Has This Been Tested?

- [x] Toggle on next nightly build
- [x] Check if survives next upgrades

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-666]: https://armbian.atlassian.net/browse/AR-666