### PR TITLE
Pinecube sound patch for kernel 5.14

### DIFF
--- a/patch/kernel/archive/sunxi-5.14/enable-sound-pinecube-kernel.patch
+++ b/patch/kernel/archive/sunxi-5.14/enable-sound-pinecube-kernel.patch
@@ -1,0 +1,69 @@
+diff --git a/arch/arm/boot/dts/sun8i-s3-pinecube.dts b/arch/arm/boot/dts/sun8i-s3-pinecube.dts
+index 4aa0ee897a0a..9416aa6f1e96 100644
+--- a/arch/arm/boot/dts/sun8i-s3-pinecube.dts
++++ b/arch/arm/boot/dts/sun8i-s3-pinecube.dts
+@@ -58,6 +58,20 @@ wifi_pwrseq: wifi_pwrseq {
+ 	};
+ };
+ 
++
++&i2s0 {
++       status = "okay";
++};
++
++&codec {
++	allwinner,audio-routing =
++		"Speaker", "LINEOUT",
++		"MIC1", "Mic",
++		"Mic",  "MBIAS";
++	allwinner,pa-gpios = <&pio 6 6 GPIO_ACTIVE_HIGH>; /* PG6 */
++	status = "okay";
++};
++
+ &csi1 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&csi1_8bit_pins>;
+diff --git a/arch/arm/boot/dts/sun8i-v3s.dtsi b/arch/arm/boot/dts/sun8i-v3s.dtsi
+index 89abd4cc7e23..1b9278f75ae3 100644
+--- a/arch/arm/boot/dts/sun8i-v3s.dtsi
++++ b/arch/arm/boot/dts/sun8i-v3s.dtsi
+@@ -408,6 +417,20 @@ lradc: lradc@1c22800 {
+ 			status = "disabled";
+ 		};
+ 
++
++               i2s0: i2s@1c22000 {
++                       #sound-dai-cells = <0>;
++                       compatible = "allwinner,sun8i-h3-i2s";
++                       reg = <0x01c22000 0x400>;
++                       interrupts = <GIC_SPI 13 IRQ_TYPE_LEVEL_HIGH>;
++                       clocks = <&ccu CLK_BUS_I2S0>, <&ccu CLK_I2S0>;
++                       clock-names = "apb", "mod";
++                       dmas = <&dma 3>, <&dma 3>;
++                       resets = <&ccu RST_BUS_I2S0>; /* TODO: Areset/sun8i-v3s-ccu says this isn't available on V3s */
++                       dma-names = "rx", "tx";
++                       status = "disabled";
++               };
++
+ 		uart0: serial@1c28000 {
+ 			compatible = "snps,dw-apb-uart";
+ 			reg = <0x01c28000 0x400>;
+diff --git a/sound/soc/sunxi/sun8i-codec-analog.c b/sound/soc/sunxi/sun8i-codec-analog.c
+index be872eefa61e..10387fa9f9c4 100644
+--- a/sound/soc/sunxi/sun8i-codec-analog.c
++++ b/sound/soc/sunxi/sun8i-codec-analog.c
+@@ -729,8 +729,12 @@ static int sun8i_codec_analog_add_mixer(struct snd_soc_component *cmpnt,
+ }
+ 
+ static const struct sun8i_codec_analog_quirks sun8i_v3s_quirks = {
+-	.has_headphone	= true,
+-	.has_hmic	= true,
++	.has_headphone  = true,
++	.has_hmic       = true,
++	.has_linein     = true,
++	.has_lineout    = true,
++	.has_mbias      = true,
++	.has_mic2       = true,
+ };
+ 
+ static int sun8i_codec_analog_cmpnt_probe(struct snd_soc_component *cmpnt)


### PR DESCRIPTION
# Description

This fix brings forward and adjusts the pinecube's enable sound patch from kernel 5.13 to 5.14. In particular, it seems that some of the device tree additions have already been mainlined so those entries have been removed from the patch.

Jira reference number N/A

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Booted a pinecube with a patches 5.14 kernel produced by the armbian build docker image and checked that alsamixer is working

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
