### PR TITLE
fix package name caused by mutter update

### DIFF
--- a/config/desktop/sid/environments/gnome/config_base/packages
+++ b/config/desktop/sid/environments/gnome/config_base/packages
@@ -32,7 +32,7 @@ gir1.2-graphene-1.0
 gir1.2-gweather-3.0
 gir1.2-ibus-1.0
 gir1.2-json-1.0
-gir1.2-mutter-9
+gir1.2-mutter-10
 gir1.2-nm-1.0
 gir1.2-nma-1.0
 gir1.2-polkit-1.0
@@ -115,7 +115,7 @@ libijs-0.35
 libimobiledevice6
 libjavascriptcoregtk-4.0-18
 libjbig2dec0
-libmutter-9-0
+libmutter-10-0
 libnautilus-extension1a
 libnma0
 libnotify-bin


### PR DESCRIPTION
# Description

Mutter update cause a package name change in sid, so the package list need update too.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] build sid gnome success: https://github.com/amazingfate/armbian-rock3a-images/runs/5800531654?check_suite_focus=true

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
