### PR TITLE
Add mtd-utils to all ARM distributions main packages

### DIFF
--- a/config/optional/architectures/arm64/_config/cli/_all_distributions/main/packages
+++ b/config/optional/architectures/arm64/_config/cli/_all_distributions/main/packages
@@ -1,3 +1,4 @@
 gpiod
 cpufrequtils
+mtd-utils
 nocache

--- a/config/optional/architectures/armhf/_config/cli/_all_distributions/main/packages
+++ b/config/optional/architectures/armhf/_config/cli/_all_distributions/main/packages
@@ -1,3 +1,4 @@
 gpiod
 cpufrequtils
+mtd-utils
 nocache


### PR DESCRIPTION
The mtd-utils package provides NAND and SPI
flash capabilities for mainline kernel /dev/mtdX devices.
This will help on board setup from SD card boot.

closes #4427

# Description

The mtd-utils package provides tools for flashing the boards NAND and/or SPI flash chips.
In the meanwhile most NAND and SPI chips are supported by mainline kernel MTD drivers.
Boards like Cubietruck or Odroid M1 can boot from NAND or SPI with mainline U-Boot.
The according flash chips can be flashed with the mtd-utils tools from the mainline kernel booted OS
after an initial Armbian SD card boot. This simplifies board setup or boards boot loader update to
enable booting from the on board soldered flash memory.

Refers to issue #4427.

# Test

This enhancement has been successfully tested on current master branch for the following build configurations:

- [x] Test 1: `BOARD=cubietruck BRANCH=current RELEASE=buster BUILD_MINIMAL=yes BUILD_DESKTOP=no KERNEL_ONLY=no KERNEL_CONFIGURE=no COMPRESS_OUTPUTIMAGE=sha,gpg,7z`
- [x] Test 2: `BOARD=cubietruck BRANCH=current RELEASE=bullseye BUILD_MINIMAL=yes BUILD_DESKTOP=no KERNEL_ONLY=no KERNEL_CONFIGURE=no COMPRESS_OUTPUTIMAGE=sha,gpg,7z`
- [x] Test 3: `BOARD=cubietruck BRANCH=current RELEASE=focal BUILD_MINIMAL=yes BUILD_DESKTOP=no KERNEL_ONLY=no KERNEL_CONFIGURE=no COMPRESS_OUTPUTIMAGE=sha,gpg,7z`

All builds did list the package `mtd-utils` in `output/debug/installed-packages-<RELEASE>-minimal.list`

# Checklist:

- [n/a] My code follows the style guidelines of this project
- [n/a] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [n/a] Any dependent changes have been merged and published in downstream modules