### PR TITLE
Added support for Linux Mint 20.3 Uma

### DIFF
--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1067,7 +1067,7 @@ prepare_host()
 
 	display_alert "Build host OS release" "${HOSTRELEASE:-(unknown)}" "info"
 
-	# Ubuntu 20.04.x (Focal), Ubuntu 21.04.x and Linux Mint 20.x x86_64 are the only fully supported host OS releases
+	# Ubuntu 21.04.x (Hirsute) x86_64 is the only fully supported host OS release
 	# Using Docker/VirtualBox/Vagrant is the only supported way to run the build script on other Linux distributions
 	#
 	# NO_HOST_RELEASE_CHECK overrides the check for a supported host system

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1056,8 +1056,8 @@ prepare_host()
 # build aarch64
   fi
 
-	# Add support for Ubuntu 20.04, 21.04 and Mint Ulyana
-	if [[ $HOSTRELEASE =~ ^(focal|hirsute|ulyana|ulyssa|bullseye)$ ]]; then
+	# Add support for Ubuntu 20.04, 21.04 and Mint 20.x
+	if [[ $HOSTRELEASE =~ ^(focal|hirsute|ulyana|ulyssa|bullseye|uma)$ ]]; then
 		hostdeps+=" python2 python3"
 		ln -fs /usr/bin/python2.7 /usr/bin/python2
 		ln -fs /usr/bin/python2.7 /usr/bin/python
@@ -1067,12 +1067,12 @@ prepare_host()
 
 	display_alert "Build host OS release" "${HOSTRELEASE:-(unknown)}" "info"
 
-	# Ubuntu 20.04.x (Focal) x86_64 is the only fully supported host OS release
+	# Ubuntu 20.04.x (Focal), Ubuntu 21.04.x and Linux Mint 20.x x86_64 are the only fully supported host OS releases
 	# Using Docker/VirtualBox/Vagrant is the only supported way to run the build script on other Linux distributions
 	#
 	# NO_HOST_RELEASE_CHECK overrides the check for a supported host system
 	# Disable host OS check at your own risk. Any issues reported with unsupported releases will be closed without discussion
-	if [[ -z $HOSTRELEASE || "buster bullseye focal hirsute debbie tricia ulyana ulyssa" != *"$HOSTRELEASE"* ]]; then
+	if [[ -z $HOSTRELEASE || "buster bullseye focal hirsute debbie tricia ulyana ulyssa uma" != *"$HOSTRELEASE"* ]]; then
 		if [[ $NO_HOST_RELEASE_CHECK == yes ]]; then
 			display_alert "You are running on an unsupported system" "${HOSTRELEASE:-(unknown)}" "wrn"
 			display_alert "Do not report any errors, warnings or other issues encountered beyond this point" "" "wrn"
@@ -1088,7 +1088,7 @@ prepare_host()
 # build aarch64
   if [[ $(dpkg --print-architecture) == amd64 ]]; then
 
-	if [[ -z $HOSTRELEASE || $HOSTRELEASE =~ ^(focal|debbie|buster|bullseye|hirsute|ulyana|ulyssa)$ ]]; then
+	if [[ -z $HOSTRELEASE || $HOSTRELEASE =~ ^(focal|debbie|buster|bullseye|hirsute|ulyana|ulyssa|uma)$ ]]; then
 	    hostdeps="${hostdeps/lib32ncurses5 lib32tinfo5/lib32ncurses6 lib32tinfo6}"
 	fi
 


### PR DESCRIPTION
# Description

Because there is actual support for Linux Mint 20.x based on Ubuntu 20.04 is it technically the same version. Only the code name change every new release. Today is Linux Mint 20.2 Uma released so i added it to the host check.

# How Has This Been Tested?

- [ x86-64 Linux Mint 20.2] Just tested on my own system and works ok.
