### PR TITLE
Update docker build images for armbian-next

### DIFF
--- a/.github/workflows/update-docker.yml
+++ b/.github/workflows/update-docker.yml
@@ -6,14 +6,7 @@ name: Update Docker
 on:
   workflow_dispatch:
   schedule:
-    - cron:  '0 0 * * 0'
-  
-  # automatically rebuild docker images when VERSION is changed on master branch
-  push:
-    branches:
-      - master
-    paths:
-      - 'VERSION'
+    - cron: '0 3 * * *' # Scheduled runs every day at 3am UTC
 
 permissions:
   contents: read
@@ -25,19 +18,6 @@ jobs:
       contents: none
 
     if: ${{ github.repository_owner == 'Armbian' }}
-    uses: armbian/scripts/.github/workflows/update-docker-image.yml@master
-
+    uses: armbian/scripts/.github/workflows/armbian-framework-docker-images.yml@master
     secrets:
       CR_PAT: ${{ secrets.CR_PAT }}
-
-  Docker-test:
-    permissions:
-      contents: none
-
-    needs: Docker
-    if: ${{ github.repository_owner == 'Armbian' }}
-    uses: armbian/scripts/.github/workflows/build-test-image-docker.yml@master
-    with:
-
-      runner: "ubuntu-latest"
-      reference: master


### PR DESCRIPTION
# Description

New Docker generating script is based on @rpardini for Armbian NEXT with one exception - hard coded values has been replaced with automated generation from our build config. We will be making Docker images for all images except [AR-1495] old releases such as Focal / Buster which are currently still tagged as supported.

To do: 
- [ ] [Switch from armbian-next to master](https://github.com/armbian/scripts/blob/master/.github/workflows/armbian-framework-docker-images.yml#L24-L61)
- [x] Resolve [AR-1495]

Script: https://github.com/armbian/scripts/pull/38/files 
Test run: https://github.com/armbian/build/actions/runs/3938745257

Jira reference number [AR-1449]

# How Has This Been Tested?

- [x] Manual run, images are deployed

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1495]: https://armbian.atlassian.net/browse/AR-1495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AR-1449]: https://armbian.atlassian.net/browse/AR-1449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ