### PR TITLE
Revert "Change bootscripts/boot-meson64.cmd memory addresses for load…

### DIFF
--- a/config/bootscripts/boot-meson64.cmd
+++ b/config/bootscripts/boot-meson64.cmd
@@ -3,10 +3,9 @@
 # Please edit /boot/armbianEnv.txt to set supported parameters
 #
 
-setenv fdt_addr_r "0x10000000"
-setenv load_addr  "0x10100000"
-setenv kernel_addr_r "0x11000000"
-setenv ramdisk_addr_r "0x19000000"
+setenv load_addr "0x32000000"
+setenv kernel_addr_r "0x34000000"
+setenv fdt_addr_r "0x4080000"
 setenv overlay_error "false"
 # default values
 setenv rootdev "/dev/mmcblk1p1"


### PR DESCRIPTION
# Description

This reverts "Change bootscripts/boot-meson64.cmd memory addresses for loading (#3171)" commit 300ff669e4955731f10f32381e6d7cb466a64a63

Breaks some GX boards. Needs more checking.


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
