### PR TITLE
JetHub H1: dirty userland fix for net interface does not up at boot

### DIFF
--- a/config/sources/families/jethub.conf
+++ b/config/sources/families/jethub.conf
@@ -153,6 +153,9 @@ family_tweaks() {
 	# Hardware init
 	chroot "${SDCARD}" /bin/bash -c "systemctl --no-reload enable jethub-initer.service >/dev/null 2>&1"
 
+	# AR-1098 userland fix for net interface does not up at boot
+	chroot "${SDCARD}" /bin/bash -c "systemctl --no-reload enable jethub-ethreset.service >/dev/null 2>&1"
+
 	# pip3 packages
 	chroot "${SDCARD}" /bin/bash -c "pip3 install pyserial intelhex python-magic" >>"${DEST}"/debug/install.log 2>&1
 
@@ -184,7 +187,12 @@ family_tweaks_bsp() {
 	cp "$SRC/packages/bsp/jethub/jethub-initer.service" "$destination/lib/systemd/system/" || exit_with_error "Unable to copy jethub-initer.service"
 	cp "$SRC/packages/bsp/jethub/${BOARD}/jethub-init" "$destination/usr/lib/armbian/" || exit_with_error "Unable to copy jethub-init"
 
+
 	if [[ "$BOARD" == jethubj80 ]]; then
+		# AR-1098 userland fix for net interface does not up at boot
+		cp "$SRC/packages/bsp/jethub/jethubj80/jethub-ethreset.service" "$destination/lib/systemd/system/" || exit_with_error "Unable to copy jethub-ethreset.service"
+		cp "$SRC/packages/bsp/jethub/jethubj80/jethub-ethreset" "$destination/usr/lib/armbian/" || exit_with_error "Unable to copy jethub-ethreset"
+
 		# Ethernet LED setup
 		cp "$SRC/packages/bsp/jethub/$BOARD/05-jethub_set_eth_leds.rules" "$destination/etc/udev/rules.d/"
 	fi

--- a/packages/bsp/jethub/jethubj80/jethub-ethreset
+++ b/packages/bsp/jethub/jethubj80/jethub-ethreset
@@ -1,0 +1,3 @@
+#!/bin/bash
+/usr/sbin/ethtool -r eth0
+exit 0

--- a/packages/bsp/jethub/jethubj80/jethub-ethreset.service
+++ b/packages/bsp/jethub/jethubj80/jethub-ethreset.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=test service
+Wants=network.target
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStartPre=/usr/bin/sleep 20
+ExecStart=/usr/lib/armbian/jethub-ethreset
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
# Description

JetHub H1: dirty userland fix for net interface does not up at boot.
Fixes only jethub-j80 bsp package.

Jira reference number [AR-1098]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] JetHub H1 starts ok
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1098]: https://armbian.atlassian.net/browse/AR-1098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ