### PR TITLE
Enable serial console on RISCV UEFI

### DIFF
--- a/config/boards/uefi-riscv64.conf
+++ b/config/boards/uefi-riscv64.conf
@@ -2,3 +2,4 @@
 export BOARD_NAME="UEFI riscv64"
 export BOARDFAMILY="uefi-riscv64"
 export KERNEL_TARGET="current,edge"
+export SERIALCON="ttyS0"


### PR DESCRIPTION
# Description

Enabling serial console so we can see it & login on console.