### PR TITLE
Change bootscripts/boot-meson64.cmd memory addresses for loading on boards with 512Mb

### DIFF
--- a/config/bootscripts/boot-meson64.cmd
+++ b/config/bootscripts/boot-meson64.cmd
@@ -3,9 +3,10 @@
 # Please edit /boot/armbianEnv.txt to set supported parameters
 #
 
-setenv load_addr "0x32000000"
-setenv kernel_addr_r "0x34000000"
-setenv fdt_addr_r "0x4080000"
+setenv fdt_addr_r "0x10000000"
+setenv load_addr  "0x10100000"
+setenv kernel_addr_r "0x11000000"
+setenv ramdisk_addr_r "0x19000000"
 setenv overlay_error "false"
 # default values
 setenv rootdev "/dev/mmcblk1p1"


### PR DESCRIPTION
# Description

Hi. I propose to change memory addr values in boot-meson64.cmd to lower.

New values:

fdt_addr_r "0x10000000" # 256Mb for fdt table, size 1Mb
load_addr  "0x10100000"  # 256Mb + 1Mb for fdt overlays, size 16Mb
kernel_addr_r "0x11000000" # 256Mb + 16Mb for linux kernel, size 128Mb
ramdisk_addr_r "0x19000000" # 256Mb + 16Mb + 128Mb for initrd, size 112Mb (on 512Mb boards)

These memory areas fully fit everything needed and will not overlap with each other in the coming years ( average sizes: kernels up to 30 MB, initrd up to 20 MB, dtb up to 100kbytes)


# How Has This Been Tested?

Tested on gxl, axg 1Gb RAM boards. Needs test on other.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
