### PR TITLE
Enable Netplan.io

### DIFF
--- a/config/cli/bullseye/main/packages.additional
+++ b/config/cli/bullseye/main/packages.additional
@@ -10,6 +10,7 @@ mc
 mmc-utils
 nano
 net-tools
+netplan.io
 network-manager
 network-manager-openvpn
 resolvconf

--- a/config/cli/buster/main/packages.additional
+++ b/config/cli/buster/main/packages.additional
@@ -9,6 +9,7 @@ lsof
 mc
 mmc-utils
 nano
+netplan.io
 net-tools
 network-manager
 network-manager-openvpn

--- a/config/cli/focal/main/packages.additional
+++ b/config/cli/focal/main/packages.additional
@@ -10,6 +10,7 @@ mc
 mmc-utils
 nano
 net-tools
+netplan.io
 network-manager
 network-manager-openvpn
 resolvconf

--- a/config/cli/impish/main/packages.additional
+++ b/config/cli/impish/main/packages.additional
@@ -9,6 +9,7 @@ mc
 mmc-utils
 nano
 net-tools
+netplan.io
 network-manager
 network-manager-openvpn
 resolvconf

--- a/config/cli/jammy/main/packages.additional
+++ b/config/cli/jammy/main/packages.additional
@@ -1,2 +1,19 @@
-network-manager network-manager-openvpn wireless-tools lsof htop mmc-utils wget nano sysstat net-tools 
-resolvconf jq libcrack2 cracklib-runtime curl mc i2c-tools
+cracklib-runtime
+curl
+htop
+i2c-tools
+iozone3
+jq
+libcrack2
+lsof
+mc
+mmc-utils
+nano
+net-tools
+netplan.io
+network-manager
+network-manager-openvpn
+resolvconf
+sysstat
+wget
+wireless-tools

--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -29,7 +29,7 @@ HOSTRELEASE=$(cat /etc/os-release | grep VERSION_CODENAME | cut -d"=" -f2)
 [[ -z $EXIT_PATCHING_ERROR ]] && EXIT_PATCHING_ERROR="" # exit patching if failed
 [[ -z $HOST ]] && HOST="$BOARD" # set hostname to the board
 cd "${SRC}" || exit
-[[ -z "${ROOTFSCACHE_VERSION}" ]] && ROOTFSCACHE_VERSION=10
+[[ -z "${ROOTFSCACHE_VERSION}" ]] && ROOTFSCACHE_VERSION=11
 [[ -z "${CHROOT_CACHE_VERSION}" ]] && CHROOT_CACHE_VERSION=7
 BUILD_REPOSITORY_URL=$(improved_git remote get-url $(improved_git remote 2>/dev/null | grep origin) 2>/dev/null)
 BUILD_REPOSITORY_COMMIT=$(improved_git describe --match=d_e_a_d_b_e_e_f --always --dirty 2>/dev/null)


### PR DESCRIPTION
# Description

[Netplan](https://netplan.io/) is a utility for easily configuring networking on a linux system. You simply create a YAML description of the required network interfaces and what each should be configured to do. From this description Netplan will generate all the necessary configuration for your chosen renderer tool.

This should simplify network configuration.

Jira reference number [AR-971]

# How Has This Been Tested?

- [ ] Added and tested on all supported variants

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-971]: https://armbian.atlassian.net/browse/AR-971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ