### PR TITLE
Fixing wrong URL path in rootfs cache rfc

### DIFF
--- a/.github/workflows/update-cache.yml
+++ b/.github/workflows/update-cache.yml
@@ -284,7 +284,7 @@ jobs:
 
           ANNOUNCE=$(cat trackerslist/trackers_best_ip.txt | head -1)ANNOUNCE=$(cat trackerslist/trackers_best_ip.txt | sed '/^$/d' | shuf -n 1)
           TRACKERS=$(cat trackerslist/trackers_all.txt | sed '/^\s*$/d' | while read line; do printf ",""${line}"; done | cut -c 2-)
-          WEBSEEDS="--webseeds=https://github.com/armbian/mirror/releases/download/_rootfs/$FILE,https://imola.armbian.com/dl/_rootfs/_rootfs/$FILE,https://stpete-mirror.armbian.com/dl/_rootfs/$FILE"
+          WEBSEEDS="--webseeds=https://github.com/armbian/mirror/releases/download/_rootfs/$FILE,https://imola.armbian.com/dl/_rootfs/$FILE,https://stpete-mirror.armbian.com/dl/_rootfs/$FILE"
           cd build/cache/rootfs.upload
           FILES=$(ls -1 *.lz4)
           for FILE in ${FILES[@]}


### PR DESCRIPTION
# Description

Fixing wrong URL path in rootfs cache rfc

Jira reference number [AR-1230]

# How Has This Been Tested?

- [x] Obvious problem. Not tested


[AR-1230]: https://armbian.atlassian.net/browse/AR-1230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ