### PR TITLE
Set ATF to fixed last known working commit id

### DIFF
--- a/config/sources/arm64.conf
+++ b/config/sources/arm64.conf
@@ -36,7 +36,7 @@ fi
 
 [[ $ATF_COMPILE != "no" && -z $ATFSOURCE ]] && ATFSOURCE='https://github.com/ARM-software/arm-trusted-firmware'
 [[ $ATF_COMPILE != "no" && -z $ATFDIR ]] && ATFDIR='arm-trusted-firmware-sunxi-mainline'
-[[ $ATF_COMPILE != "no" && -z $ATFBRANCH ]] && ATFBRANCH='branch:master'
+[[ $ATF_COMPILE != "no" && -z $ATFBRANCH ]] && ATFBRANCH='commit:af220ebbe467aa580e6b9ba554676f78ffec930f'
 [[ $ATF_COMPILE != "no" && -z $ATF_USE_GCC ]] && ATF_USE_GCC='> 8.0'
 
 [[ -z $UBOOT_USE_GCC ]]	&& UBOOT_USE_GCC='> 8.0'


### PR DESCRIPTION
# Description

After they are breaking for (probably) whole Allwinner. For making a release this is anyway a proper direction. Will check later where exactly is breaking.

Jira reference number [AR-1192]

# How Has This Been Tested?

- [x] Build Nanopi Neo2 u-boot
- [x] Build Orangepi PC2 u-boot

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1192]: https://armbian.atlassian.net/browse/AR-1192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ