### PR TITLE
Unfixing wallpaper in Gnome based desktops

### DIFF
--- a/config/desktop/focal/environments/budgie/debian/postinst
+++ b/config/desktop/focal/environments/budgie/debian/postinst
@@ -6,14 +6,6 @@ if [ -f /etc/pulse/default.pa ]; then sed "s/load-module module-udev-detect$/& t
 
 # set wallpapper to armbian
 
-keys=/etc/dconf/db/local.d/00-bg
-locks=/etc/dconf/db/local.d/locks/background
-profile=/etc/dconf/profile/user
-
-install -Dv /dev/null $keys
-install -Dv /dev/null $locks
-install -Dv /dev/null $profile
-
 echo "[org/budgie/desktop/background]
 picture-uri='file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'
 picture-options='zoom'

--- a/config/desktop/focal/environments/cinnamon/debian/postinst
+++ b/config/desktop/focal/environments/cinnamon/debian/postinst
@@ -6,14 +6,6 @@ if [ -f /etc/pulse/default.pa ]; then sed "s/load-module module-udev-detect$/& t
 
 # set wallpapper to armbian
 
-keys=/etc/dconf/db/local.d/00-bg
-locks=/etc/dconf/db/local.d/locks/background
-profile=/etc/dconf/profile/user
-
-install -Dv /dev/null $keys
-install -Dv /dev/null $locks
-install -Dv /dev/null $profile
-
 echo "[org/cinnamon/desktop/background]
 picture-uri='file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'
 picture-options='zoom'

--- a/config/desktop/focal/environments/gnome/debian/postinst
+++ b/config/desktop/focal/environments/gnome/debian/postinst
@@ -6,14 +6,6 @@ if [ -f /etc/pulse/default.pa ]; then sed "s/load-module module-udev-detect$/& t
 
 # set wallpapper to armbian
 
-keys=/etc/dconf/db/local.d/00-bg
-locks=/etc/dconf/db/local.d/locks/background
-profile=/etc/dconf/profile/user
-
-install -Dv /dev/null $keys
-install -Dv /dev/null $locks
-install -Dv /dev/null $profile
-
 echo "[org/gnome/desktop/background]
 picture-uri='file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'
 picture-options='zoom'

--- a/config/desktop/focal/environments/mate/debian/postinst
+++ b/config/desktop/focal/environments/mate/debian/postinst
@@ -6,14 +6,6 @@ if [ -f /etc/pulse/default.pa ]; then sed "s/load-module module-udev-detect$/& t
 
 # set wallpapper to armbian
 
-keys=/etc/dconf/db/local.d/00-bg
-locks=/etc/dconf/db/local.d/locks/background
-profile=/etc/dconf/profile/user
-
-install -Dv /dev/null $keys
-install -Dv /dev/null $locks
-install -Dv /dev/null $profile
-
 echo "[org/mate/desktop/background]
 picture-filename='/usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'
 picture-options='zoom'


### PR DESCRIPTION
(un)Disable change background function

https://askubuntu.com/questions/1179663/disable-change-backgound-function

# Description

We have fixed our wallpapert too hard so users couldn't change it.

Jira reference number [AR-674]

# How Has This Been Tested?

- [ ] Build image and see if you can change wallpaper

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-674]: https://armbian.atlassian.net/browse/AR-674