### PR TITLE
Fix incorrect dependency calculation.

### DIFF
--- a/lib/chroot-buildpackages.sh
+++ b/lib/chroot-buildpackages.sh
@@ -357,9 +357,8 @@ create_build_script ()
 
 	package_builddeps="$package_builddeps"
 	if [ -z "\$package_builddeps" ]; then
-		# Calculate build dependencies by a standard function and
-		# еxclude special comparison characters like "|" "(>= 9)"
-		package_builddeps="\$(dpkg-checkbuilddeps |& awk -F":" '{gsub(/[|]|[(].*[)]/, " ", \$0); print \$NF}')"
+		# Calculate build dependencies by a standard dpkg function
+		package_builddeps="\$(dpkg-checkbuilddeps |& awk -F":" '{print \$NF}')"
 	fi
 	if [[ -n "\${package_builddeps}" ]]; then
 		install_pkg_deb \${package_builddeps}


### PR DESCRIPTION
# Description
In the case when there are more than one pair of brackets,
the regular expression removes the names between the extreme
pair brackets. And dependencies cannot be installed.
Currently, the syntactic analysis of the resulting dependency
string is performed correctly by the installation function itself.
A regular expression is not needed here.

# Checklist:
- [x] Tested by building a new library package

