### PR TITLE
fixup external toolchains

### DIFF
--- a/config/sources/families/mvebu64.conf
+++ b/config/sources/families/mvebu64.conf
@@ -6,7 +6,12 @@ ATFSOURCE='https://git.trustedfirmware.org/TF-A/trusted-firmware-a.git'
 ATFDIR='arm-trusted-firmware-espressobin'
 ATFBRANCH='branch:master'
 ATF_USE_GCC='> 7.2'
-ATF_COMPILER='aarch64-linux-gnu-'
+
+if [[ "${SKIP_EXTERNAL_TOOLCHAINS}" == "yes" ]]; then
+	ATF_COMPILER='aarch64-linux-gnu-'
+else
+	ATF_COMPILER='aarch64-none-linux-gnu-'
+fi
 
 if [[ $BOARD = macchiatobin-doubleshot ]]; then
 	export SCP_BL2=$SRC/cache/sources/marvell-binaries/mrvl_scp_bl2.img
@@ -77,7 +82,12 @@ atf_custom_postprocess()
 	# prepare compilers for postprocess
 	ubootdir="$SRC/cache/sources/$BOOTDIR/${BOOTBRANCH##*:}"
 	export ATF1=$toolchain/$ATF_COMPILER
-	export ATF2=$(find_toolchain "arm-linux-gnueabi-" "> 8.0")/arm-linux-gnueabi-
+	if [[ "${SKIP_EXTERNAL_TOOLCHAINS}" == "yes" ]]; then
+        export TOOLCHAIN_NAME="arm-linux-gnueabihf-"
+    else
+        export TOOLCHAIN_NAME="arm-none-linux-gnueabihf-"
+    fi
+	export ATF2=$(find_toolchain "$TOOLCHAIN_NAME" "> 10.0")/$TOOLCHAIN_NAME
 	export BL33=$ubootdir"/u-boot.bin"
 }
 


### PR DESCRIPTION
# Description

A correction of external toolchains, though not a perfect one.  It feels like there should be a cleaner way to accomplish this goal, but the ARM external toolchains do not have the same name as the debian/ubuntu cross-compile chains.

I believe this code obviates the ATF version bump.

# How Has This Been Tested?

Running with and without SKIP_EXTERNAL_TOOLCHAIN=yes results in the ability to compile flash-image-* files
