### PR TITLE
Fix armbianmonitor if used (-d, -c) key

### DIFF
--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -1039,13 +1039,10 @@ ShowDeviceWarning() {
 } # ShowDeviceWarning
 
 GetDevice() {
-	TestPath=$(findmnt "$1" | awk -F" " '/\/dev\// {print $2"\t"$3}')
-	if [[ -z ${TestPath} && -n "${1%/*}" ]]; then
-		GetDevice "${1%/*}"
-	elif [[ -z ${TestPath} && -z "${1%/*}" ]]; then
-		findmnt / | awk -F" " '/\/dev\// {print $2"\t"$3}'
-	else
+	if TestPath=$(findmnt --noheadings --output SOURCE,FSTYPE --target "$1" --uniq); then
 		echo "${TestPath}"
+	else
+		echo "Bud Path: $1" >&2; exit 1
 	fi
 } # GetDevice
 

--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -503,13 +503,21 @@ ProcessStats() {
 } # ProcessStats
 
 MonitorIO() {
-	LastPagesOut=$(awk -F" " '/pgpgout/ {print $2}' </proc/vmstat)
-	LastWrite=$(awk -F" " "/ $1 / {print \$8}" </proc/diskstats)
+	LastPagesOut=$(awk '/pgpgout/ {print $2}' </proc/vmstat)
+	if grep -q "$1" /proc/diskstats; then
+		LastWrite=$(awk -v d="$1" '{if($3 == d) print $8}' </proc/diskstats)
+	else
+		echo "Bud argument: [$1]"
+		echo "Disks valid for monitoring: $(
+			awk '{if($8 != 0) printf "%s ", $3}' /proc/diskstats
+			)"
+		exit 1
+	fi
 	LastTimeChecked=$(date "+%s")
 	while true ; do
-		CurrentWrite=$(awk -F" " "/ $1 / {print \$8}" </proc/diskstats)
+		CurrentWrite=$(awk -v d="$1" '{if($3 == d) print $8}' </proc/diskstats)
 		if [ ${CurrentWrite} -gt ${LastWrite} ]; then
-			PagesOut=$(awk -F" " '/pgpgout/ {print $2}' </proc/vmstat)
+			PagesOut=$(awk '/pgpgout/ {print $2}' </proc/vmstat)
 			TimeNow=$(date "+%s")
 			PagesWritten=$((CurrentWrite - LastWrite))
 			PageOuts=$((PagesOut - LastPagesOut))


### PR DESCRIPTION
# Description

If the argument for the key is a long path like `/home/user/tmp/test` or a non-existent device, then an awk script error and incorrect data or nonsense is printed on the screen.

Split Pull Request [#4691]

# Checklist:
- [x] Test on board


