### PR TITLE
Add patch to support sata on Orange Pi 5

### DIFF
--- a/patch/kernel/rockchip-rk3588-legacy/2010-Add-sata-support-on-Orange-Pi-5.patch
+++ b/patch/kernel/rockchip-rk3588-legacy/2010-Add-sata-support-on-Orange-Pi-5.patch
@@ -1,0 +1,54 @@
+From fe5717078ecc8ec52d40ba56f403803bdfaff2cd Mon Sep 17 00:00:00 2001
+From: danielpinto8zz6 <danielpinto8zz6@gmail.com>
+Date: Sat, 7 Jan 2023 15:14:14 +0000
+Subject: [PATCH] Add sata support on Orange Pi 5
+
+---
+ arch/arm64/boot/dts/rockchip/overlay/Makefile |  1 +
+ .../overlay/rockchip-rk3588-opi5-sata.dts     | 21 +++++++++++++++++++
+ 2 files changed, 22 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-sata.dts
+
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts/rockchip/overlay/Makefile
+index b4a72136bdfc..5cac681ba8a5 100644
+--- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
++++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
+@@ -43,6 +43,7 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
+ 	rock-5b-radxa-display-10hd.dtbo \
+ 	rock-5b-rpi-camera-v2.dtbo \
+ 	rock-5b-sata.dtbo \
++	rockchip-rk3588-opi5-sata.dtbo \
+ 
+ dtbotxt-$(CONFIG_ARCH_ROCKCHIP) += \
+ 	README.rockchip-overlays
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-sata.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-sata.dts
+new file mode 100644
+index 000000000000..a6cbe3106e4b
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-sata.dts
+@@ -0,0 +1,21 @@
++// Orange Pi 5 Pcie M.2 to sata
++/dts-v1/;
++/plugin/;
++
++/ {
++	fragment@0 {
++		target = <&sata0>;
++
++		__overlay__ {
++			status = "okay";
++		};
++	};
++
++	fragment@1 {
++		target = <&pcie2x1l2>;
++
++		__overlay__ {
++			status = "disabled";
++		};
++	};
++};
+\ No newline at end of file
+-- 
+2.39.0
+


### PR DESCRIPTION
# Description

This allows to use ssd sata on pci in orange pi 5
Make sure you add  **overlays=opi5-sata** to **/boot/armbianEnv.txt** if you have a sata drive

# How Has This Been Tested?

Tested with local armbian build and sata m2 ssd, can list and use sata ssd

Thanks @efectn for the support