### PR TITLE
kernel: fix for 6.3+ linux-headers pkg due to upstream dir change

### DIFF
--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -372,6 +372,15 @@ function kernel_package_callback_linux_headers() {
 
 	# ${temp_file_list} is left at WORKDIR for later debugging, will be removed by WORKDIR cleanup trap
 
+	# Small detour: in v6.3-rc1, in commit https://github.com/torvalds/linux/commit/799fb82aa132fa3a3886b7872997a5a84e820062,
+	#               the tools/vm dir was renamed to tools/mm. Unfortunately tools/Makefile still expects it to exist,
+	#               and "make clean" in the "/tools" dir fails. Drop in a fake Makefile there to work around this.
+	if [[ ! -f "${headers_target_dir}/tools/vm/Makefile" ]]; then
+		display_alert "Creating fake tools/vm/Makefile" "6.3+ hackfix" "warn"
+		mkdir -p "${headers_target_dir}/tools/vm"
+		echo -e "clean:\n\techo fake clean for tools/vm" > "${headers_target_dir}/tools/vm/Makefile"
+	fi
+
 	# Now, make the script dirs clean.
 	# This is run in our _target_ dir, NOT the source tree, so we're free to make clean as we wish without invalidating the next build's cache.
 	# Understand: I'm sending the logs of this to the bitbucket ON PURPOSE: "clean" tries to use clang, ALSA, etc, which are not available.

--- a/lib/functions/compilation/kernel-make.sh
+++ b/lib/functions/compilation/kernel-make.sh
@@ -53,8 +53,8 @@ function run_kernel_make_internal() {
 		"KGZIP=pigz" "KBZIP2=pbzip2" # Parallel compression, use explicit parallel compressors https://lore.kernel.org/lkml/20200901151002.988547791@linuxfoundation.org/ # @TODO: what about XZ?
 	)
 
-	# last statement, so it passes the result to calling function. "env -i" is used for empty env
-	full_command=("${KERNEL_MAKE_RUNNER:-run_host_command_logged}" "env" "-i" "${common_make_envs[@]}"
+	# last statement, so it passes the result to calling function. "env -i" is used for empty env. "pipetty" helps to get color logs.
+	full_command=("${KERNEL_MAKE_RUNNER:-run_host_command_logged}" "pipetty" "env" "-i" "${common_make_envs[@]}"
 		make "${common_make_params_quoted[@]@Q}" "$@" "${make_filter}")
 	"${full_command[@]}" # and exit with it's code, since it's the last statement
 }


### PR DESCRIPTION
#### kernel: fix for 6.3+ linux-headers pkg due to upstream dir change
- extra: run kernel make through `pipetty` for _moar colors_

>	 Small detour: in v6.3-rc1, in commit https://github.com/torvalds/linux/commit/799fb82aa132fa3a3886b7872997a5a84e820062,
>	               the `tools/vm` dir was renamed to `tools/mm`. Unfortunately `tools/Makefile` still expects it to exist,
>	               and `make clean` in the `tools` dir fails. Drop in a fake Makefile there to work around this.

Should fix #4991 
