### PR TITLE
Fix armbian-install for selecting non formatted target partitions

### DIFF
--- a/packages/bsp/common/usr/sbin/armbian-install
+++ b/packages/bsp/common/usr/sbin/armbian-install
@@ -632,25 +632,25 @@ check_partitions()
 	IFS=" "
 	[[ -n "$1" ]] && EXCLUDE=" | grep -v $1"
 	[[ -n "$2" ]] && INCLUDE=" | grep $2" && diskcheck=$2
-	CMD="lsblk -io KNAME,FSTYPE,SIZE,TYPE,MOUNTPOINT | grep \"btrfs\|ext4\|f2fs\" $INCLUDE $EXCLUDE | grep -E '^sd|^nvme|^md|^mmc' | awk -F\" \" '/ part | raid..? / {print \$1}'"
+	CMD="lsblk -io KNAME,FSTYPE,SIZE,TYPE,MOUNTPOINT $INCLUDE $EXCLUDE | grep -E '^sd|^nvme|^md|^mmc' | awk -F\" \" '/ part | raid..? / {print \$1}'"
 	AvailablePartitions=$(eval $CMD)
 	if [[ -z $AvailablePartitions ]]; then
 		FREE_SPACE=$(parted /dev/$diskcheck unit GB print free | awk '/Free Space/{c++; sum += $3; print sum}' | tail -1)
-		dialog --yes-label "Proceed" --no-label 'Exit' --title "$title" --backtitle "$backtitle" --yesno "\nDestnation $diskcheck has $FREE_SPACE Gb of available space. \n\nAutomated install will generate needed partitions!" 9 55
+		dialog --yes-label "Proceed" --no-label 'Exit' --title "$title" --backtitle "$backtitle" --yesno "\nDestination $diskcheck has $FREE_SPACE Gb of available space. \n\nAutomated install will generate needed partitions!" 9 55
 		if [[ "${FREE_SPACE%.*}" -gt 4 && $? == 0 ]]; then
 			if [[ "$DEVICE_TYPE" == uefi && -z "$efi_partition" ]]; then
-			wipefs -aq /dev/$diskcheck
-			# create EFI parition
-	                {
-				echo n; echo ; echo ; echo ; echo +200M;
-				echo t; echo EF; echo w;
-			} | fdisk /dev/$diskcheck &> /dev/null || true
-			yes | mkfs.vfat /dev/${diskcheck}p1 &> /dev/null || true
-			fatlabel /dev/${diskcheck}p1 EFI
+				wipefs -aq /dev/$diskcheck
+				# create EFI partition
+				{
+					echo n; echo ; echo ; echo ; echo +200M;
+					echo t; echo EF; echo w;
+				} | fdisk /dev/$diskcheck &> /dev/null || true
+				yes | mkfs.vfat /dev/${diskcheck}p1 &> /dev/null || true
+				fatlabel /dev/${diskcheck}p1 EFI
 			fi
 			{
-			echo n; echo ; echo ; echo ; echo
-			echo w
+				echo n; echo ; echo ; echo ; echo
+				echo w
 			} | fdisk /dev/$diskcheck &> /dev/null || true
 			yes | mkfs.ext4 /dev/${diskcheck}p2 &> /dev/null || true
 
@@ -658,11 +658,11 @@ check_partitions()
 			emmccheck=$(ls -d -1 /dev/mmcblk* 2>/dev/null | grep -w 'mmcblk[0-9]' | grep -v "$root_partition_device");
 			efi_partition=$(LC_ALL=C fdisk -l "/dev/$diskcheck" 2>/dev/null | grep "EFI" | awk '{print $1}')
 
-			else
-				exit 11
-			fi
+		else
+			exit 11
+		fi
 	fi
-	CMD="lsblk -io KNAME,FSTYPE,SIZE,TYPE,MOUNTPOINT | grep \"btrfs\|ext4\|f2fs\" $INCLUDE $EXCLUDE | grep -E '^sd|^nvme|^md|^mmc' | awk -F\" \" '/ part | raid..? / {print \$1}' | uniq | sed 's|^|/dev/|' | nl | xargs echo -n"
+	CMD="lsblk -io KNAME,FSTYPE,SIZE,TYPE,MOUNTPOINT $INCLUDE $EXCLUDE | grep -E '^sd|^nvme|^md|^mmc' | awk -F\" \" '/ part | raid..? / {print \$1}' | uniq | sed 's|^|/dev/|' | nl | xargs echo -n"
 	partprobe
 	AvailablePartitions=$(eval $CMD)
 	PartitionOptions=($AvailablePartitions)


### PR DESCRIPTION

# Description

If there is a new SSD or harddisk used as destination with just a partition created but not yet formatted with a filesystem, then ```armbian-install``` does not provide this partition as a selectable destination.

GH reference #4576

# Changes made
- function check_partitions():
  - remove file system filter on ```lsblk``` commands for listing probable target partitions
  - fix typo "Destnation" -> "Destination"
  - fix indentation on if scopes

# Test results

1. New SSD - just a single partition was created but not yet formatted:
![image](https://user-images.githubusercontent.com/45703410/208213671-fe3c3cb4-6b28-408f-b36d-91362d5d01a9.png)

2. Script ```armbian-install``` was run on a Cubietruck board:
![image](https://user-images.githubusercontent.com/45703410/208213812-c3fae0d2-8b5e-4680-b809-ac7bbac085af.png)
![image](https://user-images.githubusercontent.com/45703410/208213825-9a749829-815c-4370-b8fa-db445968737d.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [n/a] Any dependent changes have been merged and published in downstream modules
