### PR TITLE
Fix minor typos

### DIFF
--- a/packages/bsp/aml-s9xx-box/root/install-aml-s905-emmc.sh
+++ b/packages/bsp/aml-s9xx-box/root/install-aml-s905-emmc.sh
@@ -86,7 +86,7 @@ echo "done."
 
 mount -o rw $PART_BOOT $DIR_INSTALL
 
-echo -n "Cppying BOOT..."
+echo -n "Copying BOOT..."
 cp -r /boot/* $DIR_INSTALL && sync
 echo "done."
 

--- a/packages/bsp/aml-s9xx-box/root/install-aml.sh
+++ b/packages/bsp/aml-s9xx-box/root/install-aml.sh
@@ -93,7 +93,7 @@ echo "done."
 
 mount -o rw $PART_BOOT $DIR_INSTALL
 
-echo -n "Cppying BOOT..."
+echo -n "Copying BOOT..."
 cp -r /boot/* $DIR_INSTALL && sync
 echo "done."
 


### PR DESCRIPTION
# Description

Noticed typo using `./install-aml.sh` on aml-s9xx-box with community image