### PR TITLE
Fix `pinecube` boot

### DIFF
--- a/config/bootenv/sun8i-v3s.txt
+++ b/config/bootenv/sun8i-v3s.txt
@@ -1,0 +1,5 @@
+verbosity=1
+bootlogo=false
+console=both
+disp_mode=1920x1080p60
+fdt_addr_r=0x41900000

--- a/config/sources/families/sun8i-v3s.conf
+++ b/config/sources/families/sun8i-v3s.conf
@@ -9,6 +9,7 @@
 source "${BASH_SOURCE%/*}/include/sunxi_common.inc"
 
 OVERLAY_PREFIX='sun8i-v3s'
+declare -g BOOTENV_FILE='sun8i-v3s.txt'
 
 family_tweaks_bsp_s() {
 	mkdir -p $destination/etc/default


### PR DESCRIPTION
# Description

https://forum.armbian.com/topic/28197-pinecube-error-fdt-image-overlaps-os-image/
Attempt to implement suggested fix to allow `pinecube` booting.

Basically the new `bootenv` file is a copy from `sunxi.txt` with an additional line. If there is a better way to implement this feel free to adjust as needed.

# How Has This Been Tested?

- [x] Build on arm64 using artifacts
- [x] Build on arm64 without artifacts
- [ ] Boot test not possible due to lack of hw

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
