### PR TITLE
Fix bug in vagrant options handling

### DIFF
--- a/config/templates/config-vagrant.conf
+++ b/config/templates/config-vagrant.conf
@@ -2,12 +2,13 @@
 #
 # This is a Vagrant launcher file. To set up the configuration, use command line arguments to compile.sh
 
-# remove "vagrant" from the command line
-shift
+# While we are in config-vagrant.conf, we no longer need "vagrant" option
+# So if "vagrant" wasn't removed from the command line by caller, we do it now
+[[ "$1" == "vagrant" ]] && shift
 
 # second argument can be a build parameter or a config file
 unset VAGRANT_CONF
-[[ $1 != *=* ]] && VAGRANT_CONF=$1
+[[ $1 != *=* ]] && VAGRANT_CONF=$1 && shift
 
 display_alert "Building and running the Vagrant box"
 VAGRANT_INSTALL_LOCAL_PLUGINS=1 vagrant up || vagrant up


### PR DESCRIPTION
# Description

When compiling using vagrant as build environment, the first option following vagrant is skipped.

`./compile.sh vagrant foo bar`
In this example foo is skipped. This PR fix that bug.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] An image was successfully built using vagrant as builder.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
