### PR TITLE
Kernel 5.10.y need patch adjustment for boot splash

### DIFF
--- a/lib/compilation-prepare.sh
+++ b/lib/compilation-prepare.sh
@@ -115,7 +115,10 @@ compilation_prepare()
 
 		display_alert "Adding" "Kernel splash file" "info"
 
-		process_patch_file "${SRC}/patch/misc/bootsplash-5.16.y-0000-Revert-fbcon-Avoid-cap-set-but-not-used-warning.patch" "applying"
+		if linux-version compare "${version}" ge 5.11; then
+			process_patch_file "${SRC}/patch/misc/bootsplash-5.16.y-0000-Revert-fbcon-Avoid-cap-set-but-not-used-warning.patch" "applying"
+		fi
+
 		process_patch_file "${SRC}/patch/misc/bootsplash-5.16.y-0001-Revert-fbcon-Add-option-to-enable-legacy-hardware-ac.patch" "applying"
 
 		if linux-version compare "${version}" ge 5.15; then


### PR DESCRIPTION
# Description

Kernel 5.10.y need patch adjustment for boot splash since it doesn't share all changes to the code.

Jira reference number [AR-1151]

# How Has This Been Tested?

- [x] Build test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings

[AR-1151]: https://armbian.atlassian.net/browse/AR-1151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ