### PR TITLE
rk322x: fix usb otg port disabled by mistake

### DIFF
--- a/patch/kernel/archive/rk322x-5.15/board-rk322x-box.patch
+++ b/patch/kernel/archive/rk322x-5.15/board-rk322x-box.patch
@@ -3,7 +3,7 @@ new file mode 100644
 index 000000000000..f6e249bf81b6
 --- /dev/null
 +++ b/arch/arm/boot/dts/rk322x-box.dts
-@@ -0,0 +1,752 @@
+@@ -0,0 +1,753 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +
 +/dts-v1/;
@@ -710,6 +710,7 @@ index 000000000000..f6e249bf81b6
 +
 +&usb_otg {
 +	dr_mode = "host";
++	status = "okay";
 +};
 +
 +&sdio {

--- a/patch/kernel/archive/rk322x-5.19/board-rk322x-box.patch
+++ b/patch/kernel/archive/rk322x-5.19/board-rk322x-box.patch
@@ -3,7 +3,7 @@ new file mode 100644
 index 000000000000..f6e249bf81b6
 --- /dev/null
 +++ b/arch/arm/boot/dts/rk322x-box.dts
-@@ -0,0 +1,752 @@
+@@ -0,0 +1,753 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +
 +/dts-v1/;
@@ -710,6 +710,7 @@ index 000000000000..f6e249bf81b6
 +
 +&usb_otg {
 +	dr_mode = "host";
++	status = "okay";
 +};
 +
 +&sdio {


### PR DESCRIPTION
# Description

As per subject: did a mistake and usb otg port got disabled.
This PR enables usb otg port for current and edge kernels.

# How Has This Been Tested?

- [x] Compiled device tree with success on current kernel branch

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
