### PR TITLE
Make no overhead difference between deskop and CLI

### DIFF
--- a/lib/debootstrap.sh
+++ b/lib/debootstrap.sh
@@ -559,13 +559,8 @@ PREPARE_IMAGE_SIZE
 		fi
 	else
 		local imagesize=$(( $rootfs_size + $OFFSET + $BOOTSIZE + $UEFISIZE + $EXTRA_ROOTFS_MIB_SIZE)) # MiB
-		# Hardcoded overhead +25% is needed for desktop images,
-		# for CLI it could be lower. Align the size up to 4MiB
-		if [[ $BUILD_DESKTOP == yes ]]; then
-			local sdsize=$(bc -l <<< "scale=0; ((($imagesize * 1.35) / 1 + 0) / 4 + 1) * 4")
-		else
-			local sdsize=$(bc -l <<< "scale=0; ((($imagesize * 1.30) / 1 + 0) / 4 + 1) * 4")
-		fi
+		# +40% overhead for kernel, boot loader and plymouth. Align the size up to 4MiB
+		local sdsize=$(bc -l <<< "scale=0; ((($imagesize * 1.40) / 1 + 0) / 4 + 1) * 4")
 	fi
 
 	# stage: create blank image


### PR DESCRIPTION
# Description

Since difference between desktop and CLI overhead is gone, we can remove this check and make both on the same value. Also [previously](https://github.com/armbian/build/pull/4181) overhead was not enough due to added Plymouth package.

Jira reference number [AR-1330]

# How Has This Been Tested?

- [x] Build test CLI images https://github.com/armbian/scripts/actions/runs/3052426276
- [x] Build and boot Rpi4 image

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1330]: https://armbian.atlassian.net/browse/AR-1330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ