### PR TITLE
JetHome: small fix: set CPUMIN=250000 for JetHub D1/H1

### DIFF
--- a/config/sources/families/jethub.conf
+++ b/config/sources/families/jethub.conf
@@ -1,7 +1,7 @@
 source "${BASH_SOURCE%/*}/include/meson64_common.inc"
 
 UBOOT_TARGET_MAP="u-boot-dtb.img;;u-boot.bin.sd.bin:u-boot.bin u-boot.bin:u-boot.nosd.bin u-boot-dtb.img"
-CPUMIN=100000
+CPUMIN=250000
 GOVERNOR="ondemand"
 BOOTSCRIPT="boot-jethub.cmd:boot.cmd"
 


### PR DESCRIPTION
# Description

JetHub D1 works unstable with w1-gpio on 100MHz, so set CPUMIN to 250MHz.


# How Has This Been Tested?

Tested by JetHome on new D1 board revision.

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
