### PR TITLE
armbian-audio-config: Massively speed up script

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-audio-config
+++ b/packages/bsp/common/usr/lib/armbian/armbian-audio-config
@@ -8,12 +8,12 @@
 
 mixer_cmds() {
 	parm=${4:-on}
-	echo sset "$1" "$2" $parm
-	echo sset "$1" $parm
+	echo sset "$1" "$2" "$parm"
+	echo sset "$1" "$parm"
 }
 
-if [ -f $HOME/.config/sound.conf ]; then
-	alsactl restore -f $HOME/.config/sound.conf
+if [ -f "$HOME/.config/sound.conf" ]; then
+	alsactl restore -f "$HOME/.config/sound.conf"
 else
 	# get card num
 	#card=`echo $1 | sed 's/[^0-9]*//g'`

--- a/packages/bsp/common/usr/lib/armbian/armbian-audio-config
+++ b/packages/bsp/common/usr/lib/armbian/armbian-audio-config
@@ -6,10 +6,10 @@
 [[ -z $(command -v alsactl) ]] && echo "Missing alsactl; doing nothing." && exit 0
 [[ -z $(command -v aplay) ]] && echo "Missing aplay; doing nothing." && exit 0
 
-mixer() {
+mixer_cmds() {
 	parm=${4:-on}
-	amixer -c "$1" sset "$2" "$3" $parm > /dev/null 2>&1
-	amixer -c "$1" sset "$2" $parm > /dev/null 2>&1
+	echo sset "$1" "$2" $parm
+	echo sset "$1" $parm
 }
 
 if [ -f $HOME/.config/sound.conf ]; then
@@ -20,141 +20,141 @@ else
 	card1=$(aplay -l | grep "device 0" | awk '{print $3}')
 	#echo $card
 
-	for card in $card1; do
+	for card in $card1; do (
 		#echo $card
 
 		# set common mixer params
-		mixer $card Master 0db
-		mixer $card Front 100%
-		mixer $card PCM 0db
-		mixer $card Synth 100%
+		mixer_cmds Master 0db
+		mixer_cmds Front 100%
+		mixer_cmds PCM 0db
+		mixer_cmds Synth 100%
 
 		# mute CD, since using digital audio instead
-		mixer $card CD 0% mute
+		mixer_cmds CD 0% mute
 
 		# Only unmute Line and Aux if they are possibly used.
-		#  mixer $card Line 100%
-		#  mixer $card Aux 100%
+		#  mixer_cmds Line 100%
+		#  mixer_cmds Aux 100%
 
 		# mute mic
-		mixer $card Mic 0% mute
+		mixer_cmds Mic 0% mute
 
 		# ESS 1969 chipset has 2 PCM channels
-		mixer $card PCM,1 100%
+		mixer_cmds PCM,1 100%
 
 		# Trident/YMFPCI/emu10k1
-		mixer $card Wave 100%
-		mixer $card Music 100%
-		mixer $card AC97 100%
-		mixer $card Surround 90%
-		mixer $card 'Surround Digital' 90%
-		mixer $card 'Wave Surround' 90%
-		mixer $card 'Duplicate Front' 90%
-		mixer $card 'Sigmatel 4-Speaker Stereo' 90%
+		mixer_cmds Wave 100%
+		mixer_cmds Music 100%
+		mixer_cmds AC97 100%
+		mixer_cmds Surround 90%
+		mixer_cmds 'Surround Digital' 90%
+		mixer_cmds 'Wave Surround' 90%
+		mixer_cmds 'Duplicate Front' 90%
+		mixer_cmds 'Sigmatel 4-Speaker Stereo' 90%
 
 		# CS4237B chipset:
-		mixer $card 'Master Digital' 100%
+		mixer_cmds 'Master Digital' 100%
 
 		# DRC
-		mixer $card 'Dynamic Range Compression' 90%
+		mixer_cmds 'Dynamic Range Compression' 90%
 
 		# Envy24 chips with analog outs
-		mixer $card DAC 100%
-		mixer $card DAC,0 100%
-		mixer $card DAC,1 100%
+		mixer_cmds DAC 100%
+		mixer_cmds DAC,0 100%
+		mixer_cmds DAC,1 100%
 
 		# some notebooks use headphone instead of master
-		mixer $card Headphone 100%
-		mixer $card Speaker 100%
-		mixer $card 'Internal Speaker' 0% mute
-		mixer $card Playback 100%
-		mixer $card Headphone 100%
-		mixer $card Speaker 100%
-		mixer $card Center 100%
-		mixer $card LFE 100%
-		mixer $card Center/LFE 100%
+		mixer_cmds Headphone 100%
+		mixer_cmds Speaker 100%
+		mixer_cmds 'Internal Speaker' 0% mute
+		mixer_cmds Playback 100%
+		mixer_cmds Headphone 100%
+		mixer_cmds Speaker 100%
+		mixer_cmds Center 100%
+		mixer_cmds LFE 100%
+		mixer_cmds Center/LFE 100%
 
 		# Intel P4P800-MX  (Ubuntu bug #5813)
-		mixer $card 'Master Playback Switch' on
+		mixer_cmds 'Master Playback Switch' on
 
 		# set digital output mixer params
-		mixer $card 'IEC958' 100% on
-		mixer $card 'IEC958 Output' 100%
-		mixer $card 'IEC958 Coaxial' 100%
-		mixer $card 'IEC958 LiveDrive' 100%
-		mixer $card 'IEC958 Optical Raw' 100%
-		mixer $card 'SPDIF Out' 100%
-		mixer $card 'SPDIF Front' 100%
-		mixer $card 'SPDIF Rear' 100%
-		mixer $card 'SPDIF Center/LFE' 100%
-		mixer $card 'Master Digital' 100%
+		mixer_cmds 'IEC958' 100% on
+		mixer_cmds 'IEC958 Output' 100%
+		mixer_cmds 'IEC958 Coaxial' 100%
+		mixer_cmds 'IEC958 LiveDrive' 100%
+		mixer_cmds 'IEC958 Optical Raw' 100%
+		mixer_cmds 'SPDIF Out' 100%
+		mixer_cmds 'SPDIF Front' 100%
+		mixer_cmds 'SPDIF Rear' 100%
+		mixer_cmds 'SPDIF Center/LFE' 100%
+		mixer_cmds 'Master Digital' 100%
 
-		mixer $card 'Analog Front' 100%
-		mixer $card 'Analog Rear' 100%
-		mixer $card 'Analog Center/LFE' 100%
+		mixer_cmds 'Analog Front' 100%
+		mixer_cmds 'Analog Rear' 100%
+		mixer_cmds 'Analog Center/LFE' 100%
 
 		# ASRock ION 330 (and perhaps others) has 2 IEC958 channels
-		mixer $card IEC958,0 on
-		mixer $card IEC958,1 on
+		mixer_cmds IEC958,0 on
+		mixer_cmds IEC958,1 on
 
 		# some ION2 has much more IEC958 channels ...
-		mixer $card IEC958,2 on
-		mixer $card IEC958,3 on
+		mixer_cmds IEC958,2 on
+		mixer_cmds IEC958,3 on
 
 		# ASRock ION 330 has Master Front set to 0
-		mixer $card 'Master Front' 100%
+		mixer_cmds 'Master Front' 100%
 
 		# Shuttle XS35GT needs this too
-		mixer $card 'Master',0 100% on
+		mixer_cmds 'Master',0 100% on
 
 		# and this for various Fusion devices like Zotac ZBOX
-		mixer $card 'Front',0 100% on
+		mixer_cmds 'Front',0 100% on
 
 		# NVidia CK804 sound devices
-		mixer $card 'IEC958 Playback AC97-SPSA' 100%
+		mixer_cmds 'IEC958 Playback AC97-SPSA' 100%
 
 		# Allwinner H3 Analog
-		mixer $card 'Line Out' 0db on
+		mixer_cmds 'Line Out' 0db on
 
 		# Allwinner A20 Analog
-		mixer $card 'Power Amplifier' 0db
-		mixer $card 'Power Amplifier DAC' on
-		mixer $card 'Power Amplifier Mute' on
+		mixer_cmds 'Power Amplifier' 0db
+		mixer_cmds 'Power Amplifier DAC' on
+		mixer_cmds 'Power Amplifier Mute' on
 
 		# Allwinner A64 Analog
-		mixer $card Headphone 0db on
-		mixer $card 'AIF1 Slot 0 Digital DAC' on
+		mixer_cmds Headphone 0db on
+		mixer_cmds 'AIF1 Slot 0 Digital DAC' on
 
 		# Amlogic G12 HDMI to PCM0
-		mixer $card 'FRDDR_A SINK 1 SEL' 'OUT 1'
-		mixer $card 'FRDDR_A SRC 1 EN' on
-		mixer $card 'TDMOUT_B SRC SEL' 'IN 0'
-		mixer $card 'TOHDMITX I2S SRC' 'I2S B'
-		mixer $card 'TOHDMITX' on
+		mixer_cmds 'FRDDR_A SINK 1 SEL' 'OUT 1'
+		mixer_cmds 'FRDDR_A SRC 1 EN' on
+		mixer_cmds 'TDMOUT_B SRC SEL' 'IN 0'
+		mixer_cmds 'TOHDMITX I2S SRC' 'I2S B'
+		mixer_cmds 'TOHDMITX' on
 
 		# Amlogic G12 S/PDIF to PCM1
-		mixer $card 'FRDDR_B SINK 1 SEL' 'OUT 3'
-		mixer $card 'FRDDR_B SRC 1 EN' on
-		mixer $card 'SPDIFOUT SRC SEL' 'IN 1'
-		mixer $card 'SPDIFOUT Playback' on
+		mixer_cmds 'FRDDR_B SINK 1 SEL' 'OUT 3'
+		mixer_cmds 'FRDDR_B SRC 1 EN' on
+		mixer_cmds 'SPDIFOUT SRC SEL' 'IN 1'
+		mixer_cmds 'SPDIFOUT Playback' on
 
 		# Amlogic GX HDMI and S/PDIF
-		mixer $card 'AIU HDMI CTRL SRC' 'I2S'
-		mixer $card 'AIU SPDIF SRC SEL' 'SPDIF'
+		mixer_cmds 'AIU HDMI CTRL SRC' 'I2S'
+		mixer_cmds 'AIU SPDIF SRC SEL' 'SPDIF'
 
 		# RockPI 4B Analog
-		mixer $card 'Right Headphone Mixer Right DAC' on
-		mixer $card 'Left Headphone Mixer Left DAC' on
+		mixer_cmds 'Right Headphone Mixer Right DAC' on
+		mixer_cmds 'Left Headphone Mixer Left DAC' on
 
 		# NanoPC T4 Analog
-		mixer $card 'HPO L' on
-		mixer $card 'HPO R' on
-		mixer $card 'HPOVOL L' on
-		mixer $card 'HPOVOL R' on
-		mixer $card 'HPO MIX HPVOL' on
-		mixer $card 'OUT MIXL DAC L1' on
-		mixer $card 'OUT MIXR DAC R1' on
-		mixer $card 'Stereo DAC MIXL DAC L1' on
-		mixer $card 'Stereo DAC MIXR DAC R1' on
-	done
+		mixer_cmds 'HPO L' on
+		mixer_cmds 'HPO R' on
+		mixer_cmds 'HPOVOL L' on
+		mixer_cmds 'HPOVOL R' on
+		mixer_cmds 'HPO MIX HPVOL' on
+		mixer_cmds 'OUT MIXL DAC L1' on
+		mixer_cmds 'OUT MIXR DAC R1' on
+		mixer_cmds 'Stereo DAC MIXL DAC L1' on
+		mixer_cmds 'Stereo DAC MIXR DAC R1' on
+	) | amixer -c "$card" --stdin > /dev/null 2>&1; done
 fi


### PR DESCRIPTION
# Description
This script calls amixer to set various mixer volumes, by simply trying a bunch of mixer names for each sound card in the system. In practice, this meant the amixer command was called 158 times for each sound card. The overhead of all these forks and probably also amixer startup added together to produce a noticable slowdown in startup.

For example on an Orange Pi PC, the script took about 6 seconds per soundcard. This was on a system with a few extra USB soundcards (6 alsa cards in total):

    $ time bash ./armbian-audio-config.original

     real    0m35.662s
     user    0m20.145s
     sys     0m15.145s

This commit modifies the script to spawn amixer only once per alsa card, passing all the mixer set commands through stdin. This pretty much completely kills the slowdown. On the same 6-card system:

    $ time bash ./armbian-audio-config

    real    0m0.406s
    user    0m0.345s
    sys     0m0.229s

# How Has This Been Tested?

Copied the script onto an existing system and running it manually. Changed some mixer controls with alsamixer, ran the script an confirmed they were changed back to 100%.

Have not tested a full image build, but I cannot see how this would not work.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~ - N/A
- [ ] ~~I have made corresponding changes to the documentation~~ - N/A
- [X] My changes generate no new warnings
- [ ] ~~Any dependent changes have been merged and published in downstream modules~~ - N/A