### PR TITLE
Enable generic build targets?

### DIFF
--- a/config/targets-cli-beta.conf
+++ b/config/targets-cli-beta.conf
@@ -67,16 +67,24 @@ rock-3a                      legacy          jammy       cli                    
 
 
 # Raspberry Pi4
+rpi4b                        edge            bullseye    cli                      beta         yes
+rpi4b                        edge            focal       cli                      beta         yes
 rpi4b                        edge            jammy       cli                      beta         yes
 
 
 # uefi-x86
+uefi-x86                     edge            bullseye    cli                      beta         yes
+uefi-x86                     edge            focal       cli                      beta         yes
 uefi-x86                     edge            jammy       cli                      beta         yes
 
 
 # uefi-arm64
+uefi-arm64                   edge            bullseye    cli                      beta         yes
+uefi-arm64                   edge            focal       cli                      beta         yes
 uefi-arm64                   edge            jammy       cli                      beta         yes
 
 
 # Virtual qemu
+virtual-qemu                 current         focal       cli                      beta         yes
+virtual-qemu                 current         bullseye    cli                      beta         yes
 virtual-qemu                 current         jammy       cli                      beta         yes

--- a/config/targets-desktop-beta.conf
+++ b/config/targets-desktop-beta.conf
@@ -24,21 +24,21 @@ orangepi4           edge            jammy        desktop                  beta  
 rpi4b               current         focal        desktop                  beta            yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 rpi4b               current         focal        desktop                  beta            yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 rpi4b               edge            jammy        desktop                  beta            yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-rpi4b               edge            jammy        desktop                  beta            yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+rpi4b               edge            jammy        desktop                  beta            yes           mate      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 
 # uefi-x86
 uefi-x86            edge            focal        desktop                  beta            yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 uefi-x86            edge            focal        desktop                  beta            yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 uefi-x86            edge            jammy        desktop                  beta            yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-uefi-x86            edge            jammy        desktop                  beta            yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+uefi-x86            edge            jammy        desktop                  beta            yes           mate      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 
 # uefi-arm64
 uefi-arm64          edge            focal        desktop                  beta            yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 uefi-arm64          edge            focal        desktop                  beta            yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 uefi-arm64          edge            jammy        desktop                  beta            yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-uefi-arm64          edge            jammy        desktop                  beta            yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+uefi-arm64          edge            jammy        desktop                  beta            yes           mate      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 
 # qemu virtual images

--- a/config/targets-desktop-beta.conf
+++ b/config/targets-desktop-beta.conf
@@ -21,16 +21,22 @@ orangepi4           edge            jammy        desktop                  beta  
 
 
 # Raspberry Pi4
+rpi4b               current         focal        desktop                  beta            yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+rpi4b               current         focal        desktop                  beta            yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 rpi4b               edge            jammy        desktop                  beta            yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 rpi4b               edge            jammy        desktop                  beta            yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 
 # uefi-x86
+uefi-x86            edge            focal        desktop                  beta            yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+uefi-x86            edge            focal        desktop                  beta            yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 uefi-x86            edge            jammy        desktop                  beta            yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 uefi-x86            edge            jammy        desktop                  beta            yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 
 # uefi-arm64
+uefi-arm64          edge            focal        desktop                  beta            yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+uefi-arm64          edge            focal        desktop                  beta            yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 uefi-arm64          edge            jammy        desktop                  beta            yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 uefi-arm64          edge            jammy        desktop                  beta            yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 

--- a/config/targets.conf
+++ b/config/targets.conf
@@ -408,30 +408,16 @@ jetson-nano               edge            jammy       cli                      s
 
 
 # Raspberry Pi4
-rpi4b                     current         focal       desktop                  stable         yes            xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-rpi4b                     current         focal       desktop                  stable         yes            cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-rpi4b                     edge            bullseye    cli                      stable         yes
-rpi4b                     edge            focal       cli                      stable         yes
 rpi4b                     edge            jammy       cli                      stable         yes
 
 
 # uefi-x86
-uefi-x86                  edge            bullseye    cli                      stable         yes
-uefi-x86                  edge            focal       cli                      stable         yes
-uefi-x86                  edge            focal       desktop                  stable         yes            xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-uefi-x86                  edge            focal       desktop                  stable         yes            cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 uefi-x86                  edge            jammy       cli                      stable         yes
 
 
 # uefi-arm64
-uefi-arm64                edge            bullseye    cli                      stable         yes
-uefi-arm64                edge            focal       cli                      stable         yes
-uefi-arm64                edge            focal       desktop                  stable         yes            xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-uefi-arm64                edge            focal       desktop                  stable         yes            cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 uefi-arm64                edge            jammy       cli                      stable         yes
 
 
 # Virtual qemu
 virtual-qemu              current         focal       cli                      stable         yes
-virtual-qemu              current         bullseye    cli                      stable         yes
-virtual-qemu              current         jammy       cli                      stable         yes

--- a/config/targets.conf
+++ b/config/targets.conf
@@ -408,16 +408,16 @@ jetson-nano               edge            jammy       cli                      s
 
 
 # Raspberry Pi4
-rpi4b                     edge            jammy       cli                      stable         yes
+rpi4b                     edge            jammy       cli                      stable         no
 
 
 # uefi-x86
-uefi-x86                  edge            jammy       cli                      stable         yes
+uefi-x86                  edge            jammy       cli                      stable         no
 
 
 # uefi-arm64
-uefi-arm64                edge            jammy       cli                      stable         yes
+uefi-arm64                edge            jammy       cli                      stable         no
 
 
 # Virtual qemu
-virtual-qemu              current         focal       cli                      stable         yes
+virtual-qemu              current         focal       cli                      stable         no

--- a/config/targets.conf
+++ b/config/targets.conf
@@ -408,16 +408,30 @@ jetson-nano               edge            jammy       cli                      s
 
 
 # Raspberry Pi4
-rpi4b                     edge            jammy       cli                      stable         no
+rpi4b                     current         focal       desktop                  stable         yes            xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+rpi4b                     current         focal       desktop                  stable         yes            cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+rpi4b                     edge            bullseye    cli                      stable         yes
+rpi4b                     edge            focal       cli                      stable         yes
+rpi4b                     edge            jammy       cli                      stable         yes
 
 
 # uefi-x86
-uefi-x86                  edge            jammy       cli                      stable         no
+uefi-x86                  edge            bullseye    cli                      stable         yes
+uefi-x86                  edge            focal       cli                      stable         yes
+uefi-x86                  edge            focal       desktop                  stable         yes            xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+uefi-x86                  edge            focal       desktop                  stable         yes            cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+uefi-x86                  edge            jammy       cli                      stable         yes
 
 
 # uefi-arm64
-uefi-arm64                edge            jammy       cli                      stable         no
+uefi-arm64                edge            bullseye    cli                      stable         yes
+uefi-arm64                edge            focal       cli                      stable         yes
+uefi-arm64                edge            focal       desktop                  stable         yes            xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+uefi-arm64                edge            focal       desktop                  stable         yes            cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+uefi-arm64                edge            jammy       cli                      stable         yes
 
 
 # Virtual qemu
-virtual-qemu              current         jammy       cli                      stable         no
+virtual-qemu              current         focal       cli                      stable         yes
+virtual-qemu              current         bullseye    cli                      stable         yes
+virtual-qemu              current         jammy       cli                      stable         yes


### PR DESCRIPTION
# Description

All those targets are WIP, but not having a dedicated maintainer yet. It would probably be good to make images + download pages showing WIP status asking for maintainers to show up?

There will be warning in the welcome screen and on download pages. Is that alright according to 
https://docs.armbian.com/User-Guide_Board-Support-Rules/

```
Welcome to Armbian 22.08.8 Focal with Linux 5.4.0-1048-raspi

No end-user support: work in progress
```