### PR TITLE
fix .editorconfig syntax, add rule for .conf as shell

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,7 +26,7 @@ insert_final_newline = true
 # C coding style based on Linux kernel.
 # https://www.kernel.org/doc/html/v5.0/process/coding-style.html
 
-[[{*.sh,*.inc}]]
+[*.{sh,inc,conf}]
 indent_style = tab
 indent_size = 4
 


### PR DESCRIPTION
Fix .editorconfig syntax error for .sh and .inc files, add rule for .conf same as .sh.
