### PR TITLE
remove apt cache in the rootfs

### DIFF
--- a/lib/functions/rootfs/apt-install.sh
+++ b/lib/functions/rootfs/apt-install.sh
@@ -11,6 +11,9 @@ function apt_purge_unneeded_packages() {
 	# remove packages that are no longer needed. rootfs cache + uninstall might have leftovers.
 	display_alert "No longer needed packages" "purge" "info"
 	chroot_sdcard_apt_get autoremove
+	# clean apt cache
+	display_alert "No longer needed apt cache" "purge" "info"
+	chroot_sdcard_apt_get clean
 }
 
 # this is called:


### PR DESCRIPTION
# Description

Apt cache is only useful in build time. Users usually don't need cache for installed packages. Removing them will save space and make images smaller.

Jira: [AR-1569]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Build with command `./compile.sh COMPRESS_OUTPUTIMAGE=sha,gpg,xz DEB_COMPRESS=xz DOWNLOAD_MIRROR=china BOARD=rock-5b BRANCH=legacy GITHUB_MIRROR=ghproxy RELEASE=jammy BUILD_MINIMAL=no BUILD_DESKTOP=yes KERNEL_CONFIGURE=no DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base DESKTOP_APPGROUPS_SELECTED="3dsupport browsers chat desktop_tools editors email internet multimedia office programming remote_desktop"`, saving about 300MB space.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1569]: https://armbian.atlassian.net/browse/AR-1569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ