### PR TITLE
Remove selinux due to installation issues

### DIFF
--- a/config/cli/common/main/packages.additional
+++ b/config/cli/common/main/packages.additional
@@ -54,7 +54,6 @@ qrencode
 rfkill
 rng-tools
 screen
-selinux-policy-default
 software-properties-common
 smartmontools
 stress


### PR DESCRIPTION
# Description

selinux fails to deploy in some armhf builds. Lets move it out from default package base.

Jira reference number [AR-9999]

# How Has This Been Tested?

- [ ] Complete cache rebuild