### PR TITLE
wrong toolchain was added and used for building wtmi_app.bin

### DIFF
--- a/config/sources/families/mvebu64.conf
+++ b/config/sources/families/mvebu64.conf
@@ -85,7 +85,7 @@ atf_custom_postprocess()
 	if [[ "${SKIP_EXTERNAL_TOOLCHAINS}" == "yes" ]]; then
         export TOOLCHAIN_NAME="arm-linux-gnueabi-"
     else
-        export TOOLCHAIN_NAME="arm-none-eabi-"
+        export TOOLCHAIN_NAME="arm-none-linux-gnueabihf-"
     fi
 	export ATF2=$(find_toolchain "$TOOLCHAIN_NAME" "> 10.0")/$TOOLCHAIN_NAME
 	export BL33=$ubootdir"/u-boot.bin"

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1523,7 +1523,7 @@ prepare_host()
 				"${ARMBIAN_MIRROR}/_toolchains/gcc-arm-8.3-2019.03-x86_64-aarch64-linux-gnu.tar.xz"
 				"${ARMBIAN_MIRROR}/_toolchain/gcc-arm-9.2-2019.12-x86_64-arm-none-linux-gnueabihf.tar.xz"
 				"${ARMBIAN_MIRROR}/_toolchain/gcc-arm-9.2-2019.12-x86_64-aarch64-none-linux-gnu.tar.xz"
-				"${ARMBIAN_MIRROR}/_toolchain/gcc-arm-11.2-2022.02-x86_64-arm-none-eabi.tar.xz"
+				"${ARMBIAN_MIRROR}/_toolchain/gcc-arm-11.2-2022.02-x86_64-arm-none-linux-gnueabihf.tar.xz"
 				"${ARMBIAN_MIRROR}/_toolchain/gcc-arm-11.2-2022.02-x86_64-aarch64-none-linux-gnu.tar.xz"
 				)
 


### PR DESCRIPTION
# Description
When updating the toolchain, I mentioned I didn't understand the difference between the gnueabihf and the eabi.  Well, now I understand that one of them works and the other doesn't.  So... this calls in the one that works.

