### PR TITLE
Re-enable AUFS

### DIFF
--- a/lib/compilation-prepare.sh
+++ b/lib/compilation-prepare.sh
@@ -164,7 +164,7 @@ compilation_prepare()
 	#
 	# Older versions have AUFS support with a patch
 
-	if linux-version compare "${version}" ge 5.1 && linux-version compare "${version}" le 5.17 && [ "$AUFS" == yes ]; then
+	if linux-version compare "${version}" ge 5.1 && linux-version compare "${version}" le 5.18 && [ "$AUFS" == yes ]; then
 
 		# attach to specifics tag or branch
 		local aufstag


### PR DESCRIPTION
# Description

AUFS support is usually little behind. It was updated 10 days ago and its build-able.

Jira reference number [AR-467]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Build armhf
- [x] Build arm64

[AR-467]: https://armbian.atlassian.net/browse/AR-467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ