### PR TITLE
multiple fixes for the eval + PIPESTATUS construct

### DIFF
--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -236,9 +236,9 @@ compile_uboot()
 			"${cross_compile}"' 2>>"${DEST}"/${LOG_SUBPATH}/compilation.log \
 			${PROGRESS_LOG_TO_FILE:+' | tee -a "${DEST}"/${LOG_SUBPATH}/compilation.log'} \
 			${OUTPUT_DIALOG:+' | dialog --backtitle "$backtitle" --progressbox "Compiling u-boot..." $TTY_Y $TTY_X'} \
-			${OUTPUT_VERYSILENT:+' >/dev/null 2>/dev/null'}
+			${OUTPUT_VERYSILENT:+' >/dev/null 2>/dev/null'} ';EVALPIPE=(${PIPESTATUS[@]})'
 
-		[[ ${PIPESTATUS[0]} -ne 0 ]] && exit_with_error "U-boot compilation failed"
+		[[ ${EVALPIPE[0]} -ne 0 ]] && exit_with_error "U-boot compilation failed"
 
 		[[ $(type -t uboot_custom_postprocess) == function ]] && uboot_custom_postprocess
 


### PR DESCRIPTION
### multiple fixes for the eval + PIPESTATUS construct
- try this on your bash shell:
  - `ONEVAR="testing" eval 'bash -c "echo value once $ONEVAR && false && echo value twice $ONEVAR"' '| grep value'  '| grep value' ; echo ${PIPESTATUS[*]}`
  - Notice how PIPESTATUS has only one element. and it is always true, although we failed explicitly with false in the middle of the bash.
  - That is because eval itself is considered a single command, no matter how many pipes you put in there, you'll get a single value, the return code of the LAST pipe.
  - Lets export the value of the pipe inside eval so we know outside what happened:
  - `ONEVAR="testing" eval 'bash -e -c "echo value once $ONEVAR && false && echo value twice $ONEVAR"' '| grep value'  '| grep value' ';EVALPIPE=(${PIPESTATUS[@]})' ; echo ${EVALPIPE[*]}`
- also: pass LC_ALL=C LANG=C to avoid locale warnings

Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
