### PR TITLE
Improve template config copying

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -209,7 +209,7 @@ mkdir -p "${SRC}"/userpatches
 
 
 # Create example configs if none found in userpatches
-if ! ls "${SRC}"/userpatches/{config-example.conf,config-docker.conf,config-vagrant.conf} 1> /dev/null 2>&1; then
+if ! ls "${SRC}"/userpatches/{config-default.conf,config-docker.conf,config-vagrant.conf} 1> /dev/null 2>&1; then
 
 	# Migrate old configs
 	if ls "${SRC}"/*.conf 1> /dev/null 2>&1; then

--- a/compile.sh
+++ b/compile.sh
@@ -224,6 +224,10 @@ if ! ls "${SRC}"/userpatches/{config-example.conf,config-docker.conf,config-vagr
 	# Create example config
 	if [[ ! -f "${SRC}"/userpatches/config-example.conf ]]; then
 		cp "${SRC}"/config/templates/config-example.conf "${SRC}"/userpatches/config-example.conf || exit 1
+	fi
+
+	# Link default config to example config
+	if [[ ! -f "${SRC}"/userpatches/config-default.conf ]]; then
                 ln -fs config-example.conf "${SRC}"/userpatches/config-default.conf || exit 1
 	fi
 


### PR DESCRIPTION
# Description

I was running into two problems:
 1. The build script overwrote my userpatches/config-default.conf file.
 2. It kept doing that whenever I removed userpatches/config-example.conf to clean up my userpatches directory.

There's two commits fixing this problem by:
 - Never overwriting config-default.conf (unless it is a broken symlink)
 - Not triggering the config file copy code when config-example.conf is missing.

See commit messages for more details.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] When `userpatches` is absent, template configs are copied in as expected.
- [x] When config-default.conf is made a symlink to config-foo.conf and config-example.conf is removed, the build does not modify userpatches at all.
- [x] When confg-vagrant.conf is removed, this triggers the config update again, replacing config-vagrant.conf and recreating config-example.conf as expected, but not touching config-foo.conf and config-default.conf.
- [x] When config-default.conf is made a plain file, and config-example.conf is removed, again, no userpatches modifications.
- [x] Then, removing config-vagrant.conf again triggers the same behavior, config-vagrant.conf and config-example.conf are recreated, but config-default.conf is untouched.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] ~~I have made corresponding changes to the documentation~~ - None needed
- [x] My changes generate no new warnings
- [ ] ~~Any dependent changes have been merged and published in downstream modules~~ N/A
