### PR TITLE
`rockchip-6.1`: fix `xt-q8l-v10-remote-keymap.patch` mbox formatting; rebase against 6.1.0

### DIFF
--- a/patch/kernel/archive/rockchip-6.1/xt-q8l-v10-remote-keymap.patch
+++ b/patch/kernel/archive/rockchip-6.1/xt-q8l-v10-remote-keymap.patch
@@ -1,5 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Fri, 10 Jun 2022 15:59:15 +0000
+Subject: add xt-q8l-v10 keymap and makefile
+
+---
+ drivers/media/rc/keymaps/Makefile        |  1 +
+ drivers/media/rc/keymaps/rc-xt-q8l-v10.c | 76 ++++++++++
+ include/media/rc-map.h                   |  1 +
+ 3 files changed, 78 insertions(+)
+
+diff --git a/drivers/media/rc/keymaps/Makefile b/drivers/media/rc/keymaps/Makefile
+index f513ff5caf4e..198ef8bc2614 100644
+--- a/drivers/media/rc/keymaps/Makefile
++++ b/drivers/media/rc/keymaps/Makefile
+@@ -136,4 +136,5 @@ obj-$(CONFIG_RC_MAP) += \
+ 			rc-x96max.o \
+ 			rc-xbox-360.o \
+ 			rc-xbox-dvd.o \
++			rc-xt-q8l-v10.o \
+ 			rc-zx-irdec.o
 diff --git a/drivers/media/rc/keymaps/rc-xt-q8l-v10.c b/drivers/media/rc/keymaps/rc-xt-q8l-v10.c
-index e69de29..19c7d9e 100644
+new file mode 100644
+index 000000000000..19c7d9ec8325
 --- /dev/null
 +++ b/drivers/media/rc/keymaps/rc-xt-q8l-v10.c
 @@ -0,0 +1,76 @@
@@ -80,35 +102,17 @@ index e69de29..19c7d9e 100644
 +MODULE_LICENSE("GPL");
 +MODULE_AUTHOR("Paolo Sabatino");
 diff --git a/include/media/rc-map.h b/include/media/rc-map.h
-index d621acadf..ad7abdb97 100644
+index 793b54342dff..ef7f3710eafe 100644
 --- a/include/media/rc-map.h
 +++ b/include/media/rc-map.h
-@@ -278,6 +278,7 @@ struct rc_map *rc_map_get(const char *name);
- #define RC_MAP_WINFAST_USBII_DELUXE      "rc-winfast-usbii-deluxe"
+@@ -343,6 +343,7 @@ struct rc_map *rc_map_get(const char *name);
  #define RC_MAP_X96MAX                    "rc-x96max"
+ #define RC_MAP_XBOX_360                  "rc-xbox-360"
  #define RC_MAP_XBOX_DVD                  "rc-xbox-dvd"
 +#define RC_MAP_XT_Q8L_V10                "rc-xt-q8l-v10"
  #define RC_MAP_ZX_IRDEC                  "rc-zx-irdec"
  
  /*
-
-From 33f087bf341761e6284dc6e313d63576390d6a0a Mon Sep 17 00:00:00 2001
-From: Paolo Sabatino <paolo.sabatino@gmail.com>
-Date: Fri, 10 Jun 2022 15:59:15 +0000
-Subject: [PATCH] add xt-q8l-v10 keymap makefile
-
----
- drivers/media/rc/keymaps/Makefile | 1 +
- 1 file changed, 1 insertion(+)
-
-diff --git a/drivers/media/rc/keymaps/Makefile b/drivers/media/rc/keymaps/Makefile
-index f513ff5caf4..198ef8bc261 100644
---- a/drivers/media/rc/keymaps/Makefile
-+++ b/drivers/media/rc/keymaps/Makefile
-@@ -136,4 +136,5 @@ obj-$(CONFIG_RC_MAP) += \
- 			rc-x96max.o \
- 			rc-xbox-360.o \
- 			rc-xbox-dvd.o \
-+			rc-xt-q8l-v10.o \
- 			rc-zx-irdec.o
+-- 
+Armbian
 


### PR DESCRIPTION
#### `rockchip-6.1`: fix `xt-q8l-v10-remote-keymap.patch` mbox formatting; rebase against 6.1.0

- this patch had "half-mbox" formatting
  - first a bare patch (no mbox headers, `From/Subject` etc)
  - then an mbox-formatted patch
- this causes the 1st/bare patch to be lost when parsing/applying this file with a proper mbox-enabled tool

This is meant for @paolosabatino 's appreciation since it's his patch.