### PR TITLE
JetHome: Fix compiler for bsp package

### DIFF
--- a/config/sources/families/jethub.conf
+++ b/config/sources/families/jethub.conf
@@ -95,20 +95,18 @@ comment_default_rsyslog_rules() {
 
 buildjethomecmds () {
 	local toolchain
-	JETHOME_USE_GCC="> 9.0"
-	JETHOME_COMPILER="aarch64-none-linux-gnu-"
 	# build aarch64 in amd64
 	if [[ $(dpkg --print-architecture) == amd64 ]]; then
 
-		toolchain=$(find_toolchain "$JETHOME_COMPILER" "$JETHOME_USE_GCC")
-		[[ -z $toolchain ]] && exit_with_error "Could not find required toolchain" "${JETHOME_COMPILER}gcc $JETHOME_USE_GCC"
+		toolchain=$(find_toolchain "$UBOOT_COMPILER" "$UBOOT_USE_GCC")
+		[[ -z $toolchain ]] && exit_with_error "Could not find required toolchain" "${UBOOT_COMPILER}gcc $UBOOT_USE_GCC"
 	fi
 
-	display_alert "Compiler version" "${JETHOME_COMPILER}gcc $(eval env PATH="${toolchain}:${PATH}" "${JETHOME_COMPILER}gcc" -dumpversion)" "info"
+	display_alert "Compiler version" "${UBOOT_COMPILER}gcc $(eval env PATH="${toolchain}:${PATH}" "${UBOOT_COMPILER}gcc" -dumpversion)" "info"
 
-	local gpp="${JETHOME_COMPILER}g++"
+	local gpp="${UBOOT_COMPILER}g++"
 	local gpp_options="-Os -s -Wall -Wextra -std=c++17 -I$SRC/packages/bsp/jethub"
-	local gcc="${JETHOME_COMPILER}gcc"
+	local gcc="${UBOOT_COMPILER}gcc"
 
 	env PATH="${toolchain}:${PATH}" "$gpp" $gpp_options "$SRC/packages/bsp/jethub/jethub_get_cmdline_key.cpp" -o "$destination/usr/bin/jethub_get_cmdline_key" || exit_with_error "Unable to compile jethub_get_cmdline_key.cpp"
 	env PATH="${toolchain}:${PATH}" "$gpp" $gpp_options "$SRC/packages/bsp/jethub/jethub_get_cmdline_key_cpuid.cpp" -o "$destination/usr/bin/jethub_get_cpuid" || exit_with_error "Unable to compile jethub_get_cmdline_key_cpuid.cpp"


### PR DESCRIPTION
# Description


Change compiler version in jethub bsp packages to $UBOOT_COMPILER/$UBOOT_USE_GCC. Changed only code for jethub devices.

# How Has This Been Tested?

Builds ok.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
