### PR TITLE
fix reference to espressobin u-boot tag

### DIFF
--- a/config/sources/families/mvebu64.conf
+++ b/config/sources/families/mvebu64.conf
@@ -1,6 +1,6 @@
 enable_extension "marvell-tools"
 ARCH=arm64
-BOOTBRANCH='branch:v2022.04'
+BOOTBRANCH='tag:v2022.04'
 BOOTPATCHDIR="v2022.07"
 BOOTENV_FILE='mvebu64.txt'
 BOOTSCRIPT_OUTPUT='boot.scr'


### PR DESCRIPTION
# Description

Armbian-next reveals an improper reference to u-boot sources that needed to be fixed.  This allows u-boot and kernel to build.

Jira reference number [AR-1576]

# How Has This Been Tested?

Compiled on Jammy.  Success.  No testing, because the version of u-boot didn't change, just the way it's referenced in the armbian tooling.

