### PR TITLE
rpardini's big-ish batch of `config` changes from late March/23

### DIFF
--- a/config/boards/odroidn2.conf
+++ b/config/boards/odroidn2.conf
@@ -5,15 +5,14 @@ KERNEL_TARGET="current,edge"
 FULL_DESKTOP="yes"
 FORCE_BOOTSCRIPT_UPDATE="yes"
 BOOT_LOGO="desktop"
-
-# Odroid N2 requires Odroid's u-boot for legacy kernel booting.
-# These vars will be handled by the family (meson-g12b.conf)
-USE_ODROID_UBOOT="legacy"
 BOOTCONFIG="odroid-n2_defconfig" # For mainline uboot
-BOOTCONFIG_ODROID="odroidn2_config" # For odroid uboot
-BOOTSCRIPT_ODROID="boot-odroid-n2.ini:boot.ini" # For odroid uboot, default BOOTSCRIPT is boot-meson64.cmd for mainline (in meson64_common.inc)
+
+# Newer u-boot for the N2/N2+, less patches: a single boot order patch
+BOOTBRANCH_BOARD="tag:v2022.10"
+BOOTPATCHDIR="v2022.10"
 
 # Enable writing u-boot to SPI on the N2(+) for current and edge
+# @TODO: replace this with an overlay, after meson64 overlay revamp
 # To enable the SPI NOR the -spi .dtb is required, because eMMC shares a pin with SPI on the N2(+). To use it:
 # fdtfile=amlogic/meson-g12b-odroid-n2-plus-spi.dtb # in armbianEnv.txt and reboot, then run nand-sata-install
 UBOOT_TARGET_MAP="u-boot-dtb.img;;u-boot.bin.sd.bin:u-boot.bin u-boot-dtb.img u-boot.bin:u-boot-spi.bin"
@@ -22,6 +21,7 @@ write_uboot_platform_mtd() {
 }
 
 # MAX might be different for N2/N2+, for now use N2+'s
+# @TODO: remove? cpufreq is not used anymore, instead DT should be patched
 CPUMIN=1000000
 CPUMAX=2400000
 GOVERNOR=performance # some people recommend performance to avoid random hangs after 24+ hours running.
@@ -30,3 +30,5 @@ GOVERNOR=performance # some people recommend performance to avoid random hangs a
 #    https://github.com/u-boot/u-boot/blob/v2021.04/board/amlogic/odroid-n2/odroid-n2.c#L35-L106
 # Unfortunately it uses n2_plus instead of n2-plus as the Kernel expects it.
 #    So there is a hack at and around config/bootscripts/boot-meson64.cmd L90
+# If needed (eg for extlinux) you can specify the N2/N2+/ DTB in BOOT_FDT_FILE, example for the N2+:
+# BOOT_FDT_FILE="amlogic/meson-g12b-odroid-n2-plus.dtb"

--- a/config/boards/qemu-uboot-arm64.wip
+++ b/config/boards/qemu-uboot-arm64.wip
@@ -1,8 +1,8 @@
 # qemu via uboot on arm64, for "virt" qemu machine type
-export BOARD_NAME="uefi-arm64"
-export BOARDFAMILY="uefi-arm64"
-export KERNEL_TARGET="current,edge"
+declare -g BOARD_NAME="uefi-arm64"
+declare -g BOARDFAMILY="uefi-arm64"
+declare -g KERNEL_TARGET="current,edge"
 
-export UEFI_GRUB="skip" # Skip GRUB for this board
-export SERIALCON="ttyS0"
-export QEMU_UBOOT_BOOTCONFIG="qemu_arm64_defconfig"
+declare -g UEFI_GRUB="skip" # Skip GRUB for this board
+declare -g SERIALCON="ttyS0"
+declare -g QEMU_UBOOT_BOOTCONFIG="qemu_arm64_defconfig"

--- a/config/boards/qemu-uboot-x86.wip
+++ b/config/boards/qemu-uboot-x86.wip
@@ -1,11 +1,11 @@
 # x86_64 via qemu + u-boot firmware, for q35 machine type
-export UEFI_GRUB="skip" # Skip GRUB for this board
-export BOARD_NAME="uefi-x86"
-export BOARDFAMILY="uefi-x86"
-export KERNEL_TARGET="current,edge"
+declare -g UEFI_GRUB="skip" # Skip GRUB for this board
+declare -g BOARD_NAME="uefi-x86"
+declare -g BOARDFAMILY="uefi-x86"
+declare -g KERNEL_TARGET="current,edge"
 
-export SERIALCON="ttyS0"
+declare -g SERIALCON="ttyS0"
 
 # u-boot's "x86_64" is incomplete; use the 32-bit version.
-export QEMU_UBOOT_BOOTCONFIG="qemu-x86_defconfig"
-export INITRD_ARCH='x86' # not really needed, but just in case
+declare -g QEMU_UBOOT_BOOTCONFIG="qemu-x86_defconfig"
+declare -g INITRD_ARCH='x86' # not really needed, but just in case

--- a/config/boards/rpi4b.conf
+++ b/config/boards/rpi4b.conf
@@ -1,9 +1,9 @@
 # Broadcom BCM2711 quad core 1-8Gb RAM SoC USB3 GBE USB-C WiFi/BT
-export BOARD_NAME="Raspberry Pi 4"
-export BOARDFAMILY="bcm2711"
-export KERNEL_TARGET="legacy,current,edge"
-export FK__MACHINE_MODEL="Raspberry Pi 4 Model B" # flash kernel (FK) configuration
-export ASOUND_STATE="asound.state.rpi"
+declare -g BOARD_NAME="Raspberry Pi 4"
+declare -g BOARDFAMILY="bcm2711"
+declare -g KERNEL_TARGET="legacy,current,edge"
+declare -g FK__MACHINE_MODEL="Raspberry Pi 4 Model B" # flash kernel (FK) configuration
+declare -g ASOUND_STATE="asound.state.rpi"
 
 # Our default paritioning system is leaving esp on. Rpi3 is the only board that have issues with this.
 # Removing the ESP flag from the boot partition should allow the image to boot on both the RPi3 and RPi4.
@@ -21,7 +21,7 @@ pre_initramfs_flash_kernel__write_raspi_config() {
 		max_framebuffers=2
 		over_voltage=2
 		arm_freq=1800
-		
+
 		[all]
 		kernel=vmlinuz
 		cmdline=cmdline.txt
@@ -33,18 +33,18 @@ pre_initramfs_flash_kernel__write_raspi_config() {
 
 		# enable audio (loads snd_bcm2835)
 		dtparam=audio=on
-		
+
 		# bootloader logs to serial, second stage
 		# enable_uart=1
-		
+
 		# overclock. requires decent thermals. COMMENT OUT IF DON'T USE A GREAT COOLER OR HEATSINK.
 		# over_voltage=6
 		# arm_freq=2000
-		
+
 		# uncomment to disable wifi or bt.
 		#dtoverlay=disable-wifi
 		#dtoverlay=disable-bt
-		
+
 		# gpu and 3d stuff.
 		gpu_mem=256
 		dtoverlay=vc4-fkms-v3d

--- a/config/boards/uefi-arm64.conf
+++ b/config/boards/uefi-arm64.conf
@@ -1,6 +1,6 @@
 # aarch64 via UEFI for all UEFI-enabled boards
-export BOARD_NAME="UEFI arm64"
-export BOARDFAMILY="uefi-arm64"
-export KERNEL_TARGET="legacy,current,edge"
+declare -g BOARD_NAME="UEFI arm64"
+declare -g BOARDFAMILY="uefi-arm64"
+declare -g KERNEL_TARGET="legacy,current,edge"
 
-export BOOT_LOGO=desktop
+declare -g BOOT_LOGO=desktop

--- a/config/boards/uefi-riscv64.conf
+++ b/config/boards/uefi-riscv64.conf
@@ -1,5 +1,5 @@
 # riscv64 via UEFI for all UEFI-enabled boards
-export BOARD_NAME="UEFI riscv64"
-export BOARDFAMILY="uefi-riscv64"
-export KERNEL_TARGET="legacy,current,edge"
-export SERIALCON="ttyS0"
+declare -g BOARD_NAME="UEFI riscv64"
+declare -g BOARDFAMILY="uefi-riscv64"
+declare -g KERNEL_TARGET="legacy,current,edge"
+declare -g SERIALCON="ttyS0"

--- a/config/boards/uefi-x86.conf
+++ b/config/boards/uefi-x86.conf
@@ -1,6 +1,6 @@
 # x86_64 via UEFI/BIOS for all boards
-export BOARD_NAME="UEFI x86"
-export BOARDFAMILY="uefi-x86"
-export KERNEL_TARGET="legacy,current,edge"
+declare -g BOARD_NAME="UEFI x86"
+declare -g BOARDFAMILY="uefi-x86"
+declare -g KERNEL_TARGET="legacy,current,edge"
 
-export BOOT_LOGO=desktop
+declare -g BOOT_LOGO=desktop

--- a/config/boards/virtual-qemu.wip
+++ b/config/boards/virtual-qemu.wip
@@ -7,7 +7,7 @@
 # how to run on linux
 ##!/bin/bash
 #
-#export image=armbian.img
+#declare -g image=armbian.img
 #smp=4
 #rams=1000M
 #bios=u-boot.bin

--- a/config/sources/amd64.conf
+++ b/config/sources/amd64.conf
@@ -8,26 +8,26 @@
 #
 # 'common.conf' is already sourced when this arch is sourced.
 
-export ARCH='amd64'                     # Debian name $(dpkg-architecture -qDEB_HOST_ARCH)
-export ARCHITECTURE='x86_64'            # "kernel" arch
-export KERNEL_SRC_ARCH='x86'            # kernel SRC_ARCH; there's two for x86_64
-export QEMU_BINARY='qemu-x86_64-static' # Hopefully you have this installed.
-export MAIN_CMDLINE=''                  # we set it in common, it was not set before
-export KERNEL_COMPILER=' '              # hack: use single space for host gcc. won't work on arm64 hosts
-export KERNEL_USE_GCC=' '               # more hacks.
-export KERNEL_IMAGE_TYPE='bzImage'      # Ubuntu Standard
-export KERNEL_EXTRA_TARGETS='modules'   # default is "modules dtb" but x86_64 has no DTB
-export KERNEL_BUILD_DTBS="no"           # amd64 has no DTBs. that I know of.
-export UBOOT_USE_GCC='none'             # required by configuration.sh
-#export INITRD_ARCH=amd64               # Used by u-boot for mkimage in initramfs. No u-boot for x86 yet.
+declare -g ARCH='amd64'                     # Debian name $(dpkg-architecture -qDEB_HOST_ARCH)
+declare -g ARCHITECTURE='x86_64'            # "kernel" arch
+declare -g KERNEL_SRC_ARCH='x86'            # kernel SRC_ARCH; there's two for x86_64
+declare -g QEMU_BINARY='qemu-x86_64-static' # Hopefully you have this installed.
+declare -g MAIN_CMDLINE=''                  # we set it in common, it was not set before
+declare -g KERNEL_COMPILER=' '              # hack: use single space for host gcc. won't work on arm64 hosts
+declare -g KERNEL_USE_GCC=' '               # more hacks.
+declare -g KERNEL_IMAGE_TYPE='bzImage'      # Ubuntu Standard
+declare -g KERNEL_EXTRA_TARGETS='modules'   # default is "modules dtb" but x86_64 has no DTB
+declare -g KERNEL_BUILD_DTBS="no"           # amd64 has no DTBs. that I know of.
+declare -g UBOOT_USE_GCC='none'             # required by configuration.sh
+#declare -g INITRD_ARCH=amd64               # Used by u-boot for mkimage in initramfs. No u-boot for x86 yet.
 
 # Default to mainline
 [[ -z $KERNELSOURCE ]] && KERNELSOURCE=$MAINLINE_KERNEL_SOURCE
 
 if [[ "$(uname -m)" == "aarch64" ]]; then
 	# Allow building amd64 on aarch64, but using system toolchain only
-	export KERNEL_COMPILER="x86_64-linux-gnu-"
-	export SKIP_EXTERNAL_TOOLCHAINS=yes
+	declare -g KERNEL_COMPILER="x86_64-linux-gnu-"
+	declare -g SKIP_EXTERNAL_TOOLCHAINS=yes
 fi
 
 true # make sure to exit with 0 status; this protects against shortcircuits etc above.

--- a/config/sources/arm64.conf
+++ b/config/sources/arm64.conf
@@ -8,13 +8,13 @@
 #
 # 'common.conf' is already sourced when this arch is sourced.
 
-export ARCH='arm64'
-export ARCHITECTURE='arm64'
-export KERNEL_SRC_ARCH='arm64'
-export QEMU_BINARY='qemu-aarch64-static'
-export NAME_KERNEL='Image'
-export NAME_INITRD='uInitrd'
-export KERNEL_IMAGE_TYPE='Image'
+declare -g ARCH='arm64'
+declare -g ARCHITECTURE='arm64'
+declare -g KERNEL_SRC_ARCH='arm64'
+declare -g QEMU_BINARY='qemu-aarch64-static'
+declare -g NAME_KERNEL='Image'
+declare -g NAME_INITRD='uInitrd'
+declare -g KERNEL_IMAGE_TYPE='Image'
 
 [[ -z $KERNEL_COMPILER ]] && KERNEL_COMPILER="aarch64-linux-gnu-"
 [[ -z $INITRD_ARCH ]] && INITRD_ARCH=arm64

--- a/config/sources/armhf.conf
+++ b/config/sources/armhf.conf
@@ -8,14 +8,14 @@
 #
 # 'common.conf' is already sourced when this arch is sourced.
 
-export ARCH='armhf'
-export ARCHITECTURE='arm'
-export KERNEL_SRC_ARCH='arm'
-export QEMU_BINARY='qemu-arm-static'
-export NAME_KERNEL='zImage'
-export NAME_INITRD='uInitrd'
-export INITRD_ARCH='arm'
-export KERNEL_IMAGE_TYPE='Image'
+declare -g ARCH='armhf'
+declare -g ARCHITECTURE='arm'
+declare -g KERNEL_SRC_ARCH='arm'
+declare -g QEMU_BINARY='qemu-arm-static'
+declare -g NAME_KERNEL='zImage'
+declare -g NAME_INITRD='uInitrd'
+declare -g INITRD_ARCH='arm'
+declare -g KERNEL_IMAGE_TYPE='Image'
 
 [[ -z $KERNEL_COMPILER ]] && KERNEL_COMPILER='arm-linux-gnueabihf-'
 [[ -z $UBOOT_USE_GCC ]] && UBOOT_USE_GCC='> 8.0'

--- a/config/sources/common.conf
+++ b/config/sources/common.conf
@@ -8,17 +8,17 @@
 #
 # this is sourced before any other arch specific config file, always. see main-config.sh
 
-export FAST_CREATE_IMAGE='yes'
-export MAIN_CMDLINE='rw no_console_suspend consoleblank=0 fsck.fix=yes fsck.repair=yes net.ifnames=0 splash plymouth.ignore-serial-consoles'
+declare -g FAST_CREATE_IMAGE='yes'
+declare -g MAIN_CMDLINE='rw no_console_suspend consoleblank=0 fsck.fix=yes fsck.repair=yes net.ifnames=0 splash plymouth.ignore-serial-consoles'
 
 # boot loader configuration
-[[ -z $BOOTSOURCE ]] && export BOOTSOURCE="$MAINLINE_UBOOT_SOURCE"
-[[ -z $BOOTDIR ]] && export BOOTDIR="$MAINLINE_UBOOT_DIR"
-[[ -z $BOOTBRANCH ]] && export BOOTBRANCH="${BOOTBRANCH_BOARD:-"tag:v2022.07"}"
+[[ -z $BOOTSOURCE ]] && declare -g BOOTSOURCE="$MAINLINE_UBOOT_SOURCE"
+[[ -z $BOOTDIR ]] && declare -g BOOTDIR="$MAINLINE_UBOOT_DIR"
+[[ -z $BOOTBRANCH ]] && declare -g BOOTBRANCH="${BOOTBRANCH_BOARD:-"tag:v2022.07"}"
 
 # kernel configuration
-[[ -z $KERNELDIR ]] && export KERNELDIR="$MAINLINE_KERNEL_DIR"
-[[ -z $KERNELSOURCE ]] && export KERNELSOURCE="$MAINLINE_KERNEL_SOURCE"
-[[ -z $KERNELBRANCH ]] && export KERNELBRANCH='branch:linux-6.0.y'
+[[ -z $KERNELDIR ]] && declare -g KERNELDIR="$MAINLINE_KERNEL_DIR"
+[[ -z $KERNELSOURCE ]] && declare -g KERNELSOURCE="$MAINLINE_KERNEL_SOURCE"
+[[ -z $KERNELBRANCH ]] && declare -g KERNELBRANCH='branch:linux-6.0.y'
 
 true # make sure to exit with 0 status; this protects against shortcircuits etc above.

--- a/config/sources/families/bcm2711.conf
+++ b/config/sources/families/bcm2711.conf
@@ -7,47 +7,47 @@
 # https://github.com/armbian/build/
 #
 enable_extension "flash-kernel"
-export LINUXFAMILY=bcm2711
-export ARCH=arm64
-export UEFI_FS_LABEL="RPICFG"               # Windows/Mac users will see this if they mount the SD card. Configurable, but should be uppercase always
-export SKIP_BOOTSPLASH="yes"                # video is init-ed before us
-export FK__PUBLISHED_KERNEL_VERSION="raspi" # flash kernel (FK) configuration
-export FK__KERNEL_PACKAGES=""
-export CPUMIN=500000
-export CPUMAX=2000000
-export GOVERNOR=ondemand
+declare -g LINUXFAMILY=bcm2711
+declare -g ARCH=arm64
+declare -g UEFI_FS_LABEL="RPICFG"               # Windows/Mac users will see this if they mount the SD card. Configurable, but should be uppercase always
+declare -g SKIP_BOOTSPLASH="yes"                # video is init-ed before us
+declare -g FK__PUBLISHED_KERNEL_VERSION="raspi" # flash kernel (FK) configuration
+declare -g FK__KERNEL_PACKAGES=""
+declare -g CPUMIN=500000
+declare -g CPUMAX=2000000
+declare -g GOVERNOR=ondemand
 
 case "${BRANCH}" in
 
 	ddk)
-		export RASPI_DISTRO_KERNEL=yes # This will cause board to include distro's prebuilt kernel, not from source
+		declare -g RASPI_DISTRO_KERNEL=yes # This will cause board to include distro's prebuilt kernel, not from source
 		;;
 
 	legacy)
-		export RASPI_DISTRO_KERNEL=no
-		export KERNELSOURCE='https://github.com/raspberrypi/linux'
-		export KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel. For mainline caching.
-		export KERNELBRANCH="branch:rpi-5.15.y"
-		export KERNELPATCHDIR="${LINUXFAMILY}-${BRANCH}"
-		export LINUXCONFIG="linux-${LINUXFAMILY}-${BRANCH}"
+		declare -g RASPI_DISTRO_KERNEL=no
+		declare -g KERNELSOURCE='https://github.com/raspberrypi/linux'
+		declare -g KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel. For mainline caching.
+		declare -g KERNELBRANCH="branch:rpi-5.15.y"
+		declare -g KERNELPATCHDIR="${LINUXFAMILY}-${BRANCH}"
+		declare -g LINUXCONFIG="linux-${LINUXFAMILY}-${BRANCH}"
 		;;
 
 	current)
-		export RASPI_DISTRO_KERNEL=no
-		export KERNELSOURCE='https://github.com/raspberrypi/linux'
-		export KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel. For mainline caching.
-		export KERNELBRANCH="branch:rpi-6.1.y"
-		export KERNELPATCHDIR="${LINUXFAMILY}-${BRANCH}"
-		export LINUXCONFIG="linux-${LINUXFAMILY}-${BRANCH}"
+		declare -g RASPI_DISTRO_KERNEL=no
+		declare -g KERNELSOURCE='https://github.com/raspberrypi/linux'
+		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel. For mainline caching.
+		declare -g KERNELBRANCH="branch:rpi-6.1.y"
+		declare -g KERNELPATCHDIR="${LINUXFAMILY}-${BRANCH}"
+		declare -g LINUXCONFIG="linux-${LINUXFAMILY}-${BRANCH}"
 		;;
 
 	edge)
-		export RASPI_DISTRO_KERNEL=no
-		export KERNELSOURCE='https://github.com/raspberrypi/linux'
-		export KERNEL_MAJOR_MINOR="6.2" # Major and minor versions of this kernel. For mainline caching.
-		export KERNELBRANCH="branch:rpi-6.2.y"
-		export KERNELPATCHDIR="${LINUXFAMILY}-${BRANCH}"
-		export LINUXCONFIG="linux-${LINUXFAMILY}-${BRANCH}"
+		declare -g RASPI_DISTRO_KERNEL=no
+		declare -g KERNELSOURCE='https://github.com/raspberrypi/linux'
+		declare -g KERNEL_MAJOR_MINOR="6.2" # Major and minor versions of this kernel. For mainline caching.
+		declare -g KERNELBRANCH="branch:rpi-6.2.y"
+		declare -g KERNELPATCHDIR="${LINUXFAMILY}-${BRANCH}"
+		declare -g LINUXCONFIG="linux-${LINUXFAMILY}-${BRANCH}"
 		;;
 esac
 
@@ -70,23 +70,23 @@ pre_flash_kernel__symlink_dtb_and_kernel() {
 
 extension_prepare_config__prepare_rpi_flash_kernel() {
 	display_alert "Preparing bcm2711" "${RELEASE}, distro kernel?: ${RASPI_DISTRO_KERNEL}" "info"
-	export RASPI_DISTRO_KERNEL="${RASPI_DISTRO_KERNEL:-no}" # Include a distro-built kernel?
-	export SERIALCON="${RASPI_SERIALCON:-tty1}"             # HDMI etc, not serial. most people don't have UART on rpi
+	declare -g RASPI_DISTRO_KERNEL="${RASPI_DISTRO_KERNEL:-no}" # Include a distro-built kernel?
+	declare -g SERIALCON="${RASPI_SERIALCON:-tty1}"             # HDMI etc, not serial. most people don't have UART on rpi
 	local usable_releases="jammy|kinetic|lunar"
 
 	if [[ "$RELEASE" =~ ^(${usable_releases})$ ]]; then
-		export FK__EXTRA_PACKAGES="rpi-eeprom linux-firmware linux-firmware-raspi pi-bluetooth libraspberrypi-bin cloud-initramfs-growroot"
+		declare -g FK__EXTRA_PACKAGES="rpi-eeprom linux-firmware linux-firmware-raspi pi-bluetooth libraspberrypi-bin cloud-initramfs-growroot"
 
 		if [[ "$RELEASE" =~ ^(jammy|kinetic)$ ]]; then # Add raspi-config for those releases that have it; it might be useful.
-			export FK__EXTRA_PACKAGES="${FK__EXTRA_PACKAGES} raspi-config"
+			declare -g FK__EXTRA_PACKAGES="${FK__EXTRA_PACKAGES} raspi-config"
 		fi
 
 		if [[ "${RASPI_DISTRO_KERNEL}" == "yes" ]]; then # and firmware.
 			unset KERNELSOURCE                              # Make sure Armbian will not try to compile from source.
-			export FK__KERNEL_PACKAGES="${FK__KERNEL_PACKAGES} linux-tools-raspi linux-raspi linux-image-raspi "
+			declare -g FK__KERNEL_PACKAGES="${FK__KERNEL_PACKAGES} linux-tools-raspi linux-raspi linux-image-raspi "
 			# Ubuntu Impish+ split the kernel modules, add the extra ones too.
 			if [[ "$RELEASE" =~ ^(jammy|kinetic)$ ]]; then
-				export FK__KERNEL_PACKAGES="${FK__KERNEL_PACKAGES} linux-modules-extra-raspi"
+				declare -g FK__KERNEL_PACKAGES="${FK__KERNEL_PACKAGES} linux-modules-extra-raspi"
 			fi
 		fi
 	else

--- a/config/sources/families/imx6.conf
+++ b/config/sources/families/imx6.conf
@@ -18,21 +18,21 @@ case $BRANCH in
 
 	legacy)
 
-		export KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
 		KERNELBRANCH='branch:linux-5.15.y'
 
 		;;
 
 	current)
 
-		export KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
 		KERNELBRANCH='branch:linux-6.1.y'
 
 		;;
 
 	edge)
 
-		export KERNEL_MAJOR_MINOR="6.2" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="6.2" # Major and minor versions of this kernel.
 		KERNELBRANCH='branch:linux-6.2.y'
 
 		;;

--- a/config/sources/families/imx7d.conf
+++ b/config/sources/families/imx7d.conf
@@ -19,7 +19,7 @@ case $BRANCH in
 	legacy)
 
 		KERNELSOURCE='https://source.codeaurora.org/external/imx/linux-imx'
-		export KERNEL_MAJOR_MINOR="4.14" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="4.14" # Major and minor versions of this kernel.
 		KERNELBRANCH='branch:imx_4.14.98_2.0.0_ga'
 		KERNELDIR='linux-imx7'
 		BOOTBRANCH='branch:imx_v2018.03_4.14.98_2.0.0_ga'
@@ -27,7 +27,7 @@ case $BRANCH in
 		;;
 	current)
 		KERNELSOURCE='https://source.codeaurora.org/external/imx/linux-imx'
-		export KERNEL_MAJOR_MINOR="5.4" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="5.4" # Major and minor versions of this kernel.
 		KERNELBRANCH='branch:imx_5.4.70_2.3.0'
 		KERNELDIR='linux-imx7-current'
 		BOOTBRANCH='branch:imx_v2020.04_5.4.70_2.3.0'

--- a/config/sources/families/include/meson64_common.inc
+++ b/config/sources/families/include/meson64_common.inc
@@ -17,6 +17,13 @@ BOOTBRANCH="${BOOTBRANCH_BOARD:-"tag:v2022.07"}"
 BOOTPATCHDIR="${BOOTPATCHDIR:-"v2022.07"}"
 OVERLAY_PREFIX='meson'
 
+# This is an extension method, put directly in meson64_common. A "built-in" extension if you will.
+# Bring in LibreELEC's amlogic-boot-fip repo, which is the authoritative source for FIP blobs.
+# To add FIP blobs for a new board, send a PR there, they're awesome.
+function fetch_sources_tools__libreelec_amlogic_fip() {
+	fetch_from_repo "https://github.com/LibreELEC/amlogic-boot-fip" "amlogic-boot-fip" "branch:master"
+}
+
 # this family does not need it
 ATF_COMPILE="no"
 
@@ -295,11 +302,4 @@ family_tweaks_bsp() {
 			EOF
 			;;
 	esac
-}
-
-# This is an extension method, put directly in meson64_common. A "built-in" extension if you will.
-# If used in more than one place, it could be moved to an extension: enable_extension "amlogic-fip-tools"
-function fetch_sources_tools__amlogic_fip() {
-	fetch_from_repo "https://github.com/armbian/odroidc2-blobs" "odroidc2-blobs" "branch:master"
-	fetch_from_repo "https://github.com/LibreELEC/amlogic-boot-fip" "amlogic-boot-fip" "branch:master"
 }

--- a/config/sources/families/include/meson64_common.inc
+++ b/config/sources/families/include/meson64_common.inc
@@ -39,13 +39,13 @@ GOVERNOR=${GOVERNOR:-ondemand}
 case $BRANCH in
 
 	current)
-		export KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel. For mainline caching.
+		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel. For mainline caching.
 		KERNELBRANCH='branch:linux-6.1.y'
 		KERNELPATCHDIR='meson64-current'
 		;;
 
 	edge)
-		export KERNEL_MAJOR_MINOR="6.2" # Major and minor versions of this kernel. For mainline caching.
+		declare -g KERNEL_MAJOR_MINOR="6.2" # Major and minor versions of this kernel. For mainline caching.
 		KERNELBRANCH='branch:linux-6.2.y'
 		KERNELPATCHDIR='meson64-edge'
 		;;

--- a/config/sources/families/include/meson_common.inc
+++ b/config/sources/families/include/meson_common.inc
@@ -44,7 +44,7 @@ esac
 case $BRANCH in
 	current)
 
-		export KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
 		KERNELBRANCH="branch:linux-6.1.y"
 		KERNELPATCHDIR='meson-'$BRANCH
 
@@ -52,7 +52,7 @@ case $BRANCH in
 
 	edge)
 
-		export KERNEL_MAJOR_MINOR="6.2" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="6.2" # Major and minor versions of this kernel.
 		KERNELBRANCH="branch:linux-6.2.y"
 		KERNELPATCHDIR='meson-'$BRANCH
 

--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -130,7 +130,7 @@ case $BRANCH in
 
 	current)
 
-		export KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
 		KERNELBRANCH="branch:linux-5.15.y"
 		KERNELPATCHDIR='rockchip64-'$BRANCH
 		LINUXFAMILY=rockchip64
@@ -140,7 +140,7 @@ case $BRANCH in
 	edge)
 
 		KERNELPATCHDIR='rockchip64-'$BRANCH
-		export KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
 		KERNELBRANCH="branch:linux-6.1.y"
 		LINUXFAMILY=rockchip64
 		LINUXCONFIG='linux-rockchip64-'$BRANCH

--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -7,31 +7,31 @@
 # https://github.com/armbian/build/
 #
 enable_extension "sunxi-tools"
-export ARCH=arm64
-export ATF_TARGET_MAP="PLAT=$ATF_PLAT DEBUG=1 bl31;;build/$ATF_PLAT/debug/bl31.bin"
-export BOOTDELAY=1
+declare -g ARCH=arm64
+declare -g ATF_TARGET_MAP="PLAT=$ATF_PLAT DEBUG=1 bl31;;build/$ATF_PLAT/debug/bl31.bin"
+declare -g BOOTDELAY=1
 
-export BOOTPATCHDIR='u-boot-sunxi'
-export BOOTENV_FILE='sunxi.txt'
+declare -g BOOTPATCHDIR='u-boot-sunxi'
+declare -g BOOTENV_FILE='sunxi.txt'
 UBOOT_TARGET_MAP="${UBOOT_TARGET_MAP:-;;u-boot-sunxi-with-spl.bin}"
-export BOOTSCRIPT='boot-sun50i-next.cmd:boot.cmd'
-export LINUXFAMILY=sunxi64
+declare -g BOOTSCRIPT='boot-sun50i-next.cmd:boot.cmd'
+declare -g LINUXFAMILY=sunxi64
 
 case $BRANCH in
 
 	legacy)
-		export KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
-		export KERNELBRANCH="tag:v5.15.104"
+		declare -g KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
+		declare -g KERNELBRANCH="tag:v5.15.104"
 		;;
 
 	current)
-		export KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		export KERNELBRANCH="tag:v6.1.21"
+		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
+		declare -g KERNELBRANCH="tag:v6.1.21"
 		;;
 
 	edge)
-		export KERNEL_MAJOR_MINOR="6.2" # Major and minor versions of this kernel.
-		export KERNELBRANCH="tag:v6.2.8"
+		declare -g KERNEL_MAJOR_MINOR="6.2" # Major and minor versions of this kernel.
+		declare -g KERNELBRANCH="tag:v6.2.8"
 		;;
 esac
 

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -7,32 +7,32 @@
 # https://github.com/armbian/build/
 #
 enable_extension "sunxi-tools"
-export ARCH=armhf
-export BOOTDELAY=1
-export BOOTPATCHDIR='u-boot-sunxi'
+declare -g ARCH=armhf
+declare -g BOOTDELAY=1
+declare -g BOOTPATCHDIR='u-boot-sunxi'
 UBOOT_TARGET_MAP="${UBOOT_TARGET_MAP:-;;u-boot-sunxi-with-spl.bin}"
-export BOOTSCRIPT="boot-sunxi.cmd:boot.cmd"
-export BOOTENV_FILE='sunxi.txt'
-export LINUXFAMILY=sunxi
-export UBOOT_FW_ENV='0x88000,0x20000' # /etc/fw_env.config offset and env size
-export ASOUND_STATE='asound.state.sunxi-next'
-export GOVERNOR=ondemand
+declare -g BOOTSCRIPT="boot-sunxi.cmd:boot.cmd"
+declare -g BOOTENV_FILE='sunxi.txt'
+declare -g LINUXFAMILY=sunxi
+declare -g UBOOT_FW_ENV='0x88000,0x20000' # /etc/fw_env.config offset and env size
+declare -g ASOUND_STATE='asound.state.sunxi-next'
+declare -g GOVERNOR=ondemand
 
 case $BRANCH in
 
 	legacy)
-		export KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
-		export KERNELBRANCH="tag:v5.15.104"
+		declare -g KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
+		declare -g KERNELBRANCH="tag:v5.15.104"
 		;;
 
 	current)
-		export KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		export KERNELBRANCH="tag:v6.1.21"
+		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
+		declare -g KERNELBRANCH="tag:v6.1.21"
 		;;
 
 	edge)
-		export KERNEL_MAJOR_MINOR="6.2" # Major and minor versions of this kernel.
-		export KERNELBRANCH="tag:v6.2.8"
+		declare -g KERNEL_MAJOR_MINOR="6.2" # Major and minor versions of this kernel.
+		declare -g KERNELBRANCH="tag:v6.2.8"
 		;;
 esac
 

--- a/config/sources/families/include/uefi_common.inc
+++ b/config/sources/families/include/uefi_common.inc
@@ -31,8 +31,8 @@ case "${BRANCH}" in
 
 		declare -g DISTRO_GENERIC_KERNEL=no
 		declare -g LINUXCONFIG="linux-uefi-${LINUXFAMILY}-${BRANCH}"
-		declare -g KERNEL_MAJOR_MINOR="6.1"                      # Major and minor versions of this kernel. For mainline caching.
-		declare -g KERNELBRANCH="branch:linux-6.1.y"             # Branch or tag to build from. It should match MAJOR_MINOR
+		declare -g KERNEL_MAJOR_MINOR="6.1"                       # Major and minor versions of this kernel. For mainline caching.
+		declare -g KERNELBRANCH="branch:linux-6.1.y"              # Branch or tag to build from. It should match MAJOR_MINOR
 		declare -g KERNELPATCHDIR="uefi-${LINUXFAMILY}-${BRANCH}" # Might be empty.
 		;;
 
@@ -40,8 +40,8 @@ case "${BRANCH}" in
 
 		declare -g DISTRO_GENERIC_KERNEL=no
 		declare -g LINUXCONFIG="linux-uefi-${LINUXFAMILY}-${BRANCH}"
-		declare -g KERNEL_MAJOR_MINOR="6.2"    # Major and minor versions of this kernel. For mainline caching.
-		declare -g KERNELBRANCH="branch:linux-6.2.y"             # Branch or tag to build from. It should match MAJOR_MINOR
+		declare -g KERNEL_MAJOR_MINOR="6.2"                       # Major and minor versions of this kernel. For mainline caching.
+		declare -g KERNELBRANCH="branch:linux-6.2.y"              # Branch or tag to build from. It should match MAJOR_MINOR
 		declare -g KERNELPATCHDIR="uefi-${LINUXFAMILY}-${BRANCH}" # Might be empty.
 		;;
 esac

--- a/config/sources/families/media.conf
+++ b/config/sources/families/media.conf
@@ -38,7 +38,7 @@ case $BRANCH in
 
 		if [[ $BOARD == station-p2 || $BOARD == station-m2 || $BOARD == bananapir2pro ]]; then
 			KERNELSOURCE='https://github.com/150balbes/rockchip-kernel'
-			export KERNEL_MAJOR_MINOR="4.19" # Major and minor versions of this kernel.
+			declare -g KERNEL_MAJOR_MINOR="4.19" # Major and minor versions of this kernel.
 			KERNELBRANCH='branch:kernel-4.19'
 			KERNELPATCHDIR='station-p2-'$BRANCH
 			LINUXFAMILY=station-p2
@@ -48,7 +48,7 @@ case $BRANCH in
 		elif [[ $BOARD == jetson-nano ]]; then
 			KERNELDIR='linux-nano'
 			KERNELSOURCE='https://github.com/150balbes/Jetson-Nano'
-			export KERNEL_MAJOR_MINOR="4.9" # Major and minor versions of this kernel.
+			declare -g KERNEL_MAJOR_MINOR="4.9" # Major and minor versions of this kernel.
 			KERNELBRANCH='branch:4.9.201'
 			KERNELPATCHDIR='jetson-nano-'$BRANCH
 			LINUXFAMILY=jetson-nano
@@ -59,7 +59,7 @@ case $BRANCH in
 			MODULES_INITRD="jetson-nano-legacy"
 		else
 			KERNELSOURCE='https://github.com/150balbes/rockchip-kernel'
-			export KERNEL_MAJOR_MINOR="5.10" # Major and minor versions of this kernel.
+			declare -g KERNEL_MAJOR_MINOR="5.10" # Major and minor versions of this kernel.
 			KERNELBRANCH='branch:kernel-5.10'
 			LINUXFAMILY=media
 			LINUXCONFIG='linux-media-'$BRANCH
@@ -68,7 +68,7 @@ case $BRANCH in
 		;;
 
 	current)
-		export KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
 		KERNELBRANCH="branch:linux-6.1.y"
 		LINUXCONFIG='linux-media-'$BRANCH
 		KERNELPATCHDIR='media-'$BRANCH
@@ -76,7 +76,7 @@ case $BRANCH in
 		;;
 
 	edge)
-		export KERNEL_MAJOR_MINOR="6.2" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="6.2" # Major and minor versions of this kernel.
 		KERNELBRANCH="branch:linux-6.2.y"
 		KERNELPATCHDIR='media-'$BRANCH
 		LINUXFAMILY=media

--- a/config/sources/families/meson-g12b.conf
+++ b/config/sources/families/meson-g12b.conf
@@ -9,47 +9,25 @@
 source "${BASH_SOURCE%/*}/include/meson64_common.inc"
 ASOUND_STATE="asound.state.meson64"
 
-if [[ -n ${USE_ODROID_UBOOT} ]] && [[ "${USE_ODROID_UBOOT}" == *"${BRANCH}"* ]]; then
-	# Current BRANCH is listed in USE_ODROID_UBOOT; use _ODROID variants if set.
-	BOOTCONFIG="${BOOTCONFIG_ODROID:-${BOOTCONFIG}}"
-	BOOTSCRIPT="${BOOTSCRIPT_ODROID:-${BOOTSCRIPT}}"
+# Mainline u-boot, everything is done by meson64_common.inc, we just need to handle FIP blobs
 
-	# Enable Odroid's legacy u-boot building. This requires old toolchains etc, but does NOT require FIP trees.
-	UBOOT_TARGET_MAP=';;sd_fuse/u-boot.bin'
-	UBOOT_USE_GCC='< 4.9'
-	UBOOT_TOOLCHAIN2="arm-none-eabi-:< 5.0"
-	UBOOT_COMPILER="aarch64-none-elf-"
-
-	BOOTSOURCE='https://github.com/hardkernel/u-boot.git'
-	BOOTBRANCH='branch:odroidg12-v2015.01'
-	BOOTPATCHDIR='u-boot-odroid'
-	BOOTDIR='u-boot-odroid'
-
-	write_uboot_platform() {
-		dd if=$1/u-boot.bin of=$2 bs=512 seek=1 conv=fsync > /dev/null 2>&1
-	}
-
-else
-	# Mainline u-boot, everything is done by meson64_common.inc, we just need to handle FIP blobs
-
-	# Handling of FIP blobs
-	uboot_custom_postprocess() {
-		# @TODO: these should come from FIP_TREE_BOARD/FIP_TREE_FAMILY vars in board.conf instead of hardcoded here
-		if [[ $BOARD == odroidn2* ]]; then
-			# FIP trees 'odroid-n2-plus' and 'odroid-n2' are identical.
-			uboot_g12_postprocess "$SRC"/cache/sources/amlogic-boot-fip/odroid-n2 g12b
-		elif [[ $BOARD == khadas-vim3 ]]; then
-			# 'khadas-vim3' FIP tree contains 'lpddr3_1d.fw' which will trigger '--ddrfw9' in uboot_g12_postprocess
-			uboot_g12_postprocess "$SRC"/cache/sources/amlogic-boot-fip/khadas-vim3 g12b
-		elif [[ $BOARD == radxa-zero2 ]]; then
-			uboot_g12_postprocess "$SRC"/cache/sources/amlogic-boot-fip/radxa-zero2 g12b
-		elif [[ $BOARD == bananapim2s ]]; then
-			uboot_g12_postprocess "$SRC"/cache/sources/amlogic-boot-fip/bananapi-m2s g12b
-		elif [[ $BOARD == bananapicm4io ]]; then
-			uboot_g12_postprocess "$SRC"/cache/sources/amlogic-boot-fip/bananapi-m2s g12b
-		else
-			echo "Don't know how to handle FIP trees for board '${BOARD}'"
-			exit 2
-		fi
-	}
-fi
+# Handling of FIP blobs
+function uboot_custom_postprocess() {
+	# @TODO: these should come from FIP_TREE_BOARD/FIP_TREE_FAMILY vars in board.conf instead of hardcoded here
+	if [[ $BOARD == odroidn2* ]]; then
+		# FIP trees 'odroid-n2-plus' and 'odroid-n2' are identical.
+		uboot_g12_postprocess "$SRC"/cache/sources/amlogic-boot-fip/odroid-n2 g12b
+	elif [[ $BOARD == khadas-vim3 ]]; then
+		# 'khadas-vim3' FIP tree contains 'lpddr3_1d.fw' which will trigger '--ddrfw9' in uboot_g12_postprocess
+		uboot_g12_postprocess "$SRC"/cache/sources/amlogic-boot-fip/khadas-vim3 g12b
+	elif [[ $BOARD == radxa-zero2 ]]; then
+		uboot_g12_postprocess "$SRC"/cache/sources/amlogic-boot-fip/radxa-zero2 g12b
+	elif [[ $BOARD == bananapim2s ]]; then
+		uboot_g12_postprocess "$SRC"/cache/sources/amlogic-boot-fip/bananapi-m2s g12b
+	elif [[ $BOARD == bananapicm4io ]]; then
+		uboot_g12_postprocess "$SRC"/cache/sources/amlogic-boot-fip/bananapi-m2s g12b
+	else
+		echo "Don't know how to handle FIP trees for board '${BOARD}'"
+		exit 2
+	fi
+}

--- a/config/sources/families/meson-gxbb.conf
+++ b/config/sources/families/meson-gxbb.conf
@@ -7,6 +7,12 @@
 # https://github.com/armbian/build/
 #
 source "${BASH_SOURCE%/*}/include/meson64_common.inc"
+
+# Fetch c2 blobs. Those are ancient, when first released by HK. Also used in meson-gxl.conf
+function fetch_sources_tools__amlogic_odroidc2_blobs_fip() {
+	fetch_from_repo "https://github.com/armbian/odroidc2-blobs" "odroidc2-blobs" "branch:master"
+}
+
 if [[ $BOARD == odroidc2 ]]; then
 	UBOOT_TARGET_MAP=";;$SRC/cache/sources/odroidc2-blobs/bl1.bin.hardkernel u-boot.bin"
 fi

--- a/config/sources/families/meson-gxl.conf
+++ b/config/sources/families/meson-gxl.conf
@@ -8,6 +8,11 @@
 #
 source "${BASH_SOURCE%/*}/include/meson64_common.inc"
 
+# Fetch c2 blobs. Those are ancient, when first released by HK. Also used in meson-gxbb.conf
+function fetch_sources_tools__amlogic_odroidc2_blobs_fip() {
+	fetch_from_repo "https://github.com/armbian/odroidc2-blobs" "odroidc2-blobs" "branch:master"
+}
+
 if [[ $BOARD == lafrite ]]; then
 	UBOOT_TARGET_MAP="u-boot-dtb.img;;u-boot.bin:u-boot.bin u-boot-dtb.img"
 fi
@@ -25,7 +30,6 @@ fi
 family_tweaks() {
 	:
 }
-
 
 uboot_custom_postprocess() {
 	if [[ $BOARD == lepotato ]]; then

--- a/config/sources/families/mt7623.conf
+++ b/config/sources/families/mt7623.conf
@@ -17,7 +17,7 @@ case $BRANCH in
 
 	legacy)
 
-		export KERNEL_MAJOR_MINOR="4.19" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="4.19" # Major and minor versions of this kernel.
 		KERNELBRANCH='branch:linux-4.19.y'
 
 		;;

--- a/config/sources/families/mvebu.conf
+++ b/config/sources/families/mvebu.conf
@@ -20,14 +20,14 @@ case $BRANCH in
 
 	current)
 
-		export KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
 		KERNELBRANCH='branch:linux-6.1.y'
 
 		;;
 
 	edge)
 
-		export KERNEL_MAJOR_MINOR="6.2" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="6.2" # Major and minor versions of this kernel.
 		KERNELBRANCH='branch:linux-6.2.y'
 
 		LINUXCONFIG='linux-mvebu-edge'

--- a/config/sources/families/mvebu64.conf
+++ b/config/sources/families/mvebu64.conf
@@ -17,7 +17,7 @@ enable_extension "c-plus-plus-compiler"
 # This is only used for non-Docker, since the Docker image already has it, since it includes compilers for all architectures.
 function add_host_dependencies__mvebu64_add_32_bit_c_compiler() {
 	display_alert "Adding armhf C compiler to host dependencies" "for mvebu64 BLx compile" "debug"
-	export EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} gcc-arm-linux-gnueabi" # @TODO: convert to array later
+	declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} gcc-arm-linux-gnueabi" # @TODO: convert to array later
 }
 
 ARCH=arm64
@@ -37,7 +37,7 @@ else
 fi
 
 if [[ $BOARD = macchiatobin-doubleshot ]]; then
-	export SCP_BL2=$SRC/cache/sources/marvell-binaries/mrvl_scp_bl2.img
+	declare -g SCP_BL2=$SRC/cache/sources/marvell-binaries/mrvl_scp_bl2.img
 
 	ATF_TARGET_MAP="USE_COHERENT_MEM=0 LOG_LEVEL=20 MV_DDR_PATH=$SRC/cache/sources/marvell-ddr SECURE=0 PLAT=a80x0_mcbin;;build/a80x0_mcbin/release/bl31.bin"
 	UBOOT_TARGET_MAP="DEVICE_TREE=armada-8040-mcbin ;;flash-image.bin"
@@ -56,13 +56,13 @@ case $BRANCH in
 
 	current)
 
-		export KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
 		KERNELBRANCH='branch:linux-5.15.y'
 
 		;;
 
 	edge)
-		export KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
 		KERNELBRANCH='branch:linux-6.1.y'
 		;;
 
@@ -102,14 +102,14 @@ family_tweaks_bsp() {
 atf_custom_postprocess() {
 	# prepare compilers for postprocess
 	ubootdir="$SRC/cache/sources/u-boot-worktree/$BOOTDIR/${BOOTBRANCH##*:}"
-	export ATF1=$toolchain/$ATF_COMPILER
+	declare -g ATF1=$toolchain/$ATF_COMPILER
 	if [[ "${SKIP_EXTERNAL_TOOLCHAINS}" == "yes" ]]; then
-		export TOOLCHAIN_NAME="arm-linux-gnueabi-"
+		declare -g TOOLCHAIN_NAME="arm-linux-gnueabi-"
 	else
-		export TOOLCHAIN_NAME="arm-none-linux-gnueabihf-"
+		declare -g TOOLCHAIN_NAME="arm-none-linux-gnueabihf-"
 	fi
-	export ATF2=$(find_toolchain "$TOOLCHAIN_NAME" "> 10.0")/$TOOLCHAIN_NAME
-	export BL33=$ubootdir"/u-boot.bin"
+	declare -g ATF2=$(find_toolchain "$TOOLCHAIN_NAME" "> 10.0")/$TOOLCHAIN_NAME
+	declare -g BL33=$ubootdir"/u-boot.bin"
 }
 
 uboot_custom_postprocess() {

--- a/config/sources/families/odroidxu4.conf
+++ b/config/sources/families/odroidxu4.conf
@@ -26,7 +26,7 @@ case $BRANCH in
 		;;
 
 	edge)
-		export KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
 		KERNELBRANCH='branch:linux-6.1.y'
 		KERNELDIR='linux-odroidxu4'
 		;;

--- a/config/sources/families/rk322x.conf
+++ b/config/sources/families/rk322x.conf
@@ -21,7 +21,7 @@ case $BRANCH in
 	legacy)
 
 		KERNELSOURCE='https://github.com/armbian/linux'
-		export KERNEL_MAJOR_MINOR="4.4" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="4.4" # Major and minor versions of this kernel.
 		KERNELBRANCH='branch:stable-4.4-rk3288-linux-v2.x'
 		KERNELDIR='linux-rockchip'
 
@@ -29,14 +29,14 @@ case $BRANCH in
 
 	current)
 
-		export KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
 		KERNELBRANCH='branch:linux-6.1.y'
 
 		;;
 
 	edge)
 
-		export KERNEL_MAJOR_MINOR="6.2" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="6.2" # Major and minor versions of this kernel.
 		KERNELBRANCH='branch:linux-6.2.y'
 
 		;;

--- a/config/sources/families/rk3399.conf
+++ b/config/sources/families/rk3399.conf
@@ -13,7 +13,7 @@ case $BRANCH in
 	legacy)
 
 		KERNELSOURCE='https://github.com/friendlyarm/kernel-rockchip'
-		export KERNEL_MAJOR_MINOR="4.4" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="4.4" # Major and minor versions of this kernel.
 		KERNELBRANCH='branch:nanopi4-linux-v4.4.y'
 		KERNELDIR='linux-rockchip64'
 		KERNELCONFIG='linux-rockchip64'

--- a/config/sources/families/rk3568-odroid.conf
+++ b/config/sources/families/rk3568-odroid.conf
@@ -22,7 +22,7 @@ SKIP_BOOTSPLASH="yes"
 case $BRANCH in
 
 	edge)
-		export KERNEL_MAJOR_MINOR="6.2"       # Major and minor versions of this kernel (for armbian-next)
+		declare -g KERNEL_MAJOR_MINOR="6.2" # Major and minor versions of this kernel (for armbian-next)
 		KERNELBRANCH='branch:linux-6.2.y'
 		KERNELPATCHDIR='archive/odroidm1-6.2' # Empty! Look ma, pure mainline!
 		;;

--- a/config/sources/families/rk35xx.conf
+++ b/config/sources/families/rk35xx.conf
@@ -21,7 +21,7 @@ case $BRANCH in
 		BOOTDIR='u-boot-rockchip64'
 		KERNELSOURCE='https://github.com/armbian/linux-rockchip.git'
 		KERNELBRANCH='branch:rockchip-5.10'
-		export KERNEL_MAJOR_MINOR="5.10" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="5.10" # Major and minor versions of this kernel.
 		KERNELDIR='linux-rockchip64'
 		KERNELPATCHDIR='rk35xx-legacy'
 

--- a/config/sources/families/rockchip-rk3588.conf
+++ b/config/sources/families/rockchip-rk3588.conf
@@ -22,7 +22,7 @@ case $BRANCH in
 		BOOTDIR='u-boot-rockchip64'
 		KERNELDIR='linux-rockchip64'
 		KERNELSOURCE='https://github.com/armbian/linux-rockchip'
-		export KERNEL_MAJOR_MINOR="5.10" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="5.10" # Major and minor versions of this kernel.
 		KERNELBRANCH='branch:rockchip-5.10'
 		KERNELPATCHDIR='rockchip-rk3588-legacy'
 		;;

--- a/config/sources/families/rockchip.conf
+++ b/config/sources/families/rockchip.conf
@@ -28,7 +28,7 @@ case $BRANCH in
 	legacy)
 
 		KERNELSOURCE='https://github.com/armbian/linux'
-		export KERNEL_MAJOR_MINOR="4.4" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="4.4" # Major and minor versions of this kernel.
 		KERNELBRANCH='branch:stable-4.4-rk3288-linux'
 		KERNELDIR='linux-rockchip'
 
@@ -36,14 +36,14 @@ case $BRANCH in
 
 	current)
 
-		export KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
 		KERNELBRANCH='branch:linux-6.1.y'
 
 		;;
 
 	edge)
 
-		export KERNEL_MAJOR_MINOR="6.2" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="6.2" # Major and minor versions of this kernel.
 		KERNELBRANCH='branch:linux-6.2.y'
 		;;
 

--- a/config/sources/families/rockchip64.conf
+++ b/config/sources/families/rockchip64.conf
@@ -13,7 +13,7 @@ case $BRANCH in
 	legacy)
 		KERNELDIR='linux-rockchip64'
 		KERNELSOURCE='https://github.com/ayufan-rock64/linux-kernel'
-		export KERNEL_MAJOR_MINOR="4.4" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="4.4" # Major and minor versions of this kernel.
 		KERNELBRANCH='tag:4.4.202-1237-rockchip-ayufan'
 		KERNELPATCHDIR='rockchip64-'$BRANCH
 		;;

--- a/config/sources/families/rockpis.conf
+++ b/config/sources/families/rockpis.conf
@@ -42,7 +42,7 @@ case $BRANCH in
 		UBOOT_USE_GCC='< 8.0'
 		BOOTDIR='u-boot-rockchip64'
 		KERNELSOURCE='https://github.com/piter75/rockchip-kernel'
-		export KERNEL_MAJOR_MINOR="4.4" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="4.4" # Major and minor versions of this kernel.
 		KERNELBRANCH='branch:rockpis-develop-4.4'
 		KERNELDIR='linux-rockchip64'
 		unset IDBLOADER_BLOB

--- a/config/sources/families/s5p6818.conf
+++ b/config/sources/families/s5p6818.conf
@@ -18,7 +18,7 @@ ATF_COMPILE="no"
 case $BRANCH in
 	legacy | current)
 		KERNELSOURCE='https://github.com/armbian/linux'
-		export KERNEL_MAJOR_MINOR="4.14" # Major and minor versions of this kernel. See https://github.com/armbian/linux/blob/s5p6818/Makefile
+		declare -g KERNEL_MAJOR_MINOR="4.14" # Major and minor versions of this kernel. See https://github.com/armbian/linux/blob/s5p6818/Makefile
 		KERNELBRANCH='branch:s5p6818'
 		KERNELDIR='linux-mainline'
 		;;

--- a/config/sources/families/sun50iw9.conf
+++ b/config/sources/families/sun50iw9.conf
@@ -18,7 +18,7 @@ case $BRANCH in
 
 		LINUXFAMILY=sun50iw9
 		KERNELSOURCE='https://github.com/orangepi-xunlong/linux-orangepi.git'
-		export KERNEL_MAJOR_MINOR="4.9" # Major and minor versions of this kernel.
+		declare -g KERNEL_MAJOR_MINOR="4.9" # Major and minor versions of this kernel.
 		KERNELBRANCH="branch:orange-pi-4.9-sun50iw9"
 		KERNELPATCHDIR=${BOARDFAMILY}-${BRANCH}
 		KERNELDIR='linux-orangepi'
@@ -85,7 +85,7 @@ family_tweaks_bsp() {
 uboot_custom_postprocess() {
 
 	if [[ ${BRANCH} == legacy ]]; then
-		export PATH=$SRC/packages/pack-uboot/${BOARDFAMILY}/tools/:$PATH
+		declare -g PATH=$SRC/packages/pack-uboot/${BOARDFAMILY}/tools/:$PATH
 		cp ${SRC}/packages/pack-uboot/${BOARDFAMILY}/bin/* . -r
 		cp sys_config/sys_config_${BOARD}.fex sys_config.fex
 		cp u-boot.bin u-boot.fex

--- a/config/sources/families/uefi-arm64.conf
+++ b/config/sources/families/uefi-arm64.conf
@@ -7,7 +7,7 @@
 # https://github.com/armbian/build/
 #
 # Important: LINUXFAMILY and ARCH are defined _before_ including the common family include
-export LINUXFAMILY="arm64"
-export ARCH="arm64"
+declare -g LINUXFAMILY="arm64"
+declare -g ARCH="arm64"
 source "${BASH_SOURCE%/*}/include/uefi_common.inc"
 enable_extension "grub"

--- a/config/sources/families/uefi-riscv64.conf
+++ b/config/sources/families/uefi-riscv64.conf
@@ -7,9 +7,9 @@
 # https://github.com/armbian/build/
 #
 # Important: LINUXFAMILY and ARCH are defined _before_ including the common family include
-export UBOOT_USE_GCC="none"
-export UEFI_GRUB_TERMINAL="gfxterm"
-export LINUXFAMILY="riscv64"
-export ARCH="riscv64"
+declare -g UBOOT_USE_GCC="none"
+declare -g UEFI_GRUB_TERMINAL="gfxterm"
+declare -g LINUXFAMILY="riscv64"
+declare -g ARCH="riscv64"
 source "${BASH_SOURCE%/*}/include/uefi_common.inc"
 enable_extension "grub-riscv64"

--- a/config/sources/families/uefi-x86.conf
+++ b/config/sources/families/uefi-x86.conf
@@ -8,8 +8,8 @@
 #
 # Important: LINUXFAMILY and ARCH are defined _before_ including the common family include
 [[ "$BUILD_DESKTOP" == yes && "$RELEASE" == jammy ]] && enable_extension "nvidia"
-export UEFI_GRUB_TERMINAL="gfxterm"
-export LINUXFAMILY="x86"
-export ARCH="amd64"
+declare -g UEFI_GRUB_TERMINAL="gfxterm"
+declare -g LINUXFAMILY="x86"
+declare -g ARCH="amd64"
 source "${BASH_SOURCE%/*}/include/uefi_common.inc"
 enable_extension "grub"

--- a/config/sources/families/virtual.conf
+++ b/config/sources/families/virtual.conf
@@ -8,7 +8,7 @@
 #
 BOOTBRANCH='tag:v2021.04'
 
-export KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
+declare -g KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
 KERNELBRANCH='branch:linux-5.15.y'
 
 ARCH=arm64

--- a/config/sources/families/zynq.conf
+++ b/config/sources/families/zynq.conf
@@ -11,7 +11,7 @@ SERIALCON='ttyPS0'
 LINUXFAMILY=zynq
 
 KERNELSOURCE='https://github.com/Xilinx/linux-xlnx.git'
-export KERNEL_MAJOR_MINOR="5.4" # Major and minor versions of this kernel. See https://github.com/Xilinx/linux-xlnx/blob/xilinx-v2020.2/Makefile
+declare -g KERNEL_MAJOR_MINOR="5.4" # Major and minor versions of this kernel. See https://github.com/Xilinx/linux-xlnx/blob/xilinx-v2020.2/Makefile
 KERNELBRANCH='tag:xilinx-v2020.2'
 KERNELDIR='linux-xlnx'
 KERNELPATCHDIR='zynq-'$BRANCH

--- a/config/sources/riscv64.conf
+++ b/config/sources/riscv64.conf
@@ -8,15 +8,15 @@
 #
 # 'common.conf' is already sourced when this arch is sourced.
 
-export ARCH='riscv64'
-export ARCHITECTURE='riscv'
-export KERNEL_SRC_ARCH='riscv'
-export QEMU_BINARY='qemu-riscv64-static'
-export NAME_KERNEL='Image'
-export NAME_INITRD='uInitrd'
-export KERNEL_IMAGE_TYPE='Image'
-export IMAGE_PARTITION_TABLE='gpt'
-export SKIP_EXTERNAL_TOOLCHAINS='yes'
+declare -g ARCH='riscv64'
+declare -g ARCHITECTURE='riscv'
+declare -g KERNEL_SRC_ARCH='riscv'
+declare -g QEMU_BINARY='qemu-riscv64-static'
+declare -g NAME_KERNEL='Image'
+declare -g NAME_INITRD='uInitrd'
+declare -g KERNEL_IMAGE_TYPE='Image'
+declare -g IMAGE_PARTITION_TABLE='gpt'
+declare -g SKIP_EXTERNAL_TOOLCHAINS='yes'
 
 [[ -z $KERNEL_COMPILER ]] && KERNEL_COMPILER='riscv64-linux-gnu-'
 [[ -z $UBOOT_COMPILER ]] && UBOOT_COMPILER='riscv64-linux-gnu-'


### PR DESCRIPTION
### rpardini's big-ish batch of `config` changes from late March/23

- (G) config: fix: replace undue `export` statements with `declare -g`; shellfmt
- (G) odroidn2: bump to 2022.10 u-boot with boot order patch and nothing else
  - remove old legacy uboot (odroidn2 hasn't even had a legacy BRANCH for a while)
- (G) meson64: only `gxbb` and `gxl` require fetching repo `odroidc2-blobs`, split hook

