### PR TITLE
W1 temp sensor display bugfix

### DIFF
--- a/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
+++ b/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
@@ -106,10 +106,9 @@ function ambienttemp() {
 		amb_temp=$(awk '{printf("%d",$1/1000)}' <<<${raw_temp})
 		echo $amb_temp
 	elif [[ -d $W1_DIR && $ONE_WIRE == yes ]]; then
-		device=$(ls -1 $W1_DIR | grep -Eo '^[0-9]{1,4}' | head -1)
+		device=$(ls -1 $W1_DIR | grep -E '^[0-9]{1,4}' | head -1)
 		if [[ -n $device ]]; then
-			if [[ -d ${W1_DIR}${device}/hwmon/hwmon0 ]]; then hwmon=0; else hwmon=1; fi
-			read raw_temp < ${W1_DIR}${device}/hwmon/hwmon${hwmon}/temp1_input 2>/dev/null
+			read raw_temp < ${W1_DIR}${device}/hwmon/$(ls -1 ${W1_DIR}${device}/hwmon)/temp1_input 2>/dev/null
 			amb_temp=$(awk '{printf("%d",$1/1000)}' <<<${raw_temp})
 			echo $amb_temp
 		fi


### PR DESCRIPTION
# Description

W1 temp sensor can have different properties. Adjusting

Jira reference number [AR-700]

# How Has This Been Tested?

```
System load:   2%           	Up time:       8 days 19:23		Local users:   2            	
Memory usage:  37% of 1.88G  	IP:            1.1.1.1
CPU temp:      37°C           	Ambient temp:  20°C           	
Usage of /:    31% of 7.1G   	
RX last 24h:   8.6 MiB	
```


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-700]: https://armbian.atlassian.net/browse/AR-700