### PR TITLE
Don't block but warn user on weak password

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -262,7 +262,7 @@ add_user()
 			result="$(cracklib-check <<<"$password")"
 			okay="$(awk -F': ' '{ print $2}' <<<"$result")"
 			if [[ "$okay" != "OK" ]]; then
-				echo -e "\e[0;31mWarning:\x1B[0m Weak password\!"
+				echo -e "\n\e[0;31mWarning:\x1B[0m Weak password!"
 			fi
 			echo -e ""
 			read -e -p "Please provide your real name: " -i "${RealUserName^}" RealName
@@ -347,13 +347,11 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 		if [[ "$first_input" == "$second_input" ]]; then
 			result="$(cracklib-check <<<"$password")"
 			okay="$(awk -F': ' '{ print $2}' <<<"$result")"
-			if [[ "$okay" == "OK" ]]; then
+			if [[ "$okay" != "OK" ]]; then
+				echo -e "\n\e[0;31mWarning:\x1B[0m $okay!"
 				(echo "$first_input";echo "$second_input";) | passwd root >/dev/null 2>&1
-				break
-				else
-				echo -e "Rejected - \e[0;31m$okay.\x1B[0m Try again [${REPEATS}]."
-				REPEATS=$((REPEATS - 1))
 			fi
+			break
 		elif [[ -n $password ]]; then
 			echo -e "Rejected - \e[0;31mpasswords do not match.\x1B[0m Try again [${REPEATS}]."
 			REPEATS=$((REPEATS - 1))

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -261,42 +261,40 @@ add_user()
 		if [[ "$first_input" == "$second_input" ]]; then
 			result="$(cracklib-check <<<"$password")"
 			okay="$(awk -F': ' '{ print $2}' <<<"$result")"
-			if [[ "$okay" == "OK" ]]; then
-				echo -e ""
-				read -e -p "Please provide your real name: " -i "${RealUserName^}" RealName
-
-				adduser --quiet --disabled-password --home /home/"$RealUserName" --gecos "$RealName" "$RealUserName"
-				(echo "$first_input";echo "$second_input";) | passwd "$RealUserName" >/dev/null 2>&1
-				for additionalgroup in sudo netdev audio video disk tty users games dialout plugdev input bluetooth systemd-journal ssh; do
-					usermod -aG "${additionalgroup}" "${RealUserName}" 2>/dev/null
-				done
-
-				# fix for gksu in Xenial
-				touch /home/"$RealUserName"/.Xauthority
-				chown "$RealUserName":"$RealUserName" /home/"$RealUserName"/.Xauthority
-				RealName="$(awk -F":" "/^${RealUserName}:/ {print \$5}" </etc/passwd | cut -d',' -f1)"
-				[ -z "$RealName" ] && RealName="$RealUserName"
-				echo -e "\nDear \e[0;92m${RealName}\x1B[0m, your account \e[0;92m${RealUserName}\x1B[0m has been created and is sudo enabled."
-				echo -e "Please use this account for your daily work from now on.\n"
-				rm -f /root/.not_logged_in_yet
-				chmod +x /etc/update-motd.d/*
-				# set up profile sync daemon on desktop systems
-				command -v psd >/dev/null 2>&1
-				if [ $? -eq 0 ]; then
-					echo -e "${RealUserName} ALL=(ALL) NOPASSWD: /usr/bin/psd-overlay-helper" >> /etc/sudoers
-					touch /home/"${RealUserName}"/.activate_psd
-					chown "$RealUserName":"$RealUserName" /home/"${RealUserName}"/.activate_psd
-				fi
-				break
-			else
-				echo -e "Rejected - \e[0;31m$okay.\x1B[0m Try again [${REPEATS}]."
-				REPEATS=$((REPEATS - 1))
+			if [[ "$okay" != "OK" ]]; then
+				echo -e "\e[0;31mWarning:\x1B[0m Weak password\!"
 			fi
+			echo -e ""
+			read -e -p "Please provide your real name: " -i "${RealUserName^}" RealName
+
+			adduser --quiet --disabled-password --home /home/"$RealUserName" --gecos "$RealName" "$RealUserName"
+			(echo "$first_input";echo "$second_input";) | passwd "$RealUserName" >/dev/null 2>&1
+			for additionalgroup in sudo netdev audio video disk tty users games dialout plugdev input bluetooth systemd-journal ssh; do
+				usermod -aG "${additionalgroup}" "${RealUserName}" 2>/dev/null
+			done
+
+			# fix for gksu in Xenial
+			touch /home/"$RealUserName"/.Xauthority
+			chown "$RealUserName":"$RealUserName" /home/"$RealUserName"/.Xauthority
+			RealName="$(awk -F":" "/^${RealUserName}:/ {print \$5}" </etc/passwd | cut -d',' -f1)"
+			[ -z "$RealName" ] && RealName="$RealUserName"
+			echo -e "\nDear \e[0;92m${RealName}\x1B[0m, your account \e[0;92m${RealUserName}\x1B[0m has been created and is sudo enabled."
+			echo -e "Please use this account for your daily work from now on.\n"
+			rm -f /root/.not_logged_in_yet
+			chmod +x /etc/update-motd.d/*
+			# set up profile sync daemon on desktop systems
+			command -v psd >/dev/null 2>&1
+			if [ $? -eq 0 ]; then
+				echo -e "${RealUserName} ALL=(ALL) NOPASSWD: /usr/bin/psd-overlay-helper" >> /etc/sudoers
+				touch /home/"${RealUserName}"/.activate_psd
+				chown "$RealUserName":"$RealUserName" /home/"${RealUserName}"/.activate_psd
+			fi
+			break
 		elif [[ -n $password ]]; then
 			echo -e "Rejected - \e[0;31mpasswords do not match.\x1B[0m Try again [${REPEATS}]."
 			REPEATS=$((REPEATS - 1))
 		fi
-		[[ "$REPEATS" -eq 0 ]] && exit
+		[[ "$REPEATS" -eq 0 ]] && logout
 	done
 
 }


### PR DESCRIPTION
# Description

There was complain on forums that current way of blocking weak password is out of standard. Warning on weak password should be enough.

Jira reference number [AR-1385]

# How Has This Been Tested?

- [x] Build fresh image and see if it works.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1385]: https://armbian.atlassian.net/browse/AR-1385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ