### PR TITLE
Bugfix - remove reference to aptly repository since it went offline

### DIFF
--- a/config/templates/Dockerfile
+++ b/config/templates/Dockerfile
@@ -10,14 +10,7 @@ RUN apt-get update && apt-get -y install \
     && rm -rf /var/lib/apt/lists/*
 RUN sh -c " \
     if [ $(dpkg --print-architecture) = amd64 ]; then \
-        if [ x'' != x$http_proxy ]; then \
-            curl -fsSL -x $http_proxy https://www.aptly.info/pubkey.txt | apt-key add - >/dev/null 2>&1; \
-        else \
-            curl -fsSL https://www.aptly.info/pubkey.txt | apt-key add - >/dev/null 2>&1; \
-        fi; \
-        echo \"deb http://repo.aptly.info/ nightly main\" > /etc/apt/sources.list.d/aptly.list; \
-        dpkg --add-architecture i386 \
-        && apt-get update \
+        apt-get update \
         && apt-get install -y --no-install-recommends \
         lib32ncurses6 \
         lib32stdc++6 \
@@ -66,7 +59,8 @@ RUN apt-get update \
        libbison-dev \
        libc6-amd64-cross \
        libc6-dev-armhf-cross \
-       libfdt-dev libelf-dev \
+       libfdt-dev \
+       libelf-dev \
        libfile-fcntllock-perl \
        libfl-dev \
        liblz4-tool \

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1452,26 +1452,6 @@ prepare_host()
 
 	if [ -n "${EXTRA_BUILD_DEPS}" ]; then hostdeps+=" ${EXTRA_BUILD_DEPS}"; fi
 
-	# distribution packages are buggy, download from author
-
-# build aarch64
-  if [[ $(dpkg --print-architecture) == amd64 ]]; then
-
-	if [[ ! -f /etc/apt/sources.list.d/aptly.list ]]; then
-		display_alert "Updating from external repository" "aptly" "info"
-		if [ x"" != x"${http_proxy}" ]; then
-			apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --keyserver-options http-proxy="${http_proxy}" --recv-keys ED75B5A4483DA07C >/dev/null 2>&1
-		else
-			apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ED75B5A4483DA07C >/dev/null 2>&1
-		fi
-		echo "deb http://repo.aptly.info/ nightly main" > /etc/apt/sources.list.d/aptly.list
-	else
-		sed "s/squeeze/nightly/" -i /etc/apt/sources.list.d/aptly.list
-	fi
-
-# build aarch64
-  fi
-
 	display_alert "Installing build dependencies"
 	# don't prompt for apt cacher selection
 	sudo echo "apt-cacher-ng    apt-cacher-ng/tunnelenable      boolean false" | sudo debconf-set-selections


### PR DESCRIPTION
# Description

Ubuntu from 21.10 on ships the same version.

Jira reference number [AR-1055]

Closes: https://github.com/armbian/build/issues/3415

[AR-1055]: https://armbian.atlassian.net/browse/AR-1055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ