### PR TITLE
csc support for radxa rock 4b+ using mainline edge

### DIFF
--- a/config/boards/rockpi-4bplus.csc
+++ b/config/boards/rockpi-4bplus.csc
@@ -1,0 +1,10 @@
+# Rockchip RK3399 hexa core 1-4GB SoC GBe eMMC USB3 WiFi/BT PoE
+BOARD_NAME="Rockpi 4B+"
+BOARDFAMILY="rockchip64"
+BOOTCONFIG="rock-pi-4-rk3399_defconfig"
+KERNEL_TARGET="edge"
+FULL_DESKTOP="yes"
+BOOT_LOGO="desktop"
+BOOT_FDT_FILE="rockchip/rk3399-rock-pi-4b-plus.dtb"
+BOOT_SUPPORT_SPI=yes
+DDR_BLOB="rk33/rk3399_ddr_933MHz_v1.25.bin"


### PR DESCRIPTION
# Description

CSC support for Radxa rock 4b+

only edge kernel
using latest ddr4_933 blop
using correct device tree.

tested NVME works great

![image](https://user-images.githubusercontent.com/4806336/179331462-53dcc628-4e80-4ac4-b7f8-6b73c31a05fb.png)
