### PR TITLE
Enable Orangepi 5 XFCE desktop build at CI

### DIFF
--- a/config/targets-desktop-beta.conf
+++ b/config/targets-desktop-beta.conf
@@ -2,8 +2,12 @@
 # board             branch          release     desktop|cli|minimal     stable|beta    create images  DE        DE config     Comma delimited app groups #
 ###########################################################################################################################################################
 
+# orangepi5
+orangepi5           legacy          jammy        desktop                  beta            yes           xfce          config_base   3dsupport,browsers
+
 # uefi-x86
 uefi-x86            current         jammy        desktop                  beta            yes           xfce          config_base   3dsupport,browsers
 
 # uefi-arm64
 uefi-arm64          current         jammy        desktop                  beta            yes           xfce          config_base   3dsupport,browsers
+


### PR DESCRIPTION
# Description

We expect some changes, so lets have this image ready at each rebuild.