### PR TITLE
Add basic Khadas VIM3 support

### DIFF
--- a/config/boards/khadas-vim3.wip
+++ b/config/boards/khadas-vim3.wip
@@ -1,0 +1,9 @@
+# Amlogic A311D 2/4GB RAM eMMC GBE USB3 M.2
+BOARD_NAME="Khadas VIM3"
+BOARDFAMILY="meson-g12b"
+BOOTCONFIG="khadas-vim3_defconfig"
+KERNEL_TARGET="edge"
+FULL_DESKTOP="yes"
+SERIALCON="ttyAML0"
+BOOT_LOGO="desktop"
+BOOT_FDT_FILE="amlogic/meson-g12b-a311d-khadas-vim3.dtb" # mainline kernel also carries 'meson-g12b-s922x-khadas-vim3.dtb'

--- a/config/sources/families/meson-g12b.conf
+++ b/config/sources/families/meson-g12b.conf
@@ -28,9 +28,16 @@ else
 
 	# Handling of FIP blobs
 	uboot_custom_postprocess() {
-		# FIP trees 'odroid-n2-plus' and 'odroid-n2' are identical.
+		# @TODO: these should come from FIP_TREE_BOARD/FIP_TREE_FAMILY vars in board.conf instead of hardcoded here
 		if [[ $BOARD == odroidn2* ]]; then
+			# FIP trees 'odroid-n2-plus' and 'odroid-n2' are identical.
 			uboot_g12_postprocess "$SRC"/cache/sources/amlogic-boot-fip/odroid-n2 g12b
+		elif [[ $BOARD == khadas-vim3 ]]; then
+			# 'khadas-vim3' FIP tree contains 'lpddr3_1d.fw' which will trigger '--ddrfw9' in uboot_g12_postprocess
+			uboot_g12_postprocess "$SRC"/cache/sources/amlogic-boot-fip/khadas-vim3 g12b
+		else
+			echo "Don't know how to handle FIP trees for board '${BOARD}'"
+			exit 2
 		fi
 	}
 fi


### PR DESCRIPTION
## Add basic Khadas VIM3 support

- FIP tree support was there already since #1923
- mainline u-boot in g12b was enabled by #2943

### How Has This Been Tested?

Yeah, it builds. 🐤 

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
