### PR TITLE
Honor $DEB_COMPRESS on kernels 5.3+

### DIFF
--- a/patch/misc/general-packaging-5.3.y.patch
+++ b/patch/misc/general-packaging-5.3.y.patch
@@ -1,19 +1,19 @@
-From f0c6ececf4ecf8407c96af709dc96f959299ee56 Mon Sep 17 00:00:00 2001
+From 87395a5fca108473ae5b4124fe1611d0493701ac Mon Sep 17 00:00:00 2001
 From: The-going <48602507+The-going@users.noreply.github.com>
 Date: Tue, 10 Mar 2020 17:16:41 +0300
 Subject: [PATCH] general packaging 5.3.y
 
 ---
  arch/arm64/Makefile      |   2 +-
- scripts/package/builddeb | 122 ++++++++++++++++++++++++++++++++++++++++++++---
- scripts/package/mkdebian |  15 ++++--
- 3 files changed, 128 insertions(+), 11 deletions(-)
+ scripts/package/builddeb | 116 ++++++++++++++++++++++++++++++++++++---
+ scripts/package/mkdebian |  15 ++++-
+ 3 files changed, 121 insertions(+), 12 deletions(-)
 
 diff --git a/arch/arm64/Makefile b/arch/arm64/Makefile
-index 5858d6e44926..e81b8a6fcc21 100644
+index d227cf87c..2ccca81a1 100644
 --- a/arch/arm64/Makefile
 +++ b/arch/arm64/Makefile
-@@ -142,7 +142,7 @@ core-$(CONFIG_EFI_STUB) += $(objtree)/drivers/firmware/efi/libstub/lib.a
+@@ -133,7 +133,7 @@ core-$(CONFIG_EFI_STUB) += $(objtree)/drivers/firmware/efi/libstub/lib.a
  
  # Default target when executing plain make
  boot		:= arch/arm64/boot
@@ -23,10 +23,10 @@ index 5858d6e44926..e81b8a6fcc21 100644
  all:	Image.gz
  
 diff --git a/scripts/package/builddeb b/scripts/package/builddeb
-index c4c580f547ef..2be8a687f878 100755
+index c4c580f54..3d10f513d 100755
 --- a/scripts/package/builddeb
 +++ b/scripts/package/builddeb
-@@ -41,6 +41,44 @@ create_package() {
+@@ -41,9 +41,47 @@ create_package() {
  	# in case we are in a restrictive umask environment like 0077
  	chmod -R a+rX "$pdir"
  
@@ -70,8 +70,12 @@ index c4c580f547ef..2be8a687f878 100755
 +
  	# Create the package
  	dpkg-gencontrol -p$pname -P"$pdir"
- 	dpkg --build "$pdir" ..
-@@ -51,9 +88,11 @@ tmpdir="$objtree/debian/tmp"
+-	dpkg --build "$pdir" ..
++	dpkg-deb ${KDEB_COMPRESS:+-Z$KDEB_COMPRESS} --build "$pdir" ..
+ }
+ 
+ version=$KERNELRELEASE
+@@ -51,9 +89,11 @@ tmpdir="$objtree/debian/tmp"
  kernel_headers_dir="$objtree/debian/hdrtmp"
  libc_headers_dir="$objtree/debian/headertmp"
  dbg_dir="$objtree/debian/dbgtmp"
@@ -86,7 +90,7 @@ index c4c580f547ef..2be8a687f878 100755
  dbg_packagename=$packagename-dbg
  
  if [ "$ARCH" = "um" ] ; then
-@@ -64,6 +103,15 @@ fi
+@@ -64,6 +104,15 @@ fi
  # XXX: have each arch Makefile export a variable of the canonical image install
  # path instead
  case $ARCH in
@@ -102,7 +106,7 @@ index c4c580f547ef..2be8a687f878 100755
  um)
  	installed_image_path="usr/bin/linux-$version"
  	;;
-@@ -77,7 +125,9 @@ esac
+@@ -77,7 +126,9 @@ esac
  BUILD_DEBUG=$(if_enabled_echo CONFIG_DEBUG_INFO Yes)
  
  # Setup the directory structure
@@ -113,7 +117,7 @@ index c4c580f547ef..2be8a687f878 100755
  mkdir -m 755 -p "$tmpdir/DEBIAN"
  mkdir -p "$tmpdir/lib" "$tmpdir/boot"
  mkdir -p "$kernel_headers_dir/lib/modules/$version/"
-@@ -129,6 +179,11 @@ if is_enabled CONFIG_MODULES; then
+@@ -129,6 +180,11 @@ if is_enabled CONFIG_MODULES; then
  	fi
  fi
  
@@ -125,7 +129,7 @@ index c4c580f547ef..2be8a687f878 100755
  if [ "$ARCH" != "um" ]; then
  	$MAKE -f $srctree/Makefile headers
  	$MAKE -f $srctree/Makefile headers_install INSTALL_HDR_PATH="$libc_headers_dir/usr"
-@@ -148,7 +203,7 @@ debhookdir=${KDEB_HOOKDIR:-/etc/kernel}
+@@ -148,7 +204,7 @@ debhookdir=${KDEB_HOOKDIR:-/etc/kernel}
  for script in postinst postrm preinst prerm ; do
  	mkdir -p "$tmpdir$debhookdir/$script.d"
  	cat <<EOF > "$tmpdir/DEBIAN/$script"
@@ -134,7 +138,7 @@ index c4c580f547ef..2be8a687f878 100755
  
  set -e
  
-@@ -164,9 +219,49 @@ EOF
+@@ -164,9 +220,49 @@ EOF
  	chmod 755 "$tmpdir/DEBIAN/$script"
  done
  
@@ -184,7 +188,7 @@ index c4c580f547ef..2be8a687f878 100755
  (cd $srctree; find arch/$SRCARCH -name module.lds -o -name Kbuild.platforms -o -name Platform) >> "$objtree/debian/hdrsrcfiles"
  (cd $srctree; find $(find arch/$SRCARCH -name include -o -name scripts -type d) -type f) >> "$objtree/debian/hdrsrcfiles"
  if is_enabled CONFIG_STACK_VALIDATION; then
-@@ -178,15 +282,19 @@ if is_enabled CONFIG_GCC_PLUGINS; then
+@@ -178,15 +274,19 @@ if is_enabled CONFIG_GCC_PLUGINS; then
  fi
  destdir=$kernel_headers_dir/usr/src/linux-headers-$version
  mkdir -p "$destdir"
@@ -207,7 +211,7 @@ index c4c580f547ef..2be8a687f878 100755
  
  create_package "$packagename" "$tmpdir"
 diff --git a/scripts/package/mkdebian b/scripts/package/mkdebian
-index e0750b70453f..f6f1a7c09ce7 100755
+index 357dc56bc..602e709bc 100755
 --- a/scripts/package/mkdebian
 +++ b/scripts/package/mkdebian
 @@ -94,10 +94,13 @@ else
@@ -254,5 +258,5 @@ index e0750b70453f..f6f1a7c09ce7 100755
  
  cat <<EOF > debian/rules
 -- 
-2.16.4
+2.34.1
 


### PR DESCRIPTION
# Description

This partially fixes #3762 if `DEB_COMPRESS=xz` is used.

Jira reference number [AR-1194]

# How Has This Been Tested?

- [x] Installed created packages on an Odroid HC1 running Debian bullseye
- [x] Ran `./compile REPOSITORY_UPDATE="update"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1194]: https://armbian.atlassian.net/browse/AR-1194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ