### PR TITLE
Use Fat as default bootfs type of Orange Pi 5

### DIFF
--- a/config/boards/orangepi5.wip
+++ b/config/boards/orangepi5.wip
@@ -12,7 +12,7 @@ WIREGUARD="no"
 BOOT_SUPPORT_SPI="yes"
 IMAGE_PARTITION_TABLE="gpt"
 SKIP_BOOTSPLASH="yes" # Skip boot splash patch, conflicts with CONFIG_VT=yes
-BOOTFS_TYPE="ext4"
+BOOTFS_TYPE="fat"
 
 # Override family config for this board; let's avoid conditionals in family config.
 function post_family_config__orangepi5_use_vendor_uboot() {


### PR DESCRIPTION
# Description
I was unable to boot from m2 ssd (of course with SPI NOR FLASH) when bootfs part was ext4. Then i used bootfs part as fat and it worked. I think Xunlong's Uboot source doesn't support Ext4 bootfs parts.

# How Has This Been Tested?
- [x] Tested on my Orange Pi 5

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
