### PR TITLE
Bump wireguard-manager from 06-20-2021 to 10-26-2021

### DIFF
--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -705,7 +705,7 @@ compile_armbian-config()
 
 	fetch_from_repo "https://github.com/armbian/config" "armbian-config" "branch:master"
 	fetch_from_repo "https://github.com/dylanaraps/neofetch" "neofetch" "tag:7.1.0"
-	fetch_from_repo "https://github.com/complexorganizations/wireguard-manager" "wireguard-manager" "tag:v1.0.0.06-20-2021"
+	fetch_from_repo "https://github.com/complexorganizations/wireguard-manager" "wireguard-manager" "tag:v1.0.0.10-26-2021"
 
 	mkdir -p "${tmp_dir}/${armbian_config_dir}"/{DEBIAN,usr/bin/,usr/sbin/,usr/lib/armbian-config/}
 


### PR DESCRIPTION
# Description

- More distro support
- added an optional content blocker that blocks ads and trackers and other stuff.
- fixed all the dependency issues.
- fixed the issue with unbound and ipv6
- now the server can have as many clients as they want.
- fixed the uninstall
- also the thing that people hated where it would remove things without asking, that has been removed.
- a lot of other bugs.