### PR TITLE
Add kaslrseed to Rockchip's u-boot

### DIFF
--- a/config/bootscripts/boot-rockchip64.cmd
+++ b/config/bootscripts/boot-rockchip64.cmd
@@ -71,6 +71,7 @@ else
 		source ${load_addr}
 	fi
 fi
+kaslrseed
 booti ${kernel_addr_r} ${ramdisk_addr_r} ${fdt_addr_r}
 
 # Recompile with:


### PR DESCRIPTION
# Description

Partly resolves #4306.

# How Has This Been Tested?

If the `kaslrseed` command hasn't been compiled in to u-boot, it gracefully skips generating the kASLR 

- [X] Booted on a NanoPi R4S

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
