### PR TITLE
Github actions - adding desktop package builder

### DIFF
--- a/.github/workflows/build-beta-desktop.yml
+++ b/.github/workflows/build-beta-desktop.yml
@@ -1,0 +1,137 @@
+name: Build Beta Desktop Packages
+
+on:
+#  schedule:
+#    - cron:  '0 4 * * *'
+
+  workflow_dispatch:
+
+jobs:
+
+  Prepare:
+
+    name: Find desktop variants
+    runs-on: ubuntu-latest
+    #if: ${{ github.repository_owner == 'Armbian' }}
+    outputs:
+      matrix: ${{steps.list_dirs.outputs.matrix}}
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          repository: armbian/build
+          ref: nightly
+
+      - name: Build desktops
+        id: list_dirs
+        run: |
+
+          MATRIX=$(
+          set +e
+          releases=($(find config/distributions -mindepth 1 -maxdepth 1 -type d | sed 's/.*\///' ))
+          for i in ${releases[@]}
+          do	
+            environments=($([[ -d config/desktop/$i/environments ]] && ls -1 config/desktop/$i/environments))
+            for j in ${environments[@]}
+            do
+              echo  "$i:$j"
+            done
+          done)
+          echo ::set-output name=matrix::$(for x in $(echo "${MATRIX}"); do echo $x; done|jq -cnR '[inputs | select(length>0)]' | jq)
+          
+  Desktop:
+  
+      name: "Build package"
+      needs: [ Prepare ]
+      runs-on: ubuntu-latest
+      timeout-minutes: 480
+      strategy:
+        fail-fast: false
+        matrix: 
+          node: ${{fromJson(needs.Prepare.outputs.matrix)}}
+
+      steps:
+      
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          repository: armbian/build
+          ref: nightly
+          path: build
+          clean: true
+
+      - name: Checkout support scripts
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          repository: armbian/scripts
+          path: scripts
+          clean: true
+
+      - name: Sync
+        run: |
+          mkdir -p build/userpatches
+          sudo cp scripts/configs/* build/userpatches/
+          
+      - name: Pull Docker image
+        run: |
+
+          sudo docker pull ghcr.io/armbian/build:$(cat build/VERSION | sed 's/trunk.*/trunk/')
+
+      - name: Build package
+        run: |
+
+          cd build
+          CHUNK="${{ matrix.node }}"              
+          RELEASE=$(echo $CHUNK | cut -d":" -f1)
+          DE=$(echo $CHUNK | cut -d":" -f2)
+          echo "RELEASE=${RELEASE}" >> $GITHUB_ENV
+          echo "DE=${DE}" >> $GITHUB_ENV
+          sed -i "s/-it --rm/-i --rm/" userpatches/config-docker.conf         
+          ./compile.sh docker \
+          BSP_BUILD="yes" \
+          BETA="yes" \
+          RELEASE="${RELEASE}" \
+          DESKTOP_ENVIRONMENT_CONFIG_NAME="config_base" \
+          BUILD_DESKTOP="yes" \
+          DESKTOP_ENVIRONMENT="${DE}" \
+          KERNEL_ONLY="yes" \
+          KERNEL_CONFIGURE="no" \
+          BOARD="uefi-x86" \
+          BRANCH="current" \
+          SKIP_EXTERNAL_TOOLCHAINS="yes" \
+          OFFLINE_WORK="yes" \
+          REPOSITORY_INSTALL="u-boot,kernel,armbian-config,armbian-firmware" \
+          DESKTOP_APPGROUPS_SELECTED="" \
+          EXPERT="yes"
+
+          if [[ $? -eq 0 ]]; then
+            echo "UPLOAD=true" >> $GITHUB_ENV
+          fi
+      
+      - name: Upload build artifacts
+        if: ${{ matrix.node != 'none:none' }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: armbian-${{ env.RELEASE }}-desktop-${{ env.DE }}
+          path: build/output/debs-beta/${{ env.RELEASE }}/armbian-${{ env.RELEASE }}-desktop-${{ env.DE }}_*.deb
+          if-no-files-found: ignore
+          retention-days: 10
+
+      - name: Install SSH key for storage
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.KEY_TORRENTS }}
+          known_hosts: ${{ secrets.KNOWN_HOSTS_UPLOAD }}
+          if_key_exists: replace
+
+      - name: Deploy to server
+        if: ${{ matrix.node != 'none:none' && env.UPLOAD == true }}
+        run: |
+
+          sudo apt-get -y -qq install lftp
+          lftp -u upload, -e "set net:timeout 10;set net:max-retries 16;mirror --Remove-source-files -R --no-empty-dirs --parallel=8 --no-perms $(pwd)/build/output/debs/ debs/ ;bye" sftp://users.armbian.com
+          lftp -u upload, -e "set net:timeout 10;set net:max-retries 16;mirror --Remove-source-files -R --no-empty-dirs --parallel=8 --no-perms $(pwd)/build/output/debs-beta/ debs-beta/ ;bye" sftp://users.armbian.com

--- a/.github/workflows/build-kernel-on-merge-request.yml
+++ b/.github/workflows/build-kernel-on-merge-request.yml
@@ -160,13 +160,4 @@ jobs:
           name: ${FAMILY}-${BRANCH}
           path: build/output/debs-beta/linux-*
           if-no-files-found: ignore
-          retention-days: 14
-
-      - name: Upload hash
-        if: ${{ matrix.node != 'none:none:none' }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: hash
-          path: build/cache/hash-beta/linux-*
-          if-no-files-found: ignore
-          retention-days: 14
+          retention-days: 30

--- a/.github/workflows/build-u-boot.yml
+++ b/.github/workflows/build-u-boot.yml
@@ -5,7 +5,18 @@ on:
 
 jobs:
 
+  Merge:
+    uses: armbian/scripts/.github/workflows/merge-from-branch.yml@master
+
+    with:
+      branch: 'nightly'
+
+    secrets:
+      GPG_KEY2: ${{ secrets.GPG_KEY2 }}
+      GPG_PASSPHRASE2: ${{ secrets.GPG_PASSPHRASE2 }}
+
   Prepare:
+    needs: [ Merge ]
     runs-on: [self-hosted, Linux, small]
     if: ${{ github.repository_owner == 'armbian' }}
     outputs:
@@ -20,14 +31,6 @@ jobs:
           path: build
           ref: nightly
           clean: false
-
-      - name: Cache build configurations
-        uses: actions/cache@v2
-        env:
-          cache-name: build-u-boot
-        with:
-          path: build-u-boot
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.run_id }}
 
       - name: Prepare matrix
         id: list_dirs
@@ -74,16 +77,6 @@ jobs:
           [[ -d build/output/images ]] && sudo rm -rf build/output/images/* || true
  
  
-      - name: Cache build configurations
-        uses: actions/cache@v2
-        env:
-          cache-name: build-u-boot
-        with:
-          path: build-u-boot
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.run_id }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.run_id }}
- 
       - name: Checkout Armbian build script
 
         uses: actions/checkout@v2
@@ -103,23 +96,20 @@ jobs:
           echo "BRANCH=$BRANCH" >> $GITHUB_ENV
           cd build
           [[ ! -f .ignore_changes ]] && sudo touch .ignore_changes
-          #sudo rm -rf cache/source/u-boot cache/source/linux-* output/debs/* output/debs-beta/*
           sudo rm -rf output/debs/* output/debs-beta/*
-          #./compile.sh KERNEL_ONLY="yes" BOARD="bananapi" BRANCH="current" KERNEL_CONFIGURE="no" REPOSITORY_INSTALL="u-boot,kernel" 'prepare_host_basic'
           if [[ $(curl -s http://ifconfig.me) == "93.103.15.56" ]]; then
               sudo mkdir -p cache/toolchain cache/rootfs || true
               ! sudo mountpoint -q cache/toolchain && sudo mount nas:/tank/armbian/toolchain.armbian.com cache/toolchain -o rsize=32768,wsize=32768,timeo=5,retrans=2,actimeo=60,retry=15 || true
               ! sudo mountpoint -q cache/rootfs && sudo mount nas:/tank/armbian/dl.armbian.com/_rootfs cache/rootfs -o rsize=32768,wsize=32768,timeo=5,retrans=2,actimeo=60,retry=15 || true
           fi  
           ./compile.sh ARMBIAN_MIRROR="https://github.com/armbian/mirror/releases/download/" BOARD="$BOARD" PRIVATE_CCACHE="yes" BETA="yes" KERNEL_ONLY="yes" BRANCH="$BRANCH" KERNEL_CONFIGURE="no" OFFLINE="no" REPOSITORY_INSTALL="kernel,bsp,armbian-zsh,armbian-config,armbian-firmware"
-          mkdir -p ../build-u-boot
-          cp output/debs-beta/linux-u-boot-${BRANCH}-${BOARD}_$(cat VERSION)_* ../build-u-boot/
 
       - name: upload artefacts
         uses: actions/upload-artifact@v2
         with:
           name: u-boot-${{ env.BOARD }}-${{ env.BRANCH }}
           path: build/output/debs-beta/*u-boot*
+          if-no-files-found: ignore
 
       - name: Deploy to server
         if: ${{ success() }}

--- a/.github/workflows/update-repository.yml
+++ b/.github/workflows/update-repository.yml
@@ -11,7 +11,7 @@ jobs:
     repository:
       name: Update stable package repository
       runs-on: [self-hosted, Linux, local]
-      #if: ${{ github.repository_owner == 'Armbian' && github.event.workflow_run.conclusion == 'success' }}
+      if: ${{ github.repository_owner == 'Armbian' && github.event.workflow_run.conclusion == 'success' }}
       steps:
 
         - name: Install SSH key for repository
@@ -28,7 +28,7 @@ jobs:
     repository-beta:
       name: Update beta package repository
       runs-on: [self-hosted, Linux, local]
-      #if: ${{ github.repository_owner == 'Armbian' && github.event.workflow_run.conclusion == 'success' }}
+      if: ${{ github.repository_owner == 'Armbian' && github.event.workflow_run.conclusion == 'success' }}
       steps:
 
         - name: Install SSH key for repository


### PR DESCRIPTION
# Description

Desktop package caching is essential for building or installing desktops from CLI. Enable at beta repository for start. MR also contains a few cleaning actions.

Jira reference number [AR-590]

# How Has This Been Tested?

Manual tests.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-590]: https://armbian.atlassian.net/browse/AR-590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ