### PR TITLE
Add new build dependency

### DIFF
--- a/config/templates/Dockerfile
+++ b/config/templates/Dockerfile
@@ -49,6 +49,7 @@ RUN apt-get update \
        dwarves \
        f2fs-tools \
        fakeroot \
+       fdisk \
        flex \
        gawk \
        gcc-aarch64-linux-gnu \

--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1409,7 +1409,7 @@ prepare_host()
 	nfs-kernel-server ntpdate p7zip-full parted patchutils pigz pixz          \
 	pkg-config pv python3-dev python3-distutils qemu-user-static rsync swig   \
 	systemd-container u-boot-tools udev unzip uuid-dev wget whiptail zip      \
-	zlib1g-dev zstd"
+	zlib1g-dev zstd fdisk"
 
   if [[ $(dpkg --print-architecture) == amd64 ]]; then
 


### PR DESCRIPTION
# Description

Since latest changes to the partition handling  we need to add new dependency to the build host & docker as builds [are failing](https://github.com/armbian/build/actions/runs/3055837198).

Jira reference number [AR-1332]

# How Has This Been Tested?

- [x] Starting from a clean Docker image

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1332]: https://armbian.atlassian.net/browse/AR-1332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ