### PR TITLE
Typo in create_rootfs_cache version

### DIFF
--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -190,7 +190,7 @@ create_rootfs_cache()
 		create_sources_list "$RELEASE" "$SDCARD/"
 	else
 
-		local ROOT_FS_CREATE_VERSION=${ROOT_FS_CREATE_VERSION:-$(date --utc "+%Y%M%d")}
+		local ROOT_FS_CREATE_VERSION=${ROOT_FS_CREATE_VERSION:-$(date --utc +"%Y%m%d")}
 		local cache_name=${ARCH}-${RELEASE}-${cache_type}-${packages_hash}-${ROOT_FS_CREATE_VERSION}.tar.zst
 		local cache_fname=${SRC}/cache/rootfs/${cache_name}
 


### PR DESCRIPTION
# Description

We need to use `%m` for month instand of `%M` for minute.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
