### PR TITLE
add rock-3a emmc support

### DIFF
--- a/patch/kernel/archive/rockchip64-5.18/rk3568-dts-radxa-rock3a-support.patch
+++ b/patch/kernel/archive/rockchip64-5.18/rk3568-dts-radxa-rock3a-support.patch
@@ -11,10 +11,10 @@ index 479906f3ad7b..bf2a58e3a871 100644
 subdir-y       := $(dts-dirs) overlay
 diff --git a/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts b/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
 new file mode 100644
-index 00000000000..44aa58ce21b
+index 00000000000..89420f70621
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
-@@ -0,0 +1,681 @@
+@@ -0,0 +1,710 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +
 +/dts-v1/;
@@ -82,6 +82,15 @@ index 00000000000..44aa58ce21b
 +		simple-audio-card,codec {
 +			sound-dai = <&rk809>;
 +		};
++	};
++
++	sdio_pwrseq: sdio-pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		clocks = <&rk809 1>;
++		clock-names = "ext_clock";
++		pinctrl-names = "default";
++		pinctrl-0 = <&wifi_enable_h>;
++		reset-gpios = <&gpio3 RK_PD4 GPIO_ACTIVE_LOW>;
 +	};
 +
 +	vcc12v_dcin: vcc12v-dcin {
@@ -541,6 +550,12 @@ index 00000000000..44aa58ce21b
 +			rockchip,pins = <0 RK_PA5 RK_FUNC_GPIO &pcfg_pull_none>;
 +		};
 +	};
++
++	sdio-pwrseq {
++		wifi_enable_h: wifi-enable-h {
++			rockchip,pins = <3 RK_PD4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
 +};
 +
 +&pmu_io_domains {
@@ -582,6 +597,20 @@ index 00000000000..44aa58ce21b
 +	sd-uhs-sdr104;
 +	vmmc-supply = <&vcc3v3_sd>;
 +	vqmmc-supply = <&vccio_sd>;
++	status = "okay";
++};
++
++&sdmmc2 {
++	bus-width = <4>;
++	cap-sd-highspeed;
++	cap-sdio-irq;
++	disable-wp;
++	keep-power-in-suspend;
++	mmc-pwrseq = <&sdio_pwrseq>;
++	non-removable;
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdmmc2m0_bus4 &sdmmc2m0_cmd &sdmmc2m0_clk>;
++	sd-uhs-sdr104;
 +	status = "okay";
 +};
 +


### PR DESCRIPTION
# Description

Add emmc related device tree nodes referring to [legacy kernel device tree](https://github.com/radxa/kernel/blob/stable-4.19-rock3/arch/arm64/boot/dts/rockchip/rk3568-rock-3-a.dts)

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.
I don't have emmc module on my rock-3a, but one of my friend has. Before this commit emmc is not detected and command `lsblk` doesn't show emmc block. I compiled a kernel and send it to him to test. After this commit he can install armbian to emmc and boot successfully.
- [x] Build successfully.
- [x] Emmc is detected and can install armbian to it.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
