### PR TITLE
Docker images creation is broken

### DIFF
--- a/config/templates/Dockerfile
+++ b/config/templates/Dockerfile
@@ -101,7 +101,6 @@ RUN apt-get update \
        rsync \
        swig \
        sudo \
-       systemd-container \
        tzdata \
        u-boot-tools \
        udev \

--- a/config/templates/config-docker.conf
+++ b/config/templates/config-docker.conf
@@ -6,7 +6,7 @@
 
 # Default values for Docker image
 CUSTOM_PACKAGES="g++-11-arm-linux-gnueabihf libssl3"
-BASE_IMAGE="ubuntu:22.04"
+BASE_IMAGE="ubuntu:jammy"
 
 
 [[ ! -c /dev/loop-control ]] && display_alert "/dev/loop-control does not exist, image building may not work" "" "wrn"


### PR DESCRIPTION
# Description

Removing deprecated package

Jira reference number [AR-1178]

# How Has This Been Tested?

- [ ] Docker image creation

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
