### PR TITLE
fix rock4 boards uboot spi image creating

### DIFF
--- a/config/boards/rockpi-4a.conf
+++ b/config/boards/rockpi-4a.conf
@@ -6,5 +6,6 @@ KERNEL_TARGET="legacy,current,edge"
 FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
 BOOT_FDT_FILE="rockchip/rk3399-rock-pi-4a.dtb"
+BOOT_SCENARIO="tpl-spl-blob"
 BOOT_SUPPORT_SPI=yes
 DDR_BLOB="rk33/rk3399_ddr_933MHz_v1.20.bin"

--- a/config/boards/rockpi-4b.conf
+++ b/config/boards/rockpi-4b.conf
@@ -6,6 +6,7 @@ KERNEL_TARGET="legacy,current,edge"
 FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
 BOOT_FDT_FILE="rockchip/rk3399-rock-pi-4b.dtb"
+BOOT_SCENARIO="tpl-spl-blob"
 BOOT_SUPPORT_SPI=yes
 DDR_BLOB="rk33/rk3399_ddr_933MHz_v1.20.bin"
 

--- a/config/boards/rockpi-4bplus.csc
+++ b/config/boards/rockpi-4bplus.csc
@@ -6,5 +6,6 @@ KERNEL_TARGET="edge"
 FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
 BOOT_FDT_FILE="rockchip/rk3399-rock-pi-4b-plus.dtb"
+BOOT_SCENARIO="tpl-spl-blob"
 BOOT_SUPPORT_SPI=yes
 DDR_BLOB="rk33/rk3399_ddr_933MHz_v1.25.bin"

--- a/config/boards/rockpi-4c.conf
+++ b/config/boards/rockpi-4c.conf
@@ -6,6 +6,7 @@ KERNEL_TARGET="legacy,current,edge"
 FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
 BOOT_FDT_FILE="rockchip/rk3399-rock-pi-4c.dtb"
+BOOT_SCENARIO="tpl-spl-blob"
 BOOT_SUPPORT_SPI=yes
 
 function post_family_tweaks_bsp__rockpi-4c_BSP() {

--- a/config/boards/rockpi-4cplus.csc
+++ b/config/boards/rockpi-4cplus.csc
@@ -6,4 +6,5 @@ KERNEL_TARGET="current,edge"
 FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
 BOOT_FDT_FILE="rockchip/rk3399-rock-pi-4c-plus.dtb"
+BOOT_SCENARIO="tpl-spl-blob"
 BOOT_SUPPORT_SPI=yes


### PR DESCRIPTION
# Description
https://github.com/armbian/build/commit/5dee9ee935703a559992478fa8045b464af72b50#commitcomment-111988535
Rockpi4 is using BL31 blobs to build uboot, so it should get configed with BOOT_SCENARIO="tpl-spl-blob".
If BOOT_SCENARIO is not declared it will be only-blobs by default, which will not build tpl/u-boot-tpl.bin and spl/u-boot-spl.bin needed by spi image creating.
So it's better to declare BOOT_SCENARIO="tpl-spl-blob" just like rockpro64. I don't have rock4 board so someone has to confirm this fix.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] uboot build successfully for rockpi 4a/4b/4c/4bplus/4cplus
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
