### PR TITLE
rockchip64: fix orangepi4-lts rk808 interrupt line, sdcard detection and wifi freq

### DIFF
--- a/patch/kernel/archive/rockchip64-5.15/add-board-orangepi-4-lts.patch
+++ b/patch/kernel/archive/rockchip64-5.15/add-board-orangepi-4-lts.patch
@@ -3,7 +3,7 @@ new file mode 100644
 index 00000000000..e0490aaa7ba
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4-lts.dts
-@@ -0,0 +1,1257 @@
+@@ -0,0 +1,1258 @@
 +/*
 + * SPDX-License-Identifier: (GPL-2.0+ or MIT)
 + * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd.
@@ -528,8 +528,8 @@ index 00000000000..e0490aaa7ba
 +	rk808: pmic@1b {
 +		compatible = "rockchip,rk808";
 +		reg = <0x1b>;
-+		interrupt-parent = <&gpio1>;
-+		interrupts = <21 IRQ_TYPE_LEVEL_LOW>;
++		interrupt-parent = <&gpio2>;
++		interrupts = <RK_PB2 IRQ_TYPE_LEVEL_LOW>;
 +		#clock-cells = <1>;
 +		clock-output-names = "xin32k", "rk808-clkout2";
 +		pinctrl-names = "default";
@@ -875,6 +875,7 @@ index 00000000000..e0490aaa7ba
 +};
 +
 +&i2s0 {
++	rockchip,i2s-broken-burst-len;
 +	assigned-clocks = <&cru SCLK_I2SOUT_SRC>;
 +	assigned-clock-parents = <&cru SCLK_I2S0_8CH>;
 +	resets = <&cru SRST_I2S0_8CH>, <&cru SRST_H_I2S0_8CH>;
@@ -956,8 +957,8 @@ index 00000000000..e0490aaa7ba
 +};
 +
 +&sdio0 {
-+	clock-frequency = <50000000>;
-+	clock-freq-min-max = <200000 50000000>;
++	clock-frequency = <150000000>;
++	max-frequency = <150000000>;
 +	supports-sdio;
 +	bus-width = <4>;
 +	disable-wp;
@@ -1128,7 +1129,7 @@ index 00000000000..e0490aaa7ba
 +
 +	pmic {
 +		pmic_int_l: pmic-int-l {
-+			rockchip,pins = <1 RK_PC5 RK_FUNC_GPIO &pcfg_pull_up>;
++			rockchip,pins = <2 RK_PB2 RK_FUNC_GPIO &pcfg_pull_up>;
 +		};
 +
 +		vsel1_gpio: vsel1-gpio {

--- a/patch/kernel/archive/rockchip64-5.19/add-board-orangepi-4-lts.patch
+++ b/patch/kernel/archive/rockchip64-5.19/add-board-orangepi-4-lts.patch
@@ -3,7 +3,7 @@ new file mode 100644
 index 00000000000..e0490aaa7ba
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4-lts.dts
-@@ -0,0 +1,1257 @@
+@@ -0,0 +1,1258 @@
 +/*
 + * SPDX-License-Identifier: (GPL-2.0+ or MIT)
 + * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd.
@@ -528,8 +528,8 @@ index 00000000000..e0490aaa7ba
 +	rk808: pmic@1b {
 +		compatible = "rockchip,rk808";
 +		reg = <0x1b>;
-+		interrupt-parent = <&gpio1>;
-+		interrupts = <21 IRQ_TYPE_LEVEL_LOW>;
++		interrupt-parent = <&gpio2>;
++		interrupts = <RK_PB2 IRQ_TYPE_LEVEL_LOW>;
 +		#clock-cells = <1>;
 +		clock-output-names = "xin32k", "rk808-clkout2";
 +		pinctrl-names = "default";
@@ -875,6 +875,7 @@ index 00000000000..e0490aaa7ba
 +};
 +
 +&i2s0 {
++	rockchip,i2s-broken-burst-len;
 +	assigned-clocks = <&cru SCLK_I2SOUT_SRC>;
 +	assigned-clock-parents = <&cru SCLK_I2S0_8CH>;
 +	resets = <&cru SRST_I2S0_8CH>, <&cru SRST_H_I2S0_8CH>;
@@ -956,8 +957,8 @@ index 00000000000..e0490aaa7ba
 +};
 +
 +&sdio0 {
-+	clock-frequency = <50000000>;
-+	clock-freq-min-max = <200000 50000000>;
++	clock-frequency = <150000000>;
++	max-frequency = <150000000>;
 +	supports-sdio;
 +	bus-width = <4>;
 +	disable-wp;
@@ -1128,7 +1129,7 @@ index 00000000000..e0490aaa7ba
 +
 +	pmic {
 +		pmic_int_l: pmic-int-l {
-+			rockchip,pins = <1 RK_PC5 RK_FUNC_GPIO &pcfg_pull_up>;
++			rockchip,pins = <2 RK_PB2 RK_FUNC_GPIO &pcfg_pull_up>;
 +		};
 +
 +		vsel1_gpio: vsel1-gpio {


### PR DESCRIPTION
# Description

Orange PI 4 LTS was flawed with sdcard detection issues, sometimes happening on current 5.15 kernel, practically always happening on kernel >= 5.17

All the changes have been taken from xunlong orangepi repositories device tree for kernel 5.17

Jira reference number [AR-1369]

# How Has This Been Tested?

- [x] Compiled a device tree with the changes and applied to existing system with kernel 5.19.3. After this modification, the board rebooted from sdcard 3 times out of 3. Previously the board would boot 1 time out of dozen of attempts.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1369]: https://armbian.atlassian.net/browse/AR-1369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ