### PR TITLE
Re-enable Thunderbird email client for Debian Sid

### DIFF
--- a/config/desktop/sid/appgroups/email/packages
+++ b/config/desktop/sid/appgroups/email/packages
@@ -1,0 +1,1 @@
+thunderbird


### PR DESCRIPTION
# Description

Adding missing package.

Jira reference number [AR-1337]

# How Has This Been Tested?

- [x] Manual installation

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1337]: https://armbian.atlassian.net/browse/AR-1337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ