### PR TITLE
Thermal sensor support for H616 SoC.

### DIFF
--- a/patch/kernel/archive/sunxi-5.14/h616_0024-nvmem-sunxi_sid-Support-SID-on-H616.patch
+++ b/patch/kernel/archive/sunxi-5.14/h616_0024-nvmem-sunxi_sid-Support-SID-on-H616.patch
@@ -1,0 +1,41 @@
+From 33ee10f43ed8bda3a8a4181f5738c9c62beb95bc Mon Sep 17 00:00:00 2001
+From: Kali Prasad <kprasadvnsi@protonmail.com>
+Date: Sun, 19 Sep 2021 13:28:10 +0530
+Subject: [PATCH 1/4] nvmem: sunxi_sid: Support SID on H616
+
+Add support for H616's SID controller. It supports 4K-bit
+EFUSE.
+
+Signed-off-by: Kali Prasad <kprasadvnsi@protonmail.com>
+---
+ drivers/nvmem/sunxi_sid.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/drivers/nvmem/sunxi_sid.c b/drivers/nvmem/sunxi_sid.c
+index 275b9155e473..37a6abb0ec82 100644
+--- a/drivers/nvmem/sunxi_sid.c
++++ b/drivers/nvmem/sunxi_sid.c
+@@ -195,6 +195,12 @@ static const struct sunxi_sid_cfg sun50i_h6_cfg = {
+ 	.size = 0x200,
+ };
+ 
++static const struct sunxi_sid_cfg sun50i_h616_cfg = {
++	.value_offset = 0x200,
++	.size = 0x100,
++	.need_register_readout = true,
++};
++
+ static const struct of_device_id sunxi_sid_of_match[] = {
+ 	{ .compatible = "allwinner,sun4i-a10-sid", .data = &sun4i_a10_cfg },
+ 	{ .compatible = "allwinner,sun7i-a20-sid", .data = &sun7i_a20_cfg },
+@@ -203,6 +209,7 @@ static const struct of_device_id sunxi_sid_of_match[] = {
+ 	{ .compatible = "allwinner,sun50i-a64-sid", .data = &sun50i_a64_cfg },
+ 	{ .compatible = "allwinner,sun50i-h5-sid", .data = &sun50i_a64_cfg },
+ 	{ .compatible = "allwinner,sun50i-h6-sid", .data = &sun50i_h6_cfg },
++	{ .compatible = "allwinner,sun50i-h616-sid", .data = &sun50i_h616_cfg },
+ 	{/* sentinel */},
+ };
+ MODULE_DEVICE_TABLE(of, sunxi_sid_of_match);
+-- 
+2.25.1
+

--- a/patch/kernel/archive/sunxi-5.14/h616_0025-arm64-dts-allwinner-h616-Add-device-node-for-SID.patch
+++ b/patch/kernel/archive/sunxi-5.14/h616_0025-arm64-dts-allwinner-h616-Add-device-node-for-SID.patch
@@ -1,0 +1,41 @@
+From 3ffea09cf49afc3c640db8817b899b0fa85398bf Mon Sep 17 00:00:00 2001
+From: Kali Prasad <kprasadvnsi@protonmail.com>
+Date: Sun, 19 Sep 2021 13:30:08 +0530
+Subject: [PATCH 2/4] arm64: dts: allwinner: h616: Add device node for SID
+
+The device tree binding for H616's SID controller.
+
+Signed-off-by: Kali Prasad <kprasadvnsi@protonmail.com>
+---
+ arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
+index 6a15ff2e7ebf..a53e53333cc4 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
+@@ -128,6 +128,21 @@ ccu: clock@3001000 {
+ 			#reset-cells = <1>;
+ 		};
+ 
++		sid: efuse@3006000 {
++			compatible = "allwinner,sun50i-h616-sid";
++			reg = <0x03006000 0x1000>;
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			cpu_speed_grade: cpu-speed-grade@00 {
++				reg = <0x00 0x02>;
++			};
++
++			ths_calibration: thermal-sensor-calibration@14 {
++				reg = <0x14 0x8>;
++			};
++		};
++
+ 		watchdog: watchdog@30090a0 {
+ 			compatible = "allwinner,sun50i-h616-wdt",
+ 				     "allwinner,sun6i-a31-wdt";
+-- 
+2.25.1
+

--- a/patch/kernel/archive/sunxi-5.14/h616_0026-thermal-drivers-sun8i-Add-thermal-driver-for-H616.patch
+++ b/patch/kernel/archive/sunxi-5.14/h616_0026-thermal-drivers-sun8i-Add-thermal-driver-for-H616.patch
@@ -1,0 +1,157 @@
+From d11a339f347d05e0bed6b2513f2a889230855ff0 Mon Sep 17 00:00:00 2001
+From: Kali Prasad <kprasadvnsi@protonmail.com>
+Date: Sun, 19 Sep 2021 13:32:27 +0530
+Subject: [PATCH 3/4] thermal/drivers/sun8i: Add thermal driver for H616
+
+Thermal driver for H616 SoC. Compared to H6, it has
+two additional temperature sensors for VE and DDR.
+
+Signed-off-by: Kali Prasad <kprasadvnsi@protonmail.com>
+---
+ drivers/thermal/sun8i_thermal.c | 102 ++++++++++++++++++++++++++++++++
+ 1 file changed, 102 insertions(+)
+
+diff --git a/drivers/thermal/sun8i_thermal.c b/drivers/thermal/sun8i_thermal.c
+index d9cd23cbb671..7bd661827143 100644
+--- a/drivers/thermal/sun8i_thermal.c
++++ b/drivers/thermal/sun8i_thermal.c
+@@ -108,6 +108,12 @@ static int sun50i_h5_calc_temp(struct ths_device *tmdev,
+ 		return -1590 * reg / 10 + 276000;
+ }
+ 
++static int sun50i_h616_calc_temp(struct ths_device *tmdev,
++			       int id, int reg)
++{
++	return (reg + tmdev->chip->offset) * tmdev->chip->scale;
++}
++
+ static int sun8i_ths_get_temp(void *data, int *temp)
+ {
+ 	struct tsensor *s = data;
+@@ -278,6 +284,64 @@ static int sun50i_h6_ths_calibrate(struct ths_device *tmdev,
+ 	return 0;
+ }
+ 
++static int sun50i_h616_ths_calibrate(struct ths_device *tmdev,
++				   u16 *caldata, int callen)
++{
++	struct device *dev = tmdev->dev;
++	int i, ft_temp;
++
++	if (!caldata[0])
++		return -EINVAL;
++
++	/*
++	 * h616 efuse THS calibration data layout:
++	 *
++	 * 0      11  16     27   32     43   48    57
++	 * +----------+-----------+-----------+-----------+
++	 * |  temp |  |sensor0|   |sensor1|   |sensor2|   |
++	 * +----------+-----------+-----------+-----------+
++	 *                      ^           ^           ^
++	 *                      |           |           |
++	 *                      |           |           sensor3[11:8]
++	 *                      |           sensor3[7:4]
++	 *                      sensor3[3:0]
++	 *
++	 * The calibration data on the H616 is the ambient temperature and
++	 * sensor values that are filled during the factory test stage.
++	 *
++	 * The unit of stored FT temperature is 0.1 degreee celusis.
++	 */
++	ft_temp = caldata[0] & FT_TEMP_MASK;
++
++	for (i = 0; i < tmdev->chip->sensor_num; i++) {
++		int delta, cdata, offset, reg;
++
++		if (i == 3)
++			reg = (caldata[1] >> 12)
++			      | (caldata[2] >> 12 << 4)
++			      | (caldata[3] >> 12 << 8);
++		else
++			reg = (int)caldata[i + 1] & TEMP_CALIB_MASK;
++
++		delta = (ft_temp * 100 - tmdev->chip->calc_temp(tmdev, i, reg))
++			/ tmdev->chip->scale;
++		cdata = CALIBRATE_DEFAULT - delta;
++		if (cdata & ~TEMP_CALIB_MASK) {
++			dev_warn(dev, "sensor%d is not calibrated.\n", i);
++
++			continue;
++		}
++		
++		offset = (i % 2) * 16;
++		regmap_update_bits(tmdev->regmap,
++				   SUN50I_H6_THS_TEMP_CALIB + (i / 2 * 4),
++				   0xfff << offset,
++				   cdata << offset);
++	}
++
++	return 0;
++}
++
+ static int sun8i_ths_calibrate(struct ths_device *tmdev)
+ {
+ 	struct nvmem_cell *calcell;
+@@ -460,6 +524,30 @@ static int sun50i_h6_thermal_init(struct ths_device *tmdev)
+ 	return 0;
+ }
+ 
++static int sun50i_h616_thermal_init(struct ths_device *tmdev)
++{
++	int val;
++
++	/*
++	 * For sun50iw9p1:
++	 * It is necessary that reg[0x03000000] bit[16] is 0.
++	 */
++	regmap_write(tmdev->regmap, SUN50I_THS_CTRL0,
++		     SUN8I_THS_CTRL0_T_ACQ0(47) | SUN8I_THS_CTRL2_T_ACQ1(479));
++	regmap_write(tmdev->regmap, SUN50I_H6_THS_MFC,
++		     SUN50I_THS_FILTER_EN |
++		     SUN50I_THS_FILTER_TYPE(1));
++	regmap_write(tmdev->regmap, SUN50I_H6_THS_PC,
++		     SUN50I_H6_THS_PC_TEMP_PERIOD(365));
++	val = GENMASK(tmdev->chip->sensor_num - 1, 0);
++	regmap_write(tmdev->regmap, SUN50I_H6_THS_ENABLE, val);
++	/* thermal data interrupt enable */
++	val = GENMASK(tmdev->chip->sensor_num - 1, 0);
++	regmap_write(tmdev->regmap, SUN50I_H6_THS_DIC, val);
++
++	return 0;
++}
++
+ static int sun8i_ths_register(struct ths_device *tmdev)
+ {
+ 	int i;
+@@ -628,6 +716,19 @@ static const struct ths_thermal_chip sun50i_h6_ths = {
+ 	.calc_temp = sun8i_ths_calc_temp,
+ };
+ 
++static const struct ths_thermal_chip sun50i_h616_ths = {
++	.sensor_num = 4,
++	.has_bus_clk_reset = true,
++	.ft_deviation = 8000,
++	.offset = -3255,
++	.scale = -81,
++	.temp_data_base = SUN50I_H6_THS_TEMP_DATA,
++	.calibrate = sun50i_h616_ths_calibrate,
++	.init = sun50i_h616_thermal_init,
++	.irq_ack = sun50i_h6_irq_ack,
++	.calc_temp = sun50i_h616_calc_temp,
++};
++
+ static const struct of_device_id of_ths_match[] = {
+ 	{ .compatible = "allwinner,sun8i-a83t-ths", .data = &sun8i_a83t_ths },
+ 	{ .compatible = "allwinner,sun8i-h3-ths", .data = &sun8i_h3_ths },
+@@ -636,6 +737,7 @@ static const struct of_device_id of_ths_match[] = {
+ 	{ .compatible = "allwinner,sun50i-a100-ths", .data = &sun50i_a100_ths },
+ 	{ .compatible = "allwinner,sun50i-h5-ths", .data = &sun50i_h5_ths },
+ 	{ .compatible = "allwinner,sun50i-h6-ths", .data = &sun50i_h6_ths },
++	{ .compatible = "allwinner,sun50i-h616-ths", .data = &sun50i_h616_ths },
+ 	{ /* sentinel */ },
+ };
+ MODULE_DEVICE_TABLE(of, of_ths_match);
+-- 
+2.25.1
+

--- a/patch/kernel/archive/sunxi-5.14/h616_0027-arm64-dts-allwinner-h616-Add-thermal-sensor-and.patch
+++ b/patch/kernel/archive/sunxi-5.14/h616_0027-arm64-dts-allwinner-h616-Add-thermal-sensor-and.patch
@@ -1,0 +1,135 @@
+From 6b0b525cb763df7694f84dcb91b7add3095d20b3 Mon Sep 17 00:00:00 2001
+From: Kali Prasad <kprasadvnsi@protonmail.com>
+Date: Sun, 19 Sep 2021 13:38:20 +0530
+Subject: [PATCH 4/4] arm64: dts: allwinner: h616: Add thermal sensor and
+ thermal zones
+
+There are four sensors, CPU, GPU, VE, and DDR.
+
+Signed-off-by: Kali Prasad <kprasadvnsi@protonmail.com>
+---
+ .../arm64/boot/dts/allwinner/sun50i-h616.dtsi | 74 +++++++++++++++++++
+ 1 file changed, 74 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
+index a53e53333cc4..ed0c7429aef9 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
+@@ -8,6 +8,7 @@
+ #include <dt-bindings/clock/sun50i-h6-r-ccu.h>
+ #include <dt-bindings/reset/sun50i-h616-ccu.h>
+ #include <dt-bindings/reset/sun50i-h6-r-ccu.h>
++#include <dt-bindings/thermal/thermal.h>
+ 
+ / {
+ 	interrupt-parent = <&gic>;
+@@ -24,6 +25,8 @@ cpu0: cpu@0 {
+ 			reg = <0>;
+ 			enable-method = "psci";
+ 			clocks = <&ccu CLK_CPUX>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++			#cooling-cells = <2>;
+ 		};
+ 
+ 		cpu1: cpu@1 {
+@@ -32,6 +35,8 @@ cpu1: cpu@1 {
+ 			reg = <1>;
+ 			enable-method = "psci";
+ 			clocks = <&ccu CLK_CPUX>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++			#cooling-cells = <2>;
+ 		};
+ 
+ 		cpu2: cpu@2 {
+@@ -40,6 +45,8 @@ cpu2: cpu@2 {
+ 			reg = <2>;
+ 			enable-method = "psci";
+ 			clocks = <&ccu CLK_CPUX>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++			#cooling-cells = <2>;
+ 		};
+ 
+ 		cpu3: cpu@3 {
+@@ -48,6 +55,8 @@ cpu3: cpu@3 {
+ 			reg = <3>;
+ 			enable-method = "psci";
+ 			clocks = <&ccu CLK_CPUX>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++			#cooling-cells = <2>;
+ 		};
+ 	};
+ 
+@@ -586,5 +595,70 @@ r_rsb: rsb@7083000 {
+ 			#address-cells = <1>;
+ 			#size-cells = <0>;
+ 		};
++
++		ths: thermal-sensor@5070400 {
++			compatible = "allwinner,sun50i-h616-ths";
++			reg = <0x05070400 0x400>;
++			interrupts = <GIC_SPI 19 IRQ_TYPE_LEVEL_HIGH>;
++			clocks = <&ccu CLK_BUS_THS>;
++			clock-names = "bus";
++			resets = <&ccu RST_BUS_THS>;
++			nvmem-cells = <&ths_calibration>;
++			nvmem-cell-names = "calibration";
++			#thermal-sensor-cells = <1>;
++		};
++	};
++	thermal-zones {
++		cpu-thermal {
++			polling-delay-passive = <500>;
++			polling-delay = <1000>;
++			thermal-sensors = <&ths 2>;
++			sustainable-power = <1000>;
++			k_po = <20>;
++			k_pu = <40>;
++			k_i = <0>;
++
++			trips {
++				cpu_threshold: trip-point@0 {
++					temperature = <60000>;
++					type = "passive";
++					hysteresis = <0>;
++				};
++				cpu_target: trip-point@1 {
++					temperature = <70000>;
++					type = "passive";
++					hysteresis = <0>;
++				};
++			};
++
++			cooling-maps {
++				map0 {
++					trip = <&cpu_target>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++		};
++
++		gpu-thermal {
++			polling-delay-passive = <500>;
++			polling-delay = <1000>;
++			thermal-sensors = <&ths 0>;
++			sustainable-power = <1100>;
++		};
++
++		ve-thermal {
++			polling-delay-passive = <0>;
++			polling-delay = <0>;
++			thermal-sensors = <&ths 1>;
++		};
++
++		ddr-thermal {
++			polling-delay-passive = <0>;
++			polling-delay = <0>;
++			thermal-sensors = <&ths 3>;
++		};
+ 	};
+ };
+-- 
+2.25.1
+

--- a/patch/u-boot/u-boot-sunxi/add-h616-THS-workaround.patch
+++ b/patch/u-boot/u-boot-sunxi/add-h616-THS-workaround.patch
@@ -1,0 +1,33 @@
+From 07bdfe1e2ebc51a434dbe66733378a979530abb0 Mon Sep 17 00:00:00 2001
+From: Kali Prasad <kprasadvnsi@protonmail.com>
+Date: Sat, 18 Sep 2021 22:57:05 +0530
+Subject: [PATCH] Adding h616 THS workaround.
+
+Signed-off-by: Kali Prasad <kprasadvnsi@protonmail.com>
+---
+ board/sunxi/board.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/board/sunxi/board.c b/board/sunxi/board.c
+index 1a46100e40..9f0c6d99ba 100644
+--- a/board/sunxi/board.c
++++ b/board/sunxi/board.c
+@@ -293,6 +293,15 @@ int board_init(void)
+ 		}
+ 	}
+ 
++#if CONFIG_MACH_SUN50I_H616
++	/*
++	 * The bit[16] of register reg[0x03000000] must be zero for the THS
++	 * driver to work properly in the kernel. The BSP u-boot is putting
++	 * the whole register to zero so we are doing the same.
++	 */
++	writel(0x0, SUNXI_SRAMC_BASE);
++#endif
++
+ #if CONFIG_IS_ENABLED(DM_I2C)
+ 	/*
+ 	 * Temporary workaround for enabling I2C clocks until proper sunxi DM
+-- 
+2.25.1
+


### PR DESCRIPTION
Signed-off-by: Kali Prasad <kprasadvnsi@protonmail.com>

# Description

Thermal sensor support for H616 SoC. it requires SID support so it's been added as well.
The bit[16] of register reg[0x03000000] must be zero for the THS driver to work properly
in the kernel. The BSP u-boot is putting the whole register to zero so we are doing the same.

# How Has This Been Tested?

It's been tested on an OrangePi Zero2 board.
