### PR TITLE
Adjust chroot build packages due to Jammy upgrade

### DIFF
--- a/lib/chroot-buildpackages.sh
+++ b/lib/chroot-buildpackages.sh
@@ -44,7 +44,7 @@ create_chroot()
 
 	# perhaps a temporally workaround
 	case $release in
-		buster|bullseye|focal|hirsute|sid|jammy)
+		bullseye|focal|jammy|sid)
 			includes=${includes}",perl-openssl-defaults,libnet-ssleay-perl"
 		;;
 	esac
@@ -128,6 +128,7 @@ chroot_prepare_distccd()
 	gcc_version['focal']='9.2'
 	gcc_version['hirsute']='10.2'
 	gcc_version['sid']='10.2'
+	gcc_version['jammy']='12'
 	gcc_type['armhf']='arm-linux-gnueabihf-'
 	gcc_type['arm64']='aarch64-linux-gnu-'
 	rm -f "${dest}"/cmdlist
@@ -162,8 +163,8 @@ chroot_build_packages()
 		target_arch="${ARCH}"
 	else
 		# only make packages for recent releases. There are no changes on older
-		target_release="bionic buster bullseye focal hirsute jammy sid"
-		target_arch="armhf arm64"
+		target_release="bullseye focal jammy sid"
+		target_arch="armhf arm64 amd64"
 	fi
 
 	for release in $target_release; do

--- a/packages/extras-buildpkgs/90-hostapd.conf
+++ b/packages/extras-buildpkgs/90-hostapd.conf
@@ -1,8 +1,8 @@
 # hostapd
 local package_name="hostapd"
 local package_repo="http://w1.fi/hostap.git"
-local package_ref="tag:hostap_2_9"
-local package_upstream_version="3:2.9-102"
+local package_ref="tag:hostap_2_10"
+local package_upstream_version="3:2.10-6"
 local package_install_target="hostapd"
 local package_component="${release}-utils"
 


### PR DESCRIPTION
# Description

Also bump hostapd to latest version.

Jira reference number [AR-1149]

# How Has This Been Tested?

We need to rebuild hostapd with new SSL library.

- [x] Regenerating rootfs caches

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1149]: https://armbian.atlassian.net/browse/AR-1149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ