### PR TITLE
Setting older u-boot for Allwinner H3

### DIFF
--- a/config/sources/families/sun8i.conf
+++ b/config/sources/families/sun8i.conf
@@ -7,6 +7,10 @@ fi
 [[ -z $CPUMIN ]] && CPUMIN=480000
 [[ -z $CPUMAX ]] && CPUMAX=1400000
 
+# some 32bit Allwinner devices are unstable at 2021.xx
+# https://armbian.atlassian.net/browse/AR-749
+BOOTBRANCH='tag:v2020.10'
+
 family_tweaks_s()
 {
 	if [[ ${BOARD} == nanopi-r1 ]]; then


### PR DESCRIPTION
# Description

Setting older u-boot for Allwinner H3  due to stability issues found in latest versions 2021.04

Jira reference number [AR-863]

# How Has This Been Tested?

- [x] Tested for building

Not tested yet!

[AR-863]: https://armbian.atlassian.net/browse/AR-863