### PR TITLE
Fixing Wireguard repository tag

### DIFF
--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -676,7 +676,7 @@ compile_armbian-config()
 
 	fetch_from_repo "https://github.com/armbian/config" "armbian-config" "branch:master"
 	fetch_from_repo "https://github.com/dylanaraps/neofetch" "neofetch" "tag:7.1.0"
-	fetch_from_repo "https://github.com/complexorganizations/wireguard-manager" "wireguard-manager" "tag:1.0.11"
+	fetch_from_repo "https://github.com/complexorganizations/wireguard-manager" "wireguard-manager" "tag:v1.0.0.06-20-2021"
 
 	mkdir -p "${tmp_dir}/${armbian_config_dir}"/{DEBIAN,usr/bin/,usr/sbin/,usr/lib/armbian-config/}
 


### PR DESCRIPTION
# Description

Wireguard tool Git has been reorganised and previous tags deleted. Moving to a new one.

Jira reference number [AR-819]

# How Has This Been Tested?

- [x] Build test

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

[AR-819]: https://armbian.atlassian.net/browse/AR-819