### PR TITLE
Fix armbian-install: fix variable $sduuid to be of format UUID=uuid

### DIFF
--- a/packages/bsp/common/usr/sbin/armbian-install
+++ b/packages/bsp/common/usr/sbin/armbian-install
@@ -69,6 +69,7 @@ sdblkid=$(blkid -o full /dev/mmcblk*p1 | grep -v "$root_partition_device")
 [[ -z $sdblkid ]] && sdblkid=$(blkid -o full /dev/mmcblk*p1)
 # 3 - Extract the UUID from $sdblkid via regex:
 sduuid=$(echo "$sdblkid" | sed -nE 's/^.*[[:space:]]UUID="([0-9a-zA-Z-]*)".*/\1/p')
+[[ -n $sduuid ]] && sduuid="UUID=${sduuid}"
 
 #recognize EFI
 [[ -d /sys/firmware/efi ]] && DEVICE_TYPE="uefi"

--- a/packages/bsp/common/usr/sbin/armbian-install
+++ b/packages/bsp/common/usr/sbin/armbian-install
@@ -63,13 +63,14 @@ mtdcheck=$(grep 'mtdblock' /proc/partitions | awk '{print $NF}' | xargs)
 
 # SD card boot part - to be considered more than one entry on various platforms
 # UUID=xxx...
-# 1 - Lookup mmc devices excluding the mmc device probably providing the current root partition:
-sdblkid=$(blkid -o full /dev/mmcblk*p1 | grep -v "$root_partition_device")
-# 2 - If there is nothing, then lookup any mmc partition matching /dev/mmcblk*p1:
-[[ -z $sdblkid ]] && sdblkid=$(blkid -o full /dev/mmcblk*p1)
-# 3 - Extract the UUID from $sdblkid via regex:
-sduuid=$(echo "$sdblkid" | sed -nE 's/^.*[[:space:]]UUID="([0-9a-zA-Z-]*)".*/\1/p')
-[[ -n $sduuid ]] && sduuid="UUID=${sduuid}"
+# 1 - Lookup mmc devices excluding the mmc device probably providing the current root partition as well as a probable emmc device found above:
+[[ -z $emmccheck ]] && sdblkid=$(blkid -o full /dev/mmcblk*p1 | grep -v "$root_partition_device")
+[[ -n $emmccheck ]] && sdblkid=$(blkid -o full /dev/mmcblk*p1 | grep -v "$root_partition_device" | grep -v "$emmccheck")
+# 2 - If there is nothing, then lookup any mmc partition matching /dev/mmcblk*p1 excluding probable emmc device found above
+[[ -z $sdblkid && -z $emmccheck ]] && sdblkid=$(blkid -o full /dev/mmcblk*p1)
+[[ -z $sdblkid && -n $emmccheck ]] && sdblkid=$(blkid -o full /dev/mmcblk*p1 | grep -v "$emmccheck")
+# 3 - Extract the UUID=<uuid> from $sdblkid via regex without " - as e.g.: UUID=2e1d1509-a8fc-4f8b-8a51-88fb8593f8d6
+sduuid=$(echo "$sdblkid" | sed -nE 's/^.*[[:space:]](UUID="[0-9a-zA-Z-]*").*/\1/p' | tr -d '"')
 
 #recognize EFI
 [[ -d /sys/firmware/efi ]] && DEVICE_TYPE="uefi"
@@ -855,7 +856,7 @@ main()
 				if [[ -n $emmccheck ]]; then
 					umount_device "$emmccheck"
 					format_emmc "$emmccheck"
-					else
+				else
 					umount_device '/dev/nand'
 					format_nand
 				fi


### PR DESCRIPTION
# Description

- this issue was introduced by commit 7e9ebe1
- the variable sduuid is supposed to start with "UUID="
- fixed now by prepending UUID= to $sduuid, if the "raw" $sduuid is not empty

closes Jira reference number [AR-1611]

# How Has This Been Tested?
The statement of the line fixed has been tested in an offline bash session.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code


[AR-1611]: https://armbian.atlassian.net/browse/AR-1611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ