### PR TITLE
rtlwifi: Fix p2p-go advertising

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -48,6 +48,7 @@ driver_rtl8189ES()
 		sed -i '/source "drivers\/net\/wireless\/ti\/Kconfig"/a source "drivers\/net\/wireless\/rtl8189es\/Kconfig"' \
 			"$kerneldir/drivers/net/wireless/Kconfig"
 
+		process_patch_file "${SRC}/patch/misc/wireless-rtl8189es-Fix-p2p-go-advertising.patch" "applying"
 	fi
 }
 
@@ -125,6 +126,7 @@ driver_rtl8192EU()
 		sed -i '/source "drivers\/net\/wireless\/ti\/Kconfig"/a source "drivers\/net\/wireless\/rtl8192eu\/Kconfig"' \
 			"$kerneldir/drivers/net/wireless/Kconfig"
 
+		process_patch_file "${SRC}/patch/misc/wireless-rtl8192eu-Fix-p2p-go-advertising.patch" "applying"
 	fi
 }
 
@@ -247,6 +249,7 @@ driver_rtl8811CU_rtl8821C()
 		sed -i '/source "drivers\/net\/wireless\/ti\/Kconfig"/a source "drivers\/net\/wireless\/rtl8811cu\/Kconfig"' \
 			"$kerneldir/drivers/net/wireless/Kconfig"
 
+		process_patch_file "${SRC}/patch/misc/wireless-rtl8811cu-Fix-p2p-go-advertising.patch" "applying"
 	fi
 
 }
@@ -295,6 +298,7 @@ driver_rtl8188EU_rtl8188ETV()
 		# add support for K5.12+
 		process_patch_file "${SRC}/patch/misc/wireless-realtek-8188eu-5.12.patch" "applying"
 
+		process_patch_file "${SRC}/patch/misc/wireless-rtl8188eu-Fix-p2p-go-advertising.patch" "applying"
 	fi
 }
 
@@ -335,6 +339,7 @@ driver_rtl88x2bu()
 		sed -i "/source \"drivers\/net\/wireless\/ti\/Kconfig\"/a source \"drivers\/net\/wireless\/rtl88x2bu\/Kconfig\"" \
 			"$kerneldir/drivers/net/wireless/Kconfig"
 
+		process_patch_file "${SRC}/patch/misc/wireless-rtl88x2bu-Fix-p2p-go-advertising.patch" "applying"
 	fi
 
 }
@@ -379,6 +384,8 @@ driver_rtl88x2cs()
 		echo "obj-\$(CONFIG_RTL8822CS) += rtl88x2cs/" >> "$kerneldir/drivers/net/wireless/Makefile"
 		sed -i '/source "drivers\/net\/wireless\/ti\/Kconfig"/a source "drivers\/net\/wireless\/rtl88x2cs\/Kconfig"' \
 			"$kerneldir/drivers/net/wireless/Kconfig"
+
+		process_patch_file "${SRC}/patch/misc/wireless-rtl88x2cs-Fix-p2p-go-advertising.patch" "applying"
 	fi
 }
 #_bt for blueteeth
@@ -432,6 +439,7 @@ driver_rtl8723DS()
 		sed -i '/source "drivers\/net\/wireless\/ti\/Kconfig"/a source "drivers\/net\/wireless\/rtl8723ds\/Kconfig"' \
 			"$kerneldir/drivers/net/wireless/Kconfig"
 
+		process_patch_file "${SRC}/patch/misc/wireless-rtl8723ds-Fix-p2p-go-advertising.patch" "applying"
 	fi
 }
 
@@ -467,6 +475,7 @@ driver_rtl8723DU()
 			"$kerneldir/drivers/net/wireless/Kconfig"
 
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723du-5.19.2.patch" "applying"
+		process_patch_file "${SRC}/patch/misc/wireless-rtl8723du-Fix-p2p-go-advertising.patch" "applying"
 	fi
 }
 
@@ -501,6 +510,7 @@ driver_rtl8822BS()
 		sed -i '/source "drivers\/net\/wireless\/ti\/Kconfig"/a source "drivers\/net\/wireless\/rtl8822bs\/Kconfig"' \
 			"$kerneldir/drivers/net/wireless/Kconfig"
 
+		process_patch_file "${SRC}/patch/misc/wireless-rtl8822bs-Fix-p2p-go-advertising.patch" "applying"
 	fi
 
 }

--- a/patch/misc/wireless-rtl8188eu-Fix-p2p-go-advertising.patch
+++ b/patch/misc/wireless-rtl8188eu-Fix-p2p-go-advertising.patch
@@ -1,0 +1,48 @@
+From dc53976d72d740fd83fc7de434381b8981740da7 Mon Sep 17 00:00:00 2001
+From: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+Date: Fri, 20 Jan 2023 00:00:17 +0000
+Subject: [PATCH] Fix p2p-go advertising
+
+Signed-off-by: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+---
+ .../rtl8188eu/os_dep/linux/ioctl_cfg80211.c   | 18 +++++++++++++++++
+ 1 file changed, 18 insertions(+), 0 deletion(-)
+
+diff --git a/drivers/net/wireless/rtl8188eu/os_dep/linux/ioctl_cfg80211.c b/drivers/net/wireless/rtl8188eu/os_dep/linux/ioctl_cfg80211.c
+index 56f87295e..e8b7da05b 100644
+--- a/drivers/net/wireless/rtl8188eu/os_dep/linux/ioctl_cfg80211.c
++++ b/drivers/net/wireless/rtl8188eu/os_dep/linux/ioctl_cfg80211.c
+@@ -5023,6 +5023,15 @@ static int cfg80211_rtw_start_ap(struct wiphy *wiphy, struct net_device *ndev,
+ 
+ 	adapter->mlmeextpriv.mlmext_info.hidden_ssid_mode = settings->hidden_ssid;
+ 
++	// In cases like WPS, the proberesp and assocresp IEs vary from the beacon, and need to be explicitly set
++	if (ret == 0) {
++		if (settings->beacon.proberesp_ies && settings->beacon.proberesp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) settings->beacon.proberesp_ies, settings->beacon.proberesp_ies_len, 0x2 /*PROBE_RESP*/);
++
++		if (settings->beacon.assocresp_ies && settings->beacon.assocresp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) settings->beacon.assocresp_ies, settings->beacon.assocresp_ies_len, 0x4 /*ASSOC_RESP*/);
++	}
++
+ 	if (settings->ssid && settings->ssid_len) {
+ 		WLAN_BSSID_EX *pbss_network = &adapter->mlmepriv.cur_network.network;
+ 		WLAN_BSSID_EX *pbss_network_ext = &adapter->mlmeextpriv.mlmext_info.network;
+@@ -5057,6 +5066,15 @@ static int cfg80211_rtw_change_beacon(struct wiphy *wiphy, struct net_device *nd
+ 
+ 	ret = rtw_add_beacon(adapter, info->head, info->head_len, info->tail, info->tail_len);
+ 
++	// In cases like WPS, the proberesp and assocresp IEs vary from the beacon, and need to be explicitly set
++	if (ret == 0) {
++		if (info->proberesp_ies && info->proberesp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) info->proberesp_ies, info->proberesp_ies_len, 0x2 /*PROBE_RESP*/);
++
++		if (info->assocresp_ies && info->assocresp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) info->assocresp_ies, info->assocresp_ies_len, 0x4 /*ASSOC_RESP*/);
++	}
++
+ 	return ret;
+ }
+
+-- 
+Created with Armbian build tools https://github.com/armbian/build

--- a/patch/misc/wireless-rtl8189es-Fix-p2p-go-advertising.patch
+++ b/patch/misc/wireless-rtl8189es-Fix-p2p-go-advertising.patch
@@ -1,0 +1,49 @@
+From dc53976d72d740fd83fc7de434381b8981740da7 Mon Sep 17 00:00:00 2001
+From: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+Date: Fri, 20 Jan 2023 00:00:17 +0000
+Subject: [PATCH] Fix p2p-go advertising
+
+Signed-off-by: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+---
+ .../rtl8189es/os_dep/linux/ioctl_cfg80211.c   | 18 +++++++++++++++++
+ 1 file changed, 18 insertions(+), 0 deletion(-)
+
+diff --git a/drivers/net/wireless/rtl8189es/os_dep/linux/ioctl_cfg80211.c b/drivers/net/wireless/rtl8189es/os_dep/linux/ioctl_cfg80211.c
+index 4e810e5c4..d28cb4810 100644
+--- a/drivers/net/wireless/rtl8189es/os_dep/linux/ioctl_cfg80211.c
++++ b/drivers/net/wireless/rtl8189es/os_dep/linux/ioctl_cfg80211.c
+@@ -5122,6 +5122,15 @@ static int cfg80211_rtw_start_ap(struct wiphy *wiphy, struct net_device *ndev,
+ 
+ 	adapter->mlmeextpriv.mlmext_info.hidden_ssid_mode = settings->hidden_ssid;
+ 
++	// In cases like WPS, the proberesp and assocresp IEs vary from the beacon, and need to be explicitly set
++	if (ret == 0) {
++		if (settings->beacon.proberesp_ies && settings->beacon.proberesp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) settings->beacon.proberesp_ies, settings->beacon.proberesp_ies_len, 0x2 /*PROBE_RESP*/);
++
++		if (settings->beacon.assocresp_ies && settings->beacon.assocresp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) settings->beacon.assocresp_ies, settings->beacon.assocresp_ies_len, 0x4 /*ASSOC_RESP*/);
++	}
++
+ 	if (settings->ssid && settings->ssid_len) {
+ 		WLAN_BSSID_EX *pbss_network = &adapter->mlmepriv.cur_network.network;
+ 		WLAN_BSSID_EX *pbss_network_ext = &adapter->mlmeextpriv.mlmext_info.network;
+@@ -5156,6 +5165,15 @@ static int cfg80211_rtw_change_beacon(struct wiphy *wiphy, struct net_device *nd
+ 
+ 	ret = rtw_add_beacon(adapter, info->head, info->head_len, info->tail, info->tail_len);
+ 
++	// In cases like WPS, the proberesp and assocresp IEs vary from the beacon, and need to be explicitly set
++	if (ret == 0) {
++		if (info->proberesp_ies && info->proberesp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) info->proberesp_ies, info->proberesp_ies_len, 0x2 /*PROBE_RESP*/);
++
++		if (info->assocresp_ies && info->assocresp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) info->assocresp_ies, info->assocresp_ies_len, 0x4 /*ASSOC_RESP*/);
++	}
++
+ 	return ret;
+ }
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,19, 2))
+
+-- 
+Created with Armbian build tools https://github.com/armbian/build

--- a/patch/misc/wireless-rtl8192eu-Fix-p2p-go-advertising.patch
+++ b/patch/misc/wireless-rtl8192eu-Fix-p2p-go-advertising.patch
@@ -1,0 +1,48 @@
+From dc53976d72d740fd83fc7de434381b8981740da7 Mon Sep 17 00:00:00 2001
+From: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+Date: Fri, 20 Jan 2023 00:00:17 +0000
+Subject: [PATCH] Fix p2p-go advertising
+
+Signed-off-by: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+---
+ .../rtl8192eu/os_dep/linux/ioctl_cfg80211.c   | 18 +++++++++++++++++
+ 1 file changed, 18 insertions(+), 0 deletion(-)
+
+diff --git a/drivers/net/wireless/rtl8192eu/os_dep/linux/ioctl_cfg80211.c b/drivers/net/wireless/rtl8192eu/os_dep/linux/ioctl_cfg80211.c
+index ead698a79..6f95168f7 100644
+--- a/drivers/net/wireless/rtl8192eu/os_dep/linux/ioctl_cfg80211.c
++++ b/drivers/net/wireless/rtl8192eu/os_dep/linux/ioctl_cfg80211.c
+@@ -5062,6 +5062,15 @@ static int cfg80211_rtw_start_ap(struct wiphy *wiphy, struct net_device *ndev,
+ 
+ 	adapter->mlmeextpriv.mlmext_info.hidden_ssid_mode = settings->hidden_ssid;
+ 
++	// In cases like WPS, the proberesp and assocresp IEs vary from the beacon, and need to be explicitly set
++	if (ret == 0) {
++		if (settings->beacon.proberesp_ies && settings->beacon.proberesp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) settings->beacon.proberesp_ies, settings->beacon.proberesp_ies_len, 0x2 /*PROBE_RESP*/);
++
++		if (settings->beacon.assocresp_ies && settings->beacon.assocresp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) settings->beacon.assocresp_ies, settings->beacon.assocresp_ies_len, 0x4 /*ASSOC_RESP*/);
++	}
++
+ 	if (settings->ssid && settings->ssid_len) {
+ 		WLAN_BSSID_EX *pbss_network = &adapter->mlmepriv.cur_network.network;
+ 		WLAN_BSSID_EX *pbss_network_ext = &adapter->mlmeextpriv.mlmext_info.network;
+@@ -5096,6 +5105,15 @@ static int cfg80211_rtw_change_beacon(struct wiphy *wiphy, struct net_device *nd
+ 
+ 	ret = rtw_add_beacon(adapter, info->head, info->head_len, info->tail, info->tail_len);
+ 
++	// In cases like WPS, the proberesp and assocresp IEs vary from the beacon, and need to be explicitly set
++	if (ret == 0) {
++		if (info->proberesp_ies && info->proberesp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) info->proberesp_ies, info->proberesp_ies_len, 0x2 /*PROBE_RESP*/);
++
++		if (info->assocresp_ies && info->assocresp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) info->assocresp_ies, info->assocresp_ies_len, 0x4 /*ASSOC_RESP*/);
++	}
++
+ 	return ret;
+ }
+
+-- 
+Created with Armbian build tools https://github.com/armbian/build

--- a/patch/misc/wireless-rtl8723ds-Fix-p2p-go-advertising.patch
+++ b/patch/misc/wireless-rtl8723ds-Fix-p2p-go-advertising.patch
@@ -1,0 +1,48 @@
+From dc53976d72d740fd83fc7de434381b8981740da7 Mon Sep 17 00:00:00 2001
+From: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+Date: Fri, 20 Jan 2023 00:00:17 +0000
+Subject: [PATCH] Fix p2p-go advertising
+
+Signed-off-by: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+---
+ .../rtl8723ds/os_dep/linux/ioctl_cfg80211.c   | 18 +++++++++++++++++
+ 1 file changed, 18 insertions(+), 0 deletion(-)
+
+diff --git a/drivers/net/wireless/rtl8723ds/os_dep/linux/ioctl_cfg80211.c b/drivers/net/wireless/rtl8723ds/os_dep/linux/ioctl_cfg80211.c
+index 4fff23a56..3bc08b779 100644
+--- a/drivers/net/wireless/rtl8723ds/os_dep/linux/ioctl_cfg80211.c
++++ b/drivers/net/wireless/rtl8723ds/os_dep/linux/ioctl_cfg80211.c
+@@ -4168,6 +4168,15 @@ static int cfg80211_rtw_start_ap(struct wiphy *wiphy, struct net_device *ndev,
+ 
+ 	adapter->mlmeextpriv.mlmext_info.hidden_ssid_mode = settings->hidden_ssid;
+ 
++	// In cases like WPS, the proberesp and assocresp IEs vary from the beacon, and need to be explicitly set
++	if (ret == 0) {
++		if (settings->beacon.proberesp_ies && settings->beacon.proberesp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) settings->beacon.proberesp_ies, settings->beacon.proberesp_ies_len, 0x2 /*PROBE_RESP*/);
++
++		if (settings->beacon.assocresp_ies && settings->beacon.assocresp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) settings->beacon.assocresp_ies, settings->beacon.assocresp_ies_len, 0x4 /*ASSOC_RESP*/);
++	}
++
+ 	if (settings->ssid && settings->ssid_len) {
+ 		WLAN_BSSID_EX *pbss_network = &adapter->mlmepriv.cur_network.network;
+ 		WLAN_BSSID_EX *pbss_network_ext = &adapter->mlmeextpriv.mlmext_info.network;
+@@ -4201,6 +4210,15 @@ static int cfg80211_rtw_change_beacon(struct wiphy *wiphy, struct net_device *nd
+ 
+ 	ret = rtw_add_beacon(adapter, info->head, info->head_len, info->tail, info->tail_len);
+ 
++	// In cases like WPS, the proberesp and assocresp IEs vary from the beacon, and need to be explicitly set
++	if (ret == 0) {
++		if (info->proberesp_ies && info->proberesp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) info->proberesp_ies, info->proberesp_ies_len, 0x2 /*PROBE_RESP*/);
++
++		if (info->assocresp_ies && info->assocresp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) info->assocresp_ies, info->assocresp_ies_len, 0x4 /*ASSOC_RESP*/);
++	}
++
+ 	return ret;
+ }
+
+-- 
+Created with Armbian build tools https://github.com/armbian/build

--- a/patch/misc/wireless-rtl8723du-Fix-p2p-go-advertising.patch
+++ b/patch/misc/wireless-rtl8723du-Fix-p2p-go-advertising.patch
@@ -1,0 +1,48 @@
+From dc53976d72d740fd83fc7de434381b8981740da7 Mon Sep 17 00:00:00 2001
+From: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+Date: Fri, 20 Jan 2023 00:00:17 +0000
+Subject: [PATCH] Fix p2p-go advertising
+
+Signed-off-by: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+---
+ .../rtl8723ds/os_dep/linux/ioctl_cfg80211.c   | 18 +++++++++++++++++
+ 1 file changed, 18 insertions(+), 0 deletion(-)
+
+diff --git a/drivers/net/wireless/rtl8723du/os_dep/ioctl_cfg80211.c b/drivers/net/wireless/rtl8723du/os_dep/ioctl_cfg80211.c
+index 64541a364..0dfd41477 100644
+--- a/drivers/net/wireless/rtl8723du/os_dep/ioctl_cfg80211.c
++++ b/drivers/net/wireless/rtl8723du/os_dep/ioctl_cfg80211.c
+@@ -3777,6 +3777,15 @@ static int cfg80211_rtw_start_ap(struct wiphy *wiphy, struct net_device *ndev,
+ 
+ 	adapter->mlmeextpriv.mlmext_info.hidden_ssid_mode = settings->hidden_ssid;
+ 
++	// In cases like WPS, the proberesp and assocresp IEs vary from the beacon, and need to be explicitly set
++	if (ret == 0) {
++		if (settings->beacon.proberesp_ies && settings->beacon.proberesp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) settings->beacon.proberesp_ies, settings->beacon.proberesp_ies_len, 0x2 /*PROBE_RESP*/);
++
++		if (settings->beacon.assocresp_ies && settings->beacon.assocresp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) settings->beacon.assocresp_ies, settings->beacon.assocresp_ies_len, 0x4 /*ASSOC_RESP*/);
++	}
++
+ 	if (settings->ssid && settings->ssid_len) {
+ 		struct wlan_bssid_ex *pbss_network = &adapter->mlmepriv.cur_network.network;
+ 		struct wlan_bssid_ex *pbss_network_ext = &adapter->mlmeextpriv.mlmext_info.network;
+@@ -3801,6 +3810,15 @@ static int cfg80211_rtw_change_beacon(struct wiphy *wiphy, struct net_device *nd
+ 
+ 	ret = rtw_add_beacon(adapter, info->head, info->head_len, info->tail, info->tail_len);
+ 
++	// In cases like WPS, the proberesp and assocresp IEs vary from the beacon, and need to be explicitly set
++	if (ret == 0) {
++		if (info->proberesp_ies && info->proberesp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) info->proberesp_ies, info->proberesp_ies_len, 0x2 /*PROBE_RESP*/);
++
++		if (info->assocresp_ies && info->assocresp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) info->assocresp_ies, info->assocresp_ies_len, 0x4 /*ASSOC_RESP*/);
++	}
++
+ 	return ret;
+ }
+
+-- 
+Created with Armbian build tools https://github.com/armbian/build

--- a/patch/misc/wireless-rtl8811cu-Fix-p2p-go-advertising.patch
+++ b/patch/misc/wireless-rtl8811cu-Fix-p2p-go-advertising.patch
@@ -1,0 +1,48 @@
+From dc53976d72d740fd83fc7de434381b8981740da7 Mon Sep 17 00:00:00 2001
+From: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+Date: Fri, 20 Jan 2023 00:00:17 +0000
+Subject: [PATCH] Fix p2p-go advertising
+
+Signed-off-by: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+---
+ .../rtl8811cu/os_dep/linux/ioctl_cfg80211.c   | 18 +++++++++++++++++
+ 1 file changed, 18 insertions(+), 0 deletion(-)
+
+diff --git a/drivers/net/wireless/rtl8811cu/os_dep/linux/ioctl_cfg80211.c b/drivers/net/wireless/rtl8811cu/os_dep/linux/ioctl_cfg80211.c
+index 7e7849ca6..d1f4dedfa 100755
+--- a/drivers/net/wireless/rtl8811cu/os_dep/linux/ioctl_cfg80211.c
++++ b/drivers/net/wireless/rtl8811cu/os_dep/linux/ioctl_cfg80211.c
+@@ -5359,6 +5359,15 @@ static int cfg80211_rtw_start_ap(struct wiphy *wiphy, struct net_device *ndev,
+ 	ret = rtw_add_beacon(adapter, settings->beacon.head, settings->beacon.head_len,
+ 		settings->beacon.tail, settings->beacon.tail_len);
+ 
++	// In cases like WPS, the proberesp and assocresp IEs vary from the beacon, and need to be explicitly set
++	if (ret == 0) {
++		if (settings->beacon.proberesp_ies && settings->beacon.proberesp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) settings->beacon.proberesp_ies, settings->beacon.proberesp_ies_len, 0x2 /*PROBE_RESP*/);
++
++		if (settings->beacon.assocresp_ies && settings->beacon.assocresp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) settings->beacon.assocresp_ies, settings->beacon.assocresp_ies_len, 0x4 /*ASSOC_RESP*/);
++	}
++
+ 	if (settings->ssid && settings->ssid_len) {
+ 		WLAN_BSSID_EX *pbss_network = &adapter->mlmepriv.cur_network.network;
+ 		WLAN_BSSID_EX *pbss_network_ext = &adapter->mlmeextpriv.mlmext_info.network;
+@@ -5393,6 +5402,15 @@ static int cfg80211_rtw_change_beacon(struct wiphy *wiphy, struct net_device *nd
+ 
+ 	ret = rtw_add_beacon(adapter, info->head, info->head_len, info->tail, info->tail_len);
+ 
++	// In cases like WPS, the proberesp and assocresp IEs vary from the beacon, and need to be explicitly set
++	if (ret == 0) {
++		if (info->proberesp_ies && info->proberesp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) info->proberesp_ies, info->proberesp_ies_len, 0x2 /*PROBE_RESP*/);
++
++		if (info->assocresp_ies && info->assocresp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) info->assocresp_ies, info->assocresp_ies_len, 0x4 /*ASSOC_RESP*/);
++	}
++
+ 	return ret;
+ }
+
+-- 
+Created with Armbian build tools https://github.com/armbian/build

--- a/patch/misc/wireless-rtl8822bs-Fix-p2p-go-advertising.patch
+++ b/patch/misc/wireless-rtl8822bs-Fix-p2p-go-advertising.patch
@@ -1,0 +1,48 @@
+From dc53976d72d740fd83fc7de434381b8981740da7 Mon Sep 17 00:00:00 2001
+From: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+Date: Fri, 20 Jan 2023 00:00:17 +0000
+Subject: [PATCH] Fix p2p-go advertising
+
+Signed-off-by: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+---
+ .../rtl8822bs/os_dep/linux/ioctl_cfg80211.c   | 18 +++++++++++++++++
+ 1 file changed, 18 insertions(+), 0 deletion(-)
+
+diff --git a/drivers/net/wireless/rtl8822bs/os_dep/linux/ioctl_cfg80211.c b/drivers/net/wireless/rtl8822bs/os_dep/linux/ioctl_cfg80211.c
+index 23f9409e5..661010e19 100644
+--- a/drivers/net/wireless/rtl8822bs/os_dep/linux/ioctl_cfg80211.c
++++ b/drivers/net/wireless/rtl8822bs/os_dep/linux/ioctl_cfg80211.c
+@@ -4601,6 +4601,15 @@ static int cfg80211_rtw_start_ap(struct wiphy *wiphy, struct net_device *ndev,
+ 
+ 	adapter->mlmeextpriv.mlmext_info.hidden_ssid_mode = settings->hidden_ssid;
+ 
++	// In cases like WPS, the proberesp and assocresp IEs vary from the beacon, and need to be explicitly set
++	if (ret == 0) {
++		if (settings->beacon.proberesp_ies && settings->beacon.proberesp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) settings->beacon.proberesp_ies, settings->beacon.proberesp_ies_len, 0x2 /*PROBE_RESP*/);
++
++		if (settings->beacon.assocresp_ies && settings->beacon.assocresp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) settings->beacon.assocresp_ies, settings->beacon.assocresp_ies_len, 0x4 /*ASSOC_RESP*/);
++	}
++
+ 	if (settings->ssid && settings->ssid_len) {
+ 		WLAN_BSSID_EX *pbss_network = &adapter->mlmepriv.cur_network.network;
+ 		WLAN_BSSID_EX *pbss_network_ext = &adapter->mlmeextpriv.mlmext_info.network;
+@@ -4635,6 +4644,15 @@ static int cfg80211_rtw_change_beacon(struct wiphy *wiphy, struct net_device *nd
+ 
+ 	ret = rtw_add_beacon(adapter, info->head, info->head_len, info->tail, info->tail_len);
+ 
++	// In cases like WPS, the proberesp and assocresp IEs vary from the beacon, and need to be explicitly set
++	if (ret == 0) {
++		if (info->proberesp_ies && info->proberesp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) info->proberesp_ies, info->proberesp_ies_len, 0x2 /*PROBE_RESP*/);
++
++		if (info->assocresp_ies && info->assocresp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) info->assocresp_ies, info->assocresp_ies_len, 0x4 /*ASSOC_RESP*/);
++	}
++
+ 	return ret;
+ }
+
+-- 
+Created with Armbian build tools https://github.com/armbian/build

--- a/patch/misc/wireless-rtl88x2bu-Fix-p2p-go-advertising.patch
+++ b/patch/misc/wireless-rtl88x2bu-Fix-p2p-go-advertising.patch
@@ -1,0 +1,48 @@
+From dc53976d72d740fd83fc7de434381b8981740da7 Mon Sep 17 00:00:00 2001
+From: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+Date: Fri, 20 Jan 2023 00:00:17 +0000
+Subject: [PATCH] Fix p2p-go advertising
+
+Signed-off-by: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+---
+ .../rtl88x2bu/os_dep/linux/ioctl_cfg80211.c   | 18 +++++++++++++++++
+ 1 file changed, 18 insertions(+), 0 deletion(-)
+
+diff --git a/drivers/net/wireless/rtl88x2bu/os_dep/linux/ioctl_cfg80211.c b/drivers/net/wireless/rtl88x2bu/os_dep/linux/ioctl_cfg80211.c
+index 5dfa3e138..b1259202a 100644
+--- a/drivers/net/wireless/rtl88x2bu/os_dep/linux/ioctl_cfg80211.c
++++ b/drivers/net/wireless/rtl88x2bu/os_dep/linux/ioctl_cfg80211.c
+@@ -5371,6 +5371,15 @@ static int cfg80211_rtw_start_ap(struct wiphy *wiphy, struct net_device *ndev,
+ 	ret = rtw_add_beacon(adapter, settings->beacon.head, settings->beacon.head_len,
+ 		settings->beacon.tail, settings->beacon.tail_len);
+ 
++	// In cases like WPS, the proberesp and assocresp IEs vary from the beacon, and need to be explicitly set
++	if (ret == 0) {
++		if (settings->beacon.proberesp_ies && settings->beacon.proberesp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) settings->beacon.proberesp_ies, settings->beacon.proberesp_ies_len, 0x2 /*PROBE_RESP*/);
++
++		if (settings->beacon.assocresp_ies && settings->beacon.assocresp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) settings->beacon.assocresp_ies, settings->beacon.assocresp_ies_len, 0x4 /*ASSOC_RESP*/);
++	}
++
+ 	if (settings->ssid && settings->ssid_len) {
+ 		WLAN_BSSID_EX *pbss_network = &adapter->mlmepriv.cur_network.network;
+ 		WLAN_BSSID_EX *pbss_network_ext = &adapter->mlmeextpriv.mlmext_info.network;
+@@ -5405,6 +5414,15 @@ static int cfg80211_rtw_change_beacon(struct wiphy *wiphy, struct net_device *nd
+ 
+ 	ret = rtw_add_beacon(adapter, info->head, info->head_len, info->tail, info->tail_len);
+ 
++	// In cases like WPS, the proberesp and assocresp IEs vary from the beacon, and need to be explicitly set
++	if (ret == 0) {
++		if (info->proberesp_ies && info->proberesp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) info->proberesp_ies, info->proberesp_ies_len, 0x2 /*PROBE_RESP*/);
++
++		if (info->assocresp_ies && info->assocresp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) info->assocresp_ies, info->assocresp_ies_len, 0x4 /*ASSOC_RESP*/);
++	}
++
+ 	return ret;
+ }
+
+-- 
+Created with Armbian build tools https://github.com/armbian/build

--- a/patch/misc/wireless-rtl88x2cs-Fix-p2p-go-advertising.patch
+++ b/patch/misc/wireless-rtl88x2cs-Fix-p2p-go-advertising.patch
@@ -1,0 +1,48 @@
+From dc53976d72d740fd83fc7de434381b8981740da7 Mon Sep 17 00:00:00 2001
+From: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+Date: Fri, 20 Jan 2023 00:00:17 +0000
+Subject: [PATCH] Fix p2p-go advertising
+
+Signed-off-by: Kirill Zhumarin <kirill.zhumarin@gmail.com>
+---
+ .../rtl88x2cs/os_dep/linux/ioctl_cfg80211.c   | 18 +++++++++++++++++
+ 1 file changed, 18 insertions(+), 0 deletion(-)
+
+diff --git a/drivers/net/wireless/rtl88x2cs/os_dep/linux/ioctl_cfg80211.c b/drivers/net/wireless/rtl88x2cs/os_dep/linux/ioctl_cfg80211.c
+index 452d93ab6..cc888bf5f 100755
+--- a/drivers/net/wireless/rtl88x2cs/os_dep/linux/ioctl_cfg80211.c
++++ b/drivers/net/wireless/rtl88x2cs/os_dep/linux/ioctl_cfg80211.c
+@@ -5494,6 +5494,15 @@ static int cfg80211_rtw_start_ap(struct wiphy *wiphy, struct net_device *ndev,
+ 	ret = rtw_add_beacon(adapter, settings->beacon.head, settings->beacon.head_len,
+ 		settings->beacon.tail, settings->beacon.tail_len);
+ 
++	// In cases like WPS, the proberesp and assocresp IEs vary from the beacon, and need to be explicitly set
++	if (ret == 0) {
++		if (settings->beacon.proberesp_ies && settings->beacon.proberesp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) settings->beacon.proberesp_ies, settings->beacon.proberesp_ies_len, 0x2 /*PROBE_RESP*/);
++
++		if (settings->beacon.assocresp_ies && settings->beacon.assocresp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) settings->beacon.assocresp_ies, settings->beacon.assocresp_ies_len, 0x4 /*ASSOC_RESP*/);
++	}
++
+ 	if (settings->ssid && settings->ssid_len) {
+ 		WLAN_BSSID_EX *pbss_network = &adapter->mlmepriv.cur_network.network;
+ 		WLAN_BSSID_EX *pbss_network_ext = &adapter->mlmeextpriv.mlmext_info.network;
+@@ -5528,6 +5537,15 @@ static int cfg80211_rtw_change_beacon(struct wiphy *wiphy, struct net_device *nd
+ 
+ 	ret = rtw_add_beacon(adapter, info->head, info->head_len, info->tail, info->tail_len);
+ 
++	// In cases like WPS, the proberesp and assocresp IEs vary from the beacon, and need to be explicitly set
++	if (ret == 0) {
++		if (info->proberesp_ies && info->proberesp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) info->proberesp_ies, info->proberesp_ies_len, 0x2 /*PROBE_RESP*/);
++
++		if (info->assocresp_ies && info->assocresp_ies_len > 0)
++			rtw_cfg80211_set_mgnt_wpsp2pie(ndev, (char *) info->assocresp_ies, info->assocresp_ies_len, 0x4 /*ASSOC_RESP*/);
++	}
++
+ 	return ret;
+ }
+
+-- 
+Created with Armbian build tools https://github.com/armbian/build


### PR DESCRIPTION
# Description

Backported PR from https://github.com/jwrdegoede/rtl8189ES_linux/pull/87 to all other wifi drivers. (similar to #4661)

**Need to fix, but currently skipped:**
- rtl8723cs: This driver was added to each kernel separately. Impossible to maintain. Need move driver to separated repo and add to the drivers_network.sh.
- rtl8723bs: have different code base, can't easily be ported.

# How Has This Been Tested?

- [x] It's builds without errors.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
