### PR TITLE
small batch of `lib` fixes (mid+/April'23)

### DIFF
--- a/lib/functions/artifacts/artifact-armbian-config.sh
+++ b/lib/functions/artifacts/artifact-armbian-config.sh
@@ -27,6 +27,9 @@ function artifact_armbian-config_prepare_version() {
 	run_memoized GIT_INFO_ARMBIAN_CONFIG "git2info" memoized_git_ref_to_info
 	debug_dict GIT_INFO_ARMBIAN_CONFIG
 
+	# Sanity check, the SHA1 gotta be sane.
+	[[ "${GIT_INFO_ARMBIAN_CONFIG[SHA1]}" =~ ^[0-9a-f]{40}$ ]] || exit_with_error "SHA1 is not sane: '${GIT_INFO_ARMBIAN_CONFIG[SHA1]}'"
+
 	declare fake_unchanging_base_version="1"
 
 	declare short_sha1="${GIT_INFO_ARMBIAN_CONFIG[SHA1]:0:${short_hash_size}}"

--- a/lib/functions/artifacts/artifact-armbian-zsh.sh
+++ b/lib/functions/artifacts/artifact-armbian-zsh.sh
@@ -28,6 +28,9 @@ function artifact_armbian-zsh_prepare_version() {
 	run_memoized GIT_INFO_ARMBIAN_ZSH "git2info" memoized_git_ref_to_info
 	debug_dict GIT_INFO_ARMBIAN_ZSH
 
+	# Sanity check, the SHA1 gotta be sane.
+	[[ "${GIT_INFO_ARMBIAN_ZSH[SHA1]}" =~ ^[0-9a-f]{40}$ ]] || exit_with_error "SHA1 is not sane: '${GIT_INFO_ARMBIAN_ZSH[SHA1]}'"
+
 	declare fake_unchanging_base_version="1"
 
 	declare short_sha1="${GIT_INFO_ARMBIAN_ZSH[SHA1]:0:${short_hash_size}}"

--- a/lib/functions/artifacts/artifact-firmware.sh
+++ b/lib/functions/artifacts/artifact-firmware.sh
@@ -28,6 +28,9 @@ function artifact_firmware_prepare_version() {
 	run_memoized GIT_INFO_ARMBIAN_FIRMWARE "git2info" memoized_git_ref_to_info
 	debug_dict GIT_INFO_ARMBIAN_FIRMWARE
 
+	# Sanity check, the SHA1 gotta be sane.
+	[[ "${GIT_INFO_ARMBIAN_FIRMWARE[SHA1]}" =~ ^[0-9a-f]{40}$ ]] || exit_with_error "SHA1 is not sane: '${GIT_INFO_ARMBIAN_FIRMWARE[SHA1]}'"
+
 	declare fake_unchanging_base_version="1"
 
 	declare short_sha1="${GIT_INFO_ARMBIAN_FIRMWARE[SHA1]:0:${short_hash_size}}"

--- a/lib/functions/artifacts/artifact-full_firmware.sh
+++ b/lib/functions/artifacts/artifact-full_firmware.sh
@@ -30,9 +30,15 @@ function artifact_full_firmware_prepare_version() {
 	run_memoized GIT_INFO_ARMBIAN_FIRMWARE "git2info" memoized_git_ref_to_info
 	debug_dict GIT_INFO_ARMBIAN_FIRMWARE
 
+	# Sanity check, the SHA1 gotta be sane.
+	[[ "${GIT_INFO_ARMBIAN_FIRMWARE[SHA1]}" =~ ^[0-9a-f]{40}$ ]] || exit_with_error "SHA1 is not sane: '${GIT_INFO_ARMBIAN_FIRMWARE[SHA1]}'"
+
 	declare -A GIT_INFO_MAINLINE_FIRMWARE=([GIT_SOURCE]="${MAINLINE_FIRMWARE_SOURCE}" [GIT_REF]="branch:main")
 	run_memoized GIT_INFO_MAINLINE_FIRMWARE "git2info" memoized_git_ref_to_info
 	debug_dict GIT_INFO_MAINLINE_FIRMWARE
+
+	# Sanity check, the SHA1 gotta be sane.
+	[[ "${GIT_INFO_MAINLINE_FIRMWARE[SHA1]}" =~ ^[0-9a-f]{40}$ ]] || exit_with_error "SHA1 is not sane: '${GIT_INFO_MAINLINE_FIRMWARE[SHA1]}'"
 
 	declare fake_unchanging_base_version="1"
 

--- a/lib/functions/artifacts/artifact-kernel.sh
+++ b/lib/functions/artifacts/artifact-kernel.sh
@@ -81,6 +81,9 @@ function artifact_kernel_prepare_version() {
 	fi
 	debug_dict GIT_INFO_KERNEL
 
+	# Sanity check, the SHA1 gotta be sane.
+	[[ "${GIT_INFO_KERNEL[SHA1]}" =~ ^[0-9a-f]{40}$ ]] || exit_with_error "SHA1 is not sane: '${GIT_INFO_KERNEL[SHA1]}'"
+
 	declare short_sha1="${GIT_INFO_KERNEL[SHA1]:0:${short_hash_size}}"
 
 	# get the drivers hash...

--- a/lib/functions/artifacts/artifact-rootfs.sh
+++ b/lib/functions/artifacts/artifact-rootfs.sh
@@ -17,7 +17,7 @@ function artifact_rootfs_config_dump() {
 	artifact_input_variables[DESKTOP_APPGROUPS_SELECTED]="${DESKTOP_APPGROUPS_SELECTED:-"no_DESKTOP_APPGROUPS_SELECTED_set"}"
 	# Hash of the packages added/removed by extensions
 	declare pkgs_hash="undetermined"
-	pkgs_hash="$(echo "${REMOVE_PACKAGES[*]} ${REMOVE_PACKAGES_REFS[*]}" | sha256sum | cut -d' ' -f1)"
+	pkgs_hash="$(echo "${REMOVE_PACKAGES[*]} ${EXTRA_PACKAGES_ROOTFS[*]}" | sha256sum | cut -d' ' -f1)"
 	artifact_input_variables[EXTRA_PKG_ADD_REMOVE_HASH]="${pkgs_hash}"
 }
 

--- a/lib/functions/artifacts/artifact-uboot.sh
+++ b/lib/functions/artifacts/artifact-uboot.sh
@@ -44,6 +44,9 @@ function artifact_uboot_prepare_version() {
 	run_memoized GIT_INFO_UBOOT "git2info" memoized_git_ref_to_info "include_makefile_body"
 	debug_dict GIT_INFO_UBOOT
 
+	# Sanity check, the SHA1 gotta be sane.
+	[[ "${GIT_INFO_UBOOT[SHA1]}" =~ ^[0-9a-f]{40}$ ]] || exit_with_error "SHA1 is not sane: '${GIT_INFO_UBOOT[SHA1]}'"
+
 	declare short_sha1="${GIT_INFO_UBOOT[SHA1]:0:${short_hash_size}}"
 
 	# get the uboot patches hash...

--- a/lib/functions/cli/commands.sh
+++ b/lib/functions/cli/commands.sh
@@ -30,7 +30,7 @@ function armbian_register_commands() {
 
 		["build"]="standard_build" # implemented in cli_standard_build_pre_run and cli_standard_build_run
 		["distccd"]="distccd"      # implemented in cli_distccd_pre_run and cli_distccd_run
-		["flash"]="flash"      # implemented in cli_flash_pre_run and cli_flash_run
+		["flash"]="flash"          # implemented in cli_flash_pre_run and cli_flash_run
 
 		# external tooling, made easy.
 		["oras-upload"]="oras" # implemented in cli_oras_pre_run and cli_oras_run; up/down/info are the same, see vars below

--- a/lib/functions/compilation/kernel-make.sh
+++ b/lib/functions/compilation/kernel-make.sh
@@ -53,8 +53,8 @@ function run_kernel_make_internal() {
 		"KGZIP=pigz" "KBZIP2=pbzip2" # Parallel compression, use explicit parallel compressors https://lore.kernel.org/lkml/20200901151002.988547791@linuxfoundation.org/ # @TODO: what about XZ?
 	)
 
-	# last statement, so it passes the result to calling function. "env -i" is used for empty env. "pipetty" helps to get color logs.
-	full_command=("${KERNEL_MAKE_RUNNER:-run_host_command_logged}" "pipetty" "env" "-i" "${common_make_envs[@]}"
+	# last statement, so it passes the result to calling function. "env -i" is used for empty env
+	full_command=("${KERNEL_MAKE_RUNNER:-run_host_command_logged}" "env" "-i" "${common_make_envs[@]}"
 		make "${common_make_params_quoted[@]@Q}" "$@" "${make_filter}")
 	"${full_command[@]}" # and exit with it's code, since it's the last statement
 }

--- a/lib/library-functions.sh
+++ b/lib/library-functions.sh
@@ -1153,7 +1153,6 @@ set -o errexit  ## set -e : exit the script if any statement returns a non-true 
 # shellcheck source=lib/functions/rootfs/trap-rootfs.sh
 source "${SRC}"/lib/functions/rootfs/trap-rootfs.sh
 
-
 # no errors tolerated. one last time for the win!
 #set -o pipefail  # trace ERR through pipes - will be enabled "soon"
 #set -o nounset   ## set -u : exit the script if you try to use an uninitialised variable - one day will be enabled

--- a/lib/tools/gen-library.sh
+++ b/lib/tools/gen-library.sh
@@ -42,7 +42,6 @@ find lib/functions -type f -name \*.sh | sort -h | while read -r path; do
 done
 
 cat <<- AUTOGEN_INCLUDES_FOOTER >> "${TARGET_SH}"
-
 	# no errors tolerated. one last time for the win!
 	#set -o pipefail  # trace ERR through pipes - will be enabled "soon"
 	#set -o nounset   ## set -u : exit the script if you try to use an uninitialised variable - one day will be enabled


### PR DESCRIPTION
#### small batch of `lib` fixes (mid+/April'23)

> Fixing the last batch. Some stupid mistakes.

- revert: run kernel make through `pipetty` for _moar colors_ (breaks `make menuconfig`) - thanks @EvilOlaf 
- artifacts: add git SHA1 sanity checking
- memoize-cached: add `flock` locking to `run_memoized()` to avoid error when run in parallel
- lib: shellfmt & fix gen-library to match
- artifact: rootfs: fix `artifact_rootfs_config_dump()` with added rootfs pkgs (should work now, I promise)

