### PR TITLE
Enable creating images on PR when label is set to "Desktop"

### DIFF
--- a/.github/workflows/build-test-image-docker.yml
+++ b/.github/workflows/build-test-image-docker.yml
@@ -1,10 +1,19 @@
-name: Build with Docker
+name: Build desktop at pull request
 
 on:
   workflow_dispatch:
+  pull_request:
+    types: [ labeled ]
+    paths-ignore:
+      - .github/workflows
 
 jobs:
 
   Maintain:    
-    if: github.repository_owner == 'Armbian'
+    if: ${{ github.repository_owner == 'Armbian' && github.event.label.name == 'Desktop' }}
     uses: armbian/scripts/.github/workflows/build-test-image-docker.yml@master
+
+    with
+
+      runner: "ubuntu-latest"
+      reference: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
# Description

When we are making changes to the desktops, testing is very time consuming. This small CI enhancement will generate desktop images at pull request code with direct image download as Github artefact. It takes 30-40 minutes to generate all desktop variants. Since we can't build them for all, currently we provide x86 and rpi images. [This can be changed at will](https://github.com/armbian/scripts/blob/master/.github/workflows/build-test-image-docker.yml#L18-L20).

Jira reference number [AR-1126]

# How Has This Been Tested?

- [ ] Manual test

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
