### PR TITLE
Fixing deboostrap fail due to too old ca-certificate package

### DIFF
--- a/config/cli/focal/debootstrap/components
+++ b/config/cli/focal/debootstrap/components
@@ -1,1 +1,1 @@
-main universe
+main universe restricted


### PR DESCRIPTION
# Description

Jira reference number [AR-1140]

# How Has This Been Tested?

- [x] Build Focal and Jammy desktop package

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1140]: https://armbian.atlassian.net/browse/AR-1140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ