### PR TITLE
Update only supported repositories

### DIFF
--- a/lib/general.sh
+++ b/lib/general.sh
@@ -905,6 +905,14 @@ addtorepo()
 
 	for release in "${distributions[@]}"; do
 
+		ADDING_PACKAGES="false"
+		if [[ -d "config/distributions/${release}/" ]]; then
+			[[ -n "$(cat config/distributions/${release}/support | grep "csc\|supported" 2>/dev/null)" ]] && ADDING_PACKAGES="true"
+		else
+			display_alert "Skipping adding packages (not supported)" "$release" "wrn"
+			continue
+		fi
+
 		local forceoverwrite=""
 
 		# let's drop from publish if exits
@@ -935,7 +943,7 @@ addtorepo()
 
 		# adding main
 		if find "${DEB_STORAGE}"/ -maxdepth 1 -type f -name "*.deb" 2>/dev/null | grep -q .; then
-			adding_packages "$release" "" "main"
+			[[ "${ADDING_PACKAGES}" == true ]] && adding_packages "$release" "" "main"
 		else
 			aptly repo add -config="${SCRIPTPATH}config/${REPO_CONFIG}" "${release}" "${SCRIPTPATH}config/templates/example.deb" >/dev/null
 		fi
@@ -944,7 +952,7 @@ addtorepo()
 
 		# adding main distribution packages
 		if find "${DEB_STORAGE}/${release}" -maxdepth 1 -type f -name "*.deb" 2>/dev/null | grep -q .; then
-			adding_packages "${release}-utils" "/${release}" "release packages"
+			[[ "${ADDING_PACKAGES}" == true ]] && adding_packages "${release}-utils" "/${release}" "release packages"
 		else
 			# workaround - add dummy package to not trigger error
 			aptly repo add -config="${SCRIPTPATH}config/${REPO_CONFIG}" "${release}" "${SCRIPTPATH}config/templates/example.deb" >/dev/null
@@ -952,7 +960,7 @@ addtorepo()
 
 		# adding release-specific utils
 		if find "${DEB_STORAGE}/extra/${release}-utils" -maxdepth 1 -type f -name "*.deb" 2>/dev/null | grep -q .; then
-			adding_packages "${release}-utils" "/extra/${release}-utils" "release utils"
+			[[ "${ADDING_PACKAGES}" == true ]] && adding_packages "${release}-utils" "/extra/${release}-utils" "release utils"
 		else
 			aptly repo add -config="${SCRIPTPATH}config/${REPO_CONFIG}" "${release}-utils" "${SCRIPTPATH}config/templates/example.deb" >/dev/null
 		fi
@@ -960,7 +968,7 @@ addtorepo()
 
 		# adding desktop
 		if find "${DEB_STORAGE}/extra/${release}-desktop" -maxdepth 1 -type f -name "*.deb" 2>/dev/null | grep -q .; then
-			adding_packages "${release}-desktop" "/extra/${release}-desktop" "desktop"
+			[[ "${ADDING_PACKAGES}" == true ]] && adding_packages "${release}-desktop" "/extra/${release}-desktop" "desktop"
 		else
 			# workaround - add dummy package to not trigger error
 			aptly repo add -config="${SCRIPTPATH}config/${REPO_CONFIG}" "${release}-desktop" "${SCRIPTPATH}config/templates/example.deb" >/dev/null


### PR DESCRIPTION
# Description

Don't add any packages to CSC repositories (stretch, bionic, ...), but generate index.

Jira reference number [AR-1177]

# How Has This Been Tested?

```
[ o.k. ] Using config file [ /home/igorp/Devel/build/userpatches/config-example.conf ]
[ o.k. ] Command line: setting REPOSITORY_UPDATE to [ update ]
[ o.k. ] Using user configuration override [ userpatches/lib.config ]
[ warn ] Skipping adding packages (not supported) [ stretch ]
[ warn ] Skipping adding packages (not supported) [ bionic ]
[ o.k. ] Checking and adding to repository buster [ main ]
[ o.k. ] Creating section [ main ]
[ o.k. ] Checking and adding to repository bullseye [ main ]
[ o.k. ] Adding bullseye [ linux-u-boot-odroidn2-current ]
[ o.k. ] Creating section [ main ]
[ o.k. ] Checking and adding to repository focal [ main ]
[ o.k. ] Adding focal [ linux-u-boot-odroidn2-current ]
[ warn ] Skipping adding packages (not supported) [ hirsute ]
[ warn ] Skipping adding packages (not supported) [ impish ]
[ o.k. ] Creating section [ main ]
[ o.k. ] Checking and adding to repository jammy [ main ]
[ o.k. ] Adding jammy [ linux-u-boot-odroidn2-current ]
[ o.k. ] Creating section [ main ]
[ o.k. ] Checking and adding to repository sid [ main ]
[ o.k. ] Adding sid [ linux-u-boot-odroidn2-current ]
[ o.k. ] Cleaning repository [ /home/igorp/Devel/build/output/debs ]
```

```
[ o.k. ] List of local repos [ local ]
 * [bullseye-desktop]: Armbian bullseye desktop (packages: 1)
 * [bullseye-utils]: Armbian bullseye utilities (packages: 1)
 * [bullseye]: Armbian main repository (packages: 2)
 * [buster-desktop]: Armbian buster desktop (packages: 1)
 * [buster-utils]: Armbian buster utilities (packages: 1)
 * [buster]: Armbian main repository (packages: 2)
 * [focal-desktop]: Armbian focal desktop (packages: 1)
 * [focal-utils]: Armbian focal utilities (packages: 1)
 * [focal]: Armbian main repository (packages: 2)
 * [jammy-desktop]: Armbian jammy desktop (packages: 1)
 * [jammy-utils]: Armbian jammy utilities (packages: 1)
 * [jammy]: Armbian main repository (packages: 2)
 * [sid-desktop]: Armbian sid desktop (packages: 1)
 * [sid-utils]: Armbian sid utilities (packages: 1)
 * [sid]: Armbian main repository (packages: 2)
 * [stretch-desktop]: Armbian stretch desktop (packages: 1)
 * [stretch-utils]: Armbian stretch utilities (packages: 1)
 * [stretch]: Armbian main repository (packages: 2)
 * [utils]: Armbian utilities (backwards compatibility) (packages: 0)
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1177]: https://armbian.atlassian.net/browse/AR-1177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ