### PR TITLE
Backend - enable bind mount with Github actions

### DIFF
--- a/.github/workflows/build-beta-images.yml
+++ b/.github/workflows/build-beta-images.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Clean upload folder
 
         run: |
-
+          printenv
           cd build
           while sudo mountpoint output/images -q
           do
@@ -153,7 +153,7 @@ jobs:
 
       - name: Fix permissions
         run: |
-
+          printenv
           # make sure no temporally dirs are mounted from previous runs
           while :
           do

--- a/.github/workflows/build-beta-images.yml
+++ b/.github/workflows/build-beta-images.yml
@@ -81,9 +81,6 @@ jobs:
       - name: Clean upload folder
 
         run: |
-          printenv
-          
-          echo "This is: ${{ env.ARMBIAN_CACHE_TOOLCHAIN_PATH }}"
           
           cd build
           while sudo mountpoint output/images -q
@@ -156,9 +153,6 @@ jobs:
 
       - name: Fix permissions
         run: |
-          printenv
-          
-          echo "This is: ${GITHUB_WORKFLOW} - ${ARMBIAN_CACHE_TOOLCHAIN_PATH} - ${ARMBIAN_CACHE_ROOTFS_PATH}"
           
           # make sure no temporally dirs are mounted from previous runs
           while :
@@ -230,7 +224,7 @@ jobs:
           CHUNK=$(printf "%03d" $CHUNK)
           cd build
           # use prepared configs
-          sudo -E mkdir -p userpatches
+          sudo mkdir -p userpatches
           sudo cp ../scripts/configs/* userpatches/
           # prepare host
           [[ ! -f .ignore_changes ]] && sudo touch .ignore_changes

--- a/.github/workflows/build-beta-images.yml
+++ b/.github/workflows/build-beta-images.yml
@@ -242,8 +242,6 @@ jobs:
               sudo mkdir -p cache/toolchain build/cache/rootfs || true
               ! sudo mountpoint -q cache/toolchain && sudo mount nas:/tank/armbian/toolchain.armbian.com cache/toolchain -o rsize=32768,wsize=32768,timeo=5,retrans=2,actimeo=60,retry=15 || true
               ! sudo mountpoint -q cache/rootfs && sudo mount nas:/tank/armbian/dl.armbian.com/_rootfs cache/rootfs -o rsize=32768,wsize=32768,timeo=5,retrans=2,actimeo=60,retry=15 || true
-          else
-              sudo -E rsync --size-only --delete -avr rsync://rsync.armbian.com/dl/_rootfs/. cache/rootfs/ || true
           fi
 
           # calculate how many images we can build in parallel

--- a/.github/workflows/build-beta-images.yml
+++ b/.github/workflows/build-beta-images.yml
@@ -254,7 +254,7 @@ jobs:
           sudo ln -sf ../../temp/split-${CHUNK}.conf userpatches/targets.conf
           # we enforce family skip only for kernel building
           sudo rm -f userpatches/family.skip
-          ./compile.sh all-new-beta-images MULTITHREAD="${PARALLEL_BUILDS}" GPG_PASS="${GPG_PASS}"          
+          sudo -E ./compile.sh all-new-beta-images MULTITHREAD="${PARALLEL_BUILDS}" GPG_PASS="${GPG_PASS}"          
           # umount
           while mountpoint output/images -q
           do

--- a/.github/workflows/build-beta-images.yml
+++ b/.github/workflows/build-beta-images.yml
@@ -224,7 +224,7 @@ jobs:
           CHUNK=$(printf "%03d" $CHUNK)
           cd build
           # use prepared configs
-          sudo mkdir -p userpatches
+          sudo -E mkdir -p userpatches
           sudo cp ../scripts/configs/* userpatches/
           # prepare host
           [[ ! -f .ignore_changes ]] && sudo touch .ignore_changes

--- a/.github/workflows/build-beta-images.yml
+++ b/.github/workflows/build-beta-images.yml
@@ -157,6 +157,9 @@ jobs:
       - name: Fix permissions
         run: |
           printenv
+          
+          echo "This is: ${{ env.ARMBIAN_CACHE_TOOLCHAIN_PATH }}"
+          
           # make sure no temporally dirs are mounted from previous runs
           while :
           do

--- a/.github/workflows/build-beta-images.yml
+++ b/.github/workflows/build-beta-images.yml
@@ -237,7 +237,7 @@ jobs:
               ! sudo mountpoint -q cache/toolchain && sudo mount nas:/tank/armbian/toolchain.armbian.com cache/toolchain -o rsize=32768,wsize=32768,timeo=5,retrans=2,actimeo=60,retry=15 || true
               ! sudo mountpoint -q cache/rootfs && sudo mount nas:/tank/armbian/dl.armbian.com/_rootfs cache/rootfs -o rsize=32768,wsize=32768,timeo=5,retrans=2,actimeo=60,retry=15 || true
           else
-              sudo rsync --size-only --delete -avr rsync://rsync.armbian.com/dl/_rootfs/. cache/rootfs/ || true
+              sudo -E rsync --size-only --delete -avr rsync://rsync.armbian.com/dl/_rootfs/. cache/rootfs/ || true
           fi
 
           # calculate how many images we can build in parallel

--- a/.github/workflows/build-beta-images.yml
+++ b/.github/workflows/build-beta-images.yml
@@ -158,7 +158,7 @@ jobs:
         run: |
           printenv
           
-          echo "This is: ${{ env.ARMBIAN_CACHE_TOOLCHAIN_PATH }}"
+          echo "This is: ${GITHUB_WORKFLOW} - ${ARMBIAN_CACHE_TOOLCHAIN_PATH} - ${ARMBIAN_CACHE_ROOTFS_PATH}"
           
           # make sure no temporally dirs are mounted from previous runs
           while :

--- a/.github/workflows/build-beta-images.yml
+++ b/.github/workflows/build-beta-images.yml
@@ -153,7 +153,7 @@ jobs:
 
       - name: Fix permissions
         run: |
-          
+
           # make sure no temporally dirs are mounted from previous runs
           while :
           do
@@ -218,7 +218,6 @@ jobs:
           GPG_PASS: ${{ secrets.GPG_PASSPHRASE1 }}
 
         run: |
-          printenv
           CHUNK="${{ matrix.node }}"
           CHUNK=$(echo $CHUNK | sed 's/^0*//') 
           CHUNK=$(printf "%03d" $CHUNK)

--- a/.github/workflows/build-beta-images.yml
+++ b/.github/workflows/build-beta-images.yml
@@ -218,7 +218,7 @@ jobs:
           GPG_PASS: ${{ secrets.GPG_PASSPHRASE1 }}
 
         run: |
-
+          printenv
           CHUNK="${{ matrix.node }}"
           CHUNK=$(echo $CHUNK | sed 's/^0*//') 
           CHUNK=$(printf "%03d" $CHUNK)

--- a/.github/workflows/build-beta-images.yml
+++ b/.github/workflows/build-beta-images.yml
@@ -260,7 +260,7 @@ jobs:
           sudo ln -sf ../../temp/split-${CHUNK}.conf userpatches/targets.conf
           # we enforce family skip only for kernel building
           sudo rm -f userpatches/family.skip
-          sudo -E ./compile.sh all-new-beta-images MULTITHREAD="${PARALLEL_BUILDS}" GPG_PASS="${GPG_PASS}"          
+          ./compile.sh all-new-beta-images MULTITHREAD="${PARALLEL_BUILDS}" GPG_PASS="${GPG_PASS}" ARMBIAN_CACHE_TOOLCHAIN_PATH="${ARMBIAN_CACHE_TOOLCHAIN_PATH}" ARMBIAN_CACHE_ROOTFS_PATH="${ARMBIAN_CACHE_ROOTFS_PATH}"
           # umount
           while mountpoint output/images -q
           do

--- a/.github/workflows/build-beta-images.yml
+++ b/.github/workflows/build-beta-images.yml
@@ -82,6 +82,9 @@ jobs:
 
         run: |
           printenv
+          
+          echo "This is: ${{ env.ARMBIAN_CACHE_TOOLCHAIN_PATH }}"
+          
           cd build
           while sudo mountpoint output/images -q
           do


### PR DESCRIPTION
# Description

This allows our self hosted runners to mount caches in a better way.

Jira reference number [AR-690]

# How Has This Been Tested?

Manual runs.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-690]: https://armbian.atlassian.net/browse/AR-690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ