### PR TITLE
Fix warnings: redefined CONSOLE_STDIN_SETTINGS

### DIFF
--- a/patch/u-boot/u-boot-sunxi/sunxi-boot-splash.patch
+++ b/patch/u-boot/u-boot-sunxi/sunxi-boot-splash.patch
@@ -1,22 +1,33 @@
+From 5ac0039607be388a35df2dd4729fcc9d03b84b21 Mon Sep 17 00:00:00 2001
+From: The Going <48602507+The-going@users.noreply.github.com>
+Date: Fri, 1 Apr 2022 22:57:09 +0300
+Subject: [PATCH] sunxi boot splash
+
+---
+ cmd/Kconfig                     |  1 +
+ include/config_distro_bootcmd.h |  9 +++++++++
+ include/configs/sunxi-common.h  | 16 ++++++++++++++++
+ 3 files changed, 26 insertions(+)
+
 diff --git a/cmd/Kconfig b/cmd/Kconfig
-index d6d130edfa..92795119ea 100644
+index 3a857b3f..492476e5 100644
 --- a/cmd/Kconfig
 +++ b/cmd/Kconfig
-@@ -1029,6 +1029,7 @@ menu "Misc commands"
+@@ -1662,6 +1662,7 @@ menu "Misc commands"
  config CMD_BMP
  	bool "Enable 'bmp' command"
  	depends on LCD || DM_VIDEO || VIDEO
 +	default y
  	help
- 	  This provides a way to obtain information about a BMP-format iamge
+ 	  This provides a way to obtain information about a BMP-format image
  	  and to display it. BMP (which presumably stands for BitMaP) is a
 diff --git a/include/config_distro_bootcmd.h b/include/config_distro_bootcmd.h
-index 9ed6b9892c..75d5176edf 100644
+index 750e9e04..9e70ddb3 100644
 --- a/include/config_distro_bootcmd.h
 +++ b/include/config_distro_bootcmd.h
-@@ -323,6 +323,15 @@
- 	BOOTENV_SHARED_UBIFS \
+@@ -430,6 +430,15 @@
  	BOOTENV_SHARED_EFI \
+ 	BOOTENV_SHARED_VIRTIO \
  	"boot_prefixes=/ /boot/\0" \
 +	"splashpos=m,m\0" \
 +	"splashimage=66000000\0" \
@@ -31,12 +42,12 @@ index 9ed6b9892c..75d5176edf 100644
  	"boot_script_dhcp=boot.scr.uimg\0" \
  	BOOTENV_BOOT_TARGETS \
 diff --git a/include/configs/sunxi-common.h b/include/configs/sunxi-common.h
-index 02d7be0849..cbdea20d08 100644
+index 958b850d..c4f34dbf 100644
 --- a/include/configs/sunxi-common.h
 +++ b/include/configs/sunxi-common.h
-@@ -284,6 +284,16 @@ extern int soft_i2c_gpio_scl;
- 
- #endif /* CONFIG_VIDEO */
+@@ -223,6 +223,16 @@ extern int soft_i2c_gpio_scl;
+ #define CONFIG_VIDEO_LCD_I2C_BUS	-1 /* NA, but necessary to compile */
+ #endif
  
 +#if defined CONFIG_VIDEO || defined CONFIG_DM_VIDEO
 +#define CONFIG_VIDEO_LOGO
@@ -49,17 +60,24 @@ index 02d7be0849..cbdea20d08 100644
 +#endif
 +
  /* Ethernet support */
- #ifdef CONFIG_SUNXI_EMAC
- #define CONFIG_PHY_ADDR		1
-@@ -442,6 +442,11 @@ extern int soft_i2c_gpio_scl;
- #define CONSOLE_STDIN_SETTINGS \
- 	"preboot=usb start\0" \
- 	"stdin=serial,usbkbd\0"
+ 
+ #ifdef CONFIG_USB_EHCI_HCD
+@@ -394,8 +404,14 @@ extern int soft_i2c_gpio_scl;
+ #include <config_distro_bootcmd.h>
+ 
+ #ifdef CONFIG_USB_KEYBOARD
 +#if defined CONFIG_VIDEO || defined CONFIG_DM_VIDEO
 +#define CONSOLE_STDIN_SETTINGS \
 +	"preboot=run loadsplash; usb start\0" \
 +	"stdin=serial,usbkbd\0"
++#else
+ #define CONSOLE_STDIN_SETTINGS \
+ 	"stdin=serial,usbkbd\0"
 +#endif
  #else
  #define CONSOLE_STDIN_SETTINGS \
  	"stdin=serial\0"
+-- 
+2.34.1
+
+


### PR DESCRIPTION
# Description

This patch applied correctly to the previous version of u-boot.
By version 2021.10, it is not applied correctly and when compiled in the configuration for bananapro, the compiler reports 340 warnings: redefined CONSOLE_STDIN_SETTINGS

- [x] Test build u-boot for bananapro
