### PR TITLE
fix: armbianmonitor: use cpufreq/scaling_cur_freq if 1 Cluster is available

### DIFF
--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -388,7 +388,7 @@ MonitorMode() {
 				printf "\n%s  %4s/%4s MHz %5s %s" "$(date "+%H:%M:%S")" "$Cluster0" "$Cluster1" "$LoadAvg" "$procStats"
 				;;
 			normal)
-				CpuFreq=$(awk '{printf ("%0.0f",$1/1000); }' </sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_cur_freq) 2>/dev/null
+				CpuFreq=$(awk '{printf ("%0.0f",$1/1000); }' </sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq) 2>/dev/null
 				ProcessStats
 				printf "\n%s  %4s MHz %5s %s" "$(date "+%H:%M:%S")" "$CpuFreq" "$LoadAvg" "$procStats"
 				;;


### PR DESCRIPTION
# Description

fix: armbianmonitor: use cpufreq/scaling_cur_freq if 1 Cluster is available

# How Has This Been Tested?
# Checklist:
- [x] Test on board bananapim64



