### PR TITLE
Fix broken Docker support

### DIFF
--- a/.github/workflows/build-and-upload-docker-image-to-hub.yml
+++ b/.github/workflows/build-and-upload-docker-image-to-hub.yml
@@ -1,20 +1,9 @@
 name: Docker build tests
-# This workflow is triggered every day at 2am
+# This workflow is triggered 1st, 16th and 31st
 on:
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '0 0 */15 * *'
 jobs:
-  build_on_bionic:
-    name: "PUB: sunxi u-boot Docker Bionic"
-    runs-on: ubuntu-18.04
-    steps:
-     - uses: actions/checkout@v1
-     - name: Build Docker image
-       shell: bash {0}
-       run: |
-        sed -i "s/-it --rm/-i --rm/" config/templates/config-docker.conf
-        touch .ignore_changes
-        ./compile.sh docker KERNEL_ONLY="yes" BOARD="bananapi" BRANCH="current" KERNEL_CONFIGURE="no" USE_TORRENT="yes" REPOSITORY_INSTALL="kernel"
   build_on_focal:
     name: "PUB: sunxi u-boot Docker Focal"
     runs-on: ubuntu-20.04

--- a/.github/workflows/build-and-upload-docker-image-to-hub.yml
+++ b/.github/workflows/build-and-upload-docker-image-to-hub.yml
@@ -1,20 +1,35 @@
-name: Build Docker image
+name: Docker build tests
 # This workflow is triggered 1st, 16th and 31st
 on:
+  push:
+    branches: master
   schedule:
     - cron: '0 0 */15 * *'
 jobs:
-  build:
-    name: latest
-    runs-on: ubuntu-latest
+  build_on_bionic:
+    name: "PUB: sunxi u-boot Docker Bionic"
+    runs-on: ubuntu-18.04
+    steps:
+     - uses: actions/checkout@v1
+     - name: Build Docker image
+       shell: bash {0}
+       run: |
+        sed -i "s/-it --rm/-i --rm/" config/templates/config-docker.conf
+        touch .ignore_changes
+        ./compile.sh docker KERNEL_ONLY="yes" BOARD="bananapi" BRANCH="current" KERNEL_CONFIGURE="no" USE_TORRENT="yes" REPOSITORY_INSTALL="kernel"
+  build_on_focal:
+    name: "PUB: sunxi u-boot Docker Focal"
+    runs-on: ubuntu-20.04
     steps:
      - uses: actions/checkout@v1
      - name: Login to DockerHub Registry
-       run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin   
+       run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin 
      - name: Build Docker image
+       shell: bash {0}
        run: |
-        ./compile.sh docker KERNEL_ONLY="yes" BOARD="bananapi" BRANCH="current" KERNEL_CONFIGURE="no" BSP_BUILD="yes" REPOSITORY_INSTALL="u-boot,kernel,armbian-zsh,armbian-config,armbian-firmware" IGNORE_UPDATES="yes"
+        sed -i "s/-it --rm/-i --rm/" config/templates/config-docker.conf
+        touch .ignore_changes
+        ./compile.sh docker KERNEL_ONLY="yes" BOARD="bananapi" BRANCH="current" KERNEL_CONFIGURE="no" USE_TORRENT="yes" REPOSITORY_INSTALL="kernel"
         docker tag armbian:$(cat VERSION) armbian/build:latest
      - name: Push Docker image
        run: docker push armbian/build:latest
-

--- a/.github/workflows/build-and-upload-docker-image-to-hub.yml
+++ b/.github/workflows/build-and-upload-docker-image-to-hub.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build_on_focal:
     name: "PUB: sunxi u-boot Docker Focal"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
      - uses: actions/checkout@v1
      - name: Login to DockerHub Registry

--- a/.github/workflows/build-and-upload-docker-image-to-hub.yml
+++ b/.github/workflows/build-and-upload-docker-image-to-hub.yml
@@ -1,10 +1,8 @@
 name: Docker build tests
-# This workflow is triggered 1st, 16th and 31st
+# This workflow is triggered every day at 2am
 on:
-  push:
-    branches: master
   schedule:
-    - cron: '0 0 */15 * *'
+    - cron: '0 2 * * *'
 jobs:
   build_on_bionic:
     name: "PUB: sunxi u-boot Docker Bionic"

--- a/compile.sh
+++ b/compile.sh
@@ -185,8 +185,10 @@ fi
 # check if Docker version is high enough
 [[ $(systemd-detect-virt) == 'none' ]] && dockerversion=$(docker version | grep runc -A1 | tail -n 1 | awk '{print $2}')
 if [[ "${1}" == docker && -n ${dockerversion} ]] && linux-version compare "${dockerversion}" lt 1.0.0-rc93; then
-	display_alert "Your Docker engine is too old!" "Required > 1.0.0-rc92" "err"
-	exit 1
+	display_alert "Your Docker engine is too old - using Docker from nigtly builds" "Required > 1.0.0-rc92" "wrn"
+	sed -i "s/edge/nightly/" /etc/apt/sources.list.d/docker.list
+	apt-get update
+	apt-get upgrade -y -qq
 fi
 
 # Create userpatches directory if not exists

--- a/compile.sh
+++ b/compile.sh
@@ -158,7 +158,7 @@ if [[ "${1}" == docker && -f /etc/debian_version && -z "$(command -v docker)" ]]
 
 	# add exception for Ubuntu Focal until Docker provides dedicated binary
 	codename=$(cat /etc/os-release | grep VERSION_CODENAME | cut -d"=" -f2)
-	codeid=$(cat /etc/os-release | grep ^NAME | cut -d"=" -f2 | awk '{print tolower($0)}' | tr -d '"')
+	codeid=$(cat /etc/os-release | grep ^NAME | cut -d"=" -f2 | awk '{print tolower($0)}' | tr -d '"' | awk '{print $1}')
 	[[ "${codename}" == "debbie" ]] && codename="buster" && codeid="debian"
 	[[ "${codename}" == "ulyana" ]] && codename="focal" && codeid="ubuntu"
 

--- a/compile.sh
+++ b/compile.sh
@@ -171,7 +171,7 @@ if [[ "${1}" == docker && -f /etc/debian_version && -z "$(command -v docker)" ]]
 	do
 	[[ ! $(command -v "${i}") ]] && install_packages+=${i}" "
 	done
-	[[ -z "${install_packages}" ]] && apt-get update;apt-get install -y -qq --no-install-recommends "${install_packages}"
+	[[ -z "${install_packages}" ]] && apt-get update;apt-get install -y -qq --no-install-recommends ${install_packages}
 
 	curl -fsSL "https://download.docker.com/linux/${codeid}/gpg" | apt-key add -qq - > /dev/null 2>&1
 	export DEBIAN_FRONTEND=noninteractive

--- a/compile.sh
+++ b/compile.sh
@@ -157,10 +157,10 @@ fi
 if [[ "${1}" == docker && -f /etc/debian_version && -z "$(command -v docker)" ]]; then
 
 	# add exception for Ubuntu Focal until Docker provides dedicated binary
-	codename=$(lsb_release -sc)
-	codeid=$(lsb_release -is | awk '{print tolower($0)}')
-	[[ "${codeid}" == "linuxmint" && "${codename}" == "debbie" ]] && codename="buster" && codeid="debian"
-	[[ "${codename}" == "focal" || "${codename}" == "ulyana" ]] && codename="bionic" && codeid="ubuntu"
+	codename=$(cat /etc/os-release | grep VERSION_CODENAME | cut -d"=" -f2)
+	codeid=$(cat /etc/os-release | grep ^NAME | cut -d"=" -f2 | awk '{print tolower($0)}' | tr -d '"')
+	[[ "${codename}" == "debbie" ]] && codename="buster" && codeid="debian"
+	[[ "${codename}" == "ulyana" ]] && codename="focal" && codeid="ubuntu"
 
 	display_alert "Docker not installed." "Installing" "Info"
 	echo "deb [arch=amd64] https://download.docker.com/linux/${codeid} ${codename} edge" > /etc/apt/sources.list.d/docker.list
@@ -180,6 +180,13 @@ if [[ "${1}" == docker && -f /etc/debian_version && -z "$(command -v docker)" ]]
 	display_alert "Add yourself to docker group to avoid root privileges" "" "wrn"
 	"${SRC}/compile.sh" "$@"
 	exit $?
+fi
+
+# check if Docker version is high enough
+[[ $(systemd-detect-virt) == 'none' ]] && dockerversion=$(docker version | grep runc -A1 | tail -n 1 | awk '{print $2}')
+if [[ "${1}" == docker && -n ${dockerversion} ]] && linux-version compare "${dockerversion}" lt 1.0.0-rc93; then
+	display_alert "Your Docker engine is too old!" "Required > 1.0.0-rc92" "err"
+	exit 1
 fi
 
 # Create userpatches directory if not exists

--- a/config/templates/Dockerfile
+++ b/config/templates/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:21.04
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get -y install joe software-properties-common
+RUN apt-get install -y --no-install-recommends \
        gnupg \
        gnupg1 \
        gpgv1 \

--- a/config/templates/Dockerfile
+++ b/config/templates/Dockerfile
@@ -82,8 +82,6 @@ RUN apt-get update \
        python3 \
        python3-dev \
        python3-distutils \
-       python3-pkg-resources \
-       python3-setuptools \
        qemu-user-static \
        rsync \
        swig \

--- a/config/templates/Dockerfile
+++ b/config/templates/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:21.04
 ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get -y install joe software-properties-common
+RUN add-apt-repository "deb http://archive.ubuntu.com/ubuntu hirsute main universe restricted multiverse"
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        gnupg \

--- a/config/templates/Dockerfile
+++ b/config/templates/Dockerfile
@@ -1,7 +1,5 @@
 FROM ubuntu:21.04
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get -y install joe software-properties-common
-RUN add-apt-repository "deb http://archive.ubuntu.com/ubuntu hirsute main universe restricted multiverse"
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        gnupg \

--- a/config/templates/Dockerfile
+++ b/config/templates/Dockerfile
@@ -82,6 +82,8 @@ RUN apt-get update \
        python3 \
        python3-dev \
        python3-distutils \
+       python3-pkg-resources \
+       python3-setuptools \
        qemu-user-static \
        rsync \
        swig \

--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -18,6 +18,7 @@ REVISION=$(cat "${SRC}"/VERSION)"$SUBREVISION" # all boards have same revision
 [[ -z $MAINTAINERMAIL ]] && MAINTAINERMAIL="igor.pecovnik@****l.com" # deb signature
 TZDATA=$(cat /etc/timezone) # Timezone for target is taken from host or defined here.
 USEALLCORES=yes # Use all CPU cores for compiling
+HOSTRELEASE=$(cat /etc/os-release | grep VERSION_CODENAME | cut -d"=" -f2)
 [[ -z $EXIT_PATCHING_ERROR ]] && EXIT_PATCHING_ERROR="" # exit patching if failed
 [[ -z $HOST ]] && HOST="$BOARD" # set hostname to the board
 cd "${SRC}" || exit
@@ -335,7 +336,7 @@ DESTIMG="${SRC}/.tmp/image-${MOUNT_UUID}"
 [[ $CRYPTROOT_ENABLE == yes && $RELEASE == xenial ]] && exit_with_error "Encrypted rootfs is not supported in Xenial"
 [[ $RELEASE == stretch && $CAN_BUILD_STRETCH != yes ]] && exit_with_error "Building Debian Stretch images with selected kernel is not supported"
 [[ $RELEASE == bionic && $CAN_BUILD_STRETCH != yes ]] && exit_with_error "Building Ubuntu Bionic images with selected kernel is not supported"
-[[ $RELEASE == bionic && $(lsb_release -sc) == xenial ]] && exit_with_error "Building Ubuntu Bionic images requires a Bionic build host. Please upgrade your host or select a different target OS"
+[[ $RELEASE == hirsute && $HOSTRELEASE == focal ]] && exit_with_error "Building Ubuntu Hirsute images requires Hirsute build host. Please upgrade your host or select a different target OS"
 
 [[ -n $ATFSOURCE && -z $ATF_USE_GCC ]] && exit_with_error "Error in configuration: ATF_USE_GCC is unset"
 [[ -z $UBOOT_USE_GCC ]] && exit_with_error "Error in configuration: UBOOT_USE_GCC is unset"
@@ -611,7 +612,7 @@ cat <<-EOF >> "${DEST}"/debug/output.log
 Repository: $REPOSITORY_URL
 Version: $REPOSITORY_COMMIT
 
-Host OS: $(lsb_release -sc)
+Host OS: $HOSTRELEASE
 Host arch: $(dpkg --print-architecture)
 Host system: $(uname -a)
 Virtualization type: $(systemd-detect-virt)

--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -394,9 +394,9 @@ prepare_partitions()
 	# add -N number of inodes to keep mount from running out
 	# create bigger number for desktop builds
 	if [[ $BUILD_DESKTOP == yes ]]; then local node_number=4096; else local node_number=1024; fi
-	if [[ $(lsb_release -sc) =~ bionic|buster|bullseye|cosmic|groovy|focal|hirsute|sid ]]; then
+	if [[ $HOSTRELEASE =~ bionic|buster|bullseye|cosmic|groovy|focal|hirsute|sid ]]; then
 		mkopts[ext4]="-q -m 2 -O ^64bit,^metadata_csum -N $((128*${node_number}))"
-	elif [[ $(lsb_release -sc) == xenial ]]; then
+	elif [[ $HOSTRELEASE == xenial ]]; then
 		mkopts[ext4]="-q -m 2 -N $((128*${node_number}))"
 	fi
 	mkopts[fat]='-n BOOT'

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -947,12 +947,6 @@ prepare_host_basic()
 	# wait until package manager finishes possible system maintanace
 	wait_for_package_manager
 
-	# need lsb_release to decide what to install
-	if [[ $(dpkg-query -W -f='${db:Status-Abbrev}\n' lsb-release 2>/dev/null) != *ii* ]]; then
-		display_alert "Installing package" "lsb-release"
-		apt-get -q update && apt-get install -q -y --no-install-recommends lsb-release
-	fi
-
 	# need to install dialog if person is starting with a interactive mode
 	if [[ $(dpkg-query -W -f='${db:Status-Abbrev}\n' dialog 2>/dev/null) != *ii* ]]; then
 		display_alert "Installing package" "dialog"
@@ -1026,10 +1020,8 @@ prepare_host()
 # build aarch64
   fi
 
-	local codename=$(lsb_release -sc)
-
 	# Add support for Ubuntu 20.04, 21.04 and Mint Ulyana
-	if [[ $codename =~ ^(focal|groovy|hirsute|ulyana|ulyssa|bullseye)$ ]]; then
+	if [[ $HOSTRELEASE =~ ^(focal|groovy|hirsute|ulyana|ulyssa|bullseye)$ ]]; then
 		hostdeps+=" python2 python3"
 		ln -fs /usr/bin/python2.7 /usr/bin/python2
 		ln -fs /usr/bin/python2.7 /usr/bin/python
@@ -1037,19 +1029,19 @@ prepare_host()
 		hostdeps+=" python libpython-dev"
 	fi
 
-	display_alert "Build host OS release" "${codename:-(unknown)}" "info"
+	display_alert "Build host OS release" "${HOSTRELEASE:-(unknown)}" "info"
 
 	# Ubuntu 20.04.x (Focal) x86_64 is the only fully supported host OS release
 	# Using Docker/VirtualBox/Vagrant is the only supported way to run the build script on other Linux distributions
 	#
 	# NO_HOST_RELEASE_CHECK overrides the check for a supported host system
 	# Disable host OS check at your own risk. Any issues reported with unsupported releases will be closed without discussion
-	if [[ -z $codename || "buster bullseye groovy focal hirsute debbie tricia ulyana ulyssa" != *"$codename"* ]]; then
+	if [[ -z $HOSTRELEASE || "buster bullseye groovy focal hirsute debbie tricia ulyana ulyssa" != *"$HOSTRELEASE"* ]]; then
 		if [[ $NO_HOST_RELEASE_CHECK == yes ]]; then
-			display_alert "You are running on an unsupported system" "${codename:-(unknown)}" "wrn"
+			display_alert "You are running on an unsupported system" "${HOSTRELEASE:-(unknown)}" "wrn"
 			display_alert "Do not report any errors, warnings or other issues encountered beyond this point" "" "wrn"
 		else
-			exit_with_error "It seems you ignore documentation and run an unsupported build system: ${codename:-(unknown)}"
+			exit_with_error "It seems you ignore documentation and run an unsupported build system: ${HOSTRELEASE:-(unknown)}"
 		fi
 	fi
 
@@ -1060,7 +1052,7 @@ prepare_host()
 # build aarch64
   if [[ $(dpkg --print-architecture) == amd64 ]]; then
 
-	if [[ -z $codename || $codename =~ ^(focal|groovy|debbie|buster|bullseye|hirsute|ulyana|ulyssa)$ ]]; then
+	if [[ -z $HOSTRELEASE || $HOSTRELEASE =~ ^(focal|groovy|debbie|buster|bullseye|hirsute|ulyana|ulyssa)$ ]]; then
 	    hostdeps="${hostdeps/lib32ncurses5 lib32tinfo5/lib32ncurses6 lib32tinfo6}"
 	fi
 


### PR DESCRIPTION
# Description

Along with bumping Docker image to Hirsute, we had to address few bugs. First is missing of lsb-release package which can be easily replaced by reading /etc/os-release file. Second is more problematic and is related to Docker run functionality. It was fixed in Docker beta builds, which means user has to switch to beta repository or install docker binary that is fresh enough. We don't cover installation but we throw out error that too old version is used. 

Reference: https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1916485

Jira reference number [AR-732]

# How Has This Been Tested?

./compile.sh docker

- [x] on a clean Linux Mint host which uses Focal docker repository
- [x] on a clean Ubuntu Focal host
- [x] on a clean Debian Buster host

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-732]: https://armbian.atlassian.net/browse/AR-732