### PR TITLE
Bugfix - Bananapi PRO seems to work fine with latest u-boot

### DIFF
--- a/config/sources/families/sun7i.conf
+++ b/config/sources/families/sun7i.conf
@@ -3,6 +3,8 @@ OVERLAY_PREFIX='sun7i-a20'
 [[ -z $CPUMIN ]] && CPUMIN=480000
 [[ -z $CPUMAX ]] && CPUMAX=1010000
 
+[[ $BOARD == bananapipro ]] && BOOTBRANCH='tag:v2021.07'
+
 family_tweaks_bsp_s()
 {
 	if [[ $BOARD == olimex-som204-a20 ]]; then


### PR DESCRIPTION
# Description

https://forum.armbian.com/topic/18916-ambian-fails-before-the-first-hurdle-refuses-to-boot-on-banana-pro-soc-board

Jira reference number [AR-872]

# How Has This Been Tested?

Done many reboots and it didn't break. The same has to be tested with other A20 boards

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
