### PR TITLE
Re-enable rock-3a building now that it works

### DIFF
--- a/config/targets-cli-beta.conf
+++ b/config/targets-cli-beta.conf
@@ -63,7 +63,7 @@ rk322x-box                   edge            jammy       cli                    
 
 
 # Radxa rock-3a
-#rock-3a                      legacy          jammy       cli                      beta         yes
+rock-3a                      legacy          jammy       cli                      beta         yes
 
 
 # Raspberry Pi4


### PR DESCRIPTION
# Description

Revert a change in bddce2c432a5466d880e9f95f1440e045e69f02e now that rock-3a building succeeds and provides a usable image (#3271)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Build and test full images
- [x] Build and test individual packages

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
