### PR TITLE
Fix issues in read_password()

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -27,16 +27,38 @@ read_password()
 {
 
 	unset password
+	unset charcount
 	prompt="$1 password: "
+
+	stty -echo
+
+	charcount=0
 	while IFS= read -p "$prompt" -r -s -n 1 char
 	do
 		if [[ $char == $'\0' ]]
 		then
 			break
 		fi
-		prompt='*'
-		password+="$char"
+
+		# Handle backspace
+		if [[ $char == $'\177' ]]
+		then
+			if [ $charcount -gt 0 ]
+			then
+				charcount=$((charcount-1))
+				prompt=$'\b \b'
+				password="${password%?}"
+			else
+				prompt=''
+			fi
+		else
+			charcount=$((charcount+1))
+			prompt='*'
+			password+="$char"
+		fi
 	done
+
+	stty echo
 
 }
 


### PR DESCRIPTION
# Description

I found the original `read_password()` in this [article](https://stackoverflow.com/a/1923893/8342172), and there is another [answer](https://stackoverflow.com/a/24600839/8342172) in same article point out that there are some issues with original method.

- When trying to delete by using "backspace", it will also print a `*` and also appended to password
- When pressing keys too fast, it is possible that some characters actually printed on the screen


# How Has This Been Tested?
- [x] write a basic script to test the result of read_password()
```sh
#!/bin/bash

read_password ()
{
    .......
}

read_password "Test"
echo ""
echo "Result: $password, length: "${#password}""
printf "$password" | xxd
```

If using old method, and input is "12345" with a "backspace", the result is
```sh
Test password: ******
Result: 1234, length: 6
00000000: 3132 3334 357f                           12345.
```
It will print 6 `*`, the printed `$password` is same as expected, but actually the length and the hex string is wrong.

then if using same input for new method, the result is
```sh
Test password: ****
1234, length: 4
00000000: 3132 3334                                1234
```
which only print 4 `*`, and all other thing are same as expected. 

- [x] Built an image for OrangePi PC, and tested entering password.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
