### PR TITLE
Give additional 5% of space for creating blank image

### DIFF
--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -562,9 +562,9 @@ PREPARE_IMAGE_SIZE
 		# Hardcoded overhead +25% is needed for desktop images,
 		# for CLI it could be lower. Align the size up to 4MiB
 		if [[ $BUILD_DESKTOP == yes ]]; then
-			local sdsize=$(bc -l <<< "scale=0; ((($imagesize * 1.30) / 1 + 0) / 4 + 1) * 4")
+			local sdsize=$(bc -l <<< "scale=0; ((($imagesize * 1.35) / 1 + 0) / 4 + 1) * 4")
 		else
-			local sdsize=$(bc -l <<< "scale=0; ((($imagesize * 1.25) / 1 + 0) / 4 + 1) * 4")
+			local sdsize=$(bc -l <<< "scale=0; ((($imagesize * 1.30) / 1 + 0) / 4 + 1) * 4")
 		fi
 	fi
 


### PR DESCRIPTION
# Description

In some cases (uefi-x86 jammy) we are hitting 100% of allocated space for creating images. Additional 5% should do.

Jira reference number [AR-1330]

# How Has This Been Tested?

- [x] Recreated image without, which failed, passing with additional 5%

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1330]: https://armbian.atlassian.net/browse/AR-1330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ