### PR TITLE
GH-4421 - Improve logic coding to filter build tasks

### DIFF
--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -237,7 +237,7 @@ prepare_host() {
 	fi # check offline
 
 	# enable arm binary format so that the cross-architecture chroot environment will work
-	if [[ -z "$BUILD_ONLY" || "$BUILD_ONLY" == *bootstrap* ]]; then
+	if build_task_is_enabled "bootstrap"; then
 		modprobe -q binfmt_misc
 		mountpoint -q /proc/sys/fs/binfmt_misc/ || mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc
 		if [[ "$(arch)" != "aarch64" ]]; then

--- a/lib/functions/main/build-tasks.sh
+++ b/lib/functions/main/build-tasks.sh
@@ -22,58 +22,6 @@ build_task_is_enabled() {
 
 ###############################################################################
 #
-# build_task_one_of_is_enabled()
-#
-# $1: _taskNamesToCheck - a single task name or a :comma: or :space: separated list of multiple task names to check
-# return:
-#   0 - if BUILD_ONLY is empty or if at least one task name of _taskNamesToCheck is listed by BUILD_ONLY
-#   1 - otherwise 
-#
-build_task_one_of_is_enabled() {
-	# remove all "
-	local _taskNamesToCheck=${1//\"/}
-	local _buildOnly=${BUILD_ONLY//\"/}
-	# An empty _buildOnly allows any taskname
-	[[ -z $_buildOnly ]] && return 0
-	# relace all :comma: by :space:
-	_taskNamesToCheck=${_taskNamesToCheck//,/ }
-	_buildOnly=${_buildOnly//,/ }
-	for _taskNameToCheck in ${_taskNamesToCheck}; do
-		if build_task_is_enabled "$_taskNameToCheck"; then
-			return 0
-		fi
-	done
-	return 1
-}
-
-###############################################################################
-#
-# build_task_each_of_is_enabled()
-#
-# $1: _taskNamesToCheck - a single task name or a :comma: or :space: separated list of multiple task names to check
-# return:
-#   0 - if BUILD_ONLY is empty or if all _taskNamesToCheck are listed by BUILD_ONLY
-#   1 - otherwise 
-#
-build_task_each_of_is_enabled() {
-	# remove all "
-	local _taskNamesToCheck=${1//\"/}
-	local _buildOnly=${BUILD_ONLY//\"/}
-	# An empty _buildOnly allows any taskname
-	[[ -z $_buildOnly ]] && return 0
-	# relace all :comma: by :space:
-	_taskNamesToCheck=${_taskNamesToCheck//,/ }
-	_buildOnly=${_buildOnly//,/ }
-	for _taskNameToCheck in ${_taskNamesToCheck}; do
-		if ! build_task_is_enabled "$_taskNameToCheck"; then
-			return 1
-		fi
-	done
-	return 0
-}
-
-###############################################################################
-#
 # build_validate_buildOnly()
 #
 # This function validates the list of task names defined by global

--- a/lib/functions/main/config-prepare.sh
+++ b/lib/functions/main/config-prepare.sh
@@ -112,13 +112,13 @@ function prepare_and_config_main_build_single() {
 
 	interactive_config_ask_branch
 
-	[[ "${BUILD_ONLY}" == "" || "${BUILD_ONLY}" == *bootstrap* ]] && {
+	build_task_is_enabled "bootstrap" && {
 
-	interactive_config_ask_release
+		interactive_config_ask_release
 
-	interactive_config_ask_desktop_build
+		interactive_config_ask_desktop_build
 
-	interactive_config_ask_standard_or_minimal
+		interactive_config_ask_standard_or_minimal
 	}
 
 	#prevent conflicting setup


### PR DESCRIPTION
# Description

This could either be merged into GH-4421 or later into a followup PR.

I personally would like it to get it merged already now, since it simplifies the coding and the maintainability in future.

The changes are pretty obvious.

- build-tasks.sh:
  - added functions:
    - build_task_is_enabled()
    - build_task_one_of_is_enabled()
    - build_task_each_of_is_enabled()
  - updated existing build task filter logic to use function build_task_is_enabled
- config-prepare.sh, prepare-host.sh:
  - replaced existing build task filter logic to use function build_task_is_enabled
