### PR TITLE
meson64: 6.1.y/edge: BananaPi M5: use 270 clock phase via `amlogic,mmc-phase`

### DIFF
--- a/patch/kernel/archive/meson64-6.1/board-bananapim5-sd-use-270-mmc-clock-phase-via-dt.patch
+++ b/patch/kernel/archive/meson64-6.1/board-bananapim5-sd-use-270-mmc-clock-phase-via-dt.patch
@@ -1,0 +1,43 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ricardo Pardini <ricardo@pardini.net>
+Date: Mon, 9 Jan 2023 02:18:23 +0100
+Subject: BananaPi M5: 270 clock phase, via amlogic,mmc-phase
+
+BananaPi M5: 270 clock phase, via amlogic,mmc-phase
+---
+ arch/arm64/boot/dts/amlogic/meson-sm1-bananapi-m5.dts | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-sm1-bananapi-m5.dts b/arch/arm64/boot/dts/amlogic/meson-sm1-bananapi-m5.dts
+index cadba194b149..9c3155426d40 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-sm1-bananapi-m5.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-sm1-bananapi-m5.dts
+@@ -12,6 +12,7 @@
+ #include <dt-bindings/gpio/meson-g12a-gpio.h>
+ #include <dt-bindings/sound/meson-g12a-toacodec.h>
+ #include <dt-bindings/sound/meson-g12a-tohdmitx.h>
++#include <dt-bindings/mmc/meson-gx-mmc.h>
+ 
+ / {
+ 	compatible = "bananapi,bpi-m5", "amlogic,sm1";
+@@ -558,6 +559,8 @@ &sd_emmc_b {
+ 	cd-gpios = <&gpio GPIOC_6 GPIO_ACTIVE_LOW>;
+ 	vmmc-supply = <&tflash_vdd>;
+ 	vqmmc-supply = <&vddio_c>;
++	
++	amlogic,mmc-phase = <CLK_PHASE_270 CLK_PHASE_0 CLK_PHASE_0>;
+ };
+ 
+ /* eMMC */
+@@ -577,6 +580,8 @@ &sd_emmc_c {
+ 	mmc-pwrseq = <&emmc_pwrseq>;
+ 	vmmc-supply = <&vddao_3v3>;
+ 	vqmmc-supply = <&emmc_1v8>;
++
++	amlogic,mmc-phase = <CLK_PHASE_270 CLK_PHASE_0 CLK_PHASE_0>;
+ };
+ 
+ &tdmif_b {
+-- 
+Armbian
+


### PR DESCRIPTION
#### meson64: 6.1.y/edge: BananaPi M5: use 270 clock phase via `amlogic,mmc-phase`

Original overlay

```patch
/dts-v1/;
/plugin/;

/ {
    compatible = "amlogic,g12a", "amlogic,g12b", "amlogic,sm1";
    fragment@0 {
        target-path = "/soc/mmc@ffe07000";
        overlay {
            amlogic,mmc-phase = <0x03 0x00 0x00>;
        };
    };
};
```

I think there is a JIRA for this but can't find it.

Long discussion on this with @chbgdn on Discord.
See https://discord.com/channels/854735915313659944/858684386806595584/1061788329793822841

Upstream novella https://lore.kernel.org/linux-amlogic/1j7czj2s8r.fsf@starbuckisacylon.baylibre.com/

Image for testing: https://github.com/rpardini/armbian-release/releases/download/20230109a/Armbian_20230109a-rpardini_Bananapim2s_kinetic_edge_6.1.4.img.xz
