### PR TITLE
rockchip: fix rga probe function

### DIFF
--- a/patch/kernel/archive/rockchip-5.14/1027-fix-rga-probe.patch
+++ b/patch/kernel/archive/rockchip-5.14/1027-fix-rga-probe.patch
@@ -1,0 +1,13 @@
+diff --git a/drivers/media/platform/rockchip/rga/rga.c b/drivers/media/platform/rockchip/rga/rga.c
+index 6759091b1..d99ea8973 100644
+--- a/drivers/media/platform/rockchip/rga/rga.c
++++ b/drivers/media/platform/rockchip/rga/rga.c
+@@ -895,7 +895,7 @@ static int rga_probe(struct platform_device *pdev)
+ 	}
+ 	rga->dst_mmu_pages =
+ 		(unsigned int *)__get_free_pages(GFP_KERNEL | __GFP_ZERO, 3);
+-	if (rga->dst_mmu_pages) {
++	if (!rga->dst_mmu_pages) {
+ 		ret = -ENOMEM;
+ 		goto free_src_pages;
+ 	}


### PR DESCRIPTION
# Description

Add small patch to fix rga probe function in edge 5.14 kernel

# How Has This Been Tested?

Successful kernel compile

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
