### PR TITLE
exclude cracklib

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -223,7 +223,7 @@ add_user()
 		if [[ $first_input == $second_input ]]; then
 			result="$(cracklib-check <<<"$password")"
 			okay="$(awk -F': ' '{ print $2}' <<<"$result")"
-			if [[ "$okay" == "OK" ]]; then
+			if [[ "$okay" == "OK" || "$okay" == "" ]]; then
 				echo -e ""
 				read -e -p "Please provide your real name: " -i "${RealUserName^}" RealName
 
@@ -306,7 +306,7 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 		if [[ $first_input == $second_input ]]; then
 			result="$(cracklib-check <<<"$password")"
 			okay="$(awk -F': ' '{ print $2}' <<<"$result")"
-			if [[ "$okay" == "OK" ]]; then
+			if [[ "$okay" == "OK" || "$okay" == "" ]]; then
 				(echo $first_input;echo $second_input;) | passwd root >/dev/null 2>&1
 				break
 				else


### PR DESCRIPTION
There is file /build/config/cli/hirsute/main/packages.additional
additional for me means additional, not mandatory. For my armbian build I want exclude all additionals.
So I want exclude
libcrack2 cracklib-runtime

But initial script https://forum.armbian.com/topic/7754-new-user-creation-and-password-complexity/ use it... 
If I delete libcrack2 cracklib-runtime I never can come in to armbian, armbian will reject any password. 

The problem is because $okay without cracklib contains "". So my decision is allow good passwords and passwords with $okay=="". 
I test it (my password was 0) and it is works fine! Just look https://a.radikal.ru/a31/2107/12/e1c64a512485.jpg

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Jira reference number [AR-9999]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
