### PR TITLE
add ca-certificates to debootstrap

### DIFF
--- a/config/cli/common/debootstrap/packages
+++ b/config/cli/common/debootstrap/packages
@@ -2,3 +2,4 @@ apt-utils
 locales
 console-setup
 gnupg2
+ca-certificates

--- a/config/cli/common/main/packages
+++ b/config/cli/common/main/packages
@@ -1,6 +1,5 @@
 bc
 bridge-utils
-ca-certificates
 chrony
 command-not-found
 console-setup


### PR DESCRIPTION
# Description

I want to add a ppa to a new appgroup. I need `ca-certificates` before running `apt update` or I will get `No system certificates available. Try installing ca-certificates.`.
Log: https://paste.armbian.com/oponabanom

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] apt update success with ppa

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
