### PR TITLE
Suppress error if gitconfig file does not exists

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -30,7 +30,7 @@ fi
 if [[ -f "${SRC}"/lib/general.sh ]]; then
 
 	# Declare this folder as safe
-	if [[ -z $(cat ${HOME}/.gitconfig 2>/dev/null | grep "directory = \*") ]]; then
+	if ! grep -q "directory = \*" "$HOME/.gitconfig"; then
 		git config --global --add safe.directory "*"
 	fi
 

--- a/compile.sh
+++ b/compile.sh
@@ -30,7 +30,7 @@ fi
 if [[ -f "${SRC}"/lib/general.sh ]]; then
 
 	# Declare this folder as safe
-	if ! grep -q "directory = \*" "$HOME/.gitconfig"; then
+	if ! grep -q 2>/dev/null "directory = \*" "$HOME/.gitconfig"; then
 		git config --global --add safe.directory "*"
 	fi
 

--- a/compile.sh
+++ b/compile.sh
@@ -30,7 +30,7 @@ fi
 if [[ -f "${SRC}"/lib/general.sh ]]; then
 
 	# Declare this folder as safe
-	if [[ -z $(cat ${HOME}/.gitconfig | grep "directory = \*") ]]; then
+	if [[ -z $(cat ${HOME}/.gitconfig 2>/dev/null | grep "directory = \*") ]]; then
 		git config --global --add safe.directory "*"
 	fi
 


### PR DESCRIPTION
# Description

Fixing:

`cat: /home/runner/.gitconfig: No such file or directory
`

# How Has This Been Tested?

Manual execution

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
