### PR TITLE
Add support Mint 20.1 ulyssa.

### DIFF
--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1020,7 +1020,7 @@ prepare_host()
 	local codename=$(lsb_release -sc)
 
 	# Add support for Ubuntu 20.04, 21.04 and Mint Ulyana
-	if [[ $codename =~ ^(focal|groovy|hirsute|ulyana|bullseye)$ ]]; then
+	if [[ $codename =~ ^(focal|groovy|hirsute|ulyana|ulyssa|bullseye)$ ]]; then
 		hostdeps+=" python2 python3"
 		ln -fs /usr/bin/python2.7 /usr/bin/python2
 		ln -fs /usr/bin/python2.7 /usr/bin/python
@@ -1035,7 +1035,7 @@ prepare_host()
 	#
 	# NO_HOST_RELEASE_CHECK overrides the check for a supported host system
 	# Disable host OS check at your own risk. Any issues reported with unsupported releases will be closed without discussion
-	if [[ -z $codename || "buster bullseye groovy focal hirsute debbie tricia ulyana" != *"$codename"* ]]; then
+	if [[ -z $codename || "buster bullseye groovy focal hirsute debbie tricia ulyana ulyssa" != *"$codename"* ]]; then
 		if [[ $NO_HOST_RELEASE_CHECK == yes ]]; then
 			display_alert "You are running on an unsupported system" "${codename:-(unknown)}" "wrn"
 			display_alert "Do not report any errors, warnings or other issues encountered beyond this point" "" "wrn"
@@ -1051,7 +1051,7 @@ prepare_host()
 # build aarch64
   if [[ $(dpkg --print-architecture) == amd64 ]]; then
 
-	if [[ -z $codename || $codename =~ ^(focal|groovy|debbie|buster|bullseye|hirsute|ulyana)$ ]]; then
+	if [[ -z $codename || $codename =~ ^(focal|groovy|debbie|buster|bullseye|hirsute|ulyana|ulyssa)$ ]]; then
 	    hostdeps="${hostdeps/lib32ncurses5 lib32tinfo5/lib32ncurses6 lib32tinfo6}"
 	fi
 


### PR DESCRIPTION
I upgraded my Mint system, so I modified the "lib/general.sh" script so that it can be compiled on my laptop.
Compile output:
```bash
[ o.k. ] Done building [ /path/to/build/output/images/Armbian_21.05.0-trunk_Nanopiair_focal_current_5.10.21.img ]
[ o.k. ] Runtime [ 65 min ]
[ o.k. ] Repeat Build Options [ ./compile.sh  BOARD=nanopiair BRANCH=current RELEASE=focal BUILD_MINIMAL=no BUILD_DESKTOP=no KERNEL_ONLY=no KERNEL_CONFIGURE=no COMPRESS_OUTPUTIMAGE=sha,gpg,img  ]
```