### PR TITLE
Modify the mechanism for showing IP address in 30-armbian-sysinfo

### DIFF
--- a/packages/bsp/common/etc/default/armbian-motd.dpkg-dist
+++ b/packages/bsp/common/etc/default/armbian-motd.dpkg-dist
@@ -6,7 +6,7 @@
 
 MOTD_DISABLE=""
 ONE_WIRE=""
-SHOW_IP_PATTERN="^bond.*|^[ewr].*|^br.*|^lt.*|^umts.*|^lan.*"
+HIDE_IP_PATTERN="^dummy0|^lo"
 PRIMARY_INTERFACE="$(ls -1 /sys/class/net/ | grep -v lo | egrep "enp|eth" | head -1)"
 PRIMARY_DIRECTION="rx"
 STORAGE=/dev/sda1

--- a/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
+++ b/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
@@ -19,7 +19,7 @@ MOTD_DISABLE=""
 PRIMARY_INTERFACE="eth0"
 PRIMARY_DIRECTION="rx"
 STORAGE=/dev/sda1
-SHOW_IP_PATTERN="^bond.*|^[ewr].*|^br.*|^lt.*|^umts.*|^lan.*"
+HIDE_IP_PATTERN="^dummy0|^lo"
 CPU_TEMP_LIMIT=60
 # Temperature offset in Celcius degrees
 CPU_TEMP_OFFSET=0
@@ -134,8 +134,10 @@ function get_ip_addresses() {
 	local ips=()
 	for f in /sys/class/net/*; do
 		local intf=$(basename $f)
-		# match only interface names starting with e (Ethernet), br (bridge), w (wireless), r (some Ralink drivers use ra<number> format)
-		if [[ $intf =~ $SHOW_IP_PATTERN ]]; then
+		# match only interface names "dummy0" and "lo"
+		if [[ $intf =~ $HIDE_IP_PATTERN ]]; then
+			continue
+		else
 			local tmp=$(ip -4 addr show dev $intf | awk '/inet/ {print $2}' | cut -d'/' -f1)
 			# add both name and IP - can be informative but becomes ugly with long persistent/predictable device names
 			#[[ -n $tmp ]] && ips+=("$intf: $tmp")


### PR DESCRIPTION
# Description

This PR is for #2882 

Exclude "dummy0" and "lo" interface, thus the IP address for all other interface(include those having customized name) can be properly displayed.

# How Has This Been Tested?

This is what I have for ifconfig
```sh
root@localhost:~# ifconfig -a
dummy0: flags=130<BROADCAST,NOARP>  mtu 1500
        ether 76:d9:99:2f:63:f4  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 0  bytes 0 (0.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

eth0: flags=4099<UP,BROADCAST,MULTICAST>  mtu 1500
        ether 02:81:3a:05:d0:ac  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 0  bytes 0 (0.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
        device interrupt 38

lo: flags=73<UP,LOOPBACK,RUNNING>  mtu 65536
        inet 127.0.0.1  netmask 255.0.0.0
        inet6 ::1  prefixlen 128  scopeid 0x10<host>
        loop  txqueuelen 1000  (Local Loopback)
        RX packets 2338  bytes 16837768 (16.0 MiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 2338  bytes 16837768 (16.0 MiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

usb0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 192.168.137.188  netmask 255.255.255.0  broadcast 192.168.137.255
        inet6 fe80::b7f7:6e13:ce23:9bf2  prefixlen 64  scopeid 0x20<link>
        inet6 2401:e180:8d03:5541:4893:353b:4c78:5516  prefixlen 64  scopeid 0x0<global>
        ether 8a:5e:fe:a6:ec:44  txqueuelen 1000  (Ethernet)
        RX packets 128  bytes 28684 (28.0 KiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 107  bytes 15290 (14.9 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

wlx2cda98f1a6b7: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 192.168.10.9  netmask 255.255.255.0  broadcast 192.168.10.255
        inet6 fe80::3af9:e3f:40fb:84af  prefixlen 64  scopeid 0x20<link>
        ether 2c:da:98:f1:a6:b7  txqueuelen 1000  (Ethernet)
        RX packets 659312  bytes 73426938 (70.0 MiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 488118  bytes 62256990 (59.3 MiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

root@localhost:~#
```

then this is the execute result
```sh
root@localhost:~# ./30-armbian-sysinfo
System load:   2%               Up time:       14 days 21:13
Memory usage:  10% of 999M      IP:            192.168.137.188 192.168.10.9
CPU temp:      45°C             Usage of /:    35% of 15G

root@localhost:~#
```
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
