### PR TITLE
treat rk3566 as rk3568 to make "mkimage" work

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -67,6 +67,9 @@ elif [[ "${BOOT_SOC}" == rk3568 ]]; then
 
 fi
 
+# BOOT_SOC_MKIMAGE defaults to BOOT_SOC, but can be overriden. See rk3566
+declare -g BOOT_SOC_MKIMAGE="${BOOT_SOC}"
+
 if [[ $BOOT_SOC == rk3328 ]]; then
 
 	BOOT_SCENARIO="${BOOT_SCENARIO:=only-blobs}"
@@ -97,6 +100,7 @@ elif [[ $BOOT_SOC == rk3566 ]]; then
 	BOOT_SCENARIO="${BOOT_SCENARIO:=spl-blobs}"
 	DDR_BLOB="${DDR_BLOB:=rk35/rk3566_ddr_1056MHz_v1.10.bin}"
 	BL31_BLOB='rk35/rk3568_bl31_v1.29.elf'
+	BOOT_SOC_MKIMAGE="rk3568" # mkimage does not know about rk3566, and rk3568 works.
 
 elif [[ $BOOT_SOC == rk3568 ]]; then
 
@@ -205,12 +209,13 @@ uboot_custom_postprocess() {
 		[[ ! -f "${SPL_BIN_PATH}" ]] && exit_with_error "DDR_BLOB ${SPL_BIN_PATH} does not exist for scenario ${BOOT_SCENARIO}"
 
 		display_alert "mkimage for '${BOOT_SOC}' for scenario ${BOOT_SCENARIO}" "SPL_BIN_PATH: ${SPL_BIN_PATH}" "debug"
-		run_host_command_logged tools/mkimage -n "${BOOT_SOC}" -T rksd -d "${SPL_BIN_PATH}:spl/u-boot-spl.bin" idbloader.img
+		run_host_command_logged tools/mkimage -n "${BOOT_SOC_MKIMAGE}" -T rksd -d "${SPL_BIN_PATH}:spl/u-boot-spl.bin" idbloader.img
 
 	elif [[ $BOOT_SCENARIO == "only-blobs" ]]; then
 
-		local tempfile=$(mktemp)
-		run_host_command_logged tools/mkimage -n $BOOT_SOC -T rksd -d $RKBIN_DIR/$DDR_BLOB idbloader.bin
+		local tempfile
+		tempfile=$(mktemp)
+		run_host_command_logged tools/mkimage -n "${BOOT_SOC_MKIMAGE}" -T rksd -d $RKBIN_DIR/$DDR_BLOB idbloader.bin
 		cat $RKBIN_DIR/$MINILOADER_BLOB >> idbloader.bin
 		run_host_x86_binary_logged $RKBIN_DIR/tools/loaderimage --pack --uboot ./u-boot-dtb.bin uboot.img 0x200000
 		run_host_x86_binary_logged $RKBIN_DIR/tools/trust_merger --replace bl31.elf $RKBIN_DIR/$BL31_BLOB trust.ini
@@ -233,7 +238,7 @@ uboot_custom_postprocess() {
 			dd if=idbloader.img of=rkspi_loader.img seek=64 conv=notrunc
 			dd if=u-boot.itb of=rkspi_loader.img seek=16384 conv=notrunc
 		else
-			tools/mkimage -n $BOOT_SOC -T rkspi -d tpl/u-boot-tpl.bin:spl/u-boot-spl.bin rkspi_tpl_spl.img
+			tools/mkimage -n "${BOOT_SOC_MKIMAGE}" -T rkspi -d tpl/u-boot-tpl.bin:spl/u-boot-spl.bin rkspi_tpl_spl.img
 			dd if=/dev/zero of=rkspi_loader.img count=8128 status=none
 			dd if=rkspi_tpl_spl.img of=rkspi_loader.img conv=notrunc status=none
 			dd if=u-boot.itb of=rkspi_loader.img seek=768 conv=notrunc status=none


### PR DESCRIPTION
At uboot_ custom_postprocess(), treat RK3566 as RK3568 to make mkimage work
