### PR TITLE
Set default values for hashes when empty

### DIFF
--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -569,13 +569,15 @@ CUSTOM_KERNEL_CONFIG
 	# hash origin
 	echo "${hash}" > "${HASHTARGET}.githash"
 
-	# hash_patches=
-	git -C $SRC log --format="%H" -1 -- \
-		$(realpath --relative-base="$SRC" "${SRC}/patch/kernel/${KERNELPATCHDIR}") >> "${HASHTARGET}.githash"
+	# hash_patches
+	CALC_PATCHES=$(git -C $SRC log --format="%H" -1 -- $(realpath --relative-base="$SRC" "${SRC}/patch/kernel/${KERNELPATCHDIR}"))
+	[[ -z "$CALC_PATCHES" ]] && CALC_PATCHES="null"
+	echo "$CALC_PATCHES" >> "${HASHTARGET}.githash"
 
-	# hash_kernel_config=
-	git -C $SRC log --format="%H" -1 -- \
-		$(realpath --relative-base="$SRC" "${SRC}/config/kernel/${LINUXCONFIG}.config")	>> "${HASHTARGET}.githash"
+	# hash_kernel_config
+	CALC_CONFIG=$(git -C $SRC log --format="%H" -1 -- $(realpath --relative-base="$SRC" "${SRC}/config/kernel/${LINUXCONFIG}.config"))
+	[[ -z "$CALC_CONFIG" ]] && CALC_CONFIG="null"
+	echo "$HASHES" >> "${HASHTARGET}.githash"
 
 }
 


### PR DESCRIPTION
# Description

This fixes the problem of constantly recompiling sources where patch folder is not defined. Fix already applied [on component](https://github.com/armbian/scripts/commit/ab1723594f060ac09a8d98c12299129cdd2c5dff).

Jira reference number [AR-1160]

# How Has This Been Tested?

- [x] Build Virtual qemu kernel

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1160]: https://armbian.atlassian.net/browse/AR-1160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ