### PR TITLE
Displays that EDGE branch is in action

### DIFF
--- a/packages/bsp/common/etc/update-motd.d/10-armbian-header
+++ b/packages/bsp/common/etc/update-motd.d/10-armbian-header
@@ -26,7 +26,7 @@ KERNELID=$(uname -r)
 [[ -n $(cat /proc/device-tree/model | tr -d '\000' | grep ODROID | grep Plus) ]] && BOARD_NAME+="+"
 
 TERM=linux toilet -f standard -F metal $(echo $BOARD_NAME | sed 's/Orange Pi/OPi/' | sed 's/NanoPi/NPi/' | sed 's/Banana Pi/BPi/')
-echo -e "Welcome to \e[0;91mArmbian ${VERSION} ${DISTRIBUTION_CODENAME^}\x1B[0m with \e[0;91mLinux $KERNELID\x1B[0m\n"
+echo -e "Welcome to \e[0;91mArmbian ${VERSION} ${DISTRIBUTION_CODENAME^}\x1B[0m with $([[ $BRANCH == edge ]] && echo -e "\e[0;91mbleeding\x1B[0m edge " )\e[0;91mLinux $KERNELID\x1B[0m\n"
 
 # displaying status warnings
 


### PR DESCRIPTION
# Description

DEV or EDGE branch doesn't represent anywhere that its used. Since we will provide more images of those EDGE builds closer to the Linux kernel trunk, let's distinguish this in the motd.

Change from:
`Welcome to Armbian 21.05.0-trunk Focal Linux 5.11.9-meson64`
To:
`Welcome to Armbian 21.05.0-trunk Focal with bleeding edge Linux 5.11.9-meson64`

Jira reference number [AR-704]

# How Has This Been Tested?

Cosmetic, tested manually.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-704]: https://armbian.atlassian.net/browse/AR-704