### PR TITLE
Adds SPI, I2C, and PWM DTS overlays for odroid-m1

### DIFF
--- a/patch/kernel/archive/odroidm1-6.1/board-odroidm1-spi-uart-pwm.patch
+++ b/patch/kernel/archive/odroidm1-6.1/board-odroidm1-spi-uart-pwm.patch
@@ -1,0 +1,42 @@
+diff --git a/arch/arm64/boot/dts/rockchip/rk3568-odroid-m1.dts b/arch/arm64/boot/dts/rockchip/rk3568-odroid-m1.dts
+index 59ecf868d..a0d227fdd 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3568-odroid-m1.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3568-odroid-m1.dts
+@@ -742,3 +742,37 @@ vp0_out_hdmi: endpoint@ROCKCHIP_VOP2_EP_HDMI0 {
+ 		remote-endpoint = <&hdmi_in_vp0>;
+ 	};
+ };
++
++&i2c3 {
++	status = "disabled";
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c3m1_xfer>;
++};
++
++&pwm1 {
++	status = "disabled";
++	pinctrl-0 = <&pwm1m1_pins>;
++};
++
++&pwm2 {
++	status = "disabled";
++	pinctrl-0 = <&pwm2m1_pins>;
++};
++
++&spi0 {
++	status = "disabled";
++
++	pinctrl-0 = <&spi0m1_pins>;
++	pinctrl-1 = <&spi0m1_pins_hs>;
++	num_chipselect = <1>;
++
++	cs-gpios = <&gpio2 RK_PD2 GPIO_ACTIVE_LOW>;
++};
++
++&uart1 {
++	status = "disabled";
++	dma-names = "tx", "rx";
++	/* uart1 uart1-with-ctsrts */
++	pinctrl-0 = <&uart1m1_xfer>;
++	pinctrl-1 = <&uart1m1_xfer &uart1m1_ctsn &uart1m1_rtsn>;
++};

--- a/patch/kernel/archive/odroidm1-6.1/drv-spi-spidev-remove-warnings.patch
+++ b/patch/kernel/archive/odroidm1-6.1/drv-spi-spidev-remove-warnings.patch
@@ -1,0 +1,31 @@
+From 2653defc5e22ba86bd1d455eb01fc7edd2958473 Mon Sep 17 00:00:00 2001
+From: The-going <48602507+The-going@users.noreply.github.com>
+Date: Wed, 2 Feb 2022 11:56:51 +0300
+Subject: [PATCH 08/50] drv:spi:spidev remove warnings
+
+---
+ drivers/spi/spidev.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/spi/spidev.c b/drivers/spi/spidev.c
+index b2775d82d2d7..3c65d3d74559 100644
+--- a/drivers/spi/spidev.c
++++ b/drivers/spi/spidev.c
+@@ -683,6 +683,7 @@ static const struct file_operations spidev_fops = {
+ static struct class *spidev_class;
+ 
+ static const struct spi_device_id spidev_spi_ids[] = {
++	{ .name = "spi-dev" },
+ 	{ .name = "dh2228fv" },
+ 	{ .name = "ltc2488" },
+ 	{ .name = "sx1301" },
+@@ -709,6 +710,7 @@ static int spidev_of_check(struct device *dev)
+ }
+ 
+ static const struct of_device_id spidev_dt_ids[] = {
++	{ .compatible = "armbian,spi-dev", .data = &spidev_of_check },
+ 	{ .compatible = "rohm,dh2228fv", .data = &spidev_of_check },
+ 	{ .compatible = "lineartechnology,ltc2488", .data = &spidev_of_check },
+ 	{ .compatible = "semtech,sx1301", .data = &spidev_of_check },
+-- 
+2.35.3

--- a/patch/kernel/archive/odroidm1-6.1/general-add-overlay-compilation-support.patch
+++ b/patch/kernel/archive/odroidm1-6.1/general-add-overlay-compilation-support.patch
@@ -1,0 +1,82 @@
+diff --git a/arch/arm/boot/.gitignore b/arch/arm/boot/.gitignore
+index 3c79f859..4e5c1d59 100644
+--- a/arch/arm/boot/.gitignore
++++ b/arch/arm/boot/.gitignore
+@@ -3,3 +3,5 @@ zImage
+ xipImage
+ bootpImage
+ uImage
++*.dtb*
++*.scr
+diff --git a/scripts/Makefile.dtbinst b/scripts/Makefile.dtbinst
+index 50d580d77..94bd15617 100644
+--- a/scripts/Makefile.dtbinst
++++ b/scripts/Makefile.dtbinst
+@@ -18,9 +18,12 @@ include scripts/Kbuild.include
+ include $(src)/Makefile
+ 
+ dtbs    := $(addprefix $(dst)/, $(dtb-y) $(if $(CONFIG_OF_ALL_DTBS),$(dtb-)))
++dtbos   := $(addprefix $(dst)/, $(dtbo-y))
++scrs    := $(addprefix $(dst)/, $(scr-y))
++readmes := $(addprefix $(dst)/, $(dtbotxt-y))
+ subdirs := $(addprefix $(obj)/, $(subdir-y) $(subdir-m))
+ 
+-__dtbs_install: $(dtbs) $(subdirs)
++__dtbs_install: $(dtbs) $(dtbos) $(scrs) $(readmes) $(subdirs)
+ 	@:
+ 
+ quiet_cmd_dtb_install = INSTALL $@
+@@ -29,6 +32,15 @@ quiet_cmd_dtb_install = INSTALL $@
+ $(dst)/%.dtb: $(obj)/%.dtb
+ 	$(call cmd,dtb_install)
+ 
++$(dst)/%.dtbo: $(obj)/%.dtbo
++	$(call cmd,dtb_install)
++
++$(dst)/%.scr: $(obj)/%.scr
++	$(call cmd,dtb_install)
++
++$(dst)/README.rockchip-overlays: $(src)/README.rockchip-overlays
++	$(call cmd,dtb_install)
++
+ PHONY += $(subdirs)
+ $(subdirs):
+ 	$(Q)$(MAKE) $(dtbinst)=$@ dst=$(patsubst $(obj)/%,$(dst)/%,$@)
+diff --git a/scripts/Makefile.lib b/scripts/Makefile.lib
+index 58c05e5d..2b95dda9 100644
+--- a/scripts/Makefile.lib
++++ b/scripts/Makefile.lib
+@@ -278,6 +278,9 @@ cmd_gzip = (cat $(filter-out FORCE,$^) | gzip -n -f -9 > $@) || \
+ # ---------------------------------------------------------------------------
+ DTC ?= $(objtree)/scripts/dtc/dtc
+
++# Overlay support
++DTC_FLAGS += -@ -Wno-unit_address_format -Wno-simple_bus_reg
++
+ # Disable noisy checks by default
+ ifeq ($(KBUILD_ENABLE_EXTRA_GCC_CHECKS),)
+ DTC_FLAGS += -Wno-unit_address_vs_reg \
+@@ -324,6 +327,23 @@ cmd_dtc = mkdir -p $(dir ${dtc-tmp}) ; \
+ $(obj)/%.dtb: $(src)/%.dts FORCE
+ 	$(call if_changed_dep,dtc)
+
++quiet_cmd_dtco = DTCO    $@
++cmd_dtco = mkdir -p $(dir ${dtc-tmp}) ; \
++	$(CPP) $(dtc_cpp_flags) -x assembler-with-cpp -o $(dtc-tmp) $< ; \
++	$(DTC) -O dtb -o $@ -b 0 \
++		-i $(dir $<) $(DTC_FLAGS) \
++		-d $(depfile).dtc.tmp $(dtc-tmp) ; \
++	cat $(depfile).pre.tmp $(depfile).dtc.tmp > $(depfile)
++
++$(obj)/%.dtbo: $(src)/%.dts FORCE
++	$(call if_changed_dep,dtco)
++
++quiet_cmd_scr = MKIMAGE $@
++cmd_scr = mkimage -C none -A $(ARCH) -T script -d $< $@
++
++$(obj)/%.scr: $(src)/%.scr-cmd FORCE
++	$(call if_changed,scr)
++
+ dtc-tmp = $(subst $(comma),_,$(dot-target).dts.tmp)
+
+ # Bzip2

--- a/patch/kernel/archive/odroidm1-6.1/overlays-00-add-odroid-buses.patch
+++ b/patch/kernel/archive/odroidm1-6.1/overlays-00-add-odroid-buses.patch
@@ -1,0 +1,324 @@
+diff --git a/arch/arm64/boot/dts/rockchip/Makefile b/arch/arm64/boot/dts/rockchip/Makefile
+index 5dc1607b3..397275bd5 100644
+--- a/arch/arm64/boot/dts/rockchip/Makefile
++++ b/arch/arm64/boot/dts/rockchip/Makefile
+@@ -73,3 +73,5 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-bpi-r2-pro.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-evb1-v10.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-odroid-m1.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-rock-3a.dtb
++
++subdir-y       := $(dts-dirs) overlay
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts/rockchip/overlay/Makefile
+new file mode 100644
+index 000000000..9c5a73e00
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
+@@ -0,0 +1,23 @@
++# SPDX-License-Identifier: GPL-2.0
++dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
++	rockchip-spi-spidev.dtbo \
++	rockchip-uart0.dtbo \
++	rockchip-uart0-rts_cts.dtbo \
++	rockchip-uart1.dtbo \
++	rockchip-pwm1.dtbo \
++	rockchip-pwm2.dtbo \
++	rockchip-pwm9.dtbo \
++	rockchip-i2c0.dtbo \
++	rockchip-i2c1.dtbo
++
++scr-$(CONFIG_ARCH_ROCKCHIP) += \
++       rockchip-fixup.scr
++
++dtbotxt-$(CONFIG_ARCH_ROCKCHIP) += \
++       README.rockchip-overlays
++
++targets += $(dtbo-y) $(scr-y) $(dtbotxt-y)
++
++always         := $(dtbo-y) $(scr-y) $(dtbotxt-y)
++clean-files    := *.dtbo *.scr
++
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
+new file mode 100644
+index 000000000..6f0b30acb
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
+@@ -0,0 +1,69 @@
++This document describes overlays provided in the kernel packages
++For generic Armbian overlays documentation please see
++https://docs.armbian.com/User-Guide_Allwinner_overlays/
++
++### Platform:
++
++rockchip (Rockchip)
++
++### Provided overlays:
++
++- i2c0, i2c1, spi-spidev, uart0, uart1, pwm1, pwm2, pwm9
++
++### Overlay details:
++
++### i2c0
++
++Activates TWI/I2C bus I2C3 but it will be named as I2C0 on the userspace
++
++I2C3/I2C0 pins (SCL, SDA): GPIO3B.5, GPIO3B.6
++
++### i2c1
++
++Activates TWI/I2C bus I2C1
++
++I2C1 pins (SCL, SDA): GPIO0B.3, GPIO0B.4
++
++### spi-spidev
++
++Activates SPIdev device node (/dev/spidev0.0) for userspace SPI access,
++
++SPI 0 pins (MOSI, MISO, SCK, CS): GPIO2D.1, GPIO2D.0, GPIO2D.3, GPIO2D.2
++
++Parameters:
++
++param_spidev_max_freq (int)
++	Maximum SPIdev frequency
++	Optional
++	Default: 1000000
++	Range: 3000 - 100000000
++
++### uart0
++
++Activates UART0 (alias to serial1)
++
++UART0 pins (RX, TX): GPIO3D.7, GPIO3D.6
++
++### uart1
++
++Activates UART1 (alias to serial0)
++
++UART1 pins (RX, TX): GPIO0C.0, GPIO0C.1
++
++### pwm1
++
++Activates PWM1 (pwm1_m1)
++
++PWM1 pins: GPIO0B.5
++
++### pwm2
++
++Activates PWM2 (pwm2_m1)
++
++PWM2 pins: GPIO0B.6
++
++### pwm9
++
++Activates PWM9 (pwm9_m0)
++
++PWM9 pins: GPIO3B.2
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-fixup.scr-cmd b/arch/arm64/boot/dts/rockchip/overlay/rockchip-fixup.scr-cmd
+new file mode 100644
+index 000000000..3bde2523b
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-fixup.scr-cmd
+@@ -0,0 +1,7 @@
++# overlays fixup script
++# implements (or rather substitutes) overlay arguments functionality
++# using u-boot scripting, environment variables and "fdt" command
++
++if test -n "${param_spidev_max_freq}"; then
++    fdt set /spi@fe610000/spidev spi-max-frequency "<${param_spidev_max_freq}>"
++fi
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-i2c0.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-i2c0.dts
+new file mode 100644
+index 000000000..a6942df06
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-i2c0.dts
+@@ -0,0 +1,14 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	fragment@0 {
++		// i2c3 aliased with i2c0.
++		// This activates i2c3 but it will be named as i2c0 on the userspace.
++		target = <&i2c3>;
++
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-i2c1.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-i2c1.dts
+new file mode 100644
+index 000000000..344161c2d
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-i2c1.dts
+@@ -0,0 +1,12 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	fragment@0 {
++		target = <&i2c1>;
++
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-pwm1.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-pwm1.dts
+new file mode 100644
+index 000000000..0b78ad96b
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-pwm1.dts
+@@ -0,0 +1,13 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	fragment@0 {
++		// pwmchip0, pwm@fdd70010
++		target = <&pwm1>;
++
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-pwm2.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-pwm2.dts
+new file mode 100644
+index 000000000..c7f1898e5
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-pwm2.dts
+@@ -0,0 +1,13 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	fragment@0 {
++		// pwmchip1, pwm@fdd70020
++		target = <&pwm2>;
++
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-pwm9.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-pwm9.dts
+new file mode 100644
+index 000000000..7f52929e7
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-pwm9.dts
+@@ -0,0 +1,13 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	fragment@0 {
++		// pwmchip3, pwm@fe6f0010
++		target = <&pwm9>;
++
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-spi-spidev.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-spi-spidev.dts
+new file mode 100644
+index 000000000..7639bcc6b
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-spi-spidev.dts
+@@ -0,0 +1,22 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	fragment@0 {
++		target = <&spi0>;
++
++		__overlay__ {
++			status = "okay";
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			spidev: spidev@0 {
++				status = "okay";
++				compatible = "armbian,spi-dev";
++				reg = <0>;
++				/* spi default max clock 100Mhz */
++				spi-max-frequency = <100000000>;
++			};
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-uart0-rts_cts.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-uart0-rts_cts.dts
+new file mode 100644
+index 000000000..fb855965f
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-uart0-rts_cts.dts
+@@ -0,0 +1,14 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	fragment@0 {
++		// uart1 aliased with serial0.
++		target = <&uart1>;
++
++		__overlay__ {
++			status = "okay";
++			pinctrl-names = "not_use_it", "default";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-uart0.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-uart0.dts
+new file mode 100644
+index 000000000..e57ba5499
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-uart0.dts
+@@ -0,0 +1,13 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	fragment@0 {
++		// uart1 aliased with serial0.
++		target = <&uart1>;
++
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-uart1.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-uart1.dts
+new file mode 100644
+index 000000000..cdc75c4f2
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-uart1.dts
+@@ -0,0 +1,15 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	fragment@0 {
++		// uart0 aliased with serial1.
++		target = <&uart0>;
++
++		__overlay__ {
++			status = "okay";
++
++			dma-names = "tx", "rx";
++		};
++	};
++};
+diff --git a/scripts/Makefile.lib b/scripts/Makefile.lib
+index 553018f80..707718118 100644
+--- a/scripts/Makefile.lib
++++ b/scripts/Makefile.lib
+@@ -88,6 +88,9 @@ base-dtb-y := $(foreach m, $(multi-dtb-y), $(firstword $(call suffix-search, $m,
+ 
+ always-y			+= $(dtb-y)
+ 
++# Overlay targets
++extra-y                         += $(dtbo-y) $(scr-y) $(dtbotxt-y)
++
+ # Add subdir path
+ 
+ ifneq ($(obj),.)


### PR DESCRIPTION
# Description

Adds i2c3, pwm1, pwdm2, spi0 and uart1 nodes to rk3568-odroid-m1.dts. 
Adds patch to remove spi-dev warning
Adds patch with support for overlay compilation
Adds DTS overlays for spi, uart0, uart1, pwm1, pwm2, pwm9, i2c0 and i2c1

# How Has This Been Tested?

This was tested with a 4GB M1 board. The 
- [x] SPI0:  tested with a SPI OLED display 
- [x] uart0, uart1: loopback test
- [x] pwm1, pwm2, pwm9: with scope  
- [x] i2c0, i2c1: with scope 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
