### PR TITLE
add patch to fix rk3568 vop in kernel 5.17.3

### DIFF
--- a/patch/kernel/archive/rk35xx-5.17/rk3568-fix-vop-clk.patch
+++ b/patch/kernel/archive/rk35xx-5.17/rk3568-fix-vop-clk.patch
@@ -1,0 +1,31 @@
+diff --git a/drivers/clk/rockchip/clk-rk3568.c b/drivers/clk/rockchip/clk-rk3568.c
+index 604a367bc498..63dfbeeeb06d 100644
+--- a/drivers/clk/rockchip/clk-rk3568.c
++++ b/drivers/clk/rockchip/clk-rk3568.c
+@@ -71,11 +71,17 @@ static struct rockchip_pll_rate_table rk3568_pll_rates[] = {
+ 	RK3036_PLL_RATE(500000000, 1, 125, 6, 1, 1, 0),
+ 	RK3036_PLL_RATE(408000000, 1, 68, 2, 2, 1, 0),
+ 	RK3036_PLL_RATE(312000000, 1, 78, 6, 1, 1, 0),
++	RK3036_PLL_RATE(297000000, 2, 99, 4, 1, 1, 0),
++	RK3036_PLL_RATE(241500000, 2, 161, 4, 2, 1, 0),
+ 	RK3036_PLL_RATE(216000000, 1, 72, 4, 2, 1, 0),
+ 	RK3036_PLL_RATE(200000000, 1, 100, 3, 4, 1, 0),
+ 	RK3036_PLL_RATE(148500000, 1, 99, 4, 4, 1, 0),
++	RK3036_PLL_RATE(135000000, 2, 45, 4, 1, 1, 0),
++	RK3036_PLL_RATE(119000000, 3, 119, 4, 2, 1, 0),
++	RK3036_PLL_RATE(108000000, 2, 45, 5, 1, 1, 0),
+ 	RK3036_PLL_RATE(100000000, 1, 150, 6, 6, 1, 0),
+ 	RK3036_PLL_RATE(96000000, 1, 96, 6, 4, 1, 0),
++	RK3036_PLL_RATE(78750000, 1, 96, 6, 4, 1, 0),
+ 	RK3036_PLL_RATE(74250000, 2, 99, 4, 4, 1, 0),
+ 	{ /* sentinel */ },
+ };
+@@ -1562,7 +1568,7 @@ static struct rockchip_clk_branch rk3568_clk_pmu_branches[] __initdata = {
+ 			RK3568_PMU_CLKGATE_CON(2), 14, GFLAGS),
+ 	GATE(XIN_OSC0_EDPPHY_G, "xin_osc0_edpphy_g", "xin24m", 0,
+ 			RK3568_PMU_CLKGATE_CON(2), 15, GFLAGS),
+-	MUX(CLK_HDMI_REF, "clk_hdmi_ref", clk_hdmi_ref_p, 0,
++	MUX(CLK_HDMI_REF, "clk_hdmi_ref", clk_hdmi_ref_p, CLK_SET_RATE_PARENT,
+ 			RK3568_PMU_CLKSEL_CON(8), 7, 1, MFLAGS),
+ };
+ 


### PR DESCRIPTION
# Description

3 commits by Sascha Hauer are merged into mainline, but only one of them was merged into 5.17.3
commit history of mainline 5.18-rc3: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/log/drivers/clk/rockchip/clk-rk3568.c?h=v5.18-rc3
commit history of 5.17.3: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/drivers/clk/rockchip/clk-rk3568.c?h=v5.17.3
This caused hdmi vop2 not working with kernel 5.17.3, so I make the other 2 commits as a patch to fix that.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Kernel build successfully
- [x] HDMI works again

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
