### PR TITLE
fix nfs boot image creation for #2930

### DIFF
--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -65,7 +65,7 @@ if [[ $CRYPTROOT_ENABLE == yes && -z $CRYPTROOT_PASSPHRASE ]]; then
 fi
 
 # small SD card with kernel, boot script and .dtb/.bin files
-[[ $ROOTFS_TYPE == nfs ]] && FIXED_IMAGE_SIZE=64
+[[ $ROOTFS_TYPE == nfs ]] && FIXED_IMAGE_SIZE=130
 
 # Since we are having too many options for mirror management,
 # then here is yet another mirror related option.


### PR DESCRIPTION
# Description

Fix creation image for nfs rootfs

# How Has This Been Tested?

I build 
`./compile.sh BOARD=odroidn2 CLEAN_LEVEL="image" BRANCH=edge ROOTFS_TYPE=nfs`
and 
`./compile.sh BOARD=odroidn2 CLEAN_LEVEL="image" BRANCH=edge`
second boots from sdcard as usual.
NFS version files creates without notable(?) errors. I don't know how to setup infrastructure for network boot.

