### PR TITLE
Disabling index compression seems to speed up apt search

### DIFF
--- a/packages/bsp/common/etc/apt/apt.conf.d/02-armbian-compress-indexes
+++ b/packages/bsp/common/etc/apt/apt.conf.d/02-armbian-compress-indexes
@@ -1,3 +1,3 @@
-Acquire::GzipIndexes "true";
+Acquire::GzipIndexes "false";
 Acquire::CompressionTypes::Order:: "gz";
 APT::Compressor::gzip::Cost "10";


### PR DESCRIPTION
# Description

Its an old issues and it looks like it helps:
https://forum.armbian.com/topic/14064-my-apt-search-has-become-super-slow-recently/page/2/

Jira reference number [AR-296]

# How Has This Been Tested?

Tested by community.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-296]: https://armbian.atlassian.net/browse/AR-296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ