### PR TITLE
add FIT configuration for Helios64, modify example for ebin

### DIFF
--- a/config/its/marvell/a37xx/espressobin.its
+++ b/config/its/marvell/a37xx/espressobin.its
@@ -11,7 +11,7 @@
             type = "kernel";
             arch = "arm64";
             os = "linux";
-            compression = "lzma";
+            compression = "none";
             load = <0x07000000>;
             entry = <0x07000000>;
             hash {

--- a/config/its/rockchip64/rk3399/helios64.its
+++ b/config/its/rockchip64/rk3399/helios64.its
@@ -1,0 +1,65 @@
+/dts-v1/;
+
+/ {
+  description = "Helios64 FIT Image";
+  #address-cells = <1>;
+
+  images {
+    kernel {
+      description = "Kernel 5.15.31-rk3399";
+      data  = /incbin/("/boot/vmlinuz-$(uname -r)");
+      type  = "kernel";
+      arch  = "arm64";
+      os    = "linux";
+      compression = "none";
+      load  = <0x02080000>;
+      entry = <0x02080000>;
+      hash {
+        algo = "sha1";
+      };
+    };
+    initrd {
+      description = "Initrd";
+      data = /incbin/("/boot/uInitrd");
+      type = "ramdisk";
+      arch = "arm64";
+      os   = "linux";
+      hash {
+        algo = "sha1";
+      };
+    };
+    fdt {
+      description = "Helios 64 Tree";
+      data  = /incbin/("/boot/dtb/rockchip/rk3399-kobol-helios64.dtb");
+      type  = "flat_dt";
+      arch  = "arm64";
+      compression = "none";
+      load  = <0x01f00000>;
+      entry = <0x01f00000>;
+      hash {
+        algo = "sha1";
+      };
+    };
+  };
+
+  configurations {
+    default = "Helios64";
+    Helios64 {
+      description = "Linux 5.15.31 for Rockchip64";
+      kernel = "kernel";
+      ramdisk = "initrd";
+      fdt = "fdt";
+      hash {
+        algo = "sha1";
+      };
+    };
+    Helios64-noinitrd {
+      description = "Linux 5.15.31 for Rockchip64, no initrd";
+      kernel = "kernel";
+      fdt = "fdt";
+      hash {
+        algo = "sha1";
+      };
+    };
+  };
+};


### PR DESCRIPTION
# Description

Documenting functional Image Tree Source files.  These files are not currently used for any builds.

# How Has This Been Tested?

No test needed, documentary changes

