### PR TITLE
JetHome JetHub D1/H1 patch/bsp updates

### DIFF
--- a/packages/bsp/jethub/jethubj80/bluetooth/jethub-rtk-hciattach-starter
+++ b/packages/bsp/jethub/jethubj80/bluetooth/jethub-rtk-hciattach-starter
@@ -6,7 +6,10 @@ if [ ! -f /sys/class/gpio/gpio497/value ]; then
   echo out > /sys/class/gpio/gpio497/direction
 fi
 echo 0 > /sys/class/gpio/gpio497/value && sleep 0.1
+sleep 1
 echo 1 > /sys/class/gpio/gpio497/value && sleep 0.1
 
+echo 497 > /sys/class/gpio/unexport
+
 # Attach serial devices via UART HCI to BlueZ stack
-rtk_hciattach /dev/ttyAML1 -s 115200 rtk_h5 115200
+rtk_hciattach /dev/ttyAML1 -s 115200 rtk_h5 115200 || true

--- a/patch/kernel/archive/meson64-5.10/jethome-0007-arm64-meson-fix-dts-for-JetHub-D1.patch
+++ b/patch/kernel/archive/meson64-5.10/jethome-0007-arm64-meson-fix-dts-for-JetHub-D1.patch
@@ -1,3 +1,19 @@
+From 7ee7560a8d97af8ff6e3526a8c30cd539a7945b6 Mon Sep 17 00:00:00 2001
+From: Vyacheslav Bocharov <adeep@lexina.in>
+Date: Thu, 25 Nov 2021 16:02:47 +0300
+Subject: [PATCH 1/3] arm64: meson: fix dts for JetHub D1
+
+Fix misplace of cpu_cooling_maps for JetHub D1, move it to right place.
+
+Fixes: 8e279fb29039 ("arm64: dts: meson-axg: add support for JetHub D1")
+Signed-off-by: Vyacheslav Bocharov <adeep@lexina.in>
+Reviewed-by: Neil Armstrong <narmstrong@baylibre.com>
+Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>
+Link: https://lore.kernel.org/r/20211125130246.1086627-1-adeep@lexina.in
+---
+ .../amlogic/meson-axg-jethome-jethub-j100.dts | 30 +++++++++----------
+ 1 file changed, 15 insertions(+), 15 deletions(-)
+
 diff --git a/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts b/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts
 index 52ebe371df26..561eec21b4de 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts
@@ -41,3 +57,6 @@ index 52ebe371df26..561eec21b4de 100644
  			};
  		};
  	};
+-- 
+2.30.2
+

--- a/patch/kernel/archive/meson64-5.10/jethome-0008-arm64-meson-dts-update-dts-for-JetHub-D1.patch
+++ b/patch/kernel/archive/meson64-5.10/jethome-0008-arm64-meson-dts-update-dts-for-JetHub-D1.patch
@@ -1,0 +1,26 @@
+From 350761d9fa30de0a494fc7c65a729afb2cfae1d6 Mon Sep 17 00:00:00 2001
+From: Vyacheslav Bocharov <adeep@lexina.in>
+Date: Mon, 13 Dec 2021 10:25:50 +0300
+Subject: [PATCH 2/3] arm64: meson: dts: update dts for JetHub D1 Change zigbee
+ serial alias to ttyAML2 for backward compatibility.
+
+---
+ arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts b/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts
+index 561eec21b4de..9951217ef997 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts
+@@ -18,7 +18,7 @@ / {
+ 	model = "JetHome JetHub J100";
+ 	aliases {
+ 		serial0 = &uart_AO;   /* Console */
+-		serial1 = &uart_AO_B; /* External UART (Wireless Module) */
++		serial2 = &uart_AO_B; /* External UART (Wireless Module) */
+ 		ethernet0 = &ethmac;
+ 	};
+ 
+-- 
+2.30.2
+

--- a/patch/kernel/archive/meson64-5.10/jethome-0009-arm64-meson-dts-fix-sdio-in-dts-for-JetHub-D1.patch
+++ b/patch/kernel/archive/meson64-5.10/jethome-0009-arm64-meson-dts-fix-sdio-in-dts-for-JetHub-D1.patch
@@ -1,0 +1,42 @@
+From 76ff4ce956542827f5eff43f402aae0254e3ec3a Mon Sep 17 00:00:00 2001
+From: Vyacheslav Bocharov <adeep@lexina.in>
+Date: Fri, 10 Dec 2021 08:30:10 +0300
+Subject: [PATCH 3/3] arm64: meson: dts: fix sdio in dts for JetHub D1
+
+Fix the dts to match board's reference design:
+- update vddio_boot regulator to 3.3v
+- remove emmc hs200 support due to the lack of 1.8v regulator
+
+Signed-off-by: Vyacheslav Bocharov <adeep@lexina.in>
+---
+ .../boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts     | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts b/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts
+index 9951217ef997..2965346fc47e 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts
+@@ -81,8 +81,8 @@ vddio_ao18: regulator-vddio_ao18 {
+ 	vddio_boot: regulator-vddio_boot {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "VDDIO_BOOT";
+-		regulator-min-microvolt = <1800000>;
+-		regulator-max-microvolt = <1800000>;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
+ 		vin-supply = <&vddao_3v3>;
+ 		regulator-always-on;
+ 	};
+@@ -276,8 +276,7 @@ &sd_emmc_c {
+ 	max-frequency = <200000000>;
+ 	non-removable;
+ 	disable-wp;
+-	mmc-ddr-1_8v;
+-	mmc-hs200-1_8v;
++	mmc-ddr-3_3v;
+ 
+ 	mmc-pwrseq = <&emmc_pwrseq>;
+ 
+-- 
+2.30.2
+

--- a/patch/kernel/archive/meson64-5.15/jethome-0007-arm64-meson-fix-dts-for-JetHub-D1.patch
+++ b/patch/kernel/archive/meson64-5.15/jethome-0007-arm64-meson-fix-dts-for-JetHub-D1.patch
@@ -1,3 +1,19 @@
+From 7ee7560a8d97af8ff6e3526a8c30cd539a7945b6 Mon Sep 17 00:00:00 2001
+From: Vyacheslav Bocharov <adeep@lexina.in>
+Date: Thu, 25 Nov 2021 16:02:47 +0300
+Subject: [PATCH 1/3] arm64: meson: fix dts for JetHub D1
+
+Fix misplace of cpu_cooling_maps for JetHub D1, move it to right place.
+
+Fixes: 8e279fb29039 ("arm64: dts: meson-axg: add support for JetHub D1")
+Signed-off-by: Vyacheslav Bocharov <adeep@lexina.in>
+Reviewed-by: Neil Armstrong <narmstrong@baylibre.com>
+Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>
+Link: https://lore.kernel.org/r/20211125130246.1086627-1-adeep@lexina.in
+---
+ .../amlogic/meson-axg-jethome-jethub-j100.dts | 30 +++++++++----------
+ 1 file changed, 15 insertions(+), 15 deletions(-)
+
 diff --git a/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts b/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts
 index 52ebe371df26..561eec21b4de 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts
@@ -41,3 +57,6 @@ index 52ebe371df26..561eec21b4de 100644
  			};
  		};
  	};
+-- 
+2.30.2
+

--- a/patch/kernel/archive/meson64-5.15/jethome-0008-arm64-meson-dts-update-dts-for-JetHub-D1.patch
+++ b/patch/kernel/archive/meson64-5.15/jethome-0008-arm64-meson-dts-update-dts-for-JetHub-D1.patch
@@ -1,0 +1,26 @@
+From 350761d9fa30de0a494fc7c65a729afb2cfae1d6 Mon Sep 17 00:00:00 2001
+From: Vyacheslav Bocharov <adeep@lexina.in>
+Date: Mon, 13 Dec 2021 10:25:50 +0300
+Subject: [PATCH 2/3] arm64: meson: dts: update dts for JetHub D1 Change zigbee
+ serial alias to ttyAML2 for backward compatibility.
+
+---
+ arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts b/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts
+index 561eec21b4de..9951217ef997 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts
+@@ -18,7 +18,7 @@ / {
+ 	model = "JetHome JetHub J100";
+ 	aliases {
+ 		serial0 = &uart_AO;   /* Console */
+-		serial1 = &uart_AO_B; /* External UART (Wireless Module) */
++		serial2 = &uart_AO_B; /* External UART (Wireless Module) */
+ 		ethernet0 = &ethmac;
+ 	};
+ 
+-- 
+2.30.2
+

--- a/patch/kernel/archive/meson64-5.15/jethome-0009-arm64-meson-dts-fix-sdio-in-dts-for-JetHub-D1.patch
+++ b/patch/kernel/archive/meson64-5.15/jethome-0009-arm64-meson-dts-fix-sdio-in-dts-for-JetHub-D1.patch
@@ -1,0 +1,42 @@
+From 76ff4ce956542827f5eff43f402aae0254e3ec3a Mon Sep 17 00:00:00 2001
+From: Vyacheslav Bocharov <adeep@lexina.in>
+Date: Fri, 10 Dec 2021 08:30:10 +0300
+Subject: [PATCH 3/3] arm64: meson: dts: fix sdio in dts for JetHub D1
+
+Fix the dts to match board's reference design:
+- update vddio_boot regulator to 3.3v
+- remove emmc hs200 support due to the lack of 1.8v regulator
+
+Signed-off-by: Vyacheslav Bocharov <adeep@lexina.in>
+---
+ .../boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts     | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts b/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts
+index 9951217ef997..2965346fc47e 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts
+@@ -81,8 +81,8 @@ vddio_ao18: regulator-vddio_ao18 {
+ 	vddio_boot: regulator-vddio_boot {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "VDDIO_BOOT";
+-		regulator-min-microvolt = <1800000>;
+-		regulator-max-microvolt = <1800000>;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
+ 		vin-supply = <&vddao_3v3>;
+ 		regulator-always-on;
+ 	};
+@@ -276,8 +276,7 @@ &sd_emmc_c {
+ 	max-frequency = <200000000>;
+ 	non-removable;
+ 	disable-wp;
+-	mmc-ddr-1_8v;
+-	mmc-hs200-1_8v;
++	mmc-ddr-3_3v;
+ 
+ 	mmc-pwrseq = <&emmc_pwrseq>;
+ 
+-- 
+2.30.2
+

--- a/patch/u-boot/u-boot-jethub/0001-HACK-mmc-meson-gx-limit-to-24MHz.patch
+++ b/patch/u-boot/u-boot-jethub/0001-HACK-mmc-meson-gx-limit-to-24MHz.patch
@@ -1,0 +1,27 @@
+From ff82d04354784cd982ab1a912c08d3eb22f82d13 Mon Sep 17 00:00:00 2001
+Message-Id: <ff82d04354784cd982ab1a912c08d3eb22f82d13.1632758701.git.stefan@agner.ch>
+From: Neil Armstrong <narmstrong@baylibre.com>
+Date: Mon, 2 Sep 2019 15:42:04 +0200
+Subject: [PATCH] HACK: mmc: meson-gx: limit to 24MHz
+
+Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>
+---
+ drivers/mmc/meson_gx_mmc.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/mmc/meson_gx_mmc.c b/drivers/mmc/meson_gx_mmc.c
+index fcf4f03d1e..6ded4b619b 100644
+--- a/drivers/mmc/meson_gx_mmc.c
++++ b/drivers/mmc/meson_gx_mmc.c
+@@ -279,7 +279,7 @@ static int meson_mmc_probe(struct udevice *dev)
+ 	cfg->host_caps = MMC_MODE_8BIT | MMC_MODE_4BIT |
+ 			MMC_MODE_HS_52MHz | MMC_MODE_HS;
+ 	cfg->f_min = DIV_ROUND_UP(SD_EMMC_CLKSRC_24M, CLK_MAX_DIV);
+-	cfg->f_max = 100000000; /* 100 MHz */
++	cfg->f_max = SD_EMMC_CLKSRC_24M;
+ 	cfg->b_max = 511; /* max 512 - 1 blocks */
+ 	cfg->name = dev->name;
+ 
+-- 
+2.33.0
+

--- a/patch/u-boot/u-boot-jethub/0002-image-board-fix-wrong-implementation-ram-disk-addres.patch
+++ b/patch/u-boot/u-boot-jethub/0002-image-board-fix-wrong-implementation-ram-disk-addres.patch
@@ -1,0 +1,51 @@
+From 7ab43bacd08d660867166f79a8b55f6cd3444bf8 Mon Sep 17 00:00:00 2001
+From: Artem Lapkin <email2tema@gmail.com>
+Date: Thu, 25 Nov 2021 11:08:59 +0800
+Subject: [PATCH 1/2] image-board: fix wrong implementation ram disk address
+ setup from cmdline
+
+Problem
+
+Wrong implementation logic: ramdisk cmdline image address always ignored!
+Next block { rd_addr = hextoul(select, NULL) } unusable for raw initrd.
+
+We have unbootable raw initrd images because, select_ramdisk for raw
+initrd images ignore submited select addr and setup rd_datap value to 0
+
+Signed-off-by: Artem Lapkin <art@khadas.com>
+---
+ boot/image-board.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/boot/image-board.c b/boot/image-board.c
+index bf8817165c..87a8f07432 100644
+--- a/boot/image-board.c
++++ b/boot/image-board.c
+@@ -334,7 +334,7 @@ static int select_ramdisk(bootm_headers_t *images, const char *select, u8 arch,
+ 
+ 	if (select) {
+ 		ulong default_addr;
+-		bool done = true;
++		bool done = false;
+ 
+ 		if (CONFIG_IS_ENABLED(FIT)) {
+ 			/*
+@@ -352,13 +352,13 @@ static int select_ramdisk(bootm_headers_t *images, const char *select, u8 arch,
+ 					   &fit_uname_config)) {
+ 				debug("*  ramdisk: config '%s' from image at 0x%08lx\n",
+ 				      fit_uname_config, rd_addr);
++				done = true;
+ 			} else if (fit_parse_subimage(select, default_addr,
+ 						      &rd_addr,
+ 						      &fit_uname_ramdisk)) {
+ 				debug("*  ramdisk: subimage '%s' from image at 0x%08lx\n",
+ 				      fit_uname_ramdisk, rd_addr);
+-			} else {
+-				done = false;
++				done = true;
+ 			}
+ 		}
+ 		if (!done) {
+-- 
+2.30.2
+

--- a/patch/u-boot/u-boot-jethub/0003-mmc-meson-gx-change-clock-phase-value-on-axg-SoCs.patch
+++ b/patch/u-boot/u-boot-jethub/0003-mmc-meson-gx-change-clock-phase-value-on-axg-SoCs.patch
@@ -1,0 +1,54 @@
+From 4ac22afaa40da590605cd725850b81bfb562b0fb Mon Sep 17 00:00:00 2001
+From: Vyacheslav Bocharov <adeep@lexina.in>
+Date: Thu, 2 Dec 2021 13:10:24 +0300
+Subject: [PATCH 2/2] mmc: meson-gx: change clock phase value on axg SoCs
+
+Amlogic AXG SoCs seems doesn't work over 50MHz. When phase sets to 270',
+it's working fine over 50MHz on Amlogic AXG SoCs.
+Based on 0dbb54eb3257c243c7968f967a6b183b1edb56c8 by Neil Armstrong
+<narmstrong@baylibre.com>
+
+To distinguish which value is used adds an u-boot only axg compatible.
+---
+ drivers/mmc/meson_gx_mmc.c | 5 +++--
+ drivers/mmc/meson_gx_mmc.h | 1 +
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/mmc/meson_gx_mmc.c b/drivers/mmc/meson_gx_mmc.c
+index fcf4f03d1e..718eae42ec 100644
+--- a/drivers/mmc/meson_gx_mmc.c
++++ b/drivers/mmc/meson_gx_mmc.c
+@@ -68,7 +68,8 @@ static void meson_mmc_config_clock(struct mmc *mmc)
+ 	 * Other SoCs use CLK_CO_PHASE_180 by default.
+ 	 * It needs to find what is a proper value about each SoCs.
+ 	 */
+-	if (meson_gx_mmc_is_compatible(mmc->dev, MMC_COMPATIBLE_SM1))
++	if (meson_gx_mmc_is_compatible(mmc->dev, MMC_COMPATIBLE_SM1) ||
++            meson_gx_mmc_is_compatible(mmc->dev, MMC_COMPATIBLE_AXG))
+ 		meson_mmc_clk |= CLK_CO_PHASE_270;
+ 	else
+ 		meson_mmc_clk |= CLK_CO_PHASE_180;
+@@ -322,7 +323,7 @@ int meson_mmc_bind(struct udevice *dev)
+ 
+ static const struct udevice_id meson_mmc_match[] = {
+ 	{ .compatible = "amlogic,meson-gx-mmc", .data = MMC_COMPATIBLE_GX },
+-	{ .compatible = "amlogic,meson-axg-mmc", .data = MMC_COMPATIBLE_GX },
++	{ .compatible = "amlogic,meson-axg-mmc", .data = MMC_COMPATIBLE_AXG },
+ 	{ .compatible = "amlogic,meson-sm1-mmc", .data = MMC_COMPATIBLE_SM1 },
+ 	{ /* sentinel */ }
+ };
+diff --git a/drivers/mmc/meson_gx_mmc.h b/drivers/mmc/meson_gx_mmc.h
+index 8974b78f55..53201cedda 100644
+--- a/drivers/mmc/meson_gx_mmc.h
++++ b/drivers/mmc/meson_gx_mmc.h
+@@ -12,6 +12,7 @@
+ enum meson_gx_mmc_compatible {
+ 	MMC_COMPATIBLE_GX,
+ 	MMC_COMPATIBLE_SM1,
++	MMC_COMPATIBLE_AXG,
+ };
+ 
+ #define SDIO_PORT_A			0
+-- 
+2.30.2
+


### PR DESCRIPTION
# Description

Fixes some bugs:

- JetHome: Update H1 (j80) Bluetooth init script to more stable start with kernel driver/armbian-firmware.
- JetHome: update kernel patches with last updates for JetHub devices:
  - fix JetHub D1 (j100) dts to match board's reference design (update emmc/sdio work modes)
  - renumber  patches
  - change ZigBee serial alias for JetHub D1 (j100) in dts
- Update jethub u-boot for more stable boot with new onboard emmc modules.

Сhanges affect only the jethub devices.

Jira reference number [AR-1031]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] JetHub D1 (j100)
- [X] JetHub H1 (j80)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules


[AR-1031]: https://armbian.atlassian.net/browse/AR-1031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ