### PR TITLE
[AR-1213] Fix mvebu pwm patch

### DIFF
--- a/patch/kernel/archive/mvebu-5.15/92-mvebu-gpio-remove-hardcoded-timer-assignment.patch
+++ b/patch/kernel/archive/mvebu-5.15/92-mvebu-gpio-remove-hardcoded-timer-assignment.patch
@@ -220,7 +220,7 @@ index bad399e3f..d3fdaf177 100644
  
  	regmap_read(mvchip->regs, GPIO_BLINK_EN_OFF + mvchip->offset, &u);
  	if (u)
-@@ -723,19 +796,26 @@ static void mvebu_pwm_get_state(struct pwm_chip *chip,
+@@ -796,13 +796,15 @@ static void mvebu_pwm_get_state(struct pwm_chip *chip,
  	else
  		state->enabled = false;
  
@@ -237,10 +237,12 @@ index bad399e3f..d3fdaf177 100644
  	struct mvebu_gpio_chip *mvchip = mvpwm->mvchip;
  	unsigned long long val;
  	unsigned long flags;
- 	unsigned int on, off;
+@@ -811,7 +813,12 @@ static int mvebu_pwm_apply(struct pwm_chip *chip, struct pwm_device *pwm,
+ 	if (state->polarity != PWM_POLARITY_NORMAL)
+ 		return -EINVAL;
  
 -	val = (unsigned long long) mvpwm->clk_rate * state->duty_cycle;
-+	if (chip_data)
++    if (chip_data)
 +		controller = mvebu_pwm_list[chip_data->ctrl];
 +	else
 +		controller = &mvpwm->controller;

--- a/patch/kernel/archive/mvebu-5.16/92-mvebu-gpio-remove-hardcoded-timer-assignment.patch
+++ b/patch/kernel/archive/mvebu-5.16/92-mvebu-gpio-remove-hardcoded-timer-assignment.patch
@@ -220,7 +220,7 @@ index bad399e3f..d3fdaf177 100644
  
  	regmap_read(mvchip->regs, GPIO_BLINK_EN_OFF + mvchip->offset, &u);
  	if (u)
-@@ -723,19 +796,26 @@ static void mvebu_pwm_get_state(struct pwm_chip *chip,
+@@ -796,13 +796,15 @@ static void mvebu_pwm_get_state(struct pwm_chip *chip,
  	else
  		state->enabled = false;
  
@@ -237,10 +237,12 @@ index bad399e3f..d3fdaf177 100644
  	struct mvebu_gpio_chip *mvchip = mvpwm->mvchip;
  	unsigned long long val;
  	unsigned long flags;
- 	unsigned int on, off;
+@@ -811,7 +813,12 @@ static int mvebu_pwm_apply(struct pwm_chip *chip, struct pwm_device *pwm,
+ 	if (state->polarity != PWM_POLARITY_NORMAL)
+ 		return -EINVAL;
  
 -	val = (unsigned long long) mvpwm->clk_rate * state->duty_cycle;
-+	if (chip_data)
++    if (chip_data)
 +		controller = mvebu_pwm_list[chip_data->ctrl];
 +	else
 +		controller = &mvpwm->controller;


### PR DESCRIPTION
# Description

Fixes the not matching mvebu pwm patch, no functional changes.

Jira reference number [AR-1213]

# How Has This Been Tested?
- [x] Build clearfogpro current
- [x] Build clearfogpro edge



[AR-1213]: https://armbian.atlassian.net/browse/AR-1213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ