### PR TITLE
Github action for generating desktops does not start

### DIFF
--- a/.github/workflows/build-test-image-docker.yml
+++ b/.github/workflows/build-test-image-docker.yml
@@ -10,7 +10,7 @@ on:
 jobs:
 
   Maintain:    
-    if: ${{ github.repository_owner == 'Armbian' && contains( github.event.pull_request.labels.*.name, 'desktop') }}
+    if: ${{ github.repository_owner == 'Armbian' && contains( github.event.pull_request.labels.*.name, 'Desktop :desktop_computer:') }}
     uses: armbian/scripts/.github/workflows/build-test-image-docker.yml@master
 
     with:


### PR DESCRIPTION
# Description

After changing labels, this action does not run anymore. We changed label from desktop to _Desktop :desktop_computer:_

Jira reference number [AR-1173]

[AR-1173]: https://armbian.atlassian.net/browse/AR-1173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ