### PR TITLE
Fix ath11k firmware packaging

### DIFF
--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -604,6 +604,8 @@ compile_firmware()
 		fetch_from_repo "$MAINLINE_FIRMWARE_SOURCE" "linux-firmware-git" "branch:main"
 		# cp : create hardlinks
 		cp -af --reflink=auto "${SRC}"/cache/sources/linux-firmware-git/* "${firmwaretempdir}/${plugin_dir}/lib/firmware/"
+		# cp : create hardlinks for ath11k WCN685x hw2.1 firmware since they are using the same firmware with hw2.0
+		cp -af --reflink=auto "${firmwaretempdir}/${plugin_dir}/lib/firmware/ath11k/WCN6855/hw2.0/" "${firmwaretempdir}/${plugin_dir}/lib/firmware/ath11k/WCN6855/hw2.1/"
 	fi
 	# overlay our firmware
 	# cp : create hardlinks


### PR DESCRIPTION
# Description
Make hardlinks for WCN685x hw2.1 firmware since they are using the same firmware with hw2.0

# How Has This Been Tested?
Tested using modified build script to build kernel 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
