### PR TITLE
enable 5.19.y edge kernel for the radxa zero 2 builds

### DIFF
--- a/config/boards/radxa-zero2.csc
+++ b/config/boards/radxa-zero2.csc
@@ -2,7 +2,7 @@
 BOARD_NAME="Radxa Zero 2"
 BOARDFAMILY="meson-g12b"
 BOOTCONFIG="radxa-zero2_config"
-KERNEL_TARGET="current"
+KERNEL_TARGET="current,edge"
 FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
 ASOUND_STATE="asound.state.radxa-zero2"


### PR DESCRIPTION
# Description

enable 5.19.y edge kernel for the radxa zero 2 builds on the radxa zero 2 board config
5.19.y kernel source is already  handled by meson64 config so we just have to enable the edge kernel builds on the board config

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
