### PR TITLE
Add missing I2C, SPI, PWM, UART, LCD overlays to Orange Pi 5

### DIFF
--- a/patch/kernel/rockchip-rk3588-legacy/2011-Add-missing-I2C-SPI-PWM-UART-LCD-overlays-to-OrangePi5.patch
+++ b/patch/kernel/rockchip-rk3588-legacy/2011-Add-missing-I2C-SPI-PWM-UART-LCD-overlays-to-OrangePi5.patch
@@ -1,0 +1,607 @@
+From 385db1021fd42090f6c298d79c084ec60d454f28 Mon Sep 17 00:00:00 2001
+From: Muhammed Efe Cetin <efectn@protonmail.com>
+Date: Wed, 18 Jan 2023 23:20:55 +0300
+Subject: [PATCH] Add missing I2C, SPI, PWM, UART, LCD overlays to Orange Pi 5.
+
+---
+ arch/arm64/boot/dts/rockchip/overlay/Makefile | 19 ++++
+ .../overlay/rockchip-rk3588-opi5-can1-m1.dts  | 14 +++
+ .../overlay/rockchip-rk3588-opi5-can2-m1.dts  | 14 +++
+ .../overlay/rockchip-rk3588-opi5-i2c1-m2.dts  | 14 +++
+ .../overlay/rockchip-rk3588-opi5-i2c1-m4.dts  | 14 +++
+ .../overlay/rockchip-rk3588-opi5-i2c3-m0.dts  | 14 +++
+ .../overlay/rockchip-rk3588-opi5-i2c5-m3.dts  | 14 +++
+ .../overlay/rockchip-rk3588-opi5-lcd1.dts     | 88 +++++++++++++++++++
+ .../overlay/rockchip-rk3588-opi5-lcd2.dts     | 88 +++++++++++++++++++
+ .../overlay/rockchip-rk3588-opi5-pwm0-m1.dts  | 13 +++
+ .../overlay/rockchip-rk3588-opi5-pwm1-m1.dts  | 13 +++
+ .../overlay/rockchip-rk3588-opi5-pwm1-m2.dts  | 13 +++
+ .../overlay/rockchip-rk3588-opi5-pwm15-m2.dts | 13 +++
+ .../overlay/rockchip-rk3588-opi5-pwm3-m0.dts  | 13 +++
+ .../overlay/rockchip-rk3588-opi5-pwm3-m2.dts  | 13 +++
+ ...ockchip-rk3588-opi5-spi4-m0-cs1-spidev.dts | 23 +++++
+ .../overlay/rockchip-rk3588-opi5-uart0-m2.dts | 13 +++
+ .../overlay/rockchip-rk3588-opi5-uart1-m1.dts | 13 +++
+ .../overlay/rockchip-rk3588-opi5-uart3-m0.dts | 13 +++
+ .../overlay/rockchip-rk3588-opi5-uart4-m0.dts | 13 +++
+ 20 files changed, 432 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-can1-m1.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-can2-m1.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-i2c1-m2.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-i2c1-m4.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-i2c3-m0.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-i2c5-m3.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-lcd1.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-lcd2.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-pwm0-m1.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-pwm1-m1.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-pwm1-m2.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-pwm15-m2.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-pwm3-m0.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-pwm3-m2.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-spi4-m0-cs1-spidev.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-uart0-m2.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-uart1-m1.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-uart3-m0.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-uart4-m0.dts
+
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts/rockchip/overlay/Makefile
+index be299b03a..8e347afbf 100644
+--- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
++++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
+@@ -51,6 +51,25 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
+ 	rock-5b-rpi-camera-v2.dtbo \
+ 	rock-5b-sata.dtbo \
+ 	rockchip-rk3588-opi5-sata.dtbo \
++	rockchip-rk3588-opi5-can1-m1.dtbo \
++	rockchip-rk3588-opi5-can2-m1.dtbo \
++	rockchip-rk3588-opi5-i2c1-m2.dtbo \
++	rockchip-rk3588-opi5-i2c1-m4.dtbo \
++	rockchip-rk3588-opi5-i2c3-m0.dtbo \
++	rockchip-rk3588-opi5-i2c5-m3.dtbo \
++	rockchip-rk3588-opi5-lcd1.dtbo \
++	rockchip-rk3588-opi5-lcd2.dtbo \
++	rockchip-rk3588-opi5-pwm0-m1.dtbo \
++	rockchip-rk3588-opi5-pwm1-m1.dtbo \
++	rockchip-rk3588-opi5-pwm1-m2.dtbo \
++	rockchip-rk3588-opi5-pwm3-m0.dtbo \
++	rockchip-rk3588-opi5-pwm3-m2.dtbo \
++	rockchip-rk3588-opi5-pwm15-m2.dtbo \
++	rockchip-rk3588-opi5-spi4-m0-cs1-spidev.dtbo \
++	rockchip-rk3588-opi5-uart0-m2.dtbo \
++	rockchip-rk3588-opi5-uart1-m1.dtbo \
++	rockchip-rk3588-opi5-uart3-m0.dtbo \
++	rockchip-rk3588-opi5-uart4-m0.dtbo \
+ 
+ dtbotxt-$(CONFIG_ARCH_ROCKCHIP) += \
+ 	README.rockchip-overlays
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-can1-m1.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-can1-m1.dts
+new file mode 100644
+index 000000000..b470f1e0f
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-can1-m1.dts
+@@ -0,0 +1,14 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	fragment@0 {
++		target = <&can1>;
++
++		__overlay__ {
++			status = "okay";
++			pinctrl-names = "default";
++			pinctrl-0 = <&can1m1_pins>;
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-can2-m1.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-can2-m1.dts
+new file mode 100644
+index 000000000..075686874
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-can2-m1.dts
+@@ -0,0 +1,14 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	fragment@0 {
++		target = <&can2>;
++
++		__overlay__ {
++			status = "okay";
++			pinctrl-names = "default";
++			pinctrl-0 = <&can2m1_pins>;
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-i2c1-m2.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-i2c1-m2.dts
+new file mode 100644
+index 000000000..5d8e3104f
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-i2c1-m2.dts
+@@ -0,0 +1,14 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	fragment@0 {
++		target = <&i2c1>;
++
++		__overlay__ {
++			status = "okay";
++			pinctrl-names = "default";
++			pinctrl-0 = <&i2c1m2_xfer>;
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-i2c1-m4.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-i2c1-m4.dts
+new file mode 100644
+index 000000000..e581359fe
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-i2c1-m4.dts
+@@ -0,0 +1,14 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	fragment@0 {
++		target = <&i2c1>;
++
++		__overlay__ {
++			status = "okay";
++			pinctrl-names = "default";
++			pinctrl-0 = <&i2c1m4_xfer>;
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-i2c3-m0.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-i2c3-m0.dts
+new file mode 100644
+index 000000000..c9fb6b4e5
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-i2c3-m0.dts
+@@ -0,0 +1,14 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	fragment@0 {
++		target = <&i2c3>;
++
++		__overlay__ {
++			status = "okay";
++			pinctrl-names = "default";
++			pinctrl-0 = <&i2c3m0_xfer>;
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-i2c5-m3.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-i2c5-m3.dts
+new file mode 100644
+index 000000000..be0f852b7
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-i2c5-m3.dts
+@@ -0,0 +1,14 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	fragment@0 {
++		target = <&i2c5>;
++
++		__overlay__ {
++			status = "okay";
++			pinctrl-names = "default";
++			pinctrl-0 = <&i2c5m3_xfer>;
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-lcd1.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-lcd1.dts
+new file mode 100644
+index 000000000..04ece31f0
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-lcd1.dts
+@@ -0,0 +1,88 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	fragment@0 {
++		target = <&dsi1>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++
++	fragment@1 {
++		target = <&dsi1_panel>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++
++	fragment@2 {
++		target = <&dsi1_in_vp3>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++
++	fragment@3 {
++		target = <&hdmi0>;
++		__overlay__ {
++			status = "disabled";
++		};
++	};
++
++	fragment@4 {
++		target = <&hdmi0_sound>;
++		__overlay__ {
++			status = "disabled";
++		};
++	};
++
++	fragment@5 {
++		target = <&hdptxphy_hdmi0>;
++		__overlay__ {
++			status = "disabled";
++		};
++	};
++
++	fragment@6 {
++		target = <&route_hdmi0>;
++		__overlay__ {
++			status = "disabled";
++		};
++	};
++
++	fragment@7 {
++		target = <&dp0>;
++		__overlay__ {
++			status = "disabled";
++		};
++	};
++
++	fragment@8 {
++		target = <&dp0_in_vp1>;
++		__overlay__ {
++			status = "disabled";
++		};
++	};
++
++	fragment@9 {
++		target = <&dp0_in_vp2>;
++		__overlay__ {
++			status = "disabled";
++		};
++	};
++
++	fragment@10 {
++		target = <&dp0_sound>;
++		__overlay__ {
++			status = "disabled";
++		};
++	};
++
++	fragment@11 {
++		target = <&spdif_tx2>;
++		__overlay__ {
++			status = "disabled";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-lcd2.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-lcd2.dts
+new file mode 100644
+index 000000000..30765cc8f
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-lcd2.dts
+@@ -0,0 +1,88 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	fragment@0 {
++		target = <&dsi0>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++
++	fragment@1 {
++		target = <&dsi0_panel>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++
++	fragment@2 {
++		target = <&dsi0_in_vp2>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++
++	fragment@3 {
++		target = <&hdmi0>;
++		__overlay__ {
++			status = "disabled";
++		};
++	};
++
++	fragment@4 {
++		target = <&hdmi0_sound>;
++		__overlay__ {
++			status = "disabled";
++		};
++	};
++
++	fragment@5 {
++		target = <&hdptxphy_hdmi0>;
++		__overlay__ {
++			status = "disabled";
++		};
++	};
++
++	fragment@6 {
++		target = <&route_hdmi0>;
++		__overlay__ {
++			status = "disabled";
++		};
++	};
++
++	fragment@7 {
++		target = <&dp0>;
++		__overlay__ {
++			status = "disabled";
++		};
++	};
++
++	fragment@8 {
++		target = <&dp0_in_vp1>;
++		__overlay__ {
++			status = "disabled";
++		};
++	};
++
++	fragment@9 {
++		target = <&dp0_in_vp2>;
++		__overlay__ {
++			status = "disabled";
++		};
++	};
++
++	fragment@10 {
++		target = <&dp0_sound>;
++		__overlay__ {
++			status = "disabled";
++		};
++	};
++
++	fragment@11 {
++		target = <&spdif_tx2>;
++		__overlay__ {
++			status = "disabled";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-pwm0-m1.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-pwm0-m1.dts
+new file mode 100644
+index 000000000..353162ec7
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-pwm0-m1.dts
+@@ -0,0 +1,13 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	fragment@0 {
++		target = <&pwm0>;
++
++		__overlay__ {
++			status = "okay";
++			pinctrl-0 = <&pwm0m1_pins>;
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-pwm1-m1.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-pwm1-m1.dts
+new file mode 100644
+index 000000000..e93513502
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-pwm1-m1.dts
+@@ -0,0 +1,13 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	fragment@0 {
++		target = <&pwm1>;
++
++		__overlay__ {
++			status = "okay";
++			pinctrl-0 = <&pwm1m1_pins>;
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-pwm1-m2.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-pwm1-m2.dts
+new file mode 100644
+index 000000000..155d0bd41
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-pwm1-m2.dts
+@@ -0,0 +1,13 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	fragment@0 {
++		target = <&pwm1>;
++
++		__overlay__ {
++			status = "okay";
++			pinctrl-0 = <&pwm1m2_pins>;
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-pwm15-m2.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-pwm15-m2.dts
+new file mode 100644
+index 000000000..c1b2aea10
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-pwm15-m2.dts
+@@ -0,0 +1,13 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	fragment@0 {
++		target = <&pwm15>;
++
++		__overlay__ {
++			status = "okay";
++			pinctrl-0 = <&pwm15m2_pins>;
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-pwm3-m0.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-pwm3-m0.dts
+new file mode 100644
+index 000000000..a6a9181ab
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-pwm3-m0.dts
+@@ -0,0 +1,13 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	fragment@0 {
++		target = <&pwm3>;
++
++		__overlay__ {
++			status = "okay";
++			pinctrl-0 = <&pwm3m0_pins>;
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-pwm3-m2.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-pwm3-m2.dts
+new file mode 100644
+index 000000000..b70d2097e
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-pwm3-m2.dts
+@@ -0,0 +1,13 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	fragment@0 {
++		target = <&pwm3>;
++
++		__overlay__ {
++			status = "okay";
++			pinctrl-0 = <&pwm3m2_pins>;
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-spi4-m0-cs1-spidev.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-spi4-m0-cs1-spidev.dts
+new file mode 100644
+index 000000000..513502e3d
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-spi4-m0-cs1-spidev.dts
+@@ -0,0 +1,23 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	fragment@0 {
++		target = <&spi4>;
++
++		__overlay__ {
++			status = "okay";
++			#address-cells = <1>;
++			#size-cells = <0>;
++			pinctrl-names = "default";
++			pinctrl-0 = <&spi4m0_cs1 &spi4m0_pins>;
++
++			spidev@0 {
++				compatible = "rockchip,spidev";
++				status = "okay";
++				reg = <0>;
++				spi-max-frequency = <50000000>;
++			};
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-uart0-m2.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-uart0-m2.dts
+new file mode 100644
+index 000000000..1d36d889d
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-uart0-m2.dts
+@@ -0,0 +1,13 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	fragment@0 {
++		target = <&uart0>;
++
++		__overlay__ {
++			status = "okay";
++			pinctrl-0 = <&uart0m2_xfer>;
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-uart1-m1.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-uart1-m1.dts
+new file mode 100644
+index 000000000..909f6058f
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-uart1-m1.dts
+@@ -0,0 +1,13 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	fragment@0 {
++		target = <&uart1>;
++
++		__overlay__ {
++			status = "okay";
++			pinctrl-0 = <&uart1m1_xfer>;
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-uart3-m0.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-uart3-m0.dts
+new file mode 100644
+index 000000000..c2e98cb61
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-uart3-m0.dts
+@@ -0,0 +1,13 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	fragment@0 {
++		target = <&uart3>;
++
++		__overlay__ {
++			status = "okay";
++			pinctrl-0 = <&uart3m0_xfer>;
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-uart4-m0.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-uart4-m0.dts
+new file mode 100644
+index 000000000..f47090664
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opi5-uart4-m0.dts
+@@ -0,0 +1,13 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	fragment@0 {
++		target = <&uart4>;
++
++		__overlay__ {
++			status = "okay";
++			pinctrl-0 = <&uart4m0_xfer>;
++		};
++	};
++};
+-- 
+2.39.0
+


### PR DESCRIPTION
# Description
This PR adds some missing overlays of Orange Pi 5 that doesn't exists on Radxa's kernel source. I didn't add `pwm13-m2` and `pwm14-m1` because of they were already exists.

# How Has This Been Tested?
- [x] Checked availability of PWM, I2C, SPI, UART from /dev.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
