### PR TITLE
update rkbin files of rk3588 to aviod system hangs when ddr freq is 2112MHz

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -91,8 +91,8 @@ elif [[ $BOOT_SOC == rk3568 ]]; then
 elif [[ $BOOT_SOC == rk3588 ]]; then
 
 	BOOT_SCENARIO="${BOOT_SCENARIO:=spl-blobs}"
-	DDR_BLOB="${DDR_BLOB:=rk35/rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.07.bin}"
-	BL31_BLOB='rk35/rk3588_bl31_v1.25.elf'
+	DDR_BLOB="${DDR_BLOB:=rk35/rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.08.bin}"
+	BL31_BLOB='rk35/rk3588_bl31_v1.28.elf'
 
 elif [[ $BOARD == rockpi-s ]]; then
 


### PR DESCRIPTION
# Description

My rock5b always encountered system hang with the old rkbin files when ddr freq is 2112MHz. After updating these binaries there is no system hangs.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] u-boot build successfully
- [x] no system hangs after updating u-boot

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
