### PR TITLE
When using https download for rootfs cache it gets wrong servers

### DIFF
--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1624,7 +1624,7 @@ function webseed ()
 	unset text
 	local CCODE=$(curl -s redirect.armbian.com/geoip | jq '.continent.code' -r)
 
-	if [[ "$2" == "rootfs" ]]; then
+	if [[ "$2" == rootfs* ]]; then
 		WEBSEED=($(curl -s ${1}mirrors | jq -r '.'${CCODE}' | .[] | values'))
 		else
 		WEBSEED=($(curl -s https://redirect.armbian.com/mirrors | jq -r '.'${CCODE}' | .[] | values'))


### PR DESCRIPTION
# Description

After introducing new cache system based on Git releases, ke…y also contains sub-folder.

# How Has This Been Tested?

- [x] Manual test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
