### PR TITLE
Change the driver name to sun4i_drm, fixed launch Xorg

### DIFF
--- a/patch/kernel/archive/sunxi-5.10/0001-drm-sun4i-change-the-driver-name-to-sun4i_drm.patch
+++ b/patch/kernel/archive/sunxi-5.10/0001-drm-sun4i-change-the-driver-name-to-sun4i_drm.patch
@@ -1,0 +1,13 @@
+diff --git a/drivers/gpu/drm/sun4i/sun4i_drv.c b/drivers/gpu/drm/sun4i/sun4i_drv.c
+index 29861fc81..858a24020 100644
+--- a/drivers/gpu/drm/sun4i/sun4i_drv.c
++++ b/drivers/gpu/drm/sun4i/sun4i_drv.c
+@@ -45,7 +45,7 @@ static struct drm_driver sun4i_drv_driver = {
+ 
+ 	/* Generic Operations */
+ 	.fops			= &sun4i_drv_fops,
+-	.name			= "sun4i-drm",
++	.name			= "sun4i_drm",
+ 	.desc			= "Allwinner sun4i Display Engine",
+ 	.date			= "20150629",
+ 	.major			= 1,

--- a/patch/kernel/archive/sunxi-5.11/0001-drm-sun4i-change-the-driver-name-to-sun4i_drm.patch
+++ b/patch/kernel/archive/sunxi-5.11/0001-drm-sun4i-change-the-driver-name-to-sun4i_drm.patch
@@ -1,0 +1,13 @@
+diff --git a/drivers/gpu/drm/sun4i/sun4i_drv.c b/drivers/gpu/drm/sun4i/sun4i_drv.c
+index 29861fc81..858a24020 100644
+--- a/drivers/gpu/drm/sun4i/sun4i_drv.c
++++ b/drivers/gpu/drm/sun4i/sun4i_drv.c
+@@ -45,7 +45,7 @@ static struct drm_driver sun4i_drv_driver = {
+ 
+ 	/* Generic Operations */
+ 	.fops			= &sun4i_drv_fops,
+-	.name			= "sun4i-drm",
++	.name			= "sun4i_drm",
+ 	.desc			= "Allwinner sun4i Display Engine",
+ 	.date			= "20150629",
+ 	.major			= 1,

--- a/patch/kernel/archive/sunxi-5.12/0001-drm-sun4i-change-the-driver-name-to-sun4i_drm.patch
+++ b/patch/kernel/archive/sunxi-5.12/0001-drm-sun4i-change-the-driver-name-to-sun4i_drm.patch
@@ -1,0 +1,13 @@
+diff --git a/drivers/gpu/drm/sun4i/sun4i_drv.c b/drivers/gpu/drm/sun4i/sun4i_drv.c
+index 29861fc81..858a24020 100644
+--- a/drivers/gpu/drm/sun4i/sun4i_drv.c
++++ b/drivers/gpu/drm/sun4i/sun4i_drv.c
+@@ -45,7 +45,7 @@ static struct drm_driver sun4i_drv_driver = {
+ 
+ 	/* Generic Operations */
+ 	.fops			= &sun4i_drv_fops,
+-	.name			= "sun4i-drm",
++	.name			= "sun4i_drm",
+ 	.desc			= "Allwinner sun4i Display Engine",
+ 	.date			= "20150629",
+ 	.major			= 1,

--- a/patch/kernel/archive/sunxi-5.13/0001-drm-sun4i-change-the-driver-name-to-sun4i_drm.patch
+++ b/patch/kernel/archive/sunxi-5.13/0001-drm-sun4i-change-the-driver-name-to-sun4i_drm.patch
@@ -1,0 +1,13 @@
+diff --git a/drivers/gpu/drm/sun4i/sun4i_drv.c b/drivers/gpu/drm/sun4i/sun4i_drv.c
+index 29861fc81..858a24020 100644
+--- a/drivers/gpu/drm/sun4i/sun4i_drv.c
++++ b/drivers/gpu/drm/sun4i/sun4i_drv.c
+@@ -45,7 +45,7 @@ static struct drm_driver sun4i_drv_driver = {
+ 
+ 	/* Generic Operations */
+ 	.fops			= &sun4i_drv_fops,
+-	.name			= "sun4i-drm",
++	.name			= "sun4i_drm",
+ 	.desc			= "Allwinner sun4i Display Engine",
+ 	.date			= "20150629",
+ 	.major			= 1,

--- a/patch/kernel/archive/sunxi-5.14/0001-drm-sun4i-change-the-driver-name-to-sun4i_drm.patch
+++ b/patch/kernel/archive/sunxi-5.14/0001-drm-sun4i-change-the-driver-name-to-sun4i_drm.patch
@@ -1,0 +1,13 @@
+diff --git a/drivers/gpu/drm/sun4i/sun4i_drv.c b/drivers/gpu/drm/sun4i/sun4i_drv.c
+index 29861fc81..858a24020 100644
+--- a/drivers/gpu/drm/sun4i/sun4i_drv.c
++++ b/drivers/gpu/drm/sun4i/sun4i_drv.c
+@@ -45,7 +45,7 @@ static struct drm_driver sun4i_drv_driver = {
+ 
+ 	/* Generic Operations */
+ 	.fops			= &sun4i_drv_fops,
+-	.name			= "sun4i-drm",
++	.name			= "sun4i_drm",
+ 	.desc			= "Allwinner sun4i Display Engine",
+ 	.date			= "20150629",
+ 	.major			= 1,

--- a/patch/kernel/archive/sunxi-5.15/0001-drm-sun4i-change-the-driver-name-to-sun4i_drm.patch
+++ b/patch/kernel/archive/sunxi-5.15/0001-drm-sun4i-change-the-driver-name-to-sun4i_drm.patch
@@ -1,0 +1,13 @@
+diff --git a/drivers/gpu/drm/sun4i/sun4i_drv.c b/drivers/gpu/drm/sun4i/sun4i_drv.c
+index 29861fc81..858a24020 100644
+--- a/drivers/gpu/drm/sun4i/sun4i_drv.c
++++ b/drivers/gpu/drm/sun4i/sun4i_drv.c
+@@ -45,7 +45,7 @@ static struct drm_driver sun4i_drv_driver = {
+ 
+ 	/* Generic Operations */
+ 	.fops			= &sun4i_drv_fops,
+-	.name			= "sun4i-drm",
++	.name			= "sun4i_drm",
+ 	.desc			= "Allwinner sun4i Display Engine",
+ 	.date			= "20150629",
+ 	.major			= 1,


### PR DESCRIPTION
# Description

Fixed launch of desktop environment on CubieTruck.
Topic: https://forum.armbian.com/topic/19164-cubietruck-black-screen-xfce-aiglx-error-sun4i-drm-does-not-export-required-dri-extension/
Source of inspiration: https://forum.clockworkpi.com/t/apt-full-upgrade-getting-the-new-software-updates-from-debian/5664

Without patch `/var/log/Xorg.0.log`:
```
[    59.326] (EE) AIGLX error: sun4i-drm does not export required DRI extension
[    59.550] (II) IGLX: Loaded and initialized swrast
[    59.550] (II) GLX: Initialized DRISWRAST GL provider for screen 0
```

With patch `/var/log/Xorg.0.log`:
```
[    58.156] (II) AIGLX: Loaded and initialized sun4i-drm
[    58.312] (II) GLX: Initialized DRI2 GL provider for screen 0
```

# How Has This Been Tested?

- [x] Build legacy image, uploaded to cubietruck, does not work
- [x] Build patched image, uploaded to cubietruck, it works

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
