### PR TITLE
Remove version argument check from initramfs cleanup script

### DIFF
--- a/packages/bsp/common/etc/kernel/postinst.d/xx-initramfs-cleanup
+++ b/packages/bsp/common/etc/kernel/postinst.d/xx-initramfs-cleanup
@@ -1,14 +1,6 @@
 #!/bin/sh
 
-version="$1"
-
 [ -x /usr/sbin/update-initramfs ] || exit 0
-
-# passing the kernel version is required
-if [ -z "$version" ]; then
-	echo >&2 "W: initramfs-tools: ${DPKG_MAINTSCRIPT_PACKAGE:-kernel package} did not pass a version number"
-	exit 0
-fi
 
 # avoid running multiple times
 # This script should be run after the initramfs-tools script
@@ -25,7 +17,7 @@ MOD_DIR=/lib/modules/
 files="$(find /boot -maxdepth 1 -name 'initrd.img-*' -o -name 'uInitrd-*')"
 
 for f in $files; do
-	if [ ! -d /lib/modules/"${f#*-}" ]; then
+	if [ ! -d "$MOD_DIR${f#*-}" ]; then
 		echo "Remove unused generated file: $f"; rm $f
 	fi
 done


### PR DESCRIPTION
# Description

The version argument is not used by the script anymore, hence the check is obsolete.

Additionally make use of the currently unused defined MOD_DIR variable.

Jira reference number [[AR-9999](https://armbian.atlassian.net/browse/AR-1221)]

# How Has This Been Tested?

Running the script locally, the change otherwise is trivial.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
