### PR TITLE
Change to supported Github Action module

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -87,7 +87,7 @@ jobs:
         uses: Vucko130/delete-older-releases@v0.2.1
         with:
           keep_latest: 3
-          delete_tag_pattern: latest
+          delete_tag_pattern: trunk
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -84,8 +84,9 @@ jobs:
     steps:
     
       - name: Purge old releases of trunk build
-        uses: ClementTsang/delete-tag-and-release@v0.3.1
-        with:          
+        uses: Vucko130/delete-older-releases@v0.2.1
+        with:
+          keep_latest: 3
           delete_tag_pattern: latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -165,12 +166,12 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: Vucko130/delete-older-releases@v0.2.1
+      - uses: ClementTsang/delete-tag-and-release@v0.3.1
         if: ${{ github.repository_owner == 'Armbian' && github.event.inputs.choice != 'stable'  && github.event.inputs.choice != 'rc' }}
         with:
           delete_release: true
           tag_name: latest
-          keep_latest: 3
+
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -171,6 +171,7 @@ jobs:
         with:
           delete_release: true
           tag_name: latest
+          keep_latest: 3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Purge old releases of trunk build
         uses: Vucko130/delete-older-releases@v0.2.1
         with:
-          keep_latest: 3
+          keep_latest: 7
           delete_tag_pattern: trunk
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -84,10 +84,9 @@ jobs:
     steps:
     
       - name: Purge old releases of trunk build
-        uses: Vucko130/delete-older-releases@v0.2.1
-        with:
-          keep_latest: 7
-          delete_tag_pattern: trunk
+        uses: ClementTsang/delete-tag-and-release@v0.3.1
+        with:          
+          delete_tag_pattern: latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -166,7 +166,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: dev-drprasad/delete-tag-and-release@v0.2.0
+      - uses: Vucko130/delete-older-releases@v0.2.1
         if: ${{ github.repository_owner == 'Armbian' && github.event.inputs.choice != 'stable'  && github.event.inputs.choice != 'rc' }}
         with:
           delete_release: true

--- a/.github/workflows/build-kernel-pr.yml
+++ b/.github/workflows/build-kernel-pr.yml
@@ -48,13 +48,7 @@ jobs:
     needs: [Check,Build]
     if: ${{ github.repository_owner == 'Armbian' && contains( github.event.pull_request.labels.*.name, 'Ready :arrow_right:') }}
     uses: armbian/scripts/.github/workflows/repo.yml@master
-
-    with:
-
-      uploading: "true"
-      runner: "fast"
-      reference: ${{ github.event.pull_request.head.sha }}
-
+    
     secrets:
       GPG_KEY1: ${{ secrets.GPG_KEY1 }}
       GPG_PASSPHRASE1: ${{ secrets.GPG_PASSPHRASE1 }}

--- a/.github/workflows/build-kernel-pr.yml
+++ b/.github/workflows/build-kernel-pr.yml
@@ -58,17 +58,3 @@ jobs:
 #      SCRIPTS_ACCESS_TOKEN: ${{ secrets.SCRIPTS_ACCESS_TOKEN }}
 #      KEY_TORRENTS: ${{ secrets.KEY_TORRENTS }}
 #      KNOWN_HOSTS_UPLOAD: ${{ secrets.KNOWN_HOSTS_UPLOAD }}
-
-  Clean:
-
-    name: Clean
-    needs: [Build]
-    runs-on: Linux
-    if: ${{ success() && github.repository_owner == 'Armbian' }}
-    steps:
-
-      - name: Cleaning
-        uses: geekyeggo/delete-artifact@v2    
-        with:
-          name: changes
-          failOnError: false

--- a/.github/workflows/build-kernel-pr.yml
+++ b/.github/workflows/build-kernel-pr.yml
@@ -17,7 +17,7 @@ jobs:
 
   Check:
     name: Checking
-    if: ${{ github.repository_owner == 'Armbian' && contains( github.event.pull_request.labels.*.name, 'Ready :arrow_right:') }}
+    #if: ${{ github.repository_owner == 'Armbian' && contains( github.event.pull_request.labels.*.name, 'Ready :arrow_right:') }}
     uses: armbian/scripts/.github/workflows/check-for-changes.yml@master
 
     with:
@@ -26,7 +26,7 @@ jobs:
 
   Build:
     needs: Check
-    if: ${{ github.repository_owner == 'Armbian' && contains( github.event.pull_request.labels.*.name, 'Ready :arrow_right:') }}
+    #if: ${{ github.repository_owner == 'Armbian' && contains( github.event.pull_request.labels.*.name, 'Ready :arrow_right:') }}
     uses: armbian/scripts/.github/workflows/build-kernel.yml@master
 
     with:
@@ -46,7 +46,7 @@ jobs:
 
   Repo:
     needs: [Check,Build]
-    if: ${{ github.repository_owner == 'Armbian' && contains( github.event.pull_request.labels.*.name, 'Ready :arrow_right:') }}
+    #if: ${{ github.repository_owner == 'Armbian' && contains( github.event.pull_request.labels.*.name, 'Ready :arrow_right:') }}
     uses: armbian/scripts/.github/workflows/repo.yml@master
     
     secrets:

--- a/.github/workflows/build-kernel-pr.yml
+++ b/.github/workflows/build-kernel-pr.yml
@@ -17,7 +17,7 @@ jobs:
 
   Check:
     name: Checking
-    #if: ${{ github.repository_owner == 'Armbian' && contains( github.event.pull_request.labels.*.name, 'Ready :arrow_right:') }}
+    if: ${{ github.repository_owner == 'Armbian' && contains( github.event.pull_request.labels.*.name, 'Ready :arrow_right:') }}
     uses: armbian/scripts/.github/workflows/check-for-changes.yml@master
 
     with:
@@ -26,7 +26,7 @@ jobs:
 
   Build:
     needs: Check
-    #if: ${{ github.repository_owner == 'Armbian' && contains( github.event.pull_request.labels.*.name, 'Ready :arrow_right:') }}
+    if: ${{ github.repository_owner == 'Armbian' && contains( github.event.pull_request.labels.*.name, 'Ready :arrow_right:') }}
     uses: armbian/scripts/.github/workflows/build-kernel.yml@master
 
     with:

--- a/.github/workflows/build-kernel-pr.yml
+++ b/.github/workflows/build-kernel-pr.yml
@@ -31,7 +31,27 @@ jobs:
 
     with:
 
-      uploading: "false"
+      uploading: "true"
+      runner: "fast"
+      reference: ${{ github.event.pull_request.head.sha }}
+
+    secrets:
+      GPG_KEY1: ${{ secrets.GPG_KEY1 }}
+      GPG_PASSPHRASE1: ${{ secrets.GPG_PASSPHRASE1 }}
+      GPG_KEY2: ${{ secrets.GPG_KEY2 }}
+      GPG_PASSPHRASE2: ${{ secrets.GPG_PASSPHRASE2 }}
+      SCRIPTS_ACCESS_TOKEN: ${{ secrets.SCRIPTS_ACCESS_TOKEN }}
+      KEY_TORRENTS: ${{ secrets.KEY_TORRENTS }}
+      KNOWN_HOSTS_UPLOAD: ${{ secrets.KNOWN_HOSTS_UPLOAD }}
+
+  Repo:
+    needs: [Check,Build]
+    if: ${{ github.repository_owner == 'Armbian' && contains( github.event.pull_request.labels.*.name, 'Ready :arrow_right:') }}
+    uses: armbian/scripts/.github/workflows/repo.yml@master
+
+    with:
+
+      uploading: "true"
       runner: "fast"
       reference: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/build-kernel-pr.yml
+++ b/.github/workflows/build-kernel-pr.yml
@@ -31,8 +31,9 @@ jobs:
 
     with:
 
-      uploading: "true"
+      uploading: "false"
       runner: "fast"
+      artifacts: "true"
       reference: ${{ github.event.pull_request.head.sha }}
 
     secrets:
@@ -44,16 +45,30 @@ jobs:
       KEY_TORRENTS: ${{ secrets.KEY_TORRENTS }}
       KNOWN_HOSTS_UPLOAD: ${{ secrets.KNOWN_HOSTS_UPLOAD }}
 
-  Repo:
-    needs: [Check,Build]
-    #if: ${{ github.repository_owner == 'Armbian' && contains( github.event.pull_request.labels.*.name, 'Ready :arrow_right:') }}
-    uses: armbian/scripts/.github/workflows/repo.yml@master
+#  Repo:
+#    needs: [Check,Build]
+#    #if: ${{ github.repository_owner == 'Armbian' && contains( github.event.pull_request.labels.*.name, 'Ready :arrow_right:') }}
+#    uses: armbian/scripts/.github/workflows/repo.yml@master
     
-    secrets:
-      GPG_KEY1: ${{ secrets.GPG_KEY1 }}
-      GPG_PASSPHRASE1: ${{ secrets.GPG_PASSPHRASE1 }}
-      GPG_KEY2: ${{ secrets.GPG_KEY2 }}
-      GPG_PASSPHRASE2: ${{ secrets.GPG_PASSPHRASE2 }}
-      SCRIPTS_ACCESS_TOKEN: ${{ secrets.SCRIPTS_ACCESS_TOKEN }}
-      KEY_TORRENTS: ${{ secrets.KEY_TORRENTS }}
-      KNOWN_HOSTS_UPLOAD: ${{ secrets.KNOWN_HOSTS_UPLOAD }}
+#    secrets:
+#      GPG_KEY1: ${{ secrets.GPG_KEY1 }}
+#      GPG_PASSPHRASE1: ${{ secrets.GPG_PASSPHRASE1 }}
+#      GPG_KEY2: ${{ secrets.GPG_KEY2 }}
+#      GPG_PASSPHRASE2: ${{ secrets.GPG_PASSPHRASE2 }}
+#      SCRIPTS_ACCESS_TOKEN: ${{ secrets.SCRIPTS_ACCESS_TOKEN }}
+#      KEY_TORRENTS: ${{ secrets.KEY_TORRENTS }}
+#      KNOWN_HOSTS_UPLOAD: ${{ secrets.KNOWN_HOSTS_UPLOAD }}
+
+  Clean:
+
+    name: Clean
+    needs: [Build]
+    runs-on: Linux
+    if: ${{ success() && github.repository_owner == 'Armbian' }}
+    steps:
+
+      - name: Cleaning
+        uses: geekyeggo/delete-artifact@v2    
+        with:
+          name: changes
+          failOnError: false

--- a/.github/workflows/build-train.yml
+++ b/.github/workflows/build-train.yml
@@ -358,3 +358,18 @@ jobs:
       SCRIPTS_ACCESS_TOKEN: ${{ secrets.SCRIPTS_ACCESS_TOKEN }}
       KEY_TORRENTS: ${{ secrets.KEY_TORRENTS }}
       KNOWN_HOSTS_UPLOAD: ${{ secrets.KNOWN_HOSTS_UPLOAD }}
+
+
+  Clean:
+  
+    name: Clean
+    needs: [Bump]
+    runs-on: Linux
+    if: ${{ success() && github.repository_owner == 'Armbian' }}
+    steps:
+
+      - name: Cleaning
+        uses: geekyeggo/delete-artifact@v2    
+        with:
+          name: changes
+          failOnError: false


### PR DESCRIPTION
# Description

Due to Github Actions upgrade all modules that are using Node 16 become obsolete. Action script we were using for handling TAGS is not maintained anymore so we have to switch to its fork.

# How Has This Been Tested?

- [x] Build test from a PR branch

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
