### PR TITLE
22.02: remove 'edge' (5.15) images for ODROID N2; use 5.10 current

### DIFF
--- a/config/targets.conf
+++ b/config/targets.conf
@@ -206,12 +206,12 @@ odroidc2                  edge            jammy       cli                      s
 
 
 # Odroid N2 / N2+
-odroidn2                  current         bullseye    cli                      stable         yes
-odroidn2                  current         focal       cli                      stable         adv
-odroidn2                  current         focal       desktop                  stable         adv            xfce      config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-odroidn2                  edge            jammy       desktop                  stable         yes            xfce      config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-odroidn2                  edge            jammy       desktop                  stable         yes            cinnamon  config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-odroidn2                  edge            jammy       cli                      stable         yes
+odroidn2                  current         bullseye    cli                      stable         adv
+odroidn2                  current         focal       cli                      stable         yes
+odroidn2                  current         focal       desktop                  stable         yes            xfce      config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+odroidn2                  current         jammy       desktop                  stable         adv            xfce      config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+odroidn2                  current         jammy       desktop                  stable         yes            cinnamon  config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+odroidn2                  current         jammy       cli                      stable         yes
 
 
 # Odroid HC4


### PR DESCRIPTION
22.02: remove 'edge' (5.15) images for ODROID N2; replace with current (5.10)

- current/jammy/xfce and current/bullseye become the advertised

As noted in release notes, `edge` has not been reworked yet. Stick to current, but with modern userspace.