### PR TITLE
BSP package does not contain BRANCH information 

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
+++ b/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
@@ -400,13 +400,13 @@ add_usb_storage_quirks() {
 } # add_usb_storage_quirks
 
 
-branch_naming_workaround()
-# https://armbian.atlassian.net/browse/AR-748
-# Once we rework kernel packages, this can be done better
+update_branch_from_installed_kernel()
 {
 
+	BRANCH=$(dpkg -l | grep -E "linux-image" | grep -E "current|legacy|edge" | awk '{print $2}' | cut -d"-" -f3 | head -1)
 	if grep -q BRANCH /etc/armbian-release; then
-		BRANCH=$(dpkg -l | grep -E "linux-image" | grep -E "current|legacy|edge" | awk '{print $2}' | cut -d"-" -f3 | head -1)
+		[[ -n ${BRANCH} ]] && sed -i "s/BRANCH=.*/BRANCH=$BRANCH/g" /etc/armbian-release
+	else
 		[[ -n ${BRANCH} ]] && echo "BRANCH=$BRANCH" >> /etc/armbian-release
 	fi
 }
@@ -423,7 +423,7 @@ case $1 in
 		# add usb quirks
 		add_usb_storage_quirks &
 
-		# branch naming workaround
-		branch_naming_workaround &
+		# update branch in main config
+		update_branch_from_installed_kernel &
 		;;
 esac


### PR DESCRIPTION
# Description

We need to read at store it at boot. Now this works. This is the reason why headers install doesn't work on many installations.

Jira reference number [AR-1060] [AR-1363]

# How Has This Been Tested?

- [x] Manual script execution

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1060]: https://armbian.atlassian.net/browse/AR-1060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[AR-1363]: https://armbian.atlassian.net/browse/AR-1363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ