### PR TITLE
appgroup/office: add libreoffice-gtk3 for ime support

### DIFF
--- a/config/desktop/bullseye/appgroups/office/packages
+++ b/config/desktop/bullseye/appgroups/office/packages
@@ -1,1 +1,2 @@
 libreoffice
+libreoffice-gtk3

--- a/config/desktop/buster/appgroups/office/packages
+++ b/config/desktop/buster/appgroups/office/packages
@@ -1,2 +1,3 @@
 libreoffice
+libreoffice-gtk3
 libreoffice-style-tango

--- a/config/desktop/focal/appgroups/office/packages
+++ b/config/desktop/focal/appgroups/office/packages
@@ -1,3 +1,4 @@
 libreoffice
+libreoffice-gtk3
 libreoffice-style-elementary
 simple-scan

--- a/config/desktop/sid/appgroups/office/packages
+++ b/config/desktop/sid/appgroups/office/packages
@@ -1,1 +1,2 @@
 libreoffice
+libreoffice-gtk3


### PR DESCRIPTION
# Description

Input method such as fcitx5 requires applications running under gtk or qt. We have another choice `libreoffice-qt5`, but I think preinstalled `libreoffice-gtk3` should be okay.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
