### PR TITLE
Fix: Armbianmonitor: Print the CPU frequency correctly without privileges

### DIFF
--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -26,22 +26,22 @@
 # and provides a proposal for /etc/armbianmonitor/disks.conf
 # when a new disk is found.
 #
-# In case monitoring should be activated the following file 
-# will be created: /etc/armbianmonitor/start-monitoring. If 
-# debug output has been chosen, then DEBUG will be written to 
+# In case monitoring should be activated the following file
+# will be created: /etc/armbianmonitor/start-monitoring. If
+# debug output has been chosen, then DEBUG will be written to
 # the file.
 #
 # The script will install smartmontools/gdisk if not already
-# installed and patches smartmontools' update-smart-drivedb 
+# installed and patches smartmontools' update-smart-drivedb
 # script if necessary. For disks the 'device model' will be
 # shown but internally we rely always on the GUID. This is the
 # key for entry in /etc/armbianmonitor/disks.conf
 #
 # When the script exits and the user activated monitoring it
 # recommends doing a restart since on the next reboot the
-# setup-armbian-monitoring-environment script will configure 
-# monitoring sources and decides based on the existence and 
-# contents of /etc/armbianmonitor/start-monitoring whether 
+# setup-armbian-monitoring-environment script will configure
+# monitoring sources and decides based on the existence and
+# contents of /etc/armbianmonitor/start-monitoring whether
 # rpimonitord should be started or not.
 #
 # The format of /etc/armbianmonitor/disks.conf is as follows:
@@ -54,21 +54,22 @@
 # F8D372DC-63DB-494B-B802-87DC47FAD4E1:Samsung EVO:sat::199: # SSD in USB enclosure
 #
 # - GUID is the GUID as determined by gdisk
-# - 'Name': The name as it will later be shown in RPi-Monitor, defaults to 
+# - 'Name': The name as it will later be shown in RPi-Monitor, defaults to
 #   the 'device model' read out through smartctl but can be changed to
 #   be more significant (beware that this string must contain colons!)
-# - "smartctl prefix" can be empty or should be the the necessary prefix for 
-#   USB disks, eg. '-d sat' or '-d usbjmicron' and so on -- please have a 
+# - "smartctl prefix" can be empty or should be the the necessary prefix for
+#   USB disks, eg. '-d sat' or '-d usbjmicron' and so on -- please have a
 #   look at https://www.smartmontools.org/wiki/Supported_USB-Devices
-# - "temp call" when being omitted indicates that hddtemp should be used. 
-#   Otherwise it should contain the complete command line ('DISK' will be 
-#   dynamically replaced by the device node when the actual monitoring 
+# - "temp call" when being omitted indicates that hddtemp should be used.
+#   Otherwise it should contain the complete command line ('DISK' will be
+#   dynamically replaced by the device node when the actual monitoring
 #   happens), for example:
-#   /sbin/hdparm -C DISK | grep -Eq "standby|sleeping" || /usr/sbin/smartctl -d sat -a DISK | awk -F" " '/Temperature_Cel/ {printf $10}'
+#   /sbin/hdparm -C DISK | grep -Eq "standby|sleeping" || \
+#   /usr/sbin/smartctl -d sat -a DISK | awk -F" " '/Temperature_Cel/ {printf $10}'
 # - 'CRC attribute': The decimal value of the S.M.A.R.T. attribute that
-#   is used to store the count of checksum errors between disk and host 
+#   is used to store the count of checksum errors between disk and host
 #   controller (might be omitted if the drive doesn't support it)
-# - 'LCC attribute': The decimal value of the S.M.A.R.T. attribute that 
+# - 'LCC attribute': The decimal value of the S.M.A.R.T. attribute that
 #   should contain the load cycle counter value (might be omitted
 #   if the drive doesn't support it)
 #
@@ -94,14 +95,14 @@ Main() {
 			LRED='\e[0;91m'
 		fi
 	fi
-	
+
 	[ $# -eq 0 ] && (DisplayUsage ; exit 0)
-	
+
 	ParseOptions "$@"
 
 	exit 0
 	PreRequisits
-	
+
 	# check whether user runs rpimonitord on his own or we activated it
 	if [ -f /etc/armbianmonitor/start-monitoring ]; then
 		# we should already provide monitoring, check whether DEBUG
@@ -109,12 +110,12 @@ Main() {
 		ArmbianMonitoring=TRUE
 		read -r DebugMode </etc/armbianmonitor/start-monitoring 2>/dev/null
 	fi
-	
+
 	# check whether rpimonitord is running and compare with ${ArmbianMonitoring}
 	# In case the user chose to run rpimonitord on his own, we skip the config
 	# part and only output disk info
 	:
-	
+
 	# check available disk devices
 	CheckDisks
 } # Main
@@ -322,7 +323,7 @@ MonitorMode() {
 
 	# Allow armbianmonitor to return back to armbian-config
 	trap "echo ; exit 0" 0 1 2 3 15
-	
+
 	# Try to renice to 19 to not interfere with OS behaviour
 	renice 19 $BASHPID >/dev/null 2>&1
 
@@ -427,7 +428,8 @@ MonitorMode() {
 			esac
 			printf "  %5sV" "$DCINvoltage"
 		fi
-		[ "X${CoolingState}" != "Xn/a" ] && printf "  %d/%d" "$(cat /sys/devices/virtual/thermal/cooling_device0/cur_state)" "$(cat /sys/devices/virtual/thermal/cooling_device0/max_state)"
+		[ "X${CoolingState}" != "Xn/a" ] && \
+		printf "  %d/%d" "$(cat /sys/devices/virtual/thermal/cooling_device0/cur_state)" "$(cat /sys/devices/virtual/thermal/cooling_device0/max_state)"
 		[ "$c" == "s" ] && sleep 0.3 || sleep ${SleepInterval}
 	done
 } # MonitorMode

--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -340,23 +340,19 @@ MonitorMode() {
 	SleepInterval=${interval:-5}
 
 	Sensors="/etc/armbianmonitor/datasources/"
-	if [ -f /sys/devices/system/cpu/cpu4/cpufreq/cpuinfo_cur_freq ]; then
-		DisplayHeader="Time       big.LITTLE   load %cpu %sys %usr %nice %io %irq"
-		CPUs=biglittle
-	elif [ -f /sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_cur_freq ]; then
+	if [ -f /sys/devices/system/cpu/cpu4/cpufreq/scaling_cur_freq ]; then
+		DisplayHeader="Time    CPU_cl0/CPU_cl1  load %cpu %sys %usr %nice %io %irq"
+		CPUs=dual_cluster
+		echo "Two CPU clusters are available for monitoring"
+	elif [ -f /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq ]; then
 		DisplayHeader="Time        CPU    load %cpu %sys %usr %nice %io %irq"
 		CPUs=normal
 	else
 		DisplayHeader="Time      CPU n/a    load %cpu %sys %usr %nice %io %irq"
 		CPUs=notavailable
 	fi
-	# Set freq output to --- if non-privileged. Overwrites settings above.
-	if [ "$(id -u)" != "0" ]; then
-		echo "Running unprivileged. CPU frequency will not be displayed."
-		CPUs=notavailable
-	fi
 
-	[ -f "${Sensors}/soctemp" ] && DisplayHeader="${DisplayHeader}   CPU" || SocTemp='n/a'
+	[ -f "${Sensors}/soctemp" ] && DisplayHeader="${DisplayHeader}   Tcpu" || SocTemp='n/a'
 	[ -f "${Sensors}/pmictemp" ] && DisplayHeader="${DisplayHeader}   PMIC" || PMICTemp='n/a'
 	DCIN=$(CheckDCINVoltage)
 	[ -f "${DCIN}" ] && DisplayHeader="${DisplayHeader}   DC-IN" || DCIN='n/a'
@@ -371,7 +367,7 @@ MonitorMode() {
 		if [ "$c" == "m" ]; then
 			let Counter++
 			if [ ${Counter} -eq 15 ]; then
-				printf "%s" "$DisplayHeader"
+				printf "\n\n%s" "$DisplayHeader"
 				Counter=0
 			fi
 		elif [ "$c" == "s" ]; then
@@ -385,20 +381,20 @@ MonitorMode() {
 		fi
 		LoadAvg=$(cut -f1 -d" " </proc/loadavg)
 		case ${CPUs} in
-			biglittle)
-				BigFreq=$(awk '{printf ("%0.0f",$1/1000); }' </sys/devices/system/cpu/cpu4/cpufreq/cpuinfo_cur_freq) 2>/dev/null
-				LittleFreq=$(awk '{printf ("%0.0f",$1/1000); }' </sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_cur_freq) 2>/dev/null
+			dual_cluster)
+				Cluster1=$(awk '{printf ("%0.0f",$1/1000); }' </sys/devices/system/cpu/cpu4/cpufreq/scaling_cur_freq) 2>/dev/null
+				Cluster0=$(awk '{printf ("%0.0f",$1/1000); }' </sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq) 2>/dev/null
 				ProcessStats
-				printf "\n%s: %4s/%4sMHz %5s %s" "$(date "+%H:%M:%S")" "$BigFreq" "$LittleFreq" "$LoadAvg" "$procStats"
+				printf "\n%s  %4s/%4s MHz %5s %s" "$(date "+%H:%M:%S")" "$Cluster0" "$Cluster1" "$LoadAvg" "$procStats"
 				;;
 			normal)
 				CpuFreq=$(awk '{printf ("%0.0f",$1/1000); }' </sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_cur_freq) 2>/dev/null
 				ProcessStats
-				printf "\n%s: %4sMHz %5s %s" "$(date "+%H:%M:%S")" "$CpuFreq" "$LoadAvg" "$procStats"
+				printf "\n%s  %4s MHz %5s %s" "$(date "+%H:%M:%S")" "$CpuFreq" "$LoadAvg" "$procStats"
 				;;
 			notavailable)
 				ProcessStats
-				printf "\n%s:   ---     %5s %s" "$(date "+%H:%M:%S")" "$LoadAvg" "$procStats"
+				printf "\n%s    ---     %5s %s" "$(date "+%H:%M:%S")" "$LoadAvg" "$procStats"
 				;;
 		esac
 		if [ "X${SocTemp}" != "Xn/a" ]; then
@@ -406,14 +402,14 @@ MonitorMode() {
 			if [ ${SocTemp} -ge 1000 ]; then
 				SocTemp=$(awk '{printf ("%0.1f",$1/1000); }' <<<${SocTemp})
 			fi
-			printf " %4s °C" "$SocTemp"
+			printf "  %4s °C" "$SocTemp"
 		fi
 		if [ "X${PMICTemp}" != "Xn/a" ]; then
 			read -r PMICTemp <"${Sensors}/pmictemp"
 			if [ ${PMICTemp} -ge 1000 ]; then
 				PMICTemp=$(awk '{printf ("%0.1f",$1/1000); }' <<<${PMICTemp})
 			fi
-			printf " %4s °C" "$PMICTemp"
+			printf "  %4s °C" "$PMICTemp"
 		fi
 		if [ "X${DCIN}" != "Xn/a" ]; then
 			case "${DCIN##*/}" in


### PR DESCRIPTION
# Description

Print the CPU frequency correctly without privileges.
Some CPU's have two clusters and at the same time are not representatives of the "Big.Little" architecture.
It will be correct to print about the presence of adjustment of two clusters

# How Has This Been Tested?
Before the changes:
```bash
leo@bananapim3:~$ armbianmonitor -m 1
Running unprivileged. CPU frequency will not be displayed.
Stop monitoring using [ctrl]-[c]
Warning: High update frequency (1 sec) might change system behaviour!

Time       big.LITTLE   load %cpu %sys %usr %nice %io %irq   CPU  C.St.

10:46:45:   ---      0.05   0%   0%   0%   0%   0%   0% 45,0 °C  0/5
10:46:46:   ---      0.05   1%   1%   0%   0%   0%   0% 44,8 °C  0/5
10:46:47:   ---      0.05   1%   1%   0%   0%   0%   0% 45,3 °C  0/5
10:46:48:   ---      0.05   1%   1%   0%   0%   0%   0% 45,0 °C  0/5
10:46:49:   ---      0.13   1%   1%   0%   0%   0%   0% 45,2 °C  0/5^C
```
After:
```bash
leo@bananapim3:~$ armbianmonitor -m 1
Two CPU clusters are available for monitoring
Stop monitoring using [ctrl]-[c]
Warning: High update frequency (1 sec) might change system behaviour!
Time    CPU_cl0/CPU_cl1  load %cpu %sys %usr %nice %io %irq   Tcpu  C.St.

15:31:08  1152/1152 MHz  0.25   0%   0%   0%   0%   0%   0%  30,2 °C  0/5
15:31:09  1152/1152 MHz  0.25   1%   1%   0%   0%   0%   0%  30,4 °C  0/5
15:31:10   768/ 768 MHz  0.25   1%   1%   0%   0%   0%   0%  30,3 °C  0/5
15:31:11   768/1152 MHz  0.25   1%   1%   0%   0%   0%   0%  29,3 °C  0/5
15:31:12  1344/1152 MHz  0.23   1%   1%   0%   0%   0%   0%  29,5 °C  0/5
15:31:13  1344/1152 MHz  0.23   1%   1%   0%   0%   0%   0%  29,9 °C  0/5
15:31:15   768/1152 MHz  0.23   1%   1%   0%   0%   0%   0%  29,4 °C  0/5
15:31:16  1152/1152 MHz  0.23   1%   1%   0%   0%   0%   0%  29,9 °C  0/5
15:31:17  1344/1344 MHz  0.23   1%   1%   0%   0%   0%   0%  30,4 °C  0/5
15:31:18  1344/1152 MHz  0.21   1%   1%   0%   0%   0%   0%  30,2 °C  0/5
15:31:19   768/1152 MHz  0.21   1%   1%   0%   0%   0%   0%  30,0 °C  0/5
15:31:20  1344/1152 MHz  0.21   1%   1%   0%   0%   0%   0%  29,4 °C  0/5
15:31:21  1344/1152 MHz  0.21   1%   1%   0%   0%   0%   0%  29,6 °C  0/5
15:31:23  1152/1152 MHz  0.19   1%   1%   0%   0%   0%   0%  29,8 °C  0/5

Time    CPU_cl0/CPU_cl1  load %cpu %sys %usr %nice %io %irq   Tcpu  C.St.
15:31:24  1344/1152 MHz  0.19   1%   1%   0%   0%   0%   0%  30,2 °C  0/5
15:31:25   768/1152 MHz  0.19   1%   1%   0%   0%   0%   0%  30,0 °C  0/5
15:31:26  1152/1152 MHz  0.19   1%   1%   0%   0%   0%   0%  30,1 °C  0/5
15:31:27  1344/1152 MHz  0.18   1%   1%   0%   0%   0%   0%  30,3 °C  0/5^C
```

# Checklist:

- [x] Test works on board bananapim3. CPU control of the two clusters.
