### PR TITLE
create an option to allow ipv6 downloads

### DIFF
--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -613,6 +613,8 @@ if [[ -z ${ARMBIAN_MIRROR} ]]; then
 	done
 fi
 
+[[ -z $DISABLE_IPV6 ]] && DISABLE_IPV6="true"
+
 # For (late) user override.
 # Notice: it is too late to define hook functions or add extensions in lib.config, since the extension initialization already ran by now.
 #         in case the user tries to use them in lib.config, hopefully they'll be detected as "wishful hooking" and the user will be wrn'ed.

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1624,6 +1624,7 @@ download_and_verify()
 	local filename=$2
 	local localdir=$SRC/cache/${remotedir//_}
 	local dirname=${filename//.tar.xz}
+    [[ -z $DISABLE_IPV6 ]] && DISABLE_IPV6="true"
 
         if [[ $DOWNLOAD_MIRROR == china ]]; then
 			local server="https://mirrors.tuna.tsinghua.edu.cn/armbian-releases/"
@@ -1666,7 +1667,7 @@ download_and_verify()
 	else
 		# download control file
 		local torrent=${server}$remotedir/${filename}.torrent
-		aria2c --download-result=hide --disable-ipv6=true --summary-interval=0 --console-log-level=error --auto-file-renaming=false \
+		aria2c --download-result=hide --disable-ipv6=$DISABLE_IPV6 --summary-interval=0 --console-log-level=error --auto-file-renaming=false \
 		--continue=false --allow-overwrite=true --dir="${localdir}" ${server}${remotedir}/${filename}.asc $(webseed "$remotedir/${filename}.asc") -o "${filename}.asc"
 		[[ $? -ne 0 ]] && display_alert "Failed to download control file" "" "wrn"
 	fi
@@ -1678,7 +1679,7 @@ download_and_verify()
 		local ariatorrent="--summary-interval=0 --auto-save-interval=0 --seed-time=0 --bt-stop-timeout=120 --console-log-level=error \
 		--allow-overwrite=true --download-result=hide --rpc-save-upload-metadata=false --auto-file-renaming=false \
 		--file-allocation=trunc --continue=true ${torrent} \
-		--dht-file-path=${SRC}/cache/.aria2/dht.dat --disable-ipv6=true --stderr --follow-torrent=mem --dir=$localdir"
+		--dht-file-path=${SRC}/cache/.aria2/dht.dat --disable-ipv6=$DISABLE_IPV6 --stderr --follow-torrent=mem --dir=$localdir"
 
 		# exception. It throws error if dht.dat file does not exists. Error suppress needed only at first download.
 		if [[ -f "${SRC}"/cache/.aria2/dht.dat ]]; then
@@ -1699,7 +1700,7 @@ download_and_verify()
 		if [[ ! `timeout 10 curl --head --fail --silent ${server}${remotedir}/${filename} 2>&1 >/dev/null` ]]; then
 			display_alert "downloading using http(s) network" "$filename"
 			aria2c --download-result=hide --rpc-save-upload-metadata=false --console-log-level=error \
-			--dht-file-path="${SRC}"/cache/.aria2/dht.dat --disable-ipv6=true --summary-interval=0 --auto-file-renaming=false --dir="${localdir}" ${server}${remotedir}/${filename} $(webseed "${remotedir}/${filename}") -o "${filename}"
+			--dht-file-path="${SRC}"/cache/.aria2/dht.dat --disable-ipv6=$DISABLE_IPV6 --summary-interval=0 --auto-file-renaming=false --dir="${localdir}" ${server}${remotedir}/${filename} $(webseed "${remotedir}/${filename}") -o "${filename}"
 			# mark complete
 			[[ $? -eq 0 ]] && touch "${localdir}/${filename}.complete" && echo ""
 

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1624,7 +1624,8 @@ download_and_verify()
 	local filename=$2
 	local localdir=$SRC/cache/${remotedir//_}
 	local dirname=${filename//.tar.xz}
-    [[ -z $DISABLE_IPV6 ]] && DISABLE_IPV6="true"
+
+	[[ -z $DISABLE_IPV6 ]] && DISABLE_IPV6="true"
 
         if [[ $DOWNLOAD_MIRROR == china ]]; then
 			local server="https://mirrors.tuna.tsinghua.edu.cn/armbian-releases/"


### PR DESCRIPTION
# Description

I'm on an IPv6 only home-network.  This means aria fails to download, as the scripts disable IPv6.  I'd like to add an option to enable it.

# How Has This Been Tested?

I compiled before and after making the change, and if the user doesn't explicitly change the setting, it follows the same path (which includes not downloading things for me).

