### PR TITLE
Adjusting Cinnamon Focal / Hirsute back to stock graphics

### DIFF
--- a/config/desktop/focal/environments/cinnamon/armbian/create_desktop_package.sh
+++ b/config/desktop/focal/environments/cinnamon/armbian/create_desktop_package.sh
@@ -1,11 +1,11 @@
-# install lightdm greeter
+# install default lightdm greeter settings
 cp -R "${SRC}"/packages/blobs/desktop/lightdm "${destination}"/etc/armbian
 
 # install default desktop settings
 mkdir -p "${destination}"/etc/skel
 cp -R "${SRC}"/packages/blobs/desktop/skel/. "${destination}"/etc/skel
 
-#install cinnamon desktop bar icons
+# install cinnamon desktop bar icons
 mkdir -p "${destination}"/usr/share/icons/armbian
 cp "${SRC}"/packages/blobs/desktop/desktop-icons/*.png "${destination}"/usr/share/icons/armbian
 
@@ -13,15 +13,15 @@ cp "${SRC}"/packages/blobs/desktop/desktop-icons/*.png "${destination}"/usr/shar
 mkdir -p "${destination}"/usr/share/backgrounds/armbian/
 cp "${SRC}"/packages/blobs/desktop/desktop-wallpapers/*.jpg "${destination}"/usr/share/backgrounds/armbian
 
-# install wallpapers
+# install lightdm wallpapers
 mkdir -p "${destination}"/usr/share/backgrounds/armbian-lightdm/
 cp "${SRC}"/packages/blobs/desktop/lightdm-wallpapers/*.jpg "${destination}"/usr/share/backgrounds/armbian-lightdm
 
-# install logo for login screen
+# install startup icons
 mkdir -p "${destination}"/usr/share/pixmaps/armbian
 cp "${SRC}"/packages/blobs/desktop/icons/armbian.png "${destination}"/usr/share/pixmaps/armbian
 
-#generate wallpaper list for background changer
+# generate wallpaper list for background changer
 mkdir -p "${destination}"/usr/share/cinnamon-background-properties
 cat <<EOF > "${destination}"/usr/share/cinnamon-background-properties/armbian.xml
 <?xml version="1.0"?>
@@ -111,7 +111,7 @@ cat <<EOF > "${destination}"/usr/share/cinnamon-background-properties/armbian.xm
     <pcolor>#ffffff</pcolor>
     <scolor>#000000</scolor>
   </wallpaper>
-    <wallpaper deleted="false">
+  <wallpaper deleted="false">
     <name>Armbian purplepunk-resultado</name>
     <filename>/usr/share/backgrounds/armbian/armbian-4k-purplepunk.jpg</filename>
     <options>zoom</options>

--- a/config/desktop/focal/environments/cinnamon/config_base/packages.uninstall
+++ b/config/desktop/focal/environments/cinnamon/config_base/packages.uninstall
@@ -1,1 +1,4 @@
-gdm3 gnome-software gnome-keyring
+gdm3
+gnome-software
+gnome-keyring
+tracker-extract

--- a/config/desktop/focal/environments/cinnamon/debian/postinst
+++ b/config/desktop/focal/environments/cinnamon/debian/postinst
@@ -1,8 +1,8 @@
 # overwrite stock lightdm greeter configuration
 if [ -d /etc/armbian/lightdm ]; then cp -R /etc/armbian/lightdm /etc/; fi
-if [ -f /etc/lightdm/slick-greeter.conf ]; then sed -i 's/armbian03-Dre0x-Minum-dark-blurred-3840x2160.jpg/armbian-4k-neon-gray-penguin-gauss.jpg/g' /etc/lightdm/slick-greeter.conf; fi
+#if [ -f /etc/lightdm/slick-greeter.conf ]; then sed -i 's/armbian03-Dre0x-Minum-dark-blurred-3840x2160.jpg/armbian-4k-neon-gray-penguin-gauss.jpg/g' /etc/lightdm/slick-greeter.conf; fi
 
-# Disable Pulseaudio timer scheduling which does not work with sndhdmi driver
+# disable Pulseaudio timer scheduling which does not work with sndhdmi driver
 if [ -f /etc/pulse/default.pa ]; then sed "s/load-module module-udev-detect$/& tsched=0/g" -i /etc/pulse/default.pa; fi
 
 ##dconf desktop settings
@@ -60,7 +60,7 @@ secondary-click-time=1.2
 
 [org/cinnamon/desktop/background]
 picture-options='zoom'
-picture-uri='file:///usr/share/backgrounds/armbian/armbian-4k-neon-gray-penguin.jpg'
+picture-uri='file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'
 primary-color='#456789'
 secondary-color='#FFFFFF'
 
@@ -83,7 +83,7 @@ autorun-never=false
 
 [org/cinnamon/desktop/screensaver]
 picture-options='zoom'
-picture-uri='file:///usr/share/backgrounds/armbian-lightdm/armbian-4k-neon-gray-gauss.jpg.jpg'
+picture-uri='file:///usr/share/backgrounds/armbian-lightdm/armbian03-Dre0x-Minum-dark-3840x2160'
 primary-color='#456789'
 secondary-color='#FFFFFF'
 

--- a/packages/blobs/desktop/skel/.cinnamon/configs/menu@cinnamon.org/0.json
+++ b/packages/blobs/desktop/skel/.cinnamon/configs/menu@cinnamon.org/0.json
@@ -88,7 +88,7 @@
         "default_icon": "cinnamon-symbolic",
         "dependency": "menu-custom",
         "indent": true,
-        "value": "/usr/share/icons/armbian/icon-menu-red.png"
+        "value": "/usr/share/pixmaps/armbian/armbian.png"
     },
     "menu-icon-size": {
         "type": "spinbutton",


### PR DESCRIPTION
# Description

- adjusting Cinnamon back to stock graphics
- removing tracker-extract since its crashing and is anyway useless tool
- adjusting text to meet the real meaning

Jira reference number [AR-890]

# How Has This Been Tested?

- [x] Build desktop image

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

[AR-890]: https://armbian.atlassian.net/browse/AR-890