### PR TITLE
Keep empty line in armbianEnv.txt

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
+++ b/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
@@ -365,12 +365,6 @@ add_usb_storage_quirks() {
 	# check for /boot/armbianEnv.txt existence
 	[ -f /boot/armbianEnv.txt ] || return
 
-	# cleanup. add LF. This prevents adding parameters to the same line
-	echo "" >> /boot/armbianEnv.txt;  sed -i '/^$/d;$G' /boot/armbianEnv.txt; sed -i '/^$/d;$G' /boot/armbianEnv.txt
-
-	# cleanup. remove empty lines in the middle
-	sed -i '/^$/d' /boot/armbianEnv.txt
-
 	# preserve old contents if existent
 	TMPFILE=$(mktemp /tmp/${0##*/}.XXXXXX)
 	trap "sleep 1 ; rm \"${TMPFILE}\" ; exit 0" 0 1 2 3 15
@@ -390,8 +384,7 @@ add_usb_storage_quirks() {
 	done
 
 	read USBQUIRKS <${TMPFILE}
-	sed -i '/^usbstoragequirks/d' /boot/armbianEnv.txt
-	echo "usbstoragequirks=${USBQUIRKS}" >>/boot/armbianEnv.txt
+	sed -i "s/^usbstoragequirks=.*/usbstoragequirks=${USBQUIRKS}/" /boot/armbianEnv.txt
 	sync &
 	if [ -f /sys/module/usb_storage/parameters/quirks ]; then
 		echo ${USBQUIRKS} >/sys/module/usb_storage/parameters/quirks


### PR DESCRIPTION
# Description

Keep empty line in `armbianEnv.txt`

# How Has This Been Tested?

- [ ] Test A

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
