### PR TITLE
Fix typo in boot-jethub.cmd

### DIFF
--- a/config/bootscripts/boot-jethub.cmd
+++ b/config/bootscripts/boot-jethub.cmd
@@ -54,12 +54,12 @@ if test "$board" = "jethub-j100"; then
     if test "$perev" = "02"; then
     # D1P + RTL8822CS
         echo "Applying DT kernel file for JetHub D1/P RTL8822CS device"
-        setenv fdtfile "amlogic/meson-axg-jethome-jethub-j110-rev-2.dts"
+        setenv fdtfile "amlogic/meson-axg-jethome-jethub-j110-rev-2.dtb"
     fi;
     if test "$perev" = "03"; then
     # D1P + W155S1
         echo "Applying DT kernel file for JetHub D1/P W155S1 device"
-        setenv fdtfile "amlogic/meson-axg-jethome-jethub-j110-rev-3.dts"
+        setenv fdtfile "amlogic/meson-axg-jethome-jethub-j110-rev-3.dtb"
     fi;
 fi;
 


### PR DESCRIPTION
# Description

Fix typo in boot.cmd for jethub devices

Jira reference number [AR-1232]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1232]: https://armbian.atlassian.net/browse/AR-1232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ