### PR TITLE
Enlarge dialog size to prevent string cut off

### DIFF
--- a/packages/bsp/common/usr/sbin/nand-sata-install
+++ b/packages/bsp/common/usr/sbin/nand-sata-install
@@ -194,7 +194,7 @@ create_armbian()
 	 This will take approximately $(( $((USAGE/300)) * 1 )) minutes to finish. Please wait!\n\n" 11 80
 
 	# run rsync again to silently catch outstanding changes between / and "${TempDir}"/rootfs/
-	dialog --title "$title" --backtitle "$backtitle" --infobox "\n  Cleaning up ... Almost done." 5 40
+	dialog --title "$title" --backtitle "$backtitle" --infobox "\n               Cleaning up ... Almost done." 5 60
 	rsync -avrltD --delete --exclude-from=$EX_LIST / "${TempDir}"/rootfs >/dev/null 2>&1
 
 	# creating fstab from scratch
@@ -418,7 +418,7 @@ format_nand()
 
 	show_nand_warning
 
-	dialog --title "$title" --backtitle "$backtitle" --infobox "\nFormatting ... up to one minute." 5 40
+	dialog --title "$title" --backtitle "$backtitle" --infobox "\n            Formatting ... up to one minute." 5 60
 	if [[ $DEVICE_TYPE = a20 ]]; then
 		(echo y;) | sunxi-nand-part -f a20 /dev/nand 65536 'bootloader 65536' 'linux 0' >> $logfile 2>&1
 	else
@@ -590,7 +590,7 @@ update_bootscript()
 # show warning [TEXT]
 show_warning()
 {
-	dialog --title "$title" --backtitle "$backtitle" --cr-wrap --colors --yesno " \Z1$(toilet -W -f ascii9 WARNING)\Zn\n$1" 14 53
+	dialog --title "$title" --backtitle "$backtitle" --cr-wrap --colors --yesno " \Z1$(toilet -W -f ascii9 ' WARNING')\Zn\n$1" 16 67
 	[[ $? -ne 0 ]] && exit 13
 }
 
@@ -610,7 +610,7 @@ write_uboot_to_spi_flash()
 	local MTD_BLK="/dev/$1"
 	local DIR="$2"
 	local MESSAGE="This script will update the bootloader on SPI Flash $MTD_BLK. Continue?\nIt will take up to a few minutes."
-	dialog --title "$title" --backtitle "$backtitle" --cr-wrap --colors --yesno " \Z1$(toilet -W -f ascii9 WARNING)\Zn\n$MESSAGE" 16 53
+	dialog --title "$title" --backtitle "$backtitle" --cr-wrap --colors --yesno " \Z1$(toilet -W -f ascii9 ' WARNING')\Zn\n$MESSAGE" 16 67
 	if [[ $? -eq 0 ]]; then
 		write_uboot_platform_mtd "$DIR" $MTD_BLK
 		update_bootscript
@@ -635,7 +635,7 @@ main()
 			:
 			;;
 		*)
-			dialog --title "$title" --backtitle "$backtitle" --colors --infobox '\n\Z1This tool must run from SD-card! \Zn' 5 37
+			dialog --title "$title" --backtitle "$backtitle" --colors --infobox '\n\Z1            This tool must run from SD-card! \Zn' 5 60
 			exit 15
 			;;
 	esac


### PR DESCRIPTION
# Description

Some contents will not be fully displayed, so I increased the width of the dialog, and also add some leading space to make it center aligned

# How Has This Been Tested?

before:
![image](https://user-images.githubusercontent.com/20593333/132978336-8d1a2028-11cc-4ee1-9cd4-89c38877e0f6.png)


after:
![image](https://user-images.githubusercontent.com/20593333/132978346-62ea44b8-719b-424e-aab8-105e7c19fa10.png)



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
