### PR TITLE
removed srccpy from xfce

### DIFF
--- a/config/desktop/focal/environments/xfce/config_base/packages
+++ b/config/desktop/focal/environments/xfce/config_base/packages
@@ -117,7 +117,6 @@ printer-driver-all
 profile-sync-daemon
 pulseaudio-module-bluetooth
 redshift
-scrcpy
 slick-greeter
 smbclient
 software-properties-gtk


### PR DESCRIPTION
rm srccpy app that is not used from xfce desktop packages