### PR TITLE
fix xradio random mac address issue on linux 5.13+

### DIFF
--- a/patch/misc/wireless-xradio-5.13.patch
+++ b/patch/misc/wireless-xradio-5.13.patch
@@ -1,30 +1,37 @@
-From 3538d9844d5d122ab9294f36523a718a049d4d4e Mon Sep 17 00:00:00 2001
-From: Igor Pecovnik <igor.pecovnik@gmail.com>
-Date: Tue, 20 Jul 2021 19:32:35 +0000
-Subject: [PATCH] Adjusting xradio for 5.13.y
-
-Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
----
- drivers/net/wireless/xradio/main.c | 2 ++
- 1 file changed, 2 insertions(+)
-
 diff --git a/drivers/net/wireless/xradio/main.c b/drivers/net/wireless/xradio/main.c
-index 55377f633..a4f8c399b 100644
+index 2b76ede90..272afad2b 100644
 --- a/drivers/net/wireless/xradio/main.c
 +++ b/drivers/net/wireless/xradio/main.c
-@@ -515,10 +515,12 @@ int xradio_core_init(struct sdio_func* func)
- 	hw_priv->sdio_func = func;
- 	sdio_set_drvdata(func, hw_priv);
- 
+@@ -503,7 +503,11 @@ int xradio_core_init(struct sdio_func* func)
+ 	struct ieee80211_hw *dev;
+ 	struct xradio_common *hw_priv;
+ 	unsigned char randomaddr[ETH_ALEN];
 +#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 13, 0)
+ 	const unsigned char *addr = NULL;
++#else
++	unsigned char addr[ETH_ALEN] = {0};
++#endif
+ 
+ 	//init xradio_common
+ 	dev = xradio_init_common(sizeof(struct xradio_common));
+@@ -518,12 +522,20 @@ int xradio_core_init(struct sdio_func* func)
+ 
  	// fill in mac addresses
  	if (hw_priv->pdev->of_node) {
++#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 13, 0)
  		addr = of_get_mac_address(hw_priv->pdev->of_node);
- 	}
++#else
++		int ret = of_get_mac_address(hw_priv->pdev->of_node, addr);
 +#endif
+ 	}
  	if (!addr) {
  		dev_warn(hw_priv->pdev, "no mac address provided, using random\n");
++#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 13, 0)
  		eth_random_addr(randomaddr);
--- 
-Created with Armbian build tools https://github.com/armbian/build
-
+ 		addr = randomaddr;
++#else
++		eth_random_addr(addr);
++#endif
+ 	}
+ 	for (b = 0; b < XRWL_MAX_VIFS; b++) {				/* MRK 5.5a */
+ 		memcpy(hw_priv->addresses[b].addr, addr, ETH_ALEN);


### PR DESCRIPTION
# Description

The current xradio patch causes the wifi mac address to randomize after every reboot on kernel 5.13+
Modified it to use the updated of_get_mac_address function on kernel 5.13+ and get a stable mac address


# How Has This Been Tested?

- [X] Tested patch with 5.15.85 kernel on 3 aw-h6-tv boards 
- [X] The wifi mac address is now stable/unique and not randomized after every reboot

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
