### PR TITLE
More updates for Radxa's Amlogic boards (`radxa-zero` and `radxa-zero2`)

### DIFF
--- a/config/boards/radxa-zero.conf
+++ b/config/boards/radxa-zero.conf
@@ -11,6 +11,6 @@ BOOT_LOGO="desktop"
 ASOUND_STATE="asound.state.radxa-zero"
 BOOT_FDT_FILE="amlogic/meson-g12a-radxa-zero.dtb"
 
-# Newer u-boot for the Zero; pure mainline.
+# Newer u-boot for the Zero
 BOOTBRANCH_BOARD="tag:v2022.10"
-BOOTPATCHDIR="v2022.10-NO-PATCHES-PURE-MAINLINE" # Pure mainline u-boot, no patches at all.
+BOOTPATCHDIR="v2022.10"

--- a/config/boards/radxa-zero2.csc
+++ b/config/boards/radxa-zero2.csc
@@ -7,3 +7,7 @@ FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
 ASOUND_STATE="asound.state.radxa-zero2"
 BOOT_FDT_FILE="amlogic/meson-g12b-radxa-zero2.dtb"
+
+# Newer u-boot for the Zero; Radxa's patches with new DT, Makefile and defconfig in v2022.10/board_radxa-zero2 dir
+BOOTBRANCH_BOARD="tag:v2022.10"
+BOOTPATCHDIR="v2022.10"

--- a/patch/kernel/archive/meson64-6.0/meson-g12a-pinctrl-add-missing-ir-options.patch
+++ b/patch/kernel/archive/meson64-6.0/meson-g12a-pinctrl-add-missing-ir-options.patch
@@ -1,0 +1,91 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yuntian Zhang <yt@radxa.com>
+Date: Mon, 25 Jul 2022 15:31:31 +0800
+Subject: [PATCH]  pinctrl: meson-g12a: add missing ir options
+
+Those pins are defined in S905Y2 and A311D reference manuals.
+
+Signed-off-by: Yuntian Zhang <yt@radxa.com>
+---
+ .../arm64/boot/dts/amlogic/meson-g12-common.dtsi | 16 ++++++++++++++++
+ drivers/pinctrl/meson/pinctrl-meson-g12a.c       |  9 +++++++++
+ 2 files changed, 25 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12-common.dtsi b/arch/arm64/boot/dts/amlogic/meson-g12-common.dtsi
+index 45947c1031..8bc032c38a 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-g12-common.dtsi
++++ b/arch/arm64/boot/dts/amlogic/meson-g12-common.dtsi
+@@ -562,6 +562,14 @@ mux {
+ 						};
+ 					};
+ 
++					remote_input_pins: remote-input {
++						mux {
++							groups = "remote_input";
++							function = "remote_input";
++							bias-disable;
++						};
++					};
++
+ 					mclk0_a_pins: mclk0-a {
+ 						mux {
+ 							groups = "mclk0_a";
+@@ -2000,6 +2008,14 @@ mux {
+ 							bias-disable;
+ 						};
+ 					};
++
++					remote_out_ao_pins: remote-out {
++						mux {
++							groups = "remote_ao_out";
++							function = "remote_ao_out";
++							bias-disable;
++						};
++					};
+ 				};
+ 			};
+ 
+diff --git a/drivers/pinctrl/meson/pinctrl-meson-g12a.c b/drivers/pinctrl/meson/pinctrl-meson-g12a.c
+index 5f2a6f9c96..bcf8b92d0c 100644
+--- a/drivers/pinctrl/meson/pinctrl-meson-g12a.c
++++ b/drivers/pinctrl/meson/pinctrl-meson-g12a.c
+@@ -215,6 +215,9 @@ static const unsigned int i2c3_sck_h_pins[]		= { GPIOH_1 };
+ static const unsigned int i2c3_sda_a_pins[]		= { GPIOA_14 };
+ static const unsigned int i2c3_sck_a_pins[]		= { GPIOA_15 };
+ 
++/* ir_in */
++static const unsigned int remote_input_pins[]	= { GPIOA_15 };
++
+ /* uart_a */
+ static const unsigned int uart_a_tx_pins[]		= { GPIOX_12 };
+ static const unsigned int uart_a_rx_pins[]		= { GPIOX_13 };
+@@ -744,6 +747,7 @@ static struct meson_pmx_group meson_g12a_periphs_groups[] = {
+ 	/* bank GPIOA */
+ 	GROUP(i2c3_sda_a,		2),
+ 	GROUP(i2c3_sck_a,		2),
++	GROUP(remote_input,		1),
+ 	GROUP(pdm_din0_a,		1),
+ 	GROUP(pdm_din1_a,		1),
+ 	GROUP(pdm_din2_a,		1),
+@@ -1029,6 +1033,10 @@ static const char * const i2c3_groups[] = {
+ 	"i2c3_sda_a", "i2c3_sck_a",
+ };
+ 
++static const char * const remote_input_groups[] = {
++	"remote_input",
++};
++
+ static const char * const uart_a_groups[] = {
+ 	"uart_a_tx", "uart_a_rx", "uart_a_cts", "uart_a_rts",
+ };
+@@ -1273,6 +1281,7 @@ static struct meson_pmx_func meson_g12a_periphs_functions[] = {
+ 	FUNCTION(i2c1),
+ 	FUNCTION(i2c2),
+ 	FUNCTION(i2c3),
++	FUNCTION(remote_input),
+ 	FUNCTION(uart_a),
+ 	FUNCTION(uart_b),
+ 	FUNCTION(uart_c),
+-- 
+2.37.1
+

--- a/patch/kernel/archive/meson64-6.0/meson-g12b-pinctrl-Add-missing-pinmux-for-pwm.patch
+++ b/patch/kernel/archive/meson64-6.0/meson-g12b-pinctrl-Add-missing-pinmux-for-pwm.patch
@@ -1,0 +1,125 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yuntian Zhang <yt@radxa.com>
+Date: Thu, 13 Jan 2022 21:34:10 +0800
+Subject: [PATCH] pinctrl: meson: Add several missing pinmux for pwm functions
+
+The following pin definitions are mentioned in A311D Quick
+Reference Manual and S922X Public Datasheet, but not in S905Y2
+Quick Reference Manual, so adding them to meson-g12b family.
+
+They are currently exposed in Radxa Zero 2's GPIO header.
+
+Signed-off-by: Yuntian Zhang <yt@radxa.com>
+---
+ arch/arm64/boot/dts/amlogic/meson-g12b.dtsi | 34 +++++++++++++++++++++
+ drivers/pinctrl/meson/pinctrl-meson-g12a.c  | 14 +++++++--
+ 2 files changed, 45 insertions(+), 3 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi b/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi
+index ee8fcae9f..d938f883c 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi
++++ b/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi
+@@ -139,3 +139,37 @@ map1 {
+ &mali {
+ 	dma-coherent;
+ };
++
++&periphs_pinctrl {
++	pwm_b_h_pins: pwm-b-h {
++		mux {
++			groups = "pwm_b_h";
++			function = "pwm_b";
++			bias-disable;
++		};
++	};
++
++	pwm_b_z_pins: pwm-b-z {
++		mux {
++			groups = "pwm_b_z";
++			function = "pwm_b";
++			bias-disable;
++		};
++	};
++
++	pwm_c_z_pins: pwm-c-z {
++		mux {
++			groups = "pwm_c_z";
++			function = "pwm_c";
++			bias-disable;
++		};
++	};
++
++	pwm_d_z_pins: pwm-d-z {
++		mux {
++			groups = "pwm_d_z";
++			function = "pwm_d";
++			bias-disable;
++		};
++	};
++};
+diff --git a/drivers/pinctrl/meson/pinctrl-meson-g12a.c b/drivers/pinctrl/meson/pinctrl-meson-g12a.c
+index d182a5759..5f2a6f9c9 100644
+--- a/drivers/pinctrl/meson/pinctrl-meson-g12a.c
++++ b/drivers/pinctrl/meson/pinctrl-meson-g12a.c
+@@ -267,17 +267,21 @@ static const unsigned int eth_act_led_pins[]		= { GPIOZ_15 };
+ static const unsigned int pwm_a_pins[]			= { GPIOX_6 };
+ 
+ /* pwm_b */
++static const unsigned int pwm_b_h_pins[]		= { GPIOH_7 };
+ static const unsigned int pwm_b_x7_pins[]		= { GPIOX_7 };
+ static const unsigned int pwm_b_x19_pins[]		= { GPIOX_19 };
++static const unsigned int pwm_b_z_pins[]		= { GPIOZ_0 };
+ 
+ /* pwm_c */
+ static const unsigned int pwm_c_c_pins[]		= { GPIOC_4 };
+ static const unsigned int pwm_c_x5_pins[]		= { GPIOX_5 };
+ static const unsigned int pwm_c_x8_pins[]		= { GPIOX_8 };
++static const unsigned int pwm_c_z_pins[]		= { GPIOZ_1 };
+ 
+ /* pwm_d */
+ static const unsigned int pwm_d_x3_pins[]		= { GPIOX_3 };
+ static const unsigned int pwm_d_x6_pins[]		= { GPIOX_6 };
++static const unsigned int pwm_d_z_pins[]		= { GPIOZ_2 };
+ 
+ /* pwm_e */
+ static const unsigned int pwm_e_pins[]			= { GPIOX_16 };
+@@ -590,6 +594,9 @@ static struct meson_pmx_group meson_g12a_periphs_groups[] = {
+ 	GROUP(bt565_a_din5,		2),
+ 	GROUP(bt565_a_din6,		2),
+ 	GROUP(bt565_a_din7,		2),
++	GROUP(pwm_b_z,			5),
++	GROUP(pwm_c_z,			5),
++	GROUP(pwm_d_z,			2),
+ 	GROUP(tsin_b_valid_z,		3),
+ 	GROUP(tsin_b_sop_z,		3),
+ 	GROUP(tsin_b_din0_z,		3),
+@@ -722,6 +729,7 @@ static struct meson_pmx_group meson_g12a_periphs_groups[] = {
+ 	GROUP(uart_c_rts,		2),
+ 	GROUP(iso7816_clk_h,		1),
+ 	GROUP(iso7816_data_h,		1),
++	GROUP(pwm_b_h,			5),
+ 	GROUP(pwm_f_h,			4),
+ 	GROUP(cec_ao_a_h,		4),
+ 	GROUP(cec_ao_b_h,		5),
+@@ -1057,15 +1065,15 @@ static const char * const pwm_a_groups[] = {
+ };
+ 
+ static const char * const pwm_b_groups[] = {
+-	"pwm_b_x7", "pwm_b_x19",
++	"pwm_b_h", "pwm_b_x7", "pwm_b_x19", "pwm_b_z",
+ };
+ 
+ static const char * const pwm_c_groups[] = {
+-	"pwm_c_c", "pwm_c_x5", "pwm_c_x8",
++	"pwm_c_c", "pwm_c_x5", "pwm_c_x8", "pwm_c_z",
+ };
+ 
+ static const char * const pwm_d_groups[] = {
+-	"pwm_d_x3", "pwm_d_x6",
++	"pwm_d_x3", "pwm_d_x6", "pwm_d_z",
+ };
+ 
+ static const char * const pwm_e_groups[] = {
+-- 
+2.36.1
+

--- a/patch/u-boot/v2022.10/board_radxa-zero2/0001-WIP-ARM-dts-add-support-for-Radxa-Zero2.patch
+++ b/patch/u-boot/v2022.10/board_radxa-zero2/0001-WIP-ARM-dts-add-support-for-Radxa-Zero2.patch
@@ -1,0 +1,625 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Christian Hewitt <christianshewitt@gmail.com>
+Date: Sat, 15 Jan 2022 06:17:23 +0000
+Subject: [PATCH] WIP: ARM: dts: add support for Radxa Zero2
+
+Import the initial dts (WIP) from chewitt/amlogic-5.16.y
+
+Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
+Signed-off-by: Yuntian Zhang <yt@radxa.com>
+---
+ arch/arm/dts/Makefile                         |   1 +
+ .../dts/meson-g12b-radxa-zero2-u-boot.dtsi    |   7 +
+ arch/arm/dts/meson-g12b-radxa-zero2.dts       | 574 ++++++++++++++++++
+ 3 files changed, 582 insertions(+)
+ create mode 100644 arch/arm/dts/meson-g12b-radxa-zero2-u-boot.dtsi
+ create mode 100644 arch/arm/dts/meson-g12b-radxa-zero2.dts
+
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index c752d2bd18..44241fafee 100644
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -194,6 +194,7 @@ dtb-$(CONFIG_ARCH_MESON) += \
+ 	meson-g12b-gsking-x.dtb \
+ 	meson-g12b-odroid-n2.dtb \
+ 	meson-g12b-odroid-n2-plus.dtb \
++	meson-g12b-radxa-zero2.dtb \
+ 	meson-sm1-bananapi-m5.dtb \
+ 	meson-sm1-khadas-vim3l.dtb \
+ 	meson-sm1-odroid-c4.dtb \
+diff --git a/arch/arm/dts/meson-g12b-radxa-zero2-u-boot.dtsi b/arch/arm/dts/meson-g12b-radxa-zero2-u-boot.dtsi
+new file mode 100644
+index 0000000000..236f2468dc
+--- /dev/null
++++ b/arch/arm/dts/meson-g12b-radxa-zero2-u-boot.dtsi
+@@ -0,0 +1,7 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2019 BayLibre, SAS.
++ * Author: Neil Armstrong <narmstrong@baylibre.com>
++ */
++
++#include "meson-g12-common-u-boot.dtsi"
+diff --git a/arch/arm/dts/meson-g12b-radxa-zero2.dts b/arch/arm/dts/meson-g12b-radxa-zero2.dts
+new file mode 100644
+index 0000000000..f0c9ef8592
+--- /dev/null
++++ b/arch/arm/dts/meson-g12b-radxa-zero2.dts
+@@ -0,0 +1,574 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2019 BayLibre, SAS
++ * Author: Neil Armstrong <narmstrong@baylibre.com>
++ * Copyright (c) 2019 Christian Hewitt <christianshewitt@gmail.com>
++ * Copyright (c) 2022 Radxa Limited
++ * Author: Yuntian Zhang <yt@radxa.com>
++ */
++
++/dts-v1/;
++
++#include "meson-g12b-a311d.dtsi"
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/leds/common.h>
++#include <dt-bindings/gpio/meson-g12a-gpio.h>
++#include <dt-bindings/sound/meson-g12a-tohdmitx.h>
++
++/ {
++	compatible = "radxa,zero2", "amlogic,a311d", "amlogic,g12b";
++	model = "Radxa Zero2";
++
++	aliases {
++		serial0 = &uart_AO;
++		serial2 = &uart_A;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++   fan0: pwm-fan {
++		compatible = "pwm-fan";
++		#cooling-cells = <2>;
++		cooling-min-state = <0>;
++		cooling-max-state = <3>;
++		cooling-levels = <0 120 170 220>;
++		pwms = <&pwm_AO_ab 0 40000 0>;
++	};
++
++	memory@0 {
++		device_type = "memory";
++		reg = <0x0 0x0 0x0 0x80000000>;
++	};
++
++	gpio-keys-polled {
++		compatible = "gpio-keys-polled";
++		poll-interval = <100>;
++		power-button {
++			label = "power";
++			linux,code = <KEY_POWER>;
++			gpios = <&gpio_ao GPIOAO_3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led-green {
++			color = <LED_COLOR_ID_GREEN>;
++			function = LED_FUNCTION_STATUS;
++			gpios = <&gpio GPIOA_12 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "heartbeat";
++		};
++	};
++
++	cvbs-connector {
++		status = "disabled";
++		compatible = "composite-video-connector";
++
++		port {
++			cvbs_connector_in: endpoint {
++				remote-endpoint = <&cvbs_vdac_out>;
++			};
++		};
++	};
++
++	hdmi-connector {
++		compatible = "hdmi-connector";
++		type = "a";
++
++		port {
++			hdmi_connector_in: endpoint {
++				remote-endpoint = <&hdmi_tx_tmds_out>;
++			};
++		};
++	};
++
++	emmc_pwrseq: emmc-pwrseq {
++		compatible = "mmc-pwrseq-emmc";
++		reset-gpios = <&gpio BOOT_12 GPIO_ACTIVE_LOW>;
++	};
++
++	sdio_pwrseq: sdio-pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		reset-gpios = <&gpio GPIOX_6 GPIO_ACTIVE_LOW>;
++		clocks = <&wifi32k>;
++		clock-names = "ext_clock";
++	};
++
++	typec2_vbus: regulator-typec2_vbus {
++		compatible = "regulator-fixed";
++		regulator-name = "TYPEC2_VBUS";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&ao_5v>;
++	};
++
++	ao_5v: regulator-ao_5v {
++		compatible = "regulator-fixed";
++		regulator-name = "AO_5V";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		regulator-always-on;
++	};
++
++	vcc_1v8: regulator-vcc_1v8 {
++		compatible = "regulator-fixed";
++		regulator-name = "VCC_1V8";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vcc_3v3>;
++		regulator-always-on;
++	};
++
++	vcc_3v3: regulator-vcc_3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "VCC_3V3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vddao_3v3>;
++		regulator-always-on;
++		/* FIXME: actually controlled by VDDCPU_B_EN */
++	};
++
++	vddao_1v8: regulator-vddao_1v8 {
++		compatible = "regulator-fixed";
++		regulator-name = "VDDIO_AO1V8";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vddao_3v3>;
++		regulator-always-on;
++	};
++
++	vddao_3v3: regulator-vddao_3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "VDDAO_3V3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&ao_5v>;
++		regulator-always-on;
++	};
++
++	vddcpu_a: regulator-vddcpu-a {
++		/*
++		 * MP8756GD Regulator.
++		 */
++		compatible = "pwm-regulator";
++
++		regulator-name = "VDDCPU_A";
++		regulator-min-microvolt = <730000>;
++		regulator-max-microvolt = <1022000>;
++
++		pwm-supply = <&ao_5v>;
++
++		pwms = <&pwm_ab 0 1250 0>;
++		pwm-dutycycle-range = <100 0>;
++
++		regulator-boot-on;
++		regulator-always-on;
++	};
++
++	vddcpu_b: regulator-vddcpu-b {
++		/*
++		 * Silergy SY8120B1ABC Regulator.
++		 */
++		compatible = "pwm-regulator";
++
++		regulator-name = "VDDCPU_B";
++		regulator-min-microvolt = <730000>;
++		regulator-max-microvolt = <1022000>;
++
++		pwm-supply = <&ao_5v>;
++
++		pwms = <&pwm_AO_cd 1 1250 0>;
++		pwm-dutycycle-range = <100 0>;
++
++		regulator-boot-on;
++		regulator-always-on;
++	};
++
++	sound {
++		compatible = "amlogic,axg-sound-card";
++		model = "RADXA-ZERO2";
++		audio-aux-devs = <&tdmout_b>;
++		audio-routing = "TDMOUT_B IN 0", "FRDDR_A OUT 1",
++				"TDMOUT_B IN 1", "FRDDR_B OUT 1",
++				"TDMOUT_B IN 2", "FRDDR_C OUT 1",
++				"TDM_B Playback", "TDMOUT_B OUT";
++
++		assigned-clocks = <&clkc CLKID_MPLL2>,
++				  <&clkc CLKID_MPLL0>,
++				  <&clkc CLKID_MPLL1>;
++		assigned-clock-parents = <0>, <0>, <0>;
++		assigned-clock-rates = <294912000>,
++				       <270950400>,
++				       <393216000>;
++		status = "okay";
++
++		dai-link-0 {
++			sound-dai = <&frddr_a>;
++		};
++
++		dai-link-1 {
++			sound-dai = <&frddr_b>;
++		};
++
++		dai-link-2 {
++			sound-dai = <&frddr_c>;
++		};
++
++		/* 8ch hdmi interface */
++		dai-link-3 {
++			sound-dai = <&tdmif_b>;
++			dai-format = "i2s";
++			dai-tdm-slot-tx-mask-0 = <1 1>;
++			dai-tdm-slot-tx-mask-1 = <1 1>;
++			dai-tdm-slot-tx-mask-2 = <1 1>;
++			dai-tdm-slot-tx-mask-3 = <1 1>;
++			mclk-fs = <256>;
++
++			codec {
++				sound-dai = <&tohdmitx TOHDMITX_I2S_IN_B>;
++			};
++		};
++
++		/* hdmi glue */
++		dai-link-4 {
++			sound-dai = <&tohdmitx TOHDMITX_I2S_OUT>;
++
++			codec {
++				sound-dai = <&hdmi_tx>;
++			};
++		};
++	};
++
++	wifi32k: wifi32k {
++		compatible = "pwm-clock";
++		#clock-cells = <0>;
++		clock-frequency = <32768>;
++		pwms = <&pwm_ef 0 30518 0>; /* PWM_E at 32.768KHz */
++	};
++};
++
++&periphs_pinctrl {
++	/* Ensure the TYPE C controller irq pin is not driven by the SoC */
++	fusb302_irq_pins: fusb302_irq {
++		mux {
++			groups = "GPIOA_4";
++			function = "gpio_periphs";
++			bias-pull-up;
++			output-disable;
++		};
++	};
++};
++
++&arb {
++	status = "okay";
++};
++
++&cec_AO {
++	pinctrl-0 = <&cec_ao_a_h_pins>;
++	pinctrl-names = "default";
++	status = "disabled";
++	hdmi-phandle = <&hdmi_tx>;
++};
++
++&cecb_AO {
++	pinctrl-0 = <&cec_ao_b_h_pins>;
++	pinctrl-names = "default";
++	status = "okay";
++	hdmi-phandle = <&hdmi_tx>;
++};
++
++&clkc_audio {
++	status = "okay";
++};
++
++&cpu0 {
++	cpu-supply = <&vddcpu_b>;
++	operating-points-v2 = <&cpu_opp_table_0>;
++	clocks = <&clkc CLKID_CPU_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu1 {
++	cpu-supply = <&vddcpu_b>;
++	operating-points-v2 = <&cpu_opp_table_0>;
++	clocks = <&clkc CLKID_CPU_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu100 {
++	cpu-supply = <&vddcpu_a>;
++	operating-points-v2 = <&cpub_opp_table_1>;
++	clocks = <&clkc CLKID_CPUB_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu101 {
++	cpu-supply = <&vddcpu_a>;
++	operating-points-v2 = <&cpub_opp_table_1>;
++	clocks = <&clkc CLKID_CPUB_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu102 {
++	cpu-supply = <&vddcpu_a>;
++	operating-points-v2 = <&cpub_opp_table_1>;
++	clocks = <&clkc CLKID_CPUB_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu103 {
++	cpu-supply = <&vddcpu_a>;
++	operating-points-v2 = <&cpub_opp_table_1>;
++	clocks = <&clkc CLKID_CPUB_CLK>;
++	clock-latency = <50000>;
++};
++
++&cvbs_vdac_port {
++	cvbs_vdac_out: endpoint {
++		remote-endpoint = <&cvbs_connector_in>;
++	};
++};
++
++&frddr_a {
++	status = "okay";
++};
++
++&frddr_b {
++	status = "okay";
++};
++
++&frddr_c {
++	status = "okay";
++};
++
++&gpio {
++	gpio-line-names =
++		/* GPIOZ */
++		"PIN_27", "PIN_28", "PIN_7", "PIN_11", "PIN_13", "PIN_15", "PIN_18", "PIN_40",
++		"PIN_16", "PIN_22", "", "", "", "", "", "",
++		/* GPIOH */
++		"", "", "", "", "PIN_19", "PIN_21", "PIN_24", "PIN_23",
++		"",
++		/* BOOT */
++		"", "", "", "", "", "", "", "",
++		"", "", "", "", "EMMC_PWRSEQ", "", "", "",
++		/* GPIOC */
++		"", "", "", "", "", "", "SD_CD", "PIN_36",
++		/* GPIOA */
++		"PIN_32", "PIN_12", "PIN_35", "", "FUSB_IRQ", "PIN_38", "", "",
++		"", "", "", "", "LED_GREEN", "PIN_31", "PIN_3", "PIN_5",
++		/* GPIOX */
++		"", "", "", "", "", "", "SDIO_PWRSEQ", "",
++		"", "", "", "", "", "", "", "",
++		"", "BT_SHUTDOWN", "", "";
++};
++
++&gpio_ao {
++	gpio-line-names =
++		/* GPIOAO */
++		"PIN_8", "PIN_10", "", "BTN_POWER", "", "", "", "PIN_29",
++		"PIN_33", "PIN_37", "", "FAN",
++		/* GPIOE */
++		"", "", "";
++};
++
++&hdmi_tx {
++	status = "okay";
++	pinctrl-0 = <&hdmitx_hpd_pins>, <&hdmitx_ddc_pins>;
++	pinctrl-names = "default";
++	hdmi-supply = <&ao_5v>;
++};
++
++&hdmi_tx_tmds_port {
++	hdmi_tx_tmds_out: endpoint {
++		remote-endpoint = <&hdmi_connector_in>;
++	};
++};
++
++&cpu_thermal {
++	cooling-maps {
++		map0 {
++			trip = <&cpu_passive>;
++			cooling-device = <&fan0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++		};
++	};
++};
++
++&ddr_thermal {
++	cooling-maps {
++		map0 {
++			trip = <&ddr_passive>;
++			cooling-device = <&fan0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++		};
++	};
++};
++
++&ir {
++	status = "disabled";
++	pinctrl-0 = <&remote_input_ao_pins>;
++	pinctrl-names = "default";
++};
++
++&i2c3 {
++	fusb302@22 {
++		compatible = "fcs,fusb302";
++		reg = <0x22>;
++
++		pinctrl-0 = <&fusb302_irq_pins>;
++		pinctrl-names = "default";
++		interrupt-parent = <&gpio_intc>;
++		interrupts = <59 IRQ_TYPE_LEVEL_LOW>;
++
++		vbus-supply = <&typec2_vbus>;
++
++		status = "okay";
++	};
++};
++
++&pwm_ab {
++	pinctrl-0 = <&pwm_a_e_pins>;
++	pinctrl-names = "default";
++	clocks = <&xtal>;
++	clock-names = "clkin0";
++	status = "okay";
++};
++
++&pwm_ef {
++	pinctrl-0 = <&pwm_e_pins>;
++	pinctrl-names = "default";
++	clocks = <&xtal>;
++	clock-names = "clkin2";
++	status = "okay";
++};
++
++&pwm_AO_ab {
++	pinctrl-0 = <&pwm_ao_a_pins>;
++	pinctrl-names = "default";
++	clocks = <&xtal>;
++	clock-names = "clkin3";
++	status = "okay";
++};
++
++&pwm_AO_cd {
++	pinctrl-0 = <&pwm_ao_d_e_pins>;
++	pinctrl-names = "default";
++	clocks = <&xtal>;
++	clock-names = "clkin4";
++	status = "okay";
++};
++
++&saradc {
++	status = "okay";
++	vref-supply = <&vddao_1v8>;
++};
++
++/* SDIO */
++&sd_emmc_a {
++	status = "okay";
++	pinctrl-0 = <&sdio_pins>;
++	pinctrl-1 = <&sdio_clk_gate_pins>;
++	pinctrl-names = "default", "clk-gate";
++	#address-cells = <1>;
++	#size-cells = <0>;
++
++	bus-width = <4>;
++	cap-sd-highspeed;
++	max-frequency = <80000000>;
++
++	non-removable;
++	disable-wp;
++
++	/* WiFi firmware requires power to be kept while in suspend */
++	keep-power-in-suspend;
++
++	mmc-pwrseq = <&sdio_pwrseq>;
++
++	vmmc-supply = <&vddao_3v3>;
++	vqmmc-supply = <&vddao_1v8>;
++
++	brcmf: wifi@1 {
++		reg = <1>;
++		compatible = "brcm,bcm4329-fmac";
++	};
++};
++
++/* SD card */
++&sd_emmc_b {
++	status = "okay";
++	pinctrl-0 = <&sdcard_c_pins>;
++	pinctrl-1 = <&sdcard_clk_gate_c_pins>;
++	pinctrl-names = "default", "clk-gate";
++
++	bus-width = <4>;
++	cap-sd-highspeed;
++	max-frequency = <50000000>;
++	disable-wp;
++
++	cd-gpios = <&gpio GPIOC_6 GPIO_ACTIVE_LOW>;
++	vmmc-supply = <&vddao_3v3>;
++	vqmmc-supply = <&vddao_3v3>;
++};
++
++/* eMMC */
++&sd_emmc_c {
++	status = "okay";
++	pinctrl-0 = <&emmc_ctrl_pins>, <&emmc_data_8b_pins>, <&emmc_ds_pins>;
++	pinctrl-1 = <&emmc_clk_gate_pins>;
++	pinctrl-names = "default", "clk-gate";
++
++	bus-width = <8>;
++	cap-mmc-highspeed;
++	mmc-ddr-1_8v;
++	mmc-hs200-1_8v;
++	max-frequency = <200000000>;
++	disable-wp;
++
++	mmc-pwrseq = <&emmc_pwrseq>;
++	vmmc-supply = <&vcc_3v3>;
++	vqmmc-supply = <&vcc_1v8>;
++};
++
++&tdmif_b {
++	status = "okay";
++};
++
++&tdmout_b {
++	status = "okay";
++};
++
++&tohdmitx {
++	status = "okay";
++};
++
++&uart_A {
++	status = "okay";
++	pinctrl-0 = <&uart_a_pins>, <&uart_a_cts_rts_pins>;
++	pinctrl-names = "default";
++	uart-has-rtscts;
++
++	bluetooth {
++		compatible = "brcm,bcm43438-bt";
++		shutdown-gpios = <&gpio GPIOX_17 GPIO_ACTIVE_HIGH>;
++		max-speed = <2000000>;
++		clocks = <&wifi32k>;
++		clock-names = "lpo";
++	};
++};
++
++&uart_AO {
++	status = "okay";
++	pinctrl-0 = <&uart_ao_a_pins>;
++	pinctrl-names = "default";
++};
++
++&usb {
++	status = "okay";
++};
++
++&usb3_pcie_phy {
++	phy-supply = <&typec2_vbus>;
++};
+-- 
+2.35.1
+

--- a/patch/u-boot/v2022.10/board_radxa-zero2/0002-WIP-boards-amlogic-add-Radxa-Zero2-defconfig.patch
+++ b/patch/u-boot/v2022.10/board_radxa-zero2/0002-WIP-boards-amlogic-add-Radxa-Zero2-defconfig.patch
@@ -1,0 +1,102 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Christian Hewitt <christianshewitt@gmail.com>
+Date: Sat, 15 Jan 2022 06:23:29 +0000
+Subject: [PATCH] WIP: boards: amlogic: add Radxa Zero2 defconfig
+
+Add a defconfig for the Radxa Zero2 SBC, using an Amlogic A311D chip.
+
+Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
+Signed-off-by: Yuntian Zhang <yt@radxa.com>
+---
+ board/amlogic/w400/MAINTAINERS |  1 +
+ configs/radxa-zero2_defconfig  | 69 ++++++++++++++++++++++++++++++++++
+ 2 files changed, 70 insertions(+)
+ create mode 100644 configs/radxa-zero2_defconfig
+
+diff --git a/board/amlogic/w400/MAINTAINERS b/board/amlogic/w400/MAINTAINERS
+index 991590d9f2..8587f67b46 100644
+--- a/board/amlogic/w400/MAINTAINERS
++++ b/board/amlogic/w400/MAINTAINERS
+@@ -3,4 +3,5 @@ M:	Neil Armstrong <narmstrong@baylibre.com>
+ S:	Maintained
+ L:	u-boot-amlogic@groups.io
+ F:	board/amlogic/w400/
++F:	configs/radxa-zero2_defconfig
+ F:	doc/board/amlogic/w400.rst
+diff --git a/configs/radxa-zero2_defconfig b/configs/radxa-zero2_defconfig
+new file mode 100644
+index 000000000..65f5a3bfe
+--- /dev/null
++++ b/configs/radxa-zero2_defconfig
+@@ -0,0 +1,68 @@
++CONFIG_ARM=y
++CONFIG_ARCH_MESON=y
++CONFIG_SYS_TEXT_BASE=0x01000000
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_ENV_SIZE=0x2000
++CONFIG_DM_GPIO=y
++CONFIG_DEFAULT_DEVICE_TREE="meson-g12b-radxa-zero2"
++CONFIG_MESON_G12A=y
++CONFIG_DEBUG_UART_BASE=0xff803000
++CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_IDENT_STRING=" radxa-zero2"
++CONFIG_SYS_LOAD_ADDR=0x1000000
++CONFIG_DEBUG_UART=y
++CONFIG_HAS_CUSTOM_SYS_INIT_SP_ADDR=y
++CONFIG_CUSTOM_SYS_INIT_SP_ADDR=0x20000000
++CONFIG_REMAKE_ELF=y
++CONFIG_OF_BOARD_SETUP=y
++# CONFIG_DISPLAY_CPUINFO is not set
++CONFIG_MISC_INIT_R=y
++CONFIG_SYS_MAXARGS=32
++# CONFIG_CMD_BDI is not set
++# CONFIG_CMD_IMI is not set
++CONFIG_CMD_GPIO=y
++# CONFIG_CMD_LOADS is not set
++CONFIG_CMD_MMC=y
++CONFIG_CMD_USB=y
++CONFIG_CMD_USB_MASS_STORAGE=y
++# CONFIG_CMD_SETEXPR is not set
++CONFIG_CMD_REGULATOR=y
++CONFIG_OF_CONTROL=y
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_NET_RANDOM_ETHADDR=y
++CONFIG_MMC_MESON_GX=y
++CONFIG_MTD=y
++CONFIG_DM_MTD=y
++CONFIG_MESON_G12A_USB_PHY=y
++CONFIG_PINCTRL=y
++CONFIG_PINCTRL_MESON_G12A=y
++CONFIG_POWER_DOMAIN=y
++CONFIG_MESON_EE_POWER_DOMAIN=y
++CONFIG_DM_REGULATOR=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_DM_RESET=y
++CONFIG_DEBUG_UART_ANNOUNCE=y
++CONFIG_DEBUG_UART_SKIP_INIT=y
++CONFIG_MESON_SERIAL=y
++CONFIG_USB=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_XHCI_DWC3=y
++CONFIG_USB_DWC3=y
++# CONFIG_USB_DWC3_GADGET is not set
++CONFIG_USB_DWC3_MESON_G12A=y
++CONFIG_USB_KEYBOARD=y
++CONFIG_USB_GADGET=y
++CONFIG_USB_GADGET_VENDOR_NUM=0x1b8e
++CONFIG_USB_GADGET_PRODUCT_NUM=0xfada
++CONFIG_USB_GADGET_DWC2_OTG=y
++CONFIG_USB_GADGET_DWC2_OTG_PHY_BUS_WIDTH_8=y
++CONFIG_USB_GADGET_DOWNLOAD=y
++CONFIG_DM_VIDEO=y
++# CONFIG_VIDEO_BPP8 is not set
++# CONFIG_VIDEO_BPP16 is not set
++CONFIG_SYS_WHITE_ON_BLACK=y
++CONFIG_VIDEO_MESON=y
++CONFIG_VIDEO_DT_SIMPLEFB=y
++CONFIG_SPLASH_SCREEN=y
++CONFIG_SPLASH_SCREEN_ALIGN=y
++CONFIG_OF_LIBFDT_OVERLAY=y
+-- 
+2.35.1
+

--- a/patch/u-boot/v2022.10/meson64-boot-usb-nvme-scsi-first.patch
+++ b/patch/u-boot/v2022.10/meson64-boot-usb-nvme-scsi-first.patch
@@ -1,0 +1,19 @@
+diff --git a/include/configs/meson64.h b/include/configs/meson64.h
+--- a/include/configs/meson64.h	(revision 4debc57a3da6c3f4d3f89a637e99206f4cea0a96)
++++ b/include/configs/meson64.h	(date 1668345216008)
+@@ -64,12 +64,12 @@
+ #ifndef BOOT_TARGET_DEVICES
+ #define BOOT_TARGET_DEVICES(func) \
+ 	func(ROMUSB, romusb, na)  \
+-	func(MMC, mmc, 0) \
+-	func(MMC, mmc, 1) \
+-	func(MMC, mmc, 2) \
+ 	BOOT_TARGET_DEVICES_USB(func) \
+ 	BOOT_TARGET_NVME(func) \
+ 	BOOT_TARGET_SCSI(func) \
++	func(MMC, mmc, 0) \
++	func(MMC, mmc, 1) \
++	func(MMC, mmc, 2) \
+ 	func(PXE, pxe, na) \
+ 	func(DHCP, dhcp, na)
+ #endif


### PR DESCRIPTION
#### More updates for Radxa's Amlogic boards (`radxa-zero` and `radxa-zero2`)

- `radxa-zero`: include v2022.10 standard patches (eg: boot from USB first)
- `meson64` u-boot v2022.10: change `BOOT_TARGET_DEVICES` to try to boot USB, NVME and SCSI before SD, MMC, PXE, DHCP
- u-boot: `radxa-zero2`: use `v2022.10` plus Radxa's patches
- u-boot: `radxa-zero2`: Radxa's patches for the Zero2 on `v2022.10`
- `meson64`: `6.0`: g12a and g12b pinmux patches from Radxa **common for all meson64**
- same batch, different repo: https://github.com/armbian/firmware/pull/42 "Add AW-CM256 BT firmware"