### PR TITLE
Hooks are called system wise

### DIFF
--- a/config/boards/orangepi-r1plus-lts.conf
+++ b/config/boards/orangepi-r1plus-lts.conf
@@ -60,7 +60,3 @@ cat <<- EOF > "${destination}"/etc/udev/rules.d/70-rename-lan.rules
 	RUN+="/usr/sbin/ip link set lan0 up"
 EOF
 }
-
-# Call the hook function above
-post_family_tweaks_bsp__enable_leds_orangepi_r1_plus_lts
-


### PR DESCRIPTION
# Description

No need to put call function here. Need to merge this at once as CI for community builds is failing. I am sourcing board files and  if this function is executed there, it fails.

@schwar3kat @rpardini 

# How Has This Been Tested?

- [x] Function is called also if call is not there

```
[ o.k. ] Creating board support package for CLI [ armbian-bsp-cli-orangepi-r1plus-lts ]
[ .... ] Creating board support LEDs config for orangepi-r1-plus-lts 
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
