### PR TITLE
Support only Jammy Nvidia support until we don't fix kernel headers

### DIFF
--- a/config/sources/families/uefi-x86.conf
+++ b/config/sources/families/uefi-x86.conf
@@ -1,5 +1,5 @@
 # Important: LINUXFAMILY and ARCH are defined _before_ including the common family include
-[[ "$BUILD_DESKTOP" == yes ]] && enable_extension "nvidia"
+[[ "$BUILD_DESKTOP" == yes && "$RELEASE" == jammy ]] && enable_extension "nvidia"
 export LINUXFAMILY="x86"
 export ARCH="amd64"
 source "${BASH_SOURCE%/*}/include/uefi_common.inc"


### PR DESCRIPTION
# Description

Support only Jammy Nvidia support until we don't fix kernel headers

Jira reference number [AR-1128]
Ci logs: https://github.com/armbian/build/runs/5962963889

[AR-1128]: https://armbian.atlassian.net/browse/AR-1128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ