### PR TITLE
Bugfix - we don't hardcode mainline kernel source 

### DIFF
--- a/config/sources/families/media.conf
+++ b/config/sources/families/media.conf
@@ -50,8 +50,7 @@ case $BRANCH in
 		if [[ $BOARD == station-p2 || $BOARD == station-m2 || $BOARD == quartz64a ]]; then
 			SKIP_BOOTSPLASH="yes"
 			EXTRAWIFI="no"
-			KERNELSOURCE='https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git'
-			KERNELBRANCH='tag:v5.17-rc8'
+			KERNELBRANCH='tag:v5.17'
 			KERNELPATCHDIR='station-p2-'$BRANCH
 			LINUXFAMILY=station-p2
 			LINUXCONFIG='linux-station-p2-'$BRANCH


### PR DESCRIPTION
# Description

We went to use mirrors

# How Has This Been Tested?

- [x] Build test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
