### PR TITLE
Add images building action

### DIFF
--- a/.github/workflows/build-beta-images.yml
+++ b/.github/workflows/build-beta-images.yml
@@ -1,0 +1,276 @@
+name: CLI beta images
+
+on:
+
+  workflow_run:
+
+    workflows: ["Build"]
+    branches: [master]
+    types:
+      - completed
+
+jobs:
+
+    worker-1:
+
+      name: CLI worker 1/3
+      runs-on: [self-hosted, Linux, big, cache]
+      steps:
+
+        - name: Fix permissions
+          run: |
+
+            sudo chown -R $USER:$USER .
+
+        - name: Checkout Armbian build script
+
+          uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
+            repository: armbian/build
+            path: build
+            ref: nightly
+            clean: false
+
+        - name: Checkout Armbian support scripts
+
+          uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
+            repository: armbian/scripts
+            token: ${{ secrets.SCRIPTS_ACCESS_TOKEN }}
+            path: scripts
+            clean: false
+
+        - name: Import GPG key
+
+          uses: crazy-max/ghaction-import-gpg@v3
+          with:
+            gpg-private-key: ${{ secrets.GPG_KEY2 }}
+            passphrase: ${{ secrets.GPG_PASSPHRASE2 }}
+            workdir: scripts
+            git-user-signingkey: true
+            git-commit-gpgsign: true
+        
+        - name: Build beta images
+          env:
+            GPG_PASS: ${{ secrets.PASSPHRASE }}
+
+          run: |
+
+            cd build
+
+            # use prepared configs
+            sudo cp ../scripts/configs/* userpatches/
+
+            # prepare host
+            [[ ! -f .ignore_changes ]] && sudo touch .ignore_changes
+            ./compile.sh KERNEL_ONLY="yes" BOARD="bananapi" BRANCH="current" KERNEL_CONFIGURE="no" USE_TORRENT="yes" REPOSITORY_INSTALL="kernel" 'prepare_host'
+
+            # calculate how many images we can build in parallel
+            PARALLEL_BUILDS=$(awk '{printf("%d",$1/4000)}' <<<$(($(LC_ALL=C free -w 2>/dev/null | grep "^Mem" | awk '{print $2}' || LC_ALL=C free | grep "^Mem"| awk '{print $2}')/1024)))
+
+            # cleaning leftovers if any
+            rm -rf output/images/*
+
+            # split into 2 build chunks
+            cat config/targets-cli-beta.conf | grep -v "^$" | grep -v "^#"  > userpatches/split.conf
+            split -d --number=l/2 --additional-suffix=.conf --suffix-length=1 userpatches/split.conf userpatches/split-
+
+            sudo ln -sf split-0.conf userpatches/targets.conf # Building chunk 1
+
+            ./compile.sh all-new-beta-images MULTITHREAD="${PARALLEL_BUILDS}" GPG_PASS="${GPG_PASS}"
+
+        - name: Install SSH key for storage
+
+          uses: shimataro/ssh-key-action@v2
+          with:
+            key: ${{ secrets.KEY_TORRENTS }}
+            known_hosts: ${{ secrets.KNOWN_HOSTS_UPLOAD }}
+            if_key_exists: replace
+
+        - name: Deploy to server
+
+          if: ${{ success() }}
+
+          run: |
+
+            sudo apt-get -y -qq install lftp
+            sudo chown -R $USER:$USER $(pwd)/build/output/images/
+            lftp -u upload, -e "set net:timeout 4;set net:max-retries 6;mirror --Remove-source-files -R --no-empty-dirs --parallel=8 --no-perms $(pwd)/build/output/images/ images/ ;bye" sftp://users.armbian.com
+
+    worker-2:
+
+      name: CLI worker 2/3
+      runs-on: [self-hosted, Linux, big, cache]
+      steps:
+
+        - name: Fix permissions
+          run: |
+
+            sudo chown -R $USER:$USER .
+
+        - name: Checkout Armbian build script
+
+          uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
+            repository: armbian/build
+            path: build
+            ref: nightly
+            clean: false
+
+        - name: Checkout Armbian support scripts
+
+          uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
+            repository: armbian/scripts
+            token: ${{ secrets.SCRIPTS_ACCESS_TOKEN }}
+            path: scripts
+            clean: false
+
+        - name: Import GPG key
+
+          uses: crazy-max/ghaction-import-gpg@v3
+          with:
+            gpg-private-key: ${{ secrets.GPG_KEY2 }}
+            passphrase: ${{ secrets.GPG_PASSPHRASE2 }}
+            workdir: scripts
+            git-user-signingkey: true
+            git-commit-gpgsign: true
+        
+        - name: Build beta images
+          env:
+            GPG_PASS: ${{ secrets.PASSPHRASE }}
+
+          run: |
+
+            cd build
+
+            # use prepared configs
+            sudo cp ../scripts/configs/* userpatches/
+
+            # prepare host
+            [[ ! -f .ignore_changes ]] && sudo touch .ignore_changes
+            ./compile.sh KERNEL_ONLY="yes" BOARD="bananapi" BRANCH="current" KERNEL_CONFIGURE="no" USE_TORRENT="yes" REPOSITORY_INSTALL="kernel" 'prepare_host'
+
+            # calculate how many images we can build in parallel
+            PARALLEL_BUILDS=$(awk '{printf("%d",$1/4000)}' <<<$(($(LC_ALL=C free -w 2>/dev/null | grep "^Mem" | awk '{print $2}' || LC_ALL=C free | grep "^Mem"| awk '{print $2}')/1024)))
+
+            # cleaning leftovers if any
+            rm -rf output/images/*
+
+            # split into 2 build chunks
+            cat config/targets-cli-beta.conf | grep -v "^$" | grep -v "^#"  > userpatches/split.conf
+            split -d --number=l/2 --additional-suffix=.conf --suffix-length=1 userpatches/split.conf userpatches/split-
+
+            sudo ln -sf split-1.conf userpatches/targets.conf # Building chunk 2
+
+            ./compile.sh all-new-beta-images MULTITHREAD="${PARALLEL_BUILDS}" GPG_PASS="${GPG_PASS}"
+
+        - name: Install SSH key for storage
+
+          uses: shimataro/ssh-key-action@v2
+          with:
+            key: ${{ secrets.KEY_TORRENTS }}
+            known_hosts: ${{ secrets.KNOWN_HOSTS_UPLOAD }}
+            if_key_exists: replace
+
+        - name: Deploy to server
+
+          if: ${{ success() }}
+
+          run: |
+
+            sudo apt-get -y -qq install lftp
+            sudo chown -R $USER:$USER $(pwd)/build/output/images/
+            lftp -u upload, -e "set net:timeout 4;set net:max-retries 6;mirror --Remove-source-files -R --no-empty-dirs --parallel=8 --no-perms $(pwd)/build/output/images/ images/ ;bye" sftp://users.armbian.com
+
+    worker-3:
+
+      name: CLI worker 3/3
+      runs-on: [self-hosted, Linux, big, cache]
+      steps:
+
+        - name: Fix permissions
+          run: |
+
+            sudo chown -R $USER:$USER .
+
+        - name: Checkout Armbian build script
+
+          uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
+            repository: armbian/build
+            path: build
+            ref: nightly
+            clean: false
+
+        - name: Checkout Armbian support scripts
+
+          uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
+            repository: armbian/scripts
+            token: ${{ secrets.SCRIPTS_ACCESS_TOKEN }}
+            path: scripts
+            clean: false
+
+        - name: Import GPG key
+
+          uses: crazy-max/ghaction-import-gpg@v3
+          with:
+            gpg-private-key: ${{ secrets.GPG_KEY2 }}
+            passphrase: ${{ secrets.GPG_PASSPHRASE2 }}
+            workdir: scripts
+            git-user-signingkey: true
+            git-commit-gpgsign: true
+        
+        - name: Build beta images
+          env:
+            GPG_PASS: ${{ secrets.PASSPHRASE }}
+
+          run: |
+
+            cd build
+
+            # use prepared configs
+            sudo cp ../scripts/configs/* userpatches/
+
+            # prepare host
+            [[ ! -f .ignore_changes ]] && sudo touch .ignore_changes
+            ./compile.sh KERNEL_ONLY="yes" BOARD="bananapi" BRANCH="current" KERNEL_CONFIGURE="no" USE_TORRENT="yes" REPOSITORY_INSTALL="kernel" 'prepare_host'
+
+            # calculate how many images we can build in parallel
+            PARALLEL_BUILDS=$(awk '{printf("%d",$1/4000)}' <<<$(($(LC_ALL=C free -w 2>/dev/null | grep "^Mem" | awk '{print $2}' || LC_ALL=C free | grep "^Mem"| awk '{print $2}')/1024)))
+
+            # cleaning leftovers if any
+            rm -rf output/images/*
+
+            # split into 3 build chunks
+            cat config/targets-cli-beta.conf | grep -v "^$" | grep -v "^#"  > userpatches/split.conf
+            split -d --number=l/3 --additional-suffix=.conf --suffix-length=1 userpatches/split.conf userpatches/split-
+
+            sudo ln -sf split-2.conf userpatches/targets.conf # Building chunk 3
+
+            ./compile.sh all-new-beta-images MULTITHREAD="${PARALLEL_BUILDS}" GPG_PASS="${GPG_PASS}"
+
+        - name: Install SSH key for storage
+
+          uses: shimataro/ssh-key-action@v2
+          with:
+            key: ${{ secrets.KEY_TORRENTS }}
+            known_hosts: ${{ secrets.KNOWN_HOSTS_UPLOAD }}
+            if_key_exists: replace
+
+        - name: Deploy to server
+
+          if: ${{ success() }}
+
+          run: |
+
+            sudo apt-get -y -qq install lftp
+            sudo chown -R $USER:$USER $(pwd)/build/output/images/
+            lftp -u upload, -e "set net:timeout 4;set net:max-retries 6;mirror --Remove-source-files -R --no-empty-dirs --parallel=8 --no-perms $(pwd)/build/output/images/ images/ ;bye" sftp://users.armbian.com

--- a/.github/workflows/build-beta-images.yml
+++ b/.github/workflows/build-beta-images.yml
@@ -76,9 +76,9 @@ jobs:
             # cleaning leftovers if any
             rm -rf output/images/*
 
-            # split into 2 build chunks
+            # split into 3 build chunks
             cat config/targets-cli-beta.conf | grep -v "^$" | grep -v "^#"  > userpatches/split.conf
-            split -d --number=l/2 --additional-suffix=.conf --suffix-length=1 userpatches/split.conf userpatches/split-
+            split -d --number=l/3 --additional-suffix=.conf --suffix-length=1 userpatches/split.conf userpatches/split-
 
             sudo ln -sf split-0.conf userpatches/targets.conf # Building chunk 1
 
@@ -165,9 +165,9 @@ jobs:
             # cleaning leftovers if any
             rm -rf output/images/*
 
-            # split into 2 build chunks
+            # split into 3 build chunks
             cat config/targets-cli-beta.conf | grep -v "^$" | grep -v "^#"  > userpatches/split.conf
-            split -d --number=l/2 --additional-suffix=.conf --suffix-length=1 userpatches/split.conf userpatches/split-
+            split -d --number=l/3 --additional-suffix=.conf --suffix-length=1 userpatches/split.conf userpatches/split-
 
             sudo ln -sf split-1.conf userpatches/targets.conf # Building chunk 2
 

--- a/.github/workflows/build-beta-images.yml
+++ b/.github/workflows/build-beta-images.yml
@@ -2,6 +2,8 @@ name: CLI beta images
 
 on:
 
+  workflow_dispatch:
+
   workflow_run:
 
     workflows: ["Build"]
@@ -15,6 +17,7 @@ jobs:
 
       name: CLI worker 1/3
       runs-on: [self-hosted, Linux, big, cache]
+      if: ${{ github.repository_owner == 'Armbian' }}
       steps:
 
         - name: Fix permissions
@@ -103,6 +106,7 @@ jobs:
 
       name: CLI worker 2/3
       runs-on: [self-hosted, Linux, big, cache]
+      if: ${{ github.repository_owner == 'Armbian' }}
       steps:
 
         - name: Fix permissions
@@ -191,6 +195,7 @@ jobs:
 
       name: CLI worker 3/3
       runs-on: [self-hosted, Linux, big, cache]
+      if: ${{ github.repository_owner == 'Armbian' }}
       steps:
 
         - name: Fix permissions


### PR DESCRIPTION
# Description

This action will make CLI beta images after successful run of main build script. Initially we will use up to 3 build servers to make images in parallel and distributed around runners.

# How Has This Been Tested?

Several dry runs.