### PR TITLE
The choice for kernel headers if the version is more than 5.19.

### DIFF
--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -25,7 +25,7 @@ create_linux-source_package() {
 		Maintainer: $MAINTAINER <$MAINTAINERMAIL>
 		Section: kernel
 		Priority: optional
-		Depends: binutils, coreutils
+		Depends: binutils, coreutils, linux-base
 		Provides: linux-source, linux-source-${version}-${LINUXFAMILY}
 		Recommends: gcc, make
 		Description: This package provides the source code for the Linux kernel $version

--- a/packages/armbian/builddeb
+++ b/packages/armbian/builddeb
@@ -125,6 +125,12 @@ deploy_kernel_headers() {
 	destdir=$pdir/usr/src/linux-headers-$version
 	mkdir -p $destdir
 
+	if linux-version compare "$KERNELVERSION" ge "5.19" ; then
+		configobj=CONFIG_OBJTOOL
+	else
+		configobj=CONFIG_STACK_VALIDATION
+	fi
+
 	(
 		cd $srctree
 		find . -name Makefile\* -o -name Kconfig\* -o -name \*.pl
@@ -135,7 +141,8 @@ deploy_kernel_headers() {
 	) > debian/hdrsrcfiles
 
 	{
-		if is_enabled CONFIG_STACK_VALIDATION; then
+		# This affects arch/x86
+		if is_enabled $configobj; then
 			#	echo tools/objtool/objtool
 			find tools/objtool -type f -executable
 		fi

--- a/packages/armbian/mkdebian
+++ b/packages/armbian/mkdebian
@@ -178,7 +178,8 @@ Source: $sourcename
 Section: kernel
 Priority: optional
 Maintainer: $maintainer
-Build-Depends: bc, rsync, kmod, cpio, bison, flex | flex:native $extra_build_depends
+Build-Depends: bc, rsync, kmod, cpio, bison, linux-base,
+ flex | flex:native $extra_build_depends
 Homepage: https://www.kernel.org/
 
 Package: $packagename


### PR DESCRIPTION
# Description
Ability to collect correct kernel headers for a version greater than or equal to 5.19.
These changes in the names of kernel configuration variables currently affect only arch/x86.

# Checklist:
- [x] Test build
