### PR TITLE
Added '--delete' to syncToDisk in armbian-ramlog

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-ramlog
+++ b/packages/bsp/common/usr/lib/armbian/armbian-ramlog
@@ -50,6 +50,7 @@ syncToDisk () {
 	if [ "$USE_RSYNC" = true ]; then
 		${NoCache} rsync -aXWv \
 			--exclude "lost+found" --exclude armbian-ramlog.log \
+			--delete \
 			--links \
 			${XTRA_RSYNC_TO[@]+"${XTRA_RSYNC_TO[@]}"} \
 			$RAM_LOG $HDD_LOG 2>&1 | $LOG_OUTPUT


### PR DESCRIPTION
Added rsync-option '--delete' to syncToDisk to prevent overfilled ramdisk.

# Description

The entire problem description can be found in this forum thread: https://forum.armbian.com/topic/19995-armbian-ramlog-problems-and-possible-improvements/

Jira reference number [AR-1135]

# How Has This Been Tested?

/var/log.hdd/journal will use less space right after the midnight cronjobs.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1135]: https://armbian.atlassian.net/browse/AR-1135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ