### PR TITLE
Fix Motd disk temperature

### DIFF
--- a/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
+++ b/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
@@ -158,7 +158,7 @@ function storage_info() {
 		storage_total=$(awk '/\// {print $(NF-4)}' <<<${StorageInfo})
 		if [[ -n "$(command -v smartctl)" ]]; then
 			DISK="${STORAGE::-1}"
-			storage_temp+=$(sudo smartctl -A $DISK 2> /dev/null | grep -i temperature | awk '{print $(NF-2)}')
+			storage_temp+=$(smartctl -l scttempsts $DISK 2> /dev/null | grep -i 'Current Temperature:' | awk '{print $(NF-1)}')
 		fi
 	fi
 } # storage_info


### PR DESCRIPTION
Fixes displaying of "Always°C" temperature on disks without Min/Max temperature values.

# Description

Motd script displays incorrect value if SMART data has no "(Min/Max x/x)" temperature.

For example:
Crucial MX500 returns correct value.
`194 Temperature_Celsius     0x0022   056   037   000    Old_age   Always       -       44 (Min/Max 0/63)`
`sudo smartctl -A /dev/sda 2> /dev/null | grep -i temperature | awk '{print $(NF-2)}'`
`44`

WD Purple WD40PURX returns "Always".
`194 Temperature_Celsius     0x0022   116   098   000    Old_age   Always       -       34`
`sudo smartctl -A /dev/sda 2> /dev/null | grep -i temperature | awk '{print $(NF-2)}'`
`Always`

Solution:
Parse `smartctl -l scttempsts` output instead, it's more consistent and has a side effect of not spinning up disks if they are in standby.
We also don't need `sudo` because motd scripts already run as root.


# How Has This Been Tested?

Ubuntu Bionic with smartctl 6.6

- [x] Re-login, shows correct temperature
- [x] `sudo smartctl -l scttempsts /dev/sda 2> /dev/null | grep -i 'Current Temperature:' | awk '{print $(NF-1)}'` returns correct value.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
