### PR TITLE
Improve CI test builds

### DIFF
--- a/.github/workflows/build-test-image-docker.yml
+++ b/.github/workflows/build-test-image-docker.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         board: [virtual-qemu]
         release: [focal,buster,bullseye,hirsute,jammy]
-        branch: [edge]
+        branch: [current]
     if: ${{ github.repository_owner == 'Armbian' }}
     name: Variant
     runs-on: ubuntu-latest    

--- a/.github/workflows/build-test-image-docker.yml
+++ b/.github/workflows/build-test-image-docker.yml
@@ -19,10 +19,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        board: [uefi-arm64,uefi-x86]
+        board: [uefi-arm64,uefi-x86,virtual-qemu]
         release: [focal,buster,bullseye,hirsute,jammy]
         branch: [current]
-        desktop: [yes,no]
+        desktop: [yes]
     if: ${{ github.repository_owner == 'Armbian' }}
     name: Variant
     runs-on: ubuntu-latest    

--- a/.github/workflows/build-test-image-docker.yml
+++ b/.github/workflows/build-test-image-docker.yml
@@ -55,7 +55,7 @@ jobs:
 
           sudo docker pull ghcr.io/armbian/build:$(cat build/VERSION)
 
-      - name: Build Qemu virtual image
+      - name: Build test image
         run: |
 
           cd build

--- a/.github/workflows/build-test-image-docker.yml
+++ b/.github/workflows/build-test-image-docker.yml
@@ -3,7 +3,7 @@ on:
   
   # Trigger after Docker image was built
   workflow_run:
-    workflows: ["Build test with Docker"]
+    workflows: ["Build Docker image"]
     types:
       - completed
   

--- a/.github/workflows/build-test-image-docker.yml
+++ b/.github/workflows/build-test-image-docker.yml
@@ -1,4 +1,4 @@
-name: Build With Docker Image
+name: Build test with Docker
 on:
   
   # Trigger after Docker image was built

--- a/.github/workflows/build-test-image-docker.yml
+++ b/.github/workflows/build-test-image-docker.yml
@@ -22,6 +22,7 @@ jobs:
         board: [uefi-arm64,uefi-x86]
         release: [focal,buster,bullseye,hirsute,jammy]
         branch: [current]
+        desktop: [yes,no]
     if: ${{ github.repository_owner == 'Armbian' }}
     name: Variant
     runs-on: ubuntu-latest    
@@ -89,20 +90,19 @@ jobs:
           BRANCH=${{ matrix.branch }} \
           RELEASE=${{ matrix.release }} \
           BUILD_MINIMAL=no \
-          BUILD_DESKTOP=no \
+          BUILD_DESKTOP=${{ matrix.desktop }} \
           KERNEL_ONLY=no \
           KERNEL_CONFIGURE=prebuilt \
-          COMPRESS_OUTPUTIMAGE=xz \
+          COMPRESS_OUTPUTIMAGE=no \
           IGNORE_UPDATES=yes \
           DESKTOP_ENVIRONMENT_CONFIG_NAME="config_base" \
-          BUILD_DESKTOP="yes" \
           DESKTOP_ENVIRONMENT="xfce" \
           DESKTOP_APPGROUPS_SELECTED=""
 
-      - name: Upload artefacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: virtual-qemu
-          path: build/output/images/*
-          if-no-files-found: ignore
-          retention-days: 10
+#      - name: Upload artefacts
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: virtual-qemu
+#          path: build/output/images/*
+#          if-no-files-found: ignore
+#          retention-days: 10

--- a/.github/workflows/build-test-image-docker.yml
+++ b/.github/workflows/build-test-image-docker.yml
@@ -59,12 +59,31 @@ jobs:
 
           cd build
 
+          # we need to fix this once but fake toolchain will prevent downloading it each time
+          mkdir -p cache/toolchain/gcc-linaro-7.4.1-2019.02-x86_64_aarch64-linux-gnu
+          touch cache/toolchain/gcc-linaro-7.4.1-2019.02-x86_64_aarch64-linux-gnu/.download-complete
+          mkdir -p cache/toolchain/gcc-linaro-7.4.1-2019.02-x86_64_arm-linux-gnueabi
+          touch cache/toolchain/gcc-linaro-7.4.1-2019.02-x86_64_arm-linux-gnueabi/.download-complete
+          mkdir -p cache/toolchain/gcc-linaro-aarch64-none-elf-4.8-2013.11_linux
+          touch cache/toolchain/gcc-linaro-aarch64-none-elf-4.8-2013.11_linux/.download-complete
+          mkdir -p cache/toolchain/gcc-linaro-arm-linux-gnueabihf-4.8-2014.04_linux
+          touch cache/toolchain/gcc-linaro-arm-linux-gnueabihf-4.8-2014.04_linux/.download-complete
+          mkdir -p cache/toolchain/gcc-linaro-arm-none-eabi-4.8-2014.04_linux
+          touch cache/toolchain/gcc-linaro-arm-none-eabi-4.8-2014.04_linux/.download-complete
+          mkdir -p cache/toolchain/gcc-arm-8.3-2019.03-x86_64-aarch64-linux-gnu
+          touch cache/toolchain/gcc-arm-8.3-2019.03-x86_64-aarch64-linux-gnu/.download-complete
+          mkdir -p cache/toolchain/gcc-arm-8.3-2019.03-x86_64-arm-linux-gnueabihf
+          touch cache/toolchain/gcc-arm-8.3-2019.03-x86_64-arm-linux-gnueabihf/.download-complete
+          mkdir -p cache/toolchain/gcc-arm-9.2-2019.12-x86_64-aarch64-none-linux-gnu
+          touch cache/toolchain/gcc-arm-9.2-2019.12-x86_64-aarch64-none-linux-gnu/.download-complete
+          mkdir -p cache/toolchain/gcc-arm-9.2-2019.12-x86_64-arm-none-linux-gnueabihf
+          touch cache/toolchain/gcc-arm-9.2-2019.12-x86_64-arm-none-linux-gnueabihf/.download-complete
+
           #export TERM=dumb
           sed -i "s/-it --rm/-i --rm/" userpatches/config-docker.conf          
           sed -i "s/COMPRESS_OUTPUTIMAGE=.*/COMPRESS_OUTPUTIMAGE=\"no\"/" userpatches/lib.config
           ./compile.sh docker \
           BETA=yes \
-          SKIP_EXTERNAL_TOOLCHAINS="yes" \          
           EXPERT=yes \
           BOARD=${{ matrix.board }} \
           BRANCH=${{ matrix.branch }} \

--- a/.github/workflows/build-test-image-docker.yml
+++ b/.github/workflows/build-test-image-docker.yml
@@ -59,13 +59,12 @@ jobs:
 
           cd build
 
-          export TERM=dumb
+          #export TERM=dumb
           sed -i "s/-it --rm/-i --rm/" userpatches/config-docker.conf          
           sed -i "s/COMPRESS_OUTPUTIMAGE=.*/COMPRESS_OUTPUTIMAGE=\"no\"/" userpatches/lib.config
           ./compile.sh docker \
           BETA=yes \
-          SKIP_EXTERNAL_TOOLCHAINS="yes" \
-          OFFLINE_WORK="yes" \
+          SKIP_EXTERNAL_TOOLCHAINS="yes" \          
           EXPERT=yes \
           BOARD=${{ matrix.board }} \
           BRANCH=${{ matrix.branch }} \

--- a/.github/workflows/build-test-image-docker.yml
+++ b/.github/workflows/build-test-image-docker.yml
@@ -77,10 +77,23 @@ jobs:
           touch cache/toolchain/gcc-arm-9.2-2019.12-x86_64-aarch64-none-linux-gnu/.download-complete
           mkdir -p cache/toolchain/gcc-arm-9.2-2019.12-x86_64-arm-none-linux-gnueabihf
           touch cache/toolchain/gcc-arm-9.2-2019.12-x86_64-arm-none-linux-gnueabihf/.download-complete
-
-          sed -i "s/-it --rm/-i --rm/" userpatches/config-docker.conf
+          export TERM=dumb
+          sed -i "s/-it --rm/-i --rm/" userpatches/config-docker.conf          
           sed -i "s/COMPRESS_OUTPUTIMAGE=.*/COMPRESS_OUTPUTIMAGE=\"no\"/" userpatches/lib.config
-          ./compile.sh docker BETA=yes EXPERT=yes BOARD=virtual-qemu BRANCH=${{ matrix.branch }} RELEASE=${{ matrix.release }} BUILD_MINIMAL=no BUILD_DESKTOP=no KERNEL_ONLY=no KERNEL_CONFIGURE=prebuilt COMPRESS_OUTPUTIMAGE=no IGNORE_UPDATES=yes
+          ./compile.sh docker \
+          BETA=yes \
+          SKIP_EXTERNAL_TOOLCHAINS="yes" \
+          OFFLINE_WORK="yes" \
+          EXPERT=yes \
+          BOARD=virtual-qemu \
+          BRANCH=${{ matrix.branch }} \
+          RELEASE=${{ matrix.release }} \
+          BUILD_MINIMAL=no \
+          BUILD_DESKTOP=no \
+          KERNEL_ONLY=no \
+          KERNEL_CONFIGURE=prebuilt \
+          COMPRESS_OUTPUTIMAGE=no \
+          IGNORE_UPDATES=yes
 
 #      - name: Upload artefacts
 #        uses: actions/upload-artifact@v2

--- a/.github/workflows/build-test-image-docker.yml
+++ b/.github/workflows/build-test-image-docker.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        board: [virtual-qemu]
+        board: [uefi-arm64,uefi-x86]
         release: [focal,buster,bullseye,hirsute,jammy]
         branch: [current]
     if: ${{ github.repository_owner == 'Armbian' }}
@@ -79,7 +79,7 @@ jobs:
           mkdir -p cache/toolchain/gcc-arm-9.2-2019.12-x86_64-arm-none-linux-gnueabihf
           touch cache/toolchain/gcc-arm-9.2-2019.12-x86_64-arm-none-linux-gnueabihf/.download-complete
 
-          #export TERM=dumb
+          export TERM=dumb
           sed -i "s/-it --rm/-i --rm/" userpatches/config-docker.conf          
           sed -i "s/COMPRESS_OUTPUTIMAGE=.*/COMPRESS_OUTPUTIMAGE=\"no\"/" userpatches/lib.config
           ./compile.sh docker \
@@ -92,8 +92,12 @@ jobs:
           BUILD_DESKTOP=no \
           KERNEL_ONLY=no \
           KERNEL_CONFIGURE=prebuilt \
-          COMPRESS_OUTPUTIMAGE=none \
-          IGNORE_UPDATES=yes
+          COMPRESS_OUTPUTIMAGE=xz \
+          IGNORE_UPDATES=yes \
+          DESKTOP_ENVIRONMENT_CONFIG_NAME="config_base" \
+          BUILD_DESKTOP="yes" \
+          DESKTOP_ENVIRONMENT="xfce" \
+          DESKTOP_APPGROUPS_SELECTED=""
 
       - name: Upload artefacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build-test-image-docker.yml
+++ b/.github/workflows/build-test-image-docker.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        board: [uefi-arm64,uefi-x86]
+        board: [virtual-qemu]
         release: [focal,buster,bullseye,hirsute,jammy]
         branch: [edge]
     if: ${{ github.repository_owner == 'Armbian' }}
@@ -76,9 +76,15 @@ jobs:
           KERNEL_CONFIGURE=prebuilt \
           COMPRESS_OUTPUTIMAGE=xz \
           IGNORE_UPDATES=yes
+          DESKTOP_ENVIRONMENT_CONFIG_NAME="config_base" \
+          BUILD_DESKTOP="yes" \
+          DESKTOP_ENVIRONMENT="xfce" \
+          DESKTOP_APPGROUPS_SELECTED="" \
 
       - name: Upload artefacts
         uses: actions/upload-artifact@v2
         with:
           name: virtual-qemu
           path: build/output/images/*
+          if-no-files-found: ignore
+          retention-days: 10

--- a/.github/workflows/build-test-image-docker.yml
+++ b/.github/workflows/build-test-image-docker.yml
@@ -58,25 +58,6 @@ jobs:
 
           cd build
 
-          # we need to fix this once but fake toolchain will prevent downloading it each time
-          mkdir -p cache/toolchain/gcc-linaro-7.4.1-2019.02-x86_64_aarch64-linux-gnu
-          touch cache/toolchain/gcc-linaro-7.4.1-2019.02-x86_64_aarch64-linux-gnu/.download-complete
-          mkdir -p cache/toolchain/gcc-linaro-7.4.1-2019.02-x86_64_arm-linux-gnueabi
-          touch cache/toolchain/gcc-linaro-7.4.1-2019.02-x86_64_arm-linux-gnueabi/.download-complete
-          mkdir -p cache/toolchain/gcc-linaro-aarch64-none-elf-4.8-2013.11_linux
-          touch cache/toolchain/gcc-linaro-aarch64-none-elf-4.8-2013.11_linux/.download-complete
-          mkdir -p cache/toolchain/gcc-linaro-arm-linux-gnueabihf-4.8-2014.04_linux
-          touch cache/toolchain/gcc-linaro-arm-linux-gnueabihf-4.8-2014.04_linux/.download-complete
-          mkdir -p cache/toolchain/gcc-linaro-arm-none-eabi-4.8-2014.04_linux
-          touch cache/toolchain/gcc-linaro-arm-none-eabi-4.8-2014.04_linux/.download-complete
-          mkdir -p cache/toolchain/gcc-arm-8.3-2019.03-x86_64-aarch64-linux-gnu
-          touch cache/toolchain/gcc-arm-8.3-2019.03-x86_64-aarch64-linux-gnu/.download-complete
-          mkdir -p cache/toolchain/gcc-arm-8.3-2019.03-x86_64-arm-linux-gnueabihf
-          touch cache/toolchain/gcc-arm-8.3-2019.03-x86_64-arm-linux-gnueabihf/.download-complete
-          mkdir -p cache/toolchain/gcc-arm-9.2-2019.12-x86_64-aarch64-none-linux-gnu
-          touch cache/toolchain/gcc-arm-9.2-2019.12-x86_64-aarch64-none-linux-gnu/.download-complete
-          mkdir -p cache/toolchain/gcc-arm-9.2-2019.12-x86_64-arm-none-linux-gnueabihf
-          touch cache/toolchain/gcc-arm-9.2-2019.12-x86_64-arm-none-linux-gnueabihf/.download-complete
           export TERM=dumb
           sed -i "s/-it --rm/-i --rm/" userpatches/config-docker.conf          
           sed -i "s/COMPRESS_OUTPUTIMAGE=.*/COMPRESS_OUTPUTIMAGE=\"no\"/" userpatches/lib.config

--- a/.github/workflows/build-test-image-docker.yml
+++ b/.github/workflows/build-test-image-docker.yml
@@ -19,8 +19,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        board: [uefi-arm64,uefi-x86]
         release: [focal,buster,bullseye,hirsute,jammy]
-        branch: [current]
+        branch: [edge]
     if: ${{ github.repository_owner == 'Armbian' }}
     name: Variant
     runs-on: ubuntu-latest    
@@ -66,18 +67,18 @@ jobs:
           SKIP_EXTERNAL_TOOLCHAINS="yes" \
           OFFLINE_WORK="yes" \
           EXPERT=yes \
-          BOARD=virtual-qemu \
+          BOARD=${{ matrix.board }} \
           BRANCH=${{ matrix.branch }} \
           RELEASE=${{ matrix.release }} \
           BUILD_MINIMAL=no \
           BUILD_DESKTOP=no \
           KERNEL_ONLY=no \
           KERNEL_CONFIGURE=prebuilt \
-          COMPRESS_OUTPUTIMAGE=no \
+          COMPRESS_OUTPUTIMAGE=xz \
           IGNORE_UPDATES=yes
 
-#      - name: Upload artefacts
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: virtual-qemu
-#          path: build/output/images/*
+      - name: Upload artefacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: virtual-qemu
+          path: build/output/images/*

--- a/.github/workflows/build-test-image-docker.yml
+++ b/.github/workflows/build-test-image-docker.yml
@@ -74,12 +74,8 @@ jobs:
           BUILD_DESKTOP=no \
           KERNEL_ONLY=no \
           KERNEL_CONFIGURE=prebuilt \
-          COMPRESS_OUTPUTIMAGE=xz \
+          COMPRESS_OUTPUTIMAGE=none \
           IGNORE_UPDATES=yes
-          DESKTOP_ENVIRONMENT_CONFIG_NAME="config_base" \
-          BUILD_DESKTOP="yes" \
-          DESKTOP_ENVIRONMENT="xfce" \
-          DESKTOP_APPGROUPS_SELECTED="" \
 
       - name: Upload artefacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build-test-image-docker.yml
+++ b/.github/workflows/build-test-image-docker.yml
@@ -21,8 +21,7 @@ jobs:
       matrix:
         board: [uefi-arm64,uefi-x86,virtual-qemu]
         release: [focal,buster,bullseye,hirsute,jammy]
-        branch: [current]
-        desktop: [yes]
+        desktop: [xfce]
     if: ${{ github.repository_owner == 'Armbian' }}
     name: Variant
     runs-on: ubuntu-latest    
@@ -87,16 +86,16 @@ jobs:
           BETA=yes \
           EXPERT=yes \
           BOARD=${{ matrix.board }} \
-          BRANCH=${{ matrix.branch }} \
+          BRANCH=current \
           RELEASE=${{ matrix.release }} \
           BUILD_MINIMAL=no \
-          BUILD_DESKTOP=${{ matrix.desktop }} \
+          BUILD_DESKTOP=yes \
           KERNEL_ONLY=no \
           KERNEL_CONFIGURE=prebuilt \
           COMPRESS_OUTPUTIMAGE=no \
           IGNORE_UPDATES=yes \
           DESKTOP_ENVIRONMENT_CONFIG_NAME="config_base" \
-          DESKTOP_ENVIRONMENT="xfce" \
+          DESKTOP_ENVIRONMENT=${{ matrix.desktop }} \
           DESKTOP_APPGROUPS_SELECTED=""
 
 #      - name: Upload artefacts

--- a/.github/workflows/build-test-image-docker.yml
+++ b/.github/workflows/build-test-image-docker.yml
@@ -3,7 +3,7 @@ on:
   
   # Trigger after Docker image was built
   workflow_run:
-    workflows: ["Build Docker image"]
+    workflows: ["Build test with Docker"]
     types:
       - completed
   

--- a/.github/workflows/update-repository.yml
+++ b/.github/workflows/update-repository.yml
@@ -28,7 +28,7 @@ jobs:
     repository-beta:
       name: Update beta package repository
       runs-on: [self-hosted, Linux, local]
-      if: ${{ github.repository_owner == 'Armbian' && github.event.workflow_run.conclusion == 'success' }}
+      if: ${{ github.repository_owner == 'Armbian' && github.event.workflow_run.conclusion == 'success' }} || github.event_name == 'workflow_dispatch'
       steps:
 
         - name: Install SSH key for repository

--- a/.github/workflows/update-repository.yml
+++ b/.github/workflows/update-repository.yml
@@ -11,7 +11,7 @@ jobs:
     repository:
       name: Update stable package repository
       runs-on: [self-hosted, Linux, local]
-      if: ${{ github.repository_owner == 'Armbian' && github.event.workflow_run.conclusion == 'success' }}
+      if: ${{ github.repository_owner == 'Armbian' && github.event.workflow_run.conclusion == 'success' }} || github.event_name == 'workflow_dispatch'
       steps:
 
         - name: Install SSH key for repository


### PR DESCRIPTION
# Description

- enable more docker builds, x86, arm and virtual
- build XFCE desktop test builds instead of CLI to cover wider test range
- enable manual repository rebuild