### PR TITLE
Cleanup: Removed two dead links (softlinks whose target doesn't exist)

### DIFF
--- a/config/desktop/buster/appgroups/programming/sources
+++ b/config/desktop/buster/appgroups/programming/sources
@@ -1,1 +1,0 @@
-../../../jammy/appgroups/programming/sources

--- a/patch/kernel/archive/sunxi-5.11/sunxi-5.12
+++ b/patch/kernel/archive/sunxi-5.11/sunxi-5.12
@@ -1,1 +1,0 @@
-archive/sunxi-5.12/


### PR DESCRIPTION
 Changes to be committed:
	deleted:    config/desktop/buster/appgroups/programming/sources
	deleted:    patch/kernel/archive/sunxi-5.11/sunxi-5.12

# Description

Found two softlinks whose target doesn't exist.  I'm pretty sure both of these shouldn't exist.

- [x] Built buster desktop image
