### PR TITLE
Update remove-boot-messages-from-hdmi.patch.disabled

### DIFF
--- a/patch/u-boot/u-boot-sunxi/remove-boot-messages-from-hdmi.patch.disabled
+++ b/patch/u-boot/u-boot-sunxi/remove-boot-messages-from-hdmi.patch.disabled
@@ -1,19 +1,12 @@
-This removes all boot messages but leave logo. For Plymouth configuration proceed here:
-
+This removes all pre-kernel boot messages from HDMI, but leaves logo support & UART output active. For Plymouth configuration tips, look here:
 https://forum.armbian.com/topic/10087-armbian-boot-splash-screen/?do=findComment&comment=96114
 
 diff --git a/include/configs/sunxi-common.h b/include/configs/sunxi-common.h
 --- a/include/configs/sunxi-common.h
 +++ b/include/configs/sunxi-common.h
-@@ -438,12 +438,12 @@
-
- #ifdef CONFIG_VIDEO
- #define CONSOLE_STDOUT_SETTINGS \
--	"stdout=serial,vga\0" \
--	"stderr=serial,vga\0"
-+	"stdout=serial\0" \
-+	"stderr=serial\0"
- #elif CONFIG_DM_VIDEO
+@@ -418,8 +418,8 @@
+ 
+ #ifdef CONFIG_DM_VIDEO
  #define CONSOLE_STDOUT_SETTINGS \
 -	"stdout=serial,vidconsole\0" \
 -	"stderr=serial,vidconsole\0"


### PR DESCRIPTION
Updating patch to hide u-boot (latest version) on-screen tty on Allwinner Sunxi platform.