### PR TITLE
JetHub: dont break build due to rsyslog stuff (Debian...)

### DIFF
--- a/config/sources/families/jethub.conf
+++ b/config/sources/families/jethub.conf
@@ -71,21 +71,26 @@ write_uboot_platform() {
 comment_default_rsyslog_rules() {
 	local conf_file="$SDCARD/etc/rsyslog.d/50-default.conf"
 
+	if [[ ! -f "${conf_file}" ]]; then
+		display_alert "Can't find rsyslog default config at ${conf_file}" "${RELEASE}" "wrn"
+		return 2
+	fi
+
 	local rule_file_arr=(/var/log/syslog /var/log/auth.log /var/log/kern.log /var/log/mail.log /var/log/mail.err)
 
 	rule_file_escaped_arr=("${rule_file_arr[@]}")
-	for ((i = 0;i < ${#rule_file_escaped_arr[*]}; i++)); do
-		rule_file_escaped_arr[$i]="${rule_file_arr[$i]//\//\\/}";
+	for ((i = 0; i < ${#rule_file_escaped_arr[*]}; i++)); do
+		rule_file_escaped_arr[$i]="${rule_file_arr[$i]//\//\\/}"
 	done
 
-	for ((i = 0;i < ${#rule_file_escaped_arr[*]}; i++)); do
+	for ((i = 0; i < ${#rule_file_escaped_arr[*]}; i++)); do
 		rule_file_escaped="${rule_file_escaped_arr[$i]}"
 		regexp="^[^#][^ \t]+[ \t]+.?${rule_file_escaped}.*$"
 		if grep -Pq "$regexp" "$conf_file"; then
-			sed -i -E -e "s/$regexp/#\0/g" "$conf_file" || { 
+			sed -i -E -e "s/$regexp/#\0/g" "$conf_file" || {
 				echo "sed 's/$regexp/#\0/g' $conf_file failed"
-                                return 1 
-                        }
+				return 1
+			}
 		else
 			echo "grep '$regexp' $conf_file failed"
 			return 2
@@ -93,7 +98,7 @@ comment_default_rsyslog_rules() {
 	done
 }
 
-buildjethomecmds () {
+buildjethomecmds() {
 	local toolchain
 	# build aarch64 in amd64
 	if [[ $(dpkg --print-architecture) == amd64 ]]; then
@@ -114,7 +119,7 @@ buildjethomecmds () {
 	if [[ $BOARD == jethubj80 ]]; then
 		# Bluetooth
 		install -m 755 "$SRC/packages/blobs/bt/hciattach/rtk_hciattach_$ARCH" "$destination/usr/bin/rtk_hciattach" || exit_with_error "Unable to install rtk_hciattach"
-		
+
 		cp "$SRC/packages/bsp/jethub/$BOARD/bluetooth/jethub-rtk-hciattach.service" "$destination/lib/systemd/system/" || exit_with_error "Unable to copy jethub-rtk-hciattach.service"
 
 		install -m 755 "$SRC/packages/bsp/jethub/$BOARD/bluetooth/jethub-rtk-hciattach-starter" "$destination/usr/lib/armbian/" || exit_with_error "Unable to install jethub-rtk-hciattach-starter"
@@ -141,7 +146,7 @@ buildjethomecmds () {
 
 family_tweaks() {
 	# Log rotation
-	comment_default_rsyslog_rules || exit_with_error "Unable to comment default rsyslog rules"
+	comment_default_rsyslog_rules || display_alert "Unable to comment default rsyslog rules" "${BOARD}" "wrn"
 
 	# Hardware init
 	chroot "${SDCARD}" /bin/bash -c "systemctl --no-reload enable jethub-initer.service >/dev/null 2>&1"


### PR DESCRIPTION
### JetHub: dont break build due to rsyslog stuff (Debian...)

- also, shellfmt. Sorry. (spacing/formatting)

Signed-off-by: Ricardo Pardini <ricardo@pardini.net>

This does not fix the problem, but WARNs about it and does not break the build.

I'll leave it to @adeepn to do an actual proper fix.
