### PR TITLE
Improve ARM64 UEFI support

### DIFF
--- a/packages/bsp/common/usr/sbin/armbian-install
+++ b/packages/bsp/common/usr/sbin/armbian-install
@@ -37,7 +37,7 @@ FIRSTSECTOR=32768
 #recognize_root
 root_uuid=$(sed -e 's/^.*root=//' -e 's/ .*$//' < /proc/cmdline)
 root_partition=$(blkid | tr -d '":' | grep "${root_uuid}" | awk '{print $1}')
-root_partition_device=$(echo $root_partition | sed 's/[0-9]//g')
+root_partition_device=$(lsblk -ndo pkname $root_partition)
 root_partition_device_name=$(echo $root_partition_device | sed 's/\/dev\///g')
 
 # find targets: NAND, EMMC, SATA, SPI flash, NVMe

--- a/packages/bsp/common/usr/sbin/armbian-install
+++ b/packages/bsp/common/usr/sbin/armbian-install
@@ -621,10 +621,11 @@ check_partitions()
 		dialog --yes-label "Proceed" --no-label 'Exit' --title "$title" --backtitle "$backtitle" --yesno "\nDestnation $diskcheck has $FREE_SPACE Gb of available space. \n\nAutomated install will generate needed partitions!" 9 55
 		if [[ "${FREE_SPACE%.*}" -gt 4 && $? == 0 ]]; then
 			if [[ "$DEVICE_TYPE" == uefi && -z "$efi_partition" ]]; then
+			wipefs -aq /dev/$diskcheck
 			# create EFI parition
 	                {
-	                     echo n; echo ; echo ; echo +200M; echo y; echo ;
-	                     echo t; echo uefi; echo w;
+				echo n; echo ; echo ; echo ; echo +200M;
+				echo t; echo EF; echo w;
 			} | fdisk /dev/$diskcheck &> /dev/null || true
 			yes | mkfs.vfat /dev/${diskcheck}p1 &> /dev/null || true
 			fatlabel /dev/${diskcheck}p1 EFI

--- a/packages/bsp/common/usr/sbin/armbian-install
+++ b/packages/bsp/common/usr/sbin/armbian-install
@@ -43,10 +43,11 @@ root_partition_device_name=$(echo $root_partition_device | sed 's/\/dev\///g')
 # find targets: NAND, EMMC, SATA, SPI flash, NVMe
 [[ -b /dev/nand ]] && nandcheck=$(ls -d -1 /dev/nand* | grep -w 'nand' | awk '{print $NF}');
 emmccheck=$(ls -d -1 /dev/mmcblk* 2>/dev/null | grep -w 'mmcblk[0-9]' | grep -v "$root_partition_device");
-diskcheck=$(lsblk -l | awk -F" " '/ disk / {print $1}' | grep -E '^sd|^nvme|^mmc' | grep -v "$root_partition_device_name" | grep -v boot )
+diskcheck=$(lsblk -l | awk -F" " '/ disk / {print $1}' | grep -E '^sd|^nvme|^mmc' | grep -v "$root_partition_device_name" | grep -v boot)
 spicheck=$(grep 'mtd' /proc/partitions | awk '{print $NF}')
 
-#recognize EFI partition
+#recognize EFI
+[[ -d /sys/firmware/efi ]] && DEVICE_TYPE="uefi"
 efi_partition=$(LC_ALL=C fdisk -l "/dev/$diskcheck" 2>/dev/null | grep "EFI" | awk '{print $1}')
 
 # define makefs and mount options
@@ -70,9 +71,17 @@ mountopts[ext4]='defaults,noatime,commit=600,errors=remount-ro,x-gvfs-hide	0	1'
 mountopts[btrfs]='defaults,noatime,commit=600,compress=lzo,x-gvfs-hide			0	2'
 mountopts[f2fs]='defaults,noatime,x-gvfs-hide	0	2'
 
-# Create boot and root file system "$1" = boot, "$2" = root (Example: create_armbian "/dev/nand1" "/dev/sda3")
+# Create boot and root file system #
+#
+# "$1" = boot
+# "$2" = root (Example: create_armbian "/dev/nand1" "/dev/sda3")
+# "$3" = selected UEFI root target
+#
 create_armbian()
 {
+
+	[[ -n "$3" ]] && diskcheck=$3
+
 	# create mount points, mount and clean
 	TempDir=$(mktemp -d /mnt/${0##*/}.XXXXXX || exit 2)
 	sync &&	mkdir -p "${TempDir}"/bootfs "${TempDir}"/rootfs
@@ -375,14 +384,17 @@ create_armbian()
 		ResultActive=yes
 		hibernatemenu
 
-		echo "Install frub to $efi_partition"
+		efi_partition=$(LC_ALL=C fdisk -l "/dev/$diskcheck" 2>/dev/null | grep "EFI" | awk '{print $1}')
+
+		echo "Install GRUB to $efi_partition"
 		mkdir -p "${TempDir}"/rootfs/boot/efi
 		mount $efi_partition "${TempDir}"/rootfs/boot/efi
 		mount --bind /dev "${TempDir}"/rootfs/dev
 		mount --make-rslave --bind /dev/pts "${TempDir}"/rootfs/dev/pts
 		mount --bind /proc "${TempDir}"/rootfs/proc
 		mount --make-rslave --rbind /sys "${TempDir}"/rootfs/sys
-		chroot "${TempDir}/rootfs/" /bin/bash -c "grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id=GRUB --removable >/dev/null" >> $logfile
+		arch_target=$([[ $(arch) == x86_64 ]] && echo "x86_64-efi" || echo "arm64-efi")
+		chroot "${TempDir}/rootfs/" /bin/bash -c "grub-install --target=$arch_target --efi-directory=/boot/efi --bootloader-id=GRUB --removable >/dev/null" >> $logfile
 		chroot "${TempDir}/rootfs/" /bin/bash -c "grub-mkconfig -o /boot/grub/grub.cfg >/dev/null" >> $logfile
 		grep "${TempDir}"/rootfs/sys /proc/mounts | cut -f2 -d" " | sort -r | xargs umount -n
 		umount "${TempDir}"/rootfs/proc
@@ -601,17 +613,18 @@ check_partitions()
 {
 	IFS=" "
 	[[ -n "$1" ]] && EXCLUDE=" | grep -v $1"
-	CMD="lsblk -io KNAME,FSTYPE,SIZE,TYPE,MOUNTPOINTS | grep \"btrfs\|ext4\|f2fs\" $EXCLUDE | grep -E '^sd|^nvme|^md|^mmc' | awk -F\" \" '/ part | raid..? / {print \$1}'"
+	[[ -n "$2" ]] && INCLUDE=" | grep $2" && diskcheck=$2
+	CMD="lsblk -io KNAME,FSTYPE,SIZE,TYPE,MOUNTPOINTS | grep \"btrfs\|ext4\|f2fs\" $INCLUDE $EXCLUDE | grep -E '^sd|^nvme|^md|^mmc' | awk -F\" \" '/ part | raid..? / {print \$1}'"
 	AvailablePartitions=$(eval $CMD)
 	if [[ -z $AvailablePartitions ]]; then
 		FREE_SPACE=$(parted /dev/$diskcheck unit GB print free | awk '/Free Space/{c++; sum += $3; print sum}' | tail -1)
 		dialog --yes-label "Proceed" --no-label 'Exit' --title "$title" --backtitle "$backtitle" --yesno "\nDestnation $diskcheck has $FREE_SPACE Gb of available space. \n\nAutomated install will generate needed partitions!" 9 55
-		if [[ "${FREE_SPACE%.*}" -gt 16 && $? == 0 ]]; then
+		if [[ "${FREE_SPACE%.*}" -gt 4 && $? == 0 ]]; then
 			if [[ "$DEVICE_TYPE" == uefi && -z "$efi_partition" ]]; then
 			# create EFI parition
 	                {
-	                     echo n; echo ; echo ; echo ; echo +200M;
-	                     echo t; echo EF; echo w;
+	                     echo n; echo ; echo ; echo +200M; echo y; echo ;
+	                     echo t; echo uefi; echo w;
 			} | fdisk /dev/$diskcheck &> /dev/null || true
 			yes | mkfs.vfat /dev/${diskcheck}p1 &> /dev/null || true
 			fatlabel /dev/${diskcheck}p1 EFI
@@ -630,7 +643,7 @@ check_partitions()
 				exit 11
 			fi
 	fi
-	CMD="lsblk -io KNAME,FSTYPE,SIZE,TYPE,MOUNTPOINTS | grep \"btrfs\|ext4\|f2fs\" $EXCLUDE | grep -E '^sd|^nvme|^md|^mmc' | awk -F\" \" '/ part | raid..? / {print \$1}' | uniq | sed 's|^|/dev/|' | nl | xargs echo -n"
+	CMD="lsblk -io KNAME,FSTYPE,SIZE,TYPE,MOUNTPOINTS | grep \"btrfs\|ext4\|f2fs\" $INCLUDE $EXCLUDE | grep -E '^sd|^nvme|^md|^mmc' | awk -F\" \" '/ part | raid..? / {print \$1}' | uniq | sed 's|^|/dev/|' | nl | xargs echo -n"
 	partprobe
 	AvailablePartitions=$(eval $CMD)
 	PartitionOptions=($AvailablePartitions)
@@ -715,7 +728,10 @@ main()
 
 	if [[ -n $diskcheck && -d /sys/firmware/efi ]]; then
 
-		options+=(8 "Install system to $diskcheck")
+		while read line
+		do
+			options+=("$line" "Install UEFI system with Grub")
+		done <<< "$diskcheck"
 
 	else
 
@@ -820,15 +836,15 @@ main()
 				return
 				;;
 
-			8)
+			*)
                                 title='UEFI install to internal drive'
                                 command='Reboot'
-                                check_partitions "$root_partition_device_name"
+                                check_partitions "$root_partition_device_name" "$choice"
                                 # we need to copy boot
                                 sed -i '/boot/d' $EX_LIST
                                 show_warning "This script will erase your device $DISK_ROOT_PART. Continue?"
                                 format_disk "$DISK_ROOT_PART"
-                                create_armbian "" "$DISK_ROOT_PART"
+                                create_armbian "" "$DISK_ROOT_PART" "$choice"
                                 ;;
 		esac
 	done


### PR DESCRIPTION
# Description

armbian-install should mask installing to root partition. Fixed ARM64 UEFI install. Work if installed to eMMC, installs also to NVME (T4), but u-boot fails to init PCI.  u-boot 2022.10 or .07

Jira: [AR-1355]

# How Has This Been Tested?

- [x] Manual run

To do: 
- fix labels
- change executing bit after transferring script to the target. 

[AR-1355]: https://armbian.atlassian.net/browse/AR-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ