### PR TITLE
odroidxu4: fix the `custom_kernel_config__hack_odroidxu4_firmware()` …

### DIFF
--- a/config/sources/families/odroidxu4.conf
+++ b/config/sources/families/odroidxu4.conf
@@ -29,13 +29,17 @@ CPUMAX=2000000
 GOVERNOR=ondemand
 SERIALCON=ttySAC2
 
+# @TODO: is this even needed? Looks like stuff for old HK vendor kernel...
 function custom_kernel_config__hack_odroidxu4_firmware() {
-	display_alert "Copying firmware files" "odroidxu4 VENDOR KERNEL?" "warn"
-	# check $kernel_work_dir is set and exists, or bail
-	[[ -z "${kernel_work_dir}" ]] && exit_with_error "kernel_work_dir is not set"
-	[[ ! -d "${kernel_work_dir}" ]] && exit_with_error "kernel_work_dir does not exist: ${kernel_work_dir}"
-	run_host_command_logged mkdir -pv "${kernel_work_dir}/firmware/edid"
-	run_host_command_logged cp -pv "${SRC}"/packages/blobs/odroidxu4/*.bin "${kernel_work_dir}/firmware/edid"
+	kernel_config_modifying_hashes+=("odroidxu4_firmware")
+	if [[ -f .config ]]; then
+		display_alert "Copying firmware files" "odroidxu4 VENDOR KERNEL?" "warn"
+		# check $kernel_work_dir is set and exists, or bail
+		[[ -z "${kernel_work_dir}" ]] && exit_with_error "kernel_work_dir is not set"
+		[[ ! -d "${kernel_work_dir}" ]] && exit_with_error "kernel_work_dir does not exist: ${kernel_work_dir}"
+		run_host_command_logged mkdir -pv "${kernel_work_dir}/firmware/edid"
+		run_host_command_logged cp -pv "${SRC}"/packages/blobs/odroidxu4/*.bin "${kernel_work_dir}/firmware/edid"
+	fi
 }
 
 setup_write_uboot_platform() {


### PR DESCRIPTION
#### odroidxu4: fix the `custom_kernel_config__hack_odroidxu4_firmware()` for version hash

@belegdol since you're the expert on xu4, is this even needed anymore? It probably works now, but would be nice to get rid of it.

Context: that "firmware copy for xu4" was mixed in the middle of kernel compile logic, and was extracted into a kernel config hook; kernel configs are hashed (for caching) and thus need to work even when kernel_work_dir is not set. The hash component has been added.

JIRA: AR-1548
