### PR TITLE
Convert from using uImage to Image for aml-s9xx-box

### DIFF
--- a/packages/bsp/aml-s9xx-box/boot/extlinux/extlinux.conf
+++ b/packages/bsp/aml-s9xx-box/boot/extlinux/extlinux.conf
@@ -1,5 +1,5 @@
 LABEL Armbian
-LINUX /uImage
+LINUX /Image
 INITRD /uInitrd
 
 #FDT /dtb/amlogic/meson-gxbb-p200.dtb


### PR DESCRIPTION
This is needed to bring this board in line with the expectations of the new main build (armbian-next), which dropped uImage from meson64 kernel packages.

 Changes to be committed:
        modified:   packages/bsp/aml-s9xx-box/boot/extlinux/extlinux.conf

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

More information can be found in Issue [#4874](https://github.com/armbian/build/issues/4874)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Build and install aml-s9xx-box

