### PR TITLE
Limit Action Script execution to main branch only

### DIFF
--- a/.github/workflows/build-board-list.yml
+++ b/.github/workflows/build-board-list.yml
@@ -3,6 +3,7 @@ on:
   push:
     paths:
       - 'config/boards/*.*'
+    branches: [ main ]
 
 jobs:
 


### PR DESCRIPTION
# Description

When boards are changes listen only to branch "main" as we don't want to trigger this elsewhere.

Jira reference number [AR-1664]

# How Has This Been Tested?

No need

[AR-1664]: https://armbian.atlassian.net/browse/AR-1664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ