### PR TITLE
uefi-(arm64|x86)-edge/5.19: bump to 5.19.y

### DIFF
--- a/config/sources/families/include/uefi_common.inc
+++ b/config/sources/families/include/uefi_common.inc
@@ -22,7 +22,7 @@ current)
 edge)
 	export DISTRO_GENERIC_KERNEL=no
 	export LINUXCONFIG="linux-uefi-${LINUXFAMILY}-${BRANCH}"
-	export KERNELBRANCH="branch:linux-5.18.y"
+	export KERNELBRANCH="branch:linux-5.19.y"
 	export KERNELPATCHDIR="uefi-${LINUXFAMILY}-${BRANCH}" # Might be empty.
 	export KERNELDIR="linux-uefi-${LINUXFAMILY}"          # Avoid sharing a source tree with others, until we know it's safe.
 	;;

--- a/patch/kernel/archive/uefi-arm64-5.19/0001-Revert-net-Remove-net-ipx.h-and-uapi-linux-ipx.h-hea.patch
+++ b/patch/kernel/archive/uefi-arm64-5.19/0001-Revert-net-Remove-net-ipx.h-and-uapi-linux-ipx.h-hea.patch
@@ -1,0 +1,287 @@
+From 3ec70749ae3cb072f19d886981a217121f776415 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor.pecovnik@gmail.com>
+Date: Sat, 6 Nov 2021 19:15:23 +0100
+Subject: [PATCH] Revert "net: Remove net/ipx.h and uapi/linux/ipx.h header
+ files"
+
+This reverts commit 6c9b40844751ea30c72f7a2f92f4d704bc6b2927.
+---
+ include/net/ipx.h        | 171 +++++++++++++++++++++++++++++++++++++++
+ include/uapi/linux/ipx.h |  87 ++++++++++++++++++++
+ 2 files changed, 258 insertions(+)
+ create mode 100644 include/net/ipx.h
+ create mode 100644 include/uapi/linux/ipx.h
+
+diff --git a/include/net/ipx.h b/include/net/ipx.h
+new file mode 100644
+index 000000000000..9d1342807b59
+--- /dev/null
++++ b/include/net/ipx.h
+@@ -0,0 +1,171 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++#ifndef _NET_INET_IPX_H_
++#define _NET_INET_IPX_H_
++/*
++ *	The following information is in its entirety obtained from:
++ *
++ *	Novell 'IPX Router Specification' Version 1.10 
++ *		Part No. 107-000029-001
++ *
++ *	Which is available from ftp.novell.com
++ */
++
++#include <linux/netdevice.h>
++#include <net/datalink.h>
++#include <linux/ipx.h>
++#include <linux/list.h>
++#include <linux/slab.h>
++#include <linux/refcount.h>
++
++struct ipx_address {
++	__be32  net;
++	__u8    node[IPX_NODE_LEN]; 
++	__be16  sock;
++};
++
++#define ipx_broadcast_node	"\377\377\377\377\377\377"
++#define ipx_this_node           "\0\0\0\0\0\0"
++
++#define IPX_MAX_PPROP_HOPS 8
++
++struct ipxhdr {
++	__be16			ipx_checksum __packed;
++#define IPX_NO_CHECKSUM	cpu_to_be16(0xFFFF)
++	__be16			ipx_pktsize __packed;
++	__u8			ipx_tctrl;
++	__u8			ipx_type;
++#define IPX_TYPE_UNKNOWN	0x00
++#define IPX_TYPE_RIP		0x01	/* may also be 0 */
++#define IPX_TYPE_SAP		0x04	/* may also be 0 */
++#define IPX_TYPE_SPX		0x05	/* SPX protocol */
++#define IPX_TYPE_NCP		0x11	/* $lots for docs on this (SPIT) */
++#define IPX_TYPE_PPROP		0x14	/* complicated flood fill brdcast */
++	struct ipx_address	ipx_dest __packed;
++	struct ipx_address	ipx_source __packed;
++};
++
++/* From af_ipx.c */
++extern int sysctl_ipx_pprop_broadcasting;
++
++struct ipx_interface {
++	/* IPX address */
++	__be32			if_netnum;
++	unsigned char		if_node[IPX_NODE_LEN];
++	refcount_t		refcnt;
++
++	/* physical device info */
++	struct net_device	*if_dev;
++	struct datalink_proto	*if_dlink;
++	__be16			if_dlink_type;
++
++	/* socket support */
++	unsigned short		if_sknum;
++	struct hlist_head	if_sklist;
++	spinlock_t		if_sklist_lock;
++
++	/* administrative overhead */
++	int			if_ipx_offset;
++	unsigned char		if_internal;
++	unsigned char		if_primary;
++	
++	struct list_head	node; /* node in ipx_interfaces list */
++};
++
++struct ipx_route {
++	__be32			ir_net;
++	struct ipx_interface	*ir_intrfc;
++	unsigned char		ir_routed;
++	unsigned char		ir_router_node[IPX_NODE_LEN];
++	struct list_head	node; /* node in ipx_routes list */
++	refcount_t		refcnt;
++};
++
++struct ipx_cb {
++	u8	ipx_tctrl;
++	__be32	ipx_dest_net;
++	__be32	ipx_source_net;
++	struct {
++		__be32 netnum;
++		int index;
++	} last_hop;
++};
++
++#include <net/sock.h>
++
++struct ipx_sock {
++	/* struct sock has to be the first member of ipx_sock */
++	struct sock		sk;
++	struct ipx_address	dest_addr;
++	struct ipx_interface	*intrfc;
++	__be16			port;
++#ifdef CONFIG_IPX_INTERN
++	unsigned char		node[IPX_NODE_LEN];
++#endif
++	unsigned short		type;
++	/*
++	 * To handle special ncp connection-handling sockets for mars_nwe,
++ 	 * the connection number must be stored in the socket.
++	 */
++	unsigned short		ipx_ncp_conn;
++};
++
++static inline struct ipx_sock *ipx_sk(struct sock *sk)
++{
++	return (struct ipx_sock *)sk;
++}
++
++#define IPX_SKB_CB(__skb) ((struct ipx_cb *)&((__skb)->cb[0]))
++
++#define IPX_MIN_EPHEMERAL_SOCKET	0x4000
++#define IPX_MAX_EPHEMERAL_SOCKET	0x7fff
++
++extern struct list_head ipx_routes;
++extern rwlock_t ipx_routes_lock;
++
++extern struct list_head ipx_interfaces;
++struct ipx_interface *ipx_interfaces_head(void);
++extern spinlock_t ipx_interfaces_lock;
++
++extern struct ipx_interface *ipx_primary_net;
++
++int ipx_proc_init(void);
++void ipx_proc_exit(void);
++
++const char *ipx_frame_name(__be16);
++const char *ipx_device_name(struct ipx_interface *intrfc);
++
++static __inline__ void ipxitf_hold(struct ipx_interface *intrfc)
++{
++	refcount_inc(&intrfc->refcnt);
++}
++
++void ipxitf_down(struct ipx_interface *intrfc);
++struct ipx_interface *ipxitf_find_using_net(__be32 net);
++int ipxitf_send(struct ipx_interface *intrfc, struct sk_buff *skb, char *node);
++__be16 ipx_cksum(struct ipxhdr *packet, int length);
++int ipxrtr_add_route(__be32 network, struct ipx_interface *intrfc,
++		     unsigned char *node);
++void ipxrtr_del_routes(struct ipx_interface *intrfc);
++int ipxrtr_route_packet(struct sock *sk, struct sockaddr_ipx *usipx,
++			struct msghdr *msg, size_t len, int noblock);
++int ipxrtr_route_skb(struct sk_buff *skb);
++struct ipx_route *ipxrtr_lookup(__be32 net);
++int ipxrtr_ioctl(unsigned int cmd, void __user *arg);
++
++static __inline__ void ipxitf_put(struct ipx_interface *intrfc)
++{
++	if (refcount_dec_and_test(&intrfc->refcnt))
++		ipxitf_down(intrfc);
++}
++
++static __inline__ void ipxrtr_hold(struct ipx_route *rt)
++{
++	        refcount_inc(&rt->refcnt);
++}
++
++static __inline__ void ipxrtr_put(struct ipx_route *rt)
++{
++	        if (refcount_dec_and_test(&rt->refcnt))
++			                kfree(rt);
++}
++#endif /* _NET_INET_IPX_H_ */
+diff --git a/include/uapi/linux/ipx.h b/include/uapi/linux/ipx.h
+new file mode 100644
+index 000000000000..3168137adae8
+--- /dev/null
++++ b/include/uapi/linux/ipx.h
+@@ -0,0 +1,87 @@
++/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
++#ifndef _IPX_H_
++#define _IPX_H_
++#include <linux/libc-compat.h>	/* for compatibility with glibc netipx/ipx.h */
++#include <linux/types.h>
++#include <linux/sockios.h>
++#include <linux/socket.h>
++#define IPX_NODE_LEN	6
++#define IPX_MTU		576
++
++#if __UAPI_DEF_SOCKADDR_IPX
++struct sockaddr_ipx {
++	__kernel_sa_family_t sipx_family;
++	__be16		sipx_port;
++	__be32		sipx_network;
++	unsigned char 	sipx_node[IPX_NODE_LEN];
++	__u8		sipx_type;
++	unsigned char	sipx_zero;	/* 16 byte fill */
++};
++#endif /* __UAPI_DEF_SOCKADDR_IPX */
++
++/*
++ * So we can fit the extra info for SIOCSIFADDR into the address nicely
++ */
++#define sipx_special	sipx_port
++#define sipx_action	sipx_zero
++#define IPX_DLTITF	0
++#define IPX_CRTITF	1
++
++#if __UAPI_DEF_IPX_ROUTE_DEFINITION
++struct ipx_route_definition {
++	__be32        ipx_network;
++	__be32        ipx_router_network;
++	unsigned char ipx_router_node[IPX_NODE_LEN];
++};
++#endif /* __UAPI_DEF_IPX_ROUTE_DEFINITION */
++
++#if __UAPI_DEF_IPX_INTERFACE_DEFINITION
++struct ipx_interface_definition {
++	__be32        ipx_network;
++	unsigned char ipx_device[16];
++	unsigned char ipx_dlink_type;
++#define IPX_FRAME_NONE		0
++#define IPX_FRAME_SNAP		1
++#define IPX_FRAME_8022		2
++#define IPX_FRAME_ETHERII	3
++#define IPX_FRAME_8023		4
++#define IPX_FRAME_TR_8022       5 /* obsolete */
++	unsigned char ipx_special;
++#define IPX_SPECIAL_NONE	0
++#define IPX_PRIMARY		1
++#define IPX_INTERNAL		2
++	unsigned char ipx_node[IPX_NODE_LEN];
++};
++#endif /* __UAPI_DEF_IPX_INTERFACE_DEFINITION */
++
++#if __UAPI_DEF_IPX_CONFIG_DATA
++struct ipx_config_data {
++	unsigned char	ipxcfg_auto_select_primary;
++	unsigned char	ipxcfg_auto_create_interfaces;
++};
++#endif /* __UAPI_DEF_IPX_CONFIG_DATA */
++
++/*
++ * OLD Route Definition for backward compatibility.
++ */
++
++#if __UAPI_DEF_IPX_ROUTE_DEF
++struct ipx_route_def {
++	__be32		ipx_network;
++	__be32		ipx_router_network;
++#define IPX_ROUTE_NO_ROUTER	0
++	unsigned char	ipx_router_node[IPX_NODE_LEN];
++	unsigned char	ipx_device[16];
++	unsigned short	ipx_flags;
++#define IPX_RT_SNAP		8
++#define IPX_RT_8022		4
++#define IPX_RT_BLUEBOOK		2
++#define IPX_RT_ROUTED		1
++};
++#endif /* __UAPI_DEF_IPX_ROUTE_DEF */
++
++#define SIOCAIPXITFCRT		(SIOCPROTOPRIVATE)
++#define SIOCAIPXPRISLT		(SIOCPROTOPRIVATE + 1)
++#define SIOCIPXCFGDATA		(SIOCPROTOPRIVATE + 2)
++#define SIOCIPXNCPCONN		(SIOCPROTOPRIVATE + 3)
++#endif /* _IPX_H_ */
+-- 
+2.25.1
+

--- a/patch/kernel/archive/uefi-arm64-5.19/0002-Add-PHYT0004-via-ACPI-support-to-stmmac.patch
+++ b/patch/kernel/archive/uefi-arm64-5.19/0002-Add-PHYT0004-via-ACPI-support-to-stmmac.patch
@@ -1,0 +1,378 @@
+From a0736ce7e610e35c62164da29e97d935ff79a8a0 Mon Sep 17 00:00:00 2001
+From: Ricardo Pardini <ricardo@pardini.net>
+Date: Sun, 10 Jul 2022 20:45:09 +0200
+Subject: [PATCH] Add PHYT0004 via ACPI support to stmmac
+
+---
+ .../ethernet/stmicro/stmmac/dwmac-generic.c   |  19 ++
+ .../net/ethernet/stmicro/stmmac/stmmac_main.c |   1 +
+ .../ethernet/stmicro/stmmac/stmmac_platform.c | 254 +++++++++++++++++-
+ .../ethernet/stmicro/stmmac/stmmac_platform.h |   2 +
+ 4 files changed, 275 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-generic.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-generic.c
+index 5e731a72cce8..66a090d62579 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/dwmac-generic.c
++++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-generic.c
+@@ -9,6 +9,7 @@
+  * warranty of any kind, whether express or implied.
+  */
+
++#include <linux/acpi.h>
+ #include <linux/module.h>
+ #include <linux/of.h>
+ #include <linux/platform_device.h>
+@@ -32,6 +33,12 @@ static int dwmac_generic_probe(struct platform_device *pdev)
+ 			dev_err(&pdev->dev, "dt configuration failed\n");
+ 			return PTR_ERR(plat_dat);
+ 		}
++	} else if (has_acpi_companion(&pdev->dev)) {
++		plat_dat = stmmac_probe_config_acpi(pdev, stmmac_res.mac);
++		if (!plat_dat) {
++			dev_err(&pdev->dev, "acpi configuration failed\n");
++			return  -EINVAL;
++		}
+ 	} else {
+ 		plat_dat = dev_get_platdata(&pdev->dev);
+ 		if (!plat_dat) {
+@@ -85,6 +92,17 @@ static const struct of_device_id dwmac_generic_match[] = {
+ };
+ MODULE_DEVICE_TABLE(of, dwmac_generic_match);
+
++#ifdef CONFIG_ACPI
++static const struct acpi_device_id dwmac_acpi_ids[] = {
++	{ .id = "PHYT0004" },
++	{},
++};
++
++MODULE_DEVICE_TABLE(acpi, dwmac_acpi_ids);
++#else
++#define dwmac_acpi_ids NULL
++#endif
++
+ static struct platform_driver dwmac_generic_driver = {
+ 	.probe  = dwmac_generic_probe,
+ 	.remove = stmmac_pltfr_remove,
+@@ -92,6 +110,7 @@ static struct platform_driver dwmac_generic_driver = {
+ 		.name           = STMMAC_RESOURCE_NAME,
+ 		.pm		= &stmmac_pltfr_pm_ops,
+ 		.of_match_table = of_match_ptr(dwmac_generic_match),
++		.acpi_match_table = ACPI_PTR(dwmac_acpi_ids),
+ 	},
+ };
+ module_platform_driver(dwmac_generic_driver);
+diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
+index d1a7cf4567bc..f412d397e47f 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
++++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
+@@ -14,6 +14,7 @@
+ 	https://bugzilla.stlinux.com/
+ *******************************************************************************/
+
++#include <linux/acpi.h>
+ #include <linux/clk.h>
+ #include <linux/kernel.h>
+ #include <linux/interrupt.h>
+diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
+index 11e1055e8260..9464a59762f9 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
++++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
+@@ -8,6 +8,9 @@
+   Author: Giuseppe Cavallaro <peppe.cavallaro@st.com>
+ *******************************************************************************/
+
++#include <linux/acpi.h>
++#include <linux/clk-provider.h>
++#include <linux/clkdev.h>
+ #include <linux/platform_device.h>
+ #include <linux/pm_runtime.h>
+ #include <linux/module.h>
+@@ -657,6 +660,248 @@ void stmmac_remove_config_dt(struct platform_device *pdev,
+ EXPORT_SYMBOL_GPL(stmmac_probe_config_dt);
+ EXPORT_SYMBOL_GPL(stmmac_remove_config_dt);
+
++#ifdef CONFIG_ACPI
++/*
++ * Parse ACPI _DSD to setup AXI register
++ */
++static struct stmmac_axi * stmmac_axi_setup_acpi(struct platform_device *pdev)
++{
++	struct fwnode_handle *np = dev_fwnode(&(pdev->dev));
++	struct stmmac_axi * axi;
++
++	axi = devm_kzalloc(&pdev->dev, sizeof(*axi), GFP_KERNEL);
++	if (!axi)
++		return ERR_PTR(-ENOMEM);
++
++	axi->axi_lpi_en = fwnode_property_read_bool(np, "snps,lpi_en");
++	axi->axi_xit_frm = fwnode_property_read_bool(np, "snps,xit_frm");
++	axi->axi_kbbe = fwnode_property_read_bool(np, "snps,axi_kbbe");
++	axi->axi_fb = fwnode_property_read_bool(np, "snps,axi_fb");
++	axi->axi_mb = fwnode_property_read_bool(np, "snps,axi_mb");
++	axi->axi_rb = fwnode_property_read_bool(np, "snps,axi_rb");
++
++	if (fwnode_property_read_u32(np, "snps,wr_osr_lmt", &axi->axi_wr_osr_lmt))
++		axi->axi_wr_osr_lmt = 1;
++	if (fwnode_property_read_u32(np, "snps,rd_osr_lmt", &axi->axi_rd_osr_lmt))
++		axi->axi_rd_osr_lmt = 1;
++	fwnode_property_read_u32_array(np, "snps,blen", axi->axi_blen, AXI_BLEN);
++
++	return axi;
++}
++
++/**
++ * Parse ACPI _DSD parameters for multiple queues configuration
++ */
++static void stmmac_mtl_setup_acpi(struct platform_device *pdev,
++				  struct plat_stmmacenet_data *plat)
++{
++	plat->rx_queues_to_use = 1;
++	plat->tx_queues_to_use = 1;
++
++	/**
++	 * First Queue must always be in DCB mode. As MTL_QUEUE_DCB=1 we need
++	 * to always set this, otherwise Queue will be classified as AVB
++	 * (because MTL_QUEUE_AVB = 0).
++	 */
++	plat->rx_queues_cfg[0].mode_to_use = MTL_QUEUE_DCB;
++	plat->tx_queues_cfg[0].mode_to_use = MTL_QUEUE_DCB;
++
++	plat->rx_queues_cfg[0].use_prio = true;
++
++	plat->rx_queues_cfg[0].pkt_route = 0x0;
++
++	plat->rx_sched_algorithm = MTL_RX_ALGORITHM_SP;
++	plat->tx_sched_algorithm = MTL_TX_ALGORITHM_SP;
++
++	plat->tx_queues_cfg[0].use_prio = true;
++}
++
++static int stmmac_acpi_phy(struct plat_stmmacenet_data *plat,
++			   struct fwnode_handle *np, struct device *dev)
++{
++	plat->mdio_bus_data = devm_kzalloc(dev,
++					   sizeof(struct stmmac_mdio_bus_data),
++					   GFP_KERNEL);
++
++	return 0;
++}
++
++int fw_get_phy_mode(struct fwnode_handle *np)
++{
++	const char *pm;
++	int err, i;
++
++	err = fwnode_property_read_string(np, "phy-mode", &pm);
++	if (err < 0)
++		err = fwnode_property_read_string(np, "phy-connection-mode", &pm);
++	if (err < 0)
++		return err;
++
++	for (i = 0; i < PHY_INTERFACE_MODE_MAX; i++) {
++		if (!strcasecmp(pm, phy_modes(i)))
++			return i;
++	}
++
++	return -ENODEV;
++}
++
++int stmmac_acpi_clock_setup(struct plat_stmmacenet_data *plat,
++			    struct platform_device *pdev)
++{
++	struct fwnode_handle *np = dev_fwnode(&(pdev->dev));
++	struct device * dev = &pdev->dev;
++	struct clk *clk = ERR_PTR(-ENODEV);
++	u64 clk_freq = 0;
++	int err;
++
++	err = fwnode_property_read_u64(np, "clock-frequency", &clk_freq);
++	if (err < 0)
++		clk_freq = 125000000; /* default to 125MHz */
++
++	plat->stmmac_clk = devm_clk_get(dev, dev_name(dev));
++	if (IS_ERR(plat->stmmac_clk)) {
++		clk = clk_register_fixed_rate(dev, dev_name(dev), NULL, 0, clk_freq);
++		if (IS_ERR(clk))
++			return -1;
++		if (clk_register_clkdev(clk, dev_name(dev), dev_name(dev)))
++			return -1;
++		plat->stmmac_clk = clk;
++	}
++	clk_prepare_enable(plat->stmmac_clk);
++
++	plat->pclk = devm_clk_get(dev, "pclk");
++	if (IS_ERR(plat->pclk))
++		plat->pclk = NULL;
++	clk_prepare_enable(plat->pclk);
++
++	plat->clk_ptp_ref = devm_clk_get(dev, "ptp_ref");
++	if (IS_ERR(plat->clk_ptp_ref)) {
++		plat->clk_ptp_rate = clk_get_rate(plat->stmmac_clk);
++		plat->clk_ptp_ref = NULL;
++	}
++
++	plat->stmmac_rst = devm_reset_control_get(dev,STMMAC_RESOURCE_NAME);
++	if (IS_ERR(plat->stmmac_rst)) {
++		dev_info(dev, "no reset control found\n");
++		plat->stmmac_rst = NULL;
++	}
++
++	return 0;
++}
++
++/**
++ * Parse ACPI driver parameters
++ */
++struct plat_stmmacenet_data *
++stmmac_probe_config_acpi(struct platform_device *pdev, u8 *mac)
++{
++	struct fwnode_handle *np;
++	struct plat_stmmacenet_data *plat;
++	struct stmmac_dma_cfg *dma_cfg;
++
++	plat = devm_kzalloc(&pdev->dev, sizeof(*plat), GFP_KERNEL);
++	if (!plat)
++		return ERR_PTR(-ENOMEM);
++
++	np = dev_fwnode(&(pdev->dev));
++
++	plat->interface = fw_get_phy_mode(np);
++
++	/* Get max speed of operation from device tree */
++	if (fwnode_property_read_u32(np, "max-speed", &plat->max_speed))
++		plat->max_speed = -1;
++
++	if (fwnode_property_read_u32(np, "bus_id", &plat->bus_id))
++		plat->bus_id = 2;
++
++	/* Default to PHY auto-detection */
++	plat->phy_addr = -1;
++
++	/* "snps,phy-addr" is not a standard property. Mark it as deprecated
++	 * and warn of its use. Remove this when PHY node support is added.
++         */
++	if (fwnode_property_read_u32(np, "snps,phy-addr", &plat->phy_addr) == 0)
++		dev_warn(&pdev->dev, "snps,phy-addr property is deprecated\n");
++
++	if (stmmac_acpi_phy(plat, np, &pdev->dev))
++		return ERR_PTR(-ENODEV);
++
++	fwnode_property_read_u32(np, "tx-fifo-depth", &plat->tx_fifo_size);
++	fwnode_property_read_u32(np, "rx-fifo-depth", &plat->rx_fifo_size);
++	if (plat->tx_fifo_size == 0)
++		plat->tx_fifo_size = 0x10000;
++	if (plat->rx_fifo_size == 0)
++		plat->rx_fifo_size = 0x10000;
++
++	plat->force_sf_dma_mode =
++		fwnode_property_read_bool(np, "snps,force_sf_dma_mode");
++	plat->en_tx_lpi_clockgating =
++		fwnode_property_read_bool(np, "snps,en-tx-lpi-clockgating");
++
++	/* Set the maxmtu to a default of JUMBO_LEN in case the
++	 * parameter is not present.
++	 */
++	plat->maxmtu = JUMBO_LEN;
++
++	/* Set default value for multicast hash bins */
++	plat->multicast_filter_bins = HASH_TABLE_SIZE;
++
++	/* Set default value for unicast filter entries */
++	plat->unicast_filter_entries = 1;
++
++	/* Only to "snps,dwmac" */
++	fwnode_property_read_u32(np, "max-frame-size", &plat->maxmtu);
++	fwnode_property_read_u32(np, "snps,multicast-filter-bins",
++				 &plat->multicast_filter_bins);
++	fwnode_property_read_u32(np, "snps,perfect-filter-entries",
++				 &plat->unicast_filter_entries);
++	plat->unicast_filter_entries = dwmac1000_validate_ucast_entries(
++						&pdev->dev, plat->unicast_filter_entries);
++	plat->multicast_filter_bins = dwmac1000_validate_mcast_bins(
++						&pdev->dev, plat->multicast_filter_bins);
++	plat->has_gmac = 1;
++	plat->pmt = 1;
++
++	dma_cfg = devm_kzalloc(&pdev->dev, sizeof(*dma_cfg), GFP_KERNEL);
++	if (!dma_cfg)
++		return ERR_PTR(-ENOMEM);
++	plat->dma_cfg = dma_cfg;
++
++	fwnode_property_read_u32(np, "snps,pbl", &dma_cfg->pbl);
++	if (!dma_cfg->pbl)
++		dma_cfg->pbl = DEFAULT_DMA_PBL;
++
++	fwnode_property_read_u32(np, "snps,txpbl", &dma_cfg->txpbl);
++	fwnode_property_read_u32(np, "snps,rxpbl", &dma_cfg->rxpbl);
++	dma_cfg->pblx8 = !fwnode_property_read_bool(np, "snps,no-pbl-x8");
++
++	dma_cfg->aal = fwnode_property_read_bool(np, "snps,aal");
++	dma_cfg->fixed_burst = fwnode_property_read_bool(np, "snps,fixed-burst");
++	dma_cfg->mixed_burst = fwnode_property_read_bool(np, "snps,mixed-burst");
++
++	plat->force_thresh_dma_mode = fwnode_property_read_bool(np, "snps,force_thresh_dma_mode");
++	if (plat->force_thresh_dma_mode)
++		plat->force_sf_dma_mode = 0;
++
++	fwnode_property_read_u32(np, "snps,ps-speed", &plat->mac_port_sel_speed);
++
++	plat->axi = stmmac_axi_setup_acpi(pdev);
++
++	stmmac_mtl_setup_acpi(pdev, plat);
++
++	stmmac_acpi_clock_setup(plat,pdev);
++
++	return plat;
++}
++#else
++struct plat_stmmacenet_data *
++stmmac_probe_config_acpi(struct platform_device *pdev, u8 *mac)
++{
++	return ERR_PTR(-EINVAL);
++}
++#endif /* CONFIG_ACPI */
++EXPORT_SYMBOL_GPL(stmmac_probe_config_acpi);
++
+ int stmmac_get_platform_resources(struct platform_device *pdev,
+ 				  struct stmmac_resources *stmmac_res)
+ {
+@@ -664,8 +909,14 @@ int stmmac_get_platform_resources(struct platform_device *pdev,
+
+ 	/* Get IRQ information early to have an ability to ask for deferred
+ 	 * probe if needed before we went too far with resource allocation.
++     * For ACPI _byname does not work, so we have to trust, that the
++     * first interrupt is the right one
+ 	 */
+-	stmmac_res->irq = platform_get_irq_byname(pdev, "macirq");
++    if (has_acpi_companion(&pdev->dev)) {
++	    stmmac_res->irq = platform_get_irq(pdev, 0);
++    } else {
++	    stmmac_res->irq = platform_get_irq_byname(pdev, "macirq");
++    }
+ 	if (stmmac_res->irq < 0)
+ 		return stmmac_res->irq;
+
+@@ -683,6 +934,7 @@ int stmmac_get_platform_resources(struct platform_device *pdev,
+ 			return -EPROBE_DEFER;
+ 		dev_info(&pdev->dev, "IRQ eth_wake_irq not found\n");
+ 		stmmac_res->wol_irq = stmmac_res->irq;
++		stmmac_res->lpi_irq = -1;
+ 	}
+
+ 	stmmac_res->lpi_irq =
+diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.h b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.h
+index 3fff3f59d73d..4ac60c3a4722 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.h
++++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.h
+@@ -13,6 +13,8 @@
+
+ struct plat_stmmacenet_data *
+ stmmac_probe_config_dt(struct platform_device *pdev, u8 *mac);
++struct plat_stmmacenet_data *
++stmmac_probe_config_acpi(struct platform_device *pdev, u8 *mac);
+ void stmmac_remove_config_dt(struct platform_device *pdev,
+ 			     struct plat_stmmacenet_data *plat);
+
+--
+2.37.0
+

--- a/patch/kernel/uefi-arm64-edge
+++ b/patch/kernel/uefi-arm64-edge
@@ -1,1 +1,1 @@
-archive/uefi-x86-5.15
+archive/uefi-arm64-5.19


### PR DESCRIPTION
## uefi-(arm64|x86)-edge/5.19: bump to 5.19.y
- uefi-arm64-edge/5.19: add patch for ACPI enablement of PHYT0004 onboard network card
  - reworked 5.10 version of patch to 5.19, trivial datatype change
  - sent by Dragonbox/Pythium person via @lanefu
- uefi-(arm64|x86)-edge/5.19: split patch dir from x86, otherwise identical

# Description

This was mostly done and tested together with https://github.com/armbian/build/pull/3941 in terms of builds and tests. 