### PR TITLE
armbian-firstlogin make weak password warning messages consistent for root and user

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -262,7 +262,7 @@ add_user()
 			result="$(cracklib-check <<<"$password")"
 			okay="$(awk -F': ' '{ print $2}' <<<"$result")"
 			if [[ "$okay" != "OK" ]]; then
-				echo -e "\n\e[0;31mWarning:\x1B[0m Weak password!"
+				echo -e "\n\e[0;31mWarning:\x1B[0m Weak password, $okay \b!"
 			fi
 			echo -e ""
 			read -e -p "Please provide your real name: " -i "${RealUserName^}" RealName
@@ -348,7 +348,7 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 			result="$(cracklib-check <<<"$password")"
 			okay="$(awk -F': ' '{ print $2}' <<<"$result")"
 			if [[ "$okay" != "OK" ]]; then
-				echo -e "\n\e[0;31mWarning:\x1B[0m $okay!"
+				echo -e "\n\e[0;31mWarning:\x1B[0m Weak password, $okay \b!"
 				(echo "$first_input";echo "$second_input";) | passwd root >/dev/null 2>&1
 			fi
 			break


### PR DESCRIPTION
Modify both weak password warning messages to be consistent 
Formatted as follows: "Warning: Weak password, <warning reason>!".

Jira reference number [AR-1385]

Tested on a board (Orange Pi Zero Plus)
Create root password: ******
Repeat root password: ******

Warning: Weak password, it does not contain enough DIFFERENT characters!

Create user (testuser) password: ******
Repeat user (testuser) password: ******

Warning: Weak password, it does not contain enough DIFFERENT characters!

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1385]: https://armbian.atlassian.net/browse/AR-1385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ