### PR TITLE
Error triggered when changing BSP package

### DIFF
--- a/lib/functions/bsp/bsp-cli.sh
+++ b/lib/functions/bsp/bsp-cli.sh
@@ -249,8 +249,11 @@ create_board_package() {
 
 	# won't recreate files if they were removed by user
 	# TODO: Add proper handling for updated conffiles
-	#cat <<-EOF > "${destination}"/DEBIAN/conffiles
-	#EOF
+	# We are runing this script each time apt runs. If this package is removed, file is removed and error is triggered.
+	# Keeping armbian-apt-updates as a configuration, solve the problem
+	cat <<-EOF > "${destination}"/DEBIAN/conffiles
+	/usr/lib/armbian/armbian-apt-updates
+	EOF
 
 	# copy common files from a premade directory structure
 	rsync -a ${SRC}/packages/bsp/common/* ${destination}


### PR DESCRIPTION
# Description

We are runing this script each time apt runs. If this package is removed, file is removed and error is triggered. Keeping armbian-apt-updates as a configuration, solve the problem

Jira reference number [AR-1392]

# How Has This Been Tested?

- [x] Installing and uninstalling bsp package

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1392]: https://armbian.atlassian.net/browse/AR-1392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ