### PR TITLE
rpardini's bunch of `lib` changes - **mid-April'23**

### DIFF
--- a/extensions/c-plus-plus-compiler.sh
+++ b/extensions/c-plus-plus-compiler.sh
@@ -3,5 +3,5 @@
 
 function add_host_dependencies__add_arm64_c_plus_plus_compiler() {
 	display_alert "Adding arm64 c++ compiler to host dependencies" "g++" "debug"
-	export EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} g++-aarch64-linux-gnu g++" # @TODO: convert to array later
+	declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} g++-aarch64-linux-gnu g++" # @TODO: convert to array later
 }

--- a/extensions/cleanup-space-final-image.sh
+++ b/extensions/cleanup-space-final-image.sh
@@ -1,5 +1,5 @@
 function add_host_dependencies__cleanup_space_final_image_zerofree() {
-	export EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} zerofree"
+	declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} zerofree"
 }
 
 function post_customize_image__998_cleanup_apt_stuff() {

--- a/extensions/flash-kernel.sh
+++ b/extensions/flash-kernel.sh
@@ -2,25 +2,25 @@
 # This runs *after* user_config. Don't change anything not coming from other variables or meant to be configured by the user.
 function extension_prepare_config__prepare_flash_kernel() {
 	# Configuration defaults, or lack thereof.
-	export FK__TOOL_PACKAGE="${FK__TOOL_PACKAGE:-flash-kernel}"
-	export FK__PUBLISHED_KERNEL_VERSION="${FK__PUBLISHED_KERNEL_VERSION:-undefined-flash-kernel-version}"
-	export FK__EXTRA_PACKAGES="${FK__EXTRA_PACKAGES:-undefined-flash-kernel-kernel-package}"
-	export FK__KERNEL_PACKAGES="${FK__KERNEL_PACKAGES:-}"
-	export FK__MACHINE_MODEL="${FK__MACHINE_MODEL:-Undefined Flash-Kernel Machine}"
+	declare -g FK__TOOL_PACKAGE="${FK__TOOL_PACKAGE:-flash-kernel}"
+	declare -g FK__PUBLISHED_KERNEL_VERSION="${FK__PUBLISHED_KERNEL_VERSION:-undefined-flash-kernel-version}"
+	declare -g FK__EXTRA_PACKAGES="${FK__EXTRA_PACKAGES:-undefined-flash-kernel-kernel-package}"
+	declare -g FK__KERNEL_PACKAGES="${FK__KERNEL_PACKAGES:-}"
+	declare -g FK__MACHINE_MODEL="${FK__MACHINE_MODEL:-Undefined Flash-Kernel Machine}"
 
 	# Override certain variables. A case of "this extension knows better and modifies user configurable stuff".
-	export BOOTCONFIG="none"                                                    # To try and convince lib/ to not build or install u-boot.
-	unset BOOTSOURCE                                                            # To try and convince lib/ to not build or install u-boot.
-	export UEFISIZE=256                                                         # in MiB. Not really UEFI, but partition layout is the same.
-	export BOOTSIZE=0                                                           # No separate /boot, flash-kernel will "flash" the kernel+initrd to the firmware part.
-	export UEFI_MOUNT_POINT="/boot/firmware"                                    # mount uefi partition at /boot/firmware
-	export CLOUD_INIT_CONFIG_LOCATION="/boot/firmware"                          # use /boot/firmware for cloud-init as well
-	export IMAGE_INSTALLED_KERNEL_VERSION="${FK__PUBLISHED_KERNEL_VERSION}"     # For the VERSION
-	export EXTRA_BSP_NAME="${EXTRA_BSP_NAME}-fk${FK__PUBLISHED_KERNEL_VERSION}" # Unique bsp name.
+	declare -g BOOTCONFIG="none"                                                    # To try and convince lib/ to not build or install u-boot.
+	unset BOOTSOURCE                                                                # To try and convince lib/ to not build or install u-boot.
+	declare -g UEFISIZE=256                                                         # in MiB. Not really UEFI, but partition layout is the same.
+	declare -g BOOTSIZE=0                                                           # No separate /boot, flash-kernel will "flash" the kernel+initrd to the firmware part.
+	declare -g UEFI_MOUNT_POINT="/boot/firmware"                                    # mount uefi partition at /boot/firmware
+	declare -g CLOUD_INIT_CONFIG_LOCATION="/boot/firmware"                          # use /boot/firmware for cloud-init as well
+	declare -g IMAGE_INSTALLED_KERNEL_VERSION="${FK__PUBLISHED_KERNEL_VERSION}"     # For the VERSION
+	declare -g EXTRA_BSP_NAME="${EXTRA_BSP_NAME}-fk${FK__PUBLISHED_KERNEL_VERSION}" # Unique bsp name.
 }
 
 function post_install_kernel_debs__install_kernel_and_flash_packages() {
-	export INSTALL_ARMBIAN_FIRMWARE="no" # Disable Armbian-firmware install, which would happen after this method.
+	declare -g INSTALL_ARMBIAN_FIRMWARE="no" # Disable Armbian-firmware install, which would happen after this method.
 
 	if [[ "${FK__EXTRA_PACKAGES}" != "" ]]; then
 		display_alert "Installing flash-kernel extra packages" "${FK__EXTRA_PACKAGES}"
@@ -80,7 +80,7 @@ function pre_update_initramfs__setup_flash_kernel() {
 	chroot_custom "$chroot_target" chmod -v -x "/etc/kernel/postinst.d/initramfs-tools"
 	chroot_custom "$chroot_target" chmod -v -x "/etc/initramfs/post-update.d/flash-kernel"
 
-	export FIRMWARE_DIR="${MOUNT}"/boot/firmware
+	declare -g FIRMWARE_DIR="${MOUNT}"/boot/firmware
 	call_extension_method "pre_initramfs_flash_kernel" <<- 'PRE_INITRAMFS_FLASH_KERNEL'
 		*prepare to update-initramfs before flashing kernel via flash_kernel*
 		A good spot to write firmware config to ${FIRMWARE_DIR} (/boot/firmware) before flash-kernel actually runs.

--- a/extensions/gen-sample-extension-docs.sh
+++ b/extensions/gen-sample-extension-docs.sh
@@ -17,23 +17,23 @@ function extension_metadata_ready__docs_sample_extension() {
 
 ### Common stuff
 function read_common_data() {
-	export HOOK_POINT_CALLS_COUNT=$(wc -l < "${EXTENSION_MANAGER_TMP_DIR}/hook_point_calls.txt")
-	export HOOK_POINT_CALLS_UNIQUE_COUNT=$(sort < "${EXTENSION_MANAGER_TMP_DIR}/hook_point_calls.txt" | uniq | wc -l)
-	export HOOK_POINTS_WITH_MULTIPLE_CALLS=""
+	declare -g HOOK_POINT_CALLS_COUNT=$(wc -l < "${EXTENSION_MANAGER_TMP_DIR}/hook_point_calls.txt")
+	declare -g HOOK_POINT_CALLS_UNIQUE_COUNT=$(sort < "${EXTENSION_MANAGER_TMP_DIR}/hook_point_calls.txt" | uniq | wc -l)
+	declare -g HOOK_POINTS_WITH_MULTIPLE_CALLS=""
 
 	# Read the hook_points (main, official names) from the hook point ordering file.
-	export ALL_HOOK_POINT_CALLS=$(xargs echo -n < "${EXTENSION_MANAGER_TMP_DIR}/hook_point_calls.txt")
+	declare -g ALL_HOOK_POINT_CALLS=$(xargs echo -n < "${EXTENSION_MANAGER_TMP_DIR}/hook_point_calls.txt")
 }
 
 function loop_over_hook_points_and_call() {
 	local callback="$1"
 	HOOK_POINT_COUNTER=0
 	for one_hook_point in ${ALL_HOOK_POINT_CALLS}; do
-		export HOOK_POINT_COUNTER=$((HOOK_POINT_COUNTER + 1))
-		export HOOK_POINT="${one_hook_point}"
-		export MARKDOWN_HEAD="$(head -1 "${EXTENSION_MANAGER_TMP_DIR}/${one_hook_point}.orig.md")"
-		export MARKDOWN_BODY="$(tail -n +2 "${EXTENSION_MANAGER_TMP_DIR}/${one_hook_point}.orig.md")"
-		export COMPATIBILITY_NAMES="$(xargs echo -n < "${EXTENSION_MANAGER_TMP_DIR}/${one_hook_point}.compat")"
+		declare -g HOOK_POINT_COUNTER=$((HOOK_POINT_COUNTER + 1))
+		declare -g HOOK_POINT="${one_hook_point}"
+		declare -g MARKDOWN_HEAD="$(head -1 "${EXTENSION_MANAGER_TMP_DIR}/${one_hook_point}.orig.md")"
+		declare -g MARKDOWN_BODY="$(tail -n +2 "${EXTENSION_MANAGER_TMP_DIR}/${one_hook_point}.orig.md")"
+		declare -g COMPATIBILITY_NAMES="$(xargs echo -n < "${EXTENSION_MANAGER_TMP_DIR}/${one_hook_point}.compat")"
 		${callback}
 	done
 }

--- a/extensions/grub-riscv64.sh
+++ b/extensions/grub-riscv64.sh
@@ -3,21 +3,21 @@
 function extension_prepare_config__prepare_grub-riscv64() {
 	display_alert "Prepare config" "${EXTENSION}" "info"
 	# Extension configuration defaults.
-	export DISTRO_GENERIC_KERNEL=${DISTRO_GENERIC_KERNEL:-no}             # if yes, does not build our own kernel, instead, uses generic one from distro
-	export UEFI_GRUB_TERMINAL="${UEFI_GRUB_TERMINAL:-serial console}"     # 'serial' forces grub menu on serial console. empty to not include
-	export UEFI_GRUB_DISABLE_OS_PROBER="${UEFI_GRUB_DISABLE_OS_PROBER:-}" # 'true' will disable os-probing, useful for SD cards.
-	export UEFI_GRUB_DISTRO_NAME="${UEFI_GRUB_DISTRO_NAME:-Armbian}"      # Will be used on grub menu display
-	export UEFI_GRUB_TIMEOUT=${UEFI_GRUB_TIMEOUT:-0}                      # Small timeout by default
-	export GRUB_CMDLINE_LINUX_DEFAULT="${GRUB_CMDLINE_LINUX_DEFAULT:-""}" # Cmdline by default
+	declare -g DISTRO_GENERIC_KERNEL=${DISTRO_GENERIC_KERNEL:-no}             # if yes, does not build our own kernel, instead, uses generic one from distro
+	declare -g UEFI_GRUB_TERMINAL="${UEFI_GRUB_TERMINAL:-serial console}"     # 'serial' forces grub menu on serial console. empty to not include
+	declare -g UEFI_GRUB_DISABLE_OS_PROBER="${UEFI_GRUB_DISABLE_OS_PROBER:-}" # 'true' will disable os-probing, useful for SD cards.
+	declare -g UEFI_GRUB_DISTRO_NAME="${UEFI_GRUB_DISTRO_NAME:-Armbian}"      # Will be used on grub menu display
+	declare -g UEFI_GRUB_TIMEOUT=${UEFI_GRUB_TIMEOUT:-0}                      # Small timeout by default
+	declare -g GRUB_CMDLINE_LINUX_DEFAULT="${GRUB_CMDLINE_LINUX_DEFAULT:-""}" # Cmdline by default
 	# User config overrides.
-	export BOOTCONFIG="none"                                                     # To try and convince lib/ to not build or install u-boot.
-	unset BOOTSOURCE                                                             # To try and convince lib/ to not build or install u-boot.
-	export IMAGE_PARTITION_TABLE="gpt"                                           # GPT partition table is essential for many UEFI-like implementations, eg Apple+Intel stuff.
-	export UEFISIZE=256                                                          # in MiB - grub EFI is tiny - but some EFI BIOSes ignore small too small EFI partitions
-	export BOOTSIZE=0                                                            # No separate /boot when using UEFI.
-	export CLOUD_INIT_CONFIG_LOCATION="${CLOUD_INIT_CONFIG_LOCATION:-/boot/efi}" # use /boot/efi for cloud-init as default when using Grub.
-	export EXTRA_BSP_NAME="${EXTRA_BSP_NAME}-grub"                               # Unique bsp name.
-	export UEFI_GRUB_TARGET="riscv64-efi"                                        # Default for x86_64
+	declare -g BOOTCONFIG="none"                                                     # To try and convince lib/ to not build or install u-boot.
+	unset BOOTSOURCE                                                                 # To try and convince lib/ to not build or install u-boot.
+	declare -g IMAGE_PARTITION_TABLE="gpt"                                           # GPT partition table is essential for many UEFI-like implementations, eg Apple+Intel stuff.
+	declare -g UEFISIZE=256                                                          # in MiB - grub EFI is tiny - but some EFI BIOSes ignore small too small EFI partitions
+	declare -g BOOTSIZE=0                                                            # No separate /boot when using UEFI.
+	declare -g CLOUD_INIT_CONFIG_LOCATION="${CLOUD_INIT_CONFIG_LOCATION:-/boot/efi}" # use /boot/efi for cloud-init as default when using Grub.
+	declare -g EXTRA_BSP_NAME="${EXTRA_BSP_NAME}-grub"                               # Unique bsp name.
+	declare -g UEFI_GRUB_TARGET="riscv64-efi"                                        # Default for x86_64
 
 	if [[ "${DISTRIBUTION}" != "Ubuntu" && "${BUILDING_IMAGE}" == "yes" ]]; then
 		exit_with_error "${DISTRIBUTION} is not supported yet"

--- a/extensions/grub-sbc-media.sh
+++ b/extensions/grub-sbc-media.sh
@@ -3,25 +3,25 @@
 function extension_prepare_config__prepare_grub-sbc-media() {
 	display_alert "Prepare config" "${EXTENSION}" "info"
 	# Extension configuration defaults.
-	export DISTRO_GENERIC_KERNEL=${DISTRO_GENERIC_KERNEL:-no}             # if yes, does not build our own kernel, instead, uses generic one from distro
-	export UEFI_GRUB_DISABLE_OS_PROBER="${UEFI_GRUB_DISABLE_OS_PROBER:-}" # 'true' will disable os-probing, useful for SD cards.
-	export UEFI_GRUB_DISTRO_NAME="${UEFI_GRUB_DISTRO_NAME:-Armbian}"      # Will be used on grub menu display
-	export UEFI_GRUB_TIMEOUT=${UEFI_GRUB_TIMEOUT:-3}                      # Small timeout by default
-	export UEFI_GRUB_RECORDFAIL_TIMEOUT=${UEFI_GRUB_RECORDFAIL_TIMEOUT:-3}
-	export GRUB_CMDLINE_LINUX_DEFAULT="${GRUB_CMDLINE_LINUX_DEFAULT:-}" # Cmdline by default
-	export UEFI_ENABLE_BIOS_AMD64="${UEFI_ENABLE_BIOS_AMD64:-no}"       # Enable BIOS too if target is amd64
+	declare -g DISTRO_GENERIC_KERNEL=${DISTRO_GENERIC_KERNEL:-no}             # if yes, does not build our own kernel, instead, uses generic one from distro
+	declare -g UEFI_GRUB_DISABLE_OS_PROBER="${UEFI_GRUB_DISABLE_OS_PROBER:-}" # 'true' will disable os-probing, useful for SD cards.
+	declare -g UEFI_GRUB_DISTRO_NAME="${UEFI_GRUB_DISTRO_NAME:-Armbian}"      # Will be used on grub menu display
+	declare -g UEFI_GRUB_TIMEOUT=${UEFI_GRUB_TIMEOUT:-3}                      # Small timeout by default
+	declare -g UEFI_GRUB_RECORDFAIL_TIMEOUT=${UEFI_GRUB_RECORDFAIL_TIMEOUT:-3}
+	declare -g GRUB_CMDLINE_LINUX_DEFAULT="${GRUB_CMDLINE_LINUX_DEFAULT:-}" # Cmdline by default
+	declare -g UEFI_ENABLE_BIOS_AMD64="${UEFI_ENABLE_BIOS_AMD64:-no}"       # Enable BIOS too if target is amd64
 	# User config overrides.
-	export IMAGE_PARTITION_TABLE="gpt"                                           # GPT partition table is essential for many UEFI-like implementations, eg Apple+Intel stuff.
-	export UEFISIZE=256                                                          # in MiB - grub EFI is tiny - but some EFI BIOSes ignore small too small EFI partitions
-	export BOOTSIZE=0                                                            # No separate /boot when using UEFI.
-	export CLOUD_INIT_CONFIG_LOCATION="${CLOUD_INIT_CONFIG_LOCATION:-/boot/efi}" # use /boot/efi for cloud-init as default when using Grub.
-	export EXTRA_BSP_NAME="${EXTRA_BSP_NAME}-grub"                               # Unique bsp name.
-	export UEFI_GRUB_TARGET_BIOS=""                                              # Target for BIOS GRUB install, set to i386-pc when UEFI_ENABLE_BIOS_AMD64=yes and target is amd64
-	local uefi_packages="efibootmgr efivar"                                      # Use growroot, add some efi-related packages
-	uefi_packages="os-prober grub-efi-${ARCH}-bin ${uefi_packages}"              # This works for Ubuntu and Debian, by sheer luck; common for EFI and BIOS
+	declare -g IMAGE_PARTITION_TABLE="gpt"                                           # GPT partition table is essential for many UEFI-like implementations, eg Apple+Intel stuff.
+	declare -g UEFISIZE=256                                                          # in MiB - grub EFI is tiny - but some EFI BIOSes ignore small too small EFI partitions
+	declare -g BOOTSIZE=0                                                            # No separate /boot when using UEFI.
+	declare -g CLOUD_INIT_CONFIG_LOCATION="${CLOUD_INIT_CONFIG_LOCATION:-/boot/efi}" # use /boot/efi for cloud-init as default when using Grub.
+	declare -g EXTRA_BSP_NAME="${EXTRA_BSP_NAME}-grub"                               # Unique bsp name.
+	declare -g UEFI_GRUB_TARGET_BIOS=""                                              # Target for BIOS GRUB install, set to i386-pc when UEFI_ENABLE_BIOS_AMD64=yes and target is amd64
+	local uefi_packages="efibootmgr efivar"                                          # Use growroot, add some efi-related packages
+	uefi_packages="os-prober grub-efi-${ARCH}-bin ${uefi_packages}"                  # This works for Ubuntu and Debian, by sheer luck; common for EFI and BIOS
 
-	[[ "${ARCH}" == "arm64" ]] && export uefi_packages="${uefi_packages} grub-efi-${ARCH}"
-	[[ "${ARCH}" == "arm64" ]] && export UEFI_GRUB_TARGET="arm64-efi" # Default for arm64-efi
+	[[ "${ARCH}" == "arm64" ]] && declare -g uefi_packages="${uefi_packages} grub-efi-${ARCH}"
+	[[ "${ARCH}" == "arm64" ]] && declare -g UEFI_GRUB_TARGET="arm64-efi" # Default for arm64-efi
 
 	DISTRO_KERNEL_PACKAGES=""
 	DISTRO_FIRMWARE_PACKAGES=""

--- a/extensions/grub.sh
+++ b/extensions/grub.sh
@@ -2,44 +2,44 @@
 # This runs *after* user_config. Don't change anything not coming from other variables or meant to be configured by the u ser.
 function extension_prepare_config__prepare_grub_standard() {
 	# Extension configuration defaults.
-	export DISTRO_GENERIC_KERNEL=${DISTRO_GENERIC_KERNEL:-no}             # if yes, does not build our own kernel, instead, uses generic one from distro
-	export UEFI_GRUB_TERMINAL="${UEFI_GRUB_TERMINAL:-serial console}"     # 'serial' forces grub menu on serial console. empty to not include
-	export UEFI_GRUB_DISABLE_OS_PROBER="${UEFI_GRUB_DISABLE_OS_PROBER:-}" # 'true' will disable os-probing, useful for SD cards.
-	export UEFI_GRUB_DISTRO_NAME="${UEFI_GRUB_DISTRO_NAME:-Armbian}"      # Will be used on grub menu display
-	export UEFI_GRUB_TIMEOUT=${UEFI_GRUB_TIMEOUT:-0}                      # Small timeout by default
-	export GRUB_CMDLINE_LINUX_DEFAULT="${GRUB_CMDLINE_LINUX_DEFAULT:-}"   # Cmdline by default
-	export UEFI_ENABLE_BIOS_AMD64="${UEFI_ENABLE_BIOS_AMD64:-yes}"        # Enable BIOS too if target is amd64
-	export UEFI_EXPORT_KERNEL_INITRD="${UEFI_EXPORT_KERNEL_INITRD:-no}"   # Export kernel and initrd for direct kernel boot "kexec"
+	declare -g DISTRO_GENERIC_KERNEL=${DISTRO_GENERIC_KERNEL:-no}             # if yes, does not build our own kernel, instead, uses generic one from distro
+	declare -g UEFI_GRUB_TERMINAL="${UEFI_GRUB_TERMINAL:-serial console}"     # 'serial' forces grub menu on serial console. empty to not include
+	declare -g UEFI_GRUB_DISABLE_OS_PROBER="${UEFI_GRUB_DISABLE_OS_PROBER:-}" # 'true' will disable os-probing, useful for SD cards.
+	declare -g UEFI_GRUB_DISTRO_NAME="${UEFI_GRUB_DISTRO_NAME:-Armbian}"      # Will be used on grub menu display
+	declare -g UEFI_GRUB_TIMEOUT=${UEFI_GRUB_TIMEOUT:-0}                      # Small timeout by default
+	declare -g GRUB_CMDLINE_LINUX_DEFAULT="${GRUB_CMDLINE_LINUX_DEFAULT:-}"   # Cmdline by default
+	declare -g UEFI_ENABLE_BIOS_AMD64="${UEFI_ENABLE_BIOS_AMD64:-yes}"        # Enable BIOS too if target is amd64
+	declare -g UEFI_EXPORT_KERNEL_INITRD="${UEFI_EXPORT_KERNEL_INITRD:-no}"   # export kernel and initrd for direct kernel boot "kexec"
 
 	if [[ "${UEFI_GRUB}" != "skip" ]]; then
 		# User config overrides for GRUB.
-		export BOOTCONFIG="none"                                                     # To try and convince lib/ to not build or install u-boot.
-		unset BOOTSOURCE                                                             # To try and convince lib/ to not build or install u-boot.
-		export IMAGE_PARTITION_TABLE="gpt"                                           # GPT partition table is essential for many UEFI-like implementations, eg Apple+Intel stuff.
-		export UEFISIZE=256                                                          # in MiB - grub EFI is tiny - but some EFI BIOSes ignore small too small EFI partitions
-		export BOOTSIZE=0                                                            # No separate /boot when using UEFI.
-		export CLOUD_INIT_CONFIG_LOCATION="${CLOUD_INIT_CONFIG_LOCATION:-/boot/efi}" # use /boot/efi for cloud-init as default when using Grub.
-		export EXTRA_BSP_NAME="${EXTRA_BSP_NAME}-grub"                               # Unique bsp name.
-		export UEFI_GRUB_TARGET_BIOS=""                                              # Target for BIOS GRUB install, set to i386-pc when UEFI_ENABLE_BIOS_AMD64=yes and target is amd64
-		local uefi_packages=""                                                       # Use growroot, add some efi-related packages
+		declare -g BOOTCONFIG="none"                                                     # To try and convince lib/ to not build or install u-boot.
+		unset BOOTSOURCE                                                                 # To try and convince lib/ to not build or install u-boot.
+		declare -g IMAGE_PARTITION_TABLE="gpt"                                           # GPT partition table is essential for many UEFI-like implementations, eg Apple+Intel stuff.
+		declare -g UEFISIZE=256                                                          # in MiB - grub EFI is tiny - but some EFI BIOSes ignore small too small EFI partitions
+		declare -g BOOTSIZE=0                                                            # No separate /boot when using UEFI.
+		declare -g CLOUD_INIT_CONFIG_LOCATION="${CLOUD_INIT_CONFIG_LOCATION:-/boot/efi}" # use /boot/efi for cloud-init as default when using Grub.
+		declare -g EXTRA_BSP_NAME="${EXTRA_BSP_NAME}-grub"                               # Unique bsp name.
+		declare -g UEFI_GRUB_TARGET_BIOS=""                                              # Target for BIOS GRUB install, set to i386-pc when UEFI_ENABLE_BIOS_AMD64=yes and target is amd64
+		local uefi_packages=""                                                           # Use growroot, add some efi-related packages
 
 		uefi_packages="efibootmgr efivar cloud-initramfs-growroot"      # Use growroot, add some efi-related packages
 		uefi_packages="os-prober grub-efi-${ARCH}-bin ${uefi_packages}" # This works for Ubuntu and Debian, by sheer luck; common for EFI and BIOS
 
 		# BIOS-compatibility for amd64
 		if [[ "${ARCH}" == "amd64" ]]; then
-			export UEFI_GRUB_TARGET="x86_64-efi" # Default for x86_64
+			declare -g UEFI_GRUB_TARGET="x86_64-efi" # Default for x86_64
 			if [[ "${UEFI_ENABLE_BIOS_AMD64}" == "yes" ]]; then
-				export uefi_packages="${uefi_packages} grub-pc-bin grub-pc"
-				export UEFI_GRUB_TARGET_BIOS="i386-pc"
-				export BIOSSIZE=4 # 4 MiB BIOS partition
+				declare -g uefi_packages="${uefi_packages} grub-pc-bin grub-pc"
+				declare -g UEFI_GRUB_TARGET_BIOS="i386-pc"
+				declare -g BIOSSIZE=4 # 4 MiB BIOS partition
 			else
-				export uefi_packages="${uefi_packages} grub-efi-${ARCH}"
+				declare -g uefi_packages="${uefi_packages} grub-efi-${ARCH}"
 			fi
 		fi
 
-		[[ "${ARCH}" == "arm64" ]] && export uefi_packages="${uefi_packages} grub-efi-${ARCH}"
-		[[ "${ARCH}" == "arm64" ]] && export UEFI_GRUB_TARGET="arm64-efi" # Default for arm64-efi
+		[[ "${ARCH}" == "arm64" ]] && declare -g uefi_packages="${uefi_packages} grub-efi-${ARCH}"
+		[[ "${ARCH}" == "arm64" ]] && declare -g UEFI_GRUB_TARGET="arm64-efi" # Default for arm64-efi
 	fi
 
 	if [[ "${DISTRIBUTION}" == "Ubuntu" ]]; then
@@ -53,16 +53,16 @@ function extension_prepare_config__prepare_grub_standard() {
 		# Debian's prebuilt kernels dont support hvc0, hack.
 		if [[ "${SERIALCON}" == "hvc0" ]]; then
 			display_alert "Debian's kernels don't support hvc0, changing to ttyS0" "${DISTRIBUTION}" "wrn"
-			export SERIALCON="ttyS0"
+			declare -g SERIALCON="ttyS0"
 		fi
 	fi
 
 	if [[ "${DISTRO_GENERIC_KERNEL}" == "yes" ]]; then
-		export IMAGE_INSTALLED_KERNEL_VERSION="${DISTRO_KERNEL_VER}"
-		unset KERNELSOURCE                 # This should make Armbian skip most stuff. At least, I hacked it to.
-		export INSTALL_ARMBIAN_FIRMWARE=no # Should skip build and install of Armbian-firmware.
+		declare -g IMAGE_INSTALLED_KERNEL_VERSION="${DISTRO_KERNEL_VER}"
+		unset KERNELSOURCE                     # This should make Armbian skip most stuff. At least, I hacked it to.
+		declare -g INSTALL_ARMBIAN_FIRMWARE=no # Should skip build and install of Armbian-firmware.
 	else
-		export KERNELDIR="linux-uefi-${LINUXFAMILY}" # Avoid sharing a source tree with others, until we know it's safe.
+		declare -g KERNELDIR="linux-uefi-${LINUXFAMILY}" # Avoid sharing a source tree with others, until we know it's safe.
 		# Don't install anything. Armbian handles everything.
 		DISTRO_KERNEL_PACKAGES=""
 		DISTRO_FIRMWARE_PACKAGES=""

--- a/extensions/image-output-ovf.sh
+++ b/extensions/image-output-ovf.sh
@@ -2,15 +2,15 @@ enable_extension "image-output-qcow2"
 
 #### *run before installing host dependencies*
 function add_host_dependencies__ovf_host_deps() {
-	export EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} qemu-utils"
+	declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} qemu-utils"
 }
 
 #### *allow extensions to prepare their own config, after user config is done*
 function extension_prepare_config__prepare_ovf_config() {
-	export OVF_VM_CPUS="${OVF_VM_CPUS:-4}"        # Number of CPUs
-	export OVF_VM_RAM_GB="${OVF_VM_RAM_GB:-4}"    # RAM in Gigabytes
-	export OVF_KEEP_QCOW2="${OVF_KEEP_QCOW2:-no}" # keep the qcow2 image after conversion to OVF
-	export OVF_KEEP_IMG="${OVF_KEEP_IMG:-no}"     # keep the .img image after conversion to OVF
+	declare -g OVF_VM_CPUS="${OVF_VM_CPUS:-4}"        # Number of CPUs
+	declare -g OVF_VM_RAM_GB="${OVF_VM_RAM_GB:-4}"    # RAM in Gigabytes
+	declare -g OVF_KEEP_QCOW2="${OVF_KEEP_QCOW2:-no}" # keep the qcow2 image after conversion to OVF
+	declare -g OVF_KEEP_IMG="${OVF_KEEP_IMG:-no}"     # keep the .img image after conversion to OVF
 }
 
 #### *custom post build hook*

--- a/extensions/image-output-qcow2.sh
+++ b/extensions/image-output-qcow2.sh
@@ -1,13 +1,13 @@
 function add_host_dependencies__qcow2_host_deps() {
 	[[ "${SKIP_QCOW2}" == "yes" ]] && return 0
-	export EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} qemu-utils"
+	declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} qemu-utils"
 }
 
 function post_build_image__900_convert_to_qcow2_img() {
 	[[ "${SKIP_QCOW2}" == "yes" ]] && return 0
 	[[ -z $version ]] && exit_with_error "version is not set"
 	display_alert "Converting image to qcow2" "${EXTENSION}" "info"
-	export QCOW2_IMAGE_FILE="${DESTIMG}/${version}.img.qcow2"
+	declare -g QCOW2_IMAGE_FILE="${DESTIMG}/${version}.img.qcow2"
 	run_host_command_logged qemu-img convert -f raw -O qcow2 "${DESTIMG}/${version}.img" "${QCOW2_IMAGE_FILE}"
 	run_host_command_logged qemu-img info "${QCOW2_IMAGE_FILE}"
 	if [[ "${QCOW2_RESIZE_AMOUNT}" != "" ]]; then

--- a/extensions/image-output-utm.sh
+++ b/extensions/image-output-utm.sh
@@ -2,15 +2,15 @@ enable_extension "image-output-qcow2"
 
 #### *allow extensions to prepare their own config, after user config is done*
 function extension_prepare_config__prepare_utm_config() {
-	export UTM_VM_CPUS="${UTM_VM_CPUS:-4}"        # Number of CPUs
-	export UTM_VM_RAM_GB="${UTM_VM_RAM_GB:-16}"   # RAM in Gigabytes
-	export UTM_KEEP_QCOW2="${UTM_KEEP_QCOW2:-no}" # keep the qcow2 image after conversion to UTM
-	export UTM_KEEP_IMG="${UTM_KEEP_IMG:-no}"     # keep the .img image after conversion to UTM
+	declare -g UTM_VM_CPUS="${UTM_VM_CPUS:-4}"        # Number of CPUs
+	declare -g UTM_VM_RAM_GB="${UTM_VM_RAM_GB:-16}"   # RAM in Gigabytes
+	declare -g UTM_KEEP_QCOW2="${UTM_KEEP_QCOW2:-no}" # keep the qcow2 image after conversion to UTM
+	declare -g UTM_KEEP_IMG="${UTM_KEEP_IMG:-no}"     # keep the .img image after conversion to UTM
 }
 
 function user_config__metadata_cloud_config() {
 	display_alert "Preparing UTM config" "${EXTENSION}" "info"
-	export SERIALCON="ttyS0" # UTM's serial at ttyS0, for x86 @TODO: arm64? ttyAML0?
+	declare -g SERIALCON="ttyS0" # UTM's serial at ttyS0, for x86 @TODO: arm64? ttyAML0?
 	display_alert "Prepared UTM config" "${EXTENSION}: SERIALCON: '${SERIALCON}'" "debug"
 }
 

--- a/extensions/nvidia.sh
+++ b/extensions/nvidia.sh
@@ -4,7 +4,7 @@ function extension_finish_config__build_nvidia_kernel_module() {
 		display_alert "Kernel version has no working headers package" "skipping nVidia for kernel v${KERNEL_MAJOR_MINOR}" "warn"
 		return 0
 	fi
-	export INSTALL_HEADERS="yes"
+	declare -g INSTALL_HEADERS="yes"
 	declare -g NVIDIA_DRIVER_VERSION="${NVIDIA_DRIVER_VERSION:-"510"}" # @TODO: this might vary per-release and Debian/Ubuntu
 	display_alert "Forcing INSTALL_HEADERS=yes; using nVidia driver version ${NVIDIA_DRIVER_VERSION}" "${EXTENSION}" "debug"
 }

--- a/extensions/zfs.sh
+++ b/extensions/zfs.sh
@@ -3,7 +3,7 @@ function extension_finish_config__build_zfs_kernel_module() {
 		display_alert "Kernel version has no working headers package" "skipping ZFS for kernel v${KERNEL_MAJOR_MINOR}" "warn"
 		return 0
 	fi
-	export INSTALL_HEADERS="yes"
+	declare -g INSTALL_HEADERS="yes"
 	display_alert "Forcing INSTALL_HEADERS=yes; for use with ZFS" "${EXTENSION}" "debug"
 }
 

--- a/lib/functions/artifacts/artifact-armbian-bsp-cli.sh
+++ b/lib/functions/artifacts/artifact-armbian-bsp-cli.sh
@@ -42,14 +42,15 @@ function artifact_armbian-bsp-cli_prepare_version() {
 		"${bootscript_info[bootenv_file_contents]}"
 		"${bootscript_info[has_bootscript]}"
 		"${bootscript_info[has_extlinux]}"
-		"${UBOOT_FW_ENV}"      # not included in bootscript
-		"${BOARDFAMILY}"       # /etc/armbian-release
-		"${LINUXFAMILY}"       # /etc/armbian-release
-		"${IMAGE_TYPE}"        # /etc/armbian-release
-		"${BOARD_TYPE}"        # /etc/armbian-release
-		"${INITRD_ARCH}"       # /etc/armbian-release
-		"${KERNEL_IMAGE_TYPE}" # /etc/armbian-release
-		"${VENDOR}"            # /etc/armbian-release
+		"${UBOOT_FW_ENV}"                   # not included in bootscript
+		"${KEEP_ORIGINAL_OS_RELEASE:-"no"}" # /etc/os-release
+		"${BOARDFAMILY}"                    # /etc/armbian-release
+		"${LINUXFAMILY}"                    # /etc/armbian-release
+		"${IMAGE_TYPE}"                     # /etc/armbian-release
+		"${BOARD_TYPE}"                     # /etc/armbian-release
+		"${INITRD_ARCH}"                    # /etc/armbian-release
+		"${KERNEL_IMAGE_TYPE}"              # /etc/armbian-release
+		"${VENDOR}"                         # /etc/armbian-release
 	)
 	declare hash_vars="undetermined"
 	hash_vars="$(echo "${vars_to_hash[@]}" | sha256sum | cut -d' ' -f1)"

--- a/lib/functions/artifacts/artifact-armbian-bsp-desktop.sh
+++ b/lib/functions/artifacts/artifact-armbian-bsp-desktop.sh
@@ -88,6 +88,7 @@ function artifact_armbian-bsp-desktop_cli_adapter_config_prep() {
 	: "${DESKTOP_ENVIRONMENT_CONFIG_NAME:?DESKTOP_ENVIRONMENT_CONFIG_NAME is not set}"
 
 	# this requires aggregation, and thus RELEASE, but also everything else.
+	declare -g artifact_version_requires_aggregation="yes"
 	use_board="yes" allow_no_family="no" skip_kernel="no" prep_conf_main_only_rootfs_ni < /dev/null # no stdin for this, so it bombs if tries to be interactive.
 }
 

--- a/lib/functions/artifacts/artifact-armbian-bsp-desktop.sh
+++ b/lib/functions/artifacts/artifact-armbian-bsp-desktop.sh
@@ -54,7 +54,7 @@ function artifact_armbian-bsp-desktop_prepare_version() {
 
 	artifact_name="armbian-bsp-desktop-${BOARD}-${BRANCH}"
 	artifact_type="deb"
-	artifact_base_dir="${DEB_STORAGE}"
+	artifact_base_dir="${DEB_STORAGE}/${RELEASE}"
 	artifact_final_file="${DEB_STORAGE}/${RELEASE}/${artifact_name}_${artifact_version}_${ARCH}.deb"
 
 	artifact_map_packages=(

--- a/lib/functions/artifacts/artifact-armbian-desktop.sh
+++ b/lib/functions/artifacts/artifact-armbian-desktop.sh
@@ -56,7 +56,7 @@ function artifact_armbian-desktop_prepare_version() {
 
 	artifact_name="armbian-${RELEASE}-desktop-${DESKTOP_ENVIRONMENT}"
 	artifact_type="deb"
-	artifact_base_dir="${DEB_STORAGE}"
+	artifact_base_dir="${DEB_STORAGE}/${RELEASE}"
 	artifact_final_file="${DEB_STORAGE}/${RELEASE}/${artifact_name}_${artifact_version}_all.deb"
 
 	artifact_map_packages=(

--- a/lib/functions/artifacts/artifact-armbian-desktop.sh
+++ b/lib/functions/artifacts/artifact-armbian-desktop.sh
@@ -87,6 +87,7 @@ function artifact_armbian-desktop_cli_adapter_config_prep() {
 	: "${DESKTOP_ENVIRONMENT_CONFIG_NAME:?DESKTOP_ENVIRONMENT_CONFIG_NAME is not set}"
 
 	# this requires aggregation, and thus RELEASE, but also everything else.
+	declare -g artifact_version_requires_aggregation="yes"
 	use_board="yes" allow_no_family="no" skip_kernel="no" prep_conf_main_only_rootfs_ni < /dev/null # no stdin for this, so it bombs if tries to be interactive.
 }
 

--- a/lib/functions/artifacts/artifact-rootfs.sh
+++ b/lib/functions/artifacts/artifact-rootfs.sh
@@ -99,6 +99,7 @@ function artifact_rootfs_cli_adapter_pre_run() {
 }
 
 function artifact_rootfs_cli_adapter_config_prep() {
+	declare -g artifact_version_requires_aggregation="yes"
 	declare -g ROOTFS_COMPRESSION_RATIO="${ROOTFS_COMPRESSION_RATIO:-"15"}" # default to Compress stronger when we make rootfs cache
 
 	# If BOARD is set, use it to convert to an ARCH.

--- a/lib/functions/artifacts/artifact-rootfs.sh
+++ b/lib/functions/artifacts/artifact-rootfs.sh
@@ -10,7 +10,15 @@
 function artifact_rootfs_config_dump() {
 	artifact_input_variables[ARCH]="${ARCH}"
 	artifact_input_variables[RELEASE]="${RELEASE}"
-	artifact_input_variables[CACHE_TYPE]="${cache_type:-"no_cache_type_yet"}"
+	artifact_input_variables[SELECTED_CONFIGURATION]="${SELECTED_CONFIGURATION}" # should be represented below anyway
+	artifact_input_variables[BUILD_MINIMAL]="${BUILD_MINIMAL}"
+	artifact_input_variables[DESKTOP_ENVIRONMENT]="${DESKTOP_ENVIRONMENT:-"no_DESKTOP_ENVIRONMENT_set"}"
+	artifact_input_variables[DESKTOP_ENVIRONMENT_CONFIG_NAME]="${DESKTOP_ENVIRONMENT_CONFIG_NAME:-"no_DESKTOP_ENVIRONMENT_CONFIG_NAME_set"}"
+	artifact_input_variables[DESKTOP_APPGROUPS_SELECTED]="${DESKTOP_APPGROUPS_SELECTED:-"no_DESKTOP_APPGROUPS_SELECTED_set"}"
+	# Hash of the packages added/removed by extensions
+	declare pkgs_hash="undetermined"
+	pkgs_hash="$(echo "${REMOVE_PACKAGES[*]} ${REMOVE_PACKAGES_REFS[*]}" | sha256sum | cut -d' ' -f1)"
+	artifact_input_variables[EXTRA_PKG_ADD_REMOVE_HASH]="${pkgs_hash}"
 }
 
 function artifact_rootfs_prepare_version() {

--- a/lib/functions/artifacts/artifacts-obtain.sh
+++ b/lib/functions/artifacts/artifacts-obtain.sh
@@ -141,8 +141,6 @@ function obtain_complete_artifact() {
 	debug_var artifact_final_file_basename
 	debug_var artifact_file_relative
 
-	# @TODO: possibly stop here if only for up-to-date-checking
-
 	# Determine OCI coordinates. OCI_TARGET_BASE overrides the default proposed by the artifact.
 	declare artifact_oci_target_base="undetermined"
 	if [[ -n "${OCI_TARGET_BASE}" ]]; then
@@ -154,6 +152,35 @@ function obtain_complete_artifact() {
 	[[ -z "${artifact_oci_target_base}" ]] && exit_with_error "No artifact_oci_target_base defined."
 
 	declare -g artifact_full_oci_target="${artifact_oci_target_base}${artifact_name}:${artifact_version}"
+
+	# if CONFIG_DEFS_ONLY, dump JSON and exit
+	if [[ "${CONFIG_DEFS_ONLY}" == "yes" ]]; then
+		display_alert "artifact" "CONFIG_DEFS_ONLY is set, skipping artifact creation" "warn"
+
+		declare -a wanted_vars=(
+			artifact_name
+			artifact_type
+			artifact_version
+			artifact_version_reason
+			artifact_base_dir
+			artifact_final_file
+			artifact_final_file_basename
+			artifact_file_relative
+			artifact_full_oci_target
+		)
+
+		declare -A ARTIFACTS_VAR_DICT=()
+
+		for var in "${wanted_vars[@]}"; do
+			ARTIFACTS_VAR_DICT["${var}"]="$(declare -p "${var}")"
+		done
+
+		display_alert "Dumping JSON" "for ${#ARTIFACTS_VAR_DICT[@]} variables" "ext"
+		python3 "${SRC}/lib/tools/configdump2json.py" "--args" "${ARTIFACTS_VAR_DICT[@]}" # to stdout
+
+		exit 0
+	fi
+
 
 	declare -g artifact_exists_in_local_cache="undetermined"
 	declare -g artifact_exists_in_remote_cache="undetermined"

--- a/lib/functions/artifacts/artifacts-obtain.sh
+++ b/lib/functions/artifacts/artifacts-obtain.sh
@@ -181,7 +181,6 @@ function obtain_complete_artifact() {
 		exit 0
 	fi
 
-
 	declare -g artifact_exists_in_local_cache="undetermined"
 	declare -g artifact_exists_in_remote_cache="undetermined"
 
@@ -369,5 +368,13 @@ function is_artifact_available_in_remote_cache() {
 function obtain_artifact_from_remote_cache() {
 	display_alert "Obtaining artifact from remote cache" "${artifact_full_oci_target} into ${artifact_final_file_basename}" "info"
 	oras_pull_artifact_file "${artifact_full_oci_target}" "${artifact_base_dir}" "${artifact_final_file_basename}"
+
+	# sanity check: after obtaining remotely, is it available locally? it should, otherwise there's some inconsistency.
+	declare artifact_exists_in_local_cache="not-yet-after-obtaining-remotely"
+	is_artifact_available_in_local_cache
+	if [[ "${artifact_exists_in_local_cache}" == "no" ]]; then
+		exit_with_error "Artifact is not available in local cache after obtaining remotely: ${artifact_full_oci_target} into '${artifact_base_dir}' file '${artifact_final_file_basename}'"
+	fi
+
 	return 0
 }

--- a/lib/functions/cli/cli-artifact.sh
+++ b/lib/functions/cli/cli-artifact.sh
@@ -24,7 +24,13 @@ function cli_artifact_run() {
 
 	display_alert "artifact" "${chosen_artifact}" "debug"
 	display_alert "artifact" "${chosen_artifact} :: ${chosen_artifact_impl}()" "debug"
-	artifact_cli_adapter_config_prep # only if in cli.
+	declare -g artifact_version_requires_aggregation="no" # marker
+	artifact_cli_adapter_config_prep                      # only if in cli.
+
+	# if asked by _config_prep to aggregate, and HOSTRELEASE is not set, obtain it.
+	if [[ "${artifact_version_requires_aggregation}" == "yes" ]] && [[ -z "${HOSTRELEASE}" ]]; then
+		obtain_hostrelease_only # Sets HOSTRELEASE
+	fi
 
 	# When run in GHA, assume we're checking/updating the remote cache only.
 	# Local cache is ignored, and if found, it's not unpacked, either from local or remote.
@@ -64,9 +70,5 @@ function cli_artifact_run() {
 		skip_unpack_if_found_in_caches="no"
 	fi
 
-	if [[ "${CONFIG_DEFS_ONLY}" != "yes" ]]; then
-		do_with_default_build obtain_complete_artifact # @TODO: < /dev/null -- but what about kernel configure?
-	else
-		obtain_complete_artifact
-	fi
+	do_with_default_build obtain_complete_artifact # @TODO: < /dev/null -- but what about kernel configure?
 }

--- a/lib/functions/cli/cli-artifact.sh
+++ b/lib/functions/cli/cli-artifact.sh
@@ -17,8 +17,10 @@ function cli_artifact_run() {
 	: "${chosen_artifact:?chosen_artifact is not set}"
 	: "${chosen_artifact_impl:?chosen_artifact_impl is not set}"
 
-	# Make sure ORAS tooling is installed before starting.
-	run_tool_oras
+	if [[ "${CONFIG_DEFS_ONLY}" != "yes" ]]; then
+		# Make sure ORAS tooling is installed before starting.
+		run_tool_oras
+	fi
 
 	display_alert "artifact" "${chosen_artifact}" "debug"
 	display_alert "artifact" "${chosen_artifact} :: ${chosen_artifact_impl}()" "debug"
@@ -62,5 +64,9 @@ function cli_artifact_run() {
 		skip_unpack_if_found_in_caches="no"
 	fi
 
-	do_with_default_build obtain_complete_artifact # @TODO: < /dev/null -- but what about kernel configure?
+	if [[ "${CONFIG_DEFS_ONLY}" != "yes" ]]; then
+		do_with_default_build obtain_complete_artifact # @TODO: < /dev/null -- but what about kernel configure?
+	else
+		obtain_complete_artifact
+	fi
 }

--- a/lib/functions/cli/cli-flash.sh
+++ b/lib/functions/cli/cli-flash.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (c) 2013-2023 Igor Pecovnik, igor@armbian.com
+#
+# This file is a part of the Armbian Build Framework
+# https://github.com/armbian/build/
+
+function cli_flash_pre_run() {
+	display_alert "cli_distccd_pre_run" "func cli_distccd_run :: ${ARMBIAN_COMMAND}" "warn"
+
+	# "gimme root on a Linux machine"
+	cli_standard_relaunch_docker_or_sudo
+}
+
+function cli_flash_run() {
+	if [[ "x${BOARD}x" != "xx" ]]; then
+		use_board="yes" prep_conf_main_minimal_ni < /dev/null # no stdin for this, so it bombs if tries to be interactive.
+	else
+		use_board="no" prep_conf_main_minimal_ni < /dev/null # no stdin for this, so it bombs if tries to be interactive.
+	fi
+
+	# the full build. It has its own logging sections.
+	do_with_default_build cli_flash
+}
+
+function cli_flash() {
+	declare image_file="${IMAGE:-""}"
+	# If not set, find the latest .img file in ${SRC}/output/images/
+	if [[ -z "${image_file}" ]]; then
+		# shellcheck disable=SC2012
+		image_file="$(ls -1t "${SRC}/output/images"/*"${BOARD^}_${RELEASE}_${BRANCH}"*.img | head -1)"
+		display_alert "cli_flash" "No image file specified. Using latest built image file found: ${image_file}" "info"
+	fi
+	if [[ ! -f "${image_file}" ]]; then
+		exit_with_error "No image file to flash."
+	fi
+	declare image_file_basename
+	image_file_basename="$(basename "${image_file}")"
+	display_alert "cli_flash" "Flashing image file: ${image_file_basename}" "info"
+	countdown_and_continue_if_not_aborted 3
+
+	write_image_to_device_and_run_hooks "${image_file}"
+}

--- a/lib/functions/cli/commands.sh
+++ b/lib/functions/cli/commands.sh
@@ -30,6 +30,7 @@ function armbian_register_commands() {
 
 		["build"]="standard_build" # implemented in cli_standard_build_pre_run and cli_standard_build_run
 		["distccd"]="distccd"      # implemented in cli_distccd_pre_run and cli_distccd_run
+		["flash"]="flash"      # implemented in cli_flash_pre_run and cli_flash_run
 
 		# external tooling, made easy.
 		["oras-upload"]="oras" # implemented in cli_oras_pre_run and cli_oras_run; up/down/info are the same, see vars below

--- a/lib/functions/cli/commands.sh
+++ b/lib/functions/cli/commands.sh
@@ -35,7 +35,8 @@ function armbian_register_commands() {
 		["oras-upload"]="oras" # implemented in cli_oras_pre_run and cli_oras_run; up/down/info are the same, see vars below
 
 		# all-around artifact wrapper
-		["artifact"]="artifact" # implemented in cli_artifact_pre_run and cli_artifact_run
+		["artifact"]="artifact"                  # implemented in cli_artifact_pre_run and cli_artifact_run
+		["artifact-config-dump-json"]="artifact" # implemented in cli_artifact_pre_run and cli_artifact_run
 
 		# shortcuts, see vars set below. the use legacy single build, and try to control it via variables
 		["rootfs"]="artifact"
@@ -71,6 +72,8 @@ function armbian_register_commands() {
 		["dockershell"]="DOCKER_SUBCMD='shell'"
 
 		["generate-dockerfile"]="DOCKERFILE_GENERATE_ONLY='yes'"
+
+		["artifact-config-dump-json"]='CONFIG_DEFS_ONLY="yes"'
 
 		# artifact shortcuts
 		["rootfs"]="WHAT='rootfs' ${common_cli_artifact_vars}"

--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -324,6 +324,7 @@ function do_extra_configuration() {
 	# Control aria2c's usage of ipv6.
 	[[ -z $DISABLE_IPV6 ]] && DISABLE_IPV6="true"
 
+	# @TODO this is _very legacy_ and should be removed. Old-time users might have a lib.config lying around and it will mess up things.
 	# For (late) user override.
 	# Notice: it is too late to define hook functions or add extensions in lib.config, since the extension initialization already ran by now.
 	#         in case the user tries to use them in lib.config, hopefully they'll be detected as "wishful hooking" and the user will be wrn'ed.
@@ -331,6 +332,10 @@ function do_extra_configuration() {
 		display_alert "Using user configuration override" "$USERPATCHES_PATH/lib.config" "info"
 		source "$USERPATCHES_PATH"/lib.config
 	fi
+
+	# Prepare array for extensions to fill in.
+	display_alert "Main config" "initting EXTRA_IMAGE_SUFFIXES" "debug"
+	declare -g -a EXTRA_IMAGE_SUFFIXES=()
 
 	call_extension_method "user_config" <<- 'USER_CONFIG'
 		*Invoke function with user override*
@@ -360,6 +365,16 @@ function do_extra_configuration() {
 
 	# Give the option to configure DNS server used in the chroot during the build process
 	[[ -z $NAMESERVER ]] && NAMESERVER="1.0.0.1" # default is cloudflare alternate
+
+	# Consolidate the extra image suffix. loop and add.
+	declare EXTRA_IMAGE_SUFFIX=""
+	for suffix in "${EXTRA_IMAGE_SUFFIXES[@]}"; do
+		display_alert "Adding extra image suffix" "'${suffix}'" "debug"
+		EXTRA_IMAGE_SUFFIX="${EXTRA_IMAGE_SUFFIX}${suffix}"
+	done
+	declare -g -r EXTRA_IMAGE_SUFFIX="${EXTRA_IMAGE_SUFFIX}"
+	display_alert "Extra image suffix" "'${EXTRA_IMAGE_SUFFIX}'" "debug"
+	unset EXTRA_IMAGE_SUFFIXES # get rid of this, no longer used
 
 	display_alert "Done with do_extra_configuration" "do_extra_configuration" "debug"
 }

--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -376,6 +376,17 @@ function do_extra_configuration() {
 	display_alert "Extra image suffix" "'${EXTRA_IMAGE_SUFFIX}'" "debug"
 	unset EXTRA_IMAGE_SUFFIXES # get rid of this, no longer used
 
+	# Lets estimate the image name, based on the configuration. The real image name depends on _actual_ kernel version.
+	# Here we do a gross estimate with the KERNEL_MAJOR_MINOR + ".y" version, or "generic" if not set (ddks etc).
+	declare calculated_image_version="undetermined"
+	declare predicted_kernel_version="generic"
+	if [[ -n "${KERNEL_MAJOR_MINOR}" ]]; then
+		predicted_kernel_version="${KERNEL_MAJOR_MINOR}.y"
+	fi
+	IMAGE_INSTALLED_KERNEL_VERSION="${predicted_kernel_version}" include_vendor_version="no" calculate_image_version
+
+	declare -r -g IMAGE_FILE_ID="${calculated_image_version}" # Global, readonly.
+
 	display_alert "Done with do_extra_configuration" "do_extra_configuration" "debug"
 }
 

--- a/lib/functions/host/host-release.sh
+++ b/lib/functions/host/host-release.sh
@@ -8,11 +8,8 @@
 # https://github.com/armbian/build/
 
 function obtain_and_check_host_release_and_arch() {
-	# obtain the host release either from os-release or debian_version
-	declare -g HOSTRELEASE
-	HOSTRELEASE="$(cat /etc/os-release | grep VERSION_CODENAME | cut -d"=" -f2)"
-	[[ -z $HOSTRELEASE ]] && HOSTRELEASE="$(cut -d'/' -f1 /etc/debian_version)"
-	display_alert "Build host OS release" "${HOSTRELEASE:-(unknown)}" "info"
+
+	obtain_hostrelease_only
 
 	# obtain the host arch, from dpkg
 	declare -g HOSTARCH
@@ -44,4 +41,12 @@ function obtain_and_check_host_release_and_arch() {
 			exit_with_error "Unsupported build system: '${HOSTRELEASE:-(unknown)}'"
 		fi
 	fi
+}
+
+function obtain_hostrelease_only() {
+	# obtain the host release either from os-release or debian_version
+	declare -g HOSTRELEASE
+	HOSTRELEASE="$(cat /etc/os-release | grep VERSION_CODENAME | cut -d"=" -f2)"
+	[[ -z $HOSTRELEASE ]] && HOSTRELEASE="$(cut -d'/' -f1 /etc/debian_version)"
+	display_alert "Build host OS release" "${HOSTRELEASE:-(unknown)}" "info"
 }

--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -290,8 +290,8 @@ function adaptative_prepare_host_dependencies() {
 	host_dependencies+=("python3-dev" "python3-distutils" "python3-setuptools" "python3-pip")
 
 	# Python2 -- required for some older u-boot builds
-	# Debian 'sid' does not carry python2 anymore; in this case some u-boot's might fail to build.
-	if [[ "sid bookworm" == *"${host_release}"* ]]; then
+	# Debian 'sid'/'bookworm' and Ubuntu 'lunar' does not carry python2 anymore; in this case some u-boot's might fail to build.
+	if [[ "sid bookworm lunar" == *"${host_release}"* ]]; then
 		display_alert "Python2 not available on host release '${host_release}'" "old(er) u-boot builds might/will fail" "wrn"
 	else
 		host_dependencies+=("python2" "python2-dev")

--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -19,6 +19,10 @@ function prepare_host() {
 }
 
 function assert_prepared_host() {
+	if [[ "${PRE_PREPARED_HOST:-"no"}" == "yes" ]]; then
+		return 0
+	fi
+
 	if [[ ${prepare_host_has_already_run:-0} -lt 1 ]]; then
 		exit_with_error "assert_prepared_host: Host has not yet been prepared. This is a bug in armbian-next code. Please report!"
 	fi

--- a/lib/functions/image/rootfs-to-image.sh
+++ b/lib/functions/image/rootfs-to-image.sh
@@ -19,12 +19,15 @@ function create_image_from_sdcard_rootfs() {
 	add_cleanup_handler trap_handler_cleanup_destimg
 
 	# stage: create file name
-	# determine the image file name produced. a bit late in the game, since it uses IMAGE_INSTALLED_KERNEL_VERSION which is from the kernel package.
-	# If IMAGE_VERSION has something, use it, otherwise use REVISION
-	local version="${VENDOR}_${IMAGE_VERSION:-"${REVISION}"}_${BOARD^}_${RELEASE}_${BRANCH}_${IMAGE_INSTALLED_KERNEL_VERSION/-$LINUXFAMILY/}${DESKTOP_ENVIRONMENT:+_$DESKTOP_ENVIRONMENT}"
+	# determine the image file name produced. a bit late in the game, since it uses IMAGE_INSTALLED_KERNEL_VERSION which is set in distro-agnostic.sh.
+	# If IMAGE_VERSION has something, use it, otherwise use REVISION.
+	# EXTRA_IMAGE_SUFFIX is composed at the end of main-config from extensions that add to EXTRA_IMAGE_SUFFIXES array.
+	# legacy: the "version" local variable is used elsewhere, take care changing it.
+	declare -g version="${VENDOR}_${IMAGE_VERSION:-"${REVISION}"}_${BOARD^}_${RELEASE}_${BRANCH}_${IMAGE_INSTALLED_KERNEL_VERSION/-$LINUXFAMILY/}${DESKTOP_ENVIRONMENT:+_$DESKTOP_ENVIRONMENT}${EXTRA_IMAGE_SUFFIX}"
 	[[ $BUILD_DESKTOP == yes ]] && version=${version}_desktop
 	[[ $BUILD_MINIMAL == yes ]] && version=${version}_minimal
 	[[ $ROOTFS_TYPE == nfs ]] && version=${version}_nfsboot
+	declare -r -g version="${version}" # global readonly from here
 
 	if [[ $ROOTFS_TYPE != nfs ]]; then
 		display_alert "Copying files via rsync to" "/ (MOUNT root)"

--- a/lib/functions/logging/display-alert.sh
+++ b/lib/functions/logging/display-alert.sh
@@ -15,7 +15,7 @@ function display_alert() {
 		if [[ "${POOR_MAN_PROFILER}" == "yes" ]]; then
 			poor_man_profiler
 		fi
-		echo -e "${extra_profiler}${*}" | sed 's/\x1b\[[0-9;]*m//g' >&2
+		echo -e "${extra_profiler}${3}::${1} ${2}" | sed 's/\x1b\[[0-9;]*m//g' >&2
 		return 0
 	fi
 

--- a/lib/functions/logging/logging.sh
+++ b/lib/functions/logging/logging.sh
@@ -65,17 +65,19 @@ function logging_error_show_log() {
 		echo "::endgroup::"
 	fi
 
-	if [[ -f "${logfile_to_show}" ]]; then
-		local prefix_sed_contents="${normal_color}${left_marker}${padding}👉${padding}${right_marker}    "
-		local prefix_sed_cmd="s/^/${prefix_sed_contents}/;"
-		CURRENT_LOGFILE="" display_alert "    👇👇👇 Showing logfile below 👇👇👇" "${logfile_to_show}" "err"
+	if [[ "${ANSI_COLOR}" != "none" ]]; then
+		if [[ -f "${logfile_to_show}" ]]; then
+			local prefix_sed_contents="${normal_color}${left_marker}${padding}👉${padding}${right_marker}    "
+			local prefix_sed_cmd="s/^/${prefix_sed_contents}/;"
+			CURRENT_LOGFILE="" display_alert "    👇👇👇 Showing logfile below 👇👇👇" "${logfile_to_show}" "err"
 
-		# shellcheck disable=SC2002 # my cat is great. thank you, shellcheck.
-		cat "${logfile_to_show}" | grep -v -e "^$" | sed -e "${prefix_sed_cmd}" 1>&2 # write it to stderr!!
+			# shellcheck disable=SC2002 # my cat is great. thank you, shellcheck.
+			cat "${logfile_to_show}" | grep -v -e "^$" | sed -e "${prefix_sed_cmd}" 1>&2 # write it to stderr!!
 
-		CURRENT_LOGFILE="" display_alert "    👆👆👆 Showing logfile above 👆👆👆" "${logfile_to_show}" "err"
-	else
-		CURRENT_LOGFILE="" display_alert "✋ Error log not available at this stage of build" "check messages above" "debug"
+			CURRENT_LOGFILE="" display_alert "    👆👆👆 Showing logfile above 👆👆👆" "${logfile_to_show}" "err"
+		else
+			CURRENT_LOGFILE="" display_alert "✋ Error log not available at this stage of build" "check messages above" "debug"
+		fi
 	fi
 	return 0
 }

--- a/lib/functions/main/build-packages.sh
+++ b/lib/functions/main/build-packages.sh
@@ -53,6 +53,13 @@ function determine_artifacts_to_build_for_image() {
 			artifacts_to_build+=("armbian-bsp-desktop")
 		fi
 	fi
+
+	# If we're only dumping the config, include the rootfs artifact.
+	# In a "real" build, this artifact is built/consumed by get_or_create_rootfs_cache_chroot_sdcard(), not here.
+	if [[ "${CONFIG_DEFS_ONLY}" == "yes" ]]; then
+		artifacts_to_build+=("rootfs")
+	fi
+
 }
 
 function main_default_build_packages() {

--- a/lib/functions/main/config-prepare.sh
+++ b/lib/functions/main/config-prepare.sh
@@ -53,7 +53,9 @@ function prep_conf_main_minimal_ni() {
 
 	# needed for most stuff, but not for configdump
 	if [[ "${skip_host_config:-"no"}" != "yes" ]]; then
-		check_basic_host
+		if [[ "${CONFIG_DEFS_ONLY}" != "yes" ]]; then
+			check_basic_host
+		fi
 	fi
 
 	# needed for BOARD= builds.

--- a/lib/functions/main/start-end.sh
+++ b/lib/functions/main/start-end.sh
@@ -10,6 +10,25 @@
 # Common start/end build functions. Used by the default build and others
 
 function main_default_start_build() {
+	if [[ "${PRE_PREPARED_HOST:-"no"}" != "yes" ]]; then
+		prepare_host_init # this has its own logging sections, and is possibly interactive.
+	fi
+
+	# Prepare ccache, cthreads, etc for the build
+	LOG_SECTION="prepare_compilation_vars" do_with_logging prepare_compilation_vars
+
+	# from mark_aggregation_required_in_default_build_start() possibly marked during config
+	if [[ ${aggregation_required_in_default_build_start:-0} -gt 0 ]]; then
+		display_alert "Configuration requires aggregation" "running aggregation now" "debug"
+		aggregate_packages_in_logging_section
+	else
+		display_alert "Configuration does not require aggregation" "skipping aggregation" "debug"
+	fi
+
+	return 0
+}
+
+function prepare_host_init() {
 	wait_for_disk_sync "before starting build" # fsync, wait for disk to sync, and then continue. alert user if takes too long.
 
 	# Check that WORKDIR_BASE_TMP exists; if not, create it.
@@ -48,19 +67,6 @@ function main_default_start_build() {
 	mkdir -p "${BIN_WORK_DIR}"
 	ln -s "/usr/bin/python2" "${BIN_WORK_DIR}/python"
 	declare -g PATH="${BIN_WORK_DIR}:${PATH}"
-
-	# Prepare ccache, cthreads, etc for the build
-	LOG_SECTION="prepare_compilation_vars" do_with_logging prepare_compilation_vars
-
-	# from mark_aggregation_required_in_default_build_start() possibly marked during config
-	if [[ ${aggregation_required_in_default_build_start:-0} -gt 0 ]]; then
-		display_alert "Configuration requires aggregation" "running aggregation now" "debug"
-		aggregate_packages_in_logging_section
-	else
-		display_alert "Configuration does not require aggregation" "skipping aggregation" "debug"
-	fi
-
-	return 0
 }
 
 function main_default_end_build() {

--- a/lib/functions/rootfs/distro-agnostic.sh
+++ b/lib/functions/rootfs/distro-agnostic.sh
@@ -148,7 +148,13 @@ function install_distribution_agnostic() {
 	# change console welcome text
 	echo -e "${VENDOR} ${IMAGE_VERSION:-"${REVISION}"} ${RELEASE^} \\l \n" > "${SDCARD}"/etc/issue
 	echo "${VENDOR} ${IMAGE_VERSION:-"${REVISION}"} ${RELEASE^}" > "${SDCARD}"/etc/issue.net
-	sed -i "s/^PRETTY_NAME=.*/PRETTY_NAME=\"${VENDOR} ${IMAGE_VERSION:-"${REVISION}"} ${RELEASE^}\"/" "${SDCARD}"/etc/os-release
+
+	# Keep, or change to Armbian's PRETTY_NAME in /etc/os-release (this is also done in the bsp-cli postinst)
+	if [[ "${KEEP_ORIGINAL_OS_RELEASE:-"no"}" != "yes" ]]; then
+		sed -i "s/^PRETTY_NAME=.*/PRETTY_NAME=\"${VENDOR} ${IMAGE_VERSION:-"${REVISION}"} ${RELEASE^}\"/" "${SDCARD}"/etc/os-release
+	else
+		display_alert "distro-agnostic: KEEP_ORIGINAL_OS_RELEASE" "Keeping original /etc/os-release's PRETTY_NAME as original" "warn"
+	fi
 
 	# enable few bash aliases enabled in Ubuntu by default to make it even
 	sed "s/#alias ll='ls -l'/alias ll='ls -l'/" -i "${SDCARD}"/etc/skel/.bashrc
@@ -400,11 +406,11 @@ function install_distribution_agnostic() {
 	if [[ "${BSPFREEZE:-"no"}" == yes ]]; then
 		display_alert "Freezing Armbian packages" "$BOARD" "info"
 		chroot_sdcard apt-mark hold "${image_artifacts_packages["armbian-plymouth-theme"]}" "${image_artifacts_packages["armbian-zsh"]}" \
-		"${image_artifacts_packages["armbian-config"]}" "${image_artifacts_packages["armbian-bsp-desktop"]}" \
-		"${image_artifacts_packages["armbian-desktop"]}" "${image_artifacts_packages["armbian-bsp-cli"]}" \
-		"${image_artifacts_packages["armbian-firmware"]}" "${image_artifacts_packages["armbian-firmware-full"]}" \
-		"${image_artifacts_packages["linux-headers"]}" "${image_artifacts_packages["linux-dtb"]}" \
-		"${image_artifacts_packages["linux-image"]}" "${image_artifacts_packages["uboot"]}" || true
+			"${image_artifacts_packages["armbian-config"]}" "${image_artifacts_packages["armbian-bsp-desktop"]}" \
+			"${image_artifacts_packages["armbian-desktop"]}" "${image_artifacts_packages["armbian-bsp-cli"]}" \
+			"${image_artifacts_packages["armbian-firmware"]}" "${image_artifacts_packages["armbian-firmware-full"]}" \
+			"${image_artifacts_packages["linux-headers"]}" "${image_artifacts_packages["linux-dtb"]}" \
+			"${image_artifacts_packages["linux-image"]}" "${image_artifacts_packages["uboot"]}" || true
 	fi
 
 	# remove deb files

--- a/lib/functions/rootfs/distro-agnostic.sh
+++ b/lib/functions/rootfs/distro-agnostic.sh
@@ -331,7 +331,7 @@ function install_distribution_agnostic() {
 	PRE_INSTALL_KERNEL_DEBS
 
 	# default IMAGE_INSTALLED_KERNEL_VERSION, will be parsed from Kernel version in the installed deb package.
-	IMAGE_INSTALLED_KERNEL_VERSION="linux"
+	IMAGE_INSTALLED_KERNEL_VERSION="generic"
 
 	# install kernel: image/dtb/headers
 	if [[ -n $KERNELSOURCE ]]; then

--- a/lib/library-functions.sh
+++ b/lib/library-functions.sh
@@ -204,6 +204,15 @@ source "${SRC}"/lib/functions/cli/cli-docker.sh
 #set -o nounset   ## set -u : exit the script if you try to use an uninitialised variable - one day will be enabled
 set -o errtrace # trace ERR through - enabled
 set -o errexit  ## set -e : exit the script if any statement returns a non-true return value - enabled
+### lib/functions/cli/cli-flash.sh
+# shellcheck source=lib/functions/cli/cli-flash.sh
+source "${SRC}"/lib/functions/cli/cli-flash.sh
+
+# no errors tolerated. invoked before each sourced file to make sure.
+#set -o pipefail  # trace ERR through pipes - will be enabled "soon"
+#set -o nounset   ## set -u : exit the script if you try to use an uninitialised variable - one day will be enabled
+set -o errtrace # trace ERR through - enabled
+set -o errexit  ## set -e : exit the script if any statement returns a non-true return value - enabled
 ### lib/functions/cli/cli-jsoninfo.sh
 # shellcheck source=lib/functions/cli/cli-jsoninfo.sh
 source "${SRC}"/lib/functions/cli/cli-jsoninfo.sh
@@ -1143,6 +1152,7 @@ set -o errexit  ## set -e : exit the script if any statement returns a non-true 
 ### lib/functions/rootfs/trap-rootfs.sh
 # shellcheck source=lib/functions/rootfs/trap-rootfs.sh
 source "${SRC}"/lib/functions/rootfs/trap-rootfs.sh
+
 
 # no errors tolerated. one last time for the win!
 #set -o pipefail  # trace ERR through pipes - will be enabled "soon"

--- a/lib/tools/patching.py
+++ b/lib/tools/patching.py
@@ -230,6 +230,7 @@ if apply_patches:
 		if BASE_GIT_TAG is None:
 			raise Exception("BASE_GIT_REVISION or BASE_GIT_TAG must be set")
 		else:
+			log.debug(f"Getting revision of BASE_GIT_TAG={BASE_GIT_TAG}")
 			BASE_GIT_REVISION = git_repo.tags[BASE_GIT_TAG].commit.hexsha
 			log.debug(f"Found BASE_GIT_REVISION={BASE_GIT_REVISION} for BASE_GIT_TAG={BASE_GIT_TAG}")
 


### PR DESCRIPTION
#### rpardini's bunch of `lib` changes - **mid-April'23**

> Themes:
> - actually working JSON dumps, both for images and artifacts; also fast, via `CONFIG_DEFS_ONLY`
> - actually working rootfs artifacts / remote OCI .debs per-release
> - _moar power_ to extensions, standardize some mechanisms
> - fixes


- cli: `flash`: introduce `flash` CLI command; introduce hook `post_build_image_write`
- config: refactor `calculate_image_version()` out of `create_image_from_sdcard_rootfs()`, make more flexible, predict `IMAGE_FILE_ID` during config
  - default `IMAGE_INSTALLED_KERNEL_VERSION="generic"` instead of `"linux"`
- artifact: rootfs: fix `artifact_rootfs_config_dump()` to include all inputs to aggregation
- logging: better logging when `ANSI_COLOR=none` (eg, during `info` collection)
- config/extensions: consolidate `EXTRA_IMAGE_SUFFIXES` array as _the way_ to add to image filename, during configuration
  - can add to `EXTRA_IMAGE_SUFFIXES` array during `user_config` or `extension_prepare_config`
  - in the end goes into a `EXTRA_IMAGE_SUFFIX` global readonly
  - this  simplifies extension code
  - we still can't "predict" image names during configuration since it includes the kernel version (6.2.11/generic) which only comes later
- artifacts armbian-desktop/armbian-bsp-desktop: fix `artifact_base_dir` to include `${RELEASE}/` -- otherwise local & remote paths don't match
- artifacts-obtain: add sanity check, after getting remotely, make sure it is indeed available locally
- artifacts: introduce `PRE_PREPARED_HOST=yes`: allow running pre-prepared host CLI's for artifacts that require aggregation
- artifacts/cli: introduce CLI command `artifact-config-dump-json` (alias to `artifact`, but sets `CONFIG_DEFS_ONLY=yes`)
  - if `CONFIG_DEFS_ONLY` during `obtain_complete_artifact()`, just dump JSON to stdout after calculating version/coordinates
  - don't prepare ORAS tooling if `CONFIG_DEFS_ONLY`
  - don't run in standard build (and thus don't prepare_host()) if under `CONFIG_DEFS_ONLY`
- if `CONFIG_DEFS_ONLY`, don't run `check_basic_host()`
- extensions/grub: use array for pkg list
  - also for the media-sbc clone
- patching: python: useful debug log with value of `BASE_GIT_TAG`
- extensions: don't `export`, `declare -g`
- bsp-cli/distro-agnostic: introduce `KEEP_ORIGINAL_OS_RELEASE=yes` so Debian/Ubuntu `PRETTY_NAME` is left unchanged in `/etc/os-release`
  - useful when downstream software wants exact Debian OS (eg: Home Assistant Supervised)

