### PR TITLE
copy hostdev libfdt-dev compatibility patch, fixes odroidn2

### DIFF
--- a/patch/u-boot/u-boot-odroid/fix_build_for_recent_host-side_libfdt.patch
+++ b/patch/u-boot/u-boot-odroid/fix_build_for_recent_host-side_libfdt.patch
@@ -1,0 +1,55 @@
+From 001bcba84e1f3ad0f605e5a9bb2fb5cb0e9c605d Mon Sep 17 00:00:00 2001
+From: Hugo Grostabussiat <bonstra@bonstra.fr.eu.org>
+Date: Fri, 11 Jan 2019 21:33:19 +0100
+Subject: [PATCH] tools: fix build for recent host-side libfdt
+
+Recent versions of libfdt removed the _ prefix in the header guards,
+causing clashes with the libfdt version embedded in U-boot source tree.
+---
+ include/fdt.h        | 3 ++-
+ include/libfdt.h     | 3 ++-
+ include/libfdt_env.h | 3 ++-
+ 3 files changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/include/fdt.h b/include/fdt.h
+index 526aedb515..3dd42971eb 100644
+--- a/include/fdt.h
++++ b/include/fdt.h
+@@ -1,5 +1,6 @@
+-#ifndef _FDT_H
++#if !defined(_FDT_H) && !defined(FDT_H)
+ #define _FDT_H
++#define FDT_H
+ /*
+  * libfdt - Flat Device Tree manipulation
+  * Copyright (C) 2006 David Gibson, IBM Corporation.
+diff --git a/include/libfdt.h b/include/libfdt.h
+index e2bc2e00c1..9d0d4b98ea 100644
+--- a/include/libfdt.h
++++ b/include/libfdt.h
+@@ -1,5 +1,6 @@
+-#ifndef _LIBFDT_H
++#if !defined(_LIBFDT_H) && !defined(LIBFDT_H)
+ #define _LIBFDT_H
++#define LIBFDT_H
+ /*
+  * libfdt - Flat Device Tree manipulation
+  * Copyright (C) 2006 David Gibson, IBM Corporation.
+diff --git a/include/libfdt_env.h b/include/libfdt_env.h
+index 6c6845f76c..216e5c6fa1 100644
+--- a/include/libfdt_env.h
++++ b/include/libfdt_env.h
+@@ -6,8 +6,9 @@
+  * SPDX-License-Identifier:	LGPL-2.1+
+  */
+ 
+-#ifndef _LIBFDT_ENV_H
++#if !defined(_LIBFDT_ENV_H) && !defined(LIBFDT_ENV_H)
+ #define _LIBFDT_ENV_H
++#define LIBFDT_ENV_H
+ 
+ #include "compiler.h"
+ #include "linux/types.h"
+-- 
+GitLab
+


### PR DESCRIPTION
Signed-off-by: Ricardo Pardini <ricardo@pardini.net>

# Description

#2773 fixes host-side libfdt-dev incompatibilities for the xu4 board. This just copies the patch so it also affects odroidn2.

# How Has This Been Tested?

- [x] Install libfdt-dev host-side (done automatically by build)
- [x] Build with the patch
- [x] Resulting build works

