### PR TITLE
Mount /tmp in docker builder container as tmpfs. Same as #4703

### DIFF
--- a/config/templates/config-docker.conf
+++ b/config/templates/config-docker.conf
@@ -84,6 +84,8 @@ fi
 
 # map source to Docker Working dir.
 DOCKER_FLAGS+=(-v=$SRC/:/root/armbian/)
+# map /tmp to tmpfs
+DOCKER_FLAGS+=(--mount type=tmpfs,destination=/tmp)
 
 # mount 2 named volumes - for cacheable data and compiler cache
 DOCKER_FLAGS+=(-v=armbian-cache:/root/armbian/cache -v=armbian-ccache:/root/.ccache)


### PR DESCRIPTION
Mount /tmp in docker builder container tmpfs.
Makes compilation with ccache in docker builder run faster.

Inspired by #4703