### PR TITLE
rockchip64: rework pbp patch including usb type-c extcon services

### DIFF
--- a/patch/kernel/archive/rockchip64-5.15/board-pbp-add-dp-alt-mode.patch
+++ b/patch/kernel/archive/rockchip64-5.15/board-pbp-add-dp-alt-mode.patch
@@ -387,30 +387,6 @@ index 82b19ebd7838..6f00b17afc15 100644
  static int tcpm_fw_get_caps(struct tcpm_port *port,
  			    struct fwnode_handle *fwnode)
  {
-@@ -4434,6 +4537,23 @@ static int tcpm_fw_get_caps(struct tcpm_port *port,
- 	if (!fwnode)
- 		return -EINVAL;
- 
-+#ifdef CONFIG_EXTCON
-+	ret = fwnode_property_count_u32(fwnode, "extcon-cables");
-+	if (ret > 0) {
-+		port->extcon_cables = devm_kzalloc(port->dev, sizeof(u32) * ret, GFP_KERNEL);
-+		if (!port->extcon_cables) {
-+			dev_err(port->dev, "Failed to allocate memory for extcon cable types. "\
-+				"Using default tyes");
-+			goto extcon_default;
-+		}
-+		fwnode_property_read_u32_array(fwnode, "extcon-cables", port->extcon_cables, ret);
-+	} else {
-+extcon_default:
-+		dev_info(port->dev, "No cable types defined, using default cables");
-+		port->extcon_cables = default_supported_cables;
-+	}
-+#endif
-+
- 	/* USB data support is optional */
- 	ret = fwnode_property_read_string(fwnode, "data-role", &cap_str);
- 	if (ret == 0) {
 @@ -4766,6 +4886,17 @@ struct tcpm_port *tcpm_register_port(struct device *dev, struct tcpc_dev *tcpc)
  		goto out_destroy_wq;
  
@@ -442,6 +418,34 @@ index 82b19ebd7838..6f00b17afc15 100644
  	mutex_lock(&port->lock);
  	tcpm_init(port);
  	mutex_unlock(&port->lock);
+diff --git a/drivers/usb/typec/tcpm/tcpm.c b/drivers/usb/typec/tcpm/tcpm.c
+index 7c4fa758d12..38502a2037a 100644
+--- a/drivers/usb/typec/tcpm/tcpm.c
++++ b/drivers/usb/typec/tcpm/tcpm.c
+@@ -6044,6 +6044,23 @@ static int tcpm_fw_get_caps(struct tcpm_port *port,
+ 	 * fwnode_links to/from this fwnode.
+ 	 */
+ 	fw_devlink_purge_absent_suppliers(fwnode);
++	
++#ifdef CONFIG_EXTCON
++	ret = fwnode_property_count_u32(fwnode, "extcon-cables");
++	if (ret > 0) {
++		port->extcon_cables = devm_kzalloc(port->dev, sizeof(u32) * ret, GFP_KERNEL);
++		if (!port->extcon_cables) {
++			dev_err(port->dev, "Failed to allocate memory for extcon cable types. "\
++				"Using default tyes");
++			goto extcon_default;
++		}
++		fwnode_property_read_u32_array(fwnode, "extcon-cables", port->extcon_cables, ret);
++	} else {
++extcon_default:
++		dev_info(port->dev, "No cable types defined, using default cables");
++		port->extcon_cables = default_supported_cables;
++	}
++#endif
+ 
+ 	ret = typec_get_fw_cap(&port->typec_caps, fwnode);
+ 	if (ret < 0)
 -- 
-2.26.2
+2.34.1
 


### PR DESCRIPTION
# Description

A patch for Pinebook Pro was not applying cleaning on current 5.15 rockchip64 kernel flavour, turns out that Orange Pi 4 LTS has no more HDMI video output and dmesg is lamenting about a missing `extcon` connector over fusb driver.

fusb driver has the control over video output since it has the capacity to steer video output from HDMI to DP via USB type-c connector. A broken fusb driver causes broken video output; this problem can be shared among all boards that depend upon it.

This pull request fixes the application of the Pinebook Pro patch, and perhaps fixes the Orange Pi 4 LTS broken video output.

edit: I confirm, fixing the patch fixes also video output on Opi4 LTS

Jira reference number [AR-1517]

# How Has This Been Tested?

- [x] Patch application
- [x] Compilation of the deb kernel packages
- [x] Testing on existing Orange Pi 4 LTS installation

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1517]: https://armbian.atlassian.net/browse/AR-1517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ