### PR TITLE
bcm2711: allow building KERNEL_ONLY=yes even with unsupported RELEASE

### DIFF
--- a/config/sources/families/bcm2711.conf
+++ b/config/sources/families/bcm2711.conf
@@ -82,7 +82,9 @@ extension_prepare_config__prepare_rpi_flash_kernel() {
 			fi
 		fi
 	else
-		display_alert "Can't use release for ${BOARD}. Try: ${usable_releases}" "${RELEASE}" "err"
-		exit 27
+		if [[ "${KERNEL_ONLY}" != "yes" ]]; then
+			display_alert "Can't use release for ${BOARD}. Try: ${usable_releases}" "${RELEASE}" "err"
+			exit 27
+		fi
 	fi
 }


### PR DESCRIPTION
- Check for compatibility is only relevant when building complete board or userspace, not kernel.
- this should allow CI to complete, finally
