### PR TITLE
Remove kernel package hash from MOTD

### DIFF
--- a/packages/bsp/common/etc/update-motd.d/10-armbian-header
+++ b/packages/bsp/common/etc/update-motd.d/10-armbian-header
@@ -13,6 +13,8 @@ THIS_SCRIPT="header"
 MOTD_DISABLE=""
 
 [[ -f /etc/armbian-release ]] && . /etc/armbian-release
+NOHASH_VERSION=$(echo $VERSION | sed 's/--.*//;/^$/d') # we don't need to show cache hash here
+
 if [[ -f /etc/armbian-distribution-status ]]; then
 	. /etc/armbian-distribution-status
 	[[ -f /etc/lsb-release ]] && DISTRIBUTION_CODENAME=$(grep CODENAME /etc/lsb-release | cut -d"=" -f2)
@@ -33,7 +35,7 @@ KERNELID=$(uname -r)
 [[ -f /proc/device-tree/model ]] && [[ -n $(tr -d '\000' < /proc/device-tree/model | grep ODROID | grep Plus) ]] && BOARD_NAME+="+"
 
 TERM=linux toilet -f standard -F metal $(echo $BOARD_NAME | sed 's/Orange Pi/OPi/' | sed 's/NanoPi/NPi/' | sed 's/Banana Pi/BPi/')
-echo -e "Welcome to \e[0;91mArmbian ${VERSION} ${DISTRIBUTION_CODENAME^}\x1B[0m with $([[ $BRANCH == edge ]] && echo -e "\e[0;91mbleeding\x1B[0m edge " )\e[0;91mLinux $KERNELID\x1B[0m\n"
+echo -e "Welcome to \e[0;91mArmbian ${NOHASH_VERSION} ${DISTRIBUTION_CODENAME^}\x1B[0m with $([[ $BRANCH == edge ]] && echo -e "\e[0;91mbleeding\x1B[0m edge " )\e[0;91mLinux $KERNELID\x1B[0m\n"
 
 # displaying status warnings
 


### PR DESCRIPTION
# Description

We don’t need to scare people with displaying odd hash version.

Before:
```
 _   _ _____ _____ ___        ___   __   
| | | | ____|  ___|_ _| __  _( _ ) / /_  
| | | |  _| | |_   | |  \ \/ / _ \| '_ \ 
| |_| | |___|  _|  | |   >  < (_) | (_) |
 \___/|_____|_|   |___| /_/\_\___/ \___/ 
                                         
Welcome to Armbian 23.05.0-trunk--1-PC7446-V521e-H1f65-Be6c1 Jammy with Linux 5.15.106-x86

No end-user support: built from trunk
```

After:
```
 _   _ _____ _____ ___        ___   __   
| | | | ____|  ___|_ _| __  _( _ ) / /_  
| | | |  _| | |_   | |  \ \/ / _ \| '_ \ 
| |_| | |___|  _|  | |   >  < (_) | (_) |
 \___/|_____|_|   |___| /_/\_\___/ \___/ 
                                         
Welcome to Armbian 23.05.0-trunk Jammy with Linux 5.15.106-x86

No end-user support: built from trunk
```
Jira reference number [AR-1654]

# How Has This Been Tested?

- [x] Manual execution

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1654]: https://armbian.atlassian.net/browse/AR-1654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ