### PR TITLE
Bugfix - some 32bit Allwinner devices are unstable with u-boot 2021.xx

### DIFF
--- a/config/sources/families/sun7i.conf
+++ b/config/sources/families/sun7i.conf
@@ -3,6 +3,10 @@ OVERLAY_PREFIX='sun7i-a20'
 [[ -z $CPUMIN ]] && CPUMIN=480000
 [[ -z $CPUMAX ]] && CPUMAX=1010000
 
+# some 32bit Allwinner devices are unstable at 2021.xx
+# https://armbian.atlassian.net/browse/AR-749
+BOOTBRANCH='tag:v2020.10'
+
 family_tweaks_bsp_s()
 {
 	if [[ $BOARD == olimex-som204-a20 ]]; then


### PR DESCRIPTION
# Description

Some 32bit Allwinner devices are unstable with u-boot 2021.xx - booting in most cases ends up in bootloop. Currently we don't know why this is happening, so a workaround is to move bootloader to last known working well version. If we can find out the reason, we can move back @martinayotte 

Jira reference number [AR-749]

# How Has This Been Tested?

- [x] Reboot Bananapi A20 with 2020.10 at least 10x

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-749]: https://armbian.atlassian.net/browse/AR-749