### PR TITLE
rk322x: increase to 16 stations the maximum number of ESP8089 AP clients

### DIFF
--- a/patch/kernel/archive/rk322x-5.15/wifi-4004-esp8089-kernel-driver.patch
+++ b/patch/kernel/archive/rk322x-5.15/wifi-4004-esp8089-kernel-driver.patch
@@ -5716,7 +5716,7 @@ index 000000000000..830dcac0a89b
 +#define ESP_WL_FLAG_STOP_TXQ          		BIT(3)
 +
 +#define ESP_PUB_MAX_VIF		2
-+#define ESP_PUB_MAX_STA		4	//for one interface
++#define ESP_PUB_MAX_STA		16	//for one interface
 +#define ESP_PUB_MAX_RXAMPDU	8	//for all interfaces
 +
 +enum {

--- a/patch/kernel/archive/rk322x-5.19/wifi-4004-esp8089-kernel-driver.patch
+++ b/patch/kernel/archive/rk322x-5.19/wifi-4004-esp8089-kernel-driver.patch
@@ -5715,7 +5715,7 @@ index 000000000000..830dcac0a89b
 +#define ESP_WL_FLAG_STOP_TXQ          		BIT(3)
 +
 +#define ESP_PUB_MAX_VIF		2
-+#define ESP_PUB_MAX_STA		4	//for one interface
++#define ESP_PUB_MAX_STA		16	//for one interface
 +#define ESP_PUB_MAX_RXAMPDU	8	//for all interfaces
 +
 +enum {

--- a/patch/kernel/archive/rk322x-6.0/wifi-4004-esp8089-kernel-driver.patch
+++ b/patch/kernel/archive/rk322x-6.0/wifi-4004-esp8089-kernel-driver.patch
@@ -5715,7 +5715,7 @@ index 000000000000..830dcac0a89b
 +#define ESP_WL_FLAG_STOP_TXQ          		BIT(3)
 +
 +#define ESP_PUB_MAX_VIF		2
-+#define ESP_PUB_MAX_STA		4	//for one interface
++#define ESP_PUB_MAX_STA		16	//for one interface
 +#define ESP_PUB_MAX_RXAMPDU	8	//for all interfaces
 +
 +enum {

--- a/patch/kernel/archive/rk322x-6.1/wifi-4004-esp8089-kernel-driver.patch
+++ b/patch/kernel/archive/rk322x-6.1/wifi-4004-esp8089-kernel-driver.patch
@@ -5715,7 +5715,7 @@ index 000000000000..830dcac0a89b
 +#define ESP_WL_FLAG_STOP_TXQ          		BIT(3)
 +
 +#define ESP_PUB_MAX_VIF		2
-+#define ESP_PUB_MAX_STA		4	//for one interface
++#define ESP_PUB_MAX_STA		16	//for one interface
 +#define ESP_PUB_MAX_RXAMPDU	8	//for all interfaces
 +
 +enum {


### PR DESCRIPTION
# Description

Increase the maximum number of AP connected clients to 16 instead of 4 for ESP8089 driver for rk322x family on kernels 5.15, 5.19, 6.0 and 6.1.
The patch is trivial

# How Has This Been Tested?

- [x] Packages for kernel 6.1 have been compiled and installed onto a running installation
- [x] The driver has been tested with up to 6 connected clients and worked with no issues

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
