### PR TITLE
Audio codec enable in Bpi-M2Ultra (patch)

### DIFF
--- a/patch/kernel/sunxi-dev/sun8i-r40-bpi-m2ultra-enable-audio.patch
+++ b/patch/kernel/sunxi-dev/sun8i-r40-bpi-m2ultra-enable-audio.patch
@@ -1,0 +1,68 @@
+diff --git a/arch/arm/boot/dts/sun8i-r40-bananapi-m2-ultra.dts b/arch/arm/boot/dts/sun8i-r40-bananapi-m2-ultra.dts
+index a6a1087a0c9b..3ad67d12cb9f 100644
+--- a/arch/arm/boot/dts/sun8i-r40-bananapi-m2-ultra.dts
++++ b/arch/arm/boot/dts/sun8i-r40-bananapi-m2-ultra.dts
+@@ -113,6 +113,16 @@ &ahci {
+ 	status = "okay";
+ };
+ 
++&codec {
++	allwinner,audio-routing =
++		"Headphone", "HP",
++		"Headphone", "HPCOM",
++		"MIC1", "Mic",
++		"Mic", "MBIAS";
++	allwinner,codec-analog-controls = <&codec_analog>;
++	status = "okay";
++};
++
+ &de {
+ 	status = "okay";
+ };
+diff --git a/arch/arm/boot/dts/sun8i-r40.dtsi b/arch/arm/boot/dts/sun8i-r40.dtsi
+index d5ad3b9efd12..434dcb06585a 100644
+--- a/arch/arm/boot/dts/sun8i-r40.dtsi
++++ b/arch/arm/boot/dts/sun8i-r40.dtsi
+@@ -680,6 +680,24 @@ ir1: ir@1c21c00 {
+ 			status = "disabled";
+ 		};
+ 
++		codec: codec@1c22c00 {
++			#sound-dai-cells = <0>;
++			compatible = "allwinner,sun8i-r40-codec";
++			reg = <0x01c22c00 0x300>;
++			interrupts = <GIC_SPI 30 IRQ_TYPE_LEVEL_HIGH>;
++			clocks = <&ccu CLK_BUS_CODEC>, <&ccu CLK_CODEC>;
++			clock-names = "apb", "codec";
++			resets = <&ccu RST_BUS_CODEC>;
++			dmas = <&dma 19>, <&dma 19>;
++			dma-names = "rx", "tx";
++			status = "disabled";
++		};
++
++		codec_analog: codec-analog@1c22f00 {
++			compatible = "allwinner,sun8i-a23-codec-analog";
++			reg = <0x01c22f00 0x4>;
++		};
++
+ 		ths: thermal-sensor@1c24c00 {
+ 			compatible = "allwinner,sun8i-r40-ths";
+ 			reg = <0x01c24c00 0x100>;
+diff --git a/sound/soc/sunxi/sun8i-codec-analog.c b/sound/soc/sunxi/sun8i-codec-analog.c
+index be872eefa61e..b73c09d5655a 100644
+--- a/sound/soc/sunxi/sun8i-codec-analog.c
++++ b/sound/soc/sunxi/sun8i-codec-analog.c
+@@ -686,6 +686,13 @@ static const struct sun8i_codec_analog_quirks sun8i_h3_quirks = {
+ 	.has_mic2	= true,
+ };
+ 
++static const struct sun8i_codec_analog_quirks sun8i_r40_quirks = {
++	.has headphone = true,
++	.has_linein	= true,
++	.has_mbias	= true,
++	.has_mic2	= true,
++};
++
+ static int sun8i_codec_analog_add_mixer(struct snd_soc_component *cmpnt,
+ 					const struct sun8i_codec_analog_quirks *quirks)
+ {


### PR DESCRIPTION
this patch enables the audio codec in Banana Pi M2 Ultra, tested on Armbian. I have also noticed that recompiling u-boot with these changes but with H3 compatible also activates the audio without having to compile the kernel
