### PR TITLE
Add fonts-ubuntu to the desktop packages

### DIFF
--- a/config/cli/bullseye/main/config_desktop/packages
+++ b/config/cli/bullseye/main/config_desktop/packages
@@ -5,6 +5,7 @@ build-essential
 ca-certificates
 console-setup
 crda
+fonts-ubuntu
 expect
 fbset
 flex

--- a/config/cli/buster/main/config_desktop/packages
+++ b/config/cli/buster/main/config_desktop/packages
@@ -5,6 +5,7 @@ build-essential
 ca-certificates
 console-setup
 expect
+fonts-ubuntu
 fbset
 flex
 html2text

--- a/config/cli/focal/main/config_desktop/packages
+++ b/config/cli/focal/main/config_desktop/packages
@@ -9,6 +9,7 @@ emacs-nox
 expect
 fbset
 flex
+fonts-ubuntu
 html2text
 initramfs-tools
 iptables

--- a/config/cli/jammy/main/config_desktop/packages
+++ b/config/cli/jammy/main/config_desktop/packages
@@ -8,6 +8,7 @@ emacs-nox
 expect
 fbset
 flex
+fonts-ubuntu
 html2text
 initramfs-tools
 iptables

--- a/config/cli/sid/main/config_desktop/packages
+++ b/config/cli/sid/main/config_desktop/packages
@@ -7,6 +7,7 @@ console-setup
 expect
 fbset
 flex
+fonts-ubuntu
 html2text
 initramfs-tools
 iptables


### PR DESCRIPTION
# Description

Missing font in Bullseye desktop cause strange fonts in Terminator @paolosabatino 

Jira reference number [AR-1416]

# How Has This Been Tested?

- [ ] Open terminal before and after