### PR TITLE
rk3328: add patch to enabled pcm5102 DAC on I2S1 bus

### DIFF
--- a/patch/kernel/archive/rockchip64-6.1/overlays-14-add-rk3328-pcm5102-dac.patch
+++ b/patch/kernel/archive/rockchip64-6.1/overlays-14-add-rk3328-pcm5102-dac.patch
@@ -1,0 +1,136 @@
+From f8874f8d3cefa49ef1613686296462703a5b8c7b Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Sat, 22 Apr 2023 12:31:45 +0200
+Subject: [PATCH] rk3328: add dtb overlay to enable pcm5102 DAC on i2s1 bus
+
+---
+ arch/arm64/boot/dts/rockchip/overlay/Makefile |   1 +
+ .../overlay/rockchip-rk3328-i2s1-pcm5102.dts  | 104 ++++++++++++++++++
+ 2 files changed, 105 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2s1-pcm5102.dts
+
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts/rockchip/overlay/Makefile
+index fe2e3e46e..b0ddfce1a 100644
+--- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
++++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
+@@ -25,6 +25,7 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
+ 	rockchip-rk3318-box-wlan-ap6330.dtbo \
+ 	rockchip-rk3318-box-cpu-hs.dtbo \
+ 	rockchip-rk3318-box-emmc-hs200.dtbo \
++	rockchip-rk3328-i2s1-pcm5102.dtbo \
+         rk3308-bs.dtbo rk3308-bs@1.3ghz.dtbo \
+         rk3308-sdio@10mhz.dtbo rk3308-sdio@4mhz.dtbo \
+         rk3308-emmc.dtbo
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2s1-pcm5102.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2s1-pcm5102.dts
+new file mode 100644
+index 000000000..5153440c0
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2s1-pcm5102.dts
+@@ -0,0 +1,104 @@
++/dts-v1/;
++/plugin/;
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/pinctrl/rockchip.h>
++
++/*
++ * Device tree overlay to disabled internal analog codec for
++ * rk3328 boards and enable external i2s, binding it to a
++ * pcm5102-based DAC.
++ * Tested on rock-pi E, but should be suitable for other
++ * similar boards
++ */
++
++&{/} {
++
++	pcm5102: pcm510x {
++		#sound-dai-cells = <0>;
++		compatible = "ti,pcm5102a";
++		pcm510x,format = "i2s";
++		status = "okay";
++	};
++
++	i2s_sound: i2s-sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,mclk-fs = <256>;
++		simple-audio-card,name = "I2S";
++		status = "okay";
++
++		simple-audio-card,cpu {
++			sound-dai = <&i2s1>;
++		};
++
++		simple-audio-card,codec {
++			sound-dai = <&pcm5102>;
++		};
++	};
++
++};
++
++&analog_sound {
++	status = "disabled";
++};
++
++&codec {
++	status = "disabled";
++};
++
++&i2s1_mclk {
++	rockchip,pins = <2 RK_PB7 1 &pcfg_pull_down>;
++};
++
++&i2s1_sclk {
++	rockchip,pins = <2 RK_PC2 1 &pcfg_pull_down>;
++};
++
++&i2s1_lrckrx {
++	rockchip,pins = <2 RK_PC0 1 &pcfg_pull_up>;
++};
++
++&i2s1_lrcktx {
++	rockchip,pins = <2 RK_PC1 1 &pcfg_pull_up>;
++};
++
++&i2s1_sdi {
++	rockchip,pins = <2 RK_PC3 1 &pcfg_pull_up>;
++};
++
++&i2s1_sdo {
++	rockchip,pins = <2 RK_PC7 1 &pcfg_pull_up>;
++};
++
++&i2s1_sdio1 {
++	rockchip,pins = <2 RK_PC4 1 &pcfg_pull_up>;
++};
++
++&i2s1_sdio2 {
++	rockchip,pins = <2 RK_PC5 1 &pcfg_pull_up>;
++};
++
++&i2s1_sdio3 {
++	rockchip,pins = <2 RK_PC6 1 &pcfg_pull_up>;
++};
++
++&i2s1_sleep {
++	rockchip,pins =
++	<2 RK_PB7 RK_FUNC_GPIO &pcfg_input_high>,
++	<2 RK_PC0 RK_FUNC_GPIO &pcfg_input_high>,
++	<2 RK_PC1 RK_FUNC_GPIO &pcfg_input_high>,
++	<2 RK_PC2 RK_FUNC_GPIO &pcfg_input_high>,
++	<2 RK_PC3 RK_FUNC_GPIO &pcfg_input_high>,
++	<2 RK_PC4 RK_FUNC_GPIO &pcfg_input_high>,
++	<2 RK_PC5 RK_FUNC_GPIO &pcfg_input_high>,
++	<2 RK_PC6 RK_FUNC_GPIO &pcfg_input_high>,
++	<2 RK_PC7 RK_FUNC_GPIO &pcfg_input_high>;
++};
++
++&i2s1 {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2s1_mclk>, <&i2s1_sclk>, <&i2s1_lrckrx>, <&i2s1_lrcktx>, <&i2s1_sdi>, <&i2s1_sdo>, <&i2s1_sdio1>, <&i2s1_sdio2>;
++	rockchip,playback-channels = <8>;
++};
+-- 
+2.34.1
+


### PR DESCRIPTION
# Description

RK3328 devices often have I2S1 bus available on expansion pins.
This PR introduces an overlay to enable the I2S1 bus for Rock Pi E to enable external PCM5102 DAC; I2S1 is shared for internal audio codec and external GPIO pins, so the overlay also disables the internal audio codec.

This has been tested and proved to work on Rock Pi E, should work on other boards with similar board wiring setup, but  can be also used as a base for other board/DAC combos in the future.

Jira reference number [AR-1670]

# How Has This Been Tested?

- [x] Kernel compiles successfully with patch applied
- [x] Manually installed the dtbo on a living community image for rockpi-e running edge kernel

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1670]: https://armbian.atlassian.net/browse/AR-1670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ