### PR TITLE
Enabling / disabling several CLI build targets

### DIFF
--- a/config/targets-cli-beta.conf
+++ b/config/targets-cli-beta.conf
@@ -2,8 +2,9 @@
 # board                      branch          release      desktop|cli|minimal      stable|beta  create images      #
 ####################################################################################################################
 
-# Helios64
-helios64                     edge            sid        cli                      beta         yes
+# Espressobin
+espressobin                  edge            sid         cli                      beta         yes
+espressobin                  edge            jammy       cli                      beta         yes
 
 
 # JetHub H1 (j80)
@@ -18,18 +19,6 @@ jethubj100                   edge            jammy       cli                    
 
 # Jetson Nano
 jetson-nano                  edge            sid         cli                      beta         yes
-
-
-# Khadas Vim3
-khadas-vim3                  edge            sid         cli                      beta         yes
-
-
-# Khadas Vim3l
-khadas-vim3l                 edge            sid         cli                      beta         yes
-
-
-# Khadas Edge
-khadas-edge                  edge            sid         cli                      beta         yes
 
 
 # nanopi-r2s
@@ -60,6 +49,14 @@ odroidxu4                    edge            sid         cli                    
 orangepi-r1plus              edge            sid         cli                      beta         yes
 
 
+# Orangepi 3  
+orangepi3                    edge            sid         cli                      beta         yes
+
+
+# Orangepi 4
+orangepi4                    edge            sid         cli                      beta         yes
+
+
 # Orangepi Zero
 orangepizero                 edge            sid         cli                      beta         yes
 
@@ -75,6 +72,10 @@ quartz64a                    edge            jammy       cli                    
 
 # radxa-zero
 radxa-zero                   edge            sid         cli                      beta         yes
+
+
+# radxa-zero
+radxa-zero2                  edge            sid         cli                      beta         yes
 
 
 # rk322x-box
@@ -113,7 +114,3 @@ uefi-arm64                   edge            jammy       cli                    
 # Virtual qemu
 virtual-qemu                 current         focal       cli                      beta         yes
 virtual-qemu                 current         sid         cli                      beta         yes
-
-
-# Zero Pi
-zeropi                       edge            sid         cli                      beta         yes


### PR DESCRIPTION
# Description

- EBIN has been actually in WIP state and it seems fixed
- Orangepi 3 and 4 LTS versions and Radxa Zero 2 are coming up
- Disable few that doesn't need nightly images

Jira reference number [AR-1083]

# How Has This Been Tested?

Untested yet.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1083]: https://armbian.atlassian.net/browse/AR-1083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ