### PR TITLE
The RELEASE variable cannot be empty.

### DIFF
--- a/lib/functions/configuration/interactive.sh
+++ b/lib/functions/configuration/interactive.sh
@@ -151,7 +151,7 @@ function interactive_config_ask_branch() {
 }
 
 function interactive_config_ask_release() {
-	if [[ -z "$BUILD_ONLY" || "$BUILD_ONLY" == *bootstrap* && -z "$RELEASE" ]]; then
+	if [[ -z "$RELEASE" ]]; then
 
 		options=()
 


### PR DESCRIPTION
Additional conditions for checking RELEASE are unacceptable.


