### PR TITLE
Adding codeowners configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,24 @@
+# Default code owner
+*                        @igorpecovnik
+
+# the last matching pattern takes the most
+
+*.md                     @EvilOlaf @littlecxm @TheLinuxBug @TRSx80
+*.patch                  @armbian/board-maintainers
+  
+.github/                 @littlecxm
+.vscode                  @littlecxm
+
+config/                  @armbian/board-maintainers
+config/cli               @amazingfate @paolosabatino
+config/desktop           @amazingfate @monkaBlyat @paolosabatino
+config/distributions     @rpardini @neheb
+config/its               @ManoftheSea
+config/kernel            @marcone @150balbes @Manouchehri @brentr @amazingfate @hzyitc @juanesf @catalinii 
+config/optional          @iav @hzyitc @mhoffrog
+config/sources           @armbian/board-maintainers
+config/templates         @The-going @iav @neheb
+
+lib/                     @rpardini @150balbes @The-going @iav @hzyitc @mhoffrog @armbian/build-scripts
+packages/                @matthijskooijman @SteeManMI @The-going @marcone @mklein-de @schwar3kat @joekhoobyar @armbian/board-maintainers
+tools/                   @The-going @iav @neheb @hzyitc @mhoffrog


### PR DESCRIPTION
# Description

An attempt to improve review process.

Code owners are automatically requested for review when someone opens a pull request that modifies code that they own. Code owners are not automatically requested to review draft pull requests.

Jira reference number [AR-1435]

# How Has This Been Tested?

- [ ] Not tested yet

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1435]: https://armbian.atlassian.net/browse/AR-1435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ