### PR TITLE
more of rpardini's GHA & pipeline stuff (early May/23)

### DIFF
--- a/lib/functions/artifacts/artifact-kernel.sh
+++ b/lib/functions/artifacts/artifact-kernel.sh
@@ -15,6 +15,7 @@ function artifact_kernel_config_dump() {
 	artifact_input_variables[KERNELSOURCE]="${KERNELSOURCE}"
 	artifact_input_variables[KERNELBRANCH]="${KERNELBRANCH}"
 	artifact_input_variables[KERNELPATCHDIR]="${KERNELPATCHDIR}"
+	artifact_input_variables[ARCH]="${ARCH}"
 }
 
 # This is run in a logging section.

--- a/lib/functions/artifacts/artifact-uboot.sh
+++ b/lib/functions/artifacts/artifact-uboot.sh
@@ -13,6 +13,7 @@ function artifact_uboot_config_dump() {
 	artifact_input_variables[BOOTPATCHDIR]="${BOOTPATCHDIR}"
 	artifact_input_variables[BOARD]="${BOARD}"
 	artifact_input_variables[BRANCH]="${BRANCH}"
+	artifact_input_variables[ARCH]="${ARCH}"
 }
 
 function artifact_uboot_prepare_version() {

--- a/lib/functions/cli/cli-jsoninfo.sh
+++ b/lib/functions/cli/cli-jsoninfo.sh
@@ -154,6 +154,19 @@ function cli_json_info_run() {
 				run_host_command_logged "${PYTHON3_VARS[@]}" "${PYTHON3_INFO[BIN]}" "${INFO_TOOLS_DIR}"/output-gha-matrix.py images "${OUTDATED_ARTIFACTS_IMAGES_FILE}" "${MATRIX_IMAGE_CHUNKS}" ">" "${GHA_ALL_IMAGES_JSON_MATRIX_FILE}"
 			fi
 			github_actions_add_output "image-matrix" "$(cat "${GHA_ALL_IMAGES_JSON_MATRIX_FILE}")"
+
+			# If we have userpatches/gha/chunks, run the workflow template utility
+			declare user_gha_dir="${USERPATCHES_PATH}/gha"
+			declare wf_template_dir="${user_gha_dir}/chunks"
+			if [[ -d "${wf_template_dir}" ]]; then
+				display_alert "Generating GHA workflow template" "output-gha-workflow-template :: ${wf_template_dir}" "info"
+				declare GHA_WORKFLOW_TEMPLATE_OUT_FILE="${BASE_INFO_OUTPUT_DIR}/artifact-image-complete-matrix.yml"
+				declare GHA_CONFIG_YAML_FILE="${user_gha_dir}/gha_config.yaml"
+				run_host_command_logged "${PYTHON3_VARS[@]}" "${PYTHON3_INFO[BIN]}" "${INFO_TOOLS_DIR}"/output-gha-workflow-template.py "${GHA_WORKFLOW_TEMPLATE_OUT_FILE}" "${GHA_CONFIG_YAML_FILE}" "${wf_template_dir}" "${MATRIX_ARTIFACT_CHUNKS:-"10"}" "${MATRIX_IMAGE_CHUNKS:-"10"}"
+			else
+				display_alert "Skipping GHA workflow template" "output-gha-workflow-template :: no ${wf_template_dir}" "info"
+			fi
+
 		fi
 
 		### a secondary stage, which only makes sense to be run inside GHA, and as such should be split in a different CLI or under a flag.

--- a/lib/functions/cli/commands.sh
+++ b/lib/functions/cli/commands.sh
@@ -25,8 +25,9 @@ function armbian_register_commands() {
 
 		["inventory"]="json_info" # implemented in cli_json_info_pre_run and cli_json_info_run
 		["targets"]="json_info"   # implemented in cli_json_info_pre_run and cli_json_info_run
-		["matrix"]="json_info"    # implemented in cli_json_info_pre_run and cli_json_info_run
-		["workflow"]="json_info"  # implemented in cli_json_info_pre_run and cli_json_info_run
+		["gha-matrix"]="json_info"    # implemented in cli_json_info_pre_run and cli_json_info_run
+		["gha-workflow"]="json_info"  # implemented in cli_json_info_pre_run and cli_json_info_run
+		["gha-template"]="json_info"  # implemented in cli_json_info_pre_run and cli_json_info_run
 
 		["kernel-patches-to-git"]="patch_kernel" # implemented in cli_patch_kernel_pre_run and cli_patch_kernel_run
 

--- a/lib/functions/general/python-tools.sh
+++ b/lib/functions/general/python-tools.sh
@@ -20,6 +20,7 @@ function early_prepare_pip3_dependencies_for_python_tools() {
 		"coloredlogs==15.0.1" # for colored logging
 		"PyYAML==6.0"         # for parsing/writing YAML
 		"oras==0.1.17"        # for OCI stuff in mapper-oci-update
+		"Jinja2==3.1.2"       # for templating
 	)
 	return 0
 }

--- a/lib/tools/info/output-gha-matrix.py
+++ b/lib/tools/info/output-gha-matrix.py
@@ -14,6 +14,7 @@ import sys
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from common import armbian_utils
+from common import gha
 
 # Prepare logging
 armbian_utils.setup_logging()
@@ -175,7 +176,13 @@ for i, chunk in enumerate(chunks):
 		log.error(f"Chunk '{i + 1}' is too big: {len(chunk)}")
 		sys.exit(1)
 
-	# Ensure matrix is sane...
+	# Directly set outputs for _each_ GHA chunk here. (code below is for all the chunks)
+	gha.set_gha_output(f"{type_gen}-chunk-json-{i + 1}", json.dumps({"include": chunk}))
+	# An output that is used to test for empty matrix.
+	gha.set_gha_output(f"{type_gen}-chunk-not-empty-{i + 1}", "yes" if len(chunk) > 0 else "no")
+	gha.set_gha_output(f"{type_gen}-chunk-size-{i + 1}", len(chunk))
+
+	# For the full matrix, we can't have empty chunks; use a "really" field to indicate a fake entry added to make it non-empty.
 	if len(chunk) == 0:
 		log.warning(f"Chunk '{i + 1}' for '{type_gen}' is empty, adding fake invocation.")
 		chunks[i] = [{"desc": "Fake matrix element so matrix is not empty", "runs_on": "ubuntu-latest", "invocation": "none", "really": "no"}]

--- a/lib/tools/info/output-gha-matrix.py
+++ b/lib/tools/info/output-gha-matrix.py
@@ -20,6 +20,54 @@ armbian_utils.setup_logging()
 log: logging.Logger = logging.getLogger("output-gha-matrix")
 
 
+def resolve_gha_runner_tags_via_pipeline_gha_config(input: dict, artifact_name: str, artifact_arch: str):
+	log.debug(f"Resolving GHA runner tags for artifact/image '{artifact_name}' '{artifact_arch}'")
+
+	# if no config, default to "ubuntu-latest" as a last-resort
+	ret = "ubuntu-latest"
+
+	if not "pipeline" in input:
+		log.warning(f"No 'pipeline' config in input, defaulting to '{ret}'")
+		return ret
+
+	pipeline = input["pipeline"]
+
+	if not "gha" in pipeline:
+		log.warning(f"No 'gha' config in input.pipeline, defaulting to '{ret}'")
+		return ret
+
+	gha = pipeline["gha"]
+
+	if (gha is None) or (not "runners" in gha):
+		log.warning(f"No 'runners' config in input.pipeline.gha, defaulting to '{ret}'")
+		return ret
+
+	runners = gha["runners"]
+
+	if "default" in runners:
+		ret = runners["default"]
+		log.debug(f"Found 'default' config in input.pipeline.gha.runners, defaulting to '{ret}'")
+
+	# Now, 'by-name' first.
+	if "by-name" in runners:
+		by_names = runners["by-name"]
+		if artifact_name in by_names:
+			ret = by_names[artifact_name]
+			log.debug(f"Found 'by-name' value '{artifact_name}' config in input.pipeline.gha.runners, using '{ret}'")
+
+	# Now, 'by-name-and-arch' second.
+	artifact_name_and_arch = f"{artifact_name}{f'-{artifact_arch}' if artifact_arch is not None else ''}"
+	if "by-name-and-arch" in runners:
+		by_names_and_archs = runners["by-name-and-arch"]
+		if artifact_name_and_arch in by_names_and_archs:
+			ret = by_names_and_archs[artifact_name_and_arch]
+			log.debug(f"Found 'by-name-and-arch' value '{artifact_name_and_arch}' config in input.pipeline.gha.runners, using '{ret}'")
+
+	log.info(f"Resolved GHA runs_on for name:'{artifact_name}' arch:'{artifact_arch}' to runs_on:'{ret}'")
+
+	return ret
+
+
 def generate_matrix_images(info) -> list[dict]:
 	# each image
 	matrix = []
@@ -38,12 +86,11 @@ def generate_matrix_images(info) -> list[dict]:
 
 		desc = f"{image['image_file_id']} {image_id}"
 
-		runs_on = "ubuntu-latest"
-		image_arch = image['out']['ARCH']
-		if image_arch in ["arm64"]:  # , "armhf"
-			runs_on = ["self-hosted", "Linux", f"image-{image_arch}"]
-
 		inputs = image['in']
+
+		image_arch = image['out']['ARCH']
+		runs_on = resolve_gha_runner_tags_via_pipeline_gha_config(inputs, "image", image_arch)
+
 		cmds = (armbian_utils.map_to_armbian_params(inputs["vars"]) + inputs["configs"])  # image build is "build" command, omitted here
 		invocation = " ".join(cmds)
 
@@ -65,22 +112,16 @@ def generate_matrix_artifacts(info):
 
 		desc = f"{artifact['out']['artifact_final_file_basename']}"
 
-		# runs_in = ["self-hosted", "Linux", 'armbian', f"artifact-{artifact_name}"]
-		runs_on = "fast"
-
-		# @TODO: externalize this logic.
-
-		# rootfs's fo arm64 are built on self-hosted runners tagged with "rootfs-<arch>"
-		if artifact_name in ["rootfs"]:
-			rootfs_arch = artifact['in']['inputs']['ARCH']  # @TODO we should resolve arch _much_ ealier in the pipeline and make it standard
-			if rootfs_arch in ["arm64"]:  # (future: add armhf)
-				runs_on = ["self-hosted", "Linux", f"rootfs-{rootfs_arch}"]
-
-		# all kernels are built on self-hosted runners.
-		if artifact_name in ["kernel"]:
-			runs_on = ["self-hosted", "Linux", 'alfa']
-
 		inputs = artifact['in']['original_inputs']
+
+		artifact_arch = None
+		# Try via the inputs to artifact...
+		if "inputs" in artifact['in']:
+			if "ARCH" in artifact['in']['inputs']:
+				artifact_arch = artifact['in']['inputs']['ARCH']
+
+		runs_on = resolve_gha_runner_tags_via_pipeline_gha_config(inputs, artifact_name, artifact_arch)
+
 		cmds = (["artifact"] + armbian_utils.map_to_armbian_params(inputs["vars"]) + inputs["configs"])
 		invocation = " ".join(cmds)
 

--- a/lib/tools/info/output-gha-workflow-template.py
+++ b/lib/tools/info/output-gha-workflow-template.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+
+# ‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹
+#  SPDX-License-Identifier: GPL-2.0
+#  Copyright (c) 2023 Ricardo Pardini <ricardo@pardini.net>
+#  This file is a part of the Armbian Build Framework https://github.com/armbian/build/
+# ‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹
+import logging
+import os
+import yaml
+
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from common import armbian_utils
+from jinja2 import Environment
+from jinja2 import StrictUndefined
+
+# Prepare logging
+armbian_utils.setup_logging()
+log: logging.Logger = logging.getLogger("output-gha-workflow-template")
+
+# Parse cmdline
+
+output_file = sys.argv[1]
+config_yaml_file = sys.argv[2]
+template_dir = sys.argv[3]
+num_chunks_artifacts = int(sys.argv[4])
+num_chunks_images = int(sys.argv[5])
+
+log.info(f"output_file: {output_file}")
+log.info(f"template_dir: {template_dir}")
+log.info(f"num_chunks_artifacts: {num_chunks_artifacts}")
+log.info(f"num_chunks_images: {num_chunks_images}")
+
+# load the yaml config (context for all entries)
+config = {}
+with open(config_yaml_file, "r") as f:
+	config_yaml = f.read()
+	config = yaml.load(config_yaml, Loader=yaml.FullLoader)
+
+# get a list of the .yaml files in the template dir
+template_files = [f for f in os.listdir(template_dir) if f.endswith(".yaml") or f.endswith(".yml")]
+# sort it
+template_files.sort()
+log.info(f"template_files: {template_files}")
+
+out: str = ""
+
+
+# here is a list of the filenames we expect:
+# 050.single_header.yaml
+# 150.per-chunk-artifacts_prep-outputs.yaml
+# 151.per-chunk-images_prep-outputs.yaml
+# 250.single_aggr.jobs.yaml
+# 550.per-chunk-artifacts_job.yaml
+# 650.per-chunk-images_job.yaml
+def handle_template(template_content: str, context: dict) -> str:
+	env = Environment(block_start_string='[%', block_end_string='%]',
+					  variable_start_string='[[', variable_end_string=']]', comment_start_string='[#', comment_end_string='#]',
+					  undefined=StrictUndefined)
+	jinja_template = env.from_string(template_content)
+
+	rendered = jinja_template.render(context)
+
+	# Now, strip all the lines that contain the string "<TEMPLATE-IGNORE>"
+	rendered = "\n".join([line for line in rendered.split("\n") if "<TEMPLATE-IGNORE>" not in line])
+
+	# More crazy. For the string '"TEMPLATE-JOB-NAME": # <TEMPLATE-JOB-NAME>' we will replace it with the actual job name
+	rendered = rendered.replace('"TEMPLATE-JOB-NAME": # <TEMPLATE-JOB-NAME>', f'"{context["job_name"]}": # templated "{context["job_name"]}"')
+
+	# ensure it ends with a newline
+	if not rendered.endswith("\n"):
+		rendered += "\n"
+
+	return rendered
+
+
+# loop over the template files
+for template_file in template_files:
+	# parse the filename according to the above list
+	template_order, rest = template_file.split(".", 1)
+	template_order = int(template_order)
+	# parse the type of template, separated by "_"
+	template_type, rest = rest.split("_", 1)
+	# parse the name of the template and the extension. the extension is anything after the first "."
+	template_name, template_ext = rest.split(".", 1)
+	# read the full contents of the template file as UTF-8
+	with open(os.path.join(template_dir, template_file), "r") as f:
+		template_content = f.read()
+
+	log.info(
+		f"Processing template file: {template_file} (order: {template_order}, type: {template_type}, name: {template_name}, ext:{template_ext}, len:{len(template_content)} bytes)")
+
+	# prepare quoted comma lists of the chunks, remove the first and last quotes
+	quoted_comma_list_artifact_chunk_jobs = ",".join([f"\"build-artifacts-chunk-{chunk + 1}\"" for chunk in range(num_chunks_artifacts)])[1:-1]
+
+	# same, but for images, remove the first and last quotes
+	quoted_comma_list_image_chunk_jobs = ",".join([f"\"build-images-chunk-{chunk + 1}\"" for chunk in range(num_chunks_images)])[1:-1]
+
+	context = {
+		"num_chunks_artifacts": num_chunks_artifacts,
+		"num_chunks_images": num_chunks_images,
+		"quoted_comma_list_artifact_chunk_jobs": quoted_comma_list_artifact_chunk_jobs,
+		"quoted_comma_list_image_chunk_jobs": quoted_comma_list_image_chunk_jobs
+	}
+
+	# all 'config' dict on top, for common things re-used everywhere
+	context.update(config)
+
+	out += f"\n# template file: {template_file}\n\n"
+
+	if template_type == "single":
+		context["job_name"] = "ERROR_IN_TEMPLATE!!!"
+		out += handle_template(template_content, context)
+	elif template_type == "per-chunk-artifacts":
+		for chunk in range(num_chunks_artifacts):
+			context["chunk"] = chunk + 1
+			context["num_chunks"] = num_chunks_artifacts
+			context["job_name"] = f"build-artifacts-chunk-{chunk + 1}"
+			out += handle_template(template_content, context)
+	elif template_type == "per-chunk-images":
+		for chunk in range(num_chunks_images):
+			context["chunk"] = chunk + 1
+			context["num_chunks"] = num_chunks_images
+			context["job_name"] = f"build-images-chunk-{chunk + 1}"
+			out += handle_template(template_content, context)
+	else:
+		raise Exception(f"Unknown template type: {template_type}")
+
+# write the out str to the output file
+with open(output_file, "w") as f:
+	f.write(out)
+
+log.info(f"Done. Wrote {len(out)} bytes to {output_file}")

--- a/lib/tools/info/targets-compositor.py
+++ b/lib/tools/info/targets-compositor.py
@@ -59,6 +59,10 @@ invocations_dict: list[dict] = []
 for target_name in targets["targets"]:
 	target_obj = targets["targets"][target_name]
 
+	if "enabled" in target_obj and not target_obj["enabled"]:
+		log.warning(f"Skipping disabled target '{target_name}'...")
+		continue
+
 	all_items = []
 	all_expansions = []
 


### PR DESCRIPTION
#### more of rpardini's GHA & pipeline stuff (early May/23)

- pipeline: cli: add proper `gha-` prefix to CLI commands that have something to do with GitHub Actions (thus `gha-matrix` now, and the new `gha-template`)
- stop at the correct places for `inventory` and `targets` non-GHA-specific commands
- handle `gha-template` first (and return), since it does not really depend on any info/targets/etc
  - batcat the output for show-off
- pipeline: add output-gha-workflow-template.py utility, for rendering GHA workflow YAML templates with chunks
  - python-tools: add Jinja2. Incredible how we made it this far without it.
  - output-gha-workflow-template: a double-templater, first runs jinja with a custom syntax, then "moar magic" to be useful for GHA
- pipeline: targets-compositor: whole target can be `enabled: no` to quickly disable it (as if it wasn't there)
- pipeline: output-gha-matrix: directly GHA-output `images-chunk-json-2`, `images-chunk-not-empty-2`, `images-chunk-size-2` and `artifacts-xxx` with no fake entry
  - as alternative to the full output, this allows us to skip chunkjobs when they're empty, and hopefully makes GHA-JSON-parsing 10x faster
- pipeline: output-gha-matrix: new `input.pipeline.gha.runners` in the targets.yaml for mapping GHA's `runs_on` based on name and arch
- artifact kernel/uboot: add `ARCH` to `artifact_input_variables`; used for (maybe) mapping to runner tags in JSON pipeline

