### PR TITLE
sunxi64: fix uwe5622 compile on current 5.15 kernel

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -534,7 +534,6 @@ driver_uwe5622_allwinner()
 
 		if linux-version compare "${version}" lt 6.1; then
 			process_patch_file "${SRC}/patch/misc/wireless-driver-for-uwe5622-park-link-pre-v6.1.patch" "applying"
-			process_patch_file "${SRC}/patch/misc/wireless-driver-for-uwe5622-allwinner-bt-fix.patch" "applying"
 		fi
 		
 		if linux-version compare "${version}" ge 6.1; then

--- a/patch/misc/wireless-driver-for-uwe5622-warnings.patch
+++ b/patch/misc/wireless-driver-for-uwe5622-warnings.patch
@@ -181,22 +181,6 @@ index b426bf89cd9..8000bfea378 100755
  		if ((tp_tx_buf_cnt <= TP_TX_BUF_CNT) &&
  			(tp_tx_buf_len <= TP_TX_BUF_LEN)) {
  			sprdwcn_bus_chn_deinit(&at_tx_ops);
-diff --git a/drivers/net/wireless/uwe5622/unisocwifi/cfg80211.c b/drivers/net/wireless/uwe5622/unisocwifi/cfg80211.c
-index 5d86a5cc435..f26113c08af 100755
---- a/drivers/net/wireless/uwe5622/unisocwifi/cfg80211.c
-+++ b/drivers/net/wireless/uwe5622/unisocwifi/cfg80211.c
-@@ -1747,10 +1747,6 @@ static int sprdwl_cfg80211_disconnect(struct wiphy *wiphy,
- 	struct sprdwl_vif *vif = netdev_priv(ndev);
- 	enum sm_state old_state = vif->sm_state;
- 	int ret;
--#ifdef SYNC_DISCONNECT
--	u32 msec;
--	ktime_t kt;
--#endif
- #ifdef STA_SOFTAP_SCC_MODE
- 	struct sprdwl_intf *intf = (struct sprdwl_intf *)vif->priv->hw_priv;
- 	intf->sta_home_channel = 0;
-
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/wl_core.c b/drivers/net/wireless/uwe5622/unisocwifi/wl_core.c
 index ad310450e79..206824604ec 100755
 --- a/drivers/net/wireless/uwe5622/unisocwifi/wl_core.c


### PR DESCRIPTION
# Description

Hotfix to remove a hunk from a patch that prevented compilation of uwe5622 driver on sunxi64 family for current kernel 5.15.
The hunk was just "cosmetical" because it removed a compilation warning about unused variables. There seems to be some `#define` and `#ifdef` difference on sunxi64 that causes the compilation error.

Also the application of bluetooth-fix patch has been removed from `drivers_network.sh` since the patch has been removed in the past.

# How Has This Been Tested?

- [x] Compiled current 5.15 kernel debs for OrangePi 3 LTS (sunxi64)
- [x] Compiled current 5.15 kernel debs for OrangePi 4 LTS (rockchip64)
- [x] Compiled edge 6.1 kernel debs for OrangePi4 LTS (rockchip64)

There was not field testing for this change, I **really** expect the driver to work the same as before.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
