### PR TITLE
Add support for rootfs / toolchain bind (u)mount

### DIFF
--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -35,6 +35,9 @@ debootstrap_ng()
 	rm -rf $SDCARD $MOUNT
 	mkdir -p $SDCARD $MOUNT $DEST/images $SRC/cache/rootfs
 
+	# bind mount rootfs if defined
+	[[ -d "${ARMBIAN_CACHE_ROOTFS_PATH}" ]] && mount --bind "${ARMBIAN_CACHE_ROOTFS_PATH}" "${SRC}"/cache/rootfs
+
 	# stage: verify tmpfs configuration and mount
 	# CLI needs ~1.5GiB, desktop - ~3.5GiB
 	# calculate and set tmpfs mount to use 9/10 of available RAM+SWAP

--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -36,7 +36,10 @@ debootstrap_ng()
 	mkdir -p $SDCARD $MOUNT $DEST/images $SRC/cache/rootfs
 
 	# bind mount rootfs if defined
-	[[ -d "${ARMBIAN_CACHE_ROOTFS_PATH}" ]] && mount --bind "${ARMBIAN_CACHE_ROOTFS_PATH}" "${SRC}"/cache/rootfs
+	if [[ -d "${ARMBIAN_CACHE_ROOTFS_PATH}" ]]; then
+		mountpoint -q "${SRC}"/cache/rootfs && umount -l "${SRC}"/cache/toolchain
+		mount --bind "${ARMBIAN_CACHE_ROOTFS_PATH}" "${SRC}"/cache/rootfs
+	fi
 
 	# stage: verify tmpfs configuration and mount
 	# CLI needs ~1.5GiB, desktop - ~3.5GiB

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1425,7 +1425,10 @@ prepare_host()
 		if [[ "${SKIP_EXTERNAL_TOOLCHAINS}" != "yes" ]]; then
 
 			# bind mount toolchain if defined
-			[[ -d "${ARMBIAN_CACHE_TOOLCHAIN_PATH}" ]] && mount --bind "${ARMBIAN_CACHE_TOOLCHAIN_PATH}" "${SRC}"/cache/toolchain
+			if [[ -d "${ARMBIAN_CACHE_TOOLCHAIN_PATH}" ]]; then
+				mountpoint -q "${SRC}"/cache/toolchain && umount -l "${SRC}"/cache/toolchain
+				mount --bind "${ARMBIAN_CACHE_TOOLCHAIN_PATH}" "${SRC}"/cache/toolchain
+			fi
 
 			display_alert "Checking for external GCC compilers" "" "info"
 			# download external Linaro compiler and missing special dependencies since they are needed for certain sources

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1423,6 +1423,10 @@ prepare_host()
 # build aarch64
 	if [[ $(dpkg --print-architecture) == amd64 ]]; then
 		if [[ "${SKIP_EXTERNAL_TOOLCHAINS}" != "yes" ]]; then
+
+			# bind mount toolchain if defined
+			[[ -d "${ARMBIAN_CACHE_TOOLCHAIN_PATH}" ]] && mount --bind "${ARMBIAN_CACHE_TOOLCHAIN_PATH}" "${SRC}"/cache/toolchain
+
 			display_alert "Checking for external GCC compilers" "" "info"
 			# download external Linaro compiler and missing special dependencies since they are needed for certain sources
 

--- a/lib/image-helpers.sh
+++ b/lib/image-helpers.sh
@@ -80,8 +80,10 @@ unmount_on_exit()
 		display_alert "ERROR_DEBUG_SHELL=yes, starting a shell." "ERROR_DEBUG_SHELL" "err"
 		bash < /dev/tty || true
 	fi
-	
+
 	umount_chroot "${SDCARD}/"
+	umount -l "${SRC}"/cache/toolchain
+	umount -l "${SRC}"/cache/rootfs
 	umount -l "${SDCARD}"/tmp >/dev/null 2>&1
 	umount -l "${SDCARD}" >/dev/null 2>&1
 	umount -l "${MOUNT}"/boot >/dev/null 2>&1

--- a/lib/image-helpers.sh
+++ b/lib/image-helpers.sh
@@ -82,8 +82,9 @@ unmount_on_exit()
 	fi
 
 	umount_chroot "${SDCARD}/"
-	umount -l "${SRC}"/cache/toolchain
-	umount -l "${SRC}"/cache/rootfs
+	mountpoint -q "${SRC}"/cache/toolchain && umount -l "${SRC}"/cache/toolchain
+	mountpoint -q "${SRC}"/cache/rootfs && umount -l "${SRC}"/cache/rootfs
+	unset ARMBIAN_CACHE_TOOLCHAIN_PATH ARMBIAN_CACHE_ROOTFS_PATH
 	umount -l "${SDCARD}"/tmp >/dev/null 2>&1
 	umount -l "${SDCARD}" >/dev/null 2>&1
 	umount -l "${MOUNT}"/boot >/dev/null 2>&1


### PR DESCRIPTION
# Description

Backend functionality which allows to mount rootfs / toolchain to any location via bind mount.

Jira reference number [AR-1028]

# How Has This Been Tested?

Manual run.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1028]: https://armbian.atlassian.net/browse/AR-1028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ