### PR TITLE
Bugfix: Allow to set empty cmdline params

### DIFF
--- a/lib/functions/cli/utils-cli.sh
+++ b/lib/functions/cli/utils-cli.sh
@@ -55,13 +55,14 @@ function apply_cmdline_params_to_env() {
 		local param_value param_value_desc current_env_value
 		# get the current value from the environment
 		current_env_value="${!param_name}"
-		current_env_value_desc="${current_env_value:-(empty)}"
+		current_env_value_desc="${!param_name-(unset)}"
+		current_env_value_desc="${current_env_value_desc:-(empty)}"
 		# get the new value from the dictionary
 		param_value="${ARMBIAN_PARSED_CMDLINE_PARAMS[${param_name}]}"
 		param_value_desc="${param_value:-(empty)}"
 
 		# Compare, log, and apply.
-		if [[ "${current_env_value}" != "${param_value}" ]]; then
+		if [[ -z "${!param_name+x}" ]] || [[ "${current_env_value}" != "${param_value}" ]]; then
 			display_alert "Applying cmdline param" "'$param_name': '${current_env_value_desc}' --> '${param_value_desc}' ${__my_reason}" "cmdline"
 			# use `declare -g` to make it global, we're in a function.
 			eval "declare -g $param_name=\"$param_value\""


### PR DESCRIPTION
# Description

Fix the following error:
```
[🌱] Skip     cmdline param [ 'DESKTOP_APPGROUPS_SELECTED': already set to '(empty)' early ]
```

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Run `./compile.sh DESKTOP_APPGROUPS_SELECTED=`

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
