### PR TITLE
rpi: copy DTBs to Debian/Ubuntu standard location

### DIFF
--- a/packages/armbian/builddeb
+++ b/packages/armbian/builddeb
@@ -74,12 +74,13 @@ create_package() {
 			exit 0
 		EOT
 
-		# for Ubuntu/Debian compatiblity, symlink in /lib/firmware/$version/device-tree
+		# for Ubuntu/Debian compatiblity, copy DTBs to /lib/firmware/$version/device-tree
 		cat >> $pdir/DEBIAN/postinst <<- EOT
 			cd /boot
 			ln -sfT dtb-$version dtb 2> /dev/null || mv dtb-$version dtb
 			mkdir -p /lib/firmware/$version
-			[ ! -L /lib/firmware/$version/device-tree ] && ln -s /boot/dtb-$version /lib/firmware/$version/device-tree
+			rm -rf /lib/firmware/$version/device-tree
+			cp -rp /boot/dtb-$version /lib/firmware/$version/device-tree
 			exit 0
 		EOT
 


### PR DESCRIPTION
Fix for #3461 -- that used a symlink, which might be over a FS boundary and cause problems during build.

Still JIRA [AR-1048]

[AR-1048]: https://armbian.atlassian.net/browse/AR-1048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ