### PR TITLE
variable indicating the compression ratio rootfs

### DIFF
--- a/config/templates/config-example.conf
+++ b/config/templates/config-example.conf
@@ -35,3 +35,5 @@ LIB_TAG="master"			# change to "branchname" to use any branch currently availabl
 USE_TORRENT="no"			# use torrent network for faster toolchain and cache download
 DOWNLOAD_MIRROR=""			# set to "china" to use mirrors.tuna.tsinghua.edu.cn
 CARD_DEVICE=""				# device name /dev/sdx of your SD card to burn directly to the card when done
+K_ZST="5"				# variable indicating compression ratio rootfs 1 fast 19 slow
+

--- a/lib/functions/rootfs/create-cache.sh
+++ b/lib/functions/rootfs/create-cache.sh
@@ -289,7 +289,7 @@ create_rootfs_cache() {
 		umount_chroot "$SDCARD"
 
 		tar cp --xattrs --directory=$SDCARD/ --exclude='./dev/*' --exclude='./proc/*' --exclude='./run/*' --exclude='./tmp/*' \
-			--exclude='./sys/*' --exclude='./home/*' --exclude='./root/*' . | pv -p -b -r -s $(du -sb $SDCARD/ | cut -f1) -N "$cache_name" | zstdmt -19 -c > $cache_fname
+			--exclude='./sys/*' --exclude='./home/*' --exclude='./root/*' . | pv -p -b -r -s $(du -sb $SDCARD/ | cut -f1) -N "$cache_name" | zstdmt -"$K_ZST" -c > $cache_fname
 
 		# sign rootfs cache archive that it can be used for web cache once. Internal purposes
 		if [[ -n "${GPG_PASS}" && "${SUDO_USER}" ]]; then


### PR DESCRIPTION
This does not affect the downloaded ready-made ROOTFS, but the new compression value dramatically increased the process time (2-4 times) for user configurations. Adding a variable indicating the compression ratio will make it easy to select the desired value according to the conditions of use of the assembly system. By default, the previous value is set, for a mass build (which is executed from command scripts), it is easy to add any value of the maintainer's choice and will allow you to maintain a high build speed for custom versions that are usually executed on conventional ARM devices with low performance.