### PR TITLE
Move Jetson and Pinebook Pro board tweaks to board conf file

### DIFF
--- a/config/boards/jetson-nano.conf
+++ b/config/boards/jetson-nano.conf
@@ -9,3 +9,23 @@ BOOT_FDT_FILE="nvidia/tegra210-p3450-0000.dtb"
 SRC_EXTLINUX="yes"
 SRC_CMDLINE="console=ttyS0,115200n8 console=tty0"
 
+function post_family_tweaks__Jetson-nano() {
+    display_alert "$BOARD" "Installing bsp firmware and fixups" "info"
+
+    install -m 755 $SRC/packages/blobs/jetson/jetson.sh $SDCARD/etc/initramfs-tools/hooks/jetson.sh
+	if [[ $BRANCH == legacy ]]; then
+		install -m 755 $SRC/packages/blobs/jetson/tegra21x_xusb_firmware $SDCARD/lib/firmware/tegra21x_xusb_firmware
+		install -m 755 $SRC/packages/blobs/jetson/asound.conf.tegrahda $SDCARD/etc/asound.conf.tegrahda
+		install -m 755 $SRC/packages/blobs/jetson/asound.conf.tegrahda $SDCARD/etc/asound.conf
+		install -m 755 $SRC/packages/blobs/jetson/asound.conf.tegrasndt210ref $SDCARD/etc/asound.conf.tegrasndt210ref
+		install -m 755 $SRC/packages/blobs/jetson/tegra-hda.conf $SDCARD/usr/share/alsa/cards/tegra-hda.conf
+		install -m 755 $SRC/packages/blobs/jetson/tegra-snd-t210r.conf $SDCARD/usr/share/alsa/cards/tegra-snd-t210r.conf
+		sed -e 's/exit 0//g' -i $SDCARD/etc/rc.local
+		echo "su -c 'echo 255 > /sys/devices/pwm-fan/target_pwm'" >> $SDCARD/etc/rc.local
+		echo "exit 0" >> $SDCARD/etc/rc.local
+	else
+		cp -R $SRC/packages/blobs/jetson/firmware/* $SDCARD/lib/firmware/
+	fi
+
+	return 0
+}

--- a/config/boards/pinebook-pro.conf
+++ b/config/boards/pinebook-pro.conf
@@ -10,3 +10,31 @@ BOOT_SCENARIO="blobless"
 ASOUND_STATE="asound.state.pinebook-pro"
 BOOTBRANCH_BOARD="tag:v2022.04"
 BOOTPATCHDIR="u-boot-rockchip64-v2022.04"
+
+function post_family_tweaks__PBP() {
+    display_alert "$BOARD" "Installing board tweaks" "info"
+
+	chroot $SDCARD /bin/bash -c "echo SuspendState=freeze >> /etc/systemd/sleep.conf"
+	chroot $SDCARD /bin/bash -c "echo HandlePowerKey=ignore >> /etc/systemd/login.d"
+
+	return 0
+}
+
+function post_family_tweaks_bsp__PBP_BSP() {
+    display_alert "Installing BSP firmware and fixups"
+
+	# special keys
+	mkdir -p "${destination}"/etc/skel/.config/xfce4/xfconf/xfce-perchannel-xml/
+	cp $SRC/packages/bsp/pinebook-pro/pointers.xml "${destination}"/etc/skel/.config/xfce4/xfconf/xfce-perchannel-xml/
+
+	# touchpad and keyboard tweaks
+	mkdir -p "${destination}"/etc/X11/xorg.conf.d/
+	# from https://github.com/ayufan-rock64/linux-package/tree/master/root-pinebookpro
+	cp "${SRC}"/packages/bsp/pinebook-pro/40-pinebookpro-touchpad.conf "${destination}"/etc/X11/xorg.conf.d/
+
+	# keyboard hwdb
+	mkdir -p "${destination}"/etc/udev/hwdb.d/
+	cp "${SRC}"/packages/bsp/pinebook-pro/10-usb-kbd.hwdb "${destination}"/etc/udev/hwdb.d/
+
+	return 0
+}

--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -334,12 +334,6 @@ family_tweaks() {
 
 	fi
 
-	if [[ $BOARD == pinebook-pro ]]; then
-
-		chroot $SDCARD /bin/bash -c "echo SuspendState=freeze >> /etc/systemd/sleep.conf"
-		chroot $SDCARD /bin/bash -c "echo HandlePowerKey=ignore >> /etc/systemd/login.d"
-	fi
-
 	if [[ $BOARD == station* ]]; then
 
 		cp -R $SRC/packages/blobs/rtl8723bt_fw/* $SDCARD/lib/firmware/rtl_bt/
@@ -488,22 +482,6 @@ family_tweaks_bsp() {
 		# Optional board dtbo selection script
 		mkdir -p $destination/usr/local/bin
 		install -m 755 $SRC/packages/bsp/rk3318/rk3318-config $destination/usr/sbin
-	fi
-
-	if [[ $BOARD == pinebook-pro ]]; then
-
-		# special keys
-		mkdir -p "${destination}"/etc/skel/.config/xfce4/xfconf/xfce-perchannel-xml/
-		cp $SRC/packages/bsp/pinebook-pro/pointers.xml "${destination}"/etc/skel/.config/xfce4/xfconf/xfce-perchannel-xml/
-
-		# touchpad and keyboard tweaks
-		mkdir -p "${destination}"/etc/X11/xorg.conf.d/
-		# from https://github.com/ayufan-rock64/linux-package/tree/master/root-pinebookpro
-		cp "${SRC}"/packages/bsp/pinebook-pro/40-pinebookpro-touchpad.conf "${destination}"/etc/X11/xorg.conf.d/
-
-		# keyboard hwdb
-		mkdir -p "${destination}"/etc/udev/hwdb.d/
-		cp "${SRC}"/packages/bsp/pinebook-pro/10-usb-kbd.hwdb "${destination}"/etc/udev/hwdb.d/
 	fi
 
 	# Graphics and media

--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -364,23 +364,6 @@ family_tweaks() {
 		cp -R $SRC/packages/blobs/station/firmware/* $SDCARD/lib/firmware/
 
 	fi
-
-	if [[ $BOARD == jetson-nano ]]; then
-		install -m 755 $SRC/packages/blobs/jetson/jetson.sh $SDCARD/etc/initramfs-tools/hooks/jetson.sh
-		if [[ $BRANCH == legacy ]]; then
-			install -m 755 $SRC/packages/blobs/jetson/tegra21x_xusb_firmware $SDCARD/lib/firmware/tegra21x_xusb_firmware
-			install -m 755 $SRC/packages/blobs/jetson/asound.conf.tegrahda $SDCARD/etc/asound.conf.tegrahda
-			install -m 755 $SRC/packages/blobs/jetson/asound.conf.tegrahda $SDCARD/etc/asound.conf
-			install -m 755 $SRC/packages/blobs/jetson/asound.conf.tegrasndt210ref $SDCARD/etc/asound.conf.tegrasndt210ref
-			install -m 755 $SRC/packages/blobs/jetson/tegra-hda.conf $SDCARD/usr/share/alsa/cards/tegra-hda.conf
-			install -m 755 $SRC/packages/blobs/jetson/tegra-snd-t210r.conf $SDCARD/usr/share/alsa/cards/tegra-snd-t210r.conf
-			sed -e 's/exit 0//g' -i $SDCARD/etc/rc.local
-			echo "su -c 'echo 255 > /sys/devices/pwm-fan/target_pwm'" >> $SDCARD/etc/rc.local
-			echo "exit 0" >> $SDCARD/etc/rc.local
-		else
-			cp -R $SRC/packages/blobs/jetson/firmware/* $SDCARD/lib/firmware/
-		fi
-	fi
 }
 
 family_tweaks_bsp() {


### PR DESCRIPTION
# Description

Use armbian new extensions/hooks to place the Nvidia Jetson BSP family tweaks in the Nvidia Jetson board configuration file, a more logical placement than the existing "Rockchip64"
Likewise, begin migration of board-specific tweaks to their configuration files, cleaning up the mess in the family config

# How Has This Been Tested?

Please describe the tests 

- [ ] Build shows application of extension
- [ ] Boot of board shows files where expected

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
