### PR TITLE
Update odroidxu4-current to 5.4.239

### DIFF
--- a/patch/kernel/archive/odroidxu4-5.4/patch-5.4.238-239.patch
+++ b/patch/kernel/archive/odroidxu4-5.4/patch-5.4.238-239.patch
@@ -1,0 +1,16 @@
+diff --git a/Makefile b/Makefile
+index 436450833e1c2..f966eeb6b9bca 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,7 +1,7 @@
+ # SPDX-License-Identifier: GPL-2.0
+ VERSION = 5
+ PATCHLEVEL = 4
+-SUBLEVEL = 238
++SUBLEVEL = 239
+ EXTRAVERSION =
+ NAME = Kleptomaniac Octopus
+ 
+diff --git a/tools/testing/selftests/net/fib_tests.sh b/tools/testing/selftests/net/fib_tests.sh
+old mode 100644
+new mode 100755


### PR DESCRIPTION
# Description

Update odroidxu4-current kernel to 5.4.239.

# How Has This Been Tested?

- [x] Reboot of my Odroid HC1

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules