### PR TITLE
AR-1048: rpi: *kernel* upgrades fix; fs label uppercase fix (but not a DTB fix)

### DIFF
--- a/config/sources/families/bcm2711.conf
+++ b/config/sources/families/bcm2711.conf
@@ -1,7 +1,7 @@
 enable_extension "flash-kernel"
 export LINUXFAMILY=bcm2711
 export ARCH=arm64
-export UEFI_FS_LABEL="rpicfg"               # Windows/Mac users will see this if they mount the SD card. Configurable
+export UEFI_FS_LABEL="RPICFG"               # Windows/Mac users will see this if they mount the SD card. Configurable, but should be uppercase always
 export SKIP_BOOTSPLASH="yes"                # video is init-ed before us
 export KERNELDIR='linux-rpi'                # Avoid sharing a source tree with others, until we know it's safe.
 export FK__PUBLISHED_KERNEL_VERSION="raspi" # flash kernel (FK) configuration
@@ -50,9 +50,9 @@ pre_flash_kernel__symlink_dtb_and_kernel() {
 		display_alert "Preparing DTBs and Kernel..." "bcm2711" "info"
 		mkdir -p "${MOUNT}"/etc/flash-kernel/dtbs
 
-		cat <<-EOD >>"${MOUNT}"/etc/flash-kernel/db
-			# Armbian kernels have a different flavour than expected.
-			Machine: ${FK__MACHINE_MODEL}
+		cat <<- EOD >> "${MOUNT}"/etc/flash-kernel/db
+			# Armbian kernels don't have a 'flavour'. Ignore flavors for all rpi revisions.
+			Machine: Raspberry Pi *
 			Kernel-Flavors: any
 		EOD
 


### PR DESCRIPTION
### rpi: *kernel* upgrades fix; fs label uppercase fix
- [AR-1048] 
- this fixes kernel upgrades. DTBs will be left over from ones included in original image.
- does NOT touch DTB hack; DTBs simply won't upgrade.
- (no DTB fix here! ask the-Going)


[AR-1048]: https://armbian.atlassian.net/browse/AR-1048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ