### PR TITLE
Add switch to skip image creation if it already exists

### DIFF
--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -45,6 +45,22 @@ else
 	REPO_CONFIG="aptly.conf"
 fi
 
+# image artefact destination with or without subfolder
+FINALDEST=$DEST/images
+if [[ "${MAKE_FOLDERS}" == yes ]]; then
+
+	if [[ "$RC" == yes ]]; then
+		FINALDEST=$DEST/images/"${BOARD}"/RC
+	elif [[ "$BETA" == yes ]]; then
+		FINALDEST=$DEST/images/"${BOARD}"/nightly
+	else
+		FINALDEST=$DEST/images/"${BOARD}"/archive
+	fi
+
+	install -d ${FINALDEST}
+fi
+
+
 # TODO: fixed name can't be used for parallel image building
 ROOT_MAPPER="armbian-root"
 

--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -914,21 +914,6 @@ POST_UMOUNT_FINAL_IMAGE
 	mkdir -p $DESTIMG
 	mv ${SDCARD}.raw $DESTIMG/${version}.img
 
-	FINALDEST=$DEST/images
-	[[ "${BUILD_ALL}" == yes ]] && MAKE_FOLDERS="yes"
-
-	if [[ "${MAKE_FOLDERS}" == yes ]]; then
-		if [[ "$RC" == yes ]]; then
-			FINALDEST=$DEST/images/"${BOARD}"/RC
-		elif [[ "$BETA" == yes ]]; then
-			FINALDEST=$DEST/images/"${BOARD}"/nightly
-		else
-			FINALDEST=$DEST/images/"${BOARD}"/archive
-		fi
-		install -d ${FINALDEST}
-	fi
-
-
 	# custom post_build_image_modify hook to run before fingerprinting and compression
 	[[ $(type -t post_build_image_modify) == function ]] && display_alert "Custom Hook Detected" "post_build_image_modify" "info" && post_build_image_modify "${DESTIMG}/${version}.img"
 

--- a/lib/main.sh
+++ b/lib/main.sh
@@ -525,7 +525,11 @@ overlayfs_wrapper "cleanup"
 [[ -n "${RELEASE}" && "${DESKTOP_ENVIRONMENT}" && ! -f "${DEB_STORAGE}/$RELEASE/${CHOSEN_DESKTOP}_${REVISION}_all.deb" && "${REPOSITORY_INSTALL}" != *armbian-desktop* ]] && create_desktop_package
 [[ -n "${RELEASE}" && "${DESKTOP_ENVIRONMENT}" && ! -f "${DEB_STORAGE}/${RELEASE}/${BSP_DESKTOP_PACKAGE_FULLNAME}.deb"  && "${REPOSITORY_INSTALL}" != *armbian-bsp-desktop* ]] && create_bsp_desktop_package
 
-
+# skip image creation if exists. useful for CI when making a lot of images
+if [ "$IMAGE_PRESENT" == yes ] && ls "${FINALDEST}/${VENDOR}_${REVISION}_${BOARD^}_${RELEASE}_${BRANCH}_${VER/-$LINUXFAMILY/}${DESKTOP_ENVIRONMENT:+_$DESKTOP_ENVIRONMENT}"*.xz 1> /dev/null 2>&1; then
+	display_alert "Skipping image creation" "image already made - IMAGE_PRESENT is set" "wrn"
+	exit
+fi
 
 # build additional packages
 [[ $EXTERNAL_NEW == compile ]] && chroot_build_packages


### PR DESCRIPTION
# Description

This feature is intendent for CI support.

Jira reference number [AR-1073]

# How Has This Been Tested?

- [x] Re-run image with and without switch

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1073]: https://armbian.atlassian.net/browse/AR-1073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ