### PR TITLE
meson64: edge: rebase patches onto `v6.2.1`; fix mbox for recently added patch (no actual changes)

### DIFF
--- a/patch/kernel/archive/meson64-6.2/board-odroidc4-reset-driver.patch
+++ b/patch/kernel/archive/meson64-6.2/board-odroidc4-reset-driver.patch
@@ -1,5 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ash Hughes <spirit.returned@gmail.com>
+Date: Sat, 18 Feb 2023 07:46:38 -0300
+Subject: adapted odroid-reboot driver, fix reboot on odroid C4 when using
+ UHS-II SD cards
+
+bring back fixed version of `odroid-reboot` driver (Fix reboot on odroid C4 when using UHS-II SD cards)
+---
+ arch/arm64/boot/dts/amlogic/meson-sm1-odroid-c4.dts |  10 +
+ drivers/power/reset/Kconfig                         |   7 +
+ drivers/power/reset/Makefile                        |   1 +
+ drivers/power/reset/odroid-reboot.c                 | 186 ++++++++++
+ 4 files changed, 204 insertions(+)
+
 diff --git a/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-c4.dts b/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-c4.dts
-index 8c30ce636..ee8aa390e 100644
+index 8c30ce63686e..ee8aa390ea56 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-c4.dts
 +++ b/arch/arm64/boot/dts/amlogic/meson-sm1-odroid-c4.dts
 @@ -11,6 +11,16 @@ / {
@@ -20,7 +34,7 @@ index 8c30ce636..ee8aa390e 100644
  		compatible = "gpio-leds";
  
 diff --git a/drivers/power/reset/Kconfig b/drivers/power/reset/Kconfig
-index 4b563db3a..14396a3fc 100644
+index a8c46ba5878f..f685772c8213 100644
 --- a/drivers/power/reset/Kconfig
 +++ b/drivers/power/reset/Kconfig
 @@ -141,6 +141,13 @@ config POWER_RESET_OCELOT_RESET
@@ -38,7 +52,7 @@ index 4b563db3a..14396a3fc 100644
  	bool "OXNAS SoC restart driver"
  	depends on ARCH_OXNAS
 diff --git a/drivers/power/reset/Makefile b/drivers/power/reset/Makefile
-index f606a2f60..ce0149984 100644
+index 0a39424fc558..b58a4f2891db 100644
 --- a/drivers/power/reset/Makefile
 +++ b/drivers/power/reset/Makefile
 @@ -14,6 +14,7 @@ obj-$(CONFIG_POWER_RESET_HISI) += hisi-reboot.o
@@ -51,7 +65,7 @@ index f606a2f60..ce0149984 100644
  obj-$(CONFIG_POWER_RESET_OCELOT_RESET) += ocelot-reset.o
 diff --git a/drivers/power/reset/odroid-reboot.c b/drivers/power/reset/odroid-reboot.c
 new file mode 100644
-index 000000000..00fedd36b
+index 000000000000..0339718b4a80
 --- /dev/null
 +++ b/drivers/power/reset/odroid-reboot.c
 @@ -0,0 +1,186 @@
@@ -241,3 +255,6 @@ index 000000000..00fedd36b
 +}
 +device_initcall(odroid_restart_init);
 +
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.2/drv-spi-spidev-remove-warnings.patch
+++ b/patch/kernel/archive/meson64-6.2/drv-spi-spidev-remove-warnings.patch
@@ -12,10 +12,10 @@ Remove SPIdev warnings
  1 file changed, 2 insertions(+)
 
 diff --git a/drivers/spi/spidev.c b/drivers/spi/spidev.c
-index 1935ca613447..8a4fb7a0e614 100644
+index a1ea093795cf..5dcc82c6a107 100644
 --- a/drivers/spi/spidev.c
 +++ b/drivers/spi/spidev.c
-@@ -694,6 +694,7 @@ static const struct file_operations spidev_fops = {
+@@ -704,6 +704,7 @@ static const struct file_operations spidev_fops = {
  static struct class *spidev_class;
  
  static const struct spi_device_id spidev_spi_ids[] = {
@@ -23,7 +23,7 @@ index 1935ca613447..8a4fb7a0e614 100644
  	{ .name = "dh2228fv" },
  	{ .name = "ltc2488" },
  	{ .name = "sx1301" },
-@@ -720,6 +721,7 @@ static int spidev_of_check(struct device *dev)
+@@ -730,6 +731,7 @@ static int spidev_of_check(struct device *dev)
  }
  
  static const struct of_device_id spidev_dt_ids[] = {

--- a/patch/kernel/archive/meson64-6.2/general-input-touchscreen-Add-D-WAV-Multitouch.patch
+++ b/patch/kernel/archive/meson64-6.2/general-input-touchscreen-Add-D-WAV-Multitouch.patch
@@ -13,10 +13,10 @@ Change-Id: Ia1c8c29d3f69c6ba5d630279c4cc98119b68ab71
  5 files changed, 574 insertions(+)
 
 diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
-index 0f8c11842a3a..846c82dabede 100644
+index 9e36b4cd905e..8897e84f2dd5 100644
 --- a/drivers/hid/hid-ids.h
 +++ b/drivers/hid/hid-ids.h
-@@ -1418,4 +1418,10 @@
+@@ -1421,4 +1421,10 @@
  #define USB_VENDOR_ID_SIGNOTEC			0x2133
  #define USB_DEVICE_ID_SIGNOTEC_VIEWSONIC_PD1011	0x0018
  
@@ -28,10 +28,10 @@ index 0f8c11842a3a..846c82dabede 100644
 +
  #endif
 diff --git a/drivers/hid/hid-quirks.c b/drivers/hid/hid-quirks.c
-index be3ad02573de..a2a8eb78a067 100644
+index 5bc91f68b374..d90979c6dc30 100644
 --- a/drivers/hid/hid-quirks.c
 +++ b/drivers/hid/hid-quirks.c
-@@ -878,6 +878,9 @@ static const struct hid_device_id hid_ignore_list[] = {
+@@ -879,6 +879,9 @@ static const struct hid_device_id hid_ignore_list[] = {
  	{ HID_USB_DEVICE(USB_VENDOR_ID_SYNAPTICS, USB_DEVICE_ID_SYNAPTICS_DPAD) },
  #endif
  	{ HID_USB_DEVICE(USB_VENDOR_ID_YEALINK, USB_DEVICE_ID_YEALINK_P1K_P4K_B2K) },

--- a/patch/kernel/archive/meson64-6.2/general-memory-marked-nomap.patch
+++ b/patch/kernel/archive/meson64-6.2/general-memory-marked-nomap.patch
@@ -14,10 +14,10 @@ Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
  1 file changed, 9 deletions(-)
 
 diff --git a/drivers/of/fdt.c b/drivers/of/fdt.c
-index f08b25195ae7..853b65bae5f6 100644
+index d1a68b6d03b3..81508e8b34d2 100644
 --- a/drivers/of/fdt.c
 +++ b/drivers/of/fdt.c
-@@ -481,15 +481,6 @@ static int __init early_init_dt_reserve_memory(phys_addr_t base,
+@@ -480,15 +480,6 @@ static int __init early_init_dt_reserve_memory(phys_addr_t base,
  					       phys_addr_t size, bool nomap)
  {
  	if (nomap) {

--- a/patch/kernel/archive/meson64-6.2/general-meson-gx-mmc-fix-deferred-probing.patch
+++ b/patch/kernel/archive/meson64-6.2/general-meson-gx-mmc-fix-deferred-probing.patch
@@ -16,10 +16,10 @@ Signed-off-by: Sergey Shtylyov <s.shtylyov@omp.ru>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/mmc/host/meson-gx-mmc.c b/drivers/mmc/host/meson-gx-mmc.c
-index 6e5ea0213b47..03d313a27a7a 100644
+index 5c94ad4661ce..64a1520321b0 100644
 --- a/drivers/mmc/host/meson-gx-mmc.c
 +++ b/drivers/mmc/host/meson-gx-mmc.c
-@@ -1225,8 +1225,8 @@ static int meson_mmc_probe(struct platform_device *pdev)
+@@ -1233,8 +1233,8 @@ static int meson_mmc_probe(struct platform_device *pdev)
  	}
  
  	host->irq = platform_get_irq(pdev, 0);

--- a/patch/kernel/archive/meson64-6.2/general-meson-mmc-1-arm64-amlogic-mmc-meson-gx-Add-core-tx-rx-eMMC-SD-SD.patch
+++ b/patch/kernel/archive/meson64-6.2/general-meson-mmc-1-arm64-amlogic-mmc-meson-gx-Add-core-tx-rx-eMMC-SD-SD.patch
@@ -11,10 +11,9 @@ device-tree file.
 
 Signed-off-by: Vyacheslav Bocharov <adeep@lexina.in>
 ---
- drivers/mmc/host/meson-gx-mmc.c        | 19 +++++++++-----
- include/dt-bindings/mmc/meson-gx-mmc.h | 35 ++++++++++++++++++++++++++
+ drivers/mmc/host/meson-gx-mmc.c        | 19 +++--
+ include/dt-bindings/mmc/meson-gx-mmc.h | 35 ++++++++++
  2 files changed, 48 insertions(+), 6 deletions(-)
- create mode 100644 include/dt-bindings/mmc/meson-gx-mmc.h
 
 diff --git a/drivers/mmc/host/meson-gx-mmc.c b/drivers/mmc/host/meson-gx-mmc.c
 index 64a1520321b0..fa9ec777e4a2 100644
@@ -105,5 +104,5 @@ index 000000000000..cfc4a9d75b2b
 +
 +#endif
 -- 
-2.34.1
+Armbian
 

--- a/patch/kernel/archive/meson64-6.2/general-meson-mmc-2-arm64-amlogic-dts-meson-update-meson-axg-device-tree.patch
+++ b/patch/kernel/archive/meson64-6.2/general-meson-mmc-2-arm64-amlogic-dts-meson-update-meson-axg-device-tree.patch
@@ -12,7 +12,7 @@ Signed-off-by: Vyacheslav Bocharov <adeep@lexina.in>
  1 file changed, 3 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-axg.dtsi b/arch/arm64/boot/dts/amlogic/meson-axg.dtsi
-index 1648e67afbb6..d26f3b20bfec 100644
+index 417523dc4cc0..b8a9e476bde2 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-axg.dtsi
 +++ b/arch/arm64/boot/dts/amlogic/meson-axg.dtsi
 @@ -13,6 +13,7 @@

--- a/patch/kernel/archive/meson64-6.2/meson-g12a-pinctrl-add-missing-ir-options.patch
+++ b/patch/kernel/archive/meson64-6.2/meson-g12a-pinctrl-add-missing-ir-options.patch
@@ -12,7 +12,7 @@ Signed-off-by: Yuntian Zhang <yt@radxa.com>
  2 files changed, 25 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-g12-common.dtsi b/arch/arm64/boot/dts/amlogic/meson-g12-common.dtsi
-index 9dbd50820b1c..a92c1ec9266d 100644
+index 7f55d97f6c28..ab36d2e41381 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-g12-common.dtsi
 +++ b/arch/arm64/boot/dts/amlogic/meson-g12-common.dtsi
 @@ -562,6 +562,14 @@ mux {

--- a/patch/kernel/archive/meson64-6.2/meson-gx-dts-add-support-for-GX-PM-and-VRTC.patch
+++ b/patch/kernel/archive/meson64-6.2/meson-gx-dts-add-support-for-GX-PM-and-VRTC.patch
@@ -9,7 +9,7 @@ Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>
  1 file changed, 9 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-gx.dtsi b/arch/arm64/boot/dts/amlogic/meson-gx.dtsi
-index e3c12e0be99d..4937cdc818f6 100644
+index 5eed15035b67..8f1e17a656cb 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-gx.dtsi
 +++ b/arch/arm64/boot/dts/amlogic/meson-gx.dtsi
 @@ -222,6 +222,10 @@ sm: secure-monitor {


### PR DESCRIPTION
- Before:
  `Summary: kernel patching: 62 total patches; 62 applied; 5 with problems; 1 not_mbox; 4 needs_rebase`
- After:
  `Summary: kernel patching: 62 total patches; 62 applied; 0 with problems` 


