### PR TITLE
When using PPA sources we need to run install_ppa_prerequisites

### DIFF
--- a/lib/functions/rootfs/apt-sources.sh
+++ b/lib/functions/rootfs/apt-sources.sh
@@ -41,6 +41,7 @@ add_apt_sources() {
 				display_alert "Adding APT Source ${new_apt_source}"
 
 				if [[ "${new_apt_source}" == ppa* ]]; then
+					install_ppa_prerequisites
 					# ppa with software-common-properties
 					run_on_sdcard "add-apt-repository -y -n \"${new_apt_source}\""
 					# add list with apt-add


### PR DESCRIPTION
# Description

Some has this package dependency, some not. This makes sure that PPA is always installed.

Jira reference number [AR-1405]

# How Has This Been Tested?

- [x] Test build

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1405]: https://armbian.atlassian.net/browse/AR-1405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ