### PR TITLE
not rsync /boot when copying root partition

### DIFF
--- a/lib/functions/image/rootfs-to-image.sh
+++ b/lib/functions/image/rootfs-to-image.sh
@@ -20,7 +20,7 @@ function create_image_from_sdcard_rootfs() {
 	if [[ $ROOTFS_TYPE != nfs ]]; then
 		display_alert "Copying files via rsync to" "/ (MOUNT root)"
 		run_host_command_logged rsync -aHWXh \
-			--exclude="/boot/*" \
+			--exclude="/boot" \
 			--exclude="/dev/*" \
 			--exclude="/proc/*" \
 			--exclude="/run/*" \


### PR DESCRIPTION
# Description

I'm running ./conmpile.sh on a CentOS7 host with selinux. I got this error when I have a fat32 boot partition:
`rsync: [receiver] rsync_xal_set: lsetxattr("/armbian/.tmp/mount-9164f469-ce45-41ce-af3d-07556d8996aa/boot","security.selinux") failed: Operation not supported (95)`
Since we will rsync boot partition later it should be harmless if we just exclude the whole /boot directory.
Related issue from other project: https://github.com/RPi-Distro/pi-gen/pull/261

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Build success on my selinux enabled centos7 with fat bootfs

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
