### PR TITLE
rockchip: add Orange Pi R1 Plus support

### DIFF
--- a/config/boards/orangepi-r1plus.conf
+++ b/config/boards/orangepi-r1plus.conf
@@ -1,0 +1,10 @@
+# Rockchip RK3328 quad core 1GB 2xGBE USB2 SPI
+BOARD_NAME="Orange Pi R1 Plus"
+BOARDFAMILY="rockchip64"
+BOOTCONFIG="orangepi_r1_plus_rk3328_defconfig"
+KERNEL_TARGET="current,edge"
+DEFAULT_CONSOLE="serial"
+MODULES="g_serial"
+MODULES_BLACKLIST="rockchipdrm analogix_dp dw_mipi_dsi dw_hdmi gpu_sched lima hantro_vpu"
+SERIALCON="ttyS2:1500000,ttyGS0"
+BUILD_DESKTOP="no"

--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -25,7 +25,7 @@ else # rk3308, rk3328
 
 fi
 
-if [[ $BOARD == nanopi-r2s || $BOARD == rockpi-e || $BOARD == nanopineo3 || $BOARD == renegade || $BOARD == station-m1 || $BOARD == z28pro ]]; then
+if [[ $BOARD == nanopi-r2s || $BOARD == nanopineo3 || $BOARD == orangepi-r1plus || $BOARD == renegade || $BOARD == rockpi-e || $BOARD == station-m1 || $BOARD == z28pro ]]; then
 
 	BOOT_USE_BLOBS=yes
 	BOOT_SOC=rk3328
@@ -310,7 +310,7 @@ family_tweaks()
 
 		chroot $SDCARD /bin/bash -c "systemctl --no-reload enable z28pro-bluetooth.service >/dev/null 2>&1"
 
-	elif [[ $BOARD == nanopi-r2s ]]; then
+	elif [[ $BOARD == nanopi-r2s || $BOARD == orangepi-r1plus ]]; then
 
 		# rename USB based network to lan0
 		mkdir -p $SDCARD/etc/udev/rules.d/

--- a/patch/kernel/archive/rockchip64-5.10/add-board-nanopi-r2s.patch
+++ b/patch/kernel/archive/rockchip64-5.10/add-board-nanopi-r2s.patch
@@ -951,7 +951,7 @@ new file mode 100644
 index 000000000..971397659
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-nanopi-r2-rev00.dts
-@@ -0,0 +1,116 @@
+@@ -0,0 +1,127 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2019 FriendlyElec Computer Tech. Co., Ltd.
@@ -1014,6 +1014,17 @@ index 000000000..971397659
 +
 +&leds {
 +	status = "okay";
++
++	led@2 {
++		gpios = <&gpio2 RK_PB7 GPIO_ACTIVE_HIGH>;
++		label = "lan_led";
++	};
++
++	led@3 {
++		gpios = <&gpio2 RK_PC2 GPIO_ACTIVE_HIGH>;
++		label = "wan_led";
++		linux,default-trigger = "stmmac-0:00:link";
++	};
 +};
 +
 +&rk805 {

--- a/patch/kernel/archive/rockchip64-5.10/add-board-orangepi-r1plus.patch
+++ b/patch/kernel/archive/rockchip64-5.10/add-board-orangepi-r1plus.patch
@@ -1,0 +1,52 @@
+diff --git a/arch/arm64/boot/dts/rockchip/rk3328-orangepi-r1-plus.dts b/arch/arm64/boot/dts/rockchip/rk3328-orangepi-r1-plus.dts
+new file mode 100644
+index 000000000..2ee07d15a
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3328-orangepi-r1-plus.dts
+@@ -0,0 +1,46 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2020 Shenzhen Xunlong Software CO.,Limited
++ * Copyright (c) 2021 AmadeusGhost <amadeus@jmu.edu.cn>
++ *
++ * Based on Nanopi R2S
++ */
++
++#include "rk3328-nanopi-r2-rev00.dts"
++
++/ {
++	model = "Xunlong Orange Pi R1 Plus";
++	compatible = "xunlong,orangepi-r1-plus", "rockchip,rk3328";
++};
++
++&leds_gpio {
++	rockchip,pins = <3 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>;
++};
++
++&leds {
++	led@1 {
++		gpios = <&gpio3 RK_PC5 GPIO_ACTIVE_HIGH>;
++	};
++};
++
++&mach {
++	compatible = "orangepi,board";
++	hwrev = <2>;
++	machine = "ORANGEPI-R1PLUS";
++	model = "OrangePi R1PLUS";
++};
++
++&spi0 {
++	max-freq = <48000000>;
++	status = "okay";
++
++	flash@0 {
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <10000000>;
++	};
++};
++
++&uart1 {
++	status = "okay";
++};

--- a/patch/kernel/archive/rockchip64-5.10/add-boards-to-dts-makefile.patch
+++ b/patch/kernel/archive/rockchip64-5.10/add-boards-to-dts-makefile.patch
@@ -2,12 +2,13 @@ diff --git a/arch/arm64/boot/dts/rockchip/Makefile b/arch/arm64/boot/dts/rockchi
 index 26661c7b7..1462ed38b 100644
 --- a/arch/arm64/boot/dts/rockchip/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/Makefile
-@@ -1,4 +1,17 @@
+@@ -1,4 +1,18 @@
  # SPDX-License-Identifier: GPL-2.0
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3308-rock-pi-s.dtb
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-nanopi-r2-rev00.dtb
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-nanopi-r2-rev20.dtb
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-nanopi-neo3-rev02.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-orangepi-r1-plus.dtb
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-roc-pc.dtb
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-rock-pi-e.dtb
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-z28pro.dtb

--- a/patch/kernel/archive/rockchip64-5.11/add-board-nanopi-r2s.patch
+++ b/patch/kernel/archive/rockchip64-5.11/add-board-nanopi-r2s.patch
@@ -951,7 +951,7 @@ new file mode 100644
 index 000000000..971397659
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-nanopi-r2-rev00.dts
-@@ -0,0 +1,116 @@
+@@ -0,0 +1,127 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2019 FriendlyElec Computer Tech. Co., Ltd.
@@ -1014,6 +1014,17 @@ index 000000000..971397659
 +
 +&leds {
 +	status = "okay";
++
++	led@2 {
++		gpios = <&gpio2 RK_PB7 GPIO_ACTIVE_HIGH>;
++		label = "lan_led";
++	};
++
++	led@3 {
++		gpios = <&gpio2 RK_PC2 GPIO_ACTIVE_HIGH>;
++		label = "wan_led";
++		linux,default-trigger = "stmmac-0:00:link";
++	};
 +};
 +
 +&rk805 {

--- a/patch/kernel/archive/rockchip64-5.11/add-board-orangepi-r1plus.patch
+++ b/patch/kernel/archive/rockchip64-5.11/add-board-orangepi-r1plus.patch
@@ -1,0 +1,52 @@
+diff --git a/arch/arm64/boot/dts/rockchip/rk3328-orangepi-r1-plus.dts b/arch/arm64/boot/dts/rockchip/rk3328-orangepi-r1-plus.dts
+new file mode 100644
+index 000000000..2ee07d15a
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3328-orangepi-r1-plus.dts
+@@ -0,0 +1,46 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2020 Shenzhen Xunlong Software CO.,Limited
++ * Copyright (c) 2021 AmadeusGhost <amadeus@jmu.edu.cn>
++ *
++ * Based on Nanopi R2S
++ */
++
++#include "rk3328-nanopi-r2-rev00.dts"
++
++/ {
++	model = "Xunlong Orange Pi R1 Plus";
++	compatible = "xunlong,orangepi-r1-plus", "rockchip,rk3328";
++};
++
++&leds_gpio {
++	rockchip,pins = <3 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>;
++};
++
++&leds {
++	led@1 {
++		gpios = <&gpio3 RK_PC5 GPIO_ACTIVE_HIGH>;
++	};
++};
++
++&mach {
++	compatible = "orangepi,board";
++	hwrev = <2>;
++	machine = "ORANGEPI-R1PLUS";
++	model = "OrangePi R1PLUS";
++};
++
++&spi0 {
++	max-freq = <48000000>;
++	status = "okay";
++
++	flash@0 {
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <10000000>;
++	};
++};
++
++&uart1 {
++	status = "okay";
++};

--- a/patch/kernel/archive/rockchip64-5.11/add-boards-to-dts-makefile.patch
+++ b/patch/kernel/archive/rockchip64-5.11/add-boards-to-dts-makefile.patch
@@ -2,12 +2,13 @@ diff --git a/arch/arm64/boot/dts/rockchip/Makefile b/arch/arm64/boot/dts/rockchi
 index 26661c7b7..1462ed38b 100644
 --- a/arch/arm64/boot/dts/rockchip/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/Makefile
-@@ -1,4 +1,17 @@
+@@ -1,4 +1,18 @@
  # SPDX-License-Identifier: GPL-2.0
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3308-rock-pi-s.dtb
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-nanopi-r2-rev00.dtb
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-nanopi-r2-rev20.dtb
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-nanopi-neo3-rev02.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-orangepi-r1-plus.dtb
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-roc-pc.dtb
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-rock-pi-e.dtb
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-z28pro.dtb

--- a/patch/u-boot/u-boot-rockchip64-edge/add-board-orangepi-r1plus.patch
+++ b/patch/u-boot/u-boot-rockchip64-edge/add-board-orangepi-r1plus.patch
@@ -1,0 +1,187 @@
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index 06ccc03e..a2657ebe 100644
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -109,6 +109,7 @@ dtb-$(CONFIG_ROCKCHIP_RK3308) += \
+ dtb-$(CONFIG_ROCKCHIP_RK3328) += \
+ 	rk3328-evb.dtb \
+ 	rk3328-nanopi-r2-rev00.dtb \
++	rk3328-orangepi-r1-plus.dtb \
+ 	rk3328-roc-cc.dtb \
+ 	rk3328-rock64.dtb \
+ 	rk3328-rock-pi-e.dtb
+diff --git a/arch/arm/dts/rk3328-orangepi-r1-plus-u-boot.dtsi b/arch/arm/dts/rk3328-orangepi-r1-plus-u-boot.dtsi
+new file mode 100644
+index 00000000..cf3452ea
+--- /dev/null
++++ b/arch/arm/dts/rk3328-orangepi-r1-plus-u-boot.dtsi
+@@ -0,0 +1,16 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * (C) Copyright 2018-2019 Rockchip Electronics Co., Ltd
++ */
++
++#include "rk3328-u-boot.dtsi"
++#include "rk3328-sdram-ddr4-666.dtsi"
++/ {
++	chosen {
++		u-boot,spl-boot-order = "same-as-spl", &sdmmc, &emmc;
++	};
++};
++
++&usb_host0_xhci {
++	status = "okay";
++};
+diff --git a/arch/arm/dts/rk3328-orangepi-r1-plus.dts b/arch/arm/dts/rk3328-orangepi-r1-plus.dts
+new file mode 100644
+index 00000000..23023ad0
+--- /dev/null
++++ b/arch/arm/dts/rk3328-orangepi-r1-plus.dts
+@@ -0,0 +1,48 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2020 Shenzhen Xunlong Software CO.,Limited
++ * Copyright (c) 2021 AmadeusGhost <amadeus@jmu.edu.cn>
++ *
++ * Based on Nanopi R2S
++ */
++
++#include "rk3328-nanopi-r2-rev00.dts"
++
++/ {
++	model = "Xunlong Orange Pi R1 Plus";
++	compatible = "xunlong,orangepi-r1-plus", "rockchip,rk3328";
++};
++
++&leds_gpio {
++	rockchip,pins =
++		<2 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>,
++		<2 RK_PC2 RK_FUNC_GPIO &pcfg_pull_none>,
++		<3 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>;
++};
++
++&leds {
++	led@1 {
++		gpios = <&gpio3 RK_PC5 GPIO_ACTIVE_HIGH>;
++	};
++};
++
++&mach {
++	compatible = "orangepi,board";
++	hwrev = <2>;
++	machine = "ORANGEPI-R1PLUS";
++	model = "OrangePi R1PLUS";
++};
++
++&spi0 {
++	status = "okay";
++
++	spiflash@0 {
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <10000000>;
++	};
++};
++
++&uart1 {
++	status = "okay";
++};
+diff --git a/configs/orangepi_r1_plus_rk3328_defconfig b/configs/orangepi_r1_plus_rk3328_defconfig
+new file mode 100644
+index 00000000..ddbe9715
+@@ -0,0 +1,95 @@
++CONFIG_ARM=y
++CONFIG_ARCH_ROCKCHIP=y
++CONFIG_SYS_TEXT_BASE=0x00200000
++CONFIG_ROCKCHIP_RK3328=y
++CONFIG_TPL_ROCKCHIP_COMMON_BOARD=y
++CONFIG_TPL_LIBCOMMON_SUPPORT=y
++CONFIG_TPL_LIBGENERIC_SUPPORT=y
++CONFIG_SPL_DRIVERS_MISC_SUPPORT=y
++CONFIG_ENV_OFFSET=0x3F8000
++CONFIG_SPL_STACK_R_ADDR=0x600000
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_DEBUG_UART_BASE=0xFF130000
++CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_SMBIOS_PRODUCT_NAME="rock64_rk3328"
++CONFIG_DEBUG_UART=y
++CONFIG_TPL_SYS_MALLOC_F_LEN=0x800
++# CONFIG_ANDROID_BOOT_IMAGE is not set
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y
++CONFIG_SPL_LOAD_FIT=y
++CONFIG_DEFAULT_FDT_FILE="rockchip/rk3328-orangepi-r1-plus.dtb"
++CONFIG_MISC_INIT_R=y
++# CONFIG_DISPLAY_CPUINFO is not set
++CONFIG_DISPLAY_BOARDINFO_LATE=y
++# CONFIG_SPL_RAW_IMAGE_SUPPORT is not set
++CONFIG_TPL_SYS_MALLOC_SIMPLE=y
++CONFIG_SPL_STACK_R=y
++CONFIG_SPL_ATF=y
++CONFIG_SPL_ATF_NO_PLATFORM_PARAM=y
++CONFIG_CMD_BOOTZ=y
++CONFIG_CMD_GPT=y
++CONFIG_CMD_MMC=y
++CONFIG_CMD_USB=y
++# CONFIG_CMD_SETEXPR is not set
++CONFIG_CMD_TIME=y
++CONFIG_SPL_OF_CONTROL=y
++CONFIG_TPL_OF_CONTROL=y
++CONFIG_DEFAULT_DEVICE_TREE="rk3328-orangepi-r1-plus"
++CONFIG_OF_SPL_REMOVE_PROPS="pinctrl-0 pinctrl-names clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
++CONFIG_TPL_OF_PLATDATA=y
++CONFIG_ENV_IS_IN_MMC=y
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_NET_RANDOM_ETHADDR=y
++CONFIG_TPL_DM=y
++CONFIG_REGMAP=y
++CONFIG_SPL_REGMAP=y
++CONFIG_TPL_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_SPL_SYSCON=y
++CONFIG_TPL_SYSCON=y
++CONFIG_CLK=y
++CONFIG_SPL_CLK=y
++CONFIG_FASTBOOT_BUF_ADDR=0x800800
++CONFIG_FASTBOOT_CMD_OEM_FORMAT=y
++CONFIG_ROCKCHIP_GPIO=y
++CONFIG_SYS_I2C_ROCKCHIP=y
++CONFIG_MMC_DW=y
++CONFIG_MMC_DW_ROCKCHIP=y
++CONFIG_SF_DEFAULT_SPEED=20000000
++CONFIG_DM_ETH=y
++CONFIG_ETH_DESIGNWARE=y
++CONFIG_GMAC_ROCKCHIP=y
++CONFIG_PHY=y
++CONFIG_PINCTRL=y
++CONFIG_SPL_PINCTRL=y
++CONFIG_DM_PMIC=y
++CONFIG_PMIC_RK8XX=y
++CONFIG_REGULATOR_PWM=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_REGULATOR_RK8XX=y
++CONFIG_PWM_ROCKCHIP=y
++CONFIG_RAM=y
++CONFIG_SPL_RAM=y
++CONFIG_TPL_RAM=y
++CONFIG_DM_RESET=y
++CONFIG_BAUDRATE=1500000
++CONFIG_DEBUG_UART_SHIFT=2
++CONFIG_SYSRESET=y
++# CONFIG_TPL_SYSRESET is not set
++CONFIG_USB=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_XHCI_DWC3=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_EHCI_GENERIC=y
++CONFIG_USB_OHCI_HCD=y
++CONFIG_USB_OHCI_GENERIC=y
++CONFIG_USB_DWC2=y
++CONFIG_USB_DWC3=y
++# CONFIG_USB_DWC3_GADGET is not set
++CONFIG_USB_GADGET=y
++CONFIG_USB_GADGET_DWC2_OTG=y
++CONFIG_SPL_TINY_MEMSET=y
++CONFIG_TPL_TINY_MEMSET=y
++CONFIG_ERRNO_STR=y
++CONFIG_SMBIOS_MANUFACTURER="pine64"

--- a/patch/u-boot/u-boot-rockchip64-mainline/add-board-orangepi-r1plus.patch
+++ b/patch/u-boot/u-boot-rockchip64-mainline/add-board-orangepi-r1plus.patch
@@ -1,0 +1,187 @@
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index 06ccc03e..a2657ebe 100644
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -109,6 +109,7 @@ dtb-$(CONFIG_ROCKCHIP_RK3308) += \
+ dtb-$(CONFIG_ROCKCHIP_RK3328) += \
+ 	rk3328-evb.dtb \
+ 	rk3328-nanopi-r2-rev00.dtb \
++	rk3328-orangepi-r1-plus.dtb \
+ 	rk3328-roc-cc.dtb \
+ 	rk3328-rock64.dtb \
+ 	rk3328-rock-pi-e.dtb
+diff --git a/arch/arm/dts/rk3328-orangepi-r1-plus-u-boot.dtsi b/arch/arm/dts/rk3328-orangepi-r1-plus-u-boot.dtsi
+new file mode 100644
+index 00000000..cf3452ea
+--- /dev/null
++++ b/arch/arm/dts/rk3328-orangepi-r1-plus-u-boot.dtsi
+@@ -0,0 +1,16 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * (C) Copyright 2018-2019 Rockchip Electronics Co., Ltd
++ */
++
++#include "rk3328-u-boot.dtsi"
++#include "rk3328-sdram-ddr4-666.dtsi"
++/ {
++	chosen {
++		u-boot,spl-boot-order = "same-as-spl", &sdmmc, &emmc;
++	};
++};
++
++&usb_host0_xhci {
++	status = "okay";
++};
+diff --git a/arch/arm/dts/rk3328-orangepi-r1-plus.dts b/arch/arm/dts/rk3328-orangepi-r1-plus.dts
+new file mode 100644
+index 00000000..23023ad0
+--- /dev/null
++++ b/arch/arm/dts/rk3328-orangepi-r1-plus.dts
+@@ -0,0 +1,48 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2020 Shenzhen Xunlong Software CO.,Limited
++ * Copyright (c) 2021 AmadeusGhost <amadeus@jmu.edu.cn>
++ *
++ * Based on Nanopi R2S
++ */
++
++#include "rk3328-nanopi-r2-rev00.dts"
++
++/ {
++	model = "Xunlong Orange Pi R1 Plus";
++	compatible = "xunlong,orangepi-r1-plus", "rockchip,rk3328";
++};
++
++&leds_gpio {
++	rockchip,pins =
++		<2 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>,
++		<2 RK_PC2 RK_FUNC_GPIO &pcfg_pull_none>,
++		<3 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>;
++};
++
++&leds {
++	led@1 {
++		gpios = <&gpio3 RK_PC5 GPIO_ACTIVE_HIGH>;
++	};
++};
++
++&mach {
++	compatible = "orangepi,board";
++	hwrev = <2>;
++	machine = "ORANGEPI-R1PLUS";
++	model = "OrangePi R1PLUS";
++};
++
++&spi0 {
++	status = "okay";
++
++	spiflash@0 {
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <10000000>;
++	};
++};
++
++&uart1 {
++	status = "okay";
++};
+diff --git a/configs/orangepi_r1_plus_rk3328_defconfig b/configs/orangepi_r1_plus_rk3328_defconfig
+new file mode 100644
+index 00000000..ddbe9715
+@@ -0,0 +1,95 @@
++CONFIG_ARM=y
++CONFIG_ARCH_ROCKCHIP=y
++CONFIG_SYS_TEXT_BASE=0x00200000
++CONFIG_ROCKCHIP_RK3328=y
++CONFIG_TPL_ROCKCHIP_COMMON_BOARD=y
++CONFIG_TPL_LIBCOMMON_SUPPORT=y
++CONFIG_TPL_LIBGENERIC_SUPPORT=y
++CONFIG_SPL_DRIVERS_MISC_SUPPORT=y
++CONFIG_ENV_OFFSET=0x3F8000
++CONFIG_SPL_STACK_R_ADDR=0x600000
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_DEBUG_UART_BASE=0xFF130000
++CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_SMBIOS_PRODUCT_NAME="rock64_rk3328"
++CONFIG_DEBUG_UART=y
++CONFIG_TPL_SYS_MALLOC_F_LEN=0x800
++# CONFIG_ANDROID_BOOT_IMAGE is not set
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y
++CONFIG_SPL_LOAD_FIT=y
++CONFIG_DEFAULT_FDT_FILE="rockchip/rk3328-orangepi-r1-plus.dtb"
++CONFIG_MISC_INIT_R=y
++# CONFIG_DISPLAY_CPUINFO is not set
++CONFIG_DISPLAY_BOARDINFO_LATE=y
++# CONFIG_SPL_RAW_IMAGE_SUPPORT is not set
++CONFIG_TPL_SYS_MALLOC_SIMPLE=y
++CONFIG_SPL_STACK_R=y
++CONFIG_SPL_ATF=y
++CONFIG_SPL_ATF_NO_PLATFORM_PARAM=y
++CONFIG_CMD_BOOTZ=y
++CONFIG_CMD_GPT=y
++CONFIG_CMD_MMC=y
++CONFIG_CMD_USB=y
++# CONFIG_CMD_SETEXPR is not set
++CONFIG_CMD_TIME=y
++CONFIG_SPL_OF_CONTROL=y
++CONFIG_TPL_OF_CONTROL=y
++CONFIG_DEFAULT_DEVICE_TREE="rk3328-orangepi-r1-plus"
++CONFIG_OF_SPL_REMOVE_PROPS="pinctrl-0 pinctrl-names clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
++CONFIG_TPL_OF_PLATDATA=y
++CONFIG_ENV_IS_IN_MMC=y
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_NET_RANDOM_ETHADDR=y
++CONFIG_TPL_DM=y
++CONFIG_REGMAP=y
++CONFIG_SPL_REGMAP=y
++CONFIG_TPL_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_SPL_SYSCON=y
++CONFIG_TPL_SYSCON=y
++CONFIG_CLK=y
++CONFIG_SPL_CLK=y
++CONFIG_FASTBOOT_BUF_ADDR=0x800800
++CONFIG_FASTBOOT_CMD_OEM_FORMAT=y
++CONFIG_ROCKCHIP_GPIO=y
++CONFIG_SYS_I2C_ROCKCHIP=y
++CONFIG_MMC_DW=y
++CONFIG_MMC_DW_ROCKCHIP=y
++CONFIG_SF_DEFAULT_SPEED=20000000
++CONFIG_DM_ETH=y
++CONFIG_ETH_DESIGNWARE=y
++CONFIG_GMAC_ROCKCHIP=y
++CONFIG_PHY=y
++CONFIG_PINCTRL=y
++CONFIG_SPL_PINCTRL=y
++CONFIG_DM_PMIC=y
++CONFIG_PMIC_RK8XX=y
++CONFIG_REGULATOR_PWM=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_REGULATOR_RK8XX=y
++CONFIG_PWM_ROCKCHIP=y
++CONFIG_RAM=y
++CONFIG_SPL_RAM=y
++CONFIG_TPL_RAM=y
++CONFIG_DM_RESET=y
++CONFIG_BAUDRATE=1500000
++CONFIG_DEBUG_UART_SHIFT=2
++CONFIG_SYSRESET=y
++# CONFIG_TPL_SYSRESET is not set
++CONFIG_USB=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_XHCI_DWC3=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_EHCI_GENERIC=y
++CONFIG_USB_OHCI_HCD=y
++CONFIG_USB_OHCI_GENERIC=y
++CONFIG_USB_DWC2=y
++CONFIG_USB_DWC3=y
++# CONFIG_USB_DWC3_GADGET is not set
++CONFIG_USB_GADGET=y
++CONFIG_USB_GADGET_DWC2_OTG=y
++CONFIG_SPL_TINY_MEMSET=y
++CONFIG_TPL_TINY_MEMSET=y
++CONFIG_ERRNO_STR=y
++CONFIG_SMBIOS_MANUFACTURER="pine64"


### PR DESCRIPTION
# Description

Hi, this commit add basic support for Orange Pi R1 Plus. This machine is so similar to nano-pi r2s, so I quoted the dts of r2s. 
Everything looks good to me, except the lan/wan led. Also, I tested r2s and the lan/wan led did not work normally.
Maybe it’s a good idea to write the gpio of lan/wan led into dts and use netdev to trigger?

# How Has This Been Tested?

- [x] Test in my machine: 

dmesg: https://paste.ubuntu.com/p/Sytpz2nfqz

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
