### PR TITLE
rtlwifi: Make different MAC for if1

### DIFF
--- a/patch/misc/wireless-rtl8188eu-Make-different-MAC-for-if1.patch
+++ b/patch/misc/wireless-rtl8188eu-Make-different-MAC-for-if1.patch
@@ -1,0 +1,26 @@
+From a6acdedc2b194f36f089630fb966b56408623c99 Mon Sep 17 00:00:00 2001
+From: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+Date: Thu, 19 Jan 2023 22:41:55 +0000
+Subject: [PATCH] Make different MAC for if1
+
+Signed-off-by: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+---
+ drivers/net/wireless/rtl8188eu/os_dep/linux/os_intfs.c | 2 +-
+ 1 files changed, 1 insertions(+), 1 deletions(-)
+
+diff --git a/drivers/net/wireless/rtl8188eu/os_dep/linux/os_intfs.c b/drivers/net/wireless/rtl8188eu/os_dep/linux/os_intfs.c
+index adc1963c2..d6f33a244 100644
+--- a/drivers/net/wireless/rtl8188eu/os_dep/linux/os_intfs.c
++++ b/drivers/net/wireless/rtl8188eu/os_dep/linux/os_intfs.c
+@@ -3012,7 +3012,7 @@ _adapter *rtw_drv_add_vir_if(_adapter *primary_padapter,
+ 	* If it is 1, the address is locally administered
+ 	*/
+ 	mac[0] |= BIT(1);
+-	if (padapter->iface_id > IFACE_ID1)
++	if (padapter->iface_id >= IFACE_ID1)
+ 		mac[4] ^= BIT(padapter->iface_id);
+ 
+ 	_rtw_memcpy(adapter_mac_addr(padapter), mac, ETH_ALEN);
+
+-- 
+Created with Armbian build tools https://github.com/armbian/build

--- a/patch/misc/wireless-rtl8189es-Make-different-MAC-for-if1.patch
+++ b/patch/misc/wireless-rtl8189es-Make-different-MAC-for-if1.patch
@@ -1,0 +1,26 @@
+From a6acdedc2b194f36f089630fb966b56408623c99 Mon Sep 17 00:00:00 2001
+From: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+Date: Thu, 19 Jan 2023 22:41:55 +0000
+Subject: [PATCH] Make different MAC for if1
+
+Signed-off-by: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+---
+ drivers/net/wireless/rtl8189es/os_dep/linux/os_intfs.c | 2 +-
+ 1 files changed, 1 insertions(+), 1 deletions(-)
+
+diff --git a/drivers/net/wireless/rtl8189es/os_dep/linux/os_intfs.c b/drivers/net/wireless/rtl8189es/os_dep/linux/os_intfs.c
+index bb4c5609f..f503fedc7 100644
+--- a/drivers/net/wireless/rtl8189es/os_dep/linux/os_intfs.c
++++ b/drivers/net/wireless/rtl8189es/os_dep/linux/os_intfs.c
+@@ -3145,7 +3145,7 @@ _adapter *rtw_drv_add_vir_if(_adapter *primary_padapter,
+ 	* If it is 1, the address is locally administered
+ 	*/
+ 	mac[0] |= BIT(1);
+-	if (padapter->iface_id > IFACE_ID1)
++	if (padapter->iface_id >= IFACE_ID1)
+ 		mac[4] ^= BIT(padapter->iface_id);
+ 
+ 	_rtw_memcpy(adapter_mac_addr(padapter), mac, ETH_ALEN);
+
+-- 
+Created with Armbian build tools https://github.com/armbian/build

--- a/patch/misc/wireless-rtl8192eu-Make-different-MAC-for-if1.patch
+++ b/patch/misc/wireless-rtl8192eu-Make-different-MAC-for-if1.patch
@@ -1,0 +1,26 @@
+From a6acdedc2b194f36f089630fb966b56408623c99 Mon Sep 17 00:00:00 2001
+From: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+Date: Thu, 19 Jan 2023 22:41:55 +0000
+Subject: [PATCH] Make different MAC for if1
+
+Signed-off-by: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+---
+ drivers/net/wireless/rtl8192eu/os_dep/linux/os_intfs.c | 2 +-
+ 1 files changed, 1 insertions(+), 1 deletions(-)
+
+diff --git a/drivers/net/wireless/rtl8192eu/os_dep/linux/os_intfs.c b/drivers/net/wireless/rtl8192eu/os_dep/linux/os_intfs.c
+index 1630e7820..108df75c1 100644
+--- a/drivers/net/wireless/rtl8192eu/os_dep/linux/os_intfs.c
++++ b/drivers/net/wireless/rtl8192eu/os_dep/linux/os_intfs.c
+@@ -2854,7 +2854,7 @@ _adapter *rtw_drv_add_vir_if(_adapter *primary_padapter,
+ 	* If it is 1, the address is locally administered
+ 	*/
+ 	mac[0] |= BIT(1);
+-	if (padapter->iface_id > IFACE_ID1)
++	if (padapter->iface_id >= IFACE_ID1)
+ 		mac[4] ^= BIT(padapter->iface_id);
+ 
+ 	memcpy(adapter_mac_addr(padapter), mac, ETH_ALEN);
+
+-- 
+Created with Armbian build tools https://github.com/armbian/build

--- a/patch/misc/wireless-rtl8723ds-Make-different-MAC-for-if1.patch
+++ b/patch/misc/wireless-rtl8723ds-Make-different-MAC-for-if1.patch
@@ -1,0 +1,26 @@
+From a6acdedc2b194f36f089630fb966b56408623c99 Mon Sep 17 00:00:00 2001
+From: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+Date: Thu, 19 Jan 2023 22:41:55 +0000
+Subject: [PATCH] Make different MAC for if1
+
+Signed-off-by: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+---
+ drivers/net/wireless/rtl8723ds/os_dep/linux/os_intfs.c | 2 +-
+ 1 files changed, 1 insertions(+), 1 deletions(-)
+
+diff --git a/drivers/net/wireless/rtl8723ds/os_dep/linux/os_intfs.c b/drivers/net/wireless/rtl8723ds/os_dep/linux/os_intfs.c
+index 76510e94e..29330c942 100644
+--- a/drivers/net/wireless/rtl8723ds/os_dep/linux/os_intfs.c
++++ b/drivers/net/wireless/rtl8723ds/os_dep/linux/os_intfs.c
+@@ -2409,7 +2409,7 @@ _adapter *rtw_drv_add_vir_if(_adapter *primary_padapter,
+ 	* If it is 1, the address is locally administered
+ 	*/
+ 	mac[0] |= BIT(1);
+-	if (padapter->iface_id > IFACE_ID1)
++	if (padapter->iface_id >= IFACE_ID1)
+ 		mac[4] ^= BIT(padapter->iface_id);
+ 
+ 	_rtw_memcpy(adapter_mac_addr(padapter), mac, ETH_ALEN);
+
+-- 
+Created with Armbian build tools https://github.com/armbian/build

--- a/patch/misc/wireless-rtl8811cu-Make-different-MAC-for-if1.patch
+++ b/patch/misc/wireless-rtl8811cu-Make-different-MAC-for-if1.patch
@@ -1,0 +1,25 @@
+From a6acdedc2b194f36f089630fb966b56408623c99 Mon Sep 17 00:00:00 2001
+From: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+Date: Thu, 19 Jan 2023 22:41:55 +0000
+Subject: [PATCH] Make different MAC for if1
+
+Signed-off-by: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+---
+ drivers/net/wireless/rtl8811cu/os_dep/linux/os_intfs.c | 2 +-
+ 1 files changed, 1 insertions(+), 1 deletions(-)
+
+diff --git a/drivers/net/wireless/rtl8811cu/os_dep/linux/os_intfs.c b/drivers/net/wireless/rtl8811cu/os_dep/linux/os_intfs.c
+index 67bef7886..e740fa5ed 100644
+--- a/drivers/net/wireless/rtl8811cu/os_dep/linux/os_intfs.c
++++ b/drivers/net/wireless/rtl8811cu/os_dep/linux/os_intfs.c
+@@ -3472,7 +3472,7 @@ _adapter *rtw_drv_add_vir_if(_adapter *primary_padapter,
+ 	* If it is 1, the address is locally administered
+ 	*/
+ 	mac[0] |= BIT(1);
+-	if (padapter->iface_id > IFACE_ID1)
++	if (padapter->iface_id >= IFACE_ID1)
+ 		mac[0] ^= ((padapter->iface_id)<<2);
+ 	}
+
+-- 
+Created with Armbian build tools https://github.com/armbian/build

--- a/patch/misc/wireless-rtl8812au-Make-different-MAC-for-if1.patch
+++ b/patch/misc/wireless-rtl8812au-Make-different-MAC-for-if1.patch
@@ -1,0 +1,26 @@
+From a6acdedc2b194f36f089630fb966b56408623c99 Mon Sep 17 00:00:00 2001
+From: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+Date: Thu, 19 Jan 2023 22:41:55 +0000
+Subject: [PATCH] Make different MAC for if1
+
+Signed-off-by: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+---
+ drivers/net/wireless/rtl8812au/os_dep/linux/os_intfs.c | 2 +-
+ 1 files changed, 1 insertions(+), 1 deletions(-)
+ 
+diff --git a/drivers/net/wireless/rtl8812au/os_dep/linux/os_intfs.c b/drivers/net/wireless/rtl8812au/os_dep/linux/os_intfs.c
+index 8aa7a212c..297025b1c 100644
+--- a/drivers/net/wireless/rtl8812au/os_dep/linux/os_intfs.c
++++ b/drivers/net/wireless/rtl8812au/os_dep/linux/os_intfs.c
+@@ -2932,7 +2932,7 @@ _adapter *rtw_drv_add_vir_if(_adapter *primary_padapter,
+ 	* If it is 1, the address is locally administered
+ 	*/
+ 	mac[0] |= BIT(1);
+-	if (padapter->iface_id > IFACE_ID1)
++	if (padapter->iface_id >= IFACE_ID1)
+ 		mac[4] ^= BIT(padapter->iface_id);
+ 
+ 	_rtw_memcpy(adapter_mac_addr(padapter), mac, ETH_ALEN);
+
+-- 
+Created with Armbian build tools https://github.com/armbian/build

--- a/patch/misc/wireless-rtl8822bs-Make-different-MAC-for-if1.patch
+++ b/patch/misc/wireless-rtl8822bs-Make-different-MAC-for-if1.patch
@@ -1,0 +1,26 @@
+From a6acdedc2b194f36f089630fb966b56408623c99 Mon Sep 17 00:00:00 2001
+From: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+Date: Thu, 19 Jan 2023 22:41:55 +0000
+Subject: [PATCH] Make different MAC for if1
+
+Signed-off-by: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+---
+ drivers/net/wireless/rtl8822bs/os_dep/linux/os_intfs.c | 2 +-
+ 1 files changed, 1 insertions(+), 1 deletions(-)
+
+diff --git a/drivers/net/wireless/rtl8822bs/os_dep/linux/os_intfs.c b/drivers/net/wireless/rtl8822bs/os_dep/linux/os_intfs.c
+index 7fc4a5eb8..51c286bdf 100644
+--- a/drivers/net/wireless/rtl8822bs/os_dep/linux/os_intfs.c
++++ b/drivers/net/wireless/rtl8822bs/os_dep/linux/os_intfs.c
+@@ -2748,7 +2748,7 @@ _adapter *rtw_drv_add_vir_if(_adapter *primary_padapter,
+ 	* If it is 1, the address is locally administered
+ 	*/
+ 	mac[0] |= BIT(1);
+-	if (padapter->iface_id > IFACE_ID1)
++	if (padapter->iface_id >= IFACE_ID1)
+ 		mac[4] ^= BIT(padapter->iface_id);
+ 
+ 	_rtw_memcpy(adapter_mac_addr(padapter), mac, ETH_ALEN);
+
+-- 
+Created with Armbian build tools https://github.com/armbian/build

--- a/patch/misc/wireless-rtl88x2bu-Make-different-MAC-for-if1.patch
+++ b/patch/misc/wireless-rtl88x2bu-Make-different-MAC-for-if1.patch
@@ -1,0 +1,25 @@
+From a6acdedc2b194f36f089630fb966b56408623c99 Mon Sep 17 00:00:00 2001
+From: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+Date: Thu, 19 Jan 2023 22:41:55 +0000
+Subject: [PATCH] Make different MAC for if1
+
+Signed-off-by: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+---
+ drivers/net/wireless/rtl88x2bu/os_dep/linux/os_intfs.c | 2 +-
+ 1 files changed, 1 insertions(+), 1 deletions(-)
+
+diff --git a/drivers/net/wireless/rtl88x2bu/os_dep/linux/os_intfs.c b/drivers/net/wireless/rtl88x2bu/os_dep/linux/os_intfs.c
+index e2b424932..5cd0c79dd 100644
+--- a/drivers/net/wireless/rtl88x2bu/os_dep/linux/os_intfs.c
++++ b/drivers/net/wireless/rtl88x2bu/os_dep/linux/os_intfs.c
+@@ -3481,7 +3481,7 @@ _adapter *rtw_drv_add_vir_if(_adapter *primary_padapter,
+ 	* If it is 1, the address is locally administered
+ 	*/
+ 	mac[0] |= BIT(1);
+-	if (padapter->iface_id > IFACE_ID1)
++	if (padapter->iface_id >= IFACE_ID1)
+ 		mac[0] ^= ((padapter->iface_id)<<2);
+ 	}
+
+-- 
+Created with Armbian build tools https://github.com/armbian/build

--- a/patch/misc/wireless-rtl88x2cs-Make-different-MAC-for-if1.patch
+++ b/patch/misc/wireless-rtl88x2cs-Make-different-MAC-for-if1.patch
@@ -1,0 +1,26 @@
+From a6acdedc2b194f36f089630fb966b56408623c99 Mon Sep 17 00:00:00 2001
+From: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+Date: Thu, 19 Jan 2023 22:41:55 +0000
+Subject: [PATCH] Make different MAC for if1
+
+Signed-off-by: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+---
+ drivers/net/wireless/rtl88x2cs/os_dep/linux/os_intfs.c | 2 +-
+ 1 files changed, 1 insertions(+), 1 deletions(-)
+ 
+diff --git a/drivers/net/wireless/rtl88x2cs/os_dep/linux/os_intfs.c b/drivers/net/wireless/rtl88x2cs/os_dep/linux/os_intfs.c
+index 6494e2d4e..555fe631c 100644
+--- a/drivers/net/wireless/rtl88x2cs/os_dep/linux/os_intfs.c
++++ b/drivers/net/wireless/rtl88x2cs/os_dep/linux/os_intfs.c
+@@ -3218,7 +3218,7 @@ _adapter *rtw_drv_add_vir_if(_adapter *primary_padapter,
+ 	* If it is 1, the address is locally administered
+ 	*/
+ 	mac[0] |= BIT(1);
+-	if (padapter->iface_id > IFACE_ID1)
++	if (padapter->iface_id >= IFACE_ID1)
+ 		mac[0] ^= ((padapter->iface_id)<<2);
+ 
+ 	_rtw_memcpy(adapter_mac_addr(padapter), mac, ETH_ALEN);
+
+-- 
+Created with Armbian build tools https://github.com/armbian/build


### PR DESCRIPTION
# Description

Backported PR from https://github.com/jwrdegoede/rtl8189ES_linux/pull/89 to all other wifi drivers. (similar to #4662)

**Need to fix, but currently skipped:**
- rtl8723cs: This driver was added to each kernel separately. Impossible to maintain. Need move driver to separated repo and add to the drivers_network.sh.

# How Has This Been Tested?

- [x] It's builds without errors.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
