### PR TITLE
Fix NanoPi R4S USB

### DIFF
--- a/patch/kernel/archive/rockchip64-5.10/board-nanopc-t4-add-typec-dp.patch
+++ b/patch/kernel/archive/rockchip64-5.10/board-nanopc-t4-add-typec-dp.patch
@@ -5,15 +5,22 @@ Subject: [PATCH] Patching something
 
 Signed-off-by: tonymac32 <tonymckahan@gmail.com>
 ---
- .../boot/dts/rockchip/rk3399-nanopc-t4.dts    | 83 +++++++++++++++++++
- .../boot/dts/rockchip/rk3399-nanopi4.dtsi     | 27 +++---
- 2 files changed, 98 insertions(+), 12 deletions(-)
+ .../boot/dts/rockchip/rk3399-nanopc-t4.dts    | 100 +++++++++++++++++++
+ 1 file changed, 98 insertions(+), 12 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-nanopc-t4.dts b/arch/arm64/boot/dts/rockchip/rk3399-nanopc-t4.dts
-index e0d75617b..bbe200ab6 100644
+index e0d75617b..68f1a06fa 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-nanopc-t4.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopc-t4.dts
-@@ -66,6 +66,12 @@ fan: pwm-fan {
+@@ -9,6 +9,7 @@
+  */
+ 
+ /dts-v1/;
++#include <dt-bindings/usb/pd.h>
+ #include "rk3399-nanopi4.dtsi"
+ 
+ / {
+@@ -66,6 +67,12 @@ fan: pwm-fan {
  	};
  };
  
@@ -26,7 +33,7 @@ index e0d75617b..bbe200ab6 100644
  &cpu_thermal {
  	trips {
  		cpu_warm: cpu_warm {
-@@ -94,6 +100,50 @@ map3 {
+@@ -94,6 +101,50 @@ map3 {
  	};
  };
  
@@ -77,7 +84,7 @@ index e0d75617b..bbe200ab6 100644
  &pcie0 {
  	num-lanes = <4>;
  	vpcie3v3-supply = <&vcc3v3_sys>;
-@@ -113,14 +163,47 @@ &sdhci {
+@@ -113,12 +164,57 @@ &sdhci {
  	mmc-hs400-enhanced-strobe;
  };
  
@@ -102,82 +109,39 @@ index e0d75617b..bbe200ab6 100644
 +	};
 +};
 +
++&u2phy0 {
++	extcon = <&fusb0>;
++};
++
  &u2phy0_host {
  	phy-supply = <&vcc5v0_host0>;
- };
- 
++	status = "okay";
++};
++
 +&u2phy0_otg {
++	status = "okay";
++
 +	port {
 +		u2phy0_typec_hs: endpoint {
 +			remote-endpoint = <&usb_con_hs>;
 +		};
 +	};
-+};
-+
+ };
+ 
  &u2phy1_host {
  	phy-supply = <&vcc5v0_host0>;
- };
- 
-+&usbdrd_dwc3_0 {
-+	extcon = <&fusb0>;
++	status = "okay";
 +};
 +
- &vcc5v0_sys {
- 	vin-supply = <&vcc12v0_sys>;
- };
-diff --git a/arch/arm64/boot/dts/rockchip/rk3399-nanopi4.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-nanopi4.dtsi
-index 86e802fd8..9c2e8c8ae 100644
---- a/arch/arm64/boot/dts/rockchip/rk3399-nanopi4.dtsi
-+++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi4.dtsi
-@@ -13,6 +13,7 @@
- 
- /dts-v1/;
- #include <dt-bindings/input/linux-event-codes.h>
-+#include <dt-bindings/usb/pd.h>
- #include "rk3399.dtsi"
- #include "rk3399-opp.dtsi"
- 
-@@ -706,26 +707,28 @@ &tsadc {
- 
- &u2phy0 {
- 	status = "okay";
--};
++&u2phy1_otg {
++	status = "okay";
++};
++
++&usbdrd_dwc3_0 {
 +	extcon = <&fusb0>;
- 
--&u2phy0_host {
--	status = "okay";
--};
-+	u2phy0_otg: otg-port {
-+		status = "okay";
-+	};
- 
--&u2phy0_otg {
--	status = "okay";
-+	u2phy0_host: host-port {
-+		status = "okay";
-+	};
  };
  
- &u2phy1 {
- 	status = "okay";
--};
-+	
-+	u2phy1_otg: otg-port {
-+		status = "okay";
-+	};
- 
--&u2phy1_host {
--	status = "okay";
--};
-+	u2phy1_host: host-port {
-+		status = "okay";
-+	};
- 
--&u2phy1_otg {
--	status = "okay";
- };
- 
- &uart0 {
+ &vcc5v0_sys {
 -- 
 Created with Armbian build tools https://github.com/armbian/build
 


### PR DESCRIPTION
# Description

NanoPi R4S' USB ports got disabled with https://github.com/armbian/build/pull/2676

@Tonymac32 I moved all the changes into board specific device tree.
It should be transparent but I don't have NanoPC T4 to regression test DP altmode with TypeC. Would you be able to do that?

Jira reference number [AR-780]

# How Has This Been Tested?

- [x] lsusb displays 6 USB hubs again (vs 2 without the change) http://ix.io/3oUp
- [x] usb 3.0 pendrive recognised as SuperSpeed Gen 1 in both ports
- [ ] tested NanoPC T4 for DP altmode with TypeC

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-780]: https://armbian.atlassian.net/browse/AR-780