### PR TITLE
Add overlay for rockpro64 7″ lcd

### DIFF
--- a/patch/kernel/archive/rockchip64-6.1/overlays-13-add-rockpro64-lcd.patch
+++ b/patch/kernel/archive/rockchip64-6.1/overlays-13-add-rockpro64-lcd.patch
@@ -1,0 +1,76 @@
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts/rockchip/overlay/Makefile
+index 41c323473d5..25e4e189d97 100644
+--- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
++++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
+@@ -7,6 +7,7 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
+ 	rockchip-rk3328-opp-1.5ghz.dtbo \
+ 	rockchip-rk3399-opp-2ghz.dtbo \
+ 	rockchip-rockpi4cplus-usb-host.dtbo \
++	rockchip-rockpro64-lcd.dtbo \
+ 	rockchip-spi-jedec-nor.dtbo \
+ 	rockchip-spi-spidev.dtbo \
+ 	rockchip-uart4.dtbo \
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rockpro64-lcd.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rockpro64-lcd.dts
+new file mode 100644
+index 00000000000..c9ce8f8b565
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rockpro64-lcd.dts
+@@ -0,0 +1,58 @@
++//For RockPro64 7″ LCD TOUCH SCREEN PANEL
++
++/dts-v1/;
++/plugin/;
++
++/ {
++  compatible = "rockchip,rk3399";
++	
++  fragment@0 {
++    target=<&backlight>;
++    __overlay__ {
++      status = "okay";
++    };
++  };
++  
++  fragment@1 {
++    target=<&touch>;
++    __overlay__ {
++      status = "okay";
++    };
++  };
++  
++  fragment@2 {
++    target=<&mipi_dsi>;
++    __overlay__ {
++      status = "okay";
++    };
++  }; 
++  
++  fragment@3 {
++    target=<&vopl>;
++    __overlay__ {
++      status = "okay";
++    };
++  };
++
++  fragment@4 {
++    target=<&vopl_mmu>;
++    __overlay__ {
++      status = "okay";
++    };
++  };
++  
++  fragment@5 {
++    target=<&vopb>;
++    __overlay__ {
++      status = "okay";
++    };
++  };
++
++  fragment@6 {
++    target=<&vopb_mmu>;
++    __overlay__ {
++      status = "okay";
++    };
++  };
++};
++


### PR DESCRIPTION
# Description

This overlay enable 7″ lcd([https://pine64.com/product/7-lcd-touch-screen-panel/](https://pine64.com/product/7-lcd-touch-screen-panel/)) on rockpro64 linux 6.x

# How Has This Been Tested?

I haven't a rockpro64,but it was tested in there [https://forum.armbian.com/topic/21528-possible-to-get-jammy-515-kernel-to-use-dsitp-display/?do=findComment&comment=157010](https://forum.armbian.com/topic/21528-possible-to-get-jammy-515-kernel-to-use-dsitp-display/?do=findComment&comment=157010)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
