### PR TITLE
Support for capture selection, for Allwinner A20 Audio Codec

### DIFF
--- a/patch/kernel/archive/sunxi-5.10/sunxi-adcis-select-capture-source.patch
+++ b/patch/kernel/archive/sunxi-5.10/sunxi-adcis-select-capture-source.patch
@@ -1,0 +1,108 @@
+diff --git a/sound/soc/sunxi/sun4i-codec.c b/sound/soc/sunxi/sun4i-codec.c
+index 6c13cc8..cac12ca 100644
+--- a/sound/soc/sunxi/sun4i-codec.c
++++ b/sound/soc/sunxi/sun4i-codec.c
+@@ -5,6 +5,7 @@
+  * Copyright 2015 Maxime Ripard <maxime.ripard@free-electrons.com>
+  * Copyright 2015 Adam Sampson <ats@offog.org>
+  * Copyright 2016 Chen-Yu Tsai <wens@csie.org>
++ * Copyright 2021 gryzun <gryzun_an@rambler.ru>
+  *
+  * Based on the Allwinner SDK driver, released under the GPL.
+  */
+@@ -676,6 +677,16 @@ static struct snd_soc_dai_driver sun4i_codec_dai = {
+ };
+ 
+ /*** sun4i Codec ***/
++
++static const char *adcis_text[] = {"Line In", "FM In", "Mic1 Mono", "Mic2 Mono",
++			"Mic1,Mic2", "Mic1+2 Mono", "MIX Out", "Line,Mic1"};
++
++static SOC_ENUM_SINGLE_DECL(adcis_mixer, SUN4I_CODEC_ADC_ACTL,
++					SUN4I_CODEC_ADC_ACTL_ADCIS, adcis_text);
++
++static const struct snd_kcontrol_new sun4i_codec_mux_controls =
++	SOC_DAPM_ENUM("Capture Source Capture Route", adcis_mixer);
++
+ static const struct snd_kcontrol_new sun4i_codec_pa_mute =
+ 	SOC_DAPM_SINGLE("Switch", SUN4I_CODEC_DAC_ACTL,
+ 			SUN4I_CODEC_DAC_ACTL_PA_MUTE, 1, 0);
+@@ -689,6 +700,8 @@ static DECLARE_TLV_DB_SCALE(sun4i_codec_fmin_loopback_gain_scale, -450, 150,
+ 			    0);
+ static DECLARE_TLV_DB_SCALE(sun4i_codec_micin_loopback_gain_scale, -450, 150,
+ 			    0);
++static DECLARE_TLV_DB_SCALE(sun4i_codec_capture_gain_scale, -450, 150,
++			    0);
+ static DECLARE_TLV_DB_RANGE(sun4i_codec_micin_preamp_gain_scale,
+ 			    0, 0, TLV_DB_SCALE_ITEM(0, 0, 0),
+ 			    1, 7, TLV_DB_SCALE_ITEM(3500, 300, 0));
+@@ -742,6 +755,9 @@ static const struct snd_kcontrol_new sun7i_codec_controls[] = {
+ 	SOC_SINGLE_TLV("Mic2 Boost Volume", SUN7I_CODEC_AC_MIC_PHONE_CAL,
+ 		       SUN7I_CODEC_AC_MIC_PHONE_CAL_PREG2, 7, 0,
+ 		       sun7i_codec_micin_preamp_gain_scale),
++	SOC_SINGLE_TLV("Capture Boost Capture Volume", SUN4I_CODEC_ADC_ACTL,
++		       SUN4I_CODEC_ADC_ACTL_VADCG, 7, 0,
++		       sun4i_codec_capture_gain_scale),
+ };
+ 
+ static const struct snd_kcontrol_new sun4i_codec_mixer_controls[] = {
+@@ -820,6 +836,13 @@ static const struct snd_soc_dapm_widget sun4i_codec_codec_dapm_widgets[] = {
+ 	SND_SOC_DAPM_PGA("MIC2 Pre-Amplifier", SUN4I_CODEC_ADC_ACTL,
+ 			 SUN4I_CODEC_ADC_ACTL_PREG2EN, 0, NULL, 0),
+ 
++	/* ADC Mux */
++	SND_SOC_DAPM_MUX("Right Capture Source Capture Route", SND_SOC_NOPM, 0, 0,
++		&sun4i_codec_mux_controls),
++
++	SND_SOC_DAPM_MUX("Left Capture Source Capture Route", SND_SOC_NOPM, 0, 0,
++		&sun4i_codec_mux_controls),
++
+ 	/* Power Amplifier */
+ 	SND_SOC_DAPM_MIXER("Power Amplifier", SUN4I_CODEC_ADC_ACTL,
+ 			   SUN4I_CODEC_ADC_ACTL_PA_EN, 0,
+@@ -848,6 +871,30 @@ static const struct snd_soc_dapm_route sun4i_codec_codec_dapm_routes[] = {
+ 	{ "Right ADC", NULL, "ADC" },
+ 	{ "Right DAC", NULL, "DAC" },
+ 
++	/* Left Mux Capture Routes */
++	{ "Left Capture Source Capture Route", "Mic1 Mono", "MIC1 Pre-Amplifier" },
++	{ "Left Capture Source Capture Route", "Mic2 Mono", "MIC2 Pre-Amplifier" },
++	{ "Left Capture Source Capture Route", "Line In", "Line Left" },
++	{ "Left Capture Source Capture Route", "FM In", "FM Left" },
++	{ "Left Capture Source Capture Route", "MIX Out", "Left Mixer" },
++	{ "Left Capture Source Capture Route", "Mic1,Mic2", "MIC1 Pre-Amplifier" },
++	{ "Left Capture Source Capture Route", "Mic1+2 Mono", "MIC1 Pre-Amplifier" },
++	{ "Left Capture Source Capture Route", "Mic1+2 Mono", "MIC2 Pre-Amplifier" },
++	{ "Left Capture Source Capture Route", "Line,Mic1", "Line Left" },
++	{ "Left ADC", NULL, "Left Capture Source Capture Route" },
++
++	/* Right Mux Capture Routes */
++	{ "Right Capture Source Capture Route", "Mic1 Mono", "MIC1 Pre-Amplifier" },
++	{ "Right Capture Source Capture Route", "Mic2 Mono", "MIC2 Pre-Amplifier" },
++	{ "Right Capture Source Capture Route", "Line In", "Line Right" },
++	{ "Right Capture Source Capture Route", "FM In", "FM Right" },
++	{ "Right Capture Source Capture Route", "MIX Out", "Right Mixer" },
++	{ "Right Capture Source Capture Route", "Mic1,Mic2", "MIC2 Pre-Amplifier" },
++	{ "Right Capture Source Capture Route", "Mic1+2 Mono", "MIC1 Pre-Amplifier" },
++	{ "Right Capture Source Capture Route", "Mic1+2 Mono", "MIC2 Pre-Amplifier" },
++	{ "Right Capture Source Capture Route", "Line,Mic1", "MIC1 Pre-Amplifier" },
++	{ "Right ADC", NULL, "Right Capture Source Capture Route" },
++
+ 	/* Right Mixer Routes */
+ 	{ "Right Mixer", NULL, "Mixer Enable" },
+ 	{ "Right Mixer", "Right Mixer Left DAC Playback Switch", "Left DAC" },
+@@ -877,14 +924,10 @@ static const struct snd_soc_dapm_route sun4i_codec_codec_dapm_routes[] = {
+ 	{ "HP Left", NULL, "Power Amplifier Mute" },
+ 
+ 	/* Mic1 Routes */
+-	{ "Left ADC", NULL, "MIC1 Pre-Amplifier" },
+-	{ "Right ADC", NULL, "MIC1 Pre-Amplifier" },
+ 	{ "MIC1 Pre-Amplifier", NULL, "Mic1"},
+ 	{ "Mic1", NULL, "VMIC" },
+ 
+ 	/* Mic2 Routes */
+-	{ "Left ADC", NULL, "MIC2 Pre-Amplifier" },
+-	{ "Right ADC", NULL, "MIC2 Pre-Amplifier" },
+ 	{ "MIC2 Pre-Amplifier", NULL, "Mic2"},
+ 	{ "Mic2", NULL, "VMIC" },
+ };

--- a/patch/kernel/archive/sunxi-5.11/sunxi-adcis-select-capture-source.patch
+++ b/patch/kernel/archive/sunxi-5.11/sunxi-adcis-select-capture-source.patch
@@ -1,0 +1,108 @@
+diff --git a/sound/soc/sunxi/sun4i-codec.c b/sound/soc/sunxi/sun4i-codec.c
+index 6c13cc8..cac12ca 100644
+--- a/sound/soc/sunxi/sun4i-codec.c
++++ b/sound/soc/sunxi/sun4i-codec.c
+@@ -5,6 +5,7 @@
+  * Copyright 2015 Maxime Ripard <maxime.ripard@free-electrons.com>
+  * Copyright 2015 Adam Sampson <ats@offog.org>
+  * Copyright 2016 Chen-Yu Tsai <wens@csie.org>
++ * Copyright 2021 gryzun <gryzun_an@rambler.ru>
+  *
+  * Based on the Allwinner SDK driver, released under the GPL.
+  */
+@@ -676,6 +677,16 @@ static struct snd_soc_dai_driver sun4i_codec_dai = {
+ };
+ 
+ /*** sun4i Codec ***/
++
++static const char *adcis_text[] = {"Line In", "FM In", "Mic1 Mono", "Mic2 Mono",
++			"Mic1,Mic2", "Mic1+2 Mono", "MIX Out", "Line,Mic1"};
++
++static SOC_ENUM_SINGLE_DECL(adcis_mixer, SUN4I_CODEC_ADC_ACTL,
++					SUN4I_CODEC_ADC_ACTL_ADCIS, adcis_text);
++
++static const struct snd_kcontrol_new sun4i_codec_mux_controls =
++	SOC_DAPM_ENUM("Capture Source Capture Route", adcis_mixer);
++
+ static const struct snd_kcontrol_new sun4i_codec_pa_mute =
+ 	SOC_DAPM_SINGLE("Switch", SUN4I_CODEC_DAC_ACTL,
+ 			SUN4I_CODEC_DAC_ACTL_PA_MUTE, 1, 0);
+@@ -689,6 +700,8 @@ static DECLARE_TLV_DB_SCALE(sun4i_codec_fmin_loopback_gain_scale, -450, 150,
+ 			    0);
+ static DECLARE_TLV_DB_SCALE(sun4i_codec_micin_loopback_gain_scale, -450, 150,
+ 			    0);
++static DECLARE_TLV_DB_SCALE(sun4i_codec_capture_gain_scale, -450, 150,
++			    0);
+ static DECLARE_TLV_DB_RANGE(sun4i_codec_micin_preamp_gain_scale,
+ 			    0, 0, TLV_DB_SCALE_ITEM(0, 0, 0),
+ 			    1, 7, TLV_DB_SCALE_ITEM(3500, 300, 0));
+@@ -742,6 +755,9 @@ static const struct snd_kcontrol_new sun7i_codec_controls[] = {
+ 	SOC_SINGLE_TLV("Mic2 Boost Volume", SUN7I_CODEC_AC_MIC_PHONE_CAL,
+ 		       SUN7I_CODEC_AC_MIC_PHONE_CAL_PREG2, 7, 0,
+ 		       sun7i_codec_micin_preamp_gain_scale),
++	SOC_SINGLE_TLV("Capture Boost Capture Volume", SUN4I_CODEC_ADC_ACTL,
++		       SUN4I_CODEC_ADC_ACTL_VADCG, 7, 0,
++		       sun4i_codec_capture_gain_scale),
+ };
+ 
+ static const struct snd_kcontrol_new sun4i_codec_mixer_controls[] = {
+@@ -820,6 +836,13 @@ static const struct snd_soc_dapm_widget sun4i_codec_codec_dapm_widgets[] = {
+ 	SND_SOC_DAPM_PGA("MIC2 Pre-Amplifier", SUN4I_CODEC_ADC_ACTL,
+ 			 SUN4I_CODEC_ADC_ACTL_PREG2EN, 0, NULL, 0),
+ 
++	/* ADC Mux */
++	SND_SOC_DAPM_MUX("Right Capture Source Capture Route", SND_SOC_NOPM, 0, 0,
++		&sun4i_codec_mux_controls),
++
++	SND_SOC_DAPM_MUX("Left Capture Source Capture Route", SND_SOC_NOPM, 0, 0,
++		&sun4i_codec_mux_controls),
++
+ 	/* Power Amplifier */
+ 	SND_SOC_DAPM_MIXER("Power Amplifier", SUN4I_CODEC_ADC_ACTL,
+ 			   SUN4I_CODEC_ADC_ACTL_PA_EN, 0,
+@@ -848,6 +871,30 @@ static const struct snd_soc_dapm_route sun4i_codec_codec_dapm_routes[] = {
+ 	{ "Right ADC", NULL, "ADC" },
+ 	{ "Right DAC", NULL, "DAC" },
+ 
++	/* Left Mux Capture Routes */
++	{ "Left Capture Source Capture Route", "Mic1 Mono", "MIC1 Pre-Amplifier" },
++	{ "Left Capture Source Capture Route", "Mic2 Mono", "MIC2 Pre-Amplifier" },
++	{ "Left Capture Source Capture Route", "Line In", "Line Left" },
++	{ "Left Capture Source Capture Route", "FM In", "FM Left" },
++	{ "Left Capture Source Capture Route", "MIX Out", "Left Mixer" },
++	{ "Left Capture Source Capture Route", "Mic1,Mic2", "MIC1 Pre-Amplifier" },
++	{ "Left Capture Source Capture Route", "Mic1+2 Mono", "MIC1 Pre-Amplifier" },
++	{ "Left Capture Source Capture Route", "Mic1+2 Mono", "MIC2 Pre-Amplifier" },
++	{ "Left Capture Source Capture Route", "Line,Mic1", "Line Left" },
++	{ "Left ADC", NULL, "Left Capture Source Capture Route" },
++
++	/* Right Mux Capture Routes */
++	{ "Right Capture Source Capture Route", "Mic1 Mono", "MIC1 Pre-Amplifier" },
++	{ "Right Capture Source Capture Route", "Mic2 Mono", "MIC2 Pre-Amplifier" },
++	{ "Right Capture Source Capture Route", "Line In", "Line Right" },
++	{ "Right Capture Source Capture Route", "FM In", "FM Right" },
++	{ "Right Capture Source Capture Route", "MIX Out", "Right Mixer" },
++	{ "Right Capture Source Capture Route", "Mic1,Mic2", "MIC2 Pre-Amplifier" },
++	{ "Right Capture Source Capture Route", "Mic1+2 Mono", "MIC1 Pre-Amplifier" },
++	{ "Right Capture Source Capture Route", "Mic1+2 Mono", "MIC2 Pre-Amplifier" },
++	{ "Right Capture Source Capture Route", "Line,Mic1", "MIC1 Pre-Amplifier" },
++	{ "Right ADC", NULL, "Right Capture Source Capture Route" },
++
+ 	/* Right Mixer Routes */
+ 	{ "Right Mixer", NULL, "Mixer Enable" },
+ 	{ "Right Mixer", "Right Mixer Left DAC Playback Switch", "Left DAC" },
+@@ -877,14 +924,10 @@ static const struct snd_soc_dapm_route sun4i_codec_codec_dapm_routes[] = {
+ 	{ "HP Left", NULL, "Power Amplifier Mute" },
+ 
+ 	/* Mic1 Routes */
+-	{ "Left ADC", NULL, "MIC1 Pre-Amplifier" },
+-	{ "Right ADC", NULL, "MIC1 Pre-Amplifier" },
+ 	{ "MIC1 Pre-Amplifier", NULL, "Mic1"},
+ 	{ "Mic1", NULL, "VMIC" },
+ 
+ 	/* Mic2 Routes */
+-	{ "Left ADC", NULL, "MIC2 Pre-Amplifier" },
+-	{ "Right ADC", NULL, "MIC2 Pre-Amplifier" },
+ 	{ "MIC2 Pre-Amplifier", NULL, "Mic2"},
+ 	{ "Mic2", NULL, "VMIC" },
+ };


### PR DESCRIPTION
# Description

When recording, there is no possibility to change the sound source.

See this [topic](https://forum.armbian.com/topic/17070-no-support-capture-selection-for-allwinner-a20-audio-codec/).

Thank [olegoldtom](https://forum.armbian.com/profile/17702-olegoldtom/) for this fix.

In file sun4i-codec.c there was no description of the ADCIS register, which is responsible for selecting the sound source.

This change is needed for the A20 processors. 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Built kernel and tested manually on an Olimex A20 Lime. Used `alsamixer` to change the mic source.

Capture source selection on `alsamixer` : 

![image](https://user-images.githubusercontent.com/5237465/117799918-4daec700-b25b-11eb-947f-e7f68107008c.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

