### PR TITLE
Let `linux-image` depends `linux-dtb`

### DIFF
--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -241,6 +241,11 @@ function kernel_package_callback_linux_image() {
 		run_host_command_logged cp -rp "${tmp_kernel_install_dirs[INSTALL_DTBS_PATH]}" "${package_directory}/usr/lib/linux-image-${kernel_version_family}"
 	fi
 
+	declare -a package_depends=()
+	if [[ "${KERNEL_BUILD_DTBS:-yes}" == "yes" ]]; then
+		package_depends+=( "linux-dtb-${BRANCH}-${LINUXFAMILY} (=${artifact_version})" )
+	fi
+
 	# Generate a control file
 	cat <<- CONTROL_FILE > "${package_DEBIAN_dir}/control"
 		Package: ${package_name}
@@ -251,6 +256,7 @@ function kernel_package_callback_linux_image() {
 		Section: kernel
 		Priority: optional
 		Provides: linux-image, linux-image-armbian, armbian-$BRANCH
+		Depends: $(IFS=','; echo "${package_depends[*]}")
 		Description: Armbian Linux $BRANCH kernel image ${artifact_version_reason:-"${kernel_version_family}"}
 		 This package contains the Linux kernel, modules and corresponding other
 		 files, kernel_version_family: $kernel_version_family.

--- a/lib/functions/rootfs/distro-agnostic.sh
+++ b/lib/functions/rootfs/distro-agnostic.sh
@@ -330,11 +330,15 @@ function install_distribution_agnostic() {
 
 	# install kernel: image/dtb/headers
 	if [[ -n $KERNELSOURCE ]]; then
-		install_deb_chroot "${DEB_STORAGE}/${image_artifacts_debs["linux-image"]}"
-
 		if [[ "${KERNEL_BUILD_DTBS:-"yes"}" == "yes" ]]; then
 			install_deb_chroot "${DEB_STORAGE}/${image_artifacts_debs["linux-dtb"]}"
+			# @TODO: Use `aptly` to create a local apt repo and install from it.
+			#        So we don't need to install these packages manually and then
+			#        mark them as automatically installed.
+			chroot_sdcard apt-mark auto "${image_artifacts_packages["linux-dtb"]}"
 		fi
+
+		install_deb_chroot "${DEB_STORAGE}/${image_artifacts_debs["linux-image"]}"
 
 		if [[ "${KERNEL_HAS_WORKING_HEADERS:-"no"}" == "yes" ]]; then
 			if [[ $INSTALL_HEADERS == yes ]]; then # @TODO remove? might be a good idea to always install headers.


### PR DESCRIPTION
# Description

For bootable/workable kernel, dtb is necessary.

# How Has This Been Tested?

- [X] Build
- [X] Run `apt show linux-image-current-meson` to check whether `dtb` is a dependency.
- [X] Run `apt purge --autoremove linux-image-current-meson` to check if `dtb` will be removed automatically.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved kernel package dependency management by adding version-pinned references to device tree blob packages when building custom kernels.
  * Corrected kernel installation order to ensure proper dependency resolution and automatic dependency tracking during system setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->