### PR TITLE
Remove build_desktop = no

### DIFF
--- a/config/sources/families/include/meson_common.inc
+++ b/config/sources/families/include/meson_common.inc
@@ -31,16 +31,12 @@ case $BRANCH in
 
 		KERNELBRANCH="branch:linux-5.10.y"
 		KERNELPATCHDIR='meson-'$BRANCH
-
-		BUILD_DESKTOP=no
-
         ;;
+
 	current)
 
 		KERNELBRANCH="branch:linux-5.15.y"
 		KERNELPATCHDIR='meson-'$BRANCH
-
-		BUILD_DESKTOP=no
 
 	;;
 	edge)


### PR DESCRIPTION
# Description

This is not needed anymore as we have HDMI out. And leaving this in, breaks community builds, where we want to build desktop images ...