### PR TITLE
Fix armbian-hardware-optimization logrotate editing

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
+++ b/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
@@ -51,7 +51,7 @@ prepare_board() {
 
 	CheckDevice=$(for i in /var/log /var / ; do findmnt -n -o SOURCE $i && break ; done)
 	# adjust logrotate configs
-	if [[ "${CheckDevice}" == "/dev/zram0" || "${CheckDevice}" == "armbian-ramlog" ]]; then
+	if [[ "${CheckDevice}" == *"/dev/zram"* || "${CheckDevice}" == "armbian-ramlog" ]]; then
 		for ConfigFile in /etc/logrotate.d/* ; do sed -i -e "s/\/var\/log\//\/var\/log.hdd\//g" "${ConfigFile}"; done
 		sed -i "s/\/var\/log\//\/var\/log.hdd\//g" /etc/logrotate.conf
 	else


### PR DESCRIPTION
# Description

Fixes #2692, editing of logrotate configs when ramlog is enabled and /var/log is mounted on zram device other than /dev/zram0.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Tested on a live system with reboot

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
