### PR TITLE
JetHub: add uboot.bin binary to uboot package for JetHub

### DIFF
--- a/config/sources/families/jethub.conf
+++ b/config/sources/families/jethub.conf
@@ -1,5 +1,6 @@
 source "${BASH_SOURCE%/*}/include/meson64_common.inc"
 
+UBOOT_TARGET_MAP="u-boot-dtb.img;;u-boot.bin.sd.bin:u-boot.bin u-boot.bin:u-boot.nosd.bin u-boot-dtb.img"
 CPUMIN=100000
 GOVERNOR=conservative
 BOOTBRANCH="tag:v2021.10"


### PR DESCRIPTION
# Description
Small fix. Add u-boot.bin (without sd header) for image postprocess.

# How Has This Been Tested?

Builds ok. Changes only in jethub sources.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
