### PR TITLE
add some packages into jammy gnome package list

### DIFF
--- a/config/desktop/jammy/environments/gnome/config_base/packages
+++ b/config/desktop/jammy/environments/gnome/config_base/packages
@@ -153,8 +153,6 @@ libxmuu1
 libxtst6
 libxxf86dga1
 libyelp0
-lightdm
-linux-firmware
 linux-sound-base
 mutter
 mutter-common
@@ -179,7 +177,6 @@ python3-distupgrade
 python3-update-manager
 python3-xkit
 python3-yaml
-slick-greeter
 software-properties-gtk
 spice-vdagent
 system-config-printer

--- a/config/desktop/jammy/environments/gnome/config_base/packages
+++ b/config/desktop/jammy/environments/gnome/config_base/packages
@@ -10,6 +10,9 @@ dmz-cursor-theme
 evolution-data-server
 evolution-data-server-common
 fonts-freefont-ttf
+fonts-noto-cjk
+fonts-noto-cjk-extra
+fonts-ubuntu-console
 fonts-urw-base35
 foomatic-db-compressed-ppds
 gconf2
@@ -150,6 +153,8 @@ libxmuu1
 libxtst6
 libxxf86dga1
 libyelp0
+lightdm
+linux-firmware
 linux-sound-base
 mutter
 mutter-common
@@ -174,6 +179,7 @@ python3-distupgrade
 python3-update-manager
 python3-xkit
 python3-yaml
+slick-greeter
 software-properties-gtk
 spice-vdagent
 system-config-printer


### PR DESCRIPTION
# Description

1, Add fonts-ubuntu-console because it is need by terminator as mono font.
2, Add fonts-noto-cjk and fonts-noto-cjk-extra because they solve the noto fonts when language is set to Chinese.
3, Add lightdm and slice-greeter because ubuntu use lightdm as display-manager and gdm is removed.
4, Add linux-firmware because is contains a lot of firmware(I need firmware of rtl8822ce).

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Build image with command `./compile.sh docker   BOARD=rock-3a   BRANCH=edge   RELEASE=jammy   BUILD_MINIMAL=no   BUILD_DESKTOP=yes   KERNEL_ONLY=no   KERNEL_CONFIGURE=no   DESKTOP_ENVIRONMENT=gnome   DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base   DESKTOP_APPGROUPS_SELECTED="3dsupport browsers chat desktop_tools editors email internet multimedia office programming remote_desktop"   EXPERT=yes BETA=yes COMPRESS_OUTPUTIMAGE=sha,gpg,xz` success

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
