### PR TITLE
Docker creation failed to load repository keys

### DIFF
--- a/config/templates/Dockerfile
+++ b/config/templates/Dockerfile
@@ -6,16 +6,14 @@ RUN apt-get update && apt-get -y install \
        gnupg \
        gnupg1 \
        gpgv1 \
+       curl \
     && rm -rf /var/lib/apt/lists/*
 RUN sh -c " \
     if [ $(dpkg --print-architecture) = amd64 ]; then \
         if [ x'' != x$http_proxy ]; then \
-            apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 \
-                --keyserver-options http-proxy=$http_proxy \
-                --recv-keys ED75B5A4483DA07C >/dev/null 2>&1; \
+            curl -fsSL -x $http_proxy https://www.aptly.info/pubkey.txt | apt-key add - >/dev/null 2>&1; \
         else \
-            apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 \
-                --recv-keys ED75B5A4483DA07C >/dev/null 2>&1; \
+            curl -fsSL https://www.aptly.info/pubkey.txt | apt-key add - >/dev/null 2>&1; \
         fi; \
         echo \"deb http://repo.aptly.info/ nightly main\" > /etc/apt/sources.list.d/aptly.list; \
         dpkg --add-architecture i386 \
@@ -44,7 +42,6 @@ RUN apt-get update \
        cpio \
        cryptsetup \
        cryptsetup-bin \
-       curl \
        debian-archive-keyring \
        debian-keyring \
        debootstrap \


### PR DESCRIPTION
# Description

Loading keys from keyserver can be unreliable - switching to repo hosted key.

Jira reference number [AR-821]

# How Has This Been Tested?

- [x] Built Docker image from scratch on x86 host.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

[AR-821]: https://armbian.atlassian.net/browse/AR-821