### PR TITLE
clean: remove unused code, replaced df with findmnt

### DIFF
--- a/packages/bsp/common/etc/kernel/postinst.d/xx-initramfs-cleanup
+++ b/packages/bsp/common/etc/kernel/postinst.d/xx-initramfs-cleanup
@@ -1,7 +1,5 @@
 #!/bin/sh
-
-[ -x /usr/sbin/update-initramfs ] || exit 0
-
+# echo "DEBUG: postinst: initramfs-clean: cmd: $@" >&2
 # avoid running multiple times
 # This script should be run after the initramfs-tools script
 # and under the same conditions.
@@ -12,18 +10,16 @@ if [ -n "$DEB_MAINT_PARAMS" ]; then
 	fi
 fi
 
-MOD_DIR=/lib/modules/
-
 files="$(find /boot -maxdepth 1 -name 'initrd.img-*' -o -name 'uInitrd-*')"
 
 for f in $files; do
-	if [ ! -d "$MOD_DIR${f#*-}" ]; then
+	if [ ! -d /lib/modules/"${f#*-}" ]; then
 		echo "Remove unused generated file: $f"; rm $f
 	fi
 done
 
 check_boot_dev (){
-	available_size_boot_device=$(df -h | awk '/boot$/{print $4}')
+	available_size_boot_device=$(findmnt --noheadings --output AVAIL --target /boot)
 	echo "Free space after deleting the package $DPKG_MAINTSCRIPT_PACKAGE in /boot: $available_size_boot_device" >&2
 }
 mountpoint -q /boot && check_boot_dev

--- a/packages/bsp/common/etc/kernel/postrm.d/xx-initramfs-cleanup
+++ b/packages/bsp/common/etc/kernel/postrm.d/xx-initramfs-cleanup
@@ -1,15 +1,5 @@
 #!/bin/sh
-
-version="$1"
-
-[ -x /usr/sbin/update-initramfs ] || exit 0
-
-# passing the kernel version is required
-if [ -z "$version" ]; then
-	echo >&2 "W: initramfs-tools: ${DPKG_MAINTSCRIPT_PACKAGE:-kernel package} did not pass a version number"
-	exit 0
-fi
-
+# echo "DEBUG: POSTRM: initramfs-clean: cmd: $@" >&2
 # avoid running multiple times
 # This script should be run after the initramfs-tools script
 # and under the same conditions.
@@ -20,8 +10,6 @@ if [ -n "$DEB_MAINT_PARAMS" ]; then
 	fi
 fi
 
-MOD_DIR=/lib/modules/
-
 files="$(find /boot -maxdepth 1 -name 'initrd.img-*' -o -name 'uInitrd-*')"
 
 for f in $files; do
@@ -31,7 +19,7 @@ for f in $files; do
 done
 
 check_boot_dev (){
-	available_size_boot_device=$(df -h | awk '/boot$/{print $4}')
+	available_size_boot_device=$(findmnt --noheadings --output AVAIL --target /boot)
 	echo "Free space after deleting the package $DPKG_MAINTSCRIPT_PACKAGE in /boot: $available_size_boot_device" >&2
 }
 mountpoint -q /boot && check_boot_dev


### PR DESCRIPTION
# Description

Clear the code for system scripts:
- /etc/kernel/postrm.d/xx-initramfs-cleanup
- /etc/kernel/postinst.d/xx-initramfs-cleanup

Split Pull Request [#4691]

# Checklist:

- [x] Tested on the bananapim64 device of the jammy OS
- [x] Test on a device with a separate partition `/boot` OS debian
