### PR TITLE
Adjust rk3399-legacy patches - fixes missing dtb files

### DIFF
--- a/patch/kernel/archive/rk3399-4.4/friendly-arm-modern-dts-links.patch
+++ b/patch/kernel/archive/rk3399-4.4/friendly-arm-modern-dts-links.patch
@@ -2,7 +2,7 @@ diff --git a/arch/arm64/boot/dts/rockchip/Makefile b/arch/arm64/boot/dts/rockchi
 index ef29add7..135bd50c 100644
 --- a/arch/arm64/boot/dts/rockchip/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/Makefile
-@@ -2,11 +2,15 @@ ifeq ($(CONFIG_MACH_NANOPI4),y)
+@@ -2,13 +2,17 @@ ifeq ($(CONFIG_MACH_NANOPI4),y)
  
  dtb-$(CONFIG_ARCH_ROCKCHIP) += \
  	rk3399-nanopi4-rev00.dtb \
@@ -13,6 +13,8 @@ index ef29add7..135bd50c 100644
 +	rk3399-nanopi-neo4.dtb \
  	rk3399-nanopi4-rev06.dtb \
  	rk3399-nanopi4-rev07.dtb \
+ 	rk3399-nanopi4-rev09.dtb \
+ 	rk3399-nanopi4-rev0a.dtb \
  	rk3399-nanopi4-rev21.dtb \
 +	rk3399-nanopi-m4v2.dtb \
  	rk3399-nanopi4-rev22.dtb \

--- a/patch/kernel/archive/rk3399-4.4/remove-older-8188eu-from-rockchip-wlan.patch
+++ b/patch/kernel/archive/rk3399-4.4/remove-older-8188eu-from-rockchip-wlan.patch
@@ -16,7 +16,7 @@ index fb0e47b2..10173fe6 100644
 +++ b/drivers/net/wireless/rockchip_wlan/Makefile
 @@ -1,6 +1,5 @@
  # SPDX-License-Identifier: GPL-2.0
- obj-$(CONFIG_AP6XXX)	+= rkwifi/
+ obj-$(CONFIG_BCMDHD)	+= rkwifi/
 -obj-$(CONFIG_RTL8188EU)	+= rtl8188eu/
  obj-$(CONFIG_RTL8188FU)	+= rtl8188fu/
  obj-$(CONFIG_RTL8189ES) += rtl8189es/


### PR DESCRIPTION
# Description

Fixes boot issues for FriendlyARM's boards in legacy mentioned in a [forum thread](https://forum.armbian.com/topic/21560-nanopim4v2-omv-and-4xsata-hat-does-not-boot-up-after-updating-armbian-firmwarebusterbuster-22051/).

Jira reference number [AR-1235]

# How Has This Been Tested?

- [x] Build and boot of NanoPi M4V2

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1235]: https://armbian.atlassian.net/browse/AR-1235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ