### PR TITLE
bind carrier status to underlying eth0 port, so up on boot

### DIFF
--- a/packages/bsp/mvebu64/networkd/10-lan0.network
+++ b/packages/bsp/mvebu64/networkd/10-lan0.network
@@ -3,3 +3,4 @@ Name=lan0
 
 [Network]
 Bridge=br0
+BindCarrier=eth0

--- a/packages/bsp/mvebu64/networkd/10-lan1.network
+++ b/packages/bsp/mvebu64/networkd/10-lan1.network
@@ -3,3 +3,4 @@ Name=lan1
 
 [Network]
 Bridge=br0
+BindCarrier=eth0

--- a/packages/bsp/mvebu64/networkd/10-wan.network
+++ b/packages/bsp/mvebu64/networkd/10-wan.network
@@ -3,3 +3,4 @@ Name=wan
 
 [Network]
 Bridge=br0
+BindCarrier=eth0


### PR DESCRIPTION
# Description

It seems like, with no other network service to bring them up (networking, NetworkManager), systemd-networkd will not set "up" the wan and lan0/lan1 interfaces.  To fix this, the default systemd.network files get the line "BindCarrier=eth0" to bring those three interfaces up with the mii port.

This should make no change for most users.