### PR TITLE
Armbian build system extensibility (fragments)

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -260,6 +260,11 @@ fi
 
 CONFIG_PATH=$(dirname "${CONFIG_FILE}")
 
+# Source the fragment manager library at this point, before sourcing the config.
+# This allows early calls to add_fragment(), but initialization proper is done later.
+# shellcheck source=fragments.sh
+source "${SRC}"/lib/fragments.sh
+
 display_alert "Using config file" "${CONFIG_FILE}" "info"
 pushd "${CONFIG_PATH}" > /dev/null || exit
 # shellcheck source=/dev/null

--- a/fragments/detect-wishful-hooking.sh
+++ b/fragments/detect-wishful-hooking.sh
@@ -1,0 +1,47 @@
+## Hooks
+
+# A honeypot wishful hooking. To make sure the whole thing works.
+# This is exactly the kind of hooking this fragment is meant to detect.
+# This will never run, and should be detected below, but is handled specially and ignored.
+# Note: this will never run, since we (hopefully) don't have a hook_point called 'wishful_hooking_example'.
+function wishful_hooking_example__this_will_never_run() {
+	echo "WISHFUL HOOKING -- this will never run. I promise."
+}
+
+# Run super late, hopefully at the last possible moment.
+function fragment_metadata_ready__999_detect_wishful_hooking() {
+	display_alert "Checking fragments and hooks for uncalled hook points"
+	declare -i found_honeypot_function=0
+
+	# Loop over the defined functions' keys. Find the info about the call. If not found, warn the user.
+	# shellcheck disable=SC2154 # hook-exported variable
+	for one_defined_function in ${!defined_hook_point_functions[*]}; do
+		local source_info defined_info line_info
+		defined_info="${defined_hook_point_functions["${one_defined_function}"]}"
+		source_info="${hook_point_function_trace_sources["${one_defined_function}"]}"
+		line_info="${hook_point_function_trace_lines["${one_defined_function}"]}"
+		stack="$(get_fragment_hook_stracktrace "${source_info}" "${line_info}")"
+		if [[ "$source_info" != "" ]]; then
+			# log to debug log. it's reassuring.
+			echo "\$\$\$ Hook function stacktrace for '${one_defined_function}': '${stack}' (${defined_info})" >>"${FRAGMENT_MANAGER_LOG_FILE}"
+			if [[ "${DEBUG_HOOKS}" == "yes" ]]; then
+				display_alert "Hook function stacktrace for '${one_defined_function}'" "${stack}" "wrn"
+			fi
+			continue # found a caller, move on.
+		fi
+
+		# special handling for the honeypot function. it is supposed to be always detected as uncalled.
+		if [[ "${one_defined_function}" == "wishful_hooking_example__this_will_never_run" ]]; then
+			# we expect this wishful hooking, it is done on purpose below, to make sure this code works.
+			found_honeypot_function=1
+		else
+			# unexpected wishful hooking. Log and wrn the user.
+			echo "\$\$\$ Wishful hooking detected" "Function '${one_defined_function}' is defined (${defined_info}) but never called by the build." >>"${FRAGMENT_MANAGER_LOG_FILE}"
+			display_alert "Wishful hooking detected" "Function '${one_defined_function}' is defined (${defined_info}) but never called by the build." "wrn"
+		fi
+	done
+
+	if [[ $found_honeypot_function -lt 1 ]]; then
+		display_alert "Wishful hook DETECTION FAILED" "detect-wishful-hooking is not working. Good chance the environment vars are corrupted. Avoid child shells. Sorry." "wrn" | tee -a "${FRAGMENT_MANAGER_LOG_FILE}"
+	fi
+}

--- a/fragments/detect-wishful-hooking.sh
+++ b/fragments/detect-wishful-hooking.sh
@@ -1,3 +1,6 @@
+## Configuration
+export LOG_ALL_HOOK_TRACES=no # Should we log all hook function traces to stdout? (no, or level: wrn info)
+
 ## Hooks
 
 # A honeypot wishful hooking. To make sure the whole thing works.
@@ -24,8 +27,8 @@ function fragment_metadata_ready__999_detect_wishful_hooking() {
 		if [[ "$source_info" != "" ]]; then
 			# log to debug log. it's reassuring.
 			echo "\$\$\$ Hook function stacktrace for '${one_defined_function}': '${stack}' (${defined_info})" >>"${FRAGMENT_MANAGER_LOG_FILE}"
-			if [[ "${DEBUG_HOOKS}" == "yes" ]]; then
-				display_alert "Hook function stacktrace for '${one_defined_function}'" "${stack}" "wrn"
+			if [[ "${LOG_ALL_HOOK_TRACES}" != "no" ]]; then
+				display_alert "Hook function stacktrace for '${one_defined_function}'" "${stack}" "${LOG_ALL_HOOK_TRACES}"
 			fi
 			continue # found a caller, move on.
 		fi

--- a/fragments/write-hook-docs.sh
+++ b/fragments/write-hook-docs.sh
@@ -1,0 +1,149 @@
+## Hooks
+function fragment_metadata_ready__499_display_docs_generation_start_info() {
+	display_alert "Generating hook documentation and sample fragment"
+}
+
+function fragment_metadata_ready__docs_markdown() {
+	generate_markdown_docs_to_stdout >"${DEST}/debug/hooks.auto.docs.md"
+}
+
+function fragment_metadata_ready__docs_sample_fragment() {
+	mkdir -p "${SRC}/userpatches/fragments"
+	generate_sample_fragment_to_stdout >"${SRC}/userpatches/fragments/sample-fragment.sh"
+}
+
+## Internal functions
+
+### Common stuff
+function read_common_data() {
+	export HOOK_POINT_CALLS_COUNT=$(wc -l <"${FRAGMENT_MANAGER_TMP_DIR}/hook_point_calls.txt")
+	export HOOK_POINT_CALLS_UNIQUE_COUNT=$(sort <"${FRAGMENT_MANAGER_TMP_DIR}/hook_point_calls.txt" | uniq | wc -l)
+	export HOOK_POINTS_WITH_MULTIPLE_CALLS=""
+
+	# Read the hook_points (main, official names) from the hook point ordering file.
+	export ALL_HOOK_POINT_CALLS=$(xargs echo -n <"${FRAGMENT_MANAGER_TMP_DIR}/hook_point_calls.txt")
+}
+
+function loop_over_hook_points_and_call() {
+	local callback="$1"
+	HOOK_POINT_COUNTER=0
+	for one_hook_point in ${ALL_HOOK_POINT_CALLS}; do
+		export HOOK_POINT_COUNTER=$((HOOK_POINT_COUNTER + 1))
+		export HOOK_POINT="${one_hook_point}"
+		export MARKDOWN_HEAD="$(head -1 "${FRAGMENT_MANAGER_TMP_DIR}/${one_hook_point}.orig.md")"
+		export MARKDOWN_BODY="$(tail -n +2 "${FRAGMENT_MANAGER_TMP_DIR}/${one_hook_point}.orig.md")"
+		export COMPATIBILITY_NAMES="$(xargs echo -n <"${FRAGMENT_MANAGER_TMP_DIR}/${one_hook_point}.compat")"
+		${callback}
+	done
+}
+
+## Markdown stuff
+function generate_markdown_docs_to_stdout() {
+	read_common_data
+	cat <<MASTER_HEADER
+# Armbian build system extensibility documentation
+- This documentation is auto-generated.
+MASTER_HEADER
+
+	[[ $HOOK_POINT_CALLS_COUNT -gt $HOOK_POINT_CALLS_UNIQUE_COUNT ]] && {
+		# Some hook points were called multiple times, determine which.
+		HOOK_POINTS_WITH_MULTIPLE_CALLS=$(comm -13 <(sort <"${FRAGMENT_MANAGER_TMP_DIR}/hook_point_calls.txt" | uniq) <(sort <"${FRAGMENT_MANAGER_TMP_DIR}/hook_point_calls.txt") | sort | uniq | xargs echo -n)
+
+		cat <<MULTIPLE_CALLS_WARNING
+- *Important:* The following hook points where called multiple times during the documentation generation. This can be indicative of a bug in the build system. Please check the sources for the invocation of the following hooks: \`${HOOK_POINTS_WITH_MULTIPLE_CALLS}\`.
+MULTIPLE_CALLS_WARNING
+
+	}
+
+	cat <<PRE_HOOKS_HEADER
+## Hooks
+- Hooks are listed in the order they are called.
+PRE_HOOKS_HEADER
+
+	loop_over_hook_points_and_call "generate_markdown_one_hook_point_to_stdout"
+
+	cat <<MASTER_FOOTER
+------------------------------------------------------------------------------------------
+MASTER_FOOTER
+
+}
+
+function generate_markdown_one_hook_point_to_stdout() {
+	# Hook name in 3rd level title, first line of description in a blockquote.
+	# The rest in a normal block.
+	cat <<HOOK_DOCS
+### \`${one_hook_point}\`
+> ${MARKDOWN_HEAD}
+
+${MARKDOWN_BODY}
+
+HOOK_DOCS
+
+	[[ "${COMPATIBILITY_NAMES}" != "" ]] && {
+		echo -e "\n\nAlso known as (for backwards compatibility only):"
+		for old_name in ${COMPATIBILITY_NAMES}; do
+			echo "- \`${old_name}\`"
+		done
+	}
+
+	echo ""
+}
+
+## Bash sample fragment stuff
+generate_sample_fragment_to_stdout() {
+	read_common_data
+	cat <<HEADER
+# Sample Armbian build system fragment with all hooks.
+# This file is auto-generated from the build system.
+# Please, always use the latest available version of this file as a starting point for your own fragments.
+# Read more about the build extensibility system at https://todo
+
+HEADER
+
+	loop_over_hook_points_and_call "generate_bash_sample_for_hook_point"
+}
+
+generate_bash_sample_for_hook_point() {
+	# Include the markdown documentation as a comment.
+	# Right now clean it up naively (remove backticks, mostly) but we could pipe through stuff to get better plaintext. (pandoc is a 155mb binary FYI)
+	local COMMENT_HEAD="#### $(echo "${MARKDOWN_HEAD}" | tr '`' '"')"
+	# shellcheck disable=SC2001
+	local COMMENT_BODY="$(echo "${MARKDOWN_BODY}" | tr '`' '"' | sed -e 's/^/###  /')"
+
+	local bonus=""
+	[[ "${HOOK_POINT_COUNTER}" == "1" ]] && bonus="$(echo -e "\n\texport PROGRESS_DISPLAY=verysilent # Example: export a variable. This one silences the built.")"
+
+	cat <<SAMPLE_BASH_CODE
+${COMMENT_HEAD}
+${COMMENT_BODY}
+${HOOK_POINT}__be_more_awesome() {
+	# @TODO: Here goes your code. As an example, here's a call to display_message. Bask in its colorful glory.
+	display_alert "AWESOME Sample hook ${HOOK_POINT_COUNTER}/${HOOK_POINT_CALLS_COUNT}" "making '${HOOK_POINT}' more awesome" "info"${bonus}
+	# @TODO: Please also remember to rename this function, but preserve the "${HOOK_POINT}__" prefix.
+} # end of function ${HOOK_POINT}__be_more_awesome()
+
+SAMPLE_BASH_CODE
+}
+
+## For later:
+## 	# Keep track of the variables.
+## 	local PREVIOUS_VARS=""
+## 	#export EXPORTED_VARS="$(cat "${FRAGMENT_MANAGER_TMP_DIR}/${one_hook_point}.exports" | xargs echo -n)"
+## 	export ALL_VARS="$(cat "${FRAGMENT_MANAGER_TMP_DIR}/${one_hook_point}.vars")"
+## 	export NEW_VARS=""
+## 	[[ "${PREVIOUS_VARS}" != "" ]] && {
+## 		NEW_VARS=$(comm -3 <(echo "${PREVIOUS_VARS}") <(echo "${ALL_VARS}") | sort | uniq | xargs echo -n)
+## 	}
+## 	export PREVIOUS_VARS="${ALL_VARS}"
+## 	echo "Hook ${one_hook_point} New vars: ${NEW_VARS}"
+##
+## 	cat <<EOD
+## -- one_hook_point: ${one_hook_point}
+##    EXPORTED_VARS: ${EXPORTED_VARS}
+##    ALL_VARS: ${ALL_VARS}
+## EOD
+
+## ## Commandline calling.
+## export FRAGMENT_MANAGER_TMP_DIR="$(pwd)/.tmp/.fragments"
+## fragment_metadata_ready__docs_sample_fragment
+## fragment_metadata_ready__docs_markdown

--- a/lib/distributions.sh
+++ b/lib/distributions.sh
@@ -290,6 +290,11 @@ install_common()
 		[[ $INSTALL_HEADERS == yes ]] && install_deb_chroot "linux-headers-${BRANCH}-${LINUXFAMILY}" "remote"
 	fi
 
+	call_hook_point "post_install_kernel_debs" "config_post_install_kernel_debs" << 'MARKDOWN_DOCS_FOR_HOOK'
+*allow config to do more with the installed kernel/headers*
+Called after packages, u-boot, kernel and headers installed in the chroot, but before the BSP is installed.
+MARKDOWN_DOCS_FOR_HOOK
+
 	# install board support packages
 	if [[ "${REPOSITORY_INSTALL}" != *bsp* ]]; then
 		install_deb_chroot "${DEB_STORAGE}/$RELEASE/${BSP_CLI_PACKAGE_FULLNAME}.deb" | tee "${DEST}"/debug/install.log 2>&1
@@ -372,6 +377,12 @@ install_common()
 
 	# execute $LINUXFAMILY-specific tweaks
 	[[ $(type -t family_tweaks) == function ]] && family_tweaks
+
+	call_hook_point "post_family_tweaks" << 'FAMILY_TWEAKS'
+*customize the tweaks made by $LINUXFAMILY-specific family_tweaks*
+It is run after packages are installed in the rootfs, but before enabling additional services.
+It allows implementors access to the rootfs (`${SDCARD}`) in its pristine state after packages are installed.
+FAMILY_TWEAKS
 
 	# enable additional services
 	chroot "${SDCARD}" /bin/bash -c "systemctl --no-reload enable armbian-firstrun.service >/dev/null 2>&1"
@@ -672,5 +683,11 @@ post_debootstrap_tweaks()
 	chroot "${SDCARD}" /bin/bash -c "dpkg-divert --quiet --local --rename --remove /sbin/initctl"
 	chroot "${SDCARD}" /bin/bash -c "dpkg-divert --quiet --local --rename --remove /sbin/start-stop-daemon"
 	rm -f "${SDCARD}"/usr/sbin/policy-rc.d "${SDCARD}/usr/bin/${QEMU_BINARY}"
+
+	call_hook_point "post_post_debootstrap_tweaks" "config_post_debootstrap_tweaks" << 'POST_POST_DEBOOTSTRAP_TWEAKS'
+*run after removing diversions and qemu with chroot unmounted*
+Last chance to touch the `${SDCARD}` filesystem before it is copied to the final media.
+It is too late to run any chrooted commands, since the supporting filesystems are already unmounted.
+POST_POST_DEBOOTSTRAP_TWEAKS
 
 }

--- a/lib/fragments.sh
+++ b/lib/fragments.sh
@@ -1,0 +1,373 @@
+# global variables managing the state of the fragment manager. treat as private.
+declare -A fragment_function_info                # maps a function name to a string with KEY=VALUEs information about the defining fragment
+declare -i initialize_fragment_manager_counter=0 # how many times has the fragment manager initialized?
+declare -A defined_hook_point_functions          # keeps a map of hook point functions that were defined and their fragment info
+declare -A hook_point_function_trace_sources     # keeps a map of hook point functions that were actually called and their source
+declare -A hook_point_function_trace_lines       # keeps a map of hook point functions that were actually called and their source
+# configuration.
+export DEBUG_HOOKS=no # set to yes to log every hook function called to the main build log
+
+# This is a helper function for calling hooks.
+# It follows the pattern long used in the codebase for hook-like behaviour:
+#    [[ $(type -t name_of_hook_function) == function ]] && name_of_hook_function
+# but with the following added behaviors:
+# 1) it allows for many arguments, and will treat each as a hook point.
+#    this allows for easily kept backwards compatibility when renaming hooks, for example.
+# 2) it will read the stdin and assume it's (Markdown) documentation for the hook point.
+#    combined with heredoc in the call site, it allows for "inline" documentation about the hook
+# notice: this is not involved in how the hook functions came to be. read below for that.
+call_hook_point() {
+	# First, consume the stdin and write metadata about the call.
+	write_hook_point_metadata "$@" || true
+
+	# Then a sanity check, hook points should only be invoked after the manager has initialized.
+	if [[ ${initialize_fragment_manager_counter} -lt 1 ]]; then
+		display_alert "Fragment problem" "Call to call_hook_point() (in ${BASH_SOURCE[1]- $(get_fragment_hook_stracktrace "${BASH_SOURCE[*]}" "${BASH_LINENO[*]}")}) before fragment manager is initialized." "err"
+	fi
+
+	# With DEBUG_HOOKS, log the hook call. Users might be wondering what/when is a good hook point to use, and this is visual aid.
+	[[ "${DEBUG_HOOKS}" == "yes" ]] &&
+		display_alert "Hook point '${1}' being called from" "$(get_fragment_hook_stracktrace "${BASH_SOURCE[*]}" "${BASH_LINENO[*]}")" ""
+
+	# Then call the hooks, if they are defined.
+	for hook_name in "$@"; do
+		echo "-- hook being called: ${hook_name}" >>"${FRAGMENT_MANAGER_LOG_FILE}"
+		# shellcheck disable=SC2086
+		[[ $(type -t ${hook_name}) == function ]] && { ${hook_name}; }
+	done
+}
+
+# what this does is a lot of bash mumbo-jumbo to find all board-,family-,config- or user-defined hook points.
+# the meat of this is 'compgen -A function', which is bash builtin that lists all defined functions.
+# it will then compose a full hook point (function) that calls all the implementing hooks.
+# this centralized function will then be called by the regular Armbian build system, which is oblivious to how
+# it came to be. (although it is encouraged to call hook points via call_hook_point() above)
+# to avoid hard coding the list of hook-points (eg: user_config, image_tweaks_pre_customize, etc) we use
+# a marker in the function names, namely "__" (two underscores) to determine the hook point.
+initialize_fragment_manager() {
+	# before starting, auto-add fragments specified (eg, on the command-line) via the ADD_FRAGMENTS env var. Do it only once.
+	[[ ${initialize_fragment_manager_counter} -lt 1 ]] && [[ "${ADD_FRAGMENTS}" != "" ]] && {
+		local auto_fragment
+		for auto_fragment in $(echo "${ADD_FRAGMENTS}" | tr "," " "); do
+			ADD_FRAGMENT_TRACE_HINT="CMDLINE -> " add_fragment "${auto_fragment}"
+		done
+	}
+
+	# This marks the manager as initialized, no more fragments are allowed to load after this.
+	export initialize_fragment_manager_counter=$((initialize_fragment_manager_counter + 1))
+
+	# log whats happening.
+	echo "-- initialize_fragment_manager() called." >>"${FRAGMENT_MANAGER_LOG_FILE}"
+
+	# this is the all-important separator.
+	local hook_fragment_delimiter="__"
+
+	# list all defined functions. filter only the ones that have the delimiter. get only the part before the delimiter.
+	# sort them, and make them unique. the sorting is required for uniq to work, and does not affect the ordering of execution.
+	# get them on a single line, space separated.
+	local all_hook_points
+	all_hook_points="$(compgen -A function | grep "${hook_fragment_delimiter}" | awk -F "${hook_fragment_delimiter}" '{print $1}' | sort | uniq | xargs echo -n)"
+
+	declare -i hook_points_counter=0 hook_functions_counter=0 hook_point_functions_counter=0
+
+	local FUNCTION_SORT_OPTIONS="--general-numeric-sort --ignore-case" #  --random-sort could be used to introduce chaos
+	local hook_point=""
+	# now loop over the hook_points.
+	for hook_point in ${all_hook_points}; do
+		echo "-- hook_point ${hook_point}" >>"${FRAGMENT_MANAGER_LOG_FILE}"
+
+		# check if the hook point is already defined as a function.
+		# that can happen for example with user_config(), that can be implemented itself directly by a userpatches config.
+		# for now, just warn, but we could devise a way to actually integrate it in the call list.
+		# or: advise the user to rename their user_config() function to something like user_config__make_it_awesome()
+		local existing_hook_point_function
+		existing_hook_point_function="$(compgen -A function | grep "^${hook_point}\$")"
+		if [[ "${existing_hook_point_function}" == "${hook_point}" ]]; then
+			echo "--- hook_point_functions (final sorted realnames): ${hook_point_functions}" >>"${FRAGMENT_MANAGER_LOG_FILE}"
+			display_alert "Fragment conflict" "function ${hook_point} already defined! ignoring functions: $(compgen -A function | grep "^${hook_point}${hook_fragment_delimiter}")" "wrn"
+			continue
+		fi
+
+		# for each hook_point, obtain the list of implementing functions.
+		# the sort order here is (very) relevant, since it determines final execution order.
+		# so the name of the functions actually determine the ordering.
+		local hook_point_functions hook_point_functions_pre_sort hook_point_functions_sorted_by_sort_id
+
+		# Sorting. Multiple fragments (or even the same fragment twice) can implement the same hook point
+		# as long as they have different function names (the part after the double underscore __).
+		# the order those will be called depends on the name; eg:
+		# 'hook_point__033_be_awesome()' would be caller sooner than 'hook_point__799_be_even_more_awesome()'
+		# independent from where they were defined or in which order the fragments containing them were added.
+		# since requiring specific ordering could hamper portability, we reward fragment authors who
+		# don't mind ordering for writing just: 'hook_point__be_just_awesome()' which is automatically rewritten
+		# as 'hook_point__500_be_just_awesome()'.
+		# fragment authors who care about ordering can use the 3-digit number, and use the context variables
+		# HOOK_ORDER and HOOK_POINT_TOTAL_FUNCS to confirm in which order they're being run.
+
+		# gather the real names of the functions (after the delimiter).
+		hook_point_functions_pre_sort="$(compgen -A function | grep "^${hook_point}${hook_fragment_delimiter}" | awk -F "${hook_fragment_delimiter}" '{print $2}' | xargs echo -n)"
+		echo "--- hook_point_functions_pre_sort: ${hook_point_functions_pre_sort}" >>"${FRAGMENT_MANAGER_LOG_FILE}"
+
+		# add "500_" to the names of function that do NOT start with a number.
+		# keep a reference from the new names to the old names (we'll sort on the new, but invoke the old)
+		declare -A hook_point_functions_sortname_to_realname
+		declare -A hook_point_functions_realname_to_sortname
+		for hook_point_function_realname in ${hook_point_functions_pre_sort}; do
+			local sort_id="${hook_point_function_realname}"
+			[[ ! $sort_id =~ ^[0-9] ]] && sort_id="500_${sort_id}"
+			hook_point_functions_sortname_to_realname[${sort_id}]="${hook_point_function_realname}"
+			hook_point_functions_realname_to_sortname[${hook_point_function_realname}]="${sort_id}"
+		done
+
+		# actually sort the sort_id's...
+		# shellcheck disable=SC2086
+		hook_point_functions_sorted_by_sort_id="$(echo "${hook_point_functions_realname_to_sortname[*]}" | tr " " "\n" | LC_ALL=C sort ${FUNCTION_SORT_OPTIONS} | xargs echo -n)"
+		echo "--- hook_point_functions_sorted_by_sort_id: ${hook_point_functions_sorted_by_sort_id}" >>"${FRAGMENT_MANAGER_LOG_FILE}"
+
+		# then map back to the real names, keeping the order..
+		hook_point_functions=""
+		for hook_point_function_sortname in ${hook_point_functions_sorted_by_sort_id}; do
+			hook_point_functions="${hook_point_functions} ${hook_point_functions_sortname_to_realname[${hook_point_function_sortname}]}"
+		done
+		# shellcheck disable=SC2086
+		hook_point_functions="$(echo -n ${hook_point_functions})"
+		echo "--- hook_point_functions (final sorted realnames): ${hook_point_functions}" >>"${FRAGMENT_MANAGER_LOG_FILE}"
+
+		hook_point_functions_counter=0
+		hook_points_counter=$((hook_points_counter + 1))
+
+		# determine the variables we'll pass to the hook function during execution.
+		# this helps the fragment author create fragments that are portable between userpatches and official Armbian.
+		# shellcheck disable=SC2089
+		local common_function_vars="HOOK_POINT=\"${hook_point}\""
+
+		# loop over the functions for this hook_point (keep a total for the hook point and a grand running total)
+		for hook_point_function in ${hook_point_functions}; do
+			hook_point_functions_counter=$((hook_point_functions_counter + 1))
+			hook_functions_counter=$((hook_functions_counter + 1))
+		done
+		common_function_vars="${common_function_vars} HOOK_POINT_TOTAL_FUNCS=\"${hook_point_functions_counter}\""
+
+		echo "-- hook_point: ${hook_point} will run ${hook_point_functions_counter} functions: ${hook_point_functions}" >>"${FRAGMENT_MANAGER_LOG_FILE}"
+		local temp_source_file_for_hook_point="${SRC}"/.tmp/fragment_function_definition.sh
+
+		hook_point_functions_loop_counter=0
+
+		# now compose a function definition. notice the heredoc. it will be written to tmp file, logged, then sourced.
+		# theres a lot of opportunities here, but for now I keep it simple:
+		# - execute functions in the order defined by ${hook_point_functions} above
+		# - define call-specific environment variables, to help fragment authors to write portable fragments (eg: FRAGMENT_DIR)
+		cat <<FUNCTION_DEFINITION_HEADER >"${temp_source_file_for_hook_point}"
+		${hook_point}() {
+			echo "*** Fragment-managed hook starting '${hook_point}': will run ${hook_point_functions_counter} functions: '${hook_point_functions}'" >>"\${FRAGMENT_MANAGER_LOG_FILE}"
+FUNCTION_DEFINITION_HEADER
+
+		for hook_point_function in ${hook_point_functions}; do
+			hook_point_functions_loop_counter=$((hook_point_functions_loop_counter + 1))
+
+			# store the full name in a hash, so we can track which were actually called later.
+			defined_hook_point_functions["${hook_point}${hook_fragment_delimiter}${hook_point_function}"]="DEFINED=yes ${fragment_function_info["${hook_point}${hook_fragment_delimiter}${hook_point_function}"]}"
+
+			# prepare the call context
+			local hook_point_function_variables="${common_function_vars}" # start with common vars... (eg: HOOK_POINT_TOTAL_FUNCS)
+			# add the contextual fragment info for the function (eg, FRAGMENT_DIR)
+			hook_point_function_variables="${hook_point_function_variables} ${fragment_function_info["${hook_point}${hook_fragment_delimiter}${hook_point_function}"]}"
+			# add the current execution counter, so the fragment author can know in which order it is being actually called
+			hook_point_function_variables="${hook_point_function_variables} HOOK_ORDER=\"${hook_point_functions_loop_counter}\""
+
+			# add it to our (not the call site!) environment. if we export those in the call site, the stack is corrupted.
+			local "${hook_point_function_variables}"
+
+			# output the call, passing arguments, and also logging the output to the fragments log.
+			# attention: don't pipe here (eg, capture output), otherwise hook function cant modify the environment (which is mostly the point)
+			# @TODO: better error handling. we have a good opportunity to 'set -e' here, and 'set +e' after, so that fragment authors are encouraged to write error-free handling code
+			cat <<FUNCTION_DEFINITION_CALLSITE >>"${temp_source_file_for_hook_point}"
+			hook_point_function_trace_sources["${hook_point}${hook_fragment_delimiter}${hook_point_function}"]="\${BASH_SOURCE[*]}"
+			hook_point_function_trace_lines["${hook_point}${hook_fragment_delimiter}${hook_point_function}"]="\${BASH_LINENO[*]}"
+			[[ "\${DEBUG_HOOKS}" == "yes" ]] && display_alert "Hook ${hook_point}" "${hook_point_functions_loop_counter}/${hook_point_functions_counter} (frag:${FRAGMENT:-built-in}) ${hook_point_function}" ""
+			echo "*** *** Fragment-managed hook starting ${hook_point_functions_loop_counter}/${hook_point_functions_counter} '${hook_point}${hook_fragment_delimiter}${hook_point_function}':" >>"\${FRAGMENT_MANAGER_LOG_FILE}"
+			${hook_point_function_variables} ${hook_point}${hook_fragment_delimiter}${hook_point_function} "\$@"
+			echo "*** *** Fragment-managed hook finished ${hook_point_functions_loop_counter}/${hook_point_functions_counter} '${hook_point}${hook_fragment_delimiter}${hook_point_function}':" >>"\${FRAGMENT_MANAGER_LOG_FILE}"
+FUNCTION_DEFINITION_CALLSITE
+
+			# unset fragment vars for the next loop.
+			unset FRAGMENT FRAGMENT_DIR FRAGMENT_FILE FRAGMENT_ADDED_BY
+		done
+
+		cat <<FUNCTION_DEFINITION_FOOTER >>"${temp_source_file_for_hook_point}"
+			echo "*** Fragment-managed hook ending '${hook_point}': completed." >>"\${FRAGMENT_MANAGER_LOG_FILE}"
+		} # end ${hook_point}() function
+FUNCTION_DEFINITION_FOOTER
+
+		# unsets, lest the next loop inherits them
+		unset hook_point_functions hook_point_functions_sortname_to_realname hook_point_functions_realname_to_sortname
+
+		# log what was produced in our own debug logfile
+		cat "${temp_source_file_for_hook_point}" >>"${FRAGMENT_MANAGER_LOG_FILE}"
+
+		# source the generated function.
+		# shellcheck disable=SC1090
+		source "${temp_source_file_for_hook_point}"
+
+		rm -f "${temp_source_file_for_hook_point}"
+	done
+
+	# Dont show any output until we have more than 1 hook function (we implement one already, below)
+	[[ ${hook_functions_counter} -gt 0 ]] &&
+		display_alert "Fragment manager" "processed ${hook_points_counter} hook points and ${hook_functions_counter} hook functions" "info" | tee -a "${FRAGMENT_MANAGER_LOG_FILE}"
+}
+
+# why not eat our own dog food?
+# process everything that happened during fragment related activities
+# and write it to the log. also, move the log from the .tmp dir to its
+# final location. this will make run_after_build() "hot" (eg, emit warnings)
+run_after_build__999_finish_fragment_manager() {
+	# export these maps, so the hook can access them and produce useful stuff.
+	export defined_hook_point_functions hook_point_function_trace_sources
+
+	# eat our own dog food, pt2.
+	call_hook_point "fragment_metadata_ready" <<'FRAGMENT_METADATA_READY'
+*meta-Meta time!*
+Implement this hook to work with/on the meta-data made available by the fragment manager.
+Interesting stuff to process:
+- `"${FRAGMENT_MANAGER_TMP_DIR}/hook_point_calls.txt"` contains a list of all hook points called, in order.
+- For each hook_point in the list, more files will have metadata about that hook point.
+  - `${FRAGMENT_MANAGER_TMP_DIR}/hook_point.orig.md` contains the hook documentation at the call site (inline docs), hopefully in Markdown format.
+  - `${FRAGMENT_MANAGER_TMP_DIR}/hook_point.compat` contains the compatibility names for the hooks.
+  - `${FRAGMENT_MANAGER_TMP_DIR}/hook_point.exports` contains _exported_ environment variables.
+  - `${FRAGMENT_MANAGER_TMP_DIR}/hook_point.vars` contains _all_ environment variables.
+- `${defined_hook_point_functions}` is a map of _all_ the defined hook point functions and their fragment information.
+- `${hook_point_function_trace_sources}` is a map of all the hook point functions _that were really called during the build_ and their BASH_SOURCE information.
+- `${hook_point_function_trace_lines}` is the same, but BASH_LINENO info.
+After this hook is done, the `${FRAGMENT_MANAGER_TMP_DIR}` will be removed.
+FRAGMENT_METADATA_READY
+
+	# Cleanup. Leave no trace...
+	[[ -d "${FRAGMENT_MANAGER_TMP_DIR}" ]] && rm -rf "${FRAGMENT_MANAGER_TMP_DIR}"
+
+	# Move temporary log file over to final destination, and start writing to it instead (although 999 is pretty late in the game)
+	mv "${FRAGMENT_MANAGER_LOG_FILE}" "${DEST}"/debug/
+	export FRAGMENT_MANAGER_LOG_FILE="${DEST}"/debug/fragments.log
+}
+
+# This is called by call_hook_point(). To say the truth, this should be in a fragment. But then it gets too meta for anyone's head.
+write_hook_point_metadata() {
+	local main_hook_point_name="$1"
+
+	cat - >"${FRAGMENT_MANAGER_TMP_DIR}/${main_hook_point_name}.orig.md" # Write the hook point documentation received via stdin to a tmp file for later processing.
+	shift
+	echo -n "$@" >"${FRAGMENT_MANAGER_TMP_DIR}/${main_hook_point_name}.compat"       # log the 2nd+ arguments too (those are the alternative/compatibility names), separate file.
+	compgen -A export >"${FRAGMENT_MANAGER_TMP_DIR}/${main_hook_point_name}.exports" # capture the exported env vars.
+	compgen -A variable >"${FRAGMENT_MANAGER_TMP_DIR}/${main_hook_point_name}.vars"  # capture all env vars.
+
+	# add to the list of hook points called, in order.
+	echo "${main_hook_point_name}" >>"${FRAGMENT_MANAGER_TMP_DIR}/hook_point_calls.txt"
+}
+
+# Helper function, to get clean "stack traces" that do not include the hook/fragment infrastructure code.
+get_fragment_hook_stracktrace() {
+	local sources_str="$1" # Give this ${BASH_SOURCE[*]} - expanded
+	local lines_str="$2"   # And this # Give this ${BASH_LINENO[*]} - expanded
+	local sources lines index final_stack=""
+	IFS=' ' read -r -a sources <<<"${sources_str}"
+	IFS=' ' read -r -a lines <<<"${lines_str}"
+	for index in "${!sources[@]}"; do
+		local source="${sources[index]}" line="${lines[index]}"
+		# skip fragment infrastructure sources, these only pollute the trace and add no insight to users
+		[[ ${source} == */.tmp/fragment_function_definition.sh ]] && continue
+		[[ ${source} == *lib/fragments.sh ]] && continue
+		[[ ${source} == */compile.sh ]] && continue
+		# relativize the source, otherwise too long to display
+		source="${source#"${SRC}/"}"
+		# remove 'lib/'. hope this is not too confusing.
+		source="${source#"lib/"}"
+		# add to the list
+		arrow="$([[ "$final_stack" != "" ]] && echo " -> ")"
+		final_stack="${source}:${line} ${arrow} ${final_stack} "
+	done
+	# output the result, no newline
+	echo -n $final_stack
+}
+
+# can be called by board, family, config or user to make sure a fragment is included.
+# single argument is the fragment name.
+# will look for it in /userpatches/fragments first.
+# if not found there will look in /fragments
+# if not found will throw and abort compilation (or will it? no set -e no this codebase in general)
+add_fragment() {
+	local fragment_name="$1"
+	local fragment_dir fragment_file fragment_file_in_dir fragment_floating_file stacktrace
+
+	# capture the stack leading to this, possibly with a hint in front.
+	stacktrace="${ADD_FRAGMENT_TRACE_HINT}$(get_fragment_hook_stracktrace "${BASH_SOURCE[*]}" "${BASH_LINENO[*]}")"
+
+	# if DEBUG_HOOKS, output useful stack, so user can figure out which fragments are being added where
+	[[ "${DEBUG_HOOKS}" == "yes" ]] &&
+		display_alert "Fragment being added" "${fragment_name} :: added by ${stacktrace}" ""
+
+	# first a check, has the fragment manager already initialized? then it is too late to add_fragment(). bail.
+	if [[ ${initialize_fragment_manager_counter} -gt 0 ]]; then
+		echo "ERR: Fragment problem -- already initialized -- too late to add '${fragment_name}' (trace: ${stacktrace})" | tee -a "${FRAGMENT_MANAGER_LOG_FILE}"
+		exit 2
+	fi
+
+	# there are many opportunities here. too many, actually. let userpatches override just some functions, etc.
+	for fragment_base_path in "${SRC}/userpatches/fragments" "${SRC}/fragments"; do
+		fragment_dir="${fragment_base_path}/${fragment_name}"
+		fragment_file_in_dir="${fragment_dir}/${fragment_name}.sh"
+		fragment_floating_file="${fragment_base_path}/${fragment_name}.sh"
+
+		if [[ -d "${fragment_dir}" ]] && [[ -f "${fragment_file_in_dir}" ]]; then
+			fragment_file="${fragment_file_in_dir}"
+			break
+		elif [[ -f "${fragment_floating_file}" ]]; then
+			fragment_dir="${fragment_base_path}" # this is misleading. only directory-based fragments should have this.
+			fragment_file="${fragment_floating_file}"
+			break
+		fi
+	done
+
+	# After that, we should either have fragment_file and fragment_dir, or throw.
+	if [[ ! -f "${fragment_file}" ]]; then
+		echo "ERR: Fragment problem -- cant find fragment '${fragment_name}' anywhere - called by ${BASH_SOURCE[1]}" | tee -a "${FRAGMENT_MANAGER_LOG_FILE}"
+		return 1
+	fi
+
+	local before_function_list after_function_list new_function_list
+
+	# store a list of existing functions at this point, before sourcing the fragment.
+	before_function_list="$(compgen -A function)"
+
+	# source the file. fragments are not supposed to do anything except export variables and define functions, so nothing should happen here.
+	# there is no way to enforce it though.
+	# we could punish the fragment authors who violate it by removing some essential variables temporarily from the environment during this source, and restore them later.
+	# shellcheck disable=SC1090
+	. "${fragment_file}"
+
+	# get a new list of functions after sourcing the fragment
+	after_function_list="$(compgen -A function)"
+
+	# compare before and after, thus getting the functions defined by the fragment.
+	# comm is oldskool. we like it. go "man comm" to understand -13 below
+	new_function_list="$(comm -13 <(echo "$before_function_list") <(echo "$after_function_list"))"
+
+	# iterate over defined functions, store them in global associative array fragment_function_info
+	for newly_defined_function in ${new_function_list}; do
+		echo "fragment: ${fragment_name} defined function ${newly_defined_function}" >>"${FRAGMENT_MANAGER_LOG_FILE}"
+		fragment_function_info["${newly_defined_function}"]="FRAGMENT=\"${fragment_name}\" FRAGMENT_DIR=\"${fragment_dir}\" FRAGMENT_FILE=\"${fragment_file}\" FRAGMENT_ADDED_BY=\"${stacktrace}\""
+	done
+
+	# Always output to the log
+	echo "Fragment added: '${fragment_name}': from ${fragment_file} - added by: '${stacktrace}'" >>"${FRAGMENT_MANAGER_LOG_FILE}"
+
+}
+
+# For the insanity above to (eventually) make sense to anyone we need logging. Unfortunately,
+# this runs super early (from compile.sh), and its too early to write to /output/debug.
+export FRAGMENT_MANAGER_TMP_DIR="${SRC}/.tmp/.fragments"
+export FRAGMENT_MANAGER_LOG_FILE="${SRC}/.tmp/fragments.log"
+mkdir -p "${SRC}"/.tmp "${FRAGMENT_MANAGER_TMP_DIR}"
+echo -n "" >"${FRAGMENT_MANAGER_TMP_DIR}/hook_point_calls.txt"
+
+# globally initialize the fragments log.
+echo "-- lib/fragments.sh included. logs will be below, followed by the debug generated by the initialize_fragment_manager() function." >"${FRAGMENT_MANAGER_LOG_FILE}"

--- a/lib/fragments.sh
+++ b/lib/fragments.sh
@@ -5,7 +5,8 @@ declare -A defined_hook_point_functions          # keeps a map of hook point fun
 declare -A hook_point_function_trace_sources     # keeps a map of hook point functions that were actually called and their source
 declare -A hook_point_function_trace_lines       # keeps a map of hook point functions that were actually called and their source
 # configuration.
-export DEBUG_HOOKS=no # set to yes to log every hook function called to the main build log
+export DEBUG_HOOKS=no       # set to yes to log every hook function called to the main build log
+export LOG_ADD_FRAGMENT=yes # colorful logs with stacktrace when add_fragment is called.
 
 # This is a helper function for calling hooks.
 # It follows the pattern long used in the codebase for hook-like behaviour:
@@ -176,7 +177,7 @@ FUNCTION_DEFINITION_HEADER
 			hook_point_function_variables="${hook_point_function_variables} HOOK_ORDER=\"${hook_point_functions_loop_counter}\""
 
 			# add it to our (not the call site!) environment. if we export those in the call site, the stack is corrupted.
-			local "${hook_point_function_variables}"
+			eval "${hook_point_function_variables}"
 
 			# output the call, passing arguments, and also logging the output to the fragments log.
 			# attention: don't pipe here (eg, capture output), otherwise hook function cant modify the environment (which is mostly the point)
@@ -301,8 +302,8 @@ add_fragment() {
 	# capture the stack leading to this, possibly with a hint in front.
 	stacktrace="${ADD_FRAGMENT_TRACE_HINT}$(get_fragment_hook_stracktrace "${BASH_SOURCE[*]}" "${BASH_LINENO[*]}")"
 
-	# if DEBUG_HOOKS, output useful stack, so user can figure out which fragments are being added where
-	[[ "${DEBUG_HOOKS}" == "yes" ]] &&
+	# if LOG_ADD_FRAGMENT, output useful stack, so user can figure out which fragments are being added where
+	[[ "${LOG_ADD_FRAGMENT}" == "yes" ]] &&
 		display_alert "Fragment being added" "${fragment_name} :: added by ${stacktrace}" ""
 
 	# first a check, has the fragment manager already initialized? then it is too late to add_fragment(). bail.

--- a/lib/image-helpers.sh
+++ b/lib/image-helpers.sh
@@ -111,6 +111,13 @@ customize_image()
 {
 	# for users that need to prepare files at host
 	[[ -f $USERPATCHES_PATH/customize-image-host.sh ]] && source "$USERPATCHES_PATH"/customize-image-host.sh
+
+	call_hook_point "pre_customize_image" "image_tweaks_pre_customize" << 'PRE_CUSTOMIZE_IMAGE'
+*run before customize-image.sh*
+This hook is called after `customize-image-host.sh` is called, but before the overlay is mounted.
+It thus can be used for the same purposes as `customize-image-host.sh`.
+PRE_CUSTOMIZE_IMAGE
+
 	cp "$USERPATCHES_PATH"/customize-image.sh "${SDCARD}"/tmp/customize-image.sh
 	chmod +x "${SDCARD}"/tmp/customize-image.sh
 	mkdir -p "${SDCARD}"/tmp/overlay
@@ -124,6 +131,12 @@ customize_image()
 	if [[ $CUSTOMIZE_IMAGE_RC != 0 ]]; then
 		exit_with_error "customize-image.sh exited with error (rc: $CUSTOMIZE_IMAGE_RC)"
 	fi
+
+	call_hook_point "post_customize_image" "image_tweaks_post_customize" << 'POST_CUSTOMIZE_IMAGE'
+*post customize-image.sh hook*
+Run after the customize-image.sh script is run, and the overlay is unmounted.
+POST_CUSTOMIZE_IMAGE
+
 } #############################################################################
 
 install_deb_chroot()

--- a/lib/main.sh
+++ b/lib/main.sh
@@ -376,6 +376,11 @@ else
 
 fi
 
+call_hook_point "post_determine_cthreads" "config_post_determine_cthreads" << 'POST_DETERMINE_CTHREADS'
+*give config a chance modify CTHREADS programatically. A build server may work better with hyperthreads-1 for example.*
+Called early, before any compilation work starts.
+POST_DETERMINE_CTHREADS
+
 if [[ $BETA == yes ]]; then
 	IMAGE_TYPE=nightly
 elif [[ $BETA != "yes" && $BUILD_ALL == yes && -n $GPG_PASS ]]; then
@@ -507,9 +512,12 @@ else
 	display_alert "File name" "${CHOSEN_KERNEL}_${REVISION}_${ARCH}.deb" "info"
 fi
 
-# hook for function to run after build, i.e. to change owner of $SRC
-# NOTE: this will run only if there were no errors during build process
-[[ $(type -t run_after_build) == function ]] && run_after_build || true
+call_hook_point "run_after_build"  << 'RUN_AFTER_BUILD'
+*hook for function to run after build, i.e. to change owner of `$SRC`*
+Really one of the last hooks ever called. The build has ended. Congratulations.
+- *NOTE:* this will run only if there were no errors during build process.
+RUN_AFTER_BUILD
+
 
 end=$(date +%s)
 runtime=$(((end-start)/60))

--- a/lib/makeboarddeb.sh
+++ b/lib/makeboarddeb.sh
@@ -304,7 +304,14 @@ fi
 	sed -i 's/#no-auto-down/no-auto-down/g' "${destination}"/etc/network/interfaces.default
 
 	# execute $LINUXFAMILY-specific tweaks
+	# this is invoked directly, and not as a hook. it is pre-fragments, and the families are supposed
+	# to implement them directly. We have a post_ hook next that config can use to override.
 	[[ $(type -t family_tweaks_bsp) == function ]] && family_tweaks_bsp
+
+	call_hook_point "post_family_tweaks_bsp" << 'MARKDOWN_DOCS_FOR_HOOK'
+*family_tweaks_bsp overrrides what is in the config, so give it a chance to override the family tweaks*
+This should be implemented by the config to tweak the BSP, after the board or family has had the chance to.
+MARKDOWN_DOCS_FOR_HOOK
 
 	# add some summary to the image
 	fingerprint_image "${destination}/etc/armbian.txt"

--- a/lib/makeboarddeb.sh
+++ b/lib/makeboarddeb.sh
@@ -308,10 +308,10 @@ fi
 	# to implement them directly. We have a post_ hook next that config can use to override.
 	[[ $(type -t family_tweaks_bsp) == function ]] && family_tweaks_bsp
 
-	call_hook_point "post_family_tweaks_bsp" << 'MARKDOWN_DOCS_FOR_HOOK'
+	call_hook_point "post_family_tweaks_bsp" << 'POST_FAMILY_TWEAKS_BSP'
 *family_tweaks_bsp overrrides what is in the config, so give it a chance to override the family tweaks*
 This should be implemented by the config to tweak the BSP, after the board or family has had the chance to.
-MARKDOWN_DOCS_FOR_HOOK
+POST_FAMILY_TWEAKS_BSP
 
 	# add some summary to the image
 	fingerprint_image "${destination}/etc/armbian.txt"


### PR DESCRIPTION
## Armbian build system extensibility (_fragments_)

The fragment/hook system allows the board/family developers users to independently compose complete hook point
implementations by calling all the hook functions related to that hook point, regardless of where they were defined.

### What is a _hook_ or _hook point_?

Hooks are functions called by the Armbian build system during the build. They usually follow the
pattern `post_something` or `pre_something`, but could also be `do_something`.

The build system calls these hook points at key moments so that the board configuration, family configuration or user
configuration can contribute important behavior to the build without having to hardcode it in the build system itself.

### What is a _hook function_?

A hook function is just a Bash function that follows the pattern `pre_something__do_this` where

- `pre_something` is the name of the hook point.
- `__` is a marker/separator -- very important.
- `do_this` is the name of the hook point function, and should be unique.

`lib/fragments.sh` will compose a single `pre_something()` hook, based on all the hook functions that begin with
`pre_something__`.

Hook functions will be sorted by their numerical value; hook functions that do not begin with a number will
receive `500_` prefix automatically. So the examples `pre_something__do_this` and `pre_something__500_do_this` are
equivalent, and will run

- sooner than `pre_something_900_do_smth_else`
- later than `pre_something_300_do_even_another_thing`

### What is a _fragment_?

A fragment is Bash source file that contains **exclusively**:

- variable definitions/configuration (`export SOME_CONFIG_VALUE=yes`)
- function definitions:
    - hook point function definitions
    - other internal functions

Specifically, fragment files should not contain any code outside of functions.

Fragments can be official Armbian fragments and live in `/fragments`, or can be user-specific
in `/userpatches/fragments`.

A fragment called `my-frag` could be implemented in any of the following file/dir structures:

- `/fragments/my-frag.sh` - an official, single-file fragment.
- `/userpatches/fragments/my-frag.sh` - a user fragment, single-file fragment.
- `/fragments/my-frag/my-frag.sh` - an official, directory-based fragment.
- `/userpatches/fragments/my-frag/my-frag.sh` - a user fragment, directory-based fragment.

#### Single-file vs Directory-based

They're the same, except:

- Directory-based fragment hook-functions will be passed a `${FRAGMENT_DIR}` environment variable.
- That is useful if there are other files/assets that belong together with that fragment. An example would be a template
  file, some configuration file, or other static asset that is directly related to the fragment.
- Using directory-based fragments and `${FRAGMENT_DIR}` allows for easy upstreaming of user fragments (since it just
  needs to be moved around, with no other changes) and is recommended, except for very simple fragments.

## Implementation details (`lib/fragments.sh`)

### New `call_hook_point()` function

Can be used to replace the mantra:

```bash
# name_of_hook_point is a very important stage during build
[[ $(type -t name_of_hook_point) == function ]] && name_of_hook_point
# this hook was recently renamed, its previous name was 'old_name_of_hook_point', please warn users.
```

with this little monster, complete with a bash heredoc.

```shell
call_hook_point "name_of_hook_point" "old_name_of_hook_point" << 'MARKDOWN_DOCUMENTATION_FOR_HOOK_POINT'
this is a very important stage during build (title line)
followed by some multi-line Markdown documentation
that _clearly_ explains the state of things when the hook runs
- thus serving as *inline documentation* for the hooks
MARKDOWN_DOCUMENTATION_FOR_HOOK_POINT
```

Apart from calling the hook point, hhis handles inline documentation, and backwards compatibility; the first argument is
the current name of the hook, other arguments are old names. They will all be called if their implementing functions
exist.

### New `add_fragment()` function

This function is meant to be called by board/family/user config to add a fragment to be build system. Give it a fragment
name, like `my-frag`. It does little more than find and source the fragment file, and store which functions it has
defined.

### Adding fragments from the command-line

End users can also add fragments directly from the command line, by adding `ADD_FRAGMENTS=my-frag,another-frag` to
the `./compile.sh` command line. These will be auto-added by the fragment manager.

### New `initialize_fragment_manager()` function

A complex function that uses mostly `compgen -A function` to list defined functions and does some magic.

The important thing to know is that all hook-point-function-contributing code (including calls to `add_fragment`) has be
sourced before calling `initialize_fragment_manager()`, otherwise they will not be picked up.

## Value-added functionality

Those are implemented using, of course, fragments.

### Markdown documentation generation

A fragment (`fragments/write-hook-docs.sh`) ties together metadata produced by the fragment manager, the calls
to `call_hook_point()` and their heredocs, and produces `output/debug/hooks.auto.docs.md`.

An example `hooks.auto.docs.md` produced is at: https://gist.github.com/rpardini/83ce1f81d8654a45a09d76183da69014

### Sample fragment generation, complete with all the possible hooks and documentation

Together with the Markdown docs, (`fragments/write-hook-docs.sh`) produces `userpatches/fragments/sample-fragment.sh`.

An example `sample-fragment.sh` produced is at https://gist.github.com/rpardini/9a2b61c93345feb635c873e86ab361a7

### Wishful hooking detection

A fragment (`fragments/detect-wishful-hooking.sh`) can be used to detect hook functions that are somehow wrongly defined
and warn the user about them.

## Debugging and logging

### Fragments/hooks log file: `output/debug/fragments.log`

During execution this log is kept at `.tmp/fragments.log` and then moved to `output/debug` at the end of the build. It
contains everything this insanity is doing and should help quite a bit when things go wrong.

### Full fragment debug logging to stdout

Used by the core fragment system as well as some fragments, passing `DEBUG_HOOKS=yes` will enable a log of logging to
stdout (using `display_message`). Can be useful for

- figuring out what hooks get called, and which hook point functions are actually running, and which fragments defined
  them.
- debugging which fragments are being added by which files

### Bash stacktraces

Useful stacktraces are generated (and shown if `DEBUG_HOOKS=yes` or `detect-wishful-hooking` active) for the hook points, and for calls to `add_fragment()`. With those traces we can easily identify where fragments are added and hook points are called.

## Trying it out

To try this all out, here's a base command line for a simple full (non-interactive) build, that does not use any
fragments. You can replace `BOARD=`, `RELEASE=` or other stuff, this being just an example.

```shell
./compile.sh BOARD=kvim2 BRANCH=current RELEASE=hirsute BUILD_MINIMAL=no BUILD_DESKTOP=no \
             KERNEL_ONLY=no KERNEL_CONFIGURE=no COMPRESS_OUTPUTIMAGE=img BUILD_KSRC=no CLEAN_LEVEL=none
```

Running this should run normally and produce the expected result, with little to no interference from the new fragment
system.

#### Generating documentation and sample fragment

Now, add this to the command line above, and run the build again.

```bash
./compile.sh .... ADD_FRAGMENTS=write-hook-docs
```

Then go check out:

- `output/debug/hooks.auto.docs.md` (Markdown docs)
- `userpatches/fragments/sample-fragment.sh` (Sample "awesome" fragment with all hooks)

#### Running with the sample fragment added

With the sample fragment generated above, and no other changes, we should be able to run...

```bash
# for extra debugging add DEBUG_HOOKS=yes too
./compile.sh .... ADD_FRAGMENTS=sample-fragment
```

... and check out all the produced messages coming from the hook.

## Potential / future

Right now the hook points are mostly used for delegating stuff back to the config, tweaks, etc. It is already very
useful for user fragments to change stuff, specially later in the build stages.

In the near future we could start migrating core functions to hooks+fragments, one that comes to mind is `u-boot`.

That would entail creating a few more hook points (like `do_prepare_sources`, `do_bootloader_compile`
and `do_install_bootloader_chroot` and `do_install_bootloader_sector`), and move the code into hook point functions in
a `fragments/bootloader-uboot.sh`, and have boards/families that want to use u-boot
call `add_fragment "bootloader-uboot"`: thus, support for multiple bootloaders!

Right now the fragments system works with functions, but it could be extended to manage/handle/track
the environment variables as well (eg: via `compgen -A variables`).

In a distant future, everything could be a fragment: fragments can themselves call hook points and be infinitely
extensible; the main build system would be just a series of `call_hook_point()` and no real code there.

## Example fragments (or: why the hell was all this written?)

A few examples of my own user fragments are
at https://github.com/rpardini/armbian-build/tree/rpardini-fragments/userpatches/fragments

A user-config enabling some of the fragments can be seen at https://github.com/rpardini/armbian-build/blob/rpardini-fragments/userpatches/common-rpardini.conf

Those fragments are not yet ready for upstream, but should be soon.

A more interesting example is the (new) `msm8998` family, that itself enables some fragments that it needs for a working image: https://github.com/rpardini/armbian-build/blob/rpardini-fragments/config/sources/families/msm8998.conf#L26 - watch a recording of the output of OnePlus5 build that includes most of these fragments at https://asciinema.org/a/NCpQZ0VddkXftJLcnebJkEDC9
