### PR TITLE
Update u-boot patches for JetHub D1/D1+

### DIFF
--- a/patch/u-boot/v2022.07/board_jethubj100/0007-board-amlogic-jethub-j100-add-rescue-boot-from-micro.patch
+++ b/patch/u-boot/v2022.07/board_jethubj100/0007-board-amlogic-jethub-j100-add-rescue-boot-from-micro.patch
@@ -1,0 +1,27 @@
+From 21cf625cb874d3876c08bc79d092fc34c7605752 Mon Sep 17 00:00:00 2001
+From: Viacheslav Bocharov <adeep@lexina.in>
+Date: Thu, 22 Dec 2022 12:23:35 +0300
+Subject: [PATCH 1/2] board: amlogic: jethub j100: add rescue boot from microSD
+
+The new JetHub D1+ has a microSD slot. Add resque boot from microSD
+
+Signed-off-by: Viacheslav Bocharov <adeep@lexina.in>
+---
+ include/configs/jethub.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/include/configs/jethub.h b/include/configs/jethub.h
+index 35f85095ac..e22db4991d 100644
+--- a/include/configs/jethub.h
++++ b/include/configs/jethub.h
+@@ -12,6 +12,7 @@
+ #define BOOTENV_DEV_RESCUE(devtypeu, devtypel, instance) \
+ 	"bootcmd_rescue=" \
+ 		"if gpio input 10; then " \
++		"run bootcmd_mmc0; " \
+ 		"run bootcmd_usb0;" \
+ 		"fi;\0"
+ #else
+-- 
+2.34.1
+

--- a/patch/u-boot/v2022.07/board_jethubj100/0008-ARM-amlogic-revert-JetHub-D1-eth-mac-generation-with.patch
+++ b/patch/u-boot/v2022.07/board_jethubj100/0008-ARM-amlogic-revert-JetHub-D1-eth-mac-generation-with.patch
@@ -1,0 +1,54 @@
+From 5973fc7ef66d09f15d3e7dbd2194509c2ee07def Mon Sep 17 00:00:00 2001
+From: Viacheslav Bocharov <adeep@lexina.in>
+Date: Thu, 22 Dec 2022 15:10:29 +0300
+Subject: [PATCH] ARM: amlogic: revert JetHub D1 eth mac generation with
+ manufacturer OUI
+
+Partially revert add JetHub D1 eth mac generation with manufacturer OUI
+commit 4f4f974a46244270c1c6723017711c0aa8250206
+
+Signed-off-by: Viacheslav Bocharov <adeep@lexina.in>
+---
+ board/amlogic/jethub-j100/jethub-j100.c | 19 +------------------
+ 1 file changed, 1 insertion(+), 18 deletions(-)
+
+diff --git a/board/amlogic/jethub-j100/jethub-j100.c b/board/amlogic/jethub-j100/jethub-j100.c
+index 41ef5db493..0d1cb6b21d 100644
+--- a/board/amlogic/jethub-j100/jethub-j100.c
++++ b/board/amlogic/jethub-j100/jethub-j100.c
+@@ -19,8 +19,6 @@
+ int misc_init_r(void)
+ {
+ 	u8 mac_addr[ARP_HLEN];
+-	char serial[SM_SERIAL_SIZE];
+-	u32 sid;
+ 	int ret;
+ 
+ 	char _cmdbuf[96];
+@@ -78,22 +76,7 @@ int misc_init_r(void)
+ 		}
+ 	}
+ 
+-	if (mac_addr[0]==0)
+-	  if (!meson_sm_get_serial(serial, SM_SERIAL_SIZE)) {
+-		sid = crc32(0, (unsigned char *)serial, SM_SERIAL_SIZE);
+-		/* Ensure the NIC specific bytes of the mac are not all 0 */
+-		if ((sid & 0xffff) == 0)
+-			sid |= 0x800000;
+-
+-		/* OUI registered MAC address */
+-		mac_addr[0] = 0x10;
+-		mac_addr[1] = 0x27;
+-		mac_addr[2] = 0xBE;
+-		mac_addr[3] = (sid >> 16) & 0xff;
+-		mac_addr[4] = (sid >>  8) & 0xff;
+-		mac_addr[5] = (sid >>  0) & 0xff;
+-		eth_env_set_enetaddr("ethaddr", mac_addr);
+-	  }
++	meson_generate_serial_ethaddr();
+ 
+ 	return 0;
+ }
+-- 
+2.34.1
+


### PR DESCRIPTION

# Description

Update u-boot patches for JetHub D1/D1+
- add rescue boot from microSD
- revert JetHub D1 eth mac generation with manufacturer OUI

Jira reference number [AR-1448]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1448]: https://armbian.atlassian.net/browse/AR-1448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ