### PR TITLE
Bugfix - wrong variable name

### DIFF
--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -577,7 +577,7 @@ CUSTOM_KERNEL_CONFIG
 	# hash_kernel_config
 	CALC_CONFIG=$(git -C $SRC log --format="%H" -1 -- $(realpath --relative-base="$SRC" "${SRC}/config/kernel/${LINUXCONFIG}.config"))
 	[[ -z "$CALC_CONFIG" ]] && CALC_CONFIG="null"
-	echo "$HASHES" >> "${HASHTARGET}.githash"
+	echo "$CALC_CONFIG" >> "${HASHTARGET}.githash"
 
 }
 


### PR DESCRIPTION
# Description

When fixing https://github.com/armbian/build/pull/3692 I forgot to change one variable name.

Jira reference number [AR-1160]

[AR-1160]: https://armbian.atlassian.net/browse/AR-1160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ