### PR TITLE
Store changelog for upstream changes in the cache/hash/

### DIFF
--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -521,7 +521,17 @@ compile_kernel()
 	rsync --remove-source-files -rq ./*.deb "${DEB_STORAGE}/" || exit_with_error "Failed moving kernel DEBs"
 
 	# store git hash to the file
-	echo "${hash}" > "${SRC}/cache/hash"$([[ ${BETA} == yes ]] && echo "-beta")"/linux-image-${BRANCH}-${LINUXFAMILY}.githash"
+	HASHTARGET="${SRC}/cache/hash"$([[ ${BETA} == yes ]] && echo "-beta")"/linux-image-${BRANCH}-${LINUXFAMILY}"
+	OLDHASHTARGET=$(head -1 "${HASHTARGET}.githash" 2>/dev/null)
+
+	# create change log
+	if [[ -f "${HASHTARGET}.githash" ]]; then
+		git -C ${kerneldir} log --abbrev-commit --no-merges --date-order --date=format:'%Y-%m-%d %H:%M:%S' --pretty=format:'%C(black bold)%ad%Creset%C(auto) | %s | <%an> | '${KERNELSOURCE}'/commit/%h' ${OLDHASHTARGET}..${hash} > "${HASHTARGET}.gitlog"
+		else
+		truncate "${HASHTARGET}.gitlog" --size 0
+	fi
+
+	echo "${hash}" > "${HASHTARGET}.githash"
 	[[ -z ${KERNELPATCHDIR} ]] && KERNELPATCHDIR=$LINUXFAMILY-$BRANCH
 	[[ -z ${LINUXCONFIG} ]] && LINUXCONFIG=linux-$LINUXFAMILY-$BRANCH
 	hash_watch_1=$(LC_COLLATE=C find -L "${SRC}/patch/kernel/${KERNELPATCHDIR}"/ -mindepth 1 -maxdepth 1 -printf '%s %P\n' 2> /dev/null | sort -n)

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -343,15 +343,15 @@ fetch_from_repo()
 		# remote was updated, fetch and check out updates
 		display_alert "Fetching updates"
 		case $ref_type in
-			branch) improved_git fetch --depth 1 origin "${ref_name}" ;;
-			tag) improved_git fetch --depth 1 origin tags/"${ref_name}" ;;
-			head) improved_git fetch --depth 1 origin HEAD ;;
+			branch) improved_git fetch --depth 200 origin "${ref_name}" ;;
+			tag) improved_git fetch --depth 200 origin tags/"${ref_name}" ;;
+			head) improved_git fetch --depth 200 origin HEAD ;;
 		esac
 
 		# commit type needs support for older git servers that doesn't support fetching id directly
 		if [[ $ref_type == commit ]]; then
 
-			improved_git fetch --depth 1 origin "${ref_name}"
+			improved_git fetch --depth 200 origin "${ref_name}"
 
 			# cover old type
 			if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
# Description

Jira reference number [AR-906]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Build kernel with no cache/hash/linux-image-edge-sunxi.githash files
- [ ] Build kernel with cache/hash/linux-image-edge-sunxi.githash
- [ ] Build kernel with cache/hash/linux-image-edge-sunxi.githash having older hash id which has produced expected git log

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
