### PR TITLE
Add rockchip-rk3588-opp-oc-24ghz overlay for RK3588 boards

### DIFF
--- a/patch/kernel/rockchip-rk3588-legacy/2012-Add-rockchip-rk3588-opp-oc-24ghz-overlay-for-RK3588.patch
+++ b/patch/kernel/rockchip-rk3588-legacy/2012-Add-rockchip-rk3588-opp-oc-24ghz-overlay-for-RK3588.patch
@@ -1,0 +1,388 @@
+From e25ddaf6ecf5675e4e593cc69d65fcdef74279a6 Mon Sep 17 00:00:00 2001
+From: Muhammed Efe Cetin <efectn@protonmail.com>
+Date: Mon, 23 Jan 2023 22:55:55 +0300
+Subject: [PATCH] Add rockchip-rk3588-opp-oc-24ghz overlay for RK3588 boards
+
+Add rockchip-rk3588-opp-oc-24ghz overlay for RK3588 boards
+---
+ arch/arm64/boot/dts/rockchip/overlay/Makefile |   1 +
+ .../overlay/rockchip-rk3588-opp-oc-24ghz.dts  | 355 ++++++++++++++++++
+ 2 files changed, 356 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opp-oc-24ghz.dts
+
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts/rockchip/overlay/Makefile
+index 8e347afbf..c7d53ef22 100644
+--- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
++++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
+@@ -70,6 +70,7 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
+ 	rockchip-rk3588-opi5-uart1-m1.dtbo \
+ 	rockchip-rk3588-opi5-uart3-m0.dtbo \
+ 	rockchip-rk3588-opi5-uart4-m0.dtbo \
++	rockchip-rk3588-opp-oc-24ghz.dtbo \
+ 
+ dtbotxt-$(CONFIG_ARCH_ROCKCHIP) += \
+ 	README.rockchip-overlays
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opp-oc-24ghz.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opp-oc-24ghz.dts
+new file mode 100644
+index 000000000..d329e22a3
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-opp-oc-24ghz.dts
+@@ -0,0 +1,355 @@
++// RK3588 CPU Overclock to 2.4 GHz
++
++/dts-v1/;
++/plugin/;
++
++/ {
++    metadata {
++		title ="Overclock Big Cores to 2.4 GHz on RK3588/RK3588S boards";
++		compatible = "rockchip,rk3588";
++		category = "misc";
++		description = "Overclock Big Cores to 2.4 GHz on RK3588/RK3588S boards";
++	};
++
++    fragment@0 {
++        target = <&cluster1_opp_table>;
++        __overlay__ {
++		    opp-408000000 {
++			    opp-supported-hw = <0xff 0xffff>;
++			    opp-hz = /bits/ 64 <408000000>;
++			    opp-microvolt = <675000 675000 1050000>,
++			    		<675000 675000 1050000>;
++			    clock-latency-ns = <40000>;
++			    opp-suspend;
++		    };
++		    opp-600000000 {
++			    opp-supported-hw = <0xff 0xffff>;
++			    opp-hz = /bits/ 64 <600000000>;
++			    opp-microvolt = <675000 675000 1050000>,
++			    		<675000 675000 1050000>;
++			    clock-latency-ns = <40000>;
++		    };
++		    opp-816000000 {
++			    opp-supported-hw = <0xff 0xffff>;
++			    opp-hz = /bits/ 64 <816000000>;
++			    opp-microvolt = <675000 675000 1050000>,
++			    		<675000 675000 1050000>;
++			    clock-latency-ns = <40000>;
++		    };
++		    opp-1008000000 {
++			    opp-supported-hw = <0xff 0xffff>;
++			    opp-hz = /bits/ 64 <1008000000>;
++			    opp-microvolt = <675000 675000 1050000>,
++			    		<675000 675000 1050000>;
++			    clock-latency-ns = <40000>;
++		    };
++		    opp-1200000000 {
++			    opp-supported-hw = <0xff 0xffff>;
++			    opp-hz = /bits/ 64 <1200000000>;
++			    opp-microvolt = <675000 675000 1050000>,
++			    		    <675000 675000 1050000>;
++			    clock-latency-ns = <40000>;
++		    };
++		    opp-1416000000 {
++			    opp-supported-hw = <0xff 0xffff>;
++			    opp-hz = /bits/ 64 <1416000000>;
++			    opp-microvolt = <725000 725000 1050000>,
++			    		    <725000 725000 1050000>;
++			    opp-microvolt-L2 = <712500 712500 1050000>,
++			    		   <712500 712500 1050000>;
++			    opp-microvolt-L3 = <700000 700000 1050000>,
++			    		   <700000 700000 1050000>;
++			    opp-microvolt-L4 = <700000 700000 1050000>,
++			    		   <700000 700000 1050000>;
++			    opp-microvolt-L5 = <687500 687500 1050000>,
++			    		   <687500 687500 1050000>;
++			    opp-microvolt-L6 = <675000 675000 1050000>,
++			    		   <675000 675000 1050000>;
++			    opp-microvolt-L7 = <675000 675000 1050000>,
++			    		   <675000 675000 1050000>;
++			    clock-latency-ns = <40000>;
++		    };
++		    opp-1608000000 {
++			    opp-supported-hw = <0xff 0xffff>;
++			    opp-hz = /bits/ 64 <1608000000>;
++			    opp-microvolt = <762500 762500 1050000>,
++			    		    <762500 762500 1050000>;
++			    opp-microvolt-L2 = <750000 750000 1050000>,
++					        <750000 750000 1050000>;
++			    opp-microvolt-L3 = <737500 737500 1050000>,
++					        <737500 737500 1050000>;
++			    opp-microvolt-L4 = <725000 725000 1050000>,
++					        <725000 725000 1050000>;
++			    opp-microvolt-L5 = <712500 712500 1050000>,
++					        <712500 712500 1050000>;
++			    opp-microvolt-L6 = <700000 700000 1050000>,
++					        <700000 700000 1050000>;
++			    opp-microvolt-L7 = <700000 700000 1050000>,
++					        <700000 700000 1050000>;
++			    clock-latency-ns = <40000>;
++		    };
++		    opp-1800000000 {
++			    opp-supported-hw = <0xff 0xffff>;
++			    opp-hz = /bits/ 64 <1800000000>;
++			    opp-microvolt = <850000 850000 1050000>,
++					        <850000 850000 1050000>;
++			    opp-microvolt-L1 = <837500 837500 1050000>,
++					        <837500 837500 1050000>;
++			    opp-microvolt-L2 = <825000 825000 1050000>,
++					        <825000 825000 1050000>;
++			    opp-microvolt-L3 = <812500 812500 1050000>,
++					        <812500 812500 1050000>;
++			    opp-microvolt-L4 = <800000 800000 1050000>,
++					        <800000 800000 1050000>;
++			    opp-microvolt-L5 = <787500 787500 1050000>,
++					        <787500 787500 1050000>;
++			    opp-microvolt-L6 = <775000 775000 1050000>,
++					        <775000 775000 1050000>;
++			    opp-microvolt-L7 = <762500 762500 1050000>,
++					        <762500 762500 1050000>;
++			    clock-latency-ns = <40000>;
++		    };
++		    opp-2016000000 {
++			    opp-supported-hw = <0xff 0xffff>;
++			    opp-hz = /bits/ 64 <2016000000>;
++			    opp-microvolt = <925000 925000 1050000>,
++					        <925000 925000 1050000>;
++			    opp-microvolt-L1 = <912500 912500 1050000>,
++					        <912500 912500 1050000>;
++			    opp-microvolt-L2 = <900000 900000 1050000>,
++					        <900000 900000 1050000>;
++			    opp-microvolt-L3 = <887500 887500 1050000>,
++					        <887500 887500 1050000>;
++			    opp-microvolt-L4 = <875000 875000 1050000>,
++					        <875000 875000 1050000>;
++			    opp-microvolt-L5 = <862500 862500 1050000>,
++					        <862500 862500 1050000>;
++			    opp-microvolt-L6 = <850000 850000 1050000>,
++					        <850000 850000 1050000>;
++			    opp-microvolt-L7 = <837500 837500 1050000>,
++					        <837500 837500 1050000>;
++			    clock-latency-ns = <40000>;
++		    };
++		    opp-2208000000 {
++			    opp-supported-hw = <0xff 0xffff>;
++			    opp-hz = /bits/ 64 <2208000000>;
++			    opp-microvolt = <987500 987500 1050000>,
++					        <987500 987500 1050000>;
++			    opp-microvolt-L1 = <975000 975000 1050000>,
++					        <975000 975000 1050000>;
++			    opp-microvolt-L2 = <962500 962500 1050000>,
++					        <962500 962500 1050000>;
++			    opp-microvolt-L3 = <950000 950000 1050000>,
++					        <950000 950000 1050000>;
++			    opp-microvolt-L4 = <962500 962500 1050000>,
++					        <962500 962500 1050000>;
++			    opp-microvolt-L5 = <950000 950000 1050000>,
++					        <950000 950000 1050000>;
++			    opp-microvolt-L6 = <925000 925000 1050000>,
++					        <925000 925000 1050000>;
++			    opp-microvolt-L7 = <912500 912500 1050000>,
++					        <912500 912500 1050000>;
++			    clock-latency-ns = <40000>;
++		    };
++		    opp-2256000000 {
++			    opp-supported-hw = <0xff 0xffff>;
++			    opp-hz = /bits/ 64 <2256000000>;
++			    opp-microvolt = <1000000 1000000 1050000>,
++					        <1000000 1000000 1050000>;
++			    clock-latency-ns = <40000>;
++		    };
++		    opp-2304000000 {
++			    opp-supported-hw = <0xff 0xffff>;
++			    opp-hz = /bits/ 64 <2304000000>;
++			    opp-microvolt = <1030000 1000000 1050000>,
++			    		    <1030000 1000000 1050000>;
++			    clock-latency-ns = <40000>;
++		    };
++		    opp-2352000000 {
++			    opp-supported-hw = <0xff 0xffff>;
++			    opp-hz = /bits/ 64 <2352000000>;
++			    opp-microvolt = <1040000 1010000 1050000>,
++					        <1040000 1010000 1050000>;
++			    clock-latency-ns = <40000>;
++		    };
++		    opp-2400000000 {
++			    opp-supported-hw = <0xff 0xffff>;
++			    opp-hz = /bits/ 64 <2400000000>;
++			    opp-microvolt = <1050000 1020000 1050000>,
++					        <1050000 1020000 1050000>;
++			    clock-latency-ns = <40000>;
++		    };
++        };
++    };
++
++    fragment@1 {
++        target = <&cluster2_opp_table>;
++        __overlay__ {
++		    opp-408000000 {
++			    opp-supported-hw = <0xff 0xffff>;
++			    opp-hz = /bits/ 64 <408000000>;
++			    opp-microvolt = <675000 675000 1050000>,
++					        <675000 675000 1050000>;
++			    clock-latency-ns = <40000>;
++			    opp-suspend;
++		    };
++		    opp-600000000 {
++			    opp-supported-hw = <0xff 0xffff>;
++			    opp-hz = /bits/ 64 <600000000>;
++			    opp-microvolt = <675000 675000 1050000>,
++					        <675000 675000 1050000>;
++			    clock-latency-ns = <40000>;
++		    };
++		    opp-816000000 {
++			    opp-supported-hw = <0xff 0xffff>;
++			    opp-hz = /bits/ 64 <816000000>;
++			    opp-microvolt = <675000 675000 1050000>,
++					        <675000 675000 1050000>;
++			    clock-latency-ns = <40000>;
++		    };
++		    opp-1008000000 {
++			    opp-supported-hw = <0xff 0xffff>;
++			    opp-hz = /bits/ 64 <1008000000>;
++			    opp-microvolt = <675000 675000 1050000>,
++					        <675000 675000 1050000>;
++			    clock-latency-ns = <40000>;
++		    };
++		    opp-1200000000 {
++			    opp-supported-hw = <0xff 0xffff>;
++			    opp-hz = /bits/ 64 <1200000000>;
++			    opp-microvolt = <675000 675000 1050000>,
++					        <675000 675000 1050000>;
++			    clock-latency-ns = <40000>;
++		    };
++		    opp-1416000000 {
++			    opp-supported-hw = <0xff 0xffff>;
++			    opp-hz = /bits/ 64 <1416000000>;
++			    opp-microvolt = <725000 725000 1050000>,
++					        <725000 725000 1050000>;
++			    opp-microvolt-L2 = <712500 712500 1050000>,
++					        <712500 712500 1050000>;
++			    opp-microvolt-L3 = <700000 700000 1050000>,
++					        <700000 700000 1050000>;
++			    opp-microvolt-L4 = <700000 700000 1050000>,
++					        <700000 700000 1050000>;
++			    opp-microvolt-L5 = <687500 687500 1050000>,
++					        <687500 687500 1050000>;
++			    opp-microvolt-L6 = <675000 675000 1050000>,
++					        <675000 675000 1050000>;
++			    opp-microvolt-L7 = <675000 675000 1050000>,
++					        <675000 675000 1050000>;
++			    clock-latency-ns = <40000>;
++		    };
++		    opp-1608000000 {
++			    opp-supported-hw = <0xff 0xffff>;
++			    opp-hz = /bits/ 64 <1608000000>;
++			    opp-microvolt = <762500 762500 1050000>,
++					        <762500 762500 1050000>;
++			    opp-microvolt-L2 = <750000 750000 1050000>,
++					        <750000 750000 1050000>;
++			    opp-microvolt-L3 = <737500 737500 1050000>,
++					        <737500 737500 1050000>;
++			    opp-microvolt-L4 = <725000 725000 1050000>,
++					        <725000 725000 1050000>;
++			    opp-microvolt-L5 = <712500 712500 1050000>,
++					        <712500 712500 1050000>;
++			    opp-microvolt-L6 = <700000 700000 1050000>,
++					        <700000 700000 1050000>;
++			    opp-microvolt-L7 = <700000 700000 1050000>,
++					        <700000 700000 1050000>;
++			    clock-latency-ns = <40000>;
++		    };
++		    opp-1800000000 {
++			    opp-supported-hw = <0xff 0xffff>;
++			    opp-hz = /bits/ 64 <1800000000>;
++			    opp-microvolt = <850000 850000 1050000>,
++					        <850000 850000 1050000>;
++			    opp-microvolt-L1 = <837500 837500 1050000>,
++					        <837500 837500 1050000>;
++			    opp-microvolt-L2 = <825000 825000 1050000>,
++					        <825000 825000 1050000>;
++			    opp-microvolt-L3 = <812500 812500 1050000>,
++					        <812500 812500 1050000>;
++			    opp-microvolt-L4 = <800000 800000 1050000>,
++					        <800000 800000 1050000>;
++			    opp-microvolt-L5 = <787500 787500 1050000>,
++					        <787500 787500 1050000>;
++			    opp-microvolt-L6 = <775000 775000 1050000>,
++					        <775000 775000 1050000>;
++			    opp-microvolt-L7 = <762500 762500 1050000>,
++					        <762500 762500 1050000>;
++			    clock-latency-ns = <40000>;
++		    };
++		    opp-2016000000 {
++			    opp-supported-hw = <0xff 0xffff>;
++			    opp-hz = /bits/ 64 <2016000000>;
++			    opp-microvolt = <925000 925000 1050000>,
++					        <925000 925000 1050000>;
++			    opp-microvolt-L1 = <912500 912500 1050000>,
++					        <912500 912500 1050000>;
++			    opp-microvolt-L2 = <900000 900000 1050000>,
++					        <900000 900000 1050000>;
++			    opp-microvolt-L3 = <887500 887500 1050000>,
++					        <887500 887500 1050000>;
++			    opp-microvolt-L4 = <875000 875000 1050000>,
++					        <875000 875000 1050000>;
++			    opp-microvolt-L5 = <862500 862500 1050000>,
++					        <862500 862500 1050000>;
++			    opp-microvolt-L6 = <850000 850000 1050000>,
++					        <850000 850000 1050000>;
++			    opp-microvolt-L7 = <837500 837500 1050000>,
++					        <837500 837500 1050000>;
++			    clock-latency-ns = <40000>;
++		    };
++		    opp-2208000000 {
++			    opp-supported-hw = <0xff 0xffff>;
++			    opp-hz = /bits/ 64 <2208000000>;
++			    opp-microvolt = <987500 987500 1050000>,
++					        <987500 987500 1050000>;
++			    opp-microvolt-L1 = <975000 975000 1050000>,
++					        <975000 975000 1050000>;
++			    opp-microvolt-L2 = <962500 962500 1050000>,
++					        <962500 962500 1050000>;
++			    opp-microvolt-L3 = <950000 950000 1050000>,
++					        <950000 950000 1050000>;
++			    opp-microvolt-L4 = <962500 962500 1050000>,
++					        <962500 962500 1050000>;
++			    opp-microvolt-L5 = <950000 950000 1050000>,
++					        <950000 950000 1050000>;
++			    opp-microvolt-L6 = <925000 925000 1050000>,
++					        <925000 925000 1050000>;
++			    opp-microvolt-L7 = <912500 912500 1050000>,
++					        <912500 912500 1050000>;
++			    clock-latency-ns = <40000>;
++		    };
++		    opp-2256000000 {
++			    opp-supported-hw = <0xff 0xffff>;
++			    opp-hz = /bits/ 64 <2256000000>;
++			    opp-microvolt = <1000000 1000000 1050000>,
++					        <1000000 1000000 1050000>;
++			    clock-latency-ns = <40000>;
++		    };
++		    opp-2304000000 {
++			    opp-supported-hw = <0xff 0xffff>;
++			    opp-hz = /bits/ 64 <2304000000>;
++			    opp-microvolt = <1030000 1000000 1050000>,
++					        <1030000 1000000 1050000>;
++			    clock-latency-ns = <40000>;
++		    };
++		    opp-2352000000 {
++			    opp-supported-hw = <0xff 0xffff>;
++			    opp-hz = /bits/ 64 <2352000000>;
++			    opp-microvolt = <1040000 1010000 1050000>,
++					        <1040000 1010000 1050000>;
++			    clock-latency-ns = <40000>;
++		    };
++		    opp-2400000000 {
++			    opp-supported-hw = <0xff 0xffff>;
++			    opp-hz = /bits/ 64 <2400000000>;
++			    opp-microvolt = <1050000 1020000 1050000>,
++					        <1050000 1020000 1050000>;
++			    clock-latency-ns = <40000>;
++		    };
++        };
++    };
++};
+-- 
+2.39.0
+


### PR DESCRIPTION
# Description
Most chips support 2.2GHZ as maximum freq. Needs some voltage overclock to get 2.35-2.4GHz speeds. Looks like 50 mV enough to get this speeds.

Note: Doesn't have much performance improvement. It provides better performance to disable DMC and changing governors.

# How Has This Been Tested?
- [x] Tested on OPi 5. Seems stable

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
