### PR TITLE
logging: introduce `TEXT_IS_TOO_DARK=yes` to make tool log output visible (temporary workaround)

### DIFF
--- a/lib/functions/logging/logging.sh
+++ b/lib/functions/logging/logging.sh
@@ -23,8 +23,8 @@ function logging_init() {
 	declare -g -i logging_section_counter=0 # -i: integer
 	declare -g tool_color="${gray_color}"   # default to gray... (should be ok on terminals)
 
-	# @TODO: more terminals might have a bit... impaired... default themes. correct.
-	if [[ "${TERM}" == "alacritty" ]]; then
+	# @TODO: more terminals might have a bit... impaired... default themes. workaround...
+	if [[ "${TEXT_IS_TOO_DARK:-"no"}" == "yes" || "${TERM}" == "alacritty" ]]; then
 		declare -g tool_color="${normal_color}"
 	fi
 


### PR DESCRIPTION
- I am "almost" giving up on the "bright black" == "gray" thing. There's enough bad default themes out there, and not the first time people (rightfully) complained...
- ref #4865 
