### PR TITLE
rockchip64: fix rk3328 dmc driver

### DIFF
--- a/patch/kernel/archive/rockchip64-6.1/rk3328-add-dmc-driver.patch
+++ b/patch/kernel/archive/rockchip64-6.1/rk3328-add-dmc-driver.patch
@@ -1292,10 +1292,10 @@ index 9a88faaf8..c034df869 100644
  
 diff --git a/drivers/devfreq/rk3328_dmc.c b/drivers/devfreq/rk3328_dmc.c
 new file mode 100644
-index 000000000..a33069c25
+index 00000000000..7665526f086
 --- /dev/null
 +++ b/drivers/devfreq/rk3328_dmc.c
-@@ -0,0 +1,862 @@
+@@ -0,0 +1,836 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +/*
 + * Copyright (c) 2016, Fuzhou Rockchip Electronics Co., Ltd.
@@ -1682,10 +1682,7 @@ index 000000000..a33069c25
 +
 +struct rk3328_devfreq {
 +	struct devfreq *devfreq;
-+	struct opp_table *clkname_opp_table;
-+	struct opp_table *regulators_opp_table;
 +	struct thermal_cooling_device *cooling;
-+	bool opp_of_table_added;
 +};
 +
 +struct rk3328_dmcfreq {
@@ -1985,30 +1982,16 @@ index 000000000..a33069c25
 +		devfreq->devfreq = NULL;
 +	}
 +
-+	if (devfreq->opp_of_table_added) {
-+		dev_pm_opp_of_remove_table(rdev->dev);
-+		devfreq->opp_of_table_added = false;
-+	}
-+
-+	if (devfreq->regulators_opp_table) {
-+		dev_pm_opp_put_regulators(devfreq->regulators_opp_table);
-+		devfreq->regulators_opp_table = NULL;
-+	}
-+
-+	if (devfreq->clkname_opp_table) {
-+		dev_pm_opp_put_clkname(devfreq->clkname_opp_table);
-+		devfreq->clkname_opp_table = NULL;
-+	}
 +}
 +
 +int rk3328_devfreq_init(struct rk3328_dmcfreq *rdev)
 +{
 +	struct thermal_cooling_device *cooling;
 +	struct device *dev = rdev->dev;
-+	struct opp_table *opp_table;
 +	struct devfreq *devfreq;
 +	struct rk3328_devfreq *rdevfreq = &rdev->devfreq;
-+
++	const char *regulator_names[] = { "center", NULL };
++	
 +	struct dev_pm_opp *opp;
 +	unsigned long cur_freq;
 +	int ret;
@@ -2017,30 +2000,21 @@ index 000000000..a33069c25
 +		/* Optional, continue without devfreq */
 +		return 0;
 +
-+	opp_table = dev_pm_opp_set_clkname(dev, "dmc_clk");
-+	if (IS_ERR(opp_table)) {
-+		ret = PTR_ERR(opp_table);
++	ret= devm_pm_opp_set_clkname(dev, "dmc_clk");
++	if (ret)
 +		goto err_fini;
-+	}
 +
-+	rdevfreq->clkname_opp_table = opp_table;
-+
-+	opp_table = dev_pm_opp_set_regulators(dev,
-+					      (const char *[]){ "center" });
-+	if (IS_ERR(opp_table)) {
-+		ret = PTR_ERR(opp_table);
-+
++	ret = devm_pm_opp_set_regulators(dev, regulator_names);
++	
++	if (ret) {
 +		/* Continue if the optional regulator is missing */
 +		if (ret != -ENODEV)
 +			goto err_fini;
-+	} else {
-+		rdevfreq->regulators_opp_table = opp_table;
 +	}
 +
-+	ret = dev_pm_opp_of_add_table(dev);
++	ret = devm_pm_opp_of_add_table(dev);
 +	if (ret)
 +		goto err_fini;
-+	rdevfreq->opp_of_table_added = true;
 +
 +	cur_freq = 0;
 +


### PR DESCRIPTION
# Description

Hotfix for rk3328 dram memory controller driver has some issues and causes crashes on board on which is activated (see https://github.com/armbian/build/pull/4767) on edge 6.1 kernel.
This pull request fixes the issue, plus removes some cruft and warnings from the existing code.

# How Has This Been Tested?

- [x] Compile kernel deb packages successfully
- [x] Install and test on a rk3318 system
- [x] Install and test on rk3328 system with rk805 pmic
- [x] Install and test on rk3328 Rock Pi E with rk805 pmic

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
