### PR TITLE
[ Rockchip64 ] Move board specific configs

### DIFF
--- a/config/boards/clockworkpi-a06.conf
+++ b/config/boards/clockworkpi-a06.conf
@@ -7,3 +7,39 @@ FULL_DESKTOP="yes"
 BOOT_LOGO="no"
 BOOTBRANCH_BOARD="tag:v2022.04"
 BOOTPATCHDIR="u-boot-rockchip64-v2022.04"
+
+function post_family_tweaks_bsp__clockworkpi-a06() {
+    display_alert "Installing BSP firmware and fixups"
+
+	# rotate screen & disable dpms
+	mkdir -p "$destination"/etc/X11/xorg.conf.d
+	cat <<- EOF > "$destination"/etc/X11/xorg.conf.d/10-monitor.conf
+		# set monitor
+		Section "Monitor"
+		        Identifier "DSI-1"
+		        Option "Rotate" "right"
+		        Option "DPMS" "false"
+		EndSection
+
+		Section "ServerLayout"
+		        Identifier "ServerLayout0"
+		        Option "BlankTime"  "0"
+		        Option "StandbyTime" "0"
+		        Option "SuspendTime" "0"
+		        Option "OffTime" "0"
+		EndSection
+	EOF
+	# fan support
+	install -Dm644 $SRC/packages/bsp/clockworkpi-a06/temp_fan_daemon_a06.py $destination/usr/share/clockworkpi-a06-fan-daemon/bin/temp_fan_daemon_a06.py
+	cp $SRC/packages/bsp/clockworkpi-a06/clockworkpi-a06-fan-daemon.service $destination/lib/systemd/system/
+
+	# alsa-ucm-conf profile for DevTerm A06
+	mkdir -p $destination/usr/share/alsa/ucm2/Rockchip/es8388
+	install -Dm644 $SRC/packages/bsp/clockworkpi-a06/es8388.conf $destination/usr/share/alsa/ucm2/Rockchip/es8388/es8388.conf
+	install -Dm644 $SRC/packages/bsp/clockworkpi-a06/HiFi.conf $destination/usr/share/alsa/ucm2/Rockchip/es8388/HiFi.conf
+	mkdir -p $destination/usr/share/alsa/ucm2/conf.d/simple-card
+	ln -sfv /usr/share/alsa/ucm2/Rockchip/es8388/es8388.conf \
+		$destination/usr/share/alsa/ucm2/conf.d/simple-card/rockchip,es8388-codec.conf
+
+	return 0
+}

--- a/config/boards/helios64.csc
+++ b/config/boards/helios64.csc
@@ -10,3 +10,49 @@ FULL_DESKTOP="yes"
 PACKAGE_LIST_BOARD="mdadm i2c-tools fancontrol"
 PACKAGE_LIST_BOARD_REMOVE="fake-hwclock"
 CPUMAX="1800000"
+
+function post_family_tweaks__helios64_enable_heartbeat() {
+    display_alert "$BOARD" "Installing board tweaks" "info"
+
+	chroot $SDCARD /bin/bash -c "systemctl --no-reload enable helios64-heartbeat-led.service >/dev/null 2>&1"
+
+	return 0
+}
+
+function post_family_tweaks_bsp__helios64() {
+    display_alert "Installing BSP firmware and fixups"
+
+	mkdir -p $destination/etc/udev/rules.d/
+	mkdir -p $destination/etc/systemd/system/fancontrol.service.d/
+	mkdir -p $destination/lib/systemd/system/
+	mkdir -p $destination/lib/systemd/system-shutdown/
+	cp $SRC/packages/bsp/helios64/50-usb-realtek-net.rules $destination/etc/udev/rules.d/
+	cp $SRC/packages/bsp/helios64/70-keep-usb-lan-as-eth1.rules $destination/etc/udev/rules.d/
+	cp $SRC/packages/bsp/helios64/90-helios64-ups.rules $destination/etc/udev/rules.d/
+	cp $SRC/packages/bsp/helios64/asound.conf $destination/etc/
+	install -m 755 $SRC/packages/bsp/helios64/disable_auto_poweron $destination/lib/systemd/system-shutdown/
+
+	### Fancontrol tweaks
+	# copy hwmon rules to fix device mapping
+	# changed to only use one file regardless of branch
+	install -m 644 $SRC/packages/bsp/helios64/90-helios64-hwmon.rules $destination/etc/udev/rules.d/
+
+	install -m 644 $SRC/packages/bsp/helios64/fancontrol.service.pid-override $destination/etc/systemd/system/fancontrol.service.d/pid.conf
+
+	# copy fancontrol config
+	install -m 644 $SRC/packages/bsp/helios64/fancontrol.conf $destination/etc/fancontrol
+
+	# LED tweak
+	if [[ $BRANCH == legacy ]]; then
+		install -m 644 $SRC/packages/bsp/helios64/helios64-heartbeat-led-legacy.service $destination/etc/systemd/system/helios64-heartbeat-led.service
+	else
+		install -m 644 $SRC/packages/bsp/helios64/helios64-heartbeat-led.service $destination/etc/systemd/system/
+	fi
+
+	# UPS service
+	cp $SRC/packages/bsp/helios64/helios64-ups.service $destination/lib/systemd/system/
+	cp $SRC/packages/bsp/helios64/helios64-ups.timer $destination/lib/systemd/system/
+	install -m 755 $SRC/packages/bsp/helios64/helios64-ups.sh $destination/usr/bin/helios64-ups.sh
+
+	return 0
+}

--- a/config/boards/khadas-edge2.wip
+++ b/config/boards/khadas-edge2.wip
@@ -10,3 +10,11 @@ BOOT_FDT_FILE="rockchip/rk3588s-khadas-edge2.dtb"
 SRC_EXTLINUX="yes"
 SRC_CMDLINE="console=ttyS02,1500000 console=tty0"
 IMAGE_PARTITION_TABLE="gpt"
+
+function post_family_tweaks__khadas-edge-2-firmware() {
+    display_alert "$BOARD" "Installing board tweaks" "info"
+
+	cp -R $SRC/packages/blobs/station/firmware/* $SDCARD/lib/firmware/
+
+	return 0
+}

--- a/config/boards/nanopi-r2c.conf
+++ b/config/boards/nanopi-r2c.conf
@@ -9,3 +9,13 @@ MODULES_BLACKLIST="rockchipdrm analogix_dp dw_mipi_dsi dw_hdmi gpu_sched lima ha
 SERIALCON="ttyS2:1500000,ttyGS0"
 HAS_VIDEO_OUTPUT="no"
 BOOT_FDT_FILE="rockchip/rk3328-nanopi-r2-rev06.dtb"
+
+function post_family_tweaks__nanopi-r2c_rename_USB_LAN() {
+    display_alert "$BOARD" "Installing board tweaks" "info"
+
+	# rename USB based network to lan0
+	mkdir -p $SDCARD/etc/udev/rules.d/
+	echo 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="r8152", KERNEL=="eth1", NAME="lan0"' > $SDCARD/etc/udev/rules.d/70-rename-lan.rules
+
+	return 0
+}

--- a/config/boards/nanopi-r2s.conf
+++ b/config/boards/nanopi-r2s.conf
@@ -9,3 +9,13 @@ MODULES_BLACKLIST="rockchipdrm analogix_dp dw_mipi_dsi dw_hdmi gpu_sched lima ha
 SERIALCON="ttyS2:1500000,ttyGS0"
 HAS_VIDEO_OUTPUT="no"
 BOOT_FDT_FILE="rockchip/rk3328-nanopi-r2-rev00.dtb"
+
+function post_family_tweaks__nanopi-r2s_rename_USB_LAN() {
+    display_alert "$BOARD" "Installing board tweaks" "info"
+
+	# rename USB based network to lan0
+	mkdir -p $SDCARD/etc/udev/rules.d/
+	echo 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="r8152", KERNEL=="eth1", NAME="lan0"' > $SDCARD/etc/udev/rules.d/70-rename-lan.rules
+
+	return 0
+}

--- a/config/boards/nanopim4.conf
+++ b/config/boards/nanopim4.conf
@@ -8,3 +8,22 @@ ASOUND_STATE="asound.state.rt5651"
 BOOT_LOGO="desktop"
 BOOTBRANCH_BOARD="tag:v2022.04"
 BOOTPATCHDIR="u-boot-rockchip64-v2022.04"
+
+function post_family_tweaks__m4() {
+    display_alert "$BOARD" "Installing board tweaks" "info"
+
+	# enable fan support
+	chroot $SDCARD /bin/bash -c "systemctl --no-reload enable nanopim4-pwm-fan.service >/dev/null 2>&1"
+
+	return 0
+}
+
+function post_family_tweaks_bsp__M4() {
+    display_alert "Installing BSP firmware and fixups"
+
+	# Fan support
+	cp $SRC/packages/bsp/nanopim4/nanopim4-pwm-fan.service $destination/lib/systemd/system/
+	install -m 755 $SRC/packages/bsp/nanopim4/nanopim4-pwm-fan.sh $destination/usr/bin/nanopim4-pwm-fan.sh
+
+	return 0
+}

--- a/config/boards/nanopim4v2.conf
+++ b/config/boards/nanopim4v2.conf
@@ -6,3 +6,21 @@ KERNEL_TARGET="legacy,current,edge"
 FULL_DESKTOP="yes"
 ASOUND_STATE="asound.state.rt5651"
 BOOT_LOGO="desktop"
+
+function post_family_tweaks__m4v2() {
+    display_alert "$BOARD" "Installing board tweaks" "info"
+
+	# enable fan support
+	chroot $SDCARD /bin/bash -c "systemctl --no-reload enable nanopim4-pwm-fan.service >/dev/null 2>&1"
+
+	return 0
+}
+function post_family_tweaks_bsp__M4V2() {
+    display_alert "Installing BSP firmware and fixups"
+
+	# Fan support
+	cp $SRC/packages/bsp/nanopim4/nanopim4-pwm-fan.service $destination/lib/systemd/system/
+	install -m 755 $SRC/packages/bsp/nanopim4/nanopim4-pwm-fan.sh $destination/usr/bin/nanopim4-pwm-fan.sh
+
+	return 0
+}

--- a/config/boards/orangepi-r1plus.conf
+++ b/config/boards/orangepi-r1plus.conf
@@ -9,3 +9,13 @@ MODULES_BLACKLIST="rockchipdrm analogix_dp dw_mipi_dsi dw_hdmi gpu_sched lima ha
 SERIALCON="ttyS2:1500000,ttyGS0"
 HAS_VIDEO_OUTPUT="no"
 BOOT_FDT_FILE="rockchip/rk3328-orangepi-r1-plus.dtb"
+
+function post_family_tweaks__opi-r1plus_rename_USB_LAN() {
+    display_alert "$BOARD" "Installing board tweaks" "info"
+
+	# rename USB based network to lan0
+	mkdir -p $SDCARD/etc/udev/rules.d/
+	echo 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="r8152", KERNEL=="eth1", NAME="lan0"' > $SDCARD/etc/udev/rules.d/70-rename-lan.rules
+
+	return 0
+}

--- a/config/boards/orangepi4-lts.conf
+++ b/config/boards/orangepi4-lts.conf
@@ -13,3 +13,14 @@ ASOUND_STATE="asound.state.rk3399"
 BOOT_LOGO="desktop"
 BOOTBRANCH_BOARD="tag:v2022.04"
 BOOTPATCHDIR="u-boot-rockchip64-v2022.04"
+
+function post_family_tweaks_bsp__OPi4lts() {
+    display_alert "Installing BSP firmware and fixups"
+
+	# Bluetooth on orangepi 4 LTS board is handled by a Spreadtrum (sprd) chip and requires
+	# a custom hciattach_opi binary, plus a systemd service to run it at boot time
+	install -m 755 $SRC/packages/bsp/rk3399/hciattach_opi $destination/usr/bin
+	cp $SRC/packages/bsp/rk3399/sprd-bluetooth.service $destination/lib/systemd/system/
+
+	return 0
+}

--- a/config/boards/orangepi5.conf
+++ b/config/boards/orangepi5.conf
@@ -14,6 +14,15 @@ IMAGE_PARTITION_TABLE="gpt"
 SKIP_BOOTSPLASH="yes" # Skip boot splash patch, conflicts with CONFIG_VT=yes
 BOOTFS_TYPE="fat"
 
+function post_family_tweaks__orangepi5_enable_usb2_service() {
+    display_alert "$BOARD" "Installing board tweaks" "info"
+
+	# enable usb2 init service
+	chroot $SDCARD /bin/bash -c "systemctl --no-reload enable orangepi5-usb2-init.service >/dev/null 2>&1"
+
+	return 0
+}
+
 # Override family config for this board; let's avoid conditionals in family config.
 function post_family_config__orangepi5_use_vendor_uboot() {
 	BOOTSOURCE='https://github.com/orangepi-xunlong/u-boot-orangepi.git'

--- a/config/boards/rk3318-box.tvb
+++ b/config/boards/rk3318-box.tvb
@@ -8,3 +8,13 @@ MODULES_BLACKLIST="analogix_dp bcmdhd"
 BOOT_SCENARIO="tpl-blob-atf-mainline"
 DDR_BLOB="rk33/rk3318_ddr_666Mhz_v1.16.bin"
 BOOT_SOC="rk3328"
+
+function post_family_tweaks_bsp__rk3318-box() {
+    display_alert "Installing BSP firmware and fixups"
+
+	# Optional board dtbo selection script
+	mkdir -p $destination/usr/local/bin
+	install -m 755 $SRC/packages/bsp/rk3318/rk3318-config $destination/usr/sbin
+
+	return 0
+}

--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -296,16 +296,6 @@ family_tweaks() {
 
 		chroot $SDCARD /bin/bash -c "systemctl --no-reload enable z28pro-bluetooth.service >/dev/null 2>&1"
 
-	elif [[ $BOARD == nanopi-r2s || $BOARD == nanopi-r2c || $BOARD == orangepi-r1plus ]]; then
-
-		# rename USB based network to lan0
-		mkdir -p $SDCARD/etc/udev/rules.d/
-		echo 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="r8152", KERNEL=="eth1", NAME="lan0"' > $SDCARD/etc/udev/rules.d/70-rename-lan.rules
-
-	elif [[ $BOARD == helios64 ]]; then
-
-		chroot $SDCARD /bin/bash -c "systemctl --no-reload enable helios64-heartbeat-led.service >/dev/null 2>&1"
-
 	elif [[ -f $SDCARD/lib/systemd/system/rk3399-bluetooth.service ]]; then
 
 		# install and enable Bluetooth
@@ -317,20 +307,6 @@ family_tweaks() {
 		# install and enable Bluetooth
 		chroot $SDCARD /bin/bash -c "apt-get -y -qq install rfkill bluetooth bluez bluez-tools"
 		chroot $SDCARD /bin/bash -c "systemctl --no-reload enable sprd-bluetooth.service >/dev/null 2>&1"
-
-	fi
-
-	if [[ -f $SDCARD/lib/systemd/system/orangepi5-usb2-init.service ]]; then
-
-		# enable usb2 init service
-		chroot $SDCARD /bin/bash -c "systemctl --no-reload enable orangepi5-usb2-init.service >/dev/null 2>&1"
-
-	fi
-
-	if [[ $BOARD == nanopim4* ]]; then
-
-		# enable fan support
-		chroot $SDCARD /bin/bash -c "systemctl --no-reload enable nanopim4-pwm-fan.service >/dev/null 2>&1"
 
 	fi
 
@@ -351,13 +327,6 @@ family_tweaks() {
 			chroot $SDCARD /bin/bash -c "systemctl --no-reload enable firefly-fan.service >/dev/null 2>&1"
 		fi
 
-	fi
-
-	if [[ $BOARD == khadas-edge2 ]]; then
-
-		cp -R $SRC/packages/blobs/station/firmware/* $SDCARD/lib/firmware/
-
-	fi
 }
 
 family_tweaks_bsp() {
@@ -371,38 +340,6 @@ family_tweaks_bsp() {
 			         Driver "fbdev"
 			EndSection
 		EOF
-	fi
-
-	if [[ $BOARD == clockworkpi-a06 ]]; then
-		# rotate screen & disable dpms
-		mkdir -p "$destination"/etc/X11/xorg.conf.d
-		cat <<- EOF > "$destination"/etc/X11/xorg.conf.d/10-monitor.conf
-			# set monitor
-			Section "Monitor"
-			        Identifier "DSI-1"
-			        Option "Rotate" "right"
-			        Option "DPMS" "false"
-			EndSection
-
-			Section "ServerLayout"
-			        Identifier "ServerLayout0"
-			        Option "BlankTime"  "0"
-			        Option "StandbyTime" "0"
-			        Option "SuspendTime" "0"
-			        Option "OffTime" "0"
-			EndSection
-		EOF
-		# fan support
-		install -Dm644 $SRC/packages/bsp/clockworkpi-a06/temp_fan_daemon_a06.py $destination/usr/share/clockworkpi-a06-fan-daemon/bin/temp_fan_daemon_a06.py
-		cp $SRC/packages/bsp/clockworkpi-a06/clockworkpi-a06-fan-daemon.service $destination/lib/systemd/system/
-
-		# alsa-ucm-conf profile for DevTerm A06
-		mkdir -p $destination/usr/share/alsa/ucm2/Rockchip/es8388
-		install -Dm644 $SRC/packages/bsp/clockworkpi-a06/es8388.conf $destination/usr/share/alsa/ucm2/Rockchip/es8388/es8388.conf
-		install -Dm644 $SRC/packages/bsp/clockworkpi-a06/HiFi.conf $destination/usr/share/alsa/ucm2/Rockchip/es8388/HiFi.conf
-		mkdir -p $destination/usr/share/alsa/ucm2/conf.d/simple-card
-		ln -sfv /usr/share/alsa/ucm2/Rockchip/es8388/es8388.conf \
-			$destination/usr/share/alsa/ucm2/conf.d/simple-card/rockchip,es8388-codec.conf
 	fi
 
 	if [[ $BOARD == z28pro ]]; then
@@ -423,65 +360,6 @@ family_tweaks_bsp() {
 		if [[ $BOARD == nanop*4* || $BOARD == firefly* || $BOARD == orangepi-rk3399 ]]; then
 			sed -i s%BCM4345C5%BCM4356A2%g $destination/lib/systemd/system/rk3399-bluetooth.service
 		fi
-	fi
-
-	if [[ $BOARD == orangepi4-lts ]]; then
-
-		# Bluetooth on orangepi 4 LTS board is handled by a Spreadtrum (sprd) chip and requires
-		# a custom hciattach_opi binary, plus a systemd service to run it at boot time
-		install -m 755 $SRC/packages/bsp/rk3399/hciattach_opi $destination/usr/bin
-		cp $SRC/packages/bsp/rk3399/sprd-bluetooth.service $destination/lib/systemd/system/
-
-	fi
-
-	if [[ $BOARD == nanopim4* ]]; then
-
-		# Fan support
-		cp $SRC/packages/bsp/nanopim4/nanopim4-pwm-fan.service $destination/lib/systemd/system/
-		install -m 755 $SRC/packages/bsp/nanopim4/nanopim4-pwm-fan.sh $destination/usr/bin/nanopim4-pwm-fan.sh
-
-	fi
-
-	if [[ $BOARD == helios64 ]]; then
-
-		mkdir -p $destination/etc/udev/rules.d/
-		mkdir -p $destination/etc/systemd/system/fancontrol.service.d/
-		mkdir -p $destination/lib/systemd/system/
-		mkdir -p $destination/lib/systemd/system-shutdown/
-		cp $SRC/packages/bsp/helios64/50-usb-realtek-net.rules $destination/etc/udev/rules.d/
-		cp $SRC/packages/bsp/helios64/70-keep-usb-lan-as-eth1.rules $destination/etc/udev/rules.d/
-		cp $SRC/packages/bsp/helios64/90-helios64-ups.rules $destination/etc/udev/rules.d/
-		cp $SRC/packages/bsp/helios64/asound.conf $destination/etc/
-		install -m 755 $SRC/packages/bsp/helios64/disable_auto_poweron $destination/lib/systemd/system-shutdown/
-
-		### Fancontrol tweaks
-		# copy hwmon rules to fix device mapping
-		# changed to only use one file regardless of branch
-		install -m 644 $SRC/packages/bsp/helios64/90-helios64-hwmon.rules $destination/etc/udev/rules.d/
-
-		install -m 644 $SRC/packages/bsp/helios64/fancontrol.service.pid-override $destination/etc/systemd/system/fancontrol.service.d/pid.conf
-
-		# copy fancontrol config
-		install -m 644 $SRC/packages/bsp/helios64/fancontrol.conf $destination/etc/fancontrol
-
-		# LED tweak
-		if [[ $BRANCH == legacy ]]; then
-			install -m 644 $SRC/packages/bsp/helios64/helios64-heartbeat-led-legacy.service $destination/etc/systemd/system/helios64-heartbeat-led.service
-		else
-			install -m 644 $SRC/packages/bsp/helios64/helios64-heartbeat-led.service $destination/etc/systemd/system/
-		fi
-
-		# UPS service
-		cp $SRC/packages/bsp/helios64/helios64-ups.service $destination/lib/systemd/system/
-		cp $SRC/packages/bsp/helios64/helios64-ups.timer $destination/lib/systemd/system/
-		install -m 755 $SRC/packages/bsp/helios64/helios64-ups.sh $destination/usr/bin/helios64-ups.sh
-
-	fi
-
-	if [[ $BOARD == rk3318-box ]]; then
-		# Optional board dtbo selection script
-		mkdir -p $destination/usr/local/bin
-		install -m 755 $SRC/packages/bsp/rk3318/rk3318-config $destination/usr/sbin
 	fi
 
 	# Graphics and media


### PR DESCRIPTION
# Description
Move board-specific configs from the rockchip64-common.inc file to the individual board config files using the new extension/hook system.  This removes the clutter and traceability issues of all the if ... fi constructs in the family include file, and improves the separation of individual board nuances from the build system at large.

# How Has This Been Tested?

boards available to me have been tested.  requesting help testing all (second set of eyes is good)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
