### PR TITLE
When checking for shell, use strict grep

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -88,7 +88,7 @@ set_shell()
 	fi
 	SHELL_PATH=$(grep /$USER_SHELL$ /etc/shells | tail -1)
 
-	chsh -s $(grep -iF "/$USER_SHELL" /etc/shells | tail -1)
+	chsh -s $(grep -wiF "/$USER_SHELL" /etc/shells | tail -1)
 	echo -e "\nShell: \x1B[92m${USER_SHELL^^}\x1B[0m"
 
 	# change shell for future users


### PR DESCRIPTION
# Description

Its harmless in current situation, but it can cause problems in the future. Lets fix it.

Jira reference number [AR-1069]

# How Has This Been Tested?

Manual run.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1069]: https://armbian.atlassian.net/browse/AR-1069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ