### PR TITLE
Bugfix: fix issue that 30-armbian-sysinfo doesn't show network usage

### DIFF
--- a/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
+++ b/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
@@ -155,11 +155,8 @@ display "storage temp" "$storage_temp" $HDD_TEMP_LIMIT "0" "°C" "" ; a=$((a+$?)
 display "Battery" "$battery_percent" "20" "1" "%" "$status_battery_text" ; a=$((a+$?))
 (( $a > 0 )) && echo "" # new line only if some value is displayed
 
-# Check whether PRIMARY_INTERFACE exist in /var/lib/vnstat/
-PRIMARY_INTERFACE=$(comm -12 <(ls -1 /var/lib/vnstat/ 2> /dev/null) <(echo "$PRIMARY_INTERFACE" | sed 's/+/\n/g') | sed -n -e 'H;${x;s/\n/+/g;s/^+//;p;}')
-
 line=0
-if [[ $(command -v vnstat) && -n $PRIMARY_INTERFACE ]]; then
+if [[ "$(command -v vnstat)" && $(vnstat --iflist | grep -c "$PRIMARY_INTERFACE") -eq 1 ]]; then
 	traffic=$(vnstat -i $PRIMARY_INTERFACE --oneline | cut -d";" -f4,5)
 	traffic_rx=$(echo $traffic | cut -d";" -f1,1 | sed -r 's/([0-9]+\.[0-9]{1})[0-9]*/\1/')
 	traffic_tx=$(echo $traffic | cut -d";" -f2,2 | sed -r 's/([0-9]+\.[0-9]{1})[0-9]*/\1/')


### PR DESCRIPTION
# Description

Please refer to #3897 

# How Has This Been Tested?

- Before:
```shell
root@khadas-vim1:~# /etc/update-motd.d/30-armbian-sysinfo
System load:   2%               Up time:       1:39
Memory usage:  11% of 1.89G     IP:            192.168.0.102
CPU temp:      46°C             Usage of /:    36% of 15G
```
- After:
```shell
root@khadas-vim1:~# /etc/update-motd.d/30-armbian-sysinfo
System load:   2%               Up time:       1:40
Memory usage:  11% of 1.89G     IP:            192.168.0.102
CPU temp:      46°C             Usage of /:    36% of 15G
RX today:      0 B
```
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
