### PR TITLE
Forcing artefact doesn't always work

### DIFF
--- a/lib/functions/cli/cli-artifact.sh
+++ b/lib/functions/cli/cli-artifact.sh
@@ -43,10 +43,6 @@ function cli_artifact_run() {
 		ignore_local_cache="yes"
 		deploy_to_remote="yes"
 
-		if [[ "${FORCE_ARTIFACTS_DOWNLOAD}" == "yes" ]]; then
-			skip_unpack_if_found_in_caches="no"
-		fi
-
 		# Pass ARTIFACT_USE_CACHE=yes to actually use the cache versions, but don't deploy to remote.
 		# @TODO this is confusing. each op should be individually controlled...
 		# what we want is:
@@ -59,6 +55,11 @@ function cli_artifact_run() {
 			ignore_local_cache="no"
 			deploy_to_remote="no"
 		fi
+	fi
+
+	# Force artifacts download we need to populate repository
+	if [[ "${FORCE_ARTIFACTS_DOWNLOAD}" == "yes" ]]; then
+		skip_unpack_if_found_in_caches="no"
 	fi
 
 	do_with_default_build obtain_complete_artifact # @TODO: < /dev/null -- but what about kernel configure?


### PR DESCRIPTION
# Description

If OCI_TARGET_BASE is not set, then this override doesn't work. For some reason, this hack wasn't working with u-boot packages.

# How Has This Been Tested?

- [ ] Making caches

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
