### PR TITLE
Add vnstat network statistic measurement to the standard CLI image

### DIFF
--- a/config/cli/bullseye/main/config_cli_standard/packages
+++ b/config/cli/bullseye/main/config_cli_standard/packages
@@ -2,4 +2,4 @@ bridge-utils build-essential fbset iw wpasupplicant sudo linux-base crda wireles
 unattended-upgrades console-setup unicode-data initramfs-tools ca-certificates expect 
 iptables automake html2text bison flex libwrap0-dev libssl-dev libnl-3-dev libnl-genl-3-dev 
 keyboard-configuration gnupg2 networkd-dispatcher man-db hping3 command-not-found apt-file 
-dkms python3-distutils python3-lib2to3
+dkms python3-distutils python3-lib2to3 vnstat

--- a/config/cli/buster/main/config_cli_standard/packages
+++ b/config/cli/buster/main/config_cli_standard/packages
@@ -2,4 +2,4 @@ bridge-utils build-essential fbset iw wpasupplicant sudo linux-base crda wireles
 unattended-upgrades console-setup unicode-data initramfs-tools ca-certificates expect 
 iptables automake html2text bison flex libwrap0-dev libssl-dev libnl-3-dev libnl-genl-3-dev 
 keyboard-configuration gnupg2 networkd-dispatcher man-db hping3 selinux-policy-default 
-rng-tools command-not-found apt-file dkms python3-distutils python3-lib2to3
+rng-tools command-not-found apt-file dkms python3-distutils python3-lib2to3 vnstat

--- a/config/cli/focal/main/config_cli_standard/packages
+++ b/config/cli/focal/main/config_cli_standard/packages
@@ -2,4 +2,4 @@ bridge-utils build-essential fbset iw wpasupplicant sudo linux-base crda wireles
 unattended-upgrades console-setup unicode-data initramfs-tools ca-certificates expect 
 iptables automake html2text bison flex libwrap0-dev libssl-dev libnl-3-dev libnl-genl-3-dev 
 keyboard-configuration gnupg2 networkd-dispatcher man-db hping3 selinux-policy-default 
-dkms python3-distutils python3-lib2to3
+dkms python3-distutils python3-lib2to3 vnstat


### PR DESCRIPTION
# Description

Do we add this to default CLI builds or not? Minimal is not affected.

Jira reference number [AR-673]

# How Has This Been Tested?

No need for special testing, but rootfs cache has to be rebuilt if we add this.

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-673]: https://armbian.atlassian.net/browse/AR-673