### PR TITLE
rk322x: minor device tree fixes and upgrades

### DIFF
--- a/patch/kernel/archive/rk322x-4.4/general-add-overlays.patch
+++ b/patch/kernel/archive/rk322x-4.4/general-add-overlays.patch
@@ -1,38 +1,39 @@
-From deda26719f73b351c021c08059b723b041fe9226 Mon Sep 17 00:00:00 2001
+From edb8ed8e75ded0d64b735667b1475b5988b129cd Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
-Date: Tue, 19 Oct 2021 18:13:48 +0000
-Subject: [PATCH] rk322x: overlays
+Date: Wed, 3 Nov 2021 16:53:05 +0000
+Subject: [PATCH] rk322x overlays
 
 ---
- arch/arm/boot/dts/overlay/Makefile            |  38 ++++++
- .../boot/dts/overlay/README.rk322x-overlays   |  94 ++++++++++++++
+ arch/arm/boot/dts/overlay/Makefile            |  39 ++++++
+ .../boot/dts/overlay/README.rk322x-overlays   |  95 +++++++++++++++
  .../arm/boot/dts/overlay/rk322x-bluetooth.dts |  39 ++++++
- .../arm/boot/dts/overlay/rk322x-cpu-hs-lv.dts | 113 +++++++++++++++++
+ .../arm/boot/dts/overlay/rk322x-cpu-hs-lv.dts | 113 ++++++++++++++++++
  arch/arm/boot/dts/overlay/rk322x-cpu-hs.dts   |  28 +++++
  .../boot/dts/overlay/rk322x-cpu-stability.dts |  52 ++++++++
  arch/arm/boot/dts/overlay/rk322x-ddr3-330.dts |  25 ++++
- arch/arm/boot/dts/overlay/rk322x-ddr3-528.dts |  27 ++++
- arch/arm/boot/dts/overlay/rk322x-ddr3-660.dts |  27 ++++
- arch/arm/boot/dts/overlay/rk322x-ddr3-800.dts |  27 ++++
+ arch/arm/boot/dts/overlay/rk322x-ddr3-528.dts |  27 +++++
+ arch/arm/boot/dts/overlay/rk322x-ddr3-660.dts |  27 +++++
+ arch/arm/boot/dts/overlay/rk322x-ddr3-800.dts |  27 +++++
  .../dts/overlay/rk322x-emmc-ddr-ph180.dts     |  14 +++
  .../boot/dts/overlay/rk322x-emmc-ddr-ph45.dts |  14 +++
  .../boot/dts/overlay/rk322x-emmc-hs200.dts    |  13 ++
  .../arm/boot/dts/overlay/rk322x-emmc-nand.dts |  22 ++++
  .../arm/boot/dts/overlay/rk322x-emmc-pins.dts |  22 ++++
- arch/arm/boot/dts/overlay/rk322x-emmc.dts     |  20 +++
+ arch/arm/boot/dts/overlay/rk322x-emmc.dts     |  20 ++++
  .../arm/boot/dts/overlay/rk322x-fixup.scr-cmd |   4 +
  .../dts/overlay/rk322x-led-conf-default.dts   |  22 ++++
  .../arm/boot/dts/overlay/rk322x-led-conf1.dts |  57 +++++++++
  .../arm/boot/dts/overlay/rk322x-led-conf2.dts |  57 +++++++++
  .../arm/boot/dts/overlay/rk322x-led-conf3.dts |  57 +++++++++
- .../arm/boot/dts/overlay/rk322x-led-conf4.dts |  81 ++++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf4.dts |  81 +++++++++++++
  .../arm/boot/dts/overlay/rk322x-led-conf5.dts |  97 +++++++++++++++
- .../arm/boot/dts/overlay/rk322x-led-conf6.dts | 116 ++++++++++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf6.dts | 109 +++++++++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf7.dts | 106 ++++++++++++++++
  arch/arm/boot/dts/overlay/rk322x-nand.dts     |  22 ++++
  .../dts/overlay/rk322x-wlan-alt-wiring.dts    |  66 ++++++++++
  .../boot/dts/overlay/rk322x-wlan-esp8089.dts  |  24 ++++
  .../boot/dts/overlay/rk322x-wlan-ssv6051.dts  |  24 ++++
- 28 files changed, 1202 insertions(+)
+ 29 files changed, 1303 insertions(+)
  create mode 100755 arch/arm/boot/dts/overlay/Makefile
  create mode 100755 arch/arm/boot/dts/overlay/README.rk322x-overlays
  create mode 100755 arch/arm/boot/dts/overlay/rk322x-bluetooth.dts
@@ -57,6 +58,7 @@ Subject: [PATCH] rk322x: overlays
  create mode 100644 arch/arm/boot/dts/overlay/rk322x-led-conf4.dts
  create mode 100644 arch/arm/boot/dts/overlay/rk322x-led-conf5.dts
  create mode 100644 arch/arm/boot/dts/overlay/rk322x-led-conf6.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-led-conf7.dts
  create mode 100755 arch/arm/boot/dts/overlay/rk322x-nand.dts
  create mode 100644 arch/arm/boot/dts/overlay/rk322x-wlan-alt-wiring.dts
  create mode 100755 arch/arm/boot/dts/overlay/rk322x-wlan-esp8089.dts
@@ -64,10 +66,10 @@ Subject: [PATCH] rk322x: overlays
 
 diff --git a/arch/arm/boot/dts/overlay/Makefile b/arch/arm/boot/dts/overlay/Makefile
 new file mode 100755
-index 00000000..c5e8aa8f
+index 00000000..2519dfd1
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/Makefile
-@@ -0,0 +1,38 @@
+@@ -0,0 +1,39 @@
 +# SPDX-License-Identifier: GPL-2.0
 +dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 +	rk322x-emmc.dtbo	\
@@ -83,6 +85,7 @@ index 00000000..c5e8aa8f
 +	rk322x-led-conf4.dtbo   \
 +	rk322x-led-conf5.dtbo   \
 +	rk322x-led-conf6.dtbo	\
++	rk322x-led-conf7.dtbo	\
 +	rk322x-cpu-hs.dtbo	\
 +	rk322x-cpu-stability.dtbo \
 +	rk322x-bluetooth.dtbo	\
@@ -108,10 +111,10 @@ index 00000000..c5e8aa8f
 +
 diff --git a/arch/arm/boot/dts/overlay/README.rk322x-overlays b/arch/arm/boot/dts/overlay/README.rk322x-overlays
 new file mode 100755
-index 00000000..508cff9b
+index 00000000..8f885448
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/README.rk322x-overlays
-@@ -0,0 +1,94 @@
+@@ -0,0 +1,95 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
 +https://docs.armbian.com/User-Guide_Allwinner_overlays/
@@ -175,6 +178,7 @@ index 00000000..508cff9b
 +led-conf5 is found on boards with IPB900 marking from AEMS PVT
 +led-conf6 is found on boards with MXQ_PRO_V72 and similar markings, possibly
 +with eMCP module.
++led-conf7 is found on boards with R29_MXQ marking
 +
 +### rk322x-bluetooth
 +
@@ -1152,7 +1156,7 @@ index 00000000..1450ee3c
 +};
 diff --git a/arch/arm/boot/dts/overlay/rk322x-led-conf6.dts b/arch/arm/boot/dts/overlay/rk322x-led-conf6.dts
 new file mode 100644
-index 00000000..e024ff57
+index 00000000..d6a8c18e
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/rk322x-led-conf6.dts
 @@ -0,0 +1,109 @@
@@ -1261,6 +1265,118 @@ index 00000000..e024ff57
 +		__overlay__ {
 +			max-frequency = <37500000>;
 +		};
++	};
++
++
++};
+diff --git a/arch/arm/boot/dts/overlay/rk322x-led-conf7.dts b/arch/arm/boot/dts/overlay/rk322x-led-conf7.dts
+new file mode 100644
+index 00000000..dda826d6
+--- /dev/null
++++ b/arch/arm/boot/dts/overlay/rk322x-led-conf7.dts
+@@ -0,0 +1,106 @@
++/dts-v1/;
++/plugin/;
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/pinctrl/rockchip.h>
++
++/*
++ * gpio configuration for R29_MXQ boards
++ *
++ */
++
++/ {
++
++	fragment@0 {
++		target-path = "/gpio-leds";
++		__overlay__ {
++
++			working {
++				gpios = <&gpio3 RK_PC5 GPIO_ACTIVE_HIGH>;
++				linux,default-trigger = "none";
++			};
++
++			auxiliary {
++				gpios = <&gpio0 RK_PB0 GPIO_ACTIVE_HIGH>;
++				label = "auxiliary";
++				linux,default-trigger = "mmc2";
++				default-state = "off";
++				pinctrl-names = "default";
++				pinctrl-0 = <&gpio_led_aux>;
++			};
++
++			power-status {
++				gpios = <&gpio1 RK_PA7 GPIO_ACTIVE_HIGH>;
++				label = "power-status";
++				linux,default-trigger = "none";
++				default-state = "off";
++				pinctrl-names = "default";
++				pinctrl-0 = <&gpio_led_power_status>;
++			};
++
++			power-suspend {
++				gpios = <&gpio2 RK_PB3 GPIO_ACTIVE_LOW>;
++				label = "power-suspend";
++				linux,default-trigger = "none";
++				default-state = "off";
++				pinctrl-names = "default";
++				pinctrl-0 = <&gpio_led_power_suspend>;
++			};
++
++		};
++	};
++
++	fragment@1 {
++		target-path = "/pinctrl/gpio";
++		__overlay__ {
++
++			gpio_led_aux: gpio-led-aux {
++				rockchip,pins =  <0 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
++			};
++
++			gpio_led_power_status: gpio-led-power-status {
++				rockchip,pins =  <1 RK_PA7 RK_FUNC_GPIO &pcfg_pull_none>;
++			};
++
++			gpio_led_power_suspend: gpio-led-power-suspend {
++				rockchip,pins =  <2 RK_PB3 RK_FUNC_GPIO &pcfg_pull_none>;
++			};
++
++			reset_key: reset-key {
++				rockchip,pins = <3 RK_PD1 RK_FUNC_GPIO &pcfg_pull_up>;
++			};
++
++		};
++	};
++
++	fragment@2 {
++		target = <&gpio_keys>;
++		__overlay__ {
++
++			pinctrl-names = "default";
++			pinctrl-0 = <&reset_key>;
++
++			reset {
++				gpios = <&gpio3 RK_PD1 GPIO_ACTIVE_LOW>;
++				label = "reset";
++				linux,code = <KEY_RESTART>;
++				debounce-interval = <200>;
++				wakeup-source;
++			};
++
++		};
++	};
++
++	fragment@3 {
++		target = <&emmc>;
++		__overlay__ {
++			rockchip,default-sample-phase = <112>;
++			clock-frequency = <125000000>;
++			max-frequency = <125000000>;
++		};
++
 +	};
 +
 +

--- a/patch/kernel/archive/rk322x-4.4/general-add-overlays.patch
+++ b/patch/kernel/archive/rk322x-4.4/general-add-overlays.patch
@@ -1,9 +1,73 @@
+From deda26719f73b351c021c08059b723b041fe9226 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Tue, 19 Oct 2021 18:13:48 +0000
+Subject: [PATCH] rk322x: overlays
+
+---
+ arch/arm/boot/dts/overlay/Makefile            |  38 ++++++
+ .../boot/dts/overlay/README.rk322x-overlays   |  94 ++++++++++++++
+ .../arm/boot/dts/overlay/rk322x-bluetooth.dts |  39 ++++++
+ .../arm/boot/dts/overlay/rk322x-cpu-hs-lv.dts | 113 +++++++++++++++++
+ arch/arm/boot/dts/overlay/rk322x-cpu-hs.dts   |  28 +++++
+ .../boot/dts/overlay/rk322x-cpu-stability.dts |  52 ++++++++
+ arch/arm/boot/dts/overlay/rk322x-ddr3-330.dts |  25 ++++
+ arch/arm/boot/dts/overlay/rk322x-ddr3-528.dts |  27 ++++
+ arch/arm/boot/dts/overlay/rk322x-ddr3-660.dts |  27 ++++
+ arch/arm/boot/dts/overlay/rk322x-ddr3-800.dts |  27 ++++
+ .../dts/overlay/rk322x-emmc-ddr-ph180.dts     |  14 +++
+ .../boot/dts/overlay/rk322x-emmc-ddr-ph45.dts |  14 +++
+ .../boot/dts/overlay/rk322x-emmc-hs200.dts    |  13 ++
+ .../arm/boot/dts/overlay/rk322x-emmc-nand.dts |  22 ++++
+ .../arm/boot/dts/overlay/rk322x-emmc-pins.dts |  22 ++++
+ arch/arm/boot/dts/overlay/rk322x-emmc.dts     |  20 +++
+ .../arm/boot/dts/overlay/rk322x-fixup.scr-cmd |   4 +
+ .../dts/overlay/rk322x-led-conf-default.dts   |  22 ++++
+ .../arm/boot/dts/overlay/rk322x-led-conf1.dts |  57 +++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf2.dts |  57 +++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf3.dts |  57 +++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf4.dts |  81 ++++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf5.dts |  97 +++++++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf6.dts | 116 ++++++++++++++++++
+ arch/arm/boot/dts/overlay/rk322x-nand.dts     |  22 ++++
+ .../dts/overlay/rk322x-wlan-alt-wiring.dts    |  66 ++++++++++
+ .../boot/dts/overlay/rk322x-wlan-esp8089.dts  |  24 ++++
+ .../boot/dts/overlay/rk322x-wlan-ssv6051.dts  |  24 ++++
+ 28 files changed, 1202 insertions(+)
+ create mode 100755 arch/arm/boot/dts/overlay/Makefile
+ create mode 100755 arch/arm/boot/dts/overlay/README.rk322x-overlays
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-bluetooth.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-cpu-hs-lv.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-cpu-hs.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-cpu-stability.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-ddr3-330.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-ddr3-528.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-ddr3-660.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-ddr3-800.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-emmc-ddr-ph180.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-emmc-ddr-ph45.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-emmc-hs200.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-emmc-nand.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-emmc-pins.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-emmc.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-fixup.scr-cmd
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-led-conf-default.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-led-conf1.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-led-conf2.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-led-conf3.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-led-conf4.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-led-conf5.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-led-conf6.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-nand.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-wlan-alt-wiring.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-wlan-esp8089.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-wlan-ssv6051.dts
+
 diff --git a/arch/arm/boot/dts/overlay/Makefile b/arch/arm/boot/dts/overlay/Makefile
 new file mode 100755
-index 00000000..5e2b8cb4
+index 00000000..c5e8aa8f
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/Makefile
-@@ -0,0 +1,37 @@
+@@ -0,0 +1,38 @@
 +# SPDX-License-Identifier: GPL-2.0
 +dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 +	rk322x-emmc.dtbo	\
@@ -18,6 +82,7 @@ index 00000000..5e2b8cb4
 +	rk322x-led-conf3.dtbo   \
 +	rk322x-led-conf4.dtbo   \
 +	rk322x-led-conf5.dtbo   \
++	rk322x-led-conf6.dtbo	\
 +	rk322x-cpu-hs.dtbo	\
 +	rk322x-cpu-stability.dtbo \
 +	rk322x-bluetooth.dtbo	\
@@ -43,10 +108,10 @@ index 00000000..5e2b8cb4
 +
 diff --git a/arch/arm/boot/dts/overlay/README.rk322x-overlays b/arch/arm/boot/dts/overlay/README.rk322x-overlays
 new file mode 100755
-index 00000000..cb893eb4
+index 00000000..508cff9b
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/README.rk322x-overlays
-@@ -0,0 +1,92 @@
+@@ -0,0 +1,94 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
 +https://docs.armbian.com/User-Guide_Allwinner_overlays/
@@ -108,6 +173,8 @@ index 00000000..cb893eb4
 +led-conf3 is found in boards with R28-MXQ marking
 +led-conf4 is found on boards with T066 marking
 +led-conf5 is found on boards with IPB900 marking from AEMS PVT
++led-conf6 is found on boards with MXQ_PRO_V72 and similar markings, possibly
++with eMCP module.
 +
 +### rk322x-bluetooth
 +
@@ -1083,6 +1150,128 @@ index 00000000..1450ee3c
 +
 +
 +};
+diff --git a/arch/arm/boot/dts/overlay/rk322x-led-conf6.dts b/arch/arm/boot/dts/overlay/rk322x-led-conf6.dts
+new file mode 100644
+index 00000000..e024ff57
+--- /dev/null
++++ b/arch/arm/boot/dts/overlay/rk322x-led-conf6.dts
+@@ -0,0 +1,116 @@
++/dts-v1/;
++/plugin/;
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/pinctrl/rockchip.h>
++
++/*
++ * gpio configuration for MXQ_PRO eMCP boards
++ *
++ * - enables working and auxiliary leds
++ * - fixes low strength on sdio pins for wifi
++ * - reduce frequency to 37.5 Mhz on sdio bus
++ * - correct gpio pins for wifi
++ */
++
++/ {
++
++	fragment@0 {
++		target-path = "/gpio-leds";
++		__overlay__ {
++
++			auxiliary {
++				gpios = <&gpio1 RK_PA7 GPIO_ACTIVE_LOW>;
++				label = "auxiliary";
++				linux,default-trigger = "mmc2";
++				default-state = "off";
++				pinctrl-names = "default";
++				pinctrl-0 = <&gpio_led_aux>;
++			};
++
++		};
++	};
++
++	fragment@1 {
++		target-path = "/pinctrl/gpio";
++		__overlay__ {
++
++			gpio_led_aux: gpio-led-aux {
++				rockchip,pins =  <1 RK_PA7 RK_FUNC_GPIO &pcfg_pull_none>;
++			};
++
++			reset_key: reset-key {
++				rockchip,pins = <3 RK_PD1 RK_FUNC_GPIO &pcfg_pull_up>;
++			};
++
++		};
++	};
++
++	fragment@2 {
++		target = <&gpio_keys>;
++		__overlay__ {
++
++			pinctrl-names = "default";
++			pinctrl-0 = <&reset_key>;
++
++			reset {
++				gpios = <&gpio3 RK_PD1 GPIO_ACTIVE_LOW>;
++				label = "reset";
++				linux,code = <KEY_RESTART>;
++				debounce-interval = <200>;
++				wakeup-source;
++			};
++
++			shutdown {
++				gpios = <&gpio0 RK_PA3 GPIO_ACTIVE_LOW>;
++				label = "shutdown";
++				linux,code = <KEY_POWER>;
++				debounce-interval = <200>;
++				wakeup-source;
++			};
++
++		};
++	};
++
++	fragment@3 {
++		target = <&sdio_bus4>;
++		__overlay__ {
++			rockchip,pins = <3 2 1 &pcfg_pull_up>,
++					<3 3 1 &pcfg_pull_up>,
++					<3 4 1 &pcfg_pull_up>,
++					<3 5 1 &pcfg_pull_up>;
++		};
++
++	};
++
++	fragment@4 {
++		target = <&sdio_clk>;
++		__overlay__ {
++			rockchip,pins = <3 0 1 &pcfg_pull_none>;
++		};
++	};
++
++	fragment@5 {
++		target = <&sdio_cmd>;
++		__overlay__ {
++			rockchip,pins = <3 1 1 &pcfg_pull_up>;
++		};
++	};
++
++	fragment@6 {
++		target = <&sdio>;
++		__overlay__ {
++			max-frequency = <37500000>;
++		};
++	};
++
++	fragment@7 {
++		target = <&sdio_pwrseq>;
++		__overlay__ {
++			reset-gpios = <&gpio2 RK_PD2 GPIO_ACTIVE_HIGH>;
++		};
++	};
++
++
++};
 diff --git a/arch/arm/boot/dts/overlay/rk322x-nand.dts b/arch/arm/boot/dts/overlay/rk322x-nand.dts
 new file mode 100755
 index 00000000..5675f5b3
@@ -1243,3 +1432,6 @@ index 00000000..47644f6e
 +	};
 +
 +};
+-- 
+2.30.2
+

--- a/patch/kernel/archive/rk322x-4.4/general-add-overlays.patch
+++ b/patch/kernel/archive/rk322x-4.4/general-add-overlays.patch
@@ -1155,7 +1155,7 @@ new file mode 100644
 index 00000000..e024ff57
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/rk322x-led-conf6.dts
-@@ -0,0 +1,116 @@
+@@ -0,0 +1,109 @@
 +/dts-v1/;
 +/plugin/;
 +
@@ -1260,13 +1260,6 @@ index 00000000..e024ff57
 +		target = <&sdio>;
 +		__overlay__ {
 +			max-frequency = <37500000>;
-+		};
-+	};
-+
-+	fragment@7 {
-+		target = <&sdio_pwrseq>;
-+		__overlay__ {
-+			reset-gpios = <&gpio2 RK_PD2 GPIO_ACTIVE_HIGH>;
 +		};
 +	};
 +

--- a/patch/kernel/archive/rk322x-5.10/general-add-overlays.patch
+++ b/patch/kernel/archive/rk322x-5.10/general-add-overlays.patch
@@ -1,9 +1,69 @@
+From 68961364cfe1c7102624f4eb896147747afa5707 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Wed, 3 Nov 2021 16:54:30 +0000
+Subject: [PATCH] rk322x overlays
+
+---
+ arch/arm/boot/dts/overlay/Makefile            |  35 ++++++
+ .../boot/dts/overlay/README.rk322x-overlays   |  78 ++++++++++++
+ .../arm/boot/dts/overlay/rk322x-bluetooth.dts |  39 ++++++
+ .../arm/boot/dts/overlay/rk322x-cpu-hs-lv.dts | 113 ++++++++++++++++++
+ arch/arm/boot/dts/overlay/rk322x-cpu-hs.dts   |  28 +++++
+ .../boot/dts/overlay/rk322x-cpu-stability.dts |  52 ++++++++
+ arch/arm/boot/dts/overlay/rk322x-ddr3-330.dts |  28 +++++
+ arch/arm/boot/dts/overlay/rk322x-ddr3-528.dts |  28 +++++
+ arch/arm/boot/dts/overlay/rk322x-ddr3-660.dts |  28 +++++
+ arch/arm/boot/dts/overlay/rk322x-ddr3-800.dts |  28 +++++
+ .../dts/overlay/rk322x-emmc-ddr-ph180.dts     |  14 +++
+ .../boot/dts/overlay/rk322x-emmc-ddr-ph45.dts |  14 +++
+ .../boot/dts/overlay/rk322x-emmc-hs200.dts    |  13 ++
+ .../arm/boot/dts/overlay/rk322x-emmc-pins.dts |  22 ++++
+ arch/arm/boot/dts/overlay/rk322x-emmc.dts     |  20 ++++
+ .../arm/boot/dts/overlay/rk322x-fixup.scr-cmd |   4 +
+ .../dts/overlay/rk322x-led-conf-default.dts   |  22 ++++
+ .../arm/boot/dts/overlay/rk322x-led-conf1.dts |  64 ++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf2.dts |  64 ++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf3.dts |  64 ++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf4.dts |  81 +++++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf5.dts |  97 +++++++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf6.dts | 109 +++++++++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf7.dts | 106 ++++++++++++++++
+ arch/arm/boot/dts/overlay/rk322x-nand.dts     |  22 ++++
+ .../dts/overlay/rk322x-wlan-alt-wiring.dts    |  67 +++++++++++
+ 26 files changed, 1240 insertions(+)
+ create mode 100755 arch/arm/boot/dts/overlay/Makefile
+ create mode 100755 arch/arm/boot/dts/overlay/README.rk322x-overlays
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-bluetooth.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-cpu-hs-lv.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-cpu-hs.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-cpu-stability.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-ddr3-330.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-ddr3-528.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-ddr3-660.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-ddr3-800.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-emmc-ddr-ph180.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-emmc-ddr-ph45.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-emmc-hs200.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-emmc-pins.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-emmc.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-fixup.scr-cmd
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-led-conf-default.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-led-conf1.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-led-conf2.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-led-conf3.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-led-conf4.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-led-conf5.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-led-conf6.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-led-conf7.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-nand.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-wlan-alt-wiring.dts
+
 diff --git a/arch/arm/boot/dts/overlay/Makefile b/arch/arm/boot/dts/overlay/Makefile
 new file mode 100755
-index 000000000..092ff28da
+index 000000000..b811cc9fe
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/Makefile
-@@ -0,0 +1,33 @@
+@@ -0,0 +1,35 @@
 +# SPDX-License-Identifier: GPL-2.0
 +dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 +	rk322x-emmc.dtbo	\
@@ -18,6 +78,8 @@ index 000000000..092ff28da
 +	rk322x-led-conf3.dtbo   \
 +	rk322x-led-conf4.dtbo   \
 +	rk322x-led-conf5.dtbo   \
++	rk322x-led-conf6.dtbo	\
++	rk322x-led-conf7.dtbo	\
 +	rk322x-cpu-hs.dtbo	\
 +	rk322x-wlan-alt-wiring.dtbo \
 +	rk322x-cpu-stability.dtbo \
@@ -39,10 +101,10 @@ index 000000000..092ff28da
 +
 diff --git a/arch/arm/boot/dts/overlay/README.rk322x-overlays b/arch/arm/boot/dts/overlay/README.rk322x-overlays
 new file mode 100755
-index 000000000..c3d25a204
+index 000000000..d589a37ce
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/README.rk322x-overlays
-@@ -0,0 +1,75 @@
+@@ -0,0 +1,78 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
 +https://docs.armbian.com/User-Guide_Allwinner_overlays/
@@ -105,6 +167,9 @@ index 000000000..c3d25a204
 +led-conf3 is found in boards with R28-MXQ marking
 +led-conf4 is found on boards with T066 marking
 +led-conf5 is found on boards with IPB900 marking from AEMS PVT
++led-conf6 is found on boards with MXQ_PRO_V72 and similar markings, possibly
++with eMCP module.
++led-conf7 is found on boards with R29_MXQ marking
 +
 +### rk322x-alt-wiring
 +
@@ -960,7 +1025,7 @@ index 000000000..0ebd846eb
 +};
 diff --git a/arch/arm/boot/dts/overlay/rk322x-led-conf5.dts b/arch/arm/boot/dts/overlay/rk322x-led-conf5.dts
 new file mode 100755
-index 000000000..1450ee3c3
+index 000000000..f74687eed
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/rk322x-led-conf5.dts
 @@ -0,0 +1,97 @@
@@ -1057,6 +1122,233 @@ index 000000000..1450ee3c3
 +		__overlay__ {
 +			rockchip,pins = <3 1 1 &pcfg_pull_none_8ma>;
 +		};
++	};
++
++
++};
+diff --git a/arch/arm/boot/dts/overlay/rk322x-led-conf6.dts b/arch/arm/boot/dts/overlay/rk322x-led-conf6.dts
+new file mode 100644
+index 000000000..d6a8c18ee
+--- /dev/null
++++ b/arch/arm/boot/dts/overlay/rk322x-led-conf6.dts
+@@ -0,0 +1,109 @@
++/dts-v1/;
++/plugin/;
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/pinctrl/rockchip.h>
++
++/*
++ * gpio configuration for MXQ_PRO eMCP boards
++ *
++ * - enables working and auxiliary leds
++ * - fixes low strength on sdio pins for wifi
++ * - reduce frequency to 37.5 Mhz on sdio bus
++ * - correct gpio pins for wifi
++ */
++
++/ {
++
++	fragment@0 {
++		target-path = "/gpio-leds";
++		__overlay__ {
++
++			auxiliary {
++				gpios = <&gpio1 RK_PA7 GPIO_ACTIVE_LOW>;
++				label = "auxiliary";
++				linux,default-trigger = "mmc2";
++				default-state = "off";
++				pinctrl-names = "default";
++				pinctrl-0 = <&gpio_led_aux>;
++			};
++
++		};
++	};
++
++	fragment@1 {
++		target-path = "/pinctrl/gpio";
++		__overlay__ {
++
++			gpio_led_aux: gpio-led-aux {
++				rockchip,pins =  <1 RK_PA7 RK_FUNC_GPIO &pcfg_pull_none>;
++			};
++
++			reset_key: reset-key {
++				rockchip,pins = <3 RK_PD1 RK_FUNC_GPIO &pcfg_pull_up>;
++			};
++
++		};
++	};
++
++	fragment@2 {
++		target = <&gpio_keys>;
++		__overlay__ {
++
++			pinctrl-names = "default";
++			pinctrl-0 = <&reset_key>;
++
++			reset {
++				gpios = <&gpio3 RK_PD1 GPIO_ACTIVE_LOW>;
++				label = "reset";
++				linux,code = <KEY_RESTART>;
++				debounce-interval = <200>;
++				wakeup-source;
++			};
++
++			shutdown {
++				gpios = <&gpio0 RK_PA3 GPIO_ACTIVE_LOW>;
++				label = "shutdown";
++				linux,code = <KEY_POWER>;
++				debounce-interval = <200>;
++				wakeup-source;
++			};
++
++		};
++	};
++
++	fragment@3 {
++		target = <&sdio_bus4>;
++		__overlay__ {
++			rockchip,pins = <3 2 1 &pcfg_pull_up>,
++					<3 3 1 &pcfg_pull_up>,
++					<3 4 1 &pcfg_pull_up>,
++					<3 5 1 &pcfg_pull_up>;
++		};
++
++	};
++
++	fragment@4 {
++		target = <&sdio_clk>;
++		__overlay__ {
++			rockchip,pins = <3 0 1 &pcfg_pull_none>;
++		};
++	};
++
++	fragment@5 {
++		target = <&sdio_cmd>;
++		__overlay__ {
++			rockchip,pins = <3 1 1 &pcfg_pull_up>;
++		};
++	};
++
++	fragment@6 {
++		target = <&sdio>;
++		__overlay__ {
++			max-frequency = <37500000>;
++		};
++	};
++
++
++};
+diff --git a/arch/arm/boot/dts/overlay/rk322x-led-conf7.dts b/arch/arm/boot/dts/overlay/rk322x-led-conf7.dts
+new file mode 100644
+index 000000000..dda826d6d
+--- /dev/null
++++ b/arch/arm/boot/dts/overlay/rk322x-led-conf7.dts
+@@ -0,0 +1,106 @@
++/dts-v1/;
++/plugin/;
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/pinctrl/rockchip.h>
++
++/*
++ * gpio configuration for R29_MXQ boards
++ *
++ */
++
++/ {
++
++	fragment@0 {
++		target-path = "/gpio-leds";
++		__overlay__ {
++
++			working {
++				gpios = <&gpio3 RK_PC5 GPIO_ACTIVE_HIGH>;
++				linux,default-trigger = "none";
++			};
++
++			auxiliary {
++				gpios = <&gpio0 RK_PB0 GPIO_ACTIVE_HIGH>;
++				label = "auxiliary";
++				linux,default-trigger = "mmc2";
++				default-state = "off";
++				pinctrl-names = "default";
++				pinctrl-0 = <&gpio_led_aux>;
++			};
++
++			power-status {
++				gpios = <&gpio1 RK_PA7 GPIO_ACTIVE_HIGH>;
++				label = "power-status";
++				linux,default-trigger = "none";
++				default-state = "off";
++				pinctrl-names = "default";
++				pinctrl-0 = <&gpio_led_power_status>;
++			};
++
++			power-suspend {
++				gpios = <&gpio2 RK_PB3 GPIO_ACTIVE_LOW>;
++				label = "power-suspend";
++				linux,default-trigger = "none";
++				default-state = "off";
++				pinctrl-names = "default";
++				pinctrl-0 = <&gpio_led_power_suspend>;
++			};
++
++		};
++	};
++
++	fragment@1 {
++		target-path = "/pinctrl/gpio";
++		__overlay__ {
++
++			gpio_led_aux: gpio-led-aux {
++				rockchip,pins =  <0 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
++			};
++
++			gpio_led_power_status: gpio-led-power-status {
++				rockchip,pins =  <1 RK_PA7 RK_FUNC_GPIO &pcfg_pull_none>;
++			};
++
++			gpio_led_power_suspend: gpio-led-power-suspend {
++				rockchip,pins =  <2 RK_PB3 RK_FUNC_GPIO &pcfg_pull_none>;
++			};
++
++			reset_key: reset-key {
++				rockchip,pins = <3 RK_PD1 RK_FUNC_GPIO &pcfg_pull_up>;
++			};
++
++		};
++	};
++
++	fragment@2 {
++		target = <&gpio_keys>;
++		__overlay__ {
++
++			pinctrl-names = "default";
++			pinctrl-0 = <&reset_key>;
++
++			reset {
++				gpios = <&gpio3 RK_PD1 GPIO_ACTIVE_LOW>;
++				label = "reset";
++				linux,code = <KEY_RESTART>;
++				debounce-interval = <200>;
++				wakeup-source;
++			};
++
++		};
++	};
++
++	fragment@3 {
++		target = <&emmc>;
++		__overlay__ {
++			rockchip,default-sample-phase = <112>;
++			clock-frequency = <125000000>;
++			max-frequency = <125000000>;
++		};
++
 +	};
 +
 +
@@ -1162,3 +1454,6 @@ index 000000000..f04c9ac16
 +	};
 +
 +};
+-- 
+2.30.2
+

--- a/patch/kernel/archive/rk322x-5.14/general-add-overlays.patch
+++ b/patch/kernel/archive/rk322x-5.14/general-add-overlays.patch
@@ -1,9 +1,69 @@
+From 68961364cfe1c7102624f4eb896147747afa5707 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Wed, 3 Nov 2021 16:54:30 +0000
+Subject: [PATCH] rk322x overlays
+
+---
+ arch/arm/boot/dts/overlay/Makefile            |  35 ++++++
+ .../boot/dts/overlay/README.rk322x-overlays   |  78 ++++++++++++
+ .../arm/boot/dts/overlay/rk322x-bluetooth.dts |  39 ++++++
+ .../arm/boot/dts/overlay/rk322x-cpu-hs-lv.dts | 113 ++++++++++++++++++
+ arch/arm/boot/dts/overlay/rk322x-cpu-hs.dts   |  28 +++++
+ .../boot/dts/overlay/rk322x-cpu-stability.dts |  52 ++++++++
+ arch/arm/boot/dts/overlay/rk322x-ddr3-330.dts |  28 +++++
+ arch/arm/boot/dts/overlay/rk322x-ddr3-528.dts |  28 +++++
+ arch/arm/boot/dts/overlay/rk322x-ddr3-660.dts |  28 +++++
+ arch/arm/boot/dts/overlay/rk322x-ddr3-800.dts |  28 +++++
+ .../dts/overlay/rk322x-emmc-ddr-ph180.dts     |  14 +++
+ .../boot/dts/overlay/rk322x-emmc-ddr-ph45.dts |  14 +++
+ .../boot/dts/overlay/rk322x-emmc-hs200.dts    |  13 ++
+ .../arm/boot/dts/overlay/rk322x-emmc-pins.dts |  22 ++++
+ arch/arm/boot/dts/overlay/rk322x-emmc.dts     |  20 ++++
+ .../arm/boot/dts/overlay/rk322x-fixup.scr-cmd |   4 +
+ .../dts/overlay/rk322x-led-conf-default.dts   |  22 ++++
+ .../arm/boot/dts/overlay/rk322x-led-conf1.dts |  64 ++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf2.dts |  64 ++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf3.dts |  64 ++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf4.dts |  81 +++++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf5.dts |  97 +++++++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf6.dts | 109 +++++++++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf7.dts | 106 ++++++++++++++++
+ arch/arm/boot/dts/overlay/rk322x-nand.dts     |  22 ++++
+ .../dts/overlay/rk322x-wlan-alt-wiring.dts    |  67 +++++++++++
+ 26 files changed, 1240 insertions(+)
+ create mode 100755 arch/arm/boot/dts/overlay/Makefile
+ create mode 100755 arch/arm/boot/dts/overlay/README.rk322x-overlays
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-bluetooth.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-cpu-hs-lv.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-cpu-hs.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-cpu-stability.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-ddr3-330.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-ddr3-528.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-ddr3-660.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-ddr3-800.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-emmc-ddr-ph180.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-emmc-ddr-ph45.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-emmc-hs200.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-emmc-pins.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-emmc.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-fixup.scr-cmd
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-led-conf-default.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-led-conf1.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-led-conf2.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-led-conf3.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-led-conf4.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-led-conf5.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-led-conf6.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-led-conf7.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-nand.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-wlan-alt-wiring.dts
+
 diff --git a/arch/arm/boot/dts/overlay/Makefile b/arch/arm/boot/dts/overlay/Makefile
 new file mode 100755
-index 000000000..092ff28da
+index 000000000..b811cc9fe
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/Makefile
-@@ -0,0 +1,33 @@
+@@ -0,0 +1,35 @@
 +# SPDX-License-Identifier: GPL-2.0
 +dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 +	rk322x-emmc.dtbo	\
@@ -18,6 +78,8 @@ index 000000000..092ff28da
 +	rk322x-led-conf3.dtbo   \
 +	rk322x-led-conf4.dtbo   \
 +	rk322x-led-conf5.dtbo   \
++	rk322x-led-conf6.dtbo	\
++	rk322x-led-conf7.dtbo	\
 +	rk322x-cpu-hs.dtbo	\
 +	rk322x-wlan-alt-wiring.dtbo \
 +	rk322x-cpu-stability.dtbo \
@@ -39,10 +101,10 @@ index 000000000..092ff28da
 +
 diff --git a/arch/arm/boot/dts/overlay/README.rk322x-overlays b/arch/arm/boot/dts/overlay/README.rk322x-overlays
 new file mode 100755
-index 000000000..c3d25a204
+index 000000000..d589a37ce
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/README.rk322x-overlays
-@@ -0,0 +1,75 @@
+@@ -0,0 +1,78 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
 +https://docs.armbian.com/User-Guide_Allwinner_overlays/
@@ -105,6 +167,9 @@ index 000000000..c3d25a204
 +led-conf3 is found in boards with R28-MXQ marking
 +led-conf4 is found on boards with T066 marking
 +led-conf5 is found on boards with IPB900 marking from AEMS PVT
++led-conf6 is found on boards with MXQ_PRO_V72 and similar markings, possibly
++with eMCP module.
++led-conf7 is found on boards with R29_MXQ marking
 +
 +### rk322x-alt-wiring
 +
@@ -960,7 +1025,7 @@ index 000000000..0ebd846eb
 +};
 diff --git a/arch/arm/boot/dts/overlay/rk322x-led-conf5.dts b/arch/arm/boot/dts/overlay/rk322x-led-conf5.dts
 new file mode 100755
-index 000000000..1450ee3c3
+index 000000000..f74687eed
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/rk322x-led-conf5.dts
 @@ -0,0 +1,97 @@
@@ -1057,6 +1122,233 @@ index 000000000..1450ee3c3
 +		__overlay__ {
 +			rockchip,pins = <3 1 1 &pcfg_pull_none_8ma>;
 +		};
++	};
++
++
++};
+diff --git a/arch/arm/boot/dts/overlay/rk322x-led-conf6.dts b/arch/arm/boot/dts/overlay/rk322x-led-conf6.dts
+new file mode 100644
+index 000000000..d6a8c18ee
+--- /dev/null
++++ b/arch/arm/boot/dts/overlay/rk322x-led-conf6.dts
+@@ -0,0 +1,109 @@
++/dts-v1/;
++/plugin/;
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/pinctrl/rockchip.h>
++
++/*
++ * gpio configuration for MXQ_PRO eMCP boards
++ *
++ * - enables working and auxiliary leds
++ * - fixes low strength on sdio pins for wifi
++ * - reduce frequency to 37.5 Mhz on sdio bus
++ * - correct gpio pins for wifi
++ */
++
++/ {
++
++	fragment@0 {
++		target-path = "/gpio-leds";
++		__overlay__ {
++
++			auxiliary {
++				gpios = <&gpio1 RK_PA7 GPIO_ACTIVE_LOW>;
++				label = "auxiliary";
++				linux,default-trigger = "mmc2";
++				default-state = "off";
++				pinctrl-names = "default";
++				pinctrl-0 = <&gpio_led_aux>;
++			};
++
++		};
++	};
++
++	fragment@1 {
++		target-path = "/pinctrl/gpio";
++		__overlay__ {
++
++			gpio_led_aux: gpio-led-aux {
++				rockchip,pins =  <1 RK_PA7 RK_FUNC_GPIO &pcfg_pull_none>;
++			};
++
++			reset_key: reset-key {
++				rockchip,pins = <3 RK_PD1 RK_FUNC_GPIO &pcfg_pull_up>;
++			};
++
++		};
++	};
++
++	fragment@2 {
++		target = <&gpio_keys>;
++		__overlay__ {
++
++			pinctrl-names = "default";
++			pinctrl-0 = <&reset_key>;
++
++			reset {
++				gpios = <&gpio3 RK_PD1 GPIO_ACTIVE_LOW>;
++				label = "reset";
++				linux,code = <KEY_RESTART>;
++				debounce-interval = <200>;
++				wakeup-source;
++			};
++
++			shutdown {
++				gpios = <&gpio0 RK_PA3 GPIO_ACTIVE_LOW>;
++				label = "shutdown";
++				linux,code = <KEY_POWER>;
++				debounce-interval = <200>;
++				wakeup-source;
++			};
++
++		};
++	};
++
++	fragment@3 {
++		target = <&sdio_bus4>;
++		__overlay__ {
++			rockchip,pins = <3 2 1 &pcfg_pull_up>,
++					<3 3 1 &pcfg_pull_up>,
++					<3 4 1 &pcfg_pull_up>,
++					<3 5 1 &pcfg_pull_up>;
++		};
++
++	};
++
++	fragment@4 {
++		target = <&sdio_clk>;
++		__overlay__ {
++			rockchip,pins = <3 0 1 &pcfg_pull_none>;
++		};
++	};
++
++	fragment@5 {
++		target = <&sdio_cmd>;
++		__overlay__ {
++			rockchip,pins = <3 1 1 &pcfg_pull_up>;
++		};
++	};
++
++	fragment@6 {
++		target = <&sdio>;
++		__overlay__ {
++			max-frequency = <37500000>;
++		};
++	};
++
++
++};
+diff --git a/arch/arm/boot/dts/overlay/rk322x-led-conf7.dts b/arch/arm/boot/dts/overlay/rk322x-led-conf7.dts
+new file mode 100644
+index 000000000..dda826d6d
+--- /dev/null
++++ b/arch/arm/boot/dts/overlay/rk322x-led-conf7.dts
+@@ -0,0 +1,106 @@
++/dts-v1/;
++/plugin/;
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/pinctrl/rockchip.h>
++
++/*
++ * gpio configuration for R29_MXQ boards
++ *
++ */
++
++/ {
++
++	fragment@0 {
++		target-path = "/gpio-leds";
++		__overlay__ {
++
++			working {
++				gpios = <&gpio3 RK_PC5 GPIO_ACTIVE_HIGH>;
++				linux,default-trigger = "none";
++			};
++
++			auxiliary {
++				gpios = <&gpio0 RK_PB0 GPIO_ACTIVE_HIGH>;
++				label = "auxiliary";
++				linux,default-trigger = "mmc2";
++				default-state = "off";
++				pinctrl-names = "default";
++				pinctrl-0 = <&gpio_led_aux>;
++			};
++
++			power-status {
++				gpios = <&gpio1 RK_PA7 GPIO_ACTIVE_HIGH>;
++				label = "power-status";
++				linux,default-trigger = "none";
++				default-state = "off";
++				pinctrl-names = "default";
++				pinctrl-0 = <&gpio_led_power_status>;
++			};
++
++			power-suspend {
++				gpios = <&gpio2 RK_PB3 GPIO_ACTIVE_LOW>;
++				label = "power-suspend";
++				linux,default-trigger = "none";
++				default-state = "off";
++				pinctrl-names = "default";
++				pinctrl-0 = <&gpio_led_power_suspend>;
++			};
++
++		};
++	};
++
++	fragment@1 {
++		target-path = "/pinctrl/gpio";
++		__overlay__ {
++
++			gpio_led_aux: gpio-led-aux {
++				rockchip,pins =  <0 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
++			};
++
++			gpio_led_power_status: gpio-led-power-status {
++				rockchip,pins =  <1 RK_PA7 RK_FUNC_GPIO &pcfg_pull_none>;
++			};
++
++			gpio_led_power_suspend: gpio-led-power-suspend {
++				rockchip,pins =  <2 RK_PB3 RK_FUNC_GPIO &pcfg_pull_none>;
++			};
++
++			reset_key: reset-key {
++				rockchip,pins = <3 RK_PD1 RK_FUNC_GPIO &pcfg_pull_up>;
++			};
++
++		};
++	};
++
++	fragment@2 {
++		target = <&gpio_keys>;
++		__overlay__ {
++
++			pinctrl-names = "default";
++			pinctrl-0 = <&reset_key>;
++
++			reset {
++				gpios = <&gpio3 RK_PD1 GPIO_ACTIVE_LOW>;
++				label = "reset";
++				linux,code = <KEY_RESTART>;
++				debounce-interval = <200>;
++				wakeup-source;
++			};
++
++		};
++	};
++
++	fragment@3 {
++		target = <&emmc>;
++		__overlay__ {
++			rockchip,default-sample-phase = <112>;
++			clock-frequency = <125000000>;
++			max-frequency = <125000000>;
++		};
++
 +	};
 +
 +
@@ -1162,3 +1454,6 @@ index 000000000..f04c9ac16
 +	};
 +
 +};
+-- 
+2.30.2
+

--- a/patch/kernel/archive/rk322x-5.15/general-add-overlays.patch
+++ b/patch/kernel/archive/rk322x-5.15/general-add-overlays.patch
@@ -1,9 +1,69 @@
+From 68961364cfe1c7102624f4eb896147747afa5707 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Wed, 3 Nov 2021 16:54:30 +0000
+Subject: [PATCH] rk322x overlays
+
+---
+ arch/arm/boot/dts/overlay/Makefile            |  35 ++++++
+ .../boot/dts/overlay/README.rk322x-overlays   |  78 ++++++++++++
+ .../arm/boot/dts/overlay/rk322x-bluetooth.dts |  39 ++++++
+ .../arm/boot/dts/overlay/rk322x-cpu-hs-lv.dts | 113 ++++++++++++++++++
+ arch/arm/boot/dts/overlay/rk322x-cpu-hs.dts   |  28 +++++
+ .../boot/dts/overlay/rk322x-cpu-stability.dts |  52 ++++++++
+ arch/arm/boot/dts/overlay/rk322x-ddr3-330.dts |  28 +++++
+ arch/arm/boot/dts/overlay/rk322x-ddr3-528.dts |  28 +++++
+ arch/arm/boot/dts/overlay/rk322x-ddr3-660.dts |  28 +++++
+ arch/arm/boot/dts/overlay/rk322x-ddr3-800.dts |  28 +++++
+ .../dts/overlay/rk322x-emmc-ddr-ph180.dts     |  14 +++
+ .../boot/dts/overlay/rk322x-emmc-ddr-ph45.dts |  14 +++
+ .../boot/dts/overlay/rk322x-emmc-hs200.dts    |  13 ++
+ .../arm/boot/dts/overlay/rk322x-emmc-pins.dts |  22 ++++
+ arch/arm/boot/dts/overlay/rk322x-emmc.dts     |  20 ++++
+ .../arm/boot/dts/overlay/rk322x-fixup.scr-cmd |   4 +
+ .../dts/overlay/rk322x-led-conf-default.dts   |  22 ++++
+ .../arm/boot/dts/overlay/rk322x-led-conf1.dts |  64 ++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf2.dts |  64 ++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf3.dts |  64 ++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf4.dts |  81 +++++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf5.dts |  97 +++++++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf6.dts | 109 +++++++++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf7.dts | 106 ++++++++++++++++
+ arch/arm/boot/dts/overlay/rk322x-nand.dts     |  22 ++++
+ .../dts/overlay/rk322x-wlan-alt-wiring.dts    |  67 +++++++++++
+ 26 files changed, 1240 insertions(+)
+ create mode 100755 arch/arm/boot/dts/overlay/Makefile
+ create mode 100755 arch/arm/boot/dts/overlay/README.rk322x-overlays
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-bluetooth.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-cpu-hs-lv.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-cpu-hs.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-cpu-stability.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-ddr3-330.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-ddr3-528.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-ddr3-660.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-ddr3-800.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-emmc-ddr-ph180.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-emmc-ddr-ph45.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-emmc-hs200.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-emmc-pins.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-emmc.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-fixup.scr-cmd
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-led-conf-default.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-led-conf1.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-led-conf2.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-led-conf3.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-led-conf4.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-led-conf5.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-led-conf6.dts
+ create mode 100644 arch/arm/boot/dts/overlay/rk322x-led-conf7.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-nand.dts
+ create mode 100755 arch/arm/boot/dts/overlay/rk322x-wlan-alt-wiring.dts
+
 diff --git a/arch/arm/boot/dts/overlay/Makefile b/arch/arm/boot/dts/overlay/Makefile
 new file mode 100755
-index 000000000..092ff28da
+index 000000000..b811cc9fe
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/Makefile
-@@ -0,0 +1,33 @@
+@@ -0,0 +1,35 @@
 +# SPDX-License-Identifier: GPL-2.0
 +dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 +	rk322x-emmc.dtbo	\
@@ -18,6 +78,8 @@ index 000000000..092ff28da
 +	rk322x-led-conf3.dtbo   \
 +	rk322x-led-conf4.dtbo   \
 +	rk322x-led-conf5.dtbo   \
++	rk322x-led-conf6.dtbo	\
++	rk322x-led-conf7.dtbo	\
 +	rk322x-cpu-hs.dtbo	\
 +	rk322x-wlan-alt-wiring.dtbo \
 +	rk322x-cpu-stability.dtbo \
@@ -39,10 +101,10 @@ index 000000000..092ff28da
 +
 diff --git a/arch/arm/boot/dts/overlay/README.rk322x-overlays b/arch/arm/boot/dts/overlay/README.rk322x-overlays
 new file mode 100755
-index 000000000..c3d25a204
+index 000000000..d589a37ce
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/README.rk322x-overlays
-@@ -0,0 +1,75 @@
+@@ -0,0 +1,78 @@
 +This document describes overlays provided in the kernel packages
 +For generic Armbian overlays documentation please see
 +https://docs.armbian.com/User-Guide_Allwinner_overlays/
@@ -105,6 +167,9 @@ index 000000000..c3d25a204
 +led-conf3 is found in boards with R28-MXQ marking
 +led-conf4 is found on boards with T066 marking
 +led-conf5 is found on boards with IPB900 marking from AEMS PVT
++led-conf6 is found on boards with MXQ_PRO_V72 and similar markings, possibly
++with eMCP module.
++led-conf7 is found on boards with R29_MXQ marking
 +
 +### rk322x-alt-wiring
 +
@@ -960,7 +1025,7 @@ index 000000000..0ebd846eb
 +};
 diff --git a/arch/arm/boot/dts/overlay/rk322x-led-conf5.dts b/arch/arm/boot/dts/overlay/rk322x-led-conf5.dts
 new file mode 100755
-index 000000000..1450ee3c3
+index 000000000..f74687eed
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/rk322x-led-conf5.dts
 @@ -0,0 +1,97 @@
@@ -1057,6 +1122,233 @@ index 000000000..1450ee3c3
 +		__overlay__ {
 +			rockchip,pins = <3 1 1 &pcfg_pull_none_8ma>;
 +		};
++	};
++
++
++};
+diff --git a/arch/arm/boot/dts/overlay/rk322x-led-conf6.dts b/arch/arm/boot/dts/overlay/rk322x-led-conf6.dts
+new file mode 100644
+index 000000000..d6a8c18ee
+--- /dev/null
++++ b/arch/arm/boot/dts/overlay/rk322x-led-conf6.dts
+@@ -0,0 +1,109 @@
++/dts-v1/;
++/plugin/;
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/pinctrl/rockchip.h>
++
++/*
++ * gpio configuration for MXQ_PRO eMCP boards
++ *
++ * - enables working and auxiliary leds
++ * - fixes low strength on sdio pins for wifi
++ * - reduce frequency to 37.5 Mhz on sdio bus
++ * - correct gpio pins for wifi
++ */
++
++/ {
++
++	fragment@0 {
++		target-path = "/gpio-leds";
++		__overlay__ {
++
++			auxiliary {
++				gpios = <&gpio1 RK_PA7 GPIO_ACTIVE_LOW>;
++				label = "auxiliary";
++				linux,default-trigger = "mmc2";
++				default-state = "off";
++				pinctrl-names = "default";
++				pinctrl-0 = <&gpio_led_aux>;
++			};
++
++		};
++	};
++
++	fragment@1 {
++		target-path = "/pinctrl/gpio";
++		__overlay__ {
++
++			gpio_led_aux: gpio-led-aux {
++				rockchip,pins =  <1 RK_PA7 RK_FUNC_GPIO &pcfg_pull_none>;
++			};
++
++			reset_key: reset-key {
++				rockchip,pins = <3 RK_PD1 RK_FUNC_GPIO &pcfg_pull_up>;
++			};
++
++		};
++	};
++
++	fragment@2 {
++		target = <&gpio_keys>;
++		__overlay__ {
++
++			pinctrl-names = "default";
++			pinctrl-0 = <&reset_key>;
++
++			reset {
++				gpios = <&gpio3 RK_PD1 GPIO_ACTIVE_LOW>;
++				label = "reset";
++				linux,code = <KEY_RESTART>;
++				debounce-interval = <200>;
++				wakeup-source;
++			};
++
++			shutdown {
++				gpios = <&gpio0 RK_PA3 GPIO_ACTIVE_LOW>;
++				label = "shutdown";
++				linux,code = <KEY_POWER>;
++				debounce-interval = <200>;
++				wakeup-source;
++			};
++
++		};
++	};
++
++	fragment@3 {
++		target = <&sdio_bus4>;
++		__overlay__ {
++			rockchip,pins = <3 2 1 &pcfg_pull_up>,
++					<3 3 1 &pcfg_pull_up>,
++					<3 4 1 &pcfg_pull_up>,
++					<3 5 1 &pcfg_pull_up>;
++		};
++
++	};
++
++	fragment@4 {
++		target = <&sdio_clk>;
++		__overlay__ {
++			rockchip,pins = <3 0 1 &pcfg_pull_none>;
++		};
++	};
++
++	fragment@5 {
++		target = <&sdio_cmd>;
++		__overlay__ {
++			rockchip,pins = <3 1 1 &pcfg_pull_up>;
++		};
++	};
++
++	fragment@6 {
++		target = <&sdio>;
++		__overlay__ {
++			max-frequency = <37500000>;
++		};
++	};
++
++
++};
+diff --git a/arch/arm/boot/dts/overlay/rk322x-led-conf7.dts b/arch/arm/boot/dts/overlay/rk322x-led-conf7.dts
+new file mode 100644
+index 000000000..dda826d6d
+--- /dev/null
++++ b/arch/arm/boot/dts/overlay/rk322x-led-conf7.dts
+@@ -0,0 +1,106 @@
++/dts-v1/;
++/plugin/;
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/pinctrl/rockchip.h>
++
++/*
++ * gpio configuration for R29_MXQ boards
++ *
++ */
++
++/ {
++
++	fragment@0 {
++		target-path = "/gpio-leds";
++		__overlay__ {
++
++			working {
++				gpios = <&gpio3 RK_PC5 GPIO_ACTIVE_HIGH>;
++				linux,default-trigger = "none";
++			};
++
++			auxiliary {
++				gpios = <&gpio0 RK_PB0 GPIO_ACTIVE_HIGH>;
++				label = "auxiliary";
++				linux,default-trigger = "mmc2";
++				default-state = "off";
++				pinctrl-names = "default";
++				pinctrl-0 = <&gpio_led_aux>;
++			};
++
++			power-status {
++				gpios = <&gpio1 RK_PA7 GPIO_ACTIVE_HIGH>;
++				label = "power-status";
++				linux,default-trigger = "none";
++				default-state = "off";
++				pinctrl-names = "default";
++				pinctrl-0 = <&gpio_led_power_status>;
++			};
++
++			power-suspend {
++				gpios = <&gpio2 RK_PB3 GPIO_ACTIVE_LOW>;
++				label = "power-suspend";
++				linux,default-trigger = "none";
++				default-state = "off";
++				pinctrl-names = "default";
++				pinctrl-0 = <&gpio_led_power_suspend>;
++			};
++
++		};
++	};
++
++	fragment@1 {
++		target-path = "/pinctrl/gpio";
++		__overlay__ {
++
++			gpio_led_aux: gpio-led-aux {
++				rockchip,pins =  <0 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
++			};
++
++			gpio_led_power_status: gpio-led-power-status {
++				rockchip,pins =  <1 RK_PA7 RK_FUNC_GPIO &pcfg_pull_none>;
++			};
++
++			gpio_led_power_suspend: gpio-led-power-suspend {
++				rockchip,pins =  <2 RK_PB3 RK_FUNC_GPIO &pcfg_pull_none>;
++			};
++
++			reset_key: reset-key {
++				rockchip,pins = <3 RK_PD1 RK_FUNC_GPIO &pcfg_pull_up>;
++			};
++
++		};
++	};
++
++	fragment@2 {
++		target = <&gpio_keys>;
++		__overlay__ {
++
++			pinctrl-names = "default";
++			pinctrl-0 = <&reset_key>;
++
++			reset {
++				gpios = <&gpio3 RK_PD1 GPIO_ACTIVE_LOW>;
++				label = "reset";
++				linux,code = <KEY_RESTART>;
++				debounce-interval = <200>;
++				wakeup-source;
++			};
++
++		};
++	};
++
++	fragment@3 {
++		target = <&emmc>;
++		__overlay__ {
++			rockchip,default-sample-phase = <112>;
++			clock-frequency = <125000000>;
++			max-frequency = <125000000>;
++		};
++
 +	};
 +
 +
@@ -1162,3 +1454,6 @@ index 000000000..f04c9ac16
 +	};
 +
 +};
+-- 
+2.30.2
+

--- a/patch/u-boot/u-boot-rk322x/board_rk322x-box/rk322x-box-add-device-tree.patch
+++ b/patch/u-boot/u-boot-rk322x/board_rk322x-box/rk322x-box-add-device-tree.patch
@@ -29,7 +29,7 @@ index 00000000..eb47f976
 +		Schematics say that this pin is connected to I2C0 data
 +		bus, which is usually unused on rk322x boards
 +	*/
-+		
++
 +	alt {
 +		label = "alternative";
 +		gpios = <&gpio0 RK_PA1 GPIO_ACTIVE_HIGH>;
@@ -53,7 +53,7 @@ index 00000000..eb47f976
 +};
 +
 +&sdmmc {
-+
++	cd-gpios = <&gpio1 RK_PC1 GPIO_ACTIVE_LOW>;
 +	status = "okay";
 +
 +};


### PR DESCRIPTION
# Description

Introduced a couple of device tree sets for MXQ_PRO and R29_MXQ boards.
To be squashed when merged.

# How Has This Been Tested?

Did a compilation, went well.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
