### PR TITLE
Odroid HC4: SPI-NOR dts and XT25F128B flash chip

### DIFF
--- a/config/boards/odroidhc4.conf
+++ b/config/boards/odroidhc4.conf
@@ -6,3 +6,5 @@ KERNEL_TARGET="legacy,current,edge"
 FULL_DESKTOP="no"
 SERIALCON="ttyAML0"
 BOOT_FDT_FILE="amlogic/meson-sm1-odroid-hc4.dtb"
+PACKAGE_LIST_BOARD="mtd-utils" # For SPI NOR, mtdinfo et al. Not required but nice to have
+# @TODO: write_uboot_platform_mtd() used by nand-sata-install to write u-boot to SPI

--- a/patch/kernel/archive/meson64-5.10/9999-FROMLIST-v1-spi-nor-add-support-for-XT25F128B.patch
+++ b/patch/kernel/archive/meson64-5.10/9999-FROMLIST-v1-spi-nor-add-support-for-XT25F128B.patch
@@ -1,0 +1,90 @@
+From a5dc8bb92c6b67be7e48d442e821837b03fc129a Mon Sep 17 00:00:00 2001
+From: Andreas Rammhold <andreas@rammhold.de>
+Date: Thu, 28 Jan 2021 09:43:36 +0000
+Subject: [PATCH 17/58] FROMLIST(v1): spi-nor: add support for XT25F128B
+
+This adds support for the XT25F128B as found on the RockPi4b SBC.
+
+Signed-off-by: Andreas Rammhold <andreas@rammhold.de>
+---
+
+This continues the efforts done in [1] & [2] that went stale. I've
+tested this patch on my RockPi4b which only has the xt25f128b (and not
+the xt25f32b as also propsed in [2]). I have tried to obtain a copy of
+the datasheets but was unable to find them. Not sure whre you would get
+them.
+
+While [1] was already for the new spi-nor layout it was missing the bits
+in the core.{c,h} files.
+
+[1]: https://patchwork.ozlabs.org/project/linux-mtd/patch/CAMgqO2y9MYDj6antOaWLBRKU8vGEwqCB-Y1TkXTSWsmsed+W6A@mail.gmail.com/
+[2]: https://patchwork.ozlabs.org/project/linux-mtd/patch/20200206171941.GA2398@makrotopia.org/
+---
+ drivers/mtd/spi-nor/Makefile |  1 +
+ drivers/mtd/spi-nor/core.c   |  1 +
+ drivers/mtd/spi-nor/core.h   |  1 +
+ drivers/mtd/spi-nor/xtx.c    | 16 ++++++++++++++++
+ 4 files changed, 19 insertions(+)
+ create mode 100644 drivers/mtd/spi-nor/xtx.c
+
+diff --git a/drivers/mtd/spi-nor/Makefile b/drivers/mtd/spi-nor/Makefile
+index 653923896205..3f7a52d7fa0b 100644
+--- a/drivers/mtd/spi-nor/Makefile
++++ b/drivers/mtd/spi-nor/Makefile
+@@ -17,6 +17,7 @@ spi-nor-objs			+= sst.o
+ spi-nor-objs			+= winbond.o
+ spi-nor-objs			+= xilinx.o
+ spi-nor-objs			+= xmc.o
++spi-nor-objs			+= xtx.o
+ obj-$(CONFIG_MTD_SPI_NOR)	+= spi-nor.o
+ 
+ obj-$(CONFIG_MTD_SPI_NOR)	+= controllers/
+diff --git a/drivers/mtd/spi-nor/core.c b/drivers/mtd/spi-nor/core.c
+index 0522304f52fa..9a89ec473e4b 100644
+--- a/drivers/mtd/spi-nor/core.c
++++ b/drivers/mtd/spi-nor/core.c
+@@ -2215,6 +2215,7 @@ static const struct spi_nor_manufacturer *manufacturers[] = {
+ 	&spi_nor_winbond,
+ 	&spi_nor_xilinx,
+ 	&spi_nor_xmc,
++	&spi_nor_xtx,
+ };
+ 
+ static const struct flash_info *
+diff --git a/drivers/mtd/spi-nor/core.h b/drivers/mtd/spi-nor/core.h
+index 4a3f7f150b5d..ee0e45eaffcd 100644
+--- a/drivers/mtd/spi-nor/core.h
++++ b/drivers/mtd/spi-nor/core.h
+@@ -425,6 +425,7 @@ extern const struct spi_nor_manufacturer spi_nor_sst;
+ extern const struct spi_nor_manufacturer spi_nor_winbond;
+ extern const struct spi_nor_manufacturer spi_nor_xilinx;
+ extern const struct spi_nor_manufacturer spi_nor_xmc;
++extern const struct spi_nor_manufacturer spi_nor_xtx;
+ 
+ void spi_nor_spimem_setup_op(const struct spi_nor *nor,
+ 			     struct spi_mem_op *op,
+diff --git a/drivers/mtd/spi-nor/xtx.c b/drivers/mtd/spi-nor/xtx.c
+new file mode 100644
+index 000000000000..a10102d8b3e2
+--- /dev/null
++++ b/drivers/mtd/spi-nor/xtx.c
+@@ -0,0 +1,16 @@
++// SPDX-License-Identifier: GPL-2.0
++
++#include <linux/mtd/spi-nor.h>
++
++#include "core.h"
++
++static const struct flash_info xtx_parts[] = {
++ /* XTX (Shenzhen Xin Tian Xia Tech) */
++ { "xt25f128b", INFO(0x0b4018, 0, 64 * 1024, 256, SECT_4K) },
++};
++
++const struct spi_nor_manufacturer spi_nor_xtx = {
++ .name = "xtx",
++ .parts = xtx_parts,
++ .nparts = ARRAY_SIZE(xtx_parts),
++};
+-- 
+2.25.1
+

--- a/patch/kernel/archive/meson64-5.10/9999-WIP-arm64-dts-meson-add-spifc-node-to-ODROID-HC4.patch
+++ b/patch/kernel/archive/meson64-5.10/9999-WIP-arm64-dts-meson-add-spifc-node-to-ODROID-HC4.patch
@@ -1,0 +1,41 @@
+From c56aba5bb32d03e1c8806363dfa50245175907b4 Mon Sep 17 00:00:00 2001
+From: Christian Hewitt <christianshewitt@gmail.com>
+Date: Thu, 28 Jan 2021 17:15:22 +0000
+Subject: [PATCH 27/58] WIP: arm64: dts: meson: add spifc node to ODROID-HC4
+
+Add a node for the XT25F128B SPI-NOR flash to make it accessible
+from Linux.
+
+Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
+---
+ .../boot/dts/amlogic/meson-sm1-odroid-hc4.dts      | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-hc4.dts b/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-hc4.dts
+index bf15700c4b15..5268d064ba1b 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-hc4.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-hc4.dts
+@@ -90,6 +90,20 @@ &sd_emmc_c {
+ 	status = "disabled";
+ };
+ 
++&spifc {
++	status = "okay";
++	pinctrl-0 = <&nor_pins>;
++	pinctrl-names = "default";
++
++	xt25f128b: spi-flash@0 {
++		#address-cells = <1>;
++		#size-cells = <1>;
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <104000000>;
++	};
++};
++
+ &usb {
+ 	phys = <&usb2_phy0>, <&usb2_phy1>;
+ 	phy-names = "usb2-phy0", "usb2-phy1";
+-- 
+2.25.1
+


### PR DESCRIPTION
### Odroid HC4: SPI-NOR dts and XT25F128B flash chip
- add mtd-utils to PACKAGE_LIST_BOARD.
- this should be enough to wipe Petitboot;
- more investigative work and u-boot building is needed for SPI+SATA boot

Jira reference number [AR-678] maybe also [AR-727]

Proper work on `write_uboot_platform_mtd()` and u-boot itself, for SATA support, will come separately.
This was tested on `5.10.53-meson64` (`edge` 5.13 already has these patches) and can already be used to wipe or restore Petitboot.

[AR-678]: https://armbian.atlassian.net/browse/AR-678
[AR-727]: https://armbian.atlassian.net/browse/AR-727