### PR TITLE
fixed buster xfce build to match updated builds removed packages that…

### DIFF
--- a/config/desktop/buster/environments/xfce/armbian/create_desktop_package.sh
+++ b/config/desktop/buster/environments/xfce/armbian/create_desktop_package.sh
@@ -5,18 +5,18 @@ cp -R "${SRC}"/packages/blobs/desktop/lightdm "${destination}"/etc/armbian
 mkdir -p "${destination}"/etc/skel
 cp -R "${SRC}"/packages/blobs/desktop/skel/. "${destination}"/etc/skel
 
-# using different icon pack. Workaround due to this bug https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=867779
-sed -i 's/<property name="IconThemeName" type="string" value=".*$/<property name="IconThemeName" type="string" value="Humanity-Dark"\/>/g' \
-"${destination}"/etc/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml
-
-# install dedicated startup icons
-mkdir -p "${destination}"/usr/share/pixmaps/armbian "${destination}"/etc/skel/.config/xfce4/xfconf/xfce-perchannel-xml/
-cp "${SRC}/packages/blobs/desktop/icons/${DISTRIBUTION,,}.png" "${destination}"/usr/share/pixmaps/armbian
-sed 's/xenial.png/'"${DISTRIBUTION,,}"'.png/' -i "${destination}"/etc/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
-
-# install logo for login screen
-cp "${SRC}"/packages/blobs/desktop/icons/armbian.png "${destination}"/usr/share/pixmaps/armbian
+#install cinnamon desktop bar icons
+mkdir -p "${destination}"/usr/share/icons/armbian
+cp "${SRC}"/packages/blobs/desktop/desktop-icons/*.png "${destination}"/usr/share/icons/armbian
 
 # install wallpapers
 mkdir -p "${destination}"/usr/share/backgrounds/armbian/
-cp "${SRC}"/packages/blobs/desktop/wallpapers/armbian*.jpg "${destination}"/usr/share/backgrounds/armbian/
+cp "${SRC}"/packages/blobs/desktop/desktop-wallpapers/*.jpg "${destination}"/usr/share/backgrounds/armbian
+
+# install wallpapers
+mkdir -p "${destination}"/usr/share/backgrounds/armbian-lightdm/
+cp "${SRC}"/packages/blobs/desktop/lightdm-wallpapers/*.jpg "${destination}"/usr/share/backgrounds/armbian-lightdm
+
+# install logo for login screen
+mkdir -p "${destination}"/usr/share/pixmaps/armbian
+cp "${SRC}"/packages/blobs/desktop/icons/armbian.png "${destination}"/usr/share/pixmaps/armbian

--- a/config/desktop/buster/environments/xfce/config_base/packages
+++ b/config/desktop/buster/environments/xfce/config_base/packages
@@ -4,7 +4,7 @@ xwallpaper xterm xtermcontrol xtermset libxcursor1 xcursor-themes mousetweaks xb
 lightdm numix-gtk-theme slick-greeter 
 bluez bluez-tools bluez-cups blueman 
 policykit-1 profile-sync-daemon  
-xfce4 xfce4-notifyd lxtask xfce4-terminal xfce4-screenshooter thunar-volman profile-sync-daemon \
+xfce4 xfce4-notifyd lxtask xfce4-terminal xfce4-screenshooter thunar-volman profile-sync-daemon 
 terminator mousepad numix-icon-theme numix-icon-theme-circle numix-gtk-theme viewnior gnome-screenshot 
 gtk2-engines gtk2-engines-murrine gtk2-engines-pixbuf libgtk2.0-bin 
 libpam-gnome-keyring fonts-arphic-ukai fonts-arphic-uming fonts-dejavu-core fonts-freefont-ttf fonts-guru fonts-guru-extra fonts-kacst fonts-kacst-one 

--- a/config/desktop/buster/environments/xfce/config_base/packages
+++ b/config/desktop/buster/environments/xfce/config_base/packages
@@ -1,7 +1,26 @@
-xserver-xorg xserver-xorg-video-fbdev gvfs-backends gvfs-fuse xfonts-base xinit x11-xserver-utils xfce4 lxtask xfce4-terminal 
-thunar-volman gtk2-engines gtk2-engines-murrine gtk2-engines-pixbuf libgtk2.0-bin network-manager-gnome xfce4-notifyd gnome-keyring 
-gcr libgck-1-0 p11-kit pasystray pavucontrol pulseaudio pavumeter bluez bluez-tools pulseaudio-module-bluetooth blueman libpam-gnome-keyring 
-libgl1-mesa-dri policykit-1 profile-sync-daemon gnome-orca numix-gtk-theme synaptic apt-xapian-index lightdm lightdm-gtk-greeter 
-lightdm-gtk-greeter-settings numix-gtk-theme system-config-printer system-config-printer-common printer-driver-all dbus-x11 dbus-x11 
-dictionaries-common hunspell-en-us tracker tracker-extract tracker-miner-fs policykit-1 profile-sync-daemon software-properties-common 
-samba smbclient cifs-utils xfce4-screenshooter gdebi terminator
+xserver-xorg xserver-xorg-video-fbdev xfonts-base xinit x11-xserver-utils xinit xorg-docs-core x11-apps xscreensaver xfonts-100dpi 
+xfonts-75dpi xfonts-base xfonts-encodings xfonts-scalable xfonts-utils xcursor-themes xdg-user-dirs xdg-user-dirs-gtk keyutils redshift dbus-x11 
+xwallpaper xterm xtermcontrol xtermset libxcursor1 xcursor-themes mousetweaks xbacklight brltty brltty-x11 libgl1-mesa-dri mesa-utils 
+lightdm numix-gtk-theme slick-greeter 
+bluez bluez-tools bluez-cups blueman 
+policykit-1 profile-sync-daemon  
+xfce4 xfce4-notifyd lxtask xfce4-terminal xfce4-screenshooter thunar-volman profile-sync-daemon \
+terminator mousepad numix-icon-theme numix-icon-theme-circle numix-gtk-theme viewnior gnome-screenshot 
+gtk2-engines gtk2-engines-murrine gtk2-engines-pixbuf libgtk2.0-bin 
+libpam-gnome-keyring fonts-arphic-ukai fonts-arphic-uming fonts-dejavu-core fonts-freefont-ttf fonts-guru fonts-guru-extra fonts-kacst fonts-kacst-one 
+fonts-liberation fonts-opensymbol fonts-nanum fonts-stix fonts-symbola  ttf-ubuntu-font-family fonts-ubuntu-font-family-console 
+libfont-afm-perl libfontconfig1 libfontembed1 libfontenc1 gnome-font-viewer fontconfig fontconfig-config 
+network-manager-pptp network-manager-l2tp network-manager-openconnect network-manager-openvpn network-manager-vpnc network-manager-ssh 
+libproxy1-plugin-gsettings libproxy1-plugin-networkmanager libproxy1-plugin-gsettings 
+pamix pasystray pavucontrol pavumeter pavucontrol-qt pulseaudio-module-bluetooth 
+gstreamer1.0-pulseaudio gstreamer1.0-packagekit gstreamer1.0-plugins-base-apps 
+libu2f-udev libwmf0.2-7-gtk 
+p7zip-full zip anacron doc-base foomatic-db-compressed-ppds spice-vdagent dictionaries-common hunspell-en-us 
+ghostscript-x inputattach libatk-adaptor libgail-common libnotify-bin software-properties-gtk 
+cups cups-bsd cups-client cups-filters system-config-printer system-config-printer-common printer-driver-all openprinting-ppds hplip  
+smbclient cifs-utils 
+tracker tracker-extract tracker-miner-fs update-inetd 
+laptop-detect gnome-orca evince evince-common caffeine gdebi 
+dmz-cursor-theme libgsettings-qt1 libappindicator3-1 gir1.2-appindicator3-0.1 
+
+

--- a/config/desktop/buster/environments/xfce/debian/postinst
+++ b/config/desktop/buster/environments/xfce/debian/postinst
@@ -1,5 +1,6 @@
 # overwrite stock lightdm greeter configuration
 if [ -d /etc/armbian/lightdm ]; then cp -R /etc/armbian/lightdm /etc/; fi
+if [ -f /etc/lightdm/slick-greeter.conf ]; then sed -i 's/armbian03-Dre0x-Minum-dark-blurred-3840x2160.jpg/armbian-4k-blue-monday-gauss.jpg/g' /etc/lightdm/slick-greeter.conf; fi
 
 # Adjust menu
 if [ -f /etc/xdg/menus/xfce-applications.menu ]; then


### PR DESCRIPTION
Fixed the buster xfce to match the ubuntu build minus the packages debian does not support.
fixed wallpapers for both the lightdm slick-greeter and for the xfce background. 