### PR TITLE
Re-enable 8723ds on 5.14

### DIFF
--- a/lib/compilation-prepare.sh
+++ b/lib/compilation-prepare.sh
@@ -549,7 +549,7 @@ compilation_prepare()
 
 	# Wireless drivers for Realtek 8723DS chipsets
 
-	if linux-version compare "${version}" ge 5.0 && linux-version compare "${version}" lt 5.14 && [ "$EXTRAWIFI" == yes ]; then
+	if linux-version compare "${version}" ge 5.0 && [ "$EXTRAWIFI" == yes ]; then
 
 		# attach to specifics tag or branch
 		local rtl8723dsver="branch:master"


### PR DESCRIPTION
# Description

Re-enable 8723ds on 5.14 because it's already fixed.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] On a custom board with 5.14 kernel (with Armbian build system but custom kernel source, see https://github.com/sipeed/armbian-build/tree/r329-wip)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
