### PR TITLE
Proper fix for locking desktop wallpaper

### DIFF
--- a/config/desktop/focal/environments/budgie/debian/postinst
+++ b/config/desktop/focal/environments/budgie/debian/postinst
@@ -6,6 +6,12 @@ if [ -f /etc/pulse/default.pa ]; then sed "s/load-module module-udev-detect$/& t
 
 # set wallpapper to armbian
 
+keys=/etc/dconf/db/local.d/00-bg
+profile=/etc/dconf/profile/user
+
+install -Dv /dev/null $keys
+install -Dv /dev/null $profile
+
 echo "[org/budgie/desktop/background]
 picture-uri='file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'
 picture-options='zoom'
@@ -17,16 +23,6 @@ picture-uri='file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-bl
 picture-options='zoom'
 primary-color='#456789'
 secondary-color='#FFFFFF'" >> $keys
-
-echo "/org/budgie/desktop/background/picture-uri
-/org/budgie/desktop/background/picture-options
-/org/budgie/desktop/background/primary-color
-/org/budgie/desktop/background/secondary-color
-
-/org/budgie/desktop/screensaver/picture-uri
-/org/budgie/desktop/screensaver/picture-options
-/org/budgie/desktop/screensaver/primary-color
-/org/budgie/desktop/screensaver/secondary-color" >> $locks
 
 echo "user-db:user
 system-db:local" >> $profile

--- a/config/desktop/focal/environments/cinnamon/debian/postinst
+++ b/config/desktop/focal/environments/cinnamon/debian/postinst
@@ -6,6 +6,12 @@ if [ -f /etc/pulse/default.pa ]; then sed "s/load-module module-udev-detect$/& t
 
 # set wallpapper to armbian
 
+keys=/etc/dconf/db/local.d/00-bg
+profile=/etc/dconf/profile/user
+
+install -Dv /dev/null $keys
+install -Dv /dev/null $profile
+
 echo "[org/cinnamon/desktop/background]
 picture-uri='file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'
 picture-options='zoom'
@@ -17,16 +23,6 @@ picture-uri='file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-bl
 picture-options='zoom'
 primary-color='#456789'
 secondary-color='#FFFFFF'" >> $keys
-
-echo "/org/cinnamon/desktop/background/picture-uri
-/org/cinnamon/desktop/background/picture-options
-/org/cinnamon/desktop/background/primary-color
-/org/cinnamon/desktop/background/secondary-color
-
-/org/cinnamon/desktop/screensaver/picture-uri
-/org/cinnamon/desktop/screensaver/picture-options
-/org/cinnamon/desktop/screensaver/primary-color
-/org/cinnamon/desktop/screensaver/secondary-color" >> $locks
 
 echo "user-db:user
 system-db:local" >> $profile

--- a/config/desktop/focal/environments/gnome/debian/postinst
+++ b/config/desktop/focal/environments/gnome/debian/postinst
@@ -5,6 +5,11 @@ if [ -d /etc/armbian/lightdm ]; then cp -R /etc/armbian/lightdm /etc/; fi
 if [ -f /etc/pulse/default.pa ]; then sed "s/load-module module-udev-detect$/& tsched=0/g" -i  /etc/pulse/default.pa; fi
 
 # set wallpapper to armbian
+keys=/etc/dconf/db/local.d/00-bg
+profile=/etc/dconf/profile/user
+
+install -Dv /dev/null $keys
+install -Dv /dev/null $profile
 
 echo "[org/gnome/desktop/background]
 picture-uri='file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'
@@ -17,16 +22,6 @@ picture-uri='file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-bl
 picture-options='zoom'
 primary-color='#456789'
 secondary-color='#FFFFFF'" >> $keys
-
-echo "/org/gnome/desktop/background/picture-uri
-/org/gnome/desktop/background/picture-options
-/org/gnome/desktop/background/primary-color
-/org/gnome/desktop/background/secondary-color
-
-/org/gnome/desktop/screensaver/picture-uri
-/org/gnome/desktop/screensaver/picture-options
-/org/gnome/desktop/screensaver/primary-color
-/org/gnome/desktop/screensaver/secondary-color" >> $locks
 
 echo "user-db:user
 system-db:local" >> $profile

--- a/config/desktop/focal/environments/mate/debian/postinst
+++ b/config/desktop/focal/environments/mate/debian/postinst
@@ -6,6 +6,12 @@ if [ -f /etc/pulse/default.pa ]; then sed "s/load-module module-udev-detect$/& t
 
 # set wallpapper to armbian
 
+keys=/etc/dconf/db/local.d/00-bg
+profile=/etc/dconf/profile/user
+
+install -Dv /dev/null $keys
+install -Dv /dev/null $profile
+
 echo "[org/mate/desktop/background]
 picture-filename='/usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'
 picture-options='zoom'
@@ -17,16 +23,6 @@ picture-filename='/usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-blur
 picture-options='zoom'
 primary-color='#456789'
 secondary-color='#FFFFFF'" >> $keys
-
-echo "/org/mate/desktop/background/picture-filename
-/org/mate/desktop/background/picture-options
-/org/mate/desktop/background/primary-color
-/org/mate/desktop/background/secondary-color
-
-/org/mate/screensaver/picture-filename
-/org/mate/screensaver/picture-options
-/org/mate/screensaver/primary-color
-/org/mate/screensaver/secondary-color" >> $locks
 
 echo "user-db:user
 system-db:local" >> $profile


### PR DESCRIPTION
# Description

When we have fixing wallpaper lock, too much things was removed which resulted in broken postinst script.

# How Has This Been Tested?

- [x] Build gnome desktop 
- [x] Build mate desktop 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

[AR-674]: https://armbian.atlassian.net/browse/AR-674