### PR TITLE
`mvebu64`: remove dangling symlinks for both current and edge

### DIFF
--- a/patch/kernel/mvebu64-current
+++ b/patch/kernel/mvebu64-current
@@ -1,1 +1,0 @@
-archive/mvebu64-5.15/

--- a/patch/kernel/mvebu64-edge
+++ b/patch/kernel/mvebu64-edge
@@ -1,1 +1,0 @@
-archive/mvebu64-5.15/


### PR DESCRIPTION
#### `mvebu64`: remove dangling symlinks for both current and edge

No use having them in there pointing to something that does not exist.
Also, didn't hurt.

This PR might be proof of OCD
