### PR TITLE
Fix "No space left on device" while rsync root files to image

### DIFF
--- a/lib/functions/image/partitioning.sh
+++ b/lib/functions/image/partitioning.sh
@@ -103,7 +103,7 @@ function prepare_partitions() {
 
 	# stage: calculate rootfs size
 	declare -g -i rootfs_size
-	rootfs_size=$(du -sm "${SDCARD}"/ | cut -f1) # MiB
+	rootfs_size=$(du --apparent-size -sm "${SDCARD}"/ | cut -f1) # MiB
 	display_alert "Current rootfs size" "$rootfs_size MiB" "info"
 
 	call_extension_method "prepare_image_size" "config_prepare_image_size" <<- 'PREPARE_IMAGE_SIZE'

--- a/lib/functions/main/rootfs-image.sh
+++ b/lib/functions/main/rootfs-image.sh
@@ -45,7 +45,7 @@ function build_rootfs_and_image() {
 
 	# obtain the size, in MiB, of "${SDCARD}" at this point.
 	declare -i rootfs_size_mib
-	rootfs_size_mib=$(du -sm "${SDCARD}" | awk '{print $1}')
+	rootfs_size_mib=$(du --apparent-size -sm "${SDCARD}" | awk '{print $1}')
 	display_alert "Actual rootfs size" "${rootfs_size_mib}MiB" ""
 
 	# warn if rootfs_size_mib is higher than the tmpfs_estimated_size


### PR DESCRIPTION
# Description

In some file systems, calling du shows an invalid amount of occupied filespace. The solution is to call `du` with the option `--apparent-size`

Cons: With this option du shows a slightly smaller size than the files can actually take up, because only the net sum of the file sizes is counted without taking into account the hit to the cluster size.

Fixes: https://github.com/armbian/build/pull/4857

Jira reference number [AR-1556]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested build with/without tmpfs on zfs.
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1556]: https://armbian.atlassian.net/browse/AR-1556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ