### PR TITLE
AR-1398: Fix wrong error message when missing fs tools

### DIFF
--- a/packages/bsp/common/usr/sbin/armbian-install
+++ b/packages/bsp/common/usr/sbin/armbian-install
@@ -541,6 +541,12 @@ format_emmc()
 		# (convert to sectors for partitioning)
 		DEFAULT_BOOTSIZE_SECTORS=$(((${DEFAULT_BOOTSIZE} * 1024 * 1024) / 512))
 
+		# check if the filesystem tools are actually installed
+		if ! command -v mkfs.${eMMCFilesystemChoosen} >/dev/null 2>&1; then
+			echo "Error: Filesystem tools for ${eMMCFilesystemChoosen} not installed, exiting"
+			exit 9
+		fi
+
 		# check whether swap is currently defined and a new swap partition is needed
 		grep -q swap /etc/fstab
 		case $? in

--- a/packages/bsp/common/usr/sbin/nand-sata-install
+++ b/packages/bsp/common/usr/sbin/nand-sata-install
@@ -497,6 +497,12 @@ format_emmc()
 		# (convert to sectors for partitioning)
 		DEFAULT_BOOTSIZE_SECTORS=$(((${DEFAULT_BOOTSIZE} * 1024 * 1024) / 512))
 
+		# check if the filesystem tools are actually installed
+		if ! command -v mkfs.${eMMCFilesystemChoosen} >/dev/null 2>&1; then
+			echo "Error: Filesystem tools for ${eMMCFilesystemChoosen} not installed, exiting"
+			exit 9
+		fi
+
 		# check whether swap is currently defined and a new swap partition is needed
 		grep -q swap /etc/fstab
 		case $? in


### PR DESCRIPTION
# Description

This fixes a wrong error message from `nand-sata-install` when filesystem tools are missing. 

Prior to this change, the script doesn't notice that the tools are missing and tries to actually check the target FS size.  Since that size is a blank string (because the target FS was never created), it gives a wrong error message saying that the FS is too small.

Jira reference number [AR-1398]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Tested on a nightly build with Orange PI 3 LTS

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1398]: https://armbian.atlassian.net/browse/AR-1398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ