### PR TITLE
Change custom Ubuntu mirror logic

### DIFF
--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -321,10 +321,10 @@ function do_extra_configuration() {
 		fi
 	fi
 
-	if [[ "${ARCH}" == "arm64" ]]; then
-		if [[ -n ${CUSTOM_UBUNTU_MIRROR_ARM64} ]]; then
-			display_alert "Using custom ports/arm64 mirror" "${CUSTOM_UBUNTU_MIRROR_ARM64}" "info"
-			UBUNTU_MIRROR="${CUSTOM_UBUNTU_MIRROR_ARM64}"
+	if [[ "${ARCH}" != "i386" && "${ARCH}" != "amd64" ]]; then # ports are not present on all mirrors
+		if [[ -n ${CUSTOM_UBUNTU_MIRROR_PORTS} ]]; then
+			display_alert "Using custom ports/${ARCH} mirror" "${CUSTOM_UBUNTU_MIRROR_PORTS}" "info"
+			UBUNTU_MIRROR="${CUSTOM_UBUNTU_MIRROR_PORTS}"
 		fi
 	fi
 


### PR DESCRIPTION
# Description

After today's complete stall of primary Ubuntu infrastructure I switched to mirrors in order to rebuild caches. First problem is that often mirrors for amd64 and others are placed on different locations. This part is covered but it fails for riscv64 architecture. In order to cover that too, its better to have more generic variable CUSTOM_UBUNTU_MIRROR_PORTS and have everything that is not amd64 there. By quick research - if mirror hosts arm64 it also hosts risv64 and vice versa.

Second problem - if caches are re-generated with 3rd party mirrors, release lists remain with those values. How to approach to that problem? We want that - at least our builds - are always shipped with generic entries.

# How Has This Been Tested?

- [ ] Generated rootfs with two mirrors that are fast in EU:

1. CUSTOM_UBUNTU_MIRROR_PORTS="ftp.tu-chemnitz.de/pub/linux/ubuntu-ports/"
3. CUSTOM_UBUNTU_MIRROR="mirrors.dotsrc.org/ubuntu/"


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
