### PR TITLE
rk3328: add rga node, fix probe function

### DIFF
--- a/patch/kernel/archive/rockchip64-5.14/general-fix-rga-probe.patch
+++ b/patch/kernel/archive/rockchip64-5.14/general-fix-rga-probe.patch
@@ -1,0 +1,13 @@
+diff --git a/drivers/media/platform/rockchip/rga/rga.c b/drivers/media/platform/rockchip/rga/rga.c
+index 6759091b1..d99ea8973 100644
+--- a/drivers/media/platform/rockchip/rga/rga.c
++++ b/drivers/media/platform/rockchip/rga/rga.c
+@@ -895,7 +895,7 @@ static int rga_probe(struct platform_device *pdev)
+ 	}
+ 	rga->dst_mmu_pages =
+ 		(unsigned int *)__get_free_pages(GFP_KERNEL | __GFP_ZERO, 3);
+-	if (rga->dst_mmu_pages) {
++	if (!rga->dst_mmu_pages) {
+ 		ret = -ENOMEM;
+ 		goto free_src_pages;
+ 	}

--- a/patch/kernel/archive/rockchip64-5.14/rk3328-add-rga-node.patch
+++ b/patch/kernel/archive/rockchip64-5.14/rk3328-add-rga-node.patch
@@ -1,0 +1,37 @@
+From c37d1b1a4ec6f517ba8a8b70d035979c0a9d4966 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Thu, 21 Oct 2021 18:04:17 +0000
+Subject: [PATCH] rk3328: add RGA node
+
+---
+ arch/arm64/boot/dts/rockchip/rk3328.dtsi | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3328.dtsi b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
+index 162e57936..ecff11781 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3328.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
+@@ -829,6 +829,20 @@ vop_mmu: iommu@ff373f00 {
+ 		status = "disabled";
+ 	};
+ 
++	rga: rga@ff390000 {
++		compatible = "rockchip,rk3328-rga", "rockchip,rk3399-rga";
++		reg = <0x0 0xff390000 0x0 0x1000>;
++		interrupts = <GIC_SPI 33 IRQ_TYPE_LEVEL_HIGH>;
++		clocks = <&cru ACLK_RGA>,
++			<&cru HCLK_RGA>,
++			<&cru SCLK_RGA>;
++		clock-names = "aclk", "hclk", "sclk";
++		resets = <&cru SRST_RGA>,
++			<&cru SRST_RGA_A>,
++			<&cru SRST_RGA_H>;
++		reset-names = "core", "axi", "ahb";
++	};
++
+ 	iep: iep@ff3a0000 {
+ 		compatible = "rockchip,rk3328-iep", "rockchip,rk3228-iep";
+ 		reg = <0x0 0xff3a0000 0x0 0x800>;
+-- 
+2.30.2
+


### PR DESCRIPTION
# Description

Add missing node in kernel rk3328 device tree include to enable RGA in kernel 5.14.
Also applies a patch that fix the broken initialization in upstream kernel.

# How Has This Been Tested?

Deb kernel and dtb packages have been produced by armbian build scripts and then installed on a live machine. After installing, RGA is probed correctly and v4l device is spawned:

```
[   10.839055] rockchip-rga ff390000.rga: HW Version: 0x04.00
[   10.841009] rockchip-rga ff390000.rga: Registered rockchip-rga as /dev/video0
```

Real functionality has not been yet tested due to lack of suppliers and consumers.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
