### PR TITLE
fix security repo for bullseye

### DIFF
--- a/lib/distributions.sh
+++ b/lib/distributions.sh
@@ -603,8 +603,6 @@ install_distribution_specific()
 			[[ $(grep -L "VERSION_ID=" "${SDCARD}"/etc/os-release) ]] && echo 'VERSION_ID="11"' >> "${SDCARD}"/etc/os-release
 			[[ $(grep -L "VERSION=" "${SDCARD}"/etc/os-release) ]] && echo 'VERSION="11 (bullseye)"' >> "${SDCARD}"/etc/os-release
 
-			# Bullseye changed the security repo layout, see https://www.debian.org/releases/bullseye/arm64/release-notes/ch-information.en.html#security-archive
-			sed -i "s/${RELEASE}\/updates/${RELEASE}-security/g" "${SDCARD}"/etc/apt/sources.list
 
 		;;
 	bionic|focal|hirsute|impish)

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -155,7 +155,7 @@ create_sources_list()
 	[[ -z $basedir ]] && exit_with_error "No basedir passed to create_sources_list"
 
 	case $release in
-	stretch|buster|bullseye|sid)
+	stretch|buster)
 	cat <<-EOF > "${basedir}"/etc/apt/sources.list
 	deb http://${DEBIAN_MIRROR} $release main contrib non-free
 	#deb-src http://${DEBIAN_MIRROR} $release main contrib non-free
@@ -168,6 +168,29 @@ create_sources_list()
 
 	deb http://${DEBIAN_SECURTY} ${release}/updates main contrib non-free
 	#deb-src http://${DEBIAN_SECURTY} ${release}/updates main contrib non-free
+	EOF
+	;;
+
+	bullseye|bookworm|trixie)
+	cat <<-EOF > "${basedir}"/etc/apt/sources.list
+	deb http://${DEBIAN_MIRROR} $release main contrib non-free
+	#deb-src http://${DEBIAN_MIRROR} $release main contrib non-free
+
+	deb http://${DEBIAN_MIRROR} ${release}-updates main contrib non-free
+	#deb-src http://${DEBIAN_MIRROR} ${release}-updates main contrib non-free
+
+	deb http://${DEBIAN_MIRROR} ${release}-backports main contrib non-free
+	#deb-src http://${DEBIAN_MIRROR} ${release}-backports main contrib non-free
+
+	deb http://${DEBIAN_SECURTY} ${release}-security main contrib non-free
+	#deb-src http://${DEBIAN_SECURTY} ${release}-security main contrib non-free
+	EOF
+	;;
+
+	sid) # sid is permanent unstable development and has no such thing as updates or security
+	cat <<-EOF > "${basedir}"/etc/apt/sources.list
+	deb http://${DEBIAN_MIRROR} $release main contrib non-free
+	#deb-src http://${DEBIAN_MIRROR} $release main contrib non-free
 	EOF
 	;;
 


### PR DESCRIPTION
### fix security repo for bullseye

- with bullseye, comes a security repo layout change
- see https://www.debian.org/releases/bullseye/arm64/release-notes/ch-information.en.html#security-archive

Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
