### PR TITLE
Typo in package name

### DIFF
--- a/config/desktop/focal/environments/gnome/config_base/packages
+++ b/config/desktop/focal/environments/gnome/config_base/packages
@@ -173,7 +173,7 @@ libxtst6
 libxxf86dga1
 libyelp0
 lightdm
-lightdm-dettings
+lightdm-settings
 linux-sound-base
 mutter
 mutter-common


### PR DESCRIPTION
# Description

Just a package typed wrong.
