### PR TITLE
Improve kernel security check filtering

### DIFF
--- a/.github/workflows/kernel-security-analysis-pr.yml
+++ b/.github/workflows/kernel-security-analysis-pr.yml
@@ -42,5 +42,7 @@ jobs:
        - name: Check kernel config for security issues
          run: |
            for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-               kconfig-hardened-check/bin/kconfig-hardened-check -m show_fail -c $file | sed -e 's/^/    /' >> $GITHUB_STEP_SUMMARY
+               if [[  "${file}" = config/kernel/*.config ]]; then
+                   kconfig-hardened-check/bin/kconfig-hardened-check -m show_fail -c $file | sed -e 's/^/    /' >> $GITHUB_STEP_SUMMARY
+               fi
            done


### PR DESCRIPTION
# Description

Kernel security check needs to check kernel configs only, not all changed files.

Jira reference number [AR-1589]

# How Has This Been Tested?

- [x] Manual run

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

[AR-1589]: https://armbian.atlassian.net/browse/AR-1589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ