### PR TITLE
`meson64-6.0` kernel patches: mbox formatting, archeology to find lost authors/descriptions; rebase against 6.0.12; no actual changes

### DIFF
--- a/patch/kernel/archive/meson64-6.0/add-board-radxa-zero2.patch
+++ b/patch/kernel/archive/meson64-6.0/add-board-radxa-zero2.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Christian Hewitt <christianshewitt@gmail.com>
 Date: Wed, 16 Feb 2022 07:27:07 +0000
-Subject: [PATCH] dt-bindings: arm: amlogic: add support for Radxa Zero2
+Subject: dt-bindings: arm: amlogic: add support for Radxa Zero2
 
 The Radxa Zero2 is a small form-factor SBC using the Amlogic
 A311D chip.
@@ -13,10 +13,10 @@ Signed-off-by: Yuntian Zhang <yt@radxa.com>
  1 file changed, 1 insertion(+)
 
 diff --git a/Documentation/devicetree/bindings/arm/amlogic.yaml b/Documentation/devicetree/bindings/arm/amlogic.yaml
-index 36081734f..ac6e1e79f 100644
+index 61a6cabb375b..bf32821281b1 100644
 --- a/Documentation/devicetree/bindings/arm/amlogic.yaml
 +++ b/Documentation/devicetree/bindings/arm/amlogic.yaml
-@@ -151,6 +151,7 @@ properties:
+@@ -152,6 +152,7 @@ properties:
          items:
            - enum:
                - khadas,vim3
@@ -25,12 +25,12 @@ index 36081734f..ac6e1e79f 100644
            - const: amlogic,g12b
  
 -- 
-2.36.1
+Armbian
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Yuntian Zhang <yt@radxa.com>
 Date: Fri, 14 Jan 2022 15:50:02 +0000
-Subject: [PATCH] arm64: dts: meson: add support for Radxa Zero2
+Subject: arm64: dts: meson: add support for Radxa Zero2
 
 Radxa Zero2 is a small form factor SBC based on the Amlogic A311D
 chipset that ships in a number of eMMC configurations:
@@ -49,13 +49,12 @@ chipset that ships in a number of eMMC configurations:
 Signed-off-by: Yuntian Zhang <yt@radxa.com>
 Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
 ---
- arch/arm64/boot/dts/amlogic/Makefile          |   1 +
- .../dts/amlogic/meson-g12b-radxa-zero2.dts    | 576 ++++++++++++++++++
+ arch/arm64/boot/dts/amlogic/Makefile                   |   1 +
+ arch/arm64/boot/dts/amlogic/meson-g12b-radxa-zero2.dts | 576 ++++++++++
  2 files changed, 577 insertions(+)
- create mode 100644 arch/arm64/boot/dts/amlogic/meson-g12b-radxa-zero2.dts
 
 diff --git a/arch/arm64/boot/dts/amlogic/Makefile b/arch/arm64/boot/dts/amlogic/Makefile
-index 5148cd9e5..c65266d26 100644
+index 8773211df50e..f231280cd808 100644
 --- a/arch/arm64/boot/dts/amlogic/Makefile
 +++ b/arch/arm64/boot/dts/amlogic/Makefile
 @@ -12,6 +12,7 @@ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-gtking-pro.dtb
@@ -68,7 +67,7 @@ index 5148cd9e5..c65266d26 100644
  dtb-$(CONFIG_ARCH_MESON) += meson-gxbb-kii-pro.dtb
 diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-radxa-zero2.dts b/arch/arm64/boot/dts/amlogic/meson-g12b-radxa-zero2.dts
 new file mode 100644
-index 000000000..f7da62ccf
+index 000000000000..e261ba2a4b47
 --- /dev/null
 +++ b/arch/arm64/boot/dts/amlogic/meson-g12b-radxa-zero2.dts
 @@ -0,0 +1,576 @@
@@ -649,5 +648,5 @@ index 000000000..f7da62ccf
 +	phy-supply = <&typec2_vbus>;
 +};
 -- 
-2.36.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/board-khadas-vim2-use-gpio-fan-matrix-instead-of-array.patch
+++ b/patch/kernel/archive/meson64-6.0/board-khadas-vim2-use-gpio-fan-matrix-instead-of-array.patch
@@ -1,8 +1,7 @@
-From 4f925789d0713c48deb5067187c7e5acba397054 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: David Heidelberg <david@ixit.cz>
 Date: Sat, 27 Nov 2021 07:23:35 +0000
-Subject: [PATCH 28/90] FROMLIST(v1): arm64: dts: meson: make dts use gpio-fan
- matrix instead of array
+Subject: arm64: dts: meson: make dts use gpio-fan matrix instead of array
 
 No functional changes.
 
@@ -15,10 +14,10 @@ Signed-off-by: David Heidelberg <david@ixit.cz>
  1 file changed, 5 insertions(+), 4 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts b/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts
-index 9c26d7489d2a..c5e3b5587135 100644
+index f43c45daf7eb..a24102e3d369 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts
 +++ b/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts
-@@ -54,10 +54,11 @@ gpio_fan: gpio-fan {
+@@ -52,10 +52,11 @@ gpio_fan: gpio-fan {
  		gpios = <&gpio GPIODV_14 GPIO_ACTIVE_HIGH
  			 &gpio GPIODV_15 GPIO_ACTIVE_HIGH>;
  		/* Dummy RPM values since fan is optional */
@@ -35,5 +34,5 @@ index 9c26d7489d2a..c5e3b5587135 100644
  	};
  
 -- 
-2.35.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/board-khadas-vim3-fix-missing-i2c3-nod.patch
+++ b/patch/kernel/archive/meson64-6.0/board-khadas-vim3-fix-missing-i2c3-nod.patch
@@ -1,8 +1,7 @@
-From 04ba78002ded0f9089b7fae6550a56ccd0669e65 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Christian Hewitt <christianshewitt@gmail.com>
 Date: Fri, 21 Feb 2020 04:43:22 +0000
-Subject: [PATCH 086/101] WIP: arm64: dts: meson: khadas-vim3: fix missing i2c3
- node
+Subject: WIP: arm64: dts: meson: khadas-vim3: fix missing i2c3 node
 
 Fixes: c6d29c66e582 ("arm64: dts: meson-g12b-khadas-vim3: add initial device-tree")
 
@@ -16,10 +15,10 @@ Signed-off-by: Christian Hewittt <christianshewitt@gmail.com>
  1 file changed, 7 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-khadas-vim3.dtsi b/arch/arm64/boot/dts/amlogic/meson-khadas-vim3.dtsi
-index 0ef60c7151cb..6022805d2032 100644
+index c9705941e4ab..71a5c0aa2a9b 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-khadas-vim3.dtsi
 +++ b/arch/arm64/boot/dts/amlogic/meson-khadas-vim3.dtsi
-@@ -217,6 +217,13 @@
+@@ -333,6 +333,13 @@ hdmi_tx_tmds_out: endpoint {
  	};
  };
  
@@ -34,5 +33,5 @@ index 0ef60c7151cb..6022805d2032 100644
  	status = "okay";
  	pinctrl-0 = <&i2c_ao_sck_pins>, <&i2c_ao_sda_pins>;
 -- 
-2.17.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/board-khadas-vims-add-rtc-vrtc-aliases.patch
+++ b/patch/kernel/archive/meson64-6.0/board-khadas-vims-add-rtc-vrtc-aliases.patch
@@ -1,8 +1,7 @@
-From 5ff8dfecb282089107d1bd3da6b612c5294fe0cb Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Christian Hewitt <christianshewitt@gmail.com>
 Date: Thu, 21 Jan 2021 01:35:36 +0000
-Subject: [PATCH 07/90] HACK: arm64: dts: meson: add rtc/vrtc aliases to Khadas
- VIM
+Subject: HACK: arm64: dts: meson: add rtc/vrtc aliases to Khadas VIM
 
 Add aliases to ensure the vrtc time (which normally proves first) is /dev/rtc1
 while the onboard rtc chip claims /dev/rtc0.
@@ -26,13 +25,12 @@ index 6ab1cc125b96..24af15e18026 100644
  
  	gpio-keys-polled {
 -- 
-2.35.1
+Armbian
 
-From 293a4281d04100f1a0ab8ced46a45fc557f6e130 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Christian Hewitt <christianshewitt@gmail.com>
 Date: Sat, 6 Nov 2021 13:01:08 +0000
-Subject: [PATCH 08/90] HACK: arm64: dts: meson: add rtc/vrtc aliases to Khadas
- VIM2
+Subject: HACK: arm64: dts: meson: add rtc/vrtc aliases to Khadas VIM2
 
 Add aliases to ensure the vrtc time (which normally proves first) is /dev/rtc1
 while the onboard rtc chip claims /dev/rtc0.
@@ -43,7 +41,7 @@ Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
  1 file changed, 2 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts b/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts
-index 86bdc0baf032..9c26d7489d2a 100644
+index a24102e3d369..9b0c7e9d0620 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts
 +++ b/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts
 @@ -18,6 +18,8 @@ / {
@@ -56,5 +54,5 @@ index 86bdc0baf032..9c26d7489d2a 100644
  
  	chosen {
 -- 
-2.35.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/board-nanopi-k2-add-uartC-alias.patch
+++ b/patch/kernel/archive/meson64-6.0/board-nanopi-k2-add-uartC-alias.patch
@@ -1,8 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Martin Ayotte <martinayotte@yahoo.ca>
+Date: Thu, 6 Dec 2018 18:03:17 -0500
+Subject: add uartC alias for nanopi-k2
+
+add uartC alias for nanopi-k2
+- 839f2f151073928ed1e62d415ba5317f525b9e24: 1553615840: Martin Ayotte <martinayotte@yahoo.ca>: 'add uartA overlay for Odroid-C2'
+---
+ arch/arm64/boot/dts/amlogic/meson-gxbb-nanopi-k2.dts | 1 +
+ 1 file changed, 1 insertion(+)
+
 diff --git a/arch/arm64/boot/dts/amlogic/meson-gxbb-nanopi-k2.dts b/arch/arm64/boot/dts/amlogic/meson-gxbb-nanopi-k2.dts
-index cbe99bd..80c87e0 100644
+index 7d94160f5802..cf577bc8d98b 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-gxbb-nanopi-k2.dts
 +++ b/arch/arm64/boot/dts/amlogic/meson-gxbb-nanopi-k2.dts
-@@ -13,6 +13,7 @@
+@@ -15,6 +15,7 @@ / {
  
  	aliases {
  		serial0 = &uart_AO;
@@ -10,3 +21,6 @@ index cbe99bd..80c87e0 100644
  		ethernet0 = &ethmac;
  	};
  
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.0/board-nanopi-k2-enable-emmc.patch
+++ b/patch/kernel/archive/meson64-6.0/board-nanopi-k2-enable-emmc.patch
@@ -1,8 +1,18 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor.pecovnik@gmail.com>
+Date: Tue, 4 Jun 2019 21:35:48 +0200
+Subject: nanopik2 - enable eMMC
+
+[ nanopik2 ] enable eMMC support for u-boot and kernel
+---
+ arch/arm64/boot/dts/amlogic/meson-gxbb-nanopi-k2.dts | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
 diff --git a/arch/arm64/boot/dts/amlogic/meson-gxbb-nanopi-k2.dts b/arch/arm64/boot/dts/amlogic/meson-gxbb-nanopi-k2.dts
-index 80c87e0bb..340559727 100644
+index cf577bc8d98b..2ee48261a2ea 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-gxbb-nanopi-k2.dts
 +++ b/arch/arm64/boot/dts/amlogic/meson-gxbb-nanopi-k2.dts
-@@ -382,7 +382,7 @@
+@@ -359,7 +359,7 @@ &sd_emmc_b {
  
  /* eMMC */
  &sd_emmc_c {
@@ -11,7 +21,7 @@ index 80c87e0bb..340559727 100644
  	pinctrl-0 = <&emmc_pins>, <&emmc_ds_pins>;
  	pinctrl-1 = <&emmc_clk_gate_pins>;
  	pinctrl-names = "default", "clk-gate";
-@@ -392,8 +392,6 @@
+@@ -369,8 +369,6 @@ &sd_emmc_c {
  	non-removable;
  	disable-wp;
  	cap-mmc-highspeed;
@@ -20,3 +30,6 @@ index 80c87e0bb..340559727 100644
  
  	mmc-pwrseq = <&emmc_pwrseq>;
  	vmmc-supply = <&vcc3v3>;
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.0/board-odroidc2-add-uartA-uartC.patch
+++ b/patch/kernel/archive/meson64-6.0/board-odroidc2-add-uartA-uartC.patch
@@ -1,3 +1,18 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Martin Ayotte <martinayotte@yahoo.ca>
+Date: Thu, 26 Oct 2017 16:31:22 +0300
+Subject: add uartA and uartC for Odroid-C2
+
+add uartA and uartC for Odroid-C2
+
+- 839f2f151073928ed1e62d415ba5317f525b9e24: Martin Ayotte <martinayotte@yahoo.ca>: 'add uartA overlay for Odroid-C2'
+- b5c9e6ee8d4a97c5092109a12164c131eb4b46e9: Martin Ayotte <martinayotte@yahoo.ca>: 'add uartA for odroidc2 in NEXT'
+- 22ca2b92a002fe22e2a61428741618295c424664: Martin Ayotte <martinayotte@yahoo.ca>: 'fix missing pinctrl-0 for ODroidC2 uartA'
+- 140da6ad43f4a0d47c221271f62bb7c0a57064ea: Martin Ayotte <martinayotte@yahoo.ca>: 'add uartC to OdroidC2'
+---
+ arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts | 14 ++++++++++
+ 1 file changed, 14 insertions(+)
+
 diff --git a/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts b/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts
 index 201596247fd9..b2cb12fb46fd 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts
@@ -30,3 +45,6 @@ index 201596247fd9..b2cb12fb46fd 100644
  &usb0_phy {
  	status = "disabled";
  	phy-supply = <&usb_otg_pwr>;
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.0/board-odroidc2-enable-SPI.patch
+++ b/patch/kernel/archive/meson64-6.0/board-odroidc2-enable-SPI.patch
@@ -1,3 +1,15 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Thomas McKahan <tonymckahan@gmail.com>
+Date: Sat, 6 Oct 2018 22:50:14 -0400
+Subject: Odroid C2 enable SPI
+
+Odroid C2 enable SPI
+
+- f928b31d8a1983fd8cfd9c97de084e532283b106: 1543550719: Thomas McKahan <tonymckahan@gmail.com>: '[ meson64-dev ] fix Odroid C2 boot, add spidev'
+---
+ arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts | 26 ++++++++++
+ 1 file changed, 26 insertions(+)
+
 diff --git a/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts b/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts
 index b2cb12fb46fd..c252de8e4b17 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts
@@ -35,3 +47,6 @@ index b2cb12fb46fd..c252de8e4b17 100644
  	sound {
  		compatible = "amlogic,gx-sound-card";
  		model = "ODROID-C2";
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.0/board-odroidc2-enable-scpi-dvfs.patch
+++ b/patch/kernel/archive/meson64-6.0/board-odroidc2-enable-scpi-dvfs.patch
@@ -1,8 +1,18 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zador-blood-stained <zador-blood-stained@users.noreply.github.com>
+Date: Thu, 26 Oct 2017 16:31:22 +0300
+Subject: Enable odroidc2-dev DVFS
+
+Enable odroidc2-dev DVFS (#763)
+---
+ arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
 diff --git a/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts b/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts
-index d147c853a..dbde670ba 100644
+index c252de8e4b17..7af088c7366d 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts
 +++ b/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts
-@@ -246,7 +246,8 @@
+@@ -376,7 +376,8 @@ &saradc {
  };
  
  &scpi_clocks {
@@ -12,3 +22,6 @@ index d147c853a..dbde670ba 100644
  };
  
  /* SD */
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.0/board-odroidhc4-enable-fan1_input.patch
+++ b/patch/kernel/archive/meson64-6.0/board-odroidhc4-enable-fan1_input.patch
@@ -1,7 +1,7 @@
-From 9058e8940ae84b1bc97693d9aca7b27f55bb1964 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ricardo Pardini <ricardo@pardini.net>
 Date: Sun, 26 Jun 2022 03:47:06 +0200
-Subject: [PATCH] ODROID-HC4: add DT attributes to enable fan1_input
+Subject: ODROID-HC4: add DT attributes to enable fan1_input
 
 - from vendor kernel modified DT
 - this allows userspace fancontrol/pwmconfig to work
@@ -10,7 +10,7 @@ Subject: [PATCH] ODROID-HC4: add DT attributes to enable fan1_input
  1 file changed, 4 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-hc4.dts b/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-hc4.dts
-index 0764f1bb5..2b0752144 100644
+index e3486f60645a..89ef6f07603c 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-hc4.dts
 +++ b/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-hc4.dts
 @@ -23,6 +23,10 @@ fan0: pwm-fan {
@@ -25,5 +25,5 @@ index 0764f1bb5..2b0752144 100644
  
  	leds {
 -- 
-2.36.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/board-odroidn2-add-dumb-gpio-fan.patch
+++ b/patch/kernel/archive/meson64-6.0/board-odroidn2-add-dumb-gpio-fan.patch
@@ -1,10 +1,7 @@
-From 86d9151effff69d2a8fc2027a31dd60bd8c6eb05 Mon Sep 17 00:00:00 2001
-Message-Id: <86d9151effff69d2a8fc2027a31dd60bd8c6eb05.1627311993.git.stefan@agner.ch>
-In-Reply-To: <c7825747afd8bb975dc918f28e4afe8058a518f3.1627311993.git.stefan@agner.ch>
-References: <c7825747afd8bb975dc918f28e4afe8058a518f3.1627311993.git.stefan@agner.ch>
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Mon, 11 Jan 2021 11:38:54 +0100
-Subject: [PATCH 5/9] arm64: dts: meson: g12b: add GPIO fan support
+Subject: arm64: dts: meson: g12b: add GPIO fan support
 
 Add simple GPIO fan node to support a fan on GPIO J8. Unfortunately the
 pad used to control the fan does not support real PWM, hence the RPM
@@ -13,16 +10,17 @@ cannot be modulated.
 Signed-off-by: Stefan Agner <stefan@agner.ch>
 Tested-by: Ricardo Pardini <ricardo@pardini.net>
 ---
- arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dtsi | 11 +++++++++++
- 1 file changed, 11 insertions(+)
+ arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dtsi | 9 +++++++++
+ 1 file changed, 9 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dtsi b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dtsi
---- a/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dtsi	(revision e209be874602b0a650b442801cbffe529aa7dfff)
-+++ b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dtsi	(date 1655943404649)
-@@ -44,6 +44,15 @@
+index fd3fa82e4c33..1365f2767855 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dtsi
++++ b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dtsi
+@@ -39,6 +39,15 @@ emmc_pwrseq: emmc-pwrseq {
  		reset-gpios = <&gpio BOOT_12 GPIO_ACTIVE_LOW>;
  	};
-
+ 
 +	/* 5V 80x80x10.8mm cooling fan from Hardkernel shop... */
 +	fan0: gpio-fan {
 +		#cooling-cells = <2>;
@@ -34,7 +32,7 @@ diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dtsi b/arch/arm64/
 +
  	leds {
  		compatible = "gpio-leds";
-
---
-2.32.0
+ 
+-- 
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/board-odroidn2-add-gpio-fan-as-cooling-device.patch
+++ b/patch/kernel/archive/meson64-6.0/board-odroidn2-add-gpio-fan-as-cooling-device.patch
@@ -1,32 +1,25 @@
-From f1120f132dbdf2e7f7acf328de55bbdce877d882 Mon Sep 17 00:00:00 2001
-Message-Id: <f1120f132dbdf2e7f7acf328de55bbdce877d882.1627311993.git.stefan@agner.ch>
-In-Reply-To: <c7825747afd8bb975dc918f28e4afe8058a518f3.1627311993.git.stefan@agner.ch>
-References: <c7825747afd8bb975dc918f28e4afe8058a518f3.1627311993.git.stefan@agner.ch>
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Mon, 11 Jan 2021 15:53:55 +0100
-Subject: [PATCH 6/9] arm64: dts: meson: g12b: odroid-n2: add fan as cooling
- device
-MIME-Version: 1.0
-Content-Type: text/plain; charset=UTF-8
-Content-Transfer-Encoding: 8bit
+Subject: arm64: dts: meson: g12b: odroid-n2: add fan as cooling device
 
 Add the GPIO fan as a cooling device for the CPU thermal zone. Since we
 have only full fan speed available with this, set the tripping point to
-30°C.
+30 degrees Celsius.
 
 Signed-off-by: Stefan Agner <stefan@agner.ch>
 ---
- .../dts/amlogic/meson-g12b-odroid-n2.dtsi     | 38 +++++++++++++++++++
+ arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dtsi | 38 ++++++++++
  1 file changed, 38 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dtsi b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dtsi
-index e8a3ede698b5..dd345c6aa4b5 100644
+index 1365f2767855..33323f119406 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dtsi
 +++ b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dtsi
-@@ -388,6 +388,44 @@ &clkc_audio {
+@@ -377,6 +377,44 @@ &clkc_audio {
  	status = "okay";
  };
-
+ 
 +&cpu_thermal {
 +	trips {
 +		cpu_warm: cpu_warm {
@@ -68,6 +61,6 @@ index e8a3ede698b5..dd345c6aa4b5 100644
  &cpu0 {
  	cpu-supply = <&vddcpu_b>;
  	operating-points-v2 = <&cpu_opp_table_0>;
---
-2.32.0
+-- 
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/board-odroidn2-add-spi-flash-enabled-dts.patch
+++ b/patch/kernel/archive/meson64-6.0/board-odroidn2-add-spi-flash-enabled-dts.patch
@@ -1,73 +1,18 @@
-Index: arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-spi.dts
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-spi.dts b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-spi.dts
-new file mode 100644
---- /dev/null	(date 1630421486471)
-+++ b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-spi.dts	(date 1630421486471)
-@@ -0,0 +1,11 @@
-+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
-+
-+/dts-v1/;
-+
-+#include "meson-g12b-odroid-n2.dts"
-+
-+/ {
-+	model = "Hardkernel ODROID-N2 with SPI";
-+};
-+
-+#include "meson-g12b-odroid-n2-enable-spi.dtsi"
-Index: arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-plus-spi.dts
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-plus-spi.dts b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-plus-spi.dts
-new file mode 100644
---- /dev/null	(date 1630421477913)
-+++ b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-plus-spi.dts	(date 1630421477913)
-@@ -0,0 +1,11 @@
-+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
-+
-+/dts-v1/;
-+
-+#include "meson-g12b-odroid-n2-plus.dts"
-+
-+/ {
-+	model = "Hardkernel ODROID-N2Plus with SPI";
-+};
-+
-+#include "meson-g12b-odroid-n2-enable-spi.dtsi"
-Index: arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-enable-spi.dtsi
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
-diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-enable-spi.dtsi b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-enable-spi.dtsi
-new file mode 100644
---- /dev/null	(date 1630421525557)
-+++ b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-enable-spi.dtsi	(date 1630421525557)
-@@ -0,0 +1,13 @@
-+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
-+
-+/*
-+ * Replace emmc_data_8b_pins to emmc_data_4b_pins from sd_emmc_c pinctrl-0, and change bus-width to 4 then spifc can be enabled.
-+ */
-+&sd_emmc_c {
-+	pinctrl-0 = <&emmc_ctrl_pins>, <&emmc_data_4b_pins>, <&emmc_ds_pins>;
-+	bus-width = <4>;
-+};
-+
-+&spifc {
-+	status = "okay";
-+};
-Index: arch/arm64/boot/dts/amlogic/Makefile
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ricardo Pardini <ricardo@pardini.net>
+Date: Thu, 2 Sep 2021 20:44:19 +0200
+Subject: ODROID N2(+): SPI-NOR enable via extra DTBs
+
+Kernel DTS patch to add SPI-flash-enabled DTBs (slower eMMC), produces -spi .dtbs for n2 and n2-plus
+
+Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
+---
+ arch/arm64/boot/dts/amlogic/Makefile                             |  2 ++
+ arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-enable-spi.dtsi | 13 ++++++++++
+ arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-plus-spi.dts    | 11 ++++++++
+ arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-spi.dts         | 11 ++++++++
+ 4 files changed, 37 insertions(+)
+
 diff --git a/arch/arm64/boot/dts/amlogic/Makefile b/arch/arm64/boot/dts/amlogic/Makefile
 index f231280cd808..da3225d31e38 100644
 --- a/arch/arm64/boot/dts/amlogic/Makefile
@@ -82,3 +27,59 @@ index f231280cd808..da3225d31e38 100644
  dtb-$(CONFIG_ARCH_MESON) += meson-g12b-odroid-n2.dtb
  dtb-$(CONFIG_ARCH_MESON) += meson-g12b-radxa-zero2.dtb
  dtb-$(CONFIG_ARCH_MESON) += meson-g12b-s922x-khadas-vim3.dtb
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-enable-spi.dtsi b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-enable-spi.dtsi
+new file mode 100644
+index 000000000000..a6f11e8cdfbe
+--- /dev/null
++++ b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-enable-spi.dtsi
+@@ -0,0 +1,13 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++
++/*
++ * Replace emmc_data_8b_pins to emmc_data_4b_pins from sd_emmc_c pinctrl-0, and change bus-width to 4 then spifc can be enabled.
++ */
++&sd_emmc_c {
++	pinctrl-0 = <&emmc_ctrl_pins>, <&emmc_data_4b_pins>, <&emmc_ds_pins>;
++	bus-width = <4>;
++};
++
++&spifc {
++	status = "okay";
++};
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-plus-spi.dts b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-plus-spi.dts
+new file mode 100644
+index 000000000000..f50f6f39a941
+--- /dev/null
++++ b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-plus-spi.dts
+@@ -0,0 +1,11 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++
++/dts-v1/;
++
++#include "meson-g12b-odroid-n2-plus.dts"
++
++/ {
++	model = "Hardkernel ODROID-N2Plus with SPI";
++};
++
++#include "meson-g12b-odroid-n2-enable-spi.dtsi"
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-spi.dts b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-spi.dts
+new file mode 100644
+index 000000000000..3d85c25d5fc4
+--- /dev/null
++++ b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-spi.dts
+@@ -0,0 +1,11 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++
++/dts-v1/;
++
++#include "meson-g12b-odroid-n2.dts"
++
++/ {
++	model = "Hardkernel ODROID-N2 with SPI";
++};
++
++#include "meson-g12b-odroid-n2-enable-spi.dtsi"
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.0/board-odroidn2plus-Add-missing-CPU-opp.patch
+++ b/patch/kernel/archive/meson64-6.0/board-odroidn2plus-Add-missing-CPU-opp.patch
@@ -1,18 +1,18 @@
-From 712b399ed54f49e0ac7ae92c57ed775604eaaed9 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Igor Pecovnik <igor.pecovnik@gmail.com>
 Date: Wed, 10 Feb 2021 18:07:08 +0100
-Subject: [PATCH] Add missing CPU opp values for clocking g12b / N2+ higher
+Subject: Add missing CPU opp values for clocking g12b / N2+ higher
 
 Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
 ---
- .../arm64/boot/dts/amlogic/meson-g12b-a311d.dtsi | 16 ++++++++++++++++
+ arch/arm64/boot/dts/amlogic/meson-g12b-a311d.dtsi | 16 ++++++++++
  1 file changed, 16 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-a311d.dtsi b/arch/arm64/boot/dts/amlogic/meson-g12b-a311d.dtsi
-index d61f43052..75030d197 100644
+index 8e9ad1e51d66..adc4cca55d7d 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-g12b-a311d.dtsi
 +++ b/arch/arm64/boot/dts/amlogic/meson-g12b-a311d.dtsi
-@@ -65,6 +65,14 @@ opp-1800000000 {
+@@ -45,6 +45,14 @@ opp-1800000000 {
  			opp-hz = /bits/ 64 <1800000000>;
  			opp-microvolt = <1001000>;
  		};
@@ -27,7 +27,7 @@ index d61f43052..75030d197 100644
  	};
  
  	cpub_opp_table_1: opp-table-1 {
-@@ -145,5 +153,13 @@ opp-2208000000 {
+@@ -105,5 +113,13 @@ opp-2208000000 {
                          opp-hz = /bits/ 64 <2208000000>;
                          opp-microvolt = <1011000>;
                  };
@@ -42,5 +42,5 @@ index d61f43052..75030d197 100644
  	};
  };
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/board-radxa-zero-dts-add-support-for-the-usb-c-controller.patch
+++ b/patch/kernel/archive/meson64-6.0/board-radxa-zero-dts-add-support-for-the-usb-c-controller.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Christian Hewitt <christianshewitt@gmail.com>
 Date: Tue, 17 Aug 2021 16:16:43 +0000
-Subject: [PATCH] arm64: dts: meson: radxa-zero: add support for the usb type-c
+Subject: arm64: dts: meson: radxa-zero: add support for the usb type-c
  controller
 
 Radxa Zero uses an FUSB302 type-c controller, so lets enable it.
@@ -19,11 +19,11 @@ Suggested-by: Neil Armstrong <narmstrong@baylibre.com>
 Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
 Signed-off-by: Yuntian Zhang <yt@radxa.com>
 ---
- .../dts/amlogic/meson-g12a-radxa-zero.dts     | 48 +++++++++++++++++++
- 1 file changed, 44 insertions(+)
+ arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts | 48 ++++++++++
+ 1 file changed, 48 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
-index e3bb6df42..5e3dc0134 100644
+index e3bb6df42ff3..28eaaa83a00e 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
 +++ b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
 @@ -60,6 +60,14 @@ sdio_pwrseq: sdio-pwrseq {
@@ -87,7 +87,7 @@ index e3bb6df42..5e3dc0134 100644
  &pwm_AO_cd {
  	pinctrl-0 = <&pwm_ao_d_e_pins>;
  	pinctrl-names = "default";
-@@ -403,3 +439,11 @@ &usb {
+@@ -403,3 +443,11 @@ &usb {
  	status = "okay";
  	dr_mode = "host";
  };
@@ -100,4 +100,5 @@ index e3bb6df42..5e3dc0134 100644
 +	phy-supply = <&typec2_vbus>;
 +};
 -- 
-2.36.1
+Armbian
+

--- a/patch/kernel/archive/meson64-6.0/board-radxa-zero-dts-otg-fix.patch
+++ b/patch/kernel/archive/meson64-6.0/board-radxa-zero-dts-otg-fix.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Stephen <stephen@vamrs.com>
 Date: Thu, 28 Oct 2021 14:26:24 +0800
-Subject: [PATCH] arm64: dts: radxa zero: set dr_mode of usb node to otg
+Subject: arm64: dts: radxa zero: set dr_mode of usb node to otg
 
 This enables dwc2 otg function.
 
@@ -12,15 +12,17 @@ Signed-off-by: Yuntian Zhang <yt@radxa.com>
  1 file changed, 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
-index 9519e36ab7..9095ad9018 100644
+index 28eaaa83a00e..29cfcc045bea 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
 +++ b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
-@@ -426,5 +426,4 @@ &uart_AO {
+@@ -441,7 +441,6 @@ &uart_AO {
  
  &usb {
  	status = "okay";
 -	dr_mode = "host";
  };
+ 
+ &usb2_phy0 {
 -- 
-2.36.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/board-radxa-zero-dts-slow-down-sdio-for-working-wifi.patch
+++ b/patch/kernel/archive/meson64-6.0/board-radxa-zero-dts-slow-down-sdio-for-working-wifi.patch
@@ -1,7 +1,20 @@
-diff -Naur a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
---- a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts	2022-03-20 16:14:17.000000000 -0400
-+++ b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts	2022-03-27 07:44:01.636737819 -0400
-@@ -310,7 +310,7 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yuntian Zhang <yt@radxa.com>
+Date: Mon, 27 Jun 2022 15:06:32 +0800
+Subject: VENDOR: Radxa Zero Wi-Fi fix
+
+Credit: c0rnelius from Armbian
+
+Signed-off-by: Yuntian Zhang <yt@radxa.com>
+---
+ arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
+index 29cfcc045bea..4e7781f87867 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
+@@ -350,7 +350,7 @@ &sd_emmc_a {
  
  	bus-width = <4>;
  	cap-sd-highspeed;
@@ -10,3 +23,6 @@ diff -Naur a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts b/arch/arm64/
  	max-frequency = <100000000>;
  
  	non-removable;
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.0/drv-spi-spidev-remove-warnings.patch
+++ b/patch/kernel/archive/meson64-6.0/drv-spi-spidev-remove-warnings.patch
@@ -1,11 +1,15 @@
-From 2653defc5e22ba86bd1d455eb01fc7edd2958473 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: The-going <48602507+The-going@users.noreply.github.com>
 Date: Wed, 2 Feb 2022 11:56:51 +0300
-Subject: [PATCH 08/50] drv:spi:spidev remove warnings
+Subject: drv:spi:spidev remove warnings
 
+Remove SPIdev warnings
+
+- ca478cc4e563655d99fd3380d3b1217481d6da7e: The-going <48602507+The-going@users.noreply.github.com>: 'Bugfix spidev (#3737)'
+- e7bd9b8f13af9ee054f44a422b2aca19746b9244: Tony <tonymckahan@gmail.com>: 'Add Spidev workarounds and clean patches (WIP) (#3812)'
 ---
- drivers/spi/spidev.c | 7 ++++++-
- 1 file changed, 6 insertions(+), 1 deletion(-)
+ drivers/spi/spidev.c | 2 ++
+ 1 file changed, 2 insertions(+)
 
 diff --git a/drivers/spi/spidev.c b/drivers/spi/spidev.c
 index b2775d82d2d7..3c65d3d74559 100644
@@ -28,4 +32,5 @@ index b2775d82d2d7..3c65d3d74559 100644
  	{ .compatible = "lineartechnology,ltc2488", .data = &spidev_of_check },
  	{ .compatible = "semtech,sx1301", .data = &spidev_of_check },
 -- 
-2.35.3
+Armbian
+

--- a/patch/kernel/archive/meson64-6.0/general-add-Amlogic-Meson-GX-PM-Suspend.patch
+++ b/patch/kernel/archive/meson64-6.0/general-add-Amlogic-Meson-GX-PM-Suspend.patch
@@ -1,7 +1,7 @@
-From e0252efa9190de31a2fc98eed28b273428a3fe36 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Neil Armstrong <narmstrong@baylibre.com>
 Date: Thu, 3 Nov 2016 15:29:23 +0100
-Subject: [PATCH 05/90] HACK: arm64: meson: add Amlogic Meson GX PM Suspend
+Subject: HACK: arm64: meson: add Amlogic Meson GX PM Suspend
 
 The Amlogic Meson GX SoCs uses a non-standard argument to the
 PSCI CPU_SUSPEND call to enter system suspend.
@@ -10,11 +10,10 @@ Implement such call within platform_suspend_ops.
 
 Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>
 ---
- drivers/firmware/meson/Kconfig       |  6 ++
+ drivers/firmware/meson/Kconfig       |  6 +
  drivers/firmware/meson/Makefile      |  1 +
- drivers/firmware/meson/meson_gx_pm.c | 86 ++++++++++++++++++++++++++++
+ drivers/firmware/meson/meson_gx_pm.c | 86 ++++++++++
  3 files changed, 93 insertions(+)
- create mode 100644 drivers/firmware/meson/meson_gx_pm.c
 
 diff --git a/drivers/firmware/meson/Kconfig b/drivers/firmware/meson/Kconfig
 index f2fdd3756648..d3ead92ac61b 100644
@@ -131,5 +130,5 @@ index 000000000000..c104c2e4c77f
 +MODULE_DESCRIPTION("Amlogic Meson GX PM driver");
 +MODULE_LICENSE("GPL v2");
 -- 
-2.35.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/general-add-overlay-compilation-support.patch
+++ b/patch/kernel/archive/meson64-6.0/general-add-overlay-compilation-support.patch
@@ -1,3 +1,15 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Martin Ayotte <martinayotte@yahoo.ca>
+Date: Sat, 11 Feb 2017 20:32:53 +0300
+Subject: add overlay-compilation-support to meson64-dev
+
+- 871bed1a24e21952f7aeb1981c26ad5fc573be9d: Martin Ayotte <martinayotte@yahoo.ca>: 'add overlay-compilation-support to meson64-dev'
+---
+ arch/arm/boot/.gitignore |  2 +
+ scripts/Makefile.dtbinst | 14 +++++-
+ scripts/Makefile.lib     | 22 +++++++++-
+ 3 files changed, 36 insertions(+), 2 deletions(-)
+
 diff --git a/arch/arm/boot/.gitignore b/arch/arm/boot/.gitignore
 index 8c759326baf4..e6ce8f6ad4b1 100644
 --- a/arch/arm/boot/.gitignore
@@ -43,10 +55,10 @@ index 190d781e84f4..6540de71182b 100644
  $(subdirs):
  	$(Q)$(MAKE) $(dtbinst)=$@ dst=$(patsubst $(obj)/%,$(dst)/%,$@)
 diff --git a/scripts/Makefile.lib b/scripts/Makefile.lib
-index d1425778664b..a28448cebd7c 100644
+index 3fb6a99e78c4..53a4121ca38c 100644
 --- a/scripts/Makefile.lib
 +++ b/scripts/Makefile.lib
-@@ -311,6 +311,9 @@ quiet_cmd_gzip = GZIP    $@
+@@ -312,6 +312,9 @@ quiet_cmd_gzip = GZIP    $@
  DTC ?= $(objtree)/scripts/dtc/dtc
  DTC_FLAGS += -Wno-interrupt_provider
  
@@ -56,7 +68,7 @@ index d1425778664b..a28448cebd7c 100644
  # Disable noisy checks by default
  ifeq ($(findstring 1,$(KBUILD_EXTRA_WARN)),)
  DTC_FLAGS += -Wno-unit_address_vs_reg \
-@@ -371,7 +374,7 @@ DT_BINDING_DIR := Documentation/devicetree/bindings
+@@ -372,7 +375,7 @@ DT_BINDING_DIR := Documentation/devicetree/bindings
  DT_TMP_SCHEMA := $(objtree)/$(DT_BINDING_DIR)/processed-schema.json
  
  quiet_cmd_dtb_check =	CHECK   $@
@@ -65,7 +77,7 @@ index d1425778664b..a28448cebd7c 100644
  endif
  
  define rule_dtc
-@@ -385,6 +388,23 @@ $(obj)/%.dtb: $(src)/%.dts $(DTC) $(DT_TMP_SCHEMA) FORCE
+@@ -386,6 +389,23 @@ $(obj)/%.dtb: $(src)/%.dts $(DTC) $(DT_TMP_SCHEMA) FORCE
  $(obj)/%.dtbo: $(src)/%.dts $(DTC) FORCE
  	$(call if_changed_dep,dtc)
  
@@ -89,3 +101,6 @@ index d1425778664b..a28448cebd7c 100644
  dtc-tmp = $(subst $(comma),_,$(dot-target).dts.tmp)
  
  # Bzip2
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.0/general-drm-dw-hdmi-call-hdmi_set_cts_n-after-clock.patch
+++ b/patch/kernel/archive/meson64-6.0/general-drm-dw-hdmi-call-hdmi_set_cts_n-after-clock.patch
@@ -1,18 +1,19 @@
-From 192ff185a6f85f2519cc4b97aa015a836f5a8fbb Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Mon, 9 Jul 2018 21:25:15 +0200
-Subject: [PATCH 10/84] TEMP: drm: dw-hdmi: call hdmi_set_cts_n after clock is
- enabled
+Subject: TEMP: drm: dw-hdmi: call hdmi_set_cts_n after clock is enabled
 
+Unknown patch. Archeology:
+- 99f6bef7de297253a659c22d4a35343a209f98b8: Igor Pecovnik <igorpecovnik@users.noreply.github.com>: 'Attach Meson64 CURRENT to 5.6.y and make DEV = CURRENT at this point. (#1956)'
 ---
  drivers/gpu/drm/bridge/synopsys/dw-hdmi.c | 5 +++++
  1 file changed, 5 insertions(+)
 
 diff --git a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
-index 3e1be9894ed1..733c3dec04de 100644
+index 40d8ca37f5bc..1ceb18f82f6d 100644
 --- a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
 +++ b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
-@@ -781,6 +781,11 @@ static void hdmi_enable_audio_clk(struct dw_hdmi *hdmi, bool enable)
+@@ -782,6 +782,11 @@ static void hdmi_enable_audio_clk(struct dw_hdmi *hdmi, bool enable)
  	else
  		hdmi->mc_clkdis |= HDMI_MC_CLKDIS_AUDCLK_DISABLE;
  	hdmi_writeb(hdmi, hdmi->mc_clkdis, HDMI_MC_CLKDIS);
@@ -25,5 +26,5 @@ index 3e1be9894ed1..733c3dec04de 100644
  
  static u8 *hdmi_audio_get_eld(struct dw_hdmi *hdmi)
 -- 
-2.7.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/general-drm-panfrost-fix-reference-leak.patch
+++ b/patch/kernel/archive/meson64-6.0/general-drm-panfrost-fix-reference-leak.patch
@@ -1,8 +1,7 @@
-From 0eb45601fe5d6b3aa9eb7038bb51df6b5fb9f860 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Qinglang Miao <miaoqinglang@huawei.com>
 Date: Sat, 28 Nov 2020 16:10:04 +0000
-Subject: [PATCH 08/58] FROMLIST(v1): drm/panfrost: fix reference leak in
- panfrost_job_hw_submit
+Subject: drm/panfrost: fix reference leak in panfrost_job_hw_submit
 
 pm_runtime_get_sync will increment pm usage counter even it
 failed. Forgetting to putting operation will result in a
@@ -22,10 +21,10 @@ Signed-off-by: Qinglang Miao <miaoqinglang@huawei.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/gpu/drm/panfrost/panfrost_job.c b/drivers/gpu/drm/panfrost/panfrost_job.c
-index 04e6f6f9b742..d6d5c15184f9 100644
+index 7c4208476fbd..324a83dd7355 100644
 --- a/drivers/gpu/drm/panfrost/panfrost_job.c
 +++ b/drivers/gpu/drm/panfrost/panfrost_job.c
-@@ -157,7 +157,7 @@ static void panfrost_job_hw_submit(struct panfrost_job *job, int js)
+@@ -193,7 +193,7 @@ static void panfrost_job_hw_submit(struct panfrost_job *job, int js)
  
  	panfrost_devfreq_record_busy(&pfdev->pfdevfreq);
  
@@ -35,5 +34,5 @@ index 04e6f6f9b742..d6d5c15184f9 100644
  		return;
  
 -- 
-2.25.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/general-fix-Kodi-sysinfo-CPU-information.patch
+++ b/patch/kernel/archive/meson64-6.0/general-fix-Kodi-sysinfo-CPU-information.patch
@@ -1,7 +1,7 @@
-From 5c9793b46115c2fd774678de7ff5efd7d6ae8d72 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Christian Hewitt <christianshewitt@gmail.com>
 Date: Sat, 13 Apr 2019 05:45:18 +0000
-Subject: [PATCH 03/90] HACK: arm64: fix Kodi sysinfo CPU information
+Subject: HACK: arm64: fix Kodi sysinfo CPU information
 
 This allows the CPU information to show in the Kodi sysinfo screen, e.g.
 
@@ -13,10 +13,10 @@ Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
  1 file changed, 1 insertion(+), 2 deletions(-)
 
 diff --git a/arch/arm64/kernel/cpuinfo.c b/arch/arm64/kernel/cpuinfo.c
-index 591c18a889a5..fdd91a00a285 100644
+index d7702f39b4d3..4b6ac49e34b4 100644
 --- a/arch/arm64/kernel/cpuinfo.c
 +++ b/arch/arm64/kernel/cpuinfo.c
-@@ -151,8 +151,7 @@ static int c_show(struct seq_file *m, void *v)
+@@ -169,8 +169,7 @@ static int c_show(struct seq_file *m, void *v)
  		 * "processor".  Give glibc what it expects.
  		 */
  		seq_printf(m, "processor\t: %d\n", i);
@@ -27,5 +27,5 @@ index 591c18a889a5..fdd91a00a285 100644
  
  		seq_printf(m, "BogoMIPS\t: %lu.%02lu\n",
 -- 
-2.35.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/general-gpu-drm-add-new-display-resolution-2560x1440.patch
+++ b/patch/kernel/archive/meson64-6.0/general-gpu-drm-add-new-display-resolution-2560x1440.patch
@@ -1,13 +1,13 @@
-From 9175674ca107a9090936d7373927567f41d1ae7e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Dongjin Kim <tobetter@gmail.com>
 Date: Thu, 10 Sep 2020 11:01:33 +0900
-Subject: [PATCH] ODROID-COMMON: gpu/drm: add new display resolution 2560x1440
+Subject: ODROID-COMMON: gpu/drm: add new display resolution 2560x1440
 
 Signed-off-by: Joy Cho <joy.cho@hardkernel.com>
 Signed-off-by: Dongjin Kim <tobetter@gmail.com>
 ---
- drivers/gpu/drm/meson/meson_vclk.c | 18 ++++++++++++++++++
- drivers/gpu/drm/meson/meson_venc.c |  5 +++--
+ drivers/gpu/drm/meson/meson_vclk.c | 18 ++++++++++
+ drivers/gpu/drm/meson/meson_venc.c |  5 +--
  2 files changed, 21 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/gpu/drm/meson/meson_vclk.c b/drivers/gpu/drm/meson/meson_vclk.c
@@ -72,5 +72,5 @@ index 3c55ed003359..559ab3b5e212 100644
  
  	return MODE_OK;
 -- 
-2.35.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/general-hdmi-codec-reorder-channel-allocation-list.patch
+++ b/patch/kernel/archive/meson64-6.0/general-hdmi-codec-reorder-channel-allocation-list.patch
@@ -1,7 +1,7 @@
-From dd29d3d05631c4afdab56fb696424565a4afefba Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sun, 23 Dec 2018 02:24:38 +0100
-Subject: [PATCH 53/90] WIP: ASoC: hdmi-codec: reorder channel allocation list
+Subject: WIP: ASoC: hdmi-codec: reorder channel allocation list
 
 Wrong channel allocation is selected by hdmi_codec_get_ch_alloc_table_idx().
 
@@ -20,11 +20,11 @@ most specific speaker mask at the top.
 
 Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
 ---
- sound/soc/codecs/hdmi-codec.c | 140 +++++++++++++++++++---------------
+ sound/soc/codecs/hdmi-codec.c | 140 +++++-----
  1 file changed, 77 insertions(+), 63 deletions(-)
 
 diff --git a/sound/soc/codecs/hdmi-codec.c b/sound/soc/codecs/hdmi-codec.c
-index b07607a9ecea..a12015471ea2 100644
+index 5679102de91f..36825921cefa 100644
 --- a/sound/soc/codecs/hdmi-codec.c
 +++ b/sound/soc/codecs/hdmi-codec.c
 @@ -188,84 +188,97 @@ static const struct snd_pcm_chmap_elem hdmi_codec_8ch_chmaps[] = {
@@ -198,5 +198,5 @@ index b07607a9ecea..a12015471ea2 100644
  	for (i = 0; i < info->max_channels; i++) {
  		if (hcp->chmap_idx == HDMI_CODEC_CHMAP_IDX_UNKNOWN)
 -- 
-2.35.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/general-hwmon-pwm-fan-fix-to-add-pwm1_enable-t.patch
+++ b/patch/kernel/archive/meson64-6.0/general-hwmon-pwm-fan-fix-to-add-pwm1_enable-t.patch
@@ -1,16 +1,16 @@
-From 9f34f631a394fb13fbe5c4fca5e9ab3792d4c7d6 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Dongjin Kim <tobetter@gmail.com>
 Date: Wed, 30 Jun 2021 11:38:33 +0900
-Subject: [PATCH] ODROID-COMMON: hwmon: (pwm-fan): fix to add 'pwm1_enable' to
- set PWM fan mode
+Subject: ODROID-COMMON: hwmon: (pwm-fan): fix to add 'pwm1_enable' to set PWM
+ fan mode
 
 Change-Id: If0562f497703b8660206dad80d7933902bbf53e4
 ---
- drivers/hwmon/pwm-fan.c | 67 +++++++++++++++++++++++++++++++++++++----
+ drivers/hwmon/pwm-fan.c | 67 +++++++++-
  1 file changed, 61 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/hwmon/pwm-fan.c b/drivers/hwmon/pwm-fan.c
-index f12b9a28a232..383a24316985 100644
+index 6c08551d8d14..e52e735c0ddf 100644
 --- a/drivers/hwmon/pwm-fan.c
 +++ b/drivers/hwmon/pwm-fan.c
 @@ -8,6 +8,7 @@
@@ -29,7 +29,7 @@ index f12b9a28a232..383a24316985 100644
  
  	struct hwmon_chip_info info;
  	struct hwmon_channel_info fan_channel;
-@@ -99,6 +101,10 @@ static int  __set_pwm(struct pwm_fan_ctx *ctx, unsigned long pwm)
+@@ -89,6 +91,10 @@ static int  __set_pwm(struct pwm_fan_ctx *ctx, unsigned long pwm)
  	struct pwm_state *state = &ctx->pwm_state;
  
  	mutex_lock(&ctx->lock);
@@ -40,7 +40,7 @@ index f12b9a28a232..383a24316985 100644
  	if (ctx->pwm_value == pwm)
  		goto exit_set_pwm_err;
  
-@@ -183,6 +189,51 @@ static const struct hwmon_ops pwm_fan_hwmon_ops = {
+@@ -173,6 +179,51 @@ static const struct hwmon_ops pwm_fan_hwmon_ops = {
  	.write = pwm_fan_write,
  };
  
@@ -92,7 +92,7 @@ index f12b9a28a232..383a24316985 100644
  /* thermal cooling device callbacks */
  static int pwm_fan_get_max_state(struct thermal_cooling_device *cdev,
  				 unsigned long *state)
-@@ -214,7 +265,7 @@ static int
+@@ -204,7 +255,7 @@ static int
  pwm_fan_set_cur_state(struct thermal_cooling_device *cdev, unsigned long state)
  {
  	struct pwm_fan_ctx *ctx = cdev->devdata;
@@ -101,7 +101,7 @@ index f12b9a28a232..383a24316985 100644
  
  	if (!ctx || (state > ctx->pwm_fan_max_state))
  		return -EINVAL;
-@@ -222,10 +273,12 @@ pwm_fan_set_cur_state(struct thermal_cooling_device *cdev, unsigned long state)
+@@ -212,10 +263,12 @@ pwm_fan_set_cur_state(struct thermal_cooling_device *cdev, unsigned long state)
  	if (state == ctx->pwm_fan_state)
  		return 0;
  
@@ -118,7 +118,7 @@ index f12b9a28a232..383a24316985 100644
  	}
  
  	ctx->pwm_fan_state = state;
-@@ -316,6 +369,8 @@ static int pwm_fan_probe(struct platform_device *pdev)
+@@ -306,6 +359,8 @@ static int pwm_fan_probe(struct platform_device *pdev)
  	if (IS_ERR(ctx->pwm))
  		return dev_err_probe(dev, PTR_ERR(ctx->pwm), "Could not get PWM\n");
  
@@ -127,7 +127,7 @@ index f12b9a28a232..383a24316985 100644
  	platform_set_drvdata(pdev, ctx);
  
  	ctx->reg_en = devm_regulator_get_optional(dev, "fan");
-@@ -434,7 +489,7 @@ static int pwm_fan_probe(struct platform_device *pdev)
+@@ -424,7 +479,7 @@ static int pwm_fan_probe(struct platform_device *pdev)
  	ctx->info.info = channels;
  
  	hwmon = devm_hwmon_device_register_with_info(dev, "pwmfan",
@@ -137,5 +137,5 @@ index f12b9a28a232..383a24316985 100644
  		dev_err(dev, "Failed to register hwmon device\n");
  		return PTR_ERR(hwmon);
 -- 
-2.35.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/general-input-touchscreen-Add-D-WAV-Multitouch.patch
+++ b/patch/kernel/archive/meson64-6.0/general-input-touchscreen-Add-D-WAV-Multitouch.patch
@@ -1,8 +1,7 @@
-From b615e1a2ac4cc58734db101cd209aed0a11d2343 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Hyeonki Hong <hhk7734@gmail.com>
 Date: Thu, 5 Mar 2020 19:01:43 +0900
-Subject: [PATCH] ODROID-COMMON: input/touchscreen: Add D-WAV Multitouch
- driver.
+Subject: ODROID-COMMON: input/touchscreen: Add D-WAV Multitouch driver.
 
 Change-Id: Ia1c8c29d3f69c6ba5d630279c4cc98119b68ab71
 ---
@@ -10,15 +9,14 @@ Change-Id: Ia1c8c29d3f69c6ba5d630279c4cc98119b68ab71
  drivers/hid/hid-quirks.c                |   3 +
  drivers/input/touchscreen/Kconfig       |  10 +
  drivers/input/touchscreen/Makefile      |   1 +
- drivers/input/touchscreen/dwav-usb-mt.c | 554 ++++++++++++++++++++++++
+ drivers/input/touchscreen/dwav-usb-mt.c | 554 ++++++++++
  5 files changed, 574 insertions(+)
- create mode 100644 drivers/input/touchscreen/dwav-usb-mt.c
 
 diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
-index a5a5a64c7abc..39c719033cd0 100644
+index 256795ed6247..81c98ae632c5 100644
 --- a/drivers/hid/hid-ids.h
 +++ b/drivers/hid/hid-ids.h
-@@ -1372,4 +1372,10 @@
+@@ -1407,4 +1407,10 @@
  #define USB_VENDOR_ID_SIGNOTEC			0x2133
  #define USB_DEVICE_ID_SIGNOTEC_VIEWSONIC_PD1011	0x0018
  
@@ -30,10 +28,10 @@ index a5a5a64c7abc..39c719033cd0 100644
 +
  #endif
 diff --git a/drivers/hid/hid-quirks.c b/drivers/hid/hid-quirks.c
-index ee7e504e7279..4d876faea391 100644
+index 50e1c717fc0a..b2f1a4a7367d 100644
 --- a/drivers/hid/hid-quirks.c
 +++ b/drivers/hid/hid-quirks.c
-@@ -863,6 +863,9 @@ static const struct hid_device_id hid_ignore_list[] = {
+@@ -876,6 +876,9 @@ static const struct hid_device_id hid_ignore_list[] = {
  	{ HID_USB_DEVICE(USB_VENDOR_ID_SYNAPTICS, USB_DEVICE_ID_SYNAPTICS_DPAD) },
  #endif
  	{ HID_USB_DEVICE(USB_VENDOR_ID_YEALINK, USB_DEVICE_ID_YEALINK_P1K_P4K_B2K) },
@@ -44,10 +42,10 @@ index ee7e504e7279..4d876faea391 100644
  };
  
 diff --git a/drivers/input/touchscreen/Kconfig b/drivers/input/touchscreen/Kconfig
-index 2f6adfb7b938..cec65479dc79 100644
+index 2d70c945b20a..b4043c6b68e7 100644
 --- a/drivers/input/touchscreen/Kconfig
 +++ b/drivers/input/touchscreen/Kconfig
-@@ -1367,4 +1367,14 @@ config TOUCHSCREEN_ZINITIX
+@@ -1379,4 +1379,14 @@ config TOUCHSCREEN_ZINITIX
  	  To compile this driver as a module, choose M here: the
  	  module will be called zinitix.
  
@@ -63,10 +61,10 @@ index 2f6adfb7b938..cec65479dc79 100644
 +
  endif
 diff --git a/drivers/input/touchscreen/Makefile b/drivers/input/touchscreen/Makefile
-index 39a8127cf6a5..f8bede5caafd 100644
+index 557f84fd2075..68feafadf7fe 100644
 --- a/drivers/input/touchscreen/Makefile
 +++ b/drivers/input/touchscreen/Makefile
-@@ -115,3 +115,4 @@ obj-$(CONFIG_TOUCHSCREEN_ROHM_BU21023)	+= rohm_bu21023.o
+@@ -116,3 +116,4 @@ obj-$(CONFIG_TOUCHSCREEN_ROHM_BU21023)	+= rohm_bu21023.o
  obj-$(CONFIG_TOUCHSCREEN_RASPBERRYPI_FW)	+= raspberrypi-ts.o
  obj-$(CONFIG_TOUCHSCREEN_IQS5XX)	+= iqs5xx.o
  obj-$(CONFIG_TOUCHSCREEN_ZINITIX)	+= zinitix.o
@@ -633,5 +631,5 @@ index 000000000000..7ec8b6dd15fd
 +MODULE_ALIAS("dwav_usb_mt");
 \ No newline at end of file
 -- 
-2.35.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/general-kernel-odroidn2-current.patch
+++ b/patch/kernel/archive/meson64-6.0/general-kernel-odroidn2-current.patch
@@ -1,3 +1,14 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+Date: Tue, 19 Nov 2019 23:25:39 +0100
+Subject: hack builddeb for meson64
+
+Unknown patch. Archeology:
+- ff4c1488dab1e07d35923b6f8e33c992d9ca439f: Igor Pecovnik <igorpecovnik@users.noreply.github.com>: 'Move to 5.4.y (#1686)'
+---
+ scripts/package/builddeb | 5 +++++
+ 1 file changed, 5 insertions(+)
+
 diff --git a/scripts/package/builddeb b/scripts/package/builddeb
 index 67cd420dcf89..e445d84b6cbc 100755
 --- a/scripts/package/builddeb
@@ -14,3 +25,6 @@ index 67cd420dcf89..e445d84b6cbc 100755
  create_package "$packagename" "$tmpdir"
  
  if [ -n "$BUILD_DEBUG" ] ; then
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.0/general-media-cec-silence-CEC-timeout-message-HACK.patch
+++ b/patch/kernel/archive/meson64-6.0/general-media-cec-silence-CEC-timeout-message-HACK.patch
@@ -1,7 +1,7 @@
-From 03bfb3f6a703d7671508b698c5a552d0a0e0197b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Christian Hewitt <christianshewitt@gmail.com>
 Date: Tue, 7 Jan 2020 07:12:47 +0000
-Subject: [PATCH 055/101] HACK: media: cec: silence CEC timeout message
+Subject: HACK: media: cec: silence CEC timeout message
 
 If testing with an AVR that does not pass-through CEC state the system
 log fills with timeout messages. Silence this to stop the log rotation
@@ -19,7 +19,7 @@ Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/media/cec/core/cec-adap.c b/drivers/media/cec/core/cec-adap.c
-index 8bf91b5a7d0e..74a33366cc26 100644
+index 41a79293ee02..777ed629aeb2 100644
 --- a/drivers/media/cec/core/cec-adap.c
 +++ b/drivers/media/cec/core/cec-adap.c
 @@ -501,9 +501,9 @@ int cec_thread_func(void *_adap)
@@ -36,5 +36,5 @@ index 8bf91b5a7d0e..74a33366cc26 100644
  				cec_data_cancel(adap->transmitting,
  						CEC_TX_STATUS_TIMEOUT, 0);
 -- 
-2.17.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/general-memory-marked-nomap.patch
+++ b/patch/kernel/archive/meson64-6.0/general-memory-marked-nomap.patch
@@ -1,7 +1,7 @@
-From 4d11a956070513a173dd9fd0d6e981918a6331e4 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Stefan Agner <stefan@agner.ch>
 Date: Wed, 15 Sep 2021 05:00:45 +0000
-Subject: [PATCH 11/90] HACK: of: partial revert of fdt.c changes
+Subject: HACK: of: partial revert of fdt.c changes
 
 This resolves reports similar to the below which are present in dmesg
 since Linux 5.10; which are also causing crashes in some distros:
@@ -14,11 +14,11 @@ Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
  1 file changed, 9 deletions(-)
 
 diff --git a/drivers/of/fdt.c b/drivers/of/fdt.c
-index ec315b060cd5..15e9c0c2a2c6 100644
+index 1c573e7a60bc..f9188a76500d 100644
 --- a/drivers/of/fdt.c
 +++ b/drivers/of/fdt.c
-@@ -481,15 +481,6 @@ static int __init early_init_dt_reserve_memory_arch(phys_addr_t base,
- 					phys_addr_t size, bool nomap)
+@@ -481,15 +481,6 @@ static int __init early_init_dt_reserve_memory(phys_addr_t base,
+ 					       phys_addr_t size, bool nomap)
  {
  	if (nomap) {
 -		/*
@@ -34,5 +34,5 @@ index ec315b060cd5..15e9c0c2a2c6 100644
  	}
  	return memblock_reserve(base, size);
 -- 
-2.35.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/general-meson-aiu-Fix-HDMI-codec-control-selection.patch
+++ b/patch/kernel/archive/meson64-6.0/general-meson-aiu-Fix-HDMI-codec-control-selection.patch
@@ -1,8 +1,7 @@
-From 712edc341073c350a11658186609eafd292dbe8a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
 Date: Sun, 3 Oct 2021 05:35:48 +0000
-Subject: [PATCH 27/90] FROMLIST(v1): ASoC: meson: aiu: Fix HDMI codec control
- selection
+Subject: ASoC: meson: aiu: Fix HDMI codec control selection
 
 The HDMI controllers on Amlogic Meson SoCs which use the AIU
 audio-controller have two different audio format inputs:
@@ -55,12 +54,12 @@ is not changed on purpose to not break old configurations.
 Fixes: b82b734c0e9a7 ("ASoC: meson: aiu: add hdmi codec control support")
 Signed-off-by: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
 ---
- sound/soc/meson/aiu-codec-ctrl.c  | 108 ++++++++++++++++++++++--------
- sound/soc/meson/aiu-encoder-i2s.c |   6 --
+ sound/soc/meson/aiu-codec-ctrl.c  | 108 +++++++---
+ sound/soc/meson/aiu-encoder-i2s.c |   6 -
  2 files changed, 80 insertions(+), 34 deletions(-)
 
 diff --git a/sound/soc/meson/aiu-codec-ctrl.c b/sound/soc/meson/aiu-codec-ctrl.c
-index c3ea733fce91..2b8575491aeb 100644
+index 84c10956c241..c1aa13f4d65b 100644
 --- a/sound/soc/meson/aiu-codec-ctrl.c
 +++ b/sound/soc/meson/aiu-codec-ctrl.c
 @@ -12,14 +12,60 @@
@@ -205,7 +204,7 @@ index c3ea733fce91..2b8575491aeb 100644
  
  static const struct snd_soc_dapm_widget aiu_hdmi_ctrl_widgets[] = {
 diff --git a/sound/soc/meson/aiu-encoder-i2s.c b/sound/soc/meson/aiu-encoder-i2s.c
-index 67729de41a73..88637deb2d7a 100644
+index a0dd914c8ed1..21916034a46d 100644
 --- a/sound/soc/meson/aiu-encoder-i2s.c
 +++ b/sound/soc/meson/aiu-encoder-i2s.c
 @@ -23,7 +23,6 @@
@@ -229,5 +228,5 @@ index 67729de41a73..88637deb2d7a 100644
  }
  
 -- 
-2.35.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/general-meson-gx-mmc-fix-deferred-probing.patch
+++ b/patch/kernel/archive/meson64-6.0/general-meson-gx-mmc-fix-deferred-probing.patch
@@ -1,7 +1,7 @@
-From b83c8168c58ccb96f92a4b6ecf1b8b7483fcced3 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Sergey Shtylyov <s.shtylyov@omp.ru>
 Date: Fri, 24 Dec 2021 06:09:57 +0000
-Subject: [PATCH 38/90] FROMLIST(v1): mmc: meson-gx: fix deferred probing
+Subject: mmc: meson-gx: fix deferred probing
 
 The driver overrides the error codes and IRQ0 returned by platform_get_irq()
 to -EINVAL, so if it returns -EPROBE_DEFER, the driver will fail the probe
@@ -16,10 +16,10 @@ Signed-off-by: Sergey Shtylyov <s.shtylyov@omp.ru>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/mmc/host/meson-gx-mmc.c b/drivers/mmc/host/meson-gx-mmc.c
-index 58ab9d90bc8b..1a11a4bf4d4f 100644
+index fc462995cf94..a2aacbffc3bf 100644
 --- a/drivers/mmc/host/meson-gx-mmc.c
 +++ b/drivers/mmc/host/meson-gx-mmc.c
-@@ -1183,8 +1183,8 @@ static int meson_mmc_probe(struct platform_device *pdev)
+@@ -1185,8 +1185,8 @@ static int meson_mmc_probe(struct platform_device *pdev)
  	}
  
  	host->irq = platform_get_irq(pdev, 0);
@@ -31,5 +31,5 @@ index 58ab9d90bc8b..1a11a4bf4d4f 100644
  	}
  
 -- 
-2.35.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/general-meson-mmc-1-arm64-amlogic-mmc-meson-gx-Add-core-tx-rx-eMMC-SD-SD.patch
+++ b/patch/kernel/archive/meson64-6.0/general-meson-mmc-1-arm64-amlogic-mmc-meson-gx-Add-core-tx-rx-eMMC-SD-SD.patch
@@ -1,8 +1,8 @@
-From 3774482f10291d3cbd6b22514f976edc8732759e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Vyacheslav Bocharov <adeep@lexina.in>
 Date: Mon, 7 Nov 2022 16:19:08 +0300
-Subject: [PATCH 1/3] arm64: amlogic: mmc: meson-gx: Add core, tx, rx
- eMMC/SD/SDIO phase clock settings from devicetree data
+Subject: arm64: amlogic: mmc: meson-gx: Add core, tx, rx eMMC/SD/SDIO phase
+ clock settings from devicetree data
 
 The mmc driver has the same phase values for all meson platforms. However,
 some platforms (and even some boards) require different values. This patch
@@ -11,13 +11,12 @@ device-tree file.
 
 Signed-off-by: Vyacheslav Bocharov <adeep@lexina.in>
 ---
- drivers/mmc/host/meson-gx-mmc.c        | 19 +++++++++-----
- include/dt-bindings/mmc/meson-gx-mmc.h | 35 ++++++++++++++++++++++++++
+ drivers/mmc/host/meson-gx-mmc.c        | 19 +++--
+ include/dt-bindings/mmc/meson-gx-mmc.h | 35 ++++++++++
  2 files changed, 48 insertions(+), 6 deletions(-)
- create mode 100644 include/dt-bindings/mmc/meson-gx-mmc.h
 
 diff --git a/drivers/mmc/host/meson-gx-mmc.c b/drivers/mmc/host/meson-gx-mmc.c
-index fc462995cf94..4fb09cfaa60f 100644
+index a2aacbffc3bf..cce759ed9e15 100644
 --- a/drivers/mmc/host/meson-gx-mmc.c
 +++ b/drivers/mmc/host/meson-gx-mmc.c
 @@ -27,6 +27,7 @@
@@ -105,5 +104,5 @@ index 000000000000..cfc4a9d75b2b
 +
 +#endif
 -- 
-2.30.2
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/general-meson-mmc-2-arm64-amlogic-dts-meson-update-meson-axg-device-tree.patch
+++ b/patch/kernel/archive/meson64-6.0/general-meson-mmc-2-arm64-amlogic-dts-meson-update-meson-axg-device-tree.patch
@@ -1,8 +1,8 @@
-From facd1f172280739e8342fa6418755f62c76a01ce Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Vyacheslav Bocharov <adeep@lexina.in>
 Date: Mon, 7 Nov 2022 16:19:08 +0300
-Subject: [PATCH 2/3] arm64: amlogic: dts: meson: update meson-axg device-tree
- for new core, tx, rx phase clock settings.
+Subject: arm64: amlogic: dts: meson: update meson-axg device-tree for new
+ core, tx, rx phase clock settings.
 
 Use phase 270 for core MMC clock on axg meson boards.
 
@@ -40,5 +40,5 @@ index 04f797b5a012..0af4784d84c7 100644
  
  			usb2_phy1: phy@9020 {
 -- 
-2.30.2
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/general-meson-mmc-3-arm64-dts-docs-Update-mmc-meson-gx-documentation-for.patch
+++ b/patch/kernel/archive/meson64-6.0/general-meson-mmc-3-arm64-dts-docs-Update-mmc-meson-gx-documentation-for.patch
@@ -1,8 +1,8 @@
-From 74f23d8b8f7e1284689597961dde9a7d25774d2e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Vyacheslav Bocharov <adeep@lexina.in>
 Date: Thu, 10 Nov 2022 14:52:47 +0300
-Subject: [PATCH 3/3] arm64: dts: docs: Update mmc meson-gx documentation for
- new config option amlogic,mmc-phase
+Subject: arm64: dts: docs: Update mmc meson-gx documentation for new config
+ option amlogic,mmc-phase
 
 - amlogic,mmc-phases: 3-element array of clock phases for core, tx, rx
 clock with values:
@@ -41,5 +41,5 @@ index ccc5358db131..98c89c5b3455 100644
 +		amlogic,mmc-phases = <CLK_PHASE_180 CLK_PHASE_0 CLK_PHASE_0>;
  	};
 -- 
-2.30.2
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/general-meson-vdec-add-HEVC-decode-codec.patch
+++ b/patch/kernel/archive/meson64-6.0/general-meson-vdec-add-HEVC-decode-codec.patch
@@ -1,18 +1,17 @@
-From 478ef90d4bb38e6c5ae11c4abd6142fc7336c746 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: benjamin545 <benjamin545@gmail.com>
 Date: Thu, 15 Jul 2021 17:08:42 -0400
-Subject: [PATCH 64/90] WIP: drivers: meson: vdec: add HEVC decode codec
+Subject: WIP: drivers: meson: vdec: add HEVC decode codec
 
+Unknown patch. From LibreELEC?
 ---
- drivers/staging/media/meson/vdec/Makefile     |    2 +-
- drivers/staging/media/meson/vdec/codec_hevc.c | 1440 +++++++++++++++++
- drivers/staging/media/meson/vdec/codec_hevc.h |   13 +
- drivers/staging/media/meson/vdec/esparser.c   |    2 +-
- drivers/staging/media/meson/vdec/hevc_regs.h  |    1 +
- .../staging/media/meson/vdec/vdec_platform.c  |   49 +
+ drivers/staging/media/meson/vdec/Makefile        |    2 +-
+ drivers/staging/media/meson/vdec/codec_hevc.c    | 1440 ++++++++++
+ drivers/staging/media/meson/vdec/codec_hevc.h    |   13 +
+ drivers/staging/media/meson/vdec/esparser.c      |    2 +-
+ drivers/staging/media/meson/vdec/hevc_regs.h     |    1 +
+ drivers/staging/media/meson/vdec/vdec_platform.c |   49 +
  6 files changed, 1505 insertions(+), 2 deletions(-)
- create mode 100644 drivers/staging/media/meson/vdec/codec_hevc.c
- create mode 100644 drivers/staging/media/meson/vdec/codec_hevc.h
 
 diff --git a/drivers/staging/media/meson/vdec/Makefile b/drivers/staging/media/meson/vdec/Makefile
 index 6e726af84ac9..16f848e456b9 100644
@@ -1492,7 +1491,7 @@ index 000000000000..f2f9b2464df1
 +
 +#endif
 diff --git a/drivers/staging/media/meson/vdec/esparser.c b/drivers/staging/media/meson/vdec/esparser.c
-index 610a92b9f6f2..9b6034936d32 100644
+index 86ccc8937afc..6cea1839dcca 100644
 --- a/drivers/staging/media/meson/vdec/esparser.c
 +++ b/drivers/staging/media/meson/vdec/esparser.c
 @@ -309,7 +309,7 @@ esparser_queue(struct amvdec_session *sess, struct vb2_v4l2_buffer *vbuf)
@@ -1605,5 +1604,5 @@ index 88c9d72e1c83..8592cb3aaea9 100644
  		.pixfmt = V4L2_PIX_FMT_H264,
  		.min_buffers = 2,
 -- 
-2.35.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/general-meson-vdec-add-handling-to-HEVC-decoder-.patch
+++ b/patch/kernel/archive/meson64-6.0/general-meson-vdec-add-handling-to-HEVC-decoder-.patch
@@ -1,8 +1,8 @@
-From a9f750c672c4c1238cccd1d8d76a138a5602d035 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: benjamin545 <benjamin545@gmail.com>
 Date: Mon, 2 Aug 2021 15:18:40 -0400
-Subject: [PATCH 65/90] WIP: drivers: meson: vdec: add handling to HEVC decoder
- to show frames when ready
+Subject: WIP: drivers: meson: vdec: add handling to HEVC decoder to show
+ frames when ready
 
 ..rather than when no longer referenced
 
@@ -11,7 +11,7 @@ this would cause a backup of frames that were ready to render but held up by one
 frames that were still referenced. The decoded picture buffer would fill up and stall
 playback as no new frames could be placed in the decoded picture buffer.
 ---
- drivers/staging/media/meson/vdec/codec_hevc.c | 52 ++++++++++++-------
+ drivers/staging/media/meson/vdec/codec_hevc.c | 52 ++++++----
  1 file changed, 34 insertions(+), 18 deletions(-)
 
 diff --git a/drivers/staging/media/meson/vdec/codec_hevc.c b/drivers/staging/media/meson/vdec/codec_hevc.c
@@ -153,5 +153,5 @@ index 3a6fd04a2d33..01218efde99b 100644
  
  static void codec_hevc_resume(struct amvdec_session *sess)
 -- 
-2.35.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/general-meson-vdec-check-if-parser-has-really-parser.patch
+++ b/patch/kernel/archive/meson64-6.0/general-meson-vdec-check-if-parser-has-really-parser.patch
@@ -1,16 +1,16 @@
-From cb0c20e84a934c66961ace27f340cd7c98188dbe Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Neil Armstrong <narmstrong@baylibre.com>
 Date: Mon, 22 Nov 2021 09:15:21 +0000
-Subject: [PATCH 67/90] WIP: drivers: meson: vdec: check if parser has really
- parser before marking input buffer as error
+Subject: WIP: drivers: meson: vdec: check if parser has really parser before
+ marking input buffer as error
 
 Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>
 ---
- drivers/staging/media/meson/vdec/esparser.c | 14 ++++++++++----
+ drivers/staging/media/meson/vdec/esparser.c | 14 +++++++---
  1 file changed, 10 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/staging/media/meson/vdec/esparser.c b/drivers/staging/media/meson/vdec/esparser.c
-index 9b6034936d32..bb9480f0a70c 100644
+index 6cea1839dcca..4b9ef97639c0 100644
 --- a/drivers/staging/media/meson/vdec/esparser.c
 +++ b/drivers/staging/media/meson/vdec/esparser.c
 @@ -300,6 +300,7 @@ esparser_queue(struct amvdec_session *sess, struct vb2_v4l2_buffer *vbuf)
@@ -21,7 +21,7 @@ index 9b6034936d32..bb9480f0a70c 100644
  
  	/*
  	 * When max ref frame is held by VP9, this should be -= 3 to prevent a
-@@ -349,15 +350,20 @@ esparser_queue(struct amvdec_session *sess, struct vb2_v4l2_buffer *vbuf)
+@@ -354,15 +355,20 @@ esparser_queue(struct amvdec_session *sess, struct vb2_v4l2_buffer *vbuf)
  	}
  
  	pad_size = esparser_pad_start_code(core, vb, payload_size);
@@ -47,5 +47,5 @@ index 9b6034936d32..bb9480f0a70c 100644
  
  	atomic_inc(&sess->esparser_queued_bufs);
 -- 
-2.35.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/general-meson-vdec-improve-mmu-and-fbc-handling-.patch
+++ b/patch/kernel/archive/meson64-6.0/general-meson-vdec-improve-mmu-and-fbc-handling-.patch
@@ -1,18 +1,19 @@
-From df7d1adad3f60c8cb3f33235b6301093801b7b47 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: benjamin545 <benjamin545@gmail.com>
 Date: Thu, 15 Jul 2021 16:32:39 -0400
-Subject: [PATCH 63/90] WIP: drivers: meson: vdec: improve mmu and fbc handling
- and add 10 bit handling
+Subject: WIP: drivers: meson: vdec: improve mmu and fbc handling and add 10
+ bit handling
 
+Unknown patch. From LibreELEC?
 ---
- drivers/staging/media/meson/vdec/codec_h264.c |   3 +-
- .../media/meson/vdec/codec_hevc_common.c      | 164 +++++++++++-------
- .../media/meson/vdec/codec_hevc_common.h      |   3 +-
- drivers/staging/media/meson/vdec/codec_vp9.c  |  36 ++--
- drivers/staging/media/meson/vdec/esparser.c   |   1 +
- drivers/staging/media/meson/vdec/vdec.h       |   1 +
- .../staging/media/meson/vdec/vdec_helpers.c   |  46 +++--
- .../staging/media/meson/vdec/vdec_helpers.h   |  10 +-
+ drivers/staging/media/meson/vdec/codec_h264.c        |   3 +-
+ drivers/staging/media/meson/vdec/codec_hevc_common.c | 164 ++++++----
+ drivers/staging/media/meson/vdec/codec_hevc_common.h |   3 +-
+ drivers/staging/media/meson/vdec/codec_vp9.c         |  36 +-
+ drivers/staging/media/meson/vdec/esparser.c          |   1 +
+ drivers/staging/media/meson/vdec/vdec.h              |   1 +
+ drivers/staging/media/meson/vdec/vdec_helpers.c      |  46 ++-
+ drivers/staging/media/meson/vdec/vdec_helpers.h      |  10 +-
  8 files changed, 163 insertions(+), 101 deletions(-)
 
 diff --git a/drivers/staging/media/meson/vdec/codec_h264.c b/drivers/staging/media/meson/vdec/codec_h264.c
@@ -429,10 +430,10 @@ index 897f5d7a6aad..bfc312ec2a56 100644
  		/* No frame is actually processed */
  		vp9->cur_frame = NULL;
 diff --git a/drivers/staging/media/meson/vdec/esparser.c b/drivers/staging/media/meson/vdec/esparser.c
-index e18334e57fc0..610a92b9f6f2 100644
+index 4b9ef97639c0..98f1efa4ad31 100644
 --- a/drivers/staging/media/meson/vdec/esparser.c
 +++ b/drivers/staging/media/meson/vdec/esparser.c
-@@ -319,6 +319,7 @@ esparser_queue(struct amvdec_session *sess, struct vb2_v4l2_buffer *vbuf)
+@@ -321,6 +321,7 @@ esparser_queue(struct amvdec_session *sess, struct vb2_v4l2_buffer *vbuf)
  		if (esparser_vififo_get_free_space(sess) < payload_size ||
  		    atomic_read(&sess->esparser_queued_bufs) >= num_dst_bufs)
  			return -EAGAIN;
@@ -453,7 +454,7 @@ index 0906b8fb5cc6..a48170fe4cff 100644
  	u8 quantization;
  	u8 xfer_func;
 diff --git a/drivers/staging/media/meson/vdec/vdec_helpers.c b/drivers/staging/media/meson/vdec/vdec_helpers.c
-index 203d7afa085d..23a69c51c634 100644
+index 7d2a75653250..d684057509bf 100644
 --- a/drivers/staging/media/meson/vdec/vdec_helpers.c
 +++ b/drivers/staging/media/meson/vdec/vdec_helpers.c
 @@ -50,32 +50,40 @@ void amvdec_write_parser(struct amvdec_core *core, u32 reg, u32 val)
@@ -507,7 +508,7 @@ index 203d7afa085d..23a69c51c634 100644
  
  static int canvas_alloc(struct amvdec_session *sess, u8 *canvas_id)
  {
-@@ -436,7 +444,7 @@ void amvdec_set_par_from_dar(struct amvdec_session *sess,
+@@ -440,7 +448,7 @@ void amvdec_set_par_from_dar(struct amvdec_session *sess,
  EXPORT_SYMBOL_GPL(amvdec_set_par_from_dar);
  
  void amvdec_src_change(struct amvdec_session *sess, u32 width,
@@ -516,7 +517,7 @@ index 203d7afa085d..23a69c51c634 100644
  {
  	static const struct v4l2_event ev = {
  		.type = V4L2_EVENT_SOURCE_CHANGE,
-@@ -444,25 +452,27 @@ void amvdec_src_change(struct amvdec_session *sess, u32 width,
+@@ -448,25 +456,27 @@ void amvdec_src_change(struct amvdec_session *sess, u32 width,
  
  	v4l2_ctrl_s_ctrl(sess->ctrl_min_buf_capture, dpb_size);
  
@@ -552,7 +553,7 @@ index 203d7afa085d..23a69c51c634 100644
  }
  EXPORT_SYMBOL_GPL(amvdec_src_change);
 diff --git a/drivers/staging/media/meson/vdec/vdec_helpers.h b/drivers/staging/media/meson/vdec/vdec_helpers.h
-index 88137d15aa3a..fca4251f7599 100644
+index 4bf3e61d081b..1a711679d26a 100644
 --- a/drivers/staging/media/meson/vdec/vdec_helpers.h
 +++ b/drivers/staging/media/meson/vdec/vdec_helpers.h
 @@ -27,9 +27,10 @@ void amvdec_clear_dos_bits(struct amvdec_core *core, u32 reg, u32 val);
@@ -582,5 +583,5 @@ index 88137d15aa3a..fca4251f7599 100644
  /**
   * amvdec_abort() - Abort the current decoding session
 -- 
-2.35.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/general-meson-vdec-remove-redundant-if-statement.patch
+++ b/patch/kernel/archive/meson64-6.0/general-meson-vdec-remove-redundant-if-statement.patch
@@ -1,8 +1,7 @@
-From 4aca1a59251338a9f98b58fc67e7749fae32b3be Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: benjamin545 <benjamin545@gmail.com>
 Date: Thu, 15 Jul 2021 14:32:33 -0400
-Subject: [PATCH 62/90] WIP: drivers: meson: vdec: remove redundant if
- statement
+Subject: WIP: drivers: meson: vdec: remove redundant if statement
 
 checking if sess->fmt_out->pixfmt is V4L2_PIX_FMT_VP9 was already done
 as a condition to enter the if statement where this additional check is performed
@@ -11,10 +10,10 @@ as a condition to enter the if statement where this additional check is performe
  1 file changed, 1 insertion(+), 2 deletions(-)
 
 diff --git a/drivers/staging/media/meson/vdec/esparser.c b/drivers/staging/media/meson/vdec/esparser.c
-index db7022707ff8..e18334e57fc0 100644
+index 98f1efa4ad31..06f627b141fb 100644
 --- a/drivers/staging/media/meson/vdec/esparser.c
 +++ b/drivers/staging/media/meson/vdec/esparser.c
-@@ -314,8 +314,7 @@ esparser_queue(struct amvdec_session *sess, struct vb2_v4l2_buffer *vbuf)
+@@ -315,8 +315,7 @@ esparser_queue(struct amvdec_session *sess, struct vb2_v4l2_buffer *vbuf)
  			num_dst_bufs = codec_ops->num_pending_bufs(sess);
  
  		num_dst_bufs += v4l2_m2m_num_dst_bufs_ready(sess->m2m_ctx);
@@ -25,5 +24,5 @@ index db7022707ff8..e18334e57fc0 100644
  		if (esparser_vififo_get_free_space(sess) < payload_size ||
  		    atomic_read(&sess->esparser_queued_bufs) >= num_dst_bufs)
 -- 
-2.35.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/general-meson64-overlays.patch
+++ b/patch/kernel/archive/meson64-6.0/general-meson64-overlays.patch
@@ -1,31 +1,23 @@
-From 58c5526eb1798e61e4e76d37140cf10c8d325bc7 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Zhang Ning <832666+zhangn1985@users.noreply.github.com>
 Date: Thu, 19 Sep 2019 16:20:31 +0800
-Subject: [PATCH] general: meson64 overlays
+Subject: general: meson64 overlays
 
 Signed-off-by: Zhang Ning <832666+zhangn1985@users.noreply.github.com>
 ---
- arch/arm64/boot/dts/amlogic/Makefile          |  2 ++
- arch/arm64/boot/dts/amlogic/overlay/Makefile  | 20 ++++++++++++
- .../dts/amlogic/overlay/README.meson-overlays | 20 ++++++++++++
- .../dts/amlogic/overlay/meson-fixup.scr-cmd   |  4 +++
- .../boot/dts/amlogic/overlay/meson-i2cA.dts   | 17 ++++++++++
- .../boot/dts/amlogic/overlay/meson-i2cB.dts   | 17 ++++++++++
- .../boot/dts/amlogic/overlay/meson-uartA.dts  | 11 +++++++
- .../boot/dts/amlogic/overlay/meson-uartC.dts  | 11 +++++++
- .../dts/amlogic/overlay/meson-w1-gpio.dts     | 20 ++++++++++++
- .../dts/amlogic/overlay/meson-w1AB-gpio.dts   | 32 +++++++++++++++++++
- scripts/Makefile.lib                          |  3 ++
- 11 files changed, 157 insertions(+)
- create mode 100644 arch/arm64/boot/dts/amlogic/overlay/Makefile
- create mode 100644 arch/arm64/boot/dts/amlogic/overlay/README.meson-overlays
- create mode 100644 arch/arm64/boot/dts/amlogic/overlay/meson-fixup.scr-cmd
- create mode 100644 arch/arm64/boot/dts/amlogic/overlay/meson-i2cA.dts
- create mode 100644 arch/arm64/boot/dts/amlogic/overlay/meson-i2cB.dts
- create mode 100644 arch/arm64/boot/dts/amlogic/overlay/meson-uartA.dts
- create mode 100644 arch/arm64/boot/dts/amlogic/overlay/meson-uartC.dts
- create mode 100644 arch/arm64/boot/dts/amlogic/overlay/meson-w1-gpio.dts
- create mode 100644 arch/arm64/boot/dts/amlogic/overlay/meson-w1AB-gpio.dts
+ arch/arm64/boot/dts/amlogic/Makefile                                 |  2 +
+ arch/arm64/boot/dts/amlogic/overlay/Makefile                         | 20 ++++++
+ arch/arm64/boot/dts/amlogic/overlay/README.meson-overlays            | 20 ++++++
+ arch/arm64/boot/dts/amlogic/overlay/meson-fixup.scr-cmd              |  4 ++
+ arch/arm64/boot/dts/amlogic/overlay/meson-g12-gxl-cma-pool-896MB.dts | 19 ++++++
+ arch/arm64/boot/dts/amlogic/overlay/meson-i2cA.dts                   | 17 +++++
+ arch/arm64/boot/dts/amlogic/overlay/meson-i2cB.dts                   | 17 +++++
+ arch/arm64/boot/dts/amlogic/overlay/meson-uartA.dts                  | 11 ++++
+ arch/arm64/boot/dts/amlogic/overlay/meson-uartC.dts                  | 11 ++++
+ arch/arm64/boot/dts/amlogic/overlay/meson-w1-gpio.dts                | 20 ++++++
+ arch/arm64/boot/dts/amlogic/overlay/meson-w1AB-gpio.dts              | 32 ++++++++++
+ scripts/Makefile.lib                                                 |  3 +
+ 12 files changed, 176 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/amlogic/Makefile b/arch/arm64/boot/dts/amlogic/Makefile
 index da3225d31e38..5387963c0ee4 100644
@@ -39,7 +31,7 @@ index da3225d31e38..5387963c0ee4 100644
 +subdir-y       := $(dts-dirs) overlay
 diff --git a/arch/arm64/boot/dts/amlogic/overlay/Makefile b/arch/arm64/boot/dts/amlogic/overlay/Makefile
 new file mode 100644
-index 0000000..4d83834
+index 000000000000..9d5c727602d1
 --- /dev/null
 +++ b/arch/arm64/boot/dts/amlogic/overlay/Makefile
 @@ -0,0 +1,20 @@
@@ -101,7 +93,7 @@ index 000000000000..d4c39e20a3a2
 +
 diff --git a/arch/arm64/boot/dts/amlogic/overlay/meson-g12-gxl-cma-pool-896MB.dts b/arch/arm64/boot/dts/amlogic/overlay/meson-g12-gxl-cma-pool-896MB.dts
 new file mode 100644
-index 0000000..f8c476b
+index 000000000000..f8c476b04e8c
 --- /dev/null
 +++ b/arch/arm64/boot/dts/amlogic/overlay/meson-g12-gxl-cma-pool-896MB.dts
 @@ -0,0 +1,19 @@
@@ -269,7 +261,7 @@ index 000000000000..f6b0d7eff158
 +	};
 +};
 diff --git a/scripts/Makefile.lib b/scripts/Makefile.lib
-index a28448cebd7c..175e7b53eccf 100644
+index 53a4121ca38c..7798b72ce3d6 100644
 --- a/scripts/Makefile.lib
 +++ b/scripts/Makefile.lib
 @@ -87,6 +87,9 @@ base-dtb-y := $(foreach m, $(multi-dtb-y), $(firstword $(call suffix-search, $m,
@@ -283,5 +275,5 @@ index a28448cebd7c..175e7b53eccf 100644
  
  extra-y		:= $(addprefix $(obj)/,$(extra-y))
 -- 
-2.30.2
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/general-rc-drivers-should-produce-alternate-pulse-and-space-timing-events.patch
+++ b/patch/kernel/archive/meson64-6.0/general-rc-drivers-should-produce-alternate-pulse-and-space-timing-events.patch
@@ -1,3 +1,14 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor.pecovnik@gmail.com>
+Date: Tue, 26 Jun 2018 12:47:49 +0000
+Subject: media: rc: drivers should produce alternate pulse and space timing
+ events
+
+Unknown patch. Archeology revelated nothing. Good luck...
+---
+ drivers/media/rc/meson-ir.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
 diff --git a/drivers/media/rc/meson-ir.c b/drivers/media/rc/meson-ir.c
 index 4b769111f78e..dd3aa1332f53 100644
 --- a/drivers/media/rc/meson-ir.c
@@ -12,3 +23,6 @@ index 4b769111f78e..dd3aa1332f53 100644
  
  	spin_unlock(&ir->lock);
  
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.0/general-si2168-fix-cmd-timeout.patch
+++ b/patch/kernel/archive/meson64-6.0/general-si2168-fix-cmd-timeout.patch
@@ -1,7 +1,7 @@
-From 2e01cc074cc426da4b390af025a736eda9aef80c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Koumes <koumes@centrum.cz>
 Date: Sat, 1 Jun 2019 21:20:26 +0000
-Subject: [PATCH] si2168: fix cmd timeout
+Subject: si2168: fix cmd timeout
 
 Some demuxer si2168 commands may take 130-140 ms.
 (DVB-T/T2 tuner MyGica T230C v2).
@@ -11,10 +11,10 @@ Details: https://github.com/CoreELEC/CoreELEC/pull/208
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/media/dvb-frontends/si2168.c b/drivers/media/dvb-frontends/si2168.c
-index b05e6772c..ffaba6f81 100644
+index 196e028a6617..a5c27fa07d35 100644
 --- a/drivers/media/dvb-frontends/si2168.c
 +++ b/drivers/media/dvb-frontends/si2168.c
-@@ -42,7 +42,7 @@ static int si2168_cmd_execute(struct i2c_client *client, struct si2168_cmd *cmd)
+@@ -40,7 +40,7 @@ static int si2168_cmd_execute(struct i2c_client *client, struct si2168_cmd *cmd)
  
  	if (cmd->rlen) {
  		/* wait cmd execution terminate */
@@ -24,5 +24,5 @@ index b05e6772c..ffaba6f81 100644
  		while (!time_after(jiffies, timeout)) {
  			ret = i2c_master_recv(client, cmd->args, cmd->rlen);
 -- 
-2.17.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/general-sound-soc-remove-mono-channel-as-it-curren.patch
+++ b/patch/kernel/archive/meson64-6.0/general-sound-soc-remove-mono-channel-as-it-curren.patch
@@ -1,8 +1,8 @@
-From 79828b7d8ee8674b1538514a754337554cd4f856 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: ckkim <changkon12@gmail.com>
 Date: Thu, 20 Feb 2020 18:52:57 +0900
-Subject: [PATCH] ODROID-N2: sound/soc: remove mono channel as it currently
- doesn't work hdmi output.
+Subject: ODROID-N2: sound/soc: remove mono channel as it currently doesn't
+ work hdmi output.
 
 Change-Id: I4d43b802815779687ade974f049f2b0517a411d1
 Signed-off-by: ckkim <changkon12@gmail.com>
@@ -11,7 +11,7 @@ Signed-off-by: ckkim <changkon12@gmail.com>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/sound/soc/meson/axg-frddr.c b/sound/soc/meson/axg-frddr.c
-index 37f4bb3469b5..b1cbeef98a73 100644
+index 61f9d417fd60..b0f3883af0a9 100644
 --- a/sound/soc/meson/axg-frddr.c
 +++ b/sound/soc/meson/axg-frddr.c
 @@ -106,7 +106,7 @@ static struct snd_soc_dai_driver axg_frddr_dai_drv = {
@@ -23,7 +23,7 @@ index 37f4bb3469b5..b1cbeef98a73 100644
  		.channels_max	= AXG_FIFO_CH_MAX,
  		.rates		= AXG_FIFO_RATES,
  		.formats	= AXG_FIFO_FORMATS,
-@@ -180,7 +180,7 @@ static struct snd_soc_dai_driver g12a_frddr_dai_drv = {
+@@ -181,7 +181,7 @@ static struct snd_soc_dai_driver g12a_frddr_dai_drv = {
  	.name = "FRDDR",
  	.playback = {
  		.stream_name	= "Playback",
@@ -33,5 +33,5 @@ index 37f4bb3469b5..b1cbeef98a73 100644
  		.rates		= AXG_FIFO_RATES,
  		.formats	= AXG_FIFO_FORMATS,
 -- 
-2.35.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/general-spi-nor-add-support-for-XT25F128B.patch
+++ b/patch/kernel/archive/meson64-6.0/general-spi-nor-add-support-for-XT25F128B.patch
@@ -1,7 +1,7 @@
-From a5dc8bb92c6b67be7e48d442e821837b03fc129a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Andreas Rammhold <andreas@rammhold.de>
 Date: Thu, 28 Jan 2021 09:43:36 +0000
-Subject: [PATCH 17/58] FROMLIST(v1): spi-nor: add support for XT25F128B
+Subject: spi-nor: add support for XT25F128B
 
 This adds support for the XT25F128B as found on the RockPi4b SBC.
 
@@ -23,9 +23,8 @@ in the core.{c,h} files.
  drivers/mtd/spi-nor/Makefile |  1 +
  drivers/mtd/spi-nor/core.c   |  1 +
  drivers/mtd/spi-nor/core.h   |  1 +
- drivers/mtd/spi-nor/xtx.c    | 16 ++++++++++++++++
+ drivers/mtd/spi-nor/xtx.c    | 16 ++++++++++
  4 files changed, 19 insertions(+)
- create mode 100644 drivers/mtd/spi-nor/xtx.c
 
 diff --git a/drivers/mtd/spi-nor/Makefile b/drivers/mtd/spi-nor/Makefile
 index e347b435a038..8992c592a896 100644
@@ -40,7 +39,7 @@ index e347b435a038..8992c592a896 100644
  obj-$(CONFIG_MTD_SPI_NOR)	+= spi-nor.o
  
 diff --git a/drivers/mtd/spi-nor/core.c b/drivers/mtd/spi-nor/core.c
-index 502967c76c5f..c171da5c8ca1 100644
+index bee8fc4c9f07..24ce2fd7dc40 100644
 --- a/drivers/mtd/spi-nor/core.c
 +++ b/drivers/mtd/spi-nor/core.c
 @@ -1630,6 +1630,7 @@ static const struct spi_nor_manufacturer *manufacturers[] = {
@@ -52,10 +51,10 @@ index 502967c76c5f..c171da5c8ca1 100644
  
  static const struct flash_info *spi_nor_match_id(struct spi_nor *nor,
 diff --git a/drivers/mtd/spi-nor/core.h b/drivers/mtd/spi-nor/core.h
-index 3f841ec36e56..9e29d67b419b 100644
+index 85b0cf254e97..e79188ca9955 100644
 --- a/drivers/mtd/spi-nor/core.h
 +++ b/drivers/mtd/spi-nor/core.h
-@@ -622,6 +622,7 @@ extern const struct spi_nor_manufacturer spi_nor_sst;
+@@ -627,6 +627,7 @@ extern const struct spi_nor_manufacturer spi_nor_sst;
  extern const struct spi_nor_manufacturer spi_nor_winbond;
  extern const struct spi_nor_manufacturer spi_nor_xilinx;
  extern const struct spi_nor_manufacturer spi_nor_xmc;
@@ -86,5 +85,5 @@ index 000000000000..73568854cf1e
 + .nparts = ARRAY_SIZE(xtx_parts),
 +};
 -- 
-2.30.2
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/general-usb-core-improve-handling-of-hubs-with-no-ports.patch
+++ b/patch/kernel/archive/meson64-6.0/general-usb-core-improve-handling-of-hubs-with-no-ports.patch
@@ -1,8 +1,7 @@
-From 477a4f4816028d590f7b013e04b29319dbe66a24 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Heiner Kallweit <hkallweit1@gmail.com>
 Date: Wed, 23 Feb 2022 02:21:19 +0000
-Subject: [PATCH 50/90] FROMLIST(v1): usb: core: improve handling of hubs with
- no ports
+Subject: usb: core: improve handling of hubs with no ports
 
 I get the "hub doesn't have any ports" error message on a system with
 Amlogic S905W SoC. Seems the SoC has internal USB 3.0 supports but
@@ -34,10 +33,10 @@ Signed-off-by: Heiner Kallweit <hkallweit1@gmail.com>
  1 file changed, 2 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/usb/core/hub.c b/drivers/usb/core/hub.c
-index 588f3ded89cd..4151b960915b 100644
+index bbab424b0d55..87cc6d816e91 100644
 --- a/drivers/usb/core/hub.c
 +++ b/drivers/usb/core/hub.c
-@@ -1423,9 +1423,8 @@ static int hub_configure(struct usb_hub *hub,
+@@ -1424,9 +1424,8 @@ static int hub_configure(struct usb_hub *hub,
  		ret = -ENODEV;
  		goto fail;
  	} else if (hub->descriptor->bNbrPorts == 0) {
@@ -50,5 +49,5 @@ index 588f3ded89cd..4151b960915b 100644
  
  	/*
 -- 
-2.35.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/jethome-0001-Fix-meson64-add-gpio-irq-patch-from-https-lkml.org-l.patch
+++ b/patch/kernel/archive/meson64-6.0/jethome-0001-Fix-meson64-add-gpio-irq-patch-from-https-lkml.org-l.patch
@@ -1,28 +1,28 @@
-From 369f3f5b1a0145b876407bd5900a90554cd89a05 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: usera <adeep@lexina.in>
 Date: Mon, 12 Apr 2021 17:16:42 +0300
-Subject: [PATCH 5/5] Fix:meson64: add gpio irq (patch from
+Subject: Fix:meson64: add gpio irq (patch from
  https://lkml.org/lkml/2020/11/27/8)
 
 Signed-off-by: Vyacheslav Bocharov <devel@lexina.in>
 ---
- drivers/pinctrl/meson/pinctrl-meson.c | 41 +++++++++++++++++++++++++++
+ drivers/pinctrl/meson/pinctrl-meson.c | 41 ++++++++++
  drivers/pinctrl/meson/pinctrl-meson.h |  1 +
  2 files changed, 42 insertions(+)
 
 diff --git a/drivers/pinctrl/meson/pinctrl-meson.c b/drivers/pinctrl/meson/pinctrl-meson.c
-index 49851444a6e3..3f295e9c561d 100644
+index cc2cd73ff8f9..619856b81240 100644
 --- a/drivers/pinctrl/meson/pinctrl-meson.c
 +++ b/drivers/pinctrl/meson/pinctrl-meson.c
-@@ -51,6 +51,7 @@
- #include <linux/platform_device.h>
+@@ -52,6 +52,7 @@
+ #include <linux/property.h>
  #include <linux/regmap.h>
  #include <linux/seq_file.h>
 +#include <linux/of_irq.h>
  
  #include "../core.h"
  #include "../pinctrl-utils.h"
-@@ -601,6 +602,40 @@ static int meson_gpio_get(struct gpio_chip *chip, unsigned gpio)
+@@ -602,6 +603,40 @@ static int meson_gpio_get(struct gpio_chip *chip, unsigned gpio)
  	return !!(val & BIT(bit));
  }
  
@@ -63,7 +63,7 @@ index 49851444a6e3..3f295e9c561d 100644
  static int meson_gpiolib_register(struct meson_pinctrl *pc)
  {
  	int ret;
-@@ -615,6 +650,7 @@ static int meson_gpiolib_register(struct meson_pinctrl *pc)
+@@ -616,6 +651,7 @@ static int meson_gpiolib_register(struct meson_pinctrl *pc)
  	pc->chip.direction_output = meson_gpio_direction_output;
  	pc->chip.get = meson_gpio_get;
  	pc->chip.set = meson_gpio_set;
@@ -71,8 +71,8 @@ index 49851444a6e3..3f295e9c561d 100644
  	pc->chip.base = -1;
  	pc->chip.ngpio = pc->data->num_pins;
  	pc->chip.can_sleep = false;
-@@ -685,6 +721,11 @@ static int meson_pinctrl_parse_dt(struct meson_pinctrl *pc,
- 
+@@ -681,6 +717,11 @@ static int meson_pinctrl_parse_dt(struct meson_pinctrl *pc)
+ 	gpio_np = to_of_node(gpiochip_node_get_first(pc->dev));
  	pc->of_node = gpio_np;
  
 +	pc->of_irq = of_find_compatible_node(NULL,
@@ -84,7 +84,7 @@ index 49851444a6e3..3f295e9c561d 100644
  	if (IS_ERR_OR_NULL(pc->reg_mux)) {
  		dev_err(pc->dev, "mux registers not found\n");
 diff --git a/drivers/pinctrl/meson/pinctrl-meson.h b/drivers/pinctrl/meson/pinctrl-meson.h
-index ff5372e0a475..07f277946d1b 100644
+index b197827027bd..27cae1d58f58 100644
 --- a/drivers/pinctrl/meson/pinctrl-meson.h
 +++ b/drivers/pinctrl/meson/pinctrl-meson.h
 @@ -132,6 +132,7 @@ struct meson_pinctrl {
@@ -96,5 +96,5 @@ index ff5372e0a475..07f277946d1b 100644
  
  #define FUNCTION(fn)							\
 -- 
-2.35.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/jethome-0002-arm64-dts-meson-axg-add-support-for-JetHub-D1p-j110.patch
+++ b/patch/kernel/archive/meson64-6.0/jethome-0002-arm64-dts-meson-axg-add-support-for-JetHub-D1p-j110.patch
@@ -1,7 +1,7 @@
-From 1307b424375ca85d1f3b021396c55f77dbeaf924 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Vyacheslav Bocharov <adeep@lexina.in>
 Date: Wed, 10 Aug 2022 13:40:37 +0300
-Subject: [PATCH 1/2] arm64: dts: meson-axg: add support for JetHub D1p (j110)
+Subject: arm64: dts: meson-axg: add support for JetHub D1p (j110)
 
 - add support for JetHome JetHub D1p (https://jethome.ru/d1p) is a home
 automation controller with the following features:
@@ -27,18 +27,15 @@ automation controller with the following features:
 
 Signed-off-by: Vyacheslav Bocharov <adeep@lexina.in>
 ---
- arch/arm64/boot/dts/amlogic/Makefile          |   2 +
- .../amlogic/meson-axg-jethome-jethub-j100.dts | 338 +----------------
- .../meson-axg-jethome-jethub-j110-rev-2.dts   |  37 ++
- .../meson-axg-jethome-jethub-j110-rev-3.dts   |  27 ++
- .../meson-axg-jethome-jethub-j1xx.dtsi        | 351 ++++++++++++++++++
+ arch/arm64/boot/dts/amlogic/Makefile                                |   2 +
+ arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j100.dts       | 338 +--------
+ arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j110-rev-2.dts |  37 +
+ arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j110-rev-3.dts |  27 +
+ arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j1xx.dtsi      | 351 ++++++++++
  5 files changed, 421 insertions(+), 334 deletions(-)
- create mode 100644 arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j110-rev-2.dts
- create mode 100644 arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j110-rev-3.dts
- create mode 100644 arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j1xx.dtsi
 
 diff --git a/arch/arm64/boot/dts/amlogic/Makefile b/arch/arm64/boot/dts/amlogic/Makefile
-index 8773211df50e..33e9c96af099 100644
+index 5387963c0ee4..04267e82140c 100644
 --- a/arch/arm64/boot/dts/amlogic/Makefile
 +++ b/arch/arm64/boot/dts/amlogic/Makefile
 @@ -1,6 +1,8 @@
@@ -863,5 +860,5 @@ index 000000000000..5836b0030931
 +	#cooling-cells = <2>;
 +};
 -- 
-2.30.2
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/jethome-0003-dt-bindings-arm-amlogic-add-bindings-for-Jethub-D1p-.patch
+++ b/patch/kernel/archive/meson64-6.0/jethome-0003-dt-bindings-arm-amlogic-add-bindings-for-Jethub-D1p-.patch
@@ -1,8 +1,7 @@
-From 08b0c478ad097372ab668f03db3890545aaca59d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Vyacheslav Bocharov <adeep@lexina.in>
 Date: Wed, 10 Aug 2022 13:51:46 +0300
-Subject: [PATCH 2/2] dt-bindings: arm: amlogic: add bindings for Jethub D1p
- (j110)
+Subject: dt-bindings: arm: amlogic: add bindings for Jethub D1p (j110)
 
 JetHome JetHub D1p is a home automation controller, modification
  of JetHub D1 based on Amlogic A113X
@@ -13,7 +12,7 @@ Signed-off-by: Vyacheslav Bocharov <adeep@lexina.in>
  1 file changed, 1 insertion(+)
 
 diff --git a/Documentation/devicetree/bindings/arm/amlogic.yaml b/Documentation/devicetree/bindings/arm/amlogic.yaml
-index 61a6cabb375b..9ac73e961146 100644
+index bf32821281b1..13fa041b60e9 100644
 --- a/Documentation/devicetree/bindings/arm/amlogic.yaml
 +++ b/Documentation/devicetree/bindings/arm/amlogic.yaml
 @@ -136,6 +136,7 @@ properties:
@@ -25,5 +24,5 @@ index 61a6cabb375b..9ac73e961146 100644
            - const: amlogic,meson-axg
  
 -- 
-2.30.2
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/meson-g12a-pinctrl-add-missing-ir-options.patch
+++ b/patch/kernel/archive/meson64-6.0/meson-g12a-pinctrl-add-missing-ir-options.patch
@@ -1,18 +1,18 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Yuntian Zhang <yt@radxa.com>
 Date: Mon, 25 Jul 2022 15:31:31 +0800
-Subject: [PATCH]  pinctrl: meson-g12a: add missing ir options
+Subject: pinctrl: meson-g12a: add missing ir options
 
 Those pins are defined in S905Y2 and A311D reference manuals.
 
 Signed-off-by: Yuntian Zhang <yt@radxa.com>
 ---
- .../arm64/boot/dts/amlogic/meson-g12-common.dtsi | 16 ++++++++++++++++
- drivers/pinctrl/meson/pinctrl-meson-g12a.c       |  9 +++++++++
+ arch/arm64/boot/dts/amlogic/meson-g12-common.dtsi | 16 ++++++++++
+ drivers/pinctrl/meson/pinctrl-meson-g12a.c        |  9 ++++++
  2 files changed, 25 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-g12-common.dtsi b/arch/arm64/boot/dts/amlogic/meson-g12-common.dtsi
-index 45947c1031..8bc032c38a 100644
+index 45947c1031c4..8bc032c38a50 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-g12-common.dtsi
 +++ b/arch/arm64/boot/dts/amlogic/meson-g12-common.dtsi
 @@ -562,6 +562,14 @@ mux {
@@ -46,7 +46,7 @@ index 45947c1031..8bc032c38a 100644
  			};
  
 diff --git a/drivers/pinctrl/meson/pinctrl-meson-g12a.c b/drivers/pinctrl/meson/pinctrl-meson-g12a.c
-index 5f2a6f9c96..bcf8b92d0c 100644
+index d182a575981e..74c0fd368586 100644
 --- a/drivers/pinctrl/meson/pinctrl-meson-g12a.c
 +++ b/drivers/pinctrl/meson/pinctrl-meson-g12a.c
 @@ -215,6 +215,9 @@ static const unsigned int i2c3_sck_h_pins[]		= { GPIOH_1 };
@@ -59,7 +59,7 @@ index 5f2a6f9c96..bcf8b92d0c 100644
  /* uart_a */
  static const unsigned int uart_a_tx_pins[]		= { GPIOX_12 };
  static const unsigned int uart_a_rx_pins[]		= { GPIOX_13 };
-@@ -744,6 +747,7 @@ static struct meson_pmx_group meson_g12a_periphs_groups[] = {
+@@ -736,6 +739,7 @@ static struct meson_pmx_group meson_g12a_periphs_groups[] = {
  	/* bank GPIOA */
  	GROUP(i2c3_sda_a,		2),
  	GROUP(i2c3_sck_a,		2),
@@ -67,7 +67,7 @@ index 5f2a6f9c96..bcf8b92d0c 100644
  	GROUP(pdm_din0_a,		1),
  	GROUP(pdm_din1_a,		1),
  	GROUP(pdm_din2_a,		1),
-@@ -1029,6 +1033,10 @@ static const char * const i2c3_groups[] = {
+@@ -1021,6 +1025,10 @@ static const char * const i2c3_groups[] = {
  	"i2c3_sda_a", "i2c3_sck_a",
  };
  
@@ -78,7 +78,7 @@ index 5f2a6f9c96..bcf8b92d0c 100644
  static const char * const uart_a_groups[] = {
  	"uart_a_tx", "uart_a_rx", "uart_a_cts", "uart_a_rts",
  };
-@@ -1273,6 +1281,7 @@ static struct meson_pmx_func meson_g12a_periphs_functions[] = {
+@@ -1265,6 +1273,7 @@ static struct meson_pmx_func meson_g12a_periphs_functions[] = {
  	FUNCTION(i2c1),
  	FUNCTION(i2c2),
  	FUNCTION(i2c3),
@@ -87,5 +87,5 @@ index 5f2a6f9c96..bcf8b92d0c 100644
  	FUNCTION(uart_b),
  	FUNCTION(uart_c),
 -- 
-2.37.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/meson-g12b-pinctrl-Add-missing-pinmux-for-pwm.patch
+++ b/patch/kernel/archive/meson64-6.0/meson-g12b-pinctrl-Add-missing-pinmux-for-pwm.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Yuntian Zhang <yt@radxa.com>
 Date: Thu, 13 Jan 2022 21:34:10 +0800
-Subject: [PATCH] pinctrl: meson: Add several missing pinmux for pwm functions
+Subject: pinctrl: meson: Add several missing pinmux for pwm functions
 
 The following pin definitions are mentioned in A311D Quick
 Reference Manual and S922X Public Datasheet, but not in S905Y2
@@ -11,12 +11,12 @@ They are currently exposed in Radxa Zero 2's GPIO header.
 
 Signed-off-by: Yuntian Zhang <yt@radxa.com>
 ---
- arch/arm64/boot/dts/amlogic/meson-g12b.dtsi | 34 +++++++++++++++++++++
- drivers/pinctrl/meson/pinctrl-meson-g12a.c  | 14 +++++++--
+ arch/arm64/boot/dts/amlogic/meson-g12b.dtsi | 34 ++++++++++
+ drivers/pinctrl/meson/pinctrl-meson-g12a.c  | 14 +++-
  2 files changed, 45 insertions(+), 3 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi b/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi
-index ee8fcae9f..d938f883c 100644
+index ee8fcae9f9f0..d938f883c66e 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi
 +++ b/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi
 @@ -139,3 +139,37 @@ map1 {
@@ -58,10 +58,10 @@ index ee8fcae9f..d938f883c 100644
 +	};
 +};
 diff --git a/drivers/pinctrl/meson/pinctrl-meson-g12a.c b/drivers/pinctrl/meson/pinctrl-meson-g12a.c
-index d182a5759..5f2a6f9c9 100644
+index 74c0fd368586..bcf8b92d0c6f 100644
 --- a/drivers/pinctrl/meson/pinctrl-meson-g12a.c
 +++ b/drivers/pinctrl/meson/pinctrl-meson-g12a.c
-@@ -267,17 +267,21 @@ static const unsigned int eth_act_led_pins[]		= { GPIOZ_15 };
+@@ -270,17 +270,21 @@ static const unsigned int eth_act_led_pins[]		= { GPIOZ_15 };
  static const unsigned int pwm_a_pins[]			= { GPIOX_6 };
  
  /* pwm_b */
@@ -83,7 +83,7 @@ index d182a5759..5f2a6f9c9 100644
  
  /* pwm_e */
  static const unsigned int pwm_e_pins[]			= { GPIOX_16 };
-@@ -590,6 +594,9 @@ static struct meson_pmx_group meson_g12a_periphs_groups[] = {
+@@ -593,6 +597,9 @@ static struct meson_pmx_group meson_g12a_periphs_groups[] = {
  	GROUP(bt565_a_din5,		2),
  	GROUP(bt565_a_din6,		2),
  	GROUP(bt565_a_din7,		2),
@@ -93,7 +93,7 @@ index d182a5759..5f2a6f9c9 100644
  	GROUP(tsin_b_valid_z,		3),
  	GROUP(tsin_b_sop_z,		3),
  	GROUP(tsin_b_din0_z,		3),
-@@ -722,6 +729,7 @@ static struct meson_pmx_group meson_g12a_periphs_groups[] = {
+@@ -725,6 +732,7 @@ static struct meson_pmx_group meson_g12a_periphs_groups[] = {
  	GROUP(uart_c_rts,		2),
  	GROUP(iso7816_clk_h,		1),
  	GROUP(iso7816_data_h,		1),
@@ -101,7 +101,7 @@ index d182a5759..5f2a6f9c9 100644
  	GROUP(pwm_f_h,			4),
  	GROUP(cec_ao_a_h,		4),
  	GROUP(cec_ao_b_h,		5),
-@@ -1057,15 +1065,15 @@ static const char * const pwm_a_groups[] = {
+@@ -1065,15 +1073,15 @@ static const char * const pwm_a_groups[] = {
  };
  
  static const char * const pwm_b_groups[] = {
@@ -121,5 +121,5 @@ index d182a5759..5f2a6f9c9 100644
  
  static const char * const pwm_e_groups[] = {
 -- 
-2.36.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/meson-gx-dts-add-support-for-GX-PM-and-VRTC.patch
+++ b/patch/kernel/archive/meson64-6.0/meson-gx-dts-add-support-for-GX-PM-and-VRTC.patch
@@ -1,8 +1,7 @@
-From 9c2b8d82e36bf5ce932e6561d13adf5c7c5d367f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Neil Armstrong <narmstrong@baylibre.com>
 Date: Thu, 3 Nov 2016 15:29:25 +0100
-Subject: [PATCH 06/90] HACK: arm64: dts: meson: add support for GX PM and
- Virtual RTC
+Subject: HACK: arm64: dts: meson: add support for GX PM and Virtual RTC
 
 Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>
 ---
@@ -10,7 +9,7 @@ Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>
  1 file changed, 9 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-gx.dtsi b/arch/arm64/boot/dts/amlogic/meson-gx.dtsi
-index 99b8916e0c5d..d6dc407127cd 100644
+index 023a52005494..86ffd599b086 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-gx.dtsi
 +++ b/arch/arm64/boot/dts/amlogic/meson-gx.dtsi
 @@ -221,6 +221,10 @@ sm: secure-monitor {
@@ -37,5 +36,5 @@ index 99b8916e0c5d..d6dc407127cd 100644
  				compatible = "amlogic,meson-gx-ao-cec";
  				reg = <0x0 0x00100 0x0 0x14>;
 -- 
-2.35.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/meson-gxbb-dts-i2cX-missing-pins.patch
+++ b/patch/kernel/archive/meson64-6.0/meson-gxbb-dts-i2cX-missing-pins.patch
@@ -1,3 +1,13 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Martin Ayotte <martinayotte@yahoo.ca>
+Date: Wed, 5 Dec 2018 17:35:05 -0500
+Subject: fix i2cA and i2cB miossing pins
+
+- c80617d145039a32b53e9f0908353aaea3d368a6: 1544111688: Martin Ayotte <martinayotte@yahoo.ca>: 'add i2c_B missing pins'
+---
+ arch/arm64/boot/dts/amlogic/meson-gxbb.dtsi | 4 ++++
+ 1 file changed, 4 insertions(+)
+
 diff --git a/arch/arm64/boot/dts/amlogic/meson-gxbb.dtsi b/arch/arm64/boot/dts/amlogic/meson-gxbb.dtsi
 index 7c029f552a23..b3c22861b022 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-gxbb.dtsi
@@ -20,3 +30,6 @@ index 7c029f552a23..b3c22861b022 100644
  };
  
  &i2c_C {
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.0/meson-gxbb-vdec-add-HEVC-support-to-GXBB.patch
+++ b/patch/kernel/archive/meson64-6.0/meson-gxbb-vdec-add-HEVC-support-to-GXBB.patch
@@ -1,14 +1,14 @@
-From 975c23d02776b023a75e6090b521a839e67a8c42 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Christian Hewitt <christianshewitt@gmail.com>
 Date: Sun, 21 Nov 2021 19:12:07 +0000
-Subject: [PATCH 66/90] WIP: drivers: meson: vdec: add HEVC support to GXBB
+Subject: WIP: drivers: meson: vdec: add HEVC support to GXBB
 
 It's not clear whether the GXL firmware is the same one used with GXBB
 but let's try it and see!
 
 Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
 ---
- drivers/staging/media/meson/vdec/vdec_platform.c | 12 ++++++++++++
+ drivers/staging/media/meson/vdec/vdec_platform.c | 12 ++++++++++
  1 file changed, 12 insertions(+)
 
 diff --git a/drivers/staging/media/meson/vdec/vdec_platform.c b/drivers/staging/media/meson/vdec/vdec_platform.c
@@ -35,5 +35,5 @@ index 8592cb3aaea9..810039a02b44 100644
  		.min_buffers = 2,
  		.max_buffers = 24,
 -- 
-2.35.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/meson-gxm-vdec-add-VP9-support-to-GXM.patch
+++ b/patch/kernel/archive/meson64-6.0/meson-gxm-vdec-add-VP9-support-to-GXM.patch
@@ -1,8 +1,7 @@
-From fa0fc8498a811c85bace6138f60b7d09f07d18b8 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Christian Hewitt <christianshewitt@gmail.com>
 Date: Thu, 25 Nov 2021 11:31:43 +0000
-Subject: [PATCH 43/90] FROMLIST(v1): drivers: meson: vdec: add VP9 support to
- GXM
+Subject: drivers: meson: vdec: add VP9 support to GXM
 
 VP9 support for GXM appears to have been missed from the original
 codec submission [0] but it works well, so let's add support.
@@ -11,8 +10,8 @@ codec submission [0] but it works well, so let's add support.
 
 Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
 ---
- drivers/staging/media/meson/vdec/vdec_platform.c | 12 ++++++++++++
- 1 file changed, 12 insertions(+)
+ drivers/staging/media/meson/vdec/vdec_platform.c | 14 +++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/staging/media/meson/vdec/vdec_platform.c b/drivers/staging/media/meson/vdec/vdec_platform.c
 index 810039a02b44..38f353c6d27d 100644
@@ -40,5 +39,5 @@ index 810039a02b44..38f353c6d27d 100644
  		.min_buffers = 2,
  		.max_buffers = 24,
 -- 
-2.35.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.0/meson-sm1-dts-add-higher-clocks.patch
+++ b/patch/kernel/archive/meson64-6.0/meson-sm1-dts-add-higher-clocks.patch
@@ -1,7 +1,7 @@
-From a11802ecb5686153614aa19a089900c22928988c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Igor Pecovnik <igor.pecovnik@gmail.com>
 Date: Tue, 4 Aug 2020 22:51:56 +0200
-Subject: [PATCH] Add higher clocks for SM1 family
+Subject: Add higher clocks for SM1 family
 
 Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
 ---
@@ -9,10 +9,10 @@ Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
  1 file changed, 10 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-sm1.dtsi b/arch/arm64/boot/dts/amlogic/meson-sm1.dtsi
-index d4ec735fb..a35cad1d4 100644
+index 80737731af3f..ba52da32cd73 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-sm1.dtsi
 +++ b/arch/arm64/boot/dts/amlogic/meson-sm1.dtsi
-@@ -150,6 +150,16 @@ opp-1908000000 {
+@@ -134,6 +134,16 @@ opp-1908000000 {
  			opp-hz = /bits/ 64 <1908000000>;
  			opp-microvolt = <950000>;
  		};
@@ -30,5 +30,5 @@ index d4ec735fb..a35cad1d4 100644
  };
  
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+Armbian
 


### PR DESCRIPTION
#### `meson64-6.0` kernel patches

- mbox formatting
- (git) archeology to find lost authors/descriptions
- rebase against 6.0.12
- no actual changes