### PR TITLE
fix rtl88x2bu compilation on kernel 6.3

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -364,6 +364,10 @@ driver_rtl88x2bu() {
 
 		# fix compilation for kernels >= 5.4
 		process_patch_file "${SRC}/patch/misc/wireless-rtl88x2bu-Fix-VFS-import.patch" "applying"
+
+		# fix compilation for kernels >= 6.3
+		process_patch_file "${SRC}/patch/misc/wireless-rtl88x2bu-6.3.0.patch" "applying"
+
 	fi
 
 }

--- a/patch/misc/wireless-rtl88x2bu-6.3.0.patch
+++ b/patch/misc/wireless-rtl88x2bu-6.3.0.patch
@@ -1,0 +1,38 @@
+From c0e386b763773f1fdf4621a8f4d90a146c6ffe8c Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Wed, 26 Apr 2023 19:29:42 +0000
+Subject: [PATCH] fix rtl88x2bu compilation on kernel >= 6.3.0
+
+---
+ .../net/wireless/rtl88x2bu/os_dep/linux/ioctl_cfg80211.c  | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/wireless/rtl88x2bu/os_dep/linux/ioctl_cfg80211.c b/drivers/net/wireless/rtl88x2bu/os_dep/linux/ioctl_cfg80211.c
+index b1259202abe5..f700f0590560 100644
+--- a/drivers/net/wireless/rtl88x2bu/os_dep/linux/ioctl_cfg80211.c
++++ b/drivers/net/wireless/rtl88x2bu/os_dep/linux/ioctl_cfg80211.c
+@@ -464,7 +464,9 @@ u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset,
+ 		 *  called by others with block-tx.
+ 		 */
+ 
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0))
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0))
++		cfg80211_ch_switch_started_notify(adapter->pnetdev, &chdef, 0, 0, false, 0);
++#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0))
+ 		cfg80211_ch_switch_started_notify(adapter->pnetdev, &chdef, 0, 0, false);
+ #else
+ 		cfg80211_ch_switch_started_notify(adapter->pnetdev, &chdef, 0, false);
+@@ -479,7 +481,9 @@ u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset,
+ 	if (!rtw_cfg80211_allow_ch_switch_notify(adapter))
+ 		goto exit;
+ 
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 19, 2))
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0))
++	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef, 0, 0);
++#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 19, 2))
+ 	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef, 0);
+ #else
+ 	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef);
+-- 
+2.34.1
+


### PR DESCRIPTION
# Description

As per subject, fix rtl88x2bu on kernel 6.3, useful until upstream driver get patched

# How Has This Been Tested?

- [x] Compilation for kernel 6.3 works
- [x] Compilation for kernel 6.1 works

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
