### PR TITLE
avoid getting 'unknown' TERM via serial getty

### DIFF
--- a/lib/distributions.sh
+++ b/lib/distributions.sh
@@ -138,7 +138,7 @@ install_common()
 	[Service]
 	ExecStartPre=/bin/sh -c 'exec /bin/sleep 10'
 	ExecStart=
-	ExecStart=-/sbin/agetty --noissue --autologin root %I $TERM
+	ExecStart=-/sbin/agetty --noissue --autologin root %I \$TERM
 	Type=idle
 	EOF
 	cp "${SDCARD}"/etc/systemd/system/serial-getty@.service.d/override.conf "${SDCARD}"/etc/systemd/system/getty@.service.d/override.conf


### PR DESCRIPTION
### avoid getting 'unknown' TERM via serial getty

- Escape $TERM, this is meant to be resolved at runtime and not in armbian/build's context
- This was very hard to track down, if building manually $TERM is actually valid (builder's $TERM)
- When building without a tty this shows up as "unknown"

Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
