### PR TITLE
rockchip: fix dtbs_install step for overlays

### DIFF
--- a/patch/kernel/archive/rockchip-6.3/general-add-overlay-compilation-support.patch
+++ b/patch/kernel/archive/rockchip-6.3/general-add-overlay-compilation-support.patch
@@ -36,7 +36,7 @@ index 50d580d77..94bd15617 100644
 +$(dst)/%.scr: $(obj)/%.scr
 +	$(call cmd,dtb_install)
 +
-+$(dst)/README.rk322x-overlays: $(src)/README.rk322x-overlays
++$(dst)/README.rockchip-overlays: $(src)/README.rockchip-overlays
 +	$(call cmd,dtb_install)
 +
  PHONY += $(subdirs)


### PR DESCRIPTION
# Description

Fix mistake due to patch copied as-is from rk322x family without properly checking it first :pensive: 

# How Has This Been Tested?

- [x] Kernel deb packages compiled

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
