### PR TITLE
[WIP] Enable Bananapro AHCI regulator

### DIFF
--- a/patch/kernel/archive/sunxi-5.15/patches.armbian/arm-dts-sun7i-a20-bananapro-add-ahci-regulator.patch
+++ b/patch/kernel/archive/sunxi-5.15/patches.armbian/arm-dts-sun7i-a20-bananapro-add-ahci-regulator.patch
@@ -1,0 +1,15 @@
+diff --git a/arch/arm/boot/dts/sun7i-a20-bananapro.dts b/arch/arm/boot/dts/sun7i-a20-bananapro.dts
+index e22f0e8bb..56ede0b5e 100644
+--- a/arch/arm/boot/dts/sun7i-a20-bananapro.dts
++++ b/arch/arm/boot/dts/sun7i-a20-bananapro.dts
+@@ -90,6 +90,10 @@ reg_gmac_3v3: gmac-3v3 {
+ 	};
+ };
+ 
++&reg_ahci_5v {
++	status = "okay";
++}
++
+ &ahci {
+ 	status = "okay";
+ };

--- a/patch/kernel/archive/sunxi-5.15/series.armbian
+++ b/patch/kernel/archive/sunxi-5.15/series.armbian
@@ -96,6 +96,7 @@
 	patches.armbian/arm-dts-sun8i-v3s-s3-pinecube-enable-sound-codec.patch
 	patches.armbian/arm-dts-sun8i-r40-add-clk_out_a-fix-bananam2ultra.patch
 	patches.armbian/arm-dts-sun8i-h3-bananapi-m2-plus-add-wifi_pwrseq.patch
+	patches.armbian/arm-dts-sun7i-a20-bananapro-add-ahci-regulator.patch
 	patches.armbian/arm-dts-sun7i-a20-bananapro-add-hdmi-connector-de.patch
 	patches.armbian/arm-dts-sunxi-h3-h5.dtsi-force-mmc0-bus-width.patch
 	patches.armbian/arm64-dts-sun50i-a64-pine64-enable-wifi-mmc1.patch


### PR DESCRIPTION
# Description

adding the voltage regulator pin to activate AHCI controller in sun7i A20 on Bananapi Pro.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

Status is WIP/not functional:
The patch is not processed during kernel compilation. Maybe I forgot to add something?
