### PR TITLE
Enable Debian Buster target

### DIFF
--- a/config/targets.conf
+++ b/config/targets.conf
@@ -493,6 +493,7 @@ odroidhc4                 edge            hirsute     cli                      s
 # Odroid XU4
 odroidxu4                 legacy          buster      desktop                  stable         yes            xfce      config_base   browsers
 odroidxu4                 current         focal       cli                      stable         yes
+odroidxu4                 current         buster      cli                      stable         yes
 odroidxu4                 current         bullseye    cli                      stable         yes
 odroidxu4                 current         focal       desktop                  stable         yes            xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 odroidxu4                 edge            hirsute     cli                      stable         yes


### PR DESCRIPTION
# Description

Enabling Debian Buster image is still useful for people that thinks running OMV on their HCx variant

Jira reference number [AR-899]

[AR-899]: https://armbian.atlassian.net/browse/AR-899