### PR TITLE
Remove 3D support for Station & Jetson Nano images with legacy kernel

### DIFF
--- a/config/targets.conf
+++ b/config/targets.conf
@@ -712,8 +712,8 @@ station-p1                current         jammy       desktop                  s
 # Station M2
 station-m2                legacy          bullseye    cli                      stable         yes
 station-m2                legacy          jammy       cli                      stable         yes
-station-m2                legacy          bullseye    desktop                  stable         yes            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-station-m2                legacy          jammy       desktop                  stable         adv            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+station-m2                legacy          bullseye    desktop                  stable         yes            xfce          config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+station-m2                legacy          jammy       desktop                  stable         adv            xfce          config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 #
 station-m2                current         jammy       cli                      stable         yes
 station-m2                current         bullseye    cli                      stable         yes
@@ -726,15 +726,15 @@ station-m2                current         jammy       desktop                  s
 # Station M3
 station-m3                legacy          bullseye    cli                      stable         yes
 station-m3                legacy          jammy       cli                      stable         yes
-station-m3                legacy          bullseye    desktop                  stable         adv            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-station-m3                legacy          jammy       desktop                  stable         adv            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+station-m3                legacy          bullseye    desktop                  stable         adv            xfce          config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+station-m3                legacy          jammy       desktop                  stable         adv            xfce          config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 
 # Station P2
 station-m2                legacy          bullseye    cli                      stable         yes
 station-m2                legacy          jammy       cli                      stable         yes
-station-m2                legacy          bullseye    desktop                  stable         yes            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-station-m2                legacy          jammy       desktop                  stable         adv            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+station-m2                legacy          bullseye    desktop                  stable         yes            xfce          config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+station-m2                legacy          jammy       desktop                  stable         adv            xfce          config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 #
 station-p2                current         jammy       cli                      stable         adv
 station-p2                current         bullseye    cli                      stable         yes
@@ -771,8 +771,8 @@ jethubj100                edge            jammy       cli                      s
 
 
 # Jetson Nano
-jetson-nano               legacy          jammy       desktop                  stable         yes            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-jetson-nano               legacy          bullseye    desktop                  stable         yes            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+jetson-nano               legacy          jammy       desktop                  stable         yes            xfce          config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+jetson-nano               legacy          bullseye    desktop                  stable         yes            xfce          config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 #
 jetson-nano               current         jammy       cli                      stable         adv
 jetson-nano               current         bullseye    cli                      stable         yes

--- a/config/targets.conf
+++ b/config/targets.conf
@@ -731,10 +731,10 @@ station-m3                legacy          jammy       desktop                  s
 
 
 # Station P2
-station-m2                legacy          bullseye    cli                      stable         yes
-station-m2                legacy          jammy       cli                      stable         yes
-station-m2                legacy          bullseye    desktop                  stable         yes            xfce          config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-station-m2                legacy          jammy       desktop                  stable         adv            xfce          config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+station-p2                legacy          bullseye    cli                      stable         yes
+station-p2                legacy          jammy       cli                      stable         yes
+station-p2                legacy          bullseye    desktop                  stable         yes            xfce          config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+station-p2                legacy          jammy       desktop                  stable         adv            xfce          config_base   browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 #
 station-p2                current         jammy       cli                      stable         adv
 station-p2                current         bullseye    cli                      stable         yes


### PR DESCRIPTION
Deletes a group of 3D programs\settings for DE, which causes DE to be blocked from running with the legacy kernel. 

Station M2\P2\M3
Jetson Nano
