### PR TITLE
Fix for #4146 cp: missing destination file for helios64

### DIFF
--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -188,8 +188,9 @@ compile_uboot()
 		[[ $CREATE_PATCHES == yes ]] && userpatch_create "u-boot"
 
 		if [[ -n $ATFSOURCE ]]; then
-			cp -Rv "${atftempdir}"/*.bin .
-			cp -Rv "${atftempdir}"/*.elf .
+			cp -Rv "${atftempdir}"/*.bin . 2>/dev/null || \
+			cp -Rv "${atftempdir}"/*.elf . 2>/dev/null
+			[[ $? -ne 0 ]] && exit_with_error "ATF binary not found"
 			rm -rf "${atftempdir}"
 		fi
 


### PR DESCRIPTION
Should fix #4146 message 
```
cp: missing destination file operand after '.'
```
when building image for rockchip with ATF.
