### PR TITLE
Changing Debian Bookworm to supported

### DIFF
--- a/config/distributions/bookworm/support
+++ b/config/distributions/bookworm/support
@@ -1,1 +1,1 @@
-csc
+supported


### PR DESCRIPTION
# Description

Changing support status - merge when the time is right.

Jira reference number [AR-1651]

# How Has This Been Tested?

No need, status change.

[AR-1651]: https://armbian.atlassian.net/browse/AR-1651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ