### PR TITLE
fixing the default terminal to use terminator

### DIFF
--- a/config/desktop/focal/environments/cinnamon/debian/postinst
+++ b/config/desktop/focal/environments/cinnamon/debian/postinst
@@ -67,7 +67,7 @@ secondary-color='#FFFFFF'
 [org/cinnamon/desktop/applications/terminal]
 exec='/usr/bin/terminator'
 
-[desktop/default-applications/terminal]
+[org/cinnamon/desktop/default-applications/terminal]
 exec='/usr/bin/terminator'
 
 [org/cinnamon/desktop/interface]

--- a/config/desktop/focal/environments/cinnamon/debian/postinst
+++ b/config/desktop/focal/environments/cinnamon/debian/postinst
@@ -64,6 +64,12 @@ picture-uri='file:///usr/share/backgrounds/armbian/armbian_4k_gray_resultado.jpg
 primary-color='#456789'
 secondary-color='#FFFFFF'
 
+[org/cinnamon/desktop/applications/terminal]
+exec='/usr/bin/terminator'
+
+[desktop/default-applications/terminal]
+exec='/usr/bin/terminator'
+
 [org/cinnamon/desktop/interface]
 clock-show-date=true
 cursor-theme='whiteglass'
@@ -71,9 +77,6 @@ gtk-theme='Numix'
 icon-theme='Numix'
 scaling-factor=uint32 0
 toolkit-accessibility=false
-
-[desktop/default-applications/terminal]
-exec='/usr/bin/terminator'
 
 [org/cinnamon/desktop/media-handling]
 autorun-never=false


### PR DESCRIPTION
fixed the default terminal in cinnamon to use terminator