### PR TITLE
Improve build train logic - bump version first

### DIFF
--- a/.github/workflows/build-train.yml
+++ b/.github/workflows/build-train.yml
@@ -53,7 +53,7 @@ jobs:
   Cleaning:
     permissions:
       contents: none
-    needs: Check
+    needs: Cancel
     if: ${{ success() && github.repository_owner == 'Armbian' }}
     uses: armbian/scripts/.github/workflows/clean-upload.yml@master
     secrets:
@@ -67,13 +67,11 @@ jobs:
   ##########################################################################################
 
   Bump:
-
     needs: [Cleaning]
     if: ${{ success() && github.repository_owner == 'Armbian' }}
     uses: armbian/scripts/.github/workflows/update-version.yml@master
 
     with:
-
       uploading: true
 
     secrets:

--- a/.github/workflows/build-train.yml
+++ b/.github/workflows/build-train.yml
@@ -62,6 +62,31 @@ jobs:
 
   ##########################################################################################
   #                                                                                        #
+  #                         Bump with version if compilation succeeded                     #
+  #                                                                                        #
+  ##########################################################################################
+
+  Bump:
+
+    needs: [Cleaning]
+    if: ${{ success() && github.repository_owner == 'Armbian' }}
+    uses: armbian/scripts/.github/workflows/update-version.yml@master
+
+    with:
+
+      uploading: true
+
+    secrets:
+      GPG_KEY1: ${{ secrets.GPG_KEY1 }}
+      GPG_PASSPHRASE1: ${{ secrets.GPG_PASSPHRASE1 }}
+      GPG_KEY2: ${{ secrets.GPG_KEY2 }}
+      GPG_PASSPHRASE2: ${{ secrets.GPG_PASSPHRASE2 }}
+      SCRIPTS_ACCESS_TOKEN: ${{ secrets.SCRIPTS_ACCESS_TOKEN }}
+      KEY_TORRENTS: ${{ secrets.KEY_TORRENTS }}
+      KNOWN_HOSTS_UPLOAD: ${{ secrets.KNOWN_HOSTS_UPLOAD }}
+
+  ##########################################################################################
+  #                                                                                        #
   #           Merge master into nighly image from which we build packages                  #
   #                                                                                        #
   ##########################################################################################
@@ -349,37 +374,11 @@ jobs:
       USER_REPOSITORY: ${{ secrets.USER_REPOSITORY }}
       HOST_REPOSITORY: ${{ secrets.HOST_REPOSITORY }}
       KNOWN_HOSTS_REPOSITORY: ${{ secrets.KNOWN_HOSTS_REPOSITORY }}
-
-  ##########################################################################################
-  #                                                                                        #
-  #                         Bump with version if compilation succeeded                     #
-  #                                                                                        #
-  ##########################################################################################
-
-  Bump:
-
-    needs: [apt-armbian-com,beta-armbian-com,sync-servers]
-    if: ${{ success() && github.repository_owner == 'Armbian' }}
-    uses: armbian/scripts/.github/workflows/update-version.yml@master
-
-    with:
-
-      uploading: true
-
-    secrets:
-      GPG_KEY1: ${{ secrets.GPG_KEY1 }}
-      GPG_PASSPHRASE1: ${{ secrets.GPG_PASSPHRASE1 }}
-      GPG_KEY2: ${{ secrets.GPG_KEY2 }}
-      GPG_PASSPHRASE2: ${{ secrets.GPG_PASSPHRASE2 }}
-      SCRIPTS_ACCESS_TOKEN: ${{ secrets.SCRIPTS_ACCESS_TOKEN }}
-      KEY_TORRENTS: ${{ secrets.KEY_TORRENTS }}
-      KNOWN_HOSTS_UPLOAD: ${{ secrets.KNOWN_HOSTS_UPLOAD }}
-
-
+  
   Clean:
   
     name: Clean
-    needs: [Bump]
+    needs: [apt-armbian-com,beta-armbian-com,sync-servers]
     runs-on: Linux
     if: ${{ success() && github.repository_owner == 'Armbian' }}
     steps:

--- a/.github/workflows/build-train.yml
+++ b/.github/workflows/build-train.yml
@@ -46,6 +46,22 @@ jobs:
 
   ##########################################################################################
   #                                                                                        #
+  #                           Clean upload folder                                          #
+  #                                                                                        #
+  ##########################################################################################
+
+  Cleaning:
+    permissions:
+      contents: none
+    needs: Check
+    if: ${{ success() && github.repository_owner == 'Armbian' }}
+    uses: armbian/scripts/.github/workflows/clean-upload.yml@master
+    secrets:
+      KEY_TORRENTS: ${{ secrets.KEY_TORRENTS }}
+      KNOWN_HOSTS_UPLOAD: ${{ secrets.KNOWN_HOSTS_UPLOAD }}
+
+  ##########################################################################################
+  #                                                                                        #
   #           Merge master into nighly image from which we build packages                  #
   #                                                                                        #
   ##########################################################################################

--- a/.github/workflows/build-train.yml
+++ b/.github/workflows/build-train.yml
@@ -93,7 +93,7 @@ jobs:
 
   Merge:
     name: Merging
-    needs: Cancel
+    needs: [Bump]
     if: ${{ github.repository_owner == 'Armbian' }}
     uses: armbian/scripts/.github/workflows/merge-from-branch.yml@master
 


### PR DESCRIPTION
# Description

Currently we were bumping nightly build version at the end which caused problems. Now version is bumped at start, then we clean possible left overs and start with the train.

# How Has This Been Tested?

- [x] Several manual runs