### PR TITLE
teres-a64 -> olimex-teres-a64

### DIFF
--- a/config/boards/olimex-teres-a64.csc
+++ b/config/boards/olimex-teres-a64.csc
@@ -1,5 +1,5 @@
 # Allwinner A64 quad core 2GB SoC Wi-Fi/BT
-BOARD_NAME="Teres A64"
+BOARD_NAME="OLIMEX Teres A64"
 BOARDFAMILY="sun50iw1"
 BOOTCONFIG="teres_i_defconfig"
 KERNEL_TARGET="legacy,current,edge"


### PR DESCRIPTION
Changed to follow the naming convention specified in the docs