### PR TITLE
add extlinux.conf

### DIFF
--- a/config/sources/arm64.conf
+++ b/config/sources/arm64.conf
@@ -1,5 +1,3 @@
-NAME_KERNEL="Image"
-NAME_INITRD="uInitrd"
 MAIN_CMDLINE="rootflags=data=writeback rw no_console_suspend consoleblank=0 fsck.fix=yes fsck.repair=yes net.ifnames=0 bootsplash.bootfile=bootsplash.armbian"
 INITRD_ARCH=arm64
 QEMU_BINARY="qemu-aarch64-static"

--- a/config/sources/arm64.conf
+++ b/config/sources/arm64.conf
@@ -1,3 +1,6 @@
+NAME_KERNEL="Image"
+NAME_INITRD="uInitrd"
+MAIN_CMDLINE="rootflags=data=writeback rw no_console_suspend consoleblank=0 fsck.fix=yes fsck.repair=yes net.ifnames=0 bootsplash.bootfile=bootsplash.armbian"
 INITRD_ARCH=arm64
 QEMU_BINARY="qemu-aarch64-static"
 ARCHITECTURE=arm64

--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -613,12 +613,17 @@ prepare_partitions()
 			sed -i "s/console=.*/console=$DEFAULT_CONSOLE/" $SDCARD/boot/armbianEnv.txt
 		else
 			echo "console=$DEFAULT_CONSOLE" >> $SDCARD/boot/armbianEnv.txt
-        fi
+	        fi
 	fi
 
 	# recompile .cmd to .scr if boot.cmd exists
 	[[ -f $SDCARD/boot/boot.cmd ]] && \
 		mkimage -C none -A arm -T script -d $SDCARD/boot/boot.cmd $SDCARD/boot/boot.scr > /dev/null 2>&1
+
+	if [[ -f $SDCARD/boot/extlinux/extlinux.conf ]]; then
+		echo "  APPEND root=$rootfs $SRC_CMDLINE $MAIN_CMDLINE" >> $SDCARD/boot/extlinux/extlinux.conf
+		[[ -f $SDCARD/boot/armbianEnv.txt ]] && rm $SDCARD/boot/armbianEnv.txt
+	fi
 
 } #############################################################################
 

--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -620,6 +620,7 @@ prepare_partitions()
 	[[ -f $SDCARD/boot/boot.cmd ]] && \
 		mkimage -C none -A arm -T script -d $SDCARD/boot/boot.cmd $SDCARD/boot/boot.scr > /dev/null 2>&1
 
+	# create extlinux config
 	if [[ -f $SDCARD/boot/extlinux/extlinux.conf ]]; then
 		echo "  APPEND root=$rootfs $SRC_CMDLINE $MAIN_CMDLINE" >> $SDCARD/boot/extlinux/extlinux.conf
 		[[ -f $SDCARD/boot/armbianEnv.txt ]] && rm $SDCARD/boot/armbianEnv.txt

--- a/lib/distributions.sh
+++ b/lib/distributions.sh
@@ -164,6 +164,19 @@ install_common()
 	# NOTE: this needs to be executed before family_tweaks
 	local bootscript_src=${BOOTSCRIPT%%:*}
 	local bootscript_dst=${BOOTSCRIPT##*:}
+
+	if [[ $SRC_EXTLINUX == yes ]]; then
+		mkdir -p $SDCARD/boot/extlinux
+
+		cat << EOF > "$SDCARD/boot/extlinux/extlinux.conf"
+LABEL Armbian
+  LINUX /boot/$NAME_KERNEL
+  INITRD /boot/$NAME_INITRD
+  FDT /boot/dtb/$BOOT_FDT_FILE
+EOF
+
+	else
+
 	cp "${SRC}/config/bootscripts/${bootscript_src}" "${SDCARD}/boot/${bootscript_dst}"
 
 	if [[ -n $BOOTENV_FILE ]]; then
@@ -193,6 +206,8 @@ install_common()
 
 	[[ -n $BOOT_FDT_FILE && -f "${SDCARD}"/boot/armbianEnv.txt ]] && \
 		echo "fdtfile=${BOOT_FDT_FILE}" >> "${SDCARD}/boot/armbianEnv.txt"
+
+	fi
 
 	# initial date for fake-hwclock
 	date -u '+%Y-%m-%d %H:%M:%S' > "${SDCARD}"/etc/fake-hwclock.data

--- a/lib/distributions.sh
+++ b/lib/distributions.sh
@@ -165,47 +165,48 @@ install_common()
 	local bootscript_src=${BOOTSCRIPT%%:*}
 	local bootscript_dst=${BOOTSCRIPT##*:}
 
+	# create extlinux config file
 	if [[ $SRC_EXTLINUX == yes ]]; then
-		mkdir -p $SDCARD/boot/extlinux
 
-		cat << EOF > "$SDCARD/boot/extlinux/extlinux.conf"
-LABEL Armbian
-  LINUX /boot/$NAME_KERNEL
-  INITRD /boot/$NAME_INITRD
-  FDT /boot/dtb/$BOOT_FDT_FILE
-EOF
+		mkdir -p $SDCARD/boot/extlinux
+		cat <<-EOF > "$SDCARD/boot/extlinux/extlinux.conf"
+		LABEL Armbian
+		  LINUX /boot/Image
+		  INITRD /boot/uInitrd
+		  FDT /boot/dtb/$BOOT_FDT_FILE
+	EOF
 
 	else
 
-	cp "${SRC}/config/bootscripts/${bootscript_src}" "${SDCARD}/boot/${bootscript_dst}"
+		cp "${SRC}/config/bootscripts/${bootscript_src}" "${SDCARD}/boot/${bootscript_dst}"
 
-	if [[ -n $BOOTENV_FILE ]]; then
-		if [[ -f $USERPATCHES_PATH/bootenv/$BOOTENV_FILE ]]; then
-			cp "$USERPATCHES_PATH/bootenv/${BOOTENV_FILE}" "${SDCARD}"/boot/armbianEnv.txt
-		elif [[ -f $SRC/config/bootenv/$BOOTENV_FILE ]]; then
-			cp "${SRC}/config/bootenv/${BOOTENV_FILE}" "${SDCARD}"/boot/armbianEnv.txt
+		if [[ -n $BOOTENV_FILE ]]; then
+			if [[ -f $USERPATCHES_PATH/bootenv/$BOOTENV_FILE ]]; then
+				cp "$USERPATCHES_PATH/bootenv/${BOOTENV_FILE}" "${SDCARD}"/boot/armbianEnv.txt
+			elif [[ -f $SRC/config/bootenv/$BOOTENV_FILE ]]; then
+				cp "${SRC}/config/bootenv/${BOOTENV_FILE}" "${SDCARD}"/boot/armbianEnv.txt
+			fi
 		fi
-	fi
 
-	# TODO: modify $bootscript_dst or armbianEnv.txt to make NFS boot universal
-	# instead of copying sunxi-specific template
-	if [[ $ROOTFS_TYPE == nfs ]]; then
-		display_alert "Copying NFS boot script template"
-		if [[ -f $USERPATCHES_PATH/nfs-boot.cmd ]]; then
-			cp "$USERPATCHES_PATH"/nfs-boot.cmd "${SDCARD}"/boot/boot.cmd
-		else
-			cp "${SRC}"/config/templates/nfs-boot.cmd.template "${SDCARD}"/boot/boot.cmd
+		# TODO: modify $bootscript_dst or armbianEnv.txt to make NFS boot universal
+		# instead of copying sunxi-specific template
+		if [[ $ROOTFS_TYPE == nfs ]]; then
+			display_alert "Copying NFS boot script template"
+			if [[ -f $USERPATCHES_PATH/nfs-boot.cmd ]]; then
+				cp "$USERPATCHES_PATH"/nfs-boot.cmd "${SDCARD}"/boot/boot.cmd
+			else
+				cp "${SRC}"/config/templates/nfs-boot.cmd.template "${SDCARD}"/boot/boot.cmd
+			fi
 		fi
-	fi
 
-	[[ -n $OVERLAY_PREFIX && -f "${SDCARD}"/boot/armbianEnv.txt ]] && \
-		echo "overlay_prefix=$OVERLAY_PREFIX" >> "${SDCARD}"/boot/armbianEnv.txt
+		[[ -n $OVERLAY_PREFIX && -f "${SDCARD}"/boot/armbianEnv.txt ]] && \
+			echo "overlay_prefix=$OVERLAY_PREFIX" >> "${SDCARD}"/boot/armbianEnv.txt
 
-	[[ -n $DEFAULT_OVERLAYS && -f "${SDCARD}"/boot/armbianEnv.txt ]] && \
-		echo "overlays=${DEFAULT_OVERLAYS//,/ }" >> "${SDCARD}"/boot/armbianEnv.txt
+		[[ -n $DEFAULT_OVERLAYS && -f "${SDCARD}"/boot/armbianEnv.txt ]] && \
+			echo "overlays=${DEFAULT_OVERLAYS//,/ }" >> "${SDCARD}"/boot/armbianEnv.txt
 
-	[[ -n $BOOT_FDT_FILE && -f "${SDCARD}"/boot/armbianEnv.txt ]] && \
-		echo "fdtfile=${BOOT_FDT_FILE}" >> "${SDCARD}/boot/armbianEnv.txt"
+		[[ -n $BOOT_FDT_FILE && -f "${SDCARD}"/boot/armbianEnv.txt ]] && \
+			echo "fdtfile=${BOOT_FDT_FILE}" >> "${SDCARD}/boot/armbianEnv.txt"
 
 	fi
 

--- a/lib/makeboarddeb.sh
+++ b/lib/makeboarddeb.sh
@@ -211,8 +211,8 @@ create_board_package()
     rootdev=\$(sed -e 's/^.*root=//' -e 's/ .*\$//' < /proc/cmdline)
     rootfstype=\$(sed -e 's/^.*rootfstype=//' -e 's/ .*$//' < /proc/cmdline)
 
-    # recreate armbianEnv.txt only not exists
-    if [ ! -f /boot/armbianEnv.txt ]; then
+    # recreate armbianEnv.txt if it and extlinux does not exists
+    if [ ! -f /boot/armbianEnv.txt ] && [ ! -f /boot/extlinux/extlinux.conf ]; then
       cp /usr/share/armbian/armbianEnv.txt /boot  >/dev/null 2>&1
       echo "rootdev="\$rootdev >> /boot/armbianEnv.txt
       echo "rootfstype="\$rootfstype >> /boot/armbianEnv.txt


### PR DESCRIPTION
I tried migrating the file creation code as you recommended. But as a result,  still need to have a part of the code in the same place (to add the created UUID). So the question is, what's the point of separating the code and creating unnecessary confusion in two different places ? Moreover, this does not solve the problem of deleting the armbianEnv file, it is still created (as far as I understand, this is the result of other places of the build scripts) and it has to be deleted in the same place where the UUID is formed. Using existing BOOTENV is not possible. This is due to the contradiction of text file formats. When loading variables (using the armbianEnv text file), it is mandatory to have a separator " = " between the parameters (this is the key by which the name and value are determined). In extlinux.conf, on the contrary, there should be no separator , you need a space. Based on this, I suggest using this option at the first stage. Temporarily, I also added a few variables that can be redefined depending on the specific device models and their features in the board settings files (board.conf).
