### PR TITLE
Minor fixes and update to rk322x/rk3288 patchset for edge kernel

### DIFF
--- a/patch/kernel/archive/rk322x-5.15/012-linux-1000-rockchip-wip.patch
+++ b/patch/kernel/archive/rk322x-5.15/012-linux-1000-rockchip-wip.patch
@@ -780,3 +780,32 @@ index 272ae5722..cec178404 100644
 -- 
 2.25.1
 
+From 4dbf4c09e78cd79c61dd7ecf134829b3c8b4695b Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Sun, 6 Nov 2022 17:52:27 +0000
+Subject: [PATCH] add reset properties
+
+---
+ arch/arm/boot/dts/rk322x.dtsi | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/arch/arm/boot/dts/rk322x.dtsi b/arch/arm/boot/dts/rk322x.dtsi
+index c9d71a776587..0b6516c6a476 100644
+--- a/arch/arm/boot/dts/rk322x.dtsi
++++ b/arch/arm/boot/dts/rk322x.dtsi
+@@ -783,6 +783,12 @@ vdec: video-codec@20030000 {
+ 		clocks = <&cru ACLK_RKVDEC>, <&cru HCLK_RKVDEC>,
+ 			 <&cru SCLK_VDEC_CABAC>, <&cru SCLK_VDEC_CORE>;
+ 		clock-names = "axi", "ahb", "cabac", "core";
++		resets = <&cru SRST_RKVDEC_H>, <&cru SRST_RKVDEC_A>,
++		         <&cru SRST_RKVDEC_CORE>, <&cru SRST_RKVDEC_CABAC>,
++		         <&cru SRST_RKVDEC_NOC_A>, <&cru SRST_RKVDEC_NOC_H>;
++		reset-names = "video_h", "video_a",
++			       "video_core", "video_cabac",
++			       "niu_a", "niu_h";
+ 		assigned-clocks = <&cru SCLK_VDEC_CABAC>, <&cru SCLK_VDEC_CORE>;
+ 		assigned-clock-rates = <300000000>, <300000000>;
+ 		iommus = <&vdec_mmu>;
+-- 
+2.34.1
+

--- a/patch/kernel/archive/rk322x-5.15/02-linux-0006-add-iep-node-for-rk322x.patch
+++ b/patch/kernel/archive/rk322x-5.15/02-linux-0006-add-iep-node-for-rk322x.patch
@@ -11,7 +11,7 @@ diff --git a/arch/arm/boot/dts/rk322x.dtsi b/arch/arm/boot/dts/rk322x.dtsi
 index 0ae753c1d..271e7835f 100644
 --- a/arch/arm/boot/dts/rk322x.dtsi
 +++ b/arch/arm/boot/dts/rk322x.dtsi
-@@ -834,6 +834,17 @@ rga: rga@20060000 {
+@@ -834,6 +834,20 @@ rga: rga@20060000 {
  		reset-names = "core", "axi", "ahb";
  	};
  
@@ -21,6 +21,9 @@ index 0ae753c1d..271e7835f 100644
 +		interrupts = <GIC_SPI 31 IRQ_TYPE_LEVEL_HIGH>;
 +		clocks = <&cru ACLK_IEP>, <&cru HCLK_IEP>;
 +		clock-names = "axi", "ahb";
++		resets = <&cru SRST_IEP_A>,
++		         <&cru SRST_IEP_H>;
++		reset-names = "axi", "ahb";
 +		iommus = <&iep_mmu>;
 +		power-domains = <&power RK3228_PD_VIO>;
 +		status = "disabled";

--- a/patch/kernel/archive/rk322x-5.19/01-linux-2000-v4l2-wip-rkvdec-hevc.patch
+++ b/patch/kernel/archive/rk322x-5.19/01-linux-2000-v4l2-wip-rkvdec-hevc.patch
@@ -2508,7 +2508,7 @@ index 000000000000..c3cceba837c2
 +		writel_relaxed(refer_addr | reg,
 +			       rkvdec->regs + RKVDEC_REG_H264_BASE_REFER(i));
 +
-+		reg = RKVDEC_POC_REFER(i < sl_params->num_active_dpb_entries ? dpb[i].pic_order_cnt[0] : 0);
++		reg = RKVDEC_POC_REFER(i < sl_params->num_active_dpb_entries ? dpb[i].pic_order_cnt_val : 0);
 +		writel_relaxed(reg,
 +			       rkvdec->regs + RKVDEC_REG_H264_POC_REFER0(i));
 +	}
@@ -2857,7 +2857,7 @@ index c3cceba837c2..5c341b5fa534 100644
  		writel_relaxed(refer_addr | reg,
  			       rkvdec->regs + RKVDEC_REG_H264_BASE_REFER(i));
  
--		reg = RKVDEC_POC_REFER(i < sl_params->num_active_dpb_entries ? dpb[i].pic_order_cnt[0] : 0);
+-		reg = RKVDEC_POC_REFER(i < sl_params->num_active_dpb_entries ? dpb[i].pic_order_cnt_val : 0);
 +		reg = RKVDEC_POC_REFER(i < decode_params->num_active_dpb_entries ? dpb[i].pic_order_cnt_val : 0);
  		writel_relaxed(reg,
  			       rkvdec->regs + RKVDEC_REG_H264_POC_REFER0(i));

--- a/patch/kernel/archive/rk322x-5.19/012-linux-1000-rockchip-wip.patch
+++ b/patch/kernel/archive/rk322x-5.19/012-linux-1000-rockchip-wip.patch
@@ -780,3 +780,32 @@ index 272ae5722..cec178404 100644
 -- 
 2.25.1
 
+From 4dbf4c09e78cd79c61dd7ecf134829b3c8b4695b Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Sun, 6 Nov 2022 17:52:27 +0000
+Subject: [PATCH] add reset properties
+
+---
+ arch/arm/boot/dts/rk322x.dtsi | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/arch/arm/boot/dts/rk322x.dtsi b/arch/arm/boot/dts/rk322x.dtsi
+index c9d71a776587..0b6516c6a476 100644
+--- a/arch/arm/boot/dts/rk322x.dtsi
++++ b/arch/arm/boot/dts/rk322x.dtsi
+@@ -783,6 +783,12 @@ vdec: video-codec@20030000 {
+ 		clocks = <&cru ACLK_RKVDEC>, <&cru HCLK_RKVDEC>,
+ 			 <&cru SCLK_VDEC_CABAC>, <&cru SCLK_VDEC_CORE>;
+ 		clock-names = "axi", "ahb", "cabac", "core";
++		resets = <&cru SRST_RKVDEC_H>, <&cru SRST_RKVDEC_A>,
++		         <&cru SRST_RKVDEC_CORE>, <&cru SRST_RKVDEC_CABAC>,
++		         <&cru SRST_RKVDEC_NOC_A>, <&cru SRST_RKVDEC_NOC_H>;
++		reset-names = "video_h", "video_a",
++			       "video_core", "video_cabac",
++			       "niu_a", "niu_h";
+ 		assigned-clocks = <&cru SCLK_VDEC_CABAC>, <&cru SCLK_VDEC_CORE>;
+ 		assigned-clock-rates = <300000000>, <300000000>;
+ 		iommus = <&vdec_mmu>;
+-- 
+2.34.1
+

--- a/patch/kernel/archive/rk322x-5.19/02-linux-0006-add-iep-node-for-rk322x.patch
+++ b/patch/kernel/archive/rk322x-5.19/02-linux-0006-add-iep-node-for-rk322x.patch
@@ -11,7 +11,7 @@ diff --git a/arch/arm/boot/dts/rk322x.dtsi b/arch/arm/boot/dts/rk322x.dtsi
 index 0ae753c1d..271e7835f 100644
 --- a/arch/arm/boot/dts/rk322x.dtsi
 +++ b/arch/arm/boot/dts/rk322x.dtsi
-@@ -834,6 +834,17 @@ rga: rga@20060000 {
+@@ -834,6 +834,20 @@ rga: rga@20060000 {
  		reset-names = "core", "axi", "ahb";
  	};
  
@@ -21,6 +21,9 @@ index 0ae753c1d..271e7835f 100644
 +		interrupts = <GIC_SPI 31 IRQ_TYPE_LEVEL_HIGH>;
 +		clocks = <&cru ACLK_IEP>, <&cru HCLK_IEP>;
 +		clock-names = "axi", "ahb";
++		resets = <&cru SRST_IEP_A>,
++		         <&cru SRST_IEP_H>;
++		reset-names = "axi", "ahb";
 +		iommus = <&iep_mmu>;
 +		power-domains = <&power RK3228_PD_VIO>;
 +		status = "disabled";

--- a/patch/kernel/archive/rockchip-5.19/01-linux-1000-drm-rockchip.patch
+++ b/patch/kernel/archive/rockchip-5.19/01-linux-1000-drm-rockchip.patch
@@ -1951,6 +1951,71 @@ index 306910a3a0d3..1db62a3a4c67 100644
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sun, 19 Jul 2020 16:35:11 +0000
+Subject: [PATCH] HACK: dts: rockchip: do not use vopl for hdmi
+
+---
+ arch/arm/boot/dts/rk3288.dtsi            | 9 ---------
+ arch/arm64/boot/dts/rockchip/rk3399.dtsi | 9 ---------
+ 2 files changed, 18 deletions(-)
+
+diff --git a/arch/arm/boot/dts/rk3288.dtsi b/arch/arm/boot/dts/rk3288.dtsi
+index d1ae42757242..7b2cde230b87 100644
+--- a/arch/arm/boot/dts/rk3288.dtsi
++++ b/arch/arm/boot/dts/rk3288.dtsi
+@@ -1083,11 +1083,6 @@ vopl_out: port {
+ 			#address-cells = <1>;
+ 			#size-cells = <0>;
+ 
+-			vopl_out_hdmi: endpoint@0 {
+-				reg = <0>;
+-				remote-endpoint = <&hdmi_in_vopl>;
+-			};
+-
+ 			vopl_out_edp: endpoint@1 {
+ 				reg = <1>;
+ 				remote-endpoint = <&edp_in_vopl>;
+@@ -1227,10 +1222,6 @@ hdmi_in_vopb: endpoint@0 {
+ 					reg = <0>;
+ 					remote-endpoint = <&vopb_out_hdmi>;
+ 				};
+-				hdmi_in_vopl: endpoint@1 {
+-					reg = <1>;
+-					remote-endpoint = <&vopl_out_hdmi>;
+-				};
+ 			};
+ 		};
+ 	};
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399.dtsi b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
+index fbd0346624e6..b0620c45820c 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
+@@ -1725,11 +1725,6 @@ vopl_out_edp: endpoint@1 {
+ 				remote-endpoint = <&edp_in_vopl>;
+ 			};
+ 
+-			vopl_out_hdmi: endpoint@2 {
+-				reg = <2>;
+-				remote-endpoint = <&hdmi_in_vopl>;
+-			};
+-
+ 			vopl_out_mipi1: endpoint@3 {
+ 				reg = <3>;
+ 				remote-endpoint = <&mipi1_in_vopl>;
+@@ -1923,10 +1918,6 @@ hdmi_in_vopb: endpoint@0 {
+ 					reg = <0>;
+ 					remote-endpoint = <&vopb_out_hdmi>;
+ 				};
+-				hdmi_in_vopl: endpoint@1 {
+-					reg = <1>;
+-					remote-endpoint = <&vopl_out_hdmi>;
+-				};
+ 			};
+ 		};
+ 	};
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
 Date: Fri, 20 Dec 2019 08:12:43 +0000
 Subject: [PATCH] WIP: drm/bridge: dw-hdmi: limit mode and bus format to
  max_tmds_clock
@@ -3599,60 +3664,3 @@ index abee41ae02d0..544eedb5d671 100644
  	void *priv;
  	u32 capabilities;
 
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Alex Bee <knaerzche@gmail.com>
-Date: Fri, 22 Oct 2021 11:17:30 +0200
-Subject: [PATCH] WIP: drm/bridge: synopsys: Fix CEC not working after
- power-cyclying
-
-This fixes standby -> power-on on Rockchip platform for, at least,
-RK3288/RK3328/RK3399 where CEC wasn't working after powering on again.
-It might differ for other phy implementations:
-The whole HPD-detection part shoud be reworked and we should in general
-avoid to rely in RX_SENSE phy status (at least for HDMI), since it differs
-depending on sink's implementation.
-
-Signed-off-by: Alex Bee <knaerzche@gmail.com>
----
- drivers/gpu/drm/bridge/synopsys/dw-hdmi.c | 17 +++++++++--------
- 1 file changed, 9 insertions(+), 8 deletions(-)
-
-diff --git a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
-index 428e057dd415..9f13f2aa87d1 100644
---- a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
-+++ b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
-@@ -3172,18 +3172,11 @@ static irqreturn_t dw_hdmi_irq(int irq, void *dev_id)
- 	 * ask the source to re-read the EDID.
- 	 */
- 	if (intr_stat &
--	    (HDMI_IH_PHY_STAT0_RX_SENSE | HDMI_IH_PHY_STAT0_HPD)) {
-+	    (HDMI_IH_PHY_STAT0_RX_SENSE | HDMI_IH_PHY_STAT0_HPD))
- 		dw_hdmi_setup_rx_sense(hdmi,
- 				       phy_stat & HDMI_PHY_HPD,
- 				       phy_stat & HDMI_PHY_RX_SENSE);
- 
--		if ((phy_stat & (HDMI_PHY_RX_SENSE | HDMI_PHY_HPD)) == 0) {
--			mutex_lock(&hdmi->cec_notifier_mutex);
--			cec_notifier_phys_addr_invalidate(hdmi->cec_notifier);
--			mutex_unlock(&hdmi->cec_notifier_mutex);
--		}
--	}
--
- 	if (intr_stat & HDMI_IH_PHY_STAT0_HPD) {
- 		enum drm_connector_status status = phy_int_pol & HDMI_PHY_HPD
- 						 ? connector_status_connected
-@@ -3197,6 +3190,14 @@ static irqreturn_t dw_hdmi_irq(int irq, void *dev_id)
- 			drm_helper_hpd_irq_event(hdmi->bridge.dev);
- 			drm_bridge_hpd_notify(&hdmi->bridge, status);
- 		}
-+
-+		if (status == connector_status_disconnected &&
-+		    (phy_stat & HDMI_PHY_RX_SENSE) &&
-+		    (phy_int_pol & HDMI_PHY_RX_SENSE)) {
-+			mutex_lock(&hdmi->cec_notifier_mutex);
-+			cec_notifier_phys_addr_invalidate(hdmi->cec_notifier);
-+			mutex_unlock(&hdmi->cec_notifier_mutex);
-+		}
- 	}
- 
- 	hdmi_writeb(hdmi, intr_stat, HDMI_IH_PHY_STAT0);

--- a/patch/kernel/archive/rockchip-5.19/01-linux-2000-v4l2-wip-rkvdec-hevc.patch
+++ b/patch/kernel/archive/rockchip-5.19/01-linux-2000-v4l2-wip-rkvdec-hevc.patch
@@ -2508,7 +2508,7 @@ index 000000000000..c3cceba837c2
 +		writel_relaxed(refer_addr | reg,
 +			       rkvdec->regs + RKVDEC_REG_H264_BASE_REFER(i));
 +
-+		reg = RKVDEC_POC_REFER(i < sl_params->num_active_dpb_entries ? dpb[i].pic_order_cnt[0] : 0);
++		reg = RKVDEC_POC_REFER(i < sl_params->num_active_dpb_entries ? dpb[i].pic_order_cnt_val : 0);
 +		writel_relaxed(reg,
 +			       rkvdec->regs + RKVDEC_REG_H264_POC_REFER0(i));
 +	}
@@ -2857,7 +2857,7 @@ index c3cceba837c2..5c341b5fa534 100644
  		writel_relaxed(refer_addr | reg,
  			       rkvdec->regs + RKVDEC_REG_H264_BASE_REFER(i));
  
--		reg = RKVDEC_POC_REFER(i < sl_params->num_active_dpb_entries ? dpb[i].pic_order_cnt[0] : 0);
+-		reg = RKVDEC_POC_REFER(i < sl_params->num_active_dpb_entries ? dpb[i].pic_order_cnt_val : 0);
 +		reg = RKVDEC_POC_REFER(i < decode_params->num_active_dpb_entries ? dpb[i].pic_order_cnt_val : 0);
  		writel_relaxed(reg,
  			       rkvdec->regs + RKVDEC_REG_H264_POC_REFER0(i));


### PR DESCRIPTION
# Description

Nothing fancy, just some fixes to remove unapplicable hunks and add some missing bits in the device trees for rk322x and rk3288 devices.

# How Has This Been Tested?

- [x] Built edge kernel debs and tested on live installation for rk322x and rk3288

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
