### PR TITLE
README.md: more detailed links to docs.armbian.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,12 @@ KERNEL_CONFIGURE=no \
 CARD_DEVICE="/dev/sda"
 ```
 
-[Build parameters, advanced build options, user defined configuration, build with Docker?](https://docs.armbian.com/Developer-Guide_Build-Preparation/)
+More information:
+
+- [Building Armbian](https://docs.armbian.com/Developer-Guide_Build-Preparation/) — how to start, how to automate;
+- [Build options](https://docs.armbian.com/Developer-Guide_Build-Options/) — all build options;
+- [Building with Docker](https://docs.armbian.com/Developer-Guide_Building-with-Docker/) — how to build inside container;
+- [User configuration](https://docs.armbian.com/Developer-Guide_User-Configurations/) — how to add packages, patches and override sources config;
 
 ## Compare with industry standards
 


### PR DESCRIPTION
## Description

I was surprised when I didn't find a list of all available options of `compile.sh` in this repository.

Later I found them in [Build options](https://docs.armbian.com/Developer-Guide_Build-Options/). And then I found this link in README.md:

> [Build parameters, advanced build options, user defined configuration, build with Docker?](https://docs.armbian.com/Developer-Guide_Build-Preparation/)

So, I've split the link with long line description to 4 separate links. It looks more clear (as for me):

> More information:
> 
> - [Building Armbian](https://docs.armbian.com/Developer-Guide_Build-Preparation/) — how to start, how to automate;
> - [Build options](https://docs.armbian.com/Developer-Guide_Build-Options/) — all build options;
> - [Building with Docker](https://docs.armbian.com/Developer-Guide_Building-with-Docker/) — how to build inside container;
> - [User configuration](https://docs.armbian.com/Developer-Guide_User-Configurations/) — how to add packages, patches and override sources config;


## How has this been tested?

- [x] check render at https://github.com/vazhnov/armbian-build/blob/README_more_links_to_documentation/README.md

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
