### PR TITLE
Fix common OPi 5 HDMI issues

### DIFF
--- a/patch/kernel/rockchip-rk3588-legacy/2009-OrangePi5-HDMI-Improvements.patch
+++ b/patch/kernel/rockchip-rk3588-legacy/2009-OrangePi5-HDMI-Improvements.patch
@@ -1,0 +1,73 @@
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dts b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dts
+index 09762fd1dcc3..da2bf4d91a69 100755
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dts
+@@ -41,6 +41,16 @@ vcc_1v1_nldo_s3: vcc-1v1-nldo-s3 {
+ 		vin-supply = <&vcc5v0_sys>;
+ 	};
+ 
++	hdmi0_sound: hdmi0-sound {
++		status = "okay";
++		compatible = "rockchip,hdmi";
++		rockchip,mclk-fs = <128>;
++		rockchip,card-name = "rockchip-hdmi0";
++		rockchip,cpu = <&i2s5_8ch>;
++		rockchip,codec = <&hdmi0>;
++		rockchip,jack-det;
++	};
++
+ 	leds: gpio-leds {
+ 		compatible = "gpio-leds";
+ 		pinctrl-names = "default";
+@@ -90,16 +100,13 @@ rgmii_phy1: phy@1 {
+ &hdmi0 {
+ 	enable-gpios = <&gpio4 RK_PB6 GPIO_ACTIVE_HIGH>;
+ 	status = "okay";
++	cec-enable = "true";
+ };
+ 
+ &hdmi0_in_vp0 {
+ 	status = "okay";
+ };
+ 
+-&hdmi0_sound {
+-	status = "okay";
+-};
+-
+ &hdptxphy_hdmi0 {
+ 	status = "okay";
+ };
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi.dtsi b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi.dtsi
+index 28ad1d3660aa..a6d14beafc56 100755
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi.dtsi
+@@ -578,19 +578,29 @@ &vepu {
+ &vp0 {
+ 	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER0 | 1 << ROCKCHIP_VOP2_ESMART0)>;
+ 	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART0>;
++	cursor-win-id = <ROCKCHIP_VOP2_CLUSTER0>;
+ };
+ 
+ &vp1 {
+ 	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER1 | 1 << ROCKCHIP_VOP2_ESMART1)>;
+ 	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART1>;
++	cursor-win-id = <ROCKCHIP_VOP2_CLUSTER1>;
+ };
+ 
+ &vp2 {
+ 	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER2 | 1 << ROCKCHIP_VOP2_ESMART2)>;
+ 	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART2>;
++	cursor-win-id = <ROCKCHIP_VOP2_CLUSTER2>;
+ };
+ 
+ &vp3 {
+ 	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER3 | 1 << ROCKCHIP_VOP2_ESMART3)>;
+ 	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART3>;
++	cursor-win-id = <ROCKCHIP_VOP2_CLUSTER3>;
++};
++
++/* Fix tty terminal out of screen, and most dclk of resolutions was not supported in hdmiphy clock from parent clock by default */
++&display_subsystem {
++	clocks = <&hdptxphy_hdmi_clk0>;
++	clock-names = "hdmi0_phy_pll";
+ };


### PR DESCRIPTION
# Description
This PR includes a patch that fixes:
- HDMI sound.
- X11 cursor flickering (https://github.com/radxa/kernel/pull/50)
- Missing resolutions (https://github.com/orangepi-xunlong/linux-orangepi/commit/6947bce36393fc034389ab1eef6f18a5ea64f17d)
- HDMI-CEC feature (https://github.com/radxa/kernel/commit/d35989ed644b9d67de09849779e5147f4332df55)

# How Has This Been Tested?
- [x] I compiled kernel and tested sound, flickering.
- [x] Confirmed adding missing resolutions -> https://forum.armbian.com/topic/25600-wip-current-issues/#comment-156823
- [x] HDMI-CEC is confirmed by @catalinii. Orange Pi has CEC but i'm not able to test it.   

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
