### PR TITLE
Bugfix. Create a directory for the build environment cache

### DIFF
--- a/lib/chroot-buildpackages.sh
+++ b/lib/chroot-buildpackages.sh
@@ -160,6 +160,7 @@ chroot_build_packages()
 {
 	local built_ok=()
 	local failed=()
+	mkdir -p ${SRC}/cache/buildpkg
 
 	if [[ $IMAGE_TYPE == user-built ]]; then
 		# if user-built image compile only for selected arch/release


### PR DESCRIPTION
# Description

At the very beginning of the path, create a directory for the build environment cache if it does not exist.

# Checklist:

- [x] Test build in chroot env when armbian build environment is clean.
