### PR TITLE
fix bootsplash and move set PKG_PREFIX to arm64.conf

### DIFF
--- a/config/sources/arm64.conf
+++ b/config/sources/arm64.conf
@@ -50,3 +50,16 @@ fi
 ## System toolchains don't have the -none- variant, remove it
 [[ "${SKIP_EXTERNAL_TOOLCHAINS}" == "yes" ]] && [[ "${UBOOT_COMPILER}" = *none* ]] && UBOOT_COMPILER="${UBOOT_COMPILER//-none-/-}"
 [[ "${SKIP_EXTERNAL_TOOLCHAINS}" == "yes" ]] && [[ "${ATF_COMPILER}" = *none* ]] && ATF_COMPILER="${ATF_COMPILER//-none-/-}"
+
+if [ "$(uname -m)" = "aarch64" ]; then
+	case "$(lsb_release -sc)" in
+	"bullseye"|"focal"|"hirsute"|"impish"|"jammy")
+		PKG_PREFIX="qemu-x86_64-static -L /usr/x86_64-linux-gnu "
+		;;
+	*)
+		PKG_PREFIX="qemu-x86_64 -L /usr/x86_64-linux-gnu "
+		;;
+	esac
+else
+	PKG_PREFIX=""
+fi

--- a/config/sources/families/include/meson64_common.inc
+++ b/config/sources/families/include/meson64_common.inc
@@ -40,15 +40,15 @@ case $BRANCH in
 
 esac
 
-if [ "$(uname -m)" = "aarch64" ]; then
-	if [[ "$(lsb_release -sc)" == "bullseye" || "$(lsb_release -sc)" == "focal" || "$(lsb_release -sc)" == "hirsute" || "$(lsb_release -sc)" == "impish"  || "$(lsb_release -sc)" == "jammy" ]]; then
-		PKG_PREFIX="qemu-x86_64-static -L /usr/x86_64-linux-gnu "
-	else
-		PKG_PREFIX="qemu-x86_64 "
-	fi
-else
-	PKG_PREFIX=""
-fi
+#if [ "$(uname -m)" = "aarch64" ]; then
+#	if [[ "$(lsb_release -sc)" == "bullseye" || "$(lsb_release -sc)" == "focal" || "$(lsb_release -sc)" == "hirsute" || "$(lsb_release -sc)" == "impish"  || "$(lsb_release -sc)" == "jammy" ]]; then
+#		PKG_PREFIX="qemu-x86_64-static -L /usr/x86_64-linux-gnu "
+#	else
+#		PKG_PREFIX="qemu-x86_64 "
+#	fi
+#else
+#	PKG_PREFIX=""
+#fi
 
 # this helper function includes postprocess for p212 and its variants.
 # $1 PATH for uboot blob repo

--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -15,18 +15,18 @@ BOOTPATCHDIR="u-boot-rockchip64"
 PACKAGE_LIST_FAMILY="ethtool"
 
 RKBIN_DIR="$SRC/cache/sources/rkbin-tools"
-if [ "$(uname -m)" = "aarch64" ]; then
-	case "$(lsb_release -sc)" in
-	"bullseye"|"focal"|"hirsute"|"impish"|"jammy")
-		PKG_PREFIX="qemu-x86_64-static -L /usr/x86_64-linux-gnu "
-		;;
-	*)
-		PKG_PREFIX="qemu-x86_64 -L /usr/x86_64-linux-gnu "
-		;;
-	esac
-else
-	PKG_PREFIX=""
-fi
+#if [ "$(uname -m)" = "aarch64" ]; then
+#	case "$(lsb_release -sc)" in
+#	"bullseye"|"focal"|"hirsute"|"impish"|"jammy")
+#		PKG_PREFIX="qemu-x86_64-static -L /usr/x86_64-linux-gnu "
+#		;;
+#	*)
+#		PKG_PREFIX="qemu-x86_64 -L /usr/x86_64-linux-gnu "
+#		;;
+#	esac
+#else
+#	PKG_PREFIX=""
+#fi
 
 BOOT_SOC=`expr $BOOTCONFIG : '.*\(rk[[:digit:]]\+.*\)_.*'`
 

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -698,7 +698,7 @@ display_alert "Building kernel splash logo" "$RELEASE" "info"
 	THROBBER_HEIGHT=$(identify $THROBBER | head -1 | cut -d " " -f 3 | cut -d x -f 2)
 	convert -alpha remove -background "#000000"	$LOGO "${SDCARD}"/tmp/logo.rgb
 	convert -alpha remove -background "#000000" $THROBBER "${SDCARD}"/tmp/throbber%02d.rgb
-	${SRC}/packages/blobs/splash/bootsplash-packer \
+	$PKG_PREFIX${SRC}/packages/blobs/splash/bootsplash-packer \
 	--bg_red 0x00 \
 	--bg_green 0x00 \
 	--bg_blue 0x00 \


### PR DESCRIPTION
Fixes the creation of bootsplash and combines the settings for running x86 utilities for all ARM models and will allow you to run x86 binary utilities on any node in the future.

While this has not been fully tested, we ask everyone who uses the ARM assembly to check the operation of the new version.
