### PR TITLE
Fix build for orangepizero2,  sun50iw9

### DIFF
--- a/config/sources/families/sun50iw9.conf
+++ b/config/sources/families/sun50iw9.conf
@@ -8,6 +8,7 @@ case $BRANCH in
 
 	legacy)
 
+			unset var_origin_kernel
 			LINUXFAMILY=sun50iw9
 			KERNELSOURCE='https://github.com/orangepi-xunlong/linux-orangepi.git'
 			KERNELBRANCH="branch:orange-pi-4.9-sun50iw9"
@@ -26,7 +27,7 @@ case $BRANCH in
 			ATFSOURCE=""
 			ATF_COMPILE="no"
 			INITRD_ARCH=arm
-			
+
 			ASOUND_STATE='asound.state.sun50iw9-legacy'
 
 			write_uboot_platform()
@@ -93,11 +94,11 @@ if [[ ${BRANCH} == legacy ]]; then
 	cp ${BOARD}-u-boot.dtb sunxi.fex
 	$SRC/packages/pack-uboot/${BOARDFAMILY}/tools/update_dtb sunxi.fex 4096
 	$SRC/packages/pack-uboot/${BOARDFAMILY}/tools/update_boot0 boot0_sdcard.fex	sys_config.bin SDMMC_CARD
-	
+
 	$SRC/packages/pack-uboot/${BOARDFAMILY}/tools/update_uboot -no_merge u-boot.fex sys_config.bin
 	update_uboot -no_merge u-boot.bin sys_config.bin
 	#pack boot package
-	
+
 	busybox unix2dos boot_package.cfg
 	$SRC/packages/pack-uboot/${BOARDFAMILY}/tools/dragonsecboot -pack boot_package.cfg
 fi

--- a/config/sources/families/sun50iw9.conf
+++ b/config/sources/families/sun50iw9.conf
@@ -13,6 +13,8 @@ case $BRANCH in
 			KERNELBRANCH="branch:orange-pi-4.9-sun50iw9"
 			KERNELPATCHDIR=${BOARDFAMILY}-${BRANCH}
 			KERNELDIR='linux-orangepi'
+			KERNEL_VERSION_LEVEL="4.9"
+			KERNELSOURCENAME='name=$LINUXFAMILY'
 			BOOTSOURCE='https://github.com/orangepi-xunlong/u-boot-orangepi.git'
 			BOOTBRANCH='branch:v2018.05-sun50iw9'
 			BOOTPATCHDIR=u-boot-${LINUXFAMILY}
@@ -26,7 +28,7 @@ case $BRANCH in
 			ATFSOURCE=""
 			ATF_COMPILE="no"
 			INITRD_ARCH=arm
-			
+
 			ASOUND_STATE='asound.state.sun50iw9-legacy'
 
 			write_uboot_platform()
@@ -93,11 +95,11 @@ if [[ ${BRANCH} == legacy ]]; then
 	cp ${BOARD}-u-boot.dtb sunxi.fex
 	$SRC/packages/pack-uboot/${BOARDFAMILY}/tools/update_dtb sunxi.fex 4096
 	$SRC/packages/pack-uboot/${BOARDFAMILY}/tools/update_boot0 boot0_sdcard.fex	sys_config.bin SDMMC_CARD
-	
+
 	$SRC/packages/pack-uboot/${BOARDFAMILY}/tools/update_uboot -no_merge u-boot.fex sys_config.bin
 	update_uboot -no_merge u-boot.bin sys_config.bin
 	#pack boot package
-	
+
 	busybox unix2dos boot_package.cfg
 	$SRC/packages/pack-uboot/${BOARDFAMILY}/tools/dragonsecboot -pack boot_package.cfg
 fi

--- a/config/sources/families/sun50iw9.conf
+++ b/config/sources/families/sun50iw9.conf
@@ -13,8 +13,6 @@ case $BRANCH in
 			KERNELBRANCH="branch:orange-pi-4.9-sun50iw9"
 			KERNELPATCHDIR=${BOARDFAMILY}-${BRANCH}
 			KERNELDIR='linux-orangepi'
-			KERNEL_VERSION_LEVEL="4.9"
-			KERNELSOURCENAME='name=$LINUXFAMILY'
 			BOOTSOURCE='https://github.com/orangepi-xunlong/u-boot-orangepi.git'
 			BOOTBRANCH='branch:v2018.05-sun50iw9'
 			BOOTPATCHDIR=u-boot-${LINUXFAMILY}
@@ -28,7 +26,7 @@ case $BRANCH in
 			ATFSOURCE=""
 			ATF_COMPILE="no"
 			INITRD_ARCH=arm
-
+			
 			ASOUND_STATE='asound.state.sun50iw9-legacy'
 
 			write_uboot_platform()
@@ -95,11 +93,11 @@ if [[ ${BRANCH} == legacy ]]; then
 	cp ${BOARD}-u-boot.dtb sunxi.fex
 	$SRC/packages/pack-uboot/${BOARDFAMILY}/tools/update_dtb sunxi.fex 4096
 	$SRC/packages/pack-uboot/${BOARDFAMILY}/tools/update_boot0 boot0_sdcard.fex	sys_config.bin SDMMC_CARD
-
+	
 	$SRC/packages/pack-uboot/${BOARDFAMILY}/tools/update_uboot -no_merge u-boot.fex sys_config.bin
 	update_uboot -no_merge u-boot.bin sys_config.bin
 	#pack boot package
-
+	
 	busybox unix2dos boot_package.cfg
 	$SRC/packages/pack-uboot/${BOARDFAMILY}/tools/dragonsecboot -pack boot_package.cfg
 fi


### PR DESCRIPTION
# Description
unset only for `var_origin_kernel`
# Checklist:
- [x] Test build for sun50iw9 LINUXFAMILY

