### PR TITLE
Rename "load_addr" to "scriptaddr" in u-boot scripts to match the names with the u-boot default variables.

### DIFF
--- a/config/bootscripts/boot-jethub.cmd
+++ b/config/bootscripts/boot-jethub.cmd
@@ -3,7 +3,7 @@
 # Please edit /boot/armbianEnv.txt to set supported parameters
 #
 
-setenv load_addr      "0x12000000"
+setenv scriptaddr      "0x12000000"
 setenv kernel_addr_r  "0x14000000"
 setenv ramdisk_addr_r "0x1A000000"
 setenv fdt_addr_r     "0x10800000"
@@ -14,6 +14,7 @@ setenv verbosity "1"
 setenv console "serial"
 setenv rootfstype "ext4"
 setenv docker_optimizations "on"
+setenv prefix "boot/"
 
 # Show what uboot default fdtfile is
 echo "U-boot default fdtfile: ${fdtfile}"
@@ -21,8 +22,8 @@ echo "Current variant: ${variant}"
 
 # legacy kernel values from armbianEnv.txt
 if test -e ${devtype} ${devnum} ${prefix}armbianEnv.txt; then
-	load ${devtype} ${devnum} ${load_addr} ${prefix}armbianEnv.txt
-	env import -t ${load_addr} ${filesize}
+	load ${devtype} ${devnum} ${scriptaddr} ${prefix}armbianEnv.txt
+	env import -t ${scriptaddr} ${filesize}
 fi
 
 # get PARTUUID of first partition on SD/eMMC it was loaded from
@@ -53,16 +54,16 @@ load ${devtype} ${devnum} ${fdt_addr_r} ${prefix}dtb/${fdtfile}
 fdt addr ${fdt_addr_r}
 fdt resize 65536
 for overlay_file in ${overlays}; do
-	if load ${devtype} ${devnum} ${load_addr} ${prefix}dtb/amlogic/overlay/${overlay_prefix}-${overlay_file}.dtbo; then
+	if load ${devtype} ${devnum} ${scriptaddr} ${prefix}dtb/amlogic/overlay/${overlay_prefix}-${overlay_file}.dtbo; then
 		echo "Applying kernel provided DT overlay ${overlay_prefix}-${overlay_file}.dtbo"
-		fdt apply ${load_addr} || setenv overlay_error "true"
+		fdt apply ${scriptaddr} || setenv overlay_error "true"
 	fi
 done
 
 for overlay_file in ${user_overlays}; do
-	if load ${devtype} ${devnum} ${load_addr} ${prefix}overlay-user/${overlay_file}.dtbo; then
+	if load ${devtype} ${devnum} ${scriptaddr} ${prefix}overlay-user/${overlay_file}.dtbo; then
 		echo "Applying user provided DT overlay ${overlay_file}.dtbo"
-		fdt apply ${load_addr} || setenv overlay_error "true"
+		fdt apply ${scriptaddr} || setenv overlay_error "true"
 	fi
 done
 
@@ -70,14 +71,14 @@ if test "${overlay_error}" = "true"; then
 	echo "Error applying DT overlays, restoring original DT"
 	load ${devtype} ${devnum} ${fdt_addr_r} ${prefix}dtb/${fdtfile}
 else
-	if load ${devtype} ${devnum} ${load_addr} ${prefix}dtb/amlogic/overlay/${overlay_prefix}-fixup.scr; then
+	if load ${devtype} ${devnum} ${scriptaddr} ${prefix}dtb/amlogic/overlay/${overlay_prefix}-fixup.scr; then
 		echo "Applying kernel provided DT fixup script (${overlay_prefix}-fixup.scr)"
-		source ${load_addr}
+		source ${scriptaddr}
 	fi
 	if test -e ${devtype} ${devnum} ${prefix}fixup.scr; then
-		load ${devtype} ${devnum} ${load_addr} ${prefix}fixup.scr
+		load ${devtype} ${devnum} ${scriptaddr} ${prefix}fixup.scr
 		echo "Applying user provided fixup script (fixup.scr)"
-		source ${load_addr}
+		source ${scriptaddr}
 	fi
 fi
 

--- a/config/bootscripts/boot-meson64.cmd
+++ b/config/bootscripts/boot-meson64.cmd
@@ -3,7 +3,7 @@
 # Please edit /boot/armbianEnv.txt to set supported parameters
 #
 
-setenv load_addr "0x32000000"
+setenv scriptaddr "0x32000000"
 setenv kernel_addr_r "0x34000000"
 setenv fdt_addr_r "0x4080000"
 setenv overlay_error "false"
@@ -94,8 +94,8 @@ fi
 # legacy kernel values from boot.ini
 
 if test -e ${devtype} ${devnum} ${prefix}armbianEnv.txt; then
-	load ${devtype} ${devnum} ${load_addr} ${prefix}armbianEnv.txt
-	env import -t ${load_addr} ${filesize}
+	load ${devtype} ${devnum} ${scriptaddr} ${prefix}armbianEnv.txt
+	env import -t ${scriptaddr} ${filesize}
 fi
 
 # get PARTUUID of first partition on SD/eMMC it was loaded from
@@ -140,16 +140,16 @@ else
 	fdt addr ${fdt_addr_r}
 	fdt resize 65536
 	for overlay_file in ${overlays}; do
-		if load ${devtype} ${devnum} ${load_addr} ${prefix}dtb/amlogic/overlay/${overlay_prefix}-${overlay_file}.dtbo; then
+		if load ${devtype} ${devnum} ${scriptaddr} ${prefix}dtb/amlogic/overlay/${overlay_prefix}-${overlay_file}.dtbo; then
 			echo "Applying kernel provided DT overlay ${overlay_prefix}-${overlay_file}.dtbo"
-			fdt apply ${load_addr} || setenv overlay_error "true"
+			fdt apply ${scriptaddr} || setenv overlay_error "true"
 		fi
 	done
 
 	for overlay_file in ${user_overlays}; do
-		if load ${devtype} ${devnum} ${load_addr} ${prefix}overlay-user/${overlay_file}.dtbo; then
+		if load ${devtype} ${devnum} ${scriptaddr} ${prefix}overlay-user/${overlay_file}.dtbo; then
 			echo "Applying user provided DT overlay ${overlay_file}.dtbo"
-			fdt apply ${load_addr} || setenv overlay_error "true"
+			fdt apply ${scriptaddr} || setenv overlay_error "true"
 		fi
 	done
 
@@ -157,14 +157,14 @@ else
 		echo "Error applying DT overlays, restoring original DT"
 		load ${devtype} ${devnum} ${fdt_addr_r} ${prefix}dtb/${fdtfile}
 	else
-		if load ${devtype} ${devnum} ${load_addr} ${prefix}dtb/amlogic/overlay/${overlay_prefix}-fixup.scr; then
+		if load ${devtype} ${devnum} ${scriptaddr} ${prefix}dtb/amlogic/overlay/${overlay_prefix}-fixup.scr; then
 			echo "Applying kernel provided DT fixup script (${overlay_prefix}-fixup.scr)"
-			source ${load_addr}
+			source ${scriptaddr}
 		fi
 		if test -e ${devtype} ${devnum} ${prefix}fixup.scr; then
-			load ${devtype} ${devnum} ${load_addr} ${prefix}fixup.scr
+			load ${devtype} ${devnum} ${scriptaddr} ${prefix}fixup.scr
 			echo "Applying user provided fixup script (fixup.scr)"
-			source ${load_addr}
+			source ${scriptaddr}
 		fi
 	fi
 


### PR DESCRIPTION
# Description

Rename "load_addr" to "scriptaddr" in u-boot scripts to match the names with the u-boot default variables as proposed in #amlogic discord.
Cosmetic change, prepare to move to default u-boot addr vars.

Jira reference number [AR-1008]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Build and run on my boards ok
- [ ] Check other board

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1008]: https://armbian.atlassian.net/browse/AR-1008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ