### PR TITLE
Remove pixz in favor of native xz

### DIFF
--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -277,12 +277,12 @@ function adaptative_prepare_host_dependencies() {
 		zlib1g-dev
 
 		# by-category below
-		file tree expect                     # logging utilities; expect is needed for 'unbuffer' command
-		colorized-logs                       # for ansi2html, ansi2txt, pipetty
-		unzip zip pigz pixz pbzip2 lzop zstd # compressors et al
-		parted gdisk fdisk                   # partition tools @TODO why so many?
-		aria2 curl wget axel                 # downloaders et al
-		parallel                             # do things in parallel (used for fast md5 hashing in initrd cache)
+		file tree expect                           # logging utilities; expect is needed for 'unbuffer' command
+		colorized-logs                             # for ansi2html, ansi2txt, pipetty
+		unzip zip pigz xz-utils pbzip2 lzop zstd   # compressors et al
+		parted gdisk fdisk                         # partition tools @TODO why so many?
+		aria2 curl wget axel                       # downloaders et al
+		parallel                                   # do things in parallel (used for fast md5 hashing in initrd cache)
 	)
 
 	# @TODO: distcc -- handle in extension?

--- a/lib/functions/image/compress-checksum.sh
+++ b/lib/functions/image/compress-checksum.sh
@@ -37,8 +37,8 @@ function output_images_compress_and_checksum() {
 		uncompressed_file_basename=$(basename "${uncompressed_file}")
 
 		if [[ $COMPRESS_OUTPUTIMAGE == *xz* ]]; then
-			display_alert "Compressing with pixz" "${uncompressed_file_basename}.xz" "info"
-			pixz -1 "${uncompressed_file}" # "If pixz is provided with input but no output, it will delete the input"
+			display_alert "Compressing with xz" "${uncompressed_file_basename}.xz" "info"
+			xz -T 0 -1 "${uncompressed_file}" # "If xz is provided with input but no output, it will delete the input"
 			compression_type=".xz"
 		fi
 


### PR DESCRIPTION
# Description
`pixz` was invented when `xz` did not support multi-threading natively. Now it is pretty much obsolete.

Jira reference number [AR-9999]

# How Has This Been Tested?

Hasn't. Feel free to do testings.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
