### PR TITLE
 Fix: Python2 Paths for Legacy Kernel v5.10 with Edge Release 

### DIFF
--- a/lib/functions/compilation/kernel.sh
+++ b/lib/functions/compilation/kernel.sh
@@ -45,15 +45,6 @@ compile_kernel() {
 	# re-read kernel version after patching
 	local version
 	version=$(grab_version "$kerneldir")
-	
-	# Patch python2 path for legacy kernels running on newer Debian Bulleys / Ubuntu Kinetic
-	#    Debian has a deb package the symlinks /usr/bin/python3 to /usr/bin/python so better off to Patch older Kernels
-	if linux-version compare "${version}" ge 5.10; then
-		if linux-version compare "${version}" le 5.11; then
-			display_alert "Patching" "python2" "path"
-			process_patch_file "${SRC}/patch/misc/general-kernel-python2-5.10.y.patch" "applying"
-		fi
-	fi
 
 	display_alert "Compiling $BRANCH kernel" "$version" "info"
 

--- a/lib/functions/compilation/kernel.sh
+++ b/lib/functions/compilation/kernel.sh
@@ -45,6 +45,15 @@ compile_kernel() {
 	# re-read kernel version after patching
 	local version
 	version=$(grab_version "$kerneldir")
+	
+	# Patch python2 path for legacy kernels running on newer Debian Bulleys / Ubuntu Kinetic
+	#    Debian has a deb package the symlinks /usr/bin/python3 to /usr/bin/python so better off to Patch older Kernels
+	if linux-version compare "${version}" ge 5.10; then
+		if linux-version compare "${version}" le 5.11; then
+			display_alert "Patching" "python2" "path"
+			process_patch_file "${SRC}/patch/misc/general-kernel-python2-5.10.y.patch" "applying"
+		fi
+	fi
 
 	display_alert "Compiling $BRANCH kernel" "$version" "info"
 

--- a/lib/functions/compilation/patch/kernel-bootsplash-and-drivers.sh
+++ b/lib/functions/compilation/patch/kernel-bootsplash-and-drivers.sh
@@ -9,6 +9,12 @@ compilation_prepare() {
 	# Temporally set for new "default->legacy,next->current" family naming
 
 	if linux-version compare "${version}" ge 5.10; then
+		if linux-version compare "${version}" le 5.11; then
+			# Patch python2 path for legacy kernels running on newer Debian Bulleys / Ubuntu Kinetic
+			#    Debian has a deb package the symlinks /usr/bin/python3 to /usr/bin/python so better off to Patch older Kernels
+			display_alert "Patching" "python" "info"
+			process_patch_file "${SRC}/patch/misc/general-kernel-python2-5.10.y.patch" "applying"
+		fi
 
 		if test -d ${kerneldir}/debian; then
 			rm -rf ${kerneldir}/debian/*

--- a/patch/misc/general-kernel-python2-5.10.y.patch
+++ b/patch/misc/general-kernel-python2-5.10.y.patch
@@ -1,0 +1,250 @@
+diff --git a/Documentation/networking/device_drivers/atm/cxacru-cf.py b/Documentation/networking/device_drivers/atm/cxacru-cf.py
+index b41d298398c8..413b97579405 100644
+--- a/Documentation/networking/device_drivers/atm/cxacru-cf.py
++++ b/Documentation/networking/device_drivers/atm/cxacru-cf.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ # Copyright 2009 Simon Arlott
+ #
+ # This program is free software; you can redistribute it and/or modify it
+diff --git a/Documentation/sphinx/maintainers_include.py b/Documentation/sphinx/maintainers_include.py
+index dc8fed48d3c2..395a5728d86f 100755
+--- a/Documentation/sphinx/maintainers_include.py
++++ b/Documentation/sphinx/maintainers_include.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ # SPDX-License-Identifier: GPL-2.0
+ # -*- coding: utf-8; mode: python -*-
+ # pylint: disable=R0903, C0330, R0914, R0912, E0401
+diff --git a/Documentation/target/tcm_mod_builder.py b/Documentation/target/tcm_mod_builder.py
+index 54492aa813b9..277e24566923 100755
+--- a/Documentation/target/tcm_mod_builder.py
++++ b/Documentation/target/tcm_mod_builder.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ # The TCM v4 multi-protocol fabric module generation script for drivers/target/$NEW_MOD
+ #
+ # Copyright (c) 2010 Rising Tide Systems
+diff --git a/Documentation/trace/postprocess/decode_msr.py b/Documentation/trace/postprocess/decode_msr.py
+index aa9cc7abd5c2..7c9efdc5c353 100644
+--- a/Documentation/trace/postprocess/decode_msr.py
++++ b/Documentation/trace/postprocess/decode_msr.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ # add symbolic names to read_msr / write_msr in trace
+ # decode_msr msr-index.h < trace
+ import sys
+diff --git a/Makefile b/Makefile
+index 6bbc15bea093..09063da45379 100644
+--- a/Makefile
++++ b/Makefile
+@@ -468,7 +468,7 @@ AWK		= awk
+ INSTALLKERNEL  := installkernel
+ DEPMOD		= depmod
+ PERL		= perl
+-PYTHON		= python
++PYTHON		= python2
+ PYTHON3		= python3
+ CHECK		= sparse
+ BASH		= bash
+diff --git a/arch/ia64/scripts/unwcheck.py b/arch/ia64/scripts/unwcheck.py
+index bfd1b671e35f..5f998048d68c 100644
+--- a/arch/ia64/scripts/unwcheck.py
++++ b/arch/ia64/scripts/unwcheck.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ # SPDX-License-Identifier: GPL-2.0
+ #
+ # Usage: unwcheck.py FILE
+diff --git a/drivers/staging/greybus/tools/lbtest b/drivers/staging/greybus/tools/lbtest
+index 47c481239e98..4b3773b97794 100755
+--- a/drivers/staging/greybus/tools/lbtest
++++ b/drivers/staging/greybus/tools/lbtest
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ # SPDX-License-Identifier: BSD-3-Clause
+ 
+ # Copyright (c) 2015 Google, Inc.
+diff --git a/scripts/bmpconvert b/scripts/bmpconvert
+index 9863444da093..2d5b9b3bfe2c 100755
+--- a/scripts/bmpconvert
++++ b/scripts/bmpconvert
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ # SPDX-License-Identifier: GPL-2.0 */
+ # -*- coding: utf-8 -*-
+ 
+diff --git a/scripts/checkpatch.pl b/scripts/checkpatch.pl
+index 0ad235ee96f9..3c2f0c1f0bac 100755
+--- a/scripts/checkpatch.pl
++++ b/scripts/checkpatch.pl
+@@ -910,10 +910,10 @@ sub is_maintained_obsolete {
+ sub is_SPDX_License_valid {
+ 	my ($license) = @_;
+ 
+-	return 1 if (!$tree || which("python") eq "" || !(-e "$root/scripts/spdxcheck.py") || !(-e "$gitroot"));
++	return 1 if (!$tree || which("python2") eq "" || !(-e "$root/scripts/spdxcheck.py") || !(-e "$gitroot"));
+ 
+ 	my $root_path = abs_path($root);
+-	my $status = `cd "$root_path"; echo "$license" | python scripts/spdxcheck.py -`;
++	my $status = `cd "$root_path"; echo "$license" | python2 scripts/spdxcheck.py -`;
+ 	return 0 if ($status ne "");
+ 	return 1;
+ }
+diff --git a/scripts/clang-wrapper.py b/scripts/clang-wrapper.py
+index 871aa5080bad..c5520905dab0 100755
+--- a/scripts/clang-wrapper.py
++++ b/scripts/clang-wrapper.py
+@@ -1,4 +1,4 @@
+-#! /usr/bin/env python
++#! /usr/bin/env python2
+ # -*- coding: utf-8 -*-
+ 
+ # Copyright (c) 2011-2012, The Linux Foundation. All rights reserved.
+diff --git a/scripts/gcc-wrapper.py b/scripts/gcc-wrapper.py
+index ea74ea852242..c6853b5ee8b4 100755
+--- a/scripts/gcc-wrapper.py
++++ b/scripts/gcc-wrapper.py
+@@ -1,4 +1,4 @@
+-#! /usr/bin/env python
++#! /usr/bin/env python2
+ # -*- coding: utf-8 -*-
+ 
+ # Copyright (c) 2011-2012, The Linux Foundation. All rights reserved.
+diff --git a/scripts/jobserver-exec b/scripts/jobserver-exec
+index 0fdb31a790a8..1dd35a8a277d 100755
+--- a/scripts/jobserver-exec
++++ b/scripts/jobserver-exec
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ # SPDX-License-Identifier: GPL-2.0+
+ #
+ # This determines how many parallel tasks "make" is expecting, as it is
+diff --git a/scripts/mkbootimg b/scripts/mkbootimg
+index 0c6093e19416..0d3464e8bbca 100755
+--- a/scripts/mkbootimg
++++ b/scripts/mkbootimg
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ # Copyright 2015, The Android Open Source Project
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");
+diff --git a/scripts/mkmultidtb.py b/scripts/mkmultidtb.py
+index 81b814acd304..44ade858a8d0 100755
+--- a/scripts/mkmultidtb.py
++++ b/scripts/mkmultidtb.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ # SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+ # Copyright (c) 2018 Fuzhou Rockchip Electronics Co., Ltd
+ #
+diff --git a/scripts/show_delta b/scripts/show_delta
+index 28e67e178194..a613571dad27 100755
+--- a/scripts/show_delta
++++ b/scripts/show_delta
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ # SPDX-License-Identifier: GPL-2.0-only
+ #
+ # show_deltas: Read list of printk messages instrumented with
+diff --git a/scripts/spdxcheck.py b/scripts/spdxcheck.py
+index bc87200f9c7c..9747c64288c4 100755
+--- a/scripts/spdxcheck.py
++++ b/scripts/spdxcheck.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ # SPDX-License-Identifier: GPL-2.0
+ # Copyright Thomas Gleixner <tglx@linutronix.de>
+ 
+diff --git a/scripts/tracing/draw_functrace.py b/scripts/tracing/draw_functrace.py
+index 7011fbe003ff..72001a9a9c76 100755
+--- a/scripts/tracing/draw_functrace.py
++++ b/scripts/tracing/draw_functrace.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ # SPDX-License-Identifier: GPL-2.0-only
+ 
+ """
+diff --git a/scripts/unpack_bootimg b/scripts/unpack_bootimg
+index 83c2bbe33d7d..cca9338cacd6 100755
+--- a/scripts/unpack_bootimg
++++ b/scripts/unpack_bootimg
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ # Copyright 2018, The Android Open Source Project
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");
+diff --git a/tools/hv/lsvmbus b/tools/hv/lsvmbus
+index 099f2c44dbed..cb2f7e27ea37 100644
+--- a/tools/hv/lsvmbus
++++ b/tools/hv/lsvmbus
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ # SPDX-License-Identifier: GPL-2.0
+ 
+ import os
+diff --git a/tools/perf/python/tracepoint.py b/tools/perf/python/tracepoint.py
+index 461848c7f57d..ed8377178830 100755
+--- a/tools/perf/python/tracepoint.py
++++ b/tools/perf/python/tracepoint.py
+@@ -1,4 +1,4 @@
+-#! /usr/bin/env python
++#! /usr/bin/env python2
+ # SPDX-License-Identifier: GPL-2.0
+ # -*- python -*-
+ # -*- coding: utf-8 -*-
+diff --git a/tools/perf/python/twatch.py b/tools/perf/python/twatch.py
+index 04f3db29b9bc..ab0a2970b3fb 100755
+--- a/tools/perf/python/twatch.py
++++ b/tools/perf/python/twatch.py
+@@ -1,4 +1,4 @@
+-#! /usr/bin/env python
++#! /usr/bin/env python2
+ # SPDX-License-Identifier: GPL-2.0-only
+ # -*- python -*-
+ # -*- coding: utf-8 -*-
+diff --git a/tools/perf/scripts/python/exported-sql-viewer.py b/tools/perf/scripts/python/exported-sql-viewer.py
+index 711d4f9f5645..e27e7a92fdac 100755
+--- a/tools/perf/scripts/python/exported-sql-viewer.py
++++ b/tools/perf/scripts/python/exported-sql-viewer.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ # SPDX-License-Identifier: GPL-2.0
+ # exported-sql-viewer.py: view data from sql database
+ # Copyright (c) 2014-2018, Intel Corporation.
+diff --git a/tools/power/x86/intel_pstate_tracer/intel_pstate_tracer.py b/tools/power/x86/intel_pstate_tracer/intel_pstate_tracer.py
+index e15e20696d17..c8159fe6d2e8 100755
+--- a/tools/power/x86/intel_pstate_tracer/intel_pstate_tracer.py
++++ b/tools/power/x86/intel_pstate_tracer/intel_pstate_tracer.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ # SPDX-License-Identifier: GPL-2.0-only
+ # -*- coding: utf-8 -*-
+ #
+diff --git a/tools/testing/selftests/drivers/net/mlxsw/sharedbuffer_configuration.py b/tools/testing/selftests/drivers/net/mlxsw/sharedbuffer_configuration.py
+index 2223337eed0c..81c538732185 100755
+--- a/tools/testing/selftests/drivers/net/mlxsw/sharedbuffer_configuration.py
++++ b/tools/testing/selftests/drivers/net/mlxsw/sharedbuffer_configuration.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python2
+ # SPDX-License-Identifier: GPL-2.0
+ 
+ import subprocess


### PR DESCRIPTION
I encountered some python path issues when using legacy kernel with edge release.
Rock5b Legacy Kernel v5.10 & Ubuntu Lunar.

Debian Bullseye (not tested) & Ubuntu Lunar
Don't have a /usr/bin/python symlink that points to python2, due to deprecation of Python 2 (https://wiki.debian.org/Python)
This breaks some old python scripts etc in linux-headers deb

There is also a python-is-python3 that creates a /usr/bin/python symlink pointing to python3
So better to patch the legacy kernel incase cause issues later on.

The patchfile is based off radxa kernel  linux-5.10-gen-rkr3.4

Note: Any legacy kernel build (version 5.10 and previous) will be effected on a edge release.

-------

Sorry if not implemented in correct place or patchfile name, first time using armbian build system & bash scripting etc
Thanks