### PR TITLE
Add UBOOT_ONLY config property to the default build procedure

### DIFF
--- a/lib/functions/main/config-prepare.sh
+++ b/lib/functions/main/config-prepare.sh
@@ -84,6 +84,11 @@ function prepare_and_config_main_build_single() {
 
 	fi
 
+	if [[ $UBOOT_ONLY == yes ]]; then
+		# UBOOT_ONLY implies KERNEL_ONLY=yes to make subsequent config validation happy
+		KERNEL_ONLY=yes
+	fi
+
 	# if KERNEL_ONLY, KERNEL_CONFIGURE, BOARD, BRANCH or RELEASE are not set, display selection menu
 
 	interactive_config_ask_kernel

--- a/lib/functions/main/default-build.sh
+++ b/lib/functions/main/default-build.sh
@@ -56,81 +56,91 @@ do_default() {
 		fi
 	}
 
-	# Compile kernel if packed .deb does not exist or use the one from repository
-	if [[ ! -f ${DEB_STORAGE}/${CHOSEN_KERNEL}_${REVISION}_${ARCH}.deb ]]; then
+	if [[ $UBOOT_ONLY == yes ]]; then
 
-		KDEB_CHANGELOG_DIST=$RELEASE
-		[[ -n $KERNELSOURCE ]] && [[ "${REPOSITORY_INSTALL}" != *kernel* ]] && compile_kernel
-
-	fi
-
-	# Compile armbian-config if packed .deb does not exist or use the one from repository
-	if [[ ! -f ${DEB_STORAGE}/armbian-config_${REVISION}_all.deb ]]; then
-
-		[[ "${REPOSITORY_INSTALL}" != *armbian-config* ]] && compile_armbian-config
-
-	fi
-
-	# Compile armbian-zsh if packed .deb does not exist or use the one from repository
-	if [[ ! -f ${DEB_STORAGE}/armbian-zsh_${REVISION}_all.deb ]]; then
-
-		[[ "${REPOSITORY_INSTALL}" != *armbian-zsh* ]] && compile_armbian-zsh
-
-	fi
-
-	# Compile plymouth-theme-armbian if packed .deb does not exist or use the one from repository
-	if [[ ! -f ${DEB_STORAGE}/plymouth-theme-armbian_${REVISION}_all.deb ]]; then
-
-		[[ "${REPOSITORY_INSTALL}" != *plymouth-theme-armbian* ]] && compile_plymouth-theme-armbian
-
-	fi
-
-	# Compile armbian-firmware if packed .deb does not exist or use the one from repository
-	if ! ls "${DEB_STORAGE}/armbian-firmware_${REVISION}_all.deb" 1> /dev/null 2>&1 || ! ls "${DEB_STORAGE}/armbian-firmware-full_${REVISION}_all.deb" 1> /dev/null 2>&1; then
-
-		if [[ "${REPOSITORY_INSTALL}" != *armbian-firmware* ]]; then
-			[[ "${INSTALL_ARMBIAN_FIRMWARE:-yes}" == "yes" ]] && { # Build firmware by default.
-				FULL=""
-				REPLACE="-full"
-				compile_firmware
-				FULL="-full"
-				REPLACE=""
-				compile_firmware
-			}
-
-		fi
-
-	fi
-
-	overlayfs_wrapper "cleanup"
-
-	# create board support package
-	[[ -n "${RELEASE}" && ! -f "${DEB_STORAGE}/${BSP_CLI_PACKAGE_FULLNAME}.deb" && "${REPOSITORY_INSTALL}" != *armbian-bsp-cli* ]] && create_board_package
-
-	# create desktop package
-	[[ -n "${RELEASE}" && "${DESKTOP_ENVIRONMENT}" && ! -f "${DEB_STORAGE}/$RELEASE/${CHOSEN_DESKTOP}_${REVISION}_all.deb" && "${REPOSITORY_INSTALL}" != *armbian-desktop* ]] && create_desktop_package
-	[[ -n "${RELEASE}" && "${DESKTOP_ENVIRONMENT}" && ! -f "${DEB_STORAGE}/${RELEASE}/${BSP_DESKTOP_PACKAGE_FULLNAME}.deb" && "${REPOSITORY_INSTALL}" != *armbian-bsp-desktop* ]] && create_bsp_desktop_package
-
-	# skip image creation if exists. useful for CI when making a lot of images
-	if [ "$IMAGE_PRESENT" == yes ] && ls "${FINALDEST}/${VENDOR}_${REVISION}_${BOARD^}_${RELEASE}_${BRANCH}_${VER/-$LINUXFAMILY/}${DESKTOP_ENVIRONMENT:+_$DESKTOP_ENVIRONMENT}"*.xz 1> /dev/null 2>&1; then
-		display_alert "Skipping image creation" "image already made - IMAGE_PRESENT is set" "wrn"
-		exit
-	fi
-
-	# build additional packages
-	[[ $EXTERNAL_NEW == compile ]] && chroot_build_packages
-
-	if [[ $KERNEL_ONLY != yes ]]; then
-
-		[[ $BSP_BUILD != yes ]] && debootstrap_ng
+		display_alert "U-Boot build done" "@host" "info"
+		display_alert "Target directory" "${DEB_STORAGE}/" "info"
+		display_alert "File name" "${CHOSEN_UBOOT}_${REVISION}_${ARCH}.deb" "info"
 
 	else
 
-		display_alert "Kernel build done" "@host" "info"
-		display_alert "Target directory" "${DEB_STORAGE}/" "info"
-		display_alert "File name" "${CHOSEN_KERNEL}_${REVISION}_${ARCH}.deb" "info"
+		# Compile kernel if packed .deb does not exist or use the one from repository
+		if [[ ! -f ${DEB_STORAGE}/${CHOSEN_KERNEL}_${REVISION}_${ARCH}.deb ]]; then
 
-	fi
+			KDEB_CHANGELOG_DIST=$RELEASE
+			[[ -n $KERNELSOURCE ]] && [[ "${REPOSITORY_INSTALL}" != *kernel* ]] && compile_kernel
+
+		fi
+
+		# Compile armbian-config if packed .deb does not exist or use the one from repository
+		if [[ ! -f ${DEB_STORAGE}/armbian-config_${REVISION}_all.deb ]]; then
+
+			[[ "${REPOSITORY_INSTALL}" != *armbian-config* ]] && compile_armbian-config
+
+		fi
+
+		# Compile armbian-zsh if packed .deb does not exist or use the one from repository
+		if [[ ! -f ${DEB_STORAGE}/armbian-zsh_${REVISION}_all.deb ]]; then
+
+			[[ "${REPOSITORY_INSTALL}" != *armbian-zsh* ]] && compile_armbian-zsh
+
+		fi
+
+		# Compile plymouth-theme-armbian if packed .deb does not exist or use the one from repository
+		if [[ ! -f ${DEB_STORAGE}/plymouth-theme-armbian_${REVISION}_all.deb ]]; then
+
+			[[ "${REPOSITORY_INSTALL}" != *plymouth-theme-armbian* ]] && compile_plymouth-theme-armbian
+
+		fi
+
+		# Compile armbian-firmware if packed .deb does not exist or use the one from repository
+		if ! ls "${DEB_STORAGE}/armbian-firmware_${REVISION}_all.deb" 1> /dev/null 2>&1 || ! ls "${DEB_STORAGE}/armbian-firmware-full_${REVISION}_all.deb" 1> /dev/null 2>&1; then
+
+			if [[ "${REPOSITORY_INSTALL}" != *armbian-firmware* ]]; then
+				[[ "${INSTALL_ARMBIAN_FIRMWARE:-yes}" == "yes" ]] && { # Build firmware by default.
+					FULL=""
+					REPLACE="-full"
+					compile_firmware
+					FULL="-full"
+					REPLACE=""
+					compile_firmware
+				}
+
+			fi
+
+		fi
+
+		overlayfs_wrapper "cleanup"
+
+		# create board support package
+		[[ -n "${RELEASE}" && ! -f "${DEB_STORAGE}/${BSP_CLI_PACKAGE_FULLNAME}.deb" && "${REPOSITORY_INSTALL}" != *armbian-bsp-cli* ]] && create_board_package
+
+		# create desktop package
+		[[ -n "${RELEASE}" && "${DESKTOP_ENVIRONMENT}" && ! -f "${DEB_STORAGE}/$RELEASE/${CHOSEN_DESKTOP}_${REVISION}_all.deb" && "${REPOSITORY_INSTALL}" != *armbian-desktop* ]] && create_desktop_package
+		[[ -n "${RELEASE}" && "${DESKTOP_ENVIRONMENT}" && ! -f "${DEB_STORAGE}/${RELEASE}/${BSP_DESKTOP_PACKAGE_FULLNAME}.deb" && "${REPOSITORY_INSTALL}" != *armbian-bsp-desktop* ]] && create_bsp_desktop_package
+
+		# skip image creation if exists. useful for CI when making a lot of images
+		if [ "$IMAGE_PRESENT" == yes ] && ls "${FINALDEST}/${VENDOR}_${REVISION}_${BOARD^}_${RELEASE}_${BRANCH}_${VER/-$LINUXFAMILY/}${DESKTOP_ENVIRONMENT:+_$DESKTOP_ENVIRONMENT}"*.xz 1> /dev/null 2>&1; then
+			display_alert "Skipping image creation" "image already made - IMAGE_PRESENT is set" "wrn"
+			exit
+		fi
+
+		# build additional packages
+		[[ $EXTERNAL_NEW == compile ]] && chroot_build_packages
+
+		if [[ $KERNEL_ONLY != yes ]]; then
+
+			[[ $BSP_BUILD != yes ]] && debootstrap_ng
+
+		else
+
+			display_alert "Kernel build done" "@host" "info"
+			display_alert "Target directory" "${DEB_STORAGE}/" "info"
+			display_alert "File name" "${CHOSEN_KERNEL}_${REVISION}_${ARCH}.deb" "info"
+
+		fi
+
+	fi # end of else UBOOT_ONLY
 
 	call_extension_method "run_after_build" << 'RUN_AFTER_BUILD'
 *hook for function to run after build, i.e. to change owner of `$SRC`*
@@ -148,6 +158,7 @@ RUN_AFTER_BUILD
 $([[ -n $RELEASE ]] && echo "RELEASE=${RELEASE} ")\
 $([[ -n $BUILD_MINIMAL ]] && echo "BUILD_MINIMAL=${BUILD_MINIMAL} ")\
 $([[ -n $BUILD_DESKTOP ]] && echo "BUILD_DESKTOP=${BUILD_DESKTOP} ")\
+$([[ -n $UBOOT_ONLY ]] && echo "UBOOT_ONLY=${UBOOT_ONLY} ")\
 $([[ -n $KERNEL_ONLY ]] && echo "KERNEL_ONLY=${KERNEL_ONLY} ")\
 $([[ -n $KERNEL_CONFIGURE ]] && echo "KERNEL_CONFIGURE=${KERNEL_CONFIGURE} ")\
 $([[ -n $DESKTOP_ENVIRONMENT ]] && echo "DESKTOP_ENVIRONMENT=${DESKTOP_ENVIRONMENT} ")\


### PR DESCRIPTION
This config simplifies the U-Boot build only scenario. If this switch is set, then KERNEL_ONLY is implied to "yes". The U-Boot only build also ensures proper host prepare and any other validation, the default build procedure performs.

The motivation is to simplify UBOOT_ONLY building by just one compile parameter / switch, but keeping the default
dependent compile procedures like e.g. host compare and other pre-config validations as is.
This makes it also useful for CICD compile configurations.

# Changes

- `lib/functions/main/config-prepare.sh`:
  - imply to set KERNEL_ONLY=yes, if UBOOT_ONLY is set "yes"
- `lib/functions/main/default-build.sh`:
  - changed `do_default()`:
    - added appropriate`if {U-Boot compiling} else {Kernel and other compiling - original unchanged code} fi`
      > __Note__ for the code review: The diff of this new if / else branch in `do_default()` is looking a bit irritating, since it does not reflect that the code in the new `else` branch was not touched at all rather than just indented by another `tab` character.

Closes issue #4421

# Test

- [x] Tested - see  log of bash terminal output (cut in the middle to shorten for the relevant here):
```shell
user@HOST:~/Projects/Armbian/build$ ./compile.sh BOARD=cubietruck BRANCH=current RELEASE=focal BUILD_MINIMAL=yes BUILD_DESKTOP=no UBOOT_ONLY=yes KERNEL_CONFIGURE=no COMPRESS_OUTPUTIMAGE=sha,gpg,7z SYNC_CLOCK=no
[ warn ] This script requires root privileges, trying to use sudo 
[ o.k. ] Using config file [ /home/mhoffrog/Projects/Armbian/build/userpatches/config-example.conf ]
[ o.k. ] Command line: setting BOARD to [ cubietruck ]
[ o.k. ] Command line: setting BRANCH to [ current ]
[ o.k. ] Command line: setting RELEASE to [ focal ]
[ o.k. ] Command line: setting BUILD_MINIMAL to [ yes ]
[ o.k. ] Command line: setting BUILD_DESKTOP to [ no ]
[ o.k. ] Command line: setting UBOOT_ONLY to [ yes ]
[ o.k. ] Command line: setting KERNEL_CONFIGURE to [ no ]
[ o.k. ] Command line: setting COMPRESS_OUTPUTIMAGE to [ sha,gpg,7z ]
[ o.k. ] Command line: setting SYNC_CLOCK to [ no ]
[ .... ] Extension being added [ sunxi-tools :: added by functions/cli/cli-entrypoint.sh:105 -> functions/main/config-prepare.sh:140 -> functions/configuration/main-config.sh:174 -> config/sources/families/sun7i.conf:1 -> config/sources/families/include/sunxi_common.inc:1 ]                                                                                                                    
[ o.k. ] Extension manager [ processed 3 Extension Methods calls and 3 Extension Method implementations ]
[ o.k. ] Using user configuration override [ /home/mhoffrog/Projects/Armbian/build/userpatches/lib.config ]
[ o.k. ] Preparing [ host ]
[ o.k. ] Build host OS release [ focal ]
[ .... ] Installing build dependencies 
[ o.k. ] Checking for external GCC compilers 
[ o.k. ] Downloading sources 
[ o.k. ] Checking git sources [ u-boot v2022.07 ]
[ .... ]  Cleaning ....  [ 93 files ]
[ o.k. ] Checking git sources [ linux-mainline/5.15 git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.gitorigin/linux-5.15.y ]                                                                                                                      
[ .... ] Switch v5.15.77 = da3267ca3045f6958b56cbd9d185b68f7e14216d 
[ o.k. ] Checking git sources [ sunxi-tools master ]
[ .... ] Up to date 
[ o.k. ] Cleaning /home/mhoffrog/Projects/Armbian/build/output/debs for [ cubietruck current ]
[ o.k. ] Cleaning [ u-boot/v2022.07 ]
[ o.k. ] Compiling u-boot [ 2022.07 ]
[ o.k. ] Compiler version [ arm-none-linux-gnueabihf-gcc 9.2.1 ]
[ .... ] Checking out to clean sources 
[ o.k. ] Cleaning [ u-boot/v2022.07 ]
[ o.k. ] Started patching process for [ u-boot sunxi-cubietruck-current ]
[ o.k. ] Looking for user patches in [ userpatches/u-boot/u-boot-sunxi ]
[ o.k. ] * [l][c] 0000-sunxi-allwinner-a10-spi-driver.patch 
[ o.k. ] * [l][c] 0001-add-orange-pi-3-lts-support.patch 
[ o.k. ] * [l][c] Bananapro-01-add-hdmi-de-reg_ahci_5v.patch 
[ o.k. ] * [l][c] Bananapro-02-add-AXP209-regulators.patch 
[ o.k. ] * [l][c] Merrii_Hummingbird_A20.patch 
[ o.k. ] * [l][c] add-a20-optional-eMMC.patch 
[ o.k. ] * [l][c] add-a64-olinuxino-emmc-support.patch 
[ o.k. ] * [l][c] add-a64-olinuxino-spl-spi.patch 
[ o.k. ] * [l][c] add-awsom-defconfig.patch 
[ o.k. ] * [l][c] add-emmc_support_to_neo1_and_2.patch 
[ o.k. ] * [l][c] add-h616-THS-workaround.patch 
[ o.k. ] * [l][c] add-nanopi-air-emmc.patch 
[ o.k. ] * [l][c] add-nanopi-duo.patch 
[ o.k. ] * [l][c] add-nanopi-m1-plus2-emmc.patch 
[ o.k. ] * [l][c] add-nanopi-neo-core.patch 
[ o.k. ] * [l][c] add-orangepi-plus2-emmc.patch 
[ o.k. ] * [l][c] add-orangepi-zero-plus-pxe-support.patch 
[ o.k. ] * [l][c] add-orangepi-zero-usb-boot-support.patch 
[ o.k. ] * [l][c] add-orangepi-zeroplus2_h3.patch 
[ o.k. ] * [l][c] add-sunvell-r69.patch 
[ o.k. ] * [l][c] add-xx-boot-auto-dt-select-neo2.patch 
[ o.k. ] * [l][c] add-xx-nanopi-k1-plus-emmc.patch 
[ o.k. ] * [l][c] add-xx-nanopineocore2.patch 
[ o.k. ] * [l][c] add-zeropi.patch 
[ o.k. ] * [l][c] adjust-default-dram-clockspeeds.patch 
[ o.k. ] * [l][c] adjust-small-boards-cpufreq.patch 
[ o.k. ] * [l][c] enable-autoboot-keyed.patch 
[ o.k. ] * [l][c] enable-ethernet-orangepiprime.patch 
[ o.k. ] * [l][c] enable-r_pio-gpio-access-h3-h5.patch 
[ o.k. ] * [l][c] fdt-setprop-fix-unaligned-access.patch 
[ o.k. ] * [l][c] fix-sunxi-nand-spl.patch 
[ o.k. ] * [l][c] fix-usb1-vbus-opiwin.patch 
[ o.k. ] * [l][c] h3-Fix-PLL1-setup-to-never-use-dividers.patch 
[ o.k. ] * [l][c] h3-enable-power-led.patch 
[ o.k. ] * [l][c] h3-set-safe-axi_apb-clock-dividers.patch 
[ o.k. ] * [l][c] lower-default-DRAM-freq-A64-H5.patch 
[ o.k. ] * [l][c] pinebook-add-rare-panel-support.patch 
[ o.k. ] * [l][c] sun8i-set-machid.patch 
[ o.k. ] * [l][c] sunxi-boot-splash.patch 
[ o.k. ] * [l][c] sunxi_H616_GPU_enable_hack.patch 
[ o.k. ] * [l][c] xxx-disable-de2-to-improve-edid-detection.patch 
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o
  YACC    scripts/kconfig/zconf.tab.c
...
  CAT     u-boot-dtb.bin
  COPY    u-boot.dtb
  COPY    u-boot.bin
  MKIMAGE u-boot.img
  MKIMAGE u-boot-dtb.img
  BINMAN  all
[ o.k. ] Building deb [ linux-u-boot-current-cubietruck_22.11.0-trunk_armhf.deb ]
[ o.k. ] U-Boot build done [ @host ]
[ o.k. ] Target directory [ /home/mhoffrog/Projects/Armbian/build/output/debs/ ]
[ o.k. ] File name [ linux-u-boot-current-cubietruck_22.11.0-trunk_armhf.deb ]
[ o.k. ] Runtime [ 0 min ]
[ o.k. ] Repeat Build Options [ ./compile.sh  BOARD=cubietruck BRANCH=current RELEASE=focal BUILD_MINIMAL=yes BUILD_DESKTOP=no UBOOT_ONLY=yes KERNEL_ONLY=yes KERNEL_CONFIGURE=no COMPRESS_OUTPUTIMAGE=sha,gpg,7z  ]                                                
user@HOST:~/Projects/Armbian/build$
```
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I did create pull request https://github.com/armbian/documentation/pull/279 for the appropriate Armbian doc update
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
