### PR TITLE
ODROID C4, HC4: fix u-boot map and FIP trees handling

### DIFF
--- a/config/sources/families/include/meson64_common.inc
+++ b/config/sources/families/include/meson64_common.inc
@@ -11,8 +11,8 @@ OVERLAY_PREFIX='meson'
 # this family does not need it
 ATF_COMPILE="no"
 
-if [[ $BOARD == lafrite || $BOARD == odroid*c4 ]]; then
-		UBOOT_TARGET_MAP="u-boot-dtb.img;;u-boot.bin:u-boot.bin u-boot-dtb.img"
+if [[ $BOARD == lafrite ]]; then
+	UBOOT_TARGET_MAP="u-boot-dtb.img;;u-boot.bin:u-boot.bin u-boot-dtb.img"
 fi
 
 # Set CPUMIN et al if not already set in the board config.

--- a/config/sources/families/meson-sm1.conf
+++ b/config/sources/families/meson-sm1.conf
@@ -11,16 +11,15 @@ family_tweaks()
 	:
 }
 
-uboot_custom_postprocess()
-{
+uboot_custom_postprocess() {
 	# FIP trees for C4 and HC4 are identical as of 30/06/2021
-	if [[ $BOARD == odroid-c4 ]]; then
+	if [[ $BOARD == odroidc4 ]]; then
 		uboot_g12_postprocess $SRC/cache/sources/amlogic-boot-fip/odroid-c4 g12a
-	fi
-	if [[ $BOARD == odroid-hc4 ]]; then
+	elif [[ $BOARD == odroidhc4 ]]; then
 		uboot_g12_postprocess $SRC/cache/sources/amlogic-boot-fip/odroid-hc4 g12a
-	fi
-	if [[ $BOARD == khadas-vim3l ]]; then
+	elif [[ $BOARD == khadas-vim3l ]]; then
 		uboot_g12_postprocess $SRC/cache/sources/amlogic-boot-fip/khadas-vim3l g12a
+	else
+		display_alert "uboot_custom_postprocess meson-sm1" "Unknown BOARD: $BOARD - not using FIP trees" "wrn"
 	fi
 }


### PR DESCRIPTION
### ODROID C4, HC4: fix u-boot map and FIP trees handling
- We really want the u-boot.bin.sd.bin for HC4
- During VIM3L-adding commit, "odroid*c4" was replaced with "odroid-c4" and "odroid-hc4"
  - Which is cool but it's actually "odroidc4" and "odroidhc4"
  - Add a warning to save future time if no FIP tree decided by SM1 family

Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
