### PR TITLE
[bootenv/rockchip] Force cgroup v1 usage

### DIFF
--- a/config/bootenv/rockchip.txt
+++ b/config/bootenv/rockchip.txt
@@ -1,2 +1,3 @@
 verbosity=1
 bootlogo=false
+extraargs=systemd.unified_cgroup_hierarchy=0


### PR DESCRIPTION
# Description

This commit forces cgroup v1 usage as a workaround for docker / runc BPF issues until a proper fix is submitted 

# Context
Docker 20.10+ cannot run on our Asus Tinkerboard, it throws BPF related errors (Like opencontainers/runc#2959 , especially [this comment](https://github.com/opencontainers/runc/issues/2959#issuecomment-988464142)). I tried a lot of armbian flavors (focal, jammy, bullseye + current, edge and legacy kernels), and even building an image with `CONFIG_BPF_SYSCALL=y` as suggested [by this comment](https://github.com/opencontainers/runc/issues/2959#issuecomment-988472950) but it didn't fix the issue.
The only thing that fixed docker was to add `extraargs=systemd.unified_cgroup_hierarchy=0` to `/boot/armbianEnv.txt`.

Until someone else does a proper fix to make cgroup v2 working, I suggest downgrading to cgroup v1 with this extraarg.

# How Has This Been Tested?

- [x] Tested on Asus Tinkerboard with latest 5.15 stable kernel from apt repository.
- [ ] :x: NOT tested with edge and legacy kernels
(Sorry I had to quickly put the machine into production and didn't have time to test other kernels)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
=> Does it need a documentation change ?
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
