### PR TITLE
Enable missing kernel build targets

### DIFF
--- a/config/targets.conf
+++ b/config/targets.conf
@@ -983,7 +983,8 @@ rpi4b                     current         jammy       desktop                  s
 rpi4b                     current         jammy       desktop                  stable         yes            cinnamon      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 rpi4b                     current         jammy       desktop                  stable         adv            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 rpi4b                     current         jammy       desktop                  stable         yes            kde-plasma    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-
+#
+rpi4b                     edge            jammy       cli                      stable         no
 
 # uefi-x86
 uefi-x86                  current         jammy       cli                      stable         adv
@@ -1023,3 +1024,8 @@ uefi-arm64                edge            sid         desktop                  s
 
 # Virtual qemu
 virtual-qemu              current         focal       cli                      stable         no
+
+
+# Udoo
+udoo                      current         bullseye    cli                      stable         no
+udoo                      edge            bullseye    cli                      stable         no


### PR DESCRIPTION
# Description

Even we don't provide images for imx6 or bcm-2711 edge, we need to build kernels.