### PR TITLE
rockchip64: edge kernel, remove inno usb2 phy init code causing kernel fault

### DIFF
--- a/patch/kernel/archive/rockchip64-5.19/general-fix-inno-usb2-phy-init.patch
+++ b/patch/kernel/archive/rockchip64-5.19/general-fix-inno-usb2-phy-init.patch
@@ -1,0 +1,28 @@
+From e4cd72bcf2b4581122d065c2854fdb6be4b19bc3 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Mon, 22 Aug 2022 20:51:22 +0000
+Subject: [PATCH] remove usb2phy extcon initialization causing kernel oops
+
+---
+ drivers/phy/rockchip/phy-rockchip-inno-usb2.c | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/drivers/phy/rockchip/phy-rockchip-inno-usb2.c b/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
+index 5223d4c9afdf..0341f8208989 100644
+--- a/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
++++ b/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
+@@ -1165,11 +1165,6 @@ static int rockchip_usb2phy_otg_port_init(struct rockchip_usb2phy *rphy,
+ 		if (ret)
+ 			dev_err(rphy->dev, "register USB HOST notifier failed\n");
+ 
+-		if (!of_property_read_bool(rphy->dev->of_node, "extcon")) {
+-			/* do initial sync of usb state */
+-			ret = property_enabled(rphy->grf, &rport->port_cfg->utmi_id);
+-			extcon_set_state_sync(rphy->edev, EXTCON_USB_HOST, !ret);
+-		}
+ 	}
+ 
+ out:
+-- 
+2.34.1
+


### PR DESCRIPTION
# Description

A change in kernel 5.19.2 causes kernel oops in inno usb2 phy initialization (at least) when there is an usb3 type-c connector device (like fairchild usb3 controller) trying to initialize the usb2 phy.

My Orange PI 4 LTS was entering kernel panic when the monitor was brought on by effect of fusb302 kernel module initializing the whole type-c subsystem (display port, usb2 and usb3 phys).

This patch removes the init code introduced in 5.19.2

# How Has This Been Tested?

- [x] Produced kernel debs and installed on living Orange PI 4 LTS system

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
