### PR TITLE
Fix rk322x edge kernel 6.1 compilation

### DIFF
--- a/patch/kernel/archive/rk322x-6.1/5000-drm-rockchip-hardware-cursor.patch
+++ b/patch/kernel/archive/rk322x-6.1/5000-drm-rockchip-hardware-cursor.patch
@@ -191,7 +191,7 @@ index 83a926c0a..b0832320e 100644
 +		return -EINVAL;
 +
 +	ret = drm_atomic_helper_check_plane_state(new_plane_state, crtc_state,
-+						  DRM_PLANE_HELPER_NO_SCALING, DRM_PLANE_HELPER_NO_SCALING,
++						  DRM_PLANE_NO_SCALING, DRM_PLANE_NO_SCALING,
 +						  true, true);
 +
 +	if (ret)


### PR DESCRIPTION
# Description

A couple of patches received some fixes to let kernel 6.1 compile without errors for rk322x family

# How Has This Been Tested?

- [x] Compiled edge flavour kernel for rk322x

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
