### PR TITLE
Some 30-armbian-sysinfo fixes

### DIFF
--- a/packages/bsp/common/etc/default/armbian-motd.dpkg-dist
+++ b/packages/bsp/common/etc/default/armbian-motd.dpkg-dist
@@ -2,6 +2,7 @@
 # Example:
 # MOTD_DISABLE="header tips updates"
 # ONE_WIRE="yes" show 1-wire temperature sensor if attached
+# PRIMARY_DIRECTION="rx" show daily traffic stats, options: "rx", "tx", "both", "off", vnstat needs to be installed
 
 MOTD_DISABLE=""
 ONE_WIRE=""

--- a/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
+++ b/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
@@ -223,18 +223,17 @@ display "Zram usage" "$swap_usage" "75" "0" "%" " of ${swap_total}"
 printf "IP:	       "
 printf "\x1B[92m%s\x1B[0m" "$ip_address"
 echo "" # fixed newline
-a=0;b=0;c=0
 display "CPU temp" "$board_temp" $CPU_TEMP_LIMIT "0" "°C" ""
-display "Ambient temp" "$amb_temp" $AMB_TEMP_LIMIT "0" "°C" "" ; a=$?
-(( ($a+$b) >0 )) && echo "" # new line only if some value is displayed
+display "Ambient temp" "$amb_temp" $AMB_TEMP_LIMIT "0" "°C" ""
 display "Usage of /" "$root_usage" "90" "1" "%" " of $root_total"
 echo "" # fixed newline
-display "storage/" "$storage_usage" "90" "1" "%" " of $storage_total"
-display "storage temp" "$storage_temp" $HDD_TEMP_LIMIT "0" "°C" "" ; a=$?
-display "Battery" "$battery_percent" "20" "1" "%" "$status_battery_text"
-echo ""
-line=0
+a=0
+display "storage/" "$storage_usage" "90" "1" "%" " of $storage_total" ; a=$((a+$?))
+display "storage temp" "$storage_temp" $HDD_TEMP_LIMIT "0" "°C" "" ; a=$((a+$?))
+display "Battery" "$battery_percent" "20" "1" "%" "$status_battery_text" ; a=$((a+$?))
+(( $a > 0 )) && echo "" # new line only if some value is displayed
 
+line=0
 if [[ $(command -v vnstat) ]]; then
 	traffic=$(vnstat -i $PRIMARY_INTERFACE --oneline | cut -d";" -f4,5)
 	traffic_rx=$(echo $traffic | cut -d";" -f1,1 | sed -r 's/([0-9]+\.[0-9]{1})[0-9]*/\1/')

--- a/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
+++ b/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
@@ -203,7 +203,7 @@ swap_total=$(awk '{print $(2)}' <<<${swap_info})
 # display info
 display "System load" "${load%% *}" "${critical_load}" "0" "%" ""
 
-printf "Up time:       \x1B[92m%s\x1B[0m\t\t" "$time"
+printf "Up time:       \x1B[92m%s\x1B[0m\t" "$time"
 display "Local users" "${users##* }" "3" "2" ""
 echo "" # fixed newline
 if [[ ${memory_total} -gt 1000 ]]; then
@@ -220,7 +220,7 @@ fi
 
 display "Memory usage" "$memory_usage" "70" "0" "%" " of ${memory_total}"
 display "Zram usage" "$swap_usage" "75" "0" "%" " of ${swap_total}"
-printf "IP:            "
+printf "IP:	       "
 printf "\x1B[92m%s\x1B[0m" "$ip_address"
 echo "" # fixed newline
 a=0;b=0;c=0
@@ -228,24 +228,35 @@ display "CPU temp" "$board_temp" $CPU_TEMP_LIMIT "0" "°C" ""
 display "Ambient temp" "$amb_temp" $AMB_TEMP_LIMIT "0" "°C" "" ; a=$?
 (( ($a+$b) >0 )) && echo "" # new line only if some value is displayed
 display "Usage of /" "$root_usage" "90" "1" "%" " of $root_total"
+echo "" # fixed newline
 display "storage/" "$storage_usage" "90" "1" "%" " of $storage_total"
 display "storage temp" "$storage_temp" $HDD_TEMP_LIMIT "0" "°C" "" ; a=$?
 display "Battery" "$battery_percent" "20" "1" "%" "$status_battery_text"
 echo ""
 line=0
+
 if [[ $(command -v vnstat) ]]; then
-	line=$((line+1))
-	traffic=$(vnstat -h -i $PRIMARY_INTERFACE --oneline | cut -d";" -f4,5)
+	traffic=$(vnstat -i $PRIMARY_INTERFACE --oneline | cut -d";" -f4,5)
 	traffic_rx=$(echo $traffic | cut -d";" -f1,1 | sed -r 's/([0-9]+\.[0-9]{1})[0-9]*/\1/')
 	traffic_tx=$(echo $traffic | cut -d";" -f2,2 | sed -r 's/([0-9]+\.[0-9]{1})[0-9]*/\1/')
 	[[ "$traffic" == *"Not enough"* ]] && { traffic_tx="n/a	"; traffic_rx="n/a	"; }
-	printf "${PRIMARY_DIRECTION^^} last 24h:   "
-	if [[ $PRIMARY_DIRECTION == tx ]]; then
-		printf "\x1B[92m%s\x1B[0m" "$traffic_tx"
-	else
-		printf "\x1B[92m%s\x1B[0m" "$traffic_rx"
-	fi
-	printf "\t"
+	case $PRIMARY_DIRECTION in
+		tx)
+			printf "TX today:      \x1B[92m%s\x1B[0m  \t"  "$traffic_tx"
+			line=$((line+1))
+		;;
+		rx)
+			printf "RX today:      \x1B[92m%s\x1B[0m  \t"  "$traffic_rx"
+			line=$((line+1))
+		;;
+		both)
+			printf "TX today:      \x1B[92m%s\x1B[0m  \t"  "$traffic_tx"
+			printf "RX today:      \x1B[92m%s\x1B[0m  \t"  "$traffic_rx"
+			line=$((line+1))
+		;;
+		*) #off or whatever
+		;;
+	esac
 fi
 
 if [[ $(command -v zpool) ]]; then


### PR DESCRIPTION
# Description

Fixed alignment of "Local users" and "IP" in third column.
Made it more compact by adding extra new line.
Added "both" traffic direction.
Removed "-h" vnstat argument because it doesn't do anything, changed "last 24h" to "today" (there is only "rx/tx for today" in --oneline output).
Added description in default config.
Fixed some new line logic


# How Has This Been Tested?

- [x] `sudo /etc/update-motd.d/30-armbian-sysinfo`
- [x] [Test new line logic](https://i.imgur.com/Uo6Opq3.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
