### PR TITLE
Bugfix: GRUB installation failed to install on UEFI systems

### DIFF
--- a/packages/bsp/common/usr/sbin/armbian-install
+++ b/packages/bsp/common/usr/sbin/armbian-install
@@ -396,7 +396,7 @@ create_armbian()
 		echo "GRUB_DISABLE_OS_PROBER=false" >> "${TempDir}"/rootfs/etc/default/grub.d/98-armbian.cfg
 
 		echo "$satauuid	/		$FilesystemChoosen	${mountopts[$FilesystemChoosen]}" >> "${TempDir}"/rootfs/etc/fstab
-		echo "UUID=$(lsblk -io KNAME,LABEL,UUID | grep $diskcheck | grep -i efi | awk '{print $NF}') 				/boot/efi 		vfat	 defaults 0 2" >> "${TempDir}"/rootfs/etc/fstab
+		echo "UUID=$(lsblk -io KNAME,LABEL,UUID,PARTLABEL | grep $diskcheck | grep -i efi | awk '{print $3}')				/boot/efi		vfat	 defaults 0 2" >> "${TempDir}"/rootfs/etc/fstab
 		echo "/swapfile none swap sw 0 0" >> "${TempDir}"/rootfs/etc/fstab
 
 		cat <<-hibernatemenu >"${TempDir}"/rootfs/etc/polkit-1/localauthority/50-local.d/com.ubuntu.enable-hibernate.pkla
@@ -414,15 +414,15 @@ create_armbian()
 		efi_partition=$(LC_ALL=C fdisk -l "/dev/$diskcheck" 2>/dev/null | grep "EFI" | awk '{print $1}')
 
 		echo "Install GRUB to $efi_partition"
-		mkdir -p "${TempDir}"/rootfs/boot/efi
+		mkdir -p "${TempDir}"/rootfs/{dev,proc,sys}
 		mount $efi_partition "${TempDir}"/rootfs/boot/efi
 		mount --bind /dev "${TempDir}"/rootfs/dev
 		mount --make-rslave --bind /dev/pts "${TempDir}"/rootfs/dev/pts
 		mount --bind /proc "${TempDir}"/rootfs/proc
 		mount --make-rslave --rbind /sys "${TempDir}"/rootfs/sys
 		arch_target=$([[ $(arch) == x86_64 ]] && echo "x86_64-efi" || echo "arm64-efi")
-		chroot "${TempDir}/rootfs/" /bin/bash -c "grub-install --target=$arch_target --efi-directory=/boot/efi --bootloader-id=GRUB --removable >/dev/null" >> $logfile
-		chroot "${TempDir}/rootfs/" /bin/bash -c "grub-mkconfig -o /boot/grub/grub.cfg >/dev/null" >> $logfile
+		chroot "${TempDir}/rootfs/" /bin/bash -c "grub-install --target=$arch_target --efi-directory=/boot/efi --bootloader-id=Armbian" >> $logfile
+		chroot "${TempDir}/rootfs/" /bin/bash -c "grub-mkconfig -o /boot/grub/grub.cfg" >> $logfile
 		grep "${TempDir}"/rootfs/sys /proc/mounts | cut -f2 -d" " | sort -r | xargs umount -n
 		umount "${TempDir}"/rootfs/proc
 		umount "${TempDir}"/rootfs/dev/pts


### PR DESCRIPTION
# Description

- removing "removable" paramter
- UUID from EFI partition was not found

Jira reference number [AR-1523]

# How Has This Been Tested?

- [x] (several) installs on Windows Laptop containing Windows 11

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

[AR-1523]: https://armbian.atlassian.net/browse/AR-1523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ