### PR TITLE
Cleanup whitespace in add-board-orangepi-r1-plus-lts uboot patch

### DIFF
--- a/patch/u-boot/u-boot-rockchip64/add-board-orangepi-r1-plus-lts.patch
+++ b/patch/u-boot/u-boot-rockchip64/add-board-orangepi-r1-plus-lts.patch
@@ -1,6 +1,6 @@
 From: schwar3kat <61094841+schwar3kat@users.noreply.github.com>
 Date: Wed, 08 Jun 2022 13:47:03 +1300
-Subject: Add u-boot support rk3328-orangepi-r1-plus
+Subject: [PATCH] Add u-boot support rk3328-orangepi-r1-plus-lts
 
 Signed-off-by: schwar3kat <61094841+schwar3kat@users.noreply.github.com>
 ---
@@ -751,7 +751,7 @@ index ed197fa4..6a14eada 100644
 @@ -648,6 +648,8 @@ static struct phy_driver *generic_for_phy(struct phy_device *phydev)
  	return &genphy_driver;
  }
- 
+
 +#define YT_8531C_PHY_ID 0x4f51e91b
 +
  static struct phy_driver *get_phy_driver(struct phy_device *phydev)
@@ -760,14 +760,11 @@ index ed197fa4..6a14eada 100644
 @@ -646,6 +651,10 @@ static struct phy_driver *get_phy_driver(struct phy_device *phydev,
  	int phy_id = phydev->phy_id;
  	struct phy_driver *drv = NULL;
- 
-+	if(phy_id == YT_8531C_PHY_ID)
+
++	if (phy_id == YT_8531C_PHY_ID)
 +		env_set("ethernet_phy", "yt8531c");
 +	else
 +		env_set("ethernet_phy", "rtl8211f");
  	list_for_each(entry, &phy_drivers) {
  		drv = list_entry(entry, struct phy_driver, list);
  		if ((drv->uid & drv->mask) == (phy_id & drv->mask))
-
-
-


### PR DESCRIPTION
Fix description.
Remove trailing spaces and extra line feed to improve parser compatibility. No functional changes.  Add space before bracket in code.

Jira reference number [AR-1480]

- [x] bullseye tested on orangepi-r1-plus-lts


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1480]: https://armbian.atlassian.net/browse/AR-1480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ