### PR TITLE
Sunxi 5.15

### DIFF
--- a/patch/kernel/archive/sunxi-5.15/series.armbian
+++ b/patch/kernel/archive/sunxi-5.15/series.armbian
@@ -181,5 +181,19 @@
 	patches.armbian/arm-dts-sun8i-h3-orangepi-pc-plus-add-wifi_pwrseq.patch
 	patches.armbian/arm64-dts-sun50i-h5-orangepi-prime-add-rtl8723cs.patch
 	patches.armbian/arm-dts-sun8i-h2-plus-orangepi-zero-fix-xradio-inter.patch
-	patches.armbian/drv-mtd-nand-disable-badblock-check-for-migration.patch
 	patches.armbian/Fix-duplicate-nodes-for-sun50i-h5-orangepi-pc2.patch
+
+	patches.armbian/0001-move-sun50i-h6-pwm-settings-to-its-own-overlay.patch
+	patches.armbian/0002-compile-the-pwm-overlay.patch
+	patches.armbian/0003-add-dump_reg-and-sunxi-sysinfo-drivers.patch
+	patches.armbian/0004-add-sunxi-addr-driver-used-to-fix-uwe5622-bluetooth-.patch
+	patches.armbian/0005-net-phy-support-yt8531c.patch
+	patches.armbian/0007-wireless-add-uwe5622-driver.patch
+	patches.armbian/0008-uwe5622-bluetooth-fix-firmware-init-fail.patch
+	patches.armbian/0009-allwinner-h6-support-ac200-audio-codec.patch
+	patches.armbian/0010-allwinner-add-sunxi_get_soc_chipid-and-sunxi_get_ser.patch
+	patches.armbian/0011-add-initial-support-for-orangepi3-lts.patch
+	patches.armbian/0012-fix-h6-emmc.patch
+	patches.armbian/0013-x-fix-h6-emmc-dts.patch
+	patches.armbian/0014-add-uwe-bsp-to-orangepi3-lts-dts-file.patch
+	patches.armbian/999-rollback-rsb.patch

--- a/patch/kernel/archive/sunxi-5.15/series.conf
+++ b/patch/kernel/archive/sunxi-5.15/series.conf
@@ -657,6 +657,7 @@
 	patches.armbian/arm-dts-sun8i-h3-orangepi-pc-plus-add-wifi_pwrseq.patch
 	patches.armbian/arm64-dts-sun50i-h5-orangepi-prime-add-rtl8723cs.patch
 	patches.armbian/arm-dts-sun8i-h2-plus-orangepi-zero-fix-xradio-inter.patch
+	patches.armbian/Fix-duplicate-nodes-for-sun50i-h5-orangepi-pc2.patch
 
 	patches.armbian/0001-move-sun50i-h6-pwm-settings-to-its-own-overlay.patch
 	patches.armbian/0002-compile-the-pwm-overlay.patch


### PR DESCRIPTION
# Description

fix: Fix duplicate nodes for sun50i-h5-orangepi-pc2 board

The patch must be registered in the series.conf file

# Checklist:
- [ ] Test on board

