### PR TITLE
Enable audio codec Bpi-M2Ultra (patch)

### DIFF
--- a/patch/u-boot/u-boot-sunxi/enable-audio-codec-bpim2ultra.patch
+++ b/patch/u-boot/u-boot-sunxi/enable-audio-codec-bpim2ultra.patch
@@ -1,0 +1,68 @@
+diff --git a/arch/arm/dts/sun8i-r40-bananapi-m2-ultra.dts b/arch/arm/dts/sun8i-r40-bananapi-m2-ultra.dts
+index c488aaacbd..e51ed3b64e 100644
+--- a/arch/arm/dts/sun8i-r40-bananapi-m2-ultra.dts
++++ b/arch/arm/dts/sun8i-r40-bananapi-m2-ultra.dts
+@@ -112,6 +112,15 @@
+ 	phy-supply = <&reg_eldo3>;
+ 	status = "okay";
+ };
++&codec {
++	allwinner,audio-routing =
++		"Headphone", "HP",
++		"Headphone", "HPCOM",
++		"MIC1", "Mic",
++		"Mic", "MBIAS";
++	allwinner,codec-analog-controls = <&codec_analog>;
++	status = "okay";
++};
+ 
+ &de {
+ 	status = "okay";
+diff --git a/arch/arm/dts/sun8i-r40.dtsi b/arch/arm/dts/sun8i-r40.dtsi
+index 06b685869f..27840c210a 100644
+--- a/arch/arm/dts/sun8i-r40.dtsi
++++ b/arch/arm/dts/sun8i-r40.dtsi
+@@ -180,6 +180,18 @@
+ 			interrupts = <GIC_SPI 0 IRQ_TYPE_LEVEL_HIGH>;
+ 		};
+ 
++		dma: dma-controller@1c02000 {
++			compatible = "allwinner,sun8i-r40-dma",
++				     "allwinner,sun50i-a64-dma";
++			reg = <0x01c02000 0x1000>;
++			interrupts = <GIC_SPI 27 IRQ_TYPE_LEVEL_HIGH>;
++			clocks = <&ccu CLK_BUS_DMA>;
++			dma-channels = <16>;
++			dma-requests = <31>;
++			resets = <&ccu RST_BUS_DMA>;
++			#dma-cells = <1>;
++		};
++
+ 		mmc0: mmc@1c0f000 {
+ 			compatible = "allwinner,sun8i-r40-mmc",
+ 				     "allwinner,sun50i-a64-mmc";
+@@ -411,6 +423,24 @@
+ 			reg = <0x01c20c90 0x10>;
+ 		};
+ 
++		codec: codec@1c22c00 {
++			#sound-dai-cells = <0>;
++			compatible = "allwinner,sun8i-h3-codec";
++			reg = <0x01c22c00 0x300>;
++			interrupts = <GIC_SPI 30 IRQ_TYPE_LEVEL_HIGH>;
++			clocks = <&ccu CLK_BUS_CODEC>, <&ccu CLK_CODEC>;
++			clock-names = "apb", "codec";
++			resets = <&ccu RST_BUS_CODEC>;
++			dmas = <&dma 19>, <&dma 19>;
++			dma-names = "rx", "tx";
++			status = "disabled";
++		};
++
++		codec_analog: codec-analog@1c22f00 {
++			compatible = "allwinner,sun8i-a23-codec-analog";
++			reg = <0x01c22f00 0x4>;
++		};
++
+ 		uart0: serial@1c28000 {
+ 			compatible = "snps,dw-apb-uart";
+ 			reg = <0x01c28000 0x400>;


### PR DESCRIPTION
- This patch enables the audio codec in Banana Pi M2 Ultra, tested on Armbian.
- swap patch from kernel to u-boot 
- added compatible with H3
- remove kernel patch and add to u-boot since the modules are built just need to activate in the board's dtb.

