### PR TITLE
chore: add star history in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ More information:
 - [Building with Docker](https://docs.armbian.com/Developer-Guide_Building-with-Docker/) — how to build inside container;
 - [User configuration](https://docs.armbian.com/Developer-Guide_User-Configurations/) — how to add packages, patches and override sources config;
 
-
 ## Download prebuilt images
 
 - quarterly released **supported** builds —  <https://www.armbian.com/download>
@@ -138,7 +137,7 @@ Function | Armbian | Yocto | Buildroot |
 │   └── patch                            Created patches location
 ├── packages                             Support scripts, binary blobs, packages
 │   ├── blobs                            Wallpapers, various configs, closed source bootloaders
-│   ├── bsp-cli                          Automatically added to armbian-bsp-cli package 
+│   ├── bsp-cli                          Automatically added to armbian-bsp-cli package
 │   ├── bsp-desktop                      Automatically added to armbian-bsp-desktopo package
 │   ├── bsp                              Scripts and configs overlay for rootfs
 │   └── extras-buildpkgs                 Optional compilation and packaging engine
@@ -163,7 +162,8 @@ Function | Armbian | Yocto | Buildroot |
 
 ## 🙌 Contribution
 
-### You don't need to be a programmer to help! 
+### You don't need to be a programmer to help!
+
 - The easiest way to help is by "Starring" our repository - it helps more people find our code.
 - [Check out our list of volunteer positions](https://forum.armbian.com/staffapplications/) and choose what you want to do ❤️
 - [Seed torrents](https://forum.armbian.com/topic/4198-seed-our-torrents/)
@@ -187,9 +187,10 @@ If you want to help with development, you should first review the [Development C
 ## Support
 
 Support is provided in one of two ways:
+
 - For commercial or prioritized assistance:
   - book a an hour of [professional consultation](https://calendly.com/armbian/consultation),
-  - consider becoming a project partner. Reach us out at https://armbian.com/contact,
+  - consider becoming a project partner. Reach us out at <https://armbian.com/contact>,
 - Alternatively free support is provided via [general project search engine](https://www.armbian.com/search), [documentation](https://docs.armbian.com), [community forums](https://forum.armbian.com/) or [IRC/Discord](https://docs.armbian.com/Community_IRC/). Keep in mind this is mostly provided by our awesome community members in a **best effort** manner and therefore there are no guaranteed solutions.
 
 ## Contact
@@ -219,8 +220,13 @@ Thank you to all the people who already contributed Armbian!
 ## Armbian Partners
 
 Armbian's partnership program helps to support Armbian and the Armbian community! Please take a moment to familiarize yourself with our Partners:
+
 - [Click here to visit our Partners page!](https://armbian.com/partners)
 - [How can I become a Partner?](https://forum.armbian.com/subscriptions)
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=armbian/build&type=Date)](https://star-history.com/#armbian/build&Date)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ More information:
 
 - [Building Armbian](https://docs.armbian.com/Developer-Guide_Build-Preparation/) — how to start, how to automate;
 - [Build options](https://docs.armbian.com/Developer-Guide_Build-Options/) — all build options;
-- [Building with Docker](https://docs.armbian.com/Developer-Guide_Building-with-Docker/) — how to build inside container;
 - [User configuration](https://docs.armbian.com/Developer-Guide_User-Configurations/) — how to add packages, patches and override sources config;
 
 ## Download prebuilt images
@@ -110,11 +109,23 @@ Function | Armbian | Yocto | Buildroot |
 
 ## Project structure
 
+<details><summary>Expand</summary>
+
 ```text
 ├── cache                                Work / cache directory
-│   ├── rootfs                           Compressed userspace packages cache
-│   ├── sources                          Kernel, u-boot and various drivers sources.
-│   ├── toolchains                       External cross compilers from Linaro™ or ARM™
+│   ├── aptcache                         Packages
+│   ├── ccache                           C/C++ compiler
+│   ├── docker                           Docker last pull
+│   ├── git-bare                         Minimal Git
+│   ├── git-bundles                      Full Git
+│   ├── initrd                           Ram disk
+│   ├── memoize                          Git status
+│   ├── patch                            Kernel drivers patch
+│   ├── pip                              Python
+│   ├── rootfs                           Compressed userspaces
+│   ├── sources                          Kernel, u-boot and other sources
+│   ├── tools                            Additional tools like ORAS
+│   └── utility
 ├── config                               Packages repository configurations
 │   ├── targets.conf                     Board build target configuration
 │   ├── boards                           Board configurations
@@ -127,8 +138,21 @@ Function | Armbian | Yocto | Buildroot |
 │   ├── sources                          Kernel and u-boot sources locations and scripts
 │   ├── templates                        User configuration templates which populate userpatches
 │   └── torrents                         External compiler and rootfs cache torrents
-├── extensions                           extend build system with specific functionality
+├── extensions                           Extend build system with specific functionality
 ├── lib                                  Main build framework libraries
+│   ├── functions
+│   │   ├── artifacts
+│   │   ├── bsp
+│   │   ├── cli
+│   │   ├── compilation
+│   │   ├── configuration
+│   │   ├── general
+│   │   ├── host
+│   │   ├── image
+│   │   ├── logging
+│   │   ├── main
+│   │   └── rootfs
+│   └── tools
 ├── output                               Build artifact
 │   └── deb                              Deb packages
 │   └── images                           Bootable images - RAW or compressed
@@ -159,6 +183,7 @@ Function | Armbian | Yocto | Buildroot |
     ├── misc                             User: various
     └── u-boot                           User: universal boot loader patches
 ```
+</details>
 
 ## 🙌 Contribution
 
@@ -197,7 +222,7 @@ Support is provided in one of two ways:
 
 - [Forums](https://forum.armbian.com) for Participate in Armbian
 - IRC: `#armbian` on Libera.chat
-- Discord: [http://discord.armbian.com](http://discord.armbian.com)
+- Discord: [https://discord.gg/armbian](https://discord.gg/armbian)
 - Follow [@armbian](https://twitter.com/armbian) on Twitter, [Fosstodon](https://fosstodon.org/@armbian) or [LinkedIn](https://www.linkedin.com/company/armbian).
 - Bugs: [issues](https://github.com/armbian/build/issues) / [JIRA](https://armbian.atlassian.net/jira/dashboards/10000)
 - Office hours: [Wednesday, 12 midday, 18 afternoon, CET](https://calendly.com/armbian/office-hours)


### PR DESCRIPTION
# Description

- add star history @littlecxm 
- remove link to docker instructions as obsolete @igorpecovnik 
- improve project structure info and put it under expandable summary block @igorpecovnik 
- change discord link to new official one @igorpecovnik 

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# How Has This Been Tested?

- Document(README.md) change no need unit test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
