### PR TITLE
Patches megous current branch to v5.10.82

### DIFF
--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -14,7 +14,7 @@ case $BRANCH in
 
 	current)
 		KERNEL_VERSION_LEVEL="5.10"
-		KERNELSWITCHOBJ="tag=v5.10.81"
+		KERNELSWITCHOBJ="tag=v5.10.82"
 	;;
 
 	edge)
@@ -23,15 +23,21 @@ case $BRANCH in
 	;;
 esac
 
-if [ "$KERNEL_VERSION_LEVEL" == "5.4" ]; then
-	KERNELSOURCE="https://github.com/megous/linux"
-	KERNELSOURCENAME='name=megous'
-	KERNELBRANCH="branch:orange-pi-$KERNEL_VERSION_LEVEL"
-else
-	KERNELSOURCE=$MAINLINE_KERNEL_SOURCE
-	KERNELSOURCENAME='name=origin'
-	KERNELBRANCH="branch:linux-${KERNEL_VERSION_LEVEL}.y"
-fi
+case "$KERNEL_VERSION_LEVEL" in
+
+	5.10|5.15)
+		KERNELSOURCE=$MAINLINE_KERNEL_SOURCE
+		KERNELSOURCENAME='name=origin'
+		KERNELBRANCH="branch:linux-${KERNEL_VERSION_LEVEL}.y"
+	;;
+
+	*)
+		KERNELSOURCE="https://github.com/megous/linux"
+		KERNELSOURCENAME='name=megous'
+		KERNELBRANCH="branch:orange-pi-$KERNEL_VERSION_LEVEL"
+	;;
+esac
+
 KERNELPATCHDIR='sunxi-'$BRANCH
 
 # An optional parameter for switching to a git object such as a tag, commit,

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -15,7 +15,7 @@ case $BRANCH in
 
 	current)
 		KERNEL_VERSION_LEVEL="5.10"
-		KERNELSWITCHOBJ="tag=v5.10.81"
+		KERNELSWITCHOBJ="tag=v5.10.82"
 	;;
 
 	edge)
@@ -24,15 +24,21 @@ case $BRANCH in
 	;;
 esac
 
-if [ "$KERNEL_VERSION_LEVEL" == "5.4" ]; then
-	KERNELSOURCE="https://github.com/megous/linux"
-	KERNELSOURCENAME='name=megous'
-	KERNELBRANCH="branch:orange-pi-$KERNEL_VERSION_LEVEL"
-else
-	KERNELSOURCE=$MAINLINE_KERNEL_SOURCE
-	KERNELSOURCENAME='name=origin'
-	KERNELBRANCH="branch:linux-${KERNEL_VERSION_LEVEL}.y"
-fi
+case "$KERNEL_VERSION_LEVEL" in
+
+	5.10|5.15)
+		KERNELSOURCE=$MAINLINE_KERNEL_SOURCE
+		KERNELSOURCENAME='name=origin'
+		KERNELBRANCH="branch:linux-${KERNEL_VERSION_LEVEL}.y"
+	;;
+
+	*)
+		KERNELSOURCE="https://github.com/megous/linux"
+		KERNELSOURCENAME='name=megous'
+		KERNELBRANCH="branch:orange-pi-$KERNEL_VERSION_LEVEL"
+	;;
+esac
+
 KERNELPATCHDIR='sunxi-'$BRANCH
 
 # An optional parameter for switching to a git object such as a tag, commit,

--- a/lib/compilation-prepare.sh
+++ b/lib/compilation-prepare.sh
@@ -24,7 +24,7 @@ compilation_prepare()
 	# Maintaining one from central location starting with 5.3+
 	# Temporally set for new "default->legacy,next->current" family naming
 
-	if linux-version compare "${version}" ge 5.12; then
+	if linux-version compare "${version}" ge 5.10; then
 
 		if test -d ${kerneldir}/debian
 		then
@@ -41,10 +41,6 @@ compilation_prepare()
 
 		chmod 755 ${kerneldir}/scripts/package/{builddeb,mkdebian}
 
-	elif linux-version compare "${version}" ge 5.10; then
-		display_alert "Adjusting" "packaging" "info"
-		cd "$kerneldir" || exit
-		process_patch_file "${SRC}/patch/misc/general-packaging-5.10.y.patch" "applying"
 	elif linux-version compare "${version}" ge 5.8.17 \
 		&& linux-version compare "${version}" le 5.9 \
 		|| linux-version compare "${version}" ge 5.9.2; then

--- a/patch/kernel/archive/sunxi-5.10/megous/ARM-dts-sunxi-Add-aliases-fro-mmc.patch
+++ b/patch/kernel/archive/sunxi-5.10/megous/ARM-dts-sunxi-Add-aliases-fro-mmc.patch
@@ -52,13 +52,13 @@ index 009e012b4691..8e7d20e814f0 100644
  #include <dt-bindings/thermal/thermal.h>
  
  / {
-+	aliases {
-+		mmc0 = &mmc0;
-+		mmc1 = &mmc1;
-+		mmc2 = &mmc2;
-+	};
++		aliases {
++				mmc0 = &mmc0;
++				mmc1 = &mmc1;
++				mmc2 = &mmc2;
++		};
 +
- 	cpu0_opp_table: opp_table0 {
+ 	cpu0_opp_table: opp-table-cpu {
  		compatible = "operating-points-v2";
  		opp-shared;
 -- 

--- a/patch/kernel/archive/sunxi-5.10/series.conf
+++ b/patch/kernel/archive/sunxi-5.10/series.conf
@@ -185,7 +185,7 @@
 	megous/misc-modem-power-GPIO-debugging-API.patch
 	megous/power-supply-cw2015-Silence-cw2015.patch
 	megous/media-cedrus-Fix-missing-cleanup-in-error-path.patch
-	megous/arm64-dts-pinebook-pro-Fix-display-initialization.patch
+-	megous/arm64-dts-pinebook-pro-Fix-display-initialization.patch
 	megous/media-cedrus-Fix-failure-to-clean-up-hardware-on-pro.patch
 	megous/arm64-dts-rk3399-pinebook-pro-Fix-USB-PD-charging.patch
 	megous/ARM-dts-sunxi-Add-mmc-aliases.patch


### PR DESCRIPTION
# Description
The purpose of this work is to correct warnings and possible errors at the compilation level.
Check the correctness of the kernel packages on the real board.

# How Has This Been Tested?

- [x] Test build
- [x] Test on the board

# Checklist:

- [ ] Adapt patches to the version.
- [ ] Fix trivial compiler warnings such as `warning: ISO C90`.
- [ ] Fix the [general-packaging](https://github.com/armbian/build/blob/master/patch/misc/general-packaging-5.10.y.patch) patch.

