### PR TITLE
switching the default value of image creation to fast mode

### DIFF
--- a/config/sources/arm64.conf
+++ b/config/sources/arm64.conf
@@ -18,6 +18,7 @@ ARCHITECTURE=arm64
 ARCH=arm64
 KERNEL_IMAGE_TYPE=Image
 CAN_BUILD_STRETCH=yes
+FAST_CREATE_IMAGE="yes"
 
 if [ "$(uname -m)" = "aarch64" ]; then
 	[[ $ATF_COMPILE != "no" && -z $ATF_COMPILER ]] && ATF_COMPILER="aarch64-linux-gnu-"

--- a/config/sources/armhf.conf
+++ b/config/sources/armhf.conf
@@ -18,6 +18,7 @@ ARCHITECTURE=arm
 ARCH=armhf
 KERNEL_IMAGE_TYPE=Image
 CAN_BUILD_STRETCH=yes
+FAST_CREATE_IMAGE="yes"
 
 if [ "$(uname -m)" = "aarch64" ]; then
 	[[ -z $UBOOT_COMPILER ]]	&& UBOOT_COMPILER="arm-linux-gnueabihf-"


### PR DESCRIPTION
Now, by default, the slow option of creating a blank image with the dd command is used, which takes a lot of time. This option switches the default mode to quickly create a blank image with a simple file creation command. I have been using rapid image creation for a very long time (including with native assembly on ARM devices themselves) and no problems have been detected from this mode. When switching to the fast mode, the image creation time is significantly reduced, especially in cases when non-fast media are used for assembly.
