### PR TITLE
Sync beta repository in the CI process

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -34,9 +34,25 @@ jobs:
           path: changes
           name: changes
           if-no-files-found: ignore
+
+  sync-servers:
+    name: "Sync servers"
+    needs: [ fake]
+    if: ${{ github.repository_owner == 'Armbian' }}
+    uses: armbian/scripts/.github/workflows/sync-servers.yml@master
+
+    with:
+      KEY_ID: 'upload'
+
+    secrets:
+      KEY_UPLOAD: ${{ secrets.KEY_UPLOAD }}
+      USER_REPOSITORY: ${{ secrets.USER_REPOSITORY }}
+      HOST_REPOSITORY: ${{ secrets.HOST_REPOSITORY }}
+      KNOWN_HOSTS_REPOSITORY: ${{ secrets.KNOWN_HOSTS_REPOSITORY }}
+
       
   merge:
-    needs: [ fake ]
+    needs: [ sync-servers ]
     uses: armbian/scripts/.github/workflows/merge-from-branch.yml@master    
 
     with:

--- a/.github/workflows/build-train.yml
+++ b/.github/workflows/build-train.yml
@@ -251,7 +251,7 @@ jobs:
   ##########################################################################################
 
   x86-cli-images:
-    needs: [apt-armbian-com,beta-armbian-com]
+    needs: [apt-armbian-com,beta-armbian-com,sync-servers]
     uses: armbian/scripts/.github/workflows/build-with-docker.yml@master
 
     with:
@@ -281,7 +281,7 @@ jobs:
   ##########################################################################################
 
   x86-desktop-images:
-    needs: [apt-armbian-com,beta-armbian-com]
+    needs: [apt-armbian-com,beta-armbian-com,sync-servers]
     uses: armbian/scripts/.github/workflows/build-with-docker.yml@master
 
     with:
@@ -311,7 +311,7 @@ jobs:
   ##########################################################################################
 
   cli-images:
-    needs: [apt-armbian-com,beta-armbian-com]
+    needs: [apt-armbian-com,beta-armbian-com,sync-servers]
     uses: armbian/scripts/.github/workflows/build-with-docker.yml@master
 
     with:
@@ -341,7 +341,7 @@ jobs:
   ##########################################################################################
 
   desktop-images:
-    needs: [apt-armbian-com,beta-armbian-com]
+    needs: [apt-armbian-com,beta-armbian-com,sync-servers]
     uses: armbian/scripts/.github/workflows/build-with-docker.yml@master
 
     with:

--- a/.github/workflows/build-train.yml
+++ b/.github/workflows/build-train.yml
@@ -229,6 +229,21 @@ jobs:
       HOST_REPOSITORY: ${{ secrets.HOST_REPOSITORY }}
       KNOWN_HOSTS_REPOSITORY: ${{ secrets.KNOWN_HOSTS_REPOSITORY }}
 
+  sync-servers:
+    name: "Sync servers"
+    needs: [apt-armbian-com,beta-armbian-com]
+    if: ${{ success() && github.repository_owner == 'Armbian' }}
+    uses: armbian/scripts/.github/workflows/sync-servers.yml@master
+
+    with:
+      KEY_ID: 'upload'
+
+    secrets:
+      KEY_UPLOAD: ${{ secrets.KEY_UPLOAD }}
+      USER_REPOSITORY: ${{ secrets.USER_REPOSITORY }}
+      HOST_REPOSITORY: ${{ secrets.HOST_REPOSITORY }}
+      KNOWN_HOSTS_REPOSITORY: ${{ secrets.KNOWN_HOSTS_REPOSITORY }}
+
   ##########################################################################################
   #                                                                                        #
   #                                    Build x86 CLI images                                #


### PR DESCRIPTION
# Description

Since we have more then one beta server we need to sync them before making images.

Jira reference number [AR-1120]

# How Has This Been Tested?

https://github.com/armbian/build/runs/5613891149

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1120]: https://armbian.atlassian.net/browse/AR-1120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ