### PR TITLE
`meson64`: switch `edge` kernel to `6.1.y` branch (from `6.1-rc8` tag)

### DIFF
--- a/config/sources/families/include/meson64_common.inc
+++ b/config/sources/families/include/meson64_common.inc
@@ -29,7 +29,7 @@ case $BRANCH in
 		;;
 
 	edge)
-		KERNELBRANCH='tag:v6.1-rc8'     # @TODO: Soon to be KERNELBRANCH='branch:linux-6.1.y'
+		KERNELBRANCH='branch:linux-6.1.y'
 		KERNELPATCHDIR='meson64-edge'
 		;;
 


### PR DESCRIPTION
#### `meson64`: switch `edge` kernel to `6.1.y` branch (from `6.1-rc8` tag)