### PR TITLE
Update armbian-ramlog - keep files created by logrotate

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-ramlog
+++ b/packages/bsp/common/usr/lib/armbian/armbian-ramlog
@@ -54,6 +54,10 @@ syncToDisk () {
 			--links \
 			${XTRA_RSYNC_TO[@]+"${XTRA_RSYNC_TO[@]}"} \
 			$RAM_LOG $HDD_LOG 2>&1 | $LOG_OUTPUT
+		${NoCache} rsync -aXWv \
+                        --delete \
+                        --links \
+                        ${RAM_LOG}journal/ ${HDD_LOG}journal 2>&1 | $LOG_OUTPUT		
 	else
 		${NoCache} cp -rfup $RAM_LOG -T $HDD_LOG 2>&1 | $LOG_OUTPUT
 	fi


### PR DESCRIPTION
# Description

Recently a patch solved the problem with /var/log.hdd/journal increasing in size. However, the patch also deletes all files created by logrotate. This makes logrotate useless.

This patch can at the same time decrease the size of the journal folder and keeps files created by logrotate.

see discussion at https://forum.armbian.com/topic/19995-armbian-ramlog-problems-and-possible-improvements/

# How Has This Been Tested?

I am using the changed file on my system. No problems so far.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
