### PR TITLE
Update ATF source

### DIFF
--- a/config/sources/families/sun50iw9.conf
+++ b/config/sources/families/sun50iw9.conf
@@ -39,8 +39,8 @@ case $BRANCH in
 
 	current|edge)
 
-			ATFSOURCE='https://github.com/apritzel/arm-trusted-firmware'
-			ATFBRANCH='branch:h616-v4'
+			ATFSOURCE='https://github.com/ARM-software/arm-trusted-firmware'
+			ATFBRANCH='branch:master'
 			ATF_PLAT="sun50i_h616";
 			ATF_TARGET_MAP='PLAT=sun50i_h616 DEBUG=1 bl31;;build/sun50i_h616/debug/bl31.bin'
 			BOOTBRANCH='branch:v2021.07'


### PR DESCRIPTION
# Description
Update ATF source for H616 to the mainline repo. The current source repo does not produce bootable image 

# How Has This Been Tested?
- [x ] Image build and boot
- [ ] Test B

# Checklist:

- [X ] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
