### PR TITLE
u-boot install fallback - use package version which was downloaded

### DIFF
--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -878,7 +878,12 @@ PRE_UPDATE_INITRAMFS
 	display_alert "Mount point" "$(echo -e "$freespace" | grep $MOUNT | head -1 | awk '{print $5}')" "info"
 
 	# stage: write u-boot, unless the deb is not there, which would happen if BOOTCONFIG=none
-	[[ -f "${DEB_STORAGE}"/${CHOSEN_UBOOT}_${REVISION}_${ARCH}.deb ]] &&  write_uboot $LOOP
+	# exception: if we use the one from repository, install version which was downloaded from repo
+	if [[ -f "${DEB_STORAGE}"/${CHOSEN_UBOOT}_${REVISION}_${ARCH}.deb ]]; then
+		 write_uboot $LOOP
+	elif [[ "${UPSTREM_VER}" ]]; then
+		 write_uboot $LOOP
+	fi
 
 	# fix wrong / permissions
 	chmod 755 $MOUNT


### PR DESCRIPTION
# Description

When selecting repository install u-boot might not be flashed due to version mismatch. This workaround uses version that was read from the package.

Jira reference number [AR-1062]

# How Has This Been Tested?

Few manual builds.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1062]: https://armbian.atlassian.net/browse/AR-1062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ