### PR TITLE
RockPro64: add thermal fan control

### DIFF
--- a/patch/kernel/archive/rockchip64-5.15/general-rockpro64-thermal-fan-control.patch
+++ b/patch/kernel/archive/rockchip64-5.15/general-rockpro64-thermal-fan-control.patch
@@ -1,0 +1,67 @@
+From d09ebc6ba9ccb9b36fb860b5239d488edc794dcb Mon Sep 17 00:00:00 2001
+From: Peter Geis <pgwipeout@gmail.com>
+Date: Fri, 30 Jul 2021 11:17:27 -0400
+Subject: [PATCH] arm64: dts: rockchip: add thermal fan control to rockpro64
+
+The rockpro64 had a fan node since
+commit 5882d65c1691 ("arm64: dts: rockchip: Add PWM fan for RockPro64")
+however it was never tied into the thermal driver for automatic control.
+
+Add the links to the thermal node to permit the kernel to handle this
+automatically.
+Borrowed from the (rk3399-khadas-edge.dtsi).
+
+Signed-off-by: Peter Geis <pgwipeout@gmail.com>
+Link: https://lore.kernel.org/r/20210730151727.729822-1-pgwipeout@gmail.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ .../boot/dts/rockchip/rk3399-rockpro64.dtsi   | 29 +++++++++++++++++++
+ 1 file changed, 29 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
+index 6bff8db7d33e8a..83db4ca6733497 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
+@@ -69,6 +69,7 @@
+ 
+ 	fan: pwm-fan {
+ 		compatible = "pwm-fan";
++		cooling-levels = <0 100 150 200 255>;
+ 		#cooling-cells = <2>;
+ 		fan-supply = <&vcc12v_dcin>;
+ 		pwms = <&pwm1 0 50000 0>;
+@@ -245,6 +246,34 @@
+ 	cpu-supply = <&vdd_cpu_b>;
+ };
+ 
++&cpu_thermal {
++	trips {
++		cpu_warm: cpu_warm {
++			temperature = <55000>;
++			hysteresis = <2000>;
++			type = "active";
++		};
++
++		cpu_hot: cpu_hot {
++			temperature = <65000>;
++			hysteresis = <2000>;
++			type = "active";
++		};
++	};
++
++	cooling-maps {
++		map2 {
++			trip = <&cpu_warm>;
++			cooling-device = <&fan THERMAL_NO_LIMIT 1>;
++		};
++
++		map3 {
++			trip = <&cpu_hot>;
++			cooling-device = <&fan 2 THERMAL_NO_LIMIT>;
++		};
++	};
++};
++
+ &emmc_phy {
+ 	status = "okay";
+ };


### PR DESCRIPTION
# Description

This backports a commit from the Linux kernel into version 5.15 in order to enable the automatic control of the fan, based on the CPU temperature. Otherwise, the fan would run at maximum speed all the time (per default).

# How Has This Been Tested?

I've built the kernel and installed the resulting `.deb` packages on my RockPro64 (running Bullseye). I monitored the CPU temperature and verified that the fan speeds up as soon as it hits the trip points defined in the device tree.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
