### PR TITLE
add impish to decisions about qemu-x86_64-static

### DIFF
--- a/config/sources/families/include/meson64_common.inc
+++ b/config/sources/families/include/meson64_common.inc
@@ -41,7 +41,7 @@ case $BRANCH in
 esac
 
 if [ "$(uname -m)" = "aarch64" ]; then
-	if [[ "$(lsb_release -sc)" == "focal" || "$(lsb_release -sc)" == "hirsute" ]]; then
+	if [[ "$(lsb_release -sc)" == "focal" || "$(lsb_release -sc)" == "hirsute" || "$(lsb_release -sc)" == "impish" ]]; then
 		PKG_PREFIX="qemu-x86_64-static -L /usr/x86_64-linux-gnu "
 	else
 		PKG_PREFIX="qemu-x86_64 "

--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -14,7 +14,7 @@ PACKAGE_LIST_FAMILY="ethtool"
 RKBIN_DIR="$SRC/cache/sources/rkbin-tools"
 if [ "$(uname -m)" = "aarch64" ]; then
 	case "$(lsb_release -sc)" in
-	"focal"|"hirsute")
+	"focal"|"hirsute"|"impish")
 			PKG_PREFIX="qemu-x86_64-static -L /usr/x86_64-linux-gnu "
 		;;
 	*)


### PR DESCRIPTION
### add impish to decisions about qemu-x86_64-static
- Just like focal and hirsute, qemu-x86_64-static

Signed-off-by: Ricardo Pardini <ricardo@pardini.net>

With this and #3222 it should be possible to build on Impish host.