### PR TITLE
rockchip64: set gpu governor default to simple_ondemand

### DIFF
--- a/packages/bsp/rk3399/20-gpu-governor.conf
+++ b/packages/bsp/rk3399/20-gpu-governor.conf
@@ -1,2 +1,2 @@
-# Set "performance" GPU devfreq governor, "simple_ondemand" works bad in recent kernels
-devices/platform/ff9a0000.gpu/devfreq/ff9a0000.gpu/governor = performance
+# Set "simple_ondemand" GPU devfreq governor, "performance" increase power consumption by ca. 150mW
+devices/platform/ff9a0000.gpu/devfreq/ff9a0000.gpu/governor = simple_ondemand


### PR DESCRIPTION
# Description

GPU governor for rk3399 (Mali T860, Panfrost driver) was set to “performance” 4 years ago due to issues with simple_ondemand; nowadays simple_ondemand works just fine.

This fix makes my board (Orange PI 4 LTS) consume ~25mA (125mW) less current and obviously makes soc fresher.

Jira reference number [AR-1246]

# How Has This Been Tested?

- [x] Tested setting simple_ondemand manually on official Ubuntu Jammy XFCE image
- [x] Built Ubuntu Jammy XFCE image from scratch 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1246]: https://armbian.atlassian.net/browse/AR-1246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ