### PR TITLE
Installing fake_vcgencmd for Pine64

### DIFF
--- a/config/boards/pine64.conf
+++ b/config/boards/pine64.conf
@@ -4,3 +4,16 @@ BOARDFAMILY="sun50iw1"
 BOOTCONFIG="pine64_plus_defconfig"
 KERNEL_TARGET="legacy,current,edge"
 FULL_DESKTOP="yes"
+
+function post_family_tweaks__fake_vcgencmd() {
+    display_alert "$BOARD" "Installing fake vcgencmd" "info"
+    # Never add this to Raspberry Pi board config files such as rpi4b.conf
+
+	chroot $SDCARD /bin/bash -c "curl -o /usr/bin/vcgencmd \"https://raw.githubusercontent.com/clach04/fake_vcgencmd/0.0.1/vcgencmd\""
+	chroot $SDCARD /bin/bash -c "chmod 755 /usr/bin/vcgencmd"
+	chroot $SDCARD /bin/bash -c "mkdir -p /usr/share/doc/fake_vcgencmd"
+	chroot $SDCARD /bin/bash -c "curl -o /usr/share/doc/fake_vcgencmd/LICENSE \"https://raw.githubusercontent.com/clach04/fake_vcgencmd/0.0.1/LICENSE\""
+	chroot $SDCARD /bin/bash -c "curl -o /usr/share/doc/fake_vcgencmd/README.md \"https://raw.githubusercontent.com/clach04/fake_vcgencmd/0.0.1/README.md\""
+
+	return 0
+}


### PR DESCRIPTION
# Description

Fake `vcgencmd` allows requesting information from a non-Raspberry Pi board in the same way that can be done via an executable on there. Since this command is now available, the Armbian board can also be monitored, rebooted etc via eht FOSS Android app RasPi Check.

See also:
- https://f-droid.org/en/packages/de.eidottermihi.raspicheck/
- https://github.com/eidottermihi/rpicheck/issues/161
- https://forum.armbian.com/topic/17069-android-app-to-monitor-and-restart-boards/#comment-119650
- https://github.com/clach04/fake_vcgencmd

Jira reference number [AR-9999]

# How Has This Been Tested?

Yes, made a build and it worked, also via the Android app.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
