### PR TITLE
Incorrent condition for bootscript in `create_board_package`

### DIFF
--- a/lib/makeboarddeb.sh
+++ b/lib/makeboarddeb.sh
@@ -31,7 +31,7 @@ create_board_package()
 	copy_all_packages_files_for "bsp-cli"
 
 	# install copy of boot script & environment file
-	if [[ -z "${BOOTSCRIPT}" ]]; then
+	if [[ -n "${BOOTSCRIPT}" ]]; then
 		# @TODO: add extension method bsp_prepare_bootloader(), refactor into u-boot extension
 		local bootscript_src=${BOOTSCRIPT%%:*}
 		local bootscript_dst=${BOOTSCRIPT##*:}


### PR DESCRIPTION
# Description

Incorrent condition for bootscript in `create_board_package`

# How Has This Been Tested?

No test.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
