### PR TITLE
remove hardcoded "--rm" hides config string

### DIFF
--- a/config/templates/config-docker.conf
+++ b/config/templates/config-docker.conf
@@ -43,7 +43,7 @@ DOCKER_FLAGS+=(--security-opt=apparmor:unconfined)
 
 # remove resulting container after exit to minimize clutter
 # bad side effect - named volumes are considered not attached to anything and are removed on "docker volume prune"
-#DOCKER_FLAGS+=(--rm)
+DOCKER_FLAGS+=(--rm)
 
 # pass through loop devices
 for d in /dev/loop*; do
@@ -106,10 +106,10 @@ If you prefer to use profile, for example, `userpatches/config-my.conf`,  try:
     ./compile.sh my compile_uboot
 
 EOF
-  docker run "${DOCKER_FLAGS[@]}" -it --rm --entrypoint /usr/bin/env armbian:$VERSION "$@" /bin/bash
+  docker run "${DOCKER_FLAGS[@]}" -it --entrypoint /usr/bin/env armbian:$VERSION "$@" /bin/bash
 else
   display_alert "Running the container" "" "info"
-  docker run "${DOCKER_FLAGS[@]}" -it --rm armbian:$VERSION "$@"
+  docker run "${DOCKER_FLAGS[@]}" -it armbian:$VERSION "$@"
 fi
 
 # Docker error treatment


### PR DESCRIPTION
Currently docker call parameter `--rm` declared, and remarked.
But `--rm` option hardcoded into docker call too.

Get back parameter into work.