### PR TITLE
uninstall gdm3 so kde-plasma loads up with lightdm

### DIFF
--- a/config/desktop/focal/environments/kde-plasma/config_base/packages.uninstall
+++ b/config/desktop/focal/environments/kde-plasma/config_base/packages.uninstall
@@ -1,0 +1,1 @@
+gdm3 gnome-software gnome-keyring


### PR DESCRIPTION
fix kde-plasma ... added packages.uninstall ... gdm3 was causing lightdm to not load up