### PR TITLE
logs: remove `git diff` from `GIT_INFO_ANSI`, it's somewhat useless and potentially huge leading to `argument list too long`

### DIFF
--- a/lib/functions/logging/export-logs.sh
+++ b/lib/functions/logging/export-logs.sh
@@ -9,9 +9,6 @@ function prepare_ansi_git_info_log_header() {
 		$(echo -e -n "${bright_blue_color:-}")# GIT status$(echo -e -n "${ansi_reset_color:-}")
 		$(LC_ALL=C LANG=C git -c color.status=always --work-tree="${SRC}" --git-dir="${SRC}/.git" status | sed -e "${prefix_sed_cmd}" || true)
 		${dim_line_separator}
-		$(echo -e -n "${bright_blue_color:-}")# GIT changes$(echo -e -n "${ansi_reset_color:-}")
-		$(LC_ALL=C LANG=C git --work-tree="${SRC}" --git-dir="${SRC}/.git" diff -u --color | sed -e "${prefix_sed_cmd}" || true)
-		${dim_line_separator}
 	GIT_ANSI_HEADER
 }
 


### PR DESCRIPTION
- `argument list too long` detected by @amazingfate 
- also is in general a bit leaky, people are developing and changes "leak" into logs with this
- same info could be better obtained by consolidating the logs (docker/build) into a single one later