### PR TITLE
add packets to aarch64 builder for arm-trusted-firmware #2908

### DIFF
--- a/config/templates/Dockerfile
+++ b/config/templates/Dockerfile
@@ -11,11 +11,11 @@ RUN sh -c " \
     if [ $(dpkg --print-architecture) = amd64 ]; then \
         if [ x'' != x$http_proxy ]; then \
             apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 \
-			    --keyserver-options http-proxy=$http_proxy \
-				--recv-keys ED75B5A4483DA07C >/dev/null 2>&1; \
+                --keyserver-options http-proxy=$http_proxy \
+                --recv-keys ED75B5A4483DA07C >/dev/null 2>&1; \
         else \
             apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 \
-			    --recv-keys ED75B5A4483DA07C >/dev/null 2>&1; \
+                --recv-keys ED75B5A4483DA07C >/dev/null 2>&1; \
         fi; \
         echo \"deb http://repo.aptly.info/ nightly main\" > /etc/apt/sources.list.d/aptly.list; \
         dpkg --add-architecture i386 \
@@ -57,11 +57,14 @@ RUN apt-get update \
        g++-8-arm-linux-gnueabihf \
        gawk \
        gcc-arm-linux-gnueabihf \
+       gcc-arm-linux-gnueabi \
+       gcc-arm-none-eabi \
        git \
        imagemagick \
        jq \
        kmod \
        libbison-dev \
+       libc6-amd64-cross \
        libc6-dev-armhf-cross \
        libfdt-dev \
        libfile-fcntllock-perl \
@@ -95,6 +98,7 @@ RUN apt-get update \
        python3-distutils \
        python3-pkg-resources \
        python3-setuptools \
+       qemu \
        qemu-user-static \
        rsync \
        swig \

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1023,12 +1023,14 @@ prepare_host()
   else
 
 	local hostdeps="wget ca-certificates device-tree-compiler pv bc lzop zip binfmt-support build-essential ccache debootstrap ntpdate \
-	gawk gcc-arm-linux-gnueabihf qemu-user-static u-boot-tools uuid-dev zlib1g-dev unzip libusb-1.0-0-dev fakeroot \
+	gawk gcc-arm-linux-gnueabihf gcc-arm-linux-gnueabi gcc-arm-none-eabi \
+	qemu-user-static u-boot-tools uuid-dev zlib1g-dev unzip libusb-1.0-0-dev fakeroot \
 	parted pkg-config libncurses5-dev whiptail debian-keyring debian-archive-keyring f2fs-tools libfile-fcntllock-perl rsync libssl-dev \
 	nfs-kernel-server btrfs-progs ncurses-term p7zip-full kmod dosfstools libc6-amd64-cross libc6-dev-armhf-cross imagemagick \
 	curl patchutils liblz4-tool libpython2.7-dev linux-base swig aptly acl python3-dev \
 	locales ncurses-base pixz dialog systemd-container udev libfdt-dev libc6 qemu \
-	bison libbison-dev flex libfl-dev cryptsetup gpg gnupg1 cpio aria2 pigz dirmngr python3-distutils"
+	bison libbison-dev flex libfl-dev cryptsetup gpg gnupg1 cpio aria2 pigz \
+	dirmngr python3-distutils "
 
 # build aarch64
   fi


### PR DESCRIPTION
Packages `gcc-arm-none-eabi`, `gcc-arm-linux-gnueabi` have to be on fuilder if it aarch64 architecture.
to get an error run on aarch64 builder
```
# ./compile.sh EXPERT=yes KERNEL_ONLY=no KERNEL_CONFIGURE=no BUILD_DESKTOP=no BUILD_MINIMAL=no RELEASE=focal BOARD=helios64 BRANCH=edge
```

