### PR TITLE
`uefi-arm64`: 6.1: working Phytium D2000 onboard Ethernet

### DIFF
--- a/patch/kernel/archive/uefi-arm64-6.1/driver-phytium-stmmac-acpi.patch
+++ b/patch/kernel/archive/uefi-arm64-6.1/driver-phytium-stmmac-acpi.patch
@@ -1,15 +1,59 @@
-From a0736ce7e610e35c62164da29e97d935ff79a8a0 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ricardo Pardini <ricardo@pardini.net>
-Date: Sun, 10 Jul 2022 20:45:09 +0200
-Subject: [PATCH] Add PHYT0004 via ACPI support to stmmac
+Date: Thu, 4 Aug 2022 21:49:10 +0200
+Subject: Phytium onboard ethernet drivers for 6.x
 
+ My board has two eths; only eth1 has an actual PHY and works.
+ From https://gitee.com/atzlinux/atzlinux-kernel/tree/master/debian/patch
+ rpardini hammered:
+ - small api change in upstream around 5.19
+ - Remove Kconfig deps from Feiteng stuff not in mainline
+ - Default Kconfig to module
+ Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
 ---
- .../ethernet/stmicro/stmmac/dwmac-generic.c   |  19 ++
- .../net/ethernet/stmicro/stmmac/stmmac_main.c |   1 +
- .../ethernet/stmicro/stmmac/stmmac_platform.c | 254 +++++++++++++++++-
- .../ethernet/stmicro/stmmac/stmmac_platform.h |   2 +
- 4 files changed, 275 insertions(+), 1 deletion(-)
+ drivers/net/ethernet/stmicro/stmmac/Kconfig           |  10 +
+ drivers/net/ethernet/stmicro/stmmac/Makefile          |   1 +
+ drivers/net/ethernet/stmicro/stmmac/dwmac-generic.c   |  19 +
+ drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c   | 222 ++++++++
+ drivers/net/ethernet/stmicro/stmmac/stmmac_main.c     |   1 +
+ drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c | 254 +++++++++-
+ drivers/net/ethernet/stmicro/stmmac/stmmac_platform.h |   2 +
+ drivers/net/phy/at803x.c                              |  23 +
+ 8 files changed, 531 insertions(+), 1 deletion(-)
 
+diff --git a/drivers/net/ethernet/stmicro/stmmac/Kconfig b/drivers/net/ethernet/stmicro/stmmac/Kconfig
+index 31ff35174034..716d44ab9eae 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/Kconfig
++++ b/drivers/net/ethernet/stmicro/stmmac/Kconfig
+@@ -132,6 +132,16 @@ config DWMAC_OXNAS
+ 	  This selects the Oxford Semiconductor OXNASSoC glue layer support for
+ 	  the stmmac device driver. This driver is used for OX820.
+ 
++config DWMAC_PHYTIUM
++	tristate "Phytium DWMAC support"
++	default m
++	depends on ACPI
++	help
++	  Support for Ethernet controllers on Phytium SoCs.
++
++	  This selects the Phytium DWMAC glue layer support for the stmmac
++	  device driver.
++
+ config DWMAC_QCOM_ETHQOS
+ 	tristate "Qualcomm ETHQOS support"
+ 	default ARCH_QCOM
+diff --git a/drivers/net/ethernet/stmicro/stmmac/Makefile b/drivers/net/ethernet/stmicro/stmmac/Makefile
+index d4e12e9ace4f..8bd9efb5c517 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/Makefile
++++ b/drivers/net/ethernet/stmicro/stmmac/Makefile
+@@ -20,6 +20,7 @@ obj-$(CONFIG_DWMAC_LPC18XX)	+= dwmac-lpc18xx.o
+ obj-$(CONFIG_DWMAC_MEDIATEK)	+= dwmac-mediatek.o
+ obj-$(CONFIG_DWMAC_MESON)	+= dwmac-meson.o dwmac-meson8b.o
+ obj-$(CONFIG_DWMAC_OXNAS)	+= dwmac-oxnas.o
++obj-$(CONFIG_DWMAC_PHYTIUM)	+= dwmac-phytium.o
+ obj-$(CONFIG_DWMAC_QCOM_ETHQOS)	+= dwmac-qcom-ethqos.o
+ obj-$(CONFIG_DWMAC_ROCKCHIP)	+= dwmac-rk.o
+ obj-$(CONFIG_DWMAC_SOCFPGA)	+= dwmac-altr-socfpga.o
 diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-generic.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-generic.c
 index 5e731a72cce8..66a090d62579 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/dwmac-generic.c
@@ -17,7 +61,7 @@ index 5e731a72cce8..66a090d62579 100644
 @@ -9,6 +9,7 @@
   * warranty of any kind, whether express or implied.
   */
-
+ 
 +#include <linux/acpi.h>
  #include <linux/module.h>
  #include <linux/of.h>
@@ -38,7 +82,7 @@ index 5e731a72cce8..66a090d62579 100644
 @@ -85,6 +92,17 @@ static const struct of_device_id dwmac_generic_match[] = {
  };
  MODULE_DEVICE_TABLE(of, dwmac_generic_match);
-
+ 
 +#ifdef CONFIG_ACPI
 +static const struct acpi_device_id dwmac_acpi_ids[] = {
 +	{ .id = "PHYT0004" },
@@ -61,36 +105,264 @@ index 5e731a72cce8..66a090d62579 100644
  	},
  };
  module_platform_driver(dwmac_generic_driver);
+diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
+new file mode 100644
+index 000000000000..9c0b79f11f94
+--- /dev/null
++++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
+@@ -0,0 +1,222 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ * Phytium DWMAC platform glue driver
++ *
++ * Copyright (C) 2022 Icenowy Zheng <uwu@icenowy.me>
++ */
++
++#include <linux/acpi.h>
++#include <linux/clk-provider.h>
++#include <linux/clkdev.h>
++#include <linux/module.h>
++#include <linux/platform_device.h>
++
++#include "stmmac.h"
++#include "stmmac_platform.h"
++
++/**
++ * Acquire Phytium DWMAC resources from ACPI
++ */
++int dwmac_phytium_get_resources(struct platform_device *pdev,
++				struct stmmac_resources *stmmac_res)
++{
++	memset(stmmac_res, 0, sizeof(*stmmac_res));
++
++	stmmac_res->irq = platform_get_irq(pdev, 0);
++	if (stmmac_res->irq < 0)
++		return stmmac_res->irq;
++
++	stmmac_res->addr = devm_platform_ioremap_resource(pdev, 0);
++	stmmac_res->wol_irq = stmmac_res->irq;
++	stmmac_res->lpi_irq = -ENOENT;
++
++	return PTR_ERR_OR_ZERO(stmmac_res->addr);
++}
++
++/**
++ * Parse Phytium ACPI properties
++ */
++static struct plat_stmmacenet_data *
++dwmac_phytium_parse_config_acpi(struct platform_device *pdev, const char *mac)
++{
++	struct device *dev = &pdev->dev;
++	struct fwnode_handle *np;
++	struct plat_stmmacenet_data *plat;
++	struct stmmac_dma_cfg *dma_cfg;
++	struct stmmac_axi *axi;
++	struct clk_hw *clk_hw;
++	u64 clk_freq;
++	int ret;
++
++	plat = devm_kzalloc(dev, sizeof(*plat), GFP_KERNEL);
++	if (!plat)
++		return ERR_PTR(-ENOMEM);
++
++	np = dev_fwnode(dev);
++
++	plat->phy_interface = fwnode_get_phy_mode(np);
++	plat->interface = plat->phy_interface;
++
++	/* Get max speed of operation from properties */
++	if (fwnode_property_read_u32(np, "max-speed", &plat->max_speed))
++		plat->max_speed = 1000;
++
++	if (fwnode_property_read_u32(np, "bus_id", &plat->bus_id))
++		plat->bus_id = 2;
++
++	/* Default to PHY auto-detection */
++	plat->phy_addr = -1;
++
++	plat->mdio_bus_data = devm_kzalloc(dev,
++					   sizeof(struct stmmac_mdio_bus_data),
++					   GFP_KERNEL);
++
++	fwnode_property_read_u32(np, "tx-fifo-depth", &plat->tx_fifo_size);
++	fwnode_property_read_u32(np, "rx-fifo-depth", &plat->rx_fifo_size);
++	if (plat->tx_fifo_size == 0)
++		plat->tx_fifo_size = 0x10000;
++	if (plat->rx_fifo_size == 0)
++		plat->rx_fifo_size = 0x10000;
++
++	plat->force_sf_dma_mode =
++		fwnode_property_read_bool(np, "snps,force_sf_dma_mode");
++	plat->en_tx_lpi_clockgating =
++		fwnode_property_read_bool(np, "snps,en-tx-lpi-clockgating");
++
++	/* Set the maxmtu to a default of JUMBO_LEN in case the
++	 * parameter is not present.
++	 */
++	plat->maxmtu = JUMBO_LEN;
++
++	/* Set default value for multicast hash bins */
++	plat->multicast_filter_bins = HASH_TABLE_SIZE;
++
++	/* Set default value for unicast filter entries */
++	plat->unicast_filter_entries = 1;
++
++	fwnode_property_read_u32(np, "max-frame-size", &plat->maxmtu);
++	plat->has_gmac = 1;
++	plat->pmt = 1;
++
++	dma_cfg = devm_kzalloc(dev, sizeof(*dma_cfg), GFP_KERNEL);
++	if (!dma_cfg)
++		return ERR_PTR(-ENOMEM);
++	plat->dma_cfg = dma_cfg;
++
++	fwnode_property_read_u32(np, "snps,pbl", &dma_cfg->pbl);
++	if (!dma_cfg->pbl)
++		dma_cfg->pbl = DEFAULT_DMA_PBL;
++
++	fwnode_property_read_u32(np, "snps,txpbl", &dma_cfg->txpbl);
++	fwnode_property_read_u32(np, "snps,rxpbl", &dma_cfg->rxpbl);
++	dma_cfg->pblx8 = !fwnode_property_read_bool(np, "snps,no-pbl-x8");
++
++	dma_cfg->aal = fwnode_property_read_bool(np, "snps,aal");
++	dma_cfg->fixed_burst = fwnode_property_read_bool(np, "snps,fixed-burst");
++	dma_cfg->mixed_burst = fwnode_property_read_bool(np, "snps,mixed-burst");
++
++	plat->force_thresh_dma_mode = fwnode_property_read_bool(np, "snps,force_thresh_dma_mode");
++	if (plat->force_thresh_dma_mode)
++		plat->force_sf_dma_mode = 0;
++
++	fwnode_property_read_u32(np, "snps,ps-speed", &plat->mac_port_sel_speed);
++
++	axi = devm_kzalloc(&pdev->dev, sizeof(*axi), GFP_KERNEL);
++	if (!axi)
++		return ERR_PTR(-ENOMEM);
++	plat->axi = axi;
++
++	axi->axi_wr_osr_lmt = 1;
++	axi->axi_rd_osr_lmt = 1;
++
++	plat->rx_queues_to_use = 1;
++	plat->tx_queues_to_use = 1;
++
++	/**
++	 * First Queue must always be in DCB mode. As MTL_QUEUE_DCB=1 we need
++	 * to always set this, otherwise Queue will be classified as AVB
++	 * (because MTL_QUEUE_AVB = 0).
++	 */
++	plat->rx_queues_cfg[0].mode_to_use = MTL_QUEUE_DCB;
++	plat->tx_queues_cfg[0].mode_to_use = MTL_QUEUE_DCB;
++
++	plat->rx_queues_cfg[0].use_prio = true;
++
++	plat->rx_queues_cfg[0].pkt_route = 0x0;
++
++	plat->rx_sched_algorithm = MTL_RX_ALGORITHM_SP;
++	plat->tx_sched_algorithm = MTL_TX_ALGORITHM_SP;
++
++	ret = fwnode_property_read_u64(np, "clock-frequency", &clk_freq);
++	if (ret < 0)
++		clk_freq = 125000000; /* default to 125MHz */
++
++	clk_hw = clk_hw_register_fixed_rate(dev, dev_name(dev), NULL,
++					    0, clk_freq);
++	if (IS_ERR(clk_hw))
++		return ERR_PTR(PTR_ERR(clk_hw));
++	ret = devm_clk_hw_register_clkdev(dev, clk_hw, dev_name(dev),
++					  dev_name(dev));
++	if (ret)
++		return ERR_PTR(ret);
++	plat->stmmac_clk = clk_hw->clk;
++	clk_prepare_enable(plat->stmmac_clk);
++
++	return plat;
++}
++
++static int dwmac_phytium_probe(struct platform_device *pdev)
++{
++	struct plat_stmmacenet_data *plat_dat;
++	struct stmmac_resources stmmac_res;
++	int ret;
++
++	ret = dwmac_phytium_get_resources(pdev, &stmmac_res);
++	if (ret)
++		return ret;
++
++	if (has_acpi_companion(&pdev->dev)) {
++		plat_dat = dwmac_phytium_parse_config_acpi(pdev, stmmac_res.mac);
++		if (IS_ERR(plat_dat)) {
++			dev_err(&pdev->dev, "ACPI configuration failed\n");
++			return PTR_ERR(plat_dat);
++		}
++	} else {
++		dev_err(&pdev->dev, "no ACPI properties\n");
++		return -EINVAL;
++	}
++
++	ret = stmmac_dvr_probe(&pdev->dev, plat_dat, &stmmac_res);
++	if (ret)
++		goto err_exit;
++
++	return 0;
++
++err_exit:
++	if (plat_dat->exit)
++		plat_dat->exit(pdev, plat_dat->bsp_priv);
++
++	return ret;
++}
++
++static const struct acpi_device_id dwmac_phytium_acpi_match[] = {
++	{
++		.id = "PHYT0004",
++	},
++	{}
++};
++MODULE_DEVICE_TABLE(acpi, dwmac_phytium_acpi_match);
++
++static struct platform_driver dwmac_phytium_driver = {
++	.probe  = dwmac_phytium_probe,
++	.remove = stmmac_pltfr_remove,
++	.driver = {
++		.name           = "dwmac-phytium",
++		.pm		= &stmmac_pltfr_pm_ops,
++		.acpi_match_table = ACPI_PTR(dwmac_phytium_acpi_match),
++	},
++};
++module_platform_driver(dwmac_phytium_driver);
++
++MODULE_DESCRIPTION("Glue driver for Phytium DWMAC");
++MODULE_LICENSE("GPL v2");
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index d1a7cf4567bc..f412d397e47f 100644
+index feb209d4b991..00159a867e77 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 @@ -14,6 +14,7 @@
  	https://bugzilla.stlinux.com/
  *******************************************************************************/
-
+ 
 +#include <linux/acpi.h>
  #include <linux/clk.h>
  #include <linux/kernel.h>
  #include <linux/interrupt.h>
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
-index 11e1055e8260..9464a59762f9 100644
+index eb6d9cd8e93f..63505bdb00eb 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 @@ -8,6 +8,9 @@
    Author: Giuseppe Cavallaro <peppe.cavallaro@st.com>
  *******************************************************************************/
-
+ 
 +#include <linux/acpi.h>
 +#include <linux/clk-provider.h>
 +#include <linux/clkdev.h>
  #include <linux/platform_device.h>
  #include <linux/pm_runtime.h>
  #include <linux/module.h>
-@@ -657,6 +660,248 @@ void stmmac_remove_config_dt(struct platform_device *pdev,
+@@ -658,6 +661,248 @@ void stmmac_remove_config_dt(struct platform_device *pdev,
  EXPORT_SYMBOL_GPL(stmmac_probe_config_dt);
  EXPORT_SYMBOL_GPL(stmmac_remove_config_dt);
-
+ 
 +#ifdef CONFIG_ACPI
 +/*
 + * Parse ACPI _DSD to setup AXI register
@@ -336,8 +608,8 @@ index 11e1055e8260..9464a59762f9 100644
  int stmmac_get_platform_resources(struct platform_device *pdev,
  				  struct stmmac_resources *stmmac_res)
  {
-@@ -664,8 +909,14 @@ int stmmac_get_platform_resources(struct platform_device *pdev,
-
+@@ -665,8 +910,14 @@ int stmmac_get_platform_resources(struct platform_device *pdev,
+ 
  	/* Get IRQ information early to have an ability to ask for deferred
  	 * probe if needed before we went too far with resource allocation.
 +     * For ACPI _byname does not work, so we have to trust, that the
@@ -351,28 +623,76 @@ index 11e1055e8260..9464a59762f9 100644
 +    }
  	if (stmmac_res->irq < 0)
  		return stmmac_res->irq;
-
-@@ -683,6 +934,7 @@ int stmmac_get_platform_resources(struct platform_device *pdev,
+ 
+@@ -684,6 +935,7 @@ int stmmac_get_platform_resources(struct platform_device *pdev,
  			return -EPROBE_DEFER;
  		dev_info(&pdev->dev, "IRQ eth_wake_irq not found\n");
  		stmmac_res->wol_irq = stmmac_res->irq;
 +		stmmac_res->lpi_irq = -1;
  	}
-
+ 
  	stmmac_res->lpi_irq =
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.h b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.h
 index 3fff3f59d73d..4ac60c3a4722 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.h
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.h
 @@ -13,6 +13,8 @@
-
+ 
  struct plat_stmmacenet_data *
  stmmac_probe_config_dt(struct platform_device *pdev, u8 *mac);
 +struct plat_stmmacenet_data *
 +stmmac_probe_config_acpi(struct platform_device *pdev, u8 *mac);
  void stmmac_remove_config_dt(struct platform_device *pdev,
  			     struct plat_stmmacenet_data *plat);
-
---
-2.37.0
+ 
+diff --git a/drivers/net/phy/at803x.c b/drivers/net/phy/at803x.c
+index d49965907561..9d58072b9cb4 100644
+--- a/drivers/net/phy/at803x.c
++++ b/drivers/net/phy/at803x.c
+@@ -112,6 +112,11 @@
+ #define AT803X_DEBUG_SYSTEM_CTRL_MODE		0x05
+ #define AT803X_DEBUG_TX_CLK_DLY_EN		BIT(8)
+ 
++#define AT803X_DEBUG_REG_B                      0x0B
++#define AT803X_DEBUG_REG_B_HIBERNATION_ENABLE	0x1
++#define AT803X_DEBUG_REG_B_HIBERNATION_OFFSET	15
++
++
+ #define AT803X_DEBUG_REG_HIB_CTRL		0x0b
+ #define   AT803X_DEBUG_HIB_CTRL_SEL_RST_80U	BIT(10)
+ #define   AT803X_DEBUG_HIB_CTRL_EN_ANY_CHANGE	BIT(13)
+@@ -392,6 +397,20 @@ static int at803x_enable_rx_delay(struct phy_device *phydev)
+ 				     AT803X_DEBUG_RX_CLK_DLY_EN);
+ }
+ 
++static inline int at803x_disable_hibernate(struct phy_device *phydev)
++{
++	int ret = 0;
++	u16 val = 0;
++
++	ret = at803x_debug_reg_read(phydev, AT803X_DEBUG_REG_B);
++	if (ret < 0)
++		return ret;
++
++	val = ret & 0xffff;
++	val &= (~(AT803X_DEBUG_REG_B_HIBERNATION_ENABLE << AT803X_DEBUG_REG_B_HIBERNATION_OFFSET));
++	return phy_write(phydev, AT803X_DEBUG_DATA, val);
++}
++
+ static int at803x_enable_tx_delay(struct phy_device *phydev)
+ {
+ 	return at803x_debug_reg_mask(phydev, AT803X_DEBUG_SYSTEM_CTRL_MODE, 0,
+@@ -1058,6 +1077,10 @@ static int at803x_config_init(struct phy_device *phydev)
+ 		ret = at803x_disable_rx_delay(phydev);
+ 	if (ret < 0)
+ 		return ret;
++	else
++		ret = at803x_disable_hibernate(phydev);
++	if (ret < 0)
++		return ret;
+ 
+ 	if (phydev->interface == PHY_INTERFACE_MODE_RGMII_ID ||
+ 	    phydev->interface == PHY_INTERFACE_MODE_RGMII_TXID)
+-- 
+Armbian
 


### PR DESCRIPTION
#### `uefi-arm64`: 6.1: working Phytium D2000 onboard Ethernet
- ACPI stmmac glue, PHY hack
- there are 2 gmacs, but only eth1 has an actual PHY 
- original https://gitee.com/atzlinux/atzlinux-kernel/tree/master/debian/patch
- adapted to default to =m, not require Feiteng kernel reqs, and small api change around 5.19.y (done before)
- squash and rename patch to reflect what it is
- remove numbering, let's not do numbered patches in UEFI families?
