### PR TITLE
removed gvfs-fuse from debian build cinnamon

### DIFF
--- a/config/desktop/bullseye/environments/cinnamon/config_base/packages
+++ b/config/desktop/bullseye/environments/cinnamon/config_base/packages
@@ -61,7 +61,6 @@ gtk2-engines
 gtk2-engines-murrine
 gtk2-engines-pixbuf
 gvfs-backends
-gvfs-fuse
 hplip
 hunspell-en-us
 inputattach


### PR DESCRIPTION
removed gvfs-fuse from debian bullseye desktop not used in any of the other desktops .causes nand-install errors