### PR TITLE
update u-boot config name for rock-3a

### DIFF
--- a/config/boards/rock-3a.conf
+++ b/config/boards/rock-3a.conf
@@ -1,7 +1,7 @@
 # Rockchip RK3568 quad core 1-8GB SoC GBe eMMC USB3
 BOARD_NAME="Rock 3A"
 BOARDFAMILY="rk35xx"
-BOOTCONFIG="rock-3-a-rk3568_defconfig"
+BOOTCONFIG="rock-3a-rk3568_defconfig"
 KERNEL_TARGET="legacy,edge"
 FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"


### PR DESCRIPTION
# Description

Radxa has changed the config name for rock-3a: https://github.com/radxa/u-boot/commit/41ffd0087708e3381e7e166c4ca646f31cd9e097.
We have to update it.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] u-boot build successfully

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
