### PR TITLE
add ext4 bootfs to rock5b

### DIFF
--- a/config/boards/rock-5b.wip
+++ b/config/boards/rock-5b.wip
@@ -11,3 +11,4 @@ WIREGUARD="no"
 BOOT_SUPPORT_SPI="yes"
 IMAGE_PARTITION_TABLE="gpt"
 SKIP_BOOTSPLASH="yes" # Skip boot splash patch, conflicts with CONFIG_VT=yes
+BOOTFS_TYPE="fat"

--- a/config/boards/rock-5b.wip
+++ b/config/boards/rock-5b.wip
@@ -11,4 +11,4 @@ WIREGUARD="no"
 BOOT_SUPPORT_SPI="yes"
 IMAGE_PARTITION_TABLE="gpt"
 SKIP_BOOTSPLASH="yes" # Skip boot splash patch, conflicts with CONFIG_VT=yes
-BOOTFS_TYPE="fat"
+BOOTFS_TYPE="ext4"

--- a/lib/functions/image/partitioning.sh
+++ b/lib/functions/image/partitioning.sh
@@ -32,7 +32,6 @@ prepare_partitions() {
 	if [[ $BUILD_DESKTOP == yes ]]; then local node_number=4096; else local node_number=1024; fi
 	if [[ $HOSTRELEASE =~ buster|bullseye|focal|jammy|sid ]]; then
 		mkopts[ext4]="-q -m 2 -O ^64bit,^metadata_csum -N $((128 * ${node_number}))"
-		mkopts[ext4_boot]="-q -m 2 -O ^64bit,^metadata_csum -N $((128 * 1024))"
 	fi
 	# mkopts[fat] is empty
 	mkopts[ext2]='-q'
@@ -266,11 +265,7 @@ PREPARE_IMAGE_SIZE
 	if [[ -n $bootpart ]]; then
 		display_alert "Creating /boot" "$bootfs on ${LOOP}p${bootpart}"
 		check_loop_device "${LOOP}p${bootpart}"
-		if [[ $bootfs == ext4 ]]; then
-			mkfs.${mkfs[$bootfs]} ${mkopts[${bootfs}_boot]} ${mkopts_label[$bootfs]:+${mkopts_label[$bootfs]}"$BOOT_FS_LABEL"} ${LOOP}p${bootpart} >> "${DEST}"/${LOG_SUBPATH}/install.log 2>&1
-		else
-			mkfs.${mkfs[$bootfs]} ${mkopts[$bootfs]} ${mkopts_label[$bootfs]:+${mkopts_label[$bootfs]}"$BOOT_FS_LABEL"} ${LOOP}p${bootpart} >> "${DEST}"/${LOG_SUBPATH}/install.log 2>&1
-		fi
+		mkfs.${mkfs[$bootfs]} ${mkopts[$bootfs]} ${mkopts_label[$bootfs]:+${mkopts_label[$bootfs]}"$BOOT_FS_LABEL"} ${LOOP}p${bootpart} >> "${DEST}"/${LOG_SUBPATH}/install.log 2>&1
 		mkdir -p $MOUNT/boot/
 		mount ${LOOP}p${bootpart} $MOUNT/boot/
 		echo "UUID=$(blkid -s UUID -o value ${LOOP}p${bootpart}) /boot ${mkfs[$bootfs]} defaults${mountopts[$bootfs]} 0 2" >> $SDCARD/etc/fstab

--- a/lib/functions/image/partitioning.sh
+++ b/lib/functions/image/partitioning.sh
@@ -32,6 +32,7 @@ prepare_partitions() {
 	if [[ $BUILD_DESKTOP == yes ]]; then local node_number=4096; else local node_number=1024; fi
 	if [[ $HOSTRELEASE =~ buster|bullseye|focal|jammy|sid ]]; then
 		mkopts[ext4]="-q -m 2 -O ^64bit,^metadata_csum -N $((128 * ${node_number}))"
+		mkopts[ext4_boot]="-q -m 2 -O ^64bit,^metadata_csum -N $((128 * 1024))"
 	fi
 	# mkopts[fat] is empty
 	mkopts[ext2]='-q'
@@ -265,7 +266,11 @@ PREPARE_IMAGE_SIZE
 	if [[ -n $bootpart ]]; then
 		display_alert "Creating /boot" "$bootfs on ${LOOP}p${bootpart}"
 		check_loop_device "${LOOP}p${bootpart}"
-		mkfs.${mkfs[$bootfs]} ${mkopts[$bootfs]} ${mkopts_label[$bootfs]:+${mkopts_label[$bootfs]}"$BOOT_FS_LABEL"} ${LOOP}p${bootpart} >> "${DEST}"/${LOG_SUBPATH}/install.log 2>&1
+		if [[ $bootfs == ext4 ]]; then
+			mkfs.${mkfs[$bootfs]} ${mkopts[${bootfs}_boot]} ${mkopts_label[$bootfs]:+${mkopts_label[$bootfs]}"$BOOT_FS_LABEL"} ${LOOP}p${bootpart} >> "${DEST}"/${LOG_SUBPATH}/install.log 2>&1
+		else
+			mkfs.${mkfs[$bootfs]} ${mkopts[$bootfs]} ${mkopts_label[$bootfs]:+${mkopts_label[$bootfs]}"$BOOT_FS_LABEL"} ${LOOP}p${bootpart} >> "${DEST}"/${LOG_SUBPATH}/install.log 2>&1
+		fi
 		mkdir -p $MOUNT/boot/
 		mount ${LOOP}p${bootpart} $MOUNT/boot/
 		echo "UUID=$(blkid -s UUID -o value ${LOOP}p${bootpart}) /boot ${mkfs[$bootfs]} defaults${mountopts[$bootfs]} 0 2" >> $SDCARD/etc/fstab


### PR DESCRIPTION
# Description

Although the u-boot of rock5b supports ext4, when using ext4 as a whole root partition, sometimes it will take a long time for u-boot to load kernel image, which will cause pd negotiation timeout. So a single /boot partition is still needed. I intended to use ext4 as boot partition filesystem but the ext4 /boot only has usable space 109M while the real partition size is 256M, so I use fat filesystem.

# How Has This Been Tested?


- [x] Build image sucessfully.
- [x] Image boots successfully on rock5b

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
