### PR TITLE
rockchip64: reworked PWM patch due to breakage in existing pwm dtbs

### DIFF
--- a/patch/kernel/archive/rockchip64-5.18/rk3568-pwm-rockchip.patch
+++ b/patch/kernel/archive/rockchip64-5.18/rk3568-pwm-rockchip.patch
@@ -1,5 +1,5 @@
 diff --git a/drivers/pwm/pwm-rockchip.c b/drivers/pwm/pwm-rockchip.c
-index f3647b317152..7905deaf7055 100644
+index f3647b31715..627cc1931dd 100644
 --- a/drivers/pwm/pwm-rockchip.c
 +++ b/drivers/pwm/pwm-rockchip.c
 @@ -1,9 +1,12 @@
@@ -222,7 +222,7 @@ index f3647b317152..7905deaf7055 100644
 +	 */
 +	rockchip_pwm_get_state(chip, pwm, state);
 +
-+	if (state->enabled || pc->oneshot)
++	if ((state->enabled || pc->oneshot) && pc->active_state)
 +		ret = pinctrl_select_state(pc->pinctrl, pc->active_state);
  out:
 -	clk_disable(pc->clk);
@@ -309,7 +309,7 @@ index f3647b317152..7905deaf7055 100644
  	}
  
  	count = of_count_phandle_with_args(pdev->dev.of_node,
-@@ -337,26 +398,44 @@ static int rockchip_pwm_probe(struct platform_device *pdev)
+@@ -337,26 +398,42 @@ static int rockchip_pwm_probe(struct platform_device *pdev)
  
  	ret = clk_prepare_enable(pc->clk);
  	if (ret) {
@@ -333,10 +333,8 @@ index f3647b317152..7905deaf7055 100644
 +	}
 +
 +	pc->active_state = pinctrl_lookup_state(pc->pinctrl, "active");
-+	if (IS_ERR(pc->active_state)) {
-+		dev_err(&pdev->dev, "No active pinctrl state\n");
-+		return PTR_ERR(pc->active_state);
-+	}
++	if (IS_ERR(pc->active_state))
++		pc->active_state = NULL;
 +
  	platform_set_drvdata(pdev, pc);
  
@@ -360,7 +358,7 @@ index f3647b317152..7905deaf7055 100644
  
  	ret = pwmchip_add(&pc->chip);
  	if (ret < 0) {
-@@ -365,15 +444,13 @@ static int rockchip_pwm_probe(struct platform_device *pdev)
+@@ -365,15 +442,13 @@ static int rockchip_pwm_probe(struct platform_device *pdev)
  	}
  
  	/* Keep the PWM clk enabled if the PWM appears to be up and running. */
@@ -378,7 +376,7 @@ index f3647b317152..7905deaf7055 100644
  err_clk:
  	clk_disable_unprepare(pc->clk);
  
-@@ -384,11 +461,24 @@ static int rockchip_pwm_remove(struct platform_device *pdev)
+@@ -384,11 +459,24 @@ static int rockchip_pwm_remove(struct platform_device *pdev)
  {
  	struct rockchip_pwm_chip *pc = platform_get_drvdata(pdev);
  
@@ -404,7 +402,7 @@ index f3647b317152..7905deaf7055 100644
  	return 0;
  }
  
-@@ -400,7 +490,21 @@ static struct platform_driver rockchip_pwm_driver = {
+@@ -400,7 +488,21 @@ static struct platform_driver rockchip_pwm_driver = {
  	.probe = rockchip_pwm_probe,
  	.remove = rockchip_pwm_remove,
  };


### PR DESCRIPTION
# Description

A recent rk356x patch changed part of pwm-rockchip.c file; in particular it adds a mandatory "active" pinctrl state, which is not expected for existing PWM users for all rockchip64 family chips (notably px30, rk3328 and rk3399) where PWM is in use and "active" pinctrl name is not provided.

In case PWM is used as modulator for some voltage regulation, may break opp and devfreq framework (in my particular case, a tv box, made cpu unable to do frequency scaling and prevented lima driver to be correctly setup).

This patch makes the "active" pinctrl state optional on v5.18 edge kernel for rockchip64.

# How Has This Been Tested?

- [x] Built kernel deb packages successfully, installed on existing rk3318 (rk3328 sibling) installation

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
