### PR TITLE
Remove family optimisation as they break on Debian Bookworm

### DIFF
--- a/config/sources/families/mvebu64.conf
+++ b/config/sources/families/mvebu64.conf
@@ -84,7 +84,6 @@ write_uboot_platform() {
 }
 
 family_tweaks() {
-	chroot_sdcard_apt_get remove --auto-remove linux-sound-base alsa-base alsa-utils bluez
 	[[ -f $SDCARD/etc/netplan/armbian-default.yaml ]] && sed -i "s/^  renderer.*/  renderer: networkd/" $SDCARD/etc/netplan/armbian-default.yaml
 	cp $SRC/packages/bsp/mvebu64/networkd/10* $SDCARD/etc/systemd/network/
 	if [[ $BOARD = "espressobin" ]]; then


### PR DESCRIPTION
# Description

Espressobin had some package removal optimisations which are anyway deprecated with minimal images.

# How Has This Been Tested?

Bug was found in build-all images scenario ... while switching to Bookworm target instead of Sid.