### PR TITLE
chore(deps) : Pin actions to a full length commit SHA.

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - run: |
           echo "not empty" > changes
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
         with:
           path: changes
           name: changes

--- a/.github/workflows/build-kernel-on-merge-request.yml
+++ b/.github/workflows/build-kernel-on-merge-request.yml
@@ -44,9 +44,9 @@ jobs:
     runs-on: "small"
     if: ${{ github.repository_owner == 'Armbian' }}
     steps:
-      - uses: geekyeggo/delete-artifact@v1
+      - uses: geekyeggo/delete-artifact@b73cb986740e466292a536d0e32e2666c56fdeb3 # v1
         with:
           name: changes
-      - uses: geekyeggo/delete-artifact@v1
+      - uses: geekyeggo/delete-artifact@b73cb986740e466292a536d0e32e2666c56fdeb3 # v1
         with:
           name: hash

--- a/.github/workflows/build-train.yml
+++ b/.github/workflows/build-train.yml
@@ -23,7 +23,7 @@ jobs:
     if: ${{ github.repository_owner == 'Armbian' }}
     runs-on: small
     steps:
-      - uses: n1hility/cancel-previous-runs@v2
+      - uses: n1hility/cancel-previous-runs@953c92201f368370112ea2754545cb4468d89f12 # v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build-u-boot.yml
+++ b/.github/workflows/build-u-boot.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - run: |
           echo "not empty" > changes
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
         with:
           path: changes
           name: changes

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - run: |
           echo "not empty" > changes
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
         with:
           path: changes
           name: changes

--- a/.github/workflows/forked-helper.yml
+++ b/.github/workflows/forked-helper.yml
@@ -27,7 +27,7 @@ jobs:
           echo "::set-output name=event_details::${JSON}"
       - name: Dispatch event on forked repostitory
         if: steps.get_dispatch_secret.outputs.dispatch_secret
-        uses: peter-evans/repository-dispatch@v1
+        uses: peter-evans/repository-dispatch@ce5485de42c9b2622d2ed064be479e8ed65e76f4 # v1
         with:
           token: ${{ steps.get_dispatch_secret.outputs.dispatch_secret }}
           repository: ${{ github.repository }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,6 +6,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v3
+    - uses: actions/labeler@26546f6c4d63b6c0623e8e39bde7869e3c2b1d7b # v3
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/lint-scripts-on-merge-request.yml
+++ b/.github/workflows/lint-scripts-on-merge-request.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
 
        - name: Checkout repository
-         uses: actions/checkout@v2
+         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
 
        - name: Environment variables
          run: sudo -E bash -c set
@@ -29,7 +29,7 @@ jobs:
            (for file in $(find config -type f -exec grep -Iq . {} \; -print); do shellcheck --format=diff $file; done;) 2> /dev/null > config.diff || true
 
        - name: Upload build artifacts
-         uses: actions/upload-artifact@v2
+         uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
          with:
           name: Shellcheck
           path: "*.diff"

--- a/.github/workflows/maintain.yml
+++ b/.github/workflows/maintain.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - run: |
           echo "not empty" > changes
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
         with:
           path: changes
           name: changes

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code
-        uses: actions/checkout@v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
       - name: Automatic Rebase
-        uses: cirrus-actions/rebase@1.4
+        uses: cirrus-actions/rebase@7cea12ac34ab078fa37e87798d8986185afa7bf2 # 1.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Pinned actions by SHA https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies

>Pin actions to a full length commit SHA

>Pinning an action to a full length commit SHA is currently the only way to use an action
>as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad
> actor adding a backdoor to the action's repository, as they would need
> to generate a SHA-1 collision for a valid Git object payload.

[How do I validate these SHA?](https://gist.github.com/naveensrinivasan/ca008c07279176acce28969fb77d056f)

https://julienrenaux.fr/2019/12/20/github-actions-security-risk/

https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

Also, dependabot supports upgrading based on SHA.

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>

