### PR TITLE
Syntax error fixes, dep checks & `shfmt` of board-side bash scripts

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-audio-config
+++ b/packages/bsp/common/usr/lib/armbian/armbian-audio-config
@@ -1,164 +1,160 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
+# Check that we have the tools required available, otherwise exit with no error.
+# Use command -v, not which, which is deprecated.
+[[ -z $(command -v amixer) ]] && echo "Missing amixer; doing nothing." && exit 0
+[[ -z $(command -v alsactl) ]] && echo "Missing alsactl; doing nothing." && exit 0
+[[ -z $(command -v aplay) ]] && echo "Missing aplay; doing nothing." && exit 0
 
 mixer() {
-  parm=${4:-on}
-  amixer -c "$1" sset "$2" "$3" $parm >/dev/null 2>&1
-  amixer -c "$1" sset "$2" $parm >/dev/null 2>&1
+	parm=${4:-on}
+	amixer -c "$1" sset "$2" "$3" $parm > /dev/null 2>&1
+	amixer -c "$1" sset "$2" $parm > /dev/null 2>&1
 }
 
-
 if [ -f $HOME/.config/sound.conf ]; then
-
-  alsactl restore -f $HOME/.config/sound.conf
-
+	alsactl restore -f $HOME/.config/sound.conf
 else
+	# get card num
+	#card=`echo $1 | sed 's/[^0-9]*//g'`
+	card1=$(aplay -l | grep "device 0" | awk '{print $3}')
+	#echo $card
 
-# get card num
-#card=`echo $1 | sed 's/[^0-9]*//g'`
-card1=`aplay -l | grep "device 0" | awk '{print $3}'`
-#echo $card
+	for card in $card1; do
+		#echo $card
 
-for card in $card1 
-do
+		# set common mixer params
+		mixer $card Master 0db
+		mixer $card Front 100%
+		mixer $card PCM 0db
+		mixer $card Synth 100%
 
-#echo $card
+		# mute CD, since using digital audio instead
+		mixer $card CD 0% mute
 
-# set common mixer params
-  mixer $card Master 0db
-  mixer $card Front 100%
-  mixer $card PCM 0db
-  mixer $card Synth 100%
+		# Only unmute Line and Aux if they are possibly used.
+		#  mixer $card Line 100%
+		#  mixer $card Aux 100%
 
-# mute CD, since using digital audio instead
-  mixer $card CD 0% mute
+		# mute mic
+		mixer $card Mic 0% mute
 
-# Only unmute Line and Aux if they are possibly used.
-#  mixer $card Line 100%
-#  mixer $card Aux 100%
+		# ESS 1969 chipset has 2 PCM channels
+		mixer $card PCM,1 100%
 
-# mute mic
-  mixer $card Mic 0% mute
+		# Trident/YMFPCI/emu10k1
+		mixer $card Wave 100%
+		mixer $card Music 100%
+		mixer $card AC97 100%
+		mixer $card Surround 90%
+		mixer $card 'Surround Digital' 90%
+		mixer $card 'Wave Surround' 90%
+		mixer $card 'Duplicate Front' 90%
+		mixer $card 'Sigmatel 4-Speaker Stereo' 90%
 
-# ESS 1969 chipset has 2 PCM channels
-  mixer $card PCM,1 100%
+		# CS4237B chipset:
+		mixer $card 'Master Digital' 100%
 
-# Trident/YMFPCI/emu10k1
-  mixer $card Wave 100%
-  mixer $card Music 100%
-  mixer $card AC97 100%
-  mixer $card Surround 90%
-  mixer $card 'Surround Digital' 90%
-  mixer $card 'Wave Surround' 90%
-  mixer $card 'Duplicate Front' 90%
-  mixer $card 'Sigmatel 4-Speaker Stereo' 90%
+		# DRC
+		mixer $card 'Dynamic Range Compression' 90%
 
-# CS4237B chipset:
-  mixer $card 'Master Digital' 100%
+		# Envy24 chips with analog outs
+		mixer $card DAC 100%
+		mixer $card DAC,0 100%
+		mixer $card DAC,1 100%
 
-# DRC
-  mixer $card 'Dynamic Range Compression' 90%
+		# some notebooks use headphone instead of master
+		mixer $card Headphone 100%
+		mixer $card Speaker 100%
+		mixer $card 'Internal Speaker' 0% mute
+		mixer $card Playback 100%
+		mixer $card Headphone 100%
+		mixer $card Speaker 100%
+		mixer $card Center 100%
+		mixer $card LFE 100%
+		mixer $card Center/LFE 100%
 
-# Envy24 chips with analog outs
-  mixer $card DAC 100%
-  mixer $card DAC,0 100%
-  mixer $card DAC,1 100%
+		# Intel P4P800-MX  (Ubuntu bug #5813)
+		mixer $card 'Master Playback Switch' on
 
-# some notebooks use headphone instead of master
-  mixer $card Headphone 100%
-  mixer $card Speaker 100%
-  mixer $card 'Internal Speaker' 0% mute
-  mixer $card Playback 100%
-  mixer $card Headphone 100%
-  mixer $card Speaker 100%
-  mixer $card Center 100%
-  mixer $card LFE 100%
-  mixer $card Center/LFE 100%
+		# set digital output mixer params
+		mixer $card 'IEC958' 100% on
+		mixer $card 'IEC958 Output' 100%
+		mixer $card 'IEC958 Coaxial' 100%
+		mixer $card 'IEC958 LiveDrive' 100%
+		mixer $card 'IEC958 Optical Raw' 100%
+		mixer $card 'SPDIF Out' 100%
+		mixer $card 'SPDIF Front' 100%
+		mixer $card 'SPDIF Rear' 100%
+		mixer $card 'SPDIF Center/LFE' 100%
+		mixer $card 'Master Digital' 100%
 
-# Intel P4P800-MX  (Ubuntu bug #5813)
-  mixer $card 'Master Playback Switch' on
+		mixer $card 'Analog Front' 100%
+		mixer $card 'Analog Rear' 100%
+		mixer $card 'Analog Center/LFE' 100%
 
-# set digital output mixer params
-  mixer $card 'IEC958' 100% on
-  mixer $card 'IEC958 Output' 100%
-  mixer $card 'IEC958 Coaxial' 100%
-  mixer $card 'IEC958 LiveDrive' 100%
-  mixer $card 'IEC958 Optical Raw' 100%
-  mixer $card 'SPDIF Out' 100%
-  mixer $card 'SPDIF Front' 100%
-  mixer $card 'SPDIF Rear' 100%
-  mixer $card 'SPDIF Center/LFE' 100%
-  mixer $card 'Master Digital' 100%
+		# ASRock ION 330 (and perhaps others) has 2 IEC958 channels
+		mixer $card IEC958,0 on
+		mixer $card IEC958,1 on
 
-  mixer $card 'Analog Front' 100%
-  mixer $card 'Analog Rear' 100%
-  mixer $card 'Analog Center/LFE' 100%
+		# some ION2 has much more IEC958 channels ...
+		mixer $card IEC958,2 on
+		mixer $card IEC958,3 on
 
-# ASRock ION 330 (and perhaps others) has 2 IEC958 channels
-  mixer $card IEC958,0 on
-  mixer $card IEC958,1 on
+		# ASRock ION 330 has Master Front set to 0
+		mixer $card 'Master Front' 100%
 
-# some ION2 has much more IEC958 channels ...
-  mixer $card IEC958,2 on
-  mixer $card IEC958,3 on
+		# Shuttle XS35GT needs this too
+		mixer $card 'Master',0 100% on
 
-# ASRock ION 330 has Master Front set to 0
-  mixer $card 'Master Front' 100%
+		# and this for various Fusion devices like Zotac ZBOX
+		mixer $card 'Front',0 100% on
 
-# Shuttle XS35GT needs this too
-  mixer $card 'Master',0 100% on
+		# NVidia CK804 sound devices
+		mixer $card 'IEC958 Playback AC97-SPSA' 100%
 
-# and this for various Fusion devices like Zotac ZBOX
-  mixer $card 'Front',0 100% on
+		# Allwinner H3 Analog
+		mixer $card 'Line Out' 0db on
 
-# NVidia CK804 sound devices
-  mixer $card 'IEC958 Playback AC97-SPSA' 100%
+		# Allwinner A20 Analog
+		mixer $card 'Power Amplifier' 0db
+		mixer $card 'Power Amplifier DAC' on
+		mixer $card 'Power Amplifier Mute' on
 
-# Allwinner H3 Analog
-  mixer $card 'Line Out' 0db on
+		# Allwinner A64 Analog
+		mixer $card Headphone 0db on
+		mixer $card 'AIF1 Slot 0 Digital DAC' on
 
-# Allwinner A20 Analog
-  mixer $card 'Power Amplifier' 0db
-  mixer $card 'Power Amplifier DAC' on
-  mixer $card 'Power Amplifier Mute' on
+		# Amlogic G12 HDMI to PCM0
+		mixer $card 'FRDDR_A SINK 1 SEL' 'OUT 1'
+		mixer $card 'FRDDR_A SRC 1 EN' on
+		mixer $card 'TDMOUT_B SRC SEL' 'IN 0'
+		mixer $card 'TOHDMITX I2S SRC' 'I2S B'
+		mixer $card 'TOHDMITX' on
 
-# Allwinner A64 Analog
-  mixer $card Headphone 0db on
-  mixer $card 'AIF1 Slot 0 Digital DAC' on
+		# Amlogic G12 S/PDIF to PCM1
+		mixer $card 'FRDDR_B SINK 1 SEL' 'OUT 3'
+		mixer $card 'FRDDR_B SRC 1 EN' on
+		mixer $card 'SPDIFOUT SRC SEL' 'IN 1'
+		mixer $card 'SPDIFOUT Playback' on
 
-# Amlogic G12 HDMI to PCM0
-  mixer $card 'FRDDR_A SINK 1 SEL' 'OUT 1'
-  mixer $card 'FRDDR_A SRC 1 EN' on
-  mixer $card 'TDMOUT_B SRC SEL' 'IN 0'
-  mixer $card 'TOHDMITX I2S SRC' 'I2S B'
-  mixer $card 'TOHDMITX' on
+		# Amlogic GX HDMI and S/PDIF
+		mixer $card 'AIU HDMI CTRL SRC' 'I2S'
+		mixer $card 'AIU SPDIF SRC SEL' 'SPDIF'
 
-# Amlogic G12 S/PDIF to PCM1
-  mixer $card 'FRDDR_B SINK 1 SEL' 'OUT 3'
-  mixer $card 'FRDDR_B SRC 1 EN' on
-  mixer $card 'SPDIFOUT SRC SEL' 'IN 1'
-  mixer $card 'SPDIFOUT Playback' on
+		# RockPI 4B Analog
+		mixer $card 'Right Headphone Mixer Right DAC' on
+		mixer $card 'Left Headphone Mixer Left DAC' on
 
-# Amlogic GX HDMI and S/PDIF
-  mixer $card 'AIU HDMI CTRL SRC' 'I2S'
-  mixer $card 'AIU SPDIF SRC SEL' 'SPDIF'
-
-# RockPI 4B Analog
-  mixer $card 'Right Headphone Mixer Right DAC' on
-  mixer $card 'Left Headphone Mixer Left DAC' on
-
-# NanoPC T4 Analog
-  mixer $card 'HPO L' on
-  mixer $card 'HPO R' on
-  mixer $card 'HPOVOL L' on
-  mixer $card 'HPOVOL R' on
-  mixer $card 'HPO MIX HPVOL' on
-  mixer $card 'OUT MIXL DAC L1' on
-  mixer $card 'OUT MIXR DAC R1' on
-  mixer $card 'Stereo DAC MIXL DAC L1' on
-  mixer $card 'Stereo DAC MIXR DAC R1' on
-
-done
-
+		# NanoPC T4 Analog
+		mixer $card 'HPO L' on
+		mixer $card 'HPO R' on
+		mixer $card 'HPOVOL L' on
+		mixer $card 'HPOVOL R' on
+		mixer $card 'HPO MIX HPVOL' on
+		mixer $card 'OUT MIXL DAC L1' on
+		mixer $card 'OUT MIXR DAC R1' on
+		mixer $card 'Stereo DAC MIXL DAC L1' on
+		mixer $card 'Stereo DAC MIXR DAC R1' on
+	done
 fi
-

--- a/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
+++ b/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
@@ -12,7 +12,6 @@
 # prepare_board
 # add_usb_storage_quirks
 
-
 # Read in basic OS image information
 . /etc/armbian-release
 
@@ -25,9 +24,9 @@
 set_io_scheduler() {
 
 	# Convert kernel version to integer
-	KERNELID=$(uname -r |  awk -F'.' '{print ($1 * 100) + $2}')
-	for i in $( lsblk -idn -o NAME | grep -v zram ); do
-		read ROTATE </sys/block/$i/queue/rotational
+	KERNELID=$(uname -r | awk -F'.' '{print ($1 * 100) + $2}')
+	for i in $(lsblk -idn -o NAME | grep -v zram); do
+		read ROTATE < /sys/block/$i/queue/rotational
 		case ${ROTATE} in
 			1) # mechanical drives
 				[[ $KERNELID -lt 420 ]] && sched=cfq || sched=bfq
@@ -39,31 +38,27 @@ set_io_scheduler() {
 				continue
 				;;
 		esac
-		echo $sched >/sys/block/$i/queue/scheduler
+		echo $sched > /sys/block/$i/queue/scheduler
 		echo -e "[\e[0;32m ok \x1B[0m] Setting $sched I/O scheduler for $i"
 	done
 
 } # set_io_scheduler
 
-
-
-
 prepare_board() {
 
-	CheckDevice=$(for i in /var/log /var / ; do findmnt -n -o SOURCE $i && break ; done)
+	CheckDevice=$(for i in /var/log /var /; do findmnt -n -o SOURCE $i && break; done)
 	# adjust logrotate configs
 	if [[ "${CheckDevice}" == *"/dev/zram"* || "${CheckDevice}" == "armbian-ramlog" ]]; then
-		for ConfigFile in /etc/logrotate.d/* ; do sed -i -e "s/\/var\/log\//\/var\/log.hdd\//g" "${ConfigFile}"; done
+		for ConfigFile in /etc/logrotate.d/*; do sed -i -e "s/\/var\/log\//\/var\/log.hdd\//g" "${ConfigFile}"; done
 		sed -i "s/\/var\/log\//\/var\/log.hdd\//g" /etc/logrotate.conf
 	else
-		for ConfigFile in /etc/logrotate.d/* ; do sed -i -e "s/\/var\/log.hdd\//\/var\/log\//g" "${ConfigFile}"; done
+		for ConfigFile in /etc/logrotate.d/*; do sed -i -e "s/\/var\/log.hdd\//\/var\/log\//g" "${ConfigFile}"; done
 		sed -i "s/\/var\/log.hdd\//\/var\/log\//g" /etc/logrotate.conf
 	fi
 
 	# unlock cpuinfo_cur_freq to be accesible by a normal user
 	prefix="/sys/devices/system/cpu/cpufreq"
-	for f in $(ls -1 $prefix 2> /dev/null)
-	do
+	for f in $(ls -1 $prefix 2> /dev/null); do
 		[[ -f $prefix/$f/cpuinfo_cur_freq ]] && chmod +r $prefix/$f/cpuinfo_cur_freq 2> /dev/null
 	done
 	# older kernels
@@ -77,145 +72,146 @@ prepare_board() {
 	# tweak ondemand cpufreq governor settings to increase cpufreq with IO load
 	grep -q ondemand /etc/default/cpufrequtils
 	if [ $? -eq 0 ]; then
-		echo ondemand >/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+		echo ondemand > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
 
 		case ${BOARDFAMILY} in
-		station*|media)
-			prefix="/sys/devices/system/cpu"
-			CPUFreqPolicies=($(ls -d ${prefix}/cpufreq/policy? | sed 's/freq\/policy//'))
-			if [ ${#CPUFreqPolicies[@]} -eq 1 -a -d "${prefix}/cpufreq" ]; then
-			    # if there's just a single cpufreq policy ondemand sysfs entries differ
-			    CPUFreqPolicies=${prefix}
-			fi
-			for i in ${CPUFreqPolicies[@]}; do
-			    affected_cpu=$(tr -d -c '[:digit:]' <<< ${i})
-			    echo ondemand >${prefix}/cpu${affected_cpu:-0}/cpufreq/scaling_governor
-			    echo 1 >${i}/cpufreq/ondemand/io_is_busy
-			    echo 25 >${i}/cpufreq/ondemand/up_threshold
-			    echo 10 >${i}/cpufreq/ondemand/sampling_down_factor
-			    echo 200000 >${i}/cpufreq/ondemand/sampling_rate
-			done
-		;;
-		*)
-			cd /sys/devices/system/cpu
-			for i in cpufreq/ondemand cpu0/cpufreq/ondemand cpu4/cpufreq/ondemand ; do
-				if [ -d $i ]; then
-					echo 1 >${i}/io_is_busy
-					echo 25 >${i}/up_threshold
-					echo 10 >${i}/sampling_down_factor
-					echo 200000 >${i}/sampling_rate
+			station* | media)
+				prefix="/sys/devices/system/cpu"
+				CPUFreqPolicies=($(ls -d ${prefix}/cpufreq/policy? | sed 's/freq\/policy//'))
+				if [ ${#CPUFreqPolicies[@]} -eq 1 -a -d "${prefix}/cpufreq" ]; then
+					# if there's just a single cpufreq policy ondemand sysfs entries differ
+					CPUFreqPolicies=${prefix}
 				fi
-			done
-		;;
+				for i in ${CPUFreqPolicies[@]}; do
+					affected_cpu=$(tr -d -c '[:digit:]' <<< ${i})
+					echo ondemand > ${prefix}/cpu${affected_cpu:-0}/cpufreq/scaling_governor
+					echo 1 > ${i}/cpufreq/ondemand/io_is_busy
+					echo 25 > ${i}/cpufreq/ondemand/up_threshold
+					echo 10 > ${i}/cpufreq/ondemand/sampling_down_factor
+					echo 200000 > ${i}/cpufreq/ondemand/sampling_rate
+				done
+				;;
+			*)
+				cd /sys/devices/system/cpu
+				for i in cpufreq/ondemand cpu0/cpufreq/ondemand cpu4/cpufreq/ondemand; do
+					if [ -d $i ]; then
+						echo 1 > ${i}/io_is_busy
+						echo 25 > ${i}/up_threshold
+						echo 10 > ${i}/sampling_down_factor
+						echo 200000 > ${i}/sampling_rate
+					fi
+				done
+				;;
+		esac
 
 	fi
 
 	# IRQ distribution based on $BOARDFAMILY and/or $BOARD_NAME
 	case ${BOARD} in
-		rockpro64|renegade-elite|pinebook-pro|station-p1)
+		rockpro64 | renegade-elite | pinebook-pro | station-p1)
 			BOARDFAMILY=rk3399
 			;;
 	esac
 	case ${BOARDFAMILY} in
-		cubox|udoo*) # i.MX6 boards: send Ethernet to cpu3, MMC to cpu1/cpu2 (when available)
-			echo 2 >/proc/irq/$(awk -F":" "/mmc0/ {print \$1}" </proc/interrupts | sed 's/\ //g' | head -1)/smp_affinity 2>/dev/null
-			echo 4 >/proc/irq/$(awk -F":" "/mmc1/ {print \$1}" </proc/interrupts | sed 's/\ //g' | head -1)/smp_affinity 2>/dev/null
-			echo 8 >/proc/irq/$(awk -F":" "/ethernet/ {print \$1}" </proc/interrupts | sed 's/\ //g' | head -1)/smp_affinity 2>/dev/null
-			echo 7 >/sys/class/net/eth0/queues/rx-0/rps_cpus
+		cubox | udoo*) # i.MX6 boards: send Ethernet to cpu3, MMC to cpu1/cpu2 (when available)
+			echo 2 > /proc/irq/$(awk -F":" "/mmc0/ {print \$1}" < /proc/interrupts | sed 's/\ //g' | head -1)/smp_affinity 2> /dev/null
+			echo 4 > /proc/irq/$(awk -F":" "/mmc1/ {print \$1}" < /proc/interrupts | sed 's/\ //g' | head -1)/smp_affinity 2> /dev/null
+			echo 8 > /proc/irq/$(awk -F":" "/ethernet/ {print \$1}" < /proc/interrupts | sed 's/\ //g' | head -1)/smp_affinity 2> /dev/null
+			echo 7 > /sys/class/net/eth0/queues/rx-0/rps_cpus
 			;;
 		meson-g12b) # S922X/A311D: ODROID N2, possibly VIM3, cpu0/cpu1 are the little ones
 			# MMC on cpu1, USB3 on cpu2, Ethernet on cpu3, rdma on cpu4, vsync on cpu5
-			for i in $(awk -F':' '/mmc/{print $1}' </proc/interrupts | sed 's/\ //g'); do
-				echo 1 >/proc/irq/$i/smp_affinity_list
+			for i in $(awk -F':' '/mmc/{print $1}' < /proc/interrupts | sed 's/\ //g'); do
+				echo 1 > /proc/irq/$i/smp_affinity_list
 			done
-			echo 2 >/proc/irq/$(awk -F":" "/xhci-hcd/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity_list
-			echo 3 >/proc/irq/$(awk -F":" "/eth0/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity_list
+			echo 2 > /proc/irq/$(awk -F":" "/xhci-hcd/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity_list
+			echo 3 > /proc/irq/$(awk -F":" "/eth0/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity_list
 			# mainline kernel might lack those
-			[[ -n $(grep "rdma" /proc/interrupts) ]] && echo 4 >/proc/irq/$(awk -F":" "/rdma/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity_list
-			[[ -n $(grep "osd-vsync" /proc/interrupts) ]] && echo 5 >/proc/irq/$(awk -F":" "/ osd-vsync/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity_list
+			[[ -n $(grep "rdma" /proc/interrupts) ]] && echo 4 > /proc/irq/$(awk -F":" "/rdma/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity_list
+			[[ -n $(grep "osd-vsync" /proc/interrupts) ]] && echo 5 > /proc/irq/$(awk -F":" "/ osd-vsync/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity_list
 
-                        # test fan on Odroid N2 plus - spin it up shortly
-                        if [[ -f /sys/devices/virtual/thermal/thermal_zone0/trip_point_4_temp ]]; then
-                                echo 20000 > /sys/devices/virtual/thermal/thermal_zone0/trip_point_4_temp
-                                sleep 1
-                                echo 65000 > /sys/devices/virtual/thermal/thermal_zone0/trip_point_4_temp
-                        fi
+			# test fan on Odroid N2 plus - spin it up shortly
+			if [[ -f /sys/devices/virtual/thermal/thermal_zone0/trip_point_4_temp ]]; then
+				echo 20000 > /sys/devices/virtual/thermal/thermal_zone0/trip_point_4_temp
+				sleep 1
+				echo 65000 > /sys/devices/virtual/thermal/thermal_zone0/trip_point_4_temp
+			fi
 
 			;;
 		mvebu*) # Clearfog/Turris/Helios4/Espressobin: Send network IRQs to cpu1 on both kernels
 			for i in $(awk -F':' '/mwlwifi|mvneta|eth0/{print $1}' /proc/interrupts | sed 's/\ //g'); do
-				echo 2 >/proc/irq/$i/smp_affinity
+				echo 2 > /proc/irq/$i/smp_affinity
 			done
 			;;
 		odroidc1) # ODROID-C0/C1/C1+
-			echo 1 >/proc/irq/$(awk -F":" "/usb1/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity_list
-			for i in $(awk -F':' '/Mali_/{print $1}' </proc/interrupts | sed 's/\ //g'); do echo 1 >/proc/irq/${i}/smp_affinity_list; done
-			echo 2 >/proc/irq/$(awk -F":" "/usb2/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity_list
-			echo 3 >/proc/irq/$(awk -F":" "/eth0/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity_list
-			echo 7 >/sys/class/net/eth0/queues/rx-0/rps_cpus
+			echo 1 > /proc/irq/$(awk -F":" "/usb1/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity_list
+			for i in $(awk -F':' '/Mali_/{print $1}' < /proc/interrupts | sed 's/\ //g'); do echo 1 > /proc/irq/${i}/smp_affinity_list; done
+			echo 2 > /proc/irq/$(awk -F":" "/usb2/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity_list
+			echo 3 > /proc/irq/$(awk -F":" "/eth0/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity_list
+			echo 7 > /sys/class/net/eth0/queues/rx-0/rps_cpus
 			;;
-		odroidc2|meson64) # S905/S905X/S912: both kernels: send eth0 to cpu3, mmc/usb2 to cpu2 and usb1 to cpu1
+		odroidc2 | meson64) # S905/S905X/S912: both kernels: send eth0 to cpu3, mmc/usb2 to cpu2 and usb1 to cpu1
 			# Basics: http://forum.odroid.com/viewtopic.php?f=115&t=8121#p65777
-			for i in $(awk -F':' '/sd_emmc|usb2/{print $1}' </proc/interrupts | sed 's/\ //g'); do
-				echo 1 >/proc/irq/$i/smp_affinity_list
+			for i in $(awk -F':' '/sd_emmc|usb2/{print $1}' < /proc/interrupts | sed 's/\ //g'); do
+				echo 1 > /proc/irq/$i/smp_affinity_list
 			done
-			echo 2 >/proc/irq/$(awk -F":" "/usb1/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity_list
-			echo 3 >/proc/irq/$(awk -F":" "/eth0/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity_list
-			echo 7 >/sys/class/net/eth0/queues/rx-0/rps_cpus
+			echo 2 > /proc/irq/$(awk -F":" "/usb1/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity_list
+			echo 3 > /proc/irq/$(awk -F":" "/eth0/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity_list
+			echo 7 > /sys/class/net/eth0/queues/rx-0/rps_cpus
 			;;
 		odroidxu4) # ODROID XU3/XU4/HC1/MC1/HC2
-			echo 2 >/proc/irq/$(awk -F":" "/:usb2/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
-			echo 4 >/proc/irq/$(awk -F":" "/:usb3/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
-			echo 7 >/proc/irq/$(awk -F":" "/:usb5/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity_list
-			echo 16 >/proc/irq/$(awk -F":" "/dw-mci/ {print \$1}" </proc/interrupts | sed 's/\ //g' | tail -1)/smp_affinity
-			echo 32 >/proc/irq/$(awk -F":" "/dw-mci/ {print \$1}" </proc/interrupts | sed 's/\ //g' | head -1)/smp_affinity
-			for i in $(awk -F':' '/11800000.mali/{print $1}' </proc/interrupts | sed 's/\ //g'); do
-				echo 64 >/proc/irq/$i/smp_affinity
+			echo 2 > /proc/irq/$(awk -F":" "/:usb2/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity
+			echo 4 > /proc/irq/$(awk -F":" "/:usb3/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity
+			echo 7 > /proc/irq/$(awk -F":" "/:usb5/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity_list
+			echo 16 > /proc/irq/$(awk -F":" "/dw-mci/ {print \$1}" < /proc/interrupts | sed 's/\ //g' | tail -1)/smp_affinity
+			echo 32 > /proc/irq/$(awk -F":" "/dw-mci/ {print \$1}" < /proc/interrupts | sed 's/\ //g' | head -1)/smp_affinity
+			for i in $(awk -F':' '/11800000.mali/{print $1}' < /proc/interrupts | sed 's/\ //g'); do
+				echo 64 > /proc/irq/$i/smp_affinity
 			done
-			echo 32768 >/proc/sys/net/core/rps_sock_flow_entries
+			echo 32768 > /proc/sys/net/core/rps_sock_flow_entries
 			;;
 		rockchip) # RK3288: usb1 on cpu1, usb3 (EHCI) on cpu2, eth0 and GPU on cpu3
-			echo 2 >/proc/irq/$(awk -F":" "/usb1/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
-			echo 4 >/proc/irq/$(awk -F":" "/usb3/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
-			echo 8 >/proc/irq/$(awk -F":" "/eth0/ {print \$1}" </proc/interrupts | sed 's/\ //g' | head -n1)/smp_affinity
-			echo 7 >/sys/class/net/eth0/queues/rx-0/rps_cpus
+			echo 2 > /proc/irq/$(awk -F":" "/usb1/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity
+			echo 4 > /proc/irq/$(awk -F":" "/usb3/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity
+			echo 8 > /proc/irq/$(awk -F":" "/eth0/ {print \$1}" < /proc/interrupts | sed 's/\ //g' | head -n1)/smp_affinity
+			echo 7 > /sys/class/net/eth0/queues/rx-0/rps_cpus
 			for i in $(awk -F':' '/gpu/{print $1}' /proc/interrupts | sed 's/\ //g'); do
-				echo 8 >/proc/irq/$i/smp_affinity
+				echo 8 > /proc/irq/$i/smp_affinity
 			done
 			;;
 		rk322x) # RK322x: usb otg on cpu1, usb2,3,4 (EHCI), usb5,6,7 (OHCI) on cpu2, eth and GPU on cpu3
-			echo 2 >/proc/irq/$(awk -F":" "/:usb1/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
-			echo 4 >/proc/irq/$(awk -F":" "/:usb2/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
-			echo 4 >/proc/irq/$(awk -F":" "/:usb3/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
-			echo 4 >/proc/irq/$(awk -F":" "/:usb4/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
-			echo 4 >/proc/irq/$(awk -F":" "/:usb5/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
-			echo 4 >/proc/irq/$(awk -F":" "/:usb6/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
-			echo 4 >/proc/irq/$(awk -F":" "/:usb7/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
-			echo 8 >/proc/irq/$(awk -F":" "/eth0/ {print \$1}" </proc/interrupts | sed 's/\ //g' | head -n1)/smp_affinity
-			echo 7 >/sys/class/net/eth0/queues/rx-0/rps_cpus
+			echo 2 > /proc/irq/$(awk -F":" "/:usb1/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity
+			echo 4 > /proc/irq/$(awk -F":" "/:usb2/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity
+			echo 4 > /proc/irq/$(awk -F":" "/:usb3/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity
+			echo 4 > /proc/irq/$(awk -F":" "/:usb4/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity
+			echo 4 > /proc/irq/$(awk -F":" "/:usb5/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity
+			echo 4 > /proc/irq/$(awk -F":" "/:usb6/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity
+			echo 4 > /proc/irq/$(awk -F":" "/:usb7/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity
+			echo 8 > /proc/irq/$(awk -F":" "/eth0/ {print \$1}" < /proc/interrupts | sed 's/\ //g' | head -n1)/smp_affinity
+			echo 7 > /sys/class/net/eth0/queues/rx-0/rps_cpus
 
 			# Mali in 4.4 kernel
 			for i in $(awk -F':' '/Mali_/{print $1}' /proc/interrupts | sed 's/\ //g'); do
-				echo 8 >/proc/irq/$i/smp_affinity
+				echo 8 > /proc/irq/$i/smp_affinity
 			done
 
 			# Lima in mainline kernel
-			echo 8 >/proc/irq/$(awk -F':' '/gp$/{print $1}' /proc/interrupts | sed 's/\ //g')/smp_affinity
-			echo 8 >/proc/irq/$(awk -F':' '/gpmmu/{print $1}' /proc/interrupts | sed 's/\ //g')/smp_affinity
-			echo 8 >/proc/irq/$(awk -F':' '/pp0/{print $1}' /proc/interrupts | sed 's/\ //g')/smp_affinity
+			echo 8 > /proc/irq/$(awk -F':' '/gp$/{print $1}' /proc/interrupts | sed 's/\ //g')/smp_affinity
+			echo 8 > /proc/irq/$(awk -F':' '/gpmmu/{print $1}' /proc/interrupts | sed 's/\ //g')/smp_affinity
+			echo 8 > /proc/irq/$(awk -F':' '/pp0/{print $1}' /proc/interrupts | sed 's/\ //g')/smp_affinity
 			;;
 		rockchip64) # Rock64 and Renegade: GPU on cpu1, USB3 on cpu2, Ethernet on cpu3
-			for i in $(awk -F':' '/Mali/{print $1}' </proc/interrupts | sed 's/\ //g'); do
-				echo 2 >/proc/irq/$i/smp_affinity
+			for i in $(awk -F':' '/Mali/{print $1}' < /proc/interrupts | sed 's/\ //g'); do
+				echo 2 > /proc/irq/$i/smp_affinity
 			done
-			for i in $(awk -F":" "/ehci/ {print \$1}" </proc/interrupts | sed 's/\ //g'); do
-				echo 2 >/proc/irq/$i/smp_affinity
+			for i in $(awk -F":" "/ehci/ {print \$1}" < /proc/interrupts | sed 's/\ //g'); do
+				echo 2 > /proc/irq/$i/smp_affinity
 			done
-			for i in $(awk -F":" "/ohci/ {print \$1}" </proc/interrupts | sed 's/\ //g'); do
-				echo 2 >/proc/irq/$i/smp_affinity
+			for i in $(awk -F":" "/ohci/ {print \$1}" < /proc/interrupts | sed 's/\ //g'); do
+				echo 2 > /proc/irq/$i/smp_affinity
 			done
-			for i in $(awk -F":" "/xhci/ {print \$1}" </proc/interrupts | sed 's/\ //g'); do
-				echo 4 >/proc/irq/$i/smp_affinity
+			for i in $(awk -F":" "/xhci/ {print \$1}" < /proc/interrupts | sed 's/\ //g'); do
+				echo 4 > /proc/irq/$i/smp_affinity
 			done
 
 			# Wait (up to 5s) until eth0 brought up
@@ -224,26 +220,26 @@ prepare_board() {
 				sleep 1
 			done
 
-			echo 8 >/proc/irq/$(awk -F":" "/eth0/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
-			echo 7 >/sys/class/net/eth0/queues/rx-0/rps_cpus
-			echo 32768 >/proc/sys/net/core/rps_sock_flow_entries
-			echo 32768 >/sys/class/net/eth0/queues/rx-0/rps_flow_cnt
+			echo 8 > /proc/irq/$(awk -F":" "/eth0/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity
+			echo 7 > /sys/class/net/eth0/queues/rx-0/rps_cpus
+			echo 32768 > /proc/sys/net/core/rps_sock_flow_entries
+			echo 32768 > /sys/class/net/eth0/queues/rx-0/rps_flow_cnt
 			;;
-		rk3399|media)
-			for i in $(awk -F':' '/gpu/{print $1}' </proc/interrupts | sed 's/\ //g'); do
-				echo 2 >/proc/irq/$i/smp_affinity
+		rk3399 | media)
+			for i in $(awk -F':' '/gpu/{print $1}' < /proc/interrupts | sed 's/\ //g'); do
+				echo 2 > /proc/irq/$i/smp_affinity
 			done
-			for i in $(awk -F':' '/dw-mci/{print $1}' </proc/interrupts | sed 's/\ //g'); do
-				echo 2 >/proc/irq/$i/smp_affinity
+			for i in $(awk -F':' '/dw-mci/{print $1}' < /proc/interrupts | sed 's/\ //g'); do
+				echo 2 > /proc/irq/$i/smp_affinity
 			done
-			for i in $(awk -F":" "/ehci/ {print \$1}" </proc/interrupts | sed 's/\ //g'); do
-				echo 2 >/proc/irq/$i/smp_affinity
+			for i in $(awk -F":" "/ehci/ {print \$1}" < /proc/interrupts | sed 's/\ //g'); do
+				echo 2 > /proc/irq/$i/smp_affinity
 			done
-			for i in $(awk -F":" "/ohci/ {print \$1}" </proc/interrupts | sed 's/\ //g'); do
-				echo 2 >/proc/irq/$i/smp_affinity
+			for i in $(awk -F":" "/ohci/ {print \$1}" < /proc/interrupts | sed 's/\ //g'); do
+				echo 2 > /proc/irq/$i/smp_affinity
 			done
-			for i in $(awk -F":" "/xhci/ {print \$1}" </proc/interrupts | sed 's/\ //g'); do
-				echo 4 >/proc/irq/$i/smp_affinity
+			for i in $(awk -F":" "/xhci/ {print \$1}" < /proc/interrupts | sed 's/\ //g'); do
+				echo 4 > /proc/irq/$i/smp_affinity
 			done
 
 			# Wait (up to 5s) until eth0 brought up
@@ -252,12 +248,12 @@ prepare_board() {
 				sleep 1
 			done
 
-			echo 8 >/proc/irq/$(awk -F":" "/eth0/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
-			echo 7 >/sys/class/net/eth0/queues/rx-0/rps_cpus
-			echo 32768 >/proc/sys/net/core/rps_sock_flow_entries
-			echo 32768 >/sys/class/net/eth0/queues/rx-0/rps_flow_cnt
-			for i in $(awk -F':' 'tolower($0) ~ /pcie/{print $1}' </proc/interrupts | sed 's/\ //g'); do
-				echo 16 >/proc/irq/$i/smp_affinity
+			echo 8 > /proc/irq/$(awk -F":" "/eth0/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity
+			echo 7 > /sys/class/net/eth0/queues/rx-0/rps_cpus
+			echo 32768 > /proc/sys/net/core/rps_sock_flow_entries
+			echo 32768 > /sys/class/net/eth0/queues/rx-0/rps_flow_cnt
+			for i in $(awk -F':' 'tolower($0) ~ /pcie/{print $1}' < /proc/interrupts | sed 's/\ //g'); do
+				echo 16 > /proc/irq/$i/smp_affinity
 			done
 			# set dmc memory governor to performance with default kernel
 			if [ -f /sys/bus/platform/drivers/rockchip-dmc/dmc/devfreq/dmc/governor ]; then
@@ -265,116 +261,124 @@ prepare_board() {
 			fi
 			case ${BOARD_NAME} in
 				"Helios64")
-					for i in $(awk -F":" "/xhci/ {print \$1}" </proc/interrupts | sed 's/\ //g'); do
-						echo 10 >/proc/irq/$i/smp_affinity
+					for i in $(awk -F":" "/xhci/ {print \$1}" < /proc/interrupts | sed 's/\ //g'); do
+						echo 10 > /proc/irq/$i/smp_affinity
 					done
-					for i in $(awk -F":" "/ahci/ {print \$1}" </proc/interrupts | sed 's/\ //g'); do
-						echo 30 >/proc/irq/$i/smp_affinity
+					for i in $(awk -F":" "/ahci/ {print \$1}" < /proc/interrupts | sed 's/\ //g'); do
+						echo 30 > /proc/irq/$i/smp_affinity
 					done
 					;;
 				"Pinebook Pro")
-					echo s2idle >/sys/power/mem_sleep
+					echo s2idle > /sys/power/mem_sleep
 					;;
 			esac
 			;;
 		s500) # Roseapple Pi/LeMaker Guitar: send USB IRQs to cpu1/cpu2, DMA0 to cpu2 and Ethernet + SD card to cpu3
-			echo 2 >/proc/irq/$(awk -F":" "/usb1/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
-			echo 4 >/proc/irq/$(awk -F":" "/usb2/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity 2>/dev/null
-			echo 4 >/proc/irq/$(awk -F":" "/usb3/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity 2>/dev/null
-			echo 4 >/proc/irq/$(awk -F":" "/owl_dma0/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
-			echo 8 >/proc/irq/$(awk -F":" "/ethernet_mac/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
-			echo 8 >/proc/irq/$(awk -F":" "/sdcard/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
+			echo 2 > /proc/irq/$(awk -F":" "/usb1/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity
+			echo 4 > /proc/irq/$(awk -F":" "/usb2/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity 2> /dev/null
+			echo 4 > /proc/irq/$(awk -F":" "/usb3/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity 2> /dev/null
+			echo 4 > /proc/irq/$(awk -F":" "/owl_dma0/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity
+			echo 8 > /proc/irq/$(awk -F":" "/ethernet_mac/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity
+			echo 8 > /proc/irq/$(awk -F":" "/sdcard/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity
 			;;
 		s5p6818) # NanoPi M3: dw-mci on cpu1, USB host on cpu2, GbE on cpu3, USB OTG on cpu4, video-codec on cpu5
-			for i in $(awk -F':' '/dw-mci/{print $1}' </proc/interrupts | sed 's/\ //g'); do
-				echo 1 >/proc/irq/$i/smp_affinity_list
+			for i in $(awk -F':' '/dw-mci/{print $1}' < /proc/interrupts | sed 's/\ //g'); do
+				echo 1 > /proc/irq/$i/smp_affinity_list
 			done
-			echo 2 >/proc/irq/$(awk -F":" "/usb3/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity_list
-			echo 3 >/proc/irq/$(awk -F":" "/eth0/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity_list
-			echo 4 >/proc/irq/$(awk -F":" "/usb1/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity_list
-			for i in $(awk -F':' '/c0080000.video-codec/{print $1}' </proc/interrupts | sed 's/\ //g'); do
-				echo 5 >/proc/irq/$i/smp_affinity_list
+			echo 2 > /proc/irq/$(awk -F":" "/usb3/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity_list
+			echo 3 > /proc/irq/$(awk -F":" "/eth0/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity_list
+			echo 4 > /proc/irq/$(awk -F":" "/usb1/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity_list
+			for i in $(awk -F':' '/c0080000.video-codec/{print $1}' < /proc/interrupts | sed 's/\ //g'); do
+				echo 5 > /proc/irq/$i/smp_affinity_list
 			done
-			echo 7 >/sys/class/net/eth0/queues/rx-0/rps_cpus
-			echo 32768 >/proc/sys/net/core/rps_sock_flow_entries
-			echo 32768 >/sys/class/net/eth0/queues/rx-0/rps_flow_cnt
+			echo 7 > /sys/class/net/eth0/queues/rx-0/rps_cpus
+			echo 32768 > /proc/sys/net/core/rps_sock_flow_entries
+			echo 32768 > /sys/class/net/eth0/queues/rx-0/rps_flow_cnt
 			;;
-		sun4i|sun5i|rda8810) # only one core, nothing to improve
+		sun4i | sun5i | rda8810) # only one core, nothing to improve
 			:
 			;;
 		sun6i) # Banana Pi M2: process eth0 on cpu3, SDIO on cpu2, USB on cpu1
 			for i in $(awk -F':' '/hcd:usb/{print $1}' /proc/interrupts | sed 's/\ //g'); do
-				echo 2 >/proc/irq/$i/smp_affinity
+				echo 2 > /proc/irq/$i/smp_affinity
 			done
 			for i in $(awk -F':' '/sunxi-mmc/{print $1}' /proc/interrupts | sed 's/\ //g'); do
-				echo 4 >/proc/irq/$i/smp_affinity
+				echo 4 > /proc/irq/$i/smp_affinity
 			done
-			echo 8 >/proc/irq/$(awk -F":" '/eth0/ {print $1}' </proc/interrupts | sed 's/\ //g')/smp_affinity
-			echo 7 >/sys/class/net/eth0/queues/rx-0/rps_cpus
+			echo 8 > /proc/irq/$(awk -F":" '/eth0/ {print $1}' < /proc/interrupts | sed 's/\ //g')/smp_affinity
+			echo 7 > /sys/class/net/eth0/queues/rx-0/rps_cpus
 			;;
 		sun7i) # try to redistribute eth0 irq to dedicated core
-			echo 2 >/proc/irq/$(awk -F":" '/eth0/ {print $1}' </proc/interrupts | sed 's/\ //g')/smp_affinity 2>/dev/null
+			echo 2 > /proc/irq/$(awk -F":" '/eth0/ {print $1}' < /proc/interrupts | sed 's/\ //g')/smp_affinity 2> /dev/null
 			;;
 		sun8i*) # H3/R40/V40 boards, try to do the best based on specific board since interfaces vary a lot
 			# 10 or 120 sec user feedback that the board is ready after 1st login with 3.4 kernel
 			SwapState="$(grep swap /etc/fstab)"
 			if [ "X${SwapState}" != "X" ]; then
-				(echo heartbeat >/sys/class/leds/*green*/trigger) 2>/dev/null
+				(echo heartbeat > /sys/class/leds/*green*/trigger) 2> /dev/null
 				[ -f "/root/.not_logged_in_yet" ] && BlinkTime=120 || BlinkTime=10
-				(sleep ${BlinkTime} && (echo default-on >/sys/class/leds/*green*/trigger) 2>/dev/null) &
+				(sleep ${BlinkTime} && (echo default-on > /sys/class/leds/*green*/trigger) 2> /dev/null) &
 			fi
 
 			# check kernel version for IRQ/module names
 			case ${KERNELID} in
 				3*)
 					# BSP kernel
-					GbE="gmac0"; WiFi="wlan0"; USB1="usb2"; USB2="usb3"; USB3="usb4"
+					GbE="gmac0"
+					WiFi="wlan0"
+					USB1="usb2"
+					USB2="usb3"
+					USB3="usb4"
 					;;
 				*)
 					# Mainline kernel
-					GbE="eth0"; WiFi="wlan0"; USB1="usb3"; USB2="usb4"; USB3="usb5"
+					GbE="eth0"
+					WiFi="wlan0"
+					USB1="usb3"
+					USB2="usb4"
+					USB3="usb5"
 					;;
 			esac
 			# Assign 1st and 2nd USB port to cpu1 and cpu2 on every sun8i board
-			echo 2 >/proc/irq/$(awk -F":" "/${USB1}/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
-			echo 4 >/proc/irq/$(awk -F":" "/${USB2}/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
+			echo 2 > /proc/irq/$(awk -F":" "/${USB1}/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity
+			echo 4 > /proc/irq/$(awk -F":" "/${USB2}/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity
 			case ${BOARD_NAME} in
-				"Orange Pi+"|"Orange Pi+ 2"|"Orange Pi+ 2E"|"Banana Pi M2*"|"NanoPi M1 Plus")
+				"Orange Pi+" | "Orange Pi+ 2" | "Orange Pi+ 2E" | "Banana Pi M2*" | "NanoPi M1 Plus")
 					# Send GBit Ethernet IRQs to cpu3
-					echo 8 >/proc/irq/$(awk -F":" "/${GbE}/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
-					echo 7 >/sys/class/net/eth0/queues/rx-0/rps_cpus
+					echo 8 > /proc/irq/$(awk -F":" "/${GbE}/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity
+					echo 7 > /sys/class/net/eth0/queues/rx-0/rps_cpus
 					;;
-				"NanoPi M1"|"Orange Pi PC Plus"|"Orange Pi PC +"|"Orange Pi PC"|"NanoPi Neo"|"Orange Pi Zero")
+				"NanoPi M1" | "Orange Pi PC Plus" | "Orange Pi PC +" | "Orange Pi PC" | "NanoPi Neo" | "Orange Pi Zero")
 					# Send 3rd USB port's IRQs to cpu3
-					echo 8 >/proc/irq/$(awk -F":" "/${USB3}/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
+					echo 8 > /proc/irq/$(awk -F":" "/${USB3}/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity
 					;;
-				"Orange Pi Lite"|"NanoPi Air"|"Lime A33"|"Orange Pi Zero Plus 2"*)
+				"Orange Pi Lite" | "NanoPi Air" | "Lime A33" | "Orange Pi Zero Plus 2"*)
 					# Send SDIO/mmc IRQs to cpu3
-					for i in $(awk -F':' '/sunxi-mmc/{print $1}' </proc/interrupts | sed 's/\ //g'); do
-						echo 8 >/proc/irq/$i/smp_affinity
+					for i in $(awk -F':' '/sunxi-mmc/{print $1}' < /proc/interrupts | sed 's/\ //g'); do
+						echo 8 > /proc/irq/$i/smp_affinity
 					done
 					;;
-				"Beelink X2"|"Orange Pi R1"|"ZeroPi")
+				"Beelink X2" | "Orange Pi R1" | "ZeroPi")
 					# Wifi module reload workaround / fix
 					[[ -n $(lsmod | grep 8189es) && "${BOARD_NAME}" != "ZeroPi" ]] && rmmod 8189es && modprobe 8189es
 					# Send SDIO to cpu1, USB to cpu2, Ethernet to cpu3
-					for i in $(awk -F':' '/sunxi-mmc/{print $1}' </proc/interrupts | sed 's/\ //g'); do
-						echo 2 >/proc/irq/$i/smp_affinity
+					for i in $(awk -F':' '/sunxi-mmc/{print $1}' < /proc/interrupts | sed 's/\ //g'); do
+						echo 2 > /proc/irq/$i/smp_affinity
 					done
-					for i in $(awk -F':' '/hcd:usb/{print $1}' </proc/interrupts | sed 's/\ //g'); do
-						echo 4 >/proc/irq/$i/smp_affinity
+					for i in $(awk -F':' '/hcd:usb/{print $1}' < /proc/interrupts | sed 's/\ //g'); do
+						echo 4 > /proc/irq/$i/smp_affinity
 					done
-					echo 8 >/proc/irq/$(awk -F":" "/${GbE}/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
+					echo 8 > /proc/irq/$(awk -F":" "/${GbE}/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity
 					;;
 			esac
 			;;
-		sun50i*|sunxi64*) # A64/H5 based boards like Pine64, OPi PC 2, NanoPi NEO 2
+		sun50i* | sunxi64*) # A64/H5 based boards like Pine64, OPi PC 2, NanoPi NEO 2
 			# Send IRQs for the lower real USB port (usb2) to cpu2 and for the upper (OTG/usb1) to cpu1
-			echo 2 >/proc/irq/$(awk -F":" "/usb1/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
-			echo 4 >/proc/irq/$(awk -F":" "/usb2/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
-			echo 8 >/proc/irq/$(awk -F":" "/sunxi-mmc/ {print \$1}" </proc/interrupts | sed 's/\ //g' | head -n1)/smp_affinity
-			echo 8 >/proc/irq/$(awk -F":" "/eth/ {print \$1}" </proc/interrupts | sed 's/\ //g' | head -n1)/smp_affinity
-			echo 7 >/sys/class/net/eth0/queues/rx-0/rps_cpus
+			echo 2 > /proc/irq/$(awk -F":" "/usb1/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity
+			echo 4 > /proc/irq/$(awk -F":" "/usb2/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity
+			echo 8 > /proc/irq/$(awk -F":" "/sunxi-mmc/ {print \$1}" < /proc/interrupts | sed 's/\ //g' | head -n1)/smp_affinity
+			echo 8 > /proc/irq/$(awk -F":" "/eth/ {print \$1}" < /proc/interrupts | sed 's/\ //g' | head -n1)/smp_affinity
+			echo 7 > /sys/class/net/eth0/queues/rx-0/rps_cpus
 			# OrangePi win GMAC is very unstable on gigabit. Limit it down to 100Mb solve problems
 			[[ $BOARD == orangepiwin && $BRANCH == default ]] && ethtool -s eth0 speed 100 duplex full
 			;;
@@ -387,7 +391,9 @@ add_usb_storage_quirks() {
 	[ -f /boot/armbianEnv.txt ] || return
 
 	# cleanup. add LF. This prevents adding parameters to the same line
-	echo "" >> /boot/armbianEnv.txt;  sed -i '/^$/d;$G' /boot/armbianEnv.txt; sed -i '/^$/d;$G' /boot/armbianEnv.txt
+	echo "" >> /boot/armbianEnv.txt
+	sed -i '/^$/d;$G' /boot/armbianEnv.txt
+	sed -i '/^$/d;$G' /boot/armbianEnv.txt
 
 	# cleanup. remove empty lines in the middle
 	sed -i '/^$/d' /boot/armbianEnv.txt
@@ -395,34 +401,32 @@ add_usb_storage_quirks() {
 	# preserve old contents if existent
 	TMPFILE=$(mktemp /tmp/${0##*/}.XXXXXX)
 	trap "sleep 1 ; rm \"${TMPFILE}\" ; exit 0" 0 1 2 3 15
-	awk -F"=" '/^usbstoragequirks/ {print $2}' </boot/armbianEnv.txt | tr -d -c '[:graph:]' >${TMPFILE}
+	awk -F"=" '/^usbstoragequirks/ {print $2}' < /boot/armbianEnv.txt | tr -d -c '[:graph:]' > ${TMPFILE}
 
 	# UAS blacklist Norelsys NS1068X and NS1066X since broken. Can be removed once
 	# they're blacklisted upstream
-	[ -s ${TMPFILE} ] || echo "0x2537:0x1066:u,0x2537:0x1068:u" >${TMPFILE}
+	[ -s ${TMPFILE} ] || echo "0x2537:0x1066:u,0x2537:0x1068:u" > ${TMPFILE}
 
 	# check for connected Seagate or WD HDD enclosures and blacklist them all
-	lsusb | awk -F" " '{print "0x"$6}' | sed 's/:/:0x/' | sort | uniq | while read ; do
+	lsusb | awk -F" " '{print "0x"$6}' | sed 's/:/:0x/' | sort | uniq | while read; do
 		case ${REPLY} in
-			"0x0bc2:"*|"0x1058:"*)
+			"0x0bc2:"* | "0x1058:"*)
 				grep -q "${REPLY}" ${TMPFILE} || sed -i "1 s/\$/,${REPLY}:u/" ${TMPFILE}
 				;;
 		esac
 	done
 
-	read USBQUIRKS <${TMPFILE}
+	read USBQUIRKS < ${TMPFILE}
 	sed -i '/^usbstoragequirks/d' /boot/armbianEnv.txt
-	echo "usbstoragequirks=${USBQUIRKS}" >>/boot/armbianEnv.txt
+	echo "usbstoragequirks=${USBQUIRKS}" >> /boot/armbianEnv.txt
 	sync &
 	if [ -f /sys/module/usb_storage/parameters/quirks ]; then
-		echo ${USBQUIRKS} >/sys/module/usb_storage/parameters/quirks
+		echo ${USBQUIRKS} > /sys/module/usb_storage/parameters/quirks
 	fi
 
 } # add_usb_storage_quirks
 
-
-update_branch_from_installed_kernel()
-{
+update_branch_from_installed_kernel() {
 
 	BRANCH=$(dpkg -l | grep -E "linux-image" | grep -E "current|legacy|edge" | awk '{print $2}' | cut -d"-" -f3 | head -1)
 	if grep -q BRANCH /etc/armbian-release; then
@@ -431,7 +435,6 @@ update_branch_from_installed_kernel()
 		[[ -n ${BRANCH} ]] && echo "BRANCH=$BRANCH" >> /etc/armbian-release
 	fi
 }
-
 
 case $1 in
 	*start*)


### PR DESCRIPTION
#### Syntax error fixes, dep checks & `shfmt` of board-side bash scripts

- `shfmt` everything, so maybe it's easier to understand.

- `armbian-hardware-optimization`: fix for `case` without `esac` introduced in #4417; `shfmt` 
- `armbian-audio-config`: do nothing if aplay/amixer/alsactl missing; `shfmt` 