### PR TITLE
Add gnome-system-monitor to Focal and Jammy

### DIFF
--- a/config/desktop/focal/environments/cinnamon/config_base/packages
+++ b/config/desktop/focal/environments/cinnamon/config_base/packages
@@ -59,6 +59,7 @@ gnome-user-docs-it
 gnome-user-docs-pt
 gnome-user-docs-ru
 gnome-user-docs-sl
+gnome-system-monitor
 gstreamer1.0-packagekit
 gstreamer1.0-plugins-base-apps
 gstreamer1.0-pulseaudio

--- a/config/desktop/focal/environments/mate/config_base/packages
+++ b/config/desktop/focal/environments/mate/config_base/packages
@@ -46,6 +46,7 @@ gnome-user-docs-it
 gnome-user-docs-pt
 gnome-user-docs-ru
 gnome-user-docs-sl
+gnome-system-monitor
 gstreamer1.0-packagekit
 gstreamer1.0-plugins-base-apps
 gstreamer1.0-pulseaudio

--- a/config/desktop/focal/environments/xfce/config_base/packages
+++ b/config/desktop/focal/environments/xfce/config_base/packages
@@ -47,6 +47,7 @@ gnome-user-docs-it
 gnome-user-docs-pt
 gnome-user-docs-ru
 gnome-user-docs-sl
+gnome-system-monitor
 gstreamer1.0-packagekit
 gstreamer1.0-plugins-base-apps
 gstreamer1.0-pulseaudio

--- a/config/desktop/jammy/environments/budgie/config_base/packages
+++ b/config/desktop/jammy/environments/budgie/config_base/packages
@@ -70,6 +70,7 @@ gnome-user-docs-it
 gnome-user-docs-pt
 gnome-user-docs-ru
 gnome-user-docs-sl
+gnome-system-monitor
 gstreamer1.0-packagekit
 gstreamer1.0-plugins-base-apps
 gstreamer1.0-pulseaudio

--- a/config/desktop/jammy/environments/gnome/config_base/packages
+++ b/config/desktop/jammy/environments/gnome/config_base/packages
@@ -55,6 +55,7 @@ gnome-shell
 gnome-shell-common
 gnome-shell-extension-appindicator
 gnome-shell-extension-trash
+gnome-system-monitor
 gvfs-backends
 hunspell-en-us
 inputattach


### PR DESCRIPTION
# Description

Add Gnome system monitor.

Jira reference number [AR-1068]

# How Has This Been Tested?

No need.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1068]: https://armbian.atlassian.net/browse/AR-1068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ