### PR TITLE
Update to v5.15.4 for sunxi EDGE

### DIFF
--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -16,7 +16,7 @@ case $BRANCH in
 
 	edge)
 		KERNEL_VERSION_LEVEL="5.15"
-		KERNELSWITCHOBJ="tag=v5.15.3"
+		KERNELSWITCHOBJ="tag=v5.15.4"
 	;;
 esac
 

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -17,7 +17,7 @@ case $BRANCH in
 
 	edge)
 		KERNEL_VERSION_LEVEL="5.15"
-		KERNELSWITCHOBJ="tag=v5.15.3"
+		KERNELSWITCHOBJ="tag=v5.15.4"
 	;;
 esac
 


### PR DESCRIPTION
# Description

Switching to the next version of the upstream kernel
- [ ] build for orangepi PC2

# Checklist:

- [x] Applying patches without errors

