### PR TITLE
armbian-firmware: include nic fw from linux-firmware

### DIFF
--- a/lib/compilation.sh
+++ b/lib/compilation.sh
@@ -599,14 +599,12 @@ compile_firmware()
 	plugin_dir="armbian-firmware${FULL}"
 	mkdir -p "${firmwaretempdir}/${plugin_dir}/lib/firmware"
 
+	fetch_from_repo "$MAINLINE_FIRMWARE_SOURCE" "linux-firmware-git" "branch:main"
+	# cp : create hardlinks
+	cp -af --reflink=auto "${SRC}"/cache/sources/linux-firmware-git/{ath*,mediatek,mt76*,rt*} \
+		"${firmwaretempdir}/${plugin_dir}/lib/firmware/"
+
 	fetch_from_repo "$GITHUB_SOURCE/armbian/firmware" "armbian-firmware-git" "branch:master"
-	if [[ -n $FULL ]]; then
-		fetch_from_repo "$MAINLINE_FIRMWARE_SOURCE" "linux-firmware-git" "branch:main"
-		# cp : create hardlinks
-		cp -af --reflink=auto "${SRC}"/cache/sources/linux-firmware-git/* "${firmwaretempdir}/${plugin_dir}/lib/firmware/"
-		# cp : create hardlinks for ath11k WCN685x hw2.1 firmware since they are using the same firmware with hw2.0
-		cp -af --reflink=auto "${firmwaretempdir}/${plugin_dir}/lib/firmware/ath11k/WCN6855/hw2.0/" "${firmwaretempdir}/${plugin_dir}/lib/firmware/ath11k/WCN6855/hw2.1/"
-	fi
 	# overlay our firmware
 	# cp : create hardlinks
 	cp -af --reflink=auto "${SRC}"/cache/sources/armbian-firmware-git/* "${firmwaretempdir}/${plugin_dir}/lib/firmware/"


### PR DESCRIPTION
# Description

Many network cards (wired and wireless) now require specific firmware to work, these are usually included in linux-firmware.
The idea of this commit is to include some common firmware in armbian-firmware to solve driver loading problems.
After that we can remove the same firmware files on armbian-firmware.

Note: Didn't copy the brcm part from linux-firmware because I don't have the relevant hardware to test.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] rtl8153 (NanoPi R1S H5)
- [x] mt7921 (Radxa ROCK3A)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules