### PR TITLE
Nanopc T4 - remove Hirsute from build targets

### DIFF
--- a/config/targets.conf
+++ b/config/targets.conf
@@ -125,7 +125,7 @@ nanopct4                  current         bullseye    cli                      s
 nanopct4                  current         focal       cli                      stable         yes
 nanopct4                  current         focal       desktop                  stable         yes            xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 nanopct4                  current         focal       desktop                  stable         adv            cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-nanopct4                  edge            hirsute     cli                      stable         yes
+nanopct4                  edge            jammy       cli                      stable         yes
 
 
 # nanopi-r1


### PR DESCRIPTION
# Description

We don't build Hirsute cache nor targets.

Jira reference number [AR-1057]

# How Has This Been Tested?

Untested. It's just config change.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1057]: https://armbian.atlassian.net/browse/AR-1057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ