### PR TITLE
Fix wireless modules indentation warnings

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -309,6 +309,7 @@ driver_rtl8188EU_rtl8188ETV()
 		process_patch_file "${SRC}/patch/misc/wireless-realtek-8188eu-5.12.patch" "applying"
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8188eu-Fix-uninitialized-cfg80211-chan-def.patch" "applying"
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8188eu-Fix-p2p-go-advertising.patch" "applying"
+		process_patch_file "${SRC}/patch/misc/wireless-rtl8188eu-Fix-misleading-indentation.patch" "applying"
 
 		# fix compilation for kernels >= 5.4
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8188eu-Fix-VFS-import.patch" "applying"
@@ -536,6 +537,7 @@ driver_rtl8822BS()
 
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8822bs-Fix-uninitialized-cfg80211-chan-def.patch" "applying"
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8822bs-Fix-p2p-go-advertising.patch" "applying"
+		process_patch_file "${SRC}/patch/misc/wireless-rtl8822bs-Fix-misleading-indentation.patch" "applying"
 
 		# fix compilation for kernels >= 5.4
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8822bs-Fix-VFS-import.patch" "applying"

--- a/patch/misc/wireless-rtl8188eu-Fix-misleading-indentation.patch
+++ b/patch/misc/wireless-rtl8188eu-Fix-misleading-indentation.patch
@@ -1,0 +1,80 @@
+From 1016fd9fda78a552dcc8e4cac32254aaf90cb5c4 Mon Sep 17 00:00:00 2001
+From: Ivan Podogov <ginkage@yandex.ru>
+Date: Fri, 3 Feb 2023 20:56:00 +0000
+Subject: [PATCH] Fix rtl8188eu module indentation
+
+Signed-off-by: Ivan Podogov <ginkage@yandex.ru>
+---
+ .../net/wireless/rtl8188eu/core/efuse/rtw_efuse.c   | 13 ++++++-------
+ drivers/net/wireless/rtl8188eu/core/rtw_mlme.c      |  2 +-
+ drivers/net/wireless/rtl8188eu/core/rtw_recv.c      | 10 +++++-----
+ 3 files changed, 14 insertions(+), 15 deletions(-)
+
+diff --git a/drivers/net/wireless/rtl8188eu/core/efuse/rtw_efuse.c b/drivers/net/wireless/rtl8188eu/core/efuse/rtw_efuse.c
+index 6153aaff2..1b1b2f872 100644
+--- a/drivers/net/wireless/rtl8188eu/core/efuse/rtw_efuse.c
++++ b/drivers/net/wireless/rtl8188eu/core/efuse/rtw_efuse.c
+@@ -712,8 +712,7 @@ void rtw_efuse_analyze(PADAPTER	padapter, u8 Type, u8 Fake)
+ 						offset = ((efuseExtHdr & 0xF0) >> 1) | offset_2_0;
+ 						wden = (efuseExtHdr & 0x0F);
+ 						efuseHeader2Byte = (efuseExtHdr<<8)|efuseHeader;
+-						RTW_INFO("Find efuseHeader2Byte = 0x%04X, offset=%d, wden=0x%x\n",
+-										efuseHeader2Byte, offset, wden);
++						RTW_INFO("Find efuseHeader2Byte = 0x%04X, offset=%d, wden=0x%x\n", efuseHeader2Byte, offset, wden);
+ 					}
+ 				} else {
+ 					RTW_INFO("Error, efuse[%d]=0xff, efuseExtHdr=0xff\n", eFuse_Addr-1);
+@@ -816,11 +815,11 @@ void rtw_efuse_analyze(PADAPTER	padapter, u8 Type, u8 Fake)
+ 	for (i = 0; i < mapLen; i++) {
+ 		if (i % 16 == 0)
+ 			RTW_PRINT_SEL(RTW_DBGDUMP, "0x%03x: ", i);
+-			_RTW_PRINT_SEL(RTW_DBGDUMP, "%02X%s"
+-				, pEfuseHal->fakeEfuseInitMap[i]
+-				, ((i + 1) % 16 == 0) ? "\n" : (((i + 1) % 8 == 0) ? "	  " : " ")
+-			);
+-		}
++		_RTW_PRINT_SEL(RTW_DBGDUMP, "%02X%s"
++			, pEfuseHal->fakeEfuseInitMap[i]
++			, ((i + 1) % 16 == 0) ? "\n" : (((i + 1) % 8 == 0) ? "	  " : " ")
++		);
++	}
+ 	_RTW_PRINT_SEL(RTW_DBGDUMP, "\n");
+ 
+ out_free_buffer:
+diff --git a/drivers/net/wireless/rtl8188eu/core/rtw_mlme.c b/drivers/net/wireless/rtl8188eu/core/rtw_mlme.c
+index 721b323aa..4ac76601a 100644
+--- a/drivers/net/wireless/rtl8188eu/core/rtw_mlme.c
++++ b/drivers/net/wireless/rtl8188eu/core/rtw_mlme.c
+@@ -3125,7 +3125,7 @@ void rtw_drv_scan_by_self(_adapter *padapter, u8 reason)
+ 		else
+ 		#endif
+ 			RTW_INFO(FUNC_ADPT_FMT" exit BusyTraffic\n", FUNC_ADPT_ARG(padapter));
+-			goto exit;
++		goto exit;
+ 	}
+ 	else if (ssc_chk != SS_ALLOW)
+ 		goto exit;
+diff --git a/drivers/net/wireless/rtl8188eu/core/rtw_recv.c b/drivers/net/wireless/rtl8188eu/core/rtw_recv.c
+index 4c96fc1c8..fae9d20d8 100644
+--- a/drivers/net/wireless/rtl8188eu/core/rtw_recv.c
++++ b/drivers/net/wireless/rtl8188eu/core/rtw_recv.c
+@@ -3538,11 +3538,11 @@ int validate_mp_recv_frame(_adapter *adapter, union recv_frame *precv_frame)
+ 			for (i = 0; i < precv_frame->u.hdr.len; i = i + 8)
+ 				RTW_INFO("%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X:\n", *(ptr + i),
+ 					*(ptr + i + 1), *(ptr + i + 2) , *(ptr + i + 3) , *(ptr + i + 4), *(ptr + i + 5), *(ptr + i + 6), *(ptr + i + 7));
+-				RTW_INFO("#############################\n");
+-				_rtw_memset(pmppriv->mplink_buf, '\0' , sizeof(pmppriv->mplink_buf));
+-				_rtw_memcpy(pmppriv->mplink_buf, ptr, precv_frame->u.hdr.len);
+-				pmppriv->mplink_rx_len = precv_frame->u.hdr.len;
+-				pmppriv->mplink_brx =_TRUE;
++			RTW_INFO("#############################\n");
++			_rtw_memset(pmppriv->mplink_buf, '\0' , sizeof(pmppriv->mplink_buf));
++			_rtw_memcpy(pmppriv->mplink_buf, ptr, precv_frame->u.hdr.len);
++			pmppriv->mplink_rx_len = precv_frame->u.hdr.len;
++			pmppriv->mplink_brx =_TRUE;
+ 		}
+ 	}
+ 	if (pmppriv->bloopback) {
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/misc/wireless-rtl8822bs-Fix-misleading-indentation.patch
+++ b/patch/misc/wireless-rtl8822bs-Fix-misleading-indentation.patch
@@ -1,0 +1,48 @@
+From 1016fd9fda78a552dcc8e4cac32254aaf90cb5c4 Mon Sep 17 00:00:00 2001
+From: Ivan Podogov <ginkage@yandex.ru>
+Date: Fri, 3 Feb 2023 20:56:00 +0000
+Subject: [PATCH] Fix rtl8822bs module indentation
+
+Signed-off-by: Ivan Podogov <ginkage@yandex.ru>
+---
+ .../net/wireless/rtl8822bs/core/efuse/rtw_efuse.c   | 10 +++++-----
+ .../net/wireless/rtl8822bs/hal/phydm/phydm_ccx.c    |  4 ++--
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/net/wireless/rtl8822bs/core/efuse/rtw_efuse.c b/drivers/net/wireless/rtl8822bs/core/efuse/rtw_efuse.c
+index 2f3d6cf9a..7efa31c5c 100644
+--- a/drivers/net/wireless/rtl8822bs/core/efuse/rtw_efuse.c
++++ b/drivers/net/wireless/rtl8822bs/core/efuse/rtw_efuse.c
+@@ -713,11 +713,11 @@ void rtw_efuse_analyze(PADAPTER	padapter, u8 Type, u8 Fake)
+ 	for (i = 0; i < mapLen; i++) {
+ 		if (i % 16 == 0)
+ 			RTW_PRINT_SEL(RTW_DBGDUMP, "0x%03x: ", i);
+-			_RTW_PRINT_SEL(RTW_DBGDUMP, "%02X%s"
+-				, pEfuseHal->fakeEfuseInitMap[i]
+-				, ((i + 1) % 16 == 0) ? "\n" : (((i + 1) % 8 == 0) ? "	  " : " ")
+-			);
+-		}
++		_RTW_PRINT_SEL(RTW_DBGDUMP, "%02X%s"
++			, pEfuseHal->fakeEfuseInitMap[i]
++			, ((i + 1) % 16 == 0) ? "\n" : (((i + 1) % 8 == 0) ? "	  " : " ")
++		);
++	}
+ 	_RTW_PRINT_SEL(RTW_DBGDUMP, "\n");
+ 	if (eFuseWord)
+ 		rtw_mfree((u8 *)eFuseWord, EFUSE_MAX_SECTION_NUM * (EFUSE_MAX_WORD_UNIT * 2));
+diff --git a/drivers/net/wireless/rtl8822bs/hal/phydm/phydm_ccx.c b/drivers/net/wireless/rtl8822bs/hal/phydm/phydm_ccx.c
+index 183dd2481..0fb028443 100644
+--- a/drivers/net/wireless/rtl8822bs/hal/phydm/phydm_ccx.c
++++ b/drivers/net/wireless/rtl8822bs/hal/phydm/phydm_ccx.c
+@@ -689,7 +689,7 @@ phydm_get_nhm_result(
+ 	for (i = 0; i <= 11; i++)
+ 		ccx_info->nhm_result_total += ccx_info->nhm_result[i];
+ 
+-		PHYDM_DBG(p_dm, DBG_ENV_MNTR,
++	PHYDM_DBG(p_dm, DBG_ENV_MNTR,
+ 		("NHM_result=(H->L)[%d %d %d %d (igi) %d %d %d %d %d %d %d %d]\n",
+ 			ccx_info->nhm_result[11], ccx_info->nhm_result[10], ccx_info->nhm_result[9],
+ 			ccx_info->nhm_result[8], ccx_info->nhm_result[7], ccx_info->nhm_result[6],
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+


### PR DESCRIPTION
# Description

Fix build failing due to several `-Wmisleading-indentation` warnings in wireless modules

Jira reference number [AR-9999]

# How Has This Been Tested?

Successfully compiled the kernel under Armbian itself with the following command:
`./compile.sh BOARD=rock-5b BUILD_ONLY=kernel KERNEL_CONFIGURE=no`
(was failing before this change), then flashed and booted it.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
