### PR TITLE
armbian-firstlogin: make Y/n questions consistent

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -118,9 +118,13 @@ set_timezone_and_locales()
 		if [[ -n "$WIFI_DEVICE" ]]; then
 			echo -e "Internet connection was \x1B[91mnot detected\x1B[0m."
 			echo ""
-			read -n1 -s -r -p "Connect via wireless? [Y/n] " response
-			echo ""
-			if [[ "${response}" =~ ^(Y|y|"")$ ]]; then
+			unset response
+			while [[ ! "${response}" =~ ^(Y|y|N|n)$ ]]; do
+				read -n1 -s -r -p "Connect via wireless? [Y/n] " response
+				response=${response:-Y}
+				echo "$response"
+			done
+			if [[ "${response}" =~ ^(Y|y)$ ]]; then
 				nmtui-connect
 			fi
 			echo ""
@@ -148,7 +152,8 @@ set_timezone_and_locales()
 	unset response
 	while [[ ! "${response}" =~ ^(Y|y|N|n)$ ]]; do
 		read -n1 -s -r -p "Set user language based on your location? [Y/n] " response
-		echo ""
+		response=${response:-Y}
+		echo "$response"
 	done
 	# change it only if we have a match and if we agree
 	if [[ "${response}" =~ ^(N|n)$ ]]; then


### PR DESCRIPTION
Make the two Y/n questions that firstlogin asks behave consistently with each other, and more in line with user expectation:
- Reject anything that is not Y, y, N, n or <enter>. Previously the "Connect via wireless? [Y/n]" question would interpret Y, y and <enter> as "yes", and everything else as "no", whereas the "Set user language based on your location? [Y/n]" question would loop until the user selected Y, y, N or n.
- Make pressing enter equivalent to the default "Y", since that is the capitalized option.
- Echo back what the user typed.
