### PR TITLE
Use newer gcc

### DIFF
--- a/config/sources/arm64.conf
+++ b/config/sources/arm64.conf
@@ -11,7 +11,6 @@ export NAME_INITRD='uInitrd'
 export KERNEL_IMAGE_TYPE='Image'
 
 
-[[ -z $KERNEL_COMPILER ]] && KERNEL_COMPILER="aarch64-linux-gnu-"
 [[ -z $INITRD_ARCH ]] && INITRD_ARCH=arm64
 [[ -z $UBOOT_USE_GCC ]] && UBOOT_USE_GCC='> 8.0'
 
@@ -23,10 +22,8 @@ if [ "$(uname -m)" = "aarch64" ]; then
 else
 	[[ $ATF_COMPILE != "no" && -z $ATF_COMPILER ]] && ATF_COMPILER="aarch64-none-linux-gnu-"
 	[[ -z $UBOOT_COMPILER ]] && UBOOT_COMPILER="aarch64-none-linux-gnu-"
-	# > 9.2 https://armbian.atlassian.net/browse/AR-557
-	# [[ -z $KERNEL_COMPILER ]]     && KERNEL_COMPILER="aarch64-none-linux-gnu-"
-	[[ -z $KERNEL_COMPILER ]] && KERNEL_COMPILER="aarch64-linux-gnu-"
-	[[ -z $KERNEL_USE_GCC ]] && KERNEL_USE_GCC='< 9.2'
+	[[ -z $KERNEL_COMPILER ]] && KERNEL_COMPILER="aarch64-none-linux-gnu-"
+	[[ -z $KERNEL_USE_GCC ]] && KERNEL_USE_GCC='> 5.3'
 fi
 
 [[ $ATF_COMPILE != "no" && -z $ATFSOURCE ]] && ATFSOURCE='https://github.com/ARM-software/arm-trusted-firmware'

--- a/config/sources/armhf.conf
+++ b/config/sources/armhf.conf
@@ -11,17 +11,16 @@ export NAME_INITRD='uInitrd'
 export INITRD_ARCH='arm'
 export KERNEL_IMAGE_TYPE='Image'
 
-[[ -z $KERNEL_COMPILER ]] && KERNEL_COMPILER='arm-linux-gnueabihf-'
 [[ -z $UBOOT_USE_GCC ]] && UBOOT_USE_GCC='> 8.0'
 
 if [ "$(uname -m)" = "aarch64" ]; then
 	[[ -z $UBOOT_COMPILER ]] && UBOOT_COMPILER='arm-linux-gnueabihf-'
+	[[ -z $KERNEL_COMPILER ]] && KERNEL_COMPILER='arm-linux-gnueabihf-'
 	[[ -z $KERNEL_USE_GCC ]] && KERNEL_USE_GCC='> 8.0'
 else
-	# > 9.2 https://armbian.atlassian.net/browse/AR-557
-	#[[ -z $KERNEL_COMPILER ]]      && KERNEL_COMPILER="arm-none-linux-gnueabihf-"
 	[[ -z $UBOOT_COMPILER ]] && UBOOT_COMPILER='arm-none-linux-gnueabihf-'
-	[[ -z $KERNEL_USE_GCC ]] && KERNEL_USE_GCC='< 9.2'
+	[[ -z $KERNEL_COMPILER ]] && KERNEL_COMPILER="arm-none-linux-gnueabihf-"
+	[[ -z $KERNEL_USE_GCC ]] && KERNEL_USE_GCC='> 5.1'
 fi
 
 # System toolchains don't have the -none- variant, remove it

--- a/lib/functions/compilation/utils-compilation.sh
+++ b/lib/functions/compilation/utils-compilation.sh
@@ -19,27 +19,24 @@ find_toolchain() {
 	}
 	local compiler=$1
 	local expression=$2
-	local dist=10
 	local toolchain=""
-	# extract target major.minor version from expression
-	local target_ver
-	target_ver=$(grep -oE "[[:digit:]]+\.[[:digit:]]" <<< "$expression")
+	local version=0
 	for dir in "${SRC}"/cache/toolchain/*/; do
 		# check if is a toolchain for current $ARCH
 		[[ ! -f ${dir}bin/${compiler}gcc ]] && continue
+
 		# get toolchain major.minor version
 		local gcc_ver
 		gcc_ver=$("${dir}bin/${compiler}gcc" -dumpversion | grep -oE "^[[:digit:]]+\.[[:digit:]]")
+
 		# check if toolchain version satisfies requirement
-		awk "BEGIN{exit ! ($gcc_ver $expression)}" > /dev/null || continue
-		# check if found version is the closest to target
-		# may need different logic here with more than 1 digit minor version numbers
+		# FIXME: Unsupport more than 1 digit minor version numbers
 		# numbers: 3.9 > 3.10; versions: 3.9 < 3.10
-		# dpkg --compare-versions can be used here if operators are changed
-		local d
-		d=$(awk '{x = $1 - $2}{printf "%.1f\n", (x > 0) ? x : -x}' <<< "$target_ver $gcc_ver")
-		if awk "BEGIN{exit ! ($d < $dist)}" > /dev/null; then
-			dist=$d
+		awk "BEGIN{exit ! ($gcc_ver $expression)}" > /dev/null || continue
+
+		# Check if found version is newer
+		if linux-version compare $gcc_ver ge $version; then
+			version=$gcc_ver
 			toolchain=${dir}bin
 		fi
 	done


### PR DESCRIPTION
# Description

We download some newer gcc but we didn't use it.

Since buster is eos, #2403 isn't a issue now.

So let use newer gcc.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Build arm
- [X] Build aarch64

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
