### PR TITLE
Wrong package name - typo fix

### DIFF
--- a/config/desktop/jammy/environments/mate/config_base/packages
+++ b/config/desktop/jammy/environments/mate/config_base/packages
@@ -197,7 +197,7 @@ witalian
 wportuguese
 wspanish
 wswiss
-xupower
+upower
 viewnior
 x11-apps
 x11-session-utils


### PR DESCRIPTION
# Description

We didn't spot this problem since CI was not operational due to label changes.