### PR TITLE
Synching Github runners cache with upstream

### DIFF
--- a/.github/workflows/build-beta-images.yml
+++ b/.github/workflows/build-beta-images.yml
@@ -83,6 +83,10 @@ jobs:
             [[ ! -f .ignore_changes ]] && sudo touch .ignore_changes
             ./compile.sh KERNEL_ONLY="yes" BOARD="bananapi" BRANCH="current" KERNEL_CONFIGURE="no" USE_TORRENT="yes" REPOSITORY_INSTALL="kernel" 'prepare_host'
 
+            # sync rootfs
+            mkdir -p cache/rootfs/
+            sudo rsync --size-only -avr rsync://rsync.armbian.com/dl/_rootfs/. cache/rootfs/
+
             # calculate how many images we can build in parallel
             PARALLEL_BUILDS=$(awk '{printf("%d",$1/5000)}' <<<$(($(LC_ALL=C free -w 2>/dev/null | grep "^Mem" | awk '{print $2}' || LC_ALL=C free | grep "^Mem"| awk '{print $2}')/1024)))
 

--- a/.github/workflows/build-single.yml
+++ b/.github/workflows/build-single.yml
@@ -90,6 +90,10 @@ jobs:
             ./compile.sh KERNEL_ONLY="yes" BOARD="bananapi" BRANCH="current" KERNEL_CONFIGURE="no" USE_TORRENT="yes" REPOSITORY_INSTALL="kernel" 'prepare_host'
             PARALLEL_BUILDS=$(awk '{printf("%d",$1/8000)}' <<<$(($(LC_ALL=C free -w 2>/dev/null | grep "^Mem" | awk '{print $2}' || LC_ALL=C free | grep "^Mem"| awk '{print $2}')/1024)))
 
+            # sync rootfs
+            mkdir -p cache/rootfs/
+            sudo rsync --size-only -avr rsync://rsync.armbian.com/dl/_rootfs/. cache/rootfs/
+
             # use prepared configs
             sudo cp ../scripts/configs/* userpatches/
 


### PR DESCRIPTION
# Description

Runners that build images need to have latest and greatest cache files. This commit makes sure local cache is in synch with our main build servers.

Jira reference number [AR-830]

# How Has This Been Tested?

- [x] command has been tested manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-830]: https://armbian.atlassian.net/browse/AR-830