### PR TITLE
Adjust build targets

### DIFF
--- a/config/targets-cli-beta.conf
+++ b/config/targets-cli-beta.conf
@@ -3,114 +3,105 @@
 ####################################################################################################################
 
 # Espressobin
-espressobin                  edge            sid         cli                      beta         yes
 espressobin                  edge            jammy       cli                      beta         yes
 
 
 # JetHub H1 (j80)
-jethubj80                    edge            sid         cli                      beta         yes
 jethubj80                    edge            jammy       cli                      beta         yes
 
 
 # JetHub D1 (j100)
-jethubj100                   edge            sid         cli                      beta         yes
 jethubj100                   edge            jammy       cli                      beta         yes
 
 
 # Jetson Nano
-jetson-nano                  edge            sid         cli                      beta         yes
+jetson-nano                  edge            jammy       cli                      beta         yes
 
 
 # nanopi-r2s
-nanopi-r2s                   edge            sid         cli                      beta         yes
+nanopi-r2s                   edge            jammy       cli                      beta         yes
 
 
 # nanopi-r4s
-nanopi-r4s                   edge            sid         cli                      beta         yes
+nanopi-r4s                   edge            jammy       cli                      beta         yes
 
 
 # Odroid N2 / N2+
-odroidn2                     edge            sid         cli                      beta         yes
+odroidn2                     edge            jammy       cli                      beta         yes
 
 
 # Odroid C4
-odroidc4                     edge            sid         cli                      beta         yes
+odroidc4                     edge            jammy       cli                      beta         yes
 
 
 # Odroid HC4
-odroidhc4                    edge            sid         cli                      beta         yes
+odroidhc4                    edge            jammy       cli                      beta         yes
 
 
 # Odroid XU4
-odroidxu4                    edge            sid         cli                      beta         yes
+odroidxu4                    edge            jammy       cli                      beta         yes
 
 
 # Orangepi R1+
-orangepi-r1plus              edge            sid         cli                      beta         yes
+orangepi-r1plus              edge            jammy       cli                      beta         yes
 
 
-# Orangepi 3  
-orangepi3                    edge            sid         cli                      beta         yes
+# Orangepi 3
+orangepi3                    edge            jammy       cli                      beta         yes
 
 
 # Orangepi 4
-orangepi4                    edge            sid         cli                      beta         yes
+orangepi4                    edge            jammy       cli                      beta         yes
 
 
 # Orangepi Zero
-orangepizero                 edge            sid         cli                      beta         yes
+orangepizero                 edge            jammy       cli                      beta         yes
 
 
 # Orangepi Zero 2
-orangepizero2                edge            sid         cli                      beta         yes
+orangepizero2                edge            jammy       cli                      beta         yes
 
 
 # Quartz 64 A
-quartz64a                    edge            sid         cli                      beta         yes
 quartz64a                    edge            jammy       cli                      beta         yes
 
 
 # radxa-zero
-radxa-zero                   edge            sid         cli                      beta         yes
+radxa-zero                   edge            jammy       cli                      beta         yes
 
 
 # radxa-zero
-radxa-zero2                  edge            sid         cli                      beta         yes
+radxa-zero2                  current         jammy       cli                      beta         yes
 
 
 # rk322x-box
-rk322x-box                   edge            sid         cli                      beta         yes
+rk322x-box                   edge            jammy       cli                      beta         yes
 
 
 # Radxa rock-3a
 rock-3a                      legacy          jammy       cli                      beta         yes
-rock-3a                      legacy          focal       cli                      beta         yes
 rock-3a                      edge            jammy       cli                      beta         yes
 
 
 # Raspberry Pi4
-rpi4b                        edge            focal       cli                      beta         yes
 rpi4b                        edge            jammy       cli                      beta         yes
 
 
 # Tinkerboard
-tinkerboard                  edge            sid         cli                      beta         yes
+tinkerboard                  edge            jammy       cli                      beta         yes
 
 
 # Tinkerboard 2
-tinkerboard-2                edge            sid         cli                      beta         yes
+tinkerboard-2                edge            jammy       cli                      beta         yes
 
 
 # uefi-x86
-uefi-x86                     edge            sid         cli                      beta         yes
 uefi-x86                     edge            jammy       cli                      beta         yes
 
 
 # uefi-arm64
-uefi-arm64                   edge            sid         cli                      beta         yes
 uefi-arm64                   edge            jammy       cli                      beta         yes
 
 
 # Virtual qemu
 virtual-qemu                 current         focal       cli                      beta         yes
-virtual-qemu                 current         sid         cli                      beta         yes

--- a/config/targets-desktop-beta.conf
+++ b/config/targets-desktop-beta.conf
@@ -4,12 +4,11 @@
 
 
 # nanopim4v2
-nanopim4v2          edge            jammy        desktop                  beta            yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+nanopim4v2          edge            jammy        desktop                  beta            yes           xfce      config_base   3dsupport,browsers
 
 
 # Odroid N2
-odroidn2            edge            jammy        desktop                  beta            yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-odroidn2            edge            jammy        desktop                  beta            yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+odroidn2            edge            jammy        desktop                  beta            yes           cinnamon  config_base   3dsupport,browsers
 
 
 # orangepi 3
@@ -20,24 +19,16 @@ orangepi3           edge            jammy        desktop                  beta  
 orangepi4           edge            jammy        desktop                  beta            yes           xfce      config_base   3dsupport,browsers
 
 
-# radxa-zero
-radxa-zero          edge            jammy        desktop                  beta            yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-radxa-zero          edge            jammy        desktop                  beta            yes           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-
 # Raspberry Pi4
-rpi4b               current         focal        desktop                  beta            adv           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-rpi4b               current         focal        desktop                  beta            adv           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-rpi4b               edge            jammy        desktop                  beta            yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-rpi4b               edge            jammy        desktop                  beta            yes           mate      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+rpi4b               current         jammy        desktop                  beta            adv           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+rpi4b               current         jammy        desktop                  beta            adv           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 
 # Station M2
-station-m2          edge            sid          desktop                  beta            yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 station-m2          edge            jammy        desktop                  beta            yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 
 # Station M2
-station-p2          edge            sid          desktop                  beta            yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 station-p2          edge            jammy        desktop                  beta            yes           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 
@@ -57,5 +48,5 @@ uefi-arm64          edge            jammy        desktop                  beta  
 
 
 # qemu virtual images
-virtual-qemu        current         focal        desktop                  beta            adv           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop 
+virtual-qemu        current         focal        desktop                  beta            adv           cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 virtual-qemu        current         focal        desktop                  beta            adv           xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop

--- a/config/targets.conf
+++ b/config/targets.conf
@@ -137,7 +137,7 @@ nanopi-r1                 current         focal       cli                      s
 nanopi-r1                 edge            jammy       cli                      stable         yes
 
 
-# nanopi-r2s 
+# nanopi-r2s
 nanopi-r2s                current         bullseye    cli                      stable         adv
 nanopi-r2s                current         focal       cli                      stable         adv
 nanopi-r2s                edge            jammy       cli                      stable         yes
@@ -397,6 +397,14 @@ pinebook-pro              edge            jammy       desktop                  s
 pinebook-pro              edge            jammy       desktop                  stable         yes            cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 
+# Radxa Zero
+radxa-zero                current         bullseye    cli                      stable         adv
+radxa-zero                current         focal       desktop                  stable         yes            xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+radxa-zero                current         focal       desktop                  stable         yes            cinnamon  config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+radxa-zero                edge            jammy       desktop                  stable         adv            xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+radxa-zero                edge            jammy       cli                      stable         yes
+
+
 # Renegade
 renegade                  current         bullseye    cli                      stable         adv
 renegade                  current         focal       cli                      stable         adv
@@ -411,7 +419,7 @@ rockpro64                 edge            jammy       desktop                  s
 rockpro64                 edge            jammy       cli                      stable         yes
 
 
-# rk322x-box 
+# rk322x-box
 rk322x-box                current         focal       minimal                  stable         yes
 rk322x-box                current         focal       desktop                  stable         adv            xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 rk322x-box                edge            jammy       desktop                  stable         adv            xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop


### PR DESCRIPTION
# Description

- radxa zero2 edge branch does not exists
- radxa zero no stable build targets
- debian sid builds are broken upstream, removing them
- reduce build count - we are focused to hw functions