### PR TITLE
Apply branding to kernel version

### DIFF
--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -440,6 +440,9 @@ compile_kernel()
 		fi
 	fi
 
+	# mark kernel by default
+	[[ -f .config ]] && sed -i 's/CONFIG_LOCALVERSION=""/CONFIG_LOCALVERSION="-armbian"/g' .config
+
 	call_extension_method "custom_kernel_config" << 'CUSTOM_KERNEL_CONFIG'
 *Kernel .config is in place, still clean from git version*
 Called after ${LINUXCONFIG}.config is put in place (.config).


### PR DESCRIPTION
# Description

Linux odroidn2 5.10.123-meson64 → Linux odroidn2 5.10.123-armbian-meson64 

Jira reference number [AR-1233]

# How Has This Been Tested?

- [x] Build kernel.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1233]: https://armbian.atlassian.net/browse/AR-1233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ