### PR TITLE
fix typo in budgie

### DIFF
--- a/config/desktop/focal/environments/budgie/armbian/create_desktop_package.sh
+++ b/config/desktop/focal/environments/budgie/armbian/create_desktop_package.sh
@@ -18,7 +18,7 @@ mkdir -p "${destination}"/usr/share/backgrounds/armbian-lightdm/
 cp "${SRC}"/packages/blobs/desktop/lightdm-wallpapers/*.jpg "${destination}"/usr/share/backgrounds/armbian-lightdm
 
 # install logo for login screen
-mkdir -o "${destination}"/usr/share/pixmaps/armbian
+mkdir -p "${destination}"/usr/share/pixmaps/armbian
 cp "${SRC}"/packages/blobs/desktop/icons/armbian.png "${destination}"/usr/share/pixmaps/armbian
 
 #generate wallpaper list for background changer


### PR DESCRIPTION
fixed typo in create_desktop.sh from mkdir -o to -p 