### PR TITLE
Remove the garbage from the `install.log` file

### DIFF
--- a/patch/kernel/archive/sunxi-5.15/series.conf
+++ b/patch/kernel/archive/sunxi-5.15/series.conf
@@ -471,5 +471,5 @@
 	megous/phy-rockchip-inno-usb2-Don-t-print-useless-error.patch
 	megous/input-touchscreen-goodix-Add-support-for-GT1158.patch
 	megous/arm64-dts-rk3566-qaurtz64-a-Fix-ethernet-performance.patch
-	megous/rtw88-Add-more-channels.patch
+-	megous/rtw88-Add-more-channels.patch
 	megous/drm-panel-st7703-Fix-power-off-sequence.patch


### PR DESCRIPTION
# Description

You cannot use `--info=progress2` for the `rsync`
command when all output is sent to a file.
This creates a large garbage file of more than 1.5 megabytes.

After this correction, the file size is 55 kilobytes and it can be analyzed.

- [x] Test make image
