### PR TITLE
Improving repository switch to beta

### DIFF
--- a/lib/distributions.sh
+++ b/lib/distributions.sh
@@ -441,9 +441,7 @@ FAMILY_TWEAKS
  	cp "${SRC}"/packages/bsp/armbian_first_run.txt.template "${SDCARD}"/boot/armbian_first_run.txt.template
 
 	# switch to beta repository at this stage if building nightly images
-	[[ $IMAGE_TYPE == nightly ]] \
-	&& echo "deb https://beta.armbian.com $RELEASE main ${RELEASE}-utils ${RELEASE}-desktop" \
-	> "${SDCARD}"/etc/apt/sources.list.d/armbian.list
+	[[ $IMAGE_TYPE == nightly ]] && sed -i 's/apt/beta/' "${SDCARD}"/etc/apt/sources.list.d/armbian.list
 
 	# Cosmetic fix [FAILED] Failed to start Set console font and keymap at first boot
 	[[ -f "${SDCARD}"/etc/console-setup/cached_setup_font.sh ]] \


### PR DESCRIPTION
# Description

Tiny fix for switching to nightly repository. It stop working after https://github.com/armbian/build/pull/3553

Jira reference number [AR-1170]

# How Has This Been Tested?

- [x] Generated at least one image with BETA="yes"

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1170]: https://armbian.atlassian.net/browse/AR-1170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ