### PR TITLE
extension fake-vcgencmd

### DIFF
--- a/extensions/fake-vcgencmd.sh
+++ b/extensions/fake-vcgencmd.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+function pre_umount_final_image__install_fake_vcgencmd() {
+	display_alert "Installing fake vcgencmd" "${EXTENSION}" "info"
+
+	if [[ $BOARD != rpi4b ]]; then
+		run_host_command_logged curl -vo "${MOUNT}"/usr/bin/vcgencmd "https://raw.githubusercontent.com/clach04/fake_vcgencmd/0.0.2/vcgencmd"
+		run_host_command_logged chmod -v 755 "${MOUNT}"/usr/bin/vcgencmd
+
+		run_host_command_logged mkdir -vp "${MOUNT}"/usr/share/doc/fake_vcgencmd
+		run_host_command_logged curl -vo "${MOUNT}"/usr/share/doc/fake_vcgencmd/LICENSE "https://raw.githubusercontent.com/clach04/fake_vcgencmd/0.0.2/LICENSE"
+		run_host_command_logged curl -vo "${MOUNT}"/usr/share/doc/fake_vcgencmd/README.md "https://raw.githubusercontent.com/clach04/fake_vcgencmd/0.0.2/README.md"
+	else
+		display_alert "Omitting installattion on Raspberry Pi boards as these ship the original vcgencmd" "${EXTENSION}" "info"
+	fi
+}


### PR DESCRIPTION
# Description

Extension to include fake vcgencmd to non Raspberry Pi builds to allow the Android app Raspi Check to control Armbian boards out of the box.

See also https://github.com/armbian/build/pull/5100 and https://github.com/armbian/build/pull/5095

# How Has This Been Tested?

Build for Raspberry Pi  (not installing the fake vcgencmd, bur failed for another reason on SHA-1) and non-Raspberry Pi boards (installing it)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
