### PR TITLE
i2c: mv64xxx: Atomic i2c for 5.15 kernel

### DIFF
--- a/patch/kernel/archive/sunxi-5.15/patches.armbian/i2c-mv64xxx-Add-atomic-xfer-method-to-driver.patch
+++ b/patch/kernel/archive/sunxi-5.15/patches.armbian/i2c-mv64xxx-Add-atomic-xfer-method-to-driver.patch
@@ -1,0 +1,195 @@
+From 544a8d75f3d6e60e160cd92dc56321484598a993 Mon Sep 17 00:00:00 2001
+From: Chris Morgan <macromorgan@hotmail.com>
+Date: Wed, 30 Mar 2022 12:16:57 -0500
+Subject: [PATCH] i2c: mv64xxx: Add atomic_xfer method to driver
+
+Add an atomic_xfer method to the driver so that it behaves correctly
+when controlling a PMIC that is responsible for device shutdown.
+
+The atomic_xfer method added is similar to the one from the i2c-rk3x
+driver. When running an atomic_xfer a bool flag in the driver data is
+set, the interrupt is not unmasked on transfer start, and the IRQ
+handler is manually invoked while waiting for pending transfers to
+complete.
+
+Signed-off-by: Chris Morgan <macromorgan@hotmail.com>
+Acked-by: Gregory CLEMENT <gregory.clement@bootlin.com>
+Signed-off-by: Wolfram Sang <wsa@kernel.org>
+---
+ drivers/i2c/busses/i2c-mv64xxx.c | 52 ++++++++++++++++++++++++++++----
+ 1 file changed, 46 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/i2c/busses/i2c-mv64xxx.c b/drivers/i2c/busses/i2c-mv64xxx.c
+index 424c53e4c513ff..103a05ecc3d6b0 100644
+--- a/drivers/i2c/busses/i2c-mv64xxx.c
++++ b/drivers/i2c/busses/i2c-mv64xxx.c
+@@ -150,6 +150,7 @@ struct mv64xxx_i2c_data {
+ 	/* Clk div is 2 to the power n, not 2 to the power n + 1 */
+ 	bool			clk_n_base_0;
+ 	struct i2c_bus_recovery_info	rinfo;
++	bool			atomic;
+ };
+ 
+ static struct mv64xxx_i2c_regs mv64xxx_i2c_regs_mv64xxx = {
+@@ -179,7 +180,10 @@ mv64xxx_i2c_prepare_for_io(struct mv64xxx_i2c_data *drv_data,
+ 	u32	dir = 0;
+ 
+ 	drv_data->cntl_bits = MV64XXX_I2C_REG_CONTROL_ACK |
+-		MV64XXX_I2C_REG_CONTROL_INTEN | MV64XXX_I2C_REG_CONTROL_TWSIEN;
++			      MV64XXX_I2C_REG_CONTROL_TWSIEN;
++
++	if (!drv_data->atomic)
++		drv_data->cntl_bits |= MV64XXX_I2C_REG_CONTROL_INTEN;
+ 
+ 	if (msg->flags & I2C_M_RD)
+ 		dir = 1;
+@@ -409,7 +413,8 @@ mv64xxx_i2c_do_action(struct mv64xxx_i2c_data *drv_data)
+ 	case MV64XXX_I2C_ACTION_RCV_DATA_STOP:
+ 		drv_data->msg->buf[drv_data->byte_posn++] =
+ 			readl(drv_data->reg_base + drv_data->reg_offsets.data);
+-		drv_data->cntl_bits &= ~MV64XXX_I2C_REG_CONTROL_INTEN;
++		if (!drv_data->atomic)
++			drv_data->cntl_bits &= ~MV64XXX_I2C_REG_CONTROL_INTEN;
+ 		writel(drv_data->cntl_bits | MV64XXX_I2C_REG_CONTROL_STOP,
+ 			drv_data->reg_base + drv_data->reg_offsets.control);
+ 		drv_data->block = 0;
+@@ -427,7 +432,8 @@ mv64xxx_i2c_do_action(struct mv64xxx_i2c_data *drv_data)
+ 		drv_data->rc = -EIO;
+ 		fallthrough;
+ 	case MV64XXX_I2C_ACTION_SEND_STOP:
+-		drv_data->cntl_bits &= ~MV64XXX_I2C_REG_CONTROL_INTEN;
++		if (!drv_data->atomic)
++			drv_data->cntl_bits &= ~MV64XXX_I2C_REG_CONTROL_INTEN;
+ 		writel(drv_data->cntl_bits | MV64XXX_I2C_REG_CONTROL_STOP,
+ 			drv_data->reg_base + drv_data->reg_offsets.control);
+ 		drv_data->block = 0;
+@@ -575,6 +581,17 @@ mv64xxx_i2c_wait_for_completion(struct mv64xxx_i2c_data *drv_data)
+ 		spin_unlock_irqrestore(&drv_data->lock, flags);
+ }
+ 
++static void mv64xxx_i2c_wait_polling(struct mv64xxx_i2c_data *drv_data)
++{
++	ktime_t timeout = ktime_add_ms(ktime_get(), drv_data->adapter.timeout);
++
++	while (READ_ONCE(drv_data->block) &&
++	       ktime_compare(ktime_get(), timeout) < 0) {
++		udelay(5);
++		mv64xxx_i2c_intr(0, drv_data);
++	}
++}
++
+ static int
+ mv64xxx_i2c_execute_msg(struct mv64xxx_i2c_data *drv_data, struct i2c_msg *msg,
+ 				int is_last)
+@@ -590,7 +607,11 @@ mv64xxx_i2c_execute_msg(struct mv64xxx_i2c_data *drv_data, struct i2c_msg *msg,
+ 	mv64xxx_i2c_send_start(drv_data);
+ 	spin_unlock_irqrestore(&drv_data->lock, flags);
+ 
+-	mv64xxx_i2c_wait_for_completion(drv_data);
++	if (!drv_data->atomic)
++		mv64xxx_i2c_wait_for_completion(drv_data);
++	else
++		mv64xxx_i2c_wait_polling(drv_data);
++
+ 	return drv_data->rc;
+ }
+ 
+@@ -717,7 +738,7 @@ mv64xxx_i2c_functionality(struct i2c_adapter *adap)
+ }
+ 
+ static int
+-mv64xxx_i2c_xfer(struct i2c_adapter *adap, struct i2c_msg msgs[], int num)
++mv64xxx_i2c_xfer_core(struct i2c_adapter *adap, struct i2c_msg msgs[], int num)
+ {
+ 	struct mv64xxx_i2c_data *drv_data = i2c_get_adapdata(adap);
+ 	int rc, ret = num;
+@@ -730,7 +751,7 @@ mv64xxx_i2c_xfer(struct i2c_adapter *adap, struct i2c_msg msgs[], int num)
+ 	drv_data->msgs = msgs;
+ 	drv_data->num_msgs = num;
+ 
+-	if (mv64xxx_i2c_can_offload(drv_data))
++	if (mv64xxx_i2c_can_offload(drv_data) && !drv_data->atomic)
+ 		rc = mv64xxx_i2c_offload_xfer(drv_data);
+ 	else
+ 		rc = mv64xxx_i2c_execute_msg(drv_data, &msgs[0], num == 1);
+@@ -747,8 +768,27 @@ mv64xxx_i2c_xfer(struct i2c_adapter *adap, struct i2c_msg msgs[], int num)
+ 	return ret;
+ }
+ 
++static int
++mv64xxx_i2c_xfer(struct i2c_adapter *adap, struct i2c_msg msgs[], int num)
++{
++	struct mv64xxx_i2c_data *drv_data = i2c_get_adapdata(adap);
++
++	drv_data->atomic = 0;
++	return mv64xxx_i2c_xfer_core(adap, msgs, num);
++}
++
++static int mv64xxx_i2c_xfer_atomic(struct i2c_adapter *adap,
++				   struct i2c_msg msgs[], int num)
++{
++	struct mv64xxx_i2c_data *drv_data = i2c_get_adapdata(adap);
++
++	drv_data->atomic = 1;
++	return mv64xxx_i2c_xfer_core(adap, msgs, num);
++}
++
+ static const struct i2c_algorithm mv64xxx_i2c_algo = {
+ 	.master_xfer = mv64xxx_i2c_xfer,
++	.master_xfer_atomic = mv64xxx_i2c_xfer_atomic,
+ 	.functionality = mv64xxx_i2c_functionality,
+ };
+
+From 09b343038e3470e4d0da45f0ee09fb42107e5314 Mon Sep 17 00:00:00 2001
+From: Chris Morgan <macromorgan@hotmail.com>
+Date: Fri, 25 Mar 2022 13:06:25 -0500
+Subject: [PATCH] i2c: mv64xxx: Remove shutdown method from driver
+
+When I attempt to shut down (or reboot) my R8 based NTC CHIP with this
+i2c driver I get the following error: "i2c i2c-0: mv64xxx: I2C bus
+locked, block: 1, time_left: 0". Reboots are successful but shutdowns
+freeze. If I comment out the shutdown routine the device both reboots
+and shuts down successfully without receiving this error (however it
+does receive a warning of missing atomic_xfer).
+
+It appears that very few i2c drivers have a shutdown method, I assume
+because these devices are often used to communicate with PMICs (such
+as in my case with the R8 based NTC CHIP). I'm proposing we simply
+remove this method so long as it doesn't cause trouble for others
+downstream. I'll work on an atomic_xfer method and submit that in
+a different patch.
+
+Signed-off-by: Chris Morgan <macromorgan@hotmail.com>
+Acked-by: Gregory CLEMENT <gregory.clement@bootlin.com>
+Signed-off-by: Wolfram Sang <wsa@kernel.org>
+---
+ drivers/i2c/busses/i2c-mv64xxx.c | 9 ---------
+ 1 file changed, 9 deletions(-)
+
+diff --git a/drivers/i2c/busses/i2c-mv64xxx.c b/drivers/i2c/busses/i2c-mv64xxx.c
+index 5c8e94b6cdb5a8..424c53e4c513ff 100644
+--- a/drivers/i2c/busses/i2c-mv64xxx.c
++++ b/drivers/i2c/busses/i2c-mv64xxx.c
+@@ -1047,14 +1047,6 @@ mv64xxx_i2c_remove(struct platform_device *pd)
+ 	return 0;
+ }
+ 
+-static void
+-mv64xxx_i2c_shutdown(struct platform_device *pd)
+-{
+-	pm_runtime_disable(&pd->dev);
+-	if (!pm_runtime_status_suspended(&pd->dev))
+-		mv64xxx_i2c_runtime_suspend(&pd->dev);
+-}
+-
+ static const struct dev_pm_ops mv64xxx_i2c_pm_ops = {
+ 	SET_RUNTIME_PM_OPS(mv64xxx_i2c_runtime_suspend,
+ 			   mv64xxx_i2c_runtime_resume, NULL)
+@@ -1065,7 +1057,6 @@ static const struct dev_pm_ops mv64xxx_i2c_pm_ops = {
+ static struct platform_driver mv64xxx_i2c_driver = {
+ 	.probe	= mv64xxx_i2c_probe,
+ 	.remove	= mv64xxx_i2c_remove,
+-	.shutdown = mv64xxx_i2c_shutdown,
+ 	.driver	= {
+ 		.name	= MV64XXX_I2C_CTLR_NAME,
+ 		.pm     = &mv64xxx_i2c_pm_ops,

--- a/patch/kernel/archive/sunxi-5.15/series.armbian
+++ b/patch/kernel/archive/sunxi-5.15/series.armbian
@@ -164,6 +164,7 @@
 	patches.armbian/arm64-dts-sun50i-h6-orangepi-add-cpu-opp-refs.patch
 	patches.armbian/arm64-dts-sun50i-h6-orangepi-enable-higher-clock-regulator-max-.patch
 	patches.armbian/Fix-compile-error-node-not-found.patch
+	patches.armbian/i2c-mv64xxx-Add-atomic-xfer-method-to-driver.patch
 #
 #       Old driver rtl8723cs
 #

--- a/patch/kernel/archive/sunxi-5.15/series.conf
+++ b/patch/kernel/archive/sunxi-5.15/series.conf
@@ -630,6 +630,7 @@
 	patches.armbian/arm64-dts-sun50i-h6-orangepi-add-cpu-opp-refs.patch
 	patches.armbian/arm64-dts-sun50i-h6-orangepi-enable-higher-clock-regulator-max-.patch
 	patches.armbian/Fix-compile-error-node-not-found.patch
+	patches.armbian/i2c-mv64xxx-Add-atomic-xfer-method-to-driver.patch
 
 #       The old rtl8723cs driver is enabled by default.
 #       In this case, two drivers named rtl8723cs and rtl8723cs-old


### PR DESCRIPTION
# Description

This is needed for any PMIC driver. All i2c transfers on **pm_power_off** must be atomic.

Otherwise we have something like that:
```
[ 4309.560651] reboot: Power down
[ 4309.563779] ------------[ cut here ]------------
[ 4309.568399] WARNING: CPU: 0 PID: 1 at drivers/i2c/i2c-core.h:41 i2c_smbus_xfer+0xa3/0xa8
[ 4309.576502] No atomic I2C transfer handler for 'i2c-0'
[ 4309.581637] Modules linked in: stm32f0_pmic(OE) xt_connmark nf_conntrack nf_defrag_ipv6 nf_defrag_ipv4 xt_mark nft_counter xt_comment xt_addrtype nft_compat nf_tables nfnetlink wireguard curve25519_neon libchacha20poly1305 chacha_neon poly1305_arm libcurve25519_generic ip6_udp_tunnel udp_tunnel sunrpc lz4hc lz4 8189fs cfg80211 sun4i_gpadc_iio industrialio sun8i_a33_mbus sun8i_thermal rfkill binfmt_misc cpufreq_dt evdev zram uio_pdrv_genirq uio ip_tables x_tables autofs4 spidev pwm_sun4i gpio_keys display_connector sr9700 dm9601 usbnet
[ 4309.629084] CPU: 0 PID: 1 Comm: systemd-shutdow Tainted: G           OE     5.15.86-sunxi #trunk
[ 4309.637868] Hardware name: Allwinner sun8i Family
[ 4309.642576] [<c010cd21>] (unwind_backtrace) from [<c01095fd>] (show_stack+0x11/0x14)
[ 4309.650330] [<c01095fd>] (show_stack) from [<c09e3145>] (dump_stack_lvl+0x2b/0x34)
[ 4309.657911] [<c09e3145>] (dump_stack_lvl) from [<c011c439>] (__warn+0xad/0xc0)
[ 4309.665143] [<c011c439>] (__warn) from [<c09dcdf3>] (warn_slowpath_fmt+0x5f/0x7c)
[ 4309.672632] [<c09dcdf3>] (warn_slowpath_fmt) from [<c07aae33>] (i2c_smbus_xfer+0xa3/0xa8)
[ 4309.680814] [<c07aae33>] (i2c_smbus_xfer) from [<c07ab1f3>] (i2c_smbus_write_i2c_block_data+0x4b/0x5c)
[ 4309.690123] [<c07ab1f3>] (i2c_smbus_write_i2c_block_data) from [<bfb04593>] (stm32f0_pmic_do_poweroff+0x57/0xd0 [stm32f0_pmic])
[ 4309.701628] [<bfb04593>] (stm32f0_pmic_do_poweroff [stm32f0_pmic]) from [<c0138fad>] (__do_sys_reboot+0xf5/0x16c)
[ 4309.711899] [<c0138fad>] (__do_sys_reboot) from [<c0100061>] (ret_fast_syscall+0x1/0x52)
[ 4309.719994] Exception stack(0xc1551fa8 to 0xc1551ff0)
[ 4309.725047] 1fa0:                   00000000 00000000 fee1dead 28121969 4321fedc 00000000
[ 4309.733223] 1fc0: 00000000 00000000 00000003 00000058 becb5d44 00000000 becb5a9c 4321fedc
[ 4309.741397] 1fe0: 00000058 becb59ec b6b9ea65 b6b0e616
[ 4309.746446] ---[ end trace cfd14d1670af0e52 ]---
[ 4311.614659] i2c i2c-0: mv64xxx: I2C bus locked, block: 1, time_left: 0
[ 4313.950732] i2c i2c-0: mv64xxx: I2C bus locked, block: 1, time_left: 0
[ 4316.286809] i2c i2c-0: mv64xxx: I2C bus locked, block: 1, time_left: 0
[ 4318.622887] i2c i2c-0: mv64xxx: I2C bus locked, block: 1, time_left: 0
[ 4320.958965] i2c i2c-0: mv64xxx: I2C bus locked, block: 1, time_left: 0
```

I copied this commits from mainline kernel:
- https://github.com/torvalds/linux/commit/544a8d75f3d6e60e160cd92dc56321484598a993
- https://github.com/torvalds/linux/commit/09b343038e3470e4d0da45f0ee09fb42107e5314

# How Has This Been Tested?

To see this bug just poweroff on any board with PMIC and mv64xxx i2c controller.
After this fix now works fine.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
