### PR TITLE
rockchip: rock-3a: remove unused nodes

### DIFF
--- a/patch/kernel/archive/rk35xx-5.16/rk3568-dts-radxa-rock3a-support.patch
+++ b/patch/kernel/archive/rk35xx-5.16/rk3568-dts-radxa-rock3a-support.patch
@@ -12,7 +12,7 @@ new file mode 100644
 index 000000000000..9e9124dc6c59
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3568-rock-3-a.dts
-@@ -0,0 +1,809 @@
+@@ -0,0 +1,782 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2021 Rockchip Electronics Co., Ltd.
@@ -47,7 +47,7 @@ index 000000000000..9e9124dc6c59
 +		#clock-cells = <0>;
 +	};
 +
-+    hdmi-con {
++	hdmi-con {
 +		compatible = "hdmi-connector";
 +		type = "c";
 +
@@ -69,13 +69,6 @@ index 000000000000..9e9124dc6c59
 +			pinctrl-names = "default";
 +			pinctrl-0 = <&user_led_enable_h>;
 +			retain-state-suspended;
-+		};
-+
-+		wifi-led {
-+			gpios = <&gpio2 RK_PB0 GPIO_ACTIVE_HIGH>;
-+			linux,default-trigger = "rfkill2";
-+			default-state = "on";
-+			pinctrl-0 = <&wifi_led>;
 +		};
 +	};
 +
@@ -223,8 +216,6 @@ index 000000000000..9e9124dc6c59
 +			regulator-off-in-suspend;
 +		};
 +	};
-+
-+
 +};
 +
 +&combphy0 {
@@ -273,16 +264,16 @@ index 000000000000..9e9124dc6c59
 +};
 +
 +&hdmi_in {
-+        hdmi_in_vp0: endpoint@0 {
-+                reg = <0>;
-+                remote-endpoint = <&vp0_out_hdmi>;
-+        };
++	hdmi_in_vp0: endpoint@0 {
++		reg = <0>;
++		remote-endpoint = <&vp0_out_hdmi>;
++	};
 +};
 +
 +&hdmi_out {
-+        hdmi_out_con: endpoint {
-+                remote-endpoint = <&hdmi_con_in>;
-+        };
++	hdmi_out_con: endpoint {
++		remote-endpoint = <&hdmi_con_in>;
++	};
 +};
 +
 +&i2c0 {
@@ -305,7 +296,6 @@ index 000000000000..9e9124dc6c59
 +			regulator-off-in-suspend;
 +		};
 +	};
-+
 +
 +	rk809: pmic@20 {
 +		compatible = "rockchip,rk809";
@@ -586,7 +576,6 @@ index 000000000000..9e9124dc6c59
 +	};
 +};
 +
-+
 +&mdio1 {
 +	rgmii_phy1: phy@0 {
 +		compatible = "ethernet-phy-ieee802.3-c22";
@@ -598,10 +587,6 @@ index 000000000000..9e9124dc6c59
 +	leds {
 +		user_led_enable_h: user-led-enable-h {
 +			rockchip,pins = <0 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+
-+		wifi_led: wifi-led {
-+			rockchip,pins = <2 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
 +		};
 +	};
 +
@@ -642,18 +627,6 @@ index 000000000000..9e9124dc6c59
 +		soc_slppin_rst: soc_slppin_rst {
 +			rockchip,pins =
 +				<0 RK_PA2 2 &pcfg_pull_none>;
-+		};
-+	};
-+
-+	wireless-wlan {
-+		wifi_host_wake_irq: wifi-host-wake-irq {
-+			rockchip,pins = <3 RK_PD5 RK_FUNC_GPIO &pcfg_pull_down>;
-+		};
-+	};
-+
-+	wireless-bluetooth {
-+		uart1_gpios: uart1-gpios {
-+			rockchip,pins = <2 RK_PB5 RK_FUNC_GPIO &pcfg_pull_none>;
 +		};
 +	};
 +
@@ -708,7 +681,7 @@ index 000000000000..9e9124dc6c59
 +};
 +
 +&tsadc {
-+        status = "okay";
++	status = "okay";
 +};
 +
 +&uart2 {

--- a/patch/kernel/archive/rk35xx-5.17/rk3568-dts-radxa-rock3a-support.patch
+++ b/patch/kernel/archive/rk35xx-5.17/rk3568-dts-radxa-rock3a-support.patch
@@ -12,7 +12,7 @@ new file mode 100644
 index 000000000000..1b898aff9df8
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3568-rock-3-a.dts
-@@ -0,0 +1,808 @@
+@@ -0,0 +1,781 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2021 Rockchip Electronics Co., Ltd.
@@ -47,7 +47,7 @@ index 000000000000..1b898aff9df8
 +		#clock-cells = <0>;
 +	};
 +
-+    hdmi-con {
++	hdmi-con {
 +		compatible = "hdmi-connector";
 +		type = "c";
 +
@@ -69,13 +69,6 @@ index 000000000000..1b898aff9df8
 +			pinctrl-names = "default";
 +			pinctrl-0 = <&user_led_enable_h>;
 +			retain-state-suspended;
-+		};
-+
-+		wifi-led {
-+			gpios = <&gpio2 RK_PB0 GPIO_ACTIVE_HIGH>;
-+			linux,default-trigger = "rfkill2";
-+			default-state = "on";
-+			pinctrl-0 = <&wifi_led>;
 +		};
 +	};
 +
@@ -222,8 +215,6 @@ index 000000000000..1b898aff9df8
 +			regulator-off-in-suspend;
 +		};
 +	};
-+
-+
 +};
 +
 +&combphy0 {
@@ -272,16 +263,16 @@ index 000000000000..1b898aff9df8
 +};
 +
 +&hdmi_in {
-+        hdmi_in_vp0: endpoint@0 {
-+                reg = <0>;
-+                remote-endpoint = <&vp0_out_hdmi>;
-+        };
++	hdmi_in_vp0: endpoint@0 {
++		reg = <0>;
++		remote-endpoint = <&vp0_out_hdmi>;
++	};
 +};
 +
 +&hdmi_out {
-+        hdmi_out_con: endpoint {
-+                remote-endpoint = <&hdmi_con_in>;
-+        };
++	hdmi_out_con: endpoint {
++		remote-endpoint = <&hdmi_con_in>;
++	};
 +};
 +
 +&i2c0 {
@@ -304,7 +295,6 @@ index 000000000000..1b898aff9df8
 +			regulator-off-in-suspend;
 +		};
 +	};
-+
 +
 +	rk809: pmic@20 {
 +		compatible = "rockchip,rk809";
@@ -580,7 +570,6 @@ index 000000000000..1b898aff9df8
 +	};
 +};
 +
-+
 +&mdio1 {
 +	rgmii_phy1: phy@0 {
 +		compatible = "ethernet-phy-ieee802.3-c22";
@@ -592,10 +581,6 @@ index 000000000000..1b898aff9df8
 +	leds {
 +		user_led_enable_h: user-led-enable-h {
 +			rockchip,pins = <0 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+
-+		wifi_led: wifi-led {
-+			rockchip,pins = <2 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
 +		};
 +	};
 +
@@ -636,18 +621,6 @@ index 000000000000..1b898aff9df8
 +		soc_slppin_rst: soc_slppin_rst {
 +			rockchip,pins =
 +				<0 RK_PA2 2 &pcfg_pull_none>;
-+		};
-+	};
-+
-+	wireless-wlan {
-+		wifi_host_wake_irq: wifi-host-wake-irq {
-+			rockchip,pins = <3 RK_PD5 RK_FUNC_GPIO &pcfg_pull_down>;
-+		};
-+	};
-+
-+	wireless-bluetooth {
-+		uart1_gpios: uart1-gpios {
-+			rockchip,pins = <2 RK_PB5 RK_FUNC_GPIO &pcfg_pull_none>;
 +		};
 +	};
 +
@@ -707,7 +680,7 @@ index 000000000000..1b898aff9df8
 +};
 +
 +&tsadc {
-+        status = "okay";
++	status = "okay";
 +};
 +
 +&uart2 {


### PR DESCRIPTION
# Description

Remove the useless wifi-led node for rock 3a as there is none on the board.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
