### PR TITLE
Refactored orangepi-r1plus-lts dts in u-boot add board patch.

### DIFF
--- a/patch/u-boot/u-boot-rockchip64/add-board-orangepi-r1-plus-lts.patch
+++ b/patch/u-boot/u-boot-rockchip64/add-board-orangepi-r1-plus-lts.patch
@@ -1,21 +1,14 @@
-From 47105c8bbcdd62b9d66eb98bcbc7c5607cfb8b42 Mon Sep 17 00:00:00 2001
 From: schwar3kat <61094841+schwar3kat@users.noreply.github.com>
-Date: Tue, 15 Feb 2022 13:47:03 +1300
-Subject: [PATCH] Patching something
+Date: Wed, 08 Jun 2022 13:47:03 +1300
+Subject: Add u-boot support rk3328-orangepi-r1-plus
 
 Signed-off-by: schwar3kat <61094841+schwar3kat@users.noreply.github.com>
 ---
- arch/arm/dts/Makefile                         |   2 +
- arch/arm/dts/rk3328-nanopi-r2-common.dtsi     | 624 ++++++++++++++++++
- .../dts/rk3328-nanopi-r2-rev00-u-boot.dtsi    |  16 +
- arch/arm/dts/rk3328-nanopi-r2-rev00.dts       | 145 ++++
- arch/arm/dts/rk3328-orangepi-r1-plus-lts.dts  |  48 ++
+ arch/arm/dts/Makefile                         |   1 +
+ arch/arm/dts/rk3328-orangepi-r1-plus-lts.dts  | 607 ++++++++++++++++++
  configs/orangepi_r1_plus_lts_rk3328_defconfig |  95 +++
  drivers/net/phy/phy.c                         |   9 +
- 7 files changed, 939 insertions(+)
- create mode 100644 arch/arm/dts/rk3328-nanopi-r2-common.dtsi
- create mode 100644 arch/arm/dts/rk3328-nanopi-r2-rev00-u-boot.dtsi
- create mode 100644 arch/arm/dts/rk3328-nanopi-r2-rev00.dts
+ 3 files changed, 716 insertions(+)
  create mode 100644 arch/arm/dts/rk3328-orangepi-r1-plus-lts.dts
  create mode 100644 configs/orangepi_r1_plus_lts_rk3328_defconfig
 
@@ -32,31 +25,31 @@ index becf5c9d..bc6f8b09 100644
  	rk3328-roc-cc.dtb \
  	rk3328-rock64.dtb \
  	rk3328-rock-pi-e.dtb
-diff --git a/arch/arm/dts/rk3328-nanopi-r2-common.dtsi b/arch/arm/dts/rk3328-nanopi-r2-common.dtsi
+diff --git a/arch/arm/dts/rk3328-orangepi-r1-plus-lts.dts b/arch/arm/dts/rk3328-orangepi-r1-plus-lts.dts
 new file mode 100644
-index 00000000..186b51f6
+index 00000000..3a446b4e
 --- /dev/null
-+++ b/arch/arm/dts/rk3328-nanopi-r2-common.dtsi
-@@ -0,0 +1,624 @@
++++ b/arch/arm/dts/rk3328-orangepi-r1-plus-lts.dts
+@@ -0,0 +1,607 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
-+ * Copyright (c) 2018 FriendlyElec Computer Tech. Co., Ltd.
-+ * (http://www.friendlyarm.com)
-+ *
-+ * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd
++ * Copyright (c) 2020 Shenzhen Xunlong Software CO.,Limited
++ * Copyright (c) 2021 AmadeusGhost <amadeus@jmu.edu.cn>
++ * Revised for Orange Pi R1 Plus LTS (c) 2022 schwar3kat
++ * Based on Orange Pi R1
 + */
 +
 +/dts-v1/;
-+/*#include "rk3328-dram-default-timing.dtsi"*/
++#include <dt-bindings/input/linux-event-codes.h>
 +#include "rk3328.dtsi"
 +
 +/ {
-+	model = "FriendlyElec boards based on Rockchip RK3328";
-+	compatible = "friendlyelec,nanopi-r2",
-+		   "rockchip,rk3328";
++	model = "Xunlong Orange Pi R1 Plus LTS";
++	compatible = "xunlong,orangepi-r1-plus", "rockchip,rk3328";
 +
 +	aliases {
-+/*		ethernet1 = &r8153;*/
++		ethernet1 = &rtl8153;
++		mmc0 = &sdmmc;
 +	};
 +
 +	chosen {
@@ -72,10 +65,10 @@ index 00000000..186b51f6
 +	};
 +
 +	mach: board {
-+		compatible = "friendlyelec,board";
-+		machine = "NANOPI-R2";
++		compatible = "orangepi,board";
++		machine = "ORANGEPI-R1-LTS";
 +		hwrev = <255>;
-+		model = "NanoPi R2 Series";
++		model = "OrangePi R1 Series";
 +		nvmem-cells = <&efuse_id>, <&efuse_cpu_version>;
 +		nvmem-cell-names = "id", "cpu-version";
 +	};
@@ -85,6 +78,8 @@ index 00000000..186b51f6
 +		pinctrl-names = "default";
 +		pinctrl-0 =<&leds_gpio>;
 +		status = "disabled";
++		#address-cells = <1>;
++		#size-cells = <0>;
 +
 +		led@1 {
 +			gpios = <&gpio0 RK_PA2 GPIO_ACTIVE_HIGH>;
@@ -109,18 +104,6 @@ index 00000000..186b51f6
 +		 */
 +		reset-gpios = <&gpio3 RK_PB0 GPIO_ACTIVE_LOW>;
 +	};
-+
-+/*	sdmmc_ext: dwmmc@ff5f0000 {
-+		compatible = "rockchip,rk3328-dw-mshc", "rockchip,rk3288-dw-mshc";
-+		reg = <0x0 0xff5f0000 0x0 0x4000>;
-+		clock-freq-min-max = <400000 150000000>;
-+		clocks = <&cru HCLK_SDMMC_EXT>, <&cru SCLK_SDMMC_EXT>,
-+			 <&cru SCLK_SDMMC_EXT_DRV>, <&cru SCLK_SDMMC_EXT_SAMPLE>;
-+		clock-names = "biu", "ciu", "ciu-drv", "ciu-sample";
-+		fifo-depth = <0x100>;
-+		interrupts = <GIC_SPI 4 IRQ_TYPE_LEVEL_HIGH>;
-+		status = "disabled";
-+	};*/
 +
 +	vcc_sd: sdmmc-regulator {
 +		compatible = "regulator-fixed";
@@ -181,72 +164,7 @@ index 00000000..186b51f6
 +		rockchip,grf = <&grf>;
 +		status = "disabled";
 +	};
-+
-+/*	dmc: dmc {
-+		compatible = "rockchip,rk3328-dmc";
-+		devfreq-events = <&dfi>;
-+		clocks = <&cru SCLK_DDRCLK>;
-+		clock-names = "dmc_clk";
-+		operating-points-v2 = <&dmc_opp_table>;
-+		ddr_timing = <&ddr_timing>;
-+		upthreshold = <40>;
-+		downdifferential = <20>;
-+		auto-min-freq = <786000>;
-+		auto-freq-en = <0>;
-+		#cooling-cells = <2>;
-+		status = "disabled";
-+
-+		ddr_power_model: ddr_power_model {
-+			compatible = "ddr_power_model";
-+			dynamic-power-coefficient = <120>;
-+			static-power-coefficient = <200>;
-+			ts = <32000 4700 (-80) 2>;
-+			thermal-zone = "soc-thermal";
-+		};
-+	};
-+
-+	dmc_opp_table: dmc-opp-table {
-+		compatible = "operating-points-v2";
-+
-+		rockchip,leakage-voltage-sel = <
-+			1   10    0
-+			11  254   1
-+		>;
-+		nvmem-cells = <&logic_leakage>;
-+		nvmem-cell-names = "ddr_leakage";
-+
-+		opp-786000000 {
-+			opp-hz = /bits/ 64 <786000000>;
-+			opp-microvolt = <1075000>;
-+			opp-microvolt-L0 = <1075000>;
-+			opp-microvolt-L1 = <1050000>;
-+		};
-+		opp-798000000 {
-+			opp-hz = /bits/ 64 <798000000>;
-+			opp-microvolt = <1075000>;
-+			opp-microvolt-L0 = <1075000>;
-+			opp-microvolt-L1 = <1050000>;
-+		};
-+		opp-840000000 {
-+			opp-hz = /bits/ 64 <840000000>;
-+			opp-microvolt = <1075000>;
-+			opp-microvolt-L0 = <1075000>;
-+			opp-microvolt-L1 = <1050000>;
-+		};
-+		opp-924000000 {
-+			opp-hz = /bits/ 64 <924000000>;
-+			opp-microvolt = <1100000>;
-+			opp-microvolt-L0 = <1100000>;
-+			opp-microvolt-L1 = <1075000>;
-+		};
-+		opp-1056000000 {
-+			opp-hz = /bits/ 64 <1056000000>;
-+			opp-microvolt = <1175000>;
-+			opp-microvolt-L0 = <1175000>;
-+			opp-microvolt-L1 = <1150000>;
-+		};
-+	};
-+*/};
++};
 +
 +&cpu0 {
 +	cpu-supply = <&vdd_arm>;
@@ -255,11 +173,6 @@ index 00000000..186b51f6
 +&dfi {
 +	status = "okay";
 +};
-+
-+/*&dmc {
-+	center-supply = <&vdd_logic>;
-+	status = "okay";
-+};*/
 +
 +&emmc {
 +	bus-width = <8>;
@@ -291,7 +204,7 @@ index 00000000..186b51f6
 +	clock_in_out = "input";
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&rgmiim1_pins>;
-+	phy-handle = <&rtl8211e>;
++	phy-handle = <&rtl8153>;
 +	phy-mode = "rgmii";
 +	phy-supply = <&vcc_phy>;
 +	snps,reset-active-low;
@@ -309,7 +222,7 @@ index 00000000..186b51f6
 +		#address-cells = <1>;
 +		#size-cells = <0>;
 +
-+		rtl8211e: phy@0 {
++		rtl8153: phy@0 {
 +			reg = <0>;
 +			reset-assert-us = <10000>;
 +			reset-deassert-us = <30000>;
@@ -574,135 +487,8 @@ index 00000000..186b51f6
 +	status = "okay";
 +};
 +
-+/*&sdmmc_ext {
-+	bus-width = <4>;
-+	cap-sd-highspeed;
-+	cap-sdio-irq;
-+	disable-wp;
-+	keep-power-in-suspend;
-+	max-frequency = <100000000>;
-+	mmc-pwrseq = <&sdio_pwrseq>;
-+	non-removable;
-+	num-slots = <1>;
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&sdmmc0ext_clk &sdmmc0ext_cmd &sdmmc0ext_bus4>;
-+	rockchip,default-sample-phase = <120>;
-+	supports-sdio;
-+	sd-uhs-sdr104;
-+	#address-cells = <1>;
-+	#size-cells = <0>;
-+	status = "okay";
-+
-+	brcmf: bcrmf@1 {
-+		reg = <1>;
-+		compatible = "brcm,bcm4329-fmac";
-+		interrupt-parent = <&gpio1>;
-+		interrupts = <RK_PD2 IRQ_TYPE_LEVEL_HIGH>;
-+		interrupt-names = "host-wake";
-+	};
-+};*/
-+
-+/*&tsadc {
-+	status = "okay";
-+};*/
-+
 +&uart2 {
 +	status = "okay";
-+};
-+
-+/*&u2phy {
-+	status = "okay";
-+};
-+
-+&u2phy_host {
-+	status = "okay";
-+};
-+
-+&u2phy_otg {
-+	status = "okay";
-+};
-+
-+&u3phy {
-+	vbus-supply = <&vcc_host_vbus>;
-+	status = "okay";
-+};
-+
-+&u3phy_utmi {
-+	status = "okay";
-+};
-+
-+&u3phy_pipe {
-+	status = "okay";
-+};
-+
-+&usb20_otg {
-+	status = "okay";
-+};
-+
-+&usb_host0_ehci {
-+	status = "okay";
-+};
-+
-+&usb_host0_ohci {
-+	status = "okay";
-+};
-+
-+&usbdrd3 {
-+	status = "okay";
-+};
-+
-+&usbdrd_dwc3 {
-+	status = "okay";
-+	#address-cells = <1>;
-+	#size-cells = <0>;
-+
-+	r8153: device@2 {
-+		compatible = "usbbda:8153";
-+		reg = <2>;
-+		local-mac-address = [00 00 00 00 00 00];
-+	};
-+};*/
-diff --git a/arch/arm/dts/rk3328-nanopi-r2-rev00-u-boot.dtsi b/arch/arm/dts/rk3328-nanopi-r2-rev00-u-boot.dtsi
-new file mode 100644
-index 00000000..cf3452ea
---- /dev/null
-+++ b/arch/arm/dts/rk3328-nanopi-r2-rev00-u-boot.dtsi
-@@ -0,0 +1,16 @@
-+// SPDX-License-Identifier: GPL-2.0+
-+/*
-+ * (C) Copyright 2018-2019 Rockchip Electronics Co., Ltd
-+ */
-+
-+#include "rk3328-u-boot.dtsi"
-+#include "rk3328-sdram-ddr4-666.dtsi"
-+/ {
-+	chosen {
-+		u-boot,spl-boot-order = "same-as-spl", &sdmmc, &emmc;
-+	};
-+};
-+
-+&usb_host0_xhci {
-+	status = "okay";
-+};
-diff --git a/arch/arm/dts/rk3328-nanopi-r2-rev00.dts b/arch/arm/dts/rk3328-nanopi-r2-rev00.dts
-new file mode 100644
-index 00000000..c02412b6
---- /dev/null
-+++ b/arch/arm/dts/rk3328-nanopi-r2-rev00.dts
-@@ -0,0 +1,145 @@
-+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
-+/*
-+ * Copyright (c) 2019 FriendlyElec Computer Tech. Co., Ltd.
-+ * (http://www.friendlyarm.com)
-+ */
-+
-+/dts-v1/;
-+#include <dt-bindings/input/linux-event-codes.h>
-+#include "rk3328-nanopi-r2-common.dtsi"
-+
-+/ {
-+	model = "FriendlyElec NanoPi R2S";
-+	compatible = "friendlyelec,nanopi-r2", "rockchip,rk3328";
 +
 +	gpio-keys {
 +		compatible = "gpio-keys";
@@ -714,6 +500,7 @@ index 00000000..c02412b6
 +		pinctrl-0 = <&gpio_key1>;
 +
 +		button@0 {
++		reg = <0>;
 +			gpios = <&gpio0 RK_PA0 GPIO_ACTIVE_LOW>;
 +			label = "reset";
 +			linux,code = <BTN_1>;
@@ -737,10 +524,6 @@ index 00000000..c02412b6
 +	};
 +};
 +
-+&mach {
-+	hwrev = <0>;
-+	model = "NanoPi R2S";
-+};
 +
 +&emmc {
 +	status = "disabled";
@@ -756,11 +539,13 @@ index 00000000..c02412b6
 +	led@2 {
 +		gpios = <&gpio2 RK_PB7 GPIO_ACTIVE_HIGH>;
 +		label = "lan_led";
++		reg = <0>;
 +	};
 +
 +	led@3 {
 +		gpios = <&gpio2 RK_PC2 GPIO_ACTIVE_HIGH>;
 +		label = "wan_led";
++		reg = <0>;
 +	};
 +};
 +
@@ -770,12 +555,6 @@ index 00000000..c02412b6
 +		<2 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>,
 +		<2 RK_PC2 RK_FUNC_GPIO &pcfg_pull_none>;
 +};
-+
-+/*&pwm2 {
-+	pinctrl-names = "default", "sleep";
-+	pinctrl-1 = <&pwm2_sleep_pin>;
-+	status = "okay";
-+};*/
 +
 +&rk805 {
 +	interrupt-parent = <&gpio1>;
@@ -797,10 +576,6 @@ index 00000000..c02412b6
 +	sd-uhs-sdr104;
 +	status = "okay";
 +};
-+
-+/*&sdmmc_ext {
-+	status = "disabled";
-+};*/
 +
 +&sdio_pwrseq {
 +	status = "disabled";
@@ -835,26 +610,6 @@ index 00000000..c02412b6
 +		};
 +	};
 +};
-diff --git a/arch/arm/dts/rk3328-orangepi-r1-plus-lts.dts b/arch/arm/dts/rk3328-orangepi-r1-plus-lts.dts
-new file mode 100644
-index 00000000..3a446b4e
---- /dev/null
-+++ b/arch/arm/dts/rk3328-orangepi-r1-plus-lts.dts
-@@ -0,0 +1,48 @@
-+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
-+/*
-+ * Copyright (c) 2020 Shenzhen Xunlong Software CO.,Limited
-+ * Copyright (c) 2021 AmadeusGhost <amadeus@jmu.edu.cn>
-+ *
-+ * Based on Nanopi R2S
-+ */
-+
-+#include "rk3328-nanopi-r2-rev00.dts"
-+
-+/ {
-+	model = "Xunlong Orange Pi R1 Plus LTS";
-+	compatible = "xunlong,orangepi-r1-plus", "rockchip,rk3328";
-+};
 +
 +&leds_gpio {
 +	rockchip,pins =
@@ -866,14 +621,8 @@ index 00000000..3a446b4e
 +&leds {
 +	led@1 {
 +		gpios = <&gpio3 RK_PC5 GPIO_ACTIVE_HIGH>;
++		reg = <0>;
 +	};
-+};
-+
-+&mach {
-+	compatible = "orangepi,board";
-+	hwrev = <2>;
-+	machine = "ORANGEPI-R1PLUS";
-+	model = "OrangePi R1PLUS";
 +};
 +
 +&spi0 {
@@ -889,12 +638,13 @@ index 00000000..3a446b4e
 +&uart1 {
 +	status = "okay";
 +};
++
 diff --git a/configs/orangepi_r1_plus_lts_rk3328_defconfig b/configs/orangepi_r1_plus_lts_rk3328_defconfig
 new file mode 100644
-index 00000000..627797f9
+index 000000000..627797f91
 --- /dev/null
 +++ b/configs/orangepi_r1_plus_lts_rk3328_defconfig
-@@ -0,0 +1,98 @@
+@@ -0,0 +1,99 @@
 +CONFIG_ARM=y
 +CONFIG_SKIP_LOWLEVEL_INIT=y
 +CONFIG_ARCH_ROCKCHIP=y
@@ -1018,6 +768,6 @@ index ed197fa4..6a14eada 100644
  	list_for_each(entry, &phy_drivers) {
  		drv = list_entry(entry, struct phy_driver, list);
  		if ((drv->uid & drv->mask) == (phy_id & drv->mask))
--- 
+
 
 


### PR DESCRIPTION
The current patch is a direct copy of the OEM setup.  It includes Nanopi dts files that belong to other boards.
Remove unnecessary Nanopi device tree includes and files.  
Incorporate the appropriate nodes into orangepi-r1plus-lts tree. 
Remove the Nanopi dts files from the patch. 

Jira reference number [AR-1243]

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

Tested on orangepi-r1-lts board.
Iperf tests on both ports produced expected results in bidirectional tests.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1243]: https://armbian.atlassian.net/browse/AR-1243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ