### PR TITLE
Add fonts-noto-color-emoji for terminal Emoji support

### DIFF
--- a/config/cli/common/debootstrap/config_desktop/packages
+++ b/config/cli/common/debootstrap/config_desktop/packages
@@ -1,3 +1,4 @@
 dconf-cli
+fonts-noto-color-emoji
 libglib2.0-dev
 libgtk2.0-bin


### PR DESCRIPTION
# Description

Jira reference number [AR-1602] Closing https://github.com/armbian/build/issues/4943

# How Has This Been Tested?

- [x] Build image

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1602]: https://armbian.atlassian.net/browse/AR-1602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ