### PR TITLE
multiple fixes for `mvebu64`'s u-boot compilation

### DIFF
--- a/config/sources/families/mvebu64.conf
+++ b/config/sources/families/mvebu64.conf
@@ -7,6 +7,12 @@
 # https://github.com/armbian/build/
 #
 enable_extension "marvell-tools"
+
+# The C++ compiler is no longer included by default in the Armbian build system (but required for mox related stuff)
+# Enable the extension that brings includes it. It could've been an inline extension (eg: the function right here),
+# but having a core extension allows it to be pre-included in the Dockerfile generation and thus in the Docker images.
+enable_extension "c-plus-plus-compiler"
+
 ARCH=arm64
 BOOTBRANCH='tag:v2022.04'
 BOOTPATCHDIR="v2022.07"
@@ -88,7 +94,7 @@ family_tweaks_bsp() {
 
 atf_custom_postprocess() {
 	# prepare compilers for postprocess
-	ubootdir="$SRC/cache/sources/$BOOTDIR/${BOOTBRANCH##*:}"
+	ubootdir="$SRC/cache/sources/u-boot-worktree/$BOOTDIR/${BOOTBRANCH##*:}"
 	export ATF1=$toolchain/$ATF_COMPILER
 	if [[ "${SKIP_EXTERNAL_TOOLCHAINS}" == "yes" ]]; then
 		export TOOLCHAIN_NAME="arm-linux-gnueabi-"
@@ -101,9 +107,9 @@ atf_custom_postprocess() {
 
 uboot_custom_postprocess() {
 	# clean previous
-	rm $ubootdir/flash-image*
+	run_host_command_logged rm -f "$ubootdir"/flash-image*
 	local atfdir="$SRC/cache/sources/$ATFDIR/${ATFBRANCH##*:}"
-	local ubootdir="$SRC/cache/sources/$BOOTDIR/${BOOTBRANCH##*:}"
+	local ubootdir="$SRC/cache/sources/u-boot-worktree/$BOOTDIR/${BOOTBRANCH##*:}"
 	local moxbootdir="$SRC/cache/sources/mox-boot"
 	cd $atfdir
 
@@ -114,12 +120,12 @@ uboot_custom_postprocess() {
 		display_alert "Building $FILENAME" "" "info"
 		# http://wiki.macchiatobin.net/tiki-index.php?page=Build+from+source+-+Bootloader#Building_ATF
 		run_host_command_logged make distclean
-		run_host_command_logged make USE_COHERENT_MEM=0 LOG_LEVEL=20 MV_DDR_PATH=$SRC/cache/sources/marvell-ddr PLAT=a80x0_mcbin CROSS_COMPILE=$ATF1 BL33=$BL33 mrvl_flash $CTHREADS
+		run_host_command_logged "CFLAGS=-fdiagnostics-color=always" pipetty make USE_COHERENT_MEM=0 LOG_LEVEL=20 MV_DDR_PATH=$SRC/cache/sources/marvell-ddr PLAT=a80x0_mcbin CROSS_COMPILE=$ATF1 BL33=$BL33 mrvl_flash $CTHREADS
 		run_host_command_logged cp -pv build/a80x0_mcbin/release/flash-image.bin $ubootdir/$FILENAME
 	else
 		cd $moxbootdir
 		make clean # @TODO: rpardini: why?
-		run_host_command_logged make CROSS_CM3=$ATF2 wtmi_app.bin
+		run_host_command_logged "CFLAGS=-fdiagnostics-color=always" pipetty make CROSS_CM3=$ATF2 wtmi_app.bin
 		cd $atfdir
 
 		clocks=(600_600 800_800 1000_800 1200_750)
@@ -130,9 +136,9 @@ uboot_custom_postprocess() {
 				FILENAME="flash-image-$ddrname-$j-$i.bin"
 				DDR_TOPOLOGY="${j##*_}"
 				CLOCKSPRESET="CPU_${i%_*}_DDR_${i##*_}"
-				display_alert "Building $FILENAME" "" "info"
+				display_alert "Building $FILENAME" "mvebu64" "info"
 				run_host_command_logged make distclean
-				run_host_command_logged make CROSS_COMPILE=$ATF1 \
+				run_host_command_logged "CFLAGS=-fdiagnostics-color=always" pipetty make CROSS_COMPILE=$ATF1 \
 					CROSS_CM3=$ATF2 \
 					USE_COHERENT_MEM=0 \
 					PLAT=a3700 \

--- a/config/sources/families/mvebu64.conf
+++ b/config/sources/families/mvebu64.conf
@@ -13,6 +13,13 @@ enable_extension "marvell-tools"
 # but having a core extension allows it to be pre-included in the Dockerfile generation and thus in the Docker images.
 enable_extension "c-plus-plus-compiler"
 
+# The BLx stuff requires 32-bit compiler, add it using an inline hook.
+# This is only used for non-Docker, since the Docker image already has it, since it includes compilers for all architectures.
+function add_host_dependencies__mvebu64_add_32_bit_c_compiler() {
+	display_alert "Adding armhf C compiler to host dependencies" "for mvebu64 BLx compile" "debug"
+	export EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} gcc-arm-linux-gnueabi" # @TODO: convert to array later
+}
+
 ARCH=arm64
 BOOTBRANCH='tag:v2022.04'
 BOOTPATCHDIR="v2022.07"

--- a/extensions/c-plus-plus-compiler.sh
+++ b/extensions/c-plus-plus-compiler.sh
@@ -3,5 +3,5 @@
 
 function add_host_dependencies__add_arm64_c_plus_plus_compiler() {
 	display_alert "Adding arm64 c++ compiler to host dependencies" "g++" "debug"
-	export EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} g++-aarch64-linux-gnu" # @TODO: convert to array later
+	export EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} g++-aarch64-linux-gnu g++" # @TODO: convert to array later
 }


### PR DESCRIPTION
- extension: `c-plus-plus-compiler`: include `g++` package as well as `g++-aarch64-linux-gnu` -- so host arch g++ compiler is also available
- compilation: uboot: manage `shopt nullglob` same way as IFS, so UBOOT_TARGET_MAP's with `*` somewhere are not skipped (as is the case for `mvebu64`)
- `mvebu64`: `enable_extension "c-plus-plus-compiler"`; fix refs to u-boot sources that changed; (try to) add colored logs 
- `mvebu64`: force inclusion of `gcc-arm-linux-gnueabi` 32-bit C compiler for mvebu64 non-Docker compile

these need testing, both on mvebu64 itself, but also on other families to make sure I didn't break anything