### PR TITLE
Move "Repeat Build Options" logs to start-end.sh to appear consistently on any build

### DIFF
--- a/lib/functions/cli/cli-build.sh
+++ b/lib/functions/cli/cli-build.sh
@@ -21,32 +21,7 @@ function cli_standard_build_run() {
 	# configuration etc - it initializes the extension manager; handles its own logging sections
 	prep_conf_main_build_single
 
-	# 1x: show interactively-selected as soon as possible, after config
-	produce_repeat_args_array
-	display_alert "Repeat Build Options (early)" "${repeat_args[*]}" "ext"
-
 	# the full build. It has its own logging sections.
 	do_with_default_build full_build_packages_rootfs_and_image
 
-	# 1x: show interactively-selected as soon as possible, after config
-	produce_repeat_args_array
-	display_alert "Repeat Build Options" "${repeat_args[*]}" "ext" # * = expand array, space delimited, single-word.
-
-}
-
-function produce_repeat_args_array() {
-	# Make it easy to repeat build by displaying build options used. Prepare array.
-	declare -a -g repeat_args=("./compile.sh")
-	# @TODO: missing the config file name, if any.
-	# @TODO: missing the original cli command, if different from build/docker
-	[[ -n ${BOARD} ]] && repeat_args+=("BOARD=${BOARD}")
-	[[ -n ${BRANCH} ]] && repeat_args+=("BRANCH=${BRANCH}")
-	[[ -n ${RELEASE} ]] && repeat_args+=("RELEASE=${RELEASE}")
-	[[ -n ${BUILD_MINIMAL} ]] && repeat_args+=("BUILD_MINIMAL=${BUILD_MINIMAL}")
-	[[ -n ${BUILD_DESKTOP} ]] && repeat_args+=("BUILD_DESKTOP=${BUILD_DESKTOP}")
-	[[ -n ${KERNEL_CONFIGURE} ]] && repeat_args+=("KERNEL_CONFIGURE=${KERNEL_CONFIGURE}")
-	[[ -n ${DESKTOP_ENVIRONMENT} ]] && repeat_args+=("DESKTOP_ENVIRONMENT=${DESKTOP_ENVIRONMENT}")
-	[[ -n ${DESKTOP_ENVIRONMENT_CONFIG_NAME} ]] && repeat_args+=("DESKTOP_ENVIRONMENT_CONFIG_NAME=${DESKTOP_ENVIRONMENT_CONFIG_NAME}")
-	[[ -n ${DESKTOP_APPGROUPS_SELECTED} ]] && repeat_args+=("DESKTOP_APPGROUPS_SELECTED=\"${DESKTOP_APPGROUPS_SELECTED:-"none"}\"")
-	[[ -n ${COMPRESS_OUTPUTIMAGE} ]] && repeat_args+=("COMPRESS_OUTPUTIMAGE=${COMPRESS_OUTPUTIMAGE}")
 }

--- a/lib/functions/cli/cli-docker.sh
+++ b/lib/functions/cli/cli-docker.sh
@@ -55,9 +55,6 @@ function cli_docker_run() {
 	ARMBIAN_CLI_RELAUNCH_PARAMS+=(["ARMBIAN_BUILD_UUID"]="${ARMBIAN_BUILD_UUID}") # pass down our uuid to the docker instance
 	ARMBIAN_CLI_RELAUNCH_PARAMS+=(["SKIP_LOG_ARCHIVE"]="yes")                     # launched docker instance will not cleanup logs.
 
-	declare -g ARMBIAN_CLI_RELAUNCH_ARGS=()
-	produce_relaunch_parameters # produces ARMBIAN_CLI_RELAUNCH_ARGS
-
 	case "${DOCKER_SUBCMD}" in
 		shell)
 			display_alert "Launching Docker shell" "docker-shell" "info"
@@ -73,7 +70,7 @@ function cli_docker_run() {
 			# this does NOT exit with the same exit code as the docker instance.
 			# instead, it sets the docker_exit_code variable.
 			declare -i docker_exit_code docker_produced_logs=0
-			docker_cli_launch "${ARMBIAN_CLI_RELAUNCH_ARGS[@]}" # MARK: this "re-launches" using the passed params.
+			docker_cli_launch # MARK: this "re-launches"
 
 			# Set globals to avoid:
 			# 1) showing the controlling host's log; we only want to show a ref to the Docker logfile, unless it didn't produce one.

--- a/lib/functions/cli/commands.sh
+++ b/lib/functions/cli/commands.sh
@@ -106,6 +106,7 @@ function armbian_register_commands() {
 
 	# Keep a running dict of params/variables. Can't repeat stuff here. Dict.
 	declare -g -A ARMBIAN_CLI_RELAUNCH_PARAMS=(["ARMBIAN_RELAUNCHED"]="yes")
+	declare -g -A ARMBIAN_CLI_RELAUNCH_ENVS=(["ARMBIAN_RELAUNCHED"]="yes")
 
 	# Keep a running array of config files needed for relaunch.
 	declare -g -a ARMBIAN_CLI_RELAUNCH_CONFIGS=()

--- a/lib/functions/configuration/config-desktop.sh
+++ b/lib/functions/configuration/config-desktop.sh
@@ -94,7 +94,7 @@ function interactive_desktop_main_configuration() {
 
 		display_alert "Desktops available" "${options[*]}" "debug"
 		dialog_menu "Choose a desktop environment" "$backtitle" "Select the default desktop environment to bundle with this image" "${options[@]}"
-		DESKTOP_ENVIRONMENT="${DIALOG_MENU_RESULT}"
+		set_interactive_config_value DESKTOP_ENVIRONMENT "${DIALOG_MENU_RESULT}"
 
 		unset options
 		if [[ -z "${DESKTOP_ENVIRONMENT}" ]]; then
@@ -121,7 +121,7 @@ function interactive_desktop_main_configuration() {
 		done
 
 		dialog_menu "Choose the desktop environment config" "$backtitle" "Select the configuration for this environment." "${options[@]}"
-		DESKTOP_ENVIRONMENT_CONFIG_NAME="${DIALOG_MENU_RESULT}"
+		set_interactive_config_value DESKTOP_ENVIRONMENT_CONFIG_NAME "${DIALOG_MENU_RESULT}"
 		unset options
 
 		if [[ -z $DESKTOP_ENVIRONMENT_CONFIG_NAME ]]; then
@@ -145,7 +145,7 @@ function interactive_desktop_main_configuration() {
 		done
 
 		dialog_checklist "Choose desktop softwares to add" "$backtitle" "Select which kind of softwares you'd like to add to your build" "${options[@]}"
-		DESKTOP_APPGROUPS_SELECTED="${DIALOG_CHECKLIST_RESULT}"
+		set_interactive_config_value DESKTOP_APPGROUPS_SELECTED "${DIALOG_CHECKLIST_RESULT}"
 		unset options
 	fi
 	display_alert "desktop-config" "DESKTOP_APPGROUPS_SELECTED exit: ${DESKTOP_APPGROUPS_SELECTED}" "debug"

--- a/lib/functions/configuration/interactive.sh
+++ b/lib/functions/configuration/interactive.sh
@@ -21,6 +21,15 @@ function interactive_config_prepare_terminal() {
 	fi
 	# We'll use this title on all menus
 	declare -g -r backtitle="Armbian building script, https://www.armbian.com | https://docs.armbian.com | (c) 2013-2023 Igor Pecovnik "
+	declare -A -g ARMBIAN_INTERACTIVE_CONFIGS=() # An associative array of all interactive configurations
+}
+
+# Set config variable and ARMBIAN_INTERACTIVE_CONFIGS in a consistent way
+# $1: variable name
+# $2: variable value
+function set_interactive_config_value() {
+	eval "$1"='$2'
+	eval "ARMBIAN_INTERACTIVE_CONFIGS[${1}]"='$2'
 }
 
 function interactive_finish() {
@@ -42,7 +51,7 @@ function interactive_config_ask_kernel_configure() {
 	options+=("yes" "Show a kernel configuration menu before compilation")
 	#options+=("prebuilt" "Use precompiled packages (maintained hardware only)") # @TODO armbian-next does not support this, I think.
 	dialog_if_terminal_set_vars --title "Choose an option" --backtitle "$backtitle" --no-tags --menu "Select the kernel configuration" $TTY_Y $TTY_X $((TTY_Y - 8)) "${options[@]}"
-	KERNEL_CONFIGURE="${DIALOG_RESULT}"
+	set_interactive_config_value KERNEL_CONFIGURE "${DIALOG_RESULT}"
 	[[ ${DIALOG_EXIT_CODE} != 0 ]] && exit_with_error "You cancelled interactive during kernel configuration" "Build cancelled"
 	unset options
 }
@@ -141,7 +150,7 @@ function interactive_config_ask_board_list() {
 			dialog_if_terminal_set_vars --title "Choose a board" --backtitle "$backtitle" --scrollbar \
 			--colors --extra-label "Show $WIP_BUTTON" --extra-button \
 			--menu "Select the target board. Displaying:\n$STATE_DESCRIPTION" $TTY_Y $TTY_X $((TTY_Y - 8)) "${arr_all_board_options[@]}"
-		BOARD="${DIALOG_RESULT}"
+		set_interactive_config_value BOARD "${DIALOG_RESULT}"
 		declare STATUS=${DIALOG_EXIT_CODE}
 
 		if [[ $STATUS == 3 ]]; then
@@ -182,7 +191,7 @@ function interactive_config_ask_branch() {
 		--menu "Select the target kernel branch.\nSelected BOARD='${BOARD}'\nExact kernel versions depend on selected board and its family." \
 		$TTY_Y $TTY_X $((TTY_Y - 8)) "${options[@]}"
 
-	BRANCH="${DIALOG_RESULT}"
+	set_interactive_config_value BRANCH "${DIALOG_RESULT}"
 
 	[[ -z ${BRANCH} ]] && exit_with_error "No kernel branch selected"
 	return 0
@@ -194,7 +203,7 @@ function interactive_config_ask_release() {
 	declare -a options=()
 	distros_options
 	dialog_if_terminal_set_vars --title "Choose a release package base" --backtitle "$backtitle" --menu "Select the target OS release package base; selected BRANCH='${BRANCH}'" $TTY_Y $TTY_X $((TTY_Y - 8)) "${options[@]}"
-	RELEASE="${DIALOG_RESULT}"
+	set_interactive_config_value RELEASE "${DIALOG_RESULT}"
 	[[ -z ${RELEASE} ]] && exit_with_error "No release selected"
 
 	return 0 # shortcircuit above!
@@ -213,11 +222,11 @@ function interactive_config_ask_desktop_build() {
 	options+=("yes" "Image with desktop environment")
 	dialog_if_terminal_set_vars --title "Choose image type" --backtitle "$backtitle" --no-tags \
 		--menu "Select the target image type" $TTY_Y $TTY_X $((TTY_Y - 8)) "${options[@]}"
-	BUILD_DESKTOP="${DIALOG_RESULT}"
+	set_interactive_config_value BUILD_DESKTOP "${DIALOG_RESULT}"
 	unset options
 	[[ -z $BUILD_DESKTOP ]] && exit_with_error "No image type selected"
 	if [[ ${BUILD_DESKTOP} == "yes" ]]; then
-		BUILD_MINIMAL=no
+		set_interactive_config_value BUILD_MINIMAL no
 		SELECTED_CONFIGURATION="desktop"
 	fi
 	return 0
@@ -232,7 +241,7 @@ function interactive_config_ask_standard_or_minimal() {
 	options+=("yes" "Minimal image with console interface")
 	dialog_if_terminal_set_vars --title "Choose image type" --backtitle "$backtitle" --no-tags \
 		--menu "Select the target image type" $TTY_Y $TTY_X $((TTY_Y - 8)) "${options[@]}"
-	BUILD_MINIMAL="${DIALOG_RESULT}"
+	set_interactive_config_value BUILD_MINIMAL "${DIALOG_RESULT}"
 	unset options
 	[[ -z $BUILD_MINIMAL ]] && exit_with_error "No standard/minimal selected"
 	if [[ $BUILD_MINIMAL == "yes" ]]; then

--- a/lib/functions/logging/export-logs.sh
+++ b/lib/functions/logging/export-logs.sh
@@ -38,6 +38,7 @@ function export_markdown_logs() {
 
 		### Armbian logs for ${ARMBIAN_BUILD_UUID}
 		#### Armbian build at $(LC_ALL=C LANG=C date) on $(hostname || true)
+		#### Repeat build: ${repeat_args_string:-""}
 		#### ARGs: \`${ARMBIAN_ORIGINAL_ARGV[@]@Q}\`
 	MARKDOWN_HEADER
 
@@ -119,6 +120,7 @@ function export_ansi_logs() {
 		# Armbian ANSI build logs for ${ARMBIAN_BUILD_UUID} - use "less -SR" to view
 		$(echo -e -n "${bright_blue_color:-}")# Armbian build at $(LC_ALL=C LANG=C date) on $(hostname || true)$(echo -e -n "${ansi_reset_color}")
 		${dim_line_separator}
+		$(echo -e -n "${bright_blue_color}")# Repeat build: ${repeat_args_string:-""}$(echo -e -n "${ansi_reset_color}")
 		$(echo -e -n "${bright_blue_color}")# ARGs: ${ARMBIAN_ORIGINAL_ARGV[@]@Q}$(echo -e -n "${ansi_reset_color}")
 		${dim_line_separator}
 	ANSI_HEADER

--- a/lib/functions/logging/trap-logging.sh
+++ b/lib/functions/logging/trap-logging.sh
@@ -68,6 +68,11 @@ function trap_handler_cleanup_logging() {
 		display_alert "Not archiving old logs." "CI=${CI:-false}, SKIP_LOG_ARCHIVE=${SKIP_LOG_ARCHIVE:-no}" "debug"
 	fi
 
+	# Gather repeat build args, included in the logs.
+	declare -g repeat_args=()
+	produce_repeat_args_array # produces repeat_args
+	declare repeat_args_string="${repeat_args[*]}"
+
 	## Here -- we need to definitely stop logging, cos we're gonna consolidate and delete the logs.
 	display_alert "End of logging" "STOP LOGGING: CURRENT_LOGFILE: ${CURRENT_LOGFILE}" "debug"
 
@@ -109,6 +114,8 @@ function trap_handler_cleanup_logging() {
 		display_alert "Exporting Markdown logs to GitHub Actions" "GITHUB_STEP_SUMMARY: '${GITHUB_STEP_SUMMARY}'" "info"
 		cat "${markdown_log_file}" >> "${GITHUB_STEP_SUMMARY}" || true
 	fi
+
+	unset repeat_args_string
 
 	discard_logs_tmp_dir
 }


### PR DESCRIPTION
# Description

IMO the "Repeat Build Options" log should consistently appear for any build option.
So I did update scripts as follows (copy of commit comment):

- `cli-build.sh, start-end.sh`:
  - move function produce_repeat_args_array() to start-end.sh
  - add $WHAT as first arg to produce_repeat_args_array() if $WHAT is not empty
  - move early display log of "Repeat Build Options" to function main_default_start_build()
  - move last log of "Repeat Build Options" to function main_default_end_build()
  - add last log of "Repeat Build Options" to LOG_SECTION="repeat_build_options"


# Testresults
(edited 25-Mar-2023 - according to commit  922a091, edited 28-Mar-2023, added test case `C` - according to commit 774e67b)
- [x] A: Run full build (no single artifact nor any armbian command on commandline: `$ ./compile.sh BOARD=cubietruck BRANCH=current RELEASE=focal BUILD_MINIMAL=yes BUILD_DESKTOP=no KERNEL_CONFIGURE=no COMPRESS_OUTPUTIMAGE=sha,gpg,7z SYNC_CLOCK=no CREATE_PATCHES=no` - the early log only to save time):
```
[✨] Repeat Build Options (early) [ ./compile.sh build BOARD='cubietruck' SYNC_CLOCK='no' COMPRESS_OUTPUTIMAGE='sha,gpg,7z' RELEASE='focal' SET_OWNER_TO_UID='1000' CREATE_PATCHES='no' BUILD_MINIMAL='yes' ARMBIAN_RELAUNCHED='yes' BUILD_DESKTOP='no' BRANCH='current' PREFER_DOCKER='no' KERNEL_CONFIGURE='no' ]
```

- [x] B: Run single artifact build with `u-boot` on commandline `$ ./compile.sh u-boot BOARD='cubietruck' SYNC_CLOCK='no' COMPRESS_OUTPUTIMAGE='sha,gpg,7z' RELEASE='focal' SET_OWNER_TO_UID='1000' CREATE_PATCHES='no' BUILD_MINIMAL='yes' ARMBIAN_RELAUNCHED='yes' BUILD_DESKTOP='no' BRANCH='current' PREFER_DOCKER='no' KERNEL_CONFIGURE=no`:
1. - the early log:
```
[✨] Repeat Build Options (early) [ ./compile.sh u-boot BOARD='cubietruck' SYNC_CLOCK='no' COMPRESS_OUTPUTIMAGE='sha,gpg,7z' RELEASE='focal' SET_OWNER_TO_UID='1000' CREATE_PATCHES='no' BUILD_MINIMAL='yes' ARMBIAN_RELAUNCHED='yes' BUILD_DESKTOP='no' BRANCH='current' PREFER_DOCKER='no' KERNEL_CONFIGURE='no' ]
```

2. - the final log:
```
[✨] Repeat Build Options [ ./compile.sh u-boot BOARD='cubietruck' SYNC_CLOCK='no' COMPRESS_OUTPUTIMAGE='sha,gpg,7z' RELEASE='focal' SET_OWNER_TO_UID='1000' CREATE_PATCHES='no' BUILD_MINIMAL='yes' ARMBIAN_RELAUNCHED='yes' BUILD_DESKTOP='no' BRANCH='current' PREFER_DOCKER='no' KERNEL_CONFIGURE='no' ] 
```

- [x] C: Run interactive configured build (commandline: `$ ./compile.sh` - the early log only to save time):
```
[✨] Repeat Build Options (early) [ ./compile.sh build SET_OWNER_TO_UID='1000' ARMBIAN_RELAUNCHED='yes' PREFER_DOCKER='no' BOARD='bananapim5' RELEASE='jammy' BUILD_MINIMAL='yes' BUILD_DESKTOP='no' BRANCH='current' KERNEL_CONFIGURE='no' ]
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
