### PR TITLE
Change snapless Chromium to more stable source

### DIFF
--- a/config/desktop/focal/appgroups/browsers/sources/apt/chromium-browser.source
+++ b/config/desktop/focal/appgroups/browsers/sources/apt/chromium-browser.source
@@ -1,1 +1,1 @@
-deb [signed-by=/usr/share/keyrings/chromium-browser.gpg] http://ppa.launchpadcontent.net/saiarcot895/chromium-dev/ubuntu/ focal main
+deb [signed-by=/usr/share/keyrings/chromium-browser.gpg] http://ppa.launchpadcontent.net/saiarcot895/chromium-beta/ubuntu/ focal main

--- a/config/desktop/jammy/appgroups/browsers/sources/apt/chromium-browser.source
+++ b/config/desktop/jammy/appgroups/browsers/sources/apt/chromium-browser.source
@@ -1,1 +1,1 @@
-deb [signed-by=/usr/share/keyrings/chromium-browser.gpg] http://ppa.launchpadcontent.net/saiarcot895/chromium-dev/ubuntu/ jammy main
+deb [signed-by=/usr/share/keyrings/chromium-browser.gpg] http://ppa.launchpadcontent.net/saiarcot895/chromium-beta/ubuntu/ jammy main


### PR DESCRIPTION
# Description

It seems that dev channel doesn't always produce arm64 chromium packages. Changing to beta channel seems to solve the problem.

Jira reference number [AR-1169]

# How Has This Been Tested?

- [x] Generated full Gnome Jammy desktop 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1169]: https://armbian.atlassian.net/browse/AR-1169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ