### PR TITLE
Fix mvebu current pwm timer patch

### DIFF
--- a/patch/kernel/archive/mvebu-5.15/92-mvebu-gpio-remove-hardcoded-timer-assignment.patch
+++ b/patch/kernel/archive/mvebu-5.15/92-mvebu-gpio-remove-hardcoded-timer-assignment.patch
@@ -317,45 +317,14 @@ index bad399e3f..d3fdaf177 100644
  }
  
  static int mvebu_pwm_probe(struct platform_device *pdev,
-@@ -817,26 +899,20 @@ static int mvebu_pwm_probe(struct platform_device *pdev,
+@@ -902,6 +902,7 @@ static int mvebu_pwm_probe(struct platform_device *pdev,
  	void __iomem *base;
  	u32 offset;
  	u32 set;
 +	enum mvebu_pwm_ctrl ctrl_set;
  
--	if (of_device_is_compatible(mvchip->chip.of_node,
--				    "marvell,armada-370-gpio")) {
--		/*
--		 * There are only two sets of PWM configuration registers for
--		 * all the GPIO lines on those SoCs which this driver reserves
--		 * for the first two GPIO chips. So if the resource is missing
--		 * we can't treat it as an error.
--		 */
--		if (!platform_get_resource_byname(pdev, IORESOURCE_MEM, "pwm"))
--			return 0;
--		offset = 0;
--	} else if (mvchip->soc_variant == MVEBU_GPIO_SOC_VARIANT_A8K) {
--		int ret = of_property_read_u32(dev->of_node,
--					       "marvell,pwm-offset", &offset);
--		if (ret < 0)
--			return 0;
--	} else {
-+	if (!of_device_is_compatible(mvchip->chip.of_node,
-+				    "marvell,armada-370-gpio"))
-+		return 0;
-+
-+	/*
-+	* There are only two sets of PWM configuration registers for
-+	* all the GPIO lines on those SoCs which this driver reserves
-+	* for the first two GPIO chips. So if the resource is missing
-+	* we can't treat it as an error.
-+	*/
-+	if (!platform_get_resource_byname(pdev, IORESOURCE_MEM, "pwm"))
- 		return 0;
--	}
- 
- 	if (IS_ERR(mvchip->clk))
- 		return PTR_ERR(mvchip->clk);
+ 	if (mvchip->soc_variant == MVEBU_GPIO_SOC_VARIANT_A8K) {
+ 		int ret = of_property_read_u32(dev->of_node,
 @@ -844,54 +920,39 @@ static int mvebu_pwm_probe(struct platform_device *pdev,
  	mvpwm = devm_kzalloc(dev, sizeof(struct mvebu_pwm), GFP_KERNEL);
  	if (!mvpwm)


### PR DESCRIPTION
# Description

This fixes the recently broken patch.
See #4261 and https://forum.armbian.com/topic/23824-fancontrol-service-fails-to-start-with-kernel-version-51572/

Needs to be tested on actual hardware!

# How Has This Been Tested?

- build runs ok.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

