### PR TITLE
Add support for BPI-CM4 with BPI-CM4IO

### DIFF
--- a/config/boards/bananapicm4io.conf
+++ b/config/boards/bananapicm4io.conf
@@ -1,0 +1,11 @@
+# Amlogic A311D 4GB RAM eMMC GBE USB3
+BOARD_NAME="Banana Pi CM4IO"
+BOARDFAMILY="meson-g12b"
+BOOTCONFIG="bananapi-cm4-cm4io_defconfig"
+KERNEL_TARGET="edge"
+FULL_DESKTOP="yes"
+SERIALCON="ttyAML0"
+BOOT_LOGO="desktop"
+BOOT_FDT_FILE="amlogic/meson-g12b-bananapi-cm4-cm4io.dtb"
+BOOTBRANCH_BOARD="tag:v2023.01"
+BOOTPATCHDIR="v2023.01"

--- a/config/sources/families/meson-g12b.conf
+++ b/config/sources/families/meson-g12b.conf
@@ -45,6 +45,8 @@ else
 			uboot_g12_postprocess "$SRC"/cache/sources/amlogic-boot-fip/radxa-zero2 g12b
 		elif [[ $BOARD == bananapim2s ]]; then
 			uboot_g12_postprocess "$SRC"/cache/sources/amlogic-boot-fip/bananapi-m2s g12b
+		elif [[ $BOARD == bananapicm4io ]]; then
+			uboot_g12_postprocess "$SRC"/cache/sources/amlogic-boot-fip/bananapi-m2s g12b
 		else
 			echo "Don't know how to handle FIP trees for board '${BOARD}'"
 			exit 2

--- a/patch/kernel/archive/meson64-6.2/0001-dt-bindings-arm-amlogic-Document-the-boards-with-the.patch
+++ b/patch/kernel/archive/meson64-6.2/0001-dt-bindings-arm-amlogic-Document-the-boards-with-the.patch
@@ -1,0 +1,42 @@
+From f4794df976bbf6c109f3d4bd7e247bcbfc587db6 Mon Sep 17 00:00:00 2001
+From: Neil Armstrong <neil.armstrong@linaro.org>
+Date: Mon, 6 Mar 2023 09:31:38 +0100
+Subject: [PATCH] dt-bindings: arm: amlogic: Document the boards with the
+ BPI-CM4 connected
+
+The BPI-CM4 module with an Amlogic A311D SoC is a module compatible
+with the Raspberry Pi CM4 specifications.
+
+Document the boards using this module, by specifying the BananaPi CM4
+compatible in addition to the baseboard compatible.
+
+Acked-by: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
+Reviewed-by: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+Link: https://lore.kernel.org/r/20230303-topic-amlogic-upstream-bpi-cm4-v2-1-2ecfde76fc4d@linaro.org
+Signed-off-by: Neil Armstrong <neil.armstrong@linaro.org>
+---
+ Documentation/devicetree/bindings/arm/amlogic.yaml | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/Documentation/devicetree/bindings/arm/amlogic.yaml b/Documentation/devicetree/bindings/arm/amlogic.yaml
+index e16b5fa55847..30b27917a8be 100644
+--- a/Documentation/devicetree/bindings/arm/amlogic.yaml
++++ b/Documentation/devicetree/bindings/arm/amlogic.yaml
+@@ -157,6 +157,14 @@ properties:
+           - const: amlogic,a311d
+           - const: amlogic,g12b
+ 
++      - description: Boards using the BPI-CM4 module with Amlogic Meson G12B A311D SoC
++        items:
++          - enum:
++              - bananapi,bpi-cm4io
++          - const: bananapi,bpi-cm4
++          - const: amlogic,a311d
++          - const: amlogic,g12b
++
+       - description: Boards with the Amlogic Meson G12B S922X SoC
+         items:
+           - enum:
+-- 
+2.34.1
+

--- a/patch/kernel/archive/meson64-6.2/0002-arm64-dts-amlogic-Add-initial-support-for-BPI-CM4-mo.patch
+++ b/patch/kernel/archive/meson64-6.2/0002-arm64-dts-amlogic-Add-initial-support-for-BPI-CM4-mo.patch
@@ -1,0 +1,613 @@
+From 2f449155e401644dd2f28b0ee8e17bd609e4ba0e Mon Sep 17 00:00:00 2001
+From: Neil Armstrong <neil.armstrong@linaro.org>
+Date: Mon, 6 Mar 2023 09:31:39 +0100
+Subject: [PATCH] arm64: dts: amlogic: Add initial support for BPI-CM4 module
+ with BPI-CM4IO baseboard
+
+Add support for both the BananaPi BPI-CM4 module and the BananaPi
+baseboard which is comnpatible with the RaspberryPi CM4IO baseboard.
+
+The BananaPi BPI-CM4 module follows the CM4 specifications at [1],
+but with a single HDMI port and a since DSI output.
+
+The current CM4IO baseboard DT should work fine on the Raspberry CM4
+baseboard and other derivatives baseboards, but proper DT should
+be written for other baseboards.
+
+The split is done so it's easy to describe a new CM4 baseboard, enabling
+only the necessary HW used on the baseboard.
+
+[1] https://datasheets.raspberrypi.com/cm4io/cm4io-datasheet.pdf
+
+Tested-by: Christian Hewitt <christianshewitt@gmail.com>
+Reviewed-by: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+Link: https://lore.kernel.org/r/20230303-topic-amlogic-upstream-bpi-cm4-v2-2-2ecfde76fc4d@linaro.org
+Signed-off-by: Neil Armstrong <neil.armstrong@linaro.org>
+---
+ arch/arm64/boot/dts/amlogic/Makefile          |   1 +
+ .../amlogic/meson-g12b-bananapi-cm4-cm4io.dts | 165 ++++++++
+ .../dts/amlogic/meson-g12b-bananapi-cm4.dtsi  | 388 ++++++++++++++++++
+ 3 files changed, 554 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/amlogic/meson-g12b-bananapi-cm4-cm4io.dts
+ create mode 100644 arch/arm64/boot/dts/amlogic/meson-g12b-bananapi-cm4.dtsi
+
+diff --git a/arch/arm64/boot/dts/amlogic/Makefile b/arch/arm64/boot/dts/amlogic/Makefile
+index 97b42e2100e0..d4b315a05ef9 100644
+--- a/arch/arm64/boot/dts/amlogic/Makefile
++++ b/arch/arm64/boot/dts/amlogic/Makefile
+@@ -9,6 +9,7 @@ dtb-$(CONFIG_ARCH_MESON) += meson-g12a-sei510.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-g12a-u200.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-g12a-x96-max.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-a311d-khadas-vim3.dtb
++dtb-$(CONFIG_ARCH_MESON) += meson-g12b-bananapi-cm4-cm4io.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-gsking-x.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-gtking-pro.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-gtking.dtb
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-bananapi-cm4-cm4io.dts b/arch/arm64/boot/dts/amlogic/meson-g12b-bananapi-cm4-cm4io.dts
+new file mode 100644
+index 000000000000..1b0c3881c6a1
+--- /dev/null
++++ b/arch/arm64/boot/dts/amlogic/meson-g12b-bananapi-cm4-cm4io.dts
+@@ -0,0 +1,165 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2023 Neil Armstrong <neil.armstrong@linaro.org>
++ */
++
++/dts-v1/;
++
++#include "meson-g12b-bananapi-cm4.dtsi"
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/leds/common.h>
++#include <dt-bindings/sound/meson-g12a-tohdmitx.h>
++
++/ {
++	compatible = "bananapi,bpi-cm4io", "bananapi,bpi-cm4", "amlogic,a311d", "amlogic,g12b";
++	model = "BananaPi BPI-CM4IO Baseboard with BPI-CM4 Module";
++
++	aliases {
++		ethernet0 = &ethmac;
++		i2c0 = &i2c1;
++		i2c1 = &i2c3;
++	};
++
++	adc-keys {
++		compatible = "adc-keys";
++		io-channels = <&saradc 2>;
++		io-channel-names = "buttons";
++		keyup-threshold-microvolt = <1710000>;
++
++		button-function {
++			label = "Function";
++			linux,code = <KEY_FN>;
++			press-threshold-microvolt = <10000>;
++		};
++	};
++
++	hdmi_connector: hdmi-connector {
++		compatible = "hdmi-connector";
++		type = "a";
++
++		port {
++			hdmi_connector_in: endpoint {
++				remote-endpoint = <&hdmi_tx_tmds_out>;
++			};
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led-blue {
++			color = <LED_COLOR_ID_BLUE>;
++			function = LED_FUNCTION_STATUS;
++			gpios = <&gpio_ao GPIOAO_7 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "heartbeat";
++		};
++
++		led-green {
++			color = <LED_COLOR_ID_GREEN>;
++			function = LED_FUNCTION_STATUS;
++			gpios = <&gpio_ao GPIOAO_2 GPIO_ACTIVE_HIGH>;
++		};
++	};
++
++	sound {
++		compatible = "amlogic,axg-sound-card";
++		model = "BPI-CM4IO";
++		audio-aux-devs = <&tdmout_b>;
++		audio-routing =	"TDMOUT_B IN 0", "FRDDR_A OUT 1",
++				"TDMOUT_B IN 1", "FRDDR_B OUT 1",
++				"TDMOUT_B IN 2", "FRDDR_C OUT 1",
++				"TDM_B Playback", "TDMOUT_B OUT";
++
++		assigned-clocks = <&clkc CLKID_MPLL2>,
++				  <&clkc CLKID_MPLL0>,
++				  <&clkc CLKID_MPLL1>;
++		assigned-clock-parents = <0>, <0>, <0>;
++		assigned-clock-rates = <294912000>,
++				       <270950400>,
++				       <393216000>;
++
++		dai-link-0 {
++			sound-dai = <&frddr_a>;
++		};
++
++		dai-link-1 {
++			sound-dai = <&frddr_b>;
++		};
++
++		dai-link-2 {
++			sound-dai = <&frddr_c>;
++		};
++
++		/* 8ch hdmi interface */
++		dai-link-3 {
++			sound-dai = <&tdmif_b>;
++			dai-format = "i2s";
++			dai-tdm-slot-tx-mask-0 = <1 1>;
++			dai-tdm-slot-tx-mask-1 = <1 1>;
++			dai-tdm-slot-tx-mask-2 = <1 1>;
++			dai-tdm-slot-tx-mask-3 = <1 1>;
++			mclk-fs = <256>;
++
++			codec {
++				sound-dai = <&tohdmitx TOHDMITX_I2S_IN_B>;
++			};
++		};
++
++		/* hdmi glue */
++		dai-link-4 {
++			sound-dai = <&tohdmitx TOHDMITX_I2S_OUT>;
++
++			codec {
++				sound-dai = <&hdmi_tx>;
++			};
++		};
++	};
++};
++
++&cecb_AO {
++	status = "okay";
++};
++
++&ethmac {
++	status = "okay";
++};
++
++&hdmi_tx {
++	status = "okay";
++};
++
++&hdmi_tx_tmds_port {
++	hdmi_tx_tmds_out: endpoint {
++		remote-endpoint = <&hdmi_connector_in>;
++	};
++};
++
++/* CSI port */
++&i2c1 {
++	status = "okay";
++};
++
++/* DSI port for touchscreen */
++&i2c3 {
++	status = "okay";
++};
++
++/* miniPCIe port with USB + SIM slot */
++&pcie {
++	status = "okay";
++};
++
++&sd_emmc_b {
++	status = "okay";
++};
++
++&tohdmitx {
++	status = "okay";
++};
++
++/* Peripheral Only USB-C port */
++&usb {
++	dr_mode = "peripheral";
++
++	status = "okay";
++};
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-bananapi-cm4.dtsi b/arch/arm64/boot/dts/amlogic/meson-g12b-bananapi-cm4.dtsi
+new file mode 100644
+index 000000000000..97e522921b06
+--- /dev/null
++++ b/arch/arm64/boot/dts/amlogic/meson-g12b-bananapi-cm4.dtsi
+@@ -0,0 +1,388 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2023 Neil Armstrong <neil.armstrong@linaro.org>
++ */
++
++#include "meson-g12b-a311d.dtsi"
++#include <dt-bindings/gpio/meson-g12a-gpio.h>
++
++/ {
++	aliases {
++		serial0 = &uart_AO;
++		rtc1 = &vrtc;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	emmc_pwrseq: emmc-pwrseq {
++		compatible = "mmc-pwrseq-emmc";
++		reset-gpios = <&gpio BOOT_12 GPIO_ACTIVE_LOW>;
++	};
++
++	memory@0 {
++		device_type = "memory";
++		reg = <0x0 0x0 0x0 0x40000000>;
++	};
++
++	sdio_pwrseq: sdio-pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		reset-gpios = <&gpio GPIOAO_6 GPIO_ACTIVE_LOW>;
++		clocks = <&wifi32k>;
++		clock-names = "ext_clock";
++	};
++
++	emmc_1v8: regulator-emmc-1v8 {
++		compatible = "regulator-fixed";
++		regulator-name = "EMMC_1V8";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vddao_3v3>;
++		regulator-always-on;
++	};
++
++	dc_in: regulator-dc-in {
++		compatible = "regulator-fixed";
++		regulator-name = "DC_IN";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		regulator-always-on;
++	};
++
++	vddio_c: regulator-vddio-c {
++		compatible = "regulator-gpio";
++		regulator-name = "VDDIO_C";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <3300000>;
++
++		enable-gpio = <&gpio_ao GPIOAO_3 GPIO_OPEN_DRAIN>;
++		enable-active-high;
++		regulator-always-on;
++
++		gpios = <&gpio_ao GPIOAO_9 GPIO_OPEN_DRAIN>;
++		gpios-states = <1>;
++
++		states = <1800000 0>,
++			 <3300000 1>;
++	};
++
++	vddao_1v8: regulator-vddao-1v8 {
++		compatible = "regulator-fixed";
++		regulator-name = "VDDAO_1V8";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vddao_3v3>;
++		regulator-always-on;
++	};
++
++	vddao_3v3: regulator-vddao-3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "VDDAO_3V3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&dc_in>;
++		regulator-always-on;
++	};
++
++	vddcpu_a: regulator-vddcpu-a {
++		/*
++		 * MP8756GD DC/DC Regulator.
++		 */
++		compatible = "pwm-regulator";
++
++		regulator-name = "VDDCPU_A";
++		regulator-min-microvolt = <680000>;
++		regulator-max-microvolt = <1040000>;
++
++		pwm-supply = <&dc_in>;
++
++		pwms = <&pwm_ab 0 1250 0>;
++		pwm-dutycycle-range = <100 0>;
++
++		regulator-boot-on;
++		regulator-always-on;
++	};
++
++	vddcpu_b: regulator-vddcpu-b {
++		/*
++		 * SY8120B1ABC DC/DC Regulator.
++		 */
++		compatible = "pwm-regulator";
++
++		regulator-name = "VDDCPU_B";
++		regulator-min-microvolt = <680000>;
++		regulator-max-microvolt = <1040000>;
++
++		pwm-supply = <&dc_in>;
++
++		pwms = <&pwm_AO_cd 1 1250 0>;
++		pwm-dutycycle-range = <100 0>;
++
++		regulator-boot-on;
++		regulator-always-on;
++	};
++
++	wifi32k: wifi32k {
++		compatible = "pwm-clock";
++		#clock-cells = <0>;
++		clock-frequency = <32768>;
++		pwms = <&pwm_ef 0 30518 0>; /* PWM_E at 32.768KHz */
++	};
++};
++
++&arb {
++	status = "okay";
++};
++
++&clkc_audio {
++	status = "okay";
++};
++
++&cec_AO {
++	pinctrl-0 = <&cec_ao_a_h_pins>;
++	pinctrl-names = "default";
++	hdmi-phandle = <&hdmi_tx>;
++};
++
++&cecb_AO {
++	pinctrl-0 = <&cec_ao_b_h_pins>;
++	pinctrl-names = "default";
++	hdmi-phandle = <&hdmi_tx>;
++};
++
++&cpu0 {
++	cpu-supply = <&vddcpu_b>;
++	operating-points-v2 = <&cpu_opp_table_0>;
++	clocks = <&clkc CLKID_CPU_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu1 {
++	cpu-supply = <&vddcpu_b>;
++	operating-points-v2 = <&cpu_opp_table_0>;
++	clocks = <&clkc CLKID_CPU_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu100 {
++	cpu-supply = <&vddcpu_a>;
++	operating-points-v2 = <&cpub_opp_table_1>;
++	clocks = <&clkc CLKID_CPUB_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu101 {
++	cpu-supply = <&vddcpu_a>;
++	operating-points-v2 = <&cpub_opp_table_1>;
++	clocks = <&clkc CLKID_CPUB_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu102 {
++	cpu-supply = <&vddcpu_a>;
++	operating-points-v2 = <&cpub_opp_table_1>;
++	clocks = <&clkc CLKID_CPUB_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu103 {
++	cpu-supply = <&vddcpu_a>;
++	operating-points-v2 = <&cpub_opp_table_1>;
++	clocks = <&clkc CLKID_CPUB_CLK>;
++	clock-latency = <50000>;
++};
++
++&ext_mdio {
++	external_phy: ethernet-phy@0 {
++		/* Realtek RTL8211F (0x001cc916) */
++		reg = <0>;
++		max-speed = <1000>;
++
++		interrupt-parent = <&gpio_intc>;
++		/* MAC_INTR on GPIOZ_14 */
++		interrupts = <26 IRQ_TYPE_LEVEL_LOW>;
++	};
++};
++
++/* Ethernet to be enabled in baseboard DT */
++&ethmac {
++	pinctrl-0 = <&eth_pins>, <&eth_rgmii_pins>;
++	pinctrl-names = "default";
++	phy-mode = "rgmii-txid";
++	phy-handle = <&external_phy>;
++};
++
++&frddr_a {
++	status = "okay";
++};
++
++&frddr_b {
++	status = "okay";
++};
++
++&frddr_c {
++	status = "okay";
++};
++
++/* HDMI to be enabled in baseboard DT */
++&hdmi_tx {
++	pinctrl-0 = <&hdmitx_hpd_pins>, <&hdmitx_ddc_pins>;
++	pinctrl-names = "default";
++	hdmi-supply = <&dc_in>;
++};
++
++/* "Camera" I2C bus */
++&i2c1 {
++	pinctrl-0 = <&i2c1_sda_h6_pins>, <&i2c1_sck_h7_pins>;
++	pinctrl-names = "default";
++};
++
++/* Main I2C bus */
++&i2c2 {
++	pinctrl-0 = <&i2c2_sda_x_pins>, <&i2c2_sck_x_pins>;
++	pinctrl-names = "default";
++};
++
++/* "ID" I2C bus */
++&i2c3 {
++	pinctrl-0 = <&i2c3_sda_a_pins>, <&i2c3_sck_a_pins>;
++	pinctrl-names = "default";
++};
++
++&pcie {
++	reset-gpios = <&gpio GPIOA_8 GPIO_ACTIVE_LOW>;
++};
++
++&pwm_ab {
++	pinctrl-0 = <&pwm_a_e_pins>;
++	pinctrl-names = "default";
++	clocks = <&xtal>;
++	clock-names = "clkin0";
++
++	status = "okay";
++};
++
++&pwm_ef {
++	pinctrl-0 = <&pwm_e_pins>;
++	pinctrl-names = "default";
++
++	status = "okay";
++};
++
++&pwm_AO_cd {
++	pinctrl-0 = <&pwm_ao_d_e_pins>;
++	pinctrl-names = "default";
++	clocks = <&xtal>;
++	clock-names = "clkin1";
++
++	status = "okay";
++};
++
++&saradc {
++	vref-supply = <&vddao_1v8>;
++
++	status = "okay";
++};
++
++/* on-module SDIO WiFi */
++&sd_emmc_a {
++	pinctrl-0 = <&sdio_pins>;
++	pinctrl-1 = <&sdio_clk_gate_pins>;
++	pinctrl-names = "default", "clk-gate";
++	#address-cells = <1>;
++	#size-cells = <0>;
++
++	bus-width = <4>;
++	sd-uhs-sdr104;
++	max-frequency = <50000000>;
++
++	non-removable;
++	disable-wp;
++
++	/* WiFi firmware requires power in suspend */
++	keep-power-in-suspend;
++
++	mmc-pwrseq = <&sdio_pwrseq>;
++
++	vmmc-supply = <&vddao_3v3>;
++	vqmmc-supply = <&vddao_3v3>;
++
++	status = "okay";
++
++	rtl8822cs: wifi@1 {
++		reg = <1>;
++	};
++};
++
++/* SD card to be enabled in baseboard DT */
++&sd_emmc_b {
++	pinctrl-0 = <&sdcard_c_pins>;
++	pinctrl-1 = <&sdcard_clk_gate_c_pins>;
++	pinctrl-names = "default", "clk-gate";
++
++	bus-width = <4>;
++	cap-sd-highspeed;
++	max-frequency = <50000000>;
++	disable-wp;
++
++	cd-gpios = <&gpio GPIOC_6 GPIO_ACTIVE_LOW>;
++	vmmc-supply = <&vddao_3v3>;
++	vqmmc-supply = <&vddio_c>;
++};
++
++/* on-module eMMC */
++&sd_emmc_c {
++	pinctrl-0 = <&emmc_ctrl_pins>, <&emmc_data_8b_pins>, <&emmc_ds_pins>;
++	pinctrl-1 = <&emmc_clk_gate_pins>;
++	pinctrl-names = "default", "clk-gate";
++
++	bus-width = <8>;
++	cap-mmc-highspeed;
++	mmc-ddr-1_8v;
++	mmc-hs200-1_8v;
++	max-frequency = <200000000>;
++	disable-wp;
++
++	mmc-pwrseq = <&emmc_pwrseq>;
++	vmmc-supply = <&vddao_3v3>;
++	vqmmc-supply = <&vddao_1v8>;
++
++	status = "okay";
++};
++
++&tdmif_b {
++	status = "okay";
++};
++
++&tdmout_b {
++	status = "okay";
++};
++
++/* on-module UART BT */
++&uart_A {
++	pinctrl-0 = <&uart_a_pins>, <&uart_a_cts_rts_pins>;
++	pinctrl-names = "default";
++	uart-has-rtscts;
++
++	status = "okay";
++
++	bluetooth {
++		compatible = "realtek,rtl8822cs-bt";
++		enable-gpios  = <&gpio GPIOX_17 GPIO_ACTIVE_HIGH>;
++		host-wake-gpios = <&gpio GPIOX_19 GPIO_ACTIVE_HIGH>;
++		device-wake-gpios = <&gpio GPIOX_18 GPIO_ACTIVE_HIGH>;
++	};
++};
++
++&uart_AO {
++	pinctrl-0 = <&uart_ao_a_pins>;
++	pinctrl-names = "default";
++
++	status = "okay";
++};
++
++&usb {
++	phys = <&usb2_phy0>, <&usb2_phy1>;
++	phy-names = "usb2-phy0", "usb2-phy1";
++};
+-- 
+2.34.1
+

--- a/patch/u-boot/v2023.01/board_bananapicm4io/0001-ARM-dts-import-initial-DT-for-BPI-CM4-module-with-BP.patch
+++ b/patch/u-boot/v2023.01/board_bananapicm4io/0001-ARM-dts-import-initial-DT-for-BPI-CM4-module-with-BP.patch
@@ -1,0 +1,608 @@
+From 9855552df53cdf5f8fd06fb23cf2d8149c123906 Mon Sep 17 00:00:00 2001
+From: Neil Armstrong <neil.armstrong@linaro.org>
+Date: Tue, 7 Mar 2023 09:12:30 +0100
+Subject: [PATCH] ARM: dts: import initial DT for BPI-CM4 module with BPI-CM4IO
+ baseboard
+
+Import initial support for BPI-CM4 module with BPI-CM4IO baseboard
+from the Linux submission applied at [1].
+
+The BananaPi BPI-CM4 module follows the CM4 specifications at [2],
+but with a single HDMI port and a single DSI output.
+
+The current CM4IO baseboard DT should work fine on the Raspberry CM4
+baseboard and other derivatives baseboards, but proper DT should
+be written for other baseboards.
+
+[1] https://git.kernel.org/amlogic/c/0262f2736978b1763363224698f47112a148dab0
+[2] https://datasheets.raspberrypi.com/cm4io/cm4io-datasheet.pdf
+
+Signed-off-by: Neil Armstrong <neil.armstrong@linaro.org>
+---
+ arch/arm/dts/Makefile                         |   1 +
+ .../arm/dts/meson-g12b-bananapi-cm4-cm4io.dts | 165 ++++++++
+ arch/arm/dts/meson-g12b-bananapi-cm4.dtsi     | 388 ++++++++++++++++++
+ 3 files changed, 554 insertions(+)
+ create mode 100644 arch/arm/dts/meson-g12b-bananapi-cm4-cm4io.dts
+ create mode 100644 arch/arm/dts/meson-g12b-bananapi-cm4.dtsi
+
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index 43951a7731..0937a6639b 100644
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -200,6 +200,7 @@ dtb-$(CONFIG_ARCH_MESON) += \
+ 	meson-g12b-gsking-x.dtb \
+ 	meson-g12b-odroid-n2.dtb \
+ 	meson-g12b-odroid-n2-plus.dtb \
++	meson-g12b-bananapi-cm4-cm4io.dtb \
+ 	meson-sm1-bananapi-m5.dtb \
+ 	meson-sm1-khadas-vim3l.dtb \
+ 	meson-sm1-odroid-c4.dtb \
+diff --git a/arch/arm/dts/meson-g12b-bananapi-cm4-cm4io.dts b/arch/arm/dts/meson-g12b-bananapi-cm4-cm4io.dts
+new file mode 100644
+index 0000000000..1b0c3881c6
+--- /dev/null
++++ b/arch/arm/dts/meson-g12b-bananapi-cm4-cm4io.dts
+@@ -0,0 +1,165 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2023 Neil Armstrong <neil.armstrong@linaro.org>
++ */
++
++/dts-v1/;
++
++#include "meson-g12b-bananapi-cm4.dtsi"
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/leds/common.h>
++#include <dt-bindings/sound/meson-g12a-tohdmitx.h>
++
++/ {
++	compatible = "bananapi,bpi-cm4io", "bananapi,bpi-cm4", "amlogic,a311d", "amlogic,g12b";
++	model = "BananaPi BPI-CM4IO Baseboard with BPI-CM4 Module";
++
++	aliases {
++		ethernet0 = &ethmac;
++		i2c0 = &i2c1;
++		i2c1 = &i2c3;
++	};
++
++	adc-keys {
++		compatible = "adc-keys";
++		io-channels = <&saradc 2>;
++		io-channel-names = "buttons";
++		keyup-threshold-microvolt = <1710000>;
++
++		button-function {
++			label = "Function";
++			linux,code = <KEY_FN>;
++			press-threshold-microvolt = <10000>;
++		};
++	};
++
++	hdmi_connector: hdmi-connector {
++		compatible = "hdmi-connector";
++		type = "a";
++
++		port {
++			hdmi_connector_in: endpoint {
++				remote-endpoint = <&hdmi_tx_tmds_out>;
++			};
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led-blue {
++			color = <LED_COLOR_ID_BLUE>;
++			function = LED_FUNCTION_STATUS;
++			gpios = <&gpio_ao GPIOAO_7 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "heartbeat";
++		};
++
++		led-green {
++			color = <LED_COLOR_ID_GREEN>;
++			function = LED_FUNCTION_STATUS;
++			gpios = <&gpio_ao GPIOAO_2 GPIO_ACTIVE_HIGH>;
++		};
++	};
++
++	sound {
++		compatible = "amlogic,axg-sound-card";
++		model = "BPI-CM4IO";
++		audio-aux-devs = <&tdmout_b>;
++		audio-routing =	"TDMOUT_B IN 0", "FRDDR_A OUT 1",
++				"TDMOUT_B IN 1", "FRDDR_B OUT 1",
++				"TDMOUT_B IN 2", "FRDDR_C OUT 1",
++				"TDM_B Playback", "TDMOUT_B OUT";
++
++		assigned-clocks = <&clkc CLKID_MPLL2>,
++				  <&clkc CLKID_MPLL0>,
++				  <&clkc CLKID_MPLL1>;
++		assigned-clock-parents = <0>, <0>, <0>;
++		assigned-clock-rates = <294912000>,
++				       <270950400>,
++				       <393216000>;
++
++		dai-link-0 {
++			sound-dai = <&frddr_a>;
++		};
++
++		dai-link-1 {
++			sound-dai = <&frddr_b>;
++		};
++
++		dai-link-2 {
++			sound-dai = <&frddr_c>;
++		};
++
++		/* 8ch hdmi interface */
++		dai-link-3 {
++			sound-dai = <&tdmif_b>;
++			dai-format = "i2s";
++			dai-tdm-slot-tx-mask-0 = <1 1>;
++			dai-tdm-slot-tx-mask-1 = <1 1>;
++			dai-tdm-slot-tx-mask-2 = <1 1>;
++			dai-tdm-slot-tx-mask-3 = <1 1>;
++			mclk-fs = <256>;
++
++			codec {
++				sound-dai = <&tohdmitx TOHDMITX_I2S_IN_B>;
++			};
++		};
++
++		/* hdmi glue */
++		dai-link-4 {
++			sound-dai = <&tohdmitx TOHDMITX_I2S_OUT>;
++
++			codec {
++				sound-dai = <&hdmi_tx>;
++			};
++		};
++	};
++};
++
++&cecb_AO {
++	status = "okay";
++};
++
++&ethmac {
++	status = "okay";
++};
++
++&hdmi_tx {
++	status = "okay";
++};
++
++&hdmi_tx_tmds_port {
++	hdmi_tx_tmds_out: endpoint {
++		remote-endpoint = <&hdmi_connector_in>;
++	};
++};
++
++/* CSI port */
++&i2c1 {
++	status = "okay";
++};
++
++/* DSI port for touchscreen */
++&i2c3 {
++	status = "okay";
++};
++
++/* miniPCIe port with USB + SIM slot */
++&pcie {
++	status = "okay";
++};
++
++&sd_emmc_b {
++	status = "okay";
++};
++
++&tohdmitx {
++	status = "okay";
++};
++
++/* Peripheral Only USB-C port */
++&usb {
++	dr_mode = "peripheral";
++
++	status = "okay";
++};
+diff --git a/arch/arm/dts/meson-g12b-bananapi-cm4.dtsi b/arch/arm/dts/meson-g12b-bananapi-cm4.dtsi
+new file mode 100644
+index 0000000000..97e522921b
+--- /dev/null
++++ b/arch/arm/dts/meson-g12b-bananapi-cm4.dtsi
+@@ -0,0 +1,388 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2023 Neil Armstrong <neil.armstrong@linaro.org>
++ */
++
++#include "meson-g12b-a311d.dtsi"
++#include <dt-bindings/gpio/meson-g12a-gpio.h>
++
++/ {
++	aliases {
++		serial0 = &uart_AO;
++		rtc1 = &vrtc;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	emmc_pwrseq: emmc-pwrseq {
++		compatible = "mmc-pwrseq-emmc";
++		reset-gpios = <&gpio BOOT_12 GPIO_ACTIVE_LOW>;
++	};
++
++	memory@0 {
++		device_type = "memory";
++		reg = <0x0 0x0 0x0 0x40000000>;
++	};
++
++	sdio_pwrseq: sdio-pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		reset-gpios = <&gpio GPIOAO_6 GPIO_ACTIVE_LOW>;
++		clocks = <&wifi32k>;
++		clock-names = "ext_clock";
++	};
++
++	emmc_1v8: regulator-emmc-1v8 {
++		compatible = "regulator-fixed";
++		regulator-name = "EMMC_1V8";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vddao_3v3>;
++		regulator-always-on;
++	};
++
++	dc_in: regulator-dc-in {
++		compatible = "regulator-fixed";
++		regulator-name = "DC_IN";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		regulator-always-on;
++	};
++
++	vddio_c: regulator-vddio-c {
++		compatible = "regulator-gpio";
++		regulator-name = "VDDIO_C";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <3300000>;
++
++		enable-gpio = <&gpio_ao GPIOAO_3 GPIO_OPEN_DRAIN>;
++		enable-active-high;
++		regulator-always-on;
++
++		gpios = <&gpio_ao GPIOAO_9 GPIO_OPEN_DRAIN>;
++		gpios-states = <1>;
++
++		states = <1800000 0>,
++			 <3300000 1>;
++	};
++
++	vddao_1v8: regulator-vddao-1v8 {
++		compatible = "regulator-fixed";
++		regulator-name = "VDDAO_1V8";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vddao_3v3>;
++		regulator-always-on;
++	};
++
++	vddao_3v3: regulator-vddao-3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "VDDAO_3V3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&dc_in>;
++		regulator-always-on;
++	};
++
++	vddcpu_a: regulator-vddcpu-a {
++		/*
++		 * MP8756GD DC/DC Regulator.
++		 */
++		compatible = "pwm-regulator";
++
++		regulator-name = "VDDCPU_A";
++		regulator-min-microvolt = <680000>;
++		regulator-max-microvolt = <1040000>;
++
++		pwm-supply = <&dc_in>;
++
++		pwms = <&pwm_ab 0 1250 0>;
++		pwm-dutycycle-range = <100 0>;
++
++		regulator-boot-on;
++		regulator-always-on;
++	};
++
++	vddcpu_b: regulator-vddcpu-b {
++		/*
++		 * SY8120B1ABC DC/DC Regulator.
++		 */
++		compatible = "pwm-regulator";
++
++		regulator-name = "VDDCPU_B";
++		regulator-min-microvolt = <680000>;
++		regulator-max-microvolt = <1040000>;
++
++		pwm-supply = <&dc_in>;
++
++		pwms = <&pwm_AO_cd 1 1250 0>;
++		pwm-dutycycle-range = <100 0>;
++
++		regulator-boot-on;
++		regulator-always-on;
++	};
++
++	wifi32k: wifi32k {
++		compatible = "pwm-clock";
++		#clock-cells = <0>;
++		clock-frequency = <32768>;
++		pwms = <&pwm_ef 0 30518 0>; /* PWM_E at 32.768KHz */
++	};
++};
++
++&arb {
++	status = "okay";
++};
++
++&clkc_audio {
++	status = "okay";
++};
++
++&cec_AO {
++	pinctrl-0 = <&cec_ao_a_h_pins>;
++	pinctrl-names = "default";
++	hdmi-phandle = <&hdmi_tx>;
++};
++
++&cecb_AO {
++	pinctrl-0 = <&cec_ao_b_h_pins>;
++	pinctrl-names = "default";
++	hdmi-phandle = <&hdmi_tx>;
++};
++
++&cpu0 {
++	cpu-supply = <&vddcpu_b>;
++	operating-points-v2 = <&cpu_opp_table_0>;
++	clocks = <&clkc CLKID_CPU_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu1 {
++	cpu-supply = <&vddcpu_b>;
++	operating-points-v2 = <&cpu_opp_table_0>;
++	clocks = <&clkc CLKID_CPU_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu100 {
++	cpu-supply = <&vddcpu_a>;
++	operating-points-v2 = <&cpub_opp_table_1>;
++	clocks = <&clkc CLKID_CPUB_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu101 {
++	cpu-supply = <&vddcpu_a>;
++	operating-points-v2 = <&cpub_opp_table_1>;
++	clocks = <&clkc CLKID_CPUB_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu102 {
++	cpu-supply = <&vddcpu_a>;
++	operating-points-v2 = <&cpub_opp_table_1>;
++	clocks = <&clkc CLKID_CPUB_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu103 {
++	cpu-supply = <&vddcpu_a>;
++	operating-points-v2 = <&cpub_opp_table_1>;
++	clocks = <&clkc CLKID_CPUB_CLK>;
++	clock-latency = <50000>;
++};
++
++&ext_mdio {
++	external_phy: ethernet-phy@0 {
++		/* Realtek RTL8211F (0x001cc916) */
++		reg = <0>;
++		max-speed = <1000>;
++
++		interrupt-parent = <&gpio_intc>;
++		/* MAC_INTR on GPIOZ_14 */
++		interrupts = <26 IRQ_TYPE_LEVEL_LOW>;
++	};
++};
++
++/* Ethernet to be enabled in baseboard DT */
++&ethmac {
++	pinctrl-0 = <&eth_pins>, <&eth_rgmii_pins>;
++	pinctrl-names = "default";
++	phy-mode = "rgmii-txid";
++	phy-handle = <&external_phy>;
++};
++
++&frddr_a {
++	status = "okay";
++};
++
++&frddr_b {
++	status = "okay";
++};
++
++&frddr_c {
++	status = "okay";
++};
++
++/* HDMI to be enabled in baseboard DT */
++&hdmi_tx {
++	pinctrl-0 = <&hdmitx_hpd_pins>, <&hdmitx_ddc_pins>;
++	pinctrl-names = "default";
++	hdmi-supply = <&dc_in>;
++};
++
++/* "Camera" I2C bus */
++&i2c1 {
++	pinctrl-0 = <&i2c1_sda_h6_pins>, <&i2c1_sck_h7_pins>;
++	pinctrl-names = "default";
++};
++
++/* Main I2C bus */
++&i2c2 {
++	pinctrl-0 = <&i2c2_sda_x_pins>, <&i2c2_sck_x_pins>;
++	pinctrl-names = "default";
++};
++
++/* "ID" I2C bus */
++&i2c3 {
++	pinctrl-0 = <&i2c3_sda_a_pins>, <&i2c3_sck_a_pins>;
++	pinctrl-names = "default";
++};
++
++&pcie {
++	reset-gpios = <&gpio GPIOA_8 GPIO_ACTIVE_LOW>;
++};
++
++&pwm_ab {
++	pinctrl-0 = <&pwm_a_e_pins>;
++	pinctrl-names = "default";
++	clocks = <&xtal>;
++	clock-names = "clkin0";
++
++	status = "okay";
++};
++
++&pwm_ef {
++	pinctrl-0 = <&pwm_e_pins>;
++	pinctrl-names = "default";
++
++	status = "okay";
++};
++
++&pwm_AO_cd {
++	pinctrl-0 = <&pwm_ao_d_e_pins>;
++	pinctrl-names = "default";
++	clocks = <&xtal>;
++	clock-names = "clkin1";
++
++	status = "okay";
++};
++
++&saradc {
++	vref-supply = <&vddao_1v8>;
++
++	status = "okay";
++};
++
++/* on-module SDIO WiFi */
++&sd_emmc_a {
++	pinctrl-0 = <&sdio_pins>;
++	pinctrl-1 = <&sdio_clk_gate_pins>;
++	pinctrl-names = "default", "clk-gate";
++	#address-cells = <1>;
++	#size-cells = <0>;
++
++	bus-width = <4>;
++	sd-uhs-sdr104;
++	max-frequency = <50000000>;
++
++	non-removable;
++	disable-wp;
++
++	/* WiFi firmware requires power in suspend */
++	keep-power-in-suspend;
++
++	mmc-pwrseq = <&sdio_pwrseq>;
++
++	vmmc-supply = <&vddao_3v3>;
++	vqmmc-supply = <&vddao_3v3>;
++
++	status = "okay";
++
++	rtl8822cs: wifi@1 {
++		reg = <1>;
++	};
++};
++
++/* SD card to be enabled in baseboard DT */
++&sd_emmc_b {
++	pinctrl-0 = <&sdcard_c_pins>;
++	pinctrl-1 = <&sdcard_clk_gate_c_pins>;
++	pinctrl-names = "default", "clk-gate";
++
++	bus-width = <4>;
++	cap-sd-highspeed;
++	max-frequency = <50000000>;
++	disable-wp;
++
++	cd-gpios = <&gpio GPIOC_6 GPIO_ACTIVE_LOW>;
++	vmmc-supply = <&vddao_3v3>;
++	vqmmc-supply = <&vddio_c>;
++};
++
++/* on-module eMMC */
++&sd_emmc_c {
++	pinctrl-0 = <&emmc_ctrl_pins>, <&emmc_data_8b_pins>, <&emmc_ds_pins>;
++	pinctrl-1 = <&emmc_clk_gate_pins>;
++	pinctrl-names = "default", "clk-gate";
++
++	bus-width = <8>;
++	cap-mmc-highspeed;
++	mmc-ddr-1_8v;
++	mmc-hs200-1_8v;
++	max-frequency = <200000000>;
++	disable-wp;
++
++	mmc-pwrseq = <&emmc_pwrseq>;
++	vmmc-supply = <&vddao_3v3>;
++	vqmmc-supply = <&vddao_1v8>;
++
++	status = "okay";
++};
++
++&tdmif_b {
++	status = "okay";
++};
++
++&tdmout_b {
++	status = "okay";
++};
++
++/* on-module UART BT */
++&uart_A {
++	pinctrl-0 = <&uart_a_pins>, <&uart_a_cts_rts_pins>;
++	pinctrl-names = "default";
++	uart-has-rtscts;
++
++	status = "okay";
++
++	bluetooth {
++		compatible = "realtek,rtl8822cs-bt";
++		enable-gpios  = <&gpio GPIOX_17 GPIO_ACTIVE_HIGH>;
++		host-wake-gpios = <&gpio GPIOX_19 GPIO_ACTIVE_HIGH>;
++		device-wake-gpios = <&gpio GPIOX_18 GPIO_ACTIVE_HIGH>;
++	};
++};
++
++&uart_AO {
++	pinctrl-0 = <&uart_ao_a_pins>;
++	pinctrl-names = "default";
++
++	status = "okay";
++};
++
++&usb {
++	phys = <&usb2_phy0>, <&usb2_phy1>;
++	phy-names = "usb2-phy0", "usb2-phy1";
++};
+-- 
+2.34.1
+

--- a/patch/u-boot/v2023.01/board_bananapicm4io/0002-ARM-meson-Add-initial-support-for-BPI-CM4-module-wit.patch
+++ b/patch/u-boot/v2023.01/board_bananapicm4io/0002-ARM-meson-Add-initial-support-for-BPI-CM4-module-wit.patch
@@ -1,0 +1,158 @@
+From dab3581672a85b00a2377f86fefebd0a5bf98d3a Mon Sep 17 00:00:00 2001
+From: Neil Armstrong <neil.armstrong@linaro.org>
+Date: Tue, 7 Mar 2023 09:15:45 +0100
+Subject: [PATCH] ARM: meson: Add initial support for BPI-CM4 module with
+ BPI-CM4IO baseboard
+
+Add support for both the BananaPi BPI-CM4 module and the BananaPi
+baseboard which is compatible with the RaspberryPi CM4IO baseboard.
+
+The BananaPi BPI-CM4 module follows the CM4 specifications at [1],
+but with a single HDMI port and a single DSI output.
+
+The current CM4IO baseboard DT should work fine on the Raspberry CM4
+baseboard and other derivatives baseboards, but proper DT should
+be written for other baseboards.
+
+[1] https://datasheets.raspberrypi.com/cm4io/cm4io-datasheet.pdf
+
+Signed-off-by: Neil Armstrong <neil.armstrong@linaro.org>
+---
+ .../meson-g12b-bananapi-cm4-cm4io-u-boot.dtsi |  6 ++
+ board/amlogic/u200/MAINTAINERS                |  1 +
+ configs/bananapi-cm4-cm4io_defconfig          | 85 +++++++++++++++++++
+ doc/board/amlogic/index.rst                   |  1 +
+ 4 files changed, 93 insertions(+)
+ create mode 100644 arch/arm/dts/meson-g12b-bananapi-cm4-cm4io-u-boot.dtsi
+ create mode 100644 configs/bananapi-cm4-cm4io_defconfig
+
+diff --git a/arch/arm/dts/meson-g12b-bananapi-cm4-cm4io-u-boot.dtsi b/arch/arm/dts/meson-g12b-bananapi-cm4-cm4io-u-boot.dtsi
+new file mode 100644
+index 0000000000..a60ba27806
+--- /dev/null
++++ b/arch/arm/dts/meson-g12b-bananapi-cm4-cm4io-u-boot.dtsi
+@@ -0,0 +1,6 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2023 Neil Armstrong <neil.armstrong@linaro.org>
++ */
++
++#include "meson-g12-common-u-boot.dtsi"
+diff --git a/board/amlogic/u200/MAINTAINERS b/board/amlogic/u200/MAINTAINERS
+index 47cec234a1..7535e489d1 100644
+--- a/board/amlogic/u200/MAINTAINERS
++++ b/board/amlogic/u200/MAINTAINERS
+@@ -4,6 +4,7 @@ S:	Maintained
+ L:	u-boot-amlogic@groups.io
+ F:	board/amlogic/u200/
+ F:	configs/u200_defconfig
++F:	configs/bananapi-cm4-cm4io_defconfig
+ F:	configs/bananapi-m5_defconfig
+ F:	configs/radxa-zero_defconfig
+ F:	doc/board/amlogic/u200.rst
+diff --git a/configs/bananapi-cm4-cm4io_defconfig b/configs/bananapi-cm4-cm4io_defconfig
+new file mode 100644
+index 0000000000..2eb20a8891
+--- /dev/null
++++ b/configs/bananapi-cm4-cm4io_defconfig
+@@ -0,0 +1,85 @@
++CONFIG_ARM=y
++CONFIG_ARCH_MESON=y
++CONFIG_TEXT_BASE=0x01000000
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_ENV_SIZE=0x2000
++CONFIG_DM_GPIO=y
++CONFIG_DEFAULT_DEVICE_TREE="meson-g12b-bananapi-cm4-cm4io"
++CONFIG_MESON_G12A=y
++CONFIG_DEBUG_UART_BASE=0xff803000
++CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_IDENT_STRING="bpi-cm4io"
++CONFIG_SYS_LOAD_ADDR=0x1000000
++CONFIG_DEBUG_UART=y
++CONFIG_HAS_CUSTOM_SYS_INIT_SP_ADDR=y
++CONFIG_CUSTOM_SYS_INIT_SP_ADDR=0x20000000
++CONFIG_REMAKE_ELF=y
++CONFIG_OF_BOARD_SETUP=y
++# CONFIG_DISPLAY_CPUINFO is not set
++CONFIG_MISC_INIT_R=y
++CONFIG_SYS_MAXARGS=32
++# CONFIG_CMD_BDI is not set
++# CONFIG_CMD_IMI is not set
++CONFIG_CMD_GPIO=y
++# CONFIG_CMD_LOADS is not set
++CONFIG_CMD_MMC=y
++CONFIG_CMD_PCI=y
++CONFIG_CMD_USB=y
++CONFIG_CMD_USB_MASS_STORAGE=y
++# CONFIG_CMD_SETEXPR is not set
++CONFIG_CMD_REGULATOR=y
++CONFIG_OF_CONTROL=y
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_NET_RANDOM_ETHADDR=y
++CONFIG_ADC=y
++CONFIG_SARADC_MESON=y
++CONFIG_BUTTON=y
++CONFIG_BUTTON_ADC=y
++CONFIG_MMC_MESON_GX=y
++CONFIG_PHY_REALTEK=y
++CONFIG_DM_ETH=y
++CONFIG_DM_MDIO=y
++CONFIG_DM_MDIO_MUX=y
++CONFIG_ETH_DESIGNWARE_MESON8B=y
++CONFIG_MDIO_MUX_MESON_G12A=y
++CONFIG_PCI=y
++CONFIG_PCIE_DW_MESON=y
++CONFIG_MESON_G12A_USB_PHY=y
++CONFIG_PINCTRL=y
++CONFIG_PINCTRL_MESON_G12A=y
++CONFIG_POWER_DOMAIN=y
++CONFIG_MESON_EE_POWER_DOMAIN=y
++CONFIG_DM_REGULATOR=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_DM_RESET=y
++CONFIG_DEBUG_UART_ANNOUNCE=y
++CONFIG_DEBUG_UART_SKIP_INIT=y
++CONFIG_MESON_SERIAL=y
++CONFIG_SYSINFO=y
++CONFIG_SYSINFO_SMBIOS=y
++CONFIG_USB=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_XHCI_DWC3=y
++CONFIG_USB_DWC3=y
++# CONFIG_USB_DWC3_GADGET is not set
++CONFIG_USB_DWC3_MESON_G12A=y
++CONFIG_USB_KEYBOARD=y
++CONFIG_USB_GADGET=y
++CONFIG_USB_GADGET_VENDOR_NUM=0x1b8e
++CONFIG_USB_GADGET_PRODUCT_NUM=0xfada
++CONFIG_USB_GADGET_DWC2_OTG=y
++CONFIG_USB_GADGET_DWC2_OTG_PHY_BUS_WIDTH_8=y
++CONFIG_USB_GADGET_DOWNLOAD=y
++CONFIG_VIDEO=y
++# CONFIG_VIDEO_BPP8 is not set
++# CONFIG_VIDEO_BPP16 is not set
++CONFIG_SYS_WHITE_ON_BLACK=y
++CONFIG_VIDEO_MESON=y
++CONFIG_VIDEO_DT_SIMPLEFB=y
++CONFIG_SPLASH_SCREEN=y
++CONFIG_SPLASH_SCREEN_ALIGN=y
++CONFIG_VIDEO_BMP_RLE8=y
++CONFIG_BMP_16BPP=y
++CONFIG_BMP_24BPP=y
++CONFIG_BMP_32BPP=y
++CONFIG_OF_LIBFDT_OVERLAY=y
+diff --git a/doc/board/amlogic/index.rst b/doc/board/amlogic/index.rst
+index 4d407f9362..e349ac5a75 100644
+--- a/doc/board/amlogic/index.rst
++++ b/doc/board/amlogic/index.rst
+@@ -20,6 +20,7 @@ This matrix concerns the actual source code version.
+ |                               | P200      | LibreTech-CC v1 | WeTek Core2  |             | Radxa Zero | GT-King/Pro | Odroid-C4    |
+ |                               | P201      | LibreTech-AC v2 |              |             |            | GSKing-X    | Odroid-HC4   |
+ |                               |           | JetHub J80      |              |             |            |             | BananaPi-M5  |
++|                               |           |                 |              |             |            | BPI-M4      |              |
+ +-------------------------------+-----------+-----------------+--------------+-------------+------------+-------------+--------------+
+ | UART                          | **Yes**   | **Yes**         | **Yes**      | **Yes**     | **Yes**    | **Yes**     | **Yes**      |
+ +-------------------------------+-----------+-----------------+--------------+-------------+------------+-------------+--------------+
+-- 
+2.34.1
+


### PR DESCRIPTION
# Description

This introduces support for the BPI-CM4 module following the specifications of the RPI-CM4 module, using the BPI-CM4IO baseboard, but should support any CM4 compatible baseboards.

https://wiki.banana-pi.org/Banana_Pi_BPI-CM4

The Linux DT changes has been submitted (https://lore.kernel.org/all/20230303-topic-amlogic-upstream-bpi-cm4-v2-0-2ecfde76fc4d@linaro.org/) and merged (https://git.kernel.org/amlogic/c/0262f2736978b1763363224698f47112a148dab0) upstream, the U-Boot changes are still in review (https://lore.kernel.org/all/20230307-u-boot-cm4-v1-0-43f5a393cd37@linaro.org/)

# How Has This Been Tested?

Boot tested with console & gnome desktop image via sdcard boot, ethernet & display working as expected.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
