### PR TITLE
Remove useless(?) code that caused compilation errors

### DIFF
--- a/lib/functions/main/default-build.sh
+++ b/lib/functions/main/default-build.sh
@@ -30,10 +30,6 @@ function main_default_build_single() {
 		exit 0
 	fi
 
-	if [[ $CLEAN_LEVEL == *sources* ]]; then
-		cleaning "sources"
-	fi
-
 	# Too many things being done. Allow doing only one thing. For core development, mostly.
 	# Also because "KERNEL_ONLY=yes" should really be spelled "PACKAGES_ONLY=yes"
 	local do_build_uboot="yes" do_build_kernel="yes" exit_after_kernel_build="no" exit_after_uboot_build="no" do_host_tools="yes"


### PR DESCRIPTION
I can't seem to find the reason this code was here, and it caused any build that contained `CLEAN_LEVEL="sources"` to fail.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.


# How Has This Been Tested?


- [x] Run build with this code omitted

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
