### PR TITLE
`lib/tools/shellcheck.sh`: add (very low-bar "error") checks to `config/sources` and `config/boards`

### DIFF
--- a/lib/tools/shellcheck.sh
+++ b/lib/tools/shellcheck.sh
@@ -57,41 +57,42 @@ if [[ ! -f "${SHELLCHECK_BIN}" ]]; then
 	rm -rf "${DIR_SHELLCHECK}/shellcheck-v${SHELLCHECK_VERSION}" "${SHELLCHECK_BIN}.tar.xz"
 	chmod +x "${SHELLCHECK_BIN}"
 fi
-
-declare SEVERITY="${SEVERITY:-"critical"}"
-
-declare -a params=(--check-sourced --color=always --external-sources --format=tty --shell=bash)
-case "${SEVERITY}" in
-	important)
-		params+=("--severity=warning")
-		excludes+=(
-			"SC2034" # "appears unused" -- bad, but no-one will die of this
-		)
-		;;
-
-	critical)
-		params+=("--severity=warning")
-		excludes+=(
-			"SC2034" # "appears unused" -- bad, but no-one will die of this
-			"SC2207" # "prefer mapfile" -- bad expansion, can lead to trouble; a lot of legacy pre-next code hits this
-			"SC2046" # "quote this to prevent word splitting" -- bad expansion, variant 2, a lot of legacy pre-next code hits this
-			"SC2086" # "quote this to prevent word splitting" -- bad expansion, variant 3, a lot of legacy pre-next code hits this
-			"SC2206" # (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.
-		)
-		;;
-
-	*)
-		params=("--severity=${SEVERITY}")
-		;;
-esac
-
-for exclude in "${excludes[@]}"; do
-	params+=(--exclude="${exclude}")
-done
-
 ACTUAL_VERSION="$("${SHELLCHECK_BIN}" --version | grep "^version")"
-echo "Running shellcheck ${ACTUAL_VERSION} against 'compile.sh' -- lib/ checks, severity 'SEVERITY=${SEVERITY}', please wait..."
-echo "All params: " "${params[@]}"
+
+function calculate_params_for_severity() {
+	declare SEVERITY="${SEVERITY:-"critical"}"
+
+	params+=(--check-sourced --color=always --external-sources --format=tty --shell=bash)
+	case "${SEVERITY}" in
+		important)
+			params+=("--severity=warning")
+			excludes+=(
+				"SC2034" # "appears unused" -- bad, but no-one will die of this
+			)
+			;;
+
+		critical)
+			params+=("--severity=warning")
+			excludes+=(
+				"SC2034" # "appears unused" -- bad, but no-one will die of this
+				"SC2207" # "prefer mapfile" -- bad expansion, can lead to trouble; a lot of legacy pre-next code hits this
+				"SC2046" # "quote this to prevent word splitting" -- bad expansion, variant 2, a lot of legacy pre-next code hits this
+				"SC2086" # "quote this to prevent word splitting" -- bad expansion, variant 3, a lot of legacy pre-next code hits this
+				"SC2206" # (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.
+			)
+			;;
+
+		*)
+			params+=("--severity=${SEVERITY}")
+			;;
+	esac
+
+	for exclude in "${excludes[@]}"; do
+		params+=(--exclude="${exclude}")
+	done
+}
+
+declare -a problems=()
 
 # formats:
 # checkstyle -- some XML format
@@ -99,11 +100,48 @@ echo "All params: " "${params[@]}"
 # tty - default for checkstyle
 
 cd "${SRC}" || exit 3
-# "${SHELLCHECK_BIN}" --help
-if "${SHELLCHECK_BIN}" "${params[@]}" compile.sh; then
-	echo "Congrats, no ${SEVERITY}'s detected."
-	exit 0
+
+# config/sources errors
+SEVERITY="error"
+declare -a params=()
+calculate_params_for_severity
+declare -a config_files=()
+declare -a config_source_files=()
+declare -a config_board_files=()
+mapfile -t config_source_files < <(find "${SRC}/config/sources" -type f -name "*.inc" -o -name "*.conf")
+mapfile -t config_board_files < <(find "${SRC}/config/boards" -type f -name "*.wip" -o -name "*.tvb" -o -name "*.conf" -o -name "*.csc" -o -name "*.eos")
+# add all elements of config_source_files and config_board_files to config_files
+config_files=("${config_source_files[@]}" "${config_board_files[@]}")
+
+echo "Running shellcheck ${ACTUAL_VERSION} against ${#config_files[@]} config files, severity 'SEVERITY=${SEVERITY}', please wait..."
+#echo "All params: " "${params[@]}"
+#echo "Checked files: " "${config_files[@]}"
+
+if "${SHELLCHECK_BIN}" "${params[@]}" "${config_files[@]}"; then
+	echo "Congrats, no ${SEVERITY}'s detected in config/sources."
 else
-	echo "Ooops, ${SEVERITY}'s detected."
+	echo "Ooops, ${SEVERITY}'s detected in config/sources."
+	problems+=("Ooops, ${SEVERITY}'s detected in config/sources.")
+fi
+
+# Lib/ code checks
+SEVERITY="critical"
+declare -a params=()
+calculate_params_for_severity
+echo "Running shellcheck ${ACTUAL_VERSION} against 'compile.sh' -- lib/ checks, severity 'SEVERITY=${SEVERITY}', please wait..."
+echo "All params: " "${params[@]}"
+
+if "${SHELLCHECK_BIN}" "${params[@]}" compile.sh; then
+	echo "Congrats, no ${SEVERITY}'s detected in lib/ code."
+else
+	problems+=("Ooops, ${SEVERITY}'s detected in lib/ code.")
+fi
+
+# show the problems, if any
+if [[ ${#problems[@]} -gt 0 ]]; then
+	echo "Problems detected:"
+	for problem in "${problems[@]}"; do
+		echo " - ${problem}"
+	done
 	exit 1
 fi


### PR DESCRIPTION
#### `lib/tools/shellcheck.sh`: add (very low-bar "error") checks to `config/sources` and `config/boards`

- while keeping `lib/` code in custom "critical" level


### To run (one day will be added to some pre-commit and PR checks)

```bash
bash lib/tools/shellcheck.sh
```
