### PR TITLE
Vnstat throws out garbage under certain, actually common, conditions

### DIFF
--- a/packages/bsp/common/etc/default/armbian-motd.dpkg-dist
+++ b/packages/bsp/common/etc/default/armbian-motd.dpkg-dist
@@ -7,7 +7,7 @@
 MOTD_DISABLE=""
 ONE_WIRE=""
 SHOW_IP_PATTERN="^bond.*|^[ewr].*|^br.*|^lt.*|^umts.*|^lan.*"
-PRIMARY_INTERFACE="$(ls -1 /sys/class/net/ | grep -v lo | sed -n -e 'H;${x;s/\n/+/g;s/^+//;p;}')"
+PRIMARY_INTERFACE="$(ls -1 /sys/class/net/ | grep -v lo | egrep "enp|eth" | sed -n -e 'H;${x;s/\n/+/g;s/^+//;p;}')"
 PRIMARY_DIRECTION="rx"
 STORAGE=/dev/sda1
 


### PR DESCRIPTION
# Description

Vnstat doesn't like very long input parameters and it fails on certain common wireless devices. Limiting device to eth* enp* only seems like a viable workaround.

Jira reference number [AR-740]

# How Has This Been Tested?

Manual run

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

[AR-740]: https://armbian.atlassian.net/browse/AR-740