### PR TITLE
Action script for checking integrity of images

### DIFF
--- a/.github/workflows/check-integrity.yml
+++ b/.github/workflows/check-integrity.yml
@@ -20,7 +20,6 @@ jobs:
 
       - name: Mount test folders
         run: |
-          sudo apt-get -y -qq install parallel
           sudo mkdir -p dl
           sudo mount nas:/tank/armbian/dl.armbian.com/ dl
 

--- a/.github/workflows/check-integrity.yml
+++ b/.github/workflows/check-integrity.yml
@@ -1,0 +1,36 @@
+name: Check images integrity
+
+on:
+  workflow_dispatch:
+
+jobs:
+
+  Update:
+
+    name: Check images integrity
+    runs-on: [fast, igor]
+    if: ${{ github.repository_owner == 'Armbian' }}
+    steps:
+
+      - uses: igorpecovnik/freespace@main
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get -y -qq install parallel
+
+      - name: Mount test folders
+        run: |
+          sudo apt-get -y -qq install parallel
+          sudo mkdir -p dl
+          sudo mount nas:/tank/armbian/dl.armbian.com/ dl
+
+      - name: Integrity test in parallel
+        run: |
+          FILES=$(find dl -type f -name "*.xz")
+          for FILE in ${FILES[@]}
+          do
+           echo "$FILE"
+          done | sudo --preserve-env parallel --jobs 18 '
+              xz -t {}
+          '
+          sudo umount dl


### PR DESCRIPTION
# Description

Lets have some handy tool for fast checking of images integrity. It needs 10-15m to check all images on average big runner.

Jira reference number [AR-1236]

# How Has This Been Tested?

- [x] Test run

```
xz: dl/jetson-nano/archive/Armbian_22.05.1_Jetson-nano_jammy_edge_5.18.0_xfce_desktop.img.xz: Unexpected end of input
xz: dl/khadas-vim3l/archive/Armbian_22.05.1_Khadas-vim3l_jammy_edge_5.17.5_xfce_desktop.img.xz: Unexpected end of input
xz: dl/khadas-vim3l/archive/Armbian_22.05.1_Khadas-vim3l_focal_current_5.10.110_xfce_desktop.img.xz: Unexpected end of input
xz: dl/uefi-arm64/archive/Armbian_22.05.1_Uefi-arm64_focal_current_5.15.43_xfce_desktop.img.xz: Unexpected end of input
xz: dl/khadas-vim3/archive/Armbian_22.05.1_Khadas-vim3_jammy_edge_5.17.5_xfce_desktop.img.xz: Unexpected end of input
xz: dl/station-p2/archive/Armbian_22.05.1_Station-p2_bullseye_legacy_4.19.219_xfce_desktop.img.xz: Unexpected end of input
xz: dl/khadas-vim3/archive/Armbian_22.05.1_Khadas-vim3_focal_current_5.10.110_xfce_desktop.img.xz: Unexpected end of input
xz: dl/renegade/archive/Armbian_22.05.1_Renegade_focal_current_5.15.35_xfce_desktop.img.xz: Unexpected end of input
xz: dl/orangepione/archive/Armbian_22.05.1_Orangepione_focal_current_5.15.43_xfce_desktop.img.xz: Unexpected end of input
xz: dl/orangepioneplus/archive/Armbian_22.05.1_Orangepioneplus_focal_current_5.15.43_xfce_desktop.img.xz: Unexpected end of input
xz: dl/clockworkpi-a06/archive/Armbian_22.05.1_Clockworkpi-a06_bullseye_current_5.15.35_xfce_desktop.img.xz: Unexpected end of input
xz: dl/nanopim4v2/archive/Armbian_22.05.1_Nanopim4v2_focal_current_5.15.35_cinnamon_desktop.img.xz: Unexpected end of input
xz: dl/khadas-vim2/archive/Armbian_22.05.1_Khadas-vim2_focal_current_5.10.110_xfce_desktop.img.xz: Unexpected end of input
xz: dl/firefly-rk3399/archive/Armbian_22.05.1_Firefly-rk3399_bullseye_current_5.17.9_xfce_desktop.img.xz: Unexpected end of input
xz: dl/firefly-rk3399/archive/Armbian_22.05.1_Firefly-rk3399_bullseye_edge_5.18.0_xfce_desktop.img.xz: Unexpected end of input
xz: dl/rockpi-4b/archive/Armbian_22.05.1_Rockpi-4b_jammy_edge_5.18.0_xfce_desktop.img.xz: Unexpected end of input
xz: dl/station-m2/archive/Armbian_22.05.1_Station-m2_bullseye_legacy_4.19.219_xfce_desktop.img.xz: Unexpected end of input
xz: dl/station-m2/archive/Armbian_22.05.1_Station-m2_jammy_edge_5.18.0_xfce_desktop.img.xz: Unexpected end of input
xz: dl/pineh64-b/archive/Armbian_22.05.1_Pineh64-b_focal_current_5.15.43_xfce_desktop.img.xz: Unexpected end of input
xz: dl/khadas-vim1/archive/Armbian_22.05.1_Khadas-vim1_jammy_edge_5.17.5_xfce_desktop.img.xz: Unexpected end of input
xz: dl/station-m1/archive/Armbian_22.05.1_Station-m1_bullseye_edge_5.18.0_xfce_desktop.img.xz: Unexpected end of input
xz: dl/khadas-edge/archive/Armbian_22.05.1_Khadas-edge_focal_current_5.15.35_cinnamon_desktop.img.xz: Unexpected end of input
xz: dl/khadas-edge/archive/Armbian_22.05.1_Khadas-edge_jammy_edge_5.18.0_xfce_desktop.img.xz: Unexpected end of input
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1236]: https://armbian.atlassian.net/browse/AR-1236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ