### PR TITLE
Don't use "edge" patches for "current"

### DIFF
--- a/config/sources/families/include/meson64_common.inc
+++ b/config/sources/families/include/meson64_common.inc
@@ -25,7 +25,7 @@ case $BRANCH in
 
 	current)
 		KERNELBRANCH='branch:linux-5.19.y'
-		KERNELPATCHDIR='meson64-edge'
+		KERNELPATCHDIR='meson64-current'
 		;;
 
 	edge)


### PR DESCRIPTION
meson64 (Radxa Zero and possibly others) config was using meson64-edge for both kernel 5.19 and kernel 6.0 based builds.
