### PR TITLE
Add dialog package to the minimal images

### DIFF
--- a/config/cli/common/main/packages
+++ b/config/cli/common/main/packages
@@ -6,6 +6,7 @@ console-setup
 cron
 curl
 dbus-user-session
+dialog
 debconf-utils
 debsums
 device-tree-compiler


### PR DESCRIPTION
# Description

Armbian install fails to start on minimal images

Jira reference number [AR-1623]

# How Has This Been Tested?

- [x] After installing this package installation works

[AR-1623]: https://armbian.atlassian.net/browse/AR-1623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ