### PR TITLE
rockchip64: fix SPDIF for x88pro/mxq rk3328 tvbox boards

### DIFF
--- a/patch/kernel/archive/rockchip64-5.15/overlays-09-add-rk3318-box-led-conf2.patch
+++ b/patch/kernel/archive/rockchip64-5.15/overlays-09-add-rk3318-box-led-conf2.patch
@@ -43,7 +43,7 @@ new file mode 100644
 index 000000000000..b8ed044ee52a
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-led-conf2.dts
-@@ -0,0 +1,59 @@
+@@ -0,0 +1,63 @@
 +/dts-v1/;
 +/plugin/;
 +
@@ -103,3 +103,8 @@ index 000000000000..b8ed044ee52a
 +	status = "disabled";
 +};
 +
++&spdif {
++	pinctrl-0 = <&spdifm1_tx>;
++};
++
+

--- a/patch/kernel/archive/rockchip64-5.15/overlays-10-add-rk3318-box-led-conf3.patch
+++ b/patch/kernel/archive/rockchip64-5.15/overlays-10-add-rk3318-box-led-conf3.patch
@@ -46,7 +46,7 @@ new file mode 100644
 index 000000000000..6e05145a287d
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-led-conf3.dts
-@@ -0,0 +1,300 @@
+@@ -0,0 +1,305 @@
 +/dts-v1/;
 +/plugin/;
 +
@@ -347,6 +347,11 @@ index 000000000000..6e05145a287d
 +&sdmmc_ext {
 +	status = "disabled";
 +};
++
++&spdif {
++	pinctrl-0 = <&spdifm1_tx>;
++};
++
 --
 2.30.2
 

--- a/patch/kernel/archive/rockchip64-6.1/overlays-09-add-rk3318-box-led-conf2.patch
+++ b/patch/kernel/archive/rockchip64-6.1/overlays-09-add-rk3318-box-led-conf2.patch
@@ -43,7 +43,7 @@ new file mode 100644
 index 000000000000..b8ed044ee52a
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-led-conf2.dts
-@@ -0,0 +1,59 @@
+@@ -0,0 +1,63 @@
 +/dts-v1/;
 +/plugin/;
 +
@@ -103,3 +103,8 @@ index 000000000000..b8ed044ee52a
 +	status = "disabled";
 +};
 +
++&spdif {
++	pinctrl-0 = <&spdifm1_tx>;
++};
++
+

--- a/patch/kernel/archive/rockchip64-6.1/overlays-10-add-rk3318-box-led-conf3.patch
+++ b/patch/kernel/archive/rockchip64-6.1/overlays-10-add-rk3318-box-led-conf3.patch
@@ -46,7 +46,7 @@ new file mode 100644
 index 000000000000..6e05145a287d
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-led-conf3.dts
-@@ -0,0 +1,300 @@
+@@ -0,0 +1,305 @@
 +/dts-v1/;
 +/plugin/;
 +
@@ -347,6 +347,11 @@ index 000000000000..6e05145a287d
 +&sdmmc_ext {
 +	status = "disabled";
 +};
++
++&spdif {
++	pinctrl-0 = <&spdifm1_tx>;
++};
++
 --
 2.30.2
 


### PR DESCRIPTION
# Description

Minor change that adds the right spdif pinctrl for X88 Pro and MXQ_RK3328 tvbox boards on current and edge rockchip64 family. Harmless, for all other boards, just the specific overlays are touched.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Compiled dtb/dtbo on current 5.15 kernel
- [x] Compiled dtb/dtbo on edge 6.1 kernel
- [x] Tested dtbo on a live system

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
