### PR TITLE
External compilation is not enabled by default anymore

### DIFF
--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -111,7 +111,7 @@ prepare_host() {
 		# trying to use nested containers is not a good idea, so don't permit EXTERNAL_NEW=compile
 		if [[ $EXTERNAL_NEW == compile ]]; then
 			display_alert "EXTERNAL_NEW=compile is not available when running in container, setting to prebuilt" "" "wrn"
-			EXTERNAL_NEW=prebuilt
+			EXTERNAL_NEW=no
 		fi
 		SYNC_CLOCK=no
 	fi


### PR DESCRIPTION
# Description

This and https://github.com/armbian/scripts/commit/273538dac6d298c90c70af8755862b63ba765670 will remove from installing hostapd. Leftover from previous attempt to remove hostapd.

Jira reference number [AR-1461]

# How Has This Been Tested?

- [ ] Generated image

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1461]: https://armbian.atlassian.net/browse/AR-1461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ