### PR TITLE
Adapt patches to kernel version 5.10.130

### DIFF
--- a/patch/kernel/archive/sunxi-5.10/megous/ARM-dts-sunxi-Add-aliases-fro-mmc.patch
+++ b/patch/kernel/archive/sunxi-5.10/megous/ARM-dts-sunxi-Add-aliases-fro-mmc.patch
@@ -52,11 +52,11 @@ index 009e012b4691..8e7d20e814f0 100644
  #include <dt-bindings/thermal/thermal.h>
  
  / {
-+		aliases {
-+				mmc0 = &mmc0;
-+				mmc1 = &mmc1;
-+				mmc2 = &mmc2;
-+		};
++	aliases {
++		mmc0 = &mmc0;
++		mmc1 = &mmc1;
++		mmc2 = &mmc2;
++	};
 +
  	cpu0_opp_table: opp-table-cpu {
  		compatible = "operating-points-v2";

--- a/patch/kernel/archive/sunxi-5.10/megous/cpufreq-sun50i-Show-detected-CPU-bin-for-easier-debu.patch
+++ b/patch/kernel/archive/sunxi-5.10/megous/cpufreq-sun50i-Show-detected-CPU-bin-for-easier-debu.patch
@@ -16,8 +16,8 @@ diff --git a/drivers/cpufreq/sun50i-cpufreq-nvmem.c b/drivers/cpufreq/sun50i-cpu
 index 9907a165135b..6e121f717806 100644
 --- a/drivers/cpufreq/sun50i-cpufreq-nvmem.c
 +++ b/drivers/cpufreq/sun50i-cpufreq-nvmem.c
-@@ -102,6 +102,7 @@ static int sun50i_cpufreq_nvmem_probe(struct platform_device *pdev)
- 		return ret;
+@@ -104,6 +104,7 @@ static int sun50i_cpufreq_nvmem_probe(struct platform_device *pdev)
+ 	}
  
  	snprintf(name, MAX_NAME_LEN, "speed%d", speed);
 +	pr_info("Using CPU speed bin %s\n", name);

--- a/patch/kernel/archive/sunxi-5.10/megous/mailbox-Allow-to-run-mailbox-while-timekeeping-is-su.patch
+++ b/patch/kernel/archive/sunxi-5.10/megous/mailbox-Allow-to-run-mailbox-while-timekeeping-is-su.patch
@@ -18,22 +18,24 @@ diff --git a/drivers/mailbox/mailbox.c b/drivers/mailbox/mailbox.c
 index 3e7d4b20ab34..82ca7c317700 100644
 --- a/drivers/mailbox/mailbox.c
 +++ b/drivers/mailbox/mailbox.c
-@@ -84,9 +84,11 @@ static void msg_submit(struct mbox_chan *chan)
+@@ -83,10 +83,12 @@ static void msg_submit(struct mbox_chan *chan)
+ 	spin_unlock_irqrestore(&chan->lock, flags);
  
- 	/* kick start the timer immediately to avoid delays */
  	if (!err && (chan->txdone_method & TXDONE_BY_POLL)) {
--		/* but only if not already active */
--		if (!hrtimer_active(&chan->mbox->poll_hrt))
--			hrtimer_start(&chan->mbox->poll_hrt, 0, HRTIMER_MODE_REL);
+-		/* kick start the timer immediately to avoid delays */
+-		spin_lock_irqsave(&chan->mbox->poll_hrt_lock, flags);
+-		hrtimer_start(&chan->mbox->poll_hrt, 0, HRTIMER_MODE_REL);
+-		spin_unlock_irqrestore(&chan->mbox->poll_hrt_lock, flags);
 +		if (!timekeeping_suspended) {
-+			/* but only if not already active */
-+			if (!hrtimer_active(&chan->mbox->poll_hrt))
-+				hrtimer_start(&chan->mbox->poll_hrt, 0, HRTIMER_MODE_REL);
++			/* kick start the timer immediately to avoid delays */
++			spin_lock_irqsave(&chan->mbox->poll_hrt_lock, flags);
++			hrtimer_start(&chan->mbox->poll_hrt, 0, HRTIMER_MODE_REL);
++			spin_unlock_irqrestore(&chan->mbox->poll_hrt_lock, flags);
 +		}
  	}
  }
  
-@@ -262,6 +264,24 @@ int mbox_send_message(struct mbox_chan *chan, void *mssg)
+@@ -268,6 +270,24 @@ int mbox_send_message(struct mbox_chan *chan, void *mssg)
  
  	msg_submit(chan);
  

--- a/patch/kernel/archive/sunxi-5.10/megous/power-supply-axp20x_battery-Add-support-for-reportin.patch
+++ b/patch/kernel/archive/sunxi-5.10/megous/power-supply-axp20x_battery-Add-support-for-reportin.patch
@@ -25,7 +25,7 @@ index de782f09bdc8..b906dfe85973 100644
  };
  
  static int axp20x_battery_get_max_voltage(struct axp20x_batt_ps *axp20x_batt,
-@@ -180,10 +181,30 @@ static int axp20x_get_constant_charge_current(struct axp20x_batt_ps *axp,
+@@ -180,11 +181,31 @@ static int axp20x_get_constant_charge_current(struct axp20x_batt_ps *axp,
  	return 0;
  }
  
@@ -56,7 +56,8 @@ index de782f09bdc8..b906dfe85973 100644
 +	struct power_supply_battery_info *info = &axp20x_batt->batt_info;
  	int ret = 0, reg, val1;
  
-@@ -278,6 +299,9 @@ static int axp20x_battery_get_prop(struct power_supply *psy,
+ 	switch (psp) {
+@@ -277,6 +298,9 @@ static int axp20x_battery_get_prop(struct power_supply *psy,
  		val->intval *= 1000;
  		break;
  


### PR DESCRIPTION
# Description

Adapt patches to kernel version 5.10.130

# How Has This Been Tested?

This requires testing. I didn't check.
# Checklist:
- [ ] Test build sunxi
- [x] Test build sunxi64

