### PR TITLE
RTL8189FS: Fix and enable secondary iface (wlan1)

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -85,6 +85,7 @@ driver_rtl8189FS()
 		sed -i '/source "drivers\/net\/wireless\/ti\/Kconfig"/a source "drivers\/net\/wireless\/rtl8189fs\/Kconfig"' \
 			"$kerneldir/drivers/net/wireless/Kconfig"
 
+		process_patch_file "${SRC}/patch/misc/wireless-rtl8189fs-fix-and-enable-secondary-iface.patch" "applying"
 	fi
 
 }

--- a/patch/misc/wireless-rtl8189fs-fix-and-enable-secondary-iface.patch
+++ b/patch/misc/wireless-rtl8189fs-fix-and-enable-secondary-iface.patch
@@ -4,13 +4,13 @@ Date: Fri, 6 Jan 2023 19:57:51 +0200
 Subject: [PATCH] Enable secondary interface (wlan1)
 
 ---
- Makefile | 1 +
+ drivers/net/wireless/rtl8189fs/Makefile | 1 +
  1 file changed, 1 insertion(+)
 
-diff --git a/Makefile b/Makefile
+diff --git a/drivers/net/wireless/rtl8189fs/Makefile b/drivers/net/wireless/rtl8189fs/Makefile
 index dfca3058..19df1972 100644
---- a/Makefile
-+++ b/Makefile
+--- a/drivers/net/wireless/rtl8189fs/Makefile
++++ b/drivers/net/wireless/rtl8189fs/Makefile
 @@ -24,6 +24,7 @@ EXTRA_CFLAGS += -I$(src)/include
  
  EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
@@ -25,13 +25,13 @@ Date: Fri, 6 Jan 2023 19:18:59 +0200
 Subject: [PATCH] Make different MAC for if1
 
 ---
- os_dep/linux/os_intfs.c | 2 +-
+ drivers/net/wireless/rtl8189fs/os_dep/linux/os_intfs.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/os_dep/linux/os_intfs.c b/os_dep/linux/os_intfs.c
+diff --git a/drivers/net/wireless/rtl8189fs/os_dep/linux/os_intfs.c b/drivers/net/wireless/rtl8189fs/os_dep/linux/os_intfs.c
 index 44bd029..509f2ab 100644
---- a/os_dep/linux/os_intfs.c
-+++ b/os_dep/linux/os_intfs.c
+--- a/drivers/net/wireless/rtl8189fs/os_dep/linux/os_intfs.c
++++ b/drivers/net/wireless/rtl8189fs/os_dep/linux/os_intfs.c
 @@ -3036,7 +3036,7 @@ _adapter *rtw_drv_add_vir_if(_adapter *primary_padapter,
  	* If it is 1, the address is locally administered
  	*/

--- a/patch/misc/wireless-rtl8189fs-fix-and-enable-secondary-iface.patch
+++ b/patch/misc/wireless-rtl8189fs-fix-and-enable-secondary-iface.patch
@@ -1,0 +1,43 @@
+From 3d022cc1754fbb172ee0026ea0d0d988fa448cc8 Mon Sep 17 00:00:00 2001
+From: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+Date: Fri, 6 Jan 2023 19:57:51 +0200
+Subject: [PATCH] Enable secondary interface (wlan1)
+
+---
+ Makefile | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Makefile b/Makefile
+index dfca3058..19df1972 100644
+--- a/Makefile
++++ b/Makefile
+@@ -24,6 +24,7 @@ EXTRA_CFLAGS += -I$(src)/include
+ 
+ EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+ EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
++EXTRA_CFLAGS += -DCONFIG_CONCURRENT_MODE
+ 
+ EXTRA_LDFLAGS += --strip-debug
+
+From f62142efac5b115d231fedcfa41ea5161f6d59c7 Mon Sep 17 00:00:00 2001
+From: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+Date: Fri, 6 Jan 2023 19:18:59 +0200
+Subject: [PATCH] Make different MAC for if1
+
+---
+ os_dep/linux/os_intfs.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/os_dep/linux/os_intfs.c b/os_dep/linux/os_intfs.c
+index 44bd029..509f2ab 100644
+--- a/os_dep/linux/os_intfs.c
++++ b/os_dep/linux/os_intfs.c
+@@ -3036,7 +3036,7 @@ _adapter *rtw_drv_add_vir_if(_adapter *primary_padapter,
+ 	* If it is 1, the address is locally administered
+ 	*/
+ 	mac[0] |= BIT(1);
+-	if (padapter->iface_id > IFACE_ID1)
++	if (padapter->iface_id >= IFACE_ID1)
+ 		mac[4] ^= BIT(padapter->iface_id);
+ 
+ 	_rtw_memcpy(adapter_mac_addr(padapter), mac, ETH_ALEN);


### PR DESCRIPTION
# Description

All RTL drivers have interesting working mode: -DCONFIG_CONCURRENT_MODE
With this mode we have two or three interfaces: wlan0, wlan1 and wlan2
This useful, when we need both STA and AP/P2P-GO on one wifi card.

But wlan1 is not working in the 8189FS driver.
We can create AP/P2P-GO on wlan1, and it is shown on any STA, but can't receive any RX packets.
At the same time, wlan2 always works fine! That is mysterious!
But after a few investigations, I found the reason: wlan0 and wlan1 have the same MAC! :)

For example:
```
wlan0 xx:xx:xx:xx:a5:8d
wlan1 xx:xx:xx:xx:a5:8d
wlan2 xx:xx:xx:xx:a1:8d
```

Originally, MAC changes only for if2 and later interfaces. This looks like a bug.
```C
if (padapter->iface_id > IFACE_ID1)
    mac[4] ^= BIT(padapter->iface_id);
```

After fix wlan1 now works fine and have different mac:
```C
wlan0 xx:xx:xx:xx:a5:8d
wlan1 xx:xx:xx:xx:a7:8d
wlan2 xx:xx:xx:xx:a1:8d
```

// Although we have the possibility to have two secondary interfaces, I did enable only one. I think that is more safe and basically enough.
// Also, in armbian already present RTL drivers with enabled secondary iface. For example, tinkerboard with RTL8723BS.

This patch contains my patches to the original driver repo:
- jwrdegoede/rtl8189ES_linux/pull/89
- jwrdegoede/rtl8189ES_linux/pull/90

# How Has This Been Tested?

I tested this with STA + P2P-GO (works similar to AP).

I have both connected to my WiFi router on wlan0
And P2P-GO group with connected phone to it.

- [x] ping from router to OPi works fine (over wlan0)
- [x] ping from phone to OPi works fine (over wlan1)

Any can test this:

1. Create **/etc/wpa_supplicant/wpa_supplicant-wlan0.conf** for STA
```
network={
	ssid="your_wifi_access_point"
	psk=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
	scan_ssid=1
}
```

2. Create **/etc/wpa_supplicant/wpa_supplicant-wlan1.conf** for P2P-GO
```
ctrl_interface=/var/run/wpa_supplicant
update_config=1
device_name=orangepilite
device_type=1-0050F204-1
config_methods=virtual_push_button
p2p_no_group_iface=1
```

2. Setup DHCP client for the wlan0: **/etc/systemd/network/wlan0.network**
```
[Match]
Name=wlan0

[Network]
DHCP=ipv4

[DHCPv4]
RouteMetric=10

[Link]
RequiredForOnline=false

#[Route]
#Gateway=192.168.1.1
#Destination=0.0.0.0/0
```

2. Setup DHCP server for the wlan1: **/etc/systemd/network/wlan1.network**
```
[Match]
Name=wlan1

[Network]
Address=10.7.7.7/24
DHCPServer=true
IPMasquerade=ipv4

[DHCPServer]
PoolOffset=100
PoolSize=20
EmitDNS=yes
DNS=1.1.1.1
```

3. Setup services
```
# We don't need NM
sudo systemctl disable NetworkManager
sudo systemctl stop NetworkManager

# For test we need systemd-networkd
sudo systemctl enable systemd-networkd
sudo systemctl start systemd-networkd

# Useless without NM
sudo systemctl stop wpa_supplicant
sudo systemctl disable wpa_supplicant

# Enable wpa_supplicant for wlan0 (STA)
sudo systemctl enable wpa_supplicant@wlan0
sudo systemctl start wpa_supplicant@wlan0

# Enable wpa_supplicant for wlan1 (P2P-GO)
sudo systemctl enable wpa_supplicant@wlan1
sudo systemctl start wpa_supplicant@wlan1
```

4. Now create P2P-GO:
```
sudo wpa_cli -i wlan1 p2p_group_add
```

5. Open on android "Wifi Direct" section in settings.
Now you can see "orangepilite" device in the list. Just click it!

6. Accept join req from your phone to P2P-GO
```
sudo wpa_cli -i wlan1 wps_pbc
```

In wpa_supplicant logs you can see something like that:
```
<3>P2P-DEVICE-FOUND xx:xx:xx:xx:xx:xx p2p_dev_addr=xx:xx:xx:xx:xx:xx pri_dev_type=10-0050F204-5 name='Android_6d7f' config_methods=0x188 dev_capab=0x25 group_capab=0x0 new=1
<3>P2P-PROV-DISC-PBC-REQ xx:xx:xx:xx:xx:xx p2p_dev_addr=xx:xx:xx:xx:xx:xx pri_dev_type=10-0050F204-5 name='Android_6d7f' config_methods=0x188 dev_capab=0x25 group_capab=0x0
```

```
<3>WPS-PBC-ACTIVE 
<3>P2P-PROV-DISC-PBC-REQ xx:xx:xx:xx:xx:xx p2p_dev_addr=xx:xx:xx:xx:xx:xx pri_dev_type=10-0050F204-5 name='Android_6d7f' config_methods=0x188 dev_capab=0x25 group_capab=0x0
<3>CTRL-EVENT-SUBNET-STATUS-UPDATE status=0
<3>CTRL-EVENT-EAP-STARTED xx:xx:xx:xx:xx:xx
<3>CTRL-EVENT-EAP-PROPOSED-METHOD vendor=0 method=1
<3>CTRL-EVENT-EAP-PROPOSED-METHOD vendor=14122 method=254
<3>WPS-REG-SUCCESS xx:xx:xx:xx:xx:xx xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
<3>WPS-PBC-DISABLE 
<3>WPS-SUCCESS 
<3>CTRL-EVENT-EAP-FAILURE xx:xx:xx:xx:xx:xx
<3>CTRL-EVENT-SUBNET-STATUS-UPDATE status=0
<3>AP-STA-CONNECTED xx:xx:xx:xx:xx:xx p2p_dev_addr=xx:xx:xx:xx:xx:xx
<3>EAPOL-4WAY-HS-COMPLETED xx:xx:xx:xx:xx:xx
```

That's a successful connection.

Now you can verify ping from phone to orangepilite (over WiFi Direct) and from router to orangepilite (over regular WiFi).

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
