### PR TITLE
rockchip-rk3588: add new board hinlink-h88k

### DIFF
--- a/config/boards/hinlink-h88k.csc
+++ b/config/boards/hinlink-h88k.csc
@@ -1,0 +1,25 @@
+# Rockchip RK3588 SoC octa core 4-16GB eMMC USB3 NVMe SATA 4G WiFi/BT HDMI DP HDMI-In
+BOARD_NAME="Hinlink H88K"
+BOARDFAMILY="rockchip-rk3588"
+BOOTCONFIG="rock-5b-rk3588_defconfig"
+KERNEL_TARGET="legacy"
+FULL_DESKTOP="yes"
+BOOT_LOGO="desktop"
+BOOT_FDT_FILE="rockchip/rk3588-hinlink-h88k.dtb"
+BOOT_SCENARIO="spl-blobs"
+WIREGUARD="no"
+IMAGE_PARTITION_TABLE="gpt"
+SKIP_BOOTSPLASH="yes" # Skip boot splash patch, conflicts with CONFIG_VT=yes
+
+function post_family_tweaks__hinlink_h88k_naming_audios() {
+	display_alert "$BOARD" "Renaming hinlink-h88k audios" "info"
+
+	mkdir -p $SDCARD/etc/udev/rules.d/
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-hdmi0-sound", ENV{SOUND_DESCRIPTION}="HDMI0 Audio"' > $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-hdmi1-sound", ENV{SOUND_DESCRIPTION}="HDMI1 Audio"' >> $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-hdmiin-sound", ENV{SOUND_DESCRIPTION}="HDMI-In Audio"' >> $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-dp0-sound", ENV{SOUND_DESCRIPTION}="DP0 Audio"' >> $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-es8388-sound", ENV{SOUND_DESCRIPTION}="ES8388 Audio"' >> $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+
+	return 0
+}

--- a/patch/u-boot/legacy/board_hinlink-h88k/fix_source_so_boot_scr_works.patch
+++ b/patch/u-boot/legacy/board_hinlink-h88k/fix_source_so_boot_scr_works.patch
@@ -1,0 +1,24 @@
+From ea50d7f6921e2c3017258ce8fdfad632d82fbd87 Mon Sep 17 00:00:00 2001
+From: Stephen <stephen@vamrs.com>
+Date: Mon, 8 Nov 2021 14:30:00 +0800
+Subject: [PATCH] cmd: source: fix the error that the command source failed to
+ execute
+
+Signed-off-by: Stephen <stephen@vamrs.com>
+---
+ cmd/source.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cmd/source.c b/cmd/source.c
+index 45e9794b2f3..d724d63eb7c 100644
+--- a/cmd/source.c
++++ b/cmd/source.c
+@@ -84,7 +84,7 @@ source (ulong addr, const char *fit_uname)
+ 		 * past the zero-terminated sequence of image lengths to get
+ 		 * to the actual image data
+ 		 */
+-		while (*data++ != IMAGE_PARAM_INVAL);
++		while (*data++);
+ 		break;
+ #endif
+ #if defined(CONFIG_FIT)

--- a/patch/u-boot/legacy/board_hinlink-h88k/uboot-hinlink-h88k-config.patch
+++ b/patch/u-boot/legacy/board_hinlink-h88k/uboot-hinlink-h88k-config.patch
@@ -1,0 +1,13 @@
+t a/configs/rock-5b-rk3588_defconfig b/configs/rock-5b-rk3588_defconfig
+index adcdb4d9..92951132 100644
+--- a/configs/rock-5b-rk3588_defconfig
++++ b/configs/rock-5b-rk3588_defconfig
+@@ -21,7 +21,7 @@ CONFIG_TARGET_EVB_RK3588=y
+ CONFIG_SPL_LIBDISK_SUPPORT=y
+ CONFIG_SPL_SPI_FLASH_SUPPORT=y
+ CONFIG_SPL_SPI_SUPPORT=y
+-CONFIG_DEFAULT_DEVICE_TREE="rk3588-rock-5b"
++CONFIG_DEFAULT_DEVICE_TREE="rk3588-evb"
+ CONFIG_DEBUG_UART=y
+ CONFIG_FIT=y
+ CONFIG_FIT_IMAGE_POST_PROCESS=y


### PR DESCRIPTION
# Description

Hinlink H88K is a rk3588 board with a lot of IO: https://doc.hinlink.cn/
I've been building personal images: https://github.com/amazingfate/armbian-h88k-images/
I just use the same uboot defconfig with evb uboot devicetree. I may patch the evb device tree in the future since uboot patch is board specific.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
