### PR TITLE
Add support for apt-mark hold warning

### DIFF
--- a/packages/bsp/common/etc/apt/apt.conf.d/02-armbian-postupdate
+++ b/packages/bsp/common/etc/apt/apt.conf.d/02-armbian-postupdate
@@ -1,0 +1,1 @@
+DPkg::Post-Invoke {"/usr/lib/armbian/armbian-apt-updates";};

--- a/packages/bsp/common/etc/update-motd.d/40-armbian-updates
+++ b/packages/bsp/common/etc/update-motd.d/40-armbian-updates
@@ -29,7 +29,7 @@ fi
 
 if [[ $NUM_UPDATES_ONHOLD -gt 0 ]] && grep -q linux /var/cache/apt/archives/updates.list 2>/dev/null; then
 	[[ $NUM_UPDATES -gt 0 ]] && echo -en "| " || echo -en "[ "
-	echo -en "\e[31m$NUM_UPDATES_ONHOLD firmware upgrade:\e[0m \e[1marmbian-config\e[0m "
+	echo -en "\e[31mKernel and firmware upgrades disabled:\e[0m \e[1marmbian-config\e[0m "
 fi
 
 if [[ $NUM_UPDATES -gt 0 ]] || [[ $NUM_UPDATES_ONHOLD -gt 0 ]]; then

--- a/packages/bsp/common/etc/update-motd.d/40-armbian-updates
+++ b/packages/bsp/common/etc/update-motd.d/40-armbian-updates
@@ -19,14 +19,14 @@ for f in $MOTD_DISABLE; do
 done
 
 NUM_UPDATES=0
-NUM_ONHOLD=0
 
 [[ -f /var/cache/apt/archives/updates.number ]] && . /var/cache/apt/archives/updates.number
-[[ -f /var/lib/dpkg/status ]] && NUM_ONHOLD=$(cat /var/lib/dpkg/status | grep -A 1 -B 1 hold | grep Package | cut -d" " -f2 | grep linux- | wc -l)
 
 if [[ $NUM_UPDATES -gt 0 ]]; then
 	echo -en "[\e[31m $NUM_SECURITY_UPDATES security updates available, $NUM_UPDATES updates total\e[0m: \e[1mapt upgrade\e[0m "
-	[[ $NUM_ONHOLD -gt 0 ]] && echo -en "| \e[31mkernel upgrade:\e[0m \e[1marmbian-config\e[0m "
+	if grep -q linux /var/cache/apt/archives/updates.list 2>/dev/null && [[ "$NUM_UPDATES_ONHOLD" -gt 0 ]] ; then
+	echo -en "| \e[31m$NUM_UPDATES_ONHOLD firmware upgrade:\e[0m \e[1marmbian-config\e[0m "
+	fi
 	echo -e "]"
 	echo -e "Last check: \e[92m$DATE\e[0m"
 	echo

--- a/packages/bsp/common/etc/update-motd.d/40-armbian-updates
+++ b/packages/bsp/common/etc/update-motd.d/40-armbian-updates
@@ -19,14 +19,20 @@ for f in $MOTD_DISABLE; do
 done
 
 NUM_UPDATES=0
+NUM_UPDATES_ONHOLD=0
 
 [[ -f /var/cache/apt/archives/updates.number ]] && . /var/cache/apt/archives/updates.number
 
 if [[ $NUM_UPDATES -gt 0 ]]; then
 	echo -en "[\e[31m $NUM_SECURITY_UPDATES security updates available, $NUM_UPDATES updates total\e[0m: \e[1mapt upgrade\e[0m "
-	if grep -q linux /var/cache/apt/archives/updates.list 2>/dev/null && [[ "$NUM_UPDATES_ONHOLD" -gt 0 ]] ; then
-	echo -en "| \e[31m$NUM_UPDATES_ONHOLD firmware upgrade:\e[0m \e[1marmbian-config\e[0m "
-	fi
+fi
+
+if [[ $NUM_UPDATES_ONHOLD -gt 0 ]] && grep -q linux /var/cache/apt/archives/updates.list 2>/dev/null; then
+	[[ $NUM_UPDATES -gt 0 ]] && echo -en "| " || echo -en "[ "
+	echo -en "\e[31m$NUM_UPDATES_ONHOLD firmware upgrade:\e[0m \e[1marmbian-config\e[0m "
+fi
+
+if [[ $NUM_UPDATES -gt 0 ]] || [[ $NUM_UPDATES_ONHOLD -gt 0 ]]; then
 	echo -e "]"
 	echo -e "Last check: \e[92m$DATE\e[0m"
 	echo

--- a/packages/bsp/common/etc/update-motd.d/40-armbian-updates
+++ b/packages/bsp/common/etc/update-motd.d/40-armbian-updates
@@ -19,13 +19,14 @@ for f in $MOTD_DISABLE; do
 done
 
 NUM_UPDATES=0
+NUM_ONHOLD=0
 
 [[ -f /var/cache/apt/archives/updates.number ]] && . /var/cache/apt/archives/updates.number
 [[ -f /var/lib/dpkg/status ]] && NUM_ONHOLD=$(cat /var/lib/dpkg/status | grep -A 1 -B 1 hold | grep Package | cut -d" " -f2 | grep linux- | wc -l)
 
 if [[ $NUM_UPDATES -gt 0 ]]; then
 	echo -en "[\e[31m $NUM_SECURITY_UPDATES security updates available, $NUM_UPDATES updates total\e[0m: \e[1mapt upgrade\e[0m "
-	[[ $NUM_UPDATES -gt 0 ]] && echo -en "| \e[31mkernel upgrade:\e[0m \e[1marmbian-config\e[0m "
+	[[ $NUM_ONHOLD -gt 0 ]] && echo -en "| \e[31mkernel upgrade:\e[0m \e[1marmbian-config\e[0m "
 	echo -e "]"
 	echo -e "Last check: \e[92m$DATE\e[0m"
 	echo

--- a/packages/bsp/common/etc/update-motd.d/40-armbian-updates
+++ b/packages/bsp/common/etc/update-motd.d/40-armbian-updates
@@ -21,9 +21,12 @@ done
 NUM_UPDATES=0
 
 [[ -f /var/cache/apt/archives/updates.number ]] && . /var/cache/apt/archives/updates.number
+[[ -f /var/lib/dpkg/status ]] && NUM_ONHOLD=$(cat /var/lib/dpkg/status | grep -A 1 -B 1 hold | grep Package | cut -d" " -f2 | grep linux- | wc -l)
 
 if [[ $NUM_UPDATES -gt 0 ]]; then
-	echo -e "[\e[31m $NUM_SECURITY_UPDATES security updates available, $NUM_UPDATES updates total\e[0m: \e[1mapt upgrade\e[0m ]"
+	echo -en "[\e[31m $NUM_SECURITY_UPDATES security updates available, $NUM_UPDATES updates total\e[0m: \e[1mapt upgrade\e[0m "
+	[[ $NUM_UPDATES -gt 0 ]] && echo -en "| \e[31mkernel upgrade:\e[0m \e[1marmbian-config\e[0m "
+	echo -e "]"
 	echo -e "Last check: \e[92m$DATE\e[0m"
 	echo
 fi

--- a/packages/bsp/common/usr/lib/armbian/armbian-apt-updates
+++ b/packages/bsp/common/usr/lib/armbian/armbian-apt-updates
@@ -56,7 +56,7 @@ DATE="$(date +"%Y-%m-%d %H:%M")"
 EOT
 
 # store packages list
-apt list --upgradable 2>/dev/null >| ${myfiles}
+apt list --upgradable  2>/dev/null | grep "/" >| ${myfiles}
 
 exit 0
 

--- a/packages/bsp/common/usr/lib/armbian/armbian-apt-updates
+++ b/packages/bsp/common/usr/lib/armbian/armbian-apt-updates
@@ -42,6 +42,7 @@ DISTRO=$(lsb_release -c | cut -d ":" -f 2 |  tr -d '[:space:]') && DISTRO=${DIST
 # run around the packages
 upgrades=0
 security_upgrades=0
+
 while IFS= read -r LINE; do
         # increment the upgrade counter
         (( upgrades++ ))
@@ -51,6 +52,7 @@ done < <(apt-get upgrade -s -qq | sed -n '/^Inst/p')
 
 cat >|${myfile} <<EOT
 NUM_UPDATES="${upgrades}"
+NUM_UPDATES_ONHOLD="$(apt-mark showhold | wc -l)"
 NUM_SECURITY_UPDATES="${security_upgrades}"
 DATE="$(date +"%Y-%m-%d %H:%M")"
 EOT

--- a/packages/bsp/common/usr/lib/armbian/armbian-apt-updates
+++ b/packages/bsp/common/usr/lib/armbian/armbian-apt-updates
@@ -52,7 +52,7 @@ done < <(apt-get upgrade -s -qq | sed -n '/^Inst/p')
 
 cat >|${myfile} <<EOT
 NUM_UPDATES="${upgrades}"
-NUM_UPDATES_ONHOLD="$(apt-mark showhold | wc -l)"
+NUM_UPDATES_ONHOLD="$(dpkg --list | grep ^hi | grep $(uname -r) | wc -l)"
 NUM_SECURITY_UPDATES="${security_upgrades}"
 DATE="$(date +"%Y-%m-%d %H:%M")"
 EOT

--- a/packages/bsp/common/usr/lib/armbian/armbian-apt-updates
+++ b/packages/bsp/common/usr/lib/armbian/armbian-apt-updates
@@ -34,6 +34,7 @@ fi
 [[ "$((apt-get upgrade -s -qq) 2>&1)" == *"Unmet dependencies"* ]] && exit 0
 
 myfile="/var/cache/apt/archives/updates.number"
+myfiles="/var/cache/apt/archives/updates.list"
 
 # update procedure
 DISTRO=$(lsb_release -c | cut -d ":" -f 2 |  tr -d '[:space:]') && DISTRO=${DISTRO,,}
@@ -53,6 +54,9 @@ NUM_UPDATES="${upgrades}"
 NUM_SECURITY_UPDATES="${security_upgrades}"
 DATE="$(date +"%Y-%m-%d %H:%M")"
 EOT
+
+# store packages list
+apt list --upgradable 2>/dev/null >| ${myfiles}
 
 exit 0
 


### PR DESCRIPTION
# Description

If we will be shipping firmware frozen by default, we need to warn and provide information how to update kernel. Armbian-config was updated to be able to update all packages.

Cron job is generating numbers of packages that needs to be updated. This numbers is displayed in MOTD, when > 0. Since we want to know which packages are on hold, 

- we need to know if kernel packages are on hold
- when upgrade is finished, fix numbers and update list

```
[ 78 security updates available, 203 updates total: apt upgrade | 1 firmware upgrade: armbian-config ]
Last check: 2022-10-16 15:11
```

or if only those that are on hold are not getting updated

```
[ 2 firmware upgrade: armbian-config ]
Last check: 2022-10-16 15:13
```

Jira reference number [AR-1375]

# How Has This Been Tested?

- [x] Manual run

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1375]: https://armbian.atlassian.net/browse/AR-1375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ