### PR TITLE
Add critical patches from Khadas repository

### DIFF
--- a/patch/kernel/archive/meson64-5.10/0001-arm64-dts-rockchip-emmc-remove-mmc-hs400-enhanced-st.patch
+++ b/patch/kernel/archive/meson64-5.10/0001-arm64-dts-rockchip-emmc-remove-mmc-hs400-enhanced-st.patch
@@ -1,0 +1,75 @@
+From 26e8623e687e30fa9195e9da22479ccdb6afc91b Mon Sep 17 00:00:00 2001
+From: Artem Lapkin <art@khadas.com>
+Date: Wed, 10 Nov 2021 13:22:16 +0800
+Subject: [PATCH] arm64: dts: rockchip: emmc remove mmc-hs400-enhanced-strobe
+ rk3399-khadas-edge
+
+Remove mmc-hs400-enhanced-strobe for rk3399-khadas-edge
+
+Not compitable for some eMMC chips ( BJTD4R 29.1 GiB ). And no
+performance difference in our case from emmc-hs400-enhanced-strobe option
+for other eMMC chips.
+
+Problem example ( eMMC chip BJTD4R 29.1 GiB ):
+
+[    0.068282] platform ff770000.syscon:phy@f780: Fixing up cyclic dependency with fe330000.mmc
+[    7.001493] mmc2: CQHCI version 5.10
+[    7.027971] mmc2: SDHCI controller on fe330000.mmc [fe330000.mmc] using ADMA
+.......
+[    7.207086] mmc2: mmc_select_hs400es failed, error -110
+[    7.207129] mmc2: error -110 whilst initialising MMC card
+[    7.308893] mmc2: mmc_select_hs400es failed, error -110
+[    7.308921] mmc2: error -110 whilst initialising MMC card
+[    7.427524] mmc2: mmc_select_hs400es failed, error -110
+[    7.427546] mmc2: error -110 whilst initialising MMC card
+[    7.590993] mmc2: mmc_select_hs400es failed, error -110
+[    7.591012] mmc2: error -110 whilst initialising MMC card
+
+Workable example without mmc-hs400-enhanced-strobe:
+
+[    6.960785] mmc2: CQHCI version 5.10
+[    6.984672] mmc2: SDHCI controller on fe330000.mmc [fe330000.mmc] using ADMA
+[    7.175021] mmc2: Command Queue Engine enabled
+[    7.175053] mmc2: new HS400 MMC card at address 0001
+[    7.175808] mmcblk2: mmc2:0001 BJTD4R 29.1 GiB 
+[    7.176033] mmcblk2boot0: mmc2:0001 BJTD4R 4.00 MiB 
+[    7.176245] mmcblk2boot1: mmc2:0001 BJTD4R 4.00 MiB 
+[    7.176495] mmcblk2rpmb: mmc2:0001 BJTD4R 4.00 MiB, chardev (242:0)
+
+Performance note for mmc-hs400-enhanced-strobe usage:
+
+Other chips DUTA42 116 GiB works well with or without
+mmc-hs400-enhanced-strobe!
+
+..... mmc-hs400-enhanced-strobe disabled
+
+786432000 bytes (786 MB, 750 MiB) copied, 3 s, 262 MB/s
+
+..... mmc-hs400-enhanced-strobe enabled
+
+[    7.135880] mmc2: Command Queue Engine enabled
+[    7.135928] mmc2: new HS400 Enhanced strobe MMC card at address 0001
+[    7.136992] mmcblk2: mmc2:0001 DUTA42 116 GiB 
+
+1048576000 bytes (1.0 GB, 1000 MiB) copied, 4 s, 262 MB/s
+
+Signed-off-by: Artem Lapkin <art@khadas.com>
+---
+ arch/arm64/boot/dts/rockchip/rk3399-khadas-edge.dtsi | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-khadas-edge.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-khadas-edge.dtsi
+index d5c7648c841d..f1fcc6b5b402 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-khadas-edge.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3399-khadas-edge.dtsi
+@@ -705,7 +705,6 @@ &sdmmc {
+ &sdhci {
+ 	bus-width = <8>;
+ 	mmc-hs400-1_8v;
+-	mmc-hs400-enhanced-strobe;
+ 	non-removable;
+ 	status = "okay";
+ };
+-- 
+2.25.1
+

--- a/patch/kernel/archive/meson64-5.10/0014-WIP-mmc-meson-gx-mmc-set-core-clock-phase-to-270-deg.patch
+++ b/patch/kernel/archive/meson64-5.10/0014-WIP-mmc-meson-gx-mmc-set-core-clock-phase-to-270-deg.patch
@@ -1,7 +1,7 @@
-From 7d0a1b039aafd09bbee5007422c987e3effb1741 Mon Sep 17 00:00:00 2001
+From ecf2bcae5fb4c7314f3c36842ae88a31c596d529 Mon Sep 17 00:00:00 2001
 From: Neil Armstrong <narmstrong@baylibre.com>
 Date: Thu, 14 Jan 2021 17:43:02 +0100
-Subject: [PATCH 40/58] WIP: mmc: meson-gx-mmc: set core clock phase to 270
+Subject: [PATCH 14/77] WIP: mmc: meson-gx-mmc: set core clock phase to 270
  degres for AXG compatible controllers
 
 Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>
@@ -10,7 +10,7 @@ Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>
  1 file changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/mmc/host/meson-gx-mmc.c b/drivers/mmc/host/meson-gx-mmc.c
-index eb6c02bc4a02..3f835f73adf8 100644
+index 3f28eb4d17fe..c224b0832403 100644
 --- a/drivers/mmc/host/meson-gx-mmc.c
 +++ b/drivers/mmc/host/meson-gx-mmc.c
 @@ -38,6 +38,7 @@
@@ -29,7 +29,7 @@ index eb6c02bc4a02..3f835f73adf8 100644
  };
  
  struct sd_emmc_desc {
-@@ -421,7 +423,7 @@ static int meson_mmc_clk_init(struct meson_host *host)
+@@ -426,7 +428,7 @@ static int meson_mmc_clk_init(struct meson_host *host)
  	/* init SD_EMMC_CLOCK to sane defaults w/min clock rate */
  	clk_reg = CLK_ALWAYS_ON(host);
  	clk_reg |= CLK_DIV_MASK;
@@ -38,7 +38,7 @@ index eb6c02bc4a02..3f835f73adf8 100644
  	clk_reg |= FIELD_PREP(CLK_TX_PHASE_MASK, CLK_PHASE_0);
  	clk_reg |= FIELD_PREP(CLK_RX_PHASE_MASK, CLK_PHASE_0);
  	writel(clk_reg, host->regs + SD_EMMC_CLOCK);
-@@ -1247,6 +1249,7 @@ static const struct meson_mmc_data meson_gx_data = {
+@@ -1291,6 +1293,7 @@ static const struct meson_mmc_data meson_gx_data = {
  	.rx_delay_mask	= CLK_V2_RX_DELAY_MASK,
  	.always_on	= CLK_V2_ALWAYS_ON,
  	.adjust		= SD_EMMC_ADJUST,
@@ -46,7 +46,7 @@ index eb6c02bc4a02..3f835f73adf8 100644
  };
  
  static const struct meson_mmc_data meson_axg_data = {
-@@ -1254,6 +1257,7 @@ static const struct meson_mmc_data meson_axg_data = {
+@@ -1298,6 +1301,7 @@ static const struct meson_mmc_data meson_axg_data = {
  	.rx_delay_mask	= CLK_V3_RX_DELAY_MASK,
  	.always_on	= CLK_V3_ALWAYS_ON,
  	.adjust		= SD_EMMC_V3_ADJUST,

--- a/patch/kernel/archive/meson64-5.10/0068-PCI-DWC-meson-add-256-bytes-MRRS-quirk.patch
+++ b/patch/kernel/archive/meson64-5.10/0068-PCI-DWC-meson-add-256-bytes-MRRS-quirk.patch
@@ -1,0 +1,74 @@
+From b23c8fb3421984a72578a4235746653dcd2e82b7 Mon Sep 17 00:00:00 2001
+From: Artem Lapkin <art@khadas.com>
+Date: Tue, 13 Jul 2021 10:46:41 +0800
+Subject: [PATCH v2] PCI: DWC: meson: add 256 bytes MRRS quirk
+
+256 bytes maximum read request size. They can't handle
+anything larger than this. So force this limit on
+any devices attached under these ports.
+
+Come-from: https://lkml.org/lkml/2021/6/18/160
+Come-from: https://lkml.org/lkml/2021/6/19/19
+
+It only affects PCIe in P2P, in non-P2P is will certainly affect
+transfers on the internal SoC/Processor/Chip internal bus/fabric.
+
+These quirks are currently implemented in the
+controller driver and only applies when the controller has been probed
+and to each endpoint detected on this particular controller.
+
+Continue having separate quirks for each controller if the core
+isn't the right place to handle MPS/MRRS.
+
+>> Neil
+
+Signed-off-by: Artem Lapkin <art@khadas.com>
+---
+ drivers/pci/controller/dwc/pci-meson.c | 31 ++++++++++++++++++++++++++
+ 1 file changed, 31 insertions(+)
+
+diff --git a/drivers/pci/controller/dwc/pci-meson.c b/drivers/pci/controller/dwc/pci-meson.c
+index 686ded034..1498950de 100644
+--- a/drivers/pci/controller/dwc/pci-meson.c
++++ b/drivers/pci/controller/dwc/pci-meson.c
+@@ -466,6 +466,37 @@ static int meson_pcie_probe(struct platform_device *pdev)
+ 	return ret;
+ }
+ 
++static void meson_mrrs_limit_quirk(struct pci_dev *dev)
++{
++	struct pci_bus *bus = dev->bus;
++	int mrrs, mrrs_limit = 256;
++	static const struct pci_device_id bridge_devids[] = {
++		{ PCI_DEVICE(PCI_VENDOR_ID_SYNOPSYS, PCI_DEVICE_ID_SYNOPSYS_HAPSUSB3) },
++		{ 0, },
++	};
++
++	/* look for the matching bridge */
++	while (!pci_is_root_bus(bus)) {
++		/*
++		 * 256 bytes maximum read request size. They can't handle
++		 * anything larger than this. So force this limit on
++		 * any devices attached under these ports.
++		 */
++		if (!pci_match_id(bridge_devids, bus->self)) {
++			bus = bus->parent;
++			continue;
++		}
++
++		mrrs = pcie_get_readrq(dev);
++		if (mrrs > mrrs_limit) {
++			pci_info(dev, "limiting MRRS %d to %d\n", mrrs, mrrs_limit);
++			pcie_set_readrq(dev, mrrs_limit);
++		}
++		break;
++	}
++}
++DECLARE_PCI_FIXUP_ENABLE(PCI_ANY_ID, PCI_ANY_ID, meson_mrrs_limit_quirk);
++
+ static const struct of_device_id meson_pcie_of_match[] = {
+ 	{
+ 		.compatible = "amlogic,axg-pcie",
+-- 
+2.25.1
+

--- a/patch/kernel/archive/meson64-5.15/0001-arm64-dts-rockchip-emmc-remove-mmc-hs400-enhanced-st.patch
+++ b/patch/kernel/archive/meson64-5.15/0001-arm64-dts-rockchip-emmc-remove-mmc-hs400-enhanced-st.patch
@@ -1,0 +1,75 @@
+From 26e8623e687e30fa9195e9da22479ccdb6afc91b Mon Sep 17 00:00:00 2001
+From: Artem Lapkin <art@khadas.com>
+Date: Wed, 10 Nov 2021 13:22:16 +0800
+Subject: [PATCH] arm64: dts: rockchip: emmc remove mmc-hs400-enhanced-strobe
+ rk3399-khadas-edge
+
+Remove mmc-hs400-enhanced-strobe for rk3399-khadas-edge
+
+Not compitable for some eMMC chips ( BJTD4R 29.1 GiB ). And no
+performance difference in our case from emmc-hs400-enhanced-strobe option
+for other eMMC chips.
+
+Problem example ( eMMC chip BJTD4R 29.1 GiB ):
+
+[    0.068282] platform ff770000.syscon:phy@f780: Fixing up cyclic dependency with fe330000.mmc
+[    7.001493] mmc2: CQHCI version 5.10
+[    7.027971] mmc2: SDHCI controller on fe330000.mmc [fe330000.mmc] using ADMA
+.......
+[    7.207086] mmc2: mmc_select_hs400es failed, error -110
+[    7.207129] mmc2: error -110 whilst initialising MMC card
+[    7.308893] mmc2: mmc_select_hs400es failed, error -110
+[    7.308921] mmc2: error -110 whilst initialising MMC card
+[    7.427524] mmc2: mmc_select_hs400es failed, error -110
+[    7.427546] mmc2: error -110 whilst initialising MMC card
+[    7.590993] mmc2: mmc_select_hs400es failed, error -110
+[    7.591012] mmc2: error -110 whilst initialising MMC card
+
+Workable example without mmc-hs400-enhanced-strobe:
+
+[    6.960785] mmc2: CQHCI version 5.10
+[    6.984672] mmc2: SDHCI controller on fe330000.mmc [fe330000.mmc] using ADMA
+[    7.175021] mmc2: Command Queue Engine enabled
+[    7.175053] mmc2: new HS400 MMC card at address 0001
+[    7.175808] mmcblk2: mmc2:0001 BJTD4R 29.1 GiB 
+[    7.176033] mmcblk2boot0: mmc2:0001 BJTD4R 4.00 MiB 
+[    7.176245] mmcblk2boot1: mmc2:0001 BJTD4R 4.00 MiB 
+[    7.176495] mmcblk2rpmb: mmc2:0001 BJTD4R 4.00 MiB, chardev (242:0)
+
+Performance note for mmc-hs400-enhanced-strobe usage:
+
+Other chips DUTA42 116 GiB works well with or without
+mmc-hs400-enhanced-strobe!
+
+..... mmc-hs400-enhanced-strobe disabled
+
+786432000 bytes (786 MB, 750 MiB) copied, 3 s, 262 MB/s
+
+..... mmc-hs400-enhanced-strobe enabled
+
+[    7.135880] mmc2: Command Queue Engine enabled
+[    7.135928] mmc2: new HS400 Enhanced strobe MMC card at address 0001
+[    7.136992] mmcblk2: mmc2:0001 DUTA42 116 GiB 
+
+1048576000 bytes (1.0 GB, 1000 MiB) copied, 4 s, 262 MB/s
+
+Signed-off-by: Artem Lapkin <art@khadas.com>
+---
+ arch/arm64/boot/dts/rockchip/rk3399-khadas-edge.dtsi | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-khadas-edge.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-khadas-edge.dtsi
+index d5c7648c841d..f1fcc6b5b402 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-khadas-edge.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3399-khadas-edge.dtsi
+@@ -705,7 +705,6 @@ &sdmmc {
+ &sdhci {
+ 	bus-width = <8>;
+ 	mmc-hs400-1_8v;
+-	mmc-hs400-enhanced-strobe;
+ 	non-removable;
+ 	status = "okay";
+ };
+-- 
+2.25.1
+

--- a/patch/kernel/archive/meson64-5.15/0014-WIP-mmc-meson-gx-mmc-set-core-clock-phase-to-270-deg.patch
+++ b/patch/kernel/archive/meson64-5.15/0014-WIP-mmc-meson-gx-mmc-set-core-clock-phase-to-270-deg.patch
@@ -1,0 +1,59 @@
+From ecf2bcae5fb4c7314f3c36842ae88a31c596d529 Mon Sep 17 00:00:00 2001
+From: Neil Armstrong <narmstrong@baylibre.com>
+Date: Thu, 14 Jan 2021 17:43:02 +0100
+Subject: [PATCH 14/77] WIP: mmc: meson-gx-mmc: set core clock phase to 270
+ degres for AXG compatible controllers
+
+Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>
+---
+ drivers/mmc/host/meson-gx-mmc.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/mmc/host/meson-gx-mmc.c b/drivers/mmc/host/meson-gx-mmc.c
+index 3f28eb4d17fe..c224b0832403 100644
+--- a/drivers/mmc/host/meson-gx-mmc.c
++++ b/drivers/mmc/host/meson-gx-mmc.c
+@@ -38,6 +38,7 @@
+ #define   CLK_RX_PHASE_MASK GENMASK(13, 12)
+ #define   CLK_PHASE_0 0
+ #define   CLK_PHASE_180 2
++#define   CLK_PHASE_270 3
+ #define   CLK_V2_TX_DELAY_MASK GENMASK(19, 16)
+ #define   CLK_V2_RX_DELAY_MASK GENMASK(23, 20)
+ #define   CLK_V2_ALWAYS_ON BIT(24)
+@@ -136,6 +137,7 @@ struct meson_mmc_data {
+ 	unsigned int rx_delay_mask;
+ 	unsigned int always_on;
+ 	unsigned int adjust;
++	unsigned int clk_core_phase;
+ };
+ 
+ struct sd_emmc_desc {
+@@ -426,7 +428,7 @@ static int meson_mmc_clk_init(struct meson_host *host)
+ 	/* init SD_EMMC_CLOCK to sane defaults w/min clock rate */
+ 	clk_reg = CLK_ALWAYS_ON(host);
+ 	clk_reg |= CLK_DIV_MASK;
+-	clk_reg |= FIELD_PREP(CLK_CORE_PHASE_MASK, CLK_PHASE_180);
++	clk_reg |= FIELD_PREP(CLK_CORE_PHASE_MASK, host->data->clk_core_phase);
+ 	clk_reg |= FIELD_PREP(CLK_TX_PHASE_MASK, CLK_PHASE_0);
+ 	clk_reg |= FIELD_PREP(CLK_RX_PHASE_MASK, CLK_PHASE_0);
+ 	writel(clk_reg, host->regs + SD_EMMC_CLOCK);
+@@ -1291,6 +1293,7 @@ static const struct meson_mmc_data meson_gx_data = {
+ 	.rx_delay_mask	= CLK_V2_RX_DELAY_MASK,
+ 	.always_on	= CLK_V2_ALWAYS_ON,
+ 	.adjust		= SD_EMMC_ADJUST,
++	.clk_core_phase	= CLK_PHASE_180,
+ };
+ 
+ static const struct meson_mmc_data meson_axg_data = {
+@@ -1298,6 +1301,7 @@ static const struct meson_mmc_data meson_axg_data = {
+ 	.rx_delay_mask	= CLK_V3_RX_DELAY_MASK,
+ 	.always_on	= CLK_V3_ALWAYS_ON,
+ 	.adjust		= SD_EMMC_V3_ADJUST,
++	.clk_core_phase	= CLK_PHASE_270,
+ };
+ 
+ static const struct of_device_id meson_mmc_of_match[] = {
+-- 
+2.25.1
+

--- a/patch/kernel/archive/meson64-5.15/0068-PCI-DWC-meson-add-256-bytes-MRRS-quirk.patch
+++ b/patch/kernel/archive/meson64-5.15/0068-PCI-DWC-meson-add-256-bytes-MRRS-quirk.patch
@@ -1,0 +1,74 @@
+From b23c8fb3421984a72578a4235746653dcd2e82b7 Mon Sep 17 00:00:00 2001
+From: Artem Lapkin <art@khadas.com>
+Date: Tue, 13 Jul 2021 10:46:41 +0800
+Subject: [PATCH v2] PCI: DWC: meson: add 256 bytes MRRS quirk
+
+256 bytes maximum read request size. They can't handle
+anything larger than this. So force this limit on
+any devices attached under these ports.
+
+Come-from: https://lkml.org/lkml/2021/6/18/160
+Come-from: https://lkml.org/lkml/2021/6/19/19
+
+It only affects PCIe in P2P, in non-P2P is will certainly affect
+transfers on the internal SoC/Processor/Chip internal bus/fabric.
+
+These quirks are currently implemented in the
+controller driver and only applies when the controller has been probed
+and to each endpoint detected on this particular controller.
+
+Continue having separate quirks for each controller if the core
+isn't the right place to handle MPS/MRRS.
+
+>> Neil
+
+Signed-off-by: Artem Lapkin <art@khadas.com>
+---
+ drivers/pci/controller/dwc/pci-meson.c | 31 ++++++++++++++++++++++++++
+ 1 file changed, 31 insertions(+)
+
+diff --git a/drivers/pci/controller/dwc/pci-meson.c b/drivers/pci/controller/dwc/pci-meson.c
+index 686ded034..1498950de 100644
+--- a/drivers/pci/controller/dwc/pci-meson.c
++++ b/drivers/pci/controller/dwc/pci-meson.c
+@@ -466,6 +466,37 @@ static int meson_pcie_probe(struct platform_device *pdev)
+ 	return ret;
+ }
+ 
++static void meson_mrrs_limit_quirk(struct pci_dev *dev)
++{
++	struct pci_bus *bus = dev->bus;
++	int mrrs, mrrs_limit = 256;
++	static const struct pci_device_id bridge_devids[] = {
++		{ PCI_DEVICE(PCI_VENDOR_ID_SYNOPSYS, PCI_DEVICE_ID_SYNOPSYS_HAPSUSB3) },
++		{ 0, },
++	};
++
++	/* look for the matching bridge */
++	while (!pci_is_root_bus(bus)) {
++		/*
++		 * 256 bytes maximum read request size. They can't handle
++		 * anything larger than this. So force this limit on
++		 * any devices attached under these ports.
++		 */
++		if (!pci_match_id(bridge_devids, bus->self)) {
++			bus = bus->parent;
++			continue;
++		}
++
++		mrrs = pcie_get_readrq(dev);
++		if (mrrs > mrrs_limit) {
++			pci_info(dev, "limiting MRRS %d to %d\n", mrrs, mrrs_limit);
++			pcie_set_readrq(dev, mrrs_limit);
++		}
++		break;
++	}
++}
++DECLARE_PCI_FIXUP_ENABLE(PCI_ANY_ID, PCI_ANY_ID, meson_mrrs_limit_quirk);
++
+ static const struct of_device_id meson_pcie_of_match[] = {
+ 	{
+ 		.compatible = "amlogic,axg-pcie",
+-- 
+2.25.1
+


### PR DESCRIPTION
# Adding few fixes to current and edge kernels.

- Remove mmc-hs400-enhanced-strobe for rk3399-khadas-edge
- PCI: DWC: meson: add 256 bytes MRRS quirk
- dts: rockchip: emmc remove mmc-hs400-enhanced-strobe

Jira reference number [AR-984]

# How Has This Been Tested?

- [x] Tested by Khadas on their hardware
- [ ] Tested others

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-984]: https://armbian.atlassian.net/browse/AR-984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ