### PR TITLE
Fixed recompilation of kernel headers into a single thread.

### DIFF
--- a/packages/armbian/builddeb
+++ b/packages/armbian/builddeb
@@ -77,10 +77,12 @@ EOT
 	cat >> $pdir/DEBIAN/postinst << EOT
 cd /usr/src/linux-headers-$version
 echo "Compiling headers - please wait ..."
+NCPU=\$(grep -c 'processor' /proc/cpuinfo)
 find -type f -exec touch {} +
+make -j\$NCPU M=scripts clean >/dev/null
 yes "" | make oldconfig >/dev/null
-make -j\$(grep -c 'processor' /proc/cpuinfo) -s scripts >/dev/null
-make -j\$(grep -c 'processor' /proc/cpuinfo) -s M=scripts/mod/ >/dev/null
+make -j\$NCPU -s scripts >/dev/null
+make -j\$NCPU -s M=scripts/mod/ >/dev/null
 exit 0
 EOT
 
@@ -108,9 +110,11 @@ deploy_kernel_headers () {
 
 	rm -rf $pdir
 
+	destdir=$pdir/usr/src/linux-headers-$version
+	mkdir -p $destdir
+
 	(
 		cd $srctree
-		$MAKE M=scripts clean >/dev/null
 		find . -name Makefile\* -o -name Kconfig\* -o -name \*.pl
 		find arch/*/include include scripts -type f -o -type l
 		find security/*/include -type f
@@ -130,9 +134,6 @@ deploy_kernel_headers () {
 			find scripts/gcc-plugins -name \*.so -o -name gcc-common.h
 		fi
 	} > debian/hdrobjfiles
-
-	destdir=$pdir/usr/src/linux-headers-$version
-	mkdir -p $destdir
 
 	(
 		cd $destdir

--- a/packages/armbian/mkdebian
+++ b/packages/armbian/mkdebian
@@ -231,15 +231,11 @@ cat <<EOF > debian/rules
 
 srctree ?= .
 
-build-indep:
-build-arch:
+build:
 	\$(MAKE) KERNELRELEASE=${version} ARCH=${ARCH} \
 	KBUILD_BUILD_VERSION=${revision} -f \$(srctree)/Makefile
 
-build: build-arch
-
-binary-indep:
-binary-arch: build-arch
+binary-arch:
 	\$(MAKE) KERNELRELEASE=${version} ARCH=${ARCH} \
 	KBUILD_BUILD_VERSION=${revision} -f \$(srctree)/Makefile intdeb-pkg
 


### PR DESCRIPTION
Compiling the kernel headers repeatedly and in a single thread
increased the overall package build time by several times.

Signed-off-by: The-going <48602507+The-going@users.noreply.github.com>

# Description

[ o.k. ] File name [ linux-image-edge-sunxi64_21.08.0-trunk_arm64.deb ]
[ o.k. ] Runtime [ 4 min ]
[ o.k. ] Repeat Build Options [ ./compile.sh  BOARD=bananapim64 BRANCH=edge RELEASE=focal BUILD_MINIMAL=yes BUILD_DESKTOP=no KERNEL_ONLY=yes KERNEL_CONFIGURE=no  ]

It was: when the compiler cache is full, takes 9 minutes

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
