### PR TITLE
Add fallback for debug upload

### DIFF
--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -154,8 +154,8 @@ ParseOptions() {
                                 echo -e "\nNetwork/firewall problem detected.\nTrying fallback..." >&2
                                 fping paste.armbian.com 2>/dev/null | grep -q alive
                                 if [ $? != 0 ]; then
-                                        echo -e "\nNetwork/firewall problem detected. Not able to upload debug info.\nPlease fix this or use \"-U\" instead and upload ${BOLD}whole output${NC} manually\n" >>
-                                        exit 1
+                                        echo -e "\nNetwork/firewall problem detected. Not able to upload debug info.\nPlease fix this or use \"-U\" instead and upload ${BOLD}whole output${NC} manually to an online pasteboard service\nand provide the URL in the forum where you have been asked for this.\n"
+					exit 1
                                 fi
 
                                 # we obfuscate IPv4 addresses somehow but not too much, MAC addresses have to remain

--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -158,18 +158,13 @@ ParseOptions() {
                                         exit 1
                                 fi
 
-                                # My bash foo isnt good enough to remove that function and use simple curl thingy like for ix.io
-                                fallback() {
-                                    local L="$1"
-                                    curl -X POST -s --data-binary @- "https://paste.armbian.de/documents" \
-                                    | awk -F '"' 'b{ b="."b }; {print a$4b}' a="https://paste.armbian.de/" b="${L}"
-                                }
                                 # we obfuscate IPv4 addresses somehow but not too much, MAC addresses have to remain
                                 # in clear since otherwise the log becomes worthless due to randomly generated
                                 # addresses here and there that might conflict
                                 CollectSupportInfo \
                                         | sed -E 's/([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3})/XXX.XXX.\3\4/g' \
-                                        | fallback
+                                        | curl -s --data-binary @- "https://paste.armbian.de/documents" \
+                                        | awk -F'"' '{ print "https://paste.armbian.de/" $4 }'
                                 echo -e "Please post the URL in the forum where you've been asked for.\n"
                         exit 0
                         fi

--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -146,24 +146,45 @@ ParseOptions() {
 			exit 0
 			;;
 		u)
-			# Upload /var/log/armbian-hardware-monitor.log with additional support info
-			fping ix.io 2>/dev/null | grep -q alive
-			if [ $? != 0 ]; then
-				echo -e "\nNetwork/firewall problem detected. Not able to upload debug info.\nPlease fix this or use \"-U\" instead and upload ${BOLD}whole output${NC} manually\n" >&2
-				exit 1
-			fi
-			which curl >/dev/null 2>&1 || apt-get -f -qq -y install curl
-			echo -e "System diagnosis information will now be uploaded to \c"
-			# we obfuscate IPv4 addresses somehow but not too much, MAC addresses have to remain
-			# in clear since otherwise the log becomes worthless due to randomly generated
-			# addresses here and there that might conflict
-			CollectSupportInfo \
-				| sed -E 's/([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3})/XXX.XXX.\3\4/g' \
-				| curl -F 'f:1=<-' ix.io
-			echo -e "Please post the URL in the forum where you've been asked for.\n"
-			exit 0
-			;;
-		U)
+                        # Upload /var/log/armbian-hardware-monitor.log with additional support info
+                        which curl >/dev/null 2>&1 || apt-get -f -qq -y install curl
+                        echo -e "System diagnosis information will now be uploaded to \c"
+                        fping ix.io 2>/dev/null | grep -q alive
+                        if [ $? != 0 ]; then
+                                echo -e "\nNetwork/firewall problem detected.\nTrying fallback..." >&2
+                                fping paste.armbian.de 2>/dev/null | grep -q alive
+                                if [ $? != 0 ]; then
+                                        echo -e "\nNetwork/firewall problem detected. Not able to upload debug info.\nPlease fix this or use \"-U\" instead and upload ${BOLD}whole output${NC} manually\n" >>
+                                        exit 1
+                                fi
+
+                                # My bash foo isnt good enough to remove that function and use simple curl thingy like for ix.io
+                                fallback() {
+                                    local L="$1"
+                                    curl -X POST -s --data-binary @- "https://paste.armbian.de/documents" \
+                                    | awk -F '"' 'b{ b="."b }; {print a$4b}' a="https://paste.armbian.de/" b="${L}"
+                                }
+                                # we obfuscate IPv4 addresses somehow but not too much, MAC addresses have to remain
+                                # in clear since otherwise the log becomes worthless due to randomly generated
+                                # addresses here and there that might conflict
+                                CollectSupportInfo \
+                                        | sed -E 's/([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3})/XXX.XXX.\3\4/g' \
+                                        | fallback
+                                echo -e "Please post the URL in the forum where you've been asked for.\n"
+                        exit 0
+                        fi
+
+                        # we obfuscate IPv4 addresses somehow but not too much, MAC addresses have to remain
+                        # in clear since otherwise the log becomes worthless due to randomly generated
+                        # addresses here and there that might conflict
+                        CollectSupportInfo \
+                                | sed -E 's/([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3})/XXX.XXX.\3\4/g' \
+                                | curl -F 'f:1=<-' ix.io
+                        echo -e "Please post the URL in the forum where you've been asked for.\n"
+                        exit 0
+                        ;;
+			
+                U)
 			# Send support info to stdout to be uploaded manually. Add line numbers to prevent
 			# users being creative and supressing everything that's important
 			CollectSupportInfo \

--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -874,7 +874,8 @@ gwYNGjRo0KBBw1eEfwH4UoBHAKAAAA==" | base64 --decode | tar xzf -
 
 CollectSupportInfo() {
 	[[ -s /var/log/armbian-hardware-monitor.log ]] && cat /var/log/armbian-hardware-monitor.log || zcat /var/log/armbian-hardware-monitor.log.1.gz 2>/dev/null
-	[[ -f /boot/armbianEnv.txt ]] && LOGLEVEL=$(awk -F'=' '/^verbosity/ {print $2}' /boot/armbianEnv.txt) || LOGLEVEL=1
+	[[ -f /boot/armbianEnv.txt ]] && LOGLEVEL=$(awk -F'=' '/^verbosity/ {print $2}' /boot/armbianEnv.txt)
+	LOGLEVEL=${LOGLEVEL:-1}
 	if [ ${LOGLEVEL} -gt 4 ]; then
 		VERBOSE='-v'
 		which lshw >/dev/null 2>&1 && (echo -e "\n### lshw:" ; lshw -quiet -sanitize -numeric)

--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -152,7 +152,7 @@ ParseOptions() {
                         fping ix.io 2>/dev/null | grep -q alive
                         if [ $? != 0 ]; then
                                 echo -e "\nNetwork/firewall problem detected.\nTrying fallback..." >&2
-                                fping paste.armbian.de 2>/dev/null | grep -q alive
+                                fping paste.armbian.com 2>/dev/null | grep -q alive
                                 if [ $? != 0 ]; then
                                         echo -e "\nNetwork/firewall problem detected. Not able to upload debug info.\nPlease fix this or use \"-U\" instead and upload ${BOLD}whole output${NC} manually\n" >>
                                         exit 1
@@ -163,8 +163,8 @@ ParseOptions() {
                                 # addresses here and there that might conflict
                                 CollectSupportInfo \
                                         | sed -E 's/([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3})/XXX.XXX.\3\4/g' \
-                                        | curl -s --data-binary @- "https://paste.armbian.de/documents" \
-                                        | awk -F'"' '{ print "https://paste.armbian.de/" $4 }'
+                                        | curl -s --data-binary @- "https://paste.armbian.com/documents" \
+                                        | awk -F'"' '{ print "https://paste.armbian.com/" $4 }'
                                 echo -e "Please post the URL in the forum where you've been asked for.\n"
                         exit 0
                         fi

--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -149,10 +149,10 @@ ParseOptions() {
                         # Upload /var/log/armbian-hardware-monitor.log with additional support info
                         which curl >/dev/null 2>&1 || apt-get -f -qq -y install curl
                         echo -e "System diagnosis information will now be uploaded to \c"
-                        fping ix.io 2>/dev/null | grep -q alive
+                        fping paste.armbian.com 2>/dev/null | grep -q alive
                         if [ $? != 0 ]; then
                                 echo -e "\nNetwork/firewall problem detected.\nTrying fallback..." >&2
-                                fping paste.armbian.com 2>/dev/null | grep -q alive
+                                fping ix.io 2>/dev/null | grep -q alive
                                 if [ $? != 0 ]; then
                                         echo -e "\nNetwork/firewall problem detected. Not able to upload debug info.\nPlease fix this or use \"-U\" instead and upload ${BOLD}whole output${NC} manually to an online pasteboard service\nand provide the URL in the forum where you have been asked for this.\n"
 					exit 1
@@ -161,24 +161,24 @@ ParseOptions() {
                                 # we obfuscate IPv4 addresses somehow but not too much, MAC addresses have to remain
                                 # in clear since otherwise the log becomes worthless due to randomly generated
                                 # addresses here and there that might conflict
-                                CollectSupportInfo \
-                                        | sed -E 's/([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3})/XXX.XXX.\3\4/g' \
-                                        | curl -s --data-binary @- "https://paste.armbian.com/documents" \
-                                        | awk -F'"' '{ print "https://paste.armbian.com/" $4 }'
+	                        CollectSupportInfo \
+                                | sed -E 's/([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3})/XXX.XXX.\3\4/g' \
+                                | curl -F 'f:1=<-' ix.io
                                 echo -e "Please post the URL in the forum where you've been asked for.\n"
-                        exit 0
+	                        exit 0
                         fi
 
                         # we obfuscate IPv4 addresses somehow but not too much, MAC addresses have to remain
                         # in clear since otherwise the log becomes worthless due to randomly generated
                         # addresses here and there that might conflict
                         CollectSupportInfo \
-                                | sed -E 's/([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3})/XXX.XXX.\3\4/g' \
-                                | curl -F 'f:1=<-' ix.io
+                        | sed -E 's/([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3})/XXX.XXX.\3\4/g' \
+                        | curl -s --data-binary @- "https://paste.armbian.com/documents" \
+                        | awk -F'"' '{ print "https://paste.armbian.com/" $4 }'
                         echo -e "Please post the URL in the forum where you've been asked for.\n"
                         exit 0
                         ;;
-			
+
                 U)
 			# Send support info to stdout to be uploaded manually. Add line numbers to prevent
 			# users being creative and supressing everything that's important


### PR DESCRIPTION
# Description

For the unlikely case do some unneeded work and add a fallback JUST IN CASE ix.io is unreachable or down or closes door or doomsday is coming.

Jira reference number [AR-625]

# How Has This Been Tested?
Tested with OPi Zero on 22.08

- [x] Do normal armbianmonitor -u and verify working 
- [x] Block ix.io using iptables  and retry to verify working fallback

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-625]: https://armbian.atlassian.net/browse/AR-625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ