### PR TITLE
Fix armbian header

### DIFF
--- a/packages/bsp/common/etc/update-motd.d/10-armbian-header
+++ b/packages/bsp/common/etc/update-motd.d/10-armbian-header
@@ -16,7 +16,7 @@ MOTD_DISABLE=""
 if [[ -f /etc/armbian-distribution-status ]]; then
 	. /etc/armbian-distribution-status
 	[[ -f /etc/lsb-release ]] && DISTRIBUTION_CODENAME=$(grep CODENAME /etc/lsb-release | cut -d"=" -f2)
-	[[ -f /etc/os-release ]] && DISTRIBUTION_CODENAME=$(grep VERSION_CODENAME /etc/os-release | cut -d"=" -f2)
+	[[ -z "$DISTRIBUTION_CODENAME" && -f /etc/os-release ]] && DISTRIBUTION_CODENAME=$(grep VERSION_CODENAME /etc/os-release | cut -d"=" -f2)
 	DISTRIBUTION_STATUS=$(grep "$DISTRIBUTION_CODENAME" /etc/armbian-distribution-status | cut -d"=" -f2)
 fi
 [[ -f /etc/default/armbian-motd ]] && . /etc/default/armbian-motd

--- a/packages/bsp/common/etc/update-motd.d/10-armbian-header
+++ b/packages/bsp/common/etc/update-motd.d/10-armbian-header
@@ -17,6 +17,7 @@ if [[ -f /etc/armbian-distribution-status ]]; then
 	. /etc/armbian-distribution-status
 	[[ -f /etc/lsb-release ]] && DISTRIBUTION_CODENAME=$(grep CODENAME /etc/lsb-release | cut -d"=" -f2)
 	[[ -z "$DISTRIBUTION_CODENAME" && -f /etc/os-release ]] && DISTRIBUTION_CODENAME=$(grep VERSION_CODENAME /etc/os-release | cut -d"=" -f2)
+	[[ -z "$DISTRIBUTION_CODENAME" && -x /usr/bin/lsb_release ]] && DISTRIBUTION_CODENAME=$(/usr/bin/lsb_release -c | cut -d":" -f2 | tr -d "\t")
 	DISTRIBUTION_STATUS=$(grep "$DISTRIBUTION_CODENAME" /etc/armbian-distribution-status | cut -d"=" -f2)
 fi
 [[ -f /etc/default/armbian-motd ]] && . /etc/default/armbian-motd

--- a/packages/bsp/common/etc/update-motd.d/10-armbian-header
+++ b/packages/bsp/common/etc/update-motd.d/10-armbian-header
@@ -14,8 +14,8 @@ MOTD_DISABLE=""
 
 [[ -f /etc/armbian-release ]] && . /etc/armbian-release
 [[ -f /etc/armbian-distribution-status ]] && . /etc/armbian-distribution-status
-[[ -f /etc/lsb-release && -f /etc/armbian-distribution-status ]] && DISTRIBUTION_CODENAME=$(grep CODENAME /etc/lsb-release | cut -d"=" -f2) && DISTRIBUTION_STATUS=$(grep $DISTRIBUTION_CODENAME /etc/armbian-distribution-status | cut -d"=" -f2)
-[[ -f /etc/os-release && -f /etc/armbian-distribution-status ]] && DISTRIBUTION_CODENAME=$(grep VERSION_CODENAME /etc/os-release | cut -d"=" -f2) && DISTRIBUTION_STATUS=$(grep $DISTRIBUTION_CODENAME /etc/armbian-distribution-status | cut -d"=" -f2)
+[[ -f /etc/lsb-release && -f /etc/armbian-distribution-status ]] && DISTRIBUTION_CODENAME=$(grep CODENAME /etc/lsb-release | cut -d"=" -f2) && DISTRIBUTION_STATUS=$(grep "$DISTRIBUTION_CODENAME" /etc/armbian-distribution-status | cut -d"=" -f2)
+[[ -f /etc/os-release && -f /etc/armbian-distribution-status ]] && DISTRIBUTION_CODENAME=$(grep VERSION_CODENAME /etc/os-release | cut -d"=" -f2) && DISTRIBUTION_STATUS=$(grep "$DISTRIBUTION_CODENAME" /etc/armbian-distribution-status | cut -d"=" -f2)
 [[ -f /etc/default/armbian-motd ]] && . /etc/default/armbian-motd
 
 for f in $MOTD_DISABLE; do

--- a/packages/bsp/common/etc/update-motd.d/10-armbian-header
+++ b/packages/bsp/common/etc/update-motd.d/10-armbian-header
@@ -13,9 +13,12 @@ THIS_SCRIPT="header"
 MOTD_DISABLE=""
 
 [[ -f /etc/armbian-release ]] && . /etc/armbian-release
-[[ -f /etc/armbian-distribution-status ]] && . /etc/armbian-distribution-status
-[[ -f /etc/lsb-release && -f /etc/armbian-distribution-status ]] && DISTRIBUTION_CODENAME=$(grep CODENAME /etc/lsb-release | cut -d"=" -f2) && DISTRIBUTION_STATUS=$(grep "$DISTRIBUTION_CODENAME" /etc/armbian-distribution-status | cut -d"=" -f2)
-[[ -f /etc/os-release && -f /etc/armbian-distribution-status ]] && DISTRIBUTION_CODENAME=$(grep VERSION_CODENAME /etc/os-release | cut -d"=" -f2) && DISTRIBUTION_STATUS=$(grep "$DISTRIBUTION_CODENAME" /etc/armbian-distribution-status | cut -d"=" -f2)
+if [[ -f /etc/armbian-distribution-status ]]; then
+	. /etc/armbian-distribution-status
+	[[ -f /etc/lsb-release ]] && DISTRIBUTION_CODENAME=$(grep CODENAME /etc/lsb-release | cut -d"=" -f2)
+	[[ -f /etc/os-release ]] && DISTRIBUTION_CODENAME=$(grep VERSION_CODENAME /etc/os-release | cut -d"=" -f2)
+	DISTRIBUTION_STATUS=$(grep "$DISTRIBUTION_CODENAME" /etc/armbian-distribution-status | cut -d"=" -f2)
+fi
 [[ -f /etc/default/armbian-motd ]] && . /etc/default/armbian-motd
 
 for f in $MOTD_DISABLE; do


### PR DESCRIPTION
# Description

A couple of regressions from #4013 and #3619 was fixed. The first one causes Ambian Sid images to hang until Ctrl+C is pressed at login. The second regression is minor, and 

Finally, the logic is updated to detect Debian Sid and Bookwork using lsb_release when available.

# How Has This Been Tested?

This was tested on Armbian Sid on a La Frite, by modifying the `/etc/update-motd.d/10-armbian-header` script before logging in again.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
