### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/build-cache.yml
+++ b/.github/workflows/build-cache.yml
@@ -9,9 +9,14 @@ on:
         required: true
         default: 'nightly'
 
+permissions:
+  contents: read
+
 jobs:
 
   merge:
+    permissions:
+      contents: none
     uses: armbian/scripts/.github/workflows/merge-from-branch.yml@master
 
     with:
@@ -23,6 +28,8 @@ jobs:
       GPG_PASSPHRASE2: ${{ secrets.GPG_PASSPHRASE2 }}
 
   armhf:
+    permissions:
+      contents: none
     needs: [ merge ]
     uses: armbian/scripts/.github/workflows/build-rootfs-cache.yml@master
 
@@ -39,6 +46,8 @@ jobs:
       SCRIPTS_ACCESS_TOKEN: ${{ secrets.SCRIPTS_ACCESS_TOKEN }}
 
   aarch64:
+    permissions:
+      contents: none
     needs: [ merge ]
     uses: armbian/scripts/.github/workflows/build-rootfs-cache.yml@master
 
@@ -55,6 +64,8 @@ jobs:
       SCRIPTS_ACCESS_TOKEN: ${{ secrets.SCRIPTS_ACCESS_TOKEN }}
 
   amd64:
+    permissions:
+      contents: none
     needs: [ merge ]
     uses: armbian/scripts/.github/workflows/build-rootfs-cache.yml@master
     with:
@@ -71,6 +82,8 @@ jobs:
       SCRIPTS_ACCESS_TOKEN: ${{ secrets.SCRIPTS_ACCESS_TOKEN }}
 
   jobsend:
+    permissions:
+      contents: none
     name: finish
     needs: [armhf,aarch64,amd64]
     runs-on: [ubuntu-latest]

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -25,9 +25,14 @@ on:
         required: false
         default: ''
 
+permissions:
+  contents: read
+
 jobs:
 
   fake:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     name: Source changes
     if: ${{ github.repository_owner == 'Armbian' }}
@@ -41,6 +46,8 @@ jobs:
           if-no-files-found: ignore
 
   sync-servers:
+    permissions:
+      contents: none
     name: "Sync servers"
     needs: [ fake]
     if: ${{ github.repository_owner == 'Armbian' }}
@@ -57,6 +64,8 @@ jobs:
 
       
   merge:
+    permissions:
+      contents: none
     needs: [ sync-servers ]
     uses: armbian/scripts/.github/workflows/merge-from-branch.yml@master    
 
@@ -69,6 +78,8 @@ jobs:
       GPG_PASSPHRASE2: ${{ secrets.GPG_PASSPHRASE2 }}
 
   x86:
+    permissions:
+      contents: none
     needs: [ merge ]
     uses: armbian/scripts/.github/workflows/build-with-docker.yml@master
 
@@ -93,6 +104,8 @@ jobs:
       KNOWN_HOSTS_UPLOAD: ${{ secrets.KNOWN_HOSTS_UPLOAD }}
 
   x86-desktop:
+    permissions:
+      contents: none
     needs: [ merge ]
     uses: armbian/scripts/.github/workflows/build-with-docker.yml@master
 
@@ -117,6 +130,8 @@ jobs:
       KNOWN_HOSTS_UPLOAD: ${{ secrets.KNOWN_HOSTS_UPLOAD }}
 
   cli1:
+    permissions:
+      contents: none
     needs: [ merge ]
     uses: armbian/scripts/.github/workflows/build-with-docker.yml@master
 
@@ -142,6 +157,8 @@ jobs:
 
 
   cli2:
+    permissions:
+      contents: none
     needs: [ merge ]
     uses: armbian/scripts/.github/workflows/build-with-docker.yml@master
 
@@ -166,6 +183,8 @@ jobs:
       KNOWN_HOSTS_UPLOAD: ${{ secrets.KNOWN_HOSTS_UPLOAD }}
 
   desktop1:
+    permissions:
+      contents: none
     needs: [ merge ]
     uses: armbian/scripts/.github/workflows/build-with-docker.yml@master
 
@@ -189,6 +208,8 @@ jobs:
       KNOWN_HOSTS_UPLOAD: ${{ secrets.KNOWN_HOSTS_UPLOAD }}
 
   desktop2:
+    permissions:
+      contents: none
     needs: [ merge ]
     uses: armbian/scripts/.github/workflows/build-with-docker.yml@master
 
@@ -212,6 +233,8 @@ jobs:
       KNOWN_HOSTS_UPLOAD: ${{ secrets.KNOWN_HOSTS_UPLOAD }}
 
   jobsend:
+    permissions:
+      contents: none
     name: finish
     needs: [x86,x86-desktop,cli1,desktop1,cli2,desktop2]
     runs-on: [ubuntu-latest]

--- a/.github/workflows/build-kernel-on-merge-request.yml
+++ b/.github/workflows/build-kernel-on-merge-request.yml
@@ -7,9 +7,14 @@ on:
     paths-ignore:
       - .github/workflows
 
+permissions:
+  contents: read
+
 jobs:
 
   Check:
+    permissions:
+      contents: none
     name: Checking
     if: ${{ success() && github.repository_owner == 'Armbian' }}
     uses: armbian/scripts/.github/workflows/check-for-changes.yml@master
@@ -19,6 +24,8 @@ jobs:
       runner: small
 
   Build:
+    permissions:
+      contents: none
     needs: Check
     if: ${{ success() && github.repository_owner == 'Armbian' }}
     uses: armbian/scripts/.github/workflows/build-kernel.yml@master
@@ -39,6 +46,8 @@ jobs:
       KNOWN_HOSTS_UPLOAD: ${{ secrets.KNOWN_HOSTS_UPLOAD }}
 
   jobsend:
+    permissions:
+      contents: none
     name: Cleanup
     needs: [Build]
     runs-on: "small"

--- a/.github/workflows/build-test-image-docker.yml
+++ b/.github/workflows/build-test-image-docker.yml
@@ -7,9 +7,14 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions:
+  contents: read
+
 jobs:
 
   Maintain:    
+    permissions:
+      contents: none
     if: ${{ github.repository_owner == 'Armbian' && contains( github.event.pull_request.labels.*.name, 'Desktop :desktop_computer:') }}
     uses: armbian/scripts/.github/workflows/build-test-image-docker.yml@master
 

--- a/.github/workflows/build-train.yml
+++ b/.github/workflows/build-train.yml
@@ -34,6 +34,8 @@ jobs:
   ##########################################################################################
 
   Merge:
+    permissions:
+      contents: none
     name: Merging
     needs: Cancel
     if: ${{ github.repository_owner == 'Armbian' }}
@@ -54,6 +56,8 @@ jobs:
   ##########################################################################################
 
   Check:
+    permissions:
+      contents: none
     name: Checking
     needs: Merge
     if: ${{ success() && github.repository_owner == 'Armbian' }}
@@ -70,6 +74,8 @@ jobs:
   ##########################################################################################
 
   Kernel:
+    permissions:
+      contents: none
     needs: Check
     if: ${{ success() && github.repository_owner == 'Armbian' }}
     uses: armbian/scripts/.github/workflows/build-kernel.yml@master
@@ -95,6 +101,8 @@ jobs:
   ##########################################################################################
 
   Firmware:
+    permissions:
+      contents: none
     needs: Check
     if: ${{ success() && github.repository_owner == 'Armbian' }}
     uses: armbian/scripts/.github/workflows/build-firmware.yml@master
@@ -115,6 +123,8 @@ jobs:
   ##########################################################################################
 
   Desktop:
+    permissions:
+      contents: none
     needs: Check
     if: ${{ success() && github.repository_owner == 'Armbian' }}
     uses: armbian/scripts/.github/workflows/build-desktop.yml@master
@@ -140,6 +150,8 @@ jobs:
   ##########################################################################################
 
   legacy:
+    permissions:
+      contents: none
     needs: Check
     if: ${{ success() && github.repository_owner == 'Armbian' }}
     uses: armbian/scripts/.github/workflows/build-u-boot-with-docker.yml@master
@@ -162,6 +174,8 @@ jobs:
       KNOWN_HOSTS_UPLOAD: ${{ secrets.KNOWN_HOSTS_UPLOAD }}
 
   current:
+    permissions:
+      contents: none
     needs: Check
     if: ${{ success() && github.repository_owner == 'Armbian' }}
     uses: armbian/scripts/.github/workflows/build-u-boot-with-docker.yml@master
@@ -185,6 +199,8 @@ jobs:
 
 
   edge:
+    permissions:
+      contents: none
     needs: Check
     if: ${{ success() && github.repository_owner == 'Armbian' }}
     uses: armbian/scripts/.github/workflows/build-u-boot-with-docker.yml@master
@@ -213,6 +229,8 @@ jobs:
   ##########################################################################################
   
   Deploycheck:
+    permissions:
+      contents: none
     needs: [Kernel,Desktop,Firmware,legacy,current,edge]
     if: ${{ inputs.sourcerepo != 'nightly' }}
     runs-on: ubuntu-latest
@@ -221,6 +239,8 @@ jobs:
         run: exit_with_success
 
   Deploy:
+    permissions:
+      contents: none
     needs: [Deploycheck]
     if: ${{ success() && github.repository_owner == 'Armbian' }}
     uses: armbian/scripts/.github/workflows/deploy.yml@master
@@ -239,6 +259,8 @@ jobs:
       KNOWN_HOSTS_UPLOAD: ${{ secrets.KNOWN_HOSTS_UPLOAD }}
 
   apt-armbian-com:
+    permissions:
+      contents: none
     name: "Stable repository"
     needs: [Deploy]
     if: ${{ success() && github.repository_owner == 'Armbian' }}
@@ -254,6 +276,8 @@ jobs:
       KNOWN_HOSTS_REPOSITORY: ${{ secrets.KNOWN_HOSTS_REPOSITORY }}
 
   beta-armbian-com:
+    permissions:
+      contents: none
     name: "Nighly repository"
     needs: [Deploy]
     if: ${{ success() && github.repository_owner == 'Armbian' }}
@@ -269,6 +293,8 @@ jobs:
       KNOWN_HOSTS_REPOSITORY: ${{ secrets.KNOWN_HOSTS_REPOSITORY }}
 
   sync-servers:
+    permissions:
+      contents: none
     name: "Sync servers"
     needs: [apt-armbian-com,beta-armbian-com]
     if: ${{ success() && github.repository_owner == 'Armbian' }}
@@ -290,6 +316,8 @@ jobs:
   ##########################################################################################
 
   x86-cli-images:
+    permissions:
+      contents: none
     needs: [apt-armbian-com,beta-armbian-com,sync-servers]
     uses: armbian/scripts/.github/workflows/build-with-docker.yml@master
 
@@ -320,6 +348,8 @@ jobs:
   ##########################################################################################
 
   x86-desktop-images:
+    permissions:
+      contents: none
     needs: [apt-armbian-com,beta-armbian-com,sync-servers]
     uses: armbian/scripts/.github/workflows/build-with-docker.yml@master
 
@@ -350,6 +380,8 @@ jobs:
   ##########################################################################################
 
   cli-images:
+    permissions:
+      contents: none
     needs: [apt-armbian-com,beta-armbian-com,sync-servers]
     uses: armbian/scripts/.github/workflows/build-with-docker.yml@master
 
@@ -380,6 +412,8 @@ jobs:
   ##########################################################################################
 
   desktop-images:
+    permissions:
+      contents: none
     needs: [apt-armbian-com,beta-armbian-com,sync-servers]
     uses: armbian/scripts/.github/workflows/build-with-docker.yml@master
 
@@ -409,6 +443,8 @@ jobs:
   ##########################################################################################
 
   Bump:
+    permissions:
+      contents: none
     needs: [x86-cli-images,x86-desktop-images,cli-images,desktop-images]
     if: ${{ success() && github.repository_owner == 'Armbian' }}
     uses: armbian/scripts/.github/workflows/update-version.yml@master
@@ -433,6 +469,8 @@ jobs:
   ##########################################################################################
 
   Torrents:
+    permissions:
+      contents: none
     name: Torrents
     needs: [x86-cli-images,x86-desktop-images,cli-images,desktop-images]
     if: ${{ github.repository_owner == 'Armbian' }}
@@ -452,6 +490,8 @@ jobs:
 
   Maintaining:
 
+    permissions:
+      contents: none
     needs: [Bump,Torrents]
     if: ${{ success() && github.repository_owner == 'Armbian' }}
     uses: armbian/scripts/.github/workflows/maintain-runners.yml@master

--- a/.github/workflows/build-u-boot.yml
+++ b/.github/workflows/build-u-boot.yml
@@ -9,9 +9,14 @@ on:
         options:
         - nightly
         - master
+permissions:
+  contents: read
+
 jobs:
 
   fake:
+    permissions:
+      contents: none
     runs-on: small
     name: Source changes
     if: ${{ github.repository_owner == 'Armbian' }}
@@ -25,6 +30,8 @@ jobs:
           if-no-files-found: ignore
 
   legacy:
+    permissions:
+      contents: none
     needs: [ fake ]
     uses: armbian/scripts/.github/workflows/build-u-boot-with-docker.yml@master
 
@@ -46,6 +53,8 @@ jobs:
       KNOWN_HOSTS_UPLOAD: ${{ secrets.KNOWN_HOSTS_UPLOAD }}
 
   current:
+    permissions:
+      contents: none
     needs: [ fake ]
     uses: armbian/scripts/.github/workflows/build-u-boot-with-docker.yml@master
 
@@ -68,6 +77,8 @@ jobs:
 
 
   edge:
+    permissions:
+      contents: none
     needs: [ fake ]
     uses: armbian/scripts/.github/workflows/build-u-boot-with-docker.yml@master
 

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -3,9 +3,14 @@ name: Bump version
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
 
   fake:
+    permissions:
+      contents: none
     runs-on: small
     name: Source changes
     if: ${{ github.repository_owner == 'Armbian' }}
@@ -19,6 +24,8 @@ jobs:
           if-no-files-found: ignore
 
   Bump:
+    permissions:
+      contents: none
     needs: [fake]
     if: ${{ success() && github.repository_owner == 'Armbian' }}
     uses: armbian/scripts/.github/workflows/update-version.yml@master

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,8 +2,14 @@ name: "Automatic Labeler"
 on:
 - pull_request_target
 
+permissions:
+  contents: read
+
 jobs:
   triage:
+    permissions:
+      contents: read  # for actions/labeler to determine modified files
+      pull-requests: write  # for actions/labeler to add labels to PRs
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@v3

--- a/.github/workflows/lint-scripts-on-merge-request.yml
+++ b/.github/workflows/lint-scripts-on-merge-request.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     types: [review_requested, ready_for_review]
 
+permissions:
+  contents: read
+
 jobs:
 
   Shellcheck:

--- a/.github/workflows/maintain.yml
+++ b/.github/workflows/maintain.yml
@@ -3,9 +3,14 @@ name: Maintain Runners
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
 
   fake:
+    permissions:
+      contents: none
     runs-on: small
     name: Source changes
     if: ${{ github.repository_owner == 'Armbian' }}
@@ -19,6 +24,8 @@ jobs:
           if-no-files-found: ignore
 
   Bump:
+    permissions:
+      contents: none
     needs: [ fake ]
     if: github.repository_owner == 'Armbian'
     uses: armbian/scripts/.github/workflows/maintain-runners.yml@master

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -2,8 +2,14 @@ name: Automatic Rebase
 on:
   issue_comment:
     types: [created]
+permissions:
+  contents: read
+
 jobs:
   rebase:
+    permissions:
+      contents: write  # for cirrus-actions/rebase to push code to rebase
+      pull-requests: read  # for cirrus-actions/rebase to get info about PR
     name: Rebase
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -3,9 +3,14 @@ name: Smoke tests on DUTs
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
 
   Smoke:
+    permissions:
+      contents: none
     if: ${{ github.repository_owner == 'Armbian' }}
     uses: armbian/scripts/.github/workflows/smoke-tests.yml@master
     secrets:

--- a/.github/workflows/update-docker.yml
+++ b/.github/workflows/update-docker.yml
@@ -5,9 +5,14 @@ on:
   schedule:
     - cron:  '0 0 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
 
   Docker:
+    permissions:
+      contents: none
     if: ${{ github.repository_owner == 'Armbian' }}
     uses: armbian/scripts/.github/workflows/update-docker-image.yml@master
     
@@ -15,6 +20,8 @@ jobs:
       CR_PAT: ${{ secrets.CR_PAT }}
 
   Docker-test:
+    permissions:
+      contents: none
     needs: Docker
     if: ${{ github.repository_owner == 'Armbian' }}    
     uses: armbian/scripts/.github/workflows/build-test-image-docker.yml@master

--- a/.github/workflows/update-repository.yml
+++ b/.github/workflows/update-repository.yml
@@ -3,9 +3,14 @@ name: Update Repository
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
 
   apt-armbian-com:
+    permissions:
+      contents: none
     uses: armbian/scripts/.github/workflows/update-repository.yml@master
 
     with:
@@ -18,6 +23,8 @@ jobs:
       KNOWN_HOSTS_REPOSITORY: ${{ secrets.KNOWN_HOSTS_REPOSITORY }}
 
   beta-armbian-com:
+    permissions:
+      contents: none
     uses: armbian/scripts/.github/workflows/update-repository.yml@master
 
     with:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
