### PR TITLE
Disable Github API in get_rootfs_cache_list

### DIFF
--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -124,8 +124,10 @@ get_rootfs_cache_list()
 	local packages_hash=$2
 
 	{
-		curl --silent --fail -L "https://api.github.com/repos/armbian/cache/releases?per_page=3" | jq -r '.[].tag_name' \
-		|| curl --silent --fail -L https://cache.armbian.com/rootfs/list
+		# Temportally disable Github API because we don't support to download from it
+		# curl --silent --fail -L "https://api.github.com/repos/armbian/cache/releases?per_page=3" | jq -r '.[].tag_name' \
+		# || curl --silent --fail -L https://cache.armbian.com/rootfs/list
+		curl --silent --fail -L https://cache.armbian.com/rootfs/list
 
 		find ${SRC}/cache/rootfs/ -mtime -7 -name "${ARCH}-${RELEASE}-${cache_type}-${packages_hash}-*.tar.zst" \
 			| sed -e 's#^.*/##' \


### PR DESCRIPTION
# Description

We don't support download rootfs cache from Github. So only use the `https://cache.armbian.com/rootfs/list`

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
