### PR TITLE
Remove deprecated library from Dockerfile

### DIFF
--- a/config/templates/Dockerfile
+++ b/config/templates/Dockerfile
@@ -15,8 +15,7 @@ RUN sh -c " \
         lib32ncurses6 \
         lib32stdc++6 \
         lib32tinfo6 \
-        libc6-i386 \
-        zlib1g:i386; \
+        libc6-i386; \
     fi"
 RUN apt-get update \
     && apt-get -y upgrade \

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1371,7 +1371,7 @@ prepare_host()
 
   if [[ $(dpkg --print-architecture) == amd64 ]]; then
 
-	hostdeps+=" distcc lib32ncurses-dev lib32stdc++6 libc6-i386 zlib1g:i386"
+	hostdeps+=" distcc lib32ncurses-dev lib32stdc++6 libc6-i386"
 	grep -q i386 <(dpkg --print-foreign-architectures) || dpkg --add-architecture i386
 
   elif [[ $(dpkg --print-architecture) == arm64 ]]; then


### PR DESCRIPTION
# Description

zlib1g:i386 fails to installs and it looks like we don't need it. A full CI passed without a problem. I don't recall why we needed this in 1st place.

Jira reference number [AR-590]

[AR-590]: https://armbian.atlassian.net/browse/AR-590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ