### PR TITLE
fix bananapro dts for using lima driver

### DIFF
--- a/patch/kernel/archive/sunxi-5.10/fix-bananapro-lima.patch
+++ b/patch/kernel/archive/sunxi-5.10/fix-bananapro-lima.patch
@@ -1,0 +1,59 @@
+diff --git a/arch/arm/boot/dts/sun7i-a20-bananapro.dts b/arch/arm/boot/dts/sun7i-a20-bananapro.dts
+index 0176e9de..1b17e433 100644
+--- a/arch/arm/boot/dts/sun7i-a20-bananapro.dts
++++ b/arch/arm/boot/dts/sun7i-a20-bananapro.dts
+@@ -60,6 +60,17 @@
+ 		stdout-path = "serial0:115200n8";
+ 	};
+ 
++	hdmi-connector {
++		compatible = "hdmi-connector";
++		type = "a";
++
++		port {
++			hdmi_con_in: endpoint {
++				remote-endpoint = <&hdmi_out_con>;
++			};
++		};
++	};
++
+ 	leds {
+ 		compatible = "gpio-leds";
+ 
+@@ -91,13 +102,18 @@
+ };
+ 
+ &ahci {
+-	status = "okay";
++    target-supply = <&reg_ahci_5v>;
++    status = "okay";
+ };
+ 
+ &codec {
+ 	status = "okay";
+ };
+ 
++&de {
++    status = "okay";
++};
++
+ &ehci0 {
+ 	status = "okay";
+ };
+@@ -119,6 +135,16 @@
+ 	};
+ };
+ 
++&hdmi {
++	status = "okay";
++};
++
++&hdmi_out {
++	hdmi_out_con: endpoint {
++		remote-endpoint = <&hdmi_con_in>;
++	};
++};
++
+ &i2c0 {
+ 	status = "okay";
+ 

--- a/patch/kernel/archive/sunxi-5.11/fix-bananapro-lima.patch
+++ b/patch/kernel/archive/sunxi-5.11/fix-bananapro-lima.patch
@@ -1,0 +1,59 @@
+diff --git a/arch/arm/boot/dts/sun7i-a20-bananapro.dts b/arch/arm/boot/dts/sun7i-a20-bananapro.dts
+index 0176e9de..1b17e433 100644
+--- a/arch/arm/boot/dts/sun7i-a20-bananapro.dts
++++ b/arch/arm/boot/dts/sun7i-a20-bananapro.dts
+@@ -60,6 +60,17 @@
+ 		stdout-path = "serial0:115200n8";
+ 	};
+ 
++	hdmi-connector {
++		compatible = "hdmi-connector";
++		type = "a";
++
++		port {
++			hdmi_con_in: endpoint {
++				remote-endpoint = <&hdmi_out_con>;
++			};
++		};
++	};
++
+ 	leds {
+ 		compatible = "gpio-leds";
+ 
+@@ -91,13 +102,18 @@
+ };
+ 
+ &ahci {
+-	status = "okay";
++    target-supply = <&reg_ahci_5v>;
++    status = "okay";
+ };
+ 
+ &codec {
+ 	status = "okay";
+ };
+ 
++&de {
++    status = "okay";
++};
++
+ &ehci0 {
+ 	status = "okay";
+ };
+@@ -119,6 +135,16 @@
+ 	};
+ };
+ 
++&hdmi {
++	status = "okay";
++};
++
++&hdmi_out {
++	hdmi_out_con: endpoint {
++		remote-endpoint = <&hdmi_con_in>;
++	};
++};
++
+ &i2c0 {
+ 	status = "okay";
+ 

--- a/patch/kernel/archive/sunxi-5.12/fix-bananapro-lima.patch
+++ b/patch/kernel/archive/sunxi-5.12/fix-bananapro-lima.patch
@@ -1,0 +1,59 @@
+diff --git a/arch/arm/boot/dts/sun7i-a20-bananapro.dts b/arch/arm/boot/dts/sun7i-a20-bananapro.dts
+index 0176e9de..1b17e433 100644
+--- a/arch/arm/boot/dts/sun7i-a20-bananapro.dts
++++ b/arch/arm/boot/dts/sun7i-a20-bananapro.dts
+@@ -60,6 +60,17 @@
+ 		stdout-path = "serial0:115200n8";
+ 	};
+ 
++	hdmi-connector {
++		compatible = "hdmi-connector";
++		type = "a";
++
++		port {
++			hdmi_con_in: endpoint {
++				remote-endpoint = <&hdmi_out_con>;
++			};
++		};
++	};
++
+ 	leds {
+ 		compatible = "gpio-leds";
+ 
+@@ -91,13 +102,18 @@
+ };
+ 
+ &ahci {
+-	status = "okay";
++    target-supply = <&reg_ahci_5v>;
++    status = "okay";
+ };
+ 
+ &codec {
+ 	status = "okay";
+ };
+ 
++&de {
++    status = "okay";
++};
++
+ &ehci0 {
+ 	status = "okay";
+ };
+@@ -119,6 +135,16 @@
+ 	};
+ };
+ 
++&hdmi {
++	status = "okay";
++};
++
++&hdmi_out {
++	hdmi_out_con: endpoint {
++		remote-endpoint = <&hdmi_con_in>;
++	};
++};
++
+ &i2c0 {
+ 	status = "okay";
+ 

--- a/patch/kernel/archive/sunxi-5.13/fix-bananapro-lima.patch
+++ b/patch/kernel/archive/sunxi-5.13/fix-bananapro-lima.patch
@@ -1,0 +1,59 @@
+diff --git a/arch/arm/boot/dts/sun7i-a20-bananapro.dts b/arch/arm/boot/dts/sun7i-a20-bananapro.dts
+index 0176e9de..1b17e433 100644
+--- a/arch/arm/boot/dts/sun7i-a20-bananapro.dts
++++ b/arch/arm/boot/dts/sun7i-a20-bananapro.dts
+@@ -60,6 +60,17 @@
+ 		stdout-path = "serial0:115200n8";
+ 	};
+ 
++	hdmi-connector {
++		compatible = "hdmi-connector";
++		type = "a";
++
++		port {
++			hdmi_con_in: endpoint {
++				remote-endpoint = <&hdmi_out_con>;
++			};
++		};
++	};
++
+ 	leds {
+ 		compatible = "gpio-leds";
+ 
+@@ -91,13 +102,18 @@
+ };
+ 
+ &ahci {
+-	status = "okay";
++    target-supply = <&reg_ahci_5v>;
++    status = "okay";
+ };
+ 
+ &codec {
+ 	status = "okay";
+ };
+ 
++&de {
++    status = "okay";
++};
++
+ &ehci0 {
+ 	status = "okay";
+ };
+@@ -119,6 +135,16 @@
+ 	};
+ };
+ 
++&hdmi {
++	status = "okay";
++};
++
++&hdmi_out {
++	hdmi_out_con: endpoint {
++		remote-endpoint = <&hdmi_con_in>;
++	};
++};
++
+ &i2c0 {
+ 	status = "okay";
+ 

--- a/patch/u-boot/u-boot-sunxi/fix-bananapro-lima.patch
+++ b/patch/u-boot/u-boot-sunxi/fix-bananapro-lima.patch
@@ -1,0 +1,59 @@
+diff --git a/arch/arm/dts/sun7i-a20-bananapro.dts b/arch/arm/dts/sun7i-a20-bananapro.dts
+index 0176e9de..1b17e433 100644
+--- a/arch/arm/dts/sun7i-a20-bananapro.dts
++++ b/arch/arm/dts/sun7i-a20-bananapro.dts
+@@ -60,6 +60,17 @@
+ 		stdout-path = "serial0:115200n8";
+ 	};
+ 
++	hdmi-connector {
++		compatible = "hdmi-connector";
++		type = "a";
++
++		port {
++			hdmi_con_in: endpoint {
++				remote-endpoint = <&hdmi_out_con>;
++			};
++		};
++	};
++
+ 	leds {
+ 		compatible = "gpio-leds";
+ 
+@@ -91,13 +102,18 @@
+ };
+ 
+ &ahci {
+-	status = "okay";
++    target-supply = <&reg_ahci_5v>;
++    status = "okay";
+ };
+ 
+ &codec {
+ 	status = "okay";
+ };
+ 
++&de {
++    status = "okay";
++};
++
+ &ehci0 {
+ 	status = "okay";
+ };
+@@ -119,6 +135,16 @@
+ 	};
+ };
+ 
++&hdmi {
++	status = "okay";
++};
++
++&hdmi_out {
++	hdmi_out_con: endpoint {
++		remote-endpoint = <&hdmi_con_in>;
++	};
++};
++
+ &i2c0 {
+ 	status = "okay";
+ 


### PR DESCRIPTION
Fix Banana pro dts bug with lima driver, where no /dev/dri/card1 and no hardware acceleration.
Some hdmi-related entries ported to `sun7i-a20-bananapro.dts` from `sun7i-a20-bananapi.dts`, where lima drivers works.

Context: https://forum.armbian.com/topic/14180-bananapro-lima-driver-problems/

# How Has This Been Tested?

Install armbian ubuntu hirsute (needed mesa >= 21.0.1), sway, xwayland
Apply patches to dts and Install linux-dtb-edge-sunxi_21.08.0-trunk_armhf.deb
start `sway` and `DISPLAY=:0 glxinfo | grep renderer` shows Mali400, glxgears 20 fps (without lima was 10)

Or install xserver-xorg-core >= 1.20.13 (ubuntu impish, arch linux) and run `glxinfo | grep renderer`

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules