### PR TITLE
Wrong wallpaper path on i3wm package creation

### DIFF
--- a/config/desktop/focal/environments/i3-wm/armbian/create_desktop_package.sh
+++ b/config/desktop/focal/environments/i3-wm/armbian/create_desktop_package.sh
@@ -11,4 +11,4 @@ cp "${SRC}"/packages/blobs/desktop/icons/armbian.png "${destination}"/usr/share/
 
 # install wallpapers
 mkdir -p "${destination}"/usr/share/backgrounds/armbian/
-cp "${SRC}"/packages/blobs/desktop/wallpapers/armbian*.jpg "${destination}"/usr/share/backgrounds/armbian/
+cp "${SRC}"/packages/blobs/desktop/desktop-wallpapers/armbian*.jpg "${destination}"/usr/share/backgrounds/armbian/


### PR DESCRIPTION
# Description

Fix on unsupported desktop. Found due better logging in next.