### PR TITLE
Audio codec enable in PineCube (patch)

### DIFF
--- a/patch/kernel/sunxi-dev/sun8i-s3-pinecube-enable-audio.patch
+++ b/patch/kernel/sunxi-dev/sun8i-s3-pinecube-enable-audio.patch
@@ -1,0 +1,81 @@
+diff --git a/arch/arm/boot/dts/sun8i-s3-pinecube.dts b/arch/arm/boot/dts/sun8i-s3-pinecube.dts
+index 20966e954eda..9f92098d8a02 100644
+--- a/arch/arm/boot/dts/sun8i-s3-pinecube.dts
++++ b/arch/arm/boot/dts/sun8i-s3-pinecube.dts
+@@ -58,6 +58,15 @@ wifi_pwrseq: wifi_pwrseq {
+ 	};
+ };
+ 
++&codec {
++	allwinner,pa-gpio = <&pio 6 6 GPIO_ACTIVE_HIGH>; /*PG6*/
++	allwinner,audio-routing =
++		"Speaker", "LINEOUT",
++		"MIC1", "Mic",
++		"Mic",  "MBIAS";
++	status = "okay";
++};
++
+ &csi1 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&csi1_8bit_pins>;
+diff --git a/arch/arm/boot/dts/sun8i-v3s.dtsi b/arch/arm/boot/dts/sun8i-v3s.dtsi
+index eb4cb63fef13..ebfd26ba6cd3 100644
+--- a/arch/arm/boot/dts/sun8i-v3s.dtsi
++++ b/arch/arm/boot/dts/sun8i-v3s.dtsi
+@@ -172,6 +172,15 @@ nmi_intc: interrupt-controller@1c000d0 {
+ 			interrupts = <GIC_SPI 32 IRQ_TYPE_LEVEL_HIGH>;
+ 		};
+ 
++		dma: dma-controller@1c02000 {
++			compatible = "allwinner,sun8i-v3s-dma";
++			reg = <0x01c02000 0x1000>;
++			interrupts = <GIC_SPI 50 IRQ_TYPE_LEVEL_HIGH>;
++			clocks = <&ccu CLK_BUS_DMA>;
++			resets = <&ccu RST_BUS_DMA>;
++			#dma-cells = <1>;
++		};
++
+ 		tcon0: lcd-controller@1c0c000 {
+ 			compatible = "allwinner,sun8i-v3s-tcon";
+ 			reg = <0x01c0c000 0x1000>;
+@@ -429,6 +438,25 @@ lradc: lradc@1c22800 {
+ 			status = "disabled";
+ 		};
+ 
++		codec: codec@01c22c00 {
++			#sound-dai-cells = <0>;
++			compatible = "allwinner,sun8i-v3s-codec";
++			reg = <0x01c22c00 0x400>;
++			interrupts = <GIC_SPI 29 IRQ_TYPE_LEVEL_HIGH>;
++			clocks = <&ccu CLK_BUS_CODEC>, <&ccu CLK_AC_DIG>;
++			clock-names = "apb", "codec";
++			resets = <&ccu RST_BUS_CODEC>;
++			dmas = <&dma 15>, <&dma 15>;
++			dma-names = "rx", "tx";
++			allwinner,codec-analog-controls = <&codec_analog>;
++			status = "disabled";
++		};
++
++		codec_analog: codec-analog@01c23000 {
++			compatible = "allwinner,sun8i-v3s-codec-analog";
++			reg = <0x01c23000 0x4>;
++		};
++
+ 		uart0: serial@1c28000 {
+ 			compatible = "snps,dw-apb-uart";
+ 			reg = <0x01c28000 0x400>;
+diff --git a/sound/soc/sunxi/sun8i-codec-analog.c b/sound/soc/sunxi/sun8i-codec-analog.c
+index be872eefa61e..b806121abeeb 100644
+--- a/sound/soc/sunxi/sun8i-codec-analog.c
++++ b/sound/soc/sunxi/sun8i-codec-analog.c
+@@ -731,6 +731,10 @@ static int sun8i_codec_analog_add_mixer(struct snd_soc_component *cmpnt,
+ static const struct sun8i_codec_analog_quirks sun8i_v3s_quirks = {
+ 	.has_headphone	= true,
+ 	.has_hmic	= true,
++	.has_linein	= true,
++	.has_lineout	= true,
++	.has_mbias	= true,
++	.has_mic2	= true,
+ };
+ 
+ static int sun8i_codec_analog_cmpnt_probe(struct snd_soc_component *cmpnt)


### PR DESCRIPTION
this patch enables the audio codec in pinecube, tested on NixOS, my computer doesn't have enough power to compile on my own and test.

[Commit on NixOS](https://github.com/danielfullmer/pinecube-nixos/pull/4)
[Pinecube forum](http://forum.pine64.org/showthread.php?tid=12346)
