### PR TITLE
fix rtl8723cs compilation for kernel 6.3

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -610,8 +610,12 @@ driver_rtl8723cs() {
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/Bluetooth-hci_h5-Add-support-for-binding-RTL8723CS-with-device-.patch" "applying"
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/bluetooth-h5-Don-t-re-initialize-rtl8723cs-on-resume.patch" "applying"
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/bluetooth-btrtl-add-rtl8703bs.patch" "applying"
-
 	fi
+
+	if linux-version compare "${version}" ge 6.3; then
+		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/8723cs-Port-to-6.3.patch" "applying"
+	fi
+	
 }
 
 patch_drivers_network() {

--- a/patch/misc/wireless-rtl8723cs/8723cs-Port-to-6.3.patch
+++ b/patch/misc/wireless-rtl8723cs/8723cs-Port-to-6.3.patch
@@ -1,0 +1,33 @@
+From cd536d782971138010d7007a4a012b1809f7e4fc Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Wed, 26 Apr 2023 19:16:10 +0000
+Subject: [PATCH] fix for kernel 6.3 for rtl8723cs driver
+
+---
+ drivers/staging/rtl8723cs/os_dep/linux/ioctl_cfg80211.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/staging/rtl8723cs/os_dep/linux/ioctl_cfg80211.c b/drivers/staging/rtl8723cs/os_dep/linux/ioctl_cfg80211.c
+index f50a9abaad89..a92ec4d37036 100644
+--- a/drivers/staging/rtl8723cs/os_dep/linux/ioctl_cfg80211.c
++++ b/drivers/staging/rtl8723cs/os_dep/linux/ioctl_cfg80211.c
+@@ -452,14 +452,14 @@ u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset,
+ 		goto exit;
+ 
+ 	if (started) {
+-		cfg80211_ch_switch_started_notify(adapter->pnetdev, &chdef, 0, 0, false);
++		cfg80211_ch_switch_started_notify(adapter->pnetdev, &chdef, 0, 0, false, 0);
+ 		goto exit;
+ 	}
+ 
+ 	if (!rtw_cfg80211_allow_ch_switch_notify(adapter))
+ 		goto exit;
+ 
+-	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef, 0);
++	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef, 0, 0);
+ 
+ exit:
+ 	return ret;
+-- 
+2.34.1
+


### PR DESCRIPTION
# Description

As per subject, fix rtl8723cs on kernel 6.3

# How Has This Been Tested?

- [x] Compilation for kernel 6.3 works
- [x] Compilation for kernel 6.1 works

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
