### PR TITLE
Reenable Github API to fetch rootfs-cache version

### DIFF
--- a/lib/functions/rootfs/create-cache.sh
+++ b/lib/functions/rootfs/create-cache.sh
@@ -21,10 +21,8 @@ get_rootfs_cache_list() {
 	local packages_hash=$2
 
 	{
-		# Temportally disable Github API because we don't support to download from it
-		# curl --silent --fail -L "https://api.github.com/repos/armbian/cache/releases?per_page=3" | jq -r '.[].tag_name' \
-		# || curl --silent --fail -L https://cache.armbian.com/rootfs/list
-		curl --silent --fail -L https://cache.armbian.com/rootfs/list
+		curl --silent --fail -L "https://api.github.com/repos/armbian/cache/releases?per_page=3" | jq -r '.[].tag_name' \
+		|| curl --silent --fail -L https://cache.armbian.com/rootfs/list
 
 		find ${SRC}/cache/rootfs/ -mtime -7 -name "${ARCH}-${RELEASE}-${cache_type}-${packages_hash}-*.tar.zst" |
 			sed -e 's#^.*/##' |


### PR DESCRIPTION
# Description

Now we support to download rootfs-cache from Github.

NOTE: it seem like that some mirrors is outdated. So we use Github API first.
We don't need to care about these mirrors, since we support multi-origin download.

# How Has This Been Tested?

- [X] Build

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
