### PR TITLE
packages/bsp/common: use iw instead of iwconfig

### DIFF
--- a/packages/bsp/common/etc/udev/rules.d/10-wifi-disable-powermanagement.rules
+++ b/packages/bsp/common/etc/udev/rules.d/10-wifi-disable-powermanagement.rules
@@ -1,1 +1,1 @@
-KERNEL=="wlan*", ACTION=="add", RUN+="/sbin/iwconfig wlan0 power off"
+KERNEL=="wlan*", ACTION=="add", RUN+="/sbin/iw dev %k set power_save off"


### PR DESCRIPTION
# Description

iw is the new tool to manage wireless device, which supports more nl80211 features.

This pull request introduces iw to handle udev's wifi power management instead of legacy iwconfig.

Also fix udev rule to use kernel name (%k) instead of hardcoded name.

# How Has This Been Tested?
Tested the modification locally on a meson-gxl-s905x-p212 board with 8189fs-sdio interface.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
