### PR TITLE
Fix issue with /boot on fat filesystems

### DIFF
--- a/patch/misc/general-packaging-5.10.y.patch
+++ b/patch/misc/general-packaging-5.10.y.patch
@@ -196,7 +196,7 @@ index 1b11f8993..c21d931ea 100755
 +##
 +sed -e "s/exit 0//g" -i $tmpdir/DEBIAN/postinst
 +cat >> $tmpdir/DEBIAN/postinst <<EOT
-+ln -sf $(basename $installed_image_path) /boot/$image_name 2> /dev/null || mv /$installed_image_path /boot/$image_name
++ln -sf $(basename $installed_image_path) /boot/$image_name 2> /dev/null || cp /$installed_image_path /boot/$image_name
 +touch /boot/.next
 +exit 0
 +EOT


### PR DESCRIPTION
The generated debian postinst file for the linux-image...deb currently contains the following code:

```
ln -sf vmlinuz-5.10.21-meson64 /boot/Image 2> /dev/null || mv /boot/vmlinuz-5.10.21-meson64 /boot/Image
touch /boot/.next

mkimage -A arm64 -O linux -T kernel -C none -a 0x1080000 -e 0x1080000 -n "Linux" -d /boot/vmlinuz-5.10.21-meson64 /boot/uImage  > /dev/null 2>&1
```

This causes the install of the linux-image...deb to fail if /boot is on a fat filesystem, as the "mv /boot/vmlinuz-5.10.21-meson64 /boot/Image" leaves you with only the 'Image' file (unlike the ext4 case where the link results in both a vmlinux... and Image objects)
When the following mkimage command runs it is looking for the vmlinuz... file which no longer exists in the fat filesystem case.

This could be solve by either changing the mkimage line or the mv line.  I chose to fix the mv line as this leaves the objects in the boot directory consistent between an ext4 filesystem and a fat filesystem (even though it takes up double the storage). 
