### PR TITLE
Reduce Radxa Zero's SDIO frequency 

### DIFF
--- a/patch/kernel/archive/meson64-5.10/arm64-dts-amlogic-add-support-for-Radxa-Zero.patch
+++ b/patch/kernel/archive/meson64-5.10/arm64-dts-amlogic-add-support-for-Radxa-Zero.patch
@@ -494,7 +494,7 @@ index 000000000000..d44d3881d9b9
 +	bus-width = <4>;
 +	cap-sd-highspeed;
 +	sd-uhs-sdr50;
-+	max-frequency = <100000000>;
++	max-frequency = <80000000>;
 +
 +	non-removable;
 +	disable-wp;


### PR DESCRIPTION
This fixes the issue where some boards have increased difficulty to initialize Wi-Fi hardware under the cold weather. They can usually workaround it by unloading and reloading `brcmfmac` driver but this is more user friendly.