### PR TITLE
Re-enabling support for Rpi3

### DIFF
--- a/config/boards/rpi4b.conf
+++ b/config/boards/rpi4b.conf
@@ -5,6 +5,12 @@ export KERNEL_TARGET="current,edge"
 export FK__MACHINE_MODEL="Raspberry Pi 4 Model B" # flash kernel (FK) configuration
 export ASOUND_STATE="asound.state.rpi"
 
+# Our default paritioning system is leaving esp on. Rpi3 is the only board that have issues with this.
+# Removing the ESP flag from the boot partition should allow the image to boot on both the RPi3 and RPi4.
+pre_umount_final_image__remove_esp() {
+	sudo parted -s $LOOP set 1 esp off
+}
+
 # configure stuff at the appropriate time in flash-kernel
 pre_initramfs_flash_kernel__write_raspi_config() {
 	# for serial console, there is also 'BOOT_UART=1' in 'rpi-eeprom-config' but that is for an earlier stage.


### PR DESCRIPTION
# Description

The boot partition is flagged ESP, which the PI3 does not support.

Jira reference number [AR-1467]

# How Has This Been Tested?

- [ ] Generated and boot image

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1467]: https://armbian.atlassian.net/browse/AR-1467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ