### PR TITLE
rockchip64: enable DMC on Orange Pi 4 LTS

### DIFF
--- a/patch/kernel/archive/rockchip64-6.1/add-board-orangepi-4-lts.patch
+++ b/patch/kernel/archive/rockchip64-6.1/add-board-orangepi-4-lts.patch
@@ -1,9 +1,9 @@
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4-lts.dts b/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4-lts.dts
 new file mode 100644
-index 00000000000..e0490aaa7ba
+index 00000000000..43f081ec1ab
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4-lts.dts
-@@ -0,0 +1,1258 @@
+@@ -0,0 +1,1254 @@
 +/*
 + * SPDX-License-Identifier: (GPL-2.0+ or MIT)
 + * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd.
@@ -201,21 +201,6 @@ index 00000000000..e0490aaa7ba
 +
 +	};
 +
-+	/*
-+	dw_hdmi_audio: dw-hdmi-audio {
-+		status = "disable";
-+		compatible = "rockchip,dw-hdmi-audio";
-+		#sound-dai-cells = <0>;
-+	};
-+
-+        hdmi_dp_sound: hdmi-dp-sound {
-+                status = "okay";
-+                compatible = "rockchip,rk3399-hdmi-dp";
-+                rockchip,cpu = <&i2s2>;
-+                rockchip,codec = <&hdmi>, <&cdn_dp>;
-+        };
-+        */
-+
 +	hdmi-sound {
 +		compatible = "simple-audio-card";
 +		simple-audio-card,format = "i2s";
@@ -383,6 +368,26 @@ index 00000000000..e0490aaa7ba
 +		status = "okay";
 +	};
 +
++	dmc_opp_table: dmc_opp_table {
++		compatible = "operating-points-v2";
++
++		opp00 {
++			opp-hz = /bits/ 64 <328000000>;
++			opp-microvolt = <900000>;
++		};
++
++		opp01 {
++			opp-hz = /bits/ 64 <416000000>;
++			opp-microvolt = <900000>;
++		};
++
++		opp02 {
++			opp-hz = /bits/ 64 <666000000>;
++			opp-microvolt = <900000>;
++		};
++
++	};
++
 +};
 +
 +&cpu_l0 {
@@ -442,37 +447,11 @@ index 00000000000..e0490aaa7ba
 +		status = "okay";
 +	};
 +};
-+/*
-+&spi1 {
-+    status = "okay";
-+    max-freq = <48000000>;
-+    spidev@00 {
-+        compatible = "linux,spidev";
-+        reg = <0x00>;
-+        spi-max-frequency = <48000000>;
-+    };
-+};
-+*/
 +
 +&uart0 {
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&uart0_xfer &uart0_cts &uart0_rts>;
 +	status = "okay";
-+
-+	/*
-+	bluetooth {
-+		compatible = "brcm,bcm4345c5";
-+		clocks = <&rk808 1>;
-+		clock-names = "lpo";
-+		device-wakeup-gpios = <&gpio2 RK_PD2 GPIO_ACTIVE_HIGH>;
-+		host-wakeup-gpios = <&gpio0 RK_PA4 GPIO_ACTIVE_HIGH>;
-+		shutdown-gpios = <&gpio0 RK_PB1 GPIO_ACTIVE_HIGH>;
-+		max-speed = <1500000>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&bt_host_wake &bt_wake &bt_reset>;
-+	};
-+	*/
-+
 +};
 +
 +&uart2 {
@@ -853,13 +832,6 @@ index 00000000000..e0490aaa7ba
 +		status = "okay";
 +	};
 +
-+	/*
-+	onewire_ts@2f {
-+		compatible = "onewire";
-+		reg = <0x2f>;
-+		interrupt-parent = <&gpio1>;
-+		interrupts = <20 IRQ_TYPE_EDGE_FALLING>;
-+	}; */
 +};
 +
 +&i2c7 {
@@ -1262,3 +1234,27 @@ index 00000000000..e0490aaa7ba
 +	status = "okay";
 +};
 +
++&dmc {
++	status = "okay";
++	center-supply = <&vdd_log>;
++	operating-points-v2 = <&dmc_opp_table>;
++
++	rockchip,pd-idle-ns = <160>;
++	rockchip,sr-idle-ns = <10240>;
++	rockchip,sr-mc-gate-idle-ns = <40960>;
++	rockchip,srpd-lite-idle-ns = <61440>;
++	rockchip,standby-idle-ns = <81920>;
++
++	rockchip,ddr3_odt_dis_freq = <666000000>;
++	rockchip,lpddr3_odt_dis_freq = <666000000>;
++	rockchip,lpddr4_odt_dis_freq = <666000000>;
++
++	rockchip,sr-mc-gate-idle-dis-freq-hz = <1000000000>;
++	rockchip,srpd-lite-idle-dis-freq-hz = <0>;
++	rockchip,standby-idle-dis-freq-hz = <928000000>;
++
++};
++
++&dfi {
++	status = "okay";
++};

--- a/patch/kernel/archive/rockchip64-6.1/rk3399-dmc-polling-rate.patch
+++ b/patch/kernel/archive/rockchip64-6.1/rk3399-dmc-polling-rate.patch
@@ -1,0 +1,13 @@
+diff --git a/drivers/devfreq/rk3399_dmc.c b/drivers/devfreq/rk3399_dmc.c
+index daff4070261..62f4804134c 100644
+--- a/drivers/devfreq/rk3399_dmc.c
++++ b/drivers/devfreq/rk3399_dmc.c
+@@ -430,7 +430,7 @@ static int rk3399_dmcfreq_probe(struct platform_device *pdev)
+ 	dev_pm_opp_put(opp);
+ 
+ 	data->profile = (struct devfreq_dev_profile) {
+-		.polling_ms	= 200,
++		.polling_ms	= 50,
+ 		.target		= rk3399_dmcfreq_target,
+ 		.get_dev_status	= rk3399_dmcfreq_get_dev_status,
+ 		.get_cur_freq	= rk3399_dmcfreq_get_cur_freq,


### PR DESCRIPTION
# Description

Orange Pi 4 LTS has DDR4 memory banks that always run at full speed. This PR enables the DMC driver in kernel 6.1 to lower the frequency to reduce power usage during idle periods. Benchmarks with a digital multimeter show that the power usage decreases by 200mW when the board is idling.

Jira reference number [AR-1584]

# How Has This Been Tested?

This is a pre-armbian-next era patch and has been tested to be fully functional. I rebased it successfully on main branch, but requires to be tested not to break the compilation.

- [x] compile to produce kernel deb packages

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1584]: https://armbian.atlassian.net/browse/AR-1584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ