### PR TITLE
Add option to disable MMC_MODE_HS_52MHz

### DIFF
--- a/patch/u-boot/u-boot-meson64/0001-mmc-meson_gx_mmc-Add-MMC_MESON_GX_HS52_MODE-config.patch
+++ b/patch/u-boot/u-boot-meson64/0001-mmc-meson_gx_mmc-Add-MMC_MESON_GX_HS52_MODE-config.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yuntian Zhang <yt@radxa.com>
+Date: Mon, 27 Jun 2022 14:24:38 +0800
+Subject: [PATCH] mmc: meson_gx_mmc: Add MMC_MESON_GX_HS52_MODE config
+
+This option can be turned off to disable MMC High Speed 52MHz on the
+Meson controller. This helps eMMC stability on some faulty boards.
+
+Signed-off-by: Yuntian Zhang <yt@radxa.com>
+---
+ drivers/mmc/Kconfig        | 9 +++++++++
+ drivers/mmc/meson_gx_mmc.c | 4 ++++
+ 2 files changed, 13 insertions(+)
+
+diff --git a/drivers/mmc/Kconfig b/drivers/mmc/Kconfig
+index f04cc44e19..30f276749e 100644
+--- a/drivers/mmc/Kconfig
++++ b/drivers/mmc/Kconfig
+@@ -286,6 +286,15 @@ config MMC_MESON_GX
+ 	help
+ 	 Support for EMMC host controller on Meson GX ARM SoCs platform (S905)
+ 
++config MMC_MESON_GX_HS52_MODE
++	bool "Enable MMC High Speed 52MHz mode for Meson GX EMMC controller"
++	depends on MMC_MESON_GX
++	default y
++	help
++	 This selects HS52 mode for Meson controller. Some boards have stability
++	 issue when eMMC is running at this speed, and turning HS52 off allows
++	 eMMC to function properly.
++
+ config MMC_MXC
+ 	bool "Freescale i.MX21/27/31 or MPC512x Multimedia Card support"
+ 	help
+diff --git a/drivers/mmc/meson_gx_mmc.c b/drivers/mmc/meson_gx_mmc.c
+index fcf4f03d1e..3385acfe64 100644
+--- a/drivers/mmc/meson_gx_mmc.c
++++ b/drivers/mmc/meson_gx_mmc.c
+@@ -277,7 +277,11 @@ static int meson_mmc_probe(struct udevice *dev)
+ 	cfg->voltages = MMC_VDD_33_34 | MMC_VDD_32_33 |
+ 			MMC_VDD_31_32 | MMC_VDD_165_195;
+ 	cfg->host_caps = MMC_MODE_8BIT | MMC_MODE_4BIT |
++#ifdef CONFIG_MMC_MESON_GX_HS52_MODE
+ 			MMC_MODE_HS_52MHz | MMC_MODE_HS;
++#else
++			MMC_MODE_HS;
++#endif
+ 	cfg->f_min = DIV_ROUND_UP(SD_EMMC_CLKSRC_24M, CLK_MAX_DIV);
+ 	cfg->f_max = 100000000; /* 100 MHz */
+ 	cfg->b_max = 511; /* max 512 - 1 blocks */
+-- 
+2.36.1
+

--- a/patch/u-boot/u-boot-meson64/0002-Disable-HS52-for-Radxa-Zero.patch
+++ b/patch/u-boot/u-boot-meson64/0002-Disable-HS52-for-Radxa-Zero.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yuntian Zhang <yt@radxa.com>
+Date: Mon, 27 Jun 2022 14:45:44 +0800
+Subject: [PATCH] Disable HS52 for Radxa Zero
+
+Signed-off-by: Yuntian Zhang <yt@radxa.com>
+---
+ configs/radxa-zero_defconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/configs/radxa-zero_defconfig b/configs/radxa-zero_defconfig
+index f5494609e5..3344bcb4fa 100644
+--- a/configs/radxa-zero_defconfig
++++ b/configs/radxa-zero_defconfig
+@@ -34,6 +34,7 @@ CONFIG_OF_CONTROL=y
+ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
+ CONFIG_NET_RANDOM_ETHADDR=y
+ CONFIG_MMC_MESON_GX=y
++# CONFIG_MMC_MESON_GX_HS52_MODE is not set
+ CONFIG_MTD=y
+ CONFIG_DM_MTD=y
+ CONFIG_DM_ETH=y
+-- 
+2.36.1


### PR DESCRIPTION
# Description

This hack is needed for Radxa Zero to boot from Kingston eMMC. Foresee eMMC (which is what we used originally) appears to be unaffected.

No kernel modification is required, which is explained [here](https://lists.denx.de/pipermail/u-boot/2020-December/434949.html).

Pinging @rpardini 

# How Has This Been Tested?

Several affected users including @lanefu had manually flashed a custom U-Boot with this hack and got board booting.