### PR TITLE
add eject for gnome

### DIFF
--- a/config/desktop/bullseye/environments/gnome/config_base/packages
+++ b/config/desktop/bullseye/environments/gnome/config_base/packages
@@ -8,6 +8,7 @@ cups
 dbus-x11
 dictionaries-common
 dmz-cursor-theme
+eject
 evolution-data-server
 evolution-data-server-common
 fonts-freefont-ttf

--- a/config/desktop/jammy/environments/gnome/config_base/packages
+++ b/config/desktop/jammy/environments/gnome/config_base/packages
@@ -7,6 +7,7 @@ cups
 dbus-x11
 dictionaries-common
 dmz-cursor-theme
+eject
 evolution-data-server
 evolution-data-server-common
 fonts-freefont-ttf

--- a/config/desktop/sid/environments/gnome/config_base/packages
+++ b/config/desktop/sid/environments/gnome/config_base/packages
@@ -6,6 +6,7 @@ cups
 dbus-x11
 dictionaries-common
 dmz-cursor-theme
+eject
 evolution-data-server
 evolution-data-server-common
 fonts-freefont-ttf


### PR DESCRIPTION
# Description

In gnome when I insert a u disk and want to click eject from the left dock, I get no eject command error. After installing eject package, I can eject the u disk successfully now.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
