### PR TITLE
fix - improve display alert for installing basic packages on host to …

### DIFF
--- a/lib/functions/host/basic-deps.sh
+++ b/lib/functions/host/basic-deps.sh
@@ -22,7 +22,7 @@ prepare_host_basic() {
 	done
 
 	if [[ -n $install_pack ]]; then
-		display_alert "Installing basic packages" "$install_pack"
+		display_alert "Updating and installing basic packages on host" "$install_pack"
 		sudo bash -c "apt-get -qq update && apt-get install -qq -y --no-install-recommends $install_pack"
 	fi
 


### PR DESCRIPTION
…indicate the installation occurs on host not in container.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Jira reference number [AR-9999]

# How Has This Been Tested?

removed uuid package, ran 

`./compile.sh docker-shell RELEASE=jammy BOARD=rockpro64 BRANCH=edge`

output was

```
[ .... ] Updating and installing basic packages on host [ uuid uuid-runtime  ]
Selecting previously unselected package uuid.
(Reading database ... 391502 files and directories currently installed.)
Preparing to unpack .../uuid_1.6.2-1.5build7_amd64.deb ...
Unpacking uuid (1.6.2-1.5build7) ...
Setting up uuid (1.6.2-1.5build7) ...
Processing triggers for man-db (2.9.1-1) .
```


# Checklist:

- [x] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
