### PR TITLE
Enable 3d on bullseye, buster, sid

### DIFF
--- a/config/desktop/bullseye/appgroups/3dsupport
+++ b/config/desktop/bullseye/appgroups/3dsupport
@@ -1,0 +1,1 @@
+../../buster/appgroups/3dsupport

--- a/config/desktop/buster/appgroups/3dsupport/packages
+++ b/config/desktop/buster/appgroups/3dsupport/packages
@@ -1,0 +1,4 @@
+libglx-mesa0
+libgl1-mesa-dri
+mesa-utils
+mesa-utils-extra

--- a/config/desktop/buster/environments/gnome/armbian/create_desktop_package.sh
+++ b/config/desktop/buster/environments/gnome/armbian/create_desktop_package.sh
@@ -4,11 +4,11 @@ cp -R "${SRC}"/packages/blobs/desktop/skel/. "${destination}"/etc/skel
 
 # install logo for login screen
 mkdir -p "${destination}"/usr/share/pixmaps/armbian
-cp "${SRC}"/packages/blobs/desktop/icons/armbian.png "${destination}"/usr/share/pixmaps/armbian
+cp "${SRC}"/packages/blobs/desktop/desktop-icons/armbian.png "${destination}"/usr/share/pixmaps/armbian
 
 # install wallpapers
 mkdir -p "${destination}"/usr/share/backgrounds/gnome/
-cp "${SRC}"/packages/blobs/desktop/wallpapers/armbian*.jpg "${destination}"/usr/share/backgrounds/gnome/
+cp "${SRC}"/packages/blobs/desktop/desktop-wallpapers/armbian*.jpg "${destination}"/usr/share/backgrounds/gnome/
 mkdir -p "${destination}"/usr/share/gnome-background-properties
 cat <<-EOF > "${destination}"/usr/share/gnome-background-properties/armbian.xml
 <?xml version="1.0"?>

--- a/config/desktop/sid/appgroups/3dsupport
+++ b/config/desktop/sid/appgroups/3dsupport
@@ -1,0 +1,1 @@
+../../buster/appgroups/3dsupport

--- a/config/desktop/sid/environments/gnome/armbian/create_desktop_package.sh
+++ b/config/desktop/sid/environments/gnome/armbian/create_desktop_package.sh
@@ -4,11 +4,11 @@ cp -R "${SRC}"/packages/blobs/desktop/skel/. "${destination}"/etc/skel
 
 # install logo for login screen
 mkdir -p "${destination}"/usr/share/pixmaps/armbian
-cp "${SRC}"/packages/blobs/desktop/icons/armbian.png "${destination}"/usr/share/pixmaps/armbian
+cp "${SRC}"/packages/blobs/desktop/desktop-icons/armbian.png "${destination}"/usr/share/pixmaps/armbian
 
 # install wallpapers
 mkdir -p "${destination}"/usr/share/backgrounds/gnome/
-cp "${SRC}"/packages/blobs/desktop/wallpapers/armbian*.jpg "${destination}"/usr/share/backgrounds/gnome/
+cp "${SRC}"/packages/blobs/desktop/desktop-wallpapers/armbian*.jpg "${destination}"/usr/share/backgrounds/gnome/
 mkdir -p "${destination}"/usr/share/gnome-background-properties
 cat <<-EOF > "${destination}"/usr/share/gnome-background-properties/armbian.xml
 <?xml version="1.0"?>

--- a/config/desktop/sid/environments/gnome/config_base/packages
+++ b/config/desktop/sid/environments/gnome/config_base/packages
@@ -64,7 +64,7 @@ libaspell15
 libatk-adaptor
 libcairo-gobject-perl
 libcairo-perl
-libcamel-1.2-62
+libcamel-1.2-63
 libcue2
 libdee-1.0-4
 libebackend-1.2-10
@@ -73,8 +73,8 @@ libebook-contacts-1.2-3
 libecal-2.0-1
 libedata-book-1.2-26
 libedata-cal-2.0-1
-libedataserver-1.2-25
-libedataserverui-1.2-2
+libedataserver-1.2-26
+libedataserverui-1.2-3
 libenchant-2-2
 libexempi8
 libexiv2-27
@@ -110,7 +110,7 @@ libgweather-common
 libgxps2
 libibus-1.0-5
 libical3
-libidn11
+libidn11-dev
 libijs-0.35
 libimobiledevice6
 libjavascriptcoregtk-4.0-18
@@ -123,7 +123,7 @@ libpaper1
 libphonenumber8
 libplist3
 libpoppler-glib8
-libprotobuf17
+libprotobuf23
 libpulsedsp
 libsasl2-modules
 libspeexdsp1


### PR DESCRIPTION
# Description

- add packages for 3D support
- update broken packages
- fix broken wallpaper

Jira reference number [AR-1084]

# How Has This Been Tested?

- [x] Build Debian SID with edge kernel for Allwinner H5

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1084]: https://armbian.atlassian.net/browse/AR-1084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ