### PR TITLE
Update meson64-edge patch for Kernel 5.15.7+

### DIFF
--- a/patch/kernel/archive/meson64-5.17/general-meson-aiu-Fix-HDMI-codec-control-selection.patch
+++ b/patch/kernel/archive/meson64-5.17/general-meson-aiu-Fix-HDMI-codec-control-selection.patch
@@ -188,7 +188,7 @@ index c3ea733fce91..2b8575491aeb 100644
  
  	snd_soc_dapm_mux_update_power(dapm, kcontrol, mux, e, NULL);
  
- 	return 0;
+ 	return 1;
  }
  
 -static SOC_ENUM_SINGLE_DECL(aiu_hdmi_ctrl_mux_enum, AIU_HDMI_CLK_DATA_CTRL,


### PR DESCRIPTION

# Description

Update meson64-edge/general-meson-aiu-Fix-HDMI-codec-control-selection.patch patch for Kernel 5.15.7+

Updated for work with this patch:

```
commit 1d29b712efb6ec044547a01cd2cfb69af47a21a9
Author: Mark Brown <broonie@kernel.org>
Date:   Thu Apr 21 13:38:02 2022 +0100

diff --git a/sound/soc/meson/aiu-codec-ctrl.c b/sound/soc/meson/aiu-codec-ctrl.c
index c3ea733fce91..c966fc60dc73 100644
--- a/sound/soc/meson/aiu-codec-ctrl.c
+++ b/sound/soc/meson/aiu-codec-ctrl.c
@@ -57,7 +57,7 @@ static int aiu_codec_ctrl_mux_put_enum(struct snd_kcontrol *kcontrol,

        snd_soc_dapm_mux_update_power(dapm, kcontrol, mux, e, NULL);

-       return 0;
+       return 1;
 }
```


Jira reference number [AR-1219]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Builds ok
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1219]: https://armbian.atlassian.net/browse/AR-1219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ