### PR TITLE
rk322x: update MGLRU patch for armhf for v5.17 and v5.18

### DIFF
--- a/patch/kernel/archive/rk322x-5.17/0003-mglru-framework-armhf-fix.patch
+++ b/patch/kernel/archive/rk322x-5.17/0003-mglru-framework-armhf-fix.patch
@@ -68,7 +68,7 @@ index 479cf221b59d..fe0c6475a6b4 100644
  
  	start = max(pvmw->address & PMD_MASK, pvmw->vma->vm_start);
 -	end = pmd_addr_end(pvmw->address, pvmw->vma->vm_end);
-+	end = (pvmw->address | ~PMD_MASK) + 1 ? : pvmw->vma->vm_end;
++	end = min(pvmw->address | ~PMD_MASK, pvmw->vma->vm_end - 1) + 1;
  
  	if (end - start > MIN_LRU_BATCH * PAGE_SIZE) {
  		if (pvmw->address - start < MIN_LRU_BATCH * PAGE_SIZE / 2)

--- a/patch/kernel/archive/rk322x-5.18/0003-mglru-framework-armhf-fix.patch
+++ b/patch/kernel/archive/rk322x-5.18/0003-mglru-framework-armhf-fix.patch
@@ -68,7 +68,7 @@ index 479cf221b59d..fe0c6475a6b4 100644
  
  	start = max(pvmw->address & PMD_MASK, pvmw->vma->vm_start);
 -	end = pmd_addr_end(pvmw->address, pvmw->vma->vm_end);
-+	end = (pvmw->address | ~PMD_MASK) + 1 ? : pvmw->vma->vm_end;
++	end = min(pvmw->address | ~PMD_MASK, pvmw->vma->vm_end - 1) + 1;
  
  	if (end - start > MIN_LRU_BATCH * PAGE_SIZE) {
  		if (pvmw->address - start < MIN_LRU_BATCH * PAGE_SIZE / 2)


### PR DESCRIPTION
# Description

Minor fix for MGLRU armhf patch on kernel v5.17 and v5.18

# How Has This Been Tested?

- [x] Kernel compilation completes

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
