### PR TITLE
Renaming the BSP package to armbian-bsp

### DIFF
--- a/lib/distributions.sh
+++ b/lib/distributions.sh
@@ -292,7 +292,7 @@ install_common()
 
 	# install board support packages
 	if [[ "${REPOSITORY_INSTALL}" != *bsp* ]]; then
-		install_deb_chroot "${DEB_STORAGE}/$RELEASE/${CHOSEN_ROOTFS}_${REVISION}_${ARCH}.deb" >> "${DEST}"/debug/install.log 2>&1
+		install_deb_chroot "${DEB_STORAGE}/$RELEASE/${BSP_CLI_PACKAGE_FULLNAME}.deb" >> "${DEST}"/debug/install.log 2>&1
 	else
 		install_deb_chroot "${CHOSEN_ROOTFS}" "remote"
 	fi

--- a/lib/main.sh
+++ b/lib/main.sh
@@ -392,13 +392,15 @@ BOOTSOURCEDIR="${BOOTDIR}/$(branch2dir "${BOOTBRANCH}")"
 LINUXSOURCEDIR="${KERNELDIR}/$(branch2dir "${KERNELBRANCH}")"
 [[ -n $ATFSOURCE ]] && ATFSOURCEDIR="${ATFDIR}/$(branch2dir "${ATFBRANCH}")"
 
+BSP_CLI_PACKAGE_NAME="armbian-bsp-cli-${BOARD}"
+BSP_CLI_PACKAGE_FULLNAME="${BSP_CLI_PACKAGE_NAME}_${ARCH}"
 # define package names
 DEB_BRANCH=${BRANCH//default}
 # if not empty, append hyphen
 DEB_BRANCH=${DEB_BRANCH:+${DEB_BRANCH}-}
 CHOSEN_UBOOT=linux-u-boot-${DEB_BRANCH}${BOARD}
 CHOSEN_KERNEL=linux-image-${DEB_BRANCH}${LINUXFAMILY}
-CHOSEN_ROOTFS=linux-${RELEASE}-root-${DEB_BRANCH}${BOARD}
+CHOSEN_ROOTFS=${BSP_CLI_PACKAGE_NAME}
 CHOSEN_DESKTOP=armbian-${RELEASE}-desktop-${DESKTOP_ENVIRONMENT}
 CHOSEN_KSRC=linux-source-${BRANCH}-${LINUXFAMILY}
 
@@ -492,7 +494,7 @@ fi
 overlayfs_wrapper "cleanup"
 
 # create board support package
-[[ -n $RELEASE && ! -f ${DEB_STORAGE}/$RELEASE/${CHOSEN_ROOTFS}_${REVISION}_${ARCH}.deb ]] && create_board_package
+[[ -n $RELEASE && ! -f ${DEB_STORAGE}/$RELEASE/${BSP_CLI_PACKAGE_FULLNAME}.deb ]] && create_board_package
 
 # create desktop package
 [[ -n $RELEASE && $DESKTOP_ENVIRONMENT && ! -f ${DEB_STORAGE}/$RELEASE/${CHOSEN_DESKTOP}_${REVISION}_all.deb ]] && create_desktop_package

--- a/lib/main.sh
+++ b/lib/main.sh
@@ -393,7 +393,7 @@ LINUXSOURCEDIR="${KERNELDIR}/$(branch2dir "${KERNELBRANCH}")"
 [[ -n $ATFSOURCE ]] && ATFSOURCEDIR="${ATFDIR}/$(branch2dir "${ATFBRANCH}")"
 
 BSP_CLI_PACKAGE_NAME="armbian-bsp-cli-${BOARD}"
-BSP_CLI_PACKAGE_FULLNAME="${BSP_CLI_PACKAGE_NAME}_${ARCH}"
+BSP_CLI_PACKAGE_FULLNAME="${BSP_CLI_PACKAGE_NAME}_${REVISION}_${ARCH}"
 # define package names
 DEB_BRANCH=${BRANCH//default}
 # if not empty, append hyphen

--- a/lib/makeboarddeb.sh
+++ b/lib/makeboarddeb.sh
@@ -61,14 +61,7 @@ create_board_package()
 	Provides: armbian-bsp
 	Conflicts: armbian-bsp
 	Suggests: armbian-config
-	Replaces: zram-config, base-files, armbian-tools-$RELEASE, \
-	linux-xenial-root-legacy-$BOARD, linux-xenial-root-current-$BOARD, linux-xenial-root-edge-$BOARD, \
-	linux-bionic-root-legacy-$BOARD, linux-bionic-root-current-$BOARD, linux-bionic-root-edge-$BOARD, \
-	linux-focal-root-legacy-$BOARD, linux-focal-root-current-$BOARD, linux-focal-root-edge-$BOARD, \
-	linux-stretch-root-legacy-$BOARD, linux-stretch-root-current-$BOARD, linux-stretch-root-edge-$BOARD, \
-	linux-buster-root-legacy-$BOARD, linux-buster-root-current-$BOARD, linux-buster-root-edge-$BOARD, \
-	linux-bullseye-root-legacy-$BOARD, linux-bullseye-root-current-$BOARD, linux-bullseye-root-edge-$BOARD, \
-	linux-hirsute-root-legacy-$BOARD, linux-hirsute-root-current-$BOARD, linux-hirsute-root-edge-$BOARD
+	Replaces: zram-config, base-files, armbian-tools-$RELEASE
 	Recommends: bsdutils, parted, util-linux, toilet
 	Description: Tweaks for Armbian $RELEASE on $BOARD
 	EOF
@@ -129,9 +122,6 @@ create_board_package()
 	[ -f "/lib/systemd/system/resize2fs.service" ] && rm /lib/systemd/system/resize2fs.service
 	[ -f "/usr/lib/armbian/apt-updates" ] && rm /usr/lib/armbian/apt-updates
 	[ -f "/usr/lib/armbian/firstrun-config.sh" ] && rm /usr/lib/armbian/firstrun-config.sh
-	# fix for https://bugs.launchpad.net/ubuntu/+source/lightdm-gtk-greeter/+bug/1897491
-	[ -d "/var/lib/lightdm" ] && (chown -R lightdm:lightdm /var/lib/lightdm ; chmod 0750 /var/lib/lightdm)
-	dpkg-divert --quiet --package ${BSP_CLI_PACKAGE_NAME} --add --rename --divert /etc/mpv/mpv-dist.conf /etc/mpv/mpv.conf
 	exit 0
 	EOF
 
@@ -142,7 +132,6 @@ create_board_package()
 	#!/bin/sh
 	if [ remove = "\$1" ] || [ abort-install = "\$1" ]; then
 
-	    dpkg-divert --quiet --package ${BSP_CLI_PACKAGE_NAME} --remove --rename	--divert /etc/mpv/mpv-dist.conf /etc/mpv/mpv.conf
 	    systemctl disable armbian-hardware-monitor.service armbian-hardware-optimize.service >/dev/null 2>&1
 	    systemctl disable armbian-zram-config.service armbian-ramlog.service >/dev/null 2>&1
 
@@ -331,6 +320,25 @@ fi
 	fakeroot dpkg-deb -b "${destination}" "${destination}.deb" >> "${DEST}"/debug/install.log 2>&1
 	mkdir -p "${DEB_STORAGE}/${RELEASE}/"
 	rsync --remove-source-files -rq "${destination}.deb" "${DEB_STORAGE}/${RELEASE}/"
+
+	# Can be removed after 21.05
+	# create meta package for upgrade
+	local destination=${bsptempdir}/${RELEASE}/linux-${RELEASE}-root-${DEB_BRANCH}${BOARD}_${REVISION}_${ARCH}
+	mkdir -p "${destination}"/DEBIAN
+	cat <<-EOF > "${destination}"/DEBIAN/control
+	Package: linux-${RELEASE}-root-${DEB_BRANCH}${BOARD}
+	Version: $REVISION
+	Architecture: $ARCH
+	Maintainer: $MAINTAINER <$MAINTAINERMAIL>
+	Pre-Depends: ${BSP_CLI_PACKAGE_NAME}
+	Description: Meta package that upgrades to ${BSP_CLI_PACKAGE_NAME}
+	EOF
+	display_alert "Building meta  package" "$CHOSEN_ROOTFS" "info"
+	fakeroot dpkg-deb -b "${destination}" "${destination}.deb" >> "${DEST}"/debug/install.log 2>&1
+	mkdir -p "${DEB_STORAGE}/${RELEASE}/"
+	rsync --remove-source-files -rq "${destination}.deb" "${DEB_STORAGE}/${RELEASE}/"
+	# Can be removed after 21.05
+
 	# cleanup
 	rm -rf ${bsptempdir}
 }

--- a/lib/makeboarddeb.sh
+++ b/lib/makeboarddeb.sh
@@ -20,7 +20,7 @@ create_board_package()
 	bsptempdir=$(mktemp -d)
 	chmod 700 ${bsptempdir}
 	trap "rm -rf \"${bsptempdir}\" ; exit 0" 0 1 2 3 15
-	local destination=${bsptempdir}/${RELEASE}/${CHOSEN_ROOTFS}_${REVISION}_${ARCH}
+	local destination=${bsptempdir}/${RELEASE}/${BSP_CLI_PACKAGE_FULLNAME}
 	mkdir -p "${destination}"/DEBIAN
 	cd $destination
 
@@ -50,7 +50,7 @@ create_board_package()
 	# Depends: linux-base is needed for "linux-version" command in initrd cleanup script
 	# Depends: fping is needed for armbianmonitor to upload armbian-hardware-monitor.log
 	cat <<-EOF > "${destination}"/DEBIAN/control
-	Package: linux-${RELEASE}-root-${DEB_BRANCH}${BOARD}
+	Package: ${BSP_CLI_PACKAGE_NAME}
 	Version: $REVISION
 	Architecture: $ARCH
 	Maintainer: $MAINTAINER <$MAINTAINERMAIL>
@@ -61,9 +61,16 @@ create_board_package()
 	Provides: armbian-bsp
 	Conflicts: armbian-bsp
 	Suggests: armbian-config
-	Replaces: zram-config, base-files, armbian-tools-$RELEASE
+	Replaces: zram-config, base-files, armbian-tools-$RELEASE, \
+	linux-xenial-root-legacy-$BOARD, linux-xenial-root-current-$BOARD, linux-xenial-root-edge-$BOARD, \
+	linux-bionic-root-legacy-$BOARD, linux-bionic-root-current-$BOARD, linux-bionic-root-edge-$BOARD, \
+	linux-focal-root-legacy-$BOARD, linux-focal-root-current-$BOARD, linux-focal-root-edge-$BOARD, \
+	linux-stretch-root-legacy-$BOARD, linux-stretch-root-current-$BOARD, linux-stretch-root-edge-$BOARD, \
+	linux-buster-root-legacy-$BOARD, linux-buster-root-current-$BOARD, linux-buster-root-edge-$BOARD, \
+	linux-bullseye-root-legacy-$BOARD, linux-bullseye-root-current-$BOARD, linux-bullseye-root-edge-$BOARD, \
+	linux-hirsute-root-legacy-$BOARD, linux-hirsute-root-current-$BOARD, linux-hirsute-root-edge-$BOARD
 	Recommends: bsdutils, parted, util-linux, toilet
-	Description: Armbian tweaks for $RELEASE on $BOARD ($BRANCH branch)
+	Description: Armbian tweaks for $BOARD
 	EOF
 
 	# set up pre install script
@@ -124,7 +131,7 @@ create_board_package()
 	[ -f "/usr/lib/armbian/firstrun-config.sh" ] && rm /usr/lib/armbian/firstrun-config.sh
 	# fix for https://bugs.launchpad.net/ubuntu/+source/lightdm-gtk-greeter/+bug/1897491
 	[ -d "/var/lib/lightdm" ] && (chown -R lightdm:lightdm /var/lib/lightdm ; chmod 0750 /var/lib/lightdm)
-	dpkg-divert --quiet --package linux-${RELEASE}-root-${DEB_BRANCH}${BOARD} --add --rename --divert /etc/mpv/mpv-dist.conf /etc/mpv/mpv.conf
+	dpkg-divert --quiet --package ${BSP_CLI_PACKAGE_NAME} --add --rename --divert /etc/mpv/mpv-dist.conf /etc/mpv/mpv.conf
 	exit 0
 	EOF
 
@@ -135,7 +142,7 @@ create_board_package()
 	#!/bin/sh
 	if [ remove = "\$1" ] || [ abort-install = "\$1" ]; then
 
-	    dpkg-divert --quiet --package linux-${RELEASE}-root-${DEB_BRANCH}${BOARD} --remove --rename	--divert /etc/mpv/mpv-dist.conf /etc/mpv/mpv.conf
+	    dpkg-divert --quiet --package ${BSP_CLI_PACKAGE_NAME} --remove --rename	--divert /etc/mpv/mpv-dist.conf /etc/mpv/mpv.conf
 	    systemctl disable armbian-hardware-monitor.service armbian-hardware-optimize.service >/dev/null 2>&1
 	    systemctl disable armbian-zram-config.service armbian-ramlog.service >/dev/null 2>&1
 

--- a/lib/makeboarddeb.sh
+++ b/lib/makeboarddeb.sh
@@ -70,7 +70,7 @@ create_board_package()
 	linux-bullseye-root-legacy-$BOARD, linux-bullseye-root-current-$BOARD, linux-bullseye-root-edge-$BOARD, \
 	linux-hirsute-root-legacy-$BOARD, linux-hirsute-root-current-$BOARD, linux-hirsute-root-edge-$BOARD
 	Recommends: bsdutils, parted, util-linux, toilet
-	Description: Armbian tweaks for $BOARD
+	Description: Tweaks for Armbian $RELEASE on $BOARD
 	EOF
 
 	# set up pre install script


### PR DESCRIPTION
Extracted from https://github.com/armbian/build/pull/2776

# Description

We don't need to keep board support packages for each branch and we don't need release name in the package. A cleanup and preparation for adding a desktop BSP variant, which will contain board specific desktop files.

Jira reference number [AR-596]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] package is being built
- [x] create and test meta package for automated upgrade

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Adjust armbian-config if necessary (no need since meta package does that for us)


[AR-596]: https://armbian.atlassian.net/browse/AR-596