### PR TITLE
Fix: Uniquely determine the mount point, fix: pass an argument

### DIFF
--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -1039,13 +1039,10 @@ ShowDeviceWarning() {
 } # ShowDeviceWarning
 
 GetDevice() {
-	TestPath=$(findmnt --noheadings --output SOURCE,FSTYPE "$1" --uniq)
-	if [[ -z ${TestPath} ]]; then
-		[[ -n "${1%/*}" ]] \
-			&& GetDevice "${1%/*}" \
-			|| GetDevice "/"
-	else
+	if TestPath=$(findmnt --noheadings --output SOURCE,FSTYPE --target "$1" --uniq); then
 		echo "${TestPath}"
+	else
+		echo "Bud Path: $1" >&2; exit 1
 	fi
 } # GetDevice
 

--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -503,13 +503,21 @@ ProcessStats() {
 } # ProcessStats
 
 MonitorIO() {
-	LastPagesOut=$(awk -F" " '/pgpgout/ {print $2}' </proc/vmstat)
-	LastWrite=$(awk -F" " "/ $1 / {print \$8}" </proc/diskstats)
+	LastPagesOut=$(awk '/pgpgout/ {print $2}' </proc/vmstat)
+	if grep -q "$1" /proc/diskstats; then
+		LastWrite=$(awk -v d="$1" '{if($3 == d) print $8}' </proc/diskstats)
+	else
+		echo "Bud argument: [$1]"
+		echo "Disks valid for monitoring: $(
+			awk '{if($8 != 0) printf "%s ", $3}' /proc/diskstats
+			)"
+		exit 1
+	fi
 	LastTimeChecked=$(date "+%s")
 	while true ; do
-		CurrentWrite=$(awk -F" " "/ $1 / {print \$8}" </proc/diskstats)
+		CurrentWrite=$(awk -v d="$1" '{if($3 == d) print $8}' </proc/diskstats)
 		if [ ${CurrentWrite} -gt ${LastWrite} ]; then
-			PagesOut=$(awk -F" " '/pgpgout/ {print $2}' </proc/vmstat)
+			PagesOut=$(awk '/pgpgout/ {print $2}' </proc/vmstat)
 			TimeNow=$(date "+%s")
 			PagesWritten=$((CurrentWrite - LastWrite))
 			PageOuts=$((PagesOut - LastPagesOut))


### PR DESCRIPTION
# Description

Fix: Uniquely determine the mount point in GetDevice
fix: pass an argument to the awk script as a variable
MonitorIO: Add an argument check and a hint to the user