### PR TITLE
Automatic shutdown on low battery power

### DIFF
--- a/packages/bsp/common/etc/cron.d/armbian-check-battery
+++ b/packages/bsp/common/etc/cron.d/armbian-check-battery
@@ -1,0 +1,2 @@
+# Uncomment the line below to enable 5-minutes check for a low battery level
+# */5 * * * * root bash /usr/lib/armbian/armbian-check-battery-shutdown

--- a/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
+++ b/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
@@ -164,7 +164,8 @@ function storage_info() {
 	fi
 } # storage_info
 
-
+# If this script was sourced (included) into other script to use functions, then do not execute the main part (outside functions):
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] && return 0
 
 # query various systems and send some stuff to the background for overall faster execution.
 # Works only with ambienttemp and batteryinfo since A20 is slow enough :)

--- a/packages/bsp/common/usr/lib/armbian/armbian-check-battery-shutdown
+++ b/packages/bsp/common/usr/lib/armbian/armbian-check-battery-shutdown
@@ -18,6 +18,7 @@ batteryinfo
 
 # `status_battery_text` has a leading whitespace
 if [ "$status_battery_connected" == '1' ] && [[ "$status_battery_text" =~ [[:space:]]*discharging ]]; then
+  # When no battery connected, variable `battery_percent` is not defined!
   if [ "$battery_percent" -lt "$BATTERY_PERCENT_MIN" ]; then
     logger --tag cron_check_battery_shutdown "battery_percent = $battery_percent, running shutdown"
     shutdown -h +1

--- a/packages/bsp/common/usr/lib/armbian/armbian-check-battery-shutdown
+++ b/packages/bsp/common/usr/lib/armbian/armbian-check-battery-shutdown
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -o nounset
+set -o errexit
+set -o pipefail
+shopt -s dotglob
+
+# SPDX-License-Identifier: MIT
+
+# This script should be executed every 5 minutes by a cron job `/etc/cron.d/armbian-check-battery`.
+# It checks if battery is discharging and battery level is more than 10%. If less, then start a system shutdown.
+# Script uses `batteryinfo` function from `30-armbian-sysinfo` file of Armbian distribution.
+
+BATTERY_PERCENT_MIN='10'
+
+# Import a script with a function `batteryinfo`:
+source /etc/update-motd.d/30-armbian-sysinfo
+batteryinfo
+
+# `status_battery_text` has a leading whitespace
+if [ "$status_battery_connected" == '1' ] && [[ "$status_battery_text" =~ [[:space:]]*discharging ]]; then
+  if [ "$battery_percent" -lt "$BATTERY_PERCENT_MIN" ]; then
+    logger --tag cron_check_battery_shutdown "battery_percent = $battery_percent, running shutdown"
+    shutdown -h +1
+  fi
+fi


### PR DESCRIPTION
# Description

For some SBCs, Armbian can get a battery charge level (at least for Olimex Lime2, and probably for all Allwinner SBCs with AXP209/AXP803).

It would be great if Armbian has a script and cron job to shutdown SBC on low battery level.

Here is a draft code to do this job. It already works for my project [GNSS logger](https://wiki.openstreetmap.org/wiki/User:Vazhnov_Alexey/Record_GNSS_traces), but probably requires some polishing or maybe architecture changes to be distributed with Armbian.

Questions/issues:
* Where is it better to define `BATTERY_PERCENT_MIN` variable? I'm thinking about `/etc/default/armbian-battery`.
* How is it better to disable/enable the cron job? Currently I'm using symbol "#" to disable a cron job by default.
* I use a function `batteryinfo` from `/etc/update-motd.d/30-armbian-sysinfo`, but it requires a small code change to allow importing without executing whole script (the change already included). Maybe it is better to place a function `batteryinfo` into some library.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] not tested yet

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
