### PR TITLE
Add simple graphics viewer program also to Debian builds

### DIFF
--- a/config/desktop/buster/appgroups/multimedia/packages
+++ b/config/desktop/buster/appgroups/multimedia/packages
@@ -1,3 +1,4 @@
 gimp
+eog
 mpv
 pithos


### PR DESCRIPTION
# Description

We don't have any and for Ubuntu variant recently was added.

Jira reference number [AR-1324]

[AR-1324]: https://armbian.atlassian.net/browse/AR-1324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ