### PR TITLE
Remove unused variable in format string

### DIFF
--- a/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
+++ b/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
@@ -39,10 +39,10 @@ function display() {
 	# battery red color is opposite, lower number
 	if [[ "$1" == "Battery" ]]; then local great="<"; else local great=">"; fi
 	if [[ -n "$2" && "$2" > "0" && (( "${2%.*}" -ge "$4" )) ]]; then
-	printf "%-14s%s" "$1:"
+		printf "%-14s" "$1:"
 		if awk "BEGIN{exit ! ($2 $great $3)}"; then echo -ne "\e[0;91m $2"; else echo -ne "\e[0;92m $2"; fi
-		printf "%-1s%s\x1B[0m" "$5"
-		printf "%-11s%s\t" "$6"
+		printf "%-1s\x1B[0m" "$5"
+		printf "%-11s\t" "$6"
 		return 1
 	fi
 } # display


### PR DESCRIPTION
# Description

I used `shellcheck`  and found an warning message like this
```
printf "%-14s%s" "$1:"
       ^-- SC2183: This format string has 2 variables, but is passed 1 arguments.
```

# How Has This Been Tested?

Removed the unused `%s`, and the display result is still same as before.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings