### PR TITLE
rk322x,rockchip: fix rkvdec patch due to mainlined changes

### DIFF
--- a/patch/kernel/archive/rk322x-5.19/01-linux-2000-v4l2-wip-rkvdec-hevc.patch
+++ b/patch/kernel/archive/rk322x-5.19/01-linux-2000-v4l2-wip-rkvdec-hevc.patch
@@ -2858,7 +2858,7 @@ index c3cceba837c2..5c341b5fa534 100644
  			       rkvdec->regs + RKVDEC_REG_H264_BASE_REFER(i));
  
 -		reg = RKVDEC_POC_REFER(i < sl_params->num_active_dpb_entries ? dpb[i].pic_order_cnt[0] : 0);
-+		reg = RKVDEC_POC_REFER(i < decode_params->num_active_dpb_entries ? dpb[i].pic_order_cnt[0] : 0);
++		reg = RKVDEC_POC_REFER(i < decode_params->num_active_dpb_entries ? dpb[i].pic_order_cnt_val : 0);
  		writel_relaxed(reg,
  			       rkvdec->regs + RKVDEC_REG_H264_POC_REFER0(i));
  	}
@@ -3124,7 +3124,7 @@ index b5bb4c083dbc..8467084165df 100644
  				  REF_PIC_LONG_TERM_L0(i));
  			WRITE_RPS(sl_params->ref_idx_l0[i], REF_PIC_IDX_L0(i));
 +
-+			if (dpb[sl_params->ref_idx_l0[i]].pic_order_cnt[0] > sl_params->slice_pic_order_cnt)
++			if (dpb[sl_params->ref_idx_l0[i]].pic_order_cnt_val > sl_params->slice_pic_order_cnt)
 +				lowdelay = 0;
 +
  		}
@@ -3134,7 +3134,7 @@ index b5bb4c083dbc..8467084165df 100644
  				  REF_PIC_LONG_TERM_L1(i));
  			WRITE_RPS(sl_params->ref_idx_l1[i], REF_PIC_IDX_L1(i));
 +
-+			if (dpb[sl_params->ref_idx_l1[i]].pic_order_cnt[0] > sl_params->slice_pic_order_cnt)
++			if (dpb[sl_params->ref_idx_l1[i]].pic_order_cnt_val > sl_params->slice_pic_order_cnt)
 +				lowdelay = 0;
  		}
  

--- a/patch/kernel/archive/rockchip-5.19/01-linux-2000-v4l2-wip-rkvdec-hevc.patch
+++ b/patch/kernel/archive/rockchip-5.19/01-linux-2000-v4l2-wip-rkvdec-hevc.patch
@@ -2858,7 +2858,7 @@ index c3cceba837c2..5c341b5fa534 100644
  			       rkvdec->regs + RKVDEC_REG_H264_BASE_REFER(i));
  
 -		reg = RKVDEC_POC_REFER(i < sl_params->num_active_dpb_entries ? dpb[i].pic_order_cnt[0] : 0);
-+		reg = RKVDEC_POC_REFER(i < decode_params->num_active_dpb_entries ? dpb[i].pic_order_cnt[0] : 0);
++		reg = RKVDEC_POC_REFER(i < decode_params->num_active_dpb_entries ? dpb[i].pic_order_cnt_val : 0);
  		writel_relaxed(reg,
  			       rkvdec->regs + RKVDEC_REG_H264_POC_REFER0(i));
  	}
@@ -3124,7 +3124,7 @@ index b5bb4c083dbc..8467084165df 100644
  				  REF_PIC_LONG_TERM_L0(i));
  			WRITE_RPS(sl_params->ref_idx_l0[i], REF_PIC_IDX_L0(i));
 +
-+			if (dpb[sl_params->ref_idx_l0[i]].pic_order_cnt[0] > sl_params->slice_pic_order_cnt)
++			if (dpb[sl_params->ref_idx_l0[i]].pic_order_cnt_val > sl_params->slice_pic_order_cnt)
 +				lowdelay = 0;
 +
  		}
@@ -3134,7 +3134,7 @@ index b5bb4c083dbc..8467084165df 100644
  				  REF_PIC_LONG_TERM_L1(i));
  			WRITE_RPS(sl_params->ref_idx_l1[i], REF_PIC_IDX_L1(i));
 +
-+			if (dpb[sl_params->ref_idx_l1[i]].pic_order_cnt[0] > sl_params->slice_pic_order_cnt)
++			if (dpb[sl_params->ref_idx_l1[i]].pic_order_cnt_val > sl_params->slice_pic_order_cnt)
 +				lowdelay = 0;
  		}
  


### PR DESCRIPTION
# Description

As suggested by @amazingfate [here](https://github.com/armbian/build/pull/4079), rkvdec libreelec-imported patch is breaking edge compilation due to mainlined changes in kernel 5.19.2.
This PR fixes the patch

# How Has This Been Tested?

- [x] rk322x deb packages complied properly

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
