### PR TITLE
fix wifi m1

### DIFF
--- a/lib/compilation-prepare.sh
+++ b/lib/compilation-prepare.sh
@@ -538,7 +538,7 @@ compilation_prepare()
 
 	# Wireless drivers for Realtek 8723DS chipsets
 
-	if linux-version compare "${version}" ge 5.0 && [ "$EXTRAWIFI" == yes ]; then
+	if linux-version compare "${version}" lt 5.12 && [ "$EXTRAWIFI" == yes ]; then
 
 		# attach to specifics tag or branch
 		local rtl8723dsver="branch:master"


### PR DESCRIPTION
The current WiFi module RTL8723DS does not work with the 5.12 kernel. Its build is disabled for versions 5.12 and later.
