### PR TITLE
add rk809 codec sound support to radxa rock3a

### DIFF
--- a/patch/kernel/archive/rk35xx-5.17/rk3568-dts-radxa-rock3a-support.patch
+++ b/patch/kernel/archive/rk35xx-5.17/rk3568-dts-radxa-rock3a-support.patch
@@ -9,10 +9,10 @@ index 479906f3ad7b..bf2a58e3a871 100644
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-rock-3-a.dtb
 diff --git a/arch/arm64/boot/dts/rockchip/rk3568-rock-3-a.dts b/arch/arm64/boot/dts/rockchip/rk3568-rock-3-a.dts
 new file mode 100644
-index 000000000000..9e9124dc6c59
+index 000000000000..1b898aff9df8
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3568-rock-3-a.dts
-@@ -0,0 +1,809 @@
+@@ -0,0 +1,808 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2021 Rockchip Electronics Co., Ltd.
@@ -79,18 +79,17 @@ index 000000000000..9e9124dc6c59
 +		};
 +	};
 +
-+	rk809_sound: rk809-sound {
-+		status = "okay";
++	rk809-sound {
 +		compatible = "simple-audio-card";
 +		simple-audio-card,format = "i2s";
-+		simple-audio-card,name = "rockchip,rk809-codec";
++		simple-audio-card,name = "Analog RK809";
 +		simple-audio-card,mclk-fs = <256>;
 +
 +		simple-audio-card,cpu {
 +			sound-dai = <&i2s1_8ch>;
 +		};
 +		simple-audio-card,codec {
-+			sound-dai = <&rk809_codec>;
++			sound-dai = <&rk809>;
 +		};
 +	};
 +
@@ -312,15 +311,21 @@ index 000000000000..9e9124dc6c59
 +		reg = <0x20>;
 +		interrupt-parent = <&gpio0>;
 +		interrupts = <RK_PA3 IRQ_TYPE_LEVEL_LOW>;
++		assigned-clocks = <&cru I2S1_MCLKOUT>, <&cru I2S1_MCLK_TX_IOE>;
++		assigned-clock-rates = <12288000>;
++		assigned-clock-parents = <&cru I2S1_MCLKOUT_TX>, <&cru I2S1_MCLKOUT_TX>;
 +		#clock-cells = <1>;
++		clock-names = "mclk";
++		clocks = <&cru I2S1_MCLKOUT>;
 +		pinctrl-names = "default", "pmic-sleep",
 +				"pmic-power-off", "pmic-reset";
-+		pinctrl-0 = <&pmic_int>;
++		pinctrl-0 = <&pmic_int>, <&i2s1m0_mclk>;
 +		pinctrl-1 = <&soc_slppin_slp>, <&rk817_slppin_slp>;
 +		pinctrl-2 = <&soc_slppin_gpio>, <&rk817_slppin_pwrdn>;
 +		pinctrl-3 = <&soc_slppin_gpio>, <&rk817_slppin_rst>;
 +
 +		rockchip,system-power-controller;
++		#sound-dai-cells = <0>;
 +		clock-output-names = "rk808-clkout1", "rk808-clkout2";
 +		//fb-inner-reg-idxs = <2>;
 +		/* 1: rst regs (default in codes), 0: rst the pmic */
@@ -569,19 +574,8 @@ index 000000000000..9e9124dc6c59
 +			};
 +		};
 +
-+		rk809_codec: codec {
-+			#sound-dai-cells = <0>;
-+			compatible = "rockchip,rk809-codec", "rockchip,rk817-codec";
-+			clocks = <&cru I2S1_MCLKOUT_TX>;
-+			clock-names = "mclk";
-+			assigned-clocks = <&cru I2S1_MCLKOUT_TX>;
-+			assigned-clock-parents = <&cru CLK_I2S1_8CH_TX>;
-+			pinctrl-names = "default";
-+			pinctrl-0 = <&i2s1m0_mclk>;
-+			hp-volume = <20>;
-+			spk-volume = <3>;
++		codec {
 +			mic-in-differential;
-+			status = "okay";
 +		};
 +	};
 +};
@@ -665,6 +659,11 @@ index 000000000000..9e9124dc6c59
 +};
 +
 +&i2s0_8ch {
++	status = "okay";
++};
++
++&i2s1_8ch {
++	rockchip,trcm-sync-tx-only;
 +	status = "okay";
 +};
 +

--- a/patch/kernel/archive/rk35xx-5.17/rk3568-i2s-mclk.patch
+++ b/patch/kernel/archive/rk35xx-5.17/rk3568-i2s-mclk.patch
@@ -1,0 +1,84 @@
+diff --git a/drivers/clk/rockchip/clk-rk3568.c b/drivers/clk/rockchip/clk-rk3568.c
+index 606ae6cd918b..ee8924ac0093 100644
+--- a/drivers/clk/rockchip/clk-rk3568.c
++++ b/drivers/clk/rockchip/clk-rk3568.c
+@@ -13,6 +13,8 @@
+ #include <dt-bindings/clock/rk3568-cru.h>
+ #include "clk.h"
+ 
++#define RK3568_GRF_SOC_CON1	0x504
++#define RK3568_GRF_SOC_CON2	0x508
+ #define RK3568_GRF_SOC_STATUS0	0x580
+ 
+ enum rk3568_pmu_plls {
+@@ -247,13 +249,13 @@ PNAME(dpll_gpll_cpll_p)			= { "dpll", "gpll", "cpll" };
+ PNAME(clk_ddr1x_p)			= { "clk_ddrphy1x_src", "dpll" };
+ PNAME(gpll200_gpll150_gpll100_xin24m_p)	= { "gpll_200m", "gpll_150m", "gpll_100m", "xin24m" };
+ PNAME(gpll100_gpll75_gpll50_p)		= { "gpll_100m", "gpll_75m", "cpll_50m" };
+-PNAME(i2s0_mclkout_tx_p)		= { "clk_i2s0_8ch_tx", "xin_osc0_half" };
+-PNAME(i2s0_mclkout_rx_p)		= { "clk_i2s0_8ch_rx", "xin_osc0_half" };
+-PNAME(i2s1_mclkout_tx_p)		= { "clk_i2s1_8ch_tx", "xin_osc0_half" };
+-PNAME(i2s1_mclkout_rx_p)		= { "clk_i2s1_8ch_rx", "xin_osc0_half" };
+-PNAME(i2s2_mclkout_p)			= { "clk_i2s2_2ch", "xin_osc0_half" };
+-PNAME(i2s3_mclkout_tx_p)		= { "clk_i2s3_2ch_tx", "xin_osc0_half" };
+-PNAME(i2s3_mclkout_rx_p)		= { "clk_i2s3_2ch_rx", "xin_osc0_half" };
++PNAME(i2s0_mclkout_tx_p)		= { "mclk_i2s0_8ch_tx", "xin_osc0_half" };
++PNAME(i2s0_mclkout_rx_p)		= { "mclk_i2s0_8ch_rx", "xin_osc0_half" };
++PNAME(i2s1_mclkout_tx_p)		= { "mclk_i2s1_8ch_tx", "xin_osc0_half" };
++PNAME(i2s1_mclkout_rx_p)		= { "mclk_i2s1_8ch_rx", "xin_osc0_half" };
++PNAME(i2s2_mclkout_p)			= { "mclk_i2s2_2ch", "xin_osc0_half" };
++PNAME(i2s3_mclkout_tx_p)		= { "mclk_i2s3_2ch_tx", "xin_osc0_half" };
++PNAME(i2s3_mclkout_rx_p)		= { "mclk_i2s3_2ch_rx", "xin_osc0_half" };
+ PNAME(mclk_pdm_p)			= { "gpll_300m", "cpll_250m", "gpll_200m", "gpll_100m" };
+ PNAME(clk_i2c_p)			= { "gpll_200m", "gpll_100m", "xin24m", "cpll_100m" };
+ PNAME(gpll200_gpll150_gpll100_p)	= { "gpll_200m", "gpll_150m", "gpll_100m" };
+@@ -307,6 +309,12 @@ PNAME(clk_mac_2top_p)			= { "cpll_125m", "cpll_50m", "cpll_25m", "ppll" };
+ PNAME(clk_pwm0_p)			= { "xin24m", "clk_pdpmu" };
+ PNAME(aclk_rkvdec_pre_p)		= { "gpll", "cpll" };
+ PNAME(clk_rkvdec_core_p)		= { "gpll", "cpll", "dummy_npll", "dummy_vpll" };
++PNAME(i2s1_mclkout_p)			= { "i2s1_mclkout_rx", "i2s1_mclkout_tx" };
++PNAME(i2s3_mclkout_p)			= { "i2s3_mclkout_rx", "i2s3_mclkout_tx" };
++PNAME(i2s1_mclk_rx_ioe_p)		= { "i2s1_mclkin_rx", "i2s1_mclkout_rx" };
++PNAME(i2s1_mclk_tx_ioe_p)		= { "i2s1_mclkin_tx", "i2s1_mclkout_tx" };
++PNAME(i2s2_mclk_ioe_p)			= { "i2s2_mclkin", "i2s2_mclkout" };
++PNAME(i2s3_mclk_ioe_p)			= { "i2s3_mclkin", "i2s3_mclkout" };
+ 
+ static struct rockchip_pll_clock rk3568_pmu_pll_clks[] __initdata = {
+ 	[ppll] = PLL(pll_rk3328, PLL_PPLL, "ppll",  mux_pll_p,
+@@ -704,6 +712,19 @@ static struct rockchip_clk_branch rk3568_clk_branches[] __initdata = {
+ 			RK3568_CLKSEL_CON(83), 15, 1, MFLAGS,
+ 			RK3568_CLKGATE_CON(7), 11, GFLAGS),
+ 
++	MUXGRF(I2S1_MCLKOUT, "i2s1_mclkout", i2s1_mclkout_p,  CLK_SET_RATE_PARENT | CLK_SET_RATE_NO_REPARENT,
++			RK3568_GRF_SOC_CON1, 5, 1, MFLAGS),
++	MUXGRF(I2S3_MCLKOUT, "i2s3_mclkout", i2s3_mclkout_p,  CLK_SET_RATE_PARENT | CLK_SET_RATE_NO_REPARENT,
++			RK3568_GRF_SOC_CON2, 15, 1, MFLAGS),
++	MUXGRF(I2S1_MCLK_RX_IOE, "i2s1_mclk_rx_ioe", i2s1_mclk_rx_ioe_p,  0,
++			RK3568_GRF_SOC_CON2, 0, 1, MFLAGS),
++	MUXGRF(I2S1_MCLK_TX_IOE, "i2s1_mclk_tx_ioe", i2s1_mclk_tx_ioe_p,  0,
++			RK3568_GRF_SOC_CON2, 1, 1, MFLAGS),
++	MUXGRF(I2S2_MCLK_IOE, "i2s2_mclk_ioe", i2s2_mclk_ioe_p,  0,
++			RK3568_GRF_SOC_CON2, 2, 1, MFLAGS),
++	MUXGRF(I2S3_MCLK_IOE, "i2s3_mclk_ioe", i2s3_mclk_ioe_p,  0,
++			RK3568_GRF_SOC_CON2, 3, 1, MFLAGS),
++
+ 	GATE(HCLK_PDM, "hclk_pdm", "hclk_gic_audio", 0,
+ 			RK3568_CLKGATE_CON(5), 14, GFLAGS),
+ 	COMPOSITE_NODIV(MCLK_PDM, "mclk_pdm", mclk_pdm_p, 0,
+diff --git a/include/dt-bindings/clock/rk3568-cru.h b/include/dt-bindings/clock/rk3568-cru.h
+index d29890865150..251445cf7632 100644
+--- a/include/dt-bindings/clock/rk3568-cru.h
++++ b/include/dt-bindings/clock/rk3568-cru.h
+@@ -479,6 +479,12 @@
+ #define CPLL_25M		416
+ #define CPLL_100M		417
+ #define SCLK_DDRCLK		418
++#define I2S1_MCLKOUT		419
++#define I2S3_MCLKOUT		420
++#define I2S1_MCLK_RX_IOE	421
++#define I2S1_MCLK_TX_IOE	422
++#define I2S2_MCLK_IOE		423
++#define I2S3_MCLK_IOE		424
+ 
+ #define PCLK_CORE_PVTM		450
+ 


### PR DESCRIPTION
# Description

1, Add rk809 codec support refering to [this commit in mainline](https://github.com/torvalds/linux/commit/3e4c629ca680785af2cd6bfd688e958b03db921e)
2, Fix headphone noise refering to [radxa repo](https://github.com/radxa/kernel/commit/16fc8a26b5f55e0eba664770933a6bcaeed37718)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] rk35xx edge kernel build success
- [x] radxa rock3a headphone works

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
