### PR TITLE
Fix motd vnstat traffic stats

### DIFF
--- a/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
+++ b/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
@@ -235,11 +235,11 @@ echo ""
 line=0
 if [[ $(command -v vnstat) ]]; then
 	line=$((line+1))
-	traffic=$(vnstat -d 1 -i $PRIMARY_INTERFACE --oneline | cut -d";" -f4,5)
+	traffic=$(vnstat -h -i $PRIMARY_INTERFACE --oneline | cut -d";" -f4,5)
 	traffic_rx=$(echo $traffic | cut -d";" -f1,1 | sed -r 's/([0-9]+\.[0-9]{1})[0-9]*/\1/')
 	traffic_tx=$(echo $traffic | cut -d";" -f2,2 | sed -r 's/([0-9]+\.[0-9]{1})[0-9]*/\1/')
-	[[ "$traffic" == *"Not enough"* ]] && traffic_tx="n/a	"; traffic_rx="n/a	"
-	printf "${PRIMARY_DIRECTION^^} yesterday:  "
+	[[ "$traffic" == *"Not enough"* ]] && { traffic_tx="n/a	"; traffic_rx="n/a	"; }
+	printf "${PRIMARY_DIRECTION^^} last 24h:   "
 	if [[ $PRIMARY_DIRECTION == tx ]]; then
 		printf "\x1B[92m%s\x1B[0m" "$traffic_tx"
 	else


### PR DESCRIPTION
# Description

Fixes:

RX/TX: "Unknown parameter "1". Use --help for help."
RX always displaying "n/a"

Changed:

Use -h instead of -d because vnstat -d no longer accepts an additional argument.
From vnstat man page:
 -d, --days
Show traffic statistics on a daily basis for the last 30 days.
 -h, --hours
Show traffic statistics on a hourly basis for the last 24 hours.


# How Has This Been Tested?

- [x] Relogin
- [x] sudo /etc/update-motd.d/30-armbian-sysinfo

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
