### PR TITLE
start-end.sh: Log build runtime in minutes with seconds

### DIFF
--- a/lib/functions/main/start-end.sh
+++ b/lib/functions/main/start-end.sh
@@ -72,9 +72,9 @@ function main_default_end_build() {
 
 	declare end_timestamp
 	end_timestamp=$(date +%s)
-	declare runtime=$(((end_timestamp - start_timestamp) / 60))
+	declare runtime_seconds=$((end_timestamp - start_timestamp))
 	# display_alert in its own logging section.
-	LOG_SECTION="runtime_total" do_with_logging display_alert "Runtime" "${runtime} min" "info"
+	LOG_SECTION="runtime_total" do_with_logging display_alert "Runtime" "$(printf "%d:%02d min" $((runtime_seconds / 60)) $((runtime_seconds % 60)))" "info"
 
 	return 0
 }


### PR DESCRIPTION
# Description

With particular artifacts build, build runtimes become short. So I'd like to log the runtime in minutes with seconds.

# Test result:

- [x] Run e.g.: `./compile.sh u-boot BOARD=cubietruck BRANCH=current RELEASE=focal BUILD_MINIMAL=yes BUILD_DESKTOP=no KERNEL_CONFIGURE=no COMPRESS_OUTPUTIMAGE=sha,gpg,7z SYNC_CLOCK=no CREATE_PATCHES=no`

![image](https://user-images.githubusercontent.com/45703410/226691143-b34ae527-1c50-47bc-bdd6-bc92c88fc269.png)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
