### PR TITLE
Fix disp_mode boot option on sunxi

### DIFF
--- a/config/bootenv/sunxi.txt
+++ b/config/bootenv/sunxi.txt
@@ -1,4 +1,5 @@
 verbosity=1
 bootlogo=false
 console=both
-disp_mode=1920x1080p60
+# https://wiki.archlinux.org/title/kernel_mode_setting#Forcing_modes
+#disp_mode=1920x1080@60

--- a/config/bootscripts/boot-sunxi.cmd
+++ b/config/bootscripts/boot-sunxi.cmd
@@ -9,7 +9,6 @@ setenv overlay_error "false"
 setenv verbosity "1"
 setenv console "both"
 setenv disp_mem_reserves "off"
-setenv disp_mode "1920x1080p60"
 setenv rootfstype "ext4"
 setenv docker_optimizations "on"
 setenv bootlogo "false"
@@ -46,7 +45,7 @@ else
 	setenv consoleargs "splash=verbose ${consoleargs}"
 fi
 
-setenv bootargs "root=${rootdev} rootwait rootfstype=${rootfstype} ${consoleargs} hdmi.audio=EDID:0 disp.screen0_output_mode=${disp_mode} consoleblank=0 loglevel=${verbosity} ubootpart=${partuuid} ubootsource=${devtype} usb-storage.quirks=${usbstoragequirks} ${extraargs} ${extraboardargs}"
+setenv bootargs "root=${rootdev} rootwait rootfstype=${rootfstype} ${consoleargs} video=${disp_mode} consoleblank=0 loglevel=${verbosity} ubootpart=${partuuid} ubootsource=${devtype} usb-storage.quirks=${usbstoragequirks} ${extraargs} ${extraboardargs}"
 
 if test "${disp_mem_reserves}" = "off"; then setenv bootargs "${bootargs} sunxi_ve_mem_reserve=0 sunxi_g2d_mem_reserve=0 sunxi_fb_mem_reserve=16"; fi
 if test "${docker_optimizations}" = "on"; then setenv bootargs "${bootargs} cgroup_enable=memory swapaccount=1"; fi


### PR DESCRIPTION
# Description

Setting the display mode in armbianEnv.txt no longer worked, probably because it used an old, sunxi-specific interface. See the commit message (also shown below) for details about this.

I'm marking this as draft, because:
 - I'm not sure if we should reuse the `disp_mode` variable, or maybe use a different name (`video_mode`?) to make it clearer that the values it accepts are of a slightly different format (would also help to see that older documentation does not apply to this option).
 - This fixes just sunxi, which I've been able to test only on a single board (Orange Pi PC). I'm not sure if similar changes are needed elsewhere (see last point in commit message).

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Run original image for Orange Pi PC, set `disp_mode=1280x720p60` and see that the monitor input stays at the default 1920x1080.
- [x] Run the modified image for Orange Pi PC, set `disp_mode=1280x720p60` and see that the monitor input changes to 1280x720 as expected.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - seems disp_mode is not really documented?
- [x] My changes generate no new warnings
- [ ] ~~Any dependent changes have been merged and published in downstream modules~~ N/A

# Commit message:

The disp_mode variable can be set in armbianEnv.txt and boot-sunxi.cmd (boot.scr on the final image) takes care of putting its value in the disp.screen0_output_mode variable on the kernel commandline. However, it seems that this variable is no not actually used by the kernel, probably because it applied to the sunxi video driver from the sunxi-3.x legacy kernels.

On newer kernels, it seems that the standard way to force drm/kms to use a specific mode is through the "video=" kernel argument, as documented here:

    https://wiki.archlinux.org/title/kernel_mode_setting#Forcing_modes

This commit adopts to this new way, by updating the boot script to pass the disp_mode variable to the kernel's video= parameter now.

Some additional notes:
 - The format of the variable did slightly change, exchanging the "p" for progressive with an @ to indicate the refresh rate, and the video= parameter also allows some additional details (like specifying a specific video connect, bit depth and other info). This means that existing configs are not going to end up work as-is (tried, didn't work), but that seems ok.
 - This comments out the forced 1920x1080 mode (and removes it from the boot script), leaving the default to just autodetect the resolution (which is already the current behavior, given the old option did not work).
 - This also removes the hdmi.audio option from the commandline, which was probably also specific to the old video driver (without it HDMI audio still works normally on an Orange Pi PC).
 - Note that the mode passed to video= is actually added to the list of supported modes (from EDID) as a userdef mode (shown in drm_info output), possibly replacing an existing mode, or adding a new mode if the display does not advertise support for it (no guarantee that the display can actually use the mode, of course).
 - All current sunxi kernel branches, including legacy, seem to use mainline kernels now, so supporting the old way of setting the video mode should no longer be needed.
 - The old "disp.screen0_output_mode" commandline is still used by nfs-boot.cmd.template and the armbian-install and nand-sata-install commands. Additionally, the screenx_output_mode variable is also still used by various (mostly sun50i) DTS files and FEX scripts. These might need a similar treatment, but I cannot oversee the consequences (and have no hardware to test).
