### PR TITLE
Add WiP `Mekotronics` R58 boards (`rockchip-rk3588`)

### DIFF
--- a/config/boards/mekotronics-r58-minipc.wip
+++ b/config/boards/mekotronics-r58-minipc.wip
@@ -1,0 +1,19 @@
+# Rockchip RK3588 SoC octa core 4-16GB SoC 1GBe eMMC USB3 SATA WiFi/BT
+declare -g BOARD_NAME="Mekotronics R58 MiniPC"
+declare -g BOARDFAMILY="rockchip-rk3588"
+declare -g KERNEL_TARGET="legacy"
+declare -g IMAGE_PARTITION_TABLE="gpt"
+declare -g BOOT_FDT_FILE="rockchip/rk3588-blueberry-minipc-linux.dtb" # Specific to this board
+declare -g BOOT_SCENARIO="spl-blobs"                                  # so we don't depend on defconfig naming convention
+declare -g BOOTCONFIG="mekotronics-r58-rk3588_defconfig"              # patched-in in BOOTPATCHDIR, set below.
+
+# post_family_config which only runs when branch is legacy. a shortcut, to avoid if's. you're welcome.
+function post_family_config_branch_legacy__uboot_mekotronics() {
+	display_alert "$BOARD" "Configuring Mekotronics R58 ($BOARD) u-boot" "info"
+	declare -g BOOTSOURCE='https://github.com/radxa/u-boot.git'
+	declare -g BOOTBRANCH='branch:stable-5.10-rock5'
+	declare -g OVERLAY_PREFIX='rockchip-rk3588'
+	declare -g BOOTDIR="u-boot-${BOARD}"                    # do not share u-boot directory
+	declare -g BOOTPATCHDIR="legacy/u-boot-mekotronics-r58" # common for all R58's from Mekotronics.
+	declare -g BOOTDELAY=1                                  # build injects this into u-boot config. we can then get into UMS mode and avoid the whole rockusb/rkdeveloptool thing
+}

--- a/config/boards/mekotronics-r58x-4g.wip
+++ b/config/boards/mekotronics-r58x-4g.wip
@@ -1,0 +1,19 @@
+# Rockchip RK3588 SoC octa core 4-16GB SoC 2x1GBe eMMC USB3 NVMe SATA 4G WiFi/BT HDMI DP HDMI-In RS232 RS485
+declare -g BOARD_NAME="Mekotronics R58X-4G"
+declare -g BOARDFAMILY="rockchip-rk3588"
+declare -g KERNEL_TARGET="legacy"
+declare -g IMAGE_PARTITION_TABLE="gpt"
+declare -g BOOT_FDT_FILE="rockchip/rk3588-blueberry-edge-v12-linux.dtb" # Specific to this board
+declare -g BOOT_SCENARIO="spl-blobs"                                    # so we don't depend on defconfig naming convention
+declare -g BOOTCONFIG="mekotronics-r58-rk3588_defconfig"                # patched-in in BOOTPATCHDIR, set below.
+
+# post_family_config which only runs when branch is legacy. a shortcut, to avoid if's. you're welcome.
+function post_family_config_branch_legacy__uboot_mekotronics() {
+	display_alert "$BOARD" "Configuring Mekotronics R58 ($BOARD) u-boot" "info"
+	declare -g BOOTSOURCE='https://github.com/radxa/u-boot.git'
+	declare -g BOOTBRANCH='branch:stable-5.10-rock5'
+	declare -g OVERLAY_PREFIX='rockchip-rk3588'
+	declare -g BOOTDIR="u-boot-${BOARD}"                    # do not share u-boot directory
+	declare -g BOOTPATCHDIR="legacy/u-boot-mekotronics-r58" # common for all R58's from Mekotronics.
+	declare -g BOOTDELAY=1                                  # build injects this into u-boot config. we can then get into UMS mode and avoid the whole rockusb/rkdeveloptool thing
+}

--- a/config/boards/mekotronics-r58x.wip
+++ b/config/boards/mekotronics-r58x.wip
@@ -1,0 +1,19 @@
+# Rockchip RK3588 SoC octa core 4-16GB SoC 2x1GBe eMMC USB3 NVMe SATA WiFi/BT HDMI DP HDMI-In RS232 RS485
+declare -g BOARD_NAME="Mekotronics R58X-4G"
+declare -g BOARDFAMILY="rockchip-rk3588"
+declare -g KERNEL_TARGET="legacy"
+declare -g IMAGE_PARTITION_TABLE="gpt"
+declare -g BOOT_FDT_FILE="rockchip/rk3588-blueberry-edge-v10-linux.dtb" # Specific to this board
+declare -g BOOT_SCENARIO="spl-blobs"                                    # so we don't depend on defconfig naming convention
+declare -g BOOTCONFIG="mekotronics-r58-rk3588_defconfig"                # patched-in in BOOTPATCHDIR, set below.
+
+# post_family_config which only runs when branch is legacy. a shortcut, to avoid if's. you're welcome.
+function post_family_config_branch_legacy__uboot_mekotronics() {
+	display_alert "$BOARD" "Configuring Mekotronics R58 ($BOARD) u-boot" "info"
+	declare -g BOOTSOURCE='https://github.com/radxa/u-boot.git'
+	declare -g BOOTBRANCH='branch:stable-5.10-rock5'
+	declare -g OVERLAY_PREFIX='rockchip-rk3588'
+	declare -g BOOTDIR="u-boot-${BOARD}"                    # do not share u-boot directory
+	declare -g BOOTPATCHDIR="legacy/u-boot-mekotronics-r58" # common for all R58's from Mekotronics.
+	declare -g BOOTDELAY=1                                  # build injects this into u-boot config. we can then get into UMS mode and avoid the whole rockusb/rkdeveloptool thing
+}

--- a/config/sources/families/rockchip-rk3588.conf
+++ b/config/sources/families/rockchip-rk3588.conf
@@ -12,6 +12,7 @@ BOOTSOURCE='https://github.com/radxa/u-boot.git'
 BOOTBRANCH='branch:stable-5.10-rock5'
 BOOTPATCHDIR="legacy"
 OVERLAY_PREFIX='rockchip-rk3588'
+ROCKUSB_BLOB="rk35/rk3588_spl_loader_v1.08.111.bin"
 
 case $BRANCH in
 

--- a/patch/u-boot/legacy/u-boot-mekotronics-r58/add-board-mekotronics-r58.patch
+++ b/patch/u-boot/legacy/u-boot-mekotronics-r58/add-board-mekotronics-r58.patch
@@ -1,0 +1,438 @@
+Subject: [PATCH] Hijack Rock-5A into mekotronics-r58-rk3588_defconfig; hijack DTS too
+---
+Index: arch/arm/dts/rk3588-mekotronics-r58.dts
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/arch/arm/dts/rk3588-mekotronics-r58.dts b/arch/arm/dts/rk3588-mekotronics-r58.dts
+new file mode 100644
+--- /dev/null	(revision 7ca1a89443112ff2ac11cee1356d6f8fde296897)
++++ b/arch/arm/dts/rk3588-mekotronics-r58.dts	(revision 7ca1a89443112ff2ac11cee1356d6f8fde296897)
+@@ -0,0 +1,193 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2021 Rockchip Electronics Co., Ltd
++ *
++ */
++
++/dts-v1/;
++#include "rk3588.dtsi"
++#include "rk3588-u-boot.dtsi"
++#include <dt-bindings/input/input.h>
++
++/ {
++	model = "Mekotronics R58";
++	compatible = "radxa,rock-5a", "rockchip,rk3588";
++
++	vcc12v_dcin: vcc12v-dcin {
++		u-boot,dm-pre-reloc;
++		compatible = "regulator-fixed";
++		regulator-name = "vcc12v_dcin";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <12000000>;
++		regulator-max-microvolt = <12000000>;
++	};
++
++	vcc5v0_sys: vcc5v0-sys {
++		u-boot,dm-pre-reloc;
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc12v_dcin>;
++	};
++
++	vcc_5v0: vcc-5v0 {
++		u-boot,dm-pre-reloc;
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_5v0";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		regulator-boot-on;
++		regulator-always-on;
++		enable-active-high;
++		gpio = <&gpio4 RK_PA3 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc_5v0_en>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	vcc5v0_host: vcc5v0-host-regulator {
++		u-boot,dm-pre-reloc;
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_host";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		enable-active-high;
++		gpio = <&gpio4 RK_PB5 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc5v0_host_en>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	led_sys: led-sys {
++		u-boot,dm-pre-reloc;
++		compatible = "regulator-fixed";
++		regulator-name = "led_sys";
++		enable-active-high;
++		gpio = <&gpio3 RK_PD5 GPIO_ACTIVE_HIGH>; // Turn on user led
++		regulator-boot-on;
++		regulator-always-on;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	adc-keys {
++		compatible = "adc-keys";
++		io-channels = <&saradc 1>;
++		io-channel-names = "buttons";
++		keyup-threshold-microvolt = <1800000>;
++		u-boot,dm-pre-reloc;
++		status = "okay";
++
++		volumeup-key {
++			u-boot,dm-pre-reloc;
++			linux,code = <KEY_VOLUMEUP>;
++			label = "volume up";
++			press-threshold-microvolt = <1750>;
++		};
++	};
++};
++
++&usb_host0_ehci {
++	status = "okay";
++	u-boot,dm-pre-reloc;
++};
++
++&usb_host0_ohci {
++	status = "okay";
++	u-boot,dm-pre-reloc;
++};
++
++&usb2phy2_grf {
++	status = "okay";
++	u-boot,dm-pre-reloc;
++};
++
++&u2phy2 {
++	status = "okay";
++	u-boot,dm-pre-reloc;
++};
++
++&u2phy2_host {
++	status = "okay";
++	u-boot,dm-pre-reloc;
++};
++
++&usb_host1_ehci {
++	status = "okay";
++	u-boot,dm-pre-reloc;
++};
++
++&usb_host1_ohci {
++	status = "okay";
++	u-boot,dm-pre-reloc;
++};
++
++&usb2phy3_grf {
++	status = "okay";
++	u-boot,dm-pre-reloc;
++};
++
++&u2phy3 {
++	status = "okay";
++	u-boot,dm-pre-reloc;
++};
++
++&u2phy3_host {
++	status = "okay";
++	u-boot,dm-pre-reloc;
++};
++
++&sfc {
++	status = "disabled";
++	pinctrl-names = "default";
++	pinctrl-0 = <&fspim0_pins>;
++};
++
++&spi_nor {
++	status = "disabled";
++};
++
++&pinctrl {
++
++	/delete-node/ fspi;
++	fspi {
++		u-boot,dm-spl;
++		fspim0_pins: fspim0-pins {
++			u-boot,dm-spl;
++			rockchip,pins =
++				/* fspi_clk_m0 */
++				<2 RK_PA0 2 &pcfg_pull_none>,
++				/* fspi_cs0n_m0 */
++				<2 RK_PD6 2 &pcfg_pull_none>,
++				/* fspi_d0_m0 */
++				<2 RK_PD0 2 &pcfg_pull_none>,
++				/* fspi_d1_m0 */
++				<2 RK_PD1 2 &pcfg_pull_none>,
++				/* fspi_d2_m0 */
++				<2 RK_PD2 2 &pcfg_pull_none>,
++				/* fspi_d3_m0 */
++				<2 RK_PD3 2 &pcfg_pull_none>;
++		};
++	};
++
++	usb {
++		u-boot,dm-pre-reloc;
++		vcc5v0_host_en: vcc5v0-host-en {
++			u-boot,dm-pre-reloc;
++			rockchip,pins = <4 RK_PB5 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	power {
++		u-boot,dm-spl;
++		vcc_5v0_en: vcc-5v0-en {
++			u-boot,dm-spl;
++			rockchip,pins = <4 RK_PA3 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++};
+Index: configs/mekotronics-r58-rk3588_defconfig
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/configs/mekotronics-r58-rk3588_defconfig b/configs/mekotronics-r58-rk3588_defconfig
+new file mode 100644
+--- /dev/null	(revision 7ca1a89443112ff2ac11cee1356d6f8fde296897)
++++ b/configs/mekotronics-r58-rk3588_defconfig	(revision 7ca1a89443112ff2ac11cee1356d6f8fde296897)
+@@ -0,0 +1,223 @@
++CONFIG_ARM=y
++CONFIG_ARM_CPU_SUSPEND=y
++CONFIG_ARCH_ROCKCHIP=y
++CONFIG_SPL_GPIO_SUPPORT=y
++CONFIG_SPL_LIBCOMMON_SUPPORT=y
++CONFIG_SPL_LIBGENERIC_SUPPORT=y
++CONFIG_SYS_MALLOC_F_LEN=0x80000
++CONFIG_SPL_FIT_GENERATOR="arch/arm/mach-rockchip/make_fit_atf.sh"
++CONFIG_ROCKCHIP_RK3588=y
++CONFIG_ROCKCHIP_USB_BOOT=y
++CONFIG_ROCKCHIP_FIT_IMAGE=y
++CONFIG_ROCKCHIP_HWID_DTB=y
++CONFIG_ROCKCHIP_VENDOR_PARTITION=y
++CONFIG_USING_KERNEL_DTB_V2=y
++CONFIG_ROCKCHIP_FIT_IMAGE_PACK=y
++CONFIG_ROCKCHIP_NEW_IDB=y
++CONFIG_LOADER_INI="RK3588MINIALL.ini"
++CONFIG_TRUST_INI="RK3588TRUST.ini"
++CONFIG_SPL_SERIAL_SUPPORT=y
++CONFIG_SPL_DRIVERS_MISC_SUPPORT=y
++CONFIG_TARGET_EVB_RK3588=y
++CONFIG_SPL_LIBDISK_SUPPORT=y
++CONFIG_SPL_SPI_FLASH_SUPPORT=y
++CONFIG_SPL_SPI_SUPPORT=y
++CONFIG_DEFAULT_DEVICE_TREE="rk3588-mekotronics-r58"
++CONFIG_DEBUG_UART=y
++CONFIG_LOCALVERSION="-armbian"
++# CONFIG_LOCALVERSION_AUTO is not set
++CONFIG_FIT=y
++CONFIG_FIT_IMAGE_POST_PROCESS=y
++CONFIG_FIT_HW_CRYPTO=y
++CONFIG_SPL_LOAD_FIT=y
++CONFIG_SPL_FIT_IMAGE_POST_PROCESS=y
++CONFIG_SPL_FIT_HW_CRYPTO=y
++# CONFIG_SPL_SYS_DCACHE_OFF is not set
++CONFIG_BOOTDELAY=1
++CONFIG_SYS_CONSOLE_INFO_QUIET=y
++# CONFIG_DISPLAY_CPUINFO is not set
++CONFIG_ANDROID_BOOTLOADER=y
++CONFIG_ANDROID_AVB=y
++CONFIG_ANDROID_BOOT_IMAGE_HASH=y
++CONFIG_SPL_BOARD_INIT=y
++# CONFIG_SPL_RAW_IMAGE_SUPPORT is not set
++# CONFIG_SPL_LEGACY_IMAGE_SUPPORT is not set
++CONFIG_SPL_SEPARATE_BSS=y
++CONFIG_SYS_MMCSD_RAW_MODE_U_BOOT_USE_PARTITION=y
++CONFIG_SYS_MMCSD_RAW_MODE_U_BOOT_PARTITION=0x1
++CONFIG_SPL_MMC_WRITE=y
++CONFIG_SPL_MTD_SUPPORT=y
++CONFIG_SPL_ATF=y
++CONFIG_AUTOBOOT_KEYED=y
++CONFIG_AUTOBOOT_PROMPT="Mekotronics: Autoboot in %d seconds - press SHIFT-M...\n"
++CONFIG_AUTOBOOT_STOP_STR="M"
++CONFIG_AUTOBOOT_KEYED_CTRLC=y
++CONFIG_FASTBOOT_BUF_ADDR=0xc00800
++CONFIG_FASTBOOT_BUF_SIZE=0x04000000
++CONFIG_FASTBOOT_FLASH=y
++CONFIG_FASTBOOT_FLASH_MMC_DEV=0
++CONFIG_CMD_BOOTZ=y
++CONFIG_CMD_DTIMG=y
++# CONFIG_CMD_ELF is not set
++# CONFIG_CMD_IMI is not set
++# CONFIG_CMD_IMLS is not set
++# CONFIG_CMD_XIMG is not set
++# CONFIG_CMD_LZMADEC is not set
++# CONFIG_CMD_UNZIP is not set
++# CONFIG_CMD_FLASH is not set
++# CONFIG_CMD_FPGA is not set
++CONFIG_CMD_GPT=y
++# CONFIG_CMD_LOADB is not set
++# CONFIG_CMD_LOADS is not set
++CONFIG_CMD_BOOT_ANDROID=y
++CONFIG_CMD_MMC=y
++CONFIG_CMD_PCI=y
++CONFIG_CMD_SF=y
++CONFIG_CMD_SPI=y
++CONFIG_CMD_USB=y
++CONFIG_CMD_USB_MASS_STORAGE=y
++# CONFIG_CMD_ITEST is not set
++# CONFIG_CMD_SETEXPR is not set
++CONFIG_CMD_TFTPPUT=y
++CONFIG_CMD_TFTP_BOOTM=y
++CONFIG_CMD_TFTP_FLASH=y
++# CONFIG_CMD_MISC is not set
++CONFIG_CMD_MTD_BLK=y
++# CONFIG_SPL_DOS_PARTITION is not set
++# CONFIG_ISO_PARTITION is not set
++CONFIG_EFI_PARTITION_ENTRIES_NUMBERS=64
++CONFIG_SPL_OF_CONTROL=y
++CONFIG_SPL_DTB_MINIMUM=y
++CONFIG_OF_LIVE=y
++CONFIG_OF_SPL_REMOVE_PROPS="clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
++# CONFIG_NET_TFTP_VARS is not set
++CONFIG_REGMAP=y
++CONFIG_SPL_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_SPL_SYSCON=y
++# CONFIG_SARADC_ROCKCHIP is not set
++CONFIG_SARADC_ROCKCHIP_V2=y
++CONFIG_CLK=y
++CONFIG_SPL_CLK=y
++CONFIG_CLK_SCMI=y
++CONFIG_SPL_CLK_SCMI=y
++CONFIG_DM_CRYPTO=y
++CONFIG_SPL_DM_CRYPTO=y
++CONFIG_ROCKCHIP_CRYPTO_V2=y
++CONFIG_SPL_ROCKCHIP_CRYPTO_V2=y
++CONFIG_DM_RNG=y
++CONFIG_RNG_ROCKCHIP=y
++CONFIG_SCMI_FIRMWARE=y
++CONFIG_SPL_SCMI_FIRMWARE=y
++CONFIG_ROCKCHIP_GPIO=y
++CONFIG_ROCKCHIP_GPIO_V2=y
++CONFIG_SYS_I2C_ROCKCHIP=y
++CONFIG_DM_KEY=y
++CONFIG_ADC_KEY=y
++CONFIG_MISC=y
++CONFIG_SPL_MISC=y
++CONFIG_MISC_DECOMPRESS=y
++CONFIG_SPL_MISC_DECOMPRESS=y
++CONFIG_ROCKCHIP_OTP=y
++CONFIG_ROCKCHIP_HW_DECOMPRESS=y
++CONFIG_SPL_ROCKCHIP_HW_DECOMPRESS=y
++CONFIG_SPL_ROCKCHIP_SECURE_OTP=y
++CONFIG_MMC_DW=y
++CONFIG_MMC_DW_ROCKCHIP=y
++CONFIG_MMC_SDHCI=y
++CONFIG_MMC_SDHCI_SDMA=y
++CONFIG_MMC_SDHCI_ROCKCHIP=y
++CONFIG_MTD=y
++CONFIG_MTD_BLK=y
++CONFIG_MTD_DEVICE=y
++CONFIG_NAND=y
++CONFIG_MTD_SPI_NAND=y
++CONFIG_SPI_FLASH=y
++CONFIG_SF_DEFAULT_SPEED=80000000
++CONFIG_SPI_FLASH_EON=y
++CONFIG_SPI_FLASH_GIGADEVICE=y
++CONFIG_SPI_FLASH_MACRONIX=y
++CONFIG_SPI_FLASH_SST=y
++CONFIG_SPI_FLASH_WINBOND=y
++CONFIG_SPI_FLASH_XMC=y
++CONFIG_SPI_FLASH_XTX=y
++CONFIG_SPI_FLASH_MTD=y
++CONFIG_DM_ETH=y
++CONFIG_DM_ETH_PHY=y
++CONFIG_DWC_ETH_QOS=y
++CONFIG_GMAC_ROCKCHIP=y
++CONFIG_NVME=y
++CONFIG_PCI=y
++CONFIG_DM_PCI=y
++CONFIG_DM_PCI_COMPAT=y
++CONFIG_PCIE_DW_ROCKCHIP=y
++CONFIG_PHY_ROCKCHIP_INNO_USB2=y
++CONFIG_PHY_ROCKCHIP_SAMSUNG_HDPTX=y
++CONFIG_PHY_ROCKCHIP_SNPS_PCIE3=y
++CONFIG_PINCTRL=y
++CONFIG_SPL_PINCTRL=y
++CONFIG_DM_PMIC=y
++CONFIG_PMIC_SPI_RK8XX=y
++CONFIG_REGULATOR_PWM=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_DM_REGULATOR_GPIO=y
++CONFIG_REGULATOR_RK860X=y
++CONFIG_REGULATOR_RK806=y
++CONFIG_PWM_ROCKCHIP=y
++CONFIG_RAM=y
++CONFIG_SPL_RAM=y
++CONFIG_TPL_RAM=y
++CONFIG_ROCKCHIP_SDRAM_COMMON=y
++CONFIG_ROCKCHIP_TPL_INIT_DRAM_TYPE=0
++CONFIG_DM_RESET=y
++CONFIG_SPL_DM_RESET=y
++CONFIG_SPL_RESET_ROCKCHIP=y
++CONFIG_BAUDRATE=1500000
++CONFIG_DEBUG_UART_BASE=0xFEB50000
++CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_DEBUG_UART_SHIFT=2
++CONFIG_ROCKCHIP_SPI=y
++CONFIG_ROCKCHIP_SFC=y
++CONFIG_SYSRESET=y
++CONFIG_USB=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_XHCI_DWC3=y
++CONFIG_USB_XHCI_PCI=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_EHCI_GENERIC=y
++CONFIG_USB_OHCI_HCD=y
++CONFIG_USB_OHCI_GENERIC=y
++CONFIG_USB_DWC3=y
++CONFIG_USB_DWC3_GADGET=y
++CONFIG_USB_DWC3_GENERIC=y
++CONFIG_USB_STORAGE=y
++CONFIG_USB_GADGET=y
++CONFIG_USB_GADGET_MANUFACTURER="Rockchip"
++CONFIG_USB_GADGET_VENDOR_NUM=0x2207
++CONFIG_USB_GADGET_PRODUCT_NUM=0x350a
++CONFIG_USB_GADGET_DOWNLOAD=y
++CONFIG_DM_VIDEO=y
++CONFIG_DISPLAY=y
++CONFIG_DRM_ROCKCHIP=y
++CONFIG_DRM_ROCKCHIP_DW_MIPI_DSI2=y
++CONFIG_DRM_ROCKCHIP_ANALOGIX_DP=y
++CONFIG_DRM_ROCKCHIP_SAMSUNG_MIPI_DCPHY=y
++CONFIG_USE_TINY_PRINTF=y
++CONFIG_LIB_RAND=y
++CONFIG_SPL_TINY_MEMSET=y
++CONFIG_RSA=y
++CONFIG_SPL_RSA=y
++CONFIG_RSA_N_SIZE=0x200
++CONFIG_RSA_E_SIZE=0x10
++CONFIG_RSA_C_SIZE=0x20
++CONFIG_LZ4=y
++CONFIG_ERRNO_STR=y
++# CONFIG_EFI_LOADER is not set
++CONFIG_AVB_LIBAVB=y
++CONFIG_AVB_LIBAVB_AB=y
++CONFIG_AVB_LIBAVB_ATX=y
++CONFIG_AVB_LIBAVB_USER=y
++CONFIG_RK_AVB_LIBAVB_USER=y
++CONFIG_OPTEE_CLIENT=y
++CONFIG_OPTEE_V2=y
++CONFIG_OPTEE_ALWAYS_USE_SECURITY_PARTITION=y

--- a/patch/u-boot/legacy/u-boot-mekotronics-r58/fix_source_so_boot_scr_works.patch
+++ b/patch/u-boot/legacy/u-boot-mekotronics-r58/fix_source_so_boot_scr_works.patch
@@ -1,0 +1,24 @@
+From ea50d7f6921e2c3017258ce8fdfad632d82fbd87 Mon Sep 17 00:00:00 2001
+From: Stephen <stephen@vamrs.com>
+Date: Mon, 8 Nov 2021 14:30:00 +0800
+Subject: [PATCH] cmd: source: fix the error that the command source failed to
+ execute
+
+Signed-off-by: Stephen <stephen@vamrs.com>
+---
+ cmd/source.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cmd/source.c b/cmd/source.c
+index 45e9794b2f3..d724d63eb7c 100644
+--- a/cmd/source.c
++++ b/cmd/source.c
+@@ -84,7 +84,7 @@ source (ulong addr, const char *fit_uname)
+ 		 * past the zero-terminated sequence of image lengths to get
+ 		 * to the actual image data
+ 		 */
+-		while (*data++ != IMAGE_PARAM_INVAL);
++		while (*data++);
+ 		break;
+ #endif
+ #if defined(CONFIG_FIT)


### PR DESCRIPTION
#### Add **WiP** `Mekotronics` R58 boards (`rockchip-rk3588`)

[mekotronics.com](https://www.mekotronics.com/)

- `rockchip-rk3588`: add new board `mekotronics-r58-minipc.wip` (Mekotronics R58 MiniPC, and variants)
- `rockchip-rk3588`: add new board `mekotronics-r58x.wip` (Mekotronics R58X)
- `rockchip-rk3588`: add new board `mekotronics-r58x-4g.wip` (Mekotronics R58X-4G); add u-boot patches
- `rockchip-rk3588`: set `ROCKUSB_BLOB` for RockUSB Maskrom -> Loader mode

u-boot: same as Radxa Rock-5A. RockUSB and UMS works; boot from eMMC only. No USB, no NVMe. Can stop u-boot by holding Shift-M during boot on serial console.

Kernel: was handled at https://github.com/armbian/linux-rockchip/pull/12 and https://github.com/armbian/linux-rockchip/pull/14 is pending.

Thanks @amazingfate for the kernel reviews and @monkaBlyat for the DTS's, and @NicoD-SBC for the R58X-4G unit.

![the thing](https://user-images.githubusercontent.com/639959/232171292-82f58db2-b1ee-46e4-b3ea-8a16dd6750aa.png)
![where the hell is the serial debug uart](https://user-images.githubusercontent.com/639959/232171323-b76ba45d-398e-4040-9dae-31f864418ccf.png)


