### PR TITLE
Make sure the build fails if generating uInitrd fails

### DIFF
--- a/packages/bsp/common/etc/initramfs/post-update.d/99-uboot
+++ b/packages/bsp/common/etc/initramfs/post-update.d/99-uboot
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 
 . /etc/armbian-release
 


### PR DESCRIPTION
Without this, when mkimage fails (for example because the boot partition is too small), install.log shows an error like:

    mkimage: Write only 16310208/17794920 bytes, probably no space left on the device

But this does not terminate the build, so the compile script shows no error and an image is generated, but it is unbootable.

This runs the script with -e, so when mkimage fails, the script fails, which makes update-initramfs fail, which makes the build fail.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Build image for Orange Pi PC with `BOOTFS_TYPE="fat"` and `BOOTSIZE="64"` to generate a separate boot partition that is just big enough for the regular initrd, but too small to also contain the uInitrd. Check that this build fails.
- [x] Build same image, but with `BOOTSIZE="96"` and check that the build completes and starts.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~ N/A
- [ ] ~~I have made corresponding changes to the documentation~~ N/A
- [x] My changes generate no new warnings
- [ ] ~~Any dependent changes have been merged and published in downstream modules~~ N/A
