### PR TITLE
Remove system-monitoring-center from Jammy desktop tools

### DIFF
--- a/config/desktop/jammy/appgroups/desktop_tools/packages
+++ b/config/desktop/jammy/appgroups/desktop_tools/packages
@@ -1,4 +1,3 @@
 bleachbit
 fbi
 gparted
-system-monitoring-center


### PR DESCRIPTION
…tools package.

Jammy desktop tools package contains an unavailable entry, "system-monitoring-center", this causes build to abort on both armbian-build and armbian-next when the package is selected for the build.

This patch removes "system-monitoring-center" from the package.

Jira reference number [AR-1485]

- [x] Pine64 Jammy desktop with desktop tools package built successfully on armbian-build and armbian-next
- [x] Images ran desktop successfully on Pine64

# Checklist:

- [x] My changes generate no new warnings


[AR-1485]: https://armbian.atlassian.net/browse/AR-1485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ