### PR TITLE
Fix gpg signing when sudo unavailable.

### DIFF
--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -825,8 +825,13 @@ create_image()
 			cd ${DESTIMG}
 			if [[ -n $GPG_PASS ]]; then
 				display_alert "GPG signing" "${version}.img${compression_type}" "info"
-				[[ -n ${SUDO_USER} ]] && sudo chown -R ${SUDO_USER}:${SUDO_USER} "${DESTIMG}"/
-				echo "${GPG_PASS}" | sudo -H -u ${SUDO_USER} bash -c "gpg --passphrase-fd 0 --armor --detach-sign --pinentry-mode loopback --batch --yes ${DESTIMG}/${version}.img${compression_type}" || exit 1
+				if [[ -n $SUDO_USER ]]; then
+					sudo chown -R ${SUDO_USER}:${SUDO_USER} "${DESTIMG}"/
+					SUDO_PREFIX="sudo -H -u ${SUDO_USER}"
+				else
+					SUDO_PREFIX=""
+				fi
+				echo "${GPG_PASS}" | $SUDO_PREFIX bash -c "gpg --passphrase-fd 0 --armor --detach-sign --pinentry-mode loopback --batch --yes ${DESTIMG}/${version}.img${compression_type}" || exit 1
 			else
 				display_alert "GPG signing skipped - no GPG_PASS" "${version}.img" "wrn"
 			fi


### PR DESCRIPTION
Signed-off-by: Vyacheslav Bocharov <devel@lexina.in>

# Description

When start build process via docker with COMPRESS_OUTPUTIMAGE contain gpg option, build process fails on sudo execute.
We can check for $SUDO_USER variable and start gpg without sudo (as was before b012a8a7548beb2ce38efe3574265d6db25cf4ff commit).

# How Has This Been Tested?

Build whithout $SUDO_USER complete.
# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
