### PR TITLE
Update board-rockpis-0017-WIP-Sync-rockchip_i2s_tdm-to-BSP-tree.patch

### DIFF
--- a/patch/kernel/archive/rockchip64-5.10/board-rockpis-0017-WIP-Sync-rockchip_i2s_tdm-to-BSP-tree.patch
+++ b/patch/kernel/archive/rockchip64-5.10/board-rockpis-0017-WIP-Sync-rockchip_i2s_tdm-to-BSP-tree.patch
@@ -315,16 +315,6 @@ index 61c984f10d8e..e6125ebfe5a9 100644
  	return 0;
  }
  
-@@ -419,9 +448,6 @@ static int rockchip_i2s_set_sysclk(struct snd_soc_dai *cpu_dai, int clk_id,
- 	struct rk_i2s_dev *i2s = to_info(cpu_dai);
- 	int ret;
- 
--	if (freq == 0)
--		return 0;
--
- 	ret = clk_set_rate(i2s->mclk, freq);
- 	if (ret)
- 		dev_err(i2s->dev, "Fail to set mclk %d\n", ret);
 @@ -471,7 +497,6 @@ static struct snd_soc_dai_driver rockchip_i2s_dai = {
  			    SNDRV_PCM_FMTBIT_S32_LE),
  	},


### PR DESCRIPTION
The patch got rid of a check for a 0 frequency, causing the mclk log error.  eliminate the code.

# Description

No description of the patches function, no reason I could see for getting rid of the check.

[AR-825]

# How Has This Been Tested?

Booted NanoPC T4, I2S errors gone

Booted Rock Pi S, no issues seen.
# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-825]: https://armbian.atlassian.net/browse/AR-825