### PR TITLE
Fix armbian-led-state-save.sh for boards without gpio leds.

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-led-state-save.sh
+++ b/packages/bsp/common/usr/lib/armbian/armbian-led-state-save.sh
@@ -55,7 +55,7 @@ function store_led() {
 [[ -f $STATE_PATH ]] && echo -n > $STATE_PATH
 
 for LED in /sys/class/leds/*; do
-
+	[[ -d "$LED" ]] || continue
 	store_led $LED $STATE_PATH
 	echo >> $STATE_PATH
 


### PR DESCRIPTION
# Description

Fix armbian-led-state-save.sh wrong behavior on boards without gpio leds.

Jira reference number [AR-1263]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Works on boars without leds
- [ ] Worjs on board with leds (checked odroid-c4)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1263]: https://armbian.atlassian.net/browse/AR-1263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ