### PR TITLE
Put branch value back to the /etc/armbian-release

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
+++ b/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
@@ -15,6 +15,7 @@
 
 # Read in basic OS image information
 . /etc/armbian-release
+
 # and script configuration
 . /usr/lib/armbian/armbian-common
 
@@ -398,6 +399,19 @@ add_usb_storage_quirks() {
 
 } # add_usb_storage_quirks
 
+
+branch_naming_workaround()
+# https://armbian.atlassian.net/browse/AR-748
+# Once we rework kernel packages, this can be done better
+{
+
+	if [[ -z $(cat /etc/armbian-release | grep BRANCH) ]]; then
+		BRANCH=$(dpkg -l | egrep "linux-image" | egrep "current|legacy|edge" | awk '{print $2}' | cut -d"-" -f3 | head -1)
+		[[ -n ${BRANCH} ]] && echo "BRANCH=$BRANCH" >> /etc/armbian-release
+	fi
+}
+
+
 case $1 in
 	*start*)
 		# set optimal disk scheduler settings
@@ -408,5 +422,8 @@ case $1 in
 
 		# add usb quirks
 		add_usb_storage_quirks &
+
+		# branch naming workaround
+		branch_naming_workaround &
 		;;
 esac


### PR DESCRIPTION
# Description

Extracting branch from kernel image package and write it to the /etc/armbian-release file. This information is still needed for armbian-config.

Jira reference number [AR-748]

# How Has This Been Tested?

Branch value is returned after rebooting - requires BSP packages upgrade.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-748]: https://armbian.atlassian.net/browse/AR-748