### PR TITLE
Fix building rk322x with vendor 4.4 kernel

### DIFF
--- a/patch/kernel/archive/rk322x-4.4/01-linux-0005-dts.patch
+++ b/patch/kernel/archive/rk322x-4.4/01-linux-0005-dts.patch
@@ -1,115 +1,45 @@
-From 65a89294e3434d03640530a5dda6314dd588f01f Mon Sep 17 00:00:00 2001
-From: Jonas Karlman <jonas@kwiboo.se>
-Date: Sun, 1 Jul 2018 23:22:32 +0200
-Subject: [PATCH] arm: dts: rockchip: rk3288: update dtsi
+From c49487592d1a37f15870e5d2fb0d70b1bb63793c Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Sun, 30 Apr 2023 12:31:35 +0200
+Subject: [PATCH] various device tree fixes
 
 ---
- arch/arm/boot/dts/rk3288.dtsi | 20 +++++++++++++++-----
- 1 file changed, 15 insertions(+), 5 deletions(-)
-
-diff --git a/arch/arm/boot/dts/rk3288.dtsi b/arch/arm/boot/dts/rk3288.dtsi
-index 1b7602f25f34..9cca69f9f5ba 100644
---- a/arch/arm/boot/dts/rk3288.dtsi
-+++ b/arch/arm/boot/dts/rk3288.dtsi
-@@ -352,49 +352,57 @@
- 
- 	sdmmc: dwmmc@ff0c0000 {
- 		compatible = "rockchip,rk3288-dw-mshc";
--		clock-freq-min-max = <400000 150000000>;
-+		max-frequency = <150000000>;
- 		clocks = <&cru HCLK_SDMMC>, <&cru SCLK_SDMMC>,
- 			 <&cru SCLK_SDMMC_DRV>, <&cru SCLK_SDMMC_SAMPLE>;
- 		clock-names = "biu", "ciu", "ciu-drive", "ciu-sample";
- 		fifo-depth = <0x100>;
- 		interrupts = <GIC_SPI 32 IRQ_TYPE_LEVEL_HIGH>;
- 		reg = <0x0 0xff0c0000 0x0 0x4000>;
-+		resets = <&cru SRST_MMC0>;
-+		reset-names = "reset";
- 		status = "disabled";
- 	};
- 
- 	sdio0: dwmmc@ff0d0000 {
- 		compatible = "rockchip,rk3288-dw-mshc";
--		clock-freq-min-max = <400000 150000000>;
-+		max-frequency = <150000000>;
- 		clocks = <&cru HCLK_SDIO0>, <&cru SCLK_SDIO0>,
- 			 <&cru SCLK_SDIO0_DRV>, <&cru SCLK_SDIO0_SAMPLE>;
- 		clock-names = "biu", "ciu", "ciu-drive", "ciu-sample";
- 		fifo-depth = <0x100>;
- 		interrupts = <GIC_SPI 33 IRQ_TYPE_LEVEL_HIGH>;
- 		reg = <0x0 0xff0d0000 0x0 0x4000>;
-+		resets = <&cru SRST_SDIO0>;
-+		reset-names = "reset";
- 		status = "disabled";
- 	};
- 
- 	sdio1: dwmmc@ff0e0000 {
- 		compatible = "rockchip,rk3288-dw-mshc";
--		clock-freq-min-max = <400000 150000000>;
-+		max-frequency = <150000000>;
- 		clocks = <&cru HCLK_SDIO1>, <&cru SCLK_SDIO1>,
- 			 <&cru SCLK_SDIO1_DRV>, <&cru SCLK_SDIO1_SAMPLE>;
- 		clock-names = "biu", "ciu", "ciu-drive", "ciu-sample";
- 		fifo-depth = <0x100>;
- 		interrupts = <GIC_SPI 34 IRQ_TYPE_LEVEL_HIGH>;
- 		reg = <0x0 0xff0e0000 0x0 0x4000>;
-+		resets = <&cru SRST_SDIO1>;
-+		reset-names = "reset";
- 		status = "disabled";
- 	};
- 
- 	emmc: dwmmc@ff0f0000 {
- 		compatible = "rockchip,rk3288-dw-mshc";
--		clock-freq-min-max = <400000 150000000>;
-+		max-frequency = <150000000>;
- 		clocks = <&cru HCLK_EMMC>, <&cru SCLK_EMMC>,
- 			 <&cru SCLK_EMMC_DRV>, <&cru SCLK_EMMC_SAMPLE>;
- 		clock-names = "biu", "ciu", "ciu-drive", "ciu-sample";
- 		fifo-depth = <0x100>;
- 		interrupts = <GIC_SPI 35 IRQ_TYPE_LEVEL_HIGH>;
- 		reg = <0x0 0xff0f0000 0x0 0x4000>;
-+		resets = <&cru SRST_EMMC>;
-+		reset-names = "reset";
- 		status = "disabled";
- 		supports-emmc;
- 	};
-@@ -638,6 +646,7 @@
- 		compatible = "rockchip,rk3288-tsadc";
- 		reg = <0x0 0xff280000 0x0 0x100>;
- 		interrupts = <GIC_SPI 37 IRQ_TYPE_LEVEL_HIGH>;
-+		rockchip,grf = <&grf>;
- 		clocks = <&cru SCLK_TSADC>, <&cru PCLK_TSADC>;
- 		clock-names = "tsadc", "apb_pclk";
- 		assigned-clocks = <&cru SCLK_TSADC>;
-@@ -646,7 +655,7 @@
- 		reset-names = "tsadc-apb";
- 		pinctrl-names = "gpio", "otpout";
- 		pinctrl-0 = <&otp_gpio>;
--		pinctrl-1 = <&otp_gpio>;
-+		pinctrl-1 = <&otp_out>;
- 		#thermal-sensor-cells = <1>;
- 		rockchip,hw-tshut-temp = <120000>;
- 		rockchip,hw-tshut-mode = <0>; /* tshut mode 0:CRU 1:GPIO */
-@@ -1699,6 +1708,7 @@
- 		operating-points-v2 = <&gpu_opp_table>;
- 		#cooling-cells = <2>; /* min followed by max */
- 		power-domains = <&power RK3288_PD_GPU>;
-+		power-off-delay-ms = <200>;
- 		status = "disabled";
- 
- 		upthreshold = <75>;
-
-From 4cea1d3405885efca9c1d7e80b6eeb52e40d990f Mon Sep 17 00:00:00 2001
-From: Jonas Karlman <jonas@kwiboo.se>
-Date: Sun, 13 Aug 2017 10:24:19 +0200
-Subject: [PATCH] arm: dts: rk3288-miniarm: update dts
-
----
- arch/arm/boot/dts/rk3288-miniarm.dts | 64 +++++++++++++++++++++++++++++-------
- 1 file changed, 53 insertions(+), 11 deletions(-)
+ arch/arm/boot/dts/rk3288-miniarm.dts          |   64 +-
+ arch/arm/boot/dts/rk3288-miqi.dts             |   75 +-
+ arch/arm/boot/dts/rk3288.dtsi                 |   29 +-
+ .../boot/dts/rockchip/rk3328-box-trn9.dts     |  702 ++++++++++++
+ .../boot/dts/rockchip/rk3328-box-z28.dts      |  598 ++++++++++
+ arch/arm64/boot/dts/rockchip/rk3328-box.dts   |  648 +++++++++++
+ .../rockchip/rk3328-dram-box-plus-timing.dtsi |  263 +++++
+ .../arm64/boot/dts/rockchip/rk3328-roc-cc.dts |  597 ++++++++++
+ .../arm64/boot/dts/rockchip/rk3328-rock64.dts |  286 +++--
+ .../boot/dts/rockchip/rk3328-rockbox.dts      |  583 ++++++++++
+ arch/arm64/boot/dts/rockchip/rk3328.dtsi      |   50 +-
+ .../boot/dts/rockchip/rk3399-khadas-edge.dts  |   66 ++
+ .../boot/dts/rockchip/rk3399-khadas-edge.dtsi | 1005 +++++++++++++++++
+ .../arm64/boot/dts/rockchip/rk3399-linux.dtsi |    7 +-
+ .../boot/dts/rockchip/rk3399-rock-pi-4.dts    |  926 +++++++++++++++
+ .../boot/dts/rockchip/rk3399-rock960.dts      | 1003 ++++++++++++++++
+ .../boot/dts/rockchip/rk3399-rockpro64.dts    |  421 +++----
+ .../boot/dts/rockchip/rk3399-sapphire.dts     |  170 +++
+ .../boot/dts/rockchip/rk3399-sapphire.dtsi    |   17 +-
+ arch/arm64/boot/dts/rockchip/rk3399.dtsi      |   26 +-
+ sound/soc/soc-utils.c                         |   10 +
+ 21 files changed, 7143 insertions(+), 403 deletions(-)
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3328-box-trn9.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3328-box-z28.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3328-box.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3328-dram-box-plus-timing.dtsi
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3328-rockbox.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3399-khadas-edge.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3399-khadas-edge.dtsi
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3399-rock960.dts
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3399-sapphire.dts
 
 diff --git a/arch/arm/boot/dts/rk3288-miniarm.dts b/arch/arm/boot/dts/rk3288-miniarm.dts
-index a5c5300797ab..eac9b1501878 100644
+index 25cbc25236b1..0ade1635436a 100644
 --- a/arch/arm/boot/dts/rk3288-miniarm.dts
 +++ b/arch/arm/boot/dts/rk3288-miniarm.dts
 @@ -42,11 +42,22 @@
@@ -201,8 +131,8 @@ index a5c5300797ab..eac9b1501878 100644
 +	status = "okay";
  };
  
- &dsi0 {
-@@ -238,6 +263,11 @@
+ &gpu {
+@@ -229,6 +254,11 @@
  	#address-cells = <1>;
  	#size-cells = <0>;
  	#sound-dai-cells = <0>;
@@ -214,7 +144,7 @@ index a5c5300797ab..eac9b1501878 100644
  	status = "okay";
  	/* Don't use vopl for HDMI */
  	ports {
-@@ -545,6 +575,15 @@
+@@ -541,6 +571,15 @@
  
  &i2s {
  	#sound-dai-cells = <0>;
@@ -230,7 +160,7 @@ index a5c5300797ab..eac9b1501878 100644
  	status = "okay";
  };
  
-@@ -558,7 +597,7 @@
+@@ -554,7 +593,7 @@
  &sdio0 {
  	status = "okay";
  	clock-frequency = <50000000>;
@@ -239,7 +169,7 @@ index a5c5300797ab..eac9b1501878 100644
  	bus-width = <4>;
  	cap-sd-highspeed;
  	cap-sdio-irq;
-@@ -579,7 +618,7 @@
+@@ -575,7 +614,7 @@
  
  &saradc {
  	vref-supply = <&vcc18_ldo1>;
@@ -248,7 +178,7 @@ index a5c5300797ab..eac9b1501878 100644
  };
  
  &sdmmc {
-@@ -604,7 +643,6 @@
+@@ -600,7 +639,6 @@
  &tsadc {
  	rockchip,hw-tshut-mode = <1>; /* tshut mode 0:CRU 1:GPIO */
  	rockchip,hw-tshut-polarity = <1>; /* tshut polarity 0:LOW 1:HIGH */
@@ -256,7 +186,7 @@ index a5c5300797ab..eac9b1501878 100644
  	status = "okay";
  };
  
-@@ -615,6 +653,8 @@
+@@ -611,6 +649,8 @@
  };
  
  &uart1 {
@@ -265,7 +195,7 @@ index a5c5300797ab..eac9b1501878 100644
  	status = "okay";
  };
  
-@@ -627,6 +667,8 @@
+@@ -619,6 +659,8 @@
  };
  
  &uart4 {
@@ -274,7 +204,7 @@ index a5c5300797ab..eac9b1501878 100644
  	status = "okay";
  };
  
-@@ -644,7 +686,7 @@
+@@ -636,7 +678,7 @@
  };
  
  &usb_otg {
@@ -283,18 +213,8 @@ index a5c5300797ab..eac9b1501878 100644
  };
  
  &vopb {
-
-From 3da8fccb1f5b73ef313d320925e81bd1b5cacbfa Mon Sep 17 00:00:00 2001
-From: Jonas Karlman <jonas@kwiboo.se>
-Date: Thu, 2 Nov 2017 23:17:46 +0100
-Subject: [PATCH] arm: dts: rk3288-miqi: update dts
-
----
- arch/arm/boot/dts/rk3288-miqi.dts | 75 ++++++++++++++++++++++++++-------------
- 1 file changed, 50 insertions(+), 25 deletions(-)
-
 diff --git a/arch/arm/boot/dts/rk3288-miqi.dts b/arch/arm/boot/dts/rk3288-miqi.dts
-index a2862c6a17f1..9655365db416 100644
+index fa8266d0a5f7..922841c12799 100644
 --- a/arch/arm/boot/dts/rk3288-miqi.dts
 +++ b/arch/arm/boot/dts/rk3288-miqi.dts
 @@ -43,11 +43,22 @@
@@ -421,7 +341,7 @@ index a2862c6a17f1..9655365db416 100644
  &uart3 {
  	status = "okay";
  };
-@@ -472,6 +494,10 @@ I2C
+@@ -465,6 +487,10 @@ I2C
  
  &vopl {
  	status = "okay";
@@ -432,215 +352,227 @@ index a2862c6a17f1..9655365db416 100644
  };
  
  &vopl_mmu {
-@@ -546,4 +572,3 @@ I2C
+@@ -539,4 +565,3 @@ I2C
  	};
  
  };
 -
-
-From 49c65a7f1c91517d56efdbe72a046b64b687664c Mon Sep 17 00:00:00 2001
-From: Jonas Karlman <jonas@kwiboo.se>
-Date: Wed, 17 Jan 2018 22:17:45 +0100
-Subject: [PATCH] arm64: dts: rockchip: rk3328: update dtsi
-
----
- arch/arm64/boot/dts/rockchip/rk3328.dtsi | 68 ++++++++++++++++++++++++++------
- 1 file changed, 56 insertions(+), 12 deletions(-)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3328.dtsi b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
-index 0d2251c903b1..b7b6f9304706 100644
---- a/arch/arm64/boot/dts/rockchip/rk3328.dtsi
-+++ b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
-@@ -88,6 +88,8 @@
- 			device_type = "cpu";
- 			compatible = "arm,cortex-a53", "arm,armv8";
- 			reg = <0x0 0x1>;
-+			clocks = <&cru ARMCLK>;
-+			dynamic-power-coefficient = <120>;
- 			enable-method = "psci";
- 			operating-points-v2 = <&cpu0_opp_table>;
- 		};
-@@ -95,6 +97,8 @@
- 			device_type = "cpu";
- 			compatible = "arm,cortex-a53", "arm,armv8";
- 			reg = <0x0 0x2>;
-+			clocks = <&cru ARMCLK>;
-+			dynamic-power-coefficient = <120>;
- 			enable-method = "psci";
- 			operating-points-v2 = <&cpu0_opp_table>;
- 		};
-@@ -102,6 +106,8 @@
- 			device_type = "cpu";
- 			compatible = "arm,cortex-a53", "arm,armv8";
- 			reg = <0x0 0x3>;
-+			clocks = <&cru ARMCLK>;
-+			dynamic-power-coefficient = <120>;
- 			enable-method = "psci";
- 			operating-points-v2 = <&cpu0_opp_table>;
- 		};
-@@ -161,6 +167,22 @@
- 			opp-microvolt-L1 = <1300000 1300000 1350000>;
- 			clock-latency-ns = <40000>;
- 		};
-+		/*
-+		opp-1392000000 {
-+			opp-hz = /bits/ 64 <1392000000>;
-+			opp-microvolt = <1350000 1350000 1350000>;
-+			opp-microvolt-L0 = <1350000 1350000 1350000>;
-+			opp-microvolt-L1 = <1325000 1325000 1350000>;
-+			clock-latency-ns = <40000>;
-+		};
-+		opp-1512000000 {
-+			opp-hz = /bits/ 64 <1512000000>;
-+			opp-microvolt = <1350000 1350000 1350000>;
-+			opp-microvolt-L0 = <1350000 1350000 1350000>;
-+			opp-microvolt-L1 = <1325000 1325000 1350000>;
-+			clock-latency-ns = <40000>;
-+		};
-+		*/
- 	};
+diff --git a/arch/arm/boot/dts/rk3288.dtsi b/arch/arm/boot/dts/rk3288.dtsi
+index 9c910b2edb3b..9ece8f3a2dcf 100644
+--- a/arch/arm/boot/dts/rk3288.dtsi
++++ b/arch/arm/boot/dts/rk3288.dtsi
+@@ -354,49 +354,57 @@
  
- 	arm-pmu {
-@@ -438,6 +460,7 @@
- 		reg-shift = <2>;
- 		reg-io-width = <4>;
- 		dmas = <&dmac 2>, <&dmac 3>;
-+		dma-names = "tx", "rx";
- 		pinctrl-names = "default";
- 		pinctrl-0 = <&uart0_xfer &uart0_cts &uart0_rts>;
- 		status = "disabled";
-@@ -452,6 +475,7 @@
- 		reg-shift = <2>;
- 		reg-io-width = <4>;
- 		dmas = <&dmac 4>, <&dmac 5>;
-+		dma-names = "tx", "rx";
- 		pinctrl-names = "default";
- 		pinctrl-0 = <&uart1_xfer &uart1_cts &uart1_rts>;
- 		status = "disabled";
-@@ -466,6 +490,7 @@
- 		reg-shift = <2>;
- 		reg-io-width = <4>;
- 		dmas = <&dmac 6>, <&dmac 7>;
-+		dma-names = "tx", "rx";
- 		pinctrl-names = "default";
- 		pinctrl-0 = <&uart2m1_xfer>;
- 		status = "disabled";
-@@ -704,9 +729,9 @@
- 		};
- 		opp-300000000 {
- 			opp-hz = /bits/ 64 <300000000>;
--			opp-microvolt = <975000>;
--			opp-microvolt-L0 = <975000>;
--			opp-microvolt-L1 = <950000>;
-+			opp-microvolt = <1050000>;
-+			opp-microvolt-L0 = <1050000>;
-+			opp-microvolt-L1 = <1025000>;
- 		};
- 		opp-400000000 {
- 			opp-hz = /bits/ 64 <400000000>;
-@@ -720,6 +745,14 @@
- 			opp-microvolt-L0 = <1150000>;
- 			opp-microvolt-L1 = <1100000>;
- 		};
-+		/*
-+		opp-600000000 {
-+			opp-hz = /bits/ 64 <600000000>;
-+			opp-microvolt = <1150000>;
-+			opp-microvolt-L0 = <1150000>;
-+			opp-microvolt-L1 = <1125000>;
-+		};
-+		*/
- 	};
- 
- 	vdpu: vpu_service@ff350000 {
-@@ -843,7 +876,7 @@
- 		interrupts = <GIC_SPI 74 IRQ_TYPE_LEVEL_HIGH>;
- 		interrupt-names = "rkvdec_mmu";
- 		clocks = <&cru ACLK_RKVDEC>, <&cru HCLK_RKVDEC>;
--		clock-names = "aclk_vcodec", "hclk_vcodec";
-+		clock-names = "aclk", "hclk";
- 		power-domains = <&power RK3328_PD_VIDEO>;
- 		#iommu-cells = <0>;
- 	};
-@@ -921,6 +954,8 @@
- 	vop: vop@ff370000 {
- 		compatible = "rockchip,rk3328-vop";
- 		reg = <0x0 0xff370000 0x0 0x3efc>;
-+		reg-names = "regs", "gamma_lut";
-+		rockchip,grf = <&grf>;
- 		interrupts = <GIC_SPI 32 IRQ_TYPE_LEVEL_HIGH>;
- 		clocks = <&cru ACLK_VOP>, <&cru DCLK_LCDC>, <&cru HCLK_VOP>;
- 		clock-names = "aclk_vop", "dclk_vop", "hclk_vop";
-@@ -1275,6 +1316,7 @@
- 			      "pclk_mac";
- 		resets = <&cru SRST_GMAC2IO_A>;
- 		reset-names = "stmmaceth";
-+		snps,force_thresh_dma_mode;
- 		status = "disabled";
- 	};
- 
-@@ -1345,12 +1387,14 @@
- 	sdmmc_ext: dwmmc@ff5f0000 {
- 		compatible = "rockchip,rk3328-dw-mshc", "rockchip,rk3288-dw-mshc";
- 		reg = <0x0 0xff5f0000 0x0 0x4000>;
+ 	sdmmc: dwmmc@ff0c0000 {
+ 		compatible = "rockchip,rk3288-dw-mshc";
 -		clock-freq-min-max = <400000 150000000>;
 +		max-frequency = <150000000>;
- 		clocks = <&cru HCLK_SDMMC_EXT>, <&cru SCLK_SDMMC_EXT>,
- 			 <&cru SCLK_SDMMC_EXT_DRV>, <&cru SCLK_SDMMC_EXT_SAMPLE>;
--		clock-names = "biu", "ciu", "ciu-drv", "ciu-sample";
-+		clock-names = "biu", "ciu", "ciu-drive", "ciu-sample";
+ 		clocks = <&cru HCLK_SDMMC>, <&cru SCLK_SDMMC>,
+ 			 <&cru SCLK_SDMMC_DRV>, <&cru SCLK_SDMMC_SAMPLE>;
+ 		clock-names = "biu", "ciu", "ciu-drive", "ciu-sample";
  		fifo-depth = <0x100>;
- 		interrupts = <GIC_SPI 4 IRQ_TYPE_LEVEL_HIGH>;
-+		resets = <&cru SRST_SDMMCEXT>;
+ 		interrupts = <GIC_SPI 32 IRQ_TYPE_LEVEL_HIGH>;
+ 		reg = <0x0 0xff0c0000 0x0 0x4000>;
++		resets = <&cru SRST_MMC0>;
 +		reset-names = "reset";
  		status = "disabled";
  	};
  
-
-From bffef35a0fe1b0cd133c32569b448575ae422be5 Mon Sep 17 00:00:00 2001
-From: Jonas Karlman <jonas@kwiboo.se>
-Date: Wed, 17 Jan 2018 22:17:45 +0100
-Subject: [PATCH] arm64: dts: rockchip: rk3328-rock64: update dts
-
----
- arch/arm64/boot/dts/rockchip/rk3328-rock64.dts | 262 ++++++++++++++++---------
- 1 file changed, 168 insertions(+), 94 deletions(-)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3328-rock64.dts b/arch/arm64/boot/dts/rockchip/rk3328-rock64.dts
-index 4b2eef609601..ff90c5379671 100644
---- a/arch/arm64/boot/dts/rockchip/rk3328-rock64.dts
-+++ b/arch/arm64/boot/dts/rockchip/rk3328-rock64.dts
-@@ -48,20 +48,15 @@
- 	compatible = "pine64,rock64", "rockchip,rk3328";
- 
- 	chosen {
--		bootargs = "rockchip_jtag earlycon=uart8250-32bit,0xff130000 swiotlb=1 kpti=0 coherent_pool=1m";
-+		bootargs = "earlycon=uart8250-32bit,0xff130000 swiotlb=1 kpti=0 coherent_pool=1m";
- 		stdout-path = "serial2:1500000n8";
+ 	sdio0: dwmmc@ff0d0000 {
+ 		compatible = "rockchip,rk3288-dw-mshc";
+-		clock-freq-min-max = <400000 150000000>;
++		max-frequency = <150000000>;
+ 		clocks = <&cru HCLK_SDIO0>, <&cru SCLK_SDIO0>,
+ 			 <&cru SCLK_SDIO0_DRV>, <&cru SCLK_SDIO0_SAMPLE>;
+ 		clock-names = "biu", "ciu", "ciu-drive", "ciu-sample";
+ 		fifo-depth = <0x100>;
+ 		interrupts = <GIC_SPI 33 IRQ_TYPE_LEVEL_HIGH>;
+ 		reg = <0x0 0xff0d0000 0x0 0x4000>;
++		resets = <&cru SRST_SDIO0>;
++		reset-names = "reset";
+ 		status = "disabled";
  	};
  
--	fiq-debugger {
--		compatible = "rockchip,fiq-debugger";
--		rockchip,serial-id = <2>;
--		rockchip,signal-irq = <159>;
--		rockchip,wake-irq = <0>;
--		/* If enable uart uses irq instead of fiq */
--		rockchip,irq-mode-enable = <0>;
--		rockchip,baudrate = <1500000>;  /* Only 115200 and 1500000 */
--		interrupts = <GIC_SPI 127 IRQ_TYPE_LEVEL_LOW>;
--		status = "okay";
+ 	sdio1: dwmmc@ff0e0000 {
+ 		compatible = "rockchip,rk3288-dw-mshc";
+-		clock-freq-min-max = <400000 150000000>;
++		max-frequency = <150000000>;
+ 		clocks = <&cru HCLK_SDIO1>, <&cru SCLK_SDIO1>,
+ 			 <&cru SCLK_SDIO1_DRV>, <&cru SCLK_SDIO1_SAMPLE>;
+ 		clock-names = "biu", "ciu", "ciu-drive", "ciu-sample";
+ 		fifo-depth = <0x100>;
+ 		interrupts = <GIC_SPI 34 IRQ_TYPE_LEVEL_HIGH>;
+ 		reg = <0x0 0xff0e0000 0x0 0x4000>;
++		resets = <&cru SRST_SDIO1>;
++		reset-names = "reset";
+ 		status = "disabled";
+ 	};
+ 
+ 	emmc: dwmmc@ff0f0000 {
+ 		compatible = "rockchip,rk3288-dw-mshc";
+-		clock-freq-min-max = <400000 150000000>;
++		max-frequency = <150000000>;
+ 		clocks = <&cru HCLK_EMMC>, <&cru SCLK_EMMC>,
+ 			 <&cru SCLK_EMMC_DRV>, <&cru SCLK_EMMC_SAMPLE>;
+ 		clock-names = "biu", "ciu", "ciu-drive", "ciu-sample";
+ 		fifo-depth = <0x100>;
+ 		interrupts = <GIC_SPI 35 IRQ_TYPE_LEVEL_HIGH>;
+ 		reg = <0x0 0xff0f0000 0x0 0x4000>;
++		resets = <&cru SRST_EMMC>;
++		reset-names = "reset";
+ 		status = "disabled";
+ 		supports-emmc;
+ 	};
+@@ -640,6 +648,7 @@
+ 		compatible = "rockchip,rk3288-tsadc";
+ 		reg = <0x0 0xff280000 0x0 0x100>;
+ 		interrupts = <GIC_SPI 37 IRQ_TYPE_LEVEL_HIGH>;
++		rockchip,grf = <&grf>;
+ 		clocks = <&cru SCLK_TSADC>, <&cru PCLK_TSADC>;
+ 		clock-names = "tsadc", "apb_pclk";
+ 		assigned-clocks = <&cru SCLK_TSADC>;
+@@ -648,7 +657,7 @@
+ 		reset-names = "tsadc-apb";
+ 		pinctrl-names = "gpio", "otpout";
+ 		pinctrl-0 = <&otp_gpio>;
+-		pinctrl-1 = <&otp_gpio>;
++		pinctrl-1 = <&otp_out>;
+ 		#thermal-sensor-cells = <1>;
+ 		rockchip,hw-tshut-temp = <120000>;
+ 		rockchip,hw-tshut-mode = <0>; /* tshut mode 0:CRU 1:GPIO */
+@@ -974,6 +983,7 @@
+ 					 <&cru SCLK_EDP_24M>,
+ 					 <&cru SCLK_EDP>,
+ 					 <&cru SCLK_HDMI_CEC>,
++					 <&cru SCLK_HDMI_HDCP>,
+ 					 <&cru SCLK_ISP_JPE>,
+ 					 <&cru SCLK_ISP>,
+ 					 <&cru SCLK_RGA>;
+@@ -1672,7 +1682,7 @@
+ 		clocks = <&cru  PCLK_HDMI_CTRL>, <&cru SCLK_HDMI_HDCP>, <&cru SCLK_HDMI_CEC>;
+ 		clock-names = "iahb", "isfr", "cec";
+ 		pinctrl-names = "default", "sleep";
+-		pinctrl-0 = <&hdmi_ddc>;
++		pinctrl-0 = <&hdmi_ddc &hdmi_cec_c0>;
+ 		pinctrl-1 = <&hdmi_gpio>;
+ 		power-domains = <&power RK3288_PD_VIO>;
+ 		status = "disabled";
+@@ -1798,6 +1808,7 @@
+ 		operating-points-v2 = <&gpu_opp_table>;
+ 		#cooling-cells = <2>; /* min followed by max */
+ 		power-domains = <&power RK3288_PD_GPU>;
++		power-off-delay-ms = <200>;
+ 		status = "disabled";
+ 
+ 		upthreshold = <75>;
+@@ -2069,10 +2080,14 @@
+ 						 &pcfg_pull_none>;
+ 			};
+ 
+-			hdmi_cec: hdmi-cec {
++			hdmi_cec_c0: hdmi-cec-c0 {
+ 				rockchip,pins = <7 16 RK_FUNC_2 &pcfg_pull_none>;
+ 			};
+ 
++			hdmi_cec_c7: hdmi-cec-c7 {
++				rockchip,pins = <7 23 RK_FUNC_4 &pcfg_pull_none>;
++			};
++
+ 			hdmi_ddc: hdmi-ddc {
+ 				rockchip,pins = <7 19 RK_FUNC_2 &pcfg_pull_none>,
+ 						<7 20 RK_FUNC_2 &pcfg_pull_none>;
+diff --git a/arch/arm/boot/dts/rk3288-evb-rk808-linux.dts b/arch/arm/boot/dts/rk3288-evb-rk808-linux.dts
+index 1c94ef3c811a..f942c4941aef 100644
+--- a/arch/arm/boot/dts/rk3288-evb-rk808-linux.dts
++++ b/arch/arm/boot/dts/rk3288-evb-rk808-linux.dts
+@@ -296,7 +296,7 @@
+ };
+ 
+ &hdmi {
+-	pinctrl-0 = <&hdmi_ddc>, <&hdmi_cec>;
++	pinctrl-0 = <&hdmi_ddc>, <&hdmi_cec_c0>;
+ };
+ 
+ &i2c0 {
+diff --git a/arch/arm64/boot/dts/rockchip/rk3328-box-trn9.dts b/arch/arm64/boot/dts/rockchip/rk3328-box-trn9.dts
+new file mode 100644
+index 000000000000..81ec7b66e199
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3328-box-trn9.dts
+@@ -0,0 +1,702 @@
++/*
++ * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd
++ *
++ * This file is dual-licensed: you can use it either under the terms
++ * of the GPL or the X11 license, at your option. Note that this dual
++ * licensing only applies to this file, and not this project as a
++ * whole.
++ *
++ *  a) This library is free software; you can redistribute it and/or
++ *     modify it under the terms of the GNU General Public License as
++ *     published by the Free Software Foundation; either version 2 of the
++ *     License, or (at your option) any later version.
++ *
++ *     This library is distributed in the hope that it will be useful,
++ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *     GNU General Public License for more details.
++ *
++ * Or, alternatively,
++ *
++ *  b) Permission is hereby granted, free of charge, to any person
++ *     obtaining a copy of this software and associated documentation
++ *     files (the "Software"), to deal in the Software without
++ *     restriction, including without limitation the rights to use,
++ *     copy, modify, merge, publish, distribute, sublicense, and/or
++ *     sell copies of the Software, and to permit persons to whom the
++ *     Software is furnished to do so, subject to the following
++ *     conditions:
++ *
++ *     The above copyright notice and this permission notice shall be
++ *     included in all copies or substantial portions of the Software.
++ *
++ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
++ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
++ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
++ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
++ *     OTHER DEALINGS IN THE SOFTWARE.
++ */
++
++/dts-v1/;
++#include "rk3328.dtsi"
++#include "rk3328-dram-box-plus-timing.dtsi"
++
++/ {
++	model = "Rockchip RK3328 TRN9";
++	compatible = "rockchip,rk3328-box-trn9", "rockchip,rk3328";
++
++	chosen {
++		bootargs = "swiotlb=1 kpti=0";
++	};
++
++	aliases {
++		serial0 = &uart2;
++		serial2 = &uart0;
++	};
++
 +	xin32k: xin32k {
 +		compatible = "fixed-clock";
 +		clock-frequency = <32768>;
 +		clock-output-names = "xin32k";
 +		#clock-cells = <0>;
- 	};
- 
- 	gmac_clkin: external-gmac-clock {
-@@ -71,67 +66,86 @@
- 		#clock-cells = <0>;
- 	};
- 
++	};
++
++	gmac_clkin: external-gmac-clock {
++		compatible = "fixed-clock";
++		clock-frequency = <125000000>;
++		clock-output-names = "gmac_clkin";
++		#clock-cells = <0>;
++	};
++
 +	vcc_phy: vcc-phy-regulator {
 +		compatible = "regulator-fixed";
 +		regulator-name = "vcc_phy";
@@ -657,80 +589,61 @@ index 4b2eef609601..ff90c5379671 100644
 +		regulator-max-microvolt = <5000000>;
 +	};
 +
- 	vcc_sd: sdmmc-regulator {
- 		compatible = "regulator-fixed";
--		gpio = <&gpio0 30 GPIO_ACTIVE_LOW>;
++	vcc_sd: sdmmc-regulator {
++		compatible = "regulator-fixed";
 +		gpio = <&gpio0 RK_PD6 GPIO_ACTIVE_LOW>;
- 		pinctrl-names = "default";
- 		pinctrl-0 = <&sdmmc0m1_gpio>;
- 		regulator-name = "vcc_sd";
++		pinctrl-names = "default";
++		pinctrl-0 = <&sdmmc0m1_gpio>;
++		regulator-name = "vcc_sd";
 +		regulator-always-on;
 +		regulator-boot-on;
- 		regulator-min-microvolt = <3300000>;
- 		regulator-max-microvolt = <3300000>;
- 		vin-supply = <&vcc_io>;
- 	};
- 
--	vcc_host_5v: vcc-host-5v-regulator {
-+	vcc_host_5v: vcc_otg_5v: vcc-host-5v-regulator {
- 		compatible = "regulator-fixed";
--		enable-active-high;
--		gpio = <&gpio0 0 GPIO_ACTIVE_HIGH>;
-+		gpio = <&gpio0 RK_PA2 GPIO_ACTIVE_LOW>;
- 		pinctrl-names = "default";
--		pinctrl-0 = <&usb30_host_drv>;
-+		pinctrl-0 = <&usb_host_drv>;
- 		regulator-name = "vcc_host_5v";
--		regulator-always-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc_io>;
++	};
++
++	vcc_host_5v: vcc-host-5v-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio0 RK_PA0 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&usb30_host_drv>;
++		regulator-name = "vcc_host_5v";
++		regulator-always-on;
 +		regulator-min-microvolt = <5000000>;
 +		regulator-max-microvolt = <5000000>;
- 		vin-supply = <&vcc_sys>;
- 	};
- 
--	vcc_host1_5v: vcc_otg_5v: vcc-host1-5v-regulator {
--		compatible = "regulator-fixed";
--		enable-active-high;
--		gpio = <&gpio0 27 GPIO_ACTIVE_HIGH>;
--		pinctrl-names = "default";
--		pinctrl-0 = <&usb20_host_drv>;
--		regulator-name = "vcc_host1_5v";
--		regulator-always-on;
--		vin-supply = <&vcc_sys>;
--	};
++		vin-supply = <&vcc_sys>;
++	};
++
++	vcc_host1_5v: vcc_otg_5v: vcc-host1-5v-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio0 RK_PA2 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&usb20_host_drv>;
++		regulator-name = "vcc_host1_5v";
++		regulator-always-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc_sys>;
++	};
++
 +	leds {
 +		compatible = "gpio-leds";
- 
--	vcc_sys: vcc-sys {
--		compatible = "regulator-fixed";
--		regulator-name = "vcc_sys";
--		regulator-always-on;
--		regulator-boot-on;
--		regulator-min-microvolt = <5000000>;
--		regulator-max-microvolt = <5000000>;
--	};
-+		standby-led {
++
++		power {
 +			gpios = <&rk805 0 GPIO_ACTIVE_LOW>;
-+			linux,default-trigger = "heartbeat";
++			linux,default-trigger = "default-on";
++			default-state = "on";
 +		};
- 
--	xin32k: xin32k {
--		compatible = "fixed-clock";
--		clock-frequency = <32768>;
--		clock-output-names = "xin32k";
--		#clock-cells = <0>;
-+		power-led {
-+			gpios = <&rk805 1 GPIO_ACTIVE_LOW>;
-+			linux,default-trigger = "mmc0";
-+		};
- 	};
- 
- 	ir-receiver {
- 		compatible = "gpio-ir-receiver";
++	};
++
++	ir-receiver {
++		compatible = "gpio-ir-receiver";
 +		gpios = <&gpio2 RK_PA2 GPIO_ACTIVE_LOW>;
-+		linux,rc-map-name = "rc-pine64";
- 		pinctrl-0 = <&ir_int>;
- 		pinctrl-names = "default";
--		status = "okay";
++		linux,rc-map-name = "rc-trn9";
++		pinctrl-0 = <&ir_int>;
++		pinctrl-names = "default";
 +	};
 +
 +	hdmi-sound {
@@ -744,97 +657,154 @@ index 4b2eef609601..ff90c5379671 100644
 +		simple-audio-card,codec {
 +			sound-dai = <&hdmi>;
 +		};
- 	};
- 
- 	sound {
- 		compatible = "simple-audio-card";
- 		simple-audio-card,format = "i2s";
- 		simple-audio-card,mclk-fs = <256>;
--		simple-audio-card,name = "rockchip,rk3328";
++	};
++
++	sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,mclk-fs = <256>;
 +		simple-audio-card,name = "I2S";
- 		simple-audio-card,cpu {
- 			sound-dai = <&i2s1>;
- 		};
-@@ -140,18 +154,21 @@
- 		};
- 	};
- 
--	hdmi-sound {
++		simple-audio-card,cpu {
++			sound-dai = <&i2s1>;
++		};
++		simple-audio-card,codec {
++			sound-dai = <&codec>;
++		};
++	};
++
 +	spdif-sound {
- 		compatible = "simple-audio-card";
--		simple-audio-card,format = "i2s";
--		simple-audio-card,mclk-fs = <128>;
--		simple-audio-card,name = "rockchip,hdmi";
++		compatible = "simple-audio-card";
 +		simple-audio-card,name = "SPDIF";
- 		simple-audio-card,cpu {
--			sound-dai = <&i2s0>;
++		simple-audio-card,cpu {
 +			sound-dai = <&spdif>;
- 		};
- 		simple-audio-card,codec {
--			sound-dai = <&hdmi>;
++		};
++		simple-audio-card,codec {
 +			sound-dai = <&spdif_out>;
- 		};
- 	};
++		};
++	};
 +
 +	spdif_out: spdif-out {
 +		compatible = "linux,spdif-dit";
 +		#sound-dai-cells = <0>;
 +	};
- };
- 
- &codec {
-@@ -175,6 +192,15 @@
- 	cpu-supply = <&vdd_arm>;
- };
- 
++
++	sdio_pwrseq: sdio-pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		pinctrl-names = "default";
++		pinctrl-0 = <&wifi_enable_h>;
++
++		/*
++		 * On the module itself this is one of these (depending
++		 * on the actual card populated):
++		 * - SDIO_RESET_L_WL_REG_ON
++		 * - PDN (power down when low)
++		 */
++		reset-gpios = <&gpio3 RK_PB0 GPIO_ACTIVE_LOW>;
++	};
++
++	wireless-bluetooth {
++		compatible = "bluetooth-platdata";
++		BT,power_gpio = <&gpio1 RK_PD0 GPIO_ACTIVE_HIGH>;
++		BT,wake_host_irq = <&gpio1 RK_PD2 GPIO_ACTIVE_HIGH>;
++	};
++
++	wireless-wlan {
++		compatible = "wlan-platdata";
++		rockchip,grf = <&grf>;
++		wifi_chip_type = "rtl8723bs";
++		WIFI,host_wake_irq = <&gpio3 RK_PA1 GPIO_ACTIVE_HIGH>;
++	};
++};
++
++&codec {
++	#sound-dai-cells = <0>;
++	status = "okay";
++};
++
++&cpu0 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&cpu1 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&cpu2 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&cpu3 {
++	cpu-supply = <&vdd_arm>;
++};
++
 +&dfi {
 +	status = "okay";
 +};
 +
 +&dmc {
 +	center-supply = <&vdd_logic>;
++	system-status-freq = <
++		/*system status         freq(KHz)*/
++		SYS_STATUS_NORMAL       1066000
++		SYS_STATUS_REBOOT       1066000
++		SYS_STATUS_SUSPEND      1066000
++		SYS_STATUS_VIDEO_1080P  1066000
++		SYS_STATUS_VIDEO_4K     1066000
++		SYS_STATUS_VIDEO_4K_10B 1066000
++		SYS_STATUS_PERFORMANCE  1066000
++		SYS_STATUS_BOOST        1066000
++	>;
 +	status = "okay";
 +};
 +
- &display_subsystem {
- 	status = "okay";
- };
-@@ -184,30 +210,40 @@
- 	cap-mmc-highspeed;
- 	mmc-hs200-1_8v;
- 	non-removable;
--	supports-emmc;
- 	pinctrl-names = "default";
- 	pinctrl-0 = <&emmc_clk &emmc_cmd &emmc_bus8>;
++&dmc_opp_table {
++	opp-933000000 {
++		opp-hz = /bits/ 64 <933000000>;
++		opp-microvolt = <1150000>;
++		opp-microvolt-L0 = <1150000>;
++		opp-microvolt-L1 = <1100000>;
++	};
++	opp-1066000000 {
++		opp-hz = /bits/ 64 <1066000000>;
++		opp-microvolt = <1200000>;
++		opp-microvolt-L0 = <1200000>;
++		opp-microvolt-L1 = <1175000>;
++	};
++};
++
++&display_subsystem {
++	status = "okay";
++};
++
++&emmc {
++	bus-width = <8>;
++	cap-mmc-highspeed;
++	mmc-hs200-1_8v;
++	non-removable;
++	pinctrl-names = "default";
++	pinctrl-0 = <&emmc_clk &emmc_cmd &emmc_bus8>;
 +	supports-emmc;
- 	vmmc-supply = <&vcc_io>;
- 	vqmmc-supply = <&vcc18_emmc>;
- 	status = "okay";
- };
- 
- &gmac2io {
--	phy-supply = <&vcc_io>;
--	phy-mode = "rgmii";
- 	assigned-clocks = <&cru SCLK_MAC2IO>, <&cru SCLK_MAC2IO_EXT>;
- 	assigned-clock-parents = <&gmac_clkin>, <&gmac_clkin>;
- 	clock_in_out = "input";
--	snps,reset-gpio = <&gpio1 18 GPIO_ACTIVE_LOW>;
--	snps,reset-active-low;
--	snps,reset-delays-us = <0 10000 50000>;
++	vmmc-supply = <&vcc_io>;
++	vqmmc-supply = <&vcc18_emmc>;
++	status = "okay";
++};
++
++&gmac2io {
++	assigned-clocks = <&cru SCLK_MAC2IO>, <&cru SCLK_MAC2IO_EXT>;
++	assigned-clock-parents = <&gmac_clkin>, <&gmac_clkin>;
++	clock_in_out = "input";
 +	phy-supply = <&vcc_phy>;
 +	phy-mode = "rgmii";
- 	pinctrl-names = "default";
- 	pinctrl-0 = <&rgmiim1_pins>;
--	tx_delay = <0x26>;
--	rx_delay = <0x11>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&rgmiim1_pins>;
 +	snps,reset-gpio = <&gpio1 RK_PC2 GPIO_ACTIVE_LOW>;
 +	snps,reset-active-low;
 +	snps,reset-delays-us = <0 10000 50000>;
-+	tx_delay = <0x24>;
-+	rx_delay = <0x18>;
- 	status = "okay";
- };
- 
++	tx_delay = <0x26>;
++	rx_delay = <0x11>;
++	status = "okay";
++};
++
 +&gmac2phy {
 +	phy-supply = <&vcc_phy>;
 +	assigned-clocks = <&cru SCLK_MAC2PHY_SRC>;
@@ -845,149 +815,186 @@ index 4b2eef609601..ff90c5379671 100644
 +	status = "disabled";
 +};
 +
- &gpu {
- 	status = "okay";
- 	mali-supply = <&vdd_logic>;
-@@ -223,6 +259,8 @@
- 
- &hdmi {
- 	#sound-dai-cells = <0>;
++&gpu {
++	status = "okay";
++	mali-supply = <&vdd_logic>;
++};
++
++&h265e {
++	status = "okay";
++};
++
++&h265e_mmu {
++	status = "okay";
++};
++
++&hdmi {
++	#sound-dai-cells = <0>;
 +	ddc-i2c-scl-high-time-ns = <9625>;
 +	ddc-i2c-scl-low-time-ns = <10000>;
- 	status = "okay";
- };
- 
-@@ -239,14 +277,14 @@
- 		reg = <0x18>;
- 		interrupt-parent = <&gpio2>;
- 		interrupts = <6 IRQ_TYPE_LEVEL_LOW>;
++	status = "okay";
++};
++
++&hdmiphy {
++	status = "okay";
++};
++
++&i2c1 {
++	status = "okay";
++
++	rk805: rk805@18 {
++		compatible = "rockchip,rk805";
++		status = "okay";
++		reg = <0x18>;
++		interrupt-parent = <&gpio2>;
++		interrupts = <6 IRQ_TYPE_LEVEL_LOW>;
 +		#clock-cells = <1>;
 +		clock-output-names = "rk805-clkout1", "rk805-clkout2";
- 		pinctrl-names = "default";
- 		pinctrl-0 = <&pmic_int_l>;
- 		rockchip,system-power-controller;
- 		wakeup-source;
- 		gpio-controller;
--		clock-output-names = "rk805-clkout1", "rk805-clkout2";
- 		#gpio-cells = <2>;
--		#clock-cells = <1>;
- 
- 		vcc1-supply = <&vcc_sys>;
- 		vcc2-supply = <&vcc_sys>;
-@@ -256,11 +294,11 @@
- 		vcc6-supply = <&vcc_sys>;
- 
- 		rtc {
--			status = "disabled";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pmic_int_l>;
++		rockchip,system-power-controller;
++		wakeup-source;
++		gpio-controller;
++		#gpio-cells = <2>;
++
++		vcc1-supply = <&vcc_sys>;
++		vcc2-supply = <&vcc_sys>;
++		vcc3-supply = <&vcc_sys>;
++		vcc4-supply = <&vcc_sys>;
++		vcc5-supply = <&vcc_io>;
++		vcc6-supply = <&vcc_sys>;
++
++		rtc {
 +			status = "okay";
- 		};
- 
- 		pwrkey {
--			status = "disabled";
++		};
++
++		pwrkey {
 +			status = "okay";
- 		};
- 
- 		gpio {
-@@ -280,8 +318,8 @@
- 				regulator-max-microvolt = <1450000>;
- 				regulator-initial-mode = <0x1>;
- 				regulator-ramp-delay = <12500>;
--				regulator-boot-on;
- 				regulator-always-on;
++		};
++
++		gpio {
++			status = "okay";
++		};
++
++		regulators {
++			compatible = "rk805-regulator";
++			status = "okay";
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			vdd_logic: RK805_DCDC1 {
++				regulator-compatible = "RK805_DCDC1";
++				regulator-name = "vdd_logic";
++				regulator-min-microvolt = <712500>;
++				regulator-max-microvolt = <1450000>;
++				regulator-initial-mode = <0x1>;
++				regulator-ramp-delay = <12500>;
++				regulator-always-on;
 +				regulator-boot-on;
- 				regulator-state-mem {
- 					regulator-mode = <0x2>;
- 					regulator-on-in-suspend;
-@@ -292,12 +330,13 @@
- 			vdd_arm: RK805_DCDC2 {
- 				regulator-compatible = "RK805_DCDC2";
- 				regulator-name = "vdd_arm";
++				regulator-state-mem {
++					regulator-mode = <0x2>;
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1000000>;
++				};
++			};
++
++			vdd_arm: RK805_DCDC2 {
++				regulator-compatible = "RK805_DCDC2";
++				regulator-name = "vdd_arm";
 +				regulator-init-microvolt = <1225000>;
- 				regulator-min-microvolt = <712500>;
- 				regulator-max-microvolt = <1450000>;
- 				regulator-initial-mode = <0x1>;
- 				regulator-ramp-delay = <12500>;
--				regulator-boot-on;
- 				regulator-always-on;
++				regulator-min-microvolt = <712500>;
++				regulator-max-microvolt = <1450000>;
++				regulator-initial-mode = <0x1>;
++				regulator-ramp-delay = <12500>;
++				regulator-always-on;
 +				regulator-boot-on;
- 				regulator-state-mem {
- 					regulator-mode = <0x2>;
- 					regulator-on-in-suspend;
-@@ -309,8 +348,8 @@
- 				regulator-compatible = "RK805_DCDC3";
- 				regulator-name = "vcc_ddr";
- 				regulator-initial-mode = <0x1>;
--				regulator-boot-on;
- 				regulator-always-on;
++				regulator-state-mem {
++					regulator-mode = <0x2>;
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <950000>;
++				};
++			};
++
++			vcc_ddr: RK805_DCDC3 {
++				regulator-compatible = "RK805_DCDC3";
++				regulator-name = "vcc_ddr";
++				regulator-initial-mode = <0x1>;
++				regulator-always-on;
 +				regulator-boot-on;
- 				regulator-state-mem {
- 					regulator-mode = <0x2>;
- 					regulator-on-in-suspend;
-@@ -323,8 +362,8 @@
- 				regulator-min-microvolt = <3300000>;
- 				regulator-max-microvolt = <3300000>;
- 				regulator-initial-mode = <0x1>;
--				regulator-boot-on;
- 				regulator-always-on;
++				regulator-state-mem {
++					regulator-mode = <0x2>;
++					regulator-on-in-suspend;
++				};
++			};
++
++			vcc_io: RK805_DCDC4 {
++				regulator-compatible = "RK805_DCDC4";
++				regulator-name = "vcc_io";
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-initial-mode = <0x1>;
++				regulator-always-on;
 +				regulator-boot-on;
- 				regulator-state-mem {
- 					regulator-mode = <0x2>;
- 					regulator-on-in-suspend;
-@@ -332,13 +371,13 @@
- 				};
- 			};
- 
--			vdd_18: RK805_LDO1 {
++				regulator-state-mem {
++					regulator-mode = <0x2>;
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++				};
++			};
++
 +			vcc_18: RK805_LDO1 {
- 				regulator-compatible = "RK805_LDO1";
--				regulator-name = "vdd_18";
++				regulator-compatible = "RK805_LDO1";
 +				regulator-name = "vcc_18";
- 				regulator-min-microvolt = <1800000>;
- 				regulator-max-microvolt = <1800000>;
--				regulator-boot-on;
- 				regulator-always-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-always-on;
 +				regulator-boot-on;
- 				regulator-state-mem {
- 					regulator-on-in-suspend;
- 					regulator-suspend-microvolt = <1800000>;
-@@ -350,8 +389,8 @@
- 				regulator-name = "vcc18_emmc";
- 				regulator-min-microvolt = <1800000>;
- 				regulator-max-microvolt = <1800000>;
--				regulator-boot-on;
- 				regulator-always-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vcc18_emmc: RK805_LDO2 {
++				regulator-compatible = "RK805_LDO2";
++				regulator-name = "vcc18_emmc";
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-always-on;
 +				regulator-boot-on;
- 				regulator-state-mem {
- 					regulator-on-in-suspend;
- 					regulator-suspend-microvolt = <1800000>;
-@@ -363,8 +402,8 @@
- 				regulator-name = "vdd_10";
- 				regulator-min-microvolt = <1000000>;
- 				regulator-max-microvolt = <1000000>;
--				regulator-boot-on;
- 				regulator-always-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vdd_10: RK805_LDO3 {
++				regulator-compatible = "RK805_LDO3";
++				regulator-name = "vdd_10";
++				regulator-min-microvolt = <1000000>;
++				regulator-max-microvolt = <1000000>;
++				regulator-always-on;
 +				regulator-boot-on;
- 				regulator-state-mem {
- 					regulator-on-in-suspend;
- 					regulator-suspend-microvolt = <1000000>;
-@@ -381,17 +420,35 @@
- };
- 
- &i2s1 {
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&i2s1_mclk
-+		     &i2s1_sclk
-+		     &i2s1_lrcktx
-+		     &i2s1_lrckrx
-+		     &i2s1_sdo
-+		     &i2s1_sdi
-+		     &i2s1_sdio1
-+		     &i2s1_sdio2
-+		     &i2s1_sdio3>;
- 	#sound-dai-cells = <0>;
- 	status = "okay";
- };
- 
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1000000>;
++				};
++			};
++		};
++	};
++};
++
++&i2s0 {
++	#sound-dai-cells = <0>;
++	rockchip,bclk-fs = <128>;
++	status = "okay";
++};
++
++&i2s1 {
++	#sound-dai-cells = <0>;
++	status = "okay";
++};
++
 +&iep {
 +	status = "okay";
 +};
@@ -996,70 +1003,95 @@ index 4b2eef609601..ff90c5379671 100644
 +	status = "okay";
 +};
 +
- &io_domains {
- 	status = "okay";
- 
- 	vccio1-supply = <&vcc_io>;
- 	vccio2-supply = <&vcc18_emmc>;
- 	vccio3-supply = <&vcc_io>;
--	vccio4-supply = <&vdd_18>;
++&io_domains {
++	status = "okay";
++
++	vccio1-supply = <&vcc_io>;
++	vccio2-supply = <&vcc18_emmc>;
++	vccio3-supply = <&vcc_io>;
 +	vccio4-supply = <&vcc_18>;
- 	vccio5-supply = <&vcc_io>;
- 	vccio6-supply = <&vcc_io>;
- 	pmuio-supply = <&vcc_io>;
-@@ -400,37 +457,26 @@
- &pinctrl {
- 	ir {
- 		ir_int: ir-int {
--			rockchip,pins = <2 2 RK_FUNC_GPIO &pcfg_pull_none>;
++	vccio5-supply = <&vcc_io>;
++	vccio6-supply = <&vcc_18>;
++	pmuio-supply = <&vcc_io>;
++};
++
++&pinctrl {
++	pinctrl-names = "default";
++	pinctrl-0 = <&clk_32k_out>;
++
++	clk_32k {
++		clk_32k_out: clk-32k-out {
++			rockchip,pins = <1 RK_PD4 RK_FUNC_1 &pcfg_pull_none>;
++		};
++	};
++
++	ir {
++		ir_int: ir-int {
 +			rockchip,pins = <2 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
- 		};
- 	};
- 
- 	pmic {
- 		pmic_int_l: pmic-int-l {
--			rockchip,pins = <2 6 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	pmic {
++		pmic_int_l: pmic-int-l {
 +			rockchip,pins = <2 RK_PA6 RK_FUNC_GPIO &pcfg_pull_up>;
- 		};
- 	};
- 
--	sdio-pwrseq {
--		wifi_enable_h: wifi-enable-h {
--			rockchip,pins = <1 18 RK_FUNC_GPIO &pcfg_pull_none>;
--		};
--	};
--
--	usb2 {
--		usb20_host_drv: usb20-host-drv {
--			rockchip,pins = <0 27 RK_FUNC_GPIO &pcfg_pull_none>;
--		};
--	};
--
--	usb3 {
--		usb30_host_drv: usb30-host-drv {
--			rockchip,pins = <0 0 RK_FUNC_GPIO &pcfg_pull_none>;
-+	usb {
-+		usb_host_drv: usb-host-drv {
++		};
++	};
++
++	sdio-pwrseq {
++		wifi_enable_h: wifi-enable-h {
++			rockchip,pins = <3 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>,
++				<3 RK_PA1 RK_FUNC_GPIO &pcfg_pull_none_4ma>,
++				<1 RK_PD0 RK_FUNC_GPIO &pcfg_pull_none>,
++				<1 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	usb2 {
++		usb20_host_drv: usb20-host-drv {
 +			rockchip,pins = <0 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
- 		};
- 	};
- };
- 
- &rkvdec {
- 	status = "okay";
++		};
++	};
++
++	usb3 {
++		usb30_host_drv: usb30-host-drv {
++			rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++};
++
++&rkvdec {
++	status = "okay";
 +	vcodec-supply = <&vdd_logic>;
- };
- 
- &rkvdec_mmu {
-@@ -442,11 +488,17 @@
- 	cap-mmc-highspeed;
- 	cap-sd-highspeed;
- 	disable-wp;
--	max-frequency = <150000000>;
- 	pinctrl-names = "default";
- 	pinctrl-0 = <&sdmmc0_clk &sdmmc0_cmd &sdmmc0_dectn &sdmmc0_bus4>;
--	vmmc-supply = <&vcc_sd>;
- 	supports-sd;
++};
++
++&rkvdec_mmu {
++	status = "okay";
++};
++
++&sdmmc_ext {
++	bus-width = <4>;
++	cap-sd-highspeed;
++	cap-sdio-irq;
++	disable-wp;
++	keep-power-in-suspend;
++	mmc-pwrseq = <&sdio_pwrseq>;
++	non-removable;
++	num-slots = <1>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdmmc0ext_bus4 &sdmmc0ext_cmd &sdmmc0ext_clk>;
++	sd-uhs-sdr104;
++	supports-sdio;
++	status = "okay";
++};
++
++&sdmmc {
++	bus-width = <4>;
++	cap-mmc-highspeed;
++	cap-sd-highspeed;
++	disable-wp;
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdmmc0_clk &sdmmc0_cmd &sdmmc0_dectn &sdmmc0_bus4>;
++	supports-sd;
 +	vmmc-supply = <&vcc_sd>;
 +	status = "okay";
 +};
@@ -1068,35 +1100,9 @@ index 4b2eef609601..ff90c5379671 100644
 +	#sound-dai-cells = <0>;
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&spdifm0_tx>;
- 	status = "okay";
- };
- 
-@@ -454,19 +506,43 @@
- 	status = "okay";
- 
- 	flash@0 {
--		compatible = "gigadevice,gd25q128", "jedec,spi-nor";
-+		compatible = "jedec,spi-nor";
- 		#address-cells = <1>;
- 		#size-cells = <1>;
- 		reg = <0>;
- 		m25p,fast-read;
- 		/* The max SCLK of the flash 104/80 MHZ  */
- 		spi-max-frequency = <50000000>;
++	status = "okay";
++};
 +
-+		partitions {
-+			compatible = "fixed-partitions";
-+			#address-cells = <1>;
-+			#size-cells = <1>;
-+
-+			loader@8000 {
-+				label = "loader";
-+				reg = <0x8000 0x3F0000>;
-+			};
-+		};
- 	};
- };
- 
 +&threshold {
 +	temperature = <80000>; /* millicelsius */
 +};
@@ -1109,48 +1115,697 @@ index 4b2eef609601..ff90c5379671 100644
 +	temperature = <100000>; /* millicelsius */
 +};
 +
- &tsadc {
- 	rockchip,hw-tshut-mode = <0>;
- 	rockchip,hw-tshut-polarity = <0>;
++&tsadc {
++	rockchip,hw-tshut-mode = <0>;
++	rockchip,hw-tshut-polarity = <0>;
 +	rockchip,hw-tshut-temp = <110000>;
- 	status = "okay";
- };
- 
-@@ -476,21 +552,19 @@
- 
- &u2phy {
- 	status = "okay";
--
- };
- 
- &u2phy_host {
--	phy-supply = <&vcc_host1_5v>;
- 	status = "okay";
- };
- 
- &u2phy_otg {
--	phy-supply = <&vcc_otg_5v>;
-+	vbus-supply = <&vcc_otg_5v>;
- 	status = "okay";
- };
- 
- &u3phy {
--	phy-supply = <&vcc_host_5v>;
-+	vbus-supply = <&vcc_host_5v>;
- 	status = "okay";
- };
- 
-
-From ed7848e24407cd2a65e524c46ba8fbb92db2bdc5 Mon Sep 17 00:00:00 2001
-From: Jonas Karlman <jonas@kwiboo.se>
-Date: Wed, 17 Jan 2018 22:17:45 +0100
-Subject: [PATCH] arm64: dts: rockchip: add rk3328-box board
-
----
- arch/arm64/boot/dts/rockchip/rk3328-box.dts | 648 ++++++++++++++++++++++++++++
- 1 file changed, 648 insertions(+)
- create mode 100644 arch/arm64/boot/dts/rockchip/rk3328-box.dts
-
++	status = "okay";
++};
++
++&uart2 {
++	status = "okay";
++};
++
++&u2phy {
++	status = "okay";
++};
++
++&u2phy_host {
++	phy-supply = <&vcc_host1_5v>;
++	status = "okay";
++};
++
++&u2phy_otg {
++	phy-supply = <&vcc_otg_5v>;
++	status = "okay";
++};
++
++&u3phy {
++	status = "okay";
++};
++
++&u3phy_utmi {
++	phy-supply = <&vcc_host_5v>;
++	status = "okay";
++};
++
++&u3phy_pipe {
++	phy-supply = <&vcc_host_5v>;
++	status = "okay";
++};
++
++&usb20_otg {
++	dr_mode = "host";
++	status = "okay";
++};
++
++&usb_host0_ehci {
++	status = "okay";
++};
++
++&usb_host0_ohci {
++	status = "okay";
++};
++
++&usbdrd3 {
++	status = "okay";
++};
++
++&usbdrd_dwc3 {
++	status = "okay";
++};
++
++&vop {
++	status = "okay";
++};
++
++&vop_mmu {
++	status = "okay";
++};
++
++&vpu_service {
++	status = "okay";
++};
++
++&vpu_mmu {
++	status = "okay";
++};
++
++&vepu {
++	status = "okay";
++};
++
++&vepu_mmu {
++	status = "okay";
++};
++
++&venc_srv {
++	status = "okay";
++};
+diff --git a/arch/arm64/boot/dts/rockchip/rk3328-box-z28.dts b/arch/arm64/boot/dts/rockchip/rk3328-box-z28.dts
+new file mode 100644
+index 000000000000..00a3394cefcb
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3328-box-z28.dts
+@@ -0,0 +1,598 @@
++/*
++ * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd
++ *
++ * This file is dual-licensed: you can use it either under the terms
++ * of the GPL or the X11 license, at your option. Note that this dual
++ * licensing only applies to this file, and not this project as a
++ * whole.
++ *
++ *  a) This library is free software; you can redistribute it and/or
++ *     modify it under the terms of the GNU General Public License as
++ *     published by the Free Software Foundation; either version 2 of the
++ *     License, or (at your option) any later version.
++ *
++ *     This library is distributed in the hope that it will be useful,
++ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *     GNU General Public License for more details.
++ *
++ * Or, alternatively,
++ *
++ *  b) Permission is hereby granted, free of charge, to any person
++ *     obtaining a copy of this software and associated documentation
++ *     files (the "Software"), to deal in the Software without
++ *     restriction, including without limitation the rights to use,
++ *     copy, modify, merge, publish, distribute, sublicense, and/or
++ *     sell copies of the Software, and to permit persons to whom the
++ *     Software is furnished to do so, subject to the following
++ *     conditions:
++ *
++ *     The above copyright notice and this permission notice shall be
++ *     included in all copies or substantial portions of the Software.
++ *
++ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
++ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
++ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
++ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
++ *     OTHER DEALINGS IN THE SOFTWARE.
++ */
++
++/dts-v1/;
++#include "rk3328.dtsi"
++
++/ {
++	model = "Rockchip RK3328 Z28";
++	compatible = "rockchip,rk3328-box-z28", "rockchip,rk3328";
++
++	chosen {
++		bootargs = "earlyprintk=uart8250-32bit,0xff130000 swiotlb=1 kpti=0";
++		stdout-path = "serial2:1500000n8";
++	};
++
++	xin32k: xin32k {
++		compatible = "fixed-clock";
++		clock-frequency = <32768>;
++		clock-output-names = "xin32k";
++		#clock-cells = <0>;
++	};
++
++	vcc_phy: vcc-phy-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_phy";
++		regulator-always-on;
++		regulator-boot-on;
++	};
++
++	vcc_sys: vcc-sys {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++	};
++
++	vcc_sd: sdmmc-regulator {
++		compatible = "regulator-fixed";
++		gpio = <&gpio0 RK_PD6 GPIO_ACTIVE_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&sdmmc0m1_gpio>;
++		regulator-name = "vcc_sd";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc_io>;
++	};
++
++	vcc_host_5v: vcc-host-5v-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio0 RK_PA0 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&usb30_host_drv>;
++		regulator-name = "vcc_host_5v";
++		regulator-always-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc_sys>;
++	};
++
++	vcc_host1_5v: vcc_otg_5v: vcc-host1-5v-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio0 RK_PA2 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&usb20_host_drv>;
++		regulator-name = "vcc_host1_5v";
++		regulator-always-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc_sys>;
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		power {
++			gpios = <&rk805 0 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "default-on";
++			default-state = "on";
++		};
++	};
++
++	ir-receiver {
++		compatible = "gpio-ir-receiver";
++		gpios = <&gpio2 RK_PA2 GPIO_ACTIVE_LOW>;
++		pinctrl-0 = <&ir_int>;
++		pinctrl-names = "default";
++	};
++
++	hdmi-sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,mclk-fs = <128>;
++		simple-audio-card,name = "HDMI";
++		simple-audio-card,cpu {
++			sound-dai = <&i2s0>;
++		};
++		simple-audio-card,codec {
++			sound-dai = <&hdmi>;
++		};
++	};
++
++	spdif-sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,name = "SPDIF";
++		simple-audio-card,cpu {
++			sound-dai = <&spdif>;
++		};
++		simple-audio-card,codec {
++			sound-dai = <&spdif_out>;
++		};
++	};
++
++	spdif_out: spdif-out {
++		compatible = "linux,spdif-dit";
++		#sound-dai-cells = <0>;
++	};
++
++	wireless-bluetooth {
++		compatible = "bluetooth-platdata";
++		BT,power_gpio = <&gpio2 RK_PC5 GPIO_ACTIVE_HIGH>;
++		BT,wake_host_irq = <&gpio2 RK_PC0 GPIO_ACTIVE_HIGH>;
++	};
++
++	wireless-wlan {
++		compatible = "wlan-platdata";
++		rockchip,grf = <&grf>;
++		wifi_chip_type = "rtl8188eu";
++		WIFI,poweren_gpio = <&gpio2 RK_PC3 GPIO_ACTIVE_HIGH>;
++		WIFI,reset_gpio = <&gpio2 RK_PC4 GPIO_ACTIVE_HIGH>;
++		WIFI,host_wake_irq = <&gpio2 RK_PC6 GPIO_ACTIVE_HIGH>;
++	};
++};
++
++&codec {
++	#sound-dai-cells = <0>;
++	status = "okay";
++};
++
++&cpu0 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&cpu1 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&cpu2 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&cpu3 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&dfi {
++	status = "okay";
++};
++
++&dmc {
++	center-supply = <&vdd_logic>;
++	status = "okay";
++};
++
++&display_subsystem {
++	status = "okay";
++};
++
++&emmc {
++	bus-width = <8>;
++	cap-mmc-highspeed;
++	mmc-hs200-1_8v;
++	non-removable;
++	pinctrl-names = "default";
++	pinctrl-0 = <&emmc_clk &emmc_cmd &emmc_bus8>;
++	supports-emmc;
++	vmmc-supply = <&vcc_io>;
++	vqmmc-supply = <&vcc18_emmc>;
++	status = "okay";
++};
++
++&gmac2phy {
++	phy-supply = <&vcc_phy>;
++	assigned-clocks = <&cru SCLK_MAC2PHY_SRC>;
++	assigned-clock-rate = <50000000>;
++	assigned-clocks = <&cru SCLK_MAC2PHY>;
++	assigned-clock-parents = <&cru SCLK_MAC2PHY_SRC>;
++	clock_in_out = "output";
++	status = "okay";
++};
++
++&gpu {
++	status = "okay";
++	mali-supply = <&vdd_logic>;
++};
++
++&h265e {
++	status = "okay";
++};
++
++&h265e_mmu {
++	status = "okay";
++};
++
++&hdmi {
++	#sound-dai-cells = <0>;
++	ddc-i2c-scl-high-time-ns = <9625>;
++	ddc-i2c-scl-low-time-ns = <10000>;
++	status = "okay";
++};
++
++&hdmiphy {
++	status = "okay";
++};
++
++&i2c1 {
++	status = "okay";
++
++	rk805: rk805@18 {
++		compatible = "rockchip,rk805";
++		status = "okay";
++		reg = <0x18>;
++		interrupt-parent = <&gpio2>;
++		interrupts = <6 IRQ_TYPE_LEVEL_LOW>;
++		#clock-cells = <1>;
++		clock-output-names = "rk805-clkout1", "rk805-clkout2";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pmic_int_l>;
++		rockchip,system-power-controller;
++		wakeup-source;
++		gpio-controller;
++		#gpio-cells = <2>;
++
++		vcc1-supply = <&vcc_sys>;
++		vcc2-supply = <&vcc_sys>;
++		vcc3-supply = <&vcc_sys>;
++		vcc4-supply = <&vcc_sys>;
++		vcc5-supply = <&vcc_io>;
++		vcc6-supply = <&vcc_sys>;
++
++		rtc {
++			status = "okay";
++		};
++
++		pwrkey {
++			status = "okay";
++		};
++
++		gpio {
++			status = "okay";
++		};
++
++		regulators {
++			compatible = "rk805-regulator";
++			status = "okay";
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			vdd_logic: RK805_DCDC1 {
++				regulator-compatible = "RK805_DCDC1";
++				regulator-name = "vdd_logic";
++				regulator-min-microvolt = <712500>;
++				regulator-max-microvolt = <1450000>;
++				regulator-initial-mode = <0x1>;
++				regulator-ramp-delay = <12500>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-mode = <0x2>;
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1000000>;
++				};
++			};
++
++			vdd_arm: RK805_DCDC2 {
++				regulator-compatible = "RK805_DCDC2";
++				regulator-name = "vdd_arm";
++				regulator-init-microvolt = <1225000>;
++				regulator-min-microvolt = <712500>;
++				regulator-max-microvolt = <1450000>;
++				regulator-initial-mode = <0x1>;
++				regulator-ramp-delay = <12500>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-mode = <0x2>;
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <950000>;
++				};
++			};
++
++			vcc_ddr: RK805_DCDC3 {
++				regulator-compatible = "RK805_DCDC3";
++				regulator-name = "vcc_ddr";
++				regulator-initial-mode = <0x1>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-mode = <0x2>;
++					regulator-on-in-suspend;
++				};
++			};
++
++			vcc_io: RK805_DCDC4 {
++				regulator-compatible = "RK805_DCDC4";
++				regulator-name = "vcc_io";
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-initial-mode = <0x1>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-mode = <0x2>;
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++				};
++			};
++
++			vcc_18: RK805_LDO1 {
++				regulator-compatible = "RK805_LDO1";
++				regulator-name = "vcc_18";
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vcc18_emmc: RK805_LDO2 {
++				regulator-compatible = "RK805_LDO2";
++				regulator-name = "vcc18_emmc";
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vdd_10: RK805_LDO3 {
++				regulator-compatible = "RK805_LDO3";
++				regulator-name = "vdd_10";
++				regulator-min-microvolt = <1000000>;
++				regulator-max-microvolt = <1000000>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1000000>;
++				};
++			};
++		};
++	};
++};
++
++&i2s0 {
++	#sound-dai-cells = <0>;
++	rockchip,bclk-fs = <128>;
++	status = "okay";
++};
++
++&iep {
++	status = "okay";
++};
++
++&iep_mmu {
++	status = "okay";
++};
++
++&io_domains {
++	status = "okay";
++
++	vccio1-supply = <&vcc_io>;
++	vccio2-supply = <&vcc18_emmc>;
++	vccio3-supply = <&vcc_io>;
++	vccio4-supply = <&vcc_18>;
++	vccio5-supply = <&vcc_io>;
++	vccio6-supply = <&vcc_io>;
++	pmuio-supply = <&vcc_io>;
++};
++
++&pinctrl {
++	pinctrl-names = "default";
++	pinctrl-0 = <&clk_32k_out>;
++
++	clk_32k {
++		clk_32k_out: clk-32k-out {
++			rockchip,pins = <1 RK_PD4 RK_FUNC_1 &pcfg_pull_none>;
++		};
++	};
++
++	ir {
++		ir_int: ir-int {
++			rockchip,pins = <2 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	pmic {
++		pmic_int_l: pmic-int-l {
++			rockchip,pins = <2 RK_PA6 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	usb2 {
++		usb20_host_drv: usb20-host-drv {
++			rockchip,pins = <0 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	usb3 {
++		usb30_host_drv: usb30-host-drv {
++			rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++};
++
++&rkvdec {
++	status = "okay";
++	vcodec-supply = <&vdd_logic>;
++};
++
++&rkvdec_mmu {
++	status = "okay";
++};
++
++&sdmmc {
++	bus-width = <4>;
++	cap-mmc-highspeed;
++	cap-sd-highspeed;
++	disable-wp;
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdmmc0_clk &sdmmc0_cmd &sdmmc0_dectn &sdmmc0_bus4>;
++	supports-sd;
++	vmmc-supply = <&vcc_sd>;
++	status = "okay";
++};
++
++&spdif {
++	#sound-dai-cells = <0>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&spdifm0_tx>;
++	status = "okay";
++};
++
++&threshold {
++	temperature = <80000>; /* millicelsius */
++};
++
++&target {
++	temperature = <95000>; /* millicelsius */
++};
++
++&soc_crit {
++	temperature = <100000>; /* millicelsius */
++};
++
++&tsadc {
++	rockchip,hw-tshut-mode = <0>;
++	rockchip,hw-tshut-polarity = <0>;
++	rockchip,hw-tshut-temp = <110000>;
++	status = "okay";
++};
++
++&uart0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart0_xfer &uart0_cts>;
++	status = "okay";
++};
++
++&uart2 {
++	status = "okay";
++};
++
++&u2phy {
++	status = "okay";
++};
++
++&u2phy_host {
++	phy-supply = <&vcc_host1_5v>;
++	status = "okay";
++};
++
++&u2phy_otg {
++	phy-supply = <&vcc_otg_5v>;
++	status = "okay";
++};
++
++&u3phy {
++	status = "okay";
++};
++
++&u3phy_utmi {
++	phy-supply = <&vcc_host_5v>;
++	status = "okay";
++};
++
++&u3phy_pipe {
++	phy-supply = <&vcc_host_5v>;
++	status = "okay";
++};
++
++&usb20_otg {
++	dr_mode = "host";
++	status = "okay";
++};
++
++&usb_host0_ehci {
++	status = "okay";
++};
++
++&usb_host0_ohci {
++	status = "okay";
++};
++
++&usbdrd3 {
++	status = "okay";
++};
++
++&usbdrd_dwc3 {
++	status = "okay";
++};
++
++&vop {
++	status = "okay";
++};
++
++&vop_mmu {
++	status = "okay";
++};
++
++&vpu_service {
++	status = "okay";
++};
++
++&vpu_mmu {
++	status = "okay";
++};
++
++&vepu {
++	status = "okay";
++};
++
++&vepu_mmu {
++	status = "okay";
++};
++
++&venc_srv {
++	status = "okay";
++};
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328-box.dts b/arch/arm64/boot/dts/rockchip/rk3328-box.dts
 new file mode 100644
 index 000000000000..eae652d55208
@@ -1805,17 +2460,1431 @@ index 000000000000..eae652d55208
 +&venc_srv {
 +	status = "okay";
 +};
-
-From 8d1e765adaeb6d597b7cda84c9922f2aa5d34239 Mon Sep 17 00:00:00 2001
-From: Jonas Karlman <jonas@kwiboo.se>
-Date: Wed, 17 Jan 2018 22:17:45 +0100
-Subject: [PATCH] arm64: dts: rockchip: add rk3328-rockbox board
-
----
- arch/arm64/boot/dts/rockchip/rk3328-rockbox.dts | 583 ++++++++++++++++++++++++
- 1 file changed, 583 insertions(+)
- create mode 100644 arch/arm64/boot/dts/rockchip/rk3328-rockbox.dts
-
+diff --git a/arch/arm64/boot/dts/rockchip/rk3328-dram-box-plus-timing.dtsi b/arch/arm64/boot/dts/rockchip/rk3328-dram-box-plus-timing.dtsi
+new file mode 100644
+index 000000000000..ac34cc7ab1ce
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3328-dram-box-plus-timing.dtsi
+@@ -0,0 +1,263 @@
++/*
++ * Copyright (c) 2016 Fuzhou Rockchip Electronics Co., Ltd
++ *
++ * This file is dual-licensed: you can use it either under the terms
++ * of the GPL or the X11 license, at your option. Note that this dual
++ * licensing only applies to this file, and not this project as a
++ * whole.
++ *
++ *  a) This library is free software; you can redistribute it and/or
++ *     modify it under the terms of the GNU General Public License as
++ *     published by the Free Software Foundation; either version 2 of the
++ *     License, or (at your option) any later version.
++ *
++ *     This library is distributed in the hope that it will be useful,
++ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *     GNU General Public License for more details.
++ *
++ * Or, alternatively,
++ *
++ *  b) Permission is hereby granted, free of charge, to any person
++ *     obtaining a copy of this software and associated documentation
++ *     files (the "Software"), to deal in the Software without
++ *     restriction, including without limitation the rights to use,
++ *     copy, modify, merge, publish, distribute, sublicense, and/or
++ *     sell copies of the Software, and to permit persons to whom the
++ *     Software is furnished to do so, subject to the following
++ *     conditions:
++ *
++ *     The above copyright notice and this permission notice shall be
++ *     included in all copies or substantial portions of the Software.
++ *
++ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
++ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
++ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
++ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
++ *     OTHER DEALINGS IN THE SOFTWARE.
++ */
++#include <dt-bindings/clock/rockchip-ddr.h>
++#include <dt-bindings/memory/rk3328-dram.h>
++
++&ddr_timing {
++	ddr4_odt = <DDR4_RTT_NOM_120ohm>;
++	phy_ddr4_ca_drv = <PHY_DDR4_LPDDR3_RON_RTT_25ohm>;
++	phy_ddr4_ck_drv = <PHY_DDR4_LPDDR3_RON_RTT_25ohm>;
++	phy_ddr4_dq_drv = <PHY_DDR4_LPDDR3_RON_RTT_25ohm>;
++	phy_ddr4_odt = <PHY_DDR4_LPDDR3_RON_RTT_120ohm>;
++
++	/* CA de-skew, one step is 47.8ps, range 0-15 */
++	ddr3a1_ddr4a9_de-skew = <1>;
++	ddr3a0_ddr4a10_de-skew = <1>;
++	ddr3a3_ddr4a6_de-skew = <0>;
++	ddr3a2_ddr4a4_de-skew = <1>;
++	ddr3a5_ddr4a8_de-skew = <0>;
++	ddr3a4_ddr4a5_de-skew = <1>;
++	ddr3a7_ddr4a11_de-skew = <1>;
++	ddr3a6_ddr4a7_de-skew = <0>;
++	ddr3a9_ddr4a0_de-skew = <1>;
++	ddr3a8_ddr4a13_de-skew = <0>;
++	ddr3a11_ddr4a3_de-skew = <2>;
++	ddr3a10_ddr4cs0_de-skew = <3>;
++	ddr3a13_ddr4a2_de-skew = <1>;
++	ddr3a12_ddr4ba1_de-skew = <0>;
++	ddr3a15_ddr4odt0_de-skew = <3>;
++	ddr3a14_ddr4a1_de-skew = <2>;
++	ddr3ba1_ddr4a15_de-skew = <1>;
++	ddr3ba0_ddr4bg0_de-skew = <1>;
++	ddr3ras_ddr4cke_de-skew = <3>;
++	ddr3ba2_ddr4ba0_de-skew = <1>;
++	ddr3we_ddr4bg1_de-skew = <3>;
++	ddr3cas_ddr4a12_de-skew = <1>;
++	ddr3ckn_ddr4ckn_de-skew = <4>;
++	ddr3ckp_ddr4ckp_de-skew = <4>;
++	ddr3cke_ddr4a16_de-skew = <1>;
++	ddr3odt0_ddr4a14_de-skew = <1>;
++	ddr3cs0_ddr4act_de-skew = <2>;
++	ddr3reset_ddr4reset_de-skew = <3>;
++	ddr3cs1_ddr4cs1_de-skew = <2>;
++	ddr3odt1_ddr4odt1_de-skew = <2>;
++
++	/* DATA de-skew
++	 * RX one step is 25.1ps, range 0-15
++	 * TX one step is 47.8ps, range 0-15
++	 */
++	cs0_dm0_rx_de-skew = <8>;
++	cs0_dm0_tx_de-skew = <9>;
++	cs0_dq0_rx_de-skew = <8>;
++	cs0_dq0_tx_de-skew = <9>;
++	cs0_dq1_rx_de-skew = <8>;
++	cs0_dq1_tx_de-skew = <9>;
++	cs0_dq2_rx_de-skew = <8>;
++	cs0_dq2_tx_de-skew = <9>;
++	cs0_dq3_rx_de-skew = <8>;
++	cs0_dq3_tx_de-skew = <9>;
++	cs0_dq4_rx_de-skew = <8>;
++	cs0_dq4_tx_de-skew = <9>;
++	cs0_dq5_rx_de-skew = <8>;
++	cs0_dq5_tx_de-skew = <9>;
++	cs0_dq6_rx_de-skew = <8>;
++	cs0_dq6_tx_de-skew = <9>;
++	cs0_dq7_rx_de-skew = <8>;
++	cs0_dq7_tx_de-skew = <9>;
++	cs0_dqs0_rx_de-skew = <7>;
++	cs0_dqs0p_tx_de-skew = <10>;
++	cs0_dqs0n_tx_de-skew = <10>;
++
++	cs0_dm1_rx_de-skew = <8>;
++	cs0_dm1_tx_de-skew = <8>;
++	cs0_dq8_rx_de-skew = <8>;
++	cs0_dq8_tx_de-skew = <9>;
++	cs0_dq9_rx_de-skew = <8>;
++	cs0_dq9_tx_de-skew = <8>;
++	cs0_dq10_rx_de-skew = <8>;
++	cs0_dq10_tx_de-skew = <9>;
++	cs0_dq11_rx_de-skew = <8>;
++	cs0_dq11_tx_de-skew = <8>;
++	cs0_dq12_rx_de-skew = <8>;
++	cs0_dq12_tx_de-skew = <9>;
++	cs0_dq13_rx_de-skew = <8>;
++	cs0_dq13_tx_de-skew = <8>;
++	cs0_dq14_rx_de-skew = <8>;
++	cs0_dq14_tx_de-skew = <9>;
++	cs0_dq15_rx_de-skew = <8>;
++	cs0_dq15_tx_de-skew = <8>;
++	cs0_dqs1_rx_de-skew = <8>;
++	cs0_dqs1p_tx_de-skew = <10>;
++	cs0_dqs1n_tx_de-skew = <10>;
++
++	cs0_dm2_rx_de-skew = <8>;
++	cs0_dm2_tx_de-skew = <9>;
++	cs0_dq16_rx_de-skew = <8>;
++	cs0_dq16_tx_de-skew = <9>;
++	cs0_dq17_rx_de-skew = <8>;
++	cs0_dq17_tx_de-skew = <9>;
++	cs0_dq18_rx_de-skew = <8>;
++	cs0_dq18_tx_de-skew = <9>;
++	cs0_dq19_rx_de-skew = <8>;
++	cs0_dq19_tx_de-skew = <9>;
++	cs0_dq20_rx_de-skew = <8>;
++	cs0_dq20_tx_de-skew = <9>;
++	cs0_dq21_rx_de-skew = <8>;
++	cs0_dq21_tx_de-skew = <9>;
++	cs0_dq22_rx_de-skew = <8>;
++	cs0_dq22_tx_de-skew = <9>;
++	cs0_dq23_rx_de-skew = <8>;
++	cs0_dq23_tx_de-skew = <9>;
++	cs0_dqs2_rx_de-skew = <7>;
++	cs0_dqs2p_tx_de-skew = <10>;
++	cs0_dqs2n_tx_de-skew = <10>;
++
++	cs0_dm3_rx_de-skew = <8>;
++	cs0_dm3_tx_de-skew = <8>;
++	cs0_dq24_rx_de-skew = <8>;
++	cs0_dq24_tx_de-skew = <9>;
++	cs0_dq25_rx_de-skew = <8>;
++	cs0_dq25_tx_de-skew = <8>;
++	cs0_dq26_rx_de-skew = <8>;
++	cs0_dq26_tx_de-skew = <8>;
++	cs0_dq27_rx_de-skew = <8>;
++	cs0_dq27_tx_de-skew = <8>;
++	cs0_dq28_rx_de-skew = <8>;
++	cs0_dq28_tx_de-skew = <8>;
++	cs0_dq29_rx_de-skew = <8>;
++	cs0_dq29_tx_de-skew = <8>;
++	cs0_dq30_rx_de-skew = <8>;
++	cs0_dq30_tx_de-skew = <8>;
++	cs0_dq31_rx_de-skew = <8>;
++	cs0_dq31_tx_de-skew = <8>;
++	cs0_dqs3_rx_de-skew = <8>;
++	cs0_dqs3p_tx_de-skew = <10>;
++	cs0_dqs3n_tx_de-skew = <10>;
++
++	cs1_dm0_rx_de-skew = <8>;
++	cs1_dm0_tx_de-skew = <9>;
++	cs1_dq0_rx_de-skew = <8>;
++	cs1_dq0_tx_de-skew = <9>;
++	cs1_dq1_rx_de-skew = <8>;
++	cs1_dq1_tx_de-skew = <9>;
++	cs1_dq2_rx_de-skew = <8>;
++	cs1_dq2_tx_de-skew = <9>;
++	cs1_dq3_rx_de-skew = <8>;
++	cs1_dq3_tx_de-skew = <9>;
++	cs1_dq4_rx_de-skew = <8>;
++	cs1_dq4_tx_de-skew = <9>;
++	cs1_dq5_rx_de-skew = <8>;
++	cs1_dq5_tx_de-skew = <9>;
++	cs1_dq6_rx_de-skew = <8>;
++	cs1_dq6_tx_de-skew = <9>;
++	cs1_dq7_rx_de-skew = <8>;
++	cs1_dq7_tx_de-skew = <9>;
++	cs1_dqs0_rx_de-skew = <7>;
++	cs1_dqs0p_tx_de-skew = <10>;
++	cs1_dqs0n_tx_de-skew = <10>;
++
++	cs1_dm1_rx_de-skew = <8>;
++	cs1_dm1_tx_de-skew = <8>;
++	cs1_dq8_rx_de-skew = <8>;
++	cs1_dq8_tx_de-skew = <9>;
++	cs1_dq9_rx_de-skew = <8>;
++	cs1_dq9_tx_de-skew = <8>;
++	cs1_dq10_rx_de-skew = <8>;
++	cs1_dq10_tx_de-skew = <9>;
++	cs1_dq11_rx_de-skew = <8>;
++	cs1_dq11_tx_de-skew = <8>;
++	cs1_dq12_rx_de-skew = <8>;
++	cs1_dq12_tx_de-skew = <9>;
++	cs1_dq13_rx_de-skew = <8>;
++	cs1_dq13_tx_de-skew = <8>;
++	cs1_dq14_rx_de-skew = <8>;
++	cs1_dq14_tx_de-skew = <9>;
++	cs1_dq15_rx_de-skew = <8>;
++	cs1_dq15_tx_de-skew = <8>;
++	cs1_dqs1_rx_de-skew = <8>;
++	cs1_dqs1p_tx_de-skew = <10>;
++	cs1_dqs1n_tx_de-skew = <10>;
++
++	cs1_dm2_rx_de-skew = <8>;
++	cs1_dm2_tx_de-skew = <9>;
++	cs1_dq16_rx_de-skew = <8>;
++	cs1_dq16_tx_de-skew = <9>;
++	cs1_dq17_rx_de-skew = <8>;
++	cs1_dq17_tx_de-skew = <9>;
++	cs1_dq18_rx_de-skew = <8>;
++	cs1_dq18_tx_de-skew = <9>;
++	cs1_dq19_rx_de-skew = <8>;
++	cs1_dq19_tx_de-skew = <9>;
++	cs1_dq20_rx_de-skew = <8>;
++	cs1_dq20_tx_de-skew = <9>;
++	cs1_dq21_rx_de-skew = <8>;
++	cs1_dq21_tx_de-skew = <9>;
++	cs1_dq22_rx_de-skew = <8>;
++	cs1_dq22_tx_de-skew = <9>;
++	cs1_dq23_rx_de-skew = <8>;
++	cs1_dq23_tx_de-skew = <9>;
++	cs1_dqs2_rx_de-skew = <7>;
++	cs1_dqs2p_tx_de-skew = <10>;
++	cs1_dqs2n_tx_de-skew = <10>;
++
++	cs1_dm3_rx_de-skew = <8>;
++	cs1_dm3_tx_de-skew = <8>;
++	cs1_dq24_rx_de-skew = <8>;
++	cs1_dq24_tx_de-skew = <9>;
++	cs1_dq25_rx_de-skew = <8>;
++	cs1_dq25_tx_de-skew = <8>;
++	cs1_dq26_rx_de-skew = <8>;
++	cs1_dq26_tx_de-skew = <8>;
++	cs1_dq27_rx_de-skew = <8>;
++	cs1_dq27_tx_de-skew = <8>;
++	cs1_dq28_rx_de-skew = <8>;
++	cs1_dq28_tx_de-skew = <8>;
++	cs1_dq29_rx_de-skew = <8>;
++	cs1_dq29_tx_de-skew = <8>;
++	cs1_dq30_rx_de-skew = <8>;
++	cs1_dq30_tx_de-skew = <8>;
++	cs1_dq31_rx_de-skew = <8>;
++	cs1_dq31_tx_de-skew = <8>;
++	cs1_dqs3_rx_de-skew = <8>;
++	cs1_dqs3p_tx_de-skew = <10>;
++	cs1_dqs3n_tx_de-skew = <10>;
++};
+diff --git a/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts b/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts
+new file mode 100644
+index 000000000000..5df9b4976ba2
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts
+@@ -0,0 +1,597 @@
++/*
++ * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd
++ *
++ * This file is dual-licensed: you can use it either under the terms
++ * of the GPL or the X11 license, at your option. Note that this dual
++ * licensing only applies to this file, and not this project as a
++ * whole.
++ *
++ *  a) This library is free software; you can redistribute it and/or
++ *     modify it under the terms of the GNU General Public License as
++ *     published by the Free Software Foundation; either version 2 of the
++ *     License, or (at your option) any later version.
++ *
++ *     This library is distributed in the hope that it will be useful,
++ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *     GNU General Public License for more details.
++ *
++ * Or, alternatively,
++ *
++ *  b) Permission is hereby granted, free of charge, to any person
++ *     obtaining a copy of this software and associated documentation
++ *     files (the "Software"), to deal in the Software without
++ *     restriction, including without limitation the rights to use,
++ *     copy, modify, merge, publish, distribute, sublicense, and/or
++ *     sell copies of the Software, and to permit persons to whom the
++ *     Software is furnished to do so, subject to the following
++ *     conditions:
++ *
++ *     The above copyright notice and this permission notice shall be
++ *     included in all copies or substantial portions of the Software.
++ *
++ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
++ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
++ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
++ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
++ *     OTHER DEALINGS IN THE SOFTWARE.
++ */
++
++/dts-v1/;
++#include "rk3328.dtsi"
++#include "rk3328-dram-box-plus-timing.dtsi"
++
++/ {
++	model = "Firefly ROC-RK3328-CC Board";
++	compatible = "firefly,roc-rk3328-cc", "rockchip,rk3328";
++
++	chosen {
++		bootargs = "earlyprintk=uart8250-32bit,0xff130000 swiotlb=1 kpti=0";
++		stdout-path = "serial2:1500000n8";
++	};
++
++	xin32k: xin32k {
++		compatible = "fixed-clock";
++		clock-frequency = <32768>;
++		clock-output-names = "xin32k";
++		#clock-cells = <0>;
++	};
++
++	gmac_clkin: external-gmac-clock {
++		compatible = "fixed-clock";
++		clock-frequency = <125000000>;
++		clock-output-names = "gmac_clkin";
++		#clock-cells = <0>;
++	};
++
++	vcc_phy: vcc-phy-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_phy";
++		regulator-always-on;
++		regulator-boot-on;
++	};
++
++	vcc_sys: vcc-sys {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++	};
++
++	vcc_sd: sdmmc-regulator {
++		compatible = "regulator-fixed";
++		gpio = <&gpio0 RK_PD6 GPIO_ACTIVE_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&sdmmc0m1_gpio>;
++		regulator-name = "vcc_sd";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc_io>;
++	};
++
++	vccio_sd: sdmmcio-regulator {
++		compatible = "regulator-gpio";
++		gpios = <&gpio0 RK_PD1 GPIO_ACTIVE_HIGH>;
++		states = <1800000 0x1
++			  3300000 0x0>;
++		regulator-name = "vccio_sd";
++		regulator-type = "voltage";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <3300000>;
++	};
++
++	vcc_host_5v: vcc_host1_5v: vcc_otg_5v: vcc-host-5v-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio1 RK_PD2 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&usb_host_drv>;
++		regulator-name = "vcc_host_5v";
++		regulator-always-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc_sys>;
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		power {
++			gpios = <&rk805 1 GPIO_ACTIVE_LOW>;
++			linux,default-trigger = "heartbeat";
++		};
++
++		user {
++			gpios = <&rk805 0 GPIO_ACTIVE_LOW>;
++			linux,default-trigger = "mmc0";
++		};
++	};
++
++	ir-receiver {
++		compatible = "gpio-ir-receiver";
++		gpios = <&gpio2 RK_PA2 GPIO_ACTIVE_LOW>;
++		linux,rc-map-name = "rc-roc-cc";
++		pinctrl-0 = <&ir_int>;
++		pinctrl-names = "default";
++	};
++
++	hdmi-sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,mclk-fs = <128>;
++		simple-audio-card,name = "HDMI";
++		simple-audio-card,cpu {
++			sound-dai = <&i2s0>;
++		};
++		simple-audio-card,codec {
++			sound-dai = <&hdmi>;
++		};
++	};
++
++	sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,mclk-fs = <256>;
++		simple-audio-card,name = "I2S";
++		simple-audio-card,cpu {
++			sound-dai = <&i2s1>;
++		};
++		simple-audio-card,codec {
++			sound-dai = <&codec>;
++		};
++	};
++};
++
++&codec {
++	#sound-dai-cells = <0>;
++	status = "okay";
++};
++
++&cpu0 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&cpu1 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&cpu2 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&cpu3 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&dfi {
++	status = "okay";
++};
++
++&dmc {
++	center-supply = <&vdd_logic>;
++	system-status-freq = <
++		/*system status         freq(KHz)*/
++		SYS_STATUS_NORMAL       1066000
++		SYS_STATUS_REBOOT       1066000
++		SYS_STATUS_SUSPEND      1066000
++		SYS_STATUS_VIDEO_1080P  1066000
++		SYS_STATUS_VIDEO_4K     1066000
++		SYS_STATUS_VIDEO_4K_10B 1066000
++		SYS_STATUS_PERFORMANCE  1066000
++		SYS_STATUS_BOOST        1066000
++	>;
++	status = "okay";
++};
++
++&dmc_opp_table {
++	rockchip,leakage-voltage-sel = <
++		1   8     0
++		9   254   0
++	>;
++	opp-933000000 {
++		opp-hz = /bits/ 64 <933000000>;
++		opp-microvolt = <1150000>;
++		opp-microvolt-L0 = <1150000>;
++		opp-microvolt-L1 = <1100000>;
++	};
++	opp-1066000000 {
++		opp-hz = /bits/ 64 <1066000000>;
++		opp-microvolt = <1200000>;
++		opp-microvolt-L0 = <1200000>;
++		opp-microvolt-L1 = <1175000>;
++	};
++};
++
++&display_subsystem {
++	status = "okay";
++};
++
++&emmc {
++	bus-width = <8>;
++	cap-mmc-highspeed;
++	mmc-hs200-1_8v;
++	non-removable;
++	pinctrl-names = "default";
++	pinctrl-0 = <&emmc_clk &emmc_cmd &emmc_bus8>;
++	supports-emmc;
++	vmmc-supply = <&vcc_io>;
++	vqmmc-supply = <&vcc18_emmc>;
++	status = "okay";
++};
++
++&gmac2io {
++	assigned-clocks = <&cru SCLK_MAC2IO>, <&cru SCLK_MAC2IO_EXT>;
++	assigned-clock-parents = <&gmac_clkin>, <&gmac_clkin>;
++	clock_in_out = "input";
++	phy-supply = <&vcc_phy>;
++	phy-mode = "rgmii";
++	pinctrl-names = "default";
++	pinctrl-0 = <&rgmiim1_pins>;
++	snps,reset-gpio = <&gpio1 RK_PC2 GPIO_ACTIVE_LOW>;
++	snps,reset-active-low;
++	snps,reset-delays-us = <0 10000 50000>;
++	tx_delay = <0x25>;
++	rx_delay = <0x11>;
++	status = "okay";
++};
++
++&gpu {
++	status = "okay";
++	mali-supply = <&vdd_logic>;
++};
++
++&h265e {
++	status = "okay";
++};
++
++&h265e_mmu {
++	status = "okay";
++};
++
++&hdmi {
++	#sound-dai-cells = <0>;
++	ddc-i2c-scl-high-time-ns = <9625>;
++	ddc-i2c-scl-low-time-ns = <10000>;
++	status = "okay";
++};
++
++&hdmiphy {
++	status = "okay";
++};
++
++&i2c1 {
++	status = "okay";
++
++	rk805: rk805@18 {
++		compatible = "rockchip,rk805";
++		status = "okay";
++		reg = <0x18>;
++		interrupt-parent = <&gpio1>;
++		interrupts = <24 IRQ_TYPE_LEVEL_LOW>;
++		#clock-cells = <1>;
++		clock-output-names = "rk805-clkout1", "rk805-clkout2";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pmic_int_l>;
++		rockchip,system-power-controller;
++		wakeup-source;
++		gpio-controller;
++		#gpio-cells = <2>;
++
++		vcc1-supply = <&vcc_sys>;
++		vcc2-supply = <&vcc_sys>;
++		vcc3-supply = <&vcc_sys>;
++		vcc4-supply = <&vcc_sys>;
++		vcc5-supply = <&vcc_io>;
++		vcc6-supply = <&vcc_sys>;
++
++		rtc {
++			status = "okay";
++		};
++
++		pwrkey {
++			status = "okay";
++		};
++
++		gpio {
++			status = "okay";
++		};
++
++		regulators {
++			compatible = "rk805-regulator";
++			status = "okay";
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			vdd_logic: RK805_DCDC1 {
++				regulator-compatible = "RK805_DCDC1";
++				regulator-name = "vdd_logic";
++				regulator-min-microvolt = <712500>;
++				regulator-max-microvolt = <1450000>;
++				regulator-initial-mode = <0x1>;
++				regulator-ramp-delay = <12500>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-mode = <0x2>;
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1000000>;
++				};
++			};
++
++			vdd_arm: RK805_DCDC2 {
++				regulator-compatible = "RK805_DCDC2";
++				regulator-name = "vdd_arm";
++				regulator-init-microvolt = <1225000>;
++				regulator-min-microvolt = <712500>;
++				regulator-max-microvolt = <1450000>;
++				regulator-initial-mode = <0x1>;
++				regulator-ramp-delay = <12500>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-mode = <0x2>;
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <950000>;
++				};
++			};
++
++			vcc_ddr: RK805_DCDC3 {
++				regulator-compatible = "RK805_DCDC3";
++				regulator-name = "vcc_ddr";
++				regulator-initial-mode = <0x1>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-mode = <0x2>;
++					regulator-on-in-suspend;
++				};
++			};
++
++			vcc_io: RK805_DCDC4 {
++				regulator-compatible = "RK805_DCDC4";
++				regulator-name = "vcc_io";
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-initial-mode = <0x1>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-mode = <0x2>;
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++				};
++			};
++
++			vcc_18: RK805_LDO1 {
++				regulator-compatible = "RK805_LDO1";
++				regulator-name = "vcc_18";
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vcc18_emmc: RK805_LDO2 {
++				regulator-compatible = "RK805_LDO2";
++				regulator-name = "vcc18_emmc";
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vdd_10: RK805_LDO3 {
++				regulator-compatible = "RK805_LDO3";
++				regulator-name = "vdd_10";
++				regulator-min-microvolt = <1000000>;
++				regulator-max-microvolt = <1000000>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1000000>;
++				};
++			};
++		};
++	};
++};
++
++&i2s0 {
++	#sound-dai-cells = <0>;
++	rockchip,bclk-fs = <128>;
++	status = "okay";
++};
++
++&iep {
++	status = "okay";
++};
++
++&iep_mmu {
++	status = "okay";
++};
++
++&io_domains {
++	status = "okay";
++
++	vccio1-supply = <&vcc_io>;
++	vccio2-supply = <&vcc18_emmc>;
++	vccio3-supply = <&vccio_sd>;
++	vccio4-supply = <&vcc_io>;
++	vccio5-supply = <&vcc_io>;
++	vccio6-supply = <&vcc_io>;
++	pmuio-supply = <&vcc_io>;
++};
++
++&pinctrl {
++	ir {
++		ir_int: ir-int {
++			rockchip,pins = <2 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	pmic {
++		pmic_int_l: pmic-int-l {
++			rockchip,pins = <1 RK_PD0 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	usb {
++		usb_host_drv: usb-host-drv {
++			rockchip,pins = <1 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++};
++
++&rkvdec {
++	status = "okay";
++	vcodec-supply = <&vdd_logic>;
++};
++
++&rkvdec_mmu {
++	status = "okay";
++};
++
++&sdmmc {
++	bus-width = <4>;
++	cap-mmc-highspeed;
++	cap-sd-highspeed;
++	disable-wp;
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdmmc0_clk &sdmmc0_cmd &sdmmc0_dectn &sdmmc0_bus4>;
++	supports-sd;
++	vmmc-supply = <&vcc_sd>;
++	status = "okay";
++};
++
++&threshold {
++	temperature = <80000>; /* millicelsius */
++};
++
++&target {
++	temperature = <95000>; /* millicelsius */
++};
++
++&soc_crit {
++	temperature = <100000>; /* millicelsius */
++};
++
++&tsadc {
++	rockchip,hw-tshut-mode = <0>;
++	rockchip,hw-tshut-polarity = <0>;
++	rockchip,hw-tshut-temp = <110000>;
++	status = "okay";
++};
++
++&uart2 {
++	status = "okay";
++};
++
++&u2phy {
++	status = "okay";
++};
++
++&u2phy_host {
++	phy-supply = <&vcc_host1_5v>;
++	status = "okay";
++};
++
++&u2phy_otg {
++	phy-supply = <&vcc_otg_5v>;
++	status = "okay";
++};
++
++&u3phy {
++	status = "okay";
++};
++
++&u3phy_utmi {
++	phy-supply = <&vcc_host_5v>;
++	status = "okay";
++};
++
++&u3phy_pipe {
++	phy-supply = <&vcc_host_5v>;
++	status = "okay";
++};
++
++&usb20_otg {
++	dr_mode = "host";
++	status = "okay";
++};
++
++&usb_host0_ehci {
++	status = "okay";
++};
++
++&usb_host0_ohci {
++	status = "okay";
++};
++
++&usbdrd3 {
++	status = "okay";
++};
++
++&usbdrd_dwc3 {
++	status = "okay";
++};
++
++&vop {
++	status = "okay";
++};
++
++&vop_mmu {
++	status = "okay";
++};
++
++&vpu_service {
++	status = "okay";
++};
++
++&vpu_mmu {
++	status = "okay";
++};
++
++&vepu {
++	status = "okay";
++};
++
++&vepu_mmu {
++	status = "okay";
++};
++
++&venc_srv {
++	status = "okay";
++};
+diff --git a/arch/arm64/boot/dts/rockchip/rk3328-rock64.dts b/arch/arm64/boot/dts/rockchip/rk3328-rock64.dts
+index 7ba8e54cbf47..f9c05855dd2a 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3328-rock64.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3328-rock64.dts
+@@ -48,20 +48,15 @@
+ 	compatible = "pine64,rock64", "rockchip,rk3328";
+ 
+ 	chosen {
+-		bootargs = "rockchip_jtag earlycon=uart8250-32bit,0xff130000 swiotlb=1 kpti=0 coherent_pool=1m";
++		bootargs = "earlycon=uart8250-32bit,0xff130000 swiotlb=1 kpti=0 coherent_pool=1m";
+ 		stdout-path = "serial2:1500000n8";
+ 	};
+ 
+-	fiq-debugger {
+-		compatible = "rockchip,fiq-debugger";
+-		rockchip,serial-id = <2>;
+-		rockchip,signal-irq = <159>;
+-		rockchip,wake-irq = <0>;
+-		/* If enable uart uses irq instead of fiq */
+-		rockchip,irq-mode-enable = <0>;
+-		rockchip,baudrate = <1500000>;  /* Only 115200 and 1500000 */
+-		interrupts = <GIC_SPI 127 IRQ_TYPE_LEVEL_LOW>;
+-		status = "okay";
++	xin32k: xin32k {
++		compatible = "fixed-clock";
++		clock-frequency = <32768>;
++		clock-output-names = "xin32k";
++		#clock-cells = <0>;
+ 	};
+ 
+ 	gmac_clkin: external-gmac-clock {
+@@ -71,87 +66,125 @@
+ 		#clock-cells = <0>;
+ 	};
+ 
++	vcc_phy: vcc-phy-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_phy";
++		regulator-always-on;
++		regulator-boot-on;
++	};
++
++	vcc_sys: vcc-sys {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++	};
++
+ 	vcc_sd: sdmmc-regulator {
+ 		compatible = "regulator-fixed";
+-		gpio = <&gpio0 30 GPIO_ACTIVE_LOW>;
++		gpio = <&gpio0 RK_PD6 GPIO_ACTIVE_LOW>;
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&sdmmc0m1_gpio>;
+ 		regulator-name = "vcc_sd";
++		regulator-always-on;
++		regulator-boot-on;
+ 		regulator-min-microvolt = <3300000>;
+ 		regulator-max-microvolt = <3300000>;
+ 		vin-supply = <&vcc_io>;
+ 	};
+ 
+-	vcc_host_5v: vcc-host-5v-regulator {
++	vcc_host_5v: vcc_otg_5v: vcc-host-5v-regulator {
+ 		compatible = "regulator-fixed";
+-		enable-active-high;
+-		gpio = <&gpio0 0 GPIO_ACTIVE_HIGH>;
++		gpio = <&gpio0 RK_PA2 GPIO_ACTIVE_LOW>;
+ 		pinctrl-names = "default";
+-		pinctrl-0 = <&usb30_host_drv>;
++		pinctrl-0 = <&usb_host_drv>;
+ 		regulator-name = "vcc_host_5v";
+-		regulator-always-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
+ 		vin-supply = <&vcc_sys>;
+ 	};
+ 
+-	vcc_host1_5v: vcc_otg_5v: vcc-host1-5v-regulator {
+-		compatible = "regulator-fixed";
+-		enable-active-high;
+-		gpio = <&gpio0 27 GPIO_ACTIVE_HIGH>;
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&usb20_host_drv>;
+-		regulator-name = "vcc_host1_5v";
+-		regulator-always-on;
+-		vin-supply = <&vcc_sys>;
+-	};
++	leds {
++		compatible = "gpio-leds";
+ 
+-	vcc_sys: vcc-sys {
+-		compatible = "regulator-fixed";
+-		regulator-name = "vcc_sys";
+-		regulator-always-on;
+-		regulator-boot-on;
+-		regulator-min-microvolt = <5000000>;
+-		regulator-max-microvolt = <5000000>;
+-	};
++		standby-led {
++			gpios = <&rk805 0 GPIO_ACTIVE_LOW>;
++			linux,default-trigger = "heartbeat";
++		};
+ 
+-	xin32k: xin32k {
+-		compatible = "fixed-clock";
+-		clock-frequency = <32768>;
+-		clock-output-names = "xin32k";
+-		#clock-cells = <0>;
++		power-led {
++			gpios = <&rk805 1 GPIO_ACTIVE_LOW>;
++			linux,default-trigger = "mmc0";
++		};
+ 	};
+ 
+ 	ir-receiver {
+ 		compatible = "gpio-ir-receiver";
++		gpios = <&gpio2 RK_PA2 GPIO_ACTIVE_LOW>;
++		linux,rc-map-name = "rc-pine64";
+ 		pinctrl-0 = <&ir_int>;
+ 		pinctrl-names = "default";
+-		status = "okay";
+ 	};
+ 
+-	sound {
++	dummy_codec: dummy-codec {
++		compatible = "linux,snd-soc-dummy";
++		#sound-dai-cells = <0>;
++	};
++
++	hdmi-sound {
+ 		compatible = "simple-audio-card";
+ 		simple-audio-card,format = "i2s";
+-		simple-audio-card,mclk-fs = <256>;
+-		simple-audio-card,name = "rockchip,rk3328";
++		simple-audio-card,mclk-fs = <128>;
++		simple-audio-card,name = "HDMI";
+ 		simple-audio-card,cpu {
+-			sound-dai = <&i2s1>;
++			sound-dai = <&i2s0>;
+ 		};
+ 		simple-audio-card,codec {
+-			sound-dai = <&codec>;
++			sound-dai = <&hdmi>;
+ 		};
+ 	};
+ 
+-	hdmi-sound {
++	sound {
+ 		compatible = "simple-audio-card";
+-		simple-audio-card,format = "i2s";
+-		simple-audio-card,mclk-fs = <128>;
+-		simple-audio-card,name = "rockchip,hdmi";
++		simple-audio-card,mclk-fs = <256>;
++		simple-audio-card,name = "I2S";
++		simple-audio-card,dai-link@0 {
++			format = "i2s";
++			cpu {
++				sound-dai = <&i2s1>;
++			};
++			codec {
++				sound-dai = <&codec>;
++			};
++		};
++		simple-audio-card,dai-link@1 {
++			format = "i2s";
++			cpu {
++				sound-dai = <&i2s1>;
++			};
++			codec {
++				sound-dai = <&dummy_codec>;
++			};
++		};
++	};
++
++	spdif-sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,name = "SPDIF";
+ 		simple-audio-card,cpu {
+-			sound-dai = <&i2s0>;
++			sound-dai = <&spdif>;
+ 		};
+ 		simple-audio-card,codec {
+-			sound-dai = <&hdmi>;
++			sound-dai = <&spdif_out>;
+ 		};
+ 	};
++
++	spdif_out: spdif-out {
++		compatible = "linux,spdif-dit";
++		#sound-dai-cells = <0>;
++	};
+ };
+ 
+ &codec {
+@@ -175,6 +208,15 @@
+ 	cpu-supply = <&vdd_arm>;
+ };
+ 
++&dfi {
++	status = "okay";
++};
++
++&dmc {
++	center-supply = <&vdd_logic>;
++	status = "okay";
++};
++
+ &display_subsystem {
+ 	status = "okay";
+ };
+@@ -184,30 +226,40 @@
+ 	cap-mmc-highspeed;
+ 	mmc-hs200-1_8v;
+ 	non-removable;
+-	supports-emmc;
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&emmc_clk &emmc_cmd &emmc_bus8>;
++	supports-emmc;
+ 	vmmc-supply = <&vcc_io>;
+ 	vqmmc-supply = <&vcc18_emmc>;
+ 	status = "okay";
+ };
+ 
+ &gmac2io {
+-	phy-supply = <&vcc_io>;
+-	phy-mode = "rgmii";
+ 	assigned-clocks = <&cru SCLK_MAC2IO>, <&cru SCLK_MAC2IO_EXT>;
+ 	assigned-clock-parents = <&gmac_clkin>, <&gmac_clkin>;
+ 	clock_in_out = "input";
+-	snps,reset-gpio = <&gpio1 18 GPIO_ACTIVE_LOW>;
+-	snps,reset-active-low;
+-	snps,reset-delays-us = <0 10000 50000>;
++	phy-supply = <&vcc_phy>;
++	phy-mode = "rgmii";
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&rgmiim1_pins>;
+-	tx_delay = <0x26>;
+-	rx_delay = <0x11>;
++	snps,reset-gpio = <&gpio1 RK_PC2 GPIO_ACTIVE_LOW>;
++	snps,reset-active-low;
++	snps,reset-delays-us = <0 10000 50000>;
++	tx_delay = <0x24>;
++	rx_delay = <0x18>;
+ 	status = "okay";
+ };
+ 
++&gmac2phy {
++	phy-supply = <&vcc_phy>;
++	assigned-clocks = <&cru SCLK_MAC2PHY_SRC>;
++	assigned-clock-rate = <50000000>;
++	assigned-clocks = <&cru SCLK_MAC2PHY>;
++	assigned-clock-parents = <&cru SCLK_MAC2PHY_SRC>;
++	clock_in_out = "output";
++	status = "disabled";
++};
++
+ &gpu {
+ 	status = "okay";
+ 	mali-supply = <&vdd_logic>;
+@@ -223,6 +275,8 @@
+ 
+ &hdmi {
+ 	#sound-dai-cells = <0>;
++	ddc-i2c-scl-high-time-ns = <9625>;
++	ddc-i2c-scl-low-time-ns = <10000>;
+ 	status = "okay";
+ };
+ 
+@@ -239,14 +293,14 @@
+ 		reg = <0x18>;
+ 		interrupt-parent = <&gpio2>;
+ 		interrupts = <6 IRQ_TYPE_LEVEL_LOW>;
++		#clock-cells = <1>;
++		clock-output-names = "rk805-clkout1", "rk805-clkout2";
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&pmic_int_l>;
+ 		rockchip,system-power-controller;
+ 		wakeup-source;
+ 		gpio-controller;
+-		clock-output-names = "rk805-clkout1", "rk805-clkout2";
+ 		#gpio-cells = <2>;
+-		#clock-cells = <1>;
+ 
+ 		vcc1-supply = <&vcc_sys>;
+ 		vcc2-supply = <&vcc_sys>;
+@@ -256,11 +310,11 @@
+ 		vcc6-supply = <&vcc_sys>;
+ 
+ 		rtc {
+-			status = "disabled";
++			status = "okay";
+ 		};
+ 
+ 		pwrkey {
+-			status = "disabled";
++			status = "okay";
+ 		};
+ 
+ 		gpio {
+@@ -280,8 +334,8 @@
+ 				regulator-max-microvolt = <1450000>;
+ 				regulator-initial-mode = <0x1>;
+ 				regulator-ramp-delay = <12500>;
+-				regulator-boot-on;
+ 				regulator-always-on;
++				regulator-boot-on;
+ 				regulator-state-mem {
+ 					regulator-mode = <0x2>;
+ 					regulator-on-in-suspend;
+@@ -292,12 +346,13 @@
+ 			vdd_arm: RK805_DCDC2 {
+ 				regulator-compatible = "RK805_DCDC2";
+ 				regulator-name = "vdd_arm";
++				regulator-init-microvolt = <1225000>;
+ 				regulator-min-microvolt = <712500>;
+ 				regulator-max-microvolt = <1450000>;
+ 				regulator-initial-mode = <0x1>;
+ 				regulator-ramp-delay = <12500>;
+-				regulator-boot-on;
+ 				regulator-always-on;
++				regulator-boot-on;
+ 				regulator-state-mem {
+ 					regulator-mode = <0x2>;
+ 					regulator-on-in-suspend;
+@@ -309,8 +364,8 @@
+ 				regulator-compatible = "RK805_DCDC3";
+ 				regulator-name = "vcc_ddr";
+ 				regulator-initial-mode = <0x1>;
+-				regulator-boot-on;
+ 				regulator-always-on;
++				regulator-boot-on;
+ 				regulator-state-mem {
+ 					regulator-mode = <0x2>;
+ 					regulator-on-in-suspend;
+@@ -323,8 +378,8 @@
+ 				regulator-min-microvolt = <3300000>;
+ 				regulator-max-microvolt = <3300000>;
+ 				regulator-initial-mode = <0x1>;
+-				regulator-boot-on;
+ 				regulator-always-on;
++				regulator-boot-on;
+ 				regulator-state-mem {
+ 					regulator-mode = <0x2>;
+ 					regulator-on-in-suspend;
+@@ -332,13 +387,13 @@
+ 				};
+ 			};
+ 
+-			vdd_18: RK805_LDO1 {
++			vcc_18: RK805_LDO1 {
+ 				regulator-compatible = "RK805_LDO1";
+-				regulator-name = "vdd_18";
++				regulator-name = "vcc_18";
+ 				regulator-min-microvolt = <1800000>;
+ 				regulator-max-microvolt = <1800000>;
+-				regulator-boot-on;
+ 				regulator-always-on;
++				regulator-boot-on;
+ 				regulator-state-mem {
+ 					regulator-on-in-suspend;
+ 					regulator-suspend-microvolt = <1800000>;
+@@ -350,8 +405,8 @@
+ 				regulator-name = "vcc18_emmc";
+ 				regulator-min-microvolt = <1800000>;
+ 				regulator-max-microvolt = <1800000>;
+-				regulator-boot-on;
+ 				regulator-always-on;
++				regulator-boot-on;
+ 				regulator-state-mem {
+ 					regulator-on-in-suspend;
+ 					regulator-suspend-microvolt = <1800000>;
+@@ -363,8 +418,8 @@
+ 				regulator-name = "vdd_10";
+ 				regulator-min-microvolt = <1000000>;
+ 				regulator-max-microvolt = <1000000>;
+-				regulator-boot-on;
+ 				regulator-always-on;
++				regulator-boot-on;
+ 				regulator-state-mem {
+ 					regulator-on-in-suspend;
+ 					regulator-suspend-microvolt = <1000000>;
+@@ -381,17 +436,35 @@
+ };
+ 
+ &i2s1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2s1_mclk
++		     &i2s1_sclk
++		     &i2s1_lrcktx
++		     &i2s1_lrckrx
++		     &i2s1_sdo
++		     &i2s1_sdi
++		     &i2s1_sdio1
++		     &i2s1_sdio2
++		     &i2s1_sdio3>;
+ 	#sound-dai-cells = <0>;
+ 	status = "okay";
+ };
+ 
++&iep {
++	status = "okay";
++};
++
++&iep_mmu {
++	status = "okay";
++};
++
+ &io_domains {
+ 	status = "okay";
+ 
+ 	vccio1-supply = <&vcc_io>;
+ 	vccio2-supply = <&vcc18_emmc>;
+ 	vccio3-supply = <&vcc_io>;
+-	vccio4-supply = <&vdd_18>;
++	vccio4-supply = <&vcc_18>;
+ 	vccio5-supply = <&vcc_io>;
+ 	vccio6-supply = <&vcc_io>;
+ 	pmuio-supply = <&vcc_io>;
+@@ -400,37 +473,26 @@
+ &pinctrl {
+ 	ir {
+ 		ir_int: ir-int {
+-			rockchip,pins = <2 2 RK_FUNC_GPIO &pcfg_pull_none>;
++			rockchip,pins = <2 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 	};
+ 
+ 	pmic {
+ 		pmic_int_l: pmic-int-l {
+-			rockchip,pins = <2 6 RK_FUNC_GPIO &pcfg_pull_up>;
++			rockchip,pins = <2 RK_PA6 RK_FUNC_GPIO &pcfg_pull_up>;
+ 		};
+ 	};
+ 
+-	sdio-pwrseq {
+-		wifi_enable_h: wifi-enable-h {
+-			rockchip,pins = <1 18 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-	};
+-
+-	usb2 {
+-		usb20_host_drv: usb20-host-drv {
+-			rockchip,pins = <0 27 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-	};
+-
+-	usb3 {
+-		usb30_host_drv: usb30-host-drv {
+-			rockchip,pins = <0 0 RK_FUNC_GPIO &pcfg_pull_none>;
++	usb {
++		usb_host_drv: usb-host-drv {
++			rockchip,pins = <0 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 	};
+ };
+ 
+ &rkvdec {
+ 	status = "okay";
++	vcodec-supply = <&vdd_logic>;
+ };
+ 
+ &rkvdec_mmu {
+@@ -442,11 +504,17 @@
+ 	cap-mmc-highspeed;
+ 	cap-sd-highspeed;
+ 	disable-wp;
+-	max-frequency = <150000000>;
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&sdmmc0_clk &sdmmc0_cmd &sdmmc0_dectn &sdmmc0_bus4>;
+-	vmmc-supply = <&vcc_sd>;
+ 	supports-sd;
++	vmmc-supply = <&vcc_sd>;
++	status = "okay";
++};
++
++&spdif {
++	#sound-dai-cells = <0>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&spdifm0_tx>;
+ 	status = "okay";
+ };
+ 
+@@ -454,39 +522,61 @@
+ 	status = "okay";
+ 
+ 	flash@0 {
+-		compatible = "gigadevice,gd25q128", "jedec,spi-nor";
++		compatible = "jedec,spi-nor";
+ 		#address-cells = <1>;
+ 		#size-cells = <1>;
+ 		reg = <0>;
+ 		m25p,fast-read;
+ 		/* The max SCLK of the flash 104/80 MHZ  */
+ 		spi-max-frequency = <50000000>;
++
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			loader@8000 {
++				label = "loader";
++				reg = <0x8000 0x3F0000>;
++			};
++		};
+ 	};
+ };
+ 
++&threshold {
++	temperature = <80000>; /* millicelsius */
++};
++
++&target {
++	temperature = <95000>; /* millicelsius */
++};
++
++&soc_crit {
++	temperature = <100000>; /* millicelsius */
++};
++
+ &tsadc {
+ 	rockchip,hw-tshut-mode = <0>;
+ 	rockchip,hw-tshut-polarity = <0>;
++	rockchip,hw-tshut-temp = <110000>;
+ 	status = "okay";
+ };
+ 
+ &u2phy {
+ 	status = "okay";
+-
+ };
+ 
+ &u2phy_host {
+-	phy-supply = <&vcc_host1_5v>;
+ 	status = "okay";
+ };
+ 
+ &u2phy_otg {
+-	phy-supply = <&vcc_otg_5v>;
++	vbus-supply = <&vcc_otg_5v>;
+ 	status = "okay";
+ };
+ 
+ &u3phy {
+-	phy-supply = <&vcc_host_5v>;
++	vbus-supply = <&vcc_host_5v>;
+ 	status = "okay";
+ };
+ 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328-rockbox.dts b/arch/arm64/boot/dts/rockchip/rk3328-rockbox.dts
 new file mode 100644
 index 000000000000..4ba9b1e78846
@@ -2405,4611 +4474,155 @@ index 000000000000..4ba9b1e78846
 +&venc_srv {
 +	status = "okay";
 +};
-
-From aa7c314431dcd5fd3dd6dd8b06859c472e93cf5d Mon Sep 17 00:00:00 2001
-From: Jonas Karlman <jonas@kwiboo.se>
-Date: Wed, 17 Jan 2018 22:17:45 +0100
-Subject: [PATCH] arm64: dts: rockchip: add rk3328-roc-cc board
-
----
- arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts | 576 +++++++++++++++++++++++++
- 1 file changed, 576 insertions(+)
- create mode 100644 arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts b/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts
-new file mode 100644
-index 000000000000..af2af859d56e
---- /dev/null
-+++ b/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts
-@@ -0,0 +1,576 @@
-+/*
-+ * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd
-+ *
-+ * This file is dual-licensed: you can use it either under the terms
-+ * of the GPL or the X11 license, at your option. Note that this dual
-+ * licensing only applies to this file, and not this project as a
-+ * whole.
-+ *
-+ *  a) This library is free software; you can redistribute it and/or
-+ *     modify it under the terms of the GNU General Public License as
-+ *     published by the Free Software Foundation; either version 2 of the
-+ *     License, or (at your option) any later version.
-+ *
-+ *     This library is distributed in the hope that it will be useful,
-+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ *     GNU General Public License for more details.
-+ *
-+ * Or, alternatively,
-+ *
-+ *  b) Permission is hereby granted, free of charge, to any person
-+ *     obtaining a copy of this software and associated documentation
-+ *     files (the "Software"), to deal in the Software without
-+ *     restriction, including without limitation the rights to use,
-+ *     copy, modify, merge, publish, distribute, sublicense, and/or
-+ *     sell copies of the Software, and to permit persons to whom the
-+ *     Software is furnished to do so, subject to the following
-+ *     conditions:
-+ *
-+ *     The above copyright notice and this permission notice shall be
-+ *     included in all copies or substantial portions of the Software.
-+ *
-+ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-+ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-+ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-+ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-+ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-+ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-+ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-+ *     OTHER DEALINGS IN THE SOFTWARE.
-+ */
-+
-+/dts-v1/;
-+#include "rk3328.dtsi"
-+
-+/ {
-+	model = "Firefly ROC-RK3328-CC Board";
-+	compatible = "firefly,roc-rk3328-cc", "rockchip,rk3328";
-+
-+	chosen {
-+		bootargs = "earlyprintk=uart8250-32bit,0xff130000 swiotlb=1 kpti=0";
-+		stdout-path = "serial2:1500000n8";
-+	};
-+
-+	xin32k: xin32k {
-+		compatible = "fixed-clock";
-+		clock-frequency = <32768>;
-+		clock-output-names = "xin32k";
-+		#clock-cells = <0>;
-+	};
-+
-+	gmac_clkin: external-gmac-clock {
-+		compatible = "fixed-clock";
-+		clock-frequency = <125000000>;
-+		clock-output-names = "gmac_clkin";
-+		#clock-cells = <0>;
-+	};
-+
-+	vcc_phy: vcc-phy-regulator {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc_phy";
-+		regulator-always-on;
-+		regulator-boot-on;
-+	};
-+
-+	vcc_sys: vcc-sys {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc_sys";
-+		regulator-always-on;
-+		regulator-boot-on;
-+		regulator-min-microvolt = <5000000>;
-+		regulator-max-microvolt = <5000000>;
-+	};
-+
-+	vcc_sd: sdmmc-regulator {
-+		compatible = "regulator-fixed";
-+		gpio = <&gpio0 RK_PD6 GPIO_ACTIVE_LOW>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&sdmmc0m1_gpio>;
-+		regulator-name = "vcc_sd";
-+		regulator-min-microvolt = <3300000>;
-+		regulator-max-microvolt = <3300000>;
-+		vin-supply = <&vcc_io>;
-+	};
-+
-+	vccio_sd: sdmmcio-regulator {
-+		compatible = "regulator-gpio";
-+		gpios = <&gpio0 RK_PD1 GPIO_ACTIVE_HIGH>;
-+		states = <1800000 0x1
-+			  3300000 0x0>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&sd_pwr_1800_sel>;
-+		regulator-name = "vccio_sd";
-+		regulator-type = "voltage";
-+		regulator-min-microvolt = <1800000>;
-+		regulator-max-microvolt = <3300000>;
-+	};
-+
-+	vcc_host_5v: vcc_host1_5v: vcc_otg_5v: vcc-host-5v-regulator {
-+		compatible = "regulator-fixed";
-+		enable-active-high;
-+		gpio = <&gpio1 RK_PD2 GPIO_ACTIVE_HIGH>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&usb_host_drv>;
-+		regulator-name = "vcc_host_5v";
-+		regulator-always-on;
-+		regulator-min-microvolt = <5000000>;
-+		regulator-max-microvolt = <5000000>;
-+		vin-supply = <&vcc_sys>;
-+	};
-+
-+	leds {
-+		compatible = "gpio-leds";
-+
-+		power {
-+			gpios = <&rk805 1 GPIO_ACTIVE_LOW>;
-+			linux,default-trigger = "heartbeat";
+diff --git a/arch/arm64/boot/dts/rockchip/rk3328.dtsi b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
+index 0632be9e73f8..b07dfe78dd07 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3328.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
+@@ -89,6 +89,8 @@
+ 			device_type = "cpu";
+ 			compatible = "arm,cortex-a53", "arm,armv8";
+ 			reg = <0x0 0x1>;
++			clocks = <&cru ARMCLK>;
++			dynamic-power-coefficient = <120>;
+ 			enable-method = "psci";
+ 			operating-points-v2 = <&cpu0_opp_table>;
+ 		};
+@@ -96,6 +98,8 @@
+ 			device_type = "cpu";
+ 			compatible = "arm,cortex-a53", "arm,armv8";
+ 			reg = <0x0 0x2>;
++			clocks = <&cru ARMCLK>;
++			dynamic-power-coefficient = <120>;
+ 			enable-method = "psci";
+ 			operating-points-v2 = <&cpu0_opp_table>;
+ 		};
+@@ -103,6 +107,8 @@
+ 			device_type = "cpu";
+ 			compatible = "arm,cortex-a53", "arm,armv8";
+ 			reg = <0x0 0x3>;
++			clocks = <&cru ARMCLK>;
++			dynamic-power-coefficient = <120>;
+ 			enable-method = "psci";
+ 			operating-points-v2 = <&cpu0_opp_table>;
+ 		};
+@@ -164,6 +170,22 @@
+ 			opp-microvolt-L1 = <1300000 1300000 1350000>;
+ 			clock-latency-ns = <40000>;
+ 		};
++		/*
++		opp-1392000000 {
++			opp-hz = /bits/ 64 <1392000000>;
++			opp-microvolt = <1350000 1350000 1350000>;
++			opp-microvolt-L0 = <1350000 1350000 1350000>;
++			opp-microvolt-L1 = <1325000 1325000 1350000>;
++			clock-latency-ns = <40000>;
 +		};
-+
-+		user {
-+			gpios = <&rk805 0 GPIO_ACTIVE_LOW>;
-+			linux,default-trigger = "mmc0";
++		opp-1512000000 {
++			opp-hz = /bits/ 64 <1512000000>;
++			opp-microvolt = <1350000 1350000 1350000>;
++			opp-microvolt-L0 = <1350000 1350000 1350000>;
++			opp-microvolt-L1 = <1325000 1325000 1350000>;
++			clock-latency-ns = <40000>;
 +		};
-+	};
-+
-+	ir-receiver {
-+		compatible = "gpio-ir-receiver";
-+		gpios = <&gpio2 RK_PA2 GPIO_ACTIVE_LOW>;
-+		linux,rc-map-name = "rc-roc-cc";
-+		pinctrl-0 = <&ir_int>;
-+		pinctrl-names = "default";
-+	};
-+
-+	hdmi-sound {
-+		compatible = "simple-audio-card";
-+		simple-audio-card,format = "i2s";
-+		simple-audio-card,mclk-fs = <128>;
-+		simple-audio-card,name = "HDMI";
-+		simple-audio-card,cpu {
-+			sound-dai = <&i2s0>;
-+		};
-+		simple-audio-card,codec {
-+			sound-dai = <&hdmi>;
-+		};
-+	};
-+
-+	sound {
-+		compatible = "simple-audio-card";
-+		simple-audio-card,format = "i2s";
-+		simple-audio-card,mclk-fs = <256>;
-+		simple-audio-card,name = "I2S";
-+		simple-audio-card,cpu {
-+			sound-dai = <&i2s1>;
-+		};
-+		simple-audio-card,codec {
-+			sound-dai = <&codec>;
-+		};
-+	};
-+};
-+
-+&codec {
-+	#sound-dai-cells = <0>;
-+	status = "okay";
-+};
-+
-+&cpu0 {
-+	cpu-supply = <&vdd_arm>;
-+};
-+
-+&cpu1 {
-+	cpu-supply = <&vdd_arm>;
-+};
-+
-+&cpu2 {
-+	cpu-supply = <&vdd_arm>;
-+};
-+
-+&cpu3 {
-+	cpu-supply = <&vdd_arm>;
-+};
-+
-+&dfi {
-+	status = "okay";
-+};
-+
-+&dmc {
-+	center-supply = <&vdd_logic>;
-+	status = "okay";
-+};
-+
-+&display_subsystem {
-+	status = "okay";
-+};
-+
-+&emmc {
-+	bus-width = <8>;
-+	cap-mmc-highspeed;
-+	mmc-hs200-1_8v;
-+	non-removable;
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&emmc_clk &emmc_cmd &emmc_bus8>;
-+	supports-emmc;
-+	vmmc-supply = <&vcc_io>;
-+	vqmmc-supply = <&vcc18_emmc>;
-+	status = "okay";
-+};
-+
-+&gmac2io {
-+	assigned-clocks = <&cru SCLK_MAC2IO>, <&cru SCLK_MAC2IO_EXT>;
-+	assigned-clock-parents = <&gmac_clkin>, <&gmac_clkin>;
-+	clock_in_out = "input";
-+	phy-supply = <&vcc_phy>;
-+	phy-mode = "rgmii";
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&rgmiim1_pins>;
-+	snps,reset-gpio = <&gpio1 RK_PC2 GPIO_ACTIVE_LOW>;
-+	snps,reset-active-low;
-+	snps,reset-delays-us = <0 10000 50000>;
-+	tx_delay = <0x25>;
-+	rx_delay = <0x11>;
-+	status = "okay";
-+};
-+
-+&gpu {
-+	status = "okay";
-+	mali-supply = <&vdd_logic>;
-+};
-+
-+&h265e {
-+	status = "okay";
-+};
-+
-+&h265e_mmu {
-+	status = "okay";
-+};
-+
-+&hdmi {
-+	#sound-dai-cells = <0>;
-+	ddc-i2c-scl-high-time-ns = <9625>;
-+	ddc-i2c-scl-low-time-ns = <10000>;
-+	status = "okay";
-+};
-+
-+&hdmiphy {
-+	status = "okay";
-+};
-+
-+&i2c1 {
-+	status = "okay";
-+
-+	rk805: rk805@18 {
-+		compatible = "rockchip,rk805";
-+		status = "okay";
-+		reg = <0x18>;
-+		interrupt-parent = <&gpio1>;
-+		interrupts = <24 IRQ_TYPE_LEVEL_LOW>;
-+		#clock-cells = <1>;
-+		clock-output-names = "rk805-clkout1", "rk805-clkout2";
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&pmic_int_l>;
-+		rockchip,system-power-controller;
-+		wakeup-source;
-+		gpio-controller;
-+		#gpio-cells = <2>;
-+
-+		vcc1-supply = <&vcc_sys>;
-+		vcc2-supply = <&vcc_sys>;
-+		vcc3-supply = <&vcc_sys>;
-+		vcc4-supply = <&vcc_sys>;
-+		vcc5-supply = <&vcc_io>;
-+		vcc6-supply = <&vcc_sys>;
-+
-+		rtc {
-+			status = "okay";
-+		};
-+
-+		pwrkey {
-+			status = "okay";
-+		};
-+
-+		gpio {
-+			status = "okay";
-+		};
-+
-+		regulators {
-+			compatible = "rk805-regulator";
-+			status = "okay";
-+			#address-cells = <1>;
-+			#size-cells = <0>;
-+
-+			vdd_logic: RK805_DCDC1 {
-+				regulator-compatible = "RK805_DCDC1";
-+				regulator-name = "vdd_logic";
-+				regulator-min-microvolt = <712500>;
-+				regulator-max-microvolt = <1450000>;
-+				regulator-initial-mode = <0x1>;
-+				regulator-ramp-delay = <12500>;
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-mode = <0x2>;
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <1000000>;
-+				};
-+			};
-+
-+			vdd_arm: RK805_DCDC2 {
-+				regulator-compatible = "RK805_DCDC2";
-+				regulator-name = "vdd_arm";
-+				regulator-init-microvolt = <1225000>;
-+				regulator-min-microvolt = <712500>;
-+				regulator-max-microvolt = <1450000>;
-+				regulator-initial-mode = <0x1>;
-+				regulator-ramp-delay = <12500>;
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-mode = <0x2>;
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <950000>;
-+				};
-+			};
-+
-+			vcc_ddr: RK805_DCDC3 {
-+				regulator-compatible = "RK805_DCDC3";
-+				regulator-name = "vcc_ddr";
-+				regulator-initial-mode = <0x1>;
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-mode = <0x2>;
-+					regulator-on-in-suspend;
-+				};
-+			};
-+
-+			vcc_io: RK805_DCDC4 {
-+				regulator-compatible = "RK805_DCDC4";
-+				regulator-name = "vcc_io";
-+				regulator-min-microvolt = <3300000>;
-+				regulator-max-microvolt = <3300000>;
-+				regulator-initial-mode = <0x1>;
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-mode = <0x2>;
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <3300000>;
-+				};
-+			};
-+
-+			vcc_18: RK805_LDO1 {
-+				regulator-compatible = "RK805_LDO1";
-+				regulator-name = "vcc_18";
-+				regulator-min-microvolt = <1800000>;
-+				regulator-max-microvolt = <1800000>;
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <1800000>;
-+				};
-+			};
-+
-+			vcc18_emmc: RK805_LDO2 {
-+				regulator-compatible = "RK805_LDO2";
-+				regulator-name = "vcc18_emmc";
-+				regulator-min-microvolt = <1800000>;
-+				regulator-max-microvolt = <1800000>;
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <1800000>;
-+				};
-+			};
-+
-+			vdd_10: RK805_LDO3 {
-+				regulator-compatible = "RK805_LDO3";
-+				regulator-name = "vdd_10";
-+				regulator-min-microvolt = <1000000>;
-+				regulator-max-microvolt = <1000000>;
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <1000000>;
-+				};
-+			};
-+		};
-+	};
-+};
-+
-+&i2s0 {
-+	#sound-dai-cells = <0>;
-+	rockchip,bclk-fs = <128>;
-+	status = "okay";
-+};
-+
-+&iep {
-+	status = "okay";
-+};
-+
-+&iep_mmu {
-+	status = "okay";
-+};
-+
-+&io_domains {
-+	status = "okay";
-+
-+	vccio1-supply = <&vcc_io>;
-+	vccio2-supply = <&vcc18_emmc>;
-+	vccio3-supply = <&vccio_sd>;
-+	vccio4-supply = <&vcc_io>;
-+	vccio5-supply = <&vcc_io>;
-+	vccio6-supply = <&vcc_io>;
-+	pmuio-supply = <&vcc_io>;
-+};
-+
-+&pinctrl {
-+	ir {
-+		ir_int: ir-int {
-+			rockchip,pins = <2 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+
-+	sd-pwerset {
-+		sd_pwr_1800_sel: sd-pwr-1800-sel {
-+			rockchip,pins = <0 RK_PD1 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+
-+	pmic {
-+		pmic_int_l: pmic-int-l {
-+			rockchip,pins = <1 RK_PD0 RK_FUNC_GPIO &pcfg_pull_up>;
-+		};
-+	};
-+
-+	usb {
-+		usb_host_drv: usb-host-drv {
-+			rockchip,pins = <1 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+};
-+
-+&rkvdec {
-+	status = "okay";
-+	vcodec-supply = <&vdd_logic>;
-+};
-+
-+&rkvdec_mmu {
-+	status = "okay";
-+};
-+
-+&sdmmc {
-+	bus-width = <4>;
-+	cap-mmc-highspeed;
-+	cap-sd-highspeed;
-+	disable-wp;
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&sdmmc0_clk &sdmmc0_cmd &sdmmc0_dectn &sdmmc0_bus4>;
-+	sd-uhs-sdr104;
-+	supports-sd;
-+	vmmc-supply = <&vcc_sd>;
-+	vqmmc-supply = <&vccio_sd>;
-+	status = "okay";
-+};
-+
-+&threshold {
-+	temperature = <80000>; /* millicelsius */
-+};
-+
-+&target {
-+	temperature = <95000>; /* millicelsius */
-+};
-+
-+&soc_crit {
-+	temperature = <100000>; /* millicelsius */
-+};
-+
-+&tsadc {
-+	rockchip,hw-tshut-mode = <0>;
-+	rockchip,hw-tshut-polarity = <0>;
-+	rockchip,hw-tshut-temp = <110000>;
-+	status = "okay";
-+};
-+
-+&uart2 {
-+	status = "okay";
-+};
-+
-+&u2phy {
-+	status = "okay";
-+};
-+
-+&u2phy_host {
-+	phy-supply = <&vcc_host1_5v>;
-+	status = "okay";
-+};
-+
-+&u2phy_otg {
-+	phy-supply = <&vcc_otg_5v>;
-+	status = "okay";
-+};
-+
-+&u3phy {
-+	status = "okay";
-+};
-+
-+&u3phy_utmi {
-+	phy-supply = <&vcc_host_5v>;
-+	status = "okay";
-+};
-+
-+&u3phy_pipe {
-+	phy-supply = <&vcc_host_5v>;
-+	status = "okay";
-+};
-+
-+&usb20_otg {
-+	dr_mode = "host";
-+	status = "okay";
-+};
-+
-+&usb_host0_ehci {
-+	status = "okay";
-+};
-+
-+&usb_host0_ohci {
-+	status = "okay";
-+};
-+
-+&usbdrd3 {
-+	status = "okay";
-+};
-+
-+&usbdrd_dwc3 {
-+	status = "okay";
-+};
-+
-+&vop {
-+	status = "okay";
-+};
-+
-+&vop_mmu {
-+	status = "okay";
-+};
-+
-+&vpu_service {
-+	status = "okay";
-+};
-+
-+&vpu_mmu {
-+	status = "okay";
-+};
-+
-+&vepu {
-+	status = "okay";
-+};
-+
-+&vepu_mmu {
-+	status = "okay";
-+};
-+
-+&venc_srv {
-+	status = "okay";
-+};
-
-From 1652fa888921eb14a53fd6b12b6860247d5a9d0c Mon Sep 17 00:00:00 2001
-From: Jonas Karlman <jonas@kwiboo.se>
-Date: Sun, 3 Sep 2017 11:19:19 +0200
-Subject: [PATCH] arm64: dts: rockchip: rk3328-rock64: use two dai-link for i2s
- sound
-
----
- arch/arm64/boot/dts/rockchip/rk3328-rock64.dts | 26 +++++++++++++++++++++-----
- sound/soc/soc-utils.c                          | 10 ++++++++++
- 2 files changed, 31 insertions(+), 5 deletions(-)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3328-rock64.dts b/arch/arm64/boot/dts/rockchip/rk3328-rock64.dts
-index ff90c5379671..d47d572a6ca6 100644
---- a/arch/arm64/boot/dts/rockchip/rk3328-rock64.dts
-+++ b/arch/arm64/boot/dts/rockchip/rk3328-rock64.dts
-@@ -128,6 +128,11 @@
++		*/
+ 	};
+ 
+ 	arm-pmu {
+@@ -467,6 +489,7 @@
+ 		reg-shift = <2>;
+ 		reg-io-width = <4>;
+ 		dmas = <&dmac 2>, <&dmac 3>;
++		dma-names = "tx", "rx";
  		pinctrl-names = "default";
- 	};
- 
-+	dummy_codec: dummy-codec {
-+		compatible = "linux,snd-soc-dummy";
-+		#sound-dai-cells = <0>;
-+	};
-+
- 	hdmi-sound {
- 		compatible = "simple-audio-card";
- 		simple-audio-card,format = "i2s";
-@@ -143,14 +148,25 @@
- 
- 	sound {
- 		compatible = "simple-audio-card";
--		simple-audio-card,format = "i2s";
- 		simple-audio-card,mclk-fs = <256>;
- 		simple-audio-card,name = "I2S";
--		simple-audio-card,cpu {
--			sound-dai = <&i2s1>;
-+		simple-audio-card,dai-link@0 {
-+			format = "i2s";
-+			cpu {
-+				sound-dai = <&i2s1>;
-+			};
-+			codec {
-+				sound-dai = <&codec>;
-+			};
- 		};
--		simple-audio-card,codec {
--			sound-dai = <&codec>;
-+		simple-audio-card,dai-link@1 {
-+			format = "i2s";
-+			cpu {
-+				sound-dai = <&i2s1>;
-+			};
-+			codec {
-+				sound-dai = <&dummy_codec>;
-+			};
- 		};
- 	};
- 
-diff --git a/sound/soc/soc-utils.c b/sound/soc/soc-utils.c
-index 53dd085d3ee2..bf7ce34084a9 100644
---- a/sound/soc/soc-utils.c
-+++ b/sound/soc/soc-utils.c
-@@ -19,6 +19,7 @@
- #include <sound/pcm.h>
- #include <sound/pcm_params.h>
- #include <sound/soc.h>
-+#include <linux/module.h>
- 
- int snd_soc_calc_frame_size(int sample_size, int channels, int tdm_slots)
- {
-@@ -160,9 +161,18 @@ static int snd_soc_dummy_remove(struct platform_device *pdev)
- 	return 0;
- }
- 
-+#ifdef CONFIG_OF
-+static const struct of_device_id soc_dummy_ids[] = {
-+	{ .compatible = "linux,snd-soc-dummy", },
-+	{ }
-+};
-+MODULE_DEVICE_TABLE(of, soc_dummy_ids);
-+#endif
-+
- static struct platform_driver soc_dummy_driver = {
- 	.driver = {
- 		.name = "snd-soc-dummy",
-+		.of_match_table = of_match_ptr(soc_dummy_ids),
- 	},
- 	.probe = snd_soc_dummy_probe,
- 	.remove = snd_soc_dummy_remove,
-
-From 3184eaf3788de374e37ba0ee24ce641d6a20f780 Mon Sep 17 00:00:00 2001
-From: Jonas Karlman <jonas@kwiboo.se>
-Date: Fri, 26 Jan 2018 00:03:46 +0100
-Subject: [PATCH] arm64: dts: rockchip: rk3328-roc-cc: disable sd-card voltage
- select
-
-Voltage select should set GRF_SOC_CON10 bit 1,
-vendor kernel repurpose GPIO0_D1 to signal this,
-RK kernel uses GRF_SOC_CON10 bit 1 to mute avcodec.
----
- arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts | 10 ----------
- 1 file changed, 10 deletions(-)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts b/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts
-index af2af859d56e..e911cf265a64 100644
---- a/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts
-+++ b/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts
-@@ -98,8 +98,6 @@
- 		gpios = <&gpio0 RK_PD1 GPIO_ACTIVE_HIGH>;
- 		states = <1800000 0x1
- 			  3300000 0x0>;
--		pinctrl-names = "default";
--		pinctrl-0 = <&sd_pwr_1800_sel>;
- 		regulator-name = "vccio_sd";
- 		regulator-type = "voltage";
- 		regulator-min-microvolt = <1800000>;
-@@ -433,12 +431,6 @@
- 		};
- 	};
- 
--	sd-pwerset {
--		sd_pwr_1800_sel: sd-pwr-1800-sel {
--			rockchip,pins = <0 RK_PD1 RK_FUNC_GPIO &pcfg_pull_none>;
--		};
--	};
--
- 	pmic {
- 		pmic_int_l: pmic-int-l {
- 			rockchip,pins = <1 RK_PD0 RK_FUNC_GPIO &pcfg_pull_up>;
-@@ -468,10 +460,8 @@
- 	disable-wp;
- 	pinctrl-names = "default";
- 	pinctrl-0 = <&sdmmc0_clk &sdmmc0_cmd &sdmmc0_dectn &sdmmc0_bus4>;
--	sd-uhs-sdr104;
- 	supports-sd;
- 	vmmc-supply = <&vcc_sd>;
--	vqmmc-supply = <&vccio_sd>;
- 	status = "okay";
- };
- 
-
-From 200c456121d8644da9f4ffc3ac8acf2f8f8ecb5c Mon Sep 17 00:00:00 2001
-From: Jonas Karlman <jonas@kwiboo.se>
-Date: Sun, 28 Jan 2018 15:17:34 +0100
-Subject: [PATCH] arm64: dts: rockchip: add rk3399-sapphire board
-
----
- arch/arm64/boot/dts/rockchip/rk3399-sapphire.dts | 170 +++++++++++++++++++++++
- 1 file changed, 170 insertions(+)
- create mode 100644 arch/arm64/boot/dts/rockchip/rk3399-sapphire.dts
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3399-sapphire.dts b/arch/arm64/boot/dts/rockchip/rk3399-sapphire.dts
-new file mode 100644
-index 000000000000..8706dc7d91af
---- /dev/null
-+++ b/arch/arm64/boot/dts/rockchip/rk3399-sapphire.dts
-@@ -0,0 +1,170 @@
-+/*
-+ * Copyright (c) 2016 Fuzhou Rockchip Electronics Co., Ltd
-+ *
-+ * This file is dual-licensed: you can use it either under the terms
-+ * of the GPL or the X11 license, at your option. Note that this dual
-+ * licensing only applies to this file, and not this project as a
-+ * whole.
-+ *
-+ *  a) This file is free software; you can redistribute it and/or
-+ *     modify it under the terms of the GNU General Public License as
-+ *     published by the Free Software Foundation; either version 2 of the
-+ *     License, or (at your option) any later version.
-+ *
-+ *     This file is distributed in the hope that it will be useful,
-+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ *     GNU General Public License for more details.
-+ *
-+ * Or, alternatively,
-+ *
-+ *  b) Permission is hereby granted, free of charge, to any person
-+ *     obtaining a copy of this software and associated documentation
-+ *     files (the "Software"), to deal in the Software without
-+ *     restriction, including without limitation the rights to use,
-+ *     copy, modify, merge, publish, distribute, sublicense, and/or
-+ *     sell copies of the Software, and to permit persons to whom the
-+ *     Software is furnished to do so, subject to the following
-+ *     conditions:
-+ *
-+ *     The above copyright notice and this permission notice shall be
-+ *     included in all copies or substantial portions of the Software.
-+ *
-+ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-+ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-+ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-+ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-+ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-+ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-+ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-+ *     OTHER DEALINGS IN THE SOFTWARE.
-+ */
-+
-+/dts-v1/;
-+
-+#include "rk3399-sapphire.dtsi"
-+#include "rk3399-linux.dtsi"
-+#include <dt-bindings/input/input.h>
-+
-+/ {
-+	model = "Rockchip RK3399 Sapphire Board";
-+	compatible = "rockchip,rk3399-sapphire", "rockchip,rk3399";
-+
-+	gpio-keys {
-+		compatible = "gpio-keys";
-+		#address-cells = <1>;
-+		#size-cells = <0>;
-+		autorepeat;
-+
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&pwrbtn>;
-+
-+		button@0 {
-+			gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
-+			linux,code = <KEY_POWER>;
-+			label = "GPIO Key Power";
-+			linux,input-type = <1>;
-+			gpio-key,wakeup = <1>;
-+			debounce-interval = <100>;
-+		};
-+	};
-+
-+	vccadc_ref: vccadc-ref {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc1v8_sys";
-+		regulator-always-on;
-+		regulator-boot-on;
-+		regulator-min-microvolt = <1800000>;
-+		regulator-max-microvolt = <1800000>;
-+	};
-+};
-+
-+&hdmi_sound {
-+	simple-audio-card,name = "HDMI";
-+	status = "okay";
-+};
-+
-+&i2s2 {
-+	#sound-dai-cells = <0>;
-+	rockchip,bclk-fs = <128>;
-+	status = "okay";
-+};
-+
-+&iep {
-+	status = "okay";
-+};
-+
-+&iep_mmu {
-+	status = "okay";
-+};
-+
-+&saradc {
-+	vref-supply = <&vccadc_ref>;
-+};
-+
-+&vpu {
-+	status = "okay";
-+};
-+
-+&rkvdec {
-+	status = "okay";
-+};
-+
-+&display_subsystem {
-+	ports = <&vopb_out>;
-+	status = "okay";
-+};
-+
-+&route_hdmi {
-+	status = "okay";
-+};
-+
-+&cdn_dp {
-+	status = "disabled";
-+};
-+
-+&dp_in_vopb {
-+	status = "disabled";
-+};
-+
-+&hdmi {
-+	#address-cells = <1>;
-+	#size-cells = <0>;
-+	#sound-dai-cells = <0>;
-+	status = "okay";
-+};
-+
-+&pcie_phy {
-+	status = "disabled";
-+};
-+
-+&pcie0 {
-+	status = "disabled";
-+};
-+
-+&sdio0 {
-+	status = "disabled";
-+};
-+
-+&vopb {
-+	status = "okay";
-+};
-+
-+&vopb_mmu {
-+	status = "okay";
-+};
-+
-+&pinctrl {
-+	sdio-pwrseq {
-+		wifi_enable_h: wifi-enable-h {
-+			rockchip,pins =
-+				<0 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+
-+	buttons {
-+		pwrbtn: pwrbtn {
-+			rockchip,pins = <0 5 RK_FUNC_GPIO &pcfg_pull_up>;
-+		};
-+	};
-+};
-
-From 1ac825316b3a44cd22bf7904f230e725a8163f2c Mon Sep 17 00:00:00 2001
-From: Jonas Karlman <jonas@kwiboo.se>
-Date: Sun, 28 Jan 2018 15:17:53 +0100
-Subject: [PATCH] arm64: dts: rockchip: add rk3399-rock960 board
-
----
- arch/arm64/boot/dts/rockchip/rk3399-rock960.dts | 1003 +++++++++++++++++++++++
- 1 file changed, 1003 insertions(+)
- create mode 100644 arch/arm64/boot/dts/rockchip/rk3399-rock960.dts
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rock960.dts b/arch/arm64/boot/dts/rockchip/rk3399-rock960.dts
-new file mode 100644
-index 000000000000..865a1da96aee
---- /dev/null
-+++ b/arch/arm64/boot/dts/rockchip/rk3399-rock960.dts
-@@ -0,0 +1,1003 @@
-+/*
-+ * Copyright (c) 2016 Fuzhou Rockchip Electronics Co., Ltd
-+ *
-+ * This file is dual-licensed: you can use it either under the terms
-+ * of the GPL or the X11 license, at your option. Note that this dual
-+ * licensing only applies to this file, and not this project as a
-+ * whole.
-+ *
-+ *  a) This file is free software; you can redistribute it and/or
-+ *     modify it under the terms of the GNU General Public License as
-+ *     published by the Free Software Foundation; either version 2 of the
-+ *     License, or (at your option) any later version.
-+ *
-+ *     This file is distributed in the hope that it will be useful,
-+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ *     GNU General Public License for more details.
-+ *
-+ * Or, alternatively,
-+ *
-+ *  b) Permission is hereby granted, free of charge, to any person
-+ *     obtaining a copy of this software and associated documentation
-+ *     files (the "Software"), to deal in the Software without
-+ *     restriction, including without limitation the rights to use,
-+ *     copy, modify, merge, publish, distribute, sublicense, and/or
-+ *     sell copies of the Software, and to permit persons to whom the
-+ *     Software is furnished to do so, subject to the following
-+ *     conditions:
-+ *
-+ *     The above copyright notice and this permission notice shall be
-+ *     included in all copies or substantial portions of the Software.
-+ *
-+ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-+ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-+ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-+ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-+ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-+ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-+ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-+ *     OTHER DEALINGS IN THE SOFTWARE.
-+ */
-+
-+/dts-v1/;
-+
-+#include <dt-bindings/pwm/pwm.h>
-+#include <dt-bindings/input/input.h>
-+#include "rk3399.dtsi"
-+#include "rk3399-linux.dtsi"
-+#include "rk3399-opp.dtsi"
-+
-+
-+/ {
-+	model = "ROCK960";
-+	compatible = "96rocks,rock960", "rockchip,rk3399";
-+
-+	vcc1v8_s0: vcc1v8-s0 {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc1v8_s0";
-+		regulator-min-microvolt = <1800000>;
-+		regulator-max-microvolt = <1800000>;
-+		regulator-always-on;
-+	};
-+
-+	vcc_sys: vcc-sys {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc_sys";
-+		regulator-min-microvolt = <5000000>;
-+		regulator-max-microvolt = <5000000>;
-+		regulator-always-on;
-+	};
-+
-+	vcc_phy: vcc-phy-regulator {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc_phy";
-+		regulator-always-on;
-+		regulator-boot-on;
-+	};
-+
-+	vcc3v3_sys: vcc3v3-sys {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc3v3_sys";
-+		regulator-min-microvolt = <3300000>;
-+		regulator-max-microvolt = <3300000>;
-+		regulator-always-on;
-+		vin-supply = <&vcc_sys>;
-+	};
-+
-+	vcc3v3_pcie: vcc3v3-pcie-regulator {
-+		compatible = "regulator-fixed";
-+		gpio = <&gpio3 11 GPIO_ACTIVE_LOW>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&pcie_drv>;
-+		regulator-boot-on;
-+		regulator-always-on;
-+		regulator-name = "vcc3v3_pcie";
-+		vin-supply = <&vcc3v3_sys>;
-+	};
-+
-+	vcc5v0_host: vcc5v0-host-regulator {
-+		compatible = "regulator-fixed";
-+		enable-active-high;
-+		gpio = <&gpio4 25 GPIO_ACTIVE_HIGH>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&host_vbus_drv>;
-+		regulator-name = "vcc5v0_host";
-+		regulator-always-on;
-+	};
-+
-+	vdd_log: vdd-log {
-+		compatible = "pwm-regulator";
-+		pwms = <&pwm2 0 25000 1>;
-+		regulator-name = "vdd_log";
-+		regulator-min-microvolt = <800000>;
-+		regulator-max-microvolt = <1400000>;
-+		regulator-always-on;
-+		regulator-boot-on;
-+
-+		/* for rockchip boot on */
-+		rockchip,pwm_id= <2>;
-+		rockchip,pwm_voltage = <900000>;
-+
-+		vin-supply = <&vcc_sys>;
-+	};
-+
-+	clkin_gmac: external-gmac-clock {
-+		compatible = "fixed-clock";
-+		clock-frequency = <125000000>;
-+		clock-output-names = "clkin_gmac";
-+		#clock-cells = <0>;
-+	};
-+
-+	hdmi-sound {
-+		compatible = "simple-audio-card";
-+		simple-audio-card,format = "i2s";
-+		simple-audio-card,mclk-fs = <256>;
-+		simple-audio-card,name = "HDMI";
-+		simple-audio-card,cpu {
-+			sound-dai = <&i2s2>;
-+		};
-+		simple-audio-card,codec {
-+			sound-dai = <&hdmi>;
-+		};
-+	};
-+
-+	spdif-sound {
-+		compatible = "simple-audio-card";
-+		simple-audio-card,name = "SPDIF";
-+		simple-audio-card,cpu {
-+			sound-dai = <&spdif>;
-+		};
-+		simple-audio-card,codec {
-+			sound-dai = <&spdif_out>;
-+		};
-+	};
-+
-+	spdif_out: spdif-out {
-+		compatible = "linux,spdif-dit";
-+		#sound-dai-cells = <0>;
-+	};
-+
-+	sdio_pwrseq: sdio-pwrseq {
-+		compatible = "mmc-pwrseq-simple";
-+		clocks = <&rk808 1>;
-+		clock-names = "ext_clock";
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&wifi_enable_h>;
-+		post-power-on-delay-ms = <200>;
-+		power-off-delay-us = <10>;
-+
-+		/*
-+		 * On the module itself this is one of these (depending
-+		 * on the actual card populated):
-+		 * - SDIO_RESET_L_WL_REG_ON
-+		 * - PDN (power down when low)
-+		 */
-+		reset-gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
-+	};
-+
-+	wireless-wlan {
-+		compatible = "wlan-platdata";
-+		rockchip,grf = <&grf>;
-+		wifi_chip_type = "ap6354";
-+		sdio_vref = <1800>;
-+		WIFI,host_wake_irq = <&gpio0 3 GPIO_ACTIVE_HIGH>;
-+		status = "okay";
-+	};
-+
-+	wireless-bluetooth {
-+		compatible = "bluetooth-platdata";
-+		clocks = <&rk808 1>;
-+		clock-names = "ext_clock";
-+		/* wifi-bt-power-toggle; */
-+		uart_rts_gpios = <&gpio2 19 GPIO_ACTIVE_LOW>;
-+		pinctrl-names = "default", "rts_gpio";
-+		pinctrl-0 = <&uart0_rts>;
-+		pinctrl-1 = <&uart0_gpios>;
-+		/* BT,power_gpio  = <&gpio3 19 GPIO_ACTIVE_HIGH>; */
-+		BT,reset_gpio    = <&gpio0 9 GPIO_ACTIVE_HIGH>;
-+		BT,wake_gpio     = <&gpio2 27 GPIO_ACTIVE_HIGH>;
-+		BT,wake_host_irq = <&gpio0 4 GPIO_ACTIVE_HIGH>;
-+		status = "okay";
-+	};
-+
-+	test-power {
-+		status = "okay";
-+	};
-+};
-+
-+&hdmi {
-+	#address-cells = <1>;
-+	#size-cells = <0>;
-+	#sound-dai-cells = <0>;
-+	status = "okay";
-+};
-+
-+&sdmmc {
-+	clock-frequency = <100000000>;
-+	max-frequency = <100000000>;
-+	supports-sd;
-+	bus-width = <4>;
-+	cap-mmc-highspeed;
-+	cap-sd-highspeed;
-+	disable-wp;
-+	num-slots = <1>;
-+	sd-uhs-sdr12;
-+	sd-uhs-sdr25;
-+	sd-uhs-sdr50;
-+	sd-uhs-sdr104;
-+	vqmmc-supply = <&vcc_sd>;
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&sdmmc_clk &sdmmc_cmd &sdmmc_cd &sdmmc_bus4>;
-+	card-detect-delay = <800>;
-+	status = "okay";
-+};
-+
-+&sdio0 {
-+	clock-frequency = <100000000>;
-+	max-frequency = <100000000>;
-+	supports-sdio;
-+	bus-width = <4>;
-+	disable-wp;
-+	cap-sd-highspeed;
-+	cap-sdio-irq;
-+	keep-power-in-suspend;
-+	mmc-pwrseq = <&sdio_pwrseq>;
-+	non-removable;
-+	num-slots = <1>;
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&sdio0_bus4 &sdio0_cmd &sdio0_clk>;
-+	sd-uhs-sdr104;
-+	status = "okay";
-+};
-+
-+&emmc_phy {
-+	status = "okay";
-+};
-+
-+&sdhci {
-+	bus-width = <8>;
-+	mmc-hs400-1_8v;
-+	supports-emmc;
-+	non-removable;
-+	mmc-hs400-enhanced-strobe;
-+	status = "okay";
-+};
-+
-+&i2s0 {
-+	status = "okay";
-+	rockchip,i2s-broken-burst-len;
-+	rockchip,playback-channels = <8>;
-+	rockchip,capture-channels = <8>;
-+	#sound-dai-cells = <0>;
-+};
-+
-+&i2s2 {
-+	#sound-dai-cells = <0>;
-+	rockchip,bclk-fs = <128>;
-+	status = "okay";
-+};
-+
-+&spdif {
-+	pinctrl-0 = <&spdif_bus_1>;
-+	status = "okay";
-+	#sound-dai-cells = <0>;
-+};
-+
-+&i2c0 {
-+	status = "okay";
-+	i2c-scl-rising-time-ns = <168>;
-+	i2c-scl-falling-time-ns = <4>;
-+	clock-frequency = <400000>;
-+
-+	vdd_cpu_b: syr827@40 {
-+		compatible = "silergy,syr827";
-+		reg = <0x40>;
-+		regulator-compatible = "fan53555-reg";
-+		pinctrl-0 = <&vsel1_gpio>;
-+		vsel-gpios = <&gpio1 17 GPIO_ACTIVE_HIGH>;
-+		regulator-name = "vdd_cpu_b";
-+		regulator-min-microvolt = <712500>;
-+		regulator-max-microvolt = <1500000>;
-+		regulator-ramp-delay = <1000>;
-+		fcs,suspend-voltage-selector = <1>;
-+		regulator-always-on;
-+		regulator-boot-on;
-+		vin-supply = <&vcc_sys>;
-+		regulator-state-mem {
-+			regulator-off-in-suspend;
-+		};
-+	};
-+
-+	vdd_gpu: syr828@41 {
-+		compatible = "silergy,syr828";
-+		reg = <0x41>;
-+		regulator-compatible = "fan53555-reg";
-+		pinctrl-0 = <&vsel2_gpio>;
-+		vsel-gpios = <&gpio1 14 GPIO_ACTIVE_HIGH>;
-+		regulator-name = "vdd_gpu";
-+		regulator-min-microvolt = <712500>;
-+		regulator-max-microvolt = <1500000>;
-+		regulator-ramp-delay = <1000>;
-+		fcs,suspend-voltage-selector = <1>;
-+		regulator-always-on;
-+		regulator-boot-on;
-+		vin-supply = <&vcc_sys>;
-+		regulator-initial-mode = <1>; /* 1:force PWM 2:auto */
-+		regulator-state-mem {
-+			regulator-off-in-suspend;
-+		};
-+	};
-+
-+	rk808: pmic@1b {
-+		compatible = "rockchip,rk808";
-+		reg = <0x1b>;
-+		interrupt-parent = <&gpio1>;
-+		interrupts = <21 IRQ_TYPE_LEVEL_LOW>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&pmic_int_l>;
-+		rockchip,system-power-controller;
-+		wakeup-source;
-+		#clock-cells = <1>;
-+		clock-output-names = "xin32k", "rk808-clkout2";
-+
-+		vcc1-supply = <&vcc_sys>;
-+		vcc2-supply = <&vcc_sys>;
-+		vcc3-supply = <&vcc_sys>;
-+		vcc4-supply = <&vcc_sys>;
-+		vcc6-supply = <&vcc_sys>;
-+		vcc7-supply = <&vcc_sys>;
-+		vcc8-supply = <&vcc3v3_sys>;
-+		vcc9-supply = <&vcc_sys>;
-+		vcc10-supply = <&vcc_sys>;
-+		vcc11-supply = <&vcc_sys>;
-+		vcc12-supply = <&vcc3v3_sys>;
-+		vddio-supply = <&vcc_1v8>;
-+
-+		regulators {
-+			vdd_center: DCDC_REG1 {
-+				regulator-name = "vdd_center";
-+				regulator-min-microvolt = <750000>;
-+				regulator-max-microvolt = <1350000>;
-+				regulator-ramp-delay = <6001>;
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-off-in-suspend;
-+				};
-+			};
-+
-+			vdd_cpu_l: DCDC_REG2 {
-+				regulator-name = "vdd_cpu_l";
-+				regulator-min-microvolt = <750000>;
-+				regulator-max-microvolt = <1350000>;
-+				regulator-ramp-delay = <6001>;
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-off-in-suspend;
-+				};
-+			};
-+
-+			vcc_ddr: DCDC_REG3 {
-+				regulator-name = "vcc_ddr";
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+				};
-+			};
-+
-+			vcc_1v8: DCDC_REG4 {
-+				regulator-name = "vcc_1v8";
-+				regulator-min-microvolt = <1800000>;
-+				regulator-max-microvolt = <1800000>;
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <1800000>;
-+				};
-+			};
-+
-+			vcc1v8_dvp: LDO_REG1 {
-+				regulator-name = "vcc1v8_dvp";
-+				regulator-min-microvolt = <1800000>;
-+				regulator-max-microvolt = <1800000>;
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <1800000>;
-+				};
-+			};
-+
-+			vcca1v8_hdmi: LDO_REG2 {
-+				regulator-name = "vcca1v8_hdmi";
-+				regulator-min-microvolt = <1800000>;
-+				regulator-max-microvolt = <1800000>;
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <1800000>;
-+				};
-+			};
-+
-+			vcca_1v8: LDO_REG3 {
-+				regulator-name = "vcca_1v8";
-+				regulator-min-microvolt = <1800000>;
-+				regulator-max-microvolt = <1800000>;
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <1800000>;
-+				};
-+			};
-+
-+			vcc_sd: LDO_REG4 {
-+				regulator-name = "vcc_sd";
-+				regulator-min-microvolt = <1800000>;
-+				regulator-max-microvolt = <3000000>;
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <3000000>;
-+				};
-+			};
-+
-+			vcc3v0_sd: LDO_REG5 {
-+				regulator-name = "vcc3v0_sd";
-+				regulator-min-microvolt = <3000000>;
-+				regulator-max-microvolt = <3000000>;
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <3000000>;
-+				};
-+			};
-+
-+			vcc_1v5: LDO_REG6 {
-+				regulator-name = "vcc_1v5";
-+				regulator-min-microvolt = <1500000>;
-+				regulator-max-microvolt = <1500000>;
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <1500000>;
-+				};
-+			};
-+
-+			vcca0v9_hdmi: LDO_REG7 {
-+				regulator-name = "vcca0v9_hdmi";
-+				regulator-min-microvolt = <900000>;
-+				regulator-max-microvolt = <900000>;
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <900000>;
-+				};
-+			};
-+
-+			vcc_3v0: LDO_REG8 {
-+				regulator-name = "vcc_3v0";
-+				regulator-min-microvolt = <3000000>;
-+				regulator-max-microvolt = <3000000>;
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <3000000>;
-+				};
-+			};
-+
-+			vcc3v3_s3: SWITCH_REG1 {
-+				regulator-name = "vcc3v3_s3";
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+				};
-+			};
-+
-+			vcc3v3_s0: SWITCH_REG2 {
-+				regulator-name = "vcc3v3_s0";
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+				};
-+			};
-+		};
-+	};
-+};
-+
-+&i2c1 {
-+	status = "okay";
-+};
-+
-+&i2c6 {
-+	status = "okay";
-+};
-+
-+&i2c4 {
-+	status = "okay";
-+	fusb0: fusb30x@22 {
-+		compatible = "fairchild,fusb302";
-+		reg = <0x22>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&fusb0_int>;
-+		vbus-5v-gpios = <&gpio1 3 GPIO_ACTIVE_LOW>;
-+		int-n-gpios = <&gpio1 2 GPIO_ACTIVE_HIGH>;
-+		status = "okay";
-+	};
-+};
-+
-+&i2c2 {
-+	status = "okay";
-+	camera0: camera-module@10 {
-+		status = "disabled";
-+		compatible = "omnivision,ov13850-v4l2-i2c-subdev";
-+		reg = < 0x10 >;
-+		device_type = "v4l2-i2c-subdev";
-+		clocks = <&cru SCLK_CIF_OUT>;
-+		clock-names = "clk_cif_out";
-+		pinctrl-names = "rockchip,camera_default",
-+				"rockchip,camera_sleep";
-+		pinctrl-0 = <&cam0_default_pins>;
-+		pinctrl-1 = <&cam0_sleep_pins>;
-+		//rockchip,pd-gpio = <&gpio4 4 GPIO_ACTIVE_LOW>;
-+		rockchip,pwr-gpio = <&gpio4 4 GPIO_ACTIVE_HIGH>;
-+		rockchip,rst-gpio = <&gpio3 29 GPIO_ACTIVE_LOW>;
-+		rockchip,camera-module-mclk-name = "clk_cif_out";
-+		rockchip,camera-module-facing = "back";
-+		rockchip,camera-module-name = "cmk-cb0695-fv1";
-+		rockchip,camera-module-len-name = "lg9569a2";
-+		rockchip,camera-module-fov-h = "66.0";
-+		rockchip,camera-module-fov-v = "50.1";
-+		rockchip,camera-module-orientation = <0>;
-+		rockchip,camera-module-iq-flip = <0>;
-+		rockchip,camera-module-iq-mirror = <0>;
-+		rockchip,camera-module-flip = <1>;
-+		rockchip,camera-module-mirror = <0>;
-+
-+		rockchip,camera-module-defrect0 = <2112 1568 0 0 2112 1568>;
-+		rockchip,camera-module-defrect1 = <4224 3136 0 0 4224 3136>;
-+		rockchip,camera-module-defrect3 = <3264 2448 0 0 3264 2448>;
-+		rockchip,camera-module-flash-support = <1>;
-+		rockchip,camera-module-mipi-dphy-index = <0>;
-+	};
-+
-+	camera1: camera-module@36 {
-+		status = "disabled";
-+		compatible = "omnivision,ov4690-v4l2-i2c-subdev";
-+		reg = <0x36>;
-+		device_type = "v4l2-i2c-subdev";
-+		clocks = <&cru SCLK_CIF_OUT>;
-+		clock-names = "clk_cif_out";
-+		pinctrl-names = "rockchip,camera_default",
-+				"rockchip,camera_sleep";
-+		pinctrl-0 = <&cam0_default_pins>;
-+		pinctrl-1 = <&cam0_sleep_pins>;
-+		rockchip,pd-gpio = <&gpio3 4 GPIO_ACTIVE_LOW>;
-+		//rockchip,pwr-gpio = <&gpio3 13 0>;
-+		rockchip,rst-gpio = <&gpio2 10 GPIO_ACTIVE_LOW>;
-+		rockchip,camera-module-mclk-name = "clk_cif_out";
-+		rockchip,camera-module-facing = "back";
-+		rockchip,camera-module-name = "LA6111PA";
-+		rockchip,camera-module-len-name = "YM6011P";
-+		rockchip,camera-module-fov-h = "116";
-+		rockchip,camera-module-fov-v = "61";
-+		rockchip,camera-module-orientation = <0>;
-+		rockchip,camera-module-iq-flip = <0>;
-+		rockchip,camera-module-iq-mirror = <0>;
-+		rockchip,camera-module-flip = <0>;
-+		rockchip,camera-module-mirror = <1>;
-+
-+		rockchip,camera-module-defrect0 = <2688 1520 0 0 2688 1520>;
-+		rockchip,camera-module-flash-support = <0>;
-+		rockchip,camera-module-mipi-dphy-index = <0>;
-+	};
-+
-+};
-+
-+&cpu_l0 {
-+	cpu-supply = <&vdd_cpu_l>;
-+};
-+
-+&cpu_l1 {
-+	cpu-supply = <&vdd_cpu_l>;
-+};
-+
-+&cpu_l2 {
-+	cpu-supply = <&vdd_cpu_l>;
-+};
-+
-+&cpu_l3 {
-+	cpu-supply = <&vdd_cpu_l>;
-+};
-+
-+&cpu_b0 {
-+	cpu-supply = <&vdd_cpu_b>;
-+};
-+
-+&cpu_b1 {
-+	cpu-supply = <&vdd_cpu_b>;
-+};
-+
-+&gpu {
-+	status = "okay";
-+	mali-supply = <&vdd_gpu>;
-+};
-+
-+&threshold {
-+	temperature = <85000>;
-+};
-+
-+&target {
-+	temperature = <100000>;
-+};
-+
-+&soc_crit {
-+	temperature = <105000>;
-+};
-+
-+&tcphy0 {
-+	extcon = <&fusb0>;
-+	status = "okay";
-+};
-+
-+&tcphy1 {
-+	status = "okay";
-+};
-+
-+&tsadc {
-+	/* tshut mode 0:CRU 1:GPIO */
-+	rockchip,hw-tshut-mode = <1>;
-+	/* tshut polarity 0:LOW 1:HIGH */
-+	rockchip,hw-tshut-polarity = <1>;
-+	rockchip,hw-tshut-temp = <110000>;
-+	status = "okay";
-+};
-+
-+&u2phy0 {
-+	status = "okay";
-+	extcon = <&fusb0>;
-+
-+	u2phy0_otg: otg-port {
-+		status = "okay";
-+	};
-+
-+	u2phy0_host: host-port {
-+		phy-supply = <&vcc5v0_host>;
-+		status = "okay";
-+	};
-+};
-+
-+&u2phy1 {
-+	status = "okay";
-+
-+	u2phy1_otg: otg-port {
-+		status = "okay";
-+	};
-+
-+	u2phy1_host: host-port {
-+		phy-supply = <&vcc5v0_host>;
-+		status = "okay";
-+	};
-+};
-+
-+&uart0 {
-+	dmas = <&dmac_peri 0>, <&dmac_peri 1>;
-+	dma-names = "tx", "rx";
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&uart0_xfer &uart0_cts>;
-+	status = "okay";
-+};
-+
-+&uart2 {
-+	status = "okay";
-+};
-+
-+&uart3 {
-+	dmas = <&dmac_peri 6>, <&dmac_peri 7>;
-+	dma-names = "tx", "rx";
-+	status = "okay";
-+};
-+
-+&uart4 {
-+	dmas = <&dmac_peri 8>, <&dmac_peri 9>;
-+	dma-names = "tx", "rx";
-+	status = "okay";
-+};
-+
-+&usb_host0_ehci {
-+	status = "okay";
-+};
-+
-+&usb_host0_ohci {
-+	status = "okay";
-+};
-+
-+&usb_host1_ehci {
-+	status = "okay";
-+};
-+
-+&usb_host1_ohci {
-+	status = "okay";
-+};
-+
-+&usbdrd3_0 {
-+	extcon = <&fusb0>;
-+	status = "okay";
-+};
-+
-+&usbdrd_dwc3_0 {
-+	dr_mode = "otg";
-+	status = "okay";
-+};
-+
-+&usbdrd3_1 {
-+	status = "okay";
-+};
-+
-+&usbdrd_dwc3_1 {
-+	dr_mode = "host";
-+	status = "okay";
-+};
-+
-+&pwm2 {
-+	status = "okay";
-+};
-+
-+&gmac {
-+	phy-supply = <&vcc_phy>;
-+	phy-mode = "rgmii";
-+	clock_in_out = "input";
-+	snps,reset-gpio = <&gpio3 15 GPIO_ACTIVE_LOW>;
-+	snps,reset-active-low;
-+	snps,reset-delays-us = <0 10000 50000>;
-+	assigned-clocks = <&cru SCLK_RMII_SRC>;
-+	assigned-clock-parents = <&clkin_gmac>;
-+	pinctrl-names = "default", "sleep";
-+	pinctrl-0 = <&rgmii_pins>;
-+	pinctrl-1 = <&rgmii_sleep_pins>;
-+	tx_delay = <0x28>;
-+	rx_delay = <0x11>;
-+	status = "disabled";
-+};
-+
-+&saradc {
-+	status = "okay";
-+};
-+
-+&iep {
-+	status = "okay";
-+};
-+
-+&iep_mmu {
-+	status = "okay";
-+};
-+
-+&io_domains {
-+	status = "okay";
-+
-+	bt656-supply = <&vcc1v8_s0>; /* bt656_gpio2ab_ms */
-+	audio-supply = <&vcc1v8_s0>; /* audio_gpio3d4a_ms */
-+	sdmmc-supply = <&vcc_sd>; /* sdmmc_gpio4b_ms */
-+	gpio1830-supply = <&vcc_3v0>; /* gpio1833_gpio4cd_ms */
-+};
-+
-+&pcie_phy {
-+	status = "okay";
-+};
-+
-+&pcie0 {
-+	ep-gpios = <&gpio3 9 GPIO_ACTIVE_HIGH>;
-+	num-lanes = <4>;
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&pcie_clkreqn_cpm>;
-+	status = "okay";
-+};
-+
-+&pinctrl {
-+
-+	sdio0 {
-+		sdio0_bus1: sdio0-bus1 {
-+			rockchip,pins =
-+				<2 20 RK_FUNC_1 &pcfg_pull_up_20ma>;
-+		};
-+
-+		sdio0_bus4: sdio0-bus4 {
-+			rockchip,pins =
-+				<2 20 RK_FUNC_1 &pcfg_pull_up_20ma>,
-+				<2 21 RK_FUNC_1 &pcfg_pull_up_20ma>,
-+				<2 22 RK_FUNC_1 &pcfg_pull_up_20ma>,
-+				<2 23 RK_FUNC_1 &pcfg_pull_up_20ma>;
-+		};
-+
-+		sdio0_cmd: sdio0-cmd {
-+			rockchip,pins =
-+				<2 24 RK_FUNC_1 &pcfg_pull_up_20ma>;
-+		};
-+
-+		sdio0_clk: sdio0-clk {
-+			rockchip,pins =
-+				<2 25 RK_FUNC_1 &pcfg_pull_none_20ma>;
-+		};
-+	};
-+
-+	sdmmc {
-+		sdmmc_bus1: sdmmc-bus1 {
-+			rockchip,pins =
-+				<4 8 RK_FUNC_1 &pcfg_pull_up_8ma>;
-+		};
-+
-+		sdmmc_bus4: sdmmc-bus4 {
-+			rockchip,pins =
-+				<4 8 RK_FUNC_1 &pcfg_pull_up_8ma>,
-+				<4 9 RK_FUNC_1 &pcfg_pull_up_8ma>,
-+				<4 10 RK_FUNC_1 &pcfg_pull_up_8ma>,
-+				<4 11 RK_FUNC_1 &pcfg_pull_up_8ma>;
-+		};
-+
-+		sdmmc_clk: sdmmc-clk {
-+			rockchip,pins =
-+				<4 12 RK_FUNC_1 &pcfg_pull_none_18ma>;
-+		};
-+
-+		sdmmc_cmd: sdmmc-cmd {
-+			rockchip,pins =
-+				<4 13 RK_FUNC_1 &pcfg_pull_up_8ma>;
-+		};
-+	};
-+
-+	sdio-pwrseq {
-+		wifi_enable_h: wifi-enable-h {
-+			rockchip,pins =
-+				<0 9 RK_FUNC_GPIO &pcfg_pull_none>,
-+				<0 10 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+
-+	wireless-bluetooth {
-+		uart0_gpios: uart0-gpios {
-+			rockchip,pins =
-+				<2 19 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+
-+	usb2 {
-+		host_vbus_drv: host-vbus-drv {
-+			rockchip,pins =
-+				<4 25 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+
-+	pcie {
-+		pcie_drv: pcie-drv {
-+			rockchip,pins =
-+				<3 11 RK_FUNC_GPIO &pcfg_pull_none>;
-+			};
-+	};
-+
-+	pmic {
-+		pmic_int_l: pmic-int-l {
-+			rockchip,pins =
-+				<1 21 RK_FUNC_GPIO &pcfg_pull_up>;
-+		};
-+
-+		vsel1_gpio: vsel1-gpio {
-+			rockchip,pins =
-+				<1 17 RK_FUNC_GPIO &pcfg_pull_down>;
-+		};
-+
-+		vsel2_gpio: vsel2-gpio {
-+			rockchip,pins =
-+				<1 14 RK_FUNC_GPIO &pcfg_pull_down>;
-+		};
-+	};
-+
-+	gmac {
-+		rgmii_sleep_pins: rgmii-sleep-pins {
-+			rockchip,pins =
-+				<3 15 RK_FUNC_GPIO &pcfg_output_low>;
-+		};
-+	};
-+
-+	fusb30x {
-+		fusb0_int: fusb0-int {
-+			rockchip,pins =
-+				<1 2 RK_FUNC_GPIO &pcfg_pull_up>;
-+		};
-+	};
-+};
-+
-+&pvtm {
-+	status = "okay";
-+};
-+
-+&pmu_pvtm {
-+	status = "okay";
-+};
-+
-+&pmu_io_domains {
-+	status = "okay";
-+	pmu1830-supply = <&vcc_1v8>;
-+};
-+
-+&rockchip_suspend {
-+	status = "okay";
-+	rockchip,sleep-debug-en = <0>;
-+	rockchip,sleep-mode-config = <
-+		(0
-+		| RKPM_SLP_ARMPD
-+		| RKPM_SLP_PERILPPD
-+		| RKPM_SLP_DDR_RET
-+		| RKPM_SLP_PLLPD
-+		| RKPM_SLP_CENTER_PD
-+		| RKPM_SLP_AP_PWROFF
-+		)
-+	>;
-+	rockchip,wakeup-config = <
-+		(0
-+		| RKPM_GPIO_WKUP_EN
-+		| RKPM_PWM_WKUP_EN
-+		)
-+	>;
-+	rockchip,pwm-regulator-config = <
-+		(0
-+		| PWM2_REGULATOR_EN
-+		)
-+	>;
-+	rockchip,power-ctrl =
-+		<&gpio1 17 GPIO_ACTIVE_HIGH>,
-+		<&gpio1 14 GPIO_ACTIVE_HIGH>;
-+};
-+
-+&vopb {
-+	status = "okay";
-+};
-+
-+&vopb_mmu {
-+	status = "okay";
-+};
-+
-+&cif_isp0 {
-+	rockchip,camera-modules-attached = <&camera0>;
-+	status = "okay";
-+};
-+
-+&isp0_mmu {
-+	status = "okay";
-+};
-+
-+&cif_isp1 {
-+	rockchip,camera-modules-attached = <&camera1>;
-+	status = "disabled";
-+};
-+
-+&isp1_mmu {
-+	status = "okay";
-+};
-+
-+&vpu {
-+	status = "okay";
-+	/* 0 means ion, 1 means drm */
-+	//allocator = <0>;
-+};
-+
-+&rkvdec {
-+	status = "okay";
-+	/* 0 means ion, 1 means drm */
-+	//allocator = <0>;
-+};
-+
-+&display_subsystem {
-+	status = "okay";
-+};
-
-From 493cb1d1e8ae9aeafe0a008039fb03fe7f441c8b Mon Sep 17 00:00:00 2001
-From: Jonas Karlman <jonas@kwiboo.se>
-Date: Sun, 28 Jan 2018 15:38:32 +0100
-Subject: [PATCH] arm: dts: rk3288: add cec clock and pinctrl
-
----
- arch/arm/boot/dts/rk3288.dtsi | 16 +++++++++++++---
- 1 file changed, 13 insertions(+), 3 deletions(-)
-
-diff --git a/arch/arm/boot/dts/rk3288.dtsi b/arch/arm/boot/dts/rk3288.dtsi
-index 9cca69f9f5ba..2141eb23faa7 100644
---- a/arch/arm/boot/dts/rk3288.dtsi
-+++ b/arch/arm/boot/dts/rk3288.dtsi
-@@ -981,7 +981,8 @@
- 					 <&cru PCLK_MIPI_DSI1>,
- 					 <&cru SCLK_EDP_24M>,
- 					 <&cru SCLK_EDP>,
-					 <&cru SCLK_HDMI_CEC>,
-+					 <&cru SCLK_HDMI_HDCP>,
- 					 <&cru SCLK_ISP_JPE>,
- 					 <&cru SCLK_ISP>,
- 					 <&cru SCLK_RGA>;
-@@ -1966,6 +1968,14 @@
- 						 &pcfg_pull_none>;
- 			};
- 
-+			hdmi_cec_c0: hdmi-cec-c0 {
-+				rockchip,pins = <7 16 RK_FUNC_2 &pcfg_pull_none>;
-+			};
-+
-+			hdmi_cec_c7: hdmi-cec-c7 {
-+				rockchip,pins = <7 23 RK_FUNC_4 &pcfg_pull_none>;
-+			};
-+
- 			hdmi_ddc: hdmi-ddc {
- 				rockchip,pins = <7 19 RK_FUNC_2 &pcfg_pull_none>,
- 						<7 20 RK_FUNC_2 &pcfg_pull_none>;
-
-@@ -1660,7 +1660,7 @@
-                clocks = <&cru  PCLK_HDMI_CTRL>, <&cru SCLK_HDMI_HDCP>, <&cru SCLK_HDMI_CEC>;
-                clock-names = "iahb", "isfr", "cec";
-                pinctrl-names = "default", "sleep";
--               pinctrl-0 = <&hdmi_ddc>;
-+               pinctrl-0 = <&hdmi_ddc &hdmi_cec_c0>;
-                pinctrl-1 = <&hdmi_gpio>;
-                power-domains = <&power RK3288_PD_VIO>;
-                status = "disabled";
-@@ -2050,10 +2050,6 @@
-                                                 &pcfg_pull_none>;
-                        };
- 
--                       hdmi_cec: hdmi-cec {
--                               rockchip,pins = <7 16 RK_FUNC_2 &pcfg_pull_none>;
--                       };
--
-                        hdmi_cec_c0: hdmi-cec-c0 {
-                                rockchip,pins = <7 16 RK_FUNC_2 &pcfg_pull_none>;
-                        };
-
-From d7b647f6bb133b0ee27d759900516c1750c268fe Mon Sep 17 00:00:00 2001
-From: Jonas Karlman <jonas@kwiboo.se>
-Date: Sun, 4 Mar 2018 09:08:35 +0100
-Subject: [PATCH] arm64: dts: rockchip: add rk3328-box-trn9 board
-
----
- arch/arm64/boot/dts/rockchip/rk3328-box-trn9.dts | 675 +++++++++++++++++++++++
- 1 file changed, 675 insertions(+)
- create mode 100644 arch/arm64/boot/dts/rockchip/rk3328-box-trn9.dts
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3328-box-trn9.dts b/arch/arm64/boot/dts/rockchip/rk3328-box-trn9.dts
-new file mode 100644
-index 000000000000..51d471ba8cef
---- /dev/null
-+++ b/arch/arm64/boot/dts/rockchip/rk3328-box-trn9.dts
-@@ -0,0 +1,675 @@
-+/*
-+ * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd
-+ *
-+ * This file is dual-licensed: you can use it either under the terms
-+ * of the GPL or the X11 license, at your option. Note that this dual
-+ * licensing only applies to this file, and not this project as a
-+ * whole.
-+ *
-+ *  a) This library is free software; you can redistribute it and/or
-+ *     modify it under the terms of the GNU General Public License as
-+ *     published by the Free Software Foundation; either version 2 of the
-+ *     License, or (at your option) any later version.
-+ *
-+ *     This library is distributed in the hope that it will be useful,
-+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ *     GNU General Public License for more details.
-+ *
-+ * Or, alternatively,
-+ *
-+ *  b) Permission is hereby granted, free of charge, to any person
-+ *     obtaining a copy of this software and associated documentation
-+ *     files (the "Software"), to deal in the Software without
-+ *     restriction, including without limitation the rights to use,
-+ *     copy, modify, merge, publish, distribute, sublicense, and/or
-+ *     sell copies of the Software, and to permit persons to whom the
-+ *     Software is furnished to do so, subject to the following
-+ *     conditions:
-+ *
-+ *     The above copyright notice and this permission notice shall be
-+ *     included in all copies or substantial portions of the Software.
-+ *
-+ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-+ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-+ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-+ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-+ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-+ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-+ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-+ *     OTHER DEALINGS IN THE SOFTWARE.
-+ */
-+
-+/dts-v1/;
-+#include "rk3328.dtsi"
-+
-+/ {
-+	model = "Rockchip RK3328 TRN9";
-+	compatible = "rockchip,rk3328-box-trn9", "rockchip,rk3328";
-+
-+	chosen {
-+		bootargs = "swiotlb=1 kpti=0";
-+	};
-+
-+	aliases {
-+		serial0 = &uart2;
-+		serial2 = &uart0;
-+	};
-+
-+	xin32k: xin32k {
-+		compatible = "fixed-clock";
-+		clock-frequency = <32768>;
-+		clock-output-names = "xin32k";
-+		#clock-cells = <0>;
-+	};
-+
-+	gmac_clkin: external-gmac-clock {
-+		compatible = "fixed-clock";
-+		clock-frequency = <125000000>;
-+		clock-output-names = "gmac_clkin";
-+		#clock-cells = <0>;
-+	};
-+
-+	vcc_phy: vcc-phy-regulator {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc_phy";
-+		regulator-always-on;
-+		regulator-boot-on;
-+	};
-+
-+	vcc_sys: vcc-sys {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc_sys";
-+		regulator-always-on;
-+		regulator-boot-on;
-+		regulator-min-microvolt = <5000000>;
-+		regulator-max-microvolt = <5000000>;
-+	};
-+
-+	vcc_sd: sdmmc-regulator {
-+		compatible = "regulator-fixed";
-+		gpio = <&gpio0 RK_PD6 GPIO_ACTIVE_LOW>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&sdmmc0m1_gpio>;
-+		regulator-name = "vcc_sd";
-+		regulator-always-on;
-+		regulator-boot-on;
-+		regulator-min-microvolt = <3300000>;
-+		regulator-max-microvolt = <3300000>;
-+		vin-supply = <&vcc_io>;
-+	};
-+
-+	vcc_host_5v: vcc-host-5v-regulator {
-+		compatible = "regulator-fixed";
-+		enable-active-high;
-+		gpio = <&gpio0 RK_PA0 GPIO_ACTIVE_HIGH>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&usb30_host_drv>;
-+		regulator-name = "vcc_host_5v";
-+		regulator-always-on;
-+		regulator-min-microvolt = <5000000>;
-+		regulator-max-microvolt = <5000000>;
-+		vin-supply = <&vcc_sys>;
-+	};
-+
-+	vcc_host1_5v: vcc_otg_5v: vcc-host1-5v-regulator {
-+		compatible = "regulator-fixed";
-+		enable-active-high;
-+		gpio = <&gpio0 RK_PA2 GPIO_ACTIVE_HIGH>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&usb20_host_drv>;
-+		regulator-name = "vcc_host1_5v";
-+		regulator-always-on;
-+		regulator-min-microvolt = <5000000>;
-+		regulator-max-microvolt = <5000000>;
-+		vin-supply = <&vcc_sys>;
-+	};
-+
-+	leds {
-+		compatible = "gpio-leds";
-+
-+		power {
-+			gpios = <&rk805 0 GPIO_ACTIVE_LOW>;
-+			linux,default-trigger = "default-on";
-+			default-state = "on";
-+		};
-+	};
-+
-+	ir-receiver {
-+		compatible = "gpio-ir-receiver";
-+		gpios = <&gpio2 RK_PA2 GPIO_ACTIVE_LOW>;
-+		linux,rc-map-name = "rc-trn9";
-+		pinctrl-0 = <&ir_int>;
-+		pinctrl-names = "default";
-+	};
-+
-+	hdmi-sound {
-+		compatible = "simple-audio-card";
-+		simple-audio-card,format = "i2s";
-+		simple-audio-card,mclk-fs = <128>;
-+		simple-audio-card,name = "HDMI";
-+		simple-audio-card,cpu {
-+			sound-dai = <&i2s0>;
-+		};
-+		simple-audio-card,codec {
-+			sound-dai = <&hdmi>;
-+		};
-+	};
-+
-+	sound {
-+		compatible = "simple-audio-card";
-+		simple-audio-card,format = "i2s";
-+		simple-audio-card,mclk-fs = <256>;
-+		simple-audio-card,name = "I2S";
-+		simple-audio-card,cpu {
-+			sound-dai = <&i2s1>;
-+		};
-+		simple-audio-card,codec {
-+			sound-dai = <&codec>;
-+		};
-+	};
-+
-+	spdif-sound {
-+		compatible = "simple-audio-card";
-+		simple-audio-card,name = "SPDIF";
-+		simple-audio-card,cpu {
-+			sound-dai = <&spdif>;
-+		};
-+		simple-audio-card,codec {
-+			sound-dai = <&spdif_out>;
-+		};
-+	};
-+
-+	spdif_out: spdif-out {
-+		compatible = "linux,spdif-dit";
-+		#sound-dai-cells = <0>;
-+	};
-+
-+	sdio_pwrseq: sdio-pwrseq {
-+		compatible = "mmc-pwrseq-simple";
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&wifi_enable_h>;
-+
-+		/*
-+		 * On the module itself this is one of these (depending
-+		 * on the actual card populated):
-+		 * - SDIO_RESET_L_WL_REG_ON
-+		 * - PDN (power down when low)
-+		 */
-+		reset-gpios = <&gpio3 RK_PB0 GPIO_ACTIVE_LOW>;
-+	};
-+
-+	wireless-bluetooth {
-+		compatible = "bluetooth-platdata";
-+		BT,power_gpio = <&gpio1 RK_PD0 GPIO_ACTIVE_HIGH>;
-+		BT,wake_host_irq = <&gpio1 RK_PD2 GPIO_ACTIVE_HIGH>;
-+	};
-+
-+	wireless-wlan {
-+		compatible = "wlan-platdata";
-+		rockchip,grf = <&grf>;
-+		wifi_chip_type = "rtl8723bs";
-+		WIFI,host_wake_irq = <&gpio3 RK_PA1 GPIO_ACTIVE_HIGH>;
-+	};
-+};
-+
-+&codec {
-+	#sound-dai-cells = <0>;
-+	status = "okay";
-+};
-+
-+&cpu0 {
-+	cpu-supply = <&vdd_arm>;
-+};
-+
-+&cpu1 {
-+	cpu-supply = <&vdd_arm>;
-+};
-+
-+&cpu2 {
-+	cpu-supply = <&vdd_arm>;
-+};
-+
-+&cpu3 {
-+	cpu-supply = <&vdd_arm>;
-+};
-+
-+&dfi {
-+	status = "okay";
-+};
-+
-+&dmc {
-+	center-supply = <&vdd_logic>;
-+	status = "okay";
-+};
-+
-+&display_subsystem {
-+	status = "okay";
-+};
-+
-+&emmc {
-+	bus-width = <8>;
-+	cap-mmc-highspeed;
-+	mmc-hs200-1_8v;
-+	non-removable;
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&emmc_clk &emmc_cmd &emmc_bus8>;
-+	supports-emmc;
-+	vmmc-supply = <&vcc_io>;
-+	vqmmc-supply = <&vcc18_emmc>;
-+	status = "okay";
-+};
-+
-+&gmac2io {
-+	assigned-clocks = <&cru SCLK_MAC2IO>, <&cru SCLK_MAC2IO_EXT>;
-+	assigned-clock-parents = <&gmac_clkin>, <&gmac_clkin>;
-+	clock_in_out = "input";
-+	phy-supply = <&vcc_phy>;
-+	phy-mode = "rgmii";
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&rgmiim1_pins>;
-+	snps,reset-gpio = <&gpio1 RK_PC2 GPIO_ACTIVE_LOW>;
-+	snps,reset-active-low;
-+	snps,reset-delays-us = <0 10000 50000>;
-+	tx_delay = <0x26>;
-+	rx_delay = <0x11>;
-+	status = "okay";
-+};
-+
-+&gmac2phy {
-+	phy-supply = <&vcc_phy>;
-+	assigned-clocks = <&cru SCLK_MAC2PHY_SRC>;
-+	assigned-clock-rate = <50000000>;
-+	assigned-clocks = <&cru SCLK_MAC2PHY>;
-+	assigned-clock-parents = <&cru SCLK_MAC2PHY_SRC>;
-+	clock_in_out = "output";
-+	status = "disabled";
-+};
-+
-+&gpu {
-+	status = "okay";
-+	mali-supply = <&vdd_logic>;
-+};
-+
-+&h265e {
-+	status = "okay";
-+};
-+
-+&h265e_mmu {
-+	status = "okay";
-+};
-+
-+&hdmi {
-+	#sound-dai-cells = <0>;
-+	ddc-i2c-scl-high-time-ns = <9625>;
-+	ddc-i2c-scl-low-time-ns = <10000>;
-+	status = "okay";
-+};
-+
-+&hdmiphy {
-+	status = "okay";
-+};
-+
-+&i2c1 {
-+	status = "okay";
-+
-+	rk805: rk805@18 {
-+		compatible = "rockchip,rk805";
-+		status = "okay";
-+		reg = <0x18>;
-+		interrupt-parent = <&gpio2>;
-+		interrupts = <6 IRQ_TYPE_LEVEL_LOW>;
-+		#clock-cells = <1>;
-+		clock-output-names = "rk805-clkout1", "rk805-clkout2";
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&pmic_int_l>;
-+		rockchip,system-power-controller;
-+		wakeup-source;
-+		gpio-controller;
-+		#gpio-cells = <2>;
-+
-+		vcc1-supply = <&vcc_sys>;
-+		vcc2-supply = <&vcc_sys>;
-+		vcc3-supply = <&vcc_sys>;
-+		vcc4-supply = <&vcc_sys>;
-+		vcc5-supply = <&vcc_io>;
-+		vcc6-supply = <&vcc_sys>;
-+
-+		rtc {
-+			status = "okay";
-+		};
-+
-+		pwrkey {
-+			status = "okay";
-+		};
-+
-+		gpio {
-+			status = "okay";
-+		};
-+
-+		regulators {
-+			compatible = "rk805-regulator";
-+			status = "okay";
-+			#address-cells = <1>;
-+			#size-cells = <0>;
-+
-+			vdd_logic: RK805_DCDC1 {
-+				regulator-compatible = "RK805_DCDC1";
-+				regulator-name = "vdd_logic";
-+				regulator-min-microvolt = <712500>;
-+				regulator-max-microvolt = <1450000>;
-+				regulator-initial-mode = <0x1>;
-+				regulator-ramp-delay = <12500>;
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-mode = <0x2>;
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <1000000>;
-+				};
-+			};
-+
-+			vdd_arm: RK805_DCDC2 {
-+				regulator-compatible = "RK805_DCDC2";
-+				regulator-name = "vdd_arm";
-+				regulator-init-microvolt = <1225000>;
-+				regulator-min-microvolt = <712500>;
-+				regulator-max-microvolt = <1450000>;
-+				regulator-initial-mode = <0x1>;
-+				regulator-ramp-delay = <12500>;
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-mode = <0x2>;
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <950000>;
-+				};
-+			};
-+
-+			vcc_ddr: RK805_DCDC3 {
-+				regulator-compatible = "RK805_DCDC3";
-+				regulator-name = "vcc_ddr";
-+				regulator-initial-mode = <0x1>;
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-mode = <0x2>;
-+					regulator-on-in-suspend;
-+				};
-+			};
-+
-+			vcc_io: RK805_DCDC4 {
-+				regulator-compatible = "RK805_DCDC4";
-+				regulator-name = "vcc_io";
-+				regulator-min-microvolt = <3300000>;
-+				regulator-max-microvolt = <3300000>;
-+				regulator-initial-mode = <0x1>;
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-mode = <0x2>;
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <3300000>;
-+				};
-+			};
-+
-+			vcc_18: RK805_LDO1 {
-+				regulator-compatible = "RK805_LDO1";
-+				regulator-name = "vcc_18";
-+				regulator-min-microvolt = <1800000>;
-+				regulator-max-microvolt = <1800000>;
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <1800000>;
-+				};
-+			};
-+
-+			vcc18_emmc: RK805_LDO2 {
-+				regulator-compatible = "RK805_LDO2";
-+				regulator-name = "vcc18_emmc";
-+				regulator-min-microvolt = <1800000>;
-+				regulator-max-microvolt = <1800000>;
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <1800000>;
-+				};
-+			};
-+
-+			vdd_10: RK805_LDO3 {
-+				regulator-compatible = "RK805_LDO3";
-+				regulator-name = "vdd_10";
-+				regulator-min-microvolt = <1000000>;
-+				regulator-max-microvolt = <1000000>;
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <1000000>;
-+				};
-+			};
-+		};
-+	};
-+};
-+
-+&i2s0 {
-+	#sound-dai-cells = <0>;
-+	rockchip,bclk-fs = <128>;
-+	status = "okay";
-+};
-+
-+&i2s1 {
-+	#sound-dai-cells = <0>;
-+	status = "okay";
-+};
-+
-+&iep {
-+	status = "okay";
-+};
-+
-+&iep_mmu {
-+	status = "okay";
-+};
-+
-+&io_domains {
-+	status = "okay";
-+
-+	vccio1-supply = <&vcc_io>;
-+	vccio2-supply = <&vcc18_emmc>;
-+	vccio3-supply = <&vcc_io>;
-+	vccio4-supply = <&vcc_18>;
-+	vccio5-supply = <&vcc_io>;
-+	vccio6-supply = <&vcc_18>;
-+	pmuio-supply = <&vcc_io>;
-+};
-+
-+&pinctrl {
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&clk_32k_out>;
-+
-+	clk_32k {
-+		clk_32k_out: clk-32k-out {
-+			rockchip,pins = <1 RK_PD4 RK_FUNC_1 &pcfg_pull_none>;
-+		};
-+	};
-+
-+	ir {
-+		ir_int: ir-int {
-+			rockchip,pins = <2 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+
-+	pmic {
-+		pmic_int_l: pmic-int-l {
-+			rockchip,pins = <2 RK_PA6 RK_FUNC_GPIO &pcfg_pull_up>;
-+		};
-+	};
-+
-+	sdio-pwrseq {
-+		wifi_enable_h: wifi-enable-h {
-+			rockchip,pins = <3 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>,
-+				<3 RK_PA1 RK_FUNC_GPIO &pcfg_pull_none_4ma>,
-+				<1 RK_PD0 RK_FUNC_GPIO &pcfg_pull_none>,
-+				<1 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+
-+	usb2 {
-+		usb20_host_drv: usb20-host-drv {
-+			rockchip,pins = <0 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+
-+	usb3 {
-+		usb30_host_drv: usb30-host-drv {
-+			rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+};
-+
-+&rkvdec {
-+	status = "okay";
-+	vcodec-supply = <&vdd_logic>;
-+};
-+
-+&rkvdec_mmu {
-+	status = "okay";
-+};
-+
-+&sdmmc_ext {
-+	bus-width = <4>;
-+	cap-sd-highspeed;
-+	cap-sdio-irq;
-+	disable-wp;
-+	keep-power-in-suspend;
-+	mmc-pwrseq = <&sdio_pwrseq>;
-+	non-removable;
-+	num-slots = <1>;
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&sdmmc0ext_bus4 &sdmmc0ext_cmd &sdmmc0ext_clk>;
-+	sd-uhs-sdr104;
-+	supports-sdio;
-+	status = "okay";
-+};
-+
-+&sdmmc {
-+	bus-width = <4>;
-+	cap-mmc-highspeed;
-+	cap-sd-highspeed;
-+	disable-wp;
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&sdmmc0_clk &sdmmc0_cmd &sdmmc0_dectn &sdmmc0_bus4>;
-+	supports-sd;
-+	vmmc-supply = <&vcc_sd>;
-+	status = "okay";
-+};
-+
-+&spdif {
-+	#sound-dai-cells = <0>;
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&spdifm0_tx>;
-+	status = "okay";
-+};
-+
-+&threshold {
-+	temperature = <80000>; /* millicelsius */
-+};
-+
-+&target {
-+	temperature = <95000>; /* millicelsius */
-+};
-+
-+&soc_crit {
-+	temperature = <100000>; /* millicelsius */
-+};
-+
-+&tsadc {
-+	rockchip,hw-tshut-mode = <0>;
-+	rockchip,hw-tshut-polarity = <0>;
-+	rockchip,hw-tshut-temp = <110000>;
-+	status = "okay";
-+};
-+
-+&uart2 {
-+	status = "okay";
-+};
-+
-+&u2phy {
-+	status = "okay";
-+};
-+
-+&u2phy_host {
-+	phy-supply = <&vcc_host1_5v>;
-+	status = "okay";
-+};
-+
-+&u2phy_otg {
-+	phy-supply = <&vcc_otg_5v>;
-+	status = "okay";
-+};
-+
-+&u3phy {
-+	status = "okay";
-+};
-+
-+&u3phy_utmi {
-+	phy-supply = <&vcc_host_5v>;
-+	status = "okay";
-+};
-+
-+&u3phy_pipe {
-+	phy-supply = <&vcc_host_5v>;
-+	status = "okay";
-+};
-+
-+&usb20_otg {
-+	dr_mode = "host";
-+	status = "okay";
-+};
-+
-+&usb_host0_ehci {
-+	status = "okay";
-+};
-+
-+&usb_host0_ohci {
-+	status = "okay";
-+};
-+
-+&usbdrd3 {
-+	status = "okay";
-+};
-+
-+&usbdrd_dwc3 {
-+	status = "okay";
-+};
-+
-+&vop {
-+	status = "okay";
-+};
-+
-+&vop_mmu {
-+	status = "okay";
-+};
-+
-+&vpu_service {
-+	status = "okay";
-+};
-+
-+&vpu_mmu {
-+	status = "okay";
-+};
-+
-+&vepu {
-+	status = "okay";
-+};
-+
-+&vepu_mmu {
-+	status = "okay";
-+};
-+
-+&venc_srv {
-+	status = "okay";
-+};
-
-From 9c8d6637e4223718bdefacb33c32ffd1b386a343 Mon Sep 17 00:00:00 2001
-From: Jonas Karlman <jonas@kwiboo.se>
-Date: Sun, 4 Mar 2018 09:08:35 +0100
-Subject: [PATCH] arm64: dts: rockchip: add rk3328-box-z28 board
-
----
- arch/arm64/boot/dts/rockchip/rk3328-box-z28.dts | 598 ++++++++++++++++++++++++
- 1 file changed, 598 insertions(+)
- create mode 100644 arch/arm64/boot/dts/rockchip/rk3328-box-z28.dts
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3328-box-z28.dts b/arch/arm64/boot/dts/rockchip/rk3328-box-z28.dts
-new file mode 100644
-index 000000000000..00a3394cefcb
---- /dev/null
-+++ b/arch/arm64/boot/dts/rockchip/rk3328-box-z28.dts
-@@ -0,0 +1,598 @@
-+/*
-+ * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd
-+ *
-+ * This file is dual-licensed: you can use it either under the terms
-+ * of the GPL or the X11 license, at your option. Note that this dual
-+ * licensing only applies to this file, and not this project as a
-+ * whole.
-+ *
-+ *  a) This library is free software; you can redistribute it and/or
-+ *     modify it under the terms of the GNU General Public License as
-+ *     published by the Free Software Foundation; either version 2 of the
-+ *     License, or (at your option) any later version.
-+ *
-+ *     This library is distributed in the hope that it will be useful,
-+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ *     GNU General Public License for more details.
-+ *
-+ * Or, alternatively,
-+ *
-+ *  b) Permission is hereby granted, free of charge, to any person
-+ *     obtaining a copy of this software and associated documentation
-+ *     files (the "Software"), to deal in the Software without
-+ *     restriction, including without limitation the rights to use,
-+ *     copy, modify, merge, publish, distribute, sublicense, and/or
-+ *     sell copies of the Software, and to permit persons to whom the
-+ *     Software is furnished to do so, subject to the following
-+ *     conditions:
-+ *
-+ *     The above copyright notice and this permission notice shall be
-+ *     included in all copies or substantial portions of the Software.
-+ *
-+ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-+ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-+ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-+ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-+ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-+ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-+ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-+ *     OTHER DEALINGS IN THE SOFTWARE.
-+ */
-+
-+/dts-v1/;
-+#include "rk3328.dtsi"
-+
-+/ {
-+	model = "Rockchip RK3328 Z28";
-+	compatible = "rockchip,rk3328-box-z28", "rockchip,rk3328";
-+
-+	chosen {
-+		bootargs = "earlyprintk=uart8250-32bit,0xff130000 swiotlb=1 kpti=0";
-+		stdout-path = "serial2:1500000n8";
-+	};
-+
-+	xin32k: xin32k {
-+		compatible = "fixed-clock";
-+		clock-frequency = <32768>;
-+		clock-output-names = "xin32k";
-+		#clock-cells = <0>;
-+	};
-+
-+	vcc_phy: vcc-phy-regulator {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc_phy";
-+		regulator-always-on;
-+		regulator-boot-on;
-+	};
-+
-+	vcc_sys: vcc-sys {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc_sys";
-+		regulator-always-on;
-+		regulator-boot-on;
-+		regulator-min-microvolt = <5000000>;
-+		regulator-max-microvolt = <5000000>;
-+	};
-+
-+	vcc_sd: sdmmc-regulator {
-+		compatible = "regulator-fixed";
-+		gpio = <&gpio0 RK_PD6 GPIO_ACTIVE_LOW>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&sdmmc0m1_gpio>;
-+		regulator-name = "vcc_sd";
-+		regulator-always-on;
-+		regulator-boot-on;
-+		regulator-min-microvolt = <3300000>;
-+		regulator-max-microvolt = <3300000>;
-+		vin-supply = <&vcc_io>;
-+	};
-+
-+	vcc_host_5v: vcc-host-5v-regulator {
-+		compatible = "regulator-fixed";
-+		enable-active-high;
-+		gpio = <&gpio0 RK_PA0 GPIO_ACTIVE_HIGH>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&usb30_host_drv>;
-+		regulator-name = "vcc_host_5v";
-+		regulator-always-on;
-+		regulator-min-microvolt = <5000000>;
-+		regulator-max-microvolt = <5000000>;
-+		vin-supply = <&vcc_sys>;
-+	};
-+
-+	vcc_host1_5v: vcc_otg_5v: vcc-host1-5v-regulator {
-+		compatible = "regulator-fixed";
-+		enable-active-high;
-+		gpio = <&gpio0 RK_PA2 GPIO_ACTIVE_HIGH>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&usb20_host_drv>;
-+		regulator-name = "vcc_host1_5v";
-+		regulator-always-on;
-+		regulator-min-microvolt = <5000000>;
-+		regulator-max-microvolt = <5000000>;
-+		vin-supply = <&vcc_sys>;
-+	};
-+
-+	leds {
-+		compatible = "gpio-leds";
-+
-+		power {
-+			gpios = <&rk805 0 GPIO_ACTIVE_HIGH>;
-+			linux,default-trigger = "default-on";
-+			default-state = "on";
-+		};
-+	};
-+
-+	ir-receiver {
-+		compatible = "gpio-ir-receiver";
-+		gpios = <&gpio2 RK_PA2 GPIO_ACTIVE_LOW>;
-+		pinctrl-0 = <&ir_int>;
-+		pinctrl-names = "default";
-+	};
-+
-+	hdmi-sound {
-+		compatible = "simple-audio-card";
-+		simple-audio-card,format = "i2s";
-+		simple-audio-card,mclk-fs = <128>;
-+		simple-audio-card,name = "HDMI";
-+		simple-audio-card,cpu {
-+			sound-dai = <&i2s0>;
-+		};
-+		simple-audio-card,codec {
-+			sound-dai = <&hdmi>;
-+		};
-+	};
-+
-+	spdif-sound {
-+		compatible = "simple-audio-card";
-+		simple-audio-card,name = "SPDIF";
-+		simple-audio-card,cpu {
-+			sound-dai = <&spdif>;
-+		};
-+		simple-audio-card,codec {
-+			sound-dai = <&spdif_out>;
-+		};
-+	};
-+
-+	spdif_out: spdif-out {
-+		compatible = "linux,spdif-dit";
-+		#sound-dai-cells = <0>;
-+	};
-+
-+	wireless-bluetooth {
-+		compatible = "bluetooth-platdata";
-+		BT,power_gpio = <&gpio2 RK_PC5 GPIO_ACTIVE_HIGH>;
-+		BT,wake_host_irq = <&gpio2 RK_PC0 GPIO_ACTIVE_HIGH>;
-+	};
-+
-+	wireless-wlan {
-+		compatible = "wlan-platdata";
-+		rockchip,grf = <&grf>;
-+		wifi_chip_type = "rtl8188eu";
-+		WIFI,poweren_gpio = <&gpio2 RK_PC3 GPIO_ACTIVE_HIGH>;
-+		WIFI,reset_gpio = <&gpio2 RK_PC4 GPIO_ACTIVE_HIGH>;
-+		WIFI,host_wake_irq = <&gpio2 RK_PC6 GPIO_ACTIVE_HIGH>;
-+	};
-+};
-+
-+&codec {
-+	#sound-dai-cells = <0>;
-+	status = "okay";
-+};
-+
-+&cpu0 {
-+	cpu-supply = <&vdd_arm>;
-+};
-+
-+&cpu1 {
-+	cpu-supply = <&vdd_arm>;
-+};
-+
-+&cpu2 {
-+	cpu-supply = <&vdd_arm>;
-+};
-+
-+&cpu3 {
-+	cpu-supply = <&vdd_arm>;
-+};
-+
-+&dfi {
-+	status = "okay";
-+};
-+
-+&dmc {
-+	center-supply = <&vdd_logic>;
-+	status = "okay";
-+};
-+
-+&display_subsystem {
-+	status = "okay";
-+};
-+
-+&emmc {
-+	bus-width = <8>;
-+	cap-mmc-highspeed;
-+	mmc-hs200-1_8v;
-+	non-removable;
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&emmc_clk &emmc_cmd &emmc_bus8>;
-+	supports-emmc;
-+	vmmc-supply = <&vcc_io>;
-+	vqmmc-supply = <&vcc18_emmc>;
-+	status = "okay";
-+};
-+
-+&gmac2phy {
-+	phy-supply = <&vcc_phy>;
-+	assigned-clocks = <&cru SCLK_MAC2PHY_SRC>;
-+	assigned-clock-rate = <50000000>;
-+	assigned-clocks = <&cru SCLK_MAC2PHY>;
-+	assigned-clock-parents = <&cru SCLK_MAC2PHY_SRC>;
-+	clock_in_out = "output";
-+	status = "okay";
-+};
-+
-+&gpu {
-+	status = "okay";
-+	mali-supply = <&vdd_logic>;
-+};
-+
-+&h265e {
-+	status = "okay";
-+};
-+
-+&h265e_mmu {
-+	status = "okay";
-+};
-+
-+&hdmi {
-+	#sound-dai-cells = <0>;
-+	ddc-i2c-scl-high-time-ns = <9625>;
-+	ddc-i2c-scl-low-time-ns = <10000>;
-+	status = "okay";
-+};
-+
-+&hdmiphy {
-+	status = "okay";
-+};
-+
-+&i2c1 {
-+	status = "okay";
-+
-+	rk805: rk805@18 {
-+		compatible = "rockchip,rk805";
-+		status = "okay";
-+		reg = <0x18>;
-+		interrupt-parent = <&gpio2>;
-+		interrupts = <6 IRQ_TYPE_LEVEL_LOW>;
-+		#clock-cells = <1>;
-+		clock-output-names = "rk805-clkout1", "rk805-clkout2";
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&pmic_int_l>;
-+		rockchip,system-power-controller;
-+		wakeup-source;
-+		gpio-controller;
-+		#gpio-cells = <2>;
-+
-+		vcc1-supply = <&vcc_sys>;
-+		vcc2-supply = <&vcc_sys>;
-+		vcc3-supply = <&vcc_sys>;
-+		vcc4-supply = <&vcc_sys>;
-+		vcc5-supply = <&vcc_io>;
-+		vcc6-supply = <&vcc_sys>;
-+
-+		rtc {
-+			status = "okay";
-+		};
-+
-+		pwrkey {
-+			status = "okay";
-+		};
-+
-+		gpio {
-+			status = "okay";
-+		};
-+
-+		regulators {
-+			compatible = "rk805-regulator";
-+			status = "okay";
-+			#address-cells = <1>;
-+			#size-cells = <0>;
-+
-+			vdd_logic: RK805_DCDC1 {
-+				regulator-compatible = "RK805_DCDC1";
-+				regulator-name = "vdd_logic";
-+				regulator-min-microvolt = <712500>;
-+				regulator-max-microvolt = <1450000>;
-+				regulator-initial-mode = <0x1>;
-+				regulator-ramp-delay = <12500>;
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-mode = <0x2>;
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <1000000>;
-+				};
-+			};
-+
-+			vdd_arm: RK805_DCDC2 {
-+				regulator-compatible = "RK805_DCDC2";
-+				regulator-name = "vdd_arm";
-+				regulator-init-microvolt = <1225000>;
-+				regulator-min-microvolt = <712500>;
-+				regulator-max-microvolt = <1450000>;
-+				regulator-initial-mode = <0x1>;
-+				regulator-ramp-delay = <12500>;
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-mode = <0x2>;
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <950000>;
-+				};
-+			};
-+
-+			vcc_ddr: RK805_DCDC3 {
-+				regulator-compatible = "RK805_DCDC3";
-+				regulator-name = "vcc_ddr";
-+				regulator-initial-mode = <0x1>;
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-mode = <0x2>;
-+					regulator-on-in-suspend;
-+				};
-+			};
-+
-+			vcc_io: RK805_DCDC4 {
-+				regulator-compatible = "RK805_DCDC4";
-+				regulator-name = "vcc_io";
-+				regulator-min-microvolt = <3300000>;
-+				regulator-max-microvolt = <3300000>;
-+				regulator-initial-mode = <0x1>;
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-mode = <0x2>;
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <3300000>;
-+				};
-+			};
-+
-+			vcc_18: RK805_LDO1 {
-+				regulator-compatible = "RK805_LDO1";
-+				regulator-name = "vcc_18";
-+				regulator-min-microvolt = <1800000>;
-+				regulator-max-microvolt = <1800000>;
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <1800000>;
-+				};
-+			};
-+
-+			vcc18_emmc: RK805_LDO2 {
-+				regulator-compatible = "RK805_LDO2";
-+				regulator-name = "vcc18_emmc";
-+				regulator-min-microvolt = <1800000>;
-+				regulator-max-microvolt = <1800000>;
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <1800000>;
-+				};
-+			};
-+
-+			vdd_10: RK805_LDO3 {
-+				regulator-compatible = "RK805_LDO3";
-+				regulator-name = "vdd_10";
-+				regulator-min-microvolt = <1000000>;
-+				regulator-max-microvolt = <1000000>;
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <1000000>;
-+				};
-+			};
-+		};
-+	};
-+};
-+
-+&i2s0 {
-+	#sound-dai-cells = <0>;
-+	rockchip,bclk-fs = <128>;
-+	status = "okay";
-+};
-+
-+&iep {
-+	status = "okay";
-+};
-+
-+&iep_mmu {
-+	status = "okay";
-+};
-+
-+&io_domains {
-+	status = "okay";
-+
-+	vccio1-supply = <&vcc_io>;
-+	vccio2-supply = <&vcc18_emmc>;
-+	vccio3-supply = <&vcc_io>;
-+	vccio4-supply = <&vcc_18>;
-+	vccio5-supply = <&vcc_io>;
-+	vccio6-supply = <&vcc_io>;
-+	pmuio-supply = <&vcc_io>;
-+};
-+
-+&pinctrl {
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&clk_32k_out>;
-+
-+	clk_32k {
-+		clk_32k_out: clk-32k-out {
-+			rockchip,pins = <1 RK_PD4 RK_FUNC_1 &pcfg_pull_none>;
-+		};
-+	};
-+
-+	ir {
-+		ir_int: ir-int {
-+			rockchip,pins = <2 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+
-+	pmic {
-+		pmic_int_l: pmic-int-l {
-+			rockchip,pins = <2 RK_PA6 RK_FUNC_GPIO &pcfg_pull_up>;
-+		};
-+	};
-+
-+	usb2 {
-+		usb20_host_drv: usb20-host-drv {
-+			rockchip,pins = <0 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+
-+	usb3 {
-+		usb30_host_drv: usb30-host-drv {
-+			rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+};
-+
-+&rkvdec {
-+	status = "okay";
-+	vcodec-supply = <&vdd_logic>;
-+};
-+
-+&rkvdec_mmu {
-+	status = "okay";
-+};
-+
-+&sdmmc {
-+	bus-width = <4>;
-+	cap-mmc-highspeed;
-+	cap-sd-highspeed;
-+	disable-wp;
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&sdmmc0_clk &sdmmc0_cmd &sdmmc0_dectn &sdmmc0_bus4>;
-+	supports-sd;
-+	vmmc-supply = <&vcc_sd>;
-+	status = "okay";
-+};
-+
-+&spdif {
-+	#sound-dai-cells = <0>;
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&spdifm0_tx>;
-+	status = "okay";
-+};
-+
-+&threshold {
-+	temperature = <80000>; /* millicelsius */
-+};
-+
-+&target {
-+	temperature = <95000>; /* millicelsius */
-+};
-+
-+&soc_crit {
-+	temperature = <100000>; /* millicelsius */
-+};
-+
-+&tsadc {
-+	rockchip,hw-tshut-mode = <0>;
-+	rockchip,hw-tshut-polarity = <0>;
-+	rockchip,hw-tshut-temp = <110000>;
-+	status = "okay";
-+};
-+
-+&uart0 {
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&uart0_xfer &uart0_cts>;
-+	status = "okay";
-+};
-+
-+&uart2 {
-+	status = "okay";
-+};
-+
-+&u2phy {
-+	status = "okay";
-+};
-+
-+&u2phy_host {
-+	phy-supply = <&vcc_host1_5v>;
-+	status = "okay";
-+};
-+
-+&u2phy_otg {
-+	phy-supply = <&vcc_otg_5v>;
-+	status = "okay";
-+};
-+
-+&u3phy {
-+	status = "okay";
-+};
-+
-+&u3phy_utmi {
-+	phy-supply = <&vcc_host_5v>;
-+	status = "okay";
-+};
-+
-+&u3phy_pipe {
-+	phy-supply = <&vcc_host_5v>;
-+	status = "okay";
-+};
-+
-+&usb20_otg {
-+	dr_mode = "host";
-+	status = "okay";
-+};
-+
-+&usb_host0_ehci {
-+	status = "okay";
-+};
-+
-+&usb_host0_ohci {
-+	status = "okay";
-+};
-+
-+&usbdrd3 {
-+	status = "okay";
-+};
-+
-+&usbdrd_dwc3 {
-+	status = "okay";
-+};
-+
-+&vop {
-+	status = "okay";
-+};
-+
-+&vop_mmu {
-+	status = "okay";
-+};
-+
-+&vpu_service {
-+	status = "okay";
-+};
-+
-+&vpu_mmu {
-+	status = "okay";
-+};
-+
-+&vepu {
-+	status = "okay";
-+};
-+
-+&vepu_mmu {
-+	status = "okay";
-+};
-+
-+&venc_srv {
-+	status = "okay";
-+};
-
-From 63d34d434542f4551cc12578317f7d6337918d1d Mon Sep 17 00:00:00 2001
-From: Jonas Karlman <jonas@kwiboo.se>
-Date: Tue, 10 Apr 2018 22:07:37 +0200
-Subject: [PATCH] arm64: dts: rockchip: rk3328-roc-cc: use 1066MHz ddr
- frequency
-
----
- .../dts/rockchip/rk3328-dram-box-plus-timing.dtsi  | 263 +++++++++++++++++++++
- arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts     |  33 ++-
- 2 files changed, 295 insertions(+), 1 deletion(-)
- create mode 100644 arch/arm64/boot/dts/rockchip/rk3328-dram-box-plus-timing.dtsi
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3328-dram-box-plus-timing.dtsi b/arch/arm64/boot/dts/rockchip/rk3328-dram-box-plus-timing.dtsi
-new file mode 100644
-index 000000000000..ac34cc7ab1ce
---- /dev/null
-+++ b/arch/arm64/boot/dts/rockchip/rk3328-dram-box-plus-timing.dtsi
-@@ -0,0 +1,263 @@
-+/*
-+ * Copyright (c) 2016 Fuzhou Rockchip Electronics Co., Ltd
-+ *
-+ * This file is dual-licensed: you can use it either under the terms
-+ * of the GPL or the X11 license, at your option. Note that this dual
-+ * licensing only applies to this file, and not this project as a
-+ * whole.
-+ *
-+ *  a) This library is free software; you can redistribute it and/or
-+ *     modify it under the terms of the GNU General Public License as
-+ *     published by the Free Software Foundation; either version 2 of the
-+ *     License, or (at your option) any later version.
-+ *
-+ *     This library is distributed in the hope that it will be useful,
-+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ *     GNU General Public License for more details.
-+ *
-+ * Or, alternatively,
-+ *
-+ *  b) Permission is hereby granted, free of charge, to any person
-+ *     obtaining a copy of this software and associated documentation
-+ *     files (the "Software"), to deal in the Software without
-+ *     restriction, including without limitation the rights to use,
-+ *     copy, modify, merge, publish, distribute, sublicense, and/or
-+ *     sell copies of the Software, and to permit persons to whom the
-+ *     Software is furnished to do so, subject to the following
-+ *     conditions:
-+ *
-+ *     The above copyright notice and this permission notice shall be
-+ *     included in all copies or substantial portions of the Software.
-+ *
-+ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-+ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-+ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-+ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-+ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-+ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-+ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-+ *     OTHER DEALINGS IN THE SOFTWARE.
-+ */
-+#include <dt-bindings/clock/rockchip-ddr.h>
-+#include <dt-bindings/memory/rk3328-dram.h>
-+
-+&ddr_timing {
-+	ddr4_odt = <DDR4_RTT_NOM_120ohm>;
-+	phy_ddr4_ca_drv = <PHY_DDR4_LPDDR3_RON_RTT_25ohm>;
-+	phy_ddr4_ck_drv = <PHY_DDR4_LPDDR3_RON_RTT_25ohm>;
-+	phy_ddr4_dq_drv = <PHY_DDR4_LPDDR3_RON_RTT_25ohm>;
-+	phy_ddr4_odt = <PHY_DDR4_LPDDR3_RON_RTT_120ohm>;
-+
-+	/* CA de-skew, one step is 47.8ps, range 0-15 */
-+	ddr3a1_ddr4a9_de-skew = <1>;
-+	ddr3a0_ddr4a10_de-skew = <1>;
-+	ddr3a3_ddr4a6_de-skew = <0>;
-+	ddr3a2_ddr4a4_de-skew = <1>;
-+	ddr3a5_ddr4a8_de-skew = <0>;
-+	ddr3a4_ddr4a5_de-skew = <1>;
-+	ddr3a7_ddr4a11_de-skew = <1>;
-+	ddr3a6_ddr4a7_de-skew = <0>;
-+	ddr3a9_ddr4a0_de-skew = <1>;
-+	ddr3a8_ddr4a13_de-skew = <0>;
-+	ddr3a11_ddr4a3_de-skew = <2>;
-+	ddr3a10_ddr4cs0_de-skew = <3>;
-+	ddr3a13_ddr4a2_de-skew = <1>;
-+	ddr3a12_ddr4ba1_de-skew = <0>;
-+	ddr3a15_ddr4odt0_de-skew = <3>;
-+	ddr3a14_ddr4a1_de-skew = <2>;
-+	ddr3ba1_ddr4a15_de-skew = <1>;
-+	ddr3ba0_ddr4bg0_de-skew = <1>;
-+	ddr3ras_ddr4cke_de-skew = <3>;
-+	ddr3ba2_ddr4ba0_de-skew = <1>;
-+	ddr3we_ddr4bg1_de-skew = <3>;
-+	ddr3cas_ddr4a12_de-skew = <1>;
-+	ddr3ckn_ddr4ckn_de-skew = <4>;
-+	ddr3ckp_ddr4ckp_de-skew = <4>;
-+	ddr3cke_ddr4a16_de-skew = <1>;
-+	ddr3odt0_ddr4a14_de-skew = <1>;
-+	ddr3cs0_ddr4act_de-skew = <2>;
-+	ddr3reset_ddr4reset_de-skew = <3>;
-+	ddr3cs1_ddr4cs1_de-skew = <2>;
-+	ddr3odt1_ddr4odt1_de-skew = <2>;
-+
-+	/* DATA de-skew
-+	 * RX one step is 25.1ps, range 0-15
-+	 * TX one step is 47.8ps, range 0-15
-+	 */
-+	cs0_dm0_rx_de-skew = <8>;
-+	cs0_dm0_tx_de-skew = <9>;
-+	cs0_dq0_rx_de-skew = <8>;
-+	cs0_dq0_tx_de-skew = <9>;
-+	cs0_dq1_rx_de-skew = <8>;
-+	cs0_dq1_tx_de-skew = <9>;
-+	cs0_dq2_rx_de-skew = <8>;
-+	cs0_dq2_tx_de-skew = <9>;
-+	cs0_dq3_rx_de-skew = <8>;
-+	cs0_dq3_tx_de-skew = <9>;
-+	cs0_dq4_rx_de-skew = <8>;
-+	cs0_dq4_tx_de-skew = <9>;
-+	cs0_dq5_rx_de-skew = <8>;
-+	cs0_dq5_tx_de-skew = <9>;
-+	cs0_dq6_rx_de-skew = <8>;
-+	cs0_dq6_tx_de-skew = <9>;
-+	cs0_dq7_rx_de-skew = <8>;
-+	cs0_dq7_tx_de-skew = <9>;
-+	cs0_dqs0_rx_de-skew = <7>;
-+	cs0_dqs0p_tx_de-skew = <10>;
-+	cs0_dqs0n_tx_de-skew = <10>;
-+
-+	cs0_dm1_rx_de-skew = <8>;
-+	cs0_dm1_tx_de-skew = <8>;
-+	cs0_dq8_rx_de-skew = <8>;
-+	cs0_dq8_tx_de-skew = <9>;
-+	cs0_dq9_rx_de-skew = <8>;
-+	cs0_dq9_tx_de-skew = <8>;
-+	cs0_dq10_rx_de-skew = <8>;
-+	cs0_dq10_tx_de-skew = <9>;
-+	cs0_dq11_rx_de-skew = <8>;
-+	cs0_dq11_tx_de-skew = <8>;
-+	cs0_dq12_rx_de-skew = <8>;
-+	cs0_dq12_tx_de-skew = <9>;
-+	cs0_dq13_rx_de-skew = <8>;
-+	cs0_dq13_tx_de-skew = <8>;
-+	cs0_dq14_rx_de-skew = <8>;
-+	cs0_dq14_tx_de-skew = <9>;
-+	cs0_dq15_rx_de-skew = <8>;
-+	cs0_dq15_tx_de-skew = <8>;
-+	cs0_dqs1_rx_de-skew = <8>;
-+	cs0_dqs1p_tx_de-skew = <10>;
-+	cs0_dqs1n_tx_de-skew = <10>;
-+
-+	cs0_dm2_rx_de-skew = <8>;
-+	cs0_dm2_tx_de-skew = <9>;
-+	cs0_dq16_rx_de-skew = <8>;
-+	cs0_dq16_tx_de-skew = <9>;
-+	cs0_dq17_rx_de-skew = <8>;
-+	cs0_dq17_tx_de-skew = <9>;
-+	cs0_dq18_rx_de-skew = <8>;
-+	cs0_dq18_tx_de-skew = <9>;
-+	cs0_dq19_rx_de-skew = <8>;
-+	cs0_dq19_tx_de-skew = <9>;
-+	cs0_dq20_rx_de-skew = <8>;
-+	cs0_dq20_tx_de-skew = <9>;
-+	cs0_dq21_rx_de-skew = <8>;
-+	cs0_dq21_tx_de-skew = <9>;
-+	cs0_dq22_rx_de-skew = <8>;
-+	cs0_dq22_tx_de-skew = <9>;
-+	cs0_dq23_rx_de-skew = <8>;
-+	cs0_dq23_tx_de-skew = <9>;
-+	cs0_dqs2_rx_de-skew = <7>;
-+	cs0_dqs2p_tx_de-skew = <10>;
-+	cs0_dqs2n_tx_de-skew = <10>;
-+
-+	cs0_dm3_rx_de-skew = <8>;
-+	cs0_dm3_tx_de-skew = <8>;
-+	cs0_dq24_rx_de-skew = <8>;
-+	cs0_dq24_tx_de-skew = <9>;
-+	cs0_dq25_rx_de-skew = <8>;
-+	cs0_dq25_tx_de-skew = <8>;
-+	cs0_dq26_rx_de-skew = <8>;
-+	cs0_dq26_tx_de-skew = <8>;
-+	cs0_dq27_rx_de-skew = <8>;
-+	cs0_dq27_tx_de-skew = <8>;
-+	cs0_dq28_rx_de-skew = <8>;
-+	cs0_dq28_tx_de-skew = <8>;
-+	cs0_dq29_rx_de-skew = <8>;
-+	cs0_dq29_tx_de-skew = <8>;
-+	cs0_dq30_rx_de-skew = <8>;
-+	cs0_dq30_tx_de-skew = <8>;
-+	cs0_dq31_rx_de-skew = <8>;
-+	cs0_dq31_tx_de-skew = <8>;
-+	cs0_dqs3_rx_de-skew = <8>;
-+	cs0_dqs3p_tx_de-skew = <10>;
-+	cs0_dqs3n_tx_de-skew = <10>;
-+
-+	cs1_dm0_rx_de-skew = <8>;
-+	cs1_dm0_tx_de-skew = <9>;
-+	cs1_dq0_rx_de-skew = <8>;
-+	cs1_dq0_tx_de-skew = <9>;
-+	cs1_dq1_rx_de-skew = <8>;
-+	cs1_dq1_tx_de-skew = <9>;
-+	cs1_dq2_rx_de-skew = <8>;
-+	cs1_dq2_tx_de-skew = <9>;
-+	cs1_dq3_rx_de-skew = <8>;
-+	cs1_dq3_tx_de-skew = <9>;
-+	cs1_dq4_rx_de-skew = <8>;
-+	cs1_dq4_tx_de-skew = <9>;
-+	cs1_dq5_rx_de-skew = <8>;
-+	cs1_dq5_tx_de-skew = <9>;
-+	cs1_dq6_rx_de-skew = <8>;
-+	cs1_dq6_tx_de-skew = <9>;
-+	cs1_dq7_rx_de-skew = <8>;
-+	cs1_dq7_tx_de-skew = <9>;
-+	cs1_dqs0_rx_de-skew = <7>;
-+	cs1_dqs0p_tx_de-skew = <10>;
-+	cs1_dqs0n_tx_de-skew = <10>;
-+
-+	cs1_dm1_rx_de-skew = <8>;
-+	cs1_dm1_tx_de-skew = <8>;
-+	cs1_dq8_rx_de-skew = <8>;
-+	cs1_dq8_tx_de-skew = <9>;
-+	cs1_dq9_rx_de-skew = <8>;
-+	cs1_dq9_tx_de-skew = <8>;
-+	cs1_dq10_rx_de-skew = <8>;
-+	cs1_dq10_tx_de-skew = <9>;
-+	cs1_dq11_rx_de-skew = <8>;
-+	cs1_dq11_tx_de-skew = <8>;
-+	cs1_dq12_rx_de-skew = <8>;
-+	cs1_dq12_tx_de-skew = <9>;
-+	cs1_dq13_rx_de-skew = <8>;
-+	cs1_dq13_tx_de-skew = <8>;
-+	cs1_dq14_rx_de-skew = <8>;
-+	cs1_dq14_tx_de-skew = <9>;
-+	cs1_dq15_rx_de-skew = <8>;
-+	cs1_dq15_tx_de-skew = <8>;
-+	cs1_dqs1_rx_de-skew = <8>;
-+	cs1_dqs1p_tx_de-skew = <10>;
-+	cs1_dqs1n_tx_de-skew = <10>;
-+
-+	cs1_dm2_rx_de-skew = <8>;
-+	cs1_dm2_tx_de-skew = <9>;
-+	cs1_dq16_rx_de-skew = <8>;
-+	cs1_dq16_tx_de-skew = <9>;
-+	cs1_dq17_rx_de-skew = <8>;
-+	cs1_dq17_tx_de-skew = <9>;
-+	cs1_dq18_rx_de-skew = <8>;
-+	cs1_dq18_tx_de-skew = <9>;
-+	cs1_dq19_rx_de-skew = <8>;
-+	cs1_dq19_tx_de-skew = <9>;
-+	cs1_dq20_rx_de-skew = <8>;
-+	cs1_dq20_tx_de-skew = <9>;
-+	cs1_dq21_rx_de-skew = <8>;
-+	cs1_dq21_tx_de-skew = <9>;
-+	cs1_dq22_rx_de-skew = <8>;
-+	cs1_dq22_tx_de-skew = <9>;
-+	cs1_dq23_rx_de-skew = <8>;
-+	cs1_dq23_tx_de-skew = <9>;
-+	cs1_dqs2_rx_de-skew = <7>;
-+	cs1_dqs2p_tx_de-skew = <10>;
-+	cs1_dqs2n_tx_de-skew = <10>;
-+
-+	cs1_dm3_rx_de-skew = <8>;
-+	cs1_dm3_tx_de-skew = <8>;
-+	cs1_dq24_rx_de-skew = <8>;
-+	cs1_dq24_tx_de-skew = <9>;
-+	cs1_dq25_rx_de-skew = <8>;
-+	cs1_dq25_tx_de-skew = <8>;
-+	cs1_dq26_rx_de-skew = <8>;
-+	cs1_dq26_tx_de-skew = <8>;
-+	cs1_dq27_rx_de-skew = <8>;
-+	cs1_dq27_tx_de-skew = <8>;
-+	cs1_dq28_rx_de-skew = <8>;
-+	cs1_dq28_tx_de-skew = <8>;
-+	cs1_dq29_rx_de-skew = <8>;
-+	cs1_dq29_tx_de-skew = <8>;
-+	cs1_dq30_rx_de-skew = <8>;
-+	cs1_dq30_tx_de-skew = <8>;
-+	cs1_dq31_rx_de-skew = <8>;
-+	cs1_dq31_tx_de-skew = <8>;
-+	cs1_dqs3_rx_de-skew = <8>;
-+	cs1_dqs3p_tx_de-skew = <10>;
-+	cs1_dqs3n_tx_de-skew = <10>;
-+};
-diff --git a/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts b/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts
-index e911cf265a64..5df9b4976ba2 100644
---- a/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts
-+++ b/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts
-@@ -42,6 +42,7 @@
- 
- /dts-v1/;
- #include "rk3328.dtsi"
-+#include "rk3328-dram-box-plus-timing.dtsi"
- 
- / {
- 	model = "Firefly ROC-RK3328-CC Board";
-@@ -193,7 +194,37 @@
- 
- &dmc {
- 	center-supply = <&vdd_logic>;
--	status = "okay";
-+	system-status-freq = <
-+		/*system status         freq(KHz)*/
-+		SYS_STATUS_NORMAL       1066000
-+		SYS_STATUS_REBOOT       1066000
-+		SYS_STATUS_SUSPEND      1066000
-+		SYS_STATUS_VIDEO_1080P  1066000
-+		SYS_STATUS_VIDEO_4K     1066000
-+		SYS_STATUS_VIDEO_4K_10B 1066000
-+		SYS_STATUS_PERFORMANCE  1066000
-+		SYS_STATUS_BOOST        1066000
-+	>;
-+	status = "okay";
-+};
-+
-+&dmc_opp_table {
-+	rockchip,leakage-voltage-sel = <
-+		1   8     0
-+		9   254   0
-+	>;
-+	opp-933000000 {
-+		opp-hz = /bits/ 64 <933000000>;
-+		opp-microvolt = <1150000>;
-+		opp-microvolt-L0 = <1150000>;
-+		opp-microvolt-L1 = <1100000>;
-+	};
-+	opp-1066000000 {
-+		opp-hz = /bits/ 64 <1066000000>;
-+		opp-microvolt = <1200000>;
-+		opp-microvolt-L0 = <1200000>;
-+		opp-microvolt-L1 = <1175000>;
-+	};
- };
- 
- &display_subsystem {
-
-From 76d468bccff1b742965b5a8d78beb028488ee6e3 Mon Sep 17 00:00:00 2001
-From: Jonas Karlman <jonas@kwiboo.se>
-Date: Sat, 21 Apr 2018 13:21:24 +0200
-Subject: [PATCH] arm64: dts: rockchip: rk3328-box-trn9: use 1066MHz ddr
- frequency
-
----
- arch/arm64/boot/dts/rockchip/rk3328-box-trn9.dts | 29 +++++++++++++++++++++++-
- 1 file changed, 28 insertions(+), 1 deletion(-)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3328-box-trn9.dts b/arch/arm64/boot/dts/rockchip/rk3328-box-trn9.dts
-index 51d471ba8cef..81ec7b66e199 100644
---- a/arch/arm64/boot/dts/rockchip/rk3328-box-trn9.dts
-+++ b/arch/arm64/boot/dts/rockchip/rk3328-box-trn9.dts
-@@ -42,6 +42,7 @@
- 
- /dts-v1/;
- #include "rk3328.dtsi"
-+#include "rk3328-dram-box-plus-timing.dtsi"
- 
- / {
- 	model = "Rockchip RK3328 TRN9";
-@@ -240,7 +241,33 @@
- 
- &dmc {
- 	center-supply = <&vdd_logic>;
--	status = "okay";
-+	system-status-freq = <
-+		/*system status         freq(KHz)*/
-+		SYS_STATUS_NORMAL       1066000
-+		SYS_STATUS_REBOOT       1066000
-+		SYS_STATUS_SUSPEND      1066000
-+		SYS_STATUS_VIDEO_1080P  1066000
-+		SYS_STATUS_VIDEO_4K     1066000
-+		SYS_STATUS_VIDEO_4K_10B 1066000
-+		SYS_STATUS_PERFORMANCE  1066000
-+		SYS_STATUS_BOOST        1066000
-+	>;
-+	status = "okay";
-+};
-+
-+&dmc_opp_table {
-+	opp-933000000 {
-+		opp-hz = /bits/ 64 <933000000>;
-+		opp-microvolt = <1150000>;
-+		opp-microvolt-L0 = <1150000>;
-+		opp-microvolt-L1 = <1100000>;
-+	};
-+	opp-1066000000 {
-+		opp-hz = /bits/ 64 <1066000000>;
-+		opp-microvolt = <1200000>;
-+		opp-microvolt-L0 = <1200000>;
-+		opp-microvolt-L1 = <1175000>;
-+	};
- };
- 
- &display_subsystem {
-
-From 6116b7515612fa5ce0ada65030f3cfc71eb70206 Mon Sep 17 00:00:00 2001
-From: Jonas Karlman <jonas@kwiboo.se>
-Date: Sat, 18 Aug 2018 20:53:04 +0200
-Subject: [PATCH] arm64: dts: rockchip: rk3399: update dtsi
-
----
- arch/arm64/boot/dts/rockchip/rk3399-sapphire.dtsi | 17 ++++++++++++---
- arch/arm64/boot/dts/rockchip/rk3399.dtsi          | 26 ++++++++++++++++++++++-
- 3 files changed, 40 insertions(+), 17 deletions(-)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3399-sapphire.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-sapphire.dtsi
-index 3d76b9733665..62ba4281197e 100644
---- a/arch/arm64/boot/dts/rockchip/rk3399-sapphire.dtsi
-+++ b/arch/arm64/boot/dts/rockchip/rk3399-sapphire.dtsi
-@@ -536,6 +536,14 @@
- 	status = "okay";
- };
- 
-+&pvtm {
-+	status = "okay";
-+};
-+
-+&pmu_pvtm {
-+	status = "okay";
-+};
-+
- &pmu_io_domains {
- 	status = "okay";
- 	pmu1830-supply = <&vcc_3v0>;
-@@ -563,7 +571,7 @@
- 
- &sdio0 {
- 	clock-frequency = <50000000>;
--	clock-freq-min-max = <200000 50000000>;
-+	max-frequency = <50000000>;
- 	supports-sdio;
- 	bus-width = <4>;
- 	disable-wp;
-@@ -581,14 +589,17 @@
- 
- &sdmmc {
- 	clock-frequency = <150000000>;
--	clock-freq-min-max = <100000 150000000>;
-+	max-frequency = <150000000>;
- 	supports-sd;
- 	bus-width = <4>;
- 	cap-mmc-highspeed;
- 	cap-sd-highspeed;
- 	disable-wp;
- 	num-slots = <1>;
--	//sd-uhs-sdr104;
-+	sd-uhs-sdr12;
-+	sd-uhs-sdr25;
-+	sd-uhs-sdr50;
-+	sd-uhs-sdr104;
- 	vmmc-supply = <&vcc_sd>;
- 	vqmmc-supply = <&vccio_sd>;
- 	pinctrl-names = "default";
-diff --git a/arch/arm64/boot/dts/rockchip/rk3399.dtsi b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-index 815a8c131239..fbe3d0edc961 100644
---- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-+++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-@@ -646,6 +646,8 @@
- 	uart0: serial@ff180000 {
- 		compatible = "rockchip,rk3399-uart", "snps,dw-apb-uart";
- 		reg = <0x0 0xff180000 0x0 0x100>;
-+		dmas = <&dmac_peri 0>, <&dmac_peri 1>;
-+		dma-names = "tx", "rx";
- 		clocks = <&cru SCLK_UART0>, <&cru PCLK_UART0>;
- 		clock-names = "baudclk", "apb_pclk";
- 		interrupts = <GIC_SPI 99 IRQ_TYPE_LEVEL_HIGH 0>;
-@@ -659,6 +661,8 @@
- 	uart1: serial@ff190000 {
- 		compatible = "rockchip,rk3399-uart", "snps,dw-apb-uart";
- 		reg = <0x0 0xff190000 0x0 0x100>;
-+		dmas = <&dmac_peri 2>, <&dmac_peri 3>;
-+		dma-names = "tx", "rx";
- 		clocks = <&cru SCLK_UART1>, <&cru PCLK_UART1>;
- 		clock-names = "baudclk", "apb_pclk";
- 		interrupts = <GIC_SPI 98 IRQ_TYPE_LEVEL_HIGH 0>;
-@@ -672,6 +676,8 @@
- 	uart2: serial@ff1a0000 {
- 		compatible = "rockchip,rk3399-uart", "snps,dw-apb-uart";
- 		reg = <0x0 0xff1a0000 0x0 0x100>;
-+		dmas = <&dmac_peri 4>, <&dmac_peri 5>;
-+		dma-names = "tx", "rx";
- 		clocks = <&cru SCLK_UART2>, <&cru PCLK_UART2>;
- 		clock-names = "baudclk", "apb_pclk";
- 		interrupts = <GIC_SPI 100 IRQ_TYPE_LEVEL_HIGH 0>;
-@@ -685,6 +691,8 @@
- 	uart3: serial@ff1b0000 {
- 		compatible = "rockchip,rk3399-uart", "snps,dw-apb-uart";
- 		reg = <0x0 0xff1b0000 0x0 0x100>;
-+		dmas = <&dmac_peri 6>, <&dmac_peri 7>;
-+		dma-names = "tx", "rx";
- 		clocks = <&cru SCLK_UART3>, <&cru PCLK_UART3>;
- 		clock-names = "baudclk", "apb_pclk";
- 		interrupts = <GIC_SPI 101 IRQ_TYPE_LEVEL_HIGH 0>;
-@@ -698,6 +706,8 @@
- 	spi0: spi@ff1c0000 {
- 		compatible = "rockchip,rk3399-spi", "rockchip,rk3066-spi";
- 		reg = <0x0 0xff1c0000 0x0 0x1000>;
-+		dmas = <&dmac_peri 10>, <&dmac_peri 11>;
-+		dma-names = "tx", "rx";
- 		clocks = <&cru SCLK_SPI0>, <&cru PCLK_SPI0>;
- 		clock-names = "spiclk", "apb_pclk";
- 		interrupts = <GIC_SPI 68 IRQ_TYPE_LEVEL_HIGH 0>;
-@@ -711,6 +721,8 @@
- 	spi1: spi@ff1d0000 {
- 		compatible = "rockchip,rk3399-spi", "rockchip,rk3066-spi";
- 		reg = <0x0 0xff1d0000 0x0 0x1000>;
-+		dmas = <&dmac_peri 12>, <&dmac_peri 13>;
-+		dma-names = "tx", "rx";
- 		clocks = <&cru SCLK_SPI1>, <&cru PCLK_SPI1>;
- 		clock-names = "spiclk", "apb_pclk";
- 		interrupts = <GIC_SPI 53 IRQ_TYPE_LEVEL_HIGH 0>;
-@@ -724,6 +736,8 @@
- 	spi2: spi@ff1e0000 {
- 		compatible = "rockchip,rk3399-spi", "rockchip,rk3066-spi";
- 		reg = <0x0 0xff1e0000 0x0 0x1000>;
-+		dmas = <&dmac_peri 14>, <&dmac_peri 15>;
-+		dma-names = "tx", "rx";
- 		clocks = <&cru SCLK_SPI2>, <&cru PCLK_SPI2>;
- 		clock-names = "spiclk", "apb_pclk";
- 		interrupts = <GIC_SPI 52 IRQ_TYPE_LEVEL_HIGH 0>;
-@@ -737,6 +751,8 @@
- 	spi4: spi@ff1f0000 {
- 		compatible = "rockchip,rk3399-spi", "rockchip,rk3066-spi";
- 		reg = <0x0 0xff1f0000 0x0 0x1000>;
-+		dmas = <&dmac_peri 18>, <&dmac_peri 19>;
-+		dma-names = "tx", "rx";
- 		clocks = <&cru SCLK_SPI4>, <&cru PCLK_SPI4>;
- 		clock-names = "spiclk", "apb_pclk";
- 		interrupts = <GIC_SPI 67 IRQ_TYPE_LEVEL_HIGH 0>;
-@@ -750,6 +766,8 @@
- 	spi5: spi@ff200000 {
- 		compatible = "rockchip,rk3399-spi", "rockchip,rk3066-spi";
- 		reg = <0x0 0xff200000 0x0 0x1000>;
-+		dmas = <&dmac_bus 8>, <&dmac_bus 9>;
-+		dma-names = "tx", "rx";
- 		clocks = <&cru SCLK_SPI5>, <&cru PCLK_SPI5>;
- 		clock-names = "spiclk", "apb_pclk";
- 		interrupts = <GIC_SPI 132 IRQ_TYPE_LEVEL_HIGH 0>;
-@@ -1152,6 +1170,8 @@
- 	spi3: spi@ff350000 {
- 		compatible = "rockchip,rk3399-spi", "rockchip,rk3066-spi";
- 		reg = <0x0 0xff350000 0x0 0x1000>;
-+		dmas = <&dmac_peri 16>, <&dmac_peri 17>;
-+		dma-names = "tx", "rx";
- 		clocks = <&pmucru SCLK_SPI3_PMU>, <&pmucru PCLK_SPI3_PMU>;
- 		clock-names = "spiclk", "apb_pclk";
- 		interrupts = <GIC_SPI 60 IRQ_TYPE_LEVEL_HIGH 0>;
-@@ -1165,6 +1185,8 @@
- 	uart4: serial@ff370000 {
- 		compatible = "rockchip,rk3399-uart", "snps,dw-apb-uart";
- 		reg = <0x0 0xff370000 0x0 0x100>;
-+		dmas = <&dmac_peri 8>, <&dmac_peri 9>;
-+		dma-names = "tx", "rx";
- 		clocks = <&pmucru SCLK_UART4_PMU>, <&pmucru PCLK_UART4_PMU>;
- 		clock-names = "baudclk", "apb_pclk";
- 		interrupts = <GIC_SPI 102 IRQ_TYPE_LEVEL_HIGH 0>;
-@@ -1790,6 +1812,7 @@
- 		clocks = <&cru ACLK_VOP1>, <&cru DCLK_VOP1>, <&cru HCLK_VOP1>, <&cru DCLK_VOP1_DIV>;
- 		clock-names = "aclk_vop", "dclk_vop", "hclk_vop", "dclk_source";
- 		iommus = <&vopl_mmu>;
-+		rockchip,grf = <&grf>;
- 		power-domains = <&power RK3399_PD_VOPL>;
- 		resets = <&cru SRST_A_VOP1>, <&cru SRST_H_VOP1>, <&cru SRST_D_VOP1>;
- 		reset-names = "axi", "ahb", "dclk";
-@@ -1860,6 +1883,7 @@
- 		clock-names = "aclk_vop", "dclk_vop", "hclk_vop", "dclk_source";
- 		resets = <&cru SRST_A_VOP0>, <&cru SRST_H_VOP0>, <&cru SRST_D_VOP0>;
- 		reset-names = "axi", "ahb", "dclk";
-+		rockchip,grf = <&grf>;
- 		power-domains = <&power RK3399_PD_VOPB>;
- 		iommus = <&vopb_mmu>;
+ 		pinctrl-0 = <&uart0_xfer &uart0_cts &uart0_rts>;
  		status = "disabled";
-@@ -1982,7 +2006,7 @@
- 		compatible = "rockchip,rk3399-dw-hdmi";
- 		reg = <0x0 0xff940000 0x0 0x20000>;
+@@ -481,6 +504,7 @@
+ 		reg-shift = <2>;
+ 		reg-io-width = <4>;
+ 		dmas = <&dmac 4>, <&dmac 5>;
++		dma-names = "tx", "rx";
  		pinctrl-names = "default";
--		pinctrl-0 = <&hdmi_i2c_xfer>;
-+		pinctrl-0 = <&hdmi_i2c_xfer>, <&hdmi_cec>;
- 		interrupts = <GIC_SPI 23 IRQ_TYPE_LEVEL_HIGH 0>;
- 		clocks = <&cru PCLK_HDMI_CTRL>,
- 			 <&cru SCLK_HDMI_SFR>,
-
-From caa58eaa7cec6e36cdd4e3ec91757f01504b5f2e Mon Sep 17 00:00:00 2001
-From: Jonas Karlman <jonas@kwiboo.se>
-Date: Sun, 19 Aug 2018 23:10:05 +0200
-Subject: [PATCH] arm64: dts: rk3399-rockpro64: update dts
-
----
- arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts | 421 +++++++++-------------
- 1 file changed, 175 insertions(+), 246 deletions(-)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts
-index 02b8ba7dcc94..aa1aee547036 100644
---- a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts
-+++ b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts
-@@ -8,23 +8,33 @@
- #include <dt-bindings/pwm/pwm.h>
- #include <dt-bindings/input/input.h>
- #include "rk3399.dtsi"
-+#include "rk3399-linux.dtsi"
- #include "rk3399-opp.dtsi"
- 
- / {
- 	model = "Pine64 RockPro64";
- 	compatible = "pine64,rockpro64", "rockchip,rk3399";
- 
--	chosen {
--		bootargs = "earlycon=uart8250,mmio32,0xff1a0000 swiotlb=1 coherent_pool=1m";
--		stdout-path = "serial2:1500000n8";
--	};
--
- 	/* first 64k(0xff8c0000~0xff8d0000) for ddr and suspend */
- 	iram: sram@ff8d0000 {
- 		compatible = "mmio-sram";
- 		reg = <0x0 0xff8d0000 0x0 0x20000>; /* 128k */
- 	};
- 
-+	xin32k: xin32k {
-+		compatible = "fixed-clock";
-+		clock-frequency = <32768>;
-+		clock-output-names = "xin32k";
-+		#clock-cells = <0>;
-+	};
-+
-+	clkin_gmac: external-gmac-clock {
-+		compatible = "fixed-clock";
-+		clock-frequency = <125000000>;
-+		clock-output-names = "clkin_gmac";
-+		#clock-cells = <0>;
-+	};
-+
- 	dc_12v: dc-12v {
- 		compatible = "regulator-fixed";
- 		regulator-name = "dc_12v";
-@@ -92,6 +102,7 @@
- 	vdd_log: vdd-log {
- 		compatible = "pwm-regulator";
- 		pwms = <&pwm2 0 25000 1>;
-+		pwm-supply = <&vcc_sys>;
- 		regulator-name = "vdd_log";
- 		regulator-min-microvolt = <800000>;
- 		regulator-max-microvolt = <1400000>;
-@@ -101,56 +112,54 @@
- 		/* for rockchip boot on */
- 		rockchip,pwm_id= <2>;
- 		rockchip,pwm_voltage = <900000>;
-+	};
- 
--		vin-supply = <&vcc_sys>;
-+	leds {
-+		compatible = "gpio-leds";
-+
-+		work-led {
-+			gpios = <&gpio0 RK_PB3 GPIO_ACTIVE_HIGH>;
-+			linux,default-trigger = "mmc0";
-+		};
-+
-+		diy-led {
-+			gpios = <&gpio0 RK_PA2 GPIO_ACTIVE_HIGH>;
-+			linux,default-trigger = "heartbeat";
-+		};
- 	};
- 
--	clkin_gmac: external-gmac-clock {
--		compatible = "fixed-clock";
--		clock-frequency = <125000000>;
--		clock-output-names = "clkin_gmac";
--		#clock-cells = <0>;
-+	ir-receiver {
-+		compatible = "gpio-ir-receiver";
-+		gpios = <&gpio0 RK_PA6 GPIO_ACTIVE_LOW>;
-+		linux,rc-map-name = "rc-pine64";
-+		pinctrl-0 = <&ir_int>;
-+		pinctrl-names = "default";
- 	};
- 
--	spdif-sound {
--		status = "disabled";
-+	hdmi-sound {
- 		compatible = "simple-audio-card";
--		simple-audio-card,name = "ROCKCHIP,SPDIF";
-+		simple-audio-card,format = "i2s";
-+		simple-audio-card,mclk-fs = <256>;
-+		simple-audio-card,name = "HDMI";
- 		simple-audio-card,cpu {
--			sound-dai = <&spdif>;
-+			sound-dai = <&i2s2>;
- 		};
- 		simple-audio-card,codec {
--			sound-dai = <&spdif_out>;
-+			sound-dai = <&hdmi>;
- 		};
- 	};
- 
--	spdif_out: spdif-out {
-+	hdmi-dp-sound {
-+		compatible = "rockchip,rk3399-hdmi-dp";
-+		rockchip,cpu = <&i2s2>;
-+		rockchip,codec = <&hdmi>, <&cdn_dp>;
+ 		pinctrl-0 = <&uart1_xfer &uart1_cts &uart1_rts>;
  		status = "disabled";
--		compatible = "linux,spdif-dit";
--		#sound-dai-cells = <0>;
--	};
--
--	sdio_pwrseq: sdio-pwrseq {
--		compatible = "mmc-pwrseq-simple";
--		clocks = <&rk808 1>;
--		clock-names = "ext_clock";
--		pinctrl-names = "default";
--		pinctrl-0 = <&wifi_enable_h>;
--
--		/*
--		 * On the module itself this is one of these (depending
--		 * on the actual card populated):
--		 * - SDIO_RESET_L_WL_REG_ON
--		 * - PDN (power down when low)
--		 */
--		reset-gpios = <&gpio0 RK_PB2 GPIO_ACTIVE_LOW>;
- 	};
- 
- 	es8316-sound {
--		status = "okay";
- 		compatible = "simple-audio-card";
- 		simple-audio-card,format = "i2s";
--		simple-audio-card,name = "rockchip,es8316-codec";
-+		simple-audio-card,name = "ES8316";
- 		simple-audio-card,mclk-fs = <256>;
- 		simple-audio-card,widgets =
- 			"Microphone", "Mic Jack",
-@@ -168,40 +177,59 @@
+@@ -495,6 +519,7 @@
+ 		reg-shift = <2>;
+ 		reg-io-width = <4>;
+ 		dmas = <&dmac 6>, <&dmac 7>;
++		dma-names = "tx", "rx";
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&uart2m1_xfer>;
+ 		status = "disabled";
+@@ -734,9 +759,9 @@
  		};
- 	};
- 
--	leds {
--		status = "okay";
--		compatible = "gpio-leds";
--		work-led {
--			gpios = <&gpio0 RK_PB3 GPIO_ACTIVE_HIGH>;
--			linux,default-trigger = "heartbeat";
--			default-state = "on";
-+	spdif-sound {
-+		compatible = "simple-audio-card";
-+		simple-audio-card,name = "SPDIF";
-+		simple-audio-card,cpu {
-+			sound-dai = <&spdif>;
+ 		opp-300000000 {
+ 			opp-hz = /bits/ 64 <300000000>;
+-			opp-microvolt = <975000>;
+-			opp-microvolt-L0 = <975000>;
+-			opp-microvolt-L1 = <950000>;
++			opp-microvolt = <1050000>;
++			opp-microvolt-L0 = <1050000>;
++			opp-microvolt-L1 = <1025000>;
  		};
--		diy-led {
--			gpios = <&gpio0 RK_PA2 GPIO_ACTIVE_HIGH>;
--			linux,default-trigger = "none";
--			default-state = "off";
-+		simple-audio-card,codec {
-+			sound-dai = <&spdif_out>;
+ 		opp-400000000 {
+ 			opp-hz = /bits/ 64 <400000000>;
+@@ -750,6 +775,14 @@
+ 			opp-microvolt-L0 = <1150000>;
+ 			opp-microvolt-L1 = <1100000>;
  		};
- 	};
- 
--	rk_key: rockchip-key {
--		compatible = "rockchip,key";
--		status = "okay";
-+	spdif_out: spdif-out {
-+		compatible = "linux,spdif-dit";
-+		#sound-dai-cells = <0>;
-+	};
- 
--		io-channels = <&saradc 1>;
-+	sdio_pwrseq: sdio-pwrseq {
-+		compatible = "mmc-pwrseq-simple";
-+		clocks = <&rk808 1>;
-+		clock-names = "ext_clock";
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&wifi_enable_h>;
- 
--		power-key {
--			gpios = <&gpio0 RK_PA5 GPIO_ACTIVE_LOW>;
--			linux,code = <116>;
--			label = "power";
--			gpio-key,wakeup;
--		};
 +		/*
-+		 * On the module itself this is one of these (depending
-+		 * on the actual card populated):
-+		 * - SDIO_RESET_L_WL_REG_ON
-+		 * - PDN (power down when low)
-+		 */
-+		reset-gpios = <&gpio0 RK_PB2 GPIO_ACTIVE_LOW>;
- 	};
- 
--	hdmi_dp_sound: hdmi-dp-sound {
--		status = "okay";
--		compatible = "rockchip,rk3399-hdmi-dp";
--		rockchip,cpu = <&i2s2>;
--		rockchip,codec = <&hdmi>, <&cdn_dp>;
-+	wireless-wlan {
-+		compatible = "wlan-platdata";
-+		rockchip,grf = <&grf>;
-+		wifi_chip_type = "ap6354";
-+		sdio_vref = <1800>;
-+		WIFI,host_wake_irq = <&gpio0 RK_PA3 GPIO_ACTIVE_HIGH>;
-+		status = "disabled";
-+	};
-+
-+	wireless-bluetooth {
-+		compatible = "bluetooth-platdata";
-+		clocks = <&rk808 1>;
-+		clock-names = "ext_clock";
-+		uart_rts_gpios = <&gpio2 RK_PC3 GPIO_ACTIVE_LOW>;
-+		pinctrl-names = "default", "rts_gpio";
-+		pinctrl-0 = <&uart0_rts>;
-+		pinctrl-1 = <&uart0_gpios>;
-+		BT,reset_gpio    = <&gpio0 RK_PB1 GPIO_ACTIVE_HIGH>;
-+		BT,wake_gpio     = <&gpio2 RK_PD3 GPIO_ACTIVE_HIGH>;
-+		BT,wake_host_irq = <&gpio0 RK_PA4 GPIO_ACTIVE_HIGH>;
-+		status = "disabled";
- 	};
- };
- 
-@@ -253,30 +281,21 @@
- &dmc {
- 	status = "okay";
- 	center-supply = <&vdd_center>;
--	upthreshold = <40>;
--	downdifferential = <20>;
- 	system-status-freq = <
- 		/*system status         freq(KHz)*/
- 		SYS_STATUS_NORMAL       800000
- 		SYS_STATUS_REBOOT       400000
- 		SYS_STATUS_SUSPEND      400000
--		SYS_STATUS_VIDEO_1080P  400000
-+		SYS_STATUS_VIDEO_1080P  800000
- 		SYS_STATUS_VIDEO_4K     800000
- 		SYS_STATUS_VIDEO_4K_10B 800000
- 		SYS_STATUS_PERFORMANCE  800000
--		SYS_STATUS_BOOST        400000
-+		SYS_STATUS_BOOST        800000
- 		SYS_STATUS_DUALVIEW     800000
- 		SYS_STATUS_ISP          800000
- 	>;
--	vop-bw-dmc-freq = <
--	/* min_bw(MB/s) max_bw(MB/s) freq(KHz) */
--		0       577      200000
--		578     1701     300000
--		1702    99999    400000
--	>;
--	auto-min-freq = <400000>;
-+	auto-min-freq = <800000>;
- 	auto-freq-en = <0>;
--
- };
- 
- &dmc_opp_table {
-@@ -325,42 +344,26 @@
- &display_subsystem {
- 	status = "okay";
- 
--	ports = <&vopb_out>;
--
- 	route {
- 		route_hdmi: route-hdmi {
- 			status = "okay";
- 			connect = <&vopb_out_hdmi>;
- 		};
- 
--		route_dsi: route-dsi {
--			status = "disabled";
--			connect = <&vopb_out_dsi>;
--		};
--
--		route_edp: route-edp {
--			status = "disabled";
--			connect = <&vopb_out_edp>;
-+		route_dp: route-dp {
-+			connect = <&vopl_out_dp>;
- 		};
- 	};
- };
- 
--&dp_in_vopb {
--	status = "disabled";
--};
--
--&edp {
--	/delete-node/ pinctrl-0;
--};
--
- &emmc_phy {
- 	status = "okay";
- };
- 
- &i2c0 {
- 	status = "okay";
--	i2c-scl-rising-time-ns = <168>;
--	i2c-scl-falling-time-ns = <4>;
-+	i2c-scl-rising-time-ns = <180>;
-+	i2c-scl-falling-time-ns = <30>;
- 	clock-frequency = <400000>;
- 
- 	vdd_cpu_b: syr827@40 {
-@@ -393,6 +396,7 @@
- 		regulator-max-microvolt = <1500000>;
- 		regulator-ramp-delay = <1000>;
- 		fcs,suspend-voltage-selector = <1>;
-+		regulator-always-on;
- 		regulator-boot-on;
- 		vin-supply = <&vcc_sys>;
- 		regulator-initial-mode = <1>; /* 1:force PWM 2:auto */
-@@ -411,7 +415,7 @@
- 		rockchip,system-power-controller;
- 		wakeup-source;
- 		#clock-cells = <1>;
--		clock-output-names = "xin32k", "rk808-clkout2";
-+		clock-output-names = "rk808-clkout1", "rk808-clkout2";
- 
- 		vcc1-supply = <&vcc_sys>;
- 		vcc2-supply = <&vcc_sys>;
-@@ -429,8 +433,8 @@
- 		regulators {
- 			vdd_center: DCDC_REG1 {
- 				regulator-name = "vdd_center";
--				regulator-min-microvolt = <750000>;
--				regulator-max-microvolt = <1350000>;
-+				regulator-min-microvolt = <900000>;
-+				regulator-max-microvolt = <900000>;
- 				regulator-ramp-delay = <6001>;
- 				regulator-always-on;
- 				regulator-boot-on;
-@@ -476,6 +480,7 @@
- 				regulator-name = "vcc1v8_dvp";
- 				regulator-min-microvolt = <1800000>;
- 				regulator-max-microvolt = <1800000>;
-+				regulator-always-on;
- 				regulator-boot-on;
- 				regulator-state-mem {
- 					regulator-on-in-suspend;
-@@ -487,6 +492,7 @@
- 				regulator-name = "vcc3v0_touch";
- 				regulator-min-microvolt = <3000000>;
- 				regulator-max-microvolt = <3000000>;
-+				regulator-always-on;
- 				regulator-boot-on;
- 				regulator-state-mem {
- 					regulator-on-in-suspend;
-@@ -510,6 +516,7 @@
- 				regulator-name = "vcc_sd";
- 				regulator-min-microvolt = <1800000>;
- 				regulator-max-microvolt = <3300000>;
-+				regulator-always-on;
- 				regulator-boot-on;
- 				regulator-state-mem {
- 					regulator-on-in-suspend;
-@@ -586,14 +593,6 @@
- 	};
- };
- 
--&i2s0 {
--	status = "okay";
--	rockchip,i2s-broken-burst-len;
--	rockchip,playback-channels = <8>;
--	rockchip,capture-channels = <8>;
--	#sound-dai-cells = <0>;
--};
--
- &i2c1 {
- 	status = "okay";
- 	i2c-scl-rising-time-ns = <168>;
-@@ -624,6 +623,14 @@
- 	};
- };
- 
-+&i2s0 {
-+	status = "okay";
-+	rockchip,i2s-broken-burst-len;
-+	rockchip,playback-channels = <8>;
-+	rockchip,capture-channels = <8>;
-+	#sound-dai-cells = <0>;
-+};
-+
- &i2s1 {
- 	status = "okay";
- 	rockchip,i2s-broken-burst-len;
-@@ -634,6 +641,7 @@
- 
- &i2s2 {
- 	#sound-dai-cells = <0>;
-+	rockchip,bclk-fs = <128>;
- 	status = "okay";
- };
- 
-@@ -641,6 +649,7 @@
- 	phy-supply = <&vcc_phy>;
- 	phy-mode = "rgmii";
- 	clock_in_out = "input";
-+	snps,force_thresh_dma_mode;
- 	snps,reset-gpio = <&gpio3 RK_PB7 GPIO_ACTIVE_LOW>;
- 	snps,reset-active-low;
- 	snps,reset-delays-us = <0 10000 50000>;
-@@ -660,6 +669,17 @@
- };
- 
- &hdmi {
-+	#address-cells = <1>;
-+	#size-cells = <0>;
-+	#sound-dai-cells = <0>;
-+	status = "okay";
-+};
-+
-+&iep {
-+	status = "okay";
-+};
-+
-+&iep_mmu {
- 	status = "okay";
- };
- 
-@@ -678,13 +698,17 @@
- 
- &sdmmc {
- 	clock-frequency = <50000000>;
--	clock-freq-min-max = <400000 150000000>;
-+	max-frequency = <150000000>;
- 	supports-sd;
- 	bus-width = <4>;
- 	cap-mmc-highspeed;
- 	cap-sd-highspeed;
- 	disable-wp;
- 	num-slots = <1>;
-+	sd-uhs-sdr12;
-+	sd-uhs-sdr25;
-+	sd-uhs-sdr50;
-+	sd-uhs-sdr104;
- 	vqmmc-supply = <&vcc_sd>;
- 	pinctrl-names = "default";
- 	pinctrl-0 = <&sdmmc_clk &sdmmc_cmd &sdmmc_cd &sdmmc_bus4>;
-@@ -694,7 +718,7 @@
- 
- &sdio0 {
- 	clock-frequency = <50000000>;
--	clock-freq-min-max = <200000 50000000>;
-+	max-frequency = <50000000>;
- 	supports-sdio;
- 	bus-width = <4>;
- 	disable-wp;
-@@ -707,35 +731,50 @@
- 	pinctrl-names = "default";
- 	pinctrl-0 = <&sdio0_bus4 &sdio0_cmd &sdio0_clk>;
- 	sd-uhs-sdr104;
--	status = "okay";
-+	status = "disabled";
- };
- 
- &sdhci {
- 	bus-width = <8>;
--	mmc-hs200-1_8v;
- 	mmc-hs400-1_8v;
-+	mmc-hs400-enhanced-strobe;
-+	supports-emmc;
-+	non-removable;
- 	keep-power-in-suspend;
- 	status = "okay";
- };
- 
- &spdif {
--	status = "disabled";
-+	status = "okay";
- 	pinctrl-0 = <&spdif_bus_1>;
- 	#sound-dai-cells = <0>;
- };
- 
- &spi1 {
- 	status = "okay";
-+	max-freq = <10000000>;
-+
- 	flash@0 {
--		compatible = "gigadevice,gd25q128", "jedec,spi-nor";
-+		compatible = "jedec,spi-nor";
- 		#address-cells = <1>;
- 		#size-cells = <1>;
- 		reg = <0>;
--		m25p,fast-read;
--		spi-max-frequency = <24000000>;
-+		spi-max-frequency = <10000000>;
- 	};
- };
- 
-+&threshold {
-+	temperature = <80000>;
-+};
-+
-+&target {
-+	temperature = <95000>;
-+};
-+
-+&soc_crit {
-+	temperature = <100000>;
-+};
-+
- &tcphy0 {
- 	extcon = <&fusb0>;
- 	status = "okay";
-@@ -826,114 +865,15 @@
- 	status = "okay";
- };
- 
--&pwm2 {
-+&pwm1 {
- 	status = "okay";
- 	pinctrl-names = "active";
--	pinctrl-0 = <&pwm2_pin_pull_down>;
- };
- 
--&pwm3 {
-+&pwm2 {
- 	status = "okay";
--
--	interrupts = <GIC_SPI 61 IRQ_TYPE_LEVEL_HIGH 0>;
--	compatible = "rockchip,remotectl-pwm";
--	remote_pwm_id = <3>;
--	handle_cpu_id = <1>;
--	remote_support_psci = <1>;
--
--	ir_key1 {
--		rockchip,usercode = <0x4040>;
--		rockchip,key_table =
--			<0xf2	KEY_REPLY>,
--			<0xba	KEY_BACK>,
--			<0xf4	KEY_UP>,
--			<0xf1	KEY_DOWN>,
--			<0xef	KEY_LEFT>,
--			<0xee	KEY_RIGHT>,
--			<0xbd	KEY_HOME>,
--			<0xea	KEY_VOLUMEUP>,
--			<0xe3	KEY_VOLUMEDOWN>,
--			<0xe2	KEY_SEARCH>,
--			<0xb2	KEY_POWER>,
--			<0xbc	KEY_MUTE>,
--			<0xec	KEY_MENU>,
--			<0xbf	0x190>,
--			<0xe0	0x191>,
--			<0xe1	0x192>,
--			<0xe9	183>,
--			<0xe6	248>,
--			<0xe8	185>,
--			<0xe7	186>,
--			<0xf0	388>,
--			<0xbe	0x175>;
--	};
--
--	ir_key2 {
--		rockchip,usercode = <0xff00>;
--		rockchip,key_table =
--			<0xf9	KEY_HOME>,
--			<0xbf	KEY_BACK>,
--			<0xfb	KEY_MENU>,
--			<0xaa	KEY_REPLY>,
--			<0xb9	KEY_UP>,
--			<0xe9	KEY_DOWN>,
--			<0xb8	KEY_LEFT>,
--			<0xea	KEY_RIGHT>,
--			<0xeb	KEY_VOLUMEDOWN>,
--			<0xef	KEY_VOLUMEUP>,
--			<0xf7	KEY_MUTE>,
--			<0xe7	KEY_POWER>,
--			<0xfc	KEY_POWER>,
--			<0xa9	KEY_VOLUMEDOWN>,
--			<0xa8	KEY_VOLUMEDOWN>,
--			<0xe0	KEY_VOLUMEDOWN>,
--			<0xa5	KEY_VOLUMEDOWN>,
--			<0xab	183>,
--			<0xb7	388>,
--			<0xe8	388>,
--			<0xf8	184>,
--			<0xaf	185>,
--			<0xed	KEY_VOLUMEDOWN>,
--			<0xee	186>,
--			<0xb3	KEY_VOLUMEDOWN>,
--			<0xf1	KEY_VOLUMEDOWN>,
--			<0xf2	KEY_VOLUMEDOWN>,
--			<0xf3	KEY_SEARCH>,
--			<0xb4	KEY_VOLUMEDOWN>,
--			<0xbe	KEY_SEARCH>;
--	};
--
--	ir_key3 {
--		rockchip,usercode = <0x1dcc>;
--		rockchip,key_table =
--			<0xee	KEY_REPLY>,
--			<0xf0	KEY_BACK>,
--			<0xf8	KEY_UP>,
--			<0xbb	KEY_DOWN>,
--			<0xef	KEY_LEFT>,
--			<0xed	KEY_RIGHT>,
--			<0xfc	KEY_HOME>,
--			<0xf1	KEY_VOLUMEUP>,
--			<0xfd	KEY_VOLUMEDOWN>,
--			<0xb7	KEY_SEARCH>,
--			<0xff	KEY_POWER>,
--			<0xf3	KEY_MUTE>,
--			<0xbf	KEY_MENU>,
--			<0xf9	0x191>,
--			<0xf5	0x192>,
--			<0xb3	388>,
--			<0xbe	KEY_1>,
--			<0xba	KEY_2>,
--			<0xb2	KEY_3>,
--			<0xbd	KEY_4>,
--			<0xf9	KEY_5>,
--			<0xb1	KEY_6>,
--			<0xfc	KEY_7>,
--			<0xf8	KEY_8>,
--			<0xb0	KEY_9>,
--			<0xb6	KEY_0>,
--			<0xb5	KEY_BACKSPACE>;
--	};
-+	pinctrl-names = "active";
-+	pinctrl-0 = <&pwm2_pin_pull_down>;
- };
- 
- &pinctrl {
-@@ -951,6 +891,13 @@
- 		};
- 	};
- 
-+	ir {
-+		ir_int: ir-int {
-+			rockchip,pins =
-+				<0 RK_PA6 RK_FUNC_GPIO &pcfg_pull_none>;
++		opp-600000000 {
++			opp-hz = /bits/ 64 <600000000>;
++			opp-microvolt = <1150000>;
++			opp-microvolt-L0 = <1150000>;
++			opp-microvolt-L1 = <1125000>;
 +		};
-+	};
-+
- 	pcie {
- 		pcie_pwr_en: pcie-pwr-en {
- 			rockchip,pins =
-@@ -982,6 +929,7 @@
- 	sdio-pwrseq {
- 		wifi_enable_h: wifi-enable-h {
- 			rockchip,pins =
-+				<0 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>,
- 				<0 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
- 		};
++		*/
  	};
-@@ -1085,35 +1033,6 @@
- 	status = "okay";
- };
  
--&rockchip_suspend {
--	status = "okay";
--	rockchip,sleep-debug-en = <0>;
--	rockchip,sleep-mode-config = <
--		(0
--		| RKPM_SLP_ARMPD
--		| RKPM_SLP_PERILPPD
--		| RKPM_SLP_DDR_RET
--		| RKPM_SLP_PLLPD
--		| RKPM_SLP_CENTER_PD
--		| RKPM_SLP_AP_PWROFF
--		)
--	>;
--	rockchip,wakeup-config = <
--		(0
--		| RKPM_GPIO_WKUP_EN
--		| RKPM_PWM_WKUP_EN
--		)
--	>;
--	rockchip,pwm-regulator-config = <
--		(0
--		| PWM2_REGULATOR_EN
--		)
--	>;
--	rockchip,power-ctrl =
--		<&gpio1 RK_PC1 GPIO_ACTIVE_HIGH>,
--		<&gpio1 RK_PB6 GPIO_ACTIVE_HIGH>;
--};
--
- &vdec_mmu {
- 	status = "okay";
- };
-@@ -1135,3 +1054,13 @@
- &vopb_mmu {
- 	status = "okay";
- };
-+
-+&vopl {
-+	status = "disabled";
-+	assigned-clocks = <&cru DCLK_VOP1_DIV>;
-+	assigned-clock-parents = <&cru PLL_CPLL>;
-+};
-+
-+&vopl_mmu {
-+	status = "disabled";
-+};
-
-From b48757753fd87cd0dc058e439bbd586dfbd4f6fb Mon Sep 17 00:00:00 2001
-From: Jonas Karlman <jonas@kwiboo.se>
-Date: Mon, 17 Dec 2018 07:41:38 +0100
-Subject: [PATCH] arm64: dts: rockchip: add rk3399-khadas-edge board
-
----
- .../arm64/boot/dts/rockchip/rk3399-khadas-edge.dts |   66 ++
- .../boot/dts/rockchip/rk3399-khadas-edge.dtsi      | 1005 ++++++++++++++++++++
- 2 files changed, 1071 insertions(+)
- create mode 100644 arch/arm64/boot/dts/rockchip/rk3399-khadas-edge.dts
- create mode 100644 arch/arm64/boot/dts/rockchip/rk3399-khadas-edge.dtsi
-
+ 	vdpu: vpu_service@ff350000 {
+@@ -873,7 +906,7 @@
+ 		interrupts = <GIC_SPI 74 IRQ_TYPE_LEVEL_HIGH>;
+ 		interrupt-names = "rkvdec_mmu";
+ 		clocks = <&cru ACLK_RKVDEC>, <&cru HCLK_RKVDEC>;
+-		clock-names = "aclk_vcodec", "hclk_vcodec";
++		clock-names = "aclk", "hclk";
+ 		power-domains = <&power RK3328_PD_VIDEO>;
+ 		#iommu-cells = <0>;
+ 	};
+@@ -951,6 +984,8 @@
+ 	vop: vop@ff370000 {
+ 		compatible = "rockchip,rk3328-vop";
+ 		reg = <0x0 0xff370000 0x0 0x3efc>;
++		reg-names = "regs", "gamma_lut";
++		rockchip,grf = <&grf>;
+ 		interrupts = <GIC_SPI 32 IRQ_TYPE_LEVEL_HIGH>;
+ 		clocks = <&cru ACLK_VOP>, <&cru DCLK_LCDC>, <&cru HCLK_VOP>;
+ 		clock-names = "aclk_vop", "dclk_vop", "hclk_vop";
+@@ -1305,6 +1340,7 @@
+ 			      "pclk_mac";
+ 		resets = <&cru SRST_GMAC2IO_A>;
+ 		reset-names = "stmmaceth";
++		snps,force_thresh_dma_mode;
+ 		status = "disabled";
+ 	};
+ 
+@@ -1375,12 +1411,14 @@
+ 	sdmmc_ext: dwmmc@ff5f0000 {
+ 		compatible = "rockchip,rk3328-dw-mshc", "rockchip,rk3288-dw-mshc";
+ 		reg = <0x0 0xff5f0000 0x0 0x4000>;
+-		clock-freq-min-max = <400000 150000000>;
++		max-frequency = <150000000>;
+ 		clocks = <&cru HCLK_SDMMC_EXT>, <&cru SCLK_SDMMC_EXT>,
+ 			 <&cru SCLK_SDMMC_EXT_DRV>, <&cru SCLK_SDMMC_EXT_SAMPLE>;
+-		clock-names = "biu", "ciu", "ciu-drv", "ciu-sample";
++		clock-names = "biu", "ciu", "ciu-drive", "ciu-sample";
+ 		fifo-depth = <0x100>;
+ 		interrupts = <GIC_SPI 4 IRQ_TYPE_LEVEL_HIGH>;
++		resets = <&cru SRST_SDMMCEXT>;
++		reset-names = "reset";
+ 		status = "disabled";
+ 	};
+ 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-khadas-edge.dts b/arch/arm64/boot/dts/rockchip/rk3399-khadas-edge.dts
 new file mode 100644
 index 000000000000..1381ba09b72d
@@ -8093,17 +5706,31 @@ index 000000000000..a7c14f6ccd92
 +&vopl_mmu {
 +	status = "disabled";
 +};
-
-From 2de45e1b4eb4b763bf396e768e5add15433ba0f0 Mon Sep 17 00:00:00 2001
-From: Jonas Karlman <jonas@kwiboo.se>
-Date: Sat, 19 Jan 2019 19:31:40 +0100
-Subject: [PATCH] arm64: dts: rockchip: add rk3399-rock-pi-4 board
-
----
- arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts | 926 ++++++++++++++++++++++
- 1 file changed, 926 insertions(+)
- create mode 100644 arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts
-
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-linux.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-linux.dtsi
+index 45e9575576d7..bdb4a1443281 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-linux.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3399-linux.dtsi
+@@ -47,7 +47,7 @@
+ 	compatible = "rockchip,linux", "rockchip,rk3399";
+ 
+ 	chosen {
+-		bootargs = "earlycon=uart8250,mmio32,0xff1a0000 swiotlb=1 console=ttyFIQ0 rw root=PARTUUID=614e0000-0000 rootfstype=ext4 rootwait coherent_pool=1m";
++		bootargs = "earlycon=uart8250,mmio32,0xff1a0000 swiotlb=1 coherent_pool=1m";
+ 	};
+ 
+ 	reserved-memory {
+@@ -55,11 +55,6 @@
+ 		#size-cells = <2>;
+ 		ranges;
+ 
+-		drm_logo: drm-logo@00000000 {
+-			compatible = "rockchip,drm-logo";
+-			reg = <0x0 0x0 0x0 0x0>;
+-		};
+-
+ 		ramoops_mem: region@110000 {
+ 			reg = <0x0 0x110000 0x0 0xf0000>;
+ 			reg-names = "ramoops_mem";
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts
 new file mode 100644
 index 000000000000..7b376aee97c4
@@ -9036,29 +6663,2096 @@ index 000000000000..7b376aee97c4
 +&vopl_mmu {
 +	status = "disabled";
 +};
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3399-linux.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-linux.dtsi
-index a57b372..910fee7 100644
---- a/arch/arm64/boot/dts/rockchip/rk3399-linux.dtsi
-+++ b/arch/arm64/boot/dts/rockchip/rk3399-linux.dtsi
-@@ -47,7 +47,7 @@
- 	compatible = "rockchip,linux", "rockchip,rk3399";
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rock960.dts b/arch/arm64/boot/dts/rockchip/rk3399-rock960.dts
+new file mode 100644
+index 000000000000..865a1da96aee
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3399-rock960.dts
+@@ -0,0 +1,1003 @@
++/*
++ * Copyright (c) 2016 Fuzhou Rockchip Electronics Co., Ltd
++ *
++ * This file is dual-licensed: you can use it either under the terms
++ * of the GPL or the X11 license, at your option. Note that this dual
++ * licensing only applies to this file, and not this project as a
++ * whole.
++ *
++ *  a) This file is free software; you can redistribute it and/or
++ *     modify it under the terms of the GNU General Public License as
++ *     published by the Free Software Foundation; either version 2 of the
++ *     License, or (at your option) any later version.
++ *
++ *     This file is distributed in the hope that it will be useful,
++ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *     GNU General Public License for more details.
++ *
++ * Or, alternatively,
++ *
++ *  b) Permission is hereby granted, free of charge, to any person
++ *     obtaining a copy of this software and associated documentation
++ *     files (the "Software"), to deal in the Software without
++ *     restriction, including without limitation the rights to use,
++ *     copy, modify, merge, publish, distribute, sublicense, and/or
++ *     sell copies of the Software, and to permit persons to whom the
++ *     Software is furnished to do so, subject to the following
++ *     conditions:
++ *
++ *     The above copyright notice and this permission notice shall be
++ *     included in all copies or substantial portions of the Software.
++ *
++ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
++ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
++ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
++ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
++ *     OTHER DEALINGS IN THE SOFTWARE.
++ */
++
++/dts-v1/;
++
++#include <dt-bindings/pwm/pwm.h>
++#include <dt-bindings/input/input.h>
++#include "rk3399.dtsi"
++#include "rk3399-linux.dtsi"
++#include "rk3399-opp.dtsi"
++
++
++/ {
++	model = "ROCK960";
++	compatible = "96rocks,rock960", "rockchip,rk3399";
++
++	vcc1v8_s0: vcc1v8-s0 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc1v8_s0";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		regulator-always-on;
++	};
++
++	vcc_sys: vcc-sys {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_sys";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		regulator-always-on;
++	};
++
++	vcc_phy: vcc-phy-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_phy";
++		regulator-always-on;
++		regulator-boot-on;
++	};
++
++	vcc3v3_sys: vcc3v3-sys {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc3v3_sys";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		regulator-always-on;
++		vin-supply = <&vcc_sys>;
++	};
++
++	vcc3v3_pcie: vcc3v3-pcie-regulator {
++		compatible = "regulator-fixed";
++		gpio = <&gpio3 11 GPIO_ACTIVE_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pcie_drv>;
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-name = "vcc3v3_pcie";
++		vin-supply = <&vcc3v3_sys>;
++	};
++
++	vcc5v0_host: vcc5v0-host-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio4 25 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&host_vbus_drv>;
++		regulator-name = "vcc5v0_host";
++		regulator-always-on;
++	};
++
++	vdd_log: vdd-log {
++		compatible = "pwm-regulator";
++		pwms = <&pwm2 0 25000 1>;
++		regulator-name = "vdd_log";
++		regulator-min-microvolt = <800000>;
++		regulator-max-microvolt = <1400000>;
++		regulator-always-on;
++		regulator-boot-on;
++
++		/* for rockchip boot on */
++		rockchip,pwm_id= <2>;
++		rockchip,pwm_voltage = <900000>;
++
++		vin-supply = <&vcc_sys>;
++	};
++
++	clkin_gmac: external-gmac-clock {
++		compatible = "fixed-clock";
++		clock-frequency = <125000000>;
++		clock-output-names = "clkin_gmac";
++		#clock-cells = <0>;
++	};
++
++	hdmi-sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,mclk-fs = <256>;
++		simple-audio-card,name = "HDMI";
++		simple-audio-card,cpu {
++			sound-dai = <&i2s2>;
++		};
++		simple-audio-card,codec {
++			sound-dai = <&hdmi>;
++		};
++	};
++
++	spdif-sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,name = "SPDIF";
++		simple-audio-card,cpu {
++			sound-dai = <&spdif>;
++		};
++		simple-audio-card,codec {
++			sound-dai = <&spdif_out>;
++		};
++	};
++
++	spdif_out: spdif-out {
++		compatible = "linux,spdif-dit";
++		#sound-dai-cells = <0>;
++	};
++
++	sdio_pwrseq: sdio-pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		clocks = <&rk808 1>;
++		clock-names = "ext_clock";
++		pinctrl-names = "default";
++		pinctrl-0 = <&wifi_enable_h>;
++		post-power-on-delay-ms = <200>;
++		power-off-delay-us = <10>;
++
++		/*
++		 * On the module itself this is one of these (depending
++		 * on the actual card populated):
++		 * - SDIO_RESET_L_WL_REG_ON
++		 * - PDN (power down when low)
++		 */
++		reset-gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
++	};
++
++	wireless-wlan {
++		compatible = "wlan-platdata";
++		rockchip,grf = <&grf>;
++		wifi_chip_type = "ap6354";
++		sdio_vref = <1800>;
++		WIFI,host_wake_irq = <&gpio0 3 GPIO_ACTIVE_HIGH>;
++		status = "okay";
++	};
++
++	wireless-bluetooth {
++		compatible = "bluetooth-platdata";
++		clocks = <&rk808 1>;
++		clock-names = "ext_clock";
++		/* wifi-bt-power-toggle; */
++		uart_rts_gpios = <&gpio2 19 GPIO_ACTIVE_LOW>;
++		pinctrl-names = "default", "rts_gpio";
++		pinctrl-0 = <&uart0_rts>;
++		pinctrl-1 = <&uart0_gpios>;
++		/* BT,power_gpio  = <&gpio3 19 GPIO_ACTIVE_HIGH>; */
++		BT,reset_gpio    = <&gpio0 9 GPIO_ACTIVE_HIGH>;
++		BT,wake_gpio     = <&gpio2 27 GPIO_ACTIVE_HIGH>;
++		BT,wake_host_irq = <&gpio0 4 GPIO_ACTIVE_HIGH>;
++		status = "okay";
++	};
++
++	test-power {
++		status = "okay";
++	};
++};
++
++&hdmi {
++	#address-cells = <1>;
++	#size-cells = <0>;
++	#sound-dai-cells = <0>;
++	status = "okay";
++};
++
++&sdmmc {
++	clock-frequency = <100000000>;
++	max-frequency = <100000000>;
++	supports-sd;
++	bus-width = <4>;
++	cap-mmc-highspeed;
++	cap-sd-highspeed;
++	disable-wp;
++	num-slots = <1>;
++	sd-uhs-sdr12;
++	sd-uhs-sdr25;
++	sd-uhs-sdr50;
++	sd-uhs-sdr104;
++	vqmmc-supply = <&vcc_sd>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdmmc_clk &sdmmc_cmd &sdmmc_cd &sdmmc_bus4>;
++	card-detect-delay = <800>;
++	status = "okay";
++};
++
++&sdio0 {
++	clock-frequency = <100000000>;
++	max-frequency = <100000000>;
++	supports-sdio;
++	bus-width = <4>;
++	disable-wp;
++	cap-sd-highspeed;
++	cap-sdio-irq;
++	keep-power-in-suspend;
++	mmc-pwrseq = <&sdio_pwrseq>;
++	non-removable;
++	num-slots = <1>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdio0_bus4 &sdio0_cmd &sdio0_clk>;
++	sd-uhs-sdr104;
++	status = "okay";
++};
++
++&emmc_phy {
++	status = "okay";
++};
++
++&sdhci {
++	bus-width = <8>;
++	mmc-hs400-1_8v;
++	supports-emmc;
++	non-removable;
++	mmc-hs400-enhanced-strobe;
++	status = "okay";
++};
++
++&i2s0 {
++	status = "okay";
++	rockchip,i2s-broken-burst-len;
++	rockchip,playback-channels = <8>;
++	rockchip,capture-channels = <8>;
++	#sound-dai-cells = <0>;
++};
++
++&i2s2 {
++	#sound-dai-cells = <0>;
++	rockchip,bclk-fs = <128>;
++	status = "okay";
++};
++
++&spdif {
++	pinctrl-0 = <&spdif_bus_1>;
++	status = "okay";
++	#sound-dai-cells = <0>;
++};
++
++&i2c0 {
++	status = "okay";
++	i2c-scl-rising-time-ns = <168>;
++	i2c-scl-falling-time-ns = <4>;
++	clock-frequency = <400000>;
++
++	vdd_cpu_b: syr827@40 {
++		compatible = "silergy,syr827";
++		reg = <0x40>;
++		regulator-compatible = "fan53555-reg";
++		pinctrl-0 = <&vsel1_gpio>;
++		vsel-gpios = <&gpio1 17 GPIO_ACTIVE_HIGH>;
++		regulator-name = "vdd_cpu_b";
++		regulator-min-microvolt = <712500>;
++		regulator-max-microvolt = <1500000>;
++		regulator-ramp-delay = <1000>;
++		fcs,suspend-voltage-selector = <1>;
++		regulator-always-on;
++		regulator-boot-on;
++		vin-supply = <&vcc_sys>;
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++
++	vdd_gpu: syr828@41 {
++		compatible = "silergy,syr828";
++		reg = <0x41>;
++		regulator-compatible = "fan53555-reg";
++		pinctrl-0 = <&vsel2_gpio>;
++		vsel-gpios = <&gpio1 14 GPIO_ACTIVE_HIGH>;
++		regulator-name = "vdd_gpu";
++		regulator-min-microvolt = <712500>;
++		regulator-max-microvolt = <1500000>;
++		regulator-ramp-delay = <1000>;
++		fcs,suspend-voltage-selector = <1>;
++		regulator-always-on;
++		regulator-boot-on;
++		vin-supply = <&vcc_sys>;
++		regulator-initial-mode = <1>; /* 1:force PWM 2:auto */
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++
++	rk808: pmic@1b {
++		compatible = "rockchip,rk808";
++		reg = <0x1b>;
++		interrupt-parent = <&gpio1>;
++		interrupts = <21 IRQ_TYPE_LEVEL_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pmic_int_l>;
++		rockchip,system-power-controller;
++		wakeup-source;
++		#clock-cells = <1>;
++		clock-output-names = "xin32k", "rk808-clkout2";
++
++		vcc1-supply = <&vcc_sys>;
++		vcc2-supply = <&vcc_sys>;
++		vcc3-supply = <&vcc_sys>;
++		vcc4-supply = <&vcc_sys>;
++		vcc6-supply = <&vcc_sys>;
++		vcc7-supply = <&vcc_sys>;
++		vcc8-supply = <&vcc3v3_sys>;
++		vcc9-supply = <&vcc_sys>;
++		vcc10-supply = <&vcc_sys>;
++		vcc11-supply = <&vcc_sys>;
++		vcc12-supply = <&vcc3v3_sys>;
++		vddio-supply = <&vcc_1v8>;
++
++		regulators {
++			vdd_center: DCDC_REG1 {
++				regulator-name = "vdd_center";
++				regulator-min-microvolt = <750000>;
++				regulator-max-microvolt = <1350000>;
++				regulator-ramp-delay = <6001>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_cpu_l: DCDC_REG2 {
++				regulator-name = "vdd_cpu_l";
++				regulator-min-microvolt = <750000>;
++				regulator-max-microvolt = <1350000>;
++				regulator-ramp-delay = <6001>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc_ddr: DCDC_REG3 {
++				regulator-name = "vcc_ddr";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++				};
++			};
++
++			vcc_1v8: DCDC_REG4 {
++				regulator-name = "vcc_1v8";
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vcc1v8_dvp: LDO_REG1 {
++				regulator-name = "vcc1v8_dvp";
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vcca1v8_hdmi: LDO_REG2 {
++				regulator-name = "vcca1v8_hdmi";
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vcca_1v8: LDO_REG3 {
++				regulator-name = "vcca_1v8";
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vcc_sd: LDO_REG4 {
++				regulator-name = "vcc_sd";
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <3000000>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3000000>;
++				};
++			};
++
++			vcc3v0_sd: LDO_REG5 {
++				regulator-name = "vcc3v0_sd";
++				regulator-min-microvolt = <3000000>;
++				regulator-max-microvolt = <3000000>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3000000>;
++				};
++			};
++
++			vcc_1v5: LDO_REG6 {
++				regulator-name = "vcc_1v5";
++				regulator-min-microvolt = <1500000>;
++				regulator-max-microvolt = <1500000>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1500000>;
++				};
++			};
++
++			vcca0v9_hdmi: LDO_REG7 {
++				regulator-name = "vcca0v9_hdmi";
++				regulator-min-microvolt = <900000>;
++				regulator-max-microvolt = <900000>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <900000>;
++				};
++			};
++
++			vcc_3v0: LDO_REG8 {
++				regulator-name = "vcc_3v0";
++				regulator-min-microvolt = <3000000>;
++				regulator-max-microvolt = <3000000>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3000000>;
++				};
++			};
++
++			vcc3v3_s3: SWITCH_REG1 {
++				regulator-name = "vcc3v3_s3";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++				};
++			};
++
++			vcc3v3_s0: SWITCH_REG2 {
++				regulator-name = "vcc3v3_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++				};
++			};
++		};
++	};
++};
++
++&i2c1 {
++	status = "okay";
++};
++
++&i2c6 {
++	status = "okay";
++};
++
++&i2c4 {
++	status = "okay";
++	fusb0: fusb30x@22 {
++		compatible = "fairchild,fusb302";
++		reg = <0x22>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&fusb0_int>;
++		vbus-5v-gpios = <&gpio1 3 GPIO_ACTIVE_LOW>;
++		int-n-gpios = <&gpio1 2 GPIO_ACTIVE_HIGH>;
++		status = "okay";
++	};
++};
++
++&i2c2 {
++	status = "okay";
++	camera0: camera-module@10 {
++		status = "disabled";
++		compatible = "omnivision,ov13850-v4l2-i2c-subdev";
++		reg = < 0x10 >;
++		device_type = "v4l2-i2c-subdev";
++		clocks = <&cru SCLK_CIF_OUT>;
++		clock-names = "clk_cif_out";
++		pinctrl-names = "rockchip,camera_default",
++				"rockchip,camera_sleep";
++		pinctrl-0 = <&cam0_default_pins>;
++		pinctrl-1 = <&cam0_sleep_pins>;
++		//rockchip,pd-gpio = <&gpio4 4 GPIO_ACTIVE_LOW>;
++		rockchip,pwr-gpio = <&gpio4 4 GPIO_ACTIVE_HIGH>;
++		rockchip,rst-gpio = <&gpio3 29 GPIO_ACTIVE_LOW>;
++		rockchip,camera-module-mclk-name = "clk_cif_out";
++		rockchip,camera-module-facing = "back";
++		rockchip,camera-module-name = "cmk-cb0695-fv1";
++		rockchip,camera-module-len-name = "lg9569a2";
++		rockchip,camera-module-fov-h = "66.0";
++		rockchip,camera-module-fov-v = "50.1";
++		rockchip,camera-module-orientation = <0>;
++		rockchip,camera-module-iq-flip = <0>;
++		rockchip,camera-module-iq-mirror = <0>;
++		rockchip,camera-module-flip = <1>;
++		rockchip,camera-module-mirror = <0>;
++
++		rockchip,camera-module-defrect0 = <2112 1568 0 0 2112 1568>;
++		rockchip,camera-module-defrect1 = <4224 3136 0 0 4224 3136>;
++		rockchip,camera-module-defrect3 = <3264 2448 0 0 3264 2448>;
++		rockchip,camera-module-flash-support = <1>;
++		rockchip,camera-module-mipi-dphy-index = <0>;
++	};
++
++	camera1: camera-module@36 {
++		status = "disabled";
++		compatible = "omnivision,ov4690-v4l2-i2c-subdev";
++		reg = <0x36>;
++		device_type = "v4l2-i2c-subdev";
++		clocks = <&cru SCLK_CIF_OUT>;
++		clock-names = "clk_cif_out";
++		pinctrl-names = "rockchip,camera_default",
++				"rockchip,camera_sleep";
++		pinctrl-0 = <&cam0_default_pins>;
++		pinctrl-1 = <&cam0_sleep_pins>;
++		rockchip,pd-gpio = <&gpio3 4 GPIO_ACTIVE_LOW>;
++		//rockchip,pwr-gpio = <&gpio3 13 0>;
++		rockchip,rst-gpio = <&gpio2 10 GPIO_ACTIVE_LOW>;
++		rockchip,camera-module-mclk-name = "clk_cif_out";
++		rockchip,camera-module-facing = "back";
++		rockchip,camera-module-name = "LA6111PA";
++		rockchip,camera-module-len-name = "YM6011P";
++		rockchip,camera-module-fov-h = "116";
++		rockchip,camera-module-fov-v = "61";
++		rockchip,camera-module-orientation = <0>;
++		rockchip,camera-module-iq-flip = <0>;
++		rockchip,camera-module-iq-mirror = <0>;
++		rockchip,camera-module-flip = <0>;
++		rockchip,camera-module-mirror = <1>;
++
++		rockchip,camera-module-defrect0 = <2688 1520 0 0 2688 1520>;
++		rockchip,camera-module-flash-support = <0>;
++		rockchip,camera-module-mipi-dphy-index = <0>;
++	};
++
++};
++
++&cpu_l0 {
++	cpu-supply = <&vdd_cpu_l>;
++};
++
++&cpu_l1 {
++	cpu-supply = <&vdd_cpu_l>;
++};
++
++&cpu_l2 {
++	cpu-supply = <&vdd_cpu_l>;
++};
++
++&cpu_l3 {
++	cpu-supply = <&vdd_cpu_l>;
++};
++
++&cpu_b0 {
++	cpu-supply = <&vdd_cpu_b>;
++};
++
++&cpu_b1 {
++	cpu-supply = <&vdd_cpu_b>;
++};
++
++&gpu {
++	status = "okay";
++	mali-supply = <&vdd_gpu>;
++};
++
++&threshold {
++	temperature = <85000>;
++};
++
++&target {
++	temperature = <100000>;
++};
++
++&soc_crit {
++	temperature = <105000>;
++};
++
++&tcphy0 {
++	extcon = <&fusb0>;
++	status = "okay";
++};
++
++&tcphy1 {
++	status = "okay";
++};
++
++&tsadc {
++	/* tshut mode 0:CRU 1:GPIO */
++	rockchip,hw-tshut-mode = <1>;
++	/* tshut polarity 0:LOW 1:HIGH */
++	rockchip,hw-tshut-polarity = <1>;
++	rockchip,hw-tshut-temp = <110000>;
++	status = "okay";
++};
++
++&u2phy0 {
++	status = "okay";
++	extcon = <&fusb0>;
++
++	u2phy0_otg: otg-port {
++		status = "okay";
++	};
++
++	u2phy0_host: host-port {
++		phy-supply = <&vcc5v0_host>;
++		status = "okay";
++	};
++};
++
++&u2phy1 {
++	status = "okay";
++
++	u2phy1_otg: otg-port {
++		status = "okay";
++	};
++
++	u2phy1_host: host-port {
++		phy-supply = <&vcc5v0_host>;
++		status = "okay";
++	};
++};
++
++&uart0 {
++	dmas = <&dmac_peri 0>, <&dmac_peri 1>;
++	dma-names = "tx", "rx";
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart0_xfer &uart0_cts>;
++	status = "okay";
++};
++
++&uart2 {
++	status = "okay";
++};
++
++&uart3 {
++	dmas = <&dmac_peri 6>, <&dmac_peri 7>;
++	dma-names = "tx", "rx";
++	status = "okay";
++};
++
++&uart4 {
++	dmas = <&dmac_peri 8>, <&dmac_peri 9>;
++	dma-names = "tx", "rx";
++	status = "okay";
++};
++
++&usb_host0_ehci {
++	status = "okay";
++};
++
++&usb_host0_ohci {
++	status = "okay";
++};
++
++&usb_host1_ehci {
++	status = "okay";
++};
++
++&usb_host1_ohci {
++	status = "okay";
++};
++
++&usbdrd3_0 {
++	extcon = <&fusb0>;
++	status = "okay";
++};
++
++&usbdrd_dwc3_0 {
++	dr_mode = "otg";
++	status = "okay";
++};
++
++&usbdrd3_1 {
++	status = "okay";
++};
++
++&usbdrd_dwc3_1 {
++	dr_mode = "host";
++	status = "okay";
++};
++
++&pwm2 {
++	status = "okay";
++};
++
++&gmac {
++	phy-supply = <&vcc_phy>;
++	phy-mode = "rgmii";
++	clock_in_out = "input";
++	snps,reset-gpio = <&gpio3 15 GPIO_ACTIVE_LOW>;
++	snps,reset-active-low;
++	snps,reset-delays-us = <0 10000 50000>;
++	assigned-clocks = <&cru SCLK_RMII_SRC>;
++	assigned-clock-parents = <&clkin_gmac>;
++	pinctrl-names = "default", "sleep";
++	pinctrl-0 = <&rgmii_pins>;
++	pinctrl-1 = <&rgmii_sleep_pins>;
++	tx_delay = <0x28>;
++	rx_delay = <0x11>;
++	status = "disabled";
++};
++
++&saradc {
++	status = "okay";
++};
++
++&iep {
++	status = "okay";
++};
++
++&iep_mmu {
++	status = "okay";
++};
++
++&io_domains {
++	status = "okay";
++
++	bt656-supply = <&vcc1v8_s0>; /* bt656_gpio2ab_ms */
++	audio-supply = <&vcc1v8_s0>; /* audio_gpio3d4a_ms */
++	sdmmc-supply = <&vcc_sd>; /* sdmmc_gpio4b_ms */
++	gpio1830-supply = <&vcc_3v0>; /* gpio1833_gpio4cd_ms */
++};
++
++&pcie_phy {
++	status = "okay";
++};
++
++&pcie0 {
++	ep-gpios = <&gpio3 9 GPIO_ACTIVE_HIGH>;
++	num-lanes = <4>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie_clkreqn_cpm>;
++	status = "okay";
++};
++
++&pinctrl {
++
++	sdio0 {
++		sdio0_bus1: sdio0-bus1 {
++			rockchip,pins =
++				<2 20 RK_FUNC_1 &pcfg_pull_up_20ma>;
++		};
++
++		sdio0_bus4: sdio0-bus4 {
++			rockchip,pins =
++				<2 20 RK_FUNC_1 &pcfg_pull_up_20ma>,
++				<2 21 RK_FUNC_1 &pcfg_pull_up_20ma>,
++				<2 22 RK_FUNC_1 &pcfg_pull_up_20ma>,
++				<2 23 RK_FUNC_1 &pcfg_pull_up_20ma>;
++		};
++
++		sdio0_cmd: sdio0-cmd {
++			rockchip,pins =
++				<2 24 RK_FUNC_1 &pcfg_pull_up_20ma>;
++		};
++
++		sdio0_clk: sdio0-clk {
++			rockchip,pins =
++				<2 25 RK_FUNC_1 &pcfg_pull_none_20ma>;
++		};
++	};
++
++	sdmmc {
++		sdmmc_bus1: sdmmc-bus1 {
++			rockchip,pins =
++				<4 8 RK_FUNC_1 &pcfg_pull_up_8ma>;
++		};
++
++		sdmmc_bus4: sdmmc-bus4 {
++			rockchip,pins =
++				<4 8 RK_FUNC_1 &pcfg_pull_up_8ma>,
++				<4 9 RK_FUNC_1 &pcfg_pull_up_8ma>,
++				<4 10 RK_FUNC_1 &pcfg_pull_up_8ma>,
++				<4 11 RK_FUNC_1 &pcfg_pull_up_8ma>;
++		};
++
++		sdmmc_clk: sdmmc-clk {
++			rockchip,pins =
++				<4 12 RK_FUNC_1 &pcfg_pull_none_18ma>;
++		};
++
++		sdmmc_cmd: sdmmc-cmd {
++			rockchip,pins =
++				<4 13 RK_FUNC_1 &pcfg_pull_up_8ma>;
++		};
++	};
++
++	sdio-pwrseq {
++		wifi_enable_h: wifi-enable-h {
++			rockchip,pins =
++				<0 9 RK_FUNC_GPIO &pcfg_pull_none>,
++				<0 10 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	wireless-bluetooth {
++		uart0_gpios: uart0-gpios {
++			rockchip,pins =
++				<2 19 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	usb2 {
++		host_vbus_drv: host-vbus-drv {
++			rockchip,pins =
++				<4 25 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	pcie {
++		pcie_drv: pcie-drv {
++			rockchip,pins =
++				<3 11 RK_FUNC_GPIO &pcfg_pull_none>;
++			};
++	};
++
++	pmic {
++		pmic_int_l: pmic-int-l {
++			rockchip,pins =
++				<1 21 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++
++		vsel1_gpio: vsel1-gpio {
++			rockchip,pins =
++				<1 17 RK_FUNC_GPIO &pcfg_pull_down>;
++		};
++
++		vsel2_gpio: vsel2-gpio {
++			rockchip,pins =
++				<1 14 RK_FUNC_GPIO &pcfg_pull_down>;
++		};
++	};
++
++	gmac {
++		rgmii_sleep_pins: rgmii-sleep-pins {
++			rockchip,pins =
++				<3 15 RK_FUNC_GPIO &pcfg_output_low>;
++		};
++	};
++
++	fusb30x {
++		fusb0_int: fusb0-int {
++			rockchip,pins =
++				<1 2 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++};
++
++&pvtm {
++	status = "okay";
++};
++
++&pmu_pvtm {
++	status = "okay";
++};
++
++&pmu_io_domains {
++	status = "okay";
++	pmu1830-supply = <&vcc_1v8>;
++};
++
++&rockchip_suspend {
++	status = "okay";
++	rockchip,sleep-debug-en = <0>;
++	rockchip,sleep-mode-config = <
++		(0
++		| RKPM_SLP_ARMPD
++		| RKPM_SLP_PERILPPD
++		| RKPM_SLP_DDR_RET
++		| RKPM_SLP_PLLPD
++		| RKPM_SLP_CENTER_PD
++		| RKPM_SLP_AP_PWROFF
++		)
++	>;
++	rockchip,wakeup-config = <
++		(0
++		| RKPM_GPIO_WKUP_EN
++		| RKPM_PWM_WKUP_EN
++		)
++	>;
++	rockchip,pwm-regulator-config = <
++		(0
++		| PWM2_REGULATOR_EN
++		)
++	>;
++	rockchip,power-ctrl =
++		<&gpio1 17 GPIO_ACTIVE_HIGH>,
++		<&gpio1 14 GPIO_ACTIVE_HIGH>;
++};
++
++&vopb {
++	status = "okay";
++};
++
++&vopb_mmu {
++	status = "okay";
++};
++
++&cif_isp0 {
++	rockchip,camera-modules-attached = <&camera0>;
++	status = "okay";
++};
++
++&isp0_mmu {
++	status = "okay";
++};
++
++&cif_isp1 {
++	rockchip,camera-modules-attached = <&camera1>;
++	status = "disabled";
++};
++
++&isp1_mmu {
++	status = "okay";
++};
++
++&vpu {
++	status = "okay";
++	/* 0 means ion, 1 means drm */
++	//allocator = <0>;
++};
++
++&rkvdec {
++	status = "okay";
++	/* 0 means ion, 1 means drm */
++	//allocator = <0>;
++};
++
++&display_subsystem {
++	status = "okay";
++};
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts
+index 700dec8e8d19..3e61cba4779f 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts
+@@ -8,23 +8,33 @@
+ #include <dt-bindings/pwm/pwm.h>
+ #include <dt-bindings/input/input.h>
+ #include "rk3399.dtsi"
++#include "rk3399-linux.dtsi"
+ #include "rk3399-opp.dtsi"
  
- 	chosen {
--		bootargs = "earlycon=uart8250,mmio32,0xff1a0000 swiotlb=1 console=ttyFIQ0 rw root=PARTUUID=614e0000-0000 rootfstype=ext4 rootwait coherent_pool=1m";
-+		bootargs = "earlycon=uart8250,mmio32,0xff1a0000 swiotlb=1 coherent_pool=1m";
+ / {
+ 	model = "Pine64 RockPro64";
+ 	compatible = "pine64,rockpro64", "rockchip,rk3399";
+ 
+-	chosen {
+-		bootargs = "earlycon=uart8250,mmio32,0xff1a0000 swiotlb=1 coherent_pool=1m";
+-		stdout-path = "serial2:1500000n8";
+-	};
+-
+ 	/* first 64k(0xff8c0000~0xff8d0000) for ddr and suspend */
+ 	iram: sram@ff8d0000 {
+ 		compatible = "mmio-sram";
+ 		reg = <0x0 0xff8d0000 0x0 0x20000>; /* 128k */
  	};
  
- 	reserved-memory {
-@@ -55,11 +55,6 @@
- 		#size-cells = <2>;
- 		ranges;
++	xin32k: xin32k {
++		compatible = "fixed-clock";
++		clock-frequency = <32768>;
++		clock-output-names = "xin32k";
++		#clock-cells = <0>;
++	};
++
++	clkin_gmac: external-gmac-clock {
++		compatible = "fixed-clock";
++		clock-frequency = <125000000>;
++		clock-output-names = "clkin_gmac";
++		#clock-cells = <0>;
++	};
++
+ 	dc_12v: dc-12v {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "dc_12v";
+@@ -92,6 +102,7 @@
+ 	vdd_log: vdd-log {
+ 		compatible = "pwm-regulator";
+ 		pwms = <&pwm2 0 25000 1>;
++		pwm-supply = <&vcc_sys>;
+ 		regulator-name = "vdd_log";
+ 		regulator-min-microvolt = <800000>;
+ 		regulator-max-microvolt = <1400000>;
+@@ -101,56 +112,54 @@
+ 		/* for rockchip boot on */
+ 		rockchip,pwm_id= <2>;
+ 		rockchip,pwm_voltage = <900000>;
++	};
  
--		drm_logo: drm-logo@00000000 {
--			compatible = "rockchip,drm-logo";
--			reg = <0x0 0x0 0x0 0x0>;
+-		vin-supply = <&vcc_sys>;
++	leds {
++		compatible = "gpio-leds";
++
++		work-led {
++			gpios = <&gpio0 RK_PB3 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "mmc0";
++		};
++
++		diy-led {
++			gpios = <&gpio0 RK_PA2 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "heartbeat";
++		};
+ 	};
+ 
+-	clkin_gmac: external-gmac-clock {
+-		compatible = "fixed-clock";
+-		clock-frequency = <125000000>;
+-		clock-output-names = "clkin_gmac";
+-		#clock-cells = <0>;
++	ir-receiver {
++		compatible = "gpio-ir-receiver";
++		gpios = <&gpio0 RK_PA6 GPIO_ACTIVE_LOW>;
++		linux,rc-map-name = "rc-pine64";
++		pinctrl-0 = <&ir_int>;
++		pinctrl-names = "default";
+ 	};
+ 
+-	spdif-sound {
+-		status = "disabled";
++	hdmi-sound {
+ 		compatible = "simple-audio-card";
+-		simple-audio-card,name = "ROCKCHIP,SPDIF";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,mclk-fs = <256>;
++		simple-audio-card,name = "HDMI";
+ 		simple-audio-card,cpu {
+-			sound-dai = <&spdif>;
++			sound-dai = <&i2s2>;
+ 		};
+ 		simple-audio-card,codec {
+-			sound-dai = <&spdif_out>;
++			sound-dai = <&hdmi>;
+ 		};
+ 	};
+ 
+-	spdif_out: spdif-out {
++	hdmi-dp-sound {
++		compatible = "rockchip,rk3399-hdmi-dp";
++		rockchip,cpu = <&i2s2>;
++		rockchip,codec = <&hdmi>, <&cdn_dp>;
+ 		status = "disabled";
+-		compatible = "linux,spdif-dit";
+-		#sound-dai-cells = <0>;
+-	};
+-
+-	sdio_pwrseq: sdio-pwrseq {
+-		compatible = "mmc-pwrseq-simple";
+-		clocks = <&rk808 1>;
+-		clock-names = "ext_clock";
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&wifi_enable_h>;
+-
+-		/*
+-		 * On the module itself this is one of these (depending
+-		 * on the actual card populated):
+-		 * - SDIO_RESET_L_WL_REG_ON
+-		 * - PDN (power down when low)
+-		 */
+-		reset-gpios = <&gpio0 RK_PB2 GPIO_ACTIVE_LOW>;
+ 	};
+ 
+ 	es8316-sound {
+-		status = "okay";
+ 		compatible = "simple-audio-card";
+ 		simple-audio-card,format = "i2s";
+-		simple-audio-card,name = "rockchip,es8316-codec";
++		simple-audio-card,name = "ES8316";
+ 		simple-audio-card,mclk-fs = <256>;
+ 		simple-audio-card,widgets =
+ 			"Microphone", "Mic Jack",
+@@ -168,40 +177,59 @@
+ 		};
+ 	};
+ 
+-	leds {
+-		status = "okay";
+-		compatible = "gpio-leds";
+-		work-led {
+-			gpios = <&gpio0 RK_PB3 GPIO_ACTIVE_HIGH>;
+-			linux,default-trigger = "heartbeat";
+-			default-state = "on";
++	spdif-sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,name = "SPDIF";
++		simple-audio-card,cpu {
++			sound-dai = <&spdif>;
+ 		};
+-		diy-led {
+-			gpios = <&gpio0 RK_PA2 GPIO_ACTIVE_HIGH>;
+-			linux,default-trigger = "none";
+-			default-state = "off";
++		simple-audio-card,codec {
++			sound-dai = <&spdif_out>;
+ 		};
+ 	};
+ 
+-	rk_key: rockchip-key {
+-		compatible = "rockchip,key";
+-		status = "okay";
++	spdif_out: spdif-out {
++		compatible = "linux,spdif-dit";
++		#sound-dai-cells = <0>;
++	};
+ 
+-		io-channels = <&saradc 1>;
++	sdio_pwrseq: sdio-pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		clocks = <&rk808 1>;
++		clock-names = "ext_clock";
++		pinctrl-names = "default";
++		pinctrl-0 = <&wifi_enable_h>;
+ 
+-		power-key {
+-			gpios = <&gpio0 RK_PA5 GPIO_ACTIVE_LOW>;
+-			linux,code = <116>;
+-			label = "power";
+-			gpio-key,wakeup;
+-		};
++		/*
++		 * On the module itself this is one of these (depending
++		 * on the actual card populated):
++		 * - SDIO_RESET_L_WL_REG_ON
++		 * - PDN (power down when low)
++		 */
++		reset-gpios = <&gpio0 RK_PB2 GPIO_ACTIVE_LOW>;
+ 	};
+ 
+-	hdmi_dp_sound: hdmi-dp-sound {
+-		status = "okay";
+-		compatible = "rockchip,rk3399-hdmi-dp";
+-		rockchip,cpu = <&i2s2>;
+-		rockchip,codec = <&hdmi>, <&cdn_dp>;
++	wireless-wlan {
++		compatible = "wlan-platdata";
++		rockchip,grf = <&grf>;
++		wifi_chip_type = "ap6354";
++		sdio_vref = <1800>;
++		WIFI,host_wake_irq = <&gpio0 RK_PA3 GPIO_ACTIVE_HIGH>;
++		status = "disabled";
++	};
++
++	wireless-bluetooth {
++		compatible = "bluetooth-platdata";
++		clocks = <&rk808 1>;
++		clock-names = "ext_clock";
++		uart_rts_gpios = <&gpio2 RK_PC3 GPIO_ACTIVE_LOW>;
++		pinctrl-names = "default", "rts_gpio";
++		pinctrl-0 = <&uart0_rts>;
++		pinctrl-1 = <&uart0_gpios>;
++		BT,reset_gpio    = <&gpio0 RK_PB1 GPIO_ACTIVE_HIGH>;
++		BT,wake_gpio     = <&gpio2 RK_PD3 GPIO_ACTIVE_HIGH>;
++		BT,wake_host_irq = <&gpio0 RK_PA4 GPIO_ACTIVE_HIGH>;
++		status = "disabled";
+ 	};
+ };
+ 
+@@ -253,30 +281,21 @@
+ &dmc {
+ 	status = "okay";
+ 	center-supply = <&vdd_center>;
+-	upthreshold = <40>;
+-	downdifferential = <20>;
+ 	system-status-freq = <
+ 		/*system status         freq(KHz)*/
+ 		SYS_STATUS_NORMAL       800000
+ 		SYS_STATUS_REBOOT       400000
+ 		SYS_STATUS_SUSPEND      400000
+-		SYS_STATUS_VIDEO_1080P  400000
++		SYS_STATUS_VIDEO_1080P  800000
+ 		SYS_STATUS_VIDEO_4K     800000
+ 		SYS_STATUS_VIDEO_4K_10B 800000
+ 		SYS_STATUS_PERFORMANCE  800000
+-		SYS_STATUS_BOOST        400000
++		SYS_STATUS_BOOST        800000
+ 		SYS_STATUS_DUALVIEW     800000
+ 		SYS_STATUS_ISP          800000
+ 	>;
+-	vop-bw-dmc-freq = <
+-	/* min_bw(MB/s) max_bw(MB/s) freq(KHz) */
+-		0       577      200000
+-		578     1701     300000
+-		1702    99999    400000
+-	>;
+-	auto-min-freq = <400000>;
++	auto-min-freq = <800000>;
+ 	auto-freq-en = <0>;
+-
+ };
+ 
+ &dmc_opp_table {
+@@ -325,42 +344,26 @@
+ &display_subsystem {
+ 	status = "okay";
+ 
+-	ports = <&vopb_out>;
+-
+ 	route {
+ 		route_hdmi: route-hdmi {
+ 			status = "okay";
+ 			connect = <&vopb_out_hdmi>;
+ 		};
+ 
+-		route_dsi: route-dsi {
+-			status = "disabled";
+-			connect = <&vopb_out_dsi>;
 -		};
 -
- 		ramoops_mem: region@110000 {
- 			reg = <0x0 0x110000 0x0 0xf0000>;
- 			reg-names = "ramoops_mem";
+-		route_edp: route-edp {
+-			status = "disabled";
+-			connect = <&vopb_out_edp>;
++		route_dp: route-dp {
++			connect = <&vopl_out_dp>;
+ 		};
+ 	};
+ };
+ 
+-&dp_in_vopb {
+-	status = "disabled";
+-};
+-
+-&edp {
+-	/delete-node/ pinctrl-0;
+-};
+-
+ &emmc_phy {
+ 	status = "okay";
+ };
+ 
+ &i2c0 {
+ 	status = "okay";
+-	i2c-scl-rising-time-ns = <168>;
+-	i2c-scl-falling-time-ns = <4>;
++	i2c-scl-rising-time-ns = <180>;
++	i2c-scl-falling-time-ns = <30>;
+ 	clock-frequency = <400000>;
+ 
+ 	vdd_cpu_b: syr827@40 {
+@@ -393,6 +396,7 @@
+ 		regulator-max-microvolt = <1500000>;
+ 		regulator-ramp-delay = <1000>;
+ 		fcs,suspend-voltage-selector = <1>;
++		regulator-always-on;
+ 		regulator-boot-on;
+ 		vin-supply = <&vcc_sys>;
+ 		regulator-initial-mode = <1>; /* 1:force PWM 2:auto */
+@@ -411,7 +415,7 @@
+ 		rockchip,system-power-controller;
+ 		wakeup-source;
+ 		#clock-cells = <1>;
+-		clock-output-names = "xin32k", "rk808-clkout2";
++		clock-output-names = "rk808-clkout1", "rk808-clkout2";
+ 
+ 		vcc1-supply = <&vcc_sys>;
+ 		vcc2-supply = <&vcc_sys>;
+@@ -429,8 +433,8 @@
+ 		regulators {
+ 			vdd_center: DCDC_REG1 {
+ 				regulator-name = "vdd_center";
+-				regulator-min-microvolt = <750000>;
+-				regulator-max-microvolt = <1350000>;
++				regulator-min-microvolt = <900000>;
++				regulator-max-microvolt = <900000>;
+ 				regulator-ramp-delay = <6001>;
+ 				regulator-always-on;
+ 				regulator-boot-on;
+@@ -476,6 +480,7 @@
+ 				regulator-name = "vcc1v8_dvp";
+ 				regulator-min-microvolt = <1800000>;
+ 				regulator-max-microvolt = <1800000>;
++				regulator-always-on;
+ 				regulator-boot-on;
+ 				regulator-state-mem {
+ 					regulator-on-in-suspend;
+@@ -487,6 +492,7 @@
+ 				regulator-name = "vcc3v0_touch";
+ 				regulator-min-microvolt = <3000000>;
+ 				regulator-max-microvolt = <3000000>;
++				regulator-always-on;
+ 				regulator-boot-on;
+ 				regulator-state-mem {
+ 					regulator-on-in-suspend;
+@@ -510,6 +516,7 @@
+ 				regulator-name = "vcc_sd";
+ 				regulator-min-microvolt = <1800000>;
+ 				regulator-max-microvolt = <3300000>;
++				regulator-always-on;
+ 				regulator-boot-on;
+ 				regulator-state-mem {
+ 					regulator-on-in-suspend;
+@@ -586,14 +593,6 @@
+ 	};
+ };
+ 
+-&i2s0 {
+-	status = "okay";
+-	rockchip,i2s-broken-burst-len;
+-	rockchip,playback-channels = <8>;
+-	rockchip,capture-channels = <8>;
+-	#sound-dai-cells = <0>;
+-};
+-
+ &i2c1 {
+ 	status = "okay";
+ 	i2c-scl-rising-time-ns = <168>;
+@@ -624,6 +623,14 @@
+ 	};
+ };
+ 
++&i2s0 {
++	status = "okay";
++	rockchip,i2s-broken-burst-len;
++	rockchip,playback-channels = <8>;
++	rockchip,capture-channels = <8>;
++	#sound-dai-cells = <0>;
++};
++
+ &i2s1 {
+ 	status = "okay";
+ 	rockchip,i2s-broken-burst-len;
+@@ -634,6 +641,7 @@
+ 
+ &i2s2 {
+ 	#sound-dai-cells = <0>;
++	rockchip,bclk-fs = <128>;
+ 	status = "okay";
+ };
+ 
+@@ -641,6 +649,7 @@
+ 	phy-supply = <&vcc_phy>;
+ 	phy-mode = "rgmii";
+ 	clock_in_out = "input";
++	snps,force_thresh_dma_mode;
+ 	snps,reset-gpio = <&gpio3 RK_PB7 GPIO_ACTIVE_LOW>;
+ 	snps,reset-active-low;
+ 	snps,reset-delays-us = <0 10000 50000>;
+@@ -660,6 +669,17 @@
+ };
+ 
+ &hdmi {
++	#address-cells = <1>;
++	#size-cells = <0>;
++	#sound-dai-cells = <0>;
++	status = "okay";
++};
++
++&iep {
++	status = "okay";
++};
++
++&iep_mmu {
+ 	status = "okay";
+ };
+ 
+@@ -678,13 +698,17 @@
+ 
+ &sdmmc {
+ 	clock-frequency = <50000000>;
+-	clock-freq-min-max = <400000 150000000>;
++	max-frequency = <150000000>;
+ 	supports-sd;
+ 	bus-width = <4>;
+ 	cap-mmc-highspeed;
+ 	cap-sd-highspeed;
+ 	disable-wp;
+ 	num-slots = <1>;
++	sd-uhs-sdr12;
++	sd-uhs-sdr25;
++	sd-uhs-sdr50;
++	sd-uhs-sdr104;
+ 	vqmmc-supply = <&vcc_sd>;
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&sdmmc_clk &sdmmc_cmd &sdmmc_cd &sdmmc_bus4>;
+@@ -694,7 +718,7 @@
+ 
+ &sdio0 {
+ 	clock-frequency = <50000000>;
+-	clock-freq-min-max = <200000 50000000>;
++	max-frequency = <50000000>;
+ 	supports-sdio;
+ 	bus-width = <4>;
+ 	disable-wp;
+@@ -707,35 +731,50 @@
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&sdio0_bus4 &sdio0_cmd &sdio0_clk>;
+ 	sd-uhs-sdr104;
+-	status = "okay";
++	status = "disabled";
+ };
+ 
+ &sdhci {
+ 	bus-width = <8>;
+-	mmc-hs200-1_8v;
+ 	mmc-hs400-1_8v;
++	mmc-hs400-enhanced-strobe;
++	supports-emmc;
++	non-removable;
+ 	keep-power-in-suspend;
+ 	status = "okay";
+ };
+ 
+ &spdif {
+-	status = "disabled";
++	status = "okay";
+ 	pinctrl-0 = <&spdif_bus_1>;
+ 	#sound-dai-cells = <0>;
+ };
+ 
+ &spi1 {
+ 	status = "okay";
++	max-freq = <10000000>;
++
+ 	flash@0 {
+-		compatible = "gigadevice,gd25q128", "jedec,spi-nor";
++		compatible = "jedec,spi-nor";
+ 		#address-cells = <1>;
+ 		#size-cells = <1>;
+ 		reg = <0>;
+-		m25p,fast-read;
+-		spi-max-frequency = <24000000>;
++		spi-max-frequency = <10000000>;
+ 	};
+ };
+ 
++&threshold {
++	temperature = <80000>;
++};
++
++&target {
++	temperature = <95000>;
++};
++
++&soc_crit {
++	temperature = <100000>;
++};
++
+ &tcphy0 {
+ 	extcon = <&fusb0>;
+ 	status = "okay";
+@@ -826,114 +865,15 @@
+ 	status = "okay";
+ };
+ 
+-&pwm2 {
++&pwm1 {
+ 	status = "okay";
+ 	pinctrl-names = "active";
+-	pinctrl-0 = <&pwm2_pin_pull_down>;
+ };
+ 
+-&pwm3 {
++&pwm2 {
+ 	status = "okay";
+-
+-	interrupts = <GIC_SPI 61 IRQ_TYPE_LEVEL_HIGH 0>;
+-	compatible = "rockchip,remotectl-pwm";
+-	remote_pwm_id = <3>;
+-	handle_cpu_id = <1>;
+-	remote_support_psci = <1>;
+-
+-	ir_key1 {
+-		rockchip,usercode = <0x4040>;
+-		rockchip,key_table =
+-			<0xf2	KEY_REPLY>,
+-			<0xba	KEY_BACK>,
+-			<0xf4	KEY_UP>,
+-			<0xf1	KEY_DOWN>,
+-			<0xef	KEY_LEFT>,
+-			<0xee	KEY_RIGHT>,
+-			<0xbd	KEY_HOME>,
+-			<0xea	KEY_VOLUMEUP>,
+-			<0xe3	KEY_VOLUMEDOWN>,
+-			<0xe2	KEY_SEARCH>,
+-			<0xb2	KEY_POWER>,
+-			<0xbc	KEY_MUTE>,
+-			<0xec	KEY_MENU>,
+-			<0xbf	0x190>,
+-			<0xe0	0x191>,
+-			<0xe1	0x192>,
+-			<0xe9	183>,
+-			<0xe6	248>,
+-			<0xe8	185>,
+-			<0xe7	186>,
+-			<0xf0	388>,
+-			<0xbe	0x175>;
+-	};
+-
+-	ir_key2 {
+-		rockchip,usercode = <0xff00>;
+-		rockchip,key_table =
+-			<0xf9	KEY_HOME>,
+-			<0xbf	KEY_BACK>,
+-			<0xfb	KEY_MENU>,
+-			<0xaa	KEY_REPLY>,
+-			<0xb9	KEY_UP>,
+-			<0xe9	KEY_DOWN>,
+-			<0xb8	KEY_LEFT>,
+-			<0xea	KEY_RIGHT>,
+-			<0xeb	KEY_VOLUMEDOWN>,
+-			<0xef	KEY_VOLUMEUP>,
+-			<0xf7	KEY_MUTE>,
+-			<0xe7	KEY_POWER>,
+-			<0xfc	KEY_POWER>,
+-			<0xa9	KEY_VOLUMEDOWN>,
+-			<0xa8	KEY_VOLUMEDOWN>,
+-			<0xe0	KEY_VOLUMEDOWN>,
+-			<0xa5	KEY_VOLUMEDOWN>,
+-			<0xab	183>,
+-			<0xb7	388>,
+-			<0xe8	388>,
+-			<0xf8	184>,
+-			<0xaf	185>,
+-			<0xed	KEY_VOLUMEDOWN>,
+-			<0xee	186>,
+-			<0xb3	KEY_VOLUMEDOWN>,
+-			<0xf1	KEY_VOLUMEDOWN>,
+-			<0xf2	KEY_VOLUMEDOWN>,
+-			<0xf3	KEY_SEARCH>,
+-			<0xb4	KEY_VOLUMEDOWN>,
+-			<0xbe	KEY_SEARCH>;
+-	};
+-
+-	ir_key3 {
+-		rockchip,usercode = <0x1dcc>;
+-		rockchip,key_table =
+-			<0xee	KEY_REPLY>,
+-			<0xf0	KEY_BACK>,
+-			<0xf8	KEY_UP>,
+-			<0xbb	KEY_DOWN>,
+-			<0xef	KEY_LEFT>,
+-			<0xed	KEY_RIGHT>,
+-			<0xfc	KEY_HOME>,
+-			<0xf1	KEY_VOLUMEUP>,
+-			<0xfd	KEY_VOLUMEDOWN>,
+-			<0xb7	KEY_SEARCH>,
+-			<0xff	KEY_POWER>,
+-			<0xf3	KEY_MUTE>,
+-			<0xbf	KEY_MENU>,
+-			<0xf9	0x191>,
+-			<0xf5	0x192>,
+-			<0xb3	388>,
+-			<0xbe	KEY_1>,
+-			<0xba	KEY_2>,
+-			<0xb2	KEY_3>,
+-			<0xbd	KEY_4>,
+-			<0xf9	KEY_5>,
+-			<0xb1	KEY_6>,
+-			<0xfc	KEY_7>,
+-			<0xf8	KEY_8>,
+-			<0xb0	KEY_9>,
+-			<0xb6	KEY_0>,
+-			<0xb5	KEY_BACKSPACE>;
+-	};
++	pinctrl-names = "active";
++	pinctrl-0 = <&pwm2_pin_pull_down>;
+ };
+ 
+ &pinctrl {
+@@ -951,6 +891,13 @@
+ 		};
+ 	};
+ 
++	ir {
++		ir_int: ir-int {
++			rockchip,pins =
++				<0 RK_PA6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
+ 	pcie {
+ 		pcie_pwr_en: pcie-pwr-en {
+ 			rockchip,pins =
+@@ -982,6 +929,7 @@
+ 	sdio-pwrseq {
+ 		wifi_enable_h: wifi-enable-h {
+ 			rockchip,pins =
++				<0 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>,
+ 				<0 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 	};
+@@ -1085,35 +1033,6 @@
+ 	status = "okay";
+ };
+ 
+-&rockchip_suspend {
+-	status = "okay";
+-	rockchip,sleep-debug-en = <0>;
+-	rockchip,sleep-mode-config = <
+-		(0
+-		| RKPM_SLP_ARMPD
+-		| RKPM_SLP_PERILPPD
+-		| RKPM_SLP_DDR_RET
+-		| RKPM_SLP_PLLPD
+-		| RKPM_SLP_CENTER_PD
+-		| RKPM_SLP_AP_PWROFF
+-		)
+-	>;
+-	rockchip,wakeup-config = <
+-		(0
+-		| RKPM_GPIO_WKUP_EN
+-		| RKPM_PWM_WKUP_EN
+-		)
+-	>;
+-	rockchip,pwm-regulator-config = <
+-		(0
+-		| PWM2_REGULATOR_EN
+-		)
+-	>;
+-	rockchip,power-ctrl =
+-		<&gpio1 RK_PC1 GPIO_ACTIVE_HIGH>,
+-		<&gpio1 RK_PB6 GPIO_ACTIVE_HIGH>;
+-};
+-
+ &vdec_mmu {
+ 	status = "okay";
+ };
+@@ -1135,3 +1054,13 @@
+ &vopb_mmu {
+ 	status = "okay";
+ };
++
++&vopl {
++	status = "disabled";
++	assigned-clocks = <&cru DCLK_VOP1_DIV>;
++	assigned-clock-parents = <&cru PLL_CPLL>;
++};
++
++&vopl_mmu {
++	status = "disabled";
++};
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-sapphire.dts b/arch/arm64/boot/dts/rockchip/rk3399-sapphire.dts
+new file mode 100644
+index 000000000000..8706dc7d91af
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3399-sapphire.dts
+@@ -0,0 +1,170 @@
++/*
++ * Copyright (c) 2016 Fuzhou Rockchip Electronics Co., Ltd
++ *
++ * This file is dual-licensed: you can use it either under the terms
++ * of the GPL or the X11 license, at your option. Note that this dual
++ * licensing only applies to this file, and not this project as a
++ * whole.
++ *
++ *  a) This file is free software; you can redistribute it and/or
++ *     modify it under the terms of the GNU General Public License as
++ *     published by the Free Software Foundation; either version 2 of the
++ *     License, or (at your option) any later version.
++ *
++ *     This file is distributed in the hope that it will be useful,
++ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *     GNU General Public License for more details.
++ *
++ * Or, alternatively,
++ *
++ *  b) Permission is hereby granted, free of charge, to any person
++ *     obtaining a copy of this software and associated documentation
++ *     files (the "Software"), to deal in the Software without
++ *     restriction, including without limitation the rights to use,
++ *     copy, modify, merge, publish, distribute, sublicense, and/or
++ *     sell copies of the Software, and to permit persons to whom the
++ *     Software is furnished to do so, subject to the following
++ *     conditions:
++ *
++ *     The above copyright notice and this permission notice shall be
++ *     included in all copies or substantial portions of the Software.
++ *
++ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
++ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
++ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
++ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
++ *     OTHER DEALINGS IN THE SOFTWARE.
++ */
++
++/dts-v1/;
++
++#include "rk3399-sapphire.dtsi"
++#include "rk3399-linux.dtsi"
++#include <dt-bindings/input/input.h>
++
++/ {
++	model = "Rockchip RK3399 Sapphire Board";
++	compatible = "rockchip,rk3399-sapphire", "rockchip,rk3399";
++
++	gpio-keys {
++		compatible = "gpio-keys";
++		#address-cells = <1>;
++		#size-cells = <0>;
++		autorepeat;
++
++		pinctrl-names = "default";
++		pinctrl-0 = <&pwrbtn>;
++
++		button@0 {
++			gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
++			linux,code = <KEY_POWER>;
++			label = "GPIO Key Power";
++			linux,input-type = <1>;
++			gpio-key,wakeup = <1>;
++			debounce-interval = <100>;
++		};
++	};
++
++	vccadc_ref: vccadc-ref {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc1v8_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++	};
++};
++
++&hdmi_sound {
++	simple-audio-card,name = "HDMI";
++	status = "okay";
++};
++
++&i2s2 {
++	#sound-dai-cells = <0>;
++	rockchip,bclk-fs = <128>;
++	status = "okay";
++};
++
++&iep {
++	status = "okay";
++};
++
++&iep_mmu {
++	status = "okay";
++};
++
++&saradc {
++	vref-supply = <&vccadc_ref>;
++};
++
++&vpu {
++	status = "okay";
++};
++
++&rkvdec {
++	status = "okay";
++};
++
++&display_subsystem {
++	ports = <&vopb_out>;
++	status = "okay";
++};
++
++&route_hdmi {
++	status = "okay";
++};
++
++&cdn_dp {
++	status = "disabled";
++};
++
++&dp_in_vopb {
++	status = "disabled";
++};
++
++&hdmi {
++	#address-cells = <1>;
++	#size-cells = <0>;
++	#sound-dai-cells = <0>;
++	status = "okay";
++};
++
++&pcie_phy {
++	status = "disabled";
++};
++
++&pcie0 {
++	status = "disabled";
++};
++
++&sdio0 {
++	status = "disabled";
++};
++
++&vopb {
++	status = "okay";
++};
++
++&vopb_mmu {
++	status = "okay";
++};
++
++&pinctrl {
++	sdio-pwrseq {
++		wifi_enable_h: wifi-enable-h {
++			rockchip,pins =
++				<0 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	buttons {
++		pwrbtn: pwrbtn {
++			rockchip,pins = <0 5 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-sapphire.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-sapphire.dtsi
+index fc0e9f029e5d..884a1d07d58b 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-sapphire.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3399-sapphire.dtsi
+@@ -515,6 +515,14 @@
+ 	status = "okay";
+ };
+ 
++&pvtm {
++	status = "okay";
++};
++
++&pmu_pvtm {
++	status = "okay";
++};
++
+ &pmu_io_domains {
+ 	status = "okay";
+ 	pmu1830-supply = <&vcc_3v0>;
+@@ -542,7 +550,7 @@
+ 
+ &sdio0 {
+ 	clock-frequency = <50000000>;
+-	clock-freq-min-max = <200000 50000000>;
++	max-frequency = <50000000>;
+ 	supports-sdio;
+ 	bus-width = <4>;
+ 	disable-wp;
+@@ -560,14 +568,17 @@
+ 
+ &sdmmc {
+ 	clock-frequency = <150000000>;
+-	clock-freq-min-max = <100000 150000000>;
++	max-frequency = <150000000>;
+ 	supports-sd;
+ 	bus-width = <4>;
+ 	cap-mmc-highspeed;
+ 	cap-sd-highspeed;
+ 	disable-wp;
+ 	num-slots = <1>;
+-	//sd-uhs-sdr104;
++	sd-uhs-sdr12;
++	sd-uhs-sdr25;
++	sd-uhs-sdr50;
++	sd-uhs-sdr104;
+ 	vmmc-supply = <&vcc_sd>;
+ 	vqmmc-supply = <&vccio_sd>;
+ 	pinctrl-names = "default";
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399.dtsi b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
+index 8397a5cd1e9a..506da66b1799 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
+@@ -654,6 +654,8 @@
+ 	uart0: serial@ff180000 {
+ 		compatible = "rockchip,rk3399-uart", "snps,dw-apb-uart";
+ 		reg = <0x0 0xff180000 0x0 0x100>;
++		dmas = <&dmac_peri 0>, <&dmac_peri 1>;
++		dma-names = "tx", "rx";
+ 		clocks = <&cru SCLK_UART0>, <&cru PCLK_UART0>;
+ 		clock-names = "baudclk", "apb_pclk";
+ 		interrupts = <GIC_SPI 99 IRQ_TYPE_LEVEL_HIGH 0>;
+@@ -667,6 +669,8 @@
+ 	uart1: serial@ff190000 {
+ 		compatible = "rockchip,rk3399-uart", "snps,dw-apb-uart";
+ 		reg = <0x0 0xff190000 0x0 0x100>;
++		dmas = <&dmac_peri 2>, <&dmac_peri 3>;
++		dma-names = "tx", "rx";
+ 		clocks = <&cru SCLK_UART1>, <&cru PCLK_UART1>;
+ 		clock-names = "baudclk", "apb_pclk";
+ 		interrupts = <GIC_SPI 98 IRQ_TYPE_LEVEL_HIGH 0>;
+@@ -680,6 +684,8 @@
+ 	uart2: serial@ff1a0000 {
+ 		compatible = "rockchip,rk3399-uart", "snps,dw-apb-uart";
+ 		reg = <0x0 0xff1a0000 0x0 0x100>;
++		dmas = <&dmac_peri 4>, <&dmac_peri 5>;
++		dma-names = "tx", "rx";
+ 		clocks = <&cru SCLK_UART2>, <&cru PCLK_UART2>;
+ 		clock-names = "baudclk", "apb_pclk";
+ 		interrupts = <GIC_SPI 100 IRQ_TYPE_LEVEL_HIGH 0>;
+@@ -693,6 +699,8 @@
+ 	uart3: serial@ff1b0000 {
+ 		compatible = "rockchip,rk3399-uart", "snps,dw-apb-uart";
+ 		reg = <0x0 0xff1b0000 0x0 0x100>;
++		dmas = <&dmac_peri 6>, <&dmac_peri 7>;
++		dma-names = "tx", "rx";
+ 		clocks = <&cru SCLK_UART3>, <&cru PCLK_UART3>;
+ 		clock-names = "baudclk", "apb_pclk";
+ 		interrupts = <GIC_SPI 101 IRQ_TYPE_LEVEL_HIGH 0>;
+@@ -706,6 +714,8 @@
+ 	spi0: spi@ff1c0000 {
+ 		compatible = "rockchip,rk3399-spi", "rockchip,rk3066-spi";
+ 		reg = <0x0 0xff1c0000 0x0 0x1000>;
++		dmas = <&dmac_peri 10>, <&dmac_peri 11>;
++		dma-names = "tx", "rx";
+ 		clocks = <&cru SCLK_SPI0>, <&cru PCLK_SPI0>;
+ 		clock-names = "spiclk", "apb_pclk";
+ 		interrupts = <GIC_SPI 68 IRQ_TYPE_LEVEL_HIGH 0>;
+@@ -721,6 +731,8 @@
+ 	spi1: spi@ff1d0000 {
+ 		compatible = "rockchip,rk3399-spi", "rockchip,rk3066-spi";
+ 		reg = <0x0 0xff1d0000 0x0 0x1000>;
++		dmas = <&dmac_peri 12>, <&dmac_peri 13>;
++		dma-names = "tx", "rx";
+ 		clocks = <&cru SCLK_SPI1>, <&cru PCLK_SPI1>;
+ 		clock-names = "spiclk", "apb_pclk";
+ 		interrupts = <GIC_SPI 53 IRQ_TYPE_LEVEL_HIGH 0>;
+@@ -736,6 +748,8 @@
+ 	spi2: spi@ff1e0000 {
+ 		compatible = "rockchip,rk3399-spi", "rockchip,rk3066-spi";
+ 		reg = <0x0 0xff1e0000 0x0 0x1000>;
++		dmas = <&dmac_peri 14>, <&dmac_peri 15>;
++		dma-names = "tx", "rx";
+ 		clocks = <&cru SCLK_SPI2>, <&cru PCLK_SPI2>;
+ 		clock-names = "spiclk", "apb_pclk";
+ 		interrupts = <GIC_SPI 52 IRQ_TYPE_LEVEL_HIGH 0>;
+@@ -751,6 +765,8 @@
+ 	spi4: spi@ff1f0000 {
+ 		compatible = "rockchip,rk3399-spi", "rockchip,rk3066-spi";
+ 		reg = <0x0 0xff1f0000 0x0 0x1000>;
++		dmas = <&dmac_peri 18>, <&dmac_peri 19>;
++		dma-names = "tx", "rx";
+ 		clocks = <&cru SCLK_SPI4>, <&cru PCLK_SPI4>;
+ 		clock-names = "spiclk", "apb_pclk";
+ 		interrupts = <GIC_SPI 67 IRQ_TYPE_LEVEL_HIGH 0>;
+@@ -766,6 +782,8 @@
+ 	spi5: spi@ff200000 {
+ 		compatible = "rockchip,rk3399-spi", "rockchip,rk3066-spi";
+ 		reg = <0x0 0xff200000 0x0 0x1000>;
++		dmas = <&dmac_bus 8>, <&dmac_bus 9>;
++		dma-names = "tx", "rx";
+ 		clocks = <&cru SCLK_SPI5>, <&cru PCLK_SPI5>;
+ 		clock-names = "spiclk", "apb_pclk";
+ 		interrupts = <GIC_SPI 132 IRQ_TYPE_LEVEL_HIGH 0>;
+@@ -1170,6 +1188,8 @@
+ 	spi3: spi@ff350000 {
+ 		compatible = "rockchip,rk3399-spi", "rockchip,rk3066-spi";
+ 		reg = <0x0 0xff350000 0x0 0x1000>;
++		dmas = <&dmac_peri 16>, <&dmac_peri 17>;
++		dma-names = "tx", "rx";
+ 		clocks = <&pmucru SCLK_SPI3_PMU>, <&pmucru PCLK_SPI3_PMU>;
+ 		clock-names = "spiclk", "apb_pclk";
+ 		interrupts = <GIC_SPI 60 IRQ_TYPE_LEVEL_HIGH 0>;
+@@ -1183,6 +1203,8 @@
+ 	uart4: serial@ff370000 {
+ 		compatible = "rockchip,rk3399-uart", "snps,dw-apb-uart";
+ 		reg = <0x0 0xff370000 0x0 0x100>;
++		dmas = <&dmac_peri 8>, <&dmac_peri 9>;
++		dma-names = "tx", "rx";
+ 		clocks = <&pmucru SCLK_UART4_PMU>, <&pmucru PCLK_UART4_PMU>;
+ 		clock-names = "baudclk", "apb_pclk";
+ 		interrupts = <GIC_SPI 102 IRQ_TYPE_LEVEL_HIGH 0>;
+@@ -1829,6 +1851,7 @@
+ 		clocks = <&cru ACLK_VOP1>, <&cru DCLK_VOP1>, <&cru HCLK_VOP1>, <&cru DCLK_VOP1_DIV>;
+ 		clock-names = "aclk_vop", "dclk_vop", "hclk_vop", "dclk_source";
+ 		iommus = <&vopl_mmu>;
++		rockchip,grf = <&grf>;
+ 		power-domains = <&power RK3399_PD_VOPL>;
+ 		resets = <&cru SRST_A_VOP1>, <&cru SRST_H_VOP1>, <&cru SRST_D_VOP1>;
+ 		reset-names = "axi", "ahb", "dclk";
+@@ -1899,6 +1922,7 @@
+ 		clock-names = "aclk_vop", "dclk_vop", "hclk_vop", "dclk_source";
+ 		resets = <&cru SRST_A_VOP0>, <&cru SRST_H_VOP0>, <&cru SRST_D_VOP0>;
+ 		reset-names = "axi", "ahb", "dclk";
++		rockchip,grf = <&grf>;
+ 		power-domains = <&power RK3399_PD_VOPB>;
+ 		iommus = <&vopb_mmu>;
+ 		status = "disabled";
+@@ -2023,7 +2047,7 @@
+ 		compatible = "rockchip,rk3399-dw-hdmi";
+ 		reg = <0x0 0xff940000 0x0 0x20000>;
+ 		pinctrl-names = "default";
+-		pinctrl-0 = <&hdmi_i2c_xfer>;
++		pinctrl-0 = <&hdmi_i2c_xfer>, <&hdmi_cec>;
+ 		interrupts = <GIC_SPI 23 IRQ_TYPE_LEVEL_HIGH 0>;
+ 		clocks = <&cru PCLK_HDMI_CTRL>,
+ 			 <&cru SCLK_HDMI_SFR>,
+diff --git a/sound/soc/soc-utils.c b/sound/soc/soc-utils.c
+index 53dd085d3ee2..bf7ce34084a9 100644
+--- a/sound/soc/soc-utils.c
++++ b/sound/soc/soc-utils.c
+@@ -19,6 +19,7 @@
+ #include <sound/pcm.h>
+ #include <sound/pcm_params.h>
+ #include <sound/soc.h>
++#include <linux/module.h>
+ 
+ int snd_soc_calc_frame_size(int sample_size, int channels, int tdm_slots)
+ {
+@@ -160,9 +161,18 @@ static int snd_soc_dummy_remove(struct platform_device *pdev)
+ 	return 0;
+ }
+ 
++#ifdef CONFIG_OF
++static const struct of_device_id soc_dummy_ids[] = {
++	{ .compatible = "linux,snd-soc-dummy", },
++	{ }
++};
++MODULE_DEVICE_TABLE(of, soc_dummy_ids);
++#endif
++
+ static struct platform_driver soc_dummy_driver = {
+ 	.driver = {
+ 		.name = "snd-soc-dummy",
++		.of_match_table = of_match_ptr(soc_dummy_ids),
+ 	},
+ 	.probe = snd_soc_dummy_probe,
+ 	.remove = snd_soc_dummy_remove,
+-- 
+2.34.1
+
+

--- a/patch/kernel/archive/rk322x-4.4/01-linux-0012-makefile-gcc-11.patch
+++ b/patch/kernel/archive/rk322x-4.4/01-linux-0012-makefile-gcc-11.patch
@@ -1,0 +1,64 @@
+From 75a63ec79a73ad138ae6e8514507958455042a98 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Sun, 30 Apr 2023 14:17:54 +0200
+Subject: [PATCH] fix compilation for newer arm-linux-gnueabihf compilers
+
+see here for details: https://lore.kernel.org/linux-arm-kernel/20211018140735.3714254-1-arnd@kernel.org/#r
+---
+ arch/arm/Makefile | 28 +++++++++++++++++-----------
+ 1 file changed, 17 insertions(+), 11 deletions(-)
+
+diff --git a/arch/arm/Makefile b/arch/arm/Makefile
+index 554985b5225b..c77e3705f68e 100644
+--- a/arch/arm/Makefile
++++ b/arch/arm/Makefile
+@@ -66,15 +66,15 @@ KBUILD_CFLAGS	+= $(call cc-option,-fno-ipa-sra)
+ # Note that GCC does not numerically define an architecture version
+ # macro, but instead defines a whole series of macros which makes
+ # testing for a specific architecture or later rather impossible.
+-arch-$(CONFIG_CPU_32v7M)	=-D__LINUX_ARM_ARCH__=7 -march=armv7-m -Wa,-march=armv7-m
+-arch-$(CONFIG_CPU_32v7)		=-D__LINUX_ARM_ARCH__=7 $(call cc-option,-march=armv7-a,-march=armv5t -Wa$(comma)-march=armv7-a)
+-arch-$(CONFIG_CPU_32v6)		=-D__LINUX_ARM_ARCH__=6 $(call cc-option,-march=armv6,-march=armv5t -Wa$(comma)-march=armv6)
++arch-$(CONFIG_CPU_32v7M)	=-D__LINUX_ARM_ARCH__=7 -march=armv7-m
++arch-$(CONFIG_CPU_32v7)		=-D__LINUX_ARM_ARCH__=7 -march=armv7-a
++arch-$(CONFIG_CPU_32v6)		=-D__LINUX_ARM_ARCH__=6 -march=armv6
+ # Only override the compiler option if ARMv6. The ARMv6K extensions are
+ # always available in ARMv7
+ ifeq ($(CONFIG_CPU_32v6),y)
+-arch-$(CONFIG_CPU_32v6K)	=-D__LINUX_ARM_ARCH__=6 $(call cc-option,-march=armv6k,-march=armv5t -Wa$(comma)-march=armv6k)
++arch-$(CONFIG_CPU_32v6K)	=-D__LINUX_ARM_ARCH__=6 -march=armv6k
+ endif
+-arch-$(CONFIG_CPU_32v5)		=-D__LINUX_ARM_ARCH__=5 $(call cc-option,-march=armv5te,-march=armv4t)
++arch-$(CONFIG_CPU_32v5)		=-D__LINUX_ARM_ARCH__=5 -march=armv5te
+ arch-$(CONFIG_CPU_32v4T)	=-D__LINUX_ARM_ARCH__=4 -march=armv4t
+ arch-$(CONFIG_CPU_32v4)		=-D__LINUX_ARM_ARCH__=4 -march=armv4
+ arch-$(CONFIG_CPU_32v3)		=-D__LINUX_ARM_ARCH__=3 -march=armv3
+@@ -88,7 +88,7 @@ tune-$(CONFIG_CPU_ARM720T)	=-mtune=arm7tdmi
+ tune-$(CONFIG_CPU_ARM740T)	=-mtune=arm7tdmi
+ tune-$(CONFIG_CPU_ARM9TDMI)	=-mtune=arm9tdmi
+ tune-$(CONFIG_CPU_ARM940T)	=-mtune=arm9tdmi
+-tune-$(CONFIG_CPU_ARM946E)	=$(call cc-option,-mtune=arm9e,-mtune=arm9tdmi)
++tune-$(CONFIG_CPU_ARM946E)	=-mtune=arm9e
+ tune-$(CONFIG_CPU_ARM920T)	=-mtune=arm9tdmi
+ tune-$(CONFIG_CPU_ARM922T)	=-mtune=arm9tdmi
+ tune-$(CONFIG_CPU_ARM925T)	=-mtune=arm9tdmi
+@@ -96,11 +96,11 @@ tune-$(CONFIG_CPU_ARM926T)	=-mtune=arm9tdmi
+ tune-$(CONFIG_CPU_FA526)	=-mtune=arm9tdmi
+ tune-$(CONFIG_CPU_SA110)	=-mtune=strongarm110
+ tune-$(CONFIG_CPU_SA1100)	=-mtune=strongarm1100
+-tune-$(CONFIG_CPU_XSCALE)	=$(call cc-option,-mtune=xscale,-mtune=strongarm110) -Wa,-mcpu=xscale
+-tune-$(CONFIG_CPU_XSC3)		=$(call cc-option,-mtune=xscale,-mtune=strongarm110) -Wa,-mcpu=xscale
+-tune-$(CONFIG_CPU_FEROCEON)	=$(call cc-option,-mtune=marvell-f,-mtune=xscale)
+-tune-$(CONFIG_CPU_V6)		=$(call cc-option,-mtune=arm1136j-s,-mtune=strongarm)
+-tune-$(CONFIG_CPU_V6K)		=$(call cc-option,-mtune=arm1136j-s,-mtune=strongarm)
++tune-$(CONFIG_CPU_XSCALE)	=-mtune=xscale
++tune-$(CONFIG_CPU_XSC3)		=-mtune=xscale
++tune-$(CONFIG_CPU_FEROCEON)	=-mtune=xscale
++tune-$(CONFIG_CPU_V6)		=-mtune=arm1136j-s
++tune-$(CONFIG_CPU_V6K)		=-mtune=arm1136j-s
+ 
+ # Evaluate tune cc-option calls now
+ tune-y := $(tune-y)
+-- 
+2.34.1
+

--- a/patch/kernel/archive/rk322x-4.4/01-linux-1000-pl330.patch
+++ b/patch/kernel/archive/rk322x-4.4/01-linux-1000-pl330.patch
@@ -2656,27 +2656,3 @@ index c3bd238b0c22..a25ab357b87c 100644
  	thrd->free = true;
  }
 
-From 31c885c621005218388ca68648dec38d2ea3f9a2 Mon Sep 17 00:00:00 2001
-From: John Keeping <john@metanate.com>
-Date: Tue, 17 Jul 2018 11:48:16 +0100
-Subject: [PATCH] dmaengine: pl330: fix irq race with terminate_all
-
-In pl330_update() when checking if a channel has been aborted, the
-channel's lock is not taken, only the overall pl330_dmac lock.  But in
-pl330_terminate_all() the aborted flag (req_running==-1) is set under
-the channel lock and not the pl330_dmac lock.
-
-With threaded interrupts, this leads to a potential race:
-
-    pl330_terminate_all	        pl330_update
-    -------------------         ------------
-    lock channel
-                                entry
-    lock pl330
-    _stop channel
-    unlock pl330
-                                lock pl330
-                                check req_running != -1
-    req_running = -1
-                                _start channel
-

--- a/patch/kernel/archive/rk322x-4.4/01-linux-1001-ssv6051.patch
+++ b/patch/kernel/archive/rk322x-4.4/01-linux-1001-ssv6051.patch
@@ -168,7 +168,7 @@ index f86faef..e1df615 100644
  
  
 -EXTRA_CFLAGS := -I$(KBUILD_TOP) -I$(KBUILD_TOP)/include
-+EXTRA_CFLAGS := -I$(KBUILD_TOP) -I$(KBUILD_TOP)/include -Wno-error=missing-attributes
++EXTRA_CFLAGS := -I$(KBUILD_TOP) -I$(KBUILD_TOP)/include -Wno-error=missing-attributes -Wno-error=array-bounds
  DEF_PARSER_H = $(KBUILD_TOP)/include/ssv_conf_parser.h
  $(shell env ccflags="$(ccflags-y)" $(KBUILD_TOP)/parser-conf.sh $(DEF_PARSER_H))
  


### PR DESCRIPTION
# Description

Fix some broken or malformed patches in rk322x-4.4 patch archive to compile with armbian-next build system, also introduce fixes to compiles with newer compilers.

The compilation process still produces a rate of horrible warnings in network drivers and elsewhere, so the usage of the vendor kernel is not encouraged.

Jira reference number [AR-1677]

# How Has This Been Tested?

- [x] Debian Bullseye full image built with success

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1677]: https://armbian.atlassian.net/browse/AR-1677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ