### PR TITLE
Disabled hs400 on Helios64 (hopefully only temporarily)

### DIFF
--- a/patch/kernel/archive/rockchip64-5.10/add-board-helios64.patch
+++ b/patch/kernel/archive/rockchip64-5.10/add-board-helios64.patch
@@ -14,7 +14,7 @@ new file mode 100644
 index 000000000..fae17f416
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts
-@@ -0,0 +1,1153 @@
+@@ -0,0 +1,1154 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2020 Aditya Prayoga (aditya@kobol.io)
@@ -984,8 +984,9 @@ index 000000000..fae17f416
 +	assigned-clock-rates = <150000000>;
 +	bus-width = <8>;
 +	mmc-hs200-1_8v;
-+	mmc-hs400-1_8v;
-+	mmc-hs400-enhanced-strobe;
++	// hs400 is broken on Helios64 since 5.10.60
++	// mmc-hs400-1_8v;
++	// mmc-hs400-enhanced-strobe;
 +	supports-emmc;
 +	non-removable;
 +	disable-wp;


### PR DESCRIPTION
# Description

This disables hs400 on Helios64 which is broken since Armbian 21.08 and LK 5.10.60 included in it

Jira reference number [AR-904]

# How Has This Been Tested?

- [x] nand-sata-install from SD to eMMC works without issues with this change

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-904]: https://armbian.atlassian.net/browse/AR-904