### PR TITLE
fix rtl8723du compilation on kernel 6.3

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -504,6 +504,10 @@ driver_rtl8723DU() {
 
 		# fix compilation for kernels >= 5.4
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723du-Fix-VFS-import.patch" "applying"
+
+		# fix compilation for kernels >= 6.3
+		process_patch_file "${SRC}/patch/misc/wireless-rtl8723du-6.3.patch" "applying"
+
 	fi
 }
 

--- a/patch/misc/wireless-rtl8723du-6.3.patch
+++ b/patch/misc/wireless-rtl8723du-6.3.patch
@@ -1,0 +1,41 @@
+diff --git a/drivers/net/wireless/rtl8723du/os_dep/ioctl_cfg80211.c b/drivers/net/wireless/rtl8723du/os_dep/ioctl_cfg80211.c
+index ae4aca0162ce..e57e3ca45d33 100644
+--- a/drivers/net/wireless/rtl8723du/os_dep/ioctl_cfg80211.c
++++ b/drivers/net/wireless/rtl8723du/os_dep/ioctl_cfg80211.c
+@@ -187,10 +187,13 @@ u8 rtw_cfg80211_ch_switch_notify(struct adapter *adapter, u8 ch, u8 bw, u8 offse
+ 	}
+ 
+ 	ctype = rtw_chbw_to_nl80211_channel_type(ch, bw, offset, ht);
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 2)
+-	cfg80211_ch_switch_notify(adapter->pnetdev, freq, ctype);
+-#else
++
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
++	cfg80211_ch_switch_notify(adapter->pnetdev, freq, ctype, 0, 0);
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5, 19, 2)
+ 	cfg80211_ch_switch_notify(adapter->pnetdev, freq, ctype, 0);
++#else
++	cfg80211_ch_switch_notify(adapter->pnetdev, freq, ctype);
+ #endif
+ #endif
+ 
+diff --git a/drivers/net/wireless/rtl8723du/os_dep/ioctl_cfg80211.c b/drivers/net/wireless/rtl8723du/os_dep/ioctl_cfg80211.c
+index e57e3ca45d33..01303d253971 100644
+--- a/drivers/net/wireless/rtl8723du/os_dep/ioctl_cfg80211.c
++++ b/drivers/net/wireless/rtl8723du/os_dep/ioctl_cfg80211.c
+@@ -171,10 +171,12 @@ u8 rtw_cfg80211_ch_switch_notify(struct adapter *adapter, u8 ch, u8 bw, u8 offse
+ 	if (ret != _SUCCESS)
+ 		goto exit;
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 2)
+-	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef);
+-#else
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
++	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef, 0, 0);
++#elif LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 2)
+ 	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef, 0);
++#else
++	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef);
+ #endif
+ 
+ #else

--- a/patch/misc/wireless-rtl8723du-6.3.patch
+++ b/patch/misc/wireless-rtl8723du-6.3.patch
@@ -32,7 +32,7 @@ index e57e3ca45d33..01303d253971 100644
 -#else
 +#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
 +	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef, 0, 0);
-+#elif LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 2)
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5, 19, 2)
  	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef, 0);
 +#else
 +	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef);


### PR DESCRIPTION
# Description

As per subject, fix rtl8723du on kernel 6.3, useful until upstream driver get patched

# How Has This Been Tested?

- [x] Compilation for kernel 6.3 works
- [x] Compilation for kernel 6.1 works

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
