### PR TITLE
Add new validation logic for correct selection.

### DIFF
--- a/config/sources/amd64.conf
+++ b/config/sources/amd64.conf
@@ -11,12 +11,3 @@ export UBOOT_USE_GCC="none" # required by configuration.sh
 
 # Default to mainline
 [[ -z $KERNELSOURCE ]] && KERNELSOURCE=$MAINLINE_KERNEL_SOURCE
-
-if [[ "$(uname -m)" == "aarch64" ]]; then
-	# Allow building amd64 on aarch64, but using system toolchain only
-	export KERNEL_COMPILER="x86_64-linux-gnu-"
-	export SKIP_EXTERNAL_TOOLCHAINS=yes
-	function add_host_dependencies__add_gcc_for_x86_on_aarch64_system_toolchain() {
-		export EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} gcc-x86-64-linux-gnu"
-	}
-fi

--- a/config/sources/amd64.conf
+++ b/config/sources/amd64.conf
@@ -1,10 +1,10 @@
-export ARCH=amd64                       #
-export ARCHITECTURE=x86                 # "kernel" arch
+export ARCH=amd64                       # Debian name $(dpkg-architecture -qDEB_HOST_ARCH)
+export ARCHITECTURE=x86_64              # "kernel" arch
 export QEMU_BINARY="qemu-x86_64-static" # Hopefully you have this installed.
 export KERNEL_COMPILER=' '              # hack: use single space for host gcc. won't work on arm64 hosts
 export KERNEL_USE_GCC=' '               # more hacks.
 export KERNEL_IMAGE_TYPE="bzImage"      # Ubuntu Standard
-export KERNEL_EXTRA_TARGETS="modules"   # default is "modules dtb" but x86 has no DTB
+export KERNEL_EXTRA_TARGETS="modules"   # default is "modules dtb" but x86_64 has no DTB
 #export INITRD_ARCH=amd64               # Used by u-boot for mkimage in initramfs. No u-boot for x86 yet.
 
 export UBOOT_USE_GCC="none" # required by configuration.sh

--- a/extensions/grub.sh
+++ b/extensions/grub.sh
@@ -22,7 +22,7 @@ function extension_prepare_config__prepare_flash_kernel() {
 
 	# BIOS-compatibility for amd64
 	if [[ "${ARCH}" == "amd64" ]]; then
-		export UEFI_GRUB_TARGET="x86_64-efi" # Default for x86
+		export UEFI_GRUB_TARGET="x86_64-efi" # Default for x86_64
 		if [[ "${UEFI_ENABLE_BIOS_AMD64}" == "yes" ]]; then
 			export uefi_packages="${uefi_packages} grub-pc-bin grub-pc"
 			export UEFI_GRUB_TARGET_BIOS="i386-pc"

--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -411,11 +411,16 @@ compile_kernel()
 
 	display_alert "Compiling $BRANCH kernel" "$version" "info"
 
-	# if _building_ on amd64, find the toolchain, but not if _targeting_ x86 itself. in that case just use system gcc
-	if [[ $(dpkg --print-architecture) == amd64 ]] && [[ "${ARCHITECTURE}" != "x86" ]]; then
+	# compare with the architecture of the current Debian node
+	# if it matches we use the system compiler
+	if $(dpkg-architecture -e $ARCH); then
+		display_alert "Native compilation"
+	elif [[ $(dpkg --print-architecture) == amd64 ]]; then
 		local toolchain
 		toolchain=$(find_toolchain "$KERNEL_COMPILER" "$KERNEL_USE_GCC")
 		[[ -z $toolchain ]] && exit_with_error "Could not find required toolchain" "${KERNEL_COMPILER}gcc $KERNEL_USE_GCC"
+	else
+		exit_with_error "Architecture [$ARCH] is not supported"
 	fi
 
 	display_alert "Compiler version" "${KERNEL_COMPILER}gcc $(eval env PATH="${toolchain}:${PATH}" "${KERNEL_COMPILER}gcc" -dumpversion)" "info"

--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -550,7 +550,7 @@ if [[ $DOWNLOAD_MIRROR == "bfsu" ]] ; then
 	UBUNTU_MIRROR='mirrors.bfsu.edu.cn/ubuntu-ports/'
 fi
 
-if [[ "${ARCHITECTURE}" == "x86" ]]; then
+if [[ "${ARCH}" == "amd64" ]]; then
 	UBUNTU_MIRROR='archive.ubuntu.com/ubuntu' # ports are only for non-amd64, of course.
 fi
 

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -123,14 +123,14 @@ exit_with_error()
 	display_alert "ERROR in function $_function" "$stacktrace" "err"
 	display_alert "$_description" "$_highlight" "err"
 	display_alert "Process terminated" "" "info"
-	
+
 	if [[ "${ERROR_DEBUG_SHELL}" == "yes" ]]; then
 		display_alert "MOUNT" "${MOUNT}" "err"
 		display_alert "SDCARD" "${SDCARD}" "err"
 		display_alert "Here's a shell." "debug it" "err"
 		bash < /dev/tty || true
 	fi
-	
+
 	# TODO: execute run_after_build here?
 	overlayfs_wrapper "cleanup"
 	# unlock loop device access in case of starvation
@@ -239,7 +239,7 @@ create_sources_list()
 		display_alert "Disabling armbian repo" "${ARCH}-${RELEASE}" "wrn"
 		mv "${SDCARD}"/etc/apt/sources.list.d/armbian.list "${SDCARD}"/etc/apt/sources.list.d/armbian.list.disabled
 	fi
-	
+
 	display_alert "Adding Armbian repository and authentication key" "/etc/apt/sources.list.d/armbian.list" "info"
 	cp "${SRC}"/config/armbian.key "${basedir}"
 	chroot "${basedir}" /bin/bash -c "cat armbian.key | apt-key add - > /dev/null 2>&1"
@@ -1202,7 +1202,7 @@ prepare_host()
 	if [[ $(dpkg --print-architecture) != amd64 ]]; then
 		display_alert "Please read documentation to set up proper compilation environment"
 		display_alert "https://www.armbian.com/using-armbian-tools/"
-		exit_with_error "Running this tool on non x86-x64 build host is not supported"
+		exit_with_error "Running this tool on non x86_64 build host is not supported"
 	fi
 
 # build aarch64
@@ -1315,7 +1315,7 @@ prepare_host()
 
 	local deps=()
 	local installed=$(dpkg-query -W -f '${db:Status-Abbrev}|${binary:Package}\n' '*' 2>/dev/null | grep '^ii' | awk -F '|' '{print $2}' | cut -d ':' -f 1)
-	
+
 	export EXTRA_BUILD_DEPS=""
 	call_extension_method "add_host_dependencies" <<- 'ADD_HOST_DEPENDENCIES'
 	*run before installing host dependencies*

--- a/packages/armbian/builddeb
+++ b/packages/armbian/builddeb
@@ -9,6 +9,15 @@
 # /etc/kernel/{pre,post}{inst,rm}.d/ directories (or an alternative location
 # specified in KDEB_HOOKDIR) that will be called on package install and
 # removal.
+#
+# armbian/bulddeb 0.1
+# Copyright 2021 Leonid Gasheev (The-going <48602507+The-going@users.noreply.github.com>)
+#
+# In order to make a choice, it is enough for us to check the value
+# of the variable in the kernel configuration file and Debian's own variables.
+#
+# Uncomment the next line to see all the current values.
+# echo "$(dpkg-architecture -l)" >&2
 
 set -e
 
@@ -22,6 +31,14 @@ if_enabled_echo() {
 	elif [ $# -ge 3 ]; then
 		echo -n "$3"
 	fi
+}
+
+is_native() {
+	dpkg-architecture -qDEB_BUILD_ARCH | grep -q "$(dpkg-architecture -qDEB_HOST_ARCH)"
+}
+
+is_build_on_amd64() {
+	dpkg-architecture -qDEB_BUILD_ARCH | grep -q amd64
 }
 
 create_package() {

--- a/packages/armbian/builddeb
+++ b/packages/armbian/builddeb
@@ -84,7 +84,7 @@ EOT
 	chmod 775 $pdir/DEBIAN/postinst
 	fi
 
-	# Create postinstall prerm script for headers
+	# Create postinst prerm script for headers
 	if [ "$3" = "headers" ]; then
 
 	# Set the time for all files to the current time.
@@ -149,10 +149,14 @@ deploy_kernel_headers () {
 		fi
 	} > debian/hdrobjfiles
 
-	(
+	if is_native; then
+		echo "info: Build native: Skip headers-debian-byteshift.patch" >&2
+	elif is_build_on_amd64; then
+		(
 		cd $destdir
 		patch -p1 < /tmp/headers-debian-byteshift.patch
-	)
+		)
+	fi
 
 	tar -c -f - -C $srctree -T debian/hdrsrcfiles | tar -xf - -C $destdir
 	tar -c -f - -T debian/hdrobjfiles | tar -xf - -C $destdir
@@ -365,7 +369,8 @@ if [ "$ARCH" != "um" ]; then
 	if is_enabled CONFIG_MODULES; then
 
 		if is_native ; then
-			# echo "Skip clean scripts folder" >&2
+			# echo "Skip scripts folder cleaning" >&2
+			# echo "Skip creating postinst prerm scripts for headers" >&2
 			deploy_kernel_headers $kernel_headers_dir
 			create_package $kernel_headers_packagename $kernel_headers_dir
 		else

--- a/packages/armbian/builddeb
+++ b/packages/armbian/builddeb
@@ -354,7 +354,10 @@ EOT
 create_package "$packagename" "$tmpdir"
 
 if [ "$ARCH" != "um" ]; then
-	create_package "$dtb_packagename" "$dtb_dir" "dtb"
+
+	if [ "$(cat debian/arch)" != "amd64" ]; then
+		create_package "$dtb_packagename" "$dtb_dir" "dtb"
+	fi
 
 	deploy_libc_headers $libc_headers_dir
 	create_package $libc_headers_packagename $libc_headers_dir

--- a/packages/armbian/builddeb
+++ b/packages/armbian/builddeb
@@ -307,15 +307,21 @@ EOF
 	chmod 755 "$tmpdir/DEBIAN/$script"
 done
 
-##
-## Create sym link to kernel image
-##
-sed -e "s/exit 0//g" -i $tmpdir/DEBIAN/postinst
-cat >> $tmpdir/DEBIAN/postinst <<- EOT
-ln -sf $(basename $installed_image_path) /boot/$image_name 2> /dev/null || mv /$installed_image_path /boot/$image_name
-touch /boot/.next
-exit 0
-EOT
+if is_enabled CONFIG_EFI; then
+	echo "info: UEFI support enabled." >&2
+	echo "info: Skip symbolic link creation of the postinst script" >&2
+else
+	##
+	## Create sym link to kernel image
+	##
+	echo "info: Create symbolic link in the postinst script." >&2
+	sed -e "s/exit 0//g" -i $tmpdir/DEBIAN/postinst
+	cat >> $tmpdir/DEBIAN/postinst <<- EOT
+	ln -sf $(basename $installed_image_path) /boot/$image_name 2> /dev/null || mv /$installed_image_path /boot/$image_name
+	touch /boot/.next
+	exit 0
+	EOT
+fi
 
 ##
 ## FAT install workaround

--- a/packages/armbian/builddeb
+++ b/packages/armbian/builddeb
@@ -363,11 +363,18 @@ if [ "$ARCH" != "um" ]; then
 	create_package $libc_headers_packagename $libc_headers_dir
 
 	if is_enabled CONFIG_MODULES; then
-		# Clean up the executables that are left over from
-		# cross-compilation for a different host architecture.
-		(cd $srctree; make M=scripts clean;)
-		deploy_kernel_headers $kernel_headers_dir
-		create_package $kernel_headers_packagename $kernel_headers_dir "headers"
+
+		if is_native ; then
+			# echo "Skip clean scripts folder" >&2
+			deploy_kernel_headers $kernel_headers_dir
+			create_package $kernel_headers_packagename $kernel_headers_dir
+		else
+			# Clean up the executables that are left over from
+			# cross-compilation for a different host architecture.
+			(cd $srctree; make M=scripts clean;)
+			deploy_kernel_headers $kernel_headers_dir
+			create_package $kernel_headers_packagename $kernel_headers_dir "headers"
+		fi
 	fi
 
 fi


### PR DESCRIPTION
# Description

This logic allows you to run on amd64 for arm and make an assembly for your own architecture on which the build system is running.

# How Has This Been Tested?

- [x] Test build on amd64 for amd64
- [x] Test build on amd64 for arm, arm64
