### PR TITLE
use chroot_sdcard_apt_get_install for packages

### DIFF
--- a/lib/functions/rootfs/rootfs-create.sh
+++ b/lib/functions/rootfs/rootfs-create.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 function create_new_rootfs_cache_tarball() {
 	# validate cache_fname is set
 	[[ -n "${cache_fname}" ]] || exit_with_error "create_new_rootfs_cache_tarball: cache_fname is not set"

--- a/lib/functions/rootfs/rootfs-create.sh
+++ b/lib/functions/rootfs/rootfs-create.sh
@@ -175,7 +175,7 @@ function create_new_rootfs_cache_via_debootstrap() {
 
 		# Then do the actual install.
 		export if_error_detail_message="Installation of Armbian desktop packages for ${RELEASE} ${DESKTOP_APPGROUPS_SELECTED} ${DESKTOP_ENVIRONMENT} ${BUILD_MINIMAL} failed"
-		chroot_sdcard_apt_get install "${AGGREGATED_PACKAGES_DESKTOP[@]}"
+		chroot_sdcard_apt_get_install "${AGGREGATED_PACKAGES_DESKTOP[@]}"
 	fi
 
 	# stage: check md5 sum of installed packages. Just in case. @TODO: rpardini: this should also be done when a cache is used, not only when it is created


### PR DESCRIPTION
# Description
`chroot_sdcard_apt_get install` lacks `--no-install-recommends` which will install a lot of recommended deps. We already have `chroot_sdcard_apt_get_install` with this parameter, so just change to it.
Jammy gnome rootfs before:
`-rw-rw-r--.  1 root  root  1.7G 2月  23 17:01 arm64-jammy-gnome-55e4d9f0fc31Bcc5421.tar.zst`
After:
`-rw-rw-r--.  1 root  root  1.4G 2月  24 18:42 arm64-jammy-gnome-55e4d9f0fc31Bf5cf28.tar.zst`

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] rootfs build success.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
