### PR TITLE
This modification will allow to boot an unmodified cubox-i image on t…

### DIFF
--- a/config/bootscripts/boot-cubox.cmd
+++ b/config/bootscripts/boot-cubox.cmd
@@ -8,36 +8,31 @@ setenv rootdev "/dev/mmcblk0p1"
 setenv verbosity "1"
 setenv console "display"
 setenv bootlogo "false"
-setenv rootfstype "ext4"
 setenv disp_mode "1920x1080m60"
 setenv earlycon "off"
+if test -z "${bootfstype}"; then setenv rootfstype "ext4"; else setenv rootfstype "${bootfstype}"; fi
 
-# next kernels have different u-boot without autodetection
-if ext2load mmc 0 0x00000000 /boot/.next || ext2load mmc 0 0x00000000 .next; then
-	setenv fdt_file "imx6q-cubox-i.dtb"
-else
-	run autodetectfdt
+if test "${board}" = mx6cuboxi; then 
+  setenv ramdisk_addr_r "0x14800000"
+  if test -z "${fdtfile}"; then setenv fdtfile "imx6q-cubox-i.dtb"; fi
+  if test -z "${cons}"; then setenv cons "ttymxc0,115200"; fi
 fi
 
-# additional values
-setenv load_addr "0x10800000"
-setenv ramdisk_addr "0x14800000"
-
-if ext2load mmc 0 ${load_addr} /boot/armbianEnv.txt || ext2load mmc 0 ${load_addr} armbianEnv.txt; then
-	env import -t ${load_addr} ${filesize}
+if load ${devtype} ${devnum}:${distro_bootpart} ${loadaddr} ${prefix}armbianEnv.txt ; then
+	env import -t ${loadaddr} ${filesize}
 fi
 
 if test "${console}" = "display" || test "${console}" = "both"; then setenv consoleargs "console=tty1"; fi
-if test "${console}" = "serial" || test "${console}" = "both"; then setenv consoleargs "${consoleargs} console=ttymxc0,115200"; fi
+if test "${console}" = "serial" || test "${console}" = "both"; then setenv consoleargs "${consoleargs} console=${cons}"; fi
 if test "${earlycon}" = "on"; then setenv consoleargs "earlycon ${consoleargs}"; fi
 if test "${bootlogo}" = "true"; then setenv consoleargs "bootsplash.bootfile=bootsplash.armbian ${consoleargs}"; fi
 
 setenv bootargs "root=${rootdev} rootfstype=${rootfstype} rootwait ${consoleargs} consoleblank=0 video=mxcfb0:dev=hdmi,${disp_mode},if=RGB24,bpp=32 coherent_pool=2M cma=256M@2G rd.dm=0 rd.luks=0 rd.lvm=0 raid=noautodetect pci=nomsi vt.global_cursor_default=0 loglevel=${verbosity} usb-storage.quirks=${usbstoragequirks} ${extraargs}"
-ext2load mmc 0 ${fdt_addr} /boot/dtb/${fdt_file} || fatload mmc 0 ${fdt_addr} /dtb/${fdt_file} || ext2load mmc 0 ${fdt_addr} /dtb/${fdt_file}
-ext2load mmc 0 ${ramdisk_addr} /boot/uInitrd || fatload mmc 0 ${ramdisk_addr} uInitrd || ext2load mmc 0 ${ramdisk_addr} uInitrd
-ext2load mmc 0 ${loadaddr} /boot/zImage || fatload mmc 0 ${loadaddr} zImage || ext2load mmc 0 ${loadaddr} zImage
+load ${devtype} ${devnum}:${distro_bootpart} ${fdt_addr_r} ${prefix}dtb/${fdtfile}
+load ${devtype} ${devnum}:${distro_bootpart} ${ramdisk_addr_r} ${prefix}uInitrd
+load ${devtype} ${devnum}:${distro_bootpart} ${kernel_addr_r} ${prefix}zImage
 
-bootz ${loadaddr} ${ramdisk_addr} ${fdt_addr}
+bootz ${kernel_addr_r} ${ramdisk_addr_r} ${fdt_addr_r}
 
 # Recompile with:
 # mkimage -C none -A arm -T script -d /boot/boot.cmd /boot/boot.scr


### PR DESCRIPTION
…he utilite pro. Beside of this the image can also boot from a different storage media like usb without modification, because most of the distroboot settings are going to be used now.

# Description

The u-boot firmware used for the cubox-i executes the standard distroboot set of macros. Distroboot examines several available boot options and calls for example the boot.scr script found in /boot/. There are set of predefined u-boot environment variables passed to the boot scripts which allows the script to be more portable. As a result the script doesn't need any modification when then the Armbian userland is moved to a different storage device. There is even more potential to become the Armbian userland fully storage agnostic, like OpenWRT does.  

There has been some development in the u-boot firmware which are not reflected in the boot script itself, e.g. the macro `autodetectfdt` doesn't exist anymore.  

Another benefit is the possibility to boot the unmodified cubox-i image on a different imx6 device (an Utilite Pro im my case), may be this will work for other imx6 devices as well. There might be further potential to reduce the amount of distinct boot scripts in total.

# How Has This Been Tested?

I've replaced /boot/boot.cmd and /boot/boot.scr after burning this [image](https://imola.armbian.com/dl/cubox-i/archive/Armbian_22.02.1_Cubox-i_jammy_current_5.15.25.img.xz) to a micro-sd card. The Cubox-i started without any hassle and finished the post-install actions.

# Checklist:

I  believe the standard checks might be not applicable. 

