### PR TITLE
rockchip: enable rkbin-tools extension for whole soc family

### DIFF
--- a/config/sources/families/rockchip.conf
+++ b/config/sources/families/rockchip.conf
@@ -1,3 +1,4 @@
+enable_extension "rkbin-tools"
 ARCH=armhf
 BOOTSCRIPT="boot-rockchip.cmd:boot.cmd"
 BOOTENV_FILE='rockchip.txt'


### PR DESCRIPTION
# Description

as per subject, rkbin-tools is required for some rockchip targets (notably xt-q8l-v10) and extension has not been enabled yet.
This PR enables the extension.

Jira reference number [AR-1189]

# How Has This Been Tested?

- [ ] U-boot and kernel deb packages have been compiled

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
