### PR TITLE
`meson64`: bump `edge` to `6.1-rc8`

### DIFF
--- a/config/sources/families/include/meson64_common.inc
+++ b/config/sources/families/include/meson64_common.inc
@@ -24,12 +24,12 @@ GOVERNOR=${GOVERNOR:-ondemand}
 case $BRANCH in
 
 	current)
-		KERNELBRANCH='branch:linux-5.19.y'
+		KERNELBRANCH='branch:linux-6.0.y'
 		KERNELPATCHDIR='meson64-current'
 		;;
 
 	edge)
-		KERNELBRANCH='branch:linux-6.0.y'
+		KERNELBRANCH='tag:v6.1-rc8'     # @TODO: Soon to be KERNELBRANCH='branch:linux-6.1.y'
 		KERNELPATCHDIR='meson64-edge'
 		;;
 

--- a/patch/kernel/archive/meson64-6.1/add-board-radxa-zero2.patch
+++ b/patch/kernel/archive/meson64-6.1/add-board-radxa-zero2.patch
@@ -1,0 +1,652 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Christian Hewitt <christianshewitt@gmail.com>
+Date: Wed, 16 Feb 2022 07:27:07 +0000
+Subject: dt-bindings: arm: amlogic: add support for Radxa Zero2
+
+The Radxa Zero2 is a small form-factor SBC using the Amlogic
+A311D chip.
+
+Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
+Signed-off-by: Yuntian Zhang <yt@radxa.com>
+---
+ Documentation/devicetree/bindings/arm/amlogic.yaml | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Documentation/devicetree/bindings/arm/amlogic.yaml b/Documentation/devicetree/bindings/arm/amlogic.yaml
+index 9fda2436c618..cf81dc06df2e 100644
+--- a/Documentation/devicetree/bindings/arm/amlogic.yaml
++++ b/Documentation/devicetree/bindings/arm/amlogic.yaml
+@@ -154,6 +154,7 @@ properties:
+         items:
+           - enum:
+               - khadas,vim3
++              - radxa,zero2
+           - const: amlogic,a311d
+           - const: amlogic,g12b
+ 
+-- 
+Armbian
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yuntian Zhang <yt@radxa.com>
+Date: Fri, 14 Jan 2022 15:50:02 +0000
+Subject: arm64: dts: meson: add support for Radxa Zero2
+
+Radxa Zero2 is a small form factor SBC based on the Amlogic A311D
+chipset that ships in a number of eMMC configurations:
+
+- Amlogic A311D (Quad A73 + Dual A53) CPU
+- 4GB LPDDR4 RAM
+- 32/64/128GB eMMC
+- Mali G52-MP4 GPU
+- HDMI 2.1 output (micro)
+- BCM4345 WiFi (2.4/5GHz a/b/g/n/ac) and BT 5.0
+- 1x USB 2.0 port - Type C (OTG)
+- 1x USB 3.0 port - Type C (Host)
+- 1x micro SD Card slot
+- 40 Pin GPIO header
+
+Signed-off-by: Yuntian Zhang <yt@radxa.com>
+Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
+---
+ arch/arm64/boot/dts/amlogic/Makefile                   |   1 +
+ arch/arm64/boot/dts/amlogic/meson-g12b-radxa-zero2.dts | 576 ++++++++++
+ 2 files changed, 577 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/Makefile b/arch/arm64/boot/dts/amlogic/Makefile
+index e213aeebb774..4aa1aa0e22a8 100644
+--- a/arch/arm64/boot/dts/amlogic/Makefile
++++ b/arch/arm64/boot/dts/amlogic/Makefile
+@@ -14,6 +14,7 @@ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-gtking-pro.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-gtking.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-odroid-n2-plus.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-odroid-n2.dtb
++dtb-$(CONFIG_ARCH_MESON) += meson-g12b-radxa-zero2.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-s922x-khadas-vim3.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-ugoos-am6.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-gxbb-kii-pro.dtb
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-radxa-zero2.dts b/arch/arm64/boot/dts/amlogic/meson-g12b-radxa-zero2.dts
+new file mode 100644
+index 000000000000..e261ba2a4b47
+--- /dev/null
++++ b/arch/arm64/boot/dts/amlogic/meson-g12b-radxa-zero2.dts
+@@ -0,0 +1,576 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2019 BayLibre, SAS
++ * Author: Neil Armstrong <narmstrong@baylibre.com>
++ * Copyright (c) 2019 Christian Hewitt <christianshewitt@gmail.com>
++ * Copyright (c) 2022 Radxa Limited
++ * Author: Yuntian Zhang <yt@radxa.com>
++ */
++
++/dts-v1/;
++
++#include "meson-g12b-a311d.dtsi"
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/leds/common.h>
++#include <dt-bindings/gpio/meson-g12a-gpio.h>
++#include <dt-bindings/sound/meson-g12a-tohdmitx.h>
++
++/ {
++	compatible = "radxa,zero2", "amlogic,a311d", "amlogic,g12b";
++	model = "Radxa Zero 2";
++
++	aliases {
++		serial0 = &uart_AO;
++		serial2 = &uart_A;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++   fan0: pwm-fan {
++		compatible = "pwm-fan";
++		#cooling-cells = <2>;
++		cooling-levels = <0 64 128 192 255>;
++		pwms = <&pwm_AO_ab 0 40000 0>;
++	};
++
++	memory@0 {
++		device_type = "memory";
++		reg = <0x0 0x0 0x0 0x80000000>;
++	};
++
++	gpio-keys-polled {
++		compatible = "gpio-keys-polled";
++		poll-interval = <100>;
++		power-button {
++			label = "power";
++			linux,code = <KEY_POWER>;
++			gpios = <&gpio_ao GPIOAO_3 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led-green {
++			color = <LED_COLOR_ID_GREEN>;
++			function = LED_FUNCTION_STATUS;
++			gpios = <&gpio GPIOA_12 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "heartbeat";
++		};
++	};
++
++	cvbs-connector {
++		status = "disabled";
++		compatible = "composite-video-connector";
++
++		port {
++			cvbs_connector_in: endpoint {
++				remote-endpoint = <&cvbs_vdac_out>;
++			};
++		};
++	};
++
++	hdmi-connector {
++		compatible = "hdmi-connector";
++		type = "a";
++
++		port {
++			hdmi_connector_in: endpoint {
++				remote-endpoint = <&hdmi_tx_tmds_out>;
++			};
++		};
++	};
++
++	emmc_pwrseq: emmc-pwrseq {
++		compatible = "mmc-pwrseq-emmc";
++		reset-gpios = <&gpio BOOT_12 GPIO_ACTIVE_LOW>;
++	};
++
++	sdio_pwrseq: sdio-pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		reset-gpios = <&gpio GPIOX_6 GPIO_ACTIVE_LOW>;
++		clocks = <&wifi32k>;
++		clock-names = "ext_clock";
++	};
++
++	typec2_vbus: regulator-typec2_vbus {
++		compatible = "regulator-fixed";
++		regulator-name = "TYPEC2_VBUS";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&ao_5v>;
++	};
++
++	ao_5v: regulator-ao_5v {
++		compatible = "regulator-fixed";
++		regulator-name = "AO_5V";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		regulator-always-on;
++	};
++
++	vcc_1v8: regulator-vcc_1v8 {
++		compatible = "regulator-fixed";
++		regulator-name = "VCC_1V8";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vcc_3v3>;
++		regulator-always-on;
++	};
++
++	vcc_3v3: regulator-vcc_3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "VCC_3V3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vddao_3v3>;
++		regulator-always-on;
++		/* FIXME: actually controlled by VDDCPU_B_EN */
++	};
++
++	vddao_1v8: regulator-vddao_1v8 {
++		compatible = "regulator-fixed";
++		regulator-name = "VDDIO_AO1V8";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vddao_3v3>;
++		regulator-always-on;
++	};
++
++	vddao_3v3: regulator-vddao_3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "VDDAO_3V3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&ao_5v>;
++		regulator-always-on;
++	};
++
++	vddcpu_a: regulator-vddcpu-a {
++		/*
++		 * MP8756GD Regulator.
++		 */
++		compatible = "pwm-regulator";
++
++		regulator-name = "VDDCPU_A";
++		regulator-min-microvolt = <730000>;
++		regulator-max-microvolt = <1022000>;
++
++		pwm-supply = <&ao_5v>;
++
++		pwms = <&pwm_ab 0 1250 0>;
++		pwm-dutycycle-range = <100 0>;
++
++		regulator-boot-on;
++		regulator-always-on;
++	};
++
++	vddcpu_b: regulator-vddcpu-b {
++		/*
++		 * Silergy SY8120B1ABC Regulator.
++		 */
++		compatible = "pwm-regulator";
++
++		regulator-name = "VDDCPU_B";
++		regulator-min-microvolt = <730000>;
++		regulator-max-microvolt = <1022000>;
++
++		pwm-supply = <&ao_5v>;
++
++		pwms = <&pwm_AO_cd 1 1250 0>;
++		pwm-dutycycle-range = <100 0>;
++
++		regulator-boot-on;
++		regulator-always-on;
++	};
++
++	sound {
++		compatible = "amlogic,axg-sound-card";
++		model = "RADXA-ZERO2";
++		audio-aux-devs = <&tdmout_b>;
++		audio-routing = "TDMOUT_B IN 0", "FRDDR_A OUT 1",
++				"TDMOUT_B IN 1", "FRDDR_B OUT 1",
++				"TDMOUT_B IN 2", "FRDDR_C OUT 1",
++				"TDM_B Playback", "TDMOUT_B OUT";
++
++		assigned-clocks = <&clkc CLKID_MPLL2>,
++				  <&clkc CLKID_MPLL0>,
++				  <&clkc CLKID_MPLL1>;
++		assigned-clock-parents = <0>, <0>, <0>;
++		assigned-clock-rates = <294912000>,
++				       <270950400>,
++				       <393216000>;
++		status = "okay";
++
++		dai-link-0 {
++			sound-dai = <&frddr_a>;
++		};
++
++		dai-link-1 {
++			sound-dai = <&frddr_b>;
++		};
++
++		dai-link-2 {
++			sound-dai = <&frddr_c>;
++		};
++
++		/* 8ch hdmi interface */
++		dai-link-3 {
++			sound-dai = <&tdmif_b>;
++			dai-format = "i2s";
++			dai-tdm-slot-tx-mask-0 = <1 1>;
++			dai-tdm-slot-tx-mask-1 = <1 1>;
++			dai-tdm-slot-tx-mask-2 = <1 1>;
++			dai-tdm-slot-tx-mask-3 = <1 1>;
++			mclk-fs = <256>;
++
++			codec {
++				sound-dai = <&tohdmitx TOHDMITX_I2S_IN_B>;
++			};
++		};
++
++		/* hdmi glue */
++		dai-link-4 {
++			sound-dai = <&tohdmitx TOHDMITX_I2S_OUT>;
++
++			codec {
++				sound-dai = <&hdmi_tx>;
++			};
++		};
++	};
++
++	wifi32k: wifi32k {
++		compatible = "pwm-clock";
++		#clock-cells = <0>;
++		clock-frequency = <32768>;
++		pwms = <&pwm_ef 0 30518 0>; /* PWM_E at 32.768KHz */
++	};
++};
++
++&periphs_pinctrl {
++	/* Ensure the TYPE C controller irq pin is not driven by the SoC */
++	fusb302_irq_pins: fusb302_irq {
++		mux {
++			groups = "GPIOA_13";
++			function = "gpio_periphs";
++			bias-pull-up;
++			output-disable;
++		};
++	};
++};
++
++&arb {
++	status = "okay";
++};
++
++&cec_AO {
++	pinctrl-0 = <&cec_ao_a_h_pins>;
++	pinctrl-names = "default";
++	status = "disabled";
++	hdmi-phandle = <&hdmi_tx>;
++};
++
++&cecb_AO {
++	pinctrl-0 = <&cec_ao_b_h_pins>;
++	pinctrl-names = "default";
++	status = "okay";
++	hdmi-phandle = <&hdmi_tx>;
++};
++
++&clkc_audio {
++	status = "okay";
++};
++
++&cpu0 {
++	cpu-supply = <&vddcpu_b>;
++	operating-points-v2 = <&cpu_opp_table_0>;
++	clocks = <&clkc CLKID_CPU_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu1 {
++	cpu-supply = <&vddcpu_b>;
++	operating-points-v2 = <&cpu_opp_table_0>;
++	clocks = <&clkc CLKID_CPU_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu100 {
++	cpu-supply = <&vddcpu_a>;
++	operating-points-v2 = <&cpub_opp_table_1>;
++	clocks = <&clkc CLKID_CPUB_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu101 {
++	cpu-supply = <&vddcpu_a>;
++	operating-points-v2 = <&cpub_opp_table_1>;
++	clocks = <&clkc CLKID_CPUB_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu102 {
++	cpu-supply = <&vddcpu_a>;
++	operating-points-v2 = <&cpub_opp_table_1>;
++	clocks = <&clkc CLKID_CPUB_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu103 {
++	cpu-supply = <&vddcpu_a>;
++	operating-points-v2 = <&cpub_opp_table_1>;
++	clocks = <&clkc CLKID_CPUB_CLK>;
++	clock-latency = <50000>;
++};
++
++&cvbs_vdac_port {
++	cvbs_vdac_out: endpoint {
++		remote-endpoint = <&cvbs_connector_in>;
++	};
++};
++
++&frddr_a {
++	status = "okay";
++};
++
++&frddr_b {
++	status = "okay";
++};
++
++&frddr_c {
++	status = "okay";
++};
++
++&gpio {
++	gpio-line-names =
++		/* GPIOZ */
++		"PIN_27", "PIN_28", "PIN_7", "PIN_11", "PIN_13", "PIN_15", "PIN_18", "PIN_40",
++		"PIN_16", "PIN_22", "", "", "", "", "", "",
++		/* GPIOH */
++		"", "", "", "", "PIN_19", "PIN_21", "PIN_24", "PIN_23",
++		"",
++		/* BOOT */
++		"", "", "", "", "", "", "", "",
++		"", "", "", "", "EMMC_PWRSEQ", "", "", "",
++		/* GPIOC */
++		"", "", "", "", "", "", "SD_CD", "TYPEC_MUX",
++		/* GPIOA */
++		"PIN_32", "PIN_12", "PIN_35", "PIN_36", "PIN_31", "PIN_38", "", "",
++		"", "", "", "", "LED_GREEN", "FUSB_IRQ", "PIN_3", "PIN_5",
++		/* GPIOX */
++		"", "", "", "", "", "", "SDIO_PWRSEQ", "",
++		"", "", "", "", "", "", "", "",
++		"", "BT_SHUTDOWN", "", "";
++};
++
++&gpio_ao {
++	gpio-line-names =
++		/* GPIOAO */
++		"PIN_8", "PIN_10", "", "BTN_POWER", "", "", "", "PIN_29",
++		"PIN_33", "PIN_37", "", "FAN",
++		/* GPIOE */
++		"", "", "";
++};
++
++&hdmi_tx {
++	status = "okay";
++	pinctrl-0 = <&hdmitx_hpd_pins>, <&hdmitx_ddc_pins>;
++	pinctrl-names = "default";
++	hdmi-supply = <&ao_5v>;
++};
++
++&hdmi_tx_tmds_port {
++	hdmi_tx_tmds_out: endpoint {
++		remote-endpoint = <&hdmi_connector_in>;
++	};
++};
++
++&cpu_thermal {
++	cooling-maps {
++		map0 {
++			trip = <&cpu_passive>;
++			cooling-device = <&fan0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++		};
++	};
++};
++
++&ddr_thermal {
++	cooling-maps {
++		map0 {
++			trip = <&ddr_passive>;
++			cooling-device = <&fan0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++		};
++	};
++};
++
++&ir {
++	status = "disabled";
++	pinctrl-0 = <&remote_input_ao_pins>;
++	pinctrl-names = "default";
++};
++
++&i2c3 {
++	pinctrl-0 = <&i2c3_sda_a_pins>, <&i2c3_sck_a_pins>;
++	pinctrl-names = "default";
++	status = "okay";
++
++	fusb302@22 {
++		compatible = "fcs,fusb302";
++		reg = <0x22>;
++
++		pinctrl-0 = <&fusb302_irq_pins>;
++		pinctrl-names = "default";
++		interrupt-parent = <&gpio_intc>;
++		interrupts = <74 IRQ_TYPE_LEVEL_LOW>;
++
++		vbus-supply = <&typec2_vbus>;
++
++		status = "okay";
++	};
++};
++
++&pwm_ab {
++	pinctrl-0 = <&pwm_a_e_pins>;
++	pinctrl-names = "default";
++	clocks = <&xtal>;
++	clock-names = "clkin0";
++	status = "okay";
++};
++
++&pwm_ef {
++	pinctrl-0 = <&pwm_e_pins>;
++	pinctrl-names = "default";
++	clocks = <&xtal>;
++	clock-names = "clkin2";
++	status = "okay";
++};
++
++&pwm_AO_ab {
++	pinctrl-0 = <&pwm_ao_a_pins>;
++	pinctrl-names = "default";
++	clocks = <&xtal>;
++	clock-names = "clkin3";
++	status = "okay";
++};
++
++&pwm_AO_cd {
++	pinctrl-0 = <&pwm_ao_d_e_pins>;
++	pinctrl-names = "default";
++	clocks = <&xtal>;
++	clock-names = "clkin4";
++	status = "okay";
++};
++
++&saradc {
++	status = "okay";
++	vref-supply = <&vddao_1v8>;
++};
++
++/* SDIO */
++&sd_emmc_a {
++	status = "okay";
++	pinctrl-0 = <&sdio_pins>;
++	pinctrl-1 = <&sdio_clk_gate_pins>;
++	pinctrl-names = "default", "clk-gate";
++	#address-cells = <1>;
++	#size-cells = <0>;
++
++	bus-width = <4>;
++	cap-sd-highspeed;
++	max-frequency = <80000000>;
++
++	non-removable;
++	disable-wp;
++
++	/* WiFi firmware requires power to be kept while in suspend */
++	keep-power-in-suspend;
++
++	mmc-pwrseq = <&sdio_pwrseq>;
++
++	vmmc-supply = <&vddao_3v3>;
++	vqmmc-supply = <&vddao_1v8>;
++
++	brcmf: wifi@1 {
++		reg = <1>;
++		compatible = "brcm,bcm4329-fmac";
++	};
++};
++
++/* SD card */
++&sd_emmc_b {
++	status = "okay";
++	pinctrl-0 = <&sdcard_c_pins>;
++	pinctrl-1 = <&sdcard_clk_gate_c_pins>;
++	pinctrl-names = "default", "clk-gate";
++
++	bus-width = <4>;
++	cap-sd-highspeed;
++	max-frequency = <50000000>;
++	disable-wp;
++
++	cd-gpios = <&gpio GPIOC_6 GPIO_ACTIVE_LOW>;
++	vmmc-supply = <&vddao_3v3>;
++	vqmmc-supply = <&vddao_3v3>;
++};
++
++/* eMMC */
++&sd_emmc_c {
++	status = "okay";
++	pinctrl-0 = <&emmc_ctrl_pins>, <&emmc_data_8b_pins>, <&emmc_ds_pins>;
++	pinctrl-1 = <&emmc_clk_gate_pins>;
++	pinctrl-names = "default", "clk-gate";
++
++	bus-width = <8>;
++	cap-mmc-highspeed;
++	mmc-ddr-1_8v;
++	mmc-hs200-1_8v;
++	max-frequency = <200000000>;
++	disable-wp;
++
++	mmc-pwrseq = <&emmc_pwrseq>;
++	vmmc-supply = <&vcc_3v3>;
++	vqmmc-supply = <&vcc_1v8>;
++};
++
++&tdmif_b {
++	status = "okay";
++};
++
++&tdmout_b {
++	status = "okay";
++};
++
++&tohdmitx {
++	status = "okay";
++};
++
++&uart_A {
++	status = "okay";
++	pinctrl-0 = <&uart_a_pins>, <&uart_a_cts_rts_pins>;
++	pinctrl-names = "default";
++	uart-has-rtscts;
++
++	bluetooth {
++		compatible = "brcm,bcm43438-bt";
++		shutdown-gpios = <&gpio GPIOX_17 GPIO_ACTIVE_HIGH>;
++		max-speed = <2000000>;
++		clocks = <&wifi32k>;
++		clock-names = "lpo";
++	};
++};
++
++&uart_AO {
++	status = "okay";
++	pinctrl-0 = <&uart_ao_a_pins>;
++	pinctrl-names = "default";
++};
++
++&usb {
++	status = "okay";
++};
++
++&usb3_pcie_phy {
++	phy-supply = <&typec2_vbus>;
++};
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/board-khadas-vim2-use-gpio-fan-matrix-instead-of-array.patch
+++ b/patch/kernel/archive/meson64-6.1/board-khadas-vim2-use-gpio-fan-matrix-instead-of-array.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: David Heidelberg <david@ixit.cz>
+Date: Sat, 27 Nov 2021 07:23:35 +0000
+Subject: arm64: dts: meson: make dts use gpio-fan matrix instead of array
+
+No functional changes.
+
+Adjust to comply with dt-schema requirements
+and make possible to validate values.
+
+Signed-off-by: David Heidelberg <david@ixit.cz>
+---
+ arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts b/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts
+index f43c45daf7eb..a24102e3d369 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts
+@@ -52,10 +52,11 @@ gpio_fan: gpio-fan {
+ 		gpios = <&gpio GPIODV_14 GPIO_ACTIVE_HIGH
+ 			 &gpio GPIODV_15 GPIO_ACTIVE_HIGH>;
+ 		/* Dummy RPM values since fan is optional */
+-		gpio-fan,speed-map = <0 0
+-				      1 1
+-				      2 2
+-				      3 3>;
++		gpio-fan,speed-map =
++				<0 0>,
++				<1 1>,
++				<2 2>,
++				<3 3>;
+ 		#cooling-cells = <2>;
+ 	};
+ 
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/board-khadas-vim3-fix-missing-i2c3-nod.patch
+++ b/patch/kernel/archive/meson64-6.1/board-khadas-vim3-fix-missing-i2c3-nod.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Christian Hewitt <christianshewitt@gmail.com>
+Date: Fri, 21 Feb 2020 04:43:22 +0000
+Subject: WIP: arm64: dts: meson: khadas-vim3: fix missing i2c3 node
+
+Fixes: c6d29c66e582 ("arm64: dts: meson-g12b-khadas-vim3: add initial device-tree")
+
+The i2c3 node was missed in the original device-tree and is required for the
+optional Khadas 3705 fan to work.
+
+Suggested-by: Art Nikpal <email2tema@gmail.com>
+Signed-off-by: Christian Hewittt <christianshewitt@gmail.com>
+---
+ arch/arm64/boot/dts/amlogic/meson-khadas-vim3.dtsi | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-khadas-vim3.dtsi b/arch/arm64/boot/dts/amlogic/meson-khadas-vim3.dtsi
+index c9705941e4ab..71a5c0aa2a9b 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-khadas-vim3.dtsi
++++ b/arch/arm64/boot/dts/amlogic/meson-khadas-vim3.dtsi
+@@ -333,6 +333,13 @@ hdmi_tx_tmds_out: endpoint {
+ 	};
+ };
+ 
++&i2c3 {
++	clock-frequency = <100000>;
++	pinctrl-0 = <&i2c3_sda_a_pins>, <&i2c3_sck_a_pins>;
++	pinctrl-names = "default";
++	status = "okay";
++};
++
+ &i2c_AO {
+ 	status = "okay";
+ 	pinctrl-0 = <&i2c_ao_sck_pins>, <&i2c_ao_sda_pins>;
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/board-khadas-vims-add-rtc-vrtc-aliases.patch
+++ b/patch/kernel/archive/meson64-6.1/board-khadas-vims-add-rtc-vrtc-aliases.patch
@@ -1,0 +1,58 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Christian Hewitt <christianshewitt@gmail.com>
+Date: Thu, 21 Jan 2021 01:35:36 +0000
+Subject: HACK: arm64: dts: meson: add rtc/vrtc aliases to Khadas VIM
+
+Add aliases to ensure the vrtc time (which normally proves first) is /dev/rtc1
+while the onboard rtc chip claims /dev/rtc0.
+
+Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
+---
+ arch/arm64/boot/dts/amlogic/meson-gxl-s905x-khadas-vim.dts | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-gxl-s905x-khadas-vim.dts b/arch/arm64/boot/dts/amlogic/meson-gxl-s905x-khadas-vim.dts
+index 6ab1cc125b96..24af15e18026 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-gxl-s905x-khadas-vim.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-gxl-s905x-khadas-vim.dts
+@@ -29,6 +29,8 @@ button-function {
+ 	aliases {
+ 		serial2 = &uart_AO_B;
+ 		ethernet0 = &ethmac;
++		rtc0 = &rtc;
++		rtc1 = &vrtc;
+ 	};
+ 
+ 	gpio-keys-polled {
+-- 
+Armbian
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Christian Hewitt <christianshewitt@gmail.com>
+Date: Sat, 6 Nov 2021 13:01:08 +0000
+Subject: HACK: arm64: dts: meson: add rtc/vrtc aliases to Khadas VIM2
+
+Add aliases to ensure the vrtc time (which normally proves first) is /dev/rtc1
+while the onboard rtc chip claims /dev/rtc0.
+
+Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
+---
+ arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts b/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts
+index a24102e3d369..9b0c7e9d0620 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts
+@@ -18,6 +18,8 @@ / {
+ 	aliases {
+ 		serial0 = &uart_AO;
+ 		serial2 = &uart_AO_B;
++		rtc0 = &rtc;
++		rtc1 = &vrtc;
+ 	};
+ 
+ 	chosen {
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/board-nanopi-k2-add-uartC-alias.patch
+++ b/patch/kernel/archive/meson64-6.1/board-nanopi-k2-add-uartC-alias.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Martin Ayotte <martinayotte@yahoo.ca>
+Date: Thu, 6 Dec 2018 18:03:17 -0500
+Subject: add uartC alias for nanopi-k2
+
+add uartC alias for nanopi-k2
+- 839f2f151073928ed1e62d415ba5317f525b9e24: 1553615840: Martin Ayotte <martinayotte@yahoo.ca>: 'add uartA overlay for Odroid-C2'
+---
+ arch/arm64/boot/dts/amlogic/meson-gxbb-nanopi-k2.dts | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-gxbb-nanopi-k2.dts b/arch/arm64/boot/dts/amlogic/meson-gxbb-nanopi-k2.dts
+index 7d94160f5802..cf577bc8d98b 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-gxbb-nanopi-k2.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-gxbb-nanopi-k2.dts
+@@ -15,6 +15,7 @@ / {
+ 
+ 	aliases {
+ 		serial0 = &uart_AO;
++		serial2 = &uart_C;
+ 		ethernet0 = &ethmac;
+ 	};
+ 
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/board-nanopi-k2-enable-emmc.patch
+++ b/patch/kernel/archive/meson64-6.1/board-nanopi-k2-enable-emmc.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor.pecovnik@gmail.com>
+Date: Tue, 4 Jun 2019 21:35:48 +0200
+Subject: nanopik2 - enable eMMC
+
+[ nanopik2 ] enable eMMC support for u-boot and kernel
+---
+ arch/arm64/boot/dts/amlogic/meson-gxbb-nanopi-k2.dts | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-gxbb-nanopi-k2.dts b/arch/arm64/boot/dts/amlogic/meson-gxbb-nanopi-k2.dts
+index cf577bc8d98b..2ee48261a2ea 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-gxbb-nanopi-k2.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-gxbb-nanopi-k2.dts
+@@ -359,7 +359,7 @@ &sd_emmc_b {
+ 
+ /* eMMC */
+ &sd_emmc_c {
+-	status = "disabled";
++	status = "okay";
+ 	pinctrl-0 = <&emmc_pins>, <&emmc_ds_pins>;
+ 	pinctrl-1 = <&emmc_clk_gate_pins>;
+ 	pinctrl-names = "default", "clk-gate";
+@@ -369,8 +369,6 @@ &sd_emmc_c {
+ 	non-removable;
+ 	disable-wp;
+ 	cap-mmc-highspeed;
+-	mmc-ddr-1_8v;
+-	mmc-hs200-1_8v;
+ 
+ 	mmc-pwrseq = <&emmc_pwrseq>;
+ 	vmmc-supply = <&vcc3v3>;
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/board-odroidc2-add-uartA-uartC.patch
+++ b/patch/kernel/archive/meson64-6.1/board-odroidc2-add-uartA-uartC.patch
@@ -1,0 +1,50 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Martin Ayotte <martinayotte@yahoo.ca>
+Date: Thu, 26 Oct 2017 16:31:22 +0300
+Subject: add uartA and uartC for Odroid-C2
+
+add uartA and uartC for Odroid-C2
+
+- 839f2f151073928ed1e62d415ba5317f525b9e24: Martin Ayotte <martinayotte@yahoo.ca>: 'add uartA overlay for Odroid-C2'
+- b5c9e6ee8d4a97c5092109a12164c131eb4b46e9: Martin Ayotte <martinayotte@yahoo.ca>: 'add uartA for odroidc2 in NEXT'
+- 22ca2b92a002fe22e2a61428741618295c424664: Martin Ayotte <martinayotte@yahoo.ca>: 'fix missing pinctrl-0 for ODroidC2 uartA'
+- 140da6ad43f4a0d47c221271f62bb7c0a57064ea: Martin Ayotte <martinayotte@yahoo.ca>: 'add uartC to OdroidC2'
+---
+ arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts | 14 ++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts b/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts
+index 201596247fd9..b2cb12fb46fd 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts
+@@ -17,6 +17,8 @@ / {
+ 
+ 	aliases {
+ 		serial0 = &uart_AO;
++		serial1 = &uart_A;
++		serial2 = &uart_C;
+ 		ethernet0 = &ethmac;
+ 	};
+ 
+@@ -399,6 +401,18 @@ &uart_AO {
+ 	pinctrl-names = "default";
+ };
+ 
++&uart_A {
++	status = "disabled";
++	pinctrl-0 = <&uart_a_pins>;
++	pinctrl-names = "default";
++};
++
++&uart_C {
++	status = "disabled";
++	pinctrl-0 = <&uart_c_pins>;
++	pinctrl-names = "default";
++};
++
+ &usb0_phy {
+ 	status = "disabled";
+ 	phy-supply = <&usb_otg_pwr>;
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/board-odroidc2-enable-SPI.patch
+++ b/patch/kernel/archive/meson64-6.1/board-odroidc2-enable-SPI.patch
@@ -1,0 +1,52 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Thomas McKahan <tonymckahan@gmail.com>
+Date: Sat, 6 Oct 2018 22:50:14 -0400
+Subject: Odroid C2 enable SPI
+
+Odroid C2 enable SPI
+
+- f928b31d8a1983fd8cfd9c97de084e532283b106: 1543550719: Thomas McKahan <tonymckahan@gmail.com>: '[ meson64-dev ] fix Odroid C2 boot, add spidev'
+---
+ arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts | 26 ++++++++++
+ 1 file changed, 26 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts b/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts
+index b2cb12fb46fd..c252de8e4b17 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts
+@@ -176,6 +176,32 @@ hdmi_connector_in: endpoint {
+ 		};
+ 	};
+ 
++	spi-gpio {
++		compatible = "spi-gpio";
++		#address-cells = <0x1>;
++		#size-cells = <0x0>;
++		ranges;
++		status = "disabled";
++		sck-gpios  = <&gpio GPIOX_2 0>;
++		miso-gpios = <&gpio GPIOX_4 0>;
++		mosi-gpios = <&gpio GPIOX_7 0>;
++		cs-gpios  = <&gpio GPIOX_3 0
++			     &gpio GPIOX_1 0>;
++		num-chipselects = <2>;
++
++		/* clients */
++		spidev0@0 {
++			compatible = "spidev";
++			reg = <0>;
++			spi-max-frequency = <500000>;
++		};
++		spidev0@1 {
++			compatible = "spidev";
++			reg = <1>;
++			spi-max-frequency = <500000>;
++		};
++	};
++
+ 	sound {
+ 		compatible = "amlogic,gx-sound-card";
+ 		model = "ODROID-C2";
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/board-odroidc2-enable-scpi-dvfs.patch
+++ b/patch/kernel/archive/meson64-6.1/board-odroidc2-enable-scpi-dvfs.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zador-blood-stained <zador-blood-stained@users.noreply.github.com>
+Date: Thu, 26 Oct 2017 16:31:22 +0300
+Subject: Enable odroidc2-dev DVFS
+
+Enable odroidc2-dev DVFS (#763)
+---
+ arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts b/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts
+index c252de8e4b17..7af088c7366d 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts
+@@ -376,7 +376,8 @@ &saradc {
+ };
+ 
+ &scpi_clocks {
+-	status = "disabled";
++	/* Works only with new blobs that have limited DVFS table */
++	status = "okay";
+ };
+ 
+ /* SD */
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/board-odroidhc4-enable-fan1_input.patch
+++ b/patch/kernel/archive/meson64-6.1/board-odroidhc4-enable-fan1_input.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ricardo Pardini <ricardo@pardini.net>
+Date: Sun, 26 Jun 2022 03:47:06 +0200
+Subject: ODROID-HC4: add DT attributes to enable fan1_input
+
+- from vendor kernel modified DT
+- this allows userspace fancontrol/pwmconfig to work
+---
+ arch/arm64/boot/dts/amlogic/meson-sm1-odroid-hc4.dts | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-hc4.dts b/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-hc4.dts
+index e3486f60645a..89ef6f07603c 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-hc4.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-hc4.dts
+@@ -23,6 +23,10 @@ fan0: pwm-fan {
+ 		cooling-max-state = <3>;
+ 		cooling-levels = <0 120 170 220>;
+ 		pwms = <&pwm_cd 1 40000 0>;
++		fan-supply = <&vcc_5v>;
++		interrupt-parent = <&gpio_intc>;
++		interrupts = <84 IRQ_TYPE_EDGE_FALLING>;
++		pulses-per-revolutions = <2>;
+ 	};
+ 
+ 	leds {
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/board-odroidn2-add-dumb-gpio-fan.patch
+++ b/patch/kernel/archive/meson64-6.1/board-odroidn2-add-dumb-gpio-fan.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Stefan Agner <stefan@agner.ch>
+Date: Mon, 11 Jan 2021 11:38:54 +0100
+Subject: arm64: dts: meson: g12b: add GPIO fan support
+
+Add simple GPIO fan node to support a fan on GPIO J8. Unfortunately the
+pad used to control the fan does not support real PWM, hence the RPM
+cannot be modulated.
+
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+Tested-by: Ricardo Pardini <ricardo@pardini.net>
+---
+ arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dtsi | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dtsi b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dtsi
+index fd3fa82e4c33..1365f2767855 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dtsi
++++ b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dtsi
+@@ -39,6 +39,15 @@ emmc_pwrseq: emmc-pwrseq {
+ 		reset-gpios = <&gpio BOOT_12 GPIO_ACTIVE_LOW>;
+ 	};
+ 
++	/* 5V 80x80x10.8mm cooling fan from Hardkernel shop... */
++	fan0: gpio-fan {
++		#cooling-cells = <2>;
++		compatible = "gpio-fan";
++		gpio-fan,speed-map = <0 0 1600 1>;
++		gpios = <&gpio_ao GPIOAO_10 GPIO_ACTIVE_HIGH>;
++		status = "okay";
++	};
++
+ 	leds {
+ 		compatible = "gpio-leds";
+ 
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/board-odroidn2-add-gpio-fan-as-cooling-device.patch
+++ b/patch/kernel/archive/meson64-6.1/board-odroidn2-add-gpio-fan-as-cooling-device.patch
@@ -1,0 +1,66 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Stefan Agner <stefan@agner.ch>
+Date: Mon, 11 Jan 2021 15:53:55 +0100
+Subject: arm64: dts: meson: g12b: odroid-n2: add fan as cooling device
+
+Add the GPIO fan as a cooling device for the CPU thermal zone. Since we
+have only full fan speed available with this, set the tripping point to
+30 degrees Celsius.
+
+Signed-off-by: Stefan Agner <stefan@agner.ch>
+---
+ arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dtsi | 38 ++++++++++
+ 1 file changed, 38 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dtsi b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dtsi
+index 1365f2767855..33323f119406 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dtsi
++++ b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2.dtsi
+@@ -377,6 +377,44 @@ &clkc_audio {
+ 	status = "okay";
+ };
+ 
++&cpu_thermal {
++	trips {
++		cpu_warm: cpu_warm {
++			hysteresis = <5000>;
++			temperature = <30000>;
++			type = "active";
++		};
++	};
++
++	cooling-maps {
++		map0 {
++			cooling-device =
++				<&fan0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++			trip = <&cpu_warm>;
++		};
++		map1 {
++			trip = <&cpu_passive>;
++			cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++					 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++					 <&cpu100 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++					 <&cpu101 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++					 <&cpu102 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++					 <&cpu103 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++					 <&fan0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++		};
++		map2 {
++			trip = <&cpu_hot>;
++			cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++					 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++					 <&cpu100 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++					 <&cpu101 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++					 <&cpu102 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++					 <&cpu103 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++					 <&fan0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++		};
++	};
++};
++
+ &cpu0 {
+ 	cpu-supply = <&vddcpu_b>;
+ 	operating-points-v2 = <&cpu_opp_table_0>;
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/board-odroidn2-add-spi-flash-enabled-dts.patch
+++ b/patch/kernel/archive/meson64-6.1/board-odroidn2-add-spi-flash-enabled-dts.patch
@@ -1,0 +1,85 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ricardo Pardini <ricardo@pardini.net>
+Date: Thu, 2 Sep 2021 20:44:19 +0200
+Subject: ODROID N2(+): SPI-NOR enable via extra DTBs
+
+Kernel DTS patch to add SPI-flash-enabled DTBs (slower eMMC), produces -spi .dtbs for n2 and n2-plus
+
+Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
+---
+ arch/arm64/boot/dts/amlogic/Makefile                             |  2 ++
+ arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-enable-spi.dtsi | 13 ++++++++++
+ arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-plus-spi.dts    | 11 ++++++++
+ arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-spi.dts         | 11 ++++++++
+ 4 files changed, 37 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/Makefile b/arch/arm64/boot/dts/amlogic/Makefile
+index 4aa1aa0e22a8..a3be04fd53d3 100644
+--- a/arch/arm64/boot/dts/amlogic/Makefile
++++ b/arch/arm64/boot/dts/amlogic/Makefile
+@@ -12,7 +12,9 @@ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-a311d-khadas-vim3.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-gsking-x.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-gtking-pro.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-gtking.dtb
++dtb-$(CONFIG_ARCH_MESON) += meson-g12b-odroid-n2-spi.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-odroid-n2-plus.dtb
++dtb-$(CONFIG_ARCH_MESON) += meson-g12b-odroid-n2-plus-spi.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-odroid-n2.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-radxa-zero2.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-s922x-khadas-vim3.dtb
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-enable-spi.dtsi b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-enable-spi.dtsi
+new file mode 100644
+index 000000000000..a6f11e8cdfbe
+--- /dev/null
++++ b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-enable-spi.dtsi
+@@ -0,0 +1,13 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++
++/*
++ * Replace emmc_data_8b_pins to emmc_data_4b_pins from sd_emmc_c pinctrl-0, and change bus-width to 4 then spifc can be enabled.
++ */
++&sd_emmc_c {
++	pinctrl-0 = <&emmc_ctrl_pins>, <&emmc_data_4b_pins>, <&emmc_ds_pins>;
++	bus-width = <4>;
++};
++
++&spifc {
++	status = "okay";
++};
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-plus-spi.dts b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-plus-spi.dts
+new file mode 100644
+index 000000000000..f50f6f39a941
+--- /dev/null
++++ b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-plus-spi.dts
+@@ -0,0 +1,11 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++
++/dts-v1/;
++
++#include "meson-g12b-odroid-n2-plus.dts"
++
++/ {
++	model = "Hardkernel ODROID-N2Plus with SPI";
++};
++
++#include "meson-g12b-odroid-n2-enable-spi.dtsi"
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-spi.dts b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-spi.dts
+new file mode 100644
+index 000000000000..3d85c25d5fc4
+--- /dev/null
++++ b/arch/arm64/boot/dts/amlogic/meson-g12b-odroid-n2-spi.dts
+@@ -0,0 +1,11 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++
++/dts-v1/;
++
++#include "meson-g12b-odroid-n2.dts"
++
++/ {
++	model = "Hardkernel ODROID-N2 with SPI";
++};
++
++#include "meson-g12b-odroid-n2-enable-spi.dtsi"
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/board-odroidn2plus-Add-missing-CPU-opp.patch
+++ b/patch/kernel/archive/meson64-6.1/board-odroidn2plus-Add-missing-CPU-opp.patch
@@ -1,0 +1,46 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor.pecovnik@gmail.com>
+Date: Wed, 10 Feb 2021 18:07:08 +0100
+Subject: Add missing CPU opp values for clocking g12b / N2+ higher
+
+Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
+---
+ arch/arm64/boot/dts/amlogic/meson-g12b-a311d.dtsi | 16 ++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-a311d.dtsi b/arch/arm64/boot/dts/amlogic/meson-g12b-a311d.dtsi
+index 8e9ad1e51d66..adc4cca55d7d 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-g12b-a311d.dtsi
++++ b/arch/arm64/boot/dts/amlogic/meson-g12b-a311d.dtsi
+@@ -45,6 +45,14 @@ opp-1800000000 {
+ 			opp-hz = /bits/ 64 <1800000000>;
+ 			opp-microvolt = <1001000>;
+ 		};
++		opp-1908000000 {
++			opp-hz = /bits/ 64 <1908000000>;
++			opp-microvolt = <1030000>;
++		};
++		opp-2016000000 {
++			opp-hz = /bits/ 64 <2016000000>;
++			opp-microvolt = <1040000>;
++		};
+ 	};
+ 
+ 	cpub_opp_table_1: opp-table-1 {
+@@ -105,5 +113,13 @@ opp-2208000000 {
+                         opp-hz = /bits/ 64 <2208000000>;
+                         opp-microvolt = <1011000>;
+                 };
++		opp-2304000000 {
++			opp-hz = /bits/ 64 <2304000000>;
++			opp-microvolt = <1030000>;
++		};
++		opp-2400000000 {
++			opp-hz = /bits/ 64 <2400000000>;
++			opp-microvolt = <1040000>;
++		};
+ 	};
+ };
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/board-radxa-zero-dts-add-support-for-the-usb-c-controller.patch
+++ b/patch/kernel/archive/meson64-6.1/board-radxa-zero-dts-add-support-for-the-usb-c-controller.patch
@@ -1,0 +1,104 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Christian Hewitt <christianshewitt@gmail.com>
+Date: Tue, 17 Aug 2021 16:16:43 +0000
+Subject: arm64: dts: meson: radxa-zero: add support for the usb type-c
+ controller
+
+Radxa Zero uses an FUSB302 type-c controller, so lets enable it.
+
+NB: Polarity swapping via GPIO is not implemented in the current driver
+(see drivers/usb/typec/tcpm/fusb302.c) so it is not possible to handle
+GPIOAO_6 for USB3 polarity control.
+
+Includes:
+- arm64: dts: amlogic: fix interrupt storm from fusb302 on Radxa Zero
+  it makes load average >1. use correct pin for interrupt from fusb302.
+
+Signed-off-by: FUKAUMI Naoki <naoki@radxa.com>
+Suggested-by: Neil Armstrong <narmstrong@baylibre.com>
+Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
+Signed-off-by: Yuntian Zhang <yt@radxa.com>
+---
+ arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts | 48 ++++++++++
+ 1 file changed, 48 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
+index e3bb6df42ff3..28eaaa83a00e 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
+@@ -60,6 +60,14 @@ sdio_pwrseq: sdio-pwrseq {
+ 		clock-names = "ext_clock";
+ 	};
+ 
++	typec2_vbus: regulator-typec2_vbus {
++		compatible = "regulator-fixed";
++		regulator-name = "TYPEC2_VBUS";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&ao_5v>;
++	};
++
+ 	ao_5v: regulator-ao_5v {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "AO_5V";
+@@ -191,6 +199,18 @@ wifi32k: wifi32k {
+ 	};
+ };
+ 
++&ao_pinctrl {
++	/* Ensure the TYPE C controller irq pin is not driven by the SoC */
++	fusb302_irq_pins: fusb302_irq {
++		mux {
++			groups = "GPIOAO_5";
++			function = "gpio_aobus";
++			bias-pull-up;
++			output-disable;
++		};
++	};
++};
++
+ &arb {
+ 	status = "okay";
+ };
+@@ -278,6 +298,26 @@ &ir {
+ 	pinctrl-names = "default";
+ };
+ 
++&i2c3 {
++	pinctrl-0 = <&i2c3_sda_a_pins>, <&i2c3_sck_a_pins>;
++	pinctrl-names = "default";
++	status = "okay";
++
++	fusb302@22 {
++		compatible = "fcs,fusb302";
++		reg = <0x22>;
++
++		pinctrl-0 = <&fusb302_irq_pins>;
++		pinctrl-names = "default";
++		interrupt-parent = <&gpio_intc>;
++		interrupts = <5 IRQ_TYPE_LEVEL_LOW>;
++
++		vbus-supply = <&typec2_vbus>;
++
++		status = "okay";
++	};
++};
++
+ &pwm_AO_cd {
+ 	pinctrl-0 = <&pwm_ao_d_e_pins>;
+ 	pinctrl-names = "default";
+@@ -403,3 +443,11 @@ &usb {
+ 	status = "okay";
+ 	dr_mode = "host";
+ };
++
++&usb2_phy0 {
++	phy-supply = <&typec2_vbus>;
++};
++
++&usb3_pcie_phy {
++	phy-supply = <&typec2_vbus>;
++};
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/board-radxa-zero-dts-otg-fix.patch
+++ b/patch/kernel/archive/meson64-6.1/board-radxa-zero-dts-otg-fix.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Stephen <stephen@vamrs.com>
+Date: Thu, 28 Oct 2021 14:26:24 +0800
+Subject: arm64: dts: radxa zero: set dr_mode of usb node to otg
+
+This enables dwc2 otg function.
+
+Signed-off-by: Stephen <stephen@vamrs.com>
+Signed-off-by: Yuntian Zhang <yt@radxa.com>
+---
+ arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
+index dd15c5548993..4e7781f87867 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
+@@ -441,7 +441,6 @@ &uart_AO {
+ 
+ &usb {
+ 	status = "okay";
+-	dr_mode = "host";
+ };
+ 
+ &usb2_phy0 {
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/board-radxa-zero-dts-slow-down-sdio-for-working-wifi.patch
+++ b/patch/kernel/archive/meson64-6.1/board-radxa-zero-dts-slow-down-sdio-for-working-wifi.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yuntian Zhang <yt@radxa.com>
+Date: Mon, 27 Jun 2022 15:06:32 +0800
+Subject: VENDOR: Radxa Zero Wi-Fi fix
+
+Credit: c0rnelius from Armbian
+
+Signed-off-by: Yuntian Zhang <yt@radxa.com>
+---
+ arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
+index 28eaaa83a00e..dd15c5548993 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
+@@ -350,7 +350,7 @@ &sd_emmc_a {
+ 
+ 	bus-width = <4>;
+ 	cap-sd-highspeed;
+-	sd-uhs-sdr50;
++	cap-mmc-highspeed;
+ 	max-frequency = <100000000>;
+ 
+ 	non-removable;
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/drv-spi-spidev-remove-warnings.patch
+++ b/patch/kernel/archive/meson64-6.1/drv-spi-spidev-remove-warnings.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: The-going <48602507+The-going@users.noreply.github.com>
+Date: Wed, 2 Feb 2022 11:56:51 +0300
+Subject: drv:spi:spidev remove warnings
+
+Remove SPIdev warnings
+
+- ca478cc4e563655d99fd3380d3b1217481d6da7e: The-going <48602507+The-going@users.noreply.github.com>: 'Bugfix spidev (#3737)'
+- e7bd9b8f13af9ee054f44a422b2aca19746b9244: Tony <tonymckahan@gmail.com>: 'Add Spidev workarounds and clean patches (WIP) (#3812)'
+---
+ drivers/spi/spidev.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/spi/spidev.c b/drivers/spi/spidev.c
+index b2775d82d2d7..3c65d3d74559 100644
+--- a/drivers/spi/spidev.c
++++ b/drivers/spi/spidev.c
+@@ -683,6 +683,7 @@ static const struct file_operations spidev_fops = {
+ static struct class *spidev_class;
+ 
+ static const struct spi_device_id spidev_spi_ids[] = {
++	{ .name = "spi-dev" },
+ 	{ .name = "dh2228fv" },
+ 	{ .name = "ltc2488" },
+ 	{ .name = "sx1301" },
+@@ -709,6 +710,7 @@ static int spidev_of_check(struct device *dev)
+ }
+ 
+ static const struct of_device_id spidev_dt_ids[] = {
++	{ .compatible = "armbian,spi-dev", .data = &spidev_of_check },
+ 	{ .compatible = "rohm,dh2228fv", .data = &spidev_of_check },
+ 	{ .compatible = "lineartechnology,ltc2488", .data = &spidev_of_check },
+ 	{ .compatible = "semtech,sx1301", .data = &spidev_of_check },
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/general-add-Amlogic-Meson-GX-PM-Suspend.patch
+++ b/patch/kernel/archive/meson64-6.1/general-add-Amlogic-Meson-GX-PM-Suspend.patch
@@ -1,0 +1,134 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Neil Armstrong <narmstrong@baylibre.com>
+Date: Thu, 3 Nov 2016 15:29:23 +0100
+Subject: HACK: arm64: meson: add Amlogic Meson GX PM Suspend
+
+The Amlogic Meson GX SoCs uses a non-standard argument to the
+PSCI CPU_SUSPEND call to enter system suspend.
+
+Implement such call within platform_suspend_ops.
+
+Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>
+---
+ drivers/firmware/meson/Kconfig       |  6 +
+ drivers/firmware/meson/Makefile      |  1 +
+ drivers/firmware/meson/meson_gx_pm.c | 86 ++++++++++
+ 3 files changed, 93 insertions(+)
+
+diff --git a/drivers/firmware/meson/Kconfig b/drivers/firmware/meson/Kconfig
+index f2fdd3756648..d3ead92ac61b 100644
+--- a/drivers/firmware/meson/Kconfig
++++ b/drivers/firmware/meson/Kconfig
+@@ -9,3 +9,9 @@ config MESON_SM
+ 	depends on ARM64_4K_PAGES
+ 	help
+ 	  Say y here to enable the Amlogic secure monitor driver
++
++config MESON_GX_PM
++	bool
++	default ARCH_MESON if ARM64
++	help
++	  Say y here to enable the Amlogic GX SoC Power Management
+diff --git a/drivers/firmware/meson/Makefile b/drivers/firmware/meson/Makefile
+index c6c09483b622..0193cdfee32f 100644
+--- a/drivers/firmware/meson/Makefile
++++ b/drivers/firmware/meson/Makefile
+@@ -1,2 +1,3 @@
+ # SPDX-License-Identifier: GPL-2.0-only
+ obj-$(CONFIG_MESON_SM) +=	meson_sm.o
++obj-$(CONFIG_MESON_GX_PM) +=	meson_gx_pm.o
+diff --git a/drivers/firmware/meson/meson_gx_pm.c b/drivers/firmware/meson/meson_gx_pm.c
+new file mode 100644
+index 000000000000..c104c2e4c77f
+--- /dev/null
++++ b/drivers/firmware/meson/meson_gx_pm.c
+@@ -0,0 +1,86 @@
++/*
++ * Amlogic Meson GX Power Management
++ *
++ * Copyright (c) 2016 Baylibre, SAS.
++ * Author: Neil Armstrong <narmstrong@baylibre.com>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of version 2 of the GNU General Public License as
++ * published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
++ * more details.
++ */
++
++#include <linux/module.h>
++#include <linux/of.h>
++#include <linux/platform_device.h>
++#include <linux/suspend.h>
++#include <linux/arm-smccc.h>
++
++#include <uapi/linux/psci.h>
++
++#include <asm/suspend.h>
++
++/*
++ * The Amlogic GX SoCs uses a special argument value to the
++ * PSCI CPU_SUSPEND method to enter SUSPEND_MEM.
++ */
++
++#define MESON_SUSPEND_PARAM	0x0010000
++#define PSCI_FN_NATIVE(version, name)	PSCI_##version##_FN64_##name
++
++static int meson_gx_suspend_finish(unsigned long arg)
++{
++	struct arm_smccc_res res;
++
++	arm_smccc_smc(PSCI_FN_NATIVE(0_2, CPU_SUSPEND), arg,
++		      virt_to_phys(cpu_resume), 0, 0, 0, 0, 0, &res);
++
++	return res.a0;
++}
++
++static int meson_gx_suspend_enter(suspend_state_t state)
++{
++	switch (state) {
++	case PM_SUSPEND_MEM:
++		return cpu_suspend(MESON_SUSPEND_PARAM,
++				   meson_gx_suspend_finish);
++	}
++
++	return -EINVAL;
++}
++
++static const struct platform_suspend_ops meson_gx_pm_ops = {
++		.enter = meson_gx_suspend_enter,
++		.valid = suspend_valid_only_mem,
++};
++
++static const struct of_device_id meson_gx_pm_match[] = {
++	{ .compatible = "amlogic,meson-gx-pm", },
++	{ /* sentinel */ },
++};
++MODULE_DEVICE_TABLE(of, meson_gx_pm_match);
++
++static int meson_gx_pm_probe(struct platform_device *pdev)
++{
++	suspend_set_ops(&meson_gx_pm_ops);
++
++	return 0;
++}
++
++static struct platform_driver meson_gx_pm_driver = {
++	.probe = meson_gx_pm_probe,
++	.driver = {
++		.name = "meson-gx-pm",
++		.of_match_table = meson_gx_pm_match,
++	},
++};
++
++module_platform_driver(meson_gx_pm_driver);
++
++MODULE_AUTHOR("Neil Armstrong <narmstrong@baylibre.com>");
++MODULE_DESCRIPTION("Amlogic Meson GX PM driver");
++MODULE_LICENSE("GPL v2");
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/general-add-overlay-compilation-support.patch
+++ b/patch/kernel/archive/meson64-6.1/general-add-overlay-compilation-support.patch
@@ -1,0 +1,97 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Martin Ayotte <martinayotte@yahoo.ca>
+Date: Sat, 11 Feb 2017 18:32:53 +0100
+Subject: add overlay-compilation-support to meson64-dev
+
+- 871bed1a24e21952f7aeb1981c26ad5fc573be9d: Martin Ayotte <martinayotte@yahoo.ca>: 'add overlay-compilation-support to meson64-dev'
+---
+ arch/arm/boot/.gitignore |  2 +
+ scripts/Makefile.dtbinst | 14 ++++++-
+ scripts/Makefile.lib     | 20 ++++++++++
+ 3 files changed, 35 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm/boot/.gitignore b/arch/arm/boot/.gitignore
+index 8c759326baf4..e6ce8f6ad4b1 100644
+--- a/arch/arm/boot/.gitignore
++++ b/arch/arm/boot/.gitignore
+@@ -4,3 +4,5 @@ zImage
+ xipImage
+ bootpImage
+ uImage
++*.dtb*
++*.scr
+diff --git a/scripts/Makefile.dtbinst b/scripts/Makefile.dtbinst
+index 190d781e84f4..6540de71182b 100644
+--- a/scripts/Makefile.dtbinst
++++ b/scripts/Makefile.dtbinst
+@@ -18,9 +18,12 @@ include $(srctree)/scripts/Kbuild.include
+ include $(src)/Makefile
+ 
+ dtbs    := $(addprefix $(dst)/, $(dtb-y) $(if $(CONFIG_OF_ALL_DTBS),$(dtb-)))
++dtbos   := $(addprefix $(dst)/, $(dtbo-y))
++scrs    := $(addprefix $(dst)/, $(scr-y))
++readmes := $(addprefix $(dst)/, $(dtbotxt-y))
+ subdirs := $(addprefix $(obj)/, $(subdir-y) $(subdir-m))
+ 
+-__dtbs_install: $(dtbs) $(subdirs)
++__dtbs_install: $(dtbs) $(dtbos) $(scrs) $(readmes) $(subdirs)
+ 	@:
+ 
+ quiet_cmd_dtb_install = INSTALL $@
+@@ -32,6 +35,15 @@ $(dst)/%.dtb: $(obj)/%.dtb
+ $(dst)/%.dtbo: $(obj)/%.dtbo
+ 	$(call cmd,dtb_install)
+ 
++$(dst)/%.dtbo: $(obj)/%.dtbo
++	$(call cmd,dtb_install)
++
++$(dst)/%.scr: $(obj)/%.scr
++	$(call cmd,dtb_install)
++
++$(dst)/README.meson-overlays: $(src)/README.meson-overlays
++	$(call cmd,dtb_install)
++
+ PHONY += $(subdirs)
+ $(subdirs):
+ 	$(Q)$(MAKE) $(dtbinst)=$@ dst=$(patsubst $(obj)/%,$(dst)/%,$@)
+diff --git a/scripts/Makefile.lib b/scripts/Makefile.lib
+index 3aa384cec76b..553018f80d8c 100644
+--- a/scripts/Makefile.lib
++++ b/scripts/Makefile.lib
+@@ -336,6 +336,9 @@ quiet_cmd_gzip = GZIP    $@
+ DTC ?= $(objtree)/scripts/dtc/dtc
+ DTC_FLAGS += -Wno-interrupt_provider
+ 
++# Overlay support
++DTC_FLAGS += -@ -Wno-unit_address_format -Wno-simple_bus_reg
++
+ # Disable noisy checks by default
+ ifeq ($(findstring 1,$(KBUILD_EXTRA_WARN)),)
+ DTC_FLAGS += -Wno-unit_address_vs_reg \
+@@ -408,6 +411,23 @@ $(obj)/%.dtb: $(src)/%.dts $(DTC) $(DT_TMP_SCHEMA) FORCE
+ $(obj)/%.dtbo: $(src)/%.dts $(DTC) FORCE
+ 	$(call if_changed_dep,dtc)
+ 
++quiet_cmd_dtco = DTCO    $@
++cmd_dtco = mkdir -p $(dir ${dtc-tmp}) ; \
++	$(CPP) $(dtc_cpp_flags) -x assembler-with-cpp -o $(dtc-tmp) $< ; \
++	$(DTC) -O dtb -o $@ -b 0 \
++		-i $(dir $<) $(DTC_FLAGS) \
++		-d $(depfile).dtc.tmp $(dtc-tmp) ; \
++	cat $(depfile).pre.tmp $(depfile).dtc.tmp > $(depfile)
++
++$(obj)/%.dtbo: $(src)/%.dts FORCE
++	$(call if_changed_dep,dtco)
++
++quiet_cmd_scr = MKIMAGE $@
++cmd_scr = mkimage -C none -A $(ARCH) -T script -d $< $@
++
++$(obj)/%.scr: $(src)/%.scr-cmd FORCE
++	$(call if_changed,scr)
++
+ dtc-tmp = $(subst $(comma),_,$(dot-target).dts.tmp)
+ 
+ # Bzip2
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/general-drm-dw-hdmi-call-hdmi_set_cts_n-after-clock.patch
+++ b/patch/kernel/archive/meson64-6.1/general-drm-dw-hdmi-call-hdmi_set_cts_n-after-clock.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Mon, 9 Jul 2018 21:25:15 +0200
+Subject: TEMP: drm: dw-hdmi: call hdmi_set_cts_n after clock is enabled
+
+Unknown patch. Archeology:
+- 99f6bef7de297253a659c22d4a35343a209f98b8: Igor Pecovnik <igorpecovnik@users.noreply.github.com>: 'Attach Meson64 CURRENT to 5.6.y and make DEV = CURRENT at this point. (#1956)'
+---
+ drivers/gpu/drm/bridge/synopsys/dw-hdmi.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
+index 40d8ca37f5bc..1ceb18f82f6d 100644
+--- a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
++++ b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
+@@ -782,6 +782,11 @@ static void hdmi_enable_audio_clk(struct dw_hdmi *hdmi, bool enable)
+ 	else
+ 		hdmi->mc_clkdis |= HDMI_MC_CLKDIS_AUDCLK_DISABLE;
+ 	hdmi_writeb(hdmi, hdmi->mc_clkdis, HDMI_MC_CLKDIS);
++
++	if (enable) {
++		hdmi_set_cts_n(hdmi, hdmi->audio_cts, 0);
++		hdmi_set_cts_n(hdmi, hdmi->audio_cts, hdmi->audio_n);
++	}
+ }
+ 
+ static u8 *hdmi_audio_get_eld(struct dw_hdmi *hdmi)
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/general-drm-panfrost-fix-reference-leak.patch
+++ b/patch/kernel/archive/meson64-6.1/general-drm-panfrost-fix-reference-leak.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Qinglang Miao <miaoqinglang@huawei.com>
+Date: Sat, 28 Nov 2020 16:10:04 +0000
+Subject: drm/panfrost: fix reference leak in panfrost_job_hw_submit
+
+pm_runtime_get_sync will increment pm usage counter even it
+failed. Forgetting to putting operation will result in a
+reference leak here.
+
+A new function pm_runtime_resume_and_get is introduced in
+[0] to keep usage counter balanced. So We fix the reference
+leak by replacing it with new funtion.
+
+[0] dd8088d5a896 ("PM: runtime: Add  pm_runtime_resume_and_get to deal with usage counter")
+
+Fixes: f3ba91228e8e ("drm/panfrost: Add initial panfrost driver")
+Reported-by: Hulk Robot <hulkci@huawei.com>
+Signed-off-by: Qinglang Miao <miaoqinglang@huawei.com>
+---
+ drivers/gpu/drm/panfrost/panfrost_job.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/panfrost/panfrost_job.c b/drivers/gpu/drm/panfrost/panfrost_job.c
+index dbc597ab46fb..5be832c6a89d 100644
+--- a/drivers/gpu/drm/panfrost/panfrost_job.c
++++ b/drivers/gpu/drm/panfrost/panfrost_job.c
+@@ -194,7 +194,7 @@ static void panfrost_job_hw_submit(struct panfrost_job *job, int js)
+ 
+ 	panfrost_devfreq_record_busy(&pfdev->pfdevfreq);
+ 
+-	ret = pm_runtime_get_sync(pfdev->dev);
++	ret = pm_runtime_resume_and_get(pfdev->dev);
+ 	if (ret < 0)
+ 		return;
+ 
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/general-fix-Kodi-sysinfo-CPU-information.patch
+++ b/patch/kernel/archive/meson64-6.1/general-fix-Kodi-sysinfo-CPU-information.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Christian Hewitt <christianshewitt@gmail.com>
+Date: Sat, 13 Apr 2019 05:45:18 +0000
+Subject: HACK: arm64: fix Kodi sysinfo CPU information
+
+This allows the CPU information to show in the Kodi sysinfo screen, e.g.
+
+"ARMv8 Processor rev 4 (v81)" on Amlogic devices
+
+Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
+---
+ arch/arm64/kernel/cpuinfo.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/arch/arm64/kernel/cpuinfo.c b/arch/arm64/kernel/cpuinfo.c
+index 28d4f442b0bc..d46cea365be4 100644
+--- a/arch/arm64/kernel/cpuinfo.c
++++ b/arch/arm64/kernel/cpuinfo.c
+@@ -170,8 +170,7 @@ static int c_show(struct seq_file *m, void *v)
+ 		 * "processor".  Give glibc what it expects.
+ 		 */
+ 		seq_printf(m, "processor\t: %d\n", i);
+-		if (compat)
+-			seq_printf(m, "model name\t: ARMv8 Processor rev %d (%s)\n",
++		seq_printf(m, "model name\t: ARMv8 Processor rev %d (%s)\n",
+ 				   MIDR_REVISION(midr), COMPAT_ELF_PLATFORM);
+ 
+ 		seq_printf(m, "BogoMIPS\t: %lu.%02lu\n",
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/general-gpu-drm-add-new-display-resolution-2560x1440.patch
+++ b/patch/kernel/archive/meson64-6.1/general-gpu-drm-add-new-display-resolution-2560x1440.patch
@@ -1,0 +1,76 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dongjin Kim <tobetter@gmail.com>
+Date: Thu, 10 Sep 2020 11:01:33 +0900
+Subject: ODROID-COMMON: gpu/drm: add new display resolution 2560x1440
+
+Signed-off-by: Joy Cho <joy.cho@hardkernel.com>
+Signed-off-by: Dongjin Kim <tobetter@gmail.com>
+---
+ drivers/gpu/drm/meson/meson_vclk.c | 18 ++++++++++
+ drivers/gpu/drm/meson/meson_venc.c |  5 +--
+ 2 files changed, 21 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/meson/meson_vclk.c b/drivers/gpu/drm/meson/meson_vclk.c
+index 2a82119eb58e..eb4c251d79b7 100644
+--- a/drivers/gpu/drm/meson/meson_vclk.c
++++ b/drivers/gpu/drm/meson/meson_vclk.c
+@@ -357,6 +357,8 @@ enum {
+ 	MESON_VCLK_HDMI_594000,
+ /* 2970 /1 /1 /1 /5 /1  => /1 /2 */
+ 	MESON_VCLK_HDMI_594000_YUV420,
++/* 4830 /2 /1 /2 /5 /1  => /1 /1 */
++	MESON_VCLK_HDMI_241500,
+ };
+ 
+ struct meson_vclk_params {
+@@ -467,6 +469,18 @@ struct meson_vclk_params {
+ 		.vid_pll_div = VID_PLL_DIV_5,
+ 		.vclk_div = 1,
+ 	},
++	[MESON_VCLK_HDMI_241500] = {
++		.pll_freq = 4830000,
++		.phy_freq = 2415000,
++		.venc_freq = 241500,
++		.vclk_freq = 241500,
++		.pixel_freq = 241500,
++		.pll_od1 = 2,
++		.pll_od2 = 1,
++		.pll_od3 = 2,
++		.vid_pll_div = VID_PLL_DIV_5,
++		.vclk_div = 1,
++	},
+ 	{ /* sentinel */ },
+ };
+ 
+@@ -873,6 +887,10 @@ static void meson_vclk_set(struct meson_drm *priv, unsigned int pll_base_freq,
+ 			m = 0xf7;
+ 			frac = vic_alternate_clock ? 0x8148 : 0x10000;
+ 			break;
++		case 4830000:
++			m = 0xc9;
++			frac = 0xd560;
++			break;
+ 		}
+ 
+ 		meson_hdmi_pll_set_params(priv, m, frac, od1, od2, od3);
+diff --git a/drivers/gpu/drm/meson/meson_venc.c b/drivers/gpu/drm/meson/meson_venc.c
+index 3c55ed003359..559ab3b5e212 100644
+--- a/drivers/gpu/drm/meson/meson_venc.c
++++ b/drivers/gpu/drm/meson/meson_venc.c
+@@ -866,10 +866,11 @@ meson_venc_hdmi_supported_mode(const struct drm_display_mode *mode)
+ 			    DRM_MODE_FLAG_PVSYNC | DRM_MODE_FLAG_NVSYNC))
+ 		return MODE_BAD;
+ 
+-	if (mode->hdisplay < 640 || mode->hdisplay > 1920)
++	/* support higher resolution than 1920x1080 */
++	if (mode->hdisplay < 640 || mode->hdisplay > 2560)
+ 		return MODE_BAD_HVALUE;
+ 
+-	if (mode->vdisplay < 480 || mode->vdisplay > 1200)
++	if (mode->vdisplay < 480 || mode->vdisplay > 1600)
+ 		return MODE_BAD_VVALUE;
+ 
+ 	return MODE_OK;
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/general-hdmi-codec-reorder-channel-allocation-list.patch
+++ b/patch/kernel/archive/meson64-6.1/general-hdmi-codec-reorder-channel-allocation-list.patch
@@ -1,0 +1,202 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sun, 23 Dec 2018 02:24:38 +0100
+Subject: WIP: ASoC: hdmi-codec: reorder channel allocation list
+
+Wrong channel allocation is selected by hdmi_codec_get_ch_alloc_table_idx().
+
+E.g when ELD reports FL|FR|LFE|FC|RL|RR or FL|FR|LFE|FC|RL|RR|RC|RLC|RRC
+
+ca_id 0x01 with speaker mask FL|FR|LFE gets selected instead of
+ca_id 0x03 with speaker mask FL|FR|LFE|FC for 4 channels
+
+and
+
+ca_id 0x04 with speaker mask FL|FR|RC gets selected instead of
+ca_id 0x0b with speaker mask FL|FR|LFE|FC|RL|RR for 6 channels
+
+Fix this by reorder the channel allocation list with
+most specific speaker mask at the top.
+
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+---
+ sound/soc/codecs/hdmi-codec.c | 140 +++++-----
+ 1 file changed, 77 insertions(+), 63 deletions(-)
+
+diff --git a/sound/soc/codecs/hdmi-codec.c b/sound/soc/codecs/hdmi-codec.c
+index 0b1cdb2d6049..ad05e6517706 100644
+--- a/sound/soc/codecs/hdmi-codec.c
++++ b/sound/soc/codecs/hdmi-codec.c
+@@ -184,84 +184,97 @@ static const struct snd_pcm_chmap_elem hdmi_codec_8ch_chmaps[] = {
+ /*
+  * hdmi_codec_channel_alloc: speaker configuration available for CEA
+  *
+- * This is an ordered list that must match with hdmi_codec_8ch_chmaps struct
++ * This is an ordered list where ca_id must exist in hdmi_codec_8ch_chmaps
+  * The preceding ones have better chances to be selected by
+  * hdmi_codec_get_ch_alloc_table_idx().
+  */
+ static const struct hdmi_codec_cea_spk_alloc hdmi_codec_channel_alloc[] = {
+ 	{ .ca_id = 0x00, .n_ch = 2,
+-	  .mask = FL | FR},
+-	/* 2.1 */
+-	{ .ca_id = 0x01, .n_ch = 4,
+-	  .mask = FL | FR | LFE},
+-	/* Dolby Surround */
++	  .mask = FL | FR },
++	{ .ca_id = 0x03, .n_ch = 4,
++	  .mask = FL | FR | LFE | FC },
+ 	{ .ca_id = 0x02, .n_ch = 4,
+ 	  .mask = FL | FR | FC },
+-	/* surround51 */
++	{ .ca_id = 0x01, .n_ch = 4,
++	  .mask = FL | FR | LFE },
+ 	{ .ca_id = 0x0b, .n_ch = 6,
+-	  .mask = FL | FR | LFE | FC | RL | RR},
+-	/* surround40 */
+-	{ .ca_id = 0x08, .n_ch = 6,
+-	  .mask = FL | FR | RL | RR },
+-	/* surround41 */
+-	{ .ca_id = 0x09, .n_ch = 6,
+-	  .mask = FL | FR | LFE | RL | RR },
+-	/* surround50 */
++	  .mask = FL | FR | LFE | FC | RL | RR },
+ 	{ .ca_id = 0x0a, .n_ch = 6,
+ 	  .mask = FL | FR | FC | RL | RR },
+-	/* 6.1 */
+-	{ .ca_id = 0x0f, .n_ch = 8,
+-	  .mask = FL | FR | LFE | FC | RL | RR | RC },
+-	/* surround71 */
++	{ .ca_id = 0x09, .n_ch = 6,
++	  .mask = FL | FR | LFE | RL | RR },
++	{ .ca_id = 0x08, .n_ch = 6,
++	  .mask = FL | FR | RL | RR },
++	{ .ca_id = 0x07, .n_ch = 6,
++	  .mask = FL | FR | LFE | FC | RC },
++	{ .ca_id = 0x06, .n_ch = 6,
++	  .mask = FL | FR | FC | RC },
++	{ .ca_id = 0x05, .n_ch = 6,
++	  .mask = FL | FR | LFE | RC },
++	{ .ca_id = 0x04, .n_ch = 6,
++	  .mask = FL | FR | RC },
+ 	{ .ca_id = 0x13, .n_ch = 8,
+ 	  .mask = FL | FR | LFE | FC | RL | RR | RLC | RRC },
+-	/* others */
+-	{ .ca_id = 0x03, .n_ch = 8,
+-	  .mask = FL | FR | LFE | FC },
+-	{ .ca_id = 0x04, .n_ch = 8,
+-	  .mask = FL | FR | RC},
+-	{ .ca_id = 0x05, .n_ch = 8,
+-	  .mask = FL | FR | LFE | RC },
+-	{ .ca_id = 0x06, .n_ch = 8,
+-	  .mask = FL | FR | FC | RC },
+-	{ .ca_id = 0x07, .n_ch = 8,
+-	  .mask = FL | FR | LFE | FC | RC },
+-	{ .ca_id = 0x0c, .n_ch = 8,
+-	  .mask = FL | FR | RC | RL | RR },
+-	{ .ca_id = 0x0d, .n_ch = 8,
+-	  .mask = FL | FR | LFE | RL | RR | RC },
+-	{ .ca_id = 0x0e, .n_ch = 8,
+-	  .mask = FL | FR | FC | RL | RR | RC },
+-	{ .ca_id = 0x10, .n_ch = 8,
+-	  .mask = FL | FR | RL | RR | RLC | RRC },
+-	{ .ca_id = 0x11, .n_ch = 8,
+-	  .mask = FL | FR | LFE | RL | RR | RLC | RRC },
++	{ .ca_id = 0x1f, .n_ch = 8,
++	  .mask = FL | FR | LFE | FC | RL | RR | FLC | FRC },
+ 	{ .ca_id = 0x12, .n_ch = 8,
+ 	  .mask = FL | FR | FC | RL | RR | RLC | RRC },
+-	{ .ca_id = 0x14, .n_ch = 8,
+-	  .mask = FL | FR | FLC | FRC },
+-	{ .ca_id = 0x15, .n_ch = 8,
+-	  .mask = FL | FR | LFE | FLC | FRC },
+-	{ .ca_id = 0x16, .n_ch = 8,
+-	  .mask = FL | FR | FC | FLC | FRC },
+-	{ .ca_id = 0x17, .n_ch = 8,
+-	  .mask = FL | FR | LFE | FC | FLC | FRC },
+-	{ .ca_id = 0x18, .n_ch = 8,
+-	  .mask = FL | FR | RC | FLC | FRC },
+-	{ .ca_id = 0x19, .n_ch = 8,
+-	  .mask = FL | FR | LFE | RC | FLC | FRC },
+-	{ .ca_id = 0x1a, .n_ch = 8,
+-	  .mask = FL | FR | RC | FC | FLC | FRC },
+-	{ .ca_id = 0x1b, .n_ch = 8,
+-	  .mask = FL | FR | LFE | RC | FC | FLC | FRC },
+-	{ .ca_id = 0x1c, .n_ch = 8,
+-	  .mask = FL | FR | RL | RR | FLC | FRC },
+-	{ .ca_id = 0x1d, .n_ch = 8,
+-	  .mask = FL | FR | LFE | RL | RR | FLC | FRC },
+ 	{ .ca_id = 0x1e, .n_ch = 8,
+ 	  .mask = FL | FR | FC | RL | RR | FLC | FRC },
+-	{ .ca_id = 0x1f, .n_ch = 8,
+-	  .mask = FL | FR | LFE | FC | RL | RR | FLC | FRC },
++	{ .ca_id = 0x11, .n_ch = 8,
++	  .mask = FL | FR | LFE | RL | RR | RLC | RRC },
++	{ .ca_id = 0x1d, .n_ch = 8,
++	  .mask = FL | FR | LFE | RL | RR | FLC | FRC },
++	{ .ca_id = 0x10, .n_ch = 8,
++	  .mask = FL | FR | RL | RR | RLC | RRC },
++	{ .ca_id = 0x1c, .n_ch = 8,
++	  .mask = FL | FR | RL | RR | FLC | FRC },
++	{ .ca_id = 0x0f, .n_ch = 8,
++	  .mask = FL | FR | LFE | FC | RL | RR | RC },
++	{ .ca_id = 0x1b, .n_ch = 8,
++	  .mask = FL | FR | LFE | RC | FC | FLC | FRC },
++	{ .ca_id = 0x0e, .n_ch = 8,
++	  .mask = FL | FR | FC | RL | RR | RC },
++	{ .ca_id = 0x1a, .n_ch = 8,
++	  .mask = FL | FR | RC | FC | FLC | FRC },
++	{ .ca_id = 0x0d, .n_ch = 8,
++	  .mask = FL | FR | LFE | RL | RR | RC },
++	{ .ca_id = 0x19, .n_ch = 8,
++	  .mask = FL | FR | LFE | RC | FLC | FRC },
++	{ .ca_id = 0x0c, .n_ch = 8,
++	  .mask = FL | FR | RC | RL | RR },
++	{ .ca_id = 0x18, .n_ch = 8,
++	  .mask = FL | FR | RC | FLC | FRC },
++	{ .ca_id = 0x17, .n_ch = 8,
++	  .mask = FL | FR | LFE | FC | FLC | FRC },
++	{ .ca_id = 0x16, .n_ch = 8,
++	  .mask = FL | FR | FC | FLC | FRC },
++	{ .ca_id = 0x15, .n_ch = 8,
++	  .mask = FL | FR | LFE | FLC | FRC },
++	{ .ca_id = 0x14, .n_ch = 8,
++	  .mask = FL | FR | FLC | FRC },
++	{ .ca_id = 0x0b, .n_ch = 8,
++	  .mask = FL | FR | LFE | FC | RL | RR },
++	{ .ca_id = 0x0a, .n_ch = 8,
++	  .mask = FL | FR | FC | RL | RR },
++	{ .ca_id = 0x09, .n_ch = 8,
++	  .mask = FL | FR | LFE | RL | RR },
++	{ .ca_id = 0x08, .n_ch = 8,
++	  .mask = FL | FR | RL | RR },
++	{ .ca_id = 0x07, .n_ch = 8,
++	  .mask = FL | FR | LFE | FC | RC },
++	{ .ca_id = 0x06, .n_ch = 8,
++	  .mask = FL | FR | FC | RC },
++	{ .ca_id = 0x05, .n_ch = 8,
++	  .mask = FL | FR | LFE | RC },
++	{ .ca_id = 0x04, .n_ch = 8,
++	  .mask = FL | FR | RC },
++	{ .ca_id = 0x03, .n_ch = 8,
++	  .mask = FL | FR | LFE | FC },
++	{ .ca_id = 0x02, .n_ch = 8,
++	  .mask = FL | FR | FC },
++	{ .ca_id = 0x01, .n_ch = 8,
++	  .mask = FL | FR | LFE },
+ };
+ 
+ struct hdmi_codec_priv {
+@@ -370,7 +383,8 @@ static int hdmi_codec_chmap_ctl_get(struct snd_kcontrol *kcontrol,
+ 	struct snd_pcm_chmap *info = snd_kcontrol_chip(kcontrol);
+ 	struct hdmi_codec_priv *hcp = info->private_data;
+ 
+-	map = info->chmap[hcp->chmap_idx].map;
++	if (hcp->chmap_idx != HDMI_CODEC_CHMAP_IDX_UNKNOWN)
++		map = info->chmap[hcp->chmap_idx].map;
+ 
+ 	for (i = 0; i < info->max_channels; i++) {
+ 		if (hcp->chmap_idx == HDMI_CODEC_CHMAP_IDX_UNKNOWN)
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/general-input-touchscreen-Add-D-WAV-Multitouch.patch
+++ b/patch/kernel/archive/meson64-6.1/general-input-touchscreen-Add-D-WAV-Multitouch.patch
@@ -1,0 +1,635 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Hyeonki Hong <hhk7734@gmail.com>
+Date: Thu, 5 Mar 2020 19:01:43 +0900
+Subject: ODROID-COMMON: input/touchscreen: Add D-WAV Multitouch driver.
+
+Change-Id: Ia1c8c29d3f69c6ba5d630279c4cc98119b68ab71
+---
+ drivers/hid/hid-ids.h                   |   6 +
+ drivers/hid/hid-quirks.c                |   3 +
+ drivers/input/touchscreen/Kconfig       |  10 +
+ drivers/input/touchscreen/Makefile      |   1 +
+ drivers/input/touchscreen/dwav-usb-mt.c | 554 ++++++++++
+ 5 files changed, 574 insertions(+)
+
+diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
+index dad953f66996..69ab90e228b0 100644
+--- a/drivers/hid/hid-ids.h
++++ b/drivers/hid/hid-ids.h
+@@ -1410,4 +1410,10 @@
+ #define USB_VENDOR_ID_SIGNOTEC			0x2133
+ #define USB_DEVICE_ID_SIGNOTEC_VIEWSONIC_PD1011	0x0018
+ 
++#define USB_DEVICE_ID_DWAV_MULTITOUCH	0x0005
++
++#define USB_VENDOR_ID_ODROID	0x16b4
++#define USB_DEVICE_ID_VU5	0x0704
++#define USB_DEVICE_ID_VU7PLUS	0x0705
++
+ #endif
+diff --git a/drivers/hid/hid-quirks.c b/drivers/hid/hid-quirks.c
+index 50e1c717fc0a..b2f1a4a7367d 100644
+--- a/drivers/hid/hid-quirks.c
++++ b/drivers/hid/hid-quirks.c
+@@ -876,6 +876,9 @@ static const struct hid_device_id hid_ignore_list[] = {
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_SYNAPTICS, USB_DEVICE_ID_SYNAPTICS_DPAD) },
+ #endif
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_YEALINK, USB_DEVICE_ID_YEALINK_P1K_P4K_B2K) },
++
++	{ HID_USB_DEVICE(USB_VENDOR_ID_ODROID, USB_DEVICE_ID_VU5) },
++	{ HID_USB_DEVICE(USB_VENDOR_ID_ODROID, USB_DEVICE_ID_VU7PLUS) },
+ 	{ }
+ };
+ 
+diff --git a/drivers/input/touchscreen/Kconfig b/drivers/input/touchscreen/Kconfig
+index dc90a3ea51ee..fd31ad28b952 100644
+--- a/drivers/input/touchscreen/Kconfig
++++ b/drivers/input/touchscreen/Kconfig
+@@ -1379,4 +1379,14 @@ config TOUCHSCREEN_ZINITIX
+ 	  To compile this driver as a module, choose M here: the
+ 	  module will be called zinitix.
+ 
++config TOUCHSCREEN_DWAV_USB_MT
++	tristate "D-WAV Scientific USB MultiTouch"
++	depends on USB_ARCH_HAS_HCD
++	select USB
++	help
++	  Say Y here if you have a D-WAV Scientific USB(HID) based MultiTouch
++	  controller.
++
++	  module will be called dwav-usb-mt.
++
+ endif
+diff --git a/drivers/input/touchscreen/Makefile b/drivers/input/touchscreen/Makefile
+index 557f84fd2075..68feafadf7fe 100644
+--- a/drivers/input/touchscreen/Makefile
++++ b/drivers/input/touchscreen/Makefile
+@@ -116,3 +116,4 @@ obj-$(CONFIG_TOUCHSCREEN_ROHM_BU21023)	+= rohm_bu21023.o
+ obj-$(CONFIG_TOUCHSCREEN_RASPBERRYPI_FW)	+= raspberrypi-ts.o
+ obj-$(CONFIG_TOUCHSCREEN_IQS5XX)	+= iqs5xx.o
+ obj-$(CONFIG_TOUCHSCREEN_ZINITIX)	+= zinitix.o
++obj-$(CONFIG_TOUCHSCREEN_DWAV_USB_MT)	+= dwav-usb-mt.o
+diff --git a/drivers/input/touchscreen/dwav-usb-mt.c b/drivers/input/touchscreen/dwav-usb-mt.c
+new file mode 100644
+index 000000000000..7ec8b6dd15fd
+--- /dev/null
++++ b/drivers/input/touchscreen/dwav-usb-mt.c
+@@ -0,0 +1,554 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * D-WAV Scientific USB(HID) MultiTouch Screen Driver(Based on usbtouchscreen.c)
++ *
++ * Copyright (C) Hardkernel, 2015
++ */
++
++#include <linux/kernel.h>
++#include <linux/slab.h>
++#include <linux/input.h>
++#include <linux/module.h>
++#include <linux/init.h>
++#include <linux/usb.h>
++#include <linux/usb/input.h>
++#include <linux/hid.h>
++
++#include <linux/input/mt.h>
++
++#define USB_VENDOR_ID_DWAV	0x0eef	/* 800 x 480, 7" DWAV touch */
++#define USB_DEVICE_ID_VU7	0x0005
++
++#define USB_VENDOR_ID_ODROID	0x16b4
++#define	USB_DEVICE_ID_VU5	0x0704
++#define	USB_DEVICE_ID_VU7PLUS	0x0705
++
++enum	{
++	ODROID_VU7 = 0,	/* 800 x 480, 7" Touch */
++	ODROID_VU5,	/* 800 x 480, 5" Touch */
++	ODROID_VU7PLUS,	/* 1024 x 600, 7" Touch */
++};
++
++struct usbtouch_device_info	{
++	char	name[64];
++	int	max_x;
++	int	max_y;
++	int	max_press;
++	int	max_finger;
++};
++
++const struct usbtouch_device_info DEV_INFO[] = {
++	[ODROID_VU7] = {
++		.name = "ODROID VU7 MultiTouch(800x480)",
++		.max_x = 800,
++		.max_y = 480,
++		.max_press = 255,
++		.max_finger = 5,
++	},
++	[ODROID_VU5] = {
++		.name = "ODROID VU5 MultiTouch(800x480)",
++		.max_x = 800,
++		.max_y = 480,
++		.max_press = 255,
++		.max_finger = 5,
++	},
++	[ODROID_VU7PLUS] = {
++		.name = "ODROID VU7 Plus MultiTouch(1024x600)",
++		.max_x = 1024,
++		.max_y = 600,
++		.max_press = 255,
++		.max_finger = 5,
++	},
++};
++
++static const struct usb_device_id dwav_usb_mt_devices[] = {
++	{USB_DEVICE(USB_VENDOR_ID_DWAV,   USB_DEVICE_ID_VU7),
++		.driver_info = ODROID_VU7},
++	{USB_DEVICE(USB_VENDOR_ID_ODROID, USB_DEVICE_ID_VU5),
++		.driver_info = ODROID_VU5},
++	{USB_DEVICE(USB_VENDOR_ID_ODROID, USB_DEVICE_ID_VU7PLUS),
++		.driver_info = ODROID_VU7PLUS},
++	{}
++};
++
++struct dwav_raw {                   /* Total 25 bytes */
++	unsigned char   header;     /* frame header 0xAA*/
++	unsigned char   press;
++	/* Touch flag (1:valid touch data, 0:touch finished) */
++	unsigned short  x1;         /* 1st x */
++	unsigned short  y1;         /* 1st y */
++	unsigned char   end;
++	/* 1st touch finish flags 0xBB, RPI only uses the first 7 bytes */
++	unsigned char   ids;        /* touch ID(bit field) */
++	unsigned short  y2;
++	unsigned short  x2;
++	unsigned short  y3;
++	unsigned short  x3;
++	unsigned short  y4;
++	unsigned short  x4;
++	unsigned short  y5;
++	unsigned short  x5;
++	unsigned char   tail;       /* frame end 0xCC */
++};
++
++#define	TS_EVENT_UNKNOWN	0x00
++#define	TS_EVENT_PRESS		0x01
++#define	TS_EVENT_RELEASE	0x02
++
++struct	finger_t	{
++	unsigned int	status;	/* ts event type */
++	unsigned int	x;	/* ts data x */
++	unsigned int	y;	/* ts data y */
++}	__packed;
++
++struct dwav_usb_mt  {
++	char		name[128], phys[64];
++
++	int		dev_id;
++	/* for URB Data DMA */
++	dma_addr_t	data_dma;
++	unsigned char	*data;
++	int		data_size;
++
++	struct urb		*irq;
++	struct usb_interface	*interface;
++	struct input_dev	*input;
++
++	struct finger_t		*finger;
++};
++
++static void dwav_usb_mt_report(struct dwav_usb_mt *dwav_usb_mt)
++{
++	int	id, max_x, max_y, max_press, max_finger;
++
++	max_x = DEV_INFO[dwav_usb_mt->dev_id].max_x;
++	max_y = DEV_INFO[dwav_usb_mt->dev_id].max_y;
++	max_press = DEV_INFO[dwav_usb_mt->dev_id].max_press;
++	max_finger = DEV_INFO[dwav_usb_mt->dev_id].max_finger;
++
++	for (id = 0; id < max_finger; id++)	{
++
++		if (dwav_usb_mt->finger[id].status == TS_EVENT_UNKNOWN)
++			continue;
++
++		if (dwav_usb_mt->finger[id].x >= max_x ||
++		    dwav_usb_mt->finger[id].y >= max_y)
++			continue;
++
++		input_mt_slot(dwav_usb_mt->input, id);
++
++		if (dwav_usb_mt->finger[id].status != TS_EVENT_RELEASE) {
++			input_mt_report_slot_state(dwav_usb_mt->input,
++					MT_TOOL_FINGER, true);
++			input_report_abs(dwav_usb_mt->input,
++					ABS_MT_POSITION_X,
++					dwav_usb_mt->finger[id].x);
++			input_report_abs(dwav_usb_mt->input,
++					ABS_MT_POSITION_Y,
++					dwav_usb_mt->finger[id].y);
++			input_report_abs(dwav_usb_mt->input,
++					ABS_MT_PRESSURE,
++					max_press);
++		} else {
++			input_mt_report_slot_state(dwav_usb_mt->input,
++					MT_TOOL_FINGER, false);
++			dwav_usb_mt->finger[id].status = TS_EVENT_UNKNOWN;
++		}
++		input_mt_report_pointer_emulation(dwav_usb_mt->input, true);
++		input_sync(dwav_usb_mt->input);
++	}
++}
++
++static void dwav_usb_mt_process(struct dwav_usb_mt *dwav_usb_mt,
++		unsigned char *pkt, int len)
++{
++	struct  dwav_raw *dwav_raw = (struct dwav_raw *)pkt;
++	unsigned char bit_mask, cnt;
++
++	for (cnt = 0, bit_mask = 0x01;
++	     cnt < DEV_INFO[dwav_usb_mt->dev_id].max_finger;
++	     cnt++, bit_mask <<= 1) {
++		if ((dwav_raw->ids & bit_mask) && dwav_raw->press) {
++			dwav_usb_mt->finger[cnt].status = TS_EVENT_PRESS;
++			switch (cnt) {
++			case	0:
++				dwav_usb_mt->finger[cnt].x
++					= cpu_to_be16(dwav_raw->x1);
++				dwav_usb_mt->finger[cnt].y
++					= cpu_to_be16(dwav_raw->y1);
++				break;
++			case	1:
++				dwav_usb_mt->finger[cnt].x
++					= cpu_to_be16(dwav_raw->x2);
++				dwav_usb_mt->finger[cnt].y
++					= cpu_to_be16(dwav_raw->y2);
++				break;
++			case	2:
++				dwav_usb_mt->finger[cnt].x
++					= cpu_to_be16(dwav_raw->x3);
++				dwav_usb_mt->finger[cnt].y
++					= cpu_to_be16(dwav_raw->y3);
++				break;
++			case	3:
++				dwav_usb_mt->finger[cnt].x
++					= cpu_to_be16(dwav_raw->x4);
++				dwav_usb_mt->finger[cnt].y
++					= cpu_to_be16(dwav_raw->y4);
++				break;
++			case	4:
++				dwav_usb_mt->finger[cnt].x
++					= cpu_to_be16(dwav_raw->x5);
++				dwav_usb_mt->finger[cnt].y
++					= cpu_to_be16(dwav_raw->y5);
++				break;
++			default:
++				break;
++			}
++		} else {
++			if (dwav_usb_mt->finger[cnt].status == TS_EVENT_PRESS)
++				dwav_usb_mt->finger[cnt].status
++					= TS_EVENT_RELEASE;
++			else
++				dwav_usb_mt->finger[cnt].status
++					= TS_EVENT_UNKNOWN;
++		}
++	}
++	dwav_usb_mt_report(dwav_usb_mt);
++}
++
++static void dwav_usb_mt_irq(struct urb *urb)
++{
++	struct dwav_usb_mt *dwav_usb_mt = urb->context;
++	struct device *dev = &dwav_usb_mt->interface->dev;
++	int retval;
++
++	switch (urb->status) {
++	case 0:
++		/* success */
++		break;
++	case -ETIME:
++		/* this urb is timing out */
++		dev_dbg(dev, "%s - urb timed out - was the device unplugged?\n",
++				__func__);
++		return;
++	case -ECONNRESET:
++	case -ENOENT:
++	case -ESHUTDOWN:
++	case -EPIPE:
++		/* this urb is terminated, clean up */
++		dev_dbg(dev, "%s - urb shutting down with status: %d\n",
++				__func__, urb->status);
++		return;
++	default:
++		dev_dbg(dev, "%s - nonzero urb status received: %d\n",
++				__func__, urb->status);
++		goto exit;
++	}
++
++	dwav_usb_mt_process(dwav_usb_mt, dwav_usb_mt->data, urb->actual_length);
++
++exit:
++	usb_mark_last_busy(interface_to_usbdev(dwav_usb_mt->interface));
++	retval = usb_submit_urb(urb, GFP_ATOMIC);
++	if (retval) {
++		dev_err(dev, "%s - usb_submit_urb failed with result: %d\n",
++				__func__, retval);
++	}
++}
++
++static int dwav_usb_mt_open(struct input_dev *input)
++{
++	struct dwav_usb_mt *dwav_usb_mt = input_get_drvdata(input);
++	int r;
++
++	dwav_usb_mt->irq->dev = interface_to_usbdev(dwav_usb_mt->interface);
++
++	r = usb_autopm_get_interface(dwav_usb_mt->interface) ? -EIO : 0;
++	if (r < 0)
++		goto out;
++
++	if (usb_submit_urb(dwav_usb_mt->irq, GFP_KERNEL)) {
++		r = -EIO;
++		goto out_put;
++	}
++
++	dwav_usb_mt->interface->needs_remote_wakeup = 1;
++out_put:
++	usb_autopm_put_interface(dwav_usb_mt->interface);
++out:
++	return r;
++}
++
++static void dwav_usb_mt_close(struct input_dev *input)
++{
++	struct dwav_usb_mt *dwav_usb_mt = input_get_drvdata(input);
++	int r;
++
++	usb_kill_urb(dwav_usb_mt->irq);
++
++	r = usb_autopm_get_interface(dwav_usb_mt->interface);
++
++	dwav_usb_mt->interface->needs_remote_wakeup = 0;
++	if (!r)
++		usb_autopm_put_interface(dwav_usb_mt->interface);
++}
++
++static int dwav_usb_mt_suspend(struct usb_interface *intf, pm_message_t message)
++{
++	struct dwav_usb_mt *dwav_usb_mt = usb_get_intfdata(intf);
++
++	usb_kill_urb(dwav_usb_mt->irq);
++
++	return 0;
++}
++
++static int dwav_usb_mt_resume(struct usb_interface *intf)
++{
++	struct dwav_usb_mt *dwav_usb_mt = usb_get_intfdata(intf);
++	struct input_dev *input = dwav_usb_mt->input;
++	int result = 0;
++
++	mutex_lock(&input->mutex);
++	if (input->users)
++		result = usb_submit_urb(dwav_usb_mt->irq, GFP_NOIO);
++	mutex_unlock(&input->mutex);
++
++	return result;
++}
++
++static int dwav_usb_mt_reset_resume(struct usb_interface *intf)
++{
++	struct dwav_usb_mt *dwav_usb_mt = usb_get_intfdata(intf);
++	struct input_dev *input = dwav_usb_mt->input;
++	int err = 0;
++
++	/* restart IO if needed */
++	mutex_lock(&input->mutex);
++	if (input->users)
++		err = usb_submit_urb(dwav_usb_mt->irq, GFP_NOIO);
++	mutex_unlock(&input->mutex);
++
++	return err;
++}
++
++static void dwav_usb_mt_free_buffers(struct usb_device *udev,
++				  struct dwav_usb_mt *dwav_usb_mt)
++{
++	usb_free_coherent(udev, dwav_usb_mt->data_size,
++			dwav_usb_mt->data, dwav_usb_mt->data_dma);
++}
++
++static struct usb_endpoint_descriptor *dwav_usb_mt_get_input_endpoint(
++		struct usb_host_interface *interface)
++{
++	int i;
++
++	for (i = 0; i < interface->desc.bNumEndpoints; i++) {
++		if (usb_endpoint_dir_in(&interface->endpoint[i].desc))
++			return &interface->endpoint[i].desc;
++	}
++
++	return NULL;
++}
++
++static int dwav_usb_mt_init(struct dwav_usb_mt *dwav_usb_mt, void *dev)
++{
++	int err;
++	struct input_dev *input_dev = (struct input_dev *)dev;
++
++	input_dev->name = dwav_usb_mt->name;
++	input_dev->phys = dwav_usb_mt->phys;
++
++	input_set_drvdata(input_dev, dwav_usb_mt);
++
++	input_dev->open = dwav_usb_mt_open;
++	input_dev->close = dwav_usb_mt_close;
++
++	input_dev->id.bustype = BUS_USB;
++
++	/* single touch */
++	input_dev->evbit[0] = BIT_MASK(EV_KEY) | BIT_MASK(EV_ABS);
++	input_dev->keybit[BIT_WORD(BTN_TOUCH)] = BIT_MASK(BTN_TOUCH);
++
++	input_set_abs_params(input_dev, ABS_X, 0,
++			     DEV_INFO[dwav_usb_mt->dev_id].max_x, 0, 0);
++	input_set_abs_params(input_dev, ABS_Y, 0,
++			     DEV_INFO[dwav_usb_mt->dev_id].max_y, 0, 0);
++
++	/* multi touch */
++	input_set_abs_params(input_dev, ABS_MT_POSITION_X, 0,
++			     DEV_INFO[dwav_usb_mt->dev_id].max_x, 0, 0);
++	input_set_abs_params(input_dev, ABS_MT_POSITION_Y, 0,
++			     DEV_INFO[dwav_usb_mt->dev_id].max_y, 0, 0);
++	input_mt_init_slots(input_dev,
++			     DEV_INFO[dwav_usb_mt->dev_id].max_finger, 0);
++
++	err = input_register_device(input_dev);
++	if (err) {
++		pr_err("%s - input_register_device failed, err: %d\n",
++				__func__, err);
++		return  err;
++	}
++
++	dwav_usb_mt->input = input_dev;
++
++	return  0;
++}
++
++static int dwav_usb_mt_probe(struct usb_interface *intf,
++			  const struct usb_device_id *id)
++{
++	struct dwav_usb_mt *dwav_usb_mt = NULL;
++	struct input_dev *input_dev = NULL;
++	struct usb_endpoint_descriptor *endpoint;
++	struct usb_device *udev = interface_to_usbdev(intf);
++
++	int err = 0;
++
++	endpoint = dwav_usb_mt_get_input_endpoint(intf->cur_altsetting);
++	if (!endpoint)
++		return  -ENXIO;
++
++	dwav_usb_mt = kzalloc(sizeof(struct dwav_usb_mt), GFP_KERNEL);
++	if (!dwav_usb_mt)
++		return  -ENOMEM;
++
++	dwav_usb_mt->dev_id = id->driver_info;
++
++	dwav_usb_mt->finger = kzalloc(sizeof(struct finger_t) *
++				      DEV_INFO[dwav_usb_mt->dev_id].max_finger,
++				      GFP_KERNEL);
++
++	if (!dwav_usb_mt->finger)
++		goto err_free_mem;
++
++	input_dev = input_allocate_device();
++	if (!input_dev)
++		goto err_free_mem;
++
++	dwav_usb_mt->data_size = sizeof(struct dwav_raw);
++	dwav_usb_mt->data = usb_alloc_coherent(udev, dwav_usb_mt->data_size,
++			GFP_KERNEL, &dwav_usb_mt->data_dma);
++	if (!dwav_usb_mt->data)
++		goto err_free_mem;
++
++	dwav_usb_mt->irq = usb_alloc_urb(0, GFP_KERNEL);
++	if (!dwav_usb_mt->irq) {
++		dev_dbg(&intf->dev,
++				"%s - usb_alloc_urb failed: usbtouch->irq\n",
++				__func__);
++		goto err_free_buffers;
++	}
++
++	if (usb_endpoint_type(endpoint) == USB_ENDPOINT_XFER_INT)   {
++		usb_fill_int_urb(dwav_usb_mt->irq, udev,
++			usb_rcvintpipe(udev, endpoint->bEndpointAddress),
++			dwav_usb_mt->data, dwav_usb_mt->data_size,
++			dwav_usb_mt_irq, dwav_usb_mt, endpoint->bInterval);
++	} else {
++		usb_fill_bulk_urb(dwav_usb_mt->irq, udev,
++			 usb_rcvbulkpipe(udev, endpoint->bEndpointAddress),
++			 dwav_usb_mt->data, dwav_usb_mt->data_size,
++			 dwav_usb_mt_irq, dwav_usb_mt);
++	}
++
++	dwav_usb_mt->irq->dev = udev;
++	dwav_usb_mt->irq->transfer_dma = dwav_usb_mt->data_dma;
++	dwav_usb_mt->irq->transfer_flags |= URB_NO_TRANSFER_DMA_MAP;
++
++	dwav_usb_mt->interface  = intf;
++
++	if (udev->manufacturer)
++		strlcpy(dwav_usb_mt->name,
++				udev->manufacturer, sizeof(dwav_usb_mt->name));
++
++	if (udev->product) {
++		if (udev->manufacturer)
++			strlcat(dwav_usb_mt->name,
++					" ", sizeof(dwav_usb_mt->name));
++
++		strlcat(dwav_usb_mt->name,
++				udev->product, sizeof(dwav_usb_mt->name));
++	}
++
++	if (!strlen(dwav_usb_mt->name)) {
++		snprintf(dwav_usb_mt->name, sizeof(dwav_usb_mt->name),
++				"D-WAV Scientific MultiTouch %04x:%04x",
++				le16_to_cpu(udev->descriptor.idVendor),
++				le16_to_cpu(udev->descriptor.idProduct));
++	}
++
++	usb_make_path(udev, dwav_usb_mt->phys, sizeof(dwav_usb_mt->phys));
++	strlcat(dwav_usb_mt->phys, "/input0", sizeof(dwav_usb_mt->phys));
++
++	usb_to_input_id(udev, &input_dev->id);
++
++	input_dev->dev.parent = &intf->dev;
++
++	err = dwav_usb_mt_init(dwav_usb_mt, (void *)input_dev);
++	if (err)
++		goto err_free_urb;
++
++	usb_set_intfdata(intf, dwav_usb_mt);
++
++	dev_info(&intf->dev, "%s\n", DEV_INFO[dwav_usb_mt->dev_id].name);
++
++	return 0;
++
++err_free_urb:
++	usb_free_urb(dwav_usb_mt->irq);
++
++err_free_buffers:
++	dwav_usb_mt_free_buffers(udev, dwav_usb_mt);
++
++err_free_mem:
++	if (input_dev)
++		input_free_device(input_dev);
++	kfree(dwav_usb_mt);
++
++	return err;
++}
++
++static void dwav_usb_mt_disconnect(struct usb_interface *intf)
++{
++	struct dwav_usb_mt *dwav_usb_mt = usb_get_intfdata(intf);
++
++	if (!dwav_usb_mt)
++		return;
++
++	dev_dbg(&intf->dev,
++			"%s - dwav_usb_mt is initialized, cleaning up\n",
++			__func__);
++
++	usb_set_intfdata(intf, NULL);
++
++	/* this will stop IO via close */
++	input_unregister_device(dwav_usb_mt->input);
++
++	usb_free_urb(dwav_usb_mt->irq);
++
++	dwav_usb_mt_free_buffers(interface_to_usbdev(intf), dwav_usb_mt);
++
++	kfree(dwav_usb_mt);
++}
++
++MODULE_DEVICE_TABLE(usb, dwav_usb_mt_devices);
++
++static struct usb_driver dwav_usb_mt_driver = {
++	.name = "dwav_usb_mt",
++	.probe = dwav_usb_mt_probe,
++	.disconnect = dwav_usb_mt_disconnect,
++	.suspend = dwav_usb_mt_suspend,
++	.resume = dwav_usb_mt_resume,
++	.reset_resume = dwav_usb_mt_reset_resume,
++	.id_table = dwav_usb_mt_devices,
++	.supports_autosuspend = 1,
++};
++
++module_usb_driver(dwav_usb_mt_driver);
++
++MODULE_AUTHOR("Hardkernel Co.,Ltd");
++MODULE_DESCRIPTION("D-WAV USB(HID) MultiTouch Driver");
++MODULE_LICENSE("GPL");
++
++MODULE_ALIAS("dwav_usb_mt");
+\ No newline at end of file
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/general-kernel-odroidn2-current.patch
+++ b/patch/kernel/archive/meson64-6.1/general-kernel-odroidn2-current.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+Date: Tue, 19 Nov 2019 23:25:39 +0100
+Subject: hack builddeb for meson64
+
+Unknown patch. Archeology:
+- ff4c1488dab1e07d35923b6f8e33c992d9ca439f: Igor Pecovnik <igorpecovnik@users.noreply.github.com>: 'Move to 5.4.y (#1686)'
+---
+ scripts/package/builddeb | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/scripts/package/builddeb b/scripts/package/builddeb
+index 67cd420dcf89..e445d84b6cbc 100755
+--- a/scripts/package/builddeb
++++ b/scripts/package/builddeb
+@@ -218,6 +218,11 @@ if [ "$ARCH" != "um" ]; then
+ 	create_package linux-libc-dev debian/linux-libc-dev
+ fi
+ 
++sed -e "s/exit 0//g" -i $tmpdir/DEBIAN/postinst
++cat >> $tmpdir/DEBIAN/postinst <<EOT
++mkimage -A arm64 -O linux -T kernel -C none -a 0x1080000 -e 0x1080000 -n "Linux" -d /$installed_image_path /boot/uImage  > /dev/null 2>&1
++exit 0
++EOT
+ create_package "$packagename" "$tmpdir"
+ 
+ if [ -n "$BUILD_DEBUG" ] ; then
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/general-media-cec-silence-CEC-timeout-message-HACK.patch
+++ b/patch/kernel/archive/meson64-6.1/general-media-cec-silence-CEC-timeout-message-HACK.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Christian Hewitt <christianshewitt@gmail.com>
+Date: Tue, 7 Jan 2020 07:12:47 +0000
+Subject: HACK: media: cec: silence CEC timeout message
+
+If testing with an AVR that does not pass-through CEC state the system
+log fills with timeout messages. Silence this to stop the log rotation
+and ensure other issues are visible.
+
+[   42.718009] cec-meson_ao_cec: message ff 84 50 00 01 timed out
+[   45.021994] cec-meson_ao_cec: message ff 87 00 15 82 timed out
+[   47.325965] cec-meson_ao_cec: message 10 timed out
+[   49.630023] cec-meson_ao_cec: message 10 timed out
+[   51.933960] cec-meson_ao_cec: message 10 timed out
+
+Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
+---
+ drivers/media/cec/core/cec-adap.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/media/cec/core/cec-adap.c b/drivers/media/cec/core/cec-adap.c
+index 4f5ab3cae8a7..0e2cfa59bad6 100644
+--- a/drivers/media/cec/core/cec-adap.c
++++ b/drivers/media/cec/core/cec-adap.c
+@@ -501,9 +501,9 @@ int cec_thread_func(void *_adap)
+ 			 * default).
+ 			 */
+ 			if (adap->transmitting) {
+-				pr_warn("cec-%s: message %*ph timed out\n", adap->name,
+-					adap->transmitting->msg.len,
+-					adap->transmitting->msg.msg);
++				//pr_warn("cec-%s: message %*ph timed out\n", adap->name,
++				//	adap->transmitting->msg.len,
++				//	adap->transmitting->msg.msg);
+ 				/* Just give up on this. */
+ 				cec_data_cancel(adap->transmitting,
+ 						CEC_TX_STATUS_TIMEOUT, 0);
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/general-memory-marked-nomap.patch
+++ b/patch/kernel/archive/meson64-6.1/general-memory-marked-nomap.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Stefan Agner <stefan@agner.ch>
+Date: Wed, 15 Sep 2021 05:00:45 +0000
+Subject: HACK: of: partial revert of fdt.c changes
+
+This resolves reports similar to the below which are present in dmesg
+since Linux 5.10; which are also causing crashes in some distros:
+
+[    0.000000] OF: fdt: Reserved memory: failed to reserve memory for node 'secmon@5000000': base 0x0000000005000000, size 3 MiB
+
+Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
+---
+ drivers/of/fdt.c | 9 ---------
+ 1 file changed, 9 deletions(-)
+
+diff --git a/drivers/of/fdt.c b/drivers/of/fdt.c
+index 7b571a631639..dd9f19e7938f 100644
+--- a/drivers/of/fdt.c
++++ b/drivers/of/fdt.c
+@@ -481,15 +481,6 @@ static int __init early_init_dt_reserve_memory(phys_addr_t base,
+ 					       phys_addr_t size, bool nomap)
+ {
+ 	if (nomap) {
+-		/*
+-		 * If the memory is already reserved (by another region), we
+-		 * should not allow it to be marked nomap, but don't worry
+-		 * if the region isn't memory as it won't be mapped.
+-		 */
+-		if (memblock_overlaps_region(&memblock.memory, base, size) &&
+-		    memblock_is_region_reserved(base, size))
+-			return -EBUSY;
+-
+ 		return memblock_mark_nomap(base, size);
+ 	}
+ 	return memblock_reserve(base, size);
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/general-meson-aiu-Fix-HDMI-codec-control-selection.patch
+++ b/patch/kernel/archive/meson64-6.1/general-meson-aiu-Fix-HDMI-codec-control-selection.patch
@@ -1,0 +1,232 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+Date: Sun, 3 Oct 2021 05:35:48 +0000
+Subject: ASoC: meson: aiu: Fix HDMI codec control selection
+
+The HDMI controllers on Amlogic Meson SoCs which use the AIU
+audio-controller have two different audio format inputs:
+- I2S which is also the only configuration supported on GXBB, GXL and
+  GXM SoCs since there's no SPDIF support in the DesignWare HDMI
+  controller driver (at the time of writing this)
+- SPDIF can be used optionally, including pass-through formats
+
+Switching between these requires us to set different registers:
+AIU_HDMI_CLK_DATA_CTRL[1:0] "HDMI_DATA_CLK_SEL":
+- 0x0 disables the HDMI output clock
+- 0x1 selects the PCM clock
+- 0x2 selects the AIU clock
+- 0x3 is reserved
+
+AIU_HDMI_CLK_DATA_CTRL[5:4] "HDMI_DATA_SEL":
+- 0x0 outputs constant zero, disables HDMI data
+- 0x1 selects PCM data
+- 0x2 selects AIU I2S data
+- 0x3 is reserved
+
+AIU_CLK_CTRL_MORE[6] "HDMITX_SEL_AOCLKX2":
+- 0x0 selects cts_i958 as AIU clk to hdmi_tx_audio_master_clk
+- 0x1 selects cts_aoclkx2_int as AIU clk to hdmi_tx_audio_master_clk
+
+The Meson8/8b/8m2 vendor driver uses the following settings:
+SPDIF output to the HDMI controller:
+- 0x2 (AIU clock) in AIU_HDMI_CLK_DATA_CTRL[1:0]
+- 0x0 (no HDMI data) in AIU_HDMI_CLK_DATA_CTRL[5:4]
+- 0x0 (using cts_i958 as AIU clk) in AIU_CLK_CTRL_MORE[6]
+I2S output to the HDMI controller:
+- 0x2 (AIU clock) in AIU_HDMI_CLK_DATA_CTRL[1:0]
+- 0x2 (I2S data) in AIU_HDMI_CLK_DATA_CTRL[5:4]
+- 0x0 (using cts_aoclkx2_int as AIU clk) in AIU_CLK_CTRL_MORE[6]
+
+The GXBB/GXL/GXM vendor driver uses the following settings:
+SPDIF output to the HDMI controller:
+- not setting AIU_HDMI_CLK_DATA_CTRL at all
+- 0x0 (using cts_i958 as AIU clk) in AIU_CLK_CTRL_MORE[6]
+I2S output to the HDMI controller:
+- 0x2 (AIU clock) in AIU_HDMI_CLK_DATA_CTRL[1:0]
+- 0x2 (I2S data) in AIU_HDMI_CLK_DATA_CTRL[5:4]
+- 0x0 (using cts_aoclkx2_int as AIU clk) in AIU_CLK_CTRL_MORE[6]
+
+Set the three registers at the same time following what the vendor
+driver does on Meson8/8b/8m2 SoCs. This makes the SPDIF output to the
+HDMI controller work. The entries and order of the entries in the enum
+is not changed on purpose to not break old configurations.
+
+Fixes: b82b734c0e9a7 ("ASoC: meson: aiu: add hdmi codec control support")
+Signed-off-by: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+---
+ sound/soc/meson/aiu-codec-ctrl.c  | 108 +++++++---
+ sound/soc/meson/aiu-encoder-i2s.c |   6 -
+ 2 files changed, 80 insertions(+), 34 deletions(-)
+
+diff --git a/sound/soc/meson/aiu-codec-ctrl.c b/sound/soc/meson/aiu-codec-ctrl.c
+index 84c10956c241..c1aa13f4d65b 100644
+--- a/sound/soc/meson/aiu-codec-ctrl.c
++++ b/sound/soc/meson/aiu-codec-ctrl.c
+@@ -12,14 +12,60 @@
+ #include "aiu.h"
+ #include "meson-codec-glue.h"
+ 
+-#define CTRL_CLK_SEL		GENMASK(1, 0)
+-#define CTRL_DATA_SEL_SHIFT	4
+-#define CTRL_DATA_SEL		(0x3 << CTRL_DATA_SEL_SHIFT)
+-
+-static const char * const aiu_codec_ctrl_mux_texts[] = {
+-	"DISABLED", "PCM", "I2S",
++#define AIU_HDMI_CLK_DATA_CTRL_CLK_SEL			GENMASK(1, 0)
++#define AIU_HDMI_CLK_DATA_CTRL_CLK_SEL_DISABLE		0x0
++#define AIU_HDMI_CLK_DATA_CTRL_CLK_SEL_PCM		0x1
++#define AIU_HDMI_CLK_DATA_CTRL_CLK_SEL_AIU		0x2
++#define AIU_HDMI_CLK_DATA_CTRL_DATA_SEL			GENMASK(5, 4)
++#define AIU_HDMI_CLK_DATA_CTRL_DATA_SEL_OUTPUT_ZERO	0x0
++#define AIU_HDMI_CLK_DATA_CTRL_DATA_SEL_PCM_DATA	0x1
++#define AIU_HDMI_CLK_DATA_CTRL_DATA_SEL_I2S_DATA	0x2
++
++#define AIU_CLK_CTRL_MORE_AMCLK				BIT(6)
++
++#define AIU_HDMI_CTRL_MUX_DISABLED			0
++#define AIU_HDMI_CTRL_MUX_PCM				1
++#define AIU_HDMI_CTRL_MUX_I2S				2
++
++static const char * const aiu_codec_hdmi_ctrl_mux_texts[] = {
++	[AIU_HDMI_CTRL_MUX_DISABLED] =  "DISABLED",
++	[AIU_HDMI_CTRL_MUX_PCM] = "PCM",
++	[AIU_HDMI_CTRL_MUX_I2S] = "I2S",
+ };
+ 
++static int aiu_codec_ctrl_mux_get_enum(struct snd_kcontrol *kcontrol,
++				       struct snd_ctl_elem_value *ucontrol)
++{
++	struct snd_soc_component *component =
++		snd_soc_dapm_kcontrol_component(kcontrol);
++	unsigned int ctrl, more, mux = AIU_HDMI_CTRL_MUX_DISABLED;
++
++	ctrl = snd_soc_component_read(component, AIU_HDMI_CLK_DATA_CTRL);
++	if (FIELD_GET(AIU_HDMI_CLK_DATA_CTRL_CLK_SEL, ctrl) !=
++	    AIU_HDMI_CLK_DATA_CTRL_CLK_SEL_AIU) {
++		goto out;
++	}
++
++	more = snd_soc_component_read(component, AIU_CLK_CTRL_MORE);
++	if (FIELD_GET(AIU_HDMI_CLK_DATA_CTRL_DATA_SEL, ctrl) ==
++	    AIU_HDMI_CLK_DATA_CTRL_DATA_SEL_I2S_DATA &&
++	    !!(more & AIU_CLK_CTRL_MORE_AMCLK)) {
++		mux = AIU_HDMI_CTRL_MUX_I2S;
++		goto out;
++	}
++
++	if (FIELD_GET(AIU_HDMI_CLK_DATA_CTRL_DATA_SEL, ctrl) ==
++	    AIU_HDMI_CLK_DATA_CTRL_DATA_SEL_OUTPUT_ZERO &&
++	    !(more & AIU_CLK_CTRL_MORE_AMCLK)) {
++		mux = AIU_HDMI_CTRL_MUX_PCM;
++		goto out;
++	}
++
++out:
++	ucontrol->value.enumerated.item[0] = mux;
++	return 0;
++}
++
+ static int aiu_codec_ctrl_mux_put_enum(struct snd_kcontrol *kcontrol,
+ 				       struct snd_ctl_elem_value *ucontrol)
+ {
+@@ -28,45 +74,51 @@ static int aiu_codec_ctrl_mux_put_enum(struct snd_kcontrol *kcontrol,
+ 	struct snd_soc_dapm_context *dapm =
+ 		snd_soc_dapm_kcontrol_dapm(kcontrol);
+ 	struct soc_enum *e = (struct soc_enum *)kcontrol->private_value;
+-	unsigned int mux, changed;
++	unsigned int mux, ctrl, more;
+ 
+ 	mux = snd_soc_enum_item_to_val(e, ucontrol->value.enumerated.item[0]);
+-	changed = snd_soc_component_test_bits(component, e->reg,
+-					      CTRL_DATA_SEL,
+-					      FIELD_PREP(CTRL_DATA_SEL, mux));
+ 
+-	if (!changed)
+-		return 0;
++	if (mux == AIU_HDMI_CTRL_MUX_I2S) {
++		ctrl = FIELD_PREP(AIU_HDMI_CLK_DATA_CTRL_DATA_SEL,
++				  AIU_HDMI_CLK_DATA_CTRL_DATA_SEL_I2S_DATA);
++		more = AIU_CLK_CTRL_MORE_AMCLK;
++	} else {
++		ctrl = FIELD_PREP(AIU_HDMI_CLK_DATA_CTRL_DATA_SEL,
++				  AIU_HDMI_CLK_DATA_CTRL_DATA_SEL_OUTPUT_ZERO);
++		more = 0;
++	}
++
++	if (mux == AIU_HDMI_CTRL_MUX_DISABLED) {
++		ctrl |= FIELD_PREP(AIU_HDMI_CLK_DATA_CTRL_CLK_SEL,
++				   AIU_HDMI_CLK_DATA_CTRL_CLK_SEL_DISABLE);
++	} else {
++		ctrl |= FIELD_PREP(AIU_HDMI_CLK_DATA_CTRL_CLK_SEL,
++				   AIU_HDMI_CLK_DATA_CTRL_CLK_SEL_AIU);
++	}
+ 
+ 	/* Force disconnect of the mux while updating */
+ 	snd_soc_dapm_mux_update_power(dapm, kcontrol, 0, NULL, NULL);
+ 
+-	/* Reset the source first */
+-	snd_soc_component_update_bits(component, e->reg,
+-				      CTRL_CLK_SEL |
+-				      CTRL_DATA_SEL,
+-				      FIELD_PREP(CTRL_CLK_SEL, 0) |
+-				      FIELD_PREP(CTRL_DATA_SEL, 0));
++	snd_soc_component_update_bits(component, AIU_HDMI_CLK_DATA_CTRL,
++				      AIU_HDMI_CLK_DATA_CTRL_CLK_SEL |
++				      AIU_HDMI_CLK_DATA_CTRL_DATA_SEL,
++				      ctrl);
+ 
+-	/* Set the appropriate source */
+-	snd_soc_component_update_bits(component, e->reg,
+-				      CTRL_CLK_SEL |
+-				      CTRL_DATA_SEL,
+-				      FIELD_PREP(CTRL_CLK_SEL, mux) |
+-				      FIELD_PREP(CTRL_DATA_SEL, mux));
++	snd_soc_component_update_bits(component, AIU_CLK_CTRL_MORE,
++				      AIU_CLK_CTRL_MORE_AMCLK,
++				      more);
+ 
+ 	snd_soc_dapm_mux_update_power(dapm, kcontrol, mux, e, NULL);
+ 
+ 	return 1;
+ }
+ 
+-static SOC_ENUM_SINGLE_DECL(aiu_hdmi_ctrl_mux_enum, AIU_HDMI_CLK_DATA_CTRL,
+-			    CTRL_DATA_SEL_SHIFT,
+-			    aiu_codec_ctrl_mux_texts);
++static SOC_ENUM_SINGLE_VIRT_DECL(aiu_hdmi_ctrl_mux_enum,
++				 aiu_codec_hdmi_ctrl_mux_texts);
+ 
+ static const struct snd_kcontrol_new aiu_hdmi_ctrl_mux =
+ 	SOC_DAPM_ENUM_EXT("HDMI Source", aiu_hdmi_ctrl_mux_enum,
+-			  snd_soc_dapm_get_enum_double,
++			  aiu_codec_ctrl_mux_get_enum,
+ 			  aiu_codec_ctrl_mux_put_enum);
+ 
+ static const struct snd_soc_dapm_widget aiu_hdmi_ctrl_widgets[] = {
+diff --git a/sound/soc/meson/aiu-encoder-i2s.c b/sound/soc/meson/aiu-encoder-i2s.c
+index a0dd914c8ed1..21916034a46d 100644
+--- a/sound/soc/meson/aiu-encoder-i2s.c
++++ b/sound/soc/meson/aiu-encoder-i2s.c
+@@ -23,7 +23,6 @@
+ #define AIU_CLK_CTRL_AOCLK_INVERT	BIT(6)
+ #define AIU_CLK_CTRL_LRCLK_INVERT	BIT(7)
+ #define AIU_CLK_CTRL_LRCLK_SKEW		GENMASK(9, 8)
+-#define AIU_CLK_CTRL_MORE_HDMI_AMCLK	BIT(6)
+ #define AIU_CLK_CTRL_MORE_I2S_DIV	GENMASK(5, 0)
+ #define AIU_CODEC_DAC_LRCLK_CTRL_DIV	GENMASK(11, 0)
+ 
+@@ -176,11 +175,6 @@ static int aiu_encoder_i2s_set_clocks(struct snd_soc_component *component,
+ 	if (ret)
+ 		return ret;
+ 
+-	/* Make sure amclk is used for HDMI i2s as well */
+-	snd_soc_component_update_bits(component, AIU_CLK_CTRL_MORE,
+-				      AIU_CLK_CTRL_MORE_HDMI_AMCLK,
+-				      AIU_CLK_CTRL_MORE_HDMI_AMCLK);
+-
+ 	return 0;
+ }
+ 
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/general-meson-gx-mmc-fix-deferred-probing.patch
+++ b/patch/kernel/archive/meson64-6.1/general-meson-gx-mmc-fix-deferred-probing.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Sergey Shtylyov <s.shtylyov@omp.ru>
+Date: Fri, 24 Dec 2021 06:09:57 +0000
+Subject: mmc: meson-gx: fix deferred probing
+
+The driver overrides the error codes and IRQ0 returned by platform_get_irq()
+to -EINVAL, so if it returns -EPROBE_DEFER, the driver will fail the probe
+permanently instead of the deferred probing. Switch to propagating the error
+codes upstream. IRQ0 is no longer returned by platform_get_irq(), so we now
+can safely ignore it...
+
+Fixes: cbcaac6d7dd2 ("mmc: meson-gx-mmc: Fix platform_get_irq's error checking")
+Signed-off-by: Sergey Shtylyov <s.shtylyov@omp.ru>
+---
+ drivers/mmc/host/meson-gx-mmc.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/mmc/host/meson-gx-mmc.c b/drivers/mmc/host/meson-gx-mmc.c
+index df05e60bed9a..37c9c32a2171 100644
+--- a/drivers/mmc/host/meson-gx-mmc.c
++++ b/drivers/mmc/host/meson-gx-mmc.c
+@@ -1225,8 +1225,8 @@ static int meson_mmc_probe(struct platform_device *pdev)
+ 	}
+ 
+ 	host->irq = platform_get_irq(pdev, 0);
+-	if (host->irq <= 0) {
+-		ret = -EINVAL;
++	if (host->irq < 0) {
++		ret = host->irq;
+ 		goto free_host;
+ 	}
+ 
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/general-meson-mmc-1-arm64-amlogic-mmc-meson-gx-Add-core-tx-rx-eMMC-SD-SD.patch
+++ b/patch/kernel/archive/meson64-6.1/general-meson-mmc-1-arm64-amlogic-mmc-meson-gx-Add-core-tx-rx-eMMC-SD-SD.patch
@@ -1,0 +1,108 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Vyacheslav Bocharov <adeep@lexina.in>
+Date: Mon, 7 Nov 2022 14:19:08 +0100
+Subject: arm64: amlogic: mmc: meson-gx: Add core, tx, rx eMMC/SD/SDIO phase
+ clock settings from devicetree data
+
+The mmc driver has the same phase values for all meson platforms. However,
+some platforms (and even some boards) require different values. This patch
+transfers the values from the set in the code to the variables in the
+device-tree file.
+
+Signed-off-by: Vyacheslav Bocharov <adeep@lexina.in>
+---
+ drivers/mmc/host/meson-gx-mmc.c        | 19 +++--
+ include/dt-bindings/mmc/meson-gx-mmc.h | 35 ++++++++++
+ 2 files changed, 48 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/mmc/host/meson-gx-mmc.c b/drivers/mmc/host/meson-gx-mmc.c
+index 37c9c32a2171..f89e23cfce4a 100644
+--- a/drivers/mmc/host/meson-gx-mmc.c
++++ b/drivers/mmc/host/meson-gx-mmc.c
+@@ -27,6 +27,7 @@
+ #include <linux/interrupt.h>
+ #include <linux/bitfield.h>
+ #include <linux/pinctrl/consumer.h>
++#include <dt-bindings/mmc/meson-gx-mmc.h>
+ 
+ #define DRIVER_NAME "meson-gx-mmc"
+ 
+@@ -36,8 +37,6 @@
+ #define   CLK_CORE_PHASE_MASK GENMASK(9, 8)
+ #define   CLK_TX_PHASE_MASK GENMASK(11, 10)
+ #define   CLK_RX_PHASE_MASK GENMASK(13, 12)
+-#define   CLK_PHASE_0 0
+-#define   CLK_PHASE_180 2
+ #define   CLK_V2_TX_DELAY_MASK GENMASK(19, 16)
+ #define   CLK_V2_RX_DELAY_MASK GENMASK(23, 20)
+ #define   CLK_V2_ALWAYS_ON BIT(24)
+@@ -428,13 +427,21 @@ static int meson_mmc_clk_init(struct meson_host *host)
+ 	const char *mux_parent_names[MUX_CLK_NUM_PARENTS];
+ 	const char *clk_parent[1];
+ 	u32 clk_reg;
+-
++	u32 phase[3]; // <core_phase, tx_phase, rx_phase>
++
++	if (!(host->dev && host->dev->of_node) || (device_property_read_u32_array(host->dev,
++	    "amlogic,mmc-phase", phase, 3) < 0)) {
++		dev_dbg(host->dev, "get amlogic,mmc-phase failed, use default phase settings\n");
++		phase[0] = CLK_PHASE_180;
++		phase[1] = CLK_PHASE_0;
++		phase[2] = CLK_PHASE_0;
++	}
+ 	/* init SD_EMMC_CLOCK to sane defaults w/min clock rate */
+ 	clk_reg = CLK_ALWAYS_ON(host);
+ 	clk_reg |= CLK_DIV_MASK;
+-	clk_reg |= FIELD_PREP(CLK_CORE_PHASE_MASK, CLK_PHASE_180);
+-	clk_reg |= FIELD_PREP(CLK_TX_PHASE_MASK, CLK_PHASE_0);
+-	clk_reg |= FIELD_PREP(CLK_RX_PHASE_MASK, CLK_PHASE_0);
++	clk_reg |= FIELD_PREP(CLK_CORE_PHASE_MASK, phase[0]);
++	clk_reg |= FIELD_PREP(CLK_TX_PHASE_MASK, phase[1]);
++	clk_reg |= FIELD_PREP(CLK_RX_PHASE_MASK, phase[2]);
+ 	clk_reg |= CLK_IRQ_SDIO_SLEEP(host);
+ 	writel(clk_reg, host->regs + SD_EMMC_CLOCK);
+ 
+diff --git a/include/dt-bindings/mmc/meson-gx-mmc.h b/include/dt-bindings/mmc/meson-gx-mmc.h
+new file mode 100644
+index 000000000000..cfc4a9d75b2b
+--- /dev/null
++++ b/include/dt-bindings/mmc/meson-gx-mmc.h
+@@ -0,0 +1,35 @@
++/* SPDX-License-Identifier: (GPL-2.0+ or MIT) */
++/*
++ * Copyright (c) 2022 Vyacheslav Bocharov
++ * Author: Vyacheslav Bocharov <adeep@lexina.in>
++ */
++
++#ifndef _DT_BINDINGS_MESON_GX_MMC_H
++#define _DT_BINDINGS_MESON_GX_MMC_H
++
++/*
++ * Cfg_rx_phase: RX clock phase
++ * bits: 9:8 R/W
++ * default: 0
++ * Recommended value: 0
++ *
++ * Cfg_tx_phase: TX clock phase
++ * bits: 9:8 R/W
++ * default: 0
++ * Recommended value: 2
++ *
++ * Cfg_co_phase: Core clock phase
++ * bits: 9:8 R/W
++ * default: 0
++ * Recommended value: 2
++ *
++ * values: 0: 0 phase, 1: 90 phase, 2: 180 phase, 3: 270 phase.
++ */
++
++#define   CLK_PHASE_0 0
++#define   CLK_PHASE_90 1
++#define   CLK_PHASE_180 2
++#define   CLK_PHASE_270 3
++
++
++#endif
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/general-meson-mmc-2-arm64-amlogic-dts-meson-update-meson-axg-device-tree.patch
+++ b/patch/kernel/archive/meson64-6.1/general-meson-mmc-2-arm64-amlogic-dts-meson-update-meson-axg-device-tree.patch
@@ -1,0 +1,44 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Vyacheslav Bocharov <adeep@lexina.in>
+Date: Mon, 7 Nov 2022 16:19:08 +0300
+Subject: arm64: amlogic: dts: meson: update meson-axg device-tree for new
+ core, tx, rx phase clock settings.
+
+Use phase 270 for core MMC clock on axg meson boards.
+
+Signed-off-by: Vyacheslav Bocharov <adeep@lexina.in>
+---
+ arch/arm64/boot/dts/amlogic/meson-axg.dtsi | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-axg.dtsi b/arch/arm64/boot/dts/amlogic/meson-axg.dtsi
+index 04f797b5a012..0af4784d84c7 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-axg.dtsi
++++ b/arch/arm64/boot/dts/amlogic/meson-axg.dtsi
+@@ -13,6 +13,7 @@
+ #include <dt-bindings/reset/amlogic,meson-axg-audio-arb.h>
+ #include <dt-bindings/reset/amlogic,meson-axg-reset.h>
+ #include <dt-bindings/power/meson-axg-power.h>
++#include <dt-bindings/mmc/meson-gx-mmc.h>
+ 
+ / {
+ 	compatible = "amlogic,meson-axg";
+@@ -1891,6 +1892,7 @@ sd_emmc_b: sd@5000 {
+ 					<&clkc CLKID_SD_EMMC_B_CLK0>,
+ 					<&clkc CLKID_FCLK_DIV2>;
+ 				clock-names = "core", "clkin0", "clkin1";
++				amlogic,mmc-phase = <CLK_PHASE_270 CLK_PHASE_0 CLK_PHASE_0>;
+ 				resets = <&reset RESET_SD_EMMC_B>;
+ 			};
+ 
+@@ -1904,6 +1906,7 @@ sd_emmc_c: mmc@7000 {
+ 					<&clkc CLKID_FCLK_DIV2>;
+ 				clock-names = "core", "clkin0", "clkin1";
+ 				resets = <&reset RESET_SD_EMMC_C>;
++				amlogic,mmc-phase = <CLK_PHASE_270 CLK_PHASE_0 CLK_PHASE_0>;
+ 			};
+ 
+ 			usb2_phy1: phy@9020 {
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/general-meson-mmc-3-arm64-dts-docs-Update-mmc-meson-gx-documentation-for.patch
+++ b/patch/kernel/archive/meson64-6.1/general-meson-mmc-3-arm64-dts-docs-Update-mmc-meson-gx-documentation-for.patch
@@ -1,0 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Vyacheslav Bocharov <adeep@lexina.in>
+Date: Thu, 10 Nov 2022 14:52:47 +0300
+Subject: arm64: dts: docs: Update mmc meson-gx documentation for new config
+ option amlogic,mmc-phase
+
+- amlogic,mmc-phases: 3-element array of clock phases for core, tx, rx
+clock with values:
+	0: CLK_PHASE_0 - 0 phase
+	1: CLK_PHASE_90 - 90 phase
+	2: CLK_PHASE_180 - 180 phase
+	3: CLK_PHASE_270 - 270 phase
+By default driver use <CLK_PHASE_180 CLK_PHASE_0 CLK_PHASE_0> value.
+
+Signed-off-by: Vyacheslav Bocharov <adeep@lexina.in>
+---
+ Documentation/devicetree/bindings/mmc/amlogic,meson-gx.txt | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/Documentation/devicetree/bindings/mmc/amlogic,meson-gx.txt b/Documentation/devicetree/bindings/mmc/amlogic,meson-gx.txt
+index ccc5358db131..98c89c5b3455 100644
+--- a/Documentation/devicetree/bindings/mmc/amlogic,meson-gx.txt
++++ b/Documentation/devicetree/bindings/mmc/amlogic,meson-gx.txt
+@@ -25,6 +25,12 @@ Required properties:
+ Optional properties:
+ - amlogic,dram-access-quirk: set when controller's internal DMA engine cannot access the
+   DRAM memory, like on the G12A dedicated SDIO controller.
++- amlogic,mmc-phases: 3-element array of clock phases for core, tx, rx clock with values:
++	0: CLK_PHASE_0 - 0 phase
++	1: CLK_PHASE_90 - 90 phase
++	2: CLK_PHASE_180 - 180 phase
++	3: CLK_PHASE_270 - 270 phase
++  By default driver use <CLK_PHASE_180 CLK_PHASE_0 CLK_PHASE_0> value.
+ 
+ Example:
+ 
+@@ -36,4 +42,5 @@ Example:
+ 		clock-names = "core", "clkin0", "clkin1";
+ 		pinctrl-0 = <&emmc_pins>;
+ 		resets = <&reset RESET_SD_EMMC_A>;
++		amlogic,mmc-phases = <CLK_PHASE_180 CLK_PHASE_0 CLK_PHASE_0>;
+ 	};
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/general-meson-vdec-add-HEVC-decode-codec.patch
+++ b/patch/kernel/archive/meson64-6.1/general-meson-vdec-add-HEVC-decode-codec.patch
@@ -1,0 +1,1608 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: benjamin545 <benjamin545@gmail.com>
+Date: Thu, 15 Jul 2021 17:08:42 -0400
+Subject: WIP: drivers: meson: vdec: add HEVC decode codec
+
+Unknown patch. From LibreELEC?
+---
+ drivers/staging/media/meson/vdec/Makefile        |    2 +-
+ drivers/staging/media/meson/vdec/codec_hevc.c    | 1440 ++++++++++
+ drivers/staging/media/meson/vdec/codec_hevc.h    |   13 +
+ drivers/staging/media/meson/vdec/esparser.c      |    2 +-
+ drivers/staging/media/meson/vdec/hevc_regs.h     |    1 +
+ drivers/staging/media/meson/vdec/vdec_platform.c |   49 +
+ 6 files changed, 1505 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/staging/media/meson/vdec/Makefile b/drivers/staging/media/meson/vdec/Makefile
+index 6e726af84ac9..16f848e456b9 100644
+--- a/drivers/staging/media/meson/vdec/Makefile
++++ b/drivers/staging/media/meson/vdec/Makefile
+@@ -3,6 +3,6 @@
+ 
+ meson-vdec-objs = esparser.o vdec.o vdec_helpers.o vdec_platform.o
+ meson-vdec-objs += vdec_1.o vdec_hevc.o
+-meson-vdec-objs += codec_mpeg12.o codec_h264.o codec_hevc_common.o codec_vp9.o
++meson-vdec-objs += codec_mpeg12.o codec_h264.o codec_hevc_common.o codec_vp9.o codec_hevc.o
+ 
+ obj-$(CONFIG_VIDEO_MESON_VDEC) += meson-vdec.o
+diff --git a/drivers/staging/media/meson/vdec/codec_hevc.c b/drivers/staging/media/meson/vdec/codec_hevc.c
+new file mode 100644
+index 000000000000..3a6fd04a2d33
+--- /dev/null
++++ b/drivers/staging/media/meson/vdec/codec_hevc.c
+@@ -0,0 +1,1440 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright (C) 2018 Maxime Jourdan <mjourdan@baylibre.com>
++ * Copyright (C) 2015 Amlogic, Inc. All rights reserved.
++ */
++
++#include <media/v4l2-mem2mem.h>
++#include <media/videobuf2-dma-contig.h>
++
++#include "codec_hevc.h"
++#include "dos_regs.h"
++#include "hevc_regs.h"
++#include "vdec_helpers.h"
++#include "codec_hevc_common.h"
++
++/* HEVC reg mapping */
++#define HEVC_DEC_STATUS_REG	HEVC_ASSIST_SCRATCH_0
++	#define HEVC_ACTION_DONE	0xff
++#define HEVC_RPM_BUFFER		HEVC_ASSIST_SCRATCH_1
++#define HEVC_SHORT_TERM_RPS	HEVC_ASSIST_SCRATCH_2
++#define HEVC_VPS_BUFFER		HEVC_ASSIST_SCRATCH_3
++#define HEVC_SPS_BUFFER		HEVC_ASSIST_SCRATCH_4
++#define HEVC_PPS_BUFFER		HEVC_ASSIST_SCRATCH_5
++#define HEVC_SAO_UP		HEVC_ASSIST_SCRATCH_6
++#define HEVC_STREAM_SWAP_BUFFER HEVC_ASSIST_SCRATCH_7
++#define H265_MMU_MAP_BUFFER	HEVC_ASSIST_SCRATCH_7
++#define HEVC_STREAM_SWAP_BUFFER2 HEVC_ASSIST_SCRATCH_8
++#define HEVC_sao_mem_unit	HEVC_ASSIST_SCRATCH_9
++#define HEVC_SAO_ABV		HEVC_ASSIST_SCRATCH_A
++#define HEVC_sao_vb_size	HEVC_ASSIST_SCRATCH_B
++#define HEVC_SAO_VB		HEVC_ASSIST_SCRATCH_C
++#define HEVC_SCALELUT		HEVC_ASSIST_SCRATCH_D
++#define HEVC_WAIT_FLAG		HEVC_ASSIST_SCRATCH_E
++#define RPM_CMD_REG		HEVC_ASSIST_SCRATCH_F
++#define LMEM_DUMP_ADR		HEVC_ASSIST_SCRATCH_F
++#define DEBUG_REG1		HEVC_ASSIST_SCRATCH_G
++#define HEVC_DECODE_MODE2	HEVC_ASSIST_SCRATCH_H
++#define NAL_SEARCH_CTL		HEVC_ASSIST_SCRATCH_I
++#define HEVC_DECODE_MODE	HEVC_ASSIST_SCRATCH_J
++	#define DECODE_MODE_SINGLE 0
++#define DECODE_STOP_POS		HEVC_ASSIST_SCRATCH_K
++#define HEVC_AUX_ADR		HEVC_ASSIST_SCRATCH_L
++#define HEVC_AUX_DATA_SIZE	HEVC_ASSIST_SCRATCH_M
++#define HEVC_DECODE_SIZE	HEVC_ASSIST_SCRATCH_N
++
++#define AMRISC_MAIN_REQ		 0x04
++
++/* HEVC Constants */
++#define MAX_REF_PIC_NUM		24
++#define MAX_REF_ACTIVE		16
++#define MAX_TILE_COL_NUM	10
++#define MAX_TILE_ROW_NUM	20
++#define MAX_SLICE_NUM		800
++#define INVALID_POC		0x80000000
++
++/* HEVC Workspace layout */
++#define MPRED_MV_BUF_SIZE 0x120000
++
++#define IPP_SIZE	0x4000
++#define SAO_ABV_SIZE	0x30000
++#define SAO_VB_SIZE	0x30000
++#define SH_TM_RPS_SIZE	0x800
++#define VPS_SIZE	0x800
++#define SPS_SIZE	0x800
++#define PPS_SIZE	0x2000
++#define SAO_UP_SIZE	0x2800
++#define SWAP_BUF_SIZE	0x800
++#define SWAP_BUF2_SIZE	0x800
++#define SCALELUT_SIZE	0x8000
++#define DBLK_PARA_SIZE	0x20000
++#define DBLK_DATA_SIZE	0x80000
++#define DBLK_DATA2_SIZE	0x80000
++#define MMU_VBH_SIZE	0x5000
++#define MPRED_ABV_SIZE	0x8000
++#define MPRED_MV_SIZE	(MPRED_MV_BUF_SIZE * MAX_REF_PIC_NUM)
++#define RPM_BUF_SIZE	0x100
++#define LMEM_SIZE	0xA00
++
++#define IPP_OFFSET       0x00
++#define SAO_ABV_OFFSET   (IPP_OFFSET + IPP_SIZE)
++#define SAO_VB_OFFSET    (SAO_ABV_OFFSET + SAO_ABV_SIZE)
++#define SH_TM_RPS_OFFSET (SAO_VB_OFFSET + SAO_VB_SIZE)
++#define VPS_OFFSET       (SH_TM_RPS_OFFSET + SH_TM_RPS_SIZE)
++#define SPS_OFFSET       (VPS_OFFSET + VPS_SIZE)
++#define PPS_OFFSET       (SPS_OFFSET + SPS_SIZE)
++#define SAO_UP_OFFSET    (PPS_OFFSET + PPS_SIZE)
++#define SWAP_BUF_OFFSET  (SAO_UP_OFFSET + SAO_UP_SIZE)
++#define SWAP_BUF2_OFFSET (SWAP_BUF_OFFSET + SWAP_BUF_SIZE)
++#define SCALELUT_OFFSET  (SWAP_BUF2_OFFSET + SWAP_BUF2_SIZE)
++#define DBLK_PARA_OFFSET (SCALELUT_OFFSET + SCALELUT_SIZE)
++#define DBLK_DATA_OFFSET (DBLK_PARA_OFFSET + DBLK_PARA_SIZE)
++#define DBLK_DATA2_OFFSET (DBLK_DATA_OFFSET + DBLK_DATA_SIZE)
++#define MMU_VBH_OFFSET   (DBLK_DATA2_OFFSET + DBLK_DATA2_SIZE)
++#define MPRED_ABV_OFFSET (MMU_VBH_OFFSET + MMU_VBH_SIZE)
++#define MPRED_MV_OFFSET  (MPRED_ABV_OFFSET + MPRED_ABV_SIZE)
++#define RPM_OFFSET       (MPRED_MV_OFFSET + MPRED_MV_SIZE)
++#define LMEM_OFFSET      (RPM_OFFSET + RPM_BUF_SIZE)
++
++/* ISR decode status */
++#define HEVC_DEC_IDLE                        0x0
++#define HEVC_NAL_UNIT_VPS                    0x1
++#define HEVC_NAL_UNIT_SPS                    0x2
++#define HEVC_NAL_UNIT_PPS                    0x3
++#define HEVC_NAL_UNIT_CODED_SLICE_SEGMENT    0x4
++#define HEVC_CODED_SLICE_SEGMENT_DAT         0x5
++#define HEVC_SLICE_DECODING                  0x6
++#define HEVC_NAL_UNIT_SEI                    0x7
++#define HEVC_SLICE_SEGMENT_DONE              0x8
++#define HEVC_NAL_SEARCH_DONE                 0x9
++#define HEVC_DECPIC_DATA_DONE                0xa
++#define HEVC_DECPIC_DATA_ERROR               0xb
++#define HEVC_SEI_DAT                         0xc
++#define HEVC_SEI_DAT_DONE                    0xd
++
++/* RPM misc_flag0 */
++#define PCM_LOOP_FILTER_DISABLED_FLAG_BIT		0
++#define PCM_ENABLE_FLAG_BIT				1
++#define LOOP_FILER_ACROSS_TILES_ENABLED_FLAG_BIT	2
++#define PPS_LOOP_FILTER_ACROSS_SLICES_ENABLED_FLAG_BIT	3
++#define DEBLOCKING_FILTER_OVERRIDE_ENABLED_FLAG_BIT	4
++#define PPS_DEBLOCKING_FILTER_DISABLED_FLAG_BIT		5
++#define DEBLOCKING_FILTER_OVERRIDE_FLAG_BIT		6
++#define SLICE_DEBLOCKING_FILTER_DISABLED_FLAG_BIT	7
++#define SLICE_SAO_LUMA_FLAG_BIT				8
++#define SLICE_SAO_CHROMA_FLAG_BIT			9
++#define SLICE_LOOP_FILTER_ACROSS_SLICES_ENABLED_FLAG_BIT 10
++
++/* Constants for HEVC_MPRED_CTRL1 */
++#define AMVP_MAX_NUM_CANDS_MEM	3
++#define AMVP_MAX_NUM_CANDS	2
++#define NUM_CHROMA_MODE		5
++#define DM_CHROMA_IDX		36
++
++/* Buffer sizes */
++#define SIZE_WORKSPACE ALIGN(LMEM_OFFSET + LMEM_SIZE, 64 * SZ_1K)
++#define SIZE_AUX (SZ_1K * 16)
++#define SIZE_FRAME_MMU (0x1200 * 4)
++#define RPM_SIZE 0x80
++#define RPS_USED_BIT 14
++
++/* Data received from the HW in this form, do not rearrange */
++union rpm_param {
++	struct {
++		u16 data[RPM_SIZE];
++	} l;
++	struct {
++		u16 CUR_RPS[MAX_REF_ACTIVE];
++		u16 num_ref_idx_l0_active;
++		u16 num_ref_idx_l1_active;
++		u16 slice_type;
++		u16 slice_temporal_mvp_enable_flag;
++		u16 dependent_slice_segment_flag;
++		u16 slice_segment_address;
++		u16 num_title_rows_minus1;
++		u16 pic_width_in_luma_samples;
++		u16 pic_height_in_luma_samples;
++		u16 log2_min_coding_block_size_minus3;
++		u16 log2_diff_max_min_coding_block_size;
++		u16 log2_max_pic_order_cnt_lsb_minus4;
++		u16 POClsb;
++		u16 collocated_from_l0_flag;
++		u16 collocated_ref_idx;
++		u16 log2_parallel_merge_level;
++		u16 five_minus_max_num_merge_cand;
++		u16 sps_num_reorder_pics_0;
++		u16 modification_flag;
++		u16 tiles_flags;
++		u16 num_tile_columns_minus1;
++		u16 num_tile_rows_minus1;
++		u16 tile_width[8];
++		u16 tile_height[8];
++		u16 misc_flag0;
++		u16 pps_beta_offset_div2;
++		u16 pps_tc_offset_div2;
++		u16 slice_beta_offset_div2;
++		u16 slice_tc_offset_div2;
++		u16 pps_cb_qp_offset;
++		u16 pps_cr_qp_offset;
++		u16 first_slice_segment_in_pic_flag;
++		u16 m_temporalId;
++		u16 m_nalUnitType;
++		u16 vui_num_units_in_tick_hi;
++		u16 vui_num_units_in_tick_lo;
++		u16 vui_time_scale_hi;
++		u16 vui_time_scale_lo;
++		u16 bit_depth;
++		u16 profile_etc;
++		u16 sei_frame_field_info;
++		u16 video_signal_type;
++		u16 modification_list[0x20];
++		u16 conformance_window_flag;
++		u16 conf_win_left_offset;
++		u16 conf_win_right_offset;
++		u16 conf_win_top_offset;
++		u16 conf_win_bottom_offset;
++		u16 chroma_format_idc;
++		u16 color_description;
++		u16 aspect_ratio_idc;
++		u16 sar_width;
++		u16 sar_height;
++	} p;
++};
++
++enum nal_unit_type {
++	NAL_UNIT_CODED_SLICE_BLA	= 16,
++	NAL_UNIT_CODED_SLICE_BLANT	= 17,
++	NAL_UNIT_CODED_SLICE_BLA_N_LP	= 18,
++	NAL_UNIT_CODED_SLICE_IDR	= 19,
++	NAL_UNIT_CODED_SLICE_IDR_N_LP	= 20,
++};
++
++enum slice_type {
++	B_SLICE = 0,
++	P_SLICE = 1,
++	I_SLICE = 2,
++};
++
++/* A frame being decoded */
++struct hevc_frame {
++	struct list_head list;
++	struct vb2_v4l2_buffer *vbuf;
++	u32 offset;
++	u32 poc;
++
++	int referenced;
++	u32 num_reorder_pic;
++
++	u32 cur_slice_idx;
++	u32 cur_slice_type;
++
++	/* 2 lists (L0/L1) ; 800 slices ; 16 refs */
++	u32 ref_poc_list[2][MAX_SLICE_NUM][MAX_REF_ACTIVE];
++	u32 ref_num[2];
++};
++
++struct codec_hevc {
++	struct mutex lock;
++
++	/* Common part of the HEVC decoder */
++	struct codec_hevc_common common;
++
++	/* Buffer for the HEVC Workspace */
++	void      *workspace_vaddr;
++	dma_addr_t workspace_paddr;
++
++	/* AUX buffer */
++	void      *aux_vaddr;
++	dma_addr_t aux_paddr;
++
++	/* Contains many information parsed from the bitstream */
++	union rpm_param rpm_param;
++
++	/* Information computed from the RPM */
++	u32 lcu_size; // Largest Coding Unit
++	u32 lcu_x_num;
++	u32 lcu_y_num;
++	u32 lcu_total;
++
++	/* Current Frame being handled */
++	struct hevc_frame *cur_frame;
++	u32 curr_poc;
++	/* Collocated Reference Picture */
++	struct hevc_frame *col_frame;
++	u32 col_poc;
++
++	/* All ref frames used by the HW at a given time */
++	struct list_head ref_frames_list;
++	u32 frames_num;
++
++	/* Coded resolution reported by the hardware */
++	u32 width, height;
++	/* Resolution minus the conformance window offsets */
++	u32 dst_width, dst_height;
++
++	u32 prev_tid0_poc;
++	u32 slice_segment_addr;
++	u32 slice_addr;
++	u32 ldc_flag;
++
++	/* Whether we detected the bitstream as 10-bit */
++	int is_10bit;
++};
++
++static u32 codec_hevc_num_pending_bufs(struct amvdec_session *sess)
++{
++	struct codec_hevc *hevc;
++	u32 ret;
++
++	hevc = sess->priv;
++	if (!hevc)
++		return 0;
++
++	mutex_lock(&hevc->lock);
++	ret = hevc->frames_num;
++	mutex_unlock(&hevc->lock);
++
++	return ret;
++}
++
++/* Update the L0 and L1 reference lists for a given frame */
++static void codec_hevc_update_frame_refs(struct amvdec_session *sess,
++					 struct hevc_frame *frame)
++{
++	struct codec_hevc *hevc = sess->priv;
++	union rpm_param *params = &hevc->rpm_param;
++	int num_ref_idx_l0_active =
++		(params->p.num_ref_idx_l0_active > MAX_REF_ACTIVE) ?
++		MAX_REF_ACTIVE : params->p.num_ref_idx_l0_active;
++	int num_ref_idx_l1_active =
++		(params->p.num_ref_idx_l1_active > MAX_REF_ACTIVE) ?
++		MAX_REF_ACTIVE : params->p.num_ref_idx_l1_active;
++	int ref_picset0[MAX_REF_ACTIVE] = { 0 };
++	int ref_picset1[MAX_REF_ACTIVE] = { 0 };
++	u16 *mod_list = params->p.modification_list;
++	int num_neg = 0;
++	int num_pos = 0;
++	int total_num;
++	int i;
++
++	for (i = 0; i < MAX_REF_ACTIVE; i++) {
++		frame->ref_poc_list[0][frame->cur_slice_idx][i] = 0;
++		frame->ref_poc_list[1][frame->cur_slice_idx][i] = 0;
++	}
++
++	for (i = 0; i < MAX_REF_ACTIVE; i++) {
++		u16 cur_rps = params->p.CUR_RPS[i];
++		int delt = cur_rps & ((1 << (RPS_USED_BIT - 1)) - 1);
++
++		if (cur_rps & 0x8000)
++			break;
++
++		if (!((cur_rps >> RPS_USED_BIT) & 1))
++			continue;
++
++		if ((cur_rps >> (RPS_USED_BIT - 1)) & 1) {
++			ref_picset0[num_neg] =
++			       frame->poc - ((1 << (RPS_USED_BIT - 1)) - delt);
++			num_neg++;
++		} else {
++			ref_picset1[num_pos] = frame->poc + delt;
++			num_pos++;
++		}
++	}
++
++	total_num = num_neg + num_pos;
++
++	if (total_num <= 0)
++		goto end;
++
++	for (i = 0; i < num_ref_idx_l0_active; i++) {
++		int cidx;
++		if (params->p.modification_flag & 0x1)
++			cidx = mod_list[i];
++		else
++			cidx = i % total_num;
++
++		frame->ref_poc_list[0][frame->cur_slice_idx][i] =
++			cidx >= num_neg ? ref_picset1[cidx - num_neg] :
++			ref_picset0[cidx];
++	}
++
++	if (params->p.slice_type != B_SLICE)
++		goto end;
++
++	if (params->p.modification_flag & 0x2) {
++		for (i = 0; i < num_ref_idx_l1_active; i++) {
++			int cidx;
++			if (params->p.modification_flag & 0x1)
++				cidx = mod_list[num_ref_idx_l0_active + i];
++			else
++				cidx = mod_list[i];
++
++			frame->ref_poc_list[1][frame->cur_slice_idx][i] =
++				(cidx >= num_pos) ? ref_picset0[cidx - num_pos]
++				: ref_picset1[cidx];
++		}
++	} else {
++		for (i = 0; i < num_ref_idx_l1_active; i++) {
++			int cidx = i % total_num;
++			frame->ref_poc_list[1][frame->cur_slice_idx][i] =
++				cidx >= num_pos ? ref_picset0[cidx - num_pos] :
++				ref_picset1[cidx];
++		}
++	}
++
++end:
++	frame->ref_num[0] = num_ref_idx_l0_active;
++	frame->ref_num[1] = num_ref_idx_l1_active;
++
++	dev_dbg(sess->core->dev,
++		"Frame %u; slice %u; slice_type %u; num_l0 %u; num_l1 %u\n",
++		frame->poc, frame->cur_slice_idx, params->p.slice_type,
++		frame->ref_num[0], frame->ref_num[1]);
++}
++
++static void codec_hevc_update_ldc_flag(struct codec_hevc *hevc)
++{
++	struct hevc_frame *frame = hevc->cur_frame;
++	u32 slice_type = frame->cur_slice_type;
++	u32 slice_idx = frame->cur_slice_idx;
++	int i;
++
++	hevc->ldc_flag = 0;
++
++	if (slice_type == I_SLICE)
++		return;
++
++	hevc->ldc_flag = 1;
++	for (i = 0; (i < frame->ref_num[0]) && hevc->ldc_flag; i++) {
++		if (frame->ref_poc_list[0][slice_idx][i] > frame->poc) {
++			hevc->ldc_flag = 0;
++			break;
++		}
++	}
++
++	if (slice_type == P_SLICE)
++		return;
++
++	for (i = 0; (i < frame->ref_num[1]) && hevc->ldc_flag; i++) {
++		if (frame->ref_poc_list[1][slice_idx][i] > frame->poc) {
++			hevc->ldc_flag = 0;
++			break;
++		}
++	}
++}
++
++/* Tag "old" frames that are no longer referenced */
++static void codec_hevc_update_referenced(struct codec_hevc *hevc)
++{
++	union rpm_param *param = &hevc->rpm_param;
++	struct hevc_frame *frame;
++	int i;
++	u32 curr_poc = hevc->curr_poc;
++
++	list_for_each_entry(frame, &hevc->ref_frames_list, list) {
++		int is_referenced = 0;
++		u32 poc_tmp;
++
++		if (!frame->referenced)
++			continue;
++
++		for (i = 0; i < MAX_REF_ACTIVE; i++) {
++			int delt;
++			if (param->p.CUR_RPS[i] & 0x8000)
++				break;
++
++			delt = param->p.CUR_RPS[i] &
++			       ((1 << (RPS_USED_BIT - 1)) - 1);
++			if (param->p.CUR_RPS[i] & (1 << (RPS_USED_BIT - 1))) {
++				poc_tmp = curr_poc -
++					  ((1 << (RPS_USED_BIT - 1)) - delt);
++			} else
++				poc_tmp = curr_poc + delt;
++			if (poc_tmp == frame->poc) {
++				is_referenced = 1;
++				break;
++			}
++		}
++
++		frame->referenced = is_referenced;
++	}
++}
++
++static struct hevc_frame *
++codec_hevc_get_lowest_poc_frame(struct codec_hevc *hevc)
++{
++	struct hevc_frame *tmp, *ret = NULL;
++	u32 poc = INT_MAX;
++
++	list_for_each_entry(tmp, &hevc->ref_frames_list, list) {
++		if (tmp->poc < poc) {
++			ret = tmp;
++			poc = tmp->poc;
++		}
++	}
++
++	return ret;
++}
++
++/* Try to output as many frames as possible */
++static void codec_hevc_output_frames(struct amvdec_session *sess)
++{
++	struct hevc_frame *tmp;
++	struct codec_hevc *hevc = sess->priv;
++
++	while ((tmp = codec_hevc_get_lowest_poc_frame(hevc))) {
++		if (hevc->curr_poc &&
++		    (tmp->referenced ||
++		     tmp->num_reorder_pic >= hevc->frames_num))
++			break;
++
++		dev_dbg(sess->core->dev, "DONE frame poc %u; vbuf %u\n",
++			tmp->poc, tmp->vbuf->vb2_buf.index);
++		amvdec_dst_buf_done_offset(sess, tmp->vbuf, tmp->offset,
++					   V4L2_FIELD_NONE, false);
++		list_del(&tmp->list);
++		kfree(tmp);
++		hevc->frames_num--;
++	}
++}
++
++
++static int
++codec_hevc_setup_workspace(struct amvdec_session *sess,
++			   struct codec_hevc *hevc)
++{
++	struct amvdec_core *core = sess->core;
++	u32 revision = core->platform->revision;
++	dma_addr_t wkaddr;
++
++	/* Allocate some memory for the HEVC decoder's state */
++	hevc->workspace_vaddr = dma_alloc_coherent(core->dev, SIZE_WORKSPACE,
++						   &wkaddr, GFP_KERNEL);
++	if (!hevc->workspace_vaddr)
++		return -ENOMEM;
++
++	hevc->workspace_paddr = wkaddr;
++
++	amvdec_write_dos(core, HEVCD_IPP_LINEBUFF_BASE, wkaddr + IPP_OFFSET);
++	amvdec_write_dos(core, HEVC_RPM_BUFFER, wkaddr + RPM_OFFSET);
++	amvdec_write_dos(core, HEVC_SHORT_TERM_RPS, wkaddr + SH_TM_RPS_OFFSET);
++	amvdec_write_dos(core, HEVC_VPS_BUFFER, wkaddr + VPS_OFFSET);
++	amvdec_write_dos(core, HEVC_SPS_BUFFER, wkaddr + SPS_OFFSET);
++	amvdec_write_dos(core, HEVC_PPS_BUFFER, wkaddr + PPS_OFFSET);
++	amvdec_write_dos(core, HEVC_SAO_UP, wkaddr + SAO_UP_OFFSET);
++
++	if (codec_hevc_use_mmu(revision, sess->pixfmt_cap, hevc->is_10bit)) {
++		amvdec_write_dos(core, HEVC_SAO_MMU_VH0_ADDR,
++				 wkaddr + MMU_VBH_OFFSET);
++		amvdec_write_dos(core, HEVC_SAO_MMU_VH1_ADDR,
++				 wkaddr + MMU_VBH_OFFSET + (MMU_VBH_SIZE / 2));
++
++		if (revision >= VDEC_REVISION_G12A)
++			amvdec_write_dos(core, HEVC_ASSIST_MMU_MAP_ADDR,
++					 hevc->common.mmu_map_paddr);
++		else
++			amvdec_write_dos(core, H265_MMU_MAP_BUFFER,
++					 hevc->common.mmu_map_paddr);
++	} else if (revision < VDEC_REVISION_G12A) {
++		amvdec_write_dos(core, HEVC_STREAM_SWAP_BUFFER,
++				 wkaddr + SWAP_BUF_OFFSET);
++		amvdec_write_dos(core, HEVC_STREAM_SWAP_BUFFER2,
++				 wkaddr + SWAP_BUF2_OFFSET);
++	}
++
++	amvdec_write_dos(core, HEVC_SCALELUT, wkaddr + SCALELUT_OFFSET);
++	amvdec_write_dos(core, HEVC_DBLK_CFG4, wkaddr + DBLK_PARA_OFFSET);
++	amvdec_write_dos(core, HEVC_DBLK_CFG5, wkaddr + DBLK_DATA_OFFSET);
++	if (revision >= VDEC_REVISION_G12A)
++		amvdec_write_dos(core, HEVC_DBLK_CFGE,
++				 wkaddr + DBLK_DATA2_OFFSET);
++
++	amvdec_write_dos(core, LMEM_DUMP_ADR, wkaddr + LMEM_OFFSET);
++
++	return 0;
++}
++
++static int codec_hevc_start(struct amvdec_session *sess)
++{
++	struct amvdec_core *core = sess->core;
++	struct codec_hevc *hevc;
++	u32 val;
++	int i;
++	int ret;
++
++	hevc = kzalloc(sizeof(*hevc), GFP_KERNEL);
++	if (!hevc)
++		return -ENOMEM;
++
++	INIT_LIST_HEAD(&hevc->ref_frames_list);
++	hevc->curr_poc = INVALID_POC;
++
++	ret = codec_hevc_setup_workspace(sess, hevc);
++	if (ret)
++		goto free_hevc;
++
++	val = BIT(0); /* stream_fetch_enable */
++	if (core->platform->revision >= VDEC_REVISION_G12A)
++		val |= (0xf << 25); /* arwlen_axi_max */
++	amvdec_write_dos_bits(core, HEVC_STREAM_CONTROL, val);
++
++	val = amvdec_read_dos(core, HEVC_PARSER_INT_CONTROL) & 0x03ffffff;
++	val |= (3 << 29) | BIT(27) | BIT(24) | BIT(22) | BIT(7) | BIT(4) |
++	       BIT(0);
++	amvdec_write_dos(core, HEVC_PARSER_INT_CONTROL, val);
++	amvdec_write_dos_bits(core, HEVC_SHIFT_STATUS, BIT(1) | BIT(0));
++	amvdec_write_dos(core, HEVC_SHIFT_CONTROL,
++			 (3 << 6) | BIT(5) | BIT(2) | BIT(0));
++	amvdec_write_dos(core, HEVC_CABAC_CONTROL, 1);
++	amvdec_write_dos(core, HEVC_PARSER_CORE_CONTROL, 1);
++	amvdec_write_dos(core, HEVC_DEC_STATUS_REG, 0);
++
++	amvdec_write_dos(core, HEVC_IQIT_SCALELUT_WR_ADDR, 0);
++	for (i = 0; i < 1024; ++i)
++		amvdec_write_dos(core, HEVC_IQIT_SCALELUT_DATA, 0);
++
++	amvdec_write_dos(core, HEVC_DECODE_SIZE, 0);
++
++	amvdec_write_dos(core, HEVC_PARSER_CMD_WRITE, BIT(16));
++	for (i = 0; i < ARRAY_SIZE(vdec_hevc_parser_cmd); ++i)
++		amvdec_write_dos(core, HEVC_PARSER_CMD_WRITE,
++				 vdec_hevc_parser_cmd[i]);
++
++	amvdec_write_dos(core, HEVC_PARSER_CMD_SKIP_0, PARSER_CMD_SKIP_CFG_0);
++	amvdec_write_dos(core, HEVC_PARSER_CMD_SKIP_1, PARSER_CMD_SKIP_CFG_1);
++	amvdec_write_dos(core, HEVC_PARSER_CMD_SKIP_2, PARSER_CMD_SKIP_CFG_2);
++	amvdec_write_dos(core, HEVC_PARSER_IF_CONTROL,
++			 BIT(5) | BIT(2) | BIT(0));
++
++	amvdec_write_dos(core, HEVCD_IPP_TOP_CNTL, BIT(0));
++	amvdec_write_dos(core, HEVCD_IPP_TOP_CNTL, BIT(1));
++
++	amvdec_write_dos(core, HEVC_WAIT_FLAG, 1);
++
++	/* clear mailbox interrupt */
++	amvdec_write_dos(core, HEVC_ASSIST_MBOX1_CLR_REG, 1);
++	/* enable mailbox interrupt */
++	amvdec_write_dos(core, HEVC_ASSIST_MBOX1_MASK, 1);
++	/* disable PSCALE for hardware sharing */
++	amvdec_write_dos(core, HEVC_PSCALE_CTRL, 0);
++	/* Let the uCode do all the parsing */
++	amvdec_write_dos(core, NAL_SEARCH_CTL, 0xc);
++
++	amvdec_write_dos(core, DECODE_STOP_POS, 0);
++	amvdec_write_dos(core, HEVC_DECODE_MODE, DECODE_MODE_SINGLE);
++	amvdec_write_dos(core, HEVC_DECODE_MODE2, 0);
++
++	/* AUX buffers */
++	hevc->aux_vaddr = dma_alloc_coherent(core->dev, SIZE_AUX,
++					     &hevc->aux_paddr, GFP_KERNEL);
++	if (!hevc->aux_vaddr) {
++		dev_err(core->dev, "Failed to request HEVC AUX\n");
++		ret = -ENOMEM;
++		goto free_hevc;
++	}
++
++	amvdec_write_dos(core, HEVC_AUX_ADR, hevc->aux_paddr);
++	amvdec_write_dos(core, HEVC_AUX_DATA_SIZE,
++			 (((SIZE_AUX) >> 4) << 16) | 0);
++	mutex_init(&hevc->lock);
++	sess->priv = hevc;
++
++	return 0;
++
++free_hevc:
++	kfree(hevc);
++	return ret;
++}
++
++static void codec_hevc_flush_output(struct amvdec_session *sess)
++{
++	struct codec_hevc *hevc = sess->priv;
++	struct hevc_frame *tmp;
++
++	while (!list_empty(&hevc->ref_frames_list)) {
++		tmp = codec_hevc_get_lowest_poc_frame(hevc);
++		amvdec_dst_buf_done(sess, tmp->vbuf, V4L2_FIELD_NONE);
++		list_del(&tmp->list);
++		kfree(tmp);
++		hevc->frames_num--;
++	}
++}
++
++static int codec_hevc_stop(struct amvdec_session *sess)
++{
++	struct codec_hevc *hevc = sess->priv;
++	struct amvdec_core *core = sess->core;
++
++	mutex_lock(&hevc->lock);
++	codec_hevc_flush_output(sess);
++
++	if (hevc->workspace_vaddr)
++		dma_free_coherent(core->dev, SIZE_WORKSPACE,
++				  hevc->workspace_vaddr,
++				  hevc->workspace_paddr);
++
++	if (hevc->aux_vaddr)
++		dma_free_coherent(core->dev, SIZE_AUX,
++				  hevc->aux_vaddr, hevc->aux_paddr);
++
++	codec_hevc_free_fbc_buffers(sess, &hevc->common);
++	mutex_unlock(&hevc->lock);
++	mutex_destroy(&hevc->lock);
++
++	return 0;
++}
++
++static struct hevc_frame *
++codec_hevc_get_frame_by_poc(struct codec_hevc *hevc, u32 poc)
++{
++	struct hevc_frame *tmp;
++
++	list_for_each_entry(tmp, &hevc->ref_frames_list, list) {
++		if (tmp->poc == poc)
++			return tmp;
++	}
++
++	return NULL;
++}
++
++static struct hevc_frame *
++codec_hevc_prepare_new_frame(struct amvdec_session *sess)
++{
++	struct amvdec_core *core = sess->core;
++	struct hevc_frame *new_frame = NULL;
++	struct codec_hevc *hevc = sess->priv;
++	struct vb2_v4l2_buffer *vbuf;
++	union rpm_param *params = &hevc->rpm_param;
++
++	new_frame = kzalloc(sizeof(*new_frame), GFP_KERNEL);
++	if (!new_frame)
++		return NULL;
++
++	vbuf = v4l2_m2m_dst_buf_remove(sess->m2m_ctx);
++	if (!vbuf) {
++		dev_err(sess->core->dev, "No dst buffer available\n");
++		return NULL;
++	}
++
++	new_frame->vbuf = vbuf;
++	new_frame->referenced = 1;
++	new_frame->poc = hevc->curr_poc;
++	new_frame->cur_slice_type = params->p.slice_type;
++	new_frame->num_reorder_pic = params->p.sps_num_reorder_pics_0;
++	new_frame->offset = amvdec_read_dos(core, HEVC_SHIFT_BYTE_COUNT);
++
++	list_add_tail(&new_frame->list, &hevc->ref_frames_list);
++	hevc->frames_num++;
++
++	return new_frame;
++}
++
++static void
++codec_hevc_set_sao(struct amvdec_session *sess, struct hevc_frame *frame)
++{
++	struct amvdec_core *core = sess->core;
++	struct codec_hevc *hevc = sess->priv;
++	struct vb2_buffer *vb = &frame->vbuf->vb2_buf;
++	union rpm_param *param = &hevc->rpm_param;
++	u32 pic_height_cu =
++		(hevc->height + hevc->lcu_size - 1) / hevc->lcu_size;
++	u32 sao_mem_unit = (hevc->lcu_size == 16 ? 9 :
++			   hevc->lcu_size == 32 ? 14 : 24) << 4;
++	u32 sao_vb_size = (sao_mem_unit + (2 << 4)) * pic_height_cu;
++	u32 misc_flag0 = param->p.misc_flag0;
++	dma_addr_t buf_y_paddr;
++	dma_addr_t buf_u_v_paddr;
++	u32 slice_deblocking_filter_disabled_flag;
++	u32 val, val_2;
++
++	val = (amvdec_read_dos(core, HEVC_SAO_CTRL0) & ~0xf) |
++	      ilog2(hevc->lcu_size);
++	amvdec_write_dos(core, HEVC_SAO_CTRL0, val);
++
++	amvdec_write_dos(core, HEVC_SAO_PIC_SIZE,
++			 hevc->width | (hevc->height << 16));
++	amvdec_write_dos(core, HEVC_SAO_PIC_SIZE_LCU,
++			 (hevc->lcu_x_num - 1) | (hevc->lcu_y_num - 1) << 16);
++
++	if (codec_hevc_use_downsample(sess->pixfmt_cap, hevc->is_10bit) ||
++	    codec_hevc_use_mmu(core->platform->revision, sess->pixfmt_cap,
++			       hevc->is_10bit))
++		buf_y_paddr =
++		     hevc->common.fbc_buffer_paddr[vb->index];
++	else
++		buf_y_paddr =
++		       vb2_dma_contig_plane_dma_addr(vb, 0);
++
++	if (codec_hevc_use_fbc(sess->pixfmt_cap, hevc->is_10bit)) {
++		val = amvdec_read_dos(core, HEVC_SAO_CTRL5) & ~0xff0000;
++		amvdec_write_dos(core, HEVC_SAO_CTRL5, val);
++		amvdec_write_dos(core, HEVC_CM_BODY_START_ADDR, buf_y_paddr);
++	}
++
++	if (sess->pixfmt_cap == V4L2_PIX_FMT_NV12M) {
++		buf_y_paddr =
++		       vb2_dma_contig_plane_dma_addr(vb, 0);
++		buf_u_v_paddr =
++		       vb2_dma_contig_plane_dma_addr(vb, 1);
++		amvdec_write_dos(core, HEVC_SAO_Y_START_ADDR, buf_y_paddr);
++		amvdec_write_dos(core, HEVC_SAO_C_START_ADDR, buf_u_v_paddr);
++		amvdec_write_dos(core, HEVC_SAO_Y_WPTR, buf_y_paddr);
++		amvdec_write_dos(core, HEVC_SAO_C_WPTR, buf_u_v_paddr);
++	}
++
++	if (codec_hevc_use_mmu(core->platform->revision, sess->pixfmt_cap,
++			       hevc->is_10bit)) {
++		dma_addr_t header_adr = vb2_dma_contig_plane_dma_addr(vb, 0);
++		if (codec_hevc_use_downsample(sess->pixfmt_cap, hevc->is_10bit))
++			header_adr = hevc->common.mmu_header_paddr[vb->index];
++		amvdec_write_dos(core, HEVC_CM_HEADER_START_ADDR, header_adr);
++		/* use HEVC_CM_HEADER_START_ADDR */
++		amvdec_write_dos_bits(core, HEVC_SAO_CTRL5, BIT(10));
++		amvdec_write_dos_bits(core, HEVC_SAO_CTRL9, BIT(0));
++	}
++
++	amvdec_write_dos(core, HEVC_SAO_Y_LENGTH,
++			 amvdec_get_output_size(sess));
++	amvdec_write_dos(core, HEVC_SAO_C_LENGTH,
++			 (amvdec_get_output_size(sess) / 2));
++
++	if (frame->cur_slice_idx == 0) {
++		if (core->platform->revision >= VDEC_REVISION_G12A) {
++			if (core->platform->revision >= VDEC_REVISION_SM1)
++				val = 0xfc << 8;
++			else
++				val = 0x54 << 8;
++
++			/* enable first, compressed write */
++			if (codec_hevc_use_fbc(sess->pixfmt_cap,
++					       hevc->is_10bit))
++				val |= BIT(8);
++
++			/* enable second, uncompressed write */
++			if (sess->pixfmt_cap == V4L2_PIX_FMT_NV12M)
++				val |= BIT(9);
++
++			/* dblk pipeline mode=1 for performance */
++			if (hevc->width >= 1280)
++				val |= BIT(4);
++
++			amvdec_write_dos(core, HEVC_DBLK_CFGB, val);
++			amvdec_write_dos(core, HEVC_DBLK_STS1 + 16, BIT(28));
++		}
++
++		amvdec_write_dos(core, HEVC_DBLK_CFG2,
++				 hevc->width | (hevc->height << 16));
++
++		val = 0;
++		if ((misc_flag0 >> PCM_ENABLE_FLAG_BIT) & 0x1)
++			val |= ((misc_flag0 >>
++				 PCM_LOOP_FILTER_DISABLED_FLAG_BIT) & 0x1) << 3;
++
++		val |= (param->p.pps_cb_qp_offset & 0x1f) << 4;
++		val |= (param->p.pps_cr_qp_offset & 0x1f) << 9;
++		val |= (hevc->lcu_size == 64) ? 0 :
++		       ((hevc->lcu_size == 32) ? 1 : 2);
++		amvdec_write_dos(core, HEVC_DBLK_CFG1, val);
++	}
++
++	val = amvdec_read_dos(core, HEVC_SAO_CTRL1) & ~0x3ff3;
++	val |= 0xff0; /* Set endianness for 2-bytes swaps (nv12) */
++	if (core->platform->revision < VDEC_REVISION_G12A) {
++		if (!codec_hevc_use_fbc(sess->pixfmt_cap, hevc->is_10bit))
++			val |= BIT(0); /* disable cm compression */
++		/* TOFIX: Handle Amlogic Framebuffer compression */
++	}
++
++	amvdec_write_dos(core, HEVC_SAO_CTRL1, val);
++
++	if (!codec_hevc_use_fbc(sess->pixfmt_cap, hevc->is_10bit)) {
++		/* no downscale for NV12 */
++		val = amvdec_read_dos(core, HEVC_SAO_CTRL5) & ~0xff0000;
++		amvdec_write_dos(core, HEVC_SAO_CTRL5, val);
++	}
++
++	val = amvdec_read_dos(core, HEVCD_IPP_AXIIF_CONFIG) & ~0x30;
++	val |= 0xf;
++	amvdec_write_dos(core, HEVCD_IPP_AXIIF_CONFIG, val);
++
++	val = 0;
++	val_2 = amvdec_read_dos(core, HEVC_SAO_CTRL0);
++	val_2 &= (~0x300);
++
++	slice_deblocking_filter_disabled_flag = (misc_flag0 >>
++			SLICE_DEBLOCKING_FILTER_DISABLED_FLAG_BIT) & 0x1;
++	if ((misc_flag0 & (1 << DEBLOCKING_FILTER_OVERRIDE_ENABLED_FLAG_BIT))
++		&& (misc_flag0 & (1 << DEBLOCKING_FILTER_OVERRIDE_FLAG_BIT))) {
++		val |= slice_deblocking_filter_disabled_flag << 2;
++
++		if (!slice_deblocking_filter_disabled_flag) {
++			val |= (param->p.slice_beta_offset_div2 & 0xf) << 3;
++			val |= (param->p.slice_tc_offset_div2 & 0xf) << 7;
++		}
++	} else {
++		val |=
++			((misc_flag0 >>
++			  PPS_DEBLOCKING_FILTER_DISABLED_FLAG_BIT) & 0x1) << 2;
++
++		if (((misc_flag0 >> PPS_DEBLOCKING_FILTER_DISABLED_FLAG_BIT) &
++			 0x1) == 0) {
++			val |= (param->p.pps_beta_offset_div2 & 0xf) << 3;
++			val |= (param->p.pps_tc_offset_div2 & 0xf) << 7;
++		}
++	}
++	if ((misc_flag0 & (1 << PPS_LOOP_FILTER_ACROSS_SLICES_ENABLED_FLAG_BIT))
++		&& ((misc_flag0 & (1 << SLICE_SAO_LUMA_FLAG_BIT))
++			|| (misc_flag0 & (1 << SLICE_SAO_CHROMA_FLAG_BIT))
++			|| (!slice_deblocking_filter_disabled_flag))) {
++		val |=
++			((misc_flag0 >>
++			  SLICE_LOOP_FILTER_ACROSS_SLICES_ENABLED_FLAG_BIT)
++			 & 0x1)	<< 1;
++		val_2 |=
++			((misc_flag0 >>
++			  SLICE_LOOP_FILTER_ACROSS_SLICES_ENABLED_FLAG_BIT)
++			& 0x1) << 9;
++	} else {
++		val |=
++			((misc_flag0 >>
++			  PPS_LOOP_FILTER_ACROSS_SLICES_ENABLED_FLAG_BIT)
++			 & 0x1) << 1;
++		val_2 |=
++			((misc_flag0 >>
++			  PPS_LOOP_FILTER_ACROSS_SLICES_ENABLED_FLAG_BIT)
++			 & 0x1) << 9;
++	}
++
++	amvdec_write_dos(core, HEVC_DBLK_CFG9, val);
++	amvdec_write_dos(core, HEVC_SAO_CTRL0, val_2);
++
++	amvdec_write_dos(core, HEVC_sao_mem_unit, sao_mem_unit);
++	amvdec_write_dos(core, HEVC_SAO_ABV,
++			 hevc->workspace_paddr + SAO_ABV_OFFSET);
++	amvdec_write_dos(core, HEVC_sao_vb_size, sao_vb_size);
++	amvdec_write_dos(core, HEVC_SAO_VB,
++			 hevc->workspace_paddr + SAO_VB_OFFSET);
++}
++
++static dma_addr_t codec_hevc_get_frame_mv_paddr(struct codec_hevc *hevc,
++						struct hevc_frame *frame)
++{
++	return hevc->workspace_paddr + MPRED_MV_OFFSET +
++		(frame->vbuf->vb2_buf.index * MPRED_MV_BUF_SIZE);
++}
++
++static void
++codec_hevc_set_mpred_ctrl(struct amvdec_core *core, struct codec_hevc *hevc)
++{
++	union rpm_param *param = &hevc->rpm_param;
++	u32 slice_type = param->p.slice_type;
++	u32 lcu_size_log2 = ilog2(hevc->lcu_size);
++	u32 val;
++
++	val = slice_type |
++	      MPRED_CTRL0_ABOVE_EN |
++	      MPRED_CTRL0_MV_WR_EN |
++	      MPRED_CTRL0_BUF_LINEAR |
++	      (lcu_size_log2 << 16) |
++	      (3 << 20) | /* cu_size_log2 */
++	      (param->p.log2_parallel_merge_level << 24);
++
++	if (slice_type != I_SLICE)
++		val |= MPRED_CTRL0_MV_RD_EN;
++
++	if (param->p.collocated_from_l0_flag)
++		val |= MPRED_CTRL0_COL_FROM_L0;
++
++	if (param->p.slice_temporal_mvp_enable_flag)
++		val |= MPRED_CTRL0_TMVP;
++
++	if (hevc->ldc_flag)
++		val |= MPRED_CTRL0_LDC;
++
++	if (param->p.dependent_slice_segment_flag)
++		val |= MPRED_CTRL0_NEW_SLI_SEG;
++
++	if (param->p.slice_segment_address == 0)
++		val |= MPRED_CTRL0_NEW_PIC |
++		       MPRED_CTRL0_NEW_TILE;
++
++	amvdec_write_dos(core, HEVC_MPRED_CTRL0, val);
++
++	val = (5 - param->p.five_minus_max_num_merge_cand) |
++	      (AMVP_MAX_NUM_CANDS << 4) |
++	      (AMVP_MAX_NUM_CANDS_MEM << 8) |
++	      (NUM_CHROMA_MODE << 12) |
++	      (DM_CHROMA_IDX << 16);
++	amvdec_write_dos(core, HEVC_MPRED_CTRL1, val);
++}
++
++static void codec_hevc_set_mpred_mv(struct amvdec_core *core,
++				    struct codec_hevc *hevc,
++				    struct hevc_frame *frame,
++				    struct hevc_frame *col_frame)
++{
++	union rpm_param *param = &hevc->rpm_param;
++	u32 lcu_size_log2 = ilog2(hevc->lcu_size);
++	u32 mv_mem_unit = lcu_size_log2 == 6 ? 0x200 :
++			  lcu_size_log2 == 5 ? 0x80 : 0x20;
++	dma_addr_t col_mv_rd_start_addr, col_mv_rd_ptr, col_mv_rd_end_addr;
++	dma_addr_t mpred_mv_wr_ptr;
++	u32 val;
++
++	val = amvdec_read_dos(core, HEVC_MPRED_CURR_LCU);
++
++	col_mv_rd_start_addr = codec_hevc_get_frame_mv_paddr(hevc, col_frame);
++	mpred_mv_wr_ptr = codec_hevc_get_frame_mv_paddr(hevc, frame) +
++			  (hevc->slice_addr * mv_mem_unit);
++	col_mv_rd_ptr = col_mv_rd_start_addr +
++			(hevc->slice_addr * mv_mem_unit);
++	col_mv_rd_end_addr = col_mv_rd_start_addr +
++			     (hevc->lcu_total * mv_mem_unit);
++
++	amvdec_write_dos(core, HEVC_MPRED_MV_WR_START_ADDR,
++			 codec_hevc_get_frame_mv_paddr(hevc, frame));
++	amvdec_write_dos(core, HEVC_MPRED_MV_RD_START_ADDR,
++			 col_mv_rd_start_addr);
++
++	if (param->p.slice_segment_address == 0) {
++		amvdec_write_dos(core, HEVC_MPRED_ABV_START_ADDR,
++				 hevc->workspace_paddr + MPRED_ABV_OFFSET);
++		amvdec_write_dos(core, HEVC_MPRED_MV_WPTR, mpred_mv_wr_ptr);
++		amvdec_write_dos(core, HEVC_MPRED_MV_RPTR,
++				 col_mv_rd_start_addr);
++	} else {
++		amvdec_write_dos(core, HEVC_MPRED_MV_RPTR, col_mv_rd_ptr);
++	}
++
++	amvdec_write_dos(core, HEVC_MPRED_MV_RD_END_ADDR, col_mv_rd_end_addr);
++}
++
++/* Update motion prediction with the current slice */
++static void codec_hevc_set_mpred(struct amvdec_session *sess,
++				 struct hevc_frame *frame,
++				 struct hevc_frame *col_frame)
++{
++	struct amvdec_core *core = sess->core;
++	struct codec_hevc *hevc = sess->priv;
++	u32 *ref_num = frame->ref_num;
++	u32 *ref_poc_l0 = frame->ref_poc_list[0][frame->cur_slice_idx];
++	u32 *ref_poc_l1 = frame->ref_poc_list[1][frame->cur_slice_idx];
++	u32 val;
++	int i;
++
++	codec_hevc_set_mpred_ctrl(core, hevc);
++	codec_hevc_set_mpred_mv(core, hevc, frame, col_frame);
++
++	amvdec_write_dos(core, HEVC_MPRED_PIC_SIZE,
++			 hevc->width | (hevc->height << 16));
++
++	val = ((hevc->lcu_x_num - 1) | (hevc->lcu_y_num - 1) << 16);
++	amvdec_write_dos(core, HEVC_MPRED_PIC_SIZE_LCU, val);
++
++	amvdec_write_dos(core, HEVC_MPRED_REF_NUM,
++			 (ref_num[1] << 8) | ref_num[0]);
++	amvdec_write_dos(core, HEVC_MPRED_REF_EN_L0, (1 << ref_num[0]) - 1);
++	amvdec_write_dos(core, HEVC_MPRED_REF_EN_L1, (1 << ref_num[1]) - 1);
++
++	amvdec_write_dos(core, HEVC_MPRED_CUR_POC, hevc->curr_poc);
++	amvdec_write_dos(core, HEVC_MPRED_COL_POC, hevc->col_poc);
++
++	for (i = 0; i < MAX_REF_ACTIVE; ++i) {
++		amvdec_write_dos(core, HEVC_MPRED_L0_REF00_POC + i * 4,
++				 ref_poc_l0[i]);
++		amvdec_write_dos(core, HEVC_MPRED_L1_REF00_POC + i * 4,
++				 ref_poc_l1[i]);
++	}
++}
++
++/*  motion compensation reference cache controller */
++static void codec_hevc_set_mcrcc(struct amvdec_session *sess)
++{
++	struct amvdec_core *core = sess->core;
++	struct codec_hevc *hevc = sess->priv;
++	u32 val, val_2;
++	int l0_cnt = 0;
++	int l1_cnt = 0x7fff;
++
++	if (!codec_hevc_use_fbc(sess->pixfmt_cap, hevc->is_10bit)) {
++		l0_cnt = hevc->cur_frame->ref_num[0];
++		l1_cnt = hevc->cur_frame->ref_num[1];
++	}
++
++	if (hevc->cur_frame->cur_slice_type == I_SLICE) {
++		amvdec_write_dos(core, HEVCD_MCRCC_CTL1, 0);
++		return;
++	}
++
++	if (hevc->cur_frame->cur_slice_type == P_SLICE) {
++		amvdec_write_dos(core, HEVCD_MPP_ANC_CANVAS_ACCCONFIG_ADDR,
++				 BIT(1));
++		val = amvdec_read_dos(core, HEVCD_MPP_ANC_CANVAS_DATA_ADDR);
++		val &= 0xffff;
++		val |= (val << 16);
++		amvdec_write_dos(core, HEVCD_MCRCC_CTL2, val);
++
++		if (l0_cnt == 1) {
++			amvdec_write_dos(core, HEVCD_MCRCC_CTL3, val);
++		} else {
++			val = amvdec_read_dos(core,
++					      HEVCD_MPP_ANC_CANVAS_DATA_ADDR);
++			val &= 0xffff;
++			val |= (val << 16);
++			amvdec_write_dos(core, HEVCD_MCRCC_CTL3, val);
++		}
++	} else { /* B_SLICE */
++		amvdec_write_dos(core, HEVCD_MPP_ANC_CANVAS_ACCCONFIG_ADDR, 0);
++		val = amvdec_read_dos(core, HEVCD_MPP_ANC_CANVAS_DATA_ADDR);
++		val &= 0xffff;
++		val |= (val << 16);
++		amvdec_write_dos(core, HEVCD_MCRCC_CTL2, val);
++
++		amvdec_write_dos(core, HEVCD_MPP_ANC_CANVAS_ACCCONFIG_ADDR,
++				 BIT(12) | BIT(1));
++		val_2 = amvdec_read_dos(core, HEVCD_MPP_ANC_CANVAS_DATA_ADDR);
++		val_2 &= 0xffff;
++		val_2 |= (val_2 << 16);
++		if (val == val_2 && l1_cnt > 1) {
++			val_2 = amvdec_read_dos(core,
++						HEVCD_MPP_ANC_CANVAS_DATA_ADDR);
++			val_2 &= 0xffff;
++			val_2 |= (val_2 << 16);
++		}
++		amvdec_write_dos(core, HEVCD_MCRCC_CTL3, val);
++	}
++
++	/* enable mcrcc progressive-mode */
++	amvdec_write_dos(core, HEVCD_MCRCC_CTL1, 0xff0);
++}
++
++static void codec_hevc_set_ref_list(struct amvdec_session *sess,
++				u32 ref_num, u32 *ref_poc_list)
++{
++	struct codec_hevc *hevc = sess->priv;
++	struct hevc_frame *ref_frame;
++	struct amvdec_core *core = sess->core;
++	int i;
++	u32 buf_id_y;
++	u32 buf_id_uv;
++
++	for (i = 0; i < ref_num; i++) {
++		ref_frame = codec_hevc_get_frame_by_poc(hevc, ref_poc_list[i]);
++
++		if (!ref_frame) {
++			dev_warn(core->dev, "Couldn't find ref. frame %u\n",
++				ref_poc_list[i]);
++			continue;
++		}
++
++		if (codec_hevc_use_fbc(sess->pixfmt_cap, hevc->is_10bit)) {
++			buf_id_y = buf_id_uv = ref_frame->vbuf->vb2_buf.index;
++		} else {
++			buf_id_y = ref_frame->vbuf->vb2_buf.index * 2;
++			buf_id_uv = buf_id_y + 1;
++		}
++
++		amvdec_write_dos(core, HEVCD_MPP_ANC_CANVAS_DATA_ADDR,
++				 (buf_id_uv << 16) |
++				 (buf_id_uv << 8) |
++				 buf_id_y);
++	}
++}
++
++static void codec_hevc_set_mc(struct amvdec_session *sess,
++			      struct hevc_frame *frame)
++{
++	struct amvdec_core *core = sess->core;
++
++	if (frame->cur_slice_type == I_SLICE)
++		return;
++
++	amvdec_write_dos(core, HEVCD_MPP_ANC_CANVAS_ACCCONFIG_ADDR, 1);
++	codec_hevc_set_ref_list(sess, frame->ref_num[0],
++		frame->ref_poc_list[0][frame->cur_slice_idx]);
++
++	if (frame->cur_slice_type == P_SLICE)
++		return;
++
++	amvdec_write_dos(core, HEVCD_MPP_ANC_CANVAS_ACCCONFIG_ADDR,
++			 BIT(12) | BIT(0));
++	codec_hevc_set_ref_list(sess, frame->ref_num[1],
++		frame->ref_poc_list[1][frame->cur_slice_idx]);
++}
++
++static void codec_hevc_update_col_frame(struct codec_hevc *hevc)
++{
++	struct hevc_frame *cur_frame = hevc->cur_frame;
++	union rpm_param *param = &hevc->rpm_param;
++	u32 list_no = 0;
++	u32 col_ref = param->p.collocated_ref_idx;
++	u32 col_from_l0 = param->p.collocated_from_l0_flag;
++	u32 cur_slice_idx = cur_frame->cur_slice_idx;
++
++	if (cur_frame->cur_slice_type == B_SLICE)
++		list_no = 1 - col_from_l0;
++
++	if (col_ref >= cur_frame->ref_num[list_no])
++		hevc->col_poc = INVALID_POC;
++	else
++		hevc->col_poc = cur_frame->ref_poc_list[list_no]
++						       [cur_slice_idx]
++						       [col_ref];
++
++	if (cur_frame->cur_slice_type == I_SLICE)
++		goto end;
++
++	if (hevc->col_poc != INVALID_POC)
++		hevc->col_frame = codec_hevc_get_frame_by_poc(hevc,
++							      hevc->col_poc);
++	else
++		hevc->col_frame = hevc->cur_frame;
++
++end:
++	if (!hevc->col_frame)
++		hevc->col_frame = hevc->cur_frame;
++}
++
++static void codec_hevc_update_pocs(struct amvdec_session *sess)
++{
++	struct codec_hevc *hevc = sess->priv;
++	union rpm_param *param = &hevc->rpm_param;
++	u32 nal_unit_type = param->p.m_nalUnitType;
++	u32 temporal_id = param->p.m_temporalId & 0x7;
++	int max_poc_lsb =
++		1 << (param->p.log2_max_pic_order_cnt_lsb_minus4 + 4);
++	int prev_poc_lsb;
++	int prev_poc_msb;
++	int poc_msb;
++	int poc_lsb = param->p.POClsb;
++
++	if (nal_unit_type == NAL_UNIT_CODED_SLICE_IDR ||
++	    nal_unit_type == NAL_UNIT_CODED_SLICE_IDR_N_LP) {
++		hevc->curr_poc = 0;
++		if ((temporal_id - 1) == 0)
++			hevc->prev_tid0_poc = hevc->curr_poc;
++
++		return;
++	}
++
++	prev_poc_lsb = hevc->prev_tid0_poc % max_poc_lsb;
++	prev_poc_msb = hevc->prev_tid0_poc - prev_poc_lsb;
++
++	if ((poc_lsb < prev_poc_lsb) &&
++	    ((prev_poc_lsb - poc_lsb) >= (max_poc_lsb / 2)))
++		poc_msb = prev_poc_msb + max_poc_lsb;
++	else if ((poc_lsb > prev_poc_lsb) &&
++		 ((poc_lsb - prev_poc_lsb) > (max_poc_lsb / 2)))
++		poc_msb = prev_poc_msb - max_poc_lsb;
++	else
++		poc_msb = prev_poc_msb;
++
++	if (nal_unit_type == NAL_UNIT_CODED_SLICE_BLA   ||
++	    nal_unit_type == NAL_UNIT_CODED_SLICE_BLANT ||
++	    nal_unit_type == NAL_UNIT_CODED_SLICE_BLA_N_LP)
++		poc_msb = 0;
++
++	hevc->curr_poc = (poc_msb + poc_lsb);
++	if ((temporal_id - 1) == 0)
++		hevc->prev_tid0_poc = hevc->curr_poc;
++}
++
++static void codec_hevc_process_segment_header(struct amvdec_session *sess)
++{
++	struct codec_hevc *hevc = sess->priv;
++	union rpm_param *param = &hevc->rpm_param;
++
++	if (param->p.first_slice_segment_in_pic_flag == 0) {
++		hevc->slice_segment_addr = param->p.slice_segment_address;
++		if (!param->p.dependent_slice_segment_flag)
++			hevc->slice_addr = hevc->slice_segment_addr;
++	} else {
++		hevc->slice_segment_addr = 0;
++		hevc->slice_addr = 0;
++	}
++
++	codec_hevc_update_pocs(sess);
++}
++
++static int codec_hevc_process_segment(struct amvdec_session *sess)
++{
++	struct codec_hevc *hevc = sess->priv;
++	struct amvdec_core *core = sess->core;
++	union rpm_param *param = &hevc->rpm_param;
++	u32 slice_segment_address = param->p.slice_segment_address;
++
++	/* First slice: new frame */
++	if (slice_segment_address == 0) {
++		codec_hevc_update_referenced(hevc);
++		codec_hevc_output_frames(sess);
++
++		hevc->cur_frame = codec_hevc_prepare_new_frame(sess);
++		if (!hevc->cur_frame)
++			return -1;
++	} else {
++		hevc->cur_frame->cur_slice_idx++;
++	}
++
++	codec_hevc_update_frame_refs(sess, hevc->cur_frame);
++	codec_hevc_update_col_frame(hevc);
++	codec_hevc_update_ldc_flag(hevc);
++	if (codec_hevc_use_mmu(core->platform->revision, sess->pixfmt_cap,
++			       hevc->is_10bit))
++		codec_hevc_fill_mmu_map(sess, &hevc->common,
++					&hevc->cur_frame->vbuf->vb2_buf,
++					hevc->is_10bit);
++	codec_hevc_set_mc(sess, hevc->cur_frame);
++	codec_hevc_set_mcrcc(sess);
++	codec_hevc_set_mpred(sess, hevc->cur_frame, hevc->col_frame);
++	codec_hevc_set_sao(sess, hevc->cur_frame);
++
++	amvdec_write_dos_bits(core, HEVC_WAIT_FLAG, BIT(1));
++	amvdec_write_dos(core, HEVC_DEC_STATUS_REG,
++			 HEVC_CODED_SLICE_SEGMENT_DAT);
++
++	/* Interrupt the firmware's processor */
++	amvdec_write_dos(core, HEVC_MCPU_INTR_REQ, AMRISC_MAIN_REQ);
++
++	return 0;
++}
++
++static int codec_hevc_process_rpm(struct codec_hevc *hevc)
++{
++	union rpm_param *param = &hevc->rpm_param;
++	int src_changed = 0;
++	u32 dst_width, dst_height;
++	u32 lcu_size;
++	u32 is_10bit = 0;
++
++	if (param->p.slice_segment_address	||
++	    !param->p.pic_width_in_luma_samples	||
++	    !param->p.pic_height_in_luma_samples)
++		return 0;
++
++	if (param->p.bit_depth)
++		is_10bit = 1;
++
++	hevc->width = param->p.pic_width_in_luma_samples;
++	hevc->height = param->p.pic_height_in_luma_samples;
++	dst_width = hevc->width;
++	dst_height = hevc->height;
++
++	lcu_size = 1 << (param->p.log2_min_coding_block_size_minus3 +
++		   3 + param->p.log2_diff_max_min_coding_block_size);
++
++	hevc->lcu_x_num = (hevc->width + lcu_size - 1) / lcu_size;
++	hevc->lcu_y_num = (hevc->height + lcu_size - 1) / lcu_size;
++	hevc->lcu_total = hevc->lcu_x_num * hevc->lcu_y_num;
++
++	if (param->p.conformance_window_flag) {
++		u32 sub_width = 1, sub_height = 1;
++
++		switch (param->p.chroma_format_idc) {
++		case 1:
++			sub_height = 2; /* fallthrough */
++		case 2:
++			sub_width = 2;
++			break;
++		}
++
++		dst_width -= sub_width *
++			     (param->p.conf_win_left_offset +
++			      param->p.conf_win_right_offset);
++		dst_height -= sub_height *
++			      (param->p.conf_win_top_offset +
++			       param->p.conf_win_bottom_offset);
++	}
++
++	if (dst_width != hevc->dst_width ||
++	    dst_height != hevc->dst_height ||
++	    lcu_size != hevc->lcu_size ||
++	    is_10bit != hevc->is_10bit)
++		src_changed = 1;
++
++	hevc->dst_width = dst_width;
++	hevc->dst_height = dst_height;
++	hevc->lcu_size = lcu_size;
++	hevc->is_10bit = is_10bit;
++
++	return src_changed;
++}
++
++/*
++ * The RPM section within the workspace contains
++ * many information regarding the parsed bitstream
++ */
++static void codec_hevc_fetch_rpm(struct amvdec_session *sess)
++{
++	struct codec_hevc *hevc = sess->priv;
++	u16 *rpm_vaddr = hevc->workspace_vaddr + RPM_OFFSET;
++	int i, j;
++
++	for (i = 0; i < RPM_SIZE; i += 4)
++		for (j = 0; j < 4; j++)
++			hevc->rpm_param.l.data[i + j] = rpm_vaddr[i + 3 - j];
++}
++
++static void codec_hevc_resume(struct amvdec_session *sess)
++{
++	struct codec_hevc *hevc = sess->priv;
++
++	if (codec_hevc_setup_buffers(sess, &hevc->common, hevc->is_10bit)) {
++		amvdec_abort(sess);
++		return;
++	}
++
++	codec_hevc_setup_decode_head(sess, hevc->is_10bit);
++	codec_hevc_process_segment_header(sess);
++	if (codec_hevc_process_segment(sess))
++		amvdec_abort(sess);
++}
++
++static irqreturn_t codec_hevc_threaded_isr(struct amvdec_session *sess)
++{
++	struct amvdec_core *core = sess->core;
++	struct codec_hevc *hevc = sess->priv;
++	u32 dec_status = amvdec_read_dos(core, HEVC_DEC_STATUS_REG);
++
++	if (!hevc)
++		return IRQ_HANDLED;
++
++	mutex_lock(&hevc->lock);
++	if (dec_status != HEVC_SLICE_SEGMENT_DONE) {
++		dev_err(core->dev_dec, "Unrecognized dec_status: %08X\n",
++			dec_status);
++		amvdec_abort(sess);
++		goto unlock;
++	}
++
++	sess->keyframe_found = 1;
++	codec_hevc_fetch_rpm(sess);
++	if (codec_hevc_process_rpm(hevc)) {
++		amvdec_src_change(sess, hevc->dst_width, hevc->dst_height, 16,
++				  hevc->is_10bit ? 10 : 8);
++		goto unlock;
++	}
++
++	codec_hevc_process_segment_header(sess);
++	if (codec_hevc_process_segment(sess))
++		amvdec_abort(sess);
++
++unlock:
++	mutex_unlock(&hevc->lock);
++	return IRQ_HANDLED;
++}
++
++static irqreturn_t codec_hevc_isr(struct amvdec_session *sess)
++{
++	return IRQ_WAKE_THREAD;
++}
++
++struct amvdec_codec_ops codec_hevc_ops = {
++	.start = codec_hevc_start,
++	.stop = codec_hevc_stop,
++	.isr = codec_hevc_isr,
++	.threaded_isr = codec_hevc_threaded_isr,
++	.num_pending_bufs = codec_hevc_num_pending_bufs,
++	.drain = codec_hevc_flush_output,
++	.resume = codec_hevc_resume,
++};
+diff --git a/drivers/staging/media/meson/vdec/codec_hevc.h b/drivers/staging/media/meson/vdec/codec_hevc.h
+new file mode 100644
+index 000000000000..f2f9b2464df1
+--- /dev/null
++++ b/drivers/staging/media/meson/vdec/codec_hevc.h
+@@ -0,0 +1,13 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * Copyright (C) 2018 Maxime Jourdan <maxi.jourdan@wanadoo.fr>
++ */
++
++#ifndef __MESON_VDEC_CODEC_HEVC_H_
++#define __MESON_VDEC_CODEC_HEVC_H_
++
++#include "vdec.h"
++
++extern struct amvdec_codec_ops codec_hevc_ops;
++
++#endif
+diff --git a/drivers/staging/media/meson/vdec/esparser.c b/drivers/staging/media/meson/vdec/esparser.c
+index 86ccc8937afc..6cea1839dcca 100644
+--- a/drivers/staging/media/meson/vdec/esparser.c
++++ b/drivers/staging/media/meson/vdec/esparser.c
+@@ -309,7 +309,7 @@ esparser_queue(struct amvdec_session *sess, struct vb2_v4l2_buffer *vbuf)
+ 	 * they could pause when there is no capture buffer available and
+ 	 * resume on this notification.
+ 	 */
+-	if (sess->fmt_out->pixfmt == V4L2_PIX_FMT_VP9) {
++	if (sess->fmt_out->pixfmt == V4L2_PIX_FMT_VP9 || sess->fmt_out->pixfmt ==V4L2_PIX_FMT_HEVC) {
+ 		if (codec_ops->num_pending_bufs)
+ 			num_dst_bufs = codec_ops->num_pending_bufs(sess);
+ 
+diff --git a/drivers/staging/media/meson/vdec/hevc_regs.h b/drivers/staging/media/meson/vdec/hevc_regs.h
+index 0392f41a1eed..e7eabdd2b119 100644
+--- a/drivers/staging/media/meson/vdec/hevc_regs.h
++++ b/drivers/staging/media/meson/vdec/hevc_regs.h
+@@ -205,6 +205,7 @@
+ #define HEVC_CM_HEADER_START_ADDR 0xd8a0
+ #define HEVC_CM_HEADER_LENGTH 0xd8a4
+ #define HEVC_CM_HEADER_OFFSET 0xd8ac
++#define HEVC_SAO_CTRL9 0xd8b4
+ #define HEVC_SAO_MMU_VH0_ADDR 0xd8e8
+ #define HEVC_SAO_MMU_VH1_ADDR 0xd8ec
+ 
+diff --git a/drivers/staging/media/meson/vdec/vdec_platform.c b/drivers/staging/media/meson/vdec/vdec_platform.c
+index 88c9d72e1c83..8592cb3aaea9 100644
+--- a/drivers/staging/media/meson/vdec/vdec_platform.c
++++ b/drivers/staging/media/meson/vdec/vdec_platform.c
+@@ -11,6 +11,7 @@
+ #include "vdec_hevc.h"
+ #include "codec_mpeg12.h"
+ #include "codec_h264.h"
++#include "codec_hevc.h"
+ #include "codec_vp9.h"
+ 
+ static const struct amvdec_format vdec_formats_gxbb[] = {
+@@ -64,6 +65,18 @@ static const struct amvdec_format vdec_formats_gxl[] = {
+ 		.pixfmts_cap = { V4L2_PIX_FMT_NV12M, 0 },
+ 		.flags = V4L2_FMT_FLAG_COMPRESSED |
+ 			 V4L2_FMT_FLAG_DYN_RESOLUTION,
++	}, {
++		.pixfmt = V4L2_PIX_FMT_HEVC,
++		.min_buffers = 4,
++		.max_buffers = 24,
++		.max_width = 3840,
++		.max_height = 2160,
++		.vdec_ops = &vdec_hevc_ops,
++		.codec_ops = &codec_hevc_ops,
++		.firmware_path = "meson/vdec/gxl_hevc.bin",
++		.pixfmts_cap = { V4L2_PIX_FMT_NV12M, 0 },
++		.flags = V4L2_FMT_FLAG_COMPRESSED |
++			 V4L2_FMT_FLAG_DYN_RESOLUTION,
+ 	}, {
+ 		.pixfmt = V4L2_PIX_FMT_H264,
+ 		.min_buffers = 2,
+@@ -114,6 +127,18 @@ static const struct amvdec_format vdec_formats_gxm[] = {
+ 		.pixfmts_cap = { V4L2_PIX_FMT_NV12M, 0 },
+ 		.flags = V4L2_FMT_FLAG_COMPRESSED |
+ 			 V4L2_FMT_FLAG_DYN_RESOLUTION,
++	}, {
++		.pixfmt = V4L2_PIX_FMT_HEVC,
++		.min_buffers = 4,
++		.max_buffers = 24,
++		.max_width = 3840,
++		.max_height = 2160,
++		.vdec_ops = &vdec_hevc_ops,
++		.codec_ops = &codec_hevc_ops,
++		.firmware_path = "meson/vdec/gxl_hevc.bin",
++		.pixfmts_cap = { V4L2_PIX_FMT_NV12M, 0 },
++		.flags = V4L2_FMT_FLAG_COMPRESSED |
++			 V4L2_FMT_FLAG_DYN_RESOLUTION,
+ 	}, {
+ 		.pixfmt = V4L2_PIX_FMT_H264,
+ 		.min_buffers = 2,
+@@ -165,6 +190,18 @@ static const struct amvdec_format vdec_formats_g12a[] = {
+ 		.flags = V4L2_FMT_FLAG_COMPRESSED |
+ 			 V4L2_FMT_FLAG_DYN_RESOLUTION,
+ 	}, {
++		.pixfmt = V4L2_PIX_FMT_HEVC,
++		.min_buffers = 4,
++		.max_buffers = 24,
++		.max_width = 3840,
++		.max_height = 2160,
++		.vdec_ops = &vdec_hevc_ops,
++		.codec_ops = &codec_hevc_ops,
++		.firmware_path = "meson/vdec/g12a_hevc_mmu.bin",
++		.pixfmts_cap = { V4L2_PIX_FMT_NV12M, 0 },
++		.flags = V4L2_FMT_FLAG_COMPRESSED |
++			 V4L2_FMT_FLAG_DYN_RESOLUTION,
++	},{
+ 		.pixfmt = V4L2_PIX_FMT_H264,
+ 		.min_buffers = 2,
+ 		.max_buffers = 24,
+@@ -214,6 +251,18 @@ static const struct amvdec_format vdec_formats_sm1[] = {
+ 		.pixfmts_cap = { V4L2_PIX_FMT_NV12M, 0 },
+ 		.flags = V4L2_FMT_FLAG_COMPRESSED |
+ 			 V4L2_FMT_FLAG_DYN_RESOLUTION,
++	}, {
++		.pixfmt = V4L2_PIX_FMT_HEVC,
++		.min_buffers = 4,
++		.max_buffers = 24,
++		.max_width = 3840,
++		.max_height = 2160,
++		.vdec_ops = &vdec_hevc_ops,
++		.codec_ops = &codec_hevc_ops,
++		.firmware_path = "meson/vdec/sm1_hevc_mmu.bin",
++		.pixfmts_cap = { V4L2_PIX_FMT_NV12M, 0 },
++		.flags = V4L2_FMT_FLAG_COMPRESSED |
++			 V4L2_FMT_FLAG_DYN_RESOLUTION,
+ 	}, {
+ 		.pixfmt = V4L2_PIX_FMT_H264,
+ 		.min_buffers = 2,
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/general-meson-vdec-add-handling-to-HEVC-decoder-.patch
+++ b/patch/kernel/archive/meson64-6.1/general-meson-vdec-add-handling-to-HEVC-decoder-.patch
@@ -1,0 +1,157 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: benjamin545 <benjamin545@gmail.com>
+Date: Mon, 2 Aug 2021 15:18:40 -0400
+Subject: WIP: drivers: meson: vdec: add handling to HEVC decoder to show
+ frames when ready
+
+..rather than when no longer referenced
+
+the HEVC decode driver would not show the next frame until it was no longer referenced,
+this would cause a backup of frames that were ready to render but held up by one or more
+frames that were still referenced. The decoded picture buffer would fill up and stall
+playback as no new frames could be placed in the decoded picture buffer.
+---
+ drivers/staging/media/meson/vdec/codec_hevc.c | 52 ++++++----
+ 1 file changed, 34 insertions(+), 18 deletions(-)
+
+diff --git a/drivers/staging/media/meson/vdec/codec_hevc.c b/drivers/staging/media/meson/vdec/codec_hevc.c
+index 3a6fd04a2d33..01218efde99b 100644
+--- a/drivers/staging/media/meson/vdec/codec_hevc.c
++++ b/drivers/staging/media/meson/vdec/codec_hevc.c
+@@ -223,6 +223,7 @@ struct hevc_frame {
+ 	u32 poc;
+ 
+ 	int referenced;
++	int show;
+ 	u32 num_reorder_pic;
+ 
+ 	u32 cur_slice_idx;
+@@ -448,9 +449,11 @@ static void codec_hevc_update_referenced(struct codec_hevc *hevc)
+ 			       ((1 << (RPS_USED_BIT - 1)) - 1);
+ 			if (param->p.CUR_RPS[i] & (1 << (RPS_USED_BIT - 1))) {
+ 				poc_tmp = curr_poc -
+-					  ((1 << (RPS_USED_BIT - 1)) - delt);
+-			} else
++				      ((1 << (RPS_USED_BIT - 1)) - delt);
++			} else {
+ 				poc_tmp = curr_poc + delt;
++			}
++
+ 			if (poc_tmp == frame->poc) {
+ 				is_referenced = 1;
+ 				break;
+@@ -462,13 +465,13 @@ static void codec_hevc_update_referenced(struct codec_hevc *hevc)
+ }
+ 
+ static struct hevc_frame *
+-codec_hevc_get_lowest_poc_frame(struct codec_hevc *hevc)
++codec_hevc_get_next_ready_frame(struct codec_hevc *hevc)
+ {
+ 	struct hevc_frame *tmp, *ret = NULL;
+ 	u32 poc = INT_MAX;
+ 
+ 	list_for_each_entry(tmp, &hevc->ref_frames_list, list) {
+-		if (tmp->poc < poc) {
++		if ((tmp->poc < poc) && tmp->show) {
+ 			ret = tmp;
+ 			poc = tmp->poc;
+ 		}
+@@ -478,28 +481,35 @@ codec_hevc_get_lowest_poc_frame(struct codec_hevc *hevc)
+ }
+ 
+ /* Try to output as many frames as possible */
+-static void codec_hevc_output_frames(struct amvdec_session *sess)
++static void codec_hevc_show_frames(struct amvdec_session *sess)
+ {
+-	struct hevc_frame *tmp;
++	struct hevc_frame *tmp, *n;
+ 	struct codec_hevc *hevc = sess->priv;
+ 
+-	while ((tmp = codec_hevc_get_lowest_poc_frame(hevc))) {
++	while ((tmp = codec_hevc_get_next_ready_frame(hevc))) {
+ 		if (hevc->curr_poc &&
+-		    (tmp->referenced ||
+-		     tmp->num_reorder_pic >= hevc->frames_num))
++		   (hevc->frames_num <= tmp->num_reorder_pic))
+ 			break;
+ 
+ 		dev_dbg(sess->core->dev, "DONE frame poc %u; vbuf %u\n",
+ 			tmp->poc, tmp->vbuf->vb2_buf.index);
+ 		amvdec_dst_buf_done_offset(sess, tmp->vbuf, tmp->offset,
+ 					   V4L2_FIELD_NONE, false);
++
++		tmp->show = 0;
++		hevc->frames_num--;
++	}
++
++	/* clean output frame buffer */
++	list_for_each_entry_safe(tmp, n, &hevc->ref_frames_list, list) {
++		if (tmp->referenced || tmp->show)
++			continue;
++
+ 		list_del(&tmp->list);
+ 		kfree(tmp);
+-		hevc->frames_num--;
+ 	}
+ }
+ 
+-
+ static int
+ codec_hevc_setup_workspace(struct amvdec_session *sess,
+ 			   struct codec_hevc *hevc)
+@@ -650,14 +660,17 @@ static int codec_hevc_start(struct amvdec_session *sess)
+ static void codec_hevc_flush_output(struct amvdec_session *sess)
+ {
+ 	struct codec_hevc *hevc = sess->priv;
+-	struct hevc_frame *tmp;
++	struct hevc_frame *tmp, *n;
+ 
+-	while (!list_empty(&hevc->ref_frames_list)) {
+-		tmp = codec_hevc_get_lowest_poc_frame(hevc);
++	while ((tmp = codec_hevc_get_next_ready_frame(hevc))) {
+ 		amvdec_dst_buf_done(sess, tmp->vbuf, V4L2_FIELD_NONE);
++		tmp->show = 0;
++		hevc->frames_num--;
++	}
++
++	list_for_each_entry_safe(tmp, n, &hevc->ref_frames_list, list) {
+ 		list_del(&tmp->list);
+ 		kfree(tmp);
+-		hevc->frames_num--;
+ 	}
+ }
+ 
+@@ -719,6 +732,7 @@ codec_hevc_prepare_new_frame(struct amvdec_session *sess)
+ 
+ 	new_frame->vbuf = vbuf;
+ 	new_frame->referenced = 1;
++	new_frame->show = 1;
+ 	new_frame->poc = hevc->curr_poc;
+ 	new_frame->cur_slice_type = params->p.slice_type;
+ 	new_frame->num_reorder_pic = params->p.sps_num_reorder_pics_0;
+@@ -1267,7 +1281,7 @@ static int codec_hevc_process_segment(struct amvdec_session *sess)
+ 	/* First slice: new frame */
+ 	if (slice_segment_address == 0) {
+ 		codec_hevc_update_referenced(hevc);
+-		codec_hevc_output_frames(sess);
++		codec_hevc_show_frames(sess);
+ 
+ 		hevc->cur_frame = codec_hevc_prepare_new_frame(sess);
+ 		if (!hevc->cur_frame)
+@@ -1370,9 +1384,11 @@ static void codec_hevc_fetch_rpm(struct amvdec_session *sess)
+ 	u16 *rpm_vaddr = hevc->workspace_vaddr + RPM_OFFSET;
+ 	int i, j;
+ 
+-	for (i = 0; i < RPM_SIZE; i += 4)
++	for (i = 0; i < RPM_SIZE; i += 4) {
+ 		for (j = 0; j < 4; j++)
+-			hevc->rpm_param.l.data[i + j] = rpm_vaddr[i + 3 - j];
++			hevc->rpm_param.l.data[i + j] =
++				rpm_vaddr[i + 3 - j];
++	}
+ }
+ 
+ static void codec_hevc_resume(struct amvdec_session *sess)
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/general-meson-vdec-check-if-parser-has-really-parser.patch
+++ b/patch/kernel/archive/meson64-6.1/general-meson-vdec-check-if-parser-has-really-parser.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Neil Armstrong <narmstrong@baylibre.com>
+Date: Mon, 22 Nov 2021 09:15:21 +0000
+Subject: WIP: drivers: meson: vdec: check if parser has really parser before
+ marking input buffer as error
+
+Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>
+---
+ drivers/staging/media/meson/vdec/esparser.c | 14 +++++++---
+ 1 file changed, 10 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/staging/media/meson/vdec/esparser.c b/drivers/staging/media/meson/vdec/esparser.c
+index 6cea1839dcca..4b9ef97639c0 100644
+--- a/drivers/staging/media/meson/vdec/esparser.c
++++ b/drivers/staging/media/meson/vdec/esparser.c
+@@ -300,6 +300,7 @@ esparser_queue(struct amvdec_session *sess, struct vb2_v4l2_buffer *vbuf)
+ 	u32 num_dst_bufs = 0;
+ 	u32 offset;
+ 	u32 pad_size;
++	u32 wp, wp2;
+ 
+ 	/*
+ 	 * When max ref frame is held by VP9, this should be -= 3 to prevent a
+@@ -354,15 +355,20 @@ esparser_queue(struct amvdec_session *sess, struct vb2_v4l2_buffer *vbuf)
+ 	}
+ 
+ 	pad_size = esparser_pad_start_code(core, vb, payload_size);
++	wp = amvdec_read_parser(core, PARSER_VIDEO_WP);
+ 	ret = esparser_write_data(core, phy, payload_size + pad_size);
++	wp2 = amvdec_read_parser(core, PARSER_VIDEO_WP);
+ 
+ 	if (ret <= 0) {
+-		dev_warn(core->dev, "esparser: input parsing error\n");
+-		amvdec_remove_ts(sess, vb->timestamp);
+-		v4l2_m2m_buf_done(vbuf, VB2_BUF_STATE_ERROR);
+ 		amvdec_write_parser(core, PARSER_FETCH_CMD, 0);
+ 
+-		return 0;
++		if (ret < 0 || wp2 == wp) {
++			dev_err(core->dev, "esparser: input parsing error ret %d (%x <=> %x)\n", ret, wp, wp2);
++			amvdec_remove_ts(sess, vb->timestamp);
++			v4l2_m2m_buf_done(vbuf, VB2_BUF_STATE_ERROR);
++
++			return 0;
++		}
+ 	}
+ 
+ 	atomic_inc(&sess->esparser_queued_bufs);
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/general-meson-vdec-improve-mmu-and-fbc-handling-.patch
+++ b/patch/kernel/archive/meson64-6.1/general-meson-vdec-improve-mmu-and-fbc-handling-.patch
@@ -1,0 +1,587 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: benjamin545 <benjamin545@gmail.com>
+Date: Thu, 15 Jul 2021 16:32:39 -0400
+Subject: WIP: drivers: meson: vdec: improve mmu and fbc handling and add 10
+ bit handling
+
+Unknown patch. From LibreELEC?
+---
+ drivers/staging/media/meson/vdec/codec_h264.c        |   3 +-
+ drivers/staging/media/meson/vdec/codec_hevc_common.c | 164 ++++++----
+ drivers/staging/media/meson/vdec/codec_hevc_common.h |   3 +-
+ drivers/staging/media/meson/vdec/codec_vp9.c         |  36 +-
+ drivers/staging/media/meson/vdec/esparser.c          |   1 +
+ drivers/staging/media/meson/vdec/vdec.h              |   1 +
+ drivers/staging/media/meson/vdec/vdec_helpers.c      |  46 ++-
+ drivers/staging/media/meson/vdec/vdec_helpers.h      |  10 +-
+ 8 files changed, 163 insertions(+), 101 deletions(-)
+
+diff --git a/drivers/staging/media/meson/vdec/codec_h264.c b/drivers/staging/media/meson/vdec/codec_h264.c
+index c61128fc4bb9..d53c9a464bde 100644
+--- a/drivers/staging/media/meson/vdec/codec_h264.c
++++ b/drivers/staging/media/meson/vdec/codec_h264.c
+@@ -353,7 +353,8 @@ static void codec_h264_src_change(struct amvdec_session *sess)
+ 		frame_width, frame_height, crop_right, crop_bottom);
+ 
+ 	codec_h264_set_par(sess);
+-	amvdec_src_change(sess, frame_width, frame_height, h264->max_refs + 5);
++	amvdec_src_change(sess, frame_width, frame_height,
++			  h264->max_refs + 5, 8);
+ }
+ 
+ /*
+diff --git a/drivers/staging/media/meson/vdec/codec_hevc_common.c b/drivers/staging/media/meson/vdec/codec_hevc_common.c
+index 0315cc0911cd..d6ed82dc93ca 100644
+--- a/drivers/staging/media/meson/vdec/codec_hevc_common.c
++++ b/drivers/staging/media/meson/vdec/codec_hevc_common.c
+@@ -30,8 +30,11 @@ const u16 vdec_hevc_parser_cmd[] = {
+ void codec_hevc_setup_decode_head(struct amvdec_session *sess, int is_10bit)
+ {
+ 	struct amvdec_core *core = sess->core;
+-	u32 body_size = amvdec_am21c_body_size(sess->width, sess->height);
+-	u32 head_size = amvdec_am21c_head_size(sess->width, sess->height);
++	u32 use_mmu = codec_hevc_use_mmu(core->platform->revision,
++					 sess->pixfmt_cap, is_10bit);
++	u32 body_size = amvdec_amfbc_body_size(sess->width, sess->height,
++					       is_10bit, use_mmu);
++	u32 head_size = amvdec_amfbc_head_size(sess->width, sess->height);
+ 
+ 	if (!codec_hevc_use_fbc(sess->pixfmt_cap, is_10bit)) {
+ 		/* Enable 2-plane reference read mode */
+@@ -39,9 +42,17 @@ void codec_hevc_setup_decode_head(struct amvdec_session *sess, int is_10bit)
+ 		return;
+ 	}
+ 
++	/* enable mem saving mode for 8-bit */
++	if (!is_10bit)
++		amvdec_write_dos_bits(core, HEVC_SAO_CTRL5, BIT(9));
++	else
++		amvdec_clear_dos_bits(core, HEVC_SAO_CTRL5, BIT(9));
++
+ 	if (codec_hevc_use_mmu(core->platform->revision,
+ 			       sess->pixfmt_cap, is_10bit))
+ 		amvdec_write_dos(core, HEVCD_MPP_DECOMP_CTL1, BIT(4));
++	else if (!is_10bit)
++		amvdec_write_dos(core, HEVCD_MPP_DECOMP_CTL1, BIT(3));
+ 	else
+ 		amvdec_write_dos(core, HEVCD_MPP_DECOMP_CTL1, 0);
+ 
+@@ -73,7 +84,7 @@ static void codec_hevc_setup_buffers_gxbb(struct amvdec_session *sess,
+ 
+ 		idx = vb->index;
+ 
+-		if (codec_hevc_use_downsample(sess->pixfmt_cap, is_10bit))
++		if (codec_hevc_use_fbc(sess->pixfmt_cap, is_10bit))
+ 			buf_y_paddr = comm->fbc_buffer_paddr[idx];
+ 		else
+ 			buf_y_paddr = vb2_dma_contig_plane_dma_addr(vb, 0);
+@@ -114,8 +125,8 @@ static void codec_hevc_setup_buffers_gxl(struct amvdec_session *sess,
+ {
+ 	struct amvdec_core *core = sess->core;
+ 	struct v4l2_m2m_buffer *buf;
+-	u32 revision = core->platform->revision;
+ 	u32 pixfmt_cap = sess->pixfmt_cap;
++    const u32 revision = core->platform->revision;
+ 	int i;
+ 
+ 	amvdec_write_dos(core, HEVCD_MPP_ANC2AXI_TBL_CONF_ADDR,
+@@ -127,12 +138,14 @@ static void codec_hevc_setup_buffers_gxl(struct amvdec_session *sess,
+ 		dma_addr_t buf_uv_paddr = 0;
+ 		u32 idx = vb->index;
+ 
+-		if (codec_hevc_use_mmu(revision, pixfmt_cap, is_10bit))
+-			buf_y_paddr = comm->mmu_header_paddr[idx];
+-		else if (codec_hevc_use_downsample(pixfmt_cap, is_10bit))
+-			buf_y_paddr = comm->fbc_buffer_paddr[idx];
+-		else
+-			buf_y_paddr = vb2_dma_contig_plane_dma_addr(vb, 0);
++		if (codec_hevc_use_downsample(pixfmt_cap, is_10bit)) {
++			if (codec_hevc_use_mmu(revision, pixfmt_cap, is_10bit))
++				buf_y_paddr = comm->mmu_header_paddr[idx];
++			else
++				buf_y_paddr = comm->fbc_buffer_paddr[idx];
++		} else {
++ 			buf_y_paddr = vb2_dma_contig_plane_dma_addr(vb, 0);
++		}
+ 
+ 		amvdec_write_dos(core, HEVCD_MPP_ANC2AXI_TBL_DATA,
+ 				 buf_y_paddr >> 5);
+@@ -150,60 +163,67 @@ static void codec_hevc_setup_buffers_gxl(struct amvdec_session *sess,
+ 		amvdec_write_dos(core, HEVCD_MPP_ANC_CANVAS_DATA_ADDR, 0);
+ }
+ 
+-void codec_hevc_free_fbc_buffers(struct amvdec_session *sess,
++void codec_hevc_free_mmu_headers(struct amvdec_session *sess,
+ 				 struct codec_hevc_common *comm)
+ {
+ 	struct device *dev = sess->core->dev;
+-	u32 am21_size = amvdec_am21c_size(sess->width, sess->height);
+ 	int i;
+ 
+ 	for (i = 0; i < MAX_REF_PIC_NUM; ++i) {
+-		if (comm->fbc_buffer_vaddr[i]) {
+-			dma_free_coherent(dev, am21_size,
+-					  comm->fbc_buffer_vaddr[i],
+-					  comm->fbc_buffer_paddr[i]);
+-			comm->fbc_buffer_vaddr[i] = NULL;
++		if (comm->mmu_header_vaddr[i]) {
++			dma_free_coherent(dev, MMU_COMPRESS_HEADER_SIZE,
++					  comm->mmu_header_vaddr[i],
++					  comm->mmu_header_paddr[i]);
++			comm->mmu_header_vaddr[i] = NULL;
+ 		}
+ 	}
+ }
+-EXPORT_SYMBOL_GPL(codec_hevc_free_fbc_buffers);
++EXPORT_SYMBOL_GPL(codec_hevc_free_mmu_headers);
+ 
+-static int codec_hevc_alloc_fbc_buffers(struct amvdec_session *sess,
++static int codec_hevc_alloc_mmu_headers(struct amvdec_session *sess,
+ 					struct codec_hevc_common *comm)
+ {
+ 	struct device *dev = sess->core->dev;
+ 	struct v4l2_m2m_buffer *buf;
+-	u32 am21_size = amvdec_am21c_size(sess->width, sess->height);
+ 
+ 	v4l2_m2m_for_each_dst_buf(sess->m2m_ctx, buf) {
+ 		u32 idx = buf->vb.vb2_buf.index;
+ 		dma_addr_t paddr;
+-		void *vaddr = dma_alloc_coherent(dev, am21_size, &paddr,
+-						 GFP_KERNEL);
++		void *vaddr = dma_alloc_coherent(dev, MMU_COMPRESS_HEADER_SIZE,
++						 &paddr, GFP_KERNEL);
+ 		if (!vaddr) {
+-			codec_hevc_free_fbc_buffers(sess, comm);
++			codec_hevc_free_mmu_headers(sess, comm);
+ 			return -ENOMEM;
+ 		}
+ 
+-		comm->fbc_buffer_vaddr[idx] = vaddr;
+-		comm->fbc_buffer_paddr[idx] = paddr;
++		comm->mmu_header_vaddr[idx] = vaddr;
++		comm->mmu_header_paddr[idx] = paddr;
+ 	}
+ 
+ 	return 0;
+ }
+ 
+-void codec_hevc_free_mmu_headers(struct amvdec_session *sess,
++void codec_hevc_free_fbc_buffers(struct amvdec_session *sess,
+ 				 struct codec_hevc_common *comm)
+ {
+ 	struct device *dev = sess->core->dev;
++	u32 use_mmu;
++	u32 am21_size;
+ 	int i;
+ 
++	use_mmu = codec_hevc_use_mmu(sess->core->platform->revision,
++					 sess->pixfmt_cap,
++					 sess->bitdepth == 10 ? 1 : 0);
++
++	am21_size = amvdec_amfbc_size(sess->width, sess->height,
++					  sess->bitdepth == 10 ? 1 : 0,  use_mmu);
++
+ 	for (i = 0; i < MAX_REF_PIC_NUM; ++i) {
+-		if (comm->mmu_header_vaddr[i]) {
+-			dma_free_coherent(dev, MMU_COMPRESS_HEADER_SIZE,
+-					  comm->mmu_header_vaddr[i],
+-					  comm->mmu_header_paddr[i]);
+-			comm->mmu_header_vaddr[i] = NULL;
++		if (comm->fbc_buffer_vaddr[i]) {
++			dma_free_coherent(dev, am21_size,
++					  comm->fbc_buffer_vaddr[i],
++					  comm->fbc_buffer_paddr[i]);
++			comm->fbc_buffer_vaddr[i] = NULL;
+ 		}
+ 	}
+ 
+@@ -213,33 +233,49 @@ void codec_hevc_free_mmu_headers(struct amvdec_session *sess,
+ 				  comm->mmu_map_paddr);
+ 		comm->mmu_map_vaddr = NULL;
+ 	}
++
++    codec_hevc_free_mmu_headers(sess, comm);
+ }
+-EXPORT_SYMBOL_GPL(codec_hevc_free_mmu_headers);
++EXPORT_SYMBOL_GPL(codec_hevc_free_fbc_buffers);
+ 
+-static int codec_hevc_alloc_mmu_headers(struct amvdec_session *sess,
++static int codec_hevc_alloc_fbc_buffers(struct amvdec_session *sess,
+ 					struct codec_hevc_common *comm)
+ {
+ 	struct device *dev = sess->core->dev;
+ 	struct v4l2_m2m_buffer *buf;
++	u32 use_mmu;
++	u32 am21_size;
++	const u32 revision = sess->core->platform->revision;
++	const u32 is_10bit = sess->bitdepth == 10 ? 1 : 0;
++	int ret;
+ 
+-	comm->mmu_map_vaddr = dma_alloc_coherent(dev, MMU_MAP_SIZE,
+-						 &comm->mmu_map_paddr,
+-						 GFP_KERNEL);
+-	if (!comm->mmu_map_vaddr)
+-		return -ENOMEM;
++	use_mmu = codec_hevc_use_mmu(revision, sess->pixfmt_cap,
++					 is_10bit);
++
++	am21_size = amvdec_amfbc_size(sess->width, sess->height,
++					  is_10bit, use_mmu);
+ 
+ 	v4l2_m2m_for_each_dst_buf(sess->m2m_ctx, buf) {
+ 		u32 idx = buf->vb.vb2_buf.index;
+ 		dma_addr_t paddr;
+-		void *vaddr = dma_alloc_coherent(dev, MMU_COMPRESS_HEADER_SIZE,
+-						 &paddr, GFP_KERNEL);
++		void *vaddr = dma_alloc_coherent(dev, am21_size, &paddr,
++						 GFP_KERNEL);
+ 		if (!vaddr) {
+-			codec_hevc_free_mmu_headers(sess, comm);
++			codec_hevc_free_fbc_buffers(sess, comm);
+ 			return -ENOMEM;
+ 		}
+ 
+-		comm->mmu_header_vaddr[idx] = vaddr;
+-		comm->mmu_header_paddr[idx] = paddr;
++		comm->fbc_buffer_vaddr[idx] = vaddr;
++		comm->fbc_buffer_paddr[idx] = paddr;
++	}
++
++	if (codec_hevc_use_mmu(revision, sess->pixfmt_cap, is_10bit) &&
++	    codec_hevc_use_downsample(sess->pixfmt_cap, is_10bit)) {
++		ret = codec_hevc_alloc_mmu_headers(sess, comm);
++		if (ret) {
++			codec_hevc_free_fbc_buffers(sess, comm);
++			return ret;
++		}
+ 	}
+ 
+ 	return 0;
+@@ -250,21 +286,24 @@ int codec_hevc_setup_buffers(struct amvdec_session *sess,
+ 			     int is_10bit)
+ {
+ 	struct amvdec_core *core = sess->core;
++    struct device *dev = core->dev;
+ 	int ret;
+ 
+-	if (codec_hevc_use_downsample(sess->pixfmt_cap, is_10bit)) {
+-		ret = codec_hevc_alloc_fbc_buffers(sess, comm);
+-		if (ret)
+-			return ret;
++	if (codec_hevc_use_mmu(core->platform->revision,
++			       sess->pixfmt_cap, is_10bit)) {
++		comm->mmu_map_vaddr = dma_alloc_coherent(dev, MMU_MAP_SIZE,
++							 &comm->mmu_map_paddr,
++							 GFP_KERNEL);
++		if (!comm->mmu_map_vaddr)
++			return -ENOMEM;
+ 	}
+ 
+ 	if (codec_hevc_use_mmu(core->platform->revision,
+-			       sess->pixfmt_cap, is_10bit)) {
+-		ret = codec_hevc_alloc_mmu_headers(sess, comm);
+-		if (ret) {
+-			codec_hevc_free_fbc_buffers(sess, comm);
+-			return ret;
+-		}
++			       sess->pixfmt_cap, is_10bit) ||
++	    codec_hevc_use_downsample(sess->pixfmt_cap, is_10bit)) {
++		ret = codec_hevc_alloc_fbc_buffers(sess, comm);
++		if (ret)
++ 			return ret;
+ 	}
+ 
+ 	if (core->platform->revision == VDEC_REVISION_GXBB)
+@@ -278,19 +317,24 @@ EXPORT_SYMBOL_GPL(codec_hevc_setup_buffers);
+ 
+ void codec_hevc_fill_mmu_map(struct amvdec_session *sess,
+ 			     struct codec_hevc_common *comm,
+-			     struct vb2_buffer *vb)
++			     struct vb2_buffer *vb,
++			     u32 is_10bit)
+ {
+-	u32 size = amvdec_am21c_size(sess->width, sess->height);
+-	u32 nb_pages = size / PAGE_SIZE;
++	u32 use_mmu;
++	u32 size;
++	u32 nb_pages;
+ 	u32 *mmu_map = comm->mmu_map_vaddr;
+ 	u32 first_page;
+ 	u32 i;
+ 
+-	if (sess->pixfmt_cap == V4L2_PIX_FMT_NV12M)
+-		first_page = comm->fbc_buffer_paddr[vb->index] >> PAGE_SHIFT;
+-	else
+-		first_page = vb2_dma_contig_plane_dma_addr(vb, 0) >> PAGE_SHIFT;
++	use_mmu = codec_hevc_use_mmu(sess->core->platform->revision,
++				    	 sess->pixfmt_cap, is_10bit);
++
++	size = amvdec_amfbc_size(sess->width, sess->height, is_10bit,
++				         use_mmu);
+ 
++	nb_pages = size / PAGE_SIZE;
++	first_page = comm->fbc_buffer_paddr[vb->index] >> PAGE_SHIFT;
+ 	for (i = 0; i < nb_pages; ++i)
+ 		mmu_map[i] = first_page + i;
+ }
+diff --git a/drivers/staging/media/meson/vdec/codec_hevc_common.h b/drivers/staging/media/meson/vdec/codec_hevc_common.h
+index cf072b8a9da2..13f9f1d90a94 100644
+--- a/drivers/staging/media/meson/vdec/codec_hevc_common.h
++++ b/drivers/staging/media/meson/vdec/codec_hevc_common.h
+@@ -64,6 +64,7 @@ int codec_hevc_setup_buffers(struct amvdec_session *sess,
+ 
+ void codec_hevc_fill_mmu_map(struct amvdec_session *sess,
+ 			     struct codec_hevc_common *comm,
+-			     struct vb2_buffer *vb);
++			     struct vb2_buffer *vb,
++			     u32 is_10bit);
+ 
+ #endif
+diff --git a/drivers/staging/media/meson/vdec/codec_vp9.c b/drivers/staging/media/meson/vdec/codec_vp9.c
+index 897f5d7a6aad..bfc312ec2a56 100644
+--- a/drivers/staging/media/meson/vdec/codec_vp9.c
++++ b/drivers/staging/media/meson/vdec/codec_vp9.c
+@@ -458,12 +458,6 @@ struct codec_vp9 {
+ 	struct list_head ref_frames_list;
+ 	u32 frames_num;
+ 
+-	/* In case of downsampling (decoding with FBC but outputting in NV12M),
+-	 * we need to allocate additional buffers for FBC.
+-	 */
+-	void      *fbc_buffer_vaddr[MAX_REF_PIC_NUM];
+-	dma_addr_t fbc_buffer_paddr[MAX_REF_PIC_NUM];
+-
+ 	int ref_frame_map[REF_FRAMES];
+ 	int next_ref_frame_map[REF_FRAMES];
+ 	struct vp9_frame *frame_refs[REFS_PER_FRAME];
+@@ -901,11 +895,8 @@ static void codec_vp9_set_sao(struct amvdec_session *sess,
+ 		buf_y_paddr =
+ 		       vb2_dma_contig_plane_dma_addr(vb, 0);
+ 
+-	if (codec_hevc_use_fbc(sess->pixfmt_cap, vp9->is_10bit)) {
+-		val = amvdec_read_dos(core, HEVC_SAO_CTRL5) & ~0xff0200;
+-		amvdec_write_dos(core, HEVC_SAO_CTRL5, val);
+-		amvdec_write_dos(core, HEVC_CM_BODY_START_ADDR, buf_y_paddr);
+-	}
++	if (codec_hevc_use_fbc(sess->pixfmt_cap, vp9->is_10bit))
++ 		amvdec_write_dos(core, HEVC_CM_BODY_START_ADDR, buf_y_paddr);
+ 
+ 	if (sess->pixfmt_cap == V4L2_PIX_FMT_NV12M) {
+ 		buf_y_paddr =
+@@ -920,8 +911,12 @@ static void codec_vp9_set_sao(struct amvdec_session *sess,
+ 
+ 	if (codec_hevc_use_mmu(core->platform->revision, sess->pixfmt_cap,
+ 			       vp9->is_10bit)) {
+-		amvdec_write_dos(core, HEVC_CM_HEADER_START_ADDR,
+-				 vp9->common.mmu_header_paddr[vb->index]);
++		dma_addr_t header_adr;
++		if (codec_hevc_use_downsample(sess->pixfmt_cap, vp9->is_10bit))
++			header_adr = vp9->common.mmu_header_paddr[vb->index];
++		else
++			header_adr = vb2_dma_contig_plane_dma_addr(vb, 0);
++		amvdec_write_dos(core, HEVC_CM_HEADER_START_ADDR, header_adr);
+ 		/* use HEVC_CM_HEADER_START_ADDR */
+ 		amvdec_write_dos_bits(core, HEVC_SAO_CTRL5, BIT(10));
+ 	}
+@@ -1148,9 +1143,13 @@ static void codec_vp9_set_mc(struct amvdec_session *sess,
+ {
+ 	struct amvdec_core *core = sess->core;
+ 	u32 scale = 0;
++	u32 use_mmu;
+ 	u32 sz;
+ 	int i;
+ 
++	use_mmu = codec_hevc_use_mmu(core->platform->revision,
++					 sess->pixfmt_cap, vp9->is_10bit);
++
+ 	amvdec_write_dos(core, HEVCD_MPP_ANC_CANVAS_ACCCONFIG_ADDR, 1);
+ 	codec_vp9_set_refs(sess, vp9);
+ 	amvdec_write_dos(core, HEVCD_MPP_ANC_CANVAS_ACCCONFIG_ADDR,
+@@ -1166,8 +1165,9 @@ static void codec_vp9_set_mc(struct amvdec_session *sess,
+ 		    vp9->frame_refs[i]->height != vp9->height)
+ 			scale = 1;
+ 
+-		sz = amvdec_am21c_body_size(vp9->frame_refs[i]->width,
+-					    vp9->frame_refs[i]->height);
++		sz = amvdec_amfbc_body_size(vp9->frame_refs[i]->width,
++					    vp9->frame_refs[i]->height,
++					    vp9->is_10bit, use_mmu);
+ 
+ 		amvdec_write_dos(core, VP9D_MPP_REFINFO_DATA,
+ 				 vp9->frame_refs[i]->width);
+@@ -1283,7 +1283,8 @@ static void codec_vp9_process_frame(struct amvdec_session *sess)
+ 	if (codec_hevc_use_mmu(core->platform->revision, sess->pixfmt_cap,
+ 			       vp9->is_10bit))
+ 		codec_hevc_fill_mmu_map(sess, &vp9->common,
+-					&vp9->cur_frame->vbuf->vb2_buf);
++					&vp9->cur_frame->vbuf->vb2_buf,
++					vp9->is_10bit);
+ 
+ 	intra_only = param->p.show_frame ? 0 : param->p.intra_only;
+ 
+@@ -2132,7 +2133,8 @@ static irqreturn_t codec_vp9_threaded_isr(struct amvdec_session *sess)
+ 
+ 	codec_vp9_fetch_rpm(sess);
+ 	if (codec_vp9_process_rpm(vp9)) {
+-		amvdec_src_change(sess, vp9->width, vp9->height, 16);
++		amvdec_src_change(sess, vp9->width, vp9->height, 16,
++				  vp9->is_10bit ? 10 : 8);
+ 
+ 		/* No frame is actually processed */
+ 		vp9->cur_frame = NULL;
+diff --git a/drivers/staging/media/meson/vdec/esparser.c b/drivers/staging/media/meson/vdec/esparser.c
+index 4b9ef97639c0..98f1efa4ad31 100644
+--- a/drivers/staging/media/meson/vdec/esparser.c
++++ b/drivers/staging/media/meson/vdec/esparser.c
+@@ -321,6 +321,7 @@ esparser_queue(struct amvdec_session *sess, struct vb2_v4l2_buffer *vbuf)
+ 		if (esparser_vififo_get_free_space(sess) < payload_size ||
+ 		    atomic_read(&sess->esparser_queued_bufs) >= num_dst_bufs)
+ 			return -EAGAIN;
++
+ 	} else if (esparser_vififo_get_free_space(sess) < payload_size) {
+ 		return -EAGAIN;
+ 	}
+diff --git a/drivers/staging/media/meson/vdec/vdec.h b/drivers/staging/media/meson/vdec/vdec.h
+index 0906b8fb5cc6..a48170fe4cff 100644
+--- a/drivers/staging/media/meson/vdec/vdec.h
++++ b/drivers/staging/media/meson/vdec/vdec.h
+@@ -244,6 +244,7 @@ struct amvdec_session {
+ 	u32 width;
+ 	u32 height;
+ 	u32 colorspace;
++	u32 bitdepth;
+ 	u8 ycbcr_enc;
+ 	u8 quantization;
+ 	u8 xfer_func;
+diff --git a/drivers/staging/media/meson/vdec/vdec_helpers.c b/drivers/staging/media/meson/vdec/vdec_helpers.c
+index 7d2a75653250..d684057509bf 100644
+--- a/drivers/staging/media/meson/vdec/vdec_helpers.c
++++ b/drivers/staging/media/meson/vdec/vdec_helpers.c
+@@ -50,32 +50,40 @@ void amvdec_write_parser(struct amvdec_core *core, u32 reg, u32 val)
+ }
+ EXPORT_SYMBOL_GPL(amvdec_write_parser);
+ 
+-/* 4 KiB per 64x32 block */
+-u32 amvdec_am21c_body_size(u32 width, u32 height)
++/* AMFBC body is made out of 64x32 blocks with varying block size */
++u32 amvdec_amfbc_body_size(u32 width, u32 height, u32 is_10bit, u32 use_mmu)
+ {
+ 	u32 width_64 = ALIGN(width, 64) / 64;
+ 	u32 height_32 = ALIGN(height, 32) / 32;
++	u32 blk_size = 4096;
+ 
+-	return SZ_4K * width_64 * height_32;
++	if (!is_10bit) {
++		if (use_mmu)
++			blk_size = 3200;
++		else
++			blk_size = 3072;
++	}
++
++	return blk_size * width_64 * height_32;
+ }
+-EXPORT_SYMBOL_GPL(amvdec_am21c_body_size);
++EXPORT_SYMBOL_GPL(amvdec_amfbc_body_size);
+ 
+ /* 32 bytes per 128x64 block */
+-u32 amvdec_am21c_head_size(u32 width, u32 height)
++u32 amvdec_amfbc_head_size(u32 width, u32 height)
+ {
+ 	u32 width_128 = ALIGN(width, 128) / 128;
+ 	u32 height_64 = ALIGN(height, 64) / 64;
+ 
+ 	return 32 * width_128 * height_64;
+ }
+-EXPORT_SYMBOL_GPL(amvdec_am21c_head_size);
++EXPORT_SYMBOL_GPL(amvdec_amfbc_head_size);
+ 
+-u32 amvdec_am21c_size(u32 width, u32 height)
++u32 amvdec_amfbc_size(u32 width, u32 height, u32 is_10bit, u32 use_mmu)
+ {
+-	return ALIGN(amvdec_am21c_body_size(width, height) +
+-		     amvdec_am21c_head_size(width, height), SZ_64K);
++	return ALIGN(amvdec_amfbc_body_size(width, height, is_10bit, use_mmu) +
++		     amvdec_amfbc_head_size(width, height), SZ_64K);
+ }
+-EXPORT_SYMBOL_GPL(amvdec_am21c_size);
++EXPORT_SYMBOL_GPL(amvdec_amfbc_size);
+ 
+ static int canvas_alloc(struct amvdec_session *sess, u8 *canvas_id)
+ {
+@@ -440,7 +448,7 @@ void amvdec_set_par_from_dar(struct amvdec_session *sess,
+ EXPORT_SYMBOL_GPL(amvdec_set_par_from_dar);
+ 
+ void amvdec_src_change(struct amvdec_session *sess, u32 width,
+-		       u32 height, u32 dpb_size)
++		       u32 height, u32 dpb_size, u32 bitdepth)
+ {
+ 	static const struct v4l2_event ev = {
+ 		.type = V4L2_EVENT_SOURCE_CHANGE,
+@@ -448,25 +456,27 @@ void amvdec_src_change(struct amvdec_session *sess, u32 width,
+ 
+ 	v4l2_ctrl_s_ctrl(sess->ctrl_min_buf_capture, dpb_size);
+ 
++	sess->bitdepth = bitdepth;
++
+ 	/*
+ 	 * Check if the capture queue is already configured well for our
+-	 * usecase. If so, keep decoding with it and do not send the event
++	 * usecase. If so, keep decoding with it.
+ 	 */
+ 	if (sess->streamon_cap &&
+ 	    sess->width == width &&
+ 	    sess->height == height &&
+ 	    dpb_size <= sess->num_dst_bufs) {
+ 		sess->fmt_out->codec_ops->resume(sess);
+-		return;
+-	}
++	} else {
++		sess->status = STATUS_NEEDS_RESUME;
++		sess->changed_format = 0;
++ 	}
+ 
+-	sess->changed_format = 0;
+ 	sess->width = width;
+ 	sess->height = height;
+-	sess->status = STATUS_NEEDS_RESUME;
+ 
+-	dev_dbg(sess->core->dev, "Res. changed (%ux%u), DPB size %u\n",
+-		width, height, dpb_size);
++	dev_dbg(sess->core->dev, "Res. changed (%ux%u), DPB %u, bitdepth %u\n",
++		width, height, dpb_size, bitdepth);
+ 	v4l2_event_queue_fh(&sess->fh, &ev);
+ }
+ EXPORT_SYMBOL_GPL(amvdec_src_change);
+diff --git a/drivers/staging/media/meson/vdec/vdec_helpers.h b/drivers/staging/media/meson/vdec/vdec_helpers.h
+index 4bf3e61d081b..1a711679d26a 100644
+--- a/drivers/staging/media/meson/vdec/vdec_helpers.h
++++ b/drivers/staging/media/meson/vdec/vdec_helpers.h
+@@ -27,9 +27,10 @@ void amvdec_clear_dos_bits(struct amvdec_core *core, u32 reg, u32 val);
+ u32 amvdec_read_parser(struct amvdec_core *core, u32 reg);
+ void amvdec_write_parser(struct amvdec_core *core, u32 reg, u32 val);
+ 
+-u32 amvdec_am21c_body_size(u32 width, u32 height);
+-u32 amvdec_am21c_head_size(u32 width, u32 height);
+-u32 amvdec_am21c_size(u32 width, u32 height);
++/* Helpers for the Amlogic compressed framebuffer format */
++u32 amvdec_amfbc_body_size(u32 width, u32 height, u32 is_10bit, u32 use_mmu);
++u32 amvdec_amfbc_head_size(u32 width, u32 height);
++u32 amvdec_amfbc_size(u32 width, u32 height, u32 is_10bit, u32 use_mmu);
+ 
+ /**
+  * amvdec_dst_buf_done_idx() - Signal that a buffer is done decoding
+@@ -77,9 +78,10 @@ void amvdec_set_par_from_dar(struct amvdec_session *sess,
+  * @width: picture width detected by the hardware
+  * @height: picture height detected by the hardware
+  * @dpb_size: Decoded Picture Buffer size (= amount of buffers for decoding)
++ * @bitdepth: Bit depth (usually 10 or 8) of the coded content
+  */
+ void amvdec_src_change(struct amvdec_session *sess, u32 width,
+-		       u32 height, u32 dpb_size);
++		       u32 height, u32 dpb_size, u32 bitdepth);
+ 
+ /**
+  * amvdec_abort() - Abort the current decoding session
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/general-meson-vdec-remove-redundant-if-statement.patch
+++ b/patch/kernel/archive/meson64-6.1/general-meson-vdec-remove-redundant-if-statement.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: benjamin545 <benjamin545@gmail.com>
+Date: Thu, 15 Jul 2021 14:32:33 -0400
+Subject: WIP: drivers: meson: vdec: remove redundant if statement
+
+checking if sess->fmt_out->pixfmt is V4L2_PIX_FMT_VP9 was already done
+as a condition to enter the if statement where this additional check is performed
+---
+ drivers/staging/media/meson/vdec/esparser.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/drivers/staging/media/meson/vdec/esparser.c b/drivers/staging/media/meson/vdec/esparser.c
+index 98f1efa4ad31..06f627b141fb 100644
+--- a/drivers/staging/media/meson/vdec/esparser.c
++++ b/drivers/staging/media/meson/vdec/esparser.c
+@@ -315,8 +315,7 @@ esparser_queue(struct amvdec_session *sess, struct vb2_v4l2_buffer *vbuf)
+ 			num_dst_bufs = codec_ops->num_pending_bufs(sess);
+ 
+ 		num_dst_bufs += v4l2_m2m_num_dst_bufs_ready(sess->m2m_ctx);
+-		if (sess->fmt_out->pixfmt == V4L2_PIX_FMT_VP9)
+-			num_dst_bufs -= 3;
++		num_dst_bufs -= 3;
+ 
+ 		if (esparser_vififo_get_free_space(sess) < payload_size ||
+ 		    atomic_read(&sess->esparser_queued_bufs) >= num_dst_bufs)
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/general-meson64-overlays.patch
+++ b/patch/kernel/archive/meson64-6.1/general-meson64-overlays.patch
@@ -1,0 +1,279 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Zhang Ning <832666+zhangn1985@users.noreply.github.com>
+Date: Thu, 19 Sep 2019 16:20:31 +0800
+Subject: general: meson64 overlays
+
+Signed-off-by: Zhang Ning <832666+zhangn1985@users.noreply.github.com>
+---
+ arch/arm64/boot/dts/amlogic/Makefile                                 |  2 +
+ arch/arm64/boot/dts/amlogic/overlay/Makefile                         | 20 ++++++
+ arch/arm64/boot/dts/amlogic/overlay/README.meson-overlays            | 20 ++++++
+ arch/arm64/boot/dts/amlogic/overlay/meson-fixup.scr-cmd              |  4 ++
+ arch/arm64/boot/dts/amlogic/overlay/meson-g12-gxl-cma-pool-896MB.dts | 19 ++++++
+ arch/arm64/boot/dts/amlogic/overlay/meson-i2cA.dts                   | 17 +++++
+ arch/arm64/boot/dts/amlogic/overlay/meson-i2cB.dts                   | 17 +++++
+ arch/arm64/boot/dts/amlogic/overlay/meson-uartA.dts                  | 11 ++++
+ arch/arm64/boot/dts/amlogic/overlay/meson-uartC.dts                  | 11 ++++
+ arch/arm64/boot/dts/amlogic/overlay/meson-w1-gpio.dts                | 20 ++++++
+ arch/arm64/boot/dts/amlogic/overlay/meson-w1AB-gpio.dts              | 32 ++++++++++
+ scripts/Makefile.lib                                                 |  3 +
+ 12 files changed, 176 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/Makefile b/arch/arm64/boot/dts/amlogic/Makefile
+index 606063c3204f..c11d45ee9274 100644
+--- a/arch/arm64/boot/dts/amlogic/Makefile
++++ b/arch/arm64/boot/dts/amlogic/Makefile
+@@ -76,3 +76,5 @@ dtb-$(CONFIG_ARCH_MESON) += meson-sm1-odroid-hc4.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-sm1-sei610.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-sm1-x96-air-gbit.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-sm1-x96-air.dtb
++
++subdir-y       := $(dts-dirs) overlay
+diff --git a/arch/arm64/boot/dts/amlogic/overlay/Makefile b/arch/arm64/boot/dts/amlogic/overlay/Makefile
+new file mode 100644
+index 000000000000..9d5c727602d1
+--- /dev/null
++++ b/arch/arm64/boot/dts/amlogic/overlay/Makefile
+@@ -0,0 +1,20 @@
++# SPDX-License-Identifier: GPL-2.0
++dtbo-$(CONFIG_ARCH_MESON) += \
++	meson-i2cA.dtbo \
++	meson-i2cB.dtbo \
++	meson-uartA.dtbo \
++	meson-uartC.dtbo \
++	meson-w1-gpio.dtbo \
++	meson-w1AB-gpio.dtbo \
++	meson-g12-gxl-cma-pool-896MB.dtbo
++
++scr-$(CONFIG_ARCH_MESON) += \
++       meson-fixup.scr
++
++dtbotxt-$(CONFIG_ARCH_MESON) += \
++       README.meson-overlays
++
++targets += $(dtbo-y) $(scr-y) $(dtbotxt-y)
++
++always         := $(dtbo-y) $(scr-y) $(dtbotxt-y)
++clean-files    := *.dtbo *.scr
+diff --git a/arch/arm64/boot/dts/amlogic/overlay/README.meson-overlays b/arch/arm64/boot/dts/amlogic/overlay/README.meson-overlays
+new file mode 100644
+index 000000000000..1b169a7a1525
+--- /dev/null
++++ b/arch/arm64/boot/dts/amlogic/overlay/README.meson-overlays
+@@ -0,0 +1,20 @@
++This document describes overlays provided in the kernel packages
++For generic Armbian overlays documentation please see
++https://docs.armbian.com/User-Guide_Allwinner_overlays/
++
++### Platform:
++
++meson (Amlogic)
++
++### Provided overlays:
++
++- i2c8
++
++### Overlay details:
++
++### i2c8
++
++Activates TWI/I2C bus 8
++
++I2C8 pins (SCL, SDA): GPIO1-C4, GPIO1-C5
++
+diff --git a/arch/arm64/boot/dts/amlogic/overlay/meson-fixup.scr-cmd b/arch/arm64/boot/dts/amlogic/overlay/meson-fixup.scr-cmd
+new file mode 100644
+index 000000000000..d4c39e20a3a2
+--- /dev/null
++++ b/arch/arm64/boot/dts/amlogic/overlay/meson-fixup.scr-cmd
+@@ -0,0 +1,4 @@
++# overlays fixup script
++# implements (or rather substitutes) overlay arguments functionality
++# using u-boot scripting, environment variables and "fdt" command
++
+diff --git a/arch/arm64/boot/dts/amlogic/overlay/meson-g12-gxl-cma-pool-896MB.dts b/arch/arm64/boot/dts/amlogic/overlay/meson-g12-gxl-cma-pool-896MB.dts
+new file mode 100644
+index 000000000000..f8c476b04e8c
+--- /dev/null
++++ b/arch/arm64/boot/dts/amlogic/overlay/meson-g12-gxl-cma-pool-896MB.dts
+@@ -0,0 +1,19 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "amlogic,g12a", "amlogic,g12b", "amlogic,meson-gxl";
++
++	fragment@0 {
++		target-path = "/reserved-memory";
++		__overlay__ {
++			linux,cma {
++				compatible = "shared-dma-pool";
++				reusable;
++				size = <0x0 0x38000000>;
++				alignment = <0x0 0x400000>;
++				linux,cma-default;
++			};
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/amlogic/overlay/meson-i2cA.dts b/arch/arm64/boot/dts/amlogic/overlay/meson-i2cA.dts
+new file mode 100644
+index 000000000000..bfb72feb7e36
+--- /dev/null
++++ b/arch/arm64/boot/dts/amlogic/overlay/meson-i2cA.dts
+@@ -0,0 +1,17 @@
++/dts-v1/;
++
++/ {
++    compatible = "amlogic,meson-gxbb";
++    fragment@0 {
++        target-path = "/aliases";
++        __overlay__ {
++            i2cA = "/soc/bus@c1100000/i2c@8500";
++        };
++    };
++    fragment@1 {
++	target-path = "/soc/bus@c1100000/i2c@8500";
++        __overlay__ {
++            status = "okay";
++        };
++    };
++};
+diff --git a/arch/arm64/boot/dts/amlogic/overlay/meson-i2cB.dts b/arch/arm64/boot/dts/amlogic/overlay/meson-i2cB.dts
+new file mode 100644
+index 000000000000..d75867bce99b
+--- /dev/null
++++ b/arch/arm64/boot/dts/amlogic/overlay/meson-i2cB.dts
+@@ -0,0 +1,17 @@
++/dts-v1/;
++
++/ {
++    compatible = "amlogic,meson-gxbb";
++    fragment@0 {
++        target-path = "/aliases";
++        __overlay__ {
++            i2cA = "/soc/bus@c1100000/i2c@87c0";
++        };
++    };
++    fragment@1 {
++	target-path = "/soc/bus@c1100000/i2c@87c0";
++        __overlay__ {
++            status = "okay";
++        };
++    };
++};
+diff --git a/arch/arm64/boot/dts/amlogic/overlay/meson-uartA.dts b/arch/arm64/boot/dts/amlogic/overlay/meson-uartA.dts
+new file mode 100644
+index 000000000000..3aecd60aaf64
+--- /dev/null
++++ b/arch/arm64/boot/dts/amlogic/overlay/meson-uartA.dts
+@@ -0,0 +1,11 @@
++/dts-v1/;
++
++/ {
++    compatible = "amlogic,meson-gxbb";
++    fragment@0 {
++	target-path = "/soc/bus@c1100000/serial@84c0";
++        __overlay__ {
++            status = "okay";
++        };
++    };
++};
+diff --git a/arch/arm64/boot/dts/amlogic/overlay/meson-uartC.dts b/arch/arm64/boot/dts/amlogic/overlay/meson-uartC.dts
+new file mode 100644
+index 000000000000..2b40ee4c02d3
+--- /dev/null
++++ b/arch/arm64/boot/dts/amlogic/overlay/meson-uartC.dts
+@@ -0,0 +1,11 @@
++/dts-v1/;
++
++/ {
++    compatible = "amlogic,meson-gxbb";
++    fragment@0 {
++	target-path = "/soc/bus@c1100000/serial@8700";
++        __overlay__ {
++            status = "okay";
++        };
++    };
++};
+diff --git a/arch/arm64/boot/dts/amlogic/overlay/meson-w1-gpio.dts b/arch/arm64/boot/dts/amlogic/overlay/meson-w1-gpio.dts
+new file mode 100644
+index 000000000000..ac76a4f20ab7
+--- /dev/null
++++ b/arch/arm64/boot/dts/amlogic/overlay/meson-w1-gpio.dts
+@@ -0,0 +1,20 @@
++// Definitions for w1-gpio module (without external pullup)
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "amlogic,meson-gxbb";
++
++	fragment@0 {
++		target-path = "/";
++		__overlay__ {
++
++			w1: onewire@0 {
++				compatible = "w1-gpio";
++				pinctrl-names = "default";
++				gpios = <&gpio 91 6>; // GPIOY_16
++				status = "okay";
++			};
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/amlogic/overlay/meson-w1AB-gpio.dts b/arch/arm64/boot/dts/amlogic/overlay/meson-w1AB-gpio.dts
+new file mode 100644
+index 000000000000..f6b0d7eff158
+--- /dev/null
++++ b/arch/arm64/boot/dts/amlogic/overlay/meson-w1AB-gpio.dts
+@@ -0,0 +1,32 @@
++// Definitions for w1-gpio module (without external pullup)
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "amlogic,meson-gxbb";
++
++	fragment@0 {
++		target-path = "/";
++		__overlay__ {
++
++			w1a: onewire@0 {
++				compatible = "w1-gpio";
++				pinctrl-names = "default";
++				gpios = <&gpio 91 6>; // GPIOY_16
++				status = "okay";
++			};
++		};
++	};
++	fragment@1 {
++		target-path = "/";
++		__overlay__ {
++
++			w1b: onewire@1 {
++				compatible = "w1-gpio";
++				pinctrl-names = "default";
++				gpios = <&gpio 90 6>; // GPIOY_15
++				status = "okay";
++			};
++		};
++	};
++};
+diff --git a/scripts/Makefile.lib b/scripts/Makefile.lib
+index 553018f80d8c..821e1c51aed9 100644
+--- a/scripts/Makefile.lib
++++ b/scripts/Makefile.lib
+@@ -88,6 +88,9 @@ base-dtb-y := $(foreach m, $(multi-dtb-y), $(firstword $(call suffix-search, $m,
+ 
+ always-y			+= $(dtb-y)
+ 
++# Overlay targets
++extra-y                                += $(dtbo-y) $(scr-y) $(dtbotxt-y)
++
+ # Add subdir path
+ 
+ ifneq ($(obj),.)
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/general-rc-drivers-should-produce-alternate-pulse-and-space-timing-events.patch
+++ b/patch/kernel/archive/meson64-6.1/general-rc-drivers-should-produce-alternate-pulse-and-space-timing-events.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor.pecovnik@gmail.com>
+Date: Tue, 26 Jun 2018 12:47:49 +0000
+Subject: media: rc: drivers should produce alternate pulse and space timing
+ events
+
+Unknown patch. Archeology revelated nothing. Good luck...
+---
+ drivers/media/rc/meson-ir.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/media/rc/meson-ir.c b/drivers/media/rc/meson-ir.c
+index 4b769111f78e..dd3aa1332f53 100644
+--- a/drivers/media/rc/meson-ir.c
++++ b/drivers/media/rc/meson-ir.c
+@@ -91,7 +91,8 @@ static irqreturn_t meson_ir_irq(int irqno, void *dev_id)
+ 	status = readl_relaxed(ir->reg + IR_DEC_STATUS);
+ 	rawir.pulse = !!(status & STATUS_IR_DEC_IN);
+ 
+-	ir_raw_event_store_with_timeout(ir->rc, &rawir);
++	if (ir_raw_event_store_with_filter(ir->rc, &rawir))
++		ir_raw_event_handle(ir->rc);
+ 
+ 	spin_unlock(&ir->lock);
+ 
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/general-si2168-fix-cmd-timeout.patch
+++ b/patch/kernel/archive/meson64-6.1/general-si2168-fix-cmd-timeout.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Koumes <koumes@centrum.cz>
+Date: Sat, 1 Jun 2019 21:20:26 +0000
+Subject: si2168: fix cmd timeout
+
+Some demuxer si2168 commands may take 130-140 ms.
+(DVB-T/T2 tuner MyGica T230C v2).
+Details: https://github.com/CoreELEC/CoreELEC/pull/208
+---
+ drivers/media/dvb-frontends/si2168.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/media/dvb-frontends/si2168.c b/drivers/media/dvb-frontends/si2168.c
+index 8157df4570d1..48054d792b16 100644
+--- a/drivers/media/dvb-frontends/si2168.c
++++ b/drivers/media/dvb-frontends/si2168.c
+@@ -40,7 +40,7 @@ static int si2168_cmd_execute(struct i2c_client *client, struct si2168_cmd *cmd)
+ 
+ 	if (cmd->rlen) {
+ 		/* wait cmd execution terminate */
+-		#define TIMEOUT 70
++		#define TIMEOUT 200
+ 		timeout = jiffies + msecs_to_jiffies(TIMEOUT);
+ 		while (!time_after(jiffies, timeout)) {
+ 			ret = i2c_master_recv(client, cmd->args, cmd->rlen);
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/general-sound-soc-remove-mono-channel-as-it-curren.patch
+++ b/patch/kernel/archive/meson64-6.1/general-sound-soc-remove-mono-channel-as-it-curren.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: ckkim <changkon12@gmail.com>
+Date: Thu, 20 Feb 2020 18:52:57 +0900
+Subject: ODROID-N2: sound/soc: remove mono channel as it currently doesn't
+ work hdmi output.
+
+Change-Id: I4d43b802815779687ade974f049f2b0517a411d1
+Signed-off-by: ckkim <changkon12@gmail.com>
+---
+ sound/soc/meson/axg-frddr.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/sound/soc/meson/axg-frddr.c b/sound/soc/meson/axg-frddr.c
+index 61f9d417fd60..b0f3883af0a9 100644
+--- a/sound/soc/meson/axg-frddr.c
++++ b/sound/soc/meson/axg-frddr.c
+@@ -106,7 +106,7 @@ static struct snd_soc_dai_driver axg_frddr_dai_drv = {
+ 	.name = "FRDDR",
+ 	.playback = {
+ 		.stream_name	= "Playback",
+-		.channels_min	= 1,
++		.channels_min	= 2,
+ 		.channels_max	= AXG_FIFO_CH_MAX,
+ 		.rates		= AXG_FIFO_RATES,
+ 		.formats	= AXG_FIFO_FORMATS,
+@@ -181,7 +181,7 @@ static struct snd_soc_dai_driver g12a_frddr_dai_drv = {
+ 	.name = "FRDDR",
+ 	.playback = {
+ 		.stream_name	= "Playback",
+-		.channels_min	= 1,
++		.channels_min	= 2,
+ 		.channels_max	= AXG_FIFO_CH_MAX,
+ 		.rates		= AXG_FIFO_RATES,
+ 		.formats	= AXG_FIFO_FORMATS,
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/general-spi-nor-add-support-for-XT25F128B.patch
+++ b/patch/kernel/archive/meson64-6.1/general-spi-nor-add-support-for-XT25F128B.patch
@@ -1,0 +1,89 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andreas Rammhold <andreas@rammhold.de>
+Date: Thu, 28 Jan 2021 09:43:36 +0000
+Subject: spi-nor: add support for XT25F128B
+
+This adds support for the XT25F128B as found on the RockPi4b SBC.
+
+Signed-off-by: Andreas Rammhold <andreas@rammhold.de>
+---
+
+This continues the efforts done in [1] & [2] that went stale. I've
+tested this patch on my RockPi4b which only has the xt25f128b (and not
+the xt25f32b as also propsed in [2]). I have tried to obtain a copy of
+the datasheets but was unable to find them. Not sure whre you would get
+them.
+
+While [1] was already for the new spi-nor layout it was missing the bits
+in the core.{c,h} files.
+
+[1]: https://patchwork.ozlabs.org/project/linux-mtd/patch/CAMgqO2y9MYDj6antOaWLBRKU8vGEwqCB-Y1TkXTSWsmsed+W6A@mail.gmail.com/
+[2]: https://patchwork.ozlabs.org/project/linux-mtd/patch/20200206171941.GA2398@makrotopia.org/
+---
+ drivers/mtd/spi-nor/Makefile |  1 +
+ drivers/mtd/spi-nor/core.c   |  1 +
+ drivers/mtd/spi-nor/core.h   |  1 +
+ drivers/mtd/spi-nor/xtx.c    | 16 ++++++++++
+ 4 files changed, 19 insertions(+)
+
+diff --git a/drivers/mtd/spi-nor/Makefile b/drivers/mtd/spi-nor/Makefile
+index e347b435a038..8992c592a896 100644
+--- a/drivers/mtd/spi-nor/Makefile
++++ b/drivers/mtd/spi-nor/Makefile
+@@ -17,6 +17,7 @@ spi-nor-objs			+= sst.o
+ spi-nor-objs			+= winbond.o
+ spi-nor-objs			+= xilinx.o
+ spi-nor-objs			+= xmc.o
++spi-nor-objs			+= xtx.o
+ spi-nor-$(CONFIG_DEBUG_FS)	+= debugfs.o
+ obj-$(CONFIG_MTD_SPI_NOR)	+= spi-nor.o
+ 
+diff --git a/drivers/mtd/spi-nor/core.c b/drivers/mtd/spi-nor/core.c
+index bee8fc4c9f07..24ce2fd7dc40 100644
+--- a/drivers/mtd/spi-nor/core.c
++++ b/drivers/mtd/spi-nor/core.c
+@@ -1630,6 +1630,7 @@ static const struct spi_nor_manufacturer *manufacturers[] = {
+ 	&spi_nor_winbond,
+ 	&spi_nor_xilinx,
+ 	&spi_nor_xmc,
++	&spi_nor_xtx,
+ };
+ 
+ static const struct flash_info *spi_nor_match_id(struct spi_nor *nor,
+diff --git a/drivers/mtd/spi-nor/core.h b/drivers/mtd/spi-nor/core.h
+index 85b0cf254e97..e79188ca9955 100644
+--- a/drivers/mtd/spi-nor/core.h
++++ b/drivers/mtd/spi-nor/core.h
+@@ -627,6 +627,7 @@ extern const struct spi_nor_manufacturer spi_nor_sst;
+ extern const struct spi_nor_manufacturer spi_nor_winbond;
+ extern const struct spi_nor_manufacturer spi_nor_xilinx;
+ extern const struct spi_nor_manufacturer spi_nor_xmc;
++extern const struct spi_nor_manufacturer spi_nor_xtx;
+ 
+ extern const struct attribute_group *spi_nor_sysfs_groups[];
+ 
+diff --git a/drivers/mtd/spi-nor/xtx.c b/drivers/mtd/spi-nor/xtx.c
+new file mode 100644
+index 000000000000..73568854cf1e
+--- /dev/null
++++ b/drivers/mtd/spi-nor/xtx.c
+@@ -0,0 +1,16 @@
++// SPDX-License-Identifier: GPL-2.0
++
++#include <linux/mtd/spi-nor.h>
++
++#include "core.h"
++
++static const struct flash_info xtx_parts[] = {
++ /* XTX (Shenzhen Xin Tian Xia Tech) */
++ { "xt25f128b", INFO(0x0b4018, 0, 64 * 1024, 256) },
++};
++
++const struct spi_nor_manufacturer spi_nor_xtx = {
++ .name = "xtx",
++ .parts = xtx_parts,
++ .nparts = ARRAY_SIZE(xtx_parts),
++};
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/general-usb-core-improve-handling-of-hubs-with-no-ports.patch
+++ b/patch/kernel/archive/meson64-6.1/general-usb-core-improve-handling-of-hubs-with-no-ports.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Heiner Kallweit <hkallweit1@gmail.com>
+Date: Wed, 23 Feb 2022 02:21:19 +0000
+Subject: usb: core: improve handling of hubs with no ports
+
+I get the "hub doesn't have any ports" error message on a system with
+Amlogic S905W SoC. Seems the SoC has internal USB 3.0 supports but
+is crippled with regard to USB 3.0 ports.
+Maybe we shouldn't consider this scenario an error. So let's change
+the message to info level, but otherwise keep the handling of the
+scenario as it is today. With the patch it looks like this on my
+system.
+
+dwc2 c9100000.usb: supply vusb_d not found, using dummy regulator
+dwc2 c9100000.usb: supply vusb_a not found, using dummy regulator
+dwc2 c9100000.usb: EPs: 7, dedicated fifos, 712 entries in SPRAM
+xhci-hcd xhci-hcd.0.auto: xHCI Host Controller
+xhci-hcd xhci-hcd.0.auto: new USB bus registered, assigned bus number 1
+xhci-hcd xhci-hcd.0.auto: hcc params 0x0228f664 hci version 0x100 quirks 0x0000000002010010
+xhci-hcd xhci-hcd.0.auto: irq 49, io mem 0xc9000000
+hub 1-0:1.0: USB hub found
+hub 1-0:1.0: 2 ports detected
+xhci-hcd xhci-hcd.0.auto: xHCI Host Controller
+xhci-hcd xhci-hcd.0.auto: new USB bus registered, assigned bus number 2
+xhci-hcd xhci-hcd.0.auto: Host supports USB 3.0 SuperSpeed
+usb usb2: We don't know the algorithms for LPM for this host, disabling LPM.
+hub 2-0:1.0: USB hub found
+hub 2-0:1.0: hub has no ports, exiting
+
+Signed-off-by: Heiner Kallweit <hkallweit1@gmail.com>
+---
+ drivers/usb/core/hub.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/usb/core/hub.c b/drivers/usb/core/hub.c
+index bbab424b0d55..87cc6d816e91 100644
+--- a/drivers/usb/core/hub.c
++++ b/drivers/usb/core/hub.c
+@@ -1424,9 +1424,8 @@ static int hub_configure(struct usb_hub *hub,
+ 		ret = -ENODEV;
+ 		goto fail;
+ 	} else if (hub->descriptor->bNbrPorts == 0) {
+-		message = "hub doesn't have any ports!";
+-		ret = -ENODEV;
+-		goto fail;
++		dev_info(hub_dev, "hub has no ports, exiting\n");
++		return -ENODEV;
+ 	}
+ 
+ 	/*
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/jethome-0001-Fix-meson64-add-gpio-irq-patch-from-https-lkml.org-l.patch
+++ b/patch/kernel/archive/meson64-6.1/jethome-0001-Fix-meson64-add-gpio-irq-patch-from-https-lkml.org-l.patch
@@ -1,0 +1,100 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: usera <adeep@lexina.in>
+Date: Mon, 12 Apr 2021 16:16:42 +0200
+Subject: Fix:meson64: add gpio irq (patch from
+ https://lkml.org/lkml/2020/11/27/8)
+
+Signed-off-by: Vyacheslav Bocharov <devel@lexina.in>
+---
+ drivers/pinctrl/meson/pinctrl-meson.c | 41 ++++++++++
+ drivers/pinctrl/meson/pinctrl-meson.h |  1 +
+ 2 files changed, 42 insertions(+)
+
+diff --git a/drivers/pinctrl/meson/pinctrl-meson.c b/drivers/pinctrl/meson/pinctrl-meson.c
+index 530f3f934e19..690832c48f79 100644
+--- a/drivers/pinctrl/meson/pinctrl-meson.c
++++ b/drivers/pinctrl/meson/pinctrl-meson.c
+@@ -52,6 +52,7 @@
+ #include <linux/property.h>
+ #include <linux/regmap.h>
+ #include <linux/seq_file.h>
++#include <linux/of_irq.h>
+ 
+ #include "../core.h"
+ #include "../pinctrl-utils.h"
+@@ -602,6 +603,40 @@ static int meson_gpio_get(struct gpio_chip *chip, unsigned gpio)
+ 	return !!(val & BIT(bit));
+ }
+ 
++static int meson_gpio_to_irq(struct gpio_chip *chip, unsigned int gpio)
++{
++	struct meson_pinctrl *pc = gpiochip_get_data(chip);
++	struct meson_bank *bank;
++	struct irq_fwspec fwspec;
++	int hwirq;
++
++	if (meson_get_bank(pc, gpio, &bank))
++		return -EINVAL;
++
++	if (bank->irq_first < 0) {
++		dev_warn(pc->dev, "no support irq for pin[%d]\n", gpio);
++		return -EINVAL;
++	}
++	if (!pc->of_irq) {
++		dev_err(pc->dev, "invalid device node of gpio INTC\n");
++		return -EINVAL;
++	}
++
++	hwirq = gpio - bank->first + bank->irq_first;
++	printk("gpio irq setup: hwirq: 0x%X irqfirst: 0x%X irqlast: 0x%X pin[%d]\n", hwirq, bank->irq_first, bank->irq_last, gpio);
++	if (hwirq > bank->irq_last)
++	{
++		dev_warn(pc->dev, "no more irq for pin[%d]\n", gpio);
++		return -EINVAL;
++	}
++	fwspec.fwnode = of_node_to_fwnode(pc->of_irq);
++	fwspec.param_count = 2;
++	fwspec.param[0] = hwirq;
++	fwspec.param[1] = IRQ_TYPE_NONE;
++
++	return irq_create_fwspec_mapping(&fwspec);
++}
++
+ static int meson_gpiolib_register(struct meson_pinctrl *pc)
+ {
+ 	int ret;
+@@ -617,6 +652,7 @@ static int meson_gpiolib_register(struct meson_pinctrl *pc)
+ 	pc->chip.direction_output = meson_gpio_direction_output;
+ 	pc->chip.get = meson_gpio_get;
+ 	pc->chip.set = meson_gpio_set;
++	pc->chip.to_irq = meson_gpio_to_irq;
+ 	pc->chip.base = -1;
+ 	pc->chip.ngpio = pc->data->num_pins;
+ 	pc->chip.can_sleep = false;
+@@ -680,6 +716,11 @@ static int meson_pinctrl_parse_dt(struct meson_pinctrl *pc)
+ 	pc->fwnode = gpiochip_node_get_first(pc->dev);
+ 	gpio_np = to_of_node(pc->fwnode);
+ 
++	pc->of_irq = of_find_compatible_node(NULL,
++					NULL, "amlogic,meson-gpio-intc");
++	if (!pc->of_irq)
++		pc->of_irq = of_find_compatible_node(NULL,
++				NULL, "amlogic,meson-gpio-intc-ext");
+ 	pc->reg_mux = meson_map_resource(pc, gpio_np, "mux");
+ 	if (IS_ERR_OR_NULL(pc->reg_mux)) {
+ 		dev_err(pc->dev, "mux registers not found\n");
+diff --git a/drivers/pinctrl/meson/pinctrl-meson.h b/drivers/pinctrl/meson/pinctrl-meson.h
+index 34fc4e8612e4..0f9fa04513ea 100644
+--- a/drivers/pinctrl/meson/pinctrl-meson.h
++++ b/drivers/pinctrl/meson/pinctrl-meson.h
+@@ -134,6 +134,7 @@ struct meson_pinctrl {
+ 	struct regmap *reg_ds;
+ 	struct gpio_chip chip;
+ 	struct fwnode_handle *fwnode;
++	struct device_node *of_irq;
+ };
+ 
+ #define FUNCTION(fn)							\
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/meson-g12a-pinctrl-add-missing-ir-options.patch
+++ b/patch/kernel/archive/meson64-6.1/meson-g12a-pinctrl-add-missing-ir-options.patch
@@ -1,0 +1,91 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yuntian Zhang <yt@radxa.com>
+Date: Mon, 25 Jul 2022 15:31:31 +0800
+Subject: pinctrl: meson-g12a: add missing ir options
+
+Those pins are defined in S905Y2 and A311D reference manuals.
+
+Signed-off-by: Yuntian Zhang <yt@radxa.com>
+---
+ arch/arm64/boot/dts/amlogic/meson-g12-common.dtsi | 16 ++++++++++
+ drivers/pinctrl/meson/pinctrl-meson-g12a.c        |  9 ++++++
+ 2 files changed, 25 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12-common.dtsi b/arch/arm64/boot/dts/amlogic/meson-g12-common.dtsi
+index 45947c1031c4..8bc032c38a50 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-g12-common.dtsi
++++ b/arch/arm64/boot/dts/amlogic/meson-g12-common.dtsi
+@@ -562,6 +562,14 @@ mux {
+ 						};
+ 					};
+ 
++					remote_input_pins: remote-input {
++						mux {
++							groups = "remote_input";
++							function = "remote_input";
++							bias-disable;
++						};
++					};
++
+ 					mclk0_a_pins: mclk0-a {
+ 						mux {
+ 							groups = "mclk0_a";
+@@ -2000,6 +2008,14 @@ mux {
+ 							bias-disable;
+ 						};
+ 					};
++
++					remote_out_ao_pins: remote-out {
++						mux {
++							groups = "remote_ao_out";
++							function = "remote_ao_out";
++							bias-disable;
++						};
++					};
+ 				};
+ 			};
+ 
+diff --git a/drivers/pinctrl/meson/pinctrl-meson-g12a.c b/drivers/pinctrl/meson/pinctrl-meson-g12a.c
+index d182a575981e..74c0fd368586 100644
+--- a/drivers/pinctrl/meson/pinctrl-meson-g12a.c
++++ b/drivers/pinctrl/meson/pinctrl-meson-g12a.c
+@@ -215,6 +215,9 @@ static const unsigned int i2c3_sck_h_pins[]		= { GPIOH_1 };
+ static const unsigned int i2c3_sda_a_pins[]		= { GPIOA_14 };
+ static const unsigned int i2c3_sck_a_pins[]		= { GPIOA_15 };
+ 
++/* ir_in */
++static const unsigned int remote_input_pins[]	= { GPIOA_15 };
++
+ /* uart_a */
+ static const unsigned int uart_a_tx_pins[]		= { GPIOX_12 };
+ static const unsigned int uart_a_rx_pins[]		= { GPIOX_13 };
+@@ -736,6 +739,7 @@ static struct meson_pmx_group meson_g12a_periphs_groups[] = {
+ 	/* bank GPIOA */
+ 	GROUP(i2c3_sda_a,		2),
+ 	GROUP(i2c3_sck_a,		2),
++	GROUP(remote_input,		1),
+ 	GROUP(pdm_din0_a,		1),
+ 	GROUP(pdm_din1_a,		1),
+ 	GROUP(pdm_din2_a,		1),
+@@ -1021,6 +1025,10 @@ static const char * const i2c3_groups[] = {
+ 	"i2c3_sda_a", "i2c3_sck_a",
+ };
+ 
++static const char * const remote_input_groups[] = {
++	"remote_input",
++};
++
+ static const char * const uart_a_groups[] = {
+ 	"uart_a_tx", "uart_a_rx", "uart_a_cts", "uart_a_rts",
+ };
+@@ -1265,6 +1273,7 @@ static struct meson_pmx_func meson_g12a_periphs_functions[] = {
+ 	FUNCTION(i2c1),
+ 	FUNCTION(i2c2),
+ 	FUNCTION(i2c3),
++	FUNCTION(remote_input),
+ 	FUNCTION(uart_a),
+ 	FUNCTION(uart_b),
+ 	FUNCTION(uart_c),
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/meson-g12b-pinctrl-Add-missing-pinmux-for-pwm.patch
+++ b/patch/kernel/archive/meson64-6.1/meson-g12b-pinctrl-Add-missing-pinmux-for-pwm.patch
@@ -1,0 +1,125 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yuntian Zhang <yt@radxa.com>
+Date: Thu, 13 Jan 2022 21:34:10 +0800
+Subject: pinctrl: meson: Add several missing pinmux for pwm functions
+
+The following pin definitions are mentioned in A311D Quick
+Reference Manual and S922X Public Datasheet, but not in S905Y2
+Quick Reference Manual, so adding them to meson-g12b family.
+
+They are currently exposed in Radxa Zero 2's GPIO header.
+
+Signed-off-by: Yuntian Zhang <yt@radxa.com>
+---
+ arch/arm64/boot/dts/amlogic/meson-g12b.dtsi | 34 ++++++++++
+ drivers/pinctrl/meson/pinctrl-meson-g12a.c  | 14 +++-
+ 2 files changed, 45 insertions(+), 3 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi b/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi
+index ee8fcae9f9f0..d938f883c66e 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi
++++ b/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi
+@@ -139,3 +139,37 @@ map1 {
+ &mali {
+ 	dma-coherent;
+ };
++
++&periphs_pinctrl {
++	pwm_b_h_pins: pwm-b-h {
++		mux {
++			groups = "pwm_b_h";
++			function = "pwm_b";
++			bias-disable;
++		};
++	};
++
++	pwm_b_z_pins: pwm-b-z {
++		mux {
++			groups = "pwm_b_z";
++			function = "pwm_b";
++			bias-disable;
++		};
++	};
++
++	pwm_c_z_pins: pwm-c-z {
++		mux {
++			groups = "pwm_c_z";
++			function = "pwm_c";
++			bias-disable;
++		};
++	};
++
++	pwm_d_z_pins: pwm-d-z {
++		mux {
++			groups = "pwm_d_z";
++			function = "pwm_d";
++			bias-disable;
++		};
++	};
++};
+diff --git a/drivers/pinctrl/meson/pinctrl-meson-g12a.c b/drivers/pinctrl/meson/pinctrl-meson-g12a.c
+index 74c0fd368586..bcf8b92d0c6f 100644
+--- a/drivers/pinctrl/meson/pinctrl-meson-g12a.c
++++ b/drivers/pinctrl/meson/pinctrl-meson-g12a.c
+@@ -270,17 +270,21 @@ static const unsigned int eth_act_led_pins[]		= { GPIOZ_15 };
+ static const unsigned int pwm_a_pins[]			= { GPIOX_6 };
+ 
+ /* pwm_b */
++static const unsigned int pwm_b_h_pins[]		= { GPIOH_7 };
+ static const unsigned int pwm_b_x7_pins[]		= { GPIOX_7 };
+ static const unsigned int pwm_b_x19_pins[]		= { GPIOX_19 };
++static const unsigned int pwm_b_z_pins[]		= { GPIOZ_0 };
+ 
+ /* pwm_c */
+ static const unsigned int pwm_c_c_pins[]		= { GPIOC_4 };
+ static const unsigned int pwm_c_x5_pins[]		= { GPIOX_5 };
+ static const unsigned int pwm_c_x8_pins[]		= { GPIOX_8 };
++static const unsigned int pwm_c_z_pins[]		= { GPIOZ_1 };
+ 
+ /* pwm_d */
+ static const unsigned int pwm_d_x3_pins[]		= { GPIOX_3 };
+ static const unsigned int pwm_d_x6_pins[]		= { GPIOX_6 };
++static const unsigned int pwm_d_z_pins[]		= { GPIOZ_2 };
+ 
+ /* pwm_e */
+ static const unsigned int pwm_e_pins[]			= { GPIOX_16 };
+@@ -593,6 +597,9 @@ static struct meson_pmx_group meson_g12a_periphs_groups[] = {
+ 	GROUP(bt565_a_din5,		2),
+ 	GROUP(bt565_a_din6,		2),
+ 	GROUP(bt565_a_din7,		2),
++	GROUP(pwm_b_z,			5),
++	GROUP(pwm_c_z,			5),
++	GROUP(pwm_d_z,			2),
+ 	GROUP(tsin_b_valid_z,		3),
+ 	GROUP(tsin_b_sop_z,		3),
+ 	GROUP(tsin_b_din0_z,		3),
+@@ -725,6 +732,7 @@ static struct meson_pmx_group meson_g12a_periphs_groups[] = {
+ 	GROUP(uart_c_rts,		2),
+ 	GROUP(iso7816_clk_h,		1),
+ 	GROUP(iso7816_data_h,		1),
++	GROUP(pwm_b_h,			5),
+ 	GROUP(pwm_f_h,			4),
+ 	GROUP(cec_ao_a_h,		4),
+ 	GROUP(cec_ao_b_h,		5),
+@@ -1065,15 +1073,15 @@ static const char * const pwm_a_groups[] = {
+ };
+ 
+ static const char * const pwm_b_groups[] = {
+-	"pwm_b_x7", "pwm_b_x19",
++	"pwm_b_h", "pwm_b_x7", "pwm_b_x19", "pwm_b_z",
+ };
+ 
+ static const char * const pwm_c_groups[] = {
+-	"pwm_c_c", "pwm_c_x5", "pwm_c_x8",
++	"pwm_c_c", "pwm_c_x5", "pwm_c_x8", "pwm_c_z",
+ };
+ 
+ static const char * const pwm_d_groups[] = {
+-	"pwm_d_x3", "pwm_d_x6",
++	"pwm_d_x3", "pwm_d_x6", "pwm_d_z",
+ };
+ 
+ static const char * const pwm_e_groups[] = {
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/meson-gx-dts-add-support-for-GX-PM-and-VRTC.patch
+++ b/patch/kernel/archive/meson64-6.1/meson-gx-dts-add-support-for-GX-PM-and-VRTC.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Neil Armstrong <narmstrong@baylibre.com>
+Date: Thu, 3 Nov 2016 15:29:25 +0100
+Subject: HACK: arm64: dts: meson: add support for GX PM and Virtual RTC
+
+Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>
+---
+ arch/arm64/boot/dts/amlogic/meson-gx.dtsi | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-gx.dtsi b/arch/arm64/boot/dts/amlogic/meson-gx.dtsi
+index 023a52005494..86ffd599b086 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-gx.dtsi
++++ b/arch/arm64/boot/dts/amlogic/meson-gx.dtsi
+@@ -221,6 +221,10 @@ sm: secure-monitor {
+ 		};
+ 	};
+ 
++	system-suspend {
++		compatible = "amlogic,meson-gx-pm";
++	};
++
+ 	efuse: efuse {
+ 		compatible = "amlogic,meson-gx-efuse", "amlogic,meson-gxbb-efuse";
+ 		#address-cells = <1>;
+@@ -459,6 +463,11 @@ clkc_AO: clock-controller {
+ 				};
+ 			};
+ 
++			vrtc: rtc@a8 {
++				compatible = "amlogic,meson-vrtc";
++				reg = <0x0 0x000a8 0x0 0x4>;
++			};
++
+ 			cec_AO: cec@100 {
+ 				compatible = "amlogic,meson-gx-ao-cec";
+ 				reg = <0x0 0x00100 0x0 0x14>;
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/meson-gxbb-dts-i2cX-missing-pins.patch
+++ b/patch/kernel/archive/meson64-6.1/meson-gxbb-dts-i2cX-missing-pins.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Martin Ayotte <martinayotte@yahoo.ca>
+Date: Wed, 5 Dec 2018 17:35:05 -0500
+Subject: fix i2cA and i2cB miossing pins
+
+- c80617d145039a32b53e9f0908353aaea3d368a6: 1544111688: Martin Ayotte <martinayotte@yahoo.ca>: 'add i2c_B missing pins'
+---
+ arch/arm64/boot/dts/amlogic/meson-gxbb.dtsi | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-gxbb.dtsi b/arch/arm64/boot/dts/amlogic/meson-gxbb.dtsi
+index 7c029f552a23..b3c22861b022 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-gxbb.dtsi
++++ b/arch/arm64/boot/dts/amlogic/meson-gxbb.dtsi
+@@ -333,6 +333,8 @@ &hwrng {
+ 
+ &i2c_A {
+ 	clocks = <&clkc CLKID_I2C>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c_a_pins>;
+ };
+ 
+ &i2c_AO {
+@@ -341,6 +343,8 @@ &i2c_AO {
+ 
+ &i2c_B {
+ 	clocks = <&clkc CLKID_I2C>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c_b_pins>;
+ };
+ 
+ &i2c_C {
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/meson-gxbb-vdec-add-HEVC-support-to-GXBB.patch
+++ b/patch/kernel/archive/meson64-6.1/meson-gxbb-vdec-add-HEVC-support-to-GXBB.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Christian Hewitt <christianshewitt@gmail.com>
+Date: Sun, 21 Nov 2021 19:12:07 +0000
+Subject: WIP: drivers: meson: vdec: add HEVC support to GXBB
+
+It's not clear whether the GXL firmware is the same one used with GXBB
+but let's try it and see!
+
+Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
+---
+ drivers/staging/media/meson/vdec/vdec_platform.c | 12 ++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/drivers/staging/media/meson/vdec/vdec_platform.c b/drivers/staging/media/meson/vdec/vdec_platform.c
+index 8592cb3aaea9..810039a02b44 100644
+--- a/drivers/staging/media/meson/vdec/vdec_platform.c
++++ b/drivers/staging/media/meson/vdec/vdec_platform.c
+@@ -16,6 +16,18 @@
+ 
+ static const struct amvdec_format vdec_formats_gxbb[] = {
+ 	{
++		.pixfmt = V4L2_PIX_FMT_HEVC,
++		.min_buffers = 4,
++		.max_buffers = 24,
++		.max_width = 3840,
++		.max_height = 2160,
++		.vdec_ops = &vdec_hevc_ops,
++		.codec_ops = &codec_hevc_ops,
++		.firmware_path = "meson/vdec/gxl_hevc.bin",
++		.pixfmts_cap = { V4L2_PIX_FMT_NV12M, 0 },
++		.flags = V4L2_FMT_FLAG_COMPRESSED |
++			 V4L2_FMT_FLAG_DYN_RESOLUTION,
++        }, {
+ 		.pixfmt = V4L2_PIX_FMT_H264,
+ 		.min_buffers = 2,
+ 		.max_buffers = 24,
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/meson-gxm-vdec-add-VP9-support-to-GXM.patch
+++ b/patch/kernel/archive/meson64-6.1/meson-gxm-vdec-add-VP9-support-to-GXM.patch
@@ -1,0 +1,43 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Christian Hewitt <christianshewitt@gmail.com>
+Date: Thu, 25 Nov 2021 11:31:43 +0000
+Subject: drivers: meson: vdec: add VP9 support to GXM
+
+VP9 support for GXM appears to have been missed from the original
+codec submission [0] but it works well, so let's add support.
+
+[0] https://github.com/torvalds/linux/commit/00c43088aa680989407b6afbda295f67b3f123f1
+
+Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
+---
+ drivers/staging/media/meson/vdec/vdec_platform.c | 14 +++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/staging/media/meson/vdec/vdec_platform.c b/drivers/staging/media/meson/vdec/vdec_platform.c
+index 810039a02b44..38f353c6d27d 100644
+--- a/drivers/staging/media/meson/vdec/vdec_platform.c
++++ b/drivers/staging/media/meson/vdec/vdec_platform.c
+@@ -27,7 +27,19 @@ static const struct amvdec_format vdec_formats_gxbb[] = {
+ 		.pixfmts_cap = { V4L2_PIX_FMT_NV12M, 0 },
+ 		.flags = V4L2_FMT_FLAG_COMPRESSED |
+ 			 V4L2_FMT_FLAG_DYN_RESOLUTION,
+-        }, {
++	}, {
++		.pixfmt = V4L2_PIX_FMT_VP9,
++		.min_buffers = 16,
++		.max_buffers = 24,
++		.max_width = 3840,
++		.max_height = 2160,
++		.vdec_ops = &vdec_hevc_ops,
++		.codec_ops = &codec_vp9_ops,
++		.firmware_path = "meson/vdec/gxl_vp9.bin",
++		.pixfmts_cap = { V4L2_PIX_FMT_NV12M, 0 },
++		.flags = V4L2_FMT_FLAG_COMPRESSED |
++			V4L2_FMT_FLAG_DYN_RESOLUTION,
++	}, {
+ 		.pixfmt = V4L2_PIX_FMT_H264,
+ 		.min_buffers = 2,
+ 		.max_buffers = 24,
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/meson-sm1-dts-add-higher-clocks.patch
+++ b/patch/kernel/archive/meson64-6.1/meson-sm1-dts-add-higher-clocks.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor.pecovnik@gmail.com>
+Date: Tue, 4 Aug 2020 22:51:56 +0200
+Subject: Add higher clocks for SM1 family
+
+Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
+---
+ arch/arm64/boot/dts/amlogic/meson-sm1.dtsi | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-sm1.dtsi b/arch/arm64/boot/dts/amlogic/meson-sm1.dtsi
+index 80737731af3f..ba52da32cd73 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-sm1.dtsi
++++ b/arch/arm64/boot/dts/amlogic/meson-sm1.dtsi
+@@ -134,6 +134,16 @@ opp-1908000000 {
+ 			opp-hz = /bits/ 64 <1908000000>;
+ 			opp-microvolt = <950000>;
+ 		};
++
++		opp-2016000000 {
++			opp-hz = /bits/ 64 <2016000000>;
++			opp-microvolt = <1000000>;
++		};
++
++		opp-2100000000 {
++			opp-hz = /bits/ 64 <2100000000>;
++			opp-microvolt = <1022000>;
++		};
+ 	};
+ };
+ 
+-- 
+Armbian
+

--- a/patch/kernel/meson64-current
+++ b/patch/kernel/meson64-current
@@ -1,1 +1,1 @@
-archive/meson64-5.19
+archive/meson64-6.0

--- a/patch/kernel/meson64-edge
+++ b/patch/kernel/meson64-edge
@@ -1,1 +1,1 @@
-archive/meson64-6.0
+archive/meson64-6.1


### PR DESCRIPTION
- `meson64-6.1` - rebased patches
  - 3 were mainlined:
    - JetHub device was mainlined 👏 
    - ODROID's hack for `pwm1_enable` was re-done differently in mainline
  - few fixes for overlays etc
  - rebased @adeepn clock phase patches
    - [ ] please review? should be simple but there were conflicts I resolved
- switch `current` to `6.0` (please also merge #4546 for consistency/patch formatting)

Tested devices:
- [x] Khadas VIM3
- [x] Khadas VIM3L
- [x] Radxa Zero
- [x] Radxa Zero2
- [x] ODROID N2
- [x] ODROID HC4
- [x] S912 (not-really VIM2) 