### PR TITLE
Add enable pinecube sound to 5.13 (edge)

### DIFF
--- a/patch/kernel/archive/sunxi-5.13/enable-sound-pinecube-kernel.patch
+++ b/patch/kernel/archive/sunxi-5.13/enable-sound-pinecube-kernel.patch
@@ -1,0 +1,85 @@
+diff --git a/arch/arm/boot/dts/sun8i-s3-pinecube.dts b/arch/arm/boot/dts/sun8i-s3-pinecube.dts
+index 4aa0ee897a0a..9416aa6f1e96 100644
+--- a/arch/arm/boot/dts/sun8i-s3-pinecube.dts
++++ b/arch/arm/boot/dts/sun8i-s3-pinecube.dts
+@@ -58,6 +58,15 @@ wifi_pwrseq: wifi_pwrseq {
+ 	};
+ };
+ 
++&codec {
++	allwinner,audio-routing =
++		"Speaker", "LINEOUT",
++		"MIC1", "Mic",
++		"Mic",  "MBIAS";
++	allwinner,pa-gpios = <&pio 6 6 GPIO_ACTIVE_HIGH>; /* PG6 */
++	status = "okay";
++};
++
+ &csi1 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&csi1_8bit_pins>;
+diff --git a/arch/arm/boot/dts/sun8i-v3s.dtsi b/arch/arm/boot/dts/sun8i-v3s.dtsi
+index 89abd4cc7e23..1b9278f75ae3 100644
+--- a/arch/arm/boot/dts/sun8i-v3s.dtsi
++++ b/arch/arm/boot/dts/sun8i-v3s.dtsi
+@@ -163,6 +163,15 @@ syscon: system-control@1c00000 {
+ 			ranges;
+ 		};
+ 
++		dma: dma-controller@1c02000 {
++			compatible = "allwinner,sun8i-v3s-dma";
++			reg = <0x01c02000 0x1000>;
++			interrupts = <GIC_SPI 50 IRQ_TYPE_LEVEL_HIGH>;
++			clocks = <&ccu CLK_BUS_DMA>;
++			resets = <&ccu RST_BUS_DMA>;
++			#dma-cells = <1>;
++		};
++
+ 		tcon0: lcd-controller@1c0c000 {
+ 			compatible = "allwinner,sun8i-v3s-tcon";
+ 			reg = <0x01c0c000 0x1000>;
+@@ -408,6 +417,25 @@ lradc: lradc@1c22800 {
+ 			status = "disabled";
+ 		};
+ 
++		codec: codec@1c22c00 {
++			#sound-dai-cells = <1>;
++			compatible = "allwinner,sun8i-v3s-codec";
++			reg = <0x01c22c00 0x400>;
++			interrupts = <GIC_SPI 29 IRQ_TYPE_LEVEL_HIGH>;
++			clocks = <&ccu CLK_BUS_CODEC>, <&ccu CLK_AC_DIG>;
++			clock-names = "apb", "codec";
++			resets = <&ccu RST_BUS_CODEC>;
++			dmas = <&dma 15>, <&dma 15>;
++			dma-names = "rx", "tx";
++			allwinner,codec-analog-controls = <&codec_analog>;
++			status = "disabled";
++		};
++
++		codec_analog: codec-analog@1c23000 {
++			compatible = "allwinner,sun8i-v3s-codec-analog";
++			reg = <0x01c23000 0x4>;
++		};
++
+ 		uart0: serial@1c28000 {
+ 			compatible = "snps,dw-apb-uart";
+ 			reg = <0x01c28000 0x400>;
+diff --git a/sound/soc/sunxi/sun8i-codec-analog.c b/sound/soc/sunxi/sun8i-codec-analog.c
+index be872eefa61e..10387fa9f9c4 100644
+--- a/sound/soc/sunxi/sun8i-codec-analog.c
++++ b/sound/soc/sunxi/sun8i-codec-analog.c
+@@ -729,8 +729,12 @@ static int sun8i_codec_analog_add_mixer(struct snd_soc_component *cmpnt,
+ }
+ 
+ static const struct sun8i_codec_analog_quirks sun8i_v3s_quirks = {
+-	.has_headphone	= true,
+-	.has_hmic	= true,
++	.has_headphone  = true,
++	.has_hmic       = true,
++	.has_linein     = true,
++	.has_lineout    = true,
++	.has_mbias      = true,
++	.has_mic2       = true,
+ };
+ 
+ static int sun8i_codec_analog_cmpnt_probe(struct snd_soc_component *cmpnt)


### PR DESCRIPTION
This brings the patch forward from 5.11 to the new edge 5.13 kernel

# Description

There is a patch on the sunxi 5.11 kernel archive that enables sound on the pinecube board. That may have been the edge kernel at one point for Armbian. This patch can be used with the new 5.13 edge kernel to enable sound.

Jira reference number None

# How Has This Been Tested?

This has been tested by building and installing a 5.13 kernel on a pinecube and running through some tests of audio playback and mixing.

# Checklist:

I believe that these had been followed before with the existing 5.11 patch. There is no difference in code structure between this and that one. This just copies it to the 5.13 branch.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
