### PR TITLE
Improve Docker support on github action

### DIFF
--- a/config/templates/config-docker.conf
+++ b/config/templates/config-docker.conf
@@ -106,10 +106,10 @@ If you prefer to use profile, for example, `userpatches/config-my.conf`,  try:
     ./compile.sh my compile_uboot
 
 EOF
-  docker run "${DOCKER_FLAGS[@]}" -it --rm --entrypoint /usr/bin/env armbian:$VERSION "$@" /bin/bash
+  docker run "${DOCKER_FLAGS[@]}" -i --rm --entrypoint /usr/bin/env armbian:$VERSION "$@" /bin/bash
 else
   display_alert "Running the container" "" "info"
-  docker run "${DOCKER_FLAGS[@]}" -it --rm armbian:$VERSION "$@"
+  docker run "${DOCKER_FLAGS[@]}" -i --rm armbian:$VERSION "$@"
 fi
 
 # Docker error treatment


### PR DESCRIPTION
Fixing broken Docker run in github action when running compile.sh

![before](https://user-images.githubusercontent.com/52564540/137784766-3b39f7ba-bf74-4c27-ba40-6139ac3692d0.png)

