### PR TITLE
meson64: 6.1.y/edge: rebase patches against v6.1.4 (no actual changes)

### DIFF
--- a/patch/kernel/archive/meson64-6.1/add-board-bananapi-m2s-initial-support.patch
+++ b/patch/kernel/archive/meson64-6.1/add-board-bananapi-m2s-initial-support.patch
@@ -1,14 +1,14 @@
-From b4913474d6eb819211249ea92699a619693ad47f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jean Rhum <jeanrhum@gmail.com>
 Date: Wed, 21 Dec 2022 17:56:18 +0100
-Subject: [PATCH] Initial support for Bananapi M2S
+Subject: Initial support for Bananapi M2S
 
+Initial support for Bananapi M2S
 ---
- .../devicetree/bindings/arm/amlogic.yaml      |   1 +
- arch/arm64/boot/dts/amlogic/Makefile          |   1 +
- .../amlogic/meson-g12b-a311d-bananapi-m2s.dts | 593 ++++++++++++++++++
+ Documentation/devicetree/bindings/arm/amlogic.yaml            |   1 +
+ arch/arm64/boot/dts/amlogic/Makefile                          |   1 +
+ arch/arm64/boot/dts/amlogic/meson-g12b-a311d-bananapi-m2s.dts | 593 ++++++++++
  3 files changed, 595 insertions(+)
- create mode 100644 arch/arm64/boot/dts/amlogic/meson-g12b-a311d-bananapi-m2s.dts
 
 diff --git a/Documentation/devicetree/bindings/arm/amlogic.yaml b/Documentation/devicetree/bindings/arm/amlogic.yaml
 index 9fda2436c618..bbd5f6197e4d 100644
@@ -634,5 +634,5 @@ index 000000000000..65f11dde0a7a
 +};
 +
 -- 
-2.34.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.1/board-odroidn2-add-spi-flash-enabled-dts.patch
+++ b/patch/kernel/archive/meson64-6.1/board-odroidn2-add-spi-flash-enabled-dts.patch
@@ -14,10 +14,10 @@ Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
  4 files changed, 37 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/amlogic/Makefile b/arch/arm64/boot/dts/amlogic/Makefile
-index 4aa1aa0e22a8..a3be04fd53d3 100644
+index 9e2ad0b42523..10205ee7627a 100644
 --- a/arch/arm64/boot/dts/amlogic/Makefile
 +++ b/arch/arm64/boot/dts/amlogic/Makefile
-@@ -12,7 +12,9 @@ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-a311d-khadas-vim3.dtb
+@@ -13,7 +13,9 @@ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-a311d-bananapi-m2s.dtb
  dtb-$(CONFIG_ARCH_MESON) += meson-g12b-gsking-x.dtb
  dtb-$(CONFIG_ARCH_MESON) += meson-g12b-gtking-pro.dtb
  dtb-$(CONFIG_ARCH_MESON) += meson-g12b-gtking.dtb

--- a/patch/kernel/archive/meson64-6.1/board-radxa-zero-dts-otg-fix.patch
+++ b/patch/kernel/archive/meson64-6.1/board-radxa-zero-dts-otg-fix.patch
@@ -12,7 +12,7 @@ Signed-off-by: Yuntian Zhang <yt@radxa.com>
  1 file changed, 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
-index dd15c5548993..4e7781f87867 100644
+index 28eaaa83a00e..29cfcc045bea 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
 +++ b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
 @@ -441,7 +441,6 @@ &uart_AO {

--- a/patch/kernel/archive/meson64-6.1/board-radxa-zero-dts-slow-down-sdio-for-working-wifi.patch
+++ b/patch/kernel/archive/meson64-6.1/board-radxa-zero-dts-slow-down-sdio-for-working-wifi.patch
@@ -11,7 +11,7 @@ Signed-off-by: Yuntian Zhang <yt@radxa.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
-index 28eaaa83a00e..dd15c5548993 100644
+index 29cfcc045bea..4e7781f87867 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
 +++ b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
 @@ -350,7 +350,7 @@ &sd_emmc_a {

--- a/patch/kernel/archive/meson64-6.1/drv-spi-spidev-remove-warnings.patch
+++ b/patch/kernel/archive/meson64-6.1/drv-spi-spidev-remove-warnings.patch
@@ -12,10 +12,10 @@ Remove SPIdev warnings
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/spi/spidev.c b/drivers/spi/spidev.c
-index b2775d82d2d7..3c65d3d74559 100644
+index 6313e7d0cdf8..22056740a731 100644
 --- a/drivers/spi/spidev.c
 +++ b/drivers/spi/spidev.c
-@@ -683,6 +683,7 @@ static const struct file_operations spidev_fops = {
+@@ -694,6 +694,7 @@ static const struct file_operations spidev_fops = {
  static struct class *spidev_class;
  
  static const struct spi_device_id spidev_spi_ids[] = {
@@ -23,7 +23,7 @@ index b2775d82d2d7..3c65d3d74559 100644
  	{ .name = "dh2228fv" },
  	{ .name = "ltc2488" },
  	{ .name = "sx1301" },
-@@ -709,6 +710,7 @@ static int spidev_of_check(struct device *dev)
+@@ -720,6 +721,7 @@ static int spidev_of_check(struct device *dev)
  }
  
  static const struct of_device_id spidev_dt_ids[] = {

--- a/patch/kernel/archive/meson64-6.1/general-drm-dw-hdmi-call-hdmi_set_cts_n-after-clock.patch
+++ b/patch/kernel/archive/meson64-6.1/general-drm-dw-hdmi-call-hdmi_set_cts_n-after-clock.patch
@@ -10,7 +10,7 @@ Unknown patch. Archeology:
  1 file changed, 5 insertions(+)
 
 diff --git a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
-index 40d8ca37f5bc..1ceb18f82f6d 100644
+index aa51c61a78c7..18ad3ef436f6 100644
 --- a/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
 +++ b/drivers/gpu/drm/bridge/synopsys/dw-hdmi.c
 @@ -782,6 +782,11 @@ static void hdmi_enable_audio_clk(struct dw_hdmi *hdmi, bool enable)

--- a/patch/kernel/archive/meson64-6.1/general-input-touchscreen-Add-D-WAV-Multitouch.patch
+++ b/patch/kernel/archive/meson64-6.1/general-input-touchscreen-Add-D-WAV-Multitouch.patch
@@ -13,10 +13,10 @@ Change-Id: Ia1c8c29d3f69c6ba5d630279c4cc98119b68ab71
  5 files changed, 574 insertions(+)
 
 diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
-index dad953f66996..69ab90e228b0 100644
+index 82713ef3aaa6..d12a5b48352e 100644
 --- a/drivers/hid/hid-ids.h
 +++ b/drivers/hid/hid-ids.h
-@@ -1410,4 +1410,10 @@
+@@ -1418,4 +1418,10 @@
  #define USB_VENDOR_ID_SIGNOTEC			0x2133
  #define USB_DEVICE_ID_SIGNOTEC_VIEWSONIC_PD1011	0x0018
  
@@ -28,10 +28,10 @@ index dad953f66996..69ab90e228b0 100644
 +
  #endif
 diff --git a/drivers/hid/hid-quirks.c b/drivers/hid/hid-quirks.c
-index 50e1c717fc0a..b2f1a4a7367d 100644
+index 0e9702c7f7d6..afa6f910a28f 100644
 --- a/drivers/hid/hid-quirks.c
 +++ b/drivers/hid/hid-quirks.c
-@@ -876,6 +876,9 @@ static const struct hid_device_id hid_ignore_list[] = {
+@@ -879,6 +879,9 @@ static const struct hid_device_id hid_ignore_list[] = {
  	{ HID_USB_DEVICE(USB_VENDOR_ID_SYNAPTICS, USB_DEVICE_ID_SYNAPTICS_DPAD) },
  #endif
  	{ HID_USB_DEVICE(USB_VENDOR_ID_YEALINK, USB_DEVICE_ID_YEALINK_P1K_P4K_B2K) },

--- a/patch/kernel/archive/meson64-6.1/general-meson-gx-mmc-fix-deferred-probing.patch
+++ b/patch/kernel/archive/meson64-6.1/general-meson-gx-mmc-fix-deferred-probing.patch
@@ -16,7 +16,7 @@ Signed-off-by: Sergey Shtylyov <s.shtylyov@omp.ru>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/mmc/host/meson-gx-mmc.c b/drivers/mmc/host/meson-gx-mmc.c
-index df05e60bed9a..37c9c32a2171 100644
+index 6e5ea0213b47..03d313a27a7a 100644
 --- a/drivers/mmc/host/meson-gx-mmc.c
 +++ b/drivers/mmc/host/meson-gx-mmc.c
 @@ -1225,8 +1225,8 @@ static int meson_mmc_probe(struct platform_device *pdev)

--- a/patch/kernel/archive/meson64-6.1/general-meson-mmc-1-arm64-amlogic-mmc-meson-gx-Add-core-tx-rx-eMMC-SD-SD.patch
+++ b/patch/kernel/archive/meson64-6.1/general-meson-mmc-1-arm64-amlogic-mmc-meson-gx-Add-core-tx-rx-eMMC-SD-SD.patch
@@ -16,7 +16,7 @@ Signed-off-by: Vyacheslav Bocharov <adeep@lexina.in>
  2 files changed, 48 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/mmc/host/meson-gx-mmc.c b/drivers/mmc/host/meson-gx-mmc.c
-index 37c9c32a2171..f89e23cfce4a 100644
+index 03d313a27a7a..9f632e46c487 100644
 --- a/drivers/mmc/host/meson-gx-mmc.c
 +++ b/drivers/mmc/host/meson-gx-mmc.c
 @@ -27,6 +27,7 @@

--- a/patch/kernel/archive/meson64-6.1/general-meson64-overlays.patch
+++ b/patch/kernel/archive/meson64-6.1/general-meson64-overlays.patch
@@ -20,10 +20,10 @@ Signed-off-by: Zhang Ning <832666+zhangn1985@users.noreply.github.com>
  12 files changed, 176 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/amlogic/Makefile b/arch/arm64/boot/dts/amlogic/Makefile
-index 606063c3204f..c11d45ee9274 100644
+index 10205ee7627a..82374835e1c3 100644
 --- a/arch/arm64/boot/dts/amlogic/Makefile
 +++ b/arch/arm64/boot/dts/amlogic/Makefile
-@@ -76,3 +76,5 @@ dtb-$(CONFIG_ARCH_MESON) += meson-sm1-odroid-hc4.dtb
+@@ -71,3 +71,5 @@ dtb-$(CONFIG_ARCH_MESON) += meson-sm1-odroid-hc4.dtb
  dtb-$(CONFIG_ARCH_MESON) += meson-sm1-sei610.dtb
  dtb-$(CONFIG_ARCH_MESON) += meson-sm1-x96-air-gbit.dtb
  dtb-$(CONFIG_ARCH_MESON) += meson-sm1-x96-air.dtb

--- a/patch/kernel/archive/meson64-6.1/general-spi-nor-add-support-for-XT25F128B.patch
+++ b/patch/kernel/archive/meson64-6.1/general-spi-nor-add-support-for-XT25F128B.patch
@@ -39,10 +39,10 @@ index e347b435a038..8992c592a896 100644
  obj-$(CONFIG_MTD_SPI_NOR)	+= spi-nor.o
  
 diff --git a/drivers/mtd/spi-nor/core.c b/drivers/mtd/spi-nor/core.c
-index bee8fc4c9f07..24ce2fd7dc40 100644
+index 2e0655c0b606..fafffe64b9d7 100644
 --- a/drivers/mtd/spi-nor/core.c
 +++ b/drivers/mtd/spi-nor/core.c
-@@ -1630,6 +1630,7 @@ static const struct spi_nor_manufacturer *manufacturers[] = {
+@@ -1632,6 +1632,7 @@ static const struct spi_nor_manufacturer *manufacturers[] = {
  	&spi_nor_winbond,
  	&spi_nor_xilinx,
  	&spi_nor_xmc,


### PR DESCRIPTION
#### meson64: 6.1.y/edge: rebase patches against v6.1.4 (no actual changes)