### PR TITLE
`odroidm1`: bump kernel to `6.1.y`

### DIFF
--- a/config/sources/families/rk3568-odroid.conf
+++ b/config/sources/families/rk3568-odroid.conf
@@ -16,7 +16,7 @@ case $BRANCH in
 
 	edge)
 		export KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel (for armbian-next)
-		KERNELBRANCH='tag:v6.1-rc5'
+		KERNELBRANCH='branch:linux-6.1.y'
 		KERNELPATCHDIR='archive/odroidm1-6.1'
 		;;
 


### PR DESCRIPTION
#### `odroidm1`: bump kernel to `6.1.y`