### PR TITLE
Bugfix - after upgrading to new version of re-director 

### DIFF
--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -607,7 +607,7 @@ fi
 if [[ -z ${ARMBIAN_MIRROR} ]]; then
 	while true; do
 
-		ARMBIAN_MIRROR=$(wget -SO- -T 1 -t 1 https://redirect.armbian.com 2>&1 | egrep -i "Location" | awk '{print $2}' | head -1)
+		ARMBIAN_MIRROR=$(wget -SO- -T 1 -t 1 https://redirect.armbian.com 2>&1 | egrep -i "Location" | awk '{print $2}' | head -1 | sed 's![^/]$!&/!')
 		[[ ${ARMBIAN_MIRROR} != *armbian.hosthatch* ]] && break
 
 	done

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1595,7 +1595,13 @@ function webseed ()
 	unset text
 	# Hardcoded to EU mirrors since
 	local CCODE=$(curl -s redirect.armbian.com/geoip | jq '.continent.code' -r)
+
 	WEBSEED=($(curl -s https://redirect.armbian.com/mirrors | jq -r '.'${CCODE}' | .[] | values'))
+	# Set to fixed URL if empty
+	[[ -z $CCODE ]] && WEBSEED=(
+                https://stpete-mirror.armbian.com/dl/
+                )
+
 	# aria2 simply split chunks based on sources count not depending on download speed
 	# when selecting china mirrors, use only China mirror, others are very slow there
 	if [[ $DOWNLOAD_MIRROR == china ]]; then


### PR DESCRIPTION
# Description

After upgrading to new version of re-director we can't download tool chains.

- make sure URL has / on the end is good enough fix and won't affect future implementation of re-direct @schwar3kat 
- use some predefined URL in case URL is empty

Jira reference number [AR-1139]

# How Has This Been Tested?

Build test. It downloads toolchain and rootfs cache.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1139]: https://armbian.atlassian.net/browse/AR-1139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ