### PR TITLE
rk322x: fix tsadc-related bootloop on some boards

### DIFF
--- a/patch/kernel/archive/rk322x-5.15/board-rk322x-box.patch
+++ b/patch/kernel/archive/rk322x-5.15/board-rk322x-box.patch
@@ -1,9 +1,9 @@
 diff --git a/arch/arm/boot/dts/rk322x-box.dts b/arch/arm/boot/dts/rk322x-box.dts
 new file mode 100644
-index 000000000000..f6e249bf81b6
+index 00000000000..a498bad3a4f
 --- /dev/null
 +++ b/arch/arm/boot/dts/rk322x-box.dts
-@@ -0,0 +1,753 @@
+@@ -0,0 +1,766 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +
 +/dts-v1/;
@@ -741,6 +741,19 @@ index 000000000000..f6e249bf81b6
 +	rockchip,hw-tshut-mode = <0>;
 +	rockchip,hw-tshut-polarity = <1>;
 +	rockchip,hw-tshut-temp = <110000>;
++	
++	/* delete the pinctrl-* properties because, on mainline kernel, they (in particular "default")
++	   change the GPIO configuration of the associated PIN. On most boards that pin is not connected
++	   so it does not do anything, but some other boards (X96-Mini) have that pin connected to
++	   a reset pin of the soc or whatever, thus changing the configuration of the pin at boot 
++	   causes them to bootloop.
++	   We don't really need these ones though, because since hw-tshut-mode is set to 0, the CRU
++	   unit of the SoC does the reboot*/	
++	/delete-property/ pinctrl-names;
++	/delete-property/ pinctrl-0;
++	/delete-property/ pinctrl-1;
++	/delete-property/ pinctrl-2;
++
 +	status = "okay";
 +};
 +

--- a/patch/kernel/archive/rk322x-6.1/board-rk322x-box.patch
+++ b/patch/kernel/archive/rk322x-6.1/board-rk322x-box.patch
@@ -1,9 +1,9 @@
 diff --git a/arch/arm/boot/dts/rk322x-box.dts b/arch/arm/boot/dts/rk322x-box.dts
 new file mode 100644
-index 000000000000..f6e249bf81b6
+index 00000000000..a498bad3a4f
 --- /dev/null
 +++ b/arch/arm/boot/dts/rk322x-box.dts
-@@ -0,0 +1,753 @@
+@@ -0,0 +1,766 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +
 +/dts-v1/;
@@ -741,6 +741,19 @@ index 000000000000..f6e249bf81b6
 +	rockchip,hw-tshut-mode = <0>;
 +	rockchip,hw-tshut-polarity = <1>;
 +	rockchip,hw-tshut-temp = <110000>;
++	
++	/* delete the pinctrl-* properties because, on mainline kernel, they (in particular "default")
++	   change the GPIO configuration of the associated PIN. On most boards that pin is not connected
++	   so it does not do anything, but some other boards (X96-Mini) have that pin connected to
++	   a reset pin of the soc or whatever, thus changing the configuration of the pin at boot 
++	   causes them to bootloop.
++	   We don't really need these ones though, because since hw-tshut-mode is set to 0, the CRU
++	   unit of the SoC does the reboot*/	
++	/delete-property/ pinctrl-names;
++	/delete-property/ pinctrl-0;
++	/delete-property/ pinctrl-1;
++	/delete-property/ pinctrl-2;
++
 +	status = "okay";
 +};
 +


### PR DESCRIPTION
# Description

Some rk322x boards (notably those with X96-Mini signature) are stuck in a bootloop. 
The cause has been identified in the tsadc node and in particular is related to what is described in [this](https://github.com/torvalds/linux/commit/28694e009e512451ead5519dd801f9869acb1f60) kernel pull request.

This PR simply removes the pinctrl properties, so the GPIO pin that does the reset on these board is left as per default, thus not causing any unwanted reboot.

# How Has This Been Tested?

- [x] Device tree has been compiled without errors

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
