### PR TITLE
fix rtl8812au compilation for kernel 6.3

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -182,6 +182,10 @@ driver_rtl8811_rtl8812_rtl8814_rtl8821() {
 		sed -i '/source "drivers\/net\/wireless\/ti\/Kconfig"/a source "drivers\/net\/wireless\/rtl8812au\/Kconfig"' \
 			"$kerneldir/drivers/net/wireless/Kconfig"
 
+		# fix compilation for kernels >= 6.3
+		process_patch_file "${SRC}/patch/misc/wireless-rtl8812au-6.3.patch" "applying"
+
+
 	fi
 
 }

--- a/patch/misc/wireless-rtl8812au-6.3.patch
+++ b/patch/misc/wireless-rtl8812au-6.3.patch
@@ -1,0 +1,37 @@
+From f507578759ec1331a155299a3f6d9ed1daa93682 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Wed, 26 Apr 2023 21:03:07 +0000
+Subject: [PATCH] fix rtl8812au driver for kernel 6.3
+
+---
+ .../net/wireless/rtl8812au/os_dep/linux/ioctl_cfg80211.c    | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/wireless/rtl8812au/os_dep/linux/ioctl_cfg80211.c b/drivers/net/wireless/rtl8812au/os_dep/linux/ioctl_cfg80211.c
+index f1a5493663cf..4a28b8258c54 100644
+--- a/drivers/net/wireless/rtl8812au/os_dep/linux/ioctl_cfg80211.c
++++ b/drivers/net/wireless/rtl8812au/os_dep/linux/ioctl_cfg80211.c
+@@ -460,7 +460,9 @@ u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset,
+ 
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0))
+ 	if (started) {
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0))
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0))
++		cfg80211_ch_switch_started_notify(adapter->pnetdev, &chdef, 0, 0, false, 0);
++#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0))
+ 		cfg80211_ch_switch_started_notify(adapter->pnetdev, &chdef, 0, 0, false);
+ #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 11, 0))
+ 		cfg80211_ch_switch_started_notify(adapter->pnetdev, &chdef, 0, false);
+@@ -475,6 +477,8 @@ u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset,
+ 		goto exit;
+ 
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 19, 2))
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0))
++	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef, 0, 0);
++#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 19, 2))
+ 	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef, 0);
+ #else
+ 	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef);
+-- 
+2.34.1
+


### PR DESCRIPTION
# Description

As per subject, fix rtl8812au on kernel 6.3, useful until upstream driver get patched

# How Has This Been Tested?

- [x] Compilation for kernel 6.3 works
- [x] Compilation for kernel 6.1 works

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
