### PR TITLE
Fix error in args for call aml_encrypt_gxl: incorrect path for bl2.n.bin.sig

### DIFF
--- a/config/sources/families/include/meson64_common.inc
+++ b/config/sources/families/include/meson64_common.inc
@@ -244,7 +244,7 @@ uboot_gxl_postprocess_ng()
 			--output bl2.n.bin.sig
 
     $1/aml_encrypt_gxl --bootmk --output u-boot.bin \
-			--bl2 $1/bl2.n.bin.sig \
+			--bl2 bl2.n.bin.sig \
 			--bl30 $1/bl30_new.bin.enc \
 			--bl31 $1/bl31.img.enc \
 			--bl33 bl33.bin.enc


### PR DESCRIPTION
# Description

File  config/sources/families/include/meson64_common.inc function [uboot_gxl_postprocess_ng()](https://github.com/armbian/build/commit/d7027d692ec70b9956df7e053cd1de30b10f5ed2#diff-650c0041f713239d4daaecf332ef37a9ad2e4e7d8f03a5a3398e3e1d4c687cb3R243-R244).

call     ```
$1/aml_encrypt_gxl --bl2sig --input $1/bl2_new.bin \
			--output bl2.n.bin.sig
```
writes output in current path, but next call reads silently from `$1/bl2.n.bin.sig`

So fix read from correct path.


# How Has This Been Tested?

GXL has working uboot now.


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
