### PR TITLE
BUGFIX armbian-ramlog default functionality breaking comments

### DIFF
--- a/packages/bsp/common/etc/default/armbian-ramlog.dpkg-dist
+++ b/packages/bsp/common/etc/default/armbian-ramlog.dpkg-dist
@@ -15,10 +15,11 @@ USE_RSYNC=true
 # commands used to synchronize logs to disk from RAM (XTRA_RSYNC_TO) or from
 # disk to RAM (XTRA_RSYNC_FROM).  These are bash arrays to make specifying
 # multiple arguments easy even in the presence of whitespace.
-XTRA_RSYNC_TO=(
-  ## If you use log rotation programs that datestamp their logs (e.g., runit's
-  ## svlogd or daemontools' multilog), deleting log files while synchronizing is
-  ## likely a good idea.
-  # --delete
-)
+
+
+# If you use log rotation programs that datestamp their logs (e.g., runit's
+# svlogd or daemontools' multilog), deleting log files while synchronizing is
+# likely a good idea.
+#XTRA_RSYNC_TO=(--delete)
+XTRA_RSYNC_FROM=()
 XTRA_RSYNC_FROM=()


### PR DESCRIPTION
# Description
resolves error during log rotation related to #2894

`Syntax error: "(" unexpected`

https://forum.armbian.com/topic/19564-making-espressobin-v7-work-in-2022/?do=findComment&comment=137468

Jira reference number [AR-1135]



# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Test Copied new config and applied it
- [x] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1135]: https://armbian.atlassian.net/browse/AR-1135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ