### PR TITLE
fix extlinux.conf for u-boot dtb and add arm32

### DIFF
--- a/config/sources/arm64.conf
+++ b/config/sources/arm64.conf
@@ -1,3 +1,5 @@
+NAME_KERNEL="Image"
+NAME_INITRD="uInitrd"
 MAIN_CMDLINE="rootflags=data=writeback rw no_console_suspend consoleblank=0 fsck.fix=yes fsck.repair=yes net.ifnames=0 bootsplash.bootfile=bootsplash.armbian"
 INITRD_ARCH=arm64
 QEMU_BINARY="qemu-aarch64-static"

--- a/config/sources/armhf.conf
+++ b/config/sources/armhf.conf
@@ -1,3 +1,6 @@
+NAME_KERNEL="zImage"
+NAME_INITRD="uInitrd"
+MAIN_CMDLINE="rootflags=data=writeback rw no_console_suspend consoleblank=0 fsck.fix=yes fsck.repair=yes net.ifnames=0 bootsplash.bootfile=bootsplash.armbian"
 INITRD_ARCH=arm
 QEMU_BINARY="qemu-arm-static"
 ARCHITECTURE=arm

--- a/lib/distributions.sh
+++ b/lib/distributions.sh
@@ -171,11 +171,14 @@ install_common()
 		mkdir -p $SDCARD/boot/extlinux
 		cat <<-EOF > "$SDCARD/boot/extlinux/extlinux.conf"
 		LABEL Armbian
-		  LINUX /boot/Image
-		  INITRD /boot/uInitrd
-		  FDT /boot/dtb/$BOOT_FDT_FILE
+		  LINUX /boot/$NAME_KERNEL
+		  INITRD /boot/$NAME_INITRD
 	EOF
-
+		if [[ -n $BOOT_FDT_FILE ]]; then
+			echo "  FDT /boot/dtb/$BOOT_FDT_FILE" >> "$SDCARD/boot/extlinux/extlinux.conf"
+		else
+			echo "  FDTDIR /boot/dtb/" >> "$SDCARD/boot/extlinux/extlinux.conf"
+		fi
 	else
 
 		if [ -f "${USERPATCHES_PATH}/bootscripts/${bootscript_src}" ]; then


### PR DESCRIPTION
Adding support for armhf versions (tested for rk3188 rk3288). Adds support for automatically using the DTB name to start the kernel, which is set in the u-boot itself. If a variable is not set in the BOARD.CONF file, the dtb name from u-boot is used. I checked, it works correctly.
