### PR TITLE
dev: enable tracing of functions return trap via env var

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -20,6 +20,13 @@ grep -q "[[:space:]]" <<<"${SRC}" && { echo "\"${SRC}\" contains whitespace. Not
 
 cd "${SRC}" || exit
 
+if [[ "${ARMBIAN_ENABLE_CALL_TRACING}" == "yes" ]]; then
+	set -T # inherit return/debug traps
+	mkdir -p "${SRC}"/output/debug
+	echo -n "" > "${SRC}"/output/debug/calls.txt
+	trap 'echo "${BASH_LINENO[@]}|${BASH_SOURCE[@]}|${FUNCNAME[@]}" >> ${SRC}/output/debug/calls.txt ;' RETURN
+fi
+
 if [[ -f "${SRC}"/lib/general.sh ]]; then
 
 	# shellcheck source=lib/general.sh


### PR DESCRIPTION
### dev: enable tracing of functions return trap via env var
- for some deep call stack investigation
- via environment variable `ARMBIAN_ENABLE_CALL_TRACING=yes` only. NOT parameter, too early for that.

Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
