### PR TITLE
Refactor `download_and_verify`

### DIFF
--- a/lib/configuration.sh
+++ b/lib/configuration.sh
@@ -597,16 +597,6 @@ if [[ "${ARCH}" == "amd64" ]]; then
 		fi
 fi
 
-# don't use mirrors that throws garbage on 404
-if [[ -z ${ARMBIAN_MIRROR} ]]; then
-	while true; do
-
-		ARMBIAN_MIRROR=$(wget -SO- -T 1 -t 1 https://redirect.armbian.com 2>&1 | egrep -i "Location" | awk '{print $2}' | head -1)
-		[[ ${ARMBIAN_MIRROR} != *armbian.hosthatch* ]] && break
-
-	done
-fi
-
 [[ -z $DISABLE_IPV6 ]] && DISABLE_IPV6="true"
 
 # For (late) user override.

--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -162,22 +162,14 @@ create_rootfs_cache()
 
 		display_alert "Checking cache" "$cache_name" "info"
 
-		if [[ -f ${cache_fname}.aria2 ]]; then
-			display_alert "Removing partially downloaded file."
-			rm ${cache_fname}*
-		fi
-
-		if [[ ! -f $cache_fname ]]; then
+		# if aria2 file exists download didn't succeeded
+		if [[ ! -f $cache_fname || -f ${cache_fname}.aria2 ]]; then
 			display_alert "Downloading from servers"
-			download_and_verify "rootfs" "$cache_name"
+			download_and_verify "rootfs" "$cache_name" \
+			|| continue
 		fi
 
-		if [[ ! -f ${cache_fname} ]]; then
-			display_alert "not found"
-			continue
-		fi
-
-		break
+		[[ -f $cache_fname && ! -f ${cache_fname}.aria2 ]] && break
 	done
 
 	# if aria2 file exists download didn't succeeded

--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -169,7 +169,7 @@ create_rootfs_cache()
 
 		if [[ ! -f $cache_fname ]]; then
 			display_alert "Downloading from servers"
-			download_and_verify "_rootfs" "$cache_name"
+			download_and_verify "rootfs" "$cache_name"
 		fi
 
 		if [[ ! -f ${cache_fname} ]]; then

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1563,7 +1563,7 @@ prepare_host()
 				local toolchain_zip="${SRC}/cache/toolchain/${toolchain}"
 				local toolchain_dir="${toolchain_zip%.tar.*}"
 				if [[ ! -f "${toolchain_dir}/.download-complete" ]]; then
-					download_and_verify "_toolchain" "${toolchain}"
+					download_and_verify "toolchain" "${toolchain}"
 					[[ ! -f "${toolchain_zip}" ]] && exit_with_error "Failed to download toolchain" "${toolchain}"
 
 					display_alert "decompressing"
@@ -1678,11 +1678,9 @@ function get_urls()
 download_and_verify()
 {
 
-	local catalog=${1#_}
-	local remotedir=$1
+	local catalog=$1
 	local filename=$2
-	local localdir=$SRC/cache/${remotedir//_}
-	local dirname=${filename//.tar.xz}
+	local localdir=$SRC/cache/$catalog
 
 	local keys=(
 		"8F427EAF" # Linaro Toolchain Builder

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1654,6 +1654,7 @@ function get_urls()
 			local CCODE=$(curl --silent --fail  https://cache.armbian.com/geoip | jq '.continent.code' -r)
 			local urls=(
 				# "https://cache.armbian.com/rootfs/${ROOTFSCACHE_VERSION}/${filename}"
+				"https://github.com/armbian/cache/releases/download/${ROOTFSCACHE_VERSION}/${filename}"
 
 				$( curl --silent --fail  "https://cache.armbian.com/mirrors" \
 					| jq -r "(${CCODE:+.${CCODE} // } .default) | .[]" \

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1563,8 +1563,8 @@ prepare_host()
 				local toolchain_zip="${SRC}/cache/toolchain/${toolchain}"
 				local toolchain_dir="${toolchain_zip%.tar.*}"
 				if [[ ! -f "${toolchain_dir}/.download-complete" ]]; then
-					download_and_verify "toolchain" "${toolchain}"
-					[[ ! -f "${toolchain_zip}" ]] && exit_with_error "Failed to download toolchain" "${toolchain}"
+					download_and_verify "toolchain" "${toolchain}" \
+					|| exit_with_error "Failed to download toolchain" "${toolchain}"
 
 					display_alert "decompressing"
 					pv -p -b -r -c -N "[ .... ] ${toolchain}" "${toolchain_zip}" | xz -dc | tar xp --xattrs --no-same-owner --overwrite

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1761,7 +1761,6 @@ download_and_verify()
 		ln -sf "${SRC}/config/torrents/${filename}.asc" "${localdir}/${filename}.asc"
 	else
 		# download signature file
-		local torrent=${server}$remotedir/${filename}.torrent
 		aria2c "${aria2_options[@]}" \
 			--continue=false \
 			--dir="${localdir}" --out="${filename}.asc" \
@@ -1774,6 +1773,9 @@ download_and_verify()
 			[[ $rc -ne 3 ]] && display_alert "Failed to download signature file. aria2 exit code:" "$rc" "wrn"
 			return $rc
 		fi
+
+		[[ ${USE_TORRENT} == "yes" ]] \
+		&& local torrent="${server}${remotedir}/${filename}.torrent $(webseed "${server}" "${remotedir}" "${filename}.torrent")"
 	fi
 
 	# download torrent first
@@ -1783,7 +1785,7 @@ download_and_verify()
 		aria2c "${aria2_options[@]}" \
 			--follow-torrent=mem \
 			--dir="${localdir}" \
-			"${torrent}"
+			${torrent}
 
 		# mark complete
 		[[ $? -eq 0 ]] && touch "${localdir}/${filename}.complete"

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1567,7 +1567,9 @@ prepare_host()
 					|| exit_with_error "Failed to download toolchain" "${toolchain}"
 
 					display_alert "decompressing"
-					pv -p -b -r -c -N "[ .... ] ${toolchain}" "${toolchain_zip}" | xz -dc | tar xp --xattrs --no-same-owner --overwrite
+					pv -p -b -r -c -N "[ .... ] ${toolchain}" "${toolchain_zip}" \
+					| xz -dc \
+					| tar xp --xattrs --no-same-owner --overwrite -C "${SRC}/cache/toolchain/"
 					if [[ $? -ne 0 ]]; then
 						rm -rf "${toolchain_dir}"
 						exit_with_error "Failed to decompress toolchain" "${toolchain}"
@@ -1717,8 +1719,6 @@ download_and_verify()
 		--bt-stop-timeout=30
 	)
 
-	cd "${localdir}" || exit
-
 	# use local signature file
 	if [[ -f "${SRC}/config/torrents/${filename}.asc" ]]; then
 		local torrent="${SRC}/config/torrents/${filename}.torrent"
@@ -1800,7 +1800,9 @@ download_and_verify()
 
 		else
 
-			md5sum -c --status "${localdir}/${filename}.asc" && verified=true && display_alert "Verified" "MD5" "info"
+			[[ "$(md5sum "${localdir}/${filename}" | awk '{printf $1}')" \
+				== "$(awk '{printf $1}' ${localdir}/${filename}.asc)" \
+			]] && verified=true && display_alert "Verified" "MD5" "info"
 
 		fi
 

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1544,34 +1544,46 @@ prepare_host()
 			# download external Linaro compiler and missing special dependencies since they are needed for certain sources
 
 			local toolchains=(
-				"${ARMBIAN_MIRROR}/_toolchain/gcc-linaro-aarch64-none-elf-4.8-2013.11_linux.tar.xz"
-				"${ARMBIAN_MIRROR}/_toolchain/gcc-linaro-arm-none-eabi-4.8-2014.04_linux.tar.xz"
-				"${ARMBIAN_MIRROR}/_toolchain/gcc-linaro-arm-linux-gnueabihf-4.8-2014.04_linux.tar.xz"
-				"${ARMBIAN_MIRROR}/_toolchain/gcc-linaro-7.4.1-2019.02-x86_64_arm-linux-gnueabi.tar.xz"
-				"${ARMBIAN_MIRROR}/_toolchain/gcc-linaro-7.4.1-2019.02-x86_64_aarch64-linux-gnu.tar.xz"
-				"${ARMBIAN_MIRROR}/_toolchains/gcc-arm-8.3-2019.03-x86_64-arm-linux-gnueabihf.tar.xz"
-				"${ARMBIAN_MIRROR}/_toolchains/gcc-arm-8.3-2019.03-x86_64-aarch64-linux-gnu.tar.xz"
-				"${ARMBIAN_MIRROR}/_toolchain/gcc-arm-9.2-2019.12-x86_64-arm-none-linux-gnueabihf.tar.xz"
-				"${ARMBIAN_MIRROR}/_toolchain/gcc-arm-9.2-2019.12-x86_64-aarch64-none-linux-gnu.tar.xz"
-				"${ARMBIAN_MIRROR}/_toolchain/gcc-arm-11.2-2022.02-x86_64-arm-none-linux-gnueabihf.tar.xz"
-				"${ARMBIAN_MIRROR}/_toolchain/gcc-arm-11.2-2022.02-x86_64-aarch64-none-linux-gnu.tar.xz"
+				"gcc-linaro-aarch64-none-elf-4.8-2013.11_linux.tar.xz"
+				"gcc-linaro-arm-none-eabi-4.8-2014.04_linux.tar.xz"
+				"gcc-linaro-arm-linux-gnueabihf-4.8-2014.04_linux.tar.xz"
+				"gcc-linaro-7.4.1-2019.02-x86_64_arm-linux-gnueabi.tar.xz"
+				"gcc-linaro-7.4.1-2019.02-x86_64_aarch64-linux-gnu.tar.xz"
+				"gcc-arm-8.3-2019.03-x86_64-arm-linux-gnueabihf.tar.xz"
+				"gcc-arm-8.3-2019.03-x86_64-aarch64-linux-gnu.tar.xz"
+				"gcc-arm-9.2-2019.12-x86_64-arm-none-linux-gnueabihf.tar.xz"
+				"gcc-arm-9.2-2019.12-x86_64-aarch64-none-linux-gnu.tar.xz"
+				"gcc-arm-11.2-2022.02-x86_64-arm-none-linux-gnueabihf.tar.xz"
+				"gcc-arm-11.2-2022.02-x86_64-aarch64-none-linux-gnu.tar.xz"
 				)
 
 			USE_TORRENT_STATUS=${USE_TORRENT}
 			USE_TORRENT="no"
 			for toolchain in ${toolchains[@]}; do
-				download_and_verify "_toolchain" "${toolchain##*/}"
+				local toolchain_zip="${SRC}/cache/toolchain/${toolchain}"
+				local toolchain_dir="${toolchain_zip%.tar.*}"
+				if [[ ! -f "${toolchain_dir}/.download-complete" ]]; then
+					download_and_verify "_toolchain" "${toolchain}"
+					[[ ! -f "${toolchain_zip}" ]] && exit_with_error "Failed to download toolchain" "${toolchain}"
+
+					display_alert "decompressing"
+					pv -p -b -r -c -N "[ .... ] ${toolchain}" "${toolchain_zip}" | xz -dc | tar xp --xattrs --no-same-owner --overwrite
+					if [[ $? -ne 0 ]]; then
+						rm -rf "${toolchain_dir}"
+						exit_with_error "Failed to decompress toolchain" "${toolchain}"
+					fi
+
+					touch "${toolchain_dir}/.download-complete"
+					rm -rf "${toolchain_zip}"* # Also delete asc file
+				fi
 			done
 			USE_TORRENT=${USE_TORRENT_STATUS}
 
-			rm -rf "${SRC}"/cache/toolchain/*.tar.xz*
 			local existing_dirs=( $(ls -1 "${SRC}"/cache/toolchain) )
 			for dir in ${existing_dirs[@]}; do
 				local found=no
 				for toolchain in ${toolchains[@]}; do
-					local filename=${toolchain##*/}
-					local dirname=${filename//.tar.xz}
-					[[ $dir == $dirname ]] && found=yes
+					[[ $dir == ${toolchain%.tar.*} ]] && found=yes
 				done
 				if [[ $found == no ]]; then
 					display_alert "Removing obsolete toolchain" "$dir"
@@ -1682,10 +1694,6 @@ download_and_verify()
 		else
 			local server=${ARMBIAN_MIRROR}
         fi
-
-	if [[ -f ${localdir}/${dirname}/.download-complete ]]; then
-		return
-	fi
 
 	# rootfs has its own infra
 	if [[ "${remotedir}" == "_rootfs" ]]; then
@@ -1807,14 +1815,7 @@ download_and_verify()
 
 		fi
 
-		if [[ $verified == true ]]; then
-			if [[ "${filename:(-6)}" == "tar.xz" ]]; then
-
-				display_alert "decompressing"
-				pv -p -b -r -c -N "[ .... ] ${filename}" "${filename}" | xz -dc | tar xp --xattrs --no-same-owner --overwrite
-				[[ $? -eq 0 ]] && touch "${localdir}/${dirname}/.download-complete"
-			fi
-		else
+		if [[ $verified != true ]]; then
 			exit_with_error "verification failed"
 		fi
 

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1805,6 +1805,7 @@ download_and_verify()
 		fi
 
 		if [[ $verified != true ]]; then
+			rm -rf "${localdir}/${filename}"* # We also delete asc file
 			exit_with_error "verification failed"
 		fi
 

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1772,6 +1772,7 @@ download_and_verify()
 		echo ""
 	fi
 
+	local verified=false
 	if [[ -f ${localdir}/${filename}.asc ]]; then
 
 		if grep -q 'BEGIN PGP SIGNATURE' "${localdir}/${filename}.asc"; then

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1641,7 +1641,6 @@ function get_urls()
 			local CCODE=$(curl --silent --fail https://dl.armbian.com/geoip | jq '.continent.code' -r)
 			local urls=(
 				# "https://dl.armbian.com/_toolchain/${filename}"
-				# "${ARMBIAN_MIRROR}/${filename}"
 
 				$( curl --silent --fail  "https://dl.armbian.com/mirrors" \
 					| jq -r "(${CCODE:+.${CCODE} // } .default) | .[]" \

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1697,6 +1697,8 @@ download_and_verify()
 		--download-result=hide
 
 		# Meta
+		--server-stat-if="${SRC}/cache/.aria2/server_stats"
+		--server-stat-of="${SRC}/cache/.aria2/server_stats"
 		--dht-file-path="${SRC}/cache/.aria2/dht.dat"
 		--rpc-save-upload-metadata=false
 		--auto-save-interval=0
@@ -1708,10 +1710,15 @@ download_and_verify()
 
 		# Connection
 		--disable-ipv6=$DISABLE_IPV6
+		--connect-timeout=10
+		--timeout=10
+		--allow-piece-length-change=true
+		--max-connection-per-server=2
+		--lowest-speed-limit=500K
 
 		# BT
 		--seed-time=0
-		--bt-stop-timeout=120
+		--bt-stop-timeout=30
 	)
 
         if [[ $DOWNLOAD_MIRROR == china ]]; then


### PR DESCRIPTION
# Description

- Bugfix: We didn't delete the downloaded file when verification failed. So it can be used in next time.
- Bugfix: Incorrent `CCODE` to query mirrors of `cache.armbian.com`
- Support download rootfs cache from Github
- Always require signature file
- Remove some useless requests

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Run the build script

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
