### PR TITLE
Adjust auto labeller according to label changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,34 +10,26 @@
 #
 # Please keep the labels sorted and deduplicated.
 
-"c:u-boot":
+"Hardware :gear:":
   - patch/u-boot/*
   - patch/u-boot/**/*
   - patch/atf/*
   - config/bootenv/*
   - config/bootscripts/*
-
-"c:kernel":
   - patch/kernel/*
   - patch/kernel/**/*
   - patch/misc/*
   - config/kernel/*
   - config/sources/*
-
-"c:bsp":
   - config/sources/**/*
   - config/boards/*
   - config/bootscripts/*
   - config/bootenv/*
 
-"c:build script":
+"Software :chains:":
   - lib/*
-
-"c:desktop":
-  - config/desktop/*
-
-"c:cli":
   - config/cli/*
-
-"c:actions":
   - .github/workflows/*
+
+"Desktop :desktop_computer:":
+  - config/desktop/*


### PR DESCRIPTION
# Description

After dramatically reducing labels used in build system - to improve UX and label usage, we also need to adjust our automated Actions driven labeler.

![labels](https://user-images.githubusercontent.com/6281704/166313381-11a117b8-e0e8-407b-8052-937ac94b077f.png)

Jira reference number [AR-959]

# How Has This Been Tested?

Not tested - config system changes only.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-959]: https://armbian.atlassian.net/browse/AR-959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ