### PR TITLE
rk322x-box: workaround for AR-632, installs and configures slick-greeter

### DIFF
--- a/config/optional/boards/rk322x-box/_config/desktop/focal/environments/xfce/armbian/create_desktop_package.sh
+++ b/config/optional/boards/rk322x-box/_config/desktop/focal/environments/xfce/armbian/create_desktop_package.sh
@@ -1,0 +1,3 @@
+# set slick-greeter to be enabled as default (workaround for https://armbian.atlassian.net/browse/AR-632)
+mkdir -p "${destination}/etc/armbian/lightdm/lightdm.conf.d"
+echo -e "[SeatDefaults]\ngreeter-session=slick-greeter\n" > "${destination}"/etc/armbian/lightdm/lightdm.conf.d/10-slick-greeter.conf

--- a/config/optional/boards/rk322x-box/_config/desktop/focal/environments/xfce/packages
+++ b/config/optional/boards/rk322x-box/_config/desktop/focal/environments/xfce/packages
@@ -1,0 +1,1 @@
+slick-greeter

--- a/packages/blobs/desktop/lightdm/slick-greeter.conf
+++ b/packages/blobs/desktop/lightdm/slick-greeter.conf
@@ -3,9 +3,8 @@ background = /usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-blurred-3
 theme-name = Numix
 icon-theme-name = Numix
 font-name = Sans 11
-default-user-image = /usr/share/pixmaps/armbian/armbian.png
-screensaver-timeout = 20
 draw-user-background = false
-keyboard = onboard --theme=ModelM
-reader = orca
+show-keyboard = true
+onscreen-keyboard = false
+screen-reader = true
 draw-grid = true

--- a/packages/blobs/desktop/lightdm/slick-greeter.conf
+++ b/packages/blobs/desktop/lightdm/slick-greeter.conf
@@ -1,0 +1,11 @@
+[Greeter]
+background = /usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-blurred-3840x2160.jpg
+theme-name = Numix
+icon-theme-name = Numix
+font-name = Sans 11
+default-user-image = /usr/share/pixmaps/armbian/armbian.png
+screensaver-timeout = 20
+draw-user-background = false
+keyboard = onboard --theme=ModelM
+reader = orca
+draw-grid = true


### PR DESCRIPTION
keeps lightdm-gtk-greeter installed, but configures an additional .conf file to switch to slick-greeter

# Description

As per Jira reference, lightdm-gtk-greeter seems to be broken for Ubuntu Focal armhf ~~or at least on some armhf architecture works (rk3288, Cortex-A17) and on some others loops indefinitely with 100% cpu usage (rk322x, Cortex-A7)~~ . This workaround uses the recently introduced desktop packaging to install and configure slick-greeter for rk322x-box board only.

If this is proper, the same can be replicated for other boards/families suffering the same bug (maybe related: https://forum.armbian.com/topic/18012-lightdm-gtk-greeter-eats-100-cpu-in-armbian-21023-desktop-for-orangepi-pc/)

Jira reference number AR-632

# How Has This Been Tested?

- [x] Compiled and tried a legacy 4.4 kernel Armbian build for rk322x-box
- [x] Compiled and tried a current 5.10 kernel Armbian build for rk322x-box

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
