### PR TITLE
Define panel shortcuts for Gnome x64 per appgroup

### DIFF
--- a/config/desktop/focal/environments/gnome/debian/postinst
+++ b/config/desktop/focal/environments/gnome/debian/postinst
@@ -12,7 +12,12 @@ profile=/etc/dconf/profile/user
 install -Dv /dev/null $keys
 install -Dv /dev/null $profile
 
-echo "[org/gnome/desktop/background]
+# set default shortcuts
+echo "
+[org/gnome/shell]
+favorite-apps = ['terminator.desktop']
+
+[org/gnome/desktop/background]
 picture-uri='file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'
 picture-options='zoom'
 primary-color='#456789'
@@ -28,8 +33,6 @@ echo "user-db:user
 system-db:local" >> $profile
 
 dconf update
-
-#sudo apt-get -y remove gnome-shell-extension-desktop-icons
 
 #compile schemas
 if [ -d /usr/share/glib-2.0/schemas ]; then

--- a/config/optional/architectures/amd64/_config/desktop/_all_distributions/environments/gnome/appgroups/browsers/debian/postinst
+++ b/config/optional/architectures/amd64/_config/desktop/_all_distributions/environments/gnome/appgroups/browsers/debian/postinst
@@ -1,0 +1,11 @@
+
+# install Gnome X64 specific
+
+echo "
+[org/gnome/shell]
+favorite-apps = [$(dconf read /org/gnome/shell/favorite-apps | sed 's/[][]//g') , 'google-chrome.desktop']
+" >> $keys
+
+# update
+dconf update
+

--- a/config/optional/architectures/amd64/_config/desktop/_all_distributions/environments/gnome/appgroups/email/debian/postinst
+++ b/config/optional/architectures/amd64/_config/desktop/_all_distributions/environments/gnome/appgroups/email/debian/postinst
@@ -1,0 +1,11 @@
+
+# install Gnome X64 specific favorites
+
+echo "
+[org/gnome/shell]
+favorite-apps = [$(dconf read /org/gnome/shell/favorite-apps | sed 's/[][]//g') , 'thunderbird.desktop']
+" >> $keys
+
+# Update
+dconf update
+

--- a/config/optional/architectures/amd64/_config/desktop/_all_distributions/environments/gnome/appgroups/programming/debian/postinst
+++ b/config/optional/architectures/amd64/_config/desktop/_all_distributions/environments/gnome/appgroups/programming/debian/postinst
@@ -1,0 +1,10 @@
+
+# install Gnome x64 specific favorites
+
+echo "
+[org/gnome/shell]
+favorite-apps = [$(dconf read /org/gnome/shell/favorite-apps | sed 's/[][]//g') , 'code.desktop']
+" >> $keys
+
+# Update
+dconf update


### PR DESCRIPTION
# Description

Enable Terminator by default while others - Chrome, Thunderbird and Code if enabled. X86 Only

Jira reference number [AR-1353]

# How Has This Been Tested?

- [x] Several images made and boot

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1353]: https://armbian.atlassian.net/browse/AR-1353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ