### PR TITLE
update atf to 2.6, and don't rename the elf to bin

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -120,7 +120,7 @@ prepare_boot_configuration() {
 		ATFBRANCH='tag:v2.6'
 		ATF_USE_GCC='> 6.3'
 		ATF_TARGET_MAP="M0_CROSS_COMPILE=arm-linux-gnueabi- PLAT=$BOOT_SOC bl31;;build/$BOOT_SOC/release/bl31/bl31.elf:bl31.elf"
-		ATF_TOOLCHAIN2="arm-linux-gnueabi-:> 5.0"
+		ATF_TOOLCHAIN2="arm-linux-gnueabi-:< 10.0"
 
 	elif [[ $BOOT_SCENARIO == "tpl-spl-blob" ]]; then
 

--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -113,13 +113,13 @@ esac
 prepare_boot_configuration() {
 	if [[ $BOOT_SCENARIO == "blobless" ]]; then
 
-		UBOOT_TARGET_MAP="BL31=bl31.bin idbloader.img u-boot.itb;;idbloader.img u-boot.itb"
+		UBOOT_TARGET_MAP="BL31=bl31.elf idbloader.img u-boot.itb;;idbloader.img u-boot.itb"
 		ATFSOURCE='https://github.com/ARM-software/arm-trusted-firmware'
 		ATF_COMPILER='aarch64-linux-gnu-'
 		ATFDIR='arm-trusted-firmware'
-		ATFBRANCH='tag:v2.5'
+		ATFBRANCH='tag:v2.6'
 		ATF_USE_GCC='> 6.3'
-		ATF_TARGET_MAP="M0_CROSS_COMPILE=arm-linux-gnueabi- PLAT=$BOOT_SOC bl31;;build/$BOOT_SOC/release/bl31/bl31.elf:bl31.bin"
+		ATF_TARGET_MAP="M0_CROSS_COMPILE=arm-linux-gnueabi- PLAT=$BOOT_SOC bl31;;build/$BOOT_SOC/release/bl31/bl31.elf:bl31.elf"
 		ATF_TOOLCHAIN2="arm-linux-gnueabi-:> 5.0"
 
 	elif [[ $BOOT_SCENARIO == "tpl-spl-blob" ]]; then

--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -189,6 +189,7 @@ compile_uboot()
 
 		if [[ -n $ATFSOURCE ]]; then
 			cp -Rv "${atftempdir}"/*.bin .
+			cp -Rv "${atftempdir}"/*.elf .
 			rm -rf "${atftempdir}"
 		fi
 


### PR DESCRIPTION
# Description

Update ATF from 2.5 to 2.6, and keep the bl31.elf name

# How Has This Been Tested?

Booted this version ATF on Helios64, a rk3399 board.  I have no other hardware to test other blobless configurations.

- [x] Helios64 boot

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

```
U-Boot TPL 2021.07-armbian (May 24 2022 - 19:11:58)
...
Trying to boot from BOOTROM
Returning to boot ROM...

U-Boot SPL 2021.07-armbian (May 24 2022 - 19:11:58 +0000)
Trying to boot from MMC1
NOTICE:  BL31: v2.6(release):a1f02f4f-dirty
NOTICE:  BL31: Built : 19:11:53, May 24 2022
U-Boot 2021.07-armbian (May 24 2022 - 19:11:58 +0000)

SoC: Rockchip rk3399
```
Of note: BL31: v2.6(release)