### PR TITLE
CCACHE_TEMPDIR="/tmp/ccache-tmp" if /tmp is mounted as tmpfs

### DIFF
--- a/lib/functions/main/config-prepare.sh
+++ b/lib/functions/main/config-prepare.sh
@@ -54,6 +54,10 @@ function prepare_and_config_main_build_single() {
 		# private ccache directory to avoid permission issues when using build script with "sudo"
 		# see https://ccache.samba.org/manual.html#_sharing_a_cache for alternative solution
 		[[ $PRIVATE_CCACHE == yes ]] && export CCACHE_DIR=$SRC/cache/ccache
+		# Check if /tmp is mounted as tmpfs make a temporary ccache folder there for faster operation.
+		if [ "$(findmnt --noheadings --output FSTYPE --target "/tmp" --uniq)" == "tmpfs" ]; then
+			export CCACHE_TEMPDIR="/tmp/ccache-tmp"
+		fi
 
 	else
 


### PR DESCRIPTION
# Description

When the system temporary folder is mounted as tmpfs, it makes sense to mount
the temporary compiler cache folder in /tmp. This speeds up the compilation process
and saves the hard disk resource.
About the SSD resource, I think that it is clear to everyone.

# How Has This Been Tested?
For my virtual machine 6 spu frequency 3.6G
Compile Time before: Runtime 46:43 min
Compile time after: Runtime 35:42 min

# Checklist:
- [x] Test build
