### PR TITLE
Audio codec enable in Bpi-M2Ultra

### DIFF
--- a/patch/kernel/sunxi-current/sun8i-r40-bpi-m2ultra-enable-audio.patch
+++ b/patch/kernel/sunxi-current/sun8i-r40-bpi-m2ultra-enable-audio.patch
@@ -1,0 +1,164 @@
+diff --git a/arch/arm/boot/dts/sun8i-r40-bananapi-m2-ultra.dts b/arch/arm/boot/dts/sun8i-r40-bananapi-m2-ultra.dts
+index a6a1087a0c9b..3ad67d12cb9f 100644
+--- a/arch/arm/boot/dts/sun8i-r40-bananapi-m2-ultra.dts
++++ b/arch/arm/boot/dts/sun8i-r40-bananapi-m2-ultra.dts
+@@ -113,6 +113,16 @@ &ahci {
+ 	status = "okay";
+ };
+ 
++&codec {
++	allwinner,audio-routing =
++		"Headphone", "HP",
++		"Headphone", "HPCOM",
++		"MIC1", "Mic",
++		"Mic", "MBIAS";
++	allwinner,codec-analog-controls = <&codec_analog>;
++	status = "okay";
++};
++
+ &de {
+ 	status = "okay";
+ };
+diff --git a/arch/arm/boot/dts/sun8i-r40.dtsi b/arch/arm/boot/dts/sun8i-r40.dtsi
+index d5ad3b9efd12..434dcb06585a 100644
+--- a/arch/arm/boot/dts/sun8i-r40.dtsi
++++ b/arch/arm/boot/dts/sun8i-r40.dtsi
+@@ -680,6 +680,24 @@ ir1: ir@1c21c00 {
+ 			status = "disabled";
+ 		};
+ 
++		codec: codec@1c22c00 {
++			#sound-dai-cells = <0>;
++			compatible = "allwinner,sun8i-r40-codec";
++			reg = <0x01c22c00 0x300>;
++			interrupts = <GIC_SPI 30 IRQ_TYPE_LEVEL_HIGH>;
++			clocks = <&ccu CLK_BUS_CODEC>, <&ccu CLK_CODEC>;
++			clock-names = "apb", "codec";
++			resets = <&ccu RST_BUS_CODEC>;
++			dmas = <&dma 19>, <&dma 19>;
++			dma-names = "rx", "tx";
++			status = "disabled";
++		};
++
++		codec_analog: codec-analog@1c22f00 {
++			compatible = "allwinner,sun8i-a23-codec-analog";
++			reg = <0x01c22f00 0x4>;
++		};
++
+ 		ths: thermal-sensor@1c24c00 {
+ 			compatible = "allwinner,sun8i-r40-ths";
+ 			reg = <0x01c24c00 0x100>;
+diff --git a/sound/soc/sunxi/sun4i-codec.c b/sound/soc/sunxi/sun4i-codec.c
+index 6c13cc84b3fb..e21af9f06865 100644
+--- a/sound/soc/sunxi/sun4i-codec.c
++++ b/sound/soc/sunxi/sun4i-codec.c
+@@ -1541,6 +1541,44 @@ static struct snd_soc_card *sun8i_v3s_codec_create_card(struct device *dev)
+ 	return card;
+ };
+ 
++static struct snd_soc_card *sun8i_r40_codec_create_card(struct device *dev)
++{
++	struct snd_soc_card *card;
++	int ret;
++
++	card = devm_kzalloc(dev, sizeof(*card), GFP_KERNEL);
++	if (!card)
++		return ERR_PTR(-ENOMEM);
++
++	aux_dev.dlc.of_node = of_parse_phandle(dev->of_node,
++						 "allwinner,codec-analog-controls",
++						 0);
++	if (!aux_dev.dlc.of_node) {
++		dev_err(dev, "Can't find analog controls for codec.\n");
++		return ERR_PTR(-EINVAL);
++	}
++
++	card->dai_link = sun4i_codec_create_link(dev, &card->num_links);
++	if (!card->dai_link)
++		return ERR_PTR(-ENOMEM);
++
++	card->dev		= dev;
++	card->name		= "R40 Audio Codec";
++	card->dapm_widgets	= sun6i_codec_card_dapm_widgets;
++	card->num_dapm_widgets	= ARRAY_SIZE(sun6i_codec_card_dapm_widgets);
++	card->dapm_routes	= sun8i_codec_card_routes;
++	card->num_dapm_routes	= ARRAY_SIZE(sun8i_codec_card_routes);
++	card->aux_dev		= &aux_dev;
++	card->num_aux_devs	= 1;
++	card->fully_routed	= true;
++
++	ret = snd_soc_of_parse_audio_routing(card, "allwinner,audio-routing");
++	if (ret)
++		dev_warn(dev, "failed to parse audio-routing: %d\n", ret);
++
++	return card;
++};
++
+ static const struct regmap_config sun4i_codec_regmap_config = {
+ 	.reg_bits	= 32,
+ 	.reg_stride	= 4,
+@@ -1583,6 +1621,13 @@ static const struct regmap_config sun8i_v3s_codec_regmap_config = {
+ 	.max_register	= SUN8I_H3_CODEC_ADC_DBG,
+ };
+ 
++static const struct regmap_config sun8i_r40_codec_regmap_config = {
++	.reg_bits	= 32,
++	.reg_stride	= 4,
++	.val_bits	= 32,
++	.max_register	= SUN8I_H3_CODEC_ADC_DBG,
++};
++
+ struct sun4i_codec_quirks {
+ 	const struct regmap_config *regmap_config;
+ 	const struct snd_soc_component_driver *codec;
+@@ -1660,6 +1705,21 @@ static const struct sun4i_codec_quirks sun8i_v3s_codec_quirks = {
+ 	.has_reset	= true,
+ };
+ 
++tatic const struct sun4i_codec_quirks sun8i_r40_codec_quirks = {
++	.regmap_config	= &sun8i_r40_codec_regmap_config,
++	/*
++	 * TODO Share the codec structure with A23 for now.
++	 * This should be split out when adding digital audio
++	 * processing support for the H3.
++	 */
++	.codec		= &sun8i_a23_codec_codec,
++	.create_card	= sun8i_r40_codec_create_card,
++	.reg_adc_fifoc	= REG_FIELD(SUN6I_CODEC_ADC_FIFOC, 0, 31),
++	.reg_dac_txdata	= SUN8I_H3_CODEC_DAC_TXDATA,
++	.reg_adc_rxdata	= SUN6I_CODEC_ADC_RXDATA,
++	.has_reset	= true,
++};
++
+ static const struct of_device_id sun4i_codec_of_match[] = {
+ 	{
+ 		.compatible = "allwinner,sun4i-a10-codec",
+@@ -1685,6 +1745,10 @@ static const struct of_device_id sun4i_codec_of_match[] = {
+ 		.compatible = "allwinner,sun8i-v3s-codec",
+ 		.data = &sun8i_v3s_codec_quirks,
+ 	},
++	{
++		.compatible = "allwinner,sun8i-r40-codec",
++		.data = &sun8i_r40_codec_quirks,
++	},
+ 	{}
+ };
+ MODULE_DEVICE_TABLE(of, sun4i_codec_of_match);
+diff --git a/sound/soc/sunxi/sun8i-codec-analog.c b/sound/soc/sunxi/sun8i-codec-analog.c
+index be872eefa61e..9c404486183e 100644
+--- a/sound/soc/sunxi/sun8i-codec-analog.c
++++ b/sound/soc/sunxi/sun8i-codec-analog.c
+@@ -733,6 +733,13 @@ static const struct sun8i_codec_analog_quirks sun8i_v3s_quirks = {
+ 	.has_hmic	= true,
+ };
+ 
++static const struct sun8i_codec_analog_quirks sun8i_r40_quirks = {
++	.has headphone = true,
++	.has_linein	= true,
++	.has_mbias	= true,
++	.has_mic2	= true,
++};
++
+ static int sun8i_codec_analog_cmpnt_probe(struct snd_soc_component *cmpnt)
+ {
+ 	struct device *dev = cmpnt->dev;


### PR DESCRIPTION
- This patch enables the audio codec in Banana Pi M2 Ultra, tested on Armbian. I have also noticed that recompiling u-boot with these changes but with H3 compatible also activates the audio without having to compile the kernel. 
- forwarded to current from dev.
