### PR TITLE
rk322x: fix old emmc detection on rk322x

### DIFF
--- a/patch/kernel/archive/rk322x-6.1/02-linux-0009-rk322x-fix-emmc.patch
+++ b/patch/kernel/archive/rk322x-6.1/02-linux-0009-rk322x-fix-emmc.patch
@@ -1,0 +1,87 @@
+diff --git a/drivers/mmc/host/dw_mmc-rockchip.c b/drivers/mmc/host/dw_mmc-rockchip.c
+index 2a99f15f5..d36991acd 100644
+--- a/drivers/mmc/host/dw_mmc-rockchip.c
++++ b/drivers/mmc/host/dw_mmc-rockchip.c
+@@ -15,9 +15,7 @@
+ #include "dw_mmc.h"
+ #include "dw_mmc-pltfm.h"
+ 
+-#define RK3288_CLKGEN_DIV	2
+-
+-static const unsigned int freqs[] = { 100000, 200000, 300000, 400000 };
++#define RK3288_CLKGEN_DIV       2
+ 
+ struct dw_mci_rockchip_priv_data {
+ 	struct clk		*drv_clk;
+@@ -53,7 +51,7 @@ static void dw_mci_rk3288_set_ios(struct dw_mci *host, struct mmc_ios *ios)
+ 
+ 	ret = clk_set_rate(host->ciu_clk, cclkin);
+ 	if (ret)
+-		dev_warn(host->dev, "failed to set rate %uHz err: %d\n", cclkin, ret);
++		dev_warn(host->dev, "failed to set rate %uHz\n", ios->clock);
+ 
+ 	bus_hz = clk_get_rate(host->ciu_clk) / RK3288_CLKGEN_DIV;
+ 	if (bus_hz != host->bus_hz) {
+@@ -292,39 +290,31 @@ static int dw_mci_rk3288_parse_dt(struct dw_mci *host)
+ 
+ static int dw_mci_rockchip_init(struct dw_mci *host)
+ {
+-	int ret, i;
+-
+ 	/* It is slot 8 on Rockchip SoCs */
+ 	host->sdio_id0 = 8;
+ 
+-	if (of_device_is_compatible(host->dev->of_node, "rockchip,rk3288-dw-mshc")) {
++	if (of_device_is_compatible(host->dev->of_node,
++				    "rockchip,rk3288-dw-mshc"))
+ 		host->bus_hz /= RK3288_CLKGEN_DIV;
+ 
+-		/* clock driver will fail if the clock is less than the lowest source clock
+-		 * divided by the internal clock divider. Test for the lowest available
+-		 * clock and set the minimum freq to clock / clock divider.
+-		 */
+-
+-		for (i = 0; i < ARRAY_SIZE(freqs); i++) {
+-			ret = clk_round_rate(host->ciu_clk, freqs[i] * RK3288_CLKGEN_DIV);
+-			if (ret > 0) {
+-				host->minimum_speed = ret / RK3288_CLKGEN_DIV;
+-				break;
+-			}
+-		}
+-		if (ret < 0)
+-			dev_warn(host->dev, "no valid minimum freq: %d\n", ret);
+-	}
+-
+ 	return 0;
+ }
+ 
++/* Common capabilities of RK3288 SoC */
++static unsigned long dw_mci_rk3288_dwmmc_caps[4] = {
++	MMC_CAP_CMD23,
++	MMC_CAP_CMD23,
++	MMC_CAP_CMD23,
++	MMC_CAP_CMD23,
++};
++
+ static const struct dw_mci_drv_data rk2928_drv_data = {
+ 	.init			= dw_mci_rockchip_init,
+ };
+ 
+ static const struct dw_mci_drv_data rk3288_drv_data = {
+-	.common_caps		= MMC_CAP_CMD23,
++	.caps			= dw_mci_rk3288_dwmmc_caps,
++	.num_caps		= ARRAY_SIZE(dw_mci_rk3288_dwmmc_caps),
+ 	.set_ios		= dw_mci_rk3288_set_ios,
+ 	.execute_tuning		= dw_mci_rk3288_execute_tuning,
+ 	.parse_dt		= dw_mci_rk3288_parse_dt,
+@@ -377,9 +367,7 @@ static int dw_mci_rockchip_remove(struct platform_device *pdev)
+ 	pm_runtime_disable(&pdev->dev);
+ 	pm_runtime_put_noidle(&pdev->dev);
+ 
+-	dw_mci_pltfm_remove(pdev);
+-
+-	return 0;
++	return dw_mci_pltfm_remove(pdev);
+ }
+ 
+ static const struct dev_pm_ops dw_mci_rockchip_dev_pm_ops = {


### PR DESCRIPTION
# Description

A recent couple of patches, introduced in mainline kernel 6.1 to fix some rk356x emmc detection, break the detection of some old emmc parts on rk322x. 

This PR reverts the kernel 6.1 patches until some more investigations are done to better understand the nature of the issue and if it can be solved without disturbing the mainline kernel.

Anyway this is confined into rk322x family, so anyone else is not affected by.

# How Has This Been Tested?

- [x] Built full image and tested on the problematic rk322x device

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
