### PR TITLE
armbian-ramlog: extra rsync options

### DIFF
--- a/packages/bsp/common/etc/default/armbian-ramlog.dpkg-dist
+++ b/packages/bsp/common/etc/default/armbian-ramlog.dpkg-dist
@@ -10,3 +10,15 @@ SIZE=50M
 # requires rsync installed, may provide better performance
 # due to copying only new and changed files
 USE_RSYNC=true
+
+# If USE_RSYNC is true, additional options may be specified for the rsync
+# commands used to synchronize logs to disk from RAM (XTRA_RSYNC_TO) or from
+# disk to RAM (XTRA_RSYNC_FROM).  These are bash arrays to make specifying
+# multiple arguments easy even in the presence of whitespace.
+XTRA_RSYNC_TO=(
+  ## If you use log rotation programs that datestamp their logs (e.g., runit's
+  ## svlogd or daemontools' multilog), deleting log files while synchronizing is
+  ## likely a good idea.
+  # --delete
+)
+XTRA_RSYNC_FROM=()

--- a/packages/bsp/common/usr/lib/armbian/armbian-ramlog
+++ b/packages/bsp/common/usr/lib/armbian/armbian-ramlog
@@ -48,7 +48,11 @@ syncToDisk () {
 	echo -e "\n\n$(date): Syncing logs to storage\n" | $LOG_OUTPUT
 
 	if [ "$USE_RSYNC" = true ]; then
-		${NoCache} rsync -aXWv --exclude "lost+found" --exclude armbian-ramlog.log --links $RAM_LOG $HDD_LOG 2>&1 | $LOG_OUTPUT
+		${NoCache} rsync -aXWv \
+			--exclude "lost+found" --exclude armbian-ramlog.log \
+			--links \
+			${XTRA_RSYNC_TO[@]+"${XTRA_RSYNC_TO[@]}"} \
+			$RAM_LOG $HDD_LOG 2>&1 | $LOG_OUTPUT
 	else
 		${NoCache} cp -rfup $RAM_LOG -T $HDD_LOG 2>&1 | $LOG_OUTPUT
 	fi
@@ -62,7 +66,12 @@ syncFromDisk () {
 	echo -e "\n\n$(date): Loading logs from storage\n" | $LOG_OUTPUT
 
 	if [ "$USE_RSYNC" = true ]; then
-		${NoCache} rsync -aXWv --delete --exclude "lost+found" --exclude armbian-ramlog.log --exclude *.gz --exclude *.xz --exclude='*.[0-9]' --links $HDD_LOG $RAM_LOG 2>&1 | $LOG_OUTPUT
+		${NoCache} rsync -aXWv --delete \
+			--exclude "lost+found" --exclude armbian-ramlog.log \
+			--exclude *.gz --exclude *.xz --exclude='*.[0-9]' \
+			--links \
+			${XTRA_RSYNC_FROM[@]+"${XTRA_RSYNC_FROM[@]}"} \
+			$HDD_LOG $RAM_LOG 2>&1 | $LOG_OUTPUT
 	else
 		${NoCache} find $HDD_LOG* -maxdepth 1 -type f -not \( -name '*.[0-9]' -or -name '*.xz*' -or -name '*.gz' \) | xargs cp -ut $RAM_LOG
 	fi


### PR DESCRIPTION
# Description

Add two bash arrays, XTRA_RSYNC_{FROM,TO}, defined in
/etc/default/armbian-ramlog, and expand these in the two rsync
invocations in /usr/lib/armbian/armbian-ramlog.

The use of bash arrays simplifies the use of multiple arguments and also
allows for in-band commentary between array elements.

When expanding, safely test for these arrays to exist.  This is, sadly,
a little verbose in bash, so, while here, split the rsync invocations to
use line continuations.

Fixes https://github.com/armbian/build/issues/2846

# How Has This Been Tested?

Local deployment.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

I amn't sure about style, I don't expect any additional commentary is needed, I don't believe there's any documentation to update, and I don't think there are any dependent changes. :)