### PR TITLE
Revert "Added '--delete' to syncToDisk in armbian-ramlog (#3779)"

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-ramlog
+++ b/packages/bsp/common/usr/lib/armbian/armbian-ramlog
@@ -50,7 +50,6 @@ syncToDisk () {
 	if [ "$USE_RSYNC" = true ]; then
 		${NoCache} rsync -aXWv \
 			--exclude "lost+found" --exclude armbian-ramlog.log \
-			--delete \
 			--links \
 			${XTRA_RSYNC_TO[@]+"${XTRA_RSYNC_TO[@]}"} \
 			$RAM_LOG $HDD_LOG 2>&1 | $LOG_OUTPUT


### PR DESCRIPTION
#4005 makes #3779 superfluous.

This reverts commit 6b43018c22056e2ef14197c1c80f4f57ddd02472.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Jira reference number [AR-9999]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
