### PR TITLE
Add wpasupplicant to bookworm and bullseye

### DIFF
--- a/config/cli/bullseye/main/packages.additional
+++ b/config/cli/bullseye/main/packages.additional
@@ -14,3 +14,4 @@ resolvconf
 sysstat
 wget
 wireless-tools
+wpasupplicant


### PR DESCRIPTION
# Description

Due to possible transitioning from WPA_Supplicant to Intel's IWD daemon for Linux wireless needs hard dependancy was removed. Based on https://github.com/armbian/build/pull/4817  (better to fix this in master and then cherry pick to next)

Jira reference number [AR-1534]

# How Has This Been Tested?

No needed. Without, tool is not installed anymore but we need it.

[AR-1534]: https://armbian.atlassian.net/browse/AR-1534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ