### PR TITLE
fixing budgie to use treminator as default terminal

### DIFF
--- a/config/desktop/focal/environments/budgie/debian/postinst
+++ b/config/desktop/focal/environments/budgie/debian/postinst
@@ -82,6 +82,9 @@ toolkit-accessibility=false
 [org/gnome/desktop/screensaver]
 picture-uri='file:///usr/share/backgrounds/armbian/armbian_4k_purplepunk_gauss_resultado.jpg'
 
+[org/cinnamon/desktop/default-applications/terminal]
+exec='/usr/bin/terminator'
+
 [org/gnome/desktop/wm/preferences]
 button-layout='appmenu:minimize,maximize,close'
 num-workspaces=2


### PR DESCRIPTION
adding key to dconf to set default terminal in budgie to use terminator