### PR TITLE
upgrade vcgencmd without tmp vulnerability and inclusion for bananapi…

### DIFF
--- a/config/boards/bananapim2ultra.csc
+++ b/config/boards/bananapim2ultra.csc
@@ -4,3 +4,16 @@ BOARDFAMILY="sun8i"
 BOOTCONFIG="Bananapi_M2_Ultra_defconfig"
 OVERLAY_PREFIX="sun8i-r40"
 KERNEL_TARGET="current,edge"
+
+function post_family_tweaks__fake_vcgencmd() {
+    display_alert "$BOARD" "Installing fake vcgencmd" "info"
+    # Never add this to Raspberry Pi board config files such as rpi4b.conf
+
+	chroot $SDCARD /bin/bash -c "curl -o /usr/bin/vcgencmd \"https://raw.githubusercontent.com/clach04/fake_vcgencmd/0.0.2/vcgencmd\""
+	chroot $SDCARD /bin/bash -c "chmod 755 /usr/bin/vcgencmd"
+	chroot $SDCARD /bin/bash -c "mkdir -p /usr/share/doc/fake_vcgencmd"
+	chroot $SDCARD /bin/bash -c "curl -o /usr/share/doc/fake_vcgencmd/LICENSE \"https://raw.githubusercontent.com/clach04/fake_vcgencmd/0.0.2/LICENSE\""
+	chroot $SDCARD /bin/bash -c "curl -o /usr/share/doc/fake_vcgencmd/README.md \"https://raw.githubusercontent.com/clach04/fake_vcgencmd/0.0.2/README.md\""
+
+	return 0
+}

--- a/config/boards/pine64.conf
+++ b/config/boards/pine64.conf
@@ -9,11 +9,11 @@ function post_family_tweaks__fake_vcgencmd() {
     display_alert "$BOARD" "Installing fake vcgencmd" "info"
     # Never add this to Raspberry Pi board config files such as rpi4b.conf
 
-	chroot $SDCARD /bin/bash -c "curl -o /usr/bin/vcgencmd \"https://raw.githubusercontent.com/clach04/fake_vcgencmd/0.0.1/vcgencmd\""
+	chroot $SDCARD /bin/bash -c "curl -o /usr/bin/vcgencmd \"https://raw.githubusercontent.com/clach04/fake_vcgencmd/0.0.2/vcgencmd\""
 	chroot $SDCARD /bin/bash -c "chmod 755 /usr/bin/vcgencmd"
 	chroot $SDCARD /bin/bash -c "mkdir -p /usr/share/doc/fake_vcgencmd"
-	chroot $SDCARD /bin/bash -c "curl -o /usr/share/doc/fake_vcgencmd/LICENSE \"https://raw.githubusercontent.com/clach04/fake_vcgencmd/0.0.1/LICENSE\""
-	chroot $SDCARD /bin/bash -c "curl -o /usr/share/doc/fake_vcgencmd/README.md \"https://raw.githubusercontent.com/clach04/fake_vcgencmd/0.0.1/README.md\""
+	chroot $SDCARD /bin/bash -c "curl -o /usr/share/doc/fake_vcgencmd/LICENSE \"https://raw.githubusercontent.com/clach04/fake_vcgencmd/0.0.2/LICENSE\""
+	chroot $SDCARD /bin/bash -c "curl -o /usr/share/doc/fake_vcgencmd/README.md \"https://raw.githubusercontent.com/clach04/fake_vcgencmd/0.0.2/README.md\""
 
 	return 0
 }

--- a/config/boards/rock64.conf
+++ b/config/boards/rock64.conf
@@ -5,3 +5,16 @@ BOOTCONFIG="rock64-rk3328_defconfig"
 KERNEL_TARGET="legacy,current,edge"
 FULL_DESKTOP="yes"
 BOOT_SCENARIO="blobless"
+
+function post_family_tweaks__fake_vcgencmd() {
+    display_alert "$BOARD" "Installing fake vcgencmd" "info"
+    # Never add this to Raspberry Pi board config files such as rpi4b.conf
+
+	chroot $SDCARD /bin/bash -c "curl -o /usr/bin/vcgencmd \"https://raw.githubusercontent.com/clach04/fake_vcgencmd/0.0.2/vcgencmd\""
+	chroot $SDCARD /bin/bash -c "chmod 755 /usr/bin/vcgencmd"
+	chroot $SDCARD /bin/bash -c "mkdir -p /usr/share/doc/fake_vcgencmd"
+	chroot $SDCARD /bin/bash -c "curl -o /usr/share/doc/fake_vcgencmd/LICENSE \"https://raw.githubusercontent.com/clach04/fake_vcgencmd/0.0.2/LICENSE\""
+	chroot $SDCARD /bin/bash -c "curl -o /usr/share/doc/fake_vcgencmd/README.md \"https://raw.githubusercontent.com/clach04/fake_vcgencmd/0.0.2/README.md\""
+
+	return 0
+}


### PR DESCRIPTION
# Description

Upgrade vcgencmd without tmp vulnerability and inclusion for bananapim2ultra

See also https://github.com/armbian/build/pull/5095#issuecomment-1521626783

# How Has This Been Tested?

- [x] Pine64
- [x] Rock64
- [x] Banana Pi M2 Ultra

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
