### PR TITLE
U-boot compilation for Tinkerboard break due to missing headers

### DIFF
--- a/config/templates/Dockerfile
+++ b/config/templates/Dockerfile
@@ -54,6 +54,7 @@ RUN apt-get update \
        libc6-dev-armhf-cross \
        libc6-i386 \
        libfile-fcntllock-perl \
+       libfdt-dev \
        libfl-dev \
        liblz4-tool \
        libncurses5-dev \

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1001,7 +1001,7 @@ prepare_host()
 	nfs-kernel-server btrfs-progs ncurses-term p7zip-full kmod dosfstools libc6-dev-armhf-cross imagemagick \
 	curl patchutils liblz4-tool libpython2.7-dev linux-base swig aptly acl python3-dev python3-distutils \
 	locales ncurses-base pixz dialog systemd-container udev lib32stdc++6 libc6-i386 lib32ncurses5 lib32tinfo5 \
-	bison libbison-dev flex libfl-dev cryptsetup gpg gnupg1 cpio aria2 pigz dirmngr python3-distutils jq"
+	bison libbison-dev flex libfl-dev cryptsetup gpg gnupg1 cpio aria2 pigz dirmngr python3-distutils jq libfdt-dev"
 
 # build aarch64
   else
@@ -1012,7 +1012,7 @@ prepare_host()
 	nfs-kernel-server btrfs-progs ncurses-term p7zip-full kmod dosfstools libc6-dev-armhf-cross imagemagick \
 	curl patchutils liblz4-tool libpython2.7-dev linux-base swig aptly acl python3-dev \
 	locales ncurses-base pixz dialog systemd-container udev libc6 qemu\
-	bison libbison-dev flex libfl-dev cryptsetup gpg gnupg1 cpio aria2 pigz dirmngr python3-distutils"
+	bison libbison-dev flex libfl-dev cryptsetup gpg gnupg1 cpio aria2 pigz dirmngr python3-distutils jq libfdt-dev"
 
 # build aarch64
   fi


### PR DESCRIPTION
# Description

Probably some headers were moved around and if you come from a clean system, they are missing. Adding appropriate library fixing the problem of missing headers.

Jira reference number [AR-708]

# How Has This Been Tested?

Fix was confirmed [by user reported the bug](https://forum.armbian.com/topic/17387-kernel-bugcrash-when-trying-to-connect-tinker-board-s-as-wifi-ap/?do=findComment&comment=121711).

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-708]: https://armbian.atlassian.net/browse/AR-708