### PR TITLE
Fix for wrong board status report at first login

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -356,7 +356,7 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 			echo -e "\nSupport status: \e[0;31mno support\x1B[0m (edge kernel branch)"
 		elif [[ "$DISTRIBUTION_STATUS" != "supported" ]]; then
 			echo -e "\nSupport status: \e[0;31mno support\x1B[0m (unsupported userspace)"
-		elif [[ "$BOARD_TYPE" != "supported" ]]; then
+		elif [[ "$BOARD_TYPE" != "conf" ]]; then
 			echo -e "\nSupport status: \e[0;31mcommunity support\x1B[0m (looking for a dedicated maintainer)"
 		fi
 	else


### PR DESCRIPTION
# Description

Cosmetic bugfix.

Jira reference number [AR-1239]

Ref: 
- https://github.com/armbian/build/blob/master/lib/main.sh#L260-L270
- https://github.com/armbian/build/blob/master/lib/makeboarddeb.sh#L297


# How Has This Been Tested?

- [x] Manual run

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1239]: https://armbian.atlassian.net/browse/AR-1239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ