### PR TITLE
legacy kernel custom uImage/etc via new `pre_package_kernel_image` hook; fixes for `orangepizero2`/`sun50iw9`/`legacy`

### DIFF
--- a/config/boards/orangepizero2.conf
+++ b/config/boards/orangepizero2.conf
@@ -12,14 +12,13 @@ PACKAGE_LIST_BOARD="rfkill bluetooth bluez bluez-tools"
 FORCE_BOOTSCRIPT_UPDATE="yes"
 
 function post_family_tweaks_bsp__orangepizero2_BSP() {
-    display_alert "Installing BSP firmware and fixups"
+	display_alert "Installing BSP firmware and fixups"
+	: "${destination:?}"
 
 	if [[ $BRANCH == legacy ]]; then
-
 		# Bluetooth for most of others (custom patchram is needed only in legacy)
 		install -m 755 $SRC/packages/bsp/rk3399/brcm_patchram_plus_rk3399 $destination/usr/bin
 		cp $SRC/packages/bsp/rk3399/rk3399-bluetooth.service $destination/lib/systemd/system/
-
 	fi
 
 	return 0

--- a/config/bootscripts/boot-sun50iw9.cmd
+++ b/config/bootscripts/boot-sun50iw9.cmd
@@ -61,6 +61,7 @@ for overlay_file in ${user_overlays}; do
         fi
 done
 
+# Legacy uboot, requires uImage - see pre_package_kernel_image__orangepi_legacy_uImage_manual_conversion()
 load ${devtype} ${devnum} ${ramdisk_addr_r} ${prefix}uInitrd
 load ${devtype} ${devnum} ${kernel_addr_r} ${prefix}uImage
 

--- a/config/sources/amd64.conf
+++ b/config/sources/amd64.conf
@@ -15,12 +15,16 @@ declare -g QEMU_BINARY='qemu-x86_64-static' # Hopefully you have this installed.
 declare -g MAIN_CMDLINE=''                  # we set it in common, it was not set before
 declare -g KERNEL_COMPILER=' '              # hack: use single space for host gcc. won't work on arm64 hosts
 declare -g KERNEL_USE_GCC=' '               # more hacks.
-declare -g KERNEL_IMAGE_TYPE='bzImage'      # Ubuntu Standard
-declare -g KERNEL_INSTALL_TYPE='install'    # the only one
 declare -g KERNEL_EXTRA_TARGETS='modules'   # default is "modules dtb" but x86_64 has no DTB
 declare -g KERNEL_BUILD_DTBS="no"           # amd64 has no DTBs. that I know of.
 declare -g UBOOT_USE_GCC='none'             # required by configuration.sh
 #declare -g INITRD_ARCH=amd64               # Used by u-boot for mkimage in initramfs. No u-boot for x86 yet.
+
+# Defaults, if not set by board or family.
+declare -g KERNEL_IMAGE_TYPE="${KERNEL_IMAGE_TYPE:-"bzImage"}"
+declare -g KERNEL_INSTALL_TYPE="${KERNEL_INSTALL_TYPE:-"install"}"
+#declare -g NAME_KERNEL="${NAME_KERNEL:-""}"
+#declare -g NAME_INITRD="${NAME_INITRD:-""}"
 
 # Default to mainline
 [[ -z $KERNELSOURCE ]] && KERNELSOURCE=$MAINLINE_KERNEL_SOURCE

--- a/config/sources/arm64.conf
+++ b/config/sources/arm64.conf
@@ -12,10 +12,12 @@ declare -g ARCH='arm64'
 declare -g ARCHITECTURE='arm64'
 declare -g KERNEL_SRC_ARCH='arm64'
 declare -g QEMU_BINARY='qemu-aarch64-static'
-declare -g KERNEL_IMAGE_TYPE='Image'
-declare -g KERNEL_INSTALL_TYPE='install'
-declare -g NAME_KERNEL='Image'
-declare -g NAME_INITRD='uInitrd'
+
+# Defaults, if not set by board or family.
+declare -g KERNEL_IMAGE_TYPE="${KERNEL_IMAGE_TYPE:-"Image"}"
+declare -g KERNEL_INSTALL_TYPE="${KERNEL_INSTALL_TYPE:-"install"}"
+declare -g NAME_KERNEL="${NAME_KERNEL:-"Image"}"
+declare -g NAME_INITRD="${NAME_INITRD:-"uInitrd"}"
 
 [[ -z $KERNEL_COMPILER ]] && KERNEL_COMPILER="aarch64-linux-gnu-"
 [[ -z $INITRD_ARCH ]] && INITRD_ARCH=arm64

--- a/config/sources/armhf.conf
+++ b/config/sources/armhf.conf
@@ -12,11 +12,13 @@ declare -g ARCH='armhf'
 declare -g ARCHITECTURE='arm'
 declare -g KERNEL_SRC_ARCH='arm'
 declare -g QEMU_BINARY='qemu-arm-static'
-[[ -z $KERNEL_IMAGE_TYPE ]] && declare -g KERNEL_IMAGE_TYPE='zImage'
-[[ -z $KERNEL_INSTALL_TYPE ]] && declare -g KERNEL_INSTALL_TYPE='zinstall'
-[[ -z $NAME_KERNEL ]] && declare -g NAME_KERNEL='zImage'
-declare -g NAME_INITRD='uInitrd'
 declare -g INITRD_ARCH='arm'
+
+# Defaults, if not set by board or family.
+declare -g KERNEL_IMAGE_TYPE="${KERNEL_IMAGE_TYPE:-"zImage"}"
+declare -g KERNEL_INSTALL_TYPE="${KERNEL_INSTALL_TYPE:-"zinstall"}"
+declare -g NAME_KERNEL="${NAME_KERNEL:-"zImage"}"
+declare -g NAME_INITRD="${NAME_INITRD:-"uInitrd"}"
 
 [[ -z $KERNEL_COMPILER ]] && KERNEL_COMPILER='arm-linux-gnueabihf-'
 [[ -z $UBOOT_USE_GCC ]] && UBOOT_USE_GCC='> 8.0'

--- a/config/sources/families/sun50iw9.conf
+++ b/config/sources/families/sun50iw9.conf
@@ -16,12 +16,27 @@ case $BRANCH in
 
 	legacy)
 
+		# Legacy kernel
 		LINUXFAMILY=sun50iw9
 		KERNELSOURCE='https://github.com/orangepi-xunlong/linux-orangepi.git'
 		declare -g KERNEL_MAJOR_MINOR="4.9" # Major and minor versions of this kernel.
 		KERNELBRANCH="branch:orange-pi-4.9-sun50iw9"
 		KERNELPATCHDIR=${BOARDFAMILY}-${BRANCH}
 		KERNELDIR='linux-orangepi'
+		INITRD_ARCH=arm
+		ASOUND_STATE='asound.state.sun50iw9-legacy'
+
+		# This (legacy/vendor) kernel requires uImage manual conversion; do it via a 'pre_package_kernel_image' hook.
+		function pre_package_kernel_image__orangepi_legacy_uImage_manual_conversion() {
+			display_alert "Converting" "${BOARDFAMILY} - ${LINUXFAMILY} :: legacy :: uImage" "warn"
+			if [[ -z "${kernel_image_pre_package_path}" || ! -f "${kernel_image_pre_package_path}" ]]; then
+				exit_with_error "kernel_image_pre_package_path ('${kernel_image_pre_package_path}') is not set or does not exist"
+			fi
+			run_host_command_logged mkimage -A arm -O linux -T kernel -C none -a "'0x40008000'" -e "'0x40008000'" -n "'Linux kernel'" -d "${kernel_image_pre_package_path}" "${kernel_image_pre_package_path}.uImage.tmp"
+			run_host_command_logged mv -v "${kernel_image_pre_package_path}.uImage.tmp" "${kernel_image_pre_package_path}"
+		}
+
+		# Legacy u-boot
 		BOOTSOURCE='https://github.com/orangepi-xunlong/u-boot-orangepi.git'
 		BOOTBRANCH='branch:v2018.05-sun50iw9'
 		BOOTPATCHDIR="legacy"
@@ -34,9 +49,6 @@ case $BRANCH in
 		OFFSET=20
 		ATFSOURCE=""
 		ATF_COMPILE="no"
-		INITRD_ARCH=arm
-
-		ASOUND_STATE='asound.state.sun50iw9-legacy'
 
 		# this overrides the one in sunxi64_common.inc
 		function write_uboot_platform() {
@@ -55,6 +67,12 @@ case $BRANCH in
 
 		;;
 esac
+
+# This build requires busybox (and dos2unix)
+function add_host_dependencies__sunxi_add_32_bit_c_compiler() {
+	display_alert "Adding busybox dep" "for ${BOARD} bootloader compile" "debug"
+	declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} busybox"
+}
 
 function family_tweaks_s() {
 	if [[ -f $SDCARD/lib/systemd/system/aw859a-bluetooth.service ]]; then
@@ -82,18 +100,45 @@ function family_tweaks_bsp() {
 function uboot_custom_postprocess() {
 	if [[ ${BRANCH} == legacy ]]; then
 		display_alert "Post-processing U-Boot" "$BOARD - $BRANCH" "info"
-		run_host_command_logged cp -pv ${SRC}/packages/pack-uboot/${BOARDFAMILY}/bin/* . -r
+		# "Vendor" code (by Igor) is at https://raw.githubusercontent.com/orangepi-xunlong/orangepi-build/main/external/config/sources/families/sun50iw9.conf
+
+		run_host_command_logged rm -rfv dts/*.dts sys_config ${BOARD}-u-boot.dtb
+
+		run_host_command_logged cp -rpv ${SRC}/packages/pack-uboot/${BOARDFAMILY}/bin/* .
+
 		run_host_command_logged cp -pv sys_config/sys_config_${BOARD}.fex sys_config.fex
 		run_host_command_logged cp -pv u-boot.bin u-boot.fex
+
+		# [[ ${BOARD} =~ orangepizero2-b|orangepizero2-lts ]] && run_host_command_logged mv -v boot0_sdcard_new.fex boot0_sdcard.fex # From vendor code, they have multiple of those boards
+
+		# make u-boot dtb
 		run_host_command_logged dtc -p 2048 -W no-unit_address_vs_reg -@ -O dtb -o ${BOARD}-u-boot.dtb -b 0 dts/${BOARD}-u-boot.dts
+		[[ ! -f "${BOARD}-u-boot.dtb" ]] && exit_with_error "dts compilation failed for ${BOARD}-u-boot.dtb"
+
+		run_host_command_logged busybox unix2dos sys_config.fex
+
 		run_host_command_logged $SRC/packages/pack-uboot/${BOARDFAMILY}/tools/script sys_config.fex
 		run_host_command_logged cp -pv ${BOARD}-u-boot.dtb sunxi.fex
+
 		run_host_command_logged $SRC/packages/pack-uboot/${BOARDFAMILY}/tools/update_dtb sunxi.fex 4096
 		run_host_command_logged $SRC/packages/pack-uboot/${BOARDFAMILY}/tools/update_boot0 boot0_sdcard.fex sys_config.bin SDMMC_CARD
-		# @TODO: rpardini: this looks wrong
+
+		# rpardini: this looks wrong, but isn't. look at vendor code.
 		run_host_command_logged $SRC/packages/pack-uboot/${BOARDFAMILY}/tools/update_uboot -no_merge u-boot.fex sys_config.bin
 		run_host_command_logged $SRC/packages/pack-uboot/${BOARDFAMILY}/tools/update_uboot -no_merge u-boot.bin sys_config.bin
+
+		#pack boot package
+		run_host_command_logged busybox unix2dos boot_package.cfg
 		run_host_command_logged $SRC/packages/pack-uboot/${BOARDFAMILY}/tools/dragonsecboot -pack boot_package.cfg
+
+		# From vendor code, we never had this.
+		#if [[ ${MERGE_UBOOT} == yes ]]; then
+		#	display_alert "Merge u-boot" "u-boot-${BOARD}-merged.bin" "info"
+		#	dd if=/dev/zero of=u-boot-${BOARD}-merged.bin bs=1M count=20 > /dev/null 2>&1
+		#	dd if=boot0_sdcard.fex of=u-boot-${BOARD}-merged.bin bs=8k seek=1 conv=fsync > /dev/null 2>&1
+		#	dd if=boot_package.fex of=u-boot-${BOARD}-merged.bin bs=8k seek=2050 conv=fsync > /dev/null 2>&1
+		#	mv u-boot-${BOARD}-merged.bin ${DEB_STORAGE}/u-boot/
+		#fi
 	fi
 
 	return 0

--- a/config/sources/families/sun50iw9.conf
+++ b/config/sources/families/sun50iw9.conf
@@ -27,6 +27,7 @@ case $BRANCH in
 		ASOUND_STATE='asound.state.sun50iw9-legacy'
 
 		# This (legacy/vendor) kernel requires uImage manual conversion; do it via a 'pre_package_kernel_image' hook.
+		declare -g NAME_KERNEL="uImage" # Even though that's a lie.
 		function pre_package_kernel_image__orangepi_legacy_uImage_manual_conversion() {
 			display_alert "Converting" "${BOARDFAMILY} - ${LINUXFAMILY} :: legacy :: uImage" "warn"
 			if [[ -z "${kernel_image_pre_package_path}" || ! -f "${kernel_image_pre_package_path}" ]]; then

--- a/config/sources/riscv64.conf
+++ b/config/sources/riscv64.conf
@@ -12,12 +12,14 @@ declare -g ARCH='riscv64'
 declare -g ARCHITECTURE='riscv'
 declare -g KERNEL_SRC_ARCH='riscv'
 declare -g QEMU_BINARY='qemu-riscv64-static'
-declare -g KERNEL_IMAGE_TYPE='Image'
-declare -g KERNEL_INSTALL_TYPE='install'
-declare -g NAME_KERNEL='Image'
-declare -g NAME_INITRD='uInitrd'
 declare -g IMAGE_PARTITION_TABLE='gpt'
 declare -g SKIP_EXTERNAL_TOOLCHAINS='yes'
+
+# Defaults, if not set by board or family.
+declare -g KERNEL_IMAGE_TYPE="${KERNEL_IMAGE_TYPE:-"Image"}"
+declare -g KERNEL_INSTALL_TYPE="${KERNEL_INSTALL_TYPE:-"install"}"
+declare -g NAME_KERNEL="${NAME_KERNEL:-"Image"}"
+declare -g NAME_INITRD="${NAME_INITRD:-"uInitrd"}"
 
 [[ -z $KERNEL_COMPILER ]] && KERNEL_COMPILER='riscv64-linux-gnu-'
 [[ -z $UBOOT_COMPILER ]] && UBOOT_COMPILER='riscv64-linux-gnu-'

--- a/lib/functions/artifacts/artifact-kernel.sh
+++ b/lib/functions/artifacts/artifact-kernel.sh
@@ -132,6 +132,13 @@ function artifact_kernel_prepare_version() {
 	vars_config_hash="${hash_vars}"
 	declare var_config_hash_short="${vars_config_hash:0:${short_hash_size}}"
 
+	# Hash the extension hooks
+	declare -a extension_hooks_to_hash=("pre_package_kernel_image")
+	declare -a extension_hooks_hashed=("$(dump_extension_method_sources_functions "${extension_hooks_to_hash[@]}")")
+	declare hash_hooks="undetermined"
+	hash_hooks="$(echo "${extension_hooks_hashed[@]}" | sha256sum | cut -d' ' -f1)"
+	declare hash_hooks_short="${hash_hooks:0:${short_hash_size}}"
+
 	# @TODO: include the compiler version? host release?
 
 	# get the hashes of the lib/ bash sources involved...
@@ -140,7 +147,7 @@ function artifact_kernel_prepare_version() {
 	declare bash_hash="${hash_files}"
 	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
 
-	declare common_version_suffix="S${short_sha1}-D${kernel_drivers_hash_short}-P${kernel_patches_hash_short}-C${config_hash_short}H${kernel_config_modification_hash_short}-V${var_config_hash_short}-B${bash_hash_short}"
+	declare common_version_suffix="S${short_sha1}-D${kernel_drivers_hash_short}-P${kernel_patches_hash_short}-C${config_hash_short}H${kernel_config_modification_hash_short}-HK${hash_hooks_short}-V${var_config_hash_short}-B${bash_hash_short}"
 
 	# outer scope
 	if [[ "${KERNEL_SKIP_MAKEFILE_VERSION:-"no"}" == "yes" ]]; then

--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -171,18 +171,37 @@ function kernel_package_hook_helper() {
 function kernel_package_callback_linux_image() {
 	display_alert "linux-image deb packaging" "${package_directory}" "debug"
 
-	declare installed_image_path="boot/vmlinuz-${kernel_version_family}" # using old mkdebian terminology here.
-	declare image_name="Image"                                           # "Image" for arm64. or, "zImage" for arm, or "vmlinuz" for others.
+	# @TODO: we expect _all_ kernels to produce this, which is... not true.
+	declare kernel_pre_package_path="${tmp_kernel_install_dirs[INSTALL_PATH]}"
+	declare kernel_image_pre_package_path="${kernel_pre_package_path}/vmlinuz-${kernel_version_family}"
+	declare installed_image_path="boot/vmlinuz-${kernel_version_family}" # using old mkdebian terminology here for compatibility
+
+	display_alert "Showing contents of Kbuild produced /boot" "linux-image" "debug"
+	run_host_command_logged tree -C --du -h "${tmp_kernel_install_dirs[INSTALL_PATH]}"
+
+	display_alert "Kernel-built image filetype" "vmlinuz-${kernel_version_family}: $(file --brief "${kernel_image_pre_package_path}")" "info"
+
+	declare image_name="Image" # "Image" for arm64. or, "zImage" for arm, or "vmlinuz" for others. 'image_name' is for easy mkdebian compat
 	# If NAME_KERNEL is set (usually in arch config file), warn and use that instead.
 	if [[ -n "${NAME_KERNEL}" ]]; then
 		display_alert "NAME_KERNEL is set" "using '${NAME_KERNEL}' instead of '${image_name}'" "debug"
 		image_name="${NAME_KERNEL}"
-	else
-		display_alert "NAME_KERNEL is not set" "using default '${image_name}'" "debug"
 	fi
 
-	display_alert "Showing contents of Kbuild produced /boot" "linux-image" "debug"
-	run_host_command_logged tree -C --du -h "${tmp_kernel_install_dirs[INSTALL_PATH]}"
+	# allow hook to do stuff here. Some (legacy/vendor/weird) kernels spit out a vmlinuz that needs manual conversion to uImage, etc.
+	run_host_command_logged ls -la "${kernel_pre_package_path}" "${kernel_image_pre_package_path}"
+
+	call_extension_method "pre_package_kernel_image" <<- 'PRE_PACKAGE_KERNEL_IMAGE'
+		*fix Image/uImage/zImage before packaging kernel*
+		Some (legacy/vendor) kernels need preprocessing of the produced Image/uImage/zImage before packaging.
+		Use this hook to do that, by modifying the file in place, in `${kernel_pre_package_path}` directory.
+		The final file that will be used is stored in `${kernel_image_pre_package_path}` -- which you shouldn't change.
+	PRE_PACKAGE_KERNEL_IMAGE
+
+	display_alert "Kernel image filetype after pre_package_kernel_image" "vmlinuz-${kernel_version_family}: $(file --brief "${kernel_image_pre_package_path}")" "info"
+
+	unset kernel_pre_package_path       # be done with var after hook
+	unset kernel_image_pre_package_path # be done with var after hook
 
 	run_host_command_logged cp -rp "${tmp_kernel_install_dirs[INSTALL_PATH]}" "${package_directory}/"         # /boot stuff
 	run_host_command_logged cp -rp "${tmp_kernel_install_dirs[INSTALL_MOD_PATH]}/lib" "${package_directory}/" # so "lib" stuff sits at the root

--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -209,7 +209,6 @@ function do_main_configuration() {
 	# Let's set default data if not defined in board configuration above
 	[[ -z $OFFSET ]] && OFFSET=4 # offset to 1st partition (we use 4MiB boundaries by default)
 	[[ -z $ARCH ]] && ARCH=armhf # makes little sense to default to anything...
-	KERNEL_IMAGE_TYPE=zImage
 	ATF_COMPILE=yes
 	[[ -z $WIREGUARD ]] && WIREGUARD="yes"
 	[[ -z $EXTRAWIFI ]] && EXTRAWIFI="yes"


### PR DESCRIPTION
#### legacy kernel custom uImage/etc via new `pre_package_kernel_image` hook; fixes for `orangepizero2`/`sun50iw9`/`legacy`

- kernel: introduce new hook `pre_package_kernel_image`; show vmlinuz file magic before/after hook; add `-HK` hook hash to kernel artifact version
- arch configs (all): default, but do not overwrite, `KERNEL_IMAGE_TYPE`/`KERNEL_INSTALL_TYPE`/etc: allow board/family to set first
- `orangepizero2`/`sun50iw9`/`legacy`: implement `pre_package_kernel_image` hook to convert vmlinuz to uImage manually; fix legacy u-boot build
  - sourceaddr `0x40008000` was found in Xunlong's legacy kernel source squashed into a huge commit. Thanks, Xunlong!
  - bring `busybox` dependency with inline hook for legacy u-boot "unix2dos" which is essential
- `orangepizero2`/`sun50iw9`/`legacy`: actually use `NAME_KERNEL=uImage`