### PR TITLE
Disable hardware cursor for Rock 5B and Orange Pi 5

### DIFF
--- a/patch/kernel/rockchip-rk3588-legacy/2009-Variously-HDMI-improvements-for-OPi-5.patch
+++ b/patch/kernel/rockchip-rk3588-legacy/2009-Variously-HDMI-improvements-for-OPi-5.patch
@@ -1,5 +1,15 @@
+From 97a2a58f07231ce6df61ebad890306f392b34d68 Mon Sep 17 00:00:00 2001
+From: Muhammed Efe Cetin <efectn@protonmail.com>
+Date: Tue, 31 Jan 2023 23:51:40 +0300
+Subject: [PATCH] Variously HDMI improvements for OPi 5
+
+---
+ .../boot/dts/rockchip/rk3588s-orangepi-5.dts      | 15 +++++++++++----
+ .../arm64/boot/dts/rockchip/rk3588s-orangepi.dtsi | 10 ++++++++++
+ 2 files changed, 21 insertions(+), 4 deletions(-)
+
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dts b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dts
-index 09762fd1dcc3..da2bf4d91a69 100755
+index 09762fd1d..da2bf4d91 100755
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dts
 @@ -41,6 +41,16 @@ vcc_1v1_nldo_s3: vcc-1v1-nldo-s3 {
@@ -38,36 +48,30 @@ index 09762fd1dcc3..da2bf4d91a69 100755
  	status = "okay";
  };
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi.dtsi b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi.dtsi
-index 28ad1d3660aa..a6d14beafc56 100755
+index 28ad1d366..af25013fc 100755
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi.dtsi
-@@ -578,19 +578,29 @@ &vepu {
- &vp0 {
- 	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER0 | 1 << ROCKCHIP_VOP2_ESMART0)>;
- 	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART0>;
-+	cursor-win-id = <ROCKCHIP_VOP2_CLUSTER0>;
+@@ -205,6 +205,10 @@ vcc5v0_usb: vcc5v0-usb {
+ 	};
  };
  
- &vp1 {
- 	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER1 | 1 << ROCKCHIP_VOP2_ESMART1)>;
- 	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART1>;
-+	cursor-win-id = <ROCKCHIP_VOP2_CLUSTER1>;
++&av1d {
++	status = "okay";
++};
++
+ &av1d_mmu {
+ 	status = "okay";
  };
- 
- &vp2 {
- 	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER2 | 1 << ROCKCHIP_VOP2_ESMART2)>;
- 	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART2>;
-+	cursor-win-id = <ROCKCHIP_VOP2_CLUSTER2>;
- };
- 
- &vp3 {
+@@ -594,3 +598,9 @@ &vp3 {
  	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER3 | 1 << ROCKCHIP_VOP2_ESMART3)>;
  	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART3>;
-+	cursor-win-id = <ROCKCHIP_VOP2_CLUSTER3>;
-+};
+ };
 +
 +/* Fix tty terminal out of screen, and most dclk of resolutions was not supported in hdmiphy clock from parent clock by default */
 +&display_subsystem {
 +	clocks = <&hdptxphy_hdmi_clk0>;
 +	clock-names = "hdmi0_phy_pll";
- };
++};
+-- 
+2.39.1
+

--- a/patch/kernel/rockchip-rk3588-legacy/2013-Disable-hardware-cursor-for-Rock-5B.patch
+++ b/patch/kernel/rockchip-rk3588-legacy/2013-Disable-hardware-cursor-for-Rock-5B.patch
@@ -1,0 +1,42 @@
+From 714cb0284e185509cd94f96732a4e51e23d4d22c Mon Sep 17 00:00:00 2001
+From: Muhammed Efe Cetin <efectn@protonmail.com>
+Date: Tue, 31 Jan 2023 23:55:05 +0300
+Subject: [PATCH] Disable hardware cursor for Rock 5B
+
+---
+ arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+index 8611a5a7e..3665b85c6 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+@@ -670,25 +670,21 @@ &vepu {
+ &vp0 {
+ 	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER0 | 1 << ROCKCHIP_VOP2_ESMART0)>;
+ 	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART0>;
+-	cursor-win-id = <ROCKCHIP_VOP2_CLUSTER0>;
+ };
+ 
+ &vp1 {
+ 	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER1 | 1 << ROCKCHIP_VOP2_ESMART1)>;
+ 	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART1>;
+-	cursor-win-id = <ROCKCHIP_VOP2_CLUSTER1>;
+ };
+ 
+ &vp2 {
+ 	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER2 | 1 << ROCKCHIP_VOP2_ESMART2)>;
+ 	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART2>;
+-	cursor-win-id = <ROCKCHIP_VOP2_CLUSTER2>;
+ };
+ 
+ &vp3 {
+ 	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER3 | 1 << ROCKCHIP_VOP2_ESMART3)>;
+ 	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART3>;
+-	cursor-win-id = <ROCKCHIP_VOP2_CLUSTER3>;
+ };
+ 
+ &u2phy2 {
+-- 
+2.39.1
+


### PR DESCRIPTION
# Description

Hardware cursor is currently broken and sometimes it's randomly disappearing. 

**Ref:** https://github.com/radxa/kernel/issues/57

# How Has This Been Tested?
- [ ] Compiled and checked that cursor is no longer disappearing.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
