### PR TITLE
Fix branch for linux-firmware from master to main

### DIFF
--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -590,7 +590,7 @@ compile_firmware()
 
 	fetch_from_repo "https://github.com/armbian/firmware" "armbian-firmware-git" "branch:master"
 	if [[ -n $FULL ]]; then
-		fetch_from_repo "$MAINLINE_FIRMWARE_SOURCE" "linux-firmware-git" "branch:master"
+		fetch_from_repo "$MAINLINE_FIRMWARE_SOURCE" "linux-firmware-git" "branch:main"
 		# cp : create hardlinks
 		cp -af --reflink=auto "${SRC}"/cache/sources/linux-firmware-git/* "${firmwaretempdir}/${plugin_dir}/lib/firmware/"
 	fi


### PR DESCRIPTION
# Description

Fix branch for linux-firmware from master to main

```
[ o.k. ] Checking git sources [ linux-firmware-git master ]
[ .... ] Fetching updates 
fatal: couldn't find remote ref master
fatal: couldn't find remote ref master
[ .... ] Checking out 

```
Jira reference number [AR-1043]

# How Has This Been Tested?

Build.

```
[ o.k. ] Checking git sources [ linux-firmware-git main ]
[ .... ] Fetching updates 
remote: Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
From https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware
 * branch            main       -> FETCH_HEAD
[ .... ] Checking out 
```
# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1043]: https://armbian.atlassian.net/browse/AR-1043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ