### PR TITLE
Fix install basic packages without sudo

### DIFF
--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1305,7 +1305,7 @@ prepare_host_basic()
 
 	if [[ -n $install_pack ]]; then
 		display_alert "Installing basic packages" "$install_pack"
-		apt-get -qq update && apt-get install -qq -y --no-install-recommends $install_pack
+		sudo bash -c "apt-get -qq update && apt-get install -qq -y --no-install-recommends $install_pack"
 	fi
 
 }


### PR DESCRIPTION
# Description

Installing basic packages without sudo produce errors.
Quick fix is enable sudo call.
It executed from compile.sh and generate error in docker mode.
See https://github.com/armbian/build/pull/3386

Jira reference number [AR-1045]

# How Has This Been Tested?

Build started without errors


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1045]: https://armbian.atlassian.net/browse/AR-1045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ