### PR TITLE
odroidxu4: `armv5` to `armv7-a` so it compiles with modern gcc

### DIFF
--- a/patch/u-boot/u-boot-odroidxu4/use-armv7a-for-modern-toolchain.patch
+++ b/patch/u-boot/u-boot-odroidxu4/use-armv7a-for-modern-toolchain.patch
@@ -1,0 +1,17 @@
+diff --git a/arch/arm/Makefile b/arch/arm/Makefile
+index 3e93fd6e..46dfcbc5 100644
+--- a/arch/arm/Makefile
++++ b/arch/arm/Makefile
+@@ -14,10 +14,10 @@ arch-$(CONFIG_CPU_ARM926EJS)	=-march=armv5te
+ arch-$(CONFIG_CPU_ARM946ES)	=-march=armv5te
+ arch-$(CONFIG_CPU_SA1100)	=-march=armv4
+ arch-$(CONFIG_CPU_PXA)		=
+-arch-$(CONFIG_CPU_ARM1136)	=-march=armv5
++arch-$(CONFIG_CPU_ARM1136)	=-march=armv7-a
+ arch-$(CONFIG_CPU_ARM1176)	=-march=armv5t
+ arch-$(CONFIG_CPU_V7)		=$(call cc-option, -march=armv7-a, \
+-				 $(call cc-option, -march=armv7, -march=armv5))
++				 $(call cc-option, -march=armv7, -march=armv7-a))
+ arch-$(CONFIG_ARM64)		=-march=armv8-a
+
+ # On Tegra systems we must build SPL for the armv4 core on the device


### PR DESCRIPTION
### odroidxu4: `armv5` to `armv7-a` so it compiles with modern gcc
- have absolutely no idea if this works. there's also some other `armv5` variants to try if this does not.
- XU4's CPU is Exynos5422 ARM Cortex-A15 which should be armv7-a indeed, so why not?
