### PR TITLE
Source /etc/armbian-release before the motd conf file

### DIFF
--- a/packages/bsp/common/etc/update-motd.d/10-armbian-header
+++ b/packages/bsp/common/etc/update-motd.d/10-armbian-header
@@ -12,13 +12,13 @@
 THIS_SCRIPT="header"
 MOTD_DISABLE=""
 
+. /etc/armbian-release
+
 [[ -f /etc/default/armbian-motd ]] && . /etc/default/armbian-motd
 
 for f in $MOTD_DISABLE; do
 	[[ $f == $THIS_SCRIPT ]] && exit 0
 done
-
-. /etc/armbian-release
 
 KERNELID=$(uname -r)
 


### PR DESCRIPTION
# Description

This way the user can set $BOARD_NAME in /etc/default/armbian-motd. This is useful because e.g. the Odroid HC2 is internally an Odroid XU4, and in /etc/armbian-release it shows up as Odroid XU4.

# How Has This Been Tested?

Setting the variable in /etc/default/armbian-motd works, in this scenario
