### PR TITLE
`mvebu`: 6.1: fix mbox formatting for `12-net-dsa-mv88e6xxx.patch`

### DIFF
--- a/patch/kernel/archive/mvebu-6.1/12-net-dsa-mv88e6xxx.patch
+++ b/patch/kernel/archive/mvebu-6.1/12-net-dsa-mv88e6xxx.patch
@@ -1206,7 +1206,8 @@ index 931e769fe9ce..4005a4760884 100644
  static ssize_t mv88e6xxx_pvt_write(struct file *file, const char __user *buf,
 -- 
 cgit 
-FFrom e693b19d96a9c0a21dc767676594e99645a565ff Mon Sep 17 00:00:00 2001
+
+From e693b19d96a9c0a21dc767676594e99645a565ff Mon Sep 17 00:00:00 2001
 From: Russell King <rmk+kernel@armlinux.org.uk>
 Date: Thu, 28 Sep 2017 12:09:56 +0100
 Subject: Revert "net: dsa: mv88e6xxx: remove LED control register"


### PR DESCRIPTION
#### `mvebu`: 6.1: fix mbox formatting for `12-net-dsa-mv88e6xxx.patch`

- `FFrom `... -> `\nFrom ` makes it mbox-valid again
- detected by armbian-next's Python patching which now matches mbox-to-magic-markers count

@Heisath before I forget about this