### PR TITLE
Fix rpi upgrades to kernel and dtbs

### DIFF
--- a/config/sources/families/bcm2711.conf
+++ b/config/sources/families/bcm2711.conf
@@ -1,7 +1,7 @@
 enable_extension "flash-kernel"
 export LINUXFAMILY=bcm2711
 export ARCH=arm64
-export UEFI_FS_LABEL="rpicfg"               # Windows/Mac users will see this if they mount the SD card. Configurable
+export UEFI_FS_LABEL="RPICFG"               # Windows/Mac users will see this if they mount the SD card. Configurable, but should be uppercase always
 export SKIP_BOOTSPLASH="yes"                # video is init-ed before us
 export KERNELDIR='linux-rpi'                # Avoid sharing a source tree with others, until we know it's safe.
 export FK__PUBLISHED_KERNEL_VERSION="raspi" # flash kernel (FK) configuration
@@ -50,9 +50,9 @@ pre_flash_kernel__symlink_dtb_and_kernel() {
 		display_alert "Preparing DTBs and Kernel..." "bcm2711" "info"
 		mkdir -p "${MOUNT}"/etc/flash-kernel/dtbs
 
-		cat <<-EOD >>"${MOUNT}"/etc/flash-kernel/db
-			# Armbian kernels have a different flavour than expected.
-			Machine: ${FK__MACHINE_MODEL}
+		cat <<- EOD >> "${MOUNT}"/etc/flash-kernel/db
+			# Armbian kernels don't have a 'flavour'. Ignore flavors for all rpi revisions.
+			Machine: Raspberry Pi *
 			Kernel-Flavors: any
 		EOD
 
@@ -62,7 +62,7 @@ pre_flash_kernel__symlink_dtb_and_kernel() {
 			dtbBase=$(basename "${oneDTB}")
 			cp "${MOUNT}"/boot/dtb/broadcom/"${dtbBase}" "${MOUNT}"/etc/flash-kernel/dtbs/"${dtbBase}"
 		done
-		
+
 		rm -rf "${MOUNT}"/boot/dtb* || true
 
 		# @TODO: rpardini: packaging could maybe already use the correct names? I can't figure out how.

--- a/config/sources/families/bcm2711.conf
+++ b/config/sources/families/bcm2711.conf
@@ -56,14 +56,7 @@ pre_flash_kernel__symlink_dtb_and_kernel() {
 			Kernel-Flavors: any
 		EOD
 
-		## @TODO: rpardini: a horrible hack. I'll sort this out together with overlays, later.
-		local oneDTB dtbBase
-		for oneDTB in "${MOUNT}"/boot/dtb/broadcom/*.dtb; do
-			dtbBase=$(basename "${oneDTB}")
-			cp "${MOUNT}"/boot/dtb/broadcom/"${dtbBase}" "${MOUNT}"/etc/flash-kernel/dtbs/"${dtbBase}"
-		done
-
-		rm -rf "${MOUNT}"/boot/dtb* || true
+		## DTB compatibility has been moved to symlink done in packages/armbian/builddeb
 
 		# @TODO: rpardini: packaging could maybe already use the correct names? I can't figure out how.
 		ln -s ./Image "${MOUNT}"/boot/vmlinuz

--- a/packages/armbian/builddeb
+++ b/packages/armbian/builddeb
@@ -74,14 +74,22 @@ create_package() {
 			exit 0
 		EOT
 
+		# for Ubuntu/Debian compatiblity, symlink in /lib/firmware/$version/device-tree
 		cat >> $pdir/DEBIAN/postinst <<- EOT
 			cd /boot
 			ln -sfT dtb-$version dtb 2> /dev/null || mv dtb-$version dtb
+			mkdir -p /lib/firmware/$version
+			[ ! -L /lib/firmware/$version/device-tree ] && ln -s /boot/dtb-$version /lib/firmware/$version/device-tree
 			exit 0
+		EOT
+
+		cat >> $pdir/DEBIAN/postrm <<- EOT
+			rm -rf /lib/firmware/$version
 		EOT
 
 		chmod 775 $pdir/DEBIAN/preinst
 		chmod 775 $pdir/DEBIAN/postinst
+		chmod 775 $pdir/DEBIAN/postrm
 	fi
 
 	# Create postinst prerm script for headers

--- a/packages/armbian/builddeb
+++ b/packages/armbian/builddeb
@@ -68,57 +68,56 @@ create_package() {
 	# Create preinstall and post install script to remove dtb
 	if [ "$3" = "dtb" ]; then
 
-	cat >> $pdir/DEBIAN/preinst <<EOT
-rm -rf /boot/dtb
-rm -rf /boot/dtb-$version
-exit 0
-EOT
+		cat >> $pdir/DEBIAN/preinst <<- EOT
+			rm -rf /boot/dtb
+			rm -rf /boot/dtb-$version
+			exit 0
+		EOT
 
-	cat >> $pdir/DEBIAN/postinst <<EOT
-cd /boot
-ln -sfT dtb-$version dtb 2> /dev/null || mv dtb-$version dtb
-exit 0
-EOT
+		cat >> $pdir/DEBIAN/postinst <<- EOT
+			cd /boot
+			ln -sfT dtb-$version dtb 2> /dev/null || mv dtb-$version dtb
+			exit 0
+		EOT
 
-	chmod 775 $pdir/DEBIAN/preinst
-	chmod 775 $pdir/DEBIAN/postinst
+		chmod 775 $pdir/DEBIAN/preinst
+		chmod 775 $pdir/DEBIAN/postinst
 	fi
 
 	# Create postinst prerm script for headers
 	if [ "$3" = "headers" ]; then
 
-	# Set the time for all files to the current time.
-	# And build them for the current architecture.
-	cat >> $pdir/DEBIAN/postinst << EOT
-cd /usr/src/linux-headers-$version
-echo "Compiling headers - please wait ..."
-NCPU=\$(grep -c 'processor' /proc/cpuinfo)
-find -type f -exec touch {} +
-yes "" | make oldconfig >/dev/null
-make -j\$NCPU -s scripts >/dev/null
-make -j\$NCPU -s M=scripts/mod/ >/dev/null
-exit 0
-EOT
+		# Set the time for all files to the current time.
+		# And build them for the current architecture.
+		cat >> $pdir/DEBIAN/postinst <<- EOT
+			cd /usr/src/linux-headers-$version
+			echo "Compiling headers - please wait ..."
+			NCPU=\$(grep -c 'processor' /proc/cpuinfo)
+			find -type f -exec touch {} +
+			yes "" | make oldconfig >/dev/null
+			make -j\$NCPU -s scripts >/dev/null
+			make -j\$NCPU -s M=scripts/mod/ >/dev/null
+			exit 0
+		EOT
 
-	# After the configuration and compilation processes, new files
-	# appear that the package manager does not know anything about.
-	# Just clear all the files in the target directory.
-	cat >> $pdir/DEBIAN/prerm << EOT
-rm -rf /usr/src/linux-headers-$version
-exit 0
-EOT
+		# After the configuration and compilation processes, new files
+		# appear that the package manager does not know anything about.
+		# Just clear all the files in the target directory.
+		cat >> $pdir/DEBIAN/prerm <<- EOT
+			rm -rf /usr/src/linux-headers-$version
+			exit 0
+		EOT
 
-	chmod 775 $pdir/DEBIAN/postinst
-	chmod 775 $pdir/DEBIAN/prerm
+		chmod 775 $pdir/DEBIAN/postinst
+		chmod 775 $pdir/DEBIAN/prerm
 	fi
-
 
 	# Create the package
 	dpkg-gencontrol -p$pname -P"$pdir"
 	dpkg-deb ${KDEB_COMPRESS:+-Z$KDEB_COMPRESS} --build "$pdir" ..
 }
 
-deploy_kernel_headers () {
+deploy_kernel_headers() {
 	pdir=$1
 
 	rm -rf $pdir
@@ -137,7 +136,7 @@ deploy_kernel_headers () {
 
 	{
 		if is_enabled CONFIG_STACK_VALIDATION; then
-		#	echo tools/objtool/objtool
+			#	echo tools/objtool/objtool
 			find tools/objtool -type f -executable
 		fi
 
@@ -152,8 +151,8 @@ deploy_kernel_headers () {
 		echo "info: Build native: Skip headers-debian-byteshift.patch" >&2
 	elif is_build_on_amd64; then
 		(
-		cd $destdir
-		patch -p1 < /tmp/headers-debian-byteshift.patch
+			cd $destdir
+			patch -p1 < /tmp/headers-debian-byteshift.patch
 		)
 	fi
 
@@ -168,7 +167,7 @@ deploy_kernel_headers () {
 	ln -s /usr/src/linux-headers-$version $pdir/lib/modules/$version/build
 }
 
-deploy_libc_headers () {
+deploy_libc_headers() {
 	pdir=$1
 
 	rm -rf $pdir
@@ -195,7 +194,7 @@ dtb_packagename=linux-dtb-"$BRANCH$LOCALVERSION"
 libc_headers_packagename=linux-libc-dev
 dbg_packagename=$packagename-dbg
 
-if [ "$ARCH" = "um" ] ; then
+if [ "$ARCH" = "um" ]; then
 	packagename=user-mode-linux-$version
 fi
 
@@ -203,23 +202,24 @@ fi
 # XXX: have each arch Makefile export a variable of the canonical image install
 # path instead
 case $ARCH in
-++aarch64|arm64)
-	image_name=Image
-	installed_image_path="boot/vmlinuz-$version"
-	;;
-arm*)
-	image_name=zImage
-	installed_image_path="boot/vmlinuz-$version"
-	;;
-um)
-	installed_image_path="usr/bin/linux-$version"
-	;;
-parisc|mips|powerpc)
-	installed_image_path="boot/vmlinux-$version"
-	;;
-*)
-	image_name=vmlinuz
-	installed_image_path="boot/vmlinuz-$version"
+	++aarch64 | arm64)
+		image_name=Image
+		installed_image_path="boot/vmlinuz-$version"
+		;;
+	arm*)
+		image_name=zImage
+		installed_image_path="boot/vmlinuz-$version"
+		;;
+	um)
+		installed_image_path="usr/bin/linux-$version"
+		;;
+	parisc | mips | powerpc)
+		installed_image_path="boot/vmlinux-$version"
+		;;
+	*)
+		image_name=vmlinuz
+		installed_image_path="boot/vmlinuz-$version"
+		;;
 esac
 
 BUILD_DEBUG=$(if_enabled_echo CONFIG_DEBUG_INFO Yes)
@@ -234,7 +234,7 @@ mkdir -m 755 -p "$kernel_headers_dir/lib/modules/$version/"
 mkdir -m 755 -p "$libc_headers_dir/DEBIAN"
 
 # Install the kernel
-if [ "$ARCH" = "um" ] ; then
+if [ "$ARCH" = "um" ]; then
 	mkdir -p "$tmpdir/usr/lib/uml/modules/$version" "$tmpdir/usr/bin" "$tmpdir/usr/share/doc/$packagename"
 	$MAKE linux
 	cp System.map "$tmpdir/usr/lib/uml/modules/$version/System.map"
@@ -253,7 +253,7 @@ if is_enabled CONFIG_OF_EARLY_FLATTREE; then
 	fi
 fi
 
-if grep -q '^CONFIG_OF=y' $KCONFIG_CONFIG ; then
+if grep -q '^CONFIG_OF=y' $KCONFIG_CONFIG; then
 	#mkdir -p "$tmpdir/boot/dtb"
 	INSTALL_DTBS_PATH="$dtb_dir/boot/dtb-$version" $MAKE KBUILD_SRC= dtbs_install
 fi
@@ -262,11 +262,11 @@ if is_enabled CONFIG_MODULES; then
 	INSTALL_MOD_PATH="$tmpdir" $MAKE -f $srctree/Makefile modules_install
 	rm -f "$tmpdir/lib/modules/$version/build"
 	rm -f "$tmpdir/lib/modules/$version/source"
-	if [ "$ARCH" = "um" ] ; then
+	if [ "$ARCH" = "um" ]; then
 		mv "$tmpdir/lib/modules/$version"/* "$tmpdir/usr/lib/uml/modules/$version/"
 		rmdir "$tmpdir/lib/modules/$version"
 	fi
-	if [ -n "$BUILD_DEBUG" ] ; then
+	if [ -n "$BUILD_DEBUG" ]; then
 		for module in $(find $tmpdir/lib/modules/ -name *.ko -printf '%P\n'); do
 			module=lib/modules/$module
 			mkdir -p $(dirname $dbg_dir/usr/lib/debug/$module)
@@ -291,22 +291,22 @@ fi
 # make-kpkg sets $INITRD to indicate whether an initramfs is wanted, and
 # so do we; recent versions of dracut and initramfs-tools will obey this.
 debhookdir=${KDEB_HOOKDIR:-/etc/kernel}
-for script in postinst postrm preinst prerm ; do
+for script in postinst postrm preinst prerm; do
 	mkdir -p "$tmpdir$debhookdir/$script.d"
-	cat <<EOF > "$tmpdir/DEBIAN/$script"
-#!/bin/bash
+	cat <<- EOF > "$tmpdir/DEBIAN/$script"
+		#!/bin/bash
 
-set -e
+		set -e
 
-# Pass maintainer script parameters to hook scripts
-export DEB_MAINT_PARAMS="\$*"
+		# Pass maintainer script parameters to hook scripts
+		export DEB_MAINT_PARAMS="\$*"
 
-# Tell initramfs builder whether it's wanted
-export INITRD=$(if_enabled_echo CONFIG_BLK_DEV_INITRD Yes No)
+		# Tell initramfs builder whether it's wanted
+		export INITRD=$(if_enabled_echo CONFIG_BLK_DEV_INITRD Yes No)
 
-test -d $debhookdir/$script.d && run-parts --arg="$version" --arg="/$installed_image_path" $debhookdir/$script.d
-exit 0
-EOF
+		test -d $debhookdir/$script.d && run-parts --arg="$version" --arg="/$installed_image_path" $debhookdir/$script.d
+		exit 0
+	EOF
 	chmod 755 "$tmpdir/DEBIAN/$script"
 done
 
@@ -314,38 +314,38 @@ done
 ## Create sym link to kernel image
 ##
 sed -e "s/exit 0//g" -i $tmpdir/DEBIAN/postinst
-cat >> $tmpdir/DEBIAN/postinst << EOT
-ln -sf $(basename $installed_image_path) /boot/$image_name 2> /dev/null || mv /$installed_image_path /boot/$image_name
-touch /boot/.next
-exit 0
+cat >> $tmpdir/DEBIAN/postinst <<- EOT
+	ln -sf $(basename $installed_image_path) /boot/$image_name 2> /dev/null || mv /$installed_image_path /boot/$image_name
+	touch /boot/.next
+	exit 0
 EOT
 
 ##
 ## FAT install workaround
 ##
 sed -e "s/exit 0//g" -i $tmpdir/DEBIAN/preinst
-cat >> $tmpdir/DEBIAN/preinst <<EOT
-# exit if we are running chroot
-if [ "\$(stat -c %d:%i /)" != "\$(stat -c %d:%i /proc/1/root/.)" ]; then exit 0; fi
+cat >> $tmpdir/DEBIAN/preinst <<- EOT
+	# exit if we are running chroot
+	if [ "\$(stat -c %d:%i /)" != "\$(stat -c %d:%i /proc/1/root/.)" ]; then exit 0; fi
 
-check_and_unmount (){
-	boot_device=\$(mountpoint -d /boot)
+	check_and_unmount (){
+		boot_device=\$(mountpoint -d /boot)
 
-	for file in /dev/* ; do
-		CURRENT_DEVICE=\$(printf "%d:%d" \$(stat --printf="0x%t 0x%T" \$file))
-		if [[ "\$CURRENT_DEVICE" = "\$boot_device" ]]; then
-			boot_partition=\$file
-			break
+		for file in /dev/* ; do
+			CURRENT_DEVICE=\$(printf "%d:%d" \$(stat --printf="0x%t 0x%T" \$file))
+			if [[ "\$CURRENT_DEVICE" = "\$boot_device" ]]; then
+				boot_partition=\$file
+				break
+			fi
+		done
+		bootfstype=\$(blkid -s TYPE -o value \$boot_partition)
+		if [ "\$bootfstype" = "vfat" ]; then
+			umount /boot
+			rm -f /boot/System.map* /boot/config* /boot/vmlinuz* /boot/$image_name /boot/uImage
 		fi
-	done
-	bootfstype=\$(blkid -s TYPE -o value \$boot_partition)
-	if [ "\$bootfstype" = "vfat" ]; then
-		umount /boot
-		rm -f /boot/System.map* /boot/config* /boot/vmlinuz* /boot/$image_name /boot/uImage
-	fi
-}
-mountpoint -q /boot && check_and_unmount
-exit 0
+	}
+	mountpoint -q /boot && check_and_unmount
+	exit 0
 EOT
 
 create_package "$packagename" "$tmpdir"
@@ -360,7 +360,7 @@ if [ "$ARCH" != "um" ]; then
 	create_package $libc_headers_packagename $libc_headers_dir
 
 	if is_enabled CONFIG_MODULES; then
-		if is_native ; then
+		if is_native; then
 			# echo "Skip scripts folder cleaning" >&2
 			# echo "Skip creating postinst prerm scripts for headers" >&2
 			deploy_kernel_headers $kernel_headers_dir
@@ -368,7 +368,10 @@ if [ "$ARCH" != "um" ]; then
 		else
 			# Clean up the executables that are left over from
 			# cross-compilation for a different host architecture.
-			(cd $srctree; make M=scripts clean;)
+			(
+				cd $srctree
+				make M=scripts clean
+			)
 			deploy_kernel_headers $kernel_headers_dir
 			create_package $kernel_headers_packagename $kernel_headers_dir "headers"
 		fi
@@ -376,7 +379,7 @@ if [ "$ARCH" != "um" ]; then
 
 fi
 
-if [ -n "$BUILD_DEBUG" ] ; then
+if [ -n "$BUILD_DEBUG" ]; then
 	# Build debug package
 	# Different tools want the image in different locations
 	# perf


### PR DESCRIPTION
Jira  [AR-1048]

- rpi: fix: flash-kernel fix to ignore kernel 'flavour' for all raspi's
- use uppercase RPICFG label, so it shows up on Windows/Mac (FAT requires uppercase)
- builddeb: fix indenting of heredocs and shellfmt (I can't read it otherwise; done in separate commit for clarity)
- rpi: add DTB symlink in Debian/Ubuntu standard location /lib/firmware/$version/device-tree; remove build-time-only hacks
  - this allows us to remove the most horrible hack
  - should allow for correctly working DTB upgrades
  - should NOT impact other families, although a new symlink will be created, nothing uses it.

[AR-1048]: https://armbian.atlassian.net/browse/AR-1048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ