### PR TITLE
`kernel`/`uboot`/`atf`: introduce `kernel-patch`, `uboot-patch`, `atf-patch`, `uboot-config`, `kernel-config` CLI commands; enhanced manual patching; block deprecated ways

### DIFF
--- a/lib/functions/artifacts/artifact-kernel.sh
+++ b/lib/functions/artifacts/artifact-kernel.sh
@@ -99,6 +99,13 @@ function artifact_kernel_prepare_version() {
 	patches_hash="${hash_files}"
 	declare kernel_patches_hash_short="${patches_hash:0:${short_hash_size}}"
 
+	# detour: if CREATE_PATCHES=yes, then force "999999" (six-nines)
+	if [[ "${CREATE_PATCHES}" == "yes" ]]; then
+		display_alert "Forcing kernel patches hash to 999999" "due to CREATE_PATCHES=yes" "info"
+		patches_hash="999999 (CREATE_PATCHES=yes, unable to hash)"
+		kernel_patches_hash_short="999999"
+	fi
+
 	# get the .config hash... also userpatches...
 	declare kernel_config_source_filename="" # which actual .config was used?
 	prepare_kernel_config_core_or_userpatches
@@ -201,7 +208,10 @@ function artifact_kernel_prepare_version() {
 
 function artifact_kernel_build_from_sources() {
 	compile_kernel
-	display_alert "Kernel build finished" "${artifact_version_reason}" "info"
+
+	if [[ "${ARTIFACT_WILL_NOT_BUILD}" != "yes" ]]; then # true if kernel-patch, kernel-config, etc.
+		display_alert "Kernel build finished" "${artifact_version_reason}" "info"
+	fi
 }
 
 function artifact_kernel_cli_adapter_pre_run() {
@@ -212,6 +222,16 @@ function artifact_kernel_cli_adapter_pre_run() {
 }
 
 function artifact_kernel_cli_adapter_config_prep() {
+	# Sanity check / cattle guard
+	# If KERNEL_CONFIGURE=yes, or CREATE_PATCHES=yes, user must have used the correct CLI commands, and only add those params.
+	if [[ "${KERNEL_CONFIGURE}" == "yes" && "${ARMBIAN_COMMAND}" != "kernel-config" ]]; then
+		exit_with_error "KERNEL_CONFIGURE=yes is not supported anymore. Please use the new 'kernel-config' CLI command. Current command: '${ARMBIAN_COMMAND}'"
+	fi
+
+	if [[ "${CREATE_PATCHES}" == "yes" && "${ARMBIAN_COMMAND}" != "kernel-patch" ]]; then
+		exit_with_error "CREATE_PATCHES=yes is not supported anymore. Please use the new 'kernel-patch' CLI command. Current command: '${ARMBIAN_COMMAND}'"
+	fi
+
 	use_board="yes" prep_conf_main_minimal_ni < /dev/null # no stdin for this, so it bombs if tries to be interactive.
 }
 

--- a/lib/functions/artifacts/artifacts-obtain.sh
+++ b/lib/functions/artifacts/artifacts-obtain.sh
@@ -226,6 +226,12 @@ function obtain_complete_artifact() {
 		# @TODO: if deploying to remote cache, force high compression, DEB_COMPRESS="xz"
 		artifact_build_from_sources # definitely will end up having its own logging sections
 
+		# For cases like CREATE_PATCHES=yes or KERNEL_CONFIGURE=yes, we wanna stop here. No artifact file will be created.
+		if [[ "${ARTIFACT_WILL_NOT_BUILD}" == "yes" ]]; then
+			display_alert "artifact" "ARTIFACT_WILL_NOT_BUILD is set, stopping after non-build." "debug"
+			return 0
+		fi
+
 		# pack the artifact to local cache (eg: for deb-tar)
 		LOG_SECTION="pack_artifact_to_local_cache" do_with_logging pack_artifact_to_local_cache
 
@@ -270,13 +276,7 @@ function build_artifact_for_image() {
 	# Make sure ORAS tooling is installed before starting.
 	run_tool_oras
 
-	# Detour: if building kernel, and KERNEL_CONFIGURE=yes, ignore artifact cache.
-	if [[ "${WHAT}" == "kernel" && "${KERNEL_CONFIGURE}" == "yes" ]]; then
-		display_alert "Ignoring artifact cache for kernel" "KERNEL_CONFIGURE=yes" "info"
-		ARTIFACT_IGNORE_CACHE="yes" obtain_complete_artifact
-	else
-		obtain_complete_artifact
-	fi
+	obtain_complete_artifact
 
 	return 0
 }

--- a/lib/functions/cli/cli-artifact.sh
+++ b/lib/functions/cli/cli-artifact.sh
@@ -70,5 +70,10 @@ function cli_artifact_run() {
 		skip_unpack_if_found_in_caches="no"
 	fi
 
-	do_with_default_build obtain_complete_artifact # @TODO: < /dev/null -- but what about kernel configure?
+	if [[ "${ARTIFACT_BUILD_INTERACTIVE}" == "yes" ]]; then # Set by `kernel-config`, `kernel-patch`, `uboot-config`, `uboot-patch`, etc.
+		display_alert "Running artifact build in interactive mode" "log file will be incomplete" "info"
+		do_with_default_build obtain_complete_artifact
+	else
+		do_with_default_build obtain_complete_artifact < /dev/null
+	fi
 }

--- a/lib/functions/cli/commands.sh
+++ b/lib/functions/cli/commands.sh
@@ -43,10 +43,13 @@ function armbian_register_commands() {
 		["rootfs"]="artifact"
 
 		["kernel"]="artifact"
+		["kernel-patch"]="artifact"
 		["kernel-config"]="artifact"
 
-		["u-boot"]="artifact"
 		["uboot"]="artifact"
+		["uboot-patch"]="artifact"
+		["atf-patch"]="artifact"
+		["uboot-config"]="artifact"
 
 		["firmware"]="artifact"
 		["firmware-full"]="artifact"
@@ -65,6 +68,9 @@ function armbian_register_commands() {
 	# common for all CLI-based artifact shortcuts
 	declare common_cli_artifact_vars=""
 
+	# common for interactive artifact shortcuts (configure, patch, etc)
+	declare common_cli_artifact_interactive_vars="ARTIFACT_WILL_NOT_BUILD='yes' ARTIFACT_BUILD_INTERACTIVE='yes' ARTIFACT_IGNORE_CACHE='yes'"
+
 	# Vars to be set for each command. Optional.
 	declare -g -A ARMBIAN_COMMANDS_TO_VARS_DICT=(
 		["docker-purge"]="DOCKER_SUBCMD='purge'"
@@ -79,11 +85,14 @@ function armbian_register_commands() {
 		# artifact shortcuts
 		["rootfs"]="WHAT='rootfs' ${common_cli_artifact_vars}"
 
-		["kernel-config"]="WHAT='kernel' KERNEL_CONFIGURE='yes' ARTIFACT_BUILD_INTERACTIVE='yes' ARTIFACT_IGNORE_CACHE='yes' ${common_cli_artifact_vars}"
 		["kernel"]="WHAT='kernel' ${common_cli_artifact_vars}"
+		["kernel-config"]="WHAT='kernel' KERNEL_CONFIGURE='yes' ${common_cli_artifact_interactive_vars} ${common_cli_artifact_vars}"
+		["kernel-patch"]="WHAT='kernel' CREATE_PATCHES='yes' ${common_cli_artifact_interactive_vars} ${common_cli_artifact_vars}"
 
 		["uboot"]="WHAT='uboot' ${common_cli_artifact_vars}"
-		["u-boot"]="WHAT='uboot' ${common_cli_artifact_vars}"
+		["uboot-config"]="WHAT='uboot' UBOOT_CONFIGURE='yes' ${common_cli_artifact_interactive_vars} ${common_cli_artifact_vars}"
+		["uboot-patch"]="WHAT='uboot' CREATE_PATCHES='yes' ${common_cli_artifact_interactive_vars} ${common_cli_artifact_vars}"
+		["atf-patch"]="WHAT='uboot' CREATE_PATCHES_ATF='yes' ${common_cli_artifact_interactive_vars} ${common_cli_artifact_vars}"
 
 		["firmware"]="WHAT='firmware' ${common_cli_artifact_vars}"
 		["firmware-full"]="WHAT='full_firmware' ${common_cli_artifact_vars}"

--- a/lib/functions/compilation/atf.sh
+++ b/lib/functions/compilation/atf.sh
@@ -59,7 +59,10 @@ compile_atf() {
 	advanced_patch "atf" "${ATFPATCHDIR}" "$BOARD" "$target_patchdir" "$BRANCH" "${LINUXFAMILY}-${BOARD}-${BRANCH}"
 
 	# create patch for manual source changes
-	[[ $CREATE_PATCHES == yes ]] && userpatch_create "atf"
+	if [[ $CREATE_PATCHES_ATF == yes ]]; then
+		userpatch_create "atf"
+		return 0
+	fi
 
 	# - "--no-warn-rwx-segment" is *required* for binutils 2.39 - see https://developer.trustedfirmware.org/T996
 	#   - but *not supported* by 2.38, brilliant...

--- a/lib/functions/compilation/kernel.sh
+++ b/lib/functions/compilation/kernel.sh
@@ -54,6 +54,12 @@ function compile_kernel() {
 		return 0
 	fi
 
+	# Stop after creating patches.
+	if [[ "${CREATE_PATCHES}" == yes ]]; then
+		display_alert "Stopping after creating kernel patch" "" "cachehit"
+		return 0
+	fi
+
 	# patching worked, it's a good enough indication the git-bundle worked;
 	# let's clean up the git-bundle cache, since the git-bare cache is proven working.
 	LOG_SECTION="kernel_cleanup_bundle_artifacts" do_with_logging do_with_hooks kernel_cleanup_bundle_artifacts
@@ -68,6 +74,12 @@ function compile_kernel() {
 	LOG_SECTION="kernel_determine_toolchain" do_with_logging do_with_hooks kernel_determine_toolchain
 
 	kernel_config # has it's own logging sections inside
+
+	# Stop after configuring kernel.
+	if [[ "${KERNEL_CONFIGURE}" == yes ]]; then
+		display_alert "Stopping after configuring kernel" "" "cachehit"
+		return 0
+	fi
 
 	# build via make and package .debs; they're separate sub-steps
 	kernel_prepare_build_and_package # has it's own logging sections inside

--- a/lib/functions/compilation/uboot.sh
+++ b/lib/functions/compilation/uboot.sh
@@ -43,7 +43,10 @@ function compile_uboot_target() {
 	do_with_hooks uboot_main_patching_python
 
 	# create patch for manual source changes
-	[[ $CREATE_PATCHES == yes ]] && userpatch_create "u-boot"
+	if [[ $CREATE_PATCHES == yes ]]; then
+		userpatch_create "u-boot"
+		return 0 # exit after this.
+	fi
 
 	# atftempdir comes from atf.sh's compile_atf()
 	if [[ -n $ATFSOURCE && -d "${atftempdir}" ]]; then
@@ -150,6 +153,7 @@ function compile_uboot_target() {
 		display_alert "Exporting saved config" "UBOOT_CONFIGURE=yes; experimental" "warn"
 		run_host_command_logged make savedefconfig
 		run_host_command_logged cp -v defconfig "${DEST}/defconfig-uboot-${BOARD}-${BRANCH}"
+		return 0 # exit after this
 	fi
 
 	# workaround when two compilers are needed
@@ -343,6 +347,11 @@ function compile_uboot() {
 		loop_over_uboot_targets_and_do compile_uboot_target
 	else
 		display_alert "Extensions: custom uboot built by extension" "not building regular uboot" "debug"
+	fi
+
+	if [[ "${ARTIFACT_WILL_NOT_BUILD:-"no"}" == "yes" ]]; then
+		display_alert "Extensions: artifact will not build" "not building regular uboot" "debug"
+		return 0
 	fi
 
 	display_alert "Preparing u-boot general packaging" "${version} ${target_make}"

--- a/lib/functions/compilation/utils-compilation.sh
+++ b/lib/functions/compilation/utils-compilation.sh
@@ -19,7 +19,6 @@
 # find_toolchain
 # advanced_patch
 # process_patch_file
-# userpatch_create
 # overlayfs_wrapper
 
 grab_version() {

--- a/lib/functions/main/default-build.sh
+++ b/lib/functions/main/default-build.sh
@@ -11,9 +11,22 @@
 function full_build_packages_rootfs_and_image() {
 	error_if_kernel_only_set
 
-	# Detour, warn the user about KERNEL_CONFIGURE=yes if it is set.
+	# Detour, stop if KERNEL_CONFIGURE=yes
 	if [[ "${KERNEL_CONFIGURE}" == "yes" ]]; then
-		display_alert "KERNEL_CONFIGURE=yes during image build is deprecated." "It still works, but please prefer the new way. First, run './compile.sh BOARD=${BOARD} BRANCH=${BRANCH} kernel-config'; then commit your changes; then build the image as normal. This workflow ensures consistent hashing results." "wrn"
+		display_alert "KERNEL_CONFIGURE=yes during image build is not supported anymore." "First, run './compile.sh BOARD=${BOARD} BRANCH=${BRANCH} kernel-config'; then commit your changes; then build the image as normal. This workflow ensures consistent hashing results." "wrn"
+		exit_with_error "KERNEL_CONFIGURE=yes during image build is not supported anymore. Please use the new 'kernel-config' CLI command."
+	fi
+
+	# Detour, stop if UBOOT_CONFIGURE=yes
+	if [[ "${UBOOT_CONFIGURE}" == "yes" ]]; then
+		display_alert "UBOOT_CONFIGURE=yes during image build is not supported anymore." "First, run './compile.sh BOARD=${BOARD} BRANCH=${BRANCH} uboot-config'; then commit your changes; then build the image as normal. This workflow ensures consistent hashing results." "wrn"
+		exit_with_error "UBOOT_CONFIGURE=yes during image build is not supported anymore. Please use the new 'uboot-config' CLI command."
+	fi
+
+	# Detour, stop if CREATE_PATCHES=yes.
+	if [[ "${CREATE_PATCHES}" == "yes" || "${CREATE_PATCHES_ATF}" == "yes" ]]; then
+		display_alert "CREATE_PATCHES=yes during image build is not supported anymore." "First, run './compile.sh BOARD=${BOARD} BRANCH=${BRANCH} kernel-patch'; then move the patch to the correct place and commit your changes; then build the image as normal. This workflow ensures consistent hashing results." "wrn"
+		exit_with_error "CREATE_PATCHES=yes during image build is not supported anymore. Please use the new 'kernel-patch' / 'uboot-patch' / 'atf-patch' CLI commands."
 	fi
 
 	main_default_build_packages # has its own logging sections # requires aggregation


### PR DESCRIPTION
### _the return of the son of `CREATE_PATCHES=yes` et al_
#### `kernel`/`uboot`/`atf`: introduce `kernel-patch`, `uboot-patch`, `atf-patch`, `uboot-config`, `kernel-config` CLI commands; enhanced manual patching; block deprecated ways

- all interactive commands now **don't build the artifact** anymore; just patches/.configs are produced and then build ends
  - user is required to put the produced patches in the right place and build again, for full consistency
- split ATF and U-BOOT manual patching process; use CLI command `atf-patch` to patch ATF, and `uboot-patch` to patch u-boot
- non-interactive artifact builds are now 100% sans-stdin
- introduce `uboot-config` CLI command; still experimental, only produces a defconfig and not a patch
- reworked `userpatch_create()` to be (hopefully) more useful:
  - detects a previous patch and offers to apply it before continuing
  - enters a loop showing the diff, and only proceeds when user indicates he's happy with the patch
  - produces `mbox`-formatted patches via `format-patch` and standard Armbian parameters
  - uses `MAINTAINER` and `MAINTAINERMAIL` instead of git configuration (so it works in containers)
- don't allow image builds with any patching or configuring _at all_ (it has been deprecated with a warning for months already, and results are inconsistent)
