### PR TITLE
Add rockchip-rk3588 board family to armbian-hardware-optimization

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
+++ b/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
@@ -82,7 +82,7 @@ prepare_board() {
 					# if there's just a single cpufreq policy ondemand sysfs entries differ
 					CPUFreqPolicies=${prefix}
 				fi
-				for i in ${CPUFreqPolicies[@]}; do
+				for i in "${CPUFreqPolicies[@]}"; do
 					affected_cpu=$(tr -d -c '[:digit:]' <<< ${i})
 					echo ondemand > ${prefix}/cpu${affected_cpu:-0}/cpufreq/scaling_governor
 					echo 1 > ${i}/cpufreq/ondemand/io_is_busy

--- a/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
+++ b/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
@@ -75,7 +75,7 @@ prepare_board() {
 		echo ondemand > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
 
 		case ${BOARDFAMILY} in
-			station* | media)
+			station* | media | rockchip-rk3588)
 				prefix="/sys/devices/system/cpu"
 				CPUFreqPolicies=($(ls -d ${prefix}/cpufreq/policy? | sed 's/freq\/policy//'))
 				if [ ${#CPUFreqPolicies[@]} -eq 1 -a -d "${prefix}/cpufreq" ]; then


### PR DESCRIPTION
# Description
Ondemand governor is slower than performance governor without these tweaks. Before this PR applied, just cpu0 and cpu4 have these tweaks. After the PR, missing cores also have the same tweaks. This means little performance improvement.

Jira reference number [AR-9999]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
