### PR TITLE
limit ci builds to armbian org

### DIFF
--- a/.github/workflows/build-and-upload-docker-image-to-hub.yml
+++ b/.github/workflows/build-and-upload-docker-image-to-hub.yml
@@ -7,6 +7,7 @@ jobs:
   build:
     name: latest
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'Armbian' }}
     steps:
      - uses: actions/checkout@v1
      - name: Login to DockerHub Registry

--- a/.github/workflows/cron-beta-repository.yaml
+++ b/.github/workflows/cron-beta-repository.yaml
@@ -7,6 +7,7 @@ on:
 jobs:
   build: 
     runs-on: [runner2]
+    if: ${{ github.repository_owner == 'Armbian' }}
     steps:
       - name: Run script
         shell: bash {0}

--- a/.github/workflows/testpr.yml
+++ b/.github/workflows/testpr.yml
@@ -6,6 +6,7 @@ jobs:
   shellcheck:
     name: shellcheck
     runs-on: ubuntu-20.04
+    if: ${{ github.repository_owner == 'Armbian' }}
     steps:
        - name: Checkout repository
          uses: actions/checkout@v2
@@ -23,6 +24,7 @@ jobs:
     name: Compile changed kernel
     # This job runs on self hosted Linux machine, with public label
     runs-on: [self-hosted, public, x64]
+    if: ${{ github.repository_owner == 'Armbian' }}
     steps:
 #      - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
 #        env:


### PR DESCRIPTION
This will prevent forks from attempt CI jobs and making noise