### PR TITLE
Enable rockchip64: XHCI HCD USB TRB ENT quirk for RK3328

### DIFF
--- a/patch/kernel/archive/rockchip64-5.15/general-rk3328-dtsi-trb-ent-quirk.patch
+++ b/patch/kernel/archive/rockchip64-5.15/general-rk3328-dtsi-trb-ent-quirk.patch
@@ -1,0 +1,12 @@
+diff --git a/arch/arm64/boot/dts/rockchip/rk3328.dtsi b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
+index 8f8a097c0..5fec765ab 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3328.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
+@@ -1229,6 +1229,7 @@ usbdrd3: usb@ff600000 {
+ 		snps,dis-del-phy-power-chg-quirk;
+ 		snps,dis_enblslpm_quirk;
+ 		snps,dis-tx-ipgap-linecheck-quirk;
++        snps,xhci-trb-ent-quirk;
+ 		snps,dis-u2-freeclk-exists-quirk;
+ 		snps,dis_u2_susphy_quirk;
+ 		snps,dis_u3_susphy_quirk;

--- a/patch/kernel/archive/rockchip64-5.17/general-rk3328-dtsi-trb-ent-quirk.patch
+++ b/patch/kernel/archive/rockchip64-5.17/general-rk3328-dtsi-trb-ent-quirk.patch
@@ -1,0 +1,12 @@
+diff --git a/arch/arm64/boot/dts/rockchip/rk3328.dtsi b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
+index 8f8a097c0..5fec765ab 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3328.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
+@@ -1229,6 +1229,7 @@ usbdrd3: usb@ff600000 {
+ 		snps,dis-del-phy-power-chg-quirk;
+ 		snps,dis_enblslpm_quirk;
+ 		snps,dis-tx-ipgap-linecheck-quirk;
++        snps,xhci-trb-ent-quirk;
+ 		snps,dis-u2-freeclk-exists-quirk;
+ 		snps,dis_u2_susphy_quirk;
+ 		snps,dis_u3_susphy_quirk;


### PR DESCRIPTION
Enable the dwc3 xhci usb quirk on RK3328 through device tree node properties in rk3328.dtsi

# Description

This resolves a bug that affects r8153b USB network interface causing the RX interface to hang on load on Orange Pi R1plus LTS and has been reported in Nano Pi R2S and probably affects Orange Pi R1plus and others using USB3.

On some xHCI controllers (e.g. Rockchip RK3399/RK3328/RK1808), 
they need to enable the ENT flag in the TRB data structure 
to force xHC to prefetch the next TRB of a TD. 
The quirk patch is already applied to dwc3 xhci usb on rockchip64.

This PR will enable the quirk on RK3328 through device tree node properties in rk3328.dtsi

Jira reference number [AR-1172]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.
Functional testing on Orange Pi R1plus LTS with 5.15y current:
Speeds are similar to those achieved on 5.10 with the old driver.
Iperf in the TX direction only: 883 Mbits/sec
Iperf in the RX direction only: 699 Mbits/sec

Testing bidirectional with two parallel iperf sessions:
Without speed limitations RX 651 Mbits/sec TX 307 Mbits/sec
With TX limited to 300 Mbits/sec RX about 640 Mbits/sec
With RX limited to 300 Mbits/sec TX about 600 Mbits/sec
So total bidirectional bandwidth TX + RX seems approximately around 900 Mbits/sec

Sustained iperf bidirectional load RX limited to 300 Mbits/sec was applied for 20 minutes without issues
Sustained iperf bidirectional load TX limited to 300 Mbits/sec was applied for 20 minutes without issues
Sustained iperf bidirectional load with no limitations was applied for 20 minutes without issues

Functional testing on 5.17y edge:
Testing bidirectional 20 minutes with two parallel iperf sessions:
Without speed limitations RX 649 Mbits/sec TX 309 Mbits/sec


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1172]: https://armbian.atlassian.net/browse/AR-1172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ