### PR TITLE
Remove Firefox-ESR (non snap) package from Focal builds

### DIFF
--- a/config/desktop/focal/appgroups/browsers/packages
+++ b/config/desktop/focal/appgroups/browsers/packages
@@ -1,2 +1,1 @@
 chromium-browser
-firefox-esr

--- a/config/desktop/jammy/appgroups/browsers/packages
+++ b/config/desktop/jammy/appgroups/browsers/packages
@@ -1,1 +1,2 @@
-../../../focal/appgroups/browsers/packages
+chromium-browser
+firefox-esr


### PR DESCRIPTION
# Description

Mozilla team does not provide (temporally?) packages for Focal. Well, we don't need this that urgent, so simply removing in order to have a build-able system.

Jira reference number [AR-1206]

# How Has This Been Tested?

- [x] Jammy desktop
- [x] Focal desktop


[AR-1206]: https://armbian.atlassian.net/browse/AR-1206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ