### PR TITLE
Mitigate Samba NetBios timeouts

### DIFF
--- a/lib/distributions.sh
+++ b/lib/distributions.sh
@@ -446,8 +446,8 @@ FAMILY_TWEAKS
 	chroot "${SDCARD}" /bin/bash -c "chown root:messagebus /usr/lib/dbus-1.0/dbus-daemon-launch-helper"
 	chroot "${SDCARD}" /bin/bash -c "chmod u+s /usr/lib/dbus-1.0/dbus-daemon-launch-helper"
 
-	# disable sambe since it hangs when no network is present at boot
-	chroot "${SDCARD}" /bin/bash -c "systemctl --quiet disable smbd 2> /dev/null"
+	# disable samba NetBIOS over IP name service requests since it hangs when no network is present at boot
+	chroot "${SDCARD}" /bin/bash -c "systemctl --quiet disable nmbd 2> /dev/null"
 
 	# disable low-level kernel messages for non betas
 	if [[ -z $BETA ]]; then


### PR DESCRIPTION
# Description

Workaround for Samba NetBIOS over IP name service - it hangs when no network is present at boot. Provide disabled by default.

Jira reference number [AR-1025]

# How Has This Been Tested?

Manual build and test on a laptop where we usually have no network OOB.


[AR-1025]: https://armbian.atlassian.net/browse/AR-1025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ