### PR TITLE
Optimisations after changing sunxi / sunxi64 to the mainline

### DIFF
--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -12,15 +12,9 @@ case $BRANCH in
 
 	legacy)  KERNEL_VERSION_LEVEL="5.4" ;;
 
-	current)
-		KERNEL_VERSION_LEVEL="5.10"
-		KERNELSWITCHOBJ="tag=v5.10.82"
-	;;
+	current) KERNEL_VERSION_LEVEL="5.10" ;;
 
-	edge)
-		KERNEL_VERSION_LEVEL="5.15"
-		KERNELSWITCHOBJ="tag=v5.15.5"
-	;;
+	edge) KERNEL_VERSION_LEVEL="5.15" ;;
 esac
 
 case "$KERNEL_VERSION_LEVEL" in

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -13,15 +13,10 @@ case $BRANCH in
 
 	legacy)  KERNEL_VERSION_LEVEL="5.4" ;;
 
-	current)
-		KERNEL_VERSION_LEVEL="5.10"
-		KERNELSWITCHOBJ="tag=v5.10.82"
-	;;
+	current) KERNEL_VERSION_LEVEL="5.10" ;;
 
-	edge)
-		KERNEL_VERSION_LEVEL="5.15"
-		KERNELSWITCHOBJ="tag=v5.15.5"
-	;;
+	edge) KERNEL_VERSION_LEVEL="5.15" ;;
+
 esac
 
 case "$KERNEL_VERSION_LEVEL" in
@@ -30,7 +25,6 @@ case "$KERNEL_VERSION_LEVEL" in
 		KERNELSOURCE=$MAINLINE_KERNEL_SOURCE
 		KERNELSOURCENAME='name=origin'
 		KERNELBRANCH="branch:linux-${KERNEL_VERSION_LEVEL}.y"
-	;;
 
 	*)
 		KERNELSOURCE="https://github.com/megous/linux"


### PR DESCRIPTION
# Description

We don't need to manually jump on patch versions, but we can do an automatic bump. If this is still needed, due to moving to mainline source.

Jira reference number [AR-1016]

# How Has This Been Tested?

- [ ] Run build all beta kernels locally

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1016]: https://armbian.atlassian.net/browse/AR-1016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ