### PR TITLE
add systemsettings package to KDE packages for Jammy

### DIFF
--- a/config/desktop/jammy/environments/kde-plasma/config_base/packages
+++ b/config/desktop/jammy/environments/kde-plasma/config_base/packages
@@ -118,6 +118,7 @@ slick-greeter
 smbclient
 software-properties-gtk
 spice-vdagent
+systemsettings
 system-config-printer
 system-config-printer-common
 terminator


### PR DESCRIPTION
# Description

System Settings is missing in Jammy images, this adds the package to the list.

Jira reference number [AR-1275]

# How Has This Been Tested?

- [x] An image for Orange Pi 4 LTS has been produced and tested

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1275]: https://armbian.atlassian.net/browse/AR-1275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ