### PR TITLE
remove mesa-utils-extra for sid due to upstream dependency change

### DIFF
--- a/config/desktop/sid/appgroups/3dsupport
+++ b/config/desktop/sid/appgroups/3dsupport
@@ -1,1 +1,0 @@
-../../buster/appgroups/3dsupport

--- a/config/desktop/sid/appgroups/3dsupport/packages
+++ b/config/desktop/sid/appgroups/3dsupport/packages
@@ -1,0 +1,3 @@
+libglx-mesa0
+libgl1-mesa-dri
+mesa-utils


### PR DESCRIPTION
# Description

Related #3682 . Debian sid also updates mesa-utils.


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] sid gnome build success

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
