### PR TITLE
Clean up mbox format in rk3399-ehci-probe-usb2.patch rockchip64 u-boot

### DIFF
--- a/patch/u-boot/u-boot-rockchip64/rk3399-ehci-probe-usb2.patch
+++ b/patch/u-boot/u-boot-rockchip64/rk3399-ehci-probe-usb2.patch
@@ -1,14 +1,9 @@
-From git@z Thu Jan  1 00:00:00 1970
+From ccfd8b3f8b001aab0a2469e43ce8768863cb454d Mon Sep 17 00:00:00 2001
+From: schwar3kat <61094841+schwar3kat@users.noreply.github.com>
+Date: Wed, 18 Jan 2023 15:46:39 +1300
 Subject: [PATCH] arm: dts: rockchip: rk3399: usb: ehci: Fix EHCI probe in rk3399 to access peripherals by USB 2.
-From: Xavier Drudis Ferran <xdrudis@tinet.cat>
-Date: Fri, 01 Jul 2022 20:59:59 +0200
-Message-Id: <20220701185959.GC1700@begut>
-To: u-boot@lists.denx.de
-Cc: Simon Glass <sjg@chromium.org>, Philipp Tomsich <philipp.tomsich@vrull.eu>, Kever Yang <kever.yang@rock-chips.com>, Lukasz Majewski <lukma@denx.de>, Sean Anderson <seanga2@gmail.com>, Marek Vasut <marex@denx.de>
-List-Id: U-Boot discussion <u-boot.lists.denx.de>
-MIME-Version: 1.0
-Content-Type: text/plain; charset="utf-8"
-Content-Transfer-Encoding: 7bit
+
+Commit message: Clean up mbox format in rk3399-ehci-probe-usb2.patch. No diff changes.
 
 arch/arm/dts/rk3399.dtsi has a node
 
@@ -93,12 +88,13 @@ Cc: Sean Anderson <seanga2@gmail.com>
 Cc: Marek Vasut <marex@denx.de>
 
 Signed-off-by: Xavier Drudis Ferran <xdrudis@tinet.cat>
+
 ---
  arch/arm/dts/rk3399-u-boot.dtsi | 8 ++++++++
  1 file changed, 8 insertions(+)
 
 diff --git a/arch/arm/dts/rk3399-u-boot.dtsi b/arch/arm/dts/rk3399-u-boot.dtsi
-index 716b9a433a..63c7b10405 100644
+index 716b9a43..63c7b104 100644
 --- a/arch/arm/dts/rk3399-u-boot.dtsi
 +++ b/arch/arm/dts/rk3399-u-boot.dtsi
 @@ -147,3 +147,11 @@
@@ -114,5 +110,5 @@ index 716b9a433a..63c7b10405 100644
 +	clocks = <&cru HCLK_HOST1>, <&cru HCLK_HOST1_ARB>;
 +};
 -- 
-2.20.1
+Created with Armbian build tools https://github.com/armbian/build
 


### PR DESCRIPTION
U-boot-rockchip64 rk3399-ehci-probe-usb2.patch. 
No code changes. 
Original patch applied and new patch generated then mbox tweaked to retain relevant details. 
Prevents patching errors in armbian-next.

Jira reference number [AR-1499]

- [x] Builds without errors on master
- [x] Builds without errors on armbian-next

# Checklist:

- [x] My changes generate no new warnings


[AR-1499]: https://armbian.atlassian.net/browse/AR-1499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ