### PR TITLE
Adjust build targets

### DIFF
--- a/config/targets-cli-beta.conf
+++ b/config/targets-cli-beta.conf
@@ -2,11 +2,6 @@
 # board                      branch          release      desktop|cli|minimal      stable|beta  create images      #
 ####################################################################################################################
 
-# Bananapi M5
-bananapim5                   current         jammy       minimal                  beta         yes
-bananapim5                   edge            jammy       minimal                  beta         yes
-
-
 # JetHub J80
 jethubj80                    edge            jammy       cli                      beta         yes
 
@@ -33,10 +28,6 @@ radxa-zero2                  edge            jammy       cli                    
 
 # Radxa rock-5b
 rock-5b                      legacy          jammy       cli                      beta         yes
-
-
-# Rockpi-S
-rockpi-s                     edge            jammy       minimal                  beta         yes
 
 
 # Tinkerboard 2

--- a/config/targets-desktop-beta.conf
+++ b/config/targets-desktop-beta.conf
@@ -7,6 +7,3 @@ uefi-x86            current         jammy        desktop                  beta  
 
 # uefi-arm64
 uefi-arm64          current         jammy        desktop                  beta            yes           xfce          config_base   3dsupport,browsers
-
-# clockworkpi-a06
-clockworkpi-a06     current         jammy        desktop                  beta            yes           xfce          config_base   3dsupport,browsers

--- a/config/targets.conf
+++ b/config/targets.conf
@@ -337,6 +337,18 @@ odroidn2                  current         jammy       desktop                  s
 #
 
 
+# Odroid M1
+odroidm1                  edge            jammy       cli                      stable         adv
+odroidm1                  edge            bullseye    cli                      stable         yes
+odroidm1                  edge            jammy       minimal                  stable         yes
+odroidm1                  edge            bullseye    minimal                  stable         yes
+#
+odroidm1                  edge            jammy       desktop                  stable         yes            gnome         config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+odroidm1                  edge            jammy       desktop                  stable         yes            cinnamon      config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+odroidm1                  edge            jammy       desktop                  stable         adv            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+#
+
+
 # Odroid HC4
 odroidhc4                 current         jammy       cli                      stable         adv
 odroidhc4                 current         bullseye    cli                      stable         yes


### PR DESCRIPTION
# Description

- remove BETA targets we don't need anymore. Stable images has been replaced for Clockword hw
- add Odroid M1 EDGE targets. It works pretty good and we can have those images up.
