### PR TITLE
Do not pre-install obsolete apt-transport-https

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -171,7 +171,7 @@ if [[ "${1}" == docker && -f /etc/debian_version && -z "$(command -v docker)" ]]
 	echo "deb [arch=amd64] https://download.docker.com/linux/${codeid} ${codename} edge" > /etc/apt/sources.list.d/docker.list
 
 	# minimal set of utilities that are needed for prep
-	packages=("curl" "gnupg" "apt-transport-https")
+	packages=("curl" "gnupg")
 	for i in "${packages[@]}"
 	do
 	[[ ! $(command -v "${i}") ]] && install_packages+=${i}" "

--- a/config/cli/bullseye/debootstrap/packages
+++ b/config/cli/bullseye/debootstrap/packages
@@ -1,4 +1,4 @@
-locales gnupg ifupdown apt-utils apt-transport-https ca-certificates bzip2 console-setup 
+locales gnupg ifupdown apt-utils ca-certificates bzip2 console-setup 
 cpio cron dbus init initramfs-tools iputils-ping isc-dhcp-client kmod less libpam-systemd 
 linux-base logrotate netbase netcat-openbsd rsyslog systemd sudo ucf udev whiptail 
 wireless-regdb crda dmsetup rsync tzdata haveged fdisk

--- a/config/cli/buster/debootstrap/packages
+++ b/config/cli/buster/debootstrap/packages
@@ -1,4 +1,4 @@
-locales gnupg ifupdown apt-utils apt-transport-https ca-certificates bzip2 console-setup 
+locales gnupg ifupdown apt-utils ca-certificates bzip2 console-setup 
 cpio cron dbus init initramfs-tools iputils-ping isc-dhcp-client kmod less libpam-systemd 
 linux-base logrotate netbase netcat-openbsd rsyslog systemd sudo ucf udev whiptail 
 wireless-regdb crda dmsetup rsync tzdata haveged fdisk

--- a/config/cli/focal/debootstrap/packages
+++ b/config/cli/focal/debootstrap/packages
@@ -1,4 +1,4 @@
-locales gnupg ifupdown apt-utils apt-transport-https ca-certificates bzip2 console-setup 
+locales gnupg ifupdown apt-utils ca-certificates bzip2 console-setup 
 cpio cron dbus init initramfs-tools iputils-ping isc-dhcp-client kmod less libpam-systemd 
 linux-base logrotate netbase netcat-openbsd rsyslog systemd sudo ucf udev whiptail 
 wireless-regdb crda dmsetup rsync tzdata rng-tools fdisk

--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -683,7 +683,7 @@ compile_armbian-config()
 	Maintainer: $MAINTAINER <$MAINTAINERMAIL>
 	Replaces: armbian-bsp, neofetch
 	Depends: bash, iperf3, psmisc, curl, bc, expect, dialog, pv, zip, \
-	debconf-utils, unzip, build-essential, html2text, apt-transport-https, html2text, dirmngr, software-properties-common, debconf, jq
+	debconf-utils, unzip, build-essential, html2text, html2text, dirmngr, software-properties-common, debconf, jq
 	Recommends: armbian-bsp
 	Suggests: libpam-google-authenticator, qrencode, network-manager, sunxi-tools
 	Section: utils


### PR DESCRIPTION
# Description

Since APT v1.6, HTTPS capabilities are part of the apt core package, hence apt-transport-https is not required anymore. This version is part of Debian since Stretch and Ubuntu since Bionic. The apt-transport-https still exists as transitional dummy package only.
- Changelog: https://salsa.debian.org/apt-team/apt/-/raw/main/debian/changelog
- Debian package: https://packages.debian.org/apt-transport-https
- Ubuntu package: https://packages.ubuntu.com/apt-transport-https

Jira reference number [`I'll open one, if required`]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] `apt purge apt-transport-https`
- [x] `apt install <anything_from_https_source>`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas `does not apply`
- [x] I have made corresponding changes to the documentation `does not apply`
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

I recognised there is a `nightly` branch, but I followed other open PRs to open against `master` branch. Feel free to, or ask me to rebase, if required.