### PR TITLE
rockchip64: fix rk3318-box cpu voltages

### DIFF
--- a/patch/kernel/archive/rockchip64-5.15/add-board-tvbox-rk3318.patch
+++ b/patch/kernel/archive/rockchip64-5.15/add-board-tvbox-rk3318.patch
@@ -370,13 +370,13 @@ index 00000000000..28acf1fe127
 +		};
 +		opp-1200000000 {
 +			opp-hz = /bits/ 64 <1200000000>;
-+			opp-microvolt = <1150000>;
++			opp-microvolt = <1200000>;
 +			clock-latency-ns = <40000>;
 +			status = "disabled";
 +		};
 +		opp-1296000000 {
 +			opp-hz = /bits/ 64 <1296000000>;
-+			opp-microvolt = <1200000>;
++			opp-microvolt = <1275000>;
 +			clock-latency-ns = <40000>;
 +			status = "disabled";
 +		};

--- a/patch/kernel/archive/rockchip64-5.18/add-board-tvbox-rk3318.patch
+++ b/patch/kernel/archive/rockchip64-5.18/add-board-tvbox-rk3318.patch
@@ -370,13 +370,13 @@ index 00000000000..28acf1fe127
 +		};
 +		opp-1200000000 {
 +			opp-hz = /bits/ 64 <1200000000>;
-+			opp-microvolt = <1150000>;
++			opp-microvolt = <1200000>;
 +			clock-latency-ns = <40000>;
 +			status = "disabled";
 +		};
 +		opp-1296000000 {
 +			opp-hz = /bits/ 64 <1296000000>;
-+			opp-microvolt = <1200000>;
++			opp-microvolt = <1275000>;
 +			clock-latency-ns = <40000>;
 +			status = "disabled";
 +		};


### PR DESCRIPTION
# Description

Nothing fancy: raise cpu voltages for some opps for rk3318-box board due to report instabilities.

# How Has This Been Tested?

- [x] Built armbian deb kernel/dtb packages with success

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
