### PR TITLE
remove mesa-utils-extra for jammy due to upstream dependency change

### DIFF
--- a/config/desktop/jammy/appgroups/3dsupport/packages
+++ b/config/desktop/jammy/appgroups/3dsupport/packages
@@ -1,1 +1,2 @@
-../../../focal/appgroups/3dsupport/packages
+glmark2
+mesa-utils


### PR DESCRIPTION
# Description

Ubuntu jammy updated mesa-demos, make mesa-utils conflicting with mesa-utils-extra: https://salsa.debian.org/xorg-team/app/mesa-demos/-/commit/e6fa38c1d33da80fb72e8ef7679c853d1ec29381
We have to remove mesa-utils-extra for ubuntu jammy

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Build jammy gnome success: https://github.com/amazingfate/armbian-rock3a-images/runs/6034669822?check_suite_focus=true

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
