### PR TITLE
Unlock Hirsute

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ build tools</h3>
 ## What do you need to get started?
     
 - x64 machine with at least 2GB of memory and ~35GB of disk space for a VM, container or native OS,
-- Ubuntu Focal 20.04 x64 for native building or any [Docker](https://docs.armbian.com/Developer-Guide_Building-with-Docker/) capable x64 Linux for containerised,
+- Ubuntu Hirsute 21.04 x64 for native building or any [Docker](https://docs.armbian.com/Developer-Guide_Building-with-Docker/) capable x64 Linux for containerised,
 - superuser rights (configured sudo or root access).
 
 <p align=right><a href=#table-of-contents>⇧</a></p>

--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ build tools</h3>
     
 - x64 machine with at least 2GB of memory and ~35GB of disk space for a VM, container or native OS,
 - Ubuntu Hirsute 21.04 x64 for native building or any [Docker](https://docs.armbian.com/Developer-Guide_Building-with-Docker/) capable x64 Linux for containerised,
+  - Hirsuite is required for newer non-LTS releases.. ex: Bullseye, Sid, Groovy, Hirsuite
+  - If building for LTS releases.. ex: focal, bionic, buster, It is possible to use Ubuntu 20.04 Focal, but is not supported.
 - superuser rights (configured sudo or root access).
+
 
 <p align=right><a href=#table-of-contents>⇧</a></p>
 

--- a/config/distributions/hirsute/support
+++ b/config/distributions/hirsute/support
@@ -1,1 +1,1 @@
-csc
+supported

--- a/config/templates/Dockerfile
+++ b/config/templates/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:21.04
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
# Description

Hirsute is due for release tomorrow. Also for building it or Sid / Bullseye we need it.

Resolves #2787 

Jira reference number [AR-732]

# How Has This Been Tested?

- [x] Build native hirsute
- [ ] Build under Docker (broken [due bug](https://stackoverflow.com/questions/66319610/gpg-error-in-ubuntu-21-04-after-second-apt-get-update-during-docker-build))

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-732]: https://armbian.atlassian.net/browse/AR-732