### PR TITLE
ODROID N2(+): chewitt's uboot + SPI-NOR enable via extra DTBs = SPI Boot to USB

### DIFF
--- a/config/bootscripts/boot-meson64.cmd
+++ b/config/bootscripts/boot-meson64.cmd
@@ -80,9 +80,15 @@ setenv maxcpus "4"
 echo "U-boot default fdtfile: ${fdtfile}"
 echo "Current variant: ${variant}"
 # there is a mismatch between u-boot and kernel in the n2-plus/n2_plus DTB filename.
+# Also u-boot can't seem to decide between having, or not, 'amlogic/' in there.
 if test "${variant}" = "n2_plus"; then
 	setenv fdtfile "amlogic/meson-g12b-odroid-n2-plus.dtb"
 	echo "For variant ${variant}, set default fdtfile: ${fdtfile}"
+fi
+
+if test "${variant}" = "n2-plus"; then
+	setenv fdtfile "amlogic/meson-g12b-odroid-n2-plus.dtb"
+	echo "For variant ${variant} (dash version, 2021.07 or up), set default fdtfile: ${fdtfile}"
 fi
 
 # legacy kernel values from boot.ini

--- a/config/sources/families/meson-g12b.conf
+++ b/config/sources/families/meson-g12b.conf
@@ -40,4 +40,17 @@ else
 			exit 2
 		fi
 	}
+
+	if [[ ${BRANCH} == edge ]] && [[ $BOARD == odroidn2 ]]; then
+		# Experimental, use chewitt's u-boot.
+		display_alert "Using experimental u-boot" "edge+odroidn2" "info"
+		BOOTSOURCE="https://github.com/chewitt/u-boot.git"
+		BOOTDIR='u-boot-chewitt'
+		BOOTBRANCH='branch:amlogic-2021.07'
+		UBOOT_TARGET_MAP="u-boot-dtb.img;;u-boot.bin.sd.bin:u-boot.bin u-boot-dtb.img u-boot.bin:u-boot-spi.bin"
+
+		write_uboot_platform_mtd() {
+			dd if=$1/u-boot-spi.bin of=/dev/mtdblock0
+		}
+	fi
 fi

--- a/patch/kernel/archive/meson64-5.13/9999-HACK-Add_SPI_Flash_enabled_versions_of_N2_and_N2Plus_DTBs.patch
+++ b/patch/kernel/archive/meson64-5.13/9999-HACK-Add_SPI_Flash_enabled_versions_of_N2_and_N2Plus_DTBs.patch
@@ -1,0 +1,83 @@
+Index: arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-spi.dts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-spi.dts b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-spi.dts
+new file mode 100644
+--- /dev/null	(date 1630421486471)
++++ b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-spi.dts	(date 1630421486471)
+@@ -0,0 +1,11 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++
++/dts-v1/;
++
++#include "meson-g12b-odroid-n2.dts"
++
++/ {
++	model = "Hardkernel ODROID-N2 with SPI";
++};
++
++#include "meson-g12b-odroid-n2-enable-spi.dtsi"
+Index: arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-plus-spi.dts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-plus-spi.dts b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-plus-spi.dts
+new file mode 100644
+--- /dev/null	(date 1630421477913)
++++ b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-plus-spi.dts	(date 1630421477913)
+@@ -0,0 +1,11 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++
++/dts-v1/;
++
++#include "meson-g12b-odroid-n2-plus.dts"
++
++/ {
++	model = "Hardkernel ODROID-N2Plus with SPI";
++};
++
++#include "meson-g12b-odroid-n2-enable-spi.dtsi"
+Index: arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-enable-spi.dtsi
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-enable-spi.dtsi b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-enable-spi.dtsi
+new file mode 100644
+--- /dev/null	(date 1630421525557)
++++ b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-enable-spi.dtsi	(date 1630421525557)
+@@ -0,0 +1,13 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++
++/*
++ * Replace emmc_data_8b_pins to emmc_data_4b_pins from sd_emmc_c pinctrl-0, and change bus-width to 4 then spifc can be enabled.
++ */
++&sd_emmc_c {
++	pinctrl-0 = <&emmc_ctrl_pins>, <&emmc_data_4b_pins>, <&emmc_ds_pins>;
++	bus-width = <4>;
++};
++
++&spifc {
++	status = "okay";
++};
+Index: arch/arm64/boot/dts/amlogic/Makefile
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/arch/arm64/boot/dts/amlogic/Makefile b/arch/arm64/boot/dts/amlogic/Makefile
+--- a/arch/arm64/boot/dts/amlogic/Makefile	(revision b91db6a0b52e019b6bdabea3f1dbe36d85c7e52c)
++++ b/arch/arm64/boot/dts/amlogic/Makefile	(date 1630421076946)
+@@ -9,7 +9,9 @@
+ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-a311d-khadas-vim3.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-s922x-khadas-vim3.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-odroid-n2.dtb
++dtb-$(CONFIG_ARCH_MESON) += meson-g12b-odroid-n2-spi.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-odroid-n2-plus.dtb
++dtb-$(CONFIG_ARCH_MESON) += meson-g12b-odroid-n2-plus-spi.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-ugoos-am6.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-gxbb-kii-pro.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-gxbb-nanopi-k2.dtb


### PR DESCRIPTION
### ODROID N2(+): chewitt's uboot + SPI-NOR enable via extra DTBs = SPI Boot to USB

- fix/dup bootscript, since new u-boot fixed n2_plus to n2-plus variant
- g12b: if n2 and edge, enable new u-boot; include non-SD version as SPI binary; write_uboot_platform_mtd
- Kernel DTS patch to add SPI-flash-enabled DTBs (slower eMMC), produces -spi .dtbs for n2 and n2-plus
  - This could also be an overlay, but I dunno overlays.
- SPI+USB3 boot works with "pendrive" storage, untested with cabled/high power USB->SATA or USB->NVMe

