### PR TITLE
Add support for rtl8822cs (hci_ver 0x8) bluetooth

### DIFF
--- a/lib/compilation-prepare.sh
+++ b/lib/compilation-prepare.sh
@@ -583,6 +583,17 @@ compilation_prepare()
 	fi
 
 
+	# Bluetooth support for Realtek 8822CS (hci_ver 0x8) chipsets
+
+	if linux-version compare "${version}" ge 5.11; then
+
+		display_alert "Adding" "Bluetooth support for Realtek 8822CS (hci_ver 0x8) chipsets" "info"
+
+		process_patch_file "${SRC}/patch/misc/bluetooth-rtl8822cs-hci_ver-0x8.patch" "applying"
+
+	fi
+
+
 	# Wireless drivers for Realtek 8723DS chipsets
 
 	if linux-version compare "${version}" ge 5.0 && [ "$EXTRAWIFI" == yes ]; then

--- a/patch/misc/bluetooth-rtl8822cs-hci_ver-0x8.patch
+++ b/patch/misc/bluetooth-rtl8822cs-hci_ver-0x8.patch
@@ -1,0 +1,31 @@
+From 727591f7c8180364ad3fad9b52d12688c7c629e3 Mon Sep 17 00:00:00 2001
+From: chbgdn <chbgdn@gmail.com>
+Date: Fri, 15 Oct 2021 23:08:52 +0300
+Subject: [PATCH] Bluetooth: btrtl: Add support for RTL8822C (hci ver 0008)
+
+Signed-off-by: chbgdn <chbgdn@gmail.com>
+---
+ drivers/bluetooth/btrtl.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/drivers/bluetooth/btrtl.c b/drivers/bluetooth/btrtl.c
+index 1f8afa0244d8..60c4a9976d5a 100644
+--- a/drivers/bluetooth/btrtl.c
++++ b/drivers/bluetooth/btrtl.c
+@@ -152,6 +152,13 @@ static const struct id_table ic_id_table[] = {
+ 	  .fw_name  = "rtl_bt/rtl8822cs_fw.bin",
+ 	  .cfg_name = "rtl_bt/rtl8822cs_config" },
+ 
++	/* 8822C with UART interface */
++	{ IC_INFO(RTL_ROM_LMP_8822B, 0xc, 0x8, HCI_UART),
++	  .config_needed = true,
++	  .has_rom_version = true,
++	  .fw_name  = "rtl_bt/rtl8822cs_fw.bin",
++	  .cfg_name = "rtl_bt/rtl8822cs_config" },
++
+ 	/* 8822C with USB interface */
+ 	{ IC_INFO(RTL_ROM_LMP_8822B, 0xc, 0xa, HCI_USB),
+ 	  .config_needed = false,
+-- 
+2.33.0
+


### PR DESCRIPTION
# Description

This patch add support for rtl8822cs bluetooth. Mainline kernel has support for this chipset, but in Amlogic TV-Box (and maybe in other devices) chipset reports hci_ver 0x8, but in mainline only hci_ver 0xa listed as supported.

> Bluetooth: hci0: RTL: examining hci_ver=08 hci_rev=000c lmp_ver=08 lmp_subver=8822
Bluetooth: hci0: RTL: unknown IC info, lmp subver 8822, hci rev 000c, hci ver 0008
Bluetooth: hci0: RTL: no config loaded

By adding same chipset info with changed hci_ver to realtek bluetooth driver and using proper rtl8822cs_config and rtl8822cs_fw (https://github.com/armbian/firmware/pull/27), driver will be able to initialize device and bluetooth will work.

> [    4.818304] Bluetooth: hci0: RTL: examining hci_ver=08 hci_rev=000c lmp_ver=08 lmp_subver=8822
[    4.821931] Bluetooth: hci0: RTL: rom_version status=0 version=3
[    4.821955] Bluetooth: hci0: RTL: loading rtl_bt/rtl8822cs_fw.bin
[    4.826380] Bluetooth: hci0: RTL: loading rtl_bt/rtl8822cs_config.bin
[    4.847922] Bluetooth: hci0: RTL: cfg_sz 73, total sz 40777
root@Amlogic:~# hciconfig -a
hci0:   Type: Primary  Bus: UART
        BD Address: XX:XX:XX:XX:XX:XX  ACL MTU: 1021:5  SCO MTU: 255:11
        UP RUNNING 
        RX bytes:225719 acl:0 sco:0 events:5816 errors:0
        TX bytes:88722 acl:0 sco:0 commands:978 errors:0

RTL8822CS device-tree node example
```
&uart_A {
	status = "okay";

	pinctrl-0 = <&uart_a_pins>, <&uart_a_cts_rts_pins>;
	pinctrl-names = "default";
	uart-has-rtscts;

	bluetooth {
		compatible = "realtek,rtl8822cs-bt";
                enable-gpios = <&gpio GPIOX_17 GPIO_ACTIVE_HIGH>;
                host-wake-gpios = <&gpio GPIOX_19 GPIO_ACTIVE_HIGH>;
	};
};
```
Or adding with overlay
```
/dts-v1/;
/plugin/;

/ {
    compatible = "amlogic,sm1";
    fragment@0 {
        target-path = "/soc/bus@ffd00000/serial@24000";
        __overlay__ {
            status = "okay";

            pinctrl-0 = <&uart_a_pins>, <&uart_a_cts_rts_pins>;
            pinctrl-names = "default";
            uart-has-rtscts;

            bluetooth {
                compatible = "realtek,rtl8822cs-bt";
                enable-gpios = <&gpio 82 0>;
                host-wake-gpios = <&gpio 84 0>;
            };
        };
    };
};
```

I think this patch shouldn't break anything, so I add it to misc, not meson64-edge patch-set.
Maybe on some boards this chipset report same hci_ver and patch will be useful for other boards.

# How Has This Been Tested?

Tested on X96 Max+ (meson-sm1) with rtl8822cs chipset

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
