### PR TITLE
helios64: fix udev rules to let fancontrol work again

### DIFF
--- a/packages/bsp/helios64/90-helios64-hwmon.rules
+++ b/packages/bsp/helios64/90-helios64-hwmon.rules
@@ -13,7 +13,7 @@ SUBSYSTEM!="hwmon|thermal", GOTO="helios64_hwmon_end"
 ENV{HWMON_PATH}="/sys%p"
 #
 ATTR{type}=="soc-thermal", ENV{HWMON_PATH}="/sys%p/temp", ENV{HELIOS64_SYMLINK}="/dev/thermal-cpu/temp1_input", RUN+="/usr/bin/mkdir /dev/thermal-cpu/"
-ATTR{name}=="cpu", ENV{IS_HELIOS64_HWMON}="1", ENV{HELIOS64_SYMLINK}="/dev/thermal-cpu"
+ATTR{name}=="cpu|cpu_thermal", ENV{IS_HELIOS64_HWMON}="1", ENV{HELIOS64_SYMLINK}="/dev/thermal-cpu"
 #
 ENV{IS_HELIOS64_HWMON}=="1", ATTR{name}=="lm75", ENV{HELIOS64_SYMLINK}="/dev/thermal-board"
 ENV{_IS_HELIOS64_FAN_}=="1", ENV{HELIOS64_SYMLINK}="/dev/fan-$env{_HELIOS64_FAN_}"


### PR DESCRIPTION
# Description

Helios64 with current and edge builds turns fans to 100%, fancontrol can't start, discussion https://forum.armbian.com/topic/18793-temp-fix-for-armbian-bsp-cli-helios64-21058-fancontrol-service-fail

# How Has This Been Tested?

I manual fix udev rules file on booted fresh-builded as "edge" armbian on helios64 hardware, restart fancontrol service, and run "7z b" as cpu burner to see, if fans reacts to temperature. Yes, it does.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
