### PR TITLE
Fix redundant log writing

### DIFF
--- a/packages/bsp/common/etc/cron.daily/armbian-ram-logging
+++ b/packages/bsp/common/etc/cron.daily/armbian-ram-logging
@@ -1,2 +1,6 @@
 #!/bin/sh
+# Only run on systems where logrotate is a cron job
+if [ -f /lib/systemd/system/logrotate.timer ]; then
+    exit 0
+fi
 /usr/lib/armbian/armbian-ramlog write >/dev/null 2>&1

--- a/packages/bsp/common/etc/cron.daily/armbian-ram-logging
+++ b/packages/bsp/common/etc/cron.daily/armbian-ram-logging
@@ -1,6 +1,4 @@
 #!/bin/sh
 # Only run on systems where logrotate is a cron job
-if [ -f /lib/systemd/system/logrotate.timer ]; then
-    exit 0
-fi
+systemctl is-active --quiet logrotate.timer && exit 0
 /usr/lib/armbian/armbian-ramlog write >/dev/null 2>&1


### PR DESCRIPTION
# Description

Fixes #2739, calling "armbian-ramlog write" twice on systems with logrotate systemd unit.

# How Has This Been Tested?

- [x] Running the script manually.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
