### PR TITLE
Move helios64 to blobless u-boot

### DIFF
--- a/config/boards/helios64.csc
+++ b/config/boards/helios64.csc
@@ -2,6 +2,7 @@
 BOARD_NAME="Helios64"
 BOARDFAMILY="rk3399"
 BOOTCONFIG="helios64-rk3399_defconfig"
+BOOT_SCENARIO="blobless"
 KERNEL_TARGET="legacy,current,edge"
 MODULES="lm75 ledtrig-netdev"
 MODULES_LEGACY="lm75"


### PR DESCRIPTION
# Description
Change the board description for Helios64 to do a blobless u-boot.

Jira reference number [AR-9999]

# How Has This Been Tested?
- [x] Boots on Helios64 good image with newly flashed idbloader and u-boot.itb

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
