### PR TITLE
Fix the builddeb script so linux-image upgrades work correctly

### DIFF
--- a/packages/armbian/builddeb
+++ b/packages/armbian/builddeb
@@ -317,7 +317,7 @@ done
 ##
 sed -e "s/exit 0//g" -i $tmpdir/DEBIAN/postinst
 cat >> $tmpdir/DEBIAN/postinst <<- EOT
-	ln -sf $(basename $installed_image_path) /boot/$image_name 2> /dev/null || mv /$installed_image_path /boot/$image_name
+	ln -sf $(basename $installed_image_path) /boot/$image_name 2> /dev/null || cp /$installed_image_path /boot/$image_name
 	touch /boot/.next
 	exit 0
 EOT


### PR DESCRIPTION
Fix the builddeb script so linux-image upgrades work correctly
on fat /boot partitions.

Currently the postinst file that is created has the following contents:
...
ln -sf vmlinuz-6.0.10-meson64 /boot/Image 2> /dev/null || mv /boot/vmlinuz-6.0.10-meson64 /boot/Image
touch /boot/.next

mkimage -A arm64 -O linux -T kernel -C none -a 0x1080000 -e 0x1080000 -n "Linux" -d /boot/vmlinuz-6.0.10-meson64 /boot/uImage  > /dev/null 2>&1
exit 0
...

In the first line on a fat filesystem the mv command leaves the system without a file named 'vmlinuz...'.  The following mkimage command is looking for the vmlinuz... file that is no longer there and fails.
This fix changes the 'mv' to a 'cp' so that the files in the directory are the same regardless of the type of partition (i.e. the softlink in the ext4 case leaves both objects and the fat case now leaves both objects as well, at the cost of disk space)

With this fix the amlogic tv box builds can now upgrade to the latest community build kernels without errors.



 Changes to be committed:
	modified:   packages/armbian/builddeb

# Description

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Local build and tested on both an s905w and s905x2 based amlogic TV box
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
