### PR TITLE
update bl31 and ddr blobs of rk3568

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -88,8 +88,8 @@ elif [[ $BOOT_SOC == rk3566 ]]; then
 elif [[ $BOOT_SOC == rk3568 ]]; then
 
 	BOOT_SCENARIO="${BOOT_SCENARIO:=spl-blobs}"
-	DDR_BLOB="${DDR_BLOB:=rk35/rk3568_ddr_1560MHz_v1.10.bin}"
-	BL31_BLOB='rk35/rk3568_bl31_v1.28.elf'
+	DDR_BLOB="${DDR_BLOB:=rk35/rk3568_ddr_1560MHz_v1.13.bin}"
+	BL31_BLOB='rk35/rk3568_bl31_v1.32.elf'
 
 elif [[ $BOOT_SOC == rk3588 ]]; then
 


### PR DESCRIPTION
# Description

These two blob files have been in repo armbian/rkbin for a long time: armbian/rkbin#8. I test them on rock-3a today. Should be okay to update.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Tested on rock-3a

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
