### PR TITLE
allwinner-boot-splash.patch: Fix sunxi uboot redefined warnings on "CONFIG_VIDEO_*"

### DIFF
--- a/patch/u-boot/u-boot-sunxi/allwinner-boot-splash.patch
+++ b/patch/u-boot/u-boot-sunxi/allwinner-boot-splash.patch
@@ -45,18 +45,32 @@ diff --git a/include/configs/sunxi-common.h b/include/configs/sunxi-common.h
 index 958b850d..c4f34dbf 100644
 --- a/include/configs/sunxi-common.h
 +++ b/include/configs/sunxi-common.h
-@@ -223,6 +223,16 @@ extern int soft_i2c_gpio_scl;
+@@ -223,6 +223,30 @@ extern int soft_i2c_gpio_scl;
  #define CONFIG_VIDEO_LCD_I2C_BUS	-1 /* NA, but necessary to compile */
  #endif
  
 +#if defined CONFIG_VIDEO || defined CONFIG_DM_VIDEO
++#if !defined CONFIG_VIDEO_LOGO
 +#define CONFIG_VIDEO_LOGO
++#endif
++#if !defined CONFIG_SPLASH_SCREEN
 +#define CONFIG_SPLASH_SCREEN
++#endif
++#if !defined CONFIG_SPLASH_SCREEN_ALIGN
 +#define CONFIG_SPLASH_SCREEN_ALIGN
++#endif
++#if !defined CONFIG_BMP_16BPP
 +#define CONFIG_BMP_16BPP
++#endif
++#if !defined CONFIG_BMP_24BPP
 +#define CONFIG_BMP_24BPP
++#endif
++#if !defined CONFIG_BMP_32BPP
 +#define CONFIG_BMP_32BPP
++#endif
++#if !defined CONFIG_VIDEO_BMP_RLE8
 +#define CONFIG_VIDEO_BMP_RLE8
++#endif
 +#endif
 +
  /* Ethernet support */


### PR DESCRIPTION
# Description
Current U-Boot compile on SUNXI 32-bit boards comes up with a couple of CONFIG_ redefined warnings.

Root cause is allwinner-boot-splash.patch. If `CONFIG_VIDEO` or `CONFIG_DM_VIDEO` is defined, then this patch is defining a couple of dependent configs - regardless if those are defined already.

# Solution
Wrap those defines with an appropriate `if !defined` pattern.

# How Has This Been Tested?
- [x] Test 1: Compile for a SUNXI 32-bit board - e.g.: `/compile.sh u-boot BOARD=bananapipro BRANCH=current RELEASE=focal BUILD_MINIMAL=yes BUILD_DESKTOP=no KERNEL_CONFIGURE=no COMPRESS_OUTPUTIMAGE=sha,gpg,7z SYNC_CLOCK=no CREATE_PATCHES=no`

- [x] Test 2: Compile for a SUNXI 64-bit board does not create any warning.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings