### PR TITLE
Enable 32b meson kernel compilation

### DIFF
--- a/config/sources/families/include/meson_common.inc
+++ b/config/sources/families/include/meson_common.inc
@@ -9,6 +9,8 @@ CPUMIN=504000
 CPUMAX=1632000
 GOVERNOR=ondemand
 
+SKIP_BOOTSPLASH="yes"
+
 case $BOARD in
 	odroidc1)
 

--- a/config/targets-cli-beta.conf
+++ b/config/targets-cli-beta.conf
@@ -71,6 +71,6 @@ uefi-arm64                   edge            jammy       cli                    
 virtual-qemu                 current         jammy       cli                      beta         yes
 
 
-# One cloud kernel only
+# OneCloud kernel only
 onecloud                     current         jammy       cli                      beta         no
 onecloud                     edge            jammy       cli                      beta         no

--- a/config/targets-cli-beta.conf
+++ b/config/targets-cli-beta.conf
@@ -69,3 +69,8 @@ uefi-arm64                   edge            jammy       cli                    
 
 # Virtual qemu
 virtual-qemu                 current         jammy       cli                      beta         yes
+
+
+# One cloud kernel only
+onecloud                     current         jammy       cli                      beta         no
+onecloud                     edge            jammy       cli                      beta         no


### PR DESCRIPTION
# Description

In order to build those images as community targets we have to build kernels automated way. Enabling.

# How Has This Been Tested?

- [x] Build test for current and edge

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
