### PR TITLE
Enable audio codec Pinecube (patch)

### DIFF
--- a/patch/u-boot/u-boot-sunxi/enable-audio-codec-pinecube.patch
+++ b/patch/u-boot/u-boot-sunxi/enable-audio-codec-pinecube.patch
@@ -1,0 +1,66 @@
+diff --git a/arch/arm/dts/sun8i-s3-pinecube.dts b/arch/arm/dts/sun8i-s3-pinecube.dts
+index 9bab6b7f40..e24d8314f4 100644
+--- a/arch/arm/dts/sun8i-s3-pinecube.dts
++++ b/arch/arm/dts/sun8i-s3-pinecube.dts
+@@ -58,6 +58,15 @@
+ 	};
+ };
+ 
++&codec {
++	allwinner,audio-routing =
++		"Speaker", "LINEOUT",
++		"MIC1", "Mic",
++		"Mic",  "HBIAS";
++	allwinner,pa-gpios = <&pio 6 6 GPIO_ACTIVE_HIGH>; /* PG6 */
++	status = "okay";
++};
++
+ &csi1 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&csi1_8bit_pins>;
+diff --git a/arch/arm/dts/sun8i-v3s.dtsi b/arch/arm/dts/sun8i-v3s.dtsi
+index 0c73416769..d70ed8bc8c 100644
+--- a/arch/arm/dts/sun8i-v3s.dtsi
++++ b/arch/arm/dts/sun8i-v3s.dtsi
+@@ -163,6 +163,15 @@
+ 			ranges;
+ 		};
+ 
++		dma: dma-controller@1c02000 {
++			compatible = "allwinner,sun8i-v3s-dma";
++			reg = <0x01c02000 0x1000>;
++			interrupts = <GIC_SPI 50 IRQ_TYPE_LEVEL_HIGH>;
++			clocks = <&ccu CLK_BUS_DMA>;
++			resets = <&ccu RST_BUS_DMA>;
++			#dma-cells = <1>;
++		};
++
+ 		tcon0: lcd-controller@1c0c000 {
+ 			compatible = "allwinner,sun8i-v3s-tcon";
+ 			reg = <0x01c0c000 0x1000>;
+@@ -408,6 +417,25 @@
+ 			status = "disabled";
+ 		};
+ 
++		codec: codec@1c22c00 {
++			#sound-dai-cells = <0>;
++			compatible = "allwinner,sun8i-h3-codec";
++			reg = <0x01c22c00 0x400>;
++			interrupts = <GIC_SPI 29 IRQ_TYPE_LEVEL_HIGH>;
++			clocks = <&ccu CLK_BUS_CODEC>, <&ccu CLK_AC_DIG>;
++			clock-names = "apb", "codec";
++			resets = <&ccu RST_BUS_CODEC>;
++			dmas = <&dma 15>, <&dma 15>;
++			dma-names = "rx", "tx";
++			allwinner,codec-analog-controls = <&codec_analog>;
++			status = "disabled";
++		};
++
++		codec_analog: codec-analog@1c23000 {
++			compatible = "allwinner,sun8i-h3-codec-analog";
++			reg = <0x01c23000 0x4>;
++		};
++
+ 		uart0: serial@1c28000 {
+ 			compatible = "snps,dw-apb-uart";
+ 			reg = <0x01c28000 0x400>;


### PR DESCRIPTION
- This patch enables the audio codec in Pinecube, tested on Armbian recompiling u-boot..
- swap patch from kernel to u-boot
- added compatible with H3
- remove kernel patch and add to u-boot since the modules are built just need to activate in the board's dtb.