### PR TITLE
Adjust 3rd party drivers for kernel 6.1.y

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -133,7 +133,7 @@ driver_rtl8811_rtl8812_rtl8814_rtl8821()
 	if linux-version compare "${version}" ge 3.14 && [ "$EXTRAWIFI" == yes ]; then
 
 		# attach to specifics tag or branch
-		local rtl8812auver="commit:41532e3b16dcf27f06e6fe5a26314f3aa24d4f87"
+		local rtl8812auver="commit:450db78f7bd23f0c611553eb475fa5b5731d6497"
 
 		display_alert "Adding" "Wireless drivers for Realtek 8811, 8812, 8814 and 8821 chipsets ${rtl8812auver}" "info"
 
@@ -214,15 +214,15 @@ driver_rtl8811CU_rtl8821C()
 	if linux-version compare "${version}" ge 3.14 && [ "$EXTRAWIFI" == yes ]; then
 
 		# attach to specifics tag or branch
-		local rtl8811cuver="commit:8c2226a74ae718439d56248bd2e44ccf717086d5"
+		local rtl8811cuver="commit:7b8c45a270454f05e2dbf3beeb4afcf817db65da"
 
 		display_alert "Adding" "Wireless drivers for Realtek RTL8811CU and RTL8821C chipsets ${rtl8811cuver}" "info"
 
-		fetch_from_repo "$GITHUB_SOURCE/brektrou/rtl8821CU" "rtl8811cu" "${rtl8811cuver}" "yes"
+		fetch_from_repo "$GITHUB_SOURCE/morrownr/8821cu-20210118" "rtl8811cu" "${rtl8811cuver}" "yes"
 		cd "$kerneldir" || exit
 		rm -rf "$kerneldir/drivers/net/wireless/rtl8811cu"
 		mkdir -p "$kerneldir/drivers/net/wireless/rtl8811cu/"
-		cp -R "${SRC}/cache/sources/rtl8811cu/${rtl8811cuver#*:}"/{core,hal,include,os_dep,platform,rtl8821c.mk} \
+		cp -R "${SRC}/cache/sources/rtl8811cu/${rtl8811cuver#*:}"/{core,hal,include,os_dep,platform,*.mk} \
 			"$kerneldir/drivers/net/wireless/rtl8811cu"
 
 		# Makefile

--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -3,7 +3,7 @@
 driver_rtl8152_rtl8153()
 {
 	# Updated USB network drivers for RTL8152/RTL8153 based dongles that also support 2.5Gbs variants
-	if linux-version compare "${version}" ge 5.4 && linux-version compare "${version}" le 5.12 && [ $LINUXFAMILY != mvebu64 ] && [ $LINUXFAMILY != rk322x ] && [ $LINUXFAMILY != odroidxu4 ] && [ $EXTRAWIFI == yes ]; then
+	if linux-version compare "${version}" ge 5.4 && linux-version compare "${version}" le 5.12 && [ "$LINUXFAMILY" != mvebu64 ] && [ "$LINUXFAMILY" != rk322x ] && [ "$LINUXFAMILY" != odroidxu4 ] && [ "$EXTRAWIFI" == yes ]; then
 
 		# attach to specifics tag or branch
 		local rtl8152ver="branch:master"
@@ -312,7 +312,7 @@ driver_rtl88x2bu()
 	if linux-version compare "${version}" ge 5.0 && [ "$EXTRAWIFI" == yes ]; then
 
 		# attach to specifics tag or branch
-		local rtl88x2buver="commit:00f51d93fe8309b0e23782ad621a038c98c7f031"
+		local rtl88x2buver="commit:8bf3c489da36815b3789d053b49fcd0000209f03"
 
 		display_alert "Adding" "Wireless drivers for Realtek 88x2bu chipsets ${rtl88x2buver}" "info"
 
@@ -333,12 +333,12 @@ driver_rtl88x2bu()
 			"$kerneldir/drivers/net/wireless/rtl88x2bu/Kconfig"
 
 		# Adjust path
-		sed -i 's/include $(src)\/rtl8822b.mk /include $(TopDIR)\/drivers\/net\/wireless\/rtl88x2bu\/rtl8822b.mk/' \
+		sed -i "s/include \$(src)\/rtl8822b.mk /include \$(TopDIR)\/drivers\/net\/wireless\/rtl88x2bu\/rtl8822b.mk/" \
 			"$kerneldir/drivers/net/wireless/rtl88x2bu/Makefile"
 
 		# Add to section Makefile
 		echo "obj-\$(CONFIG_RTL8822BU) += rtl88x2bu/" >> "$kerneldir/drivers/net/wireless/Makefile"
-		sed -i '/source "drivers\/net\/wireless\/ti\/Kconfig"/a source "drivers\/net\/wireless\/rtl88x2bu\/Kconfig"' \
+		sed -i "/source \"drivers\/net\/wireless\/ti\/Kconfig\"/a source \"drivers\/net\/wireless\/rtl88x2bu\/Kconfig\"" \
 			"$kerneldir/drivers/net/wireless/Kconfig"
 
 	fi
@@ -374,7 +374,7 @@ driver_rtl88x2cs()
 			"$kerneldir/drivers/net/wireless/rtl88x2cs/Kconfig"
 
 		# Adjust path
-		sed -i 's/include $(src)\/rtl8822c.mk/include $(TopDIR)\/drivers\/net\/wireless\/rtl88x2cs\/rtl8822c.mk/' \
+		sed -i "s/include \$(src)\/rtl8822c.mk/include \$(TopDIR)\/drivers\/net\/wireless\/rtl88x2cs\/rtl8822c.mk/" \
 			"$kerneldir/drivers/net/wireless/rtl88x2cs/Makefile"
 
 		# Disable debug
@@ -446,7 +446,7 @@ driver_rtl8723DU()
 
 	# Wireless drivers for Realtek 8723DU chipsets
 
-	if linux-version compare $version ge 5.0 && [ "$EXTRAWIFI" == yes ]; then
+	if linux-version compare "${version}" ge 5.0 && [ "$EXTRAWIFI" == yes ]; then
 
 		local rtl8723duver="branch:master"
 
@@ -454,23 +454,23 @@ driver_rtl8723DU()
 
 		fetch_from_repo "$GITHUB_SOURCE/lwfinger/rtl8723du" "rtl8723du" "${rtl8723duver}" "yes"
 		cd "$kerneldir" || exit
-		rm -rf $kerneldir/drivers/net/wireless/rtl8723du
-		mkdir -p $kerneldir/drivers/net/wireless/rtl8723du/
-		cp -R ${SRC}/cache/sources/rtl8723du/${rtl8723duver#*:}/{core,hal,include,os_dep,platform} \
-			$kerneldir/drivers/net/wireless/rtl8723du
+		rm -rf "$kerneldir/drivers/net/wireless/rtl8723du"
+		mkdir -p "$kerneldir/drivers/net/wireless/rtl8723du/"
+		cp -R "${SRC}/cache/sources/rtl8723du/${rtl8723duver#*:}"/{core,hal,include,os_dep,platform} \
+			"$kerneldir/drivers/net/wireless/rtl8723du"
 
 		# Makefile
-		cp ${SRC}/cache/sources/rtl8723du/${rtl8723duver#*:}/Makefile \
-			$kerneldir/drivers/net/wireless/rtl8723du/Makefile
+		cp "${SRC}/cache/sources/rtl8723du/${rtl8723duver#*:}"/Makefile \
+			"$kerneldir/drivers/net/wireless/rtl8723du/Makefile"
 
 		# Disable debug
 		sed -i "s/^CONFIG_RTW_DEBUG.*/CONFIG_RTW_DEBUG = n/" \
-			$kerneldir/drivers/net/wireless/rtl8723du/Makefile
+			"$kerneldir/drivers/net/wireless/rtl8723du/Makefile"
 
 		# Add to section Makefile
-		echo "obj-\$(CONFIG_RTL8723DU) += rtl8723du/" >> $kerneldir/drivers/net/wireless/Makefile
+		echo "obj-\$(CONFIG_RTL8723DU) += rtl8723du/" >> "$kerneldir/drivers/net/wireless/Makefile"
 		sed -i '/source "drivers\/net\/wireless\/ti\/Kconfig"/a source "drivers\/net\/wireless\/rtl8723du\/Kconfig"' \
-			$kerneldir/drivers/net/wireless/Kconfig
+			"$kerneldir/drivers/net/wireless/Kconfig"
 
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723du-5.19.2.patch" "applying"
 	fi
@@ -489,13 +489,13 @@ driver_rtl8822BS()
 		fetch_from_repo "$GITHUB_SOURCE/150balbes/wifi" "rtl8822bs" "${rtl8822bsver}" "yes"
 		cd "$kerneldir" || exit
 		rm -rf "$kerneldir/drivers/net/wireless/rtl8822bs"
-		mkdir -p $kerneldir/drivers/net/wireless/rtl8822bs/
+		mkdir -p "$kerneldir/drivers/net/wireless/rtl8822bs/"
 		cp -R "${SRC}/cache/sources/rtl8822bs/${rtl8822bsver#*:}"/{core,hal,include,os_dep,platform,bluetooth,getAP,rtl8822b.mk} \
-			$kerneldir/drivers/net/wireless/rtl8822bs
+			"$kerneldir/drivers/net/wireless/rtl8822bs"
 
 		# Makefile
 		cp "${SRC}/cache/sources/rtl8822bs/${rtl8822bsver#*:}/Makefile" \
-			$kerneldir/drivers/net/wireless/rtl8822bs/Makefile
+			"$kerneldir/drivers/net/wireless/rtl8822bs/Makefile"
 
 		# Kconfig
 		sed -i 's/---help---/help/g' "${SRC}/cache/sources/rtl8822bs/${rtl8822bsver#*:}/Kconfig"
@@ -503,9 +503,9 @@ driver_rtl8822BS()
 			"$kerneldir/drivers/net/wireless/rtl8822bs/Kconfig"
 
 		# Add to section Makefile
-		echo "obj-\$(CONFIG_RTL8822BS) += rtl8822bs/" >> $kerneldir/drivers/net/wireless/Makefile
+		echo "obj-\$(CONFIG_RTL8822BS) += rtl8822bs/" >> "$kerneldir/drivers/net/wireless/Makefile"
 		sed -i '/source "drivers\/net\/wireless\/ti\/Kconfig"/a source "drivers\/net\/wireless\/rtl8822bs\/Kconfig"' \
-			$kerneldir/drivers/net/wireless/Kconfig
+			"$kerneldir/drivers/net/wireless/Kconfig"
 
 	fi
 

--- a/lib/functions/compilation/patch/kernel-bootsplash-and-drivers.sh
+++ b/lib/functions/compilation/patch/kernel-bootsplash-and-drivers.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 compilation_prepare() {
-	
+
 	source ${SRC}/lib/functions/compilation/patch/drivers_network.sh
 
 	# Packaging patch for modern kernels should be one for all.
@@ -106,7 +106,7 @@ compilation_prepare() {
 	# since plymouth introduction, boot scripts are not supporting this method anymore.
 	# In order to enable it, you need to use this: setenv consoleargs "bootsplash.bootfile=bootsplash.armbian ${consoleargs}"
 
-	if linux-version compare "${version}" ge 5.15 && [ "${SKIP_BOOTSPLASH}" != yes ]; then
+	if linux-version compare "${version}" ge 5.15 && linux-version compare "${version}" lt 6.1 && [ "${SKIP_BOOTSPLASH}" != yes ]; then
 
 		display_alert "Adding" "Kernel splash file" "info"
 


### PR DESCRIPTION
# Description

- General: disable kernel boot splash > 6.1 We don't use it anymore and its time to go rest.
- Adjust 881xau, 8811cu, [88xbu](https://github.com/armbian/build/pull/4552)
- @adeepn  you have a patch for 6.1 ready? For jethome-ru/rtl88x2cs

Jira reference number [AR-1432]

# How Has This Been Tested?

- [x] Build test

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1432]: https://armbian.atlassian.net/browse/AR-1432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ