### PR TITLE
add ghproxy to GITHUB_MIRROR

### DIFF
--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -198,6 +198,9 @@ function do_main_configuration() {
 		fastgit)
 			GITHUB_SOURCE='https://hub.fastgit.xyz'
 			;;
+		ghproxy)
+			GITHUB_SOURCE='https://ghproxy.com/https://github.com'
+			;;
 		gitclone)
 			GITHUB_SOURCE='https://gitclone.com/github.com'
 			;;

--- a/lib/functions/general/git-ref2info.sh
+++ b/lib/functions/general/git-ref2info.sh
@@ -29,7 +29,21 @@ function memoized_git_ref_to_info() {
 			sha1="${ref_name}"
 			;;
 		*)
-			sha1="$(git ls-remote --exit-code "${MEMO_DICT[GIT_SOURCE]}" "${ref_name}" | cut -f1)"
+			case "${GITHUB_MIRROR}" in
+				"ghproxy")
+					case "${MEMO_DICT[GIT_SOURCE]}" in
+						"https://github.com/"*)
+							sha1="$(git ls-remote --exit-code "https://ghproxy.com/${MEMO_DICT[GIT_SOURCE]}" "${ref_name}" | cut -f1)"
+							;;
+						*)
+							sha1="$(git ls-remote --exit-code "${MEMO_DICT[GIT_SOURCE]}" "${ref_name}" | cut -f1)"
+							;;
+					esac
+					;;
+				*)
+					sha1="$(git ls-remote --exit-code "${MEMO_DICT[GIT_SOURCE]}" "${ref_name}" | cut -f1)"
+					;;
+			esac
 			;;
 	esac
 
@@ -67,7 +81,14 @@ function memoized_git_ref_to_info() {
 					declare org_and_repo=""
 					org_and_repo="$(echo "${git_source}" | cut -d/ -f4-5)"
 					org_and_repo="${org_and_repo%.git}" # remove .git if present
-					url="https://raw.githubusercontent.com/${org_and_repo}/${sha1}/Makefile"
+					case "${GITHUB_MIRROR}" in
+						"ghproxy")
+							url="https://ghproxy.com/https://raw.githubusercontent.com/${org_and_repo}/${sha1}/Makefile"
+							;;
+						*)
+							url="https://raw.githubusercontent.com/${org_and_repo}/${sha1}/Makefile"
+							;;
+					esac
 					;;
 
 				"https://gitlab.com/"*)


### PR DESCRIPTION
# Description

[ghproxy](https://ghproxy.com/) is a github mirror making use of cloudflare cdn, which is ultra fast in China.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Build kernel with `./compile.sh kernel COMPRESS_OUTPUTIMAGE=sha,gpg,xz DEB_COMPRESS=xz DOWNLOAD_MIRROR=china BOARD=rock-5b BRANCH=legacy GITHUB_MIRROR=ghproxy`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
