### PR TITLE
AR-315: Add support for GPT table inside nand-sata-install

### DIFF
--- a/packages/bsp/common/usr/sbin/nand-sata-install
+++ b/packages/bsp/common/usr/sbin/nand-sata-install
@@ -465,7 +465,10 @@ format_emmc()
 		LASTSECTOR=$(( 32768 * $(parted "$1" unit s print -sm | awk -F":" "/^${QUOTED_DEVICE}/ {printf (\"%0d\", ( \$2 * 99 / 3276800))}") -1 ))
 	fi
 
-	parted -s "$1" -- mklabel msdos
+	# get target partition table type from the root partition device
+	PART_TABLE_TYPE=$(parted "$root_partition_device" print -sm | awk -F ":" -v pattern="$root_partition_device" '$0 ~ pattern {print $6}')
+
+	parted -s "$1" -- mklabel "$PART_TABLE_TYPE"
 	dialog --title "$title" --backtitle "$backtitle" --infobox "\nFormating $1 to $eMMCFilesystemChoosen ... please wait." 5 60
 	# we can't boot from btrfs or f2fs
 	if [[ $eMMCFilesystemChoosen =~ ^(btrfs|f2fs)$ ]]; then


### PR DESCRIPTION
# Description

As proposed [here](https://forum.armbian.com/topic/16324-add-support-for-gpt-table-inside-nand-sata-install/):

- get the partition table type of the root partition device (running system)
- use it to replicate the same type for the emmc partition table

That way, if a board supports GPT, the image configuration for the board will reflect it using the IMAGE_PARTITION_TABLE variable.

The image will be created accordingly and then once run on the device nand-sata-install will replicate it during the emmc partitioning without logic duplication.

Jira reference number [AR-315](https://armbian.atlassian.net/browse/AR-315)

# How Has This Been Tested?

I just run shellcheck on the new lines and tested that the variable is correctly constructed on my helios64:

`root_partition_device="/dev/mmcblk2"`
`PART_TABLE_TYPE=$(parted "$root_partition_device" print -sm | awk -F ":" -v pattern="$root_partition_device" '$0 ~ pattern {print $6}')`
`echo "$PART_TABLE_TYPE"`

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
