### PR TITLE
Rebuild board selection for generating official images

### DIFF
--- a/.github/workflows/build-board-list.yml
+++ b/.github/workflows/build-board-list.yml
@@ -1,0 +1,19 @@
+name: Rebuild board list in GHA menu
+on:
+  push:
+    paths:
+      - 'config/boards/*.*'
+
+jobs:
+
+  Run:
+    name: "Execute workflow"
+    if: ${{ github.repository_owner == 'Armbian' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.ACCESS_TOKEN }}
+          repository: armbian/os
+          event-type: "Repository update"

--- a/.github/workflows/build-board-list.yml
+++ b/.github/workflows/build-board-list.yml
@@ -16,4 +16,4 @@ jobs:
         with:
           token: ${{ secrets.ACCESS_TOKEN }}
           repository: armbian/os
-          event-type: "Repository update"
+          event-type: "Refresh board list"


### PR DESCRIPTION
# Description

Whenever something is changed in the `config/boards/` folder execute rebuild of [board build list GitHub action](https://github.com/armbian/os/actions/workflows/build-images.yml). This simplify board images re-build process as one can only select image from the list. Version is bumped automatic, build list variant is [predefined](https://github.com/armbian/os/tree/main/targets).

![image](https://user-images.githubusercontent.com/6281704/232584403-a4d331d3-838f-41f7-a1db-c545e5acb875.png)

Jira reference number [AR-1664]

# How Has This Been Tested?

- [x] Manual execute from another repository

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] [I have made corresponding changes to the documentation](https://github.com/armbian/documentation/pull/329)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1664]: https://armbian.atlassian.net/browse/AR-1664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ