### PR TITLE
Add switch to force artefacts download

### DIFF
--- a/lib/functions/cli/cli-artifact.sh
+++ b/lib/functions/cli/cli-artifact.sh
@@ -43,6 +43,10 @@ function cli_artifact_run() {
 		ignore_local_cache="yes"
 		deploy_to_remote="yes"
 
+		if [[ "${FORCE_ARTIFACTS_DOWNLOAD}" == "yes" ]]; then
+			skip_unpack_if_found_in_caches="no"
+		fi
+
 		# Pass ARTIFACT_USE_CACHE=yes to actually use the cache versions, but don't deploy to remote.
 		# @TODO this is confusing. each op should be individually controlled...
 		# what we want is:


### PR DESCRIPTION
# Description

For populating repository we need to obtain all artefacts that are in OCI_TARGET_BASE

# How Has This Been Tested?

- [x] Test run in development branch

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
