### PR TITLE
armbian-truncate-logs: Use journalctl --quiet

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-truncate-logs
+++ b/packages/bsp/common/usr/lib/armbian/armbian-truncate-logs
@@ -29,5 +29,5 @@ if [ $logusage -ge $treshold ]; then
     # remove
     /usr/bin/find /var/log -name '*.[0-9]' -or -name '*.gz' | xargs -r rm -f
     # vacuum systemd-journald
-    [ -d /var/log/journal ] && journalctl --vacuum-size=${JOURNAL_SIZE}
+    [ -d /var/log/journal ] && journalctl --quiet --vacuum-size=${JOURNAL_SIZE}
 fi


### PR DESCRIPTION
# Description

By default, cron sends an email to the system admin if it finds anything in the stderr of the process. 
journalctl sends "diag output" to stderr (see https://github.com/systemd/systemd/issues/380).
The easiest way to prevent sporadic emails is to call journalctl with --quiet.

# How Has This Been Tested?

Manually on my setup.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
