### PR TITLE
fix: chroot buid: Selecting value "user-built" for proper operation

### DIFF
--- a/lib/functions/main/config-prepare.sh
+++ b/lib/functions/main/config-prepare.sh
@@ -151,9 +151,9 @@ function prepare_and_config_main_build_single() {
 Called early, before any compilation work starts.
 POST_DETERMINE_CTHREADS
 
-	if [[ $BETA == yes ]]; then
+	if [[ "$BETA" == "yes" ]]; then
 		IMAGE_TYPE=nightly
-	elif [[ $BETA != "yes" ]]; then
+	elif [ "$BETA" == "no" ] || [ "$RC" == "yes" ]; then
 		IMAGE_TYPE=stable
 	else
 		IMAGE_TYPE=user-built


### PR DESCRIPTION
The else condition will never be met.
```
if [[ "$BETA" == "yes" ]]; then
	IMAGE_TYPE=nightly
elif [[ "$BETA" != "yes" ]]; then
	IMAGE_TYPE=stable
else
	IMAGE_TYPE=user-built
fi
```
# Description
The chroot_build_packages function collects all packages everything for all operating systems and the user is drowning in the amount of code being executed.

The logic of choice should be based on this:
https://github.com/armbian/scripts/tree/master/configs

# How Has This Been Tested?


- [x] Test building with the `EXTERNAL_NEW="compile"`  parameter
