### PR TITLE
rk322x: minor fixes, change default phase shift for eMCP

### DIFF
--- a/packages/bsp/rk322x/rk322x-config
+++ b/packages/bsp/rk322x/rk322x-config
@@ -91,7 +91,7 @@ DT_LED_OVERLAYS+=(["led-conf2"]="R329q, MXQ-RK3229")
 DT_LED_OVERLAYS+=(["led-conf3"]="R28-MXQ")
 DT_LED_OVERLAYS+=(["led-conf4"]="T066/T066-V2")
 DT_LED_OVERLAYS+=(["led-conf5"]="AEMS IPB900")
-DT_LED_OVERLAYS+=(["led-conf6"]="MXQPRO_V72/V73)")
+DT_LED_OVERLAYS+=(["led-conf6"]="MXQPRO_V72/V73")
 DT_LED_OVERLAYS+=(["led-conf7"]="R29_MXQ")
 
 DT_LED_OVERLAYS_ORDER=("led-conf-default" "led-conf1" "led-conf2" "led-conf3" "led-conf4" "led-conf5" "led-conf6" "led-conf7")

--- a/patch/kernel/archive/rk322x-5.15/board-rk322x-box.patch
+++ b/patch/kernel/archive/rk322x-5.15/board-rk322x-box.patch
@@ -358,7 +358,7 @@ index 000000000000..f6e249bf81b6
 +	/delete-property/ pinctrl-names;
 +	/delete-property/ pinctrl-0;
 +	/delete-property/ rockchip,default-sample-phase;
-+	rockchip,default-sample-phase = <180>;
++	rockchip,default-sample-phase = <90>;
 +};
 +
 +&gmac {

--- a/patch/kernel/archive/rk322x-5.15/general-add-overlays.patch
+++ b/patch/kernel/archive/rk322x-5.15/general-add-overlays.patch
@@ -1,37 +1,37 @@
-From 700cbde2890adf66b668b2edb941b773d7bf2254 Mon Sep 17 00:00:00 2001
+From 330824ee7a46474f18d44d247633469e63675afa Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
-Date: Sun, 2 Oct 2022 11:00:19 +0000
+Date: Tue, 4 Oct 2022 15:15:19 +0000
 Subject: [PATCH] rk322x device tree overlays
 
 ---
- arch/arm/boot/dts/overlay/Makefile            |  39 ++++++
- .../boot/dts/overlay/README.rk322x-overlays   |  90 +++++++++++++
- .../arm/boot/dts/overlay/rk322x-bt-8723cs.dts |  19 +++
- .../arm/boot/dts/overlay/rk322x-cpu-hs-lv.dts |  68 ++++++++++
- arch/arm/boot/dts/overlay/rk322x-cpu-hs.dts   |  28 ++++
- .../boot/dts/overlay/rk322x-cpu-stability.dts |  52 ++++++++
- arch/arm/boot/dts/overlay/rk322x-ddr3-330.dts |  28 ++++
- arch/arm/boot/dts/overlay/rk322x-ddr3-528.dts |  28 ++++
- arch/arm/boot/dts/overlay/rk322x-ddr3-660.dts |  28 ++++
- arch/arm/boot/dts/overlay/rk322x-ddr3-800.dts |  28 ++++
- .../dts/overlay/rk322x-emmc-ddr-ph180.dts     |  14 ++
- .../boot/dts/overlay/rk322x-emmc-ddr-ph45.dts |  14 ++
- .../boot/dts/overlay/rk322x-emmc-hs200.dts    |  13 ++
- .../arm/boot/dts/overlay/rk322x-emmc-pins.dts |  22 +++
- arch/arm/boot/dts/overlay/rk322x-emmc.dts     |  20 +++
+ arch/arm/boot/dts/overlay/Makefile            |  39 +++++++
+ .../boot/dts/overlay/README.rk322x-overlays   |  90 +++++++++++++++
+ .../arm/boot/dts/overlay/rk322x-bt-8723cs.dts |  19 ++++
+ .../arm/boot/dts/overlay/rk322x-cpu-hs-lv.dts |  68 +++++++++++
+ arch/arm/boot/dts/overlay/rk322x-cpu-hs.dts   |  28 +++++
+ .../boot/dts/overlay/rk322x-cpu-stability.dts |  52 +++++++++
+ arch/arm/boot/dts/overlay/rk322x-ddr3-330.dts |  28 +++++
+ arch/arm/boot/dts/overlay/rk322x-ddr3-528.dts |  28 +++++
+ arch/arm/boot/dts/overlay/rk322x-ddr3-660.dts |  28 +++++
+ arch/arm/boot/dts/overlay/rk322x-ddr3-800.dts |  28 +++++
+ .../dts/overlay/rk322x-emmc-ddr-ph180.dts     |  14 +++
+ .../boot/dts/overlay/rk322x-emmc-ddr-ph45.dts |  14 +++
+ .../boot/dts/overlay/rk322x-emmc-hs200.dts    |  13 +++
+ .../arm/boot/dts/overlay/rk322x-emmc-pins.dts |  22 ++++
+ arch/arm/boot/dts/overlay/rk322x-emmc.dts     |  20 ++++
  .../arm/boot/dts/overlay/rk322x-fixup.scr-cmd |   4 +
- .../dts/overlay/rk322x-led-conf-default.dts   |  22 +++
- .../arm/boot/dts/overlay/rk322x-led-conf1.dts |  64 +++++++++
- .../arm/boot/dts/overlay/rk322x-led-conf2.dts |  64 +++++++++
- .../arm/boot/dts/overlay/rk322x-led-conf3.dts |  64 +++++++++
- .../arm/boot/dts/overlay/rk322x-led-conf4.dts |  96 ++++++++++++++
- .../arm/boot/dts/overlay/rk322x-led-conf5.dts |  97 ++++++++++++++
- .../arm/boot/dts/overlay/rk322x-led-conf6.dts | 125 ++++++++++++++++++
- .../arm/boot/dts/overlay/rk322x-led-conf7.dts | 106 +++++++++++++++
- arch/arm/boot/dts/overlay/rk322x-nand.dts     |  22 +++
+ .../dts/overlay/rk322x-led-conf-default.dts   |  22 ++++
+ .../arm/boot/dts/overlay/rk322x-led-conf1.dts |  64 +++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf2.dts |  64 +++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf3.dts |  64 +++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf4.dts |  96 ++++++++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf5.dts |  97 ++++++++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf6.dts |  96 ++++++++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf7.dts | 106 ++++++++++++++++++
+ arch/arm/boot/dts/overlay/rk322x-nand.dts     |  22 ++++
  .../dts/overlay/rk322x-usb-otg-peripheral.dts |  11 ++
- .../dts/overlay/rk322x-wlan-alt-wiring.dts    |  67 ++++++++++
- 27 files changed, 1233 insertions(+)
+ .../dts/overlay/rk322x-wlan-alt-wiring.dts    |  67 +++++++++++
+ 27 files changed, 1204 insertions(+)
  create mode 100755 arch/arm/boot/dts/overlay/Makefile
  create mode 100755 arch/arm/boot/dts/overlay/README.rk322x-overlays
  create mode 100644 arch/arm/boot/dts/overlay/rk322x-bt-8723cs.dts
@@ -1096,10 +1096,10 @@ index 000000000000..f74687eedc9e
 +};
 diff --git a/arch/arm/boot/dts/overlay/rk322x-led-conf6.dts b/arch/arm/boot/dts/overlay/rk322x-led-conf6.dts
 new file mode 100644
-index 000000000000..92cc548b0fe3
+index 000000000000..0c737f896f4e
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/rk322x-led-conf6.dts
-@@ -0,0 +1,125 @@
+@@ -0,0 +1,96 @@
 +/dts-v1/;
 +/plugin/;
 +
@@ -1110,37 +1110,16 @@ index 000000000000..92cc548b0fe3
 +/*
 + * gpio configuration for MXQ_PRO eMCP boards
 + *
-+ * - enables working and auxiliary leds
 + * - fixes low strength on sdio pins for wifi
-+ * - reduce frequency to 37.5 Mhz on sdio bus
 + * - correct gpio pins for wifi
++ * - set emmc pins and default phase shift
 + */
 +
 +/ {
 +
 +	fragment@0 {
-+		target-path = "/gpio-leds";
-+		__overlay__ {
-+
-+			auxiliary {
-+				gpios = <&gpio1 RK_PA7 GPIO_ACTIVE_LOW>;
-+				label = "auxiliary";
-+				linux,default-trigger = "mmc2";
-+				default-state = "off";
-+				pinctrl-names = "default";
-+				pinctrl-0 = <&gpio_led_aux>;
-+			};
-+
-+		};
-+	};
-+
-+	fragment@1 {
 +		target-path = "/pinctrl/gpio";
 +		__overlay__ {
-+
-+			gpio_led_aux: gpio-led-aux {
-+				rockchip,pins =  <1 RK_PA7 RK_FUNC_GPIO &pcfg_pull_none>;
-+			};
 +
 +			reset_key: reset-key {
 +				rockchip,pins = <3 RK_PD1 RK_FUNC_GPIO &pcfg_pull_up>;
@@ -1149,7 +1128,7 @@ index 000000000000..92cc548b0fe3
 +		};
 +	};
 +
-+	fragment@2 {
++	fragment@1 {
 +		target = <&gpio_keys>;
 +		__overlay__ {
 +
@@ -1163,19 +1142,11 @@ index 000000000000..92cc548b0fe3
 +				debounce-interval = <200>;
 +				wakeup-source;
 +			};
-+
-+			shutdown {
-+				gpios = <&gpio0 RK_PA3 GPIO_ACTIVE_LOW>;
-+				label = "shutdown";
-+				linux,code = <KEY_POWER>;
-+				debounce-interval = <200>;
-+				wakeup-source;
-+			};
-+
++		
 +		};
 +	};
 +
-+	fragment@3 {
++	fragment@2 {
 +		target = <&sdio_bus4>;
 +		__overlay__ {
 +			rockchip,pins = <3 2 1 &pcfg_pull_up>,
@@ -1186,21 +1157,21 @@ index 000000000000..92cc548b0fe3
 +
 +	};
 +
-+	fragment@4 {
++	fragment@3 {
 +		target = <&sdio_clk>;
 +		__overlay__ {
 +			rockchip,pins = <3 0 1 &pcfg_pull_none>;
 +		};
 +	};
 +
-+	fragment@5 {
++	fragment@4 {
 +		target = <&sdio_cmd>;
 +		__overlay__ {
 +			rockchip,pins = <3 1 1 &pcfg_pull_up>;
 +		};
 +	};
 +
-+	fragment@6 {
++	fragment@5 {
 +		target = <&sdio_pwrseq>;
 +		__overlay__ {
 +			post-power-on-delay-ms = <300>;
@@ -1209,7 +1180,7 @@ index 000000000000..92cc548b0fe3
 +		};
 +	};
 +
-+	fragment@7 {
++	fragment@6 {
 +		target = <&sdio>;
 +		__overlay__ {
 +			#address-cells = <1>;

--- a/patch/kernel/archive/rk322x-5.19/board-rk322x-box.patch
+++ b/patch/kernel/archive/rk322x-5.19/board-rk322x-box.patch
@@ -358,7 +358,7 @@ index 000000000000..f6e249bf81b6
 +	/delete-property/ pinctrl-names;
 +	/delete-property/ pinctrl-0;
 +	/delete-property/ rockchip,default-sample-phase;
-+	rockchip,default-sample-phase = <180>;
++	rockchip,default-sample-phase = <90>;
 +};
 +
 +&gmac {

--- a/patch/kernel/archive/rk322x-5.19/general-add-overlays.patch
+++ b/patch/kernel/archive/rk322x-5.19/general-add-overlays.patch
@@ -1,37 +1,37 @@
-From 700cbde2890adf66b668b2edb941b773d7bf2254 Mon Sep 17 00:00:00 2001
+From 330824ee7a46474f18d44d247633469e63675afa Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
-Date: Sun, 2 Oct 2022 11:00:19 +0000
+Date: Tue, 4 Oct 2022 15:15:19 +0000
 Subject: [PATCH] rk322x device tree overlays
 
 ---
- arch/arm/boot/dts/overlay/Makefile            |  39 ++++++
- .../boot/dts/overlay/README.rk322x-overlays   |  90 +++++++++++++
- .../arm/boot/dts/overlay/rk322x-bt-8723cs.dts |  19 +++
- .../arm/boot/dts/overlay/rk322x-cpu-hs-lv.dts |  68 ++++++++++
- arch/arm/boot/dts/overlay/rk322x-cpu-hs.dts   |  28 ++++
- .../boot/dts/overlay/rk322x-cpu-stability.dts |  52 ++++++++
- arch/arm/boot/dts/overlay/rk322x-ddr3-330.dts |  28 ++++
- arch/arm/boot/dts/overlay/rk322x-ddr3-528.dts |  28 ++++
- arch/arm/boot/dts/overlay/rk322x-ddr3-660.dts |  28 ++++
- arch/arm/boot/dts/overlay/rk322x-ddr3-800.dts |  28 ++++
- .../dts/overlay/rk322x-emmc-ddr-ph180.dts     |  14 ++
- .../boot/dts/overlay/rk322x-emmc-ddr-ph45.dts |  14 ++
- .../boot/dts/overlay/rk322x-emmc-hs200.dts    |  13 ++
- .../arm/boot/dts/overlay/rk322x-emmc-pins.dts |  22 +++
- arch/arm/boot/dts/overlay/rk322x-emmc.dts     |  20 +++
+ arch/arm/boot/dts/overlay/Makefile            |  39 +++++++
+ .../boot/dts/overlay/README.rk322x-overlays   |  90 +++++++++++++++
+ .../arm/boot/dts/overlay/rk322x-bt-8723cs.dts |  19 ++++
+ .../arm/boot/dts/overlay/rk322x-cpu-hs-lv.dts |  68 +++++++++++
+ arch/arm/boot/dts/overlay/rk322x-cpu-hs.dts   |  28 +++++
+ .../boot/dts/overlay/rk322x-cpu-stability.dts |  52 +++++++++
+ arch/arm/boot/dts/overlay/rk322x-ddr3-330.dts |  28 +++++
+ arch/arm/boot/dts/overlay/rk322x-ddr3-528.dts |  28 +++++
+ arch/arm/boot/dts/overlay/rk322x-ddr3-660.dts |  28 +++++
+ arch/arm/boot/dts/overlay/rk322x-ddr3-800.dts |  28 +++++
+ .../dts/overlay/rk322x-emmc-ddr-ph180.dts     |  14 +++
+ .../boot/dts/overlay/rk322x-emmc-ddr-ph45.dts |  14 +++
+ .../boot/dts/overlay/rk322x-emmc-hs200.dts    |  13 +++
+ .../arm/boot/dts/overlay/rk322x-emmc-pins.dts |  22 ++++
+ arch/arm/boot/dts/overlay/rk322x-emmc.dts     |  20 ++++
  .../arm/boot/dts/overlay/rk322x-fixup.scr-cmd |   4 +
- .../dts/overlay/rk322x-led-conf-default.dts   |  22 +++
- .../arm/boot/dts/overlay/rk322x-led-conf1.dts |  64 +++++++++
- .../arm/boot/dts/overlay/rk322x-led-conf2.dts |  64 +++++++++
- .../arm/boot/dts/overlay/rk322x-led-conf3.dts |  64 +++++++++
- .../arm/boot/dts/overlay/rk322x-led-conf4.dts |  96 ++++++++++++++
- .../arm/boot/dts/overlay/rk322x-led-conf5.dts |  97 ++++++++++++++
- .../arm/boot/dts/overlay/rk322x-led-conf6.dts | 125 ++++++++++++++++++
- .../arm/boot/dts/overlay/rk322x-led-conf7.dts | 106 +++++++++++++++
- arch/arm/boot/dts/overlay/rk322x-nand.dts     |  22 +++
+ .../dts/overlay/rk322x-led-conf-default.dts   |  22 ++++
+ .../arm/boot/dts/overlay/rk322x-led-conf1.dts |  64 +++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf2.dts |  64 +++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf3.dts |  64 +++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf4.dts |  96 ++++++++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf5.dts |  97 ++++++++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf6.dts |  96 ++++++++++++++++
+ .../arm/boot/dts/overlay/rk322x-led-conf7.dts | 106 ++++++++++++++++++
+ arch/arm/boot/dts/overlay/rk322x-nand.dts     |  22 ++++
  .../dts/overlay/rk322x-usb-otg-peripheral.dts |  11 ++
- .../dts/overlay/rk322x-wlan-alt-wiring.dts    |  67 ++++++++++
- 27 files changed, 1233 insertions(+)
+ .../dts/overlay/rk322x-wlan-alt-wiring.dts    |  67 +++++++++++
+ 27 files changed, 1204 insertions(+)
  create mode 100755 arch/arm/boot/dts/overlay/Makefile
  create mode 100755 arch/arm/boot/dts/overlay/README.rk322x-overlays
  create mode 100644 arch/arm/boot/dts/overlay/rk322x-bt-8723cs.dts
@@ -1096,10 +1096,10 @@ index 000000000000..f74687eedc9e
 +};
 diff --git a/arch/arm/boot/dts/overlay/rk322x-led-conf6.dts b/arch/arm/boot/dts/overlay/rk322x-led-conf6.dts
 new file mode 100644
-index 000000000000..92cc548b0fe3
+index 000000000000..0c737f896f4e
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/rk322x-led-conf6.dts
-@@ -0,0 +1,125 @@
+@@ -0,0 +1,96 @@
 +/dts-v1/;
 +/plugin/;
 +
@@ -1110,37 +1110,16 @@ index 000000000000..92cc548b0fe3
 +/*
 + * gpio configuration for MXQ_PRO eMCP boards
 + *
-+ * - enables working and auxiliary leds
 + * - fixes low strength on sdio pins for wifi
-+ * - reduce frequency to 37.5 Mhz on sdio bus
 + * - correct gpio pins for wifi
++ * - set emmc pins and default phase shift
 + */
 +
 +/ {
 +
 +	fragment@0 {
-+		target-path = "/gpio-leds";
-+		__overlay__ {
-+
-+			auxiliary {
-+				gpios = <&gpio1 RK_PA7 GPIO_ACTIVE_LOW>;
-+				label = "auxiliary";
-+				linux,default-trigger = "mmc2";
-+				default-state = "off";
-+				pinctrl-names = "default";
-+				pinctrl-0 = <&gpio_led_aux>;
-+			};
-+
-+		};
-+	};
-+
-+	fragment@1 {
 +		target-path = "/pinctrl/gpio";
 +		__overlay__ {
-+
-+			gpio_led_aux: gpio-led-aux {
-+				rockchip,pins =  <1 RK_PA7 RK_FUNC_GPIO &pcfg_pull_none>;
-+			};
 +
 +			reset_key: reset-key {
 +				rockchip,pins = <3 RK_PD1 RK_FUNC_GPIO &pcfg_pull_up>;
@@ -1149,7 +1128,7 @@ index 000000000000..92cc548b0fe3
 +		};
 +	};
 +
-+	fragment@2 {
++	fragment@1 {
 +		target = <&gpio_keys>;
 +		__overlay__ {
 +
@@ -1163,19 +1142,11 @@ index 000000000000..92cc548b0fe3
 +				debounce-interval = <200>;
 +				wakeup-source;
 +			};
-+
-+			shutdown {
-+				gpios = <&gpio0 RK_PA3 GPIO_ACTIVE_LOW>;
-+				label = "shutdown";
-+				linux,code = <KEY_POWER>;
-+				debounce-interval = <200>;
-+				wakeup-source;
-+			};
-+
++		
 +		};
 +	};
 +
-+	fragment@3 {
++	fragment@2 {
 +		target = <&sdio_bus4>;
 +		__overlay__ {
 +			rockchip,pins = <3 2 1 &pcfg_pull_up>,
@@ -1186,21 +1157,21 @@ index 000000000000..92cc548b0fe3
 +
 +	};
 +
-+	fragment@4 {
++	fragment@3 {
 +		target = <&sdio_clk>;
 +		__overlay__ {
 +			rockchip,pins = <3 0 1 &pcfg_pull_none>;
 +		};
 +	};
 +
-+	fragment@5 {
++	fragment@4 {
 +		target = <&sdio_cmd>;
 +		__overlay__ {
 +			rockchip,pins = <3 1 1 &pcfg_pull_up>;
 +		};
 +	};
 +
-+	fragment@6 {
++	fragment@5 {
 +		target = <&sdio_pwrseq>;
 +		__overlay__ {
 +			post-power-on-delay-ms = <300>;
@@ -1209,7 +1180,7 @@ index 000000000000..92cc548b0fe3
 +		};
 +	};
 +
-+	fragment@7 {
++	fragment@6 {
 +		target = <&sdio>;
 +		__overlay__ {
 +			#address-cells = <1>;


### PR DESCRIPTION
# Description

Minor fixes to led-conf6, default phase shifting for emmc controller se to 90° instead of 180° that was causing some eMCP to be not detected even in high-speed mode

# How Has This Been Tested?

Quick check directly on a live installation

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
