### PR TITLE
rootfs: add artifact name prefix and `EXTRA_ROOTFS_NAME` suffix (for extensions), `yyyymm` one-per-month auto-version in place of `REVISION` for artifact version

### DIFF
--- a/lib/functions/artifacts/artifact-rootfs.sh
+++ b/lib/functions/artifacts/artifact-rootfs.sh
@@ -41,16 +41,18 @@ function artifact_rootfs_prepare_version() {
 		"cache_id \"${rootfs_cache_id}\""
 	)
 
-	# @TODO: "rootfs_cache_id" contains "cache_type", split so we don't repeat ourselves
-	# @TODO: gotta include the extensions rootfs-modifying id to cache_type...
+	# rootfs does NOT include ${artifact_prefix_version} -- there's no reason to, since rootfs is not in an apt repo
+	# instead, we use YYYYMM to make a new rootfs cache version per-month, even if nothing else changes.
+	declare yyyymm="undetermined"
+	yyyymm="$(date +%Y%m)"
 
 	# outer scope
-	artifact_version="${artifact_prefix_version}${rootfs_cache_id}"
+	artifact_version="${yyyymm}-${rootfs_cache_id}"
 	artifact_version_reason="${reasons[*]}"
-	artifact_name="${ARCH}-${RELEASE}-${cache_type}"
+	artifact_name="rootfs-${ARCH}-${RELEASE}-${cache_type}"
 	artifact_type="tar.zst"
 	artifact_base_dir="${SRC}/cache/rootfs"
-	artifact_final_file="${SRC}/cache/rootfs/${ARCH}-${RELEASE}-${rootfs_cache_id}.tar.zst"
+	artifact_final_file="${SRC}/cache/rootfs/${artifact_name}_${artifact_version}.tar.zst"
 
 	return 0
 }

--- a/lib/functions/artifacts/artifacts-obtain.sh
+++ b/lib/functions/artifacts/artifacts-obtain.sh
@@ -68,6 +68,8 @@ function initialize_artifact() {
 }
 
 function obtain_complete_artifact() {
+	: "${artifact_prefix_version:?artifact_prefix_version is not set}"
+
 	declare -g artifact_name="undetermined"
 	declare -g artifact_type="undetermined"
 	declare -g artifact_version="undetermined"
@@ -102,8 +104,10 @@ function obtain_complete_artifact() {
 	[[ "x${artifact_base_dir}x" == "xx" || "${artifact_base_dir}" == "undetermined" ]] && exit_with_error "artifact_base_dir is not set after artifact_prepare_version"
 	[[ "x${artifact_final_file}x" == "xx" || "${artifact_final_file}" == "undetermined" ]] && exit_with_error "artifact_final_file is not set after artifact_prepare_version"
 
-	# validate artifact_version begins with artifact_prefix_version
-	[[ "${artifact_version}" =~ ^${artifact_prefix_version} ]] || exit_with_error "artifact_version '${artifact_version}' does not begin with artifact_prefix_version '${artifact_prefix_version}'"
+	# validate artifact_version begins with artifact_prefix_version when building deb packages (or deb-tar)
+	if [[ "${artifact_type}" != "tar.zst" ]]; then
+		[[ "${artifact_version}" =~ ^${artifact_prefix_version} ]] || exit_with_error "artifact_version '${artifact_version}' does not begin with artifact_prefix_version '${artifact_prefix_version}'"
+	fi
 
 	# validate artifact_type... it must be one of the supported types
 	case "${artifact_type}" in

--- a/lib/functions/rootfs/create-cache.sh
+++ b/lib/functions/rootfs/create-cache.sh
@@ -28,16 +28,17 @@ function calculate_rootfs_cache_id() {
 
 	declare cache_type="cli"
 	[[ ${BUILD_DESKTOP} == yes ]] && cache_type="xfce-desktop"
-	[[ -n ${DESKTOP_ENVIRONMENT} ]] && cache_type="${DESKTOP_ENVIRONMENT}" # @TODO: this is missing "-desktop"
+	[[ -n ${DESKTOP_ENVIRONMENT} ]] && cache_type="${DESKTOP_ENVIRONMENT}-desktop"
 	[[ ${BUILD_MINIMAL} == yes ]] && cache_type="minimal"
 
-	# @TODO: rpardini: allow extensions to modify cache_type, eg, "-cloud-mluc". *think* before doing this
+	# allow extensions to modify cache_type, since they may have used add_packages_to_rootfs() or remove_packages()
+	cache_type="${cache_type}${EXTRA_ROOTFS_NAME:-""}"
 
 	declare -g -r cache_type="${cache_type}"
 
-	declare -g -r rootfs_cache_id="${cache_type}-${packages_hash}"
+	declare -g -r rootfs_cache_id="${packages_hash}"
 
-	display_alert "calculate_rootfs_cache_id: done." "rootfs_cache_id: '${rootfs_cache_id}'" "debug"
+	display_alert "calculate_rootfs_cache_id: done." "cache_type: '${cache_type}' - rootfs_cache_id: '${rootfs_cache_id}'" "debug"
 }
 
 # called by artifact-rootfs::artifact_rootfs_build_from_sources()


### PR DESCRIPTION
#### rootfs: add artifact name prefix and `EXTRA_ROOTFS_NAME` suffix (for extensions), `yyyymm` one-per-month auto-version in place of `REVISION` for artifact version

- rootfs is not a deb package, and thus not subject to the same strict ordering rules of `artifact_prefix_version`
  - replace with `yyyymm` (`202305`) in version so we get one-per-month automatically
