### PR TITLE
rpardini's big batch of fixes from middle March/23; include `VERSION` in all artifacts; fix `KERNEL_CONFIGURE`; etc

### DIFF
--- a/config/desktop/jammy/appgroups/browsers/packages
+++ b/config/desktop/jammy/appgroups/browsers/packages
@@ -1,2 +1,1 @@
 chromium-browser
-firefox-esr

--- a/config/sources/families/bcm2711.conf
+++ b/config/sources/families/bcm2711.conf
@@ -90,7 +90,7 @@ extension_prepare_config__prepare_rpi_flash_kernel() {
 			fi
 		fi
 	else
-		if [[ "${KERNEL_ONLY}" != "yes" ]]; then
+		if [[ "${BUILDING_IMAGE}" == "yes" ]]; then
 			display_alert "Can't use release for ${BOARD}. Try: ${usable_releases}" "${RELEASE}" "err"
 			exit 27
 		fi

--- a/config/sources/families/odroidxu4.conf
+++ b/config/sources/families/odroidxu4.conf
@@ -19,7 +19,8 @@ case $BRANCH in
 	current)
 
 		KERNELSOURCE='https://github.com/hardkernel/linux'
-		export KERNEL_MAJOR_MINOR="5.4" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="5.4"           # Major and minor versions of this kernel.
+		declare -g KERNEL_SKIP_MAKEFILE_VERSION="yes" # Armbian patches change the version here, so no use having it in the version string.
 		KERNELBRANCH='branch:odroid-5.4.y'
 		KERNELDIR='linux-odroidxu4'
 		;;

--- a/config/sources/families/rockchip-rk3588.conf
+++ b/config/sources/families/rockchip-rk3588.conf
@@ -33,7 +33,7 @@ case $BRANCH in
 		LINUXFAMILY=rockchip-rk3588
 		LINUXCONFIG='linux-rockchip-rk3588-'$BRANCH
 		KERNEL_MAJOR_MINOR="6.2" # Major and minor versions of this kernel.
-		KERNELBRANCH='branch:6.2.y'
+		KERNELBRANCH='branch:linux-6.2.y'
 		KERNELPATCHDIR='rockchip-rk3588-edge'
 		;;
 

--- a/config/templates/config-example.conf
+++ b/config/templates/config-example.conf
@@ -1,7 +1,6 @@
 # Read build script documentation https://docs.armbian.com/Developer-Guide_Build-Options/
 # for detailed explanation of these options and for additional options not listed here
 
-KERNEL_ONLY=""      # leave empty to select each time, set to "yes" or "no" to skip dialog prompt
 KERNEL_CONFIGURE="" # leave empty to select each time, set to "yes" or "no" to skip dialog prompt
 CLEAN_LEVEL=""      # comma-separated list of clean targets:
 :                   # --> "make-atf" = make clean for ATF, if it is built.

--- a/extensions/grub-riscv64.sh
+++ b/extensions/grub-riscv64.sh
@@ -19,7 +19,7 @@ function extension_prepare_config__prepare_grub-riscv64() {
 	export EXTRA_BSP_NAME="${EXTRA_BSP_NAME}-grub"                               # Unique bsp name.
 	export UEFI_GRUB_TARGET="riscv64-efi"                                        # Default for x86_64
 
-	if [[ "${DISTRIBUTION}" != "Ubuntu" && "${KERNEL_ONLY}" == "no" ]]; then
+	if [[ "${DISTRIBUTION}" != "Ubuntu" && "${BUILDING_IMAGE}" == "yes" ]]; then
 		exit_with_error "${DISTRIBUTION} is not supported yet"
 	fi
 

--- a/lib/functions/artifacts/artifact-firmware.sh
+++ b/lib/functions/artifacts/artifact-firmware.sh
@@ -71,7 +71,6 @@ function artifact_firmware_cli_adapter_pre_run() {
 }
 
 function artifact_firmware_cli_adapter_config_prep() {
-	declare KERNEL_ONLY="yes"                            # @TODO: this is a hack, for the board/family code's benefit...
 	use_board="no" prep_conf_main_minimal_ni < /dev/null # no stdin for this, so it bombs if tries to be interactive.
 }
 

--- a/lib/functions/artifacts/artifact-firmware.sh
+++ b/lib/functions/artifacts/artifact-firmware.sh
@@ -34,7 +34,7 @@ function artifact_firmware_prepare_version() {
 	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
 
 	# outer scope
-	artifact_version="${fake_unchanging_base_version}-SA${short_sha1}-B${bash_hash_short}"
+	artifact_version="${artifact_prefix_version}${fake_unchanging_base_version}-SA${short_sha1}-B${bash_hash_short}"
 
 	declare -a reasons=(
 		"Armbian firmware git revision \"${GIT_INFO_ARMBIAN_FIRMWARE[SHA1]}\""

--- a/lib/functions/artifacts/artifact-full_firmware.sh
+++ b/lib/functions/artifacts/artifact-full_firmware.sh
@@ -10,6 +10,7 @@
 function artifact_full_firmware_prepare_version() {
 	artifact_version="undetermined"        # outer scope
 	artifact_version_reason="undetermined" # outer scope
+	[[ -z "${artifact_prefix_version}" ]] && exit_with_error "artifact_prefix_version is not set"
 
 	local ARMBIAN_FIRMWARE_SOURCE="${ARMBIAN_FIRMWARE_GIT_SOURCE:-"https://github.com/armbian/firmware"}"
 	local ARMBIAN_FIRMWARE_BRANCH="branch:${ARMBIAN_FIRMWARE_GIT_BRANCH:-"master"}"
@@ -40,7 +41,7 @@ function artifact_full_firmware_prepare_version() {
 	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
 
 	# outer scope
-	artifact_version="${fake_unchanging_base_version}-SA${short_sha1}-SM${short_sha1_mainline}-B${bash_hash_short}"
+	artifact_version="${artifact_prefix_version}${fake_unchanging_base_version}-SA${short_sha1}-SM${short_sha1_mainline}-B${bash_hash_short}"
 
 	declare -a reasons=(
 		"Armbian firmware git revision \"${GIT_INFO_ARMBIAN_FIRMWARE[SHA1]}\""

--- a/lib/functions/artifacts/artifact-full_firmware.sh
+++ b/lib/functions/artifacts/artifact-full_firmware.sh
@@ -79,7 +79,6 @@ function artifact_full_firmware_cli_adapter_pre_run() {
 }
 
 function artifact_full_firmware_cli_adapter_config_prep() {
-	declare KERNEL_ONLY="yes"                            # @TODO: this is a hack, for the board/family code's benefit...
 	use_board="no" prep_conf_main_minimal_ni < /dev/null # no stdin for this, so it bombs if tries to be interactive.
 }
 

--- a/lib/functions/artifacts/artifact-kernel.sh
+++ b/lib/functions/artifacts/artifact-kernel.sh
@@ -14,6 +14,7 @@
 function artifact_kernel_prepare_version() {
 	artifact_version="undetermined"        # outer scope
 	artifact_version_reason="undetermined" # outer scope
+	[[ -z "${artifact_prefix_version}" ]] && exit_with_error "artifact_prefix_version is not set"
 
 	# - Given KERNELSOURCE and KERNELBRANCH, get:
 	#    - SHA1 of the commit (this is generic... and used for other pkgs)
@@ -101,7 +102,8 @@ function artifact_kernel_prepare_version() {
 	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
 
 	# outer scope
-	artifact_version="${GIT_INFO_KERNEL[MAKEFILE_VERSION]}-S${short_sha1}-D${kernel_drivers_hash_short}-P${kernel_patches_hash_short}-C${config_hash_short}H${kernel_config_modification_hash_short}-B${bash_hash_short}"
+	# @TODO: support NOT having the GIT_INFO_KERNEL, for families that patch the version or are private...
+	artifact_version="${artifact_prefix_version}${GIT_INFO_KERNEL[MAKEFILE_VERSION]}-S${short_sha1}-D${kernel_drivers_hash_short}-P${kernel_patches_hash_short}-C${config_hash_short}H${kernel_config_modification_hash_short}-B${bash_hash_short}"
 
 	declare -a reasons=(
 		"version \"${GIT_INFO_KERNEL[MAKEFILE_FULL_VERSION]}\""

--- a/lib/functions/artifacts/artifact-kernel.sh
+++ b/lib/functions/artifacts/artifact-kernel.sh
@@ -178,7 +178,6 @@ function artifact_kernel_cli_adapter_pre_run() {
 }
 
 function artifact_kernel_cli_adapter_config_prep() {
-	declare KERNEL_ONLY="yes"                             # @TODO: this is a hack, for the board/family code's benefit...
 	use_board="yes" prep_conf_main_minimal_ni < /dev/null # no stdin for this, so it bombs if tries to be interactive.
 }
 

--- a/lib/functions/artifacts/artifact-rootfs.sh
+++ b/lib/functions/artifacts/artifact-rootfs.sh
@@ -10,6 +10,7 @@
 function artifact_rootfs_prepare_version() {
 	artifact_version="undetermined"        # outer scope
 	artifact_version_reason="undetermined" # outer scope
+	[[ -z "${artifact_prefix_version}" ]] && exit_with_error "artifact_prefix_version is not set"
 
 	assert_requires_aggregation # Bombs if aggregation has not run
 
@@ -30,7 +31,7 @@ function artifact_rootfs_prepare_version() {
 	# @TODO: gotta include the extensions rootfs-modifying id to cache_type...
 
 	# outer scope
-	artifact_version="${rootfs_cache_id}"
+	artifact_version="${artifact_prefix_version}${rootfs_cache_id}"
 	artifact_version_reason="${reasons[*]}"
 	artifact_name="${ARCH}-${RELEASE}-${cache_type}"
 	artifact_type="tar.zst"

--- a/lib/functions/artifacts/artifact-uboot.sh
+++ b/lib/functions/artifacts/artifact-uboot.sh
@@ -10,6 +10,7 @@
 function artifact_uboot_prepare_version() {
 	artifact_version="undetermined"        # outer scope
 	artifact_version_reason="undetermined" # outer scope
+	[[ -z "${artifact_prefix_version}" ]] && exit_with_error "artifact_prefix_version is not set"
 
 	# Prepare the version, "sans-repos": just the armbian/build repo contents are available.
 	# It is OK to reach out to the internet for a curl or ls-remote, but not for a git clone/fetch.
@@ -53,7 +54,7 @@ function artifact_uboot_prepare_version() {
 	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
 
 	# outer scope
-	artifact_version="${GIT_INFO_UBOOT[MAKEFILE_VERSION]}-S${short_sha1}-P${uboot_patches_hash_short}-B${bash_hash_short}"
+	artifact_version="${artifact_prefix_version}${GIT_INFO_UBOOT[MAKEFILE_VERSION]}-S${short_sha1}-P${uboot_patches_hash_short}-B${bash_hash_short}"
 
 	declare -a reasons=(
 		"version \"${GIT_INFO_UBOOT[MAKEFILE_FULL_VERSION]}\""

--- a/lib/functions/artifacts/artifact-uboot.sh
+++ b/lib/functions/artifacts/artifact-uboot.sh
@@ -101,7 +101,6 @@ function artifact_uboot_cli_adapter_pre_run() {
 }
 
 function artifact_uboot_cli_adapter_config_prep() {
-	declare KERNEL_ONLY="yes"                             # @TODO: this is a hack, for the board/family code's benefit...
 	use_board="yes" prep_conf_main_minimal_ni < /dev/null # no stdin for this, so it bombs if tries to be interactive.
 }
 

--- a/lib/functions/artifacts/artifacts-obtain.sh
+++ b/lib/functions/artifacts/artifacts-obtain.sh
@@ -219,6 +219,9 @@ function obtain_complete_artifact() {
 function build_artifact_for_image() {
 	initialize_artifact "${WHAT}"
 
+	# Make sure ORAS tooling is installed before starting.
+	run_tool_oras
+
 	# Detour: if building kernel, and KERNEL_CONFIGURE=yes, ignore artifact cache.
 	if [[ "${WHAT}" == "kernel" && "${KERNEL_CONFIGURE}" == "yes" ]]; then
 		display_alert "Ignoring artifact cache for kernel" "KERNEL_CONFIGURE=yes" "info"

--- a/lib/functions/artifacts/artifacts-obtain.sh
+++ b/lib/functions/artifacts/artifacts-obtain.sh
@@ -218,7 +218,16 @@ function obtain_complete_artifact() {
 # This is meant to be run after config, inside default build.
 function build_artifact_for_image() {
 	initialize_artifact "${WHAT}"
-	obtain_complete_artifact
+
+	# Detour: if building kernel, and KERNEL_CONFIGURE=yes, ignore artifact cache.
+	if [[ "${WHAT}" == "kernel" && "${KERNEL_CONFIGURE}" == "yes" ]]; then
+		display_alert "Ignoring artifact cache for kernel" "KERNEL_CONFIGURE=yes" "info"
+		ARTIFACT_IGNORE_CACHE="yes" obtain_complete_artifact
+	else
+		obtain_complete_artifact
+	fi
+
+	return 0
 }
 
 function pack_artifact_to_local_cache() {

--- a/lib/functions/artifacts/artifacts-obtain.sh
+++ b/lib/functions/artifacts/artifacts-obtain.sh
@@ -101,6 +101,9 @@ function obtain_complete_artifact() {
 	[[ "x${artifact_base_dir}x" == "xx" || "${artifact_base_dir}" == "undetermined" ]] && exit_with_error "artifact_base_dir is not set after artifact_prepare_version"
 	[[ "x${artifact_final_file}x" == "xx" || "${artifact_final_file}" == "undetermined" ]] && exit_with_error "artifact_final_file is not set after artifact_prepare_version"
 
+	# validate artifact_version begins with artifact_prefix_version
+	[[ "${artifact_version}" =~ ^${artifact_prefix_version} ]] || exit_with_error "artifact_version '${artifact_version}' does not begin with artifact_prefix_version '${artifact_prefix_version}'"
+
 	# validate artifact_type... it must be one of the supported types
 	case "${artifact_type}" in
 		deb | deb-tar)

--- a/lib/functions/cli/cli-artifact.sh
+++ b/lib/functions/cli/cli-artifact.sh
@@ -17,6 +17,9 @@ function cli_artifact_run() {
 	: "${chosen_artifact:?chosen_artifact is not set}"
 	: "${chosen_artifact_impl:?chosen_artifact_impl is not set}"
 
+	# Make sure ORAS tooling is installed before starting.
+	run_tool_oras
+
 	display_alert "artifact" "${chosen_artifact}" "debug"
 	display_alert "artifact" "${chosen_artifact} :: ${chosen_artifact_impl}()" "debug"
 	artifact_cli_adapter_config_prep # only if in cli.

--- a/lib/functions/cli/cli-build.sh
+++ b/lib/functions/cli/cli-build.sh
@@ -15,6 +15,9 @@ function cli_standard_build_pre_run() {
 }
 
 function cli_standard_build_run() {
+	declare -g -r BUILDING_IMAGE=yes # Marker; meaning "we are building an image, not just an artifact"
+	declare -g -r NEEDS_BINFMT="yes" # Marker; make sure binfmts are installed during prepare_host_interactive
+
 	# configuration etc - it initializes the extension manager; handles its own logging sections
 	prep_conf_main_build_single
 
@@ -41,7 +44,6 @@ function produce_repeat_args_array() {
 	[[ -n ${RELEASE} ]] && repeat_args+=("RELEASE=${RELEASE}")
 	[[ -n ${BUILD_MINIMAL} ]] && repeat_args+=("BUILD_MINIMAL=${BUILD_MINIMAL}")
 	[[ -n ${BUILD_DESKTOP} ]] && repeat_args+=("BUILD_DESKTOP=${BUILD_DESKTOP}")
-	[[ -n ${KERNEL_ONLY} ]] && repeat_args+=("KERNEL_ONLY=${KERNEL_ONLY}")
 	[[ -n ${KERNEL_CONFIGURE} ]] && repeat_args+=("KERNEL_CONFIGURE=${KERNEL_CONFIGURE}")
 	[[ -n ${DESKTOP_ENVIRONMENT} ]] && repeat_args+=("DESKTOP_ENVIRONMENT=${DESKTOP_ENVIRONMENT}")
 	[[ -n ${DESKTOP_ENVIRONMENT_CONFIG_NAME} ]] && repeat_args+=("DESKTOP_ENVIRONMENT_CONFIG_NAME=${DESKTOP_ENVIRONMENT_CONFIG_NAME}")

--- a/lib/functions/cli/cli-patch.sh
+++ b/lib/functions/cli/cli-patch.sh
@@ -26,7 +26,6 @@ function cli_patch_kernel_run() {
 	display_alert "Patching kernel" "$BRANCH" "info"
 	declare -g SYNC_CLOCK=no       # don't waste time syncing the clock
 	declare -g JUST_KERNEL=yes     # only for kernel.
-	declare -g KERNEL_ONLY=yes     # don't build images
 	declare -g PATCHES_TO_GIT=yes  # commit to git.
 	declare -g PATCH_ONLY=yes      # stop after patching.
 	declare -g DEBUG_PATCHING=yes  # debug patching.

--- a/lib/functions/cli/entrypoint.sh
+++ b/lib/functions/cli/entrypoint.sh
@@ -169,6 +169,9 @@ function cli_entrypoint() {
 		apply_cmdline_params_to_env "after config '${config_filename}'" # which uses ARMBIAN_PARSED_CMDLINE_PARAMS
 	done
 
+	# Early check for deprecations
+	error_if_lib_tag_set     # make sure users are not thrown off by using old parameter which does nothing anymore; explain
+
 	display_alert "Executing final CLI command" "${ARMBIAN_COMMAND}" "debug"
 	armbian_cli_run_command
 	display_alert "Done Executing final CLI command" "${ARMBIAN_COMMAND}" "debug"

--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -438,5 +438,17 @@ function kernel_package_callback_linux_headers() {
 			make ARCH="${SRC_ARCH}" -j\$NCPU tools/objtool
 			echo "Done compiling kernel-headers tools (${kernel_version_family})."
 		EOT_POSTINST
+
+		if [[ "${ARCH}" == "amd64" ]]; then # This really only works on x86/amd64; @TODO revisit later
+			cat <<- EOT_POSTINST_OBJTOOL
+				echo "Compiling kernel-header objtool (${kernel_version_family})."
+				make ARCH="${SRC_ARCH}" -j\$NCPU tools/objtool
+				echo "Done compiling kernel-header objtool (${kernel_version_family})."
+			EOT_POSTINST_OBJTOOL
+		fi
+
+		cat <<- EOT_POSTINST_FINISH
+			echo "Done compiling kernel-headers tools (${kernel_version_family})."
+		EOT_POSTINST_FINISH
 	)
 }

--- a/lib/functions/compilation/uboot.sh
+++ b/lib/functions/compilation/uboot.sh
@@ -402,6 +402,6 @@ function compile_uboot() {
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 
-	display_alert "Built u-boot deb OK" "${uboot_name}.deb" "info"
+	display_alert "Built u-boot deb OK" "linux-u-boot-${BOARD}-${BRANCH} ${artifact_version}" "info"
 	return 0 # success
 }

--- a/lib/functions/configuration/aggregation.sh
+++ b/lib/functions/configuration/aggregation.sh
@@ -18,7 +18,7 @@ function mark_aggregation_required_in_default_build_start() {
 }
 
 function aggregate_packages_in_logging_section() {
-	# Aggregate packages, in its own logging section; this decides internally on KERNEL_ONLY=no
+	# Aggregate packages, in its own logging section
 	# We need aggregation to be able to build bsp packages, which contain scripts coming from the aggregation.
 	LOG_SECTION="aggregate_packages" do_with_logging aggregate_packages
 }
@@ -26,23 +26,21 @@ function aggregate_packages_in_logging_section() {
 # This used to be called from config (main-config), but now it's moved default-build, after prepare_host, so Python hostdeps are available.
 # So the aggregation results (hash, etc) are not available for config-dump.
 function aggregate_packages() {
-	if [[ "${KERNEL_ONLY}" != "yes" ]]; then # @TODO: remove, this is not the right place to decide this.
 
-		if [[ ${aggregation_has_already_run:-0} -gt 0 ]]; then
-			exit_with_error "aggregate_packages: Aggregation has already run"
-		fi
-
-		display_alert "Aggregating packages" "rootfs" "info"
-		aggregate_all_packages_python
-		call_extension_method "post_aggregate_packages" "user_config_post_aggregate_packages" <<- 'POST_AGGREGATE_PACKAGES'
-			*After all aggregations are done*
-			Called after aggregating all package lists.
-			Packages will still be installed after this is called. It is not possible to change anything, though.
-		POST_AGGREGATE_PACKAGES
-
-		declare -i -g -r aggregation_has_already_run=1 # global, readonly.
-
+	if [[ ${aggregation_has_already_run:-0} -gt 0 ]]; then
+		exit_with_error "aggregate_packages: Aggregation has already run"
 	fi
+
+	display_alert "Aggregating packages" "rootfs" "info"
+	aggregate_all_packages_python
+	call_extension_method "post_aggregate_packages" "user_config_post_aggregate_packages" <<- 'POST_AGGREGATE_PACKAGES'
+		*After all aggregations are done*
+		Called after aggregating all package lists.
+		Packages will still be installed after this is called. It is not possible to change anything, though.
+	POST_AGGREGATE_PACKAGES
+
+	declare -i -g -r aggregation_has_already_run=1 # global, readonly.
+
 }
 
 function aggregate_all_packages_python() {

--- a/lib/functions/configuration/interactive.sh
+++ b/lib/functions/configuration/interactive.sh
@@ -33,19 +33,7 @@ function interactive_finish() {
 }
 
 function interactive_config_ask_kernel() {
-	interactive_config_ask_kernel_only
 	interactive_config_ask_kernel_configure
-}
-
-function interactive_config_ask_kernel_only() {
-	# if KERNEL_ONLY, KERNEL_CONFIGURE, BOARD, BRANCH or RELEASE are not set, display selection menu
-	[[ -n ${KERNEL_ONLY} ]] && return 0
-	options+=("no" "Full OS image for flashing")
-	options+=("yes" "U-boot and kernel packages ONLY")
-	dialog_if_terminal_set_vars --title "Choose an option" --backtitle "$backtitle" --no-tags --menu "Select what to build" $TTY_Y $TTY_X $((TTY_Y - 8)) "${options[@]}"
-	KERNEL_ONLY="${DIALOG_RESULT}"
-	[[ "${DIALOG_EXIT_CODE}" != "0" ]] && exit_with_error "You cancelled interactive during KERNEL_ONLY selection: '${DIALOG_EXIT_CODE}'" "Build cancelled: ${DIALOG_EXIT_CODE}"
-	unset options
 }
 
 function interactive_config_ask_kernel_configure() {
@@ -201,7 +189,6 @@ function interactive_config_ask_branch() {
 }
 
 function interactive_config_ask_release() {
-	[[ $KERNEL_ONLY == yes ]] && return 0 # Don't ask if building packages only.
 	[[ -n ${RELEASE} ]] && return 0
 
 	declare -a options=()
@@ -217,7 +204,6 @@ function interactive_config_ask_desktop_build() {
 	# don't show desktop option if we choose minimal build
 	[[ $HAS_VIDEO_OUTPUT == no || $BUILD_MINIMAL == yes ]] && BUILD_DESKTOP=no
 
-	[[ $KERNEL_ONLY == yes ]] && return 0
 	[[ -n ${BUILD_DESKTOP} ]] && return 0
 
 	# read distribution support status which is written to the armbian-release file
@@ -238,7 +224,7 @@ function interactive_config_ask_desktop_build() {
 }
 
 function interactive_config_ask_standard_or_minimal() {
-	[[ $KERNEL_ONLY == yes ]] && return 0
+	[[ "${BUILDING_IMAGE}" != "yes" ]] && return 0
 	[[ $BUILD_DESKTOP != no ]] && return 0
 	[[ -n $BUILD_MINIMAL ]] && return 0
 	options=()

--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -23,11 +23,21 @@ function do_main_configuration() {
 	# common options
 	# daily beta build contains date in subrevision
 	#if [[ $BETA == yes && -z $SUBREVISION ]]; then SUBREVISION="."$(date --date="tomorrow" +"%j"); fi
+	declare revision_from="undetermined"
 	if [ -f $USERPATCHES_PATH/VERSION ]; then
 		REVISION=$(cat "${USERPATCHES_PATH}"/VERSION)"$SUBREVISION" # all boards have same revision
+		revision_from="userpatches VERSION file"
 	else
 		REVISION=$(cat "${SRC}"/VERSION)"$SUBREVISION" # all boards have same revision
+		revision_from="main VERSION file"
 	fi
+
+	declare -g -r REVISION="${REVISION}"
+	display_alert "Using revision from" "${revision_from}: '${REVISION}" "info"
+
+	# This is the prefix used by all artifacts. Readonly. It's just $REVISION and a double dash.
+	declare -r -g artifact_prefix_version="${REVISION}--"
+
 	[[ -z $VENDOR ]] && VENDOR="Armbian"
 	[[ -z $ROOTPWD ]] && ROOTPWD="1234"                                  # Must be changed @first login
 	[[ -z $MAINTAINER ]] && MAINTAINER="Igor Pecovnik"                   # deb signature
@@ -241,7 +251,7 @@ function do_main_configuration() {
 		*give the config a chance to override the family/arch defaults, per branch*
 		This hook is called after the family configuration (`sources/families/xxx.conf`) is sourced,
 		and after `post_family_config()` hook is already run.
-		The sole purpose of this is to avoid "case ... esac for $BRANCH" in the board configuration, 
+		The sole purpose of this is to avoid "case ... esac for $BRANCH" in the board configuration,
 		allowing separate functions for different branches. You're welcome.
 	POST_FAMILY_CONFIG_PER_BRANCH
 

--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -347,6 +347,8 @@ function do_extra_configuration() {
 		This runs *after* user_config. Don't change anything not coming from other variables or meant to be configured by the user.
 	EXTENSION_PREPARE_CONFIG
 
+	error_if_lib_tag_set # make sure users are not thrown off by using old parameter which does nothing anymore
+
 	# apt-cacher-ng mirror configurarion
 	APT_MIRROR=$DEBIAN_MIRROR
 	if [[ $DISTRIBUTION == Ubuntu ]]; then

--- a/lib/functions/general/deprecations.sh
+++ b/lib/functions/general/deprecations.sh
@@ -1,0 +1,7 @@
+function error_if_kernel_only_set() {
+	if [[ "x${KERNEL_ONLY}x" != "xx" ]]; then
+		display_alert "KERNEL_ONLY is not supported; use new" "./compile.sh kernel BOARD=${BOARD} BRANCH=${BRANCH} kernel" "err"
+		exit_with_error "KERNEL_ONLY is set.This is not supported anymore. Please remove it, and use the new CLI commands."
+		return 1
+	fi
+}

--- a/lib/functions/general/deprecations.sh
+++ b/lib/functions/general/deprecations.sh
@@ -5,3 +5,10 @@ function error_if_kernel_only_set() {
 		return 1
 	fi
 }
+
+function error_if_lib_tag_set() {
+	if [[ "x${LIB_TAG}x" != "xx" ]]; then
+		exit_with_error "LIB_TAG is set.This is not supported anymore. Please remove it, and manage the git branches manually."
+		return 1
+	fi
+}

--- a/lib/functions/general/oci-oras.sh
+++ b/lib/functions/general/oci-oras.sh
@@ -81,6 +81,12 @@ function run_tool_oras() {
 		display_alert "Calling ORAS with retries ${retries}" "$*" "debug"
 		do_with_retries ${retries} "${ORAS_BIN}" "$@"
 	else
+		# If any parameters passed, call ORAS, otherwise exit. We call it this way (sans-parameters) early to prepare ORAS tooling.
+		if [[ $# -eq 0 ]]; then
+			display_alert "No parameters passed to ORAS" "ORAS" "debug"
+			return 0
+		fi
+
 		display_alert "Calling ORAS" "$*" "debug"
 		"${ORAS_BIN}" "$@"
 	fi

--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -449,6 +449,7 @@ function docker_cli_prepare_launch() {
 		# - bind-mount the Docker config file (if it exists)
 		if [[ -n "${OCI_TARGET_BASE}" ]]; then
 			display_alert "Detected" "OCI_TARGET_BASE: '${OCI_TARGET_BASE}'" "debug"
+			DOCKER_ARGS+=("--env" "OCI_TARGET_BASE=${OCI_TARGET_BASE}")
 
 			# Mount the Docker config file (if it exists)
 			local docker_config_file_host="${HOME}/.docker/config.json"

--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -113,11 +113,12 @@ function prepare_host_noninteractive() {
 		download_external_toolchains # Mostly deprecated, since SKIP_EXTERNAL_TOOLCHAINS=yes is the default
 	fi
 
-	# if we're building an image, not only packages...
+	# NEEDS_BINFMT=yes is set by default build and rootfs artifact build.
+	# if we're building an image, not only packages/artifacts...
 	# ... and the host arch does not match the target arch ...
 	# ... we then require binfmt_misc to be enabled.
 	# "enable arm binary format so that the cross-architecture chroot environment will work"
-	if [[ "${KERNEL_ONLY}" != "yes" ]] || [[ "${NEEDS_BINFMT:-"no"}" == "yes" ]]; then
+	if [[ "${NEEDS_BINFMT:-"no"}" == "yes" ]]; then
 
 		if [[ "${SHOW_DEBUG}" == "yes" ]]; then
 			display_alert "Debugging binfmt - early" "/proc/sys/fs/binfmt_misc/" "debug"

--- a/lib/functions/image/compress-checksum.sh
+++ b/lib/functions/image/compress-checksum.sh
@@ -29,6 +29,8 @@ function output_images_compress_and_checksum() {
 		[[ -L "${uncompressed_file}" ]] && continue
 		# if image is not a file, skip it
 		[[ ! -f "${uncompressed_file}" ]] && continue
+		# if filename ends in .txt, skip it
+		[[ "${uncompressed_file}" == *.txt ]] && continue
 
 		# get just the filename, sans path
 		declare uncompressed_file_basename

--- a/lib/functions/image/rootfs-to-image.sh
+++ b/lib/functions/image/rootfs-to-image.sh
@@ -19,8 +19,9 @@ function create_image_from_sdcard_rootfs() {
 	add_cleanup_handler trap_handler_cleanup_destimg
 
 	# stage: create file name
-	# @TODO: rpardini: determine the image file name produced. a bit late in the game, since it uses IMAGE_INSTALLED_KERNEL_VERSION which is from the kernel package.
-	local version="${VENDOR}_${REVISION}_${BOARD^}_${RELEASE}_${BRANCH}_${IMAGE_INSTALLED_KERNEL_VERSION/-$LINUXFAMILY/}${DESKTOP_ENVIRONMENT:+_$DESKTOP_ENVIRONMENT}"
+	# determine the image file name produced. a bit late in the game, since it uses IMAGE_INSTALLED_KERNEL_VERSION which is from the kernel package.
+	# If IMAGE_VERSION has something, use it, otherwise use REVISION
+	local version="${VENDOR}_${IMAGE_VERSION:-"${REVISION}"}_${BOARD^}_${RELEASE}_${BRANCH}_${IMAGE_INSTALLED_KERNEL_VERSION/-$LINUXFAMILY/}${DESKTOP_ENVIRONMENT:+_$DESKTOP_ENVIRONMENT}"
 	[[ $BUILD_DESKTOP == yes ]] && version=${version}_desktop
 	[[ $BUILD_MINIMAL == yes ]] && version=${version}_minimal
 	[[ $ROOTFS_TYPE == nfs ]] && version=${version}_nfsboot

--- a/lib/functions/logging/logging.sh
+++ b/lib/functions/logging/logging.sh
@@ -28,11 +28,11 @@ function logging_init() {
 	declare -g bright_yellow_color="\e[1;33m" yellow_color="\e[0;33m"
 	declare -g ansi_reset_color="\e[0m"
 	declare -g -i logging_section_counter=0 # -i: integer
-	declare -g tool_color="${gray_color}"   # default to gray... (should be ok on terminals)
+	declare -g tool_color="${normal_color}" # default to normal color.
 
-	# @TODO: more terminals might have a bit... impaired... default themes. correct.
-	if [[ "${TERM}" == "alacritty" ]]; then
-		declare -g tool_color="${normal_color}"
+	# A few terminals, like iTerm2, are known to correctly display "bright black" as gray. Use that if available.
+	if [[ "${ITERM_SHELL_INTEGRATION_INSTALLED:-"No"}" == "Yes" ]]; then
+		declare -g tool_color="${gray_color}"
 	fi
 
 	if [[ "${CI}" == "true" ]]; then # ... but that is too dark for Github Actions

--- a/lib/functions/main/build-packages.sh
+++ b/lib/functions/main/build-packages.sh
@@ -94,16 +94,6 @@ function main_default_build_packages() {
 	overlayfs_wrapper "cleanup"
 	reset_uid_owner "${DEB_STORAGE}"
 
-	# end of kernel-only, so display what was built.
-	if [[ "${KERNEL_ONLY}" != "yes" ]]; then
-		display_alert "Kernel build done" "@host" "target-reached"
-		display_alert "Target directory" "${DEB_STORAGE}/" "info"
-		display_alert "File name" "${CHOSEN_KERNEL}_${REVISION}_${ARCH}.deb" "info"
-	elif [[ "${KERNEL_ONLY}" == "yes" ]]; then
-		display_alert "using legacy option" "KERNEL_ONLY=yes; stopping build mid-packages" "warn"
-		return 0
-	fi
-
 	# Further packages require aggregation (BSPs use aggregated stuff, etc)
 	assert_requires_aggregation # Bombs if aggregation has not run
 

--- a/lib/functions/main/config-interactive.sh
+++ b/lib/functions/main/config-interactive.sh
@@ -8,10 +8,9 @@
 # https://github.com/armbian/build/
 
 function config_possibly_interactive_kernel_board() {
-	# if KERNEL_ONLY, KERNEL_CONFIGURE, BOARD, BRANCH or RELEASE are not set, display selection menu
+	# if KERNEL_CONFIGURE, BOARD, BRANCH or RELEASE are not set, display selection menu
 
 	interactive_config_ask_kernel
-	[[ -z $KERNEL_ONLY ]] && exit_with_error "No option selected: KERNEL_ONLY"
 	[[ -z $KERNEL_CONFIGURE ]] && exit_with_error "No option selected: KERNEL_CONFIGURE"
 
 	interactive_config_ask_board_list # this uses get_list_of_all_buildable_boards
@@ -26,7 +25,8 @@ function config_possibly_interactive_branch_release_desktop_minimal() {
 	[[ ${KERNEL_TARGET} != *${BRANCH}* && ${BRANCH} != "ddk" ]] && exit_with_error "Kernel branch not defined for this board: '${BRANCH}' for '${BOARD}'"
 
 	interactive_config_ask_release
-	[[ -z $RELEASE && ${KERNEL_ONLY} != yes ]] && exit_with_error "No release selected: RELEASE"
+	# If building image or rootfs (and thus "NEEDS_BINFMT=yes"), then RELEASE must be set.
+	[[ -z $RELEASE && ${NEEDS_BINFMT} == yes ]] && exit_with_error "No release selected: RELEASE"
 
 	interactive_config_ask_desktop_build
 	interactive_config_ask_standard_or_minimal

--- a/lib/functions/main/config-prepare.sh
+++ b/lib/functions/main/config-prepare.sh
@@ -167,10 +167,6 @@ function config_pre_main() {
 		SELECTED_CONFIGURATION="cli_minimal"
 	fi
 
-	# @TODO: remove this?
-	[[ ${KERNEL_CONFIGURE} == prebuilt ]] && [[ -z ${REPOSITORY_INSTALL} ]] &&
-		REPOSITORY_INSTALL="u-boot,kernel,bsp,armbian-zsh,armbian-config,armbian-bsp-cli,armbian-firmware${BUILD_DESKTOP:+,armbian-desktop,armbian-bsp-desktop}"
-
 	return 0 # shortcircuit above
 }
 

--- a/lib/functions/main/default-build.sh
+++ b/lib/functions/main/default-build.sh
@@ -11,6 +11,11 @@
 function full_build_packages_rootfs_and_image() {
 	error_if_kernel_only_set
 
+	# Detour, warn the user about KERNEL_CONFIGURE=yes if it is set.
+	if [[ "${KERNEL_CONFIGURE}" == "yes" ]]; then
+		display_alert "KERNEL_CONFIGURE=yes during image build is deprecated." "It still works, but please prefer the new way. First, run './compile.sh BOARD=${BOARD} BRANCH=${BRANCH} kernel-config'; then commit your changes; then build the image as normal. This workflow ensures consistent hashing results." "wrn"
+	fi
+
 	main_default_build_packages # has its own logging sections # requires aggregation
 
 	# build rootfs and image

--- a/lib/functions/main/default-build.sh
+++ b/lib/functions/main/default-build.sh
@@ -9,16 +9,15 @@
 
 # This does NOT run under the logging manager.
 function full_build_packages_rootfs_and_image() {
+	error_if_kernel_only_set
 
 	main_default_build_packages # has its own logging sections # requires aggregation
 
-	# build rootfs, if not only kernel. Again, read "KERNEL_ONLY" as if it was "PACKAGES_ONLY"
-	if [[ "${KERNEL_ONLY}" != "yes" ]]; then
-		display_alert "Building image" "${BOARD}" "target-started"
-		assert_requires_aggregation # Bombs if aggregation has not run
-		build_rootfs_and_image      # old "debootstrap-ng"; has its own logging sections.
-		display_alert "Done building image" "${BOARD}" "target-reached"
-	fi
+	# build rootfs and image
+	display_alert "Building image" "${BOARD}" "target-started"
+	assert_requires_aggregation # Bombs if aggregation has not run
+	build_rootfs_and_image      # old "debootstrap-ng"; has its own logging sections.
+	display_alert "Done building image" "${BOARD}" "target-reached"
 }
 
 function do_with_default_build() {

--- a/lib/functions/rootfs/distro-agnostic.sh
+++ b/lib/functions/rootfs/distro-agnostic.sh
@@ -145,9 +145,9 @@ function install_distribution_agnostic() {
 	#chroot "${SDCARD}" /bin/bash -c "chage -d 0 root"
 
 	# change console welcome text
-	echo -e "${VENDOR} ${REVISION} ${RELEASE^} \\l \n" > "${SDCARD}"/etc/issue
-	echo "${VENDOR} ${REVISION} ${RELEASE^}" > "${SDCARD}"/etc/issue.net
-	sed -i "s/^PRETTY_NAME=.*/PRETTY_NAME=\"${VENDOR} $REVISION ${RELEASE^}\"/" "${SDCARD}"/etc/os-release
+	echo -e "${VENDOR} ${IMAGE_VERSION:-"${REVISION}"} ${RELEASE^} \\l \n" > "${SDCARD}"/etc/issue
+	echo "${VENDOR} ${IMAGE_VERSION:-"${REVISION}"} ${RELEASE^}" > "${SDCARD}"/etc/issue.net
+	sed -i "s/^PRETTY_NAME=.*/PRETTY_NAME=\"${VENDOR} ${IMAGE_VERSION:-"${REVISION}"} ${RELEASE^}\"/" "${SDCARD}"/etc/os-release
 
 	# enable few bash aliases enabled in Ubuntu by default to make it even
 	sed "s/#alias ll='ls -l'/alias ll='ls -l'/" -i "${SDCARD}"/etc/skel/.bashrc

--- a/lib/library-functions.sh
+++ b/lib/library-functions.sh
@@ -528,6 +528,15 @@ source "${SRC}"/lib/functions/general/countdown.sh
 #set -o nounset   ## set -u : exit the script if you try to use an uninitialised variable - one day will be enabled
 set -o errtrace # trace ERR through - enabled
 set -o errexit  ## set -e : exit the script if any statement returns a non-true return value - enabled
+### lib/functions/general/deprecations.sh
+# shellcheck source=lib/functions/general/deprecations.sh
+source "${SRC}"/lib/functions/general/deprecations.sh
+
+# no errors tolerated. invoked before each sourced file to make sure.
+#set -o pipefail  # trace ERR through pipes - will be enabled "soon"
+#set -o nounset   ## set -u : exit the script if you try to use an uninitialised variable - one day will be enabled
+set -o errtrace # trace ERR through - enabled
+set -o errexit  ## set -e : exit the script if any statement returns a non-true return value - enabled
 ### lib/functions/general/downloads.sh
 # shellcheck source=lib/functions/general/downloads.sh
 source "${SRC}"/lib/functions/general/downloads.sh
@@ -1044,6 +1053,7 @@ set -o errexit  ## set -e : exit the script if any statement returns a non-true 
 ### lib/functions/rootfs/trap-rootfs.sh
 # shellcheck source=lib/functions/rootfs/trap-rootfs.sh
 source "${SRC}"/lib/functions/rootfs/trap-rootfs.sh
+
 
 # no errors tolerated. one last time for the win!
 #set -o pipefail  # trace ERR through pipes - will be enabled "soon"

--- a/lib/tools/info.py
+++ b/lib/tools/info.py
@@ -133,7 +133,6 @@ if not os.path.exists(compile_sh_full_path):
 	raise Exception("Can't find compile.sh")
 
 common_compile_params = {
-	"KERNEL_ONLY": "yes",
 	"BUILD_MINIMAL": "no",
 	# "DEB_COMPRESS": "none",
 	# "CLOUD_IMAGE": "yes",


### PR DESCRIPTION
### big batch of all-around fixes (Version prefix, issues)

Sorry for the long PR, but sending each of those separately is pointless, they make sense together and depend on each other for the most part.

👉  The .deb Versions are now prefixed with `$REVISION` (`VERSION` file), which should solve for much crazy when using the Armbian repo. This is still keeping the cache key and .deb `Version: ` tied together, and will need more work down the line. This is a good enough fix for now, since keeping hit ratio across releases is not yet our priority.

- don't use "bright black" ANSI for logging unless we're running under a known-good terminal (eg, iTerm2)
- docker: fix: pass down `OCI_TARGET_BASE` to Docker instance automatically
- kinetic: desktop: browsers appgroup: remove `firefox-esr` -- thanks, Ubuntu :-(
- rockchip-rk3588: `edge`: fix, I messed up move from 6.2-rc7 to 6.2.y :facepalm:
- artifacts (all): require prefixing of `artifact_version` with `artifact_prefix_version` (which is `${REVISION}--`)
- artifact: kernel: introduce `KERNEL_SKIP_MAKEFILE_VERSION=yes` -- for families that patch their kernel's Makefile version; in that case only SHA1 is present in version
- `odroidxu4`/`current`: set `KERNEL_SKIP_MAKEFILE_VERSION=yes`
- rootfs-to-image/distro-agnostic: introduce `IMAGE_VERSION`, can be used to override `VERSION` file (`$REVISION`) just for image filename/issue/os-release
- compress-checksum: don't compress files ending in `.txt`, thanks
- artifact: kernel: use `C999999` for .config hash is `KERNEL_CONFIGURE=yes`; force ignore cache if so
- completely remove any traces of `KERNEL_ONLY` and exit with error if set
- stop the build if `LIB_TAG` is set at all; some users expect it to work while it doesn't
- warn about `KERNEL_CONFIGURE=yes` being deprecated during image build; instructions on how to do it properly
- prepare `ORAS` tooling early, so we don't get spurious failures "only on first build"
- check early (before running any CLI command) for old `LIB_TAG` usage
- kernel-headers: don't try to build `objtool` if not amd64 target

