### PR TITLE
Add support for JetHub D1 new revision with AP6256 WiFi/BT

### DIFF
--- a/config/sources/families/jethub.conf
+++ b/config/sources/families/jethub.conf
@@ -139,7 +139,7 @@ buildjethomecmds() {
 		# Wifi & Bluetooth
 		mkdir -p --mode=755 "$destination/lib/firmware/" || exit_with_error "Unable to mkdir firmware"
 		mkdir --mode=775 "$destination/lib/firmware/brcm/" || exit_with_error "Unable to mkdir brcm"
-		cp -P "$SRC"/packages/bsp/jethub/"$BOARD"/{BCM4345C0.hcd,'brcmfmac43455-sdio.jethome,jethub-j100.txt','brcmfmac43455-sdio.jethome,jethub-j100.bin'} "$destination/lib/firmware/brcm/" || exit_with_error "Unable to copy brcm firmware symlinks"
+		cp -P "$SRC"/packages/bsp/jethub/"$BOARD"/{BCM4345C0.hcd,'brcmfmac43455-sdio.jethome,jethub-j100.txt','brcmfmac43455-sdio.jethome,jethub-j100.bin','brcmfmac43456-sdio.jethome,jethub-j100.txt','brcmfmac43456-sdio.jethome,jethub-j100.bin'} "$destination/lib/firmware/brcm/" || exit_with_error "Unable to copy brcm firmware symlinks"
 
 	else
 		exit_with_error "Unexpected board \"$BOARD\""

--- a/packages/bsp/jethub/jethubj100/brcmfmac43456-sdio.jethome,jethub-j100.bin
+++ b/packages/bsp/jethub/jethubj100/brcmfmac43456-sdio.jethome,jethub-j100.bin
@@ -1,0 +1,1 @@
+brcmfmac43456-sdio.bin

--- a/packages/bsp/jethub/jethubj100/brcmfmac43456-sdio.jethome,jethub-j100.txt
+++ b/packages/bsp/jethub/jethubj100/brcmfmac43456-sdio.jethome,jethub-j100.txt
@@ -1,0 +1,1 @@
+brcmfmac43456-sdio.txt


### PR DESCRIPTION
# Description

Add symlinks for AP6256 WiFi/BT adapter in JetHub D1 new revision.
For full support need a new clm_blob file https://github.com/armbian/firmware/pull/28

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
