### PR TITLE
Add new options to handle mirror selection better

### DIFF
--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -91,11 +91,20 @@ esac
 
 MAINLINE_KERNEL_DIR='linux-mainline'
 
-if [[ $USE_GITHUB_UBOOT_MIRROR == yes ]]; then
-	MAINLINE_UBOOT_SOURCE='https://github.com/u-boot/u-boot'
-else
-	MAINLINE_UBOOT_SOURCE='https://source.denx.de/u-boot/u-boot.git'
-fi
+[[ $USE_GITHUB_UBOOT_MIRROR == yes ]] && UBOOT_MIRROR=github
+
+case $UBOOT_MIRROR in
+	gitee)
+		MAINLINE_UBOOT_SOURCE='https://gitee.com/mirrors/u-boot.git'
+		;;
+	github)
+		MAINLINE_UBOOT_SOURCE='https://github.com/u-boot/u-boot'
+		;;
+	*)
+		MAINLINE_UBOOT_SOURCE='https://source.denx.de/u-boot/u-boot.git'
+		;;
+esac
+
 MAINLINE_UBOOT_DIR='u-boot'
 
 # Let's set default data if not defined in board configuration above

--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -67,6 +67,20 @@ fi
 # small SD card with kernel, boot script and .dtb/.bin files
 [[ $ROOTFS_TYPE == nfs ]] && FIXED_IMAGE_SIZE=64
 
+# Since we are having too many options for mirror management,
+# then here is yet another mirror related option.
+# Respecting user's override in case a mirror is unreachable.
+case $REGIONAL_MIRROR in
+	china)
+		[[ -z $USE_MAINLINE_GOOGLE_MIRROR ]] && [[ -z $MAINLINE_MIRROR ]] && MAINLINE_MIRROR=tuna
+		[[ -z $USE_GITHUB_UBOOT_MIRROR ]] && [[ -z $UBOOT_MIRROR ]] && UBOOT_MIRROR=gitee
+		[[ -z $GITHUB_MIRROR ]] && GITHUB_MIRROR=fastgit
+		[[ -z $DOWNLOAD_MIRROR ]] && DOWNLOAD_MIRROR=china
+		;;
+	*)
+		;;
+esac
+
 # used by multiple sources - reduce code duplication
 [[ $USE_MAINLINE_GOOGLE_MIRROR == yes ]] && MAINLINE_MIRROR=google
 

--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -107,6 +107,21 @@ esac
 
 MAINLINE_UBOOT_DIR='u-boot'
 
+case $GITHUB_MIRROR in
+	fastgit)
+		GITHUB_SOURCE='https://hub.fastgit.org/'
+		;;
+	gitclone)
+		GITHUB_SOURCE='https://gitclone.com/github.com/'
+		;;
+	cnpmjs)
+		GITHUB_SOURCE='https://github.com.cnpmjs.org/'
+		;;
+	*)
+		GITHUB_SOURCE='https://github.com/'
+		;;
+esac
+
 # Let's set default data if not defined in board configuration above
 [[ -z $OFFSET ]] && OFFSET=4 # offset to 1st partition (we use 4MiB boundaries by default)
 ARCH=armhf

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -425,6 +425,9 @@ fetch_from_repo()
 	local ref=$3
 	local ref_subdir=$4
 
+	# Set GitHub mirror before anything else touches $url
+	url=${url//'https://github.com/'/$GITHUB_SOURCE}
+
 	if [ "$dir" == "linux-mainline" ] && [[ "$LINUXFAMILY" == sunxi* ]]; then
 		unset LINUXSOURCEDIR
 		LINUXSOURCEDIR="linux-mainline/$KERNEL_VERSION_LEVEL"


### PR DESCRIPTION
# Description

Add new option UBOOT_MIRROR to select different mirror for U-Boot, similar to MAINLINE_MIRROR option. Added mainly to support a new Chinese mirror to speed up download.

 - set to `github` to use mirror provided by Github, the same as `USE_GITHUB_UBOOT_MIRROR=yes`.
 - set to `gitee` to use mirror provided by Gitee, a Chinese git service.
 - leave it unset to use offical `source.denx.de`.

Additionally GITHUB_MIRROR option allows users to choose from fastgit, gitclone, and cnpmjs as their GitHub speed-up option.

Finally REGIONAL_MIRROR for Chinese user to set 4 mirror options at once. If user explicitly specifies a mirror then that one will be used instead.

# How Has This Been Tested?

`./compile.sh docker BOARD=radxa-zero BRANCH=current RELEASE=bullseye BUILD_MINIMAL=yes BUILD_DESKTOP=no KERNEL_ONLY=no KERNEL_CONFIGURE=no DOWNLOAD_MIRROR=china MAINLINE_MIRROR=tuna UBOOT_MIRROR=gitee GITHUB_MIRROR=fastgit` followed by:

`./compile.sh docker BOARD=radxa-zero BRANCH=current RELEASE=bullseye BUILD_MINIMAL=yes BUILD_DESKTOP=no KERNEL_ONLY=no KERNEL_CONFIGURE=no REGIONAL_MIRROR=china`

Both completes without error.