### PR TITLE
Gnome Foccal FIx

### DIFF
--- a/config/desktop/focal/environments/gnome/config_base/packages
+++ b/config/desktop/focal/environments/gnome/config_base/packages
@@ -232,7 +232,8 @@ xinput
 xorg
 xorg-docs-core
 xserver-common
-xserver-xorgxserver-xorg-video-fbdev
+xserver-xorg
+xserver-xorg-video-fbdev
 xwayland
 yaru-theme-gnome-shell
 yelp


### PR DESCRIPTION
fixed 2 lines that had merged to 1 
