### PR TITLE
Firstrun 2

### DIFF
--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -871,6 +871,10 @@ PRE_UPDATE_INITRAMFS
 	# fix wrong / permissions
 	chmod 755 $MOUNT
 
+	# cleanup image according to systemd.io/BUILDING_IMAGES/
+	echo -e "uninitialized\n" > ${MOUNT}/etc/machine-id
+	rm ${MOUNT}/var/lib/systemd/random-seed ${MOUNT}/var/lib/dbus/machine-id
+
 	call_extension_method "pre_umount_final_image" "config_pre_umount_final_image" << 'PRE_UMOUNT_FINAL_IMAGE'
 *allow config to hack into the image before the unmount*
 Called before unmounting both `/root` and `/boot`.

--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -74,6 +74,9 @@ PRE_INSTALL_DISTRIBUTION_SPECIFIC
 	# install from apt.armbian.com
 	[[ $EXTERNAL_NEW == prebuilt ]] && chroot_installpackages "yes"
 
+	# remove existing ssh keys
+	rm -f ${SDCARD}/etc/ssh/ssh_host_*
+
 	# stage: user customization script
 	# NOTE: installing too many packages may fill tmpfs mount
 	customize_image

--- a/packages/bsp/common/lib/systemd/system/armbian-firstrun-config.service
+++ b/packages/bsp/common/lib/systemd/system/armbian-firstrun-config.service
@@ -3,13 +3,15 @@
 
 [Unit]
 Description=Armbian first run optional user configuration
-Wants=network-online.target
+Wants=network-online.target first-boot-complete.target
 After=network.target network-online.target
+Before=first-boot-complete.target
 ConditionPathExists=/boot/armbian_first_run.txt
 ConditionPathExists=/root/.not_logged_in_yet
+ConditionFirstBoot=yes
 
 [Service]
-Type=idle
+Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/lib/armbian/armbian-firstrun-config
 TimeoutStartSec=2min

--- a/packages/bsp/common/lib/systemd/system/armbian-firstrun.service
+++ b/packages/bsp/common/lib/systemd/system/armbian-firstrun.service
@@ -4,10 +4,11 @@
 
 [Unit]
 Description=Armbian first run tasks
-Before=getty.target system-getty.slice
+Before=getty.target system-getty.slice first-boot-complete.target ssh.service
+Wants=first-boot-complete.target
 
 [Service]
-Type=simple
+Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/lib/armbian/armbian-firstrun start
 TimeoutStartSec=2min

--- a/packages/bsp/common/lib/systemd/system/armbian-resize-filesystem.service
+++ b/packages/bsp/common/lib/systemd/system/armbian-resize-filesystem.service
@@ -4,9 +4,10 @@
 
 [Unit]
 Description=Armbian filesystem resize
-Before=basic.target
+Before=basic.target first-boot-complete.target
 After=sysinit.target local-fs.target
 DefaultDependencies=no
+Wants=first-boot-complete.target
 
 [Service]
 Type=oneshot

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstrun
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstrun
@@ -53,10 +53,8 @@ case "$1" in
 	sed '1s/^/IMAGE_UUID=/' /proc/sys/kernel/random/uuid >> /etc/armbian-image-release
 
 	# SSH Keys creation
-	rm -f /etc/ssh/ssh_host*
 	read entropy_before </proc/sys/kernel/random/entropy_avail
-	dpkg-reconfigure openssh-server >/dev/null 2>&1
-	service sshd restart
+	dpkg-reconfigure -fnoninteractive openssh-server >/dev/null 2>&1
 	read entropy_after </proc/sys/kernel/random/entropy_avail
 	echo -e "\n### [firstrun] Recreated SSH keys (entropy: ${entropy_before} ${entropy_after})" >>${Log}
 
@@ -129,7 +127,6 @@ case "$1" in
 	[[ $BRANCH == dev && $LINUXFAMILY == rockchip ]] && set_fixed_mac
 	[[ $BRANCH == current && $LINUXFAMILY == odroidc1 ]] && set_fixed_mac
 	[[ $LINUXFAMILY == meson64 ]] && set_fixed_mac
-	systemctl disable armbian-firstrun
 	exit 0
 	;;
 

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstrun
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstrun
@@ -105,12 +105,9 @@ case "$1" in
 
 		mvebu64|mt7623)
 			# configure/enable/start systemd-networkd
-			systemctl start systemd-networkd.service
-			systemctl start systemd-resolved.service
-			systemctl enable systemd-networkd.service
-			systemctl enable systemd-resolved.service
 			ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
-			systemctl restart systemd-networkd
+			systemctl enable --now systemd-networkd.service
+			systemctl enable --now systemd-resolved.service
 			;;
 		odroidc1)
 			if [[ -f /boot/boot.ini ]]; then


### PR DESCRIPTION
# Description

Cleanup and order firstrun scripts to use systemd firstboot logic.
Cleanup image according to systemd so multiple flashes don't share machine-id or random seed
Cleanup espressobin-related logic enabling networkd and resolved services.

Replaces #3642 and #3769

Jira reference number [AR-1174]

# How Has This Been Tested?

- [ ] Flash the new image and see if it completes firstrun scripts and populates /etc/machine-id

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
