### PR TITLE
Set maximum priority for Armbian repository

### DIFF
--- a/packages/bsp/common/etc/apt/preferences.d/armbian
+++ b/packages/bsp/common/etc/apt/preferences.d/armbian
@@ -1,0 +1,3 @@
+Package: *
+Pin: release o=armbian
+Pin-Priority: 1001


### PR DESCRIPTION
# Description

We are providing several 3rd party packages in our repository such as Mozilla Firefox or Chromium. In order to prevent installing snapd version from Ubuntu, we have to set higher priority for packages that are coming from our repository.

Jira reference number [AR-1662]

# How Has This Been Tested?

```
desktop:preferences.d:% apt-cache policy | grep armbian
1001 http://beta.armbian.com jammy/jammy-desktop all Packages
     origin beta.armbian.com
1001 http://beta.armbian.com jammy/jammy-desktop amd64 Packages
     origin beta.armbian.com
1001 http://beta.armbian.com jammy/jammy-utils all Packages
     origin beta.armbian.com
1001 http://beta.armbian.com jammy/jammy-utils amd64 Packages
     origin beta.armbian.com
1001 http://beta.armbian.com jammy/main amd64 Packages
     origin beta.armbian.com
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1662]: https://armbian.atlassian.net/browse/AR-1662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ