### PR TITLE
Update the rtl8189fs patch

### DIFF
--- a/patch/kernel/archive/sunxi-5.10/disable-debug-rtl8189fs.patch
+++ b/patch/kernel/archive/sunxi-5.10/disable-debug-rtl8189fs.patch
@@ -1,13 +1,13 @@
-diff --git a/drivers/net/wireless/rtl8189fs/include/autoconf.h b/drivers/net/wireless/rtl8189fs/include/autoconf.h
-index 44efe42..6f40903 100644
---- a/drivers/net/wireless/rtl8189fs/include/autoconf.h
-+++ b/drivers/net/wireless/rtl8189fs/include/autoconf.h
-@@ -224,7 +224,7 @@
- /*
-  * Debug Related Config
-  */
--#define CONFIG_DEBUG /* DBG_871X, etc... */
-+//#define CONFIG_DEBUG /* DBG_871X, etc... */
- 
- #ifdef CONFIG_DEBUG
- #define DBG	1	// for ODM & BTCOEX debug
+diff --git a/drivers/net/wireless/rtl8189fs/Makefile b/drivers/net/wireless/rtl8189fs/Makefile
+index dfca305..d56dcfd 100644
+--- a/drivers/net/wireless/rtl8189fs/Makefile
++++ b/drivers/net/wireless/rtl8189fs/Makefile
+@@ -88,7 +88,7 @@ CONFIG_RTW_WIFI_HAL = n
+ CONFIG_ICMP_VOQ = n
+ CONFIG_IP_R_MONITOR = n #arp VOQ and high rate
+ ########################## Debug ###########################
+-CONFIG_RTW_DEBUG = y
++CONFIG_RTW_DEBUG = n
+ # default log level is _DRV_INFO_ = 4,
+ # please refer to "How_to_set_driver_debug_log_level.doc" to set the available level.
+ CONFIG_RTW_LOG_LEVEL = 4

--- a/patch/kernel/archive/sunxi-5.11/disable-debug-rtl8189fs.patch
+++ b/patch/kernel/archive/sunxi-5.11/disable-debug-rtl8189fs.patch
@@ -1,13 +1,13 @@
-diff --git a/drivers/net/wireless/rtl8189fs/include/autoconf.h b/drivers/net/wireless/rtl8189fs/include/autoconf.h
-index 44efe42..6f40903 100644
---- a/drivers/net/wireless/rtl8189fs/include/autoconf.h
-+++ b/drivers/net/wireless/rtl8189fs/include/autoconf.h
-@@ -224,7 +224,7 @@
- /*
-  * Debug Related Config
-  */
--#define CONFIG_DEBUG /* DBG_871X, etc... */
-+//#define CONFIG_DEBUG /* DBG_871X, etc... */
- 
- #ifdef CONFIG_DEBUG
- #define DBG	1	// for ODM & BTCOEX debug
+diff --git a/drivers/net/wireless/rtl8189fs/Makefile b/drivers/net/wireless/rtl8189fs/Makefile
+index dfca305..d56dcfd 100644
+--- a/drivers/net/wireless/rtl8189fs/Makefile
++++ b/drivers/net/wireless/rtl8189fs/Makefile
+@@ -88,7 +88,7 @@ CONFIG_RTW_WIFI_HAL = n
+ CONFIG_ICMP_VOQ = n
+ CONFIG_IP_R_MONITOR = n #arp VOQ and high rate
+ ########################## Debug ###########################
+-CONFIG_RTW_DEBUG = y
++CONFIG_RTW_DEBUG = n
+ # default log level is _DRV_INFO_ = 4,
+ # please refer to "How_to_set_driver_debug_log_level.doc" to set the available level.
+ CONFIG_RTW_LOG_LEVEL = 4

--- a/patch/kernel/archive/sunxi-5.12/disable-debug-rtl8189fs.patch
+++ b/patch/kernel/archive/sunxi-5.12/disable-debug-rtl8189fs.patch
@@ -1,13 +1,13 @@
-diff --git a/drivers/net/wireless/rtl8189fs/include/autoconf.h b/drivers/net/wireless/rtl8189fs/include/autoconf.h
-index 44efe42..6f40903 100644
---- a/drivers/net/wireless/rtl8189fs/include/autoconf.h
-+++ b/drivers/net/wireless/rtl8189fs/include/autoconf.h
-@@ -224,7 +224,7 @@
- /*
-  * Debug Related Config
-  */
--#define CONFIG_DEBUG /* DBG_871X, etc... */
-+//#define CONFIG_DEBUG /* DBG_871X, etc... */
- 
- #ifdef CONFIG_DEBUG
- #define DBG	1	// for ODM & BTCOEX debug
+diff --git a/drivers/net/wireless/rtl8189fs/Makefile b/drivers/net/wireless/rtl8189fs/Makefile
+index dfca305..d56dcfd 100644
+--- a/drivers/net/wireless/rtl8189fs/Makefile
++++ b/drivers/net/wireless/rtl8189fs/Makefile
+@@ -88,7 +88,7 @@ CONFIG_RTW_WIFI_HAL = n
+ CONFIG_ICMP_VOQ = n
+ CONFIG_IP_R_MONITOR = n #arp VOQ and high rate
+ ########################## Debug ###########################
+-CONFIG_RTW_DEBUG = y
++CONFIG_RTW_DEBUG = n
+ # default log level is _DRV_INFO_ = 4,
+ # please refer to "How_to_set_driver_debug_log_level.doc" to set the available level.
+ CONFIG_RTW_LOG_LEVEL = 4

--- a/patch/kernel/archive/sunxi-5.13/disable-debug-rtl8189fs.patch
+++ b/patch/kernel/archive/sunxi-5.13/disable-debug-rtl8189fs.patch
@@ -1,13 +1,13 @@
-diff --git a/drivers/net/wireless/rtl8189fs/include/autoconf.h b/drivers/net/wireless/rtl8189fs/include/autoconf.h
-index 44efe42..6f40903 100644
---- a/drivers/net/wireless/rtl8189fs/include/autoconf.h
-+++ b/drivers/net/wireless/rtl8189fs/include/autoconf.h
-@@ -224,7 +224,7 @@
- /*
-  * Debug Related Config
-  */
--#define CONFIG_DEBUG /* DBG_871X, etc... */
-+//#define CONFIG_DEBUG /* DBG_871X, etc... */
- 
- #ifdef CONFIG_DEBUG
- #define DBG	1	// for ODM & BTCOEX debug
+diff --git a/drivers/net/wireless/rtl8189fs/Makefile b/drivers/net/wireless/rtl8189fs/Makefile
+index dfca305..d56dcfd 100644
+--- a/drivers/net/wireless/rtl8189fs/Makefile
++++ b/drivers/net/wireless/rtl8189fs/Makefile
+@@ -88,7 +88,7 @@ CONFIG_RTW_WIFI_HAL = n
+ CONFIG_ICMP_VOQ = n
+ CONFIG_IP_R_MONITOR = n #arp VOQ and high rate
+ ########################## Debug ###########################
+-CONFIG_RTW_DEBUG = y
++CONFIG_RTW_DEBUG = n
+ # default log level is _DRV_INFO_ = 4,
+ # please refer to "How_to_set_driver_debug_log_level.doc" to set the available level.
+ CONFIG_RTW_LOG_LEVEL = 4

--- a/patch/kernel/archive/sunxi-5.14/disable-debug-rtl8189fs.patch
+++ b/patch/kernel/archive/sunxi-5.14/disable-debug-rtl8189fs.patch
@@ -1,13 +1,13 @@
-diff --git a/drivers/net/wireless/rtl8189fs/include/autoconf.h b/drivers/net/wireless/rtl8189fs/include/autoconf.h
-index 44efe42..6f40903 100644
---- a/drivers/net/wireless/rtl8189fs/include/autoconf.h
-+++ b/drivers/net/wireless/rtl8189fs/include/autoconf.h
-@@ -224,7 +224,7 @@
- /*
-  * Debug Related Config
-  */
--#define CONFIG_DEBUG /* DBG_871X, etc... */
-+//#define CONFIG_DEBUG /* DBG_871X, etc... */
- 
- #ifdef CONFIG_DEBUG
- #define DBG	1	// for ODM & BTCOEX debug
+diff --git a/drivers/net/wireless/rtl8189fs/Makefile b/drivers/net/wireless/rtl8189fs/Makefile
+index dfca305..d56dcfd 100644
+--- a/drivers/net/wireless/rtl8189fs/Makefile
++++ b/drivers/net/wireless/rtl8189fs/Makefile
+@@ -88,7 +88,7 @@ CONFIG_RTW_WIFI_HAL = n
+ CONFIG_ICMP_VOQ = n
+ CONFIG_IP_R_MONITOR = n #arp VOQ and high rate
+ ########################## Debug ###########################
+-CONFIG_RTW_DEBUG = y
++CONFIG_RTW_DEBUG = n
+ # default log level is _DRV_INFO_ = 4,
+ # please refer to "How_to_set_driver_debug_log_level.doc" to set the available level.
+ CONFIG_RTW_LOG_LEVEL = 4

--- a/patch/kernel/archive/sunxi-5.15/disable-debug-rtl8189fs.patch
+++ b/patch/kernel/archive/sunxi-5.15/disable-debug-rtl8189fs.patch
@@ -1,13 +1,13 @@
-diff --git a/drivers/net/wireless/rtl8189fs/include/autoconf.h b/drivers/net/wireless/rtl8189fs/include/autoconf.h
-index 44efe42..6f40903 100644
---- a/drivers/net/wireless/rtl8189fs/include/autoconf.h
-+++ b/drivers/net/wireless/rtl8189fs/include/autoconf.h
-@@ -224,7 +224,7 @@
- /*
-  * Debug Related Config
-  */
--#define CONFIG_DEBUG /* DBG_871X, etc... */
-+//#define CONFIG_DEBUG /* DBG_871X, etc... */
- 
- #ifdef CONFIG_DEBUG
- #define DBG	1	// for ODM & BTCOEX debug
+diff --git a/drivers/net/wireless/rtl8189fs/Makefile b/drivers/net/wireless/rtl8189fs/Makefile
+index dfca305..d56dcfd 100644
+--- a/drivers/net/wireless/rtl8189fs/Makefile
++++ b/drivers/net/wireless/rtl8189fs/Makefile
+@@ -88,7 +88,7 @@ CONFIG_RTW_WIFI_HAL = n
+ CONFIG_ICMP_VOQ = n
+ CONFIG_IP_R_MONITOR = n #arp VOQ and high rate
+ ########################## Debug ###########################
+-CONFIG_RTW_DEBUG = y
++CONFIG_RTW_DEBUG = n
+ # default log level is _DRV_INFO_ = 4,
+ # please refer to "How_to_set_driver_debug_log_level.doc" to set the available level.
+ CONFIG_RTW_LOG_LEVEL = 4

--- a/patch/kernel/archive/sunxi-5.16/disable-debug-rtl8189fs.patch
+++ b/patch/kernel/archive/sunxi-5.16/disable-debug-rtl8189fs.patch
@@ -1,13 +1,13 @@
-diff --git a/drivers/net/wireless/rtl8189fs/include/autoconf.h b/drivers/net/wireless/rtl8189fs/include/autoconf.h
-index 44efe42..6f40903 100644
---- a/drivers/net/wireless/rtl8189fs/include/autoconf.h
-+++ b/drivers/net/wireless/rtl8189fs/include/autoconf.h
-@@ -224,7 +224,7 @@
- /*
-  * Debug Related Config
-  */
--#define CONFIG_DEBUG /* DBG_871X, etc... */
-+//#define CONFIG_DEBUG /* DBG_871X, etc... */
- 
- #ifdef CONFIG_DEBUG
- #define DBG	1	// for ODM & BTCOEX debug
+diff --git a/drivers/net/wireless/rtl8189fs/Makefile b/drivers/net/wireless/rtl8189fs/Makefile
+index dfca305..d56dcfd 100644
+--- a/drivers/net/wireless/rtl8189fs/Makefile
++++ b/drivers/net/wireless/rtl8189fs/Makefile
+@@ -88,7 +88,7 @@ CONFIG_RTW_WIFI_HAL = n
+ CONFIG_ICMP_VOQ = n
+ CONFIG_IP_R_MONITOR = n #arp VOQ and high rate
+ ########################## Debug ###########################
+-CONFIG_RTW_DEBUG = y
++CONFIG_RTW_DEBUG = n
+ # default log level is _DRV_INFO_ = 4,
+ # please refer to "How_to_set_driver_debug_log_level.doc" to set the available level.
+ CONFIG_RTW_LOG_LEVEL = 4

--- a/patch/kernel/archive/sunxi-5.17/disable-debug-rtl8189fs.patch
+++ b/patch/kernel/archive/sunxi-5.17/disable-debug-rtl8189fs.patch
@@ -1,13 +1,13 @@
-diff --git a/drivers/net/wireless/rtl8189fs/include/autoconf.h b/drivers/net/wireless/rtl8189fs/include/autoconf.h
-index 44efe42..6f40903 100644
---- a/drivers/net/wireless/rtl8189fs/include/autoconf.h
-+++ b/drivers/net/wireless/rtl8189fs/include/autoconf.h
-@@ -224,7 +224,7 @@
- /*
-  * Debug Related Config
-  */
--#define CONFIG_DEBUG /* DBG_871X, etc... */
-+//#define CONFIG_DEBUG /* DBG_871X, etc... */
- 
- #ifdef CONFIG_DEBUG
- #define DBG	1	// for ODM & BTCOEX debug
+diff --git a/drivers/net/wireless/rtl8189fs/Makefile b/drivers/net/wireless/rtl8189fs/Makefile
+index dfca305..d56dcfd 100644
+--- a/drivers/net/wireless/rtl8189fs/Makefile
++++ b/drivers/net/wireless/rtl8189fs/Makefile
+@@ -88,7 +88,7 @@ CONFIG_RTW_WIFI_HAL = n
+ CONFIG_ICMP_VOQ = n
+ CONFIG_IP_R_MONITOR = n #arp VOQ and high rate
+ ########################## Debug ###########################
+-CONFIG_RTW_DEBUG = y
++CONFIG_RTW_DEBUG = n
+ # default log level is _DRV_INFO_ = 4,
+ # please refer to "How_to_set_driver_debug_log_level.doc" to set the available level.
+ CONFIG_RTW_LOG_LEVEL = 4


### PR DESCRIPTION
# Description

This PR should update rtl8189fs patches.

I created a PR in the [rtl8189ES_linux](https://github.com/jwrdegoede/rtl8189ES_linux) repo that updates the driver to the latest version for 8189fs, 
This PR updates the patches to compile in the latest 8189fs driver version

Depends on [This downstream PR](https://github.com/jwrdegoede/rtl8189ES_linux/pull/71)

# How Has This Been Tested?

N/A

# Checklist:

- [x] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
