### PR TITLE
Add CLI beta build for Orange Pi 5, fix desktop build

### DIFF
--- a/config/targets-cli-beta.conf
+++ b/config/targets-cli-beta.conf
@@ -28,7 +28,11 @@ radxa-zero2                  edge            jammy       cli                    
 
 # Radxa rock-5b
 rock-5b                      legacy          jammy       cli                      beta         yes
-rock-5b                      edge            lunar       cli                      beta         yes 
+rock-5b                      edge            lunar       cli                      beta         yes
+
+
+# Orange Pi 5
+orangepi5                    legacy          jammy       cli                      beta         yes
 
 
 # Tinkerboard 2

--- a/config/targets-desktop-beta.conf
+++ b/config/targets-desktop-beta.conf
@@ -3,7 +3,7 @@
 ###########################################################################################################################################################
 
 # orangepi5
-orangepi5           legacy          jammy        desktop                  beta            yes           xfce          config_base   3dsupport,browsers
+orangepi5           legacy          jammy        desktop                  beta            yes           xfce          config_base   browsers
 
 # uefi-x86
 uefi-x86            current         jammy        desktop                  beta            yes           xfce          config_base   3dsupport,browsers


### PR DESCRIPTION
# Description
Beta builds are not able to start X11 since `3dsupport` group is exists on images. Oibaf PPA is definitely incompatible with RK3588 boards. It's not also exists on main target config. 

- I also added beta build option for CLI. If you are not OK to that, i can remove it.

# How Has This Been Tested?
- [x] I didn't test it but i'm sure `3dsupport` breaks X11 on RK3588 boards. (I built an image that have Oibaf PPA and it wasn't also able to get X11)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
