### PR TITLE
Add missing packages creation to build train

### DIFF
--- a/.github/workflows/build-train.yml
+++ b/.github/workflows/build-train.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: small
     steps:
       - uses: n1hility/cancel-previous-runs@v2
-        with: 
+        with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
   ##########################################################################################
@@ -27,7 +27,7 @@ jobs:
   #           Merge master into nighly image from which we build packages                  #
   #                                                                                        #
   ##########################################################################################
-  
+
   Merge:
     name: Merging
     needs: Cancel
@@ -75,6 +75,26 @@ jobs:
       GPG_PASSPHRASE1: ${{ secrets.GPG_PASSPHRASE1 }}
       GPG_KEY2: ${{ secrets.GPG_KEY2 }}
       GPG_PASSPHRASE2: ${{ secrets.GPG_PASSPHRASE2 }}
+      SCRIPTS_ACCESS_TOKEN: ${{ secrets.SCRIPTS_ACCESS_TOKEN }}
+      KEY_TORRENTS: ${{ secrets.KEY_TORRENTS }}
+      KNOWN_HOSTS_UPLOAD: ${{ secrets.KNOWN_HOSTS_UPLOAD }}
+
+  ##########################################################################################
+  #                                                                                        #
+  #                      Build changed firmware, zsh, armbian-config                       #
+  #                                                                                        #
+  ##########################################################################################
+
+  Firmware:
+    needs: Check
+    if: ${{ success() && github.repository_owner == 'Armbian' }}
+    uses: armbian/scripts/.github/workflows/build-firmware.yml@master
+
+    with:
+      reference: nightly
+      runner: small
+
+    secrets:
       SCRIPTS_ACCESS_TOKEN: ${{ secrets.SCRIPTS_ACCESS_TOKEN }}
       KEY_TORRENTS: ${{ secrets.KEY_TORRENTS }}
       KNOWN_HOSTS_UPLOAD: ${{ secrets.KNOWN_HOSTS_UPLOAD }}
@@ -183,7 +203,7 @@ jobs:
   ##########################################################################################
 
   Deploy:
-    needs: [Kernel,Desktop,legacy,current,edge]
+    needs: [Kernel,Desktop,Firmware,legacy,current,edge]
     if: ${{ success() && github.repository_owner == 'Armbian' }}
     uses: armbian/scripts/.github/workflows/deploy.yml@master
 
@@ -209,7 +229,7 @@ jobs:
     with:
       KEY_ID: 'repository'
 
-    secrets:  
+    secrets:
       KEY_REPOSITORY: ${{ secrets.KEY_REPOSITORY }}
       USER_REPOSITORY: ${{ secrets.USER_REPOSITORY }}
       HOST_REPOSITORY: ${{ secrets.HOST_REPOSITORY }}
@@ -224,7 +244,7 @@ jobs:
     with:
       KEY_ID: 'repository-beta'
 
-    secrets:  
+    secrets:
       KEY_REPOSITORY: ${{ secrets.KEY_REPOSITORY_BETA }}
       USER_REPOSITORY: ${{ secrets.USER_REPOSITORY }}
       HOST_REPOSITORY: ${{ secrets.HOST_REPOSITORY }}
@@ -256,7 +276,7 @@ jobs:
     uses: armbian/scripts/.github/workflows/build-with-docker.yml@master
 
     with:
- 
+
       variant: 'cli:beta'
       runner: "small"
       sourcerepo: 'nightly'
@@ -316,7 +336,7 @@ jobs:
     uses: armbian/scripts/.github/workflows/build-with-docker.yml@master
 
     with:
- 
+
       variant: 'cli:beta'
       runner: "small"
       sourcerepo: 'nightly'
@@ -350,7 +370,7 @@ jobs:
       runner: "big"
       sourcerepo: 'nightly'
       part: 1
-      of: 1      
+      of: 1
       include: ''
       exclude: 'grep -v uefi-x86 | '
       uploading: false
@@ -393,7 +413,7 @@ jobs:
   #                        Update download links and create torrents                       #
   #                                                                                        #
   ##########################################################################################
-  
+
   Torrents:
     name: Torrents
     needs: [x86-cli-images,x86-desktop-images,cli-images,desktop-images]

--- a/.github/workflows/build-train.yml
+++ b/.github/workflows/build-train.yml
@@ -95,7 +95,6 @@ jobs:
       runner: small
 
     secrets:
-      SCRIPTS_ACCESS_TOKEN: ${{ secrets.SCRIPTS_ACCESS_TOKEN }}
       KEY_TORRENTS: ${{ secrets.KEY_TORRENTS }}
       KNOWN_HOSTS_UPLOAD: ${{ secrets.KNOWN_HOSTS_UPLOAD }}
 

--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -546,7 +546,7 @@ CUSTOM_KERNEL_CONFIG
 	if  [[ -z ${KERNEL_VERSION_LEVEL} ]]; then
 		git -C ${kerneldir} cat-file -t ${OLDHASHTARGET} >/dev/null 2>&1
 		[[ $? -ne 0 ]] && OLDHASHTARGET=$(git -C ${kerneldir} show HEAD~199 --pretty=format:"%H" --no-patch)
-		else
+	else
 		git -C ${kerneldir} cat-file -t ${OLDHASHTARGET} >/dev/null 2>&1
 		[[ $? -ne 0 ]] && OLDHASHTARGET=$(git -C ${kerneldir} rev-list --max-parents=0 HEAD)
 	fi
@@ -566,10 +566,16 @@ CUSTOM_KERNEL_CONFIG
 	# create change log
 	git --no-pager -C ${kerneldir} log --abbrev-commit --oneline --no-patch --no-merges --date-order --date=format:'%Y-%m-%d %H:%M:%S' --pretty=format:'%C(black bold)%ad%Creset%C(auto) | %s | <%an> | <a href='$URL'%H>%H</a>' ${OLDHASHTARGET}..${hash} > "${HASHTARGET}.gitlog"
 
+	# hash origin
 	echo "${hash}" > "${HASHTARGET}.githash"
-	hash_watch_1=$(LC_COLLATE=C find -L "${SRC}/patch/kernel/${KERNELPATCHDIR}"/ -name '*.patch' -mindepth 1 -maxdepth 1 -printf '%s %P\n' 2> /dev/null | LC_COLLATE=C sort -n)
-	hash_watch_2=$(cat "${SRC}/config/kernel/${LINUXCONFIG}.config")
-	echo "${hash_watch_1}${hash_watch_2}" | improved_git hash-object --stdin >> "${HASHTARGET}.githash"
+
+	# hash_patches=
+	git -C $SRC log --format="%H" -1 -- \
+		$(realpath --relative-base="$SRC" "${SRC}/patch/kernel/${KERNELPATCHDIR}") >> "${HASHTARGET}.githash"
+
+	# hash_kernel_config=
+	git -C $SRC log --format="%H" -1 -- \
+		$(realpath --relative-base="$SRC" "${SRC}/config/kernel/${LINUXCONFIG}.config")	>> "${HASHTARGET}.githash"
 
 }
 

--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -567,7 +567,7 @@ CUSTOM_KERNEL_CONFIG
 	git --no-pager -C ${kerneldir} log --abbrev-commit --oneline --no-patch --no-merges --date-order --date=format:'%Y-%m-%d %H:%M:%S' --pretty=format:'%C(black bold)%ad%Creset%C(auto) | %s | <%an> | <a href='$URL'%H>%H</a>' ${OLDHASHTARGET}..${hash} > "${HASHTARGET}.gitlog"
 
 	echo "${hash}" > "${HASHTARGET}.githash"
-	hash_watch_1=$(LC_COLLATE=C find -L "${SRC}/patch/kernel/${KERNELPATCHDIR}"/ -name '*.patch' -mindepth 1 -maxdepth 1 -printf '%s %P\n' 2> /dev/null | LC_COLLATE=C sort -n)
+	hash_watch_1=$(LC_COLLATE=C find -L "${SRC}/patch/kernel/${KERNELPATCHDIR}"/ -type f \( -iname \*.patch -o -iname \series.* \) -mindepth 1 -maxdepth 1 -printf '%s %P\n' 2> /dev/null | LC_COLLATE=C sort -n)
 	hash_watch_2=$(cat "${SRC}/config/kernel/${LINUXCONFIG}.config")
 	echo "${hash_watch_1}${hash_watch_2}" | improved_git hash-object --stdin >> "${HASHTARGET}.githash"
 

--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -567,7 +567,7 @@ CUSTOM_KERNEL_CONFIG
 	git --no-pager -C ${kerneldir} log --abbrev-commit --oneline --no-patch --no-merges --date-order --date=format:'%Y-%m-%d %H:%M:%S' --pretty=format:'%C(black bold)%ad%Creset%C(auto) | %s | <%an> | <a href='$URL'%H>%H</a>' ${OLDHASHTARGET}..${hash} > "${HASHTARGET}.gitlog"
 
 	echo "${hash}" > "${HASHTARGET}.githash"
-	hash_watch_1=$(LC_COLLATE=C find -L "${SRC}/patch/kernel/${KERNELPATCHDIR}"/ -type f \( -iname \*.patch -o -iname \series.* \) -mindepth 1 -maxdepth 1 -printf '%s %P\n' 2> /dev/null | LC_COLLATE=C sort -n)
+	hash_watch_1=$(LC_COLLATE=C find -L "${SRC}/patch/kernel/${KERNELPATCHDIR}"/ -name '*.patch' -mindepth 1 -maxdepth 1 -printf '%s %P\n' 2> /dev/null | LC_COLLATE=C sort -n)
 	hash_watch_2=$(cat "${SRC}/config/kernel/${LINUXCONFIG}.config")
 	echo "${hash_watch_1}${hash_watch_2}" | improved_git hash-object --stdin >> "${HASHTARGET}.githash"
 


### PR DESCRIPTION
# Description

We forgot to build armbian-config, zsh and firmware in the nightly build train. Perhaps they were in some instance, but now they seems to be missing.

Jira reference number [AR-1144]

# How Has This Been Tested?

- [x] Test dry run

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1144]: https://armbian.atlassian.net/browse/AR-1144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ