### PR TITLE
Prevent error at password strength check

### DIFF
--- a/config/cli/bullseye/main/packages
+++ b/config/cli/bullseye/main/packages
@@ -1,4 +1,5 @@
 bc
+cracklib-runtime
 chrony
 debconf-utils
 device-tree-compiler

--- a/config/cli/buster/main/packages
+++ b/config/cli/buster/main/packages
@@ -1,5 +1,6 @@
 bc
 chrony
+cracklib-runtime
 debconf-utils
 device-tree-compiler
 dialog

--- a/config/cli/buster/main/packages.additional
+++ b/config/cli/buster/main/packages.additional
@@ -1,4 +1,3 @@
-cracklib-runtime
 curl
 htop
 i2c-tools

--- a/config/cli/focal/main/packages
+++ b/config/cli/focal/main/packages
@@ -1,5 +1,6 @@
 bc
 chrony
+cracklib-runtime
 debconf-utils
 device-tree-compiler
 dialog

--- a/config/cli/focal/main/packages.additional
+++ b/config/cli/focal/main/packages.additional
@@ -1,4 +1,3 @@
-cracklib-runtime
 curl
 htop
 i2c-tools

--- a/config/cli/jammy/main/packages
+++ b/config/cli/jammy/main/packages
@@ -1,5 +1,6 @@
 bc
 chrony
+cracklib-runtime
 debconf-utils
 device-tree-compiler
 dialog

--- a/config/cli/jammy/main/packages.additional
+++ b/config/cli/jammy/main/packages.additional
@@ -1,4 +1,3 @@
-cracklib-runtime
 curl
 htop
 i2c-tools

--- a/config/cli/sid/main/packages
+++ b/config/cli/sid/main/packages
@@ -1,5 +1,6 @@
 bc
 chrony
+cracklib-runtime
 debconf-utils
 device-tree-compiler
 dialog

--- a/config/cli/sid/main/packages.additional
+++ b/config/cli/sid/main/packages.additional
@@ -1,4 +1,3 @@
-cracklib-runtime
 curl
 htop
 i2c-tools


### PR DESCRIPTION
# Description

Cracklib check library must be present in minimal variant. Re-adding after recent too intensive packages cleanup.

Jira reference number [AR-1524]

# How Has This Been Tested?

- [x] Generated Debian boolseye minimal

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1524]: https://armbian.atlassian.net/browse/AR-1524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ