### PR TITLE
fixes for general 32-bit bootloader compile on `sunxi`/`sunxi64` and `sun50iw9` legacy u-boot postprocess

### DIFF
--- a/config/sources/families/sun50iw9.conf
+++ b/config/sources/families/sun50iw9.conf
@@ -38,15 +38,15 @@ case $BRANCH in
 
 		ASOUND_STATE='asound.state.sun50iw9-legacy'
 
-		write_uboot_platform() {
-			dd if=$1/boot0_sdcard.fex of=$2 bs=8k seek=1 conv=fsync > /dev/null 2>&1
-			dd if=$1/boot_package.fex of=$2 bs=8k seek=2050 conv=fsync > /dev/null 2>&1 || true
+		# this overrides the one in sunxi64_common.inc
+		function write_uboot_platform() {
+			dd if=$1/boot0_sdcard.fex of=$2 bs=8k seek=1 conv=fsync
+			dd if=$1/boot_package.fex of=$2 bs=8k seek=2050 conv=fsync
 		}
 
 		;;
 
 	current | edge)
-
 		ATFSOURCE='https://github.com/ARM-software/arm-trusted-firmware'
 		ATFBRANCH='branch:master'
 		ATF_PLAT="sun50i_h616"
@@ -56,21 +56,18 @@ case $BRANCH in
 		;;
 esac
 
-family_tweaks_s() {
+function family_tweaks_s() {
 	if [[ -f $SDCARD/lib/systemd/system/aw859a-bluetooth.service ]]; then
-
 		# Enable Bluetooth
 		chroot $SDCARD /bin/bash -c "systemctl --no-reload enable aw859a-bluetooth.service >/dev/null 2>&1"
 	fi
 
 	if [[ -f $SDCARD/lib/systemd/system/hdmi-audio.service ]]; then
-
 		chroot $SDCARD /bin/bash -c "systemctl --no-reload enable hdmi-audio.service >/dev/null 2>&1"
 	fi
 }
 
-family_tweaks_bsp() {
-
+function family_tweaks_bsp() {
 	if [[ ${BOARD} == orangepizero2 && ${BRANCH} == legacy ]]; then
 		install -m 755 $SRC/packages/blobs/bt/hciattach/hciattach_opi_$ARCH $destination/usr/bin/hciattach_opi
 		cp $SRC/packages/bsp/sunxi/aw859a-bluetooth.service $destination/lib/systemd/system/
@@ -82,29 +79,22 @@ family_tweaks_bsp() {
 	fi
 }
 
-uboot_custom_postprocess() {
-
+function uboot_custom_postprocess() {
 	if [[ ${BRANCH} == legacy ]]; then
-		declare -g PATH=$SRC/packages/pack-uboot/${BOARDFAMILY}/tools/:$PATH
-		cp ${SRC}/packages/pack-uboot/${BOARDFAMILY}/bin/* . -r
-		cp sys_config/sys_config_${BOARD}.fex sys_config.fex
-		cp u-boot.bin u-boot.fex
-
-		# make u-boot dtb
-		$SRC/packages/pack-uboot/${BOARDFAMILY}/tools/dtc -p 2048 -W no-unit_address_vs_reg -@ -O dtb -o ${BOARD}-u-boot.dtb -b 0 dts/${BOARD}-u-boot.dts
-
-		# @TODO: rpardini: hmm? # busybox unix2dos sys_config.fex
-		$SRC/packages/pack-uboot/${BOARDFAMILY}/tools/script sys_config.fex
-		cp ${BOARD}-u-boot.dtb sunxi.fex
-		$SRC/packages/pack-uboot/${BOARDFAMILY}/tools/update_dtb sunxi.fex 4096
-		$SRC/packages/pack-uboot/${BOARDFAMILY}/tools/update_boot0 boot0_sdcard.fex sys_config.bin SDMMC_CARD
-
-		$SRC/packages/pack-uboot/${BOARDFAMILY}/tools/update_uboot -no_merge u-boot.fex sys_config.bin
-		update_uboot -no_merge u-boot.bin sys_config.bin
-		#pack boot package
-
-		# @TODO: rpardini: hmm? # busybox unix2dos boot_package.cfg
-		$SRC/packages/pack-uboot/${BOARDFAMILY}/tools/dragonsecboot -pack boot_package.cfg
+		display_alert "Post-processing U-Boot" "$BOARD - $BRANCH" "info"
+		run_host_command_logged cp -pv ${SRC}/packages/pack-uboot/${BOARDFAMILY}/bin/* . -r
+		run_host_command_logged cp -pv sys_config/sys_config_${BOARD}.fex sys_config.fex
+		run_host_command_logged cp -pv u-boot.bin u-boot.fex
+		run_host_command_logged dtc -p 2048 -W no-unit_address_vs_reg -@ -O dtb -o ${BOARD}-u-boot.dtb -b 0 dts/${BOARD}-u-boot.dts
+		run_host_command_logged $SRC/packages/pack-uboot/${BOARDFAMILY}/tools/script sys_config.fex
+		run_host_command_logged cp -pv ${BOARD}-u-boot.dtb sunxi.fex
+		run_host_command_logged $SRC/packages/pack-uboot/${BOARDFAMILY}/tools/update_dtb sunxi.fex 4096
+		run_host_command_logged $SRC/packages/pack-uboot/${BOARDFAMILY}/tools/update_boot0 boot0_sdcard.fex sys_config.bin SDMMC_CARD
+		# @TODO: rpardini: this looks wrong
+		run_host_command_logged $SRC/packages/pack-uboot/${BOARDFAMILY}/tools/update_uboot -no_merge u-boot.fex sys_config.bin
+		run_host_command_logged $SRC/packages/pack-uboot/${BOARDFAMILY}/tools/update_uboot -no_merge u-boot.bin sys_config.bin
+		run_host_command_logged $SRC/packages/pack-uboot/${BOARDFAMILY}/tools/dragonsecboot -pack boot_package.cfg
 	fi
 
+	return 0
 }

--- a/extensions/sunxi-tools.sh
+++ b/extensions/sunxi-tools.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+
+# Most sunxi stuff, even if 64-bit, requires 32-bit compiler, add it.
+# This is only used for non-Docker, since the Docker image already has it, since it includes compilers for all architectures.
+function add_host_dependencies__sunxi_add_32_bit_c_compiler() {
+	display_alert "Adding armhf C compiler to host dependencies" "for sunxi bootloader compile" "debug"
+	declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} gcc-arm-linux-gnueabi" # @TODO: convert to array later
+}
+
 function fetch_sources_tools__sunxi_tools() {
 	fetch_from_repo "https://github.com/linux-sunxi/sunxi-tools" "sunxi-tools" "branch:master"
 }


### PR DESCRIPTION
#### fixes for general 32-bit bootloader compile on `sunxi`/`sunxi64` and `sun50iw9` legacy u-boot postprocess

- `sun50iw9`/`legacy`: armbian-next'ify, add logging, avoid changing global `PATH`, use host `dtc` utility, make `write_uboot_platform()` verbose 
- sunxi-tools: bring in `gcc-arm-linux-gnueabi` hostdep required for building sunxi's boot stages (even on arm64 targets)