### PR TITLE
sunxi-5.17: fix: cpu opp table sun8i-a83t

### DIFF
--- a/patch/kernel/archive/sunxi-5.17/patches.armbian/fix-cpu-opp-table-sun8i-a83t.patch
+++ b/patch/kernel/archive/sunxi-5.17/patches.armbian/fix-cpu-opp-table-sun8i-a83t.patch
@@ -1,0 +1,115 @@
+From 91fd8b82e2223a55ab739a6b5d34fba3bbde0182 Mon Sep 17 00:00:00 2001
+From: The-going <48602507+The-going@users.noreply.github.com>
+Date: Fri, 27 May 2022 14:45:59 +0300
+Subject: [PATCH] fix: cpu opp table sun8i-a83t
+
+cpu opp table can only be a multiple of the integer 24 * 8 * n
+---
+ arch/arm/boot/dts/sun8i-a83t.dtsi | 52 +++++++++++++++++++------------
+ 1 file changed, 32 insertions(+), 20 deletions(-)
+
+diff --git a/arch/arm/boot/dts/sun8i-a83t.dtsi b/arch/arm/boot/dts/sun8i-a83t.dtsi
+index f0711d68b..4fad00e0e 100644
+--- a/arch/arm/boot/dts/sun8i-a83t.dtsi
++++ b/arch/arm/boot/dts/sun8i-a83t.dtsi
+@@ -224,32 +224,38 @@ cpu0_opp_table: opp-table-cluster0 {
+ 		compatible = "operating-points-v2";
+ 		opp-shared;
+ 
+-		opp-480000000 {
+-			opp-hz = /bits/ 64 <480000000>;
++		opp-576000000 {
++			opp-hz = /bits/ 64 <576000000>; /* 24x8x3 */
+ 			opp-microvolt = <840000>;
+ 			clock-latency-ns = <244144>; /* 8 32k periods */
+ 		};
+ 
+-		opp-1008000000 {
+-			opp-hz = /bits/ 64 <1008000000>;
++		opp-768000000 {
++			opp-hz = /bits/ 64 <768000000>; /* 24x8x4 */
+ 			opp-microvolt = <840000>;
+ 			clock-latency-ns = <244144>; /* 8 32k periods */
+ 		};
+ 
+-		opp-1412000000 {
+-			opp-hz = /bits/ 64 <1412000000>;
++		opp-1152000000 {
++			opp-hz = /bits/ 64 <1152000000>; /* 24x8x6 */
++			opp-microvolt = <900000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-1344000000 {
++			opp-hz = /bits/ 64 <1344000000>; /* 24x8x7 */
+ 			opp-microvolt = <920000>;
+ 			clock-latency-ns = <244144>; /* 8 32k periods */
+ 		};
+ 
+-		opp-1608000000 {
+-			opp-hz = /bits/ 64 <1608000000>;
++		opp-1536000000 {
++			opp-hz = /bits/ 64 <1536000000>; /* 24x8x8 */
+ 			opp-microvolt = <1000000>;
+ 			clock-latency-ns = <244144>; /* 8 32k periods */
+ 		};
+ 
+-		opp-1800000000 {
+-			opp-hz = /bits/ 64 <1800000000>;
++		opp-1728000000 {
++			opp-hz = /bits/ 64 <1728000000>; /* 24x8x9 */
+ 			opp-microvolt = <1080000>;
+ 			clock-latency-ns = <244144>; /* 8 32k periods */
+ 		};
+@@ -259,32 +265,38 @@ cpu1_opp_table: opp-table-cluster1 {
+ 		compatible = "operating-points-v2";
+ 		opp-shared;
+ 
+-		opp-480000000 {
+-			opp-hz = /bits/ 64 <480000000>;
++		opp-576000000 {
++			opp-hz = /bits/ 64 <576000000>; /* 24x8x3 */
+ 			opp-microvolt = <840000>;
+ 			clock-latency-ns = <244144>; /* 8 32k periods */
+ 		};
+ 
+-		opp-1008000000 {
+-			opp-hz = /bits/ 64 <1008000000>;
++		opp-768000000 {
++			opp-hz = /bits/ 64 <768000000>; /* 24x8x4 */
+ 			opp-microvolt = <840000>;
+ 			clock-latency-ns = <244144>; /* 8 32k periods */
+ 		};
+ 
+-		opp-1412000000 {
+-			opp-hz = /bits/ 64 <1412000000>;
++		opp-1152000000 {
++			opp-hz = /bits/ 64 <1152000000>; /* 24x8x6 */
++			opp-microvolt = <900000>;
++			clock-latency-ns = <244144>; /* 8 32k periods */
++		};
++
++		opp-1344000000 {
++			opp-hz = /bits/ 64 <1344000000>; /* 24x8x7 */
+ 			opp-microvolt = <920000>;
+ 			clock-latency-ns = <244144>; /* 8 32k periods */
+ 		};
+ 
+-		opp-1608000000 {
+-			opp-hz = /bits/ 64 <1608000000>;
++		opp-1536000000 {
++			opp-hz = /bits/ 64 <1536000000>; /* 24x8x8 */
+ 			opp-microvolt = <1000000>;
+ 			clock-latency-ns = <244144>; /* 8 32k periods */
+ 		};
+ 
+-		opp-1800000000 {
+-			opp-hz = /bits/ 64 <1800000000>;
++		opp-1728000000 {
++			opp-hz = /bits/ 64 <1728000000>; /* 24x8x9 */
+ 			opp-microvolt = <1080000>;
+ 			clock-latency-ns = <244144>; /* 8 32k periods */
+ 		};
+-- 
+2.35.3
+

--- a/patch/kernel/archive/sunxi-5.17/series.armbian
+++ b/patch/kernel/archive/sunxi-5.17/series.armbian
@@ -166,7 +166,7 @@
 	patches.armbian/arm-dts-sun8i-h3-orangepi-pc-plus-add-wifi_pwrseq.patch
 	patches.armbian/arm64-dts-sun50i-h5-orangepi-prime-add-rtl8723cs.patch
 	patches.armbian/arm-dts-sun8i-h2-plus-orangepi-zero-fix-xradio-inter.patch
--	patches.armbian/drv-mtd-nand-disable-badblock-check-for-migration.patch
+	patches.armbian/fix-cpu-opp-table-sun8i-a83t.patch
 
 	patches.armbian/0001-move-sun50i-h6-pwm-settings-to-its-own-overlay.patch
 	patches.armbian/0002-compile-the-pwm-overlay.patch
@@ -175,7 +175,6 @@
 	patches.armbian/0005-net-phy-support-yt8531c.patch
 	patches.armbian/0006-h6-dts-overlay-fix-spidev.patch
 	patches.armbian/0007-wireless-add-uwe5622-driver.patch
--	patches.armbian/0008-uwe5622-bluetooth-fix-firmware-init-fail.patch
 	patches.armbian/0009-allwinner-h6-support-ac200-audio-codec.patch
 	patches.armbian/0010-allwinner-add-sunxi_get_soc_chipid-and-sunxi_get_ser.patch
 	patches.armbian/0011-add-initial-support-for-orangepi3-lts.patch

--- a/patch/kernel/archive/sunxi-5.17/series.conf
+++ b/patch/kernel/archive/sunxi-5.17/series.conf
@@ -751,6 +751,7 @@
 	patches.armbian/arm-dts-sun8i-h3-orangepi-pc-plus-add-wifi_pwrseq.patch
 	patches.armbian/arm64-dts-sun50i-h5-orangepi-prime-add-rtl8723cs.patch
 	patches.armbian/arm-dts-sun8i-h2-plus-orangepi-zero-fix-xradio-inter.patch
+	patches.armbian/fix-cpu-opp-table-sun8i-a83t.patch
 
 	patches.armbian/0001-move-sun50i-h6-pwm-settings-to-its-own-overlay.patch
 	patches.armbian/0002-compile-the-pwm-overlay.patch


### PR DESCRIPTION

# Description

cpu opp table for sun8i-a83t can only be a multiple
of the integer 24 * 8 * n

# Checklist:
- [ ] Test build
- [ ] Test work on board

