### PR TITLE
Enable AUFS on 6.1.y

### DIFF
--- a/lib/functions/compilation/patch/kernel-bootsplash-and-drivers.sh
+++ b/lib/functions/compilation/patch/kernel-bootsplash-and-drivers.sh
@@ -172,7 +172,7 @@ compilation_prepare() {
 	#
 	# Older versions have AUFS support with a patch
 
-	if linux-version compare "${version}" gt 5.11 && linux-version compare "${version}" lt 6.1 && [ "$AUFS" == yes ]; then
+	if linux-version compare "${version}" gt 5.11 && linux-version compare "${version}" lt 6.2 && [ "$AUFS" == yes ]; then
 
 		# attach to specifics tag or branch
 		local aufstag


### PR DESCRIPTION
# Description

Re-enable AUFS.

Jira reference number [AR-1458]

# How Has This Been Tested?

- [x] Build test.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1458]: https://armbian.atlassian.net/browse/AR-1458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ