### PR TITLE
Disable bootsplash for linux ≥ 5.19

### DIFF
--- a/lib/compilation-prepare.sh
+++ b/lib/compilation-prepare.sh
@@ -120,7 +120,7 @@ compilation_prepare()
 	# Linux splash file
 	#
 
-	if linux-version compare "${version}" ge 5.10 && [ $SKIP_BOOTSPLASH != yes ]; then
+	if linux-version compare "${version}" ge 5.10 && linux-version compare "${version}" lt 5.19 && [ $SKIP_BOOTSPLASH != yes ]; then
 
 		display_alert "Adding" "Kernel splash file" "info"
 		if linux-version compare "${version}" ge 5.11; then


### PR DESCRIPTION
# Description

fbcon implementation has been changed to the degree that its not sane to maintain the patchset anymore. We are disabling bootspash starting with 5.19.y. A replacement is needed to be done. This require:

- installing plymouth
- generating or converting boot graphic to meet new way
- implementing and testing

Jira reference number [AR-1278]

https://github.com/armbian/build/pull/4039

# How Has This Been Tested?

- [x] Build test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1278]: https://armbian.atlassian.net/browse/AR-1278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ