### PR TITLE
amd64: fixes for REPOSITORY_INSTALL scenario, don't disable amd64 repo

### DIFF
--- a/lib/distributions.sh
+++ b/lib/distributions.sh
@@ -312,7 +312,9 @@ PRE_INSTALL_KERNEL_DEBS
 			VER=$(dpkg-deb -f "${SDCARD}"/var/cache/apt/archives/linux-image-${BRANCH}-${LINUXFAMILY}*_${ARCH}.deb Source)
 			VER="${VER/-$LINUXFAMILY/}"
 			VER="${VER/linux-/}"
-			install_deb_chroot "linux-dtb-${BRANCH}-${LINUXFAMILY}" "remote"
+			if [[ "${ARCH}" != "amd64" ]]; then # amd64 does not have dtb package, see packages/armbian/builddeb:355
+				install_deb_chroot "linux-dtb-${BRANCH}-${LINUXFAMILY}" "remote"
+			fi
 			[[ $INSTALL_HEADERS == yes ]] && install_deb_chroot "linux-headers-${BRANCH}-${LINUXFAMILY}" "remote"
 		fi
 	}

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -234,8 +234,8 @@ create_sources_list()
 	# replace local package server if defined. Suitable for development
 	[[ -n $LOCAL_MIRROR ]] && echo "deb http://$LOCAL_MIRROR $RELEASE main ${RELEASE}-utils ${RELEASE}-desktop" > "${basedir}"/etc/apt/sources.list.d/armbian.list
 
-	# disable repo if amd64 or SKIP_ARMBIAN_REPO=yes
-	if [[ "${ARCH}" == "amd64" ]] || [[ "${SKIP_ARMBIAN_REPO}" == "yes" ]]; then
+	# disable repo if SKIP_ARMBIAN_REPO=yes
+	if [[ "${SKIP_ARMBIAN_REPO}" == "yes" ]]; then
 		display_alert "Disabling armbian repo" "${ARCH}-${RELEASE}" "wrn"
 		mv "${SDCARD}"/etc/apt/sources.list.d/armbian.list "${SDCARD}"/etc/apt/sources.list.d/armbian.list.disabled
 	fi


### PR DESCRIPTION
- now we have proper amd64 repo published!, remove disable
- amd64 does not have dtb package anymore, don't try to install it from repo

Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
