### PR TITLE
rockchip64: enable dmc on Rock PI E board

### DIFF
--- a/patch/kernel/archive/rockchip64-6.1/board-rockpi3-enable-dmc.patch
+++ b/patch/kernel/archive/rockchip64-6.1/board-rockpi3-enable-dmc.patch
@@ -1,0 +1,22 @@
+diff --git a/arch/arm64/boot/dts/rockchip/rk3328-rock-pi-e.dts b/arch/arm64/boot/dts/rockchip/rk3328-rock-pi-e.dts
+index 018a3a5075c..9b3453cece8 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3328-rock-pi-e.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3328-rock-pi-e.dts
+@@ -15,6 +15,7 @@
+ #include <dt-bindings/pinctrl/rockchip.h>
+ 
+ #include "rk3328.dtsi"
++#include "rk3328-dram-default-timing.dtsi"
+ 
+ / {
+ 	model = "Radxa ROCK Pi E";
+@@ -388,3 +389,9 @@ &usbdrd3 {
+ &usb_host0_ehci {
+ 	status = "okay";
+ };
++
++&dmc {
++	status = "okay";
++	center-supply = <&vdd_log>;
++	ddr_timing = <&ddr_timing>;
++};


### PR DESCRIPTION
# Description

Due to "recent" fixes to the rk3328 dram memory controller driver (see https://github.com/armbian/build/pull/4774) and tests/benchmarks being made on Rock Pi E board, enable the dmc driver on such CSC board for a nice and free speed bump

Jira reference number [AR-1585]

# How Has This Been Tested?

The patch is from the pre-armbian-next era and has been tested there to be fully functional, I will check that it does not break compilation on main branch as soon as possible.

- [x] compile deb kernel packages on main branch

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1585]: https://armbian.atlassian.net/browse/AR-1585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ