### PR TITLE
Remove hostapd from packages list

### DIFF
--- a/config/cli/bullseye/main/config_cli_standard/packages.additional
+++ b/config/cli/bullseye/main/config_cli_standard/packages.additional
@@ -11,7 +11,6 @@ f3
 git
 haveged
 hdparm
-hostapd
 i2c-tools
 ifenslave
 iotop

--- a/config/cli/bullseye/main/config_desktop/packages.additional
+++ b/config/cli/bullseye/main/config_desktop/packages.additional
@@ -11,7 +11,6 @@ f3
 git
 haveged
 hdparm
-hostapd
 ifenslave
 iotop
 iperf3

--- a/config/cli/buster/main/config_cli_standard/packages.additional
+++ b/config/cli/buster/main/config_cli_standard/packages.additional
@@ -11,7 +11,6 @@ f3
 git
 haveged
 hdparm
-hostapd
 i2c-tools
 ifenslave
 iotop

--- a/config/cli/buster/main/config_desktop/packages.additional
+++ b/config/cli/buster/main/config_desktop/packages.additional
@@ -11,7 +11,6 @@ f3
 git
 haveged
 hdparm
-hostapd
 ifenslave
 iotop
 iperf3

--- a/config/cli/focal/main/config_cli_standard/packages.additional
+++ b/config/cli/focal/main/config_cli_standard/packages.additional
@@ -11,7 +11,6 @@ f3
 git
 haveged
 hdparm
-hostapd
 ifenslave
 iotop
 iperf3

--- a/config/cli/focal/main/config_desktop/packages.additional
+++ b/config/cli/focal/main/config_desktop/packages.additional
@@ -11,7 +11,6 @@ f3
 git
 haveged
 hdparm
-hostapd
 ifenslave
 iotop
 iperf3

--- a/config/cli/sid/main/config_cli_standard/packages.additional
+++ b/config/cli/sid/main/config_cli_standard/packages.additional
@@ -10,7 +10,6 @@ f3
 git
 haveged
 hdparm
-hostapd
 i2c-tools
 ifenslave
 iotop

--- a/config/cli/sid/main/config_desktop/packages.additional
+++ b/config/cli/sid/main/config_desktop/packages.additional
@@ -10,7 +10,6 @@ f3
 git
 haveged
 hdparm
-hostapd
 ifenslave
 iotop
 iperf3

--- a/config/sources/families/jethub.conf
+++ b/config/sources/families/jethub.conf
@@ -161,9 +161,6 @@ family_tweaks() {
 	# pip3 packages
 	chroot "${SDCARD}" /bin/bash -c "pip3 install pyserial intelhex python-magic" >> "${DEST}"/debug/install.log 2>&1
 
-	# Hostapd
-	chroot "${SDCARD}" /bin/bash -c "systemctl --no-reload disable hostapd.service >/dev/null 2>&1"
-
 	if [[ "$BOARD" == jethubj80 ]]; then
 		# Bluetooth
 		chroot "${SDCARD}" /bin/bash -c "systemctl --no-reload enable jethub-rtk-hciattach.service >/dev/null 2>&1"


### PR DESCRIPTION
# Description

This is really not needed default tool. Rely on installation from armbian-config.

Jira reference number [AR-1461]

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1461]: https://armbian.atlassian.net/browse/AR-1461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ