### PR TITLE
fix rock3a UBOOT_TARGET_MAP

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -142,7 +142,9 @@ prepare_boot_configuration() {
 
 	if [[ $BOOT_SUPPORT_SPI == yes ]]; then
 
-		UBOOT_TARGET_MAP="BL31=$RKBIN_DIR/$BL31_BLOB tpl/u-boot-tpl.bin spl/u-boot-spl.bin u-boot.itb ${UBOOT_TARGET_MAP} rkspi_loader.img"
+		if [[ $BOARD != "rock-3a" ]]; then
+			UBOOT_TARGET_MAP="BL31=$RKBIN_DIR/$BL31_BLOB tpl/u-boot-tpl.bin spl/u-boot-spl.bin u-boot.itb ${UBOOT_TARGET_MAP} rkspi_loader.img"
+		fi
 
 	fi
 }


### PR DESCRIPTION
# Description

Pull request #3838 add spi boot support for rock-3a. It can build successfully on my local machine, but build will fail in github workflow environment: https://github.com/amazingfate/armbian-rock3a-images/runs/6648716251?check_suite_focus=true#step:3.
After this fix build is ok now: https://github.com/amazingfate/armbian-rock3a-images/runs/6649318129?check_suite_focus=true

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Build sucessfully in github workflowwnvironment.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
