### PR TITLE
Fix nfs build

### DIFF
--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -82,7 +82,7 @@ if [[ $CRYPTROOT_ENABLE == yes && -z $CRYPTROOT_PASSPHRASE ]]; then
 fi
 
 # small SD card with kernel, boot script and .dtb/.bin files
-[[ $ROOTFS_TYPE == nfs ]] && FIXED_IMAGE_SIZE=64
+[[ $ROOTFS_TYPE == nfs ]] && FIXED_IMAGE_SIZE=256
 
 # Since we are having too many options for mirror management,
 # then here is yet another mirror related option.


### PR DESCRIPTION
# Description

This PR address the following issue while build as NFS:
```
[ .... ] Copying files to [ /boot ]

sent 18.23M bytes  received 4.74K bytes  36.46M bytes/sec
total size is 18.21M  speedup is 1.00
find: ‘/root/armbian-onecloud/.tmp/mount-ea6d8ff5-ed2a-4888-8361-6ae990318e95/lib/modules/’: No such file or directory
[ error ] ERROR in function update_initramfs [ main.sh:588 -> main.sh:549 -> debootstrap.sh:98 -> debootstrap.sh:863 -> debootstrap.sh:789 -> general.sh:0 ]
[ error ] No kernel installed for the version [ 5.17.11 ]
[ o.k. ] Process terminated 
[ error ] unmount_on_exit() called! [ main.sh:1 -> image-helpers.sh:0 ]
[ o.k. ] Unmounting [ /root/armbian-onecloud/.tmp/rootfs-ea6d8ff5-ed2a-4888-8361-6ae990318e95/ ]
[ error ] ERROR in function unmount_on_exit [ main.sh:1 -> image-helpers.sh:94 -> general.sh:0 ]
[ error ] debootstrap-ng was interrupted 
[ o.k. ] Process terminated
```

# How Has This Been Tested?

- [X] Build

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
