### PR TITLE
CI framework improvement - commit linting

### DIFF
--- a/.github/COMMIT_CONVENTION.md
+++ b/.github/COMMIT_CONVENTION.md
@@ -1,0 +1,93 @@
+## Git Commit Message Convention
+
+> This is adapted from [Angular's commit convention](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular).
+
+#### TL;DR
+
+Messages must be matched by the following regex:
+
+``` js
+/^(revert: )?(feat|fix|docs|style|refactor|perf|test|workflow|ci|chore|types)(\(.+\))?: .{1,50}/
+```
+
+#### Examples
+
+Appears under "Features" header, `compiler` subheader:
+
+```
+feat(compiler): add 'comments' option
+```
+
+Appears under "Bug Fixes" header, `bananapi` subheader, with a link to issue #28:
+
+```
+fix(bananapi): enable CONFIG_NETFILTER_XT_TARGET_LOG
+
+close #28
+```
+
+Appears under "Performance Improvements" header, and under "Breaking Changes" with the breaking change explanation:
+
+```
+perf(core): improve vdom diffing by removing 'foo' option
+
+BREAKING CHANGE: The 'foo' option has been removed.
+```
+
+The following commit and commit `667ecc1` do not appear in the changelog if they are under the same release. If not, the revert commit appears under the "Reverts" header.
+
+```
+revert: feat(compiler): add 'comments' option
+
+This reverts commit 667ecc1654a317a13331b17617d973392f415f02.
+```
+
+### Full Message Format
+
+A commit message consists of a **header**, **body** and **footer**.  The header has a **type**, **scope** and **subject**:
+
+```
+<type>(<scope>): <subject>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+The **header** is mandatory and the **scope** of the header is optional.
+
+A `!` MAY be appended prior to the `:` in the type/scope prefix, to further draw attention to breaking changes. `BREAKING CHANGE:` description MUST also be included in the body or footer, along with the `!` in the prefix.
+
+### Revert
+
+If the commit reverts a previous commit, it should begin with `revert:`, followed by the header of the reverted commit. In the body it should say: `This reverts commit <hash>.`, where the hash is the SHA of the commit being reverted.
+
+### Type
+
+If the prefix is `feat`, `fix` or `perf`, it will appear in the changelog. However if there is any [BREAKING CHANGE](#footer), the commit will always appear in the changelog.
+
+Other prefixes are up to your discretion. Suggested prefixes are `docs`, `chore`, `style`, `refactor`, and `test` for non-changelog related tasks.
+
+### Scope
+
+The scope could be anything specifying place of the commit change. For example `core`, `compiler`, `ssr`, `v-model`, `transition` etc...
+
+### Subject
+
+The subject contains succinct description of the change:
+
+* use the imperative, present tense: "change" not "changed" nor "changes"
+* don't capitalize first letter
+* no dot (.) at the end
+
+### Body
+
+Just as in the **subject**, use the imperative, present tense: "change" not "changed" nor "changes".
+The body should include the motivation for the change and contrast this with previous behavior.
+
+### Footer
+
+The footer should contain any information about **Breaking Changes** and is also the place to
+reference GitHub issues that this commit **Closes**.
+
+**Breaking Changes** should start with the word `BREAKING CHANGE:` with a space or two newlines. The rest of the commit message is then used for this.

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,33 @@
+name: Lint Commit Messages
+on: [pull_request]
+
+jobs:
+    commitlint:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout Project
+              uses: actions/checkout@v2
+              with:
+                  # for pull_request so we can do HEAD^2
+                  fetch-depth: 2
+
+            - name: Get commit message
+              id: get_commit_message
+              run: |
+                  if   [[ '${{ github.event_name }}' == 'push' ]]; then
+                    echo ::set-output name=commit_message::$(git log --format=%B -n 1 HEAD)
+                  elif [[ '${{ github.event_name }}' == 'pull_request' ]]; then
+                    echo ::set-output name=commit_message::$(git log --format=%B -n 1 HEAD^2)
+                  fi
+
+            - name: "Check latest commit message"
+              run: |
+                  commit_regex='^Merge.+|(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|types)(\(.+\))?: .{1,50}'
+                  if ! grep -iqE "$commit_regex" "${{ steps.get_commit_message.outputs.commit_message }}"; then
+                     echo
+                     echo "  Error: proper commit message format is required for automated changelog generation."
+                     echo
+                     echo "  - See .github/COMMIT_CONVENTION.md for more details."
+                     echo
+                     exit 1
+                  fi

--- a/.github/workflows/lint-commit-pr.yml
+++ b/.github/workflows/lint-commit-pr.yml
@@ -1,12 +1,13 @@
 name: Lint Commit Messages
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
     commitlint:
+        name: "Lint commit"
         runs-on: ubuntu-latest
         steps:
             - name: Checkout Project
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                   # for pull_request so we can do HEAD^2
                   fetch-depth: 2
@@ -15,18 +16,16 @@ jobs:
               id: get_commit_message
               run: |
                   if   [[ '${{ github.event_name }}' == 'push' ]]; then
-                    echo ::set-output name=commit_message::$(git log --format=%B -n 1 HEAD)
+                    echo "commit_message=$(git log --format=%B -n 1 HEAD)" >> $GITHUB_OUTPUT
                   elif [[ '${{ github.event_name }}' == 'pull_request' ]]; then
-                    echo ::set-output name=commit_message::$(git log --format=%B -n 1 HEAD^2)
+                    echo "commit_message=$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_OUTPUT
                   fi
-
             - name: "Check latest commit message"
               run: |
-                  commit_regex='^Merge.+|(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|types)(\(.+\))?: .{1,50}'
-                  if ! grep -iqE "$commit_regex" "${{ steps.get_commit_message.outputs.commit_message }}"; then
+                  PATTERN='^Merge.+|(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|types)(\(.+\))?: .{1,50}'
+                  if ! [[ "${{ steps.get_commit_message.outputs.commit_message }}" =~ $PATTERN ]]; then
                      echo
                      echo "  Error: proper commit message format is required for automated changelog generation."
-                     echo
                      echo "  - See .github/COMMIT_CONVENTION.md for more details."
                      echo
                      exit 1


### PR DESCRIPTION
# Description

Rework of https://github.com/armbian/build/pull/3583

- remove left-hook and pre-commit linting as this is now well covered withing build framework and separate linter.

@littlecxm 

Jira reference number [AR-1613]

# How Has This Been Tested?

- [x] In private repo

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1613]: https://armbian.atlassian.net/browse/AR-1613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ