### PR TITLE
Fix U-Boot SUNXI NAND SPL

### DIFF
--- a/patch/u-boot/u-boot-sunxi/fix-sunxi-nand-spl.patch
+++ b/patch/u-boot/u-boot-sunxi/fix-sunxi-nand-spl.patch
@@ -1,0 +1,13 @@
+diff --git a/drivers/mtd/nand/raw/sunxi_nand_spl.c b/drivers/mtd/nand/raw/sunxi_nand_spl.c
+index a29a76c5..6de0b0a3 100644
+--- a/drivers/mtd/nand/raw/sunxi_nand_spl.c
++++ b/drivers/mtd/nand/raw/sunxi_nand_spl.c
+@@ -208,7 +208,7 @@ static void nand_apply_config(const struct nfc_config *conf)
+ 
+ 	val = readl(SUNXI_NFC_BASE + NFC_CTL);
+ 	val &= ~NFC_CTL_PAGE_SIZE_MASK;
+-	writel(val | NFC_CTL_RAM_METHOD | NFC_CTL_PAGE_SIZE(conf->page_size),
++	writel(val | NFC_CTL_PAGE_SIZE(conf->page_size),
+ 	       SUNXI_NFC_BASE + NFC_CTL);
+ 	writel(conf->ecc_size, SUNXI_NFC_BASE + NFC_CNT);
+ 	writel(conf->page_size, SUNXI_NFC_BASE + NFC_SPARE_AREA);


### PR DESCRIPTION
This fix is provided by mainline U-Boot since v2022.10. For any details refer to:
https://github.com/u-boot/u-boot/commit/5fd30ed78539e11c2c155001a88f483441a96ebd

fixes #4401

# Tested:

- [x] Current Armbian build includes the patch with success
- [x] Has been tested on a Cubietruck board

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (s. U-Boot mainline reference above)
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
