### PR TITLE
Upstream packages naming has been changed

### DIFF
--- a/config/desktop/bullseye/environments/kde-plasma/config_base/packages
+++ b/config/desktop/bullseye/environments/kde-plasma/config_base/packages
@@ -49,7 +49,7 @@ hunspell-en-us
 inputattach
 kde-plasma-desktop
 keyutils
-kwin
+kwin-x11
 laptop-detect
 libatk-adaptor
 libcvc0


### PR DESCRIPTION
# Description

Jira reference number [AR-1286]

# How Has This Been Tested?

- [x] Generated bullseye-kde-plasma-arm64.e08...e6c.tar.zst: 2.92GiB [ 647MiB/s]

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1286]: https://armbian.atlassian.net/browse/AR-1286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ