### PR TITLE
fix install emmc for all station m*\p*

### DIFF
--- a/packages/bsp/common/usr/sbin/nand-sata-install
+++ b/packages/bsp/common/usr/sbin/nand-sata-install
@@ -31,7 +31,7 @@ elif grep -q 'sun5i' /proc/cpuinfo; then DEVICE_TYPE="a13";
 else DEVICE_TYPE="a20"; fi
 BOOTLOADER="${CWD}/${DEVICE_TYPE}/bootloader"
 case ${LINUXFAMILY} in
-	rk3328|rk3399|rk35xx|rockchip64|rockpis|station|media)
+	rk3328|rk3399|rk35xx|rockchip64|rockpis|station*|media)
 		FIRSTSECTOR=32768
 		;;
 	*)


### PR DESCRIPTION
A strange error was found in all models that use LINUXFAMILY=media, the value "station-p2" gets into the image. details are here.

https://forum.armbian.com/topic/18852-board-bring-up-station-p2-rk3568-m2-rk3566/?do=findComment&comment=136590

may have to update the links\images to the corrected version on the download site?