### PR TITLE
Adjust build targets

### DIFF
--- a/config/targets-cli-beta.conf
+++ b/config/targets-cli-beta.conf
@@ -3,73 +3,68 @@
 ####################################################################################################################
 
 # Helios64
-helios64                     edge            impish      cli                      beta         yes
+helios64                     edge            jammy       cli                      beta         yes
 
 
 # JetHub H1 (j80)
-jethubj80                    current         focal        cli                      beta         yes
-jethubj80                    edge            focal        cli                      beta         yes
-jethubj80                    current         hirsute      cli                      beta         yes
-jethubj80                    edge            hirsute      cli                      beta         yes
+jethubj80                    edge            jammy       cli                      beta         yes
+
 
 # JetHub D1 (j100)
-jethubj100                   current         focal        cli                      beta         yes
-jethubj100                   edge            focal        cli                      beta         yes
-jethubj100                   current         hirsute      cli                      beta         yes
-jethubj100                   edge            hirsute      cli                      beta         yes
+jethubj100                   edge            jammy       cli                      beta         yes
 
 
 # Jetson Nano
-jetson-nano                  edge            impish      cli                      beta         yes
+jetson-nano                  edge            jammy       cli                      beta         yes
 
 
 # Khadas Vim3
-khadas-vim3                  edge            impish      cli                      beta         yes
+khadas-vim3                  edge            jammy       cli                      beta         yes
 
 
 # Khadas Vim3l
-khadas-vim3l                 edge            impish      cli                      beta         yes
+khadas-vim3l                 edge            jammy       cli                      beta         yes
 
 
 # Khadas Edge
-khadas-edge                  edge            impish      cli                      beta         yes
+khadas-edge                  edge            jammy       cli                      beta         yes
 
 
 # nanopi-r2s
-nanopi-r2s                   edge            impish      cli                      beta         yes
+nanopi-r2s                   edge            jammy       cli                      beta         yes
 
 
 # nanopi-r4s
-nanopi-r4s                   edge            impish      cli                      beta         yes
+nanopi-r4s                   edge            jammy       cli                      beta         yes
 
 
 # Odroid N2 / N2+
-odroidn2                     edge            impish      cli                      beta         yes
+odroidn2                     edge            jammy       cli                      beta         yes
 
 
 # Odroid C4
-odroidc4                     edge            impish      cli                      beta         yes
+odroidc4                     edge            jammy       cli                      beta         yes
 
 
 # Odroid HC4
-odroidhc4                    edge            impish      cli                      beta         yes
+odroidhc4                    edge            jammy       cli                      beta         yes
 
 
 # Orangepi R1+
-orangepi-r1plus              edge            impish      cli                      beta         yes
+orangepi-r1plus              edge            jammy       cli                      beta         yes
 
 
 # Orangepi Zero 2
-orangepizero2                edge            impish      cli                      beta         yes
+orangepizero2                edge            jammy       cli                      beta         yes
 
 
 # rk322x-box
-rk322x-box                   edge            impish      cli                      beta         yes
+rk322x-box                   edge            jammy       cli                      beta         yes
 
 
 # Radxa rock-3a
-rock-3a                      legacy          impish      cli                      beta         yes
+rock-3a                      legacy          jammy       cli                      beta         yes
 
 
 # Virtual qemu
-virtual-qemu                 current         impish      cli                      beta         yes
+virtual-qemu                 current         jammy       cli                      beta         yes

--- a/config/targets.conf
+++ b/config/targets.conf
@@ -1063,6 +1063,20 @@ zeropi                    current         focal       cli                      s
 zeropi                    edge            hirsute     cli                      stable         yes
 
 
+# JetHub H1 (j80)
+jethubj80                 current         focal       cli                      stable         yes
+jethubj80                 edge            focal       cli                      stable         yes
+jethubj80                 current         hirsute     cli                      stable         yes
+jethubj80                 edge            hirsute     cli                      stable         yes
+ 
+
+# JetHub D1 (j100)
+jethubj100                current         focal       cli                      stable         yes
+jethubj100                edge            focal       cli                      stable         yes
+jethubj100                current         hirsute     cli                      stable         yes
+jethubj100                edge            hirsute     cli                      stable         yes
+
+
 # Jetson Nano
 jetson-nano               current         focal       minimal                  stable         yes
 jetson-nano               legacy          buster      desktop                  stable         yes            xfce      config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop


### PR DESCRIPTION
# Description

- nightly builds will be Jammy / 20.04
- moving JetHub to stable @adeepn so bsp packages are produced properly. And anyway this is a supported target. Nightly builds are only one image / hw, unless this is really needed?