### PR TITLE
Sunxi 6.1 / 6.2: h616 (OrangePi Zero 2): Fix thermal zones (add missing trips)

### DIFF
--- a/patch/kernel/archive/sunxi-6.1/patches.armbian/arm64-dts-allwinner-h616-Fix-thermal-zones-missing-trips.patch
+++ b/patch/kernel/archive/sunxi-6.1/patches.armbian/arm64-dts-allwinner-h616-Fix-thermal-zones-missing-trips.patch
@@ -1,0 +1,82 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20Dzieko=C5=84ski?=
+ <michal.dziekonski+github@gmail.com>
+Date: Wed, 3 May 2023 12:10:01 +0000
+Subject: arm64: dts: allwinner: h616: Fix thermal zones (add missing trips)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Michał Dziekoński <michal.dziekonski+github@gmail.com>
+---
+ arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi | 29 ++++++++++
+ 1 file changed, 29 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
+index 44c794688..7ff911107 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
+@@ -887,10 +887,15 @@ cpu_threshold: trip-point@0 {
+ 				cpu_target: trip-point@1 {
+ 					temperature = <70000>;
+ 					type = "passive";
+ 					hysteresis = <0>;
+ 				};
++				cpu_temp_critical: trip-point@2 {
++					temperature = <110000>;
++					type = "critical";
++					hysteresis = <0>;
++				};
+ 			};
+ 
+ 			cooling-maps {
+ 				map0 {
+ 					trip = <&cpu_target>;
+@@ -905,20 +910,44 @@ map0 {
+ 		gpu-thermal {
+ 			polling-delay-passive = <500>;
+ 			polling-delay = <1000>;
+ 			thermal-sensors = <&ths 0>;
+ 			sustainable-power = <1100>;
++
++			trips {
++				gpu_temp_critical: trip-point@0 {
++					temperature = <110000>;
++					type = "critical";
++					hysteresis = <0>;
++				};
++			};
+ 		};
+ 
+ 		ve-thermal {
+ 			polling-delay-passive = <0>;
+ 			polling-delay = <0>;
+ 			thermal-sensors = <&ths 1>;
++
++			trips {
++				ve_temp_critical: trip-point@0 {
++					temperature = <110000>;
++					type = "critical";
++					hysteresis = <0>;
++				};
++			};
+ 		};
+ 
+ 		ddr-thermal {
+ 			polling-delay-passive = <0>;
+ 			polling-delay = <0>;
+ 			thermal-sensors = <&ths 3>;
++
++			trips {
++				ddr_temp_critical: trip-point@0 {
++					temperature = <110000>;
++					type = "critical";
++					hysteresis = <0>;
++				};
++			};
+ 		};
+ 	};
+ };
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/kernel/archive/sunxi-6.1/series.armbian
+++ b/patch/kernel/archive/sunxi-6.1/series.armbian
@@ -89,6 +89,7 @@
 	patches.armbian/arm64-dts-sun50i-h616-x96-mate-add-hdmi.patch
 	patches.armbian/arm64-dts-allwinner-h616-Add-device-node-for-SID.patch
 	patches.armbian/arm64-dts-allwinner-h616-Add-thermal-sensor-and-thermal-zones.patch
+	patches.armbian/arm64-dts-allwinner-h616-Fix-thermal-zones-missing-trips.patch
 ###################
 	patches.armbian/arm64-dts-sun50i-a64-pinebook-enable-Bluetooth.patch
 	patches.armbian/arm64-dts-sun50i-a64-pine64-enable-Bluetooth.patch

--- a/patch/kernel/archive/sunxi-6.1/series.conf
+++ b/patch/kernel/archive/sunxi-6.1/series.conf
@@ -493,6 +493,7 @@
 	patches.armbian/arm64-dts-sun50i-h616-x96-mate-add-hdmi.patch
 	patches.armbian/arm64-dts-allwinner-h616-Add-device-node-for-SID.patch
 	patches.armbian/arm64-dts-allwinner-h616-Add-thermal-sensor-and-thermal-zones.patch
+	patches.armbian/arm64-dts-allwinner-h616-Fix-thermal-zones-missing-trips.patch
 ###################
 	patches.armbian/arm64-dts-sun50i-a64-pinebook-enable-Bluetooth.patch
 	patches.armbian/arm64-dts-sun50i-a64-pine64-enable-Bluetooth.patch

--- a/patch/kernel/archive/sunxi-6.2/patches.armbian/arm64-dts-allwinner-h616-Fix-thermal-zones-missing-trips.patch
+++ b/patch/kernel/archive/sunxi-6.2/patches.armbian/arm64-dts-allwinner-h616-Fix-thermal-zones-missing-trips.patch
@@ -1,0 +1,82 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20Dzieko=C5=84ski?=
+ <michal.dziekonski+github@gmail.com>
+Date: Wed, 3 May 2023 12:17:28 +0000
+Subject: arm64: dts: allwinner: h616: Fix thermal zones (add missing trips)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Michał Dziekoński <michal.dziekonski+github@gmail.com>
+---
+ arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi | 29 ++++++++++
+ 1 file changed, 29 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
+index 8628a9e3d..17b13d319 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
+@@ -875,10 +875,15 @@ cpu_threshold: trip-point@0 {
+ 				cpu_target: trip-point@1 {
+ 					temperature = <70000>;
+ 					type = "passive";
+ 					hysteresis = <0>;
+ 				};
++				cpu_temp_critical: trip-point@2 {
++					temperature = <110000>;
++					type = "critical";
++					hysteresis = <0>;
++				};
+ 			};
+ 
+ 			cooling-maps {
+ 				map0 {
+ 					trip = <&cpu_target>;
+@@ -893,20 +898,44 @@ map0 {
+ 		gpu-thermal {
+ 			polling-delay-passive = <500>;
+ 			polling-delay = <1000>;
+ 			thermal-sensors = <&ths 0>;
+ 			sustainable-power = <1100>;
++
++			trips {
++				gpu_temp_critical: trip-point@0 {
++					temperature = <110000>;
++					type = "critical";
++					hysteresis = <0>;
++				};
++			};
+ 		};
+ 
+ 		ve-thermal {
+ 			polling-delay-passive = <0>;
+ 			polling-delay = <0>;
+ 			thermal-sensors = <&ths 1>;
++
++			trips {
++				ve_temp_critical: trip-point@0 {
++					temperature = <110000>;
++					type = "critical";
++					hysteresis = <0>;
++				};
++			};
+ 		};
+ 
+ 		ddr-thermal {
+ 			polling-delay-passive = <0>;
+ 			polling-delay = <0>;
+ 			thermal-sensors = <&ths 3>;
++
++			trips {
++				ddr_temp_critical: trip-point@0 {
++					temperature = <110000>;
++					type = "critical";
++					hysteresis = <0>;
++				};
++			};
+ 		};
+ 	};
+ };
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/kernel/archive/sunxi-6.2/series.armbian
+++ b/patch/kernel/archive/sunxi-6.2/series.armbian
@@ -105,6 +105,7 @@
 	patches.armbian/arm64-dts-sun50i-h616-x96-mate-add-hdmi.patch
 	patches.armbian/arm64-dts-allwinner-h616-Add-device-node-for-SID.patch
 	patches.armbian/arm64-dts-allwinner-h616-Add-thermal-sensor-and-thermal-zones.patch
+	patches.armbian/arm64-dts-allwinner-h616-Fix-thermal-zones-missing-trips.patch
 ###################
 	patches.armbian/arm64-dts-sun50i-a64-pine64-enable-Bluetooth.patch
 	patches.armbian/arm64-dts-sun50i-a64-sopine-baseboard-enable-Bluetooth.patch

--- a/patch/kernel/archive/sunxi-6.2/series.conf
+++ b/patch/kernel/archive/sunxi-6.2/series.conf
@@ -501,6 +501,7 @@
 	patches.armbian/arm64-dts-sun50i-h616-x96-mate-add-hdmi.patch
 	patches.armbian/arm64-dts-allwinner-h616-Add-device-node-for-SID.patch
 	patches.armbian/arm64-dts-allwinner-h616-Add-thermal-sensor-and-thermal-zones.patch
+	patches.armbian/arm64-dts-allwinner-h616-Fix-thermal-zones-missing-trips.patch
 ###################
 	patches.armbian/arm64-dts-sun50i-a64-pine64-enable-Bluetooth.patch
 	patches.armbian/arm64-dts-sun50i-a64-sopine-baseboard-enable-Bluetooth.patch


### PR DESCRIPTION
# Description

These patches fix an issue present on newer Kernels (6.1+, no idea if older kernels are affected as well), where the thermal sensors are unavailable (`/sys/class/thermal` is empty). By applying these patches, thermal sensors are available to use.

The problem seems to be related by how Linux thermal driver [`drivers/thermal/thermal_of.c`](https://github.com/torvalds/linux/blob/v6.1/drivers/thermal/thermal_of.c#L610-L614) handles thermal zones without trips defined - if it doesn't exist, throw an error. I'm not Linux expert, but it looks like 6.1 brought some thermal driver refactoring, which might have caused this behavior. 

Before the patches, with logging verbosity set to `7`, there's also an error present in boot log related to the sensor's init process:
https://paste.armbian.com/awikixucez
```
...
[    1.255888] thermal_sys: Failed to find 'trips' node
[    1.255901] thermal_sys: Failed to find trip points for thermal-sensor id=0
[    1.255916] sun8i-thermal 5070400.thermal-sensor: Failed to register sensor 0 (-EINVAL)
[    1.255925] sun8i-thermal: probe of 5070400.thermal-sensor failed with error -22
...
```

With the patches applied, the errors are no longer present:
(sunxi-6.1 log): https://paste.armbian.com/jomezorune
(sunxi-6.2 log): https://paste.armbian.com/kutozasuji

# Changes

- Added one trip to each thermal zone with missing trips (GPU, DDR & VE).
  - Added `critical` trip point, set to 110C, corresponding to the recommended Tj max, as per H616 documentation (found here: https://linux-sunxi.org/H616)
- For completeness, added new `critical` trip point for CPU thermal zone, similar to trips mentioned above

# How Has This Been Tested?

Both kernel versions have been compiled before and after applying patches and tested like this:
1. Check if the board boots up
2. Proceed with minimal initial setup
3. Be logged in as `root`
4. Check if sensors are available by using the following command:  
```
ls /sys/class/thermal/
```
- Expected result: there are 4 directories present in the output
- Actual result (before patch): output is empty
5. Check if sensors provide meaningful temperatures by using the following commands:
```
cat /sys/class/thermal/thermal_zone0/temp
cat /sys/class/thermal/thermal_zone1/temp
cat /sys/class/thermal/thermal_zone2/temp
cat /sys/class/thermal/thermal_zone3/temp
```
- Expected results: each sensor readout outputs sensible temperature (in my case, ~50 C)
- Actual result (before patch): no output, commands fail

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
