### PR TITLE
rockchip64: fix pwm regulators that use pinctrl "active" configuration

### DIFF
--- a/patch/kernel/archive/rockchip64-5.15/add-board-orangepi-4-lts.patch
+++ b/patch/kernel/archive/rockchip64-5.15/add-board-orangepi-4-lts.patch
@@ -880,7 +880,7 @@ index 00000000000..4adb1534ea5
 +
 +&pwm2 {
 +	status = "okay";
-+	pinctrl-names = "active";
++	pinctrl-names = "default";
 +	pinctrl-0 = <&pwm2_pin_pull_down>;
 +};
 +

--- a/patch/kernel/archive/rockchip64-5.15/add-board-orangepi-4.patch
+++ b/patch/kernel/archive/rockchip64-5.15/add-board-orangepi-4.patch
@@ -841,7 +841,7 @@ index 000000000..1e1747ceb
 +
 +&pwm2 {
 +	status = "okay";
-+	pinctrl-names = "active";
++	pinctrl-names = "default";
 +	pinctrl-0 = <&pwm2_pin_pull_down>;
 +};
 +

--- a/patch/kernel/archive/rockchip64-5.15/add-board-tinker-board-2.patch
+++ b/patch/kernel/archive/rockchip64-5.15/add-board-tinker-board-2.patch
@@ -571,7 +571,7 @@ index 000000000..dc337bee0
 +
 +&pwm2 {
 +	status = "okay";
-+	pinctrl-names = "active";
++	pinctrl-names = "default";
 +	pinctrl-0 = <&pwm2_pin_pull_down>;
 +};
 +


### PR DESCRIPTION
# Description

After some inspections related to pwm patch recently introduced and reverted on v5.18 kernel patchset (see https://github.com/armbian/build/pull/3928), it turned out that some boards (OrangePI 4/LTS, Tinkerboard 2) use a pinctrl configuration name **active** which is inherited from legacy kernel.
Mainline kernel does not use such pinctrl configuration name, but wants **default**.

This effect of this misnaming is an increased voltage supplied to "vdd_log" regulator and an increased power consumption since the configuration **active** is just ignored on mainline kernel.

Power consumption has been tested using a regular multimeter, on my OrangePI 4 LTS board, and with the patch applied results in a saving of ~40mA (200mW).

Jira reference number [AR-1247]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Built a Ubuntu Jammy Xfce image for OrangePI 4 LTS and tested on the board

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1247]: https://armbian.atlassian.net/browse/AR-1247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ