### PR TITLE
rockchip64: switch orangepi 4/LTS to mainline USB3 Type-C controller driver

### DIFF
--- a/patch/kernel/archive/rockchip64-5.15/add-board-orangepi-4-lts.patch
+++ b/patch/kernel/archive/rockchip64-5.15/add-board-orangepi-4-lts.patch
@@ -1,9 +1,9 @@
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4-lts.dts b/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4-lts.dts
 new file mode 100644
-index 00000000000..4adb1534ea5
+index 00000000000..e0490aaa7ba
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4-lts.dts
-@@ -0,0 +1,1183 @@
+@@ -0,0 +1,1257 @@
 +/*
 + * SPDX-License-Identifier: (GPL-2.0+ or MIT)
 + * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd.
@@ -17,6 +17,7 @@ index 00000000000..4adb1534ea5
 +#include <dt-bindings/pwm/pwm.h>
 +#include <dt-bindings/usb/pd.h>
 +#include <dt-bindings/leds/common.h>
++#include <dt-bindings/usb/pd.h>
 +#include "rk3399.dtsi"
 +#include "rk3399-opp.dtsi"
 +
@@ -785,12 +786,63 @@ index 00000000000..4adb1534ea5
 +	clock-frequency = <400000>;
 +
 +	fusb0: fusb30x@22 {
-+		compatible = "fairchild,fusb302";
++		compatible = "fcs,fusb302";
 +		reg = <0x22>;
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&fusb0_int>;
-+		int-n-gpios = <&gpio1 RK_PA2 GPIO_ACTIVE_HIGH>;
++		interrupt-parent = <&gpio1>;
++		interrupts = <RK_PA2 IRQ_TYPE_LEVEL_LOW>;
++		vbus-supply = <&vbus_typec>;
 +		status = "okay";
++
++		connector {
++			compatible = "usb-c-connector";
++			data-role = "dual";
++			label = "USB-C";
++			op-sink-microwatt = <1000000>;
++			power-role = "dual";
++			sink-pdos =
++				<PDO_FIXED(5000, 2500, PDO_FIXED_USB_COMM)>;
++			source-pdos =
++				<PDO_FIXED(5000, 1400, PDO_FIXED_USB_COMM)>;
++			try-power-role = "sink";
++
++			extcon-cables = <1 2 5 6 9 10 12 44>;
++			typec-altmodes = <0xff01 1 0x001c0000 1>;
++
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				port@0 {
++					reg = <0>;
++
++					usbc_hs: endpoint {
++						remote-endpoint =
++							<&u2phy0_typec_hs>;
++					};
++				};
++
++				port@1 {
++					reg = <1>;
++
++					usbc_ss: endpoint {
++						remote-endpoint =
++							<&tcphy0_typec_ss>;
++					};
++				};
++
++				port@2 {
++					reg = <2>;
++
++					usbc_dp: endpoint {
++						remote-endpoint =
++							<&tcphy0_typec_dp>;
++					};
++				};
++			};
++		};
++
 +	};
 +
 +	ft5x06_ts@38 {
@@ -950,13 +1002,28 @@ index 00000000000..4adb1534ea5
 +	status = "okay";
 +};
 +
++&tcphy0_dp {
++	port {
++		tcphy0_typec_dp: endpoint {
++			remote-endpoint = <&usbc_dp>;
++		};
++	};
++};
++
++&tcphy0_usb3 {
++	port {
++		tcphy0_typec_ss: endpoint {
++			remote-endpoint = <&usbc_ss>;
++		};
++	};
++};
++
 +&tcphy1 {
 +	status = "okay";
 +};
 +
 +&u2phy0 {
 +	status = "okay";
-+	extcon = <&fusb0>;
 +
 +	u2phy0_otg: otg-port {
 +		status = "okay";
@@ -966,6 +1033,13 @@ index 00000000000..4adb1534ea5
 +		phy-supply = <&usb3_vbus>;
 +		status = "okay";
 +	};
++
++	port {
++		u2phy0_typec_hs: endpoint {
++			remote-endpoint = <&usbc_hs>;
++		};
++	};
++
 +};
 +
 +&u2phy1 {

--- a/patch/kernel/archive/rockchip64-5.15/add-board-orangepi-4.patch
+++ b/patch/kernel/archive/rockchip64-5.15/add-board-orangepi-4.patch
@@ -1,9 +1,9 @@
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4.dts b/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4.dts
 new file mode 100644
-index 000000000..1e1747ceb
+index 00000000000..9efe2513944
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4.dts
-@@ -0,0 +1,1123 @@
+@@ -0,0 +1,1194 @@
 +/*
 + * SPDX-License-Identifier: (GPL-2.0+ or MIT)
 + * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd.
@@ -740,13 +740,63 @@ index 000000000..1e1747ceb
 +	clock-frequency = <400000>;
 +
 +	fusb0: fusb30x@22 {
-+		compatible = "fairchild,fusb302";
++		compatible = "fcs,fusb302";
 +		reg = <0x22>;
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&fusb0_int>;
-+		int-n-gpios = <&gpio1 RK_PA2 GPIO_ACTIVE_HIGH>;
-+		vbus-5v-gpios = <&gpio2 RK_PB4 GPIO_ACTIVE_HIGH>;
++		interrupt-parent = <&gpio1>;
++		interrupts = <RK_PA2 IRQ_TYPE_LEVEL_LOW>;
++		vbus-supply = <&vbus_typec>;
 +		status = "okay";
++
++		connector {
++			compatible = "usb-c-connector";
++			data-role = "dual";
++			label = "USB-C";
++			op-sink-microwatt = <1000000>;
++			power-role = "dual";
++			sink-pdos =
++				<PDO_FIXED(5000, 2500, PDO_FIXED_USB_COMM)>;
++			source-pdos =
++				<PDO_FIXED(5000, 1400, PDO_FIXED_USB_COMM)>;
++			try-power-role = "sink";
++
++			extcon-cables = <1 2 5 6 9 10 12 44>;
++			typec-altmodes = <0xff01 1 0x001c0000 1>;
++
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				port@0 {
++					reg = <0>;
++
++					usbc_hs: endpoint {
++						remote-endpoint =
++							<&u2phy0_typec_hs>;
++					};
++				};
++
++				port@1 {
++					reg = <1>;
++
++					usbc_ss: endpoint {
++						remote-endpoint =
++							<&tcphy0_typec_ss>;
++					};
++				};
++
++				port@2 {
++					reg = <2>;
++
++					usbc_dp: endpoint {
++						remote-endpoint =
++							<&tcphy0_typec_dp>;
++					};
++				};
++			};
++		};
++
 +	};
 +
 +	ft5x06_ts@38 {
@@ -910,13 +960,28 @@ index 000000000..1e1747ceb
 +	status = "okay";
 +};
 +
++&tcphy0_dp {
++	port {
++		tcphy0_typec_dp: endpoint {
++			remote-endpoint = <&usbc_dp>;
++		};
++	};
++};
++
++&tcphy0_usb3 {
++	port {
++		tcphy0_typec_ss: endpoint {
++			remote-endpoint = <&usbc_ss>;
++		};
++	};
++};
++
 +&tcphy1 {
 +	status = "okay";
 +};
 +
 +&u2phy0 {
 +	status = "okay";
-+	extcon = <&fusb0>;
 +
 +	u2phy0_otg: otg-port {
 +		status = "okay";
@@ -925,6 +990,12 @@ index 000000000..1e1747ceb
 +	u2phy0_host: host-port {
 +		phy-supply = <&usb3_vbus>;
 +		status = "okay";
++	};
++
++	port {
++		u2phy0_typec_hs: endpoint {
++			remote-endpoint = <&usbc_hs>;
++		};
 +	};
 +};
 +

--- a/patch/kernel/archive/rockchip64-5.18/add-board-orangepi-4-lts.patch
+++ b/patch/kernel/archive/rockchip64-5.18/add-board-orangepi-4-lts.patch
@@ -1,9 +1,9 @@
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4-lts.dts b/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4-lts.dts
 new file mode 100644
-index 00000000000..4adb1534ea5
+index 00000000000..e0490aaa7ba
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4-lts.dts
-@@ -0,0 +1,1183 @@
+@@ -0,0 +1,1257 @@
 +/*
 + * SPDX-License-Identifier: (GPL-2.0+ or MIT)
 + * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd.
@@ -17,6 +17,7 @@ index 00000000000..4adb1534ea5
 +#include <dt-bindings/pwm/pwm.h>
 +#include <dt-bindings/usb/pd.h>
 +#include <dt-bindings/leds/common.h>
++#include <dt-bindings/usb/pd.h>
 +#include "rk3399.dtsi"
 +#include "rk3399-opp.dtsi"
 +
@@ -785,12 +786,63 @@ index 00000000000..4adb1534ea5
 +	clock-frequency = <400000>;
 +
 +	fusb0: fusb30x@22 {
-+		compatible = "fairchild,fusb302";
++		compatible = "fcs,fusb302";
 +		reg = <0x22>;
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&fusb0_int>;
-+		int-n-gpios = <&gpio1 RK_PA2 GPIO_ACTIVE_HIGH>;
++		interrupt-parent = <&gpio1>;
++		interrupts = <RK_PA2 IRQ_TYPE_LEVEL_LOW>;
++		vbus-supply = <&vbus_typec>;
 +		status = "okay";
++
++		connector {
++			compatible = "usb-c-connector";
++			data-role = "dual";
++			label = "USB-C";
++			op-sink-microwatt = <1000000>;
++			power-role = "dual";
++			sink-pdos =
++				<PDO_FIXED(5000, 2500, PDO_FIXED_USB_COMM)>;
++			source-pdos =
++				<PDO_FIXED(5000, 1400, PDO_FIXED_USB_COMM)>;
++			try-power-role = "sink";
++
++			extcon-cables = <1 2 5 6 9 10 12 44>;
++			typec-altmodes = <0xff01 1 0x001c0000 1>;
++
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				port@0 {
++					reg = <0>;
++
++					usbc_hs: endpoint {
++						remote-endpoint =
++							<&u2phy0_typec_hs>;
++					};
++				};
++
++				port@1 {
++					reg = <1>;
++
++					usbc_ss: endpoint {
++						remote-endpoint =
++							<&tcphy0_typec_ss>;
++					};
++				};
++
++				port@2 {
++					reg = <2>;
++
++					usbc_dp: endpoint {
++						remote-endpoint =
++							<&tcphy0_typec_dp>;
++					};
++				};
++			};
++		};
++
 +	};
 +
 +	ft5x06_ts@38 {
@@ -880,7 +932,7 @@ index 00000000000..4adb1534ea5
 +
 +&pwm2 {
 +	status = "okay";
-+	pinctrl-names = "active";
++	pinctrl-names = "default";
 +	pinctrl-0 = <&pwm2_pin_pull_down>;
 +};
 +
@@ -950,13 +1002,28 @@ index 00000000000..4adb1534ea5
 +	status = "okay";
 +};
 +
++&tcphy0_dp {
++	port {
++		tcphy0_typec_dp: endpoint {
++			remote-endpoint = <&usbc_dp>;
++		};
++	};
++};
++
++&tcphy0_usb3 {
++	port {
++		tcphy0_typec_ss: endpoint {
++			remote-endpoint = <&usbc_ss>;
++		};
++	};
++};
++
 +&tcphy1 {
 +	status = "okay";
 +};
 +
 +&u2phy0 {
 +	status = "okay";
-+	extcon = <&fusb0>;
 +
 +	u2phy0_otg: otg-port {
 +		status = "okay";
@@ -966,6 +1033,13 @@ index 00000000000..4adb1534ea5
 +		phy-supply = <&usb3_vbus>;
 +		status = "okay";
 +	};
++
++	port {
++		u2phy0_typec_hs: endpoint {
++			remote-endpoint = <&usbc_hs>;
++		};
++	};
++
 +};
 +
 +&u2phy1 {

--- a/patch/kernel/archive/rockchip64-5.18/add-board-orangepi-4.patch
+++ b/patch/kernel/archive/rockchip64-5.18/add-board-orangepi-4.patch
@@ -1,9 +1,9 @@
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4.dts b/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4.dts
 new file mode 100644
-index 000000000..1e1747ceb
+index 00000000000..9efe2513944
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4.dts
-@@ -0,0 +1,1123 @@
+@@ -0,0 +1,1194 @@
 +/*
 + * SPDX-License-Identifier: (GPL-2.0+ or MIT)
 + * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd.
@@ -740,13 +740,63 @@ index 000000000..1e1747ceb
 +	clock-frequency = <400000>;
 +
 +	fusb0: fusb30x@22 {
-+		compatible = "fairchild,fusb302";
++		compatible = "fcs,fusb302";
 +		reg = <0x22>;
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&fusb0_int>;
-+		int-n-gpios = <&gpio1 RK_PA2 GPIO_ACTIVE_HIGH>;
-+		vbus-5v-gpios = <&gpio2 RK_PB4 GPIO_ACTIVE_HIGH>;
++		interrupt-parent = <&gpio1>;
++		interrupts = <RK_PA2 IRQ_TYPE_LEVEL_LOW>;
++		vbus-supply = <&vbus_typec>;
 +		status = "okay";
++
++		connector {
++			compatible = "usb-c-connector";
++			data-role = "dual";
++			label = "USB-C";
++			op-sink-microwatt = <1000000>;
++			power-role = "dual";
++			sink-pdos =
++				<PDO_FIXED(5000, 2500, PDO_FIXED_USB_COMM)>;
++			source-pdos =
++				<PDO_FIXED(5000, 1400, PDO_FIXED_USB_COMM)>;
++			try-power-role = "sink";
++
++			extcon-cables = <1 2 5 6 9 10 12 44>;
++			typec-altmodes = <0xff01 1 0x001c0000 1>;
++
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				port@0 {
++					reg = <0>;
++
++					usbc_hs: endpoint {
++						remote-endpoint =
++							<&u2phy0_typec_hs>;
++					};
++				};
++
++				port@1 {
++					reg = <1>;
++
++					usbc_ss: endpoint {
++						remote-endpoint =
++							<&tcphy0_typec_ss>;
++					};
++				};
++
++				port@2 {
++					reg = <2>;
++
++					usbc_dp: endpoint {
++						remote-endpoint =
++							<&tcphy0_typec_dp>;
++					};
++				};
++			};
++		};
++
 +	};
 +
 +	ft5x06_ts@38 {
@@ -841,7 +891,7 @@ index 000000000..1e1747ceb
 +
 +&pwm2 {
 +	status = "okay";
-+	pinctrl-names = "active";
++	pinctrl-names = "default";
 +	pinctrl-0 = <&pwm2_pin_pull_down>;
 +};
 +
@@ -910,13 +960,28 @@ index 000000000..1e1747ceb
 +	status = "okay";
 +};
 +
++&tcphy0_dp {
++	port {
++		tcphy0_typec_dp: endpoint {
++			remote-endpoint = <&usbc_dp>;
++		};
++	};
++};
++
++&tcphy0_usb3 {
++	port {
++		tcphy0_typec_ss: endpoint {
++			remote-endpoint = <&usbc_ss>;
++		};
++	};
++};
++
 +&tcphy1 {
 +	status = "okay";
 +};
 +
 +&u2phy0 {
 +	status = "okay";
-+	extcon = <&fusb0>;
 +
 +	u2phy0_otg: otg-port {
 +		status = "okay";
@@ -925,6 +990,12 @@ index 000000000..1e1747ceb
 +	u2phy0_host: host-port {
 +		phy-supply = <&usb3_vbus>;
 +		status = "okay";
++	};
++
++	port {
++		u2phy0_typec_hs: endpoint {
++			remote-endpoint = <&usbc_hs>;
++		};
 +	};
 +};
 +


### PR DESCRIPTION
# Description

Orange Pi 4 and Orange Pi 4 LTS were the last boards using staging USB3 Type-C controller.

This PR moves both of them to use mainline driver, so staging driver can be removed from patchset (as suggested by @Tonymac32 here: https://github.com/armbian/build/pull/3953#issuecomment-1172962963)

Most of the changes have been adapted upon the same nodes from tinkerboard 2 device tree and GPIOs have been adjusted.

Since both opi4 and opi4 LTS share the same hardware, I felt it could be useful to change on both boards. Probably if it works for my opi4 LTS also works for regular opi4; I will do my tests, if @piter75 wants to do private tests, in compatibility with his free time and will, I guess it is very welcome, but as long as the USB3 hardware is the same I guess mine would be enough.

As side note, this also fixes the "active" -> "default" pinctrl for pwm2 on **edge** kernel device tree (https://github.com/armbian/build/pull/3935)

Jira reference number [AR-1256]

# How Has This Been Tested?

- [ ] Build an image for Orange Pi 4 and test USB Type C functionality
- [x] Build an image for Orange Pi 4 LTS and test USB Type C functionality

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1256]: https://armbian.atlassian.net/browse/AR-1256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ