### PR TITLE
Include alsa-utils in minimal cli builds

### DIFF
--- a/config/cli/common/main/packages
+++ b/config/cli/common/main/packages
@@ -1,3 +1,4 @@
+alsa-utils
 bc
 bridge-utils
 chrony

--- a/config/cli/common/main/packages.additional
+++ b/config/cli/common/main/packages.additional
@@ -1,4 +1,3 @@
-alsa-utils
 apt-file
 apt-utils
 aptitude


### PR DESCRIPTION
This ensures that the armbian-audio-config script actually works in minimal builds too.

This fixes #5012 (AR-1644)

# How Has This Been Tested?

 - `./compile.sh BOARD=orangepipc BRANCH=current RELEASE=jammy BUILD_MINIMAL=yes BUILD_DESKTOP=no KERNEL_CONFIGURE=prebuilt`
 - booting it
 - Installing mpg321
 - Trying to play some audio file on the minijack output: `mpg321 -a hw:0 sample-15s.mp3`, which produces audible sound
 - Using alsamixer to see that the "Line out" control of card 0 is indeed successfully unmuted and set to 45% (0dB), presumably by armbian-audio-config

# Checklist:

- [ ] ~~My code follows the style guidelines of this project~~ N/A
- [ ] ~~I have performed a self-review of my own code~~ N/A
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~ N/A
- [ ] ~~I have made corresponding changes to the documentation~~ N/A
- [X] My changes generate no new warnings
- [ ] ~~Any dependent changes have been merged and published in downstream modules~~ N/A