### PR TITLE
update rk35xx legacy kernel source to github

### DIFF
--- a/config/sources/families/rk35xx.conf
+++ b/config/sources/families/rk35xx.conf
@@ -19,8 +19,8 @@ case $BRANCH in
 		UBOOT_COMPILER="aarch64-linux-gnu-"
 		UBOOT_USE_GCC='< 8.0'
 		BOOTDIR='u-boot-rockchip64'
-		KERNELSOURCE='https://gitlab.com/rk3588_linux/rk/kernel.git'
-		KERNELBRANCH='tag:linux-5.10-gen-rkr3.6'
+		KERNELSOURCE='https://github.com/armbian/linux-rockchip.git'
+		KERNELBRANCH='branch:rockchip-5.10'
 		export KERNEL_MAJOR_MINOR="5.10" # Major and minor versions of this kernel.
 		KERNELDIR='linux-rockchip64'
 		KERNELPATCHDIR='rk35xx-legacy'


### PR DESCRIPTION
# Description

We already have mantained a [rockchip-5.10](https://github.com/armbian/linux-rockchip.git) kernel based on rockchip's sdk rkr3.6. No need to use that read only gitlab sdk repo.


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] rock3a kernel build sucess

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
