### PR TITLE
fix ghproxy accelerated url

### DIFF
--- a/lib/functions/general/git.sh
+++ b/lib/functions/general/git.sh
@@ -86,7 +86,7 @@ function fetch_from_repo() {
 	local git_work_dir
 
 	# Set GitHub mirror before anything else touches $url
-	url=${url//'https://github.com/'/$GITHUB_SOURCE'/'}
+	url="$(echo "$url" | sed "s|^https://github.com/|${GITHUB_SOURCE}/|")"
 
 	# The 'offline' variable must always be set to 'true' or 'false'
 	local offline=false


### PR DESCRIPTION
# Description
ghproxy url is something like `https://ghproxy.com/https://gtihub.com/armbian/build`, which contains `https://gtihub.com`. Without this patch git will fetch from `https://ghproxy.com/https://ghproxy.com/https://gtihub.com/armbian/build`. Just skip modifying the url when ghproxy is set.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Build with `GITHUB_MIRROR=ghproxy`.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
