### PR TITLE
load board config again to allow overwrite family config

### DIFF
--- a/config/boards/odroidc1.eos
+++ b/config/boards/odroidc1.eos
@@ -3,8 +3,23 @@ BOARD_NAME="Odroid C1"
 BOARDFAMILY="meson8b"
 KERNEL_TARGET="legacy,current,edge"
 
+BOOTDIR='u-boot-odroidc1'
+BOOTSOURCE='https://github.com/hardkernel/u-boot.git'
+BOOTBRANCH='branch:odroidc-v2011.03'
+BOOTPATCHDIR="legacy"
+UBOOT_COMPILER="arm-linux-gnueabihf-"
+UBOOT_USE_GCC='< 4.9'
 BOOTCONFIG="odroidc_config"
 BOOTSCRIPT="boot-odroid-c1.ini:boot.ini"
 
+UBOOT_TARGET_MAP=';;sd_fuse/bl1.bin.hardkernel sd_fuse/u-boot.bin'
+
 BOOTSIZE="200"
 BOOTFS_TYPE="fat"
+
+write_uboot_platform() {
+    dd if=$1/bl1.bin.hardkernel of=$2 bs=1 count=442 conv=fsync > /dev/null 2>&1
+    dd if=$1/bl1.bin.hardkernel of=$2 bs=512 skip=1 seek=1 conv=fsync > /dev/null 2>&1
+    dd if=$1/u-boot.bin of=$2 bs=512 seek=64 conv=fsync > /dev/null 2>&1
+    dd if=/dev/zero of=$2 seek=1024 count=32 bs=512 conv=fsync > /dev/null 2>&1
+}

--- a/config/boards/onecloud.csc
+++ b/config/boards/onecloud.csc
@@ -15,3 +15,7 @@ BOOTFS_TYPE="fat"
 # FIXED_IMAGE_SIZE=7456
 
 BOOT_LOGO=desktop
+
+family_tweaks() {
+    cp $SRC/packages/blobs/splash/armbian-u-boot-24.bmp $SDCARD/boot/boot.bmp
+}

--- a/config/sources/families/include/meson_common.inc
+++ b/config/sources/families/include/meson_common.inc
@@ -11,28 +11,6 @@ GOVERNOR=ondemand
 
 SKIP_BOOTSPLASH="yes"
 
-case $BOARD in
-	odroidc1)
-
-		BOOTDIR='u-boot-odroidc1'
-		BOOTSOURCE='https://github.com/hardkernel/u-boot.git'
-		BOOTBRANCH='branch:odroidc-v2011.03'
-		BOOTPATCHDIR="legacy"
-		UBOOT_COMPILER="arm-linux-gnueabihf-"
-		UBOOT_USE_GCC='< 4.9'
-
-		UBOOT_TARGET_MAP=';;sd_fuse/bl1.bin.hardkernel sd_fuse/u-boot.bin'
-
-		write_uboot_platform() {
-			dd if=$1/bl1.bin.hardkernel of=$2 bs=1 count=442 conv=fsync > /dev/null 2>&1
-			dd if=$1/bl1.bin.hardkernel of=$2 bs=512 skip=1 seek=1 conv=fsync > /dev/null 2>&1
-			dd if=$1/u-boot.bin of=$2 bs=512 seek=64 conv=fsync > /dev/null 2>&1
-			dd if=/dev/zero of=$2 seek=1024 count=32 bs=512 conv=fsync > /dev/null 2>&1
-		}
-
-		;;
-esac
-
 case $BRANCH in
 	legacy)
 
@@ -55,14 +33,6 @@ case $BRANCH in
 
 		;;
 esac
-
-family_tweaks() {
-	case $BOARD in
-		onecloud)
-			cp $SRC/packages/blobs/splash/armbian-u-boot-24.bmp $SDCARD/boot/boot.bmp
-			;;
-	esac
-}
 
 family_tweaks_bsp() {
 	mkdir -p "$destination/etc/X11/xorg.conf.d"

--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -181,6 +181,9 @@ function do_main_configuration() {
 	# load architecture defaults
 	source "${SRC}/config/sources/${ARCH}.conf"
 
+	# load board config again to allow overwrite family config
+	source "${SRC}/config/boards/${BOARD}.${BOARD_TYPE}"
+
 	if [[ "$HAS_VIDEO_OUTPUT" == "no" ]]; then
 		SKIP_BOOTSPLASH="yes"
 		PLYMOUTH="no"


### PR DESCRIPTION
# Description

The board config is only contain some variable assignments, so it should be safe to be sourced twice. If it doesn't, we can fix easily.

With this, we can overwrite the family config. So we don't need to check `BOARD` in family config ( e.g. the u-boot config ) . Just define it in board config.

# How Has This Been Tested?

[ ] Build and run test for all board

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
