### PR TITLE
debootstrap.sh fixes for GPT partition table use

### DIFF
--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -680,7 +680,7 @@ PREPARE_IMAGE_SIZE
 		mkfs.${mkfs[$ROOTFS_TYPE]} ${mkopts[$ROOTFS_TYPE]=:''} ${mkopts_label[$ROOTFS_TYPE]:+${mkopts_label[$ROOTFS_TYPE]}${ROOT_FS_LABEL}} ${rootdevice} >> ${DEST}/${LOG_SUBPATH}/install.log 2>&1
 		[[ $ROOTFS_TYPE == ext4 ]] && tune2fs -o journal_data_writeback $rootdevice > /dev/null
 		[[ $ROOTFS_TYPE == btrfs && $BTRFS_COMPRESSION != none ]] && local rfsmntopt='-o compress-force='${BTRFS_COMPRESSION}
-		mount ${rfsmntopt:=''} ${rootdevice} ${MOUNT}
+		mount ${rfsmntopt:=} ${rootdevice} ${MOUNT}
 		# create fstab (and crypttab) entry
 		if [[ $CRYPTROOT_ENABLE == yes ]]; then
 			# map the LUKS container partition via its UUID to be the 'cryptroot' device
@@ -695,13 +695,13 @@ PREPARE_IMAGE_SIZE
 		local bootdevice="${LOOP}p${bootpart}"
 		display_alert "Creating boot fs" "${bootfs} on ${bootdevice}"
 		check_loop_device ${bootdevice}
-		mkfs.${mkfs[$bootfs]} ${mkopts[$bootfs]:=''} ${mkopts_label[$bootfs]:+${mkopts_label[$bootfs]}${BOOT_FS_LABEL}} ${bootdevice} >> ${DEST}/${LOG_SUBPATH}/install.log 2>&1
+		mkfs.${mkfs[$bootfs]} ${mkopts[$bootfs]:=} ${mkopts_label[$bootfs]:+${mkopts_label[$bootfs]}${BOOT_FS_LABEL}} ${bootdevice} >> ${DEST}/${LOG_SUBPATH}/install.log 2>&1
 		mkdir -p ${MOUNT}/boot
 		[[ ${bootfs} == fat ]] && {
 			local bfsmntopt="${mkfs[$bootfs]:+ -t vfat}"' '
 			display_alert "Mount command line parameter with the type of the boot file system:" "${bfsmntopt}"
 		}
-		mount ${bfsmntopt:=''} ${bootdevice} ${MOUNT}/boot
+		mount ${bfsmntopt:=} ${bootdevice} ${MOUNT}/boot
 		echo "UUID=$(blkid -s UUID -o value ${bootdevice}) /boot ${mkfs[$bootfs]} defaults${mountopts[$bootfs]} 0 2" >> ${SDCARD}/etc/fstab
 	fi
 	if [[ -n $uefipart ]]; then


### PR DESCRIPTION
Fixes to correctly create a GPT partition table with fat boot partition and ext4 rootfs partition.
fix1: mkfs interprets command line parameters differently when the partition table is of GPT type.
fix2: some unset parameters were imported into command lines. In case of unset they now are set empty so that no ambiguity exists as what bash does with it.
fix3: mounting of the boot fs loop is helped by hints about the partition being vfat type. 
fix4: filling of the boot fs at the mount point had wrong reference to the boot folder to be rsync-ed.

Tested on a Rock 3A board (rk3568 SoC), written to eMMC memory.
OS boots, parted indicates proper OS partition and file system structure GPT, boot partition : fat, rootfs partition: ext4 
