### PR TITLE
Add meson64 patch net: phy: meson-gxl: fix interrupt handling in forced mode

### DIFF
--- a/patch/kernel/archive/meson64-5.15/net-net-phy-meson-gxl-fix-interrupt-handling-in-forced-mode.patch
+++ b/patch/kernel/archive/meson64-5.15/net-net-phy-meson-gxl-fix-interrupt-handling-in-forced-mode.patch
@@ -1,0 +1,83 @@
+From: Heiner Kallweit <hkallweit1@gmail.com>
+Subject: [PATCH net] net: phy: meson-gxl: fix interrupt handling in forced
+
+This PHY doesn't support a link-up interrupt source. If aneg is enabled
+we use the "aneg complete" interrupt for this purpose, but if aneg is
+disabled link-up isn't signaled currently.
+According to a vendor driver there's an additional "energy detect"
+interrupt source that can be used to signal link-up if aneg is disabled.
+We can safely ignore this interrupt source if aneg is enabled.
+
+This patch was tested on a TX3 Mini TV box with S905W (even though
+boot message says it's a S905D).
+
+This issue has been existing longer, but due to changes in phylib and
+the driver the patch applies only from the commit marked as fixed.
+
+Fixes: 84c8f773d2dc ("net: phy: meson-gxl: remove the use of .ack_callback()")
+Signed-off-by: Heiner Kallweit <hkallweit1@gmail.com>
+---
+ drivers/net/phy/meson-gxl.c | 23 +++++++++++++----------
+ 1 file changed, 13 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/net/phy/meson-gxl.c b/drivers/net/phy/meson-gxl.c
+index 7e7904fee..c49062ad7 100644
+--- a/drivers/net/phy/meson-gxl.c
++++ b/drivers/net/phy/meson-gxl.c
+@@ -30,8 +30,12 @@
+ #define  INTSRC_LINK_DOWN	BIT(4)
+ #define  INTSRC_REMOTE_FAULT	BIT(5)
+ #define  INTSRC_ANEG_COMPLETE	BIT(6)
++#define  INTSRC_ENERGY_DETECT	BIT(7)
+ #define INTSRC_MASK	30
+ 
++#define INT_SOURCES (INTSRC_LINK_DOWN | INTSRC_ANEG_COMPLETE | \
++		     INTSRC_ENERGY_DETECT)
++
+ #define BANK_ANALOG_DSP		0
+ #define BANK_WOL		1
+ #define BANK_BIST		3
+@@ -200,7 +204,6 @@ static int meson_gxl_ack_interrupt(struct phy_device *phydev)
+ 
+ static int meson_gxl_config_intr(struct phy_device *phydev)
+ {
+-	u16 val;
+ 	int ret;
+ 
+ 	if (phydev->interrupts == PHY_INTERRUPT_ENABLED) {
+@@ -209,16 +212,9 @@ static int meson_gxl_config_intr(struct phy_device *phydev)
+ 		if (ret)
+ 			return ret;
+ 
+-		val = INTSRC_ANEG_PR
+-			| INTSRC_PARALLEL_FAULT
+-			| INTSRC_ANEG_LP_ACK
+-			| INTSRC_LINK_DOWN
+-			| INTSRC_REMOTE_FAULT
+-			| INTSRC_ANEG_COMPLETE;
+-		ret = phy_write(phydev, INTSRC_MASK, val);
++		ret = phy_write(phydev, INTSRC_MASK, INT_SOURCES);
+ 	} else {
+-		val = 0;
+-		ret = phy_write(phydev, INTSRC_MASK, val);
++		ret = phy_write(phydev, INTSRC_MASK, 0);
+ 
+ 		/* Ack any pending IRQ */
+ 		ret = meson_gxl_ack_interrupt(phydev);
+@@ -237,9 +233,16 @@ static irqreturn_t meson_gxl_handle_interrupt(struct phy_device *phydev)
+ 		return IRQ_NONE;
+ 	}
+ 
++	irq_status &= INT_SOURCES;
++
+ 	if (irq_status == 0)
+ 		return IRQ_NONE;
+ 
++	/* Aneg-complete interrupt is used for link-up detection */
++	if (phydev->autoneg == AUTONEG_ENABLE &&
++	    irq_status == INTSRC_ENERGY_DETECT)
++		return IRQ_HANDLED;
++
+ 	phy_trigger_machine(phydev);
+ 
+ 	return IRQ_HANDLED;

--- a/patch/kernel/archive/meson64-5.15/net-net-phy-meson-gxl-improve-link-up-behavior.patch
+++ b/patch/kernel/archive/meson64-5.15/net-net-phy-meson-gxl-improve-link-up-behavior.patch
@@ -1,0 +1,36 @@
+Date: Wed, 9 Mar 2022 22:04:47 +0100
+From: Heiner Kallweit <hkallweit1@gmail.com>
+Subject: [PATCH net] net: phy: meson-gxl: improve link-up behavior
+
+Sometimes the link comes up but no data flows. This patch fixes
+this behavior. It's not clear what's the root cause of the issue.
+
+According to the tests one other link-up issue remains.
+In very rare cases the link isn't even reported as up.
+
+Fixes: 84c8f773d2dc ("net: phy: meson-gxl: remove the use of .ack_callback()")
+Tested-by: Erico Nunes <nunes.erico@gmail.com>
+Signed-off-by: Heiner Kallweit <hkallweit1@gmail.com>
+---
+ drivers/net/phy/meson-gxl.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/phy/meson-gxl.c b/drivers/net/phy/meson-gxl.c
+index c49062ad7..73f7962a3 100644
+--- a/drivers/net/phy/meson-gxl.c
++++ b/drivers/net/phy/meson-gxl.c
+@@ -243,7 +243,13 @@ static irqreturn_t meson_gxl_handle_interrupt(struct phy_device *phydev)
+ 	    irq_status == INTSRC_ENERGY_DETECT)
+ 		return IRQ_HANDLED;
+ 
+-	phy_trigger_machine(phydev);
++	/* Give PHY some time before MAC starts sending data. This works
++	 * around an issue where network doesn't come up properly.
++	 */
++	if (!(irq_status & INTSRC_LINK_DOWN))
++		phy_queue_state_machine(phydev, msecs_to_jiffies(100));
++	else
++		phy_trigger_machine(phydev);
+ 
+ 	return IRQ_HANDLED;
+ }


### PR DESCRIPTION
# Description

Fixes [AR-1097] only for meson64-edge kernel.

https://patchwork.kernel.org/project/linux-amlogic/patch/04cac530-ea1b-850e-6cfa-144a55c4d75d@gmail.com/

This PHY doesn't support a link-up interrupt source. If aneg is enabled
we use the "aneg complete" interrupt for this purpose, but if aneg is
disabled link-up isn't signaled currently.
According to a vendor driver there's an additional "energy detect"
interrupt source that can be used to signal link-up if aneg is disabled.
We can safely ignore this interrupt source if aneg is enabled.

This patch was tested on a TX3 Mini TV box with S905W (even though
boot message says it's a S905D).

This issue has been existing longer, but due to changes in phylib and
the driver the patch applies only from the commit marked as fixed.

Fixes: 84c8f773d2dc ("net: phy: meson-gxl: remove the use of .ack_callback()")
Signed-off-by: Heiner Kallweit <hkallweit1@gmail.com>

Jira reference number [AR-1097]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] fixed bug on JetHub H1

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1097]: https://armbian.atlassian.net/browse/AR-1097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AR-1097]: https://armbian.atlassian.net/browse/AR-1097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ