### PR TITLE
Remove conflicting package due to Jammy user base

### DIFF
--- a/config/cli/focal/debootstrap/packages
+++ b/config/cli/focal/debootstrap/packages
@@ -23,7 +23,6 @@ locales
 logrotate
 netbase
 netcat-openbsd
-rng-tools
 rsync
 rsyslog
 sudo

--- a/lib/chroot-buildpackages.sh
+++ b/lib/chroot-buildpackages.sh
@@ -44,7 +44,7 @@ create_chroot()
 
 	# perhaps a temporally workaround
 	case $release in
-		buster|bullseye|focal|hirsute|sid)
+		buster|bullseye|focal|hirsute|sid|jammy)
 			includes=${includes}",perl-openssl-defaults,libnet-ssleay-perl"
 		;;
 	esac

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1370,7 +1370,7 @@ prepare_host()
 	build-essential  ca-certificates ccache cpio cryptsetup curl              \
 	debian-archive-keyring debian-keyring debootstrap device-tree-compiler    \
 	dialog dirmngr dosfstools dwarves f2fs-tools fakeroot flex gawk           \
-	gcc-arm-linux-gnueabi gcc-aarch64-linux-gnu gdisk gnupg1 gpg              \
+	gcc-arm-linux-gnueabi gcc-aarch64-linux-gnu gdisk gpg                     \
 	imagemagick jq kmod libbison-dev libc6-dev-armhf-cross libcrypto++-dev    \
 	libelf-dev libfdt-dev libfile-fcntllock-perl                              \
 	libfl-dev liblz4-tool libncurses-dev libpython2.7-dev libssl-dev          \


### PR DESCRIPTION
# Description

- Aptly does not want gnupg1 that is shipped with Jammy anymore. We need to check what does that means for generating repos - if / when we are going to change from Focal.

Jira reference number [AR-1149]

# How Has This Been Tested?

- [x] Build test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1149]: https://armbian.atlassian.net/browse/AR-1149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ