### PR TITLE
Allow copying bootscript when BOOTCONFIG=none

### DIFF
--- a/lib/distributions.sh
+++ b/lib/distributions.sh
@@ -193,7 +193,7 @@ install_common()
 		fi
 	else
 
-		if [[ "${BOOTCONFIG}" != "none" ]]; then
+		if [[ -n "${BOOTSCRIPT}" ]]; then
 			if [ -f "${USERPATCHES_PATH}/bootscripts/${bootscript_src}" ]; then
 				cp "${USERPATCHES_PATH}/bootscripts/${bootscript_src}" "${SDCARD}/boot/${bootscript_dst}"
 			else

--- a/lib/makeboarddeb.sh
+++ b/lib/makeboarddeb.sh
@@ -31,30 +31,29 @@ create_board_package()
 	copy_all_packages_files_for "bsp-cli"
 
 	# install copy of boot script & environment file
-	if [[ "${BOOTCONFIG}" != "none" ]]; then
+	if [[ -z "${BOOTSCRIPT}" ]]; then
 		# @TODO: add extension method bsp_prepare_bootloader(), refactor into u-boot extension
 		local bootscript_src=${BOOTSCRIPT%%:*}
 		local bootscript_dst=${BOOTSCRIPT##*:}
 		mkdir -p "${destination}"/usr/share/armbian/
 	
-		# create extlinux config file
-		if [[ $SRC_EXTLINUX != yes ]]; then
-			if [ -f "${USERPATCHES_PATH}/bootscripts/${bootscript_src}" ]; then
-			  cp "${USERPATCHES_PATH}/bootscripts/${bootscript_src}" "${destination}/usr/share/armbian/${bootscript_dst}"
-			else
-			  cp "${SRC}/config/bootscripts/${bootscript_src}" "${destination}/usr/share/armbian/${bootscript_dst}"
-			fi
-			[[ -n $BOOTENV_FILE && -f $SRC/config/bootenv/$BOOTENV_FILE ]] && \
-				cp "${SRC}/config/bootenv/${BOOTENV_FILE}" "${destination}"/usr/share/armbian/armbianEnv.txt
+		if [ -f "${USERPATCHES_PATH}/bootscripts/${bootscript_src}" ]; then
+			cp "${USERPATCHES_PATH}/bootscripts/${bootscript_src}" "${destination}/usr/share/armbian/${bootscript_dst}"
+		else
+			cp "${SRC}/config/bootscripts/${bootscript_src}" "${destination}/usr/share/armbian/${bootscript_dst}"
 		fi
-	
-		# add configuration for setting uboot environment from userspace with: fw_setenv fw_printenv
-		if [[ -n $UBOOT_FW_ENV ]]; then
-			UBOOT_FW_ENV=($(tr ',' ' ' <<< "$UBOOT_FW_ENV"))
-			mkdir -p "${destination}"/etc
-			echo "# Device to access      offset           env size" > "${destination}"/etc/fw_env.config
-			echo "/dev/mmcblk0	${UBOOT_FW_ENV[0]}	${UBOOT_FW_ENV[1]}" >> "${destination}"/etc/fw_env.config
+
+		if [[ -n $BOOTENV_FILE && -f $SRC/config/bootenv/$BOOTENV_FILE ]]; then
+			cp "${SRC}/config/bootenv/${BOOTENV_FILE}" "${destination}"/usr/share/armbian/armbianEnv.txt
 		fi
+	fi
+
+	# add configuration for setting uboot environment from userspace with: fw_setenv fw_printenv
+	if [[ -n $UBOOT_FW_ENV ]]; then
+		UBOOT_FW_ENV=($(tr ',' ' ' <<< "$UBOOT_FW_ENV"))
+		mkdir -p "${destination}"/etc
+		echo "# Device to access      offset           env size" > "${destination}"/etc/fw_env.config
+		echo "/dev/mmcblk0	${UBOOT_FW_ENV[0]}	${UBOOT_FW_ENV[1]}" >> "${destination}"/etc/fw_env.config
 	fi
 
 	# Replaces: base-files is needed to replace /etc/update-motd.d/ files on Xenial


### PR DESCRIPTION
# Description

If we don't need to build u-boot, we can special BOOTCONFIG=none.

But this will also prevent to copy bootscript.

# How Has This Been Tested?

- [X] Build

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
