### PR TITLE
Revert "docker: fix: pass down `OCI_TARGET_BASE` to Docker instance automatically

### DIFF
--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -449,7 +449,6 @@ function docker_cli_prepare_launch() {
 		# - bind-mount the Docker config file (if it exists)
 		if [[ -n "${OCI_TARGET_BASE}" ]]; then
 			display_alert "Detected" "OCI_TARGET_BASE: '${OCI_TARGET_BASE}'" "debug"
-			DOCKER_ARGS+=("--env" "OCI_TARGET_BASE=${OCI_TARGET_BASE}")
 
 			# Mount the Docker config file (if it exists)
 			local docker_config_file_host="${HOME}/.docker/config.json"


### PR DESCRIPTION
# Description

This reverts commit 99313504830558bf7524a92899939887f9ed8f56.

After this images compilation stop working under Docker / Github Actions. ORAS is looking for cache in the repository where we are running it from and ignoring definitions in `lib/functions/artifacts/artifact-kernel.sh`

Wrong:
Error: ghcr.io/armbian/**os**/kernel-rk3568-odroid-edge:23.05.0-trunk--6.2.7-Safe5-D2a58-P0000-Cc2daHfe66-Bc6dc: not found

Correct:
Error: ghcr.io/armbian/**cache-kernel**/kernel-rk3568-odroid-edge:23.05.0-trunk--6.2.7-Safe5-D2a58-P0000-Cc2daHfe66-Bc6dc: not found

Closing https://github.com/armbian/build/issues/4959

Jira reference number [AR-1617]

# How Has This Been Tested?

- [x] Run image compilation by attacking to the commit

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1617]: https://armbian.atlassian.net/browse/AR-1617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ