### PR TITLE
Add latest patches for JetHub D1 with saradc support from u-boot master 

### DIFF
--- a/patch/u-boot/u-boot-meson64/board_jethubj100/0001-clk-meson-add-minimal-driver-for-axg-ao-clocks.patch
+++ b/patch/u-boot/u-boot-meson64/board_jethubj100/0001-clk-meson-add-minimal-driver-for-axg-ao-clocks.patch
@@ -1,0 +1,123 @@
+From 772a67bd3eaa2f626a19c31b1332b3e4ee377291 Mon Sep 17 00:00:00 2001
+From: Vyacheslav Bocharov <adeep@lexina.in>
+Date: Wed, 20 Apr 2022 20:25:10 +0300
+Subject: [PATCH 1/6] clk: meson: add minimal driver for axg-ao clocks
+
+Add minimal driver AO clocks on meson AXG family. Only ADC related clocks
+are supported.
+
+Signed-off-by: Vyacheslav Bocharov <adeep@lexina.in>
+Reviewed-by: Sean Anderson <seanga2@gmail.com>
+Reviewed-by: Neil Armstrong <narmstrong@baylibre.com>
+---
+ drivers/clk/meson/Makefile |  1 +
+ drivers/clk/meson/axg-ao.c | 86 ++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 87 insertions(+)
+ create mode 100644 drivers/clk/meson/axg-ao.c
+
+diff --git a/drivers/clk/meson/Makefile b/drivers/clk/meson/Makefile
+index b9c6bd66cf..a486b13e9c 100644
+--- a/drivers/clk/meson/Makefile
++++ b/drivers/clk/meson/Makefile
+@@ -5,5 +5,6 @@
+ 
+ obj-$(CONFIG_CLK_MESON_GX) += gxbb.o
+ obj-$(CONFIG_CLK_MESON_AXG) += axg.o
++obj-$(CONFIG_CLK_MESON_AXG) += axg-ao.o
+ obj-$(CONFIG_CLK_MESON_G12A) += g12a.o
+ obj-$(CONFIG_CLK_MESON_G12A) += g12a-ao.o
+diff --git a/drivers/clk/meson/axg-ao.c b/drivers/clk/meson/axg-ao.c
+new file mode 100644
+index 0000000000..311ffc1cca
+--- /dev/null
++++ b/drivers/clk/meson/axg-ao.c
+@@ -0,0 +1,86 @@
++// SPDX-License-Identifier: GPL-2.0+
++
++#include <common.h>
++#include <log.h>
++#include <asm/io.h>
++#include <clk-uclass.h>
++#include <dm.h>
++#include <regmap.h>
++#include <syscon.h>
++#include <dt-bindings/clock/axg-aoclkc.h>
++
++#include "clk_meson.h"
++
++struct meson_clk {
++	struct regmap *map;
++};
++
++#define AO_CLK_GATE0		0x40
++#define AO_SAR_CLK		0x90
++
++static struct meson_gate gates[] = {
++	MESON_GATE(CLKID_AO_SAR_ADC, AO_CLK_GATE0, 7),
++	MESON_GATE(CLKID_AO_SAR_ADC_CLK, AO_SAR_CLK, 7),
++};
++
++static int meson_set_gate(struct clk *clk, bool on)
++{
++	struct meson_clk *priv = dev_get_priv(clk->dev);
++	struct meson_gate *gate;
++
++	gate = &gates[clk->id];
++
++	regmap_update_bits(priv->map, gate->reg,
++			   BIT(gate->bit), on ? BIT(gate->bit) : 0);
++
++	return 0;
++}
++
++static int meson_clk_enable(struct clk *clk)
++{
++	return meson_set_gate(clk, true);
++}
++
++static int meson_clk_disable(struct clk *clk)
++{
++	return meson_set_gate(clk, false);
++}
++
++static int meson_clk_probe(struct udevice *dev)
++{
++	struct meson_clk *priv = dev_get_priv(dev);
++
++	priv->map = syscon_node_to_regmap(dev_ofnode(dev_get_parent(dev)));
++	if (IS_ERR(priv->map))
++		return PTR_ERR(priv->map);
++
++	return 0;
++}
++
++static int meson_clk_request(struct clk *clk)
++{
++	if (clk->id >= ARRAY_SIZE(gates))
++		return -ENOENT;
++
++	return 0;
++}
++
++static struct clk_ops meson_clk_ops = {
++	.disable	= meson_clk_disable,
++	.enable		= meson_clk_enable,
++	.request	= meson_clk_request,
++};
++
++static const struct udevice_id meson_clk_ids[] = {
++	{ .compatible = "amlogic,meson-axg-aoclkc" },
++	{ }
++};
++
++U_BOOT_DRIVER(meson_clk_axg_ao) = {
++	.name		= "meson_clk_axg_ao",
++	.id		= UCLASS_CLK,
++	.of_match	= meson_clk_ids,
++	.priv_auto	= sizeof(struct meson_clk),
++	.ops		= &meson_clk_ops,
++	.probe		= meson_clk_probe,
++};
+-- 
+2.30.2
+

--- a/patch/u-boot/u-boot-meson64/board_jethubj100/0002-clk-meson-fix-driver-name-for-g12a-ao-clocks.patch
+++ b/patch/u-boot/u-boot-meson64/board_jethubj100/0002-clk-meson-fix-driver-name-for-g12a-ao-clocks.patch
@@ -1,0 +1,29 @@
+From 886996fb4a6aa6b698c06bf846d1078acddedd8a Mon Sep 17 00:00:00 2001
+From: Vyacheslav Bocharov <adeep@lexina.in>
+Date: Wed, 20 Apr 2022 20:26:47 +0300
+Subject: [PATCH 2/6] clk: meson: fix driver name for g12a-ao clocks
+
+Update the clk-g12a-ao driver from "axg" to "g12a"
+
+Signed-off-by: Vyacheslav Bocharov <adeep@lexina.in>
+Acked-by: Neil Armstrong <narmstrong@baylibre.com>
+---
+ drivers/clk/meson/g12a-ao.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/clk/meson/g12a-ao.c b/drivers/clk/meson/g12a-ao.c
+index 0148529e04..17b11eb52a 100644
+--- a/drivers/clk/meson/g12a-ao.c
++++ b/drivers/clk/meson/g12a-ao.c
+@@ -73,7 +73,7 @@ static const struct udevice_id meson_clk_ids[] = {
+ 	{ }
+ };
+ 
+-U_BOOT_DRIVER(meson_clk_axg) = {
++U_BOOT_DRIVER(meson_clk_g12a_ao) = {
+ 	.name		= "meson_clk_g12a_ao",
+ 	.id		= UCLASS_CLK,
+ 	.of_match	= meson_clk_ids,
+-- 
+2.30.2
+

--- a/patch/u-boot/u-boot-meson64/board_jethubj100/0003-clk-meson-update-driver-for-g12a-ao-clocks.patch
+++ b/patch/u-boot/u-boot-meson64/board_jethubj100/0003-clk-meson-update-driver-for-g12a-ao-clocks.patch
@@ -1,0 +1,55 @@
+From feb1522d6c82d3bcd322a8a68b5591c115fff1b1 Mon Sep 17 00:00:00 2001
+From: Vyacheslav Bocharov <adeep@lexina.in>
+Date: Fri, 22 Apr 2022 08:22:22 +0300
+Subject: [PATCH 3/6] clk: meson: update driver for g12a-ao clocks
+
+Update g12a-ao clk driver:
+- move clk->id check to .request function
+- remove unnecessary check (gate->reg == 0)
+
+Signed-off-by: Vyacheslav Bocharov <adeep@lexina.in>
+---
+ drivers/clk/meson/g12a-ao.c | 15 +++++++++------
+ 1 file changed, 9 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/clk/meson/g12a-ao.c b/drivers/clk/meson/g12a-ao.c
+index 17b11eb52a..1a855a6896 100644
+--- a/drivers/clk/meson/g12a-ao.c
++++ b/drivers/clk/meson/g12a-ao.c
+@@ -28,14 +28,8 @@ static int meson_set_gate(struct clk *clk, bool on)
+ 	struct meson_clk *priv = dev_get_priv(clk->dev);
+ 	struct meson_gate *gate;
+ 
+-	if (clk->id >= ARRAY_SIZE(gates))
+-		return -ENOENT;
+-
+ 	gate = &gates[clk->id];
+ 
+-	if (gate->reg == 0)
+-		return 0;
+-
+ 	regmap_update_bits(priv->map, gate->reg,
+ 			   BIT(gate->bit), on ? BIT(gate->bit) : 0);
+ 
+@@ -63,9 +57,18 @@ static int meson_clk_probe(struct udevice *dev)
+ 	return 0;
+ }
+ 
++static int meson_clk_request(struct clk *clk)
++{
++	if (clk->id >= ARRAY_SIZE(gates))
++		return -ENOENT;
++
++	return 0;
++}
++
+ static struct clk_ops meson_clk_ops = {
+ 	.disable	= meson_clk_disable,
+ 	.enable		= meson_clk_enable,
++	.request	= meson_clk_request,
+ };
+ 
+ static const struct udevice_id meson_clk_ids[] = {
+-- 
+2.30.2
+

--- a/patch/u-boot/u-boot-meson64/board_jethubj100/0004-adc-meson-saradc-add-AXG-variant.patch
+++ b/patch/u-boot/u-boot-meson64/board_jethubj100/0004-adc-meson-saradc-add-AXG-variant.patch
@@ -1,0 +1,29 @@
+From d88c6ad4b878b4a8431a56168bbdfe0eed2b10a5 Mon Sep 17 00:00:00 2001
+From: Vyacheslav Bocharov <adeep@lexina.in>
+Date: Wed, 20 Apr 2022 20:28:45 +0300
+Subject: [PATCH 4/6] adc: meson-saradc: add AXG variant
+
+Add support for the SARADC variant found on the AXG SoCs family.
+
+Signed-off-by: Vyacheslav Bocharov <adeep@lexina.in>
+Acked-by: Neil Armstrong <narmstrong@baylibre.com>
+---
+ drivers/adc/meson-saradc.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/adc/meson-saradc.c b/drivers/adc/meson-saradc.c
+index 1a45a3a265..37023512f0 100644
+--- a/drivers/adc/meson-saradc.c
++++ b/drivers/adc/meson-saradc.c
+@@ -737,6 +737,8 @@ static const struct udevice_id meson_saradc_ids[] = {
+ 	  .data = (ulong)&gxl_saradc_data },
+ 	{ .compatible = "amlogic,meson-g12a-saradc",
+ 	  .data = (ulong)&gxl_saradc_data },
++	{ .compatible = "amlogic,meson-axg-saradc",
++	  .data = (ulong)&gxl_saradc_data },
+ 	{ }
+ };
+ 
+-- 
+2.30.2
+

--- a/patch/u-boot/u-boot-meson64/board_jethubj100/0005-board-amlogic-jethub-j100-enable-saradc-in-dts.patch
+++ b/patch/u-boot/u-boot-meson64/board_jethubj100/0005-board-amlogic-jethub-j100-enable-saradc-in-dts.patch
@@ -1,0 +1,33 @@
+From 9742e39c0d5df757c205e7482825ebbf1e8dccdc Mon Sep 17 00:00:00 2001
+From: Vyacheslav Bocharov <adeep@lexina.in>
+Date: Wed, 20 Apr 2022 20:32:15 +0300
+Subject: [PATCH 5/6] board: amlogic: jethub j100: enable saradc in dts
+
+Prepare to use ADC channel 1 to check the hardware revision of the board:
+- add u-boot dts include with saradc node
+
+Signed-off-by: Vyacheslav Bocharov <adeep@lexina.in>
+---
+ arch/arm/dts/meson-axg-jethome-jethub-j100-u-boot.dtsi | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+ create mode 100644 arch/arm/dts/meson-axg-jethome-jethub-j100-u-boot.dtsi
+
+diff --git a/arch/arm/dts/meson-axg-jethome-jethub-j100-u-boot.dtsi b/arch/arm/dts/meson-axg-jethome-jethub-j100-u-boot.dtsi
+new file mode 100644
+index 0000000000..3ecb233f8e
+--- /dev/null
++++ b/arch/arm/dts/meson-axg-jethome-jethub-j100-u-boot.dtsi
+@@ -0,0 +1,10 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2022 Vyacheslav Bocharov <adeep@lexina.in>
++ * Author: Vyacheslav Bocharov <adeep@lexina.in>
++ */
++
++&saradc {
++	status = "okay";
++	vref-supply = <&vddio_ao18>;
++};
+-- 
+2.30.2
+

--- a/patch/u-boot/u-boot-meson64/board_jethubj100/0006-board-amlogic-jethub-j100-enable-saradc-in-config.patch
+++ b/patch/u-boot/u-boot-meson64/board_jethubj100/0006-board-amlogic-jethub-j100-enable-saradc-in-config.patch
@@ -1,0 +1,39 @@
+From 150baa6ff7846f19defd5cbfcaf95dffabcb8aba Mon Sep 17 00:00:00 2001
+From: Vyacheslav Bocharov <adeep@lexina.in>
+Date: Wed, 20 Apr 2022 20:35:00 +0300
+Subject: [PATCH 6/6] board: amlogic: jethub j100: enable saradc in config
+
+Enable ADC in board config file
+
+Signed-off-by: Vyacheslav Bocharov <adeep@lexina.in>
+Reviewed-by: Neil Armstrong <narmstrong@baylibre.com>
+---
+ configs/jethub_j100_defconfig | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/configs/jethub_j100_defconfig b/configs/jethub_j100_defconfig
+index 1c6db9f6a0..a30940bf1c 100644
+--- a/configs/jethub_j100_defconfig
++++ b/configs/jethub_j100_defconfig
+@@ -17,6 +17,7 @@ CONFIG_REMAKE_ELF=y
+ CONFIG_OF_BOARD_SETUP=y
+ # CONFIG_DISPLAY_CPUINFO is not set
+ CONFIG_MISC_INIT_R=y
++CONFIG_CMD_ADC=y
+ # CONFIG_CMD_BDI is not set
+ # CONFIG_CMD_IMI is not set
+ CONFIG_CMD_EEPROM=y
+@@ -34,6 +35,10 @@ CONFIG_OF_CONTROL=y
+ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
+ CONFIG_DM_I2C=y
+ CONFIG_SYS_I2C_MESON=y
++CONFIG_ADC=y
++CONFIG_SARADC_MESON=y
++CONFIG_CLK=y
++CONFIG_CLK_MESON_AXG=y
+ CONFIG_MMC_MESON_GX=y
+ CONFIG_MTD_UBI=y
+ CONFIG_PHY_REALTEK=y
+-- 
+2.30.2
+


### PR DESCRIPTION
# Description

Add latest patchset https://patchwork.ozlabs.org/project/uboot/list/?series=296568 for JetHub D1 (Applied to  uboot-amlogic) with:
- add support for AXG in saradc driver
- add simple clk-ao driver for AXG (base is taken from g12a)
- fix typo in the g12a-clk-ao driver name
- move clk->id check to .request function for g12a-clk-ao driver
- remove unnecessary check (gate->reg == 0) in g12a-clk-ao driver
- enable saradc in dts/board config for JetHub D1 (j100)

Jira reference number [AR-1165]

# How Has This Been Tested?

Fixes only saradc for JetHub D1 board, boots ok

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1165]: https://armbian.atlassian.net/browse/AR-1165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ