### PR TITLE
feat: install_pkg_deb: Add the ability to install package files in function

### DIFF
--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1202,13 +1202,14 @@ wait_for_package_manager()
 
 
 
-# Installing debian packages in the armbian build system.
+# Installing debian packages or package files in the armbian build system.
 # The function accepts four optional parameters:
 # autoupdate - If the installation list is not empty then update first.
 # upgrade, clean - the same name for apt
 # verbose - detailed log for the function
 #
 # list="pkg1 pkg2 pkg3 pkgbadname pkg-1.0 | pkg-2.0 pkg5 (>= 9)"
+# or list="pkg1 pkg2 /path-to/output/debs/file-name.deb"
 # install_pkg_deb upgrade verbose $list
 # or
 # install_pkg_deb autoupdate $list
@@ -1223,7 +1224,9 @@ wait_for_package_manager()
 install_pkg_deb ()
 {
 	local list=""
+	local listdeb=""
 	local log_file
+	local add_for_install
 	local for_install
 	local need_autoup=false
 	local need_upgrade=false
@@ -1235,7 +1238,12 @@ install_pkg_deb ()
 	local tmp_file=$(mktemp /tmp/install_log_XXXXX)
 	export DEBIAN_FRONTEND=noninteractive
 
-	list=$(
+	if [ -d $(dirname $LOG_OUTPUT_FILE) ]; then
+		log_file=${LOG_OUTPUT_FILE}
+	else
+		log_file="${SRC}/output/${LOG_SUBPATH}/install.log"
+	fi
+
 	for p in $*;do
 		case $p in
 			autoupdate) need_autoup=true; continue ;;
@@ -1243,21 +1251,32 @@ install_pkg_deb ()
 			clean) need_clean=true; continue ;;
 			verbose) need_verbose=true; continue ;;
 			\||\(*|*\)) continue ;;
+			*[.]deb) listdeb+=" $p"; continue ;;
+			*) list+=" $p" ;;
 		esac
-		echo " $p"
 	done
-	)
-
-	if [ -d $(dirname $LOG_OUTPUT_FILE) ]; then
-		log_file=${LOG_OUTPUT_FILE}
-	else
-		log_file="${SRC}/output/${LOG_SUBPATH}/install.log"
-	fi
 
 	# This is necessary first when there is no apt cache.
 	if $need_upgrade; then
 		apt-get -q update || echo "apt cannot update" >>$tmp_file
 		apt-get -y upgrade || echo "apt cannot upgrade" >>$tmp_file
+	fi
+
+	# Install debian package files
+	if [ -n "$listdeb" ];then
+		for f in $listdeb;do
+			# Calculate dependencies for installing the package file
+			add_for_install=" $(
+				dpkg-deb -f $f Depends | awk '{gsub(/[,]/, "", $0); print $0}'
+			)"
+
+			echo -e "\nfile $f depends on:\n$add_for_install"  >>$log_file
+			install_pkg_deb $add_for_install
+			dpkg -i $f 2>>$log_file
+			dpkg-query -W \
+					   -f '${binary:Package;-27} ${Version;-23}\n' \
+					   $(dpkg-deb -f $f Package) >>$log_file
+		done
 	fi
 
 	# If the package is not installed, check the latest


### PR DESCRIPTION
# Description

Continuation of work on the development of a unified package installation function in the armbian build system.
Sometimes we need to install a package as a package file that is located in the local directory. Now the function will independently calculate the package dependencies and install these dependencies and the package file itself.

# How Has This Been Tested?

It is well tested. We can start using this new opportunity.

- [x] The installation of packages that are not available in the available repositories has been tested.
      The packages were taken\downloaded from third-party sources.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
