### PR TITLE
rockchip64: add realtek rtl8723cs and rtl8703bs wifi/bt for edge 5.15 kernel

### DIFF
--- a/config/kernel/linux-rockchip64-edge.config
+++ b/config/kernel/linux-rockchip64-edge.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.15.15 Kernel Configuration
+# Linux/arm64 5.15.16 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (GNU Toolchain for the A-profile Architecture 8.3-2019.03 (arm-rel-8.36)) 8.3.0"
 CONFIG_CC_IS_GCC=y
@@ -3332,6 +3332,7 @@ CONFIG_RTL8723_COMMON=m
 CONFIG_RTLBTCOEXIST=m
 CONFIG_RTL8XXXU=m
 # CONFIG_RTL8XXXU_UNTESTED is not set
+CONFIG_RTL8723CS=m
 CONFIG_RTW88=m
 # CONFIG_RTW88_8822BE is not set
 # CONFIG_RTW88_8822CE is not set

--- a/patch/kernel/archive/rockchip64-5.15/general-bluetooth-02-add-support-for-RTL8723CS.patch
+++ b/patch/kernel/archive/rockchip64-5.15/general-bluetooth-02-add-support-for-RTL8723CS.patch
@@ -1,0 +1,257 @@
+From 26e61cffb09c1f5519a4eeb9d9e99239d58b6c2d Mon Sep 17 00:00:00 2001
+From: Ondrej Jirman <megous@megous.com>
+Date: Thu, 1 Jul 2021 11:22:23 +0200
+Subject: [PATCH 302/467] Bluetooth: btrtl: add support for the RTL8723CS
+
+The Realtek RTL8723CS is SDIO WiFi chip. It also contains a Bluetooth
+module which is connected via UART to the host.
+
+It shares lmp subversion with 8703B, so Realtek's userspace
+initialization tool (rtk_hciattach) differentiates varieties of RTL8723CS
+(CG, VF, XX) with RTL8703B using vendor's command to read chip type.
+
+Also this chip declares support for some features it doesn't support
+so add a quirk to indicate that these features are broken.
+
+Signed-off-by: Vasily Khoruzhick <anarsoul@gmail.com>
+Signed-off-by: Ondrej Jirman <megous@megous.com>
+---
+ drivers/bluetooth/btrtl.c | 119 +++++++++++++++++++++++++++++++++++++-
+ drivers/bluetooth/btrtl.h |   5 ++
+ 2 files changed, 121 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/bluetooth/btrtl.c b/drivers/bluetooth/btrtl.c
+index 1f8afa024..fd293a9c4 100644
+--- a/drivers/bluetooth/btrtl.c
++++ b/drivers/bluetooth/btrtl.c
+@@ -17,7 +17,12 @@
+ 
+ #define VERSION "0.1"
+ 
++#define RTL_CHIP_8723CS_CG	3
++#define RTL_CHIP_8723CS_VF	4
++#define RTL_CHIP_8723CS_XX	5
+ #define RTL_EPATCH_SIGNATURE	"Realtech"
++#define RTL_ROM_LMP_3499	0x3499
++#define RTL_ROM_LMP_8703B	0x8703
+ #define RTL_ROM_LMP_8723A	0x1200
+ #define RTL_ROM_LMP_8723B	0x8723
+ #define RTL_ROM_LMP_8821A	0x8821
+@@ -30,6 +35,7 @@
+ #define IC_MATCH_FL_HCIREV	(1 << 1)
+ #define IC_MATCH_FL_HCIVER	(1 << 2)
+ #define IC_MATCH_FL_HCIBUS	(1 << 3)
++#define IC_MATCH_FL_CHIP_TYPE	(1 << 4)
+ #define IC_INFO(lmps, hcir, hciv, bus) \
+ 	.match_flags = IC_MATCH_FL_LMPSUBV | IC_MATCH_FL_HCIREV | \
+ 		       IC_MATCH_FL_HCIVER | IC_MATCH_FL_HCIBUS, \
+@@ -57,6 +63,7 @@ struct id_table {
+ 	__u16 hci_rev;
+ 	__u8 hci_ver;
+ 	__u8 hci_bus;
++	__u8 chip_type;
+ 	bool config_needed;
+ 	bool has_rom_version;
+ 	char *fw_name;
+@@ -96,6 +103,39 @@ static const struct id_table ic_id_table[] = {
+ 	  .fw_name  = "rtl_bt/rtl8723b_fw.bin",
+ 	  .cfg_name = "rtl_bt/rtl8723b_config" },
+ 
++	/* 8723CS-CG */
++	{ .match_flags = IC_MATCH_FL_LMPSUBV | IC_MATCH_FL_CHIP_TYPE |
++			 IC_MATCH_FL_HCIBUS,
++	  .lmp_subver = RTL_ROM_LMP_8703B,
++	  .chip_type = RTL_CHIP_8723CS_CG,
++	  .hci_bus = HCI_UART,
++	  .config_needed = true,
++	  .has_rom_version = true,
++	  .fw_name  = "rtl_bt/rtl8723cs_cg_fw.bin",
++	  .cfg_name = "rtl_bt/rtl8723cs_cg_config" },
++
++	/* 8723CS-VF */
++	{ .match_flags = IC_MATCH_FL_LMPSUBV | IC_MATCH_FL_CHIP_TYPE |
++			 IC_MATCH_FL_HCIBUS,
++	  .lmp_subver = RTL_ROM_LMP_8703B,
++	  .chip_type = RTL_CHIP_8723CS_VF,
++	  .hci_bus = HCI_UART,
++	  .config_needed = true,
++	  .has_rom_version = true,
++	  .fw_name  = "rtl_bt/rtl8723cs_vf_fw.bin",
++	  .cfg_name = "rtl_bt/rtl8723cs_vf_config" },
++
++	/* 8723CS-XX */
++	{ .match_flags = IC_MATCH_FL_LMPSUBV | IC_MATCH_FL_CHIP_TYPE |
++			 IC_MATCH_FL_HCIBUS,
++	  .lmp_subver = RTL_ROM_LMP_8703B,
++	  .chip_type = RTL_CHIP_8723CS_XX,
++	  .hci_bus = HCI_UART,
++	  .config_needed = true,
++	  .has_rom_version = true,
++	  .fw_name  = "rtl_bt/rtl8723cs_xx_fw.bin",
++	  .cfg_name = "rtl_bt/rtl8723cs_xx_config" },
++
+ 	/* 8723D */
+ 	{ IC_INFO(RTL_ROM_LMP_8723B, 0xd, 0x8, HCI_USB),
+ 	  .config_needed = true,
+@@ -175,7 +215,8 @@ static const struct id_table ic_id_table[] = {
+ 	};
+ 
+ static const struct id_table *btrtl_match_ic(u16 lmp_subver, u16 hci_rev,
+-					     u8 hci_ver, u8 hci_bus)
++					     u8 hci_ver, u8 hci_bus,
++					     u8 chip_type)
+ {
+ 	int i;
+ 
+@@ -192,6 +233,9 @@ static const struct id_table *btrtl_match_ic(u16 lmp_subver, u16 hci_rev,
+ 		if ((ic_id_table[i].match_flags & IC_MATCH_FL_HCIBUS) &&
+ 		    (ic_id_table[i].hci_bus != hci_bus))
+ 			continue;
++		if ((ic_id_table[i].match_flags & IC_MATCH_FL_CHIP_TYPE) &&
++		    (ic_id_table[i].chip_type != chip_type))
++			continue;
+ 
+ 		break;
+ 	}
+@@ -274,6 +318,7 @@ static int rtlbt_parse_firmware(struct hci_dev *hdev,
+ 		{ RTL_ROM_LMP_8723B, 1 },
+ 		{ RTL_ROM_LMP_8821A, 2 },
+ 		{ RTL_ROM_LMP_8761A, 3 },
++		{ RTL_ROM_LMP_8703B, 7 },
+ 		{ RTL_ROM_LMP_8822B, 8 },
+ 		{ RTL_ROM_LMP_8723B, 9 },	/* 8723D */
+ 		{ RTL_ROM_LMP_8821A, 10 },	/* 8821C */
+@@ -552,6 +597,48 @@ static int btrtl_setup_rtl8723b(struct hci_dev *hdev,
+ 	return ret;
+ }
+ 
++static bool rtl_has_chip_type(u16 lmp_subver)
++{
++	switch (lmp_subver) {
++	case RTL_ROM_LMP_8703B:
++		return true;
++	default:
++		break;
++	}
++
++	return  false;
++}
++
++static int rtl_read_chip_type(struct hci_dev *hdev, u8 *type)
++{
++	struct rtl_chip_type_evt *chip_type;
++	struct sk_buff *skb;
++	const unsigned char cmd_buf[] = {0x00, 0x94, 0xa0, 0x00, 0xb0};
++
++	/* Read RTL chip type command */
++	skb = __hci_cmd_sync(hdev, 0xfc61, 5, cmd_buf, HCI_INIT_TIMEOUT);
++	if (IS_ERR(skb)) {
++		rtl_dev_err(hdev, "Read chip type failed (%ld)",
++			    PTR_ERR(skb));
++		return PTR_ERR(skb);
++	}
++
++	if (skb->len != sizeof(*chip_type)) {
++		rtl_dev_err(hdev, "RTL chip type event length mismatch");
++		kfree_skb(skb);
++		return -EIO;
++	}
++
++	chip_type = (struct rtl_chip_type_evt *)skb->data;
++	rtl_dev_info(hdev, "chip_type status=%x type=%x",
++		     chip_type->status, chip_type->type);
++
++	*type = chip_type->type & 0x0f;
++
++	kfree_skb(skb);
++	return 0;
++}
++
+ void btrtl_free(struct btrtl_device_info *btrtl_dev)
+ {
+ 	kvfree(btrtl_dev->fw_data);
+@@ -568,7 +655,7 @@ struct btrtl_device_info *btrtl_initialize(struct hci_dev *hdev,
+ 	struct hci_rp_read_local_version *resp;
+ 	char cfg_name[40];
+ 	u16 hci_rev, lmp_subver;
+-	u8 hci_ver;
++	u8 hci_ver, chip_type = 0;
+ 	int ret;
+ 	u16 opcode;
+ 	u8 cmd[2];
+@@ -638,8 +725,14 @@ struct btrtl_device_info *btrtl_initialize(struct hci_dev *hdev,
+ out_free:
+ 	kfree_skb(skb);
+ 
++	if (rtl_has_chip_type(lmp_subver)) {
++		ret = rtl_read_chip_type(hdev, &chip_type);
++		if (ret)
++			goto err_free;
++	}
++
+ 	btrtl_dev->ic_info = btrtl_match_ic(lmp_subver, hci_rev, hci_ver,
+-					    hdev->bus);
++					    hdev->bus, chip_type);
+ 
+ 	if (!btrtl_dev->ic_info) {
+ 		rtl_dev_info(hdev, "unknown IC info, lmp subver %04x, hci rev %04x, hci ver %04x",
+@@ -722,6 +815,7 @@ int btrtl_download_firmware(struct hci_dev *hdev,
+ 	case RTL_ROM_LMP_8761A:
+ 	case RTL_ROM_LMP_8822B:
+ 	case RTL_ROM_LMP_8852A:
++	case RTL_ROM_LMP_8703B:
+ 		return btrtl_setup_rtl8723b(hdev, btrtl_dev);
+ 	default:
+ 		rtl_dev_info(hdev, "assuming no firmware upload needed");
+@@ -752,6 +846,19 @@ void btrtl_set_quirks(struct hci_dev *hdev, struct btrtl_device_info *btrtl_dev)
+ 		rtl_dev_dbg(hdev, "WBS supported not enabled.");
+ 		break;
+ 	}
++
++	switch (btrtl_dev->ic_info->lmp_subver) {
++	case RTL_ROM_LMP_8703B:
++		/* 8723CS reports two pages for local ext features,
++		 * but it doesn't support any features from page 2 -
++		 * it either responds with garbage or with error status
++		 */
++		set_bit(HCI_QUIRK_BROKEN_LOCAL_EXT_FTR_MAX_PAGE,
++			&hdev->quirks);
++		break;
++	default:
++		break;
++	}
+ }
+ EXPORT_SYMBOL_GPL(btrtl_set_quirks);
+ 
+@@ -910,6 +1017,12 @@ MODULE_FIRMWARE("rtl_bt/rtl8723b_fw.bin");
+ MODULE_FIRMWARE("rtl_bt/rtl8723b_config.bin");
+ MODULE_FIRMWARE("rtl_bt/rtl8723bs_fw.bin");
+ MODULE_FIRMWARE("rtl_bt/rtl8723bs_config.bin");
++MODULE_FIRMWARE("rtl_bt/rtl8723cs_cg_fw.bin");
++MODULE_FIRMWARE("rtl_bt/rtl8723cs_cg_config.bin");
++MODULE_FIRMWARE("rtl_bt/rtl8723cs_vf_fw.bin");
++MODULE_FIRMWARE("rtl_bt/rtl8723cs_vf_config.bin");
++MODULE_FIRMWARE("rtl_bt/rtl8723cs_xx_fw.bin");
++MODULE_FIRMWARE("rtl_bt/rtl8723cs_xx_config.bin");
+ MODULE_FIRMWARE("rtl_bt/rtl8723ds_fw.bin");
+ MODULE_FIRMWARE("rtl_bt/rtl8723ds_config.bin");
+ MODULE_FIRMWARE("rtl_bt/rtl8761a_fw.bin");
+diff --git a/drivers/bluetooth/btrtl.h b/drivers/bluetooth/btrtl.h
+index 2c441bda3..1c6282241 100644
+--- a/drivers/bluetooth/btrtl.h
++++ b/drivers/bluetooth/btrtl.h
+@@ -14,6 +14,11 @@
+ 
+ struct btrtl_device_info;
+ 
++struct rtl_chip_type_evt {
++	__u8 status;
++	__u8 type;
++} __packed;
++
+ struct rtl_download_cmd {
+ 	__u8 index;
+ 	__u8 data[RTL_FRAG_LEN];
+-- 
+2.34.0
+

--- a/patch/kernel/archive/rockchip64-5.15/general-bluetooth-03-hci_h5-add-binding-RTL8723CS.patch
+++ b/patch/kernel/archive/rockchip64-5.15/general-bluetooth-03-hci_h5-add-binding-RTL8723CS.patch
@@ -1,0 +1,31 @@
+From 8fc0422773dc5274fa32e2a5a6ce2e1f0a96d78c Mon Sep 17 00:00:00 2001
+From: Vasily Khoruzhick <anarsoul@gmail.com>
+Date: Wed, 31 Oct 2018 20:07:41 -0700
+Subject: [PATCH 304/467] Bluetooth: hci_h5: Add support for binding RTL8723CS
+ with device tree
+
+RTL8723CS is often used in ARM boards, so add ability to bind it
+using device tree.
+
+Signed-off-by: Vasily Khoruzhick <anarsoul@gmail.com>
+Signed-off-by: Ondrej Jirman <megous@megous.com>
+---
+ drivers/bluetooth/hci_h5.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/bluetooth/hci_h5.c b/drivers/bluetooth/hci_h5.c
+index d49a39d17..c9b54335a 100644
+--- a/drivers/bluetooth/hci_h5.c
++++ b/drivers/bluetooth/hci_h5.c
+@@ -1100,6 +1100,8 @@ static const struct of_device_id rtl_bluetooth_of_match[] = {
+ 	  .data = (const void *)&h5_data_rtl8723bs },
+ 	{ .compatible = "realtek,rtl8723ds-bt",
+ 	  .data = (const void *)&h5_data_rtl8723bs },
++	{ .compatible = "realtek,rtl8723cs-bt",
++	  .data = (const void *)&h5_data_rtl8723bs },
+ #endif
+ 	{ },
+ };
+-- 
+2.34.0
+

--- a/patch/kernel/archive/rockchip64-5.15/general-bluetooth-04-add-rtl8703bs.patch
+++ b/patch/kernel/archive/rockchip64-5.15/general-bluetooth-04-add-rtl8703bs.patch
@@ -1,0 +1,42 @@
+From f0c05140b92cca447cd55a93ad4de141d0f117f1 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Thu, 9 Dec 2021 22:47:36 +0000
+Subject: [PATCH] rtl8703bs: add chip type to list and info block
+
+---
+ drivers/bluetooth/btrtl.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/drivers/bluetooth/btrtl.c b/drivers/bluetooth/btrtl.c
+index ad4085eede4..2c227bf4e00 100644
+--- a/drivers/bluetooth/btrtl.c
++++ b/drivers/bluetooth/btrtl.c
+@@ -20,6 +20,7 @@
+ #define RTL_CHIP_8723CS_CG	3
+ #define RTL_CHIP_8723CS_VF	4
+ #define RTL_CHIP_8723CS_XX	5
++#define RTL_CHIP_8703BS		7
+ #define RTL_EPATCH_SIGNATURE	"Realtech"
+ #define RTL_ROM_LMP_3499	0x3499
+ #define RTL_ROM_LMP_8703B	0x8703
+@@ -136,6 +137,17 @@ static const struct id_table ic_id_table[] = {
+ 	  .fw_name  = "rtl_bt/rtl8723cs_xx_fw.bin",
+ 	  .cfg_name = "rtl_bt/rtl8723cs_xx_config" },
+ 
++	/* 8703BS */
++	{ .match_flags = IC_MATCH_FL_LMPSUBV | IC_MATCH_FL_CHIP_TYPE |
++			 IC_MATCH_FL_HCIBUS,
++	  .lmp_subver = RTL_ROM_LMP_8703B,
++	  .chip_type = RTL_CHIP_8703BS,
++	  .hci_bus = HCI_UART,
++	  .config_needed = true,
++	  .has_rom_version = true,
++	  .fw_name  = "rtl_bt/rtl8723cs_xx_fw.bin",
++	  .cfg_name = "rtl_bt/rtl8723cs_xx_config" },
++
+ 	/* 8723D */
+ 	{ IC_INFO(RTL_ROM_LMP_8723B, 0xd, 0x8, HCI_USB),
+ 	  .config_needed = true,
+-- 
+2.30.2
+

--- a/patch/kernel/archive/rockchip64-5.15/wifi-4001-add-realtek-8723cs-kconfig-makefile.patch
+++ b/patch/kernel/archive/rockchip64-5.15/wifi-4001-add-realtek-8723cs-kconfig-makefile.patch
@@ -1,0 +1,26 @@
+diff --git a/drivers/net/wireless/realtek/Kconfig b/drivers/net/wireless/realtek/Kconfig
+index 8ea2d8d..600c44d 100644
+--- a/drivers/net/wireless/realtek/Kconfig
++++ b/drivers/net/wireless/realtek/Kconfig
+@@ -13,8 +13,9 @@ config WLAN_VENDOR_REALTEK
+ if WLAN_VENDOR_REALTEK
+ 
+ source "drivers/net/wireless/realtek/rtl818x/Kconfig"
+ source "drivers/net/wireless/realtek/rtlwifi/Kconfig"
+ source "drivers/net/wireless/realtek/rtl8xxxu/Kconfig"
++source "drivers/net/wireless/realtek/rtl8723cs/Kconfig"
+ source "drivers/net/wireless/realtek/rtw88/Kconfig"
+ 
+ endif # WLAN_VENDOR_REALTEK
+diff --git a/drivers/net/wireless/realtek/Makefile b/drivers/net/wireless/realtek/Makefile
+index 9c78deb5..07b47850 100644
+--- a/drivers/net/wireless/realtek/Makefile
++++ b/drivers/net/wireless/realtek/Makefile
+@@ -4,6 +4,7 @@
+ 
+ obj-$(CONFIG_RTL8180)		+= rtl818x/
+ obj-$(CONFIG_RTL8187)		+= rtl818x/
++obj-$(CONFIG_RTL8723CS)         += rtl8723cs/
+ obj-$(CONFIG_RTLWIFI)		+= rtlwifi/
+ obj-$(CONFIG_RTL8XXXU)		+= rtl8xxxu/
+ 

--- a/patch/kernel/archive/rockchip64-5.15/wifi-4002-realtek-8723cs-Fix-IEEE80211_MAX_AMPDU_BUF.patch
+++ b/patch/kernel/archive/rockchip64-5.15/wifi-4002-realtek-8723cs-Fix-IEEE80211_MAX_AMPDU_BUF.patch
@@ -1,0 +1,31 @@
+From 4f15b08033441eeb2004c2a7ec19c91e1e75c332 Mon Sep 17 00:00:00 2001
+From: The-going <48602507+The-going@users.noreply.github.com>
+Date: Mon, 22 Nov 2021 18:53:11 +0300
+Subject: [PATCH] wifi 4002 realtek 8723cs Fix IEEE80211_MAX_AMPDU_BUF
+ redefined
+
+After v4.19 linux kernel, this definition is not required.
+The 1 drivers/net/wireless/realtek/rtlwifi/base.c file uses
+the variable IEEE80211_MAX_AMPDU_BUF_HT.
+
+See `git log -p b8042b3da925f390c1482b -3` command in
+git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git
+---
+ drivers/net/wireless/realtek/rtl8723cs/include/wifi.h | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/drivers/net/wireless/realtek/rtl8723cs/include/wifi.h b/drivers/net/wireless/realtek/rtl8723cs/include/wifi.h
+index 9d21a5afd..8ef0fd7ff 100644
+--- a/drivers/net/wireless/realtek/rtl8723cs/include/wifi.h
++++ b/drivers/net/wireless/realtek/rtl8723cs/include/wifi.h
+@@ -1006,7 +1006,6 @@ typedef enum _HT_CAP_AMPDU_DENSITY {
+  * According to IEEE802.11n spec size varies from 8K to 64K (in powers of 2)
+  */
+ #define IEEE80211_MIN_AMPDU_BUF 0x8
+-#define IEEE80211_MAX_AMPDU_BUF 0x40
+ 
+ 
+ /* Spatial Multiplexing Power Save Modes */
+-- 
+2.33.1
+


### PR DESCRIPTION
# Description

Add several patches to bring in rtl8723cs and 8703bs SDIO chips support for wifi and bluetooth via kernel serdev framework

# How Has This Been Tested?

- [x] Compilation of a rockchip64-edge kernel
- [x] Report of a user from tv-box forum that tested a custom kernel with patches enabled that says that "everything works fine!"

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings: some more warnings are reported in `compilation.log` as a realtek tradition
- [x] Any dependent changes have been merged and published in downstream modules
