### PR TITLE
Sprinkle some custom hooks in multiple key moments during build.

### DIFF
--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -123,6 +123,9 @@ fi
 # load architecture defaults
 source "${SRC}/config/sources/${ARCH}.conf"
 
+# give the config a chance to override the family/arch defaults
+[[ $(type -t config_tweaks_post_family_config) == function ]] && config_tweaks_post_family_config
+
 # Myy : Menu configuration for choosing desktop configurations
 
 show_menu() {
@@ -534,6 +537,7 @@ if [[ -f $USERPATCHES_PATH/lib.config ]]; then
 	source "$USERPATCHES_PATH"/lib.config
 fi
 
+# For user override, using a function.
 if [[ "$(type -t user_config)" == "function" ]]; then
 	display_alert "Invoke function with user override" "user_config" "info"
 	user_config
@@ -602,6 +606,12 @@ display_alert "PACKAGE_LIST : \"${PACKAGE_LIST}\"" >> "${DEST}"/debug/output.log
 
 # Give the option to configure DNS server used in the chroot during the build process
 [[ -z $NAMESERVER ]] && NAMESERVER="1.0.0.1" # default is cloudflare alternate
+
+# For final user override, using a function, after all aggregations are done.
+if [[ "$(type -t user_config_post_aggregate_packages)" == "function" ]]; then
+	display_alert "Invoke function with user override" "user_config_post_aggregate_packages" "info"
+	user_config_post_aggregate_packages
+fi
 
 # debug
 cat <<-EOF >> "${DEST}"/debug/output.log

--- a/lib/distributions.sh
+++ b/lib/distributions.sh
@@ -289,6 +289,9 @@ install_common()
 		install_deb_chroot "linux-dtb-${BRANCH}-${LINUXFAMILY}" "remote"
 		[[ $INSTALL_HEADERS == yes ]] && install_deb_chroot "linux-headers-${BRANCH}-${LINUXFAMILY}" "remote"
 	fi
+	
+	# hook, allow config to do more with the installed kernel/headers
+	[[ $(type -t config_post_install_kernel_debs) == function ]] && config_post_install_kernel_debs
 
 	# install board support packages
 	if [[ "${REPOSITORY_INSTALL}" != *bsp* ]]; then
@@ -667,5 +670,8 @@ post_debootstrap_tweaks()
 	chroot "${SDCARD}" /bin/bash -c "dpkg-divert --quiet --local --rename --remove /sbin/initctl"
 	chroot "${SDCARD}" /bin/bash -c "dpkg-divert --quiet --local --rename --remove /sbin/start-stop-daemon"
 	rm -f "${SDCARD}"/usr/sbin/policy-rc.d "${SDCARD}/usr/bin/${QEMU_BINARY}"
+
+	# delegate back to config
+	[[ $(type -t config_post_debootstrap_tweaks) == function ]] && config_post_debootstrap_tweaks
 
 }

--- a/lib/image-helpers.sh
+++ b/lib/image-helpers.sh
@@ -108,6 +108,10 @@ customize_image()
 {
 	# for users that need to prepare files at host
 	[[ -f $USERPATCHES_PATH/customize-image-host.sh ]] && source "$USERPATCHES_PATH"/customize-image-host.sh
+
+	# let user customize further via function
+	[[ $(type -t image_tweaks_pre_customize) == function ]] && image_tweaks_pre_customize
+
 	cp "$USERPATCHES_PATH"/customize-image.sh "${SDCARD}"/tmp/customize-image.sh
 	chmod +x "${SDCARD}"/tmp/customize-image.sh
 	mkdir -p "${SDCARD}"/tmp/overlay
@@ -121,6 +125,10 @@ customize_image()
 	if [[ $CUSTOMIZE_IMAGE_RC != 0 ]]; then
 		exit_with_error "customize-image.sh exited with error (rc: $CUSTOMIZE_IMAGE_RC)"
 	fi
+
+	# let user customize further, out of the chroot.
+	[[ $(type -t image_tweaks_post_customize) == function ]] && image_tweaks_post_customize
+
 } #############################################################################
 
 install_deb_chroot()

--- a/lib/main.sh
+++ b/lib/main.sh
@@ -376,6 +376,9 @@ else
 
 fi
 
+# give config a chance modify CTHREADS programatically. A build server may work beter with hyperthreads-1 for example.
+[[ $(type -t config_post_determine_cthreads) == function ]] && config_post_determine_cthreads
+
 if [[ $BETA == yes ]]; then
 	IMAGE_TYPE=nightly
 elif [[ $BETA != "yes" && $BUILD_ALL == yes && -n $GPG_PASS ]]; then

--- a/lib/makeboarddeb.sh
+++ b/lib/makeboarddeb.sh
@@ -307,6 +307,9 @@ fi
 	# execute $LINUXFAMILY-specific tweaks
 	[[ $(type -t family_tweaks_bsp) == function ]] && family_tweaks_bsp
 
+	# family_tweaks_bsp overrrides what is in the config, so give it a chance to override the family tweaks
+	[[ $(type -t config_tweaks_bsp) == function ]] && config_tweaks_bsp
+
 	# add some summary to the image
 	fingerprint_image "${destination}/etc/armbian.txt"
 


### PR DESCRIPTION
These allow for more substantial changes to the build in a custom configuration (`userpatches/config-xxx.conf`), without having to change Armbian sources. Essentially it allows for more customization points (using functions). It should be safe, eg, every hook point tests for the existence of the hook function before calling it.
Having written those around 6 months ago and  having done countless rebasing, I'm trying to offload them unto upstream.

Some possible uses:
- Override family-set values without changing family/include
- Replacing the onboarding process (eg, with `cloud-init`)
- Replacing NetworkManager with netplan
- Preconfiguring zram, zswap and some services
- Customizing the BSP package contents
- Dynamic calculation of image size
- Capturing the rootfs as an e2image dump for fast flashing
- Copy kernel-headers .deb to rootfs, but don't install it

Signed-off-by: Ricardo Pardini <ricardo@pardini.net>

## Examples of usage

Mostly a mess, but some examples of usage can be seen on https://github.com/rpardini/armbian-build/tree/rpardini-stable/userpatches - for example:
- https://github.com/rpardini/armbian-build/blob/rpardini-stable/userpatches/config-rpardini-hc4.conf
It uses a naive/hardcoded "fragment" composition using function calls, but this will soon be replaced by a module/fragment auto-aggregator (since bash lends itself so well to this kind of thing ;-) )
This is most definitely not ready for merging yet -- probably not even for review.

Hope this is enough to warrant a merge, thanks

