### PR TITLE
add compatibility with old u-boot environment

### DIFF
--- a/config/bootscripts/boot-espressobin.cmd
+++ b/config/bootscripts/boot-espressobin.cmd
@@ -48,4 +48,4 @@ ext4load $devtype ${devnum}:1 $ramdisk_addr_r ${prefix}$initrd_image
 ext4load $devtype ${devnum}:1 $fdt_addr_r ${prefix}$fdt_name
 
 booti $kernel_addr_r $ramdisk_addr_r $fdt_addr_r
-# mkimage -C none -A arm -T script -d /boot/boot.cmd /boot/boot.scr.uimg
+# mkimage -C none -A arm -T script -d /boot/boot.cmd /boot/boot.scr

--- a/config/bootscripts/boot-espressobin.cmd
+++ b/config/bootscripts/boot-espressobin.cmd
@@ -3,6 +3,23 @@
 # Please edit /boot/armbianEnv.txt to set supported parameters
 #
 
+# Some tests to try to keep compatibility with old variables
+if test -z "${kernel_addr_r}"; then
+  setenv kernel_addr_r $kernel_addr
+fi
+if test -z "${ramdisk_addr_r}"; then
+  setenv ramdisk_addr_r $initrd_addr
+fi
+if test -z "${fdt_addr_r}"; then
+  setenv fdt_addr_r $fdt_addr
+fi
+if test -z "${distro_bootpart}"; then
+  setenv distro_bootpart 1
+fi
+if test -z "${devtype}"; then
+  setenv devtype $boot_interface
+fi
+
 load ${devtype} ${devnum}:${distro_bootpart} ${scriptaddr} ${prefix}armbianEnv.txt
 env import -t ${scriptaddr} ${filesize}
 
@@ -12,4 +29,23 @@ load $devtype ${devnum}:${distro_bootpart} $ramdisk_addr_r ${prefix}espressobin.
 
 bootm ${ramdisk_addr_r}#$board_version
 
+# fallback to non-FIT image
+if test -z "${image_name}"; then
+  setenv image_name "Image"
+fi
+if test -z "${initrd_image}"; then
+  setenv initrd_image "uInitrd"
+fi
+if test -z "${fdt_name}"; then
+  if test -z "${fdtfile}"; then
+    setenv fdt_name "dtb/marvell/armada-3720-espressobin.dtb"
+  else
+    setenv fdt_name "dtb/$fdtfile"
+  fi
+fi
+ext4load $devtype ${devnum}:1 $kernel_addr_r ${prefix}$image_name
+ext4load $devtype ${devnum}:1 $ramdisk_addr_r ${prefix}$initrd_image
+ext4load $devtype ${devnum}:1 $fdt_addr_r ${prefix}$fdt_name
+
+booti $kernel_addr_r $ramdisk_addr_r $fdt_addr_r
 # mkimage -C none -A arm -T script -d /boot/boot.cmd /boot/boot.scr.uimg

--- a/config/sources/families/mvebu64.conf
+++ b/config/sources/families/mvebu64.conf
@@ -2,7 +2,7 @@ enable_extension "marvell-tools"
 ARCH=arm64
 BOOTBRANCH='branch:v2022.04'
 BOOTENV_FILE='mvebu64.txt'
-BOOTSCRIPT_OUTPUT='boot.scr.uimg'
+BOOTSCRIPT_OUTPUT='boot.scr'
 ATFSOURCE='https://git.trustedfirmware.org/TF-A/trusted-firmware-a.git'
 ATFDIR='arm-trusted-firmware-espressobin'
 ATFBRANCH='branch:master'


### PR DESCRIPTION
# Description

Make compatibility changes to remove the need to update u-boot environment
Jira reference number [AR-1191]

# How Has This Been Tested?

- [x] Boot with this revision of the boot script on new u-boot environment
- [x] Boot with this revision of the boot script on old u-boot environment




[AR-1191]: https://armbian.atlassian.net/browse/AR-1191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ