### PR TITLE
Pinecube: add i2s device to the sound patch

### DIFF
--- a/patch/kernel/archive/sunxi-5.13/enable-sound-pinecube-kernel.patch
+++ b/patch/kernel/archive/sunxi-5.13/enable-sound-pinecube-kernel.patch
@@ -2,10 +2,15 @@ diff --git a/arch/arm/boot/dts/sun8i-s3-pinecube.dts b/arch/arm/boot/dts/sun8i-s
 index 4aa0ee897a0a..9416aa6f1e96 100644
 --- a/arch/arm/boot/dts/sun8i-s3-pinecube.dts
 +++ b/arch/arm/boot/dts/sun8i-s3-pinecube.dts
-@@ -58,6 +58,15 @@ wifi_pwrseq: wifi_pwrseq {
+@@ -58,6 +58,20 @@ wifi_pwrseq: wifi_pwrseq {
  	};
  };
  
++
++&i2s0 {
++       status = "okay";
++};
++
 +&codec {
 +	allwinner,audio-routing =
 +		"Speaker", "LINEOUT",
@@ -38,10 +43,24 @@ index 89abd4cc7e23..1b9278f75ae3 100644
  		tcon0: lcd-controller@1c0c000 {
  			compatible = "allwinner,sun8i-v3s-tcon";
  			reg = <0x01c0c000 0x1000>;
-@@ -408,6 +417,25 @@ lradc: lradc@1c22800 {
+@@ -408,6 +417,39 @@ lradc: lradc@1c22800 {
  			status = "disabled";
  		};
  
++
++               i2s0: i2s@1c22000 {
++                       #sound-dai-cells = <0>;
++                       compatible = "allwinner,sun8i-h3-i2s";
++                       reg = <0x01c22000 0x400>;
++                       interrupts = <GIC_SPI 13 IRQ_TYPE_LEVEL_HIGH>;
++                       clocks = <&ccu CLK_BUS_I2S0>, <&ccu CLK_I2S0>;
++                       clock-names = "apb", "mod";
++                       dmas = <&dma 3>, <&dma 3>;
++                       resets = <&ccu RST_BUS_I2S0>; /* TODO: Areset/sun8i-v3s-ccu says this isn't available on V3s */
++                       dma-names = "rx", "tx";
++                       status = "disabled";
++               };
++
 +		codec: codec@1c22c00 {
 +			#sound-dai-cells = <1>;
 +			compatible = "allwinner,sun8i-v3s-codec";


### PR DESCRIPTION
# Description

This fix ports the addition of the i2s device for PineCube from the Daniel Fullmer / Icenowy's patch for NixOS: https://github.com/danielfullmer/pinecube-nixos/blob/master/kernel/Pine64-PineCube-support.patch

With this patch full sound playback and recording should be possible on the device.

Jira reference number N/A

# How Has This Been Tested?

This has been tested by building the kernel and device tree Debian packages using this repository and testing the sound and general functionality of the PineCube with the changes. Sound playback and recording is now possible using arecord and aplay with tweaks to the i2s settings using alsamixer.

# Checklist:

Any feedback on the following is appreciated and I can make necessary changes.

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
