### PR TITLE
Only enable serial logins if enabled.

### DIFF
--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -165,6 +165,7 @@ function do_main_configuration() {
 	[[ -z $IMAGE_PARTITION_TABLE ]] && IMAGE_PARTITION_TABLE="msdos"
 	[[ -z $EXTRA_BSP_NAME ]] && EXTRA_BSP_NAME=""
 	[[ -z $EXTRA_ROOTFS_MIB_SIZE ]] && EXTRA_ROOTFS_MIB_SIZE=0
+	[[ -z $SERIAL_AUTOLOGIN ]] && SERIAL_AUTOLOGIN="yes"
 
 	# single ext4 partition is the default and preferred configuration
 	#BOOTFS_TYPE=''

--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -165,7 +165,7 @@ function do_main_configuration() {
 	[[ -z $IMAGE_PARTITION_TABLE ]] && IMAGE_PARTITION_TABLE="msdos"
 	[[ -z $EXTRA_BSP_NAME ]] && EXTRA_BSP_NAME=""
 	[[ -z $EXTRA_ROOTFS_MIB_SIZE ]] && EXTRA_ROOTFS_MIB_SIZE=0
-	[[ -z $SERIAL_AUTOLOGIN ]] && SERIAL_AUTOLOGIN="yes"
+	[[ -z $CONSOLE_AUTOLOGIN ]] && CONSOLE_AUTOLOGIN="yes"
 
 	# single ext4 partition is the default and preferred configuration
 	#BOOTFS_TYPE=''

--- a/lib/functions/rootfs/distro-agnostic.sh
+++ b/lib/functions/rootfs/distro-agnostic.sh
@@ -109,17 +109,19 @@ install_common() {
 	# set root password
 	chroot "${SDCARD}" /bin/bash -c "(echo $ROOTPWD;echo $ROOTPWD;) | passwd root >/dev/null 2>&1"
 
-	# enable automated login to console(s)
-	mkdir -p "${SDCARD}"/etc/systemd/system/getty@.service.d/
-	mkdir -p "${SDCARD}"/etc/systemd/system/serial-getty@.service.d/
-	cat <<- EOF > "${SDCARD}"/etc/systemd/system/serial-getty@.service.d/override.conf
-		[Service]
-		ExecStartPre=/bin/sh -c 'exec /bin/sleep 10'
-		ExecStart=
-		ExecStart=-/sbin/agetty --noissue --autologin root %I \$TERM
-		Type=idle
-	EOF
-	cp "${SDCARD}"/etc/systemd/system/serial-getty@.service.d/override.conf "${SDCARD}"/etc/systemd/system/getty@.service.d/override.conf
+	if [[ $SERIAL_AUTOLOGIN == yes ]]; then
+		# enable automated login to console(s)
+		mkdir -p "${SDCARD}"/etc/systemd/system/getty@.service.d/
+		mkdir -p "${SDCARD}"/etc/systemd/system/serial-getty@.service.d/
+		cat <<- EOF > "${SDCARD}"/etc/systemd/system/serial-getty@.service.d/override.conf
+			[Service]
+			ExecStartPre=/bin/sh -c 'exec /bin/sleep 10'
+			ExecStart=
+			ExecStart=-/sbin/agetty --noissue --autologin root %I \$TERM
+			Type=idle
+		EOF
+		cp "${SDCARD}"/etc/systemd/system/serial-getty@.service.d/override.conf "${SDCARD}"/etc/systemd/system/getty@.service.d/override.conf
+	fi
 
 	# force change root password at first login
 	#chroot "${SDCARD}" /bin/bash -c "chage -d 0 root"

--- a/lib/functions/rootfs/distro-agnostic.sh
+++ b/lib/functions/rootfs/distro-agnostic.sh
@@ -109,7 +109,7 @@ install_common() {
 	# set root password
 	chroot "${SDCARD}" /bin/bash -c "(echo $ROOTPWD;echo $ROOTPWD;) | passwd root >/dev/null 2>&1"
 
-	if [[ $SERIAL_AUTOLOGIN == yes ]]; then
+	if [[ $CONSOLE_AUTOLOGIN == yes ]]; then
 		# enable automated login to console(s)
 		mkdir -p "${SDCARD}"/etc/systemd/system/getty@.service.d/
 		mkdir -p "${SDCARD}"/etc/systemd/system/serial-getty@.service.d/


### PR DESCRIPTION
# Description

Having auto-login isn't always desirable for production images.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Booted on a NanoPi R4S

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
