### PR TITLE
fixing menu look for both debian/ubuntu

### DIFF
--- a/packages/blobs/desktop/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml
+++ b/packages/blobs/desktop/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml
@@ -2,7 +2,7 @@
 
 <channel name="xsettings" version="1.0">
   <property name="Net" type="empty">
-    <property name="ThemeName" type="string" value="NumixBlue"/>
+    <property name="ThemeName" type="string" value="Xfce-dusk"/>
     <property name="IconThemeName" type="string" value="LoginIcons"/>
     <property name="DoubleClickTime" type="empty"/>
     <property name="DoubleClickDistance" type="empty"/>


### PR DESCRIPTION
ubuntu does not have the theme package to match ubuntu so had to change the background to one both debian and ubuntu have.

