### PR TITLE
add emmc variants to FIT image

### DIFF
--- a/config/its/marvell/a37xx/espressobin.its
+++ b/config/its/marvell/a37xx/espressobin.its
@@ -52,6 +52,30 @@
                 algo = "sha1";
             };
         };
+        fdtv5-emmc {
+            description = "Flattened Device Tree ebinv5 with eMMC";
+            data = /incbin/("/boot/dtb/marvell/armada-3720-espressobin-emmc.dtb");
+            type = "flat_dt";
+            arch = "arm64";
+            compression = "none";
+            load = <0x06f00000>;
+            entry = <0x06f00000>;
+            hash {
+                algo = "sha1";
+            };
+        };
+        fdtv7-emmc {
+            description = "Flattened Device Tree ebinv7";
+            data = /incbin/("/boot/dtb/marvell/armada-3720-espressobin-v7-emmc.dtb");
+            type = "flat_dt";
+            arch = "arm64";
+            compression = "none";
+            load = <0x06f00000>;
+            entry = <0x06f00000>;
+            hash {
+                algo = "sha1";
+            };
+        };
     };
 
     configurations {
@@ -70,6 +94,24 @@
             kernel = "kernel";
             ramdisk = "ramdisk";
             fdt = "fdtv7";
+            hash {
+                algo = "sha1";
+            };
+        };
+        v5-emmc {
+            description = "Standard Boot ebinv5 with emmc";
+            kernel = "kernel";
+            ramdisk = "ramdisk";
+            fdt = "fdtv5-emmc";
+            hash {
+                algo = "sha1";
+            };
+        };
+        v7 {
+            description = "Standard Boot ebinv7 with emmc";
+            kernel = "kernel";
+            ramdisk = "ramdisk";
+            fdt = "fdtv7-emmc";
             hash {
                 algo = "sha1";
             };


### PR DESCRIPTION
# Description
Add the emmc DTBs to the FIT image

# How Has This Been Tested?

Don't have emmc hardware, but it's very similar to the v5 and v7

# Checklist:
