### PR TITLE
return COMPRESS_OUTPUTIMAGE=gz option

### DIFF
--- a/lib/functions/image/compress-checksum.sh
+++ b/lib/functions/image/compress-checksum.sh
@@ -42,6 +42,12 @@ function output_images_compress_and_checksum() {
 			compression_type=".xz"
 		fi
 
+		if [[ $COMPRESS_OUTPUTIMAGE == *gz* ]]; then
+			display_alert "Compressing to gzip" "${uncompressed_file_basename}.gz" "info"
+			pigz "${uncompressed_file}"
+			compression_type=".gz"
+		fi
+
 		if [[ $COMPRESS_OUTPUTIMAGE == *sha* ]]; then
 			display_alert "SHA256 calculating" "${uncompressed_file_basename}${compression_type}" "info"
 			sha256sum -b "${uncompressed_file}${compression_type}" > "${uncompressed_file}${compression_type}".sha


### PR DESCRIPTION
Return COMPRESS_OUTPUTIMAGE=gz option

# How Has This Been Tested?
./compile.sh helios BOARD=helios64 BRANCH=current COMPRESS_OUTPUTIMAGE=gz,sha

- [x] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
