### PR TITLE
chore: add git hooks & code lint

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,7 +17,7 @@ indent_size = 4
 trim_trailing_whitespace = false
 insert_final_newline = false
 
-[*.json]
+[{*.json,*.yml,*.yaml}]
 indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true

--- a/.lefthook/commit-msg/verify-commit-msg
+++ b/.lefthook/commit-msg/verify-commit-msg
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Author: CXM
+
+# input
+INPUT_FILE=$1
+START_LINE=$(head -n1 $INPUT_FILE)
+# color scheme
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+# pattern
+PATTERN="^^(revert: )?(feat|fix|polish|docs|style|refactor|perf|test|workflow|ci|chore|types|build)(\(.+\))?: .{1,50}"
+
+if ! [[ "$START_LINE" =~ $PATTERN ]]; then
+	printf "${RED}Proper commit message format is required for automated changelog generation. Examples:\n"
+	printf "${GREEN}feat(compiler): add 'comments' option\n"
+	exit 1
+fi

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,13 @@
+commit-msg:
+        scripts:
+                "verify-commit-msg":
+                        runner: bash
+
+pre-commit:
+        commands:
+                check:
+                        glob: "*.{sh}"
+                        run: shellcheck {staged_files}
+                format:
+                        glob: "*.{sh,inc}"
+                        run: shfmt -w {staged_files} && git add {staged_files}


### PR DESCRIPTION
# Description

add code & formatter and commit message lint

## 1.Install
[lefthook](https://github.com/evilmartians/lefthook),[shellcheck](https://github.com/koalaman/shellcheck) and [shfmt](https://github.com/mvdan/sh)

## 2.Config
just run `lefthook install && lefthook run pre-commit` in project root dir to enable git hooks

## 3.Result

 - Wrong commit message:
![Untitled](https://user-images.githubusercontent.com/16154023/160265371-5cd069c8-b17a-4f5a-ace9-1027e1f8d396.gif)

 - Illegal bash:
(e.g:)
<img width="465" alt="image" src="https://user-images.githubusercontent.com/16154023/160265404-4747bc43-b3bd-47c6-a0e6-a9b7fc519849.png">

![Untitled1](https://user-images.githubusercontent.com/16154023/160265468-d3acf1c1-797b-46f9-a7c2-346bc55e555f.gif)

