### PR TITLE
SUNXI: Update setting of UBOOT_TARGET_MAP to allow overriding

### DIFF
--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -5,7 +5,7 @@ BOOTDELAY=1
 
 BOOTPATCHDIR='u-boot-sunxi'
 BOOTENV_FILE='sunxi.txt'
-UBOOT_TARGET_MAP=';;u-boot-sunxi-with-spl.bin'
+UBOOT_TARGET_MAP="${UBOOT_TARGET_MAP:-;;u-boot-sunxi-with-spl.bin}"
 BOOTSCRIPT='boot-sun50i-next.cmd:boot.cmd'
 LINUXFAMILY=sunxi64
 

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -2,7 +2,7 @@ enable_extension "sunxi-tools"
 ARCH=armhf
 BOOTDELAY=1
 BOOTPATCHDIR='u-boot-sunxi'
-UBOOT_TARGET_MAP=';;u-boot-sunxi-with-spl.bin'
+UBOOT_TARGET_MAP="${UBOOT_TARGET_MAP:-;;u-boot-sunxi-with-spl.bin}"
 BOOTSCRIPT="boot-sunxi.cmd:boot.cmd"
 BOOTENV_FILE='sunxi.txt'
 LINUXFAMILY=sunxi


### PR DESCRIPTION
# Description

UBOOT_TARGET_MAP in `config\sources\families\include\sunxi_common.inc` and in `config\sources\families\include\sunxi64_common.inc` has been changed to use the original definition as default to allow overriding from an already existing definition of `UBOOT_TARGET_MAP`by e.g. a board configuration file.

Issue reference: #4478

# Test results

This has been tested by a build process for a Cubietruck board.
File content of `config/boards/cubietruck.csc`:
```
# Allwinner A20 dual core 2GB RAM SoC 1xSATA GBE WiFi/BT
BOARD_NAME="Cubietruck"
BOARDFAMILY="sun7i"
BOOTCONFIG="Cubietruck_config"
KERNEL_TARGET="legacy,current,edge"
UBOOT_TARGET_MAP=";;u-boot-sunxi-with-spl.bin spl/sunxi-spl-with-ecc.bin:u-boot-sunxi-nand-spl-with-ecc.bin u-boot-dtb.img"
```

- [x] Test succeeded for a Cubietruck board build with UBOOT_TARGET_MAP defined in `config/boards/cubietruck.csc`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [n/a] Any dependent changes have been merged and published in downstream modules
