### PR TITLE
Add option to override default ubuntu arhive

### DIFF
--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -591,7 +591,7 @@ fi
 if [[ "${ARCH}" == "amd64" ]]; then
 	UBUNTU_MIRROR='archive.ubuntu.com/ubuntu' # ports are only for non-amd64, of course.
 
-		if [[ -z ${CUSTOM_UBUNTU_MIRROR} ]]; then # ubuntu redirector doesn't work well on amd64
+		if [[ -n ${CUSTOM_UBUNTU_MIRROR} ]]; then # ubuntu redirector doesn't work well on amd64
 			UBUNTU_MIRROR="${CUSTOM_UBUNTU_MIRROR}"
 		fi
 fi

--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -590,6 +590,10 @@ fi
 
 if [[ "${ARCH}" == "amd64" ]]; then
 	UBUNTU_MIRROR='archive.ubuntu.com/ubuntu' # ports are only for non-amd64, of course.
+
+		if [[ -z ${CUSTOM_UBUNTU_MIRROR} ]]; then # ubuntu redirector doesn't work well on amd64
+			UBUNTU_MIRROR="${CUSTOM_UBUNTU_MIRROR}"
+		fi
 fi
 
 # don't use mirrors that throws garbage on 404


### PR DESCRIPTION
# Description

This fixes random "Hash Sum mismatch" when making Ubuntu Jammy images. Perhaps its just a temporally, but we need this now. Switch doesn't harm and can also speed up assembly time.

Only affects x86 arch.

Jira reference number [AR-1079]

# How Has This Been Tested?

One manual run.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1079]: https://armbian.atlassian.net/browse/AR-1079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ