### PR TITLE
rockchip: add missing rk3288-tinker-s.dts file

### DIFF
--- a/patch/kernel/archive/rockchip-4.4/5000-add-link-for-tinker-dtb-file.patch
+++ b/patch/kernel/archive/rockchip-4.4/5000-add-link-for-tinker-dtb-file.patch
@@ -2,11 +2,12 @@ diff --git a/arch/arm/boot/dts/Makefile b/arch/arm/boot/dts/Makefile
 index eff87a3..58fade2 100644
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -762,6 +762,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += \
+@@ -762,6 +762,8 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += \
  	rk3288-firefly-rk808.dtb \
  	rk3288-firefly.dtb \
  	rk3288-miniarm.dtb \
 + 	rk3288-tinker.dtb \
++ 	rk3288-tinker-s.dtb \
  	rk3288-miqi.dtb \
  	rk3288-phycore-rdk.dtb \
  	rk3288-popmetal.dtb \
@@ -15,6 +16,14 @@ new file mode 120000
 index 0000000..830ab68
 --- /dev/null
 +++ b/arch/arm/boot/dts/rk3288-tinker.dts
+@@ -0,0 +1 @@
++rk3288-miniarm.dts
+\ No newline at end of file
+diff --git a/arch/arm/boot/dts/rk3288-tinker-s.dts b/arch/arm/boot/dts/rk3288-tinker-s.dts
+new file mode 120000
+index 0000000..830ab68
+--- /dev/null
++++ b/arch/arm/boot/dts/rk3288-tinker-s.dts
 @@ -0,0 +1 @@
 +rk3288-miniarm.dts
 \ No newline at end of file


### PR DESCRIPTION
fix the kernel 4.4 boot issue introduced by 3f30b48 (#2791)
