### PR TITLE
Add TV Box targets to stable builds

### DIFF
--- a/config/targets.conf
+++ b/config/targets.conf
@@ -4,6 +4,14 @@
 #                                                     minimal                                 (adv)ertise                                                       #
 #################################################################################################################################################################
 
+# aml-s9xx-box
+aml-s9xx-box              current         bullseye    cli                      stable         yes
+aml-s9xx-box              current         jammy       cli                      stable         yes
+#
+aml-s9xx-box              current         bullseye    desktop                  stable         yes            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+aml-s9xx-box              current         jammy       desktop                  stable         yes            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+
+
 # Bananapi M1 / M1+ A20
 bananapi                  current         bullseye    cli                      stable         yes
 bananapi                  current         jammy       cli                      stable         adv
@@ -683,6 +691,15 @@ rk322x-box                current         jammy       cli                      s
 rk322x-box                current         jammy       desktop                  stable         adv            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 #
 rk322x-box                edge            bullseye    cli                      stable         no
+
+
+# rk3318-box
+rk3318-box                current         bullseye    cli                      stable         yes
+rk3318-box                current         jammy       cli                      stable         yes
+#
+rk3318-box                current         jammy       desktop                  stable         yes            xfce          config_base   3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+#
+rk3318-box                edge            bullseye    cli                      stable         no
 
 
 # Rock64


### PR DESCRIPTION
Add TV Box targets to stable builds per discussion at the 23/01/18 Developers Meeting.
Added aml-s9xx-box and rk3318-box (rk322x-box was already there)

 Changes to be committed:
	modified:   config/targets.conf

