### PR TITLE
Filter out docker veth interfaces

### DIFF
--- a/packages/bsp/common/etc/default/armbian-motd.dpkg-dist
+++ b/packages/bsp/common/etc/default/armbian-motd.dpkg-dist
@@ -7,7 +7,7 @@
 MOTD_DISABLE=""
 ONE_WIRE=""
 SHOW_IP_PATTERN="^bond.*|^[ewr].*|^br.*|^lt.*|^umts.*|^lan.*"
-PRIMARY_INTERFACE="$(ls -1 /sys/class/net/ | grep -v lo | egrep "enp|eth" | head -1)"
+PRIMARY_INTERFACE="$(ls -1 /sys/class/net/ | grep -Ev "(lo|veth*|br-*)" | egrep "enp|eth" | head -1)"
 PRIMARY_DIRECTION="rx"
 STORAGE=/dev/sda1
 


### PR DESCRIPTION
# Description

A naïve attempt to grep out docker interfaces from vnstat used in the motd.


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Ran `ls -1 /sys/class/net/ | grep -Ev "(lo|veth*|br-*)" | sed -n -e 'H;${x;s/\n/+/g;s/^+//;p;}'` and compared to the existing `ls -1 /sys/class/net/ | grep -v lo | sed -n -e 'H;${x;s/\n/+/g;s/^+//;p;}'` expression in /etc/default/armbian-motd
- [X] Substituted inline PRIMARY_INTERFACES in /etc/update-motd.d/30-armbian-sysinfo with the expression and ran the script

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
