### PR TITLE
Add xfs support into docker builder container

### DIFF
--- a/config/templates/Dockerfile
+++ b/config/templates/Dockerfile
@@ -96,6 +96,7 @@ RUN apt-get update \
        uuid-runtime \
        wget \
        whiptail \
+       xfsprogs \
        xxd \
        zip \
        zlib1g-dev \


### PR DESCRIPTION
Without it `ROOTFS_TYPE=xfs` not work with docker
