### PR TITLE
Activate sun4i_csi module in linux-sunxi-edge

### DIFF
--- a/config/kernel/linux-sunxi-edge.config
+++ b/config/kernel/linux-sunxi-edge.config
@@ -4401,7 +4401,7 @@ CONFIG_VIDEO_CADENCE_CSI2TX=m
 #
 # Sunxi media platform drivers
 #
-# CONFIG_VIDEO_SUN4I_CSI is not set
+CONFIG_VIDEO_SUN4I_CSI=m
 CONFIG_VIDEO_SUN6I_CSI=m
 
 #


### PR DESCRIPTION
Activating sun4i_csi as a kernel module is required to activate csi0/1 on sun4i-a10, sun7i-a20 and sun8i-r40.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Jira reference number [AR-9999]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
