### PR TITLE
unified location for u-boot

### DIFF
--- a/packages/bsp/common/usr/sbin/nand-sata-install
+++ b/packages/bsp/common/usr/sbin/nand-sata-install
@@ -30,14 +30,7 @@ if grep -q 'sun4i' /proc/cpuinfo; then DEVICE_TYPE="a10";
 elif grep -q 'sun5i' /proc/cpuinfo; then DEVICE_TYPE="a13";
 else DEVICE_TYPE="a20"; fi
 BOOTLOADER="${CWD}/${DEVICE_TYPE}/bootloader"
-case ${LINUXFAMILY} in
-	rk3328|rk3399|rk35xx|rockchip64|rockpis|station)
-		FIRSTSECTOR=32768
-		;;
-	*)
-		FIRSTSECTOR=8192
-		;;
-esac
+FIRSTSECTOR=32768
 
 #recognize_root
 root_uuid=$(sed -e 's/^.*root=//' -e 's/ .*$//' < /proc/cmdline)


### PR DESCRIPTION
unified location for u-boot placement, uniform size on media for u-boot placement for all supported device models. This will make it easy to implement a single command in the u-boot update scripts to create and restore a backup copy before installing a new version (via the dd utility).
