### PR TITLE
Extend network interface auto detection to suppress errors

### DIFF
--- a/packages/bsp/common/etc/default/armbian-motd.dpkg-dist
+++ b/packages/bsp/common/etc/default/armbian-motd.dpkg-dist
@@ -7,7 +7,7 @@
 MOTD_DISABLE=""
 ONE_WIRE=""
 HIDE_IP_PATTERN="^dummy0|^lo"
-PRIMARY_INTERFACE="$(ls -1 /sys/class/net/ | grep -v lo | grep -E "en|eth|wl" | head -1)"
+PRIMARY_INTERFACE="$(ls -1 /sys/class/net/ | grep -E "en|eth|wl" | head -1)"
 PRIMARY_DIRECTION="rx"
 STORAGE=/dev/sda1
 

--- a/packages/bsp/common/etc/default/armbian-motd.dpkg-dist
+++ b/packages/bsp/common/etc/default/armbian-motd.dpkg-dist
@@ -7,7 +7,7 @@
 MOTD_DISABLE=""
 ONE_WIRE=""
 HIDE_IP_PATTERN="^dummy0|^lo"
-PRIMARY_INTERFACE="$(ls -1 /sys/class/net/ | grep -v lo | grep -E "enp|eth" | head -1)"
+PRIMARY_INTERFACE="$(ls -1 /sys/class/net/ | grep -v lo | grep -E "en|eth|wl" | head -1)"
 PRIMARY_DIRECTION="rx"
 STORAGE=/dev/sda1
 

--- a/packages/bsp/common/etc/default/armbian-motd.dpkg-dist
+++ b/packages/bsp/common/etc/default/armbian-motd.dpkg-dist
@@ -7,7 +7,7 @@
 MOTD_DISABLE=""
 ONE_WIRE=""
 HIDE_IP_PATTERN="^dummy0|^lo"
-PRIMARY_INTERFACE="$(ls -1 /sys/class/net/ | grep -E "en|eth|wl" | head -1)"
+PRIMARY_INTERFACE="$(ls -1 /sys/class/net/ | grep -E "en|eth|wl" -m 1)"
 PRIMARY_DIRECTION="rx"
 STORAGE=/dev/sda1
 


### PR DESCRIPTION
# Description

Cosmetic issue on MOTD.

```System load:   6%               Up time:       11:17
Memory usage:  14% of 1.94G     IP:            172.17.0.1 192.168.1.154
CPU temp:      60°C             Usage of /:    8% of 29G
RX today:      Error: No interface matching "veth3fb48f0" found in database.
```

Jira reference number [AR-1285]

# How Has This Been Tested?

- [x] Manual test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1285]: https://armbian.atlassian.net/browse/AR-1285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ