### PR TITLE
Packaging

### DIFF
--- a/config/sources/families/bcm2711.conf
+++ b/config/sources/families/bcm2711.conf
@@ -1,7 +1,7 @@
 enable_extension "flash-kernel"
 export LINUXFAMILY=bcm2711
 export ARCH=arm64
-export UEFI_FS_LABEL="RPICFG"               # Windows/Mac users will see this if they mount the SD card. Configurable, but should be uppercase always
+export UEFI_FS_LABEL="rpicfg"               # Windows/Mac users will see this if they mount the SD card. Configurable
 export SKIP_BOOTSPLASH="yes"                # video is init-ed before us
 export KERNELDIR='linux-rpi'                # Avoid sharing a source tree with others, until we know it's safe.
 export FK__PUBLISHED_KERNEL_VERSION="raspi" # flash kernel (FK) configuration
@@ -50,13 +50,20 @@ pre_flash_kernel__symlink_dtb_and_kernel() {
 		display_alert "Preparing DTBs and Kernel..." "bcm2711" "info"
 		mkdir -p "${MOUNT}"/etc/flash-kernel/dtbs
 
-		cat <<- EOD >> "${MOUNT}"/etc/flash-kernel/db
-			# Armbian kernels don't have a 'flavour'. Ignore flavors for all rpi revisions.
-			Machine: Raspberry Pi *
+		cat <<-EOD >>"${MOUNT}"/etc/flash-kernel/db
+			# Armbian kernels have a different flavour than expected.
+			Machine: ${FK__MACHINE_MODEL}
 			Kernel-Flavors: any
 		EOD
 
-		## DTB compatibility has been moved to symlink done in packages/armbian/builddeb
+		## @TODO: rpardini: a horrible hack. I'll sort this out together with overlays, later.
+		local oneDTB dtbBase
+		for oneDTB in "${MOUNT}"/boot/dtb/broadcom/*.dtb; do
+			dtbBase=$(basename "${oneDTB}")
+			cp "${MOUNT}"/boot/dtb/broadcom/"${dtbBase}" "${MOUNT}"/etc/flash-kernel/dtbs/"${dtbBase}"
+		done
+		
+		rm -rf "${MOUNT}"/boot/dtb* || true
 
 		# @TODO: rpardini: packaging could maybe already use the correct names? I can't figure out how.
 		ln -s ./Image "${MOUNT}"/boot/vmlinuz

--- a/packages/armbian/builddeb
+++ b/packages/armbian/builddeb
@@ -74,13 +74,12 @@ create_package() {
 			exit 0
 		EOT
 
-		# for Ubuntu/Debian compatiblity, copy DTBs to /lib/firmware/$version/device-tree
+		# for Ubuntu/Debian compatiblity, symlink in /lib/firmware/$version/device-tree
 		cat >> $pdir/DEBIAN/postinst <<- EOT
 			cd /boot
 			ln -sfT dtb-$version dtb 2> /dev/null || mv dtb-$version dtb
 			mkdir -p /lib/firmware/$version
-			rm -rf /lib/firmware/$version/device-tree
-			cp -rp /boot/dtb-$version /lib/firmware/$version/device-tree
+			[ ! -L /lib/firmware/$version/device-tree ] && ln -s /boot/dtb-$version /lib/firmware/$version/device-tree
 			exit 0
 		EOT
 

--- a/packages/armbian/builddeb
+++ b/packages/armbian/builddeb
@@ -74,22 +74,14 @@ create_package() {
 			exit 0
 		EOT
 
-		# for Ubuntu/Debian compatiblity, symlink in /lib/firmware/$version/device-tree
 		cat >> $pdir/DEBIAN/postinst <<- EOT
 			cd /boot
 			ln -sfT dtb-$version dtb 2> /dev/null || mv dtb-$version dtb
-			mkdir -p /lib/firmware/$version
-			[ ! -L /lib/firmware/$version/device-tree ] && ln -s /boot/dtb-$version /lib/firmware/$version/device-tree
 			exit 0
-		EOT
-
-		cat >> $pdir/DEBIAN/postrm <<- EOT
-			rm -rf /lib/firmware/$version
 		EOT
 
 		chmod 775 $pdir/DEBIAN/preinst
 		chmod 775 $pdir/DEBIAN/postinst
-		chmod 775 $pdir/DEBIAN/postrm
 	fi
 
 	# Create postinst prerm script for headers
@@ -210,7 +202,7 @@ fi
 # XXX: have each arch Makefile export a variable of the canonical image install
 # path instead
 case $ARCH in
-	++aarch64 | arm64)
+	++aarch64|arm64)
 		image_name=Image
 		installed_image_path="boot/vmlinuz-$version"
 		;;
@@ -221,7 +213,7 @@ case $ARCH in
 	um)
 		installed_image_path="usr/bin/linux-$version"
 		;;
-	parisc | mips | powerpc)
+	parisc|mips|powerpc)
 		installed_image_path="boot/vmlinux-$version"
 		;;
 	*)
@@ -270,10 +262,12 @@ if is_enabled CONFIG_MODULES; then
 	INSTALL_MOD_PATH="$tmpdir" $MAKE -f $srctree/Makefile modules_install
 	rm -f "$tmpdir/lib/modules/$version/build"
 	rm -f "$tmpdir/lib/modules/$version/source"
+
 	if [ "$ARCH" = "um" ]; then
 		mv "$tmpdir/lib/modules/$version"/* "$tmpdir/usr/lib/uml/modules/$version/"
 		rmdir "$tmpdir/lib/modules/$version"
 	fi
+
 	if [ -n "$BUILD_DEBUG" ]; then
 		for module in $(find $tmpdir/lib/modules/ -name *.ko -printf '%P\n'); do
 			module=lib/modules/$module
@@ -346,6 +340,7 @@ cat >> $tmpdir/DEBIAN/preinst <<- EOT
 				break
 			fi
 		done
+
 		bootfstype=\$(blkid -s TYPE -o value \$boot_partition)
 		if [ "\$bootfstype" = "vfat" ]; then
 			umount /boot


### PR DESCRIPTION
# Description

Revert "Fix rpi upgrades to kernel and dtbs (#3461)"
    
    This reverts commit 3b7f5b1f3418b7ad7a7c03f2af6d8da66f20bcb9.
    
    Copying dtb files to a folder that cannot belong to a dtb package
    creates additional clutter. If this is required for an individual
    family, then it is necessary to implement it at the level of system
    scripts. And only for this family.

- [x] Test Rebuild for sunxi64


