### PR TITLE
Rockchip64-current: fix nanoPi NEO 3 DTS makefile

### DIFF
--- a/patch/kernel/archive/rockchip64-5.15/add-board-xxx-nanopi-Neo3-with-enabled-I2S-and-spdif.patch
+++ b/patch/kernel/archive/rockchip64-5.15/add-board-xxx-nanopi-Neo3-with-enabled-I2S-and-spdif.patch
@@ -5,9 +5,8 @@ Subject: [PATCH] Add Nanopi Neo3 with enabled I2S and spdif
 
 Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
 ---
- arch/arm64/boot/dts/rockchip/Makefile         |   1 +
  .../dts/rockchip/rk3328-nanopi-neo3-rev02.dts | 195 ++++++++++++++++++
- 2 files changed, 196 insertions(+)
+ 1 files changed, 195 insertions(+)
  create mode 100644 arch/arm64/boot/dts/rockchip/rk3328-nanopi-neo3-rev02.dts
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328-nanopi-neo3-rev02.dts b/arch/arm64/boot/dts/rockchip/rk3328-nanopi-neo3-rev02.dts

--- a/patch/kernel/archive/rockchip64-5.15/add-boards-to-dts-makefile.patch
+++ b/patch/kernel/archive/rockchip64-5.15/add-boards-to-dts-makefile.patch
@@ -2,11 +2,12 @@ diff --git a/arch/arm64/boot/dts/rockchip/Makefile b/arch/arm64/boot/dts/rockchi
 index 26661c7b7..1462ed38b 100644
 --- a/arch/arm64/boot/dts/rockchip/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/Makefile
-@@ -1,4 +1,22 @@
+@@ -1,4 +1,23 @@
  # SPDX-License-Identifier: GPL-2.0
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-rock-pi-e.dtb
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3308-rock-pi-s.dtb
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3318-box.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-nanopi-neo3-rev02.dtb
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-nanopi-r2-rev00.dtb
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-nanopi-r2-rev06.dtb
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-nanopi-r2-rev20.dtb


### PR DESCRIPTION
Changes to the add-board patch did not get added to the makefile patch.  Fixed.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Jira reference number [AR-1258]

# How Has This Been Tested?

Build and boot tested

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1258]: https://armbian.atlassian.net/browse/AR-1258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ