### PR TITLE
Fix missing interactive KERNEL_ONLY selection

### DIFF
--- a/lib/functions/configuration/interactive.sh
+++ b/lib/functions/configuration/interactive.sh
@@ -13,12 +13,12 @@ function interactive_config_prepare_terminal() {
 }
 
 function interactive_config_ask_kernel() {
-#	interactive_config_ask_kernel_only
+	interactive_config_ask_kernel_only
 	interactive_config_ask_kernel_configure
 }
 
 function interactive_config_ask_kernel_only() {
-	if [[ -z $KERNEL_ONLY ]]; then
+	if [[ -z $KERNEL_ONLY ]] && [[ -z $BUILD_ONLY ]]; then
 
 		options+=("yes" "U-boot and kernel packages")
 		options+=("no" "Full OS image for flashing")

--- a/lib/functions/main/config-prepare.sh
+++ b/lib/functions/main/config-prepare.sh
@@ -87,9 +87,9 @@ function prepare_and_config_main_build_single() {
 
 	# if KERNEL_ONLY, KERNEL_CONFIGURE, BOARD, BRANCH or RELEASE are not set, display selection menu
 
-	backward_compatibility_build_only
-
 	interactive_config_ask_kernel
+
+	backward_compatibility_build_only
 
 	interactive_config_ask_board_list
 


### PR DESCRIPTION
- This selection did get disabled by the BUILD_ONLY option implementation
- This fix will re-enable the KERNEL_ONLY selection for intermediate backward compatibility

# Description

@The-going This PR is due to a comment from @igorpecovnik on #4455, asking, if it was inteded to switch off the interactive KERNEL_ONLY selection.
I guess for now we should keep this interactive feature in for backward compatibility.
This PR would fix it.

This is a followup to fix this introduced by #4455

# Test

- [x] Interactive call of `./compile.sh` - the interactive KERNEL_ONLY selection dialog appears again and KERNEL_ONLY=yes is propagated to BUILD_ONLY as expected

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [n/a] Any dependent changes have been merged and published in downstream modules
