### PR TITLE
wait for systemd fully started before first login

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -270,6 +270,10 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 	desktop_lightdm=$(dpkg-query -W -f='${db:Status-Abbrev}\n' lightdm 2>/dev/null)
 	desktop_gdm3=$(dpkg-query -W -f='${db:Status-Abbrev}\n' gdm3 2>/dev/null)
 
+	echo -e "\nWaiting for system to finish booting...\n"
+
+	systemctl is-system-running --wait
+
 	if [ "$IMAGE_TYPE" != "nightly" ]; then
 		if [ "$BRANCH" == "dev" ]; then
 			echo -e "\nYou are using an Armbian preview build !!!"


### PR DESCRIPTION
# Description

On first boot, the system console output can sometimes coverup the first login prompt.... delay has been added to wait for systemd to be fully booted before prompting user.   This has been a complaint on forums or issues elsewhere, can't find the reference.

Jira reference number [AR-837]

# How Has This Been Tested?

@RichNeese  tested and was happy.   He wasn't happy before.


[AR-837]: https://armbian.atlassian.net/browse/AR-837