### PR TITLE
fixed typo's in the wallpaper xml file for xfce desktop

### DIFF
--- a/packages/blobs/desktop/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-desktop.xml
+++ b/packages/blobs/desktop/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-desktop.xml
@@ -60,12 +60,12 @@
       <property name="workspace0" type="empty">
         <property name="color-style" type="int" value="0"/>
         <property name="image-style" type="int" value="5"/>
-        <property name="last-image" type="string" value="/usr/share/backgrounds/armbian/armbian-4k-blue-peng>
+        <property name="last-image" type="string" value="/usr/share/backgrounds/armbian/armbian-4k-blue-monday.jpg"/>
       </property>
       <property name="workspace1" type="empty">
         <property name="color-style" type="int" value="0"/>
         <property name="image-style" type="int" value="5"/>
-        <property name="last-image" type="string" value="/usr/share/backgrounds/armbian/armbian-4k-blue-circ>
+        <property name="last-image" type="string" value="/usr/share/backgrounds/armbian/armbian-4k-blue-circle.jpg"/>
       </property>
     </property>
     <property name="single-workspace-mode" type="bool" value="false"/>


### PR DESCRIPTION
fixed typo in the xfce desktop xml file for wallpapers set for each desktop.
