### PR TITLE
begin to support u-boot distroboot on espressobin

### DIFF
--- a/config/bootenv/mvebu64.txt
+++ b/config/bootenv/mvebu64.txt
@@ -1,6 +1,1 @@
 verbosity=1
-emmc_fix=off
-spi_workaround=off
-#eth1addr=fa:ad:4e:25:fb:84
-#eth2addr=fa:ad:4e:84:25:2f
-#eth3addr=00:50:43:0d:19:18

--- a/config/bootscripts/boot-espressobin.cmd
+++ b/config/bootscripts/boot-espressobin.cmd
@@ -3,22 +3,15 @@
 # Please edit /boot/armbianEnv.txt to set supported parameters
 #
 
-# default values
-setenv rootdev "/dev/mmcblk0p1"
-setenv verbosity "7"
-setenv rootfstype "ext4"
-setenv fdt_name_a dtb/marvell/armada-3720-community.dtb
-setenv fdt_name_b dtb/marvell/armada-3720-espressobin.dtb
-
-load ${boot_interface} ${devnum}:1 ${scriptaddr} ${prefix}armbianEnv.txt
+load ${devtype} ${devnum}:${distro_bootpart} ${scriptaddr} ${prefix}armbianEnv.txt
 env import -t ${scriptaddr} ${filesize}
 
 setenv bootargs "$console root=${rootdev} rootfstype=${rootfstype} rootwait loglevel=${verbosity} usb-storage.quirks=${usbstoragequirks}  ${extraargs}"
 
-ext4load $boot_interface 0:1 $kernel_addr ${prefix}$image_name
-ext4load $boot_interface 0:1 $initrd_addr ${prefix}$initrd_image
-ext4load $boot_interface 0:1 $fdt_addr ${prefix}$fdt_name_a
-ext4load $boot_interface 0:1 $fdt_addr ${prefix}$fdt_name_b
+load $devtype ${devnum}:${distro_bootpart} $kernel_addr_r ${prefix}Image
+load $devtype ${devnum}:${distro_bootpart} $ramdisk_addr_r ${prefix}uInitrd
+load $devtype ${devnum}:${distro_bootpart} $fdt_addr_r ${prefix}dtb/$fdtfile
 
-booti $kernel_addr $initrd_addr $fdt_addr
-# mkimage -C none -A arm -T script -d /boot/boot.cmd /boot/boot.scr
+booti $kernel_addr_r $ramdisk_addr_r $fdt_addr_r
+
+# mkimage -C none -A arm -T script -d /boot/boot.cmd /boot/boot.scr.uimg

--- a/config/sources/families/mvebu64.conf
+++ b/config/sources/families/mvebu64.conf
@@ -2,6 +2,7 @@ enable_extension "marvell-tools"
 ARCH=arm64
 BOOTBRANCH='branch:v2022.01'
 BOOTENV_FILE='mvebu64.txt'
+BOOTSCRIPT_OUTPUT='boot.scr.uimg'
 ATFSOURCE='https://git.trustedfirmware.org/TF-A/trusted-firmware-a.git'
 ATFDIR='arm-trusted-firmware-espressobin'
 ATFBRANCH='branch:master'

--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -736,8 +736,12 @@ PREPARE_IMAGE_SIZE
 	fi
 
 	# recompile .cmd to .scr if boot.cmd exists
-	[[ -f $SDCARD/boot/boot.cmd ]] && \
-		mkimage -C none -A arm -T script -d $SDCARD/boot/boot.cmd $SDCARD/boot/boot.scr > /dev/null 2>&1
+    
+	if [[ -f $SDCARD/boot/boot.cmd ]]; then
+		if [ -z $BOOTSCRIPT_OUTPUT ]; then BOOTSCRIPT_OUTPUT=boot.scr; fi
+		mkimage -C none -A arm -T script -d $SDCARD/boot/boot.cmd $SDCARD/boot/$BOOTSCRIPT_OUTPUT > /dev/null 2>&1
+	fi
+
 
 	# create extlinux config
 	if [[ -f $SDCARD/boot/extlinux/extlinux.conf ]]; then


### PR DESCRIPTION
# Description

Latest u-boot for espressobin has support for distroboot, which allows u-boot to scan for {extlinux config, boot.scr.uimg, efi files}.  If we compile the boot script to the new filename, we can avoid breaking old installs without new u-boot while supporting new ones that flash a new u-boot.  No support for old u-boot and new image, though.

# How Has This Been Tested?

I'm still working on testing, and that's why this is a draft.

There's a chance this will break the mcbin, which I think is in the same mvebu64 family.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
