### PR TITLE
meson: add hostdev libfdt-dev compatibility patch

### DIFF
--- a/patch/u-boot/u-boot-meson/fix_build_for_recent_host-side_libfdt.patch
+++ b/patch/u-boot/u-boot-meson/fix_build_for_recent_host-side_libfdt.patch
@@ -1,0 +1,39 @@
+diff --git a/include/fdt.h b/include/fdt.h
+index c51212e..1ad49cb 100644
+--- a/include/fdt.h
++++ b/include/fdt.h
+@@ -1,5 +1,6 @@
+-#ifndef _FDT_H
++#if !defined(_FDT_H) && !defined(FDT_H)
+ #define _FDT_H
++#define FDT_H
+ 
+ #ifndef __ASSEMBLY__
+ 
+diff --git a/include/libfdt.h b/include/libfdt.h
+index d23d40e..bc08e6a 100644
+--- a/include/libfdt.h
++++ b/include/libfdt.h
+@@ -1,5 +1,6 @@
+-#ifndef _LIBFDT_H
++#if !defined(_LIBFDT_H) && !defined(LIBFDT_H)
+ #define _LIBFDT_H
++#define LIBFDT_H
+ /*
+  * libfdt - Flat Device Tree manipulation
+  * Copyright (C) 2006 David Gibson, IBM Corporation.
+diff --git a/include/libfdt_env.h b/include/libfdt_env.h
+index bf63583..7d0e54e 100644
+--- a/include/libfdt_env.h
++++ b/include/libfdt_env.h
+@@ -18,8 +18,9 @@
+  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+  */
+ 
+-#ifndef _LIBFDT_ENV_H
++#if !defined(_LIBFDT_ENV_H) && !defined(LIBFDT_ENV_H)
+ #define _LIBFDT_ENV_H
++#define LIBFDT_ENV_H
+ 
+ #include "compiler.h"
+ 


### PR DESCRIPTION
# Description

Same as #2773 and #2780. Both of them fix host-side libfdt-dev incompatibilities for the xu4 and the odroidn2 board. This is for ordoidc1(meson). lol

# How Has This Been Tested?

Just build

- [X] Build

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
