### PR TITLE
Add support for build all images to build train

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -20,6 +20,11 @@ on:
         description: Source repository
         required: true
         default: 'nightly'
+      advanced:
+        description: 'Advanced (| grep "board"'
+        required: false
+        default: '| grep ""'
+
 jobs:
 
   fake:

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -21,7 +21,7 @@ on:
         required: true
         default: 'nightly'
       advanced:
-        description: 'Advanced (grep board |)'
+        description: 'Single board (grep -w tinkerboard |)'
         required: false
         default: ''
 

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -111,7 +111,7 @@ jobs:
       SSH_KEY_TORRENTS: ${{ secrets.KEY_TORRENTS }}
       KNOWN_HOSTS_UPLOAD: ${{ secrets.KNOWN_HOSTS_UPLOAD }}
 
-  cli:
+  cli1:
     needs: [ merge ]
     uses: armbian/scripts/.github/workflows/build-with-docker.yml@master
 
@@ -121,7 +121,7 @@ jobs:
       sourcerepo: '${{ github.event.inputs.sourcerepo }}'
       runner: '${{ github.event.inputs.runner }}'
       part: 1
-      of: 1
+      of: 2
       include: ''
       exclude: 'grep -v uefi-x86 | '
       uploading: false
@@ -136,7 +136,31 @@ jobs:
       KNOWN_HOSTS_UPLOAD: ${{ secrets.KNOWN_HOSTS_UPLOAD }}
 
 
-  desktop:
+  cli2:
+    needs: [ merge ]
+    uses: armbian/scripts/.github/workflows/build-with-docker.yml@master
+
+    with:
+
+      variant: 'cli:${{ github.event.inputs.choice }}'
+      sourcerepo: '${{ github.event.inputs.sourcerepo }}'
+      runner: '${{ github.event.inputs.runner }}'
+      part: 2
+      of: 2
+      include: ''
+      exclude: 'grep -v uefi-x86 | '
+      uploading: false
+
+    secrets:
+      GPG_KEY1: ${{ secrets.GPG_KEY1 }}
+      GPG_PASSPHRASE1: ${{ secrets.GPG_PASSPHRASE1 }}
+      GPG_KEY2: ${{ secrets.GPG_KEY2 }}
+      GPG_PASSPHRASE2: ${{ secrets.GPG_PASSPHRASE2 }}
+      SCRIPTS_ACCESS_TOKEN: ${{ secrets.SCRIPTS_ACCESS_TOKEN }}
+      SSH_KEY_TORRENTS: ${{ secrets.KEY_TORRENTS }}
+      KNOWN_HOSTS_UPLOAD: ${{ secrets.KNOWN_HOSTS_UPLOAD }}
+
+  desktop1:
     needs: [ merge ]
     uses: armbian/scripts/.github/workflows/build-with-docker.yml@master
 
@@ -145,7 +169,30 @@ jobs:
       sourcerepo: '${{ github.event.inputs.sourcerepo }}'
       runner: "big"
       part: 1
-      of: 1      
+      of: 2
+      include: ''
+      exclude: 'grep -v uefi-x86 | '
+      uploading: false
+
+    secrets:
+      GPG_KEY1: ${{ secrets.GPG_KEY1 }}
+      GPG_PASSPHRASE1: ${{ secrets.GPG_PASSPHRASE1 }}
+      GPG_KEY2: ${{ secrets.GPG_KEY2 }}
+      GPG_PASSPHRASE2: ${{ secrets.GPG_PASSPHRASE2 }}
+      SCRIPTS_ACCESS_TOKEN: ${{ secrets.SCRIPTS_ACCESS_TOKEN }}
+      SSH_KEY_TORRENTS: ${{ secrets.KEY_TORRENTS }}
+      KNOWN_HOSTS_UPLOAD: ${{ secrets.KNOWN_HOSTS_UPLOAD }}
+
+  desktop2:
+    needs: [ merge ]
+    uses: armbian/scripts/.github/workflows/build-with-docker.yml@master
+
+    with:
+      variant: 'desktop:${{ github.event.inputs.choice }}'
+      sourcerepo: '${{ github.event.inputs.sourcerepo }}'
+      runner: "big"
+      part: 2
+      of: 2
       include: ''
       exclude: 'grep -v uefi-x86 | '
       uploading: false
@@ -161,7 +208,7 @@ jobs:
 
   jobsend:
     name: finish
-    needs: [x86,x86-desktop,cli,desktop]
+    needs: [x86,x86-desktop,cli1,desktop1,cli2,desktop2]
     runs-on: [ubuntu-latest]
     if: ${{ github.repository_owner == 'Armbian' }}
     steps:

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -79,7 +79,7 @@ jobs:
       runner: '${{ github.event.inputs.runner }}'
       part: 1
       of: 1
-      include: 'grep uefi-x86 | '
+      include: 'grep uefi-x86 | ${{ github.event.inputs.advanced }}'
       exclude: ''
       uploading: false
 
@@ -103,7 +103,7 @@ jobs:
       runner: "big"
       part: 1
       of: 1
-      include: 'grep uefi-x86 | '
+      include: 'grep uefi-x86 | ${{ github.event.inputs.advanced }}'
       exclude: ''
       uploading: false
 
@@ -127,7 +127,7 @@ jobs:
       runner: '${{ github.event.inputs.runner }}'
       part: 1
       of: 2
-      include: ''
+      include: '${{ github.event.inputs.advanced }}'
       exclude: 'grep -v uefi-x86 | '
       uploading: false
 
@@ -152,7 +152,7 @@ jobs:
       runner: '${{ github.event.inputs.runner }}'
       part: 2
       of: 2
-      include: ''
+      include: '${{ github.event.inputs.advanced }}'
       exclude: 'grep -v uefi-x86 | '
       uploading: false
 
@@ -175,7 +175,7 @@ jobs:
       runner: "big"
       part: 1
       of: 2
-      include: ''
+      include: '${{ github.event.inputs.advanced }}'
       exclude: 'grep -v uefi-x86 | '
       uploading: false
 
@@ -198,7 +198,7 @@ jobs:
       runner: "big"
       part: 2
       of: 2
-      include: ''
+      include: '${{ github.event.inputs.advanced }}'
       exclude: 'grep -v uefi-x86 | '
       uploading: false
 

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -21,9 +21,9 @@ on:
         required: true
         default: 'nightly'
       advanced:
-        description: 'Advanced (| grep "board"'
+        description: 'Advanced (grep board |)'
         required: false
-        default: '| grep ""'
+        default: ''
 
 jobs:
 

--- a/.github/workflows/build-train.yml
+++ b/.github/workflows/build-train.yml
@@ -101,6 +101,7 @@ jobs:
 
     with:
       reference: '${{ github.event.inputs.sourcerepo }}'
+      uploading: true
       runner: small
 
     secrets:

--- a/.github/workflows/build-train.yml
+++ b/.github/workflows/build-train.yml
@@ -2,6 +2,11 @@ name: Build train
 
 on:
   workflow_dispatch:
+    inputs:
+      sourcerepo:
+        description: Source repository
+        required: true
+        default: 'nightly'
   push:
     branches:
       - master
@@ -55,7 +60,7 @@ jobs:
     uses: armbian/scripts/.github/workflows/check-for-changes.yml@master
 
     with:
-      reference: nightly
+      reference: '${{ github.event.inputs.sourcerepo }}'
       runner: small
 
   ##########################################################################################
@@ -72,7 +77,7 @@ jobs:
     with:
       uploading: true
       runner: fast
-      reference: nightly
+      reference: '${{ github.event.inputs.sourcerepo }}'
 
     secrets:
       GPG_KEY1: ${{ secrets.GPG_KEY1 }}
@@ -95,7 +100,7 @@ jobs:
     uses: armbian/scripts/.github/workflows/build-firmware.yml@master
 
     with:
-      reference: nightly
+      reference: '${{ github.event.inputs.sourcerepo }}'
       runner: small
 
     secrets:
@@ -143,7 +148,7 @@ jobs:
       include: 'grep legacy | '
       exclude: ''
       uploading: false
-      destref: 'nightly'
+      destref: '${{ github.event.inputs.sourcerepo }}'
 
     secrets:
       GPG_KEY1: ${{ secrets.GPG_KEY1 }}
@@ -165,7 +170,7 @@ jobs:
       include: 'grep current | '
       exclude: ''
       uploading: false
-      destref: 'nightly'
+      destref: '${{ github.event.inputs.sourcerepo }}'
 
     secrets:
       GPG_KEY1: ${{ secrets.GPG_KEY1 }}
@@ -188,7 +193,7 @@ jobs:
       include: 'grep edge | '
       exclude: ''
       uploading: false
-      destref: 'nightly'
+      destref: '${{ github.event.inputs.sourcerepo }}'
 
     secrets:
       GPG_KEY1: ${{ secrets.GPG_KEY1 }}
@@ -282,7 +287,7 @@ jobs:
 
       variant: 'cli:beta'
       runner: "small"
-      sourcerepo: 'nightly'
+      sourcerepo: '${{ github.event.inputs.sourcerepo }}'
       part: 1
       of: 1
       include: 'grep uefi-x86 | '
@@ -312,7 +317,7 @@ jobs:
 
       variant: 'desktop:beta'
       runner: "big"
-      sourcerepo: 'nightly'
+      sourcerepo: '${{ github.event.inputs.sourcerepo }}'
       part: 1
       of: 1
       include: 'grep uefi-x86 | '
@@ -342,7 +347,7 @@ jobs:
 
       variant: 'cli:beta'
       runner: "small"
-      sourcerepo: 'nightly'
+      sourcerepo: '${{ github.event.inputs.sourcerepo }}'
       part: 1
       of: 1
       include: ''
@@ -371,7 +376,7 @@ jobs:
     with:
       variant: 'desktop:beta'
       runner: "big"
-      sourcerepo: 'nightly'
+      sourcerepo: '${{ github.event.inputs.sourcerepo }}'
       part: 1
       of: 1
       include: ''

--- a/.github/workflows/build-train.yml
+++ b/.github/workflows/build-train.yml
@@ -121,6 +121,7 @@ jobs:
     with:
       uploading: true
       runner: small
+      reference: '${{ github.event.inputs.sourcerepo }}'
 
     secrets:
       GPG_KEY1: ${{ secrets.GPG_KEY1 }}

--- a/.github/workflows/build-train.yml
+++ b/.github/workflows/build-train.yml
@@ -19,7 +19,7 @@ jobs:
   #                                                                                        #
   ##########################################################################################
 
-  Cancel:
+  Cancel:    
     if: ${{ github.repository_owner == 'Armbian' }}
     runs-on: small
     steps:
@@ -211,9 +211,17 @@ jobs:
   #                         Store build hashes for future comparission                     #
   #                                                                                        #
   ##########################################################################################
+  
+  Deploycheck:
+    needs: [Kernel,Desktop,Firmware,legacy,current,edge]
+    if: ${{ inputs.sourcerepo != 'nightly' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Early exit
+        run: exit_with_success
 
   Deploy:
-    needs: [Kernel,Desktop,Firmware,legacy,current,edge]
+    needs: [Deploycheck]
     if: ${{ success() && github.repository_owner == 'Armbian' }}
     uses: armbian/scripts/.github/workflows/deploy.yml@master
 


### PR DESCRIPTION
# Description

Current changes fixes a problem when we need to go over the matrix limit (256 jobs per workflow run). It cuts jobs down to two, but this number can be adjusted if we would need to build thousands of images at once. Another fix is generating images for stable, rc and nightly scenarios and as well as re-generating images for particular board only. Or some other custom condition on the build list. 

# How Has This Been Tested?

- [x] Generating stable images
- [x] Generating rc images
- [x] Generating nighly images
- [x] Generating one board images

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
