### PR TITLE
artifact-uboot: add hashes for extension and old-timey `-H`ooks and `-V`ariables hash

### DIFF
--- a/lib/functions/artifacts/artifact-uboot.sh
+++ b/lib/functions/artifacts/artifact-uboot.sh
@@ -129,7 +129,15 @@ function artifact_uboot_build_from_sources() {
 
 	declare uboot_git_revision="not_determined_yet"
 	LOG_SECTION="uboot_prepare_git" do_with_logging_unless_user_terminal uboot_prepare_git
-	LOG_SECTION="compile_uboot" do_with_logging compile_uboot
+
+	# Hack, if UBOOT_CONFIGURE=yes, don't run under logging manager. Emit a warning about it.
+	if [[ "${UBOOT_CONFIGURE:-"no"}" == "yes" ]]; then
+		display_alert "Warning" "UBOOT_CONFIGURE=yes, so we're not logging the build process of u-boot so it can be interactive." "wrn"
+		compile_uboot
+		display_alert "Warning" "UBOOT_CONFIGURE=yes, so we've not logged the build process of u-boot so it could be interactive." "wrn"
+	else
+		LOG_SECTION="compile_uboot" do_with_logging compile_uboot
+	fi
 }
 
 function artifact_uboot_cli_adapter_pre_run() {

--- a/lib/functions/artifacts/artifact-uboot.sh
+++ b/lib/functions/artifacts/artifact-uboot.sh
@@ -55,6 +55,34 @@ function artifact_uboot_prepare_version() {
 	patches_hash="${hash_files}"
 	declare uboot_patches_hash_short="${patches_hash:0:${short_hash_size}}"
 
+	# Hash the extension hooks
+	declare -a extension_hooks_to_hash=(
+		"post_uboot_custom_postprocess" "fetch_custom_uboot" "build_custom_uboot"
+		"pre_config_uboot_target" "post_uboot_custom_postprocess" "post_uboot_custom_postprocess"
+	)
+	declare -a extension_hooks_hashed=("$(dump_extension_method_sources_functions "${extension_hooks_to_hash[@]}")")
+	declare hash_hooks="undetermined"
+	hash_hooks="$(echo "${extension_hooks_hashed[@]}" | sha256sum | cut -d' ' -f1)"
+
+	# Hash the old-timey hooks
+	declare hash_functions="undetermined"
+	calculate_hash_for_function_bodies "write_uboot_platform" "write_uboot_platform_mtd" "setup_write_uboot_platform"
+	declare hash_uboot_functions="${hash_functions}"
+
+	# Hash those two together
+	declare hash_hooks_and_functions="undetermined"
+	hash_hooks_and_functions="$(echo "${hash_hooks}" "${hash_uboot_functions}" | sha256sum | cut -d' ' -f1)"
+	declare hash_hooks_and_functions_short="${hash_hooks_and_functions:0:${short_hash_size}}"
+
+	# Hash variables that affect the build and package of u-boot
+	declare -a vars_to_hash=(
+		"${BOOTDELAY}" "${UBOOT_DEBUGGING}"
+	)
+	declare hash_vars="undetermined"
+	hash_vars="$(echo "${vars_to_hash[@]}" | sha256sum | cut -d' ' -f1)"
+	declare vars_config_hash="${hash_vars}"
+	declare var_config_hash_short="${vars_config_hash:0:${short_hash_size}}"
+
 	# get the hashes of the lib/ bash sources involved...
 	declare hash_files="undetermined"
 	calculate_hash_for_files "${SRC}"/lib/functions/compilation/uboot*.sh
@@ -62,12 +90,15 @@ function artifact_uboot_prepare_version() {
 	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
 
 	# outer scope
-	artifact_version="${artifact_prefix_version}${GIT_INFO_UBOOT[MAKEFILE_VERSION]}-S${short_sha1}-P${uboot_patches_hash_short}-B${bash_hash_short}"
+	artifact_version="${artifact_prefix_version}${GIT_INFO_UBOOT[MAKEFILE_VERSION]}-S${short_sha1}-P${uboot_patches_hash_short}-H${hash_hooks_and_functions_short}-V${var_config_hash_short}-B${bash_hash_short}"
 
 	declare -a reasons=(
 		"version \"${GIT_INFO_UBOOT[MAKEFILE_FULL_VERSION]}\""
 		"git revision \"${GIT_INFO_UBOOT[SHA1]}\""
 		"patches hash \"${patches_hash}\""
+		"Extension hooks hash \"${hash_hooks}\""
+		"uboot functions hash \"${hash_uboot_functions}\""
+		"variables hash \"${vars_config_hash}\""
 		"framework bash hash \"${bash_hash}\""
 	)
 

--- a/lib/functions/compilation/uboot.sh
+++ b/lib/functions/compilation/uboot.sh
@@ -144,6 +144,14 @@ function compile_uboot_target() {
 
 	fi
 
+	if [[ "${UBOOT_CONFIGURE:-"no"}" == "yes" ]]; then
+		display_alert "Configuring u-boot" "UBOOT_CONFIGURE=yes; experimental" "warn"
+		run_host_command_dialog make menuconfig
+		display_alert "Exporting saved config" "UBOOT_CONFIGURE=yes; experimental" "warn"
+		run_host_command_logged make savedefconfig
+		run_host_command_logged cp -v defconfig "${DEST}/defconfig-uboot-${BOARD}-${BRANCH}"
+	fi
+
 	# workaround when two compilers are needed
 	cross_compile="CROSS_COMPILE=\"$CCACHE $UBOOT_COMPILER\""
 	[[ -n $UBOOT_TOOLCHAIN2 ]] && cross_compile="ARMBIAN=foe" # empty parameter is not allowed

--- a/lib/functions/general/hash-files.sh
+++ b/lib/functions/general/hash-files.sh
@@ -62,3 +62,22 @@ function calculate_hash_for_files() {
 		display_alert "Full hash input for files:" "\n${full_hash}\n" "debug"
 	fi
 }
+
+# helper, not strictly about files, but about functions. still hashing, though. outer scope: declare hash_functions="undetermined"
+function calculate_hash_for_function_bodies() {
+	declare -a function_bodies=()
+	for func in "$@"; do
+		# skip if function doesn't exist...
+		if [[ $(type -t "${func}") != function ]]; then
+			continue
+		fi
+		function_bodies+=("$(declare -f "${func}")")
+	done
+
+	if [[ ${#function_bodies[@]} -eq 0 ]]; then
+		hash_functions="0000000000000000"
+	else
+		hash_functions="$(echo "${function_bodies[@]}" | sha256sum | cut -d' ' -f1)"
+	fi
+	return 0
+}


### PR DESCRIPTION
Now changes to most variables/hooks affecting u-boot are correctly hashed and changes cause a recompile/cache miss as they should

- Extra: `UBOOT_CONFIGURE=yes` experimental, nothing fancy or magic, might be useful for some, does not export patches, only the defconfig bare. Goes a bit crazy if multiple targets (runs and exports twice+).
