### PR TITLE
JetHome: add bullseye stable current and beta edge build targets

### DIFF
--- a/config/targets-cli-beta.conf
+++ b/config/targets-cli-beta.conf
@@ -7,10 +7,12 @@ helios64                     edge            jammy       cli                    
 
 
 # JetHub H1 (j80)
+jethubj80                    edge            bullseye    cli                      beta         yes
 jethubj80                    edge            jammy       cli                      beta         yes
 
 
 # JetHub D1 (j100)
+jethubj100                   edge            bullseye    cli                      beta         yes
 jethubj100                   edge            jammy       cli                      beta         yes
 
 

--- a/config/targets.conf
+++ b/config/targets.conf
@@ -387,6 +387,7 @@ zeropi                    edge            jammy       cli                      s
 
 
 # JetHub H1 (j80)
+jethubj80                 current         bullseye    cli                      stable         yes
 jethubj80                 current         focal       cli                      stable         yes
 jethubj80                 edge            focal       cli                      stable         yes
 jethubj80                 current         jammy       cli                      stable         yes
@@ -394,6 +395,7 @@ jethubj80                 edge            jammy       cli                      s
 
 
 # JetHub D1 (j100)
+jethubj100                current         bullseye    cli                      stable         yes
 jethubj100                current         focal       cli                      stable         yes
 jethubj100                edge            focal       cli                      stable         yes
 jethubj100                current         jammy       cli                      stable         yes


### PR DESCRIPTION
# Description

JetHome: add bullseye stable current and beta edge build targets
Jira reference number [AR-1047]

# How Has This Been Tested?

Builds ok.

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1047]: https://armbian.atlassian.net/browse/AR-1047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ