### PR TITLE
aml-s9xx-box: Move board specific bsp file handling to the board config

### DIFF
--- a/config/boards/aml-s9xx-box.tvb
+++ b/config/boards/aml-s9xx-box.tvb
@@ -10,3 +10,13 @@ FULL_DESKTOP="yes"
 ASOUND_STATE="asound.state.mesongx"
 BOOT_LOGO="desktop"
 SRC_CMDLINE='rootflags=data=writeback console=ttyAML0,115200n8 console=tty0'
+
+
+function post_family_tweaks__config_aml-s9xx-box_bsp() {
+
+    display_alert "$BOARD" "Installing bsp files" "info"
+
+    cp -r $SRC/packages/bsp/aml-s9xx-box/boot $SDCARD
+    install -m 755 $SRC/packages/bsp/aml-s9xx-box/root/install-aml.sh $SDCARD/root
+    install -m 644 $SRC/packages/bsp/aml-s9xx-box/root/fstab.template $SDCARD/root
+}

--- a/config/sources/families/meson-gxl.conf
+++ b/config/sources/families/meson-gxl.conf
@@ -23,12 +23,9 @@ if [[ $BOARD = khadas-vim2 ]]; then
 fi
 
 family_tweaks() {
-	if [[ $BOARD = aml-s9xx-box ]]; then
-		cp -r $SRC/packages/bsp/aml-s9xx-box/boot $SDCARD
-		install -m 755 $SRC/packages/bsp/aml-s9xx-box/root/install-aml.sh $SDCARD/root
-		install -m 644 $SRC/packages/bsp/aml-s9xx-box/root/fstab.template $SDCARD/root
-	fi
+	:
 }
+
 
 uboot_custom_postprocess() {
 	if [[ $BOARD == lepotato ]]; then


### PR DESCRIPTION
aml-s9xx-box: Move board specific bsp file handling to the board
config file from from the family config file

 Changes to be committed:
	modified:   config/boards/aml-s9xx-box.tvb
	modified:   config/sources/families/meson-gxl.conf


- [x] Built and verified files in aml-s9xx-box build
