### PR TITLE
Skip checking TX/RX for interface not exists in /var/lib/vnstat/

### DIFF
--- a/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
+++ b/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
@@ -87,8 +87,8 @@ function batteryinfo() {
 		read status_battery_connected < $legacy_dir/axp20x-battery/present
 		if [[ "$status_battery_connected" == "1" ]]; then
 			status_battery_text=" "$(awk '{print tolower($0)}' < $legacy_dir/axp20x-battery/status)
-	                read status_ac_connect < $legacy_dir/axp813-ac/present
-	                read battery_percent< $legacy_dir/axp20x-battery/capacity
+			read status_ac_connect < $legacy_dir/axp813-ac/present
+			read battery_percent< $legacy_dir/axp20x-battery/capacity
 		fi
 	elif [[ -e "$legacy_dir/battery" ]]; then
 		if [[ (("$(cat $legacy_dir/battery/voltage_now)" -gt "5" )) ]]; then
@@ -100,7 +100,7 @@ function batteryinfo() {
 
 function ambienttemp() {
 	# define where w1 usually shows up
-        W1_DIR="/sys/devices/w1_bus_master1/"
+	W1_DIR="/sys/devices/w1_bus_master1/"
 	if [ -f /etc/armbianmonitor/datasources/ambienttemp ]; then
 		read raw_temp </etc/armbianmonitor/datasources/ambienttemp 2>/dev/null
 		amb_temp=$(awk '{printf("%d",$1/1000)}' <<<${raw_temp})
@@ -208,7 +208,7 @@ printf "Up time:       \x1B[92m%s\x1B[0m\t" "$time"
 display "Local users" "${users##* }" "3" "2" ""
 echo "" # fixed newline
 if [[ ${memory_total} -gt 1000 ]]; then
-	 memory_total=$(awk '{printf("%.2f",$1/1024)}' <<<${memory_total})"G"
+	memory_total=$(awk '{printf("%.2f",$1/1024)}' <<<${memory_total})"G"
 else
 	memory_total+="M"
 fi
@@ -233,6 +233,9 @@ display "storage/" "$storage_usage" "90" "1" "%" " of $storage_total" ; a=$((a+$
 display "storage temp" "$storage_temp" $HDD_TEMP_LIMIT "0" "°C" "" ; a=$((a+$?))
 display "Battery" "$battery_percent" "20" "1" "%" "$status_battery_text" ; a=$((a+$?))
 (( $a > 0 )) && echo "" # new line only if some value is displayed
+
+# Check whether PRIMARY_INTERFACE exist in /var/lib/vnstat/
+PRIMARY_INTERFACE=$(comm -12 <(ls -1 /var/lib/vnstat/) <(echo "$PRIMARY_INTERFACE" | sed 's/+/\n/g') | sed -n -e 'H;${x;s/\n/+/g;s/^+//;p;}')
 
 line=0
 if [[ $(command -v vnstat) && -n $PRIMARY_INTERFACE ]]; then


### PR DESCRIPTION
# Description

Hi,

There is an ethernet adapter and a wifi dongle plugged to my device, and when I login to device, I will get an error for `RX today`
```shell
  ___  ____  _   ____   ____
 / _ \|  _ \(_) |  _ \ / ___|
| | | | |_) | | | |_) | |
| |_| |  __/| | |  __/| |___
 \___/|_|   |_| |_|    \____|

Welcome to Armbian 21.05.1 Buster with Linux 5.10.34-sunxi

System load:   2%               Up time:       32 min
Memory usage:  8% of 999M       IP:            192.168.10.9
CPU temp:      44°C             Usage of /:    9% of 15G
RX today:      Error: Unable to read database "/var/lib/vnstat/enx00e04c68ddfc": No such file or directory Merge "enx00e04c68ddfc+eth0+wlx74da38f" failed.

Last login: Thu Jul  1 14:17:04 2021 from 192.168.10.5
root@orangepipc:~# 
```

Here is my ifconfig
```shell
root@orangepipc:~# ifconfig
enx00e04c68ddfc: flags=4099<UP,BROADCAST,MULTICAST>  mtu 1500
        ether 00:e0:4c:68:dd:fc  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 0  bytes 0 (0.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

eth0: flags=4099<UP,BROADCAST,MULTICAST>  mtu 1500
        ether 02:81:3a:05:d0:ac  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 0  bytes 0 (0.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
        device interrupt 46

lo: flags=73<UP,LOOPBACK,RUNNING>  mtu 65536
        inet 127.0.0.1  netmask 255.0.0.0
        inet6 ::1  prefixlen 128  scopeid 0x10<host>
        loop  txqueuelen 1000  (Local Loopback)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 0  bytes 0 (0.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

wlx74da38f146a7: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 192.168.10.9  netmask 255.255.255.0  broadcast 192.168.10.255
        inet6 fe80::f54a:f7d8:459d:b38  prefixlen 64  scopeid 0x20<link>
        ether 74:da:38:f1:46:a7  txqueuelen 1000  (Ethernet)
        RX packets 1964  bytes 168624 (164.6 KiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 1015  bytes 222779 (217.5 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
```

And the `/etc/default/armbian-motd`  is

```
root@orangepipc:~# cat /etc/default/armbian-motd
# add space-separated list of MOTD script names (without number) to exclude them from MOTD
# Example:
# MOTD_DISABLE="header tips updates"
# ONE_WIRE="yes" show 1-wire temperature sensor if attached
# PRIMARY_DIRECTION="rx" show daily traffic stats, options: "rx", "tx", "both", "off", vnstat needs to be installed

MOTD_DISABLE=""
ONE_WIRE=""
SHOW_IP_PATTERN="^bond.*|^[ewr].*|^br.*|^lt.*|^umts.*|^lan.*"
PRIMARY_INTERFACE="$(ls -1 /sys/class/net/ | grep -v lo | sed -n -e 'H;${x;s/\n/+/g;s/^+//;p;}')"
PRIMARY_DIRECTION="rx"
STORAGE=/dev/sda1

# Temperature offset in Celcius degrees
CPU_TEMP_OFFSET=0

# Define where red color is used
CPU_TEMP_LIMIT=60
HDD_TEMP_LIMIT=60
AMB_TEMP_LIMIT=40
```

For the `PRIMARY_INTERFACE`, I will get `enx00e04c68ddfc+eth0+wlx74da38f146a7` in my case, but there is actually no `enx00e04c68ddfc` inside the `/var/lib/vnstat`, which will cause the error described at the top.

# How Has This Been Tested?

- [x] Test A

Here is the test result:
```shell
System load:   2%               Up time:       56 min
Memory usage:  8% of 999M       IP:            192.168.10.9
CPU temp:      40°C             Usage of /:    9% of 15G
RX today:      785 KiB
```


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


------
BTW, actually I did not find the style guidelines in this repo, so I am not sure whether I am doing it correctly, please let me know if I did anything incorrect, thanks!