### PR TITLE
Revive rock64 and rockpi-4a/4b/4c

### DIFF
--- a/config/targets-cli-beta.conf
+++ b/config/targets-cli-beta.conf
@@ -82,9 +82,19 @@ radxa-zero2                  current         jammy       cli                    
 rk322x-box                   edge            jammy       cli                      beta         yes
 
 
+# Pine64 Rock64
+rock64                       edge            jammy       cli                      beta         yes
+
+
 # Radxa rock-3a
 rock-3a                      legacy          jammy       cli                      beta         yes
 rock-3a                      edge            jammy       cli                      beta         yes
+
+
+# Radxa rockpi-4
+rockpi-4a                    edge            jammy       cli                      beta         yes
+rockpi-4b                    edge            jammy       cli                      beta         yes
+rockpi-4c                    edge            jammy       cli                      beta         yes
 
 
 # Raspberry Pi4

--- a/config/targets.conf
+++ b/config/targets.conf
@@ -441,6 +441,30 @@ rk322x-box                current         focal       desktop                  s
 rk322x-box                edge            jammy       desktop                  stable         adv            xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 
+# Rock64
+rock64                    current         bullseye    cli                      stable         yes
+rock64                    current         jammy       desktop                  stable         yes            xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+rock64                    edge            jammy       cli                      stable         yes
+
+
+# Rockpi 4a
+rockpi-4a                 current         bullseye    cli                      stable         yes
+rockpi-4a                 edge            jammy       desktop                  stable         yes            xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+rockpi-4a                 edge            jammy       cli                      stable         yes
+
+
+# Rockpi 4b
+rockpi-4b                 current         bullseye    cli                      stable         yes
+rockpi-4b                 edge            jammy       desktop                  stable         yes            xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+rockpi-4b                 edge            jammy       cli                      stable         yes
+
+
+# Rockpi 4c
+rockpi-4c                 current         bullseye    cli                      stable         yes
+rockpi-4c                 edge            jammy       desktop                  stable         yes            xfce      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+rockpi-4c                 edge            jammy       cli                      stable         yes
+
+
 # Tinkerboard
 tinkerboard               current         bullseye    cli                      stable         adv
 tinkerboard               current         focal       cli                      stable         yes


### PR DESCRIPTION
# Description

Restore Rock64 and RockPi 4A/4B/4C builds.

# How Has This Been Tested?

It hasn't yet. Need to get these changes integrated to the build system so I _can_ test the images on the SBCs :)
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
