### PR TITLE
Bugfix - HDMI rules are causing flickering

### DIFF
--- a/config/sources/families/include/meson64_common.inc
+++ b/config/sources/families/include/meson64_common.inc
@@ -261,8 +261,6 @@ family_tweaks_bsp()
 {
 	mkdir -p $destination/etc/udev/rules.d
 	mkdir -p $destination/usr/local/bin
-	cp $SRC/packages/bsp/rockchip/hdmi.rules $destination/etc/udev/rules.d
-	install -m 755 $SRC/packages/bsp/rockchip/hdmi-hotplug $destination/usr/local/bin
 
 	mkdir -p "$destination"/etc/X11/xorg.conf.d
 	case "${BOARD}" in


### PR DESCRIPTION
# Description

Removing udev rules which were causing flickering.

Jira reference number [AR-1061]

# How Has This Been Tested?

- [x] Generated and run Debian Cinnamon image with EDGE kernel (5.17.5)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings

[AR-1061]: https://armbian.atlassian.net/browse/AR-1061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ