### PR TITLE
Look for bash shebang from start of the line

### DIFF
--- a/.github/workflows/lint-scripts-pr.yml
+++ b/.github/workflows/lint-scripts-pr.yml
@@ -35,7 +35,7 @@ jobs:
            ret=0
 
            for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-             if grep -qE "#\!/" $file; then
+             if grep -qE "^#\!/" $file; then
 
                  shellcheck --severity=error $file || ret=$?
 


### PR DESCRIPTION
# Description

Linter is detecting bash shebang that is coming with a patch or some other anomaly. We don't want that.

Jira reference number [AR-1588]

# How Has This Been Tested?

- [x] Manual execution

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1588]: https://armbian.atlassian.net/browse/AR-1588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ