### PR TITLE
DTB fix for Station M3

### DIFF
--- a/config/sources/families/media.conf
+++ b/config/sources/families/media.conf
@@ -41,7 +41,7 @@ case $BRANCH in
 			KERNELBRANCH='branch:kernel-5.10'
 			LINUXFAMILY=station-m3
 			LINUXCONFIG='linux-station-m3-'$BRANCH
-			KERNELPATCHDIR='station-m3-'$BRANCH
+			KERNELPATCHDIR='media-'$BRANCH
 			AUFS="no"
 		elif [[ $BOARD == jetson-nano ]]; then
 			KERNELDIR='linux-nano'

--- a/patch/kernel/archive/media-5.10/00980-builddeb.patch
+++ b/patch/kernel/archive/media-5.10/00980-builddeb.patch
@@ -1,0 +1,101 @@
+--- a/scripts/package/builddeb
++++ b/scripts/package/builddeb
+@@ -64,25 +64,6 @@
+ 	chmod -R a+rX "$pdir"
+ 	# in case we build in a setuid/setgid directory
+ 	chmod -R ug-s "$pdir"
+-
+-	# Create preinstall and post install script to remove dtb
+-	if [ "$3" = "dtb" ]; then
+-
+-		cat >> $pdir/DEBIAN/preinst <<- EOT
+-			rm -rf /boot/dtb
+-			rm -rf /boot/dtb-$version
+-			exit 0
+-		EOT
+-
+-		cat >> $pdir/DEBIAN/postinst <<- EOT
+-			cd /boot
+-			ln -sfT dtb-$version dtb 2> /dev/null || mv dtb-$version dtb
+-			exit 0
+-		EOT
+-
+-		chmod 775 $pdir/DEBIAN/preinst
+-		chmod 775 $pdir/DEBIAN/postinst
+-	fi
+ 
+ 	# Create postinst prerm script for headers
+ 	if [ "$3" = "headers" ]; then
+@@ -187,10 +168,8 @@
+ kernel_headers_dir="debian/hdrtmp"
+ libc_headers_dir="debian/headertmp"
+ dbg_dir="debian/dbgtmp"
+-dtb_dir="debian/dtbtmp"
+ packagename=linux-image-"$BRANCH$LOCALVERSION"
+ kernel_headers_packagename=linux-headers-"$BRANCH$LOCALVERSION"
+-dtb_packagename=linux-dtb-"$BRANCH$LOCALVERSION"
+ libc_headers_packagename=linux-libc-dev
+ dbg_packagename=$packagename-dbg
+ 
+@@ -225,11 +204,9 @@
+ BUILD_DEBUG=$(if_enabled_echo CONFIG_DEBUG_INFO Yes)
+ 
+ # Setup the directory structure
+-rm -rf "$tmpdir" "$dbg_dir" "$dtb_dir" debian/files
++rm -rf "$tmpdir" "$dbg_dir" debian/files
+ mkdir -m 755 -p "$tmpdir/DEBIAN"
+ mkdir -p "$tmpdir/lib" "$tmpdir/boot"
+-mkdir -m 755 -p "$dtb_dir/DEBIAN"
+-mkdir -p "$dtb_dir/boot/dtb-$version" "$dtb_dir/usr/share/doc/$dtb_packagename"
+ mkdir -m 755 -p "$kernel_headers_dir/lib/modules/$version/"
+ mkdir -m 755 -p "$libc_headers_dir/DEBIAN"
+ 
+@@ -249,13 +226,8 @@
+ if is_enabled CONFIG_OF_EARLY_FLATTREE; then
+ 	# Only some architectures with OF support have this target
+ 	if [ -d "${srctree}/arch/$SRCARCH/boot/dts" ]; then
+-		$MAKE -f $srctree/Makefile INSTALL_DTBS_PATH="$tmpdir/usr/lib/linux-image-$version" dtbs_install
+-	fi
+-fi
+-
+-if grep -q '^CONFIG_OF=y' $KCONFIG_CONFIG; then
+-	#mkdir -p "$tmpdir/boot/dtb"
+-	INSTALL_DTBS_PATH="$dtb_dir/boot/dtb-$version" $MAKE KBUILD_SRC= dtbs_install
++		$MAKE -f $srctree/Makefile INSTALL_DTBS_PATH="$tmpdir/boot/linux-image-$version" dtbs_install
++	fi
+ fi
+ 
+ if is_enabled CONFIG_MODULES; then
+@@ -318,6 +290,8 @@
+ sed -e "s/exit 0//g" -i $tmpdir/DEBIAN/postinst
+ cat >> $tmpdir/DEBIAN/postinst <<- EOT
+ 	ln -sf $(basename $installed_image_path) /boot/$image_name 2> /dev/null || mv /$installed_image_path /boot/$image_name
++	cd /boot
++	ln -sfT linux-image-$version dtb 2> /dev/null || mv linux-image-$version dtb
+ 	touch /boot/.next
+ 	exit 0
+ EOT
+@@ -346,6 +320,10 @@
+ 			rm -f /boot/System.map* /boot/config* /boot/vmlinuz* /boot/$image_name /boot/uImage
+ 		fi
+ 	}
++#	if [ -d /boot/dtb ]; then
++		rm -rf /boot/dtb
++		rm -rf /boot/linux-image-$version
++#	fi
+ 	mountpoint -q /boot && check_boot_dev
+ 	exit 0
+ EOT
+@@ -353,11 +331,6 @@
+ create_package "$packagename" "$tmpdir"
+ 
+ if [ "$ARCH" != "um" ]; then
+-
+-	if [ "$(cat debian/arch)" != "amd64" ]; then # No DTB for amd64 target
+-		create_package "$dtb_packagename" "$dtb_dir" "dtb"
+-	fi
+-
+ 	deploy_libc_headers $libc_headers_dir
+ 	create_package $libc_headers_packagename $libc_headers_dir
+ 
+

--- a/patch/kernel/archive/media-5.10/00981-mkdebian.patch
+++ b/patch/kernel/archive/media-5.10/00981-mkdebian.patch
@@ -1,0 +1,24 @@
+--- a/scripts/package/mkdebian
++++ b/scripts/package/mkdebian
+@@ -98,7 +98,6 @@
+ packagename=linux-image-"$BRANCH$LOCALVERSION"
+ kernel_headers_packagename=linux-headers-"$BRANCH$LOCALVERSION"
+ libc_headers_packagename=linux-libc-dev
+-dtb_packagename=linux-dtb-"$BRANCH$LOCALVERSION"
+ dbg_packagename=$packagename-dbg
+ 
+ if [ "$ARCH" = "um" ] ; then
+@@ -198,12 +197,6 @@
+  This package provides userspaces headers from the Linux kernel.  These headers
+  are used by the installed headers for GNU glibc and other system libraries.
+ Multi-Arch: same
+-
+-Package: $dtb_packagename
+-Architecture: $debarch
+-Provides: linux-dtb, linux-dtb-armbian, armbian-$BRANCH
+-Description: Armbian Linux DTB, version $version $BRANCH
+- This package contains device blobs from the Linux kernel, version $version
+ EOF
+ 
+ if is_enabled CONFIG_MODULES; then
+

--- a/patch/kernel/media-legacy
+++ b/patch/kernel/media-legacy
@@ -1,0 +1,1 @@
+archive/media-5.10


### PR DESCRIPTION
Transfers DTB to a package shared with the kernel DEB. Solves the problem of missing DTB when using an assembly from the package repository.
