### PR TITLE
remove twice declared uboot make targets for rkspi image

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -189,7 +189,7 @@ prepare_boot_configuration() {
 	if [[ $BOOT_SUPPORT_SPI == yes ]]; then
 
 		if [[ "${BOOT_SPI_RKSPI_LOADER:-"no"}" != "yes" ]]; then
-			UBOOT_TARGET_MAP="BL31=$RKBIN_DIR/$BL31_BLOB tpl/u-boot-tpl.bin spl/u-boot-spl.bin u-boot.dtb u-boot.itb ${UBOOT_TARGET_MAP} rkspi_loader.img"
+			UBOOT_TARGET_MAP="${UBOOT_TARGET_MAP} tpl/u-boot-tpl.bin spl/u-boot-spl.bin u-boot.itb rkspi_loader.img"
 		else
 			UBOOT_TARGET_MAP="${UBOOT_TARGET_MAP} rkspi_loader.img"
 		fi


### PR DESCRIPTION
# Description

#5114
The uboot targets are declared twice, which is strange. And no need to build uboot.dtb.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Build for rockpro64 success: https://paste.next.armbian.com/okogutizaw

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
