### PR TITLE
Remove incorrectly duplicated GPIO pins from I2C7, name I2C7/I2C8 bus, from README.rockchip-overlays

### DIFF
--- a/patch/kernel/archive/rk3399-4.4/general-rockchip-overlays.patch
+++ b/patch/kernel/archive/rk3399-4.4/general-rockchip-overlays.patch
@@ -59,13 +59,13 @@ index e69de29..9512445 100644
 +
 +Activates TWI/I2C bus 7
 +
-+I2C7 pins (SCL, SDA): GPIO2-B0, GPIO2-A7 GPIO1-C5, GPIO1-C4
++I2C7 pins (DVP) (SCL, SDA): GPIO2-B0, GPIO2-A7
 +
 +### i2c8
 +
 +Activates TWI/I2C bus 8
 +
-+I2C8 pins (SCL, SDA): GPIO1-C5, GPIO1-C4
++I2C8 pins (pi-conn) (pi-conn) (SCL, SDA): GPIO1-C5, GPIO1-C4
 +
 +### pcie-gen2
 +

--- a/patch/kernel/archive/rockchip64-4.4/general-rockchip-overlays.patch
+++ b/patch/kernel/archive/rockchip64-4.4/general-rockchip-overlays.patch
@@ -59,13 +59,13 @@ index e69de29..9512445 100644
 +
 +Activates TWI/I2C bus 7
 +
-+I2C7 pins (SCL, SDA): GPIO2-B0, GPIO2-A7 GPIO1-C5, GPIO1-C4
++I2C7 pins (DVP) (SCL, SDA): GPIO2-B0, GPIO2-A7
 +
 +### i2c8
 +
 +Activates TWI/I2C bus 8
 +
-+I2C8 pins (SCL, SDA): GPIO1-C5, GPIO1-C4
++I2C8 pins (pi-conn) (pi-conn) (SCL, SDA): GPIO1-C5, GPIO1-C4
 +
 +### pcie-gen2
 +

--- a/patch/kernel/archive/rockchip64-5.10/general-rockchip-overlays.patch
+++ b/patch/kernel/archive/rockchip64-5.10/general-rockchip-overlays.patch
@@ -59,13 +59,13 @@ index e69de29..9512445 100644
 +
 +Activates TWI/I2C bus 7
 +
-+I2C7 pins (SCL, SDA): GPIO2-B0, GPIO2-A7 GPIO1-C5, GPIO1-C4
++I2C7 pins (DVP) (SCL, SDA): GPIO2-B0, GPIO2-A7
 +
 +### i2c8
 +
 +Activates TWI/I2C bus 8
 +
-+I2C8 pins (SCL, SDA): GPIO1-C5, GPIO1-C4
++I2C8 pins (pi-conn) (pi-conn) (SCL, SDA): GPIO1-C5, GPIO1-C4
 +
 +### pcie-gen2
 +

--- a/patch/kernel/archive/rockchip64-5.12/general-rockchip-overlays.patch
+++ b/patch/kernel/archive/rockchip64-5.12/general-rockchip-overlays.patch
@@ -59,13 +59,13 @@ index e69de29..9512445 100644
 +
 +Activates TWI/I2C bus 7
 +
-+I2C7 pins (SCL, SDA): GPIO2-B0, GPIO2-A7 GPIO1-C5, GPIO1-C4
++I2C7 pins (DVP) (SCL, SDA): GPIO2-B0, GPIO2-A7
 +
 +### i2c8
 +
 +Activates TWI/I2C bus 8
 +
-+I2C8 pins (SCL, SDA): GPIO1-C5, GPIO1-C4
++I2C8 pins (pi-conn) (pi-conn) (SCL, SDA): GPIO1-C5, GPIO1-C4
 +
 +### pcie-gen2
 +

--- a/patch/kernel/archive/rockchip64-5.13/general-rockchip-overlays.patch
+++ b/patch/kernel/archive/rockchip64-5.13/general-rockchip-overlays.patch
@@ -59,13 +59,13 @@ index e69de29..9512445 100644
 +
 +Activates TWI/I2C bus 7
 +
-+I2C7 pins (SCL, SDA): GPIO2-B0, GPIO2-A7 GPIO1-C5, GPIO1-C4
++I2C7 pins (DVP) (SCL, SDA): GPIO2-B0, GPIO2-A7
 +
 +### i2c8
 +
 +Activates TWI/I2C bus 8
 +
-+I2C8 pins (SCL, SDA): GPIO1-C5, GPIO1-C4
++I2C8 pins (pi-conn) (pi-conn) (SCL, SDA): GPIO1-C5, GPIO1-C4
 +
 +### pcie-gen2
 +

--- a/patch/kernel/archive/rockchip64-5.14/general-rockchip-overlays.patch
+++ b/patch/kernel/archive/rockchip64-5.14/general-rockchip-overlays.patch
@@ -59,13 +59,13 @@ index e69de29..9512445 100644
 +
 +Activates TWI/I2C bus 7
 +
-+I2C7 pins (SCL, SDA): GPIO2-B0, GPIO2-A7 GPIO1-C5, GPIO1-C4
++I2C7 pins (DVP) (SCL, SDA): GPIO2-B0, GPIO2-A7
 +
 +### i2c8
 +
 +Activates TWI/I2C bus 8
 +
-+I2C8 pins (SCL, SDA): GPIO1-C5, GPIO1-C4
++I2C8 pins (pi-conn) (pi-conn) (SCL, SDA): GPIO1-C5, GPIO1-C4
 +
 +### pcie-gen2
 +

--- a/patch/kernel/archive/rockchip64-5.15/general-rockchip-overlays.patch
+++ b/patch/kernel/archive/rockchip64-5.15/general-rockchip-overlays.patch
@@ -59,13 +59,13 @@ index e69de29..9512445 100644
 +
 +Activates TWI/I2C bus 7
 +
-+I2C7 pins (SCL, SDA): GPIO2-B0, GPIO2-A7 GPIO1-C5, GPIO1-C4
++I2C7 pins (DVP) (SCL, SDA): GPIO2-B0, GPIO2-A7
 +
 +### i2c8
 +
 +Activates TWI/I2C bus 8
 +
-+I2C8 pins (SCL, SDA): GPIO1-C5, GPIO1-C4
++I2C8 pins (pi-conn) (pi-conn) (SCL, SDA): GPIO1-C5, GPIO1-C4
 +
 +### pcie-gen2
 +

--- a/patch/kernel/media-current/general-rockchip-overlays.patch
+++ b/patch/kernel/media-current/general-rockchip-overlays.patch
@@ -59,13 +59,13 @@ index e69de29..9512445 100644
 +
 +Activates TWI/I2C bus 7
 +
-+I2C7 pins (SCL, SDA): GPIO2-B0, GPIO2-A7 GPIO1-C5, GPIO1-C4
++I2C7 pins (DVP) (SCL, SDA): GPIO2-B0, GPIO2-A7
 +
 +### i2c8
 +
 +Activates TWI/I2C bus 8
 +
-+I2C8 pins (SCL, SDA): GPIO1-C5, GPIO1-C4
++I2C8 pins (pi-conn) (SCL, SDA): GPIO1-C5, GPIO1-C4
 +
 +### pcie-gen2
 +

--- a/patch/kernel/media-edge/general-rockchip-overlays.patch
+++ b/patch/kernel/media-edge/general-rockchip-overlays.patch
@@ -59,13 +59,13 @@ index e69de29..9512445 100644
 +
 +Activates TWI/I2C bus 7
 +
-+I2C7 pins (SCL, SDA): GPIO2-B0, GPIO2-A7 GPIO1-C5, GPIO1-C4
++I2C7 pins (DVP) (SCL, SDA): GPIO2-B0, GPIO2-A7
 +
 +### i2c8
 +
 +Activates TWI/I2C bus 8
 +
-+I2C8 pins (SCL, SDA): GPIO1-C5, GPIO1-C4
++I2C8 pins (pi-conn) (pi-conn) (SCL, SDA): GPIO1-C5, GPIO1-C4
 +
 +### pcie-gen2
 +


### PR DESCRIPTION
# Description

This is a simple documentation patch which removes incorrectly duplicated GPIO pin definitions from README.rockchip-overlays.  Additionally, it names the gpio bus for clarity (I2C7 := DVP, I2C8 := Pi connector)

This prevents user error when trying to utilize the various GPIO pins and not being able to identify the correct bus to use.

# How Has This Been Tested?

Documentation changes only.  Verified using pine64/rockpro schematic diagrams and build documentation

# Checklist:

- [n/a] My code follows the style guidelines of this project
- [n/a] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [n/a] Any dependent changes have been merged and published in downstream modules
