### PR TITLE
Sunxi 5.15

### DIFF
--- a/patch/kernel/archive/sunxi-5.15/patches.armbian/Bananapro-add-AXP209-regulators.patch
+++ b/patch/kernel/archive/sunxi-5.15/patches.armbian/Bananapro-add-AXP209-regulators.patch
@@ -1,0 +1,72 @@
+From 0067fd674e3a8892ed6ae1b85b0ffd6247c486e6 Mon Sep 17 00:00:00 2001
+From: The-going <48602507+The-going@users.noreply.github.com>
+Date: Tue, 12 Apr 2022 21:14:36 +0300
+Subject: [PATCH 2/2] Bananapro add AXP209 regulators
+
+Author: Heiko Jehmlich <hje@jecons.de>
+Signed-off-by: Heiko Jehmlich <hje@jecons.de>
+---
+ arch/arm/boot/dts/sun7i-a20-bananapro.dts | 50 +++++++++++++++++++++++
+ 1 file changed, 50 insertions(+)
+
+diff --git a/arch/arm/boot/dts/sun7i-a20-bananapro.dts b/arch/arm/boot/dts/sun7i-a20-bananapro.dts
+index 3a34fb39a..d5bc59060 100644
+--- a/arch/arm/boot/dts/sun7i-a20-bananapro.dts
++++ b/arch/arm/boot/dts/sun7i-a20-bananapro.dts
+@@ -257,3 +257,53 @@ &usbphy {
+ &reg_ahci_5v {
+ 	status = "okay";
+ };
++
++#include "axp209.dtsi"
++
++&ac_power_supply {
++	status = "okay";
++};
++
++&battery_power_supply {
++	status = "okay";
++};
++
++&reg_dcdc2 {
++	regulator-always-on;
++	regulator-min-microvolt = <1000000>;
++	regulator-max-microvolt = <1450000>;
++	regulator-name = "vdd-cpu";
++};
++
++&reg_dcdc3 {
++	regulator-always-on;
++	regulator-min-microvolt = <1000000>;
++	regulator-max-microvolt = <1400000>;
++	regulator-name = "vdd-int-dll";
++};
++
++&reg_ldo1 {
++	regulator-name = "vdd-rtc";
++};
++
++&reg_ldo2 {
++	regulator-always-on;
++	regulator-min-microvolt = <3000000>;
++	regulator-max-microvolt = <3000000>;
++	regulator-name = "avcc";
++};
++
++&reg_ldo3 {
++	regulator-always-on;
++	regulator-min-microvolt = <2800000>;
++	regulator-max-microvolt = <2800000>;
++	regulator-name = "vddio-csi0";
++	regulator-ramp-delay = <1600>;
++};
++
++&reg_ldo4 {
++	regulator-always-on; /* required for SATA */
++	regulator-min-microvolt = <2800000>;
++	regulator-max-microvolt = <2800000>;
++	regulator-name = "vddio-csi1";
++};
+-- 
+2.34.1
+

--- a/patch/kernel/archive/sunxi-5.15/patches.armbian/arm-dts-sun7i-a20-bananapro-add-hdmi-de-reg_ahci_5v.patch
+++ b/patch/kernel/archive/sunxi-5.15/patches.armbian/arm-dts-sun7i-a20-bananapro-add-hdmi-de-reg_ahci_5v.patch
@@ -1,14 +1,14 @@
-From 927ca4b6c7648cd69605ca95bf87bea310e27e3b Mon Sep 17 00:00:00 2001
+From f23eaded52f1fb4561fa6bc1f00e09e925cdbbe6 Mon Sep 17 00:00:00 2001
 From: The-going <48602507+The-going@users.noreply.github.com>
-Date: Fri, 28 Jan 2022 15:15:19 +0300
-Subject: [PATCH 7/8] arm:dts: sun7i-a20-bananapro add hdmi-connector, de
+Date: Tue, 12 Apr 2022 20:59:42 +0300
+Subject: [PATCH 1/2] arm:dts: sun7i-a20-bananapro add hdmi, de, reg_ahci_5v
 
 ---
- arch/arm/boot/dts/sun7i-a20-bananapro.dts | 26 +++++++++++++++++++++++
- 1 file changed, 26 insertions(+)
+ arch/arm/boot/dts/sun7i-a20-bananapro.dts | 30 +++++++++++++++++++++++
+ 1 file changed, 30 insertions(+)
 
 diff --git a/arch/arm/boot/dts/sun7i-a20-bananapro.dts b/arch/arm/boot/dts/sun7i-a20-bananapro.dts
-index e68748076..10ee53fba 100644
+index e68748076..3a34fb39a 100644
 --- a/arch/arm/boot/dts/sun7i-a20-bananapro.dts
 +++ b/arch/arm/boot/dts/sun7i-a20-bananapro.dts
 @@ -60,6 +60,17 @@ chosen {
@@ -65,6 +65,14 @@ index e68748076..10ee53fba 100644
  &i2c0 {
  	status = "okay";
  
+@@ -227,3 +253,7 @@ &usbphy {
+ 	usb2_vbus-supply = <&reg_usb2_vbus>;
+ 	status = "okay";
+ };
++
++&reg_ahci_5v {
++	status = "okay";
++};
 -- 
-2.31.1
+2.34.1
 

--- a/patch/kernel/archive/sunxi-5.15/series.conf
+++ b/patch/kernel/archive/sunxi-5.15/series.conf
@@ -564,7 +564,8 @@
 	patches.armbian/arm-dts-sun8i-v3s-s3-pinecube-enable-sound-codec.patch
 	patches.armbian/arm-dts-sun8i-r40-add-clk_out_a-fix-bananam2ultra.patch
 	patches.armbian/arm-dts-sun8i-h3-bananapi-m2-plus-add-wifi_pwrseq.patch
-	patches.armbian/arm-dts-sun7i-a20-bananapro-add-hdmi-connector-de.patch
+	patches.armbian/arm-dts-sun7i-a20-bananapro-add-hdmi-de-reg_ahci_5v.patch
+	patches.armbian/Bananapro-add-AXP209-regulators.patch
 	patches.armbian/arm-dts-sunxi-h3-h5.dtsi-force-mmc0-bus-width.patch
 	patches.armbian/arm64-dts-sun50i-a64-pine64-enable-wifi-mmc1.patch
 	patches.armbian/arm64-dts-sun50i-h6-Add-AC200-EPHY-related-nodes.patch
@@ -655,4 +656,4 @@
 	patches.armbian/arm-dts-sun8i-h3-orangepi-pc-plus-add-wifi_pwrseq.patch
 	patches.armbian/arm64-dts-sun50i-h5-orangepi-prime-add-rtl8723cs.patch
 	patches.armbian/arm-dts-sun8i-h2-plus-orangepi-zero-fix-xradio-inter.patch
-	patches.armbian/drv-mtd-nand-disable-badblock-check-for-migration.patch
+-	patches.armbian/drv-mtd-nand-disable-badblock-check-for-migration.patch


### PR DESCRIPTION
# Description

Author: Heiko Jehmlich [hje@jecons.de](mailto:hje@jecons.de)

-  sunxi-5.15: adding the voltage regulator pin to activate AHCI controller in sun7i A20 on Bananapi Pro.
-  sunxi-5.15: Bananapro: add AXP209 regulators
- sunxi-5.15: Fix series.conf, Disable the patch that is not being applied

This pull request is a split and a combination of these two #3554 #3651  to properly merge with the master.

# Checklist:
- [x] Test build
- [ ] Test B

