### PR TITLE
`armbian,spi-dev` hacks also for rockchip64-5.18, .19, and 6.0.y

### DIFF
--- a/patch/kernel/archive/rockchip64-5.18/drv-spi-spidev-remove-warnings.patch
+++ b/patch/kernel/archive/rockchip64-5.18/drv-spi-spidev-remove-warnings.patch
@@ -1,0 +1,32 @@
+From 2653defc5e22ba86bd1d455eb01fc7edd2958473 Mon Sep 17 00:00:00 2001
+From: The-going <48602507+The-going@users.noreply.github.com>
+Date: Wed, 2 Feb 2022 11:56:51 +0300
+Subject: [PATCH 08/50] drv:spi:spidev remove warnings
+
+---
+ drivers/spi/spidev.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/spi/spidev.c b/drivers/spi/spidev.c
+index 1bd73e322..bd4e2c185 100644
+--- a/drivers/spi/spidev.c
++++ b/drivers/spi/spidev.c
+@@ -674,6 +674,7 @@ static const struct file_operations spidev_fops = {
+ static struct class *spidev_class;
+ 
+ static const struct spi_device_id spidev_spi_ids[] = {
++	{ .name = "spi-dev" },
+ 	{ .name = "dh2228fv" },
+ 	{ .name = "ltc2488" },
+ 	{ .name = "sx1301" },
+@@ -688,6 +689,7 @@ MODULE_DEVICE_TABLE(spi, spidev_spi_ids);
+ 
+ #ifdef CONFIG_OF
+ static const struct of_device_id spidev_dt_ids[] = {
++	{ .compatible = "armbian,spi-dev" },
+ 	{ .compatible = "rohm,dh2228fv" },
+ 	{ .compatible = "lineartechnology,ltc2488" },
+ 	{ .compatible = "semtech,sx1301" },
+-- 
+2.35.3
+

--- a/patch/kernel/archive/rockchip64-5.18/general-rockchip-overlays.patch
+++ b/patch/kernel/archive/rockchip64-5.18/general-rockchip-overlays.patch
@@ -380,7 +380,7 @@ index 0000000..fe8fb14
 +			#address-cells = <1>;
 +			#size-cells = <0>;
 +			spidev {
-+				compatible = "spidev";
++				compatible = "armbian,spi-dev";
 +				status = "disabled";
 +				reg = <0>;
 +				spi-max-frequency = <10000000>;
@@ -394,7 +394,7 @@ index 0000000..fe8fb14
 +			#address-cells = <1>;
 +			#size-cells = <0>;
 +			spidev {
-+				compatible = "spidev";
++				compatible = "armbian,spi-dev";
 +				status = "disabled";
 +				reg = <0>;
 +				spi-max-frequency = <10000000>;
@@ -408,7 +408,7 @@ index 0000000..fe8fb14
 +			#address-cells = <1>;
 +			#size-cells = <0>;
 +			spidev {
-+				compatible = "spidev";
++				compatible = "armbian,spi-dev";
 +				status = "disabled";
 +				reg = <0>;
 +				spi-max-frequency = <10000000>;
@@ -422,7 +422,7 @@ index 0000000..fe8fb14
 +			#address-cells = <1>;
 +			#size-cells = <0>;
 +			spidev {
-+				compatible = "spidev";
++				compatible = "armbian,spi-dev";
 +				status = "disabled";
 +				reg = <0>;
 +				spi-max-frequency = <10000000>;

--- a/patch/kernel/archive/rockchip64-5.19/drv-spi-spidev-remove-warnings.patch
+++ b/patch/kernel/archive/rockchip64-5.19/drv-spi-spidev-remove-warnings.patch
@@ -1,0 +1,31 @@
+From 2653defc5e22ba86bd1d455eb01fc7edd2958473 Mon Sep 17 00:00:00 2001
+From: The-going <48602507+The-going@users.noreply.github.com>
+Date: Wed, 2 Feb 2022 11:56:51 +0300
+Subject: [PATCH 08/50] drv:spi:spidev remove warnings
+
+---
+ drivers/spi/spidev.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/spi/spidev.c b/drivers/spi/spidev.c
+index b2775d82d2d7..3c65d3d74559 100644
+--- a/drivers/spi/spidev.c
++++ b/drivers/spi/spidev.c
+@@ -683,6 +683,7 @@ static const struct file_operations spidev_fops = {
+ static struct class *spidev_class;
+ 
+ static const struct spi_device_id spidev_spi_ids[] = {
++	{ .name = "spi-dev" },
+ 	{ .name = "dh2228fv" },
+ 	{ .name = "ltc2488" },
+ 	{ .name = "sx1301" },
+@@ -709,6 +710,7 @@ static int spidev_of_check(struct device *dev)
+ }
+ 
+ static const struct of_device_id spidev_dt_ids[] = {
++	{ .compatible = "armbian,spi-dev", .data = &spidev_of_check },
+ 	{ .compatible = "rohm,dh2228fv", .data = &spidev_of_check },
+ 	{ .compatible = "lineartechnology,ltc2488", .data = &spidev_of_check },
+ 	{ .compatible = "semtech,sx1301", .data = &spidev_of_check },
+-- 
+2.35.3

--- a/patch/kernel/archive/rockchip64-5.19/general-rockchip-overlays.patch
+++ b/patch/kernel/archive/rockchip64-5.19/general-rockchip-overlays.patch
@@ -380,7 +380,7 @@ index 0000000..fe8fb14
 +			#address-cells = <1>;
 +			#size-cells = <0>;
 +			spidev {
-+				compatible = "spidev";
++				compatible = "armbian,spi-dev";
 +				status = "disabled";
 +				reg = <0>;
 +				spi-max-frequency = <10000000>;
@@ -394,7 +394,7 @@ index 0000000..fe8fb14
 +			#address-cells = <1>;
 +			#size-cells = <0>;
 +			spidev {
-+				compatible = "spidev";
++				compatible = "armbian,spi-dev";
 +				status = "disabled";
 +				reg = <0>;
 +				spi-max-frequency = <10000000>;
@@ -408,7 +408,7 @@ index 0000000..fe8fb14
 +			#address-cells = <1>;
 +			#size-cells = <0>;
 +			spidev {
-+				compatible = "spidev";
++				compatible = "armbian,spi-dev";
 +				status = "disabled";
 +				reg = <0>;
 +				spi-max-frequency = <10000000>;
@@ -422,7 +422,7 @@ index 0000000..fe8fb14
 +			#address-cells = <1>;
 +			#size-cells = <0>;
 +			spidev {
-+				compatible = "spidev";
++				compatible = "armbian,spi-dev";
 +				status = "disabled";
 +				reg = <0>;
 +				spi-max-frequency = <10000000>;
@@ -508,10 +508,10 @@ index 26e6af4..65b9435 100644
 @@ -65,6 +65,9 @@ real-objs-m := $(foreach m, $(obj-m), $(if $(strip $($(m:.o=-objs)) $($(m:.o=-y)
  extra-y				+= $(dtb-y)
  extra-$(CONFIG_OF_ALL_DTBS)	+= $(dtb-)
- 
+
 +# Overlay targets
 +extra-y				+= $(dtbo-y) $(scr-y) $(dtbotxt-y)
 +
  # Add subdir path
- 
+
  extra-y		:= $(addprefix $(obj)/,$(extra-y))

--- a/patch/kernel/archive/rockchip64-6.0/drv-spi-spidev-remove-warnings.patch
+++ b/patch/kernel/archive/rockchip64-6.0/drv-spi-spidev-remove-warnings.patch
@@ -1,0 +1,31 @@
+From 2653defc5e22ba86bd1d455eb01fc7edd2958473 Mon Sep 17 00:00:00 2001
+From: The-going <48602507+The-going@users.noreply.github.com>
+Date: Wed, 2 Feb 2022 11:56:51 +0300
+Subject: [PATCH 08/50] drv:spi:spidev remove warnings
+
+---
+ drivers/spi/spidev.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/spi/spidev.c b/drivers/spi/spidev.c
+index b2775d82d2d7..3c65d3d74559 100644
+--- a/drivers/spi/spidev.c
++++ b/drivers/spi/spidev.c
+@@ -683,6 +683,7 @@ static const struct file_operations spidev_fops = {
+ static struct class *spidev_class;
+ 
+ static const struct spi_device_id spidev_spi_ids[] = {
++	{ .name = "spi-dev" },
+ 	{ .name = "dh2228fv" },
+ 	{ .name = "ltc2488" },
+ 	{ .name = "sx1301" },
+@@ -709,6 +710,7 @@ static int spidev_of_check(struct device *dev)
+ }
+ 
+ static const struct of_device_id spidev_dt_ids[] = {
++	{ .compatible = "armbian,spi-dev", .data = &spidev_of_check },
+ 	{ .compatible = "rohm,dh2228fv", .data = &spidev_of_check },
+ 	{ .compatible = "lineartechnology,ltc2488", .data = &spidev_of_check },
+ 	{ .compatible = "semtech,sx1301", .data = &spidev_of_check },
+-- 
+2.35.3

--- a/patch/kernel/archive/rockchip64-6.0/general-rockchip-overlays.patch
+++ b/patch/kernel/archive/rockchip64-6.0/general-rockchip-overlays.patch
@@ -380,7 +380,7 @@ index 0000000..fe8fb14
 +			#address-cells = <1>;
 +			#size-cells = <0>;
 +			spidev {
-+				compatible = "spidev";
++				compatible = "armbian,spi-dev";
 +				status = "disabled";
 +				reg = <0>;
 +				spi-max-frequency = <10000000>;
@@ -394,7 +394,7 @@ index 0000000..fe8fb14
 +			#address-cells = <1>;
 +			#size-cells = <0>;
 +			spidev {
-+				compatible = "spidev";
++				compatible = "armbian,spi-dev";
 +				status = "disabled";
 +				reg = <0>;
 +				spi-max-frequency = <10000000>;
@@ -408,7 +408,7 @@ index 0000000..fe8fb14
 +			#address-cells = <1>;
 +			#size-cells = <0>;
 +			spidev {
-+				compatible = "spidev";
++				compatible = "armbian,spi-dev";
 +				status = "disabled";
 +				reg = <0>;
 +				spi-max-frequency = <10000000>;
@@ -422,7 +422,7 @@ index 0000000..fe8fb14
 +			#address-cells = <1>;
 +			#size-cells = <0>;
 +			spidev {
-+				compatible = "spidev";
++				compatible = "armbian,spi-dev";
 +				status = "disabled";
 +				reg = <0>;
 +				spi-max-frequency = <10000000>;


### PR DESCRIPTION
#### `armbian,spi-dev` hacks also for rockchip64-5.18, .19, and 6.0.y

- Original PR's
  - https://github.com/armbian/build/pull/3737
  - https://github.com/armbian/build/pull/3812
- Just rolling these forward to 5.18/19 and 6.0