### PR TITLE
Add build targets which only build kernels

### DIFF
--- a/config/targets.conf
+++ b/config/targets.conf
@@ -73,11 +73,15 @@ espressobin               current         bullseye    cli                      s
 espressobin               current         jammy       cli                      stable         adv
 espressobin               current         bullseye    minimal                  stable         yes
 espressobin               current         jammy       minimal                  stable         yes
+#
+espressobin               edge            jammy       minimal                  stable         no
 
 
 # Helios4
 helios4                   current         bullseye    cli                      stable         adv
 helios4                   current         jammy       cli                      stable         adv
+#
+helios4                   edge            jammy       cli                      stable         no
 
 
 # Clearfog Base
@@ -333,6 +337,8 @@ odroidxu4                 current         jammy       minimal                  s
 odroidxu4                 current         bullseye    minimal                  stable         yes
 #
 odroidxu4                 current         jammy       desktop                  stable         adv            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+#
+odroidxu4                 edge            jammy       cli                      stable         no
 
 
 # orangepi 3
@@ -588,6 +594,8 @@ rk322x-box                current         bullseye    cli                      s
 rk322x-box                current         jammy       cli                      stable         adv
 #
 rk322x-box                current         jammy       desktop                  stable         adv            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+#
+rk322x-box                edge            bullseye    cli                      stable         no
 
 
 # Rock64
@@ -664,6 +672,8 @@ tinkerboard               current         jammy       minimal                  s
 tinkerboard               current         bullseye    minimal                  stable         yes
 #
 tinkerboard               current         jammy       desktop                  stable         adv            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+#
+tinkerboard               edge            bullseye    cli                      stable         no
 
 
 # Tritium H3
@@ -789,6 +799,8 @@ rpi4b                     current         jammy       minimal                  s
 rpi4b                     current         jammy       desktop                  stable         adv            gnome         config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 rpi4b                     current         jammy       desktop                  stable         yes            cinnamon      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 rpi4b                     current         jammy       desktop                  stable         adv            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+#
+rpi4b                     edge            jammy       cli                      stable         no
 
 
 # uefi-x86


### PR DESCRIPTION
# Description

This is handy to have set by default in case we want to recreate repository with all kernels we need.

This only enable rebuilding kernels without making image.