### PR TITLE
add fonts-noto-cjk to desktop package list

### DIFF
--- a/config/desktop/bullseye/environments/cinnamon/config_base/packages
+++ b/config/desktop/bullseye/environments/cinnamon/config_base/packages
@@ -28,6 +28,7 @@ evince
 evince-common
 fontconfig
 fontconfig-config
+fonts-noto-cjk
 fonts-ubuntu
 fonts-ubuntu-console
 foomatic-db-compressed-ppds

--- a/config/desktop/bullseye/environments/gnome/config_base/packages
+++ b/config/desktop/bullseye/environments/gnome/config_base/packages
@@ -8,6 +8,7 @@ dmz-cursor-theme
 dconf-cli
 eject
 foomatic-db-compressed-ppds
+fonts-noto-cjk
 fonts-ubuntu
 fonts-ubuntu-console
 gdebi

--- a/config/desktop/buster/environments/cinnamon/config_base/packages
+++ b/config/desktop/buster/environments/cinnamon/config_base/packages
@@ -28,6 +28,7 @@ evince
 evince-common
 fontconfig
 fontconfig-config
+fonts-noto-cjk
 fonts-ubuntu
 fonts-ubuntu-console
 foomatic-db-compressed-ppds

--- a/config/desktop/buster/environments/gnome/config_base/packages
+++ b/config/desktop/buster/environments/gnome/config_base/packages
@@ -8,6 +8,7 @@ dmz-cursor-theme
 dconf-cli
 eject
 foomatic-db-compressed-ppds
+fonts-noto-cjk
 fonts-ubuntu
 fonts-ubuntu-console
 gdebi

--- a/config/desktop/buster/environments/xfce/config_base/packages
+++ b/config/desktop/buster/environments/xfce/config_base/packages
@@ -18,6 +18,7 @@ evince
 evince-common
 fontconfig
 fontconfig-config
+fonts-noto-cjk
 fonts-ubuntu
 fonts-ubuntu-console
 foomatic-db-compressed-ppds

--- a/config/desktop/focal/environments/cinnamon/config_base/packages
+++ b/config/desktop/focal/environments/cinnamon/config_base/packages
@@ -28,6 +28,7 @@ evince
 evince-common
 fontconfig
 fontconfig-config
+fonts-noto-cjk
 fonts-ubuntu
 fonts-ubuntu-console
 foomatic-db-compressed-ppds

--- a/config/desktop/focal/environments/gnome/config_base/packages
+++ b/config/desktop/focal/environments/gnome/config_base/packages
@@ -8,6 +8,7 @@ dmz-cursor-theme
 dconf-cli
 eject
 foomatic-db-compressed-ppds
+fonts-noto-cjk
 fonts-ubuntu
 fonts-ubuntu-console
 gdebi

--- a/config/desktop/focal/environments/xfce/config_base/packages
+++ b/config/desktop/focal/environments/xfce/config_base/packages
@@ -18,6 +18,7 @@ evince
 evince-common
 fontconfig
 fontconfig-config
+fonts-noto-cjk
 fonts-ubuntu
 fonts-ubuntu-console
 foomatic-db-compressed-ppds

--- a/config/desktop/jammy/environments/cinnamon/config_base/packages
+++ b/config/desktop/jammy/environments/cinnamon/config_base/packages
@@ -28,6 +28,7 @@ evince
 evince-common
 fontconfig
 fontconfig-config
+fonts-noto-cjk
 fonts-ubuntu
 fonts-ubuntu-console
 foomatic-db-compressed-ppds

--- a/config/desktop/jammy/environments/gnome/config_base/packages
+++ b/config/desktop/jammy/environments/gnome/config_base/packages
@@ -8,6 +8,7 @@ dmz-cursor-theme
 dconf-cli
 eject
 foomatic-db-compressed-ppds
+fonts-noto-cjk
 fonts-ubuntu
 fonts-ubuntu-console
 gdebi

--- a/config/desktop/jammy/environments/xfce/config_base/packages
+++ b/config/desktop/jammy/environments/xfce/config_base/packages
@@ -18,6 +18,7 @@ evince
 evince-common
 fontconfig
 fontconfig-config
+fonts-noto-cjk
 fonts-ubuntu
 fonts-ubuntu-console
 foomatic-db-compressed-ppds

--- a/config/desktop/kinetic/environments/cinnamon/config_base/packages
+++ b/config/desktop/kinetic/environments/cinnamon/config_base/packages
@@ -28,6 +28,7 @@ evince
 evince-common
 fontconfig
 fontconfig-config
+fonts-noto-cjk
 fonts-ubuntu
 fonts-ubuntu-console
 foomatic-db-compressed-ppds

--- a/config/desktop/kinetic/environments/xfce/config_base/packages
+++ b/config/desktop/kinetic/environments/xfce/config_base/packages
@@ -18,6 +18,7 @@ evince
 evince-common
 fontconfig
 fontconfig-config
+fonts-noto-cjk
 fonts-ubuntu
 fonts-ubuntu-console
 foomatic-db-compressed-ppds

--- a/config/desktop/sid/environments/cinnamon/config_base/packages
+++ b/config/desktop/sid/environments/cinnamon/config_base/packages
@@ -28,6 +28,7 @@ evince
 evince-common
 fontconfig
 fontconfig-config
+fonts-noto-cjk
 fonts-ubuntu
 fonts-ubuntu-console
 foomatic-db-compressed-ppds


### PR DESCRIPTION
# Description

When language Chinese/Janpanese/Korean is set, because of lacking fonts the CJK characters are displayed like tofu. Pakcage `fonts-noto-cjk` comes to solve this just like its name. It is removed in https://github.com/armbian/build/commit/74aa5d9e0a23b949df7ff0c2bcda6666897c20b9, and I add it back.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] jammy gnome rootfs built with packages `fonts-noto-cjk`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
