### PR TITLE
Remove workflow cancellation when generating images

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -62,24 +62,10 @@ env:
 
 jobs:
 
-
-  Cancel:
-    name: "Cancel currently active"
-    if: ${{ github.repository_owner == 'Armbian' && github.event.schedule == '' }}
-    runs-on: small
-    timeout-minutes: 3
-    steps:
-      - uses: styfle/cancel-workflow-action@0.11.0
-        if: ${{ github.event.schedule == '' }}
-        with:
-          all_but_latest: true
-          access_token: ${{ secrets.GITHUB_TOKEN }}
-
   clean:
 
     if: ${{ github.repository_owner == 'Armbian' }}
     name: Purge older releases
-    needs: [ Cancel ]
     runs-on: [ubuntu-latest]
     steps:
     

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Purge old releases of trunk build
         uses: Vucko130/delete-older-releases@v0.2.1
         with:
-          keep_latest: 7
+          keep_latest: 32
           delete_tag_pattern: trunk
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

- we should be able to run multiple images build jobs at once.
- enlarge keeping releases from 7 to 32

# How Has This Been Tested?

- [x] Manual run of two concurrent build jobs