### PR TITLE
workaround for orangepi 3 lts ethernet problem

### DIFF
--- a/patch/kernel/archive/sunxi-5.15/patches.armbian/0011-add-initial-support-for-orangepi3-lts.patch
+++ b/patch/kernel/archive/sunxi-5.15/patches.armbian/0011-add-initial-support-for-orangepi3-lts.patch
@@ -27,7 +27,7 @@ new file mode 100644
 index 000000000..cc5a73026
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-3-lts.dts
-@@ -0,0 +1,398 @@
+@@ -0,0 +1,397 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +// Copyright (C) 2019 Ondřej Jirman <megous@megous.com>
 +
@@ -178,6 +178,9 @@ index 000000000..cc5a73026
 +	phy-supply = <&reg_gmac_3v3>;
 +	allwinner,rx-delay-ps = <200>;
 +	allwinner,tx-delay-ps = <300>;
++	snps,reset-gpio = <&pio 3 14 GPIO_ACTIVE_LOW>; /* PD14 */
++	snps,reset-delays-us = <0 10000 1000000>;
++	snps,reset-active-low;
 +	status = "okay";
 +};
 +
@@ -185,10 +188,6 @@ index 000000000..cc5a73026
 +	ext_rgmii_phy: ethernet-phy@1 {
 +		compatible = "ethernet-phy-ieee802.3-c22";
 +		reg = <1>;
-+
-+		reset-gpios = <&pio 3 14 GPIO_ACTIVE_LOW>; /* PD14 */
-+		reset-assert-us = <15000>;
-+		reset-deassert-us = <40000>;
 +	};
 +};
 +


### PR DESCRIPTION
Method from uboot Odroid C2 fix, same problem same workaround.

# Description

On linux 5.15 the new ethernet chip can not be resetted properly. The workaround from uboot Odroid C2 is tested able to fix this.

The commit updates the existing patch.

https://forum.armbian.com/topic/19846-orange-pi3-lts/page/10/#comment-141243

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [√ ] Test ethernet with modified dtb

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
