### PR TITLE
Add gcc-aarch64-linux-gnu into dockerfile

### DIFF
--- a/config/templates/Dockerfile
+++ b/config/templates/Dockerfile
@@ -50,6 +50,7 @@ RUN apt-get update \
        fakeroot \
        flex \
        gawk \
+       gcc-aarch64-linux-gnu \
        gcc-arm-linux-gnueabihf \
        gcc-arm-linux-gnueabi \
        gcc-arm-none-eabi \


### PR DESCRIPTION
Add gcc-aarch64-linux-gnu into dockerfile to make possible build in docker without external toolkit on x64 builder


