### PR TITLE
Disables the use of the obiabf repository by default

### DIFF
--- a/config/desktop/jammy/appgroups/3dsupport/sources/apt/oibaf.source
+++ b/config/desktop/jammy/appgroups/3dsupport/sources/apt/oibaf.source
@@ -1,1 +1,1 @@
-deb [signed-by=/usr/share/keyrings/oibaf.gpg] http://ppa.launchpadcontent.net/oibaf/graphics-drivers/ubuntu/ jammy main
+#deb [signed-by=/usr/share/keyrings/oibaf.gpg] http://ppa.launchpadcontent.net/oibaf/graphics-drivers/ubuntu/ jammy main


### PR DESCRIPTION
Disables the use of the obiabf repository by default. Using these packages by default regularly causes problems. The background does not work, the DE does not start, etc. testing has shown that the current version of mesa works fine and does not create problems with all DE. Users who need this experimental version can enable and use it themselves.