### PR TITLE
Remove broken font from Ubuntu Lunar

### DIFF
--- a/config/desktop/kinetic/environments/xfce/config_base/packages
+++ b/config/desktop/kinetic/environments/xfce/config_base/packages
@@ -43,7 +43,6 @@ keyutils
 laptop-detect
 libatk-adaptor
 libfontconfig1
-libfontembed1
 libfontenc1
 libgail-common
 libgl1-mesa-dri


### PR DESCRIPTION
# Description

  [🐳|🌱] Installing 128 desktop packages [ lunar xfce ]
  [🐳|🔨]   E: Unable to locate package libfontembed1
  [🐳|🔨]   Reading package lists...
  [🐳|🔨]   Building dependency tree...
  [🐳|🔨]   Reading state information...
  [🐳|🔨]   E: Unable to locate package libfontembed1
