### PR TITLE
Add packages needed to satisfy CONFIG_DEBUG_INFO_BTF.

### DIFF
--- a/config/templates/Dockerfile
+++ b/config/templates/Dockerfile
@@ -49,6 +49,7 @@ RUN apt-get update \
        dialog \
        distcc \
        dosfstools \
+       dwarves \
        f2fs-tools \
        fakeroot \
        flex \

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1231,7 +1231,7 @@ prepare_host()
 	nfs-kernel-server btrfs-progs ncurses-term p7zip-full kmod dosfstools libc6-dev-armhf-cross imagemagick \
 	curl patchutils liblz4-tool libpython2.7-dev linux-base swig aptly acl python3-dev python3-distutils \
 	locales ncurses-base pixz dialog systemd-container udev libfdt-dev libelf-dev lib32stdc++6 libc6-i386 lib32ncurses5 lib32tinfo5 \
-	bison libbison-dev flex libfl-dev cryptsetup gpg gnupg1 cpio aria2 pigz dirmngr python3-distutils jq distcc gdisk"
+	bison libbison-dev flex libfl-dev cryptsetup gpg gnupg1 cpio aria2 pigz dirmngr python3-distutils jq distcc gdisk dwarves"
 
 # build aarch64
   else
@@ -1244,7 +1244,7 @@ prepare_host()
 	curl patchutils liblz4-tool libpython2.7-dev linux-base swig aptly acl python3-dev \
 	locales ncurses-base pixz dialog systemd-container udev libfdt-dev libelf-dev libc6 qemu \
 	bison libbison-dev flex libfl-dev cryptsetup gpg gnupg1 cpio aria2 pigz \
-	dirmngr python3-distutils jq gdisk"
+	dirmngr python3-distutils jq gdisk dwarves"
 
 # build aarch64
   fi


### PR DESCRIPTION
Hi.


First of all, I hope you are fine and the same for your relatives.

I use armbian on lepotato to test a tool which interacts with [BPF kernel VM](https://ebpf.io/).
The default kernel does not come with the options I need, thus I cloned this repo and build it myself.
Particularly, I need `CONFIG_DEBUG_INFO_BTF` which in turns needs `libelf-dev` and `pahole` (which can be found in `dwarves` package) to be installed.
So, I added these two packages in container Dockerfile, so I do not have errors when using `./compile.sh docker`.

I understand my use case is really really specific (how many people on earth compile arm based kernel with `CONFIG_DEBUG_INFO_BTF`?), so I would totally understand if you find this contribution does not fit armbian goal.
On the other side, I thought it can benefit the community, so this is why I opened this PR.
Anyway, thank you for the review and this project.


Best regards.