### PR TITLE
Extending free memory detection to swap

### DIFF
--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -36,10 +36,9 @@ debootstrap_ng()
 	mkdir -p $SDCARD $MOUNT $DEST/images $SRC/cache/rootfs
 
 	# stage: verify tmpfs configuration and mount
-	# default maximum size for tmpfs mount is 1/2 of available RAM
-	# CLI needs ~1.2GiB+ (Xenial CLI), Desktop - ~2.8GiB+ (Xenial Desktop w/o HW acceleration)
-	# calculate and set tmpfs mount to use 2/3 of available RAM
-	local phymem=$(( $(awk '/MemTotal/ {print $2}' /proc/meminfo) / 1024 * 2 / 3 )) # MiB
+	# CLI needs ~1.5GiB, desktop - ~3.5GiB
+	# calculate and set tmpfs mount to use 2/3 of available RAM+SWAP
+	local phymem=$(( (($(awk '/MemTotal/ {print $2}' /proc/meminfo) + $(awk '/SwapTotal/ {print $2}' /proc/meminfo))) / 1024 * 2 / 3 )) # MiB
 	if [[ $BUILD_DESKTOP == yes ]]; then local tmpfs_max_size=3500; else local tmpfs_max_size=1500; fi # MiB
 	if [[ $FORCE_USE_RAMDISK == no ]]; then	local use_tmpfs=no
 	elif [[ $FORCE_USE_RAMDISK == yes || $phymem -gt $tmpfs_max_size ]]; then


### PR DESCRIPTION
# Description

Host machines with 4Gb physical memory are unable to build all images. During workiin on CI improvements it was noticed that runners with just 4Gb of memory are unable to create rootfs cache or make an images even that should be sufficient. Memory reservations are set very conservatively and we can keep that since adding a swap into the equation proves to be enough. If host machine is running Armbian (which will be in most cases) our ZRAM / ZSWAP memory management takes care of securing that extra needed memory.

Jira reference number [AR-937]

# How Has This Been Tested?

- [x] Build cache on Nanopi M4
- [x] Build image on x86 VM with 4G memory and 2G of swap

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-937]: https://armbian.atlassian.net/browse/AR-937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ