### PR TITLE
rpardini's fight with space-containing PARAMs - early May/'23

### DIFF
--- a/lib/functions/artifacts/artifact-rootfs.sh
+++ b/lib/functions/artifacts/artifact-rootfs.sh
@@ -41,6 +41,13 @@ function artifact_rootfs_prepare_version() {
 		"cache_id \"${rootfs_cache_id}\""
 	)
 
+	# add more reasons for desktop stuff
+	if [[ "${DESKTOP_ENVIRONMENT}" != "" ]]; then
+		reasons+=("desktop_environment \"${DESKTOP_ENVIRONMENT}\"")
+		reasons+=("desktop_environment_config_name \"${DESKTOP_ENVIRONMENT_CONFIG_NAME}\"")
+		reasons+=("desktop_appgroups_selected \"${DESKTOP_APPGROUPS_SELECTED}\"")
+	fi
+
 	# rootfs does NOT include ${artifact_prefix_version} -- there's no reason to, since rootfs is not in an apt repo
 	# instead, we use YYYYMM to make a new rootfs cache version per-month, even if nothing else changes.
 	declare yyyymm="undetermined"

--- a/lib/functions/cli/cli-configdump.sh
+++ b/lib/functions/cli/cli-configdump.sh
@@ -15,6 +15,12 @@ function cli_config_dump_json_run() {
 	# configuration etc - it initializes the extension manager
 	do_capturing_defs config_board_and_remove_useless < /dev/null # this sets CAPTURED_VARS_NAMES and CAPTURED_VARS_ARRAY; the < /dev/null is take away the terminal from stdin
 
+	if [[ "${ARMBIAN_COMMAND}" == "config-dump-no-json" ]]; then
+		# for debugging the bash-declare-to-JSON parser
+		echo "${CAPTURED_VARS_ARRAY[@]}"
+		return 0
+	fi
+
 	# convert to JSON, using python helper; each var is passed via a command line argument; that way we avoid newline/nul-char separation issues
 	display_alert "Dumping JSON" "for ${#CAPTURED_VARS_ARRAY[@]} variables" "ext"
 	python3 "${SRC}/lib/tools/configdump2json.py" "--args" "${CAPTURED_VARS_ARRAY[@]}" # to stdout

--- a/lib/functions/cli/commands.sh
+++ b/lib/functions/cli/commands.sh
@@ -20,14 +20,16 @@ function armbian_register_commands() {
 		["requirements"]="requirements" # implemented in cli_requirements_pre_run and cli_requirements_run
 
 		# Given a board/config/exts, dump out the (non-userspace) JSON of configuration
-		["configdump"]="config_dump_json"       # implemented in cli_config_dump_json_pre_run and cli_config_dump_json_run
-		["config-dump-json"]="config_dump_json" # implemented in cli_config_dump_json_pre_run and cli_config_dump_json_run
+		["configdump"]="config_dump_json"          # implemented in cli_config_dump_json_pre_run and cli_config_dump_json_run
+		["config-dump"]="config_dump_json"         # implemented in cli_config_dump_json_pre_run and cli_config_dump_json_run
+		["config-dump-json"]="config_dump_json"    # implemented in cli_config_dump_json_pre_run and cli_config_dump_json_run
+		["config-dump-no-json"]="config_dump_json" # implemented in cli_config_dump_json_pre_run and cli_config_dump_json_run
 
-		["inventory"]="json_info" # implemented in cli_json_info_pre_run and cli_json_info_run
-		["targets"]="json_info"   # implemented in cli_json_info_pre_run and cli_json_info_run
-		["gha-matrix"]="json_info"    # implemented in cli_json_info_pre_run and cli_json_info_run
-		["gha-workflow"]="json_info"  # implemented in cli_json_info_pre_run and cli_json_info_run
-		["gha-template"]="json_info"  # implemented in cli_json_info_pre_run and cli_json_info_run
+		["inventory"]="json_info"    # implemented in cli_json_info_pre_run and cli_json_info_run
+		["targets"]="json_info"      # implemented in cli_json_info_pre_run and cli_json_info_run
+		["gha-matrix"]="json_info"   # implemented in cli_json_info_pre_run and cli_json_info_run
+		["gha-workflow"]="json_info" # implemented in cli_json_info_pre_run and cli_json_info_run
+		["gha-template"]="json_info" # implemented in cli_json_info_pre_run and cli_json_info_run
 
 		["kernel-patches-to-git"]="patch_kernel" # implemented in cli_patch_kernel_pre_run and cli_patch_kernel_run
 

--- a/lib/functions/main/start-end.sh
+++ b/lib/functions/main/start-end.sh
@@ -145,8 +145,14 @@ function produce_repeat_args_array() {
 	# get the sorted keys of the repeat_params associative array into an array
 	declare -a repeat_params_keys_sorted=($(printf '%s\0' "${!repeat_params[@]}" | sort -z | xargs -0 -n 1 printf '%s\n'))
 
-	for param_name in "${repeat_params_keys_sorted[@]}"; do         # add sorted repeat_params to repeat_args
-		repeat_args+=("${param_name}=${repeat_params[${param_name}]}") # could add @Q here, but it's not necessary
+	for param_name in "${repeat_params_keys_sorted[@]}"; do # add sorted repeat_params to repeat_args
+		declare repeat_value="${repeat_params[${param_name}]}"
+		# does it contain spaces? if so, quote it.
+		if [[ "${repeat_value}" =~ [[:space:]] ]]; then
+			repeat_args+=("${param_name}=${repeat_value@Q}") # quote
+		else
+			repeat_args+=("${param_name}=${repeat_value}")
+		fi
 	done
 
 	return 0

--- a/lib/tools/aggregation.py
+++ b/lib/tools/aggregation.py
@@ -49,8 +49,7 @@ USERPATCHES_PATH = armbian_utils.get_from_env_or_bomb("USERPATCHES_PATH")
 armbian_utils.show_incoming_environment()
 
 util.SELECTED_CONFIGURATION = armbian_utils.get_from_env_or_bomb("SELECTED_CONFIGURATION")  # "cli_standard"
-util.DESKTOP_APPGROUPS_SELECTED = armbian_utils.parse_env_for_tokens(
-	"DESKTOP_APPGROUPS_SELECTED")  # ["browsers", "chat"]
+util.DESKTOP_APPGROUPS_SELECTED = armbian_utils.parse_env_for_tokens("DESKTOP_APPGROUPS_SELECTED")  # ["browsers", "chat"]
 util.SRC = armbian_build_directory
 
 util.AGGREGATION_SEARCH_ROOT_ABSOLUTE_DIRS = [
@@ -194,6 +193,10 @@ with open(output_file, "w") as bash, SummarizedMarkdownWriter("aggregation.md", 
 	for id, name, value, extra_func in output_lists:
 		stats = util.prepare_bash_output_array_for_list(bash, md, name, value, extra_func)
 		md.add_summary(f"{id}: {stats['number_items']}")
+
+	# extra: if DESKTOP, add number of DESKTOP_APPGROUPS_SELECTED to the summary
+	if BUILD_DESKTOP:
+		md.add_summary(f"desktop_appgroups: {len(util.DESKTOP_APPGROUPS_SELECTED)}")
 
 	# The rootfs hash (md5) is used as a cache key.
 	bash.write(f"declare -g -r AGGREGATED_ROOTFS_HASH='{AGGREGATED_ROOTFS_HASH}'\n")  # (this done simply cos it has no newlines)

--- a/lib/tools/common/armbian_utils.py
+++ b/lib/tools/common/armbian_utils.py
@@ -16,9 +16,10 @@ import multiprocessing
 import os
 import re
 import subprocess
+import sys
 from pathlib import Path
 
-import sys
+REGEX_WHITESPACE_LINEBREAK_COMMA_SEMICOLON = r"[\s,;\n]+"
 
 ARMBIAN_CONFIG_REGEX_KERNEL_TARGET = r"^([export |declare -g]+)?KERNEL_TARGET=\"(.*)\""
 
@@ -32,8 +33,9 @@ def parse_env_for_tokens(env_name):
 	if val is None:
 		return result
 	# tokenize val; split by whitespace, line breaks, commas, and semicolons.
+	tokens = re.split(REGEX_WHITESPACE_LINEBREAK_COMMA_SEMICOLON, val)
 	# trim whitespace from tokens.
-	return [token for token in [token.strip() for token in (val.split())] if token != ""]
+	return [token for token in [token.strip() for token in (tokens)] if token != ""]
 
 
 def get_from_env(env_name):

--- a/lib/tools/common/armbian_utils.py
+++ b/lib/tools/common/armbian_utils.py
@@ -205,10 +205,12 @@ def armbian_get_all_boards_inventory():
 	return info_for_board
 
 
-def map_to_armbian_params(map_params):
+def map_to_armbian_params(map_params, quote_params=False) -> list[str]:
 	ret = []
 	for param in map_params:
 		ret.append(param + "=" + map_params[param])
+	if quote_params:
+		ret = ["'" + param + "'" for param in ret]  # single-quote each param...
 	return ret
 
 

--- a/lib/tools/info/output-gha-matrix.py
+++ b/lib/tools/info/output-gha-matrix.py
@@ -92,7 +92,7 @@ def generate_matrix_images(info) -> list[dict]:
 		image_arch = image['out']['ARCH']
 		runs_on = resolve_gha_runner_tags_via_pipeline_gha_config(inputs, "image", image_arch)
 
-		cmds = (armbian_utils.map_to_armbian_params(inputs["vars"]) + inputs["configs"])  # image build is "build" command, omitted here
+		cmds = (armbian_utils.map_to_armbian_params(inputs["vars"], True) + inputs["configs"])  # image build is "build" command, omitted here
 		invocation = " ".join(cmds)
 
 		item = {"desc": desc, "runs_on": runs_on, "invocation": invocation}
@@ -123,7 +123,7 @@ def generate_matrix_artifacts(info):
 
 		runs_on = resolve_gha_runner_tags_via_pipeline_gha_config(inputs, artifact_name, artifact_arch)
 
-		cmds = (["artifact"] + armbian_utils.map_to_armbian_params(inputs["vars"]) + inputs["configs"])
+		cmds = (["artifact"] + armbian_utils.map_to_armbian_params(inputs["vars"], True) + inputs["configs"])
 		invocation = " ".join(cmds)
 
 		item = {"desc": desc, "runs_on": runs_on, "invocation": invocation}

--- a/lib/tools/info/output-gha-workflow.py
+++ b/lib/tools/info/output-gha-workflow.py
@@ -154,7 +154,7 @@ for artifact_id in info["artifacts"]:
 		runs_on = ["self-hosted", "Linux", "alfa"]
 
 	inputs = artifact['in']['original_inputs']
-	cmds = (["artifact"] + armbian_utils.map_to_armbian_params(inputs["vars"]) + inputs["configs"])
+	cmds = (["artifact"] + armbian_utils.map_to_armbian_params(inputs["vars"], True) + inputs["configs"])
 	invocation = " ".join(cmds)
 
 	item = {"desc": desc, "runs_on": runs_on, "invocation": invocation}
@@ -195,7 +195,7 @@ for image_id in info["images"]:
 		runs_on = ["self-hosted", "Linux", f"image-{image_arch}"]
 
 	inputs = image['in']
-	cmds = (armbian_utils.map_to_armbian_params(inputs["vars"]) + inputs["configs"])  # image build is "build" command, omitted here
+	cmds = (armbian_utils.map_to_armbian_params(inputs["vars"], True) + inputs["configs"])  # image build is "build" command, omitted here
 	invocation = " ".join(cmds)
 
 	iJob: ImageJob = ImageJob(f"image-{image_id}", f"{desc}")


### PR DESCRIPTION
#### rpardini's fight with space-containing PARAMs - early May/'23

> Turns out @mhoffrog  was right, repeat build params need escaping. This simple rabbit goes down a hole that spans the JSON `config-dump` output, the pipeline JSON parsing, and the GHA matrix encoding. Phew.

- pipeline: correctly quote params passed over pure strings (eg in the GHA JSON matrixes) so values with spaces are not mangled
- `bash_declare_parser`: parse space-separated single-quoted array values correctly ('THIS=has space' is a single token, not two)
- `aggregation`: `armbian_utils.parse_env_for_tokens()` now actually does what it said on the box "split by whitespace, line breaks, commas, and semicolons"; add appgroups summary
- `artifact-rootfs`: add desktop info (environment, config_name, appgroups) to `artifact_version_reason` (so we can debug when I mess up later)
- `configdump`: alias `config-dump`, `config-dump-json` and new `config-dump-no-json` (bash declare format)
- `produce_repeat_args_array`: @mhoffrog was right, we need to quote repeat params; (here I'm being stubborn and only quoting the ones that have spaces in them)

