### PR TITLE
Fix for build error on aarch64 with ERROR in function check_loop_device

### DIFF
--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -634,7 +634,7 @@ PREPARE_IMAGE_SIZE
 
 	check_loop_device "$LOOP"
 
-	losetup $LOOP ${SDCARD}.raw
+	losetup -P $LOOP ${SDCARD}.raw
 
 	# loop device was grabbed here, unlock
 	flock -u $FD
@@ -736,7 +736,7 @@ PREPARE_IMAGE_SIZE
 	fi
 
 	# recompile .cmd to .scr if boot.cmd exists
-    
+
 	if [[ -f $SDCARD/boot/boot.cmd ]]; then
 		if [ -z $BOOTSCRIPT_OUTPUT ]; then BOOTSCRIPT_OUTPUT=boot.scr; fi
 		mkimage -C none -A arm -T script -d $SDCARD/boot/boot.cmd $SDCARD/boot/$BOOTSCRIPT_OUTPUT > /dev/null 2>&1


### PR DESCRIPTION
Image building in ubuntu jammy on aarch64 platform breaks with diagnostic 
```
[ o.k. ] Calling image customization script [ customize-image.sh ]
[ o.k. ] No longer needed packages [ purge ]
[ o.k. ] Unmounting [ /root/armbian/.tmp/rootfs-4a58bdb8-aac0-472d-8f05-0d11ef0816e8 ]
[ o.k. ] Preparing image file for rootfs [ odroidn2 jammy ]
[ o.k. ] Current rootfs size [ 1285 MiB ]
[ o.k. ] Creating blank image for rootfs [ 1612 MiB ]
[ o.k. ] Creating partitions [ root: ext4 ]
[ error ] ERROR in function check_loop_device [ main.sh:588 -> main.sh:549 -> debootstrap.sh:97 -> debootstrap.sh:658 -> image-helpers.sh:112 -> general.sh:0 ]
[ error ] Device node /dev/loop0p1 does not exist
[ o.k. ] Process terminated
```
I found there no /dev/loop0p1 devices for partitions after loop mounting. Only on aarch64. On x64 devices for partitions are present.
Then I found adding -P to `losetup` fixes it.

# How Has This Been Tested?

- [×] Build image for Rockpi-4a on Odroid-N2 Ubuntu Jammy, then boot Rockpi board from that image
- [×]  Build image for Rockpi-4a on x64 Ubuntu Jammy, then boot Rockpi board from that image

# Checklist:

- [×] My code follows the style guidelines of this project
- [] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [×] My changes generate no new warnings
- [] Any dependent changes have been merged and published in downstream modules
