### PR TITLE
Rework make linux headers

### DIFF
--- a/packages/armbian/builddeb
+++ b/packages/armbian/builddeb
@@ -78,7 +78,6 @@ EOT
 cd /usr/src/linux-headers-$version
 echo "Compiling headers - please wait ..."
 find -type f -exec touch {} +
-make -j\$(grep -c 'processor' /proc/cpuinfo) M=scripts clean >/dev/null
 yes "" | make oldconfig >/dev/null
 make -j\$(grep -c 'processor' /proc/cpuinfo) -s scripts >/dev/null
 make -j\$(grep -c 'processor' /proc/cpuinfo) -s M=scripts/mod/ >/dev/null
@@ -111,6 +110,7 @@ deploy_kernel_headers () {
 
 	(
 		cd $srctree
+		$MAKE M=scripts clean >/dev/null
 		find . -name Makefile\* -o -name Kconfig\* -o -name \*.pl
 		find arch/*/include include scripts -type f -o -type l
 		find security/*/include -type f
@@ -330,11 +330,11 @@ exit 0
 EOT
 
 if [ "$ARCH" != "um" ]; then
-	deploy_kernel_headers $kernel_headers_dir
-	create_package $kernel_headers_packagename $kernel_headers_dir "headers"
-
 	deploy_libc_headers $libc_headers_dir
 	create_package $libc_headers_packagename $libc_headers_dir
+
+	deploy_kernel_headers $kernel_headers_dir
+	create_package $kernel_headers_packagename $kernel_headers_dir "headers"
 
 	create_package "$dtb_packagename" "$dtb_dir" "dtb"
 fi


### PR DESCRIPTION
Signed-off-by: The-going <48602507+The-going@users.noreply.github.com>

# Description

The script directory is cleared before the file search is started.
This eliminates archiving errors.

Building kernel packages using CCACHE takes 6 minutes.
Of these, it takes about two minutes to build the kernel header module.
