### PR TITLE
Allow numbers in username

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -249,7 +249,7 @@ add_user()
 	while [ -f "/root/.not_logged_in_yet" ]; do
 		echo -e "\nPlease provide a username (eg. your first name): \c"
 		read -r -e username
-		if ! grep '^[a-zA-Z]*$' <<< "$username" > /dev/null ; then
+		if ! grep '^[a-zA-Z0-9]*$' <<< "$username" > /dev/null ; then
 			echo -e "\n\x1B[91mError\x1B[0m: illegal characters in username"
 			return
 		fi


### PR DESCRIPTION
# Description

Not allowing numbers in username is a bit too harsh condition.

Jira reference number [AR-1642] Closing https://github.com/armbian/build/issues/5006

# How Has This Been Tested?

- [x] Manual grep

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1642]: https://armbian.atlassian.net/browse/AR-1642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ