### PR TITLE
Adjust UEFI build targets

### DIFF
--- a/config/targets-desktop-beta.conf
+++ b/config/targets-desktop-beta.conf
@@ -8,15 +8,15 @@ rock-5b             legacy          jammy        desktop                  beta  
 
 
 # uefi-x86
-uefi-x86            current         jammy        desktop                  beta            yes           xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-uefi-x86            current         jammy        desktop                  beta            yes           gnome         config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-uefi-x86            current         jammy        desktop                  beta            yes           cinnamon      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+uefi-x86            current         jammy        desktop                  beta            yes           xfce          config_base   3dsupport,browsers
+uefi-x86            current         jammy        desktop                  beta            yes           gnome         config_base   3dsupport,browsers
+uefi-x86            current         jammy        desktop                  beta            yes           cinnamon      config_base   3dsupport,browsers
 
 
 # uefi-arm64
-uefi-arm64          current         jammy        desktop                  beta            yes           xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-uefi-arm64          current         jammy        desktop                  beta            yes           gnome         config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-uefi-arm64          current         jammy        desktop                  beta            yes           cinnamon      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+uefi-arm64          current         jammy        desktop                  beta            yes           xfce          config_base   3dsupport,browsers
+uefi-arm64          current         jammy        desktop                  beta            yes           gnome         config_base   3dsupport,browsers
+uefi-arm64          current         jammy        desktop                  beta            yes           cinnamon      config_base   3dsupport,browsers
 
 
 # qemu virtual images

--- a/config/targets.conf
+++ b/config/targets.conf
@@ -997,39 +997,23 @@ rpi4b                     current         jammy       desktop                  s
 rpi4b                     edge            jammy       cli                      stable         no
 
 # uefi-x86
-uefi-x86                  current         jammy       cli                      stable         adv
+uefi-x86                  current         jammy       cli                      stable         yes
 uefi-x86                  current         bullseye    cli                      stable         yes
 uefi-x86                  edge            sid         cli                      stable         yes
 #
-uefi-x86                  current         jammy       desktop                  stable         yes            gnome         config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-uefi-x86                  current         jammy       desktop                  stable         yes            budgie        config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+uefi-x86                  current         jammy       desktop                  stable         adv            gnome         config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 uefi-x86                  current         jammy       desktop                  stable         yes            cinnamon      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 uefi-x86                  current         jammy       desktop                  stable         adv            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-uefi-x86                  current         jammy       desktop                  stable         yes            kde-plasma    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-#
-uefi-x86                  edge            sid         desktop                  stable         yes            gnome         config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-uefi-x86                  edge            sid         desktop                  stable         yes            budgie        config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-uefi-x86                  edge            sid         desktop                  stable         yes            cinnamon      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-uefi-x86                  edge            sid         desktop                  stable         yes            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-uefi-x86                  edge            sid         desktop                  stable         yes            kde-plasma    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 
 # uefi-arm64
-uefi-arm64                current         jammy       cli                      stable         adv
+uefi-arm64                current         jammy       cli                      stable         yes
 uefi-arm64                current         bullseye    cli                      stable         yes
 uefi-arm64                edge            sid         cli                      stable         yes
 #
-uefi-arm64                current         jammy       desktop                  stable         yes            gnome         config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-uefi-arm64                current         jammy       desktop                  stable         yes            budgie        config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+uefi-arm64                current         jammy       desktop                  stable         adv            gnome         config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 uefi-arm64                current         jammy       desktop                  stable         yes            cinnamon      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 uefi-arm64                current         jammy       desktop                  stable         adv            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-uefi-arm64                current         sid         desktop                  stable         yes            kde-plasma    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-#
-uefi-arm64                edge            sid         desktop                  stable         yes            gnome         config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-uefi-arm64                edge            sid         desktop                  stable         yes            budgie        config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-uefi-arm64                edge            sid         desktop                  stable         yes            cinnamon      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-uefi-arm64                edge            sid         desktop                  stable         yes            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-uefi-arm64                edge            sid         desktop                  stable         yes            kde-plasma    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 
 # Virtual qemu


### PR DESCRIPTION
# Description

- remove Budgie and KDE since they are not in a good shape
- we can't build full desktop at CI since image exceeds upload limits
- in both variants expose desktops