### PR TITLE
Revert CONFIG_TYPEC_DP_ALTMODE=m

### DIFF
--- a/config/kernel/linux-rockchip64-edge.config
+++ b/config/kernel/linux-rockchip64-edge.config
@@ -6866,7 +6866,8 @@ CONFIG_TYPEC_MUX_PI3USB30532=m
 #
 # USB Type-C Alternate Mode drivers
 #
-# CONFIG_TYPEC_DP_ALTMODE is not set
+CONFIG_TYPEC_DP_ALTMODE=m
+# CONFIG_TYPEC_NVIDIA_ALTMODE is not set
 # end of USB Type-C Alternate Mode drivers
 
 CONFIG_USB_ROLE_SWITCH=y


### PR DESCRIPTION
Accidental change linux-rockchip64-edge.config

Revert accidental change.
Jira reference number [AR-1100]

Board works with and without the change.


[AR-1100]: https://armbian.atlassian.net/browse/AR-1100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ