### PR TITLE
Thermal / temperature monitoring for jetson nano

### DIFF
--- a/config/kernel/linux-media-current.config
+++ b/config/kernel/linux-media-current.config
@@ -4956,7 +4956,7 @@ CONFIG_ROCKCHIP_THERMAL=y
 #
 # NVIDIA Tegra thermal drivers
 #
-# CONFIG_TEGRA_SOCTHERM is not set
+CONFIG_TEGRA_SOCTHERM=m
 CONFIG_TEGRA_BPMP_THERMAL=m
 # end of NVIDIA Tegra thermal drivers
 

--- a/config/kernel/linux-media-edge.config
+++ b/config/kernel/linux-media-edge.config
@@ -4998,7 +4998,7 @@ CONFIG_ROCKCHIP_THERMAL=y
 #
 # NVIDIA Tegra thermal drivers
 #
-# CONFIG_TEGRA_SOCTHERM is not set
+CONFIG_TEGRA_SOCTHERM=m
 CONFIG_TEGRA_BPMP_THERMAL=m
 # end of NVIDIA Tegra thermal drivers
 


### PR DESCRIPTION
# Description

Adding thermal / temperature monitoring support for NVIDIA Jetson Nano.

This activates the compatible tegra_soctherm kernel module for the tegra210 soctherm device. 

Temperatures included:
| Path  | Description |
| ------------- | ------------- |
|  /sys/devices/virtual/thermal/thermal_zone0/temp | cpu  |
|  /sys/devices/virtual/thermal/thermal_zone1/temp | mem  |
|  /sys/devices/virtual/thermal/thermal_zone2/temp | gpu  |
|  /sys/devices/virtual/thermal/thermal_zone3/temp | pllx  |

Kernel Module source:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/thermal/tegra/tegra210-soctherm.c


# How Has This Been Tested?

Tested on a NVIDIA Jetson Nano aArmbian 22.05.0-trunk Bullseye with Linux 5.17.5-media build.

**Kernel config**
CONFIG_TEGRA_SOCTHERM=m

**Build options**
./compile.sh BOARD=jetson-nano BRANCH=current RELEASE=bullseye BUILD_MINIMAL=no BUILD_DESKTOP=no KERNEL_ONLY=no KERNEL_CONFIGURE=yes COMPRESS_OUTPUTIMAGE=sha,gpg,img
