### PR TITLE
adjust patches for rk322x, rockchip edge 5.18 kernel

### DIFF
--- a/patch/kernel/archive/rk322x-5.18/01-linux-0011-v4l2-from-list.patch
+++ b/patch/kernel/archive/rk322x-5.18/01-linux-0011-v4l2-from-list.patch
@@ -131,39 +131,6 @@ index efd316550807..c88e817cac0a 100644
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Mon, 6 Jul 2020 21:54:35 +0000
-Subject: [PATCH] media: rkvdec: h264: Fix bit depth wrap in pps packet
-
-The luma and chroma bit depth fields in the pps packet is 3 bits wide.
-8 is wrongly added to the bit depth value written to these 3-bit fields.
-Because only the 3 LSB is written the hardware is configured correctly.
-
-Correct this by not adding 8 to the luma and chroma bit depth value.
-
-Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
-Reviewed-by: Ezequiel Garcia <ezequiel@collabora.com>
----
- drivers/staging/media/rkvdec/rkvdec-h264.c | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
-
-diff --git a/drivers/staging/media/rkvdec/rkvdec-h264.c b/drivers/staging/media/rkvdec/rkvdec-h264.c
-index a379e43147fb..503ae683d0fd 100644
---- a/drivers/staging/media/rkvdec/rkvdec-h264.c
-+++ b/drivers/staging/media/rkvdec/rkvdec-h264.c
-@@ -661,8 +661,8 @@ static void assemble_hw_pps(struct rkvdec_ctx *ctx,
- 	WRITE_PPS(0xff, PROFILE_IDC);
- 	WRITE_PPS(1, CONSTRAINT_SET3_FLAG);
- 	WRITE_PPS(sps->chroma_format_idc, CHROMA_FORMAT_IDC);
--	WRITE_PPS(sps->bit_depth_luma_minus8 + 8, BIT_DEPTH_LUMA);
--	WRITE_PPS(sps->bit_depth_chroma_minus8 + 8, BIT_DEPTH_CHROMA);
-+	WRITE_PPS(sps->bit_depth_luma_minus8, BIT_DEPTH_LUMA);
-+	WRITE_PPS(sps->bit_depth_chroma_minus8, BIT_DEPTH_CHROMA);
- 	WRITE_PPS(0, QPPRIME_Y_ZERO_TRANSFORM_BYPASS_FLAG);
- 	WRITE_PPS(sps->log2_max_frame_num_minus4, LOG2_MAX_FRAME_NUM_MINUS4);
- 	WRITE_PPS(sps->max_num_ref_frames, MAX_NUM_REF_FRAMES);
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Jonas Karlman <jonas@kwiboo.se>
-Date: Mon, 6 Jul 2020 21:54:35 +0000
 Subject: [PATCH] media: v4l2-common: Add helpers to calculate bytesperline and
  sizeimage
 

--- a/patch/kernel/archive/rk322x-5.18/01-linux-1001-v4l2-rockchip.patch
+++ b/patch/kernel/archive/rk322x-5.18/01-linux-1001-v4l2-rockchip.patch
@@ -98,27 +98,6 @@ index c9a551dbd9bc..6ce11b736363 100644
  	/*
  	 * Assign an invalid pic_num if DPB entry at that position is inactive.
  	 * If we assign 0 in that position hardware will treat that as a real
-@@ -763,19 +767,7 @@ static void assemble_hw_rps(struct rkvdec_ctx *ctx,
- 	for (j = 0; j < RKVDEC_NUM_REFLIST; j++) {
- 		for (i = 0; i < h264_ctx->reflists.num_valid; i++) {
- 			u8 dpb_valid = 0;
--			u8 idx = 0;
--
--			switch (j) {
--			case 0:
--				idx = h264_ctx->reflists.p[i];
--				break;
--			case 1:
--				idx = h264_ctx->reflists.b0[i];
--				break;
--			case 2:
--				idx = h264_ctx->reflists.b1[i];
--				break;
--			}
-+			u8 idx = reflists[j][i];
- 
- 			if (idx >= ARRAY_SIZE(dec_params->dpb))
- 				continue;
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
@@ -143,88 +122,6 @@ index 6ce11b736363..9c3f08c94800 100644
  	u16 *p = (u16 *)hw_rps;
  
  	memset(hw_rps, 0, sizeof(priv_tbl->rps));
-@@ -764,18 +764,71 @@ static void assemble_hw_rps(struct rkvdec_ctx *ctx,
- 		p[i] = dpb[i].frame_num - max_frame_num;
- 	}
- 
--	for (j = 0; j < RKVDEC_NUM_REFLIST; j++) {
--		for (i = 0; i < h264_ctx->reflists.num_valid; i++) {
--			u8 dpb_valid = 0;
--			u8 idx = reflists[j][i];
-+	if (!(dec_params->flags & V4L2_H264_DECODE_PARAM_FLAG_FIELD_PIC)) {
-+		for (j = 0; j < RKVDEC_NUM_REFLIST; j++) {
-+			for (i = 0; i < h264_ctx->reflists.num_valid; i++) {
-+				u8 dpb_valid = 0;
-+				u8 idx = reflists[j][i];
- 
--			if (idx >= ARRAY_SIZE(dec_params->dpb))
--				continue;
--			dpb_valid = !!(dpb[idx].flags &
--				       V4L2_H264_DPB_ENTRY_FLAG_ACTIVE);
-+				if (idx >= ARRAY_SIZE(dec_params->dpb))
-+					continue;
-+				dpb_valid = !!(dpb[idx].flags &
-+					       V4L2_H264_DPB_ENTRY_FLAG_ACTIVE);
- 
--			set_ps_field(hw_rps, DPB_INFO(i, j),
--				     idx | dpb_valid << 4);
-+				set_ps_field(hw_rps, DPB_INFO(i, j),
-+					     idx | dpb_valid << 4);
-+			}
-+		}
-+		return;
-+	}
-+
-+	for (j = 0; j < RKVDEC_NUM_REFLIST; j++) {
-+		enum v4l2_h264_field_reference a_parity =
-+			(dec_params->flags & V4L2_H264_DECODE_PARAM_FLAG_BOTTOM_FIELD)
-+			? V4L2_H264_BOTTOM_FIELD_REF : V4L2_H264_TOP_FIELD_REF;
-+		enum v4l2_h264_field_reference b_parity =
-+			(dec_params->flags & V4L2_H264_DECODE_PARAM_FLAG_BOTTOM_FIELD)
-+			? V4L2_H264_TOP_FIELD_REF : V4L2_H264_BOTTOM_FIELD_REF;
-+		u32 flags = V4L2_H264_DPB_ENTRY_FLAG_LONG_TERM;
-+		i = 0;
-+
-+		for (k = 0; k < 2; k++) {
-+			u8 a = 0;
-+			u8 b = 0;
-+			u32 long_term = k ? V4L2_H264_DPB_ENTRY_FLAG_LONG_TERM : 0;
-+
-+		while (a < h264_ctx->reflists.num_valid || b < h264_ctx->reflists.num_valid) {
-+			for (; a < h264_ctx->reflists.num_valid; a++) {
-+				u8 idx = reflists[j][a];
-+				if (idx >= ARRAY_SIZE(dec_params->dpb))
-+					continue;
-+				if ((dpb[idx].reference & a_parity) == a_parity &&
-+				    (dpb[idx].flags & flags) == long_term) {
-+					set_ps_field(hw_rps, DPB_INFO(i, j),
-+					             idx | (1 << 4));
-+					set_ps_field(hw_rps, BOTTOM_FLAG(i, j),
-+						a_parity == V4L2_H264_BOTTOM_FIELD_REF);
-+					i++;
-+					a++;
-+					break;
-+				}
-+			}
-+			for (; b < h264_ctx->reflists.num_valid; b++) {
-+				u8 idx = reflists[j][b];
-+				if (idx >= ARRAY_SIZE(dec_params->dpb))
-+					continue;
-+				if ((dpb[idx].reference & b_parity) == b_parity &&
-+				    (dpb[idx].flags & flags) == long_term) {
-+					set_ps_field(hw_rps, DPB_INFO(i, j),
-+					             idx | (1 << 4));
-+					set_ps_field(hw_rps, BOTTOM_FLAG(i, j),
-+						b_parity == V4L2_H264_BOTTOM_FIELD_REF);
-+					i++;
-+					b++;
-+					break;
-+				}
-+			}
-+		}
- 		}
- 	}
- }
 @@ -968,10 +1021,6 @@ static void config_registers(struct rkvdec_ctx *ctx,
  				       rkvdec->regs + RKVDEC_REG_H264_BASE_REFER15);
  	}
@@ -430,52 +327,6 @@ index 7b56a68c176c..befa69d5c855 100644
  				dpb_valid |= BIT(HANTRO_H264_DPB_SIZE * 2 - 1 - i);
  
  			if (dpb[i / 2].flags & V4L2_H264_DPB_ENTRY_FLAG_LONG_TERM)
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Alex Bee <knaerzche@gmail.com>
-Date: Wed, 14 Oct 2020 13:42:01 +0200
-Subject: [PATCH] media: rkvdec: adapt to match 5.11 H.264 uapi changes
-
-Signed-off-by: Alex Bee <knaerzche@gmail.com>
----
- drivers/staging/media/rkvdec/rkvdec-h264.c | 8 ++++----
- 1 file changed, 4 insertions(+), 4 deletions(-)
-
-diff --git a/drivers/staging/media/rkvdec/rkvdec-h264.c b/drivers/staging/media/rkvdec/rkvdec-h264.c
-index 9c3f08c94800..7238117b6cf4 100644
---- a/drivers/staging/media/rkvdec/rkvdec-h264.c
-+++ b/drivers/staging/media/rkvdec/rkvdec-h264.c
-@@ -783,10 +783,10 @@ static void assemble_hw_rps(struct rkvdec_ctx *ctx,
- 	}
- 
- 	for (j = 0; j < RKVDEC_NUM_REFLIST; j++) {
--		enum v4l2_h264_field_reference a_parity =
-+		u8 a_parity =
- 			(dec_params->flags & V4L2_H264_DECODE_PARAM_FLAG_BOTTOM_FIELD)
- 			? V4L2_H264_BOTTOM_FIELD_REF : V4L2_H264_TOP_FIELD_REF;
--		enum v4l2_h264_field_reference b_parity =
-+		u8 b_parity =
- 			(dec_params->flags & V4L2_H264_DECODE_PARAM_FLAG_BOTTOM_FIELD)
- 			? V4L2_H264_TOP_FIELD_REF : V4L2_H264_BOTTOM_FIELD_REF;
- 		u32 flags = V4L2_H264_DPB_ENTRY_FLAG_LONG_TERM;
-@@ -802,7 +802,7 @@ static void assemble_hw_rps(struct rkvdec_ctx *ctx,
- 				u8 idx = reflists[j][a];
- 				if (idx >= ARRAY_SIZE(dec_params->dpb))
- 					continue;
--				if ((dpb[idx].reference & a_parity) == a_parity &&
-+				if ((dpb[idx].fields & a_parity) == a_parity &&
- 				    (dpb[idx].flags & flags) == long_term) {
- 					set_ps_field(hw_rps, DPB_INFO(i, j),
- 					             idx | (1 << 4));
-@@ -817,7 +817,7 @@ static void assemble_hw_rps(struct rkvdec_ctx *ctx,
- 				u8 idx = reflists[j][b];
- 				if (idx >= ARRAY_SIZE(dec_params->dpb))
- 					continue;
--				if ((dpb[idx].reference & b_parity) == b_parity &&
-+				if ((dpb[idx].fields & b_parity) == b_parity &&
- 				    (dpb[idx].flags & flags) == long_term) {
- 					set_ps_field(hw_rps, DPB_INFO(i, j),
- 					             idx | (1 << 4));
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Randy Li <ayaka@soulik.info>

--- a/patch/kernel/archive/rockchip-5.18/01-linux-0011-v4l2-from-list.patch
+++ b/patch/kernel/archive/rockchip-5.18/01-linux-0011-v4l2-from-list.patch
@@ -131,39 +131,6 @@ index efd316550807..c88e817cac0a 100644
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Mon, 6 Jul 2020 21:54:35 +0000
-Subject: [PATCH] media: rkvdec: h264: Fix bit depth wrap in pps packet
-
-The luma and chroma bit depth fields in the pps packet is 3 bits wide.
-8 is wrongly added to the bit depth value written to these 3-bit fields.
-Because only the 3 LSB is written the hardware is configured correctly.
-
-Correct this by not adding 8 to the luma and chroma bit depth value.
-
-Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
-Reviewed-by: Ezequiel Garcia <ezequiel@collabora.com>
----
- drivers/staging/media/rkvdec/rkvdec-h264.c | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
-
-diff --git a/drivers/staging/media/rkvdec/rkvdec-h264.c b/drivers/staging/media/rkvdec/rkvdec-h264.c
-index a379e43147fb..503ae683d0fd 100644
---- a/drivers/staging/media/rkvdec/rkvdec-h264.c
-+++ b/drivers/staging/media/rkvdec/rkvdec-h264.c
-@@ -661,8 +661,8 @@ static void assemble_hw_pps(struct rkvdec_ctx *ctx,
- 	WRITE_PPS(0xff, PROFILE_IDC);
- 	WRITE_PPS(1, CONSTRAINT_SET3_FLAG);
- 	WRITE_PPS(sps->chroma_format_idc, CHROMA_FORMAT_IDC);
--	WRITE_PPS(sps->bit_depth_luma_minus8 + 8, BIT_DEPTH_LUMA);
--	WRITE_PPS(sps->bit_depth_chroma_minus8 + 8, BIT_DEPTH_CHROMA);
-+	WRITE_PPS(sps->bit_depth_luma_minus8, BIT_DEPTH_LUMA);
-+	WRITE_PPS(sps->bit_depth_chroma_minus8, BIT_DEPTH_CHROMA);
- 	WRITE_PPS(0, QPPRIME_Y_ZERO_TRANSFORM_BYPASS_FLAG);
- 	WRITE_PPS(sps->log2_max_frame_num_minus4, LOG2_MAX_FRAME_NUM_MINUS4);
- 	WRITE_PPS(sps->max_num_ref_frames, MAX_NUM_REF_FRAMES);
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Jonas Karlman <jonas@kwiboo.se>
-Date: Mon, 6 Jul 2020 21:54:35 +0000
 Subject: [PATCH] media: v4l2-common: Add helpers to calculate bytesperline and
  sizeimage
 

--- a/patch/kernel/archive/rockchip-5.18/01-linux-1001-v4l2-rockchip.patch
+++ b/patch/kernel/archive/rockchip-5.18/01-linux-1001-v4l2-rockchip.patch
@@ -98,27 +98,6 @@ index c9a551dbd9bc..6ce11b736363 100644
  	/*
  	 * Assign an invalid pic_num if DPB entry at that position is inactive.
  	 * If we assign 0 in that position hardware will treat that as a real
-@@ -763,19 +767,7 @@ static void assemble_hw_rps(struct rkvdec_ctx *ctx,
- 	for (j = 0; j < RKVDEC_NUM_REFLIST; j++) {
- 		for (i = 0; i < h264_ctx->reflists.num_valid; i++) {
- 			u8 dpb_valid = 0;
--			u8 idx = 0;
--
--			switch (j) {
--			case 0:
--				idx = h264_ctx->reflists.p[i];
--				break;
--			case 1:
--				idx = h264_ctx->reflists.b0[i];
--				break;
--			case 2:
--				idx = h264_ctx->reflists.b1[i];
--				break;
--			}
-+			u8 idx = reflists[j][i];
- 
- 			if (idx >= ARRAY_SIZE(dec_params->dpb))
- 				continue;
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
@@ -143,88 +122,6 @@ index 6ce11b736363..9c3f08c94800 100644
  	u16 *p = (u16 *)hw_rps;
  
  	memset(hw_rps, 0, sizeof(priv_tbl->rps));
-@@ -764,18 +764,71 @@ static void assemble_hw_rps(struct rkvdec_ctx *ctx,
- 		p[i] = dpb[i].frame_num - max_frame_num;
- 	}
- 
--	for (j = 0; j < RKVDEC_NUM_REFLIST; j++) {
--		for (i = 0; i < h264_ctx->reflists.num_valid; i++) {
--			u8 dpb_valid = 0;
--			u8 idx = reflists[j][i];
-+	if (!(dec_params->flags & V4L2_H264_DECODE_PARAM_FLAG_FIELD_PIC)) {
-+		for (j = 0; j < RKVDEC_NUM_REFLIST; j++) {
-+			for (i = 0; i < h264_ctx->reflists.num_valid; i++) {
-+				u8 dpb_valid = 0;
-+				u8 idx = reflists[j][i];
- 
--			if (idx >= ARRAY_SIZE(dec_params->dpb))
--				continue;
--			dpb_valid = !!(dpb[idx].flags &
--				       V4L2_H264_DPB_ENTRY_FLAG_ACTIVE);
-+				if (idx >= ARRAY_SIZE(dec_params->dpb))
-+					continue;
-+				dpb_valid = !!(dpb[idx].flags &
-+					       V4L2_H264_DPB_ENTRY_FLAG_ACTIVE);
- 
--			set_ps_field(hw_rps, DPB_INFO(i, j),
--				     idx | dpb_valid << 4);
-+				set_ps_field(hw_rps, DPB_INFO(i, j),
-+					     idx | dpb_valid << 4);
-+			}
-+		}
-+		return;
-+	}
-+
-+	for (j = 0; j < RKVDEC_NUM_REFLIST; j++) {
-+		enum v4l2_h264_field_reference a_parity =
-+			(dec_params->flags & V4L2_H264_DECODE_PARAM_FLAG_BOTTOM_FIELD)
-+			? V4L2_H264_BOTTOM_FIELD_REF : V4L2_H264_TOP_FIELD_REF;
-+		enum v4l2_h264_field_reference b_parity =
-+			(dec_params->flags & V4L2_H264_DECODE_PARAM_FLAG_BOTTOM_FIELD)
-+			? V4L2_H264_TOP_FIELD_REF : V4L2_H264_BOTTOM_FIELD_REF;
-+		u32 flags = V4L2_H264_DPB_ENTRY_FLAG_LONG_TERM;
-+		i = 0;
-+
-+		for (k = 0; k < 2; k++) {
-+			u8 a = 0;
-+			u8 b = 0;
-+			u32 long_term = k ? V4L2_H264_DPB_ENTRY_FLAG_LONG_TERM : 0;
-+
-+		while (a < h264_ctx->reflists.num_valid || b < h264_ctx->reflists.num_valid) {
-+			for (; a < h264_ctx->reflists.num_valid; a++) {
-+				u8 idx = reflists[j][a];
-+				if (idx >= ARRAY_SIZE(dec_params->dpb))
-+					continue;
-+				if ((dpb[idx].reference & a_parity) == a_parity &&
-+				    (dpb[idx].flags & flags) == long_term) {
-+					set_ps_field(hw_rps, DPB_INFO(i, j),
-+					             idx | (1 << 4));
-+					set_ps_field(hw_rps, BOTTOM_FLAG(i, j),
-+						a_parity == V4L2_H264_BOTTOM_FIELD_REF);
-+					i++;
-+					a++;
-+					break;
-+				}
-+			}
-+			for (; b < h264_ctx->reflists.num_valid; b++) {
-+				u8 idx = reflists[j][b];
-+				if (idx >= ARRAY_SIZE(dec_params->dpb))
-+					continue;
-+				if ((dpb[idx].reference & b_parity) == b_parity &&
-+				    (dpb[idx].flags & flags) == long_term) {
-+					set_ps_field(hw_rps, DPB_INFO(i, j),
-+					             idx | (1 << 4));
-+					set_ps_field(hw_rps, BOTTOM_FLAG(i, j),
-+						b_parity == V4L2_H264_BOTTOM_FIELD_REF);
-+					i++;
-+					b++;
-+					break;
-+				}
-+			}
-+		}
- 		}
- 	}
- }
 @@ -968,10 +1021,6 @@ static void config_registers(struct rkvdec_ctx *ctx,
  				       rkvdec->regs + RKVDEC_REG_H264_BASE_REFER15);
  	}
@@ -430,52 +327,6 @@ index 7b56a68c176c..befa69d5c855 100644
  				dpb_valid |= BIT(HANTRO_H264_DPB_SIZE * 2 - 1 - i);
  
  			if (dpb[i / 2].flags & V4L2_H264_DPB_ENTRY_FLAG_LONG_TERM)
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Alex Bee <knaerzche@gmail.com>
-Date: Wed, 14 Oct 2020 13:42:01 +0200
-Subject: [PATCH] media: rkvdec: adapt to match 5.11 H.264 uapi changes
-
-Signed-off-by: Alex Bee <knaerzche@gmail.com>
----
- drivers/staging/media/rkvdec/rkvdec-h264.c | 8 ++++----
- 1 file changed, 4 insertions(+), 4 deletions(-)
-
-diff --git a/drivers/staging/media/rkvdec/rkvdec-h264.c b/drivers/staging/media/rkvdec/rkvdec-h264.c
-index 9c3f08c94800..7238117b6cf4 100644
---- a/drivers/staging/media/rkvdec/rkvdec-h264.c
-+++ b/drivers/staging/media/rkvdec/rkvdec-h264.c
-@@ -783,10 +783,10 @@ static void assemble_hw_rps(struct rkvdec_ctx *ctx,
- 	}
- 
- 	for (j = 0; j < RKVDEC_NUM_REFLIST; j++) {
--		enum v4l2_h264_field_reference a_parity =
-+		u8 a_parity =
- 			(dec_params->flags & V4L2_H264_DECODE_PARAM_FLAG_BOTTOM_FIELD)
- 			? V4L2_H264_BOTTOM_FIELD_REF : V4L2_H264_TOP_FIELD_REF;
--		enum v4l2_h264_field_reference b_parity =
-+		u8 b_parity =
- 			(dec_params->flags & V4L2_H264_DECODE_PARAM_FLAG_BOTTOM_FIELD)
- 			? V4L2_H264_TOP_FIELD_REF : V4L2_H264_BOTTOM_FIELD_REF;
- 		u32 flags = V4L2_H264_DPB_ENTRY_FLAG_LONG_TERM;
-@@ -802,7 +802,7 @@ static void assemble_hw_rps(struct rkvdec_ctx *ctx,
- 				u8 idx = reflists[j][a];
- 				if (idx >= ARRAY_SIZE(dec_params->dpb))
- 					continue;
--				if ((dpb[idx].reference & a_parity) == a_parity &&
-+				if ((dpb[idx].fields & a_parity) == a_parity &&
- 				    (dpb[idx].flags & flags) == long_term) {
- 					set_ps_field(hw_rps, DPB_INFO(i, j),
- 					             idx | (1 << 4));
-@@ -817,7 +817,7 @@ static void assemble_hw_rps(struct rkvdec_ctx *ctx,
- 				u8 idx = reflists[j][b];
- 				if (idx >= ARRAY_SIZE(dec_params->dpb))
- 					continue;
--				if ((dpb[idx].reference & b_parity) == b_parity &&
-+				if ((dpb[idx].fields & b_parity) == b_parity &&
- 				    (dpb[idx].flags & flags) == long_term) {
- 					set_ps_field(hw_rps, DPB_INFO(i, j),
- 					             idx | (1 << 4));
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Randy Li <ayaka@soulik.info>

--- a/patch/kernel/archive/rockchip-5.18/xt-q8l-v10-remote-keymap.patch
+++ b/patch/kernel/archive/rockchip-5.18/xt-q8l-v10-remote-keymap.patch
@@ -91,13 +91,24 @@ index d621acadf..ad7abdb97 100644
  #define RC_MAP_ZX_IRDEC                  "rc-zx-irdec"
  
  /*
+
+From 33f087bf341761e6284dc6e313d63576390d6a0a Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Fri, 10 Jun 2022 15:59:15 +0000
+Subject: [PATCH] add xt-q8l-v10 keymap makefile
+
+---
+ drivers/media/rc/keymaps/Makefile | 1 +
+ 1 file changed, 1 insertion(+)
+
 diff --git a/drivers/media/rc/keymaps/Makefile b/drivers/media/rc/keymaps/Makefile
-index 5b1399af6..ec9ce1206 100644
+index f513ff5caf4..198ef8bc261 100644
 --- a/drivers/media/rc/keymaps/Makefile
 +++ b/drivers/media/rc/keymaps/Makefile
-@@ -117,4 +117,5 @@ obj-$(CONFIG_RC_MAP) += rc-adstech-dvb-t-pci.o \
- 			rc-winfast-usbii-deluxe.o \
- 			rc-su3000.o \
+@@ -136,4 +136,5 @@ obj-$(CONFIG_RC_MAP) += \
+ 			rc-x96max.o \
+ 			rc-xbox-360.o \
  			rc-xbox-dvd.o \
 +			rc-xt-q8l-v10.o \
- 			rc-x96max.o \
+ 			rc-zx-irdec.o
+


### PR DESCRIPTION
# Description

Adjust mainlined patches that prevent compilation.
Didn't try to compile, just a quick check to verify it passes patching phase without failures.

# How Has This Been Tested?

- [x] Patching completes for rk322x family
- [x] Patching completes for rockchip family

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
