### PR TITLE
Fix  helios64 vdd-log supply warning

### DIFF
--- a/patch/kernel/archive/rockchip64-5.15/add-board-helios64.patch
+++ b/patch/kernel/archive/rockchip64-5.15/add-board-helios64.patch
@@ -224,12 +224,12 @@ index 000000000..fae17f416
 +	vdd_log: vdd-log {
 +		compatible = "pwm-regulator";
 +		pwms = <&pwm2 0 25000 1>;
++		pwm-supply = <&vcc5v0_sys>;
 +		regulator-name = "vdd_log";
 +		regulator-always-on;
 +		regulator-boot-on;
 +		regulator-min-microvolt = <830000>;
 +		regulator-max-microvolt = <1400000>;
-+		vin-supply = <&vcc5v0_sys>;
 +		regulator-state-mem {
 +			regulator-on-in-suspend;
 +			regulator-suspend-microvolt = <900000>;

--- a/patch/kernel/archive/rockchip64-6.1/add-board-helios64.patch
+++ b/patch/kernel/archive/rockchip64-6.1/add-board-helios64.patch
@@ -224,12 +224,12 @@ index 000000000..fae17f416
 +	vdd_log: vdd-log {
 +		compatible = "pwm-regulator";
 +		pwms = <&pwm2 0 25000 1>;
++		pwm-supply = <&vcc5v0_sys>;
 +		regulator-name = "vdd_log";
 +		regulator-always-on;
 +		regulator-boot-on;
 +		regulator-min-microvolt = <830000>;
 +		regulator-max-microvolt = <1400000>;
-+		vin-supply = <&vcc5v0_sys>;
 +		regulator-state-mem {
 +			regulator-on-in-suspend;
 +			regulator-suspend-microvolt = <900000>;


### PR DESCRIPTION
# Description

I change both edge and current.

vdd-log supply is pwm-supply, not vin-supply.
Fixes vdd-log supply ending up the dummy regulator.

[    1.783479] pwm-regulator vdd-log: Looking up pwm-supply from device tree
[    1.783505] pwm-regulator vdd-log: Looking up pwm-supply property in node /vdd-log failed
[    1.783556] vdd_log: supplied by regulator-dummy

Per https://lore.kernel.org/all/20211227234529.1970281-2-heiko@sntech.de/ there will be no functional change as the supplying regulator is an always-on fixed-regulator.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
