### PR TITLE
Update export-logs.sh to use primary Armbian paste server

### DIFF
--- a/lib/functions/logging/export-logs.sh
+++ b/lib/functions/logging/export-logs.sh
@@ -171,10 +171,10 @@ function export_ansi_logs() {
 		if [[ "${SHARE_LOG:-"no"}" == "yes" ]]; then
 			display_alert "SHARE_LOG=yes, uploading log" "uploading logs" "info"
 			declare logs_url="undetermined"
-			logs_url=$(curl --silent --data-binary "@${target_relative_to_src}" "https://paste.next.armbian.com/log" | xargs echo -n || true) # don't fail
+			logs_url=$(curl --silent --data-binary "@${target_relative_to_src}" "https://paste.armbian.com/log" | xargs echo -n || true) # don't fail
 			display_alert "Log uploaded, share URL:" "${logs_url}" ""
 		else
-			display_alert "Share log manually (or SHARE_LOG=yes):" "curl --data-binary @${target_relative_to_src} https://paste.next.armbian.com/log"
+			display_alert "Share log manually (or SHARE_LOG=yes):" "curl --data-binary @${target_relative_to_src} https://paste.armbian.com/log"
 		fi
 	fi
 


### PR DESCRIPTION
# Description

Changing export-logs.sh script from posting to armbian.next.armbian.com to posting to the primary paste server which has now been upgraded at paste.armbian.com.

Jira reference number [INFRA-13]

# How Has This Been Tested?

- [x] Manual run

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

[INFRA-13]: https://armbian.atlassian.net/browse/INFRA-13?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ