### PR TITLE
add patch to avoid meson64 random reboots under load

### DIFF
--- a/patch/kernel/archive/meson64-5.15/0009-memory-marked-nomap.patch
+++ b/patch/kernel/archive/meson64-5.15/0009-memory-marked-nomap.patch
@@ -1,0 +1,19 @@
+diff -Naur a/drivers/of/fdt.c b/drivers/of/fdt.c
+--- a/drivers/of/fdt.c	2022-01-27 05:05:44.000000000 -0500
++++ b/drivers/of/fdt.c	2022-01-27 11:30:37.610221700 -0500
+@@ -480,15 +480,6 @@
+ 					phys_addr_t size, bool nomap)
+ {
+ 	if (nomap) {
+-		/*
+-		 * If the memory is already reserved (by another region), we
+-		 * should not allow it to be marked nomap, but don't worry
+-		 * if the region isn't memory as it won't be mapped.
+-		 */
+-		if (memblock_overlaps_region(&memblock.memory, base, size) &&
+-		    memblock_is_region_reserved(base, size))
+-			return -EBUSY;
+-
+ 		return memblock_mark_nomap(base, size);
+ 	}
+ 	return memblock_reserve(base, size);


### PR DESCRIPTION
Patch to avoid random reboots of Odroid-N2 under load.
solution from @pyavitz
patch taken from https://raw.githubusercontent.com/pyavitz/debian-image-builder/feature/patches/amlogic/009-memory-marked-nomap.patch, discussion https://lore.kernel.org/linux-amlogic/1c71a7c1e58590811094ebdd0e1abc54@agner.ch/T/#t, 

I build N2 edge image with this patch, it applies without errors and seems solves random reboot problem.