### PR TITLE
Suppress RX today error in MOTD if wrong NIC is detected

### DIFF
--- a/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
+++ b/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
@@ -44,7 +44,7 @@ function display() {
 	# $1=name $2=value $3=red_limit $4=minimal_show_limit $5=unit $6=after $7=acs/desc{
 	# battery red color is opposite, lower number
 	if [[ "$1" == "Battery" ]]; then local great="<"; else local great=">"; fi
-	if [[ -n "$2" && "$2" > "0" && (( "${2%.*}" -ge "$4" )) ]]; then
+	if [[ -n "$2" && "$2" -gt "0" && (( "${2%.*}" -ge "$4" )) ]]; then
 		printf "%-14s" "$1:"
 		if awk "BEGIN{exit ! ($2 $great $3)}"; then echo -ne "\e[0;91m $2"; else echo -ne "\e[0;92m $2"; fi
 		printf "%-1s\x1B[0m" "$5"

--- a/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
+++ b/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
@@ -156,7 +156,7 @@ display "Battery" "$battery_percent" "20" "1" "%" "$status_battery_text" ; a=$((
 (( $a > 0 )) && echo "" # new line only if some value is displayed
 
 line=0
-if [[ "$(command -v vnstat)" && $(vnstat --iflist | grep -c "$PRIMARY_INTERFACE") -eq 1 && $(vnstat -i $PRIMARY_INTERFACE --oneline | cut -d";" -f4,5) != *Error* ]]; then
+if vnstat -i "$PRIMARY_INTERFACE" &> /dev/null && [[ -n "$PRIMARY_INTERFACE" ]]; then
 	traffic=$(vnstat -i $PRIMARY_INTERFACE --oneline | cut -d";" -f4,5)
 	traffic_rx=$(echo $traffic | cut -d";" -f1,1 | sed -r 's/([0-9]+\.[0-9]{1})[0-9]*/\1/')
 	traffic_tx=$(echo $traffic | cut -d";" -f2,2 | sed -r 's/([0-9]+\.[0-9]{1})[0-9]*/\1/')

--- a/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
+++ b/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
@@ -156,7 +156,7 @@ display "Battery" "$battery_percent" "20" "1" "%" "$status_battery_text" ; a=$((
 (( $a > 0 )) && echo "" # new line only if some value is displayed
 
 line=0
-if [[ "$(command -v vnstat)" && $(vnstat --iflist | grep -c "$PRIMARY_INTERFACE") -eq 1 ]]; then
+if [[ "$(command -v vnstat)" && $(vnstat --iflist | grep -c "$PRIMARY_INTERFACE") -eq 1 && $(vnstat -i $PRIMARY_INTERFACE --oneline | cut -d";" -f4,5) != *Error* ]]; then
 	traffic=$(vnstat -i $PRIMARY_INTERFACE --oneline | cut -d";" -f4,5)
 	traffic_rx=$(echo $traffic | cut -d";" -f1,1 | sed -r 's/([0-9]+\.[0-9]{1})[0-9]*/\1/')
 	traffic_tx=$(echo $traffic | cut -d";" -f2,2 | sed -r 's/([0-9]+\.[0-9]{1})[0-9]*/\1/')

--- a/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
+++ b/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
@@ -156,7 +156,7 @@ display "Battery" "$battery_percent" "20" "1" "%" "$status_battery_text" ; a=$((
 (( $a > 0 )) && echo "" # new line only if some value is displayed
 
 line=0
-if vnstat -i "$PRIMARY_INTERFACE" &> /dev/null && [[ -n "$PRIMARY_INTERFACE" ]]; then
+if [[ -n "$PRIMARY_INTERFACE" ]] && vnstat -i "$PRIMARY_INTERFACE" &> /dev/null; then
 	traffic=$(vnstat -i $PRIMARY_INTERFACE --oneline | cut -d";" -f4,5)
 	traffic_rx=$(echo $traffic | cut -d";" -f1,1 | sed -r 's/([0-9]+\.[0-9]{1})[0-9]*/\1/')
 	traffic_tx=$(echo $traffic | cut -d";" -f2,2 | sed -r 's/([0-9]+\.[0-9]{1})[0-9]*/\1/')


### PR DESCRIPTION
# Description

We are using this:
PRIMARY_INTERFACE="$(ls -1 /sys/class/net/ | grep -v lo | egrep "enp|eth" | head -1)"
to detect primary interface. Sometimes it doesn't find proper one. This add additional check.

Before:
```
System load:   5%           	Up time:       11 min	Local users:   2            	
Memory usage:  14% of 982M   	IP:	       10.0.30.126
CPU temp:      35°C           	Usage of /:    11% of 28G    	
RX today:      Error: No interface matching "--oneline" found in database.
```
After:
```
System load:   5%           	Up time:       15 min	Local users:   2            	
Memory usage:  14% of 982M   	IP:	       10.0.30.126
CPU temp:      34°C           	Usage of /:    11% of 28G    	
RX today:      62.0 MiB
```
Jira reference number [AR-1450]

# How Has This Been Tested?

- [x] Manual test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1450]: https://armbian.atlassian.net/browse/AR-1450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ