### PR TITLE
kernel: postinst: use `--nofsroot` option to `findmnt` when finding `/boot`'s filesystem type

### DIFF
--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -245,7 +245,7 @@ function kernel_package_callback_linux_image() {
 			if [[ "${script}" == "preinst" ]]; then
 				cat <<- HOOK_FOR_REMOVE_VFAT_BOOT_FILES
 					check_boot_dev (){
-						boot_partition=\$(findmnt -n -o SOURCE /boot)
+						boot_partition=\$(findmnt --nofsroot -n -o SOURCE /boot)
 						bootfstype=\$(blkid -s TYPE -o value \$boot_partition)
 						if [ "\$bootfstype" = "vfat" ]; then
 							rm -f /boot/System.map* /boot/config* /boot/vmlinuz* /boot/$image_name /boot/uImage


### PR DESCRIPTION
#### kernel: postinst: use `--nofsroot` option to `findmnt` when finding `/boot`'s filesystem type

- otherwise we might get `/dev/mmcblk2p1[/boot]` when `/boot` is bind-mounted
- `--nofsroot: don't print [/dir] for bind or btrfs mounts`
