### PR TITLE
Update arm64-dts-Add-sun50i-h616-orangepi-zero2-device.patch

### DIFF
--- a/patch/kernel/archive/sunxi-5.19/patches.armbian/arm64-dts-Add-sun50i-h616-orangepi-zero2-device.patch
+++ b/patch/kernel/archive/sunxi-5.19/patches.armbian/arm64-dts-Add-sun50i-h616-orangepi-zero2-device.patch
@@ -236,7 +236,7 @@ index 000000000..a26201288
 +			};
 +
 +			reg_dcdce: dcdce {
-+				regulator-boot-on;
++				regulator-always-on;
 +				regulator-min-microvolt = <3300000>;
 +				regulator-max-microvolt = <3300000>;
 +				regulator-name = "vcc-eth-mmc";


### PR DESCRIPTION
# Description

Change from regulator-boot-on to regulator-always-on. 

# How Has This Been Tested?

Currently adopted  5.20-1 
Reboot board. 

+			reg_dcdce: dcdce {
+				regulator-always-on;

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
