### PR TITLE
Add warning when build environment is WSL2 docker

### DIFF
--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1293,7 +1293,11 @@ prepare_host()
 	fi
 
 	if grep -qE "(Microsoft|WSL)" /proc/version; then
-		exit_with_error "Windows subsystem for Linux is not a supported build environment"
+		if [ -f /.dockerenv ]; then
+			display_alert "WSL2 Docker build images may failed" "" "wrn"
+		else
+			exit_with_error "Windows subsystem for Linux is not a supported build environment"
+		fi
 	fi
 
 # build aarch64

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1294,7 +1294,7 @@ prepare_host()
 
 	if grep -qE "(Microsoft|WSL)" /proc/version; then
 		if [ -f /.dockerenv ]; then
-			display_alert "WSL2 Docker build images may failed" "" "wrn"
+			display_alert "Building images using Docker on WSL2 may fail" "" "wrn"
 		else
 			exit_with_error "Windows subsystem for Linux is not a supported build environment"
 		fi


### PR DESCRIPTION
For issue [WSL2 Docker can not build](https://github.com/armbian/build/issues/3337)
Let WSL Docker build pass, but give a warning
