### PR TITLE
Fix warning: "IEEE80211_MAX_AMPDU_BUF" redefined if rtl8723cs module build

### DIFF
--- a/patch/kernel/archive/sunxi-5.10/wifi-4002-realtek-8723cs-Fix-IEEE80211_MAX_AMPDU_BUF.patch
+++ b/patch/kernel/archive/sunxi-5.10/wifi-4002-realtek-8723cs-Fix-IEEE80211_MAX_AMPDU_BUF.patch
@@ -1,0 +1,31 @@
+From 4f15b08033441eeb2004c2a7ec19c91e1e75c332 Mon Sep 17 00:00:00 2001
+From: The-going <48602507+The-going@users.noreply.github.com>
+Date: Mon, 22 Nov 2021 18:53:11 +0300
+Subject: [PATCH] wifi 4002 realtek 8723cs Fix IEEE80211_MAX_AMPDU_BUF
+ redefined
+
+After v4.19 linux kernel, this definition is not required.
+The 1 drivers/net/wireless/realtek/rtlwifi/base.c file uses
+the variable IEEE80211_MAX_AMPDU_BUF_HT.
+
+See `git log -p b8042b3da925f390c1482b -3` command in
+git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git
+---
+ drivers/net/wireless/realtek/rtl8723cs/include/wifi.h | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/drivers/net/wireless/realtek/rtl8723cs/include/wifi.h b/drivers/net/wireless/realtek/rtl8723cs/include/wifi.h
+index 9d21a5afd..8ef0fd7ff 100644
+--- a/drivers/net/wireless/realtek/rtl8723cs/include/wifi.h
++++ b/drivers/net/wireless/realtek/rtl8723cs/include/wifi.h
+@@ -1006,7 +1006,6 @@ typedef enum _HT_CAP_AMPDU_DENSITY {
+  * According to IEEE802.11n spec size varies from 8K to 64K (in powers of 2)
+  */
+ #define IEEE80211_MIN_AMPDU_BUF 0x8
+-#define IEEE80211_MAX_AMPDU_BUF 0x40
+ 
+ 
+ /* Spatial Multiplexing Power Save Modes */
+-- 
+2.33.1
+

--- a/patch/kernel/archive/sunxi-5.15/wifi-4002-realtek-8723cs-Fix-IEEE80211_MAX_AMPDU_BUF.patch
+++ b/patch/kernel/archive/sunxi-5.15/wifi-4002-realtek-8723cs-Fix-IEEE80211_MAX_AMPDU_BUF.patch
@@ -1,0 +1,31 @@
+From 4f15b08033441eeb2004c2a7ec19c91e1e75c332 Mon Sep 17 00:00:00 2001
+From: The-going <48602507+The-going@users.noreply.github.com>
+Date: Mon, 22 Nov 2021 18:53:11 +0300
+Subject: [PATCH] wifi 4002 realtek 8723cs Fix IEEE80211_MAX_AMPDU_BUF
+ redefined
+
+After v4.19 linux kernel, this definition is not required.
+The 1 drivers/net/wireless/realtek/rtlwifi/base.c file uses
+the variable IEEE80211_MAX_AMPDU_BUF_HT.
+
+See `git log -p b8042b3da925f390c1482b -3` command in
+git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git
+---
+ drivers/net/wireless/realtek/rtl8723cs/include/wifi.h | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/drivers/net/wireless/realtek/rtl8723cs/include/wifi.h b/drivers/net/wireless/realtek/rtl8723cs/include/wifi.h
+index 9d21a5afd..8ef0fd7ff 100644
+--- a/drivers/net/wireless/realtek/rtl8723cs/include/wifi.h
++++ b/drivers/net/wireless/realtek/rtl8723cs/include/wifi.h
+@@ -1006,7 +1006,6 @@ typedef enum _HT_CAP_AMPDU_DENSITY {
+  * According to IEEE802.11n spec size varies from 8K to 64K (in powers of 2)
+  */
+ #define IEEE80211_MIN_AMPDU_BUF 0x8
+-#define IEEE80211_MAX_AMPDU_BUF 0x40
+ 
+ 
+ /* Spatial Multiplexing Power Save Modes */
+-- 
+2.33.1
+

--- a/patch/kernel/archive/sunxi-5.4/wifi-4002-realtek-8723cs-Fix-IEEE80211_MAX_AMPDU_BUF.patch
+++ b/patch/kernel/archive/sunxi-5.4/wifi-4002-realtek-8723cs-Fix-IEEE80211_MAX_AMPDU_BUF.patch
@@ -1,0 +1,31 @@
+From 4f15b08033441eeb2004c2a7ec19c91e1e75c332 Mon Sep 17 00:00:00 2001
+From: The-going <48602507+The-going@users.noreply.github.com>
+Date: Mon, 22 Nov 2021 18:53:11 +0300
+Subject: [PATCH] wifi 4002 realtek 8723cs Fix IEEE80211_MAX_AMPDU_BUF
+ redefined
+
+After v4.19 linux kernel, this definition is not required.
+The 1 drivers/net/wireless/realtek/rtlwifi/base.c file uses
+the variable IEEE80211_MAX_AMPDU_BUF_HT.
+
+See `git log -p b8042b3da925f390c1482b -3` command in
+git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git
+---
+ drivers/net/wireless/realtek/rtl8723cs/include/wifi.h | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/drivers/net/wireless/realtek/rtl8723cs/include/wifi.h b/drivers/net/wireless/realtek/rtl8723cs/include/wifi.h
+index 9d21a5afd..8ef0fd7ff 100644
+--- a/drivers/net/wireless/realtek/rtl8723cs/include/wifi.h
++++ b/drivers/net/wireless/realtek/rtl8723cs/include/wifi.h
+@@ -1006,7 +1006,6 @@ typedef enum _HT_CAP_AMPDU_DENSITY {
+  * According to IEEE802.11n spec size varies from 8K to 64K (in powers of 2)
+  */
+ #define IEEE80211_MIN_AMPDU_BUF 0x8
+-#define IEEE80211_MAX_AMPDU_BUF 0x40
+ 
+ 
+ /* Spatial Multiplexing Power Save Modes */
+-- 
+2.33.1
+


### PR DESCRIPTION
# Description

All warnings:
```
debug> grep warning: compilation.log | wc -l
152
```
A large number of garbage warnings:
```
debug> grep warning: compilation.log | grep IEEE80211_MAX_AMPDU_BUF | wc -l
103
```

After v4.19 linux kernel, this definition is not required.

Check:
```
list="$(find drivers/net/wireless/realtek/ -type f)"
for f in $list;do awk -v f=$f '/IEEE80211_MAX_AMPDU_BUF/{print f}' $f;done
drivers/net/wireless/realtek/rtlwifi/base.c
drivers/net/wireless/realtek/rtl8723cs/include/wifi.h
```

Only one drivers/net/wireless/realtek/rtlwifi/base.c file uses
the definition IEEE80211_MAX_AMPDU_BUF_HT.

or

See `git log -p b8042b3da925f390c1482b -3` command in
git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git

# How Has This Been Tested?

- [x] Test only build kernel
