### PR TITLE
Enable additional minimal CLI build targets

### DIFF
--- a/config/targets.conf
+++ b/config/targets.conf
@@ -80,6 +80,8 @@ espressobin               edge            jammy       minimal                  s
 # Helios4
 helios4                   current         bullseye    cli                      stable         adv
 helios4                   current         jammy       cli                      stable         adv
+helios4                   current         bullseye    minimal                  stable         yes
+helios4                   current         jammy       minimal                  stable         yes
 #
 helios4                   edge            jammy       cli                      stable         no
 
@@ -87,16 +89,22 @@ helios4                   edge            jammy       cli                      s
 # Clearfog Base
 clearfogbase              current         bullseye    cli                      stable         adv
 clearfogbase              current         jammy       cli                      stable         adv
+clearfogbase              current         bullseye    minimal                  stable         yes
+clearfogbase              current         jammy       minimal                  stable         yes
 
 
 # Clearfog Pro
 clearfogpro               current         bullseye    cli                      stable         adv
 clearfogpro               current         jammy       cli                      stable         adv
+clearfogpro               current         bullseye    minimal                  stable         yes
+clearfogpro               current         jammy       minimal                  stable         yes
 
 
 # Khadas Vim1
 khadas-vim1               current         jammy       cli                      stable         adv
 khadas-vim1               current         bullseye    cli                      stable         yes
+khadas-vim1               current         jammy       minimal                  stable         yes
+khadas-vim1               current         bullseye    minimal                  stable         yes
 #
 khadas-vim1               current         jammy       desktop                  stable         yes            gnome         config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 khadas-vim1               current         jammy       desktop                  stable         yes            cinnamon      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
@@ -106,6 +114,8 @@ khadas-vim1               current         jammy       desktop                  s
 # Khadas Vim2
 khadas-vim2               current         jammy       cli                      stable         adv
 khadas-vim2               current         bullseye    cli                      stable         yes
+khadas-vim2               current         jammy       minimal                  stable         yes
+khadas-vim2               current         bullseye    minimal                  stable         yes
 #
 khadas-vim2               current         jammy       desktop                  stable         yes            gnome         config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 khadas-vim2               current         jammy       desktop                  stable         yes            cinnamon      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
@@ -115,6 +125,8 @@ khadas-vim2               current         jammy       desktop                  s
 # Khadas Vim3l
 khadas-vim3l              current         jammy       cli                      stable         adv
 khadas-vim3l              current         bullseye    cli                      stable         yes
+khadas-vim3l              current         jammy       minimal                  stable         yes
+khadas-vim3l              current         bullseye    minimal                  stable         yes
 #
 khadas-vim3l              current         jammy       desktop                  stable         yes            gnome         config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 khadas-vim3l              current         jammy       desktop                  stable         yes            cinnamon      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
@@ -124,6 +136,8 @@ khadas-vim3l              current         jammy       desktop                  s
 # Khadas Vim3
 khadas-vim3               current         jammy       cli                      stable         adv
 khadas-vim3               current         bullseye    cli                      stable         yes
+khadas-vim3               current         jammy       minimal                  stable         yes
+khadas-vim3               current         bullseye    minimal                  stable         yes
 #
 khadas-vim3               current         jammy       desktop                  stable         yes            gnome         config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 khadas-vim3               current         jammy       desktop                  stable         yes            cinnamon      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
@@ -133,6 +147,8 @@ khadas-vim3               current         jammy       desktop                  s
 # Khadas Edge V
 khadas-edge               current         jammy       cli                      stable         adv
 khadas-edge               current         bullseye    cli                      stable         yes
+khadas-edge               current         jammy       minimal                  stable         yes
+khadas-edge               current         bullseye    minimal                  stable         yes
 #
 khadas-edge               current         jammy       desktop                  stable         yes            gnome         config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 khadas-edge               current         jammy       desktop                  stable         yes            cinnamon      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
@@ -142,6 +158,8 @@ khadas-edge               current         jammy       desktop                  s
 # La frite
 lafrite                   current         jammy       cli                      stable         adv
 lafrite                   current         bullseye    cli                      stable         yes
+lafrite                   current         jammy       minimal                  stable         yes
+lafrite                   current         bullseye    minimal                  stable         yes
 #
 lafrite                   current         jammy       desktop                  stable         yes            gnome         config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 lafrite                   current         jammy       desktop                  stable         yes            cinnamon      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
@@ -151,6 +169,8 @@ lafrite                   current         jammy       desktop                  s
 # Lepotato
 lepotato                  current         jammy       cli                      stable         adv
 lepotato                  current         bullseye    cli                      stable         yes
+lepotato                  current         jammy       minimal                  stable         yes
+lepotato                  current         bullseye    minimal                  stable         yes
 #
 lepotato                  current         jammy       desktop                  stable         yes            gnome         config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 lepotato                  current         jammy       desktop                  stable         yes            cinnamon      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
@@ -160,6 +180,8 @@ lepotato                  current         jammy       desktop                  s
 # Olimex Lime2
 lime2                     current         bullseye    cli                      stable         yes
 lime2                     current         jammy       cli                      stable         adv
+lime2                     current         bullseye    minimal                  stable         yes
+lime2                     current         jammy       minimal                  stable         yes
 #
 lime2                     current         jammy       desktop                  stable         adv            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
@@ -167,6 +189,8 @@ lime2                     current         jammy       desktop                  s
 # Olimex Lime A64
 lime-a64                  current         jammy       cli                      stable         adv
 lime-a64                  current         bullseye    cli                      stable         yes
+lime-a64                  current         jammy       minimal                  stable         yes
+lime-a64                  current         bullseye    minimal                  stable         yes
 #
 lime-a64                  current         jammy       desktop                  stable         yes            gnome         config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 lime-a64                  current         jammy       desktop                  stable         yes            cinnamon      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
@@ -176,6 +200,8 @@ lime-a64                  current         jammy       desktop                  s
 # NanoPC T4
 nanopct4                  current         jammy       cli                      stable         adv
 nanopct4                  current         bullseye    cli                      stable         yes
+nanopct4                  current         jammy       minimal                  stable         yes
+nanopct4                  current         bullseye    minimal                  stable         yes
 #
 nanopct4                  current         jammy       desktop                  stable         yes            gnome         config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 nanopct4                  current         jammy       desktop                  stable         yes            cinnamon      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
@@ -372,7 +398,7 @@ orangepi4                 current         bullseye    minimal                  s
 orangepi4                 current         jammy       desktop                  stable         yes            gnome         config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 orangepi4                 current         jammy       desktop                  stable         yes            cinnamon      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 orangepi4                 current         jammy       desktop                  stable         adv            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-#
+
 
 
 # Orangepi 4 LTS
@@ -384,7 +410,6 @@ orangepi4-lts             current         bullseye    minimal                  s
 orangepi4-lts             current         jammy       desktop                  stable         yes            gnome         config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 orangepi4-lts             current         jammy       desktop                  stable         yes            cinnamon      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 orangepi4-lts             current         jammy       desktop                  stable         adv            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-#
 
 
 # Orangepi R1
@@ -393,20 +418,26 @@ orangepi-r1               current         bullseye    cli                      s
 orangepi-r1               current         jammy       minimal                  stable         yes
 orangepi-r1               current         bullseye    minimal                  stable         yes
 
+
 # orangepi R1+
 orangepi-r1plus           current         jammy       cli                      stable         adv
 orangepi-r1plus           current         bullseye    cli                      stable         adv
 orangepi-r1plus           current         jammy       minimal                  stable         yes
 orangepi-r1plus           current         bullseye    minimal                  stable         yes
 
+
 # Orangepi R1+ LTS
 orangepi-r1plus-lts       current         bullseye    cli                      stable         adv
 orangepi-r1plus-lts       current         jammy       cli                      stable         adv
+orangepi-r1plus-lts       current         bullseye    minimal                  stable         yes
+orangepi-r1plus-lts       current         jammy       minimal                  stable         yes
 
 
 # orangepilite
 orangepilite              current         bullseye    cli                      stable         yes
 orangepilite              current         jammy       cli                      stable         adv
+orangepilite              current         bullseye    minimal                  stable         yes
+orangepilite              current         jammy       minimal                  stable         yes
 #
 orangepilite              current         jammy       desktop                  stable         adv            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
@@ -414,6 +445,8 @@ orangepilite              current         jammy       desktop                  s
 # orangepilite2
 orangepilite2             current         bullseye    cli                      stable         yes
 orangepilite2             current         jammy       cli                      stable         adv
+orangepilite2             current         bullseye    minimal                  stable         yes
+orangepilite2             current         jammy       minimal                  stable         yes
 #
 orangepilite2             current         jammy       desktop                  stable         adv            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
@@ -421,6 +454,8 @@ orangepilite2             current         jammy       desktop                  s
 # orangepioneplus
 orangepioneplus           current         bullseye    cli                      stable         yes
 orangepioneplus           current         jammy       cli                      stable         adv
+orangepioneplus           current         bullseye    minimal                  stable         yes
+orangepioneplus           current         jammy       minimal                  stable         yes
 #
 orangepioneplus           current         jammy       desktop                  stable         adv            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
@@ -428,6 +463,8 @@ orangepioneplus           current         jammy       desktop                  s
 # orangepione
 orangepione               current         bullseye    cli                      stable         yes
 orangepione               current         jammy       cli                      stable         adv
+orangepione               current         bullseye    minimal                  stable         yes
+orangepione               current         jammy       minimal                  stable         yes
 #
 orangepione               current         jammy       desktop                  stable         adv            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
@@ -435,6 +472,8 @@ orangepione               current         jammy       desktop                  s
 # orangepipc
 orangepipc                current         bullseye    cli                      stable         yes
 orangepipc                current         jammy       cli                      stable         adv
+orangepipc                current         bullseye    minimal                  stable         yes
+orangepipc                current         jammy       minimal                  stable         yes
 #
 orangepipc                current         jammy       desktop                  stable         adv            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
@@ -442,6 +481,8 @@ orangepipc                current         jammy       desktop                  s
 # orangepipc2
 orangepipc2               current         jammy       cli                      stable         adv
 orangepipc2               current         bullseye    cli                      stable         yes
+orangepipc2               current         jammy       minimal                  stable         yes
+orangepipc2               current         bullseye    minimal                  stable         yes
 #
 orangepipc2               current         jammy       desktop                  stable         yes            gnome         config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 orangepipc2               current         jammy       desktop                  stable         yes            cinnamon      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
@@ -452,6 +493,8 @@ orangepipc2               current         jammy       desktop                  s
 # orangepipcplus
 orangepipcplus            current         bullseye    cli                      stable         yes
 orangepipcplus            current         jammy       cli                      stable         adv
+orangepipcplus            current         bullseye    minimal                  stable         yes
+orangepipcplus            current         jammy       minimal                  stable         yes
 #
 orangepipcplus            current         jammy       desktop                  stable         adv            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
@@ -459,6 +502,8 @@ orangepipcplus            current         jammy       desktop                  s
 # orangepiplus
 orangepiplus              current         bullseye    cli                      stable         yes
 orangepiplus              current         jammy       cli                      stable         adv
+orangepiplus              current         bullseye    minimal                  stable         yes
+orangepiplus              current         jammy       minimal                  stable         yes
 #
 orangepiplus              current         jammy       desktop                  stable         adv            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
@@ -623,6 +668,8 @@ rock-3a                   edge            jammy       desktop                  s
 # Rockpi 4a
 rockpi-4a                 current         jammy       cli                      stable         adv
 rockpi-4a                 current         bullseye    cli                      stable         yes
+rockpi-4a                 current         jammy       minimal                  stable         yes
+rockpi-4a                 current         bullseye    minimal                  stable         yes
 #
 rockpi-4a                 current         jammy       desktop                  stable         yes            gnome         config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 rockpi-4a                 current         jammy       desktop                  stable         yes            cinnamon      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
@@ -632,6 +679,8 @@ rockpi-4a                 current         jammy       desktop                  s
 # Rockpi 4b
 rockpi-4b                 current         jammy       cli                      stable         adv
 rockpi-4b                 current         bullseye    cli                      stable         yes
+rockpi-4b                 current         jammy       minimal                  stable         yes
+rockpi-4b                 current         bullseye    minimal                  stable         yes
 #
 rockpi-4b                 current         jammy       desktop                  stable         yes            gnome         config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 rockpi-4b                 current         jammy       desktop                  stable         yes            cinnamon      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
@@ -641,6 +690,8 @@ rockpi-4b                 current         jammy       desktop                  s
 # Rockpi 4c
 rockpi-4c                 current         jammy       cli                      stable         adv
 rockpi-4c                 current         bullseye    cli                      stable         yes
+rockpi-4c                 current         jammy       minimal                  stable         yes
+rockpi-4c                 current         bullseye    minimal                  stable         yes
 #
 rockpi-4c                 current         jammy       desktop                  stable         yes            gnome         config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 rockpi-4c                 current         jammy       desktop                  stable         yes            cinnamon      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
@@ -668,8 +719,8 @@ rockpi-s                  edge            bullseye    minimal                  s
 # Tinkerboard
 tinkerboard               current         bullseye    cli                      stable         yes
 tinkerboard               current         jammy       cli                      stable         adv
-tinkerboard               current         jammy       minimal                  stable         yes
 tinkerboard               current         bullseye    minimal                  stable         yes
+tinkerboard               current         jammy       minimal                  stable         yes
 #
 tinkerboard               current         jammy       desktop                  stable         adv            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 #
@@ -679,6 +730,8 @@ tinkerboard               edge            bullseye    cli                      s
 # Tritium H3
 tritium-h3                current         bullseye    cli                      stable         yes
 tritium-h3                current         jammy       cli                      stable         adv
+tritium-h3                current         bullseye    minimal                  stable         yes
+tritium-h3                current         jammy       minimal                  stable         yes
 #
 tritium-h3                current         jammy       desktop                  stable         adv            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
@@ -686,6 +739,8 @@ tritium-h3                current         jammy       desktop                  s
 # Tritium H5
 tritium-h5                current         jammy       cli                      stable         adv
 tritium-h5                current         bullseye    cli                      stable         yes
+tritium-h5                current         jammy       minimal                  stable         yes
+tritium-h5                current         bullseye    minimal                  stable         yes
 #
 tritium-h5                current         jammy       desktop                  stable         yes            gnome         config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 tritium-h5                current         jammy       desktop                  stable         yes            cinnamon      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop


### PR DESCRIPTION
# Description

Enabling several minimal images as per user request. We already enabled images on targets where such images might be interesting. They are also coming [to all community builds](https://github.com/armbian/community).

# Why this is useful?

Some people prefer or need as images that contains nothing but bare system. Initial root size only at **around 0.5Gb!!!** (size differs from kernel and user space architecture)

![htopneo](https://user-images.githubusercontent.com/6281704/204137613-c8ff0398-edb6-400e-93de-4ddcbc539a30.png)
![freeneo](https://user-images.githubusercontent.com/6281704/204137615-3489cd28-fe8f-40e5-86a1-8fd5ce7d83a2.png)

Tests was done on very old and slow 32bit device. Only there such measures really means something. Nanopi Neo v1 booted up **in less then 20s with all standard services** ... (systemd-analyze: Startup finished in 5.052s (kernel) + 14.010s (userspace) = 19.063s)