### PR TITLE
Debian SID Docker image is failing 

### DIFF
--- a/config/templates/Dockerfile
+++ b/config/templates/Dockerfile
@@ -95,7 +95,6 @@ RUN apt-get update \
        python3-distutils \
        python3-pkg-resources \
        python3-setuptools \
-       qemu \
        qemu-utils \
        qemu-user-static \
        rsync \

--- a/config/templates/config-docker.conf
+++ b/config/templates/config-docker.conf
@@ -5,7 +5,7 @@
 
 
 # Default values for Docker image
-CUSTOM_PACKAGES="g++-11-arm-linux-gnueabihf libssl3"
+CUSTOM_PACKAGES="g++-11-arm-linux-gnueabihf libssl3 qemu"
 BASE_IMAGE="ubuntu:jammy"
 
 


### PR DESCRIPTION
# Description

Package deprecation in Debian SID.

Jira reference number [AR-1178]

[AR-1178]: https://armbian.atlassian.net/browse/AR-1178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ