### PR TITLE
Fix bug: Return correct exit code after compiling with docker or vagrant

### DIFF
--- a/config/templates/config-docker.conf
+++ b/config/templates/config-docker.conf
@@ -146,4 +146,4 @@ case $STATUS in
 esac
 
 # don't need to proceed further on the host
-exit 0
+exit $STATUS

--- a/config/templates/config-vagrant.conf
+++ b/config/templates/config-vagrant.conf
@@ -18,10 +18,11 @@ vagrant ssh-config
 display_alert "Trying to connect using SSH"
 
 IFS=' ' vagrant ssh -c "cd armbian; sudo ./compile.sh $VAGRANT_CONF $*"
+ret=$?
 
 display_alert "Press <Enter> to halt the Vagrant box"
 read
 vagrant halt
 
 # don't need to proceed further on the host
-exit 0
+exit $ret


### PR DESCRIPTION
# Description

`config-docker.conf` and `config-vagrant.conf` don't return the corrent exit code.

Note: `config-vagrant.conf` has so many problems that I can't build full image with it. So I use `JUST_INIT=yes` to test.

# How Has This Been Tested?

- [X] docker
  - [X] Build and check the exit code
  - [X] Change something to cause compilation failed.
  - [X] Build and check the exit code
- [X] vagrant
  - [X] Build with `JUST_INIT=yes` and check the exit code
  - [X] Change something to cause compilation failed.
  - [X] Build and check the exit code

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
