### PR TITLE
Bugfix: aria2: Failed to open ServerStat file

### DIFF
--- a/lib/general.sh
+++ b/lib/general.sh
@@ -1689,6 +1689,7 @@ download_and_verify()
 		"9F0E78D5" # Igor Pecovnik
 	)
 
+	mkdir -p "${SRC}/cache/.aria2"
 	local aria2_options=(
 		# Display
 		--console-log-level=error


### PR DESCRIPTION
# Description

Address the following issue.

```
Failed to open ServerStat file /root/armbian-onecloud/cache/.aria2/server_stats for read.
```

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Build

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
