### PR TITLE
Fix the amlogic tvbox build's extlinux.conf to use uImage for the kernel

### DIFF
--- a/packages/armbian/builddeb
+++ b/packages/armbian/builddeb
@@ -317,7 +317,7 @@ done
 ##
 sed -e "s/exit 0//g" -i $tmpdir/DEBIAN/postinst
 cat >> $tmpdir/DEBIAN/postinst <<- EOT
-	ln -sf $(basename $installed_image_path) /boot/$image_name 2> /dev/null || mv /$installed_image_path /boot/$image_name
+	ln -sf $(basename $installed_image_path) /boot/$image_name 2> /dev/null || cp /$installed_image_path /boot/$image_name
 	touch /boot/.next
 	exit 0
 EOT

--- a/packages/bsp/aml-s9xx-box/boot/extlinux/extlinux.conf
+++ b/packages/bsp/aml-s9xx-box/boot/extlinux/extlinux.conf
@@ -1,5 +1,5 @@
 LABEL Armbian
-LINUX /Image
+LINUX /uImage
 INITRD /uInitrd
 
 #FDT /dtb/amlogic/meson-gxbb-p200.dtb


### PR DESCRIPTION
Fix the amlogic tvbox build's extlinux.conf to use uImage for the kernel
image file instead of Image as some of the included uboot files do not support the Image format and require the uImage.
 Changes to be committed:
	modified:   packages/bsp/aml-s9xx-box/boot/extlinux/extlinux.conf

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Local build and test install on multiple amlogic based TV boxes
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
