### PR TITLE
khadas-edge2: very initial patches from Khadas tree, rebased on top of Radxa/rk3.4

### DIFF
--- a/patch/kernel/rockchip-rk3588-legacy/3000-add-board-khadas-edge2-and-drivers.patch
+++ b/patch/kernel/rockchip-rk3588-legacy/3000-add-board-khadas-edge2-and-drivers.patch
@@ -1,4 +1,4 @@
-From 498b68833515c25bba637ae715d07d0599b5c7e1 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Tue, 19 Jul 2022 08:55:30 +0800
 Subject: Some of Khadas Edge2 DT, mcu stuff extracted from Khadas .66 tree,
@@ -8,7 +8,6 @@ This does not include all changes from Khadas, has has
 - all the DT, modified to avoid clashing with the common dtsi files
 - some new drivers used in the DT: mcu, wdt
 - hacks to other drivers
-
 ---
  arch/arm64/boot/dts/rockchip/rk3588-nvr-demo-khadas-edge2.dtsi     |  832 +++++
  arch/arm64/boot/dts/rockchip/rk3588-rk806-single-khadas-edge2.dtsi |  396 +++

--- a/patch/kernel/rockchip-rk3588-legacy/3000-add-board-khadas-edge2-and-drivers.patch
+++ b/patch/kernel/rockchip-rk3588-legacy/3000-add-board-khadas-edge2-and-drivers.patch
@@ -1,0 +1,5602 @@
+From 498b68833515c25bba637ae715d07d0599b5c7e1 Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Tue, 19 Jul 2022 08:55:30 +0800
+Subject: Some of Khadas Edge2 DT, mcu stuff extracted from Khadas .66 tree,
+ rebased against .100
+
+This does not include all changes from Khadas, has has
+- all the DT, modified to avoid clashing with the common dtsi files
+- some new drivers used in the DT: mcu, wdt
+- hacks to other drivers
+
+---
+ arch/arm64/boot/dts/rockchip/rk3588-nvr-demo-khadas-edge2.dtsi     |  832 +++++
+ arch/arm64/boot/dts/rockchip/rk3588-rk806-single-khadas-edge2.dtsi |  396 +++
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi      |  468 +++
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts              |  951 ++++++
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi             | 1705 ++++++++++
+ drivers/bluetooth/btbcm.c                                          |    1 +
+ drivers/input/sensors/accel/kxtj9.c                                |   18 +-
+ drivers/input/sensors/sensor-dev.c                                 |    2 +-
+ drivers/leds/leds-gpio.c                                           |   40 +-
+ drivers/misc/Kconfig                                               |   18 +-
+ drivers/misc/Makefile                                              |    4 +-
+ drivers/misc/khadas-mcu.c                                          |  696 ++++
+ drivers/thermal/rockchip_thermal.c                                 |   17 +
+ drivers/watchdog/Kconfig                                           |   10 +
+ drivers/watchdog/Makefile                                          |    1 +
+ drivers/watchdog/khadas_wdt.c                                      |  157 +
+ include/dt-bindings/soc/rockchip,boot-mode.h                       |    3 +-
+ 17 files changed, 5305 insertions(+), 14 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-nvr-demo-khadas-edge2.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-nvr-demo-khadas-edge2.dtsi
+new file mode 100644
+index 000000000000..ea7304d7e60d
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nvr-demo-khadas-edge2.dtsi
+@@ -0,0 +1,832 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2021 Rockchip Electronics Co., Ltd.
++ *
++ */
++
++#include "rk3588.dtsi"
++#include "rk3588-nvr.dtsi"
++#include "rk3588-rk806-single.dtsi"
++
++/ {
++	i2s0_sound: i2s0-sound {
++		status = "okay";
++		compatible = "simple-audio-card";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,mclk-fs = <256>;
++		simple-audio-card,name = "rockchip,es8311";
++		simple-audio-card,dai-link@0 {
++			format = "i2s";
++			cpu {
++				sound-dai = <&i2s0_8ch>;
++			};
++			codec {
++				sound-dai = <&es8311>;
++			};
++		};
++	};
++
++	leds: leds {
++		compatible = "gpio-leds";
++		hdd_led: hdd-led {
++			gpios = <&gpio3 RK_PC1 GPIO_ACTIVE_HIGH>;
++			default-state = "off";
++		};
++		net_led: net-led {
++			gpios = <&gpio3 RK_PC0 GPIO_ACTIVE_HIGH>;
++			default-state = "off";
++		};
++		work_led: work-led {
++			gpios = <&gpio3 RK_PB7 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "heartbeat";
++		};
++	};
++
++	pcie30_avdd0v75: pcie30-avdd0v75 {
++		compatible = "regulator-fixed";
++		regulator-name = "pcie30_avdd0v75";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <750000>;
++		regulator-max-microvolt = <750000>;
++		vin-supply = <&vdd_0v75_s0>;
++	};
++
++	pcie30_avdd1v8: pcie30-avdd1v8 {
++		compatible = "regulator-fixed";
++		regulator-name = "pcie30_avdd1v8";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&avcc_1v8_s0>;
++	};
++
++	vcc12v_dcin: vcc12v-dcin {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc12v_dcin";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <12000000>;
++		regulator-max-microvolt = <12000000>;
++	};
++
++	vcc3v3_pcie30: vcc3v3-pcie30 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc3v3_pcie30";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		enable-active-high;
++		gpios = <&gpio3 RK_PD5 GPIO_ACTIVE_HIGH>;
++		startup-delay-us = <7500>;
++		vin-supply = <&vcc12v_dcin>;
++	};
++
++	vcc5v0_sys: vcc5v0-sys {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc12v_dcin>;
++	};
++
++	vcc5v0_host: vcc5v0-host-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_host";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		enable-active-high;
++		gpio = <&gpio4 RK_PB0 GPIO_ACTIVE_HIGH>;
++		vin-supply = <&vcc5v0_sys>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc5v0_host_en>;
++	};
++
++	vcc5v0_otg: vcc5v0-otg-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_otg";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		enable-active-high;
++		gpio = <&gpio4 RK_PA7 GPIO_ACTIVE_HIGH>;
++		vin-supply = <&vcc5v0_sys>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc5v0_otg_en>;
++	};
++
++	vcc_1v1_nldo_s3: vcc-1v1-nldo-s3 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_1v1_nldo_s3";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <1100000>;
++		regulator-max-microvolt = <1100000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++};
++
++&combphy0_ps {
++	pinctrl-names = "default";
++	pinctrl-0 = <&sata0_pm_reset>;
++	status = "okay";
++};
++
++&combphy1_ps {
++	pinctrl-names = "default";
++	pinctrl-0 = <&sata1_pm_reset>;
++	status = "okay";
++};
++
++&combphy2_psu {
++	status = "okay";
++};
++
++&dp0 {
++	pinctrl-0 = <&dp0m2_pins>;
++	pinctrl-names = "default";
++	status = "okay";
++};
++
++&dp0_in_vp0 {
++	status = "okay";
++};
++
++&dp0_in_vp1 {
++	status = "okay";
++};
++
++&dp0_in_vp2 {
++	status = "okay";
++};
++
++&dp1 {
++	pinctrl-0 = <&dp1m2_pins &dp1_hdmi_ctl>;
++	pinctrl-names = "default";
++	status = "okay";
++};
++
++&dp1_in_vp0 {
++	status = "okay";
++};
++
++&dp1_in_vp1 {
++	status = "okay";
++};
++
++&dp1_in_vp2 {
++	status = "okay";
++};
++
++&gmac0 {
++	/* Use rgmii-rxid mode to disable rx delay inside Soc */
++	phy-mode = "rgmii-rxid";
++	clock_in_out = "output";
++
++	snps,reset-gpio = <&gpio4 RK_PB3 GPIO_ACTIVE_LOW>;
++	snps,reset-active-low;
++	/* Reset time is 20ms, 100ms for rtl8211f */
++	snps,reset-delays-us = <0 20000 100000>;
++
++	pinctrl-names = "default";
++	pinctrl-0 = <&gmac0_miim
++		     &gmac0_tx_bus2
++		     &gmac0_rx_bus2
++		     &gmac0_rgmii_clk
++		     &gmac0_rgmii_bus>;
++
++	tx_delay = <0x44>;
++	/* rx_delay = <0x4f>; */
++
++	phy-handle = <&rgmii_phy0>;
++	status = "okay";
++};
++
++&gmac1 {
++	/* Use rgmii-rxid mode to disable rx delay inside Soc */
++	phy-mode = "rgmii-rxid";
++	clock_in_out = "output";
++
++	snps,reset-gpio = <&gpio4 RK_PA2 GPIO_ACTIVE_LOW>;
++	snps,reset-active-low;
++	/* Reset time is 20ms, 100ms for rtl8211f */
++	snps,reset-delays-us = <0 20000 100000>;
++
++	pinctrl-names = "default";
++	pinctrl-0 = <&gmac1_miim
++		     &gmac1_tx_bus2
++		     &gmac1_rx_bus2
++		     &gmac1_rgmii_clk
++		     &gmac1_rgmii_bus>;
++
++	tx_delay = <0x42>;
++	/* rx_delay = <0x4f>; */
++
++	phy-handle = <&rgmii_phy1>;
++	status = "okay";
++};
++
++&hdmi0 {
++	enable-gpios = <&gpio4 RK_PB1 GPIO_ACTIVE_HIGH>;
++	status = "okay";
++};
++
++&hdmi0_in_vp0 {
++	status = "okay";
++};
++
++&hdmi0_in_vp1 {
++	status = "okay";
++};
++
++&hdmi0_in_vp2 {
++	status = "okay";
++};
++
++&hdmi0_sound {
++	status = "okay";
++};
++
++&hdmi1 {
++	enable-gpios = <&gpio4 RK_PB2 GPIO_ACTIVE_HIGH>;
++	status = "okay";
++};
++
++&hdmi1_in_vp0 {
++	status = "okay";
++};
++
++&hdmi1_in_vp1 {
++	status = "okay";
++};
++
++&hdmi1_in_vp2 {
++	status = "okay";
++};
++
++&hdmi1_sound {
++	status = "okay";
++};
++
++&hdptxphy_hdmi0 {
++	status = "okay";
++};
++
++&hdptxphy_hdmi1 {
++	status = "okay";
++};
++
++&i2c0 {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c0m2_xfer>;
++
++	vdd_cpu_big0_s0: vdd_cpu_big0_mem_s0: rk8602@42 {
++		compatible = "rockchip,rk8602";
++		reg = <0x42>;
++		vin-supply = <&vcc5v0_sys>;
++		regulator-compatible = "rk860x-reg";
++		regulator-name = "vdd_cpu_big0_s0";
++		regulator-min-microvolt = <550000>;
++		regulator-max-microvolt = <1050000>;
++		regulator-ramp-delay = <2300>;
++		rockchip,suspend-voltage-selector = <1>;
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++
++	vdd_cpu_big1_s0: vdd_cpu_big1_mem_s0: rk8603@43 {
++		compatible = "rockchip,rk8603";
++		reg = <0x43>;
++		vin-supply = <&vcc5v0_sys>;
++		regulator-compatible = "rk860x-reg";
++		regulator-name = "vdd_cpu_big1_s0";
++		regulator-min-microvolt = <550000>;
++		regulator-max-microvolt = <1050000>;
++		regulator-ramp-delay = <2300>;
++		rockchip,suspend-voltage-selector = <1>;
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++};
++
++&i2c2 {
++	status = "okay";
++
++	vdd_npu_s0: vdd_npu_mem_s0: rk8602@42 {
++		compatible = "rockchip,rk8602";
++		reg = <0x42>;
++		vin-supply = <&vcc5v0_sys>;
++		regulator-compatible = "rk860x-reg";
++		regulator-name = "vdd_npu_s0";
++		regulator-min-microvolt = <550000>;
++		regulator-max-microvolt = <950000>;
++		regulator-ramp-delay = <2300>;
++		rockchip,suspend-voltage-selector = <1>;
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++};
++
++&i2c3 {
++	status = "okay";
++	es8311: es8311@18 {
++		status = "okay";
++		compatible = "everest,es8311";
++		reg = <0x18>;
++		#sound-dai-cells = <0>;
++		adc-pga-gain = <6>;     /* 18dB */
++		adc-volume = <0xbf>;    /* 0dB */
++		dac-volume = <0xbf>;    /* 0dB */
++		aec-mode = "adc left, adc right";
++		clocks = <&cru I2S0_8CH_MCLKOUT>;
++		clock-names = "mclk";
++		assigned-clocks = <&cru I2S0_8CH_MCLKOUT>;
++		assigned-clock-rates = <12288000>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&i2s0_mclk>;
++	};
++};
++
++&i2c4 {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c4m3_xfer>;
++};
++
++&i2c5 {
++	status = "okay";
++};
++
++&i2c6 {
++	status = "okay";
++	hym8563: hym8563@51 {
++		compatible = "haoyu,hym8563";
++		reg = <0x51>;
++
++		pinctrl-names = "default";
++		pinctrl-0 = <&rtc_int>;
++
++		interrupt-parent = <&gpio0>;
++		interrupts = <RK_PB2 IRQ_TYPE_LEVEL_LOW>;
++		wakeup-source;
++	};
++};
++
++&i2s0_8ch {
++	status = "okay";
++	pinctrl-0 = <&i2s0_lrck
++		     &i2s0_sclk
++		     &i2s0_sdi0
++		     &i2s0_sdo0>;
++};
++
++&i2s5_8ch {
++	status = "okay";
++};
++
++&i2s6_8ch {
++	status = "okay";
++};
++
++&mdio0 {
++	rgmii_phy0: phy@1 {
++		compatible = "ethernet-phy-ieee802.3-c22";
++		reg = <0x1>;
++	};
++};
++
++&mdio1 {
++	rgmii_phy1: phy@1 {
++		compatible = "ethernet-phy-ieee802.3-c22";
++		reg = <0x1>;
++	};
++};
++
++&pcie30phy {
++	status = "okay";
++};
++
++&pcie3x4 {
++	reset-gpios = <&gpio4 RK_PB6 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc3v3_pcie30>;
++	status = "okay";
++};
++
++&pwm3 {
++	compatible = "rockchip,remotectl-pwm";
++	pinctrl-names = "default";
++	pinctrl-0 = <&pwm3m0_pins>;
++	remote_pwm_id = <3>;
++	handle_cpu_id = <1>;
++	remote_support_psci = <0>;
++	status = "okay";
++
++	ir_key1 {
++		rockchip,usercode = <0x4040>;
++		rockchip,key_table =
++			<0xf2	KEY_REPLY>,
++			<0xba	KEY_BACK>,
++			<0xf4	KEY_UP>,
++			<0xf1	KEY_DOWN>,
++			<0xef	KEY_LEFT>,
++			<0xee	KEY_RIGHT>,
++			<0xbd	KEY_HOME>,
++			<0xea	KEY_VOLUMEUP>,
++			<0xe3	KEY_VOLUMEDOWN>,
++			<0xe2	KEY_SEARCH>,
++			<0xb2	KEY_POWER>,
++			<0xbc	KEY_MUTE>,
++			<0xec	KEY_MENU>,
++			<0xbf	0x190>,
++			<0xe0	0x191>,
++			<0xe1	0x192>,
++			<0xe9	183>,
++			<0xe6	248>,
++			<0xe8	185>,
++			<0xe7	186>,
++			<0xf0	388>,
++			<0xbe	0x175>;
++	};
++
++	ir_key2 {
++		rockchip,usercode = <0xff00>;
++		rockchip,key_table =
++			<0xf9	KEY_HOME>,
++			<0xbf	KEY_BACK>,
++			<0xfb	KEY_MENU>,
++			<0xaa	KEY_REPLY>,
++			<0xb9	KEY_UP>,
++			<0xe9	KEY_DOWN>,
++			<0xb8	KEY_LEFT>,
++			<0xea	KEY_RIGHT>,
++			<0xeb	KEY_VOLUMEDOWN>,
++			<0xef	KEY_VOLUMEUP>,
++			<0xf7	KEY_MUTE>,
++			<0xe7	KEY_POWER>,
++			<0xfc	KEY_POWER>,
++			<0xa9	KEY_VOLUMEDOWN>,
++			<0xa8	KEY_PLAYPAUSE>,
++			<0xe0	KEY_VOLUMEDOWN>,
++			<0xa5	KEY_VOLUMEDOWN>,
++			<0xab	183>,
++			<0xb7	388>,
++			<0xe8	388>,
++			<0xf8	184>,
++			<0xaf	185>,
++			<0xed	KEY_VOLUMEDOWN>,
++			<0xee	186>,
++			<0xb3	KEY_VOLUMEDOWN>,
++			<0xf1	KEY_VOLUMEDOWN>,
++			<0xf2	KEY_VOLUMEDOWN>,
++			<0xf3	KEY_SEARCH>,
++			<0xb4	KEY_VOLUMEDOWN>,
++			<0xa4	KEY_SETUP>,
++			<0xbe	KEY_SEARCH>;
++	};
++
++	ir_key3 {
++		rockchip,usercode = <0x1dcc>;
++		rockchip,key_table =
++			<0xee	KEY_REPLY>,
++			<0xf0	KEY_BACK>,
++			<0xf8	KEY_UP>,
++			<0xbb	KEY_DOWN>,
++			<0xef	KEY_LEFT>,
++			<0xed	KEY_RIGHT>,
++			<0xfc	KEY_HOME>,
++			<0xf1	KEY_VOLUMEUP>,
++			<0xfd	KEY_VOLUMEDOWN>,
++			<0xb7	KEY_SEARCH>,
++			<0xff	KEY_POWER>,
++			<0xf3	KEY_MUTE>,
++			<0xbf	KEY_MENU>,
++			<0xf9	0x191>,
++			<0xf5	0x192>,
++			<0xb3	388>,
++			<0xbe	KEY_1>,
++			<0xba	KEY_2>,
++			<0xb2	KEY_3>,
++			<0xbd	KEY_4>,
++			<0xf9	KEY_5>,
++			<0xb1	KEY_6>,
++			<0xfc	KEY_7>,
++			<0xf8	KEY_8>,
++			<0xb0	KEY_9>,
++			<0xb6	KEY_0>,
++			<0xb5	KEY_BACKSPACE>;
++	};
++};
++/*
++&rk806single {
++	pinctrl-names = "default", "pmic-power-off";
++	pinctrl-0 = <&pmic_pins>, <&rk806_dvs1_null>, <&rk806_dvs2_null>, <&rk806_dvs3_null>;
++	pinctrl-1 = <&rk806_dvs1_slp>, <&rk806_dvs2_null>, <&rk806_dvs3_null>;
++
++	regulators {
++		avcc_1v8_s0: PLDO_REG1 {
++			regulator-always-on;
++			regulator-boot-on;
++			regulator-min-microvolt = <1800000>;
++			regulator-max-microvolt = <1800000>;
++			regulator-name = "avcc_1v8_s0";
++			regulator-state-mem {
++				regulator-on-in-suspend;
++				regulator-suspend-microvolt = <1800000>;
++			};
++		};
++	};
++};
++*/
++&rockchip_suspend {
++	status = "okay";
++	rockchip,sleep-debug-en = <1>;
++	rockchip,virtual-poweroff = <1>;
++	rockchip,sleep-mode-config = <
++		(0
++		| RKPM_SLP_ARMOFF_DDRPD
++		)
++	>;
++	rockchip,wakeup-config = <
++		(0
++		| RKPM_CPU0_WKUP_EN
++		| RKPM_GPIO_WKUP_EN
++		)
++	>;
++};
++
++&route_dp0 {
++	status = "okay";
++	force-output;
++	connect = <&vp2_out_dp0>;
++
++	force_timing {
++		clock-frequency = <65000000>;
++		hactive = <1024>;
++		vactive = <768>;
++		hfront-porch = <24>;
++		hsync-len = <136>;
++		hback-porch = <160>;
++		vfront-porch = <3>;
++		vsync-len = <6>;
++		vback-porch = <29>;
++		hsync-active = <0>;
++		vsync-active = <0>;
++		de-active = <0>;
++		pixelclk-active = <0>;
++	};
++
++};
++
++&route_dp1 {
++	status = "okay";
++	force-output;
++	connect = <&vp2_out_dp1>;
++
++	force_timing {
++		clock-frequency = <65000000>;
++		hactive = <1024>;
++		vactive = <768>;
++		hfront-porch = <24>;
++		hsync-len = <136>;
++		hback-porch = <160>;
++		vfront-porch = <3>;
++		vsync-len = <6>;
++		vback-porch = <29>;
++		hsync-active = <0>;
++		vsync-active = <0>;
++		de-active = <0>;
++		pixelclk-active = <0>;
++	};
++
++};
++
++&route_hdmi0 {
++	status = "okay";
++	force-output;
++	connect = <&vp2_out_hdmi0>;
++
++	force_timing {
++		clock-frequency = <65000000>;
++		hactive = <1024>;
++		vactive = <768>;
++		hfront-porch = <24>;
++		hsync-len = <136>;
++		hback-porch = <160>;
++		vfront-porch = <3>;
++		vsync-len = <6>;
++		vback-porch = <29>;
++		hsync-active = <0>;
++		vsync-active = <0>;
++		de-active = <0>;
++		pixelclk-active = <0>;
++	};
++
++};
++
++&route_hdmi1 {
++	status = "okay";
++	force-output;
++	connect = <&vp2_out_hdmi1>;
++
++	force_timing {
++		clock-frequency = <65000000>;
++		hactive = <1024>;
++		vactive = <768>;
++		hfront-porch = <24>;
++		hsync-len = <136>;
++		hback-porch = <160>;
++		vfront-porch = <3>;
++		vsync-len = <6>;
++		vback-porch = <29>;
++		hsync-active = <0>;
++		vsync-active = <0>;
++		de-active = <0>;
++		pixelclk-active = <0>;
++	};
++
++};
++
++&sata0 {
++	status = "okay";
++};
++
++&sata1 {
++	status = "okay";
++};
++
++&sdhci {
++	bus-width = <8>;
++	no-sdio;
++	no-sd;
++	non-removable;
++	max-frequency = <200000000>;
++	mmc-hs400-1_8v;
++	mmc-hs400-enhanced-strobe;
++	status = "okay";
++};
++
++&pinctrl {
++	dp {
++		dp1_hdmi_ctl: dp-hdmi-ctl {
++			rockchip,pins = <0 RK_PD5 RK_FUNC_GPIO &pcfg_pull_up>,
++					<3 RK_PB2 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	rtc {
++		rtc_int: rtc-int {
++			rockchip,pins = <0 RK_PB2 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	usb {
++		vcc5v0_host_en: vcc5v0-host-en {
++			rockchip,pins = <4 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		vcc5v0_otg_en: vcc5v0-otg-en {
++			rockchip,pins = <4 RK_PA7 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	sata {
++		sata0_pm_reset: sata0-pm-reset {
++			rockchip,pins = <4 RK_PA0 RK_FUNC_GPIO &pcfg_output_high>;
++		};
++		sata1_pm_reset: sata1-pm-reset {
++			rockchip,pins = <4 RK_PA1 RK_FUNC_GPIO &pcfg_output_high>;
++		};
++	};
++};
++
++&u2phy0 {
++	status = "okay";
++};
++
++&u2phy1 {
++	status = "okay";
++};
++
++&u2phy2 {
++	status = "okay";
++};
++
++&u2phy3 {
++	status = "okay";
++};
++
++&u2phy0_otg {
++	vbus-supply = <&vcc5v0_otg>;
++	status = "okay";
++};
++
++&u2phy1_otg {
++	phy-supply = <&vcc5v0_host>;
++	status = "okay";
++};
++
++&u2phy2_host {
++	phy-supply = <&vcc5v0_host>;
++	status = "okay";
++};
++
++&u2phy3_host {
++	phy-supply = <&vcc5v0_host>;
++	status = "okay";
++};
++
++&usb_host0_ehci {
++	status = "okay";
++};
++
++&usb_host0_ohci {
++	status = "okay";
++};
++
++&usb_host1_ehci {
++	status = "okay";
++};
++
++&usb_host1_ohci {
++	status = "okay";
++};
++
++&usbdp_phy0 {
++	rockchip,dp-lane-mux = < 2 3 >;
++	status = "okay";
++};
++
++&usbdp_phy0_dp {
++	status = "okay";
++};
++
++&usbdp_phy0_u3 {
++	status = "okay";
++};
++
++&usbdp_phy1 {
++	rockchip,dp-lane-mux = < 0 1 2 3 >;
++	status = "okay";
++};
++
++&usbdp_phy1_dp {
++	status = "okay";
++};
++
++&usbdp_phy1_u3 {
++	maximum-speed = "high-speed";
++	status = "okay";
++};
++
++&usbdrd3_0 {
++	status = "okay";
++};
++
++&usbdrd3_1 {
++	status = "okay";
++};
++
++&usbdrd_dwc3_0 {
++	dr_mode = "peripheral";
++	status = "okay";
++};
++
++&usbdrd_dwc3_1 {
++	dr_mode = "host";
++	maximum-speed = "high-speed";
++	status = "okay";
++};
++
++&usbhost3_0 {
++	status = "okay";
++};
++
++&usbhost_dwc3_0 {
++	dr_mode = "host";
++	status = "okay";
++};
++
++&vdd_log_s0 {
++	regulator-state-mem {
++		regulator-on-in-suspend;
++		regulator-suspend-microvolt = <750000>;
++	};
++};
++
++&vdd_vdenc_s0 {
++	regulator-init-microvolt = <750000>;
++};
++
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-rk806-single-khadas-edge2.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-rk806-single-khadas-edge2.dtsi
+new file mode 100644
+index 000000000000..a65a39564ba2
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rk806-single-khadas-edge2.dtsi
+@@ -0,0 +1,396 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2022 Wesion Technology Co., Ltd.
++ *
++ */
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/pinctrl/rockchip.h>
++
++&spi2 {
++	status = "okay";
++	assigned-clocks = <&cru CLK_SPI2>;
++	assigned-clock-rates = <200000000>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi2m2_cs0 &spi2m2_pins>;
++	num-cs = <1>;
++
++	rk806single: rk806single@0 {
++		compatible = "rockchip,rk806";
++		spi-max-frequency = <1000000>;
++		reg = <0x0>;
++
++		interrupt-parent = <&gpio0>;
++		interrupts = <7 IRQ_TYPE_LEVEL_LOW>;
++
++		pinctrl-names = "default", "pmic-power-off";
++		pinctrl-0 = <&pmic_pins>, <&rk806_dvs1_null>, <&rk806_dvs2_null>, <&rk806_dvs3_null>;
++		pinctrl-1 = <&rk806_dvs1_pwrdn>;
++
++		/* 2800mv-3500mv */
++		low_voltage_threshold = <3000>;
++		/* 2700mv-3400mv */
++		shutdown_voltage_threshold = <2700>;
++		/* 140 160 */
++		shutdown_temperture_threshold = <160>;
++		hotdie_temperture_threshold = <115>;
++
++		/* 0: restart PMU;
++		 * 1: reset all the power off reset registers,
++		 *    forcing the state to switch to ACTIVE mode;
++		 * 2: Reset all the power off reset registers,
++		 *    forcing the state to switch to ACTIVE mode,
++		 *    and simultaneously pull down the RESETB PIN for 5mS before releasing
++		 */
++		pmic-reset-func = <1>;
++
++		vcc1-supply = <&vcc5v0_sys>;
++		vcc2-supply = <&vcc5v0_sys>;
++		vcc3-supply = <&vcc5v0_sys>;
++		vcc4-supply = <&vcc5v0_sys>;
++		vcc5-supply = <&vcc5v0_sys>;
++		vcc6-supply = <&vcc5v0_sys>;
++		vcc7-supply = <&vcc5v0_sys>;
++		vcc8-supply = <&vcc5v0_sys>;
++		vcc9-supply = <&vcc5v0_sys>;
++		vcc10-supply = <&vcc5v0_sys>;
++		vcc11-supply = <&vcc_2v0_pldo_s3>;
++		vcc12-supply = <&vcc5v0_sys>;
++		vcc13-supply = <&vcc_1v1_nldo_s3>;
++		vcc14-supply = <&vcc_1v1_nldo_s3>;
++		vcca-supply = <&vcc5v0_sys>;
++
++		pwrkey {
++			status = "okay";
++		};
++
++		pinctrl_rk806: pinctrl_rk806 {
++			gpio-controller;
++			#gpio-cells = <2>;
++
++			rk806_dvs1_null: rk806_dvs1_null {
++				pins = "gpio_pwrctrl2";
++				function = "pin_fun0";
++			};
++
++			rk806_dvs1_slp: rk806_dvs1_slp {
++				pins = "gpio_pwrctrl1";
++				function = "pin_fun1";
++			};
++
++			rk806_dvs1_pwrdn: rk806_dvs1_pwrdn {
++				pins = "gpio_pwrctrl1";
++				function = "pin_fun2";
++			};
++
++			rk806_dvs1_rst: rk806_dvs1_rst {
++				pins = "gpio_pwrctrl1";
++				function = "pin_fun3";
++			};
++
++			rk806_dvs2_null: rk806_dvs2_null {
++				pins = "gpio_pwrctrl2";
++				function = "pin_fun0";
++			};
++
++			rk806_dvs2_slp: rk806_dvs2_slp {
++				pins = "gpio_pwrctrl2";
++				function = "pin_fun1";
++			};
++
++			rk806_dvs2_pwrdn: rk806_dvs2_pwrdn {
++				pins = "gpio_pwrctrl2";
++				function = "pin_fun2";
++			};
++
++			rk806_dvs2_rst: rk806_dvs2_rst {
++				pins = "gpio_pwrctrl2";
++				function = "pin_fun3";
++			};
++
++			rk806_dvs2_dvs: rk806_dvs2_dvs {
++				pins = "gpio_pwrctrl2";
++				function = "pin_fun4";
++			};
++
++			rk806_dvs2_gpio: rk806_dvs2_gpio {
++				pins = "gpio_pwrctrl2";
++				function = "pin_fun5";
++			};
++
++			rk806_dvs3_null: rk806_dvs3_null {
++				pins = "gpio_pwrctrl3";
++				function = "pin_fun0";
++			};
++
++			rk806_dvs3_slp: rk806_dvs3_slp {
++				pins = "gpio_pwrctrl3";
++				function = "pin_fun1";
++			};
++
++			rk806_dvs3_pwrdn: rk806_dvs3_pwrdn {
++				pins = "gpio_pwrctrl3";
++				function = "pin_fun2";
++			};
++
++			rk806_dvs3_rst: rk806_dvs3_rst {
++				pins = "gpio_pwrctrl3";
++				function = "pin_fun3";
++			};
++
++			rk806_dvs3_dvs: rk806_dvs3_dvs {
++				pins = "gpio_pwrctrl3";
++				function = "pin_fun4";
++			};
++
++			rk806_dvs3_gpio: rk806_dvs3_gpio {
++				pins = "gpio_pwrctrl3";
++				function = "pin_fun5";
++			};
++		};
++
++		regulators {
++			vdd_gpu_s0: vdd_gpu_mem_s0: DCDC_REG1 {
++				regulator-boot-on;
++				regulator-min-microvolt = <550000>;
++				regulator-max-microvolt = <950000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_gpu_s0";
++				regulator-enable-ramp-delay = <400>;
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_cpu_lit_s0: vdd_cpu_lit_mem_s0: DCDC_REG2 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <550000>;
++				regulator-max-microvolt = <950000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_cpu_lit_s0";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_log_s0: DCDC_REG3 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <675000>;
++				regulator-max-microvolt = <750000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_log_s0";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++					regulator-suspend-microvolt = <750000>;
++				};
++			};
++
++			vdd_vdenc_s0: vdd_vdenc_mem_s0: DCDC_REG4 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <550000>;
++				regulator-max-microvolt = <950000>;
++				regulator-init-microvolt = <750000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_vdenc_s0";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_ddr_s0: DCDC_REG5 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <675000>;
++				regulator-max-microvolt = <900000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_ddr_s0";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++					regulator-suspend-microvolt = <850000>;
++				};
++			};
++
++			vdd2_ddr_s3: DCDC_REG6 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-name = "vdd2_ddr_s3";
++				regulator-state-mem {
++					regulator-on-in-suspend;
++				};
++			};
++
++			vcc_2v0_pldo_s3: DCDC_REG7 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <2000000>;
++				regulator-max-microvolt = <2000000>;
++				regulator-name = "vdd_2v0_pldo_s3";
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <2000000>;
++				};
++			};
++
++			vcc_3v3_s3: DCDC_REG8 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-name = "vcc_3v3_s3";
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++				};
++			};
++
++			vddq_ddr_s0: DCDC_REG9 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-name = "vddq_ddr_s0";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc_1v8_s3: DCDC_REG10 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "vcc_1v8_s3";
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			avcc_1v8_s0: PLDO_REG2 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "avcc_1v8_s0";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc_1v8_s0: PLDO_REG1 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "vcc_1v8_s0";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			avdd_1v2_s0: PLDO_REG3 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1200000>;
++				regulator-max-microvolt = <1200000>;
++				regulator-name = "avdd_1v2_s0";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc_3v3_s0: PLDO_REG4 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-name = "vcc_3v3_s0";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vccio_sd_s0: PLDO_REG5 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-name = "vccio_sd_s0";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			pldo6_s3: PLDO_REG6 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "pldo6_s3";
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vdd_0v75_s3: NLDO_REG1 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <750000>;
++				regulator-max-microvolt = <750000>;
++				regulator-name = "vdd_0v75_s3";
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <750000>;
++				};
++			};
++
++			vdd_ddr_pll_s0: NLDO_REG2 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <850000>;
++				regulator-max-microvolt = <850000>;
++				regulator-name = "vdd_ddr_pll_s0";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++					regulator-suspend-microvolt = <850000>;
++				};
++			};
++
++			avdd_0v75_s0: NLDO_REG3 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <837500>;
++				regulator-max-microvolt = <837500>;
++				regulator-name = "avdd_0v75_s0";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_0v85_s0: NLDO_REG4 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <850000>;
++				regulator-max-microvolt = <850000>;
++				regulator-name = "vdd_0v85_s0";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_0v75_s0: NLDO_REG5 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <750000>;
++				regulator-max-microvolt = <750000>;
++				regulator-name = "vdd_0v75_s0";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi
+new file mode 100644
+index 000000000000..2e27954aed42
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi
+@@ -0,0 +1,468 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2022 Wesion Technology Co., Ltd.
++ *
++ */
++
++&csi2_dcphy0 {
++	status = "okay";
++
++	ports {
++		#address-cells = <1>;
++		#size-cells = <0>;
++		port@0 {
++			reg = <0>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			mipi_in_dcphy0: endpoint@1 {
++				reg = <1>;
++				remote-endpoint = <&imx415b_out0>;
++				data-lanes = <1 2 3 4>;
++			};
++		};
++		port@1 {
++			reg = <1>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			csidcphy0_out: endpoint@0 {
++				reg = <0>;
++				remote-endpoint = <&mipi0_csi2_input>;
++			};
++		};
++	};
++};
++
++&mipi_dcphy0 {
++	status = "okay";
++};
++
++&csi2_dcphy1 {
++	status = "okay";
++
++	ports {
++		#address-cells = <1>;
++		#size-cells = <0>;
++		port@0 {
++			reg = <0>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			mipi_in_dcphy1: endpoint@1 {
++				reg = <1>;
++				remote-endpoint = <&imx415f_out1>;
++				data-lanes = <1 2 3 4>;
++			};
++		};
++		port@1 {
++			reg = <1>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			csidcphy1_out: endpoint@0 {
++				reg = <0>;
++				remote-endpoint = <&mipi1_csi2_input>;
++			};
++		};
++	};
++};
++
++&mipi_dcphy1 {
++	status = "okay";
++};
++
++&csi2_dphy0 {
++	status = "okay";
++
++	ports {
++		#address-cells = <1>;
++		#size-cells = <0>;
++		port@0 {
++			reg = <0>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			mipidphy0_in_ucam0: endpoint@1 {
++				reg = <1>;
++				remote-endpoint = <&imx415c_out0>;
++				data-lanes = <1 2 3 4>;
++			};
++		};
++		port@1 {
++			reg = <1>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			csidphy0_out: endpoint@0 {
++				reg = <0>;
++				remote-endpoint = <&mipi2_csi2_input>;
++			};
++		};
++	};
++};
++
++&csi2_dphy0_hw {
++	status = "okay";
++};
++
++&i2c4 {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c4m3_xfer>;
++
++	dw9714b: dw9714b@c {
++		compatible = "dongwoon,dw9714";
++		status = "okay";
++		reg = <0x0c>;
++		pinctrl-names = "focusb_gpios";
++		pinctrl-0 = <&focusb_gpio>;
++		focus-gpios = <&gpio1 RK_PA0 GPIO_ACTIVE_HIGH>;
++		rockchip,vcm-start-current = <20>;
++		rockchip,vcm-rated-current = <76>;
++		rockchip,vcm-step-mode = <0>;
++		rockchip,camera-module-index = <0>;
++		rockchip,camera-module-facing = "back";
++	};
++
++	imx415b: imx415b@1a {
++		compatible = "sony,imx415";
++		status = "okay";
++		reg = <0x1a>;
++		clocks = <&cru CLK_MIPI_CAMARAOUT_M1>;
++		clock-names = "xvclk";
++		power-domains = <&power RK3588_PD_VI>;
++		pinctrl-names = "default", "camb_gpios";
++		pinctrl-0 = <&mipim1_camera1_clk>, <&camb_gpio>;
++		rockchip,grf = <&sys_grf>;
++		reset-gpios = <&gpio1 RK_PB2 GPIO_ACTIVE_LOW>;
++		pwdn-gpios = <&gpio1 RK_PB3 GPIO_ACTIVE_HIGH>;
++		rockchip,camera-module-index = <0>;
++		rockchip,camera-module-facing = "back";
++		rockchip,camera-module-name = "CMK-OT2022-PX1";
++		rockchip,camera-module-lens-name = "IR0147-50IRC-8M-F20";
++		lens-focus = <&dw9714b>;
++		port {
++			imx415b_out0: endpoint {
++				remote-endpoint = <&mipi_in_dcphy0>;
++				data-lanes = <1 2 3 4>;
++			};
++		};
++	};
++};
++
++&i2c3 {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c3m0_xfer>;
++
++	dw9714f: dw9714f@c {
++		compatible = "dongwoon,dw9714";
++		status = "okay";
++		reg = <0x0c>;
++		pinctrl-names = "focusf_gpios";
++		pinctrl-0 = <&focusf_gpio>;
++		focus-gpios = <&gpio1 RK_PA1 GPIO_ACTIVE_HIGH>;
++		rockchip,vcm-start-current = <20>;
++		rockchip,vcm-rated-current = <76>;
++		rockchip,vcm-step-mode = <0>;
++		rockchip,camera-module-index = <1>;
++		rockchip,camera-module-facing = "front";
++	};
++
++	imx415f: imx415f@1a {
++		compatible = "sony,imx415";
++		status = "okay";
++		reg = <0x1a>;
++		clocks = <&cru CLK_MIPI_CAMARAOUT_M2>;
++		clock-names = "xvclk";
++		power-domains = <&power RK3588_PD_VI>;
++		pinctrl-names = "default", "camf_gpios";
++		pinctrl-0 = <&mipim1_camera2_clk>, <&camf_gpio>;
++		rockchip,grf = <&sys_grf>;
++		reset-gpios = <&gpio3 RK_PC6 GPIO_ACTIVE_LOW>;
++		pwdn-gpios = <&gpio3 RK_PC5 GPIO_ACTIVE_HIGH>;
++		rockchip,camera-module-index = <1>;
++		rockchip,camera-module-facing = "front";
++		rockchip,camera-module-name = "CMK-OT2022-PX1";
++		rockchip,camera-module-lens-name = "IR0147-50IRC-8M-F20";
++		lens-focus = <&dw9714f>;
++		port {
++			imx415f_out1: endpoint {
++				remote-endpoint = <&mipi_in_dcphy1>;
++				data-lanes = <1 2 3 4>;
++			};
++		};
++	};
++};
++
++&i2c8 {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c8m2_xfer>;
++
++	dw9714c: dw9714c@c {
++		compatible = "dongwoon,dw9714";
++		status = "okay";
++		reg = <0x0c>;
++		pinctrl-names = "focusc_gpios";
++		pinctrl-0 = <&focusc_gpio>;
++		focus-gpios = <&gpio1 RK_PA6 GPIO_ACTIVE_HIGH>;
++		rockchip,vcm-start-current = <20>;
++		rockchip,vcm-rated-current = <76>;
++		rockchip,vcm-step-mode = <0>;
++		rockchip,camera-module-index = <0>;
++		rockchip,camera-module-facing = "back";
++	};
++
++	imx415: imx415@1a {
++		compatible = "sony,imx415";
++		reg = <0x1a>;
++		clocks = <&cru CLK_MIPI_CAMARAOUT_M3>;
++		clock-names = "xvclk";
++		pinctrl-names = "default", "camc_gpios";
++		pinctrl-0 = <&mipim1_camera3_clk>, <&camc_gpio>;
++		power-domains = <&power RK3588_PD_VI>;
++		reset-gpios = <&gpio3 RK_PB4 GPIO_ACTIVE_LOW>;	
++		pwdn-gpios = <&gpio1 RK_PA4 GPIO_ACTIVE_HIGH>;
++		rockchip,camera-module-index = <0>;
++		rockchip,camera-module-facing = "back";
++		rockchip,camera-module-name = "CMK-OT2022-PX1";
++		rockchip,camera-module-lens-name = "IR0147-50IRC-8M-F20";
++		lens-focus = <&dw9714c>;
++		port {
++			imx415c_out0: endpoint {
++				remote-endpoint = <&mipidphy0_in_ucam0>;
++				data-lanes = <1 2 3 4>;
++			};
++		};
++	};
++};
++
++&pinctrl {
++	cam {
++		camf_gpio: camf-gpio {
++			rockchip,pins =
++				<3 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>,
++				<3 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++		camb_gpio: camb-gpio {
++			rockchip,pins =
++				<1 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>,
++				<1 RK_PB3 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++		camc_gpio: camc-gpio {
++			rockchip,pins =
++				<3 RK_PB4 RK_FUNC_GPIO &pcfg_pull_none>,
++				<1 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++		focusb_gpio: focusb-gpio {
++			rockchip,pins =
++				<1 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++		focusf_gpio: focusf-gpio {
++			rockchip,pins =
++				<1 RK_PA1 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++		focusc_gpio: focusc-gpio {
++			rockchip,pins =
++				<1 RK_PA6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++};
++
++&mipi0_csi2 {
++	status = "okay";
++
++	ports {
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		port@0 {
++			reg = <0>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			mipi0_csi2_input: endpoint@1 {
++				reg = <1>;
++				remote-endpoint = <&csidcphy0_out>;
++			};
++		};
++
++		port@1 {
++			reg = <1>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			mipi0_csi2_output: endpoint@0 {
++				reg = <0>;
++				remote-endpoint = <&cif_mipi_in0>;
++			};
++		};
++	};
++};
++
++&mipi1_csi2 {
++	status = "okay";
++
++	ports {
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		port@0 {
++			reg = <0>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			mipi1_csi2_input: endpoint@1 {
++				reg = <1>;
++				remote-endpoint = <&csidcphy1_out>;
++			};
++		};
++
++		port@1 {
++			reg = <1>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			mipi1_csi2_output: endpoint@0 {
++				reg = <0>;
++				remote-endpoint = <&cif_mipi_in1>;
++			};
++		};
++	};
++};
++
++&mipi2_csi2 {
++	status = "okay";
++
++	ports {
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		port@0 {
++			reg = <0>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			mipi2_csi2_input: endpoint@1 {
++				reg = <1>;
++				remote-endpoint = <&csidphy0_out>;
++			};
++		};
++
++		port@1 {
++			reg = <1>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			mipi2_csi2_output: endpoint@0 {
++				reg = <0>;
++				remote-endpoint = <&cif_mipi2_in0>;
++			};
++		};
++	};
++};
++
++&rkcif {
++	status = "okay";
++};
++
++&rkcif_mipi_lvds {
++	status = "okay";
++
++	port {
++		cif_mipi_in0: endpoint {
++			remote-endpoint = <&mipi0_csi2_output>;
++		};
++	};
++};
++
++&rkcif_mipi_lvds_sditf {
++	status = "okay";
++
++	port {
++		mipi_lvds_sditf: endpoint {
++			remote-endpoint = <&isp1_in1>;
++		};
++	};
++};
++
++&rkcif_mipi_lvds1 {
++	status = "okay";
++
++	port {
++		cif_mipi_in1: endpoint {
++			remote-endpoint = <&mipi1_csi2_output>;
++		};
++	};
++};
++
++&rkcif_mipi_lvds1_sditf {
++	status = "okay";
++
++	port {
++		mipi1_lvds_sditf: endpoint {
++			remote-endpoint = <&isp1_in2>;
++		};
++	};
++};
++
++&rkcif_mipi_lvds2 {
++	status = "okay";
++
++	port {
++		cif_mipi2_in0: endpoint {
++			remote-endpoint = <&mipi2_csi2_output>;
++		};
++	};
++};
++
++&rkcif_mipi_lvds2_sditf {
++	status = "okay";
++
++	port {
++		mipi_lvds2_sditf: endpoint {
++			remote-endpoint = <&isp0_vir0>;
++		};
++	};
++};
++
++&rkcif_mmu {
++	status = "okay";
++};
++
++&rkisp_unite {
++	status = "okay";
++
++};
++
++&rkisp_unite_mmu {
++	status = "okay";
++};
++
++&rkisp0_vir0 {
++	status = "okay";
++	/*
++	 * dual isp process image case
++	 * other rkisp hw and virtual nodes should disabled
++	 */
++	rockchip,hw = <&rkisp_unite>;
++	port {
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		isp1_in1: endpoint@0 {
++			reg = <0>;
++			remote-endpoint = <&mipi_lvds_sditf>;
++		};
++		isp1_in2: endpoint@1 {
++			reg = <1>;
++			remote-endpoint = <&mipi1_lvds_sditf>;
++		};
++		isp0_vir0: endpoint@2 {
++			reg = <2>;
++			remote-endpoint = <&mipi_lvds2_sditf>;
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+new file mode 100644
+index 000000000000..dfacb4da2db7
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -0,0 +1,951 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2022 Wesion Technology Co., Ltd.
++ *
++ */
++/dts-v1/;
++
++#include "dt-bindings/usb/pd.h"
++#include "rk3588s.dtsi"
++#include "rk3588s-khadas-edge2.dtsi"
++#include "rk3588-rk806-single-khadas-edge2.dtsi"
++#include "rk3588-linux.dtsi"
++#include "rk3588s-khadas-edge2-camera.dtsi"
++
++
++/ {
++	model = "Khadas Edge2";
++	compatible = "khadas,edge2", "rockchip,rk3588";
++
++	combophy_avdd0v85: combophy-avdd0v85 {
++		compatible = "regulator-fixed";
++		regulator-name = "combophy_avdd0v85";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <850000>;
++		regulator-max-microvolt = <850000>;
++		vin-supply = <&vdd_0v85_s0>;
++	};
++
++	combophy_avdd1v8: combophy-avdd1v8 {
++		compatible = "regulator-fixed";
++		regulator-name = "combophy_avdd1v8";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&avcc_1v8_s0>;
++	};
++
++	sound_micarray: sound-micarray {
++		status = "okay";
++		compatible = "simple-audio-card";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,name = "rockchip,sound-micarray";
++		simple-audio-card,mclk-fs = <256>;
++		simple-audio-card,dai-link@0 {
++			format = "pdm";
++			cpu {
++				sound-dai = <&pdm0>;
++			};
++			codec {
++				sound-dai = <&dummy_codec>;
++			};
++		};
++	};
++
++	dummy_codec: dummy-codec {
++		compatible = "rockchip,dummy-codec";
++		#sound-dai-cells = <0>;
++		status = "okay";
++	};
++
++	es8316_sound: es8316-sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,mclk-fs = <256>;
++		simple-audio-card,name = "rockchip,es8316-codec";
++		simple-audio-card,dai-link@0 {
++			format = "i2s";
++			cpu {
++				sound-dai = <&i2s0_8ch>;
++			};
++			codec {
++				sound-dai = <&es8316>;
++			};
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++		pinctrl-names = "default";
++		pinctrl-0 = <&red_led_gpio &green_led_gpio &blue_led_gpio>;
++
++		red_led {
++			gpios = <&gpio4 RK_PB4 GPIO_ACTIVE_HIGH>;
++			label = "red_led";
++			linux,default-trigger = "none";
++			default-state = "off";
++		};
++
++		green_led {
++			gpios = <&gpio4 RK_PB2 GPIO_ACTIVE_HIGH>;
++			label = "green_led";
++			linux,default-trigger = "default-on";
++			default-state = "on";
++		};
++
++		blue_led {
++			gpios = <&gpio4 RK_PB3 GPIO_ACTIVE_HIGH>;
++			label = "blue_led";
++			linux,default-trigger = "none";
++			default-state = "off";
++		};
++	};
++
++	khadas_wdt {
++		compatible = "linux,wdt-khadas";
++		status = "okay";
++		hw_margin_ms = <500>;
++		hw-gpios = <&gpio0 RK_PB0 GPIO_ACTIVE_HIGH>;
++	};
++
++//	fan: pwm-fan {
++//		compatible = "pwm-fan";
++//		#cooling-cells = <2>;
++//		pwms = <&pwm11 0 50000 0>;
++//	};
++
++	vbus5v0_typec: vbus5v0-typec {
++		compatible = "regulator-fixed";
++		regulator-name = "vbus5v0_typec";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		enable-active-high;
++		gpio = <&gpio3 RK_PA4 GPIO_ACTIVE_HIGH>;
++		vin-supply = <&vcc5v0_usb>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&typec5v_pwren>;
++	};
++
++	vcc3v3_pcie20: vcc3v3-pcie20 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc3v3_pcie20";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		enable-active-high;
++		gpios = <&gpio0 RK_PC4 GPIO_ACTIVE_HIGH>;
++		startup-delay-us = <5000>;
++		vin-supply = <&vcc12v_dcin>;
++	};
++
++	vcc5v0_host: vcc5v0-host {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_host";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		enable-active-high;
++		gpio = <&gpio1 RK_PB1 GPIO_ACTIVE_HIGH>;
++		vin-supply = <&vcc5v0_usb>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc5v0_host_en>;
++	};
++
++	vcc_sd: vcc-sd {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_sd";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		enable-active-high;
++		gpio = <&gpio1 RK_PB6 GPIO_ACTIVE_HIGH>;
++		vin-supply = <&vcc_3v3_s3>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc_sd_en>;
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++
++	wireless_bluetooth: wireless-bluetooth {
++		compatible = "bluetooth-platdata";
++		clocks = <&pt7c4363>;
++		clock-names = "ext_clock";
++		uart_rts_gpios = <&gpio3 RK_PD2 GPIO_ACTIVE_LOW>;
++		pinctrl-names = "default", "rts_gpio";
++		pinctrl-0 = <&uart9m2_rtsn>, <&bt_gpio>;
++		pinctrl-1 = <&uart9_gpios>;
++		BT,reset_gpio    = <&gpio0 RK_PD4 GPIO_ACTIVE_HIGH>;
++		BT,wake_gpio     = <&gpio0 RK_PD3 GPIO_ACTIVE_HIGH>;
++		BT,wake_host_irq = <&gpio0 RK_PD5 GPIO_ACTIVE_HIGH>;
++		status = "okay";
++	};
++
++	bt-sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,format = "dsp_a";
++		simple-audio-card,bitclock-inversion = <1>;
++		simple-audio-card,mclk-fs = <256>;
++		simple-audio-card,name = "rockchip,bt";
++		simple-audio-card,cpu {
++			sound-dai = <&i2s2_2ch>;
++		};
++		simple-audio-card,codec {
++			sound-dai = <&bt_sco>;
++		};
++	};
++
++	bt_sco: bt-sco {
++		compatible = "delta,dfbmcs320";
++		#sound-dai-cells = <0>;
++		status = "okay";
++	};
++
++	wireless_wlan: wireless-wlan {
++		compatible = "wlan-platdata";
++		wifi_chip_type = "ap6275p";
++		pinctrl-names = "default";
++		pinctrl-0 = <&wifi_host_wake_irq>;
++		WIFI,host_wake_irq = <&gpio0 RK_PA0 GPIO_ACTIVE_HIGH>;
++	//	WIFI,poweren_gpio = <&gpio0 RK_PC7 GPIO_ACTIVE_HIGH>;
++		status = "okay";
++	};
++
++	vcc3v3_lcd1_en: vcc3v3-lcd1-en {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc3v3_lcd1_en";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		gpio = <&gpio4 RK_PA4 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++		regulator-boot-on;
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++
++	};
++
++	vcc3v3_lcd2_en: vcc3v3-lcd2-en {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc3v3_lcd2_en";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		gpio = <&gpio4 RK_PB0 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++		regulator-boot-on;
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++
++	};
++
++};
++
++&backlight_mipi0 {
++	pwms = <&pwm12 0 25000 0>;
++	power-supply = <&vcc3v3_lcd1_en>;
++	status = "okay";
++};
++
++&backlight_mipi1 {
++	pwms = <&pwm13 0 25000 0>;
++	power-supply = <&vcc3v3_lcd2_en>;
++	status = "disabled";
++};
++
++
++&combphy0_ps {
++	status = "okay";
++};
++
++&cru {
++	assigned-clock-rates =
++            <1100000000>, <786432000>,
++            <850000000>, <1188000000>,
++            <702000000>,
++            <400000000>, <500000000>,
++            <800000000>, <100000000>,
++            <400000000>, <100000000>,
++            <200000000>, <800000000>,
++            <375000000>, <150000000>,
++            <200000000>;
++};
++
++&dp0 {
++	status = "okay";
++};
++
++&dp0_in_vp2 {
++	status = "okay";
++};
++
++&dp0_sound{
++	status = "okay";
++};
++
++&dsi0 {
++	status = "disabled";
++	reset-delay-ms = <20>;
++	reset-gpios = <&gpio4 RK_PA3 GPIO_ACTIVE_HIGH>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&lcd1_rst_gpio>;
++
++};
++
++&dsi0_panel {
++	status = "okay";
++	power-supply = <&vcc3v3_lcd1_en>;
++};
++
++&dsi0_in_vp2 {
++	status = "disabled";
++};
++
++&dsi0_in_vp3 {
++	status = "okay";
++};
++
++&hdmi0_sound {
++	status = "okay";
++};
++
++&route_dsi0 {
++	status = "okay";
++	connect = <&vp3_out_dsi0>;
++};
++
++&mipi_dcphy0 {
++	status = "okay";
++};
++
++&dsi1 {
++	reset-delay-ms = <20>;
++	reset-gpios = <&gpio4 RK_PA7 GPIO_ACTIVE_HIGH>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&lcd2_rst_gpio1>;
++	status = "disabled";
++};
++
++&dsi1_panel {
++	status = "disabled";
++	power-supply = <&vcc3v3_lcd2_en>;
++};
++
++&mipi_dcphy1 {
++	status = "okay";
++};
++
++&dsi1_in_vp2 {
++	status = "disabled";
++};
++
++&dsi1_in_vp3 {
++	status = "disabled";
++};
++
++&route_dsi1 {
++	status = "disabled";
++	connect = <&vp3_out_dsi1>;
++};
++
++//&hdptxphy0 {
++	/* Single Vdiff Training Table for power reduction (optional) */
++//	training-table = /bits/ 8 <
++		/* voltage swing 0, pre-emphasis 0->3 */
++//		0x0d 0x00 0x00 0x00 0x00 0x00
++//		0x0d 0x00 0x00 0x00 0x00 0x00
++//		0x0d 0x00 0x00 0x00 0x00 0x00
++//		0x0d 0x00 0x00 0x00 0x00 0x00
++		/* voltage swing 1, pre-emphasis 0->2 */
++//		0x0d 0x00 0x00 0x00 0x00 0x00
++//		0x0d 0x00 0x00 0x00 0x00 0x00
++//		0x0d 0x00 0x00 0x00 0x00 0x00
++		/* voltage swing 2, pre-emphasis 0->1 */
++//		0x0d 0x00 0x00 0x00 0x00 0x00
++//		0x0d 0x00 0x00 0x00 0x00 0x00
++		/* voltage swing 3, pre-emphasis 0 */
++//		0x0d 0x00 0x00 0x00 0x00 0x00
++//	>;
++//	status = "okay";
++//};
++
++&hdmi0 {
++	enable-gpios = <&gpio4 RK_PB1 GPIO_ACTIVE_HIGH>;
++	status = "okay";
++};
++
++&hdmi0_in_vp0 {
++	status = "okay";
++ };
++
++&hdptxphy_hdmi0 {
++	status = "okay";
++ };
++
++&i2s2_2ch {
++	status = "okay";
++};
++
++&i2c0 {
++    status = "okay";
++    pinctrl-names = "default";
++    pinctrl-0 = <&i2c0m2_xfer>;
++
++    vdd_cpu_big0_s0: vdd_cpu_big0_mem_s0: rk8602@42 {
++        compatible = "rockchip,rk8602";
++        reg = <0x42>;
++        vin-supply = <&vcc5v0_sys>;
++        regulator-compatible = "rk860x-reg";
++        regulator-name = "vdd_cpu_big0_s0";
++        regulator-min-microvolt = <550000>;
++        regulator-max-microvolt = <1050000>;
++        regulator-ramp-delay = <12500>;
++        rockchip,suspend-voltage-selector = <1>;
++        regulator-boot-on;
++        regulator-always-on;
++        regulator-state-mem {
++            regulator-off-in-suspend;
++        };
++    };
++
++    vdd_cpu_big1_s0: vdd_cpu_big1_mem_s0: rk8603@43 {
++        compatible = "rockchip,rk8603";
++        reg = <0x43>;
++        vin-supply = <&vcc5v0_sys>;
++        regulator-compatible = "rk860x-reg";
++        regulator-name = "vdd_cpu_big1_s0";
++        regulator-min-microvolt = <550000>;
++        regulator-max-microvolt = <1050000>;
++        regulator-ramp-delay = <12500>;
++        rockchip,suspend-voltage-selector = <1>;
++        regulator-boot-on;
++        regulator-always-on;
++        regulator-state-mem {
++            regulator-off-in-suspend;
++        };
++    };
++};
++
++&i2s5_8ch {
++	status = "okay";
++};
++
++&i2c2 {
++
++    status = "okay";
++
++    vdd_npu_s0: vdd_npu_mem_s0: rk8602@42 {
++        compatible = "rockchip,rk8602";
++        reg = <0x42>;
++        vin-supply = <&vcc5v0_sys>;
++        regulator-compatible = "rk860x-reg";
++        regulator-name = "vdd_npu_s0";
++        regulator-min-microvolt = <550000>;
++        regulator-max-microvolt = <950000>;
++        regulator-ramp-delay = <12500>;
++        rockchip,suspend-voltage-selector = <1>;
++        regulator-boot-on;
++        regulator-always-on;
++        regulator-state-mem {
++            regulator-off-in-suspend;
++        };
++    };
++
++    usbc0: fusb302@22 {
++        compatible = "fcs,fusb302";
++        reg = <0x22>;
++        interrupt-parent = <&gpio1>;
++        interrupts = <RK_PB5 IRQ_TYPE_LEVEL_LOW>;
++        int-n-gpios = <&gpio1 RK_PB5 GPIO_ACTIVE_LOW>;
++        pinctrl-names = "default";
++        pinctrl-0 = <&usbc0_int>;
++        vbus-supply = <&vbus5v0_typec>;
++        status = "okay";
++
++        ports {
++            #address-cells = <1>;
++            #size-cells = <0>;
++
++            port@0 {
++                reg = <0>;
++                usbc0_role_sw: endpoint@0 {
++                    remote-endpoint = <&dwc3_0_role_switch>;
++                };
++            };
++        };
++
++        usb_con: connector {
++            compatible = "usb-c-connector";
++            label = "USB-C";
++            data-role = "dual";
++            power-role = "dual";
++            try-power-role = "sink";
++            op-sink-microwatt = <1000000>;
++            sink-pdos =
++                <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)
++                 PDO_FIXED(9000, 3000, PDO_FIXED_USB_COMM)
++                 PDO_FIXED(12000, 3000, PDO_FIXED_USB_COMM)>;
++            source-pdos =
++                <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>;
++
++            altmodes {
++                #address-cells = <1>;
++                #size-cells = <0>;
++
++                altmode@0 {
++                    reg = <0>;
++                    svid = <0xff01>;
++                    vdo = <0xffffffff>;
++                };
++            };
++
++             ports {
++                #address-cells = <1>;
++                #size-cells = <0>;
++
++                port@0 {
++                    reg = <0>;
++                    usbc0_orien_sw: endpoint {
++                        remote-endpoint = <&usbdp_phy0_orientation_switch>;
++                    };
++                };
++
++                port@1 {
++                    reg = <1>;
++                    dp_altmode_mux: endpoint {
++                        remote-endpoint = <&usbdp_phy0_dp_altmode_mux>;
++                    };
++                };
++            };
++        };
++    };
++
++    pt7c4363: pt7c4363@51 {
++        compatible = "haoyu,hym8563";
++        reg = <0x51>;
++        #clock-cells = <0>;
++        clock-frequency = <32768>;
++        clock-output-names = "pt7c4363";
++        wakeup-source;
++    };
++
++    mcu: khadas-mcu@18 {
++        compatible = "khadas-mcu";
++        status = "okay";
++        reg = <0x18>;
++        fan,trig_temp_level0 = <50>;
++        fan,trig_temp_level1 = <60>;
++        fan,trig_temp_level2 = <70>;
++        fan,trig_temp_level3 = <80>;
++        hwver = "EDGE2.V11";
++
++    };
++};
++
++&reboot_mode {
++	mode-reboot_test = <BOOT_REBOOT_TEST>;
++};
++
++&i2c3 {
++	status = "okay";
++
++	gs_kxtj3: gs_kxtj3@e {
++		compatible = "gs_kxtj3";
++		reg = <0x0e>;
++		irq-gpio = <&gpio1 RK_PB0 IRQ_TYPE_EDGE_RISING>;
++		irq_enable = <0>;
++		poll_delay_ms = <30>;
++		type = <SENSOR_TYPE_ACCEL>;
++		layout = <0>;
++		status = "okay";
++	};
++
++	es8316: es8316@10 {
++		status = "okay";
++		#sound-dai-cells = <0>;
++		compatible = "everest,es8316";
++		reg = <0x10>;
++		clocks = <&cru I2S0_8CH_MCLKOUT>;
++		clock-names = "mclk";
++		assigned-clocks = <&cru I2S0_8CH_MCLKOUT>;
++		assigned-clock-rates = <12288000>;
++		pinctrl-names = "default","hp_det","spk_con";
++		pinctrl-0 = <&i2s0_mclk>,<&hp_det>,<&spk_con>;
++		spk-con-gpio = <&gpio1 RK_PD0 GPIO_ACTIVE_HIGH>;
++		hp-det-gpio = <&gpio1 RK_PD3 GPIO_ACTIVE_LOW>;
++	};
++
++};
++
++&i2c4 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c4m3_xfer>;
++	status = "okay";
++};
++
++&i2c5 {
++	status = "disabled";
++
++	ls_stk3332: light@47 {
++		compatible = "ls_stk3332";
++		status = "disabled";
++		reg = <0x47>;
++		type = <SENSOR_TYPE_LIGHT>;
++		irq_enable = <0>;
++		als_threshold_high = <100>;
++		als_threshold_low = <10>;
++		als_ctrl_gain = <2>; /* 0:x1 1:x4 2:x16 3:x64 */
++		poll_delay_ms = <100>;
++	};
++
++	ps_stk3332: proximity@47 {
++		compatible = "ps_stk3332";
++		status = "disabled";
++		reg = <0x47>;
++		type = <SENSOR_TYPE_PROXIMITY>;
++		//pinctrl-names = "default";
++		//pinctrl-0 = <&gpio3_c6>;
++		//irq-gpio = <&gpio3 RK_PC6 IRQ_TYPE_LEVEL_LOW>;
++		//irq_enable = <1>;
++		ps_threshold_high = <0x200>;
++		ps_threshold_low = <0x100>;
++		ps_ctrl_gain = <3>; /* 0:x1 1:x2 2:x5 3:x8 */
++		ps_led_current = <4>; /* 0:3.125mA 1:6.25mA 2:12.5mA 3:25mA 4:50mA 5:100mA*/
++		poll_delay_ms = <100>;
++	};
++
++	mpu6500_acc: mpu_acc@68 {
++		compatible = "mpu6500_acc";
++		reg = <0x68>;
++		irq-gpio = <&gpio3 RK_PB4 IRQ_TYPE_EDGE_RISING>;
++		irq_enable = <0>;
++		poll_delay_ms = <30>;
++		type = <SENSOR_TYPE_ACCEL>;
++		layout = <5>;
++	};
++
++	mpu6500_gyro: mpu_gyro@68 {
++		compatible = "mpu6500_gyro";
++		reg = <0x68>;
++		poll_delay_ms = <30>;
++		type = <SENSOR_TYPE_GYROSCOPE>;
++		layout = <5>;
++	};
++};
++
++&i2c6 {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c6m0_xfer>;
++
++	ft5336@38 {
++		compatible = "edt,edt-ft5336", "ft5x06";
++		reg = <0x38>;
++		interrupt-parent = <&gpio0>;
++		interrupts = <RK_PC6 IRQ_TYPE_EDGE_FALLING>;
++		reset-gpio = <&gpio0 RK_PC5 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&tp_rst_gpio>;
++		status = "okay";
++	};
++
++};
++
++&pcie2x1l1 {
++//	reset-gpios = <&gpio4 RK_PA2 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc3v3_pcie20>;
++	status = "disabled";
++};
++
++&pcie2x1l2 {
++//	reset-gpios = <&gpio4 RK_PC1 GPIO_ACTIVE_HIGH>;
++	reset-gpios = <&gpio3 RK_PD1 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc3v3_pcie20>;
++	rockchip,skip-scan-in-resume;
++	status = "okay";
++};
++
++&pdm0 {
++	pinctrl-names = "default";
++    pinctrl-0 = <&pdm0m0_clk
++    &pdm0m0_clk1
++    &pdm0m0_sdi0
++    &pdm0m0_sdi1
++    &pdm0m0_sdi2>;
++    rockchip,path-map = <0 1 2 3>;
++    status = "okay";
++};
++
++&pinctrl {
++	audio {
++		hp_det: hp-det {
++			rockchip,pins = <1 RK_PD3 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++		spk_con: spk-con {
++			rockchip,pins = <1 RK_PD0 RK_FUNC_GPIO &pcfg_pull_down>;
++		};
++	};
++
++	lcd {
++		lcd1_rst_gpio: lcd1-rst-gpio {
++			rockchip,pins = <4 RK_PA3 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++		lcd2_rst_gpio1: lcd2-rst-gpio1 {
++			rockchip,pins = <4 RK_PA7 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	leds {
++		red_led_gpio: red-led-gpio {
++			rockchip,pins = <4 RK_PB4 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++
++		green_led_gpio: green-led-gpio {
++			rockchip,pins = <4 RK_PB2 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++
++		blue_led_gpio: blue-led-gpio {
++			rockchip,pins = <4 RK_PB3 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	usb {
++		vcc5v0_host_en: vcc5v0-host-en {
++			rockchip,pins = <1 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	vcc_sd {
++		vcc_sd_en: vcc-sd-en {
++			rockchip,pins = <1 RK_PB6 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	usb-typec {
++		usbc0_int: usbc0-int {
++			rockchip,pins = <1 RK_PB5 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++
++		typec5v_pwren: typec5v-pwren {
++			rockchip,pins = <3 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	ft5336 {
++		tp_rst_gpio: tp-rst-gpio {
++			rockchip,pins = <0 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>;
++       };
++   };
++
++	wireless-bluetooth {
++		uart9_gpios: uart9-gpios {
++			rockchip,pins = <3 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		bt_gpio: bt-gpio {
++			rockchip,pins =
++				<0 RK_PD4 RK_FUNC_GPIO &pcfg_pull_none>,
++				<0 RK_PD3 RK_FUNC_GPIO &pcfg_pull_up>,
++				<0 RK_PD5 RK_FUNC_GPIO &pcfg_pull_down>;
++		};
++	};
++
++	wireless-wlan {
++		wifi_host_wake_irq: wifi-host-wake-irq {
++			rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_down>;
++		};
++
++	//	wifi_poweren_gpio: wifi-poweren-gpio {
++	//		rockchip,pins = <0 RK_PC7 RK_FUNC_GPIO &pcfg_pull_up>;
++	//	};
++	};
++};
++
++&pwm3 {
++	compatible = "rockchip,remotectl-pwm";
++	pinctrl-names = "default";
++	pinctrl-0 = <&pwm3m3_pins>;
++	remote_pwm_id = <3>;
++	handle_cpu_id = <1>;
++	remote_support_psci = <0>;
++	status = "okay";
++
++	ir_key1 {
++		rockchip,usercode = <0xff00>;
++		rockchip,key_table =
++			<0xeb 116>,		//KEY_POWER
++			<0xec 139>,		//KEY_MENU
++			<0xfc 103>,		//KEY_UP
++			<0xfd 108>,		//KEY_DOWN
++			<0xf1 105>,		//KEY_LEFT
++			<0xe5 106>,		//KEY_RIGHT
++			<0xf8 28>, 		//KEY_Enter
++			<0xa7 114>,		//KEY_VOLUMEDOWN
++			<0xa3 388>,
++			<0xa4 388>,		//KEY_CURSOR
++			<0xf4 115>,		//KEY_VOLUMEUP
++			<0xfe 158>,		//KEY_BACK
++			<0xb7 172>;		//KEY_HOMEPAGE
++	};
++};
++
++&pwm7 {
++	pinctrl-0 = <&pwm7m0_pins>;
++	status = "disabled";
++};
++
++&pwm12 {
++	pinctrl-0 = <&pwm12m1_pins>;
++	status = "okay";
++};
++
++&pwm13 {
++	pinctrl-0 = <&pwm13m1_pins>;
++	status = "okay";
++};
++
++
++&rockchip_suspend {
++
++    rockchip,sleep-mode-config = <
++        (0
++        | RKPM_SLP_ARMOFF_DDRPD
++        | RKPM_SLP_PMU_PMUALIVE_32K
++        | RKPM_SLP_PMU_DIS_OSC
++        | RKPM_SLP_32K_EXT
++        | RKPM_SLP_PMU_DBG
++        )
++    >;
++};
++
++&route_hdmi0 {
++    status = "okay";
++    connect = <&vp0_out_hdmi0>;
++    /delete-property/ force-output;
++    /delete-node/ force_timing;
++};
++
++&sdmmc {
++	status = "okay";
++	card-detect-delay = <1200>;
++};
++
++&sfc {
++	pinctrl-names = "default";
++	pinctrl-0 = <&fspim2_pins>;
++	status = "okay";
++};
++
++&spdif_tx1 {
++	status = "disabled";
++	pinctrl-names = "default";
++	pinctrl-0 = <&spdif1m1_tx>;
++};
++
++&spdif_tx1_dc {
++	status = "disabled";
++};
++
++&spdif_tx1_sound {
++	status = "disabled";
++};
++
++&spdif_tx2 {
++	status = "okay";
++};
++
++&spi1 {
++	status = "disabled";
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi1m1_cs0 &spi1m1_pins>;
++};
++
++&tsadc {
++	status = "okay";
++};
++
++&u2phy0_otg {
++	rockchip,typec-vbus-det;
++};
++
++&u2phy2_host {
++	phy-supply = <&vcc5v0_host>;
++};
++
++&u2phy3_host {
++	phy-supply = <&vcc5v0_host>;
++};
++
++&uart9 {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart9m2_xfer &uart9m2_ctsn>;
++};
++
++&usbdp_phy0 {
++	orientation-switch;
++	svid = <0xff01>;
++	sbu1-dc-gpios = <&gpio4 RK_PA0 GPIO_ACTIVE_HIGH>;
++	sbu2-dc-gpios = <&gpio4 RK_PA1 GPIO_ACTIVE_HIGH>;
++
++	port {
++		#address-cells = <1>;
++		#size-cells = <0>;
++		usbdp_phy0_orientation_switch: endpoint@0 {
++			reg = <0>;
++			remote-endpoint = <&usbc0_orien_sw>;
++		};
++
++		usbdp_phy0_dp_altmode_mux: endpoint@1 {
++			reg = <1>;
++			remote-endpoint = <&dp_altmode_mux>;
++		};
++	};
++};
++
++&usbdrd_dwc3_0 {
++	usb-role-switch;
++	port {
++		#address-cells = <1>;
++		#size-cells = <0>;
++		dwc3_0_role_switch: endpoint@0 {
++			reg = <0>;
++			remote-endpoint = <&usbc0_role_sw>;
++		};
++	};
++};
++
++&usbhost3_0 {
++	status = "okay";
++};
++
++&usbhost_dwc3_0 {
++	dr_mode = "host";
++	status = "okay";
++};
++
++&vdd_log_s0 {
++    regulator-state-mem {
++        regulator-on-in-suspend;
++        regulator-suspend-microvolt = <750000>;
++    };
++};
++
++&vcc_1v8_s0 {
++    /delete-property/ regulator-state-mem;
++    regulator-state-mem {
++        regulator-on-in-suspend;
++        regulator-suspend-microvolt = <1800000>;
++    };
++};
++
++&vcc_3v3_s0 {
++    /delete-property/ regulator-state-mem;
++    regulator-state-mem {
++        regulator-on-in-suspend;
++        regulator-suspend-microvolt = <3300000>;
++    };
++};
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi
+new file mode 100644
+index 000000000000..c06bc4fda155
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi
+@@ -0,0 +1,1705 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2022 Wesion Technology Co., Ltd.
++ *
++ */
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/pwm/pwm.h>
++#include <dt-bindings/pinctrl/rockchip.h>
++#include <dt-bindings/input/rk-input.h>
++#include <dt-bindings/display/drm_mipi_dsi.h>
++#include <dt-bindings/display/rockchip_vop.h>
++#include <dt-bindings/sensor-dev.h>
++
++/ {
++	adc_keys: adc-keys {
++		compatible = "adc-keys";
++		io-channels = <&saradc 1>;
++		io-channel-names = "buttons";
++		keyup-threshold-microvolt = <1800000>;
++		poll-interval = <100>;
++
++		home-key {
++			label = "home";
++			linux,code = <KEY_HOMEPAGE>;
++			press-threshold-microvolt = <17000>;
++		};
++	};
++
++	backlight_mipi0: backlight-mipi0 {
++		compatible = "pwm-backlight";
++		brightness-levels = <
++			  0  20  20  21  21  22  22  23
++			 23  24  24  25  25  26  26  27
++			 27  28  28  29  29  30  30  31
++			 31  32  32  33  33  34  34  35
++			 35  36  36  37  37  38  38  39
++			 40  41  42  43  44  45  46  47
++			 48  49  50  51  52  53  54  55
++			 56  57  58  59  60  61  62  63
++			 64  65  66  67  68  69  70  71
++			 72  73  74  75  76  77  78  79
++			 80  81  82  83  84  85  86  87
++			 88  89  90  91  92  93  94  95
++			 96  97  98  99 100 101 102 103
++			104 105 106 107 108 109 110 111
++			112 113 114 115 116 117 118 119
++			120 121 122 123 124 125 126 127
++			128 129 130 131 132 133 134 135
++			136 137 138 139 140 141 142 143
++			144 145 146 147 148 149 150 151
++			152 153 154 155 156 157 158 159
++			160 161 162 163 164 165 166 167
++			168 169 170 171 172 173 174 175
++			176 177 178 179 180 181 182 183
++			184 185 186 187 188 189 190 191
++			192 193 194 195 196 197 198 199
++			200 201 202 203 204 205 206 207
++			208 209 210 211 212 213 214 215
++			216 217 218 219 220 221 222 223
++			224 225 226 227 228 229 230 231
++			232 233 234 235 236 237 238 239
++			240 241 242 243 244 245 246 247
++			248 249 250 251 252 253 254 255
++		>;
++		default-brightness-level = <200>;
++	};
++
++	dp0_sound: dp0-sound {
++		status = "disabled";
++		compatible = "rockchip,hdmi";
++		rockchip,card-name= "rockchip,dp0";
++		rockchip,mclk-fs = <512>;
++		rockchip,cpu = <&spdif_tx2>;
++		rockchip,codec = <&dp0 1>;
++		rockchip,jack-det;
++	};
++
++	backlight_mipi1: backlight-mipi1 {
++        compatible = "pwm-backlight";
++        brightness-levels = <
++              0  20  20  21  21  22  22  23
++             23  24  24  25  25  26  26  27
++             27  28  28  29  29  30  30  31
++             31  32  32  33  33  34  34  35
++             35  36  36  37  37  38  38  39
++             40  41  42  43  44  45  46  47
++             48  49  50  51  52  53  54  55
++             56  57  58  59  60  61  62  63
++             64  65  66  67  68  69  70  71
++             72  73  74  75  76  77  78  79
++             80  81  82  83  84  85  86  87
++             88  89  90  91  92  93  94  95
++             96  97  98  99 100 101 102 103
++            104 105 106 107 108 109 110 111
++            112 113 114 115 116 117 118 119
++            120 121 122 123 124 125 126 127
++            128 129 130 131 132 133 134 135
++            136 137 138 139 140 141 142 143
++            144 145 146 147 148 149 150 151
++            152 153 154 155 156 157 158 159
++            160 161 162 163 164 165 166 167
++            168 169 170 171 172 173 174 175
++            176 177 178 179 180 181 182 183
++            184 185 186 187 188 189 190 191
++            192 193 194 195 196 197 198 199
++            200 201 202 203 204 205 206 207
++            208 209 210 211 212 213 214 215
++            216 217 218 219 220 221 222 223
++            224 225 226 227 228 229 230 231
++            232 233 234 235 236 237 238 239
++            240 241 242 243 244 245 246 247
++            248 249 250 251 252 253 254 255
++        >;
++        default-brightness-level = <200>;
++    };
++
++
++
++	hdmi0_sound: hdmi0-sound {
++		status = "disabled";
++		compatible = "simple-audio-card";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,mclk-fs = <128>;
++		simple-audio-card,name = "rockchip,hdmi0";
++
++		simple-audio-card,cpu {
++			sound-dai = <&i2s5_8ch>;
++		};
++		simple-audio-card,codec {
++			sound-dai = <&hdmi0>;
++		};
++	};
++
++	spdif_tx1_dc: spdif-tx1-dc {
++		status = "disabled";
++		compatible = "linux,spdif-dit";
++		#sound-dai-cells = <0>;
++	};
++
++	spdif_tx1_sound: spdif-tx1-sound {
++		status = "disabled";
++		compatible = "simple-audio-card";
++		simple-audio-card,name = "rockchip,spdif-tx1";
++		simple-audio-card,cpu {
++			sound-dai = <&spdif_tx1>;
++		};
++		simple-audio-card,codec {
++			sound-dai = <&spdif_tx1_dc>;
++		};
++	};
++
++	test-power {
++		status = "okay";
++	};
++
++	vcc12v_dcin: vcc12v-dcin {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc12v_dcin";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <12000000>;
++		regulator-max-microvolt = <12000000>;
++	};
++
++	vcc5v0_sys: vcc5v0-sys {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc12v_dcin>;
++	};
++
++	vcc_1v1_nldo_s3: vcc-1v1-nldo-s3 {
++        compatible = "regulator-fixed";
++        regulator-name = "vcc_1v1_nldo_s3";
++        regulator-always-on;
++        regulator-boot-on;
++        regulator-min-microvolt = <1100000>;
++        regulator-max-microvolt = <1100000>;
++        vin-supply = <&vcc5v0_sys>;
++    };
++
++	vcc5v0_usbdcin: vcc5v0-usbdcin {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_usbdcin";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc12v_dcin>;
++	};
++
++	vcc5v0_usb: vcc5v0-usb {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_usb";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc5v0_usbdcin>;
++	};
++};
++
++&av1d_mmu {
++	status = "okay";
++};
++
++&combphy0_ps {
++	status = "okay";
++};
++
++&combphy2_psu {
++	status = "okay";
++};
++
++&cpu_l0 {
++	cpu-supply = <&vdd_cpu_lit_s0>;
++	mem-supply = <&vdd_cpu_lit_mem_s0>;
++};
++
++&cpu_b0 {
++	cpu-supply = <&vdd_cpu_big0_s0>;
++	mem-supply = <&vdd_cpu_big0_mem_s0>;
++};
++
++&cpu_b2 {
++	cpu-supply = <&vdd_cpu_big1_s0>;
++	mem-supply = <&vdd_cpu_big1_mem_s0>;
++};
++
++&dsi0 {
++	status = "disabled";
++	//rockchip,lane-rate = <1000>;
++	dsi0_panel: panel@0 {
++		status = "okay";
++		compatible = "simple-panel-dsi";
++		reg = <0>;
++		backlight = <&backlight_mipi0>;
++	//	reset-delay-ms = <60>;
++		enable-delay-ms = <60>;
++		prepare-delay-ms = <60>;
++		unprepare-delay-ms = <60>;
++		disable-delay-ms = <60>;
++		dsi,flags = <(MIPI_DSI_MODE_VIDEO | MIPI_DSI_MODE_VIDEO_BURST |
++			MIPI_DSI_MODE_LPM | MIPI_DSI_MODE_EOT_PACKET)>;
++		dsi,format = <MIPI_DSI_FMT_RGB888>;
++		dsi,lanes  = <4>;
++		panel-init-sequence = [
++			15 00 02 FF 05
++			15 00 02 FB 01
++			15 64 02 C5 01
++			15 00 02 FF EE
++			15 00 02 FB 01
++			15 00 02 1F 45
++			15 00 02 24 4F
++			15 00 02 38 C8
++			15 00 02 39 27
++			15 00 02 1E 77
++			15 00 02 1D 0F
++			15 00 02 7E 71
++			15 00 02 7C 03
++			15 00 02 FF 00
++			15 00 02 FB 01
++			15 00 02 35 01
++			15 00 02 FF 01
++			15 00 02 FB 01
++			15 00 02 00 01
++			15 00 02 01 55
++			15 00 02 02 40
++			15 00 02 05 40
++			15 00 02 06 4A
++			15 00 02 07 24
++			15 00 02 08 0C
++			15 00 02 0B 7D
++			15 00 02 0C 7D
++			15 00 02 0E B0
++			15 00 02 0F AE
++			15 00 02 11 10
++			15 00 02 12 10
++			15 00 02 13 03
++			15 00 02 14 4A
++			15 00 02 15 12
++			15 00 02 16 12
++			15 00 02 18 00
++			15 00 02 19 77
++			15 00 02 1A 55
++			15 00 02 1B 13
++			15 00 02 1C 00
++			15 00 02 1D 00
++			15 00 02 1E 13
++			15 00 02 1F 00
++			15 00 02 23 00
++			15 00 02 24 00
++			15 00 02 25 00
++			15 00 02 26 00
++			15 00 02 27 00
++			15 00 02 28 00
++			15 00 02 35 00
++			15 00 02 66 00
++			15 00 02 58 82
++			15 00 02 59 02
++			15 00 02 5A 02
++			15 00 02 5B 02
++			15 00 02 5C 82
++			15 00 02 5D 82
++			15 00 02 5E 02
++			15 00 02 5F 02
++			15 00 02 72 31
++			15 00 02 FF 05
++			15 00 02 FB 01
++			15 00 02 00 01
++			15 00 02 01 0B
++			15 00 02 02 0C
++			15 00 02 03 09
++			15 00 02 04 0A
++			15 00 02 05 00
++			15 00 02 06 0F
++			15 00 02 07 10
++			15 00 02 08 00
++			15 00 02 09 00
++			15 00 02 0A 00
++			15 00 02 0B 00
++			15 00 02 0C 00
++			15 00 02 0D 13
++			15 00 02 0E 15
++			15 00 02 0F 17
++			15 00 02 10 01
++			15 00 02 11 0B
++			15 00 02 12 0C
++			15 00 02 13 09
++			15 00 02 14 0A
++			15 00 02 15 00
++			15 00 02 16 0F
++			15 00 02 17 10
++			15 00 02 18 00
++			15 00 02 19 00
++			15 00 02 1A 00
++			15 00 02 1B 00
++			15 00 02 1C 00
++			15 00 02 1D 13
++			15 00 02 1E 15
++			15 00 02 1F 17
++			15 00 02 20 00
++			15 00 02 21 03
++			15 00 02 22 01
++			15 00 02 23 40
++			15 00 02 24 40
++			15 00 02 25 ED
++			15 00 02 29 58
++			15 00 02 2A 12
++			15 00 02 2B 01
++			15 00 02 4B 06
++			15 00 02 4C 11
++			15 00 02 4D 20
++			15 00 02 4E 02
++			15 00 02 4F 02
++			15 00 02 50 20
++			15 00 02 51 61
++			15 00 02 52 01
++			15 00 02 53 63
++			15 00 02 54 77
++			15 00 02 55 ED
++			15 00 02 5B 00
++			15 00 02 5C 00
++			15 00 02 5D 00
++			15 00 02 5E 00
++			15 00 02 5F 15
++			15 00 02 60 75
++			15 00 02 61 00
++			15 00 02 62 00
++			15 00 02 63 00
++			15 00 02 64 00
++			15 00 02 65 00
++			15 00 02 66 00
++			15 00 02 67 00
++			15 00 02 68 04
++			15 00 02 69 00
++			15 00 02 6A 00
++			15 00 02 6C 40
++			15 00 02 75 01
++			15 00 02 76 01
++			15 00 02 7A 80
++			15 00 02 7B A3
++			15 00 02 7C D8
++			15 00 02 7D 60
++			15 00 02 7F 15
++			15 00 02 80 81
++			15 00 02 83 05
++			15 00 02 93 08
++			15 00 02 94 10
++			15 00 02 8A 00
++			15 00 02 9B 0F
++			15 00 02 EA FF
++			15 00 02 EC 00
++			15 00 02 FF 01
++			15 00 02 FB 01
++			15 00 02 75 00
++			15 00 02 76 DF
++			15 00 02 77 00
++			15 00 02 78 E4
++			15 00 02 79 00
++			15 00 02 7A ED
++			15 00 02 7B 00
++			15 00 02 7C F6
++			15 00 02 7D 00
++			15 00 02 7E FF
++			15 00 02 7F 01
++			15 00 02 80 07
++			15 00 02 81 01
++			15 00 02 82 10
++			15 00 02 83 01
++			15 00 02 84 18
++			15 00 02 85 01
++			15 00 02 86 20
++			15 00 02 87 01
++			15 00 02 88 3D
++			15 00 02 89 01
++			15 00 02 8A 56
++			15 00 02 8B 01
++			15 00 02 8C 84
++			15 00 02 8D 01
++			15 00 02 8E AB
++			15 00 02 8F 01
++			15 00 02 90 EC
++			15 00 02 91 02
++			15 00 02 92 22
++			15 00 02 93 02
++			15 00 02 94 23
++			15 00 02 95 02
++			15 00 02 96 55
++			15 00 02 97 02
++			15 00 02 98 8B
++			15 00 02 99 02
++			15 00 02 9A AF
++			15 00 02 9B 02
++			15 00 02 9C DF
++			15 00 02 9D 03
++			15 00 02 9E 01
++			15 00 02 9F 03
++			15 00 02 A0 2C
++			15 00 02 A2 03
++			15 00 02 A3 39
++			15 00 02 A4 03
++			15 00 02 A5 47
++			15 00 02 A6 03
++			15 00 02 A7 56
++			15 00 02 A9 03
++			15 00 02 AA 66
++			15 00 02 AB 03
++			15 00 02 AC 76
++			15 00 02 AD 03
++			15 00 02 AE 85
++			15 00 02 AF 03
++			15 00 02 B0 90
++			15 00 02 B1 03
++			15 00 02 B2 CB
++			15 00 02 B3 00
++			15 00 02 B4 DF
++			15 00 02 B5 00
++			15 00 02 B6 E4
++			15 00 02 B7 00
++			15 00 02 B8 ED
++			15 00 02 B9 00
++			15 00 02 BA F6
++			15 00 02 BB 00
++			15 00 02 BC FF
++			15 00 02 BD 01
++			15 00 02 BE 07
++			15 00 02 BF 01
++			15 00 02 C0 10
++			15 00 02 C1 01
++			15 00 02 C2 18
++			15 00 02 C3 01
++			15 00 02 C4 20
++			15 00 02 C5 01
++			15 00 02 C6 3D
++			15 00 02 C7 01
++			15 00 02 C8 56
++			15 00 02 C9 01
++			15 00 02 CA 84
++			15 00 02 CB 01
++			15 00 02 CC AB
++			15 00 02 CD 01
++			15 00 02 CE EC
++			15 00 02 CF 02
++			15 00 02 D0 22
++			15 00 02 D1 02
++			15 00 02 D2 23
++			15 00 02 D3 02
++			15 00 02 D4 55
++			15 00 02 D5 02
++			15 00 02 D6 8B
++			15 00 02 D7 02
++			15 00 02 D8 AF
++			15 00 02 D9 02
++			15 00 02 DA DF
++			15 00 02 DB 03
++			15 00 02 DC 01
++			15 00 02 DD 03
++			15 00 02 DE 2C
++			15 00 02 DF 03
++			15 00 02 E0 39
++			15 00 02 E1 03
++			15 00 02 E2 47
++			15 00 02 E3 03
++			15 00 02 E4 56
++			15 00 02 E5 03
++			15 00 02 E6 66
++			15 00 02 E7 03
++			15 00 02 E8 76
++			15 00 02 E9 03
++			15 00 02 EA 85
++			15 00 02 EB 03
++			15 00 02 EC 90
++			15 00 02 ED 03
++			15 00 02 EE CB
++			15 00 02 EF 00
++			15 00 02 F0 BB
++			15 00 02 F1 00
++			15 00 02 F2 C0
++			15 00 02 F3 00
++			15 00 02 F4 CC
++			15 00 02 F5 00
++			15 00 02 F6 D6
++			15 00 02 F7 00
++			15 00 02 F8 E1
++			15 00 02 F9 00
++			15 00 02 FA EA
++			15 00 02 FF 02
++			15 00 02 FB 01
++			15 00 02 00 00
++			15 00 02 01 F4
++			15 00 02 02 00
++			15 00 02 03 EF
++			15 00 02 04 01
++			15 00 02 05 07
++			15 00 02 06 01
++			15 00 02 07 28
++			15 00 02 08 01
++			15 00 02 09 44
++			15 00 02 0A 01
++			15 00 02 0B 76
++			15 00 02 0C 01
++			15 00 02 0D A0
++			15 00 02 0E 01
++			15 00 02 0F E7
++			15 00 02 10 02
++			15 00 02 11 1F
++			15 00 02 12 02
++			15 00 02 13 22
++			15 00 02 14 02
++			15 00 02 15 54
++			15 00 02 16 02
++			15 00 02 17 8B
++			15 00 02 18 02
++			15 00 02 19 AF
++			15 00 02 1A 02
++			15 00 02 1B E0
++			15 00 02 1C 03
++			15 00 02 1D 01
++			15 00 02 1E 03
++			15 00 02 1F 2D
++			15 00 02 20 03
++			15 00 02 21 39
++			15 00 02 22 03
++			15 00 02 23 47
++			15 00 02 24 03
++			15 00 02 25 57
++			15 00 02 26 03
++			15 00 02 27 65
++			15 00 02 28 03
++			15 00 02 29 77
++			15 00 02 2A 03
++			15 00 02 2B 85
++			15 00 02 2D 03
++			15 00 02 2F 8F
++			15 00 02 30 03
++			15 00 02 31 CB
++			15 00 02 32 00
++			15 00 02 33 BB
++			15 00 02 34 00
++			15 00 02 35 C0
++			15 00 02 36 00
++			15 00 02 37 CC
++			15 00 02 38 00
++			15 00 02 39 D6
++			15 00 02 3A 00
++			15 00 02 3B E1
++			15 00 02 3D 00
++			15 00 02 3F EA
++			15 00 02 40 00
++			15 00 02 41 F4
++			15 00 02 42 00
++			15 00 02 43 FE
++			15 00 02 44 01
++			15 00 02 45 07
++			15 00 02 46 01
++			15 00 02 47 28
++			15 00 02 48 01
++			15 00 02 49 44
++			15 00 02 4A 01
++			15 00 02 4B 76
++			15 00 02 4C 01
++			15 00 02 4D A0
++			15 00 02 4E 01
++			15 00 02 4F E7
++			15 00 02 50 02
++			15 00 02 51 1F
++			15 00 02 52 02
++			15 00 02 53 22
++			15 00 02 54 02
++			15 00 02 55 54
++			15 00 02 56 02
++			15 00 02 58 8B
++			15 00 02 59 02
++			15 00 02 5A AF
++			15 00 02 5B 02
++			15 00 02 5C E0
++			15 00 02 5D 03
++			15 00 02 5E 01
++			15 00 02 5F 03
++			15 00 02 60 2D
++			15 00 02 61 03
++			15 00 02 62 39
++			15 00 02 63 03
++			15 00 02 64 47
++			15 00 02 65 03
++			15 00 02 66 57
++			15 00 02 67 03
++			15 00 02 68 65
++			15 00 02 69 03
++			15 00 02 6A 77
++			15 00 02 6B 03
++			15 00 02 6C 85
++			15 00 02 6D 03
++			15 00 02 6E 8F
++			15 00 02 6F 03
++			15 00 02 70 CB
++			15 00 02 71 00
++			15 00 02 72 00
++			15 00 02 73 00
++			15 00 02 74 21
++			15 00 02 75 00
++			15 00 02 76 4C
++			15 00 02 77 00
++			15 00 02 78 6B
++			15 00 02 79 00
++			15 00 02 7A 85
++			15 00 02 7B 00
++			15 00 02 7C 9A
++			15 00 02 7D 00
++			15 00 02 7E AD
++			15 00 02 7F 00
++			15 00 02 80 BE
++			15 00 02 81 00
++			15 00 02 82 CD
++			15 00 02 83 01
++			15 00 02 84 01
++			15 00 02 85 01
++			15 00 02 86 29
++			15 00 02 87 01
++			15 00 02 88 68
++			15 00 02 89 01
++			15 00 02 8A 98
++			15 00 02 8B 01
++			15 00 02 8C E5
++			15 00 02 8D 02
++			15 00 02 8E 1E
++			15 00 02 8F 02
++			15 00 02 90 30
++			15 00 02 91 02
++			15 00 02 92 52
++			15 00 02 93 02
++			15 00 02 94 88
++			15 00 02 95 02
++			15 00 02 96 AA
++			15 00 02 97 02
++			15 00 02 98 D7
++			15 00 02 99 02
++			15 00 02 9A F7
++			15 00 02 9B 03
++			15 00 02 9C 21
++			15 00 02 9D 03
++			15 00 02 9E 2E
++			15 00 02 9F 03
++			15 00 02 A0 3D
++			15 00 02 A2 03
++			15 00 02 A3 4C
++			15 00 02 A4 03
++			15 00 02 A5 5E
++			15 00 02 A6 03
++			15 00 02 A7 71
++			15 00 02 A9 03
++			15 00 02 AA 86
++			15 00 02 AB 03
++			15 00 02 AC 94
++			15 00 02 AD 03
++			15 00 02 AE FA
++			15 00 02 AF 00
++			15 00 02 B0 00
++			15 00 02 B1 00
++			15 00 02 B2 21
++			15 00 02 B3 00
++			15 00 02 B4 4C
++			15 00 02 B5 00
++			15 00 02 B6 6B
++			15 00 02 B7 00
++			15 00 02 B8 85
++			15 00 02 B9 00
++			15 00 02 BA 9A
++			15 00 02 BB 00
++			15 00 02 BC AD
++			15 00 02 BD 00
++			15 00 02 BE BE
++			15 00 02 BF 00
++			15 00 02 C0 CD
++			15 00 02 C1 01
++			15 00 02 C2 01
++			15 00 02 C3 01
++			15 00 02 C4 29
++			15 00 02 C5 01
++			15 00 02 C6 68
++			15 00 02 C7 01
++			15 00 02 C8 98
++			15 00 02 C9 01
++			15 00 02 CA E5
++			15 00 02 CB 02
++			15 00 02 CC 1E
++			15 00 02 CD 02
++			15 00 02 CE 20
++			15 00 02 CF 02
++			15 00 02 D0 52
++			15 00 02 D1 02
++			15 00 02 D2 88
++			15 00 02 D3 02
++			15 00 02 D4 AA
++			15 00 02 D5 02
++			15 00 02 D6 D7
++			15 00 02 D7 02
++			15 00 02 D8 F7
++			15 00 02 D9 03
++			15 00 02 DA 21
++			15 00 02 DB 03
++			15 00 02 DC 2E
++			15 00 02 DD 03
++			15 00 02 DE 3D
++			15 00 02 DF 03
++			15 00 02 E0 4C
++			15 00 02 E1 03
++			15 00 02 E2 5E
++			15 00 02 E3 03
++			15 00 02 E4 71
++			15 00 02 E5 03
++			15 00 02 E6 86
++			15 00 02 E7 03
++			15 00 02 E8 94
++			15 00 02 E9 03
++			15 00 02 EA FA
++			15 00 02 FF 01
++			15 00 02 FB 01
++			15 00 02 FF 02
++			15 00 02 FB 01
++			15 00 02 FF 04
++			15 00 02 FB 01
++			15 00 02 FF 00
++			15 00 02 D3 05
++			15 00 02 D4 04
++			05 78 01 11
++			15 00 02 FF 00
++			15 00 02 35 00
++			05 0A 01 29
++		];
++
++		panel-exit-sequence = [
++			05 05 01 28
++			05 78 01 10
++		];
++
++		disp_timings0: display-timings {
++			native-mode = <&dsi0_timing0>;
++			dsi0_timing0: timing0 {
++				clock-frequency = <152198100>;
++				hactive = <1080>;
++				vactive = <1920>;
++				hfront-porch = <104>;
++				hsync-len = <4>;
++				hback-porch = <127>;
++				vfront-porch = <4>;
++				vsync-len = <2>;
++				vback-porch = <3>;
++				hsync-active = <0>;
++				vsync-active = <0>;
++				de-active = <0>;
++				pixelclk-active = <0>;
++			};
++		};
++
++		ports {
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			port@0 {
++				reg = <0>;
++				panel_in_dsi: endpoint {
++					remote-endpoint = <&dsi_out_panel>;
++				};
++			};
++		};
++	};
++
++	ports {
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		port@1 {
++			reg = <1>;
++			dsi_out_panel: endpoint {
++				remote-endpoint = <&panel_in_dsi>;
++			};
++		};
++	};
++
++};
++
++&dsi1 {
++	status = "disabled";
++	//rockchip,lane-rate = <1000>;
++	dsi1_panel: panel@0 {
++		status = "disabled";
++		compatible = "simple-panel-dsi";
++		reg = <0>;
++		backlight = <&backlight_mipi1>;
++//		reset-delay-ms = <60>;
++		enable-delay-ms = <60>;
++		prepare-delay-ms = <60>;
++		unprepare-delay-ms = <60>;
++		disable-delay-ms = <60>;
++		dsi,flags = <(MIPI_DSI_MODE_VIDEO | MIPI_DSI_MODE_VIDEO_BURST |
++			MIPI_DSI_MODE_LPM | MIPI_DSI_MODE_EOT_PACKET)>;
++		dsi,format = <MIPI_DSI_FMT_RGB888>;
++		dsi,lanes  = <4>;
++		panel-init-sequence = [
++			15 00 02 FF 05
++			15 00 02 FB 01
++			15 64 02 C5 01
++			15 00 02 FF EE
++			15 00 02 FB 01
++			15 00 02 1F 45
++			15 00 02 24 4F
++			15 00 02 38 C8
++			15 00 02 39 27
++			15 00 02 1E 77
++			15 00 02 1D 0F
++			15 00 02 7E 71
++			15 00 02 7C 03
++			15 00 02 FF 00
++			15 00 02 FB 01
++			15 00 02 35 01
++			15 00 02 FF 01
++			15 00 02 FB 01
++			15 00 02 00 01
++			15 00 02 01 55
++			15 00 02 02 40
++			15 00 02 05 40
++			15 00 02 06 4A
++			15 00 02 07 24
++			15 00 02 08 0C
++			15 00 02 0B 7D
++			15 00 02 0C 7D
++			15 00 02 0E B0
++			15 00 02 0F AE
++			15 00 02 11 10
++			15 00 02 12 10
++			15 00 02 13 03
++			15 00 02 14 4A
++			15 00 02 15 12
++			15 00 02 16 12
++			15 00 02 18 00
++			15 00 02 19 77
++			15 00 02 1A 55
++			15 00 02 1B 13
++			15 00 02 1C 00
++			15 00 02 1D 00
++			15 00 02 1E 13
++			15 00 02 1F 00
++			15 00 02 23 00
++			15 00 02 24 00
++			15 00 02 25 00
++			15 00 02 26 00
++			15 00 02 27 00
++			15 00 02 28 00
++			15 00 02 35 00
++			15 00 02 66 00
++			15 00 02 58 82
++			15 00 02 59 02
++			15 00 02 5A 02
++			15 00 02 5B 02
++			15 00 02 5C 82
++			15 00 02 5D 82
++			15 00 02 5E 02
++			15 00 02 5F 02
++			15 00 02 72 31
++			15 00 02 FF 05
++			15 00 02 FB 01
++			15 00 02 00 01
++			15 00 02 01 0B
++			15 00 02 02 0C
++			15 00 02 03 09
++			15 00 02 04 0A
++			15 00 02 05 00
++			15 00 02 06 0F
++			15 00 02 07 10
++			15 00 02 08 00
++			15 00 02 09 00
++			15 00 02 0A 00
++			15 00 02 0B 00
++			15 00 02 0C 00
++			15 00 02 0D 13
++			15 00 02 0E 15
++			15 00 02 0F 17
++			15 00 02 10 01
++			15 00 02 11 0B
++			15 00 02 12 0C
++			15 00 02 13 09
++			15 00 02 14 0A
++			15 00 02 15 00
++			15 00 02 16 0F
++			15 00 02 17 10
++			15 00 02 18 00
++			15 00 02 19 00
++			15 00 02 1A 00
++			15 00 02 1B 00
++			15 00 02 1C 00
++			15 00 02 1D 13
++			15 00 02 1E 15
++			15 00 02 1F 17
++			15 00 02 20 00
++			15 00 02 21 03
++			15 00 02 22 01
++			15 00 02 23 40
++			15 00 02 24 40
++			15 00 02 25 ED
++			15 00 02 29 58
++			15 00 02 2A 12
++			15 00 02 2B 01
++			15 00 02 4B 06
++			15 00 02 4C 11
++			15 00 02 4D 20
++			15 00 02 4E 02
++			15 00 02 4F 02
++			15 00 02 50 20
++			15 00 02 51 61
++			15 00 02 52 01
++			15 00 02 53 63
++			15 00 02 54 77
++			15 00 02 55 ED
++			15 00 02 5B 00
++			15 00 02 5C 00
++			15 00 02 5D 00
++			15 00 02 5E 00
++			15 00 02 5F 15
++			15 00 02 60 75
++			15 00 02 61 00
++			15 00 02 62 00
++			15 00 02 63 00
++			15 00 02 64 00
++			15 00 02 65 00
++			15 00 02 66 00
++			15 00 02 67 00
++			15 00 02 68 04
++			15 00 02 69 00
++			15 00 02 6A 00
++			15 00 02 6C 40
++			15 00 02 75 01
++			15 00 02 76 01
++			15 00 02 7A 80
++			15 00 02 7B A3
++			15 00 02 7C D8
++			15 00 02 7D 60
++			15 00 02 7F 15
++			15 00 02 80 81
++			15 00 02 83 05
++			15 00 02 93 08
++			15 00 02 94 10
++			15 00 02 8A 00
++			15 00 02 9B 0F
++			15 00 02 EA FF
++			15 00 02 EC 00
++			15 00 02 FF 01
++			15 00 02 FB 01
++			15 00 02 75 00
++			15 00 02 76 DF
++			15 00 02 77 00
++			15 00 02 78 E4
++			15 00 02 79 00
++			15 00 02 7A ED
++			15 00 02 7B 00
++			15 00 02 7C F6
++			15 00 02 7D 00
++			15 00 02 7E FF
++			15 00 02 7F 01
++			15 00 02 80 07
++			15 00 02 81 01
++			15 00 02 82 10
++			15 00 02 83 01
++			15 00 02 84 18
++			15 00 02 85 01
++			15 00 02 86 20
++			15 00 02 87 01
++			15 00 02 88 3D
++			15 00 02 89 01
++			15 00 02 8A 56
++			15 00 02 8B 01
++			15 00 02 8C 84
++			15 00 02 8D 01
++			15 00 02 8E AB
++			15 00 02 8F 01
++			15 00 02 90 EC
++			15 00 02 91 02
++			15 00 02 92 22
++			15 00 02 93 02
++			15 00 02 94 23
++			15 00 02 95 02
++			15 00 02 96 55
++			15 00 02 97 02
++			15 00 02 98 8B
++			15 00 02 99 02
++			15 00 02 9A AF
++			15 00 02 9B 02
++			15 00 02 9C DF
++			15 00 02 9D 03
++			15 00 02 9E 01
++			15 00 02 9F 03
++			15 00 02 A0 2C
++			15 00 02 A2 03
++			15 00 02 A3 39
++			15 00 02 A4 03
++			15 00 02 A5 47
++			15 00 02 A6 03
++			15 00 02 A7 56
++			15 00 02 A9 03
++			15 00 02 AA 66
++			15 00 02 AB 03
++			15 00 02 AC 76
++			15 00 02 AD 03
++			15 00 02 AE 85
++			15 00 02 AF 03
++			15 00 02 B0 90
++			15 00 02 B1 03
++			15 00 02 B2 CB
++			15 00 02 B3 00
++			15 00 02 B4 DF
++			15 00 02 B5 00
++			15 00 02 B6 E4
++			15 00 02 B7 00
++			15 00 02 B8 ED
++			15 00 02 B9 00
++			15 00 02 BA F6
++			15 00 02 BB 00
++			15 00 02 BC FF
++			15 00 02 BD 01
++			15 00 02 BE 07
++			15 00 02 BF 01
++			15 00 02 C0 10
++			15 00 02 C1 01
++			15 00 02 C2 18
++			15 00 02 C3 01
++			15 00 02 C4 20
++			15 00 02 C5 01
++			15 00 02 C6 3D
++			15 00 02 C7 01
++			15 00 02 C8 56
++			15 00 02 C9 01
++			15 00 02 CA 84
++			15 00 02 CB 01
++			15 00 02 CC AB
++			15 00 02 CD 01
++			15 00 02 CE EC
++			15 00 02 CF 02
++			15 00 02 D0 22
++			15 00 02 D1 02
++			15 00 02 D2 23
++			15 00 02 D3 02
++			15 00 02 D4 55
++			15 00 02 D5 02
++			15 00 02 D6 8B
++			15 00 02 D7 02
++			15 00 02 D8 AF
++			15 00 02 D9 02
++			15 00 02 DA DF
++			15 00 02 DB 03
++			15 00 02 DC 01
++			15 00 02 DD 03
++			15 00 02 DE 2C
++			15 00 02 DF 03
++			15 00 02 E0 39
++			15 00 02 E1 03
++			15 00 02 E2 47
++			15 00 02 E3 03
++			15 00 02 E4 56
++			15 00 02 E5 03
++			15 00 02 E6 66
++			15 00 02 E7 03
++			15 00 02 E8 76
++			15 00 02 E9 03
++			15 00 02 EA 85
++			15 00 02 EB 03
++			15 00 02 EC 90
++			15 00 02 ED 03
++			15 00 02 EE CB
++			15 00 02 EF 00
++			15 00 02 F0 BB
++			15 00 02 F1 00
++			15 00 02 F2 C0
++			15 00 02 F3 00
++			15 00 02 F4 CC
++			15 00 02 F5 00
++			15 00 02 F6 D6
++			15 00 02 F7 00
++			15 00 02 F8 E1
++			15 00 02 F9 00
++			15 00 02 FA EA
++			15 00 02 FF 02
++			15 00 02 FB 01
++			15 00 02 00 00
++			15 00 02 01 F4
++			15 00 02 02 00
++			15 00 02 03 EF
++			15 00 02 04 01
++			15 00 02 05 07
++			15 00 02 06 01
++			15 00 02 07 28
++			15 00 02 08 01
++			15 00 02 09 44
++			15 00 02 0A 01
++			15 00 02 0B 76
++			15 00 02 0C 01
++			15 00 02 0D A0
++			15 00 02 0E 01
++			15 00 02 0F E7
++			15 00 02 10 02
++			15 00 02 11 1F
++			15 00 02 12 02
++			15 00 02 13 22
++			15 00 02 14 02
++			15 00 02 15 54
++			15 00 02 16 02
++			15 00 02 17 8B
++			15 00 02 18 02
++			15 00 02 19 AF
++			15 00 02 1A 02
++			15 00 02 1B E0
++			15 00 02 1C 03
++			15 00 02 1D 01
++			15 00 02 1E 03
++			15 00 02 1F 2D
++			15 00 02 20 03
++			15 00 02 21 39
++			15 00 02 22 03
++			15 00 02 23 47
++			15 00 02 24 03
++			15 00 02 25 57
++			15 00 02 26 03
++			15 00 02 27 65
++			15 00 02 28 03
++			15 00 02 29 77
++			15 00 02 2A 03
++			15 00 02 2B 85
++			15 00 02 2D 03
++			15 00 02 2F 8F
++			15 00 02 30 03
++			15 00 02 31 CB
++			15 00 02 32 00
++			15 00 02 33 BB
++			15 00 02 34 00
++			15 00 02 35 C0
++			15 00 02 36 00
++			15 00 02 37 CC
++			15 00 02 38 00
++			15 00 02 39 D6
++			15 00 02 3A 00
++			15 00 02 3B E1
++			15 00 02 3D 00
++			15 00 02 3F EA
++			15 00 02 40 00
++			15 00 02 41 F4
++			15 00 02 42 00
++			15 00 02 43 FE
++			15 00 02 44 01
++			15 00 02 45 07
++			15 00 02 46 01
++			15 00 02 47 28
++			15 00 02 48 01
++			15 00 02 49 44
++			15 00 02 4A 01
++			15 00 02 4B 76
++			15 00 02 4C 01
++			15 00 02 4D A0
++			15 00 02 4E 01
++			15 00 02 4F E7
++			15 00 02 50 02
++			15 00 02 51 1F
++			15 00 02 52 02
++			15 00 02 53 22
++			15 00 02 54 02
++			15 00 02 55 54
++			15 00 02 56 02
++			15 00 02 58 8B
++			15 00 02 59 02
++			15 00 02 5A AF
++			15 00 02 5B 02
++			15 00 02 5C E0
++			15 00 02 5D 03
++			15 00 02 5E 01
++			15 00 02 5F 03
++			15 00 02 60 2D
++			15 00 02 61 03
++			15 00 02 62 39
++			15 00 02 63 03
++			15 00 02 64 47
++			15 00 02 65 03
++			15 00 02 66 57
++			15 00 02 67 03
++			15 00 02 68 65
++			15 00 02 69 03
++			15 00 02 6A 77
++			15 00 02 6B 03
++			15 00 02 6C 85
++			15 00 02 6D 03
++			15 00 02 6E 8F
++			15 00 02 6F 03
++			15 00 02 70 CB
++			15 00 02 71 00
++			15 00 02 72 00
++			15 00 02 73 00
++			15 00 02 74 21
++			15 00 02 75 00
++			15 00 02 76 4C
++			15 00 02 77 00
++			15 00 02 78 6B
++			15 00 02 79 00
++			15 00 02 7A 85
++			15 00 02 7B 00
++			15 00 02 7C 9A
++			15 00 02 7D 00
++			15 00 02 7E AD
++			15 00 02 7F 00
++			15 00 02 80 BE
++			15 00 02 81 00
++			15 00 02 82 CD
++			15 00 02 83 01
++			15 00 02 84 01
++			15 00 02 85 01
++			15 00 02 86 29
++			15 00 02 87 01
++			15 00 02 88 68
++			15 00 02 89 01
++			15 00 02 8A 98
++			15 00 02 8B 01
++			15 00 02 8C E5
++			15 00 02 8D 02
++			15 00 02 8E 1E
++			15 00 02 8F 02
++			15 00 02 90 30
++			15 00 02 91 02
++			15 00 02 92 52
++			15 00 02 93 02
++			15 00 02 94 88
++			15 00 02 95 02
++			15 00 02 96 AA
++			15 00 02 97 02
++			15 00 02 98 D7
++			15 00 02 99 02
++			15 00 02 9A F7
++			15 00 02 9B 03
++			15 00 02 9C 21
++			15 00 02 9D 03
++			15 00 02 9E 2E
++			15 00 02 9F 03
++			15 00 02 A0 3D
++			15 00 02 A2 03
++			15 00 02 A3 4C
++			15 00 02 A4 03
++			15 00 02 A5 5E
++			15 00 02 A6 03
++			15 00 02 A7 71
++			15 00 02 A9 03
++			15 00 02 AA 86
++			15 00 02 AB 03
++			15 00 02 AC 94
++			15 00 02 AD 03
++			15 00 02 AE FA
++			15 00 02 AF 00
++			15 00 02 B0 00
++			15 00 02 B1 00
++			15 00 02 B2 21
++			15 00 02 B3 00
++			15 00 02 B4 4C
++			15 00 02 B5 00
++			15 00 02 B6 6B
++			15 00 02 B7 00
++			15 00 02 B8 85
++			15 00 02 B9 00
++			15 00 02 BA 9A
++			15 00 02 BB 00
++			15 00 02 BC AD
++			15 00 02 BD 00
++			15 00 02 BE BE
++			15 00 02 BF 00
++			15 00 02 C0 CD
++			15 00 02 C1 01
++			15 00 02 C2 01
++			15 00 02 C3 01
++			15 00 02 C4 29
++			15 00 02 C5 01
++			15 00 02 C6 68
++			15 00 02 C7 01
++			15 00 02 C8 98
++			15 00 02 C9 01
++			15 00 02 CA E5
++			15 00 02 CB 02
++			15 00 02 CC 1E
++			15 00 02 CD 02
++			15 00 02 CE 20
++			15 00 02 CF 02
++			15 00 02 D0 52
++			15 00 02 D1 02
++			15 00 02 D2 88
++			15 00 02 D3 02
++			15 00 02 D4 AA
++			15 00 02 D5 02
++			15 00 02 D6 D7
++			15 00 02 D7 02
++			15 00 02 D8 F7
++			15 00 02 D9 03
++			15 00 02 DA 21
++			15 00 02 DB 03
++			15 00 02 DC 2E
++			15 00 02 DD 03
++			15 00 02 DE 3D
++			15 00 02 DF 03
++			15 00 02 E0 4C
++			15 00 02 E1 03
++			15 00 02 E2 5E
++			15 00 02 E3 03
++			15 00 02 E4 71
++			15 00 02 E5 03
++			15 00 02 E6 86
++			15 00 02 E7 03
++			15 00 02 E8 94
++			15 00 02 E9 03
++			15 00 02 EA FA
++			15 00 02 FF 01
++			15 00 02 FB 01
++			15 00 02 FF 02
++			15 00 02 FB 01
++			15 00 02 FF 04
++			15 00 02 FB 01
++			15 00 02 FF 00
++			15 00 02 D3 05
++			15 00 02 D4 04
++			05 78 01 11
++			15 00 02 FF 00
++			15 00 02 35 00
++			05 0A 01 29
++		];
++
++		panel-exit-sequence = [
++			05 05 01 28
++			05 78 01 10
++		];
++
++		disp_timings1: display-timings {
++			native-mode = <&dsi1_timing0>;
++			dsi1_timing0: timing0 {
++				clock-frequency = <152198100>;
++				hactive = <1080>;
++				vactive = <1920>;
++				hfront-porch = <104>;
++				hsync-len = <4>;
++				hback-porch = <127>;
++				vfront-porch = <4>;
++				vsync-len = <2>;
++				vback-porch = <3>;
++				hsync-active = <0>;
++				vsync-active = <0>;
++				de-active = <0>;
++				pixelclk-active = <0>;
++			};
++		};
++
++		ports {
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			port@0 {
++				reg = <0>;
++				panel_in_dsi1: endpoint {
++					remote-endpoint = <&dsi1_out_panel>;
++				};
++			};
++		};
++	};
++
++	ports {
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		port@1 {
++			reg = <1>;
++			dsi1_out_panel: endpoint {
++				remote-endpoint = <&panel_in_dsi1>;
++			};
++		};
++	};
++
++};
++
++&gpu {
++	mali-supply = <&vdd_gpu_s0>;
++	mem-supply = <&vdd_gpu_mem_s0>;
++	status = "okay";
++};
++
++&i2s0_8ch {
++	status = "okay";
++	pinctrl-0 = <&i2s0_lrck
++		     &i2s0_sclk
++		     &i2s0_sdi0
++		     &i2s0_sdo0>;
++};
++
++&iep {
++	status = "okay";
++};
++
++&iep_mmu {
++	status = "okay";
++};
++
++&jpegd {
++	status = "okay";
++};
++
++&jpegd_mmu {
++	status = "okay";
++};
++
++&jpege_ccu {
++	status = "okay";
++};
++
++&jpege0 {
++	status = "okay";
++};
++
++&jpege0_mmu {
++	status = "okay";
++};
++
++&jpege1 {
++	status = "okay";
++};
++
++&jpege1_mmu {
++	status = "okay";
++};
++
++&jpege2 {
++	status = "okay";
++};
++
++&jpege2_mmu {
++	status = "okay";
++};
++
++&jpege3 {
++	status = "okay";
++};
++
++&jpege3_mmu {
++	status = "okay";
++};
++
++&mpp_srv {
++	status = "okay";
++};
++
++&rga3_core0 {
++	status = "okay";
++};
++
++&rga3_0_mmu {
++	status = "okay";
++};
++
++&rga3_core1 {
++	status = "okay";
++};
++
++&rga3_1_mmu {
++	status = "okay";
++};
++
++&rga2 {
++	status = "okay";
++};
++
++&rknpu {
++	rknpu-supply = <&vdd_npu_s0>;
++	mem-supply = <&vdd_npu_mem_s0>;
++	status = "okay";
++};
++
++&rknpu_mmu {
++	status = "okay";
++};
++
++&rkvdec_ccu {
++	status = "okay";
++};
++
++&rkvdec0 {
++	status = "okay";
++};
++
++&rkvdec0_mmu {
++	status = "okay";
++};
++
++&rkvdec1 {
++	status = "okay";
++};
++
++&rkvdec1_mmu {
++	status = "okay";
++};
++
++&rkvenc_ccu {
++	status = "okay";
++};
++
++&rkvenc0 {
++	status = "okay";
++};
++
++&rkvenc0_mmu {
++	status = "okay";
++};
++
++&rkvenc1 {
++	status = "okay";
++};
++
++&rkvenc1_mmu {
++	status = "okay";
++};
++
++&rockchip_suspend {
++	status = "okay";
++	rockchip,sleep-debug-en = <1>;
++};
++
++&saradc {
++	status = "okay";
++	vref-supply = <&vcc_1v8_s0>;
++};
++
++&sdhci {
++	bus-width = <8>;
++	no-sdio;
++	no-sd;
++	non-removable;
++	max-frequency = <200000000>;
++	mmc-hs400-1_8v;
++	mmc-hs400-enhanced-strobe;
++	status = "okay";
++};
++
++&sdmmc {
++	max-frequency = <150000000>;
++	no-sdio;
++	no-mmc;
++	bus-width = <4>;
++	cap-mmc-highspeed;
++	cap-sd-highspeed;
++	disable-wp;
++	sd-uhs-sdr104;
++	vmmc-supply = <&vcc_sd>;
++	vqmmc-supply = <&vccio_sd_s0>;
++	status = "disabled";
++};
++
++&tsadc {
++	status = "okay";
++};
++
++&u2phy0 {
++	status = "okay";
++};
++
++&u2phy2 {
++	status = "okay";
++};
++
++&u2phy3 {
++	status = "okay";
++};
++
++&u2phy0_otg {
++	status = "okay";
++};
++
++&u2phy2_host {
++	status = "okay";
++};
++
++&u2phy3_host {
++	status = "okay";
++};
++
++&usb_host0_ehci {
++	status = "okay";
++};
++
++&usb_host0_ohci {
++	status = "okay";
++};
++
++&usb_host1_ehci {
++	status = "okay";
++};
++
++&usb_host1_ohci {
++	status = "okay";
++};
++
++&usbdp_phy0 {
++	status = "okay";
++};
++
++&usbdp_phy0_dp {
++	status = "okay";
++};
++
++&usbdp_phy0_u3 {
++	status = "okay";
++};
++
++&usbdrd3_0 {
++	status = "okay";
++};
++
++&usbdrd_dwc3_0 {
++	dr_mode = "otg";
++	status = "okay";
++};
++
++&usbhost3_0 {
++	status = "okay";
++};
++
++&usbhost_dwc3_0 {
++	status = "okay";
++};
++
++&vdpu {
++	status = "okay";
++};
++
++&vdpu_mmu {
++	status = "okay";
++};
++
++&vop {
++	status = "okay";
++};
++
++&vop_mmu {
++	status = "okay";
++};
++
++/* vp0 & vp1 splice for 8K output */
++&vp0 {
++	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER0 | 1 << ROCKCHIP_VOP2_ESMART0)>;
++	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART0>;
++};
++
++&vp1 {
++	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER1 | 1 << ROCKCHIP_VOP2_ESMART1)>;
++	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART1>;
++};
++
++&vp2 {
++	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER2 | 1 << ROCKCHIP_VOP2_ESMART2)>;
++	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART2>;
++};
++
++&vp3 {
++	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER3 | 1 << ROCKCHIP_VOP2_ESMART3)>;
++	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART3>;
++};
+diff --git a/drivers/bluetooth/btbcm.c b/drivers/bluetooth/btbcm.c
+index 1b9743b7f2ef..c5af5715cd17 100644
+--- a/drivers/bluetooth/btbcm.c
++++ b/drivers/bluetooth/btbcm.c
+@@ -387,6 +387,7 @@ struct bcm_subver_table {
+ };
+ 
+ static const struct bcm_subver_table bcm_uart_subver_table[] = {
++	{ 0x1111, "BCM4362A2"	},	/* 000.017.017 */
+ 	{ 0x4103, "BCM4330B1"	},	/* 002.001.003 */
+ 	{ 0x410d, "BCM4334B0"	},	/* 002.001.013 */
+ 	{ 0x410e, "BCM43341B0"	},	/* 002.001.014 */
+diff --git a/drivers/input/sensors/accel/kxtj9.c b/drivers/input/sensors/accel/kxtj9.c
+index 4726c5f73b54..116f7b605d74 100644
+--- a/drivers/input/sensors/accel/kxtj9.c
++++ b/drivers/input/sensors/accel/kxtj9.c
+@@ -32,6 +32,7 @@
+ #include <linux/sensor-dev.h>
+ 
+ 
++#define KXTJ3_DEVID 0x35 //KXTJ3 id
+ #define KXTJ9_DEVID	0x09	//chip id
+ #define KXTJ9_RANGE	(2 * 16384)
+ 
+@@ -78,6 +79,7 @@
+ /* CONTROL REGISTER 1 BITS */
+ #define KXTJ9_DISABLE			0x7F
+ #define KXTJ9_ENABLE			(1 << 7)
++#define KXTJ3_INT_ENABLE               (1 << 5)
+ /* INPUT_ABS CONSTANTS */
+ #define FUZZ			3
+ #define FLAT			3
+@@ -109,6 +111,7 @@
+ #define KXTJ9_PRECISION       12
+ #define KXTJ9_BOUNDARY        (0x1 << (KXTJ9_PRECISION - 1))
+ #define KXTJ9_GRAVITY_STEP    KXTJ9_RANGE / KXTJ9_BOUNDARY
++#define KXTJ3_GRAVITY_STEP    KXTJ9_RANGE / KXTJ9_BOUNDARY
+ 
+ 
+ /****************operate according to sensor chip:start************/
+@@ -176,6 +179,9 @@ static int sensor_init(struct i2c_client *client)
+ 	}
+ 	
+ 	sensor->ops->ctrl_data = (KXTJ9_RES_12BIT | KXTJ9_G_2G);
++	if(sensor->pdata->irq_enable)
++		sensor->ops->ctrl_data |= KXTJ3_INT_ENABLE;
++
+ 	result = sensor_write_reg(client, sensor->ops->ctrl_reg, sensor->ops->ctrl_data);
+ 	if(result)
+ 	{
+@@ -192,7 +198,12 @@ static short sensor_convert_data(struct i2c_client *client, char high_byte, char
+ 	struct sensor_private_data *sensor =
+ 	    (struct sensor_private_data *) i2c_get_clientdata(client);	
+ 	//int precision = sensor->ops->precision;
+-	switch (sensor->devid) {	
++	switch (sensor->devid) {
++		case KXTJ3_DEVID:
++			result = (((short)high_byte << 8) | ((short)low_byte)) >> 4;
++			result *= KXTJ3_GRAVITY_STEP;
++			break;
++
+ 		case KXTJ9_DEVID:		
+ 			result = (((short)high_byte << 8) | ((short)low_byte)) >> 4;
+ 			result *= KXTJ9_GRAVITY_STEP;
+@@ -284,7 +295,7 @@ static struct sensor_operate gsensor_kxtj9_ops = {
+ 	.read_reg			= KXTJ9_XOUT_L,
+ 	.read_len			= 6,
+ 	.id_reg			= KXTJ9_WHO_AM_I,
+-	.id_data			= KXTJ9_DEVID,
++	.id_data			= KXTJ3_DEVID,
+ 	.precision			= KXTJ9_PRECISION,
+ 	.ctrl_reg			= KXTJ9_CTRL_REG1,
+ 	.int_status_reg	= KXTJ9_INT_REL,
+@@ -309,6 +320,7 @@ static int gsensor_kxtj9_remove(struct i2c_client *client)
+ 
+ static const struct i2c_device_id gsensor_kxtj9_id[] = {
+ 	{"gs_kxtj9", ACCEL_ID_KXTJ9},
++	{"gs_kxtj3", ACCEL_ID_KXTJ9},
+ 	{}
+ };
+ 
+@@ -318,7 +330,7 @@ static struct i2c_driver gsensor_kxtj9_driver = {
+ 	.shutdown = sensor_shutdown,
+ 	.id_table = gsensor_kxtj9_id,
+ 	.driver = {
+-		.name = "gsensor_kxtj9",
++		.name = "gsensor_kxtj3",
+ 	#ifdef CONFIG_PM
+ 		.pm = &sensor_pm_ops,
+ 	#endif
+diff --git a/drivers/input/sensors/sensor-dev.c b/drivers/input/sensors/sensor-dev.c
+index eb93e19157ea..1c873d3c1b15 100644
+--- a/drivers/input/sensors/sensor-dev.c
++++ b/drivers/input/sensors/sensor-dev.c
+@@ -1447,7 +1447,7 @@ static int sensor_misc_device_register(struct sensor_private_data *sensor, int t
+ 			sensor->fops.release = gsensor_dev_release;
+ 
+ 			sensor->miscdev.minor = MISC_DYNAMIC_MINOR;
+-			sensor->miscdev.name = "mma8452_daemon";
++			sensor->miscdev.name = "accel";
+ 			sensor->miscdev.fops = &sensor->fops;
+ 		} else {
+ 			memcpy(&sensor->miscdev, sensor->ops->misc_dev, sizeof(*sensor->ops->misc_dev));
+diff --git a/drivers/leds/leds-gpio.c b/drivers/leds/leds-gpio.c
+index 93f5b1b60fde..7d7b3c7581ed 100644
+--- a/drivers/leds/leds-gpio.c
++++ b/drivers/leds/leds-gpio.c
+@@ -78,6 +78,25 @@ static int create_gpio_led(const struct gpio_led *template,
+ 	struct led_init_data init_data = {};
+ 	int ret, state;
+ 
++	led_dat->gpiod = template->gpiod;
++	if (!led_dat->gpiod) {
++		unsigned long flags = GPIOF_OUT_INIT_LOW;
++		if (!gpio_is_valid(template->gpio)) {
++			dev_info(parent, "Skipping unavailable LED gpio %d (%s)\n",
++					template->gpio, template->name);
++			return 0;
++		}
++		if (template->active_low)
++			flags |= GPIOF_ACTIVE_LOW;
++		ret = devm_gpio_request_one(parent, template->gpio, flags,
++									template->name);
++		if (ret < 0)
++			return ret;
++		led_dat->gpiod = gpio_to_desc(template->gpio);
++		if (!led_dat->gpiod)
++			return -EINVAL;
++	}
++	led_dat->cdev.name = template->name;
+ 	led_dat->cdev.default_trigger = template->default_trigger;
+ 	led_dat->can_sleep = gpiod_cansleep(led_dat->gpiod);
+ 	if (!led_dat->can_sleep)
+@@ -125,6 +144,12 @@ struct gpio_leds_priv {
+ 	struct gpio_led_data leds[];
+ };
+ 
++static inline int sizeof_gpio_leds_priv(int num_leds)
++{
++	return sizeof(struct gpio_leds_priv) +
++			(sizeof(struct gpio_led_data) * num_leds);
++}
++
+ static struct gpio_leds_priv *gpio_leds_create(struct platform_device *pdev)
+ {
+ 	struct device *dev = &pdev->dev;
+@@ -145,19 +170,30 @@ static struct gpio_leds_priv *gpio_leds_create(struct platform_device *pdev)
+ 		struct gpio_led led = {};
+ 		const char *state = NULL;
+ 
++		struct device_node *np = to_of_node(child);
++		ret = fwnode_property_read_string(child, "label", &led.name);
++		if (ret && IS_ENABLED(CONFIG_OF) && np)
++			led.name = np->name;
++		if (!led.name) {
++			fwnode_handle_put(child);
++			return ERR_PTR(-EINVAL);
++		}
++
+ 		/*
+ 		 * Acquire gpiod from DT with uninitialized label, which
+ 		 * will be updated after LED class device is registered,
+ 		 * Only then the final LED name is known.
+ 		 */
+ 		led.gpiod = devm_fwnode_get_gpiod_from_child(dev, NULL, child,
+-							     GPIOD_ASIS,
+-							     NULL);
++							     GPIOD_ASIS,led.name);
+ 		if (IS_ERR(led.gpiod)) {
+ 			fwnode_handle_put(child);
+ 			return ERR_CAST(led.gpiod);
+ 		}
+ 
++		fwnode_property_read_string(child, "linux,default-trigger",
++						&led.default_trigger);
++
+ 		led_dat->gpiod = led.gpiod;
+ 
+ 		if (!fwnode_property_read_string(child, "default-state",
+diff --git a/drivers/misc/Kconfig b/drivers/misc/Kconfig
+index 62f35ba898de..9b51e716f7f8 100644
+--- a/drivers/misc/Kconfig
++++ b/drivers/misc/Kconfig
+@@ -5,12 +5,6 @@
+ 
+ menu "Misc devices"
+ 
+-config RK803
+-	tristate "RK803"
+-	default n
+-	help
+-	  Driver for RK803 which is used for driving porjector and IR flood LED.
+-
+ config SENSORS_LIS3LV02D
+ 	tristate
+ 	depends on INPUT
+@@ -487,6 +481,18 @@ config HISI_HIKEY_USB
+ 	  switching between the dual-role USB-C port and the USB-A host ports
+ 	  using only one USB controller.
+ 
++config RK803
++	tristate "RK803"
++	default n
++	help
++	  Driver for RK803 which is used for driving porjector and IR flood LED.
++
++config KHADAS_MCU
++	tristate "Khadas MCU control driver"
++	default n
++	help
++	  This driver allow to control MCU.
++
+ source "drivers/misc/c2port/Kconfig"
+ source "drivers/misc/eeprom/Kconfig"
+ source "drivers/misc/cb710/Kconfig"
+diff --git a/drivers/misc/Makefile b/drivers/misc/Makefile
+index 8be76bac6eb8..574b8ff68cda 100644
+--- a/drivers/misc/Makefile
++++ b/drivers/misc/Makefile
+@@ -3,7 +3,7 @@
+ # Makefile for misc devices that really don't fit anywhere else.
+ #
+ 
+-obj-$(CONFIG_RK803)		+= rk803.o
++KBUILD_CFLAGS += -Wno-unused-function
+ obj-$(CONFIG_IBM_ASM)		+= ibmasm/
+ obj-$(CONFIG_IBMVMC)		+= ibmvmc.o
+ obj-$(CONFIG_AD525X_DPOT)	+= ad525x_dpot.o
+@@ -59,3 +59,5 @@ obj-$(CONFIG_UACCE)		+= uacce/
+ obj-$(CONFIG_XILINX_SDFEC)	+= xilinx_sdfec.o
+ obj-$(CONFIG_HISI_HIKEY_USB)	+= hisi_hikey_usb.o
+ obj-$(CONFIG_UID_SYS_STATS)	+= uid_sys_stats.o
++obj-$(CONFIG_RK803)		+= rk803.o
++obj-$(CONFIG_KHADAS_MCU) += khadas-mcu.o
+diff --git a/drivers/misc/khadas-mcu.c b/drivers/misc/khadas-mcu.c
+new file mode 100644
+index 000000000000..03f4eedbb62d
+--- /dev/null
++++ b/drivers/misc/khadas-mcu.c
+@@ -0,0 +1,696 @@
++/*
++ * Khadas Edge2 MCU control driver
++ *
++ * Written by: Nick <nick@khadas.com>
++ *
++ * Copyright (C) 2022 Wesion Technologies Ltd.
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License version 2 as
++ * published by the Free Software Foundation.
++ */
++
++#include <linux/module.h>
++#include <linux/i2c.h>
++#include <linux/string.h>
++#include <linux/list.h>
++#include <linux/sysfs.h>
++#include <linux/ctype.h>
++#include <linux/device.h>
++#include <linux/slab.h>
++#include <linux/of.h>
++#include <linux/of_address.h>
++
++/* Device registers */
++#define MCU_PWR_OFF_CMD_REG       0x80
++#define MCU_SHUTDOWN_NORMAL_REG   0x2c
++
++/*Fan device*/
++#define MCU_CMD_FAN_STATUS_CTRL_REGv2   0x8A
++
++#define MCU_FAN_TRIG_TEMP_LEVEL0        60  // 50 degree if not set
++#define MCU_FAN_TRIG_TEMP_LEVEL1        80  // 60 degree if not set
++#define MCU_FAN_TRIG_TEMP_LEVEL2        100 // 70 degree if not set
++#define MCU_FAN_TRIG_MAXTEMP            105
++#define MCU_FAN_LOOP_SECS               (30 * HZ)   // 30 seconds
++#define MCU_FAN_TEST_LOOP_SECS          (5 * HZ)  // 5 seconds
++#define MCU_FAN_LOOP_NODELAY_SECS       0
++#define MCU_FAN_SPEED_OFF               0
++#define MCU_FAN_SPEED_LOW               1
++#define MCU_FAN_SPEED_MID               2
++#define MCU_FAN_SPEED_HIGH              3
++#define MCU_FAN_SPEED_LOW_V2            0x32
++#define MCU_FAN_SPEED_MID_V2            0x48
++#define MCU_FAN_SPEED_HIGH_V2           0x64
++
++enum khadas_board {
++	KHADAS_BOARD_NONE = 0,
++	KHADAS_BOARD_EDGE2
++};
++
++enum khadas_board_hwver {
++	KHADAS_BOARD_HWVER_NONE = 0,
++	KHADAS_BOARD_HWVER_V11
++};
++
++enum mcu_fan_mode {
++	MCU_FAN_MODE_MANUAL = 0,
++	MCU_FAN_MODE_AUTO
++};
++
++enum mcu_fan_level {
++	MCU_FAN_LEVEL_0 = 0,
++	MCU_FAN_LEVEL_1,
++	MCU_FAN_LEVEL_2,
++	MCU_FAN_LEVEL_3
++};
++
++enum mcu_fan_status {
++	MCU_FAN_STATUS_DISABLE = 0,
++	MCU_FAN_STATUS_ENABLE,
++};
++
++struct mcu_fan_data {
++    struct platform_device *pdev;
++    struct class *fan_class;
++    struct delayed_work work;
++    struct delayed_work fan_test_work;
++    enum mcu_fan_status enable;
++    enum mcu_fan_mode mode;
++    enum mcu_fan_level level;
++    int trig_temp_level0;
++    int trig_temp_level1;
++    int trig_temp_level2;
++};
++
++struct mcu_data {
++	struct i2c_client *client;
++	struct class *mcu_class;
++	enum khadas_board board;
++	enum khadas_board_hwver hwver;
++	struct mcu_fan_data fan_data;
++};
++
++struct mcu_data *g_mcu_data;
++
++static int i2c_master_reg8_send(const struct i2c_client *client,
++		const char reg, const char *buf, int count)
++{
++	struct i2c_adapter *adap = client->adapter;
++	struct i2c_msg msg;
++	int ret;
++	char *tx_buf = kzalloc(count + 1, GFP_KERNEL);
++	if (!tx_buf)
++		return -ENOMEM;
++	tx_buf[0] = reg;
++	memcpy(tx_buf+1, buf, count);
++
++	msg.addr = client->addr;
++	msg.flags = client->flags;
++	msg.len = count + 1;
++	msg.buf = (char *)tx_buf;
++
++	ret = i2c_transfer(adap, &msg, 1);
++	kfree(tx_buf);
++	return (ret == 1) ? count : ret;
++}
++
++static int i2c_master_reg8_recv(const struct i2c_client *client,
++		const char reg, char *buf, int count)
++{
++	struct i2c_adapter *adap = client->adapter;
++	struct i2c_msg msgs[2];
++	int ret;
++	char reg_buf = reg;
++
++	msgs[0].addr = client->addr;
++	msgs[0].flags = client->flags;
++	msgs[0].len = 1;
++	msgs[0].buf = &reg_buf;
++
++	msgs[1].addr = client->addr;
++	msgs[1].flags = client->flags | I2C_M_RD;
++	msgs[1].len = count;
++	msgs[1].buf = (char *)buf;
++
++	ret = i2c_transfer(adap, msgs, 2);
++
++	return (ret == 2) ? count : ret;
++}
++
++static int mcu_i2c_read_regs(struct i2c_client *client,
++		u8 reg, u8 buf[], unsigned len)
++{
++	int ret;
++	ret = i2c_master_reg8_recv(client, reg, buf, len);
++	return ret;
++}
++
++static int mcu_i2c_write_regs(struct i2c_client *client,
++		u8 reg, u8 const buf[], __u16 len)
++{
++	int ret;
++
++	ret = i2c_master_reg8_send(client, reg, buf, (int)len);
++
++	return ret;
++}
++
++static int is_mcu_fan_control_supported(void)
++{
++	// MCU FAN control is supported for:
++	// 1. Khadas EDGE2
++	if (g_mcu_data->board == KHADAS_BOARD_EDGE2) {
++		if (g_mcu_data->hwver >= KHADAS_BOARD_HWVER_V11)
++			return 1;
++		else
++			return 0;
++	} else {
++			return 0;
++	}
++
++}
++static void mcu_fan_level_set(struct mcu_fan_data *fan_data, int level)
++{
++    if (is_mcu_fan_control_supported()) {
++        int ret;
++        u8 data = 0;
++
++        g_mcu_data->fan_data.level = level;
++
++		if (g_mcu_data->board == KHADAS_BOARD_EDGE2) {
++            if (level == 0)
++                data = MCU_FAN_SPEED_OFF;
++            else if (level == 1)
++                data = MCU_FAN_SPEED_LOW_V2;
++            else if (level == 2)
++                data = MCU_FAN_SPEED_MID_V2;
++            else if (level == 3)
++                data = MCU_FAN_SPEED_HIGH_V2;
++            ret = mcu_i2c_write_regs(g_mcu_data->client,
++                    MCU_CMD_FAN_STATUS_CTRL_REGv2,
++                    &data, 1);
++            if (ret < 0) {
++                pr_debug("write fan control err\n");
++                return;
++            }
++	      }
++    }
++}
++
++extern int rk_get_temperature(void);
++
++static void fan_work_func(struct work_struct *_work)
++{
++    if (is_mcu_fan_control_supported()) {
++        int temp = -EINVAL;
++        struct mcu_fan_data *fan_data = &g_mcu_data->fan_data;
++
++		if (g_mcu_data->board == KHADAS_BOARD_EDGE2) {
++            temp = rk_get_temperature();
++		} else {
++           temp = fan_data->trig_temp_level0;
++		}
++
++		if (temp != -EINVAL) {
++            if (temp < fan_data->trig_temp_level0)
++                mcu_fan_level_set(fan_data, 0);
++            else if (temp < fan_data->trig_temp_level1)
++                mcu_fan_level_set(fan_data, 1);
++            else if (temp < fan_data->trig_temp_level2)
++                mcu_fan_level_set(fan_data, 2);
++            else
++                mcu_fan_level_set(fan_data, 3);
++        }
++
++        schedule_delayed_work(&fan_data->work, MCU_FAN_LOOP_SECS);
++    }
++}
++
++static void khadas_fan_set(struct mcu_fan_data  *fan_data)
++{
++	if (is_mcu_fan_control_supported()) {
++        cancel_delayed_work(&fan_data->work);
++        if (fan_data->enable == MCU_FAN_STATUS_DISABLE) {
++            mcu_fan_level_set(fan_data, 0);
++            return;
++        }
++        switch (fan_data->mode) {
++        case MCU_FAN_MODE_MANUAL:
++            switch (fan_data->level) {
++				case MCU_FAN_LEVEL_0:
++					mcu_fan_level_set(fan_data, 0);
++					break;
++				case MCU_FAN_LEVEL_1:
++					mcu_fan_level_set(fan_data, 1);
++					break;
++				case MCU_FAN_LEVEL_2:
++					mcu_fan_level_set(fan_data, 2);
++					break;
++				case MCU_FAN_LEVEL_3:
++					mcu_fan_level_set(fan_data, 3);
++					break;
++				default:
++					break;
++            }
++            break;
++		case MCU_FAN_MODE_AUTO:
++            // FIXME: achieve with a better way
++			schedule_delayed_work(&fan_data->work,
++                    MCU_FAN_LOOP_NODELAY_SECS);
++			break;
++		default:
++			break;
++        }
++    }
++}
++
++static ssize_t show_fan_enable(struct class *cls,
++             struct class_attribute *attr, char *buf)
++{
++    return sprintf(buf, "Fan enable: %d\n", g_mcu_data->fan_data.enable);
++}
++
++static ssize_t store_fan_enable(struct class *cls, struct class_attribute *attr,
++               const char *buf, size_t count)
++{
++    int enable;
++
++    if (kstrtoint(buf, 0, &enable))
++        return -EINVAL;
++
++    // 0: manual, 1: auto
++    if (enable >= 0 && enable < 2) {
++        g_mcu_data->fan_data.enable = enable;
++        khadas_fan_set(&g_mcu_data->fan_data);
++    }
++
++	return count;
++}
++
++
++static ssize_t show_fan_mode(struct class *cls,
++             struct class_attribute *attr, char *buf)
++{
++    return sprintf(buf, "Fan mode: %d\n", g_mcu_data->fan_data.mode);
++}
++
++static ssize_t store_fan_mode(struct class *cls, struct class_attribute *attr,
++               const char *buf, size_t count)
++{
++    int mode;
++
++    if (kstrtoint(buf, 0, &mode))
++        return -EINVAL;
++
++    // 0: manual, 1: auto
++    if (mode >= 0 && mode < 2) {
++        g_mcu_data->fan_data.mode = mode;
++        khadas_fan_set(&g_mcu_data->fan_data);
++    }
++
++    return count;
++}
++
++static ssize_t show_fan_level(struct class *cls,
++             struct class_attribute *attr, char *buf)
++{
++    return sprintf(buf, "Fan level: %d\n", g_mcu_data->fan_data.level);
++}
++
++static ssize_t store_fan_level(struct class *cls, struct class_attribute *attr,
++               const char *buf, size_t count)
++{
++    int level;
++
++    if (kstrtoint(buf, 0, &level))
++        return -EINVAL;
++
++    if (level >= 0 && level < 4) {
++        g_mcu_data->fan_data.level = level;
++        khadas_fan_set(&g_mcu_data->fan_data);
++    }
++
++    return count;
++}
++
++static ssize_t show_fan_temp(struct class *cls,
++             struct class_attribute *attr, char *buf)
++{
++    struct mcu_fan_data *fan_data = &g_mcu_data->fan_data;
++    int temp = -EINVAL;
++
++    if (g_mcu_data->board == KHADAS_BOARD_EDGE2)
++        temp = rk_get_temperature();
++    else
++        temp = fan_data->trig_temp_level0;
++
++    return sprintf(buf,
++            "cpu_temp:%d\nFan trigger temperature: level0:%d level1:%d level2:%d\n",
++            temp, g_mcu_data->fan_data.trig_temp_level0,
++            g_mcu_data->fan_data.trig_temp_level1,
++            g_mcu_data->fan_data.trig_temp_level2);
++}
++
++void fan_level_set(struct mcu_data *ug_mcu_data)
++{
++    struct mcu_fan_data *fan_data = &g_mcu_data->fan_data;
++    int temp = -EINVAL;
++
++    if (ug_mcu_data->board == KHADAS_BOARD_EDGE2)
++        temp = rk_get_temperature();
++    else
++        temp = fan_data->trig_temp_level0;
++
++    if (temp != -EINVAL) {
++        if (temp < ug_mcu_data->fan_data.trig_temp_level0)
++            mcu_fan_level_set(fan_data, 0);
++        else if (temp < ug_mcu_data->fan_data.trig_temp_level1)
++            mcu_fan_level_set(fan_data, 1);
++        else if (temp < ug_mcu_data->fan_data.trig_temp_level2)
++            mcu_fan_level_set(fan_data, 2);
++        else
++            mcu_fan_level_set(fan_data, 3);
++    }
++}
++
++static ssize_t show_fan_trigger_low(struct class *cls,
++        struct class_attribute *attr, char *buf)
++{
++    return sprintf(buf,
++            "Fan trigger low speed temperature:%d\n",
++            g_mcu_data->fan_data.trig_temp_level0);
++}
++
++static ssize_t store_fan_trigger_low(struct class *cls,
++        struct class_attribute *attr,
++        const char *buf, size_t count)
++{
++    int trigger;
++
++    if (kstrtoint(buf, 0, &trigger))
++        return -EINVAL;
++
++    if (trigger >= g_mcu_data->fan_data.trig_temp_level1) {
++        pr_err("Invalid parameter\n");
++        return -EINVAL;
++    }
++
++    g_mcu_data->fan_data.trig_temp_level0 = trigger;
++
++    fan_level_set(g_mcu_data);
++
++    return count;
++}
++
++static ssize_t show_fan_trigger_mid(struct class *cls,
++        struct class_attribute *attr, char *buf)
++{
++    return sprintf(buf,
++            "Fan trigger mid speed temperature:%d\n",
++            g_mcu_data->fan_data.trig_temp_level1);
++}
++
++static ssize_t store_fan_trigger_mid(struct class *cls,
++        struct class_attribute *attr,
++        const char *buf, size_t count)
++{
++    int trigger;
++
++    if (kstrtoint(buf, 0, &trigger))
++        return -EINVAL;
++
++    if (trigger >= g_mcu_data->fan_data.trig_temp_level2 ||
++            trigger <= g_mcu_data->fan_data.trig_temp_level0){
++        pr_err("Invalid parameter\n");
++        return -EINVAL;
++    }
++
++    g_mcu_data->fan_data.trig_temp_level1 = trigger;
++
++    fan_level_set(g_mcu_data);
++
++    return count;
++}
++
++static ssize_t show_fan_trigger_high(struct class *cls,
++        struct class_attribute *attr, char *buf)
++{
++    return sprintf(buf,
++            "Fan trigger high speed temperature:%d\n",
++            g_mcu_data->fan_data.trig_temp_level2);
++}
++
++static ssize_t store_fan_trigger_high(struct class *cls,
++        struct class_attribute *attr,
++        const char *buf, size_t count)
++{
++    int trigger;
++
++    if (kstrtoint(buf, 0, &trigger))
++        return -EINVAL;
++
++    if (trigger <= g_mcu_data->fan_data.trig_temp_level1) {
++        pr_err("Invalid parameter\n");
++        return -EINVAL;
++    }
++
++    g_mcu_data->fan_data.trig_temp_level2 = trigger;
++
++    fan_level_set(g_mcu_data);
++
++    return count;
++}
++
++static ssize_t store_mcu_poweroff(struct class *cls,struct class_attribute *attr,
++				const char *buf, size_t count)
++{
++	int ret;
++	int val;
++	char reg;
++
++	if (kstrtoint(buf, 0, &val))
++		return -EINVAL;
++
++	if (val != 1)
++		return -EINVAL;
++
++	reg = (char)val;
++
++	ret = mcu_i2c_write_regs(g_mcu_data->client,MCU_PWR_OFF_CMD_REG,
++							&reg, 1);
++	if (ret < 0) {
++		pr_debug("write poweroff cmd error\n");
++		return ret;
++	}
++
++	return count;
++}
++
++static ssize_t store_mcu_rst(struct class *cls, struct class_attribute *attr,
++				const char *buf, size_t count)
++{
++	char reg;
++	int ret;
++	int rst;
++
++	if (kstrtoint(buf, 0, &rst))
++		return -EINVAL;
++
++	reg = rst;
++	ret = mcu_i2c_write_regs(g_mcu_data->client,MCU_SHUTDOWN_NORMAL_REG,
++							&reg, 1);
++	if (ret < 0) {
++		pr_debug("write poweroff cmd error\n");
++		return ret;
++	}
++
++	return count;
++}
++
++static struct class_attribute fan_class_attrs[] = {
++    __ATTR(enable, 0644, show_fan_enable, store_fan_enable),
++    __ATTR(mode, 0644, show_fan_mode, store_fan_mode),
++    __ATTR(level, 0644, show_fan_level, store_fan_level),
++    __ATTR(trigger_temp_low, 0644,
++            show_fan_trigger_low, store_fan_trigger_low),
++    __ATTR(trigger_temp_mid, 0644,
++            show_fan_trigger_mid, store_fan_trigger_mid),
++    __ATTR(trigger_temp_high, 0644,
++            show_fan_trigger_high, store_fan_trigger_high),
++    __ATTR(temp, 0644, show_fan_temp, NULL),
++};
++
++static struct class_attribute mcu_class_attrs[] = {
++	__ATTR(poweroff, 0644, NULL, store_mcu_poweroff),
++	__ATTR(rst, 0644, NULL, store_mcu_rst),
++};
++
++static void create_mcu_attrs(void) {
++	int i;
++
++	g_mcu_data->mcu_class = class_create(THIS_MODULE, "mcu");
++	if (IS_ERR(g_mcu_data->mcu_class)) {
++		pr_err("create mcu_class debug class fail\n");
++
++		return;
++	}
++	for (i = 0; i < ARRAY_SIZE(mcu_class_attrs); i++) {
++		if (class_create_file(g_mcu_data->mcu_class, &mcu_class_attrs[i]));
++			pr_err("create mcu attribute %s fail\n",
++							mcu_class_attrs[i].attr.name);
++	}
++
++	if (is_mcu_fan_control_supported()) {
++		g_mcu_data->fan_data.fan_class = class_create(THIS_MODULE, "fan");
++			if (IS_ERR(g_mcu_data->fan_data.fan_class)) {
++				pr_err("create fan_class debug class fail\n");
++				return;
++			}
++			for (i = 0; i < ARRAY_SIZE(fan_class_attrs); i++) {
++				if (class_create_file(g_mcu_data->fan_data.fan_class,
++                        &fan_class_attrs[i]))
++					pr_err("create fan attribute %s fail\n", fan_class_attrs[i].attr.name);
++        }
++	}
++}
++
++static int mcu_parse_dt(struct device *dev)
++{
++	int ret = 0;
++	const char *hwver = NULL;
++
++	if (NULL == dev) return -EINVAL;
++
++	ret = of_property_read_string(dev->of_node, "hwver", &hwver);
++	if (ret < 0) {
++			return 0;
++	} else {
++			if (strstr(hwver, "EDGE2"))
++					g_mcu_data->board = KHADAS_BOARD_EDGE2;
++			else
++					g_mcu_data->board = KHADAS_BOARD_NONE;
++
++			if (g_mcu_data->board == KHADAS_BOARD_EDGE2) {
++					if (strcmp(hwver, "EDGE2.V11") == 0)
++							g_mcu_data->hwver = KHADAS_BOARD_HWVER_V11;
++			}
++	}
++
++		ret = of_property_read_u32(dev->of_node,
++            "fan,trig_temp_level0",
++            &g_mcu_data->fan_data.trig_temp_level0);
++    if (ret < 0)
++        g_mcu_data->fan_data.trig_temp_level0 =
++            MCU_FAN_TRIG_TEMP_LEVEL0;
++    ret = of_property_read_u32(dev->of_node,
++            "fan,trig_temp_level1",
++            &g_mcu_data->fan_data.trig_temp_level1);
++    if (ret < 0)
++        g_mcu_data->fan_data.trig_temp_level1 =
++            MCU_FAN_TRIG_TEMP_LEVEL1;
++    ret = of_property_read_u32(dev->of_node,
++            "fan,trig_temp_level2",&g_mcu_data->fan_data.trig_temp_level2);
++    if (ret < 0){
++        g_mcu_data->fan_data.trig_temp_level2 =MCU_FAN_TRIG_TEMP_LEVEL2;
++	}
++
++	return ret;
++}
++
++static int mcu_probe(struct i2c_client *client, const struct i2c_device_id *id)
++{
++	printk("%s\n", __func__);
++
++	if (!i2c_check_functionality(client->adapter, I2C_FUNC_I2C))
++		return -ENODEV;
++
++	g_mcu_data = kzalloc(sizeof(struct mcu_data), GFP_KERNEL);
++
++	if (g_mcu_data == NULL)
++		return -ENOMEM;
++
++	mcu_parse_dt(&client->dev);
++
++	g_mcu_data->client = client;
++
++	g_mcu_data->fan_data.mode = MCU_FAN_MODE_AUTO;
++	g_mcu_data->fan_data.level = MCU_FAN_LEVEL_0;
++	g_mcu_data->fan_data.enable = MCU_FAN_STATUS_ENABLE;
++
++	INIT_DELAYED_WORK(&g_mcu_data->fan_data.work, fan_work_func);
++	mcu_fan_level_set(&g_mcu_data->fan_data, 0);
++	schedule_delayed_work(&g_mcu_data->fan_data.work, MCU_FAN_LOOP_SECS);
++	create_mcu_attrs();
++
++	return 0;
++}
++
++static int mcu_remove(struct i2c_client *client)
++{
++	kfree(g_mcu_data);
++	return 0;
++}
++
++static void khadas_fan_shutdown(struct i2c_client *client)
++{
++    g_mcu_data->fan_data.enable = MCU_FAN_STATUS_DISABLE;
++    khadas_fan_set(&g_mcu_data->fan_data);
++}
++
++#ifdef CONFIG_PM_SLEEP
++static int khadas_fan_suspend(struct device *dev)
++{
++    cancel_delayed_work(&g_mcu_data->fan_data.work);
++    mcu_fan_level_set(&g_mcu_data->fan_data, 0);
++
++    return 0;
++}
++
++static int khadas_fan_resume(struct device *dev)
++{
++    khadas_fan_set(&g_mcu_data->fan_data);
++
++    return 0;
++}
++
++static const struct dev_pm_ops fan_dev_pm_ops = {
++    SET_SYSTEM_SLEEP_PM_OPS(khadas_fan_suspend, khadas_fan_resume)
++};
++
++#define FAN_PM_OPS (&(fan_dev_pm_ops))
++
++#endif
++
++static const struct i2c_device_id mcu_id[] = {
++	{ "khadas-mcu", 0 },
++	{ }
++};
++MODULE_DEVICE_TABLE(i2c, mcu_id);
++
++
++static struct of_device_id mcu_dt_ids[] = {
++	{ .compatible = "khadas-mcu" },
++	{},
++};
++MODULE_DEVICE_TABLE(i2c, mcu_dt_ids);
++
++struct i2c_driver mcu_driver = {
++	.driver  = {
++		.name   = "khadas-mcu",
++		.owner  = THIS_MODULE,
++		.of_match_table = of_match_ptr(mcu_dt_ids),
++#ifdef CONFIG_PM_SLEEP
++		.pm = FAN_PM_OPS,
++#endif
++	},
++	.probe		= mcu_probe,
++	.remove 	= mcu_remove,
++	.shutdown = khadas_fan_shutdown,
++	.id_table	= mcu_id,
++};
++module_i2c_driver(mcu_driver);
++
++MODULE_AUTHOR("Nick <nick@khadas.com>");
++MODULE_DESCRIPTION("Khadas Edge2 MCU control driver");
++MODULE_LICENSE("GPL");
+diff --git a/drivers/thermal/rockchip_thermal.c b/drivers/thermal/rockchip_thermal.c
+index 4e8b45219431..73a7e54b6051 100644
+--- a/drivers/thermal/rockchip_thermal.c
++++ b/drivers/thermal/rockchip_thermal.c
+@@ -328,6 +328,8 @@ struct tsadc_table {
+ 	int temp;
+ };
+ 
++static struct rockchip_thermal_sensor  *g_tsensor_data_ptr;
++
+ static const struct tsadc_table rv1106_code_table[] = {
+ 	{0, -40000},
+ 	{396, -40000},
+@@ -1854,6 +1856,20 @@ static int rockchip_thermal_get_temp(void *_sensor, int *out_temp)
+ 	return retval;
+ }
+ 
++int rk_get_temperature(void)
++{
++	int temp;
++	int ret;
++
++	ret = rockchip_thermal_get_temp(g_tsensor_data_ptr, &temp);
++		if (ret) {
++			pr_debug("rk_get_temp failed!\n");
++			return ret;
++		}
++	     return temp / 1000;
++}
++EXPORT_SYMBOL(rk_get_temperature);
++
+ static const struct thermal_zone_of_device_ops rockchip_of_thermal_ops = {
+ 	.get_temp = rockchip_thermal_get_temp,
+ 	.set_trips = rockchip_thermal_set_trips,
+@@ -2198,6 +2214,7 @@ static int rockchip_thermal_probe(struct platform_device *pdev)
+ 	thermal->panic_nb.notifier_call = rockchip_thermal_panic;
+ 	atomic_notifier_chain_register(&panic_notifier_list,
+ 				       &thermal->panic_nb);
++	g_tsensor_data_ptr = &thermal->sensors[0];
+ 
+ 	dev_info(&pdev->dev, "tsadc is probed successfully!\n");
+ 
+diff --git a/drivers/watchdog/Kconfig b/drivers/watchdog/Kconfig
+index 01ce3f41cc21..bde9e629ec45 100644
+--- a/drivers/watchdog/Kconfig
++++ b/drivers/watchdog/Kconfig
+@@ -865,6 +865,16 @@ config MEDIATEK_WATCHDOG
+ 	  To compile this driver as a module, choose M here: the
+ 	  module will be called mtk_wdt.
+ 
++config KHADAS_WATCHDOG
++	tristate "KHADAS watchdog support"
++	default y
++	help
++	 Say Y here to include watchdog support embedded into KHADAS.
++	 If the watchdog timer expires, TPS3851 will shut down all its power
++	 supplies.
++	 To compile this driver as a module, choose M here: the
++	 module will be called KHADAS_wdt.
++
+ config DIGICOLOR_WATCHDOG
+ 	tristate "Conexant Digicolor SoCs watchdog support"
+ 	depends on ARCH_DIGICOLOR || COMPILE_TEST
+diff --git a/drivers/watchdog/Makefile b/drivers/watchdog/Makefile
+index 071a2e50be98..0dc45e86a352 100644
+--- a/drivers/watchdog/Makefile
++++ b/drivers/watchdog/Makefile
+@@ -25,6 +25,7 @@ obj-$(CONFIG_WATCHDOG_PRETIMEOUT_GOV_PANIC)	+= pretimeout_panic.o
+ obj-$(CONFIG_PCWATCHDOG) += pcwd.o
+ obj-$(CONFIG_MIXCOMWD) += mixcomwd.o
+ obj-$(CONFIG_WDT) += wdt.o
++obj-$(CONFIG_KHADAS_WATCHDOG) += khadas_wdt.o
+ 
+ # PCI-based Watchdog Cards
+ obj-$(CONFIG_PCIPCWATCHDOG) += pcwd_pci.o
+diff --git a/drivers/watchdog/khadas_wdt.c b/drivers/watchdog/khadas_wdt.c
+new file mode 100644
+index 000000000000..3b28a52fd6ae
+--- /dev/null
++++ b/drivers/watchdog/khadas_wdt.c
+@@ -0,0 +1,157 @@
++//#define DEBUG
++
++#include <linux/kernel.h>
++#include <linux/types.h>
++#include <linux/init.h>
++#include <linux/platform_device.h>
++#include <linux/gpio.h>
++#include <linux/of_platform.h>
++#include <linux/of_gpio.h>
++#include <linux/slab.h>
++#include <linux/workqueue.h>
++#include <linux/module.h>
++#include <linux/device.h>
++#include <asm/io.h>
++#include <asm/uaccess.h>
++#include <linux/fs.h>
++#include <linux/timer.h>
++#include <linux/jiffies.h>
++
++static struct timer_list mytimer;
++static unsigned int hw_margin = 3;
++static int khadas_input_pin;
++static unsigned int khadas_enble = 1;
++
++static void time_pre(struct timer_list *timer)
++{
++	static unsigned int flag=0;
++    flag = !flag;
++	gpio_direction_output(khadas_input_pin, flag);
++
++    //printk("%s\n", __func__);
++    mytimer.expires = jiffies + hw_margin * HZ/1000;  // 500ms 运行一次
++	if(khadas_enble)
++		mod_timer(&mytimer, mytimer.expires);
++}
++
++/*
++static void wdt_exit(void)
++{
++    if(timer_pending(&mytimer))
++    {
++        del_timer(&mytimer);
++    }
++    printk("exit Success \n");
++}*/
++
++static ssize_t show_enble(struct class *cls,
++				struct class_attribute *attr, char *buf)
++{
++	return sprintf(buf, "%d\n", khadas_enble);
++}
++
++static ssize_t store_enble(struct class *cls, struct class_attribute *attr,
++		        const char *buf, size_t count)
++{
++	int enable;
++
++	if (kstrtoint(buf, 0, &enable)){
++		printk("khadas_enble error\n");
++		return -EINVAL;
++	}
++	printk("khadas_enble=%d\n",enable);
++	khadas_enble = enable;
++	if(khadas_enble){
++		mytimer.expires = jiffies + hw_margin * HZ/1000;  // 500ms 运行一次
++		mod_timer(&mytimer, mytimer.expires);
++	}
++	return count;
++}
++
++static ssize_t store_pin_out(struct class *cls, struct class_attribute *attr,
++		        const char *buf, size_t count)
++{
++	int enable;
++
++	if (kstrtoint(buf, 0, &enable)){
++		printk("khadas_pin_out error\n");
++		return -EINVAL;
++	}
++	printk("khadas_pin_out=%d\n",enable);
++	gpio_direction_output(khadas_input_pin, enable);
++	return count;
++}
++
++static struct class_attribute khadas_attrs[] = {
++	__ATTR(enble, 0644, show_enble, store_enble),
++	__ATTR(pin_out, 0644, NULL, store_pin_out),
++};
++
++static void create_khadas_attrs(void)
++{
++	int i;
++	struct class *khadas_class;
++	printk("%s\n",__func__);
++	khadas_class = class_create(THIS_MODULE, "khadas");
++	if (IS_ERR(khadas_class)) {
++		pr_err("create khadas_class debug class fail\n");
++		return;
++	}
++	for (i = 0; i < ARRAY_SIZE(khadas_attrs); i++) {
++		if (class_create_file(khadas_class, &khadas_attrs[i]))
++			pr_err("create khadas attribute %s fail\n", khadas_attrs[i].attr.name);
++	}
++}
++
++static int wdt_probe(struct platform_device *pdev)
++{
++	const char *value;
++	int ret;
++	printk("hw_wdt enter probe\n");
++
++	ret = of_property_read_u32(pdev->dev.of_node,"hw_margin_ms", &hw_margin);
++	if (ret)
++		return ret;
++
++	ret = of_property_read_string(pdev->dev.of_node,
++					  "hw-gpios", &value);
++	if (ret) {
++		printk("no hw-gpios");
++		return -1;
++	} else {
++		khadas_input_pin = of_get_named_gpio_flags
++						(pdev->dev.of_node,
++						"hw-gpios",
++						0, NULL);
++		printk("hlm hw-gpios: %d.\n", khadas_input_pin);
++		ret = gpio_request(khadas_input_pin, "khadas");
++	}
++
++    timer_setup(&mytimer, time_pre, 0);
++    mytimer.expires = jiffies + hw_margin * HZ/1000; //// 5ms 运行一次
++    add_timer(&mytimer);
++	create_khadas_attrs();
++	return 0;
++}
++
++static const struct of_device_id hw_khadas_wdt_dt_ids[] = {
++	{ .compatible = "linux,wdt-khadas", },
++	{ }
++};
++MODULE_DEVICE_TABLE(of, hw_khadas_wdt_dt_ids);
++
++static struct platform_driver khadas_wdt_driver = {
++	.driver	= {
++		.name		= "hw_khadas_wdt",
++		.of_match_table	= hw_khadas_wdt_dt_ids,
++	},
++	.probe	= wdt_probe,
++};
++
++static int __init wdt_drv_init(void)
++{
++	return platform_driver_register(&khadas_wdt_driver);
++}
++arch_initcall(wdt_drv_init);
++
++MODULE_LICENSE("GPL");
+diff --git a/include/dt-bindings/soc/rockchip,boot-mode.h b/include/dt-bindings/soc/rockchip,boot-mode.h
+index 1436e1d32619..c617db54b09c 100644
+--- a/include/dt-bindings/soc/rockchip,boot-mode.h
++++ b/include/dt-bindings/soc/rockchip,boot-mode.h
+@@ -20,5 +20,6 @@
+ #define BOOT_CHARGING		(REBOOT_FLAG + 11)
+ /* enter usb mass storage mode */
+ #define BOOT_UMS		(REBOOT_FLAG + 12)
+-
++/* enter reboot test mode */
++#define BOOT_REBOOT_TEST        (REBOOT_FLAG + 14)
+ #endif
+-- 
+Armbian
+

--- a/patch/kernel/rockchip-rk3588-legacy/3001_most_of_khadas_incl_dts_and_drivers.patch
+++ b/patch/kernel/rockchip-rk3588-legacy/3001_most_of_khadas_incl_dts_and_drivers.patch
@@ -1,4 +1,4 @@
-From cda3b5543a39e9c8c897f3a4a1005aa169fbe608 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Tue, 19 Jul 2022 08:55:30 +0800
 Subject: arm64: rockchip: Edge2: configure Edge2 basic support
@@ -11,143 +11,208 @@ kedges_defconfig from rockchip_linux_defconfig rk3588_edge.config
 Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
 Change-Id: I3510b4538920e4fb1ed5e9f242b6a591f04d9ef2
 ---
- arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi |  345 +++
- arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts         |  801 +++++++
- arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi        | 1148 ++++++++++
- arch/arm64/configs/kedges_defconfig                           |  595 +++++
- 4 files changed, 2889 insertions(+)
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi |  303 +-
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts         |  908 +++--
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi        | 1681 ++++------
+ arch/arm64/configs/kedges_defconfig                           |  595 ++++
+ 4 files changed, 1626 insertions(+), 1861 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi
-new file mode 100644
-index 000000000000..9d0593167702
---- /dev/null
+index 2e27954aed42..9d0593167702 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi
-@@ -0,0 +1,345 @@
-+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
-+/*
-+ * Copyright (c) 2022 Wesion Technology Co., Ltd.
-+ *
-+ */
-+
-+&csi2_dcphy0 {
-+	status = "okay";
-+
-+	ports {
-+		#address-cells = <1>;
-+		#size-cells = <0>;
-+		port@0 {
-+			reg = <0>;
-+			#address-cells = <1>;
-+			#size-cells = <0>;
-+
+@@ -15,12 +15,18 @@ port@0 {
+ 			#address-cells = <1>;
+ 			#size-cells = <0>;
+ 
+-			mipi_in_dcphy0: endpoint@1 {
 +			dp_mipi_in: endpoint@1 {
-+				reg = <1>;
+ 				reg = <1>;
+-				remote-endpoint = <&imx415b_out0>;
 +				remote-endpoint = <&lt7911d_out>;
 +				data-lanes = <1 2 3 4>;
 +			};
 +			mipi_in_dcphy0: endpoint@2 {
 +				reg = <2>;
 +				remote-endpoint = <&ov50c40_out0>;
-+				data-lanes = <1 2 3 4>;
-+			};
-+		};
+ 				data-lanes = <1 2 3 4>;
+ 			};
+ 		};
 +
-+		port@1 {
-+			reg = <1>;
-+			#address-cells = <1>;
-+			#size-cells = <0>;
-+
-+			csidcphy0_out: endpoint@0 {
-+				reg = <0>;
-+				remote-endpoint = <&mipi0_csi2_input>;
-+			};
-+		};
-+	};
-+};
-+
-+&csi2_dcphy1 {
-+	status = "okay";
-+
-+	ports {
-+		#address-cells = <1>;
-+		#size-cells = <0>;
-+		port@0 {
-+			reg = <0>;
-+			#address-cells = <1>;
-+			#size-cells = <0>;
-+
-+			mipi_in_dcphy1: endpoint@1 {
-+				reg = <1>;
+ 		port@1 {
+ 			reg = <1>;
+ 			#address-cells = <1>;
+@@ -34,10 +40,6 @@ csidcphy0_out: endpoint@0 {
+ 	};
+ };
+ 
+-&mipi_dcphy0 {
+-	status = "okay";
+-};
+-
+ &csi2_dcphy1 {
+ 	status = "okay";
+ 
+@@ -51,7 +53,7 @@ port@0 {
+ 
+ 			mipi_in_dcphy1: endpoint@1 {
+ 				reg = <1>;
+-				remote-endpoint = <&imx415f_out1>;
 +				remote-endpoint = <&ov50c40_out1>;
-+				data-lanes = <1 2 3 4>;
-+			};
-+		};
-+		port@1 {
-+			reg = <1>;
-+			#address-cells = <1>;
-+			#size-cells = <0>;
-+
-+			csidcphy1_out: endpoint@0 {
-+				reg = <0>;
-+				remote-endpoint = <&mipi1_csi2_input>;
-+			};
-+		};
-+	};
-+};
-+
+ 				data-lanes = <1 2 3 4>;
+ 			};
+ 		};
+@@ -68,209 +70,139 @@ csidcphy1_out: endpoint@0 {
+ 	};
+ };
+ 
+-&mipi_dcphy1 {
+-	status = "okay";
+-};
+-
+-&csi2_dphy0 {
+-	status = "okay";
+-
+-	ports {
+-		#address-cells = <1>;
+-		#size-cells = <0>;
+-		port@0 {
+-			reg = <0>;
+-			#address-cells = <1>;
+-			#size-cells = <0>;
+-
+-			mipidphy0_in_ucam0: endpoint@1 {
+-				reg = <1>;
+-				remote-endpoint = <&imx415c_out0>;
+-				data-lanes = <1 2 3 4>;
+-			};
+-		};
+-		port@1 {
+-			reg = <1>;
+-			#address-cells = <1>;
+-			#size-cells = <0>;
+-
+-			csidphy0_out: endpoint@0 {
+-				reg = <0>;
+-				remote-endpoint = <&mipi2_csi2_input>;
+-			};
+-		};
+-	};
+-};
+-
+-&csi2_dphy0_hw {
+-	status = "okay";
+-};
+-
+-&i2c4 {
 +&i2c6 {
-+	status = "okay";
-+	pinctrl-names = "default";
+ 	status = "okay";
+ 	pinctrl-names = "default";
+-	pinctrl-0 = <&i2c4m3_xfer>;
 +	pinctrl-0 = <&i2c6m4_xfer>;
-+
+ 
+-	dw9714b: dw9714b@c {
+-		compatible = "dongwoon,dw9714";
 +	aw8601: aw8601@c {
 +		compatible = "awinic,aw8601";
-+		status = "okay";
-+		reg = <0x0c>;
+ 		status = "okay";
+ 		reg = <0x0c>;
+-		pinctrl-names = "focusb_gpios";
+-		pinctrl-0 = <&focusb_gpio>;
+-		focus-gpios = <&gpio1 RK_PA0 GPIO_ACTIVE_HIGH>;
+-		rockchip,vcm-start-current = <20>;
+-		rockchip,vcm-rated-current = <76>;
+-		rockchip,vcm-step-mode = <0>;
 +		rockchip,vcm-start-current = <56>;
 +		rockchip,vcm-rated-current = <96>;
 +		rockchip,vcm-step-mode = <4>;
-+		rockchip,camera-module-index = <0>;
-+		rockchip,camera-module-facing = "back";
-+	};
-+
+ 		rockchip,camera-module-index = <0>;
+ 		rockchip,camera-module-facing = "back";
+ 	};
+ 
+-	imx415b: imx415b@1a {
+-		compatible = "sony,imx415";
 +	lt7911d: lt7911d@2b {
 +		compatible = "lontium,lt7911d";
-+		status = "okay";
+ 		status = "okay";
+-		reg = <0x1a>;
 +		reg = <0x2b>;
-+		clocks = <&cru CLK_MIPI_CAMARAOUT_M1>;
-+		clock-names = "xvclk";
+ 		clocks = <&cru CLK_MIPI_CAMARAOUT_M1>;
+ 		clock-names = "xvclk";
 +		interrupt-parent = <&gpio3>;
 +		interrupts = <RK_PD4 IRQ_TYPE_EDGE_RISING>;
-+		power-domains = <&power RK3588_PD_VI>;
+ 		power-domains = <&power RK3588_PD_VI>;
+-		pinctrl-names = "default", "camb_gpios";
+-		pinctrl-0 = <&mipim1_camera1_clk>, <&camb_gpio>;
+-		rockchip,grf = <&sys_grf>;
+-		reset-gpios = <&gpio1 RK_PB2 GPIO_ACTIVE_LOW>;
+-		pwdn-gpios = <&gpio1 RK_PB3 GPIO_ACTIVE_HIGH>;
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&mipim1_camera1_clk>;
 +		reset-gpios = <&gpio3 RK_PC4 GPIO_ACTIVE_LOW>;
 +		power-gpios = <&gpio1 RK_PA6 GPIO_ACTIVE_HIGH>;
 +		// hpd-ctl-gpios = <&gpio3 RK_PC5 GPIO_ACTIVE_HIGH>;
 +		// plugin-det-gpios = <&gpio0 RK_PD6 GPIO_ACTIVE_LOW>;
-+		rockchip,camera-module-index = <0>;
-+		rockchip,camera-module-facing = "back";
+ 		rockchip,camera-module-index = <0>;
+ 		rockchip,camera-module-facing = "back";
+-		rockchip,camera-module-name = "CMK-OT2022-PX1";
+-		rockchip,camera-module-lens-name = "IR0147-50IRC-8M-F20";
+-		lens-focus = <&dw9714b>;
 +		rockchip,camera-module-name = "LT7911D";
 +		rockchip,camera-module-lens-name = "NC";
-+		port {
+ 		port {
+-			imx415b_out0: endpoint {
+-				remote-endpoint = <&mipi_in_dcphy0>;
 +			lt7911d_out: endpoint {
 +				remote-endpoint = <&dp_mipi_in>;
-+				data-lanes = <1 2 3 4>;
-+			};
-+		};
-+	};
-+
+ 				data-lanes = <1 2 3 4>;
+ 			};
+ 		};
+ 	};
+-};
+-
+-&i2c3 {
+-	status = "okay";
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&i2c3m0_xfer>;
+ 
+-	dw9714f: dw9714f@c {
+-		compatible = "dongwoon,dw9714";
 +	ov50c40: ov50c40@36 {
 +		compatible = "ovti,ov50c40";
-+		status = "okay";
+ 		status = "okay";
+-		reg = <0x0c>;
+-		pinctrl-names = "focusf_gpios";
+-		pinctrl-0 = <&focusf_gpio>;
+-		focus-gpios = <&gpio1 RK_PA1 GPIO_ACTIVE_HIGH>;
+-		rockchip,vcm-start-current = <20>;
+-		rockchip,vcm-rated-current = <76>;
+-		rockchip,vcm-step-mode = <0>;
+-		rockchip,camera-module-index = <1>;
+-		rockchip,camera-module-facing = "front";
+-	};
+-
+-	imx415f: imx415f@1a {
+-		compatible = "sony,imx415";
+-		status = "okay";
+-		reg = <0x1a>;
+-		clocks = <&cru CLK_MIPI_CAMARAOUT_M2>;
 +		reg = <0x36>;
 +		clocks = <&cru CLK_MIPI_CAMARAOUT_M1>;
-+		clock-names = "xvclk";
-+		power-domains = <&power RK3588_PD_VI>;
+ 		clock-names = "xvclk";
+ 		power-domains = <&power RK3588_PD_VI>;
+-		pinctrl-names = "default", "camf_gpios";
+-		pinctrl-0 = <&mipim1_camera2_clk>, <&camf_gpio>;
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&mipim1_camera1_clk>;
-+		rockchip,grf = <&sys_grf>;
+ 		rockchip,grf = <&sys_grf>;
+-		reset-gpios = <&gpio3 RK_PC6 GPIO_ACTIVE_LOW>;
+-		pwdn-gpios = <&gpio3 RK_PC5 GPIO_ACTIVE_HIGH>;
+-		rockchip,camera-module-index = <1>;
+-		rockchip,camera-module-facing = "front";
+-		rockchip,camera-module-name = "CMK-OT2022-PX1";
+-		rockchip,camera-module-lens-name = "IR0147-50IRC-8M-F20";
+-		lens-focus = <&dw9714f>;
 +		reset-gpios = <&gpio3 RK_PC4 GPIO_ACTIVE_LOW>;
 +		pwdn-gpios = <&gpio3 RK_PD4 GPIO_ACTIVE_LOW>;
 +		rockchip,camera-module-index = <0>;
@@ -156,70 +221,127 @@ index 000000000000..9d0593167702
 +		rockchip,camera-module-lens-name = "ZE0082C1";
 +		eeprom-ctrl = <&otp_eeprom>;
 +		lens-focus = <&aw8601>;
-+		port {
+ 		port {
+-			imx415f_out1: endpoint {
+-				remote-endpoint = <&mipi_in_dcphy1>;
 +			ov50c40_out0: endpoint {
 +				remote-endpoint = <&mipi_in_dcphy0>;
-+				data-lanes = <1 2 3 4>;
-+			};
-+		};
-+	};
+ 				data-lanes = <1 2 3 4>;
+ 			};
+ 		};
+ 	};
 +
 +	otp_eeprom: otp_eeprom@50 {
 +		compatible = "rk,otp_eeprom";
 +		status = "okay";
 +		reg = <0x50>;
 +	};
-+};
-+
+ };
+ 
+-&i2c8 {
 +&i2c7 {
-+	status = "okay";
-+	pinctrl-names = "default";
+ 	status = "okay";
+ 	pinctrl-names = "default";
+-	pinctrl-0 = <&i2c8m2_xfer>;
 +	pinctrl-0 = <&i2c7m2_xfer>;
-+
+ 
+-	dw9714c: dw9714c@c {
+-		compatible = "dongwoon,dw9714";
 +	aw8601b: aw8601b@c {
 +		compatible = "awinic,aw8601";
-+		status = "okay";
-+		reg = <0x0c>;
+ 		status = "okay";
+ 		reg = <0x0c>;
+-		pinctrl-names = "focusc_gpios";
+-		pinctrl-0 = <&focusc_gpio>;
+-		focus-gpios = <&gpio1 RK_PA6 GPIO_ACTIVE_HIGH>;
+-		rockchip,vcm-start-current = <20>;
+-		rockchip,vcm-rated-current = <76>;
+-		rockchip,vcm-step-mode = <0>;
+-		rockchip,camera-module-index = <0>;
 +		rockchip,vcm-start-current = <56>;
 +		rockchip,vcm-rated-current = <96>;
 +		rockchip,vcm-step-mode = <4>;
 +		rockchip,camera-module-index = <1>;
-+		rockchip,camera-module-facing = "back";
-+	};
-+
+ 		rockchip,camera-module-facing = "back";
+ 	};
+ 
+-	imx415: imx415@1a {
+-		compatible = "sony,imx415";
+-		reg = <0x1a>;
+-		clocks = <&cru CLK_MIPI_CAMARAOUT_M3>;
 +	ov50c40b: ov50c40b@36 {
 +		compatible = "ovti,ov50c40";
 +		status = "okay";
 +		reg = <0x36>;
 +		clocks = <&cru CLK_MIPI_CAMARAOUT_M2>;
-+		clock-names = "xvclk";
-+		power-domains = <&power RK3588_PD_VI>;
+ 		clock-names = "xvclk";
+-		pinctrl-names = "default", "camc_gpios";
+-		pinctrl-0 = <&mipim1_camera3_clk>, <&camc_gpio>;
+ 		power-domains = <&power RK3588_PD_VI>;
+-		reset-gpios = <&gpio3 RK_PB4 GPIO_ACTIVE_LOW>;	
+-		pwdn-gpios = <&gpio1 RK_PA4 GPIO_ACTIVE_HIGH>;
+-		rockchip,camera-module-index = <0>;
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&mipim1_camera2_clk>;
 +		rockchip,grf = <&sys_grf>;
 +		reset-gpios = <&gpio3 RK_PC5 GPIO_ACTIVE_LOW>;
 +		pwdn-gpios = <&gpio3 RK_PD5 GPIO_ACTIVE_LOW>;
 +		rockchip,camera-module-index = <1>;
-+		rockchip,camera-module-facing = "back";
+ 		rockchip,camera-module-facing = "back";
+-		rockchip,camera-module-name = "CMK-OT2022-PX1";
+-		rockchip,camera-module-lens-name = "IR0147-50IRC-8M-F20";
+-		lens-focus = <&dw9714c>;
 +		rockchip,camera-module-name = "HZGA06";
 +		rockchip,camera-module-lens-name = "ZE0082C1";
 +		eeprom-ctrl = <&otp_eeprom_b>;
 +		lens-focus = <&aw8601b>;
-+		port {
+ 		port {
+-			imx415c_out0: endpoint {
+-				remote-endpoint = <&mipidphy0_in_ucam0>;
 +			ov50c40_out1: endpoint {
 +				remote-endpoint = <&mipi_in_dcphy1>;
-+				data-lanes = <1 2 3 4>;
-+			};
-+		};
-+	};
-+
+ 				data-lanes = <1 2 3 4>;
+ 			};
+ 		};
+ 	};
+-};
+ 
+-&pinctrl {
+-	cam {
+-		camf_gpio: camf-gpio {
+-			rockchip,pins =
+-				<3 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>,
+-				<3 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-		camb_gpio: camb-gpio {
+-			rockchip,pins =
+-				<1 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>,
+-				<1 RK_PB3 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-		camc_gpio: camc-gpio {
+-			rockchip,pins =
+-				<3 RK_PB4 RK_FUNC_GPIO &pcfg_pull_none>,
+-				<1 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-		focusb_gpio: focusb-gpio {
+-			rockchip,pins =
+-				<1 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-		focusf_gpio: focusf-gpio {
+-			rockchip,pins =
+-				<1 RK_PA1 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-		focusc_gpio: focusc-gpio {
+-			rockchip,pins =
+-				<1 RK_PA6 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
 +	otp_eeprom_b: otp_eeprom_b@50 {
 +		compatible = "rk,otp_eeprom";
 +		status = "okay";
 +		reg = <0x50>;
-+	};
-+};
-+
+ 	};
+ };
+ 
 +&mipi_dcphy0 {
 +	status = "okay";
 +};
@@ -228,210 +350,121 @@ index 000000000000..9d0593167702
 +	status = "okay";
 +};
 +
-+&mipi0_csi2 {
-+	status = "okay";
-+
-+	ports {
-+		#address-cells = <1>;
-+		#size-cells = <0>;
-+
-+		port@0 {
-+			reg = <0>;
-+			#address-cells = <1>;
-+			#size-cells = <0>;
-+
-+			mipi0_csi2_input: endpoint@1 {
-+				reg = <1>;
-+				remote-endpoint = <&csidcphy0_out>;
-+			};
-+		};
-+
-+		port@1 {
-+			reg = <1>;
-+			#address-cells = <1>;
-+			#size-cells = <0>;
-+
-+			mipi0_csi2_output: endpoint@0 {
-+				reg = <0>;
-+				remote-endpoint = <&cif_mipi_in0>;
-+			};
-+		};
-+	};
-+};
-+
-+&mipi1_csi2 {
-+	status = "okay";
-+
-+	ports {
-+		#address-cells = <1>;
-+		#size-cells = <0>;
-+
-+		port@0 {
-+			reg = <0>;
-+			#address-cells = <1>;
-+			#size-cells = <0>;
-+
-+			mipi1_csi2_input: endpoint@1 {
-+				reg = <1>;
-+				remote-endpoint = <&csidcphy1_out>;
-+			};
-+		};
-+
-+		port@1 {
-+			reg = <1>;
-+			#address-cells = <1>;
-+			#size-cells = <0>;
-+
-+			mipi1_csi2_output: endpoint@0 {
-+				reg = <0>;
-+				remote-endpoint = <&cif_mipi_in1>;
-+			};
-+		};
-+	};
-+};
-+
-+&rkcif {
-+	status = "okay";
-+};
-+
-+&rkcif_mipi_lvds {
-+	status = "okay";
-+
-+	port {
-+		cif_mipi_in0: endpoint {
-+			remote-endpoint = <&mipi0_csi2_output>;
-+		};
-+	};
-+};
-+
-+&rkcif_mipi_lvds_sditf {
-+	status = "okay";
-+
-+	port {
-+		mipi_lvds_sditf: endpoint {
-+			remote-endpoint = <&isp1_in1>;
-+		};
-+	};
-+};
-+
-+&rkcif_mipi_lvds1 {
-+	status = "okay";
-+
-+	port {
-+		cif_mipi_in1: endpoint {
-+			remote-endpoint = <&mipi1_csi2_output>;
-+		};
-+	};
-+};
-+
-+&rkcif_mipi_lvds1_sditf {
-+	status = "okay";
-+
-+	port {
-+		mipi1_lvds_sditf: endpoint {
-+			remote-endpoint = <&isp1_in2>;
-+		};
-+	};
-+};
-+
-+&rkcif_mmu {
-+	status = "okay";
-+};
-+
-+&rkisp_unite {
-+	status = "okay";
-+
-+};
-+
-+&rkisp_unite_mmu {
-+	status = "okay";
-+};
-+
-+&rkisp0_vir0 {
-+	status = "okay";
-+	/*
-+	 * dual isp process image case
-+	 * other rkisp hw and virtual nodes should disabled
-+	 */
-+	rockchip,hw = <&rkisp_unite>;
-+	port {
-+		#address-cells = <1>;
-+		#size-cells = <0>;
-+
-+		isp1_in1: endpoint@0 {
-+			reg = <0>;
-+			remote-endpoint = <&mipi_lvds_sditf>;
-+		};
-+		isp1_in2: endpoint@1 {
-+			reg = <1>;
-+			remote-endpoint = <&mipi1_lvds_sditf>;
-+		};
-+	};
-+};
+ &mipi0_csi2 {
+ 	status = "okay";
+ 
+@@ -333,37 +265,6 @@ mipi1_csi2_output: endpoint@0 {
+ 	};
+ };
+ 
+-&mipi2_csi2 {
+-	status = "okay";
+-
+-	ports {
+-		#address-cells = <1>;
+-		#size-cells = <0>;
+-
+-		port@0 {
+-			reg = <0>;
+-			#address-cells = <1>;
+-			#size-cells = <0>;
+-
+-			mipi2_csi2_input: endpoint@1 {
+-				reg = <1>;
+-				remote-endpoint = <&csidphy0_out>;
+-			};
+-		};
+-
+-		port@1 {
+-			reg = <1>;
+-			#address-cells = <1>;
+-			#size-cells = <0>;
+-
+-			mipi2_csi2_output: endpoint@0 {
+-				reg = <0>;
+-				remote-endpoint = <&cif_mipi2_in0>;
+-			};
+-		};
+-	};
+-};
+-
+ &rkcif {
+ 	status = "okay";
+ };
+@@ -408,26 +309,6 @@ mipi1_lvds_sditf: endpoint {
+ 	};
+ };
+ 
+-&rkcif_mipi_lvds2 {
+-	status = "okay";
+-
+-	port {
+-		cif_mipi2_in0: endpoint {
+-			remote-endpoint = <&mipi2_csi2_output>;
+-		};
+-	};
+-};
+-
+-&rkcif_mipi_lvds2_sditf {
+-	status = "okay";
+-
+-	port {
+-		mipi_lvds2_sditf: endpoint {
+-			remote-endpoint = <&isp0_vir0>;
+-		};
+-	};
+-};
+-
+ &rkcif_mmu {
+ 	status = "okay";
+ };
+@@ -460,9 +341,5 @@ isp1_in2: endpoint@1 {
+ 			reg = <1>;
+ 			remote-endpoint = <&mipi1_lvds_sditf>;
+ 		};
+-		isp0_vir0: endpoint@2 {
+-			reg = <2>;
+-			remote-endpoint = <&mipi_lvds2_sditf>;
+-		};
+ 	};
+ };
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
-new file mode 100644
-index 000000000000..91ce4c575d14
---- /dev/null
+index dfacb4da2db7..91ce4c575d14 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
-@@ -0,0 +1,801 @@
-+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
-+/*
-+ * Copyright (c) 2022 Wesion Technology Co., Ltd.
-+ *
-+ */
-+/dts-v1/;
-+
-+#include "dt-bindings/usb/pd.h"
-+#include "rk3588s.dtsi"
-+#include "rk3588s-khadas-edge2.dtsi"
+@@ -8,7 +8,7 @@
+ #include "dt-bindings/usb/pd.h"
+ #include "rk3588s.dtsi"
+ #include "rk3588s-khadas-edge2.dtsi"
+-#include "rk3588-rk806-single-khadas-edge2.dtsi"
 +#include "rk3588s-rk806-dual.dtsi"
-+#include "rk3588-linux.dtsi"
-+#include "rk3588s-khadas-edge2-camera.dtsi"
-+
-+
-+/ {
-+	model = "Khadas Edge2";
-+	compatible = "khadas,edge2", "rockchip,rk3588";
-+
-+	combophy_avdd0v85: combophy-avdd0v85 {
-+		compatible = "regulator-fixed";
-+		regulator-name = "combophy_avdd0v85";
-+		regulator-boot-on;
-+		regulator-always-on;
-+		regulator-min-microvolt = <850000>;
-+		regulator-max-microvolt = <850000>;
-+		vin-supply = <&vdd_0v85_s0>;
-+	};
-+
-+	combophy_avdd1v8: combophy-avdd1v8 {
-+		compatible = "regulator-fixed";
-+		regulator-name = "combophy_avdd1v8";
-+		regulator-boot-on;
-+		regulator-always-on;
-+		regulator-min-microvolt = <1800000>;
-+		regulator-max-microvolt = <1800000>;
-+		vin-supply = <&avcc_1v8_s0>;
-+	};
-+
+ #include "rk3588-linux.dtsi"
+ #include "rk3588s-khadas-edge2-camera.dtsi"
+ 
+@@ -37,7 +37,7 @@ combophy_avdd1v8: combophy-avdd1v8 {
+ 		vin-supply = <&avcc_1v8_s0>;
+ 	};
+ 
+-	sound_micarray: sound-micarray {
 +	es7202_sound_micarray: es7202-sound-micarray {
-+		status = "okay";
-+		compatible = "simple-audio-card";
-+		simple-audio-card,format = "i2s";
-+		simple-audio-card,name = "rockchip,sound-micarray";
-+		simple-audio-card,mclk-fs = <256>;
-+		simple-audio-card,dai-link@0 {
-+			format = "pdm";
-+			cpu {
-+				sound-dai = <&pdm0>;
-+			};
-+			codec {
+ 		status = "okay";
+ 		compatible = "simple-audio-card";
+ 		simple-audio-card,format = "i2s";
+@@ -49,92 +49,125 @@ cpu {
+ 				sound-dai = <&pdm0>;
+ 			};
+ 			codec {
+-				sound-dai = <&dummy_codec>;
 +				sound-dai = <&es7202>;
-+			};
-+		};
-+	};
-+
+ 			};
+ 		};
+ 	};
+ 
+-	dummy_codec: dummy-codec {
+-		compatible = "rockchip,dummy-codec";
+-		#sound-dai-cells = <0>;
 +	es8388_sound: es8388-sound {
-+		status = "okay";
+ 		status = "okay";
 +		compatible = "rockchip,multicodecs-card";
 +		rockchip,card-name = "rockchip-es8388";
 +		hp-det-gpio = <&gpio1 RK_PD0 GPIO_ACTIVE_LOW>;
@@ -465,23 +498,52 @@ index 000000000000..91ce4c575d14
 +			linux,code = <KEY_PLAYPAUSE>;
 +			press-threshold-microvolt = <2000>;
 +		};
-+	};
-+
+ 	};
+ 
+-	es8316_sound: es8316-sound {
+-		compatible = "simple-audio-card";
+-		simple-audio-card,format = "i2s";
+-		simple-audio-card,mclk-fs = <256>;
+-		simple-audio-card,name = "rockchip,es8316-codec";
+-		simple-audio-card,dai-link@0 {
+-			format = "i2s";
+-			cpu {
+-				sound-dai = <&i2s0_8ch>;
+-			};
+-			codec {
+-				sound-dai = <&es8316>;
+-			};
+-		};
 +	fan: pwm-fan {
 +		compatible = "pwm-fan";
 +		#cooling-cells = <2>;
 +		pwms = <&pwm11 0 50000 0>;
-+	};
-+
+ 	};
+ 
+-	leds {
+-		compatible = "gpio-leds";
 +	hall_sensor: hall-mh248 {
 +		compatible = "hall-mh248";
-+		pinctrl-names = "default";
+ 		pinctrl-names = "default";
+-		pinctrl-0 = <&red_led_gpio &green_led_gpio &blue_led_gpio>;
+-
+-		red_led {
+-			gpios = <&gpio4 RK_PB4 GPIO_ACTIVE_HIGH>;
+-			label = "red_led";
+-			linux,default-trigger = "none";
+-			default-state = "off";
+-		};
 +		pinctrl-0 = <&mh248_irq_gpio>;
 +		irq-gpio = <&gpio0 RK_PD4 IRQ_TYPE_EDGE_BOTH>;
 +		hall-active = <1>;
 +		status = "okay";
 +	};
-+
+ 
+-		green_led {
+-			gpios = <&gpio4 RK_PB2 GPIO_ACTIVE_HIGH>;
+-			label = "green_led";
+-			linux,default-trigger = "default-on";
+-			default-state = "on";
 +	panel-edp {
 +		compatible = "simple-panel";
 +		backlight = <&backlight>;
@@ -507,27 +569,46 @@ index 000000000000..91ce4c575d14
 +			vsync-active = <0>;
 +			de-active = <0>;
 +			pixelclk-active = <0>;
-+		};
-+
+ 		};
+ 
+-		blue_led {
+-			gpios = <&gpio4 RK_PB3 GPIO_ACTIVE_HIGH>;
+-			label = "blue_led";
+-			linux,default-trigger = "none";
+-			default-state = "off";
 +		port {
 +			panel_in_edp: endpoint {
 +				remote-endpoint = <&edp_out_panel>;
 +			};
-+		};
-+	};
-+
-+	vbus5v0_typec: vbus5v0-typec {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vbus5v0_typec";
-+		regulator-min-microvolt = <5000000>;
-+		regulator-max-microvolt = <5000000>;
-+		enable-active-high;
+ 		};
+ 	};
+ 
+-	khadas_wdt {
+-		compatible = "linux,wdt-khadas";
+-		status = "okay";
+-		hw_margin_ms = <500>;
+-		hw-gpios = <&gpio0 RK_PB0 GPIO_ACTIVE_HIGH>;
+-	};
+-
+-//	fan: pwm-fan {
+-//		compatible = "pwm-fan";
+-//		#cooling-cells = <2>;
+-//		pwms = <&pwm11 0 50000 0>;
+-//	};
+-
+ 	vbus5v0_typec: vbus5v0-typec {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vbus5v0_typec";
+ 		regulator-min-microvolt = <5000000>;
+ 		regulator-max-microvolt = <5000000>;
+ 		enable-active-high;
+-		gpio = <&gpio3 RK_PA4 GPIO_ACTIVE_HIGH>;
 +		gpio = <&gpio1 RK_PA1 GPIO_ACTIVE_HIGH>;
-+		vin-supply = <&vcc5v0_usb>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&typec5v_pwren>;
-+	};
-+
+ 		vin-supply = <&vcc5v0_usb>;
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&typec5v_pwren>;
+ 	};
+ 
 +	vcc3v3_lcd_edp: vcc3v3-lcd-edp {
 +		compatible = "regulator-fixed";
 +		regulator-name = "vcc3v3_lcd_edp";
@@ -537,134 +618,487 @@ index 000000000000..91ce4c575d14
 +		vin-supply = <&vcc_3v3_s3>;
 +	};
 +
-+	vcc3v3_pcie20: vcc3v3-pcie20 {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc3v3_pcie20";
-+		regulator-min-microvolt = <3300000>;
-+		regulator-max-microvolt = <3300000>;
-+		enable-active-high;
+ 	vcc3v3_pcie20: vcc3v3-pcie20 {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vcc3v3_pcie20";
+ 		regulator-min-microvolt = <3300000>;
+ 		regulator-max-microvolt = <3300000>;
+ 		enable-active-high;
+-		gpios = <&gpio0 RK_PC4 GPIO_ACTIVE_HIGH>;
 +		gpios = <&gpio4 RK_PB1 GPIO_ACTIVE_HIGH>;
-+		startup-delay-us = <5000>;
-+		vin-supply = <&vcc12v_dcin>;
-+	};
-+
-+	vcc5v0_host: vcc5v0-host {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc5v0_host";
-+		regulator-boot-on;
-+		regulator-always-on;
-+		regulator-min-microvolt = <5000000>;
-+		regulator-max-microvolt = <5000000>;
-+		enable-active-high;
-+		gpio = <&gpio1 RK_PB1 GPIO_ACTIVE_HIGH>;
-+		vin-supply = <&vcc5v0_usb>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&vcc5v0_host_en>;
-+	};
-+
-+	wireless_bluetooth: wireless-bluetooth {
-+		compatible = "bluetooth-platdata";
+ 		startup-delay-us = <5000>;
+ 		vin-supply = <&vcc12v_dcin>;
+ 	};
+@@ -153,54 +186,17 @@ vcc5v0_host: vcc5v0-host {
+ 		pinctrl-0 = <&vcc5v0_host_en>;
+ 	};
+ 
+-	vcc_sd: vcc-sd {
+-		compatible = "regulator-fixed";
+-		regulator-name = "vcc_sd";
+-		regulator-boot-on;
+-		regulator-always-on;
+-		regulator-min-microvolt = <3300000>;
+-		regulator-max-microvolt = <3300000>;
+-		enable-active-high;
+-		gpio = <&gpio1 RK_PB6 GPIO_ACTIVE_HIGH>;
+-		vin-supply = <&vcc_3v3_s3>;
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&vcc_sd_en>;
+-		regulator-state-mem {
+-			regulator-off-in-suspend;
+-		};
+-	};
+-
+ 	wireless_bluetooth: wireless-bluetooth {
+ 		compatible = "bluetooth-platdata";
+-		clocks = <&pt7c4363>;
 +		clocks = <&hym8563>;
-+		clock-names = "ext_clock";
+ 		clock-names = "ext_clock";
+-		uart_rts_gpios = <&gpio3 RK_PD2 GPIO_ACTIVE_LOW>;
 +		uart_rts_gpios = <&gpio3 RK_PA4 GPIO_ACTIVE_LOW>;
-+		pinctrl-names = "default", "rts_gpio";
+ 		pinctrl-names = "default", "rts_gpio";
+-		pinctrl-0 = <&uart9m2_rtsn>, <&bt_gpio>;
+-		pinctrl-1 = <&uart9_gpios>;
+-		BT,reset_gpio    = <&gpio0 RK_PD4 GPIO_ACTIVE_HIGH>;
+-		BT,wake_gpio     = <&gpio0 RK_PD3 GPIO_ACTIVE_HIGH>;
+-		BT,wake_host_irq = <&gpio0 RK_PD5 GPIO_ACTIVE_HIGH>;
+-		status = "okay";
+-	};
+-
+-	bt-sound {
+-		compatible = "simple-audio-card";
+-		simple-audio-card,format = "dsp_a";
+-		simple-audio-card,bitclock-inversion = <1>;
+-		simple-audio-card,mclk-fs = <256>;
+-		simple-audio-card,name = "rockchip,bt";
+-		simple-audio-card,cpu {
+-			sound-dai = <&i2s2_2ch>;
+-		};
+-		simple-audio-card,codec {
+-			sound-dai = <&bt_sco>;
+-		};
+-	};
+-
+-	bt_sco: bt-sco {
+-		compatible = "delta,dfbmcs320";
+-		#sound-dai-cells = <0>;
 +		pinctrl-0 = <&uart8m1_rtsn>, <&bt_gpio>;
 +		pinctrl-1 = <&uart8_gpios>;
 +		BT,reset_gpio    = <&gpio3 RK_PB7 GPIO_ACTIVE_HIGH>;
 +		BT,wake_gpio     = <&gpio3 RK_PC1 GPIO_ACTIVE_HIGH>;
 +		BT,wake_host_irq = <&gpio3 RK_PC0 GPIO_ACTIVE_HIGH>;
-+		status = "okay";
-+	};
-+
-+	wireless_wlan: wireless-wlan {
-+		compatible = "wlan-platdata";
-+		wifi_chip_type = "ap6275p";
-+		pinctrl-names = "default";
+ 		status = "okay";
+ 	};
+ 
+@@ -208,77 +204,28 @@ wireless_wlan: wireless-wlan {
+ 		compatible = "wlan-platdata";
+ 		wifi_chip_type = "ap6275p";
+ 		pinctrl-names = "default";
+-		pinctrl-0 = <&wifi_host_wake_irq>;
 +		pinctrl-0 = <&wifi_host_wake_irq>, <&wifi_poweren_gpio>;
-+		WIFI,host_wake_irq = <&gpio0 RK_PA0 GPIO_ACTIVE_HIGH>;
+ 		WIFI,host_wake_irq = <&gpio0 RK_PA0 GPIO_ACTIVE_HIGH>;
+-	//	WIFI,poweren_gpio = <&gpio0 RK_PC7 GPIO_ACTIVE_HIGH>;
 +		WIFI,poweren_gpio = <&gpio0 RK_PC7 GPIO_ACTIVE_HIGH>;
-+		status = "okay";
-+	};
-+};
-+
+ 		status = "okay";
+ 	};
+-
+-	vcc3v3_lcd1_en: vcc3v3-lcd1-en {
+-		compatible = "regulator-fixed";
+-		regulator-name = "vcc3v3_lcd1_en";
+-		regulator-min-microvolt = <3300000>;
+-		regulator-max-microvolt = <3300000>;
+-		gpio = <&gpio4 RK_PA4 GPIO_ACTIVE_HIGH>;
+-		enable-active-high;
+-		regulator-boot-on;
+-		regulator-state-mem {
+-			regulator-off-in-suspend;
+-		};
+-
+-	};
+-
+-	vcc3v3_lcd2_en: vcc3v3-lcd2-en {
+-		compatible = "regulator-fixed";
+-		regulator-name = "vcc3v3_lcd2_en";
+-		regulator-min-microvolt = <3300000>;
+-		regulator-max-microvolt = <3300000>;
+-		gpio = <&gpio4 RK_PB0 GPIO_ACTIVE_HIGH>;
+-		enable-active-high;
+-		regulator-boot-on;
+-		regulator-state-mem {
+-			regulator-off-in-suspend;
+-		};
+-
+-	};
+-
+ };
+ 
+-&backlight_mipi0 {
 +&backlight {
-+	pwms = <&pwm12 0 25000 0>;
+ 	pwms = <&pwm12 0 25000 0>;
+-	power-supply = <&vcc3v3_lcd1_en>;
 +	power-supply = <&vcc3v3_lcd_edp>;
-+	status = "okay";
-+};
-+
-+&combphy0_ps {
-+	status = "okay";
-+};
-+
-+&dp0 {
-+	status = "okay";
-+};
-+
+ 	status = "okay";
+ };
+ 
+-&backlight_mipi1 {
+-	pwms = <&pwm13 0 25000 0>;
+-	power-supply = <&vcc3v3_lcd2_en>;
+-	status = "disabled";
+-};
+-
+-
+ &combphy0_ps {
+ 	status = "okay";
+ };
+ 
+-&cru {
+-	assigned-clock-rates =
+-            <1100000000>, <786432000>,
+-            <850000000>, <1188000000>,
+-            <702000000>,
+-            <400000000>, <500000000>,
+-            <800000000>, <100000000>,
+-            <400000000>, <100000000>,
+-            <200000000>, <800000000>,
+-            <375000000>, <150000000>,
+-            <200000000>;
+-};
+-
+ &dp0 {
+ 	status = "okay";
+ };
+ 
+-&dp0_in_vp2 {
 +&dp0_in_vp1 {
-+	status = "okay";
-+};
-+
-+&dp0_sound{
-+	status = "okay";
-+};
-+
+ 	status = "okay";
+ };
+ 
+@@ -286,308 +233,88 @@ &dp0_sound{
+ 	status = "okay";
+ };
+ 
+-&dsi0 {
+-	status = "disabled";
+-	reset-delay-ms = <20>;
+-	reset-gpios = <&gpio4 RK_PA3 GPIO_ACTIVE_HIGH>;
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&lcd1_rst_gpio>;
+-
+-};
+-
+-&dsi0_panel {
 +&edp0 {
 +	force-hpd;
-+	status = "okay";
-+
+ 	status = "okay";
+-	power-supply = <&vcc3v3_lcd1_en>;
+-};
+ 
+-&dsi0_in_vp2 {
+-	status = "disabled";
+-};
+-
+-&dsi0_in_vp3 {
+-	status = "okay";
+-};
+-
+-&hdmi0_sound {
+-	status = "okay";
+-};
+-
+-&route_dsi0 {
+-	status = "okay";
+-	connect = <&vp3_out_dsi0>;
+-};
+-
+-&mipi_dcphy0 {
+-	status = "okay";
+-};
+-
+-&dsi1 {
+-	reset-delay-ms = <20>;
+-	reset-gpios = <&gpio4 RK_PA7 GPIO_ACTIVE_HIGH>;
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&lcd2_rst_gpio1>;
+-	status = "disabled";
+-};
 +	ports {
 +		port@1 {
 +			reg = <1>;
-+
+ 
+-&dsi1_panel {
+-	status = "disabled";
+-	power-supply = <&vcc3v3_lcd2_en>;
 +			edp_out_panel: endpoint {
 +				remote-endpoint = <&panel_in_edp>;
 +			};
 +		};
 +	};
-+};
-+
+ };
+ 
+-&mipi_dcphy1 {
 +&edp0_in_vp2 {
-+	status = "okay";
-+};
-+
+ 	status = "okay";
+ };
+ 
+-&dsi1_in_vp2 {
+-	status = "disabled";
+-};
+-
+-&dsi1_in_vp3 {
+-	status = "disabled";
+-};
+-
+-&route_dsi1 {
+-	status = "disabled";
+-	connect = <&vp3_out_dsi1>;
+-};
+-
+-//&hdptxphy0 {
 +&hdptxphy0 {
-+	/* Single Vdiff Training Table for power reduction (optional) */
+ 	/* Single Vdiff Training Table for power reduction (optional) */
+-//	training-table = /bits/ 8 <
 +	training-table = /bits/ 8 <
-+		/* voltage swing 0, pre-emphasis 0->3 */
+ 		/* voltage swing 0, pre-emphasis 0->3 */
+-//		0x0d 0x00 0x00 0x00 0x00 0x00
+-//		0x0d 0x00 0x00 0x00 0x00 0x00
+-//		0x0d 0x00 0x00 0x00 0x00 0x00
+-//		0x0d 0x00 0x00 0x00 0x00 0x00
 +		0x0d 0x00 0x00 0x00 0x00 0x00
 +		0x0d 0x00 0x00 0x00 0x00 0x00
 +		0x0d 0x00 0x00 0x00 0x00 0x00
 +		0x0d 0x00 0x00 0x00 0x00 0x00
-+		/* voltage swing 1, pre-emphasis 0->2 */
+ 		/* voltage swing 1, pre-emphasis 0->2 */
+-//		0x0d 0x00 0x00 0x00 0x00 0x00
+-//		0x0d 0x00 0x00 0x00 0x00 0x00
+-//		0x0d 0x00 0x00 0x00 0x00 0x00
 +		0x0d 0x00 0x00 0x00 0x00 0x00
 +		0x0d 0x00 0x00 0x00 0x00 0x00
 +		0x0d 0x00 0x00 0x00 0x00 0x00
-+		/* voltage swing 2, pre-emphasis 0->1 */
+ 		/* voltage swing 2, pre-emphasis 0->1 */
+-//		0x0d 0x00 0x00 0x00 0x00 0x00
+-//		0x0d 0x00 0x00 0x00 0x00 0x00
 +		0x0d 0x00 0x00 0x00 0x00 0x00
 +		0x0d 0x00 0x00 0x00 0x00 0x00
-+		/* voltage swing 3, pre-emphasis 0 */
+ 		/* voltage swing 3, pre-emphasis 0 */
+-//		0x0d 0x00 0x00 0x00 0x00 0x00
+-//	>;
+-//	status = "okay";
+-//};
+-
+-&hdmi0 {
+-	enable-gpios = <&gpio4 RK_PB1 GPIO_ACTIVE_HIGH>;
+-	status = "okay";
+-};
+-
+-&hdmi0_in_vp0 {
+-	status = "okay";
+- };
+-
+-&hdptxphy_hdmi0 {
+-	status = "okay";
+- };
+-
+-&i2s2_2ch {
+-	status = "okay";
+-};
+-
+-&i2c0 {
+-    status = "okay";
+-    pinctrl-names = "default";
+-    pinctrl-0 = <&i2c0m2_xfer>;
+-
+-    vdd_cpu_big0_s0: vdd_cpu_big0_mem_s0: rk8602@42 {
+-        compatible = "rockchip,rk8602";
+-        reg = <0x42>;
+-        vin-supply = <&vcc5v0_sys>;
+-        regulator-compatible = "rk860x-reg";
+-        regulator-name = "vdd_cpu_big0_s0";
+-        regulator-min-microvolt = <550000>;
+-        regulator-max-microvolt = <1050000>;
+-        regulator-ramp-delay = <12500>;
+-        rockchip,suspend-voltage-selector = <1>;
+-        regulator-boot-on;
+-        regulator-always-on;
+-        regulator-state-mem {
+-            regulator-off-in-suspend;
+-        };
+-    };
+-
+-    vdd_cpu_big1_s0: vdd_cpu_big1_mem_s0: rk8603@43 {
+-        compatible = "rockchip,rk8603";
+-        reg = <0x43>;
+-        vin-supply = <&vcc5v0_sys>;
+-        regulator-compatible = "rk860x-reg";
+-        regulator-name = "vdd_cpu_big1_s0";
+-        regulator-min-microvolt = <550000>;
+-        regulator-max-microvolt = <1050000>;
+-        regulator-ramp-delay = <12500>;
+-        rockchip,suspend-voltage-selector = <1>;
+-        regulator-boot-on;
+-        regulator-always-on;
+-        regulator-state-mem {
+-            regulator-off-in-suspend;
+-        };
+-    };
+-};
+-
+-&i2s5_8ch {
 +		0x0d 0x00 0x00 0x00 0x00 0x00
 +	>;
-+	status = "okay";
-+};
-+
-+&i2c3 {
-+	status = "okay";
-+
+ 	status = "okay";
+ };
+ 
+-&i2c2 {
+-
+-    status = "okay";
+-
+-    vdd_npu_s0: vdd_npu_mem_s0: rk8602@42 {
+-        compatible = "rockchip,rk8602";
+-        reg = <0x42>;
+-        vin-supply = <&vcc5v0_sys>;
+-        regulator-compatible = "rk860x-reg";
+-        regulator-name = "vdd_npu_s0";
+-        regulator-min-microvolt = <550000>;
+-        regulator-max-microvolt = <950000>;
+-        regulator-ramp-delay = <12500>;
+-        rockchip,suspend-voltage-selector = <1>;
+-        regulator-boot-on;
+-        regulator-always-on;
+-        regulator-state-mem {
+-            regulator-off-in-suspend;
+-        };
+-    };
+-
+-    usbc0: fusb302@22 {
+-        compatible = "fcs,fusb302";
+-        reg = <0x22>;
+-        interrupt-parent = <&gpio1>;
+-        interrupts = <RK_PB5 IRQ_TYPE_LEVEL_LOW>;
+-        int-n-gpios = <&gpio1 RK_PB5 GPIO_ACTIVE_LOW>;
+-        pinctrl-names = "default";
+-        pinctrl-0 = <&usbc0_int>;
+-        vbus-supply = <&vbus5v0_typec>;
+-        status = "okay";
+-
+-        ports {
+-            #address-cells = <1>;
+-            #size-cells = <0>;
+-
+-            port@0 {
+-                reg = <0>;
+-                usbc0_role_sw: endpoint@0 {
+-                    remote-endpoint = <&dwc3_0_role_switch>;
+-                };
+-            };
+-        };
+-
+-        usb_con: connector {
+-            compatible = "usb-c-connector";
+-            label = "USB-C";
+-            data-role = "dual";
+-            power-role = "dual";
+-            try-power-role = "sink";
+-            op-sink-microwatt = <1000000>;
+-            sink-pdos =
+-                <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)
+-                 PDO_FIXED(9000, 3000, PDO_FIXED_USB_COMM)
+-                 PDO_FIXED(12000, 3000, PDO_FIXED_USB_COMM)>;
+-            source-pdos =
+-                <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>;
+-
+-            altmodes {
+-                #address-cells = <1>;
+-                #size-cells = <0>;
+-
+-                altmode@0 {
+-                    reg = <0>;
+-                    svid = <0xff01>;
+-                    vdo = <0xffffffff>;
+-                };
+-            };
+-
+-             ports {
+-                #address-cells = <1>;
+-                #size-cells = <0>;
+-
+-                port@0 {
+-                    reg = <0>;
+-                    usbc0_orien_sw: endpoint {
+-                        remote-endpoint = <&usbdp_phy0_orientation_switch>;
+-                    };
+-                };
+-
+-                port@1 {
+-                    reg = <1>;
+-                    dp_altmode_mux: endpoint {
+-                        remote-endpoint = <&usbdp_phy0_dp_altmode_mux>;
+-                    };
+-                };
+-            };
+-        };
+-    };
+-
+-    pt7c4363: pt7c4363@51 {
+-        compatible = "haoyu,hym8563";
+-        reg = <0x51>;
+-        #clock-cells = <0>;
+-        clock-frequency = <32768>;
+-        clock-output-names = "pt7c4363";
+-        wakeup-source;
+-    };
+-
+-    mcu: khadas-mcu@18 {
+-        compatible = "khadas-mcu";
+-        status = "okay";
+-        reg = <0x18>;
+-        fan,trig_temp_level0 = <50>;
+-        fan,trig_temp_level1 = <60>;
+-        fan,trig_temp_level2 = <70>;
+-        fan,trig_temp_level3 = <80>;
+-        hwver = "EDGE2.V11";
+-
+-    };
+-};
+-
+-&reboot_mode {
+-	mode-reboot_test = <BOOT_REBOOT_TEST>;
+-};
+-
+ &i2c3 {
+ 	status = "okay";
+ 
+-	gs_kxtj3: gs_kxtj3@e {
+-		compatible = "gs_kxtj3";
+-		reg = <0x0e>;
+-		irq-gpio = <&gpio1 RK_PB0 IRQ_TYPE_EDGE_RISING>;
+-		irq_enable = <0>;
+-		poll_delay_ms = <30>;
+-		type = <SENSOR_TYPE_ACCEL>;
+-		layout = <0>;
+-		status = "okay";
+-	};
+-
+-	es8316: es8316@10 {
 +	es8388: es8388@11 {
-+		status = "okay";
-+		#sound-dai-cells = <0>;
+ 		status = "okay";
+ 		#sound-dai-cells = <0>;
+-		compatible = "everest,es8316";
+-		reg = <0x10>;
 +		compatible = "everest,es8388", "everest,es8323";
 +		reg = <0x11>;
-+		clocks = <&cru I2S0_8CH_MCLKOUT>;
-+		clock-names = "mclk";
-+		assigned-clocks = <&cru I2S0_8CH_MCLKOUT>;
-+		assigned-clock-rates = <12288000>;
+ 		clocks = <&cru I2S0_8CH_MCLKOUT>;
+ 		clock-names = "mclk";
+ 		assigned-clocks = <&cru I2S0_8CH_MCLKOUT>;
+ 		assigned-clock-rates = <12288000>;
+-		pinctrl-names = "default","hp_det","spk_con";
+-		pinctrl-0 = <&i2s0_mclk>,<&hp_det>,<&spk_con>;
+-		spk-con-gpio = <&gpio1 RK_PD0 GPIO_ACTIVE_HIGH>;
+-		hp-det-gpio = <&gpio1 RK_PD3 GPIO_ACTIVE_LOW>;
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&i2s0_mclk>;
-+	};
-+
+ 	};
+ 
 +	es7202: es7202@32 {
 +		status = "okay";
 +		#sound-dai-cells = <0>;
@@ -672,12 +1106,12 @@ index 000000000000..91ce4c575d14
 +		power-supply = <&vcc_1v8_s0>;	/* only 1v8 or 3v3, default is 3v3 */
 +		reg = <0x32>;
 +	};
-+};
-+
-+&i2c4 {
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&i2c4m3_xfer>;
-+	status = "okay";
+ };
+ 
+ &i2c4 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&i2c4m3_xfer>;
+ 	status = "okay";
 +
 +	gsl3673@40 {
 +		compatible = "GSL,GSL3673";
@@ -687,72 +1121,40 @@ index 000000000000..91ce4c575d14
 +		irq_gpio_number = <&gpio1 RK_PB5 IRQ_TYPE_LEVEL_LOW>;
 +		rst_gpio_number = <&gpio1 RK_PB4 GPIO_ACTIVE_HIGH>;
 +	};
-+};
-+
-+&i2c5 {
+ };
+ 
+ &i2c5 {
+-	status = "disabled";
 +	status = "okay";
-+
-+	ls_stk3332: light@47 {
-+		compatible = "ls_stk3332";
-+		status = "disabled";
-+		reg = <0x47>;
-+		type = <SENSOR_TYPE_LIGHT>;
-+		irq_enable = <0>;
-+		als_threshold_high = <100>;
-+		als_threshold_low = <10>;
-+		als_ctrl_gain = <2>; /* 0:x1 1:x4 2:x16 3:x64 */
-+		poll_delay_ms = <100>;
-+	};
-+
-+	ps_stk3332: proximity@47 {
-+		compatible = "ps_stk3332";
-+		status = "disabled";
-+		reg = <0x47>;
-+		type = <SENSOR_TYPE_PROXIMITY>;
-+		//pinctrl-names = "default";
-+		//pinctrl-0 = <&gpio3_c6>;
-+		//irq-gpio = <&gpio3 RK_PC6 IRQ_TYPE_LEVEL_LOW>;
-+		//irq_enable = <1>;
-+		ps_threshold_high = <0x200>;
-+		ps_threshold_low = <0x100>;
-+		ps_ctrl_gain = <3>; /* 0:x1 1:x2 2:x5 3:x8 */
-+		ps_led_current = <4>; /* 0:3.125mA 1:6.25mA 2:12.5mA 3:25mA 4:50mA 5:100mA*/
-+		poll_delay_ms = <100>;
-+	};
-+
-+	mpu6500_acc: mpu_acc@68 {
-+		compatible = "mpu6500_acc";
-+		reg = <0x68>;
-+		irq-gpio = <&gpio3 RK_PB4 IRQ_TYPE_EDGE_RISING>;
-+		irq_enable = <0>;
-+		poll_delay_ms = <30>;
-+		type = <SENSOR_TYPE_ACCEL>;
-+		layout = <5>;
-+	};
-+
-+	mpu6500_gyro: mpu_gyro@68 {
-+		compatible = "mpu6500_gyro";
-+		reg = <0x68>;
-+		poll_delay_ms = <30>;
-+		type = <SENSOR_TYPE_GYROSCOPE>;
-+		layout = <5>;
-+	};
-+};
-+
+ 
+ 	ls_stk3332: light@47 {
+ 		compatible = "ls_stk3332";
+@@ -636,79 +363,133 @@ mpu6500_gyro: mpu_gyro@68 {
+ 	};
+ };
+ 
+-&i2c6 {
 +&i2c8 {
-+	status = "okay";
-+	pinctrl-names = "default";
+ 	status = "okay";
+ 	pinctrl-names = "default";
+-	pinctrl-0 = <&i2c6m0_xfer>;
 +	pinctrl-0 = <&i2c8m2_xfer>;
-+
+ 
+-	ft5336@38 {
+-		compatible = "edt,edt-ft5336", "ft5x06";
+-		reg = <0x38>;
 +	usbc0: fusb302@22 {
 +		compatible = "fcs,fusb302";
 +		reg = <0x22>;
-+		interrupt-parent = <&gpio0>;
+ 		interrupt-parent = <&gpio0>;
+-		interrupts = <RK_PC6 IRQ_TYPE_EDGE_FALLING>;
+-		reset-gpio = <&gpio0 RK_PC5 GPIO_ACTIVE_HIGH>;
 +		interrupts = <RK_PD3 IRQ_TYPE_LEVEL_LOW>;
-+		pinctrl-names = "default";
+ 		pinctrl-names = "default";
+-		pinctrl-0 = <&tp_rst_gpio>;
 +		pinctrl-0 = <&usbc0_int>;
 +		vbus-supply = <&vbus5v0_typec>;
-+		status = "okay";
+ 		status = "okay";
 +
 +		ports {
 +			#address-cells = <1>;
@@ -808,8 +1210,8 @@ index 000000000000..91ce4c575d14
 +				};
 +			};
 +		};
-+	};
-+
+ 	};
+ 
 +	hym8563: hym8563@51 {
 +		compatible = "haoyu,hym8563";
 +		reg = <0x51>;
@@ -822,103 +1224,147 @@ index 000000000000..91ce4c575d14
 +		interrupts = <RK_PC4 IRQ_TYPE_LEVEL_LOW>;
 +		wakeup-source;
 +	};
-+};
-+
-+&pcie2x1l1 {
+ };
+ 
+ &pcie2x1l1 {
+-//	reset-gpios = <&gpio4 RK_PA2 GPIO_ACTIVE_HIGH>;
 +	reset-gpios = <&gpio4 RK_PA2 GPIO_ACTIVE_HIGH>;
-+	vpcie3v3-supply = <&vcc3v3_pcie20>;
+ 	vpcie3v3-supply = <&vcc3v3_pcie20>;
+-	status = "disabled";
 +	status = "okay";
-+};
-+
-+&pcie2x1l2 {
+ };
+ 
+ &pcie2x1l2 {
+-//	reset-gpios = <&gpio4 RK_PC1 GPIO_ACTIVE_HIGH>;
+-	reset-gpios = <&gpio3 RK_PD1 GPIO_ACTIVE_HIGH>;
+-	vpcie3v3-supply = <&vcc3v3_pcie20>;
 +	reset-gpios = <&gpio4 RK_PC1 GPIO_ACTIVE_HIGH>;
-+	rockchip,skip-scan-in-resume;
+ 	rockchip,skip-scan-in-resume;
+ 	status = "okay";
+ };
+ 
+ &pdm0 {
+-	pinctrl-names = "default";
+-    pinctrl-0 = <&pdm0m0_clk
+-    &pdm0m0_clk1
+-    &pdm0m0_sdi0
+-    &pdm0m0_sdi1
+-    &pdm0m0_sdi2>;
+-    rockchip,path-map = <0 1 2 3>;
+-    status = "okay";
 +	status = "okay";
-+};
-+
-+&pdm0 {
-+	status = "okay";
-+};
-+
-+&pinctrl {
+ };
+ 
+ &pinctrl {
+-	audio {
 +	headphone {
-+		hp_det: hp-det {
+ 		hp_det: hp-det {
+-			rockchip,pins = <1 RK_PD3 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-		spk_con: spk-con {
+-			rockchip,pins = <1 RK_PD0 RK_FUNC_GPIO &pcfg_pull_down>;
 +			rockchip,pins = <1 RK_PD0 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+
+ 		};
+ 	};
+ 
+-	lcd {
+-		lcd1_rst_gpio: lcd1-rst-gpio {
+-			rockchip,pins = <4 RK_PA3 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-		lcd2_rst_gpio1: lcd2-rst-gpio1 {
+-			rockchip,pins = <4 RK_PA7 RK_FUNC_GPIO &pcfg_pull_up>;
 +	hym8563 {
 +		hym8563_int: hym8563-int {
 +			rockchip,pins = <0 RK_PC4 RK_FUNC_GPIO &pcfg_pull_up>;
-+		};
-+	};
-+
+ 		};
+ 	};
+ 
+-	leds {
+-		red_led_gpio: red-led-gpio {
+-			rockchip,pins = <4 RK_PB4 RK_FUNC_GPIO &pcfg_pull_up>;
 +	lcd {
 +		lcd_rst_gpio: lcd-rst-gpio {
 +			rockchip,pins = <1 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
+ 		};
 +	};
-+
+ 
+-		green_led_gpio: green-led-gpio {
+-			rockchip,pins = <4 RK_PB2 RK_FUNC_GPIO &pcfg_pull_up>;
 +	sensor {
 +		mh248_irq_gpio: mh248_irq_gpio {
 +			rockchip,pins = <0 RK_PD4 RK_FUNC_GPIO &pcfg_pull_up>;
-+		};
-+
+ 		};
+ 
+-		blue_led_gpio: blue-led-gpio {
+-			rockchip,pins = <4 RK_PB3 RK_FUNC_GPIO &pcfg_pull_up>;
 +		mpu6500_irq_gpio: mpu6500_irq_gpio {
 +			rockchip,pins = <3 RK_PB4 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+
-+	usb {
-+		vcc5v0_host_en: vcc5v0-host-en {
-+			rockchip,pins = <1 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+
-+	usb-typec {
-+		usbc0_int: usbc0-int {
+ 		};
+ 	};
+ 
+@@ -718,38 +499,26 @@ vcc5v0_host_en: vcc5v0-host-en {
+ 		};
+ 	};
+ 
+-	vcc_sd {
+-		vcc_sd_en: vcc-sd-en {
+-			rockchip,pins = <1 RK_PB6 RK_FUNC_GPIO &pcfg_pull_up>;
+-		};
+-	};
+-
+ 	usb-typec {
+ 		usbc0_int: usbc0-int {
+-			rockchip,pins = <1 RK_PB5 RK_FUNC_GPIO &pcfg_pull_up>;
 +			rockchip,pins = <0 RK_PD3 RK_FUNC_GPIO &pcfg_pull_up>;
-+		};
-+
-+		typec5v_pwren: typec5v-pwren {
+ 		};
+ 
+ 		typec5v_pwren: typec5v-pwren {
+-			rockchip,pins = <3 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
 +			rockchip,pins = <1 RK_PA1 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+
-+	wireless-bluetooth {
+ 		};
+ 	};
+ 
+-	ft5336 {
+-		tp_rst_gpio: tp-rst-gpio {
+-			rockchip,pins = <0 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>;
+-       };
+-   };
+-
+ 	wireless-bluetooth {
+-		uart9_gpios: uart9-gpios {
+-			rockchip,pins = <3 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
 +		uart8_gpios: uart8-gpios {
 +			rockchip,pins = <3 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+
-+		bt_gpio: bt-gpio {
-+			rockchip,pins =
+ 		};
+ 
+ 		bt_gpio: bt-gpio {
+ 			rockchip,pins =
+-				<0 RK_PD4 RK_FUNC_GPIO &pcfg_pull_none>,
+-				<0 RK_PD3 RK_FUNC_GPIO &pcfg_pull_up>,
+-				<0 RK_PD5 RK_FUNC_GPIO &pcfg_pull_down>;
 +				<3 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>,
 +				<3 RK_PC1 RK_FUNC_GPIO &pcfg_pull_up>,
 +				<3 RK_PC0 RK_FUNC_GPIO &pcfg_pull_down>;
-+		};
-+	};
-+
-+	wireless-wlan {
-+		wifi_host_wake_irq: wifi-host-wake-irq {
-+			rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_down>;
-+		};
-+
+ 		};
+ 	};
+ 
+@@ -758,9 +527,9 @@ wifi_host_wake_irq: wifi-host-wake-irq {
+ 			rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_down>;
+ 		};
+ 
+-	//	wifi_poweren_gpio: wifi-poweren-gpio {
+-	//		rockchip,pins = <0 RK_PC7 RK_FUNC_GPIO &pcfg_pull_up>;
+-	//	};
 +		wifi_poweren_gpio: wifi-poweren-gpio {
 +			rockchip,pins = <0 RK_PC7 RK_FUNC_GPIO &pcfg_pull_up>;
 +		};
-+	};
-+};
-+
-+&pwm3 {
-+	compatible = "rockchip,remotectl-pwm";
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&pwm3m3_pins>;
-+	remote_pwm_id = <3>;
-+	handle_cpu_id = <1>;
-+	remote_support_psci = <0>;
-+	status = "okay";
-+
-+	ir_key1 {
+ 	};
+ };
+ 
+@@ -774,27 +543,104 @@ &pwm3 {
+ 	status = "okay";
+ 
+ 	ir_key1 {
 +		rockchip,usercode = <0x4040>;
 +		rockchip,key_table =
 +			<0xf2   KEY_REPLY>,
@@ -946,8 +1392,27 @@ index 000000000000..91ce4c575d14
 +	};
 +
 +	ir_key2 {
-+		rockchip,usercode = <0xff00>;
-+		rockchip,key_table =
+ 		rockchip,usercode = <0xff00>;
+ 		rockchip,key_table =
+-			<0xeb 116>,		//KEY_POWER
+-			<0xec 139>,		//KEY_MENU
+-			<0xfc 103>,		//KEY_UP
+-			<0xfd 108>,		//KEY_DOWN
+-			<0xf1 105>,		//KEY_LEFT
+-			<0xe5 106>,		//KEY_RIGHT
+-			<0xf8 28>, 		//KEY_Enter
+-			<0xa7 114>,		//KEY_VOLUMEDOWN
+-			<0xa3 388>,
+-			<0xa4 388>,		//KEY_CURSOR
+-			<0xf4 115>,		//KEY_VOLUMEUP
+-			<0xfe 158>,		//KEY_BACK
+-			<0xb7 172>;		//KEY_HOMEPAGE
+-	};
+-};
+-
+-&pwm7 {
+-	pinctrl-0 = <&pwm7m0_pins>;
+-	status = "disabled";
 +			<0xf9   KEY_HOME>,
 +			<0xbf   KEY_BACK>,
 +			<0xfb   KEY_MENU>,
@@ -1017,141 +1482,108 @@ index 000000000000..91ce4c575d14
 +&pwm11 {
 +	pinctrl-0 = <&pwm11m1_pins>;
 +	status = "okay";
-+};
-+
-+&pwm12 {
-+	pinctrl-0 = <&pwm12m1_pins>;
-+	status = "okay";
-+};
-+
-+&rockchip_suspend {
-+
-+    rockchip,sleep-mode-config = <
-+        (0
-+        | RKPM_SLP_ARMOFF_DDRPD
-+        | RKPM_SLP_PMU_PMUALIVE_32K
-+        | RKPM_SLP_PMU_DIS_OSC
-+        | RKPM_SLP_32K_EXT
-+        | RKPM_SLP_PMU_DBG
-+        )
-+    >;
-+};
-+
-+&route_hdmi0 {
-+    status = "okay";
-+    connect = <&vp0_out_hdmi0>;
-+    /delete-property/ force-output;
-+    /delete-node/ force_timing;
-+};
-+
+ };
+ 
+ &pwm12 {
+@@ -802,12 +648,6 @@ &pwm12 {
+ 	status = "okay";
+ };
+ 
+-&pwm13 {
+-	pinctrl-0 = <&pwm13m1_pins>;
+-	status = "okay";
+-};
+-
+-
+ &rockchip_suspend {
+ 
+     rockchip,sleep-mode-config = <
+@@ -828,14 +668,12 @@ &route_hdmi0 {
+     /delete-node/ force_timing;
+ };
+ 
+-&sdmmc {
 +&route_edp0 {
 +	connect = <&vp2_out_edp0>;
-+	status = "okay";
-+};
-+
+ 	status = "okay";
+-	card-detect-delay = <1200>;
+ };
+ 
+-&sfc {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&fspim2_pins>;
 +&sdmmc {
+ 	status = "okay";
+ };
+ 
+@@ -846,24 +684,14 @@ &spdif_tx1 {
+ };
+ 
+ &spdif_tx1_dc {
+-	status = "disabled";
 +	status = "okay";
-+};
-+
-+&spdif_tx1 {
-+	status = "disabled";
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&spdif1m1_tx>;
-+};
-+
-+&spdif_tx1_dc {
-+	status = "okay";
-+};
-+
-+&spdif_tx1_sound {
-+	status = "okay";
-+};
-+
+ };
+ 
+ &spdif_tx1_sound {
+-	status = "disabled";
+-};
+-
+-&spdif_tx2 {
+ 	status = "okay";
+ };
+ 
+-&spi1 {
+-	status = "disabled";
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&spi1m1_cs0 &spi1m1_pins>;
+-};
+-
+-&tsadc {
 +&spdif_tx2 {
-+	status = "okay";
-+};
-+
-+&u2phy0_otg {
-+	rockchip,typec-vbus-det;
-+};
-+
-+&u2phy2_host {
-+	phy-supply = <&vcc5v0_host>;
-+};
-+
-+&u2phy3_host {
-+	phy-supply = <&vcc5v0_host>;
-+};
-+
+ 	status = "okay";
+ };
+ 
+@@ -879,17 +707,17 @@ &u2phy3_host {
+ 	phy-supply = <&vcc5v0_host>;
+ };
+ 
+-&uart9 {
 +&uart8 {
-+	status = "okay";
-+	pinctrl-names = "default";
+ 	status = "okay";
+ 	pinctrl-names = "default";
+-	pinctrl-0 = <&uart9m2_xfer &uart9m2_ctsn>;
 +	pinctrl-0 = <&uart8m1_xfer &uart8m1_ctsn>;
-+};
-+
-+&usbdp_phy0 {
-+	orientation-switch;
-+	svid = <0xff01>;
+ };
+ 
+ &usbdp_phy0 {
+ 	orientation-switch;
+ 	svid = <0xff01>;
+-	sbu1-dc-gpios = <&gpio4 RK_PA0 GPIO_ACTIVE_HIGH>;
+-	sbu2-dc-gpios = <&gpio4 RK_PA1 GPIO_ACTIVE_HIGH>;
 +	sbu1-dc-gpios = <&gpio1 RK_PB6 GPIO_ACTIVE_HIGH>;
 +	sbu2-dc-gpios = <&gpio1 RK_PB7 GPIO_ACTIVE_HIGH>;
-+
-+	port {
-+		#address-cells = <1>;
-+		#size-cells = <0>;
-+		usbdp_phy0_orientation_switch: endpoint@0 {
-+			reg = <0>;
-+			remote-endpoint = <&usbc0_orien_sw>;
-+		};
-+
-+		usbdp_phy0_dp_altmode_mux: endpoint@1 {
-+			reg = <1>;
-+			remote-endpoint = <&dp_altmode_mux>;
-+		};
-+	};
-+};
-+
-+&usbdrd_dwc3_0 {
-+	usb-role-switch;
-+	port {
-+		#address-cells = <1>;
-+		#size-cells = <0>;
-+		dwc3_0_role_switch: endpoint@0 {
-+			reg = <0>;
-+			remote-endpoint = <&usbc0_role_sw>;
-+		};
-+	};
-+};
-+
-+&usbhost3_0 {
+ 
+ 	port {
+ 		#address-cells = <1>;
+@@ -919,12 +747,11 @@ dwc3_0_role_switch: endpoint@0 {
+ };
+ 
+ &usbhost3_0 {
+-	status = "okay";
 +	status = "disabled";
-+};
-+
-+&usbhost_dwc3_0 {
+ };
+ 
+ &usbhost_dwc3_0 {
+-	dr_mode = "host";
+-	status = "okay";
 +	status = "disabled";
-+};
-+
-+&vdd_log_s0 {
-+    regulator-state-mem {
-+        regulator-on-in-suspend;
-+        regulator-suspend-microvolt = <750000>;
-+    };
-+};
-+
-+&vcc_1v8_s0 {
-+    /delete-property/ regulator-state-mem;
-+    regulator-state-mem {
-+        regulator-on-in-suspend;
-+        regulator-suspend-microvolt = <1800000>;
-+    };
-+};
-+
-+&vcc_3v3_s0 {
-+    /delete-property/ regulator-state-mem;
-+    regulator-state-mem {
-+        regulator-on-in-suspend;
-+        regulator-suspend-microvolt = <3300000>;
-+    };
-+};
+ };
+ 
+ &vdd_log_s0 {
+@@ -949,3 +776,26 @@ regulator-state-mem {
+         regulator-suspend-microvolt = <3300000>;
+     };
+ };
 +
 +/* vp0 & vp3 are not used on this board */
 +&vp0 {
@@ -1176,38 +1608,21 @@ index 000000000000..91ce4c575d14
 +	/delete-property/ rockchip,primary-plane;
 +};
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi
-new file mode 100644
-index 000000000000..9d041508cac9
---- /dev/null
+index c06bc4fda155..9d041508cac9 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi
-@@ -0,0 +1,1148 @@
-+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
-+/*
-+ * Copyright (c) 2022 Wesion Technology Co., Ltd.
-+ *
-+ */
-+
-+#include <dt-bindings/gpio/gpio.h>
-+#include <dt-bindings/pwm/pwm.h>
-+#include <dt-bindings/pinctrl/rockchip.h>
-+#include <dt-bindings/input/rk-input.h>
-+#include <dt-bindings/display/drm_mipi_dsi.h>
-+#include <dt-bindings/display/rockchip_vop.h>
-+#include <dt-bindings/sensor-dev.h>
-+
-+/ {
-+	adc_keys: adc-keys {
-+		compatible = "adc-keys";
-+		io-channels = <&saradc 1>;
-+		io-channel-names = "buttons";
-+		keyup-threshold-microvolt = <1800000>;
-+		poll-interval = <100>;
-+
+@@ -20,14 +20,32 @@ adc_keys: adc-keys {
+ 		keyup-threshold-microvolt = <1800000>;
+ 		poll-interval = <100>;
+ 
+-		home-key {
+-			label = "home";
+-			linux,code = <KEY_HOMEPAGE>;
 +		vol-up-key {
 +			label = "volume up";
 +			linux,code = <KEY_VOLUMEUP>;
-+			press-threshold-microvolt = <17000>;
-+		};
+ 			press-threshold-microvolt = <17000>;
+ 		};
 +
 +		vol-down-key {
 +			label = "volume down";
@@ -1226,179 +1641,612 @@ index 000000000000..9d041508cac9
 +			linux,code = <KEY_BACK>;
 +			press-threshold-microvolt = <1235000>;
 +		};
-+	};
-+
+ 	};
+ 
+-	backlight_mipi0: backlight-mipi0 {
 +	backlight: backlight {
-+		compatible = "pwm-backlight";
-+		brightness-levels = <
-+			  0  20  20  21  21  22  22  23
-+			 23  24  24  25  25  26  26  27
-+			 27  28  28  29  29  30  30  31
-+			 31  32  32  33  33  34  34  35
-+			 35  36  36  37  37  38  38  39
-+			 40  41  42  43  44  45  46  47
-+			 48  49  50  51  52  53  54  55
-+			 56  57  58  59  60  61  62  63
-+			 64  65  66  67  68  69  70  71
-+			 72  73  74  75  76  77  78  79
-+			 80  81  82  83  84  85  86  87
-+			 88  89  90  91  92  93  94  95
-+			 96  97  98  99 100 101 102 103
-+			104 105 106 107 108 109 110 111
-+			112 113 114 115 116 117 118 119
-+			120 121 122 123 124 125 126 127
-+			128 129 130 131 132 133 134 135
-+			136 137 138 139 140 141 142 143
-+			144 145 146 147 148 149 150 151
-+			152 153 154 155 156 157 158 159
-+			160 161 162 163 164 165 166 167
-+			168 169 170 171 172 173 174 175
-+			176 177 178 179 180 181 182 183
-+			184 185 186 187 188 189 190 191
-+			192 193 194 195 196 197 198 199
-+			200 201 202 203 204 205 206 207
-+			208 209 210 211 212 213 214 215
-+			216 217 218 219 220 221 222 223
-+			224 225 226 227 228 229 230 231
-+			232 233 234 235 236 237 238 239
-+			240 241 242 243 244 245 246 247
-+			248 249 250 251 252 253 254 255
-+		>;
-+		default-brightness-level = <200>;
-+	};
-+
-+	dp0_sound: dp0-sound {
-+		status = "disabled";
-+		compatible = "rockchip,hdmi";
-+		rockchip,card-name= "rockchip,dp0";
-+		rockchip,mclk-fs = <512>;
-+		rockchip,cpu = <&spdif_tx2>;
-+		rockchip,codec = <&dp0 1>;
-+		rockchip,jack-det;
-+	};
-+
-+	hdmi0_sound: hdmi0-sound {
-+		status = "disabled";
-+		compatible = "simple-audio-card";
-+		simple-audio-card,format = "i2s";
-+		simple-audio-card,mclk-fs = <128>;
-+		simple-audio-card,name = "rockchip,hdmi0";
-+
-+		simple-audio-card,cpu {
-+			sound-dai = <&i2s5_8ch>;
-+		};
-+		simple-audio-card,codec {
-+			sound-dai = <&hdmi0>;
-+		};
-+	};
-+
-+	spdif_tx1_dc: spdif-tx1-dc {
-+		status = "disabled";
-+		compatible = "linux,spdif-dit";
-+		#sound-dai-cells = <0>;
-+	};
-+
-+	spdif_tx1_sound: spdif-tx1-sound {
-+		status = "disabled";
-+		compatible = "simple-audio-card";
-+		simple-audio-card,name = "rockchip,spdif-tx1";
-+		simple-audio-card,cpu {
-+			sound-dai = <&spdif_tx1>;
-+		};
-+		simple-audio-card,codec {
-+			sound-dai = <&spdif_tx1_dc>;
-+		};
-+	};
-+
-+	test-power {
-+		status = "okay";
-+	};
-+
-+	vcc12v_dcin: vcc12v-dcin {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc12v_dcin";
-+		regulator-always-on;
-+		regulator-boot-on;
-+		regulator-min-microvolt = <12000000>;
-+		regulator-max-microvolt = <12000000>;
-+	};
-+
-+	vcc5v0_sys: vcc5v0-sys {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc5v0_sys";
-+		regulator-always-on;
-+		regulator-boot-on;
-+		regulator-min-microvolt = <5000000>;
-+		regulator-max-microvolt = <5000000>;
-+		vin-supply = <&vcc12v_dcin>;
-+	};
-+
-+	vcc5v0_usbdcin: vcc5v0-usbdcin {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc5v0_usbdcin";
-+		regulator-always-on;
-+		regulator-boot-on;
-+		regulator-min-microvolt = <5000000>;
-+		regulator-max-microvolt = <5000000>;
-+		vin-supply = <&vcc12v_dcin>;
-+	};
-+
-+	vcc5v0_usb: vcc5v0-usb {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc5v0_usb";
-+		regulator-always-on;
-+		regulator-boot-on;
-+		regulator-min-microvolt = <5000000>;
-+		regulator-max-microvolt = <5000000>;
-+		vin-supply = <&vcc5v0_usbdcin>;
-+	};
-+};
-+
-+&av1d_mmu {
-+	status = "okay";
-+};
-+
-+&combphy0_ps {
-+	status = "okay";
-+};
-+
-+&combphy2_psu {
-+	status = "okay";
-+};
-+
-+&cpu_l0 {
-+	cpu-supply = <&vdd_cpu_lit_s0>;
-+	mem-supply = <&vdd_cpu_lit_mem_s0>;
-+};
-+
-+&cpu_b0 {
-+	cpu-supply = <&vdd_cpu_big0_s0>;
-+	mem-supply = <&vdd_cpu_big0_mem_s0>;
-+};
-+
-+&cpu_b2 {
-+	cpu-supply = <&vdd_cpu_big1_s0>;
-+	mem-supply = <&vdd_cpu_big1_mem_s0>;
-+};
-+
-+&dsi0 {
-+	status = "disabled";
-+	//rockchip,lane-rate = <1000>;
-+	dsi0_panel: panel@0 {
-+		status = "okay";
-+		compatible = "simple-panel-dsi";
-+		reg = <0>;
+ 		compatible = "pwm-backlight";
+ 		brightness-levels = <
+ 			  0  20  20  21  21  22  22  23
+@@ -76,47 +94,6 @@ dp0_sound: dp0-sound {
+ 		rockchip,jack-det;
+ 	};
+ 
+-	backlight_mipi1: backlight-mipi1 {
+-        compatible = "pwm-backlight";
+-        brightness-levels = <
+-              0  20  20  21  21  22  22  23
+-             23  24  24  25  25  26  26  27
+-             27  28  28  29  29  30  30  31
+-             31  32  32  33  33  34  34  35
+-             35  36  36  37  37  38  38  39
+-             40  41  42  43  44  45  46  47
+-             48  49  50  51  52  53  54  55
+-             56  57  58  59  60  61  62  63
+-             64  65  66  67  68  69  70  71
+-             72  73  74  75  76  77  78  79
+-             80  81  82  83  84  85  86  87
+-             88  89  90  91  92  93  94  95
+-             96  97  98  99 100 101 102 103
+-            104 105 106 107 108 109 110 111
+-            112 113 114 115 116 117 118 119
+-            120 121 122 123 124 125 126 127
+-            128 129 130 131 132 133 134 135
+-            136 137 138 139 140 141 142 143
+-            144 145 146 147 148 149 150 151
+-            152 153 154 155 156 157 158 159
+-            160 161 162 163 164 165 166 167
+-            168 169 170 171 172 173 174 175
+-            176 177 178 179 180 181 182 183
+-            184 185 186 187 188 189 190 191
+-            192 193 194 195 196 197 198 199
+-            200 201 202 203 204 205 206 207
+-            208 209 210 211 212 213 214 215
+-            216 217 218 219 220 221 222 223
+-            224 225 226 227 228 229 230 231
+-            232 233 234 235 236 237 238 239
+-            240 241 242 243 244 245 246 247
+-            248 249 250 251 252 253 254 255
+-        >;
+-        default-brightness-level = <200>;
+-    };
+-
+-
+-
+ 	hdmi0_sound: hdmi0-sound {
+ 		status = "disabled";
+ 		compatible = "simple-audio-card";
+@@ -173,16 +150,6 @@ vcc5v0_sys: vcc5v0-sys {
+ 		vin-supply = <&vcc12v_dcin>;
+ 	};
+ 
+-	vcc_1v1_nldo_s3: vcc-1v1-nldo-s3 {
+-        compatible = "regulator-fixed";
+-        regulator-name = "vcc_1v1_nldo_s3";
+-        regulator-always-on;
+-        regulator-boot-on;
+-        regulator-min-microvolt = <1100000>;
+-        regulator-max-microvolt = <1100000>;
+-        vin-supply = <&vcc5v0_sys>;
+-    };
+-
+ 	vcc5v0_usbdcin: vcc5v0-usbdcin {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vcc5v0_usbdcin";
+@@ -238,8 +205,8 @@ dsi0_panel: panel@0 {
+ 		status = "okay";
+ 		compatible = "simple-panel-dsi";
+ 		reg = <0>;
+-		backlight = <&backlight_mipi0>;
+-	//	reset-delay-ms = <60>;
 +		backlight = <&backlight>;
 +		reset-delay-ms = <60>;
-+		enable-delay-ms = <60>;
-+		prepare-delay-ms = <60>;
-+		unprepare-delay-ms = <60>;
-+		disable-delay-ms = <60>;
-+		dsi,flags = <(MIPI_DSI_MODE_VIDEO | MIPI_DSI_MODE_VIDEO_BURST |
-+			MIPI_DSI_MODE_LPM | MIPI_DSI_MODE_EOT_PACKET)>;
-+		dsi,format = <MIPI_DSI_FMT_RGB888>;
-+		dsi,lanes  = <4>;
-+		panel-init-sequence = [
+ 		enable-delay-ms = <60>;
+ 		prepare-delay-ms = <60>;
+ 		unprepare-delay-ms = <60>;
+@@ -249,548 +216,286 @@ dsi0_panel: panel@0 {
+ 		dsi,format = <MIPI_DSI_FMT_RGB888>;
+ 		dsi,lanes  = <4>;
+ 		panel-init-sequence = [
+-			15 00 02 FF 05
+-			15 00 02 FB 01
+-			15 64 02 C5 01
+-			15 00 02 FF EE
+-			15 00 02 FB 01
+-			15 00 02 1F 45
+-			15 00 02 24 4F
+-			15 00 02 38 C8
+-			15 00 02 39 27
+-			15 00 02 1E 77
+-			15 00 02 1D 0F
+-			15 00 02 7E 71
+-			15 00 02 7C 03
+-			15 00 02 FF 00
+-			15 00 02 FB 01
+-			15 00 02 35 01
+-			15 00 02 FF 01
+-			15 00 02 FB 01
+-			15 00 02 00 01
+-			15 00 02 01 55
+-			15 00 02 02 40
+-			15 00 02 05 40
+-			15 00 02 06 4A
+-			15 00 02 07 24
+-			15 00 02 08 0C
+-			15 00 02 0B 7D
+-			15 00 02 0C 7D
+-			15 00 02 0E B0
+-			15 00 02 0F AE
+-			15 00 02 11 10
+-			15 00 02 12 10
+-			15 00 02 13 03
+-			15 00 02 14 4A
+-			15 00 02 15 12
+-			15 00 02 16 12
+-			15 00 02 18 00
+-			15 00 02 19 77
+-			15 00 02 1A 55
+-			15 00 02 1B 13
+-			15 00 02 1C 00
+-			15 00 02 1D 00
+-			15 00 02 1E 13
+-			15 00 02 1F 00
+-			15 00 02 23 00
+-			15 00 02 24 00
+-			15 00 02 25 00
+-			15 00 02 26 00
+-			15 00 02 27 00
+-			15 00 02 28 00
+-			15 00 02 35 00
+-			15 00 02 66 00
+-			15 00 02 58 82
+-			15 00 02 59 02
+-			15 00 02 5A 02
+-			15 00 02 5B 02
+-			15 00 02 5C 82
+-			15 00 02 5D 82
+-			15 00 02 5E 02
+-			15 00 02 5F 02
+-			15 00 02 72 31
+-			15 00 02 FF 05
+-			15 00 02 FB 01
+-			15 00 02 00 01
+-			15 00 02 01 0B
+-			15 00 02 02 0C
+-			15 00 02 03 09
+-			15 00 02 04 0A
+-			15 00 02 05 00
+-			15 00 02 06 0F
+-			15 00 02 07 10
+-			15 00 02 08 00
+-			15 00 02 09 00
+-			15 00 02 0A 00
+-			15 00 02 0B 00
+-			15 00 02 0C 00
+-			15 00 02 0D 13
+-			15 00 02 0E 15
+-			15 00 02 0F 17
+-			15 00 02 10 01
+-			15 00 02 11 0B
+-			15 00 02 12 0C
+-			15 00 02 13 09
+-			15 00 02 14 0A
+-			15 00 02 15 00
+-			15 00 02 16 0F
+-			15 00 02 17 10
+-			15 00 02 18 00
+-			15 00 02 19 00
+-			15 00 02 1A 00
+-			15 00 02 1B 00
+-			15 00 02 1C 00
+-			15 00 02 1D 13
+-			15 00 02 1E 15
+-			15 00 02 1F 17
+-			15 00 02 20 00
+-			15 00 02 21 03
+-			15 00 02 22 01
+-			15 00 02 23 40
+-			15 00 02 24 40
+-			15 00 02 25 ED
+-			15 00 02 29 58
+-			15 00 02 2A 12
+-			15 00 02 2B 01
+-			15 00 02 4B 06
+-			15 00 02 4C 11
+-			15 00 02 4D 20
+-			15 00 02 4E 02
+-			15 00 02 4F 02
+-			15 00 02 50 20
+-			15 00 02 51 61
+-			15 00 02 52 01
+-			15 00 02 53 63
+-			15 00 02 54 77
+-			15 00 02 55 ED
+-			15 00 02 5B 00
+-			15 00 02 5C 00
+-			15 00 02 5D 00
+-			15 00 02 5E 00
+-			15 00 02 5F 15
+-			15 00 02 60 75
+-			15 00 02 61 00
+-			15 00 02 62 00
+-			15 00 02 63 00
+-			15 00 02 64 00
+-			15 00 02 65 00
+-			15 00 02 66 00
+-			15 00 02 67 00
+-			15 00 02 68 04
+-			15 00 02 69 00
+-			15 00 02 6A 00
+-			15 00 02 6C 40
+-			15 00 02 75 01
+-			15 00 02 76 01
+-			15 00 02 7A 80
+-			15 00 02 7B A3
+-			15 00 02 7C D8
+-			15 00 02 7D 60
+-			15 00 02 7F 15
+-			15 00 02 80 81
+-			15 00 02 83 05
+-			15 00 02 93 08
+-			15 00 02 94 10
+-			15 00 02 8A 00
+-			15 00 02 9B 0F
+-			15 00 02 EA FF
+-			15 00 02 EC 00
+-			15 00 02 FF 01
+-			15 00 02 FB 01
+-			15 00 02 75 00
+-			15 00 02 76 DF
+-			15 00 02 77 00
+-			15 00 02 78 E4
+-			15 00 02 79 00
+-			15 00 02 7A ED
+-			15 00 02 7B 00
+-			15 00 02 7C F6
+-			15 00 02 7D 00
+-			15 00 02 7E FF
+-			15 00 02 7F 01
+-			15 00 02 80 07
+-			15 00 02 81 01
+-			15 00 02 82 10
+-			15 00 02 83 01
+-			15 00 02 84 18
+-			15 00 02 85 01
+-			15 00 02 86 20
+-			15 00 02 87 01
+-			15 00 02 88 3D
+-			15 00 02 89 01
+-			15 00 02 8A 56
+-			15 00 02 8B 01
+-			15 00 02 8C 84
+-			15 00 02 8D 01
+-			15 00 02 8E AB
+-			15 00 02 8F 01
+-			15 00 02 90 EC
+-			15 00 02 91 02
+-			15 00 02 92 22
+-			15 00 02 93 02
+-			15 00 02 94 23
+-			15 00 02 95 02
+-			15 00 02 96 55
+-			15 00 02 97 02
+-			15 00 02 98 8B
+-			15 00 02 99 02
+-			15 00 02 9A AF
+-			15 00 02 9B 02
+-			15 00 02 9C DF
+-			15 00 02 9D 03
+-			15 00 02 9E 01
+-			15 00 02 9F 03
+-			15 00 02 A0 2C
+-			15 00 02 A2 03
+-			15 00 02 A3 39
+-			15 00 02 A4 03
+-			15 00 02 A5 47
+-			15 00 02 A6 03
+-			15 00 02 A7 56
+-			15 00 02 A9 03
+-			15 00 02 AA 66
+-			15 00 02 AB 03
+-			15 00 02 AC 76
+-			15 00 02 AD 03
+-			15 00 02 AE 85
+-			15 00 02 AF 03
+-			15 00 02 B0 90
+-			15 00 02 B1 03
+-			15 00 02 B2 CB
+-			15 00 02 B3 00
+-			15 00 02 B4 DF
+-			15 00 02 B5 00
+-			15 00 02 B6 E4
+-			15 00 02 B7 00
+-			15 00 02 B8 ED
+-			15 00 02 B9 00
+-			15 00 02 BA F6
+-			15 00 02 BB 00
+-			15 00 02 BC FF
+-			15 00 02 BD 01
+-			15 00 02 BE 07
+-			15 00 02 BF 01
+-			15 00 02 C0 10
+-			15 00 02 C1 01
+-			15 00 02 C2 18
+-			15 00 02 C3 01
+-			15 00 02 C4 20
+-			15 00 02 C5 01
+-			15 00 02 C6 3D
+-			15 00 02 C7 01
+-			15 00 02 C8 56
+-			15 00 02 C9 01
+-			15 00 02 CA 84
+-			15 00 02 CB 01
+-			15 00 02 CC AB
+-			15 00 02 CD 01
+-			15 00 02 CE EC
+-			15 00 02 CF 02
+-			15 00 02 D0 22
+-			15 00 02 D1 02
+-			15 00 02 D2 23
+-			15 00 02 D3 02
+-			15 00 02 D4 55
+-			15 00 02 D5 02
+-			15 00 02 D6 8B
+-			15 00 02 D7 02
+-			15 00 02 D8 AF
+-			15 00 02 D9 02
+-			15 00 02 DA DF
+-			15 00 02 DB 03
+-			15 00 02 DC 01
+-			15 00 02 DD 03
+-			15 00 02 DE 2C
+-			15 00 02 DF 03
+-			15 00 02 E0 39
+-			15 00 02 E1 03
+-			15 00 02 E2 47
+-			15 00 02 E3 03
+-			15 00 02 E4 56
+-			15 00 02 E5 03
+-			15 00 02 E6 66
+-			15 00 02 E7 03
+-			15 00 02 E8 76
+-			15 00 02 E9 03
+-			15 00 02 EA 85
+-			15 00 02 EB 03
+-			15 00 02 EC 90
+-			15 00 02 ED 03
+-			15 00 02 EE CB
+-			15 00 02 EF 00
+-			15 00 02 F0 BB
+-			15 00 02 F1 00
+-			15 00 02 F2 C0
+-			15 00 02 F3 00
+-			15 00 02 F4 CC
+-			15 00 02 F5 00
+-			15 00 02 F6 D6
+-			15 00 02 F7 00
+-			15 00 02 F8 E1
+-			15 00 02 F9 00
+-			15 00 02 FA EA
+-			15 00 02 FF 02
+-			15 00 02 FB 01
+-			15 00 02 00 00
+-			15 00 02 01 F4
+-			15 00 02 02 00
+-			15 00 02 03 EF
+-			15 00 02 04 01
+-			15 00 02 05 07
+-			15 00 02 06 01
+-			15 00 02 07 28
+-			15 00 02 08 01
+-			15 00 02 09 44
+-			15 00 02 0A 01
+-			15 00 02 0B 76
+-			15 00 02 0C 01
+-			15 00 02 0D A0
+-			15 00 02 0E 01
+-			15 00 02 0F E7
+-			15 00 02 10 02
+-			15 00 02 11 1F
+-			15 00 02 12 02
+-			15 00 02 13 22
+-			15 00 02 14 02
+-			15 00 02 15 54
+-			15 00 02 16 02
+-			15 00 02 17 8B
+-			15 00 02 18 02
+-			15 00 02 19 AF
+-			15 00 02 1A 02
+-			15 00 02 1B E0
+-			15 00 02 1C 03
+-			15 00 02 1D 01
+-			15 00 02 1E 03
+-			15 00 02 1F 2D
+-			15 00 02 20 03
+-			15 00 02 21 39
+-			15 00 02 22 03
+-			15 00 02 23 47
+-			15 00 02 24 03
+-			15 00 02 25 57
+-			15 00 02 26 03
+-			15 00 02 27 65
+-			15 00 02 28 03
+-			15 00 02 29 77
+-			15 00 02 2A 03
+-			15 00 02 2B 85
+-			15 00 02 2D 03
+-			15 00 02 2F 8F
+-			15 00 02 30 03
+-			15 00 02 31 CB
+-			15 00 02 32 00
+-			15 00 02 33 BB
+-			15 00 02 34 00
+-			15 00 02 35 C0
+-			15 00 02 36 00
+-			15 00 02 37 CC
+-			15 00 02 38 00
+-			15 00 02 39 D6
+-			15 00 02 3A 00
+-			15 00 02 3B E1
+-			15 00 02 3D 00
+-			15 00 02 3F EA
+-			15 00 02 40 00
+-			15 00 02 41 F4
+-			15 00 02 42 00
+-			15 00 02 43 FE
+-			15 00 02 44 01
+-			15 00 02 45 07
+-			15 00 02 46 01
+-			15 00 02 47 28
+-			15 00 02 48 01
+-			15 00 02 49 44
+-			15 00 02 4A 01
+-			15 00 02 4B 76
+-			15 00 02 4C 01
+-			15 00 02 4D A0
+-			15 00 02 4E 01
+-			15 00 02 4F E7
+-			15 00 02 50 02
+-			15 00 02 51 1F
+-			15 00 02 52 02
+-			15 00 02 53 22
+-			15 00 02 54 02
+-			15 00 02 55 54
+-			15 00 02 56 02
+-			15 00 02 58 8B
+-			15 00 02 59 02
+-			15 00 02 5A AF
+-			15 00 02 5B 02
+-			15 00 02 5C E0
+-			15 00 02 5D 03
+-			15 00 02 5E 01
+-			15 00 02 5F 03
+-			15 00 02 60 2D
+-			15 00 02 61 03
+-			15 00 02 62 39
+-			15 00 02 63 03
+-			15 00 02 64 47
+-			15 00 02 65 03
+-			15 00 02 66 57
+-			15 00 02 67 03
+-			15 00 02 68 65
+-			15 00 02 69 03
+-			15 00 02 6A 77
+-			15 00 02 6B 03
+-			15 00 02 6C 85
+-			15 00 02 6D 03
+-			15 00 02 6E 8F
+-			15 00 02 6F 03
+-			15 00 02 70 CB
+-			15 00 02 71 00
+-			15 00 02 72 00
+-			15 00 02 73 00
+-			15 00 02 74 21
+-			15 00 02 75 00
+-			15 00 02 76 4C
+-			15 00 02 77 00
+-			15 00 02 78 6B
+-			15 00 02 79 00
+-			15 00 02 7A 85
+-			15 00 02 7B 00
+-			15 00 02 7C 9A
+-			15 00 02 7D 00
+-			15 00 02 7E AD
+-			15 00 02 7F 00
+-			15 00 02 80 BE
+-			15 00 02 81 00
+-			15 00 02 82 CD
+-			15 00 02 83 01
+-			15 00 02 84 01
+-			15 00 02 85 01
+-			15 00 02 86 29
+-			15 00 02 87 01
+-			15 00 02 88 68
+-			15 00 02 89 01
+-			15 00 02 8A 98
+-			15 00 02 8B 01
+-			15 00 02 8C E5
+-			15 00 02 8D 02
+-			15 00 02 8E 1E
+-			15 00 02 8F 02
+-			15 00 02 90 30
+-			15 00 02 91 02
+-			15 00 02 92 52
+-			15 00 02 93 02
+-			15 00 02 94 88
+-			15 00 02 95 02
+-			15 00 02 96 AA
+-			15 00 02 97 02
+-			15 00 02 98 D7
+-			15 00 02 99 02
+-			15 00 02 9A F7
+-			15 00 02 9B 03
+-			15 00 02 9C 21
+-			15 00 02 9D 03
+-			15 00 02 9E 2E
+-			15 00 02 9F 03
+-			15 00 02 A0 3D
+-			15 00 02 A2 03
+-			15 00 02 A3 4C
+-			15 00 02 A4 03
+-			15 00 02 A5 5E
+-			15 00 02 A6 03
+-			15 00 02 A7 71
+-			15 00 02 A9 03
+-			15 00 02 AA 86
+-			15 00 02 AB 03
+-			15 00 02 AC 94
+-			15 00 02 AD 03
+-			15 00 02 AE FA
+-			15 00 02 AF 00
+-			15 00 02 B0 00
+-			15 00 02 B1 00
+-			15 00 02 B2 21
+-			15 00 02 B3 00
+-			15 00 02 B4 4C
+-			15 00 02 B5 00
+-			15 00 02 B6 6B
+-			15 00 02 B7 00
+-			15 00 02 B8 85
+-			15 00 02 B9 00
+-			15 00 02 BA 9A
+-			15 00 02 BB 00
+-			15 00 02 BC AD
+-			15 00 02 BD 00
+-			15 00 02 BE BE
+-			15 00 02 BF 00
+-			15 00 02 C0 CD
+-			15 00 02 C1 01
+-			15 00 02 C2 01
+-			15 00 02 C3 01
+-			15 00 02 C4 29
+-			15 00 02 C5 01
+-			15 00 02 C6 68
+-			15 00 02 C7 01
+-			15 00 02 C8 98
+-			15 00 02 C9 01
+-			15 00 02 CA E5
+-			15 00 02 CB 02
+-			15 00 02 CC 1E
+-			15 00 02 CD 02
+-			15 00 02 CE 20
+-			15 00 02 CF 02
+-			15 00 02 D0 52
+-			15 00 02 D1 02
+-			15 00 02 D2 88
+-			15 00 02 D3 02
+-			15 00 02 D4 AA
+-			15 00 02 D5 02
+-			15 00 02 D6 D7
+-			15 00 02 D7 02
+-			15 00 02 D8 F7
+-			15 00 02 D9 03
+-			15 00 02 DA 21
+-			15 00 02 DB 03
+-			15 00 02 DC 2E
+-			15 00 02 DD 03
+-			15 00 02 DE 3D
+-			15 00 02 DF 03
+-			15 00 02 E0 4C
+-			15 00 02 E1 03
+-			15 00 02 E2 5E
+-			15 00 02 E3 03
+-			15 00 02 E4 71
+-			15 00 02 E5 03
+-			15 00 02 E6 86
+-			15 00 02 E7 03
+-			15 00 02 E8 94
+-			15 00 02 E9 03
+-			15 00 02 EA FA
+-			15 00 02 FF 01
+-			15 00 02 FB 01
+-			15 00 02 FF 02
+-			15 00 02 FB 01
+-			15 00 02 FF 04
+-			15 00 02 FB 01
+-			15 00 02 FF 00
+-			15 00 02 D3 05
+-			15 00 02 D4 04
 +			23 00 02 FE 21
 +			23 00 02 04 00
 +			23 00 02 00 64
@@ -1658,79 +2506,578 @@ index 000000000000..9d041508cac9
 +			23 00 02 51 8F
 +			23 00 02 FE 00
 +			23 00 02 35 00
-+			05 78 01 11
+ 			05 78 01 11
+-			15 00 02 FF 00
+-			15 00 02 35 00
+-			05 0A 01 29
 +			05 1E 01 29
-+		];
-+
-+		panel-exit-sequence = [
+ 		];
+ 
+ 		panel-exit-sequence = [
+-			05 05 01 28
+-			05 78 01 10
 +			05 00 01 28
 +			05 00 01 10
-+		];
-+
-+		disp_timings0: display-timings {
-+			native-mode = <&dsi0_timing0>;
-+			dsi0_timing0: timing0 {
+ 		];
+ 
+ 		disp_timings0: display-timings {
+ 			native-mode = <&dsi0_timing0>;
+ 			dsi0_timing0: timing0 {
+-				clock-frequency = <152198100>;
 +				clock-frequency = <132000000>;
-+				hactive = <1080>;
-+				vactive = <1920>;
+ 				hactive = <1080>;
+ 				vactive = <1920>;
+-				hfront-porch = <104>;
 +				hfront-porch = <15>;
-+				hsync-len = <4>;
+ 				hsync-len = <4>;
+-				hback-porch = <127>;
+-				vfront-porch = <4>;
 +				hback-porch = <30>;
 +				vfront-porch = <15>;
-+				vsync-len = <2>;
+ 				vsync-len = <2>;
+-				vback-porch = <3>;
 +				vback-porch = <15>;
-+				hsync-active = <0>;
-+				vsync-active = <0>;
-+				de-active = <0>;
-+				pixelclk-active = <0>;
-+			};
-+		};
-+
-+		ports {
-+			#address-cells = <1>;
-+			#size-cells = <0>;
-+
-+			port@0 {
-+				reg = <0>;
-+				panel_in_dsi: endpoint {
-+					remote-endpoint = <&dsi_out_panel>;
-+				};
-+			};
-+		};
-+	};
-+
-+	ports {
-+		#address-cells = <1>;
-+		#size-cells = <0>;
-+
-+		port@1 {
-+			reg = <1>;
-+			dsi_out_panel: endpoint {
-+				remote-endpoint = <&panel_in_dsi>;
-+			};
-+		};
-+	};
-+
-+};
-+
-+&dsi1 {
-+	status = "disabled";
-+	//rockchip,lane-rate = <1000>;
-+	dsi1_panel: panel@0 {
+ 				hsync-active = <0>;
+ 				vsync-active = <0>;
+ 				de-active = <0>;
+@@ -829,11 +534,11 @@ &dsi1 {
+ 	status = "disabled";
+ 	//rockchip,lane-rate = <1000>;
+ 	dsi1_panel: panel@0 {
+-		status = "disabled";
 +		status = "okay";
-+		compatible = "simple-panel-dsi";
-+		reg = <0>;
+ 		compatible = "simple-panel-dsi";
+ 		reg = <0>;
+-		backlight = <&backlight_mipi1>;
+-//		reset-delay-ms = <60>;
 +		backlight = <&backlight>;
 +		reset-delay-ms = <60>;
-+		enable-delay-ms = <60>;
-+		prepare-delay-ms = <60>;
-+		unprepare-delay-ms = <60>;
-+		disable-delay-ms = <60>;
-+		dsi,flags = <(MIPI_DSI_MODE_VIDEO | MIPI_DSI_MODE_VIDEO_BURST |
-+			MIPI_DSI_MODE_LPM | MIPI_DSI_MODE_EOT_PACKET)>;
-+		dsi,format = <MIPI_DSI_FMT_RGB888>;
-+		dsi,lanes  = <4>;
-+		panel-init-sequence = [
+ 		enable-delay-ms = <60>;
+ 		prepare-delay-ms = <60>;
+ 		unprepare-delay-ms = <60>;
+@@ -843,548 +548,286 @@ dsi1_panel: panel@0 {
+ 		dsi,format = <MIPI_DSI_FMT_RGB888>;
+ 		dsi,lanes  = <4>;
+ 		panel-init-sequence = [
+-			15 00 02 FF 05
+-			15 00 02 FB 01
+-			15 64 02 C5 01
+-			15 00 02 FF EE
+-			15 00 02 FB 01
+-			15 00 02 1F 45
+-			15 00 02 24 4F
+-			15 00 02 38 C8
+-			15 00 02 39 27
+-			15 00 02 1E 77
+-			15 00 02 1D 0F
+-			15 00 02 7E 71
+-			15 00 02 7C 03
+-			15 00 02 FF 00
+-			15 00 02 FB 01
+-			15 00 02 35 01
+-			15 00 02 FF 01
+-			15 00 02 FB 01
+-			15 00 02 00 01
+-			15 00 02 01 55
+-			15 00 02 02 40
+-			15 00 02 05 40
+-			15 00 02 06 4A
+-			15 00 02 07 24
+-			15 00 02 08 0C
+-			15 00 02 0B 7D
+-			15 00 02 0C 7D
+-			15 00 02 0E B0
+-			15 00 02 0F AE
+-			15 00 02 11 10
+-			15 00 02 12 10
+-			15 00 02 13 03
+-			15 00 02 14 4A
+-			15 00 02 15 12
+-			15 00 02 16 12
+-			15 00 02 18 00
+-			15 00 02 19 77
+-			15 00 02 1A 55
+-			15 00 02 1B 13
+-			15 00 02 1C 00
+-			15 00 02 1D 00
+-			15 00 02 1E 13
+-			15 00 02 1F 00
+-			15 00 02 23 00
+-			15 00 02 24 00
+-			15 00 02 25 00
+-			15 00 02 26 00
+-			15 00 02 27 00
+-			15 00 02 28 00
+-			15 00 02 35 00
+-			15 00 02 66 00
+-			15 00 02 58 82
+-			15 00 02 59 02
+-			15 00 02 5A 02
+-			15 00 02 5B 02
+-			15 00 02 5C 82
+-			15 00 02 5D 82
+-			15 00 02 5E 02
+-			15 00 02 5F 02
+-			15 00 02 72 31
+-			15 00 02 FF 05
+-			15 00 02 FB 01
+-			15 00 02 00 01
+-			15 00 02 01 0B
+-			15 00 02 02 0C
+-			15 00 02 03 09
+-			15 00 02 04 0A
+-			15 00 02 05 00
+-			15 00 02 06 0F
+-			15 00 02 07 10
+-			15 00 02 08 00
+-			15 00 02 09 00
+-			15 00 02 0A 00
+-			15 00 02 0B 00
+-			15 00 02 0C 00
+-			15 00 02 0D 13
+-			15 00 02 0E 15
+-			15 00 02 0F 17
+-			15 00 02 10 01
+-			15 00 02 11 0B
+-			15 00 02 12 0C
+-			15 00 02 13 09
+-			15 00 02 14 0A
+-			15 00 02 15 00
+-			15 00 02 16 0F
+-			15 00 02 17 10
+-			15 00 02 18 00
+-			15 00 02 19 00
+-			15 00 02 1A 00
+-			15 00 02 1B 00
+-			15 00 02 1C 00
+-			15 00 02 1D 13
+-			15 00 02 1E 15
+-			15 00 02 1F 17
+-			15 00 02 20 00
+-			15 00 02 21 03
+-			15 00 02 22 01
+-			15 00 02 23 40
+-			15 00 02 24 40
+-			15 00 02 25 ED
+-			15 00 02 29 58
+-			15 00 02 2A 12
+-			15 00 02 2B 01
+-			15 00 02 4B 06
+-			15 00 02 4C 11
+-			15 00 02 4D 20
+-			15 00 02 4E 02
+-			15 00 02 4F 02
+-			15 00 02 50 20
+-			15 00 02 51 61
+-			15 00 02 52 01
+-			15 00 02 53 63
+-			15 00 02 54 77
+-			15 00 02 55 ED
+-			15 00 02 5B 00
+-			15 00 02 5C 00
+-			15 00 02 5D 00
+-			15 00 02 5E 00
+-			15 00 02 5F 15
+-			15 00 02 60 75
+-			15 00 02 61 00
+-			15 00 02 62 00
+-			15 00 02 63 00
+-			15 00 02 64 00
+-			15 00 02 65 00
+-			15 00 02 66 00
+-			15 00 02 67 00
+-			15 00 02 68 04
+-			15 00 02 69 00
+-			15 00 02 6A 00
+-			15 00 02 6C 40
+-			15 00 02 75 01
+-			15 00 02 76 01
+-			15 00 02 7A 80
+-			15 00 02 7B A3
+-			15 00 02 7C D8
+-			15 00 02 7D 60
+-			15 00 02 7F 15
+-			15 00 02 80 81
+-			15 00 02 83 05
+-			15 00 02 93 08
+-			15 00 02 94 10
+-			15 00 02 8A 00
+-			15 00 02 9B 0F
+-			15 00 02 EA FF
+-			15 00 02 EC 00
+-			15 00 02 FF 01
+-			15 00 02 FB 01
+-			15 00 02 75 00
+-			15 00 02 76 DF
+-			15 00 02 77 00
+-			15 00 02 78 E4
+-			15 00 02 79 00
+-			15 00 02 7A ED
+-			15 00 02 7B 00
+-			15 00 02 7C F6
+-			15 00 02 7D 00
+-			15 00 02 7E FF
+-			15 00 02 7F 01
+-			15 00 02 80 07
+-			15 00 02 81 01
+-			15 00 02 82 10
+-			15 00 02 83 01
+-			15 00 02 84 18
+-			15 00 02 85 01
+-			15 00 02 86 20
+-			15 00 02 87 01
+-			15 00 02 88 3D
+-			15 00 02 89 01
+-			15 00 02 8A 56
+-			15 00 02 8B 01
+-			15 00 02 8C 84
+-			15 00 02 8D 01
+-			15 00 02 8E AB
+-			15 00 02 8F 01
+-			15 00 02 90 EC
+-			15 00 02 91 02
+-			15 00 02 92 22
+-			15 00 02 93 02
+-			15 00 02 94 23
+-			15 00 02 95 02
+-			15 00 02 96 55
+-			15 00 02 97 02
+-			15 00 02 98 8B
+-			15 00 02 99 02
+-			15 00 02 9A AF
+-			15 00 02 9B 02
+-			15 00 02 9C DF
+-			15 00 02 9D 03
+-			15 00 02 9E 01
+-			15 00 02 9F 03
+-			15 00 02 A0 2C
+-			15 00 02 A2 03
+-			15 00 02 A3 39
+-			15 00 02 A4 03
+-			15 00 02 A5 47
+-			15 00 02 A6 03
+-			15 00 02 A7 56
+-			15 00 02 A9 03
+-			15 00 02 AA 66
+-			15 00 02 AB 03
+-			15 00 02 AC 76
+-			15 00 02 AD 03
+-			15 00 02 AE 85
+-			15 00 02 AF 03
+-			15 00 02 B0 90
+-			15 00 02 B1 03
+-			15 00 02 B2 CB
+-			15 00 02 B3 00
+-			15 00 02 B4 DF
+-			15 00 02 B5 00
+-			15 00 02 B6 E4
+-			15 00 02 B7 00
+-			15 00 02 B8 ED
+-			15 00 02 B9 00
+-			15 00 02 BA F6
+-			15 00 02 BB 00
+-			15 00 02 BC FF
+-			15 00 02 BD 01
+-			15 00 02 BE 07
+-			15 00 02 BF 01
+-			15 00 02 C0 10
+-			15 00 02 C1 01
+-			15 00 02 C2 18
+-			15 00 02 C3 01
+-			15 00 02 C4 20
+-			15 00 02 C5 01
+-			15 00 02 C6 3D
+-			15 00 02 C7 01
+-			15 00 02 C8 56
+-			15 00 02 C9 01
+-			15 00 02 CA 84
+-			15 00 02 CB 01
+-			15 00 02 CC AB
+-			15 00 02 CD 01
+-			15 00 02 CE EC
+-			15 00 02 CF 02
+-			15 00 02 D0 22
+-			15 00 02 D1 02
+-			15 00 02 D2 23
+-			15 00 02 D3 02
+-			15 00 02 D4 55
+-			15 00 02 D5 02
+-			15 00 02 D6 8B
+-			15 00 02 D7 02
+-			15 00 02 D8 AF
+-			15 00 02 D9 02
+-			15 00 02 DA DF
+-			15 00 02 DB 03
+-			15 00 02 DC 01
+-			15 00 02 DD 03
+-			15 00 02 DE 2C
+-			15 00 02 DF 03
+-			15 00 02 E0 39
+-			15 00 02 E1 03
+-			15 00 02 E2 47
+-			15 00 02 E3 03
+-			15 00 02 E4 56
+-			15 00 02 E5 03
+-			15 00 02 E6 66
+-			15 00 02 E7 03
+-			15 00 02 E8 76
+-			15 00 02 E9 03
+-			15 00 02 EA 85
+-			15 00 02 EB 03
+-			15 00 02 EC 90
+-			15 00 02 ED 03
+-			15 00 02 EE CB
+-			15 00 02 EF 00
+-			15 00 02 F0 BB
+-			15 00 02 F1 00
+-			15 00 02 F2 C0
+-			15 00 02 F3 00
+-			15 00 02 F4 CC
+-			15 00 02 F5 00
+-			15 00 02 F6 D6
+-			15 00 02 F7 00
+-			15 00 02 F8 E1
+-			15 00 02 F9 00
+-			15 00 02 FA EA
+-			15 00 02 FF 02
+-			15 00 02 FB 01
+-			15 00 02 00 00
+-			15 00 02 01 F4
+-			15 00 02 02 00
+-			15 00 02 03 EF
+-			15 00 02 04 01
+-			15 00 02 05 07
+-			15 00 02 06 01
+-			15 00 02 07 28
+-			15 00 02 08 01
+-			15 00 02 09 44
+-			15 00 02 0A 01
+-			15 00 02 0B 76
+-			15 00 02 0C 01
+-			15 00 02 0D A0
+-			15 00 02 0E 01
+-			15 00 02 0F E7
+-			15 00 02 10 02
+-			15 00 02 11 1F
+-			15 00 02 12 02
+-			15 00 02 13 22
+-			15 00 02 14 02
+-			15 00 02 15 54
+-			15 00 02 16 02
+-			15 00 02 17 8B
+-			15 00 02 18 02
+-			15 00 02 19 AF
+-			15 00 02 1A 02
+-			15 00 02 1B E0
+-			15 00 02 1C 03
+-			15 00 02 1D 01
+-			15 00 02 1E 03
+-			15 00 02 1F 2D
+-			15 00 02 20 03
+-			15 00 02 21 39
+-			15 00 02 22 03
+-			15 00 02 23 47
+-			15 00 02 24 03
+-			15 00 02 25 57
+-			15 00 02 26 03
+-			15 00 02 27 65
+-			15 00 02 28 03
+-			15 00 02 29 77
+-			15 00 02 2A 03
+-			15 00 02 2B 85
+-			15 00 02 2D 03
+-			15 00 02 2F 8F
+-			15 00 02 30 03
+-			15 00 02 31 CB
+-			15 00 02 32 00
+-			15 00 02 33 BB
+-			15 00 02 34 00
+-			15 00 02 35 C0
+-			15 00 02 36 00
+-			15 00 02 37 CC
+-			15 00 02 38 00
+-			15 00 02 39 D6
+-			15 00 02 3A 00
+-			15 00 02 3B E1
+-			15 00 02 3D 00
+-			15 00 02 3F EA
+-			15 00 02 40 00
+-			15 00 02 41 F4
+-			15 00 02 42 00
+-			15 00 02 43 FE
+-			15 00 02 44 01
+-			15 00 02 45 07
+-			15 00 02 46 01
+-			15 00 02 47 28
+-			15 00 02 48 01
+-			15 00 02 49 44
+-			15 00 02 4A 01
+-			15 00 02 4B 76
+-			15 00 02 4C 01
+-			15 00 02 4D A0
+-			15 00 02 4E 01
+-			15 00 02 4F E7
+-			15 00 02 50 02
+-			15 00 02 51 1F
+-			15 00 02 52 02
+-			15 00 02 53 22
+-			15 00 02 54 02
+-			15 00 02 55 54
+-			15 00 02 56 02
+-			15 00 02 58 8B
+-			15 00 02 59 02
+-			15 00 02 5A AF
+-			15 00 02 5B 02
+-			15 00 02 5C E0
+-			15 00 02 5D 03
+-			15 00 02 5E 01
+-			15 00 02 5F 03
+-			15 00 02 60 2D
+-			15 00 02 61 03
+-			15 00 02 62 39
+-			15 00 02 63 03
+-			15 00 02 64 47
+-			15 00 02 65 03
+-			15 00 02 66 57
+-			15 00 02 67 03
+-			15 00 02 68 65
+-			15 00 02 69 03
+-			15 00 02 6A 77
+-			15 00 02 6B 03
+-			15 00 02 6C 85
+-			15 00 02 6D 03
+-			15 00 02 6E 8F
+-			15 00 02 6F 03
+-			15 00 02 70 CB
+-			15 00 02 71 00
+-			15 00 02 72 00
+-			15 00 02 73 00
+-			15 00 02 74 21
+-			15 00 02 75 00
+-			15 00 02 76 4C
+-			15 00 02 77 00
+-			15 00 02 78 6B
+-			15 00 02 79 00
+-			15 00 02 7A 85
+-			15 00 02 7B 00
+-			15 00 02 7C 9A
+-			15 00 02 7D 00
+-			15 00 02 7E AD
+-			15 00 02 7F 00
+-			15 00 02 80 BE
+-			15 00 02 81 00
+-			15 00 02 82 CD
+-			15 00 02 83 01
+-			15 00 02 84 01
+-			15 00 02 85 01
+-			15 00 02 86 29
+-			15 00 02 87 01
+-			15 00 02 88 68
+-			15 00 02 89 01
+-			15 00 02 8A 98
+-			15 00 02 8B 01
+-			15 00 02 8C E5
+-			15 00 02 8D 02
+-			15 00 02 8E 1E
+-			15 00 02 8F 02
+-			15 00 02 90 30
+-			15 00 02 91 02
+-			15 00 02 92 52
+-			15 00 02 93 02
+-			15 00 02 94 88
+-			15 00 02 95 02
+-			15 00 02 96 AA
+-			15 00 02 97 02
+-			15 00 02 98 D7
+-			15 00 02 99 02
+-			15 00 02 9A F7
+-			15 00 02 9B 03
+-			15 00 02 9C 21
+-			15 00 02 9D 03
+-			15 00 02 9E 2E
+-			15 00 02 9F 03
+-			15 00 02 A0 3D
+-			15 00 02 A2 03
+-			15 00 02 A3 4C
+-			15 00 02 A4 03
+-			15 00 02 A5 5E
+-			15 00 02 A6 03
+-			15 00 02 A7 71
+-			15 00 02 A9 03
+-			15 00 02 AA 86
+-			15 00 02 AB 03
+-			15 00 02 AC 94
+-			15 00 02 AD 03
+-			15 00 02 AE FA
+-			15 00 02 AF 00
+-			15 00 02 B0 00
+-			15 00 02 B1 00
+-			15 00 02 B2 21
+-			15 00 02 B3 00
+-			15 00 02 B4 4C
+-			15 00 02 B5 00
+-			15 00 02 B6 6B
+-			15 00 02 B7 00
+-			15 00 02 B8 85
+-			15 00 02 B9 00
+-			15 00 02 BA 9A
+-			15 00 02 BB 00
+-			15 00 02 BC AD
+-			15 00 02 BD 00
+-			15 00 02 BE BE
+-			15 00 02 BF 00
+-			15 00 02 C0 CD
+-			15 00 02 C1 01
+-			15 00 02 C2 01
+-			15 00 02 C3 01
+-			15 00 02 C4 29
+-			15 00 02 C5 01
+-			15 00 02 C6 68
+-			15 00 02 C7 01
+-			15 00 02 C8 98
+-			15 00 02 C9 01
+-			15 00 02 CA E5
+-			15 00 02 CB 02
+-			15 00 02 CC 1E
+-			15 00 02 CD 02
+-			15 00 02 CE 20
+-			15 00 02 CF 02
+-			15 00 02 D0 52
+-			15 00 02 D1 02
+-			15 00 02 D2 88
+-			15 00 02 D3 02
+-			15 00 02 D4 AA
+-			15 00 02 D5 02
+-			15 00 02 D6 D7
+-			15 00 02 D7 02
+-			15 00 02 D8 F7
+-			15 00 02 D9 03
+-			15 00 02 DA 21
+-			15 00 02 DB 03
+-			15 00 02 DC 2E
+-			15 00 02 DD 03
+-			15 00 02 DE 3D
+-			15 00 02 DF 03
+-			15 00 02 E0 4C
+-			15 00 02 E1 03
+-			15 00 02 E2 5E
+-			15 00 02 E3 03
+-			15 00 02 E4 71
+-			15 00 02 E5 03
+-			15 00 02 E6 86
+-			15 00 02 E7 03
+-			15 00 02 E8 94
+-			15 00 02 E9 03
+-			15 00 02 EA FA
+-			15 00 02 FF 01
+-			15 00 02 FB 01
+-			15 00 02 FF 02
+-			15 00 02 FB 01
+-			15 00 02 FF 04
+-			15 00 02 FB 01
+-			15 00 02 FF 00
+-			15 00 02 D3 05
+-			15 00 02 D4 04
 +			23 00 02 FE 21
 +			23 00 02 04 00
 +			23 00 02 00 64
@@ -1990,345 +3337,49 @@ index 000000000000..9d041508cac9
 +			23 00 02 51 8F
 +			23 00 02 FE 00
 +			23 00 02 35 00
-+			05 78 01 11
+ 			05 78 01 11
+-			15 00 02 FF 00
+-			15 00 02 35 00
+-			05 0A 01 29
 +			05 1E 01 29
-+		];
-+
-+		panel-exit-sequence = [
+ 		];
+ 
+ 		panel-exit-sequence = [
+-			05 05 01 28
+-			05 78 01 10
 +			05 00 01 28
 +			05 00 01 10
-+		];
-+
-+		disp_timings1: display-timings {
-+			native-mode = <&dsi1_timing0>;
-+			dsi1_timing0: timing0 {
+ 		];
+ 
+ 		disp_timings1: display-timings {
+ 			native-mode = <&dsi1_timing0>;
+ 			dsi1_timing0: timing0 {
+-				clock-frequency = <152198100>;
 +				clock-frequency = <132000000>;
-+				hactive = <1080>;
-+				vactive = <1920>;
+ 				hactive = <1080>;
+ 				vactive = <1920>;
+-				hfront-porch = <104>;
 +				hfront-porch = <15>;
-+				hsync-len = <4>;
+ 				hsync-len = <4>;
+-				hback-porch = <127>;
+-				vfront-porch = <4>;
 +				hback-porch = <30>;
 +				vfront-porch = <15>;
-+				vsync-len = <2>;
+ 				vsync-len = <2>;
+-				vback-porch = <3>;
 +				vback-porch = <15>;
-+				hsync-active = <0>;
-+				vsync-active = <0>;
-+				de-active = <0>;
-+				pixelclk-active = <0>;
-+			};
-+		};
-+
-+		ports {
-+			#address-cells = <1>;
-+			#size-cells = <0>;
-+
-+			port@0 {
-+				reg = <0>;
-+				panel_in_dsi1: endpoint {
-+					remote-endpoint = <&dsi1_out_panel>;
-+				};
-+			};
-+		};
-+	};
-+
-+	ports {
-+		#address-cells = <1>;
-+		#size-cells = <0>;
-+
-+		port@1 {
-+			reg = <1>;
-+			dsi1_out_panel: endpoint {
-+				remote-endpoint = <&panel_in_dsi1>;
-+			};
-+		};
-+	};
-+
-+};
-+
-+&gpu {
-+	mali-supply = <&vdd_gpu_s0>;
-+	mem-supply = <&vdd_gpu_mem_s0>;
-+	status = "okay";
-+};
-+
-+&i2s0_8ch {
-+	status = "okay";
-+	pinctrl-0 = <&i2s0_lrck
-+		     &i2s0_sclk
-+		     &i2s0_sdi0
-+		     &i2s0_sdo0>;
-+};
-+
-+&iep {
-+	status = "okay";
-+};
-+
-+&iep_mmu {
-+	status = "okay";
-+};
-+
-+&jpegd {
-+	status = "okay";
-+};
-+
-+&jpegd_mmu {
-+	status = "okay";
-+};
-+
-+&jpege_ccu {
-+	status = "okay";
-+};
-+
-+&jpege0 {
-+	status = "okay";
-+};
-+
-+&jpege0_mmu {
-+	status = "okay";
-+};
-+
-+&jpege1 {
-+	status = "okay";
-+};
-+
-+&jpege1_mmu {
-+	status = "okay";
-+};
-+
-+&jpege2 {
-+	status = "okay";
-+};
-+
-+&jpege2_mmu {
-+	status = "okay";
-+};
-+
-+&jpege3 {
-+	status = "okay";
-+};
-+
-+&jpege3_mmu {
-+	status = "okay";
-+};
-+
-+&mpp_srv {
-+	status = "okay";
-+};
-+
-+&rga3_core0 {
-+	status = "okay";
-+};
-+
-+&rga3_0_mmu {
-+	status = "okay";
-+};
-+
-+&rga3_core1 {
-+	status = "okay";
-+};
-+
-+&rga3_1_mmu {
-+	status = "okay";
-+};
-+
-+&rga2 {
-+	status = "okay";
-+};
-+
-+&rknpu {
-+	rknpu-supply = <&vdd_npu_s0>;
-+	mem-supply = <&vdd_npu_mem_s0>;
-+	status = "okay";
-+};
-+
-+&rknpu_mmu {
-+	status = "okay";
-+};
-+
-+&rkvdec_ccu {
-+	status = "okay";
-+};
-+
-+&rkvdec0 {
-+	status = "okay";
-+};
-+
-+&rkvdec0_mmu {
-+	status = "okay";
-+};
-+
-+&rkvdec1 {
-+	status = "okay";
-+};
-+
-+&rkvdec1_mmu {
-+	status = "okay";
-+};
-+
-+&rkvenc_ccu {
-+	status = "okay";
-+};
-+
-+&rkvenc0 {
-+	status = "okay";
-+};
-+
-+&rkvenc0_mmu {
-+	status = "okay";
-+};
-+
-+&rkvenc1 {
-+	status = "okay";
-+};
-+
-+&rkvenc1_mmu {
-+	status = "okay";
-+};
-+
-+&rockchip_suspend {
-+	status = "okay";
-+	rockchip,sleep-debug-en = <1>;
-+};
-+
-+&saradc {
-+	status = "okay";
-+	vref-supply = <&vcc_1v8_s0>;
-+};
-+
-+&sdhci {
-+	bus-width = <8>;
-+	no-sdio;
-+	no-sd;
-+	non-removable;
-+	max-frequency = <200000000>;
-+	mmc-hs400-1_8v;
-+	mmc-hs400-enhanced-strobe;
-+	status = "okay";
-+};
-+
-+&sdmmc {
-+	max-frequency = <150000000>;
-+	no-sdio;
-+	no-mmc;
-+	bus-width = <4>;
-+	cap-mmc-highspeed;
-+	cap-sd-highspeed;
-+	disable-wp;
-+	sd-uhs-sdr104;
+ 				hsync-active = <0>;
+ 				vsync-active = <0>;
+ 				de-active = <0>;
+@@ -1589,7 +1032,7 @@ &sdmmc {
+ 	cap-sd-highspeed;
+ 	disable-wp;
+ 	sd-uhs-sdr104;
+-	vmmc-supply = <&vcc_sd>;
 +	vmmc-supply = <&vcc_3v3_sd_s0>;
-+	vqmmc-supply = <&vccio_sd_s0>;
-+	status = "disabled";
-+};
-+
-+&tsadc {
-+	status = "okay";
-+};
-+
-+&u2phy0 {
-+	status = "okay";
-+};
-+
-+&u2phy2 {
-+	status = "okay";
-+};
-+
-+&u2phy3 {
-+	status = "okay";
-+};
-+
-+&u2phy0_otg {
-+	status = "okay";
-+};
-+
-+&u2phy2_host {
-+	status = "okay";
-+};
-+
-+&u2phy3_host {
-+	status = "okay";
-+};
-+
-+&usb_host0_ehci {
-+	status = "okay";
-+};
-+
-+&usb_host0_ohci {
-+	status = "okay";
-+};
-+
-+&usb_host1_ehci {
-+	status = "okay";
-+};
-+
-+&usb_host1_ohci {
-+	status = "okay";
-+};
-+
-+&usbdp_phy0 {
-+	status = "okay";
-+};
-+
-+&usbdp_phy0_dp {
-+	status = "okay";
-+};
-+
-+&usbdp_phy0_u3 {
-+	status = "okay";
-+};
-+
-+&usbdrd3_0 {
-+	status = "okay";
-+};
-+
-+&usbdrd_dwc3_0 {
-+	dr_mode = "otg";
-+	status = "okay";
-+};
-+
-+&usbhost3_0 {
-+	status = "okay";
-+};
-+
-+&usbhost_dwc3_0 {
-+	status = "okay";
-+};
-+
-+&vdpu {
-+	status = "okay";
-+};
-+
-+&vdpu_mmu {
-+	status = "okay";
-+};
-+
-+&vop {
-+	status = "okay";
-+};
-+
-+&vop_mmu {
-+	status = "okay";
-+};
-+
-+/* vp0 & vp1 splice for 8K output */
-+&vp0 {
-+	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER0 | 1 << ROCKCHIP_VOP2_ESMART0)>;
-+	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART0>;
-+};
-+
-+&vp1 {
-+	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER1 | 1 << ROCKCHIP_VOP2_ESMART1)>;
-+	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART1>;
-+};
-+
-+&vp2 {
-+	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER2 | 1 << ROCKCHIP_VOP2_ESMART2)>;
-+	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART2>;
-+};
-+
-+&vp3 {
-+	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER3 | 1 << ROCKCHIP_VOP2_ESMART3)>;
-+	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART3>;
-+};
+ 	vqmmc-supply = <&vccio_sd_s0>;
+ 	status = "disabled";
+ };
 diff --git a/arch/arm64/configs/kedges_defconfig b/arch/arm64/configs/kedges_defconfig
 new file mode 100644
 index 000000000000..e654b39e731e
@@ -2933,8 +3984,7 @@ index 000000000000..e654b39e731e
 -- 
 Armbian
 
-
-From d56f7d22522b9491485b00b6db86d41a150f87bc Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Fri, 13 May 2022 01:15:20 +0800
 Subject: [RPARDINI INTERVENTION TO SEPARATE FILES] arm64: dts: rockchip:
@@ -2943,1252 +3993,10 @@ Subject: [RPARDINI INTERVENTION TO SEPARATE FILES] arm64: dts: rockchip:
 Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
 Change-Id: Idb72870baacbff412a222639c9513ce099789c88
 ---
- arch/arm64/boot/dts/rockchip/rk3588-nvr-demo-khadas-edge2.dtsi     | 832 ++++++++++
- arch/arm64/boot/dts/rockchip/rk3588-rk806-single-khadas-edge2.dtsi | 396 +++++
- arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts              |  65 +-
- arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi             |  12 +-
- 4 files changed, 1303 insertions(+), 2 deletions(-)
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts  | 65 +++++++++-
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi | 12 +-
+ 2 files changed, 75 insertions(+), 2 deletions(-)
 
-diff --git a/arch/arm64/boot/dts/rockchip/rk3588-nvr-demo-khadas-edge2.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-nvr-demo-khadas-edge2.dtsi
-new file mode 100644
-index 000000000000..ea7304d7e60d
---- /dev/null
-+++ b/arch/arm64/boot/dts/rockchip/rk3588-nvr-demo-khadas-edge2.dtsi
-@@ -0,0 +1,832 @@
-+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
-+/*
-+ * Copyright (c) 2021 Rockchip Electronics Co., Ltd.
-+ *
-+ */
-+
-+#include "rk3588.dtsi"
-+#include "rk3588-nvr.dtsi"
-+#include "rk3588-rk806-single.dtsi"
-+
-+/ {
-+	i2s0_sound: i2s0-sound {
-+		status = "okay";
-+		compatible = "simple-audio-card";
-+		simple-audio-card,format = "i2s";
-+		simple-audio-card,mclk-fs = <256>;
-+		simple-audio-card,name = "rockchip,es8311";
-+		simple-audio-card,dai-link@0 {
-+			format = "i2s";
-+			cpu {
-+				sound-dai = <&i2s0_8ch>;
-+			};
-+			codec {
-+				sound-dai = <&es8311>;
-+			};
-+		};
-+	};
-+
-+	leds: leds {
-+		compatible = "gpio-leds";
-+		hdd_led: hdd-led {
-+			gpios = <&gpio3 RK_PC1 GPIO_ACTIVE_HIGH>;
-+			default-state = "off";
-+		};
-+		net_led: net-led {
-+			gpios = <&gpio3 RK_PC0 GPIO_ACTIVE_HIGH>;
-+			default-state = "off";
-+		};
-+		work_led: work-led {
-+			gpios = <&gpio3 RK_PB7 GPIO_ACTIVE_HIGH>;
-+			linux,default-trigger = "heartbeat";
-+		};
-+	};
-+
-+	pcie30_avdd0v75: pcie30-avdd0v75 {
-+		compatible = "regulator-fixed";
-+		regulator-name = "pcie30_avdd0v75";
-+		regulator-boot-on;
-+		regulator-always-on;
-+		regulator-min-microvolt = <750000>;
-+		regulator-max-microvolt = <750000>;
-+		vin-supply = <&vdd_0v75_s0>;
-+	};
-+
-+	pcie30_avdd1v8: pcie30-avdd1v8 {
-+		compatible = "regulator-fixed";
-+		regulator-name = "pcie30_avdd1v8";
-+		regulator-boot-on;
-+		regulator-always-on;
-+		regulator-min-microvolt = <1800000>;
-+		regulator-max-microvolt = <1800000>;
-+		vin-supply = <&avcc_1v8_s0>;
-+	};
-+
-+	vcc12v_dcin: vcc12v-dcin {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc12v_dcin";
-+		regulator-always-on;
-+		regulator-boot-on;
-+		regulator-min-microvolt = <12000000>;
-+		regulator-max-microvolt = <12000000>;
-+	};
-+
-+	vcc3v3_pcie30: vcc3v3-pcie30 {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc3v3_pcie30";
-+		regulator-min-microvolt = <3300000>;
-+		regulator-max-microvolt = <3300000>;
-+		enable-active-high;
-+		gpios = <&gpio3 RK_PD5 GPIO_ACTIVE_HIGH>;
-+		startup-delay-us = <7500>;
-+		vin-supply = <&vcc12v_dcin>;
-+	};
-+
-+	vcc5v0_sys: vcc5v0-sys {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc5v0_sys";
-+		regulator-always-on;
-+		regulator-boot-on;
-+		regulator-min-microvolt = <5000000>;
-+		regulator-max-microvolt = <5000000>;
-+		vin-supply = <&vcc12v_dcin>;
-+	};
-+
-+	vcc5v0_host: vcc5v0-host-regulator {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc5v0_host";
-+		regulator-boot-on;
-+		regulator-always-on;
-+		regulator-min-microvolt = <5000000>;
-+		regulator-max-microvolt = <5000000>;
-+		enable-active-high;
-+		gpio = <&gpio4 RK_PB0 GPIO_ACTIVE_HIGH>;
-+		vin-supply = <&vcc5v0_sys>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&vcc5v0_host_en>;
-+	};
-+
-+	vcc5v0_otg: vcc5v0-otg-regulator {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc5v0_otg";
-+		regulator-min-microvolt = <5000000>;
-+		regulator-max-microvolt = <5000000>;
-+		enable-active-high;
-+		gpio = <&gpio4 RK_PA7 GPIO_ACTIVE_HIGH>;
-+		vin-supply = <&vcc5v0_sys>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&vcc5v0_otg_en>;
-+	};
-+
-+	vcc_1v1_nldo_s3: vcc-1v1-nldo-s3 {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc_1v1_nldo_s3";
-+		regulator-always-on;
-+		regulator-boot-on;
-+		regulator-min-microvolt = <1100000>;
-+		regulator-max-microvolt = <1100000>;
-+		vin-supply = <&vcc5v0_sys>;
-+	};
-+};
-+
-+&combphy0_ps {
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&sata0_pm_reset>;
-+	status = "okay";
-+};
-+
-+&combphy1_ps {
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&sata1_pm_reset>;
-+	status = "okay";
-+};
-+
-+&combphy2_psu {
-+	status = "okay";
-+};
-+
-+&dp0 {
-+	pinctrl-0 = <&dp0m2_pins>;
-+	pinctrl-names = "default";
-+	status = "okay";
-+};
-+
-+&dp0_in_vp0 {
-+	status = "okay";
-+};
-+
-+&dp0_in_vp1 {
-+	status = "okay";
-+};
-+
-+&dp0_in_vp2 {
-+	status = "okay";
-+};
-+
-+&dp1 {
-+	pinctrl-0 = <&dp1m2_pins &dp1_hdmi_ctl>;
-+	pinctrl-names = "default";
-+	status = "okay";
-+};
-+
-+&dp1_in_vp0 {
-+	status = "okay";
-+};
-+
-+&dp1_in_vp1 {
-+	status = "okay";
-+};
-+
-+&dp1_in_vp2 {
-+	status = "okay";
-+};
-+
-+&gmac0 {
-+	/* Use rgmii-rxid mode to disable rx delay inside Soc */
-+	phy-mode = "rgmii-rxid";
-+	clock_in_out = "output";
-+
-+	snps,reset-gpio = <&gpio4 RK_PB3 GPIO_ACTIVE_LOW>;
-+	snps,reset-active-low;
-+	/* Reset time is 20ms, 100ms for rtl8211f */
-+	snps,reset-delays-us = <0 20000 100000>;
-+
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&gmac0_miim
-+		     &gmac0_tx_bus2
-+		     &gmac0_rx_bus2
-+		     &gmac0_rgmii_clk
-+		     &gmac0_rgmii_bus>;
-+
-+	tx_delay = <0x44>;
-+	/* rx_delay = <0x4f>; */
-+
-+	phy-handle = <&rgmii_phy0>;
-+	status = "okay";
-+};
-+
-+&gmac1 {
-+	/* Use rgmii-rxid mode to disable rx delay inside Soc */
-+	phy-mode = "rgmii-rxid";
-+	clock_in_out = "output";
-+
-+	snps,reset-gpio = <&gpio4 RK_PA2 GPIO_ACTIVE_LOW>;
-+	snps,reset-active-low;
-+	/* Reset time is 20ms, 100ms for rtl8211f */
-+	snps,reset-delays-us = <0 20000 100000>;
-+
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&gmac1_miim
-+		     &gmac1_tx_bus2
-+		     &gmac1_rx_bus2
-+		     &gmac1_rgmii_clk
-+		     &gmac1_rgmii_bus>;
-+
-+	tx_delay = <0x42>;
-+	/* rx_delay = <0x4f>; */
-+
-+	phy-handle = <&rgmii_phy1>;
-+	status = "okay";
-+};
-+
-+&hdmi0 {
-+	enable-gpios = <&gpio4 RK_PB1 GPIO_ACTIVE_HIGH>;
-+	status = "okay";
-+};
-+
-+&hdmi0_in_vp0 {
-+	status = "okay";
-+};
-+
-+&hdmi0_in_vp1 {
-+	status = "okay";
-+};
-+
-+&hdmi0_in_vp2 {
-+	status = "okay";
-+};
-+
-+&hdmi0_sound {
-+	status = "okay";
-+};
-+
-+&hdmi1 {
-+	enable-gpios = <&gpio4 RK_PB2 GPIO_ACTIVE_HIGH>;
-+	status = "okay";
-+};
-+
-+&hdmi1_in_vp0 {
-+	status = "okay";
-+};
-+
-+&hdmi1_in_vp1 {
-+	status = "okay";
-+};
-+
-+&hdmi1_in_vp2 {
-+	status = "okay";
-+};
-+
-+&hdmi1_sound {
-+	status = "okay";
-+};
-+
-+&hdptxphy_hdmi0 {
-+	status = "okay";
-+};
-+
-+&hdptxphy_hdmi1 {
-+	status = "okay";
-+};
-+
-+&i2c0 {
-+	status = "okay";
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&i2c0m2_xfer>;
-+
-+	vdd_cpu_big0_s0: vdd_cpu_big0_mem_s0: rk8602@42 {
-+		compatible = "rockchip,rk8602";
-+		reg = <0x42>;
-+		vin-supply = <&vcc5v0_sys>;
-+		regulator-compatible = "rk860x-reg";
-+		regulator-name = "vdd_cpu_big0_s0";
-+		regulator-min-microvolt = <550000>;
-+		regulator-max-microvolt = <1050000>;
-+		regulator-ramp-delay = <2300>;
-+		rockchip,suspend-voltage-selector = <1>;
-+		regulator-boot-on;
-+		regulator-always-on;
-+		regulator-state-mem {
-+			regulator-off-in-suspend;
-+		};
-+	};
-+
-+	vdd_cpu_big1_s0: vdd_cpu_big1_mem_s0: rk8603@43 {
-+		compatible = "rockchip,rk8603";
-+		reg = <0x43>;
-+		vin-supply = <&vcc5v0_sys>;
-+		regulator-compatible = "rk860x-reg";
-+		regulator-name = "vdd_cpu_big1_s0";
-+		regulator-min-microvolt = <550000>;
-+		regulator-max-microvolt = <1050000>;
-+		regulator-ramp-delay = <2300>;
-+		rockchip,suspend-voltage-selector = <1>;
-+		regulator-boot-on;
-+		regulator-always-on;
-+		regulator-state-mem {
-+			regulator-off-in-suspend;
-+		};
-+	};
-+};
-+
-+&i2c2 {
-+	status = "okay";
-+
-+	vdd_npu_s0: vdd_npu_mem_s0: rk8602@42 {
-+		compatible = "rockchip,rk8602";
-+		reg = <0x42>;
-+		vin-supply = <&vcc5v0_sys>;
-+		regulator-compatible = "rk860x-reg";
-+		regulator-name = "vdd_npu_s0";
-+		regulator-min-microvolt = <550000>;
-+		regulator-max-microvolt = <950000>;
-+		regulator-ramp-delay = <2300>;
-+		rockchip,suspend-voltage-selector = <1>;
-+		regulator-boot-on;
-+		regulator-always-on;
-+		regulator-state-mem {
-+			regulator-off-in-suspend;
-+		};
-+	};
-+};
-+
-+&i2c3 {
-+	status = "okay";
-+	es8311: es8311@18 {
-+		status = "okay";
-+		compatible = "everest,es8311";
-+		reg = <0x18>;
-+		#sound-dai-cells = <0>;
-+		adc-pga-gain = <6>;     /* 18dB */
-+		adc-volume = <0xbf>;    /* 0dB */
-+		dac-volume = <0xbf>;    /* 0dB */
-+		aec-mode = "adc left, adc right";
-+		clocks = <&cru I2S0_8CH_MCLKOUT>;
-+		clock-names = "mclk";
-+		assigned-clocks = <&cru I2S0_8CH_MCLKOUT>;
-+		assigned-clock-rates = <12288000>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&i2s0_mclk>;
-+	};
-+};
-+
-+&i2c4 {
-+	status = "okay";
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&i2c4m3_xfer>;
-+};
-+
-+&i2c5 {
-+	status = "okay";
-+};
-+
-+&i2c6 {
-+	status = "okay";
-+	hym8563: hym8563@51 {
-+		compatible = "haoyu,hym8563";
-+		reg = <0x51>;
-+
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&rtc_int>;
-+
-+		interrupt-parent = <&gpio0>;
-+		interrupts = <RK_PB2 IRQ_TYPE_LEVEL_LOW>;
-+		wakeup-source;
-+	};
-+};
-+
-+&i2s0_8ch {
-+	status = "okay";
-+	pinctrl-0 = <&i2s0_lrck
-+		     &i2s0_sclk
-+		     &i2s0_sdi0
-+		     &i2s0_sdo0>;
-+};
-+
-+&i2s5_8ch {
-+	status = "okay";
-+};
-+
-+&i2s6_8ch {
-+	status = "okay";
-+};
-+
-+&mdio0 {
-+	rgmii_phy0: phy@1 {
-+		compatible = "ethernet-phy-ieee802.3-c22";
-+		reg = <0x1>;
-+	};
-+};
-+
-+&mdio1 {
-+	rgmii_phy1: phy@1 {
-+		compatible = "ethernet-phy-ieee802.3-c22";
-+		reg = <0x1>;
-+	};
-+};
-+
-+&pcie30phy {
-+	status = "okay";
-+};
-+
-+&pcie3x4 {
-+	reset-gpios = <&gpio4 RK_PB6 GPIO_ACTIVE_HIGH>;
-+	vpcie3v3-supply = <&vcc3v3_pcie30>;
-+	status = "okay";
-+};
-+
-+&pwm3 {
-+	compatible = "rockchip,remotectl-pwm";
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&pwm3m0_pins>;
-+	remote_pwm_id = <3>;
-+	handle_cpu_id = <1>;
-+	remote_support_psci = <0>;
-+	status = "okay";
-+
-+	ir_key1 {
-+		rockchip,usercode = <0x4040>;
-+		rockchip,key_table =
-+			<0xf2	KEY_REPLY>,
-+			<0xba	KEY_BACK>,
-+			<0xf4	KEY_UP>,
-+			<0xf1	KEY_DOWN>,
-+			<0xef	KEY_LEFT>,
-+			<0xee	KEY_RIGHT>,
-+			<0xbd	KEY_HOME>,
-+			<0xea	KEY_VOLUMEUP>,
-+			<0xe3	KEY_VOLUMEDOWN>,
-+			<0xe2	KEY_SEARCH>,
-+			<0xb2	KEY_POWER>,
-+			<0xbc	KEY_MUTE>,
-+			<0xec	KEY_MENU>,
-+			<0xbf	0x190>,
-+			<0xe0	0x191>,
-+			<0xe1	0x192>,
-+			<0xe9	183>,
-+			<0xe6	248>,
-+			<0xe8	185>,
-+			<0xe7	186>,
-+			<0xf0	388>,
-+			<0xbe	0x175>;
-+	};
-+
-+	ir_key2 {
-+		rockchip,usercode = <0xff00>;
-+		rockchip,key_table =
-+			<0xf9	KEY_HOME>,
-+			<0xbf	KEY_BACK>,
-+			<0xfb	KEY_MENU>,
-+			<0xaa	KEY_REPLY>,
-+			<0xb9	KEY_UP>,
-+			<0xe9	KEY_DOWN>,
-+			<0xb8	KEY_LEFT>,
-+			<0xea	KEY_RIGHT>,
-+			<0xeb	KEY_VOLUMEDOWN>,
-+			<0xef	KEY_VOLUMEUP>,
-+			<0xf7	KEY_MUTE>,
-+			<0xe7	KEY_POWER>,
-+			<0xfc	KEY_POWER>,
-+			<0xa9	KEY_VOLUMEDOWN>,
-+			<0xa8	KEY_PLAYPAUSE>,
-+			<0xe0	KEY_VOLUMEDOWN>,
-+			<0xa5	KEY_VOLUMEDOWN>,
-+			<0xab	183>,
-+			<0xb7	388>,
-+			<0xe8	388>,
-+			<0xf8	184>,
-+			<0xaf	185>,
-+			<0xed	KEY_VOLUMEDOWN>,
-+			<0xee	186>,
-+			<0xb3	KEY_VOLUMEDOWN>,
-+			<0xf1	KEY_VOLUMEDOWN>,
-+			<0xf2	KEY_VOLUMEDOWN>,
-+			<0xf3	KEY_SEARCH>,
-+			<0xb4	KEY_VOLUMEDOWN>,
-+			<0xa4	KEY_SETUP>,
-+			<0xbe	KEY_SEARCH>;
-+	};
-+
-+	ir_key3 {
-+		rockchip,usercode = <0x1dcc>;
-+		rockchip,key_table =
-+			<0xee	KEY_REPLY>,
-+			<0xf0	KEY_BACK>,
-+			<0xf8	KEY_UP>,
-+			<0xbb	KEY_DOWN>,
-+			<0xef	KEY_LEFT>,
-+			<0xed	KEY_RIGHT>,
-+			<0xfc	KEY_HOME>,
-+			<0xf1	KEY_VOLUMEUP>,
-+			<0xfd	KEY_VOLUMEDOWN>,
-+			<0xb7	KEY_SEARCH>,
-+			<0xff	KEY_POWER>,
-+			<0xf3	KEY_MUTE>,
-+			<0xbf	KEY_MENU>,
-+			<0xf9	0x191>,
-+			<0xf5	0x192>,
-+			<0xb3	388>,
-+			<0xbe	KEY_1>,
-+			<0xba	KEY_2>,
-+			<0xb2	KEY_3>,
-+			<0xbd	KEY_4>,
-+			<0xf9	KEY_5>,
-+			<0xb1	KEY_6>,
-+			<0xfc	KEY_7>,
-+			<0xf8	KEY_8>,
-+			<0xb0	KEY_9>,
-+			<0xb6	KEY_0>,
-+			<0xb5	KEY_BACKSPACE>;
-+	};
-+};
-+/*
-+&rk806single {
-+	pinctrl-names = "default", "pmic-power-off";
-+	pinctrl-0 = <&pmic_pins>, <&rk806_dvs1_null>, <&rk806_dvs2_null>, <&rk806_dvs3_null>;
-+	pinctrl-1 = <&rk806_dvs1_slp>, <&rk806_dvs2_null>, <&rk806_dvs3_null>;
-+
-+	regulators {
-+		avcc_1v8_s0: PLDO_REG1 {
-+			regulator-always-on;
-+			regulator-boot-on;
-+			regulator-min-microvolt = <1800000>;
-+			regulator-max-microvolt = <1800000>;
-+			regulator-name = "avcc_1v8_s0";
-+			regulator-state-mem {
-+				regulator-on-in-suspend;
-+				regulator-suspend-microvolt = <1800000>;
-+			};
-+		};
-+	};
-+};
-+*/
-+&rockchip_suspend {
-+	status = "okay";
-+	rockchip,sleep-debug-en = <1>;
-+	rockchip,virtual-poweroff = <1>;
-+	rockchip,sleep-mode-config = <
-+		(0
-+		| RKPM_SLP_ARMOFF_DDRPD
-+		)
-+	>;
-+	rockchip,wakeup-config = <
-+		(0
-+		| RKPM_CPU0_WKUP_EN
-+		| RKPM_GPIO_WKUP_EN
-+		)
-+	>;
-+};
-+
-+&route_dp0 {
-+	status = "okay";
-+	force-output;
-+	connect = <&vp2_out_dp0>;
-+
-+	force_timing {
-+		clock-frequency = <65000000>;
-+		hactive = <1024>;
-+		vactive = <768>;
-+		hfront-porch = <24>;
-+		hsync-len = <136>;
-+		hback-porch = <160>;
-+		vfront-porch = <3>;
-+		vsync-len = <6>;
-+		vback-porch = <29>;
-+		hsync-active = <0>;
-+		vsync-active = <0>;
-+		de-active = <0>;
-+		pixelclk-active = <0>;
-+	};
-+
-+};
-+
-+&route_dp1 {
-+	status = "okay";
-+	force-output;
-+	connect = <&vp2_out_dp1>;
-+
-+	force_timing {
-+		clock-frequency = <65000000>;
-+		hactive = <1024>;
-+		vactive = <768>;
-+		hfront-porch = <24>;
-+		hsync-len = <136>;
-+		hback-porch = <160>;
-+		vfront-porch = <3>;
-+		vsync-len = <6>;
-+		vback-porch = <29>;
-+		hsync-active = <0>;
-+		vsync-active = <0>;
-+		de-active = <0>;
-+		pixelclk-active = <0>;
-+	};
-+
-+};
-+
-+&route_hdmi0 {
-+	status = "okay";
-+	force-output;
-+	connect = <&vp2_out_hdmi0>;
-+
-+	force_timing {
-+		clock-frequency = <65000000>;
-+		hactive = <1024>;
-+		vactive = <768>;
-+		hfront-porch = <24>;
-+		hsync-len = <136>;
-+		hback-porch = <160>;
-+		vfront-porch = <3>;
-+		vsync-len = <6>;
-+		vback-porch = <29>;
-+		hsync-active = <0>;
-+		vsync-active = <0>;
-+		de-active = <0>;
-+		pixelclk-active = <0>;
-+	};
-+
-+};
-+
-+&route_hdmi1 {
-+	status = "okay";
-+	force-output;
-+	connect = <&vp2_out_hdmi1>;
-+
-+	force_timing {
-+		clock-frequency = <65000000>;
-+		hactive = <1024>;
-+		vactive = <768>;
-+		hfront-porch = <24>;
-+		hsync-len = <136>;
-+		hback-porch = <160>;
-+		vfront-porch = <3>;
-+		vsync-len = <6>;
-+		vback-porch = <29>;
-+		hsync-active = <0>;
-+		vsync-active = <0>;
-+		de-active = <0>;
-+		pixelclk-active = <0>;
-+	};
-+
-+};
-+
-+&sata0 {
-+	status = "okay";
-+};
-+
-+&sata1 {
-+	status = "okay";
-+};
-+
-+&sdhci {
-+	bus-width = <8>;
-+	no-sdio;
-+	no-sd;
-+	non-removable;
-+	max-frequency = <200000000>;
-+	mmc-hs400-1_8v;
-+	mmc-hs400-enhanced-strobe;
-+	status = "okay";
-+};
-+
-+&pinctrl {
-+	dp {
-+		dp1_hdmi_ctl: dp-hdmi-ctl {
-+			rockchip,pins = <0 RK_PD5 RK_FUNC_GPIO &pcfg_pull_up>,
-+					<3 RK_PB2 RK_FUNC_GPIO &pcfg_pull_up>;
-+		};
-+	};
-+
-+	rtc {
-+		rtc_int: rtc-int {
-+			rockchip,pins = <0 RK_PB2 RK_FUNC_GPIO &pcfg_pull_up>;
-+		};
-+	};
-+
-+	usb {
-+		vcc5v0_host_en: vcc5v0-host-en {
-+			rockchip,pins = <4 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+
-+		vcc5v0_otg_en: vcc5v0-otg-en {
-+			rockchip,pins = <4 RK_PA7 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+
-+	sata {
-+		sata0_pm_reset: sata0-pm-reset {
-+			rockchip,pins = <4 RK_PA0 RK_FUNC_GPIO &pcfg_output_high>;
-+		};
-+		sata1_pm_reset: sata1-pm-reset {
-+			rockchip,pins = <4 RK_PA1 RK_FUNC_GPIO &pcfg_output_high>;
-+		};
-+	};
-+};
-+
-+&u2phy0 {
-+	status = "okay";
-+};
-+
-+&u2phy1 {
-+	status = "okay";
-+};
-+
-+&u2phy2 {
-+	status = "okay";
-+};
-+
-+&u2phy3 {
-+	status = "okay";
-+};
-+
-+&u2phy0_otg {
-+	vbus-supply = <&vcc5v0_otg>;
-+	status = "okay";
-+};
-+
-+&u2phy1_otg {
-+	phy-supply = <&vcc5v0_host>;
-+	status = "okay";
-+};
-+
-+&u2phy2_host {
-+	phy-supply = <&vcc5v0_host>;
-+	status = "okay";
-+};
-+
-+&u2phy3_host {
-+	phy-supply = <&vcc5v0_host>;
-+	status = "okay";
-+};
-+
-+&usb_host0_ehci {
-+	status = "okay";
-+};
-+
-+&usb_host0_ohci {
-+	status = "okay";
-+};
-+
-+&usb_host1_ehci {
-+	status = "okay";
-+};
-+
-+&usb_host1_ohci {
-+	status = "okay";
-+};
-+
-+&usbdp_phy0 {
-+	rockchip,dp-lane-mux = < 2 3 >;
-+	status = "okay";
-+};
-+
-+&usbdp_phy0_dp {
-+	status = "okay";
-+};
-+
-+&usbdp_phy0_u3 {
-+	status = "okay";
-+};
-+
-+&usbdp_phy1 {
-+	rockchip,dp-lane-mux = < 0 1 2 3 >;
-+	status = "okay";
-+};
-+
-+&usbdp_phy1_dp {
-+	status = "okay";
-+};
-+
-+&usbdp_phy1_u3 {
-+	maximum-speed = "high-speed";
-+	status = "okay";
-+};
-+
-+&usbdrd3_0 {
-+	status = "okay";
-+};
-+
-+&usbdrd3_1 {
-+	status = "okay";
-+};
-+
-+&usbdrd_dwc3_0 {
-+	dr_mode = "peripheral";
-+	status = "okay";
-+};
-+
-+&usbdrd_dwc3_1 {
-+	dr_mode = "host";
-+	maximum-speed = "high-speed";
-+	status = "okay";
-+};
-+
-+&usbhost3_0 {
-+	status = "okay";
-+};
-+
-+&usbhost_dwc3_0 {
-+	dr_mode = "host";
-+	status = "okay";
-+};
-+
-+&vdd_log_s0 {
-+	regulator-state-mem {
-+		regulator-on-in-suspend;
-+		regulator-suspend-microvolt = <750000>;
-+	};
-+};
-+
-+&vdd_vdenc_s0 {
-+	regulator-init-microvolt = <750000>;
-+};
-+
-diff --git a/arch/arm64/boot/dts/rockchip/rk3588-rk806-single-khadas-edge2.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-rk806-single-khadas-edge2.dtsi
-new file mode 100644
-index 000000000000..a65a39564ba2
---- /dev/null
-+++ b/arch/arm64/boot/dts/rockchip/rk3588-rk806-single-khadas-edge2.dtsi
-@@ -0,0 +1,396 @@
-+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
-+/*
-+ * Copyright (c) 2022 Wesion Technology Co., Ltd.
-+ *
-+ */
-+
-+#include <dt-bindings/gpio/gpio.h>
-+#include <dt-bindings/pinctrl/rockchip.h>
-+
-+&spi2 {
-+	status = "okay";
-+	assigned-clocks = <&cru CLK_SPI2>;
-+	assigned-clock-rates = <200000000>;
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&spi2m2_cs0 &spi2m2_pins>;
-+	num-cs = <1>;
-+
-+	rk806single: rk806single@0 {
-+		compatible = "rockchip,rk806";
-+		spi-max-frequency = <1000000>;
-+		reg = <0x0>;
-+
-+		interrupt-parent = <&gpio0>;
-+		interrupts = <7 IRQ_TYPE_LEVEL_LOW>;
-+
-+		pinctrl-names = "default", "pmic-power-off";
-+		pinctrl-0 = <&pmic_pins>, <&rk806_dvs1_null>, <&rk806_dvs2_null>, <&rk806_dvs3_null>;
-+		pinctrl-1 = <&rk806_dvs1_pwrdn>;
-+
-+		/* 2800mv-3500mv */
-+		low_voltage_threshold = <3000>;
-+		/* 2700mv-3400mv */
-+		shutdown_voltage_threshold = <2700>;
-+		/* 140 160 */
-+		shutdown_temperture_threshold = <160>;
-+		hotdie_temperture_threshold = <115>;
-+
-+		/* 0: restart PMU;
-+		 * 1: reset all the power off reset registers,
-+		 *    forcing the state to switch to ACTIVE mode;
-+		 * 2: Reset all the power off reset registers,
-+		 *    forcing the state to switch to ACTIVE mode,
-+		 *    and simultaneously pull down the RESETB PIN for 5mS before releasing
-+		 */
-+		pmic-reset-func = <1>;
-+
-+		vcc1-supply = <&vcc5v0_sys>;
-+		vcc2-supply = <&vcc5v0_sys>;
-+		vcc3-supply = <&vcc5v0_sys>;
-+		vcc4-supply = <&vcc5v0_sys>;
-+		vcc5-supply = <&vcc5v0_sys>;
-+		vcc6-supply = <&vcc5v0_sys>;
-+		vcc7-supply = <&vcc5v0_sys>;
-+		vcc8-supply = <&vcc5v0_sys>;
-+		vcc9-supply = <&vcc5v0_sys>;
-+		vcc10-supply = <&vcc5v0_sys>;
-+		vcc11-supply = <&vcc_2v0_pldo_s3>;
-+		vcc12-supply = <&vcc5v0_sys>;
-+		vcc13-supply = <&vcc_1v1_nldo_s3>;
-+		vcc14-supply = <&vcc_1v1_nldo_s3>;
-+		vcca-supply = <&vcc5v0_sys>;
-+
-+		pwrkey {
-+			status = "okay";
-+		};
-+
-+		pinctrl_rk806: pinctrl_rk806 {
-+			gpio-controller;
-+			#gpio-cells = <2>;
-+
-+			rk806_dvs1_null: rk806_dvs1_null {
-+				pins = "gpio_pwrctrl2";
-+				function = "pin_fun0";
-+			};
-+
-+			rk806_dvs1_slp: rk806_dvs1_slp {
-+				pins = "gpio_pwrctrl1";
-+				function = "pin_fun1";
-+			};
-+
-+			rk806_dvs1_pwrdn: rk806_dvs1_pwrdn {
-+				pins = "gpio_pwrctrl1";
-+				function = "pin_fun2";
-+			};
-+
-+			rk806_dvs1_rst: rk806_dvs1_rst {
-+				pins = "gpio_pwrctrl1";
-+				function = "pin_fun3";
-+			};
-+
-+			rk806_dvs2_null: rk806_dvs2_null {
-+				pins = "gpio_pwrctrl2";
-+				function = "pin_fun0";
-+			};
-+
-+			rk806_dvs2_slp: rk806_dvs2_slp {
-+				pins = "gpio_pwrctrl2";
-+				function = "pin_fun1";
-+			};
-+
-+			rk806_dvs2_pwrdn: rk806_dvs2_pwrdn {
-+				pins = "gpio_pwrctrl2";
-+				function = "pin_fun2";
-+			};
-+
-+			rk806_dvs2_rst: rk806_dvs2_rst {
-+				pins = "gpio_pwrctrl2";
-+				function = "pin_fun3";
-+			};
-+
-+			rk806_dvs2_dvs: rk806_dvs2_dvs {
-+				pins = "gpio_pwrctrl2";
-+				function = "pin_fun4";
-+			};
-+
-+			rk806_dvs2_gpio: rk806_dvs2_gpio {
-+				pins = "gpio_pwrctrl2";
-+				function = "pin_fun5";
-+			};
-+
-+			rk806_dvs3_null: rk806_dvs3_null {
-+				pins = "gpio_pwrctrl3";
-+				function = "pin_fun0";
-+			};
-+
-+			rk806_dvs3_slp: rk806_dvs3_slp {
-+				pins = "gpio_pwrctrl3";
-+				function = "pin_fun1";
-+			};
-+
-+			rk806_dvs3_pwrdn: rk806_dvs3_pwrdn {
-+				pins = "gpio_pwrctrl3";
-+				function = "pin_fun2";
-+			};
-+
-+			rk806_dvs3_rst: rk806_dvs3_rst {
-+				pins = "gpio_pwrctrl3";
-+				function = "pin_fun3";
-+			};
-+
-+			rk806_dvs3_dvs: rk806_dvs3_dvs {
-+				pins = "gpio_pwrctrl3";
-+				function = "pin_fun4";
-+			};
-+
-+			rk806_dvs3_gpio: rk806_dvs3_gpio {
-+				pins = "gpio_pwrctrl3";
-+				function = "pin_fun5";
-+			};
-+		};
-+
-+		regulators {
-+			vdd_gpu_s0: vdd_gpu_mem_s0: DCDC_REG1 {
-+				regulator-boot-on;
-+				regulator-min-microvolt = <550000>;
-+				regulator-max-microvolt = <950000>;
-+				regulator-ramp-delay = <12500>;
-+				regulator-name = "vdd_gpu_s0";
-+				regulator-enable-ramp-delay = <400>;
-+				regulator-state-mem {
-+					regulator-off-in-suspend;
-+				};
-+			};
-+
-+			vdd_cpu_lit_s0: vdd_cpu_lit_mem_s0: DCDC_REG2 {
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-min-microvolt = <550000>;
-+				regulator-max-microvolt = <950000>;
-+				regulator-ramp-delay = <12500>;
-+				regulator-name = "vdd_cpu_lit_s0";
-+				regulator-state-mem {
-+					regulator-off-in-suspend;
-+				};
-+			};
-+
-+			vdd_log_s0: DCDC_REG3 {
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-min-microvolt = <675000>;
-+				regulator-max-microvolt = <750000>;
-+				regulator-ramp-delay = <12500>;
-+				regulator-name = "vdd_log_s0";
-+				regulator-state-mem {
-+					regulator-off-in-suspend;
-+					regulator-suspend-microvolt = <750000>;
-+				};
-+			};
-+
-+			vdd_vdenc_s0: vdd_vdenc_mem_s0: DCDC_REG4 {
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-min-microvolt = <550000>;
-+				regulator-max-microvolt = <950000>;
-+				regulator-init-microvolt = <750000>;
-+				regulator-ramp-delay = <12500>;
-+				regulator-name = "vdd_vdenc_s0";
-+				regulator-state-mem {
-+					regulator-off-in-suspend;
-+				};
-+			};
-+
-+			vdd_ddr_s0: DCDC_REG5 {
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-min-microvolt = <675000>;
-+				regulator-max-microvolt = <900000>;
-+				regulator-ramp-delay = <12500>;
-+				regulator-name = "vdd_ddr_s0";
-+				regulator-state-mem {
-+					regulator-off-in-suspend;
-+					regulator-suspend-microvolt = <850000>;
-+				};
-+			};
-+
-+			vdd2_ddr_s3: DCDC_REG6 {
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-name = "vdd2_ddr_s3";
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+				};
-+			};
-+
-+			vcc_2v0_pldo_s3: DCDC_REG7 {
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-min-microvolt = <2000000>;
-+				regulator-max-microvolt = <2000000>;
-+				regulator-name = "vdd_2v0_pldo_s3";
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <2000000>;
-+				};
-+			};
-+
-+			vcc_3v3_s3: DCDC_REG8 {
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-min-microvolt = <3300000>;
-+				regulator-max-microvolt = <3300000>;
-+				regulator-name = "vcc_3v3_s3";
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <3300000>;
-+				};
-+			};
-+
-+			vddq_ddr_s0: DCDC_REG9 {
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-name = "vddq_ddr_s0";
-+				regulator-state-mem {
-+					regulator-off-in-suspend;
-+				};
-+			};
-+
-+			vcc_1v8_s3: DCDC_REG10 {
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-min-microvolt = <1800000>;
-+				regulator-max-microvolt = <1800000>;
-+				regulator-name = "vcc_1v8_s3";
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <1800000>;
-+				};
-+			};
-+
-+			avcc_1v8_s0: PLDO_REG2 {
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-min-microvolt = <1800000>;
-+				regulator-max-microvolt = <1800000>;
-+				regulator-name = "avcc_1v8_s0";
-+				regulator-state-mem {
-+					regulator-off-in-suspend;
-+				};
-+			};
-+
-+			vcc_1v8_s0: PLDO_REG1 {
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-min-microvolt = <1800000>;
-+				regulator-max-microvolt = <1800000>;
-+				regulator-name = "vcc_1v8_s0";
-+				regulator-state-mem {
-+					regulator-off-in-suspend;
-+					regulator-suspend-microvolt = <1800000>;
-+				};
-+			};
-+
-+			avdd_1v2_s0: PLDO_REG3 {
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-min-microvolt = <1200000>;
-+				regulator-max-microvolt = <1200000>;
-+				regulator-name = "avdd_1v2_s0";
-+				regulator-state-mem {
-+					regulator-off-in-suspend;
-+				};
-+			};
-+
-+			vcc_3v3_s0: PLDO_REG4 {
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-min-microvolt = <3300000>;
-+				regulator-max-microvolt = <3300000>;
-+				regulator-name = "vcc_3v3_s0";
-+				regulator-state-mem {
-+					regulator-off-in-suspend;
-+				};
-+			};
-+
-+			vccio_sd_s0: PLDO_REG5 {
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-min-microvolt = <1800000>;
-+				regulator-max-microvolt = <3300000>;
-+				regulator-name = "vccio_sd_s0";
-+				regulator-state-mem {
-+					regulator-off-in-suspend;
-+				};
-+			};
-+
-+			pldo6_s3: PLDO_REG6 {
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-min-microvolt = <1800000>;
-+				regulator-max-microvolt = <1800000>;
-+				regulator-name = "pldo6_s3";
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <1800000>;
-+				};
-+			};
-+
-+			vdd_0v75_s3: NLDO_REG1 {
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-min-microvolt = <750000>;
-+				regulator-max-microvolt = <750000>;
-+				regulator-name = "vdd_0v75_s3";
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <750000>;
-+				};
-+			};
-+
-+			vdd_ddr_pll_s0: NLDO_REG2 {
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-min-microvolt = <850000>;
-+				regulator-max-microvolt = <850000>;
-+				regulator-name = "vdd_ddr_pll_s0";
-+				regulator-state-mem {
-+					regulator-off-in-suspend;
-+					regulator-suspend-microvolt = <850000>;
-+				};
-+			};
-+
-+			avdd_0v75_s0: NLDO_REG3 {
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-min-microvolt = <837500>;
-+				regulator-max-microvolt = <837500>;
-+				regulator-name = "avdd_0v75_s0";
-+				regulator-state-mem {
-+					regulator-off-in-suspend;
-+				};
-+			};
-+
-+			vdd_0v85_s0: NLDO_REG4 {
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-min-microvolt = <850000>;
-+				regulator-max-microvolt = <850000>;
-+				regulator-name = "vdd_0v85_s0";
-+				regulator-state-mem {
-+					regulator-off-in-suspend;
-+				};
-+			};
-+
-+			vdd_0v75_s0: NLDO_REG5 {
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-min-microvolt = <750000>;
-+				regulator-max-microvolt = <750000>;
-+				regulator-name = "vdd_0v75_s0";
-+				regulator-state-mem {
-+					regulator-off-in-suspend;
-+				};
-+			};
-+		};
-+	};
-+};
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
 index 91ce4c575d14..ee2589a4616a 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
@@ -4305,8 +4113,7 @@ index 9d041508cac9..b2e4026031ea 100644
 -- 
 Armbian
 
-
-From ebe4239f0eb65c95e41f5e8ef74ab4c31dde730b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Fri, 13 May 2022 10:03:09 +0800
 Subject: arm64: dts: rockchip: Edge2: fix sdmmc
@@ -4383,8 +4190,7 @@ index b2e4026031ea..b00639cf0db5 100644
 -- 
 Armbian
 
-
-From bc0f95e09ca28f0440615964432dd3763498e4f4 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Tue, 19 Jul 2022 09:14:20 +0800
 Subject: arm64: dts: rockchip: Edge2: HDMI: support HDMI display
@@ -4596,8 +4402,7 @@ index a5cc248b2866..347f8168602b 100644
 -- 
 Armbian
 
-
-From 2d0479c0a4a27a4b42bf099821071c026b6534de Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Mon, 16 May 2022 17:25:26 +0800
 Subject: arm64: dts: rockchip: Edge2: add spi flash NOR support
@@ -4628,8 +4433,7 @@ index 347f8168602b..3dd02f8d37c2 100644
 -- 
 Armbian
 
-
-From ef78208359a0635549879e46dea0aae9743c2ab2 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Tue, 17 May 2022 10:07:55 +0800
 Subject: arm64: dts: rockchip: Edge2: support fusb302
@@ -4668,8 +4472,7 @@ index 3dd02f8d37c2..d7841afbd2f7 100644
 -- 
 Armbian
 
-
-From 05b865db3a1b549a04ec983c036bab6fa301ae90 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Tue, 17 May 2022 10:49:51 +0800
 Subject: arm64: dts: rockchip: Edge2: enable usb host power
@@ -4705,8 +4508,7 @@ index d7841afbd2f7..b9870eb92632 100644
 -- 
 Armbian
 
-
-From 1e749bb345578ec37e53796ed0ba514bc3c04145 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Tue, 17 May 2022 11:09:12 +0800
 Subject: arm64: dts: rockchip: Edge2: USB: fix USB host 3.0
@@ -4748,8 +4550,7 @@ index b9870eb92632..0eb33d5d1a6d 100644
 -- 
 Armbian
 
-
-From 5ee16d7d44c36e7881af30fc2610c9cd04480242 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Tue, 17 May 2022 11:22:29 +0800
 Subject: arm64: dts: rockchip: Edge2: support TYPEC0
@@ -4812,8 +4613,7 @@ index 0eb33d5d1a6d..eb46232340e5 100644
 -- 
 Armbian
 
-
-From 7c05cbfdd7c317bf661538a89ea988ec06cd5873 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Thu, 19 May 2022 11:52:17 +0800
 Subject: arm64: dts: rockchip: Edge2: RTC: support PT7C4363
@@ -4872,8 +4672,7 @@ index eb46232340e5..461492d48c12 100644
 -- 
 Armbian
 
-
-From 911fa11cb23b3bf9dde93ef902b3eb6c92d61398 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Tue, 17 May 2022 16:19:29 +0800
 Subject: arm64: rockchip: Edge2: supoort AP6275P wifi and bt
@@ -4985,23 +4784,19 @@ index e654b39e731e..31c282f08e70 100644
 -- 
 Armbian
 
-
-From 84c535f0c96ed5b7d34137c9ec6f31cca09464df Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
-Date: Tue, 17 May 2022 18:20:01 +0800
-Subject: Edge2: gsensor: support kxtj3 driver
+Date: Tue, 17 May 2022 19:14:32 +0800
+Subject: arm64: dts: rockchip: Edge2: enable spi1
 
 Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
-Change-Id: I68fd23ad2ec9121967b1d50f7f508bf263ce25d2
+Change-Id: Ife106f2b4eaefc947aba04aee81e93460d56c90a
 ---
- arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 11 ++++++
- arch/arm64/configs/kedges_defconfig                   |  3 ++
- drivers/input/sensors/accel/kxtj9.c                   | 18 ++++++++--
- drivers/input/sensors/sensor-dev.c                    |  2 +-
- 4 files changed, 30 insertions(+), 4 deletions(-)
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 23 ++++++++++
+ 1 file changed, 23 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
-index 76235fa01710..3e891b324247 100644
+index 76235fa01710..0e3b5b10dd83 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
 @@ -307,6 +307,17 @@ regulator-state-mem {
@@ -5022,131 +4817,7 @@ index 76235fa01710..3e891b324247 100644
  	es8388: es8388@11 {
  		status = "okay";
  		#sound-dai-cells = <0>;
-diff --git a/arch/arm64/configs/kedges_defconfig b/arch/arm64/configs/kedges_defconfig
-index 31c282f08e70..ac5ba22fa5e7 100644
---- a/arch/arm64/configs/kedges_defconfig
-+++ b/arch/arm64/configs/kedges_defconfig
-@@ -202,6 +202,9 @@ CONFIG_TOUCHSCREEN_ELAN=y
- CONFIG_TOUCHSCREEN_USB_COMPOSITE=y
- CONFIG_ROCKCHIP_REMOTECTL=y
- CONFIG_ROCKCHIP_REMOTECTL_PWM=y
-+CONFIG_SENSOR_DEVICE=y
-+CONFIG_GSENSOR_DEVICE=y
-+CONFIG_GS_KXTJ9=y
- CONFIG_INPUT_MISC=y
- CONFIG_INPUT_UINPUT=y
- CONFIG_INPUT_RK805_PWRKEY=y
-diff --git a/drivers/input/sensors/accel/kxtj9.c b/drivers/input/sensors/accel/kxtj9.c
-index 4726c5f73b54..116f7b605d74 100644
---- a/drivers/input/sensors/accel/kxtj9.c
-+++ b/drivers/input/sensors/accel/kxtj9.c
-@@ -32,6 +32,7 @@
- #include <linux/sensor-dev.h>
- 
- 
-+#define KXTJ3_DEVID 0x35 //KXTJ3 id
- #define KXTJ9_DEVID	0x09	//chip id
- #define KXTJ9_RANGE	(2 * 16384)
- 
-@@ -78,6 +79,7 @@
- /* CONTROL REGISTER 1 BITS */
- #define KXTJ9_DISABLE			0x7F
- #define KXTJ9_ENABLE			(1 << 7)
-+#define KXTJ3_INT_ENABLE               (1 << 5)
- /* INPUT_ABS CONSTANTS */
- #define FUZZ			3
- #define FLAT			3
-@@ -109,6 +111,7 @@
- #define KXTJ9_PRECISION       12
- #define KXTJ9_BOUNDARY        (0x1 << (KXTJ9_PRECISION - 1))
- #define KXTJ9_GRAVITY_STEP    KXTJ9_RANGE / KXTJ9_BOUNDARY
-+#define KXTJ3_GRAVITY_STEP    KXTJ9_RANGE / KXTJ9_BOUNDARY
- 
- 
- /****************operate according to sensor chip:start************/
-@@ -176,6 +179,9 @@ static int sensor_init(struct i2c_client *client)
- 	}
- 	
- 	sensor->ops->ctrl_data = (KXTJ9_RES_12BIT | KXTJ9_G_2G);
-+	if(sensor->pdata->irq_enable)
-+		sensor->ops->ctrl_data |= KXTJ3_INT_ENABLE;
-+
- 	result = sensor_write_reg(client, sensor->ops->ctrl_reg, sensor->ops->ctrl_data);
- 	if(result)
- 	{
-@@ -192,7 +198,12 @@ static short sensor_convert_data(struct i2c_client *client, char high_byte, char
- 	struct sensor_private_data *sensor =
- 	    (struct sensor_private_data *) i2c_get_clientdata(client);	
- 	//int precision = sensor->ops->precision;
--	switch (sensor->devid) {	
-+	switch (sensor->devid) {
-+		case KXTJ3_DEVID:
-+			result = (((short)high_byte << 8) | ((short)low_byte)) >> 4;
-+			result *= KXTJ3_GRAVITY_STEP;
-+			break;
-+
- 		case KXTJ9_DEVID:		
- 			result = (((short)high_byte << 8) | ((short)low_byte)) >> 4;
- 			result *= KXTJ9_GRAVITY_STEP;
-@@ -284,7 +295,7 @@ static struct sensor_operate gsensor_kxtj9_ops = {
- 	.read_reg			= KXTJ9_XOUT_L,
- 	.read_len			= 6,
- 	.id_reg			= KXTJ9_WHO_AM_I,
--	.id_data			= KXTJ9_DEVID,
-+	.id_data			= KXTJ3_DEVID,
- 	.precision			= KXTJ9_PRECISION,
- 	.ctrl_reg			= KXTJ9_CTRL_REG1,
- 	.int_status_reg	= KXTJ9_INT_REL,
-@@ -309,6 +320,7 @@ static int gsensor_kxtj9_remove(struct i2c_client *client)
- 
- static const struct i2c_device_id gsensor_kxtj9_id[] = {
- 	{"gs_kxtj9", ACCEL_ID_KXTJ9},
-+	{"gs_kxtj3", ACCEL_ID_KXTJ9},
- 	{}
- };
- 
-@@ -318,7 +330,7 @@ static struct i2c_driver gsensor_kxtj9_driver = {
- 	.shutdown = sensor_shutdown,
- 	.id_table = gsensor_kxtj9_id,
- 	.driver = {
--		.name = "gsensor_kxtj9",
-+		.name = "gsensor_kxtj3",
- 	#ifdef CONFIG_PM
- 		.pm = &sensor_pm_ops,
- 	#endif
-diff --git a/drivers/input/sensors/sensor-dev.c b/drivers/input/sensors/sensor-dev.c
-index eb93e19157ea..1c873d3c1b15 100644
---- a/drivers/input/sensors/sensor-dev.c
-+++ b/drivers/input/sensors/sensor-dev.c
-@@ -1447,7 +1447,7 @@ static int sensor_misc_device_register(struct sensor_private_data *sensor, int t
- 			sensor->fops.release = gsensor_dev_release;
- 
- 			sensor->miscdev.minor = MISC_DYNAMIC_MINOR;
--			sensor->miscdev.name = "mma8452_daemon";
-+			sensor->miscdev.name = "accel";
- 			sensor->miscdev.fops = &sensor->fops;
- 		} else {
- 			memcpy(&sensor->miscdev, sensor->ops->misc_dev, sizeof(*sensor->ops->misc_dev));
--- 
-Armbian
-
-
-From 878771cb9829d0be036ad277e9c603787d7f23d7 Mon Sep 17 00:00:00 2001
-From: Jack Zhao <jack.zhao@wesion.com>
-Date: Tue, 17 May 2022 19:14:32 +0800
-Subject: arm64: dts: rockchip: Edge2: enable spi1
-
-Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
-Change-Id: Ife106f2b4eaefc947aba04aee81e93460d56c90a
----
- arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 12 ++++++++++
- 1 file changed, 12 insertions(+)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
-index 3e891b324247..0e3b5b10dd83 100644
---- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
-+++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
-@@ -739,6 +739,18 @@ &spdif_tx2 {
+@@ -728,6 +739,18 @@ &spdif_tx2 {
  	status = "okay";
  };
  
@@ -5168,51 +4839,7 @@ index 3e891b324247..0e3b5b10dd83 100644
 -- 
 Armbian
 
-
-From 5ea47dc6271a6fe972de70b51d64072be1a796db Mon Sep 17 00:00:00 2001
-From: Jack Zhao <jack.zhao@wesion.com>
-Date: Tue, 17 May 2022 20:02:54 +0800
-Subject: Edge2: add reboot test mode
-
-Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
-Change-Id: If1f11a39f7be7f6f6f662359a4e388fe934e2ef4
----
- arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 4 ++++
- include/dt-bindings/soc/rockchip,boot-mode.h          | 3 ++-
- 2 files changed, 6 insertions(+), 1 deletion(-)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
-index 0e3b5b10dd83..551d4ad67017 100644
---- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
-+++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
-@@ -304,6 +304,10 @@ regulator-state-mem {
- 
- };
- 
-+&reboot_mode {
-+	mode-reboot_test = <BOOT_REBOOT_TEST>;
-+};
-+
- &i2c3 {
- 	status = "okay";
- 
-diff --git a/include/dt-bindings/soc/rockchip,boot-mode.h b/include/dt-bindings/soc/rockchip,boot-mode.h
-index 1436e1d32619..c617db54b09c 100644
---- a/include/dt-bindings/soc/rockchip,boot-mode.h
-+++ b/include/dt-bindings/soc/rockchip,boot-mode.h
-@@ -20,5 +20,6 @@
- #define BOOT_CHARGING		(REBOOT_FLAG + 11)
- /* enter usb mass storage mode */
- #define BOOT_UMS		(REBOOT_FLAG + 12)
--
-+/* enter reboot test mode */
-+#define BOOT_REBOOT_TEST        (REBOOT_FLAG + 14)
- #endif
--- 
-Armbian
-
-
-From 0a75614de22c821085e261e49d9fad48f191e935 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Tue, 17 May 2022 20:07:27 +0800
 Subject: arm64: dts: rockchip: Edge2: Key: configure fun key as home key
@@ -5263,257 +4890,24 @@ index b00639cf0db5..12232bdd3896 100644
 -- 
 Armbian
 
-
-From df78a98d5ad0d1557607a92ecb7a1e6df91fb796 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
-Date: Thu, 28 Apr 2022 09:18:40 +0800
-Subject: drivers: Edge2: Watchdog: add khadas watchdog driver
+Date: Wed, 18 May 2022 21:31:27 +0800
+Subject: [NEEDS INTERVENTION DROP?] Edge2: TP: support khadas TS050 TP
 
 Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
-Change-Id: I10d552e7401d38545085ecb7ad67f3727475f5e2
+Change-Id: I7780692c1f18c6c57438127ea0644dc9f700f916
 ---
- arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts |   7 +
- drivers/watchdog/Kconfig                              |  10 +
- drivers/watchdog/Makefile                             |   1 +
- drivers/watchdog/khadas_wdt.c                         | 157 ++++++++++
- 4 files changed, 175 insertions(+)
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts |  80 ++-
+ arch/arm64/configs/kedges_defconfig                   |  10 +
+ drivers/input/touchscreen/edt-ft5x06.c                | 322 ++++------
+ 3 files changed, 209 insertions(+), 203 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
-index 551d4ad67017..078b1ec2cd07 100644
+index 0e3b5b10dd83..7709819eadb9 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
-@@ -91,6 +91,13 @@ play-pause-key {
- 		};
- 	};
- 
-+	khadas_wdt {
-+		compatible = "linux,wdt-khadas";
-+		status = "okay";
-+		hw_margin_ms = <500>;
-+		hw-gpios = <&gpio0 RK_PB0 GPIO_ACTIVE_HIGH>;
-+	};
-+
- 	fan: pwm-fan {
- 		compatible = "pwm-fan";
- 		#cooling-cells = <2>;
-diff --git a/drivers/watchdog/Kconfig b/drivers/watchdog/Kconfig
-index 01ce3f41cc21..bde9e629ec45 100644
---- a/drivers/watchdog/Kconfig
-+++ b/drivers/watchdog/Kconfig
-@@ -865,6 +865,16 @@ config MEDIATEK_WATCHDOG
- 	  To compile this driver as a module, choose M here: the
- 	  module will be called mtk_wdt.
- 
-+config KHADAS_WATCHDOG
-+	tristate "KHADAS watchdog support"
-+	default y
-+	help
-+	 Say Y here to include watchdog support embedded into KHADAS.
-+	 If the watchdog timer expires, TPS3851 will shut down all its power
-+	 supplies.
-+	 To compile this driver as a module, choose M here: the
-+	 module will be called KHADAS_wdt.
-+
- config DIGICOLOR_WATCHDOG
- 	tristate "Conexant Digicolor SoCs watchdog support"
- 	depends on ARCH_DIGICOLOR || COMPILE_TEST
-diff --git a/drivers/watchdog/Makefile b/drivers/watchdog/Makefile
-index 071a2e50be98..0dc45e86a352 100644
---- a/drivers/watchdog/Makefile
-+++ b/drivers/watchdog/Makefile
-@@ -25,6 +25,7 @@ obj-$(CONFIG_WATCHDOG_PRETIMEOUT_GOV_PANIC)	+= pretimeout_panic.o
- obj-$(CONFIG_PCWATCHDOG) += pcwd.o
- obj-$(CONFIG_MIXCOMWD) += mixcomwd.o
- obj-$(CONFIG_WDT) += wdt.o
-+obj-$(CONFIG_KHADAS_WATCHDOG) += khadas_wdt.o
- 
- # PCI-based Watchdog Cards
- obj-$(CONFIG_PCIPCWATCHDOG) += pcwd_pci.o
-diff --git a/drivers/watchdog/khadas_wdt.c b/drivers/watchdog/khadas_wdt.c
-new file mode 100644
-index 000000000000..3b28a52fd6ae
---- /dev/null
-+++ b/drivers/watchdog/khadas_wdt.c
-@@ -0,0 +1,157 @@
-+//#define DEBUG
-+
-+#include <linux/kernel.h>
-+#include <linux/types.h>
-+#include <linux/init.h>
-+#include <linux/platform_device.h>
-+#include <linux/gpio.h>
-+#include <linux/of_platform.h>
-+#include <linux/of_gpio.h>
-+#include <linux/slab.h>
-+#include <linux/workqueue.h>
-+#include <linux/module.h>
-+#include <linux/device.h>
-+#include <asm/io.h>
-+#include <asm/uaccess.h>
-+#include <linux/fs.h>
-+#include <linux/timer.h>
-+#include <linux/jiffies.h>
-+
-+static struct timer_list mytimer;
-+static unsigned int hw_margin = 3;
-+static int khadas_input_pin;
-+static unsigned int khadas_enble = 1;
-+
-+static void time_pre(struct timer_list *timer)
-+{
-+	static unsigned int flag=0;
-+    flag = !flag;
-+	gpio_direction_output(khadas_input_pin, flag);
-+
-+    //printk("%s\n", __func__);
-+    mytimer.expires = jiffies + hw_margin * HZ/1000;  // 500ms 运行一次
-+	if(khadas_enble)
-+		mod_timer(&mytimer, mytimer.expires);
-+}
-+
-+/*
-+static void wdt_exit(void)
-+{
-+    if(timer_pending(&mytimer))
-+    {
-+        del_timer(&mytimer);
-+    }
-+    printk("exit Success \n");
-+}*/
-+
-+static ssize_t show_enble(struct class *cls,
-+				struct class_attribute *attr, char *buf)
-+{
-+	return sprintf(buf, "%d\n", khadas_enble);
-+}
-+
-+static ssize_t store_enble(struct class *cls, struct class_attribute *attr,
-+		        const char *buf, size_t count)
-+{
-+	int enable;
-+
-+	if (kstrtoint(buf, 0, &enable)){
-+		printk("khadas_enble error\n");
-+		return -EINVAL;
-+	}
-+	printk("khadas_enble=%d\n",enable);
-+	khadas_enble = enable;
-+	if(khadas_enble){
-+		mytimer.expires = jiffies + hw_margin * HZ/1000;  // 500ms 运行一次
-+		mod_timer(&mytimer, mytimer.expires);
-+	}
-+	return count;
-+}
-+
-+static ssize_t store_pin_out(struct class *cls, struct class_attribute *attr,
-+		        const char *buf, size_t count)
-+{
-+	int enable;
-+
-+	if (kstrtoint(buf, 0, &enable)){
-+		printk("khadas_pin_out error\n");
-+		return -EINVAL;
-+	}
-+	printk("khadas_pin_out=%d\n",enable);
-+	gpio_direction_output(khadas_input_pin, enable);
-+	return count;
-+}
-+
-+static struct class_attribute khadas_attrs[] = {
-+	__ATTR(enble, 0644, show_enble, store_enble),
-+	__ATTR(pin_out, 0644, NULL, store_pin_out),
-+};
-+
-+static void create_khadas_attrs(void)
-+{
-+	int i;
-+	struct class *khadas_class;
-+	printk("%s\n",__func__);
-+	khadas_class = class_create(THIS_MODULE, "khadas");
-+	if (IS_ERR(khadas_class)) {
-+		pr_err("create khadas_class debug class fail\n");
-+		return;
-+	}
-+	for (i = 0; i < ARRAY_SIZE(khadas_attrs); i++) {
-+		if (class_create_file(khadas_class, &khadas_attrs[i]))
-+			pr_err("create khadas attribute %s fail\n", khadas_attrs[i].attr.name);
-+	}
-+}
-+
-+static int wdt_probe(struct platform_device *pdev)
-+{
-+	const char *value;
-+	int ret;
-+	printk("hw_wdt enter probe\n");
-+
-+	ret = of_property_read_u32(pdev->dev.of_node,"hw_margin_ms", &hw_margin);
-+	if (ret)
-+		return ret;
-+
-+	ret = of_property_read_string(pdev->dev.of_node,
-+					  "hw-gpios", &value);
-+	if (ret) {
-+		printk("no hw-gpios");
-+		return -1;
-+	} else {
-+		khadas_input_pin = of_get_named_gpio_flags
-+						(pdev->dev.of_node,
-+						"hw-gpios",
-+						0, NULL);
-+		printk("hlm hw-gpios: %d.\n", khadas_input_pin);
-+		ret = gpio_request(khadas_input_pin, "khadas");
-+	}
-+
-+    timer_setup(&mytimer, time_pre, 0);
-+    mytimer.expires = jiffies + hw_margin * HZ/1000; //// 5ms 运行一次
-+    add_timer(&mytimer);
-+	create_khadas_attrs();
-+	return 0;
-+}
-+
-+static const struct of_device_id hw_khadas_wdt_dt_ids[] = {
-+	{ .compatible = "linux,wdt-khadas", },
-+	{ }
-+};
-+MODULE_DEVICE_TABLE(of, hw_khadas_wdt_dt_ids);
-+
-+static struct platform_driver khadas_wdt_driver = {
-+	.driver	= {
-+		.name		= "hw_khadas_wdt",
-+		.of_match_table	= hw_khadas_wdt_dt_ids,
-+	},
-+	.probe	= wdt_probe,
-+};
-+
-+static int __init wdt_drv_init(void)
-+{
-+	return platform_driver_register(&khadas_wdt_driver);
-+}
-+arch_initcall(wdt_drv_init);
-+
-+MODULE_LICENSE("GPL");
--- 
-Armbian
-
-
-From be6411201273ea38a15df6cb3c5da84d9b4c48c3 Mon Sep 17 00:00:00 2001
-From: Jack Zhao <jack.zhao@wesion.com>
-Date: Tue, 17 May 2022 23:25:12 +0800
-Subject: Edge2: led: support khadas RGB led
-
-Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
-Change-Id: Idd15329fa0c3ca58555ceb5306cd64c2d9652232
----
- arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 41 ++++++++++
- arch/arm64/configs/kedges_defconfig                   |  5 ++
- drivers/leds/leds-gpio.c                              | 40 ++++++++-
- 3 files changed, 84 insertions(+), 2 deletions(-)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
-index 078b1ec2cd07..96af7bfee0d7 100644
---- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
-+++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
-@@ -91,6 +91,33 @@ play-pause-key {
+@@ -91,6 +91,40 @@ play-pause-key {
  		};
  	};
  
@@ -5544,508 +4938,28 @@ index 078b1ec2cd07..96af7bfee0d7 100644
 +		};
 +	};
 +
- 	khadas_wdt {
- 		compatible = "linux,wdt-khadas";
- 		status = "okay";
-@@ -540,6 +567,20 @@ mpu6500_irq_gpio: mpu6500_irq_gpio {
- 		};
- 	};
- 
-+	leds {
-+		red_led_gpio: red-led-gpio {
-+			rockchip,pins = <4 RK_PB4 RK_FUNC_GPIO &pcfg_pull_up>;
-+		};
-+
-+		green_led_gpio: green-led-gpio {
-+			rockchip,pins = <4 RK_PB2 RK_FUNC_GPIO &pcfg_pull_up>;
-+		};
-+
-+		blue_led_gpio: blue-led-gpio {
-+			rockchip,pins = <4 RK_PB3 RK_FUNC_GPIO &pcfg_pull_up>;
-+		};
++	khadas_wdt {
++		compatible = "linux,wdt-khadas";
++		status = "okay";
++		hw_margin_ms = <500>;
++		hw-gpios = <&gpio0 RK_PB0 GPIO_ACTIVE_HIGH>;
 +	};
 +
- 	usb {
- 		vcc5v0_host_en: vcc5v0-host-en {
- 			rockchip,pins = <4 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
-diff --git a/arch/arm64/configs/kedges_defconfig b/arch/arm64/configs/kedges_defconfig
-index ac5ba22fa5e7..b874726d50aa 100644
---- a/arch/arm64/configs/kedges_defconfig
-+++ b/arch/arm64/configs/kedges_defconfig
-@@ -451,6 +451,11 @@ CONFIG_NEW_LEDS=y
- CONFIG_LEDS_CLASS=y
- CONFIG_LEDS_GPIO=y
- CONFIG_LEDS_IS31FL32XX=y
-+CONFIG_LEDS_TRIGGERS=y
-+CONFIG_LEDS_TRIGGER_TIMER=y
-+CONFIG_LEDS_TRIGGER_HEARTBEAT=y
-+CONFIG_LEDS_TRIGGER_BACKLIGHT=y
-+CONFIG_LEDS_TRIGGER_DEFAULT_ON=y
- CONFIG_RTC_CLASS=y
- CONFIG_RTC_DRV_HYM8563=y
- CONFIG_RTC_DRV_RK808=y
-diff --git a/drivers/leds/leds-gpio.c b/drivers/leds/leds-gpio.c
-index 93f5b1b60fde..7d7b3c7581ed 100644
---- a/drivers/leds/leds-gpio.c
-+++ b/drivers/leds/leds-gpio.c
-@@ -78,6 +78,25 @@ static int create_gpio_led(const struct gpio_led *template,
- 	struct led_init_data init_data = {};
- 	int ret, state;
+ 	fan: pwm-fan {
+ 		compatible = "pwm-fan";
+ 		#cooling-cells = <2>;
+@@ -304,6 +338,10 @@ regulator-state-mem {
  
-+	led_dat->gpiod = template->gpiod;
-+	if (!led_dat->gpiod) {
-+		unsigned long flags = GPIOF_OUT_INIT_LOW;
-+		if (!gpio_is_valid(template->gpio)) {
-+			dev_info(parent, "Skipping unavailable LED gpio %d (%s)\n",
-+					template->gpio, template->name);
-+			return 0;
-+		}
-+		if (template->active_low)
-+			flags |= GPIOF_ACTIVE_LOW;
-+		ret = devm_gpio_request_one(parent, template->gpio, flags,
-+									template->name);
-+		if (ret < 0)
-+			return ret;
-+		led_dat->gpiod = gpio_to_desc(template->gpio);
-+		if (!led_dat->gpiod)
-+			return -EINVAL;
-+	}
-+	led_dat->cdev.name = template->name;
- 	led_dat->cdev.default_trigger = template->default_trigger;
- 	led_dat->can_sleep = gpiod_cansleep(led_dat->gpiod);
- 	if (!led_dat->can_sleep)
-@@ -125,6 +144,12 @@ struct gpio_leds_priv {
- 	struct gpio_led_data leds[];
  };
  
-+static inline int sizeof_gpio_leds_priv(int num_leds)
-+{
-+	return sizeof(struct gpio_leds_priv) +
-+			(sizeof(struct gpio_led_data) * num_leds);
-+}
-+
- static struct gpio_leds_priv *gpio_leds_create(struct platform_device *pdev)
- {
- 	struct device *dev = &pdev->dev;
-@@ -145,19 +170,30 @@ static struct gpio_leds_priv *gpio_leds_create(struct platform_device *pdev)
- 		struct gpio_led led = {};
- 		const char *state = NULL;
- 
-+		struct device_node *np = to_of_node(child);
-+		ret = fwnode_property_read_string(child, "label", &led.name);
-+		if (ret && IS_ENABLED(CONFIG_OF) && np)
-+			led.name = np->name;
-+		if (!led.name) {
-+			fwnode_handle_put(child);
-+			return ERR_PTR(-EINVAL);
-+		}
-+
- 		/*
- 		 * Acquire gpiod from DT with uninitialized label, which
- 		 * will be updated after LED class device is registered,
- 		 * Only then the final LED name is known.
- 		 */
- 		led.gpiod = devm_fwnode_get_gpiod_from_child(dev, NULL, child,
--							     GPIOD_ASIS,
--							     NULL);
-+							     GPIOD_ASIS,led.name);
- 		if (IS_ERR(led.gpiod)) {
- 			fwnode_handle_put(child);
- 			return ERR_CAST(led.gpiod);
- 		}
- 
-+		fwnode_property_read_string(child, "linux,default-trigger",
-+						&led.default_trigger);
-+
- 		led_dat->gpiod = led.gpiod;
- 
- 		if (!fwnode_property_read_string(child, "default-state",
--- 
-Armbian
-
-
-From d6596a29bffc37810449b3af05637b68529ea826 Mon Sep 17 00:00:00 2001
-From: Jack Zhao <jack.zhao@wesion.com>
-Date: Tue, 17 May 2022 17:42:16 +0200
-Subject: [NEEDS INTERVENTION] Edge2: misc: add MCU control driver
-
-Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
-Change-Id: I29d1caeb110f0a9387db0cde98a81e58f50ed1e4
----
- arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts |   6 +
- arch/arm64/configs/kedges_defconfig                   |   1 +
- drivers/misc/Kconfig                                  |  18 +-
- drivers/misc/Makefile                                 |   3 +-
- drivers/misc/khadas-mcu.c                             | 256 ++++++++++
- 5 files changed, 277 insertions(+), 7 deletions(-)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
-index 96af7bfee0d7..778bfd5428ac 100644
---- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
-+++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
-@@ -448,6 +448,12 @@ &i2c6 {
- 	pinctrl-names = "default";
- 	pinctrl-0 = <&i2c6m3_xfer>;
- 
-+	mcu: khadas-mcu@18 {
-+		compatible = "khadas-mcu";
-+		status = "okay";
-+		reg = <0x18>;
-+	};
-+
- 	usbc0: fusb302@22 {
- 		compatible = "fcs,fusb302";
- 		reg = <0x22>;
-diff --git a/arch/arm64/configs/kedges_defconfig b/arch/arm64/configs/kedges_defconfig
-index b874726d50aa..bb036a0d57e8 100644
---- a/arch/arm64/configs/kedges_defconfig
-+++ b/arch/arm64/configs/kedges_defconfig
-@@ -122,6 +122,7 @@ CONFIG_BLK_DEV_RAM=y
- CONFIG_BLK_DEV_RAM_COUNT=1
- CONFIG_BLK_DEV_NVME=y
- CONFIG_SRAM=y
-+CONFIG_KHADAS_MCU=y
- CONFIG_BLK_DEV_SD=y
- CONFIG_BLK_DEV_SR=y
- CONFIG_SCSI_SCAN_ASYNC=y
-diff --git a/drivers/misc/Kconfig b/drivers/misc/Kconfig
-index 62f35ba898de..9b51e716f7f8 100644
---- a/drivers/misc/Kconfig
-+++ b/drivers/misc/Kconfig
-@@ -5,12 +5,6 @@
- 
- menu "Misc devices"
- 
--config RK803
--	tristate "RK803"
--	default n
--	help
--	  Driver for RK803 which is used for driving porjector and IR flood LED.
--
- config SENSORS_LIS3LV02D
- 	tristate
- 	depends on INPUT
-@@ -487,6 +481,18 @@ config HISI_HIKEY_USB
- 	  switching between the dual-role USB-C port and the USB-A host ports
- 	  using only one USB controller.
- 
-+config RK803
-+	tristate "RK803"
-+	default n
-+	help
-+	  Driver for RK803 which is used for driving porjector and IR flood LED.
-+
-+config KHADAS_MCU
-+	tristate "Khadas MCU control driver"
-+	default n
-+	help
-+	  This driver allow to control MCU.
-+
- source "drivers/misc/c2port/Kconfig"
- source "drivers/misc/eeprom/Kconfig"
- source "drivers/misc/cb710/Kconfig"
-diff --git a/drivers/misc/Makefile b/drivers/misc/Makefile
-index 8be76bac6eb8..965648611ae4 100644
---- a/drivers/misc/Makefile
-+++ b/drivers/misc/Makefile
-@@ -3,7 +3,6 @@
- # Makefile for misc devices that really don't fit anywhere else.
- #
- 
--obj-$(CONFIG_RK803)		+= rk803.o
- obj-$(CONFIG_IBM_ASM)		+= ibmasm/
- obj-$(CONFIG_IBMVMC)		+= ibmvmc.o
- obj-$(CONFIG_AD525X_DPOT)	+= ad525x_dpot.o
-@@ -59,3 +58,5 @@ obj-$(CONFIG_UACCE)		+= uacce/
- obj-$(CONFIG_XILINX_SDFEC)	+= xilinx_sdfec.o
- obj-$(CONFIG_HISI_HIKEY_USB)	+= hisi_hikey_usb.o
- obj-$(CONFIG_UID_SYS_STATS)	+= uid_sys_stats.o
-+obj-$(CONFIG_RK803)		+= rk803.o
-+obj-$(CONFIG_KHADAS_MCU) += khadas-mcu.o
-diff --git a/drivers/misc/khadas-mcu.c b/drivers/misc/khadas-mcu.c
-new file mode 100644
-index 000000000000..1677294ee617
---- /dev/null
-+++ b/drivers/misc/khadas-mcu.c
-@@ -0,0 +1,256 @@
-+/*
-+ * Khadas Edge2 MCU control driver
-+ *
-+ * Written by: Nick <nick@khadas.com>
-+ *
-+ * Copyright (C) 2022 Wesion Technologies Ltd.
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License version 2 as
-+ * published by the Free Software Foundation.
-+ */
-+
-+#include <linux/module.h>
-+#include <linux/i2c.h>
-+#include <linux/string.h>
-+#include <linux/list.h>
-+#include <linux/sysfs.h>
-+#include <linux/ctype.h>
-+#include <linux/device.h>
-+#include <linux/slab.h>
-+#include <linux/of.h>
-+#include <linux/of_address.h>
-+
-+/* Device registers */
-+#define MCU_PWR_OFF_CMD_REG       0x80
-+#define MCU_SHUTDOWN_NORMAL_REG   0x2c
-+
-+struct mcu_data {
-+	struct i2c_client *client;
-+	struct class *mcu_class;
++&reboot_mode {
++	mode-reboot_test = <BOOT_REBOOT_TEST>;
 +};
 +
-+struct mcu_data *g_mcu_data;
-+
-+static int i2c_master_reg8_send(const struct i2c_client *client,
-+		const char reg, const char *buf, int count)
-+{
-+	struct i2c_adapter *adap = client->adapter;
-+	struct i2c_msg msg;
-+	int ret;
-+	char *tx_buf = kzalloc(count + 1, GFP_KERNEL);
-+	if (!tx_buf)
-+		return -ENOMEM;
-+	tx_buf[0] = reg;
-+	memcpy(tx_buf+1, buf, count);
-+
-+	msg.addr = client->addr;
-+	msg.flags = client->flags;
-+	msg.len = count + 1;
-+	msg.buf = (char *)tx_buf;
-+
-+	ret = i2c_transfer(adap, &msg, 1);
-+	kfree(tx_buf);
-+	return (ret == 1) ? count : ret;
-+}
-+
-+/*static int i2c_master_reg8_recv(const struct i2c_client *client,
-+		const char reg, char *buf, int count)
-+{
-+	struct i2c_adapter *adap = client->adapter;
-+	struct i2c_msg msgs[2];
-+	int ret;
-+	char reg_buf = reg;
-+
-+	msgs[0].addr = client->addr;
-+	msgs[0].flags = client->flags;
-+	msgs[0].len = 1;
-+	msgs[0].buf = &reg_buf;
-+
-+	msgs[1].addr = client->addr;
-+	msgs[1].flags = client->flags | I2C_M_RD;
-+	msgs[1].len = count;
-+	msgs[1].buf = (char *)buf;
-+
-+	ret = i2c_transfer(adap, msgs, 2);
-+
-+	return (ret == 2) ? count : ret;
-+}*/
-+
-+/*static int mcu_i2c_read_regs(struct i2c_client *client,
-+		u8 reg, u8 buf[], unsigned len)
-+{
-+	int ret;
-+	ret = i2c_master_reg8_recv(client, reg, buf, len);
-+	return ret;
-+}*/
-+
-+static int mcu_i2c_write_regs(struct i2c_client *client,
-+		u8 reg, u8 const buf[], __u16 len)
-+{
-+	int ret;
-+
-+	ret = i2c_master_reg8_send(client, reg, buf, (int)len);
-+
-+	return ret;
-+}
-+
-+static ssize_t store_mcu_poweroff(struct class *cls,struct class_attribute *attr,
-+				const char *buf, size_t count)
-+{
-+	int ret;
-+	int val;
-+	char reg;
-+
-+	if (kstrtoint(buf, 0, &val))
-+		return -EINVAL;
-+
-+	if (val != 1)
-+		return -EINVAL;
-+
-+	reg = (char)val;
-+
-+	ret = mcu_i2c_write_regs(g_mcu_data->client,MCU_PWR_OFF_CMD_REG,
-+							&reg, 1);
-+	if (ret < 0) {
-+		pr_debug("write poweroff cmd error\n");
-+		return ret;
-+	}
-+
-+	return count;
-+}
-+
-+static ssize_t store_mcu_rst(struct class *cls, struct class_attribute *attr,
-+				const char *buf, size_t count)
-+{
-+	char reg;
-+	int ret;
-+	int rst;
-+
-+	if (kstrtoint(buf, 0, &rst))
-+		return -EINVAL;
-+
-+	reg = rst;
-+	ret = mcu_i2c_write_regs(g_mcu_data->client,MCU_SHUTDOWN_NORMAL_REG,
-+							&reg, 1);
-+	if (ret < 0) {
-+		pr_debug("write poweroff cmd error\n");
-+		return ret;
-+	}
-+
-+	return count;
-+}
-+
-+static struct class_attribute mcu_class_attrs[] = {
-+	__ATTR(poweroff, 0644, NULL, store_mcu_poweroff),
-+	__ATTR(rst, 0644, NULL, store_mcu_rst),
-+};
-+
-+static void create_mcu_attrs(void) {
-+	int i;
-+
-+	g_mcu_data->mcu_class = class_create(THIS_MODULE, "mcu");
-+	if (IS_ERR(g_mcu_data->mcu_class)) {
-+		pr_err("create mcu_class debug class fail\n");
-+
-+		return;
-+	}
-+	for (i = 0; i < ARRAY_SIZE(mcu_class_attrs); i++) {
-+		if (class_create_file(g_mcu_data->mcu_class, &mcu_class_attrs[i]));
-+			pr_err("create mcu attribute %s fail\n",
-+							mcu_class_attrs[i].attr.name);
-+	}
-+}
-+
-+static int mcu_parse_dt(struct device *dev)
-+{
-+	int ret = 0;
-+
-+	if (NULL == dev) return -EINVAL;
-+
-+	return ret;
-+}
-+
-+static int mcu_probe(struct i2c_client *client, const struct i2c_device_id *id)
-+{
-+	printk("%s\n", __func__);
-+
-+	if (!i2c_check_functionality(client->adapter, I2C_FUNC_I2C))
-+		return -ENODEV;
-+
-+	g_mcu_data = kzalloc(sizeof(struct mcu_data), GFP_KERNEL);
-+
-+	if (g_mcu_data == NULL)
-+		return -ENOMEM;
-+
-+	mcu_parse_dt(&client->dev);
-+
-+	g_mcu_data->client = client;
-+
-+	create_mcu_attrs();
-+
-+	return 0;
-+}
-+
-+static int mcu_remove(struct i2c_client *client)
-+{
-+	kfree(g_mcu_data);
-+	return 0;
-+}
-+
-+static void mcu_shutdown(struct i2c_client *client)
-+{
-+	kfree(g_mcu_data);
-+}
-+
-+#ifdef CONFIG_PM_SLEEP
-+static int mcu_suspend(struct device *dev)
-+{
-+	return 0;
-+}
-+
-+static int mcu_resume(struct device *dev)
-+{
-+	return 0;
-+}
-+
-+static const struct dev_pm_ops mcu_dev_pm_ops = {
-+	SET_SYSTEM_SLEEP_PM_OPS(mcu_suspend, mcu_resume)
-+};
-+
-+#define MCU_PM_OPS (&(mcu_dev_pm_ops))
-+
-+#endif
-+
-+static const struct i2c_device_id mcu_id[] = {
-+	{ "khadas-mcu", 0 },
-+	{ }
-+};
-+MODULE_DEVICE_TABLE(i2c, mcu_id);
-+
-+
-+static struct of_device_id mcu_dt_ids[] = {
-+	{ .compatible = "khadas-mcu" },
-+	{},
-+};
-+MODULE_DEVICE_TABLE(i2c, mcu_dt_ids);
-+
-+struct i2c_driver mcu_driver = {
-+	.driver  = {
-+		.name   = "khadas-mcu",
-+		.owner  = THIS_MODULE,
-+		.of_match_table = of_match_ptr(mcu_dt_ids),
-+#ifdef CONFIG_PM_SLEEP
-+		.pm = MCU_PM_OPS,
-+#endif
-+	},
-+	.probe		= mcu_probe,
-+	.remove 	= mcu_remove,
-+	.shutdown = mcu_shutdown,
-+	.id_table	= mcu_id,
-+};
-+module_i2c_driver(mcu_driver);
-+
-+MODULE_AUTHOR("Nick <nick@khadas.com>");
-+MODULE_DESCRIPTION("Khadas Edge2 MCU control driver");
-+MODULE_LICENSE("GPL");
--- 
-Armbian
-
-
-From 7f030cbfa9fd1325dced8abd18bca792380e9811 Mon Sep 17 00:00:00 2001
-From: Jack Zhao <jack.zhao@wesion.com>
-Date: Wed, 18 May 2022 21:31:27 +0800
-Subject: [NEEDS INTERVENTION DROP?] Edge2: TP: support khadas TS050 TP
-
-Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
-Change-Id: I7780692c1f18c6c57438127ea0644dc9f700f916
----
- arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts |  22 +-
- arch/arm64/configs/kedges_defconfig                   |   1 +
- drivers/input/touchscreen/edt-ft5x06.c                | 322 ++++------
- 3 files changed, 142 insertions(+), 203 deletions(-)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
-index 778bfd5428ac..7709819eadb9 100644
---- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
-+++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
-@@ -383,13 +383,15 @@ &i2c4 {
+ &i2c3 {
+ 	status = "okay";
+ 
+@@ -345,13 +383,15 @@ &i2c4 {
  	pinctrl-0 = <&i2c4m3_xfer>;
  	status = "okay";
  
@@ -6068,7 +4982,41 @@ index 778bfd5428ac..7709819eadb9 100644
  	};
  };
  
-@@ -609,6 +611,12 @@ typec5v_pwren: typec5v-pwren {
+@@ -410,6 +450,12 @@ &i2c6 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&i2c6m3_xfer>;
+ 
++	mcu: khadas-mcu@18 {
++		compatible = "khadas-mcu";
++		status = "okay";
++		reg = <0x18>;
++	};
++
+ 	usbc0: fusb302@22 {
+ 		compatible = "fcs,fusb302";
+ 		reg = <0x22>;
+@@ -529,6 +575,20 @@ mpu6500_irq_gpio: mpu6500_irq_gpio {
+ 		};
+ 	};
+ 
++	leds {
++		red_led_gpio: red-led-gpio {
++			rockchip,pins = <4 RK_PB4 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++
++		green_led_gpio: green-led-gpio {
++			rockchip,pins = <4 RK_PB2 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++
++		blue_led_gpio: blue-led-gpio {
++			rockchip,pins = <4 RK_PB3 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
+ 	usb {
+ 		vcc5v0_host_en: vcc5v0-host-en {
+ 			rockchip,pins = <4 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
+@@ -551,6 +611,12 @@ typec5v_pwren: typec5v-pwren {
  		};
  	};
  
@@ -6082,10 +5030,18 @@ index 778bfd5428ac..7709819eadb9 100644
  		uart9_gpios: uart9-gpios {
  			rockchip,pins = <3 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
 diff --git a/arch/arm64/configs/kedges_defconfig b/arch/arm64/configs/kedges_defconfig
-index bb036a0d57e8..a859db38f300 100644
+index 31c282f08e70..a859db38f300 100644
 --- a/arch/arm64/configs/kedges_defconfig
 +++ b/arch/arm64/configs/kedges_defconfig
-@@ -200,6 +200,7 @@ CONFIG_TOUCHSCREEN_ATMEL_MXT=y
+@@ -122,6 +122,7 @@ CONFIG_BLK_DEV_RAM=y
+ CONFIG_BLK_DEV_RAM_COUNT=1
+ CONFIG_BLK_DEV_NVME=y
+ CONFIG_SRAM=y
++CONFIG_KHADAS_MCU=y
+ CONFIG_BLK_DEV_SD=y
+ CONFIG_BLK_DEV_SR=y
+ CONFIG_SCSI_SCAN_ASYNC=y
+@@ -199,9 +200,13 @@ CONFIG_TOUCHSCREEN_ATMEL_MXT=y
  CONFIG_TOUCHSCREEN_GSL3673=y
  CONFIG_TOUCHSCREEN_GT1X=y
  CONFIG_TOUCHSCREEN_ELAN=y
@@ -6093,6 +5049,24 @@ index bb036a0d57e8..a859db38f300 100644
  CONFIG_TOUCHSCREEN_USB_COMPOSITE=y
  CONFIG_ROCKCHIP_REMOTECTL=y
  CONFIG_ROCKCHIP_REMOTECTL_PWM=y
++CONFIG_SENSOR_DEVICE=y
++CONFIG_GSENSOR_DEVICE=y
++CONFIG_GS_KXTJ9=y
+ CONFIG_INPUT_MISC=y
+ CONFIG_INPUT_UINPUT=y
+ CONFIG_INPUT_RK805_PWRKEY=y
+@@ -448,6 +453,11 @@ CONFIG_NEW_LEDS=y
+ CONFIG_LEDS_CLASS=y
+ CONFIG_LEDS_GPIO=y
+ CONFIG_LEDS_IS31FL32XX=y
++CONFIG_LEDS_TRIGGERS=y
++CONFIG_LEDS_TRIGGER_TIMER=y
++CONFIG_LEDS_TRIGGER_HEARTBEAT=y
++CONFIG_LEDS_TRIGGER_BACKLIGHT=y
++CONFIG_LEDS_TRIGGER_DEFAULT_ON=y
+ CONFIG_RTC_CLASS=y
+ CONFIG_RTC_DRV_HYM8563=y
+ CONFIG_RTC_DRV_RK808=y
 diff --git a/drivers/input/touchscreen/edt-ft5x06.c b/drivers/input/touchscreen/edt-ft5x06.c
 index 6ff81d48da86..ec540e0b3135 100644
 --- a/drivers/input/touchscreen/edt-ft5x06.c
@@ -6834,8 +5808,7 @@ index 6ff81d48da86..ec540e0b3135 100644
 -- 
 Armbian
 
-
-From 106019ed6db370e45a53c3fbf20e252b56f9315f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Tue, 19 Jul 2022 10:15:35 +0800
 Subject: [NEEDS INTERVENTION DROP?] Edge2: lcd: support khadas mipi lcd panel
@@ -8904,8 +7877,7 @@ index f55a3a5c5c7c..1a2882f157ee 100644
 -- 
 Armbian
 
-
-From 4f39570e28369a9a205853d3f1df934883bece5d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Tue, 31 May 2022 11:56:00 +0800
 Subject: arm64: dts: rockchip: Edge2: support DP display
@@ -8932,8 +7904,7 @@ index 5292573bdac0..9727962fc984 100644
 -- 
 Armbian
 
-
-From 97578958bc0a7f5b93eba849327ceb7961f478a5 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Tue, 19 Jul 2022 10:20:01 +0800
 Subject: arm64: dts: rockchip: Edge2: Enable HDMI sound card
@@ -8973,8 +7944,7 @@ index 9727962fc984..a20327cfbb7f 100644
 -- 
 Armbian
 
-
-From d49dac0867bfb4088a4a2f5b1697d8964918fab9 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Tue, 19 Jul 2022 10:29:09 +0800
 Subject: arm64: dts: rockchip: Edge2: support DMIC array
@@ -9050,8 +8020,7 @@ index a20327cfbb7f..c6102dc3b8c9 100644
 -- 
 Armbian
 
-
-From 20bd49afa37ea8ff6ebade93f300139dba26d4a6 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Tue, 19 Jul 2022 11:00:07 +0800
 Subject: Edge2: support codec es8316
@@ -9163,8 +8132,7 @@ index c6102dc3b8c9..bf516e72503f 100644
 -- 
 Armbian
 
-
-From 03159ec03ca9fd53dbb18cf83f76c84685d6d6af Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Mon, 6 Jun 2022 15:35:45 +0800
 Subject: arm64: dts: Edge2: camera: add imx415 camera
@@ -9543,8 +8511,7 @@ index 9d0593167702..9e4f755c36c7 100644
 -- 
 Armbian
 
-
-From d90ce84fb0a801dcf81e2734a5cf22347c2b9afb Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Tue, 14 Jun 2022 15:12:06 +0800
 Subject: arm64: dts: rockchip: Edge2: support 8k
@@ -9582,8 +8549,7 @@ index bf516e72503f..b9eabde9f97f 100644
 -- 
 Armbian
 
-
-From b5e94586e1b93c3c52761d703f07b8ea6d8725ad Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Tue, 28 Jun 2022 13:57:54 +0800
 Subject: Edge2: change bluetooth to mainline way
@@ -9664,681 +8630,7 @@ index a859db38f300..ad7439f1785f 100644
 -- 
 Armbian
 
-
-From 687278a91d2f6442034b643d2440804c123ef0bf Mon Sep 17 00:00:00 2001
-From: Jack Zhao <jack.zhao@wesion.com>
-Date: Thu, 30 Jun 2022 22:16:41 +0800
-Subject: [MIGHT NEED INTERVENTION MCU THERMAL STUFF] Edge2: support fan
- function
-
-Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
-Change-Id: I23105fba75af5a0861258b40410a7773b6f87bb9
----
- arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts |  10 +
- drivers/misc/Makefile                                 |   1 +
- drivers/misc/khadas-mcu.c                             | 472 +++++++++-
- drivers/thermal/rockchip_thermal.c                    |  17 +
- 4 files changed, 485 insertions(+), 15 deletions(-)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
-index eb9e415aa291..d25c29ccdb00 100644
---- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
-+++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
-@@ -545,6 +545,12 @@ mcu: khadas-mcu@18 {
- 		compatible = "khadas-mcu";
- 		status = "okay";
- 		reg = <0x18>;
-+		fan,trig_temp_level0 = <50>;
-+		fan,trig_temp_level1 = <60>;
-+		fan,trig_temp_level2 = <70>;
-+		fan,trig_temp_level3 = <80>;
-+		hwver = "EDGE2.V10";
-+
- 	};
- 
- 	usbc0: fusb302@22 {
-@@ -921,6 +927,10 @@ spidev@1 {
- 	};
- };
- 
-+&tsadc {
-+	status = "okay";
-+};
-+
- &u2phy0_otg {
- 	rockchip,typec-vbus-det;
- };
-diff --git a/drivers/misc/Makefile b/drivers/misc/Makefile
-index 965648611ae4..574b8ff68cda 100644
---- a/drivers/misc/Makefile
-+++ b/drivers/misc/Makefile
-@@ -3,6 +3,7 @@
- # Makefile for misc devices that really don't fit anywhere else.
- #
- 
-+KBUILD_CFLAGS += -Wno-unused-function
- obj-$(CONFIG_IBM_ASM)		+= ibmasm/
- obj-$(CONFIG_IBMVMC)		+= ibmvmc.o
- obj-$(CONFIG_AD525X_DPOT)	+= ad525x_dpot.o
-diff --git a/drivers/misc/khadas-mcu.c b/drivers/misc/khadas-mcu.c
-index 1677294ee617..67c3d6a6ee91 100644
---- a/drivers/misc/khadas-mcu.c
-+++ b/drivers/misc/khadas-mcu.c
-@@ -25,9 +25,70 @@
- #define MCU_PWR_OFF_CMD_REG       0x80
- #define MCU_SHUTDOWN_NORMAL_REG   0x2c
- 
-+/*Fan device*/
-+#define MCU_CMD_FAN_STATUS_CTRL_REGv2   0x8A
-+
-+#define MCU_FAN_TRIG_TEMP_LEVEL0        60  // 50 degree if not set
-+#define MCU_FAN_TRIG_TEMP_LEVEL1        80  // 60 degree if not set
-+#define MCU_FAN_TRIG_TEMP_LEVEL2        100 // 70 degree if not set
-+#define MCU_FAN_TRIG_MAXTEMP            105
-+#define MCU_FAN_LOOP_SECS               (30 * HZ)   // 30 seconds
-+#define MCU_FAN_TEST_LOOP_SECS          (5 * HZ)  // 5 seconds
-+#define MCU_FAN_LOOP_NODELAY_SECS       0
-+#define MCU_FAN_SPEED_OFF               0
-+#define MCU_FAN_SPEED_LOW               1
-+#define MCU_FAN_SPEED_MID               2
-+#define MCU_FAN_SPEED_HIGH              3
-+#define MCU_FAN_SPEED_LOW_V2            0x32
-+#define MCU_FAN_SPEED_MID_V2            0x48
-+#define MCU_FAN_SPEED_HIGH_V2           0x64
-+
-+enum khadas_board {
-+	KHADAS_BOARD_NONE = 0,
-+	KHADAS_BOARD_EDGE2
-+};
-+
-+enum khadas_board_hwver {
-+	KHADAS_BOARD_HWVER_NONE = 0,
-+	KHADAS_BOARD_HWVER_V10
-+};
-+
-+enum mcu_fan_mode {
-+	MCU_FAN_MODE_MANUAL = 0,
-+	MCU_FAN_MODE_AUTO
-+};
-+
-+enum mcu_fan_level {
-+	MCU_FAN_LEVEL_0 = 0,
-+	MCU_FAN_LEVEL_1,
-+	MCU_FAN_LEVEL_2,
-+	MCU_FAN_LEVEL_3
-+};
-+
-+enum mcu_fan_status {
-+	MCU_FAN_STATUS_DISABLE = 0,
-+	MCU_FAN_STATUS_ENABLE,
-+};
-+
-+struct mcu_fan_data {
-+    struct platform_device *pdev;
-+    struct class *fan_class;
-+    struct delayed_work work;
-+    struct delayed_work fan_test_work;
-+    enum mcu_fan_status enable;
-+    enum mcu_fan_mode mode;
-+    enum mcu_fan_level level;
-+    int trig_temp_level0;
-+    int trig_temp_level1;
-+    int trig_temp_level2;
-+};
-+
- struct mcu_data {
- 	struct i2c_client *client;
- 	struct class *mcu_class;
-+	enum khadas_board board;
-+	enum khadas_board_hwver hwver;
-+	struct mcu_fan_data fan_data;
- };
- 
- struct mcu_data *g_mcu_data;
-@@ -54,7 +115,7 @@ static int i2c_master_reg8_send(const struct i2c_client *client,
- 	return (ret == 1) ? count : ret;
- }
- 
--/*static int i2c_master_reg8_recv(const struct i2c_client *client,
-+static int i2c_master_reg8_recv(const struct i2c_client *client,
- 		const char reg, char *buf, int count)
- {
- 	struct i2c_adapter *adap = client->adapter;
-@@ -75,15 +136,15 @@ static int i2c_master_reg8_send(const struct i2c_client *client,
- 	ret = i2c_transfer(adap, msgs, 2);
- 
- 	return (ret == 2) ? count : ret;
--}*/
-+}
- 
--/*static int mcu_i2c_read_regs(struct i2c_client *client,
-+static int mcu_i2c_read_regs(struct i2c_client *client,
- 		u8 reg, u8 buf[], unsigned len)
- {
- 	int ret;
- 	ret = i2c_master_reg8_recv(client, reg, buf, len);
- 	return ret;
--}*/
-+}
- 
- static int mcu_i2c_write_regs(struct i2c_client *client,
- 		u8 reg, u8 const buf[], __u16 len)
-@@ -95,6 +156,314 @@ static int mcu_i2c_write_regs(struct i2c_client *client,
- 	return ret;
- }
- 
-+static int is_mcu_fan_control_supported(void)
-+{
-+	// MCU FAN control is supported for:
-+	// 1. Khadas EDGE2
-+	if (g_mcu_data->board == KHADAS_BOARD_EDGE2) {
-+		if (g_mcu_data->hwver >= KHADAS_BOARD_HWVER_V10)
-+			return 1;
-+		else
-+			return 0;
-+	} else {
-+			return 0;
-+	}
-+
-+}
-+static void mcu_fan_level_set(struct mcu_fan_data *fan_data, int level)
-+{
-+    if (is_mcu_fan_control_supported()) {
-+        int ret;
-+        u8 data = 0;
-+
-+        g_mcu_data->fan_data.level = level;
-+
-+		if (g_mcu_data->board == KHADAS_BOARD_EDGE2) {
-+            if (level == 0)
-+                data = MCU_FAN_SPEED_OFF;
-+            else if (level == 1)
-+                data = MCU_FAN_SPEED_LOW_V2;
-+            else if (level == 2)
-+                data = MCU_FAN_SPEED_MID_V2;
-+            else if (level == 3)
-+                data = MCU_FAN_SPEED_HIGH_V2;
-+            ret = mcu_i2c_write_regs(g_mcu_data->client,
-+                    MCU_CMD_FAN_STATUS_CTRL_REGv2,
-+                    &data, 1);
-+            if (ret < 0) {
-+                pr_debug("write fan control err\n");
-+                return;
-+            }
-+	      }
-+    }
-+}
-+
-+extern int rk_get_temperature(void);
-+
-+static void fan_work_func(struct work_struct *_work)
-+{
-+    if (is_mcu_fan_control_supported()) {
-+        int temp = -EINVAL;
-+        struct mcu_fan_data *fan_data = &g_mcu_data->fan_data;
-+
-+		if (g_mcu_data->board == KHADAS_BOARD_EDGE2) {
-+				printk("temp start23!!\r\n");
-+            temp = rk_get_temperature();
-+		} else {
-+			printk("temp start!!\r\n");
-+           temp = fan_data->trig_temp_level0;
-+		}
-+
-+		if (temp != -EINVAL) {
-+            if (temp < fan_data->trig_temp_level0)
-+                mcu_fan_level_set(fan_data, 0);
-+            else if (temp < fan_data->trig_temp_level1)
-+                mcu_fan_level_set(fan_data, 1);
-+            else if (temp < fan_data->trig_temp_level2)
-+                mcu_fan_level_set(fan_data, 2);
-+            else
-+                mcu_fan_level_set(fan_data, 3);
-+        }
-+
-+        schedule_delayed_work(&fan_data->work, MCU_FAN_LOOP_SECS);
-+    }
-+}
-+
-+static void khadas_fan_set(struct mcu_fan_data  *fan_data)
-+{
-+	if (is_mcu_fan_control_supported()) {
-+        cancel_delayed_work(&fan_data->work);
-+        if (fan_data->enable == MCU_FAN_STATUS_DISABLE) {
-+            mcu_fan_level_set(fan_data, 0);
-+            return;
-+        }
-+        switch (fan_data->mode) {
-+        case MCU_FAN_MODE_MANUAL:
-+            switch (fan_data->level) {
-+				case MCU_FAN_LEVEL_0:
-+					mcu_fan_level_set(fan_data, 0);
-+					break;
-+				case MCU_FAN_LEVEL_1:
-+					mcu_fan_level_set(fan_data, 1);
-+					break;
-+				case MCU_FAN_LEVEL_2:
-+					mcu_fan_level_set(fan_data, 2);
-+					break;
-+				case MCU_FAN_LEVEL_3:
-+					mcu_fan_level_set(fan_data, 3);
-+					break;
-+				default:
-+					break;
-+            }
-+            break;
-+		case MCU_FAN_MODE_AUTO:
-+            // FIXME: achieve with a better way
-+			schedule_delayed_work(&fan_data->work,
-+                    MCU_FAN_LOOP_NODELAY_SECS);
-+			break;
-+		default:
-+			break;
-+        }
-+    }
-+}
-+
-+static ssize_t show_fan_enable(struct class *cls,
-+             struct class_attribute *attr, char *buf)
-+{
-+    return sprintf(buf, "Fan enable: %d\n", g_mcu_data->fan_data.enable);
-+}
-+
-+static ssize_t store_fan_enable(struct class *cls, struct class_attribute *attr,
-+               const char *buf, size_t count)
-+{
-+    int enable;
-+
-+    if (kstrtoint(buf, 0, &enable))
-+        return -EINVAL;
-+
-+    // 0: manual, 1: auto
-+    if (enable >= 0 && enable < 2) {
-+        g_mcu_data->fan_data.enable = enable;
-+        khadas_fan_set(&g_mcu_data->fan_data);
-+    }
-+
-+	return count;
-+}
-+
-+
-+static ssize_t show_fan_mode(struct class *cls,
-+             struct class_attribute *attr, char *buf)
-+{
-+    return sprintf(buf, "Fan mode: %d\n", g_mcu_data->fan_data.mode);
-+}
-+
-+static ssize_t store_fan_mode(struct class *cls, struct class_attribute *attr,
-+               const char *buf, size_t count)
-+{
-+    int mode;
-+
-+    if (kstrtoint(buf, 0, &mode))
-+        return -EINVAL;
-+
-+    // 0: manual, 1: auto
-+    if (mode >= 0 && mode < 2) {
-+        g_mcu_data->fan_data.mode = mode;
-+        khadas_fan_set(&g_mcu_data->fan_data);
-+    }
-+
-+    return count;
-+}
-+
-+static ssize_t show_fan_level(struct class *cls,
-+             struct class_attribute *attr, char *buf)
-+{
-+    return sprintf(buf, "Fan level: %d\n", g_mcu_data->fan_data.level);
-+}
-+
-+static ssize_t store_fan_level(struct class *cls, struct class_attribute *attr,
-+               const char *buf, size_t count)
-+{
-+    int level;
-+
-+    if (kstrtoint(buf, 0, &level))
-+        return -EINVAL;
-+
-+    if (level >= 0 && level < 4) {
-+        g_mcu_data->fan_data.level = level;
-+        khadas_fan_set(&g_mcu_data->fan_data);
-+    }
-+
-+    return count;
-+}
-+
-+static ssize_t show_fan_temp(struct class *cls,
-+             struct class_attribute *attr, char *buf)
-+{
-+    struct mcu_fan_data *fan_data = &g_mcu_data->fan_data;
-+    int temp = -EINVAL;
-+
-+    if (g_mcu_data->board == KHADAS_BOARD_EDGE2)
-+        temp = rk_get_temperature();
-+    else
-+        temp = fan_data->trig_temp_level0;
-+
-+    return sprintf(buf,
-+            "cpu_temp:%d\nFan trigger temperature: level0:%d level1:%d level2:%d\n",
-+            temp, g_mcu_data->fan_data.trig_temp_level0,
-+            g_mcu_data->fan_data.trig_temp_level1,
-+            g_mcu_data->fan_data.trig_temp_level2);
-+}
-+
-+void fan_level_set(struct mcu_data *ug_mcu_data)
-+{
-+    struct mcu_fan_data *fan_data = &g_mcu_data->fan_data;
-+    int temp = -EINVAL;
-+
-+    if (ug_mcu_data->board == KHADAS_BOARD_EDGE2)
-+        temp = rk_get_temperature();
-+    else
-+        temp = fan_data->trig_temp_level0;
-+
-+    if (temp != -EINVAL) {
-+        if (temp < ug_mcu_data->fan_data.trig_temp_level0)
-+            mcu_fan_level_set(fan_data, 0);
-+        else if (temp < ug_mcu_data->fan_data.trig_temp_level1)
-+            mcu_fan_level_set(fan_data, 1);
-+        else if (temp < ug_mcu_data->fan_data.trig_temp_level2)
-+            mcu_fan_level_set(fan_data, 2);
-+        else
-+            mcu_fan_level_set(fan_data, 3);
-+    }
-+}
-+
-+static ssize_t show_fan_trigger_low(struct class *cls,
-+        struct class_attribute *attr, char *buf)
-+{
-+    return sprintf(buf,
-+            "Fan trigger low speed temperature:%d\n",
-+            g_mcu_data->fan_data.trig_temp_level0);
-+}
-+
-+static ssize_t store_fan_trigger_low(struct class *cls,
-+        struct class_attribute *attr,
-+        const char *buf, size_t count)
-+{
-+    int trigger;
-+
-+    if (kstrtoint(buf, 0, &trigger))
-+        return -EINVAL;
-+
-+    if (trigger >= g_mcu_data->fan_data.trig_temp_level1) {
-+        pr_err("Invalid parameter\n");
-+        return -EINVAL;
-+    }
-+
-+    g_mcu_data->fan_data.trig_temp_level0 = trigger;
-+
-+    fan_level_set(g_mcu_data);
-+
-+    return count;
-+}
-+
-+static ssize_t show_fan_trigger_mid(struct class *cls,
-+        struct class_attribute *attr, char *buf)
-+{
-+    return sprintf(buf,
-+            "Fan trigger mid speed temperature:%d\n",
-+            g_mcu_data->fan_data.trig_temp_level1);
-+}
-+
-+static ssize_t store_fan_trigger_mid(struct class *cls,
-+        struct class_attribute *attr,
-+        const char *buf, size_t count)
-+{
-+    int trigger;
-+
-+    if (kstrtoint(buf, 0, &trigger))
-+        return -EINVAL;
-+
-+    if (trigger >= g_mcu_data->fan_data.trig_temp_level2 ||
-+            trigger <= g_mcu_data->fan_data.trig_temp_level0){
-+        pr_err("Invalid parameter\n");
-+        return -EINVAL;
-+    }
-+
-+    g_mcu_data->fan_data.trig_temp_level1 = trigger;
-+
-+    fan_level_set(g_mcu_data);
-+
-+    return count;
-+}
-+
-+static ssize_t show_fan_trigger_high(struct class *cls,
-+        struct class_attribute *attr, char *buf)
-+{
-+    return sprintf(buf,
-+            "Fan trigger high speed temperature:%d\n",
-+            g_mcu_data->fan_data.trig_temp_level2);
-+}
-+
-+static ssize_t store_fan_trigger_high(struct class *cls,
-+        struct class_attribute *attr,
-+        const char *buf, size_t count)
-+{
-+    int trigger;
-+
-+    if (kstrtoint(buf, 0, &trigger))
-+        return -EINVAL;
-+
-+    if (trigger <= g_mcu_data->fan_data.trig_temp_level1) {
-+        pr_err("Invalid parameter\n");
-+        return -EINVAL;
-+    }
-+
-+    g_mcu_data->fan_data.trig_temp_level2 = trigger;
-+
-+    fan_level_set(g_mcu_data);
-+
-+    return count;
-+}
-+
- static ssize_t store_mcu_poweroff(struct class *cls,struct class_attribute *attr,
- 				const char *buf, size_t count)
- {
-@@ -141,6 +510,19 @@ static ssize_t store_mcu_rst(struct class *cls, struct class_attribute *attr,
- 	return count;
- }
- 
-+static struct class_attribute fan_class_attrs[] = {
-+    __ATTR(enable, 0644, show_fan_enable, store_fan_enable),
-+    __ATTR(mode, 0644, show_fan_mode, store_fan_mode),
-+    __ATTR(level, 0644, show_fan_level, store_fan_level),
-+    __ATTR(trigger_temp_low, 0644,
-+            show_fan_trigger_low, store_fan_trigger_low),
-+    __ATTR(trigger_temp_mid, 0644,
-+            show_fan_trigger_mid, store_fan_trigger_mid),
-+    __ATTR(trigger_temp_high, 0644,
-+            show_fan_trigger_high, store_fan_trigger_high),
-+    __ATTR(temp, 0644, show_fan_temp, NULL),
-+};
-+
- static struct class_attribute mcu_class_attrs[] = {
- 	__ATTR(poweroff, 0644, NULL, store_mcu_poweroff),
- 	__ATTR(rst, 0644, NULL, store_mcu_rst),
-@@ -160,14 +542,61 @@ static void create_mcu_attrs(void) {
- 			pr_err("create mcu attribute %s fail\n",
- 							mcu_class_attrs[i].attr.name);
- 	}
-+
-+	if (is_mcu_fan_control_supported()) {
-+		g_mcu_data->fan_data.fan_class = class_create(THIS_MODULE, "fan");
-+			if (IS_ERR(g_mcu_data->fan_data.fan_class)) {
-+				pr_err("create fan_class debug class fail\n");
-+				return;
-+			}
-+			for (i = 0; i < ARRAY_SIZE(fan_class_attrs); i++) {
-+				if (class_create_file(g_mcu_data->fan_data.fan_class,
-+                        &fan_class_attrs[i]))
-+					pr_err("create fan attribute %s fail\n", fan_class_attrs[i].attr.name);
-+        }
-+	}
- }
- 
- static int mcu_parse_dt(struct device *dev)
- {
- 	int ret = 0;
-+	const char *hwver = NULL;
- 
- 	if (NULL == dev) return -EINVAL;
- 
-+	ret = of_property_read_string(dev->of_node, "hwver", &hwver);
-+	if (ret < 0) {
-+			return 0;
-+	} else {
-+			if (strstr(hwver, "EDGE2"))
-+					g_mcu_data->board = KHADAS_BOARD_EDGE2;
-+			else
-+					g_mcu_data->board = KHADAS_BOARD_NONE;
-+
-+			if (g_mcu_data->board == KHADAS_BOARD_EDGE2) {
-+					if (strcmp(hwver, "EDGE2.V10") == 0)
-+							g_mcu_data->hwver = KHADAS_BOARD_HWVER_V10;
-+			}
-+	}
-+
-+		ret = of_property_read_u32(dev->of_node,
-+            "fan,trig_temp_level0",
-+            &g_mcu_data->fan_data.trig_temp_level0);
-+    if (ret < 0)
-+        g_mcu_data->fan_data.trig_temp_level0 =
-+            MCU_FAN_TRIG_TEMP_LEVEL0;
-+    ret = of_property_read_u32(dev->of_node,
-+            "fan,trig_temp_level1",
-+            &g_mcu_data->fan_data.trig_temp_level1);
-+    if (ret < 0)
-+        g_mcu_data->fan_data.trig_temp_level1 =
-+            MCU_FAN_TRIG_TEMP_LEVEL1;
-+    ret = of_property_read_u32(dev->of_node,
-+            "fan,trig_temp_level2",&g_mcu_data->fan_data.trig_temp_level2);
-+    if (ret < 0){
-+        g_mcu_data->fan_data.trig_temp_level2 =MCU_FAN_TRIG_TEMP_LEVEL2;
-+	}
-+
- 	return ret;
- }
- 
-@@ -187,6 +616,13 @@ static int mcu_probe(struct i2c_client *client, const struct i2c_device_id *id)
- 
- 	g_mcu_data->client = client;
- 
-+	g_mcu_data->fan_data.mode = MCU_FAN_MODE_AUTO;
-+	g_mcu_data->fan_data.level = MCU_FAN_LEVEL_0;
-+	g_mcu_data->fan_data.enable = MCU_FAN_STATUS_ENABLE;
-+
-+	INIT_DELAYED_WORK(&g_mcu_data->fan_data.work, fan_work_func);
-+	mcu_fan_level_set(&g_mcu_data->fan_data, 0);
-+	schedule_delayed_work(&g_mcu_data->fan_data.work, MCU_FAN_LOOP_SECS);
- 	create_mcu_attrs();
- 
- 	return 0;
-@@ -198,27 +634,33 @@ static int mcu_remove(struct i2c_client *client)
- 	return 0;
- }
- 
--static void mcu_shutdown(struct i2c_client *client)
-+static void khadas_fan_shutdown(struct i2c_client *client)
- {
--	kfree(g_mcu_data);
-+    g_mcu_data->fan_data.enable = MCU_FAN_STATUS_DISABLE;
-+    khadas_fan_set(&g_mcu_data->fan_data);
- }
- 
- #ifdef CONFIG_PM_SLEEP
--static int mcu_suspend(struct device *dev)
-+static int khadas_fan_suspend(struct device *dev)
- {
--	return 0;
-+    cancel_delayed_work(&g_mcu_data->fan_data.work);
-+    mcu_fan_level_set(&g_mcu_data->fan_data, 0);
-+
-+    return 0;
- }
- 
--static int mcu_resume(struct device *dev)
-+static int khadas_fan_resume(struct device *dev)
- {
--	return 0;
-+    khadas_fan_set(&g_mcu_data->fan_data);
-+
-+    return 0;
- }
- 
--static const struct dev_pm_ops mcu_dev_pm_ops = {
--	SET_SYSTEM_SLEEP_PM_OPS(mcu_suspend, mcu_resume)
-+static const struct dev_pm_ops fan_dev_pm_ops = {
-+    SET_SYSTEM_SLEEP_PM_OPS(khadas_fan_suspend, khadas_fan_resume)
- };
- 
--#define MCU_PM_OPS (&(mcu_dev_pm_ops))
-+#define FAN_PM_OPS (&(fan_dev_pm_ops))
- 
- #endif
- 
-@@ -241,12 +683,12 @@ struct i2c_driver mcu_driver = {
- 		.owner  = THIS_MODULE,
- 		.of_match_table = of_match_ptr(mcu_dt_ids),
- #ifdef CONFIG_PM_SLEEP
--		.pm = MCU_PM_OPS,
-+		.pm = FAN_PM_OPS,
- #endif
- 	},
- 	.probe		= mcu_probe,
- 	.remove 	= mcu_remove,
--	.shutdown = mcu_shutdown,
-+	.shutdown = khadas_fan_shutdown,
- 	.id_table	= mcu_id,
- };
- module_i2c_driver(mcu_driver);
-diff --git a/drivers/thermal/rockchip_thermal.c b/drivers/thermal/rockchip_thermal.c
-index 4e8b45219431..73a7e54b6051 100644
---- a/drivers/thermal/rockchip_thermal.c
-+++ b/drivers/thermal/rockchip_thermal.c
-@@ -328,6 +328,8 @@ struct tsadc_table {
- 	int temp;
- };
- 
-+static struct rockchip_thermal_sensor  *g_tsensor_data_ptr;
-+
- static const struct tsadc_table rv1106_code_table[] = {
- 	{0, -40000},
- 	{396, -40000},
-@@ -1854,6 +1856,20 @@ static int rockchip_thermal_get_temp(void *_sensor, int *out_temp)
- 	return retval;
- }
- 
-+int rk_get_temperature(void)
-+{
-+	int temp;
-+	int ret;
-+
-+	ret = rockchip_thermal_get_temp(g_tsensor_data_ptr, &temp);
-+		if (ret) {
-+			pr_debug("rk_get_temp failed!\n");
-+			return ret;
-+		}
-+	     return temp / 1000;
-+}
-+EXPORT_SYMBOL(rk_get_temperature);
-+
- static const struct thermal_zone_of_device_ops rockchip_of_thermal_ops = {
- 	.get_temp = rockchip_thermal_get_temp,
- 	.set_trips = rockchip_thermal_set_trips,
-@@ -2198,6 +2214,7 @@ static int rockchip_thermal_probe(struct platform_device *pdev)
- 	thermal->panic_nb.notifier_call = rockchip_thermal_panic;
- 	atomic_notifier_chain_register(&panic_notifier_list,
- 				       &thermal->panic_nb);
-+	g_tsensor_data_ptr = &thermal->sensors[0];
- 
- 	dev_info(&pdev->dev, "tsadc is probed successfully!\n");
- 
--- 
-Armbian
-
-
-From 11163f5b39499a02d17efcbea459289e550cf9ad Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Fri, 1 Jul 2022 15:21:22 +0800
 Subject: Edge2: WIFI: configure WiFi to dynamically load modules
@@ -10346,12 +8638,12 @@ Subject: Edge2: WIFI: configure WiFi to dynamically load modules
 Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
 Change-Id: I1d289465b87137044d723ce8786c9b0ebfe30dfb
 ---
- arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 13 +++++-----
- arch/arm64/configs/kedges_defconfig                   |  4 +--
- 2 files changed, 9 insertions(+), 8 deletions(-)
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 23 +++++++---
+ arch/arm64/configs/kedges_defconfig                   |  4 +-
+ 2 files changed, 19 insertions(+), 8 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
-index d25c29ccdb00..af36d6db66e3 100644
+index eb9e415aa291..af36d6db66e3 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
 @@ -143,7 +143,7 @@ vcc3v3_pcie20: vcc3v3-pcie20 {
@@ -10375,7 +8667,20 @@ index d25c29ccdb00..af36d6db66e3 100644
  		status = "okay";
  	};
  
-@@ -641,6 +641,7 @@ &pcie2x1l1 {
+@@ -545,6 +545,12 @@ mcu: khadas-mcu@18 {
+ 		compatible = "khadas-mcu";
+ 		status = "okay";
+ 		reg = <0x18>;
++		fan,trig_temp_level0 = <50>;
++		fan,trig_temp_level1 = <60>;
++		fan,trig_temp_level2 = <70>;
++		fan,trig_temp_level3 = <80>;
++		hwver = "EDGE2.V10";
++
+ 	};
+ 
+ 	usbc0: fusb302@22 {
+@@ -635,6 +641,7 @@ &pcie2x1l1 {
  &pcie2x1l2 {
  //	reset-gpios = <&gpio4 RK_PC1 GPIO_ACTIVE_HIGH>;
  	reset-gpios = <&gpio3 RK_PD1 GPIO_ACTIVE_HIGH>;
@@ -10383,7 +8688,7 @@ index d25c29ccdb00..af36d6db66e3 100644
  	rockchip,skip-scan-in-resume;
  	status = "okay";
  };
-@@ -745,9 +746,9 @@ wifi_host_wake_irq: wifi-host-wake-irq {
+@@ -739,9 +746,9 @@ wifi_host_wake_irq: wifi-host-wake-irq {
  			rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_down>;
  		};
  
@@ -10396,6 +8701,17 @@ index d25c29ccdb00..af36d6db66e3 100644
  	};
  };
  
+@@ -921,6 +928,10 @@ spidev@1 {
+ 	};
+ };
+ 
++&tsadc {
++	status = "okay";
++};
++
+ &u2phy0_otg {
+ 	rockchip,typec-vbus-det;
+ };
 diff --git a/arch/arm64/configs/kedges_defconfig b/arch/arm64/configs/kedges_defconfig
 index ad7439f1785f..79c327af8e9d 100644
 --- a/arch/arm64/configs/kedges_defconfig
@@ -10414,8 +8730,7 @@ index ad7439f1785f..79c327af8e9d 100644
 -- 
 Armbian
 
-
-From 490f9f937b2bfc55151442c64e001be9b2de0268 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Sun, 3 Jul 2022 11:02:30 +0800
 Subject: arm64: dts: rockchip: Edge2: modify power pin of SD card
@@ -10442,8 +8757,7 @@ index af36d6db66e3..8c26cef28306 100644
 -- 
 Armbian
 
-
-From b57eb137c9ee4c821e1b75b0b94e59a55d03063e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Tue, 19 Jul 2022 11:14:39 +0800
 Subject: arm64: dts: rockchip: Edge2: HDMI: modify the enable
@@ -10479,8 +8793,7 @@ index 8c26cef28306..54378b6eb309 100644
 -- 
 Armbian
 
-
-From 5112645a85889dd4069510f8906234d104ab6e67 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Mon, 4 Jul 2022 09:48:52 +0800
 Subject: arm64: dts: rockchip: Edge2: mount fusb302 to i2c2
@@ -10654,8 +8967,7 @@ index 54378b6eb309..e26b92dfd61d 100644
 -- 
 Armbian
 
-
-From eb6eea26bca7ea7acd4737dc3c74c611d90ec16e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Mon, 4 Jul 2022 10:10:44 +0800
 Subject: arm64: dts: rockchip: Edge2: modify the pin of USB power
@@ -10691,8 +9003,7 @@ index e26b92dfd61d..1b84fa8c6c23 100644
 -- 
 Armbian
 
-
-From 4bce0edda0e02d6eb8c29bb445fa69e58a5f56e2 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Mon, 4 Jul 2022 10:35:06 +0800
 Subject: arm64: dts: rockchip: Edge2: modify the pin of typec0 int
@@ -10719,8 +9030,7 @@ index 1b84fa8c6c23..19cebdd854f3 100644
 -- 
 Armbian
 
-
-From f56d8b508a072d24c02b70a6ff1fdaaa6f9608d3 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Mon, 4 Jul 2022 11:05:53 +0800
 Subject: arm64: dts: rockchip: Edge2: modify the power pin of WiFi
@@ -10747,8 +9057,7 @@ index 19cebdd854f3..392e74ff2e83 100644
 -- 
 Armbian
 
-
-From fed21b6e4e4a4f33e3efa00e260fbc6666cd0bc4 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Mon, 4 Jul 2022 12:37:25 +0800
 Subject: arm64: dts: rockchip: Edge2: RTC: configure pt7c4363 to i2c2
@@ -10796,8 +9105,7 @@ index 392e74ff2e83..7d11aa804095 100644
 -- 
 Armbian
 
-
-From 4b03cac2e9ae4ff2e2d5c9f88c15333ebae27aaf Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Mon, 4 Jul 2022 15:20:52 +0800
 Subject: arm64: dts: rockchip: Edge2: fix khadas RGB led
@@ -10840,8 +9148,7 @@ index 7d11aa804095..27ad51bf4237 100644
 -- 
 Armbian
 
-
-From 5088b579d83c352fc67bd26d5720759282901332 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Mon, 4 Jul 2022 16:44:22 +0800
 Subject: Edge2: fix MCU and fan
@@ -10850,8 +9157,7 @@ Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
 Change-Id: Id6d9980f32b281db7156d5699524c7b4134fc59c
 ---
  arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 24 +++++-----
- drivers/misc/khadas-mcu.c                             | 10 ++--
- 2 files changed, 16 insertions(+), 18 deletions(-)
+ 1 file changed, 12 insertions(+), 12 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
 index 27ad51bf4237..b8e8fc3611be 100644
@@ -10895,55 +9201,10 @@ index 27ad51bf4237..b8e8fc3611be 100644
  };
  
  &pcie2x1l1 {
-diff --git a/drivers/misc/khadas-mcu.c b/drivers/misc/khadas-mcu.c
-index 67c3d6a6ee91..03f4eedbb62d 100644
---- a/drivers/misc/khadas-mcu.c
-+++ b/drivers/misc/khadas-mcu.c
-@@ -50,7 +50,7 @@ enum khadas_board {
- 
- enum khadas_board_hwver {
- 	KHADAS_BOARD_HWVER_NONE = 0,
--	KHADAS_BOARD_HWVER_V10
-+	KHADAS_BOARD_HWVER_V11
- };
- 
- enum mcu_fan_mode {
-@@ -161,7 +161,7 @@ static int is_mcu_fan_control_supported(void)
- 	// MCU FAN control is supported for:
- 	// 1. Khadas EDGE2
- 	if (g_mcu_data->board == KHADAS_BOARD_EDGE2) {
--		if (g_mcu_data->hwver >= KHADAS_BOARD_HWVER_V10)
-+		if (g_mcu_data->hwver >= KHADAS_BOARD_HWVER_V11)
- 			return 1;
- 		else
- 			return 0;
-@@ -207,10 +207,8 @@ static void fan_work_func(struct work_struct *_work)
-         struct mcu_fan_data *fan_data = &g_mcu_data->fan_data;
- 
- 		if (g_mcu_data->board == KHADAS_BOARD_EDGE2) {
--				printk("temp start23!!\r\n");
-             temp = rk_get_temperature();
- 		} else {
--			printk("temp start!!\r\n");
-            temp = fan_data->trig_temp_level0;
- 		}
- 
-@@ -574,8 +572,8 @@ static int mcu_parse_dt(struct device *dev)
- 					g_mcu_data->board = KHADAS_BOARD_NONE;
- 
- 			if (g_mcu_data->board == KHADAS_BOARD_EDGE2) {
--					if (strcmp(hwver, "EDGE2.V10") == 0)
--							g_mcu_data->hwver = KHADAS_BOARD_HWVER_V10;
-+					if (strcmp(hwver, "EDGE2.V11") == 0)
-+							g_mcu_data->hwver = KHADAS_BOARD_HWVER_V11;
- 			}
- 	}
- 
 -- 
 Armbian
 
-
-From 91f9a2e4ee7e6b955f876d007f625f9c36c45020 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Tue, 19 Jul 2022 11:31:09 +0800
 Subject: arm64: dts: rockchip: Edge2: fix khadas TS050 TP
@@ -11040,8 +9301,7 @@ index b8e8fc3611be..1bf9dedf6521 100644
 -- 
 Armbian
 
-
-From d70fd7fdea9b1059a375b71852f53036239d6bbe Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Tue, 19 Jul 2022 11:46:37 +0800
 Subject: arm64: dts: rockchip: Edge2: fix khadas mipi lcd panel
@@ -11231,8 +9491,7 @@ index 5a2174676012..c06bc4fda155 100644
 -- 
 Armbian
 
-
-From 323551e03c5f47ffdc0ff42bef193003ee1dccc8 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Tue, 5 Jul 2022 10:43:57 +0800
 Subject: arm64: dts: rockchip: Edge2: fix DP display
@@ -11262,8 +9521,7 @@ index 65df29866c69..8f67b29850a9 100644
 -- 
 Armbian
 
-
-From 527e99b99d1751b94325747f5655cca02f634f94 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Tue, 19 Jul 2022 11:52:18 +0800
 Subject: arm64: dts: rockchip: Edge2: fix camera
@@ -11651,8 +9909,7 @@ index 8f67b29850a9..49926c83b46b 100644
 -- 
 Armbian
 
-
-From 553e5b37cb841adfb803d997f3a5cd9eda6dade3 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Tue, 19 Jul 2022 15:54:13 +0800
 Subject: arm64: dts: Edge2: turn on Bluetooth mic
@@ -11708,8 +9965,7 @@ index 49926c83b46b..1e0e271574eb 100644
 -- 
 Armbian
 
-
-From 22b55aa1e0018545fd39f9fa2799b920440260c6 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jack Zhao <jack.zhao@wesion.com>
 Date: Thu, 21 Jul 2022 14:07:02 +0800
 Subject: arm64: dts: rockchip: Edge2: remove redundant device nodes
@@ -11758,8 +10014,7 @@ index 1e0e271574eb..4c8efd889a1a 100644
 -- 
 Armbian
 
-
-From e885bf862eb2d5b59692463404db55453423dd61 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nick Xie <nick@khadas.com>
 Date: Fri, 26 Aug 2022 16:52:06 +0800
 Subject: arm64: dts: Edge2: disable mipi dsi
@@ -11786,8 +10041,7 @@ index 4c8efd889a1a..a77be850eaf3 100644
 -- 
 Armbian
 
-
-From 18a2faebd627373afd2ea6e166b496c3159692de Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nick Xie <nick@khadas.com>
 Date: Mon, 17 Oct 2022 12:03:48 +0800
 Subject: arm64: dts: Edge2: disable spi1 by default
@@ -11814,8 +10068,7 @@ index a77be850eaf3..edb3cc49eb16 100644
 -- 
 Armbian
 
-
-From 833788ba6b65dd7566d5f24f8f02f2a2d1ba539b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nick Xie <nick@khadas.com>
 Date: Mon, 17 Oct 2022 16:42:23 +0800
 Subject: arm64: dts: Edge2: move spidev to overlays
@@ -11846,8 +10099,7 @@ index edb3cc49eb16..30dfed67f92c 100644
 -- 
 Armbian
 
-
-From b1cb1e25a0cda9600cd2e4c44c10d40b60630cf8 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nick Xie <nick@khadas.com>
 Date: Sat, 5 Nov 2022 02:55:54 +0100
 Subject: bt: disable HCIUART_BCM
@@ -12985,8 +11237,7 @@ index 79c327af8e9d..03e52e066c58 100644
 -- 
 Armbian
 
-
-From 7a08282c7b26233bc24aa9102989db0df5bf47c1 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Yan Wang <frank@khadas.com>
 Date: Mon, 21 Nov 2022 21:55:40 +0800
 Subject: arm64: dts: Edge2: fix imx415
@@ -13162,8 +11413,7 @@ index c1b0f47e2b51..c82770442ee7 100644
 -- 
 Armbian
 
-
-From 18a66b69e56dd37af7c68660dc0702daa55b7215 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nick Xie <nick@khadas.com>
 Date: Tue, 22 Nov 2022 18:01:43 +0800
 Subject: arm64: dts: camera: Edge2: update lens pinctrl
@@ -13233,8 +11483,7 @@ index c82770442ee7..2e27954aed42 100644
 -- 
 Armbian
 
-
-From b84d2982273b805dd1bacac84367121d793a80c5 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nick Xie <nick@khadas.com>
 Date: Tue, 22 Nov 2022 18:02:42 +0800
 Subject: arm64: dts: camera: Edge2: enable mipi_dcphy1
@@ -13261,8 +11510,7 @@ index b2f4fa6b4c09..1174918ed5a0 100644
 -- 
 Armbian
 
-
-From bc37974513c6022a26cabefd4df89cea955606fb Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ivan Li <ivan.li@wesion.com>
 Date: Mon, 5 Dec 2022 10:42:34 +0800
 Subject: dts: rockchip: Edge2: IR: Add khadas remote key value
@@ -13362,8 +11610,7 @@ index 1174918ed5a0..f8c09cdba478 100644
 -- 
 Armbian
 
-
-From 745f671aa85983ef6de01b12d04db7d596760fdc Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nick Xie <nick@khadas.com>
 Date: Tue, 6 Dec 2022 17:25:46 +0800
 Subject: arm64: dts: IR: Edge2: remove unused IR map
@@ -13484,36 +11731,6 @@ index f8c09cdba478..dfacb4da2db7 100644
  };
  
  &pwm7 {
--- 
-Armbian
-
-
-From d194909d2bee110ea2e118bc39d50692c5f301c6 Mon Sep 17 00:00:00 2001
-From: Angus Ainslie <angus@akkea.ca>
-Date: Thu, 12 Aug 2021 09:52:18 -0700
-Subject: Bluetooth: btbcm: add patch ram for bluetooth
-
-Bluetooth on the BCM43752 needs a patchram file to function correctly.
-
-Signed-off-by: Angus Ainslie <angus@akkea.ca>
-Signed-off-by: Marcel Holtmann <marcel@holtmann.org>
-Change-Id: Ieaeb28c8cdfdfdebe4f5be547a01024ba4188cb9
----
- drivers/bluetooth/btbcm.c | 1 +
- 1 file changed, 1 insertion(+)
-
-diff --git a/drivers/bluetooth/btbcm.c b/drivers/bluetooth/btbcm.c
-index 1b9743b7f2ef..c5af5715cd17 100644
---- a/drivers/bluetooth/btbcm.c
-+++ b/drivers/bluetooth/btbcm.c
-@@ -387,6 +387,7 @@ struct bcm_subver_table {
- };
- 
- static const struct bcm_subver_table bcm_uart_subver_table[] = {
-+	{ 0x1111, "BCM4362A2"	},	/* 000.017.017 */
- 	{ 0x4103, "BCM4330B1"	},	/* 002.001.003 */
- 	{ 0x410d, "BCM4334B0"	},	/* 002.001.013 */
- 	{ 0x410e, "BCM43341B0"	},	/* 002.001.014 */
 -- 
 Armbian
 

--- a/patch/kernel/rockchip-rk3588-legacy/3001_most_of_khadas_incl_dts_and_drivers.patch.disabled
+++ b/patch/kernel/rockchip-rk3588-legacy/3001_most_of_khadas_incl_dts_and_drivers.patch.disabled
@@ -1,0 +1,13519 @@
+From cda3b5543a39e9c8c897f3a4a1005aa169fbe608 Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Tue, 19 Jul 2022 08:55:30 +0800
+Subject: arm64: rockchip: Edge2: configure Edge2 basic support
+
+rk3588s-khadas-edge2.dts from rk3588s-evb1-lp4x-v10-linux.dts rk3588s-evb1-lp4x.dtsi
+rk3588s-khadas-edge2.dtsi from rk3588s-evb.dtsi
+rk3588s-khadas-edge2-camera.dtsi from rk3588s-evb1-lp4x-v10-camera.dtsi
+kedges_defconfig from rockchip_linux_defconfig rk3588_edge.config
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: I3510b4538920e4fb1ed5e9f242b6a591f04d9ef2
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi |  345 +++
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts         |  801 +++++++
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi        | 1148 ++++++++++
+ arch/arm64/configs/kedges_defconfig                           |  595 +++++
+ 4 files changed, 2889 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi
+new file mode 100644
+index 000000000000..9d0593167702
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi
+@@ -0,0 +1,345 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2022 Wesion Technology Co., Ltd.
++ *
++ */
++
++&csi2_dcphy0 {
++	status = "okay";
++
++	ports {
++		#address-cells = <1>;
++		#size-cells = <0>;
++		port@0 {
++			reg = <0>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			dp_mipi_in: endpoint@1 {
++				reg = <1>;
++				remote-endpoint = <&lt7911d_out>;
++				data-lanes = <1 2 3 4>;
++			};
++			mipi_in_dcphy0: endpoint@2 {
++				reg = <2>;
++				remote-endpoint = <&ov50c40_out0>;
++				data-lanes = <1 2 3 4>;
++			};
++		};
++
++		port@1 {
++			reg = <1>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			csidcphy0_out: endpoint@0 {
++				reg = <0>;
++				remote-endpoint = <&mipi0_csi2_input>;
++			};
++		};
++	};
++};
++
++&csi2_dcphy1 {
++	status = "okay";
++
++	ports {
++		#address-cells = <1>;
++		#size-cells = <0>;
++		port@0 {
++			reg = <0>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			mipi_in_dcphy1: endpoint@1 {
++				reg = <1>;
++				remote-endpoint = <&ov50c40_out1>;
++				data-lanes = <1 2 3 4>;
++			};
++		};
++		port@1 {
++			reg = <1>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			csidcphy1_out: endpoint@0 {
++				reg = <0>;
++				remote-endpoint = <&mipi1_csi2_input>;
++			};
++		};
++	};
++};
++
++&i2c6 {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c6m4_xfer>;
++
++	aw8601: aw8601@c {
++		compatible = "awinic,aw8601";
++		status = "okay";
++		reg = <0x0c>;
++		rockchip,vcm-start-current = <56>;
++		rockchip,vcm-rated-current = <96>;
++		rockchip,vcm-step-mode = <4>;
++		rockchip,camera-module-index = <0>;
++		rockchip,camera-module-facing = "back";
++	};
++
++	lt7911d: lt7911d@2b {
++		compatible = "lontium,lt7911d";
++		status = "okay";
++		reg = <0x2b>;
++		clocks = <&cru CLK_MIPI_CAMARAOUT_M1>;
++		clock-names = "xvclk";
++		interrupt-parent = <&gpio3>;
++		interrupts = <RK_PD4 IRQ_TYPE_EDGE_RISING>;
++		power-domains = <&power RK3588_PD_VI>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&mipim1_camera1_clk>;
++		reset-gpios = <&gpio3 RK_PC4 GPIO_ACTIVE_LOW>;
++		power-gpios = <&gpio1 RK_PA6 GPIO_ACTIVE_HIGH>;
++		// hpd-ctl-gpios = <&gpio3 RK_PC5 GPIO_ACTIVE_HIGH>;
++		// plugin-det-gpios = <&gpio0 RK_PD6 GPIO_ACTIVE_LOW>;
++		rockchip,camera-module-index = <0>;
++		rockchip,camera-module-facing = "back";
++		rockchip,camera-module-name = "LT7911D";
++		rockchip,camera-module-lens-name = "NC";
++		port {
++			lt7911d_out: endpoint {
++				remote-endpoint = <&dp_mipi_in>;
++				data-lanes = <1 2 3 4>;
++			};
++		};
++	};
++
++	ov50c40: ov50c40@36 {
++		compatible = "ovti,ov50c40";
++		status = "okay";
++		reg = <0x36>;
++		clocks = <&cru CLK_MIPI_CAMARAOUT_M1>;
++		clock-names = "xvclk";
++		power-domains = <&power RK3588_PD_VI>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&mipim1_camera1_clk>;
++		rockchip,grf = <&sys_grf>;
++		reset-gpios = <&gpio3 RK_PC4 GPIO_ACTIVE_LOW>;
++		pwdn-gpios = <&gpio3 RK_PD4 GPIO_ACTIVE_LOW>;
++		rockchip,camera-module-index = <0>;
++		rockchip,camera-module-facing = "back";
++		rockchip,camera-module-name = "HZGA06";
++		rockchip,camera-module-lens-name = "ZE0082C1";
++		eeprom-ctrl = <&otp_eeprom>;
++		lens-focus = <&aw8601>;
++		port {
++			ov50c40_out0: endpoint {
++				remote-endpoint = <&mipi_in_dcphy0>;
++				data-lanes = <1 2 3 4>;
++			};
++		};
++	};
++
++	otp_eeprom: otp_eeprom@50 {
++		compatible = "rk,otp_eeprom";
++		status = "okay";
++		reg = <0x50>;
++	};
++};
++
++&i2c7 {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c7m2_xfer>;
++
++	aw8601b: aw8601b@c {
++		compatible = "awinic,aw8601";
++		status = "okay";
++		reg = <0x0c>;
++		rockchip,vcm-start-current = <56>;
++		rockchip,vcm-rated-current = <96>;
++		rockchip,vcm-step-mode = <4>;
++		rockchip,camera-module-index = <1>;
++		rockchip,camera-module-facing = "back";
++	};
++
++	ov50c40b: ov50c40b@36 {
++		compatible = "ovti,ov50c40";
++		status = "okay";
++		reg = <0x36>;
++		clocks = <&cru CLK_MIPI_CAMARAOUT_M2>;
++		clock-names = "xvclk";
++		power-domains = <&power RK3588_PD_VI>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&mipim1_camera2_clk>;
++		rockchip,grf = <&sys_grf>;
++		reset-gpios = <&gpio3 RK_PC5 GPIO_ACTIVE_LOW>;
++		pwdn-gpios = <&gpio3 RK_PD5 GPIO_ACTIVE_LOW>;
++		rockchip,camera-module-index = <1>;
++		rockchip,camera-module-facing = "back";
++		rockchip,camera-module-name = "HZGA06";
++		rockchip,camera-module-lens-name = "ZE0082C1";
++		eeprom-ctrl = <&otp_eeprom_b>;
++		lens-focus = <&aw8601b>;
++		port {
++			ov50c40_out1: endpoint {
++				remote-endpoint = <&mipi_in_dcphy1>;
++				data-lanes = <1 2 3 4>;
++			};
++		};
++	};
++
++	otp_eeprom_b: otp_eeprom_b@50 {
++		compatible = "rk,otp_eeprom";
++		status = "okay";
++		reg = <0x50>;
++	};
++};
++
++&mipi_dcphy0 {
++	status = "okay";
++};
++
++&mipi_dcphy1 {
++	status = "okay";
++};
++
++&mipi0_csi2 {
++	status = "okay";
++
++	ports {
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		port@0 {
++			reg = <0>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			mipi0_csi2_input: endpoint@1 {
++				reg = <1>;
++				remote-endpoint = <&csidcphy0_out>;
++			};
++		};
++
++		port@1 {
++			reg = <1>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			mipi0_csi2_output: endpoint@0 {
++				reg = <0>;
++				remote-endpoint = <&cif_mipi_in0>;
++			};
++		};
++	};
++};
++
++&mipi1_csi2 {
++	status = "okay";
++
++	ports {
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		port@0 {
++			reg = <0>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			mipi1_csi2_input: endpoint@1 {
++				reg = <1>;
++				remote-endpoint = <&csidcphy1_out>;
++			};
++		};
++
++		port@1 {
++			reg = <1>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			mipi1_csi2_output: endpoint@0 {
++				reg = <0>;
++				remote-endpoint = <&cif_mipi_in1>;
++			};
++		};
++	};
++};
++
++&rkcif {
++	status = "okay";
++};
++
++&rkcif_mipi_lvds {
++	status = "okay";
++
++	port {
++		cif_mipi_in0: endpoint {
++			remote-endpoint = <&mipi0_csi2_output>;
++		};
++	};
++};
++
++&rkcif_mipi_lvds_sditf {
++	status = "okay";
++
++	port {
++		mipi_lvds_sditf: endpoint {
++			remote-endpoint = <&isp1_in1>;
++		};
++	};
++};
++
++&rkcif_mipi_lvds1 {
++	status = "okay";
++
++	port {
++		cif_mipi_in1: endpoint {
++			remote-endpoint = <&mipi1_csi2_output>;
++		};
++	};
++};
++
++&rkcif_mipi_lvds1_sditf {
++	status = "okay";
++
++	port {
++		mipi1_lvds_sditf: endpoint {
++			remote-endpoint = <&isp1_in2>;
++		};
++	};
++};
++
++&rkcif_mmu {
++	status = "okay";
++};
++
++&rkisp_unite {
++	status = "okay";
++
++};
++
++&rkisp_unite_mmu {
++	status = "okay";
++};
++
++&rkisp0_vir0 {
++	status = "okay";
++	/*
++	 * dual isp process image case
++	 * other rkisp hw and virtual nodes should disabled
++	 */
++	rockchip,hw = <&rkisp_unite>;
++	port {
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		isp1_in1: endpoint@0 {
++			reg = <0>;
++			remote-endpoint = <&mipi_lvds_sditf>;
++		};
++		isp1_in2: endpoint@1 {
++			reg = <1>;
++			remote-endpoint = <&mipi1_lvds_sditf>;
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+new file mode 100644
+index 000000000000..91ce4c575d14
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -0,0 +1,801 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2022 Wesion Technology Co., Ltd.
++ *
++ */
++/dts-v1/;
++
++#include "dt-bindings/usb/pd.h"
++#include "rk3588s.dtsi"
++#include "rk3588s-khadas-edge2.dtsi"
++#include "rk3588s-rk806-dual.dtsi"
++#include "rk3588-linux.dtsi"
++#include "rk3588s-khadas-edge2-camera.dtsi"
++
++
++/ {
++	model = "Khadas Edge2";
++	compatible = "khadas,edge2", "rockchip,rk3588";
++
++	combophy_avdd0v85: combophy-avdd0v85 {
++		compatible = "regulator-fixed";
++		regulator-name = "combophy_avdd0v85";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <850000>;
++		regulator-max-microvolt = <850000>;
++		vin-supply = <&vdd_0v85_s0>;
++	};
++
++	combophy_avdd1v8: combophy-avdd1v8 {
++		compatible = "regulator-fixed";
++		regulator-name = "combophy_avdd1v8";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&avcc_1v8_s0>;
++	};
++
++	es7202_sound_micarray: es7202-sound-micarray {
++		status = "okay";
++		compatible = "simple-audio-card";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,name = "rockchip,sound-micarray";
++		simple-audio-card,mclk-fs = <256>;
++		simple-audio-card,dai-link@0 {
++			format = "pdm";
++			cpu {
++				sound-dai = <&pdm0>;
++			};
++			codec {
++				sound-dai = <&es7202>;
++			};
++		};
++	};
++
++	es8388_sound: es8388-sound {
++		status = "okay";
++		compatible = "rockchip,multicodecs-card";
++		rockchip,card-name = "rockchip-es8388";
++		hp-det-gpio = <&gpio1 RK_PD0 GPIO_ACTIVE_LOW>;
++		io-channels = <&saradc 3>;
++		io-channel-names = "adc-detect";
++		keyup-threshold-microvolt = <1800000>;
++		poll-interval = <100>;
++		spk-con-gpio = <&gpio4 RK_PA5 GPIO_ACTIVE_HIGH>;
++		hp-con-gpio = <&gpio4 RK_PA4 GPIO_ACTIVE_HIGH>;
++		rockchip,format = "i2s";
++		rockchip,mclk-fs = <256>;
++		rockchip,cpu = <&i2s0_8ch>;
++		rockchip,codec = <&es8388>;
++		rockchip,audio-routing =
++			"Headphone", "LOUT1",
++			"Headphone", "ROUT1",
++			"Speaker", "LOUT2",
++			"Speaker", "ROUT2",
++			"Headphone", "Headphone Power",
++			"Headphone", "Headphone Power",
++			"Speaker", "Speaker Power",
++			"Speaker", "Speaker Power",
++			"LINPUT1", "Main Mic",
++			"LINPUT2", "Main Mic",
++			"RINPUT1", "Headset Mic",
++			"RINPUT2", "Headset Mic";
++		pinctrl-names = "default";
++		pinctrl-0 = <&hp_det>;
++		play-pause-key {
++			label = "playpause";
++			linux,code = <KEY_PLAYPAUSE>;
++			press-threshold-microvolt = <2000>;
++		};
++	};
++
++	fan: pwm-fan {
++		compatible = "pwm-fan";
++		#cooling-cells = <2>;
++		pwms = <&pwm11 0 50000 0>;
++	};
++
++	hall_sensor: hall-mh248 {
++		compatible = "hall-mh248";
++		pinctrl-names = "default";
++		pinctrl-0 = <&mh248_irq_gpio>;
++		irq-gpio = <&gpio0 RK_PD4 IRQ_TYPE_EDGE_BOTH>;
++		hall-active = <1>;
++		status = "okay";
++	};
++
++	panel-edp {
++		compatible = "simple-panel";
++		backlight = <&backlight>;
++		power-supply = <&vcc3v3_lcd_edp>;
++		prepare-delay-ms = <120>;
++		enable-delay-ms = <120>;
++		unprepare-delay-ms = <120>;
++		disable-delay-ms = <120>;
++		width-mm = <129>;
++		height-mm = <171>;
++
++		panel-timing {
++			clock-frequency = <200000000>;
++			hactive = <1536>;
++			vactive = <2048>;
++			hfront-porch = <12>;
++			hsync-len = <16>;
++			hback-porch = <48>;
++			vfront-porch = <8>;
++			vsync-len = <4>;
++			vback-porch = <8>;
++			hsync-active = <0>;
++			vsync-active = <0>;
++			de-active = <0>;
++			pixelclk-active = <0>;
++		};
++
++		port {
++			panel_in_edp: endpoint {
++				remote-endpoint = <&edp_out_panel>;
++			};
++		};
++	};
++
++	vbus5v0_typec: vbus5v0-typec {
++		compatible = "regulator-fixed";
++		regulator-name = "vbus5v0_typec";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		enable-active-high;
++		gpio = <&gpio1 RK_PA1 GPIO_ACTIVE_HIGH>;
++		vin-supply = <&vcc5v0_usb>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&typec5v_pwren>;
++	};
++
++	vcc3v3_lcd_edp: vcc3v3-lcd-edp {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc3v3_lcd_edp";
++		gpio = <&gpio1 RK_PA5 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++		regulator-boot-on;
++		vin-supply = <&vcc_3v3_s3>;
++	};
++
++	vcc3v3_pcie20: vcc3v3-pcie20 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc3v3_pcie20";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		enable-active-high;
++		gpios = <&gpio4 RK_PB1 GPIO_ACTIVE_HIGH>;
++		startup-delay-us = <5000>;
++		vin-supply = <&vcc12v_dcin>;
++	};
++
++	vcc5v0_host: vcc5v0-host {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_host";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		enable-active-high;
++		gpio = <&gpio1 RK_PB1 GPIO_ACTIVE_HIGH>;
++		vin-supply = <&vcc5v0_usb>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc5v0_host_en>;
++	};
++
++	wireless_bluetooth: wireless-bluetooth {
++		compatible = "bluetooth-platdata";
++		clocks = <&hym8563>;
++		clock-names = "ext_clock";
++		uart_rts_gpios = <&gpio3 RK_PA4 GPIO_ACTIVE_LOW>;
++		pinctrl-names = "default", "rts_gpio";
++		pinctrl-0 = <&uart8m1_rtsn>, <&bt_gpio>;
++		pinctrl-1 = <&uart8_gpios>;
++		BT,reset_gpio    = <&gpio3 RK_PB7 GPIO_ACTIVE_HIGH>;
++		BT,wake_gpio     = <&gpio3 RK_PC1 GPIO_ACTIVE_HIGH>;
++		BT,wake_host_irq = <&gpio3 RK_PC0 GPIO_ACTIVE_HIGH>;
++		status = "okay";
++	};
++
++	wireless_wlan: wireless-wlan {
++		compatible = "wlan-platdata";
++		wifi_chip_type = "ap6275p";
++		pinctrl-names = "default";
++		pinctrl-0 = <&wifi_host_wake_irq>, <&wifi_poweren_gpio>;
++		WIFI,host_wake_irq = <&gpio0 RK_PA0 GPIO_ACTIVE_HIGH>;
++		WIFI,poweren_gpio = <&gpio0 RK_PC7 GPIO_ACTIVE_HIGH>;
++		status = "okay";
++	};
++};
++
++&backlight {
++	pwms = <&pwm12 0 25000 0>;
++	power-supply = <&vcc3v3_lcd_edp>;
++	status = "okay";
++};
++
++&combphy0_ps {
++	status = "okay";
++};
++
++&dp0 {
++	status = "okay";
++};
++
++&dp0_in_vp1 {
++	status = "okay";
++};
++
++&dp0_sound{
++	status = "okay";
++};
++
++&edp0 {
++	force-hpd;
++	status = "okay";
++
++	ports {
++		port@1 {
++			reg = <1>;
++
++			edp_out_panel: endpoint {
++				remote-endpoint = <&panel_in_edp>;
++			};
++		};
++	};
++};
++
++&edp0_in_vp2 {
++	status = "okay";
++};
++
++&hdptxphy0 {
++	/* Single Vdiff Training Table for power reduction (optional) */
++	training-table = /bits/ 8 <
++		/* voltage swing 0, pre-emphasis 0->3 */
++		0x0d 0x00 0x00 0x00 0x00 0x00
++		0x0d 0x00 0x00 0x00 0x00 0x00
++		0x0d 0x00 0x00 0x00 0x00 0x00
++		0x0d 0x00 0x00 0x00 0x00 0x00
++		/* voltage swing 1, pre-emphasis 0->2 */
++		0x0d 0x00 0x00 0x00 0x00 0x00
++		0x0d 0x00 0x00 0x00 0x00 0x00
++		0x0d 0x00 0x00 0x00 0x00 0x00
++		/* voltage swing 2, pre-emphasis 0->1 */
++		0x0d 0x00 0x00 0x00 0x00 0x00
++		0x0d 0x00 0x00 0x00 0x00 0x00
++		/* voltage swing 3, pre-emphasis 0 */
++		0x0d 0x00 0x00 0x00 0x00 0x00
++	>;
++	status = "okay";
++};
++
++&i2c3 {
++	status = "okay";
++
++	es8388: es8388@11 {
++		status = "okay";
++		#sound-dai-cells = <0>;
++		compatible = "everest,es8388", "everest,es8323";
++		reg = <0x11>;
++		clocks = <&cru I2S0_8CH_MCLKOUT>;
++		clock-names = "mclk";
++		assigned-clocks = <&cru I2S0_8CH_MCLKOUT>;
++		assigned-clock-rates = <12288000>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&i2s0_mclk>;
++	};
++
++	es7202: es7202@32 {
++		status = "okay";
++		#sound-dai-cells = <0>;
++		compatible = "ES7202_PDM_ADC_1";
++		power-supply = <&vcc_1v8_s0>;	/* only 1v8 or 3v3, default is 3v3 */
++		reg = <0x32>;
++	};
++};
++
++&i2c4 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c4m3_xfer>;
++	status = "okay";
++
++	gsl3673@40 {
++		compatible = "GSL,GSL3673";
++		reg = <0x40>;
++		screen_max_x = <1536>;
++		screen_max_y = <2048>;
++		irq_gpio_number = <&gpio1 RK_PB5 IRQ_TYPE_LEVEL_LOW>;
++		rst_gpio_number = <&gpio1 RK_PB4 GPIO_ACTIVE_HIGH>;
++	};
++};
++
++&i2c5 {
++	status = "okay";
++
++	ls_stk3332: light@47 {
++		compatible = "ls_stk3332";
++		status = "disabled";
++		reg = <0x47>;
++		type = <SENSOR_TYPE_LIGHT>;
++		irq_enable = <0>;
++		als_threshold_high = <100>;
++		als_threshold_low = <10>;
++		als_ctrl_gain = <2>; /* 0:x1 1:x4 2:x16 3:x64 */
++		poll_delay_ms = <100>;
++	};
++
++	ps_stk3332: proximity@47 {
++		compatible = "ps_stk3332";
++		status = "disabled";
++		reg = <0x47>;
++		type = <SENSOR_TYPE_PROXIMITY>;
++		//pinctrl-names = "default";
++		//pinctrl-0 = <&gpio3_c6>;
++		//irq-gpio = <&gpio3 RK_PC6 IRQ_TYPE_LEVEL_LOW>;
++		//irq_enable = <1>;
++		ps_threshold_high = <0x200>;
++		ps_threshold_low = <0x100>;
++		ps_ctrl_gain = <3>; /* 0:x1 1:x2 2:x5 3:x8 */
++		ps_led_current = <4>; /* 0:3.125mA 1:6.25mA 2:12.5mA 3:25mA 4:50mA 5:100mA*/
++		poll_delay_ms = <100>;
++	};
++
++	mpu6500_acc: mpu_acc@68 {
++		compatible = "mpu6500_acc";
++		reg = <0x68>;
++		irq-gpio = <&gpio3 RK_PB4 IRQ_TYPE_EDGE_RISING>;
++		irq_enable = <0>;
++		poll_delay_ms = <30>;
++		type = <SENSOR_TYPE_ACCEL>;
++		layout = <5>;
++	};
++
++	mpu6500_gyro: mpu_gyro@68 {
++		compatible = "mpu6500_gyro";
++		reg = <0x68>;
++		poll_delay_ms = <30>;
++		type = <SENSOR_TYPE_GYROSCOPE>;
++		layout = <5>;
++	};
++};
++
++&i2c8 {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c8m2_xfer>;
++
++	usbc0: fusb302@22 {
++		compatible = "fcs,fusb302";
++		reg = <0x22>;
++		interrupt-parent = <&gpio0>;
++		interrupts = <RK_PD3 IRQ_TYPE_LEVEL_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&usbc0_int>;
++		vbus-supply = <&vbus5v0_typec>;
++		status = "okay";
++
++		ports {
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			port@0 {
++				reg = <0>;
++				usbc0_role_sw: endpoint@0 {
++					remote-endpoint = <&dwc3_0_role_switch>;
++				};
++			};
++		};
++
++		usb_con: connector {
++			compatible = "usb-c-connector";
++			label = "USB-C";
++			data-role = "dual";
++			power-role = "dual";
++			try-power-role = "sink";
++			op-sink-microwatt = <1000000>;
++			sink-pdos =
++				<PDO_FIXED(5000, 1000, PDO_FIXED_USB_COMM)>;
++			source-pdos =
++				<PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>;
++
++			altmodes {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				altmode@0 {
++					reg = <0>;
++					svid = <0xff01>;
++					vdo = <0xffffffff>;
++				};
++			};
++
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				port@0 {
++					reg = <0>;
++					usbc0_orien_sw: endpoint {
++						remote-endpoint = <&usbdp_phy0_orientation_switch>;
++					};
++				};
++
++				port@1 {
++					reg = <1>;
++					dp_altmode_mux: endpoint {
++						remote-endpoint = <&usbdp_phy0_dp_altmode_mux>;
++					};
++				};
++			};
++		};
++	};
++
++	hym8563: hym8563@51 {
++		compatible = "haoyu,hym8563";
++		reg = <0x51>;
++		#clock-cells = <0>;
++		clock-frequency = <32768>;
++		clock-output-names = "hym8563";
++		pinctrl-names = "default";
++		pinctrl-0 = <&hym8563_int>;
++		interrupt-parent = <&gpio0>;
++		interrupts = <RK_PC4 IRQ_TYPE_LEVEL_LOW>;
++		wakeup-source;
++	};
++};
++
++&pcie2x1l1 {
++	reset-gpios = <&gpio4 RK_PA2 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc3v3_pcie20>;
++	status = "okay";
++};
++
++&pcie2x1l2 {
++	reset-gpios = <&gpio4 RK_PC1 GPIO_ACTIVE_HIGH>;
++	rockchip,skip-scan-in-resume;
++	status = "okay";
++};
++
++&pdm0 {
++	status = "okay";
++};
++
++&pinctrl {
++	headphone {
++		hp_det: hp-det {
++			rockchip,pins = <1 RK_PD0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	hym8563 {
++		hym8563_int: hym8563-int {
++			rockchip,pins = <0 RK_PC4 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	lcd {
++		lcd_rst_gpio: lcd-rst-gpio {
++			rockchip,pins = <1 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	sensor {
++		mh248_irq_gpio: mh248_irq_gpio {
++			rockchip,pins = <0 RK_PD4 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++
++		mpu6500_irq_gpio: mpu6500_irq_gpio {
++			rockchip,pins = <3 RK_PB4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	usb {
++		vcc5v0_host_en: vcc5v0-host-en {
++			rockchip,pins = <1 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	usb-typec {
++		usbc0_int: usbc0-int {
++			rockchip,pins = <0 RK_PD3 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++
++		typec5v_pwren: typec5v-pwren {
++			rockchip,pins = <1 RK_PA1 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	wireless-bluetooth {
++		uart8_gpios: uart8-gpios {
++			rockchip,pins = <3 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		bt_gpio: bt-gpio {
++			rockchip,pins =
++				<3 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>,
++				<3 RK_PC1 RK_FUNC_GPIO &pcfg_pull_up>,
++				<3 RK_PC0 RK_FUNC_GPIO &pcfg_pull_down>;
++		};
++	};
++
++	wireless-wlan {
++		wifi_host_wake_irq: wifi-host-wake-irq {
++			rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_down>;
++		};
++
++		wifi_poweren_gpio: wifi-poweren-gpio {
++			rockchip,pins = <0 RK_PC7 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++};
++
++&pwm3 {
++	compatible = "rockchip,remotectl-pwm";
++	pinctrl-names = "default";
++	pinctrl-0 = <&pwm3m3_pins>;
++	remote_pwm_id = <3>;
++	handle_cpu_id = <1>;
++	remote_support_psci = <0>;
++	status = "okay";
++
++	ir_key1 {
++		rockchip,usercode = <0x4040>;
++		rockchip,key_table =
++			<0xf2   KEY_REPLY>,
++			<0xba   KEY_BACK>,
++			<0xf4   KEY_UP>,
++			<0xf1   KEY_DOWN>,
++			<0xef   KEY_LEFT>,
++			<0xee   KEY_RIGHT>,
++			<0xbd   KEY_HOME>,
++			<0xea   KEY_VOLUMEUP>,
++			<0xe3   KEY_VOLUMEDOWN>,
++			<0xe2   KEY_SEARCH>,
++			<0xb2   KEY_POWER>,
++			<0xbc   KEY_MUTE>,
++			<0xec   KEY_MENU>,
++			<0xbf   0x190>,
++			<0xe0   0x191>,
++			<0xe1   0x192>,
++			<0xe9   183>,
++			<0xe6   248>,
++			<0xe8   185>,
++			<0xe7   186>,
++			<0xf0   388>,
++			<0xbe   0x175>;
++	};
++
++	ir_key2 {
++		rockchip,usercode = <0xff00>;
++		rockchip,key_table =
++			<0xf9   KEY_HOME>,
++			<0xbf   KEY_BACK>,
++			<0xfb   KEY_MENU>,
++			<0xaa   KEY_REPLY>,
++			<0xb9   KEY_UP>,
++			<0xe9   KEY_DOWN>,
++			<0xb8   KEY_LEFT>,
++			<0xea   KEY_RIGHT>,
++			<0xeb   KEY_VOLUMEDOWN>,
++			<0xef   KEY_VOLUMEUP>,
++			<0xf7   KEY_MUTE>,
++			<0xe7   KEY_POWER>,
++			<0xfc   KEY_POWER>,
++			<0xa9   KEY_VOLUMEDOWN>,
++			<0xa8   KEY_PLAYPAUSE>,
++			<0xe0   KEY_VOLUMEDOWN>,
++			<0xa5   KEY_VOLUMEDOWN>,
++			<0xab   183>,
++			<0xb7   388>,
++			<0xe8   388>,
++			<0xf8   184>,
++			<0xaf   185>,
++			<0xed   KEY_VOLUMEDOWN>,
++			<0xee   186>,
++			<0xb3   KEY_VOLUMEDOWN>,
++			<0xf1   KEY_VOLUMEDOWN>,
++			<0xf2   KEY_VOLUMEDOWN>,
++			<0xf3   KEY_SEARCH>,
++			<0xb4   KEY_VOLUMEDOWN>,
++			<0xa4   KEY_SETUP>,
++			<0xbe   KEY_SEARCH>;
++	};
++
++	ir_key3 {
++		rockchip,usercode = <0x1dcc>;
++		rockchip,key_table =
++			<0xee   KEY_REPLY>,
++			<0xf0   KEY_BACK>,
++			<0xf8   KEY_UP>,
++			<0xbb   KEY_DOWN>,
++			<0xef   KEY_LEFT>,
++			<0xed   KEY_RIGHT>,
++			<0xfc   KEY_HOME>,
++			<0xf1   KEY_VOLUMEUP>,
++			<0xfd   KEY_VOLUMEDOWN>,
++			<0xb7   KEY_SEARCH>,
++			<0xff   KEY_POWER>,
++			<0xf3   KEY_MUTE>,
++			<0xbf   KEY_MENU>,
++			<0xf9   0x191>,
++			<0xf5   0x192>,
++			<0xb3   388>,
++			<0xbe   KEY_1>,
++			<0xba   KEY_2>,
++			<0xb2   KEY_3>,
++			<0xbd   KEY_4>,
++			<0xf9   KEY_5>,
++			<0xb1   KEY_6>,
++			<0xfc   KEY_7>,
++			<0xf8   KEY_8>,
++			<0xb0   KEY_9>,
++			<0xb6   KEY_0>,
++			<0xb5   KEY_BACKSPACE>;
++	};
++};
++
++&pwm11 {
++	pinctrl-0 = <&pwm11m1_pins>;
++	status = "okay";
++};
++
++&pwm12 {
++	pinctrl-0 = <&pwm12m1_pins>;
++	status = "okay";
++};
++
++&rockchip_suspend {
++
++    rockchip,sleep-mode-config = <
++        (0
++        | RKPM_SLP_ARMOFF_DDRPD
++        | RKPM_SLP_PMU_PMUALIVE_32K
++        | RKPM_SLP_PMU_DIS_OSC
++        | RKPM_SLP_32K_EXT
++        | RKPM_SLP_PMU_DBG
++        )
++    >;
++};
++
++&route_hdmi0 {
++    status = "okay";
++    connect = <&vp0_out_hdmi0>;
++    /delete-property/ force-output;
++    /delete-node/ force_timing;
++};
++
++&route_edp0 {
++	connect = <&vp2_out_edp0>;
++	status = "okay";
++};
++
++&sdmmc {
++	status = "okay";
++};
++
++&spdif_tx1 {
++	status = "disabled";
++	pinctrl-names = "default";
++	pinctrl-0 = <&spdif1m1_tx>;
++};
++
++&spdif_tx1_dc {
++	status = "okay";
++};
++
++&spdif_tx1_sound {
++	status = "okay";
++};
++
++&spdif_tx2 {
++	status = "okay";
++};
++
++&u2phy0_otg {
++	rockchip,typec-vbus-det;
++};
++
++&u2phy2_host {
++	phy-supply = <&vcc5v0_host>;
++};
++
++&u2phy3_host {
++	phy-supply = <&vcc5v0_host>;
++};
++
++&uart8 {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart8m1_xfer &uart8m1_ctsn>;
++};
++
++&usbdp_phy0 {
++	orientation-switch;
++	svid = <0xff01>;
++	sbu1-dc-gpios = <&gpio1 RK_PB6 GPIO_ACTIVE_HIGH>;
++	sbu2-dc-gpios = <&gpio1 RK_PB7 GPIO_ACTIVE_HIGH>;
++
++	port {
++		#address-cells = <1>;
++		#size-cells = <0>;
++		usbdp_phy0_orientation_switch: endpoint@0 {
++			reg = <0>;
++			remote-endpoint = <&usbc0_orien_sw>;
++		};
++
++		usbdp_phy0_dp_altmode_mux: endpoint@1 {
++			reg = <1>;
++			remote-endpoint = <&dp_altmode_mux>;
++		};
++	};
++};
++
++&usbdrd_dwc3_0 {
++	usb-role-switch;
++	port {
++		#address-cells = <1>;
++		#size-cells = <0>;
++		dwc3_0_role_switch: endpoint@0 {
++			reg = <0>;
++			remote-endpoint = <&usbc0_role_sw>;
++		};
++	};
++};
++
++&usbhost3_0 {
++	status = "disabled";
++};
++
++&usbhost_dwc3_0 {
++	status = "disabled";
++};
++
++&vdd_log_s0 {
++    regulator-state-mem {
++        regulator-on-in-suspend;
++        regulator-suspend-microvolt = <750000>;
++    };
++};
++
++&vcc_1v8_s0 {
++    /delete-property/ regulator-state-mem;
++    regulator-state-mem {
++        regulator-on-in-suspend;
++        regulator-suspend-microvolt = <1800000>;
++    };
++};
++
++&vcc_3v3_s0 {
++    /delete-property/ regulator-state-mem;
++    regulator-state-mem {
++        regulator-on-in-suspend;
++        regulator-suspend-microvolt = <3300000>;
++    };
++};
++
++/* vp0 & vp3 are not used on this board */
++&vp0 {
++	/delete-property/ rockchip,plane-mask;
++	/delete-property/ rockchip,primary-plane;
++};
++
++&vp1 {
++	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER0 | 1 << ROCKCHIP_VOP2_ESMART0 |
++				1 << ROCKCHIP_VOP2_CLUSTER1 | 1 << ROCKCHIP_VOP2_ESMART1)>;
++	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART1>;
++};
++
++&vp2 {
++	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER2 | 1 << ROCKCHIP_VOP2_ESMART2 |
++				1 << ROCKCHIP_VOP2_CLUSTER3 | 1 << ROCKCHIP_VOP2_ESMART3)>;
++	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART2>;
++};
++
++&vp3 {
++	/delete-property/ rockchip,plane-mask;
++	/delete-property/ rockchip,primary-plane;
++};
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi
+new file mode 100644
+index 000000000000..9d041508cac9
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi
+@@ -0,0 +1,1148 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2022 Wesion Technology Co., Ltd.
++ *
++ */
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/pwm/pwm.h>
++#include <dt-bindings/pinctrl/rockchip.h>
++#include <dt-bindings/input/rk-input.h>
++#include <dt-bindings/display/drm_mipi_dsi.h>
++#include <dt-bindings/display/rockchip_vop.h>
++#include <dt-bindings/sensor-dev.h>
++
++/ {
++	adc_keys: adc-keys {
++		compatible = "adc-keys";
++		io-channels = <&saradc 1>;
++		io-channel-names = "buttons";
++		keyup-threshold-microvolt = <1800000>;
++		poll-interval = <100>;
++
++		vol-up-key {
++			label = "volume up";
++			linux,code = <KEY_VOLUMEUP>;
++			press-threshold-microvolt = <17000>;
++		};
++
++		vol-down-key {
++			label = "volume down";
++			linux,code = <KEY_VOLUMEDOWN>;
++			press-threshold-microvolt = <417000>;
++		};
++
++		menu-key {
++			label = "menu";
++			linux,code = <KEY_MENU>;
++			press-threshold-microvolt = <890000>;
++		};
++
++		back-key {
++			label = "back";
++			linux,code = <KEY_BACK>;
++			press-threshold-microvolt = <1235000>;
++		};
++	};
++
++	backlight: backlight {
++		compatible = "pwm-backlight";
++		brightness-levels = <
++			  0  20  20  21  21  22  22  23
++			 23  24  24  25  25  26  26  27
++			 27  28  28  29  29  30  30  31
++			 31  32  32  33  33  34  34  35
++			 35  36  36  37  37  38  38  39
++			 40  41  42  43  44  45  46  47
++			 48  49  50  51  52  53  54  55
++			 56  57  58  59  60  61  62  63
++			 64  65  66  67  68  69  70  71
++			 72  73  74  75  76  77  78  79
++			 80  81  82  83  84  85  86  87
++			 88  89  90  91  92  93  94  95
++			 96  97  98  99 100 101 102 103
++			104 105 106 107 108 109 110 111
++			112 113 114 115 116 117 118 119
++			120 121 122 123 124 125 126 127
++			128 129 130 131 132 133 134 135
++			136 137 138 139 140 141 142 143
++			144 145 146 147 148 149 150 151
++			152 153 154 155 156 157 158 159
++			160 161 162 163 164 165 166 167
++			168 169 170 171 172 173 174 175
++			176 177 178 179 180 181 182 183
++			184 185 186 187 188 189 190 191
++			192 193 194 195 196 197 198 199
++			200 201 202 203 204 205 206 207
++			208 209 210 211 212 213 214 215
++			216 217 218 219 220 221 222 223
++			224 225 226 227 228 229 230 231
++			232 233 234 235 236 237 238 239
++			240 241 242 243 244 245 246 247
++			248 249 250 251 252 253 254 255
++		>;
++		default-brightness-level = <200>;
++	};
++
++	dp0_sound: dp0-sound {
++		status = "disabled";
++		compatible = "rockchip,hdmi";
++		rockchip,card-name= "rockchip,dp0";
++		rockchip,mclk-fs = <512>;
++		rockchip,cpu = <&spdif_tx2>;
++		rockchip,codec = <&dp0 1>;
++		rockchip,jack-det;
++	};
++
++	hdmi0_sound: hdmi0-sound {
++		status = "disabled";
++		compatible = "simple-audio-card";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,mclk-fs = <128>;
++		simple-audio-card,name = "rockchip,hdmi0";
++
++		simple-audio-card,cpu {
++			sound-dai = <&i2s5_8ch>;
++		};
++		simple-audio-card,codec {
++			sound-dai = <&hdmi0>;
++		};
++	};
++
++	spdif_tx1_dc: spdif-tx1-dc {
++		status = "disabled";
++		compatible = "linux,spdif-dit";
++		#sound-dai-cells = <0>;
++	};
++
++	spdif_tx1_sound: spdif-tx1-sound {
++		status = "disabled";
++		compatible = "simple-audio-card";
++		simple-audio-card,name = "rockchip,spdif-tx1";
++		simple-audio-card,cpu {
++			sound-dai = <&spdif_tx1>;
++		};
++		simple-audio-card,codec {
++			sound-dai = <&spdif_tx1_dc>;
++		};
++	};
++
++	test-power {
++		status = "okay";
++	};
++
++	vcc12v_dcin: vcc12v-dcin {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc12v_dcin";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <12000000>;
++		regulator-max-microvolt = <12000000>;
++	};
++
++	vcc5v0_sys: vcc5v0-sys {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc12v_dcin>;
++	};
++
++	vcc5v0_usbdcin: vcc5v0-usbdcin {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_usbdcin";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc12v_dcin>;
++	};
++
++	vcc5v0_usb: vcc5v0-usb {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_usb";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc5v0_usbdcin>;
++	};
++};
++
++&av1d_mmu {
++	status = "okay";
++};
++
++&combphy0_ps {
++	status = "okay";
++};
++
++&combphy2_psu {
++	status = "okay";
++};
++
++&cpu_l0 {
++	cpu-supply = <&vdd_cpu_lit_s0>;
++	mem-supply = <&vdd_cpu_lit_mem_s0>;
++};
++
++&cpu_b0 {
++	cpu-supply = <&vdd_cpu_big0_s0>;
++	mem-supply = <&vdd_cpu_big0_mem_s0>;
++};
++
++&cpu_b2 {
++	cpu-supply = <&vdd_cpu_big1_s0>;
++	mem-supply = <&vdd_cpu_big1_mem_s0>;
++};
++
++&dsi0 {
++	status = "disabled";
++	//rockchip,lane-rate = <1000>;
++	dsi0_panel: panel@0 {
++		status = "okay";
++		compatible = "simple-panel-dsi";
++		reg = <0>;
++		backlight = <&backlight>;
++		reset-delay-ms = <60>;
++		enable-delay-ms = <60>;
++		prepare-delay-ms = <60>;
++		unprepare-delay-ms = <60>;
++		disable-delay-ms = <60>;
++		dsi,flags = <(MIPI_DSI_MODE_VIDEO | MIPI_DSI_MODE_VIDEO_BURST |
++			MIPI_DSI_MODE_LPM | MIPI_DSI_MODE_EOT_PACKET)>;
++		dsi,format = <MIPI_DSI_FMT_RGB888>;
++		dsi,lanes  = <4>;
++		panel-init-sequence = [
++			23 00 02 FE 21
++			23 00 02 04 00
++			23 00 02 00 64
++			23 00 02 2A 00
++			23 00 02 26 64
++			23 00 02 54 00
++			23 00 02 50 64
++			23 00 02 7B 00
++			23 00 02 77 64
++			23 00 02 A2 00
++			23 00 02 9D 64
++			23 00 02 C9 00
++			23 00 02 C5 64
++			23 00 02 01 71
++			23 00 02 27 71
++			23 00 02 51 71
++			23 00 02 78 71
++			23 00 02 9E 71
++			23 00 02 C6 71
++			23 00 02 02 89
++			23 00 02 28 89
++			23 00 02 52 89
++			23 00 02 79 89
++			23 00 02 9F 89
++			23 00 02 C7 89
++			23 00 02 03 9E
++			23 00 02 29 9E
++			23 00 02 53 9E
++			23 00 02 7A 9E
++			23 00 02 A0 9E
++			23 00 02 C8 9E
++			23 00 02 09 00
++			23 00 02 05 B0
++			23 00 02 31 00
++			23 00 02 2B B0
++			23 00 02 5A 00
++			23 00 02 55 B0
++			23 00 02 80 00
++			23 00 02 7C B0
++			23 00 02 A7 00
++			23 00 02 A3 B0
++			23 00 02 CE 00
++			23 00 02 CA B0
++			23 00 02 06 C0
++			23 00 02 2D C0
++			23 00 02 56 C0
++			23 00 02 7D C0
++			23 00 02 A4 C0
++			23 00 02 CB C0
++			23 00 02 07 CF
++			23 00 02 2F CF
++			23 00 02 58 CF
++			23 00 02 7E CF
++			23 00 02 A5 CF
++			23 00 02 CC CF
++			23 00 02 08 DD
++			23 00 02 30 DD
++			23 00 02 59 DD
++			23 00 02 7F DD
++			23 00 02 A6 DD
++			23 00 02 CD DD
++			23 00 02 0E 15
++			23 00 02 0A E9
++			23 00 02 36 15
++			23 00 02 32 E9
++			23 00 02 5F 15
++			23 00 02 5B E9
++			23 00 02 85 15
++			23 00 02 81 E9
++			23 00 02 AD 15
++			23 00 02 A9 E9
++			23 00 02 D3 15
++			23 00 02 CF E9
++			23 00 02 0B 14
++			23 00 02 33 14
++			23 00 02 5C 14
++			23 00 02 82 14
++			23 00 02 AA 14
++			23 00 02 D0 14
++			23 00 02 0C 36
++			23 00 02 34 36
++			23 00 02 5D 36
++			23 00 02 83 36
++			23 00 02 AB 36
++			23 00 02 D1 36
++			23 00 02 0D 6B
++			23 00 02 35 6B
++			23 00 02 5E 6B
++			23 00 02 84 6B
++			23 00 02 AC 6B
++			23 00 02 D2 6B
++			23 00 02 13 5A
++			23 00 02 0F 94
++			23 00 02 3B 5A
++			23 00 02 37 94
++			23 00 02 64 5A
++			23 00 02 60 94
++			23 00 02 8A 5A
++			23 00 02 86 94
++			23 00 02 B2 5A
++			23 00 02 AE 94
++			23 00 02 D8 5A
++			23 00 02 D4 94
++			23 00 02 10 D1
++			23 00 02 38 D1
++			23 00 02 61 D1
++			23 00 02 87 D1
++			23 00 02 AF D1
++			23 00 02 D5 D1
++			23 00 02 11 04
++			23 00 02 39 04
++			23 00 02 62 04
++			23 00 02 88 04
++			23 00 02 B0 04
++			23 00 02 D6 04
++			23 00 02 12 05
++			23 00 02 3A 05
++			23 00 02 63 05
++			23 00 02 89 05
++			23 00 02 B1 05
++			23 00 02 D7 05
++			23 00 02 18 AA
++			23 00 02 14 36
++			23 00 02 42 AA
++			23 00 02 3D 36
++			23 00 02 69 AA
++			23 00 02 65 36
++			23 00 02 8F AA
++			23 00 02 8B 36
++			23 00 02 B7 AA
++			23 00 02 B3 36
++			23 00 02 DD AA
++			23 00 02 D9 36
++			23 00 02 15 74
++			23 00 02 3F 74
++			23 00 02 66 74
++			23 00 02 8C 74
++			23 00 02 B4 74
++			23 00 02 DA 74
++			23 00 02 16 9F
++			23 00 02 40 9F
++			23 00 02 67 9F
++			23 00 02 8D 9F
++			23 00 02 B5 9F
++			23 00 02 DB 9F
++			23 00 02 17 DC
++			23 00 02 41 DC
++			23 00 02 68 DC
++			23 00 02 8E DC
++			23 00 02 B6 DC
++			23 00 02 DC DC
++			23 00 02 1D FF
++			23 00 02 19 03
++			23 00 02 47 FF
++			23 00 02 43 03
++			23 00 02 6E FF
++			23 00 02 6A 03
++			23 00 02 94 FF
++			23 00 02 90 03
++			23 00 02 BC FF
++			23 00 02 B8 03
++			23 00 02 E2 FF
++			23 00 02 DE 03
++			23 00 02 1A 35
++			23 00 02 44 35
++			23 00 02 6B 35
++			23 00 02 91 35
++			23 00 02 B9 35
++			23 00 02 DF 35
++			23 00 02 1B 45
++			23 00 02 45 45
++			23 00 02 6C 45
++			23 00 02 92 45
++			23 00 02 BA 45
++			23 00 02 E0 45
++			23 00 02 1C 55
++			23 00 02 46 55
++			23 00 02 6D 55
++			23 00 02 93 55
++			23 00 02 BB 55
++			23 00 02 E1 55
++			23 00 02 22 FF
++			23 00 02 1E 68
++			23 00 02 4C FF
++			23 00 02 48 68
++			23 00 02 73 FF
++			23 00 02 6F 68
++			23 00 02 99 FF
++			23 00 02 95 68
++			23 00 02 C1 FF
++			23 00 02 BD 68
++			23 00 02 E7 FF
++			23 00 02 E3 68
++			23 00 02 1F 7E
++			23 00 02 49 7E
++			23 00 02 70 7E
++			23 00 02 96 7E
++			23 00 02 BE 7E
++			23 00 02 E4 7E
++			23 00 02 20 97
++			23 00 02 4A 97
++			23 00 02 71 97
++			23 00 02 97 97
++			23 00 02 BF 97
++			23 00 02 E5 97
++			23 00 02 21 B5
++			23 00 02 4B B5
++			23 00 02 72 B5
++			23 00 02 98 B5
++			23 00 02 C0 B5
++			23 00 02 E6 B5
++			23 00 02 25 F0
++			23 00 02 23 E8
++			23 00 02 4F F0
++			23 00 02 4D E8
++			23 00 02 76 F0
++			23 00 02 74 E8
++			23 00 02 9C F0
++			23 00 02 9A E8
++			23 00 02 C4 F0
++			23 00 02 C2 E8
++			23 00 02 EA F0
++			23 00 02 E8 E8
++			23 00 02 24 FF
++			23 00 02 4E FF
++			23 00 02 75 FF
++			23 00 02 9B FF
++			23 00 02 C3 FF
++			23 00 02 E9 FF
++			23 00 02 FE 3D
++			23 00 02 00 04
++			23 00 02 FE 23
++			23 00 02 08 82
++			23 00 02 0A 00
++			23 00 02 0B 00
++			23 00 02 0C 01
++			23 00 02 16 00
++			23 00 02 18 02
++			23 00 02 1B 04
++			23 00 02 19 04
++			23 00 02 1C 81
++			23 00 02 1F 00
++			23 00 02 20 03
++			23 00 02 23 04
++			23 00 02 21 01
++			23 00 02 54 63
++			23 00 02 55 54
++			23 00 02 6E 45
++			23 00 02 6D 36
++			23 00 02 FE 3D
++			23 00 02 55 78
++			23 00 02 FE 20
++			23 00 02 26 30
++			23 00 02 FE 3D
++			23 00 02 20 71
++			23 00 02 50 8F
++			23 00 02 51 8F
++			23 00 02 FE 00
++			23 00 02 35 00
++			05 78 01 11
++			05 1E 01 29
++		];
++
++		panel-exit-sequence = [
++			05 00 01 28
++			05 00 01 10
++		];
++
++		disp_timings0: display-timings {
++			native-mode = <&dsi0_timing0>;
++			dsi0_timing0: timing0 {
++				clock-frequency = <132000000>;
++				hactive = <1080>;
++				vactive = <1920>;
++				hfront-porch = <15>;
++				hsync-len = <4>;
++				hback-porch = <30>;
++				vfront-porch = <15>;
++				vsync-len = <2>;
++				vback-porch = <15>;
++				hsync-active = <0>;
++				vsync-active = <0>;
++				de-active = <0>;
++				pixelclk-active = <0>;
++			};
++		};
++
++		ports {
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			port@0 {
++				reg = <0>;
++				panel_in_dsi: endpoint {
++					remote-endpoint = <&dsi_out_panel>;
++				};
++			};
++		};
++	};
++
++	ports {
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		port@1 {
++			reg = <1>;
++			dsi_out_panel: endpoint {
++				remote-endpoint = <&panel_in_dsi>;
++			};
++		};
++	};
++
++};
++
++&dsi1 {
++	status = "disabled";
++	//rockchip,lane-rate = <1000>;
++	dsi1_panel: panel@0 {
++		status = "okay";
++		compatible = "simple-panel-dsi";
++		reg = <0>;
++		backlight = <&backlight>;
++		reset-delay-ms = <60>;
++		enable-delay-ms = <60>;
++		prepare-delay-ms = <60>;
++		unprepare-delay-ms = <60>;
++		disable-delay-ms = <60>;
++		dsi,flags = <(MIPI_DSI_MODE_VIDEO | MIPI_DSI_MODE_VIDEO_BURST |
++			MIPI_DSI_MODE_LPM | MIPI_DSI_MODE_EOT_PACKET)>;
++		dsi,format = <MIPI_DSI_FMT_RGB888>;
++		dsi,lanes  = <4>;
++		panel-init-sequence = [
++			23 00 02 FE 21
++			23 00 02 04 00
++			23 00 02 00 64
++			23 00 02 2A 00
++			23 00 02 26 64
++			23 00 02 54 00
++			23 00 02 50 64
++			23 00 02 7B 00
++			23 00 02 77 64
++			23 00 02 A2 00
++			23 00 02 9D 64
++			23 00 02 C9 00
++			23 00 02 C5 64
++			23 00 02 01 71
++			23 00 02 27 71
++			23 00 02 51 71
++			23 00 02 78 71
++			23 00 02 9E 71
++			23 00 02 C6 71
++			23 00 02 02 89
++			23 00 02 28 89
++			23 00 02 52 89
++			23 00 02 79 89
++			23 00 02 9F 89
++			23 00 02 C7 89
++			23 00 02 03 9E
++			23 00 02 29 9E
++			23 00 02 53 9E
++			23 00 02 7A 9E
++			23 00 02 A0 9E
++			23 00 02 C8 9E
++			23 00 02 09 00
++			23 00 02 05 B0
++			23 00 02 31 00
++			23 00 02 2B B0
++			23 00 02 5A 00
++			23 00 02 55 B0
++			23 00 02 80 00
++			23 00 02 7C B0
++			23 00 02 A7 00
++			23 00 02 A3 B0
++			23 00 02 CE 00
++			23 00 02 CA B0
++			23 00 02 06 C0
++			23 00 02 2D C0
++			23 00 02 56 C0
++			23 00 02 7D C0
++			23 00 02 A4 C0
++			23 00 02 CB C0
++			23 00 02 07 CF
++			23 00 02 2F CF
++			23 00 02 58 CF
++			23 00 02 7E CF
++			23 00 02 A5 CF
++			23 00 02 CC CF
++			23 00 02 08 DD
++			23 00 02 30 DD
++			23 00 02 59 DD
++			23 00 02 7F DD
++			23 00 02 A6 DD
++			23 00 02 CD DD
++			23 00 02 0E 15
++			23 00 02 0A E9
++			23 00 02 36 15
++			23 00 02 32 E9
++			23 00 02 5F 15
++			23 00 02 5B E9
++			23 00 02 85 15
++			23 00 02 81 E9
++			23 00 02 AD 15
++			23 00 02 A9 E9
++			23 00 02 D3 15
++			23 00 02 CF E9
++			23 00 02 0B 14
++			23 00 02 33 14
++			23 00 02 5C 14
++			23 00 02 82 14
++			23 00 02 AA 14
++			23 00 02 D0 14
++			23 00 02 0C 36
++			23 00 02 34 36
++			23 00 02 5D 36
++			23 00 02 83 36
++			23 00 02 AB 36
++			23 00 02 D1 36
++			23 00 02 0D 6B
++			23 00 02 35 6B
++			23 00 02 5E 6B
++			23 00 02 84 6B
++			23 00 02 AC 6B
++			23 00 02 D2 6B
++			23 00 02 13 5A
++			23 00 02 0F 94
++			23 00 02 3B 5A
++			23 00 02 37 94
++			23 00 02 64 5A
++			23 00 02 60 94
++			23 00 02 8A 5A
++			23 00 02 86 94
++			23 00 02 B2 5A
++			23 00 02 AE 94
++			23 00 02 D8 5A
++			23 00 02 D4 94
++			23 00 02 10 D1
++			23 00 02 38 D1
++			23 00 02 61 D1
++			23 00 02 87 D1
++			23 00 02 AF D1
++			23 00 02 D5 D1
++			23 00 02 11 04
++			23 00 02 39 04
++			23 00 02 62 04
++			23 00 02 88 04
++			23 00 02 B0 04
++			23 00 02 D6 04
++			23 00 02 12 05
++			23 00 02 3A 05
++			23 00 02 63 05
++			23 00 02 89 05
++			23 00 02 B1 05
++			23 00 02 D7 05
++			23 00 02 18 AA
++			23 00 02 14 36
++			23 00 02 42 AA
++			23 00 02 3D 36
++			23 00 02 69 AA
++			23 00 02 65 36
++			23 00 02 8F AA
++			23 00 02 8B 36
++			23 00 02 B7 AA
++			23 00 02 B3 36
++			23 00 02 DD AA
++			23 00 02 D9 36
++			23 00 02 15 74
++			23 00 02 3F 74
++			23 00 02 66 74
++			23 00 02 8C 74
++			23 00 02 B4 74
++			23 00 02 DA 74
++			23 00 02 16 9F
++			23 00 02 40 9F
++			23 00 02 67 9F
++			23 00 02 8D 9F
++			23 00 02 B5 9F
++			23 00 02 DB 9F
++			23 00 02 17 DC
++			23 00 02 41 DC
++			23 00 02 68 DC
++			23 00 02 8E DC
++			23 00 02 B6 DC
++			23 00 02 DC DC
++			23 00 02 1D FF
++			23 00 02 19 03
++			23 00 02 47 FF
++			23 00 02 43 03
++			23 00 02 6E FF
++			23 00 02 6A 03
++			23 00 02 94 FF
++			23 00 02 90 03
++			23 00 02 BC FF
++			23 00 02 B8 03
++			23 00 02 E2 FF
++			23 00 02 DE 03
++			23 00 02 1A 35
++			23 00 02 44 35
++			23 00 02 6B 35
++			23 00 02 91 35
++			23 00 02 B9 35
++			23 00 02 DF 35
++			23 00 02 1B 45
++			23 00 02 45 45
++			23 00 02 6C 45
++			23 00 02 92 45
++			23 00 02 BA 45
++			23 00 02 E0 45
++			23 00 02 1C 55
++			23 00 02 46 55
++			23 00 02 6D 55
++			23 00 02 93 55
++			23 00 02 BB 55
++			23 00 02 E1 55
++			23 00 02 22 FF
++			23 00 02 1E 68
++			23 00 02 4C FF
++			23 00 02 48 68
++			23 00 02 73 FF
++			23 00 02 6F 68
++			23 00 02 99 FF
++			23 00 02 95 68
++			23 00 02 C1 FF
++			23 00 02 BD 68
++			23 00 02 E7 FF
++			23 00 02 E3 68
++			23 00 02 1F 7E
++			23 00 02 49 7E
++			23 00 02 70 7E
++			23 00 02 96 7E
++			23 00 02 BE 7E
++			23 00 02 E4 7E
++			23 00 02 20 97
++			23 00 02 4A 97
++			23 00 02 71 97
++			23 00 02 97 97
++			23 00 02 BF 97
++			23 00 02 E5 97
++			23 00 02 21 B5
++			23 00 02 4B B5
++			23 00 02 72 B5
++			23 00 02 98 B5
++			23 00 02 C0 B5
++			23 00 02 E6 B5
++			23 00 02 25 F0
++			23 00 02 23 E8
++			23 00 02 4F F0
++			23 00 02 4D E8
++			23 00 02 76 F0
++			23 00 02 74 E8
++			23 00 02 9C F0
++			23 00 02 9A E8
++			23 00 02 C4 F0
++			23 00 02 C2 E8
++			23 00 02 EA F0
++			23 00 02 E8 E8
++			23 00 02 24 FF
++			23 00 02 4E FF
++			23 00 02 75 FF
++			23 00 02 9B FF
++			23 00 02 C3 FF
++			23 00 02 E9 FF
++			23 00 02 FE 3D
++			23 00 02 00 04
++			23 00 02 FE 23
++			23 00 02 08 82
++			23 00 02 0A 00
++			23 00 02 0B 00
++			23 00 02 0C 01
++			23 00 02 16 00
++			23 00 02 18 02
++			23 00 02 1B 04
++			23 00 02 19 04
++			23 00 02 1C 81
++			23 00 02 1F 00
++			23 00 02 20 03
++			23 00 02 23 04
++			23 00 02 21 01
++			23 00 02 54 63
++			23 00 02 55 54
++			23 00 02 6E 45
++			23 00 02 6D 36
++			23 00 02 FE 3D
++			23 00 02 55 78
++			23 00 02 FE 20
++			23 00 02 26 30
++			23 00 02 FE 3D
++			23 00 02 20 71
++			23 00 02 50 8F
++			23 00 02 51 8F
++			23 00 02 FE 00
++			23 00 02 35 00
++			05 78 01 11
++			05 1E 01 29
++		];
++
++		panel-exit-sequence = [
++			05 00 01 28
++			05 00 01 10
++		];
++
++		disp_timings1: display-timings {
++			native-mode = <&dsi1_timing0>;
++			dsi1_timing0: timing0 {
++				clock-frequency = <132000000>;
++				hactive = <1080>;
++				vactive = <1920>;
++				hfront-porch = <15>;
++				hsync-len = <4>;
++				hback-porch = <30>;
++				vfront-porch = <15>;
++				vsync-len = <2>;
++				vback-porch = <15>;
++				hsync-active = <0>;
++				vsync-active = <0>;
++				de-active = <0>;
++				pixelclk-active = <0>;
++			};
++		};
++
++		ports {
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			port@0 {
++				reg = <0>;
++				panel_in_dsi1: endpoint {
++					remote-endpoint = <&dsi1_out_panel>;
++				};
++			};
++		};
++	};
++
++	ports {
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		port@1 {
++			reg = <1>;
++			dsi1_out_panel: endpoint {
++				remote-endpoint = <&panel_in_dsi1>;
++			};
++		};
++	};
++
++};
++
++&gpu {
++	mali-supply = <&vdd_gpu_s0>;
++	mem-supply = <&vdd_gpu_mem_s0>;
++	status = "okay";
++};
++
++&i2s0_8ch {
++	status = "okay";
++	pinctrl-0 = <&i2s0_lrck
++		     &i2s0_sclk
++		     &i2s0_sdi0
++		     &i2s0_sdo0>;
++};
++
++&iep {
++	status = "okay";
++};
++
++&iep_mmu {
++	status = "okay";
++};
++
++&jpegd {
++	status = "okay";
++};
++
++&jpegd_mmu {
++	status = "okay";
++};
++
++&jpege_ccu {
++	status = "okay";
++};
++
++&jpege0 {
++	status = "okay";
++};
++
++&jpege0_mmu {
++	status = "okay";
++};
++
++&jpege1 {
++	status = "okay";
++};
++
++&jpege1_mmu {
++	status = "okay";
++};
++
++&jpege2 {
++	status = "okay";
++};
++
++&jpege2_mmu {
++	status = "okay";
++};
++
++&jpege3 {
++	status = "okay";
++};
++
++&jpege3_mmu {
++	status = "okay";
++};
++
++&mpp_srv {
++	status = "okay";
++};
++
++&rga3_core0 {
++	status = "okay";
++};
++
++&rga3_0_mmu {
++	status = "okay";
++};
++
++&rga3_core1 {
++	status = "okay";
++};
++
++&rga3_1_mmu {
++	status = "okay";
++};
++
++&rga2 {
++	status = "okay";
++};
++
++&rknpu {
++	rknpu-supply = <&vdd_npu_s0>;
++	mem-supply = <&vdd_npu_mem_s0>;
++	status = "okay";
++};
++
++&rknpu_mmu {
++	status = "okay";
++};
++
++&rkvdec_ccu {
++	status = "okay";
++};
++
++&rkvdec0 {
++	status = "okay";
++};
++
++&rkvdec0_mmu {
++	status = "okay";
++};
++
++&rkvdec1 {
++	status = "okay";
++};
++
++&rkvdec1_mmu {
++	status = "okay";
++};
++
++&rkvenc_ccu {
++	status = "okay";
++};
++
++&rkvenc0 {
++	status = "okay";
++};
++
++&rkvenc0_mmu {
++	status = "okay";
++};
++
++&rkvenc1 {
++	status = "okay";
++};
++
++&rkvenc1_mmu {
++	status = "okay";
++};
++
++&rockchip_suspend {
++	status = "okay";
++	rockchip,sleep-debug-en = <1>;
++};
++
++&saradc {
++	status = "okay";
++	vref-supply = <&vcc_1v8_s0>;
++};
++
++&sdhci {
++	bus-width = <8>;
++	no-sdio;
++	no-sd;
++	non-removable;
++	max-frequency = <200000000>;
++	mmc-hs400-1_8v;
++	mmc-hs400-enhanced-strobe;
++	status = "okay";
++};
++
++&sdmmc {
++	max-frequency = <150000000>;
++	no-sdio;
++	no-mmc;
++	bus-width = <4>;
++	cap-mmc-highspeed;
++	cap-sd-highspeed;
++	disable-wp;
++	sd-uhs-sdr104;
++	vmmc-supply = <&vcc_3v3_sd_s0>;
++	vqmmc-supply = <&vccio_sd_s0>;
++	status = "disabled";
++};
++
++&tsadc {
++	status = "okay";
++};
++
++&u2phy0 {
++	status = "okay";
++};
++
++&u2phy2 {
++	status = "okay";
++};
++
++&u2phy3 {
++	status = "okay";
++};
++
++&u2phy0_otg {
++	status = "okay";
++};
++
++&u2phy2_host {
++	status = "okay";
++};
++
++&u2phy3_host {
++	status = "okay";
++};
++
++&usb_host0_ehci {
++	status = "okay";
++};
++
++&usb_host0_ohci {
++	status = "okay";
++};
++
++&usb_host1_ehci {
++	status = "okay";
++};
++
++&usb_host1_ohci {
++	status = "okay";
++};
++
++&usbdp_phy0 {
++	status = "okay";
++};
++
++&usbdp_phy0_dp {
++	status = "okay";
++};
++
++&usbdp_phy0_u3 {
++	status = "okay";
++};
++
++&usbdrd3_0 {
++	status = "okay";
++};
++
++&usbdrd_dwc3_0 {
++	dr_mode = "otg";
++	status = "okay";
++};
++
++&usbhost3_0 {
++	status = "okay";
++};
++
++&usbhost_dwc3_0 {
++	status = "okay";
++};
++
++&vdpu {
++	status = "okay";
++};
++
++&vdpu_mmu {
++	status = "okay";
++};
++
++&vop {
++	status = "okay";
++};
++
++&vop_mmu {
++	status = "okay";
++};
++
++/* vp0 & vp1 splice for 8K output */
++&vp0 {
++	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER0 | 1 << ROCKCHIP_VOP2_ESMART0)>;
++	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART0>;
++};
++
++&vp1 {
++	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER1 | 1 << ROCKCHIP_VOP2_ESMART1)>;
++	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART1>;
++};
++
++&vp2 {
++	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER2 | 1 << ROCKCHIP_VOP2_ESMART2)>;
++	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART2>;
++};
++
++&vp3 {
++	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER3 | 1 << ROCKCHIP_VOP2_ESMART3)>;
++	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART3>;
++};
+diff --git a/arch/arm64/configs/kedges_defconfig b/arch/arm64/configs/kedges_defconfig
+new file mode 100644
+index 000000000000..e654b39e731e
+--- /dev/null
++++ b/arch/arm64/configs/kedges_defconfig
+@@ -0,0 +1,595 @@
++CONFIG_DEFAULT_HOSTNAME="localhost"
++CONFIG_SYSVIPC=y
++CONFIG_NO_HZ=y
++CONFIG_HIGH_RES_TIMERS=y
++CONFIG_PREEMPT_VOLUNTARY=y
++CONFIG_IKCONFIG=y
++CONFIG_IKCONFIG_PROC=y
++CONFIG_LOG_BUF_SHIFT=18
++CONFIG_UCLAMP_TASK=y
++CONFIG_UCLAMP_BUCKETS_COUNT=20
++CONFIG_CGROUPS=y
++CONFIG_CGROUP_SCHED=y
++CONFIG_CFS_BANDWIDTH=y
++CONFIG_UCLAMP_TASK_GROUP=y
++CONFIG_CGROUP_FREEZER=y
++CONFIG_CPUSETS=y
++CONFIG_CGROUP_DEVICE=y
++CONFIG_CGROUP_CPUACCT=y
++CONFIG_NAMESPACES=y
++CONFIG_USER_NS=y
++CONFIG_BLK_DEV_INITRD=y
++CONFIG_CC_OPTIMIZE_FOR_SIZE=y
++CONFIG_EMBEDDED=y
++# CONFIG_COMPAT_BRK is not set
++CONFIG_PROFILING=y
++CONFIG_ARCH_ROCKCHIP=y
++# CONFIG_ARM64_ERRATUM_826319 is not set
++# CONFIG_ARM64_ERRATUM_827319 is not set
++# CONFIG_ARM64_ERRATUM_824069 is not set
++# CONFIG_ARM64_ERRATUM_819472 is not set
++# CONFIG_ARM64_ERRATUM_832075 is not set
++# CONFIG_CAVIUM_ERRATUM_22375 is not set
++# CONFIG_CAVIUM_ERRATUM_23154 is not set
++CONFIG_SCHED_MC=y
++CONFIG_NR_CPUS=8
++CONFIG_HZ_300=y
++CONFIG_COMPAT=y
++CONFIG_ARMV8_DEPRECATED=y
++CONFIG_SWP_EMULATION=y
++CONFIG_CP15_BARRIER_EMULATION=y
++CONFIG_SETEND_EMULATION=y
++CONFIG_ARM64_PSEUDO_NMI=y
++CONFIG_PM_DEBUG=y
++CONFIG_PM_ADVANCED_DEBUG=y
++CONFIG_WQ_POWER_EFFICIENT_DEFAULT=y
++CONFIG_ENERGY_MODEL=y
++CONFIG_CPU_IDLE=y
++CONFIG_ARM_CPUIDLE=y
++CONFIG_ARM_PSCI_CPUIDLE=y
++CONFIG_CPU_FREQ=y
++CONFIG_CPU_FREQ_STAT=y
++CONFIG_CPU_FREQ_TIMES=y
++CONFIG_CPU_FREQ_GOV_POWERSAVE=y
++CONFIG_CPU_FREQ_GOV_USERSPACE=y
++CONFIG_CPU_FREQ_GOV_ONDEMAND=y
++CONFIG_CPU_FREQ_GOV_CONSERVATIVE=y
++CONFIG_CPUFREQ_DT=y
++CONFIG_ARM_ROCKCHIP_CPUFREQ=y
++CONFIG_ARM_SCMI_PROTOCOL=y
++CONFIG_ROCKCHIP_SIP=y
++CONFIG_ARM64_CRYPTO=y
++CONFIG_CRYPTO_SHA1_ARM64_CE=y
++CONFIG_CRYPTO_SHA2_ARM64_CE=y
++CONFIG_CRYPTO_GHASH_ARM64_CE=y
++CONFIG_CRYPTO_AES_ARM64_CE_CCM=y
++CONFIG_CRYPTO_AES_ARM64_CE_BLK=y
++CONFIG_MODULES=y
++CONFIG_MODULE_FORCE_LOAD=y
++CONFIG_MODULE_UNLOAD=y
++CONFIG_MODULE_FORCE_UNLOAD=y
++CONFIG_PARTITION_ADVANCED=y
++CONFIG_CMDLINE_PARTITION=y
++# CONFIG_COMPACTION is not set
++CONFIG_DEFAULT_MMAP_MIN_ADDR=32768
++CONFIG_CMA=y
++CONFIG_ZSMALLOC=y
++CONFIG_NET=y
++CONFIG_PACKET=y
++CONFIG_UNIX=y
++CONFIG_XFRM_USER=y
++CONFIG_NET_KEY=y
++CONFIG_INET=y
++CONFIG_IP_MULTICAST=y
++CONFIG_IP_ADVANCED_ROUTER=y
++CONFIG_IP_MROUTE=y
++CONFIG_SYN_COOKIES=y
++# CONFIG_INET_DIAG is not set
++# CONFIG_IPV6_SIT is not set
++CONFIG_NETFILTER=y
++CONFIG_IP_NF_IPTABLES=y
++CONFIG_IP_NF_MANGLE=y
++CONFIG_BT=y
++CONFIG_BT_RFCOMM=y
++CONFIG_BT_HIDP=y
++CONFIG_BT_HCIBTUSB=y
++CONFIG_BT_HCIUART=y
++CONFIG_BT_HCIUART_ATH3K=y
++CONFIG_BT_HCIBFUSB=y
++CONFIG_BT_HCIVHCI=y
++CONFIG_BT_MRVL=y
++CONFIG_BT_MRVL_SDIO=y
++CONFIG_RFKILL=y
++CONFIG_RFKILL_RK=y
++CONFIG_PCI=y
++CONFIG_PCIEPORTBUS=y
++CONFIG_PCIEASPM_POWERSAVE=y
++CONFIG_PCIE_ROCKCHIP_HOST=y
++CONFIG_PCIE_DW_ROCKCHIP=y
++CONFIG_DEVTMPFS=y
++CONFIG_DEVTMPFS_MOUNT=y
++CONFIG_DEBUG_DEVRES=y
++CONFIG_CONNECTOR=y
++CONFIG_MTD=y
++CONFIG_MTD_CMDLINE_PARTS=y
++CONFIG_MTD_BLOCK=y
++CONFIG_MTD_SPI_NAND=y
++CONFIG_MTD_SPI_NOR=y
++CONFIG_MTD_UBI=y
++CONFIG_ZRAM=y
++CONFIG_BLK_DEV_LOOP=y
++CONFIG_BLK_DEV_RAM=y
++CONFIG_BLK_DEV_RAM_COUNT=1
++CONFIG_BLK_DEV_NVME=y
++CONFIG_SRAM=y
++CONFIG_BLK_DEV_SD=y
++CONFIG_BLK_DEV_SR=y
++CONFIG_SCSI_SCAN_ASYNC=y
++CONFIG_SCSI_SPI_ATTRS=y
++CONFIG_ATA=y
++CONFIG_SATA_AHCI=y
++CONFIG_SATA_AHCI_PLATFORM=y
++# CONFIG_ATA_SFF is not set
++CONFIG_MD=y
++CONFIG_NETDEVICES=y
++# CONFIG_NET_VENDOR_3COM is not set
++# CONFIG_NET_VENDOR_ADAPTEC is not set
++# CONFIG_NET_VENDOR_AGERE is not set
++# CONFIG_NET_VENDOR_ALTEON is not set
++# CONFIG_NET_VENDOR_AMD is not set
++# CONFIG_NET_VENDOR_ARC is not set
++# CONFIG_NET_VENDOR_ATHEROS is not set
++# CONFIG_NET_VENDOR_BROADCOM is not set
++# CONFIG_NET_VENDOR_BROCADE is not set
++# CONFIG_NET_VENDOR_CAVIUM is not set
++# CONFIG_NET_VENDOR_CHELSIO is not set
++# CONFIG_NET_VENDOR_CISCO is not set
++# CONFIG_NET_VENDOR_DEC is not set
++# CONFIG_NET_VENDOR_DLINK is not set
++# CONFIG_NET_VENDOR_EMULEX is not set
++# CONFIG_NET_VENDOR_EZCHIP is not set
++# CONFIG_NET_VENDOR_HISILICON is not set
++# CONFIG_NET_VENDOR_INTEL is not set
++# CONFIG_NET_VENDOR_MARVELL is not set
++# CONFIG_NET_VENDOR_MELLANOX is not set
++# CONFIG_NET_VENDOR_MICREL is not set
++# CONFIG_NET_VENDOR_MICROCHIP is not set
++# CONFIG_NET_VENDOR_MYRI is not set
++# CONFIG_NET_VENDOR_NATSEMI is not set
++# CONFIG_NET_VENDOR_NVIDIA is not set
++# CONFIG_NET_VENDOR_OKI is not set
++# CONFIG_NET_VENDOR_QLOGIC is not set
++# CONFIG_NET_VENDOR_QUALCOMM is not set
++# CONFIG_NET_VENDOR_RDC is not set
++CONFIG_R8168=y
++# CONFIG_NET_VENDOR_RENESAS is not set
++# CONFIG_NET_VENDOR_ROCKER is not set
++# CONFIG_NET_VENDOR_SAMSUNG is not set
++# CONFIG_NET_VENDOR_SEEQ is not set
++# CONFIG_NET_VENDOR_SILAN is not set
++# CONFIG_NET_VENDOR_SIS is not set
++# CONFIG_NET_VENDOR_SMSC is not set
++CONFIG_STMMAC_ETH=y
++# CONFIG_NET_VENDOR_SUN is not set
++# CONFIG_NET_VENDOR_SYNOPSYS is not set
++# CONFIG_NET_VENDOR_TEHUTI is not set
++# CONFIG_NET_VENDOR_TI is not set
++# CONFIG_NET_VENDOR_VIA is not set
++# CONFIG_NET_VENDOR_WIZNET is not set
++CONFIG_ROCKCHIP_PHY=y
++CONFIG_USB_RTL8150=y
++CONFIG_USB_RTL8152=y
++CONFIG_WL_ROCKCHIP=y
++CONFIG_WIFI_LOAD_DRIVER_WHEN_KERNEL_BOOTUP=y
++CONFIG_AP6XXX=y
++CONFIG_BCMDHD_PCIE=y
++CONFIG_INPUT_FF_MEMLESS=y
++CONFIG_INPUT_EVDEV=y
++CONFIG_KEYBOARD_ADC=y
++# CONFIG_KEYBOARD_ATKBD is not set
++CONFIG_KEYBOARD_GPIO=y
++CONFIG_KEYBOARD_GPIO_POLLED=y
++# CONFIG_MOUSE_PS2 is not set
++CONFIG_MOUSE_CYAPA=y
++CONFIG_MOUSE_ELAN_I2C=y
++CONFIG_INPUT_TOUCHSCREEN=y
++CONFIG_TOUCHSCREEN_ATMEL_MXT=y
++CONFIG_TOUCHSCREEN_GSL3673=y
++CONFIG_TOUCHSCREEN_GT1X=y
++CONFIG_TOUCHSCREEN_ELAN=y
++CONFIG_TOUCHSCREEN_USB_COMPOSITE=y
++CONFIG_ROCKCHIP_REMOTECTL=y
++CONFIG_ROCKCHIP_REMOTECTL_PWM=y
++CONFIG_INPUT_MISC=y
++CONFIG_INPUT_UINPUT=y
++CONFIG_INPUT_RK805_PWRKEY=y
++# CONFIG_SERIO is not set
++# CONFIG_LEGACY_PTYS is not set
++CONFIG_SERIAL_8250=y
++CONFIG_SERIAL_8250_CONSOLE=y
++# CONFIG_SERIAL_8250_PCI is not set
++CONFIG_SERIAL_8250_NR_UARTS=10
++CONFIG_SERIAL_8250_RUNTIME_UARTS=10
++CONFIG_SERIAL_8250_DW=y
++CONFIG_SERIAL_OF_PLATFORM=y
++CONFIG_HW_RANDOM=y
++CONFIG_HW_RANDOM_ROCKCHIP=y
++CONFIG_TCG_TPM=y
++CONFIG_TCG_TIS_I2C_INFINEON=y
++CONFIG_I2C_CHARDEV=y
++CONFIG_I2C_RK3X=y
++CONFIG_SPI=y
++CONFIG_SPI_BITBANG=y
++CONFIG_SPI_ROCKCHIP=y
++CONFIG_SPI_ROCKCHIP_SFC=y
++CONFIG_SPI_SPIDEV=y
++CONFIG_PINCTRL_RK805=y
++CONFIG_PINCTRL_RK806=y
++CONFIG_GPIO_SYSFS=y
++CONFIG_GPIO_GENERIC_PLATFORM=y
++CONFIG_POWER_RESET_GPIO=y
++CONFIG_POWER_RESET_GPIO_RESTART=y
++CONFIG_SYSCON_REBOOT_MODE=y
++CONFIG_BATTERY_CW2017=y
++CONFIG_BATTERY_SBS=y
++CONFIG_CHARGER_GPIO=y
++CONFIG_CHARGER_BQ24735=y
++CONFIG_CHARGER_BQ25700=y
++CONFIG_BATTERY_RK817=y
++CONFIG_CHARGER_RK817=y
++CONFIG_THERMAL=y
++CONFIG_THERMAL_WRITABLE_TRIPS=y
++CONFIG_THERMAL_DEFAULT_GOV_POWER_ALLOCATOR=y
++CONFIG_THERMAL_GOV_FAIR_SHARE=y
++CONFIG_THERMAL_GOV_STEP_WISE=y
++CONFIG_THERMAL_GOV_USER_SPACE=y
++CONFIG_THERMAL_GOV_POWER_ALLOCATOR=y
++CONFIG_CPU_THERMAL=y
++CONFIG_DEVFREQ_THERMAL=y
++CONFIG_ROCKCHIP_THERMAL=y
++CONFIG_WATCHDOG=y
++CONFIG_DW_WATCHDOG=y
++CONFIG_MFD_RK806_SPI=y
++CONFIG_MFD_RK808=y
++CONFIG_MFD_TPS6586X=y
++CONFIG_REGULATOR=y
++CONFIG_REGULATOR_DEBUG=y
++CONFIG_REGULATOR_FIXED_VOLTAGE=y
++CONFIG_REGULATOR_ACT8865=y
++CONFIG_REGULATOR_FAN53555=y
++CONFIG_REGULATOR_GPIO=y
++CONFIG_REGULATOR_LP8752=y
++CONFIG_REGULATOR_MP8865=y
++CONFIG_REGULATOR_PWM=y
++CONFIG_REGULATOR_RK806=y
++CONFIG_REGULATOR_RK808=y
++CONFIG_REGULATOR_RK860X=y
++CONFIG_REGULATOR_TPS65132=y
++CONFIG_REGULATOR_TPS6586X=y
++CONFIG_REGULATOR_XZ3216=y
++CONFIG_MEDIA_SUPPORT=y
++CONFIG_MEDIA_USB_SUPPORT=y
++CONFIG_USB_VIDEO_CLASS=y
++# CONFIG_USB_VIDEO_CLASS_INPUT_EVDEV is not set
++# CONFIG_USB_GSPCA is not set
++CONFIG_V4L_PLATFORM_DRIVERS=y
++CONFIG_VIDEO_ROCKCHIP_CIF=y
++CONFIG_VIDEO_ROCKCHIP_ISP=y
++CONFIG_VIDEO_ROCKCHIP_ISPP=y
++CONFIG_VIDEO_ROCKCHIP_HDMIRX=y
++CONFIG_V4L_MEM2MEM_DRIVERS=y
++CONFIG_VIDEO_ROCKCHIP_RGA=y
++CONFIG_VIDEO_LT6911UXC=y
++CONFIG_VIDEO_LT7911D=y
++CONFIG_VIDEO_RK628_CSI=y
++CONFIG_VIDEO_RK628_BT1120=y
++CONFIG_VIDEO_TC35874X=y
++CONFIG_VIDEO_RK_IRCUT=y
++CONFIG_VIDEO_GC8034=y
++CONFIG_VIDEO_IMX415=y
++CONFIG_VIDEO_IMX464=y
++CONFIG_VIDEO_OS04A10=y
++CONFIG_VIDEO_OV4689=y
++CONFIG_VIDEO_OV50C40=y
++CONFIG_VIDEO_OV5695=y
++CONFIG_VIDEO_OV7251=y
++CONFIG_VIDEO_OV13850=y
++# CONFIG_VGA_ARB is not set
++CONFIG_DRM=y
++CONFIG_DRM_IGNORE_IOTCL_PERMIT=y
++CONFIG_DRM_DP_AUX_CHARDEV=y
++CONFIG_DRM_LOAD_EDID_FIRMWARE=y
++CONFIG_DRM_ROCKCHIP=y
++CONFIG_ROCKCHIP_ANALOGIX_DP=y
++CONFIG_ROCKCHIP_CDN_DP=y
++CONFIG_ROCKCHIP_DW_HDMI=y
++CONFIG_ROCKCHIP_DW_MIPI_DSI=y
++CONFIG_ROCKCHIP_DW_DP=y
++CONFIG_ROCKCHIP_INNO_HDMI=y
++CONFIG_ROCKCHIP_LVDS=y
++CONFIG_ROCKCHIP_RGB=y
++CONFIG_DRM_PANEL_SIMPLE=y
++CONFIG_DRM_DISPLAY_CONNECTOR=y
++CONFIG_DRM_SII902X=y
++CONFIG_DRM_DW_HDMI_I2S_AUDIO=y
++CONFIG_DRM_DW_HDMI_CEC=y
++CONFIG_MALI400=y
++CONFIG_MALI450=y
++# CONFIG_MALI400_PROFILING is not set
++CONFIG_MALI_SHARED_INTERRUPTS=y
++CONFIG_MALI_DT=y
++CONFIG_MALI_DEVFREQ=y
++CONFIG_MALI_MIDGARD=y
++CONFIG_MALI_EXPERT=y
++CONFIG_MALI_PLATFORM_THIRDPARTY=y
++CONFIG_MALI_PLATFORM_THIRDPARTY_NAME="rk"
++CONFIG_MALI_DEBUG=y
++CONFIG_MALI_PWRSOFT_765=y
++CONFIG_MALI_BIFROST=y
++CONFIG_MALI_PLATFORM_NAME="rk"
++CONFIG_MALI_CSF_SUPPORT=y
++CONFIG_MALI_BIFROST_EXPERT=y
++CONFIG_MALI_BIFROST_DEBUG=y
++CONFIG_BACKLIGHT_CLASS_DEVICE=y
++CONFIG_BACKLIGHT_PWM=y
++CONFIG_ROCKCHIP_MULTI_RGA=y
++CONFIG_ROCKCHIP_MPP_SERVICE=y
++CONFIG_ROCKCHIP_MPP_RKVDEC=y
++CONFIG_ROCKCHIP_MPP_RKVDEC2=y
++CONFIG_ROCKCHIP_MPP_RKVENC=y
++CONFIG_ROCKCHIP_MPP_RKVENC2=y
++CONFIG_ROCKCHIP_MPP_VDPU1=y
++CONFIG_ROCKCHIP_MPP_VEPU1=y
++CONFIG_ROCKCHIP_MPP_VDPU2=y
++CONFIG_ROCKCHIP_MPP_VEPU2=y
++CONFIG_ROCKCHIP_MPP_IEP2=y
++CONFIG_ROCKCHIP_MPP_JPGDEC=y
++CONFIG_ROCKCHIP_MPP_AV1DEC=y
++CONFIG_FRAMEBUFFER_CONSOLE=y
++CONFIG_SOUND=y
++CONFIG_SND=y
++CONFIG_SND_HRTIMER=y
++CONFIG_SND_DYNAMIC_MINORS=y
++# CONFIG_SND_SUPPORT_OLD_API is not set
++CONFIG_SND_SEQUENCER=y
++CONFIG_SND_SEQ_DUMMY=y
++# CONFIG_SND_PCI is not set
++# CONFIG_SND_SPI is not set
++CONFIG_SND_USB_AUDIO=y
++CONFIG_SND_SOC=y
++CONFIG_SND_SOC_ROCKCHIP=y
++CONFIG_SND_SOC_ROCKCHIP_I2S_TDM=y
++CONFIG_SND_SOC_ROCKCHIP_PDM=y
++CONFIG_SND_SOC_ROCKCHIP_SPDIF=y
++CONFIG_SND_SOC_ROCKCHIP_SPDIFRX=y
++CONFIG_SND_SOC_ROCKCHIP_MAX98090=y
++CONFIG_SND_SOC_ROCKCHIP_MULTICODECS=y
++CONFIG_SND_SOC_ROCKCHIP_RT5645=y
++CONFIG_SND_SOC_ROCKCHIP_HDMI=y
++CONFIG_SND_SOC_DUMMY_CODEC=y
++CONFIG_SND_SOC_ES7202=y
++CONFIG_SND_SOC_ES7243E=y
++CONFIG_SND_SOC_ES8311=y
++CONFIG_SND_SOC_ES8316=y
++CONFIG_SND_SOC_ES8323=y
++CONFIG_SND_SOC_ES8326=y
++CONFIG_SND_SOC_RK3308=y
++CONFIG_SND_SOC_RK3328=y
++CONFIG_SND_SOC_RK817=y
++CONFIG_SND_SOC_RK_CODEC_DIGITAL=y
++CONFIG_SND_SOC_RT5616=y
++CONFIG_SND_SOC_RT5640=y
++CONFIG_SND_SOC_RT5651=y
++CONFIG_SND_SOC_SPDIF=y
++CONFIG_SND_SIMPLE_CARD=y
++CONFIG_HID_BATTERY_STRENGTH=y
++CONFIG_HIDRAW=y
++CONFIG_UHID=y
++CONFIG_HID_KENSINGTON=y
++CONFIG_HID_MULTITOUCH=y
++CONFIG_USB_HIDDEV=y
++CONFIG_I2C_HID=y
++CONFIG_USB_ANNOUNCE_NEW_DEVICES=y
++# CONFIG_USB_DEFAULT_PERSIST is not set
++CONFIG_USB_OTG=y
++CONFIG_USB_MON=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_EHCI_ROOT_HUB_TT=y
++CONFIG_USB_EHCI_HCD_PLATFORM=y
++CONFIG_USB_OHCI_HCD=y
++# CONFIG_USB_OHCI_HCD_PCI is not set
++CONFIG_USB_OHCI_HCD_PLATFORM=y
++CONFIG_USB_ACM=y
++CONFIG_USB_STORAGE=y
++CONFIG_USB_UAS=y
++CONFIG_USB_DWC3=y
++CONFIG_USB_DWC2=y
++CONFIG_USB_SERIAL=y
++CONFIG_USB_SERIAL_GENERIC=y
++CONFIG_USB_SERIAL_CP210X=y
++CONFIG_USB_SERIAL_FTDI_SIO=y
++CONFIG_USB_SERIAL_KEYSPAN=y
++CONFIG_USB_SERIAL_PL2303=y
++CONFIG_USB_SERIAL_OTI6858=y
++CONFIG_USB_SERIAL_QUALCOMM=y
++CONFIG_USB_SERIAL_SIERRAWIRELESS=y
++CONFIG_USB_SERIAL_OPTION=y
++CONFIG_USB_GADGET=y
++CONFIG_USB_GADGET_DEBUG_FILES=y
++CONFIG_USB_GADGET_VBUS_DRAW=500
++CONFIG_USB_CONFIGFS=y
++CONFIG_USB_CONFIGFS_UEVENT=y
++CONFIG_USB_CONFIGFS_ACM=y
++CONFIG_USB_CONFIGFS_RNDIS=y
++CONFIG_USB_CONFIGFS_MASS_STORAGE=y
++CONFIG_USB_CONFIGFS_F_FS=y
++CONFIG_USB_CONFIGFS_F_UAC1=y
++CONFIG_USB_CONFIGFS_F_UAC2=y
++CONFIG_USB_CONFIGFS_F_HID=y
++CONFIG_USB_CONFIGFS_F_UVC=y
++CONFIG_TYPEC_TCPM=y
++CONFIG_TYPEC_TCPCI=y
++CONFIG_TYPEC_HUSB311=y
++CONFIG_TYPEC_FUSB302=y
++CONFIG_TYPEC_DP_ALTMODE=y
++CONFIG_MMC=y
++CONFIG_MMC_BLOCK_MINORS=32
++CONFIG_MMC_TEST=y
++CONFIG_MMC_SDHCI=y
++CONFIG_MMC_SDHCI_PLTFM=y
++CONFIG_MMC_SDHCI_OF_ARASAN=y
++CONFIG_MMC_SDHCI_OF_DWCMSHC=y
++CONFIG_MMC_DW=y
++CONFIG_MMC_DW_ROCKCHIP=y
++CONFIG_NEW_LEDS=y
++CONFIG_LEDS_CLASS=y
++CONFIG_LEDS_GPIO=y
++CONFIG_LEDS_IS31FL32XX=y
++CONFIG_RTC_CLASS=y
++CONFIG_RTC_DRV_HYM8563=y
++CONFIG_RTC_DRV_RK808=y
++CONFIG_DMADEVICES=y
++CONFIG_PL330_DMA=y
++CONFIG_DMABUF_DEBUG=y
++CONFIG_SW_SYNC=y
++CONFIG_DMABUF_HEAPS=y
++CONFIG_DMABUF_SYSFS_STATS=y
++CONFIG_DMABUF_HEAPS_DEFERRED_FREE=y
++CONFIG_DMABUF_HEAPS_PAGE_POOL=y
++CONFIG_DMABUF_HEAPS_SYSTEM=y
++CONFIG_DMABUF_HEAPS_CMA=y
++CONFIG_STAGING=y
++CONFIG_FIQ_DEBUGGER=y
++CONFIG_FIQ_DEBUGGER_NO_SLEEP=y
++CONFIG_FIQ_DEBUGGER_CONSOLE=y
++CONFIG_FIQ_DEBUGGER_CONSOLE_DEFAULT_ENABLE=y
++CONFIG_FIQ_DEBUGGER_TRUST_ZONE=y
++CONFIG_RK_CONSOLE_THREAD=y
++CONFIG_COMMON_CLK_RK808=y
++CONFIG_COMMON_CLK_SCMI=y
++CONFIG_COMMON_CLK_PWM=y
++CONFIG_MAILBOX=y
++CONFIG_ROCKCHIP_IOMMU=y
++CONFIG_ARM_SMMU_V3=y
++CONFIG_CPU_PX30=y
++CONFIG_CPU_RK1808=y
++CONFIG_CPU_RK3328=y
++CONFIG_CPU_RK3399=y
++CONFIG_CPU_RK3568=y
++CONFIG_CPU_RK3588=y
++CONFIG_ROCKCHIP_CPUINFO=y
++CONFIG_ROCKCHIP_GRF=y
++CONFIG_ROCKCHIP_IODOMAIN=y
++CONFIG_ROCKCHIP_IPA=y
++CONFIG_ROCKCHIP_OPP=y
++CONFIG_ROCKCHIP_PM_DOMAINS=y
++CONFIG_ROCKCHIP_PVTM=y
++CONFIG_ROCKCHIP_SUSPEND_MODE=y
++CONFIG_ROCKCHIP_SYSTEM_MONITOR=y
++CONFIG_ROCKCHIP_VENDOR_STORAGE=y
++CONFIG_ROCKCHIP_MMC_VENDOR_STORAGE=y
++CONFIG_ROCKCHIP_VENDOR_STORAGE_UPDATE_LOADER=y
++CONFIG_ROCKCHIP_DEBUG=y
++CONFIG_PM_DEVFREQ=y
++CONFIG_DEVFREQ_GOV_PERFORMANCE=y
++CONFIG_DEVFREQ_GOV_POWERSAVE=y
++CONFIG_DEVFREQ_GOV_USERSPACE=y
++CONFIG_ARM_ROCKCHIP_BUS_DEVFREQ=y
++CONFIG_ARM_ROCKCHIP_DMC_DEVFREQ=y
++CONFIG_DEVFREQ_EVENT_ROCKCHIP_NOCP=y
++CONFIG_IIO=y
++CONFIG_ROCKCHIP_SARADC=y
++CONFIG_SENSORS_ISL29018=y
++CONFIG_SENSORS_TSL2563=y
++CONFIG_TSL2583=y
++CONFIG_IIO_SYSFS_TRIGGER=y
++CONFIG_PWM=y
++CONFIG_PWM_ROCKCHIP=y
++CONFIG_PHY_ROCKCHIP_CSI2_DPHY=y
++CONFIG_PHY_ROCKCHIP_DP=y
++CONFIG_PHY_ROCKCHIP_EMMC=y
++CONFIG_PHY_ROCKCHIP_INNO_HDMI=y
++CONFIG_PHY_ROCKCHIP_INNO_USB2=y
++CONFIG_PHY_ROCKCHIP_INNO_USB3=y
++CONFIG_PHY_ROCKCHIP_INNO_DSIDPHY=y
++CONFIG_PHY_ROCKCHIP_NANENG_COMBO_PHY=y
++CONFIG_PHY_ROCKCHIP_NANENG_EDP=y
++CONFIG_PHY_ROCKCHIP_PCIE=y
++CONFIG_PHY_ROCKCHIP_SAMSUNG_DCPHY=y
++CONFIG_PHY_ROCKCHIP_SAMSUNG_HDPTX=y
++CONFIG_PHY_ROCKCHIP_SAMSUNG_HDPTX_HDMI=y
++CONFIG_PHY_ROCKCHIP_SNPS_PCIE3=y
++CONFIG_PHY_ROCKCHIP_TYPEC=y
++CONFIG_PHY_ROCKCHIP_USB=y
++CONFIG_PHY_ROCKCHIP_USBDP=y
++CONFIG_ANDROID=y
++CONFIG_ROCKCHIP_EFUSE=y
++CONFIG_ROCKCHIP_OTP=y
++CONFIG_TEE=y
++CONFIG_OPTEE=y
++CONFIG_RK_HEADSET=y
++CONFIG_ROCKCHIP_RKNPU=y
++CONFIG_EXT4_FS=y
++CONFIG_EXT4_FS_POSIX_ACL=y
++CONFIG_EXT4_FS_SECURITY=y
++CONFIG_XFS_FS=y
++# CONFIG_DNOTIFY is not set
++CONFIG_FUSE_FS=y
++CONFIG_ISO9660_FS=y
++CONFIG_JOLIET=y
++CONFIG_ZISOFS=y
++CONFIG_VFAT_FS=y
++CONFIG_FAT_DEFAULT_CODEPAGE=936
++CONFIG_FAT_DEFAULT_IOCHARSET="utf8"
++CONFIG_NTFS_FS=y
++CONFIG_TMPFS=y
++CONFIG_TMPFS_POSIX_ACL=y
++CONFIG_EFIVAR_FS=y
++CONFIG_JFFS2_FS=y
++CONFIG_UBIFS_FS=y
++CONFIG_UBIFS_FS_ADVANCED_COMPR=y
++CONFIG_SQUASHFS=y
++CONFIG_PSTORE=y
++CONFIG_PSTORE_CONSOLE=y
++CONFIG_PSTORE_RAM=y
++CONFIG_NFS_FS=y
++CONFIG_NFS_V3_ACL=y
++CONFIG_NFS_V4=y
++CONFIG_NFS_SWAP=y
++CONFIG_NLS_DEFAULT="utf8"
++CONFIG_NLS_CODEPAGE_437=y
++CONFIG_NLS_CODEPAGE_936=y
++CONFIG_NLS_ASCII=y
++CONFIG_NLS_ISO8859_1=y
++CONFIG_NLS_UTF8=y
++CONFIG_UNICODE=y
++CONFIG_CRYPTO_SHA512=y
++CONFIG_CRYPTO_TWOFISH=y
++CONFIG_CRYPTO_ANSI_CPRNG=y
++CONFIG_CRYPTO_USER_API_HASH=y
++CONFIG_CRYPTO_USER_API_SKCIPHER=y
++CONFIG_CRYPTO_DEV_ROCKCHIP=y
++CONFIG_CRYPTO_DEV_ROCKCHIP_DEV=y
++CONFIG_CRC_CCITT=y
++CONFIG_CRC_T10DIF=y
++CONFIG_CRC7=y
++# CONFIG_XZ_DEC_X86 is not set
++# CONFIG_XZ_DEC_POWERPC is not set
++# CONFIG_XZ_DEC_IA64 is not set
++# CONFIG_XZ_DEC_SPARC is not set
++CONFIG_DMA_CMA=y
++CONFIG_CMA_SIZE_MBYTES=128
++CONFIG_PRINTK_TIME=y
++CONFIG_PRINTK_TIME_FROM_ARM_ARCH_TIMER=y
++CONFIG_DYNAMIC_DEBUG=y
++CONFIG_DEBUG_INFO=y
++CONFIG_MAGIC_SYSRQ=y
++CONFIG_MAGIC_SYSRQ_DEFAULT_ENABLE=0
++CONFIG_SCHEDSTATS=y
++CONFIG_DEBUG_SPINLOCK=y
++CONFIG_DEBUG_CREDENTIALS=y
++CONFIG_RCU_CPU_STALL_TIMEOUT=60
++CONFIG_FUNCTION_TRACER=y
++CONFIG_BLK_DEV_IO_TRACE=y
++CONFIG_LKDTM=y
+-- 
+Armbian
+
+
+From d56f7d22522b9491485b00b6db86d41a150f87bc Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Fri, 13 May 2022 01:15:20 +0800
+Subject: [RPARDINI INTERVENTION TO SEPARATE FILES] arm64: dts: rockchip:
+ Edge2: PMIC: support rk806 single
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: Idb72870baacbff412a222639c9513ce099789c88
+---
+ arch/arm64/boot/dts/rockchip/rk3588-nvr-demo-khadas-edge2.dtsi     | 832 ++++++++++
+ arch/arm64/boot/dts/rockchip/rk3588-rk806-single-khadas-edge2.dtsi | 396 +++++
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts              |  65 +-
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi             |  12 +-
+ 4 files changed, 1303 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-nvr-demo-khadas-edge2.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-nvr-demo-khadas-edge2.dtsi
+new file mode 100644
+index 000000000000..ea7304d7e60d
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nvr-demo-khadas-edge2.dtsi
+@@ -0,0 +1,832 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2021 Rockchip Electronics Co., Ltd.
++ *
++ */
++
++#include "rk3588.dtsi"
++#include "rk3588-nvr.dtsi"
++#include "rk3588-rk806-single.dtsi"
++
++/ {
++	i2s0_sound: i2s0-sound {
++		status = "okay";
++		compatible = "simple-audio-card";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,mclk-fs = <256>;
++		simple-audio-card,name = "rockchip,es8311";
++		simple-audio-card,dai-link@0 {
++			format = "i2s";
++			cpu {
++				sound-dai = <&i2s0_8ch>;
++			};
++			codec {
++				sound-dai = <&es8311>;
++			};
++		};
++	};
++
++	leds: leds {
++		compatible = "gpio-leds";
++		hdd_led: hdd-led {
++			gpios = <&gpio3 RK_PC1 GPIO_ACTIVE_HIGH>;
++			default-state = "off";
++		};
++		net_led: net-led {
++			gpios = <&gpio3 RK_PC0 GPIO_ACTIVE_HIGH>;
++			default-state = "off";
++		};
++		work_led: work-led {
++			gpios = <&gpio3 RK_PB7 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "heartbeat";
++		};
++	};
++
++	pcie30_avdd0v75: pcie30-avdd0v75 {
++		compatible = "regulator-fixed";
++		regulator-name = "pcie30_avdd0v75";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <750000>;
++		regulator-max-microvolt = <750000>;
++		vin-supply = <&vdd_0v75_s0>;
++	};
++
++	pcie30_avdd1v8: pcie30-avdd1v8 {
++		compatible = "regulator-fixed";
++		regulator-name = "pcie30_avdd1v8";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&avcc_1v8_s0>;
++	};
++
++	vcc12v_dcin: vcc12v-dcin {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc12v_dcin";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <12000000>;
++		regulator-max-microvolt = <12000000>;
++	};
++
++	vcc3v3_pcie30: vcc3v3-pcie30 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc3v3_pcie30";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		enable-active-high;
++		gpios = <&gpio3 RK_PD5 GPIO_ACTIVE_HIGH>;
++		startup-delay-us = <7500>;
++		vin-supply = <&vcc12v_dcin>;
++	};
++
++	vcc5v0_sys: vcc5v0-sys {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc12v_dcin>;
++	};
++
++	vcc5v0_host: vcc5v0-host-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_host";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		enable-active-high;
++		gpio = <&gpio4 RK_PB0 GPIO_ACTIVE_HIGH>;
++		vin-supply = <&vcc5v0_sys>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc5v0_host_en>;
++	};
++
++	vcc5v0_otg: vcc5v0-otg-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_otg";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		enable-active-high;
++		gpio = <&gpio4 RK_PA7 GPIO_ACTIVE_HIGH>;
++		vin-supply = <&vcc5v0_sys>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc5v0_otg_en>;
++	};
++
++	vcc_1v1_nldo_s3: vcc-1v1-nldo-s3 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_1v1_nldo_s3";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <1100000>;
++		regulator-max-microvolt = <1100000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++};
++
++&combphy0_ps {
++	pinctrl-names = "default";
++	pinctrl-0 = <&sata0_pm_reset>;
++	status = "okay";
++};
++
++&combphy1_ps {
++	pinctrl-names = "default";
++	pinctrl-0 = <&sata1_pm_reset>;
++	status = "okay";
++};
++
++&combphy2_psu {
++	status = "okay";
++};
++
++&dp0 {
++	pinctrl-0 = <&dp0m2_pins>;
++	pinctrl-names = "default";
++	status = "okay";
++};
++
++&dp0_in_vp0 {
++	status = "okay";
++};
++
++&dp0_in_vp1 {
++	status = "okay";
++};
++
++&dp0_in_vp2 {
++	status = "okay";
++};
++
++&dp1 {
++	pinctrl-0 = <&dp1m2_pins &dp1_hdmi_ctl>;
++	pinctrl-names = "default";
++	status = "okay";
++};
++
++&dp1_in_vp0 {
++	status = "okay";
++};
++
++&dp1_in_vp1 {
++	status = "okay";
++};
++
++&dp1_in_vp2 {
++	status = "okay";
++};
++
++&gmac0 {
++	/* Use rgmii-rxid mode to disable rx delay inside Soc */
++	phy-mode = "rgmii-rxid";
++	clock_in_out = "output";
++
++	snps,reset-gpio = <&gpio4 RK_PB3 GPIO_ACTIVE_LOW>;
++	snps,reset-active-low;
++	/* Reset time is 20ms, 100ms for rtl8211f */
++	snps,reset-delays-us = <0 20000 100000>;
++
++	pinctrl-names = "default";
++	pinctrl-0 = <&gmac0_miim
++		     &gmac0_tx_bus2
++		     &gmac0_rx_bus2
++		     &gmac0_rgmii_clk
++		     &gmac0_rgmii_bus>;
++
++	tx_delay = <0x44>;
++	/* rx_delay = <0x4f>; */
++
++	phy-handle = <&rgmii_phy0>;
++	status = "okay";
++};
++
++&gmac1 {
++	/* Use rgmii-rxid mode to disable rx delay inside Soc */
++	phy-mode = "rgmii-rxid";
++	clock_in_out = "output";
++
++	snps,reset-gpio = <&gpio4 RK_PA2 GPIO_ACTIVE_LOW>;
++	snps,reset-active-low;
++	/* Reset time is 20ms, 100ms for rtl8211f */
++	snps,reset-delays-us = <0 20000 100000>;
++
++	pinctrl-names = "default";
++	pinctrl-0 = <&gmac1_miim
++		     &gmac1_tx_bus2
++		     &gmac1_rx_bus2
++		     &gmac1_rgmii_clk
++		     &gmac1_rgmii_bus>;
++
++	tx_delay = <0x42>;
++	/* rx_delay = <0x4f>; */
++
++	phy-handle = <&rgmii_phy1>;
++	status = "okay";
++};
++
++&hdmi0 {
++	enable-gpios = <&gpio4 RK_PB1 GPIO_ACTIVE_HIGH>;
++	status = "okay";
++};
++
++&hdmi0_in_vp0 {
++	status = "okay";
++};
++
++&hdmi0_in_vp1 {
++	status = "okay";
++};
++
++&hdmi0_in_vp2 {
++	status = "okay";
++};
++
++&hdmi0_sound {
++	status = "okay";
++};
++
++&hdmi1 {
++	enable-gpios = <&gpio4 RK_PB2 GPIO_ACTIVE_HIGH>;
++	status = "okay";
++};
++
++&hdmi1_in_vp0 {
++	status = "okay";
++};
++
++&hdmi1_in_vp1 {
++	status = "okay";
++};
++
++&hdmi1_in_vp2 {
++	status = "okay";
++};
++
++&hdmi1_sound {
++	status = "okay";
++};
++
++&hdptxphy_hdmi0 {
++	status = "okay";
++};
++
++&hdptxphy_hdmi1 {
++	status = "okay";
++};
++
++&i2c0 {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c0m2_xfer>;
++
++	vdd_cpu_big0_s0: vdd_cpu_big0_mem_s0: rk8602@42 {
++		compatible = "rockchip,rk8602";
++		reg = <0x42>;
++		vin-supply = <&vcc5v0_sys>;
++		regulator-compatible = "rk860x-reg";
++		regulator-name = "vdd_cpu_big0_s0";
++		regulator-min-microvolt = <550000>;
++		regulator-max-microvolt = <1050000>;
++		regulator-ramp-delay = <2300>;
++		rockchip,suspend-voltage-selector = <1>;
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++
++	vdd_cpu_big1_s0: vdd_cpu_big1_mem_s0: rk8603@43 {
++		compatible = "rockchip,rk8603";
++		reg = <0x43>;
++		vin-supply = <&vcc5v0_sys>;
++		regulator-compatible = "rk860x-reg";
++		regulator-name = "vdd_cpu_big1_s0";
++		regulator-min-microvolt = <550000>;
++		regulator-max-microvolt = <1050000>;
++		regulator-ramp-delay = <2300>;
++		rockchip,suspend-voltage-selector = <1>;
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++};
++
++&i2c2 {
++	status = "okay";
++
++	vdd_npu_s0: vdd_npu_mem_s0: rk8602@42 {
++		compatible = "rockchip,rk8602";
++		reg = <0x42>;
++		vin-supply = <&vcc5v0_sys>;
++		regulator-compatible = "rk860x-reg";
++		regulator-name = "vdd_npu_s0";
++		regulator-min-microvolt = <550000>;
++		regulator-max-microvolt = <950000>;
++		regulator-ramp-delay = <2300>;
++		rockchip,suspend-voltage-selector = <1>;
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++};
++
++&i2c3 {
++	status = "okay";
++	es8311: es8311@18 {
++		status = "okay";
++		compatible = "everest,es8311";
++		reg = <0x18>;
++		#sound-dai-cells = <0>;
++		adc-pga-gain = <6>;     /* 18dB */
++		adc-volume = <0xbf>;    /* 0dB */
++		dac-volume = <0xbf>;    /* 0dB */
++		aec-mode = "adc left, adc right";
++		clocks = <&cru I2S0_8CH_MCLKOUT>;
++		clock-names = "mclk";
++		assigned-clocks = <&cru I2S0_8CH_MCLKOUT>;
++		assigned-clock-rates = <12288000>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&i2s0_mclk>;
++	};
++};
++
++&i2c4 {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c4m3_xfer>;
++};
++
++&i2c5 {
++	status = "okay";
++};
++
++&i2c6 {
++	status = "okay";
++	hym8563: hym8563@51 {
++		compatible = "haoyu,hym8563";
++		reg = <0x51>;
++
++		pinctrl-names = "default";
++		pinctrl-0 = <&rtc_int>;
++
++		interrupt-parent = <&gpio0>;
++		interrupts = <RK_PB2 IRQ_TYPE_LEVEL_LOW>;
++		wakeup-source;
++	};
++};
++
++&i2s0_8ch {
++	status = "okay";
++	pinctrl-0 = <&i2s0_lrck
++		     &i2s0_sclk
++		     &i2s0_sdi0
++		     &i2s0_sdo0>;
++};
++
++&i2s5_8ch {
++	status = "okay";
++};
++
++&i2s6_8ch {
++	status = "okay";
++};
++
++&mdio0 {
++	rgmii_phy0: phy@1 {
++		compatible = "ethernet-phy-ieee802.3-c22";
++		reg = <0x1>;
++	};
++};
++
++&mdio1 {
++	rgmii_phy1: phy@1 {
++		compatible = "ethernet-phy-ieee802.3-c22";
++		reg = <0x1>;
++	};
++};
++
++&pcie30phy {
++	status = "okay";
++};
++
++&pcie3x4 {
++	reset-gpios = <&gpio4 RK_PB6 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc3v3_pcie30>;
++	status = "okay";
++};
++
++&pwm3 {
++	compatible = "rockchip,remotectl-pwm";
++	pinctrl-names = "default";
++	pinctrl-0 = <&pwm3m0_pins>;
++	remote_pwm_id = <3>;
++	handle_cpu_id = <1>;
++	remote_support_psci = <0>;
++	status = "okay";
++
++	ir_key1 {
++		rockchip,usercode = <0x4040>;
++		rockchip,key_table =
++			<0xf2	KEY_REPLY>,
++			<0xba	KEY_BACK>,
++			<0xf4	KEY_UP>,
++			<0xf1	KEY_DOWN>,
++			<0xef	KEY_LEFT>,
++			<0xee	KEY_RIGHT>,
++			<0xbd	KEY_HOME>,
++			<0xea	KEY_VOLUMEUP>,
++			<0xe3	KEY_VOLUMEDOWN>,
++			<0xe2	KEY_SEARCH>,
++			<0xb2	KEY_POWER>,
++			<0xbc	KEY_MUTE>,
++			<0xec	KEY_MENU>,
++			<0xbf	0x190>,
++			<0xe0	0x191>,
++			<0xe1	0x192>,
++			<0xe9	183>,
++			<0xe6	248>,
++			<0xe8	185>,
++			<0xe7	186>,
++			<0xf0	388>,
++			<0xbe	0x175>;
++	};
++
++	ir_key2 {
++		rockchip,usercode = <0xff00>;
++		rockchip,key_table =
++			<0xf9	KEY_HOME>,
++			<0xbf	KEY_BACK>,
++			<0xfb	KEY_MENU>,
++			<0xaa	KEY_REPLY>,
++			<0xb9	KEY_UP>,
++			<0xe9	KEY_DOWN>,
++			<0xb8	KEY_LEFT>,
++			<0xea	KEY_RIGHT>,
++			<0xeb	KEY_VOLUMEDOWN>,
++			<0xef	KEY_VOLUMEUP>,
++			<0xf7	KEY_MUTE>,
++			<0xe7	KEY_POWER>,
++			<0xfc	KEY_POWER>,
++			<0xa9	KEY_VOLUMEDOWN>,
++			<0xa8	KEY_PLAYPAUSE>,
++			<0xe0	KEY_VOLUMEDOWN>,
++			<0xa5	KEY_VOLUMEDOWN>,
++			<0xab	183>,
++			<0xb7	388>,
++			<0xe8	388>,
++			<0xf8	184>,
++			<0xaf	185>,
++			<0xed	KEY_VOLUMEDOWN>,
++			<0xee	186>,
++			<0xb3	KEY_VOLUMEDOWN>,
++			<0xf1	KEY_VOLUMEDOWN>,
++			<0xf2	KEY_VOLUMEDOWN>,
++			<0xf3	KEY_SEARCH>,
++			<0xb4	KEY_VOLUMEDOWN>,
++			<0xa4	KEY_SETUP>,
++			<0xbe	KEY_SEARCH>;
++	};
++
++	ir_key3 {
++		rockchip,usercode = <0x1dcc>;
++		rockchip,key_table =
++			<0xee	KEY_REPLY>,
++			<0xf0	KEY_BACK>,
++			<0xf8	KEY_UP>,
++			<0xbb	KEY_DOWN>,
++			<0xef	KEY_LEFT>,
++			<0xed	KEY_RIGHT>,
++			<0xfc	KEY_HOME>,
++			<0xf1	KEY_VOLUMEUP>,
++			<0xfd	KEY_VOLUMEDOWN>,
++			<0xb7	KEY_SEARCH>,
++			<0xff	KEY_POWER>,
++			<0xf3	KEY_MUTE>,
++			<0xbf	KEY_MENU>,
++			<0xf9	0x191>,
++			<0xf5	0x192>,
++			<0xb3	388>,
++			<0xbe	KEY_1>,
++			<0xba	KEY_2>,
++			<0xb2	KEY_3>,
++			<0xbd	KEY_4>,
++			<0xf9	KEY_5>,
++			<0xb1	KEY_6>,
++			<0xfc	KEY_7>,
++			<0xf8	KEY_8>,
++			<0xb0	KEY_9>,
++			<0xb6	KEY_0>,
++			<0xb5	KEY_BACKSPACE>;
++	};
++};
++/*
++&rk806single {
++	pinctrl-names = "default", "pmic-power-off";
++	pinctrl-0 = <&pmic_pins>, <&rk806_dvs1_null>, <&rk806_dvs2_null>, <&rk806_dvs3_null>;
++	pinctrl-1 = <&rk806_dvs1_slp>, <&rk806_dvs2_null>, <&rk806_dvs3_null>;
++
++	regulators {
++		avcc_1v8_s0: PLDO_REG1 {
++			regulator-always-on;
++			regulator-boot-on;
++			regulator-min-microvolt = <1800000>;
++			regulator-max-microvolt = <1800000>;
++			regulator-name = "avcc_1v8_s0";
++			regulator-state-mem {
++				regulator-on-in-suspend;
++				regulator-suspend-microvolt = <1800000>;
++			};
++		};
++	};
++};
++*/
++&rockchip_suspend {
++	status = "okay";
++	rockchip,sleep-debug-en = <1>;
++	rockchip,virtual-poweroff = <1>;
++	rockchip,sleep-mode-config = <
++		(0
++		| RKPM_SLP_ARMOFF_DDRPD
++		)
++	>;
++	rockchip,wakeup-config = <
++		(0
++		| RKPM_CPU0_WKUP_EN
++		| RKPM_GPIO_WKUP_EN
++		)
++	>;
++};
++
++&route_dp0 {
++	status = "okay";
++	force-output;
++	connect = <&vp2_out_dp0>;
++
++	force_timing {
++		clock-frequency = <65000000>;
++		hactive = <1024>;
++		vactive = <768>;
++		hfront-porch = <24>;
++		hsync-len = <136>;
++		hback-porch = <160>;
++		vfront-porch = <3>;
++		vsync-len = <6>;
++		vback-porch = <29>;
++		hsync-active = <0>;
++		vsync-active = <0>;
++		de-active = <0>;
++		pixelclk-active = <0>;
++	};
++
++};
++
++&route_dp1 {
++	status = "okay";
++	force-output;
++	connect = <&vp2_out_dp1>;
++
++	force_timing {
++		clock-frequency = <65000000>;
++		hactive = <1024>;
++		vactive = <768>;
++		hfront-porch = <24>;
++		hsync-len = <136>;
++		hback-porch = <160>;
++		vfront-porch = <3>;
++		vsync-len = <6>;
++		vback-porch = <29>;
++		hsync-active = <0>;
++		vsync-active = <0>;
++		de-active = <0>;
++		pixelclk-active = <0>;
++	};
++
++};
++
++&route_hdmi0 {
++	status = "okay";
++	force-output;
++	connect = <&vp2_out_hdmi0>;
++
++	force_timing {
++		clock-frequency = <65000000>;
++		hactive = <1024>;
++		vactive = <768>;
++		hfront-porch = <24>;
++		hsync-len = <136>;
++		hback-porch = <160>;
++		vfront-porch = <3>;
++		vsync-len = <6>;
++		vback-porch = <29>;
++		hsync-active = <0>;
++		vsync-active = <0>;
++		de-active = <0>;
++		pixelclk-active = <0>;
++	};
++
++};
++
++&route_hdmi1 {
++	status = "okay";
++	force-output;
++	connect = <&vp2_out_hdmi1>;
++
++	force_timing {
++		clock-frequency = <65000000>;
++		hactive = <1024>;
++		vactive = <768>;
++		hfront-porch = <24>;
++		hsync-len = <136>;
++		hback-porch = <160>;
++		vfront-porch = <3>;
++		vsync-len = <6>;
++		vback-porch = <29>;
++		hsync-active = <0>;
++		vsync-active = <0>;
++		de-active = <0>;
++		pixelclk-active = <0>;
++	};
++
++};
++
++&sata0 {
++	status = "okay";
++};
++
++&sata1 {
++	status = "okay";
++};
++
++&sdhci {
++	bus-width = <8>;
++	no-sdio;
++	no-sd;
++	non-removable;
++	max-frequency = <200000000>;
++	mmc-hs400-1_8v;
++	mmc-hs400-enhanced-strobe;
++	status = "okay";
++};
++
++&pinctrl {
++	dp {
++		dp1_hdmi_ctl: dp-hdmi-ctl {
++			rockchip,pins = <0 RK_PD5 RK_FUNC_GPIO &pcfg_pull_up>,
++					<3 RK_PB2 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	rtc {
++		rtc_int: rtc-int {
++			rockchip,pins = <0 RK_PB2 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	usb {
++		vcc5v0_host_en: vcc5v0-host-en {
++			rockchip,pins = <4 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		vcc5v0_otg_en: vcc5v0-otg-en {
++			rockchip,pins = <4 RK_PA7 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	sata {
++		sata0_pm_reset: sata0-pm-reset {
++			rockchip,pins = <4 RK_PA0 RK_FUNC_GPIO &pcfg_output_high>;
++		};
++		sata1_pm_reset: sata1-pm-reset {
++			rockchip,pins = <4 RK_PA1 RK_FUNC_GPIO &pcfg_output_high>;
++		};
++	};
++};
++
++&u2phy0 {
++	status = "okay";
++};
++
++&u2phy1 {
++	status = "okay";
++};
++
++&u2phy2 {
++	status = "okay";
++};
++
++&u2phy3 {
++	status = "okay";
++};
++
++&u2phy0_otg {
++	vbus-supply = <&vcc5v0_otg>;
++	status = "okay";
++};
++
++&u2phy1_otg {
++	phy-supply = <&vcc5v0_host>;
++	status = "okay";
++};
++
++&u2phy2_host {
++	phy-supply = <&vcc5v0_host>;
++	status = "okay";
++};
++
++&u2phy3_host {
++	phy-supply = <&vcc5v0_host>;
++	status = "okay";
++};
++
++&usb_host0_ehci {
++	status = "okay";
++};
++
++&usb_host0_ohci {
++	status = "okay";
++};
++
++&usb_host1_ehci {
++	status = "okay";
++};
++
++&usb_host1_ohci {
++	status = "okay";
++};
++
++&usbdp_phy0 {
++	rockchip,dp-lane-mux = < 2 3 >;
++	status = "okay";
++};
++
++&usbdp_phy0_dp {
++	status = "okay";
++};
++
++&usbdp_phy0_u3 {
++	status = "okay";
++};
++
++&usbdp_phy1 {
++	rockchip,dp-lane-mux = < 0 1 2 3 >;
++	status = "okay";
++};
++
++&usbdp_phy1_dp {
++	status = "okay";
++};
++
++&usbdp_phy1_u3 {
++	maximum-speed = "high-speed";
++	status = "okay";
++};
++
++&usbdrd3_0 {
++	status = "okay";
++};
++
++&usbdrd3_1 {
++	status = "okay";
++};
++
++&usbdrd_dwc3_0 {
++	dr_mode = "peripheral";
++	status = "okay";
++};
++
++&usbdrd_dwc3_1 {
++	dr_mode = "host";
++	maximum-speed = "high-speed";
++	status = "okay";
++};
++
++&usbhost3_0 {
++	status = "okay";
++};
++
++&usbhost_dwc3_0 {
++	dr_mode = "host";
++	status = "okay";
++};
++
++&vdd_log_s0 {
++	regulator-state-mem {
++		regulator-on-in-suspend;
++		regulator-suspend-microvolt = <750000>;
++	};
++};
++
++&vdd_vdenc_s0 {
++	regulator-init-microvolt = <750000>;
++};
++
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-rk806-single-khadas-edge2.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-rk806-single-khadas-edge2.dtsi
+new file mode 100644
+index 000000000000..a65a39564ba2
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rk806-single-khadas-edge2.dtsi
+@@ -0,0 +1,396 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2022 Wesion Technology Co., Ltd.
++ *
++ */
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/pinctrl/rockchip.h>
++
++&spi2 {
++	status = "okay";
++	assigned-clocks = <&cru CLK_SPI2>;
++	assigned-clock-rates = <200000000>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi2m2_cs0 &spi2m2_pins>;
++	num-cs = <1>;
++
++	rk806single: rk806single@0 {
++		compatible = "rockchip,rk806";
++		spi-max-frequency = <1000000>;
++		reg = <0x0>;
++
++		interrupt-parent = <&gpio0>;
++		interrupts = <7 IRQ_TYPE_LEVEL_LOW>;
++
++		pinctrl-names = "default", "pmic-power-off";
++		pinctrl-0 = <&pmic_pins>, <&rk806_dvs1_null>, <&rk806_dvs2_null>, <&rk806_dvs3_null>;
++		pinctrl-1 = <&rk806_dvs1_pwrdn>;
++
++		/* 2800mv-3500mv */
++		low_voltage_threshold = <3000>;
++		/* 2700mv-3400mv */
++		shutdown_voltage_threshold = <2700>;
++		/* 140 160 */
++		shutdown_temperture_threshold = <160>;
++		hotdie_temperture_threshold = <115>;
++
++		/* 0: restart PMU;
++		 * 1: reset all the power off reset registers,
++		 *    forcing the state to switch to ACTIVE mode;
++		 * 2: Reset all the power off reset registers,
++		 *    forcing the state to switch to ACTIVE mode,
++		 *    and simultaneously pull down the RESETB PIN for 5mS before releasing
++		 */
++		pmic-reset-func = <1>;
++
++		vcc1-supply = <&vcc5v0_sys>;
++		vcc2-supply = <&vcc5v0_sys>;
++		vcc3-supply = <&vcc5v0_sys>;
++		vcc4-supply = <&vcc5v0_sys>;
++		vcc5-supply = <&vcc5v0_sys>;
++		vcc6-supply = <&vcc5v0_sys>;
++		vcc7-supply = <&vcc5v0_sys>;
++		vcc8-supply = <&vcc5v0_sys>;
++		vcc9-supply = <&vcc5v0_sys>;
++		vcc10-supply = <&vcc5v0_sys>;
++		vcc11-supply = <&vcc_2v0_pldo_s3>;
++		vcc12-supply = <&vcc5v0_sys>;
++		vcc13-supply = <&vcc_1v1_nldo_s3>;
++		vcc14-supply = <&vcc_1v1_nldo_s3>;
++		vcca-supply = <&vcc5v0_sys>;
++
++		pwrkey {
++			status = "okay";
++		};
++
++		pinctrl_rk806: pinctrl_rk806 {
++			gpio-controller;
++			#gpio-cells = <2>;
++
++			rk806_dvs1_null: rk806_dvs1_null {
++				pins = "gpio_pwrctrl2";
++				function = "pin_fun0";
++			};
++
++			rk806_dvs1_slp: rk806_dvs1_slp {
++				pins = "gpio_pwrctrl1";
++				function = "pin_fun1";
++			};
++
++			rk806_dvs1_pwrdn: rk806_dvs1_pwrdn {
++				pins = "gpio_pwrctrl1";
++				function = "pin_fun2";
++			};
++
++			rk806_dvs1_rst: rk806_dvs1_rst {
++				pins = "gpio_pwrctrl1";
++				function = "pin_fun3";
++			};
++
++			rk806_dvs2_null: rk806_dvs2_null {
++				pins = "gpio_pwrctrl2";
++				function = "pin_fun0";
++			};
++
++			rk806_dvs2_slp: rk806_dvs2_slp {
++				pins = "gpio_pwrctrl2";
++				function = "pin_fun1";
++			};
++
++			rk806_dvs2_pwrdn: rk806_dvs2_pwrdn {
++				pins = "gpio_pwrctrl2";
++				function = "pin_fun2";
++			};
++
++			rk806_dvs2_rst: rk806_dvs2_rst {
++				pins = "gpio_pwrctrl2";
++				function = "pin_fun3";
++			};
++
++			rk806_dvs2_dvs: rk806_dvs2_dvs {
++				pins = "gpio_pwrctrl2";
++				function = "pin_fun4";
++			};
++
++			rk806_dvs2_gpio: rk806_dvs2_gpio {
++				pins = "gpio_pwrctrl2";
++				function = "pin_fun5";
++			};
++
++			rk806_dvs3_null: rk806_dvs3_null {
++				pins = "gpio_pwrctrl3";
++				function = "pin_fun0";
++			};
++
++			rk806_dvs3_slp: rk806_dvs3_slp {
++				pins = "gpio_pwrctrl3";
++				function = "pin_fun1";
++			};
++
++			rk806_dvs3_pwrdn: rk806_dvs3_pwrdn {
++				pins = "gpio_pwrctrl3";
++				function = "pin_fun2";
++			};
++
++			rk806_dvs3_rst: rk806_dvs3_rst {
++				pins = "gpio_pwrctrl3";
++				function = "pin_fun3";
++			};
++
++			rk806_dvs3_dvs: rk806_dvs3_dvs {
++				pins = "gpio_pwrctrl3";
++				function = "pin_fun4";
++			};
++
++			rk806_dvs3_gpio: rk806_dvs3_gpio {
++				pins = "gpio_pwrctrl3";
++				function = "pin_fun5";
++			};
++		};
++
++		regulators {
++			vdd_gpu_s0: vdd_gpu_mem_s0: DCDC_REG1 {
++				regulator-boot-on;
++				regulator-min-microvolt = <550000>;
++				regulator-max-microvolt = <950000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_gpu_s0";
++				regulator-enable-ramp-delay = <400>;
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_cpu_lit_s0: vdd_cpu_lit_mem_s0: DCDC_REG2 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <550000>;
++				regulator-max-microvolt = <950000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_cpu_lit_s0";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_log_s0: DCDC_REG3 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <675000>;
++				regulator-max-microvolt = <750000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_log_s0";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++					regulator-suspend-microvolt = <750000>;
++				};
++			};
++
++			vdd_vdenc_s0: vdd_vdenc_mem_s0: DCDC_REG4 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <550000>;
++				regulator-max-microvolt = <950000>;
++				regulator-init-microvolt = <750000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_vdenc_s0";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_ddr_s0: DCDC_REG5 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <675000>;
++				regulator-max-microvolt = <900000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_ddr_s0";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++					regulator-suspend-microvolt = <850000>;
++				};
++			};
++
++			vdd2_ddr_s3: DCDC_REG6 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-name = "vdd2_ddr_s3";
++				regulator-state-mem {
++					regulator-on-in-suspend;
++				};
++			};
++
++			vcc_2v0_pldo_s3: DCDC_REG7 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <2000000>;
++				regulator-max-microvolt = <2000000>;
++				regulator-name = "vdd_2v0_pldo_s3";
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <2000000>;
++				};
++			};
++
++			vcc_3v3_s3: DCDC_REG8 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-name = "vcc_3v3_s3";
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++				};
++			};
++
++			vddq_ddr_s0: DCDC_REG9 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-name = "vddq_ddr_s0";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc_1v8_s3: DCDC_REG10 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "vcc_1v8_s3";
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			avcc_1v8_s0: PLDO_REG2 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "avcc_1v8_s0";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc_1v8_s0: PLDO_REG1 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "vcc_1v8_s0";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			avdd_1v2_s0: PLDO_REG3 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1200000>;
++				regulator-max-microvolt = <1200000>;
++				regulator-name = "avdd_1v2_s0";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc_3v3_s0: PLDO_REG4 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-name = "vcc_3v3_s0";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vccio_sd_s0: PLDO_REG5 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-name = "vccio_sd_s0";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			pldo6_s3: PLDO_REG6 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "pldo6_s3";
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vdd_0v75_s3: NLDO_REG1 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <750000>;
++				regulator-max-microvolt = <750000>;
++				regulator-name = "vdd_0v75_s3";
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <750000>;
++				};
++			};
++
++			vdd_ddr_pll_s0: NLDO_REG2 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <850000>;
++				regulator-max-microvolt = <850000>;
++				regulator-name = "vdd_ddr_pll_s0";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++					regulator-suspend-microvolt = <850000>;
++				};
++			};
++
++			avdd_0v75_s0: NLDO_REG3 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <837500>;
++				regulator-max-microvolt = <837500>;
++				regulator-name = "avdd_0v75_s0";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_0v85_s0: NLDO_REG4 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <850000>;
++				regulator-max-microvolt = <850000>;
++				regulator-name = "vdd_0v85_s0";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_0v75_s0: NLDO_REG5 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <750000>;
++				regulator-max-microvolt = <750000>;
++				regulator-name = "vdd_0v75_s0";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 91ce4c575d14..ee2589a4616a 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -8,7 +8,7 @@
+ #include "dt-bindings/usb/pd.h"
+ #include "rk3588s.dtsi"
+ #include "rk3588s-khadas-edge2.dtsi"
+-#include "rk3588s-rk806-dual.dtsi"
++#include "rk3588-rk806-single-khadas-edge2.dtsi"
+ #include "rk3588-linux.dtsi"
+ #include "rk3588s-khadas-edge2-camera.dtsi"
+ 
+@@ -273,6 +273,69 @@ &hdptxphy0 {
+ 	status = "okay";
+ };
+ 
++&i2c0 {
++    status = "okay";
++    pinctrl-names = "default";
++    pinctrl-0 = <&i2c0m2_xfer>;
++
++    vdd_cpu_big0_s0: vdd_cpu_big0_mem_s0: rk8602@42 {
++        compatible = "rockchip,rk8602";
++        reg = <0x42>;
++        vin-supply = <&vcc5v0_sys>;
++        regulator-compatible = "rk860x-reg";
++        regulator-name = "vdd_cpu_big0_s0";
++        regulator-min-microvolt = <550000>;
++        regulator-max-microvolt = <1050000>;
++        regulator-ramp-delay = <12500>;
++        rockchip,suspend-voltage-selector = <1>;
++        regulator-boot-on;
++        regulator-always-on;
++        regulator-state-mem {
++            regulator-off-in-suspend;
++        };
++    };
++
++    vdd_cpu_big1_s0: vdd_cpu_big1_mem_s0: rk8603@43 {
++        compatible = "rockchip,rk8603";
++        reg = <0x43>;
++        vin-supply = <&vcc5v0_sys>;
++        regulator-compatible = "rk860x-reg";
++        regulator-name = "vdd_cpu_big1_s0";
++        regulator-min-microvolt = <550000>;
++        regulator-max-microvolt = <1050000>;
++        regulator-ramp-delay = <12500>;
++        rockchip,suspend-voltage-selector = <1>;
++        regulator-boot-on;
++        regulator-always-on;
++        regulator-state-mem {
++            regulator-off-in-suspend;
++        };
++    };
++};
++
++&i2c2 {
++
++    status = "okay";
++
++    vdd_npu_s0: vdd_npu_mem_s0: rk8602@42 {
++        compatible = "rockchip,rk8602";
++        reg = <0x42>;
++        vin-supply = <&vcc5v0_sys>;
++        regulator-compatible = "rk860x-reg";
++        regulator-name = "vdd_npu_s0";
++        regulator-min-microvolt = <550000>;
++        regulator-max-microvolt = <950000>;
++        regulator-ramp-delay = <12500>;
++        rockchip,suspend-voltage-selector = <1>;
++        regulator-boot-on;
++        regulator-always-on;
++        regulator-state-mem {
++            regulator-off-in-suspend;
++        };
++    };
++
++};
++
+ &i2c3 {
+ 	status = "okay";
+ 
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi
+index 9d041508cac9..b2e4026031ea 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi
+@@ -150,6 +150,16 @@ vcc5v0_sys: vcc5v0-sys {
+ 		vin-supply = <&vcc12v_dcin>;
+ 	};
+ 
++	vcc_1v1_nldo_s3: vcc-1v1-nldo-s3 {
++        compatible = "regulator-fixed";
++        regulator-name = "vcc_1v1_nldo_s3";
++        regulator-always-on;
++        regulator-boot-on;
++        regulator-min-microvolt = <1100000>;
++        regulator-max-microvolt = <1100000>;
++        vin-supply = <&vcc5v0_sys>;
++    };
++
+ 	vcc5v0_usbdcin: vcc5v0-usbdcin {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vcc5v0_usbdcin";
+@@ -1032,7 +1042,7 @@ &sdmmc {
+ 	cap-sd-highspeed;
+ 	disable-wp;
+ 	sd-uhs-sdr104;
+-	vmmc-supply = <&vcc_3v3_sd_s0>;
++//	vmmc-supply = <&vcc_3v3_sd_s0>;
+ 	vqmmc-supply = <&vccio_sd_s0>;
+ 	status = "disabled";
+ };
+-- 
+Armbian
+
+
+From ebe4239f0eb65c95e41f5e8ef74ab4c31dde730b Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Fri, 13 May 2022 10:03:09 +0800
+Subject: arm64: dts: rockchip: Edge2: fix sdmmc
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: Iaf9beabe5c204a435f295ff1fc69d38537ea4b72
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts  | 24 ++++++++++
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi |  2 +-
+ 2 files changed, 25 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index ee2589a4616a..a5cc248b2866 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -186,6 +186,23 @@ vcc5v0_host: vcc5v0-host {
+ 		pinctrl-0 = <&vcc5v0_host_en>;
+ 	};
+ 
++	vcc_sd: vcc-sd {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_sd";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		enable-active-high;
++		gpio = <&gpio0 RK_PC5 GPIO_ACTIVE_HIGH>;
++		vin-supply = <&vcc_3v3_s3>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc_sd_en>;
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++
+ 	wireless_bluetooth: wireless-bluetooth {
+ 		compatible = "bluetooth-platdata";
+ 		clocks = <&hym8563>;
+@@ -562,6 +579,12 @@ vcc5v0_host_en: vcc5v0-host-en {
+ 		};
+ 	};
+ 
++	vcc_sd {
++		vcc_sd_en: vcc-sd-en {
++			rockchip,pins = <0 RK_PC5 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
+ 	usb-typec {
+ 		usbc0_int: usbc0-int {
+ 			rockchip,pins = <0 RK_PD3 RK_FUNC_GPIO &pcfg_pull_up>;
+@@ -738,6 +761,7 @@ &route_edp0 {
+ 
+ &sdmmc {
+ 	status = "okay";
++	card-detect-delay = <1200>;
+ };
+ 
+ &spdif_tx1 {
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi
+index b2e4026031ea..b00639cf0db5 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi
+@@ -1042,7 +1042,7 @@ &sdmmc {
+ 	cap-sd-highspeed;
+ 	disable-wp;
+ 	sd-uhs-sdr104;
+-//	vmmc-supply = <&vcc_3v3_sd_s0>;
++	vmmc-supply = <&vcc_sd>;
+ 	vqmmc-supply = <&vccio_sd_s0>;
+ 	status = "disabled";
+ };
+-- 
+Armbian
+
+
+From bc0f95e09ca28f0440615964432dd3763498e4f4 Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Tue, 19 Jul 2022 09:14:20 +0800
+Subject: arm64: dts: rockchip: Edge2: HDMI: support HDMI display
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: Ic32eb246a607242217b7bd459bab48b013716c37
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 135 ++--------
+ 1 file changed, 29 insertions(+), 106 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index a5cc248b2866..347f8168602b 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -106,40 +106,6 @@ hall_sensor: hall-mh248 {
+ 		status = "okay";
+ 	};
+ 
+-	panel-edp {
+-		compatible = "simple-panel";
+-		backlight = <&backlight>;
+-		power-supply = <&vcc3v3_lcd_edp>;
+-		prepare-delay-ms = <120>;
+-		enable-delay-ms = <120>;
+-		unprepare-delay-ms = <120>;
+-		disable-delay-ms = <120>;
+-		width-mm = <129>;
+-		height-mm = <171>;
+-
+-		panel-timing {
+-			clock-frequency = <200000000>;
+-			hactive = <1536>;
+-			vactive = <2048>;
+-			hfront-porch = <12>;
+-			hsync-len = <16>;
+-			hback-porch = <48>;
+-			vfront-porch = <8>;
+-			vsync-len = <4>;
+-			vback-porch = <8>;
+-			hsync-active = <0>;
+-			vsync-active = <0>;
+-			de-active = <0>;
+-			pixelclk-active = <0>;
+-		};
+-
+-		port {
+-			panel_in_edp: endpoint {
+-				remote-endpoint = <&edp_out_panel>;
+-			};
+-		};
+-	};
+-
+ 	vbus5v0_typec: vbus5v0-typec {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vbus5v0_typec";
+@@ -152,15 +118,6 @@ vbus5v0_typec: vbus5v0-typec {
+ 		pinctrl-0 = <&typec5v_pwren>;
+ 	};
+ 
+-	vcc3v3_lcd_edp: vcc3v3-lcd-edp {
+-		compatible = "regulator-fixed";
+-		regulator-name = "vcc3v3_lcd_edp";
+-		gpio = <&gpio1 RK_PA5 GPIO_ACTIVE_HIGH>;
+-		enable-active-high;
+-		regulator-boot-on;
+-		vin-supply = <&vcc_3v3_s3>;
+-	};
+-
+ 	vcc3v3_pcie20: vcc3v3-pcie20 {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vcc3v3_pcie20";
+@@ -230,7 +187,7 @@ wireless_wlan: wireless-wlan {
+ 
+ &backlight {
+ 	pwms = <&pwm12 0 25000 0>;
+-	power-supply = <&vcc3v3_lcd_edp>;
++	power-supply = <&vcc_3v3_s0>;
+ 	status = "okay";
+ };
+ 
+@@ -250,46 +207,40 @@ &dp0_sound{
+ 	status = "okay";
+ };
+ 
+-&edp0 {
+-	force-hpd;
+-	status = "okay";
+-
+-	ports {
+-		port@1 {
+-			reg = <1>;
+-
+-			edp_out_panel: endpoint {
+-				remote-endpoint = <&panel_in_edp>;
+-			};
+-		};
+-	};
+-};
+-
+-&edp0_in_vp2 {
+-	status = "okay";
+-};
+-
+-&hdptxphy0 {
++//&hdptxphy0 {
+ 	/* Single Vdiff Training Table for power reduction (optional) */
+-	training-table = /bits/ 8 <
++//	training-table = /bits/ 8 <
+ 		/* voltage swing 0, pre-emphasis 0->3 */
+-		0x0d 0x00 0x00 0x00 0x00 0x00
+-		0x0d 0x00 0x00 0x00 0x00 0x00
+-		0x0d 0x00 0x00 0x00 0x00 0x00
+-		0x0d 0x00 0x00 0x00 0x00 0x00
++//		0x0d 0x00 0x00 0x00 0x00 0x00
++//		0x0d 0x00 0x00 0x00 0x00 0x00
++//		0x0d 0x00 0x00 0x00 0x00 0x00
++//		0x0d 0x00 0x00 0x00 0x00 0x00
+ 		/* voltage swing 1, pre-emphasis 0->2 */
+-		0x0d 0x00 0x00 0x00 0x00 0x00
+-		0x0d 0x00 0x00 0x00 0x00 0x00
+-		0x0d 0x00 0x00 0x00 0x00 0x00
++//		0x0d 0x00 0x00 0x00 0x00 0x00
++//		0x0d 0x00 0x00 0x00 0x00 0x00
++//		0x0d 0x00 0x00 0x00 0x00 0x00
+ 		/* voltage swing 2, pre-emphasis 0->1 */
+-		0x0d 0x00 0x00 0x00 0x00 0x00
+-		0x0d 0x00 0x00 0x00 0x00 0x00
++//		0x0d 0x00 0x00 0x00 0x00 0x00
++//		0x0d 0x00 0x00 0x00 0x00 0x00
+ 		/* voltage swing 3, pre-emphasis 0 */
+-		0x0d 0x00 0x00 0x00 0x00 0x00
+-	>;
++//		0x0d 0x00 0x00 0x00 0x00 0x00
++//	>;
++//	status = "okay";
++//};
++
++&hdmi0 {
++	enable-gpios = <&gpio1 RK_PA5 GPIO_ACTIVE_HIGH>;
+ 	status = "okay";
+ };
+ 
++&hdmi0_in_vp0 {
++	status = "okay";
++ };
++
++&hdptxphy_hdmi0 {
++	status = "okay";
++ };
++
+ &i2c0 {
+     status = "okay";
+     pinctrl-names = "default";
+@@ -529,13 +480,13 @@ hym8563: hym8563@51 {
+ };
+ 
+ &pcie2x1l1 {
+-	reset-gpios = <&gpio4 RK_PA2 GPIO_ACTIVE_HIGH>;
++//	reset-gpios = <&gpio4 RK_PA2 GPIO_ACTIVE_HIGH>;
+ 	vpcie3v3-supply = <&vcc3v3_pcie20>;
+ 	status = "okay";
+ };
+ 
+ &pcie2x1l2 {
+-	reset-gpios = <&gpio4 RK_PC1 GPIO_ACTIVE_HIGH>;
++//	reset-gpios = <&gpio4 RK_PC1 GPIO_ACTIVE_HIGH>;
+ 	rockchip,skip-scan-in-resume;
+ 	status = "okay";
+ };
+@@ -754,11 +705,6 @@ &route_hdmi0 {
+     /delete-node/ force_timing;
+ };
+ 
+-&route_edp0 {
+-	connect = <&vp2_out_edp0>;
+-	status = "okay";
+-};
+-
+ &sdmmc {
+ 	status = "okay";
+ 	card-detect-delay = <1200>;
+@@ -863,26 +809,3 @@ regulator-state-mem {
+         regulator-suspend-microvolt = <3300000>;
+     };
+ };
+-
+-/* vp0 & vp3 are not used on this board */
+-&vp0 {
+-	/delete-property/ rockchip,plane-mask;
+-	/delete-property/ rockchip,primary-plane;
+-};
+-
+-&vp1 {
+-	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER0 | 1 << ROCKCHIP_VOP2_ESMART0 |
+-				1 << ROCKCHIP_VOP2_CLUSTER1 | 1 << ROCKCHIP_VOP2_ESMART1)>;
+-	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART1>;
+-};
+-
+-&vp2 {
+-	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER2 | 1 << ROCKCHIP_VOP2_ESMART2 |
+-				1 << ROCKCHIP_VOP2_CLUSTER3 | 1 << ROCKCHIP_VOP2_ESMART3)>;
+-	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART2>;
+-};
+-
+-&vp3 {
+-	/delete-property/ rockchip,plane-mask;
+-	/delete-property/ rockchip,primary-plane;
+-};
+-- 
+Armbian
+
+
+From 2d0479c0a4a27a4b42bf099821071c026b6534de Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Mon, 16 May 2022 17:25:26 +0800
+Subject: arm64: dts: rockchip: Edge2: add spi flash NOR support
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: I53ff66f0956a29a0729a08e29d4af0106f05757d
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 347f8168602b..3dd02f8d37c2 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -710,6 +710,12 @@ &sdmmc {
+ 	card-detect-delay = <1200>;
+ };
+ 
++&sfc {
++	pinctrl-names = "default";
++	pinctrl-0 = <&fspim2_pins>;
++	status = "okay";
++};
++
+ &spdif_tx1 {
+ 	status = "disabled";
+ 	pinctrl-names = "default";
+-- 
+Armbian
+
+
+From ef78208359a0635549879e46dea0aae9743c2ab2 Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Tue, 17 May 2022 10:07:55 +0800
+Subject: arm64: dts: rockchip: Edge2: support fusb302
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: Id17b3c80810edec26af2093c976587b277d4a78e
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 3dd02f8d37c2..d7841afbd2f7 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -394,16 +394,17 @@ mpu6500_gyro: mpu_gyro@68 {
+ 	};
+ };
+ 
+-&i2c8 {
++&i2c6 {
+ 	status = "okay";
+ 	pinctrl-names = "default";
+-	pinctrl-0 = <&i2c8m2_xfer>;
++	pinctrl-0 = <&i2c6m3_xfer>;
+ 
+ 	usbc0: fusb302@22 {
+ 		compatible = "fcs,fusb302";
+ 		reg = <0x22>;
+ 		interrupt-parent = <&gpio0>;
+-		interrupts = <RK_PD3 IRQ_TYPE_LEVEL_LOW>;
++		interrupts = <RK_PC6 IRQ_TYPE_LEVEL_LOW>;
++		int-n-gpios = <&gpio0 RK_PC6 GPIO_ACTIVE_LOW>;
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&usbc0_int>;
+ 		vbus-supply = <&vbus5v0_typec>;
+-- 
+Armbian
+
+
+From 05b865db3a1b549a04ec983c036bab6fa301ae90 Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Tue, 17 May 2022 10:49:51 +0800
+Subject: arm64: dts: rockchip: Edge2: enable usb host power
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: Ia1c7b5b7cb5828717d61c4b6b6b3569d1098ab32
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index d7841afbd2f7..b9870eb92632 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -137,7 +137,7 @@ vcc5v0_host: vcc5v0-host {
+ 		regulator-min-microvolt = <5000000>;
+ 		regulator-max-microvolt = <5000000>;
+ 		enable-active-high;
+-		gpio = <&gpio1 RK_PB1 GPIO_ACTIVE_HIGH>;
++		gpio = <&gpio4 RK_PA4 GPIO_ACTIVE_HIGH>;
+ 		vin-supply = <&vcc5v0_usb>;
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&vcc5v0_host_en>;
+@@ -527,7 +527,7 @@ mpu6500_irq_gpio: mpu6500_irq_gpio {
+ 
+ 	usb {
+ 		vcc5v0_host_en: vcc5v0-host-en {
+-			rockchip,pins = <1 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;
++			rockchip,pins = <4 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 	};
+ 
+-- 
+Armbian
+
+
+From 1e749bb345578ec37e53796ed0ba514bc3c04145 Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Tue, 17 May 2022 11:09:12 +0800
+Subject: arm64: dts: rockchip: Edge2: USB: fix USB host 3.0
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: I94b7e3f0d50d5bfaf27828eef21b742c02b3e752
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index b9870eb92632..0eb33d5d1a6d 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -483,7 +483,7 @@ hym8563: hym8563@51 {
+ &pcie2x1l1 {
+ //	reset-gpios = <&gpio4 RK_PA2 GPIO_ACTIVE_HIGH>;
+ 	vpcie3v3-supply = <&vcc3v3_pcie20>;
+-	status = "okay";
++	status = "disabled";
+ };
+ 
+ &pcie2x1l2 {
+@@ -787,11 +787,12 @@ dwc3_0_role_switch: endpoint@0 {
+ };
+ 
+ &usbhost3_0 {
+-	status = "disabled";
++	status = "okay";
+ };
+ 
+ &usbhost_dwc3_0 {
+-	status = "disabled";
++	dr_mode = "host";
++	status = "okay";
+ };
+ 
+ &vdd_log_s0 {
+-- 
+Armbian
+
+
+From 5ee16d7d44c36e7881af30fc2610c9cd04480242 Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Tue, 17 May 2022 11:22:29 +0800
+Subject: arm64: dts: rockchip: Edge2: support TYPEC0
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: Ib599d12c9677da5b6bef855bd492f7b83cc1c7e7
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 14 ++++++----
+ 1 file changed, 8 insertions(+), 6 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 0eb33d5d1a6d..eb46232340e5 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -112,7 +112,7 @@ vbus5v0_typec: vbus5v0-typec {
+ 		regulator-min-microvolt = <5000000>;
+ 		regulator-max-microvolt = <5000000>;
+ 		enable-active-high;
+-		gpio = <&gpio1 RK_PA1 GPIO_ACTIVE_HIGH>;
++		gpio = <&gpio3 RK_PA4 GPIO_ACTIVE_HIGH>;
+ 		vin-supply = <&vcc5v0_usb>;
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&typec5v_pwren>;
+@@ -430,7 +430,9 @@ usb_con: connector {
+ 			try-power-role = "sink";
+ 			op-sink-microwatt = <1000000>;
+ 			sink-pdos =
+-				<PDO_FIXED(5000, 1000, PDO_FIXED_USB_COMM)>;
++				<PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)
++				 PDO_FIXED(9000, 3000, PDO_FIXED_USB_COMM)
++				 PDO_FIXED(12000, 3000, PDO_FIXED_USB_COMM)>;
+ 			source-pdos =
+ 				<PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>;
+ 
+@@ -539,11 +541,11 @@ vcc_sd_en: vcc-sd-en {
+ 
+ 	usb-typec {
+ 		usbc0_int: usbc0-int {
+-			rockchip,pins = <0 RK_PD3 RK_FUNC_GPIO &pcfg_pull_up>;
++			rockchip,pins = <0 RK_PC6 RK_FUNC_GPIO &pcfg_pull_up>;
+ 		};
+ 
+ 		typec5v_pwren: typec5v-pwren {
+-			rockchip,pins = <1 RK_PA1 RK_FUNC_GPIO &pcfg_pull_none>;
++			rockchip,pins = <3 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 	};
+ 
+@@ -756,8 +758,8 @@ &uart8 {
+ &usbdp_phy0 {
+ 	orientation-switch;
+ 	svid = <0xff01>;
+-	sbu1-dc-gpios = <&gpio1 RK_PB6 GPIO_ACTIVE_HIGH>;
+-	sbu2-dc-gpios = <&gpio1 RK_PB7 GPIO_ACTIVE_HIGH>;
++	sbu1-dc-gpios = <&gpio4 RK_PA0 GPIO_ACTIVE_HIGH>;
++	sbu2-dc-gpios = <&gpio4 RK_PA1 GPIO_ACTIVE_HIGH>;
+ 
+ 	port {
+ 		#address-cells = <1>;
+-- 
+Armbian
+
+
+From 7c05cbfdd7c317bf661538a89ea988ec06cd5873 Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Thu, 19 May 2022 11:52:17 +0800
+Subject: arm64: dts: rockchip: Edge2: RTC: support PT7C4363
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: I6ab9b91ccb54f5b76566322c09021c618d201fcb
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 16 ++--------
+ 1 file changed, 3 insertions(+), 13 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index eb46232340e5..461492d48c12 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -162,7 +162,7 @@ regulator-state-mem {
+ 
+ 	wireless_bluetooth: wireless-bluetooth {
+ 		compatible = "bluetooth-platdata";
+-		clocks = <&hym8563>;
++		clocks = <&pt7c4363>;
+ 		clock-names = "ext_clock";
+ 		uart_rts_gpios = <&gpio3 RK_PA4 GPIO_ACTIVE_LOW>;
+ 		pinctrl-names = "default", "rts_gpio";
+@@ -468,16 +468,12 @@ dp_altmode_mux: endpoint {
+ 		};
+ 	};
+ 
+-	hym8563: hym8563@51 {
++	pt7c4363: pt7c4363@51 {
+ 		compatible = "haoyu,hym8563";
+ 		reg = <0x51>;
+ 		#clock-cells = <0>;
+ 		clock-frequency = <32768>;
+-		clock-output-names = "hym8563";
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&hym8563_int>;
+-		interrupt-parent = <&gpio0>;
+-		interrupts = <RK_PC4 IRQ_TYPE_LEVEL_LOW>;
++		clock-output-names = "pt7c4363";
+ 		wakeup-source;
+ 	};
+ };
+@@ -505,12 +501,6 @@ hp_det: hp-det {
+ 		};
+ 	};
+ 
+-	hym8563 {
+-		hym8563_int: hym8563-int {
+-			rockchip,pins = <0 RK_PC4 RK_FUNC_GPIO &pcfg_pull_up>;
+-		};
+-	};
+-
+ 	lcd {
+ 		lcd_rst_gpio: lcd-rst-gpio {
+ 			rockchip,pins = <1 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
+-- 
+Armbian
+
+
+From 911fa11cb23b3bf9dde93ef902b3eb6c92d61398 Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Tue, 17 May 2022 16:19:29 +0800
+Subject: arm64: rockchip: Edge2: supoort AP6275P wifi and bt
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: I7fc1c3a8f51282d29dd26d59cc642755b91f979f
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 31 +++++-----
+ arch/arm64/configs/kedges_defconfig                   |  2 +
+ 2 files changed, 18 insertions(+), 15 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 461492d48c12..76235fa01710 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -103,7 +103,7 @@ hall_sensor: hall-mh248 {
+ 		pinctrl-0 = <&mh248_irq_gpio>;
+ 		irq-gpio = <&gpio0 RK_PD4 IRQ_TYPE_EDGE_BOTH>;
+ 		hall-active = <1>;
+-		status = "okay";
++		status = "disabled";
+ 	};
+ 
+ 	vbus5v0_typec: vbus5v0-typec {
+@@ -164,13 +164,13 @@ wireless_bluetooth: wireless-bluetooth {
+ 		compatible = "bluetooth-platdata";
+ 		clocks = <&pt7c4363>;
+ 		clock-names = "ext_clock";
+-		uart_rts_gpios = <&gpio3 RK_PA4 GPIO_ACTIVE_LOW>;
++		uart_rts_gpios = <&gpio3 RK_PD2 GPIO_ACTIVE_LOW>;
+ 		pinctrl-names = "default", "rts_gpio";
+-		pinctrl-0 = <&uart8m1_rtsn>, <&bt_gpio>;
+-		pinctrl-1 = <&uart8_gpios>;
+-		BT,reset_gpio    = <&gpio3 RK_PB7 GPIO_ACTIVE_HIGH>;
+-		BT,wake_gpio     = <&gpio3 RK_PC1 GPIO_ACTIVE_HIGH>;
+-		BT,wake_host_irq = <&gpio3 RK_PC0 GPIO_ACTIVE_HIGH>;
++		pinctrl-0 = <&uart9m2_rtsn>, <&bt_gpio>;
++		pinctrl-1 = <&uart9_gpios>;
++		BT,reset_gpio    = <&gpio0 RK_PD4 GPIO_ACTIVE_HIGH>;
++		BT,wake_gpio     = <&gpio0 RK_PD3 GPIO_ACTIVE_HIGH>;
++		BT,wake_host_irq = <&gpio0 RK_PD5 GPIO_ACTIVE_HIGH>;
+ 		status = "okay";
+ 	};
+ 
+@@ -345,7 +345,7 @@ gsl3673@40 {
+ };
+ 
+ &i2c5 {
+-	status = "okay";
++	status = "disabled";
+ 
+ 	ls_stk3332: light@47 {
+ 		compatible = "ls_stk3332";
+@@ -486,6 +486,7 @@ &pcie2x1l1 {
+ 
+ &pcie2x1l2 {
+ //	reset-gpios = <&gpio4 RK_PC1 GPIO_ACTIVE_HIGH>;
++	reset-gpios = <&gpio3 RK_PD1 GPIO_ACTIVE_HIGH>;
+ 	rockchip,skip-scan-in-resume;
+ 	status = "okay";
+ };
+@@ -540,15 +541,15 @@ typec5v_pwren: typec5v-pwren {
+ 	};
+ 
+ 	wireless-bluetooth {
+-		uart8_gpios: uart8-gpios {
+-			rockchip,pins = <3 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
++		uart9_gpios: uart9-gpios {
++			rockchip,pins = <3 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 
+ 		bt_gpio: bt-gpio {
+ 			rockchip,pins =
+-				<3 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>,
+-				<3 RK_PC1 RK_FUNC_GPIO &pcfg_pull_up>,
+-				<3 RK_PC0 RK_FUNC_GPIO &pcfg_pull_down>;
++				<0 RK_PD4 RK_FUNC_GPIO &pcfg_pull_none>,
++				<0 RK_PD3 RK_FUNC_GPIO &pcfg_pull_up>,
++				<0 RK_PD5 RK_FUNC_GPIO &pcfg_pull_down>;
+ 		};
+ 	};
+ 
+@@ -739,10 +740,10 @@ &u2phy3_host {
+ 	phy-supply = <&vcc5v0_host>;
+ };
+ 
+-&uart8 {
++&uart9 {
+ 	status = "okay";
+ 	pinctrl-names = "default";
+-	pinctrl-0 = <&uart8m1_xfer &uart8m1_ctsn>;
++	pinctrl-0 = <&uart9m2_xfer &uart9m2_ctsn>;
+ };
+ 
+ &usbdp_phy0 {
+diff --git a/arch/arm64/configs/kedges_defconfig b/arch/arm64/configs/kedges_defconfig
+index e654b39e731e..31c282f08e70 100644
+--- a/arch/arm64/configs/kedges_defconfig
++++ b/arch/arm64/configs/kedges_defconfig
+@@ -183,6 +183,8 @@ CONFIG_WL_ROCKCHIP=y
+ CONFIG_WIFI_LOAD_DRIVER_WHEN_KERNEL_BOOTUP=y
+ CONFIG_AP6XXX=y
+ CONFIG_BCMDHD_PCIE=y
++CONFIG_BCMDHD_FW_PATH="/lib/firmware/brcm/fw_bcmdhd.bin"
++CONFIG_BCMDHD_NVRAM_PATH="/lib/firmware/brcm/nvram.txt"
+ CONFIG_INPUT_FF_MEMLESS=y
+ CONFIG_INPUT_EVDEV=y
+ CONFIG_KEYBOARD_ADC=y
+-- 
+Armbian
+
+
+From 84c535f0c96ed5b7d34137c9ec6f31cca09464df Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Tue, 17 May 2022 18:20:01 +0800
+Subject: Edge2: gsensor: support kxtj3 driver
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: I68fd23ad2ec9121967b1d50f7f508bf263ce25d2
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 11 ++++++
+ arch/arm64/configs/kedges_defconfig                   |  3 ++
+ drivers/input/sensors/accel/kxtj9.c                   | 18 ++++++++--
+ drivers/input/sensors/sensor-dev.c                    |  2 +-
+ 4 files changed, 30 insertions(+), 4 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 76235fa01710..3e891b324247 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -307,6 +307,17 @@ regulator-state-mem {
+ &i2c3 {
+ 	status = "okay";
+ 
++	gs_kxtj3: gs_kxtj3@e {
++		compatible = "gs_kxtj3";
++		reg = <0x0e>;
++		irq-gpio = <&gpio1 RK_PB0 IRQ_TYPE_EDGE_RISING>;
++		irq_enable = <0>;
++		poll_delay_ms = <30>;
++		type = <SENSOR_TYPE_ACCEL>;
++		layout = <0>;
++		status = "okay";
++	};
++
+ 	es8388: es8388@11 {
+ 		status = "okay";
+ 		#sound-dai-cells = <0>;
+diff --git a/arch/arm64/configs/kedges_defconfig b/arch/arm64/configs/kedges_defconfig
+index 31c282f08e70..ac5ba22fa5e7 100644
+--- a/arch/arm64/configs/kedges_defconfig
++++ b/arch/arm64/configs/kedges_defconfig
+@@ -202,6 +202,9 @@ CONFIG_TOUCHSCREEN_ELAN=y
+ CONFIG_TOUCHSCREEN_USB_COMPOSITE=y
+ CONFIG_ROCKCHIP_REMOTECTL=y
+ CONFIG_ROCKCHIP_REMOTECTL_PWM=y
++CONFIG_SENSOR_DEVICE=y
++CONFIG_GSENSOR_DEVICE=y
++CONFIG_GS_KXTJ9=y
+ CONFIG_INPUT_MISC=y
+ CONFIG_INPUT_UINPUT=y
+ CONFIG_INPUT_RK805_PWRKEY=y
+diff --git a/drivers/input/sensors/accel/kxtj9.c b/drivers/input/sensors/accel/kxtj9.c
+index 4726c5f73b54..116f7b605d74 100644
+--- a/drivers/input/sensors/accel/kxtj9.c
++++ b/drivers/input/sensors/accel/kxtj9.c
+@@ -32,6 +32,7 @@
+ #include <linux/sensor-dev.h>
+ 
+ 
++#define KXTJ3_DEVID 0x35 //KXTJ3 id
+ #define KXTJ9_DEVID	0x09	//chip id
+ #define KXTJ9_RANGE	(2 * 16384)
+ 
+@@ -78,6 +79,7 @@
+ /* CONTROL REGISTER 1 BITS */
+ #define KXTJ9_DISABLE			0x7F
+ #define KXTJ9_ENABLE			(1 << 7)
++#define KXTJ3_INT_ENABLE               (1 << 5)
+ /* INPUT_ABS CONSTANTS */
+ #define FUZZ			3
+ #define FLAT			3
+@@ -109,6 +111,7 @@
+ #define KXTJ9_PRECISION       12
+ #define KXTJ9_BOUNDARY        (0x1 << (KXTJ9_PRECISION - 1))
+ #define KXTJ9_GRAVITY_STEP    KXTJ9_RANGE / KXTJ9_BOUNDARY
++#define KXTJ3_GRAVITY_STEP    KXTJ9_RANGE / KXTJ9_BOUNDARY
+ 
+ 
+ /****************operate according to sensor chip:start************/
+@@ -176,6 +179,9 @@ static int sensor_init(struct i2c_client *client)
+ 	}
+ 	
+ 	sensor->ops->ctrl_data = (KXTJ9_RES_12BIT | KXTJ9_G_2G);
++	if(sensor->pdata->irq_enable)
++		sensor->ops->ctrl_data |= KXTJ3_INT_ENABLE;
++
+ 	result = sensor_write_reg(client, sensor->ops->ctrl_reg, sensor->ops->ctrl_data);
+ 	if(result)
+ 	{
+@@ -192,7 +198,12 @@ static short sensor_convert_data(struct i2c_client *client, char high_byte, char
+ 	struct sensor_private_data *sensor =
+ 	    (struct sensor_private_data *) i2c_get_clientdata(client);	
+ 	//int precision = sensor->ops->precision;
+-	switch (sensor->devid) {	
++	switch (sensor->devid) {
++		case KXTJ3_DEVID:
++			result = (((short)high_byte << 8) | ((short)low_byte)) >> 4;
++			result *= KXTJ3_GRAVITY_STEP;
++			break;
++
+ 		case KXTJ9_DEVID:		
+ 			result = (((short)high_byte << 8) | ((short)low_byte)) >> 4;
+ 			result *= KXTJ9_GRAVITY_STEP;
+@@ -284,7 +295,7 @@ static struct sensor_operate gsensor_kxtj9_ops = {
+ 	.read_reg			= KXTJ9_XOUT_L,
+ 	.read_len			= 6,
+ 	.id_reg			= KXTJ9_WHO_AM_I,
+-	.id_data			= KXTJ9_DEVID,
++	.id_data			= KXTJ3_DEVID,
+ 	.precision			= KXTJ9_PRECISION,
+ 	.ctrl_reg			= KXTJ9_CTRL_REG1,
+ 	.int_status_reg	= KXTJ9_INT_REL,
+@@ -309,6 +320,7 @@ static int gsensor_kxtj9_remove(struct i2c_client *client)
+ 
+ static const struct i2c_device_id gsensor_kxtj9_id[] = {
+ 	{"gs_kxtj9", ACCEL_ID_KXTJ9},
++	{"gs_kxtj3", ACCEL_ID_KXTJ9},
+ 	{}
+ };
+ 
+@@ -318,7 +330,7 @@ static struct i2c_driver gsensor_kxtj9_driver = {
+ 	.shutdown = sensor_shutdown,
+ 	.id_table = gsensor_kxtj9_id,
+ 	.driver = {
+-		.name = "gsensor_kxtj9",
++		.name = "gsensor_kxtj3",
+ 	#ifdef CONFIG_PM
+ 		.pm = &sensor_pm_ops,
+ 	#endif
+diff --git a/drivers/input/sensors/sensor-dev.c b/drivers/input/sensors/sensor-dev.c
+index eb93e19157ea..1c873d3c1b15 100644
+--- a/drivers/input/sensors/sensor-dev.c
++++ b/drivers/input/sensors/sensor-dev.c
+@@ -1447,7 +1447,7 @@ static int sensor_misc_device_register(struct sensor_private_data *sensor, int t
+ 			sensor->fops.release = gsensor_dev_release;
+ 
+ 			sensor->miscdev.minor = MISC_DYNAMIC_MINOR;
+-			sensor->miscdev.name = "mma8452_daemon";
++			sensor->miscdev.name = "accel";
+ 			sensor->miscdev.fops = &sensor->fops;
+ 		} else {
+ 			memcpy(&sensor->miscdev, sensor->ops->misc_dev, sizeof(*sensor->ops->misc_dev));
+-- 
+Armbian
+
+
+From 878771cb9829d0be036ad277e9c603787d7f23d7 Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Tue, 17 May 2022 19:14:32 +0800
+Subject: arm64: dts: rockchip: Edge2: enable spi1
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: Ife106f2b4eaefc947aba04aee81e93460d56c90a
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 12 ++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 3e891b324247..0e3b5b10dd83 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -739,6 +739,18 @@ &spdif_tx2 {
+ 	status = "okay";
+ };
+ 
++&spi1 {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi1m1_cs0 &spi1m1_pins>;
++	spidev@1 {
++		compatible = "rockchip,spidev";
++		reg = <1>;
++		spi-max-frequency = <100000000>;
++		status = "okay";
++	};
++};
++
+ &u2phy0_otg {
+ 	rockchip,typec-vbus-det;
+ };
+-- 
+Armbian
+
+
+From 5ea47dc6271a6fe972de70b51d64072be1a796db Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Tue, 17 May 2022 20:02:54 +0800
+Subject: Edge2: add reboot test mode
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: If1f11a39f7be7f6f6f662359a4e388fe934e2ef4
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 4 ++++
+ include/dt-bindings/soc/rockchip,boot-mode.h          | 3 ++-
+ 2 files changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 0e3b5b10dd83..551d4ad67017 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -304,6 +304,10 @@ regulator-state-mem {
+ 
+ };
+ 
++&reboot_mode {
++	mode-reboot_test = <BOOT_REBOOT_TEST>;
++};
++
+ &i2c3 {
+ 	status = "okay";
+ 
+diff --git a/include/dt-bindings/soc/rockchip,boot-mode.h b/include/dt-bindings/soc/rockchip,boot-mode.h
+index 1436e1d32619..c617db54b09c 100644
+--- a/include/dt-bindings/soc/rockchip,boot-mode.h
++++ b/include/dt-bindings/soc/rockchip,boot-mode.h
+@@ -20,5 +20,6 @@
+ #define BOOT_CHARGING		(REBOOT_FLAG + 11)
+ /* enter usb mass storage mode */
+ #define BOOT_UMS		(REBOOT_FLAG + 12)
+-
++/* enter reboot test mode */
++#define BOOT_REBOOT_TEST        (REBOOT_FLAG + 14)
+ #endif
+-- 
+Armbian
+
+
+From 0a75614de22c821085e261e49d9fad48f191e935 Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Tue, 17 May 2022 20:07:27 +0800
+Subject: arm64: dts: rockchip: Edge2: Key: configure fun key as home key
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: I28af84c0898469c455ad7e2b82aed2feb5e843ba
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi | 24 ++--------
+ 1 file changed, 3 insertions(+), 21 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi
+index b00639cf0db5..12232bdd3896 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi
+@@ -20,29 +20,11 @@ adc_keys: adc-keys {
+ 		keyup-threshold-microvolt = <1800000>;
+ 		poll-interval = <100>;
+ 
+-		vol-up-key {
+-			label = "volume up";
+-			linux,code = <KEY_VOLUMEUP>;
++		home-key {
++			label = "home";
++			linux,code = <KEY_HOMEPAGE>;
+ 			press-threshold-microvolt = <17000>;
+ 		};
+-
+-		vol-down-key {
+-			label = "volume down";
+-			linux,code = <KEY_VOLUMEDOWN>;
+-			press-threshold-microvolt = <417000>;
+-		};
+-
+-		menu-key {
+-			label = "menu";
+-			linux,code = <KEY_MENU>;
+-			press-threshold-microvolt = <890000>;
+-		};
+-
+-		back-key {
+-			label = "back";
+-			linux,code = <KEY_BACK>;
+-			press-threshold-microvolt = <1235000>;
+-		};
+ 	};
+ 
+ 	backlight: backlight {
+-- 
+Armbian
+
+
+From df78a98d5ad0d1557607a92ecb7a1e6df91fb796 Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Thu, 28 Apr 2022 09:18:40 +0800
+Subject: drivers: Edge2: Watchdog: add khadas watchdog driver
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: I10d552e7401d38545085ecb7ad67f3727475f5e2
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts |   7 +
+ drivers/watchdog/Kconfig                              |  10 +
+ drivers/watchdog/Makefile                             |   1 +
+ drivers/watchdog/khadas_wdt.c                         | 157 ++++++++++
+ 4 files changed, 175 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 551d4ad67017..078b1ec2cd07 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -91,6 +91,13 @@ play-pause-key {
+ 		};
+ 	};
+ 
++	khadas_wdt {
++		compatible = "linux,wdt-khadas";
++		status = "okay";
++		hw_margin_ms = <500>;
++		hw-gpios = <&gpio0 RK_PB0 GPIO_ACTIVE_HIGH>;
++	};
++
+ 	fan: pwm-fan {
+ 		compatible = "pwm-fan";
+ 		#cooling-cells = <2>;
+diff --git a/drivers/watchdog/Kconfig b/drivers/watchdog/Kconfig
+index 01ce3f41cc21..bde9e629ec45 100644
+--- a/drivers/watchdog/Kconfig
++++ b/drivers/watchdog/Kconfig
+@@ -865,6 +865,16 @@ config MEDIATEK_WATCHDOG
+ 	  To compile this driver as a module, choose M here: the
+ 	  module will be called mtk_wdt.
+ 
++config KHADAS_WATCHDOG
++	tristate "KHADAS watchdog support"
++	default y
++	help
++	 Say Y here to include watchdog support embedded into KHADAS.
++	 If the watchdog timer expires, TPS3851 will shut down all its power
++	 supplies.
++	 To compile this driver as a module, choose M here: the
++	 module will be called KHADAS_wdt.
++
+ config DIGICOLOR_WATCHDOG
+ 	tristate "Conexant Digicolor SoCs watchdog support"
+ 	depends on ARCH_DIGICOLOR || COMPILE_TEST
+diff --git a/drivers/watchdog/Makefile b/drivers/watchdog/Makefile
+index 071a2e50be98..0dc45e86a352 100644
+--- a/drivers/watchdog/Makefile
++++ b/drivers/watchdog/Makefile
+@@ -25,6 +25,7 @@ obj-$(CONFIG_WATCHDOG_PRETIMEOUT_GOV_PANIC)	+= pretimeout_panic.o
+ obj-$(CONFIG_PCWATCHDOG) += pcwd.o
+ obj-$(CONFIG_MIXCOMWD) += mixcomwd.o
+ obj-$(CONFIG_WDT) += wdt.o
++obj-$(CONFIG_KHADAS_WATCHDOG) += khadas_wdt.o
+ 
+ # PCI-based Watchdog Cards
+ obj-$(CONFIG_PCIPCWATCHDOG) += pcwd_pci.o
+diff --git a/drivers/watchdog/khadas_wdt.c b/drivers/watchdog/khadas_wdt.c
+new file mode 100644
+index 000000000000..3b28a52fd6ae
+--- /dev/null
++++ b/drivers/watchdog/khadas_wdt.c
+@@ -0,0 +1,157 @@
++//#define DEBUG
++
++#include <linux/kernel.h>
++#include <linux/types.h>
++#include <linux/init.h>
++#include <linux/platform_device.h>
++#include <linux/gpio.h>
++#include <linux/of_platform.h>
++#include <linux/of_gpio.h>
++#include <linux/slab.h>
++#include <linux/workqueue.h>
++#include <linux/module.h>
++#include <linux/device.h>
++#include <asm/io.h>
++#include <asm/uaccess.h>
++#include <linux/fs.h>
++#include <linux/timer.h>
++#include <linux/jiffies.h>
++
++static struct timer_list mytimer;
++static unsigned int hw_margin = 3;
++static int khadas_input_pin;
++static unsigned int khadas_enble = 1;
++
++static void time_pre(struct timer_list *timer)
++{
++	static unsigned int flag=0;
++    flag = !flag;
++	gpio_direction_output(khadas_input_pin, flag);
++
++    //printk("%s\n", __func__);
++    mytimer.expires = jiffies + hw_margin * HZ/1000;  // 500ms 运行一次
++	if(khadas_enble)
++		mod_timer(&mytimer, mytimer.expires);
++}
++
++/*
++static void wdt_exit(void)
++{
++    if(timer_pending(&mytimer))
++    {
++        del_timer(&mytimer);
++    }
++    printk("exit Success \n");
++}*/
++
++static ssize_t show_enble(struct class *cls,
++				struct class_attribute *attr, char *buf)
++{
++	return sprintf(buf, "%d\n", khadas_enble);
++}
++
++static ssize_t store_enble(struct class *cls, struct class_attribute *attr,
++		        const char *buf, size_t count)
++{
++	int enable;
++
++	if (kstrtoint(buf, 0, &enable)){
++		printk("khadas_enble error\n");
++		return -EINVAL;
++	}
++	printk("khadas_enble=%d\n",enable);
++	khadas_enble = enable;
++	if(khadas_enble){
++		mytimer.expires = jiffies + hw_margin * HZ/1000;  // 500ms 运行一次
++		mod_timer(&mytimer, mytimer.expires);
++	}
++	return count;
++}
++
++static ssize_t store_pin_out(struct class *cls, struct class_attribute *attr,
++		        const char *buf, size_t count)
++{
++	int enable;
++
++	if (kstrtoint(buf, 0, &enable)){
++		printk("khadas_pin_out error\n");
++		return -EINVAL;
++	}
++	printk("khadas_pin_out=%d\n",enable);
++	gpio_direction_output(khadas_input_pin, enable);
++	return count;
++}
++
++static struct class_attribute khadas_attrs[] = {
++	__ATTR(enble, 0644, show_enble, store_enble),
++	__ATTR(pin_out, 0644, NULL, store_pin_out),
++};
++
++static void create_khadas_attrs(void)
++{
++	int i;
++	struct class *khadas_class;
++	printk("%s\n",__func__);
++	khadas_class = class_create(THIS_MODULE, "khadas");
++	if (IS_ERR(khadas_class)) {
++		pr_err("create khadas_class debug class fail\n");
++		return;
++	}
++	for (i = 0; i < ARRAY_SIZE(khadas_attrs); i++) {
++		if (class_create_file(khadas_class, &khadas_attrs[i]))
++			pr_err("create khadas attribute %s fail\n", khadas_attrs[i].attr.name);
++	}
++}
++
++static int wdt_probe(struct platform_device *pdev)
++{
++	const char *value;
++	int ret;
++	printk("hw_wdt enter probe\n");
++
++	ret = of_property_read_u32(pdev->dev.of_node,"hw_margin_ms", &hw_margin);
++	if (ret)
++		return ret;
++
++	ret = of_property_read_string(pdev->dev.of_node,
++					  "hw-gpios", &value);
++	if (ret) {
++		printk("no hw-gpios");
++		return -1;
++	} else {
++		khadas_input_pin = of_get_named_gpio_flags
++						(pdev->dev.of_node,
++						"hw-gpios",
++						0, NULL);
++		printk("hlm hw-gpios: %d.\n", khadas_input_pin);
++		ret = gpio_request(khadas_input_pin, "khadas");
++	}
++
++    timer_setup(&mytimer, time_pre, 0);
++    mytimer.expires = jiffies + hw_margin * HZ/1000; //// 5ms 运行一次
++    add_timer(&mytimer);
++	create_khadas_attrs();
++	return 0;
++}
++
++static const struct of_device_id hw_khadas_wdt_dt_ids[] = {
++	{ .compatible = "linux,wdt-khadas", },
++	{ }
++};
++MODULE_DEVICE_TABLE(of, hw_khadas_wdt_dt_ids);
++
++static struct platform_driver khadas_wdt_driver = {
++	.driver	= {
++		.name		= "hw_khadas_wdt",
++		.of_match_table	= hw_khadas_wdt_dt_ids,
++	},
++	.probe	= wdt_probe,
++};
++
++static int __init wdt_drv_init(void)
++{
++	return platform_driver_register(&khadas_wdt_driver);
++}
++arch_initcall(wdt_drv_init);
++
++MODULE_LICENSE("GPL");
+-- 
+Armbian
+
+
+From be6411201273ea38a15df6cb3c5da84d9b4c48c3 Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Tue, 17 May 2022 23:25:12 +0800
+Subject: Edge2: led: support khadas RGB led
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: Idd15329fa0c3ca58555ceb5306cd64c2d9652232
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 41 ++++++++++
+ arch/arm64/configs/kedges_defconfig                   |  5 ++
+ drivers/leds/leds-gpio.c                              | 40 ++++++++-
+ 3 files changed, 84 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 078b1ec2cd07..96af7bfee0d7 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -91,6 +91,33 @@ play-pause-key {
+ 		};
+ 	};
+ 
++	leds {
++		compatible = "gpio-leds";
++		pinctrl-names = "default";
++		pinctrl-0 = <&red_led_gpio &green_led_gpio &blue_led_gpio>;
++
++		red_led {
++			gpios = <&gpio4 RK_PB4 GPIO_ACTIVE_LOW>;
++			label = "red_led";
++			linux,default-trigger = "none";
++			default-state = "off";
++		};
++
++		green_led {
++			gpios = <&gpio4 RK_PB2 GPIO_ACTIVE_LOW>;
++			label = "green_led";
++			linux,default-trigger = "default-on";
++			default-state = "on";
++		};
++
++		blue_led {
++			gpios = <&gpio4 RK_PB3 GPIO_ACTIVE_LOW>;
++			label = "blue_led";
++			linux,default-trigger = "none";
++			default-state = "off";
++		};
++	};
++
+ 	khadas_wdt {
+ 		compatible = "linux,wdt-khadas";
+ 		status = "okay";
+@@ -540,6 +567,20 @@ mpu6500_irq_gpio: mpu6500_irq_gpio {
+ 		};
+ 	};
+ 
++	leds {
++		red_led_gpio: red-led-gpio {
++			rockchip,pins = <4 RK_PB4 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++
++		green_led_gpio: green-led-gpio {
++			rockchip,pins = <4 RK_PB2 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++
++		blue_led_gpio: blue-led-gpio {
++			rockchip,pins = <4 RK_PB3 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
+ 	usb {
+ 		vcc5v0_host_en: vcc5v0-host-en {
+ 			rockchip,pins = <4 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
+diff --git a/arch/arm64/configs/kedges_defconfig b/arch/arm64/configs/kedges_defconfig
+index ac5ba22fa5e7..b874726d50aa 100644
+--- a/arch/arm64/configs/kedges_defconfig
++++ b/arch/arm64/configs/kedges_defconfig
+@@ -451,6 +451,11 @@ CONFIG_NEW_LEDS=y
+ CONFIG_LEDS_CLASS=y
+ CONFIG_LEDS_GPIO=y
+ CONFIG_LEDS_IS31FL32XX=y
++CONFIG_LEDS_TRIGGERS=y
++CONFIG_LEDS_TRIGGER_TIMER=y
++CONFIG_LEDS_TRIGGER_HEARTBEAT=y
++CONFIG_LEDS_TRIGGER_BACKLIGHT=y
++CONFIG_LEDS_TRIGGER_DEFAULT_ON=y
+ CONFIG_RTC_CLASS=y
+ CONFIG_RTC_DRV_HYM8563=y
+ CONFIG_RTC_DRV_RK808=y
+diff --git a/drivers/leds/leds-gpio.c b/drivers/leds/leds-gpio.c
+index 93f5b1b60fde..7d7b3c7581ed 100644
+--- a/drivers/leds/leds-gpio.c
++++ b/drivers/leds/leds-gpio.c
+@@ -78,6 +78,25 @@ static int create_gpio_led(const struct gpio_led *template,
+ 	struct led_init_data init_data = {};
+ 	int ret, state;
+ 
++	led_dat->gpiod = template->gpiod;
++	if (!led_dat->gpiod) {
++		unsigned long flags = GPIOF_OUT_INIT_LOW;
++		if (!gpio_is_valid(template->gpio)) {
++			dev_info(parent, "Skipping unavailable LED gpio %d (%s)\n",
++					template->gpio, template->name);
++			return 0;
++		}
++		if (template->active_low)
++			flags |= GPIOF_ACTIVE_LOW;
++		ret = devm_gpio_request_one(parent, template->gpio, flags,
++									template->name);
++		if (ret < 0)
++			return ret;
++		led_dat->gpiod = gpio_to_desc(template->gpio);
++		if (!led_dat->gpiod)
++			return -EINVAL;
++	}
++	led_dat->cdev.name = template->name;
+ 	led_dat->cdev.default_trigger = template->default_trigger;
+ 	led_dat->can_sleep = gpiod_cansleep(led_dat->gpiod);
+ 	if (!led_dat->can_sleep)
+@@ -125,6 +144,12 @@ struct gpio_leds_priv {
+ 	struct gpio_led_data leds[];
+ };
+ 
++static inline int sizeof_gpio_leds_priv(int num_leds)
++{
++	return sizeof(struct gpio_leds_priv) +
++			(sizeof(struct gpio_led_data) * num_leds);
++}
++
+ static struct gpio_leds_priv *gpio_leds_create(struct platform_device *pdev)
+ {
+ 	struct device *dev = &pdev->dev;
+@@ -145,19 +170,30 @@ static struct gpio_leds_priv *gpio_leds_create(struct platform_device *pdev)
+ 		struct gpio_led led = {};
+ 		const char *state = NULL;
+ 
++		struct device_node *np = to_of_node(child);
++		ret = fwnode_property_read_string(child, "label", &led.name);
++		if (ret && IS_ENABLED(CONFIG_OF) && np)
++			led.name = np->name;
++		if (!led.name) {
++			fwnode_handle_put(child);
++			return ERR_PTR(-EINVAL);
++		}
++
+ 		/*
+ 		 * Acquire gpiod from DT with uninitialized label, which
+ 		 * will be updated after LED class device is registered,
+ 		 * Only then the final LED name is known.
+ 		 */
+ 		led.gpiod = devm_fwnode_get_gpiod_from_child(dev, NULL, child,
+-							     GPIOD_ASIS,
+-							     NULL);
++							     GPIOD_ASIS,led.name);
+ 		if (IS_ERR(led.gpiod)) {
+ 			fwnode_handle_put(child);
+ 			return ERR_CAST(led.gpiod);
+ 		}
+ 
++		fwnode_property_read_string(child, "linux,default-trigger",
++						&led.default_trigger);
++
+ 		led_dat->gpiod = led.gpiod;
+ 
+ 		if (!fwnode_property_read_string(child, "default-state",
+-- 
+Armbian
+
+
+From d6596a29bffc37810449b3af05637b68529ea826 Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Tue, 17 May 2022 17:42:16 +0200
+Subject: [NEEDS INTERVENTION] Edge2: misc: add MCU control driver
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: I29d1caeb110f0a9387db0cde98a81e58f50ed1e4
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts |   6 +
+ arch/arm64/configs/kedges_defconfig                   |   1 +
+ drivers/misc/Kconfig                                  |  18 +-
+ drivers/misc/Makefile                                 |   3 +-
+ drivers/misc/khadas-mcu.c                             | 256 ++++++++++
+ 5 files changed, 277 insertions(+), 7 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 96af7bfee0d7..778bfd5428ac 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -448,6 +448,12 @@ &i2c6 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&i2c6m3_xfer>;
+ 
++	mcu: khadas-mcu@18 {
++		compatible = "khadas-mcu";
++		status = "okay";
++		reg = <0x18>;
++	};
++
+ 	usbc0: fusb302@22 {
+ 		compatible = "fcs,fusb302";
+ 		reg = <0x22>;
+diff --git a/arch/arm64/configs/kedges_defconfig b/arch/arm64/configs/kedges_defconfig
+index b874726d50aa..bb036a0d57e8 100644
+--- a/arch/arm64/configs/kedges_defconfig
++++ b/arch/arm64/configs/kedges_defconfig
+@@ -122,6 +122,7 @@ CONFIG_BLK_DEV_RAM=y
+ CONFIG_BLK_DEV_RAM_COUNT=1
+ CONFIG_BLK_DEV_NVME=y
+ CONFIG_SRAM=y
++CONFIG_KHADAS_MCU=y
+ CONFIG_BLK_DEV_SD=y
+ CONFIG_BLK_DEV_SR=y
+ CONFIG_SCSI_SCAN_ASYNC=y
+diff --git a/drivers/misc/Kconfig b/drivers/misc/Kconfig
+index 62f35ba898de..9b51e716f7f8 100644
+--- a/drivers/misc/Kconfig
++++ b/drivers/misc/Kconfig
+@@ -5,12 +5,6 @@
+ 
+ menu "Misc devices"
+ 
+-config RK803
+-	tristate "RK803"
+-	default n
+-	help
+-	  Driver for RK803 which is used for driving porjector and IR flood LED.
+-
+ config SENSORS_LIS3LV02D
+ 	tristate
+ 	depends on INPUT
+@@ -487,6 +481,18 @@ config HISI_HIKEY_USB
+ 	  switching between the dual-role USB-C port and the USB-A host ports
+ 	  using only one USB controller.
+ 
++config RK803
++	tristate "RK803"
++	default n
++	help
++	  Driver for RK803 which is used for driving porjector and IR flood LED.
++
++config KHADAS_MCU
++	tristate "Khadas MCU control driver"
++	default n
++	help
++	  This driver allow to control MCU.
++
+ source "drivers/misc/c2port/Kconfig"
+ source "drivers/misc/eeprom/Kconfig"
+ source "drivers/misc/cb710/Kconfig"
+diff --git a/drivers/misc/Makefile b/drivers/misc/Makefile
+index 8be76bac6eb8..965648611ae4 100644
+--- a/drivers/misc/Makefile
++++ b/drivers/misc/Makefile
+@@ -3,7 +3,6 @@
+ # Makefile for misc devices that really don't fit anywhere else.
+ #
+ 
+-obj-$(CONFIG_RK803)		+= rk803.o
+ obj-$(CONFIG_IBM_ASM)		+= ibmasm/
+ obj-$(CONFIG_IBMVMC)		+= ibmvmc.o
+ obj-$(CONFIG_AD525X_DPOT)	+= ad525x_dpot.o
+@@ -59,3 +58,5 @@ obj-$(CONFIG_UACCE)		+= uacce/
+ obj-$(CONFIG_XILINX_SDFEC)	+= xilinx_sdfec.o
+ obj-$(CONFIG_HISI_HIKEY_USB)	+= hisi_hikey_usb.o
+ obj-$(CONFIG_UID_SYS_STATS)	+= uid_sys_stats.o
++obj-$(CONFIG_RK803)		+= rk803.o
++obj-$(CONFIG_KHADAS_MCU) += khadas-mcu.o
+diff --git a/drivers/misc/khadas-mcu.c b/drivers/misc/khadas-mcu.c
+new file mode 100644
+index 000000000000..1677294ee617
+--- /dev/null
++++ b/drivers/misc/khadas-mcu.c
+@@ -0,0 +1,256 @@
++/*
++ * Khadas Edge2 MCU control driver
++ *
++ * Written by: Nick <nick@khadas.com>
++ *
++ * Copyright (C) 2022 Wesion Technologies Ltd.
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License version 2 as
++ * published by the Free Software Foundation.
++ */
++
++#include <linux/module.h>
++#include <linux/i2c.h>
++#include <linux/string.h>
++#include <linux/list.h>
++#include <linux/sysfs.h>
++#include <linux/ctype.h>
++#include <linux/device.h>
++#include <linux/slab.h>
++#include <linux/of.h>
++#include <linux/of_address.h>
++
++/* Device registers */
++#define MCU_PWR_OFF_CMD_REG       0x80
++#define MCU_SHUTDOWN_NORMAL_REG   0x2c
++
++struct mcu_data {
++	struct i2c_client *client;
++	struct class *mcu_class;
++};
++
++struct mcu_data *g_mcu_data;
++
++static int i2c_master_reg8_send(const struct i2c_client *client,
++		const char reg, const char *buf, int count)
++{
++	struct i2c_adapter *adap = client->adapter;
++	struct i2c_msg msg;
++	int ret;
++	char *tx_buf = kzalloc(count + 1, GFP_KERNEL);
++	if (!tx_buf)
++		return -ENOMEM;
++	tx_buf[0] = reg;
++	memcpy(tx_buf+1, buf, count);
++
++	msg.addr = client->addr;
++	msg.flags = client->flags;
++	msg.len = count + 1;
++	msg.buf = (char *)tx_buf;
++
++	ret = i2c_transfer(adap, &msg, 1);
++	kfree(tx_buf);
++	return (ret == 1) ? count : ret;
++}
++
++/*static int i2c_master_reg8_recv(const struct i2c_client *client,
++		const char reg, char *buf, int count)
++{
++	struct i2c_adapter *adap = client->adapter;
++	struct i2c_msg msgs[2];
++	int ret;
++	char reg_buf = reg;
++
++	msgs[0].addr = client->addr;
++	msgs[0].flags = client->flags;
++	msgs[0].len = 1;
++	msgs[0].buf = &reg_buf;
++
++	msgs[1].addr = client->addr;
++	msgs[1].flags = client->flags | I2C_M_RD;
++	msgs[1].len = count;
++	msgs[1].buf = (char *)buf;
++
++	ret = i2c_transfer(adap, msgs, 2);
++
++	return (ret == 2) ? count : ret;
++}*/
++
++/*static int mcu_i2c_read_regs(struct i2c_client *client,
++		u8 reg, u8 buf[], unsigned len)
++{
++	int ret;
++	ret = i2c_master_reg8_recv(client, reg, buf, len);
++	return ret;
++}*/
++
++static int mcu_i2c_write_regs(struct i2c_client *client,
++		u8 reg, u8 const buf[], __u16 len)
++{
++	int ret;
++
++	ret = i2c_master_reg8_send(client, reg, buf, (int)len);
++
++	return ret;
++}
++
++static ssize_t store_mcu_poweroff(struct class *cls,struct class_attribute *attr,
++				const char *buf, size_t count)
++{
++	int ret;
++	int val;
++	char reg;
++
++	if (kstrtoint(buf, 0, &val))
++		return -EINVAL;
++
++	if (val != 1)
++		return -EINVAL;
++
++	reg = (char)val;
++
++	ret = mcu_i2c_write_regs(g_mcu_data->client,MCU_PWR_OFF_CMD_REG,
++							&reg, 1);
++	if (ret < 0) {
++		pr_debug("write poweroff cmd error\n");
++		return ret;
++	}
++
++	return count;
++}
++
++static ssize_t store_mcu_rst(struct class *cls, struct class_attribute *attr,
++				const char *buf, size_t count)
++{
++	char reg;
++	int ret;
++	int rst;
++
++	if (kstrtoint(buf, 0, &rst))
++		return -EINVAL;
++
++	reg = rst;
++	ret = mcu_i2c_write_regs(g_mcu_data->client,MCU_SHUTDOWN_NORMAL_REG,
++							&reg, 1);
++	if (ret < 0) {
++		pr_debug("write poweroff cmd error\n");
++		return ret;
++	}
++
++	return count;
++}
++
++static struct class_attribute mcu_class_attrs[] = {
++	__ATTR(poweroff, 0644, NULL, store_mcu_poweroff),
++	__ATTR(rst, 0644, NULL, store_mcu_rst),
++};
++
++static void create_mcu_attrs(void) {
++	int i;
++
++	g_mcu_data->mcu_class = class_create(THIS_MODULE, "mcu");
++	if (IS_ERR(g_mcu_data->mcu_class)) {
++		pr_err("create mcu_class debug class fail\n");
++
++		return;
++	}
++	for (i = 0; i < ARRAY_SIZE(mcu_class_attrs); i++) {
++		if (class_create_file(g_mcu_data->mcu_class, &mcu_class_attrs[i]));
++			pr_err("create mcu attribute %s fail\n",
++							mcu_class_attrs[i].attr.name);
++	}
++}
++
++static int mcu_parse_dt(struct device *dev)
++{
++	int ret = 0;
++
++	if (NULL == dev) return -EINVAL;
++
++	return ret;
++}
++
++static int mcu_probe(struct i2c_client *client, const struct i2c_device_id *id)
++{
++	printk("%s\n", __func__);
++
++	if (!i2c_check_functionality(client->adapter, I2C_FUNC_I2C))
++		return -ENODEV;
++
++	g_mcu_data = kzalloc(sizeof(struct mcu_data), GFP_KERNEL);
++
++	if (g_mcu_data == NULL)
++		return -ENOMEM;
++
++	mcu_parse_dt(&client->dev);
++
++	g_mcu_data->client = client;
++
++	create_mcu_attrs();
++
++	return 0;
++}
++
++static int mcu_remove(struct i2c_client *client)
++{
++	kfree(g_mcu_data);
++	return 0;
++}
++
++static void mcu_shutdown(struct i2c_client *client)
++{
++	kfree(g_mcu_data);
++}
++
++#ifdef CONFIG_PM_SLEEP
++static int mcu_suspend(struct device *dev)
++{
++	return 0;
++}
++
++static int mcu_resume(struct device *dev)
++{
++	return 0;
++}
++
++static const struct dev_pm_ops mcu_dev_pm_ops = {
++	SET_SYSTEM_SLEEP_PM_OPS(mcu_suspend, mcu_resume)
++};
++
++#define MCU_PM_OPS (&(mcu_dev_pm_ops))
++
++#endif
++
++static const struct i2c_device_id mcu_id[] = {
++	{ "khadas-mcu", 0 },
++	{ }
++};
++MODULE_DEVICE_TABLE(i2c, mcu_id);
++
++
++static struct of_device_id mcu_dt_ids[] = {
++	{ .compatible = "khadas-mcu" },
++	{},
++};
++MODULE_DEVICE_TABLE(i2c, mcu_dt_ids);
++
++struct i2c_driver mcu_driver = {
++	.driver  = {
++		.name   = "khadas-mcu",
++		.owner  = THIS_MODULE,
++		.of_match_table = of_match_ptr(mcu_dt_ids),
++#ifdef CONFIG_PM_SLEEP
++		.pm = MCU_PM_OPS,
++#endif
++	},
++	.probe		= mcu_probe,
++	.remove 	= mcu_remove,
++	.shutdown = mcu_shutdown,
++	.id_table	= mcu_id,
++};
++module_i2c_driver(mcu_driver);
++
++MODULE_AUTHOR("Nick <nick@khadas.com>");
++MODULE_DESCRIPTION("Khadas Edge2 MCU control driver");
++MODULE_LICENSE("GPL");
+-- 
+Armbian
+
+
+From 7f030cbfa9fd1325dced8abd18bca792380e9811 Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Wed, 18 May 2022 21:31:27 +0800
+Subject: [NEEDS INTERVENTION DROP?] Edge2: TP: support khadas TS050 TP
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: I7780692c1f18c6c57438127ea0644dc9f700f916
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts |  22 +-
+ arch/arm64/configs/kedges_defconfig                   |   1 +
+ drivers/input/touchscreen/edt-ft5x06.c                | 322 ++++------
+ 3 files changed, 142 insertions(+), 203 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 778bfd5428ac..7709819eadb9 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -383,13 +383,15 @@ &i2c4 {
+ 	pinctrl-0 = <&i2c4m3_xfer>;
+ 	status = "okay";
+ 
+-	gsl3673@40 {
+-		compatible = "GSL,GSL3673";
+-		reg = <0x40>;
+-		screen_max_x = <1536>;
+-		screen_max_y = <2048>;
+-		irq_gpio_number = <&gpio1 RK_PB5 IRQ_TYPE_LEVEL_LOW>;
+-		rst_gpio_number = <&gpio1 RK_PB4 GPIO_ACTIVE_HIGH>;
++	 ft5336@38 {
++		compatible = "edt,edt-ft5336", "ft5x06";
++		reg = <0x38>;
++		interrupt-parent = <&gpio1>;
++		interrupts = <RK_PB5 IRQ_TYPE_EDGE_FALLING>;
++		reset-gpio = <&gpio1 RK_PB4 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&tp_rst_gpio>;
++		status = "okay";
+ 	};
+ };
+ 
+@@ -609,6 +611,12 @@ typec5v_pwren: typec5v-pwren {
+ 		};
+ 	};
+ 
++	ft5336 {
++		tp_rst_gpio: tp-rst-gpio {
++			rockchip,pins = <1 RK_PB4 RK_FUNC_GPIO &pcfg_pull_none>;
++       };
++   };
++
+ 	wireless-bluetooth {
+ 		uart9_gpios: uart9-gpios {
+ 			rockchip,pins = <3 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
+diff --git a/arch/arm64/configs/kedges_defconfig b/arch/arm64/configs/kedges_defconfig
+index bb036a0d57e8..a859db38f300 100644
+--- a/arch/arm64/configs/kedges_defconfig
++++ b/arch/arm64/configs/kedges_defconfig
+@@ -200,6 +200,7 @@ CONFIG_TOUCHSCREEN_ATMEL_MXT=y
+ CONFIG_TOUCHSCREEN_GSL3673=y
+ CONFIG_TOUCHSCREEN_GT1X=y
+ CONFIG_TOUCHSCREEN_ELAN=y
++CONFIG_TOUCHSCREEN_EDT_FT5X06=y
+ CONFIG_TOUCHSCREEN_USB_COMPOSITE=y
+ CONFIG_ROCKCHIP_REMOTECTL=y
+ CONFIG_ROCKCHIP_REMOTECTL_PWM=y
+diff --git a/drivers/input/touchscreen/edt-ft5x06.c b/drivers/input/touchscreen/edt-ft5x06.c
+index 6ff81d48da86..ec540e0b3135 100644
+--- a/drivers/input/touchscreen/edt-ft5x06.c
++++ b/drivers/input/touchscreen/edt-ft5x06.c
+@@ -69,17 +69,17 @@
+ #define EDT_RAW_DATA_RETRIES		100
+ #define EDT_RAW_DATA_DELAY		1000 /* usec */
+ 
+-enum edt_pmode {
++/*enum edt_pmode {
+ 	EDT_PMODE_NOT_SUPPORTED,
+ 	EDT_PMODE_HIBERNATE,
+ 	EDT_PMODE_POWEROFF,
+-};
++};*/
+ 
+ enum edt_ver {
+ 	EDT_M06,
+ 	EDT_M09,
+ 	EDT_M12,
+-	EV_FT,
++//	EV_FT,
+ 	GENERIC_FT,
+ };
+ 
+@@ -88,8 +88,8 @@ struct edt_reg_addr {
+ 	int reg_report_rate;
+ 	int reg_gain;
+ 	int reg_offset;
+-	int reg_offset_x;
+-	int reg_offset_y;
++//	int reg_offset_x;
++//	int reg_offset_y;
+ 	int reg_num_x;
+ 	int reg_num_y;
+ };
+@@ -100,7 +100,7 @@ struct edt_ft5x06_ts_data {
+ 	struct touchscreen_properties prop;
+ 	u16 num_x;
+ 	u16 num_y;
+-	struct regulator *vcc;
++//	struct regulator *vcc;
+ 
+ 	struct gpio_desc *reset_gpio;
+ 	struct gpio_desc *wake_gpio;
+@@ -113,15 +113,18 @@ struct edt_ft5x06_ts_data {
+ 
+ 	struct mutex mutex;
+ 	bool factory_mode;
+-	enum edt_pmode suspend_mode;
++//	enum edt_pmode suspend_mode;
+ 	int threshold;
+ 	int gain;
+ 	int offset;
+-	int offset_x;
+-	int offset_y;
++//	int offset_x;
++//	int offset_y;
+ 	int report_rate;
+ 	int max_support_points;
+ 
++	int x_resolution;
++	int y_resolution;
++
+ 	char name[EDT_NAME_LEN];
+ 
+ 	struct edt_reg_addr reg_addr;
+@@ -130,6 +133,8 @@ struct edt_ft5x06_ts_data {
+ 
+ struct edt_i2c_chip_data {
+ 	int  max_support_points;
++	int x_resolution;
++	int y_resolution;
+ };
+ 
+ static int edt_ft5x06_ts_readwrite(struct i2c_client *client,
+@@ -203,7 +208,7 @@ static irqreturn_t edt_ft5x06_ts_isr(int irq, void *dev_id)
+ 
+ 	case EDT_M09:
+ 	case EDT_M12:
+-	case EV_FT:
++//	case EV_FT:
+ 	case GENERIC_FT:
+ 		cmd = 0x0;
+ 		offset = 3;
+@@ -243,6 +248,7 @@ static irqreturn_t edt_ft5x06_ts_isr(int irq, void *dev_id)
+ 
+ 	for (i = 0; i < tsdata->max_support_points; i++) {
+ 		u8 *buf = &rdbuf[i * tplen + offset];
++		bool down;
+ 
+ 		type = buf[0] >> 6;
+ 		/* ignore Reserved events */
+@@ -253,19 +259,26 @@ static irqreturn_t edt_ft5x06_ts_isr(int irq, void *dev_id)
+ 		if (tsdata->version == EDT_M06 && type == TOUCH_EVENT_DOWN)
+ 			continue;
+ 
+-		x = get_unaligned_be16(buf) & 0x0fff;
+-		y = get_unaligned_be16(buf + 2) & 0x0fff;
++	//	x = get_unaligned_be16(buf) & 0x0fff;
++	//	y = get_unaligned_be16(buf + 2) & 0x0fff;
+ 		/* The FT5x26 send the y coordinate first */
+-		if (tsdata->version == EV_FT)
+-			swap(x, y);
++	//	if (tsdata->version == EV_FT)
++	//		swap(x, y);
++		x = ((buf[0] << 8) | buf[1]) & 0x0fff;
++		y = ((buf[2] << 8) | buf[3]) & 0x0fff;
+ 
+ 		id = (buf[2] >> 4) & 0x0f;
++		down = type != TOUCH_EVENT_UP;
+ 
+ 		input_mt_slot(tsdata->input, id);
+-		if (input_mt_report_slot_state(tsdata->input, MT_TOOL_FINGER,
+-					       type != TOUCH_EVENT_UP))
+-			touchscreen_report_pos(tsdata->input, &tsdata->prop,
+-					       x, y, true);
++	//	if (input_mt_report_slot_state(tsdata->input, MT_TOOL_FINGER,
++	//				       type != TOUCH_EVENT_UP))
++	//		touchscreen_report_pos(tsdata->input, &tsdata->prop,
++	//				       x, y, true);
++		input_mt_report_slot_state(tsdata->input, MT_TOOL_FINGER, down);
++		if (!down)
++			continue;
++		touchscreen_report_pos(tsdata->input, &tsdata->prop, x, y,true);
+ 	}
+ 
+ 	input_mt_report_pointer_emulation(tsdata->input, true);
+@@ -291,7 +304,7 @@ static int edt_ft5x06_register_write(struct edt_ft5x06_ts_data *tsdata,
+ 
+ 	case EDT_M09:
+ 	case EDT_M12:
+-	case EV_FT:
++//	case EV_FT:
+ 	case GENERIC_FT:
+ 		wrbuf[0] = addr;
+ 		wrbuf[1] = value;
+@@ -332,7 +345,7 @@ static int edt_ft5x06_register_read(struct edt_ft5x06_ts_data *tsdata,
+ 
+ 	case EDT_M09:
+ 	case EDT_M12:
+-	case EV_FT:
++//	case EV_FT:
+ 	case GENERIC_FT:
+ 		wrbuf[0] = addr;
+ 		error = edt_ft5x06_ts_readwrite(tsdata->client, 1,
+@@ -355,10 +368,10 @@ struct edt_ft5x06_attribute {
+ 	u8 limit_high;
+ 	u8 addr_m06;
+ 	u8 addr_m09;
+-	u8 addr_ev;
++//	u8 addr_ev;
+ };
+ 
+-#define EDT_ATTR(_field, _mode, _addr_m06, _addr_m09, _addr_ev,		\
++#define EDT_ATTR(_field, _mode, _addr_m06, _addr_m09,		\
+ 		_limit_low, _limit_high)				\
+ 	struct edt_ft5x06_attribute edt_ft5x06_attr_##_field = {	\
+ 		.dattr = __ATTR(_field, _mode,				\
+@@ -367,7 +380,6 @@ struct edt_ft5x06_attribute {
+ 		.field_offset = offsetof(struct edt_ft5x06_ts_data, _field), \
+ 		.addr_m06 = _addr_m06,					\
+ 		.addr_m09 = _addr_m09,					\
+-		.addr_ev  = _addr_ev,					\
+ 		.limit_low = _limit_low,				\
+ 		.limit_high = _limit_high,				\
+ 	}
+@@ -404,9 +416,9 @@ static ssize_t edt_ft5x06_setting_show(struct device *dev,
+ 		addr = attr->addr_m09;
+ 		break;
+ 
+-	case EV_FT:
+-		addr = attr->addr_ev;
+-		break;
++//	case EV_FT:
++//		addr = attr->addr_ev;
++//		break;
+ 
+ 	default:
+ 		error = -ENODEV;
+@@ -479,10 +491,6 @@ static ssize_t edt_ft5x06_setting_store(struct device *dev,
+ 		addr = attr->addr_m09;
+ 		break;
+ 
+-	case EV_FT:
+-		addr = attr->addr_ev;
+-		break;
+-
+ 	default:
+ 		error = -ENODEV;
+ 		goto out;
+@@ -506,28 +514,22 @@ static ssize_t edt_ft5x06_setting_store(struct device *dev,
+ 
+ /* m06, m09: range 0-31, m12: range 0-5 */
+ static EDT_ATTR(gain, S_IWUSR | S_IRUGO, WORK_REGISTER_GAIN,
+-		M09_REGISTER_GAIN, EV_REGISTER_GAIN, 0, 31);
++		M09_REGISTER_GAIN, 0, 31);
+ /* m06, m09: range 0-31, m12: range 0-16 */
+ static EDT_ATTR(offset, S_IWUSR | S_IRUGO, WORK_REGISTER_OFFSET,
+-		M09_REGISTER_OFFSET, NO_REGISTER, 0, 31);
+-/* m06, m09, m12: no supported, ev_ft: range 0-80 */
+-static EDT_ATTR(offset_x, S_IWUSR | S_IRUGO, NO_REGISTER, NO_REGISTER,
+-		EV_REGISTER_OFFSET_X, 0, 80);
+-/* m06, m09, m12: no supported, ev_ft: range 0-80 */
+-static EDT_ATTR(offset_y, S_IWUSR | S_IRUGO, NO_REGISTER, NO_REGISTER,
+-		EV_REGISTER_OFFSET_Y, 0, 80);
++		M09_REGISTER_OFFSET, 0, 31);
+ /* m06: range 20 to 80, m09: range 0 to 30, m12: range 1 to 255... */
+ static EDT_ATTR(threshold, S_IWUSR | S_IRUGO, WORK_REGISTER_THRESHOLD,
+-		M09_REGISTER_THRESHOLD, EV_REGISTER_THRESHOLD, 0, 255);
++		M09_REGISTER_THRESHOLD, 20, 80);
+ /* m06: range 3 to 14, m12: (0x64: 100Hz) */
+ static EDT_ATTR(report_rate, S_IWUSR | S_IRUGO, WORK_REGISTER_REPORT_RATE,
+-		NO_REGISTER, NO_REGISTER, 0, 255);
++		NO_REGISTER, 3, 14);
+ 
+ static struct attribute *edt_ft5x06_attrs[] = {
+ 	&edt_ft5x06_attr_gain.dattr.attr,
+ 	&edt_ft5x06_attr_offset.dattr.attr,
+-	&edt_ft5x06_attr_offset_x.dattr.attr,
+-	&edt_ft5x06_attr_offset_y.dattr.attr,
++//	&edt_ft5x06_attr_offset_x.dattr.attr,
++//	&edt_ft5x06_attr_offset_y.dattr.attr,
+ 	&edt_ft5x06_attr_threshold.dattr.attr,
+ 	&edt_ft5x06_attr_report_rate.dattr.attr,
+ 	NULL
+@@ -537,7 +539,7 @@ static const struct attribute_group edt_ft5x06_attr_group = {
+ 	.attrs = edt_ft5x06_attrs,
+ };
+ 
+-static void edt_ft5x06_restore_reg_parameters(struct edt_ft5x06_ts_data *tsdata)
++/*static void edt_ft5x06_restore_reg_parameters(struct edt_ft5x06_ts_data *tsdata)
+ {
+ 	struct edt_reg_addr *reg_addr = &tsdata->reg_addr;
+ 
+@@ -558,7 +560,7 @@ static void edt_ft5x06_restore_reg_parameters(struct edt_ft5x06_ts_data *tsdata)
+ 		edt_ft5x06_register_write(tsdata, reg_addr->reg_report_rate,
+ 				  tsdata->report_rate);
+ 
+-}
++}*/
+ 
+ #ifdef CONFIG_DEBUG_FS
+ static int edt_ft5x06_factory_mode(struct edt_ft5x06_ts_data *tsdata)
+@@ -625,6 +627,7 @@ static int edt_ft5x06_work_mode(struct edt_ft5x06_ts_data *tsdata)
+ {
+ 	struct i2c_client *client = tsdata->client;
+ 	int retries = EDT_SWITCH_MODE_RETRIES;
++	struct edt_reg_addr *reg_addr = &tsdata->reg_addr;
+ 	int ret;
+ 	int error;
+ 
+@@ -656,7 +659,17 @@ static int edt_ft5x06_work_mode(struct edt_ft5x06_ts_data *tsdata)
+ 	kfree(tsdata->raw_buffer);
+ 	tsdata->raw_buffer = NULL;
+ 
+-	edt_ft5x06_restore_reg_parameters(tsdata);
++//	edt_ft5x06_restore_reg_parameters(tsdata);
++	edt_ft5x06_register_write(tsdata, reg_addr->reg_threshold,
++					tsdata->threshold);
++	edt_ft5x06_register_write(tsdata, reg_addr->reg_gain,
++					tsdata->gain);
++	edt_ft5x06_register_write(tsdata, reg_addr->reg_offset,
++					tsdata->offset);
++	if (reg_addr->reg_report_rate)
++			edt_ft5x06_register_write(tsdata, reg_addr->reg_report_rate,
++							tsdata->report_rate);
++
+ 	enable_irq(client->irq);
+ 
+ 	return 0;
+@@ -781,6 +794,9 @@ static void edt_ft5x06_ts_prepare_debugfs(struct edt_ft5x06_ts_data *tsdata,
+ 					  const char *debugfs_name)
+ {
+ 	tsdata->debug_dir = debugfs_create_dir(debugfs_name, NULL);
++	if (!tsdata->debug_dir)
++			return;
++
+ 
+ 	debugfs_create_u16("num_x", S_IRUSR, tsdata->debug_dir, &tsdata->num_x);
+ 	debugfs_create_u16("num_y", S_IRUSR, tsdata->debug_dir, &tsdata->num_y);
+@@ -799,10 +815,10 @@ static void edt_ft5x06_ts_teardown_debugfs(struct edt_ft5x06_ts_data *tsdata)
+ 
+ #else
+ 
+-static int edt_ft5x06_factory_mode(struct edt_ft5x06_ts_data *tsdata)
++/*static int edt_ft5x06_factory_mode(struct edt_ft5x06_ts_data *tsdata)
+ {
+ 	return -ENOSYS;
+-}
++}*/
+ 
+ static void edt_ft5x06_ts_prepare_debugfs(struct edt_ft5x06_ts_data *tsdata,
+ 					  const char *debugfs_name)
+@@ -833,7 +849,7 @@ static int edt_ft5x06_ts_identify(struct i2c_client *client,
+ 					EDT_NAME_LEN - 1, rdbuf);
+ 	if (error)
+ 		return error;
+-
++	dev_info(&client->dev, "tp version \"%s\"\n", rdbuf);
+ 	/* Probe content for something consistent.
+ 	 * M06 starts with a response byte, M12 gives the data directly.
+ 	 * M09/Generic does not provide model number information.
+@@ -876,7 +892,8 @@ static int edt_ft5x06_ts_identify(struct i2c_client *client,
+ 		 * touches and EDT M09 is that we know how to retrieve
+ 		 * the max coordinates for the latter.
+ 		 */
+-		tsdata->version = GENERIC_FT;
++	//	tsdata->version = GENERIC_FT;
++		tsdata->version = EDT_M09;
+ 
+ 		error = edt_ft5x06_ts_readwrite(client, 1, "\xA6",
+ 						2, rdbuf);
+@@ -889,45 +906,8 @@ static int edt_ft5x06_ts_identify(struct i2c_client *client,
+ 						1, rdbuf);
+ 		if (error)
+ 			return error;
+-
+-		/* This "model identification" is not exact. Unfortunately
+-		 * not all firmwares for the ft5x06 put useful values in
+-		 * the identification registers.
+-		 */
+-		switch (rdbuf[0]) {
+-		case 0x35:   /* EDT EP0350M09 */
+-		case 0x43:   /* EDT EP0430M09 */
+-		case 0x50:   /* EDT EP0500M09 */
+-		case 0x57:   /* EDT EP0570M09 */
+-		case 0x70:   /* EDT EP0700M09 */
+-			tsdata->version = EDT_M09;
+-			snprintf(model_name, EDT_NAME_LEN, "EP0%i%i0M09",
+-				rdbuf[0] >> 4, rdbuf[0] & 0x0F);
+-			break;
+-		case 0xa1:   /* EDT EP1010ML00 */
+-			tsdata->version = EDT_M09;
+-			snprintf(model_name, EDT_NAME_LEN, "EP%i%i0ML00",
+-				rdbuf[0] >> 4, rdbuf[0] & 0x0F);
+-			break;
+-		case 0x5a:   /* Solomon Goldentek Display */
+-			snprintf(model_name, EDT_NAME_LEN, "GKTW50SCED1R0");
+-			break;
+-		case 0x59:  /* Evervision Display with FT5xx6 TS */
+-			tsdata->version = EV_FT;
+-			error = edt_ft5x06_ts_readwrite(client, 1, "\x53",
+-							1, rdbuf);
+-			if (error)
+-				return error;
+-			strlcpy(fw_version, rdbuf, 1);
+-			snprintf(model_name, EDT_NAME_LEN,
+-				 "EVERVISION-FT5726NEi");
+-			break;
+-		default:
+-			snprintf(model_name, EDT_NAME_LEN,
+-				 "generic ft5x06 (%02x)",
+-				 rdbuf[0]);
+-			break;
+-		}
++		snprintf(model_name, EDT_NAME_LEN, "EP0%i%i0M09",
++					rdbuf[0] >> 4, rdbuf[0] & 0x0F);
+ 	}
+ 
+ 	return 0;
+@@ -954,13 +934,14 @@ static void edt_ft5x06_ts_get_defaults(struct device *dev,
+ 
+ 	error = device_property_read_u32(dev, "offset", &val);
+ 	if (!error) {
+-		if (reg_addr->reg_offset != NO_REGISTER)
+-			edt_ft5x06_register_write(tsdata,
+-						  reg_addr->reg_offset, val);
++	//	if (reg_addr->reg_offset != NO_REGISTER)
++	//		edt_ft5x06_register_write(tsdata,
++	//					  reg_addr->reg_offset, val);
++		edt_ft5x06_register_write(tsdata, reg_addr->reg_offset, val);
+ 		tsdata->offset = val;
+ 	}
+ 
+-	error = device_property_read_u32(dev, "offset-x", &val);
++/*	error = device_property_read_u32(dev, "offset-x", &val);
+ 	if (!error) {
+ 		if (reg_addr->reg_offset_x != NO_REGISTER)
+ 			edt_ft5x06_register_write(tsdata,
+@@ -974,7 +955,7 @@ static void edt_ft5x06_ts_get_defaults(struct device *dev,
+ 			edt_ft5x06_register_write(tsdata,
+ 						  reg_addr->reg_offset_y, val);
+ 		tsdata->offset_y = val;
+-	}
++	}*/
+ }
+ 
+ static void
+@@ -985,7 +966,7 @@ edt_ft5x06_ts_get_parameters(struct edt_ft5x06_ts_data *tsdata)
+ 	tsdata->threshold = edt_ft5x06_register_read(tsdata,
+ 						     reg_addr->reg_threshold);
+ 	tsdata->gain = edt_ft5x06_register_read(tsdata, reg_addr->reg_gain);
+-	if (reg_addr->reg_offset != NO_REGISTER)
++/*	if (reg_addr->reg_offset != NO_REGISTER)
+ 		tsdata->offset =
+ 			edt_ft5x06_register_read(tsdata, reg_addr->reg_offset);
+ 	if (reg_addr->reg_offset_x != NO_REGISTER)
+@@ -993,11 +974,12 @@ edt_ft5x06_ts_get_parameters(struct edt_ft5x06_ts_data *tsdata)
+ 						reg_addr->reg_offset_x);
+ 	if (reg_addr->reg_offset_y != NO_REGISTER)
+ 		tsdata->offset_y = edt_ft5x06_register_read(tsdata,
+-						reg_addr->reg_offset_y);
++						reg_addr->reg_offset_y);*/
++	tsdata->offset = edt_ft5x06_register_read(tsdata, reg_addr->reg_offset);
+ 	if (reg_addr->reg_report_rate != NO_REGISTER)
+ 		tsdata->report_rate = edt_ft5x06_register_read(tsdata,
+ 						reg_addr->reg_report_rate);
+-	if (tsdata->version == EDT_M06 ||
++/*	if (tsdata->version == EDT_M06 ||
+ 	    tsdata->version == EDT_M09 ||
+ 	    tsdata->version == EDT_M12) {
+ 		tsdata->num_x = edt_ft5x06_register_read(tsdata,
+@@ -1007,7 +989,7 @@ edt_ft5x06_ts_get_parameters(struct edt_ft5x06_ts_data *tsdata)
+ 	} else {
+ 		tsdata->num_x = -1;
+ 		tsdata->num_y = -1;
+-	}
++	}*/
+ }
+ 
+ static void
+@@ -1021,8 +1003,8 @@ edt_ft5x06_ts_set_regs(struct edt_ft5x06_ts_data *tsdata)
+ 		reg_addr->reg_report_rate = WORK_REGISTER_REPORT_RATE;
+ 		reg_addr->reg_gain = WORK_REGISTER_GAIN;
+ 		reg_addr->reg_offset = WORK_REGISTER_OFFSET;
+-		reg_addr->reg_offset_x = NO_REGISTER;
+-		reg_addr->reg_offset_y = NO_REGISTER;
++	//	reg_addr->reg_offset_x = NO_REGISTER;
++	//	reg_addr->reg_offset_y = NO_REGISTER;
+ 		reg_addr->reg_num_x = WORK_REGISTER_NUM_X;
+ 		reg_addr->reg_num_y = WORK_REGISTER_NUM_Y;
+ 		break;
+@@ -1033,13 +1015,13 @@ edt_ft5x06_ts_set_regs(struct edt_ft5x06_ts_data *tsdata)
+ 		reg_addr->reg_report_rate = NO_REGISTER;
+ 		reg_addr->reg_gain = M09_REGISTER_GAIN;
+ 		reg_addr->reg_offset = M09_REGISTER_OFFSET;
+-		reg_addr->reg_offset_x = NO_REGISTER;
+-		reg_addr->reg_offset_y = NO_REGISTER;
++	//	reg_addr->reg_offset_x = NO_REGISTER;
++	//	reg_addr->reg_offset_y = NO_REGISTER;
+ 		reg_addr->reg_num_x = M09_REGISTER_NUM_X;
+ 		reg_addr->reg_num_y = M09_REGISTER_NUM_Y;
+ 		break;
+ 
+-	case EV_FT:
++/*	case EV_FT:
+ 		reg_addr->reg_threshold = EV_REGISTER_THRESHOLD;
+ 		reg_addr->reg_gain = EV_REGISTER_GAIN;
+ 		reg_addr->reg_offset = NO_REGISTER;
+@@ -1049,24 +1031,25 @@ edt_ft5x06_ts_set_regs(struct edt_ft5x06_ts_data *tsdata)
+ 		reg_addr->reg_num_y = NO_REGISTER;
+ 		reg_addr->reg_report_rate = NO_REGISTER;
+ 		break;
++		*/
+ 
+ 	case GENERIC_FT:
+ 		/* this is a guesswork */
+ 		reg_addr->reg_threshold = M09_REGISTER_THRESHOLD;
+ 		reg_addr->reg_gain = M09_REGISTER_GAIN;
+ 		reg_addr->reg_offset = M09_REGISTER_OFFSET;
+-		reg_addr->reg_offset_x = NO_REGISTER;
+-		reg_addr->reg_offset_y = NO_REGISTER;
++//		reg_addr->reg_offset_x = NO_REGISTER;
++//		reg_addr->reg_offset_y = NO_REGISTER;
+ 		break;
+ 	}
+ }
+ 
+-static void edt_ft5x06_disable_regulator(void *arg)
++/*static void edt_ft5x06_disable_regulator(void *arg)
+ {
+ 	struct edt_ft5x06_ts_data *data = arg;
+ 
+ 	regulator_disable(data->vcc);
+-}
++}*/
+ 
+ static int edt_ft5x06_ts_probe(struct i2c_client *client,
+ 					 const struct i2c_device_id *id)
+@@ -1079,7 +1062,8 @@ static int edt_ft5x06_ts_probe(struct i2c_client *client,
+ 	int error;
+ 	char fw_version[EDT_NAME_LEN];
+ 
+-	dev_dbg(&client->dev, "probing for EDT FT5x06 I2C\n");
++//	dev_dbg(&client->dev, "probing for EDT FT5x06 I2C\n");
++	dev_info(&client->dev, "probing for EDT FT5x06 I2C\n");
+ 
+ 	tsdata = devm_kzalloc(&client->dev, sizeof(*tsdata), GFP_KERNEL);
+ 	if (!tsdata) {
+@@ -1097,7 +1081,7 @@ static int edt_ft5x06_ts_probe(struct i2c_client *client,
+ 
+ 	tsdata->max_support_points = chip_data->max_support_points;
+ 
+-	tsdata->vcc = devm_regulator_get(&client->dev, "vcc");
++/*	tsdata->vcc = devm_regulator_get(&client->dev, "vcc");
+ 	if (IS_ERR(tsdata->vcc)) {
+ 		error = PTR_ERR(tsdata->vcc);
+ 		if (error != -EPROBE_DEFER)
+@@ -1117,7 +1101,9 @@ static int edt_ft5x06_ts_probe(struct i2c_client *client,
+ 					 tsdata);
+ 	if (error)
+ 		return error;
+-
++		*/
++	tsdata->num_x = chip_data->x_resolution;
++	tsdata->num_y = chip_data->y_resolution;
+ 	tsdata->reset_gpio = devm_gpiod_get_optional(&client->dev,
+ 						     "reset", GPIOD_OUT_HIGH);
+ 	if (IS_ERR(tsdata->reset_gpio)) {
+@@ -1142,12 +1128,12 @@ static int edt_ft5x06_ts_probe(struct i2c_client *client,
+ 	 * the EDT_PMODE_POWEROFF test since this is the deepest possible sleep
+ 	 * mode.
+ 	 */
+-	if (tsdata->reset_gpio)
++/*	if (tsdata->reset_gpio)
+ 		tsdata->suspend_mode = EDT_PMODE_POWEROFF;
+ 	else if (tsdata->wake_gpio)
+ 		tsdata->suspend_mode = EDT_PMODE_HIBERNATE;
+ 	else
+-		tsdata->suspend_mode = EDT_PMODE_NOT_SUPPORTED;
++		tsdata->suspend_mode = EDT_PMODE_NOT_SUPPORTED;*/
+ 
+ 	if (tsdata->wake_gpio) {
+ 		usleep_range(5000, 6000);
+@@ -1158,6 +1144,7 @@ static int edt_ft5x06_ts_probe(struct i2c_client *client,
+ 		usleep_range(5000, 6000);
+ 		gpiod_set_value_cansleep(tsdata->reset_gpio, 0);
+ 		msleep(300);
++		gpiod_set_value_cansleep(tsdata->reset_gpio, 1);
+ 	}
+ 
+ 	input = devm_input_allocate_device(&client->dev);
+@@ -1187,28 +1174,17 @@ static int edt_ft5x06_ts_probe(struct i2c_client *client,
+ 	edt_ft5x06_ts_get_defaults(&client->dev, tsdata);
+ 	edt_ft5x06_ts_get_parameters(tsdata);
+ 
+-	dev_dbg(&client->dev,
++	dev_info(&client->dev,
+ 		"Model \"%s\", Rev. \"%s\", %dx%d sensors\n",
+ 		tsdata->name, fw_version, tsdata->num_x, tsdata->num_y);
+ 
+ 	input->name = tsdata->name;
+ 	input->id.bustype = BUS_I2C;
+ 	input->dev.parent = &client->dev;
+-
+-	if (tsdata->version == EDT_M06 ||
+-	    tsdata->version == EDT_M09 ||
+-	    tsdata->version == EDT_M12) {
+-		input_set_abs_params(input, ABS_MT_POSITION_X,
+-				     0, tsdata->num_x * 64 - 1, 0, 0);
+-		input_set_abs_params(input, ABS_MT_POSITION_Y,
+-				     0, tsdata->num_y * 64 - 1, 0, 0);
+-	} else {
+-		/* Unknown maximum values. Specify via devicetree */
+-		input_set_abs_params(input, ABS_MT_POSITION_X,
+-				     0, 65535, 0, 0);
+-		input_set_abs_params(input, ABS_MT_POSITION_Y,
+-				     0, 65535, 0, 0);
+-	}
++	input_set_abs_params(input, ABS_MT_POSITION_X,
++					0, tsdata->num_x, 0, 0);
++	input_set_abs_params(input, ABS_MT_POSITION_Y,
++					0, tsdata->num_y, 0, 0);
+ 
+ 	touchscreen_parse_properties(input, true, &tsdata->prop);
+ 
+@@ -1218,7 +1194,7 @@ static int edt_ft5x06_ts_probe(struct i2c_client *client,
+ 		dev_err(&client->dev, "Unable to init MT slots.\n");
+ 		return error;
+ 	}
+-
++	input_set_drvdata(input, tsdata);
+ 	i2c_set_clientdata(client, tsdata);
+ 
+ 	irq_flags = irq_get_trigger_type(client->irq);
+@@ -1244,7 +1220,8 @@ static int edt_ft5x06_ts_probe(struct i2c_client *client,
+ 
+ 	edt_ft5x06_ts_prepare_debugfs(tsdata, dev_driver_string(&client->dev));
+ 
+-	dev_dbg(&client->dev,
++	device_init_wakeup(&client->dev, 1);
++	dev_info(&client->dev,
+ 		"EDT FT5x06 initialized: IRQ %d, WAKE pin %d, Reset pin %d.\n",
+ 		client->irq,
+ 		tsdata->wake_gpio ? desc_to_gpio(tsdata->wake_gpio) : -1,
+@@ -1265,24 +1242,10 @@ static int edt_ft5x06_ts_remove(struct i2c_client *client)
+ static int __maybe_unused edt_ft5x06_ts_suspend(struct device *dev)
+ {
+ 	struct i2c_client *client = to_i2c_client(dev);
+-	struct edt_ft5x06_ts_data *tsdata = i2c_get_clientdata(client);
+-	struct gpio_desc *reset_gpio = tsdata->reset_gpio;
+-	int ret;
+ 
+ 	if (device_may_wakeup(dev))
+-		return 0;
+-
+-	if (tsdata->suspend_mode == EDT_PMODE_NOT_SUPPORTED)
+-		return 0;
+-
+-	/* Enter hibernate mode. */
+-	ret = edt_ft5x06_register_write(tsdata, PMOD_REGISTER_OPMODE,
+-					PMOD_REGISTER_HIBERNATE);
+-	if (ret)
+-		dev_warn(dev, "Failed to set hibernate mode\n");
+-
+-	if (tsdata->suspend_mode == EDT_PMODE_HIBERNATE)
+-		return 0;
++//		return 0;
++		enable_irq_wake(client->irq);
+ 
+ 	/*
+ 	 * Power-off according the datasheet. Cut the power may leaf the irq
+@@ -1290,14 +1253,6 @@ static int __maybe_unused edt_ft5x06_ts_suspend(struct device *dev)
+ 	 * settings. Disable the irq to avoid adjusting each host till the
+ 	 * device is back in a full functional state.
+ 	 */
+-	disable_irq(tsdata->client->irq);
+-
+-	gpiod_set_value_cansleep(reset_gpio, 1);
+-	usleep_range(1000, 2000);
+-
+-	ret = regulator_disable(tsdata->vcc);
+-	if (ret)
+-		dev_warn(dev, "Failed to disable vcc\n");
+ 
+ 	return 0;
+ }
+@@ -1305,17 +1260,11 @@ static int __maybe_unused edt_ft5x06_ts_suspend(struct device *dev)
+ static int __maybe_unused edt_ft5x06_ts_resume(struct device *dev)
+ {
+ 	struct i2c_client *client = to_i2c_client(dev);
+-	struct edt_ft5x06_ts_data *tsdata = i2c_get_clientdata(client);
+-	int ret = 0;
++//	struct edt_ft5x06_ts_data *tsdata = i2c_get_clientdata(client);
++//	int ret = 0;
+ 
+ 	if (device_may_wakeup(dev))
+-		return 0;
+-
+-	if (tsdata->suspend_mode == EDT_PMODE_NOT_SUPPORTED)
+-		return 0;
+-
+-	if (tsdata->suspend_mode == EDT_PMODE_POWEROFF) {
+-		struct gpio_desc *reset_gpio = tsdata->reset_gpio;
++	//	return 0;
+ 
+ 		/*
+ 		 * We can't check if the regulator is a dummy or a real
+@@ -1325,34 +1274,10 @@ static int __maybe_unused edt_ft5x06_ts_resume(struct device *dev)
+ 		 * of. Toggle the reset pin is also a way to exit the hibernate
+ 		 * mode.
+ 		 */
+-		gpiod_set_value_cansleep(reset_gpio, 1);
+-		usleep_range(5000, 6000);
+-
+-		ret = regulator_enable(tsdata->vcc);
+-		if (ret) {
+-			dev_err(dev, "Failed to enable vcc\n");
+-			return ret;
+-		}
+-
+-		usleep_range(1000, 2000);
+-		gpiod_set_value_cansleep(reset_gpio, 0);
+-		msleep(300);
+-
+-		edt_ft5x06_restore_reg_parameters(tsdata);
+-		enable_irq(tsdata->client->irq);
++		disable_irq_wake(client->irq);
+ 
+-		if (tsdata->factory_mode)
+-			ret = edt_ft5x06_factory_mode(tsdata);
+-	} else {
+-		struct gpio_desc *wake_gpio = tsdata->wake_gpio;
+-
+-		gpiod_set_value_cansleep(wake_gpio, 0);
+-		usleep_range(5000, 6000);
+-		gpiod_set_value_cansleep(wake_gpio, 1);
+-	}
+ 
+-
+-	return ret;
++	return 0;
+ }
+ 
+ static SIMPLE_DEV_PM_OPS(edt_ft5x06_ts_pm_ops,
+@@ -1366,38 +1291,43 @@ static const struct edt_i2c_chip_data edt_ft5506_data = {
+ 	.max_support_points = 10,
+ };
+ 
+-static const struct edt_i2c_chip_data edt_ft6236_data = {
+-	.max_support_points = 2,
++static const struct edt_i2c_chip_data edt_ft5336_data = {
++	.max_support_points = 5,
++	.x_resolution = 1080,
++	.y_resolution = 1920,
+ };
+ 
+ static const struct i2c_device_id edt_ft5x06_ts_id[] = {
+ 	{ .name = "edt-ft5x06", .driver_data = (long)&edt_ft5x06_data },
+ 	{ .name = "edt-ft5506", .driver_data = (long)&edt_ft5506_data },
+-	{ .name = "ev-ft5726", .driver_data = (long)&edt_ft5506_data },
++//	{ .name = "ev-ft5726", .driver_data = (long)&edt_ft5506_data },
+ 	/* Note no edt- prefix for compatibility with the ft6236.c driver */
+-	{ .name = "ft6236", .driver_data = (long)&edt_ft6236_data },
++//	{ .name = "ft6236", .driver_data = (long)&edt_ft6236_data },
+ 	{ /* sentinel */ }
+ };
+ MODULE_DEVICE_TABLE(i2c, edt_ft5x06_ts_id);
+ 
++#ifdef CONFIG_OF
+ static const struct of_device_id edt_ft5x06_of_match[] = {
+ 	{ .compatible = "edt,edt-ft5206", .data = &edt_ft5x06_data },
+ 	{ .compatible = "edt,edt-ft5306", .data = &edt_ft5x06_data },
+ 	{ .compatible = "edt,edt-ft5406", .data = &edt_ft5x06_data },
+ 	{ .compatible = "edt,edt-ft5506", .data = &edt_ft5506_data },
+-	{ .compatible = "evervision,ev-ft5726", .data = &edt_ft5506_data },
++//	{ .compatible = "evervision,ev-ft5726", .data = &edt_ft5506_data },
+ 	/* Note focaltech vendor prefix for compatibility with ft6236.c */
+-	{ .compatible = "focaltech,ft6236", .data = &edt_ft6236_data },
++//	{ .compatible = "focaltech,ft6236", .data = &edt_ft6236_data },
++	{ .compatible = "edt,edt-ft5336", .data = &edt_ft5336_data },
+ 	{ /* sentinel */ }
+ };
+ MODULE_DEVICE_TABLE(of, edt_ft5x06_of_match);
++#endif
+ 
+ static struct i2c_driver edt_ft5x06_ts_driver = {
+ 	.driver = {
+ 		.name = "edt_ft5x06",
+-		.of_match_table = edt_ft5x06_of_match,
++		.of_match_table = of_match_ptr(edt_ft5x06_of_match),
+ 		.pm = &edt_ft5x06_ts_pm_ops,
+-		.probe_type = PROBE_PREFER_ASYNCHRONOUS,
++//		.probe_type = PROBE_PREFER_ASYNCHRONOUS,
+ 	},
+ 	.id_table = edt_ft5x06_ts_id,
+ 	.probe    = edt_ft5x06_ts_probe,
+-- 
+Armbian
+
+
+From 106019ed6db370e45a53c3fbf20e252b56f9315f Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Tue, 19 Jul 2022 10:15:35 +0800
+Subject: [NEEDS INTERVENTION DROP?] Edge2: lcd: support khadas mipi lcd panel
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: I6162a06d65a4e72f006b8bc739a73f72a3722138
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts  |  108 +-
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi | 1645 +++++++---
+ drivers/gpu/drm/panel/panel-simple.c                   |   30 +-
+ drivers/gpu/drm/rockchip/dw-mipi-dsi2-rockchip.c       |   45 +
+ 4 files changed, 1262 insertions(+), 566 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 7709819eadb9..5292573bdac0 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -125,11 +125,11 @@ khadas_wdt {
+ 		hw-gpios = <&gpio0 RK_PB0 GPIO_ACTIVE_HIGH>;
+ 	};
+ 
+-	fan: pwm-fan {
+-		compatible = "pwm-fan";
+-		#cooling-cells = <2>;
+-		pwms = <&pwm11 0 50000 0>;
+-	};
++//	fan: pwm-fan {
++//		compatible = "pwm-fan";
++//		#cooling-cells = <2>;
++//		pwms = <&pwm11 0 50000 0>;
++//	};
+ 
+ 	hall_sensor: hall-mh248 {
+ 		compatible = "hall-mh248";
+@@ -217,14 +217,36 @@ wireless_wlan: wireless-wlan {
+ 		WIFI,poweren_gpio = <&gpio0 RK_PC7 GPIO_ACTIVE_HIGH>;
+ 		status = "okay";
+ 	};
++
++	vcc3v3_lcd_en: vcc3v3-lcd-en {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc3v3_lcd_en";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		gpio = <&gpio0 RK_PC4 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++		regulator-boot-on;
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++
++	};
++
+ };
+ 
+-&backlight {
+-	pwms = <&pwm12 0 25000 0>;
+-	power-supply = <&vcc_3v3_s0>;
++&backlight_mipi0 {
++	pwms = <&pwm7 0 25000 0>;
++	power-supply = <&vcc3v3_lcd_en>;
+ 	status = "okay";
+ };
+ 
++&backlight_mipi1 {
++	pwms = <&pwm12 0 25000 0>;
++	power-supply = <&vcc3v3_lcd_en>;
++	status = "disabled";
++};
++
++
+ &combphy0_ps {
+ 	status = "okay";
+ };
+@@ -241,6 +263,67 @@ &dp0_sound{
+ 	status = "okay";
+ };
+ 
++&dsi0 {
++	status = "okay";
++	reset-delay-ms = <20>;
++	reset-gpios = <&gpio4 RK_PA3 GPIO_ACTIVE_HIGH>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&lcd_rst_gpio>;
++
++};
++
++&dsi0_panel {
++	status = "okay";
++	power-supply = <&vcc3v3_lcd_en>;
++};
++
++&dsi0_in_vp2 {
++	status = "disabled";
++};
++
++&dsi0_in_vp3 {
++	status = "okay";
++};
++
++&route_dsi0 {
++	status = "okay";
++	connect = <&vp3_out_dsi0>;
++};
++
++&mipi_dcphy0 {
++	status = "okay";
++};
++
++&dsi1 {
++	reset-delay-ms = <20>;
++	reset-gpios = <&gpio1 RK_PB1 GPIO_ACTIVE_HIGH>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&lcd_rst_gpio1>;
++	status = "disabled";
++};
++
++&dsi1_panel {
++	status = "disabled";
++	power-supply = <&vcc3v3_lcd_en>;
++};
++
++&mipi_dcphy1 {
++	status = "disabled";
++};
++
++&dsi1_in_vp2 {
++	status = "disabled";
++};
++
++&dsi1_in_vp3 {
++	status = "disabled";
++};
++
++&route_dsi1 {
++	status = "disabled";
++	connect = <&vp3_out_dsi1>;
++};
++
+ //&hdptxphy0 {
+ 	/* Single Vdiff Training Table for power reduction (optional) */
+ //	training-table = /bits/ 8 <
+@@ -555,7 +638,7 @@ &pdm0 {
+ &pinctrl {
+ 	headphone {
+ 		hp_det: hp-det {
+-			rockchip,pins = <1 RK_PD0 RK_FUNC_GPIO &pcfg_pull_none>;
++			rockchip,pins = <4 RK_PA3 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 	};
+ 
+@@ -563,6 +646,9 @@ lcd {
+ 		lcd_rst_gpio: lcd-rst-gpio {
+ 			rockchip,pins = <1 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
++		lcd_rst_gpio1: lcd-rst-gpio1 {
++			rockchip,pins = <1 RK_PB1 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
+ 	};
+ 
+ 	sensor {
+@@ -746,8 +832,8 @@ ir_key3 {
+ 	};
+ };
+ 
+-&pwm11 {
+-	pinctrl-0 = <&pwm11m1_pins>;
++&pwm7 {
++	pinctrl-0 = <&pwm7m0_pins>;
+ 	status = "okay";
+ };
+ 
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi
+index 12232bdd3896..5a2174676012 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi
+@@ -27,7 +27,7 @@ home-key {
+ 		};
+ 	};
+ 
+-	backlight: backlight {
++	backlight_mipi0: backlight-mipi0 {
+ 		compatible = "pwm-backlight";
+ 		brightness-levels = <
+ 			  0  20  20  21  21  22  22  23
+@@ -76,6 +76,47 @@ dp0_sound: dp0-sound {
+ 		rockchip,jack-det;
+ 	};
+ 
++	backlight_mipi1: backlight-mipi1 {
++        compatible = "pwm-backlight";
++        brightness-levels = <
++              0  20  20  21  21  22  22  23
++             23  24  24  25  25  26  26  27
++             27  28  28  29  29  30  30  31
++             31  32  32  33  33  34  34  35
++             35  36  36  37  37  38  38  39
++             40  41  42  43  44  45  46  47
++             48  49  50  51  52  53  54  55
++             56  57  58  59  60  61  62  63
++             64  65  66  67  68  69  70  71
++             72  73  74  75  76  77  78  79
++             80  81  82  83  84  85  86  87
++             88  89  90  91  92  93  94  95
++             96  97  98  99 100 101 102 103
++            104 105 106 107 108 109 110 111
++            112 113 114 115 116 117 118 119
++            120 121 122 123 124 125 126 127
++            128 129 130 131 132 133 134 135
++            136 137 138 139 140 141 142 143
++            144 145 146 147 148 149 150 151
++            152 153 154 155 156 157 158 159
++            160 161 162 163 164 165 166 167
++            168 169 170 171 172 173 174 175
++            176 177 178 179 180 181 182 183
++            184 185 186 187 188 189 190 191
++            192 193 194 195 196 197 198 199
++            200 201 202 203 204 205 206 207
++            208 209 210 211 212 213 214 215
++            216 217 218 219 220 221 222 223
++            224 225 226 227 228 229 230 231
++            232 233 234 235 236 237 238 239
++            240 241 242 243 244 245 246 247
++            248 249 250 251 252 253 254 255
++        >;
++        default-brightness-level = <200>;
++    };
++
++
++
+ 	hdmi0_sound: hdmi0-sound {
+ 		status = "disabled";
+ 		compatible = "simple-audio-card";
+@@ -197,8 +238,8 @@ dsi0_panel: panel@0 {
+ 		status = "okay";
+ 		compatible = "simple-panel-dsi";
+ 		reg = <0>;
+-		backlight = <&backlight>;
+-		reset-delay-ms = <60>;
++		backlight = <&backlight_mipi0>;
++	//	reset-delay-ms = <60>;
+ 		enable-delay-ms = <60>;
+ 		prepare-delay-ms = <60>;
+ 		unprepare-delay-ms = <60>;
+@@ -208,286 +249,548 @@ dsi0_panel: panel@0 {
+ 		dsi,format = <MIPI_DSI_FMT_RGB888>;
+ 		dsi,lanes  = <4>;
+ 		panel-init-sequence = [
+-			23 00 02 FE 21
+-			23 00 02 04 00
+-			23 00 02 00 64
+-			23 00 02 2A 00
+-			23 00 02 26 64
+-			23 00 02 54 00
+-			23 00 02 50 64
+-			23 00 02 7B 00
+-			23 00 02 77 64
+-			23 00 02 A2 00
+-			23 00 02 9D 64
+-			23 00 02 C9 00
+-			23 00 02 C5 64
+-			23 00 02 01 71
+-			23 00 02 27 71
+-			23 00 02 51 71
+-			23 00 02 78 71
+-			23 00 02 9E 71
+-			23 00 02 C6 71
+-			23 00 02 02 89
+-			23 00 02 28 89
+-			23 00 02 52 89
+-			23 00 02 79 89
+-			23 00 02 9F 89
+-			23 00 02 C7 89
+-			23 00 02 03 9E
+-			23 00 02 29 9E
+-			23 00 02 53 9E
+-			23 00 02 7A 9E
+-			23 00 02 A0 9E
+-			23 00 02 C8 9E
+-			23 00 02 09 00
+-			23 00 02 05 B0
+-			23 00 02 31 00
+-			23 00 02 2B B0
+-			23 00 02 5A 00
+-			23 00 02 55 B0
+-			23 00 02 80 00
+-			23 00 02 7C B0
+-			23 00 02 A7 00
+-			23 00 02 A3 B0
+-			23 00 02 CE 00
+-			23 00 02 CA B0
+-			23 00 02 06 C0
+-			23 00 02 2D C0
+-			23 00 02 56 C0
+-			23 00 02 7D C0
+-			23 00 02 A4 C0
+-			23 00 02 CB C0
+-			23 00 02 07 CF
+-			23 00 02 2F CF
+-			23 00 02 58 CF
+-			23 00 02 7E CF
+-			23 00 02 A5 CF
+-			23 00 02 CC CF
+-			23 00 02 08 DD
+-			23 00 02 30 DD
+-			23 00 02 59 DD
+-			23 00 02 7F DD
+-			23 00 02 A6 DD
+-			23 00 02 CD DD
+-			23 00 02 0E 15
+-			23 00 02 0A E9
+-			23 00 02 36 15
+-			23 00 02 32 E9
+-			23 00 02 5F 15
+-			23 00 02 5B E9
+-			23 00 02 85 15
+-			23 00 02 81 E9
+-			23 00 02 AD 15
+-			23 00 02 A9 E9
+-			23 00 02 D3 15
+-			23 00 02 CF E9
+-			23 00 02 0B 14
+-			23 00 02 33 14
+-			23 00 02 5C 14
+-			23 00 02 82 14
+-			23 00 02 AA 14
+-			23 00 02 D0 14
+-			23 00 02 0C 36
+-			23 00 02 34 36
+-			23 00 02 5D 36
+-			23 00 02 83 36
+-			23 00 02 AB 36
+-			23 00 02 D1 36
+-			23 00 02 0D 6B
+-			23 00 02 35 6B
+-			23 00 02 5E 6B
+-			23 00 02 84 6B
+-			23 00 02 AC 6B
+-			23 00 02 D2 6B
+-			23 00 02 13 5A
+-			23 00 02 0F 94
+-			23 00 02 3B 5A
+-			23 00 02 37 94
+-			23 00 02 64 5A
+-			23 00 02 60 94
+-			23 00 02 8A 5A
+-			23 00 02 86 94
+-			23 00 02 B2 5A
+-			23 00 02 AE 94
+-			23 00 02 D8 5A
+-			23 00 02 D4 94
+-			23 00 02 10 D1
+-			23 00 02 38 D1
+-			23 00 02 61 D1
+-			23 00 02 87 D1
+-			23 00 02 AF D1
+-			23 00 02 D5 D1
+-			23 00 02 11 04
+-			23 00 02 39 04
+-			23 00 02 62 04
+-			23 00 02 88 04
+-			23 00 02 B0 04
+-			23 00 02 D6 04
+-			23 00 02 12 05
+-			23 00 02 3A 05
+-			23 00 02 63 05
+-			23 00 02 89 05
+-			23 00 02 B1 05
+-			23 00 02 D7 05
+-			23 00 02 18 AA
+-			23 00 02 14 36
+-			23 00 02 42 AA
+-			23 00 02 3D 36
+-			23 00 02 69 AA
+-			23 00 02 65 36
+-			23 00 02 8F AA
+-			23 00 02 8B 36
+-			23 00 02 B7 AA
+-			23 00 02 B3 36
+-			23 00 02 DD AA
+-			23 00 02 D9 36
+-			23 00 02 15 74
+-			23 00 02 3F 74
+-			23 00 02 66 74
+-			23 00 02 8C 74
+-			23 00 02 B4 74
+-			23 00 02 DA 74
+-			23 00 02 16 9F
+-			23 00 02 40 9F
+-			23 00 02 67 9F
+-			23 00 02 8D 9F
+-			23 00 02 B5 9F
+-			23 00 02 DB 9F
+-			23 00 02 17 DC
+-			23 00 02 41 DC
+-			23 00 02 68 DC
+-			23 00 02 8E DC
+-			23 00 02 B6 DC
+-			23 00 02 DC DC
+-			23 00 02 1D FF
+-			23 00 02 19 03
+-			23 00 02 47 FF
+-			23 00 02 43 03
+-			23 00 02 6E FF
+-			23 00 02 6A 03
+-			23 00 02 94 FF
+-			23 00 02 90 03
+-			23 00 02 BC FF
+-			23 00 02 B8 03
+-			23 00 02 E2 FF
+-			23 00 02 DE 03
+-			23 00 02 1A 35
+-			23 00 02 44 35
+-			23 00 02 6B 35
+-			23 00 02 91 35
+-			23 00 02 B9 35
+-			23 00 02 DF 35
+-			23 00 02 1B 45
+-			23 00 02 45 45
+-			23 00 02 6C 45
+-			23 00 02 92 45
+-			23 00 02 BA 45
+-			23 00 02 E0 45
+-			23 00 02 1C 55
+-			23 00 02 46 55
+-			23 00 02 6D 55
+-			23 00 02 93 55
+-			23 00 02 BB 55
+-			23 00 02 E1 55
+-			23 00 02 22 FF
+-			23 00 02 1E 68
+-			23 00 02 4C FF
+-			23 00 02 48 68
+-			23 00 02 73 FF
+-			23 00 02 6F 68
+-			23 00 02 99 FF
+-			23 00 02 95 68
+-			23 00 02 C1 FF
+-			23 00 02 BD 68
+-			23 00 02 E7 FF
+-			23 00 02 E3 68
+-			23 00 02 1F 7E
+-			23 00 02 49 7E
+-			23 00 02 70 7E
+-			23 00 02 96 7E
+-			23 00 02 BE 7E
+-			23 00 02 E4 7E
+-			23 00 02 20 97
+-			23 00 02 4A 97
+-			23 00 02 71 97
+-			23 00 02 97 97
+-			23 00 02 BF 97
+-			23 00 02 E5 97
+-			23 00 02 21 B5
+-			23 00 02 4B B5
+-			23 00 02 72 B5
+-			23 00 02 98 B5
+-			23 00 02 C0 B5
+-			23 00 02 E6 B5
+-			23 00 02 25 F0
+-			23 00 02 23 E8
+-			23 00 02 4F F0
+-			23 00 02 4D E8
+-			23 00 02 76 F0
+-			23 00 02 74 E8
+-			23 00 02 9C F0
+-			23 00 02 9A E8
+-			23 00 02 C4 F0
+-			23 00 02 C2 E8
+-			23 00 02 EA F0
+-			23 00 02 E8 E8
+-			23 00 02 24 FF
+-			23 00 02 4E FF
+-			23 00 02 75 FF
+-			23 00 02 9B FF
+-			23 00 02 C3 FF
+-			23 00 02 E9 FF
+-			23 00 02 FE 3D
+-			23 00 02 00 04
+-			23 00 02 FE 23
+-			23 00 02 08 82
+-			23 00 02 0A 00
+-			23 00 02 0B 00
+-			23 00 02 0C 01
+-			23 00 02 16 00
+-			23 00 02 18 02
+-			23 00 02 1B 04
+-			23 00 02 19 04
+-			23 00 02 1C 81
+-			23 00 02 1F 00
+-			23 00 02 20 03
+-			23 00 02 23 04
+-			23 00 02 21 01
+-			23 00 02 54 63
+-			23 00 02 55 54
+-			23 00 02 6E 45
+-			23 00 02 6D 36
+-			23 00 02 FE 3D
+-			23 00 02 55 78
+-			23 00 02 FE 20
+-			23 00 02 26 30
+-			23 00 02 FE 3D
+-			23 00 02 20 71
+-			23 00 02 50 8F
+-			23 00 02 51 8F
+-			23 00 02 FE 00
+-			23 00 02 35 00
++			15 00 02 FF 05
++			15 00 02 FB 01
++			15 64 02 C5 01
++			15 00 02 FF EE
++			15 00 02 FB 01
++			15 00 02 1F 45
++			15 00 02 24 4F
++			15 00 02 38 C8
++			15 00 02 39 27
++			15 00 02 1E 77
++			15 00 02 1D 0F
++			15 00 02 7E 71
++			15 00 02 7C 03
++			15 00 02 FF 00
++			15 00 02 FB 01
++			15 00 02 35 01
++			15 00 02 FF 01
++			15 00 02 FB 01
++			15 00 02 00 01
++			15 00 02 01 55
++			15 00 02 02 40
++			15 00 02 05 40
++			15 00 02 06 4A
++			15 00 02 07 24
++			15 00 02 08 0C
++			15 00 02 0B 7D
++			15 00 02 0C 7D
++			15 00 02 0E B0
++			15 00 02 0F AE
++			15 00 02 11 10
++			15 00 02 12 10
++			15 00 02 13 03
++			15 00 02 14 4A
++			15 00 02 15 12
++			15 00 02 16 12
++			15 00 02 18 00
++			15 00 02 19 77
++			15 00 02 1A 55
++			15 00 02 1B 13
++			15 00 02 1C 00
++			15 00 02 1D 00
++			15 00 02 1E 13
++			15 00 02 1F 00
++			15 00 02 23 00
++			15 00 02 24 00
++			15 00 02 25 00
++			15 00 02 26 00
++			15 00 02 27 00
++			15 00 02 28 00
++			15 00 02 35 00
++			15 00 02 66 00
++			15 00 02 58 82
++			15 00 02 59 02
++			15 00 02 5A 02
++			15 00 02 5B 02
++			15 00 02 5C 82
++			15 00 02 5D 82
++			15 00 02 5E 02
++			15 00 02 5F 02
++			15 00 02 72 31
++			15 00 02 FF 05
++			15 00 02 FB 01
++			15 00 02 00 01
++			15 00 02 01 0B
++			15 00 02 02 0C
++			15 00 02 03 09
++			15 00 02 04 0A
++			15 00 02 05 00
++			15 00 02 06 0F
++			15 00 02 07 10
++			15 00 02 08 00
++			15 00 02 09 00
++			15 00 02 0A 00
++			15 00 02 0B 00
++			15 00 02 0C 00
++			15 00 02 0D 13
++			15 00 02 0E 15
++			15 00 02 0F 17
++			15 00 02 10 01
++			15 00 02 11 0B
++			15 00 02 12 0C
++			15 00 02 13 09
++			15 00 02 14 0A
++			15 00 02 15 00
++			15 00 02 16 0F
++			15 00 02 17 10
++			15 00 02 18 00
++			15 00 02 19 00
++			15 00 02 1A 00
++			15 00 02 1B 00
++			15 00 02 1C 00
++			15 00 02 1D 13
++			15 00 02 1E 15
++			15 00 02 1F 17
++			15 00 02 20 00
++			15 00 02 21 03
++			15 00 02 22 01
++			15 00 02 23 40
++			15 00 02 24 40
++			15 00 02 25 ED
++			15 00 02 29 58
++			15 00 02 2A 12
++			15 00 02 2B 01
++			15 00 02 4B 06
++			15 00 02 4C 11
++			15 00 02 4D 20
++			15 00 02 4E 02
++			15 00 02 4F 02
++			15 00 02 50 20
++			15 00 02 51 61
++			15 00 02 52 01
++			15 00 02 53 63
++			15 00 02 54 77
++			15 00 02 55 ED
++			15 00 02 5B 00
++			15 00 02 5C 00
++			15 00 02 5D 00
++			15 00 02 5E 00
++			15 00 02 5F 15
++			15 00 02 60 75
++			15 00 02 61 00
++			15 00 02 62 00
++			15 00 02 63 00
++			15 00 02 64 00
++			15 00 02 65 00
++			15 00 02 66 00
++			15 00 02 67 00
++			15 00 02 68 04
++			15 00 02 69 00
++			15 00 02 6A 00
++			15 00 02 6C 40
++			15 00 02 75 01
++			15 00 02 76 01
++			15 00 02 7A 80
++			15 00 02 7B A3
++			15 00 02 7C D8
++			15 00 02 7D 60
++			15 00 02 7F 15
++			15 00 02 80 81
++			15 00 02 83 05
++			15 00 02 93 08
++			15 00 02 94 10
++			15 00 02 8A 00
++			15 00 02 9B 0F
++			15 00 02 EA FF
++			15 00 02 EC 00
++			15 00 02 FF 01
++			15 00 02 FB 01
++			15 00 02 75 00
++			15 00 02 76 DF
++			15 00 02 77 00
++			15 00 02 78 E4
++			15 00 02 79 00
++			15 00 02 7A ED
++			15 00 02 7B 00
++			15 00 02 7C F6
++			15 00 02 7D 00
++			15 00 02 7E FF
++			15 00 02 7F 01
++			15 00 02 80 07
++			15 00 02 81 01
++			15 00 02 82 10
++			15 00 02 83 01
++			15 00 02 84 18
++			15 00 02 85 01
++			15 00 02 86 20
++			15 00 02 87 01
++			15 00 02 88 3D
++			15 00 02 89 01
++			15 00 02 8A 56
++			15 00 02 8B 01
++			15 00 02 8C 84
++			15 00 02 8D 01
++			15 00 02 8E AB
++			15 00 02 8F 01
++			15 00 02 90 EC
++			15 00 02 91 02
++			15 00 02 92 22
++			15 00 02 93 02
++			15 00 02 94 23
++			15 00 02 95 02
++			15 00 02 96 55
++			15 00 02 97 02
++			15 00 02 98 8B
++			15 00 02 99 02
++			15 00 02 9A AF
++			15 00 02 9B 02
++			15 00 02 9C DF
++			15 00 02 9D 03
++			15 00 02 9E 01
++			15 00 02 9F 03
++			15 00 02 A0 2C
++			15 00 02 A2 03
++			15 00 02 A3 39
++			15 00 02 A4 03
++			15 00 02 A5 47
++			15 00 02 A6 03
++			15 00 02 A7 56
++			15 00 02 A9 03
++			15 00 02 AA 66
++			15 00 02 AB 03
++			15 00 02 AC 76
++			15 00 02 AD 03
++			15 00 02 AE 85
++			15 00 02 AF 03
++			15 00 02 B0 90
++			15 00 02 B1 03
++			15 00 02 B2 CB
++			15 00 02 B3 00
++			15 00 02 B4 DF
++			15 00 02 B5 00
++			15 00 02 B6 E4
++			15 00 02 B7 00
++			15 00 02 B8 ED
++			15 00 02 B9 00
++			15 00 02 BA F6
++			15 00 02 BB 00
++			15 00 02 BC FF
++			15 00 02 BD 01
++			15 00 02 BE 07
++			15 00 02 BF 01
++			15 00 02 C0 10
++			15 00 02 C1 01
++			15 00 02 C2 18
++			15 00 02 C3 01
++			15 00 02 C4 20
++			15 00 02 C5 01
++			15 00 02 C6 3D
++			15 00 02 C7 01
++			15 00 02 C8 56
++			15 00 02 C9 01
++			15 00 02 CA 84
++			15 00 02 CB 01
++			15 00 02 CC AB
++			15 00 02 CD 01
++			15 00 02 CE EC
++			15 00 02 CF 02
++			15 00 02 D0 22
++			15 00 02 D1 02
++			15 00 02 D2 23
++			15 00 02 D3 02
++			15 00 02 D4 55
++			15 00 02 D5 02
++			15 00 02 D6 8B
++			15 00 02 D7 02
++			15 00 02 D8 AF
++			15 00 02 D9 02
++			15 00 02 DA DF
++			15 00 02 DB 03
++			15 00 02 DC 01
++			15 00 02 DD 03
++			15 00 02 DE 2C
++			15 00 02 DF 03
++			15 00 02 E0 39
++			15 00 02 E1 03
++			15 00 02 E2 47
++			15 00 02 E3 03
++			15 00 02 E4 56
++			15 00 02 E5 03
++			15 00 02 E6 66
++			15 00 02 E7 03
++			15 00 02 E8 76
++			15 00 02 E9 03
++			15 00 02 EA 85
++			15 00 02 EB 03
++			15 00 02 EC 90
++			15 00 02 ED 03
++			15 00 02 EE CB
++			15 00 02 EF 00
++			15 00 02 F0 BB
++			15 00 02 F1 00
++			15 00 02 F2 C0
++			15 00 02 F3 00
++			15 00 02 F4 CC
++			15 00 02 F5 00
++			15 00 02 F6 D6
++			15 00 02 F7 00
++			15 00 02 F8 E1
++			15 00 02 F9 00
++			15 00 02 FA EA
++			15 00 02 FF 02
++			15 00 02 FB 01
++			15 00 02 00 00
++			15 00 02 01 F4
++			15 00 02 02 00
++			15 00 02 03 EF
++			15 00 02 04 01
++			15 00 02 05 07
++			15 00 02 06 01
++			15 00 02 07 28
++			15 00 02 08 01
++			15 00 02 09 44
++			15 00 02 0A 01
++			15 00 02 0B 76
++			15 00 02 0C 01
++			15 00 02 0D A0
++			15 00 02 0E 01
++			15 00 02 0F E7
++			15 00 02 10 02
++			15 00 02 11 1F
++			15 00 02 12 02
++			15 00 02 13 22
++			15 00 02 14 02
++			15 00 02 15 54
++			15 00 02 16 02
++			15 00 02 17 8B
++			15 00 02 18 02
++			15 00 02 19 AF
++			15 00 02 1A 02
++			15 00 02 1B E0
++			15 00 02 1C 03
++			15 00 02 1D 01
++			15 00 02 1E 03
++			15 00 02 1F 2D
++			15 00 02 20 03
++			15 00 02 21 39
++			15 00 02 22 03
++			15 00 02 23 47
++			15 00 02 24 03
++			15 00 02 25 57
++			15 00 02 26 03
++			15 00 02 27 65
++			15 00 02 28 03
++			15 00 02 29 77
++			15 00 02 2A 03
++			15 00 02 2B 85
++			15 00 02 2D 03
++			15 00 02 2F 8F
++			15 00 02 30 03
++			15 00 02 31 CB
++			15 00 02 32 00
++			15 00 02 33 BB
++			15 00 02 34 00
++			15 00 02 35 C0
++			15 00 02 36 00
++			15 00 02 37 CC
++			15 00 02 38 00
++			15 00 02 39 D6
++			15 00 02 3A 00
++			15 00 02 3B E1
++			15 00 02 3D 00
++			15 00 02 3F EA
++			15 00 02 40 00
++			15 00 02 41 F4
++			15 00 02 42 00
++			15 00 02 43 FE
++			15 00 02 44 01
++			15 00 02 45 07
++			15 00 02 46 01
++			15 00 02 47 28
++			15 00 02 48 01
++			15 00 02 49 44
++			15 00 02 4A 01
++			15 00 02 4B 76
++			15 00 02 4C 01
++			15 00 02 4D A0
++			15 00 02 4E 01
++			15 00 02 4F E7
++			15 00 02 50 02
++			15 00 02 51 1F
++			15 00 02 52 02
++			15 00 02 53 22
++			15 00 02 54 02
++			15 00 02 55 54
++			15 00 02 56 02
++			15 00 02 58 8B
++			15 00 02 59 02
++			15 00 02 5A AF
++			15 00 02 5B 02
++			15 00 02 5C E0
++			15 00 02 5D 03
++			15 00 02 5E 01
++			15 00 02 5F 03
++			15 00 02 60 2D
++			15 00 02 61 03
++			15 00 02 62 39
++			15 00 02 63 03
++			15 00 02 64 47
++			15 00 02 65 03
++			15 00 02 66 57
++			15 00 02 67 03
++			15 00 02 68 65
++			15 00 02 69 03
++			15 00 02 6A 77
++			15 00 02 6B 03
++			15 00 02 6C 85
++			15 00 02 6D 03
++			15 00 02 6E 8F
++			15 00 02 6F 03
++			15 00 02 70 CB
++			15 00 02 71 00
++			15 00 02 72 00
++			15 00 02 73 00
++			15 00 02 74 21
++			15 00 02 75 00
++			15 00 02 76 4C
++			15 00 02 77 00
++			15 00 02 78 6B
++			15 00 02 79 00
++			15 00 02 7A 85
++			15 00 02 7B 00
++			15 00 02 7C 9A
++			15 00 02 7D 00
++			15 00 02 7E AD
++			15 00 02 7F 00
++			15 00 02 80 BE
++			15 00 02 81 00
++			15 00 02 82 CD
++			15 00 02 83 01
++			15 00 02 84 01
++			15 00 02 85 01
++			15 00 02 86 29
++			15 00 02 87 01
++			15 00 02 88 68
++			15 00 02 89 01
++			15 00 02 8A 98
++			15 00 02 8B 01
++			15 00 02 8C E5
++			15 00 02 8D 02
++			15 00 02 8E 1E
++			15 00 02 8F 02
++			15 00 02 90 30
++			15 00 02 91 02
++			15 00 02 92 52
++			15 00 02 93 02
++			15 00 02 94 88
++			15 00 02 95 02
++			15 00 02 96 AA
++			15 00 02 97 02
++			15 00 02 98 D7
++			15 00 02 99 02
++			15 00 02 9A F7
++			15 00 02 9B 03
++			15 00 02 9C 21
++			15 00 02 9D 03
++			15 00 02 9E 2E
++			15 00 02 9F 03
++			15 00 02 A0 3D
++			15 00 02 A2 03
++			15 00 02 A3 4C
++			15 00 02 A4 03
++			15 00 02 A5 5E
++			15 00 02 A6 03
++			15 00 02 A7 71
++			15 00 02 A9 03
++			15 00 02 AA 86
++			15 00 02 AB 03
++			15 00 02 AC 94
++			15 00 02 AD 03
++			15 00 02 AE FA
++			15 00 02 AF 00
++			15 00 02 B0 00
++			15 00 02 B1 00
++			15 00 02 B2 21
++			15 00 02 B3 00
++			15 00 02 B4 4C
++			15 00 02 B5 00
++			15 00 02 B6 6B
++			15 00 02 B7 00
++			15 00 02 B8 85
++			15 00 02 B9 00
++			15 00 02 BA 9A
++			15 00 02 BB 00
++			15 00 02 BC AD
++			15 00 02 BD 00
++			15 00 02 BE BE
++			15 00 02 BF 00
++			15 00 02 C0 CD
++			15 00 02 C1 01
++			15 00 02 C2 01
++			15 00 02 C3 01
++			15 00 02 C4 29
++			15 00 02 C5 01
++			15 00 02 C6 68
++			15 00 02 C7 01
++			15 00 02 C8 98
++			15 00 02 C9 01
++			15 00 02 CA E5
++			15 00 02 CB 02
++			15 00 02 CC 1E
++			15 00 02 CD 02
++			15 00 02 CE 20
++			15 00 02 CF 02
++			15 00 02 D0 52
++			15 00 02 D1 02
++			15 00 02 D2 88
++			15 00 02 D3 02
++			15 00 02 D4 AA
++			15 00 02 D5 02
++			15 00 02 D6 D7
++			15 00 02 D7 02
++			15 00 02 D8 F7
++			15 00 02 D9 03
++			15 00 02 DA 21
++			15 00 02 DB 03
++			15 00 02 DC 2E
++			15 00 02 DD 03
++			15 00 02 DE 3D
++			15 00 02 DF 03
++			15 00 02 E0 4C
++			15 00 02 E1 03
++			15 00 02 E2 5E
++			15 00 02 E3 03
++			15 00 02 E4 71
++			15 00 02 E5 03
++			15 00 02 E6 86
++			15 00 02 E7 03
++			15 00 02 E8 94
++			15 00 02 E9 03
++			15 00 02 EA FA
++			15 00 02 FF 01
++			15 00 02 FB 01
++			15 00 02 FF 02
++			15 00 02 FB 01
++			15 00 02 FF 04
++			15 00 02 FB 01
++			15 00 02 FF 00
++			15 00 02 D3 05
++			15 00 02 D4 04
+ 			05 78 01 11
+-			05 1E 01 29
++			15 00 02 FF 00
++			15 00 02 35 00
++			05 0A 01 29
+ 		];
+ 
+ 		panel-exit-sequence = [
+-			05 00 01 28
+-			05 00 01 10
++			05 05 01 28
++			05 78 01 10
+ 		];
+ 
+ 		disp_timings0: display-timings {
+ 			native-mode = <&dsi0_timing0>;
+ 			dsi0_timing0: timing0 {
+-				clock-frequency = <132000000>;
++				clock-frequency = <120000000>;
+ 				hactive = <1080>;
+ 				vactive = <1920>;
+-				hfront-porch = <15>;
++				hfront-porch = <104>;
+ 				hsync-len = <4>;
+-				hback-porch = <30>;
+-				vfront-porch = <15>;
++				hback-porch = <127>;
++				vfront-porch = <4>;
+ 				vsync-len = <2>;
+-				vback-porch = <15>;
++				vback-porch = <3>;
+ 				hsync-active = <0>;
+ 				vsync-active = <0>;
+ 				de-active = <0>;
+@@ -526,11 +829,11 @@ &dsi1 {
+ 	status = "disabled";
+ 	//rockchip,lane-rate = <1000>;
+ 	dsi1_panel: panel@0 {
+-		status = "okay";
++		status = "disabled";
+ 		compatible = "simple-panel-dsi";
+ 		reg = <0>;
+-		backlight = <&backlight>;
+-		reset-delay-ms = <60>;
++		backlight = <&backlight_mipi1>;
++//		reset-delay-ms = <60>;
+ 		enable-delay-ms = <60>;
+ 		prepare-delay-ms = <60>;
+ 		unprepare-delay-ms = <60>;
+@@ -540,286 +843,548 @@ dsi1_panel: panel@0 {
+ 		dsi,format = <MIPI_DSI_FMT_RGB888>;
+ 		dsi,lanes  = <4>;
+ 		panel-init-sequence = [
+-			23 00 02 FE 21
+-			23 00 02 04 00
+-			23 00 02 00 64
+-			23 00 02 2A 00
+-			23 00 02 26 64
+-			23 00 02 54 00
+-			23 00 02 50 64
+-			23 00 02 7B 00
+-			23 00 02 77 64
+-			23 00 02 A2 00
+-			23 00 02 9D 64
+-			23 00 02 C9 00
+-			23 00 02 C5 64
+-			23 00 02 01 71
+-			23 00 02 27 71
+-			23 00 02 51 71
+-			23 00 02 78 71
+-			23 00 02 9E 71
+-			23 00 02 C6 71
+-			23 00 02 02 89
+-			23 00 02 28 89
+-			23 00 02 52 89
+-			23 00 02 79 89
+-			23 00 02 9F 89
+-			23 00 02 C7 89
+-			23 00 02 03 9E
+-			23 00 02 29 9E
+-			23 00 02 53 9E
+-			23 00 02 7A 9E
+-			23 00 02 A0 9E
+-			23 00 02 C8 9E
+-			23 00 02 09 00
+-			23 00 02 05 B0
+-			23 00 02 31 00
+-			23 00 02 2B B0
+-			23 00 02 5A 00
+-			23 00 02 55 B0
+-			23 00 02 80 00
+-			23 00 02 7C B0
+-			23 00 02 A7 00
+-			23 00 02 A3 B0
+-			23 00 02 CE 00
+-			23 00 02 CA B0
+-			23 00 02 06 C0
+-			23 00 02 2D C0
+-			23 00 02 56 C0
+-			23 00 02 7D C0
+-			23 00 02 A4 C0
+-			23 00 02 CB C0
+-			23 00 02 07 CF
+-			23 00 02 2F CF
+-			23 00 02 58 CF
+-			23 00 02 7E CF
+-			23 00 02 A5 CF
+-			23 00 02 CC CF
+-			23 00 02 08 DD
+-			23 00 02 30 DD
+-			23 00 02 59 DD
+-			23 00 02 7F DD
+-			23 00 02 A6 DD
+-			23 00 02 CD DD
+-			23 00 02 0E 15
+-			23 00 02 0A E9
+-			23 00 02 36 15
+-			23 00 02 32 E9
+-			23 00 02 5F 15
+-			23 00 02 5B E9
+-			23 00 02 85 15
+-			23 00 02 81 E9
+-			23 00 02 AD 15
+-			23 00 02 A9 E9
+-			23 00 02 D3 15
+-			23 00 02 CF E9
+-			23 00 02 0B 14
+-			23 00 02 33 14
+-			23 00 02 5C 14
+-			23 00 02 82 14
+-			23 00 02 AA 14
+-			23 00 02 D0 14
+-			23 00 02 0C 36
+-			23 00 02 34 36
+-			23 00 02 5D 36
+-			23 00 02 83 36
+-			23 00 02 AB 36
+-			23 00 02 D1 36
+-			23 00 02 0D 6B
+-			23 00 02 35 6B
+-			23 00 02 5E 6B
+-			23 00 02 84 6B
+-			23 00 02 AC 6B
+-			23 00 02 D2 6B
+-			23 00 02 13 5A
+-			23 00 02 0F 94
+-			23 00 02 3B 5A
+-			23 00 02 37 94
+-			23 00 02 64 5A
+-			23 00 02 60 94
+-			23 00 02 8A 5A
+-			23 00 02 86 94
+-			23 00 02 B2 5A
+-			23 00 02 AE 94
+-			23 00 02 D8 5A
+-			23 00 02 D4 94
+-			23 00 02 10 D1
+-			23 00 02 38 D1
+-			23 00 02 61 D1
+-			23 00 02 87 D1
+-			23 00 02 AF D1
+-			23 00 02 D5 D1
+-			23 00 02 11 04
+-			23 00 02 39 04
+-			23 00 02 62 04
+-			23 00 02 88 04
+-			23 00 02 B0 04
+-			23 00 02 D6 04
+-			23 00 02 12 05
+-			23 00 02 3A 05
+-			23 00 02 63 05
+-			23 00 02 89 05
+-			23 00 02 B1 05
+-			23 00 02 D7 05
+-			23 00 02 18 AA
+-			23 00 02 14 36
+-			23 00 02 42 AA
+-			23 00 02 3D 36
+-			23 00 02 69 AA
+-			23 00 02 65 36
+-			23 00 02 8F AA
+-			23 00 02 8B 36
+-			23 00 02 B7 AA
+-			23 00 02 B3 36
+-			23 00 02 DD AA
+-			23 00 02 D9 36
+-			23 00 02 15 74
+-			23 00 02 3F 74
+-			23 00 02 66 74
+-			23 00 02 8C 74
+-			23 00 02 B4 74
+-			23 00 02 DA 74
+-			23 00 02 16 9F
+-			23 00 02 40 9F
+-			23 00 02 67 9F
+-			23 00 02 8D 9F
+-			23 00 02 B5 9F
+-			23 00 02 DB 9F
+-			23 00 02 17 DC
+-			23 00 02 41 DC
+-			23 00 02 68 DC
+-			23 00 02 8E DC
+-			23 00 02 B6 DC
+-			23 00 02 DC DC
+-			23 00 02 1D FF
+-			23 00 02 19 03
+-			23 00 02 47 FF
+-			23 00 02 43 03
+-			23 00 02 6E FF
+-			23 00 02 6A 03
+-			23 00 02 94 FF
+-			23 00 02 90 03
+-			23 00 02 BC FF
+-			23 00 02 B8 03
+-			23 00 02 E2 FF
+-			23 00 02 DE 03
+-			23 00 02 1A 35
+-			23 00 02 44 35
+-			23 00 02 6B 35
+-			23 00 02 91 35
+-			23 00 02 B9 35
+-			23 00 02 DF 35
+-			23 00 02 1B 45
+-			23 00 02 45 45
+-			23 00 02 6C 45
+-			23 00 02 92 45
+-			23 00 02 BA 45
+-			23 00 02 E0 45
+-			23 00 02 1C 55
+-			23 00 02 46 55
+-			23 00 02 6D 55
+-			23 00 02 93 55
+-			23 00 02 BB 55
+-			23 00 02 E1 55
+-			23 00 02 22 FF
+-			23 00 02 1E 68
+-			23 00 02 4C FF
+-			23 00 02 48 68
+-			23 00 02 73 FF
+-			23 00 02 6F 68
+-			23 00 02 99 FF
+-			23 00 02 95 68
+-			23 00 02 C1 FF
+-			23 00 02 BD 68
+-			23 00 02 E7 FF
+-			23 00 02 E3 68
+-			23 00 02 1F 7E
+-			23 00 02 49 7E
+-			23 00 02 70 7E
+-			23 00 02 96 7E
+-			23 00 02 BE 7E
+-			23 00 02 E4 7E
+-			23 00 02 20 97
+-			23 00 02 4A 97
+-			23 00 02 71 97
+-			23 00 02 97 97
+-			23 00 02 BF 97
+-			23 00 02 E5 97
+-			23 00 02 21 B5
+-			23 00 02 4B B5
+-			23 00 02 72 B5
+-			23 00 02 98 B5
+-			23 00 02 C0 B5
+-			23 00 02 E6 B5
+-			23 00 02 25 F0
+-			23 00 02 23 E8
+-			23 00 02 4F F0
+-			23 00 02 4D E8
+-			23 00 02 76 F0
+-			23 00 02 74 E8
+-			23 00 02 9C F0
+-			23 00 02 9A E8
+-			23 00 02 C4 F0
+-			23 00 02 C2 E8
+-			23 00 02 EA F0
+-			23 00 02 E8 E8
+-			23 00 02 24 FF
+-			23 00 02 4E FF
+-			23 00 02 75 FF
+-			23 00 02 9B FF
+-			23 00 02 C3 FF
+-			23 00 02 E9 FF
+-			23 00 02 FE 3D
+-			23 00 02 00 04
+-			23 00 02 FE 23
+-			23 00 02 08 82
+-			23 00 02 0A 00
+-			23 00 02 0B 00
+-			23 00 02 0C 01
+-			23 00 02 16 00
+-			23 00 02 18 02
+-			23 00 02 1B 04
+-			23 00 02 19 04
+-			23 00 02 1C 81
+-			23 00 02 1F 00
+-			23 00 02 20 03
+-			23 00 02 23 04
+-			23 00 02 21 01
+-			23 00 02 54 63
+-			23 00 02 55 54
+-			23 00 02 6E 45
+-			23 00 02 6D 36
+-			23 00 02 FE 3D
+-			23 00 02 55 78
+-			23 00 02 FE 20
+-			23 00 02 26 30
+-			23 00 02 FE 3D
+-			23 00 02 20 71
+-			23 00 02 50 8F
+-			23 00 02 51 8F
+-			23 00 02 FE 00
+-			23 00 02 35 00
++			15 00 02 FF 05
++			15 00 02 FB 01
++			15 64 02 C5 01
++			15 00 02 FF EE
++			15 00 02 FB 01
++			15 00 02 1F 45
++			15 00 02 24 4F
++			15 00 02 38 C8
++			15 00 02 39 27
++			15 00 02 1E 77
++			15 00 02 1D 0F
++			15 00 02 7E 71
++			15 00 02 7C 03
++			15 00 02 FF 00
++			15 00 02 FB 01
++			15 00 02 35 01
++			15 00 02 FF 01
++			15 00 02 FB 01
++			15 00 02 00 01
++			15 00 02 01 55
++			15 00 02 02 40
++			15 00 02 05 40
++			15 00 02 06 4A
++			15 00 02 07 24
++			15 00 02 08 0C
++			15 00 02 0B 7D
++			15 00 02 0C 7D
++			15 00 02 0E B0
++			15 00 02 0F AE
++			15 00 02 11 10
++			15 00 02 12 10
++			15 00 02 13 03
++			15 00 02 14 4A
++			15 00 02 15 12
++			15 00 02 16 12
++			15 00 02 18 00
++			15 00 02 19 77
++			15 00 02 1A 55
++			15 00 02 1B 13
++			15 00 02 1C 00
++			15 00 02 1D 00
++			15 00 02 1E 13
++			15 00 02 1F 00
++			15 00 02 23 00
++			15 00 02 24 00
++			15 00 02 25 00
++			15 00 02 26 00
++			15 00 02 27 00
++			15 00 02 28 00
++			15 00 02 35 00
++			15 00 02 66 00
++			15 00 02 58 82
++			15 00 02 59 02
++			15 00 02 5A 02
++			15 00 02 5B 02
++			15 00 02 5C 82
++			15 00 02 5D 82
++			15 00 02 5E 02
++			15 00 02 5F 02
++			15 00 02 72 31
++			15 00 02 FF 05
++			15 00 02 FB 01
++			15 00 02 00 01
++			15 00 02 01 0B
++			15 00 02 02 0C
++			15 00 02 03 09
++			15 00 02 04 0A
++			15 00 02 05 00
++			15 00 02 06 0F
++			15 00 02 07 10
++			15 00 02 08 00
++			15 00 02 09 00
++			15 00 02 0A 00
++			15 00 02 0B 00
++			15 00 02 0C 00
++			15 00 02 0D 13
++			15 00 02 0E 15
++			15 00 02 0F 17
++			15 00 02 10 01
++			15 00 02 11 0B
++			15 00 02 12 0C
++			15 00 02 13 09
++			15 00 02 14 0A
++			15 00 02 15 00
++			15 00 02 16 0F
++			15 00 02 17 10
++			15 00 02 18 00
++			15 00 02 19 00
++			15 00 02 1A 00
++			15 00 02 1B 00
++			15 00 02 1C 00
++			15 00 02 1D 13
++			15 00 02 1E 15
++			15 00 02 1F 17
++			15 00 02 20 00
++			15 00 02 21 03
++			15 00 02 22 01
++			15 00 02 23 40
++			15 00 02 24 40
++			15 00 02 25 ED
++			15 00 02 29 58
++			15 00 02 2A 12
++			15 00 02 2B 01
++			15 00 02 4B 06
++			15 00 02 4C 11
++			15 00 02 4D 20
++			15 00 02 4E 02
++			15 00 02 4F 02
++			15 00 02 50 20
++			15 00 02 51 61
++			15 00 02 52 01
++			15 00 02 53 63
++			15 00 02 54 77
++			15 00 02 55 ED
++			15 00 02 5B 00
++			15 00 02 5C 00
++			15 00 02 5D 00
++			15 00 02 5E 00
++			15 00 02 5F 15
++			15 00 02 60 75
++			15 00 02 61 00
++			15 00 02 62 00
++			15 00 02 63 00
++			15 00 02 64 00
++			15 00 02 65 00
++			15 00 02 66 00
++			15 00 02 67 00
++			15 00 02 68 04
++			15 00 02 69 00
++			15 00 02 6A 00
++			15 00 02 6C 40
++			15 00 02 75 01
++			15 00 02 76 01
++			15 00 02 7A 80
++			15 00 02 7B A3
++			15 00 02 7C D8
++			15 00 02 7D 60
++			15 00 02 7F 15
++			15 00 02 80 81
++			15 00 02 83 05
++			15 00 02 93 08
++			15 00 02 94 10
++			15 00 02 8A 00
++			15 00 02 9B 0F
++			15 00 02 EA FF
++			15 00 02 EC 00
++			15 00 02 FF 01
++			15 00 02 FB 01
++			15 00 02 75 00
++			15 00 02 76 DF
++			15 00 02 77 00
++			15 00 02 78 E4
++			15 00 02 79 00
++			15 00 02 7A ED
++			15 00 02 7B 00
++			15 00 02 7C F6
++			15 00 02 7D 00
++			15 00 02 7E FF
++			15 00 02 7F 01
++			15 00 02 80 07
++			15 00 02 81 01
++			15 00 02 82 10
++			15 00 02 83 01
++			15 00 02 84 18
++			15 00 02 85 01
++			15 00 02 86 20
++			15 00 02 87 01
++			15 00 02 88 3D
++			15 00 02 89 01
++			15 00 02 8A 56
++			15 00 02 8B 01
++			15 00 02 8C 84
++			15 00 02 8D 01
++			15 00 02 8E AB
++			15 00 02 8F 01
++			15 00 02 90 EC
++			15 00 02 91 02
++			15 00 02 92 22
++			15 00 02 93 02
++			15 00 02 94 23
++			15 00 02 95 02
++			15 00 02 96 55
++			15 00 02 97 02
++			15 00 02 98 8B
++			15 00 02 99 02
++			15 00 02 9A AF
++			15 00 02 9B 02
++			15 00 02 9C DF
++			15 00 02 9D 03
++			15 00 02 9E 01
++			15 00 02 9F 03
++			15 00 02 A0 2C
++			15 00 02 A2 03
++			15 00 02 A3 39
++			15 00 02 A4 03
++			15 00 02 A5 47
++			15 00 02 A6 03
++			15 00 02 A7 56
++			15 00 02 A9 03
++			15 00 02 AA 66
++			15 00 02 AB 03
++			15 00 02 AC 76
++			15 00 02 AD 03
++			15 00 02 AE 85
++			15 00 02 AF 03
++			15 00 02 B0 90
++			15 00 02 B1 03
++			15 00 02 B2 CB
++			15 00 02 B3 00
++			15 00 02 B4 DF
++			15 00 02 B5 00
++			15 00 02 B6 E4
++			15 00 02 B7 00
++			15 00 02 B8 ED
++			15 00 02 B9 00
++			15 00 02 BA F6
++			15 00 02 BB 00
++			15 00 02 BC FF
++			15 00 02 BD 01
++			15 00 02 BE 07
++			15 00 02 BF 01
++			15 00 02 C0 10
++			15 00 02 C1 01
++			15 00 02 C2 18
++			15 00 02 C3 01
++			15 00 02 C4 20
++			15 00 02 C5 01
++			15 00 02 C6 3D
++			15 00 02 C7 01
++			15 00 02 C8 56
++			15 00 02 C9 01
++			15 00 02 CA 84
++			15 00 02 CB 01
++			15 00 02 CC AB
++			15 00 02 CD 01
++			15 00 02 CE EC
++			15 00 02 CF 02
++			15 00 02 D0 22
++			15 00 02 D1 02
++			15 00 02 D2 23
++			15 00 02 D3 02
++			15 00 02 D4 55
++			15 00 02 D5 02
++			15 00 02 D6 8B
++			15 00 02 D7 02
++			15 00 02 D8 AF
++			15 00 02 D9 02
++			15 00 02 DA DF
++			15 00 02 DB 03
++			15 00 02 DC 01
++			15 00 02 DD 03
++			15 00 02 DE 2C
++			15 00 02 DF 03
++			15 00 02 E0 39
++			15 00 02 E1 03
++			15 00 02 E2 47
++			15 00 02 E3 03
++			15 00 02 E4 56
++			15 00 02 E5 03
++			15 00 02 E6 66
++			15 00 02 E7 03
++			15 00 02 E8 76
++			15 00 02 E9 03
++			15 00 02 EA 85
++			15 00 02 EB 03
++			15 00 02 EC 90
++			15 00 02 ED 03
++			15 00 02 EE CB
++			15 00 02 EF 00
++			15 00 02 F0 BB
++			15 00 02 F1 00
++			15 00 02 F2 C0
++			15 00 02 F3 00
++			15 00 02 F4 CC
++			15 00 02 F5 00
++			15 00 02 F6 D6
++			15 00 02 F7 00
++			15 00 02 F8 E1
++			15 00 02 F9 00
++			15 00 02 FA EA
++			15 00 02 FF 02
++			15 00 02 FB 01
++			15 00 02 00 00
++			15 00 02 01 F4
++			15 00 02 02 00
++			15 00 02 03 EF
++			15 00 02 04 01
++			15 00 02 05 07
++			15 00 02 06 01
++			15 00 02 07 28
++			15 00 02 08 01
++			15 00 02 09 44
++			15 00 02 0A 01
++			15 00 02 0B 76
++			15 00 02 0C 01
++			15 00 02 0D A0
++			15 00 02 0E 01
++			15 00 02 0F E7
++			15 00 02 10 02
++			15 00 02 11 1F
++			15 00 02 12 02
++			15 00 02 13 22
++			15 00 02 14 02
++			15 00 02 15 54
++			15 00 02 16 02
++			15 00 02 17 8B
++			15 00 02 18 02
++			15 00 02 19 AF
++			15 00 02 1A 02
++			15 00 02 1B E0
++			15 00 02 1C 03
++			15 00 02 1D 01
++			15 00 02 1E 03
++			15 00 02 1F 2D
++			15 00 02 20 03
++			15 00 02 21 39
++			15 00 02 22 03
++			15 00 02 23 47
++			15 00 02 24 03
++			15 00 02 25 57
++			15 00 02 26 03
++			15 00 02 27 65
++			15 00 02 28 03
++			15 00 02 29 77
++			15 00 02 2A 03
++			15 00 02 2B 85
++			15 00 02 2D 03
++			15 00 02 2F 8F
++			15 00 02 30 03
++			15 00 02 31 CB
++			15 00 02 32 00
++			15 00 02 33 BB
++			15 00 02 34 00
++			15 00 02 35 C0
++			15 00 02 36 00
++			15 00 02 37 CC
++			15 00 02 38 00
++			15 00 02 39 D6
++			15 00 02 3A 00
++			15 00 02 3B E1
++			15 00 02 3D 00
++			15 00 02 3F EA
++			15 00 02 40 00
++			15 00 02 41 F4
++			15 00 02 42 00
++			15 00 02 43 FE
++			15 00 02 44 01
++			15 00 02 45 07
++			15 00 02 46 01
++			15 00 02 47 28
++			15 00 02 48 01
++			15 00 02 49 44
++			15 00 02 4A 01
++			15 00 02 4B 76
++			15 00 02 4C 01
++			15 00 02 4D A0
++			15 00 02 4E 01
++			15 00 02 4F E7
++			15 00 02 50 02
++			15 00 02 51 1F
++			15 00 02 52 02
++			15 00 02 53 22
++			15 00 02 54 02
++			15 00 02 55 54
++			15 00 02 56 02
++			15 00 02 58 8B
++			15 00 02 59 02
++			15 00 02 5A AF
++			15 00 02 5B 02
++			15 00 02 5C E0
++			15 00 02 5D 03
++			15 00 02 5E 01
++			15 00 02 5F 03
++			15 00 02 60 2D
++			15 00 02 61 03
++			15 00 02 62 39
++			15 00 02 63 03
++			15 00 02 64 47
++			15 00 02 65 03
++			15 00 02 66 57
++			15 00 02 67 03
++			15 00 02 68 65
++			15 00 02 69 03
++			15 00 02 6A 77
++			15 00 02 6B 03
++			15 00 02 6C 85
++			15 00 02 6D 03
++			15 00 02 6E 8F
++			15 00 02 6F 03
++			15 00 02 70 CB
++			15 00 02 71 00
++			15 00 02 72 00
++			15 00 02 73 00
++			15 00 02 74 21
++			15 00 02 75 00
++			15 00 02 76 4C
++			15 00 02 77 00
++			15 00 02 78 6B
++			15 00 02 79 00
++			15 00 02 7A 85
++			15 00 02 7B 00
++			15 00 02 7C 9A
++			15 00 02 7D 00
++			15 00 02 7E AD
++			15 00 02 7F 00
++			15 00 02 80 BE
++			15 00 02 81 00
++			15 00 02 82 CD
++			15 00 02 83 01
++			15 00 02 84 01
++			15 00 02 85 01
++			15 00 02 86 29
++			15 00 02 87 01
++			15 00 02 88 68
++			15 00 02 89 01
++			15 00 02 8A 98
++			15 00 02 8B 01
++			15 00 02 8C E5
++			15 00 02 8D 02
++			15 00 02 8E 1E
++			15 00 02 8F 02
++			15 00 02 90 30
++			15 00 02 91 02
++			15 00 02 92 52
++			15 00 02 93 02
++			15 00 02 94 88
++			15 00 02 95 02
++			15 00 02 96 AA
++			15 00 02 97 02
++			15 00 02 98 D7
++			15 00 02 99 02
++			15 00 02 9A F7
++			15 00 02 9B 03
++			15 00 02 9C 21
++			15 00 02 9D 03
++			15 00 02 9E 2E
++			15 00 02 9F 03
++			15 00 02 A0 3D
++			15 00 02 A2 03
++			15 00 02 A3 4C
++			15 00 02 A4 03
++			15 00 02 A5 5E
++			15 00 02 A6 03
++			15 00 02 A7 71
++			15 00 02 A9 03
++			15 00 02 AA 86
++			15 00 02 AB 03
++			15 00 02 AC 94
++			15 00 02 AD 03
++			15 00 02 AE FA
++			15 00 02 AF 00
++			15 00 02 B0 00
++			15 00 02 B1 00
++			15 00 02 B2 21
++			15 00 02 B3 00
++			15 00 02 B4 4C
++			15 00 02 B5 00
++			15 00 02 B6 6B
++			15 00 02 B7 00
++			15 00 02 B8 85
++			15 00 02 B9 00
++			15 00 02 BA 9A
++			15 00 02 BB 00
++			15 00 02 BC AD
++			15 00 02 BD 00
++			15 00 02 BE BE
++			15 00 02 BF 00
++			15 00 02 C0 CD
++			15 00 02 C1 01
++			15 00 02 C2 01
++			15 00 02 C3 01
++			15 00 02 C4 29
++			15 00 02 C5 01
++			15 00 02 C6 68
++			15 00 02 C7 01
++			15 00 02 C8 98
++			15 00 02 C9 01
++			15 00 02 CA E5
++			15 00 02 CB 02
++			15 00 02 CC 1E
++			15 00 02 CD 02
++			15 00 02 CE 20
++			15 00 02 CF 02
++			15 00 02 D0 52
++			15 00 02 D1 02
++			15 00 02 D2 88
++			15 00 02 D3 02
++			15 00 02 D4 AA
++			15 00 02 D5 02
++			15 00 02 D6 D7
++			15 00 02 D7 02
++			15 00 02 D8 F7
++			15 00 02 D9 03
++			15 00 02 DA 21
++			15 00 02 DB 03
++			15 00 02 DC 2E
++			15 00 02 DD 03
++			15 00 02 DE 3D
++			15 00 02 DF 03
++			15 00 02 E0 4C
++			15 00 02 E1 03
++			15 00 02 E2 5E
++			15 00 02 E3 03
++			15 00 02 E4 71
++			15 00 02 E5 03
++			15 00 02 E6 86
++			15 00 02 E7 03
++			15 00 02 E8 94
++			15 00 02 E9 03
++			15 00 02 EA FA
++			15 00 02 FF 01
++			15 00 02 FB 01
++			15 00 02 FF 02
++			15 00 02 FB 01
++			15 00 02 FF 04
++			15 00 02 FB 01
++			15 00 02 FF 00
++			15 00 02 D3 05
++			15 00 02 D4 04
+ 			05 78 01 11
+-			05 1E 01 29
++			15 00 02 FF 00
++			15 00 02 35 00
++			05 0A 01 29
+ 		];
+ 
+ 		panel-exit-sequence = [
+-			05 00 01 28
+-			05 00 01 10
++			05 05 01 28
++			05 78 01 10
+ 		];
+ 
+ 		disp_timings1: display-timings {
+ 			native-mode = <&dsi1_timing0>;
+ 			dsi1_timing0: timing0 {
+-				clock-frequency = <132000000>;
++				clock-frequency = <120000000>;
+ 				hactive = <1080>;
+ 				vactive = <1920>;
+-				hfront-porch = <15>;
++				hfront-porch = <104>;
+ 				hsync-len = <4>;
+-				hback-porch = <30>;
+-				vfront-porch = <15>;
++				hback-porch = <127>;
++				vfront-porch = <4>;
+ 				vsync-len = <2>;
+-				vback-porch = <15>;
++				vback-porch = <3>;
+ 				hsync-active = <0>;
+ 				vsync-active = <0>;
+ 				de-active = <0>;
+diff --git a/drivers/gpu/drm/panel/panel-simple.c b/drivers/gpu/drm/panel/panel-simple.c
+index 4e298108a62e..0a2a972d1a7a 100644
+--- a/drivers/gpu/drm/panel/panel-simple.c
++++ b/drivers/gpu/drm/panel/panel-simple.c
+@@ -114,7 +114,7 @@ struct panel_desc {
+ 		unsigned int enable;
+ 		unsigned int disable;
+ 		unsigned int unprepare;
+-		unsigned int reset;
++	//	unsigned int reset;
+ 		unsigned int init;
+ 	} delay;
+ 
+@@ -140,7 +140,7 @@ struct panel_simple {
+ 	struct i2c_adapter *ddc;
+ 
+ 	struct gpio_desc *enable_gpio;
+-	struct gpio_desc *reset_gpio;
++//	struct gpio_desc *reset_gpio;
+ 	struct gpio_desc *hpd_gpio;
+ 
+ 	struct drm_display_mode override_mode;
+@@ -462,7 +462,7 @@ static int panel_simple_unprepare(struct drm_panel *panel)
+ 		if (p->dsi)
+ 			panel_simple_xfer_dsi_cmd_seq(p, p->desc->exit_seq);
+ 
+-	gpiod_direction_output(p->reset_gpio, 1);
++//	gpiod_direction_output(p->reset_gpio, 1);
+ 	gpiod_direction_output(p->enable_gpio, 0);
+ 
+ 	panel_simple_regulator_disable(p);
+@@ -544,12 +544,12 @@ static int panel_simple_prepare(struct drm_panel *panel)
+ 		}
+ 	}
+ 
+-	gpiod_direction_output(p->reset_gpio, 1);
++//	gpiod_direction_output(p->reset_gpio, 1);
+ 
+-	if (p->desc->delay.reset)
+-		msleep(p->desc->delay.reset);
++//	if (p->desc->delay.reset)
++//		msleep(p->desc->delay.reset);
+ 
+-	gpiod_direction_output(p->reset_gpio, 0);
++//	gpiod_direction_output(p->reset_gpio, 0);
+ 
+ 	if (p->desc->delay.init)
+ 		msleep(p->desc->delay.init);
+@@ -810,13 +810,13 @@ static int panel_simple_probe(struct device *dev, const struct panel_desc *desc)
+ 		return err;
+ 	}
+ 
+-	panel->reset_gpio = devm_gpiod_get_optional(dev, "reset", GPIOD_ASIS);
+-	if (IS_ERR(panel->reset_gpio)) {
+-		err = PTR_ERR(panel->reset_gpio);
+-		if (err != -EPROBE_DEFER)
+-			dev_err(dev, "failed to get reset GPIO: %d\n", err);
+-		return err;
+-	}
++//	panel->reset_gpio = devm_gpiod_get_optional(dev, "reset", GPIOD_ASIS);
++//	if (IS_ERR(panel->reset_gpio)) {
++//		err = PTR_ERR(panel->reset_gpio);
++//		if (err != -EPROBE_DEFER)
++//			dev_err(dev, "failed to get reset GPIO: %d\n", err);
++//		return err;
++//	}
+ 
+ 	err = of_drm_get_panel_orientation(dev->of_node, &panel->orientation);
+ 	if (err) {
+@@ -4665,7 +4665,7 @@ static int panel_simple_of_get_desc_data(struct device *dev,
+ 	of_property_read_u32(np, "enable-delay-ms", &desc->delay.enable);
+ 	of_property_read_u32(np, "disable-delay-ms", &desc->delay.disable);
+ 	of_property_read_u32(np, "unprepare-delay-ms", &desc->delay.unprepare);
+-	of_property_read_u32(np, "reset-delay-ms", &desc->delay.reset);
++//	of_property_read_u32(np, "reset-delay-ms", &desc->delay.reset);
+ 	of_property_read_u32(np, "init-delay-ms", &desc->delay.init);
+ 
+ 	data = of_get_property(np, "panel-init-sequence", &len);
+diff --git a/drivers/gpu/drm/rockchip/dw-mipi-dsi2-rockchip.c b/drivers/gpu/drm/rockchip/dw-mipi-dsi2-rockchip.c
+index f55a3a5c5c7c..1a2882f157ee 100644
+--- a/drivers/gpu/drm/rockchip/dw-mipi-dsi2-rockchip.c
++++ b/drivers/gpu/drm/rockchip/dw-mipi-dsi2-rockchip.c
+@@ -275,6 +275,8 @@ struct dw_mipi_dsi2 {
+ 	struct rockchip_drm_sub_dev sub_dev;
+ 
+ 	struct gpio_desc *te_gpio;
++	struct gpio_desc *reset_gpio;
++	unsigned int reset_ms;
+ 	bool user_split_mode;
+ 	struct drm_property *user_split_mode_prop;
+ };
+@@ -476,6 +478,12 @@ static void dw_mipi_dsi2_encoder_disable(struct drm_encoder *encoder)
+ 		return;
+ 
+ 	s->output_if &= ~(dsi2->id ? VOP_OUTPUT_IF_MIPI1 : VOP_OUTPUT_IF_MIPI0);
++	if (dsi2->reset_ms)
++		msleep(dsi2->reset_ms);
++	gpiod_direction_output(dsi2->reset_gpio, 0);
++	if (dsi2->reset_ms)
++		msleep(dsi2->reset_ms);
++
+ }
+ 
+ static void dw_mipi_dsi2_get_lane_rate(struct dw_mipi_dsi2 *dsi2)
+@@ -838,6 +846,15 @@ static void dw_mipi_dsi2_encoder_enable(struct drm_encoder *encoder)
+ {
+ 	struct dw_mipi_dsi2 *dsi2 = encoder_to_dsi2(encoder);
+ 
++	gpiod_direction_output(dsi2->reset_gpio, 1);
++	if (dsi2->reset_ms)
++		msleep(dsi2->reset_ms);
++	gpiod_direction_output(dsi2->reset_gpio, 0);
++	if (dsi2->reset_ms)
++		msleep(dsi2->reset_ms);
++	gpiod_direction_output(dsi2->reset_gpio, 1);
++	if (dsi2->reset_ms)
++		msleep(dsi2->reset_ms);
+ 	dw_mipi_dsi2_get_lane_rate(dsi2);
+ 
+ 	if (dsi2->dcphy)
+@@ -1530,6 +1547,7 @@ static int dw_mipi_dsi2_probe(struct platform_device *pdev)
+ {
+ 	struct device *dev = &pdev->dev;
+ 	struct dw_mipi_dsi2 *dsi2;
++	struct device_node *np = dev->of_node;
+ 	struct resource *res;
+ 	void __iomem *regs;
+ 	int id;
+@@ -1617,6 +1635,14 @@ static int dw_mipi_dsi2_probe(struct platform_device *pdev)
+ 			return ret;
+ 		}
+ 	}
++	of_property_read_u32(np, "reset-delay-ms", &dsi2->reset_ms);
++	dsi2->reset_gpio = devm_gpiod_get_optional(dsi2->dev, "reset", GPIOD_ASIS);
++	if (IS_ERR(dsi2->reset_gpio)) {
++		ret = PTR_ERR(dsi2->reset_gpio);
++		if (ret != -EPROBE_DEFER)
++			dev_err(dev, "failed to get reset GPIO: %d\n", ret);
++		return ret;
++	}
+ 
+ 	ret = devm_request_irq(dev, dsi2->irq, dw_mipi_dsi2_irq_handler,
+ 			       IRQF_SHARED, dev_name(dev), dsi2);
+@@ -1661,6 +1687,24 @@ static __maybe_unused int dw_mipi_dsi2_runtime_resume(struct device *dev)
+ 	return 0;
+ }
+ 
++static void dw_mipi_dsi2_shutdown(struct platform_device *pdev){
++
++	struct device *dev = &pdev->dev;
++	struct dw_mipi_dsi2 *dsi2 = dev_get_drvdata(dev);
++
++	//printk("hlm dw_mipi_dsi2_shutdown\n");
++	gpiod_direction_output(dsi2->reset_gpio, 1);
++	if(dsi2->reset_ms)
++		msleep(dsi2->reset_ms);
++
++	gpiod_direction_output(dsi2->reset_gpio, 0);
++	if (dsi2->reset_ms)
++		msleep(dsi2->reset_ms);
++	gpiod_direction_output(dsi2->reset_gpio, 1);
++	if (dsi2->reset_ms)
++		msleep(dsi2->reset_ms);
++}
++
+ static const struct dev_pm_ops dw_mipi_dsi2_rockchip_pm_ops = {
+ 	SET_RUNTIME_PM_OPS(dw_mipi_dsi2_runtime_suspend,
+ 			   dw_mipi_dsi2_runtime_resume, NULL)
+@@ -1708,4 +1752,5 @@ struct platform_driver dw_mipi_dsi2_rockchip_driver = {
+ 		.pm = &dw_mipi_dsi2_rockchip_pm_ops,
+ 		.name = "dw-mipi-dsi2",
+ 	},
++	.shutdown = dw_mipi_dsi2_shutdown,
+ };
+-- 
+Armbian
+
+
+From 4f39570e28369a9a205853d3f1df934883bece5d Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Tue, 31 May 2022 11:56:00 +0800
+Subject: arm64: dts: rockchip: Edge2: support DP display
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: Id21c182051e807e795f759248b8ed573ece73b02
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 5292573bdac0..9727962fc984 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -255,7 +255,7 @@ &dp0 {
+ 	status = "okay";
+ };
+ 
+-&dp0_in_vp1 {
++&dp0_in_vp2 {
+ 	status = "okay";
+ };
+ 
+-- 
+Armbian
+
+
+From 97578958bc0a7f5b93eba849327ceb7961f478a5 Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Tue, 19 Jul 2022 10:20:01 +0800
+Subject: arm64: dts: rockchip: Edge2: Enable HDMI sound card
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: Ia78a627c80a8e30c861a72d9199417ddc7b1c516
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 9727962fc984..a20327cfbb7f 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -285,6 +285,10 @@ &dsi0_in_vp3 {
+ 	status = "okay";
+ };
+ 
++&hdmi0_sound {
++	status = "okay";
++};
++
+ &route_dsi0 {
+ 	status = "okay";
+ 	connect = <&vp3_out_dsi0>;
+@@ -398,6 +402,10 @@ regulator-state-mem {
+     };
+ };
+ 
++&i2s5_8ch {
++	status = "okay";
++};
++
+ &i2c2 {
+ 
+     status = "okay";
+-- 
+Armbian
+
+
+From d49dac0867bfb4088a4a2f5b1697d8964918fab9 Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Tue, 19 Jul 2022 10:29:09 +0800
+Subject: arm64: dts: rockchip: Edge2: support DMIC array
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: Ied4e34a19c2b69814babd820b04f811361149add
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 23 ++++++++--
+ 1 file changed, 18 insertions(+), 5 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index a20327cfbb7f..c6102dc3b8c9 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -37,7 +37,7 @@ combophy_avdd1v8: combophy-avdd1v8 {
+ 		vin-supply = <&avcc_1v8_s0>;
+ 	};
+ 
+-	es7202_sound_micarray: es7202-sound-micarray {
++	sound_micarray: sound-micarray {
+ 		status = "okay";
+ 		compatible = "simple-audio-card";
+ 		simple-audio-card,format = "i2s";
+@@ -49,11 +49,17 @@ cpu {
+ 				sound-dai = <&pdm0>;
+ 			};
+ 			codec {
+-				sound-dai = <&es7202>;
++				sound-dai = <&dummy_codec>;
+ 			};
+ 		};
+ 	};
+ 
++	dummy_codec: dummy-codec {
++		compatible = "rockchip,dummy-codec";
++		#sound-dai-cells = <0>;
++		status = "okay";
++	};
++
+ 	es8388_sound: es8388-sound {
+ 		status = "okay";
+ 		compatible = "rockchip,multicodecs-card";
+@@ -640,7 +646,14 @@ &pcie2x1l2 {
+ };
+ 
+ &pdm0 {
+-	status = "okay";
++	pinctrl-names = "default";
++    pinctrl-0 = <&pdm0m0_clk
++    &pdm0m0_clk1
++    &pdm0m0_sdi0
++    &pdm0m0_sdi1
++    &pdm0m0_sdi2>;
++    rockchip,path-map = <0 1 2 3>;
++    status = "okay";
+ };
+ 
+ &pinctrl {
+@@ -888,11 +901,11 @@ &spdif_tx1 {
+ };
+ 
+ &spdif_tx1_dc {
+-	status = "okay";
++	status = "disabled";
+ };
+ 
+ &spdif_tx1_sound {
+-	status = "okay";
++	status = "disabled";
+ };
+ 
+ &spdif_tx2 {
+-- 
+Armbian
+
+
+From 20bd49afa37ea8ff6ebade93f300139dba26d4a6 Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Tue, 19 Jul 2022 11:00:07 +0800
+Subject: Edge2: support codec es8316
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: I9371a6e2bead5cb829d3808d699ae97c8414859d
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 66 ++++------
+ 1 file changed, 25 insertions(+), 41 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index c6102dc3b8c9..bf516e72503f 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -60,40 +60,19 @@ dummy_codec: dummy-codec {
+ 		status = "okay";
+ 	};
+ 
+-	es8388_sound: es8388-sound {
+-		status = "okay";
+-		compatible = "rockchip,multicodecs-card";
+-		rockchip,card-name = "rockchip-es8388";
+-		hp-det-gpio = <&gpio1 RK_PD0 GPIO_ACTIVE_LOW>;
+-		io-channels = <&saradc 3>;
+-		io-channel-names = "adc-detect";
+-		keyup-threshold-microvolt = <1800000>;
+-		poll-interval = <100>;
+-		spk-con-gpio = <&gpio4 RK_PA5 GPIO_ACTIVE_HIGH>;
+-		hp-con-gpio = <&gpio4 RK_PA4 GPIO_ACTIVE_HIGH>;
+-		rockchip,format = "i2s";
+-		rockchip,mclk-fs = <256>;
+-		rockchip,cpu = <&i2s0_8ch>;
+-		rockchip,codec = <&es8388>;
+-		rockchip,audio-routing =
+-			"Headphone", "LOUT1",
+-			"Headphone", "ROUT1",
+-			"Speaker", "LOUT2",
+-			"Speaker", "ROUT2",
+-			"Headphone", "Headphone Power",
+-			"Headphone", "Headphone Power",
+-			"Speaker", "Speaker Power",
+-			"Speaker", "Speaker Power",
+-			"LINPUT1", "Main Mic",
+-			"LINPUT2", "Main Mic",
+-			"RINPUT1", "Headset Mic",
+-			"RINPUT2", "Headset Mic";
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&hp_det>;
+-		play-pause-key {
+-			label = "playpause";
+-			linux,code = <KEY_PLAYPAUSE>;
+-			press-threshold-microvolt = <2000>;
++	es8316_sound: es8316-sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,mclk-fs = <256>;
++		simple-audio-card,name = "rockchip,es8316-codec";
++		simple-audio-card,dai-link@0 {
++			format = "i2s";
++			cpu {
++				sound-dai = <&i2s0_8ch>;
++			};
++			codec {
++				sound-dai = <&es8316>;
++			};
+ 		};
+ 	};
+ 
+@@ -453,17 +432,19 @@ gs_kxtj3: gs_kxtj3@e {
+ 		status = "okay";
+ 	};
+ 
+-	es8388: es8388@11 {
++	es8316: es8316@10 {
+ 		status = "okay";
+ 		#sound-dai-cells = <0>;
+-		compatible = "everest,es8388", "everest,es8323";
+-		reg = <0x11>;
++		compatible = "everest,es8316";
++		reg = <0x10>;
+ 		clocks = <&cru I2S0_8CH_MCLKOUT>;
+ 		clock-names = "mclk";
+ 		assigned-clocks = <&cru I2S0_8CH_MCLKOUT>;
+ 		assigned-clock-rates = <12288000>;
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&i2s0_mclk>;
++		pinctrl-names = "default","hp_det","spk_con";
++		pinctrl-0 = <&i2s0_mclk>,<&hp_det>,<&spk_con>;
++		spk-con-gpio = <&gpio1 RK_PD0 GPIO_ACTIVE_HIGH>;
++		hp-det-gpio = <&gpio1 RK_PD3 GPIO_ACTIVE_LOW>;
+ 	};
+ 
+ 	es7202: es7202@32 {
+@@ -657,9 +638,12 @@ &pdm0m0_sdi1
+ };
+ 
+ &pinctrl {
+-	headphone {
++	audio {
+ 		hp_det: hp-det {
+-			rockchip,pins = <4 RK_PA3 RK_FUNC_GPIO &pcfg_pull_none>;
++			rockchip,pins = <1 RK_PD3 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++		spk_con: spk-con {
++			rockchip,pins = <1 RK_PD0 RK_FUNC_GPIO &pcfg_pull_down>;
+ 		};
+ 	};
+ 
+-- 
+Armbian
+
+
+From 03159ec03ca9fd53dbb18cf83f76c84685d6d6af Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Mon, 6 Jun 2022 15:35:45 +0800
+Subject: arm64: dts: Edge2: camera: add imx415 camera
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: I28c50b3d81816b04855bdb38ee54441d0cd83d39
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi | 255 +++++++---
+ 1 file changed, 184 insertions(+), 71 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi
+index 9d0593167702..9e4f755c36c7 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi
+@@ -15,14 +15,9 @@ port@0 {
+ 			#address-cells = <1>;
+ 			#size-cells = <0>;
+ 
+-			dp_mipi_in: endpoint@1 {
++			mipi_in_dcphy0: endpoint@1 {
+ 				reg = <1>;
+-				remote-endpoint = <&lt7911d_out>;
+-				data-lanes = <1 2 3 4>;
+-			};
+-			mipi_in_dcphy0: endpoint@2 {
+-				reg = <2>;
+-				remote-endpoint = <&ov50c40_out0>;
++				remote-endpoint = <&imx415b_out0>;
+ 				data-lanes = <1 2 3 4>;
+ 			};
+ 		};
+@@ -53,7 +48,7 @@ port@0 {
+ 
+ 			mipi_in_dcphy1: endpoint@1 {
+ 				reg = <1>;
+-				remote-endpoint = <&ov50c40_out1>;
++				remote-endpoint = <&imx415f_out1>;
+ 				data-lanes = <1 2 3 4>;
+ 			};
+ 		};
+@@ -70,12 +65,42 @@ csidcphy1_out: endpoint@0 {
+ 	};
+ };
+ 
+-&i2c6 {
++&csi2_dphy0 {
++   status = "okay";
++
++    ports {
++        #address-cells = <1>;
++       #size-cells = <0>;
++        port@0 {
++           reg = <0>;
++            #address-cells = <1>;
++           #size-cells = <0>;
++
++           mipidphy0_in_ucam0: endpoint@1 {
++               reg = <1>;
++               remote-endpoint = <&imx415c_out0>;
++               data-lanes = <1 2 3 4>;
++           };
++       };
++       port@1 {
++           reg = <1>;
++           #address-cells = <1>;
++           #size-cells = <0>;
++
++           csidphy0_out: endpoint@0 {
++               reg = <0>;
++               remote-endpoint = <&mipi2_csi2_input>;
++           };
++       };
++   };
++};
++
++&i2c4 {
+ 	status = "okay";
+ 	pinctrl-names = "default";
+-	pinctrl-0 = <&i2c6m4_xfer>;
++	pinctrl-0 = <&i2c4m3_xfer>;
+ 
+-	aw8601: aw8601@c {
++	aw8601b: aw8601b@c {
+ 		compatible = "awinic,aw8601";
+ 		status = "okay";
+ 		reg = <0x0c>;
+@@ -86,113 +111,146 @@ aw8601: aw8601@c {
+ 		rockchip,camera-module-facing = "back";
+ 	};
+ 
+-	lt7911d: lt7911d@2b {
+-		compatible = "lontium,lt7911d";
++	imx415b: imx415b@37 {
++		compatible = "sony,imx415";
+ 		status = "okay";
+-		reg = <0x2b>;
++		reg = <0x37>;
+ 		clocks = <&cru CLK_MIPI_CAMARAOUT_M1>;
+ 		clock-names = "xvclk";
+-		interrupt-parent = <&gpio3>;
+-		interrupts = <RK_PD4 IRQ_TYPE_EDGE_RISING>;
+ 		power-domains = <&power RK3588_PD_VI>;
+ 		pinctrl-names = "default";
+-		pinctrl-0 = <&mipim1_camera1_clk>;
+-		reset-gpios = <&gpio3 RK_PC4 GPIO_ACTIVE_LOW>;
+-		power-gpios = <&gpio1 RK_PA6 GPIO_ACTIVE_HIGH>;
+-		// hpd-ctl-gpios = <&gpio3 RK_PC5 GPIO_ACTIVE_HIGH>;
+-		// plugin-det-gpios = <&gpio0 RK_PD6 GPIO_ACTIVE_LOW>;
++		pinctrl-0 = <&mipim1_camera1_clk &camb_gpio>;
++		rockchip,grf = <&sys_grf>;
++		reset-gpios = <&gpio1 RK_PB2 GPIO_ACTIVE_LOW>;
++		pwdn-gpios = <&gpio1 RK_PB3 GPIO_ACTIVE_LOW>;
+ 		rockchip,camera-module-index = <0>;
+ 		rockchip,camera-module-facing = "back";
+-		rockchip,camera-module-name = "LT7911D";
+-		rockchip,camera-module-lens-name = "NC";
++		rockchip,camera-module-name = "CMK-OT2022-PX1";
++		rockchip,camera-module-lens-name = "IR0147-50IRC-8M-F20";
++	//	eeprom-ctrl = <&otp_eeprom>;
++		lens-focus = <&aw8601b>;
+ 		port {
+-			lt7911d_out: endpoint {
+-				remote-endpoint = <&dp_mipi_in>;
++			imx415b_out0: endpoint {
++				remote-endpoint = <&mipi_in_dcphy0>;
+ 				data-lanes = <1 2 3 4>;
+ 			};
+ 		};
+ 	};
+ 
+-	ov50c40: ov50c40@36 {
+-		compatible = "ovti,ov50c40";
++//	otp_eeprom: otp_eeprom@50 {
++//		compatible = "rk,otp_eeprom";
++//		status = "okay";
++//		reg = <0x50>;
++//	};
++};
++
++&i2c3 {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c3m0_xfer>;
++
++	aw8601f: aw8601f@c {
++		compatible = "awinic,aw8601";
+ 		status = "okay";
+-		reg = <0x36>;
+-		clocks = <&cru CLK_MIPI_CAMARAOUT_M1>;
++		reg = <0x0c>;
++		rockchip,vcm-start-current = <56>;
++		rockchip,vcm-rated-current = <96>;
++		rockchip,vcm-step-mode = <4>;
++		rockchip,camera-module-index = <1>;
++		rockchip,camera-module-facing = "front";
++	};
++
++	imx415f: imx415f@37 {
++		compatible = "sony,imx415";
++		status = "okay";
++		reg = <0x37>;
++		clocks = <&cru CLK_MIPI_CAMARAOUT_M2>;
+ 		clock-names = "xvclk";
+ 		power-domains = <&power RK3588_PD_VI>;
+ 		pinctrl-names = "default";
+-		pinctrl-0 = <&mipim1_camera1_clk>;
++		pinctrl-0 = <&mipim1_camera2_clk &camf_gpio>;
+ 		rockchip,grf = <&sys_grf>;
+-		reset-gpios = <&gpio3 RK_PC4 GPIO_ACTIVE_LOW>;
+-		pwdn-gpios = <&gpio3 RK_PD4 GPIO_ACTIVE_LOW>;
+-		rockchip,camera-module-index = <0>;
+-		rockchip,camera-module-facing = "back";
+-		rockchip,camera-module-name = "HZGA06";
+-		rockchip,camera-module-lens-name = "ZE0082C1";
+-		eeprom-ctrl = <&otp_eeprom>;
+-		lens-focus = <&aw8601>;
++		reset-gpios = <&gpio3 RK_PC6 GPIO_ACTIVE_LOW>;
++		pwdn-gpios = <&gpio3 RK_PC5 GPIO_ACTIVE_LOW>;
++		rockchip,camera-module-index = <1>;
++		rockchip,camera-module-facing = "front";
++		rockchip,camera-module-name = "CMK-OT2022-PX1";
++		rockchip,camera-module-lens-name = "IR0147-50IRC-8M-F20";
++//		eeprom-ctrl = <&otp_eeprom_b>;
++		lens-focus = <&aw8601f>;
+ 		port {
+-			ov50c40_out0: endpoint {
+-				remote-endpoint = <&mipi_in_dcphy0>;
++			imx415f_out1: endpoint {
++				remote-endpoint = <&mipi_in_dcphy1>;
+ 				data-lanes = <1 2 3 4>;
+ 			};
+ 		};
+ 	};
+ 
+-	otp_eeprom: otp_eeprom@50 {
+-		compatible = "rk,otp_eeprom";
+-		status = "okay";
+-		reg = <0x50>;
+-	};
++//	otp_eeprom_b: otp_eeprom_b@50 {
++//		compatible = "rk,otp_eeprom";
++//		status = "okay";
++//		reg = <0x50>;
++//	};
+ };
+ 
+-&i2c7 {
++&i2c8 {
+ 	status = "okay";
+ 	pinctrl-names = "default";
+-	pinctrl-0 = <&i2c7m2_xfer>;
++	pinctrl-0 = <&i2c8m2_xfer>;
+ 
+-	aw8601b: aw8601b@c {
++	aw8601c: aw8601c@c {
+ 		compatible = "awinic,aw8601";
+ 		status = "okay";
+ 		reg = <0x0c>;
+ 		rockchip,vcm-start-current = <56>;
+ 		rockchip,vcm-rated-current = <96>;
+ 		rockchip,vcm-step-mode = <4>;
+-		rockchip,camera-module-index = <1>;
++		rockchip,camera-module-index = <2>;
+ 		rockchip,camera-module-facing = "back";
+ 	};
+ 
+-	ov50c40b: ov50c40b@36 {
+-		compatible = "ovti,ov50c40";
+-		status = "okay";
+-		reg = <0x36>;
+-		clocks = <&cru CLK_MIPI_CAMARAOUT_M2>;
++	imx415: imx415@37 {
++		compatible = "sony,imx415";
++		reg = <0x37>;
++		clocks = <&cru CLK_MIPI_CAMARAOUT_M3>;
+ 		clock-names = "xvclk";
+-		power-domains = <&power RK3588_PD_VI>;
+ 		pinctrl-names = "default";
+-		pinctrl-0 = <&mipim1_camera2_clk>;
+-		rockchip,grf = <&sys_grf>;
+-		reset-gpios = <&gpio3 RK_PC5 GPIO_ACTIVE_LOW>;
+-		pwdn-gpios = <&gpio3 RK_PD5 GPIO_ACTIVE_LOW>;
+-		rockchip,camera-module-index = <1>;
++		pinctrl-0 = <&mipim1_camera3_clk &camc_gpio>;
++		power-domains = <&power RK3588_PD_VI>;
++		reset-gpios = <&gpio3 RK_PB4 GPIO_ACTIVE_LOW>;
++		pwdn-gpios = <&gpio1 RK_PA4 GPIO_ACTIVE_LOW>;
++		rockchip,camera-module-index = <2>;
+ 		rockchip,camera-module-facing = "back";
+-		rockchip,camera-module-name = "HZGA06";
+-		rockchip,camera-module-lens-name = "ZE0082C1";
+-		eeprom-ctrl = <&otp_eeprom_b>;
+-		lens-focus = <&aw8601b>;
++		rockchip,camera-module-name = "CMK-OT2022-PX1";
++		rockchip,camera-module-lens-name = "IR0147-50IRC-8M-F20";
++		lens-focus = <&aw8601c>;
+ 		port {
+-			ov50c40_out1: endpoint {
+-				remote-endpoint = <&mipi_in_dcphy1>;
++				imx415c_out0: endpoint {
++				remote-endpoint = <&mipidphy0_in_ucam0>;
+ 				data-lanes = <1 2 3 4>;
+ 			};
+ 		};
+ 	};
++};
+ 
+-	otp_eeprom_b: otp_eeprom_b@50 {
+-		compatible = "rk,otp_eeprom";
+-		status = "okay";
+-		reg = <0x50>;
+-	};
++&pinctrl {
++   cam {
++       camf_gpio: camf-gpio {
++           rockchip,pins =
++               <3 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>,
++               <3 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>;
++       };
++       camb_gpio: camb-gpio {
++           rockchip,pins =
++               <1 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>,
++               <1 RK_PB3 RK_FUNC_GPIO &pcfg_pull_none>;
++       };
++       camc_gpio: camc-gpio {
++           rockchip,pins =
++               <3 RK_PB4 RK_FUNC_GPIO &pcfg_pull_none>,
++               <1 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
++       };
++   };
+ };
+ 
+ &mipi_dcphy0 {
+@@ -265,6 +323,37 @@ mipi1_csi2_output: endpoint@0 {
+ 	};
+ };
+ 
++&mipi2_csi2 {
++   status = "okay";
++
++   ports {
++       #address-cells = <1>;
++       #size-cells = <0>;
++
++       port@0 {
++           reg = <0>;
++           #address-cells = <1>;
++           #size-cells = <0>;
++
++           mipi2_csi2_input: endpoint@1 {
++               reg = <1>;
++               remote-endpoint = <&csidphy0_out>;
++           };
++       };
++
++       port@1 {
++           reg = <1>;
++           #address-cells = <1>;
++           #size-cells = <0>;
++
++           mipi2_csi2_output: endpoint@0 {
++               reg = <0>;
++               remote-endpoint = <&cif_mipi2_in0>;
++           };
++       };
++   };
++};
++
+ &rkcif {
+ 	status = "okay";
+ };
+@@ -299,6 +388,16 @@ cif_mipi_in1: endpoint {
+ 	};
+ };
+ 
++&rkcif_mipi_lvds2 {
++    status = "okay";
++
++   port {
++       cif_mipi2_in0: endpoint {
++           remote-endpoint = <&mipi2_csi2_output>;
++       };
++   };
++};
++
+ &rkcif_mipi_lvds1_sditf {
+ 	status = "okay";
+ 
+@@ -309,6 +408,16 @@ mipi1_lvds_sditf: endpoint {
+ 	};
+ };
+ 
++&rkcif_mipi_lvds2_sditf {
++	status = "okay";
++
++	port {
++		mipi_lvds2_sditf: endpoint {
++			remote-endpoint = <&isp0_vir0>;
++		};
++	};
++};
++
+ &rkcif_mmu {
+ 	status = "okay";
+ };
+@@ -341,5 +450,9 @@ isp1_in2: endpoint@1 {
+ 			reg = <1>;
+ 			remote-endpoint = <&mipi1_lvds_sditf>;
+ 		};
++		isp0_vir0: endpoint@2 {
++			reg = <2>;
++			remote-endpoint = <&mipi_lvds2_sditf>;
++		};
+ 	};
+ };
+-- 
+Armbian
+
+
+From d90ce84fb0a801dcf81e2734a5cf22347c2b9afb Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Tue, 14 Jun 2022 15:12:06 +0800
+Subject: arm64: dts: rockchip: Edge2: support 8k
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: I1b756664532a24f93fbb86e3505161c80ff79f3b
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 13 ++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index bf516e72503f..b9eabde9f97f 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -236,6 +236,19 @@ &combphy0_ps {
+ 	status = "okay";
+ };
+ 
++&cru {
++	assigned-clock-rates =
++            <1100000000>, <786432000>,
++            <850000000>, <1188000000>,
++            <702000000>,
++            <400000000>, <500000000>,
++            <800000000>, <100000000>,
++            <400000000>, <100000000>,
++            <200000000>, <800000000>,
++            <375000000>, <150000000>,
++            <200000000>;
++};
++
+ &dp0 {
+ 	status = "okay";
+ };
+-- 
+Armbian
+
+
+From b5e94586e1b93c3c52761d703f07b8ea6d8725ad Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Tue, 28 Jun 2022 13:57:54 +0800
+Subject: Edge2: change bluetooth to mainline way
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: Ifab39231c7dd6083de08bdaebfde7b1b6696f21b
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts |  6 +++
+ arch/arm64/configs/kedges_defconfig                   | 24 ++++++----
+ 2 files changed, 20 insertions(+), 10 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index b9eabde9f97f..eb9e415aa291 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -937,6 +937,12 @@ &uart9 {
+ 	status = "okay";
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&uart9m2_xfer &uart9m2_ctsn>;
++	uart-has-rtscts;
++	bluetooth {
++		compatible = "brcm,bcm43438-bt";
++		max-speed = <4000000>;
++		clock-names = "lpo";
++	};
+ };
+ 
+ &usbdp_phy0 {
+diff --git a/arch/arm64/configs/kedges_defconfig b/arch/arm64/configs/kedges_defconfig
+index a859db38f300..ad7439f1785f 100644
+--- a/arch/arm64/configs/kedges_defconfig
++++ b/arch/arm64/configs/kedges_defconfig
+@@ -89,16 +89,18 @@ CONFIG_SYN_COOKIES=y
+ CONFIG_NETFILTER=y
+ CONFIG_IP_NF_IPTABLES=y
+ CONFIG_IP_NF_MANGLE=y
+-CONFIG_BT=y
+-CONFIG_BT_RFCOMM=y
+-CONFIG_BT_HIDP=y
+-CONFIG_BT_HCIBTUSB=y
+-CONFIG_BT_HCIUART=y
+-CONFIG_BT_HCIUART_ATH3K=y
+-CONFIG_BT_HCIBFUSB=y
+-CONFIG_BT_HCIVHCI=y
+-CONFIG_BT_MRVL=y
+-CONFIG_BT_MRVL_SDIO=y
++CONFIG_BT=m
++CONFIG_BT_RFCOMM=m
++CONFIG_BT_RFCOMM_TTY=y
++CONFIG_BT_BNEP=m
++CONFIG_BT_BNEP_MC_FILTER=y
++CONFIG_BT_BNEP_PROTO_FILTER=y
++CONFIG_BT_HIDP=m
++CONFIG_BT_HS=y
++CONFIG_BT_HCIBTUSB=m
++CONFIG_BT_HCIBTSDIO=m
++CONFIG_BT_HCIUART=m
++CONFIG_BT_HCIUART_BCM=y
+ CONFIG_RFKILL=y
+ CONFIG_RFKILL_RK=y
+ CONFIG_PCI=y
+@@ -219,6 +221,7 @@ CONFIG_SERIAL_8250_NR_UARTS=10
+ CONFIG_SERIAL_8250_RUNTIME_UARTS=10
+ CONFIG_SERIAL_8250_DW=y
+ CONFIG_SERIAL_OF_PLATFORM=y
++CONFIG_SERIAL_DEV_BUS=y
+ CONFIG_HW_RANDOM=y
+ CONFIG_HW_RANDOM_ROCKCHIP=y
+ CONFIG_TCG_TPM=y
+@@ -576,6 +579,7 @@ CONFIG_NLS_ASCII=y
+ CONFIG_NLS_ISO8859_1=y
+ CONFIG_NLS_UTF8=y
+ CONFIG_UNICODE=y
++CONFIG_CRYPTO_ECDH=y
+ CONFIG_CRYPTO_SHA512=y
+ CONFIG_CRYPTO_TWOFISH=y
+ CONFIG_CRYPTO_ANSI_CPRNG=y
+-- 
+Armbian
+
+
+From 687278a91d2f6442034b643d2440804c123ef0bf Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Thu, 30 Jun 2022 22:16:41 +0800
+Subject: [MIGHT NEED INTERVENTION MCU THERMAL STUFF] Edge2: support fan
+ function
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: I23105fba75af5a0861258b40410a7773b6f87bb9
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts |  10 +
+ drivers/misc/Makefile                                 |   1 +
+ drivers/misc/khadas-mcu.c                             | 472 +++++++++-
+ drivers/thermal/rockchip_thermal.c                    |  17 +
+ 4 files changed, 485 insertions(+), 15 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index eb9e415aa291..d25c29ccdb00 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -545,6 +545,12 @@ mcu: khadas-mcu@18 {
+ 		compatible = "khadas-mcu";
+ 		status = "okay";
+ 		reg = <0x18>;
++		fan,trig_temp_level0 = <50>;
++		fan,trig_temp_level1 = <60>;
++		fan,trig_temp_level2 = <70>;
++		fan,trig_temp_level3 = <80>;
++		hwver = "EDGE2.V10";
++
+ 	};
+ 
+ 	usbc0: fusb302@22 {
+@@ -921,6 +927,10 @@ spidev@1 {
+ 	};
+ };
+ 
++&tsadc {
++	status = "okay";
++};
++
+ &u2phy0_otg {
+ 	rockchip,typec-vbus-det;
+ };
+diff --git a/drivers/misc/Makefile b/drivers/misc/Makefile
+index 965648611ae4..574b8ff68cda 100644
+--- a/drivers/misc/Makefile
++++ b/drivers/misc/Makefile
+@@ -3,6 +3,7 @@
+ # Makefile for misc devices that really don't fit anywhere else.
+ #
+ 
++KBUILD_CFLAGS += -Wno-unused-function
+ obj-$(CONFIG_IBM_ASM)		+= ibmasm/
+ obj-$(CONFIG_IBMVMC)		+= ibmvmc.o
+ obj-$(CONFIG_AD525X_DPOT)	+= ad525x_dpot.o
+diff --git a/drivers/misc/khadas-mcu.c b/drivers/misc/khadas-mcu.c
+index 1677294ee617..67c3d6a6ee91 100644
+--- a/drivers/misc/khadas-mcu.c
++++ b/drivers/misc/khadas-mcu.c
+@@ -25,9 +25,70 @@
+ #define MCU_PWR_OFF_CMD_REG       0x80
+ #define MCU_SHUTDOWN_NORMAL_REG   0x2c
+ 
++/*Fan device*/
++#define MCU_CMD_FAN_STATUS_CTRL_REGv2   0x8A
++
++#define MCU_FAN_TRIG_TEMP_LEVEL0        60  // 50 degree if not set
++#define MCU_FAN_TRIG_TEMP_LEVEL1        80  // 60 degree if not set
++#define MCU_FAN_TRIG_TEMP_LEVEL2        100 // 70 degree if not set
++#define MCU_FAN_TRIG_MAXTEMP            105
++#define MCU_FAN_LOOP_SECS               (30 * HZ)   // 30 seconds
++#define MCU_FAN_TEST_LOOP_SECS          (5 * HZ)  // 5 seconds
++#define MCU_FAN_LOOP_NODELAY_SECS       0
++#define MCU_FAN_SPEED_OFF               0
++#define MCU_FAN_SPEED_LOW               1
++#define MCU_FAN_SPEED_MID               2
++#define MCU_FAN_SPEED_HIGH              3
++#define MCU_FAN_SPEED_LOW_V2            0x32
++#define MCU_FAN_SPEED_MID_V2            0x48
++#define MCU_FAN_SPEED_HIGH_V2           0x64
++
++enum khadas_board {
++	KHADAS_BOARD_NONE = 0,
++	KHADAS_BOARD_EDGE2
++};
++
++enum khadas_board_hwver {
++	KHADAS_BOARD_HWVER_NONE = 0,
++	KHADAS_BOARD_HWVER_V10
++};
++
++enum mcu_fan_mode {
++	MCU_FAN_MODE_MANUAL = 0,
++	MCU_FAN_MODE_AUTO
++};
++
++enum mcu_fan_level {
++	MCU_FAN_LEVEL_0 = 0,
++	MCU_FAN_LEVEL_1,
++	MCU_FAN_LEVEL_2,
++	MCU_FAN_LEVEL_3
++};
++
++enum mcu_fan_status {
++	MCU_FAN_STATUS_DISABLE = 0,
++	MCU_FAN_STATUS_ENABLE,
++};
++
++struct mcu_fan_data {
++    struct platform_device *pdev;
++    struct class *fan_class;
++    struct delayed_work work;
++    struct delayed_work fan_test_work;
++    enum mcu_fan_status enable;
++    enum mcu_fan_mode mode;
++    enum mcu_fan_level level;
++    int trig_temp_level0;
++    int trig_temp_level1;
++    int trig_temp_level2;
++};
++
+ struct mcu_data {
+ 	struct i2c_client *client;
+ 	struct class *mcu_class;
++	enum khadas_board board;
++	enum khadas_board_hwver hwver;
++	struct mcu_fan_data fan_data;
+ };
+ 
+ struct mcu_data *g_mcu_data;
+@@ -54,7 +115,7 @@ static int i2c_master_reg8_send(const struct i2c_client *client,
+ 	return (ret == 1) ? count : ret;
+ }
+ 
+-/*static int i2c_master_reg8_recv(const struct i2c_client *client,
++static int i2c_master_reg8_recv(const struct i2c_client *client,
+ 		const char reg, char *buf, int count)
+ {
+ 	struct i2c_adapter *adap = client->adapter;
+@@ -75,15 +136,15 @@ static int i2c_master_reg8_send(const struct i2c_client *client,
+ 	ret = i2c_transfer(adap, msgs, 2);
+ 
+ 	return (ret == 2) ? count : ret;
+-}*/
++}
+ 
+-/*static int mcu_i2c_read_regs(struct i2c_client *client,
++static int mcu_i2c_read_regs(struct i2c_client *client,
+ 		u8 reg, u8 buf[], unsigned len)
+ {
+ 	int ret;
+ 	ret = i2c_master_reg8_recv(client, reg, buf, len);
+ 	return ret;
+-}*/
++}
+ 
+ static int mcu_i2c_write_regs(struct i2c_client *client,
+ 		u8 reg, u8 const buf[], __u16 len)
+@@ -95,6 +156,314 @@ static int mcu_i2c_write_regs(struct i2c_client *client,
+ 	return ret;
+ }
+ 
++static int is_mcu_fan_control_supported(void)
++{
++	// MCU FAN control is supported for:
++	// 1. Khadas EDGE2
++	if (g_mcu_data->board == KHADAS_BOARD_EDGE2) {
++		if (g_mcu_data->hwver >= KHADAS_BOARD_HWVER_V10)
++			return 1;
++		else
++			return 0;
++	} else {
++			return 0;
++	}
++
++}
++static void mcu_fan_level_set(struct mcu_fan_data *fan_data, int level)
++{
++    if (is_mcu_fan_control_supported()) {
++        int ret;
++        u8 data = 0;
++
++        g_mcu_data->fan_data.level = level;
++
++		if (g_mcu_data->board == KHADAS_BOARD_EDGE2) {
++            if (level == 0)
++                data = MCU_FAN_SPEED_OFF;
++            else if (level == 1)
++                data = MCU_FAN_SPEED_LOW_V2;
++            else if (level == 2)
++                data = MCU_FAN_SPEED_MID_V2;
++            else if (level == 3)
++                data = MCU_FAN_SPEED_HIGH_V2;
++            ret = mcu_i2c_write_regs(g_mcu_data->client,
++                    MCU_CMD_FAN_STATUS_CTRL_REGv2,
++                    &data, 1);
++            if (ret < 0) {
++                pr_debug("write fan control err\n");
++                return;
++            }
++	      }
++    }
++}
++
++extern int rk_get_temperature(void);
++
++static void fan_work_func(struct work_struct *_work)
++{
++    if (is_mcu_fan_control_supported()) {
++        int temp = -EINVAL;
++        struct mcu_fan_data *fan_data = &g_mcu_data->fan_data;
++
++		if (g_mcu_data->board == KHADAS_BOARD_EDGE2) {
++				printk("temp start23!!\r\n");
++            temp = rk_get_temperature();
++		} else {
++			printk("temp start!!\r\n");
++           temp = fan_data->trig_temp_level0;
++		}
++
++		if (temp != -EINVAL) {
++            if (temp < fan_data->trig_temp_level0)
++                mcu_fan_level_set(fan_data, 0);
++            else if (temp < fan_data->trig_temp_level1)
++                mcu_fan_level_set(fan_data, 1);
++            else if (temp < fan_data->trig_temp_level2)
++                mcu_fan_level_set(fan_data, 2);
++            else
++                mcu_fan_level_set(fan_data, 3);
++        }
++
++        schedule_delayed_work(&fan_data->work, MCU_FAN_LOOP_SECS);
++    }
++}
++
++static void khadas_fan_set(struct mcu_fan_data  *fan_data)
++{
++	if (is_mcu_fan_control_supported()) {
++        cancel_delayed_work(&fan_data->work);
++        if (fan_data->enable == MCU_FAN_STATUS_DISABLE) {
++            mcu_fan_level_set(fan_data, 0);
++            return;
++        }
++        switch (fan_data->mode) {
++        case MCU_FAN_MODE_MANUAL:
++            switch (fan_data->level) {
++				case MCU_FAN_LEVEL_0:
++					mcu_fan_level_set(fan_data, 0);
++					break;
++				case MCU_FAN_LEVEL_1:
++					mcu_fan_level_set(fan_data, 1);
++					break;
++				case MCU_FAN_LEVEL_2:
++					mcu_fan_level_set(fan_data, 2);
++					break;
++				case MCU_FAN_LEVEL_3:
++					mcu_fan_level_set(fan_data, 3);
++					break;
++				default:
++					break;
++            }
++            break;
++		case MCU_FAN_MODE_AUTO:
++            // FIXME: achieve with a better way
++			schedule_delayed_work(&fan_data->work,
++                    MCU_FAN_LOOP_NODELAY_SECS);
++			break;
++		default:
++			break;
++        }
++    }
++}
++
++static ssize_t show_fan_enable(struct class *cls,
++             struct class_attribute *attr, char *buf)
++{
++    return sprintf(buf, "Fan enable: %d\n", g_mcu_data->fan_data.enable);
++}
++
++static ssize_t store_fan_enable(struct class *cls, struct class_attribute *attr,
++               const char *buf, size_t count)
++{
++    int enable;
++
++    if (kstrtoint(buf, 0, &enable))
++        return -EINVAL;
++
++    // 0: manual, 1: auto
++    if (enable >= 0 && enable < 2) {
++        g_mcu_data->fan_data.enable = enable;
++        khadas_fan_set(&g_mcu_data->fan_data);
++    }
++
++	return count;
++}
++
++
++static ssize_t show_fan_mode(struct class *cls,
++             struct class_attribute *attr, char *buf)
++{
++    return sprintf(buf, "Fan mode: %d\n", g_mcu_data->fan_data.mode);
++}
++
++static ssize_t store_fan_mode(struct class *cls, struct class_attribute *attr,
++               const char *buf, size_t count)
++{
++    int mode;
++
++    if (kstrtoint(buf, 0, &mode))
++        return -EINVAL;
++
++    // 0: manual, 1: auto
++    if (mode >= 0 && mode < 2) {
++        g_mcu_data->fan_data.mode = mode;
++        khadas_fan_set(&g_mcu_data->fan_data);
++    }
++
++    return count;
++}
++
++static ssize_t show_fan_level(struct class *cls,
++             struct class_attribute *attr, char *buf)
++{
++    return sprintf(buf, "Fan level: %d\n", g_mcu_data->fan_data.level);
++}
++
++static ssize_t store_fan_level(struct class *cls, struct class_attribute *attr,
++               const char *buf, size_t count)
++{
++    int level;
++
++    if (kstrtoint(buf, 0, &level))
++        return -EINVAL;
++
++    if (level >= 0 && level < 4) {
++        g_mcu_data->fan_data.level = level;
++        khadas_fan_set(&g_mcu_data->fan_data);
++    }
++
++    return count;
++}
++
++static ssize_t show_fan_temp(struct class *cls,
++             struct class_attribute *attr, char *buf)
++{
++    struct mcu_fan_data *fan_data = &g_mcu_data->fan_data;
++    int temp = -EINVAL;
++
++    if (g_mcu_data->board == KHADAS_BOARD_EDGE2)
++        temp = rk_get_temperature();
++    else
++        temp = fan_data->trig_temp_level0;
++
++    return sprintf(buf,
++            "cpu_temp:%d\nFan trigger temperature: level0:%d level1:%d level2:%d\n",
++            temp, g_mcu_data->fan_data.trig_temp_level0,
++            g_mcu_data->fan_data.trig_temp_level1,
++            g_mcu_data->fan_data.trig_temp_level2);
++}
++
++void fan_level_set(struct mcu_data *ug_mcu_data)
++{
++    struct mcu_fan_data *fan_data = &g_mcu_data->fan_data;
++    int temp = -EINVAL;
++
++    if (ug_mcu_data->board == KHADAS_BOARD_EDGE2)
++        temp = rk_get_temperature();
++    else
++        temp = fan_data->trig_temp_level0;
++
++    if (temp != -EINVAL) {
++        if (temp < ug_mcu_data->fan_data.trig_temp_level0)
++            mcu_fan_level_set(fan_data, 0);
++        else if (temp < ug_mcu_data->fan_data.trig_temp_level1)
++            mcu_fan_level_set(fan_data, 1);
++        else if (temp < ug_mcu_data->fan_data.trig_temp_level2)
++            mcu_fan_level_set(fan_data, 2);
++        else
++            mcu_fan_level_set(fan_data, 3);
++    }
++}
++
++static ssize_t show_fan_trigger_low(struct class *cls,
++        struct class_attribute *attr, char *buf)
++{
++    return sprintf(buf,
++            "Fan trigger low speed temperature:%d\n",
++            g_mcu_data->fan_data.trig_temp_level0);
++}
++
++static ssize_t store_fan_trigger_low(struct class *cls,
++        struct class_attribute *attr,
++        const char *buf, size_t count)
++{
++    int trigger;
++
++    if (kstrtoint(buf, 0, &trigger))
++        return -EINVAL;
++
++    if (trigger >= g_mcu_data->fan_data.trig_temp_level1) {
++        pr_err("Invalid parameter\n");
++        return -EINVAL;
++    }
++
++    g_mcu_data->fan_data.trig_temp_level0 = trigger;
++
++    fan_level_set(g_mcu_data);
++
++    return count;
++}
++
++static ssize_t show_fan_trigger_mid(struct class *cls,
++        struct class_attribute *attr, char *buf)
++{
++    return sprintf(buf,
++            "Fan trigger mid speed temperature:%d\n",
++            g_mcu_data->fan_data.trig_temp_level1);
++}
++
++static ssize_t store_fan_trigger_mid(struct class *cls,
++        struct class_attribute *attr,
++        const char *buf, size_t count)
++{
++    int trigger;
++
++    if (kstrtoint(buf, 0, &trigger))
++        return -EINVAL;
++
++    if (trigger >= g_mcu_data->fan_data.trig_temp_level2 ||
++            trigger <= g_mcu_data->fan_data.trig_temp_level0){
++        pr_err("Invalid parameter\n");
++        return -EINVAL;
++    }
++
++    g_mcu_data->fan_data.trig_temp_level1 = trigger;
++
++    fan_level_set(g_mcu_data);
++
++    return count;
++}
++
++static ssize_t show_fan_trigger_high(struct class *cls,
++        struct class_attribute *attr, char *buf)
++{
++    return sprintf(buf,
++            "Fan trigger high speed temperature:%d\n",
++            g_mcu_data->fan_data.trig_temp_level2);
++}
++
++static ssize_t store_fan_trigger_high(struct class *cls,
++        struct class_attribute *attr,
++        const char *buf, size_t count)
++{
++    int trigger;
++
++    if (kstrtoint(buf, 0, &trigger))
++        return -EINVAL;
++
++    if (trigger <= g_mcu_data->fan_data.trig_temp_level1) {
++        pr_err("Invalid parameter\n");
++        return -EINVAL;
++    }
++
++    g_mcu_data->fan_data.trig_temp_level2 = trigger;
++
++    fan_level_set(g_mcu_data);
++
++    return count;
++}
++
+ static ssize_t store_mcu_poweroff(struct class *cls,struct class_attribute *attr,
+ 				const char *buf, size_t count)
+ {
+@@ -141,6 +510,19 @@ static ssize_t store_mcu_rst(struct class *cls, struct class_attribute *attr,
+ 	return count;
+ }
+ 
++static struct class_attribute fan_class_attrs[] = {
++    __ATTR(enable, 0644, show_fan_enable, store_fan_enable),
++    __ATTR(mode, 0644, show_fan_mode, store_fan_mode),
++    __ATTR(level, 0644, show_fan_level, store_fan_level),
++    __ATTR(trigger_temp_low, 0644,
++            show_fan_trigger_low, store_fan_trigger_low),
++    __ATTR(trigger_temp_mid, 0644,
++            show_fan_trigger_mid, store_fan_trigger_mid),
++    __ATTR(trigger_temp_high, 0644,
++            show_fan_trigger_high, store_fan_trigger_high),
++    __ATTR(temp, 0644, show_fan_temp, NULL),
++};
++
+ static struct class_attribute mcu_class_attrs[] = {
+ 	__ATTR(poweroff, 0644, NULL, store_mcu_poweroff),
+ 	__ATTR(rst, 0644, NULL, store_mcu_rst),
+@@ -160,14 +542,61 @@ static void create_mcu_attrs(void) {
+ 			pr_err("create mcu attribute %s fail\n",
+ 							mcu_class_attrs[i].attr.name);
+ 	}
++
++	if (is_mcu_fan_control_supported()) {
++		g_mcu_data->fan_data.fan_class = class_create(THIS_MODULE, "fan");
++			if (IS_ERR(g_mcu_data->fan_data.fan_class)) {
++				pr_err("create fan_class debug class fail\n");
++				return;
++			}
++			for (i = 0; i < ARRAY_SIZE(fan_class_attrs); i++) {
++				if (class_create_file(g_mcu_data->fan_data.fan_class,
++                        &fan_class_attrs[i]))
++					pr_err("create fan attribute %s fail\n", fan_class_attrs[i].attr.name);
++        }
++	}
+ }
+ 
+ static int mcu_parse_dt(struct device *dev)
+ {
+ 	int ret = 0;
++	const char *hwver = NULL;
+ 
+ 	if (NULL == dev) return -EINVAL;
+ 
++	ret = of_property_read_string(dev->of_node, "hwver", &hwver);
++	if (ret < 0) {
++			return 0;
++	} else {
++			if (strstr(hwver, "EDGE2"))
++					g_mcu_data->board = KHADAS_BOARD_EDGE2;
++			else
++					g_mcu_data->board = KHADAS_BOARD_NONE;
++
++			if (g_mcu_data->board == KHADAS_BOARD_EDGE2) {
++					if (strcmp(hwver, "EDGE2.V10") == 0)
++							g_mcu_data->hwver = KHADAS_BOARD_HWVER_V10;
++			}
++	}
++
++		ret = of_property_read_u32(dev->of_node,
++            "fan,trig_temp_level0",
++            &g_mcu_data->fan_data.trig_temp_level0);
++    if (ret < 0)
++        g_mcu_data->fan_data.trig_temp_level0 =
++            MCU_FAN_TRIG_TEMP_LEVEL0;
++    ret = of_property_read_u32(dev->of_node,
++            "fan,trig_temp_level1",
++            &g_mcu_data->fan_data.trig_temp_level1);
++    if (ret < 0)
++        g_mcu_data->fan_data.trig_temp_level1 =
++            MCU_FAN_TRIG_TEMP_LEVEL1;
++    ret = of_property_read_u32(dev->of_node,
++            "fan,trig_temp_level2",&g_mcu_data->fan_data.trig_temp_level2);
++    if (ret < 0){
++        g_mcu_data->fan_data.trig_temp_level2 =MCU_FAN_TRIG_TEMP_LEVEL2;
++	}
++
+ 	return ret;
+ }
+ 
+@@ -187,6 +616,13 @@ static int mcu_probe(struct i2c_client *client, const struct i2c_device_id *id)
+ 
+ 	g_mcu_data->client = client;
+ 
++	g_mcu_data->fan_data.mode = MCU_FAN_MODE_AUTO;
++	g_mcu_data->fan_data.level = MCU_FAN_LEVEL_0;
++	g_mcu_data->fan_data.enable = MCU_FAN_STATUS_ENABLE;
++
++	INIT_DELAYED_WORK(&g_mcu_data->fan_data.work, fan_work_func);
++	mcu_fan_level_set(&g_mcu_data->fan_data, 0);
++	schedule_delayed_work(&g_mcu_data->fan_data.work, MCU_FAN_LOOP_SECS);
+ 	create_mcu_attrs();
+ 
+ 	return 0;
+@@ -198,27 +634,33 @@ static int mcu_remove(struct i2c_client *client)
+ 	return 0;
+ }
+ 
+-static void mcu_shutdown(struct i2c_client *client)
++static void khadas_fan_shutdown(struct i2c_client *client)
+ {
+-	kfree(g_mcu_data);
++    g_mcu_data->fan_data.enable = MCU_FAN_STATUS_DISABLE;
++    khadas_fan_set(&g_mcu_data->fan_data);
+ }
+ 
+ #ifdef CONFIG_PM_SLEEP
+-static int mcu_suspend(struct device *dev)
++static int khadas_fan_suspend(struct device *dev)
+ {
+-	return 0;
++    cancel_delayed_work(&g_mcu_data->fan_data.work);
++    mcu_fan_level_set(&g_mcu_data->fan_data, 0);
++
++    return 0;
+ }
+ 
+-static int mcu_resume(struct device *dev)
++static int khadas_fan_resume(struct device *dev)
+ {
+-	return 0;
++    khadas_fan_set(&g_mcu_data->fan_data);
++
++    return 0;
+ }
+ 
+-static const struct dev_pm_ops mcu_dev_pm_ops = {
+-	SET_SYSTEM_SLEEP_PM_OPS(mcu_suspend, mcu_resume)
++static const struct dev_pm_ops fan_dev_pm_ops = {
++    SET_SYSTEM_SLEEP_PM_OPS(khadas_fan_suspend, khadas_fan_resume)
+ };
+ 
+-#define MCU_PM_OPS (&(mcu_dev_pm_ops))
++#define FAN_PM_OPS (&(fan_dev_pm_ops))
+ 
+ #endif
+ 
+@@ -241,12 +683,12 @@ struct i2c_driver mcu_driver = {
+ 		.owner  = THIS_MODULE,
+ 		.of_match_table = of_match_ptr(mcu_dt_ids),
+ #ifdef CONFIG_PM_SLEEP
+-		.pm = MCU_PM_OPS,
++		.pm = FAN_PM_OPS,
+ #endif
+ 	},
+ 	.probe		= mcu_probe,
+ 	.remove 	= mcu_remove,
+-	.shutdown = mcu_shutdown,
++	.shutdown = khadas_fan_shutdown,
+ 	.id_table	= mcu_id,
+ };
+ module_i2c_driver(mcu_driver);
+diff --git a/drivers/thermal/rockchip_thermal.c b/drivers/thermal/rockchip_thermal.c
+index 4e8b45219431..73a7e54b6051 100644
+--- a/drivers/thermal/rockchip_thermal.c
++++ b/drivers/thermal/rockchip_thermal.c
+@@ -328,6 +328,8 @@ struct tsadc_table {
+ 	int temp;
+ };
+ 
++static struct rockchip_thermal_sensor  *g_tsensor_data_ptr;
++
+ static const struct tsadc_table rv1106_code_table[] = {
+ 	{0, -40000},
+ 	{396, -40000},
+@@ -1854,6 +1856,20 @@ static int rockchip_thermal_get_temp(void *_sensor, int *out_temp)
+ 	return retval;
+ }
+ 
++int rk_get_temperature(void)
++{
++	int temp;
++	int ret;
++
++	ret = rockchip_thermal_get_temp(g_tsensor_data_ptr, &temp);
++		if (ret) {
++			pr_debug("rk_get_temp failed!\n");
++			return ret;
++		}
++	     return temp / 1000;
++}
++EXPORT_SYMBOL(rk_get_temperature);
++
+ static const struct thermal_zone_of_device_ops rockchip_of_thermal_ops = {
+ 	.get_temp = rockchip_thermal_get_temp,
+ 	.set_trips = rockchip_thermal_set_trips,
+@@ -2198,6 +2214,7 @@ static int rockchip_thermal_probe(struct platform_device *pdev)
+ 	thermal->panic_nb.notifier_call = rockchip_thermal_panic;
+ 	atomic_notifier_chain_register(&panic_notifier_list,
+ 				       &thermal->panic_nb);
++	g_tsensor_data_ptr = &thermal->sensors[0];
+ 
+ 	dev_info(&pdev->dev, "tsadc is probed successfully!\n");
+ 
+-- 
+Armbian
+
+
+From 11163f5b39499a02d17efcbea459289e550cf9ad Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Fri, 1 Jul 2022 15:21:22 +0800
+Subject: Edge2: WIFI: configure WiFi to dynamically load modules
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: I1d289465b87137044d723ce8786c9b0ebfe30dfb
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 13 +++++-----
+ arch/arm64/configs/kedges_defconfig                   |  4 +--
+ 2 files changed, 9 insertions(+), 8 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index d25c29ccdb00..af36d6db66e3 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -143,7 +143,7 @@ vcc3v3_pcie20: vcc3v3-pcie20 {
+ 		regulator-min-microvolt = <3300000>;
+ 		regulator-max-microvolt = <3300000>;
+ 		enable-active-high;
+-		gpios = <&gpio4 RK_PB1 GPIO_ACTIVE_HIGH>;
++		gpios = <&gpio0 RK_PC7 GPIO_ACTIVE_HIGH>;
+ 		startup-delay-us = <5000>;
+ 		vin-supply = <&vcc12v_dcin>;
+ 	};
+@@ -197,9 +197,9 @@ wireless_wlan: wireless-wlan {
+ 		compatible = "wlan-platdata";
+ 		wifi_chip_type = "ap6275p";
+ 		pinctrl-names = "default";
+-		pinctrl-0 = <&wifi_host_wake_irq>, <&wifi_poweren_gpio>;
++		pinctrl-0 = <&wifi_host_wake_irq>;
+ 		WIFI,host_wake_irq = <&gpio0 RK_PA0 GPIO_ACTIVE_HIGH>;
+-		WIFI,poweren_gpio = <&gpio0 RK_PC7 GPIO_ACTIVE_HIGH>;
++	//	WIFI,poweren_gpio = <&gpio0 RK_PC7 GPIO_ACTIVE_HIGH>;
+ 		status = "okay";
+ 	};
+ 
+@@ -641,6 +641,7 @@ &pcie2x1l1 {
+ &pcie2x1l2 {
+ //	reset-gpios = <&gpio4 RK_PC1 GPIO_ACTIVE_HIGH>;
+ 	reset-gpios = <&gpio3 RK_PD1 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc3v3_pcie20>;
+ 	rockchip,skip-scan-in-resume;
+ 	status = "okay";
+ };
+@@ -745,9 +746,9 @@ wifi_host_wake_irq: wifi-host-wake-irq {
+ 			rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_down>;
+ 		};
+ 
+-		wifi_poweren_gpio: wifi-poweren-gpio {
+-			rockchip,pins = <0 RK_PC7 RK_FUNC_GPIO &pcfg_pull_up>;
+-		};
++	//	wifi_poweren_gpio: wifi-poweren-gpio {
++	//		rockchip,pins = <0 RK_PC7 RK_FUNC_GPIO &pcfg_pull_up>;
++	//	};
+ 	};
+ };
+ 
+diff --git a/arch/arm64/configs/kedges_defconfig b/arch/arm64/configs/kedges_defconfig
+index ad7439f1785f..79c327af8e9d 100644
+--- a/arch/arm64/configs/kedges_defconfig
++++ b/arch/arm64/configs/kedges_defconfig
+@@ -183,8 +183,8 @@ CONFIG_ROCKCHIP_PHY=y
+ CONFIG_USB_RTL8150=y
+ CONFIG_USB_RTL8152=y
+ CONFIG_WL_ROCKCHIP=y
+-CONFIG_WIFI_LOAD_DRIVER_WHEN_KERNEL_BOOTUP=y
+-CONFIG_AP6XXX=y
++CONFIG_WIFI_BUILD_MODULE=y
++CONFIG_AP6XXX=m
+ CONFIG_BCMDHD_PCIE=y
+ CONFIG_BCMDHD_FW_PATH="/lib/firmware/brcm/fw_bcmdhd.bin"
+ CONFIG_BCMDHD_NVRAM_PATH="/lib/firmware/brcm/nvram.txt"
+-- 
+Armbian
+
+
+From 490f9f937b2bfc55151442c64e001be9b2de0268 Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Sun, 3 Jul 2022 11:02:30 +0800
+Subject: arm64: dts: rockchip: Edge2: modify power pin of SD card
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: I413ef6d38f03f17579801007ab577a8f9187ee75
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index af36d6db66e3..8c26cef28306 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -170,7 +170,7 @@ vcc_sd: vcc-sd {
+ 		regulator-min-microvolt = <3300000>;
+ 		regulator-max-microvolt = <3300000>;
+ 		enable-active-high;
+-		gpio = <&gpio0 RK_PC5 GPIO_ACTIVE_HIGH>;
++		gpio = <&gpio1 RK_PB6 GPIO_ACTIVE_HIGH>;
+ 		vin-supply = <&vcc_3v3_s3>;
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&vcc_sd_en>;
+-- 
+Armbian
+
+
+From b57eb137c9ee4c821e1b75b0b94e59a55d03063e Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Tue, 19 Jul 2022 11:14:39 +0800
+Subject: arm64: dts: rockchip: Edge2: HDMI: modify the enable
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: I742519d06490d297563ec2bfe048f86a5e2a5900
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 8c26cef28306..54378b6eb309 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -348,7 +348,7 @@ &route_dsi1 {
+ //};
+ 
+ &hdmi0 {
+-	enable-gpios = <&gpio1 RK_PA5 GPIO_ACTIVE_HIGH>;
++	enable-gpios = <&gpio4 RK_PB1 GPIO_ACTIVE_HIGH>;
+ 	status = "okay";
+ };
+ 
+@@ -539,7 +539,7 @@ mpu6500_gyro: mpu_gyro@68 {
+ &i2c6 {
+ 	status = "okay";
+ 	pinctrl-names = "default";
+-	pinctrl-0 = <&i2c6m3_xfer>;
++	pinctrl-0 = <&i2c6m0_xfer>;
+ 
+ 	mcu: khadas-mcu@18 {
+ 		compatible = "khadas-mcu";
+-- 
+Armbian
+
+
+From 5112645a85889dd4069510f8906234d104ab6e67 Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Mon, 4 Jul 2022 09:48:52 +0800
+Subject: arm64: dts: rockchip: Edge2: mount fusb302 to i2c2
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: Ie13b21b8ec92a6e090348000a9d3ff8c610d9b82
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 142 +++++-----
+ 1 file changed, 72 insertions(+), 70 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 54378b6eb309..e26b92dfd61d 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -425,6 +425,78 @@ regulator-state-mem {
+         };
+     };
+ 
++    usbc0: fusb302@22 {
++        compatible = "fcs,fusb302";
++        reg = <0x22>;
++        interrupt-parent = <&gpio1>;
++        interrupts = <RK_PB5 IRQ_TYPE_LEVEL_LOW>;
++        int-n-gpios = <&gpio1 RK_PB5 GPIO_ACTIVE_LOW>;
++        pinctrl-names = "default";
++        pinctrl-0 = <&usbc0_int>;
++        vbus-supply = <&vbus5v0_typec>;
++        status = "okay";
++
++        ports {
++            #address-cells = <1>;
++            #size-cells = <0>;
++
++            port@0 {
++                reg = <0>;
++                usbc0_role_sw: endpoint@0 {
++                    remote-endpoint = <&dwc3_0_role_switch>;
++                };
++            };
++        };
++
++        usb_con: connector {
++            compatible = "usb-c-connector";
++            label = "USB-C";
++            data-role = "dual";
++            power-role = "dual";
++            try-power-role = "sink";
++            op-sink-microwatt = <1000000>;
++            sink-pdos =
++                <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)
++                 PDO_FIXED(9000, 3000, PDO_FIXED_USB_COMM)
++                 PDO_FIXED(12000, 3000, PDO_FIXED_USB_COMM)
++                 PDO_FIXED(15000, 3000, PDO_FIXED_USB_COMM)
++                 PDO_FIXED(18000, 3000, PDO_FIXED_USB_COMM)
++                 PDO_FIXED(20000, 3000, PDO_FIXED_USB_COMM)>;
++            source-pdos =
++                <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>;
++
++            altmodes {
++                #address-cells = <1>;
++                #size-cells = <0>;
++
++                altmode@0 {
++                    reg = <0>;
++                    svid = <0xff01>;
++                    vdo = <0xffffffff>;
++                };
++            };
++
++             ports {
++                #address-cells = <1>;
++                #size-cells = <0>;
++
++                port@0 {
++                    reg = <0>;
++                    usbc0_orien_sw: endpoint {
++                        remote-endpoint = <&usbdp_phy0_orientation_switch>;
++                    };
++                };
++
++                port@1 {
++                    reg = <1>;
++                    dp_altmode_mux: endpoint {
++                        remote-endpoint = <&usbdp_phy0_dp_altmode_mux>;
++                    };
++                };
++            };
++        };
++    };
++
+ };
+ 
+ &reboot_mode {
+@@ -552,76 +624,6 @@ mcu: khadas-mcu@18 {
+ 		hwver = "EDGE2.V10";
+ 
+ 	};
+-
+-	usbc0: fusb302@22 {
+-		compatible = "fcs,fusb302";
+-		reg = <0x22>;
+-		interrupt-parent = <&gpio0>;
+-		interrupts = <RK_PC6 IRQ_TYPE_LEVEL_LOW>;
+-		int-n-gpios = <&gpio0 RK_PC6 GPIO_ACTIVE_LOW>;
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&usbc0_int>;
+-		vbus-supply = <&vbus5v0_typec>;
+-		status = "okay";
+-
+-		ports {
+-			#address-cells = <1>;
+-			#size-cells = <0>;
+-
+-			port@0 {
+-				reg = <0>;
+-				usbc0_role_sw: endpoint@0 {
+-					remote-endpoint = <&dwc3_0_role_switch>;
+-				};
+-			};
+-		};
+-
+-		usb_con: connector {
+-			compatible = "usb-c-connector";
+-			label = "USB-C";
+-			data-role = "dual";
+-			power-role = "dual";
+-			try-power-role = "sink";
+-			op-sink-microwatt = <1000000>;
+-			sink-pdos =
+-				<PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)
+-				 PDO_FIXED(9000, 3000, PDO_FIXED_USB_COMM)
+-				 PDO_FIXED(12000, 3000, PDO_FIXED_USB_COMM)>;
+-			source-pdos =
+-				<PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>;
+-
+-			altmodes {
+-				#address-cells = <1>;
+-				#size-cells = <0>;
+-
+-				altmode@0 {
+-					reg = <0>;
+-					svid = <0xff01>;
+-					vdo = <0xffffffff>;
+-				};
+-			};
+-
+-			ports {
+-				#address-cells = <1>;
+-				#size-cells = <0>;
+-
+-				port@0 {
+-					reg = <0>;
+-					usbc0_orien_sw: endpoint {
+-						remote-endpoint = <&usbdp_phy0_orientation_switch>;
+-					};
+-				};
+-
+-				port@1 {
+-					reg = <1>;
+-					dp_altmode_mux: endpoint {
+-						remote-endpoint = <&usbdp_phy0_dp_altmode_mux>;
+-					};
+-				};
+-			};
+-		};
+-	};
+-
+ 	pt7c4363: pt7c4363@51 {
+ 		compatible = "haoyu,hym8563";
+ 		reg = <0x51>;
+-- 
+Armbian
+
+
+From eb6eea26bca7ea7acd4737dc3c74c611d90ec16e Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Mon, 4 Jul 2022 10:10:44 +0800
+Subject: arm64: dts: rockchip: Edge2: modify the pin of USB power
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: Ia0f2aef282e370d57fac4524c36a5c2b2fea9603
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index e26b92dfd61d..1b84fa8c6c23 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -156,7 +156,7 @@ vcc5v0_host: vcc5v0-host {
+ 		regulator-min-microvolt = <5000000>;
+ 		regulator-max-microvolt = <5000000>;
+ 		enable-active-high;
+-		gpio = <&gpio4 RK_PA4 GPIO_ACTIVE_HIGH>;
++		gpio = <&gpio1 RK_PB1 GPIO_ACTIVE_HIGH>;
+ 		vin-supply = <&vcc5v0_usb>;
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&vcc5v0_host_en>;
+@@ -704,7 +704,7 @@ blue_led_gpio: blue-led-gpio {
+ 
+ 	usb {
+ 		vcc5v0_host_en: vcc5v0-host-en {
+-			rockchip,pins = <4 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
++			rockchip,pins = <1 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 	};
+ 
+-- 
+Armbian
+
+
+From 4bce0edda0e02d6eb8c29bb445fa69e58a5f56e2 Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Mon, 4 Jul 2022 10:35:06 +0800
+Subject: arm64: dts: rockchip: Edge2: modify the pin of typec0 int
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: I3c1054ea39831927dd2c9c1561554b86a0ca47f9
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 1b84fa8c6c23..19cebdd854f3 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -716,7 +716,7 @@ vcc_sd_en: vcc-sd-en {
+ 
+ 	usb-typec {
+ 		usbc0_int: usbc0-int {
+-			rockchip,pins = <0 RK_PC6 RK_FUNC_GPIO &pcfg_pull_up>;
++			rockchip,pins = <1 RK_PB5 RK_FUNC_GPIO &pcfg_pull_up>;
+ 		};
+ 
+ 		typec5v_pwren: typec5v-pwren {
+-- 
+Armbian
+
+
+From f56d8b508a072d24c02b70a6ff1fdaaa6f9608d3 Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Mon, 4 Jul 2022 11:05:53 +0800
+Subject: arm64: dts: rockchip: Edge2: modify the power pin of WiFi
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: Icf0e8b0a8f5be6243e9ddce8863d1a02fa3c6410
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 19cebdd854f3..392e74ff2e83 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -143,7 +143,7 @@ vcc3v3_pcie20: vcc3v3-pcie20 {
+ 		regulator-min-microvolt = <3300000>;
+ 		regulator-max-microvolt = <3300000>;
+ 		enable-active-high;
+-		gpios = <&gpio0 RK_PC7 GPIO_ACTIVE_HIGH>;
++		gpios = <&gpio0 RK_PC4 GPIO_ACTIVE_HIGH>;
+ 		startup-delay-us = <5000>;
+ 		vin-supply = <&vcc12v_dcin>;
+ 	};
+-- 
+Armbian
+
+
+From fed21b6e4e4a4f33e3efa00e260fbc6666cd0bc4 Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Mon, 4 Jul 2022 12:37:25 +0800
+Subject: arm64: dts: rockchip: Edge2: RTC: configure pt7c4363 to i2c2
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: I81edd9b9a537f75677d8fa6c7a85bf8e9b72cbdf
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 16 +++++-----
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 392e74ff2e83..7d11aa804095 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -497,6 +497,14 @@ dp_altmode_mux: endpoint {
+         };
+     };
+ 
++    pt7c4363: pt7c4363@51 {
++        compatible = "haoyu,hym8563";
++        reg = <0x51>;
++        #clock-cells = <0>;
++        clock-frequency = <32768>;
++        clock-output-names = "pt7c4363";
++        wakeup-source;
++    };
+ };
+ 
+ &reboot_mode {
+@@ -624,14 +632,6 @@ mcu: khadas-mcu@18 {
+ 		hwver = "EDGE2.V10";
+ 
+ 	};
+-	pt7c4363: pt7c4363@51 {
+-		compatible = "haoyu,hym8563";
+-		reg = <0x51>;
+-		#clock-cells = <0>;
+-		clock-frequency = <32768>;
+-		clock-output-names = "pt7c4363";
+-		wakeup-source;
+-	};
+ };
+ 
+ &pcie2x1l1 {
+-- 
+Armbian
+
+
+From 4b03cac2e9ae4ff2e2d5c9f88c15333ebae27aaf Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Mon, 4 Jul 2022 15:20:52 +0800
+Subject: arm64: dts: rockchip: Edge2: fix khadas RGB led
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: I79b3235a3f8543927717ca4b806ebc8775ea4ab9
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 7d11aa804095..27ad51bf4237 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -82,21 +82,21 @@ leds {
+ 		pinctrl-0 = <&red_led_gpio &green_led_gpio &blue_led_gpio>;
+ 
+ 		red_led {
+-			gpios = <&gpio4 RK_PB4 GPIO_ACTIVE_LOW>;
++			gpios = <&gpio4 RK_PB4 GPIO_ACTIVE_HIGH>;
+ 			label = "red_led";
+ 			linux,default-trigger = "none";
+ 			default-state = "off";
+ 		};
+ 
+ 		green_led {
+-			gpios = <&gpio4 RK_PB2 GPIO_ACTIVE_LOW>;
++			gpios = <&gpio4 RK_PB2 GPIO_ACTIVE_HIGH>;
+ 			label = "green_led";
+ 			linux,default-trigger = "default-on";
+ 			default-state = "on";
+ 		};
+ 
+ 		blue_led {
+-			gpios = <&gpio4 RK_PB3 GPIO_ACTIVE_LOW>;
++			gpios = <&gpio4 RK_PB3 GPIO_ACTIVE_HIGH>;
+ 			label = "blue_led";
+ 			linux,default-trigger = "none";
+ 			default-state = "off";
+-- 
+Armbian
+
+
+From 5088b579d83c352fc67bd26d5720759282901332 Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Mon, 4 Jul 2022 16:44:22 +0800
+Subject: Edge2: fix MCU and fan
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: Id6d9980f32b281db7156d5699524c7b4134fc59c
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 24 +++++-----
+ drivers/misc/khadas-mcu.c                             | 10 ++--
+ 2 files changed, 16 insertions(+), 18 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 27ad51bf4237..b8e8fc3611be 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -505,6 +505,18 @@ pt7c4363: pt7c4363@51 {
+         clock-output-names = "pt7c4363";
+         wakeup-source;
+     };
++
++    mcu: khadas-mcu@18 {
++        compatible = "khadas-mcu";
++        status = "okay";
++        reg = <0x18>;
++        fan,trig_temp_level0 = <50>;
++        fan,trig_temp_level1 = <60>;
++        fan,trig_temp_level2 = <70>;
++        fan,trig_temp_level3 = <80>;
++        hwver = "EDGE2.V11";
++
++    };
+ };
+ 
+ &reboot_mode {
+@@ -620,18 +632,6 @@ &i2c6 {
+ 	status = "okay";
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&i2c6m0_xfer>;
+-
+-	mcu: khadas-mcu@18 {
+-		compatible = "khadas-mcu";
+-		status = "okay";
+-		reg = <0x18>;
+-		fan,trig_temp_level0 = <50>;
+-		fan,trig_temp_level1 = <60>;
+-		fan,trig_temp_level2 = <70>;
+-		fan,trig_temp_level3 = <80>;
+-		hwver = "EDGE2.V10";
+-
+-	};
+ };
+ 
+ &pcie2x1l1 {
+diff --git a/drivers/misc/khadas-mcu.c b/drivers/misc/khadas-mcu.c
+index 67c3d6a6ee91..03f4eedbb62d 100644
+--- a/drivers/misc/khadas-mcu.c
++++ b/drivers/misc/khadas-mcu.c
+@@ -50,7 +50,7 @@ enum khadas_board {
+ 
+ enum khadas_board_hwver {
+ 	KHADAS_BOARD_HWVER_NONE = 0,
+-	KHADAS_BOARD_HWVER_V10
++	KHADAS_BOARD_HWVER_V11
+ };
+ 
+ enum mcu_fan_mode {
+@@ -161,7 +161,7 @@ static int is_mcu_fan_control_supported(void)
+ 	// MCU FAN control is supported for:
+ 	// 1. Khadas EDGE2
+ 	if (g_mcu_data->board == KHADAS_BOARD_EDGE2) {
+-		if (g_mcu_data->hwver >= KHADAS_BOARD_HWVER_V10)
++		if (g_mcu_data->hwver >= KHADAS_BOARD_HWVER_V11)
+ 			return 1;
+ 		else
+ 			return 0;
+@@ -207,10 +207,8 @@ static void fan_work_func(struct work_struct *_work)
+         struct mcu_fan_data *fan_data = &g_mcu_data->fan_data;
+ 
+ 		if (g_mcu_data->board == KHADAS_BOARD_EDGE2) {
+-				printk("temp start23!!\r\n");
+             temp = rk_get_temperature();
+ 		} else {
+-			printk("temp start!!\r\n");
+            temp = fan_data->trig_temp_level0;
+ 		}
+ 
+@@ -574,8 +572,8 @@ static int mcu_parse_dt(struct device *dev)
+ 					g_mcu_data->board = KHADAS_BOARD_NONE;
+ 
+ 			if (g_mcu_data->board == KHADAS_BOARD_EDGE2) {
+-					if (strcmp(hwver, "EDGE2.V10") == 0)
+-							g_mcu_data->hwver = KHADAS_BOARD_HWVER_V10;
++					if (strcmp(hwver, "EDGE2.V11") == 0)
++							g_mcu_data->hwver = KHADAS_BOARD_HWVER_V11;
+ 			}
+ 	}
+ 
+-- 
+Armbian
+
+
+From 91f9a2e4ee7e6b955f876d007f625f9c36c45020 Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Tue, 19 Jul 2022 11:31:09 +0800
+Subject: arm64: dts: rockchip: Edge2: fix khadas TS050 TP
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: I9fd8d7a2ed77511d29aefbca0388d9a9c559bcf0
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 26 +++++++---
+ 1 file changed, 19 insertions(+), 7 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index b8e8fc3611be..1bf9dedf6521 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -262,7 +262,7 @@ &dp0_sound{
+ };
+ 
+ &dsi0 {
+-	status = "okay";
++	status = "disabled";
+ 	reset-delay-ms = <20>;
+ 	reset-gpios = <&gpio4 RK_PA3 GPIO_ACTIVE_HIGH>;
+ 	pinctrl-names = "default";
+@@ -271,7 +271,7 @@ &dsi0 {
+ };
+ 
+ &dsi0_panel {
+-	status = "okay";
++	status = "disabled";
+ 	power-supply = <&vcc3v3_lcd_en>;
+ };
+ 
+@@ -280,7 +280,7 @@ &dsi0_in_vp2 {
+ };
+ 
+ &dsi0_in_vp3 {
+-	status = "okay";
++	status = "disabled";
+ };
+ 
+ &hdmi0_sound {
+@@ -288,12 +288,12 @@ &hdmi0_sound {
+ };
+ 
+ &route_dsi0 {
+-	status = "okay";
++	status = "disabled";
+ 	connect = <&vp3_out_dsi0>;
+ };
+ 
+ &mipi_dcphy0 {
+-	status = "okay";
++	status = "disabled";
+ };
+ 
+ &dsi1 {
+@@ -632,6 +632,18 @@ &i2c6 {
+ 	status = "okay";
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&i2c6m0_xfer>;
++
++	ft5336@38 {
++		compatible = "edt,edt-ft5336", "ft5x06";
++		reg = <0x38>;
++		interrupt-parent = <&gpio0>;
++		interrupts = <RK_PC6 IRQ_TYPE_EDGE_FALLING>;
++		reset-gpio = <&gpio0 RK_PC5 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&tp_rst_gpio>;
++		status = "okay";
++	};
++
+ };
+ 
+ &pcie2x1l1 {
+@@ -710,7 +722,7 @@ vcc5v0_host_en: vcc5v0-host-en {
+ 
+ 	vcc_sd {
+ 		vcc_sd_en: vcc-sd-en {
+-			rockchip,pins = <0 RK_PC5 RK_FUNC_GPIO &pcfg_pull_up>;
++			rockchip,pins = <1 RK_PB6 RK_FUNC_GPIO &pcfg_pull_up>;
+ 		};
+ 	};
+ 
+@@ -726,7 +738,7 @@ typec5v_pwren: typec5v-pwren {
+ 
+ 	ft5336 {
+ 		tp_rst_gpio: tp-rst-gpio {
+-			rockchip,pins = <1 RK_PB4 RK_FUNC_GPIO &pcfg_pull_none>;
++			rockchip,pins = <0 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>;
+        };
+    };
+ 
+-- 
+Armbian
+
+
+From d70fd7fdea9b1059a375b71852f53036239d6bbe Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Tue, 19 Jul 2022 11:46:37 +0800
+Subject: arm64: dts: rockchip: Edge2: fix khadas mipi lcd panel
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: I3c452421013ec22255a79344848e1f48af884141
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts  | 64 ++++++----
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi |  4 +-
+ 2 files changed, 44 insertions(+), 24 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 1bf9dedf6521..65df29866c69 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -203,12 +203,26 @@ wireless_wlan: wireless-wlan {
+ 		status = "okay";
+ 	};
+ 
+-	vcc3v3_lcd_en: vcc3v3-lcd-en {
++	vcc3v3_lcd1_en: vcc3v3-lcd1-en {
+ 		compatible = "regulator-fixed";
+-		regulator-name = "vcc3v3_lcd_en";
++		regulator-name = "vcc3v3_lcd1_en";
+ 		regulator-min-microvolt = <3300000>;
+ 		regulator-max-microvolt = <3300000>;
+-		gpio = <&gpio0 RK_PC4 GPIO_ACTIVE_HIGH>;
++		gpio = <&gpio4 RK_PA4 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++		regulator-boot-on;
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++
++	};
++
++	vcc3v3_lcd2_en: vcc3v3-lcd2-en {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc3v3_lcd2_en";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		gpio = <&gpio4 RK_PB0 GPIO_ACTIVE_HIGH>;
+ 		enable-active-high;
+ 		regulator-boot-on;
+ 		regulator-state-mem {
+@@ -220,14 +234,14 @@ regulator-state-mem {
+ };
+ 
+ &backlight_mipi0 {
+-	pwms = <&pwm7 0 25000 0>;
+-	power-supply = <&vcc3v3_lcd_en>;
++	pwms = <&pwm12 0 25000 0>;
++	power-supply = <&vcc3v3_lcd1_en>;
+ 	status = "okay";
+ };
+ 
+ &backlight_mipi1 {
+-	pwms = <&pwm12 0 25000 0>;
+-	power-supply = <&vcc3v3_lcd_en>;
++	pwms = <&pwm13 0 25000 0>;
++	power-supply = <&vcc3v3_lcd2_en>;
+ 	status = "disabled";
+ };
+ 
+@@ -262,17 +276,17 @@ &dp0_sound{
+ };
+ 
+ &dsi0 {
+-	status = "disabled";
++	status = "okay";
+ 	reset-delay-ms = <20>;
+ 	reset-gpios = <&gpio4 RK_PA3 GPIO_ACTIVE_HIGH>;
+ 	pinctrl-names = "default";
+-	pinctrl-0 = <&lcd_rst_gpio>;
++	pinctrl-0 = <&lcd1_rst_gpio>;
+ 
+ };
+ 
+ &dsi0_panel {
+-	status = "disabled";
+-	power-supply = <&vcc3v3_lcd_en>;
++	status = "okay";
++	power-supply = <&vcc3v3_lcd1_en>;
+ };
+ 
+ &dsi0_in_vp2 {
+@@ -280,7 +294,7 @@ &dsi0_in_vp2 {
+ };
+ 
+ &dsi0_in_vp3 {
+-	status = "disabled";
++	status = "okay";
+ };
+ 
+ &hdmi0_sound {
+@@ -288,25 +302,25 @@ &hdmi0_sound {
+ };
+ 
+ &route_dsi0 {
+-	status = "disabled";
++	status = "okay";
+ 	connect = <&vp3_out_dsi0>;
+ };
+ 
+ &mipi_dcphy0 {
+-	status = "disabled";
++	status = "okay";
+ };
+ 
+ &dsi1 {
+ 	reset-delay-ms = <20>;
+-	reset-gpios = <&gpio1 RK_PB1 GPIO_ACTIVE_HIGH>;
++	reset-gpios = <&gpio4 RK_PA7 GPIO_ACTIVE_HIGH>;
+ 	pinctrl-names = "default";
+-	pinctrl-0 = <&lcd_rst_gpio1>;
++	pinctrl-0 = <&lcd2_rst_gpio1>;
+ 	status = "disabled";
+ };
+ 
+ &dsi1_panel {
+ 	status = "disabled";
+-	power-supply = <&vcc3v3_lcd_en>;
++	power-supply = <&vcc3v3_lcd2_en>;
+ };
+ 
+ &mipi_dcphy1 {
+@@ -682,11 +696,11 @@ spk_con: spk-con {
+ 	};
+ 
+ 	lcd {
+-		lcd_rst_gpio: lcd-rst-gpio {
+-			rockchip,pins = <1 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
++		lcd1_rst_gpio: lcd1-rst-gpio {
++			rockchip,pins = <4 RK_PA3 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+-		lcd_rst_gpio1: lcd-rst-gpio1 {
+-			rockchip,pins = <1 RK_PB1 RK_FUNC_GPIO &pcfg_pull_up>;
++		lcd2_rst_gpio1: lcd2-rst-gpio1 {
++			rockchip,pins = <4 RK_PA7 RK_FUNC_GPIO &pcfg_pull_up>;
+ 		};
+ 	};
+ 
+@@ -873,7 +887,7 @@ ir_key3 {
+ 
+ &pwm7 {
+ 	pinctrl-0 = <&pwm7m0_pins>;
+-	status = "okay";
++	status = "disabled";
+ };
+ 
+ &pwm12 {
+@@ -881,6 +895,12 @@ &pwm12 {
+ 	status = "okay";
+ };
+ 
++&pwm13 {
++	pinctrl-0 = <&pwm13m1_pins>;
++	status = "okay";
++};
++
++
+ &rockchip_suspend {
+ 
+     rockchip,sleep-mode-config = <
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi
+index 5a2174676012..c06bc4fda155 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi
+@@ -782,7 +782,7 @@ dsi0_panel: panel@0 {
+ 		disp_timings0: display-timings {
+ 			native-mode = <&dsi0_timing0>;
+ 			dsi0_timing0: timing0 {
+-				clock-frequency = <120000000>;
++				clock-frequency = <152198100>;
+ 				hactive = <1080>;
+ 				vactive = <1920>;
+ 				hfront-porch = <104>;
+@@ -1376,7 +1376,7 @@ dsi1_panel: panel@0 {
+ 		disp_timings1: display-timings {
+ 			native-mode = <&dsi1_timing0>;
+ 			dsi1_timing0: timing0 {
+-				clock-frequency = <120000000>;
++				clock-frequency = <152198100>;
+ 				hactive = <1080>;
+ 				vactive = <1920>;
+ 				hfront-porch = <104>;
+-- 
+Armbian
+
+
+From 323551e03c5f47ffdc0ff42bef193003ee1dccc8 Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Tue, 5 Jul 2022 10:43:57 +0800
+Subject: arm64: dts: rockchip: Edge2: fix DP display
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: I50d7644dbde930e7894ba6eee8eba67bae833236
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 65df29866c69..8f67b29850a9 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -472,10 +472,7 @@ usb_con: connector {
+             sink-pdos =
+                 <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)
+                  PDO_FIXED(9000, 3000, PDO_FIXED_USB_COMM)
+-                 PDO_FIXED(12000, 3000, PDO_FIXED_USB_COMM)
+-                 PDO_FIXED(15000, 3000, PDO_FIXED_USB_COMM)
+-                 PDO_FIXED(18000, 3000, PDO_FIXED_USB_COMM)
+-                 PDO_FIXED(20000, 3000, PDO_FIXED_USB_COMM)>;
++                 PDO_FIXED(12000, 3000, PDO_FIXED_USB_COMM)>;
+             source-pdos =
+                 <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>;
+ 
+-- 
+Armbian
+
+
+From 527e99b99d1751b94325747f5655cca02f634f94 Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Tue, 19 Jul 2022 11:52:18 +0800
+Subject: arm64: dts: rockchip: Edge2: fix camera
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: I0f5f4bffcdbf532fb11a80a4e3c72dd9e546c5f8
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi | 219 +++++-----
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts         |  19 -
+ 2 files changed, 104 insertions(+), 134 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi
+index 9e4f755c36c7..c1b0f47e2b51 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi
+@@ -21,7 +21,6 @@ mipi_in_dcphy0: endpoint@1 {
+ 				data-lanes = <1 2 3 4>;
+ 			};
+ 		};
+-
+ 		port@1 {
+ 			reg = <1>;
+ 			#address-cells = <1>;
+@@ -35,6 +34,10 @@ csidcphy0_out: endpoint@0 {
+ 	};
+ };
+ 
++&mipi_dcphy0 {
++	status = "okay";
++};
++
+ &csi2_dcphy1 {
+ 	status = "okay";
+ 
+@@ -65,34 +68,42 @@ csidcphy1_out: endpoint@0 {
+ 	};
+ };
+ 
++&mipi_dcphy1 {
++	status = "okay";
++};
++
+ &csi2_dphy0 {
+-   status = "okay";
+-
+-    ports {
+-        #address-cells = <1>;
+-       #size-cells = <0>;
+-        port@0 {
+-           reg = <0>;
+-            #address-cells = <1>;
+-           #size-cells = <0>;
+-
+-           mipidphy0_in_ucam0: endpoint@1 {
+-               reg = <1>;
+-               remote-endpoint = <&imx415c_out0>;
+-               data-lanes = <1 2 3 4>;
+-           };
+-       };
+-       port@1 {
+-           reg = <1>;
+-           #address-cells = <1>;
+-           #size-cells = <0>;
+-
+-           csidphy0_out: endpoint@0 {
+-               reg = <0>;
+-               remote-endpoint = <&mipi2_csi2_input>;
+-           };
+-       };
+-   };
++	status = "okay";
++
++	ports {
++		#address-cells = <1>;
++		#size-cells = <0>;
++		port@0 {
++			reg = <0>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			mipidphy0_in_ucam0: endpoint@1 {
++				reg = <1>;
++				remote-endpoint = <&imx415c_out0>;
++				data-lanes = <1 2 3 4>;
++			};
++		};
++		port@1 {
++			reg = <1>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			csidphy0_out: endpoint@0 {
++				reg = <0>;
++				remote-endpoint = <&mipi2_csi2_input>;
++			};
++		};
++	};
++};
++
++&csi2_dphy0_hw {
++	status = "okay";
+ };
+ 
+ &i2c4 {
+@@ -118,8 +129,8 @@ imx415b: imx415b@37 {
+ 		clocks = <&cru CLK_MIPI_CAMARAOUT_M1>;
+ 		clock-names = "xvclk";
+ 		power-domains = <&power RK3588_PD_VI>;
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&mipim1_camera1_clk &camb_gpio>;
++		pinctrl-names = "default", "camb_gpios";
++		pinctrl-0 = <&mipim1_camera1_clk>, <&camb_gpio>;
+ 		rockchip,grf = <&sys_grf>;
+ 		reset-gpios = <&gpio1 RK_PB2 GPIO_ACTIVE_LOW>;
+ 		pwdn-gpios = <&gpio1 RK_PB3 GPIO_ACTIVE_LOW>;
+@@ -127,7 +138,6 @@ imx415b: imx415b@37 {
+ 		rockchip,camera-module-facing = "back";
+ 		rockchip,camera-module-name = "CMK-OT2022-PX1";
+ 		rockchip,camera-module-lens-name = "IR0147-50IRC-8M-F20";
+-	//	eeprom-ctrl = <&otp_eeprom>;
+ 		lens-focus = <&aw8601b>;
+ 		port {
+ 			imx415b_out0: endpoint {
+@@ -136,12 +146,6 @@ imx415b_out0: endpoint {
+ 			};
+ 		};
+ 	};
+-
+-//	otp_eeprom: otp_eeprom@50 {
+-//		compatible = "rk,otp_eeprom";
+-//		status = "okay";
+-//		reg = <0x50>;
+-//	};
+ };
+ 
+ &i2c3 {
+@@ -167,8 +171,8 @@ imx415f: imx415f@37 {
+ 		clocks = <&cru CLK_MIPI_CAMARAOUT_M2>;
+ 		clock-names = "xvclk";
+ 		power-domains = <&power RK3588_PD_VI>;
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&mipim1_camera2_clk &camf_gpio>;
++		pinctrl-names = "default", "camf_gpios";
++		pinctrl-0 = <&mipim1_camera2_clk>, <&camf_gpio>;
+ 		rockchip,grf = <&sys_grf>;
+ 		reset-gpios = <&gpio3 RK_PC6 GPIO_ACTIVE_LOW>;
+ 		pwdn-gpios = <&gpio3 RK_PC5 GPIO_ACTIVE_LOW>;
+@@ -176,7 +180,6 @@ imx415f: imx415f@37 {
+ 		rockchip,camera-module-facing = "front";
+ 		rockchip,camera-module-name = "CMK-OT2022-PX1";
+ 		rockchip,camera-module-lens-name = "IR0147-50IRC-8M-F20";
+-//		eeprom-ctrl = <&otp_eeprom_b>;
+ 		lens-focus = <&aw8601f>;
+ 		port {
+ 			imx415f_out1: endpoint {
+@@ -185,12 +188,6 @@ imx415f_out1: endpoint {
+ 			};
+ 		};
+ 	};
+-
+-//	otp_eeprom_b: otp_eeprom_b@50 {
+-//		compatible = "rk,otp_eeprom";
+-//		status = "okay";
+-//		reg = <0x50>;
+-//	};
+ };
+ 
+ &i2c8 {
+@@ -205,7 +202,7 @@ aw8601c: aw8601c@c {
+ 		rockchip,vcm-start-current = <56>;
+ 		rockchip,vcm-rated-current = <96>;
+ 		rockchip,vcm-step-mode = <4>;
+-		rockchip,camera-module-index = <2>;
++		rockchip,camera-module-index = <0>;
+ 		rockchip,camera-module-facing = "back";
+ 	};
+ 
+@@ -214,18 +211,18 @@ imx415: imx415@37 {
+ 		reg = <0x37>;
+ 		clocks = <&cru CLK_MIPI_CAMARAOUT_M3>;
+ 		clock-names = "xvclk";
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&mipim1_camera3_clk &camc_gpio>;
++		pinctrl-names = "default", "camc_gpios";
++		pinctrl-0 = <&mipim1_camera3_clk>, <&camc_gpio>;
+ 		power-domains = <&power RK3588_PD_VI>;
+-		reset-gpios = <&gpio3 RK_PB4 GPIO_ACTIVE_LOW>;
++		reset-gpios = <&gpio3 RK_PB4 GPIO_ACTIVE_LOW>;	
+ 		pwdn-gpios = <&gpio1 RK_PA4 GPIO_ACTIVE_LOW>;
+-		rockchip,camera-module-index = <2>;
++		rockchip,camera-module-index = <0>;
+ 		rockchip,camera-module-facing = "back";
+ 		rockchip,camera-module-name = "CMK-OT2022-PX1";
+ 		rockchip,camera-module-lens-name = "IR0147-50IRC-8M-F20";
+ 		lens-focus = <&aw8601c>;
+ 		port {
+-				imx415c_out0: endpoint {
++			imx415c_out0: endpoint {
+ 				remote-endpoint = <&mipidphy0_in_ucam0>;
+ 				data-lanes = <1 2 3 4>;
+ 			};
+@@ -234,31 +231,23 @@ imx415c_out0: endpoint {
+ };
+ 
+ &pinctrl {
+-   cam {
+-       camf_gpio: camf-gpio {
+-           rockchip,pins =
+-               <3 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>,
+-               <3 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>;
+-       };
+-       camb_gpio: camb-gpio {
+-           rockchip,pins =
+-               <1 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>,
+-               <1 RK_PB3 RK_FUNC_GPIO &pcfg_pull_none>;
+-       };
+-       camc_gpio: camc-gpio {
+-           rockchip,pins =
+-               <3 RK_PB4 RK_FUNC_GPIO &pcfg_pull_none>,
+-               <1 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
+-       };
+-   };
+-};
+-
+-&mipi_dcphy0 {
+-	status = "okay";
+-};
+-
+-&mipi_dcphy1 {
+-	status = "okay";
++	cam {
++		camf_gpio: camf-gpio {
++			rockchip,pins =
++				<3 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>,
++				<3 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++		camb_gpio: camb-gpio {
++			rockchip,pins =
++				<1 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>,
++				<1 RK_PB3 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++		camc_gpio: camc-gpio {
++			rockchip,pins =
++				<3 RK_PB4 RK_FUNC_GPIO &pcfg_pull_none>,
++				<1 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
+ };
+ 
+ &mipi0_csi2 {
+@@ -324,34 +313,34 @@ mipi1_csi2_output: endpoint@0 {
+ };
+ 
+ &mipi2_csi2 {
+-   status = "okay";
+-
+-   ports {
+-       #address-cells = <1>;
+-       #size-cells = <0>;
+-
+-       port@0 {
+-           reg = <0>;
+-           #address-cells = <1>;
+-           #size-cells = <0>;
+-
+-           mipi2_csi2_input: endpoint@1 {
+-               reg = <1>;
+-               remote-endpoint = <&csidphy0_out>;
+-           };
+-       };
+-
+-       port@1 {
+-           reg = <1>;
+-           #address-cells = <1>;
+-           #size-cells = <0>;
+-
+-           mipi2_csi2_output: endpoint@0 {
+-               reg = <0>;
+-               remote-endpoint = <&cif_mipi2_in0>;
+-           };
+-       };
+-   };
++	status = "okay";
++
++	ports {
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		port@0 {
++			reg = <0>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			mipi2_csi2_input: endpoint@1 {
++				reg = <1>;
++				remote-endpoint = <&csidphy0_out>;
++			};
++		};
++
++		port@1 {
++			reg = <1>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			mipi2_csi2_output: endpoint@0 {
++				reg = <0>;
++				remote-endpoint = <&cif_mipi2_in0>;
++			};
++		};
++	};
+ };
+ 
+ &rkcif {
+@@ -388,16 +377,6 @@ cif_mipi_in1: endpoint {
+ 	};
+ };
+ 
+-&rkcif_mipi_lvds2 {
+-    status = "okay";
+-
+-   port {
+-       cif_mipi2_in0: endpoint {
+-           remote-endpoint = <&mipi2_csi2_output>;
+-       };
+-   };
+-};
+-
+ &rkcif_mipi_lvds1_sditf {
+ 	status = "okay";
+ 
+@@ -408,6 +387,16 @@ mipi1_lvds_sditf: endpoint {
+ 	};
+ };
+ 
++&rkcif_mipi_lvds2 {
++	status = "okay";
++
++	port {
++		cif_mipi2_in0: endpoint {
++			remote-endpoint = <&mipi2_csi2_output>;
++		};
++	};
++};
++
+ &rkcif_mipi_lvds2_sditf {
+ 	status = "okay";
+ 
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 8f67b29850a9..49926c83b46b 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -116,15 +116,6 @@ khadas_wdt {
+ //		pwms = <&pwm11 0 50000 0>;
+ //	};
+ 
+-	hall_sensor: hall-mh248 {
+-		compatible = "hall-mh248";
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&mh248_irq_gpio>;
+-		irq-gpio = <&gpio0 RK_PD4 IRQ_TYPE_EDGE_BOTH>;
+-		hall-active = <1>;
+-		status = "disabled";
+-	};
+-
+ 	vbus5v0_typec: vbus5v0-typec {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vbus5v0_typec";
+@@ -701,16 +692,6 @@ lcd2_rst_gpio1: lcd2-rst-gpio1 {
+ 		};
+ 	};
+ 
+-	sensor {
+-		mh248_irq_gpio: mh248_irq_gpio {
+-			rockchip,pins = <0 RK_PD4 RK_FUNC_GPIO &pcfg_pull_up>;
+-		};
+-
+-		mpu6500_irq_gpio: mpu6500_irq_gpio {
+-			rockchip,pins = <3 RK_PB4 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-	};
+-
+ 	leds {
+ 		red_led_gpio: red-led-gpio {
+ 			rockchip,pins = <4 RK_PB4 RK_FUNC_GPIO &pcfg_pull_up>;
+-- 
+Armbian
+
+
+From 553e5b37cb841adfb803d997f3a5cd9eda6dade3 Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Tue, 19 Jul 2022 15:54:13 +0800
+Subject: arm64: dts: Edge2: turn on Bluetooth mic
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: I62690e831153cdb96e51abc5cbaa72c7ae06b392
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 24 ++++++++++
+ 1 file changed, 24 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 49926c83b46b..1e0e271574eb 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -184,6 +184,26 @@ wireless_bluetooth: wireless-bluetooth {
+ 		status = "okay";
+ 	};
+ 
++	bt-sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,format = "dsp_a";
++		simple-audio-card,bitclock-inversion = <1>;
++		simple-audio-card,mclk-fs = <256>;
++		simple-audio-card,name = "rockchip,bt";
++		simple-audio-card,cpu {
++			sound-dai = <&i2s2_2ch>;
++		};
++		simple-audio-card,codec {
++			sound-dai = <&bt_sco>;
++		};
++	};
++
++	bt_sco: bt-sco {
++		compatible = "delta,dfbmcs320";
++		#sound-dai-cells = <0>;
++		status = "okay";
++	};
++
+ 	wireless_wlan: wireless-wlan {
+ 		compatible = "wlan-platdata";
+ 		wifi_chip_type = "ap6275p";
+@@ -365,6 +385,10 @@ &hdptxphy_hdmi0 {
+ 	status = "okay";
+  };
+ 
++&i2s2_2ch {
++	status = "okay";
++};
++
+ &i2c0 {
+     status = "okay";
+     pinctrl-names = "default";
+-- 
+Armbian
+
+
+From 22b55aa1e0018545fd39f9fa2799b920440260c6 Mon Sep 17 00:00:00 2001
+From: Jack Zhao <jack.zhao@wesion.com>
+Date: Thu, 21 Jul 2022 14:07:02 +0800
+Subject: arm64: dts: rockchip: Edge2: remove redundant device nodes
+
+Signed-off-by: Jack Zhao <jack.zhao@wesion.com>
+Change-Id: I96c4d51876e77ba727df47d596b74b0765e5dcf7
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 18 ----------
+ 1 file changed, 18 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 1e0e271574eb..4c8efd889a1a 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -578,30 +578,12 @@ es8316: es8316@10 {
+ 		hp-det-gpio = <&gpio1 RK_PD3 GPIO_ACTIVE_LOW>;
+ 	};
+ 
+-	es7202: es7202@32 {
+-		status = "okay";
+-		#sound-dai-cells = <0>;
+-		compatible = "ES7202_PDM_ADC_1";
+-		power-supply = <&vcc_1v8_s0>;	/* only 1v8 or 3v3, default is 3v3 */
+-		reg = <0x32>;
+-	};
+ };
+ 
+ &i2c4 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&i2c4m3_xfer>;
+ 	status = "okay";
+-
+-	 ft5336@38 {
+-		compatible = "edt,edt-ft5336", "ft5x06";
+-		reg = <0x38>;
+-		interrupt-parent = <&gpio1>;
+-		interrupts = <RK_PB5 IRQ_TYPE_EDGE_FALLING>;
+-		reset-gpio = <&gpio1 RK_PB4 GPIO_ACTIVE_HIGH>;
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&tp_rst_gpio>;
+-		status = "okay";
+-	};
+ };
+ 
+ &i2c5 {
+-- 
+Armbian
+
+
+From e885bf862eb2d5b59692463404db55453423dd61 Mon Sep 17 00:00:00 2001
+From: Nick Xie <nick@khadas.com>
+Date: Fri, 26 Aug 2022 16:52:06 +0800
+Subject: arm64: dts: Edge2: disable mipi dsi
+
+Signed-off-by: Nick Xie <nick@khadas.com>
+Change-Id: I626cfa8fee30e9bf8458514356ade1ae6e0087f1
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 4c8efd889a1a..a77be850eaf3 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -287,7 +287,7 @@ &dp0_sound{
+ };
+ 
+ &dsi0 {
+-	status = "okay";
++	status = "disabled";
+ 	reset-delay-ms = <20>;
+ 	reset-gpios = <&gpio4 RK_PA3 GPIO_ACTIVE_HIGH>;
+ 	pinctrl-names = "default";
+-- 
+Armbian
+
+
+From 18a2faebd627373afd2ea6e166b496c3159692de Mon Sep 17 00:00:00 2001
+From: Nick Xie <nick@khadas.com>
+Date: Mon, 17 Oct 2022 12:03:48 +0800
+Subject: arm64: dts: Edge2: disable spi1 by default
+
+Signed-off-by: Nick Xie <nick@khadas.com>
+Change-Id: I2690029ee999ba582090967c8c1bb34c26a8fe95
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index a77be850eaf3..edb3cc49eb16 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -935,7 +935,7 @@ &spdif_tx2 {
+ };
+ 
+ &spi1 {
+-	status = "okay";
++	status = "disabled";
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&spi1m1_cs0 &spi1m1_pins>;
+ 	spidev@1 {
+-- 
+Armbian
+
+
+From 833788ba6b65dd7566d5f24f8f02f2a2d1ba539b Mon Sep 17 00:00:00 2001
+From: Nick Xie <nick@khadas.com>
+Date: Mon, 17 Oct 2022 16:42:23 +0800
+Subject: arm64: dts: Edge2: move spidev to overlays
+
+Signed-off-by: Nick Xie <nick@khadas.com>
+Change-Id: Ibf107cfd9bb79a854c5dfd9f27a0aa1a4db5eaf0
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index edb3cc49eb16..30dfed67f92c 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -938,12 +938,6 @@ &spi1 {
+ 	status = "disabled";
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&spi1m1_cs0 &spi1m1_pins>;
+-	spidev@1 {
+-		compatible = "rockchip,spidev";
+-		reg = <1>;
+-		spi-max-frequency = <100000000>;
+-		status = "okay";
+-	};
+ };
+ 
+ &tsadc {
+-- 
+Armbian
+
+
+From b1cb1e25a0cda9600cd2e4c44c10d40b60630cf8 Mon Sep 17 00:00:00 2001
+From: Nick Xie <nick@khadas.com>
+Date: Sat, 5 Nov 2022 02:55:54 +0100
+Subject: bt: disable HCIUART_BCM
+
+Signed-off-by: Nick Xie <nick@khadas.com>
+Change-Id: Ie8eb10211bd6799e20dafb69aab17f9cd46b341d
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts |   6 -
+ arch/arm64/configs/kedges_defconfig                   | 884 +++++++++-
+ 2 files changed, 827 insertions(+), 63 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 30dfed67f92c..b2f4fa6b4c09 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -960,12 +960,6 @@ &uart9 {
+ 	status = "okay";
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&uart9m2_xfer &uart9m2_ctsn>;
+-	uart-has-rtscts;
+-	bluetooth {
+-		compatible = "brcm,bcm43438-bt";
+-		max-speed = <4000000>;
+-		clock-names = "lpo";
+-	};
+ };
+ 
+ &usbdp_phy0 {
+diff --git a/arch/arm64/configs/kedges_defconfig b/arch/arm64/configs/kedges_defconfig
+index 79c327af8e9d..03e52e066c58 100644
+--- a/arch/arm64/configs/kedges_defconfig
++++ b/arch/arm64/configs/kedges_defconfig
+@@ -1,25 +1,34 @@
+ CONFIG_DEFAULT_HOSTNAME="localhost"
+ CONFIG_SYSVIPC=y
++CONFIG_POSIX_MQUEUE=y
+ CONFIG_NO_HZ=y
+ CONFIG_HIGH_RES_TIMERS=y
+-CONFIG_PREEMPT_VOLUNTARY=y
++CONFIG_PREEMPT=y
+ CONFIG_IKCONFIG=y
+ CONFIG_IKCONFIG_PROC=y
+ CONFIG_LOG_BUF_SHIFT=18
+ CONFIG_UCLAMP_TASK=y
+ CONFIG_UCLAMP_BUCKETS_COUNT=20
+ CONFIG_CGROUPS=y
++CONFIG_MEMCG=y
++CONFIG_BLK_CGROUP=y
+ CONFIG_CGROUP_SCHED=y
+ CONFIG_CFS_BANDWIDTH=y
++CONFIG_RT_GROUP_SCHED=y
+ CONFIG_UCLAMP_TASK_GROUP=y
++CONFIG_CGROUP_PIDS=y
++CONFIG_CGROUP_RDMA=y
+ CONFIG_CGROUP_FREEZER=y
+ CONFIG_CPUSETS=y
+ CONFIG_CGROUP_DEVICE=y
+ CONFIG_CGROUP_CPUACCT=y
++CONFIG_CGROUP_PERF=y
++CONFIG_CGROUP_BPF=y
+ CONFIG_NAMESPACES=y
+ CONFIG_USER_NS=y
+ CONFIG_BLK_DEV_INITRD=y
+ CONFIG_CC_OPTIMIZE_FOR_SIZE=y
++CONFIG_BPF_SYSCALL=y
+ CONFIG_EMBEDDED=y
+ # CONFIG_COMPAT_BRK is not set
+ CONFIG_PROFILING=y
+@@ -58,7 +67,8 @@ CONFIG_CPUFREQ_DT=y
+ CONFIG_ARM_ROCKCHIP_CPUFREQ=y
+ CONFIG_ARM_SCMI_PROTOCOL=y
+ CONFIG_ROCKCHIP_SIP=y
+-CONFIG_ARM64_CRYPTO=y
++CONFIG_VIRTUALIZATION=y
++CONFIG_KVM=y
+ CONFIG_CRYPTO_SHA1_ARM64_CE=y
+ CONFIG_CRYPTO_SHA2_ARM64_CE=y
+ CONFIG_CRYPTO_GHASH_ARM64_CE=y
+@@ -68,6 +78,7 @@ CONFIG_MODULES=y
+ CONFIG_MODULE_FORCE_LOAD=y
+ CONFIG_MODULE_UNLOAD=y
+ CONFIG_MODULE_FORCE_UNLOAD=y
++CONFIG_BLK_DEV_THROTTLING=y
+ CONFIG_PARTITION_ADVANCED=y
+ CONFIG_CMDLINE_PARTITION=y
+ # CONFIG_COMPACTION is not set
+@@ -77,18 +88,375 @@ CONFIG_ZSMALLOC=y
+ CONFIG_NET=y
+ CONFIG_PACKET=y
+ CONFIG_UNIX=y
+-CONFIG_XFRM_USER=y
+-CONFIG_NET_KEY=y
++CONFIG_XFRM_USER=m
++CONFIG_XFRM_STATISTICS=y
++CONFIG_NET_KEY=m
+ CONFIG_INET=y
+ CONFIG_IP_MULTICAST=y
+ CONFIG_IP_ADVANCED_ROUTER=y
++CONFIG_IP_MULTIPLE_TABLES=y
++CONFIG_IP_ROUTE_MULTIPATH=y
++CONFIG_IP_ROUTE_VERBOSE=y
++CONFIG_IP_PNP=y
++CONFIG_IP_PNP_DHCP=y
++CONFIG_IP_PNP_RARP=y
++CONFIG_NET_IPIP=m
++CONFIG_NET_IPGRE_DEMUX=m
++CONFIG_NET_IPGRE=m
+ CONFIG_IP_MROUTE=y
+-CONFIG_SYN_COOKIES=y
+-# CONFIG_INET_DIAG is not set
+-# CONFIG_IPV6_SIT is not set
++CONFIG_IP_MROUTE_MULTIPLE_TABLES=y
++CONFIG_IP_PIMSM_V1=y
++CONFIG_IP_PIMSM_V2=y
++CONFIG_NET_IPVTI=m
++CONFIG_NET_FOU=m
++CONFIG_INET_AH=m
++CONFIG_INET_ESP=m
++CONFIG_INET_ESP_OFFLOAD=m
++CONFIG_INET_ESPINTCP=y
++CONFIG_INET_IPCOMP=m
++CONFIG_INET_DIAG=m
++CONFIG_TCP_CONG_ADVANCED=y
++CONFIG_TCP_CONG_BBR=m
++CONFIG_IPV6=m
++CONFIG_IPV6_ROUTER_PREF=y
++CONFIG_IPV6_ROUTE_INFO=y
++CONFIG_INET6_AH=m
++CONFIG_INET6_ESP=m
++CONFIG_INET6_ESP_OFFLOAD=m
++CONFIG_INET6_IPCOMP=m
++CONFIG_IPV6_ILA=m
++CONFIG_IPV6_VTI=m
++CONFIG_IPV6_SIT_6RD=y
++CONFIG_IPV6_GRE=m
++CONFIG_IPV6_MULTIPLE_TABLES=y
++CONFIG_IPV6_SUBTREES=y
++CONFIG_IPV6_MROUTE=y
++CONFIG_IPV6_MROUTE_MULTIPLE_TABLES=y
++CONFIG_IPV6_PIMSM_V2=y
++CONFIG_NETWORK_PHY_TIMESTAMPING=y
+ CONFIG_NETFILTER=y
+-CONFIG_IP_NF_IPTABLES=y
+-CONFIG_IP_NF_MANGLE=y
++CONFIG_BRIDGE_NETFILTER=m
++CONFIG_NF_CONNTRACK=m
++CONFIG_NF_CONNTRACK_ZONES=y
++# CONFIG_NF_CONNTRACK_PROCFS is not set
++CONFIG_NF_CONNTRACK_FTP=m
++CONFIG_NF_CONNTRACK_H323=m
++CONFIG_NF_CONNTRACK_IRC=m
++CONFIG_NF_CONNTRACK_NETBIOS_NS=m
++CONFIG_NF_CONNTRACK_SNMP=m
++CONFIG_NF_CONNTRACK_PPTP=m
++CONFIG_NF_CONNTRACK_SANE=m
++CONFIG_NF_CONNTRACK_SIP=m
++CONFIG_NF_CONNTRACK_TFTP=m
++CONFIG_NF_CT_NETLINK=m
++CONFIG_NF_TABLES=m
++CONFIG_NF_TABLES_INET=y
++CONFIG_NF_TABLES_NETDEV=y
++CONFIG_NFT_NUMGEN=m
++CONFIG_NFT_CT=m
++CONFIG_NFT_FLOW_OFFLOAD=m
++CONFIG_NFT_COUNTER=m
++CONFIG_NFT_CONNLIMIT=m
++CONFIG_NFT_LOG=m
++CONFIG_NFT_LIMIT=m
++CONFIG_NFT_MASQ=m
++CONFIG_NFT_REDIR=m
++CONFIG_NFT_NAT=m
++CONFIG_NFT_TUNNEL=m
++CONFIG_NFT_OBJREF=m
++CONFIG_NFT_QUEUE=m
++CONFIG_NFT_QUOTA=m
++CONFIG_NFT_REJECT=m
++CONFIG_NFT_COMPAT=m
++CONFIG_NFT_HASH=m
++CONFIG_NFT_XFRM=m
++CONFIG_NFT_SOCKET=m
++CONFIG_NFT_OSF=m
++CONFIG_NFT_TPROXY=m
++CONFIG_NFT_SYNPROXY=m
++CONFIG_NFT_DUP_NETDEV=m
++CONFIG_NFT_FWD_NETDEV=m
++CONFIG_NF_FLOW_TABLE_INET=m
++CONFIG_NF_FLOW_TABLE=m
++CONFIG_NETFILTER_XTABLES=y
++CONFIG_NETFILTER_XT_TARGET_CHECKSUM=m
++CONFIG_NETFILTER_XT_TARGET_CLASSIFY=m
++CONFIG_NETFILTER_XT_TARGET_CONNMARK=m
++CONFIG_NETFILTER_XT_TARGET_DSCP=m
++CONFIG_NETFILTER_XT_TARGET_HMARK=m
++CONFIG_NETFILTER_XT_TARGET_IDLETIMER=m
++CONFIG_NETFILTER_XT_TARGET_LED=m
++CONFIG_NETFILTER_XT_TARGET_LOG=m
++CONFIG_NETFILTER_XT_TARGET_MARK=m
++CONFIG_NETFILTER_XT_TARGET_NFLOG=m
++CONFIG_NETFILTER_XT_TARGET_NFQUEUE=m
++CONFIG_NETFILTER_XT_TARGET_NOTRACK=m
++CONFIG_NETFILTER_XT_TARGET_TEE=m
++CONFIG_NETFILTER_XT_TARGET_TPROXY=m
++CONFIG_NETFILTER_XT_TARGET_TRACE=m
++CONFIG_NETFILTER_XT_TARGET_SECMARK=m
++CONFIG_NETFILTER_XT_TARGET_TCPMSS=m
++CONFIG_NETFILTER_XT_TARGET_TCPOPTSTRIP=m
++CONFIG_NETFILTER_XT_MATCH_ADDRTYPE=m
++CONFIG_NETFILTER_XT_MATCH_BPF=m
++CONFIG_NETFILTER_XT_MATCH_CGROUP=m
++CONFIG_NETFILTER_XT_MATCH_CLUSTER=m
++CONFIG_NETFILTER_XT_MATCH_COMMENT=m
++CONFIG_NETFILTER_XT_MATCH_CONNBYTES=m
++CONFIG_NETFILTER_XT_MATCH_CONNLABEL=m
++CONFIG_NETFILTER_XT_MATCH_CONNLIMIT=m
++CONFIG_NETFILTER_XT_MATCH_CONNMARK=m
++CONFIG_NETFILTER_XT_MATCH_CONNTRACK=m
++CONFIG_NETFILTER_XT_MATCH_CPU=m
++CONFIG_NETFILTER_XT_MATCH_DCCP=m
++CONFIG_NETFILTER_XT_MATCH_DEVGROUP=m
++CONFIG_NETFILTER_XT_MATCH_DSCP=m
++CONFIG_NETFILTER_XT_MATCH_ECN=y
++CONFIG_NETFILTER_XT_MATCH_ESP=m
++CONFIG_NETFILTER_XT_MATCH_HASHLIMIT=m
++CONFIG_NETFILTER_XT_MATCH_HELPER=m
++CONFIG_NETFILTER_XT_MATCH_HL=y
++CONFIG_NETFILTER_XT_MATCH_IPCOMP=m
++CONFIG_NETFILTER_XT_MATCH_IPRANGE=m
++CONFIG_NETFILTER_XT_MATCH_IPVS=m
++CONFIG_NETFILTER_XT_MATCH_LENGTH=m
++CONFIG_NETFILTER_XT_MATCH_LIMIT=m
++CONFIG_NETFILTER_XT_MATCH_MAC=m
++CONFIG_NETFILTER_XT_MATCH_MARK=m
++CONFIG_NETFILTER_XT_MATCH_MULTIPORT=m
++CONFIG_NETFILTER_XT_MATCH_NFACCT=m
++CONFIG_NETFILTER_XT_MATCH_OSF=m
++CONFIG_NETFILTER_XT_MATCH_OWNER=m
++CONFIG_NETFILTER_XT_MATCH_POLICY=m
++CONFIG_NETFILTER_XT_MATCH_PHYSDEV=m
++CONFIG_NETFILTER_XT_MATCH_PKTTYPE=m
++CONFIG_NETFILTER_XT_MATCH_QUOTA=m
++CONFIG_NETFILTER_XT_MATCH_QUOTA2=m
++CONFIG_NETFILTER_XT_MATCH_QUOTA2_LOG=y
++CONFIG_NETFILTER_XT_MATCH_RATEEST=m
++CONFIG_NETFILTER_XT_MATCH_REALM=m
++CONFIG_NETFILTER_XT_MATCH_RECENT=m
++CONFIG_NETFILTER_XT_MATCH_SOCKET=m
++CONFIG_NETFILTER_XT_MATCH_STATE=m
++CONFIG_NETFILTER_XT_MATCH_STATISTIC=m
++CONFIG_NETFILTER_XT_MATCH_STRING=m
++CONFIG_NETFILTER_XT_MATCH_TCPMSS=m
++CONFIG_NETFILTER_XT_MATCH_TIME=m
++CONFIG_NETFILTER_XT_MATCH_U32=m
++CONFIG_IP_SET=m
++CONFIG_IP_SET_BITMAP_IP=m
++CONFIG_IP_SET_BITMAP_IPMAC=m
++CONFIG_IP_SET_BITMAP_PORT=m
++CONFIG_IP_SET_HASH_IP=m
++CONFIG_IP_SET_HASH_IPPORT=m
++CONFIG_IP_SET_HASH_IPPORTIP=m
++CONFIG_IP_SET_HASH_IPPORTNET=m
++CONFIG_IP_SET_HASH_NET=m
++CONFIG_IP_SET_HASH_NETPORT=m
++CONFIG_IP_SET_HASH_NETIFACE=m
++CONFIG_IP_SET_LIST_SET=m
++CONFIG_IP_VS=m
++CONFIG_IP_VS_IPV6=y
++CONFIG_IP_VS_PROTO_TCP=y
++CONFIG_IP_VS_PROTO_UDP=y
++CONFIG_IP_VS_PROTO_ESP=y
++CONFIG_IP_VS_PROTO_AH=y
++CONFIG_IP_VS_PROTO_SCTP=y
++CONFIG_IP_VS_RR=m
++CONFIG_IP_VS_WRR=m
++CONFIG_IP_VS_LC=m
++CONFIG_IP_VS_WLC=m
++CONFIG_IP_VS_LBLC=m
++CONFIG_IP_VS_LBLCR=m
++CONFIG_IP_VS_DH=m
++CONFIG_IP_VS_SH=m
++CONFIG_IP_VS_SED=m
++CONFIG_IP_VS_NQ=m
++CONFIG_IP_VS_FTP=m
++CONFIG_IP_VS_PE_SIP=m
++CONFIG_NFT_DUP_IPV4=m
++CONFIG_NFT_FIB_IPV4=m
++CONFIG_NF_TABLES_ARP=y
++CONFIG_NF_FLOW_TABLE_IPV4=m
++CONFIG_NF_LOG_ARP=m
++CONFIG_IP_NF_IPTABLES=m
++CONFIG_IP_NF_MATCH_AH=m
++CONFIG_IP_NF_MATCH_ECN=m
++CONFIG_IP_NF_MATCH_RPFILTER=m
++CONFIG_IP_NF_MATCH_TTL=m
++CONFIG_IP_NF_FILTER=m
++CONFIG_IP_NF_TARGET_REJECT=m
++CONFIG_IP_NF_NAT=m
++CONFIG_IP_NF_TARGET_MASQUERADE=m
++CONFIG_IP_NF_TARGET_NETMAP=m
++CONFIG_IP_NF_TARGET_REDIRECT=m
++CONFIG_IP_NF_MANGLE=m
++CONFIG_IP_NF_TARGET_CLUSTERIP=m
++CONFIG_IP_NF_TARGET_ECN=m
++CONFIG_IP_NF_TARGET_TTL=m
++CONFIG_IP_NF_RAW=m
++CONFIG_IP_NF_ARPTABLES=m
++CONFIG_IP_NF_ARPFILTER=m
++CONFIG_IP_NF_ARP_MANGLE=m
++CONFIG_NFT_DUP_IPV6=m
++CONFIG_NFT_FIB_IPV6=m
++CONFIG_NF_FLOW_TABLE_IPV6=m
++CONFIG_IP6_NF_IPTABLES=m
++CONFIG_IP6_NF_MATCH_AH=m
++CONFIG_IP6_NF_MATCH_EUI64=m
++CONFIG_IP6_NF_MATCH_FRAG=m
++CONFIG_IP6_NF_MATCH_OPTS=m
++CONFIG_IP6_NF_MATCH_HL=m
++CONFIG_IP6_NF_MATCH_IPV6HEADER=m
++CONFIG_IP6_NF_MATCH_MH=m
++CONFIG_IP6_NF_MATCH_RPFILTER=m
++CONFIG_IP6_NF_MATCH_RT=m
++CONFIG_IP6_NF_MATCH_SRH=m
++CONFIG_IP6_NF_TARGET_HL=m
++CONFIG_IP6_NF_FILTER=m
++CONFIG_IP6_NF_TARGET_REJECT=m
++CONFIG_IP6_NF_TARGET_SYNPROXY=m
++CONFIG_IP6_NF_MANGLE=m
++CONFIG_IP6_NF_RAW=m
++CONFIG_IP6_NF_SECURITY=m
++CONFIG_IP6_NF_NAT=m
++CONFIG_IP6_NF_TARGET_MASQUERADE=m
++CONFIG_IP6_NF_TARGET_NPT=m
++CONFIG_NF_TABLES_BRIDGE=m
++CONFIG_NFT_BRIDGE_REJECT=m
++CONFIG_BRIDGE_NF_EBTABLES=m
++CONFIG_BRIDGE_EBT_BROUTE=m
++CONFIG_BRIDGE_EBT_T_FILTER=m
++CONFIG_BRIDGE_EBT_T_NAT=m
++CONFIG_BRIDGE_EBT_802_3=m
++CONFIG_BRIDGE_EBT_AMONG=m
++CONFIG_BRIDGE_EBT_ARP=m
++CONFIG_BRIDGE_EBT_IP=m
++CONFIG_BRIDGE_EBT_IP6=m
++CONFIG_BRIDGE_EBT_LIMIT=m
++CONFIG_BRIDGE_EBT_MARK=m
++CONFIG_BRIDGE_EBT_PKTTYPE=m
++CONFIG_BRIDGE_EBT_STP=m
++CONFIG_BRIDGE_EBT_VLAN=m
++CONFIG_BRIDGE_EBT_ARPREPLY=m
++CONFIG_BRIDGE_EBT_DNAT=m
++CONFIG_BRIDGE_EBT_MARK_T=m
++CONFIG_BRIDGE_EBT_REDIRECT=m
++CONFIG_BRIDGE_EBT_SNAT=m
++CONFIG_BRIDGE_EBT_LOG=m
++CONFIG_BRIDGE_EBT_NFLOG=m
++CONFIG_SCTP_COOKIE_HMAC_SHA1=y
++CONFIG_ATM=m
++CONFIG_L2TP=m
++CONFIG_L2TP_V3=y
++CONFIG_L2TP_IP=m
++CONFIG_L2TP_ETH=m
++CONFIG_BRIDGE=m
++CONFIG_BRIDGE_VLAN_FILTERING=y
++CONFIG_VLAN_8021Q=m
++CONFIG_VLAN_8021Q_GVRP=y
++CONFIG_NET_SCHED=y
++CONFIG_NET_SCH_CBQ=m
++CONFIG_NET_SCH_HTB=m
++CONFIG_NET_SCH_HFSC=m
++CONFIG_NET_SCH_ATM=m
++CONFIG_NET_SCH_PRIO=m
++CONFIG_NET_SCH_MULTIQ=m
++CONFIG_NET_SCH_RED=m
++CONFIG_NET_SCH_SFB=m
++CONFIG_NET_SCH_SFQ=m
++CONFIG_NET_SCH_TEQL=m
++CONFIG_NET_SCH_TBF=m
++CONFIG_NET_SCH_GRED=m
++CONFIG_NET_SCH_DSMARK=m
++CONFIG_NET_SCH_NETEM=m
++CONFIG_NET_SCH_DRR=m
++CONFIG_NET_SCH_MQPRIO=m
++CONFIG_NET_SCH_CHOKE=m
++CONFIG_NET_SCH_QFQ=m
++CONFIG_NET_SCH_CODEL=m
++CONFIG_NET_SCH_FQ_CODEL=m
++CONFIG_NET_SCH_CAKE=m
++CONFIG_NET_SCH_FQ=m
++CONFIG_NET_SCH_HHF=m
++CONFIG_NET_SCH_PIE=m
++CONFIG_NET_SCH_PLUG=m
++CONFIG_NET_CLS_BASIC=m
++CONFIG_NET_CLS_TCINDEX=m
++CONFIG_NET_CLS_ROUTE4=m
++CONFIG_NET_CLS_FW=m
++CONFIG_NET_CLS_U32=m
++CONFIG_CLS_U32_MARK=y
++CONFIG_NET_CLS_RSVP=m
++CONFIG_NET_CLS_RSVP6=m
++CONFIG_NET_CLS_FLOW=m
++CONFIG_NET_CLS_CGROUP=m
++CONFIG_NET_CLS_BPF=m
++CONFIG_NET_EMATCH=y
++CONFIG_NET_EMATCH_CMP=m
++CONFIG_NET_EMATCH_U32=m
++CONFIG_NET_EMATCH_META=m
++CONFIG_NET_EMATCH_TEXT=m
++CONFIG_NET_EMATCH_CANID=y
++CONFIG_NET_EMATCH_IPSET=m
++CONFIG_NET_CLS_ACT=y
++CONFIG_NET_ACT_POLICE=m
++CONFIG_NET_ACT_GACT=m
++CONFIG_GACT_PROB=y
++CONFIG_NET_ACT_MIRRED=m
++CONFIG_NET_ACT_IPT=m
++CONFIG_NET_ACT_NAT=m
++CONFIG_NET_ACT_PEDIT=m
++CONFIG_NET_ACT_SIMP=m
++CONFIG_NET_ACT_SKBEDIT=m
++CONFIG_NET_ACT_CSUM=m
++CONFIG_BATMAN_ADV=m
++CONFIG_OPENVSWITCH=m
++CONFIG_VSOCKETS=m
++CONFIG_CGROUP_NET_PRIO=y
++CONFIG_NET_PKTGEN=m
++CONFIG_HAMRADIO=y
++CONFIG_AX25=m
++CONFIG_NETROM=m
++CONFIG_ROSE=m
++CONFIG_MKISS=m
++CONFIG_6PACK=m
++CONFIG_BPQETHER=m
++CONFIG_BAYCOM_SER_FDX=m
++CONFIG_BAYCOM_SER_HDX=m
++CONFIG_YAM=m
++CONFIG_CAN=m
++CONFIG_CAN_J1939=m
++CONFIG_CAN_ISOTP=m
++CONFIG_CAN_VCAN=m
++CONFIG_CAN_VXCAN=m
++CONFIG_CAN_SLCAN=m
++CONFIG_CAN_FLEXCAN=m
++CONFIG_CAN_GRCAN=m
++CONFIG_CAN_KVASER_PCIEFD=m
++CONFIG_CAN_XILINXCAN=m
++CONFIG_CAN_C_CAN=m
++CONFIG_CAN_CC770=m
++CONFIG_CAN_IFI_CANFD=m
++CONFIG_CAN_M_CAN=m
++CONFIG_CAN_M_CAN_PLATFORM=m
++CONFIG_CAN_M_CAN_TCAN4X5X=m
++CONFIG_CAN_PEAK_PCIEFD=m
++CONFIG_CAN_ROCKCHIP=m
++CONFIG_CANFD_ROCKCHIP=m
++CONFIG_CAN_SJA1000=m
++CONFIG_CAN_SOFTING=m
++CONFIG_CAN_HI311X=m
++CONFIG_CAN_MCP251X=m
++CONFIG_CAN_MCP251XFD=m
++CONFIG_CAN_8DEV_USB=m
++CONFIG_CAN_EMS_USB=m
++CONFIG_CAN_ESD_USB2=m
++CONFIG_CAN_GS_USB=m
++CONFIG_CAN_KVASER_USB=m
++CONFIG_CAN_MCBA_USB=m
++CONFIG_CAN_PEAK_USB=m
++CONFIG_CAN_UCAN=m
+ CONFIG_BT=m
+ CONFIG_BT_RFCOMM=m
+ CONFIG_BT_RFCOMM_TTY=y
+@@ -100,9 +468,14 @@ CONFIG_BT_HS=y
+ CONFIG_BT_HCIBTUSB=m
+ CONFIG_BT_HCIBTSDIO=m
+ CONFIG_BT_HCIUART=m
+-CONFIG_BT_HCIUART_BCM=y
++CONFIG_BT_HCIUART_H4=y
++CONFIG_MAC80211_MESH=y
++CONFIG_MAC80211_LEDS=y
+ CONFIG_RFKILL=y
++CONFIG_RFKILL_INPUT=y
+ CONFIG_RFKILL_RK=y
++CONFIG_NET_9P=m
++CONFIG_NFC=m
+ CONFIG_PCI=y
+ CONFIG_PCIEPORTBUS=y
+ CONFIG_PCIEASPM_POWERSAVE=y
+@@ -112,29 +485,83 @@ CONFIG_DEVTMPFS=y
+ CONFIG_DEVTMPFS_MOUNT=y
+ CONFIG_DEBUG_DEVRES=y
+ CONFIG_CONNECTOR=y
+-CONFIG_MTD=y
+-CONFIG_MTD_CMDLINE_PARTS=y
+-CONFIG_MTD_BLOCK=y
+-CONFIG_MTD_SPI_NAND=y
+-CONFIG_MTD_SPI_NOR=y
+-CONFIG_MTD_UBI=y
+-CONFIG_ZRAM=y
++CONFIG_MTD=m
++CONFIG_MTD_CMDLINE_PARTS=m
++CONFIG_MTD_BLOCK=m
++CONFIG_MTD_SPI_NAND=m
++CONFIG_MTD_SPI_NOR=m
++CONFIG_MTD_UBI=m
++CONFIG_ZRAM=m
+ CONFIG_BLK_DEV_LOOP=y
++CONFIG_BLK_DEV_CRYPTOLOOP=m
++CONFIG_BLK_DEV_DRBD=m
++CONFIG_BLK_DEV_NBD=m
+ CONFIG_BLK_DEV_RAM=y
+ CONFIG_BLK_DEV_RAM_COUNT=1
++CONFIG_CDROM_PKTCDVD=m
++CONFIG_ATA_OVER_ETH=m
+ CONFIG_BLK_DEV_NVME=y
+ CONFIG_SRAM=y
+ CONFIG_KHADAS_MCU=y
++CONFIG_SCSI=y
+ CONFIG_BLK_DEV_SD=y
+ CONFIG_BLK_DEV_SR=y
+ CONFIG_SCSI_SCAN_ASYNC=y
+ CONFIG_SCSI_SPI_ATTRS=y
+-CONFIG_ATA=y
+-CONFIG_SATA_AHCI=y
+-CONFIG_SATA_AHCI_PLATFORM=y
++CONFIG_ATA=m
++CONFIG_SATA_AHCI=m
++CONFIG_SATA_AHCI_PLATFORM=m
+ # CONFIG_ATA_SFF is not set
+ CONFIG_MD=y
++CONFIG_BLK_DEV_DM=m
++CONFIG_DM_UNSTRIPED=m
++CONFIG_DM_CRYPT=m
++CONFIG_DM_SNAPSHOT=m
++CONFIG_DM_THIN_PROVISIONING=m
++CONFIG_DM_CACHE=m
++CONFIG_DM_WRITECACHE=m
++CONFIG_DM_EBS=m
++CONFIG_DM_ERA=m
++CONFIG_DM_CLONE=m
++CONFIG_DM_MIRROR=m
++CONFIG_DM_LOG_USERSPACE=m
++CONFIG_DM_RAID=m
++CONFIG_DM_ZERO=m
++CONFIG_DM_MULTIPATH=m
++CONFIG_DM_MULTIPATH_QL=m
++CONFIG_DM_MULTIPATH_ST=m
++CONFIG_DM_MULTIPATH_HST=m
++CONFIG_DM_DELAY=m
++CONFIG_DM_DUST=m
++CONFIG_DM_UEVENT=y
++CONFIG_DM_FLAKEY=m
++CONFIG_DM_VERITY=m
++CONFIG_DM_VERITY_VERIFY_ROOTHASH_SIG=y
++CONFIG_DM_VERITY_FEC=y
++CONFIG_DM_SWITCH=m
++CONFIG_DM_LOG_WRITES=m
++CONFIG_DM_INTEGRITY=m
++CONFIG_DM_BOW=m
++CONFIG_TARGET_CORE=m
++CONFIG_TCM_IBLOCK=m
++CONFIG_TCM_FILEIO=m
++CONFIG_TCM_PSCSI=m
++CONFIG_TCM_USER2=m
++CONFIG_LOOPBACK_TARGET=m
++CONFIG_ISCSI_TARGET=m
+ CONFIG_NETDEVICES=y
++CONFIG_DUMMY=m
++CONFIG_WIREGUARD=m
++CONFIG_IFB=m
++CONFIG_MACVLAN=m
++CONFIG_MACVTAP=m
++CONFIG_IPVLAN=m
++CONFIG_IPVTAP=m
++CONFIG_VXLAN=m
++CONFIG_NETCONSOLE=m
++CONFIG_TUN=m
++CONFIG_VETH=m
++CONFIG_NET_VRF=m
+ # CONFIG_NET_VENDOR_3COM is not set
+ # CONFIG_NET_VENDOR_ADAPTEC is not set
+ # CONFIG_NET_VENDOR_AGERE is not set
+@@ -180,8 +607,55 @@ CONFIG_STMMAC_ETH=y
+ # CONFIG_NET_VENDOR_VIA is not set
+ # CONFIG_NET_VENDOR_WIZNET is not set
+ CONFIG_ROCKCHIP_PHY=y
+-CONFIG_USB_RTL8150=y
+-CONFIG_USB_RTL8152=y
++CONFIG_PPP=m
++CONFIG_PPP_BSDCOMP=m
++CONFIG_PPP_DEFLATE=m
++CONFIG_PPP_FILTER=y
++CONFIG_PPP_MPPE=m
++CONFIG_PPP_MULTILINK=y
++CONFIG_PPPOATM=m
++CONFIG_PPPOE=m
++CONFIG_PPTP=m
++CONFIG_PPPOL2TP=m
++CONFIG_PPP_ASYNC=m
++CONFIG_PPP_SYNC_TTY=m
++CONFIG_SLIP=m
++CONFIG_SLIP_COMPRESSED=y
++CONFIG_SLIP_SMART=y
++CONFIG_USB_NET_DRIVERS=m
++CONFIG_USB_CATC=m
++CONFIG_USB_KAWETH=m
++CONFIG_USB_PEGASUS=m
++CONFIG_USB_RTL8150=m
++CONFIG_USB_RTL8152=m
++CONFIG_USB_LAN78XX=m
++CONFIG_USB_USBNET=m
++CONFIG_USB_NET_CDC_EEM=m
++CONFIG_USB_NET_HUAWEI_CDC_NCM=m
++CONFIG_USB_NET_CDC_MBIM=m
++CONFIG_USB_NET_DM9601=m
++CONFIG_USB_NET_SR9700=m
++CONFIG_USB_NET_SR9800=m
++CONFIG_USB_NET_SMSC75XX=m
++CONFIG_USB_NET_SMSC95XX=m
++CONFIG_USB_NET_GL620A=m
++CONFIG_USB_NET_PLUSB=m
++CONFIG_USB_NET_MCS7830=m
++CONFIG_USB_NET_RNDIS_HOST=m
++CONFIG_USB_ALI_M5632=y
++CONFIG_USB_AN2720=y
++CONFIG_USB_EPSON2888=y
++CONFIG_USB_KC2190=y
++CONFIG_USB_NET_CX82310_ETH=m
++CONFIG_USB_NET_KALMIA=m
++CONFIG_USB_NET_QMI_WWAN=m
++CONFIG_USB_HSO=m
++CONFIG_USB_NET_INT51X1=m
++CONFIG_USB_IPHETH=m
++CONFIG_USB_SIERRA_NET=m
++CONFIG_USB_VL600=m
++CONFIG_USB_NET_CH9200=m
++CONFIG_USB_NET_AQC111=m
+ CONFIG_WL_ROCKCHIP=y
+ CONFIG_WIFI_BUILD_MODULE=y
+ CONFIG_AP6XXX=m
+@@ -189,6 +663,9 @@ CONFIG_BCMDHD_PCIE=y
+ CONFIG_BCMDHD_FW_PATH="/lib/firmware/brcm/fw_bcmdhd.bin"
+ CONFIG_BCMDHD_NVRAM_PATH="/lib/firmware/brcm/nvram.txt"
+ CONFIG_INPUT_FF_MEMLESS=y
++CONFIG_INPUT_MATRIXKMAP=m
++CONFIG_INPUT_MOUSEDEV=y
++CONFIG_INPUT_JOYDEV=m
+ CONFIG_INPUT_EVDEV=y
+ CONFIG_KEYBOARD_ADC=y
+ # CONFIG_KEYBOARD_ATKBD is not set
+@@ -197,13 +674,21 @@ CONFIG_KEYBOARD_GPIO_POLLED=y
+ # CONFIG_MOUSE_PS2 is not set
+ CONFIG_MOUSE_CYAPA=y
+ CONFIG_MOUSE_ELAN_I2C=y
++CONFIG_INPUT_JOYSTICK=y
++CONFIG_JOYSTICK_IFORCE=m
++CONFIG_JOYSTICK_IFORCE_USB=m
++CONFIG_JOYSTICK_XPAD=m
++CONFIG_JOYSTICK_XPAD_FF=y
++CONFIG_JOYSTICK_XPAD_LEDS=y
++CONFIG_JOYSTICK_PSXPAD_SPI=m
++CONFIG_JOYSTICK_PSXPAD_SPI_FF=y
+ CONFIG_INPUT_TOUCHSCREEN=y
+ CONFIG_TOUCHSCREEN_ATMEL_MXT=y
+ CONFIG_TOUCHSCREEN_GSL3673=y
+ CONFIG_TOUCHSCREEN_GT1X=y
+ CONFIG_TOUCHSCREEN_ELAN=y
+ CONFIG_TOUCHSCREEN_EDT_FT5X06=y
+-CONFIG_TOUCHSCREEN_USB_COMPOSITE=y
++CONFIG_TOUCHSCREEN_USB_COMPOSITE=m
+ CONFIG_ROCKCHIP_REMOTECTL=y
+ CONFIG_ROCKCHIP_REMOTECTL_PWM=y
+ CONFIG_SENSOR_DEVICE=y
+@@ -232,11 +717,16 @@ CONFIG_SPI=y
+ CONFIG_SPI_BITBANG=y
+ CONFIG_SPI_ROCKCHIP=y
+ CONFIG_SPI_ROCKCHIP_SFC=y
+-CONFIG_SPI_SPIDEV=y
++CONFIG_SPI_SPIDEV=m
++CONFIG_SPI_SLAVE=y
++CONFIG_PPS_CLIENT_KTIMER=m
++CONFIG_PPS_CLIENT_LDISC=m
++CONFIG_PPS_CLIENT_GPIO=m
+ CONFIG_PINCTRL_RK805=y
+ CONFIG_PINCTRL_RK806=y
+ CONFIG_GPIO_SYSFS=y
+ CONFIG_GPIO_GENERIC_PLATFORM=y
++CONFIG_W1=m
+ CONFIG_POWER_RESET_GPIO=y
+ CONFIG_POWER_RESET_GPIO_RESTART=y
+ CONFIG_SYSCON_REBOOT_MODE=y
+@@ -395,14 +885,76 @@ CONFIG_SND_SIMPLE_CARD=y
+ CONFIG_HID_BATTERY_STRENGTH=y
+ CONFIG_HIDRAW=y
+ CONFIG_UHID=y
+-CONFIG_HID_KENSINGTON=y
+-CONFIG_HID_MULTITOUCH=y
++CONFIG_HID_A4TECH=m
++CONFIG_HID_ACRUX=m
++CONFIG_HID_APPLE=m
++CONFIG_HID_APPLEIR=m
++CONFIG_HID_ASUS=m
++CONFIG_HID_BELKIN=m
++CONFIG_HID_BETOP_FF=m
++CONFIG_HID_BIGBEN_FF=m
++CONFIG_HID_CHERRY=m
++CONFIG_HID_CHICONY=m
++CONFIG_HID_CYPRESS=m
++CONFIG_HID_DRAGONRISE=m
++CONFIG_HID_EMS_FF=m
++CONFIG_HID_ELECOM=m
++CONFIG_HID_ELO=m
++CONFIG_HID_EZKEY=m
++CONFIG_HID_GEMBIRD=m
++CONFIG_HID_HOLTEK=m
++CONFIG_HID_KEYTOUCH=m
++CONFIG_HID_KYE=m
++CONFIG_HID_UCLOGIC=m
++CONFIG_HID_WALTOP=m
++CONFIG_HID_GYRATION=m
++CONFIG_HID_TWINHAN=m
++CONFIG_HID_KENSINGTON=m
++CONFIG_HID_LCPOWER=m
++CONFIG_HID_LOGITECH=m
++CONFIG_HID_LOGITECH_DJ=m
++CONFIG_LOGITECH_FF=y
++CONFIG_LOGIRUMBLEPAD2_FF=y
++CONFIG_LOGIG940_FF=y
++CONFIG_HID_MAGICMOUSE=m
++CONFIG_HID_MICROSOFT=m
++CONFIG_HID_MONTEREY=m
++CONFIG_HID_MULTITOUCH=m
++CONFIG_HID_NTRIG=m
++CONFIG_HID_ORTEK=m
++CONFIG_HID_PANTHERLORD=m
++CONFIG_HID_PETALYNX=m
++CONFIG_HID_PICOLCD=m
++CONFIG_HID_PLANTRONICS=m
++CONFIG_HID_PLAYSTATION=m
++CONFIG_PLAYSTATION_FF=y
++CONFIG_HID_ROCCAT=m
++CONFIG_HID_SAITEK=y
++CONFIG_HID_SAMSUNG=m
++CONFIG_HID_SONY=m
++CONFIG_SONY_FF=y
++CONFIG_HID_SPEEDLINK=m
++CONFIG_HID_STEAM=m
++CONFIG_HID_STEELSERIES=m
++CONFIG_HID_SUNPLUS=m
++CONFIG_HID_GREENASIA=m
++CONFIG_HID_SMARTJOYPLUS=m
++CONFIG_HID_TOPSEED=m
++CONFIG_HID_THINGM=m
++CONFIG_HID_THRUSTMASTER=m
++CONFIG_HID_WACOM=m
++CONFIG_HID_WIIMOTE=m
++CONFIG_HID_XINMO=m
++CONFIG_HID_ZEROPLUS=m
++CONFIG_HID_ZYDACRON=m
++CONFIG_HID_PID=y
+ CONFIG_USB_HIDDEV=y
+ CONFIG_I2C_HID=y
++CONFIG_USB=y
+ CONFIG_USB_ANNOUNCE_NEW_DEVICES=y
+ # CONFIG_USB_DEFAULT_PERSIST is not set
+ CONFIG_USB_OTG=y
+-CONFIG_USB_MON=y
++CONFIG_USB_MON=m
+ CONFIG_USB_XHCI_HCD=y
+ CONFIG_USB_EHCI_HCD=y
+ CONFIG_USB_EHCI_ROOT_HUB_TT=y
+@@ -410,34 +962,138 @@ CONFIG_USB_EHCI_HCD_PLATFORM=y
+ CONFIG_USB_OHCI_HCD=y
+ # CONFIG_USB_OHCI_HCD_PCI is not set
+ CONFIG_USB_OHCI_HCD_PLATFORM=y
+-CONFIG_USB_ACM=y
++CONFIG_USB_PRINTER=m
++CONFIG_USB_TMC=m
+ CONFIG_USB_STORAGE=y
++CONFIG_USB_STORAGE_REALTEK=m
++CONFIG_USB_STORAGE_DATAFAB=m
++CONFIG_USB_STORAGE_FREECOM=m
++CONFIG_USB_STORAGE_ISD200=m
++CONFIG_USB_STORAGE_USBAT=m
++CONFIG_USB_STORAGE_SDDR09=m
++CONFIG_USB_STORAGE_SDDR55=m
++CONFIG_USB_STORAGE_JUMPSHOT=m
++CONFIG_USB_STORAGE_ALAUDA=m
++CONFIG_USB_STORAGE_ONETOUCH=m
++CONFIG_USB_STORAGE_KARMA=m
++CONFIG_USB_STORAGE_CYPRESS_ATACB=m
++CONFIG_USB_STORAGE_ENE_UB6250=m
+ CONFIG_USB_UAS=y
++CONFIG_USB_MDC800=m
++CONFIG_USB_MICROTEK=m
++CONFIG_USBIP_CORE=m
++CONFIG_USBIP_VHCI_HCD=m
++CONFIG_USBIP_HOST=m
++CONFIG_USBIP_VUDC=m
+ CONFIG_USB_DWC3=y
+ CONFIG_USB_DWC2=y
+-CONFIG_USB_SERIAL=y
++CONFIG_USB_SERIAL=m
+ CONFIG_USB_SERIAL_GENERIC=y
+-CONFIG_USB_SERIAL_CP210X=y
+-CONFIG_USB_SERIAL_FTDI_SIO=y
+-CONFIG_USB_SERIAL_KEYSPAN=y
+-CONFIG_USB_SERIAL_PL2303=y
+-CONFIG_USB_SERIAL_OTI6858=y
+-CONFIG_USB_SERIAL_QUALCOMM=y
+-CONFIG_USB_SERIAL_SIERRAWIRELESS=y
+-CONFIG_USB_SERIAL_OPTION=y
++CONFIG_USB_SERIAL_SIMPLE=m
++CONFIG_USB_SERIAL_AIRCABLE=m
++CONFIG_USB_SERIAL_ARK3116=m
++CONFIG_USB_SERIAL_BELKIN=m
++CONFIG_USB_SERIAL_CH341=m
++CONFIG_USB_SERIAL_WHITEHEAT=m
++CONFIG_USB_SERIAL_DIGI_ACCELEPORT=m
++CONFIG_USB_SERIAL_CP210X=m
++CONFIG_USB_SERIAL_CYPRESS_M8=m
++CONFIG_USB_SERIAL_EMPEG=m
++CONFIG_USB_SERIAL_FTDI_SIO=m
++CONFIG_USB_SERIAL_VISOR=m
++CONFIG_USB_SERIAL_IPAQ=m
++CONFIG_USB_SERIAL_IR=m
++CONFIG_USB_SERIAL_EDGEPORT=m
++CONFIG_USB_SERIAL_EDGEPORT_TI=m
++CONFIG_USB_SERIAL_F81232=m
++CONFIG_USB_SERIAL_F8153X=m
++CONFIG_USB_SERIAL_GARMIN=m
++CONFIG_USB_SERIAL_IPW=m
++CONFIG_USB_SERIAL_IUU=m
++CONFIG_USB_SERIAL_KEYSPAN_PDA=m
++CONFIG_USB_SERIAL_KEYSPAN=m
++CONFIG_USB_SERIAL_KLSI=m
++CONFIG_USB_SERIAL_KOBIL_SCT=m
++CONFIG_USB_SERIAL_MCT_U232=m
++CONFIG_USB_SERIAL_METRO=m
++CONFIG_USB_SERIAL_MOS7720=m
++CONFIG_USB_SERIAL_MOS7840=m
++CONFIG_USB_SERIAL_MXUPORT=m
++CONFIG_USB_SERIAL_NAVMAN=m
++CONFIG_USB_SERIAL_PL2303=m
++CONFIG_USB_SERIAL_OTI6858=m
++CONFIG_USB_SERIAL_QCAUX=m
++CONFIG_USB_SERIAL_QUALCOMM=m
++CONFIG_USB_SERIAL_SPCP8X5=m
++CONFIG_USB_SERIAL_SAFE=m
++CONFIG_USB_SERIAL_SAFE_PADDED=y
++CONFIG_USB_SERIAL_SIERRAWIRELESS=m
++CONFIG_USB_SERIAL_SYMBOL=m
++CONFIG_USB_SERIAL_TI=m
++CONFIG_USB_SERIAL_CYBERJACK=m
++CONFIG_USB_SERIAL_XIRCOM=m
++CONFIG_USB_SERIAL_OPTION=m
++CONFIG_USB_SERIAL_OMNINET=m
++CONFIG_USB_SERIAL_OPTICON=m
++CONFIG_USB_SERIAL_XSENS_MT=m
++CONFIG_USB_SERIAL_WISHBONE=m
++CONFIG_USB_SERIAL_SSU100=m
++CONFIG_USB_SERIAL_QT2=m
++CONFIG_USB_SERIAL_UPD78F0730=m
++CONFIG_USB_EMI62=m
++CONFIG_USB_EMI26=m
++CONFIG_USB_ADUTUX=m
++CONFIG_USB_SEVSEG=m
++CONFIG_USB_LEGOTOWER=m
++CONFIG_USB_LCD=m
++CONFIG_USB_CYPRESS_CY7C63=m
++CONFIG_USB_CYTHERM=m
++CONFIG_USB_IDMOUSE=m
++CONFIG_USB_FTDI_ELAN=m
++CONFIG_USB_APPLEDISPLAY=m
++CONFIG_USB_SISUSBVGA=m
++CONFIG_USB_LD=m
++CONFIG_USB_TRANCEVIBRATOR=m
++CONFIG_USB_IOWARRIOR=m
++CONFIG_USB_TEST=m
++CONFIG_USB_ISIGHTFW=m
++CONFIG_USB_YUREX=m
+ CONFIG_USB_GADGET=y
+-CONFIG_USB_GADGET_DEBUG_FILES=y
+ CONFIG_USB_GADGET_VBUS_DRAW=500
+-CONFIG_USB_CONFIGFS=y
++CONFIG_USB_CONFIGFS=m
+ CONFIG_USB_CONFIGFS_UEVENT=y
++CONFIG_USB_CONFIGFS_SERIAL=y
+ CONFIG_USB_CONFIGFS_ACM=y
++CONFIG_USB_CONFIGFS_OBEX=y
++CONFIG_USB_CONFIGFS_NCM=y
++CONFIG_USB_CONFIGFS_ECM=y
++CONFIG_USB_CONFIGFS_ECM_SUBSET=y
+ CONFIG_USB_CONFIGFS_RNDIS=y
++CONFIG_USB_CONFIGFS_EEM=y
+ CONFIG_USB_CONFIGFS_MASS_STORAGE=y
++CONFIG_USB_CONFIGFS_F_LB_SS=y
+ CONFIG_USB_CONFIGFS_F_FS=y
++CONFIG_USB_CONFIGFS_F_AUDIO_SRC=y
+ CONFIG_USB_CONFIGFS_F_UAC1=y
+ CONFIG_USB_CONFIGFS_F_UAC2=y
++CONFIG_USB_CONFIGFS_F_MIDI=y
+ CONFIG_USB_CONFIGFS_F_HID=y
+ CONFIG_USB_CONFIGFS_F_UVC=y
++CONFIG_USB_CONFIGFS_F_PRINTER=y
++CONFIG_USB_CONFIGFS_F_TCM=y
++CONFIG_USB_ZERO=m
++CONFIG_USB_AUDIO=m
++CONFIG_USB_ETH=m
++CONFIG_USB_GADGETFS=m
++CONFIG_USB_MASS_STORAGE=m
++CONFIG_USB_GADGET_TARGET=m
++CONFIG_USB_G_SERIAL=m
++CONFIG_USB_MIDI_GADGET=m
++CONFIG_USB_G_PRINTER=m
++CONFIG_USB_CDC_COMPOSITE=m
++CONFIG_USB_G_ACM_MS=m
++CONFIG_USB_G_MULTI=m
++CONFIG_USB_G_HID=m
+ CONFIG_TYPEC_TCPM=y
+ CONFIG_TYPEC_TCPCI=y
+ CONFIG_TYPEC_HUSB311=y
+@@ -452,11 +1108,9 @@ CONFIG_MMC_SDHCI_OF_ARASAN=y
+ CONFIG_MMC_SDHCI_OF_DWCMSHC=y
+ CONFIG_MMC_DW=y
+ CONFIG_MMC_DW_ROCKCHIP=y
+-CONFIG_NEW_LEDS=y
+ CONFIG_LEDS_CLASS=y
+ CONFIG_LEDS_GPIO=y
+ CONFIG_LEDS_IS31FL32XX=y
+-CONFIG_LEDS_TRIGGERS=y
+ CONFIG_LEDS_TRIGGER_TIMER=y
+ CONFIG_LEDS_TRIGGER_HEARTBEAT=y
+ CONFIG_LEDS_TRIGGER_BACKLIGHT=y
+@@ -474,6 +1128,7 @@ CONFIG_DMABUF_HEAPS_DEFERRED_FREE=y
+ CONFIG_DMABUF_HEAPS_PAGE_POOL=y
+ CONFIG_DMABUF_HEAPS_SYSTEM=y
+ CONFIG_DMABUF_HEAPS_CMA=y
++CONFIG_UIO=y
+ CONFIG_STAGING=y
+ CONFIG_FIQ_DEBUGGER=y
+ CONFIG_FIQ_DEBUGGER_NO_SLEEP=y
+@@ -504,6 +1159,7 @@ CONFIG_ROCKCHIP_SUSPEND_MODE=y
+ CONFIG_ROCKCHIP_SYSTEM_MONITOR=y
+ CONFIG_ROCKCHIP_VENDOR_STORAGE=y
+ CONFIG_ROCKCHIP_MMC_VENDOR_STORAGE=y
++CONFIG_ROCKCHIP_MTD_VENDOR_STORAGE=m
+ CONFIG_ROCKCHIP_VENDOR_STORAGE_UPDATE_LOADER=y
+ CONFIG_ROCKCHIP_DEBUG=y
+ CONFIG_PM_DEVFREQ=y
+@@ -548,23 +1204,71 @@ CONFIG_ROCKCHIP_RKNPU=y
+ CONFIG_EXT4_FS=y
+ CONFIG_EXT4_FS_POSIX_ACL=y
+ CONFIG_EXT4_FS_SECURITY=y
+-CONFIG_XFS_FS=y
+-# CONFIG_DNOTIFY is not set
+-CONFIG_FUSE_FS=y
+-CONFIG_ISO9660_FS=y
++CONFIG_REISERFS_FS=m
++CONFIG_REISERFS_FS_XATTR=y
++CONFIG_REISERFS_FS_POSIX_ACL=y
++CONFIG_REISERFS_FS_SECURITY=y
++CONFIG_JFS_FS=m
++CONFIG_JFS_POSIX_ACL=y
++CONFIG_JFS_SECURITY=y
++CONFIG_JFS_STATISTICS=y
++CONFIG_XFS_FS=m
++CONFIG_XFS_QUOTA=y
++CONFIG_XFS_POSIX_ACL=y
++CONFIG_XFS_RT=y
++CONFIG_GFS2_FS=m
++CONFIG_OCFS2_FS=m
++CONFIG_BTRFS_FS=m
++CONFIG_BTRFS_FS_POSIX_ACL=y
++CONFIG_BTRFS_ASSERT=y
++CONFIG_BTRFS_FS_REF_VERIFY=y
++CONFIG_NILFS2_FS=m
++CONFIG_F2FS_FS=m
++CONFIG_F2FS_FS_SECURITY=y
++CONFIG_FS_ENCRYPTION=y
++CONFIG_FANOTIFY=y
++CONFIG_QFMT_V1=m
++CONFIG_QFMT_V2=m
++CONFIG_AUTOFS4_FS=y
++CONFIG_FUSE_FS=m
++CONFIG_CUSE=m
++CONFIG_OVERLAY_FS=m
++CONFIG_OVERLAY_FS_INDEX=y
++CONFIG_OVERLAY_FS_XINO_AUTO=y
++CONFIG_OVERLAY_FS_METACOPY=y
++CONFIG_FSCACHE=y
++CONFIG_FSCACHE_STATS=y
++CONFIG_FSCACHE_HISTOGRAM=y
++CONFIG_CACHEFILES=y
++CONFIG_ISO9660_FS=m
+ CONFIG_JOLIET=y
+ CONFIG_ZISOFS=y
++CONFIG_UDF_FS=m
++CONFIG_MSDOS_FS=y
+ CONFIG_VFAT_FS=y
+ CONFIG_FAT_DEFAULT_CODEPAGE=936
+ CONFIG_FAT_DEFAULT_IOCHARSET="utf8"
+-CONFIG_NTFS_FS=y
++CONFIG_EXFAT_FS=m
++CONFIG_NTFS_FS=m
++CONFIG_NTFS_RW=y
+ CONFIG_TMPFS=y
+ CONFIG_TMPFS_POSIX_ACL=y
++CONFIG_CONFIGFS_FS=y
+ CONFIG_EFIVAR_FS=y
+-CONFIG_JFFS2_FS=y
+-CONFIG_UBIFS_FS=y
++CONFIG_ECRYPT_FS=m
++CONFIG_HFS_FS=m
++CONFIG_HFSPLUS_FS=m
++CONFIG_JFFS2_FS=m
++CONFIG_JFFS2_SUMMARY=y
++CONFIG_UBIFS_FS=m
+ CONFIG_UBIFS_FS_ADVANCED_COMPR=y
+ CONFIG_SQUASHFS=y
++CONFIG_SQUASHFS_XATTR=y
++CONFIG_SQUASHFS_LZ4=y
++CONFIG_SQUASHFS_LZO=y
++CONFIG_SQUASHFS_XZ=y
++CONFIG_SQUASHFS_ZSTD=y
++CONFIG_SQUASHFS_4K_DEVBLK_SIZE=y
+ CONFIG_PSTORE=y
+ CONFIG_PSTORE_CONSOLE=y
+ CONFIG_PSTORE_RAM=y
+@@ -572,24 +1276,91 @@ CONFIG_NFS_FS=y
+ CONFIG_NFS_V3_ACL=y
+ CONFIG_NFS_V4=y
+ CONFIG_NFS_SWAP=y
++CONFIG_NFS_V4_1=y
++CONFIG_NFS_V4_2=y
++CONFIG_ROOT_NFS=y
++CONFIG_NFS_FSCACHE=y
++CONFIG_NFS_V4_2_READ_PLUS=y
++CONFIG_NFSD=m
++CONFIG_NFSD_V3_ACL=y
++CONFIG_NFSD_V4=y
++CONFIG_CEPH_FS=m
++CONFIG_CIFS=m
++CONFIG_CIFS_STATS2=y
++CONFIG_CIFS_WEAK_PW_HASH=y
++CONFIG_CIFS_UPCALL=y
++CONFIG_CIFS_XATTR=y
++CONFIG_CIFS_POSIX=y
++CONFIG_CIFS_DFS_UPCALL=y
++CONFIG_CIFS_FSCACHE=y
++CONFIG_9P_FS=m
++CONFIG_9P_FS_POSIX_ACL=y
+ CONFIG_NLS_DEFAULT="utf8"
+ CONFIG_NLS_CODEPAGE_437=y
+-CONFIG_NLS_CODEPAGE_936=y
++CONFIG_NLS_CODEPAGE_737=m
++CONFIG_NLS_CODEPAGE_775=m
++CONFIG_NLS_CODEPAGE_850=m
++CONFIG_NLS_CODEPAGE_852=m
++CONFIG_NLS_CODEPAGE_855=m
++CONFIG_NLS_CODEPAGE_857=m
++CONFIG_NLS_CODEPAGE_860=m
++CONFIG_NLS_CODEPAGE_861=m
++CONFIG_NLS_CODEPAGE_862=m
++CONFIG_NLS_CODEPAGE_863=m
++CONFIG_NLS_CODEPAGE_864=m
++CONFIG_NLS_CODEPAGE_865=m
++CONFIG_NLS_CODEPAGE_866=m
++CONFIG_NLS_CODEPAGE_869=m
++CONFIG_NLS_CODEPAGE_936=m
++CONFIG_NLS_CODEPAGE_950=m
++CONFIG_NLS_CODEPAGE_932=m
++CONFIG_NLS_CODEPAGE_949=m
++CONFIG_NLS_CODEPAGE_874=m
++CONFIG_NLS_ISO8859_8=m
++CONFIG_NLS_CODEPAGE_1250=m
++CONFIG_NLS_CODEPAGE_1251=m
+ CONFIG_NLS_ASCII=y
+-CONFIG_NLS_ISO8859_1=y
+-CONFIG_NLS_UTF8=y
++CONFIG_NLS_ISO8859_1=m
++CONFIG_NLS_ISO8859_2=m
++CONFIG_NLS_ISO8859_3=m
++CONFIG_NLS_ISO8859_4=m
++CONFIG_NLS_ISO8859_5=m
++CONFIG_NLS_ISO8859_6=m
++CONFIG_NLS_ISO8859_7=m
++CONFIG_NLS_ISO8859_9=m
++CONFIG_NLS_ISO8859_13=m
++CONFIG_NLS_ISO8859_14=m
++CONFIG_NLS_ISO8859_15=m
++CONFIG_NLS_KOI8_R=m
++CONFIG_NLS_KOI8_U=m
++CONFIG_DLM=m
+ CONFIG_UNICODE=y
+-CONFIG_CRYPTO_ECDH=y
+-CONFIG_CRYPTO_SHA512=y
++CONFIG_TRUSTED_KEYS=y
++CONFIG_SECURITY=y
++CONFIG_SECURITY_SELINUX=y
++CONFIG_SECURITY_APPARMOR=y
++CONFIG_DEFAULT_SECURITY_DAC=y
++CONFIG_CRYPTO_USER=m
++CONFIG_CRYPTO_CRYPTD=m
++CONFIG_CRYPTO_CHACHA20POLY1305=m
++CONFIG_CRYPTO_ADIANTUM=m
++CONFIG_CRYPTO_XCBC=m
++CONFIG_CRYPTO_BLAKE2S=m
++CONFIG_CRYPTO_MICHAEL_MIC=m
++CONFIG_CRYPTO_WP512=m
+ CONFIG_CRYPTO_TWOFISH=y
++CONFIG_CRYPTO_LZO=y
++CONFIG_CRYPTO_LZ4=m
+ CONFIG_CRYPTO_ANSI_CPRNG=y
+-CONFIG_CRYPTO_USER_API_HASH=y
+-CONFIG_CRYPTO_USER_API_SKCIPHER=y
++CONFIG_CRYPTO_USER_API_HASH=m
++CONFIG_CRYPTO_USER_API_SKCIPHER=m
++CONFIG_CRYPTO_USER_API_RNG=m
++CONFIG_CRYPTO_USER_API_AEAD=m
+ CONFIG_CRYPTO_DEV_ROCKCHIP=y
+ CONFIG_CRYPTO_DEV_ROCKCHIP_DEV=y
+ CONFIG_CRC_CCITT=y
+-CONFIG_CRC_T10DIF=y
+ CONFIG_CRC7=y
++CONFIG_LIBCRC32C=y
+ # CONFIG_XZ_DEC_X86 is not set
+ # CONFIG_XZ_DEC_POWERPC is not set
+ # CONFIG_XZ_DEC_IA64 is not set
+@@ -599,7 +1370,6 @@ CONFIG_CMA_SIZE_MBYTES=128
+ CONFIG_PRINTK_TIME=y
+ CONFIG_PRINTK_TIME_FROM_ARM_ARCH_TIMER=y
+ CONFIG_DYNAMIC_DEBUG=y
+-CONFIG_DEBUG_INFO=y
+ CONFIG_MAGIC_SYSRQ=y
+ CONFIG_MAGIC_SYSRQ_DEFAULT_ENABLE=0
+ CONFIG_SCHEDSTATS=y
+-- 
+Armbian
+
+
+From 7a08282c7b26233bc24aa9102989db0df5bf47c1 Mon Sep 17 00:00:00 2001
+From: Yan Wang <frank@khadas.com>
+Date: Mon, 21 Nov 2022 21:55:40 +0800
+Subject: arm64: dts: Edge2: fix imx415
+
+Signed-off-by: Yan Wang <frank@khadas.com>
+Change-Id: I37ac2f7a04ca457ad725e83245ef7709c5925590
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi | 75 ++++++----
+ 1 file changed, 48 insertions(+), 27 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi
+index c1b0f47e2b51..c82770442ee7 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi
+@@ -111,21 +111,24 @@ &i2c4 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&i2c4m3_xfer>;
+ 
+-	aw8601b: aw8601b@c {
+-		compatible = "awinic,aw8601";
++	dw9714b: dw9714b@c {
++		compatible = "dongwoon,dw9714";
+ 		status = "okay";
+ 		reg = <0x0c>;
+-		rockchip,vcm-start-current = <56>;
+-		rockchip,vcm-rated-current = <96>;
+-		rockchip,vcm-step-mode = <4>;
++		pinctrl-names = "camd_gpios";
++		pinctrl-0 = <&camd_gpio>;
++		focus-gpios = <&gpio1 RK_PA0 GPIO_ACTIVE_HIGH>;
++		rockchip,vcm-start-current = <20>;
++		rockchip,vcm-rated-current = <76>;
++		rockchip,vcm-step-mode = <0>;
+ 		rockchip,camera-module-index = <0>;
+ 		rockchip,camera-module-facing = "back";
+ 	};
+ 
+-	imx415b: imx415b@37 {
++	imx415b: imx415b@1a {
+ 		compatible = "sony,imx415";
+ 		status = "okay";
+-		reg = <0x37>;
++		reg = <0x1a>;
+ 		clocks = <&cru CLK_MIPI_CAMARAOUT_M1>;
+ 		clock-names = "xvclk";
+ 		power-domains = <&power RK3588_PD_VI>;
+@@ -133,12 +136,12 @@ imx415b: imx415b@37 {
+ 		pinctrl-0 = <&mipim1_camera1_clk>, <&camb_gpio>;
+ 		rockchip,grf = <&sys_grf>;
+ 		reset-gpios = <&gpio1 RK_PB2 GPIO_ACTIVE_LOW>;
+-		pwdn-gpios = <&gpio1 RK_PB3 GPIO_ACTIVE_LOW>;
++		pwdn-gpios = <&gpio1 RK_PB3 GPIO_ACTIVE_HIGH>;
+ 		rockchip,camera-module-index = <0>;
+ 		rockchip,camera-module-facing = "back";
+ 		rockchip,camera-module-name = "CMK-OT2022-PX1";
+ 		rockchip,camera-module-lens-name = "IR0147-50IRC-8M-F20";
+-		lens-focus = <&aw8601b>;
++		lens-focus = <&dw9714b>;
+ 		port {
+ 			imx415b_out0: endpoint {
+ 				remote-endpoint = <&mipi_in_dcphy0>;
+@@ -153,21 +156,24 @@ &i2c3 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&i2c3m0_xfer>;
+ 
+-	aw8601f: aw8601f@c {
+-		compatible = "awinic,aw8601";
++	dw9714f: dw9714f@c {
++		compatible = "dongwoon,dw9714";
+ 		status = "okay";
+ 		reg = <0x0c>;
+-		rockchip,vcm-start-current = <56>;
+-		rockchip,vcm-rated-current = <96>;
+-		rockchip,vcm-step-mode = <4>;
++		pinctrl-names = "cama_gpios";
++		pinctrl-0 = <&cama_gpio>;
++		focus-gpios = <&gpio1 RK_PA1 GPIO_ACTIVE_HIGH>;
++		rockchip,vcm-start-current = <20>;
++		rockchip,vcm-rated-current = <76>;
++		rockchip,vcm-step-mode = <0>;
+ 		rockchip,camera-module-index = <1>;
+ 		rockchip,camera-module-facing = "front";
+ 	};
+ 
+-	imx415f: imx415f@37 {
++	imx415f: imx415f@1a {
+ 		compatible = "sony,imx415";
+ 		status = "okay";
+-		reg = <0x37>;
++		reg = <0x1a>;
+ 		clocks = <&cru CLK_MIPI_CAMARAOUT_M2>;
+ 		clock-names = "xvclk";
+ 		power-domains = <&power RK3588_PD_VI>;
+@@ -175,12 +181,12 @@ imx415f: imx415f@37 {
+ 		pinctrl-0 = <&mipim1_camera2_clk>, <&camf_gpio>;
+ 		rockchip,grf = <&sys_grf>;
+ 		reset-gpios = <&gpio3 RK_PC6 GPIO_ACTIVE_LOW>;
+-		pwdn-gpios = <&gpio3 RK_PC5 GPIO_ACTIVE_LOW>;
++		pwdn-gpios = <&gpio3 RK_PC5 GPIO_ACTIVE_HIGH>;
+ 		rockchip,camera-module-index = <1>;
+ 		rockchip,camera-module-facing = "front";
+ 		rockchip,camera-module-name = "CMK-OT2022-PX1";
+ 		rockchip,camera-module-lens-name = "IR0147-50IRC-8M-F20";
+-		lens-focus = <&aw8601f>;
++		lens-focus = <&dw9714f>;
+ 		port {
+ 			imx415f_out1: endpoint {
+ 				remote-endpoint = <&mipi_in_dcphy1>;
+@@ -195,32 +201,35 @@ &i2c8 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&i2c8m2_xfer>;
+ 
+-	aw8601c: aw8601c@c {
+-		compatible = "awinic,aw8601";
++	dw9714c: dw9714c@c {
++		compatible = "dongwoon,dw9714";
+ 		status = "okay";
+ 		reg = <0x0c>;
+-		rockchip,vcm-start-current = <56>;
+-		rockchip,vcm-rated-current = <96>;
+-		rockchip,vcm-step-mode = <4>;
++		pinctrl-names = "camn_gpios";
++		pinctrl-0 = <&camn_gpio>;
++		focus-gpios = <&gpio1 RK_PA6 GPIO_ACTIVE_HIGH>;
++		rockchip,vcm-start-current = <20>;
++		rockchip,vcm-rated-current = <76>;
++		rockchip,vcm-step-mode = <0>;
+ 		rockchip,camera-module-index = <0>;
+ 		rockchip,camera-module-facing = "back";
+ 	};
+ 
+-	imx415: imx415@37 {
++	imx415: imx415@1a {
+ 		compatible = "sony,imx415";
+-		reg = <0x37>;
++		reg = <0x1a>;
+ 		clocks = <&cru CLK_MIPI_CAMARAOUT_M3>;
+ 		clock-names = "xvclk";
+ 		pinctrl-names = "default", "camc_gpios";
+ 		pinctrl-0 = <&mipim1_camera3_clk>, <&camc_gpio>;
+ 		power-domains = <&power RK3588_PD_VI>;
+ 		reset-gpios = <&gpio3 RK_PB4 GPIO_ACTIVE_LOW>;	
+-		pwdn-gpios = <&gpio1 RK_PA4 GPIO_ACTIVE_LOW>;
++		pwdn-gpios = <&gpio1 RK_PA4 GPIO_ACTIVE_HIGH>;
+ 		rockchip,camera-module-index = <0>;
+ 		rockchip,camera-module-facing = "back";
+ 		rockchip,camera-module-name = "CMK-OT2022-PX1";
+ 		rockchip,camera-module-lens-name = "IR0147-50IRC-8M-F20";
+-		lens-focus = <&aw8601c>;
++		lens-focus = <&dw9714c>;
+ 		port {
+ 			imx415c_out0: endpoint {
+ 				remote-endpoint = <&mipidphy0_in_ucam0>;
+@@ -247,6 +256,18 @@ camc_gpio: camc-gpio {
+ 				<3 RK_PB4 RK_FUNC_GPIO &pcfg_pull_none>,
+ 				<1 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
++		camd_gpio: camd-gpio {
++			rockchip,pins =
++				<1 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++		cama_gpio: cama-gpio {
++			rockchip,pins =
++				<1 RK_PA1 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++		camn_gpio: camn-gpio {
++			rockchip,pins =
++				<1 RK_PA6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
+ 	};
+ };
+ 
+-- 
+Armbian
+
+
+From 18a66b69e56dd37af7c68660dc0702daa55b7215 Mon Sep 17 00:00:00 2001
+From: Nick Xie <nick@khadas.com>
+Date: Tue, 22 Nov 2022 18:01:43 +0800
+Subject: arm64: dts: camera: Edge2: update lens pinctrl
+
+Signed-off-by: Nick Xie <nick@khadas.com>
+Change-Id: Ib182b40579785a20a1a37dbc05df6e3da0e56068
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi | 18 +++++-----
+ 1 file changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi
+index c82770442ee7..2e27954aed42 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2-camera.dtsi
+@@ -115,8 +115,8 @@ dw9714b: dw9714b@c {
+ 		compatible = "dongwoon,dw9714";
+ 		status = "okay";
+ 		reg = <0x0c>;
+-		pinctrl-names = "camd_gpios";
+-		pinctrl-0 = <&camd_gpio>;
++		pinctrl-names = "focusb_gpios";
++		pinctrl-0 = <&focusb_gpio>;
+ 		focus-gpios = <&gpio1 RK_PA0 GPIO_ACTIVE_HIGH>;
+ 		rockchip,vcm-start-current = <20>;
+ 		rockchip,vcm-rated-current = <76>;
+@@ -160,8 +160,8 @@ dw9714f: dw9714f@c {
+ 		compatible = "dongwoon,dw9714";
+ 		status = "okay";
+ 		reg = <0x0c>;
+-		pinctrl-names = "cama_gpios";
+-		pinctrl-0 = <&cama_gpio>;
++		pinctrl-names = "focusf_gpios";
++		pinctrl-0 = <&focusf_gpio>;
+ 		focus-gpios = <&gpio1 RK_PA1 GPIO_ACTIVE_HIGH>;
+ 		rockchip,vcm-start-current = <20>;
+ 		rockchip,vcm-rated-current = <76>;
+@@ -205,8 +205,8 @@ dw9714c: dw9714c@c {
+ 		compatible = "dongwoon,dw9714";
+ 		status = "okay";
+ 		reg = <0x0c>;
+-		pinctrl-names = "camn_gpios";
+-		pinctrl-0 = <&camn_gpio>;
++		pinctrl-names = "focusc_gpios";
++		pinctrl-0 = <&focusc_gpio>;
+ 		focus-gpios = <&gpio1 RK_PA6 GPIO_ACTIVE_HIGH>;
+ 		rockchip,vcm-start-current = <20>;
+ 		rockchip,vcm-rated-current = <76>;
+@@ -256,15 +256,15 @@ camc_gpio: camc-gpio {
+ 				<3 RK_PB4 RK_FUNC_GPIO &pcfg_pull_none>,
+ 				<1 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+-		camd_gpio: camd-gpio {
++		focusb_gpio: focusb-gpio {
+ 			rockchip,pins =
+ 				<1 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+-		cama_gpio: cama-gpio {
++		focusf_gpio: focusf-gpio {
+ 			rockchip,pins =
+ 				<1 RK_PA1 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+-		camn_gpio: camn-gpio {
++		focusc_gpio: focusc-gpio {
+ 			rockchip,pins =
+ 				<1 RK_PA6 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+-- 
+Armbian
+
+
+From b84d2982273b805dd1bacac84367121d793a80c5 Mon Sep 17 00:00:00 2001
+From: Nick Xie <nick@khadas.com>
+Date: Tue, 22 Nov 2022 18:02:42 +0800
+Subject: arm64: dts: camera: Edge2: enable mipi_dcphy1
+
+Signed-off-by: Nick Xie <nick@khadas.com>
+Change-Id: I196ae6d2f7bb6e68f3ebeec3f7ff15d3e1e762df
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index b2f4fa6b4c09..1174918ed5a0 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -335,7 +335,7 @@ &dsi1_panel {
+ };
+ 
+ &mipi_dcphy1 {
+-	status = "disabled";
++	status = "okay";
+ };
+ 
+ &dsi1_in_vp2 {
+-- 
+Armbian
+
+
+From bc37974513c6022a26cabefd4df89cea955606fb Mon Sep 17 00:00:00 2001
+From: Ivan Li <ivan.li@wesion.com>
+Date: Mon, 5 Dec 2022 10:42:34 +0800
+Subject: dts: rockchip: Edge2: IR: Add khadas remote key value
+
+Signed-off-by: Ivan Li <ivan.li@wesion.com>
+Change-Id: I577f17e26eedfddba2a73ad121fe563a81e197df
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 75 ++++++----
+ 1 file changed, 44 insertions(+), 31 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 1174918ed5a0..f8c09cdba478 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -803,37 +803,50 @@ ir_key1 {
+ 	ir_key2 {
+ 		rockchip,usercode = <0xff00>;
+ 		rockchip,key_table =
+-			<0xf9   KEY_HOME>,
+-			<0xbf   KEY_BACK>,
+-			<0xfb   KEY_MENU>,
+-			<0xaa   KEY_REPLY>,
+-			<0xb9   KEY_UP>,
+-			<0xe9   KEY_DOWN>,
+-			<0xb8   KEY_LEFT>,
+-			<0xea   KEY_RIGHT>,
+-			<0xeb   KEY_VOLUMEDOWN>,
+-			<0xef   KEY_VOLUMEUP>,
+-			<0xf7   KEY_MUTE>,
+-			<0xe7   KEY_POWER>,
+-			<0xfc   KEY_POWER>,
+-			<0xa9   KEY_VOLUMEDOWN>,
+-			<0xa8   KEY_PLAYPAUSE>,
+-			<0xe0   KEY_VOLUMEDOWN>,
+-			<0xa5   KEY_VOLUMEDOWN>,
+-			<0xab   183>,
+-			<0xb7   388>,
+-			<0xe8   388>,
+-			<0xf8   184>,
+-			<0xaf   185>,
+-			<0xed   KEY_VOLUMEDOWN>,
+-			<0xee   186>,
+-			<0xb3   KEY_VOLUMEDOWN>,
+-			<0xf1   KEY_VOLUMEDOWN>,
+-			<0xf2   KEY_VOLUMEDOWN>,
+-			<0xf3   KEY_SEARCH>,
+-			<0xb4   KEY_VOLUMEDOWN>,
+-			<0xa4   KEY_SETUP>,
+-			<0xbe   KEY_SEARCH>;
++//			<0xf9   KEY_HOME>,
++//			<0xbf   KEY_BACK>,
++//			<0xfb   KEY_MENU>,
++//			<0xaa   KEY_REPLY>,
++//			<0xb9   KEY_UP>,
++//			<0xe9   KEY_DOWN>,
++//			<0xb8   KEY_LEFT>,
++//			<0xea   KEY_RIGHT>,
++//			<0xeb   KEY_VOLUMEDOWN>,
++//			<0xef   KEY_VOLUMEUP>,
++//			<0xf7   KEY_MUTE>,
++//			<0xe7   KEY_POWER>,
++//			<0xfc   KEY_POWER>,
++//			<0xa9   KEY_VOLUMEDOWN>,
++//			<0xa8   KEY_PLAYPAUSE>,
++//			<0xe0   KEY_VOLUMEDOWN>,
++//			<0xa5   KEY_VOLUMEDOWN>,
++//			<0xab   183>,
++//			<0xb7   388>,
++//			<0xe8   388>,
++//			<0xf8   184>,
++//			<0xaf   185>,
++//			<0xed   KEY_VOLUMEDOWN>,
++//			<0xee   186>,
++//			<0xb3   KEY_VOLUMEDOWN>,
++//			<0xf1   KEY_VOLUMEDOWN>,
++//			<0xf2   KEY_VOLUMEDOWN>,
++//			<0xf3   KEY_SEARCH>,
++//			<0xb4   KEY_VOLUMEDOWN>,
++//			<0xa4   KEY_SETUP>,
++//			<0xbe   KEY_SEARCH>;
++			<0xeb 116>,		//KEY_POWER
++			<0xec 139>,		//KEY_MENU
++			<0xfc 103>,		//KEY_UP
++			<0xfd 108>,		//KEY_DOWN
++			<0xf1 105>,		//KEY_LEFT
++			<0xe5 106>,		//KEY_RIGHT
++			<0xf8 28>, 		//KEY_Enter
++			<0xa7 114>,		//KEY_VOLUMEDOWN
++			<0xa3 388>,
++			<0xa4 388>,		//KEY_CURSOR
++			<0xf4 115>,		//KEY_VOLUMEUP
++			<0xfe 158>,		//KEY_BACK
++			<0xb7 172>;		//KEY_HOMEPAGE
+ 	};
+ 
+ 	ir_key3 {
+-- 
+Armbian
+
+
+From 745f671aa85983ef6de01b12d04db7d596760fdc Mon Sep 17 00:00:00 2001
+From: Nick Xie <nick@khadas.com>
+Date: Tue, 6 Dec 2022 17:25:46 +0800
+Subject: arm64: dts: IR: Edge2: remove unused IR map
+
+Signed-off-by: Nick Xie <nick@khadas.com>
+Change-Id: I8cd387844b3ddd6efebf2dce9eb6fe93871b89d4
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 90 ----------
+ 1 file changed, 90 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index f8c09cdba478..dfacb4da2db7 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -774,66 +774,8 @@ &pwm3 {
+ 	status = "okay";
+ 
+ 	ir_key1 {
+-		rockchip,usercode = <0x4040>;
+-		rockchip,key_table =
+-			<0xf2   KEY_REPLY>,
+-			<0xba   KEY_BACK>,
+-			<0xf4   KEY_UP>,
+-			<0xf1   KEY_DOWN>,
+-			<0xef   KEY_LEFT>,
+-			<0xee   KEY_RIGHT>,
+-			<0xbd   KEY_HOME>,
+-			<0xea   KEY_VOLUMEUP>,
+-			<0xe3   KEY_VOLUMEDOWN>,
+-			<0xe2   KEY_SEARCH>,
+-			<0xb2   KEY_POWER>,
+-			<0xbc   KEY_MUTE>,
+-			<0xec   KEY_MENU>,
+-			<0xbf   0x190>,
+-			<0xe0   0x191>,
+-			<0xe1   0x192>,
+-			<0xe9   183>,
+-			<0xe6   248>,
+-			<0xe8   185>,
+-			<0xe7   186>,
+-			<0xf0   388>,
+-			<0xbe   0x175>;
+-	};
+-
+-	ir_key2 {
+ 		rockchip,usercode = <0xff00>;
+ 		rockchip,key_table =
+-//			<0xf9   KEY_HOME>,
+-//			<0xbf   KEY_BACK>,
+-//			<0xfb   KEY_MENU>,
+-//			<0xaa   KEY_REPLY>,
+-//			<0xb9   KEY_UP>,
+-//			<0xe9   KEY_DOWN>,
+-//			<0xb8   KEY_LEFT>,
+-//			<0xea   KEY_RIGHT>,
+-//			<0xeb   KEY_VOLUMEDOWN>,
+-//			<0xef   KEY_VOLUMEUP>,
+-//			<0xf7   KEY_MUTE>,
+-//			<0xe7   KEY_POWER>,
+-//			<0xfc   KEY_POWER>,
+-//			<0xa9   KEY_VOLUMEDOWN>,
+-//			<0xa8   KEY_PLAYPAUSE>,
+-//			<0xe0   KEY_VOLUMEDOWN>,
+-//			<0xa5   KEY_VOLUMEDOWN>,
+-//			<0xab   183>,
+-//			<0xb7   388>,
+-//			<0xe8   388>,
+-//			<0xf8   184>,
+-//			<0xaf   185>,
+-//			<0xed   KEY_VOLUMEDOWN>,
+-//			<0xee   186>,
+-//			<0xb3   KEY_VOLUMEDOWN>,
+-//			<0xf1   KEY_VOLUMEDOWN>,
+-//			<0xf2   KEY_VOLUMEDOWN>,
+-//			<0xf3   KEY_SEARCH>,
+-//			<0xb4   KEY_VOLUMEDOWN>,
+-//			<0xa4   KEY_SETUP>,
+-//			<0xbe   KEY_SEARCH>;
+ 			<0xeb 116>,		//KEY_POWER
+ 			<0xec 139>,		//KEY_MENU
+ 			<0xfc 103>,		//KEY_UP
+@@ -848,38 +790,6 @@ ir_key2 {
+ 			<0xfe 158>,		//KEY_BACK
+ 			<0xb7 172>;		//KEY_HOMEPAGE
+ 	};
+-
+-	ir_key3 {
+-		rockchip,usercode = <0x1dcc>;
+-		rockchip,key_table =
+-			<0xee   KEY_REPLY>,
+-			<0xf0   KEY_BACK>,
+-			<0xf8   KEY_UP>,
+-			<0xbb   KEY_DOWN>,
+-			<0xef   KEY_LEFT>,
+-			<0xed   KEY_RIGHT>,
+-			<0xfc   KEY_HOME>,
+-			<0xf1   KEY_VOLUMEUP>,
+-			<0xfd   KEY_VOLUMEDOWN>,
+-			<0xb7   KEY_SEARCH>,
+-			<0xff   KEY_POWER>,
+-			<0xf3   KEY_MUTE>,
+-			<0xbf   KEY_MENU>,
+-			<0xf9   0x191>,
+-			<0xf5   0x192>,
+-			<0xb3   388>,
+-			<0xbe   KEY_1>,
+-			<0xba   KEY_2>,
+-			<0xb2   KEY_3>,
+-			<0xbd   KEY_4>,
+-			<0xf9   KEY_5>,
+-			<0xb1   KEY_6>,
+-			<0xfc   KEY_7>,
+-			<0xf8   KEY_8>,
+-			<0xb0   KEY_9>,
+-			<0xb6   KEY_0>,
+-			<0xb5   KEY_BACKSPACE>;
+-	};
+ };
+ 
+ &pwm7 {
+-- 
+Armbian
+
+
+From d194909d2bee110ea2e118bc39d50692c5f301c6 Mon Sep 17 00:00:00 2001
+From: Angus Ainslie <angus@akkea.ca>
+Date: Thu, 12 Aug 2021 09:52:18 -0700
+Subject: Bluetooth: btbcm: add patch ram for bluetooth
+
+Bluetooth on the BCM43752 needs a patchram file to function correctly.
+
+Signed-off-by: Angus Ainslie <angus@akkea.ca>
+Signed-off-by: Marcel Holtmann <marcel@holtmann.org>
+Change-Id: Ieaeb28c8cdfdfdebe4f5be547a01024ba4188cb9
+---
+ drivers/bluetooth/btbcm.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/bluetooth/btbcm.c b/drivers/bluetooth/btbcm.c
+index 1b9743b7f2ef..c5af5715cd17 100644
+--- a/drivers/bluetooth/btbcm.c
++++ b/drivers/bluetooth/btbcm.c
+@@ -387,6 +387,7 @@ struct bcm_subver_table {
+ };
+ 
+ static const struct bcm_subver_table bcm_uart_subver_table[] = {
++	{ 0x1111, "BCM4362A2"	},	/* 000.017.017 */
+ 	{ 0x4103, "BCM4330B1"	},	/* 002.001.003 */
+ 	{ 0x410d, "BCM4334B0"	},	/* 002.001.013 */
+ 	{ 0x410e, "BCM43341B0"	},	/* 002.001.014 */
+-- 
+Armbian
+


### PR DESCRIPTION
I have started this months ago, but due to high demand from other subjects (armbian-next) haven't had time to finish.

What I did here was take Khadas tree (.66) and rebase it on top of rk3.4/Radxa tree (.110) for the rock-5b, similar to what was done for the OrangePi5. Some patches conflicted and I intervened (those are marked as intervention).

This needs review, a board file, a developer with the new Khadas I/O board for UART, and some luck, patience to fix my mistakes, and might just work. Who knows? If it's useless just bin this...

There's two patch files, one with stuff I deemed "required" and other with stuff "might be nice". The MCU stuff of Khadas is heavily entwined in there...

The complete git tree with those patches is at
- summary: https://rpardini.github.io/linux/armbian_rockchip_rk3588_legacy_with_initial_kedge2_20230203.html
- git tree: https://github.com/rpardini/linux/tree/armbian_rockchip_rk3588_legacy_with_initial_kedge2_20230203

Pinging @150balbes who @igorpecovnik told me might be working the kedge2...
