### PR TITLE
We need to read DISTRIBUTION_STATUS in order to have information about

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -6,6 +6,10 @@
 # License version 2. This program is licensed "as is" without any
 # warranty of any kind, whether express or implied.
 
+# read distribution status
+[[ -f /etc/lsb-release ]] && . /etc/lsb-release
+[[ -n "$DISTRIB_CODENAME" && -f /etc/armbian-distribution-status ]] && DISTRIBUTION_STATUS=$(cat /etc/armbian-distribution-status | grep "$DISTRIB_CODENAME" | cut -d"=" -f2)
+
 . /etc/armbian-release
 
 


### PR DESCRIPTION
# Description

In first run script we show image support status but only in case image is not supported (nighly, self build, edge). We rely on information that is stored in /etc/armbian-distribution-status which is a part of BSP package.

Jira reference number [AR-1197]

# How Has This Been Tested?

- [ ] Generated image

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
