### PR TITLE
SUNXI: Add missing print for NAND boot source

### DIFF
--- a/config/bootscripts/boot-sunxi.cmd
+++ b/config/bootscripts/boot-sunxi.cmd
@@ -19,6 +19,7 @@ setenv earlycon "off"
 
 # Print boot source
 itest.b *0x28 == 0x00 && echo "U-boot loaded from SD"
+itest.b *0x28 == 0x01 && echo "U-boot loaded from NAND"
 itest.b *0x28 == 0x02 && echo "U-boot loaded from eMMC or secondary SD"
 itest.b *0x28 == 0x03 && echo "U-boot loaded from SPI"
 


### PR DESCRIPTION
fixes #4532

# Description
In case of booting from NAND SUNXI boards are not echoing "U-Boot loaded from NAND".

refers to GH-4532

# Testresult

This has been tested on a Cubietruck board.

- [x] Test s. screenshot:
![image](https://user-images.githubusercontent.com/45703410/205752368-d38f9a06-5c39-41bf-aa9e-91309c98f404.png)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [n/a] Any dependent changes have been merged and published in downstream modules
