### PR TITLE
fix Lightdm for sid XFCE

### DIFF
--- a/config/desktop/sid/environments/xfce/config_base/packages
+++ b/config/desktop/sid/environments/xfce/config_base/packages
@@ -35,6 +35,7 @@ profile-sync-daemon
 pulseaudio
 pulseaudio-module-bluetooth
 samba
+slick-greeter
 smbclient
 software-properties-common
 synaptic


### PR DESCRIPTION
fixes the Lightdm startup failure on Debian Sid XFCE
