### PR TITLE
JetHome: fix thermal zones in JetHub D1 dts file

### DIFF
--- a/patch/kernel/archive/meson64-5.10/jethome-0098-thermal.patch
+++ b/patch/kernel/archive/meson64-5.10/jethome-0098-thermal.patch
@@ -1,0 +1,43 @@
+diff --git a/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts b/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts
+index 52ebe371df26..561eec21b4de 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts
+@@ -134,23 +134,23 @@ cpu_critical: cpu-critical {
+ 					type = "critical";
+ 				};
+ 			};
+-		};
+ 
+-		cpu_cooling_maps: cooling-maps {
+-			map0 {
+-				trip = <&cpu_passive>;
+-				cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+-						<&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+-						<&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+-						<&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+-			};
++			cpu_cooling_maps: cooling-maps {
++				map0 {
++					trip = <&cpu_passive>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							<&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							<&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							<&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
+ 
+-			map1 {
+-				trip = <&cpu_hot>;
+-				cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+-						<&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+-						<&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+-						<&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				map1 {
++					trip = <&cpu_hot>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							<&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							<&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							<&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
+ 			};
+ 		};
+ 	};

--- a/patch/kernel/archive/meson64-5.15/jethome-0098-thermal.patch
+++ b/patch/kernel/archive/meson64-5.15/jethome-0098-thermal.patch
@@ -1,0 +1,43 @@
+diff --git a/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts b/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts
+index 52ebe371df26..561eec21b4de 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts
+@@ -134,23 +134,23 @@ cpu_critical: cpu-critical {
+ 					type = "critical";
+ 				};
+ 			};
+-		};
+ 
+-		cpu_cooling_maps: cooling-maps {
+-			map0 {
+-				trip = <&cpu_passive>;
+-				cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+-						<&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+-						<&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+-						<&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+-			};
++			cpu_cooling_maps: cooling-maps {
++				map0 {
++					trip = <&cpu_passive>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							<&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							<&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							<&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
+ 
+-			map1 {
+-				trip = <&cpu_hot>;
+-				cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+-						<&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+-						<&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+-						<&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				map1 {
++					trip = <&cpu_hot>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							<&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							<&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							<&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
+ 			};
+ 		};
+ 	};


### PR DESCRIPTION
# Description

Update kernel patches for JetHub D1, sync with linux-amlogic.
Changes only for JetHub devices.

Fixes cpu_cooling_maps misplace

Jira reference number [AR-1010]

# How Has This Been Tested?

- [X] Build jethub
- [X] Run jethub

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1010]: https://armbian.atlassian.net/browse/AR-1010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ