### PR TITLE
Fix meson memory addresses for loading kernel/ramdisk/dtb on 512Mb boards

### DIFF
--- a/config/bootscripts/boot-meson64.cmd
+++ b/config/bootscripts/boot-meson64.cmd
@@ -3,9 +3,10 @@
 # Please edit /boot/armbianEnv.txt to set supported parameters
 #
 
-setenv load_addr "0x32000000"
-setenv kernel_addr_r "0x34000000"
-setenv fdt_addr_r "0x4080000"
+setenv load_addr      "0x01100000"
+setenv kernel_addr_r  "0x02000000"
+setenv fdt_addr_r     "0x01000000"
+setenv ramdisk_addr_r "0x04080000"
 setenv overlay_error "false"
 # default values
 setenv rootdev "/dev/mmcblk1p1"


### PR DESCRIPTION
# Description

Fixes:   #3171 #3244

Tested-by: @Tonymac32, @adeepn

Update memory addresses for boot-meson64.cmd for 512Mb boards.

Jira reference number [AR-987]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] tested C2, K2, Le Potato
- [X] tested JetHub j80, j100

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-987]: https://armbian.atlassian.net/browse/AR-987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ