### PR TITLE
armbian-install: further fixes plus MTD char driven flash support

### DIFF
--- a/packages/bsp/common/usr/sbin/armbian-install
+++ b/packages/bsp/common/usr/sbin/armbian-install
@@ -12,7 +12,13 @@
 # Import:
 # DIR: path to u-boot directory
 # write_uboot_platform: function to write u-boot to a block device
-# write_uboot_platform_mtd: function to write u-boot to a mtd (eg. SPI flash) device
+# write_uboot_platform_mtd:
+#   function to write u-boot to a mtd (eg. SPI flash) device
+#   $1 = u-boot files directory
+#   $2 = first MTD device path (e.g.: /dev/mtdblock0) - this is for backward compatibility before Armbian 23.nn
+#   $3 = Log file name
+#   $4 = :space: separated list of all MTD device names
+#        Note: MTD char device names are passed in format device_name:partition_label - e.g.: mtd0:SPL
 
 [[ -f /usr/lib/u-boot/platform_install.sh ]] && source /usr/lib/u-boot/platform_install.sh
 
@@ -41,11 +47,19 @@ root_partition_name=$(echo $root_partition | sed 's/\/dev\///g')
 root_partition_device_name=$(lsblk -ndo pkname $root_partition)
 root_partition_device=/dev/$root_partition_device_name
 
-# find targets: NAND, EMMC, SATA, SPI flash, NVMe
+# find targets: legacy SUNXI NAND, EMMC, SATA, NVMe, MTD block and/or MTD char driven flash
 [[ -b /dev/nand ]] && nandcheck=$(ls -d -1 /dev/nand* | grep -w 'nand' | awk '{print $NF}');
 emmccheck=$(ls -d -1 /dev/mmcblk* 2>/dev/null | grep -w 'mmcblk[0-9]' | grep -v "$root_partition_device");
 diskcheck=$(lsblk -l | awk -F" " '/ disk / {print $1}' | grep -E '^sd|^nvme|^mmc' | grep -v "$root_partition_device_name" | grep -v boot)
-spicheck=$(grep 'mtd' /proc/partitions | awk '{print $NF}')
+# Start mtdcheck with probable MTD block device partitions:
+mtdcheck=$(grep 'mtdblock' /proc/partitions | awk '{print $NF}' | xargs)
+# Append mtdcheck with probable MTD char devices filtered for partition name(s)
+# containing "spl" or "boot" case insensitive,
+# since we are currently interested in MTD partitions for boot flashing only.
+# Note: The following statement will add matching MTD char device names
+#       combined with partition name (separated from devicename by a :colon:):
+#       mtd0:partition0_name mtd1:partition1_name ... mtdN:partitionN_name
+[[ -f /proc/mtd ]] && mtdcheck="$mtdcheck${mtdcheck:+ }$(grep -i -E '^mtd[0-9]+:.*(spl|boot).*' /proc/mtd | awk '{print $1$NF}' | sed 's/\"//g' | xargs)"
 
 # SD card boot part - to be considered more than one entry on various platforms
 # UUID=xxx...
@@ -94,7 +108,7 @@ create_armbian()
 		[[ -n $2 ]] && ( mount -o compress-force=zlib "$2" "${TempDir}"/rootfs 2> /dev/null || mount "$2" "${TempDir}"/rootfs )
 	else
 		[[ -n $2 ]] && ( mount -o compress-force=zlib "$2" "${TempDir}"/rootfs 2> /dev/null || mount "$2" "${TempDir}"/rootfs )
-		[[ -n $1 && $1 != "spi" ]] && mount "$1" "${TempDir}"/bootfs
+		[[ -n $1 && $1 != "mtd" ]] && mount "$1" "${TempDir}"/bootfs
 	fi
 	rm -rf "${TempDir}"/bootfs/* "${TempDir}"/rootfs/*
 
@@ -419,9 +433,9 @@ create_armbian()
 
 
 
-	# Boot from SPI, root = SATA / USB
+	# Boot from MTD flash, root = SATA / USB
 	#
-	if [[ $1 == *spi* ]]; then
+	if [[ $1 == *mtd* ]]; then
 		if [[ -f "${TempDir}"/rootfs/boot/armbianEnv.txt ]]; then
 			sed -e 's,rootdev=.*,rootdev='"$satauuid"',g' -i "${TempDir}"/rootfs/boot/armbianEnv.txt
 		fi
@@ -734,15 +748,23 @@ stop_running_services()
 	done
 }
 
-# show warning and write u-boot to SPI flash $1 = spi device name, $2 = u-boot files directory
-write_uboot_to_spi_flash()
+# show warning and write u-boot to MTD device(s)
+#  $1 = u-boot files directory
+#  $2 = space separated list of all MTD block and/or MTD char device partitions
+write_uboot_to_mtd_flash()
 {
-	local MTD_BLK="/dev/$1"
-	local DIR="$2"
-	local MESSAGE="This script will update the bootloader on SPI Flash $MTD_BLK. Continue?\nIt will take up to a few minutes."
-	dialog --title "$title" --backtitle "$backtitle" --cr-wrap --colors --yesno " \Z1$(toilet -W -f ascii9 ' WARNING')\Zn\n$MESSAGE" 16 67
+	local DIR="$1"
+	local MTD_ALL_DEVICE_PARTITIONS="$2"
+	# For backward compatibility to existing implementations of function write_uboot_platform_mtd
+	# we have to provide the first device as a dedicated device path:
+	local MTD_DEFAULT_DEVICE_PATH="/dev/${MTD_ALL_DEVICE_PARTITIONS%% *}"
+	# If the first device is a char device partition, it contains a :colon:
+	# -> so we have to take the part before the colon only
+	MTD_DEFAULT_DEVICE_PATH="${MTD_DEFAULT_DEVICE_PATH%%:*}"
+	local MESSAGE="This script will update the bootloader on one or multiple of these MTD devices:\n[ $MTD_ALL_DEVICE_PARTITIONS ]\n\nIt may take up to a few minutes - Continue?"
+	dialog --title "$title" --backtitle "$backtitle" --cr-wrap --colors --yesno " \Z1$(toilet -W -f ascii9 ' WARNING')\Zn\n$MESSAGE" 19 67
 	if [[ $? -eq 0 ]]; then
-		write_uboot_platform_mtd "$DIR" $MTD_BLK
+		write_uboot_platform_mtd "$DIR" "$MTD_DEFAULT_DEVICE_PATH" "$logfile" "$MTD_ALL_DEVICE_PARTITIONS"
 		update_bootscript
 		echo 'Done'
 	fi
@@ -768,7 +790,7 @@ main()
 		dest_boot=$emmccheck'p1'
 		dest_root=$emmccheck'p1'
 	else
-		ichip='NAND'
+		ichip='legacy SUNXI NAND'
 		dest_boot='/dev/nand1'
 		dest_root='/dev/nand2'
 	fi
@@ -785,13 +807,13 @@ main()
 		[[ -n $sduuid && -n $diskcheck ]]					&& options+=(1 'Boot from SD - system on SATA, USB or NVMe')
 		[[ -n $emmccheck ]] 						&& options+=(2 "Boot from $ichip - system on $ichip")
 		[[ -n $emmccheck && -n $diskcheck ]] 				&& options+=(3 "Boot from $ichip - system on SATA, USB or NVMe")
-		[[ -n $spicheck ]] 						&& options+=(4 'Boot from SPI  - system on SATA, USB or NVMe')
+		[[ -n $mtdcheck ]] 						&& options+=(4 'Boot from MTD Flash - system on SATA, USB or NVMe')
 		[[ -n ${root_partition_device} && ${DEVICE_TYPE} != "uefi" ]]	&& options+=(5 'Install/Update the bootloader on SD/eMMC')
 		[[ ( $LINUXFAMILY == odroidxu4 || $LINUXFAMILY == mvebu* \
 		|| $LINUXFAMILY == mt7623 ) && \
 		( -b /dev/mmcblk0boot0 || -b /dev/mmcblk1boot0 ) ]]		&& options+=(6 'Install/Update the bootloader on special eMMC partition')
-		[[ -n $spicheck && \
-		$(type -t write_uboot_platform_mtd) == function ]] 		&& options+=(7 'Install/Update the bootloader on SPI Flash')
+		[[ -n $mtdcheck && \
+		$(type -t write_uboot_platform_mtd) == function ]] 		&& options+=(7 'Install/Update the bootloader on MTD Flash')
 	fi
 
 	[[ ${#options[@]} -eq 0 || "$root_uuid" == "$emmcuuid" || "$root_uuid" == "/dev/nand2" ]] && \
@@ -842,21 +864,21 @@ main()
 				;;
 			4)
 				# Espressobin has flash boot by default
-				title='SPI flash boot | USB/SATA/NVMe root install'
+				title='MTD Flash boot | USB/SATA/NVMe root install'
 				command='Power off'
 				# we need to copy boot
 				sed -i '/boot/d' $EX_LIST
 				check_partitions
 				show_warning "This script will erase your device $DISK_ROOT_PART. Continue?"
 				format_disk "$DISK_ROOT_PART"
-				create_armbian 'spi' "$DISK_ROOT_PART"
+				create_armbian 'mtd' "$DISK_ROOT_PART"
 
 				if [[ $(type -t write_uboot_platform_mtd) == function ]]; then
 					dialog --title "$title" --backtitle "$backtitle" --yesno \
-						"Do you want to write the bootloader to SPI flash?\n\nIt is required if you have not done it before or if you have some non-Armbian bootloader in SPI." 8 60
+						"Do you want to write the bootloader to MTD Flash?\n\nIt is required if you have not done it before or if you have some non-Armbian bootloader in this flash." 8 60
 
 					if [[ $? -eq 0 ]]; then
-						write_uboot_to_spi_flash $spicheck "$DIR"
+						write_uboot_to_mtd_flash "$DIR" "$mtdcheck"
 					fi
 				fi
 				;;
@@ -879,7 +901,7 @@ main()
 				return
 				;;
 			7)
-				write_uboot_to_spi_flash $spicheck "$DIR"
+				write_uboot_to_mtd_flash "$DIR" "$mtdcheck"
 				return
 				;;
 

--- a/packages/bsp/common/usr/sbin/armbian-install
+++ b/packages/bsp/common/usr/sbin/armbian-install
@@ -37,6 +37,7 @@ FIRSTSECTOR=32768
 #recognize_root
 root_uuid=$(sed -e 's/^.*root=//' -e 's/ .*$//' < /proc/cmdline)
 root_partition=$(blkid | tr -d '":' | grep "${root_uuid}" | awk '{print $1}')
+root_partition_name=$(echo $root_partition | sed 's/\/dev\///g')
 root_partition_device_name=$(lsblk -ndo pkname $root_partition)
 root_partition_device=/dev/$root_partition_device_name
 
@@ -637,7 +638,7 @@ check_partitions()
 	IFS=" "
 	[[ -n "$1" ]] && EXCLUDE=" | grep -v $1"
 	[[ -n "$2" ]] && INCLUDE=" | grep $2" && diskcheck=$2
-	CMD="lsblk -io KNAME,FSTYPE,SIZE,TYPE,MOUNTPOINT $INCLUDE $EXCLUDE | grep -E '^sd|^nvme|^md|^mmc' | awk -F\" \" '/ part | raid..? / {print \$1}'"
+	CMD="lsblk -io KNAME,FSTYPE,SIZE,TYPE,MOUNTPOINT | grep -v -w $root_partition_name $INCLUDE $EXCLUDE | grep -E '^sd|^nvme|^md|^mmc' | awk -F\" \" '/ part | raid..? / {print \$1}'"
 	AvailablePartitions=$(eval $CMD)
 	if [[ -z $AvailablePartitions ]]; then
 		FREE_SPACE=$(parted /dev/$diskcheck unit GB print free | awk '/Free Space/{c++; sum += $3; print sum}' | tail -1)
@@ -667,7 +668,7 @@ check_partitions()
 			exit 11
 		fi
 	fi
-	CMD="lsblk -io KNAME,FSTYPE,SIZE,TYPE,MOUNTPOINT $INCLUDE $EXCLUDE | grep -E '^sd|^nvme|^md|^mmc' | awk -F\" \" '/ part | raid..? / {print \$1}' | uniq | sed 's|^|/dev/|' | nl | xargs echo -n"
+	CMD="lsblk -io KNAME,FSTYPE,SIZE,TYPE,MOUNTPOINT | grep -v -w $root_partition_name $INCLUDE $EXCLUDE | grep -E '^sd|^nvme|^md|^mmc' | awk -F\" \" '/ part | raid..? / {print \$1}' | uniq | sed 's|^|/dev/|' | nl | xargs echo -n"
 	partprobe
 	AvailablePartitions=$(eval $CMD)
 	PartitionOptions=($AvailablePartitions)

--- a/packages/bsp/common/usr/sbin/armbian-install
+++ b/packages/bsp/common/usr/sbin/armbian-install
@@ -641,10 +641,29 @@ check_partitions()
 	CMD="lsblk -io KNAME,FSTYPE,SIZE,TYPE,MOUNTPOINT | grep -v -w $root_partition_name $INCLUDE $EXCLUDE | grep -E '^sd|^nvme|^md|^mmc' | awk -F\" \" '/ part | raid..? / {print \$1}'"
 	AvailablePartitions=$(eval $CMD)
 	if [[ -z $AvailablePartitions ]]; then
-		FREE_SPACE=$(parted /dev/$diskcheck unit GB print free | awk '/Free Space/{c++; sum += $3; print sum}' | tail -1)
-		dialog --yes-label "Proceed" --no-label 'Exit' --title "$title" --backtitle "$backtitle" --yesno "\nDestination $diskcheck has $FREE_SPACE Gb of available space. \n\nAutomated install will generate needed partitions!" 9 55
-		if [[ "${FREE_SPACE%.*}" -gt 4 && $? == 0 ]]; then
-			if [[ "$DEVICE_TYPE" == uefi && -z "$efi_partition" ]]; then
+		# Consider brand new devices or devices with a wiped partition table
+		if [[ -z $(blkid /dev/$diskcheck) ]]; then
+			# There is not yet any partition table on the disk device.
+			# => we have to calc the size in GB directly from the device.
+			FREE_SPACE=$(echo "scale=0; $(blockdev --getsize64 /dev/$diskcheck)/1024^3" | bc -l)
+		else
+			# The device has an initial partition table
+			FREE_SPACE=$(parted /dev/$diskcheck unit GB print free | awk '/Free Space/{c++; sum += $3; print sum}' | tail -1)
+		fi
+		# Logic for auto created partitions:
+		#  1. Check for a minimum free space of 4GB for a partition
+		#  2. Ask user to proceed with auto-created partition(s) or not
+		#  3. Distinguish between UEFI and non UEFI device
+		#  4. Create partition of full free size for a non UEFI device
+		#
+		if [[ "${FREE_SPACE%.*}" -lt 4 ]]; then
+			dialog --ok-label 'Exit' --title ' Warning ' --backtitle "$backtitle" --colors --no-collapse --msgbox "\n\Z1There is not enough free capacity on /dev/$diskcheck. Please check your device.\Zn" 7 52
+			exit 11
+		fi
+		dialog --yes-label "Proceed" --no-label 'Exit' --title "$title" --backtitle "$backtitle" --yesno "\nDestination $diskcheck has ${FREE_SPACE}GB of available space. \n\nAutomated install will generate needed partition(s)!" 9 55
+		[[ $? -ne 0 ]] && exit 11
+		if [[ "$DEVICE_TYPE" == uefi ]]; then
+			if [[ -z "$efi_partition" ]]; then
 				wipefs -aq /dev/$diskcheck
 				# create EFI partition
 				{
@@ -663,9 +682,12 @@ check_partitions()
 			# re-read
 			emmccheck=$(ls -d -1 /dev/mmcblk* 2>/dev/null | grep -w 'mmcblk[0-9]' | grep -v "$root_partition_device");
 			efi_partition=$(LC_ALL=C fdisk -l "/dev/$diskcheck" 2>/dev/null | grep "EFI" | awk '{print $1}')
-
 		else
-			exit 11
+			# Create new partition of max free size
+			{
+				echo n; echo ; echo ; echo ; echo
+				echo w
+			} | fdisk /dev/$diskcheck &> /dev/null || true
 		fi
 	fi
 	CMD="lsblk -io KNAME,FSTYPE,SIZE,TYPE,MOUNTPOINT | grep -v -w $root_partition_name $INCLUDE $EXCLUDE | grep -E '^sd|^nvme|^md|^mmc' | awk -F\" \" '/ part | raid..? / {print \$1}' | uniq | sed 's|^|/dev/|' | nl | xargs echo -n"

--- a/packages/bsp/common/usr/sbin/armbian-install
+++ b/packages/bsp/common/usr/sbin/armbian-install
@@ -46,6 +46,15 @@ emmccheck=$(ls -d -1 /dev/mmcblk* 2>/dev/null | grep -w 'mmcblk[0-9]' | grep -v 
 diskcheck=$(lsblk -l | awk -F" " '/ disk / {print $1}' | grep -E '^sd|^nvme|^mmc' | grep -v "$root_partition_device_name" | grep -v boot)
 spicheck=$(grep 'mtd' /proc/partitions | awk '{print $NF}')
 
+# SD card boot part - to be considered more than one entry on various platforms
+# UUID=xxx...
+# 1 - Lookup mmc devices excluding the mmc device probably providing the current root partition:
+sdblkid=$(blkid -o full /dev/mmcblk*p1 | grep -v "$root_partition_device")
+# 2 - If there is nothing, then lookup any mmc partition matching /dev/mmcblk*p1:
+[[ -z $sdblkid ]] && sdblkid=$(blkid -o full /dev/mmcblk*p1)
+# 3 - Extract the UUID from $sdblkid via regex:
+sduuid=$(echo "$sdblkid" | sed -nE 's/^.*[[:space:]]UUID="([0-9a-zA-Z-]*)".*/\1/p')
+
 #recognize EFI
 [[ -d /sys/firmware/efi ]] && DEVICE_TYPE="uefi"
 efi_partition=$(LC_ALL=C fdisk -l "/dev/$diskcheck" 2>/dev/null | grep "EFI" | awk '{print $1}')
@@ -91,10 +100,6 @@ create_armbian()
 	# sata root part
 	# UUID=xxx...
 	satauuid=$(blkid -o export "$2" | grep -w UUID)
-
-	# SD card boot part -- wrong since more than one entry on various platforms
-	# UUID=xxx...
-	sduuid=$(blkid -o export /dev/mmcblk*p1 | grep -w UUID | grep -v "$root_partition_device")
 
 	# write information to log
 	echo -e "\nOld UUID:  ${root_uuid}" >> $logfile
@@ -754,7 +759,7 @@ main()
 
 	else
 
-		[[ -n $diskcheck ]] 						&& options+=(1 'Boot from SD - system on SATA, USB or NVMe')
+		[[ -n $sduuid && -n $diskcheck ]]					&& options+=(1 'Boot from SD - system on SATA, USB or NVMe')
 		[[ -n $emmccheck ]] 						&& options+=(2 "Boot from $ichip - system on $ichip")
 		[[ -n $emmccheck && -n $diskcheck ]] 				&& options+=(3 "Boot from $ichip - system on SATA, USB or NVMe")
 		[[ -n $spicheck ]] 						&& options+=(4 'Boot from SPI  - system on SATA, USB or NVMe')

--- a/packages/bsp/common/usr/sbin/armbian-install
+++ b/packages/bsp/common/usr/sbin/armbian-install
@@ -37,8 +37,8 @@ FIRSTSECTOR=32768
 #recognize_root
 root_uuid=$(sed -e 's/^.*root=//' -e 's/ .*$//' < /proc/cmdline)
 root_partition=$(blkid | tr -d '":' | grep "${root_uuid}" | awk '{print $1}')
-root_partition_device=$(lsblk -ndo pkname $root_partition)
-root_partition_device_name=$(echo $root_partition_device | sed 's/\/dev\///g')
+root_partition_device_name=$(lsblk -ndo pkname $root_partition)
+root_partition_device=/dev/$root_partition_device_name
 
 # find targets: NAND, EMMC, SATA, SPI flash, NVMe
 [[ -b /dev/nand ]] && nandcheck=$(ls -d -1 /dev/nand* | grep -w 'nand' | awk '{print $NF}');


### PR DESCRIPTION
### Updates made by 21-Dec-2022: Screenshots of test runs added

# Description of changes by commit

1. **Fix variable $root_partition_device to be a device path - as it is intended to be.**
   Otherwise at least this line would fail:
https://github.com/armbian/build/blob/8cc5b2664c8e49e252e5d383b983b8601440d8e7/packages/bsp/common/usr/sbin/armbian-install#L539
   root_partition_device is all time equal to root_partition_device_name,
   since the ```lsblk``` does not list device path names rather than just the device (end-)name.
   Fixed to get e.g.:
  ```
   root_partition_device=/dev/mmcblk0
   root_partition_device_name=mmcblk0
  ```
   commit: d7cf33ae3ce9850d4b9e0f9edb4ec7595fb2220a

---

2. **Fix determination and usage of variable ```$sduuid```**
**Issue:** The last grep filter in the following line is useless, since ```blkid -o export``` provides a multiline output - one attribute per line - means that the device name is not on the same line as the UUID=... attribute.
https://github.com/armbian/build/blob/8cc5b2664c8e49e252e5d383b983b8601440d8e7/packages/bsp/common/usr/sbin/armbian-install#L97
Fixed as follows:
- a) use ```blkid -o full ...``` instead to get all attributes printed on same line
- b) lookup mmc devices excluding the mmc device probably
      providing the current root partition
- c) if there is no sduuid determined by this lookup,
       then lookup any mmc partition matching /dev/mmcblk*p1
- d) move the sduuid calculation to the script header
      to enable usage for scenario selection filtering
- e) hide installation scenario 1) selection,
      if  ```$sduuid``` is empty, since  ```$sduuid``` is essential for that scenario
  
  commit: 7e9ebe1861f6db6f30cd6fae5eff5594d6e5bdd9
---
3. **Hide current root partition device from destination selection**
- add new variable $root_partition_name
- use this variable to filter current root partition from destination selection in check_partitions()
  
  commit: e791261c65152c504aa0a0ece5af72031e2af800
---
4. **Fix behavior in case of no available partition**
- The logic in check_partitions() in case of no available
  partition is improved not to fail for a hidden reason
  and UX for fresh disk devices is improved
- Fix the calculation of $FREE_SPACE for devices without or
  with an empty partition table
- Ask the user to proceed AFTER the minimum free capacity
  required is verified
- Improve the logic for auto-creating initial partitions
  as follows:
    a) Check for a minimum free space of 4GB for a partition
    b) Ask user to proceed with auto-created partition(s) or not
    c) Distinguish between UEFI and non UEFI device
    d) Create a partition of full free size for non UEFI devices also

  commit: 6173bb24e4b0ec7b00c13ed2153ccbb7d7e4cda5
---
5. **Add support for MTD char driven flash**
- replace $spicheck by $mtdcheck
- add probable MTD char device partitions to $mtdcheck
- update comments and dialog content:
  - replace "SPI Flash" by "MTD Flash"
- replace call of "create_armbian 'spi' ..." by "create_armbian 'mtd' ..."
- update description for /dev/nand1 /dev/nand2 as "legacy SUNXI NAND"
- additional parameters passed to import function "write_uboot_platform_mtd":
   $3 - Log file name
   $4 - SPACE separated list of all MTD device partition(s)

  commit: 660e181beadb11a2176ee6c5b42147a3534b9a99
---

# How Has This Been Tested?

- [x] Tested on a Cubietruck board:
    - booted from SD card [Image build](https://github.com/MHARMBIAN/build_actions/releases/tag/v2022.12.09)
    - Select "_MTD Flash boot | USB/SATA/NVMe root install_"
    - installing to a SATA SSD without any partition table initialized
    - MTD char driven partitions mtd0-mtd3 matching SPL and U-Boot partition labels / names.
![image](https://user-images.githubusercontent.com/45703410/208778661-0831cc5b-9f46-4f1c-890c-40740e696ea9.png)
![image](https://user-images.githubusercontent.com/45703410/208773147-ecf64b8a-acb3-40b5-b707-076deb7b24ff.png)
![image](https://user-images.githubusercontent.com/45703410/208772407-883da5c8-d253-400c-aba6-9be23628b8ce.png)
![image](https://user-images.githubusercontent.com/45703410/208773337-3b577c4f-d342-4459-b571-24088eb561dd.png)
![image](https://user-images.githubusercontent.com/45703410/208773584-3a6c7a91-3cd9-46ce-9dd2-38e1e3a15382.png)
![image](https://user-images.githubusercontent.com/45703410/208774036-f5dd028a-25a8-4e79-9343-5a4f81e9613d.png)
![image](https://user-images.githubusercontent.com/45703410/208774102-db0ef193-6b33-45e7-b60e-029c8d926d12.png)
![image](https://user-images.githubusercontent.com/45703410/208774158-3b9f976e-038c-4ad8-ad42-f17f49143407.png)
![image](https://user-images.githubusercontent.com/45703410/208774331-a0c2c365-1bd0-46a9-b8be-6850f9048fcf.png)
![image](https://user-images.githubusercontent.com/45703410/208774500-d7588e86-d283-4c49-bb9b-912be0111145.png)
![image](https://user-images.githubusercontent.com/45703410/208775523-3507b8d8-3b86-4676-bf8a-a9a8e61e8b38.png)
![image](https://user-images.githubusercontent.com/45703410/208775116-c2a987ef-7911-48e4-ae6a-ead7cee84dd7.png)

TEST ended as expected!

- [x] Test for current mtdblock compatibility on a Cubietruck board - with **mtdblock** driver loaded as module:
    - The mtdblock driver will not actually be used
    - This is only to test the script and the ```write_uboot_platform_mtd()``` call signature backward compatibility
    - MTD char partitions have been filtered off by emulating that /proc/mtd would not be there
![image](https://user-images.githubusercontent.com/45703410/208783231-4ea6877c-d3f7-4592-ae87-a2b100770896.png)
![image](https://user-images.githubusercontent.com/45703410/208787301-24db5248-0904-4fff-aef0-fc8e03ef23d3.png)
![image](https://user-images.githubusercontent.com/45703410/208787720-10a81702-e663-44b7-8c32-9644acf5ac0f.png)

Would be good, if somebody else could run a test on:

- EFI board
- Board with mtdblock driven SPI flash

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [n/a] Any dependent changes have been merged and published in downstream modules
