### PR TITLE
Use a shorter label as the default value for bootfs to avoid mkfs.fat fail

### DIFF
--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -484,7 +484,7 @@ prepare_partitions()
 	UEFI_MOUNT_POINT=${UEFI_MOUNT_POINT:-/boot/efi}
 	UEFI_FS_LABEL="${UEFI_FS_LABEL:-armbiefi}"
 	ROOT_FS_LABEL="${ROOT_FS_LABEL:-armbian_root}"
-	BOOT_FS_LABEL="${BOOT_FS_LABEL:-armbian_boot}"
+	BOOT_FS_LABEL="${BOOT_FS_LABEL:-armbianboot}"
 
 	call_extension_method "pre_prepare_partitions" "prepare_partitions_custom" <<'PRE_PREPARE_PARTITIONS'
 *allow custom options for mkfs*


### PR DESCRIPTION
# Description

When LABEL is longer than 11 characters, `mkfs.fat 4.2 (2021-01-31) ` will fail while `mkfs.fat 4.1 (2017-01-24)` will cut it.

I want to split out a new function for formating filesystem. But unfortunally, there is a hook `pre_prepare_partitions` and `prepare_partitions_custom`. And `bcm2711` use it for LABEL. Here is my try: [hzyitc/armbian-onecloud#6c190484](https://github.com/hzyitc/armbian-onecloud/commit/6c1904842eff025252846bd4b33203e965e973d9)

## The source of `mkfs.fat`:

### v4.1: https://github.com/dosfstools/dosfstools/blob/v4.1/src/mkfs.fat.c#L1500:
```
	case 'n':		/* n : Volume name */
	    sprintf(volume_name, "%-11.11s", optarg);
	    for (i = 0; volume_name[i] && i < 11; i++)
		/* don't know if here should be more strict !uppercase(label[i]) */
		if (islower(volume_name[i])) {
		    fprintf(stderr,
		            "mkfs.fat: warning - lowercase labels might not work properly with DOS or Windows\n");
		    break;
		}

	    break;
```

### v4.2: https://github.com/dosfstools/dosfstools/blob/v4.2/src/mkfs.fat.c#L706:
```
    len = mbstowcs(NULL, volume_name, 0);
    if (len != (size_t)-1 && len > 11)
	die("Label can be no longer than 11 characters");
```

# How Has This Been Tested?

No test

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
