### PR TITLE
Fixed issue with NVMe identification in rk3399-rock-pi-4.dts

### DIFF
--- a/patch/kernel/archive/rockchip64-5.15/board-rockpi4-0003-arm64-dts-pcie.patch
+++ b/patch/kernel/archive/rockchip64-5.15/board-rockpi4-0003-arm64-dts-pcie.patch
@@ -1,8 +1,8 @@
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
-index 1ae1ebd4e..2f84397d5 100644
+index 642b6490f..b87b495fa 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
-@@ -62,6 +62,8 @@
+@@ -80,6 +80,8 @@ vcc3v3_pcie: vcc3v3-pcie-regulator {
  		regulator-name = "vcc3v3_pcie";
  		regulator-always-on;
  		regulator-boot-on;
@@ -11,25 +11,14 @@ index 1ae1ebd4e..2f84397d5 100644
  		vin-supply = <&vcc5v0_sys>;
  	};
  
-@@ -434,6 +459,21 @@
- 	gpio1830-supply = <&vcc_3v0>;
- };
- 
-+&pcie0 {
-+	ep-gpios = <&gpio4 RK_PD3 GPIO_ACTIVE_HIGH>;
-+	num-lanes = <4>;
-+	max-link-speed = <1>;
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&pcie_clkreqnb_cpm>;
+@@ -523,9 +525,9 @@ &pcie0 {
+ 	num-lanes = <4>;
+ 	pinctrl-0 = <&pcie_clkreqnb_cpm>;
+ 	pinctrl-names = "default";
+-	vpcie0v9-supply = <&vcc_0v9>;
+-	vpcie1v8-supply = <&vcc_1v8>;
 +	vpcie12v-supply = <&vcc12v_dcin>;
-+	vpcie3v3-supply = <&vcc3v3_pcie>;
-+	status = "okay";
-+};
-+
-+&pcie_phy {
-+	status = "okay";
-+};
-+
- &pmu_io_domains {
+ 	vpcie3v3-supply = <&vcc3v3_pcie>;
++	bus-scan-delay-ms = <1500>;
  	status = "okay";
- 
+ };

--- a/patch/kernel/archive/rockchip64-6.1/board-rockpi4-0003-arm64-dts-pcie.patch
+++ b/patch/kernel/archive/rockchip64-6.1/board-rockpi4-0003-arm64-dts-pcie.patch
@@ -1,8 +1,8 @@
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
-index 1ae1ebd4e..2f84397d5 100644
+index 6ec65b460e2..bd7895553d7 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
-@@ -62,6 +62,8 @@
+@@ -113,6 +113,8 @@ vcc3v3_pcie: vcc3v3-pcie-regulator {
  		regulator-name = "vcc3v3_pcie";
  		regulator-always-on;
  		regulator-boot-on;
@@ -11,25 +11,14 @@ index 1ae1ebd4e..2f84397d5 100644
  		vin-supply = <&vcc5v0_sys>;
  	};
  
-@@ -434,6 +459,21 @@
- 	gpio1830-supply = <&vcc_3v0>;
- };
- 
-+&pcie0 {
-+	ep-gpios = <&gpio4 RK_PD3 GPIO_ACTIVE_HIGH>;
-+	num-lanes = <4>;
-+	max-link-speed = <1>;
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&pcie_clkreqnb_cpm>;
+@@ -528,9 +530,11 @@ &pcie0 {
+ 	num-lanes = <4>;
+ 	pinctrl-0 = <&pcie_clkreqnb_cpm>;
+ 	pinctrl-names = "default";
 +	vpcie12v-supply = <&vcc12v_dcin>;
-+	vpcie3v3-supply = <&vcc3v3_pcie>;
-+	status = "okay";
-+};
-+
-+&pcie_phy {
-+	status = "okay";
-+};
-+
- &pmu_io_domains {
+ 	vpcie0v9-supply = <&vcc_0v9>;
+ 	vpcie1v8-supply = <&vcc_1v8>;
+ 	vpcie3v3-supply = <&vcc3v3_pcie>;
++	bus-scan-delay-ms = <1500>;
  	status = "okay";
- 
+ };


### PR DESCRIPTION
# Description
During the investigation of the issue, was found that the [rk3399-rock-pi-4.dtsi file](https://github.com/torvalds/linux/commits/v6.1/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi) had undergone significant changes, which created a mess in the code during the patch application and unstable pcie operation.
```
&pcie0 {
	ep-gpios = <&gpio4 RK_PD3 GPIO_ACTIVE_HIGH>;
	num-lanes = <4>;
	max-link-speed = <1>;
	pinctrl-names = "default";
	pinctrl-0 = <&pcie_clkreqnb_cpm>;
	vpcie12v-supply = <&vcc12v_dcin>;
	vpcie3v3-supply = <&vcc3v3_pcie>;
	status = "okay";
};

&pcie_phy {
	status = "okay";
};

&pmu_io_domains {
	status = "okay";

	pmu1830-supply = <&vcc_3v0>;
};

&pcie_phy {
	status = "okay";
};

&pcie0 {
	ep-gpios = <&gpio4 RK_PD3 GPIO_ACTIVE_HIGH>;
	num-lanes = <4>;
	pinctrl-0 = <&pcie_clkreqnb_cpm>;
	pinctrl-names = "default";
	vpcie0v9-supply = <&vcc_0v9>;
	vpcie1v8-supply = <&vcc_1v8>;
	vpcie3v3-supply = <&vcc3v3_pcie>;
	status = "okay";
};
```
The patch was put in order and tested on different builds.

# How Has This Been Tested?

[See full story of the investigation](https://forum.armbian.com/topic/24605-issue-with-emmc-nvme/#comment-156107)

The kernel 5.15.y works fine in all possible ways boot: cold boot; soft reboot, boot from eMMC when system on eMMC; etc...
There are still unstable soft-reboot on the kernel 6.1.y + overlays=pcie-gen2, but this is all better than don't booting at all. And also I think it's can depends on my current hardwere.

- [x] RockPi 4b v1.5 + remotable eMMC + NVMe KingSpec M.2 NMVe SSD NE 2280 512 GB
- [x] RockPi 4b v1.5 + remotable eMMC + NVMe KingSpec M.2 NMVe SSD NE 2280 1 TB

Work without any problem:
- [x] Armbian_23.02.0-trunk_Rockpi-4b_bullseye_current_5.15.85.img
- [x] Armbian_23.02.0-trunk_Rockpi-4b_jammy_current_5.15.85.img

Sometimes does not define Name when overlays=pcie-gen2 is enabled (only then soft reboot):
- [x] Armbian_23.02.0-trunk_Rockpi-4b_sid_edge_6.1.1.img
- [x] Armbian_23.02.0-trunk_Rockpi-4b_kinetic_edge_6.1.1.img

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
