### PR TITLE
fix rock-3a spi UBOOT_TARGET_MAP

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -144,6 +144,8 @@ prepare_boot_configuration() {
 
 		if [[ $BOARD != "rock-3a" ]]; then
 			UBOOT_TARGET_MAP="BL31=$RKBIN_DIR/$BL31_BLOB tpl/u-boot-tpl.bin spl/u-boot-spl.bin u-boot.itb ${UBOOT_TARGET_MAP} rkspi_loader.img"
+		else
+			UBOOT_TARGET_MAP="${UBOOT_TARGET_MAP} rkspi_loader.img"
 		fi
 
 	fi


### PR DESCRIPTION
# Description

In pull request #3845 I remove the UBOOT_TARGET_MAP for rkspi_loader.img to fix github workflow build error, but on the other hand spi image rkspi_loader.img will not get build in the u-boot deb package. So I add rkspi_loader.img back to UBOOT_TARGET_MAP.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Github workflow build successfully: https://github.com/amazingfate/armbian-rock3a-images/runs/6728809237?check_suite_focus=true
- [ ] Package linux-u-boot has rkspi_loader.img.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [] Any dependent changes have been merged and published in downstream modules
