### PR TITLE
Add gpio power reset for hci_h5 controllers in h5_btrtl_open

### DIFF
--- a/lib/compilation-prepare.sh
+++ b/lib/compilation-prepare.sh
@@ -590,6 +590,7 @@ compilation_prepare()
 		display_alert "Adding" "Bluetooth support for Realtek 8822CS (hci_ver 0x8) chipsets" "info"
 
 		process_patch_file "${SRC}/patch/misc/bluetooth-rtl8822cs-hci_ver-0x8.patch" "applying"
+		process_patch_file "${SRC}/patch/misc/Bluetooth-hci_h5-Add-power-reset-via-gpio-in-h5_btrt.patch" "applying"
 
 	fi
 

--- a/patch/misc/Bluetooth-hci_h5-Add-power-reset-via-gpio-in-h5_btrt.patch
+++ b/patch/misc/Bluetooth-hci_h5-Add-power-reset-via-gpio-in-h5_btrt.patch
@@ -1,0 +1,32 @@
+From 9acbe79e6e546c216dff1bc9b45d7262c5952b6c Mon Sep 17 00:00:00 2001
+From: Vyacheslav Bocharov <adeep@lexina.in>
+Date: Tue, 19 Oct 2021 12:46:06 +0300
+Subject: [PATCH 2/2] Bluetooth: hci_h5: Add power reset via gpio in
+ h5_btrtl_open
+
+Add power reset via enable-gpios in h5_btrtl_open function.
+
+Signed-off-by: Vyacheslav Bocharov <adeep@lexina.in>
+---
+ drivers/bluetooth/hci_h5.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/drivers/bluetooth/hci_h5.c b/drivers/bluetooth/hci_h5.c
+index 0c0dedece59c..ab7c929cc25d 100644
+--- a/drivers/bluetooth/hci_h5.c
++++ b/drivers/bluetooth/hci_h5.c
+@@ -968,6 +968,11 @@ static void h5_btrtl_open(struct h5 *h5)
+ 					 SUSPEND_TIMEOUT_MS);
+ 	pm_runtime_enable(&h5->hu->serdev->dev);
+ 
++	/* The controller needs reset to startup */
++	gpiod_set_value_cansleep(h5->enable_gpio, 0);
++	gpiod_set_value_cansleep(h5->device_wake_gpio, 0);
++	msleep(100);
++
+ 	/* The controller needs up to 500ms to wakeup */
+ 	gpiod_set_value_cansleep(h5->enable_gpio, 1);
+ 	gpiod_set_value_cansleep(h5->device_wake_gpio, 1);
+-- 
+2.30.2
+


### PR DESCRIPTION
# Description

This extends support for https://github.com/armbian/build/pull/3201 
The new patch adds a power reset for the Bluetooth controller via the gpio line specified in dts. Without resetting, the controller does not always start when the board is powered on.

The patch only corrects the code for the realtek rtl8822cs-bt, rtl8723bs-bt chips.

# How Has This Been Tested?

Works on JetHub H1 rtl882cs with hci_ver 0x08. 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
