### PR TITLE
Adjust compiler fixes that it builds on more modern build host

### DIFF
--- a/patch/kernel/mvebu64-legacy/0001-fixing-dtc-error.patch
+++ b/patch/kernel/mvebu64-legacy/0001-fixing-dtc-error.patch
@@ -1,0 +1,26 @@
+From 3a3274fe09d70fd25607eac945f5c17bd48d4e7b Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor.pecovnik@gmail.com>
+Date: Mon, 8 Mar 2021 06:54:40 +0000
+Subject: [PATCH] fixing dtc error
+
+Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
+---
+ scripts/dtc/dtc-lexer.lex.c_shipped | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/scripts/dtc/dtc-lexer.lex.c_shipped b/scripts/dtc/dtc-lexer.lex.c_shipped
+index 011bb963..c3b63163 100644
+--- a/scripts/dtc/dtc-lexer.lex.c_shipped
++++ b/scripts/dtc/dtc-lexer.lex.c_shipped
+@@ -631,7 +631,7 @@ char *yytext;
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+ 
+-YYLTYPE yylloc;
++extern YYLTYPE yylloc;
+ extern bool treesource_error;
+ 
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/kernel/rk322x-legacy/0001-fixing-dtc-error.patch
+++ b/patch/kernel/rk322x-legacy/0001-fixing-dtc-error.patch
@@ -1,0 +1,26 @@
+From 3a3274fe09d70fd25607eac945f5c17bd48d4e7b Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor.pecovnik@gmail.com>
+Date: Mon, 8 Mar 2021 06:54:40 +0000
+Subject: [PATCH] fixing dtc error
+
+Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
+---
+ scripts/dtc/dtc-lexer.lex.c_shipped | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/scripts/dtc/dtc-lexer.lex.c_shipped b/scripts/dtc/dtc-lexer.lex.c_shipped
+index 011bb963..c3b63163 100644
+--- a/scripts/dtc/dtc-lexer.lex.c_shipped
++++ b/scripts/dtc/dtc-lexer.lex.c_shipped
+@@ -631,7 +631,7 @@ char *yytext;
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+ 
+-YYLTYPE yylloc;
++extern YYLTYPE yylloc;
+ extern bool treesource_error;
+ 
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/kernel/rk3399-legacy/0001-fixing-dtc-error.patch
+++ b/patch/kernel/rk3399-legacy/0001-fixing-dtc-error.patch
@@ -1,0 +1,26 @@
+From 3a3274fe09d70fd25607eac945f5c17bd48d4e7b Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor.pecovnik@gmail.com>
+Date: Mon, 8 Mar 2021 06:54:40 +0000
+Subject: [PATCH] fixing dtc error
+
+Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
+---
+ scripts/dtc/dtc-lexer.lex.c_shipped | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/scripts/dtc/dtc-lexer.lex.c_shipped b/scripts/dtc/dtc-lexer.lex.c_shipped
+index 011bb963..c3b63163 100644
+--- a/scripts/dtc/dtc-lexer.lex.c_shipped
++++ b/scripts/dtc/dtc-lexer.lex.c_shipped
+@@ -631,7 +631,7 @@ char *yytext;
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+ 
+-YYLTYPE yylloc;
++extern YYLTYPE yylloc;
+ extern bool treesource_error;
+ 
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/kernel/rockchip-legacy/0001-fixing-dtc-error.patch
+++ b/patch/kernel/rockchip-legacy/0001-fixing-dtc-error.patch
@@ -1,0 +1,26 @@
+From 3a3274fe09d70fd25607eac945f5c17bd48d4e7b Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor.pecovnik@gmail.com>
+Date: Mon, 8 Mar 2021 06:54:40 +0000
+Subject: [PATCH] fixing dtc error
+
+Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
+---
+ scripts/dtc/dtc-lexer.lex.c_shipped | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/scripts/dtc/dtc-lexer.lex.c_shipped b/scripts/dtc/dtc-lexer.lex.c_shipped
+index 011bb963..c3b63163 100644
+--- a/scripts/dtc/dtc-lexer.lex.c_shipped
++++ b/scripts/dtc/dtc-lexer.lex.c_shipped
+@@ -631,7 +631,7 @@ char *yytext;
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+ 
+-YYLTYPE yylloc;
++extern YYLTYPE yylloc;
+ extern bool treesource_error;
+ 
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/kernel/rockchip64-legacy/0001-fixing-dtc-error.patch
+++ b/patch/kernel/rockchip64-legacy/0001-fixing-dtc-error.patch
@@ -1,0 +1,26 @@
+From 3a3274fe09d70fd25607eac945f5c17bd48d4e7b Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor.pecovnik@gmail.com>
+Date: Mon, 8 Mar 2021 06:54:40 +0000
+Subject: [PATCH] fixing dtc error
+
+Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
+---
+ scripts/dtc/dtc-lexer.lex.c_shipped | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/scripts/dtc/dtc-lexer.lex.c_shipped b/scripts/dtc/dtc-lexer.lex.c_shipped
+index 011bb963..c3b63163 100644
+--- a/scripts/dtc/dtc-lexer.lex.c_shipped
++++ b/scripts/dtc/dtc-lexer.lex.c_shipped
+@@ -631,7 +631,7 @@ char *yytext;
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+ 
+-YYLTYPE yylloc;
++extern YYLTYPE yylloc;
+ extern bool treesource_error;
+ 
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/u-boot/u-boot-clearfog/0001-fixing-dtc-error.patch
+++ b/patch/u-boot/u-boot-clearfog/0001-fixing-dtc-error.patch
@@ -1,0 +1,26 @@
+From a842a521b0532213286532542c8a7c98f2f2addf Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor.pecovnik@gmail.com>
+Date: Mon, 8 Mar 2021 09:38:23 +0000
+Subject: [PATCH] ;mmc;u-boot-spl-mmc.kwb:u-boot.emmc
+
+Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
+---
+ scripts/dtc/dtc-lexer.lex.c_shipped | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/scripts/dtc/dtc-lexer.lex.c_shipped b/scripts/dtc/dtc-lexer.lex.c_shipped
+index 011bb96..c3b6316 100644
+--- a/scripts/dtc/dtc-lexer.lex.c_shipped
++++ b/scripts/dtc/dtc-lexer.lex.c_shipped
+@@ -631,7 +631,7 @@ char *yytext;
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+ 
+-YYLTYPE yylloc;
++extern YYLTYPE yylloc;
+ extern bool treesource_error;
+ 
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/u-boot/u-boot-helios4/0001-fixing-dtc-error.patch
+++ b/patch/u-boot/u-boot-helios4/0001-fixing-dtc-error.patch
@@ -1,0 +1,26 @@
+From 97bca7b4cec321501a710cb0ce8b598a9e746a19 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor.pecovnik@gmail.com>
+Date: Mon, 8 Mar 2021 13:12:41 +0000
+Subject: [PATCH] ;spi;u-boot-spl.kwb:u-boot.flash
+
+Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
+---
+ scripts/dtc/dtc-lexer.l | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/scripts/dtc/dtc-lexer.l b/scripts/dtc/dtc-lexer.l
+index fd825eb..f57c9a7 100644
+--- a/scripts/dtc/dtc-lexer.l
++++ b/scripts/dtc/dtc-lexer.l
+@@ -38,7 +38,7 @@ LINECOMMENT	"//".*\n
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+ 
+-YYLTYPE yylloc;
++extern YYLTYPE yylloc;
+ extern bool treesource_error;
+ 
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/u-boot/u-boot-rockchip/board_miqi/0001-fixing-dtc-error.patch
+++ b/patch/u-boot/u-boot-rockchip/board_miqi/0001-fixing-dtc-error.patch
@@ -1,0 +1,50 @@
+From 984f669554fafda41bc906cac6c27b81ee70a8e9 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor.pecovnik@gmail.com>
+Date: Mon, 8 Mar 2021 17:19:49 +0000
+Subject: [PATCH] Patching something
+
+Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
+---
+ arch/arm/dts/Makefile               | 5 -----
+ scripts/dtc/dtc-lexer.lex.c_shipped | 2 +-
+ 2 files changed, 1 insertion(+), 6 deletions(-)
+
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index 6db64f9..7ec176d 100644
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -28,7 +28,6 @@ dtb-$(CONFIG_EXYNOS5) += exynos5250-arndale.dtb \
+ 	exynos5422-odroidxu3.dtb
+ dtb-$(CONFIG_EXYNOS7420) += exynos7420-espresso7420.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += \
+-	rk3036-sdk.dtb \
+ 	rk3188-radxarock.dtb \
+ 	rk3288-evb.dtb \
+ 	rk3288-fennec.dtb \
+@@ -43,10 +42,6 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += \
+ 	rk3288-veyron-minnie.dtb \
+ 	rk3288-vyasa.dtb \
+ 	rk3328-evb.dtb \
+-	rk3368-lion.dtb \
+-	rk3368-sheep.dtb \
+-	rk3368-geekbox.dtb \
+-	rk3368-px5-evb.dtb \
+ 	rk3399-evb.dtb \
+ 	rk3399-firefly.dtb \
+ 	rk3399-puma-ddr1333.dtb \
+diff --git a/scripts/dtc/dtc-lexer.lex.c_shipped b/scripts/dtc/dtc-lexer.lex.c_shipped
+index 3934d86..3b43158 100644
+--- a/scripts/dtc/dtc-lexer.lex.c_shipped
++++ b/scripts/dtc/dtc-lexer.lex.c_shipped
+@@ -639,7 +639,7 @@ char *yytext;
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+ 
+-YYLTYPE yylloc;
++extern YYLTYPE yylloc;
+ extern bool treesource_error;
+ 
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/u-boot/u-boot-rockchip/board_tinkerboard/0001-fixing-dtc-error.patch
+++ b/patch/u-boot/u-boot-rockchip/board_tinkerboard/0001-fixing-dtc-error.patch
@@ -1,0 +1,26 @@
+From 55c00b50794b6cb5c47489b1526d971619d75355 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor.pecovnik@gmail.com>
+Date: Mon, 8 Mar 2021 17:05:15 +0000
+Subject: [PATCH] Patching something
+
+Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
+---
+ scripts/dtc/dtc-lexer.l | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/scripts/dtc/dtc-lexer.l b/scripts/dtc/dtc-lexer.l
+index fd825eb..f57c9a7 100644
+--- a/scripts/dtc/dtc-lexer.l
++++ b/scripts/dtc/dtc-lexer.l
+@@ -38,7 +38,7 @@ LINECOMMENT	"//".*\n
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+ 
+-YYLTYPE yylloc;
++extern YYLTYPE yylloc;
+ extern bool treesource_error;
+ 
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+


### PR DESCRIPTION
# Description

We are building recent images on Ubuntu Hirsute since only there we can build Bullseye / Hirsute images ... due to qemu bug.

# How Has This Been Tested?

- [x] Build u-boots on Focal host
- [x] Build u-boots on Hirsute host

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
