### PR TITLE
remove files in /boot at preinst when bootfs is vfat

### DIFF
--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -235,6 +235,28 @@ function kernel_package_callback_linux_image() {
 				test -d ${debian_kernel_hook_dir}/${script}.d && run-parts --arg="${kernel_version_family}" --arg="/${installed_image_path}" ${debian_kernel_hook_dir}/${script}.d
 			KERNEL_HOOK_DELEGATION
 
+			if [[ "${script}" == "preinst" ]]; then
+				cat <<- HOOK_FOR_REMOVE_VFAT_BOOT_FILES
+					check_boot_dev (){
+						boot_device=\$(mountpoint -d /boot)
+
+						for file in /dev/* ; do
+							CURRENT_DEVICE=\$(printf "%d:%d" \$(stat --printf="0x%t 0x%T" \$file))
+							if [[ "\$CURRENT_DEVICE" = "\$boot_device" ]]; then
+								boot_partition=\$file
+								break
+							fi
+						done
+
+						bootfstype=\$(blkid -s TYPE -o value \$boot_partition)
+						if [ "\$bootfstype" = "vfat" ]; then
+							rm -f /boot/System.map* /boot/config* /boot/vmlinuz* /boot/$image_name /boot/uImage
+						fi
+					}
+					mountpoint -q /boot && check_boot_dev
+				HOOK_FOR_REMOVE_VFAT_BOOT_FILES
+			fi
+
 			# @TODO: only if u-boot, only for postinst. Gotta find a hook scheme for these...
 			if [[ "${script}" == "postinst" ]]; then
 				cat <<- HOOK_FOR_LINK_TO_LAST_INSTALLED_KERNEL

--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -238,16 +238,7 @@ function kernel_package_callback_linux_image() {
 			if [[ "${script}" == "preinst" ]]; then
 				cat <<- HOOK_FOR_REMOVE_VFAT_BOOT_FILES
 					check_boot_dev (){
-						boot_device=\$(mountpoint -d /boot)
-
-						for file in /dev/* ; do
-							CURRENT_DEVICE=\$(printf "%d:%d" \$(stat --printf="0x%t 0x%T" \$file))
-							if [[ "\$CURRENT_DEVICE" = "\$boot_device" ]]; then
-								boot_partition=\$file
-								break
-							fi
-						done
-
+						boot_partition=\$(findmnt -n -o SOURCE /boot)
 						bootfstype=\$(blkid -s TYPE -o value \$boot_partition)
 						if [ "\$bootfstype" = "vfat" ]; then
 							rm -f /boot/System.map* /boot/config* /boot/vmlinuz* /boot/$image_name /boot/uImage


### PR DESCRIPTION
# Description

Copied from https://github.com/armbian/build/blob/master/packages/armbian/builddeb#L336

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Build kernel package success
- [x] Install on my rock-5b with vfat bootfs success

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
