### PR TITLE
WaveShare Touchscreen Driver Fix (Odroid) "disable_vu7"

### DIFF
--- a/config/bootscripts/boot-meson64.cmd
+++ b/config/bootscripts/boot-meson64.cmd
@@ -129,8 +129,9 @@ else
 	if test "${console}" = "display" || test "${console}" = "both"; then setenv consoleargs "console=ttyAML0,115200 console=tty1"; fi
 	if test "${console}" = "serial"; then setenv consoleargs "console=ttyAML0,115200"; fi
 	if test "${bootlogo}" = "true"; then setenv consoleargs "bootsplash.bootfile=bootsplash.armbian ${consoleargs}"; fi
+	if test "${disable_vu7}" = "false"; then setenv usbhidquirks "usbhid.quirks=0x0eef:0x0005:0x0004"; fi
 
-	setenv bootargs "root=${rootdev} rootwait rootfstype=${rootfstype} ${consoleargs} consoleblank=0 coherent_pool=2M loglevel=${verbosity} ubootpart=${partuuid} libata.force=noncq usb-storage.quirks=${usbstoragequirks} ${extraargs} ${extraboardargs}"
+	setenv bootargs "root=${rootdev} rootwait rootfstype=${rootfstype} ${consoleargs} consoleblank=0 coherent_pool=2M loglevel=${verbosity} ubootpart=${partuuid} libata.force=noncq usb-storage.quirks=${usbstoragequirks} ${usbhidquirks} ${extraargs} ${extraboardargs}"
 	if test "${docker_optimizations}" = "on"; then setenv bootargs "${bootargs} cgroup_enable=memory swapaccount=1"; fi
 	echo "Mainline bootargs: ${bootargs}"
 

--- a/patch/kernel/archive/meson64-5.10/hardkernel-0015-COMMON-input-touchscreen-Add-D-WAV-Multitouch.patch
+++ b/patch/kernel/archive/meson64-5.10/hardkernel-0015-COMMON-input-touchscreen-Add-D-WAV-Multitouch.patch
@@ -7,11 +7,11 @@ Subject: [PATCH 15/74] ODROID-COMMON: input/touchscreen: Add D-WAV Multitouch
 Change-Id: Ia1c8c29d3f69c6ba5d630279c4cc98119b68ab71
 ---
  drivers/hid/hid-ids.h                   |   6 +
- drivers/hid/hid-quirks.c                |   4 +
+ drivers/hid/hid-quirks.c                |   3 +
  drivers/input/touchscreen/Kconfig       |  10 +
  drivers/input/touchscreen/Makefile      |   1 +
  drivers/input/touchscreen/dwav-usb-mt.c | 554 ++++++++++++++++++++++++
- 5 files changed, 575 insertions(+)
+ 5 files changed, 574 insertions(+)
  create mode 100644 drivers/input/touchscreen/dwav-usb-mt.c
 
 diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
@@ -33,12 +33,11 @@ diff --git a/drivers/hid/hid-quirks.c b/drivers/hid/hid-quirks.c
 index 934fc0a798d4..9cf96f48238e 100644
 --- a/drivers/hid/hid-quirks.c
 +++ b/drivers/hid/hid-quirks.c
-@@ -845,6 +845,10 @@ static const struct hid_device_id hid_ignore_list[] = {
+@@ -845,6 +845,9 @@ static const struct hid_device_id hid_ignore_list[] = {
  	{ HID_USB_DEVICE(USB_VENDOR_ID_SYNAPTICS, USB_DEVICE_ID_SYNAPTICS_DPAD) },
  #endif
  	{ HID_USB_DEVICE(USB_VENDOR_ID_YEALINK, USB_DEVICE_ID_YEALINK_P1K_P4K_B2K) },
 +
-+	{ HID_USB_DEVICE(USB_VENDOR_ID_DWAV, USB_DEVICE_ID_DWAV_MULTITOUCH) },
 +	{ HID_USB_DEVICE(USB_VENDOR_ID_ODROID, USB_DEVICE_ID_VU5) },
 +	{ HID_USB_DEVICE(USB_VENDOR_ID_ODROID, USB_DEVICE_ID_VU7PLUS) },
  	{ }

--- a/patch/kernel/archive/meson64-5.11/hardkernel-0015-COMMON-input-touchscreen-Add-D-WAV-Multitouch.patch
+++ b/patch/kernel/archive/meson64-5.11/hardkernel-0015-COMMON-input-touchscreen-Add-D-WAV-Multitouch.patch
@@ -7,11 +7,11 @@ Subject: [PATCH 15/74] ODROID-COMMON: input/touchscreen: Add D-WAV Multitouch
 Change-Id: Ia1c8c29d3f69c6ba5d630279c4cc98119b68ab71
 ---
  drivers/hid/hid-ids.h                   |   6 +
- drivers/hid/hid-quirks.c                |   4 +
+ drivers/hid/hid-quirks.c                |   3 +
  drivers/input/touchscreen/Kconfig       |  10 +
  drivers/input/touchscreen/Makefile      |   1 +
  drivers/input/touchscreen/dwav-usb-mt.c | 554 ++++++++++++++++++++++++
- 5 files changed, 575 insertions(+)
+ 5 files changed, 574 insertions(+)
  create mode 100644 drivers/input/touchscreen/dwav-usb-mt.c
 
 diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
@@ -33,12 +33,11 @@ diff --git a/drivers/hid/hid-quirks.c b/drivers/hid/hid-quirks.c
 index 934fc0a798d4..9cf96f48238e 100644
 --- a/drivers/hid/hid-quirks.c
 +++ b/drivers/hid/hid-quirks.c
-@@ -845,6 +845,10 @@ static const struct hid_device_id hid_ignore_list[] = {
+@@ -845,6 +845,9 @@ static const struct hid_device_id hid_ignore_list[] = {
  	{ HID_USB_DEVICE(USB_VENDOR_ID_SYNAPTICS, USB_DEVICE_ID_SYNAPTICS_DPAD) },
  #endif
  	{ HID_USB_DEVICE(USB_VENDOR_ID_YEALINK, USB_DEVICE_ID_YEALINK_P1K_P4K_B2K) },
 +
-+	{ HID_USB_DEVICE(USB_VENDOR_ID_DWAV, USB_DEVICE_ID_DWAV_MULTITOUCH) },
 +	{ HID_USB_DEVICE(USB_VENDOR_ID_ODROID, USB_DEVICE_ID_VU5) },
 +	{ HID_USB_DEVICE(USB_VENDOR_ID_ODROID, USB_DEVICE_ID_VU7PLUS) },
  	{ }

--- a/patch/kernel/archive/meson64-5.12/hardkernel-0015-COMMON-input-touchscreen-Add-D-WAV-Multitouch.patch
+++ b/patch/kernel/archive/meson64-5.12/hardkernel-0015-COMMON-input-touchscreen-Add-D-WAV-Multitouch.patch
@@ -7,11 +7,11 @@ Subject: [PATCH 15/74] ODROID-COMMON: input/touchscreen: Add D-WAV Multitouch
 Change-Id: Ia1c8c29d3f69c6ba5d630279c4cc98119b68ab71
 ---
  drivers/hid/hid-ids.h                   |   6 +
- drivers/hid/hid-quirks.c                |   4 +
+ drivers/hid/hid-quirks.c                |   3 +
  drivers/input/touchscreen/Kconfig       |  10 +
  drivers/input/touchscreen/Makefile      |   1 +
  drivers/input/touchscreen/dwav-usb-mt.c | 554 ++++++++++++++++++++++++
- 5 files changed, 575 insertions(+)
+ 5 files changed, 574 insertions(+)
  create mode 100644 drivers/input/touchscreen/dwav-usb-mt.c
 
 diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
@@ -33,12 +33,11 @@ diff --git a/drivers/hid/hid-quirks.c b/drivers/hid/hid-quirks.c
 index 934fc0a798d4..9cf96f48238e 100644
 --- a/drivers/hid/hid-quirks.c
 +++ b/drivers/hid/hid-quirks.c
-@@ -845,6 +845,10 @@ static const struct hid_device_id hid_ignore_list[] = {
+@@ -845,6 +845,9 @@ static const struct hid_device_id hid_ignore_list[] = {
  	{ HID_USB_DEVICE(USB_VENDOR_ID_SYNAPTICS, USB_DEVICE_ID_SYNAPTICS_DPAD) },
  #endif
  	{ HID_USB_DEVICE(USB_VENDOR_ID_YEALINK, USB_DEVICE_ID_YEALINK_P1K_P4K_B2K) },
 +
-+	{ HID_USB_DEVICE(USB_VENDOR_ID_DWAV, USB_DEVICE_ID_DWAV_MULTITOUCH) },
 +	{ HID_USB_DEVICE(USB_VENDOR_ID_ODROID, USB_DEVICE_ID_VU5) },
 +	{ HID_USB_DEVICE(USB_VENDOR_ID_ODROID, USB_DEVICE_ID_VU7PLUS) },
  	{ }

--- a/patch/kernel/archive/meson64-5.13/hardkernel-0015-COMMON-input-touchscreen-Add-D-WAV-Multitouch.patch
+++ b/patch/kernel/archive/meson64-5.13/hardkernel-0015-COMMON-input-touchscreen-Add-D-WAV-Multitouch.patch
@@ -7,11 +7,11 @@ Subject: [PATCH 15/74] ODROID-COMMON: input/touchscreen: Add D-WAV Multitouch
 Change-Id: Ia1c8c29d3f69c6ba5d630279c4cc98119b68ab71
 ---
  drivers/hid/hid-ids.h                   |   6 +
- drivers/hid/hid-quirks.c                |   4 +
+ drivers/hid/hid-quirks.c                |   3 +
  drivers/input/touchscreen/Kconfig       |  10 +
  drivers/input/touchscreen/Makefile      |   1 +
  drivers/input/touchscreen/dwav-usb-mt.c | 554 ++++++++++++++++++++++++
- 5 files changed, 575 insertions(+)
+ 5 files changed, 574 insertions(+)
  create mode 100644 drivers/input/touchscreen/dwav-usb-mt.c
 
 diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
@@ -33,12 +33,11 @@ diff --git a/drivers/hid/hid-quirks.c b/drivers/hid/hid-quirks.c
 index 934fc0a798d4..9cf96f48238e 100644
 --- a/drivers/hid/hid-quirks.c
 +++ b/drivers/hid/hid-quirks.c
-@@ -845,6 +845,10 @@ static const struct hid_device_id hid_ignore_list[] = {
+@@ -845,6 +845,9 @@ static const struct hid_device_id hid_ignore_list[] = {
  	{ HID_USB_DEVICE(USB_VENDOR_ID_SYNAPTICS, USB_DEVICE_ID_SYNAPTICS_DPAD) },
  #endif
  	{ HID_USB_DEVICE(USB_VENDOR_ID_YEALINK, USB_DEVICE_ID_YEALINK_P1K_P4K_B2K) },
 +
-+	{ HID_USB_DEVICE(USB_VENDOR_ID_DWAV, USB_DEVICE_ID_DWAV_MULTITOUCH) },
 +	{ HID_USB_DEVICE(USB_VENDOR_ID_ODROID, USB_DEVICE_ID_VU5) },
 +	{ HID_USB_DEVICE(USB_VENDOR_ID_ODROID, USB_DEVICE_ID_VU7PLUS) },
  	{ }

--- a/patch/kernel/archive/meson64-5.14/hardkernel-0015-COMMON-input-touchscreen-Add-D-WAV-Multitouch.patch
+++ b/patch/kernel/archive/meson64-5.14/hardkernel-0015-COMMON-input-touchscreen-Add-D-WAV-Multitouch.patch
@@ -7,11 +7,11 @@ Subject: [PATCH 15/74] ODROID-COMMON: input/touchscreen: Add D-WAV Multitouch
 Change-Id: Ia1c8c29d3f69c6ba5d630279c4cc98119b68ab71
 ---
  drivers/hid/hid-ids.h                   |   6 +
- drivers/hid/hid-quirks.c                |   4 +
+ drivers/hid/hid-quirks.c                |   3 +
  drivers/input/touchscreen/Kconfig       |  10 +
  drivers/input/touchscreen/Makefile      |   1 +
  drivers/input/touchscreen/dwav-usb-mt.c | 554 ++++++++++++++++++++++++
- 5 files changed, 575 insertions(+)
+ 5 files changed, 574 insertions(+)
  create mode 100644 drivers/input/touchscreen/dwav-usb-mt.c
 
 diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
@@ -33,12 +33,11 @@ diff --git a/drivers/hid/hid-quirks.c b/drivers/hid/hid-quirks.c
 index 934fc0a798d4..9cf96f48238e 100644
 --- a/drivers/hid/hid-quirks.c
 +++ b/drivers/hid/hid-quirks.c
-@@ -845,6 +845,10 @@ static const struct hid_device_id hid_ignore_list[] = {
+@@ -845,6 +845,9 @@ static const struct hid_device_id hid_ignore_list[] = {
  	{ HID_USB_DEVICE(USB_VENDOR_ID_SYNAPTICS, USB_DEVICE_ID_SYNAPTICS_DPAD) },
  #endif
  	{ HID_USB_DEVICE(USB_VENDOR_ID_YEALINK, USB_DEVICE_ID_YEALINK_P1K_P4K_B2K) },
 +
-+	{ HID_USB_DEVICE(USB_VENDOR_ID_DWAV, USB_DEVICE_ID_DWAV_MULTITOUCH) },
 +	{ HID_USB_DEVICE(USB_VENDOR_ID_ODROID, USB_DEVICE_ID_VU5) },
 +	{ HID_USB_DEVICE(USB_VENDOR_ID_ODROID, USB_DEVICE_ID_VU7PLUS) },
  	{ }

--- a/patch/kernel/archive/meson64-5.15/hardkernel-0015-COMMON-input-touchscreen-Add-D-WAV-Multitouch.patch
+++ b/patch/kernel/archive/meson64-5.15/hardkernel-0015-COMMON-input-touchscreen-Add-D-WAV-Multitouch.patch
@@ -7,11 +7,11 @@ Subject: [PATCH 15/74] ODROID-COMMON: input/touchscreen: Add D-WAV Multitouch
 Change-Id: Ia1c8c29d3f69c6ba5d630279c4cc98119b68ab71
 ---
  drivers/hid/hid-ids.h                   |   6 +
- drivers/hid/hid-quirks.c                |   4 +
+ drivers/hid/hid-quirks.c                |   3 +
  drivers/input/touchscreen/Kconfig       |  10 +
  drivers/input/touchscreen/Makefile      |   1 +
  drivers/input/touchscreen/dwav-usb-mt.c | 554 ++++++++++++++++++++++++
- 5 files changed, 575 insertions(+)
+ 5 files changed, 574 insertions(+)
  create mode 100644 drivers/input/touchscreen/dwav-usb-mt.c
 
 diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
@@ -33,12 +33,11 @@ diff --git a/drivers/hid/hid-quirks.c b/drivers/hid/hid-quirks.c
 index 934fc0a798d4..9cf96f48238e 100644
 --- a/drivers/hid/hid-quirks.c
 +++ b/drivers/hid/hid-quirks.c
-@@ -845,6 +845,10 @@ static const struct hid_device_id hid_ignore_list[] = {
+@@ -845,6 +845,9 @@ static const struct hid_device_id hid_ignore_list[] = {
  	{ HID_USB_DEVICE(USB_VENDOR_ID_SYNAPTICS, USB_DEVICE_ID_SYNAPTICS_DPAD) },
  #endif
  	{ HID_USB_DEVICE(USB_VENDOR_ID_YEALINK, USB_DEVICE_ID_YEALINK_P1K_P4K_B2K) },
 +
-+	{ HID_USB_DEVICE(USB_VENDOR_ID_DWAV, USB_DEVICE_ID_DWAV_MULTITOUCH) },
 +	{ HID_USB_DEVICE(USB_VENDOR_ID_ODROID, USB_DEVICE_ID_VU5) },
 +	{ HID_USB_DEVICE(USB_VENDOR_ID_ODROID, USB_DEVICE_ID_VU7PLUS) },
  	{ }

--- a/patch/kernel/archive/meson64-5.17/general-input-touchscreen-Add-D-WAV-Multitouch.patch
+++ b/patch/kernel/archive/meson64-5.17/general-input-touchscreen-Add-D-WAV-Multitouch.patch
@@ -7,11 +7,11 @@ Subject: [PATCH] ODROID-COMMON: input/touchscreen: Add D-WAV Multitouch
 Change-Id: Ia1c8c29d3f69c6ba5d630279c4cc98119b68ab71
 ---
  drivers/hid/hid-ids.h                   |   6 +
- drivers/hid/hid-quirks.c                |   4 +
+ drivers/hid/hid-quirks.c                |   3 +
  drivers/input/touchscreen/Kconfig       |  10 +
  drivers/input/touchscreen/Makefile      |   1 +
  drivers/input/touchscreen/dwav-usb-mt.c | 554 ++++++++++++++++++++++++
- 5 files changed, 575 insertions(+)
+ 5 files changed, 574 insertions(+)
  create mode 100644 drivers/input/touchscreen/dwav-usb-mt.c
 
 diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
@@ -33,12 +33,11 @@ diff --git a/drivers/hid/hid-quirks.c b/drivers/hid/hid-quirks.c
 index ee7e504e7279..4d876faea391 100644
 --- a/drivers/hid/hid-quirks.c
 +++ b/drivers/hid/hid-quirks.c
-@@ -863,6 +863,10 @@ static const struct hid_device_id hid_ignore_list[] = {
+@@ -863,6 +863,9 @@ static const struct hid_device_id hid_ignore_list[] = {
  	{ HID_USB_DEVICE(USB_VENDOR_ID_SYNAPTICS, USB_DEVICE_ID_SYNAPTICS_DPAD) },
  #endif
  	{ HID_USB_DEVICE(USB_VENDOR_ID_YEALINK, USB_DEVICE_ID_YEALINK_P1K_P4K_B2K) },
 +
-+	{ HID_USB_DEVICE(USB_VENDOR_ID_DWAV, USB_DEVICE_ID_DWAV_MULTITOUCH) },
 +	{ HID_USB_DEVICE(USB_VENDOR_ID_ODROID, USB_DEVICE_ID_VU5) },
 +	{ HID_USB_DEVICE(USB_VENDOR_ID_ODROID, USB_DEVICE_ID_VU7PLUS) },
  	{ }


### PR DESCRIPTION
WaveShare Touchscreen Driver Fix (Odroid)

# Description

A number of other WaveShare screens also use ID: 0eef:0005 and therefore the patch used to enforce the VU7 driver breaks these other screens. This was the purpose of the "disable_vu7" env boot param which correctly defaults to true. However, this is ignored in boot.cmd + the patches for the kernel reverse the changes made by Hardkernel to fix this problem. 

I have corrected the problem by removing 0eef:0005 from the driver enforced ignore_list and changed boot.cmd to allow the "disable_vu7" to function correctly (adding usbhid quirk when set to false).

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- Ran build of current kernel (meson 5.10) to test that changes are working as expected. They are. Touchscreen now works and is attached to the usbhid driver. 
- Can not test functionality of VU7 (do not have VU7) however I have created this patch from the fixes applied by Hardkernel. When updating "disable_vu7"=false the screen does not function correctly (as before) and is assigned dwav_usb_mt driver implying the changes to boot.cmd work correctly. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
