### PR TITLE
Enable non-free-firmware repository for Debian Sid

### DIFF
--- a/lib/functions/rootfs/distro-specific.sh
+++ b/lib/functions/rootfs/distro-specific.sh
@@ -147,11 +147,11 @@ function create_sources_list() {
 
 		sid) # sid is permanent unstable development and has no such thing as updates or security
 			cat <<- EOF > "${basedir}"/etc/apt/sources.list
-				deb http://${DEBIAN_MIRROR} $release main contrib non-free
-				#deb-src http://${DEBIAN_MIRROR} $release main contrib non-free
+				deb http://${DEBIAN_MIRROR} $release main contrib non-free non-free-firmware
+				#deb-src http://${DEBIAN_MIRROR} $release main contrib non-free non-free-firmware
 
-				deb http://${DEBIAN_MIRROR} unstable main contrib non-free
-				#deb-src http://${DEBIAN_MIRROR} unstable main contrib non-free
+				deb http://${DEBIAN_MIRROR} unstable main contrib non-free non-free-firmware
+				#deb-src http://${DEBIAN_MIRROR} unstable main contrib non-free non-free-firmware
 			EOF
 			;;
 


### PR DESCRIPTION
# Description

Addressing:

  [🐳|💥] Error context msg [ Installation of Armbian main packages for sid 3dsupport xfce no failed ]
  Error:  Error context msg Installation of Armbian main packages for sid 3dsupport xfce no failed
  [🐳|🔨]   Reading package lists...
  [🐳|🔨]   Building dependency tree...
  [🐳|🔨]   E: Unable to locate package firmware-sof-signed

Jira reference number [AR-1648]

# How Has This Been Tested?

- [ ] Not needed

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1648]: https://armbian.atlassian.net/browse/AR-1648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ