### PR TITLE
Fix USB OTG on Radxa Zero

### DIFF
--- a/patch/kernel/archive/meson64-5.19/board-radxa-zero-dts-otg-fix.patch
+++ b/patch/kernel/archive/meson64-5.19/board-radxa-zero-dts-otg-fix.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Stephen <stephen@vamrs.com>
+Date: Thu, 28 Oct 2021 14:26:24 +0800
+Subject: [PATCH] arm64: dts: radxa zero: set dr_mode of usb node to otg
+
+This enables dwc2 otg function.
+
+Signed-off-by: Stephen <stephen@vamrs.com>
+Signed-off-by: Yuntian Zhang <yt@radxa.com>
+---
+ arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
+index 9519e36ab7..9095ad9018 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
+@@ -426,5 +426,4 @@ &uart_AO {
+ 
+ &usb {
+ 	status = "okay";
+-	dr_mode = "host";
+ };
+-- 
+2.36.1
+

--- a/patch/kernel/archive/meson64-6.0/board-radxa-zero-dts-otg-fix.patch
+++ b/patch/kernel/archive/meson64-6.0/board-radxa-zero-dts-otg-fix.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Stephen <stephen@vamrs.com>
+Date: Thu, 28 Oct 2021 14:26:24 +0800
+Subject: [PATCH] arm64: dts: radxa zero: set dr_mode of usb node to otg
+
+This enables dwc2 otg function.
+
+Signed-off-by: Stephen <stephen@vamrs.com>
+Signed-off-by: Yuntian Zhang <yt@radxa.com>
+---
+ arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
+index 9519e36ab7..9095ad9018 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
+@@ -426,5 +426,4 @@ &uart_AO {
+ 
+ &usb {
+ 	status = "okay";
+-	dr_mode = "host";
+ };
+-- 
+2.36.1
+


### PR DESCRIPTION
The OTG port was accidentally set to host mode in the dtb.
