### PR TITLE
Typo bug - wrong board name will break CI

### DIFF
--- a/config/targets-cli-beta.conf
+++ b/config/targets-cli-beta.conf
@@ -68,7 +68,7 @@ orangepizero                 edge            sid         cli                    
 orangepizero2                edge            sid         cli                      beta         yes
 
 
-# Quartz64 A
+# Quartz 64 A
 quartz64a                    edge            sid         cli                      beta         yes
 quartz64a                    edge            jammy       cli                      beta         yes
 

--- a/config/targets-cli-beta.conf
+++ b/config/targets-cli-beta.conf
@@ -69,7 +69,7 @@ orangepizero2                edge            sid         cli                    
 
 
 # Quartz64 A
-quartz54a                    edge            sid         cli                      beta         yes
+quartz64a                    edge            sid         cli                      beta         yes
 quartz64a                    edge            jammy       cli                      beta         yes
 
 


### PR DESCRIPTION
# Description

Didn't notice wrong board name in https://github.com/armbian/build/pull/3539