### PR TITLE
meson64: 6.1.y/edge: docs: fix zero2's patch after bpim2s's addition

### DIFF
--- a/patch/kernel/archive/meson64-6.1/add-board-radxa-zero2.patch
+++ b/patch/kernel/archive/meson64-6.1/add-board-radxa-zero2.patch
@@ -13,13 +13,13 @@ Signed-off-by: Yuntian Zhang <yt@radxa.com>
  1 file changed, 1 insertion(+)
 
 diff --git a/Documentation/devicetree/bindings/arm/amlogic.yaml b/Documentation/devicetree/bindings/arm/amlogic.yaml
-index 9fda2436c618..cf81dc06df2e 100644
+index bbd5f6197e4d..6edb1b771cdc 100644
 --- a/Documentation/devicetree/bindings/arm/amlogic.yaml
 +++ b/Documentation/devicetree/bindings/arm/amlogic.yaml
-@@ -154,6 +154,7 @@ properties:
-         items:
+@@ -155,6 +155,7 @@ properties:
            - enum:
                - khadas,vim3
+               - bananapi,m2s
 +              - radxa,zero2
            - const: amlogic,a311d
            - const: amlogic,g12b
@@ -54,10 +54,10 @@ Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
  2 files changed, 577 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/amlogic/Makefile b/arch/arm64/boot/dts/amlogic/Makefile
-index e213aeebb774..4aa1aa0e22a8 100644
+index 858ae834cc9f..9e2ad0b42523 100644
 --- a/arch/arm64/boot/dts/amlogic/Makefile
 +++ b/arch/arm64/boot/dts/amlogic/Makefile
-@@ -14,6 +14,7 @@ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-gtking-pro.dtb
+@@ -15,6 +15,7 @@ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-gtking-pro.dtb
  dtb-$(CONFIG_ARCH_MESON) += meson-g12b-gtking.dtb
  dtb-$(CONFIG_ARCH_MESON) += meson-g12b-odroid-n2-plus.dtb
  dtb-$(CONFIG_ARCH_MESON) += meson-g12b-odroid-n2.dtb


### PR DESCRIPTION
#### meson64: 6.1.y/edge: docs: fix zero2's patch after bpim2s's addition
