### PR TITLE
Remove ext2 and ext3 filesystem option from armbian-install

### DIFF
--- a/packages/bsp/common/usr/sbin/armbian-install
+++ b/packages/bsp/common/usr/sbin/armbian-install
@@ -489,8 +489,8 @@ format_emmc()
 	# choose and create fs
 	IFS=" "
 	BTRFS=$(grep -o btrfs /proc/filesystems)
-	FilesystemTargets="1 ext4 4 f2fs"
-	[[ -n $BTRFS && ! `uname -r | grep '^3.' ` ]] && FilesystemTargets=$FilesystemTargets" 5 $BTRFS"
+	FilesystemTargets="1 ext4 2 f2fs"
+	[[ -n $BTRFS && ! `uname -r | grep '^3.' ` ]] && FilesystemTargets=$FilesystemTargets" 3 $BTRFS"
 	FilesystemOptions=($FilesystemTargets)
 
 	FilesystemCmd=(dialog --title "Select filesystem type for eMMC $1" --backtitle "$backtitle" --menu "\n$infos" 10 60 16)
@@ -586,7 +586,7 @@ format_disk()
 		*)
 			BTRFS=$(grep -o btrfs /proc/filesystems)
 			FilesystemTargets='1 ext4'
-			[[ -n $BTRFS && ! `uname -r | grep '^3.' ` && $choice != 6 ]] && FilesystemTargets=$FilesystemTargets" 4 $BTRFS"
+			[[ -n $BTRFS && ! `uname -r | grep '^3.' ` && $choice != 6 ]] && FilesystemTargets=$FilesystemTargets" 2 $BTRFS"
 			;;
 	esac
 	FilesystemOptions=($FilesystemTargets)

--- a/packages/bsp/common/usr/sbin/armbian-install
+++ b/packages/bsp/common/usr/sbin/armbian-install
@@ -54,19 +54,13 @@ efi_partition=$(LC_ALL=C fdisk -l "/dev/$diskcheck" 2>/dev/null | grep "EFI" | a
 declare -A mkopts mountopts
 # for ARMv7 remove 64bit feature from default mke2fs format features
 if [[ $LINUXFAMILY == mvebu ]]; then
-	mkopts[ext2]='-O ^64bit -qF'
-	mkopts[ext3]='-O ^64bit -qF'
 	mkopts[ext4]='-O ^64bit -qF'
 else
-	mkopts[ext2]='-qF'
-	mkopts[ext3]='-qF'
 	mkopts[ext4]='-qF'
 fi
 mkopts[btrfs]='-f'
 mkopts[f2fs]='-f'
 
-mountopts[ext2]='defaults,noatime,commit=600,errors=remount-ro,x-gvfs-hide	0	1'
-mountopts[ext3]='defaults,noatime,commit=600,errors=remount-ro,x-gvfs-hide	0	1'
 mountopts[ext4]='defaults,noatime,commit=600,errors=remount-ro,x-gvfs-hide	0	1'
 mountopts[btrfs]='defaults,noatime,commit=600,compress=lzo,x-gvfs-hide			0	2'
 mountopts[f2fs]='defaults,noatime,x-gvfs-hide	0	2'
@@ -495,7 +489,7 @@ format_emmc()
 	# choose and create fs
 	IFS=" "
 	BTRFS=$(grep -o btrfs /proc/filesystems)
-	FilesystemTargets="1 ext4 2 ext3 3 ext2 4 f2fs"
+	FilesystemTargets="1 ext4 4 f2fs"
 	[[ -n $BTRFS && ! `uname -r | grep '^3.' ` ]] && FilesystemTargets=$FilesystemTargets" 5 $BTRFS"
 	FilesystemOptions=($FilesystemTargets)
 
@@ -591,7 +585,7 @@ format_disk()
 			;;
 		*)
 			BTRFS=$(grep -o btrfs /proc/filesystems)
-			FilesystemTargets='1 ext4 2 ext3 3 ext2'
+			FilesystemTargets='1 ext4'
 			[[ -n $BTRFS && ! `uname -r | grep '^3.' ` && $choice != 6 ]] && FilesystemTargets=$FilesystemTargets" 4 $BTRFS"
 			;;
 	esac


### PR DESCRIPTION
# Description

Cleaning deprecated options from installer.

Jira reference number [AR-1355]

# How Has This Been Tested?

- [x] Manual run

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1355]: https://armbian.atlassian.net/browse/AR-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ