### PR TITLE
ODROID HC4: edge: experimental: SPI+SATA boot via chewitt's amlogic u-boot tree

### DIFF
--- a/config/sources/families/meson-sm1.conf
+++ b/config/sources/families/meson-sm1.conf
@@ -6,6 +6,26 @@ GOVERNOR=ondemand
 
 [[ ${BRANCH} == legacy ]] && SERIALCON=ttyS0
 
+if [[ ${BRANCH} == edge ]] && [[ $BOARD == odroidhc4 ]]; then
+	# Experimental, use chewitt's u-boot, which enables SPI+SATA booting.
+	display_alert "Using experimental u-boot with SPI+SATA" "edge+odroidhc4" "info"
+	BOOTSOURCE="https://github.com/chewitt/u-boot.git"
+	BOOTDIR='u-boot-chewitt'
+	BOOTBRANCH='branch:amlogic-2021.07'
+	UBOOT_TARGET_MAP="u-boot-dtb.img;;u-boot.bin.sd.bin:u-boot.bin u-boot-dtb.img u-boot.bin:u-boot-spi.bin"
+	BOOTCONFIG="odroid-hc4_defconfig" # hc4_defconfig vs c4_defconfig, enables PCIe+SATA stuff.
+
+	write_uboot_platform_mtd() {
+		if [[ -f $1/u-boot-spi.bin ]]; then
+			dd if=$1/u-boot-spi.bin of=/dev/mtdblock0
+			sync
+		else
+			echo "SPI u-boot image not found!"
+			exit 1
+		fi
+	}
+fi
+
 family_tweaks()
 {
 	:


### PR DESCRIPTION
### ODROID HC4: edge: experimental: SPI+SATA boot via chewitt's amlogic u-boot tree

- There's a new defconfig for hc4 in his tree that enables SATA.
- His tree is based off 2021.07

Jira reference number [AR-678]

# How Has This Been Tested?

- [x] Tested with nand-sata-install


[AR-678]: https://armbian.atlassian.net/browse/AR-678