### PR TITLE
Bugfix - Budgie desktop fails to build on Jammy

### DIFF
--- a/config/desktop/jammy/environments/budgie/config_base/packages
+++ b/config/desktop/jammy/environments/budgie/config_base/packages
@@ -39,9 +39,7 @@ budgie-wallpapers-focal
 budgie-wallstreet
 budgie-weathershow-applet
 budgie-welcome
-budgie-window-mover-applet
 budgie-window-shuffler
-budgie-workspace-overview-applet
 budgie-workspace-stopwatch-applet
 cifs-utils
 colord


### PR DESCRIPTION
# Description

Remove missing packages that were preventing successful assembly.

Jira reference number [AR-1171]

# How Has This Been Tested?

- [x] Build and flash image

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings

[AR-1171]: https://armbian.atlassian.net/browse/AR-1171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ