### PR TITLE
Switch rockpi-s to EDGE

### DIFF
--- a/config/targets.conf
+++ b/config/targets.conf
@@ -852,8 +852,8 @@ rockpi-4c                 edge            sid         desktop                  s
 rockpi-4c                 edge            sid         desktop                  stable         yes            kde-plasma    config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 # Rockpi-S
-rockpi-s                  current         jammy       cli                      stable         adv
-rockpi-s                  current         bullseye    cli                      stable         adv
+rockpi-s                  edge            jammy       cli                      stable         adv
+rockpi-s                  edge            bullseye    cli                      stable         adv
 rockpi-s                  edge            sid         cli                      stable         yes
 
 # Tinkerboard


### PR DESCRIPTION
# Description

Adjustments were done only for most recent kernel which is soon going to be next CURRENT. Board was not supported until recently. Once K5.19.y is current, we can revert this.