### PR TITLE
Fix issues 4589

### DIFF
--- a/lib/functions/rootfs/distro-agnostic.sh
+++ b/lib/functions/rootfs/distro-agnostic.sh
@@ -299,6 +299,9 @@ PRE_INSTALL_KERNEL_DEBS
 				install_deb_chroot "${DEB_STORAGE}/${CHOSEN_KERNEL/image/dtb}_${REVISION}_${ARCH}.deb"
 			fi
 			if [[ $INSTALL_HEADERS == yes ]]; then
+				chroot "${SDCARD}" /bin/bash -c "DEBIAN_FRONTEND=noninteractive \
+					apt-get ${APT_EXTRA_DIST_PARAMS} -yqq --no-install-recommends \
+					install build-essential kmod debhelper devscripts" >> "${DEST}"/${LOG_SUBPATH}/install.log
 				install_deb_chroot "${DEB_STORAGE}/${CHOSEN_KERNEL/image/headers}_${REVISION}_${ARCH}.deb"
 			fi
 		else

--- a/packages/armbian/builddeb
+++ b/packages/armbian/builddeb
@@ -92,12 +92,6 @@ create_package() {
 		cat >> $pdir/DEBIAN/postinst <<- EOT
 			cd /usr/src/linux-headers-$version
 			echo "Compiling headers - please wait ..."
-			echo "SUBARCH=$SUBARCH" >&2
-			echo "ARCH=$ARCH"  >&2
-			echo "SRCARCH=$SRCARCH"  >&2
-			echo "UTS_MACHINE=$UTS_MACHINE" >&2
-			echo "DEB_BUILD_ARCH=$(dpkg-architecture -qDEB_BUILD_ARCH)" >&2
-			echo "DEB_HOST_ARCH=$(dpkg-architecture -qDEB_HOST_ARCH)" >&2
 			NCPU=\$(grep -c 'processor' /proc/cpuinfo)
 			find -type f -exec touch {} +
 			yes "" | make ARCH=$ARCH oldconfig >/dev/null

--- a/packages/armbian/builddeb
+++ b/packages/armbian/builddeb
@@ -92,11 +92,17 @@ create_package() {
 		cat >> $pdir/DEBIAN/postinst <<- EOT
 			cd /usr/src/linux-headers-$version
 			echo "Compiling headers - please wait ..."
+			echo "SUBARCH=$SUBARCH" >&2
+			echo "ARCH=$ARCH"  >&2
+			echo "SRCARCH=$SRCARCH"  >&2
+			echo "UTS_MACHINE=$UTS_MACHINE" >&2
+			echo "DEB_BUILD_ARCH=$(dpkg-architecture -qDEB_BUILD_ARCH)" >&2
+			echo "DEB_HOST_ARCH=$(dpkg-architecture -qDEB_HOST_ARCH)" >&2
 			NCPU=\$(grep -c 'processor' /proc/cpuinfo)
 			find -type f -exec touch {} +
-			yes "" | make oldconfig >/dev/null
-			make -j\$NCPU -s scripts >/dev/null
-			make -j\$NCPU -s M=scripts/mod/ >/dev/null
+			yes "" | make ARCH=$ARCH oldconfig >/dev/null
+			make -j\$NCPU ARCH=$ARCH -s scripts >/dev/null
+			make -j\$NCPU ARCH=$ARCH -s M=scripts/mod/ >/dev/null
 			exit 0
 		EOT
 


### PR DESCRIPTION
# Description

We need to pre-install the necessary dependencies if the INSTALL_HEADERS=yes key has been selected.
We have to pass the architecture value to the "make" command in the kernel header compilation script.

Issues reference number #4589 

# How Has This Been Tested?
This is how the log looks with the debug code enabled: For sunxi64:
```bash
Unpacking linux-headers-current-sunxi64 (23.02.0-trunk) ...
Setting up flex (2.6.4-8build2) ...
Setting up libssl-dev:arm64 (3.0.2-0ubuntu1.7) ...
Setting up bison (2:3.8.2+dfsg-1build1) ...
update-alternatives: using /usr/bin/bison.yacc to provide /usr/bin/yacc (yacc) in auto mode
Setting up linux-headers-current-sunxi64 (23.02.0-trunk) ...
Compiling headers - please wait ...
SUBARCH=
ARCH=arm64
SRCARCH=arm64
UTS_MACHINE=aarch64
DEB_BUILD_ARCH=amd64
DEB_HOST_ARCH=arm64
Processing triggers for man-db (2.10.2-1) ...
```
It is the same for sunxi.

# Checklist:
- [x] Test build image for bananapim3
- [x] Test build image for bananapim64


