### PR TITLE
enable mipi-dsi on Rockchip

### DIFF
--- a/config/kernel/linux-rockchip-current.config
+++ b/config/kernel/linux-rockchip-current.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.1.20 Kernel Configuration
+# Linux/arm 6.1.23 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-linux-gnueabihf-gcc (Ubuntu 11.3.0-1ubuntu1~22.04) 11.3.0"
 CONFIG_CC_IS_GCC=y
@@ -4567,7 +4567,7 @@ CONFIG_ROCKCHIP_VOP=y
 # CONFIG_ROCKCHIP_ANALOGIX_DP is not set
 # CONFIG_ROCKCHIP_CDN_DP is not set
 CONFIG_ROCKCHIP_DW_HDMI=y
-# CONFIG_ROCKCHIP_DW_MIPI_DSI is not set
+CONFIG_ROCKCHIP_DW_MIPI_DSI=y
 # CONFIG_ROCKCHIP_INNO_HDMI is not set
 CONFIG_ROCKCHIP_LVDS=y
 # CONFIG_ROCKCHIP_RGB is not set
@@ -4708,6 +4708,7 @@ CONFIG_DRM_DW_HDMI=y
 CONFIG_DRM_DW_HDMI_I2S_AUDIO=m
 # CONFIG_DRM_DW_HDMI_GP_AUDIO is not set
 CONFIG_DRM_DW_HDMI_CEC=m
+CONFIG_DRM_DW_MIPI_DSI=y
 # end of Display Interface Bridges
 
 # CONFIG_DRM_STI is not set


### PR DESCRIPTION
# Description

Enable mainline mipi-dsi driver for Rockchip.  This permits the use of the RPi 7" LCD and equivalents (device tree overlay required)

# How Has This Been Tested?

boot no error (module not loaded as not enabled in DT)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
