### PR TITLE
Fix docker image

### DIFF
--- a/config/templates/Dockerfile
+++ b/config/templates/Dockerfile
@@ -21,7 +21,7 @@ RUN sh -c " \
         libc6-i386; \
     fi"
 RUN apt-get update \
-    && apt-get -y upgrade \
+    && apt-get -y dist-upgrade \
     && apt-get install -y --no-install-recommends \
        $CUSTOM_PACKAGES \
        acl \

--- a/config/templates/Dockerfile
+++ b/config/templates/Dockerfile
@@ -3,7 +3,7 @@ FROM $BASE_IMAGE as armbian_builder
 ARG CUSTOM_PACKAGES='g++-11-arm-linux-gnueabihf libssl3'
 ENV CUSTOM_PACKAGES $CUSTOM_PACKAGES
 ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get -y install \
+RUN apt-get update && apt-get -y dist-upgrade && apt-get -y install \
        joe \
        software-properties-common \
        gnupg \


### PR DESCRIPTION
# Description

I get build failure on github workflows these days: https://github.com/amazingfate/armbian-rock3a-images/runs/7027392971?check_suite_focus=true.
Root cause is that packages in docker images pulled from docker hub is older than the packages we want to install, so a dist-upgrade is needed.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Build on github workflow doesn't have errors in docker build step: https://github.com/amazingfate/armbian-rock3a-images/runs/7037134062?check_suite_focus=true

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
