### PR TITLE
add rk3328 device tree overlays for uart1 and i2c0

### DIFF
--- a/patch/kernel/archive/rockchip64-5.15/rk3328-device-tree-overlays-uart1-i2c0.patch
+++ b/patch/kernel/archive/rockchip64-5.15/rk3328-device-tree-overlays-uart1-i2c0.patch
@@ -1,0 +1,99 @@
+From 0a11005a8a39ed8d84c42a0f29636631db621f0a Mon Sep 17 00:00:00 2001
+From: Kat Schwarz <schwar3kat@armbian.com>
+Date: Sun, 22 Jan 2023 21:16:07 +1300
+Subject: [PATCH] add-rk3328-dtbo-uart1-i2c0
+
+RK3328 UART1 and I2C0 are available on Orange Pi R1 Plus LTS 13 pin connector.
+Add two device tree overlay files for rk3328 uart1 and i2c0.
+
+Signed-off-by: Kat Schwarz <schwar3kat@armbian.com>
+---
+ arch/arm64/boot/dts/rockchip/overlay/Makefile   |  2 ++
+ .../rockchip/overlay/README.rockchip-overlays   | 12 ++++++++++++
+ .../rockchip/overlay/rockchip-rk3328-i2c0.dts   | 13 +++++++++++++
+ .../rockchip/overlay/rockchip-rk3328-uart1.dts  | 17 +++++++++++++++++
+ 4 files changed, 44 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2c0.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-uart1.dts
+
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts/rockchip/overlay/Makefile
+index 7813ae347..53f8412d7 100644
+--- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
++++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
+@@ -3,6 +3,8 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
+ 	rockchip-i2c7.dtbo \
+ 	rockchip-i2c8.dtbo \
+ 	rockchip-pcie-gen2.dtbo \
++    rockchip-rk3328-i2c0.dtbo \
++    rockchip-rk3328-uart1.dtbo \
+ 	rockchip-rk3328-opp-1.4ghz.dtbo \
+ 	rockchip-rk3328-opp-1.5ghz.dtbo \
+ 	rockchip-rk3399-opp-2ghz.dtbo \
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
+index 07e79b04d..16942a511 100644
+--- a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
++++ b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
+@@ -29,6 +29,18 @@ I2C8 pins (pi-conn) (pi-conn) (SCL, SDA): GPIO1-C5, GPIO1-C4
+ Enables PCIe Gen2 link speed on RK3399.
+ WARNING! Not officially supported by Rockchip!!!
+ 
++### rk3328-i2c0
++
++Activates TWI/I2C bus 0
++
++I2C0 (SCL, SDA): GPIO2-D0, GPIO2-D1
++
++### rk3328-uart1
++
++Activates UART1
++
++UART1 pins (RX, TX): GPIO3_A6, GPIO3_A4
++
+ ### rk3328-opp-1.4ghz
+ 
+ Adds the 1.4GHz opp for overclocking
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2c0.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2c0.dts
+new file mode 100644
+index 000000000..af2d61ecd
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2c0.dts
+@@ -0,0 +1,13 @@
++/dts-v1/;
++
++/ {
++	compatible = "rockchip,rk3328";
++
++	fragment@0 {
++		target-path = "/i2c@ff150000";
++
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-uart1.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-uart1.dts
+new file mode 100644
+index 000000000..9ff6a0018
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-uart1.dts
+@@ -0,0 +1,17 @@
++/dts-v1/;
++
++/ {
++	compatible = "rockchip,rk3328";
++
++	fragment@1 {
++		target = <0xffffffff>;
++
++		__overlay__ {
++			status = "okay";
++		};
++	};
++
++	__fixups__ {
++		uart1 = "/fragment@1:target:0";
++	};
++};
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/kernel/archive/rockchip64-5.17/rk3328-device-tree-overlays-uart1-i2c0.patch
+++ b/patch/kernel/archive/rockchip64-5.17/rk3328-device-tree-overlays-uart1-i2c0.patch
@@ -1,0 +1,99 @@
+From 0a11005a8a39ed8d84c42a0f29636631db621f0a Mon Sep 17 00:00:00 2001
+From: Kat Schwarz <schwar3kat@armbian.com>
+Date: Sun, 22 Jan 2023 21:16:07 +1300
+Subject: [PATCH] add-rk3328-dtbo-uart1-i2c0
+
+RK3328 UART1 and I2C0 are available on Orange Pi R1 Plus LTS 13 pin connector.
+Add two device tree overlay files for rk3328 uart1 and i2c0.
+
+Signed-off-by: Kat Schwarz <schwar3kat@armbian.com>
+---
+ arch/arm64/boot/dts/rockchip/overlay/Makefile   |  2 ++
+ .../rockchip/overlay/README.rockchip-overlays   | 12 ++++++++++++
+ .../rockchip/overlay/rockchip-rk3328-i2c0.dts   | 13 +++++++++++++
+ .../rockchip/overlay/rockchip-rk3328-uart1.dts  | 17 +++++++++++++++++
+ 4 files changed, 44 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2c0.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-uart1.dts
+
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts/rockchip/overlay/Makefile
+index 7813ae347..53f8412d7 100644
+--- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
++++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
+@@ -3,6 +3,8 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
+ 	rockchip-i2c7.dtbo \
+ 	rockchip-i2c8.dtbo \
+ 	rockchip-pcie-gen2.dtbo \
++    rockchip-rk3328-i2c0.dtbo \
++    rockchip-rk3328-uart1.dtbo \
+ 	rockchip-rk3328-opp-1.4ghz.dtbo \
+ 	rockchip-rk3328-opp-1.5ghz.dtbo \
+ 	rockchip-rk3399-opp-2ghz.dtbo \
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
+index 07e79b04d..16942a511 100644
+--- a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
++++ b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
+@@ -29,6 +29,18 @@ I2C8 pins (pi-conn) (pi-conn) (SCL, SDA): GPIO1-C5, GPIO1-C4
+ Enables PCIe Gen2 link speed on RK3399.
+ WARNING! Not officially supported by Rockchip!!!
+ 
++### rk3328-i2c0
++
++Activates TWI/I2C bus 0
++
++I2C0 (SCL, SDA): GPIO2-D0, GPIO2-D1
++
++### rk3328-uart1
++
++Activates UART1
++
++UART1 pins (RX, TX): GPIO3_A6, GPIO3_A4
++
+ ### rk3328-opp-1.4ghz
+ 
+ Adds the 1.4GHz opp for overclocking
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2c0.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2c0.dts
+new file mode 100644
+index 000000000..af2d61ecd
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2c0.dts
+@@ -0,0 +1,13 @@
++/dts-v1/;
++
++/ {
++	compatible = "rockchip,rk3328";
++
++	fragment@0 {
++		target-path = "/i2c@ff150000";
++
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-uart1.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-uart1.dts
+new file mode 100644
+index 000000000..9ff6a0018
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-uart1.dts
+@@ -0,0 +1,17 @@
++/dts-v1/;
++
++/ {
++	compatible = "rockchip,rk3328";
++
++	fragment@1 {
++		target = <0xffffffff>;
++
++		__overlay__ {
++			status = "okay";
++		};
++	};
++
++	__fixups__ {
++		uart1 = "/fragment@1:target:0";
++	};
++};
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/kernel/archive/rockchip64-5.18/rk3328-device-tree-overlays-uart1-i2c0.patch
+++ b/patch/kernel/archive/rockchip64-5.18/rk3328-device-tree-overlays-uart1-i2c0.patch
@@ -1,0 +1,99 @@
+From 0a11005a8a39ed8d84c42a0f29636631db621f0a Mon Sep 17 00:00:00 2001
+From: Kat Schwarz <schwar3kat@armbian.com>
+Date: Sun, 22 Jan 2023 21:16:07 +1300
+Subject: [PATCH] add-rk3328-dtbo-uart1-i2c0
+
+RK3328 UART1 and I2C0 are available on Orange Pi R1 Plus LTS 13 pin connector.
+Add two device tree overlay files for rk3328 uart1 and i2c0.
+
+Signed-off-by: Kat Schwarz <schwar3kat@armbian.com>
+---
+ arch/arm64/boot/dts/rockchip/overlay/Makefile   |  2 ++
+ .../rockchip/overlay/README.rockchip-overlays   | 12 ++++++++++++
+ .../rockchip/overlay/rockchip-rk3328-i2c0.dts   | 13 +++++++++++++
+ .../rockchip/overlay/rockchip-rk3328-uart1.dts  | 17 +++++++++++++++++
+ 4 files changed, 44 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2c0.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-uart1.dts
+
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts/rockchip/overlay/Makefile
+index 7813ae347..53f8412d7 100644
+--- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
++++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
+@@ -3,6 +3,8 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
+ 	rockchip-i2c7.dtbo \
+ 	rockchip-i2c8.dtbo \
+ 	rockchip-pcie-gen2.dtbo \
++    rockchip-rk3328-i2c0.dtbo \
++    rockchip-rk3328-uart1.dtbo \
+ 	rockchip-rk3328-opp-1.4ghz.dtbo \
+ 	rockchip-rk3328-opp-1.5ghz.dtbo \
+ 	rockchip-rk3399-opp-2ghz.dtbo \
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
+index 07e79b04d..16942a511 100644
+--- a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
++++ b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
+@@ -29,6 +29,18 @@ I2C8 pins (pi-conn) (pi-conn) (SCL, SDA): GPIO1-C5, GPIO1-C4
+ Enables PCIe Gen2 link speed on RK3399.
+ WARNING! Not officially supported by Rockchip!!!
+ 
++### rk3328-i2c0
++
++Activates TWI/I2C bus 0
++
++I2C0 (SCL, SDA): GPIO2-D0, GPIO2-D1
++
++### rk3328-uart1
++
++Activates UART1
++
++UART1 pins (RX, TX): GPIO3_A6, GPIO3_A4
++
+ ### rk3328-opp-1.4ghz
+ 
+ Adds the 1.4GHz opp for overclocking
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2c0.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2c0.dts
+new file mode 100644
+index 000000000..af2d61ecd
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2c0.dts
+@@ -0,0 +1,13 @@
++/dts-v1/;
++
++/ {
++	compatible = "rockchip,rk3328";
++
++	fragment@0 {
++		target-path = "/i2c@ff150000";
++
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-uart1.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-uart1.dts
+new file mode 100644
+index 000000000..9ff6a0018
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-uart1.dts
+@@ -0,0 +1,17 @@
++/dts-v1/;
++
++/ {
++	compatible = "rockchip,rk3328";
++
++	fragment@1 {
++		target = <0xffffffff>;
++
++		__overlay__ {
++			status = "okay";
++		};
++	};
++
++	__fixups__ {
++		uart1 = "/fragment@1:target:0";
++	};
++};
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/kernel/archive/rockchip64-5.19/rk3328-device-tree-overlays-uart1-i2c0.patch
+++ b/patch/kernel/archive/rockchip64-5.19/rk3328-device-tree-overlays-uart1-i2c0.patch
@@ -1,0 +1,99 @@
+From 0a11005a8a39ed8d84c42a0f29636631db621f0a Mon Sep 17 00:00:00 2001
+From: Kat Schwarz <schwar3kat@armbian.com>
+Date: Sun, 22 Jan 2023 21:16:07 +1300
+Subject: [PATCH] add-rk3328-dtbo-uart1-i2c0
+
+RK3328 UART1 and I2C0 are available on Orange Pi R1 Plus LTS 13 pin connector.
+Add two device tree overlay files for rk3328 uart1 and i2c0.
+
+Signed-off-by: Kat Schwarz <schwar3kat@armbian.com>
+---
+ arch/arm64/boot/dts/rockchip/overlay/Makefile   |  2 ++
+ .../rockchip/overlay/README.rockchip-overlays   | 12 ++++++++++++
+ .../rockchip/overlay/rockchip-rk3328-i2c0.dts   | 13 +++++++++++++
+ .../rockchip/overlay/rockchip-rk3328-uart1.dts  | 17 +++++++++++++++++
+ 4 files changed, 44 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2c0.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-uart1.dts
+
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts/rockchip/overlay/Makefile
+index 7813ae347..53f8412d7 100644
+--- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
++++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
+@@ -3,6 +3,8 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
+ 	rockchip-i2c7.dtbo \
+ 	rockchip-i2c8.dtbo \
+ 	rockchip-pcie-gen2.dtbo \
++    rockchip-rk3328-i2c0.dtbo \
++    rockchip-rk3328-uart1.dtbo \
+ 	rockchip-rk3328-opp-1.4ghz.dtbo \
+ 	rockchip-rk3328-opp-1.5ghz.dtbo \
+ 	rockchip-rk3399-opp-2ghz.dtbo \
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
+index 07e79b04d..16942a511 100644
+--- a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
++++ b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
+@@ -29,6 +29,18 @@ I2C8 pins (pi-conn) (pi-conn) (SCL, SDA): GPIO1-C5, GPIO1-C4
+ Enables PCIe Gen2 link speed on RK3399.
+ WARNING! Not officially supported by Rockchip!!!
+ 
++### rk3328-i2c0
++
++Activates TWI/I2C bus 0
++
++I2C0 (SCL, SDA): GPIO2-D0, GPIO2-D1
++
++### rk3328-uart1
++
++Activates UART1
++
++UART1 pins (RX, TX): GPIO3_A6, GPIO3_A4
++
+ ### rk3328-opp-1.4ghz
+ 
+ Adds the 1.4GHz opp for overclocking
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2c0.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2c0.dts
+new file mode 100644
+index 000000000..af2d61ecd
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2c0.dts
+@@ -0,0 +1,13 @@
++/dts-v1/;
++
++/ {
++	compatible = "rockchip,rk3328";
++
++	fragment@0 {
++		target-path = "/i2c@ff150000";
++
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-uart1.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-uart1.dts
+new file mode 100644
+index 000000000..9ff6a0018
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-uart1.dts
+@@ -0,0 +1,17 @@
++/dts-v1/;
++
++/ {
++	compatible = "rockchip,rk3328";
++
++	fragment@1 {
++		target = <0xffffffff>;
++
++		__overlay__ {
++			status = "okay";
++		};
++	};
++
++	__fixups__ {
++		uart1 = "/fragment@1:target:0";
++	};
++};
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/kernel/archive/rockchip64-6.0/rk3328-device-tree-overlays-uart1-i2c0.patch
+++ b/patch/kernel/archive/rockchip64-6.0/rk3328-device-tree-overlays-uart1-i2c0.patch
@@ -1,0 +1,99 @@
+From 0a11005a8a39ed8d84c42a0f29636631db621f0a Mon Sep 17 00:00:00 2001
+From: Kat Schwarz <schwar3kat@armbian.com>
+Date: Sun, 22 Jan 2023 21:16:07 +1300
+Subject: [PATCH] add-rk3328-dtbo-uart1-i2c0
+
+RK3328 UART1 and I2C0 are available on Orange Pi R1 Plus LTS 13 pin connector.
+Add two device tree overlay files for rk3328 uart1 and i2c0.
+
+Signed-off-by: Kat Schwarz <schwar3kat@armbian.com>
+---
+ arch/arm64/boot/dts/rockchip/overlay/Makefile   |  2 ++
+ .../rockchip/overlay/README.rockchip-overlays   | 12 ++++++++++++
+ .../rockchip/overlay/rockchip-rk3328-i2c0.dts   | 13 +++++++++++++
+ .../rockchip/overlay/rockchip-rk3328-uart1.dts  | 17 +++++++++++++++++
+ 4 files changed, 44 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2c0.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-uart1.dts
+
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts/rockchip/overlay/Makefile
+index 7813ae347..53f8412d7 100644
+--- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
++++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
+@@ -3,6 +3,8 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
+ 	rockchip-i2c7.dtbo \
+ 	rockchip-i2c8.dtbo \
+ 	rockchip-pcie-gen2.dtbo \
++    rockchip-rk3328-i2c0.dtbo \
++    rockchip-rk3328-uart1.dtbo \
+ 	rockchip-rk3328-opp-1.4ghz.dtbo \
+ 	rockchip-rk3328-opp-1.5ghz.dtbo \
+ 	rockchip-rk3399-opp-2ghz.dtbo \
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
+index 07e79b04d..16942a511 100644
+--- a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
++++ b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
+@@ -29,6 +29,18 @@ I2C8 pins (pi-conn) (pi-conn) (SCL, SDA): GPIO1-C5, GPIO1-C4
+ Enables PCIe Gen2 link speed on RK3399.
+ WARNING! Not officially supported by Rockchip!!!
+ 
++### rk3328-i2c0
++
++Activates TWI/I2C bus 0
++
++I2C0 (SCL, SDA): GPIO2-D0, GPIO2-D1
++
++### rk3328-uart1
++
++Activates UART1
++
++UART1 pins (RX, TX): GPIO3_A6, GPIO3_A4
++
+ ### rk3328-opp-1.4ghz
+ 
+ Adds the 1.4GHz opp for overclocking
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2c0.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2c0.dts
+new file mode 100644
+index 000000000..af2d61ecd
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2c0.dts
+@@ -0,0 +1,13 @@
++/dts-v1/;
++
++/ {
++	compatible = "rockchip,rk3328";
++
++	fragment@0 {
++		target-path = "/i2c@ff150000";
++
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-uart1.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-uart1.dts
+new file mode 100644
+index 000000000..9ff6a0018
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-uart1.dts
+@@ -0,0 +1,17 @@
++/dts-v1/;
++
++/ {
++	compatible = "rockchip,rk3328";
++
++	fragment@1 {
++		target = <0xffffffff>;
++
++		__overlay__ {
++			status = "okay";
++		};
++	};
++
++	__fixups__ {
++		uart1 = "/fragment@1:target:0";
++	};
++};
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/kernel/archive/rockchip64-6.1/rk3328-device-tree-overlays-uart1-i2c0.patch
+++ b/patch/kernel/archive/rockchip64-6.1/rk3328-device-tree-overlays-uart1-i2c0.patch
@@ -1,0 +1,99 @@
+From 0a11005a8a39ed8d84c42a0f29636631db621f0a Mon Sep 17 00:00:00 2001
+From: Kat Schwarz <schwar3kat@armbian.com>
+Date: Sun, 22 Jan 2023 21:16:07 +1300
+Subject: [PATCH] add-rk3328-dtbo-uart1-i2c0
+
+RK3328 UART1 and I2C0 are available on Orange Pi R1 Plus LTS 13 pin connector.
+Add two device tree overlay files for rk3328 uart1 and i2c0.
+
+Signed-off-by: Kat Schwarz <schwar3kat@armbian.com>
+---
+ arch/arm64/boot/dts/rockchip/overlay/Makefile   |  2 ++
+ .../rockchip/overlay/README.rockchip-overlays   | 12 ++++++++++++
+ .../rockchip/overlay/rockchip-rk3328-i2c0.dts   | 13 +++++++++++++
+ .../rockchip/overlay/rockchip-rk3328-uart1.dts  | 17 +++++++++++++++++
+ 4 files changed, 44 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2c0.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-uart1.dts
+
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts/rockchip/overlay/Makefile
+index 7813ae347..53f8412d7 100644
+--- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
++++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
+@@ -3,6 +3,8 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
+ 	rockchip-i2c7.dtbo \
+ 	rockchip-i2c8.dtbo \
+ 	rockchip-pcie-gen2.dtbo \
++    rockchip-rk3328-i2c0.dtbo \
++    rockchip-rk3328-uart1.dtbo \
+ 	rockchip-rk3328-opp-1.4ghz.dtbo \
+ 	rockchip-rk3328-opp-1.5ghz.dtbo \
+ 	rockchip-rk3399-opp-2ghz.dtbo \
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
+index 07e79b04d..16942a511 100644
+--- a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
++++ b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
+@@ -29,6 +29,18 @@ I2C8 pins (pi-conn) (pi-conn) (SCL, SDA): GPIO1-C5, GPIO1-C4
+ Enables PCIe Gen2 link speed on RK3399.
+ WARNING! Not officially supported by Rockchip!!!
+ 
++### rk3328-i2c0
++
++Activates TWI/I2C bus 0
++
++I2C0 (SCL, SDA): GPIO2-D0, GPIO2-D1
++
++### rk3328-uart1
++
++Activates UART1
++
++UART1 pins (RX, TX): GPIO3_A6, GPIO3_A4
++
+ ### rk3328-opp-1.4ghz
+ 
+ Adds the 1.4GHz opp for overclocking
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2c0.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2c0.dts
+new file mode 100644
+index 000000000..af2d61ecd
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2c0.dts
+@@ -0,0 +1,13 @@
++/dts-v1/;
++
++/ {
++	compatible = "rockchip,rk3328";
++
++	fragment@0 {
++		target-path = "/i2c@ff150000";
++
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-uart1.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-uart1.dts
+new file mode 100644
+index 000000000..9ff6a0018
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-uart1.dts
+@@ -0,0 +1,17 @@
++/dts-v1/;
++
++/ {
++	compatible = "rockchip,rk3328";
++
++	fragment@1 {
++		target = <0xffffffff>;
++
++		__overlay__ {
++			status = "okay";
++		};
++	};
++
++	__fixups__ {
++		uart1 = "/fragment@1:target:0";
++	};
++};
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+


### PR DESCRIPTION
RK3328 UART1 and I2C0 are available on Orange Pi R1 Plus LTS 13 pin connector. 
Add device tree overlay files for rk3328 uart1 and i2c0.

I have noticed chatter on Github (@rpardini) around dtbo naming conventions.  I'm therefore not absolutely clear on what is expected.  Historic dtbo's for rk33xx are formatted with a rockchip prefix (there are some exceptions).

I've used the rockchip prefix:
rockchip-rk3328-i2c0.dtbo
rockchip-rk3328-uart1.dtbo

And the "Hardware" selection in armbian-config displays them correctly without the prefix.
![armbian-config](https://user-images.githubusercontent.com/61094841/215905069-8e6c55ea-40c9-4c19-b852-f09b4c899f74.png)

Jira reference number [AR-1509]
# How Has This Been Tested?
- [x] Builds correctly and produces the dtbo's
- [x] Tested that the "Hardware" can be selected via armbian-config
- [x] Tested on orangepi-r1plus-lts

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

[AR-1509]: https://armbian.atlassian.net/browse/AR-1509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ