### PR TITLE
armbian-firstlogin: Make sure that the first charactor of username isn't number

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -249,7 +249,7 @@ add_user()
 	while [ -f "/root/.not_logged_in_yet" ]; do
 		echo -e "\nPlease provide a username (eg. your first name): \c"
 		read -r -e username
-		if ! grep '^[a-zA-Z0-9]*$' <<< "$username" > /dev/null ; then
+		if ! grep '^[a-zA-Z][a-zA-Z0-9]*$' <<< "$username" > /dev/null ; then
 			echo -e "\n\x1B[91mError\x1B[0m: illegal characters in username"
 			return
 		fi


### PR DESCRIPTION
# Description

#5007 Support unmbers in username. But don't make sure that the first charactor of username isn't number. So let's fix it.

# How Has This Been Tested?

- [x] Manual grep

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
