### PR TITLE
Rework u-boot writing part

### DIFF
--- a/lib/image-helpers.sh
+++ b/lib/image-helpers.sh
@@ -99,7 +99,10 @@ write_uboot()
 	else
 		dpkg -x "${DEB_STORAGE}/${CHOSEN_UBOOT}_${revision}_${ARCH}.deb" ${TEMP_DIR}/
 	fi
-	write_uboot_platform "${TEMP_DIR}/usr/lib/${CHOSEN_UBOOT}_${revision}_${ARCH}" "$loop"
+
+	# source platform install to read $DIR
+	source ${TEMP_DIR}/usr/lib/u-boot/platform_install.sh
+	write_uboot_platform "${TEMP_DIR}${DIR}" "$loop"
 	[[ $? -ne 0 ]] && exit_with_error "U-boot bootloader failed to install" "@host"
 	rm -rf ${TEMP_DIR}
 } #############################################################################


### PR DESCRIPTION
# Description

When creating images from the packages from repository, u-boot choose wrong directory to get binaries from. Now we are reading directory value from the package right before writing to the device.

Close https://github.com/armbian/build/issues/2840

# How Has This Been Tested?

- build image from sources
- build image from repository packages (several ones)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
