### PR TITLE
Re-enable Debian stretch repository

### DIFF
--- a/lib/general.sh
+++ b/lib/general.sh
@@ -688,7 +688,8 @@ addtorepo()
 # parameter "delete" remove incoming directory if publishing is succesful
 # function: cycle trough distributions
 
-	local distributions=("bionic" "buster" "bullseye" "focal" "hirsute" "sid")
+	local distributions=("stretch" "bionic" "buster" "bullseye" "focal" "hirsute" "sid")
+	#local distributions=($(grep -rw config/distributions/*/ -e 'supported' | cut -d"/" -f3))
 	local errors=0
 
 	for release in "${distributions[@]}"; do
@@ -817,7 +818,8 @@ repo-manipulate()
 # "update" search for new files in output/debs* to add them to repository
 # "purge" leave only last 5 versions
 
-	local DISTROS=($(grep -rw config/distributions/*/ -e 'supported' | cut -d"/" -f3))
+	local DISTROS=("stretch" "bionic" "buster" "bullseye" "focal" "hirsute" "sid")
+	#local DISTROS=($(grep -rw config/distributions/*/ -e 'supported' | cut -d"/" -f3))
 
 	case $@ in
 


### PR DESCRIPTION
# Description

According to the user pleads and our quick investigation about usage, we should re-enable Debian Stretch repository index re-creation. This doesn't produce more in term of space, but rebuilding will take a bit more time. Let's hope repository won't break down. 

Jira reference number [AR-887]

# How Has This Been Tested?

Try building BSP packages.

[AR-887]: https://armbian.atlassian.net/browse/AR-887