### PR TITLE
Bugfix: debugging package for kernel are not created #3405

### DIFF
--- a/packages/armbian/mkdebian
+++ b/packages/armbian/mkdebian
@@ -223,6 +223,7 @@ fi
 
 if is_enabled CONFIG_DEBUG_INFO; then
 cat <<EOF >> debian/control
+
 Package: $dbg_packagename
 Section: debug
 Architecture: $debarch


### PR DESCRIPTION
# Description

Build a debugging package for the kernel if the CONFIG_DEBUG_INFO=y parameter is set in the kernel configuration.
Issues: packages are not created #3405 

# Checklist:
- [x] Test build with the  [config-sunxi64.conf](https://nopaste.net/XirP7ZCLpR) file provided by the @ArgonautQ user.

