### PR TITLE
Enable access to kernel syslog to everyone

### DIFF
--- a/lib/distributions.sh
+++ b/lib/distributions.sh
@@ -473,6 +473,9 @@ FAMILY_TWEAKS
 		sed -i "s/^#kernel.printk*/kernel.printk/" "${SDCARD}"/etc/sysctl.conf
 	fi
 
+	# enable access to kernel syslog to everyone
+	chroot "${SDCARD}" /bin/bash -c "echo 'kernel.dmesg_restrict=0' | sudo tee -a /etc/sysctl.conf > /dev/null"
+
 	# disable repeated messages due to xconsole not being installed.
 	[[ -f "${SDCARD}"/etc/rsyslog.d/50-default.conf ]] && \
 	sed '/daemon\.\*\;mail.*/,/xconsole/ s/.*/#&/' -i "${SDCARD}"/etc/rsyslog.d/50-default.conf


### PR DESCRIPTION
# Description

Not having kernel log (dmesg) is ... annoying.

Jira reference number [AR-1356]

# How Has This Been Tested?

- [ ] Run dmesg

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
