### PR TITLE
Re-enable Olimex Teres A64

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -54,5 +54,3 @@ config/kernel/linux-uefi-riscv64-current.config             @igorpecovnik
 config/kernel/linux-uefi-riscv64-edge.config                @igorpecovnik
 config/kernel/linux-uefi-x86-current.config                 @igorpecovnik
 config/kernel/linux-uefi-x86-edge.config                    @igorpecovnik
-
-config/boards/olimex-teres-a64.conf                         @Kreyren

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -54,3 +54,5 @@ config/kernel/linux-uefi-riscv64-current.config             @igorpecovnik
 config/kernel/linux-uefi-riscv64-edge.config                @igorpecovnik
 config/kernel/linux-uefi-x86-current.config                 @igorpecovnik
 config/kernel/linux-uefi-x86-edge.config                    @igorpecovnik
+
+config/boards/olimex-teres-a64.conf                         @Kreyren

--- a/config/boards/olimex-teres-a64.conf
+++ b/config/boards/olimex-teres-a64.conf
@@ -7,28 +7,12 @@ BOARDFAMILY="sun50iw1"
 # Legacy has been removed as it's too old and disfunctional for this board
 KERNEL_TARGET="current,edge"
 
-# Enforcing 'msdos' as 'gpt' was not tested
-IMAGE_PARTITION_TABLE="msdos"
-
 # Enable serial console by default
 DEFAULT_CONSOLE="serial"
 SERIALCON="ttyS0:115200"
 
 # Bootloader
-## Has custom default configuration of the u-boot that should be used -- https://linux-sunxi.org/Olimex_Teres-A64#Mainline_U-Boot
 BOOTCONFIG="teres_i_defconfig"
 
-## Observed issues on insufficient size, thus enforced -- https://github.com/OLIMEX/DIY-LAPTOP/issues/52
-BOOTSIZE="256"
-
-## Seems to be the most reliable and bootloader should stay as separate partition
-BOOTFS_TYPE="fat"
-
-# Firmware
-## According to h-node it's able to run firmware-less on linux-libre with a hack[https://h-node.org/wifi/view/en/1725/Realtek-Semiconductor-Co---Ltd--RTL8723BE-PCIe-Wireless-Network-Adapter]
-## Firmware rtlwifi/rtl8723bs (provided in 'firmware-realtek' on debian) is needed for WiFi/BLE module[https://olimex.miraheze.org/wiki/Products/Teres-1#Non-Free]
-## NOTE(Krey): Pulseaudio is needed for the audio to work especially in pipewire configuration, I wasn't able to make it work just off of ALSA
-PACKAGE_LIST_BOARD="firmware-realtek pulseaudio"
-
-# Floods the system with bunch of bloat where we only need 'firmware-realtek'
-INSTALL_ARMBIAN_FIRMWARE="no"
+# NOTE(Krey): Pulseaudio is needed for the audio to work especially in pipewire configuration, I wasn't able to make it work just off of ALSA
+PACKAGE_LIST_BOARD="pulseaudio"

--- a/config/boards/olimex-teres-a64.conf
+++ b/config/boards/olimex-teres-a64.conf
@@ -1,0 +1,34 @@
+# Allwinner A64 quad core 2GB SoC Wi-Fi/BT Revision C
+BOARD_NAME="OLIMEX Teres A64" 
+
+# Specified in https://linux-sunxi.org/Allwinner_SoC_Family
+BOARDFAMILY="sun50iw1"
+
+# Legacy has been removed as it's too old and disfunctional for this board
+KERNEL_TARGET="current,edge"
+
+# Enforcing 'msdos' as 'gpt' was not tested
+IMAGE_PARTITION_TABLE="msdos"
+
+# Enable serial console by default
+DEFAULT_CONSOLE="serial"
+SERIALCON="ttyS0:115200"
+
+# Bootloader
+## Has custom default configuration of the u-boot that should be used -- https://linux-sunxi.org/Olimex_Teres-A64#Mainline_U-Boot
+BOOTCONFIG="teres_i_defconfig"
+
+## Observed issues on insufficient size, thus enforced -- https://github.com/OLIMEX/DIY-LAPTOP/issues/52
+BOOTSIZE="256"
+
+## Seems to be the most reliable and bootloader should stay as separate partition
+BOOTFS_TYPE="fat"
+
+# Firmware
+## According to h-node it's able to run firmware-less on linux-libre with a hack[https://h-node.org/wifi/view/en/1725/Realtek-Semiconductor-Co---Ltd--RTL8723BE-PCIe-Wireless-Network-Adapter]
+## Firmware rtlwifi/rtl8723bs (provided in 'firmware-realtek' on debian) is needed for WiFi/BLE module[https://olimex.miraheze.org/wiki/Products/Teres-1#Non-Free]
+## NOTE(Krey): Pulseaudio is needed for the audio to work especially in pipewire configuration, I wasn't able to make it work just off of ALSA
+PACKAGE_LIST_BOARD="firmware-realtek pulseaudio"
+
+# Floods the system with bunch of bloat where we only need 'firmware-realtek'
+INSTALL_ARMBIAN_FIRMWARE="no"

--- a/config/boards/teres-a64.csc
+++ b/config/boards/teres-a64.csc
@@ -1,7 +1,0 @@
-# Allwinner A64 quad core 2GB SoC Wi-Fi/BT
-BOARD_NAME="Teres A64"
-BOARDFAMILY="sun50iw1"
-BOOTCONFIG="teres_i_defconfig"
-KERNEL_TARGET="legacy,current,edge"
-FULL_DESKTOP="yes"
-BOOT_LOGO="desktop"


### PR DESCRIPTION
# Description

Rework of https://github.com/armbian/build/pull/4807 as its not possible to push into the original branch to fix remaining problems and merge.

Removed necessary config options:

- all u-boot configs are custom
- we avoid FAT boot if possible. This hardware boots from ext4 without problems. Changing to fat will not help in reliability.
- armbian wireless package have all firmware needed for this hw and for most popular USB dongles. If those wireless drivers firmware would be considered as a bloatware, we should also make very custom kernel and remove all things that are wasteful for this device. We could do that, but what we don't have is - time.
- build config has been moved to [different repository](https://github.com/armbian/os/tree/main/targets) with last major code switch
- we are not using CODEOWNERS for board config levels and in past two months that we have used this functionality, we only had problems and we will limit it down (nothing to do with this PR anyway)
- [board maintainers guidelines needed that hardware keeps supported status](https://docs.armbian.com/Board_Maintainers_Procedures_and_Guidelines/)

P.S.
You are welcome to rework your PR and close mine.

Jira reference number [AR-1555]

# How Has This Been Tested?

- [ ] Files are [here](https://imola.armbian.com/dl/olimex-teres-a64/nightly/).

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1555]: https://armbian.atlassian.net/browse/AR-1555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ