### PR TITLE
Packaging

### DIFF
--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -381,9 +381,6 @@ compile_kernel()
 	fi
 	cd "${kerneldir}" || exit
 
-	if ! grep -qoE '^-rc[[:digit:]]+' <(grep "^EXTRAVERSION" Makefile | head -1 | awk '{print $(NF)}'); then
-		sed -i 's/EXTRAVERSION = .*/EXTRAVERSION = /' Makefile
-	fi
 	rm -f localversion
 
 	# read kernel version

--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -668,7 +668,14 @@ prepare_partitions()
 update_initramfs()
 {
 	local chroot_target=$1
-	update_initramfs_cmd="update-initramfs -uv -k ${VER}-${LINUXFAMILY}"
+	local target_dir=$(
+		find ${chroot_target}/lib/modules/ -maxdepth 1 -type d -name "*${VER}*"
+	)
+	if [ "$target_dir" != "" ]; then
+		update_initramfs_cmd="update-initramfs -uv -k $(basename $target_dir)"
+	else
+		exit_with_error "No kernel installed for the version" "${VER}"
+	fi
 	display_alert "Updating initramfs..." "$update_initramfs_cmd" ""
 	cp /usr/bin/$QEMU_BINARY $chroot_target/usr/bin/
 	mount_chroot "$chroot_target/"

--- a/packages/armbian/builddeb
+++ b/packages/armbian/builddeb
@@ -334,8 +334,10 @@ if [ "$ARCH" != "um" ]; then
 	deploy_libc_headers $libc_headers_dir
 	create_package $libc_headers_packagename $libc_headers_dir
 
-	deploy_kernel_headers $kernel_headers_dir
-	create_package $kernel_headers_packagename $kernel_headers_dir "headers"
+	if is_enabled CONFIG_MODULES; then
+		deploy_kernel_headers $kernel_headers_dir
+		create_package $kernel_headers_packagename $kernel_headers_dir "headers"
+	fi
 
 	create_package "$dtb_packagename" "$dtb_dir" "dtb"
 fi

--- a/packages/armbian/mkdebian
+++ b/packages/armbian/mkdebian
@@ -187,16 +187,6 @@ Description: Linux kernel, armbian version $version $BRANCH
  This package contains the Linux kernel, modules and corresponding other
  files, version: $version.
 
-Package: $kernel_headers_packagename
-Section: devel
-Architecture: $debarch
-Provides: linux-headers, linux-headers-armbian, armbian-$BRANCH
-Depends: make, gcc, libc6-dev, bison, flex, libssl-dev
-Description: Linux kernel headers for $version on $debarch $BRANCH
- This package provides kernel header files for $version on $debarch
- .
- This is useful for people who need to build external modules
-
 Package: $libc_headers_packagename
 Section: devel
 Provides: linux-kernel-headers
@@ -214,6 +204,21 @@ Provides: linux-dtb, linux-dtb-armbian, armbian-$BRANCH
 Description: Armbian Linux DTB, version $version $BRANCH
  This package contains device blobs from the Linux kernel, version $version
 EOF
+
+if is_enabled CONFIG_MODULES; then
+cat <<EOF >> debian/control
+
+Package: $kernel_headers_packagename
+Section: devel
+Architecture: $debarch
+Provides: linux-headers, linux-headers-armbian, armbian-$BRANCH
+Depends: make, gcc, libc6-dev, bison, flex, libssl-dev
+Description: Linux kernel headers for $version on $debarch $BRANCH
+ This package provides kernel header files for $version on $debarch
+ .
+ This is useful for people who need to build external modules
+EOF
+fi
 
 if is_enabled CONFIG_DEBUG_INFO; then
 cat <<EOF >> debian/control

--- a/packages/armbian/mkdebian
+++ b/packages/armbian/mkdebian
@@ -85,6 +85,7 @@ set_debarch() {
 }
 
 # Some variables and settings used throughout the script
+KDEB_SOURCENAME=linux-$KERNELRELEASE
 version=$KERNELRELEASE
 if [ -n "$KDEB_PKGVERSION" ]; then
 	packageversion=$KDEB_PKGVERSION


### PR DESCRIPTION
Description

Now the EDGE kernel version 5.13 can be built.
If you add the local version to the kernel configuration file, this situation will also be handled correctly, packages and the image will be assembled.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
