### PR TITLE
Change apt's default compression method to gzip

### DIFF
--- a/packages/bsp/common/etc/apt/apt.conf.d/02-armbian-compress-indexes
+++ b/packages/bsp/common/etc/apt/apt.conf.d/02-armbian-compress-indexes
@@ -1,2 +1,3 @@
 Acquire::GzipIndexes "true";
 Acquire::CompressionTypes::Order:: "gz";
+APT::Compressor::gzip::Cost "10";


### PR DESCRIPTION
# Description

APT uses lz4 as its default compression method, but Some ARM board has performance problem on it.
This setting make apt prefer gzip over lz4.

cf. https://forum.armbian.com/topic/14064-my-apt-search-has-become-super-slow-recently/page/2/

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
