### PR TITLE
armbian-firstlogin: remove unnecessary check

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -411,7 +411,6 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 		printf "\nYou selected \e[0;91mZSH\x1B[0m as your default shell. If you want to use it right away, please logout and login! \n\n"
 	fi
 
-	declare ConfigureDisplay
 	# check whether desktop environment has to be considered
 	if [ -n "$desktop_lightdm" ] && [ -n "$RealName" ] ; then
 
@@ -454,7 +453,7 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 				# Let the user reboot now otherwise start desktop environment
 				printf "\n\n\e[0;91mWarning: a reboot is needed to finish resizing the filesystem \x1B[0m \n"
 				printf "\e[0;91mPlease reboot the system now \x1B[0m \n\n"
-			elif [ -z "$ConfigureDisplay" ] || [ "$ConfigureDisplay" = "n" ] || [ "$ConfigureDisplay" = "N" ]; then
+			else
 				echo -e "\n\e[1m\e[39mNow starting desktop environment...\x1B[0m\n"
 				sleep 1
 				service lightdm start 2>/dev/null
@@ -486,7 +485,7 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 					printf "\n\n\e[0;91mWarning: a reboot is needed to finish resizing the filesystem \x1B[0m \n"
 					printf "\e[0;91mPlease reboot the system now \x1B[0m \n\n"
 
-				elif [ -z "$ConfigureDisplay" ] || [ "$ConfigureDisplay" = "n" ] || [ "$ConfigureDisplay" = "N" ]; then
+				else
 
 					echo -e "\n\e[1m\e[39mNow starting desktop environment...\x1B[0m\n"
 					sleep 1

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -357,8 +357,8 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 			okay="$(awk -F': ' '{ print $2}' <<<"$result")"
 			if [[ "$okay" != "OK" ]]; then
 				echo -e "\n\e[0;31mWarning:\x1B[0m Weak password, $okay \b!"
-				(echo "$first_input";echo "$second_input";) | passwd root >/dev/null 2>&1
 			fi
+			(echo "$first_input";echo "$second_input";) | passwd root >/dev/null 2>&1
 			break
 		elif [[ -n $password ]]; then
 			echo -e "Rejected - \e[0;31mpasswords do not match.\x1B[0m Try again [${REPEATS}]."


### PR DESCRIPTION
Commit c90986492252a85db3357362594e5c40b80fbf95 removed a prompt asking the user if they want to change display settings, but didn't remove the checks that later used the answer. Since it's been like this for 2 years now apparently without issue, remove the checks and the shellcheck workaround.
