### PR TITLE
Skip workflow if previous step failed, fix runner arch dependency

### DIFF
--- a/.github/workflows/build-beta-desktop.yml
+++ b/.github/workflows/build-beta-desktop.yml
@@ -12,7 +12,7 @@ jobs:
 
     name: Find desktop variants
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'Armbian' }}
+    if: ${{ github.repository_owner == 'Armbian' && github.event.workflow_run.conclusion == 'success' }} || github.event_name == 'workflow_dispatch'
     outputs:
       matrix: ${{steps.list_dirs.outputs.matrix}}
     steps:

--- a/.github/workflows/build-cache.yml
+++ b/.github/workflows/build-cache.yml
@@ -30,6 +30,7 @@ jobs:
 
     with:
       rootfsarch: 'bananapi'
+      runner: 'small'
       branch: ${{ github.event.inputs.branch }}
 
     secrets:  
@@ -45,6 +46,7 @@ jobs:
 
     with:
       rootfsarch: 'lepotato'
+      runner: 'small'
       branch: ${{ github.event.inputs.branch }}
 
     secrets:
@@ -60,6 +62,7 @@ jobs:
     with:
 
       rootfsarch: 'uefi-x86'
+      runner: 'x64'
       branch: ${{ github.event.inputs.branch }}
 
     secrets:

--- a/.github/workflows/build-test-image-docker.yml
+++ b/.github/workflows/build-test-image-docker.yml
@@ -22,7 +22,7 @@ jobs:
         board: [uefi-arm64,uefi-x86,virtual-qemu]
         release: [focal,buster,bullseye,hirsute,jammy]
         desktop: [xfce]
-    if: ${{ github.repository_owner == 'Armbian' }}
+    if: ${{ github.repository_owner == 'Armbian' && github.event.workflow_run.conclusion == 'success' }} || github.event_name == 'workflow_dispatch'
     name: Variant
     runs-on: ubuntu-latest    
     steps:


### PR DESCRIPTION
# Description

- skip workflow if previous step failed
- x86 targets doesn't build on aarch64 runners. Select appropriate runners arch within action script.


Jira reference number [AR-590]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- Workin the same way in another script

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-590]: https://armbian.atlassian.net/browse/AR-590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ