### PR TITLE
remove machine-id before making image, to be generated at 'firstboot'

### DIFF
--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -871,8 +871,9 @@ PRE_UPDATE_INITRAMFS
 	# fix wrong / permissions
 	chmod 755 $MOUNT
 
-	# remove machine-id so images self-initialize
-    rm ${MOUNT}/etc/machine-id ${MOUNT}/var/lib/dbus/machine-id
+	# systemd image cleanup
+    echo -e "uninitialized\n" > ${MOUNT}/etc/machine-id
+    rm ${MOUNT}/var/lib/systemd/random-seed
 
 	call_extension_method "pre_umount_final_image" "config_pre_umount_final_image" << 'PRE_UMOUNT_FINAL_IMAGE'
 *allow config to hack into the image before the unmount*

--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -871,6 +871,9 @@ PRE_UPDATE_INITRAMFS
 	# fix wrong / permissions
 	chmod 755 $MOUNT
 
+	# remove machine-id so images self-initialize
+    rm ${MOUNT}/etc/machine-id
+
 	call_extension_method "pre_umount_final_image" "config_pre_umount_final_image" << 'PRE_UMOUNT_FINAL_IMAGE'
 *allow config to hack into the image before the unmount*
 Called before unmounting both `/root` and `/boot`.

--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -872,7 +872,7 @@ PRE_UPDATE_INITRAMFS
 	chmod 755 $MOUNT
 
 	# remove machine-id so images self-initialize
-    rm ${MOUNT}/etc/machine-id
+    rm ${MOUNT}/etc/machine-id ${MOUNT}/var/lib/dbus/machine-id
 
 	call_extension_method "pre_umount_final_image" "config_pre_umount_final_image" << 'PRE_UMOUNT_FINAL_IMAGE'
 *allow config to hack into the image before the unmount*

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstrun
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstrun
@@ -54,7 +54,7 @@ case "$1" in
 
 	# SSH Keys creation
 	read entropy_before </proc/sys/kernel/random/entropy_avail
-	[[ -f /etc/ssh/ssh_host_ed25519_key ]] || ssh-keygen -q -f /etc/ssh/ssh_host_ed25519_key -t ed25519 -N ''
+    dpkg-reconfigure -fnoninteractive openssh-server
 	read entropy_after </proc/sys/kernel/random/entropy_avail
 	echo -e "\n### [firstrun] Recreated SSH keys (entropy: ${entropy_before} ${entropy_after})" >>${Log}
 

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstrun
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstrun
@@ -53,10 +53,8 @@ case "$1" in
 	sed '1s/^/IMAGE_UUID=/' /proc/sys/kernel/random/uuid >> /etc/armbian-image-release
 
 	# SSH Keys creation
-	rm -f /etc/ssh/ssh_host*
 	read entropy_before </proc/sys/kernel/random/entropy_avail
-	dpkg-reconfigure openssh-server >/dev/null 2>&1
-
+	[[ -f /etc/ssh/ssh_host_ed25519_key ]] || ssh-keygen -q -f /etc/ssh/ssh_host_ed25519_key -t ed25519 -N ''
 	read entropy_after </proc/sys/kernel/random/entropy_avail
 	echo -e "\n### [firstrun] Recreated SSH keys (entropy: ${entropy_before} ${entropy_after})" >>${Log}
 

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstrun
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstrun
@@ -107,12 +107,9 @@ case "$1" in
 
 		mvebu64|mt7623)
 			# configure/enable/start systemd-networkd
-			systemctl start systemd-networkd.service
-			systemctl start systemd-resolved.service
-			systemctl enable systemd-networkd.service
-			systemctl enable systemd-resolved.service
 			ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
-			systemctl restart systemd-networkd
+			systemctl enable --now systemd-resolved.service
+			systemctl enable --now systemd-networkd.service
 			;;
 		odroidc1)
 			if [[ -f /boot/boot.ini ]]; then


### PR DESCRIPTION
# Description

chroot installation is populating machine-id, which makes systemd skip firstboot scripts
