### PR TITLE
Fix patch applicability for the sun50i-h5-orangepi-zero-plus board

### DIFF
--- a/patch/kernel/archive/sunxi-5.10/board-h5-orangepi-zero-plus-fixes.patch
+++ b/patch/kernel/archive/sunxi-5.10/board-h5-orangepi-zero-plus-fixes.patch
@@ -1,13 +1,22 @@
+From 53b693e0c8b3a6422bc789c77c04279c9770a231 Mon Sep 17 00:00:00 2001
+From: The Going <48602507+The-going@users.noreply.github.com>
+Date: Sat, 2 Apr 2022 12:08:47 +0300
+Subject: [PATCH] arm64: dts: sun50i-h5-orangepi-zero-plus fixes
+
+---
+ .../sun50i-h5-orangepi-zero-plus.dts          | 25 ++++++++++++++++++-
+ 1 file changed, 24 insertions(+), 1 deletion(-)
+
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-zero-plus.dts b/arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-zero-plus.dts
-index ef5ca6444..a3359924f 100644
+index de448ca51..a3359924f 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-zero-plus.dts
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-zero-plus.dts
 @@ -4,6 +4,7 @@
- 
+
  /dts-v1/;
  #include "sun50i-h5.dtsi"
 +#include "sun50i-h5-cpu-opp.dtsi"
- 
+
  #include <dt-bindings/gpio/gpio.h>
  #include <dt-bindings/input/input.h>
 @@ -36,12 +37,13 @@ leds {
@@ -17,14 +26,14 @@ index ef5ca6444..a3359924f 100644
 -			default-state = "on";
 +			linux,default-trigger = "default-on";
  		};
- 
+
  		status {
  			label = "orangepi:red:status";
  			gpios = <&pio 0 17 GPIO_ACTIVE_HIGH>; /* PA17 */
 +			linux,default-trigger = "heartbeat";
  		};
  	};
- 
+
 @@ -54,6 +56,27 @@ reg_gmac_3v3: gmac-3v3 {
  		enable-active-high;
  		gpio = <&pio 3 6 GPIO_ACTIVE_HIGH>; /* PD6 */
@@ -51,14 +60,8 @@ index ef5ca6444..a3359924f 100644
 +&cpu0 {
 +	cpu-supply = <&reg_sy8113b>;
  };
- 
+
  &ehci0 {
-@@ -69,7 +92,7 @@ &emac {
- 	pinctrl-0 = <&emac_rgmii_pins>;
- 	phy-supply = <&reg_gmac_3v3>;
- 	phy-handle = <&ext_rgmii_phy>;
--	phy-mode = "rgmii";
-+	phy-mode = "rgmii-id";
- 	status = "okay";
- };
- 
+--
+2.34.1
+


### PR DESCRIPTION
# Description

Remove the patch piece from the patch file. This fix is present in the upstream version of the kernel.

- [x] Test build kernel

