### PR TITLE
Exclude IP of network interface with :avahi at the end of name

### DIFF
--- a/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
+++ b/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
@@ -138,7 +138,7 @@ function get_ip_addresses() {
 		if [[ $intf =~ $HIDE_IP_PATTERN ]]; then
 			continue
 		else
-			local tmp=$(ip -4 addr show dev $intf | awk '/inet/ {print $2}' | cut -d'/' -f1)
+			local tmp=$(ip -4 addr show dev $intf | grep -v "$intf:avahi" | awk '/inet/ {print $2}' | cut -d'/' -f1)
 			# add both name and IP - can be informative but becomes ugly with long persistent/predictable device names
 			#[[ -n $tmp ]] && ips+=("$intf: $tmp")
 			# add IP only


### PR DESCRIPTION
# Description

I found that `30-armbian-sysinfo` will show the IP of `eth0:avahi`. like this

```
System load:   2%               Up time:       13:29
Memory usage:  10% of 999M      IP:            169.254.8.161 192.168.10.18
CPU temp:      40°C             Usage of /:    40% of 15G
```

Here is part of my ifconfig
```
root@localhost:~# ifconfig
eth0: flags=4099<UP,BROADCAST,MULTICAST>  mtu 1500
        ether 02:81:3a:05:d0:ac  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 0  bytes 0 (0.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
        device interrupt 38

eth0:avahi: flags=4099<UP,BROADCAST,MULTICAST>  mtu 1500
        inet 169.254.8.161  netmask 255.255.0.0  broadcast 169.254.255.255
        ether 02:81:3a:05:d0:ac  txqueuelen 1000  (Ethernet)
        device interrupt 38
```

Here are interfaces that I have
```
root@localhost:~# ls -1 /sys/class/net/
dummy0
eth0
lo
wlxXXXXXXXXXX
```

```
root@localhost:~# ip -4 addr show dev eth0
3: eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc mq state DOWN group default qlen 1000
    inet 169.254.8.161/16 brd 169.254.255.255 scope link eth0:avahi
       valid_lft forever preferred_lft forever
```

I think would be a good idea to exclude `eth0:avahi`, the fact that eth0:avahi appears means that the system failed to get an IP on the eth0 interface, so I assume the IP of `eth0:avahi` might not be a useful info for user

# How Has This Been Tested?

Test Result:
```
System load:   2%               Up time:       13:28
Memory usage:  10% of 999M      IP:            192.168.10.18
CPU temp:      41°C             Usage of /:    40% of 15G
```
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
