### PR TITLE
`rockchip64`/`edge`/`6.3`: rebase/rewrite patches against `v6.3.1`

### DIFF
--- a/patch/kernel/archive/rockchip64-6.3/add-board-Z28-PRO-as-link-to-Rock64.patch
+++ b/patch/kernel/archive/rockchip64-6.3/add-board-Z28-PRO-as-link-to-Rock64.patch
@@ -1,22 +1,21 @@
-From d1fb54e1292f2896fc7e485ee13ef2a8a7e87bb5 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Igor Pecovnik <igor.pecovnik@gmail.com>
 Date: Sat, 14 Nov 2020 18:47:08 +0100
-Subject: [PATCH] Add Z28 PRO as link to Rock64
+Subject: Add Z28 PRO as link to Rock64
 
 Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
 ---
  arch/arm64/boot/dts/rockchip/rk3328-z28pro.dts | 1 +
  1 file changed, 1 insertion(+)
- create mode 120000 arch/arm64/boot/dts/rockchip/rk3328-z28pro.dts
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328-z28pro.dts b/arch/arm64/boot/dts/rockchip/rk3328-z28pro.dts
 new file mode 120000
-index 000000000..69752a370
+index 000000000000..69752a370163
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-z28pro.dts
 @@ -0,0 +1 @@
 +rk3328-rock64.dts
 \ No newline at end of file
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/add-board-helios64.patch
+++ b/patch/kernel/archive/rockchip64-6.3/add-board-helios64.patch
@@ -1,37 +1,75 @@
-From 8f81af6941883fdc1d238d85bf282c2a61ffa349 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Aditya Prayoga <aditya@kobol.io>
 Date: Tue, 15 Sep 2020 20:04:22 +0700
-Subject: [PATCH] Add board Helios64
+Subject: Add board Helios64
+
+note: rpardini: this patch was rebased on top of 6.3.1, finally admitting
+that it used to blindly overwrite the mainline dts (it was added when helios64
+was not in the tree, and thus a "file addition"). the resulting patch
+is the complete set of changes actually done.
 
 Signed-off-by: Aditya Prayoga <aditya@kobol.io>
 ---
- .../boot/dts/rockchip/rk3399-kobol-helios64.dts     | 1084 +++++++++++++++++
- 2 files changed, 1085 insertions(+)
- create mode 100644 arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts
+ arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts | 996 +++++++---
+ 1 file changed, 764 insertions(+), 232 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts b/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts
-new file mode 100644
-index 000000000..fae17f416
---- /dev/null
+index 1eb287a3f8c0..ac0da7b7f43c 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts
-@@ -0,0 +1,1154 @@
-+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
-+/*
+@@ -1,53 +1,37 @@
+ // SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+ /*
+- * Copyright (c) 2020 Aditya Prayoga <aditya@kobol.io>
+- */
+-
+-/*
+- * The Kobol Helios64 is a board designed to operate as a NAS and optionally
+- * ships with an enclosing that can host five 2.5" hard disks.
+- *
+- * See https://wiki.kobol.io/helios64/intro/ for further details.
 + * Copyright (c) 2020 Aditya Prayoga (aditya@kobol.io)
-+ */
-+
-+/dts-v1/;
+  */
+ 
+ /dts-v1/;
 +#include <dt-bindings/input/linux-event-codes.h>
 +#include <dt-bindings/pwm/pwm.h>
 +#include <dt-bindings/input/input.h>
 +#include <dt-bindings/usb/pd.h>
-+#include "rk3399.dtsi"
-+#include "rk3399-opp.dtsi"
-+
-+/ {
+ #include "rk3399.dtsi"
+ #include "rk3399-opp.dtsi"
+ 
+ / {
+-	model = "Kobol Helios64";
 +	model = "Helios64";
-+	compatible = "kobol,helios64", "rockchip,rk3399";
-+
+ 	compatible = "kobol,helios64", "rockchip,rk3399";
+ 
+-	aliases {
+-		mmc0 = &sdmmc;
+-		mmc1 = &sdhci;
+-		spi1 = &spi1;
+-		spi2 = &spi2;
+-		spi5 = &spi5;
+-	};
+-
+-	avdd_0v9_s0: avdd-0v9-s0 {
+-		compatible = "regulator-fixed";
+-		regulator-name = "avdd_0v9_s0";
+-		regulator-always-on;
+-		regulator-boot-on;
+-		regulator-min-microvolt = <900000>;
+-		regulator-max-microvolt = <900000>;
+-		vin-supply = <&vcc1v8_sys_s3>;
+-	};
+-
+-	avdd_1v8_s0: avdd-1v8-s0 {
+-		compatible = "regulator-fixed";
+-		regulator-name = "avdd_1v8_s0";
+-		regulator-always-on;
+-		regulator-boot-on;
+-		regulator-min-microvolt = <1800000>;
+-		regulator-max-microvolt = <1800000>;
+-		vin-supply = <&vcc3v3_sys_s3>;
 +	adc-keys {
 +		compatible = "adc-keys";
 +		io-channels = <&saradc 1>;
@@ -44,20 +82,32 @@ index 000000000..fae17f416
 +			linux,code = <BTN_1>;
 +			press-threshold-microvolt = <100000>;
 +		};
-+	};
-+
+ 	};
+ 
+-	chosen {
+-		stdout-path = "serial2:1500000n8";
 +	beeper: beeper {
 +		compatible = "gpio-beeper";
 +		gpios = <&gpio4 RK_PD3 GPIO_ACTIVE_HIGH>;
-+	};
-+
-+	clkin_gmac: external-gmac-clock {
-+		compatible = "fixed-clock";
-+		clock-frequency = <125000000>;
-+		clock-output-names = "clkin_gmac";
-+		#clock-cells = <0>;
-+	};
-+
+ 	};
+ 
+ 	clkin_gmac: external-gmac-clock {
+@@ -57,107 +41,86 @@ clkin_gmac: external-gmac-clock {
+ 		#clock-cells = <0>;
+ 	};
+ 
+-	fan1 {
+-		/* fan connected to P7 */
+-		compatible = "pwm-fan";
+-		pwms = <&pwm0 0 40000 0>;
+-		cooling-levels = <0 80 170 255>;
+-	};
+-
+-	fan2 {
+-		/* fan connected to P6 */
+-		compatible = "pwm-fan";
+-		pwms = <&pwm1 0 40000 0>;
+-		cooling-levels = <0 80 170 255>;
 +	vcc12v_dcin: vcc12v-dcin {
 +		compatible = "regulator-fixed";
 +		regulator-name = "vcc12v_dcin";
@@ -65,8 +115,24 @@ index 000000000..fae17f416
 +		regulator-boot-on;
 +		regulator-min-microvolt = <12000000>;
 +		regulator-max-microvolt = <12000000>;
-+	};
-+
+ 	};
+ 
+-	leds {
+-		compatible = "gpio-leds";
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&sys_grn_led_on &sys_red_led_on>;
+-
+-		led-0 {
+-			label = "helios64:green:status";
+-			gpios = <&gpio0 RK_PB4 GPIO_ACTIVE_HIGH>;
+-			default-state = "on";
+-		};
+-
+-		led-1 {
+-			label = "helios64:red:fault";
+-			gpios = <&gpio0 RK_PB5 GPIO_ACTIVE_HIGH>;
+-			default-state = "keep";
+-		};
 +	vcc12v_dcin_bkup: vcc12v-dcin-bkup {
 +		compatible = "regulator-fixed";
 +		regulator-name = "vcc12v_dcin_bkup";
@@ -75,85 +141,116 @@ index 000000000..fae17f416
 +		regulator-min-microvolt = <12000000>;
 +		regulator-max-microvolt = <12000000>;
 +		vin-supply = <&vcc12v_dcin>;
-+	};
-+
+ 	};
+ 
+-	hdd_a_power: hdd-a-power {
 +	vcc12v_hdd: vcc12v-hdd {
-+		compatible = "regulator-fixed";
+ 		compatible = "regulator-fixed";
+-		enable-active-high;
+-		gpio = <&gpio1 RK_PA0 GPIO_ACTIVE_HIGH>;
+-		pinctrl-0 = <&hdd_a_power_en>;
+-		pinctrl-names = "default";
 +		regulator-name = "vcc12v_hdd";
-+		regulator-always-on;
-+		regulator-boot-on;
+ 		regulator-always-on;
+ 		regulator-boot-on;
+-		regulator-name = "hdd_a_power";
+-		startup-delay-us = <2000000>;
 +		regulator-min-microvolt = <12000000>;
 +		regulator-max-microvolt = <12000000>;
 +		vin-supply = <&vcc12v_dcin_bkup>;
-+	};
-+
+ 	};
+ 
+-	hdd_b_power: hdd-b-power {
 +	/* switched by pmic_sleep */
 +	vcc1v8_sys_s0: vcc1v8-sys-s0 {
-+		compatible = "regulator-fixed";
+ 		compatible = "regulator-fixed";
+-		enable-active-high;
+-		gpio = <&gpio1 RK_PA1 GPIO_ACTIVE_HIGH>;
+-		pinctrl-0 = <&hdd_b_power_en>;
+-		pinctrl-names = "default";
 +		regulator-name = "vcc1v8_sys_s0";
-+		regulator-always-on;
-+		regulator-boot-on;
+ 		regulator-always-on;
+ 		regulator-boot-on;
+-		regulator-name = "hdd_b_power";
+-		startup-delay-us = <2000000>;
 +		regulator-min-microvolt = <1800000>;
 +		regulator-max-microvolt = <1800000>;
 +		vin-supply = <&vcc1v8_sys_s3>;
-+	};
-+
+ 	};
+ 
+-	pcie_power: pcie-power {
 +	vcc0v9_s3: vcc0v9-s3 {
-+		compatible = "regulator-fixed";
+ 		compatible = "regulator-fixed";
+-		enable-active-high;
+-		gpio = <&gpio1 RK_PD0 GPIO_ACTIVE_HIGH>;
+-		pinctrl-0 = <&pcie_pwr>;
+-		pinctrl-names = "default";
 +		regulator-name = "vcc0v9_s3";
 +		regulator-always-on;
-+		regulator-boot-on;
+ 		regulator-boot-on;
+-		regulator-name = "pcie_power";
+-		startup-delay-us = <10000>;
+-		vin-supply = <&vcc5v0_perdev>;
 +		regulator-min-microvolt = <900000>;
 +		regulator-max-microvolt = <900000>;
 +		vin-supply = <&vcc3v3_sys_s3>;
-+	};
-+
+ 	};
+ 
+-	usblan_power: usblan-power {
 +	avdd_0v9_s0: avdd-0v9-s0 {
-+		compatible = "regulator-fixed";
+ 		compatible = "regulator-fixed";
+-		enable-active-high;
+-		gpio = <&gpio1 RK_PC7 GPIO_ACTIVE_HIGH>;
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&usb_lan_en>;
+-		regulator-name = "usblan_power";
 +		regulator-name = "avdd_0v9_s0";
-+		regulator-always-on;
-+		regulator-boot-on;
+ 		regulator-always-on;
+ 		regulator-boot-on;
+-		vin-supply = <&vcc5v0_usb>;
 +		regulator-min-microvolt = <900000>;
 +		regulator-max-microvolt = <900000>;
 +		vin-supply = <&vcc1v8_sys_s3>;
-+	};
-+
+ 	};
+ 
+-	vcc1v8_sys_s0: vcc1v8-sys-s0 {
 +	avdd_1v8_s0: avdd-1v8-s0 {
-+		compatible = "regulator-fixed";
+ 		compatible = "regulator-fixed";
+-		regulator-name = "vcc1v8_sys_s0";
 +		regulator-name = "avdd_1v8_s0";
-+		regulator-always-on;
-+		regulator-boot-on;
-+		regulator-min-microvolt = <1800000>;
-+		regulator-max-microvolt = <1800000>;
+ 		regulator-always-on;
+ 		regulator-boot-on;
+ 		regulator-min-microvolt = <1800000>;
+ 		regulator-max-microvolt = <1800000>;
+-		vin-supply = <&vcc1v8_sys_s3>;
 +		vin-supply = <&vcc3v3_sys_s3>;
-+	};
-+
+ 	};
+ 
+-	vcc3v0_sd: vcc3v0-sd {
 +	pcie_power: pcie-power {
-+		compatible = "regulator-fixed";
-+		enable-active-high;
+ 		compatible = "regulator-fixed";
+ 		enable-active-high;
+-		gpio = <&gpio0 RK_PA1 GPIO_ACTIVE_HIGH>;
+-		regulator-name = "vcc3v0_sd";
+-		regulator-boot-on;
+-		regulator-min-microvolt = <3000000>;
+-		regulator-max-microvolt = <3000000>;
 +		gpio = <&gpio1 RK_PD0 GPIO_ACTIVE_HIGH>;
-+		pinctrl-names = "default";
+ 		pinctrl-names = "default";
+-		pinctrl-0 = <&sdmmc0_pwr_h>;
+-		vin-supply = <&vcc3v3_sys_s3>;
 +		pinctrl-0 = <&pcie_pwr_en>;
 +		regulator-name = "pcie_power";
 +		regulator-boot-on;
 +		startup-delay-us = <10000>;
 +		vin-supply = <&vcc5v0_perdev>;
-+	};
-+
-+	vcc3v3_sys_s3: vcc_lan: vcc3v3-sys-s3 {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc3v3_sys_s3";
-+		regulator-always-on;
-+		regulator-boot-on;
-+		regulator-min-microvolt = <3300000>;
-+		regulator-max-microvolt = <3300000>;
-+		vin-supply = <&vcc5v0_sys>;
-+
-+		regulator-state-mem {
-+			regulator-on-in-suspend;
-+		};
-+	};
-+
+ 	};
+ 
+ 	vcc3v3_sys_s3: vcc_lan: vcc3v3-sys-s3 {
+@@ -174,6 +137,39 @@ regulator-state-mem {
+ 		};
+ 	};
+ 
 +	vcc3v0_sd: vcc3v0-sd {
 +		compatible = "regulator-fixed";
 +		regulator-name = "vcc3v0_sd";
@@ -187,16 +284,13 @@ index 000000000..fae17f416
 +		vin-supply = <&vcc5v0_usb>;
 +	};
 +
-+	vcc5v0_perdev: vcc5v0-perdev {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc5v0_perdev";
-+		regulator-always-on;
-+		regulator-boot-on;
-+		regulator-min-microvolt = <5000000>;
-+		regulator-max-microvolt = <5000000>;
-+		vin-supply = <&vcc12v_dcin_bkup>;
-+	};
-+
+ 	vcc5v0_perdev: vcc5v0-perdev {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vcc5v0_perdev";
+@@ -184,6 +180,16 @@ vcc5v0_perdev: vcc5v0-perdev {
+ 		vin-supply = <&vcc12v_dcin_bkup>;
+ 	};
+ 
 +	vcc5v0_hdd: vcc5v0-hdd {
 +		compatible = "regulator-fixed";
 +		regulator-name = "vcc5v0_hdd";
@@ -207,20 +301,14 @@ index 000000000..fae17f416
 +		vin-supply = <&vcc12v_dcin_bkup>;
 +	};
 +
-+	vcc5v0_sys: vcc5v0-sys {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc5v0_sys";
-+		regulator-always-on;
-+		regulator-boot-on;
-+		regulator-min-microvolt = <5000000>;
-+		regulator-max-microvolt = <5000000>;
-+		vin-supply = <&vcc12v_dcin_bkup>;
-+
-+		regulator-state-mem {
-+			regulator-on-in-suspend;
-+		};
-+	};
-+
+ 	vcc5v0_sys: vcc5v0-sys {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vcc5v0_sys";
+@@ -198,68 +204,213 @@ regulator-state-mem {
+ 		};
+ 	};
+ 
+-	vcc5v0_usb: vcc5v0-usb {
 +	vdd_log: vdd-log {
 +		compatible = "pwm-regulator";
 +		pwms = <&pwm2 0 25000 1>;
@@ -237,39 +325,66 @@ index 000000000..fae17f416
 +	};
 +
 +	power_hdd_a: power-hdd-a {
-+		compatible = "regulator-fixed";
-+		enable-active-high;
+ 		compatible = "regulator-fixed";
+ 		enable-active-high;
+-		gpio = <&gpio1 RK_PC6 GPIO_ACTIVE_HIGH>;
 +		gpio = <&gpio1 RK_PA0 GPIO_ACTIVE_HIGH>;
-+		pinctrl-names = "default";
+ 		pinctrl-names = "default";
+-		pinctrl-0 = <&vcc5v0_usb_en>;
+-		regulator-name = "vcc5v0_usb";
 +		pinctrl-0 = <&hdd_a_power>;
 +		regulator-name = "power_hdd_a";
-+		regulator-always-on;
-+		regulator-boot-on;
-+	};
-+
+ 		regulator-always-on;
+ 		regulator-boot-on;
+-		regulator-min-microvolt = <5000000>;
+-		regulator-max-microvolt = <5000000>;
+-		vin-supply = <&vcc5v0_perdev>;
+ 	};
+ 
+-	vcc12v_dcin: vcc12v-dcin {
 +	power_hdd_b: power-hdd-b {
-+		compatible = "regulator-fixed";
+ 		compatible = "regulator-fixed";
+-		regulator-name = "vcc12v_dcin";
 +		enable-active-high;
 +		gpio = <&gpio1 RK_PA1 GPIO_ACTIVE_HIGH>;
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&hdd_b_power>;
 +		regulator-name = "power_hdd_b";
-+		regulator-always-on;
-+		regulator-boot-on;
-+	};
-+
+ 		regulator-always-on;
+ 		regulator-boot-on;
+-		regulator-min-microvolt = <12000000>;
+-		regulator-max-microvolt = <12000000>;
+ 	};
+ 
+-	vcc12v_dcin_bkup: vcc12v-dcin-bkup {
 +	usblan_power: usblan-power {
-+		compatible = "regulator-fixed";
+ 		compatible = "regulator-fixed";
+-		regulator-name = "vcc12v_dcin_bkup";
 +		enable-active-high;
 +		gpio = <&gpio1 RK_PC7 GPIO_ACTIVE_HIGH>;
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&usb_lan_en>;
 +		regulator-name = "usblan_power";
-+		regulator-always-on;
-+		regulator-boot-on;
+ 		regulator-always-on;
+ 		regulator-boot-on;
+-		regulator-min-microvolt = <12000000>;
+-		regulator-max-microvolt = <12000000>;
+-		vin-supply = <&vcc12v_dcin>;
 +		vin-supply = <&vcc5v0_usb>;
-+	};
-+
+ 	};
+-};
+ 
+-/*
+- * The system doesn't run stable with cpu freq enabled, so disallow the lower
+- * frequencies until this problem is properly understood and resolved.
+- */
+-&cluster0_opp {
+-	/delete-node/ opp00;
+-	/delete-node/ opp01;
+-	/delete-node/ opp02;
+-	/delete-node/ opp03;
+-	/delete-node/ opp04;
+-};
 +	fan1: p7-fan {
 +		compatible = "pwm-fan";
 +		pwms = <&pwm0 0 40000 0>;
@@ -278,7 +393,16 @@ index 000000000..fae17f416
 +		#cooling-cells = <2>;
 +		cooling-levels = <0 80 170 255>;
 +	};
-+
+ 
+-&cluster1_opp {
+-	/delete-node/ opp00;
+-	/delete-node/ opp01;
+-	/delete-node/ opp02;
+-	/delete-node/ opp03;
+-	/delete-node/ opp04;
+-	/delete-node/ opp05;
+-	/delete-node/ opp06;
+-};
 +	fan2: p6-fan {
 +		compatible = "pwm-fan";
 +		pwms = <&pwm1 0 40000 0>;
@@ -287,7 +411,9 @@ index 000000000..fae17f416
 +		#cooling-cells = <2>;
 +		cooling-levels = <0 80 170 255>;
 +	};
-+
+ 
+-&cpu_b0 {
+-	cpu-supply = <&vdd_cpu_b>;
 +	gpio-charger {
 +		compatible = "gpio-charger";
 +		charger-type = "mains";
@@ -422,30 +548,21 @@ index 000000000..fae17f416
 +			mode = <0x23>;
 +		};
 +	};
-+};
-+
+ };
+ 
+-&cpu_b1 {
+-	cpu-supply = <&vdd_cpu_b>;
 +&cdn_dp {
 +	status = "okay";
 +	extcon = <&fusb0>;
 +	phys = <&tcphy0_dp>;
-+};
-+
-+&cpu_l0 {
-+	cpu-supply = <&vdd_cpu_l>;
-+};
-+
-+&cpu_l1 {
-+	cpu-supply = <&vdd_cpu_l>;
-+};
-+
-+&cpu_l2 {
-+	cpu-supply = <&vdd_cpu_l>;
-+};
-+
-+&cpu_l3 {
-+	cpu-supply = <&vdd_cpu_l>;
-+};
-+
+ };
+ 
+ &cpu_l0 {
+@@ -278,23 +429,36 @@ &cpu_l3 {
+ 	cpu-supply = <&vdd_cpu_l>;
+ };
+ 
 +&cpu_b0 {
 +	cpu-supply = <&vdd_cpu_b>;
 +};
@@ -454,21 +571,27 @@ index 000000000..fae17f416
 +	cpu-supply = <&vdd_cpu_b>;
 +};
 +
-+&emmc_phy {
-+	status = "okay";
-+};
-+
-+&gmac {
-+	assigned-clocks = <&cru SCLK_RMII_SRC>;
+ &emmc_phy {
+ 	status = "okay";
+ };
+ 
+ &gmac {
+-	assigned-clock-parents = <&clkin_gmac>;
+ 	assigned-clocks = <&cru SCLK_RMII_SRC>;
 +	assigned-clock-parents = <&clkin_gmac>;
-+	clock_in_out = "input";
-+	phy-supply = <&vcc_lan>;
+ 	clock_in_out = "input";
+-	phy-mode = "rgmii";
+ 	phy-supply = <&vcc_lan>;
 +	phy-mode = "rgmii";
-+	pinctrl-names = "default";
+ 	pinctrl-names = "default";
+-	pinctrl-0 = <&rgmii_pins &gphy_reset>;
+-	rx_delay = <0x20>;
+-	tx_delay = <0x28>;
 +	pinctrl-0 = <&rgmii_pins &rgmii_phy_reset>;
 +	snps,reset-gpio = <&gpio3 RK_PB7 GPIO_ACTIVE_LOW>;
-+	snps,reset-active-low;
-+	snps,reset-delays-us = <0 10000 50000>;
+ 	snps,reset-active-low;
+ 	snps,reset-delays-us = <0 10000 50000>;
+-	snps,reset-gpio = <&gpio3 RK_PB7 GPIO_ACTIVE_LOW>;
 +	tx_delay = <0x28>;
 +	rx_delay = <0x20>;
 +	status = "okay";
@@ -476,41 +599,34 @@ index 000000000..fae17f416
 +
 +&gpu {
 +	mali-supply = <&vdd_gpu>;
-+	status = "okay";
-+};
-+
-+&i2c0 {
-+	clock-frequency = <400000>;
-+	i2c-scl-rising-time-ns = <168>;
-+	i2c-scl-falling-time-ns = <4>;
-+	status = "okay";
-+
-+	rk808: pmic@1b {
-+		compatible = "rockchip,rk808";
-+		reg = <0x1b>;
+ 	status = "okay";
+ };
+ 
+@@ -307,12 +471,15 @@ &i2c0 {
+ 	rk808: pmic@1b {
+ 		compatible = "rockchip,rk808";
+ 		reg = <0x1b>;
 +		#clock-cells = <1>;
 +		clock-output-names = "xin32k", "rk808-clkout2";
-+		interrupt-parent = <&gpio0>;
-+		interrupts = <10 IRQ_TYPE_LEVEL_LOW>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&pmic_int_l>;
-+		rockchip,system-power-controller;
+ 		interrupt-parent = <&gpio0>;
+ 		interrupts = <10 IRQ_TYPE_LEVEL_LOW>;
+-		clock-output-names = "xin32k", "rk808-clkout2";
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&pmic_int_l>;
+ 		rockchip,system-power-controller;
 +		wakeup-source;
 +
-+		vcc1-supply = <&vcc5v0_sys>;
-+		vcc2-supply = <&vcc5v0_sys>;
-+		vcc3-supply = <&vcc5v0_sys>;
-+		vcc4-supply = <&vcc5v0_sys>;
-+		vcc6-supply = <&vcc5v0_sys>;
-+		vcc7-supply = <&vcc5v0_sys>;
-+		vcc8-supply = <&vcc3v3_sys_s3>;
-+		vcc9-supply = <&vcc5v0_sys>;
-+		vcc10-supply = <&vcc5v0_sys>;
-+		vcc11-supply = <&vcc5v0_sys>;
-+		vcc12-supply = <&vcc3v3_sys_s3>;
-+		vddio-supply = <&vcc3v0_s3>;
-+
-+		regulators {
+ 		vcc1-supply = <&vcc5v0_sys>;
+ 		vcc2-supply = <&vcc5v0_sys>;
+ 		vcc3-supply = <&vcc5v0_sys>;
+@@ -325,10 +492,21 @@ rk808: pmic@1b {
+ 		vcc11-supply = <&vcc5v0_sys>;
+ 		vcc12-supply = <&vcc3v3_sys_s3>;
+ 		vddio-supply = <&vcc3v0_s3>;
+-		wakeup-source;
+-		#clock-cells = <1>;
+ 
+ 		regulators {
 +			vdd_center: DCDC_REG1 {
 +				regulator-name = "vdd_center";
 +				regulator-always-on;
@@ -524,18 +640,19 @@ index 000000000..fae17f416
 +				};
 +			};
 +
-+			vdd_cpu_l: DCDC_REG2 {
-+				regulator-name = "vdd_cpu_l";
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-min-microvolt = <750000>;
-+				regulator-max-microvolt = <1350000>;
-+				regulator-ramp-delay = <6001>;
-+				regulator-state-mem {
-+					regulator-off-in-suspend;
-+				};
-+			};
-+
+ 			vdd_cpu_l: DCDC_REG2 {
+ 				regulator-name = "vdd_cpu_l";
+ 				regulator-always-on;
+@@ -336,19 +514,48 @@ vdd_cpu_l: DCDC_REG2 {
+ 				regulator-min-microvolt = <750000>;
+ 				regulator-max-microvolt = <1350000>;
+ 				regulator-ramp-delay = <6001>;
+-
+ 				regulator-state-mem {
+ 					regulator-off-in-suspend;
+ 				};
+ 			};
+ 
 +			vcc_ddr_s3: DCDC_REG3 {
 +				regulator-name = "vcc_ddr_s3";
 +				regulator-always-on;
@@ -545,12 +662,12 @@ index 000000000..fae17f416
 +				};
 +			};
 +
-+			vcc1v8_sys_s3: DCDC_REG4 {
-+				regulator-name = "vcc1v8_sys_s3";
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-min-microvolt = <1800000>;
-+				regulator-max-microvolt = <1800000>;
+ 			vcc1v8_sys_s3: DCDC_REG4 {
+ 				regulator-name = "vcc1v8_sys_s3";
+ 				regulator-always-on;
+ 				regulator-boot-on;
+ 				regulator-min-microvolt = <1800000>;
+ 				regulator-max-microvolt = <1800000>;
 +				regulator-state-mem {
 +					regulator-on-in-suspend;
 +					regulator-suspend-microvolt = <1800000>;
@@ -566,31 +683,27 @@ index 000000000..fae17f416
 +			vcc3v0_touch: LDO_REG2 {
 +				regulator-name = "vcc3v0_touch";
 +			};
-+
+ 
 +			vcc1v8_s3: LDO_REG3 {
 +				regulator-name = "vcc1v8_s3";
 +				regulator-always-on;
 +				regulator-boot-on;
 +				regulator-min-microvolt = <1800000>;
 +				regulator-max-microvolt = <1800000>;
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <1800000>;
-+				};
-+			};
-+
-+			vcc_sdio_s0: LDO_REG4 {
-+				regulator-name = "vcc_sdio_s0";
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-min-microvolt = <1800000>;
-+				regulator-max-microvolt = <3000000>;
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <3000000>;
-+				};
-+			};
-+
+ 				regulator-state-mem {
+ 					regulator-on-in-suspend;
+ 					regulator-suspend-microvolt = <1800000>;
+@@ -361,25 +568,61 @@ vcc_sdio_s0: LDO_REG4 {
+ 				regulator-boot-on;
+ 				regulator-min-microvolt = <1800000>;
+ 				regulator-max-microvolt = <3000000>;
+-
+ 				regulator-state-mem {
+ 					regulator-on-in-suspend;
+ 					regulator-suspend-microvolt = <3000000>;
+ 				};
+ 			};
+ 
 +			/* not used */
 +			vcca3v0_codec: LDO_REG5 {
 +				regulator-name = "vcca3v0_codec";
@@ -613,17 +726,18 @@ index 000000000..fae17f416
 +				regulator-name = "vcca1v8_codec";
 +			};
 +
-+			vcc3v0_s3: LDO_REG8 {
-+				regulator-name = "vcc3v0_s3";
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-min-microvolt = <3000000>;
-+				regulator-max-microvolt = <3000000>;
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <3000000>;
-+				};
-+			};
+ 			vcc3v0_s3: LDO_REG8 {
+ 				regulator-name = "vcc3v0_s3";
+ 				regulator-always-on;
+ 				regulator-boot-on;
+ 				regulator-min-microvolt = <3000000>;
+ 				regulator-max-microvolt = <3000000>;
+-
+ 				regulator-state-mem {
+ 					regulator-on-in-suspend;
+ 					regulator-suspend-microvolt = <3000000>;
+ 				};
+ 			};
 +
 +			vcc3v3_sys_s0: SWITCH_REG1 {
 +				regulator-name = "vcc3v3_sys_s0";
@@ -640,21 +754,21 @@ index 000000000..fae17f416
 +			vcc3v3_s0: SWITCH_REG2 {
 +				regulator-name = "vcc3v3_s0";
 +			};
-+		};
-+	};
-+
-+	vdd_cpu_b: regulator@40 {
-+		compatible = "silergy,syr827";
-+		reg = <0x40>;
-+		fcs,suspend-voltage-selector = <1>;
+ 		};
+ 	};
+ 
+@@ -387,12 +630,33 @@ vdd_cpu_b: regulator@40 {
+ 		compatible = "silergy,syr827";
+ 		reg = <0x40>;
+ 		fcs,suspend-voltage-selector = <1>;
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&vsel1_gpio>;
-+		regulator-name = "vdd_cpu_b";
+ 		regulator-name = "vdd_cpu_b";
 +		regulator-min-microvolt = <712500>;
 +		regulator-max-microvolt = <1500000>;
 +		regulator-ramp-delay = <40000>;
-+		regulator-always-on;
-+		regulator-boot-on;
+ 		regulator-always-on;
+ 		regulator-boot-on;
 +		vin-supply = <&vcc5v0_sys>;
 +
 +		regulator-state-mem {
@@ -669,25 +783,18 @@ index 000000000..fae17f416
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&vsel2_gpio>;
 +		regulator-name = "vdd_gpu";
-+		regulator-min-microvolt = <712500>;
-+		regulator-max-microvolt = <1500000>;
-+		regulator-ramp-delay = <1000>;
+ 		regulator-min-microvolt = <712500>;
+ 		regulator-max-microvolt = <1500000>;
+ 		regulator-ramp-delay = <1000>;
 +		regulator-always-on;
 +		regulator-boot-on;
-+		vin-supply = <&vcc5v0_sys>;
-+
-+		regulator-state-mem {
-+			regulator-off-in-suspend;
-+		};
-+	};
-+};
-+
-+&i2c2 {
-+	clock-frequency = <400000>;
-+	i2c-scl-rising-time-ns = <160>;
-+	i2c-scl-falling-time-ns = <30>;
-+	status = "okay";
-+
+ 		vin-supply = <&vcc5v0_sys>;
+ 
+ 		regulator-state-mem {
+@@ -407,56 +671,222 @@ &i2c2 {
+ 	i2c-scl-falling-time-ns = <30>;
+ 	status = "okay";
+ 
 +	gpio-expander@20 {
 +		compatible = "nxp,pca9555";
 +		reg = <0x20>;
@@ -702,12 +809,18 @@ index 000000000..fae17f416
 +		vcc-supply = <&vcc3v3_sys_s3>;
 +	};
 +
-+	temp@4c {
+ 	temp@4c {
+-		compatible = "national,lm75";
 +		compatible = "onnn,lm75";
-+		reg = <0x4c>;
-+	};
-+};
-+
+ 		reg = <0x4c>;
+ 	};
+ };
+ 
+-&io_domains {
+-	audio-supply = <&vcc1v8_sys_s0>;
+-	bt656-supply = <&vcc1v8_sys_s0>;
+-	gpio1830-supply = <&vcc3v0_s3>;
+-	sdmmc-supply = <&vcc_sdio_s0>;
 +&i2c4 {
 +	clock-frequency = <400000>;
 +	i2c-scl-rising-time-ns = <160>;
@@ -765,9 +878,10 @@ index 000000000..fae17f416
 +
 +/* I2C on UEXT */
 +&i2c7 {
-+	status = "okay";
-+};
-+
+ 	status = "okay";
+ };
+ 
+-&pcie_phy {
 +/* External I2C */
 +&i2c8 {
 +	status = "okay";
@@ -775,9 +889,9 @@ index 000000000..fae17f416
 +
 +&i2s2 {
 +	#sound-dai-cells = <0>;
-+	status = "okay";
-+};
-+
+ 	status = "okay";
+ };
+ 
 +&io_domains {
 +	status = "okay";
 +	bt656-supply = <&vcc1v8_sys_s0>;
@@ -786,24 +900,27 @@ index 000000000..fae17f416
 +	gpio1830-supply = <&vcc3v0_s3>;
 +};
 +
-+&pcie0 {
-+	ep-gpios = <&gpio2 RK_PD4 GPIO_ACTIVE_HIGH>;
-+	num-lanes = <2>;
+ &pcie0 {
+ 	ep-gpios = <&gpio2 RK_PD4 GPIO_ACTIVE_HIGH>;
+-	max-link-speed = <2>;
+ 	num-lanes = <2>;
 +	max-link-speed = <2>;
-+	pinctrl-names = "default";
+ 	pinctrl-names = "default";
+-	status = "okay";
+-
 +	pinctrl-0 = <&pcie_prst &pcie_clkreqn_cpm>;
-+	vpcie12v-supply = <&vcc12v_dcin>;
-+	vpcie3v3-supply = <&pcie_power>;
-+	vpcie1v8-supply = <&avdd_1v8_s0>;
-+	vpcie0v9-supply = <&avdd_0v9_s0>;
+ 	vpcie12v-supply = <&vcc12v_dcin>;
+ 	vpcie3v3-supply = <&pcie_power>;
+ 	vpcie1v8-supply = <&avdd_1v8_s0>;
+ 	vpcie0v9-supply = <&avdd_0v9_s0>;
 +	status = "okay";
 +};
 +
 +&pcie_phy {
 +	status = "okay";
-+};
-+
-+&pinctrl {
+ };
+ 
+ &pinctrl {
 +	buttons {
 +		pwrbtn: pwrbtn {
 +			rockchip,pins = <0 RK_PA5 RK_FUNC_GPIO &pcfg_pull_up>;
@@ -846,14 +963,18 @@ index 000000000..fae17f416
 +		};
 +	};
 +
-+	gmac {
+ 	gmac {
+-		gphy_reset: gphy-reset {
+-			rockchip,pins = <3 RK_PB7 RK_FUNC_GPIO &pcfg_output_low>;
 +		rgmii_phy_reset: rgmii-phy-reset {
 +			rockchip,pins =
 +				<3 RK_PB7 RK_FUNC_GPIO &pcfg_output_low>;
-+		};
-+	};
-+
-+	leds {
+ 		};
+ 	};
+ 
+ 	leds {
+-		sys_grn_led_on: sys-grn-led-on {
+-			rockchip,pins = <0 RK_PB4 RK_FUNC_GPIO &pcfg_pull_down>;
 +		network_act: network-act {
 +			rockchip,pins =
 +				<0 RK_PA4 RK_FUNC_GPIO &pcfg_pull_down>;
@@ -889,28 +1010,32 @@ index 000000000..fae17f416
 +		pca0_pins: pca0-pins {
 +			rockchip,pins =
 +				<0 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+
+ 		};
+ 
+-		sys_red_led_on: sys-red-led-on {
+-			rockchip,pins = <0 RK_PB5 RK_FUNC_GPIO &pcfg_pull_down>;
 +		wake_on_lan: wake-on-lan {
 +			rockchip,pins =
 +				<0 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+
-+	pcie {
+ 		};
+ 	};
+ 
+ 	pcie {
+-		pcie_pwr: pcie-pwr {
 +		pcie_prst: pcie-prst {
 +			rockchip,pins =
 +				<2 RK_PD4 RK_FUNC_GPIO &pcfg_pull_none>;
 +		};
 +
 +		pcie_pwr_en: pcie-pwr-en {
-+			rockchip,pins =
-+				<1 RK_PD0 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+
-+	pmic {
-+		pmic_int_l: pmic-int-l {
+ 			rockchip,pins =
+ 				<1 RK_PD0 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+@@ -464,31 +894,45 @@ pcie_pwr: pcie-pwr {
+ 
+ 	pmic {
+ 		pmic_int_l: pmic-int-l {
+-			rockchip,pins = <0 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
 +			rockchip,pins =
 +				<0 RK_PB2 RK_FUNC_GPIO &pcfg_pull_up>;
 +		};
@@ -923,47 +1048,58 @@ index 000000000..fae17f416
 +		vsel2_gpio: vsel2-gpio {
 +			rockchip,pins =
 +				<1 RK_PB6 RK_FUNC_GPIO &pcfg_pull_down>;
-+		};
-+	};
-+
+ 		};
+ 	};
+ 
+-	power {
+-		hdd_a_power_en: hdd-a-power-en {
+-			rockchip,pins = <1 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
 +	power  {
 +		hdd_a_power: hdd-a-power {
 +			rockchip,pins =
 +				<1 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+
+ 		};
+ 
+-		hdd_b_power_en: hdd-b-power-en {
+-			rockchip,pins = <1 RK_PA1 RK_FUNC_GPIO &pcfg_pull_none>;
 +		hdd_b_power: hdd-b-power {
 +			rockchip,pins =
 +				<1 RK_PA1 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+
-+		vcc5v0_usb_en: vcc5v0-usb-en {
+ 		};
+ 
+ 		vcc5v0_usb_en: vcc5v0-usb-en {
+-			rockchip,pins = <1 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
 +			rockchip,pins =
 +				<1 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+
+ 		};
+ 
+-		usb_lan_en: usb-lan-en {
+-			rockchip,pins = <1 RK_PC7 RK_FUNC_GPIO &pcfg_pull_none>;
 +		sdmmc0_pwr_h: sdmmc0-pwr-h {
 +			rockchip,pins =
 +				<0 RK_PA1 RK_FUNC_GPIO &pcfg_output_high>;
-+		};
-+
+ 		};
+-	};
+ 
+-	vcc3v0-sd {
+-		sdmmc0_pwr_h: sdmmc0-pwr-h {
+-			rockchip,pins = <0 RK_PA1 RK_FUNC_GPIO &pcfg_pull_up>;
 +		usb_lan_en: usb-lan-en {
 +			rockchip,pins =
 +				<1 RK_PC7 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+};
-+
-+&pmu_io_domains {
-+	pmu1830-supply = <&vcc3v0_s3>;
-+	status = "okay";
-+};
-+
-+&pwm0 {
-+	status = "okay";
-+};
-+
-+&pwm1 {
+ 		};
+ 	};
+ };
+@@ -499,28 +943,46 @@ &pmu_io_domains {
+ };
+ 
+ &pwm0 {
+-	/* pwm-fan on P7 */
+ 	status = "okay";
+ };
+ 
+ &pwm1 {
+-	/* pwm-fan on P6 */
 +	status = "okay";
 +};
 +
@@ -977,49 +1113,53 @@ index 000000000..fae17f416
 +
 +&saradc {
 +	vref-supply = <&vcc1v8_s3>;
-+	status = "okay";
-+};
-+
-+&sdhci {
+ 	status = "okay";
+ };
+ 
+ &sdhci {
 +	assigned-clock-rates = <150000000>;
-+	bus-width = <8>;
-+	mmc-hs200-1_8v;
+ 	bus-width = <8>;
+ 	mmc-hs200-1_8v;
 +	// hs400 is broken on Helios64 since 5.10.60
 +	// mmc-hs400-1_8v;
 +	// mmc-hs400-enhanced-strobe;
 +	supports-emmc;
-+	non-removable;
+ 	non-removable;
+-	vqmmc-supply = <&vcc1v8_sys_s0>;
 +	disable-wp;
-+	status = "okay";
+ 	status = "okay";
 +	vqmmc-supply = <&vcc1v8_sys_s0>;
-+};
-+
-+&sdmmc {
-+	bus-width = <4>;
-+	cap-sd-highspeed;
+ };
+ 
+ &sdmmc {
+ 	bus-width = <4>;
+ 	cap-sd-highspeed;
+-	cd-gpios = <&gpio0 RK_PA7 GPIO_ACTIVE_LOW>;
 +	cd-gpios = <&gpio0 RK_PA7 GPIO_ACTIVE_LOW>; // TODO: verify what needs to be done to use implicit CD definition
-+	disable-wp;
+ 	disable-wp;
 +	sd-uhs-sdr104;
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&sdmmc_clk &sdmmc_cmd &sdmmc_cd &sdmmc_bus4>;
-+	vmmc-supply = <&vcc3v0_sd>;
-+	vqmmc-supply = <&vcc_sdio_s0>;
-+	status = "okay";
-+};
-+
-+&spi1 {
-+	status = "okay";
-+};
-+
-+/* UEXT connector */
-+&spi2 {
-+	status = "okay";
-+};
-+
-+&spi5 {
-+	status = "okay";
-+};
-+
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&sdmmc_clk &sdmmc_cmd &sdmmc_cd &sdmmc_bus4>;
+ 	vmmc-supply = <&vcc3v0_sd>;
+@@ -530,14 +992,6 @@ &sdmmc {
+ 
+ &spi1 {
+ 	status = "okay";
+-
+-	spiflash: flash@0 {
+-		compatible = "jedec,spi-nor";
+-		reg = <0x0>;
+-		spi-max-frequency = <25000000>;
+-		status = "okay";
+-		m25p,fast-read;
+-	};
+ };
+ 
+ /* UEXT connector */
+@@ -549,8 +1003,28 @@ &spi5 {
+ 	status = "okay";
+ };
+ 
 +&tcphy0 {
 +	extcon = <&fusb0>;
 +	status = "okay";
@@ -1041,29 +1181,29 @@ index 000000000..fae17f416
 +	};
 +};
 +
-+&tcphy1 {
-+	status = "okay";
-+};
-+
-+&tsadc {
-+	/* tshut mode 0:CRU 1:GPIO */
-+	rockchip,hw-tshut-mode = <1>;
-+	/* tshut polarity 0:LOW 1:HIGH */
-+	rockchip,hw-tshut-polarity = <1>;
-+	status = "okay";
-+};
-+
+ &tcphy1 {
+-	/* phy for &usbdrd_dwc3_1 */
+ 	status = "okay";
+ };
+ 
+@@ -562,61 +1036,119 @@ &tsadc {
+ 	status = "okay";
+ };
+ 
+-&u2phy1 {
 +&u2phy0 {
-+	status = "okay";
-+
+ 	status = "okay";
+ 
+-	otg-port {
+-		/* phy for &usbdrd_dwc3_1 */
 +	u2phy0_otg: otg-port {
 +		status = "okay";
 +	};
 +
 +	u2phy0_host: host-port {
-+		phy-supply = <&vcc5v0_usb>;
-+		status = "okay";
-+	};
+ 		phy-supply = <&vcc5v0_usb>;
+ 		status = "okay";
+ 	};
 +
 +	port {
 +		u2phy0_typec_hs: endpoint {
@@ -1084,12 +1224,12 @@ index 000000000..fae17f416
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&uart0_xfer>;
 +	status = "okay";
-+};
-+
-+&uart2 {
-+	status = "okay";
-+};
-+
+ };
+ 
+ &uart2 {
+ 	status = "okay";
+ };
+ 
 +&usb_host0_ehci {
 +	status = "okay";
 +};
@@ -1107,10 +1247,13 @@ index 000000000..fae17f416
 +	dr_mode = "otg";
 +};
 +
-+&usbdrd3_1 {
-+	status = "okay";
+ &usbdrd3_1 {
+ 	status = "okay";
 +};
-+
+ 
+-	usb@fe900000 {
+-		dr_mode = "host";
+-		status = "okay";
 +&usbdrd_dwc3_1 {
 +	status = "okay";
 +	dr_mode = "host";
@@ -1121,38 +1264,63 @@ index 000000000..fae17f416
 +	int_hub: hub@1 {
 +		compatible = "usb2109,0815";
 +		reg = <1>;
-+		#address-cells = <1>;
-+		#size-cells = <0>;
-+
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+ 
+-		hub@1 {
+-			compatible = "usb2109,0815";
 +		int_hub_port1: port@1 {
-+			reg = <1>;
+ 			reg = <1>;
+-			#address-cells = <1>;
+-			#size-cells = <0>;
 +			#trigger-source-cells = <0>;
 +		};
-+
+ 
+-			port@1 {
+-				reg = <1>;
+-				#trigger-source-cells = <0>;
+-			};
 +		int_hub_port2: port@2 {
 +			reg = <2>;
 +			#trigger-source-cells = <0>;
 +		};
-+
+ 
+-			port@2 {
+-				reg = <2>;
+-				#trigger-source-cells = <0>;
+-			};
 +		int_hub_port3: port@3 {
 +			reg = <3>;
 +			#trigger-source-cells = <0>;
 +		};
-+
+ 
+-			port@3 {
+-				reg = <3>;
+-				#trigger-source-cells = <0>;
+-			};
 +		usb_lan: device@4 {
 +			compatible = "usbbda,8156";
 +			reg = <4>;
-+
+ 
+-			device@4 {
+-				compatible = "usbbda,8156";
+-				reg = <4>;
+-				#address-cells = <2>;
+-				#size-cells = <0>;
 +			#address-cells = <2>;
 +			#size-cells = <0>;
-+
+ 
+-				interface@0 {	/* interface 0 of configuration 1 */
+-					compatible = "usbbda,8156.config1.0";
+-					reg = <0 1>;
+-				};
 +			interface@0 {	/* interface 0 of configuration 1 */
 +				compatible = "usbbda,8156.config1.0";
 +				reg = <0 1>;
-+			};
-+		};
-+	};
-+};
+ 			};
+ 		};
+ 	};
+ };
 +
 +&vopb {
 +	status = "okay";
@@ -1170,6 +1338,6 @@ index 000000000..fae17f416
 +	status = "okay";
 +};
 \ No newline at end of file
---
-Created with Armbian build tools https://github.com/armbian/build
+-- 
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/add-board-nanopi-m4v2.patch
+++ b/patch/kernel/archive/rockchip64-6.3/add-board-nanopi-m4v2.patch
@@ -1,6 +1,145 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Piotr Szczepanik <piter75@gmail.com>
+Date: Thu, 28 Nov 2019 22:29:54 +0000
+Subject: [ARCHEOLOGY] Initial addition of NanoPi M4V2
+
+> X-Git-Archeology: - Revision c4eecbcef0d4dc499baf0155449e71dc774bc7c4: https://github.com/armbian/build/commit/c4eecbcef0d4dc499baf0155449e71dc774bc7c4
+> X-Git-Archeology:   Date: Thu, 28 Nov 2019 22:29:54 +0000
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Initial addition of NanoPi M4V2
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 5438468273da3e2af1de167cc72cf56823b8f51d: https://github.com/armbian/build/commit/5438468273da3e2af1de167cc72cf56823b8f51d
+> X-Git-Archeology:   Date: Sun, 29 Dec 2019 22:13:43 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Tweaked rx_delay to 0x16 for NanoPi M4V2 in current/dev (#1698)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 83cf87922b93cb27e03a59e6c4121c7d99bb41c4: https://github.com/armbian/build/commit/83cf87922b93cb27e03a59e6c4121c7d99bb41c4
+> X-Git-Archeology:   Date: Fri, 07 Feb 2020 22:21:01 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: FDT file configurable per board
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 75d0f64e3d75e7c34466871b9723ef1a238609d8: https://github.com/armbian/build/commit/75d0f64e3d75e7c34466871b9723ef1a238609d8
+> X-Git-Archeology:   Date: Fri, 17 Apr 2020 21:30:37 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rk3399 to u-boot v2020.04 (#1873)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 5a2b2c360b9c26ca4bd0d309af7cd3994fd08b7d: https://github.com/armbian/build/commit/5a2b2c360b9c26ca4bd0d309af7cd3994fd08b7d
+> X-Git-Archeology:   Date: Sun, 03 May 2020 19:15:46 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Prepare rockchip64 for switch to mainline u-boot and switched ROCK Pi 4 (#1934)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 88a585a3fe56bf9eb8c1df8993fe34830597ca77: https://github.com/armbian/build/commit/88a585a3fe56bf9eb8c1df8993fe34830597ca77
+> X-Git-Archeology:   Date: Sat, 18 Jul 2020 00:06:01 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Update mainline u-boot for rockchip64 / rk3399 to v2020.07 (#2086)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6e4078974bcf69c5e49bb78b920d52d62dc29f6b: https://github.com/armbian/build/commit/6e4078974bcf69c5e49bb78b920d52d62dc29f6b
+> X-Git-Archeology:   Date: Sun, 19 Jul 2020 00:07:03 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Adjusted patches for rockchip64 mainline u-boot (fuzzines, upstreamed file)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 1432a5cb96dc7dc290e48879de897af59bb954cb: https://github.com/armbian/build/commit/1432a5cb96dc7dc290e48879de897af59bb954cb
+> X-Git-Archeology:   Date: Mon, 14 Dec 2020 23:57:57 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Consolidate all dts Makefile changes in a single patch in rockchip64-dev
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 2a3c216d4107ddf30abadc6ba3c5707c1fa59ff2: https://github.com/armbian/build/commit/2a3c216d4107ddf30abadc6ba3c5707c1fa59ff2
+> X-Git-Archeology:   Date: Mon, 04 Jan 2021 01:02:20 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switched rockchip64/rk3399 to u-boot v2020.10 (#2512)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 18cf7aff702832cf672117f5dc1fe4ad37598837: https://github.com/armbian/build/commit/18cf7aff702832cf672117f5dc1fe4ad37598837
+> X-Git-Archeology:   Date: Tue, 05 Jan 2021 23:35:03 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Consolidate all dts Makefile changes in a single patch in rockchip64-current (#2535)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision a6ee913fae3afc7ae74bb1fdaf1f571ec30493ac: https://github.com/armbian/build/commit/a6ee913fae3afc7ae74bb1fdaf1f571ec30493ac
+> X-Git-Archeology:   Date: Tue, 02 Mar 2021 21:07:22 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: NanoPi M4V2 stability fix for current and dev (#2663)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0cdffb29b07305209efb12cf3b5ac6032d3a1153: https://github.com/armbian/build/commit/0cdffb29b07305209efb12cf3b5ac6032d3a1153
+> X-Git-Archeology:   Date: Wed, 24 Mar 2021 19:01:53 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Renaming DEV branch to EDGE (#2704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e7377248b3cae186e24e2be781cd3365b43246f0: https://github.com/armbian/build/commit/e7377248b3cae186e24e2be781cd3365b43246f0
+> X-Git-Archeology:   Date: Thu, 22 Jul 2021 00:15:54 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Second part of EDGE bumping to 5.13.y (#3045)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 744ea89a589d62cb6f409baab60fc6664520bc39: https://github.com/armbian/build/commit/744ea89a589d62cb6f409baab60fc6664520bc39
+> X-Git-Archeology:   Date: Wed, 08 Sep 2021 17:51:34 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bumping EDGE kernel to 5.14.y (#3125)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 86abac1fd4e169712a44d245cf7adef4ee17c420: https://github.com/armbian/build/commit/86abac1fd4e169712a44d245cf7adef4ee17c420
+> X-Git-Archeology:   Date: Tue, 26 Oct 2021 22:14:41 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Cleanup u-boot configurations for rockchip64 derivatives (#3150)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e: https://github.com/armbian/build/commit/dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e
+> X-Git-Archeology:   Date: Tue, 09 Nov 2021 18:06:34 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump imx6, xu4, rockchip64 and jetson-nano to 5.15 (#3238)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 71ff7b3b989dcb7e86b7e1c00a408a2f53744ea0: https://github.com/armbian/build/commit/71ff7b3b989dcb7e86b7e1c00a408a2f53744ea0
+> X-Git-Archeology:   Date: Thu, 11 Nov 2021 23:49:52 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switched rockchip64 u-boot to v2021.07 (#3233)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 26437e36c18bb09484f4150e396a1784cc6471b7: https://github.com/armbian/build/commit/26437e36c18bb09484f4150e396a1784cc6471b7
+> X-Git-Archeology:   Date: Thu, 16 Jun 2022 12:27:05 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switched rockchip64 u-boot to v2022.04 (#3871)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 2813365dd25e3ad110936cbf014b95b38d7090ec: https://github.com/armbian/build/commit/2813365dd25e3ad110936cbf014b95b38d7090ec
+> X-Git-Archeology:   Date: Mon, 07 Nov 2022 21:29:00 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Move known non working rockhip64 boards to previous boot loader (#4392)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3399-nanopi-m4v2.dts | 78 ++++++++++
+ 1 file changed, 78 insertions(+)
+
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-nanopi-m4v2.dts b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-m4v2.dts
 new file mode 100644
-index 000000000..60358ab8c
+index 000000000000..3ac64b5a7b14
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-m4v2.dts
 @@ -0,0 +1,78 @@
@@ -82,3 +221,6 @@ index 000000000..60358ab8c
 +	regulator-always-on;
 +	vin-supply = <&vdd_5v>;
 +};
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/add-board-nanopi-neo3-with-enabled-I2S-and-spdif.patch
+++ b/patch/kernel/archive/rockchip64-6.3/add-board-nanopi-neo3-with-enabled-I2S-and-spdif.patch
@@ -1,13 +1,16 @@
-From 3d8e4be5ff1783dffc6cad7d69f06366e0eb5d6c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Igor Pecovnik <igor.pecovnik@gmail.com>
 Date: Mon, 7 Sep 2020 21:21:55 +0200
-Subject: [PATCH] Add Nanopi Neo3 with enabled I2S and spdif
+Subject: Add Nanopi Neo3 with enabled I2S and spdif
 
 Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
 ---
+ arch/arm64/boot/dts/rockchip/rk3328-nanopi-neo3-rev02.dts | 195 ++++++++++
+ 1 file changed, 195 insertions(+)
+
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328-nanopi-neo3-rev02.dts b/arch/arm64/boot/dts/rockchip/rk3328-nanopi-neo3-rev02.dts
 new file mode 100644
-index 000000000..bf0a625fe
+index 000000000000..496e334d3030
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-nanopi-neo3-rev02.dts
 @@ -0,0 +1,195 @@
@@ -206,6 +209,6 @@ index 000000000..bf0a625fe
 +    pinctl-0 = <&uart1_xfer>;
 +};
 +
---
-Created with Armbian build tools https://github.com/armbian/build
+-- 
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/add-board-nanopi-r2c.patch
+++ b/patch/kernel/archive/rockchip64-6.3/add-board-nanopi-r2c.patch
@@ -1,6 +1,62 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "Ruikai (Rick) Liu" <rickliu2000@outlook.com>
+Date: Wed, 15 Sep 2021 22:20:35 +0200
+Subject: [ARCHEOLOGY] Add NanoPi R2C support (#3138)
+
+> X-Git-Archeology: > recovered message: > * Add NanoPi R2C support
+> X-Git-Archeology: > recovered message: > * Bring NanoPi R2C, R2S to edge
+> X-Git-Archeology: - Revision 687c3639183e23e06406739af1684fdeb3efa454: https://github.com/armbian/build/commit/687c3639183e23e06406739af1684fdeb3efa454
+> X-Git-Archeology:   Date: Wed, 15 Sep 2021 22:20:35 +0200
+> X-Git-Archeology:   From: Ruikai (Rick) Liu <rickliu2000@outlook.com>
+> X-Git-Archeology:   Subject: Add NanoPi R2C support (#3138)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e: https://github.com/armbian/build/commit/dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e
+> X-Git-Archeology:   Date: Tue, 09 Nov 2021 18:06:34 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump imx6, xu4, rockchip64 and jetson-nano to 5.15 (#3238)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3328-nanopi-r2-rev06.dts | 89 ++++++++++
+ 1 file changed, 89 insertions(+)
+
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328-nanopi-r2-rev06.dts b/arch/arm64/boot/dts/rockchip/rk3328-nanopi-r2-rev06.dts
 new file mode 100644
-index 000000000000..6322f59939b8
+index 000000000000..21be5a2c5030
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-nanopi-r2-rev06.dts
 @@ -0,0 +1,89 @@
@@ -93,3 +149,6 @@ index 000000000000..6322f59939b8
 +		};
 +	};
 +};
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/add-board-nanopi-r2s.patch
+++ b/patch/kernel/archive/rockchip64-6.3/add-board-nanopi-r2s.patch
@@ -1,19 +1,17 @@
-From f051544daa4dd8039b30f9a10ee509a65ba26147 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
 Date: Sat, 7 Jan 2023 11:59:47 +0000
-Subject: [PATCH] rockchip64: consolidate nanopi r2s device trees
+Subject: rockchip64: consolidate nanopi r2s device trees
 
 ---
- .../dts/rockchip/rk3328-nanopi-r2-rev00.dts   | 126 +++++
- .../dts/rockchip/rk3328-nanopi-r2-rev20.dts   |  39 ++
- .../boot/dts/rockchip/rk3328-nanopi-r2s.dts   | 493 ++++++++++++------
+ arch/arm64/boot/dts/rockchip/rk3328-nanopi-r2-rev00.dts | 126 +++
+ arch/arm64/boot/dts/rockchip/rk3328-nanopi-r2-rev20.dts |  39 +
+ arch/arm64/boot/dts/rockchip/rk3328-nanopi-r2s.dts      | 493 ++++++----
  3 files changed, 490 insertions(+), 168 deletions(-)
- create mode 100644 arch/arm64/boot/dts/rockchip/rk3328-nanopi-r2-rev00.dts
- create mode 100644 arch/arm64/boot/dts/rockchip/rk3328-nanopi-r2-rev20.dts
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328-nanopi-r2-rev00.dts b/arch/arm64/boot/dts/rockchip/rk3328-nanopi-r2-rev00.dts
 new file mode 100644
-index 00000000000..8ba95189c03
+index 000000000000..8ba95189c031
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-nanopi-r2-rev00.dts
 @@ -0,0 +1,126 @@
@@ -145,7 +143,7 @@ index 00000000000..8ba95189c03
 +};
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328-nanopi-r2-rev20.dts b/arch/arm64/boot/dts/rockchip/rk3328-nanopi-r2-rev20.dts
 new file mode 100644
-index 00000000000..ad327ca5685
+index 000000000000..ad327ca56858
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-nanopi-r2-rev20.dts
 @@ -0,0 +1,39 @@
@@ -189,7 +187,7 @@ index 00000000000..ad327ca5685
 +	};
 +};
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328-nanopi-r2s.dts b/arch/arm64/boot/dts/rockchip/rk3328-nanopi-r2s.dts
-index 1445b879ac7..7fff7ef89d9 100644
+index 1445b879ac7a..7fff7ef89d9f 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3328-nanopi-r2s.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-nanopi-r2s.dts
 @@ -1,118 +1,166 @@
@@ -908,7 +906,6 @@ index 1445b879ac7..7fff7ef89d9 100644
 -&usb_host0_ohci {
 -	status = "okay";
 -};
-
---
-2.34.1
+-- 
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/add-board-nanopi-r4s.patch
+++ b/patch/kernel/archive/rockchip64-6.3/add-board-nanopi-r4s.patch
@@ -1,14 +1,14 @@
-From baad3620b42d91baa729b6f5c959657b93e76bda Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
 Date: Sat, 7 Jan 2023 12:09:38 +0000
-Subject: [PATCH] rockchip64: consolidate nanopi-r4s dts patch
+Subject: rockchip64: consolidate nanopi-r4s dts patch
 
 ---
- .../boot/dts/rockchip/rk3399-nanopi-r4s.dts   | 149 ++++++++++--------
+ arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts | 149 ++++++----
  1 file changed, 86 insertions(+), 63 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts
-index fe5b5261001..41bd45763d2 100644
+index fe5b52610010..41bd45763d2e 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts
 @@ -1,15 +1,7 @@
@@ -224,5 +224,5 @@ index fe5b5261001..41bd45763d2 100644
 +	status = "disabled";
 +};
 -- 
-2.34.1
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/add-board-orangepi-4-lts.patch
+++ b/patch/kernel/archive/rockchip64-6.3/add-board-orangepi-4-lts.patch
@@ -1,6 +1,188 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor.pecovnik@gmail.com>
+Date: Sat, 11 Aug 2018 23:12:58 +0200
+Subject: [ARCHEOLOGY] Initial support for RK3399 Firefly and FriendlyARM PC T4
+
+> X-Git-Archeology: > recovered message: > Based on work of David Huang https://github.com/hjc4869 Changed in the transition:
+> X-Git-Archeology: > recovered message: > - firefly family was renamed to rk3399, which we actually never started to use. It was made for Odroid N1, which will never be sold
+> X-Git-Archeology: > recovered message: > - adjusted compiler toolchain2 parameter
+> X-Git-Archeology: > recovered message: > - added standard wireless drivers
+> X-Git-Archeology: > recovered message: > - kernel config with the following changes: Docker dependencies, ZRAM, CPUfreq info, ...
+> X-Git-Archeology: > recovered message: > - added upstream patches
+> X-Git-Archeology: > recovered message: > - made test Ubuntu Bionic desktop and CLI Stretch build, bootlog: http://ix.io/1jVu
+> X-Git-Archeology: > recovered message: > TBD: wifi and BT support, mainline kernel, ...
+> X-Git-Archeology: - Revision 6d82a8974872ee261006d2cdf6726b7d13df5032: https://github.com/armbian/build/commit/6d82a8974872ee261006d2cdf6726b7d13df5032
+> X-Git-Archeology:   Date: Sat, 11 Aug 2018 23:12:58 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igor.pecovnik@gmail.com>
+> X-Git-Archeology:   Subject: Initial support for RK3399 Firefly and FriendlyARM PC T4
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0fd231be0063a5631628571956635f2787e94b47: https://github.com/armbian/build/commit/0fd231be0063a5631628571956635f2787e94b47
+> X-Git-Archeology:   Date: Thu, 30 Aug 2018 21:24:59 +0800
+> X-Git-Archeology:   From: Jingchuan Huang <hjc@hjc.im>
+> X-Git-Archeology:   Subject: Add NanoPi M4/NEO4 device tree.
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 18215550b367919c1b270185e110b901e2843edd: https://github.com/armbian/build/commit/18215550b367919c1b270185e110b901e2843edd
+> X-Git-Archeology:   Date: Sat, 20 Oct 2018 04:04:59 +0000
+> X-Git-Archeology:   From: 5kft <5kft@users.noreply.github.com>
+> X-Git-Archeology:   Subject: [rk3399-dev] added support for the status_led, set default to heartbeat
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision f18360d1ef5d6487392ff4079301bca97945e704: https://github.com/armbian/build/commit/f18360d1ef5d6487392ff4079301bca97945e704
+> X-Git-Archeology:   Date: Wed, 24 Oct 2018 17:03:35 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igor.pecovnik@gmail.com>
+> X-Git-Archeology:   Subject: [rk3399-dev] Merging rk3399-DEV with rockchip64-DEV on sources, patches and config level. Leave family intact, add 1.5 OPP for RK3328, add upstream patch for rk3399-default
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 758db7522a4480796bc7ac6b4972d279ea9af04d: https://github.com/armbian/build/commit/758db7522a4480796bc7ac6b4972d279ea9af04d
+> X-Git-Archeology:   Date: Mon, 24 Dec 2018 11:06:59 -0500
+> X-Git-Archeology:   From: Martin Ayotte <martinayotte@yahoo.ca>
+> X-Git-Archeology:   Subject: initial commit for orangepi-rk3399.wip
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 5a0e3b6dcb79bc7605d6f95eebbb1133a1f7acb6: https://github.com/armbian/build/commit/5a0e3b6dcb79bc7605d6f95eebbb1133a1f7acb6
+> X-Git-Archeology:   Date: Fri, 28 Dec 2018 15:36:33 -0500
+> X-Git-Archeology:   From: Martin Ayotte <martinayotte@yahoo.ca>
+> X-Git-Archeology:   Subject: fix vcc5v0_host for USB1_HOST_EN in OrangePi-RK3399
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 53bcf26db6fbadfb2b10dfd166ae5a04bc834c4c: https://github.com/armbian/build/commit/53bcf26db6fbadfb2b10dfd166ae5a04bc834c4c
+> X-Git-Archeology:   Date: Fri, 15 Mar 2019 18:46:14 -0400
+> X-Git-Archeology:   From: Martin Ayotte <martinayotte@yahoo.ca>
+> X-Git-Archeology:   Subject: switch RK3399 to 5.0.y
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision c71a67643cdb3778c832531f2798fc33d343f5c5: https://github.com/armbian/build/commit/c71a67643cdb3778c832531f2798fc33d343f5c5
+> X-Git-Archeology:   Date: Wed, 17 Apr 2019 12:22:56 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igor.pecovnik@gmail.com>
+> X-Git-Archeology:   Subject: [ rockchip64 rk3399 default and dev ] update upstream tags and adjust patches, tested for building
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision d9fb5bfe8fe4d4964a1f4a086b8d1b47421fdd25: https://github.com/armbian/build/commit/d9fb5bfe8fe4d4964a1f4a086b8d1b47421fdd25
+> X-Git-Archeology:   Date: Fri, 24 Jan 2020 15:27:04 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: OrangePi 4 preliminary support (rk3399-legacy kernel)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 027c3f1a0a2b5c5471c083332687a41059c551ad: https://github.com/armbian/build/commit/027c3f1a0a2b5c5471c083332687a41059c551ad
+> X-Git-Archeology:   Date: Fri, 24 Jan 2020 19:04:42 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: OrangePi 4 preliminary support (current and dev kernels)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 720959e43e46584107b6b28b8c3b7edeb7513d58: https://github.com/armbian/build/commit/720959e43e46584107b6b28b8c3b7edeb7513d58
+> X-Git-Archeology:   Date: Fri, 24 Jan 2020 22:52:41 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Fixed the codec probe crash in "dev" for OrangePi 4
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ba80dbc93e92e5dbcf124c33a6c4f9d5a54a7e15: https://github.com/armbian/build/commit/ba80dbc93e92e5dbcf124c33a6c4f9d5a54a7e15
+> X-Git-Archeology:   Date: Thu, 19 Mar 2020 20:41:04 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: OrangePi 4 device tree cleanup part 1 (#1809)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e14a61c229db1216fedc397e351c4bed15df820e: https://github.com/armbian/build/commit/e14a61c229db1216fedc397e351c4bed15df820e
+> X-Git-Archeology:   Date: Sun, 05 Apr 2020 18:15:06 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Fixed sound from rt5651 on OrangePi 4 (#1870)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dc2b43562e126a8fbf994896c006ded5cc7e8bc0: https://github.com/armbian/build/commit/dc2b43562e126a8fbf994896c006ded5cc7e8bc0
+> X-Git-Archeology:   Date: Sun, 05 Apr 2020 23:27:22 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Added more specific "compatible" string for OrangePi 4
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision af2b7127b13a0f126cd7bf0f94f8cfda7bfc68fb: https://github.com/armbian/build/commit/af2b7127b13a0f126cd7bf0f94f8cfda7bfc68fb
+> X-Git-Archeology:   Date: Fri, 17 Apr 2020 08:37:12 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Fixed OrangePi 4 bluetooth and mic in current - based on https://github.com/armbian/build/pull/1888
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 5e37270da5c3be8c7e441f4e65b343188b7e59d4: https://github.com/armbian/build/commit/5e37270da5c3be8c7e441f4e65b343188b7e59d4
+> X-Git-Archeology:   Date: Fri, 17 Apr 2020 08:37:41 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Removed unused wlan and blootooth from OrangePi 4 modern targets
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 40a3d4ecb9a75c17183e2129491b7bc03060a315: https://github.com/armbian/build/commit/40a3d4ecb9a75c17183e2129491b7bc03060a315
+> X-Git-Archeology:   Date: Sun, 17 May 2020 18:42:24 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Fixed rt5651 codec probing after its driver was changed to module (#1969)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision df0083d39588139bb2685d1e829a526104d3a347: https://github.com/armbian/build/commit/df0083d39588139bb2685d1e829a526104d3a347
+> X-Git-Archeology:   Date: Sat, 06 Jun 2020 19:52:47 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Enabled HDMI audio for OrangePi 4 (#2009)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 812245def37a695bce9e7ece148b2920d82c8b37: https://github.com/armbian/build/commit/812245def37a695bce9e7ece148b2920d82c8b37
+> X-Git-Archeology:   Date: Sat, 18 Jul 2020 23:07:01 +0200
+> X-Git-Archeology:   From: Werner <EvilOlaf@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Move rockchip/64 current to 5.7.y (#2099)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 4d4c3f58ffc1cbfbb060cbabc9eb414036a2fda5: https://github.com/armbian/build/commit/4d4c3f58ffc1cbfbb060cbabc9eb414036a2fda5
+> X-Git-Archeology:   Date: Wed, 02 Sep 2020 23:22:09 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switched rockchip64 curent to kernel 5.8.y (#2175)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 18cf7aff702832cf672117f5dc1fe4ad37598837: https://github.com/armbian/build/commit/18cf7aff702832cf672117f5dc1fe4ad37598837
+> X-Git-Archeology:   Date: Tue, 05 Jan 2021 23:35:03 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Consolidate all dts Makefile changes in a single patch in rockchip64-current (#2535)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0cdffb29b07305209efb12cf3b5ac6032d3a1153: https://github.com/armbian/build/commit/0cdffb29b07305209efb12cf3b5ac6032d3a1153
+> X-Git-Archeology:   Date: Wed, 24 Mar 2021 19:01:53 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Renaming DEV branch to EDGE (#2704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e7377248b3cae186e24e2be781cd3365b43246f0: https://github.com/armbian/build/commit/e7377248b3cae186e24e2be781cd3365b43246f0
+> X-Git-Archeology:   Date: Thu, 22 Jul 2021 00:15:54 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Second part of EDGE bumping to 5.13.y (#3045)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 388e9bbf5ebd83bad953ad0e0a7a0a41ba2a6ed8: https://github.com/armbian/build/commit/388e9bbf5ebd83bad953ad0e0a7a0a41ba2a6ed8
+> X-Git-Archeology:   Date: Tue, 14 Jun 2022 12:11:33 +0200
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: Support for OrangePi4 LTS board (#3770)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision b88a8a7dce4a6b3e72d0b180798f13359d98cd14: https://github.com/armbian/build/commit/b88a8a7dce4a6b3e72d0b180798f13359d98cd14
+> X-Git-Archeology:   Date: Fri, 17 Jun 2022 10:07:06 +0200
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip64: orangepi4 LTS sdmmc bus pins strength increased for better stability with UHS modes
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 19d1ce656ef19ca50ff3bce72115e5ea64c897fd: https://github.com/armbian/build/commit/19d1ce656ef19ca50ff3bce72115e5ea64c897fd
+> X-Git-Archeology:   Date: Sun, 26 Jun 2022 15:14:53 +0200
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip64: fix pwm regulators that use pinctrl "active" configuration
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6ba9883baa854a0ee46cac763defdf47b48f3b97: https://github.com/armbian/build/commit/6ba9883baa854a0ee46cac763defdf47b48f3b97
+> X-Git-Archeology:   Date: Sun, 31 Jul 2022 01:10:00 +0200
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip64: switch orangepi 4/LTS to mainline USB3 Type-C controller driver
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision f2ddee56a1bb4d88de43900d6467ef89d5293251: https://github.com/armbian/build/commit/f2ddee56a1bb4d88de43900d6467ef89d5293251
+> X-Git-Archeology:   Date: Thu, 13 Oct 2022 18:17:46 +0200
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: fix orangepi4-lts rk808 interrupt line, sdcard detection and wifi freq (#4278)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 06ff3e3f07e3a02f4ee4a1d761f2dbf928e9edf1: https://github.com/armbian/build/commit/06ff3e3f07e3a02f4ee4a1d761f2dbf928e9edf1
+> X-Git-Archeology:   Date: Wed, 08 Mar 2023 11:12:41 +0100
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip64: enable orange pi 4 lts DMC driver
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3399-orangepi-4-lts.dts | 1254 ++++++++++
+ 1 file changed, 1254 insertions(+)
+
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4-lts.dts b/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4-lts.dts
 new file mode 100644
-index 00000000000..43f081ec1ab
+index 000000000000..43f081ec1ab3
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4-lts.dts
 @@ -0,0 +1,1254 @@
@@ -1258,3 +1440,6 @@ index 00000000000..43f081ec1ab
 +&dfi {
 +	status = "okay";
 +};
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/add-board-orangepi-4.patch
+++ b/patch/kernel/archive/rockchip64-6.3/add-board-orangepi-4.patch
@@ -1,6 +1,243 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor.pecovnik@gmail.com>
+Date: Sat, 11 Aug 2018 23:12:58 +0200
+Subject: [ARCHEOLOGY] Initial support for RK3399 Firefly and FriendlyARM PC T4
+
+> X-Git-Archeology: > recovered message: > Based on work of David Huang https://github.com/hjc4869 Changed in the transition:
+> X-Git-Archeology: > recovered message: > - firefly family was renamed to rk3399, which we actually never started to use. It was made for Odroid N1, which will never be sold
+> X-Git-Archeology: > recovered message: > - adjusted compiler toolchain2 parameter
+> X-Git-Archeology: > recovered message: > - added standard wireless drivers
+> X-Git-Archeology: > recovered message: > - kernel config with the following changes: Docker dependencies, ZRAM, CPUfreq info, ...
+> X-Git-Archeology: > recovered message: > - added upstream patches
+> X-Git-Archeology: > recovered message: > - made test Ubuntu Bionic desktop and CLI Stretch build, bootlog: http://ix.io/1jVu
+> X-Git-Archeology: > recovered message: > TBD: wifi and BT support, mainline kernel, ...
+> X-Git-Archeology: - Revision 6d82a8974872ee261006d2cdf6726b7d13df5032: https://github.com/armbian/build/commit/6d82a8974872ee261006d2cdf6726b7d13df5032
+> X-Git-Archeology:   Date: Sat, 11 Aug 2018 23:12:58 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igor.pecovnik@gmail.com>
+> X-Git-Archeology:   Subject: Initial support for RK3399 Firefly and FriendlyARM PC T4
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0fd231be0063a5631628571956635f2787e94b47: https://github.com/armbian/build/commit/0fd231be0063a5631628571956635f2787e94b47
+> X-Git-Archeology:   Date: Thu, 30 Aug 2018 21:24:59 +0800
+> X-Git-Archeology:   From: Jingchuan Huang <hjc@hjc.im>
+> X-Git-Archeology:   Subject: Add NanoPi M4/NEO4 device tree.
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 18215550b367919c1b270185e110b901e2843edd: https://github.com/armbian/build/commit/18215550b367919c1b270185e110b901e2843edd
+> X-Git-Archeology:   Date: Sat, 20 Oct 2018 04:04:59 +0000
+> X-Git-Archeology:   From: 5kft <5kft@users.noreply.github.com>
+> X-Git-Archeology:   Subject: [rk3399-dev] added support for the status_led, set default to heartbeat
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision f18360d1ef5d6487392ff4079301bca97945e704: https://github.com/armbian/build/commit/f18360d1ef5d6487392ff4079301bca97945e704
+> X-Git-Archeology:   Date: Wed, 24 Oct 2018 17:03:35 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igor.pecovnik@gmail.com>
+> X-Git-Archeology:   Subject: [rk3399-dev] Merging rk3399-DEV with rockchip64-DEV on sources, patches and config level. Leave family intact, add 1.5 OPP for RK3328, add upstream patch for rk3399-default
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 758db7522a4480796bc7ac6b4972d279ea9af04d: https://github.com/armbian/build/commit/758db7522a4480796bc7ac6b4972d279ea9af04d
+> X-Git-Archeology:   Date: Mon, 24 Dec 2018 11:06:59 -0500
+> X-Git-Archeology:   From: Martin Ayotte <martinayotte@yahoo.ca>
+> X-Git-Archeology:   Subject: initial commit for orangepi-rk3399.wip
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 5a0e3b6dcb79bc7605d6f95eebbb1133a1f7acb6: https://github.com/armbian/build/commit/5a0e3b6dcb79bc7605d6f95eebbb1133a1f7acb6
+> X-Git-Archeology:   Date: Fri, 28 Dec 2018 15:36:33 -0500
+> X-Git-Archeology:   From: Martin Ayotte <martinayotte@yahoo.ca>
+> X-Git-Archeology:   Subject: fix vcc5v0_host for USB1_HOST_EN in OrangePi-RK3399
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 53bcf26db6fbadfb2b10dfd166ae5a04bc834c4c: https://github.com/armbian/build/commit/53bcf26db6fbadfb2b10dfd166ae5a04bc834c4c
+> X-Git-Archeology:   Date: Fri, 15 Mar 2019 18:46:14 -0400
+> X-Git-Archeology:   From: Martin Ayotte <martinayotte@yahoo.ca>
+> X-Git-Archeology:   Subject: switch RK3399 to 5.0.y
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision c71a67643cdb3778c832531f2798fc33d343f5c5: https://github.com/armbian/build/commit/c71a67643cdb3778c832531f2798fc33d343f5c5
+> X-Git-Archeology:   Date: Wed, 17 Apr 2019 12:22:56 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igor.pecovnik@gmail.com>
+> X-Git-Archeology:   Subject: [ rockchip64 rk3399 default and dev ] update upstream tags and adjust patches, tested for building
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision a22b07948a898485db733189edea0f1e4b753071: https://github.com/armbian/build/commit/a22b07948a898485db733189edea0f1e4b753071
+> X-Git-Archeology:   Date: Fri, 24 Jan 2020 14:21:27 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: OrangePi 4 preliminary support (kernel dt from NanoPi M4)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision d9fb5bfe8fe4d4964a1f4a086b8d1b47421fdd25: https://github.com/armbian/build/commit/d9fb5bfe8fe4d4964a1f4a086b8d1b47421fdd25
+> X-Git-Archeology:   Date: Fri, 24 Jan 2020 15:27:04 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: OrangePi 4 preliminary support (rk3399-legacy kernel)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 027c3f1a0a2b5c5471c083332687a41059c551ad: https://github.com/armbian/build/commit/027c3f1a0a2b5c5471c083332687a41059c551ad
+> X-Git-Archeology:   Date: Fri, 24 Jan 2020 19:04:42 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: OrangePi 4 preliminary support (current and dev kernels)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e4be7bcfd8dcc556ea38b0b286e4d8ba0c8c5881: https://github.com/armbian/build/commit/e4be7bcfd8dcc556ea38b0b286e4d8ba0c8c5881
+> X-Git-Archeology:   Date: Fri, 24 Jan 2020 19:17:26 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: OrangePi 4 preliminary support (fixed default FDT file name)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 720959e43e46584107b6b28b8c3b7edeb7513d58: https://github.com/armbian/build/commit/720959e43e46584107b6b28b8c3b7edeb7513d58
+> X-Git-Archeology:   Date: Fri, 24 Jan 2020 22:52:41 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Fixed the codec probe crash in "dev" for OrangePi 4
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ba80dbc93e92e5dbcf124c33a6c4f9d5a54a7e15: https://github.com/armbian/build/commit/ba80dbc93e92e5dbcf124c33a6c4f9d5a54a7e15
+> X-Git-Archeology:   Date: Thu, 19 Mar 2020 20:41:04 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: OrangePi 4 device tree cleanup part 1 (#1809)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e14a61c229db1216fedc397e351c4bed15df820e: https://github.com/armbian/build/commit/e14a61c229db1216fedc397e351c4bed15df820e
+> X-Git-Archeology:   Date: Sun, 05 Apr 2020 18:15:06 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Fixed sound from rt5651 on OrangePi 4 (#1870)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dc2b43562e126a8fbf994896c006ded5cc7e8bc0: https://github.com/armbian/build/commit/dc2b43562e126a8fbf994896c006ded5cc7e8bc0
+> X-Git-Archeology:   Date: Sun, 05 Apr 2020 23:27:22 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Added more specific "compatible" string for OrangePi 4
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision af2b7127b13a0f126cd7bf0f94f8cfda7bfc68fb: https://github.com/armbian/build/commit/af2b7127b13a0f126cd7bf0f94f8cfda7bfc68fb
+> X-Git-Archeology:   Date: Fri, 17 Apr 2020 08:37:12 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Fixed OrangePi 4 bluetooth and mic in current - based on https://github.com/armbian/build/pull/1888
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 5e37270da5c3be8c7e441f4e65b343188b7e59d4: https://github.com/armbian/build/commit/5e37270da5c3be8c7e441f4e65b343188b7e59d4
+> X-Git-Archeology:   Date: Fri, 17 Apr 2020 08:37:41 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Removed unused wlan and blootooth from OrangePi 4 modern targets
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 75d0f64e3d75e7c34466871b9723ef1a238609d8: https://github.com/armbian/build/commit/75d0f64e3d75e7c34466871b9723ef1a238609d8
+> X-Git-Archeology:   Date: Fri, 17 Apr 2020 21:30:37 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rk3399 to u-boot v2020.04 (#1873)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 5a2b2c360b9c26ca4bd0d309af7cd3994fd08b7d: https://github.com/armbian/build/commit/5a2b2c360b9c26ca4bd0d309af7cd3994fd08b7d
+> X-Git-Archeology:   Date: Sun, 03 May 2020 19:15:46 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Prepare rockchip64 for switch to mainline u-boot and switched ROCK Pi 4 (#1934)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 40a3d4ecb9a75c17183e2129491b7bc03060a315: https://github.com/armbian/build/commit/40a3d4ecb9a75c17183e2129491b7bc03060a315
+> X-Git-Archeology:   Date: Sun, 17 May 2020 18:42:24 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Fixed rt5651 codec probing after its driver was changed to module (#1969)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision df0083d39588139bb2685d1e829a526104d3a347: https://github.com/armbian/build/commit/df0083d39588139bb2685d1e829a526104d3a347
+> X-Git-Archeology:   Date: Sat, 06 Jun 2020 19:52:47 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Enabled HDMI audio for OrangePi 4 (#2009)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 88a585a3fe56bf9eb8c1df8993fe34830597ca77: https://github.com/armbian/build/commit/88a585a3fe56bf9eb8c1df8993fe34830597ca77
+> X-Git-Archeology:   Date: Sat, 18 Jul 2020 00:06:01 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Update mainline u-boot for rockchip64 / rk3399 to v2020.07 (#2086)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 812245def37a695bce9e7ece148b2920d82c8b37: https://github.com/armbian/build/commit/812245def37a695bce9e7ece148b2920d82c8b37
+> X-Git-Archeology:   Date: Sat, 18 Jul 2020 23:07:01 +0200
+> X-Git-Archeology:   From: Werner <EvilOlaf@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Move rockchip/64 current to 5.7.y (#2099)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6e4078974bcf69c5e49bb78b920d52d62dc29f6b: https://github.com/armbian/build/commit/6e4078974bcf69c5e49bb78b920d52d62dc29f6b
+> X-Git-Archeology:   Date: Sun, 19 Jul 2020 00:07:03 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Adjusted patches for rockchip64 mainline u-boot (fuzzines, upstreamed file)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 4d4c3f58ffc1cbfbb060cbabc9eb414036a2fda5: https://github.com/armbian/build/commit/4d4c3f58ffc1cbfbb060cbabc9eb414036a2fda5
+> X-Git-Archeology:   Date: Wed, 02 Sep 2020 23:22:09 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switched rockchip64 curent to kernel 5.8.y (#2175)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 18cf7aff702832cf672117f5dc1fe4ad37598837: https://github.com/armbian/build/commit/18cf7aff702832cf672117f5dc1fe4ad37598837
+> X-Git-Archeology:   Date: Tue, 05 Jan 2021 23:35:03 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Consolidate all dts Makefile changes in a single patch in rockchip64-current (#2535)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 3ce107f35826cc51a42d24d0140f8f27325b46c9: https://github.com/armbian/build/commit/3ce107f35826cc51a42d24d0140f8f27325b46c9
+> X-Git-Archeology:   Date: Sun, 24 Jan 2021 21:24:06 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Disable excessive logging for OrangePi 4 in u-boot
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0cdffb29b07305209efb12cf3b5ac6032d3a1153: https://github.com/armbian/build/commit/0cdffb29b07305209efb12cf3b5ac6032d3a1153
+> X-Git-Archeology:   Date: Wed, 24 Mar 2021 19:01:53 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Renaming DEV branch to EDGE (#2704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e7377248b3cae186e24e2be781cd3365b43246f0: https://github.com/armbian/build/commit/e7377248b3cae186e24e2be781cd3365b43246f0
+> X-Git-Archeology:   Date: Thu, 22 Jul 2021 00:15:54 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Second part of EDGE bumping to 5.13.y (#3045)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 744ea89a589d62cb6f409baab60fc6664520bc39: https://github.com/armbian/build/commit/744ea89a589d62cb6f409baab60fc6664520bc39
+> X-Git-Archeology:   Date: Wed, 08 Sep 2021 17:51:34 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bumping EDGE kernel to 5.14.y (#3125)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 86abac1fd4e169712a44d245cf7adef4ee17c420: https://github.com/armbian/build/commit/86abac1fd4e169712a44d245cf7adef4ee17c420
+> X-Git-Archeology:   Date: Tue, 26 Oct 2021 22:14:41 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Cleanup u-boot configurations for rockchip64 derivatives (#3150)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e: https://github.com/armbian/build/commit/dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e
+> X-Git-Archeology:   Date: Tue, 09 Nov 2021 18:06:34 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump imx6, xu4, rockchip64 and jetson-nano to 5.15 (#3238)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 26437e36c18bb09484f4150e396a1784cc6471b7: https://github.com/armbian/build/commit/26437e36c18bb09484f4150e396a1784cc6471b7
+> X-Git-Archeology:   Date: Thu, 16 Jun 2022 12:27:05 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switched rockchip64 u-boot to v2022.04 (#3871)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 19d1ce656ef19ca50ff3bce72115e5ea64c897fd: https://github.com/armbian/build/commit/19d1ce656ef19ca50ff3bce72115e5ea64c897fd
+> X-Git-Archeology:   Date: Sun, 26 Jun 2022 15:14:53 +0200
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip64: fix pwm regulators that use pinctrl "active" configuration
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6ba9883baa854a0ee46cac763defdf47b48f3b97: https://github.com/armbian/build/commit/6ba9883baa854a0ee46cac763defdf47b48f3b97
+> X-Git-Archeology:   Date: Sun, 31 Jul 2022 01:10:00 +0200
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip64: switch orangepi 4/LTS to mainline USB3 Type-C controller driver
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 2813365dd25e3ad110936cbf014b95b38d7090ec: https://github.com/armbian/build/commit/2813365dd25e3ad110936cbf014b95b38d7090ec
+> X-Git-Archeology:   Date: Mon, 07 Nov 2022 21:29:00 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Move known non working rockhip64 boards to previous boot loader (#4392)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3399-orangepi-4.dts | 1194 ++++++++++
+ 1 file changed, 1194 insertions(+)
+
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4.dts b/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4.dts
 new file mode 100644
-index 00000000000..9efe2513944
+index 000000000000..976d3f9964f3
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4.dts
 @@ -0,0 +1,1194 @@
@@ -1198,3 +1435,6 @@ index 00000000000..9efe2513944
 +	status = "okay";
 +};
 +
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/add-board-orangepi-r1-plus-lts.patch
+++ b/patch/kernel/archive/rockchip64-6.3/add-board-orangepi-r1-plus-lts.patch
@@ -1,17 +1,16 @@
-From c163dea909a2900a78ad8041de42b6509c8e3910 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: schwar3kat <schwar3kat@armbian.com>
 Date: Mon, 30 Jan 2023 18:48:33 +1300
-Subject: [PATCH] add-board-orangepi-r1-plus-lts.patch
+Subject: add-board-orangepi-r1-plus-lts.patch
 
 Signed-off-by: schwar3kat <schwar3kat@armbian.com>
 ---
- .../rockchip/rk3328-orangepi-r1-plus-lts.dts  | 446 ++++++++++++++++++
+ arch/arm64/boot/dts/rockchip/rk3328-orangepi-r1-plus-lts.dts | 446 ++++++++++
  1 file changed, 446 insertions(+)
- create mode 100644 arch/arm64/boot/dts/rockchip/rk3328-orangepi-r1-plus-lts.dts
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328-orangepi-r1-plus-lts.dts b/arch/arm64/boot/dts/rockchip/rk3328-orangepi-r1-plus-lts.dts
 new file mode 100644
-index 000000000..2bc432168
+index 000000000000..2bc4321686bf
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-orangepi-r1-plus-lts.dts
 @@ -0,0 +1,446 @@
@@ -462,5 +461,5 @@ index 000000000..2bc432168
 +	};
 +};
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/add-board-orangepi-r1-plus.patch
+++ b/patch/kernel/archive/rockchip64-6.3/add-board-orangepi-r1-plus.patch
@@ -1,88 +1,180 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+Date: Sat, 20 Jun 2020 22:39:57 +0200
+Subject: [ARCHEOLOGY] Initial ROCK Pi E support (as WIP) (#2042)
+
+note: rpardini: rebased on top of v6.3.1. this patch used to overwrite
+a file, and is now a complete diff.
+
+> X-Git-Archeology: > recovered message: > * WIP: Adding RockpiE config
+> X-Git-Archeology: > recovered message: > Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
+> X-Git-Archeology: > recovered message: > * Mainline u-boot for ROCK Pi E
+> X-Git-Archeology: > recovered message: > * Initial ROCK Pi E device tree in kernel
+> X-Git-Archeology: > recovered message: > * Fixed supplies for ROCK Pi E device tree
+> X-Git-Archeology: > recovered message: > * Adjusted u-boot load address for rockchip64 boards with 256MB eg. ROCK Pi E
+> X-Git-Archeology: > recovered message: > * Blacklisted lima on ROCK Pi E
+> X-Git-Archeology: > recovered message: > * Fixed ROCK Pi E patch after merge from master
+> X-Git-Archeology: > recovered message: > * Removed mode settings from rk805 regulators
+> X-Git-Archeology: > recovered message: > * Fixed issues with offloading for gigabit interface of RockPi E
+> X-Git-Archeology: > recovered message: > * Adjusted ROCK Pi E board config
+> X-Git-Archeology: > recovered message: > * Added dev branch for ROCK Pi E
+> X-Git-Archeology: > recovered message: > * Add build targets
+> X-Git-Archeology: > recovered message: > Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
+> X-Git-Archeology: > recovered message: > * Exchange legacy to current in ROCK Pi E build targets
+> X-Git-Archeology: > recovered message: > Co-authored-by: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology: - Revision e1ecb098330dc372740371dc2386f911833a0529: https://github.com/armbian/build/commit/e1ecb098330dc372740371dc2386f911833a0529
+> X-Git-Archeology:   Date: Sat, 20 Jun 2020 22:39:57 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Initial ROCK Pi E support (as WIP) (#2042)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 72257bd0648c28fca32962126bb885a4a2c188cc: https://github.com/armbian/build/commit/72257bd0648c28fca32962126bb885a4a2c188cc
+> X-Git-Archeology:   Date: Tue, 23 Jun 2020 16:37:54 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Make USB3 support of ROCK Pi E on par with other rk3328 boards (#2050)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e36ce875b025e112127cf8cc2d34825ebfe36569: https://github.com/armbian/build/commit/e36ce875b025e112127cf8cc2d34825ebfe36569
+> X-Git-Archeology:   Date: Tue, 10 Nov 2020 21:43:13 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switched rockchip64-current to linux 5.9.y (#2309)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ccbc888b3f5731790128684959b55b6552e26190: https://github.com/armbian/build/commit/ccbc888b3f5731790128684959b55b6552e26190
+> X-Git-Archeology:   Date: Sat, 28 Nov 2020 16:52:34 +0100
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: add dts rk3328-roc-pc, fix WIFI and USB 3.0 rk3328 (#2390)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 25bd76527e1276c4c00829f68c0ca0742ecc94c1: https://github.com/armbian/build/commit/25bd76527e1276c4c00829f68c0ca0742ecc94c1
+> X-Git-Archeology:   Date: Sat, 28 Nov 2020 18:10:53 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Fix roc-rk3328-pc device tree reference to missing RK_FUNC_1
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dfd5cf9692e97774f7f0bfd72227144e36f58070: https://github.com/armbian/build/commit/dfd5cf9692e97774f7f0bfd72227144e36f58070
+> X-Git-Archeology:   Date: Sun, 13 Dec 2020 22:13:03 -0500
+> X-Git-Archeology:   From: tonymac32 <tonymckahan@gmail.com>
+> X-Git-Archeology:   Subject: [ rockchip64 ] Clean up patchset
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 25e0f1633467c020f6ae68d09964a522fbfbe613: https://github.com/armbian/build/commit/25e0f1633467c020f6ae68d09964a522fbfbe613
+> X-Git-Archeology:   Date: Mon, 18 Jan 2021 23:21:40 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Adjusted power and pmic configuration for Station M1 in current/dev
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0cdffb29b07305209efb12cf3b5ac6032d3a1153: https://github.com/armbian/build/commit/0cdffb29b07305209efb12cf3b5ac6032d3a1153
+> X-Git-Archeology:   Date: Wed, 24 Mar 2021 19:01:53 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Renaming DEV branch to EDGE (#2704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision d8dbefd61838e5b0cfc2b93d2d168f3fb2666dfb: https://github.com/armbian/build/commit/d8dbefd61838e5b0cfc2b93d2d168f3fb2666dfb
+> X-Git-Archeology:   Date: Tue, 27 Jul 2021 00:05:09 -0400
+> X-Git-Archeology:   From: tonymac32 <tonymckahan@gmail.com>
+> X-Git-Archeology:   Subject: [ rockchip64 ] rk3328 change to mainline USB3
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision a16699260fb786a4d89a1c335722e9fed49d19d2: https://github.com/armbian/build/commit/a16699260fb786a4d89a1c335722e9fed49d19d2
+> X-Git-Archeology:   Date: Fri, 08 Jul 2022 22:35:59 +1200
+> X-Git-Archeology:   From: schwar3kat <61094841+schwar3kat@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Refactored orangepi-r1plus-lts dts in kernel add board patch
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8648dde23ff090b5fb704adab036ed14cd944ba3: https://github.com/armbian/build/commit/8648dde23ff090b5fb704adab036ed14cd944ba3
+> X-Git-Archeology:   Date: Thu, 22 Sep 2022 10:25:28 +0200
+> X-Git-Archeology:   From: aiamadeus <42570690+aiamadeus@users.noreply.github.com>
+> X-Git-Archeology:   Subject: rockchip: fixes support for orangepi-r1plus (#4215)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3328-orangepi-r1-plus.dts | 109 +++++++---
+ 1 file changed, 73 insertions(+), 36 deletions(-)
+
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328-orangepi-r1-plus.dts b/arch/arm64/boot/dts/rockchip/rk3328-orangepi-r1-plus.dts
-new file mode 100644
-index 000000000..2ee07d15a
---- /dev/null
+index dc83d74045a3..4fe8eb39b64f 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3328-orangepi-r1-plus.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-orangepi-r1-plus.dts
-@@ -0,0 +1,410 @@
-+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
-+
-+/dts-v1/;
-+
+@@ -1,13 +1,10 @@
+ // SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+-/*
+- * Based on rk3328-nanopi-r2s.dts, which is:
+- *   Copyright (c) 2020 David Bauer <mail@david-bauer.net>
+- */
+ 
+ /dts-v1/;
+ 
 +#include <dt-bindings/input/input.h>
-+#include <dt-bindings/gpio/gpio.h>
+ #include <dt-bindings/gpio/gpio.h>
+-#include <dt-bindings/leds/common.h>
 +#include "rk3328-dram-default-timing.dtsi"
-+#include "rk3328.dtsi"
-+
-+/ {
-+	model = "Xunlong Orange Pi R1 Plus";
-+	compatible = "xunlong,orangepi-r1-plus", "rockchip,rk3328";
-+
-+	aliases {
-+		ethernet1 = &rtl8153;
-+		mmc0 = &sdmmc;
-+	};
-+
-+	chosen {
-+		stdout-path = "serial2:1500000n8";
-+	};
-+
-+	gmac_clk: gmac-clock {
-+		compatible = "fixed-clock";
-+		clock-frequency = <125000000>;
-+		clock-output-names = "gmac_clkin";
-+		#clock-cells = <0>;
-+	};
-+
-+	leds {
-+		compatible = "gpio-leds";
-+		pinctrl-0 = <&lan_led_pin>, <&sys_led_pin>, <&wan_led_pin>;
-+		pinctrl-names = "default";
-+
+ #include "rk3328.dtsi"
+ 
+ / {
+@@ -35,23 +32,20 @@ leds {
+ 		pinctrl-0 = <&lan_led_pin>, <&sys_led_pin>, <&wan_led_pin>;
+ 		pinctrl-names = "default";
+ 
+-		led-0 {
+-			function = LED_FUNCTION_LAN;
+-			color = <LED_COLOR_ID_GREEN>;
 +		lan_led: led-0 {
-+			gpios = <&gpio2 RK_PB7 GPIO_ACTIVE_HIGH>;
+ 			gpios = <&gpio2 RK_PB7 GPIO_ACTIVE_HIGH>;
 +			label = "orangepi-r1-plus:green:lan";
-+		};
-+
+ 		};
+ 
+-		led-1 {
+-			function = LED_FUNCTION_STATUS;
+-			color = <LED_COLOR_ID_RED>;
 +		sys_led: led-1 {
-+			gpios = <&gpio3 RK_PC5 GPIO_ACTIVE_HIGH>;
+ 			gpios = <&gpio3 RK_PC5 GPIO_ACTIVE_HIGH>;
 +			label = "orangepi-r1-plus:red:status";
-+			linux,default-trigger = "heartbeat";
-+		};
-+
+ 			linux,default-trigger = "heartbeat";
+ 		};
+ 
+-		led-2 {
+-			function = LED_FUNCTION_WAN;
+-			color = <LED_COLOR_ID_GREEN>;
 +		wan_led: led-2 {
-+			gpios = <&gpio2 RK_PC2 GPIO_ACTIVE_HIGH>;
+ 			gpios = <&gpio2 RK_PC2 GPIO_ACTIVE_HIGH>;
 +			label = "orangepi-r1-plus:green:wan";
-+		};
-+	};
-+
-+	vcc_sd: sdmmc-regulator {
-+		compatible = "regulator-fixed";
-+		gpio = <&gpio0 RK_PD6 GPIO_ACTIVE_LOW>;
-+		pinctrl-0 = <&sdmmc0m1_pin>;
-+		pinctrl-names = "default";
-+		regulator-name = "vcc_sd";
-+		regulator-boot-on;
+ 		};
+ 	};
+ 
+@@ -62,19 +56,19 @@ vcc_sd: sdmmc-regulator {
+ 		pinctrl-names = "default";
+ 		regulator-name = "vcc_sd";
+ 		regulator-boot-on;
+-		vin-supply = <&vcc_io>;
 +		vin-supply = <&vcc_io_33>;
-+	};
-+
+ 	};
+ 
+-	vcc_sys: vcc-sys-regulator {
 +	vdd_5v: vdd-5v {
-+		compatible = "regulator-fixed";
+ 		compatible = "regulator-fixed";
+-		regulator-name = "vcc_sys";
 +		regulator-name = "vdd_5v";
-+		regulator-always-on;
-+		regulator-boot-on;
-+		regulator-min-microvolt = <5000000>;
-+		regulator-max-microvolt = <5000000>;
-+	};
-+
+ 		regulator-always-on;
+ 		regulator-boot-on;
+ 		regulator-min-microvolt = <5000000>;
+ 		regulator-max-microvolt = <5000000>;
+ 	};
+ 
+-	vdd_5v_lan: vdd-5v-lan-regulator {
 +	vdd_5v_lan: vdd-5v-lan {
-+		compatible = "regulator-fixed";
-+		enable-active-high;
-+		gpio = <&gpio2 RK_PC6 GPIO_ACTIVE_HIGH>;
-+		pinctrl-0 = <&lan_vdd_pin>;
-+		pinctrl-names = "default";
-+		regulator-name = "vdd_5v_lan";
-+		regulator-always-on;
-+		regulator-boot-on;
+ 		compatible = "regulator-fixed";
+ 		enable-active-high;
+ 		gpio = <&gpio2 RK_PC6 GPIO_ACTIVE_HIGH>;
+@@ -83,7 +77,34 @@ vdd_5v_lan: vdd-5v-lan-regulator {
+ 		regulator-name = "vdd_5v_lan";
+ 		regulator-always-on;
+ 		regulator-boot-on;
+-		vin-supply = <&vcc_sys>;
 +		vin-supply = <&vdd_5v>;
 +	};
 +
@@ -111,25 +203,13 @@ index 000000000..2ee07d15a
 +			opp-hz = /bits/ 64 <1056000000>;
 +			opp-microvolt = <1175000 1175000 1200000>;
 +		};
-+	};
-+};
-+
-+&cpu0 {
-+	cpu-supply = <&vdd_arm>;
-+};
-+
-+&cpu1 {
-+	cpu-supply = <&vdd_arm>;
-+};
-+
-+&cpu2 {
-+	cpu-supply = <&vdd_arm>;
-+};
-+
-+&cpu3 {
-+	cpu-supply = <&vdd_arm>;
-+};
-+
+ 	};
+ };
+ 
+@@ -103,6 +124,16 @@ &cpu3 {
+ 	cpu-supply = <&vdd_arm>;
+ };
+ 
 +&dfi {
 +	status = "okay";
 +};
@@ -140,277 +220,116 @@ index 000000000..2ee07d15a
 +	status = "okay";
 +};
 +
-+&display_subsystem {
-+	status = "disabled";
-+};
-+
-+&gmac2io {
-+	assigned-clocks = <&cru SCLK_MAC2IO>, <&cru SCLK_MAC2IO_EXT>;
-+	assigned-clock-parents = <&gmac_clk>, <&gmac_clk>;
-+	clock_in_out = "input";
-+	phy-handle = <&rtl8211e>;
-+	phy-mode = "rgmii";
+ &display_subsystem {
+ 	status = "disabled";
+ };
+@@ -113,7 +144,7 @@ &gmac2io {
+ 	clock_in_out = "input";
+ 	phy-handle = <&rtl8211e>;
+ 	phy-mode = "rgmii";
+-	phy-supply = <&vcc_io>;
 +	phy-supply = <&vcc_io_33>;
-+	pinctrl-0 = <&rgmiim1_pins>;
-+	pinctrl-names = "default";
-+	snps,aal;
-+	rx_delay = <0x18>;
-+	tx_delay = <0x24>;
-+	status = "okay";
-+
-+	mdio {
-+		compatible = "snps,dwmac-mdio";
-+		#address-cells = <1>;
-+		#size-cells = <0>;
-+
-+		rtl8211e: ethernet-phy@1 {
-+			reg = <1>;
-+			pinctrl-0 = <&eth_phy_reset_pin>;
-+			pinctrl-names = "default";
-+			reset-assert-us = <10000>;
-+			reset-deassert-us = <50000>;
-+			reset-gpios = <&gpio1 RK_PC2 GPIO_ACTIVE_LOW>;
-+		};
-+	};
-+};
-+
+ 	pinctrl-0 = <&rgmiim1_pins>;
+ 	pinctrl-names = "default";
+ 	snps,aal;
+@@ -137,6 +168,10 @@ rtl8211e: ethernet-phy@1 {
+ 	};
+ };
+ 
 +&i2c0 {
 +	status = "okay";
 +};
 +
-+&i2c1 {
-+	status = "okay";
-+
-+	rk805: pmic@18 {
-+		compatible = "rockchip,rk805";
-+		reg = <0x18>;
-+		interrupt-parent = <&gpio1>;
-+		interrupts = <24 IRQ_TYPE_LEVEL_LOW>;
-+		#clock-cells = <1>;
-+		clock-output-names = "xin32k", "rk805-clkout2";
-+		gpio-controller;
-+		#gpio-cells = <2>;
-+		pinctrl-0 = <&pmic_int_l>;
-+		pinctrl-names = "default";
-+		rockchip,system-power-controller;
-+		wakeup-source;
-+
+ &i2c1 {
+ 	status = "okay";
+ 
+@@ -154,18 +189,19 @@ rk805: pmic@18 {
+ 		rockchip,system-power-controller;
+ 		wakeup-source;
+ 
+-		vcc1-supply = <&vcc_sys>;
+-		vcc2-supply = <&vcc_sys>;
+-		vcc3-supply = <&vcc_sys>;
+-		vcc4-supply = <&vcc_sys>;
+-		vcc5-supply = <&vcc_io>;
+-		vcc6-supply = <&vcc_sys>;
 +		vcc1-supply = <&vdd_5v>;
 +		vcc2-supply = <&vdd_5v>;
 +		vcc3-supply = <&vdd_5v>;
 +		vcc4-supply = <&vdd_5v>;
 +		vcc5-supply = <&vcc_io_33>;
 +		vcc6-supply = <&vdd_5v>;
-+
-+		regulators {
-+			vdd_log: DCDC_REG1 {
-+				regulator-name = "vdd_log";
-+				regulator-always-on;
-+				regulator-boot-on;
+ 
+ 		regulators {
+ 			vdd_log: DCDC_REG1 {
+ 				regulator-name = "vdd_log";
+ 				regulator-always-on;
+ 				regulator-boot-on;
 +				regulator-init-microvolt = <1075000>;
-+				regulator-min-microvolt = <712500>;
-+				regulator-max-microvolt = <1450000>;
-+				regulator-ramp-delay = <12500>;
-+
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <1000000>;
-+				};
-+			};
-+
-+			vdd_arm: DCDC_REG2 {
-+				regulator-name = "vdd_arm";
-+				regulator-always-on;
-+				regulator-boot-on;
+ 				regulator-min-microvolt = <712500>;
+ 				regulator-max-microvolt = <1450000>;
+ 				regulator-ramp-delay = <12500>;
+@@ -180,6 +216,7 @@ vdd_arm: DCDC_REG2 {
+ 				regulator-name = "vdd_arm";
+ 				regulator-always-on;
+ 				regulator-boot-on;
 +				regulator-init-microvolt = <1225000>;
-+				regulator-min-microvolt = <712500>;
-+				regulator-max-microvolt = <1450000>;
-+				regulator-ramp-delay = <12500>;
-+
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <950000>;
-+				};
-+			};
-+
-+			vcc_ddr: DCDC_REG3 {
-+				regulator-name = "vcc_ddr";
-+				regulator-always-on;
-+				regulator-boot-on;
-+
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+				};
-+			};
-+
+ 				regulator-min-microvolt = <712500>;
+ 				regulator-max-microvolt = <1450000>;
+ 				regulator-ramp-delay = <12500>;
+@@ -200,8 +237,8 @@ regulator-state-mem {
+ 				};
+ 			};
+ 
+-			vcc_io: DCDC_REG4 {
+-				regulator-name = "vcc_io";
 +			vcc_io_33: DCDC_REG4 {
 +				regulator-name = "vcc_io_33";
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-min-microvolt = <3300000>;
-+				regulator-max-microvolt = <3300000>;
-+
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <3300000>;
-+				};
-+			};
-+
-+			vcc_18: LDO_REG1 {
-+				regulator-name = "vcc_18";
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-min-microvolt = <1800000>;
-+				regulator-max-microvolt = <1800000>;
-+
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <1800000>;
-+				};
-+			};
-+
-+			vcc18_emmc: LDO_REG2 {
-+				regulator-name = "vcc18_emmc";
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-min-microvolt = <1800000>;
-+				regulator-max-microvolt = <1800000>;
-+
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <1800000>;
-+				};
-+			};
-+
-+			vdd_10: LDO_REG3 {
-+				regulator-name = "vdd_10";
-+				regulator-always-on;
-+				regulator-boot-on;
-+				regulator-min-microvolt = <1000000>;
-+				regulator-max-microvolt = <1000000>;
-+
-+				regulator-state-mem {
-+					regulator-on-in-suspend;
-+					regulator-suspend-microvolt = <1000000>;
-+				};
-+			};
-+		};
-+	};
-+};
-+
-+&io_domains {
+ 				regulator-always-on;
+ 				regulator-boot-on;
+ 				regulator-min-microvolt = <3300000>;
+@@ -256,13 +293,13 @@ regulator-state-mem {
+ };
+ 
+ &io_domains {
+-	pmuio-supply = <&vcc_io>;
+-	vccio1-supply = <&vcc_io>;
 +	pmuio-supply = <&vcc_io_33>;
 +	vccio1-supply = <&vcc_io_33>;
-+	vccio2-supply = <&vcc18_emmc>;
+ 	vccio2-supply = <&vcc18_emmc>;
+-	vccio3-supply = <&vcc_io>;
+-	vccio4-supply = <&vcc_io>;
+-	vccio5-supply = <&vcc_io>;
+-	vccio6-supply = <&vcc_io>;
 +	vccio3-supply = <&vcc_io_33>;
 +	vccio4-supply = <&vcc_io_33>;
 +	vccio5-supply = <&vcc_io_33>;
 +	vccio6-supply = <&vcc_io_33>;
-+	status = "okay";
-+};
-+
-+&pinctrl {
-+	gmac2io {
-+		eth_phy_reset_pin: eth-phy-reset-pin {
-+			rockchip,pins = <1 RK_PC2 RK_FUNC_GPIO &pcfg_pull_down>;
-+		};
-+	};
-+
-+	leds {
-+		lan_led_pin: lan-led-pin {
-+			rockchip,pins = <2 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+
-+		sys_led_pin: sys-led-pin {
-+			rockchip,pins = <3 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+
-+		wan_led_pin: wan-led-pin {
-+			rockchip,pins = <2 RK_PC2 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+
-+	lan {
-+		lan_vdd_pin: lan-vdd-pin {
-+			rockchip,pins = <2 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+
-+	pmic {
-+		pmic_int_l: pmic-int-l {
-+			rockchip,pins = <1 RK_PD0 RK_FUNC_GPIO &pcfg_pull_up>;
-+		};
-+	};
-+};
-+
-+&pwm2 {
-+	status = "okay";
-+};
-+
-+&sdmmc {
-+	bus-width = <4>;
-+	cap-sd-highspeed;
-+	disable-wp;
-+	pinctrl-0 = <&sdmmc0_clk>, <&sdmmc0_cmd>, <&sdmmc0_dectn>, <&sdmmc0_bus4>;
-+	pinctrl-names = "default";
-+	vmmc-supply = <&vcc_sd>;
-+	status = "okay";
-+};
-+
-+&spi0 {
-+	status = "okay";
-+
-+	flash@0 {
-+		compatible = "jedec,spi-nor";
-+		reg = <0>;
-+		spi-max-frequency = <50000000>;
-+	};
-+};
-+
-+&tsadc {
-+	rockchip,hw-tshut-mode = <0>;
-+	rockchip,hw-tshut-polarity = <0>;
-+	status = "okay";
-+};
-+
-+&u2phy {
-+	status = "okay";
-+};
-+
-+&u2phy_host {
-+	status = "okay";
-+};
-+
-+&u2phy_otg {
-+	status = "okay";
-+};
-+
-+&uart2 {
-+	status = "okay";
-+};
-+
-+&usb20_otg {
-+	status = "okay";
+ 	status = "okay";
+ };
+ 
+@@ -347,8 +384,8 @@ &uart2 {
+ };
+ 
+ &usb20_otg {
+-	dr_mode = "host";
+ 	status = "okay";
 +	dr_mode = "host";
-+};
-+
-+&usbdrd3 {
-+	dr_mode = "host";
-+	status = "okay";
-+	#address-cells = <1>;
-+	#size-cells = <0>;
-+
-+	rtl8153: device@2 {
-+		compatible = "usbbda,8153";
-+		reg = <2>;
+ };
+ 
+ &usbdrd3 {
+@@ -357,10 +394,10 @@ &usbdrd3 {
+ 	#address-cells = <1>;
+ 	#size-cells = <0>;
+ 
+-	/* Second port is for USB 3.0 */
+ 	rtl8153: device@2 {
+ 		compatible = "usbbda,8153";
+ 		reg = <2>;
 +		realtek,led-data = <0x87>;
-+	};
-+};
-+
-+&usb_host0_ehci {
-+	status = "okay";
-+};
-+
-+&usb_host0_ohci {
-+	status = "okay";
-+};
+ 	};
+ };
+ 
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/add-board-rk3328-roc-pc.patch
+++ b/patch/kernel/archive/rockchip64-6.3/add-board-rk3328-roc-pc.patch
@@ -1,33 +1,42 @@
-From df33a68c3fdf58fd87f0599bcc49e7f09cf916ba Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
 Date: Tue, 12 Oct 2021 19:34:29 +0000
-Subject: [PATCH] enable dmc for rk3328-roc-pc
+Subject: enable dmc for rk3328-roc-pc
 
 ---
- .../arm64/boot/dts/rockchip/rk3328-roc-pc.dts | 529 ++++++++++++++++++
- 1 file changed, 529 insertions(+)
- create mode 100644 arch/arm64/boot/dts/rockchip/rk3328-roc-pc.dts
+ arch/arm64/boot/dts/rockchip/rk3328-roc-pc.dts | 525 ++++++++--
+ 1 file changed, 466 insertions(+), 59 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328-roc-pc.dts b/arch/arm64/boot/dts/rockchip/rk3328-roc-pc.dts
-new file mode 100644
-index 000000000..08d77c694
---- /dev/null
+index e3e3984d01d4..02047f049822 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3328-roc-pc.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-roc-pc.dts
-@@ -0,0 +1,517 @@
+@@ -1,110 +1,517 @@
+-// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+-// Copyright (c) 2021 T-Chip Intelligent Technology Co., Ltd
 +/*
 + * SPDX-License-Identifier: (GPL-2.0+ or MIT)
 + * Copyright (c) 2016 Fuzhou Rockchip Electronics Co., Ltd
 + */
-+
-+/dts-v1/;
+ 
+ /dts-v1/;
+-
 +#include "rk3328-roc-pc-dram-timing.dtsi"
 +#include "rk3328.dtsi"
-+#include <dt-bindings/input/input.h>
-+
-+/ {
+ #include <dt-bindings/input/input.h>
+ 
+-#include "rk3328-roc-cc.dts"
+-
+ / {
+-	model = "Firefly ROC-RK3328-PC";
 +	model = "Firefly roc-rk3328-pc";
-+	compatible = "firefly,roc-rk3328-pc", "rockchip,rk3328";
-+
+ 	compatible = "firefly,roc-rk3328-pc", "rockchip,rk3328";
+ 
+-	adc-keys {
+-		compatible = "adc-keys";
+-		io-channels = <&saradc 0>;
+-		io-channel-names = "buttons";
+-		keyup-threshold-microvolt = <1750000>;
 +	aliases {
 +		mmc0 = &sdmmc;
 +		mmc1 = &emmc; /* MMC boot device */
@@ -52,7 +61,12 @@ index 000000000..08d77c694
 +			sound-dai = <&codec>;
 +		};
 +	};
-+
+ 
+-		/* This button is unpopulated out of the factory. */
+-		button-recovery {
+-			label = "Recovery";
+-			linux,code = <KEY_VENDOR>;
+-			press-threshold-microvolt = <10000>;
 +	hdmi-sound {
 +		compatible = "simple-audio-card";
 +		simple-audio-card,format = "i2s";
@@ -60,7 +74,7 @@ index 000000000..08d77c694
 +		simple-audio-card,name = "rockchip,hdmi";
 +		simple-audio-card,cpu {
 +			sound-dai = <&i2s0>;
-+		};
+ 		};
 +		simple-audio-card,codec {
 +			sound-dai = <&hdmi>;
 +		};
@@ -83,24 +97,33 @@ index 000000000..08d77c694
 +		regulator-name = "vcc_phy";
 +		regulator-always-on;
 +		regulator-boot-on;
-+	};
-+
+ 	};
+ 
+-	ir-receiver {
+-		compatible = "gpio-ir-receiver";
+-		gpios = <&gpio2 RK_PA2 GPIO_ACTIVE_LOW>;
+-		linux,rc-map-name = "rc-khadas";
 +	vcc_phy: vcc-phy-regulator {
 +		compatible = "regulator-fixed";
 +		enable-active-high;
 +		gpio = <&gpio0 RK_PA2 GPIO_ACTIVE_HIGH>;
-+		pinctrl-names = "default";
+ 		pinctrl-names = "default";
+-		pinctrl-0 = <&ir_int>;
 +		pinctrl-0 = <&usb20_host_drv>;
 +		regulator-name = "vcc_host1_5v";
 +		regulator-always-on;
 +		regulator-boot-on;
 +		vin-supply = <&vcc_sys>;
-+	};
-+
+ 	};
+ 
+-	sdio_pwrseq: sdio-pwrseq {
+-		compatible = "mmc-pwrseq-simple";
 +	vcc_sd: sdmmc-regulator {
 +		compatible = "regulator-fixed";
 +		gpio = <&gpio0 30 GPIO_ACTIVE_LOW>;
-+		pinctrl-names = "default";
+ 		pinctrl-names = "default";
+-		pinctrl-0 = <&wifi_en>, <&wifi_host_wake>;
+-		reset-gpios = <&gpio3 RK_PB0 GPIO_ACTIVE_LOW>;
 +		pinctrl-0 = <&sdmmc0m1_pin>;
 +		regulator-name = "vcc_sd";
 +		regulator-min-microvolt = <3300000>;
@@ -165,9 +188,11 @@ index 000000000..08d77c694
 +			opp-hz = /bits/ 64 <924000000>;
 +			opp-microvolt = <1100000 1100000 1200000>;
 +		};
-+	};
-+};
-+
+ 	};
+ };
+ 
+-&codec {
+-	mute-gpios = <&grf_gpio 0 GPIO_ACTIVE_LOW>;
 +&dfi {
 +	status = "okay";
 +};
@@ -192,13 +217,17 @@ index 000000000..08d77c694
 +
 +&cpu0 {
 +	cpu-supply = <&vdd_arm>;
-+};
-+
-+&gpu {
+ };
+ 
+ &gpu {
 +	status = "okay";
-+	mali-supply = <&vdd_logic>;
-+};
-+
+ 	mali-supply = <&vdd_logic>;
+ };
+ 
+-&pinctrl {
+-	ir {
+-		ir_int: ir-int {
+-			rockchip,pins = <2 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
 +&gmac2phy {
 +	phy-supply = <&vcc_phy>;
 +	clock_in_out = "output";
@@ -341,8 +370,12 @@ index 000000000..08d77c694
 +
 +		rtc {
 +			status = "okay";
-+		};
-+
+ 		};
+-	};
+ 
+-	sdmmcio {
+-		sdio_per_pin: sdio-per-pin {
+-			rockchip,pins = <0 RK_PD3 RK_FUNC_GPIO &pcfg_pull_down>;
 +		pwrkey {
 +			status = "okay";
 +		};
@@ -439,14 +472,17 @@ index 000000000..08d77c694
 +					regulator-suspend-microvolt = <1100000>;
 +				};
 +			};
-+		};
-+	};
+ 		};
+ 	};
 +};
 +
 +&pinctrl {
 +	pinctrl-names = "default";
 +    pinctrl-0 = <&clk_32k_out>;
-+
+ 
+-	wifi {
+-		wifi_en: wifi-en {
+-			rockchip,pins = <3 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
 +    clk_32k {
 +		clk_32k_out: clk-32k-out {
 +			rockchip,pins =
@@ -458,56 +494,77 @@ index 000000000..08d77c694
 +		pmic_int_l: pmic-int-l {
 +			rockchip,pins =
 +				<2 RK_PA6 RK_FUNC_GPIO &pcfg_pull_up>;	/* gpio2_a6 */
-+		};
+ 		};
 +	};
-+
+ 
+-		wifi_host_wake: wifi-host-wake {
+-			rockchip,pins = <3 RK_PA1 RK_FUNC_GPIO &pcfg_pull_none_4ma>;
 +	sdio-pwrseq {
 +		wifi_enable_h: wifi-enable-h {
 +			rockchip,pins = <3 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>,
 +				<3 RK_PA1 RK_FUNC_GPIO &pcfg_pull_none_4ma>,
 +				<1 RK_PD0 RK_FUNC_GPIO &pcfg_pull_none>,
 +				<1 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
+ 		};
 +	};
-+
+ 
+-		bt_rst: bt-rst {
+-			rockchip,pins = <1 RK_PD0 RK_FUNC_GPIO &pcfg_pull_none>;
 +	usb2 {
 +		usb20_host_drv: usb20-host-drv {
 +			rockchip,pins = <0 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
+ 		};
 +	};
-+
+ 
+-		bt_en: bt-en {
+-			rockchip,pins = <1 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
 +	usb3 {
 +		usb30_host_drv: usb30-host-drv {
 +			rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+};
-+
+ 		};
+ 	};
+ };
+ 
+-&pmic_int_l {
+-	rockchip,pins = <0 RK_PA2 RK_FUNC_GPIO &pcfg_pull_up>;
 +&u2phy {
 +	status = "okay";
-+};
-+
+ };
+ 
+-&rk805 {
+-	interrupt-parent = <&gpio0>;
+-	interrupts = <RK_PA2 IRQ_TYPE_LEVEL_LOW>;
 +&u2phy_host {
 +	status = "okay";
-+};
-+
+ };
+ 
+-&saradc {
+-	vref-supply = <&vcc_18>;
 +&u2phy_otg {
 +	status = "okay";
 +};
 +
 +&uart2 {
-+	status = "okay";
-+};
-+
+ 	status = "okay";
+ };
+ 
+-&usb20_host_drv {
+-	rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_up>;
 +&usb20_otg {
 +	dr_mode = "host";
 +	status = "okay";
-+};
-+
+ };
+ 
+-&vcc_host1_5v {
+-	gpio = <&gpio0 RK_PA0 GPIO_ACTIVE_HIGH>;
 +&usb_host0_ehci {
 +	status = "okay";
-+};
-+
+ };
+ 
+-&vcc_sdio {
+-	gpios = <&gpio0 RK_PD3 GPIO_ACTIVE_HIGH>;
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&sdio_per_pin>;
 +&usb_host0_ohci {
 +	status = "okay";
 +};
@@ -530,7 +587,7 @@ index 000000000..08d77c694
 +	status = "okay";
 +	rockchip,hw-tshut-mode = <1>; /* tshut mode 0:CRU 1:GPIO */
 +	rockchip,hw-tshut-polarity = <1>; /* tshut polarity 0:LOW 1:HIGH */
-+};
+ };
 -- 
-2.30.2
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/add-board-rock-pi-4c-plus.patch
+++ b/patch/kernel/archive/rockchip64-6.3/add-board-rock-pi-4c-plus.patch
@@ -1,10 +1,58 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+Date: Wed, 2 Nov 2022 06:58:31 +0100
+Subject: [ARCHEOLOGY] Add Radxa ROCK Pi 4C Plus (#4129)
+
+> X-Git-Archeology: > recovered message: > * Add Rockpi 4C+
+> X-Git-Archeology: > recovered message: > * add newer patches:
+> X-Git-Archeology: > recovered message: > - apply patches from RadxaNaoki <noaki@radxa.com>
+> X-Git-Archeology: > recovered message: > - ref 5652d6f9c2a4e2c50ac1040c0388859381b0616f: arm64: dts: rockchip: add gmac for ROCK 4C+ (#17)
+> X-Git-Archeology: > recovered message: > - apply latest patches from Marcone <marco.nelissen@gmail.com>
+> X-Git-Archeology: > recovered message: > - ref e39da181b099a86f5440ed1c08fc699d4a65aed7: arm64: dts: rockchip: Make Rock Pi 4C+ ethernet actually work
+> X-Git-Archeology: > recovered message: > - ref 8c519612eeb852268371b3c596eec4622460e5bf: arm64: dts: rockchip: add Rock Pi 4C+ LEDs
+> X-Git-Archeology: > recovered message: > - ref 726441afe687ea6059bac37f145ff204b75430f7: arm64: dts: rockchip: enable Rock Pi 4C+ wifi
+> X-Git-Archeology: > recovered message: > - ref caad7bef3b5558e2598480c0a0089e2ac3cedcdd: arm64: dts: rockchip: enable Rock Pi 4C+ nvme
+> X-Git-Archeology: > recovered message: > - ref 6cdc3215d1691bcd2a407a30e88efa0cec179eb2: arm64: dts: rockchip: enable Rock Pi 4C+ OTG
+> X-Git-Archeology: > recovered message: > * default top USB3 port to host mode
+> X-Git-Archeology: > recovered message: > * get 2nd HDMI port to work at least. :)
+> X-Git-Archeology: > recovered message: > * revert OTG USB3.1 port back to otg mode
+> X-Git-Archeology: > recovered message: > * [rockpi4c+] update board def.  add usb host overlay.
+> X-Git-Archeology: > recovered message: > * remove redundant HDMI clocks and voltages
+> X-Git-Archeology: > recovered message: > * enable test builds for Rock PI 4 C+
+> X-Git-Archeology: > recovered message: > * [rockpi4c+] add USB host overlay
+> X-Git-Archeology: > recovered message: > Co-authored-by: Joe Khoobyar <fourheads@gmail.com>
+> X-Git-Archeology: - Revision 9780da320eeb45832ddb680959646fcc5a6a38c3: https://github.com/armbian/build/commit/9780da320eeb45832ddb680959646fcc5a6a38c3
+> X-Git-Archeology:   Date: Wed, 02 Nov 2022 06:58:31 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Add Radxa ROCK Pi 4C Plus (#4129)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision af24261cad8aac0fe13efd57449a82ab1b33e868: https://github.com/armbian/build/commit/af24261cad8aac0fe13efd57449a82ab1b33e868
+> X-Git-Archeology:   Date: Wed, 02 Nov 2022 10:45:35 -0400
+> X-Git-Archeology:   From: Joe Khoobyar <joekhoobyar@users.noreply.github.com>
+> X-Git-Archeology:   Subject: AR-1301: add edge and desktop (#4377)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/Makefile                   |   1 +
+ arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4c-plus.dts | 720 ++++++++++
+ 2 files changed, 721 insertions(+)
+
 diff --git a/arch/arm64/boot/dts/rockchip/Makefile b/arch/arm64/boot/dts/rockchip/Makefile
-index 7eb135a5143f..1574279e61e8 100644
+index 99a44c400d6a..855348816853 100644
 --- a/arch/arm64/boot/dts/rockchip/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/Makefile
-@@ -39,6 +39,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-roc-pc-mezzanine.dtb
- dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-rock-pi-4a.dtb
+@@ -60,6 +60,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-rock-pi-4a-plus.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-rock-pi-4b.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-rock-pi-4b-plus.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-rock-pi-4c.dtb
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-rock-pi-4c-plus.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-rock960.dtb
@@ -736,3 +784,6 @@ index 000000000000..9fc8d5baba54
 +		};
 +	};
 +};
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/add-board-tinker-board-2.patch
+++ b/patch/kernel/archive/rockchip64-6.3/add-board-tinker-board-2.patch
@@ -1,17 +1,16 @@
-From 98250da85549f89a889424926d3552f4abd09a1f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: tonymac32 <tonymckahan@gmail.com>
 Date: Tue, 2 Mar 2021 15:50:01 -0500
-Subject: [PATCH] Patching something
+Subject: Adding DTS for the Tinkerboard-2
 
 Signed-off-by: tonymac32 <tonymckahan@gmail.com>
 ---
- .../boot/dts/rockchip/rk3399-tinker-2.dts     | 613 ++++++++++++++++++
- 1 files changed, 613 insertions(+)
- create mode 100644 arch/arm64/boot/dts/rockchip/rk3399-tinker-2.dts
+ arch/arm64/boot/dts/rockchip/rk3399-tinker-2.dts | 751 ++++++++++
+ 1 file changed, 751 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-tinker-2.dts b/arch/arm64/boot/dts/rockchip/rk3399-tinker-2.dts
 new file mode 100644
-index 000000000..dc337bee0
+index 000000000000..0f4b28ae0118
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-tinker-2.dts
 @@ -0,0 +1,751 @@
@@ -767,5 +766,5 @@ index 000000000..dc337bee0
 +	status = "okay";
 +}; 
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/add-board-tvbox-rk3318.patch
+++ b/patch/kernel/archive/rockchip64-6.3/add-board-tvbox-rk3318.patch
@@ -1,324 +1,49 @@
-diff --git a/arch/arm64/boot/dts/rockchip/rk3318-dram-default-timing.dtsi b/arch/arm64/boot/dts/rockchip/rk3318-dram-default-timing.dtsi
-new file mode 100644
-index 000000000..31a28d829
---- /dev/null
-+++ b/arch/arm64/boot/dts/rockchip/rk3318-dram-default-timing.dtsi
-@@ -0,0 +1,311 @@
-+/*
-+ * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd
-+ *
-+ * This file is dual-licensed: you can use it either under the terms
-+ * of the GPL or the X11 license, at your option. Note that this dual
-+ * licensing only applies to this file, and not this project as a
-+ * whole.
-+ *
-+ *  a) This library is free software; you can redistribute it and/or
-+ *     modify it under the terms of the GNU General Public License as
-+ *     published by the Free Software Foundation; either version 2 of the
-+ *     License, or (at your option) any later version.
-+ *
-+ *     This library is distributed in the hope that it will be useful,
-+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ *     GNU General Public License for more details.
-+ *
-+ * Or, alternatively,
-+ *
-+ *  b) Permission is hereby granted, free of charge, to any person
-+ *     obtaining a copy of this software and associated documentation
-+ *     files (the "Software"), to deal in the Software without
-+ *     restriction, including without limitation the rights to use,
-+ *     copy, modify, merge, publish, distribute, sublicense, and/or
-+ *     sell copies of the Software, and to permit persons to whom the
-+ *     Software is furnished to do so, subject to the following
-+ *     conditions:
-+ *
-+ *     The above copyright notice and this permission notice shall be
-+ *     included in all copies or substantial portions of the Software.
-+ *
-+ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-+ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-+ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-+ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-+ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-+ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-+ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-+ *     OTHER DEALINGS IN THE SOFTWARE.
-+ */
-+#include <dt-bindings/clock/rockchip-ddr.h>
-+#include <dt-bindings/memory/rk3328-dram.h>
-+
-+/ {
-+	ddr_timing: ddr_timing {
-+		compatible = "rockchip,ddr-timing";
-+		ddr3_speed_bin = <DDR3_DEFAULT>;
-+		ddr4_speed_bin = <DDR4_DEFAULT>;
-+		pd_idle = <0>;
-+		sr_idle = <0>;
-+		sr_mc_gate_idle = <0>;
-+		srpd_lite_idle	= <0>;
-+		standby_idle = <0>;
-+
-+		auto_pd_dis_freq = <1066>;
-+		auto_sr_dis_freq = <800>;
-+		ddr3_dll_dis_freq = <300>;
-+		ddr4_dll_dis_freq = <625>;
-+		phy_dll_dis_freq = <400>;
-+
-+		ddr3_odt_dis_freq = <100>;
-+		phy_ddr3_odt_dis_freq = <100>;
-+		ddr3_drv = <DDR3_DS_40ohm>;
-+		ddr3_odt = <DDR3_ODT_120ohm>;
-+		phy_ddr3_ca_drv = <PHY_DDR3_RON_RTT_23ohm>;
-+		phy_ddr3_ck_drv = <PHY_DDR3_RON_RTT_34ohm>;
-+		phy_ddr3_dq_drv = <PHY_DDR3_RON_RTT_34ohm>;
-+		phy_ddr3_odt = <PHY_DDR3_RON_RTT_150ohm>;
-+
-+		lpddr3_odt_dis_freq = <666>;
-+		phy_lpddr3_odt_dis_freq = <666>;
-+		lpddr3_drv = <LP3_DS_40ohm>;
-+		lpddr3_odt = <LP3_ODT_240ohm>;
-+		phy_lpddr3_ca_drv = <PHY_DDR4_LPDDR3_RON_RTT_34ohm>;
-+		phy_lpddr3_ck_drv = <PHY_DDR4_LPDDR3_RON_RTT_43ohm>;
-+		phy_lpddr3_dq_drv = <PHY_DDR4_LPDDR3_RON_RTT_34ohm>;
-+		phy_lpddr3_odt = <PHY_DDR4_LPDDR3_RON_RTT_240ohm>;
-+
-+		lpddr4_odt_dis_freq = <800>;
-+		phy_lpddr4_odt_dis_freq = <800>;
-+		lpddr4_drv = <LP4_PDDS_60ohm>;
-+		lpddr4_dq_odt = <LP4_DQ_ODT_40ohm>;
-+		lpddr4_ca_odt = <LP4_CA_ODT_40ohm>;
-+		phy_lpddr4_ca_drv = <PHY_DDR4_LPDDR3_RON_RTT_40ohm>;
-+		phy_lpddr4_ck_cs_drv = <PHY_DDR4_LPDDR3_RON_RTT_80ohm>;
-+		phy_lpddr4_dq_drv = <PHY_DDR4_LPDDR3_RON_RTT_80ohm>;
-+		phy_lpddr4_odt = <PHY_DDR4_LPDDR3_RON_RTT_60ohm>;
-+
-+		ddr4_odt_dis_freq = <666>;
-+		phy_ddr4_odt_dis_freq = <666>;
-+		ddr4_drv = <DDR4_DS_34ohm>;
-+		ddr4_odt = <DDR4_RTT_NOM_240ohm>;
-+		phy_ddr4_ca_drv = <PHY_DDR4_LPDDR3_RON_RTT_34ohm>;
-+		phy_ddr4_ck_drv = <PHY_DDR4_LPDDR3_RON_RTT_43ohm>;
-+		phy_ddr4_dq_drv = <PHY_DDR4_LPDDR3_RON_RTT_34ohm>;
-+		phy_ddr4_odt = <PHY_DDR4_LPDDR3_RON_RTT_240ohm>;
-+
-+		/* CA de-skew, one step is 47.8ps, range 0-15 */
-+		ddr3a1_ddr4a9_de-skew = <2>;
-+		ddr3a0_ddr4a10_de-skew = <3>;
-+		ddr3a3_ddr4a6_de-skew = <3>;
-+		ddr3a2_ddr4a4_de-skew = <2>;
-+		ddr3a5_ddr4a8_de-skew = <3>;
-+		ddr3a4_ddr4a5_de-skew = <2>;
-+		ddr3a7_ddr4a11_de-skew = <3>;
-+		ddr3a6_ddr4a7_de-skew = <2>;
-+		ddr3a9_ddr4a0_de-skew = <2>;
-+		ddr3a8_ddr4a13_de-skew = <1>;
-+		ddr3a11_ddr4a3_de-skew = <2>;
-+		ddr3a10_ddr4cs0_de-skew = <2>;
-+		ddr3a13_ddr4a2_de-skew = <1>;
-+		ddr3a12_ddr4ba1_de-skew = <2>;
-+		ddr3a15_ddr4odt0_de-skew = <3>;
-+		ddr3a14_ddr4a1_de-skew = <2>;
-+		ddr3ba1_ddr4a15_de-skew = <2>;
-+		ddr3ba0_ddr4bg0_de-skew = <4>;
-+		ddr3ras_ddr4cke_de-skew = <4>;
-+		ddr3ba2_ddr4ba0_de-skew = <3>;
-+		ddr3we_ddr4bg1_de-skew = <2>;
-+		ddr3cas_ddr4a12_de-skew = <2>;
-+		ddr3ckn_ddr4ckn_de-skew = <11>;
-+		ddr3ckp_ddr4ckp_de-skew = <11>;
-+		ddr3cke_ddr4a16_de-skew = <2>;
-+		ddr3odt0_ddr4a14_de-skew = <4>;
-+		ddr3cs0_ddr4act_de-skew = <4>;
-+		ddr3reset_ddr4reset_de-skew = <7>;
-+		ddr3cs1_ddr4cs1_de-skew = <7>;
-+		ddr3odt1_ddr4odt1_de-skew = <7>;
-+
-+		/* DATA de-skew
-+		 * RX one step is 25.1ps, range 0-15
-+		 * TX one step is 47.8ps, range 0-15
-+		 */
-+		cs0_dm0_rx_de-skew = <12>;
-+		cs0_dm0_tx_de-skew = <10>;
-+		cs0_dq0_rx_de-skew = <12>;
-+		cs0_dq0_tx_de-skew = <10>;
-+		cs0_dq1_rx_de-skew = <12>;
-+		cs0_dq1_tx_de-skew = <10>;
-+		cs0_dq2_rx_de-skew = <12>;
-+		cs0_dq2_tx_de-skew = <10>;
-+		cs0_dq3_rx_de-skew = <12>;
-+		cs0_dq3_tx_de-skew = <10>;
-+		cs0_dq4_rx_de-skew = <12>;
-+		cs0_dq4_tx_de-skew = <10>;
-+		cs0_dq5_rx_de-skew = <12>;
-+		cs0_dq5_tx_de-skew = <10>;
-+		cs0_dq6_rx_de-skew = <12>;
-+		cs0_dq6_tx_de-skew = <10>;
-+		cs0_dq7_rx_de-skew = <12>;
-+		cs0_dq7_tx_de-skew = <10>;
-+		cs0_dqs0_rx_de-skew = <10>;
-+		cs0_dqs0p_tx_de-skew = <12>;
-+		cs0_dqs0n_tx_de-skew = <12>;
-+
-+		cs0_dm1_rx_de-skew = <10>;
-+		cs0_dm1_tx_de-skew = <8>;
-+		cs0_dq8_rx_de-skew = <10>;
-+		cs0_dq8_tx_de-skew = <8>;
-+		cs0_dq9_rx_de-skew = <10>;
-+		cs0_dq9_tx_de-skew = <8>;
-+		cs0_dq10_rx_de-skew = <10>;
-+		cs0_dq10_tx_de-skew = <8>;
-+		cs0_dq11_rx_de-skew = <10>;
-+		cs0_dq11_tx_de-skew = <8>;
-+		cs0_dq12_rx_de-skew = <10>;
-+		cs0_dq12_tx_de-skew = <8>;
-+		cs0_dq13_rx_de-skew = <10>;
-+		cs0_dq13_tx_de-skew = <8>;
-+		cs0_dq14_rx_de-skew = <10>;
-+		cs0_dq14_tx_de-skew = <8>;
-+		cs0_dq15_rx_de-skew = <10>;
-+		cs0_dq15_tx_de-skew = <8>;
-+		cs0_dqs1_rx_de-skew = <9>;
-+		cs0_dqs1p_tx_de-skew = <10>;
-+		cs0_dqs1n_tx_de-skew = <10>;
-+
-+		cs0_dm2_rx_de-skew = <10>;
-+		cs0_dm2_tx_de-skew = <9>;
-+		cs0_dq16_rx_de-skew = <10>;
-+		cs0_dq16_tx_de-skew = <9>;
-+		cs0_dq17_rx_de-skew = <10>;
-+		cs0_dq17_tx_de-skew = <9>;
-+		cs0_dq18_rx_de-skew = <10>;
-+		cs0_dq18_tx_de-skew = <9>;
-+		cs0_dq19_rx_de-skew = <10>;
-+		cs0_dq19_tx_de-skew = <9>;
-+		cs0_dq20_rx_de-skew = <10>;
-+		cs0_dq20_tx_de-skew = <9>;
-+		cs0_dq21_rx_de-skew = <10>;
-+		cs0_dq21_tx_de-skew = <9>;
-+		cs0_dq22_rx_de-skew = <10>;
-+		cs0_dq22_tx_de-skew = <9>;
-+		cs0_dq23_rx_de-skew = <10>;
-+		cs0_dq23_tx_de-skew = <9>;
-+		cs0_dqs2_rx_de-skew = <9>;
-+		cs0_dqs2p_tx_de-skew = <11>;
-+		cs0_dqs2n_tx_de-skew = <11>;
-+
-+		cs0_dm3_rx_de-skew = <7>;
-+		cs0_dm3_tx_de-skew = <7>;
-+		cs0_dq24_rx_de-skew = <7>;
-+		cs0_dq24_tx_de-skew = <7>;
-+		cs0_dq25_rx_de-skew = <7>;
-+		cs0_dq25_tx_de-skew = <7>;
-+		cs0_dq26_rx_de-skew = <7>;
-+		cs0_dq26_tx_de-skew = <7>;
-+		cs0_dq27_rx_de-skew = <7>;
-+		cs0_dq27_tx_de-skew = <7>;
-+		cs0_dq28_rx_de-skew = <7>;
-+		cs0_dq28_tx_de-skew = <7>;
-+		cs0_dq29_rx_de-skew = <7>;
-+		cs0_dq29_tx_de-skew = <7>;
-+		cs0_dq30_rx_de-skew = <7>;
-+		cs0_dq30_tx_de-skew = <7>;
-+		cs0_dq31_rx_de-skew = <7>;
-+		cs0_dq31_tx_de-skew = <7>;
-+		cs0_dqs3_rx_de-skew = <7>;
-+		cs0_dqs3p_tx_de-skew = <10>;
-+		cs0_dqs3n_tx_de-skew = <10>;
-+
-+		cs1_dm0_rx_de-skew = <7>;
-+		cs1_dm0_tx_de-skew = <8>;
-+		cs1_dq0_rx_de-skew = <7>;
-+		cs1_dq0_tx_de-skew = <8>;
-+		cs1_dq1_rx_de-skew = <7>;
-+		cs1_dq1_tx_de-skew = <8>;
-+		cs1_dq2_rx_de-skew = <7>;
-+		cs1_dq2_tx_de-skew = <8>;
-+		cs1_dq3_rx_de-skew = <7>;
-+		cs1_dq3_tx_de-skew = <8>;
-+		cs1_dq4_rx_de-skew = <7>;
-+		cs1_dq4_tx_de-skew = <8>;
-+		cs1_dq5_rx_de-skew = <7>;
-+		cs1_dq5_tx_de-skew = <8>;
-+		cs1_dq6_rx_de-skew = <7>;
-+		cs1_dq6_tx_de-skew = <8>;
-+		cs1_dq7_rx_de-skew = <7>;
-+		cs1_dq7_tx_de-skew = <8>;
-+		cs1_dqs0_rx_de-skew = <6>;
-+		cs1_dqs0p_tx_de-skew = <9>;
-+		cs1_dqs0n_tx_de-skew = <9>;
-+
-+		cs1_dm1_rx_de-skew = <7>;
-+		cs1_dm1_tx_de-skew = <7>;
-+		cs1_dq8_rx_de-skew = <7>;
-+		cs1_dq8_tx_de-skew = <8>;
-+		cs1_dq9_rx_de-skew = <7>;
-+		cs1_dq9_tx_de-skew = <7>;
-+		cs1_dq10_rx_de-skew = <7>;
-+		cs1_dq10_tx_de-skew = <8>;
-+		cs1_dq11_rx_de-skew = <7>;
-+		cs1_dq11_tx_de-skew = <7>;
-+		cs1_dq12_rx_de-skew = <7>;
-+		cs1_dq12_tx_de-skew = <8>;
-+		cs1_dq13_rx_de-skew = <7>;
-+		cs1_dq13_tx_de-skew = <7>;
-+		cs1_dq14_rx_de-skew = <7>;
-+		cs1_dq14_tx_de-skew = <8>;
-+		cs1_dq15_rx_de-skew = <7>;
-+		cs1_dq15_tx_de-skew = <7>;
-+		cs1_dqs1_rx_de-skew = <7>;
-+		cs1_dqs1p_tx_de-skew = <9>;
-+		cs1_dqs1n_tx_de-skew = <9>;
-+
-+		cs1_dm2_rx_de-skew = <7>;
-+		cs1_dm2_tx_de-skew = <8>;
-+		cs1_dq16_rx_de-skew = <7>;
-+		cs1_dq16_tx_de-skew = <8>;
-+		cs1_dq17_rx_de-skew = <7>;
-+		cs1_dq17_tx_de-skew = <8>;
-+		cs1_dq18_rx_de-skew = <7>;
-+		cs1_dq18_tx_de-skew = <8>;
-+		cs1_dq19_rx_de-skew = <7>;
-+		cs1_dq19_tx_de-skew = <8>;
-+		cs1_dq20_rx_de-skew = <7>;
-+		cs1_dq20_tx_de-skew = <8>;
-+		cs1_dq21_rx_de-skew = <7>;
-+		cs1_dq21_tx_de-skew = <8>;
-+		cs1_dq22_rx_de-skew = <7>;
-+		cs1_dq22_tx_de-skew = <8>;
-+		cs1_dq23_rx_de-skew = <7>;
-+		cs1_dq23_tx_de-skew = <8>;
-+		cs1_dqs2_rx_de-skew = <6>;
-+		cs1_dqs2p_tx_de-skew = <9>;
-+		cs1_dqs2n_tx_de-skew = <9>;
-+
-+		cs1_dm3_rx_de-skew = <7>;
-+		cs1_dm3_tx_de-skew = <7>;
-+		cs1_dq24_rx_de-skew = <7>;
-+		cs1_dq24_tx_de-skew = <8>;
-+		cs1_dq25_rx_de-skew = <7>;
-+		cs1_dq25_tx_de-skew = <7>;
-+		cs1_dq26_rx_de-skew = <7>;
-+		cs1_dq26_tx_de-skew = <7>;
-+		cs1_dq27_rx_de-skew = <7>;
-+		cs1_dq27_tx_de-skew = <7>;
-+		cs1_dq28_rx_de-skew = <7>;
-+		cs1_dq28_tx_de-skew = <7>;
-+		cs1_dq29_rx_de-skew = <7>;
-+		cs1_dq29_tx_de-skew = <7>;
-+		cs1_dq30_rx_de-skew = <7>;
-+		cs1_dq30_tx_de-skew = <7>;
-+		cs1_dq31_rx_de-skew = <7>;
-+		cs1_dq31_tx_de-skew = <7>;
-+		cs1_dqs3_rx_de-skew = <7>;
-+		cs1_dqs3p_tx_de-skew = <9>;
-+		cs1_dqs3n_tx_de-skew = <9>;
-+	};
-+};
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paolo <paolo.sabatino@gmail.com>
+Date: Thu, 23 Jun 2022 08:30:54 +0200
+Subject: [ARCHEOLOGY] rockchip64: add rk3318-box tvbox board patch and
+ configurations (#3921)
+
+> X-Git-Archeology: > recovered message: > * rockchip64: add rk3318-box tvbox board patch and configurations
+> X-Git-Archeology: > recovered message: > * rockchip64: add missing bcm43342 patch for edge kernel
+> X-Git-Archeology: - Revision 2ca6a9381db4b875533926e0eae9d3d17f68ad06: https://github.com/armbian/build/commit/2ca6a9381db4b875533926e0eae9d3d17f68ad06
+> X-Git-Archeology:   Date: Thu, 23 Jun 2022 08:30:54 +0200
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip64: add rk3318-box tvbox board patch and configurations (#3921)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0310f955051adafee3a9701e7e54f01d6a496ff5: https://github.com/armbian/build/commit/0310f955051adafee3a9701e7e54f01d6a496ff5
+> X-Git-Archeology:   Date: Sat, 09 Jul 2022 16:30:16 +0200
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip64: fix rk3318-box cpu voltages (#3976)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3318-box.dts                  | 736 ++++++++++
+ arch/arm64/boot/dts/rockchip/rk3318-dram-default-timing.dtsi | 311 ++++
+ 2 files changed, 1047 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3318-box.dts b/arch/arm64/boot/dts/rockchip/rk3318-box.dts
 new file mode 100644
-index 00000000000..28acf1fe127
+index 000000000000..cfc43f6476e9
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3318-box.dts
 @@ -0,0 +1,736 @@
@@ -1058,3 +783,323 @@ index 00000000000..28acf1fe127
 +&analog_sound {
 +	status = "okay";
 +};
+diff --git a/arch/arm64/boot/dts/rockchip/rk3318-dram-default-timing.dtsi b/arch/arm64/boot/dts/rockchip/rk3318-dram-default-timing.dtsi
+new file mode 100644
+index 000000000000..31a28d82952f
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3318-dram-default-timing.dtsi
+@@ -0,0 +1,311 @@
++/*
++ * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd
++ *
++ * This file is dual-licensed: you can use it either under the terms
++ * of the GPL or the X11 license, at your option. Note that this dual
++ * licensing only applies to this file, and not this project as a
++ * whole.
++ *
++ *  a) This library is free software; you can redistribute it and/or
++ *     modify it under the terms of the GNU General Public License as
++ *     published by the Free Software Foundation; either version 2 of the
++ *     License, or (at your option) any later version.
++ *
++ *     This library is distributed in the hope that it will be useful,
++ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *     GNU General Public License for more details.
++ *
++ * Or, alternatively,
++ *
++ *  b) Permission is hereby granted, free of charge, to any person
++ *     obtaining a copy of this software and associated documentation
++ *     files (the "Software"), to deal in the Software without
++ *     restriction, including without limitation the rights to use,
++ *     copy, modify, merge, publish, distribute, sublicense, and/or
++ *     sell copies of the Software, and to permit persons to whom the
++ *     Software is furnished to do so, subject to the following
++ *     conditions:
++ *
++ *     The above copyright notice and this permission notice shall be
++ *     included in all copies or substantial portions of the Software.
++ *
++ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
++ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
++ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
++ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
++ *     OTHER DEALINGS IN THE SOFTWARE.
++ */
++#include <dt-bindings/clock/rockchip-ddr.h>
++#include <dt-bindings/memory/rk3328-dram.h>
++
++/ {
++	ddr_timing: ddr_timing {
++		compatible = "rockchip,ddr-timing";
++		ddr3_speed_bin = <DDR3_DEFAULT>;
++		ddr4_speed_bin = <DDR4_DEFAULT>;
++		pd_idle = <0>;
++		sr_idle = <0>;
++		sr_mc_gate_idle = <0>;
++		srpd_lite_idle	= <0>;
++		standby_idle = <0>;
++
++		auto_pd_dis_freq = <1066>;
++		auto_sr_dis_freq = <800>;
++		ddr3_dll_dis_freq = <300>;
++		ddr4_dll_dis_freq = <625>;
++		phy_dll_dis_freq = <400>;
++
++		ddr3_odt_dis_freq = <100>;
++		phy_ddr3_odt_dis_freq = <100>;
++		ddr3_drv = <DDR3_DS_40ohm>;
++		ddr3_odt = <DDR3_ODT_120ohm>;
++		phy_ddr3_ca_drv = <PHY_DDR3_RON_RTT_23ohm>;
++		phy_ddr3_ck_drv = <PHY_DDR3_RON_RTT_34ohm>;
++		phy_ddr3_dq_drv = <PHY_DDR3_RON_RTT_34ohm>;
++		phy_ddr3_odt = <PHY_DDR3_RON_RTT_150ohm>;
++
++		lpddr3_odt_dis_freq = <666>;
++		phy_lpddr3_odt_dis_freq = <666>;
++		lpddr3_drv = <LP3_DS_40ohm>;
++		lpddr3_odt = <LP3_ODT_240ohm>;
++		phy_lpddr3_ca_drv = <PHY_DDR4_LPDDR3_RON_RTT_34ohm>;
++		phy_lpddr3_ck_drv = <PHY_DDR4_LPDDR3_RON_RTT_43ohm>;
++		phy_lpddr3_dq_drv = <PHY_DDR4_LPDDR3_RON_RTT_34ohm>;
++		phy_lpddr3_odt = <PHY_DDR4_LPDDR3_RON_RTT_240ohm>;
++
++		lpddr4_odt_dis_freq = <800>;
++		phy_lpddr4_odt_dis_freq = <800>;
++		lpddr4_drv = <LP4_PDDS_60ohm>;
++		lpddr4_dq_odt = <LP4_DQ_ODT_40ohm>;
++		lpddr4_ca_odt = <LP4_CA_ODT_40ohm>;
++		phy_lpddr4_ca_drv = <PHY_DDR4_LPDDR3_RON_RTT_40ohm>;
++		phy_lpddr4_ck_cs_drv = <PHY_DDR4_LPDDR3_RON_RTT_80ohm>;
++		phy_lpddr4_dq_drv = <PHY_DDR4_LPDDR3_RON_RTT_80ohm>;
++		phy_lpddr4_odt = <PHY_DDR4_LPDDR3_RON_RTT_60ohm>;
++
++		ddr4_odt_dis_freq = <666>;
++		phy_ddr4_odt_dis_freq = <666>;
++		ddr4_drv = <DDR4_DS_34ohm>;
++		ddr4_odt = <DDR4_RTT_NOM_240ohm>;
++		phy_ddr4_ca_drv = <PHY_DDR4_LPDDR3_RON_RTT_34ohm>;
++		phy_ddr4_ck_drv = <PHY_DDR4_LPDDR3_RON_RTT_43ohm>;
++		phy_ddr4_dq_drv = <PHY_DDR4_LPDDR3_RON_RTT_34ohm>;
++		phy_ddr4_odt = <PHY_DDR4_LPDDR3_RON_RTT_240ohm>;
++
++		/* CA de-skew, one step is 47.8ps, range 0-15 */
++		ddr3a1_ddr4a9_de-skew = <2>;
++		ddr3a0_ddr4a10_de-skew = <3>;
++		ddr3a3_ddr4a6_de-skew = <3>;
++		ddr3a2_ddr4a4_de-skew = <2>;
++		ddr3a5_ddr4a8_de-skew = <3>;
++		ddr3a4_ddr4a5_de-skew = <2>;
++		ddr3a7_ddr4a11_de-skew = <3>;
++		ddr3a6_ddr4a7_de-skew = <2>;
++		ddr3a9_ddr4a0_de-skew = <2>;
++		ddr3a8_ddr4a13_de-skew = <1>;
++		ddr3a11_ddr4a3_de-skew = <2>;
++		ddr3a10_ddr4cs0_de-skew = <2>;
++		ddr3a13_ddr4a2_de-skew = <1>;
++		ddr3a12_ddr4ba1_de-skew = <2>;
++		ddr3a15_ddr4odt0_de-skew = <3>;
++		ddr3a14_ddr4a1_de-skew = <2>;
++		ddr3ba1_ddr4a15_de-skew = <2>;
++		ddr3ba0_ddr4bg0_de-skew = <4>;
++		ddr3ras_ddr4cke_de-skew = <4>;
++		ddr3ba2_ddr4ba0_de-skew = <3>;
++		ddr3we_ddr4bg1_de-skew = <2>;
++		ddr3cas_ddr4a12_de-skew = <2>;
++		ddr3ckn_ddr4ckn_de-skew = <11>;
++		ddr3ckp_ddr4ckp_de-skew = <11>;
++		ddr3cke_ddr4a16_de-skew = <2>;
++		ddr3odt0_ddr4a14_de-skew = <4>;
++		ddr3cs0_ddr4act_de-skew = <4>;
++		ddr3reset_ddr4reset_de-skew = <7>;
++		ddr3cs1_ddr4cs1_de-skew = <7>;
++		ddr3odt1_ddr4odt1_de-skew = <7>;
++
++		/* DATA de-skew
++		 * RX one step is 25.1ps, range 0-15
++		 * TX one step is 47.8ps, range 0-15
++		 */
++		cs0_dm0_rx_de-skew = <12>;
++		cs0_dm0_tx_de-skew = <10>;
++		cs0_dq0_rx_de-skew = <12>;
++		cs0_dq0_tx_de-skew = <10>;
++		cs0_dq1_rx_de-skew = <12>;
++		cs0_dq1_tx_de-skew = <10>;
++		cs0_dq2_rx_de-skew = <12>;
++		cs0_dq2_tx_de-skew = <10>;
++		cs0_dq3_rx_de-skew = <12>;
++		cs0_dq3_tx_de-skew = <10>;
++		cs0_dq4_rx_de-skew = <12>;
++		cs0_dq4_tx_de-skew = <10>;
++		cs0_dq5_rx_de-skew = <12>;
++		cs0_dq5_tx_de-skew = <10>;
++		cs0_dq6_rx_de-skew = <12>;
++		cs0_dq6_tx_de-skew = <10>;
++		cs0_dq7_rx_de-skew = <12>;
++		cs0_dq7_tx_de-skew = <10>;
++		cs0_dqs0_rx_de-skew = <10>;
++		cs0_dqs0p_tx_de-skew = <12>;
++		cs0_dqs0n_tx_de-skew = <12>;
++
++		cs0_dm1_rx_de-skew = <10>;
++		cs0_dm1_tx_de-skew = <8>;
++		cs0_dq8_rx_de-skew = <10>;
++		cs0_dq8_tx_de-skew = <8>;
++		cs0_dq9_rx_de-skew = <10>;
++		cs0_dq9_tx_de-skew = <8>;
++		cs0_dq10_rx_de-skew = <10>;
++		cs0_dq10_tx_de-skew = <8>;
++		cs0_dq11_rx_de-skew = <10>;
++		cs0_dq11_tx_de-skew = <8>;
++		cs0_dq12_rx_de-skew = <10>;
++		cs0_dq12_tx_de-skew = <8>;
++		cs0_dq13_rx_de-skew = <10>;
++		cs0_dq13_tx_de-skew = <8>;
++		cs0_dq14_rx_de-skew = <10>;
++		cs0_dq14_tx_de-skew = <8>;
++		cs0_dq15_rx_de-skew = <10>;
++		cs0_dq15_tx_de-skew = <8>;
++		cs0_dqs1_rx_de-skew = <9>;
++		cs0_dqs1p_tx_de-skew = <10>;
++		cs0_dqs1n_tx_de-skew = <10>;
++
++		cs0_dm2_rx_de-skew = <10>;
++		cs0_dm2_tx_de-skew = <9>;
++		cs0_dq16_rx_de-skew = <10>;
++		cs0_dq16_tx_de-skew = <9>;
++		cs0_dq17_rx_de-skew = <10>;
++		cs0_dq17_tx_de-skew = <9>;
++		cs0_dq18_rx_de-skew = <10>;
++		cs0_dq18_tx_de-skew = <9>;
++		cs0_dq19_rx_de-skew = <10>;
++		cs0_dq19_tx_de-skew = <9>;
++		cs0_dq20_rx_de-skew = <10>;
++		cs0_dq20_tx_de-skew = <9>;
++		cs0_dq21_rx_de-skew = <10>;
++		cs0_dq21_tx_de-skew = <9>;
++		cs0_dq22_rx_de-skew = <10>;
++		cs0_dq22_tx_de-skew = <9>;
++		cs0_dq23_rx_de-skew = <10>;
++		cs0_dq23_tx_de-skew = <9>;
++		cs0_dqs2_rx_de-skew = <9>;
++		cs0_dqs2p_tx_de-skew = <11>;
++		cs0_dqs2n_tx_de-skew = <11>;
++
++		cs0_dm3_rx_de-skew = <7>;
++		cs0_dm3_tx_de-skew = <7>;
++		cs0_dq24_rx_de-skew = <7>;
++		cs0_dq24_tx_de-skew = <7>;
++		cs0_dq25_rx_de-skew = <7>;
++		cs0_dq25_tx_de-skew = <7>;
++		cs0_dq26_rx_de-skew = <7>;
++		cs0_dq26_tx_de-skew = <7>;
++		cs0_dq27_rx_de-skew = <7>;
++		cs0_dq27_tx_de-skew = <7>;
++		cs0_dq28_rx_de-skew = <7>;
++		cs0_dq28_tx_de-skew = <7>;
++		cs0_dq29_rx_de-skew = <7>;
++		cs0_dq29_tx_de-skew = <7>;
++		cs0_dq30_rx_de-skew = <7>;
++		cs0_dq30_tx_de-skew = <7>;
++		cs0_dq31_rx_de-skew = <7>;
++		cs0_dq31_tx_de-skew = <7>;
++		cs0_dqs3_rx_de-skew = <7>;
++		cs0_dqs3p_tx_de-skew = <10>;
++		cs0_dqs3n_tx_de-skew = <10>;
++
++		cs1_dm0_rx_de-skew = <7>;
++		cs1_dm0_tx_de-skew = <8>;
++		cs1_dq0_rx_de-skew = <7>;
++		cs1_dq0_tx_de-skew = <8>;
++		cs1_dq1_rx_de-skew = <7>;
++		cs1_dq1_tx_de-skew = <8>;
++		cs1_dq2_rx_de-skew = <7>;
++		cs1_dq2_tx_de-skew = <8>;
++		cs1_dq3_rx_de-skew = <7>;
++		cs1_dq3_tx_de-skew = <8>;
++		cs1_dq4_rx_de-skew = <7>;
++		cs1_dq4_tx_de-skew = <8>;
++		cs1_dq5_rx_de-skew = <7>;
++		cs1_dq5_tx_de-skew = <8>;
++		cs1_dq6_rx_de-skew = <7>;
++		cs1_dq6_tx_de-skew = <8>;
++		cs1_dq7_rx_de-skew = <7>;
++		cs1_dq7_tx_de-skew = <8>;
++		cs1_dqs0_rx_de-skew = <6>;
++		cs1_dqs0p_tx_de-skew = <9>;
++		cs1_dqs0n_tx_de-skew = <9>;
++
++		cs1_dm1_rx_de-skew = <7>;
++		cs1_dm1_tx_de-skew = <7>;
++		cs1_dq8_rx_de-skew = <7>;
++		cs1_dq8_tx_de-skew = <8>;
++		cs1_dq9_rx_de-skew = <7>;
++		cs1_dq9_tx_de-skew = <7>;
++		cs1_dq10_rx_de-skew = <7>;
++		cs1_dq10_tx_de-skew = <8>;
++		cs1_dq11_rx_de-skew = <7>;
++		cs1_dq11_tx_de-skew = <7>;
++		cs1_dq12_rx_de-skew = <7>;
++		cs1_dq12_tx_de-skew = <8>;
++		cs1_dq13_rx_de-skew = <7>;
++		cs1_dq13_tx_de-skew = <7>;
++		cs1_dq14_rx_de-skew = <7>;
++		cs1_dq14_tx_de-skew = <8>;
++		cs1_dq15_rx_de-skew = <7>;
++		cs1_dq15_tx_de-skew = <7>;
++		cs1_dqs1_rx_de-skew = <7>;
++		cs1_dqs1p_tx_de-skew = <9>;
++		cs1_dqs1n_tx_de-skew = <9>;
++
++		cs1_dm2_rx_de-skew = <7>;
++		cs1_dm2_tx_de-skew = <8>;
++		cs1_dq16_rx_de-skew = <7>;
++		cs1_dq16_tx_de-skew = <8>;
++		cs1_dq17_rx_de-skew = <7>;
++		cs1_dq17_tx_de-skew = <8>;
++		cs1_dq18_rx_de-skew = <7>;
++		cs1_dq18_tx_de-skew = <8>;
++		cs1_dq19_rx_de-skew = <7>;
++		cs1_dq19_tx_de-skew = <8>;
++		cs1_dq20_rx_de-skew = <7>;
++		cs1_dq20_tx_de-skew = <8>;
++		cs1_dq21_rx_de-skew = <7>;
++		cs1_dq21_tx_de-skew = <8>;
++		cs1_dq22_rx_de-skew = <7>;
++		cs1_dq22_tx_de-skew = <8>;
++		cs1_dq23_rx_de-skew = <7>;
++		cs1_dq23_tx_de-skew = <8>;
++		cs1_dqs2_rx_de-skew = <6>;
++		cs1_dqs2p_tx_de-skew = <9>;
++		cs1_dqs2n_tx_de-skew = <9>;
++
++		cs1_dm3_rx_de-skew = <7>;
++		cs1_dm3_tx_de-skew = <7>;
++		cs1_dq24_rx_de-skew = <7>;
++		cs1_dq24_tx_de-skew = <8>;
++		cs1_dq25_rx_de-skew = <7>;
++		cs1_dq25_tx_de-skew = <7>;
++		cs1_dq26_rx_de-skew = <7>;
++		cs1_dq26_tx_de-skew = <7>;
++		cs1_dq27_rx_de-skew = <7>;
++		cs1_dq27_tx_de-skew = <7>;
++		cs1_dq28_rx_de-skew = <7>;
++		cs1_dq28_tx_de-skew = <7>;
++		cs1_dq29_rx_de-skew = <7>;
++		cs1_dq29_tx_de-skew = <7>;
++		cs1_dq30_rx_de-skew = <7>;
++		cs1_dq30_tx_de-skew = <7>;
++		cs1_dq31_rx_de-skew = <7>;
++		cs1_dq31_tx_de-skew = <7>;
++		cs1_dqs3_rx_de-skew = <7>;
++		cs1_dqs3p_tx_de-skew = <9>;
++		cs1_dqs3n_tx_de-skew = <9>;
++	};
++};
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/add-boards-to-dts-makefile.patch
+++ b/patch/kernel/archive/rockchip64-6.3/add-boards-to-dts-makefile.patch
@@ -1,5 +1,149 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Piotr Szczepanik <piter75@gmail.com>
+Date: Mon, 14 Dec 2020 23:57:57 +0100
+Subject: Add boards DTS to Makefile
+
+> X-Git-Archeology: - Revision 2ccaee6343060b6614693fbcba36f8386457b850: https://github.com/armbian/build/commit/2ccaee6343060b6614693fbcba36f8386457b850
+> X-Git-Archeology:   Date: Mon, 14 Dec 2020 23:57:57 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Enable station-m1 (roc-rk3328-pc) in rockchip64-dev too
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 1432a5cb96dc7dc290e48879de897af59bb954cb: https://github.com/armbian/build/commit/1432a5cb96dc7dc290e48879de897af59bb954cb
+> X-Git-Archeology:   Date: Mon, 14 Dec 2020 23:57:57 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Consolidate all dts Makefile changes in a single patch in rockchip64-dev
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 19a963189510a541a0486933eb8eaa1d7bc7f695: https://github.com/armbian/build/commit/19a963189510a541a0486933eb8eaa1d7bc7f695
+> X-Git-Archeology:   Date: Mon, 28 Dec 2020 22:44:02 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: - add Neo3 to DEV (#2504)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 18cf7aff702832cf672117f5dc1fe4ad37598837: https://github.com/armbian/build/commit/18cf7aff702832cf672117f5dc1fe4ad37598837
+> X-Git-Archeology:   Date: Tue, 05 Jan 2021 23:35:03 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Consolidate all dts Makefile changes in a single patch in rockchip64-current (#2535)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision d5ab47bff7813b5e94ed239ec6007613740932ba: https://github.com/armbian/build/commit/d5ab47bff7813b5e94ed239ec6007613740932ba
+> X-Git-Archeology:   Date: Sun, 10 Jan 2021 12:40:11 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Minor tweaks to NanoPi R4S configuration (#2543)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 804c57dd5925e67383a3d82c85f18868a6173d4b: https://github.com/armbian/build/commit/804c57dd5925e67383a3d82c85f18868a6173d4b
+> X-Git-Archeology:   Date: Tue, 26 Jan 2021 21:22:37 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Enable RTC (hym8563) for Station P1 in mainline (renaming DT in process) (#2577)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0cdffb29b07305209efb12cf3b5ac6032d3a1153: https://github.com/armbian/build/commit/0cdffb29b07305209efb12cf3b5ac6032d3a1153
+> X-Git-Archeology:   Date: Wed, 24 Mar 2021 19:01:53 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Renaming DEV branch to EDGE (#2704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 05a72b8954e932089d4867b55da0d353dc4ba1ac: https://github.com/armbian/build/commit/05a72b8954e932089d4867b55da0d353dc4ba1ac
+> X-Git-Archeology:   Date: Mon, 12 Apr 2021 22:32:21 +0200
+> X-Git-Archeology:   From: AmadeusGhost <42570690+AmadeusGhost@users.noreply.github.com>
+> X-Git-Archeology:   Subject: rockchip: add Orange Pi R1 Plus support (#2755)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e7377248b3cae186e24e2be781cd3365b43246f0: https://github.com/armbian/build/commit/e7377248b3cae186e24e2be781cd3365b43246f0
+> X-Git-Archeology:   Date: Thu, 22 Jul 2021 00:15:54 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Second part of EDGE bumping to 5.13.y (#3045)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 744ea89a589d62cb6f409baab60fc6664520bc39: https://github.com/armbian/build/commit/744ea89a589d62cb6f409baab60fc6664520bc39
+> X-Git-Archeology:   Date: Wed, 08 Sep 2021 17:51:34 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bumping EDGE kernel to 5.14.y (#3125)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 687c3639183e23e06406739af1684fdeb3efa454: https://github.com/armbian/build/commit/687c3639183e23e06406739af1684fdeb3efa454
+> X-Git-Archeology:   Date: Wed, 15 Sep 2021 22:20:35 +0200
+> X-Git-Archeology:   From: Ruikai (Rick) Liu <rickliu2000@outlook.com>
+> X-Git-Archeology:   Subject: Add NanoPi R2C support (#3138)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e: https://github.com/armbian/build/commit/dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e
+> X-Git-Archeology:   Date: Tue, 09 Nov 2021 18:06:34 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump imx6, xu4, rockchip64 and jetson-nano to 5.15 (#3238)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6ff15fe54f0423267ef464927e3780bc47703eed: https://github.com/armbian/build/commit/6ff15fe54f0423267ef464927e3780bc47703eed
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 15:03:33 +0100
+> X-Git-Archeology:   From: schwar3kat <61094841+schwar3kat@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Add orangepi r1 plus lts (#3514)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 1f54bc33b8dda678de473d7d006a9a7f6ab0b86b: https://github.com/armbian/build/commit/1f54bc33b8dda678de473d7d006a9a7f6ab0b86b
+> X-Git-Archeology:   Date: Wed, 11 May 2022 21:47:28 +0200
+> X-Git-Archeology:   From: CXM <16154023+littlecxm@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Add clockworkpi-a06 support (#3768)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 388e9bbf5ebd83bad953ad0e0a7a0a41ba2a6ed8: https://github.com/armbian/build/commit/388e9bbf5ebd83bad953ad0e0a7a0a41ba2a6ed8
+> X-Git-Archeology:   Date: Tue, 14 Jun 2022 12:11:33 +0200
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: Support for OrangePi4 LTS board (#3770)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 2ca6a9381db4b875533926e0eae9d3d17f68ad06: https://github.com/armbian/build/commit/2ca6a9381db4b875533926e0eae9d3d17f68ad06
+> X-Git-Archeology:   Date: Thu, 23 Jun 2022 08:30:54 +0200
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip64: add rk3318-box tvbox board patch and configurations (#3921)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 76192f1fa830a2c0fcf7a511bfbc119705b46a22: https://github.com/armbian/build/commit/76192f1fa830a2c0fcf7a511bfbc119705b46a22
+> X-Git-Archeology:   Date: Wed, 06 Jul 2022 10:38:09 -0400
+> X-Git-Archeology:   From: Tony <tonymckahan@gmail.com>
+> X-Git-Archeology:   Subject: RK3328 cleanup (#3963)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 44ac745ae34bc3863e0a5a51d1f300968d426811: https://github.com/armbian/build/commit/44ac745ae34bc3863e0a5a51d1f300968d426811
+> X-Git-Archeology:   Date: Sun, 10 Jul 2022 02:14:03 -0400
+> X-Git-Archeology:   From: Tony <tonymckahan@gmail.com>
+> X-Git-Archeology:   Subject: Rockchip64-current: fix nanoPi NEO 3 DTS makefile (#3979)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 2f1140edb1078b4a6a3e73466df942aa36194c46: https://github.com/armbian/build/commit/2f1140edb1078b4a6a3e73466df942aa36194c46
+> X-Git-Archeology:   Date: Tue, 20 Sep 2022 08:50:23 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-enable Neo3 in the EDGE kernel (#4193)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 588c2ec17e709dec19304fa50522459702ebfadd: https://github.com/armbian/build/commit/588c2ec17e709dec19304fa50522459702ebfadd
+> X-Git-Archeology:   Date: Fri, 23 Dec 2022 21:57:53 +0100
+> X-Git-Archeology:   From: brentr <brent@mbari.org>
+> X-Git-Archeology:   Subject: Rockpis devtree mainlined (#4603)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/Makefile | 18 ++++++++++
+ 1 file changed, 18 insertions(+)
+
 diff --git a/arch/arm64/boot/dts/rockchip/Makefile b/arch/arm64/boot/dts/rockchip/Makefile
-index 26661c7b7..1462ed38b 100644
+index 855348816853..68b486245580 100644
 --- a/arch/arm64/boot/dts/rockchip/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/Makefile
 @@ -1,4 +1,22 @@
@@ -25,3 +169,6 @@ index 26661c7b7..1462ed38b 100644
  dtb-$(CONFIG_ARCH_ROCKCHIP) += px30-evb.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += px30-engicam-px30-core-ctouch2.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += px30-engicam-px30-core-ctouch2-of10.dtb
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/add-driver-for-Motorcomm-YT85xx+PHYs.patch
+++ b/patch/kernel/archive/rockchip64-6.3/add-driver-for-Motorcomm-YT85xx+PHYs.patch
@@ -1,25 +1,26 @@
-From 3b60e97e8cf8a1ae78ec68a2fed37cd763675e56 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: baiywt <baiywt_gj@163.com>
 Date: Fri, 18 Feb 2022 16:38:43 +0800
-Subject: [PATCH] Add yt8531c support. 
+Subject: Add yt8531c support
+
+note: rpardini: rebased on top of v6.3.1. drivers/net/phy/motorcomm.c was an overwrite,
+and is now a diff.
+
 Adapted from orangepi-xunlong/openwrt - 600-Add-yt8531c-support.patch by schwar3kat
 ---
  drivers/net/phy/Kconfig       |    5 +
- drivers/net/phy/motorcomm.c   | 1540 +++++++++++++++++++++++++++++++++
- drivers/net/phy/yt8614-phy.h  |  491 +++++++++++
- include/linux/motorcomm_phy.h |  119 +++
- 5 files changed, 2156 insertions(+)
- create mode 100644 drivers/net/phy/motorcomm.c
- create mode 100644 drivers/net/phy/yt8614-phy.h
- create mode 100644 include/linux/motorcomm_phy.h
+ drivers/net/phy/motorcomm.c   | 3045 ++++------
+ drivers/net/phy/yt8614-phy.h  |  491 ++
+ include/linux/motorcomm_phy.h |  119 +
+ 4 files changed, 1803 insertions(+), 1857 deletions(-)
 
 diff --git a/drivers/net/phy/Kconfig b/drivers/net/phy/Kconfig
-index ce030fcb1..ff4861847 100644
+index 54874555c921..e4b1bcd23cf6 100644
 --- a/drivers/net/phy/Kconfig
 +++ b/drivers/net/phy/Kconfig
-@@ -297,6 +297,11 @@ config MICROSEMI_PHY
- 	help
- 	  Currently supports VSC8514, VSC8530, VSC8531, VSC8540 and VSC8541 PHYs
+@@ -259,6 +259,11 @@ config MOTORCOMM_PHY
+ 	  Enables support for Motorcomm network PHYs.
+ 	  Currently supports YT85xx Gigabit Ethernet PHYs.
  
 +config MOTORCOMM_PHY
 +        tristate "Motorcomm PHYs"
@@ -30,14 +31,17 @@ index ce030fcb1..ff4861847 100644
  	tristate "National Semiconductor PHYs"
  	help
 diff --git a/drivers/net/phy/motorcomm.c b/drivers/net/phy/motorcomm.c
-new file mode 100644
-index 000000000..74eef3dfa
---- /dev/null
+index 2fa5a90e073b..74eef3dfad3e 100644
+--- a/drivers/net/phy/motorcomm.c
 +++ b/drivers/net/phy/motorcomm.c
-@@ -0,0 +1,1540 @@
-+/*
+@@ -1,2209 +1,1540 @@
+-// SPDX-License-Identifier: GPL-2.0+
+ /*
+- * Motorcomm 8511/8521/8531/8531S PHY driver.
 + * drivers/net/phy/motorcomm.c
-+ *
+  *
+- * Author: Peter Geis <pgwipeout@gmail.com>
+- * Author: Frank <Frank.Sae@motor-comm.com>
 + * Driver for Motorcomm PHYs
 + *
 + * Author: Leilei Zhao <leilei.zhao@motorcomm.com>
@@ -54,13 +58,29 @@ index 000000000..74eef3dfa
 + *		100/10 Phys : yt8512, yt8512b, yt8510
 + *		Automotive 100Mb Phys : yt8010
 + *		Automotive 100/10 hyper range Phys: yt8510
-+ */
-+
-+#include <linux/kernel.h>
-+#include <linux/module.h>
-+#include <linux/phy.h>
+  */
+ 
+-#include <linux/etherdevice.h>
+ #include <linux/kernel.h>
+ #include <linux/module.h>
+ #include <linux/phy.h>
 +#include <linux/motorcomm_phy.h>
-+#include <linux/of.h>
+ #include <linux/of.h>
+-
+-#define PHY_ID_YT8511		0x0000010a
+-#define PHY_ID_YT8521		0x0000011a
+-#define PHY_ID_YT8531		0x4f51e91b
+-#define PHY_ID_YT8531S		0x4f51e91a
+-
+-/* YT8521/YT8531S Register Overview
+- *	UTP Register space	|	FIBER Register space
+- *  ------------------------------------------------------------
+- * |	UTP MII			|	FIBER MII		|
+- * |	UTP MMD			|				|
+- * |	UTP Extended		|	FIBER Extended		|
+- *  ------------------------------------------------------------
+- * |			Common Extended				|
+- *  ------------------------------------------------------------
 +#include <linux/clk.h>
 +#include <linux/delay.h>
 +#ifndef LINUX_VERSION_CODE
@@ -77,58 +97,313 @@ index 000000000..74eef3dfa
 +
 +/* if system depends on ethernet packet to restore from sleep, please define this macro to 1
 + * otherwise, define it to 0.
-+ */
+  */
 +#define SYS_WAKEUP_BASED_ON_ETH_PKT 	1
-+
+ 
+-/* 0x10 ~ 0x15 , 0x1E and 0x1F are common MII registers of yt phy */
+-
+-/* Specific Function Control Register */
+-#define YTPHY_SPECIFIC_FUNCTION_CONTROL_REG	0x10
+-
+-/* 2b00 Manual MDI configuration
+- * 2b01 Manual MDIX configuration
+- * 2b10 Reserved
+- * 2b11 Enable automatic crossover for all modes  *default*
+- */
+-#define YTPHY_SFCR_MDI_CROSSOVER_MODE_MASK	(BIT(6) | BIT(5))
+-#define YTPHY_SFCR_CROSSOVER_EN			BIT(3)
+-#define YTPHY_SFCR_SQE_TEST_EN			BIT(2)
+-#define YTPHY_SFCR_POLARITY_REVERSAL_EN		BIT(1)
+-#define YTPHY_SFCR_JABBER_DIS			BIT(0)
+-
+-/* Specific Status Register */
+-#define YTPHY_SPECIFIC_STATUS_REG		0x11
+-#define YTPHY_SSR_SPEED_MODE_OFFSET		14
+-
+-#define YTPHY_SSR_SPEED_MODE_MASK		(BIT(15) | BIT(14))
+-#define YTPHY_SSR_SPEED_10M			0x0
+-#define YTPHY_SSR_SPEED_100M			0x1
+-#define YTPHY_SSR_SPEED_1000M			0x2
+-#define YTPHY_SSR_DUPLEX_OFFSET			13
+-#define YTPHY_SSR_DUPLEX			BIT(13)
+-#define YTPHY_SSR_PAGE_RECEIVED			BIT(12)
+-#define YTPHY_SSR_SPEED_DUPLEX_RESOLVED		BIT(11)
+-#define YTPHY_SSR_LINK				BIT(10)
+-#define YTPHY_SSR_MDIX_CROSSOVER		BIT(6)
+-#define YTPHY_SSR_DOWNGRADE			BIT(5)
+-#define YTPHY_SSR_TRANSMIT_PAUSE		BIT(3)
+-#define YTPHY_SSR_RECEIVE_PAUSE			BIT(2)
+-#define YTPHY_SSR_POLARITY			BIT(1)
+-#define YTPHY_SSR_JABBER			BIT(0)
+-
+-/* Interrupt enable Register */
+-#define YTPHY_INTERRUPT_ENABLE_REG		0x12
+-#define YTPHY_IER_WOL				BIT(6)
+-
+-/* Interrupt Status Register */
+-#define YTPHY_INTERRUPT_STATUS_REG		0x13
+-#define YTPHY_ISR_AUTONEG_ERR			BIT(15)
+-#define YTPHY_ISR_SPEED_CHANGED			BIT(14)
+-#define YTPHY_ISR_DUPLEX_CHANGED		BIT(13)
+-#define YTPHY_ISR_PAGE_RECEIVED			BIT(12)
+-#define YTPHY_ISR_LINK_FAILED			BIT(11)
+-#define YTPHY_ISR_LINK_SUCCESSED		BIT(10)
+-#define YTPHY_ISR_WOL				BIT(6)
+-#define YTPHY_ISR_WIRESPEED_DOWNGRADE		BIT(5)
+-#define YTPHY_ISR_SERDES_LINK_FAILED		BIT(3)
+-#define YTPHY_ISR_SERDES_LINK_SUCCESSED		BIT(2)
+-#define YTPHY_ISR_POLARITY_CHANGED		BIT(1)
+-#define YTPHY_ISR_JABBER_HAPPENED		BIT(0)
+-
+-/* Speed Auto Downgrade Control Register */
+-#define YTPHY_SPEED_AUTO_DOWNGRADE_CONTROL_REG	0x14
+-#define YTPHY_SADCR_SPEED_DOWNGRADE_EN		BIT(5)
+-
+-/* If these bits are set to 3, the PHY attempts five times ( 3(set value) +
+- * additional 2) before downgrading, default 0x3
 +/* to enable system WOL of phy, please define this macro to 1
 + * otherwise, define it to 0.
-+ */
+  */
+-#define YTPHY_SADCR_SPEED_RETRY_LIMIT		(0x3 << 2)
 +#define YTPHY_ENABLE_WOL 		0
-+
+ 
+-/* Rx Error Counter Register */
+-#define YTPHY_RX_ERROR_COUNTER_REG		0x15
+-
+-/* Extended Register's Address Offset Register */
+-#define YTPHY_PAGE_SELECT			0x1E
+-
+-/* Extended Register's Data Register */
+-#define YTPHY_PAGE_DATA				0x1F
+-
+-/* FIBER Auto-Negotiation link partner ability */
+-#define YTPHY_FLPA_PAUSE			(0x3 << 7)
+-#define YTPHY_FLPA_ASYM_PAUSE			(0x2 << 7)
+-
+-#define YT8511_PAGE_SELECT	0x1e
+-#define YT8511_PAGE		0x1f
+-#define YT8511_EXT_CLK_GATE	0x0c
+-#define YT8511_EXT_DELAY_DRIVE	0x0d
+-#define YT8511_EXT_SLEEP_CTRL	0x27
+-
+-/* 2b00 25m from pll
+- * 2b01 25m from xtl *default*
+- * 2b10 62.m from pll
+- * 2b11 125m from pll
 +/* some GMAC need clock input from PHY, for eg., 125M, please enable this macro
 + * by degault, it is set to 0
 + * NOTE: this macro will need macro SYS_WAKEUP_BASED_ON_ETH_PKT to set to 1
-+ */
+  */
+-#define YT8511_CLK_125M		(BIT(2) | BIT(1))
+-#define YT8511_PLLON_SLP	BIT(14)
 +#define GMAC_CLOCK_INPUT_NEEDED 1
-+
-+
+ 
+-/* RX Delay enabled = 1.8ns 1000T, 8ns 10/100T */
+-#define YT8511_DELAY_RX		BIT(0)
+ 
+-/* TX Gig-E Delay is bits 7:4, default 0x5
+- * TX Fast-E Delay is bits 15:12, default 0xf
+- * Delay = 150ps * N - 250ps
+- * On = 2000ps, off = 50ps
+- */
+-#define YT8511_DELAY_GE_TX_EN	(0xf << 4)
+-#define YT8511_DELAY_GE_TX_DIS	(0x2 << 4)
+-#define YT8511_DELAY_FE_TX_EN	(0xf << 12)
+-#define YT8511_DELAY_FE_TX_DIS	(0x2 << 12)
+-
+-/* Extended register is different from MMD Register and MII Register.
+- * We can use ytphy_read_ext/ytphy_write_ext/ytphy_modify_ext function to
+- * operate extended register.
+- * Extended Register  start
+- */
 +#define YT8521_PHY_MODE_FIBER	1 //fiber mode only
 +#define YT8521_PHY_MODE_UTP		2 //utp mode only
 +#define YT8521_PHY_MODE_POLL	3 //fiber and utp, poll mode
-+
+ 
+-/* Phy gmii clock gating Register */
+-#define YT8521_CLOCK_GATING_REG			0xC
+-#define YT8521_CGR_RX_CLK_EN			BIT(12)
 +/* please make choice according to system design
 + * for Fiber only system, please define YT8521_PHY_MODE_CURR 1
 + * for UTP only system, please define YT8521_PHY_MODE_CURR 2
 + * for combo system, please define YT8521_PHY_MODE_CURR 3 
 + */
 +#define YT8521_PHY_MODE_CURR	3
-+
+ 
+-#define YT8521_EXTREG_SLEEP_CONTROL1_REG	0x27
+-#define YT8521_ESC1R_SLEEP_SW			BIT(15)
+-#define YT8521_ESC1R_PLLON_SLP			BIT(14)
 +/**** configuration section end ***********/
-+
-+
+ 
+-/* Phy fiber Link timer cfg2 Register */
+-#define YT8521_LINK_TIMER_CFG2_REG		0xA5
+-#define YT8521_LTCR_EN_AUTOSEN			BIT(15)
+ 
+-/* 0xA000, 0xA001, 0xA003, 0xA006 ~ 0xA00A and 0xA012 are common ext registers
+- * of yt8521 phy. There is no need to switch reg space when operating these
+- * registers.
+- */
 +/* no need to change below */
-+
+ 
+-#define YT8521_REG_SPACE_SELECT_REG		0xA000
+-#define YT8521_RSSR_SPACE_MASK			BIT(1)
+-#define YT8521_RSSR_FIBER_SPACE			(0x1 << 1)
+-#define YT8521_RSSR_UTP_SPACE			(0x0 << 1)
+-#define YT8521_RSSR_TO_BE_ARBITRATED		(0xFF)
 +#if (YTPHY_ENABLE_WOL)
 +#undef SYS_WAKEUP_BASED_ON_ETH_PKT
 +#define SYS_WAKEUP_BASED_ON_ETH_PKT 	1
 +#endif
-+
+ 
+-#define YT8521_CHIP_CONFIG_REG			0xA001
+-#define YT8521_CCR_SW_RST			BIT(15)
+-/* 1b0 disable 1.9ns rxc clock delay  *default*
+- * 1b1 enable 1.9ns rxc clock delay
+- */
+-#define YT8521_CCR_RXC_DLY_EN			BIT(8)
+-#define YT8521_CCR_RXC_DLY_1_900_NS		1900
+-
+-#define YT8521_CCR_MODE_SEL_MASK		(BIT(2) | BIT(1) | BIT(0))
+-#define YT8521_CCR_MODE_UTP_TO_RGMII		0
+-#define YT8521_CCR_MODE_FIBER_TO_RGMII		1
+-#define YT8521_CCR_MODE_UTP_FIBER_TO_RGMII	2
+-#define YT8521_CCR_MODE_UTP_TO_SGMII		3
+-#define YT8521_CCR_MODE_SGPHY_TO_RGMAC		4
+-#define YT8521_CCR_MODE_SGMAC_TO_RGPHY		5
+-#define YT8521_CCR_MODE_UTP_TO_FIBER_AUTO	6
+-#define YT8521_CCR_MODE_UTP_TO_FIBER_FORCE	7
+-
+-/* 3 phy polling modes,poll mode combines utp and fiber mode*/
+-#define YT8521_MODE_FIBER			0x1
+-#define YT8521_MODE_UTP				0x2
+-#define YT8521_MODE_POLL			0x3
+-
+-#define YT8521_RGMII_CONFIG1_REG		0xA003
+-/* 1b0 use original tx_clk_rgmii  *default*
+- * 1b1 use inverted tx_clk_rgmii.
+- */
+-#define YT8521_RC1R_TX_CLK_SEL_INVERTED		BIT(14)
+-#define YT8521_RC1R_RX_DELAY_MASK		GENMASK(13, 10)
+-#define YT8521_RC1R_FE_TX_DELAY_MASK		GENMASK(7, 4)
+-#define YT8521_RC1R_GE_TX_DELAY_MASK		GENMASK(3, 0)
+-#define YT8521_RC1R_RGMII_0_000_NS		0
+-#define YT8521_RC1R_RGMII_0_150_NS		1
+-#define YT8521_RC1R_RGMII_0_300_NS		2
+-#define YT8521_RC1R_RGMII_0_450_NS		3
+-#define YT8521_RC1R_RGMII_0_600_NS		4
+-#define YT8521_RC1R_RGMII_0_750_NS		5
+-#define YT8521_RC1R_RGMII_0_900_NS		6
+-#define YT8521_RC1R_RGMII_1_050_NS		7
+-#define YT8521_RC1R_RGMII_1_200_NS		8
+-#define YT8521_RC1R_RGMII_1_350_NS		9
+-#define YT8521_RC1R_RGMII_1_500_NS		10
+-#define YT8521_RC1R_RGMII_1_650_NS		11
+-#define YT8521_RC1R_RGMII_1_800_NS		12
+-#define YT8521_RC1R_RGMII_1_950_NS		13
+-#define YT8521_RC1R_RGMII_2_100_NS		14
+-#define YT8521_RC1R_RGMII_2_250_NS		15
+-
+-#define YTPHY_MISC_CONFIG_REG			0xA006
+-#define YTPHY_MCR_FIBER_SPEED_MASK		BIT(0)
+-#define YTPHY_MCR_FIBER_1000BX			(0x1 << 0)
+-#define YTPHY_MCR_FIBER_100FX			(0x0 << 0)
+-
+-/* WOL MAC ADDR: MACADDR2(highest), MACADDR1(middle), MACADDR0(lowest) */
+-#define YTPHY_WOL_MACADDR2_REG			0xA007
+-#define YTPHY_WOL_MACADDR1_REG			0xA008
+-#define YTPHY_WOL_MACADDR0_REG			0xA009
+-
+-#define YTPHY_WOL_CONFIG_REG			0xA00A
+-#define YTPHY_WCR_INTR_SEL			BIT(6)
+-#define YTPHY_WCR_ENABLE			BIT(3)
+-
+-/* 2b00 84ms
+- * 2b01 168ms  *default*
+- * 2b10 336ms
+- * 2b11 672ms
+- */
+-#define YTPHY_WCR_PULSE_WIDTH_MASK		(BIT(2) | BIT(1))
+-#define YTPHY_WCR_PULSE_WIDTH_672MS		(BIT(2) | BIT(1))
 +/* workaround for 8521 fiber 100m mode */
 +static int link_mode_8521 = 0; //0: no link; 1: utp; 32: fiber. traced that 1000m fiber uses 32.
 +static int link_mode_8614[4] = {0}; //0: no link; 1: utp; 32: fiber. traced that 1000m fiber uses 32.
-+
+ 
+-/* 1b0 Interrupt and WOL events is level triggered and active LOW  *default*
+- * 1b1 Interrupt and WOL events is pulse triggered and active LOW
+- */
+-#define YTPHY_WCR_TYPE_PULSE			BIT(0)
 +/* for multiple port phy, base phy address */
 +static unsigned int yt_mport_base_phy_addr = 0xff; //0xff: invalid; for 8618
 +static unsigned int yt_mport_base_phy_addr_8614 = 0xff; //0xff: invalid;
-+
+ 
+-#define YTPHY_SYNCE_CFG_REG			0xA012
+-#define YT8521_SCR_SYNCE_ENABLE			BIT(5)
+-/* 1b0 output 25m clock
+- * 1b1 output 125m clock  *default*
+- */
+-#define YT8521_SCR_CLK_FRE_SEL_125M		BIT(3)
+-#define YT8521_SCR_CLK_SRC_MASK			GENMASK(2, 1)
+-#define YT8521_SCR_CLK_SRC_PLL_125M		0
+-#define YT8521_SCR_CLK_SRC_UTP_RX		1
+-#define YT8521_SCR_CLK_SRC_SDS_RX		2
+-#define YT8521_SCR_CLK_SRC_REF_25M		3
+-#define YT8531_SCR_SYNCE_ENABLE			BIT(6)
+-/* 1b0 output 25m clock   *default*
+- * 1b1 output 125m clock
+- */
+-#define YT8531_SCR_CLK_FRE_SEL_125M		BIT(4)
+-#define YT8531_SCR_CLK_SRC_MASK			GENMASK(3, 1)
+-#define YT8531_SCR_CLK_SRC_PLL_125M		0
+-#define YT8531_SCR_CLK_SRC_UTP_RX		1
+-#define YT8531_SCR_CLK_SRC_SDS_RX		2
+-#define YT8531_SCR_CLK_SRC_CLOCK_FROM_DIGITAL	3
+-#define YT8531_SCR_CLK_SRC_REF_25M		4
+-#define YT8531_SCR_CLK_SRC_SSC_25M		5
+-
+-/* Extended Register  end */
+-
+-#define YTPHY_DTS_OUTPUT_CLK_DIS		0
+-#define YTPHY_DTS_OUTPUT_CLK_25M		25000000
+-#define YTPHY_DTS_OUTPUT_CLK_125M		125000000
+-
+-struct yt8521_priv {
+-	/* combo_advertising is used for case of YT8521 in combo mode,
+-	 * this means that yt8521 may work in utp or fiber mode which depends
+-	 * on which media is connected (YT8521_RSSR_TO_BE_ARBITRATED).
+-	 */
+-	__ETHTOOL_DECLARE_LINK_MODE_MASK(combo_advertising);
+-
+-	/* YT8521_MODE_FIBER / YT8521_MODE_UTP / YT8521_MODE_POLL*/
+-	u8 polling_mode;
+-	u8 strap_mode; /* 8 working modes  */
+-	/* current reg page of yt8521 phy:
+-	 * YT8521_RSSR_UTP_SPACE
+-	 * YT8521_RSSR_FIBER_SPACE
+-	 * YT8521_RSSR_TO_BE_ARBITRATED
+-	 */
+-	u8 reg_page;
+-};
 +int phy_yt8531_led_fixup(struct mii_bus *bus, int addr);
 +int yt8511_config_out_125m(struct mii_bus *bus, int phy_id);
-+
+ 
+-/**
+- * ytphy_read_ext() - read a PHY's extended register
+- * @phydev: a pointer to a &struct phy_device
+- * @regnum: register number to read
+- *
+- * NOTE:The caller must have taken the MDIO bus lock.
+- *
+- * returns the value of regnum reg or negative error code
+- */
+-static int ytphy_read_ext(struct phy_device *phydev, u16 regnum)
 +#if ( LINUX_VERSION_CODE > KERNEL_VERSION(5,0,0) )
 +int genphy_config_init(struct phy_device *phydev)
-+{
-+	int ret;
-+
+ {
+ 	int ret;
+ 
+-	ret = __phy_write(phydev, YTPHY_PAGE_SELECT, regnum);
+-	if (ret < 0)
+-		return ret;
 +	printk (KERN_INFO "yzhang..read phyaddr=%d, phyid=%08x\n",phydev->mdio.addr, phydev->phy_id);
 +
 +	if(phydev->phy_id == 0x4f51e91b)
@@ -138,78 +413,179 @@ index 000000000..74eef3dfa
 +		printk (KERN_INFO "yzhang..8511 set 125m clk out, reg=%#04x\n",phydev->mdio.bus->read(phydev->mdio.bus,phydev->mdio.addr,0x1f)/*double check as delay*/);
 +		if (ret<0)
 +			printk (KERN_INFO "yzhang..failed to set 125m clk out, ret=%d\n",ret);
-+
+ 
+-	return __phy_read(phydev, YTPHY_PAGE_DATA);
 +		phy_yt8531_led_fixup(phydev->mdio.bus, phydev->mdio.addr);
 +	}
 +	return  genphy_read_abilities(phydev);
-+}
+ }
 +#endif
-+
+ 
+-/**
+- * ytphy_read_ext_with_lock() - read a PHY's extended register
+- * @phydev: a pointer to a &struct phy_device
+- * @regnum: register number to read
+- *
+- * returns the value of regnum reg or negative error code
+- */
+-static int ytphy_read_ext_with_lock(struct phy_device *phydev, u16 regnum)
 +#if ( LINUX_VERSION_CODE < KERNEL_VERSION(4,0,0) )
 +static int ytphy_config_init(struct phy_device *phydev)
-+{
+ {
+-	int ret;
+-
+-	phy_lock_mdio_bus(phydev);
+-	ret = ytphy_read_ext(phydev, regnum);
+-	phy_unlock_mdio_bus(phydev);
+-
+-	return ret;
 +	return 0;
-+}
+ }
 +#endif
-+
+ 
+-/**
+- * ytphy_write_ext() - write a PHY's extended register
+- * @phydev: a pointer to a &struct phy_device
+- * @regnum: register number to write
+- * @val: value to write to @regnum
+- *
+- * NOTE:The caller must have taken the MDIO bus lock.
+- *
+- * returns 0 or negative error code
+- */
+-static int ytphy_write_ext(struct phy_device *phydev, u16 regnum, u16 val)
 +static int ytphy_read_ext(struct phy_device *phydev, u32 regnum)
-+{
-+	int ret;
+ {
+ 	int ret;
 +	int val;
-+
+ 
+-	ret = __phy_write(phydev, YTPHY_PAGE_SELECT, regnum);
 +	ret = phy_write(phydev, REG_DEBUG_ADDR_OFFSET, regnum);
-+	if (ret < 0)
-+		return ret;
-+
+ 	if (ret < 0)
+ 		return ret;
+ 
+-	return __phy_write(phydev, YTPHY_PAGE_DATA, val);
 +	val = phy_read(phydev, REG_DEBUG_DATA);
 +
 +	return val;
-+}
-+
+ }
+ 
+-/**
+- * ytphy_write_ext_with_lock() - write a PHY's extended register
+- * @phydev: a pointer to a &struct phy_device
+- * @regnum: register number to write
+- * @val: value to write to @regnum
+- *
+- * returns 0 or negative error code
+- */
+-static int ytphy_write_ext_with_lock(struct phy_device *phydev, u16 regnum,
+-				     u16 val)
 +static int ytphy_write_ext(struct phy_device *phydev, u32 regnum, u16 val)
-+{
-+	int ret;
-+
+ {
+ 	int ret;
+ 
+-	phy_lock_mdio_bus(phydev);
+-	ret = ytphy_write_ext(phydev, regnum, val);
+-	phy_unlock_mdio_bus(phydev);
 +	ret = phy_write(phydev, REG_DEBUG_ADDR_OFFSET, regnum);
 +	if (ret < 0)
 +		return ret;
 +
 +	ret = phy_write(phydev, REG_DEBUG_DATA, val);
-+
-+	return ret;
-+}
-+
+ 
+ 	return ret;
+ }
+ 
+-/**
+- * ytphy_modify_ext() - bits modify a PHY's extended register
+- * @phydev: a pointer to a &struct phy_device
+- * @regnum: register number to write
+- * @mask: bit mask of bits to clear
+- * @set: bit mask of bits to set
+- *
+- * NOTE: Convenience function which allows a PHY's extended register to be
+- * modified as new register value = (old register value & ~mask) | set.
+- * The caller must have taken the MDIO bus lock.
+- *
+- * returns 0 or negative error code
+- */
+-static int ytphy_modify_ext(struct phy_device *phydev, u16 regnum, u16 mask,
+-			    u16 set)
 +static int yt8010_config_aneg(struct phy_device *phydev)
-+{
+ {
+-	int ret;
+-
+-	ret = __phy_write(phydev, YTPHY_PAGE_SELECT, regnum);
+-	if (ret < 0)
+-		return ret;
+-
+-	return __phy_modify(phydev, YTPHY_PAGE_DATA, mask, set);
 +	phydev->speed = SPEED_100;
 +	return 0;
-+}
-+
+ }
+ 
+-/**
+- * ytphy_modify_ext_with_lock() - bits modify a PHY's extended register
+- * @phydev: a pointer to a &struct phy_device
+- * @regnum: register number to write
+- * @mask: bit mask of bits to clear
+- * @set: bit mask of bits to set
+- *
+- * NOTE: Convenience function which allows a PHY's extended register to be
+- * modified as new register value = (old register value & ~mask) | set.
+- *
+- * returns 0 or negative error code
+- */
+-static int ytphy_modify_ext_with_lock(struct phy_device *phydev, u16 regnum,
+-				      u16 mask, u16 set)
 +static int yt8512_clk_init(struct phy_device *phydev)
-+{
-+	int ret;
+ {
+ 	int ret;
 +	int val;
 +
 +	val = ytphy_read_ext(phydev, YT8512_EXTREG_AFE_PLL);
 +	if (val < 0)
 +		return val;
-+
+ 
+-	phy_lock_mdio_bus(phydev);
+-	ret = ytphy_modify_ext(phydev, regnum, mask, set);
+-	phy_unlock_mdio_bus(phydev);
 +	val |= YT8512_CONFIG_PLL_REFCLK_SEL_EN;
-+
+ 
+-	return ret;
+-}
 +	ret = ytphy_write_ext(phydev, YT8512_EXTREG_AFE_PLL, val);
 +	if (ret < 0)
 +		return ret;
-+
+ 
+-/**
+- * ytphy_get_wol() - report whether wake-on-lan is enabled
+- * @phydev: a pointer to a &struct phy_device
+- * @wol: a pointer to a &struct ethtool_wolinfo
+- *
+- * NOTE: YTPHY_WOL_CONFIG_REG is common ext reg.
+- */
+-static void ytphy_get_wol(struct phy_device *phydev,
+-			  struct ethtool_wolinfo *wol)
+-{
+-	int wol_config;
 +	val = ytphy_read_ext(phydev, YT8512_EXTREG_EXTEND_COMBO);
 +	if (val < 0)
 +		return val;
-+
+ 
+-	wol->supported = WAKE_MAGIC;
+-	wol->wolopts = 0;
 +	val |= YT8512_CONTROL1_RMII_EN;
-+
+ 
+-	wol_config = ytphy_read_ext_with_lock(phydev, YTPHY_WOL_CONFIG_REG);
+-	if (wol_config < 0)
+-		return;
 +	ret = ytphy_write_ext(phydev, YT8512_EXTREG_EXTEND_COMBO, val);
 +	if (ret < 0)
 +		return ret;
-+
+ 
+-	if (wol_config & YTPHY_WCR_ENABLE)
+-		wol->wolopts |= WAKE_MAGIC;
 +	val = phy_read(phydev, MII_BMCR);
 +	if (val < 0)
 +		return val;
@@ -218,46 +594,127 @@ index 000000000..74eef3dfa
 +	ret = phy_write(phydev, MII_BMCR, val);
 +
 +	return ret;
-+}
-+
+ }
+ 
+-/**
+- * ytphy_set_wol() - turn wake-on-lan on or off
+- * @phydev: a pointer to a &struct phy_device
+- * @wol: a pointer to a &struct ethtool_wolinfo
+- *
+- * NOTE: YTPHY_WOL_CONFIG_REG, YTPHY_WOL_MACADDR2_REG, YTPHY_WOL_MACADDR1_REG
+- * and YTPHY_WOL_MACADDR0_REG are common ext reg. The
+- * YTPHY_INTERRUPT_ENABLE_REG of UTP is special, fiber also use this register.
+- *
+- * returns 0 or negative errno code
+- */
+-static int ytphy_set_wol(struct phy_device *phydev, struct ethtool_wolinfo *wol)
 +static int yt8512_led_init(struct phy_device *phydev)
-+{
+ {
+-	struct net_device *p_attached_dev;
+-	const u16 mac_addr_reg[] = {
+-		YTPHY_WOL_MACADDR2_REG,
+-		YTPHY_WOL_MACADDR1_REG,
+-		YTPHY_WOL_MACADDR0_REG,
+-	};
+-	const u8 *mac_addr;
+-	int old_page;
+-	int ret = 0;
+-	u16 mask;
+-	u16 val;
+-	u8 i;
+-
+-	if (wol->wolopts & WAKE_MAGIC) {
+-		p_attached_dev = phydev->attached_dev;
+-		if (!p_attached_dev)
+-			return -ENODEV;
 +	int ret;
 +	int val;
 +	int mask;
-+
+ 
+-		mac_addr = (const u8 *)p_attached_dev->dev_addr;
+-		if (!is_valid_ether_addr(mac_addr))
+-			return -EINVAL;
 +	val = ytphy_read_ext(phydev, YT8512_EXTREG_LED0);
 +	if (val < 0)
 +		return val;
-+
+ 
+-		/* lock mdio bus then switch to utp reg space */
+-		old_page = phy_select_page(phydev, YT8521_RSSR_UTP_SPACE);
+-		if (old_page < 0)
+-			goto err_restore_page;
 +	val |= YT8512_LED0_ACT_BLK_IND;
-+
+ 
+-		/* Store the device address for the magic packet */
+-		for (i = 0; i < 3; i++) {
+-			ret = ytphy_write_ext(phydev, mac_addr_reg[i],
+-					      ((mac_addr[i * 2] << 8)) |
+-						      (mac_addr[i * 2 + 1]));
+-			if (ret < 0)
+-				goto err_restore_page;
+-		}
 +	mask = YT8512_LED0_DIS_LED_AN_TRY | YT8512_LED0_BT_BLK_EN |
 +		YT8512_LED0_HT_BLK_EN | YT8512_LED0_COL_BLK_EN |
 +		YT8512_LED0_BT_ON_EN;
 +	val &= ~mask;
-+
+ 
+-		/* Enable WOL feature */
+-		mask = YTPHY_WCR_PULSE_WIDTH_MASK | YTPHY_WCR_INTR_SEL;
+-		val = YTPHY_WCR_ENABLE | YTPHY_WCR_INTR_SEL;
+-		val |= YTPHY_WCR_TYPE_PULSE | YTPHY_WCR_PULSE_WIDTH_672MS;
+-		ret = ytphy_modify_ext(phydev, YTPHY_WOL_CONFIG_REG, mask, val);
+-		if (ret < 0)
+-			goto err_restore_page;
 +	ret = ytphy_write_ext(phydev, YT8512_EXTREG_LED0, val);
 +	if (ret < 0)
 +		return ret;
-+
+ 
+-		/* Enable WOL interrupt */
+-		ret = __phy_modify(phydev, YTPHY_INTERRUPT_ENABLE_REG, 0,
+-				   YTPHY_IER_WOL);
+-		if (ret < 0)
+-			goto err_restore_page;
 +	val = ytphy_read_ext(phydev, YT8512_EXTREG_LED1);
 +	if (val < 0)
 +		return val;
-+
+ 
+-	} else {
+-		old_page = phy_select_page(phydev, YT8521_RSSR_UTP_SPACE);
+-		if (old_page < 0)
+-			goto err_restore_page;
 +	val |= YT8512_LED1_BT_ON_EN;
-+
+ 
+-		/* Disable WOL feature */
+-		mask = YTPHY_WCR_ENABLE | YTPHY_WCR_INTR_SEL;
+-		ret = ytphy_modify_ext(phydev, YTPHY_WOL_CONFIG_REG, mask, 0);
 +	mask = YT8512_LED1_TXACT_BLK_EN | YT8512_LED1_RXACT_BLK_EN;
 +	val &= ~mask;
-+
+ 
+-		/* Disable WOL interrupt */
+-		ret = __phy_modify(phydev, YTPHY_INTERRUPT_ENABLE_REG,
+-				   YTPHY_IER_WOL, 0);
+-		if (ret < 0)
+-			goto err_restore_page;
+-	}
 +	ret = ytphy_write_ext(phydev, YT8512_LED1_BT_ON_EN, val);
-+
+ 
+-err_restore_page:
+-	return phy_restore_page(phydev, old_page, ret);
 +	return ret;
-+}
-+
+ }
+ 
+-static int yt8531_set_wol(struct phy_device *phydev,
+-			  struct ethtool_wolinfo *wol)
 +static int yt8512_config_init(struct phy_device *phydev)
-+{
-+	int ret;
+ {
+-	const u16 mac_addr_reg[] = {
+-		YTPHY_WOL_MACADDR2_REG,
+-		YTPHY_WOL_MACADDR1_REG,
+-		YTPHY_WOL_MACADDR0_REG,
+-	};
+-	const u8 *mac_addr;
+-	u16 mask, val;
+ 	int ret;
+-	u8 i;
 +	int val;
 +#if ( LINUX_VERSION_CODE < KERNEL_VERSION(4,0,0) )
 +	ret = ytphy_config_init(phydev);
@@ -266,37 +723,98 @@ index 000000000..74eef3dfa
 +#endif
 +	if (ret < 0)
 +		return ret;
-+
+ 
+-	if (wol->wolopts & WAKE_MAGIC) {
+-		mac_addr = phydev->attached_dev->dev_addr;
 +	ret = yt8512_clk_init(phydev);
 +	if (ret < 0)
 +		return ret;
-+
+ 
+-		/* Store the device address for the magic packet */
+-		for (i = 0; i < 3; i++) {
+-			ret = ytphy_write_ext_with_lock(phydev, mac_addr_reg[i],
+-							((mac_addr[i * 2] << 8)) |
+-							(mac_addr[i * 2 + 1]));
+-			if (ret < 0)
+-				return ret;
+-		}
 +	ret = yt8512_led_init(phydev);
-+
+ 
+-		/* Enable WOL feature */
+-		mask = YTPHY_WCR_PULSE_WIDTH_MASK | YTPHY_WCR_INTR_SEL;
+-		val = YTPHY_WCR_ENABLE | YTPHY_WCR_INTR_SEL;
+-		val |= YTPHY_WCR_TYPE_PULSE | YTPHY_WCR_PULSE_WIDTH_672MS;
+-		ret = ytphy_modify_ext_with_lock(phydev, YTPHY_WOL_CONFIG_REG,
+-						 mask, val);
+-		if (ret < 0)
+-			return ret;
 +	/* disable auto sleep */
 +	val = ytphy_read_ext(phydev, YT8512_EXTREG_SLEEP_CONTROL1);
 +	if (val < 0)
 +		return val;
-+
+ 
+-		/* Enable WOL interrupt */
+-		ret = phy_modify(phydev, YTPHY_INTERRUPT_ENABLE_REG, 0,
+-				 YTPHY_IER_WOL);
+-		if (ret < 0)
+-			return ret;
+-	} else {
+-		/* Disable WOL feature */
+-		mask = YTPHY_WCR_ENABLE | YTPHY_WCR_INTR_SEL;
+-		ret = ytphy_modify_ext_with_lock(phydev, YTPHY_WOL_CONFIG_REG,
+-						 mask, 0);
+-
+-		/* Disable WOL interrupt */
+-		ret = phy_modify(phydev, YTPHY_INTERRUPT_ENABLE_REG,
+-				 YTPHY_IER_WOL, 0);
+-		if (ret < 0)
+-			return ret;
+-	}
 +	val &= (~BIT(YT8512_EN_SLEEP_SW_BIT));
-+
+ 
+-	return 0;
 +	ret = ytphy_write_ext(phydev, YT8512_EXTREG_SLEEP_CONTROL1, val);
 +	if (ret < 0)
 +		return ret;
 +
 +	return ret;
-+}
-+
+ }
+ 
+-static int yt8511_read_page(struct phy_device *phydev)
 +static int yt8512_read_status(struct phy_device *phydev)
-+{
+ {
+-	return __phy_read(phydev, YT8511_PAGE_SELECT);
+-};
 +	int ret;
 +	int val;
 +	int speed, speed_mode, duplex;
-+
+ 
+-static int yt8511_write_page(struct phy_device *phydev, int page)
+-{
+-	return __phy_write(phydev, YT8511_PAGE_SELECT, page);
+-};
 +	ret = genphy_update_link(phydev);
 +	if (ret)
 +		return ret;
-+
+ 
+-static int yt8511_config_init(struct phy_device *phydev)
+-{
+-	int oldpage, ret = 0;
+-	unsigned int ge, fe;
+-
+-	oldpage = phy_select_page(phydev, YT8511_EXT_CLK_GATE);
+-	if (oldpage < 0)
+-		goto err_restore_page;
+-
+-	/* set rgmii delay mode */
+-	switch (phydev->interface) {
+-	case PHY_INTERFACE_MODE_RGMII:
+-		ge = YT8511_DELAY_GE_TX_DIS;
+-		fe = YT8511_DELAY_FE_TX_DIS;
+-		break;
+-	case PHY_INTERFACE_MODE_RGMII_RXID:
+-		ge = YT8511_DELAY_RX | YT8511_DELAY_GE_TX_DIS;
+-		fe = YT8511_DELAY_FE_TX_DIS;
 +	val = phy_read(phydev, REG_PHY_SPEC_STATUS);
 +	if (val < 0)
 +		return val;
@@ -306,10 +824,16 @@ index 000000000..74eef3dfa
 +	switch (speed_mode) {
 +	case 0:
 +		speed = SPEED_10;
-+		break;
+ 		break;
+-	case PHY_INTERFACE_MODE_RGMII_TXID:
+-		ge = YT8511_DELAY_GE_TX_EN;
+-		fe = YT8511_DELAY_FE_TX_EN;
 +	case 1:
 +		speed = SPEED_100;
-+		break;
+ 		break;
+-	case PHY_INTERFACE_MODE_RGMII_ID:
+-		ge = YT8511_DELAY_RX | YT8511_DELAY_GE_TX_EN;
+-		fe = YT8511_DELAY_FE_TX_EN;
 +	case 2:
 +	case 3:
 +	default:
@@ -318,12 +842,22 @@ index 000000000..74eef3dfa
 +#else
 +		speed = SPEED_UNKNOWN;
 +#endif
-+		break;
-+	}
-+
+ 		break;
+-	default: /* do not support other modes */
+-		ret = -EOPNOTSUPP;
+-		goto err_restore_page;
+ 	}
+ 
+-	ret = __phy_modify(phydev, YT8511_PAGE, (YT8511_DELAY_RX | YT8511_DELAY_GE_TX_EN), ge);
+-	if (ret < 0)
+-		goto err_restore_page;
 +	phydev->speed = speed;
 +	phydev->duplex = duplex;
-+
+ 
+-	/* set clock mode to 125mhz */
+-	ret = __phy_modify(phydev, YT8511_PAGE, 0, YT8511_CLK_125M);
+-	if (ret < 0)
+-		goto err_restore_page;
 +	return 0;
 +}
 +#if ( LINUX_VERSION_CODE < KERNEL_VERSION(4,0,0) )
@@ -332,19 +866,29 @@ index 000000000..74eef3dfa
 +int yt8521_soft_reset(struct phy_device *phydev)
 +{
 +	int ret;
-+
+ 
+-	/* fast ethernet delay is in a separate page */
+-	ret = __phy_write(phydev, YT8511_PAGE_SELECT, YT8511_EXT_DELAY_DRIVE);
 +	ytphy_write_ext(phydev, 0xa000, 0);
 +	ret = genphy_soft_reset(phydev);
-+	if (ret < 0)
+ 	if (ret < 0)
+-		goto err_restore_page;
 +		return ret;
-+
+ 
+-	ret = __phy_modify(phydev, YT8511_PAGE, YT8511_DELAY_FE_TX_EN, fe);
+-	if (ret < 0)
+-		goto err_restore_page;
 +	ytphy_write_ext(phydev, 0xa000, 2);
 +	ret = genphy_soft_reset(phydev);
 +	if (ret < 0) {
 +		ytphy_write_ext(phydev, 0xa000, 0);
 +		return ret;
 +	}
-+
+ 
+-	/* leave pll enabled in sleep */
+-	ret = __phy_write(phydev, YT8511_PAGE_SELECT, YT8511_EXT_SLEEP_CTRL);
+-	if (ret < 0)
+-		goto err_restore_page;
 +	return 0;
 +}
 +#else
@@ -357,76 +901,194 @@ index 000000000..74eef3dfa
 +
 +	val = ytphy_read_ext(phydev, 0xa001);
 +	ytphy_write_ext(phydev, 0xa001, (val & ~0x8000));
-+
+ 
+-	ret = __phy_modify(phydev, YT8511_PAGE, 0, YT8511_PLLON_SLP);
 +	ret = genphy_soft_reset(phydev);
-+	if (ret < 0)
+ 	if (ret < 0)
+-		goto err_restore_page;
 +		return ret;
-+
+ 
+-err_restore_page:
+-	return phy_restore_page(phydev, oldpage, ret);
 +	return 0;
-+}
+ }
 +#endif
-+
+ 
+-/**
+- * yt8521_read_page() - read reg page
+- * @phydev: a pointer to a &struct phy_device
+- *
+- * returns current reg space of yt8521 (YT8521_RSSR_FIBER_SPACE/
+- * YT8521_RSSR_UTP_SPACE) or negative errno code
+- */
+-static int yt8521_read_page(struct phy_device *phydev)
 +#endif
 +
 +#if GMAC_CLOCK_INPUT_NEEDED
 +static int ytphy_mii_rd_ext(struct mii_bus *bus, int phy_id, u32 regnum)
-+{
+ {
+-	int old_page;
 +	int ret;
 +	int val;
-+
+ 
+-	old_page = ytphy_read_ext(phydev, YT8521_REG_SPACE_SELECT_REG);
+-	if (old_page < 0)
+-		return old_page;
 +	ret = bus->write(bus, phy_id, REG_DEBUG_ADDR_OFFSET, regnum);
 +	if (ret < 0)
 +		return ret;
-+
+ 
+-	if ((old_page & YT8521_RSSR_SPACE_MASK) == YT8521_RSSR_FIBER_SPACE)
+-		return YT8521_RSSR_FIBER_SPACE;
 +	val = bus->read(bus, phy_id, REG_DEBUG_DATA);
-+
+ 
+-	return YT8521_RSSR_UTP_SPACE;
+-};
 +	return val;
 +}
-+
+ 
+-/**
+- * yt8521_write_page() - write reg page
+- * @phydev: a pointer to a &struct phy_device
+- * @page: The reg page(YT8521_RSSR_FIBER_SPACE/YT8521_RSSR_UTP_SPACE) to write.
+- *
+- * returns 0 or negative errno code
+- */
+-static int yt8521_write_page(struct phy_device *phydev, int page)
 +static int ytphy_mii_wr_ext(struct mii_bus *bus, int phy_id, u32 regnum, u16 val)
-+{
+ {
+-	int mask = YT8521_RSSR_SPACE_MASK;
+-	int set;
+-
+-	if ((page & YT8521_RSSR_SPACE_MASK) == YT8521_RSSR_FIBER_SPACE)
+-		set = YT8521_RSSR_FIBER_SPACE;
+-	else
+-		set = YT8521_RSSR_UTP_SPACE;
 +	int ret;
-+
+ 
+-	return ytphy_modify_ext(phydev, YT8521_REG_SPACE_SELECT_REG, mask, set);
+-};
 +	ret = bus->write(bus, phy_id, REG_DEBUG_ADDR_OFFSET, regnum);
 +	if (ret < 0)
 +		return ret;
-+
+ 
+-/**
+- * struct ytphy_cfg_reg_map - map a config value to a register value
+- * @cfg: value in device configuration
+- * @reg: value in the register
+- */
+-struct ytphy_cfg_reg_map {
+-	u32 cfg;
+-	u32 reg;
+-};
 +	ret = bus->write(bus, phy_id, REG_DEBUG_DATA, val);
-+
+ 
+-static const struct ytphy_cfg_reg_map ytphy_rgmii_delays[] = {
+-	/* for tx delay / rx delay with YT8521_CCR_RXC_DLY_EN is not set. */
+-	{ 0,	YT8521_RC1R_RGMII_0_000_NS },
+-	{ 150,	YT8521_RC1R_RGMII_0_150_NS },
+-	{ 300,	YT8521_RC1R_RGMII_0_300_NS },
+-	{ 450,	YT8521_RC1R_RGMII_0_450_NS },
+-	{ 600,	YT8521_RC1R_RGMII_0_600_NS },
+-	{ 750,	YT8521_RC1R_RGMII_0_750_NS },
+-	{ 900,	YT8521_RC1R_RGMII_0_900_NS },
+-	{ 1050,	YT8521_RC1R_RGMII_1_050_NS },
+-	{ 1200,	YT8521_RC1R_RGMII_1_200_NS },
+-	{ 1350,	YT8521_RC1R_RGMII_1_350_NS },
+-	{ 1500,	YT8521_RC1R_RGMII_1_500_NS },
+-	{ 1650,	YT8521_RC1R_RGMII_1_650_NS },
+-	{ 1800,	YT8521_RC1R_RGMII_1_800_NS },
+-	{ 1950,	YT8521_RC1R_RGMII_1_950_NS },	/* default tx/rx delay */
+-	{ 2100,	YT8521_RC1R_RGMII_2_100_NS },
+-	{ 2250,	YT8521_RC1R_RGMII_2_250_NS },
+-
+-	/* only for rx delay with YT8521_CCR_RXC_DLY_EN is set. */
+-	{ 0    + YT8521_CCR_RXC_DLY_1_900_NS,	YT8521_RC1R_RGMII_0_000_NS },
+-	{ 150  + YT8521_CCR_RXC_DLY_1_900_NS,	YT8521_RC1R_RGMII_0_150_NS },
+-	{ 300  + YT8521_CCR_RXC_DLY_1_900_NS,	YT8521_RC1R_RGMII_0_300_NS },
+-	{ 450  + YT8521_CCR_RXC_DLY_1_900_NS,	YT8521_RC1R_RGMII_0_450_NS },
+-	{ 600  + YT8521_CCR_RXC_DLY_1_900_NS,	YT8521_RC1R_RGMII_0_600_NS },
+-	{ 750  + YT8521_CCR_RXC_DLY_1_900_NS,	YT8521_RC1R_RGMII_0_750_NS },
+-	{ 900  + YT8521_CCR_RXC_DLY_1_900_NS,	YT8521_RC1R_RGMII_0_900_NS },
+-	{ 1050 + YT8521_CCR_RXC_DLY_1_900_NS,	YT8521_RC1R_RGMII_1_050_NS },
+-	{ 1200 + YT8521_CCR_RXC_DLY_1_900_NS,	YT8521_RC1R_RGMII_1_200_NS },
+-	{ 1350 + YT8521_CCR_RXC_DLY_1_900_NS,	YT8521_RC1R_RGMII_1_350_NS },
+-	{ 1500 + YT8521_CCR_RXC_DLY_1_900_NS,	YT8521_RC1R_RGMII_1_500_NS },
+-	{ 1650 + YT8521_CCR_RXC_DLY_1_900_NS,	YT8521_RC1R_RGMII_1_650_NS },
+-	{ 1800 + YT8521_CCR_RXC_DLY_1_900_NS,	YT8521_RC1R_RGMII_1_800_NS },
+-	{ 1950 + YT8521_CCR_RXC_DLY_1_900_NS,	YT8521_RC1R_RGMII_1_950_NS },
+-	{ 2100 + YT8521_CCR_RXC_DLY_1_900_NS,	YT8521_RC1R_RGMII_2_100_NS },
+-	{ 2250 + YT8521_CCR_RXC_DLY_1_900_NS,	YT8521_RC1R_RGMII_2_250_NS }
+-};
 +	return ret;
 +}
-+
+ 
+-static u32 ytphy_get_delay_reg_value(struct phy_device *phydev,
+-				     const char *prop_name,
+-				     const struct ytphy_cfg_reg_map *tbl,
+-				     int tb_size,
+-				     u16 *rxc_dly_en,
+-				     u32 dflt)
 +int yt8511_config_dis_txdelay(struct mii_bus *bus, int phy_id)
-+{
+ {
+-	struct device_node *node = phydev->mdio.dev.of_node;
+-	int tb_size_half = tb_size / 2;
+-	u32 val;
+-	int i;
 +    int ret;
 +    int val;
-+
+ 
+-	if (of_property_read_u32(node, prop_name, &val))
+-		goto err_dts_val;
 +    /* disable auto sleep */
 +    val = ytphy_mii_rd_ext(bus, phy_id, 0x27);
 +    if (val < 0)
 +            return val;
-+
+ 
+-	/* when rxc_dly_en is NULL, it is get the delay for tx, only half of
+-	 * tb_size is valid.
+-	 */
+-	if (!rxc_dly_en)
+-		tb_size = tb_size_half;
 +    val &= (~BIT(15));
-+
+ 
+-	for (i = 0; i < tb_size; i++) {
+-		if (tbl[i].cfg == val) {
+-			if (rxc_dly_en && i < tb_size_half)
+-				*rxc_dly_en = 0;
+-			return tbl[i].reg;
+-		}
+-	}
 +    ret = ytphy_mii_wr_ext(bus, phy_id, 0x27, val);
 +    if (ret < 0)
 +            return ret;
-+
+ 
+-	phydev_warn(phydev, "Unsupported value %d for %s using default (%u)\n",
+-		    val, prop_name, dflt);
 +    /* enable RXC clock when no wire plug */
 +    val = ytphy_mii_rd_ext(bus, phy_id, 0xc);
 +    if (val < 0)
 +            return val;
-+
+ 
+-err_dts_val:
+-	/* when rxc_dly_en is not NULL, it is get the delay for rx.
+-	 * The rx default in dts and ytphy_rgmii_clk_delay_config is 1950 ps,
+-	 * so YT8521_CCR_RXC_DLY_EN should not be set.
+-	 */
+-	if (rxc_dly_en)
+-		*rxc_dly_en = 0;
 +    /* ext reg 0xc b[7:4]
 +	Tx Delay time = 150ps * N - 250ps
 +    */
 +    val &= ~(0xf << 4);
 +    ret = ytphy_mii_wr_ext(bus, phy_id, 0xc, val);
 +    printk("yt8511_config_dis_txdelay..phy txdelay, val=%#08x\n",val);
-+
+ 
+-	return dflt;
 +    return ret;
-+}
-+
+ }
+ 
+-static int ytphy_rgmii_clk_delay_config(struct phy_device *phydev)
 +int phy_yt8531_led_fixup(struct mii_bus *bus, int addr)
 +{
 +	printk("%s in\n", __func__);
@@ -439,10 +1101,39 @@ index 000000000..74eef3dfa
 +}
 +
 +int yt8511_config_out_125m(struct mii_bus *bus, int addr)
-+{
-+	int ret;
+ {
+-	int tb_size = ARRAY_SIZE(ytphy_rgmii_delays);
+-	u16 rxc_dly_en = YT8521_CCR_RXC_DLY_EN;
+-	u32 rx_reg, tx_reg;
+-	u16 mask, val = 0;
+ 	int ret;
 +	int val;
-+
+ 
+-	rx_reg = ytphy_get_delay_reg_value(phydev, "rx-internal-delay-ps",
+-					   ytphy_rgmii_delays, tb_size,
+-					   &rxc_dly_en,
+-					   YT8521_RC1R_RGMII_1_950_NS);
+-	tx_reg = ytphy_get_delay_reg_value(phydev, "tx-internal-delay-ps",
+-					   ytphy_rgmii_delays, tb_size, NULL,
+-					   YT8521_RC1R_RGMII_1_950_NS);
+-
+-	switch (phydev->interface) {
+-	case PHY_INTERFACE_MODE_RGMII:
+-		rxc_dly_en = 0;
+-		break;
+-	case PHY_INTERFACE_MODE_RGMII_RXID:
+-		val |= FIELD_PREP(YT8521_RC1R_RX_DELAY_MASK, rx_reg);
+-		break;
+-	case PHY_INTERFACE_MODE_RGMII_TXID:
+-		rxc_dly_en = 0;
+-		val |= FIELD_PREP(YT8521_RC1R_GE_TX_DELAY_MASK, tx_reg);
+-		break;
+-	case PHY_INTERFACE_MODE_RGMII_ID:
+-		val |= FIELD_PREP(YT8521_RC1R_RX_DELAY_MASK, rx_reg) |
+-		       FIELD_PREP(YT8521_RC1R_GE_TX_DELAY_MASK, tx_reg);
+-		break;
+-	default: /* do not support other modes */
+-		return -EOPNOTSUPP;
 +	mdelay(50);
 +	ret = ytphy_mii_wr_ext(bus, addr, 0xa012, 0xd0);
 +
@@ -453,8 +1144,10 @@ index 000000000..74eef3dfa
 +	{
 +		printk("yt8511_config_out_125m error\n");
 +		return -1;
-+	}
-+
+ 	}
+ 
+-	ret = ytphy_modify_ext(phydev, YT8521_CHIP_CONFIG_REG,
+-			       YT8521_CCR_RXC_DLY_EN, rxc_dly_en);
 +	/* disable auto sleep */
 +	val = ytphy_mii_rd_ext(bus, addr, 0x27);
 +	if (val < 0)
@@ -488,36 +1181,61 @@ index 000000000..74eef3dfa
 +	val = bus->read(bus, phy_id, 0x9/*master/slave config reg*/);
 +	val |= (0x3<<11); //to be manual config and force to be master
 +	ret = bus->write(bus, phy_id, 0x9, val); //take effect until phy soft reset
-+	if (ret < 0)
-+		return ret;
-+
+ 	if (ret < 0)
+ 		return ret;
+ 
+-	/* Generally, it is not necessary to adjust YT8521_RC1R_FE_TX_DELAY */
+-	mask = YT8521_RC1R_RX_DELAY_MASK | YT8521_RC1R_GE_TX_DELAY_MASK;
+-	return ytphy_modify_ext(phydev, YT8521_RGMII_CONFIG1_REG, mask, val);
 +	printk("yt8511_config_out_125m, phy to be master, val=%#08x\n",val);
 +#endif
 +
 +    return ret;
-+}
-+
+ }
+ 
+-static int ytphy_rgmii_clk_delay_config_with_lock(struct phy_device *phydev)
 +EXPORT_SYMBOL(yt8511_config_out_125m);
 +
 +static int yt8511_config_init(struct phy_device *phydev)
-+{
-+	int ret;
-+
+ {
+ 	int ret;
+ 
+-	phy_lock_mdio_bus(phydev);
+-	ret = ytphy_rgmii_clk_delay_config(phydev);
+-	phy_unlock_mdio_bus(phydev);
 +#if ( LINUX_VERSION_CODE < KERNEL_VERSION(4,0,0) )
 +	ret = ytphy_config_init(phydev);
 +#else
 +	ret = genphy_config_init(phydev);
 +#endif
-+
-+	return ret;
-+}
+ 
+ 	return ret;
+ }
 +#endif /*GMAC_CLOCK_INPUT_NEEDED*/
-+
+ 
+-/**
+- * yt8521_probe() - read chip config then set suitable polling_mode
+- * @phydev: a pointer to a &struct phy_device
+- *
+- * returns 0 or negative errno code
+- */
+-static int yt8521_probe(struct phy_device *phydev)
 +#if (YTPHY_ENABLE_WOL)
 +static int ytphy_switch_reg_space(struct phy_device *phydev, int space)
-+{
-+	int ret;
-+
+ {
+-	struct device_node *node = phydev->mdio.dev.of_node;
+-	struct device *dev = &phydev->mdio.dev;
+-	struct yt8521_priv *priv;
+-	int chip_config;
+-	u16 mask, val;
+-	u32 freq;
+ 	int ret;
+ 
+-	priv = devm_kzalloc(dev, sizeof(*priv), GFP_KERNEL);
+-	if (!priv)
+-		return -ENOMEM;
+-
+-	phydev->priv = priv;
 +	if (space == YTPHY_REG_SPACE_UTP){
 +		ret = ytphy_write_ext(phydev, 0xa000, 0);
 +	}else{
@@ -526,16 +1244,106 @@ index 000000000..74eef3dfa
 +	
 +	return ret;
 +}
-+
+ 
+-	chip_config = ytphy_read_ext_with_lock(phydev, YT8521_CHIP_CONFIG_REG);
+-	if (chip_config < 0)
+-		return chip_config;
 +static int ytphy_wol_en_cfg(struct phy_device *phydev, ytphy_wol_cfg_t wol_cfg)
 +{
 +	int ret=0;
 +	int val=0;
-+
+ 
+-	priv->strap_mode = chip_config & YT8521_CCR_MODE_SEL_MASK;
+-	switch (priv->strap_mode) {
+-	case YT8521_CCR_MODE_FIBER_TO_RGMII:
+-	case YT8521_CCR_MODE_SGPHY_TO_RGMAC:
+-	case YT8521_CCR_MODE_SGMAC_TO_RGPHY:
+-		priv->polling_mode = YT8521_MODE_FIBER;
+-		priv->reg_page = YT8521_RSSR_FIBER_SPACE;
+-		phydev->port = PORT_FIBRE;
+-		break;
+-	case YT8521_CCR_MODE_UTP_FIBER_TO_RGMII:
+-	case YT8521_CCR_MODE_UTP_TO_FIBER_AUTO:
+-	case YT8521_CCR_MODE_UTP_TO_FIBER_FORCE:
+-		priv->polling_mode = YT8521_MODE_POLL;
+-		priv->reg_page = YT8521_RSSR_TO_BE_ARBITRATED;
+-		phydev->port = PORT_NONE;
+-		break;
+-	case YT8521_CCR_MODE_UTP_TO_SGMII:
+-	case YT8521_CCR_MODE_UTP_TO_RGMII:
+-		priv->polling_mode = YT8521_MODE_UTP;
+-		priv->reg_page = YT8521_RSSR_UTP_SPACE;
+-		phydev->port = PORT_TP;
+-		break;
+-	}
+-	/* set default reg space */
+-	if (priv->reg_page != YT8521_RSSR_TO_BE_ARBITRATED) {
+-		ret = ytphy_write_ext_with_lock(phydev,
+-						YT8521_REG_SPACE_SELECT_REG,
+-						priv->reg_page);
+-		if (ret < 0)
+-			return ret;
+-	}
 +	val = ytphy_read_ext(phydev, YTPHY_WOL_CFG_REG);
 +	if (val < 0)
 +		return val;
-+
+ 
+-	if (of_property_read_u32(node, "motorcomm,clk-out-frequency-hz", &freq))
+-		freq = YTPHY_DTS_OUTPUT_CLK_DIS;
+-
+-	if (phydev->drv->phy_id == PHY_ID_YT8521) {
+-		switch (freq) {
+-		case YTPHY_DTS_OUTPUT_CLK_DIS:
+-			mask = YT8521_SCR_SYNCE_ENABLE;
+-			val = 0;
+-			break;
+-		case YTPHY_DTS_OUTPUT_CLK_25M:
+-			mask = YT8521_SCR_SYNCE_ENABLE |
+-			       YT8521_SCR_CLK_SRC_MASK |
+-			       YT8521_SCR_CLK_FRE_SEL_125M;
+-			val = YT8521_SCR_SYNCE_ENABLE |
+-			      FIELD_PREP(YT8521_SCR_CLK_SRC_MASK,
+-					 YT8521_SCR_CLK_SRC_REF_25M);
+-			break;
+-		case YTPHY_DTS_OUTPUT_CLK_125M:
+-			mask = YT8521_SCR_SYNCE_ENABLE |
+-			       YT8521_SCR_CLK_SRC_MASK |
+-			       YT8521_SCR_CLK_FRE_SEL_125M;
+-			val = YT8521_SCR_SYNCE_ENABLE |
+-			      YT8521_SCR_CLK_FRE_SEL_125M |
+-			      FIELD_PREP(YT8521_SCR_CLK_SRC_MASK,
+-					 YT8521_SCR_CLK_SRC_PLL_125M);
+-			break;
+-		default:
+-			phydev_warn(phydev, "Freq err:%u\n", freq);
+-			return -EINVAL;
+-		}
+-	} else if (phydev->drv->phy_id == PHY_ID_YT8531S) {
+-		switch (freq) {
+-		case YTPHY_DTS_OUTPUT_CLK_DIS:
+-			mask = YT8531_SCR_SYNCE_ENABLE;
+-			val = 0;
+-			break;
+-		case YTPHY_DTS_OUTPUT_CLK_25M:
+-			mask = YT8531_SCR_SYNCE_ENABLE |
+-			       YT8531_SCR_CLK_SRC_MASK |
+-			       YT8531_SCR_CLK_FRE_SEL_125M;
+-			val = YT8531_SCR_SYNCE_ENABLE |
+-			      FIELD_PREP(YT8531_SCR_CLK_SRC_MASK,
+-					 YT8531_SCR_CLK_SRC_REF_25M);
+-			break;
+-		case YTPHY_DTS_OUTPUT_CLK_125M:
+-			mask = YT8531_SCR_SYNCE_ENABLE |
+-			       YT8531_SCR_CLK_SRC_MASK |
+-			       YT8531_SCR_CLK_FRE_SEL_125M;
+-			val = YT8531_SCR_SYNCE_ENABLE |
+-			      YT8531_SCR_CLK_FRE_SEL_125M |
+-			      FIELD_PREP(YT8531_SCR_CLK_SRC_MASK,
+-					 YT8531_SCR_CLK_SRC_PLL_125M);
+-			break;
+-		default:
+-			phydev_warn(phydev, "Freq err:%u\n", freq);
+-			return -EINVAL;
 +	if(wol_cfg.enable) {
 +		val |= YTPHY_WOL_CFG_EN;
 +
@@ -559,52 +1367,124 @@ index 000000000..74eef3dfa
 +				val |= YTPHY_WOL_CFG_WIDTH1;
 +				val |= YTPHY_WOL_CFG_WIDTH2;
 +			}
-+		}
-+	} else {
+ 		}
+ 	} else {
+-		phydev_warn(phydev, "PHY id err\n");
+-		return -EINVAL;
 +		val &= ~YTPHY_WOL_CFG_EN;
 +		val &= ~YTPHY_WOL_CFG_INTR_SEL;
-+	}
-+
+ 	}
+ 
+-	return ytphy_modify_ext_with_lock(phydev, YTPHY_SYNCE_CFG_REG, mask,
+-					  val);
 +	ret = ytphy_write_ext(phydev, YTPHY_WOL_CFG_REG, val);
 +	if (ret < 0)
 +		return ret;
 +
 +	return 0;
-+}
-+
+ }
+ 
+-static int yt8531_probe(struct phy_device *phydev)
 +static void ytphy_get_wol(struct phy_device *phydev, struct ethtool_wolinfo *wol)
-+{
+ {
+-	struct device_node *node = phydev->mdio.dev.of_node;
+-	u16 mask, val;
+-	u32 freq;
 +	int val = 0;
-+
+ 
+-	if (of_property_read_u32(node, "motorcomm,clk-out-frequency-hz", &freq))
+-		freq = YTPHY_DTS_OUTPUT_CLK_DIS;
 +	wol->supported = WAKE_MAGIC;
 +	wol->wolopts = 0;
-+
+ 
+-	switch (freq) {
+-	case YTPHY_DTS_OUTPUT_CLK_DIS:
+-		mask = YT8531_SCR_SYNCE_ENABLE;
+-		val = 0;
+-		break;
+-	case YTPHY_DTS_OUTPUT_CLK_25M:
+-		mask = YT8531_SCR_SYNCE_ENABLE | YT8531_SCR_CLK_SRC_MASK |
+-		       YT8531_SCR_CLK_FRE_SEL_125M;
+-		val = YT8531_SCR_SYNCE_ENABLE |
+-		      FIELD_PREP(YT8531_SCR_CLK_SRC_MASK,
+-				 YT8531_SCR_CLK_SRC_REF_25M);
+-		break;
+-	case YTPHY_DTS_OUTPUT_CLK_125M:
+-		mask = YT8531_SCR_SYNCE_ENABLE | YT8531_SCR_CLK_SRC_MASK |
+-		       YT8531_SCR_CLK_FRE_SEL_125M;
+-		val = YT8531_SCR_SYNCE_ENABLE | YT8531_SCR_CLK_FRE_SEL_125M |
+-		      FIELD_PREP(YT8531_SCR_CLK_SRC_MASK,
+-				 YT8531_SCR_CLK_SRC_PLL_125M);
+-		break;
+-	default:
+-		phydev_warn(phydev, "Freq err:%u\n", freq);
+-		return -EINVAL;
+-	}
 +	val = ytphy_read_ext(phydev, YTPHY_WOL_CFG_REG);
 +	if (val < 0)
 +		return;
 +
 +	if (val & YTPHY_WOL_CFG_EN)
 +		wol->wolopts |= WAKE_MAGIC;
-+
+ 
+-	return ytphy_modify_ext_with_lock(phydev, YTPHY_SYNCE_CFG_REG, mask,
+-					  val);
 +	return;
-+}
-+
+ }
+ 
+-/**
+- * ytphy_utp_read_lpa() - read LPA then setup lp_advertising for utp
+- * @phydev: a pointer to a &struct phy_device
+- *
+- * NOTE:The caller must have taken the MDIO bus lock.
+- *
+- * returns 0 or negative errno code
+- */
+-static int ytphy_utp_read_lpa(struct phy_device *phydev)
 +static int ytphy_set_wol(struct phy_device *phydev, struct ethtool_wolinfo *wol)
-+{
+ {
+-	int lpa, lpagb;
+-
+-	if (phydev->autoneg == AUTONEG_ENABLE) {
+-		if (!phydev->autoneg_complete) {
+-			mii_stat1000_mod_linkmode_lpa_t(phydev->lp_advertising,
+-							0);
+-			mii_lpa_mod_linkmode_lpa_t(phydev->lp_advertising, 0);
+-			return 0;
+-		}
+-
+-		if (phydev->is_gigabit_capable) {
+-			lpagb = __phy_read(phydev, MII_STAT1000);
+-			if (lpagb < 0)
+-				return lpagb;
 +	int ret, pre_page, val;
 +	ytphy_wol_cfg_t wol_cfg;
 +	struct net_device *p_attached_dev = phydev->attached_dev;
-+
+ 
+-			if (lpagb & LPA_1000MSFAIL) {
+-				int adv = __phy_read(phydev, MII_CTRL1000);
 +	memset(&wol_cfg,0,sizeof(ytphy_wol_cfg_t));
 +	pre_page = ytphy_read_ext(phydev, 0xa000);
 +	if (pre_page < 0)
 +		return pre_page;
-+
+ 
+-				if (adv < 0)
+-					return adv;
 +	/* Switch to phy UTP page */
 +	ret = ytphy_switch_reg_space(phydev, YTPHY_REG_SPACE_UTP);
 +	if (ret < 0)
 +		return ret;
-+
+ 
+-				if (adv & CTL1000_ENABLE_MASTER)
+-					phydev_err(phydev, "Master/Slave resolution failed, maybe conflicting manual settings?\n");
+-				else
+-					phydev_err(phydev, "Master/Slave resolution failed\n");
+-				return -ENOLINK;
+-			}
+-
+-			mii_stat1000_mod_linkmode_lpa_t(phydev->lp_advertising,
+-							lpagb);
+-		}
 +	if (wol->wolopts & WAKE_MAGIC) {
 +		
 +		/* Enable the WOL interrupt */
@@ -613,7 +1493,10 @@ index 000000000..74eef3dfa
 +		ret = phy_write(phydev, YTPHY_UTP_INTR_REG, val);
 +		if (ret < 0)
 +			return ret;
-+
+ 
+-		lpa = __phy_read(phydev, MII_LPA);
+-		if (lpa < 0)
+-			return lpa;
 +		/* Set the WOL config */
 +		wol_cfg.enable = 1; //enable
 +		wol_cfg.type= YTPHY_WOL_TYPE_PULSE;
@@ -621,7 +1504,8 @@ index 000000000..74eef3dfa
 +		ret = ytphy_wol_en_cfg(phydev, wol_cfg);
 +		if (ret < 0)
 +			return ret;
-+
+ 
+-		mii_lpa_mod_linkmode_lpa_t(phydev->lp_advertising, lpa);
 +		/* Store the device address for the magic packet */
 +		ret = ytphy_write_ext(phydev, YTPHY_MAGIC_PACKET_MAC_ADDR2,
 +				((p_attached_dev->dev_addr[0] << 8) |
@@ -638,27 +1522,45 @@ index 000000000..74eef3dfa
 +				 p_attached_dev->dev_addr[5]));
 +		if (ret < 0)
 +			return ret;
-+	} else {
+ 	} else {
+-		linkmode_zero(phydev->lp_advertising);
 +		wol_cfg.enable = 0; //disable
 +		wol_cfg.type= YTPHY_WOL_TYPE_MAX;
 +		wol_cfg.width= YTPHY_WOL_WIDTH_MAX;
 +		ret = ytphy_wol_en_cfg(phydev, wol_cfg);
 +		if (ret < 0)
 +			return ret;
-+	}
-+
+ 	}
+ 
 +	/* Recover to previous register space page */
 +	ret = ytphy_switch_reg_space(phydev, pre_page);
 +	if (ret < 0)
 +		return ret;
 +
-+	return 0;
-+}
-+
+ 	return 0;
+ }
+ 
+-/**
+- * yt8521_adjust_status() - update speed and duplex to phydev. when in fiber
+- * mode, adjust speed and duplex.
+- * @phydev: a pointer to a &struct phy_device
+- * @status: yt8521 status read from YTPHY_SPECIFIC_STATUS_REG
+- * @is_utp: false(yt8521 work in fiber mode) or true(yt8521 work in utp mode)
+- *
+- * NOTE:The caller must have taken the MDIO bus lock.
+- *
+- * returns 0
+- */
+-static int yt8521_adjust_status(struct phy_device *phydev, int status,
+-				bool is_utp)
 +#endif /*(YTPHY_ENABLE_WOL)*/
 +
 +static int yt8521_config_init(struct phy_device *phydev)
-+{
+ {
+-	int speed_mode, duplex;
+-	int speed;
+-	int err;
+-	int lpa;
 +	int ret;
 +	int val;
 +
@@ -672,14 +1574,20 @@ index 000000000..74eef3dfa
 +#endif
 +	if (ret < 0)
 +		return ret;
-+
+ 
+-	if (is_utp)
+-		duplex = (status & YTPHY_SSR_DUPLEX) >> YTPHY_SSR_DUPLEX_OFFSET;
+-	else
+-		duplex = DUPLEX_FULL;	/* for fiber, it always DUPLEX_FULL */
 +	/* disable auto sleep */
 +	val = ytphy_read_ext(phydev, YT8521_EXTREG_SLEEP_CONTROL1);
 +	if (val < 0)
 +		return val;
-+
+ 
+-	speed_mode = (status & YTPHY_SSR_SPEED_MODE_MASK) >>
+-		     YTPHY_SSR_SPEED_MODE_OFFSET;
 +	val &= (~BIT(YT8521_EN_SLEEP_SW_BIT));
-+
+ 
 +	ret = ytphy_write_ext(phydev, YT8521_EXTREG_SLEEP_CONTROL1, val);
 +	if (ret < 0)
 +		return ret;
@@ -716,87 +1624,316 @@ index 000000000..74eef3dfa
 +
 +	duplex = (val & YT8512_DUPLEX) >> YT8521_DUPLEX_BIT;
 +	speed_mode = (val & YT8521_SPEED_MODE) >> YT8521_SPEED_MODE_BIT;
-+	switch (speed_mode) {
+ 	switch (speed_mode) {
+-	case YTPHY_SSR_SPEED_10M:
 +	case 0:
-+		if (is_utp)
-+			speed = SPEED_10;
-+		break;
+ 		if (is_utp)
+ 			speed = SPEED_10;
+-		else
+-			/* for fiber, it will never run here, default to
+-			 * SPEED_UNKNOWN
+-			 */
+-			speed = SPEED_UNKNOWN;
+ 		break;
+-	case YTPHY_SSR_SPEED_100M:
 +	case 1:
-+		speed = SPEED_100;
-+		break;
+ 		speed = SPEED_100;
+ 		break;
+-	case YTPHY_SSR_SPEED_1000M:
 +	case 2:
-+		speed = SPEED_1000;
-+		break;
+ 		speed = SPEED_1000;
+ 		break;
 +	case 3:
 +		break;
-+	default:
+ 	default:
 +#if ( LINUX_VERSION_CODE < KERNEL_VERSION(4,0,0) )
 +		speed = -1;
 +#else
-+		speed = SPEED_UNKNOWN;
+ 		speed = SPEED_UNKNOWN;
 +#endif
-+		break;
-+	}
-+
-+	phydev->speed = speed;
-+	phydev->duplex = duplex;
+ 		break;
+ 	}
+ 
+ 	phydev->speed = speed;
+ 	phydev->duplex = duplex;
+-
+-	if (is_utp) {
+-		err = ytphy_utp_read_lpa(phydev);
+-		if (err < 0)
+-			return err;
+-
+-		phy_resolve_aneg_pause(phydev);
+-	} else {
+-		lpa = __phy_read(phydev, MII_LPA);
+-		if (lpa < 0)
+-			return lpa;
+-
+-		/* only support 1000baseX Full */
+-		linkmode_mod_bit(ETHTOOL_LINK_MODE_1000baseX_Full_BIT,
+-				 phydev->lp_advertising, lpa & LPA_1000XFULL);
+-
+-		if (!(lpa & YTPHY_FLPA_PAUSE)) {
+-			phydev->pause = 0;
+-			phydev->asym_pause = 0;
+-		} else if ((lpa & YTPHY_FLPA_ASYM_PAUSE)) {
+-			phydev->pause = 1;
+-			phydev->asym_pause = 1;
+-		} else {
+-			phydev->pause = 1;
+-			phydev->asym_pause = 0;
+-		}
+-	}
 +	//printk (KERN_INFO "yt8521_adjust_status call out,regval=0x%04x,mode=%s,speed=%dm...\n", val,is_utp?"utp":"fiber", phydev->speed);
-+
-+	return 0;
-+}
-+
+ 
+ 	return 0;
+ }
+ 
+-/**
+- * yt8521_read_status_paged() -  determines the speed and duplex of one page
+- * @phydev: a pointer to a &struct phy_device
+- * @page: The reg page(YT8521_RSSR_FIBER_SPACE/YT8521_RSSR_UTP_SPACE) to
+- * operate.
+- *
+- * returns 1 (utp or fiber link),0 (no link) or negative errno code
 +/*
 + * for fiber mode, when speed is 100M, there is no definition for autonegotiation, and
 + * this function handles this case and return 1 per linux kernel's polling.
-+ */
+  */
+-static int yt8521_read_status_paged(struct phy_device *phydev, int page)
 +int yt8521_aneg_done (struct phy_device *phydev)
-+{
-+
+ {
+-	int fiber_latch_val;
+-	int fiber_curr_val;
+-	int old_page;
+-	int ret = 0;
+-	int status;
+-	int link;
+-
+-	linkmode_zero(phydev->lp_advertising);
+-	phydev->duplex = DUPLEX_UNKNOWN;
+-	phydev->speed = SPEED_UNKNOWN;
+-	phydev->asym_pause = 0;
+-	phydev->pause = 0;
+-
+-	/* YT8521 has two reg space (utp/fiber) for linkup with utp/fiber
+-	 * respectively. but for utp/fiber combo mode, reg space should be
+-	 * arbitrated based on media priority. by default, utp takes
+-	 * priority. reg space should be properly set before read
+-	 * YTPHY_SPECIFIC_STATUS_REG.
+-	 */
+-
+-	page &= YT8521_RSSR_SPACE_MASK;
+-	old_page = phy_select_page(phydev, page);
+-	if (old_page < 0)
+-		goto err_restore_page;
+-
+-	/* Read YTPHY_SPECIFIC_STATUS_REG, which indicates the speed and duplex
+-	 * of the PHY is actually using.
+-	 */
+-	ret = __phy_read(phydev, YTPHY_SPECIFIC_STATUS_REG);
+-	if (ret < 0)
+-		goto err_restore_page;
+-
+-	status = ret;
+-	link = !!(status & YTPHY_SSR_LINK);
+-
+-	/* When PHY is in fiber mode, speed transferred from 1000Mbps to
+-	 * 100Mbps,there is not link down from YTPHY_SPECIFIC_STATUS_REG, so
+-	 * we need check MII_BMSR to identify such case.
+-	 */
+-	if (page == YT8521_RSSR_FIBER_SPACE) {
+-		ret = __phy_read(phydev, MII_BMSR);
+-		if (ret < 0)
+-			goto err_restore_page;
+-
+-		fiber_latch_val = ret;
+-		ret = __phy_read(phydev, MII_BMSR);
+-		if (ret < 0)
+-			goto err_restore_page;
+-
+-		fiber_curr_val = ret;
+-		if (link && fiber_latch_val != fiber_curr_val) {
+-			link = 0;
+-			phydev_info(phydev,
+-				    "%s, fiber link down detect, latch = %04x, curr = %04x\n",
+-				    __func__, fiber_latch_val, fiber_curr_val);
+-		}
+-	} else {
+-		/* Read autonegotiation status */
+-		ret = __phy_read(phydev, MII_BMSR);
+-		if (ret < 0)
+-			goto err_restore_page;
+ 
+-		phydev->autoneg_complete = ret & BMSR_ANEGCOMPLETE ? 1 : 0;
+-	}
 +	//printk("yt8521_aneg_done callin,speed=%dm,linkmoded=%d\n", phydev->speed,link_mode_8521);
-+
+ 
+-	if (link) {
+-		if (page == YT8521_RSSR_UTP_SPACE)
+-			yt8521_adjust_status(phydev, status, true);
+-		else
+-			yt8521_adjust_status(phydev, status, false);
 +	if((32 == link_mode_8521) && (SPEED_100 == phydev->speed))
 +	{
 +		return 1/*link_mode_8521*/;
-+	}
-+
+ 	}
+-	return phy_restore_page(phydev, old_page, link);
+ 
+-err_restore_page:
+-	return phy_restore_page(phydev, old_page, ret);
 +#if ( LINUX_VERSION_CODE > KERNEL_VERSION(3,11,0) )
 +	return genphy_aneg_done(phydev);
 +#else
 +	return 1;
 +#endif
-+}
-+
-+static int yt8521_read_status(struct phy_device *phydev)
-+{
-+	int ret;
+ }
+ 
+-/**
+- * yt8521_read_status() -  determines the negotiated speed and duplex
+- * @phydev: a pointer to a &struct phy_device
+- *
+- * returns 0 or negative errno code
+- */
+ static int yt8521_read_status(struct phy_device *phydev)
+ {
+-	struct yt8521_priv *priv = phydev->priv;
+-	int link_fiber = 0;
+-	int link_utp;
+-	int link;
+ 	int ret;
 +	volatile int val, yt8521_fiber_latch_val, yt8521_fiber_curr_val;
 +	volatile int link;
 +	int link_utp = 0, link_fiber = 0;
-+
+ 
+-	if (priv->reg_page != YT8521_RSSR_TO_BE_ARBITRATED) {
+-		link = yt8521_read_status_paged(phydev, priv->reg_page);
+-		if (link < 0)
+-			return link;
+-	} else {
+-		/* when page is YT8521_RSSR_TO_BE_ARBITRATED, arbitration is
+-		 * needed. by default, utp is higher priority.
+-		 */
+-
+-		link_utp = yt8521_read_status_paged(phydev,
+-						    YT8521_RSSR_UTP_SPACE);
+-		if (link_utp < 0)
+-			return link_utp;
+-
+-		if (!link_utp) {
+-			link_fiber = yt8521_read_status_paged(phydev,
+-							      YT8521_RSSR_FIBER_SPACE);
+-			if (link_fiber < 0)
+-				return link_fiber;
+-		}
 +#if (YT8521_PHY_MODE_CURR != YT8521_PHY_MODE_FIBER)
 +	/* reading UTP */
 +	ret = ytphy_write_ext(phydev, 0xa000, 0);
 +	if (ret < 0)
 +		return ret;
-+
+ 
+-		link = link_utp || link_fiber;
+-	}
 +	val = phy_read(phydev, REG_PHY_SPEC_STATUS);
 +	if (val < 0)
 +		return val;
-+
+ 
 +	link = val & (BIT(YT8521_LINK_STATUS_BIT));
-+	if (link) {
+ 	if (link) {
+-		if (phydev->link == 0) {
+-			/* arbitrate reg space based on linkup media type. */
+-			if (priv->polling_mode == YT8521_MODE_POLL &&
+-			    priv->reg_page == YT8521_RSSR_TO_BE_ARBITRATED) {
+-				if (link_fiber)
+-					priv->reg_page =
+-						YT8521_RSSR_FIBER_SPACE;
+-				else
+-					priv->reg_page = YT8521_RSSR_UTP_SPACE;
+-
+-				ret = ytphy_write_ext_with_lock(phydev,
+-								YT8521_REG_SPACE_SELECT_REG,
+-								priv->reg_page);
+-				if (ret < 0)
+-					return ret;
+-
+-				phydev->port = link_fiber ? PORT_FIBRE : PORT_TP;
+-
+-				phydev_info(phydev, "%s, link up, media: %s\n",
+-					    __func__,
+-					    (phydev->port == PORT_TP) ?
+-					    "UTP" : "Fiber");
+-			}
+-		}
+-		phydev->link = 1;
 +		link_utp = 1;
 +		link_mode_8521 = 1;
 +		yt8521_adjust_status(phydev, val, 1);
-+	} else {
+ 	} else {
+-		if (phydev->link == 1) {
+-			phydev_info(phydev, "%s, link down, media: %s\n",
+-				    __func__, (phydev->port == PORT_TP) ?
+-				    "UTP" : "Fiber");
+-
+-			/* When in YT8521_MODE_POLL mode, need prepare for next
+-			 * arbitration.
+-			 */
+-			if (priv->polling_mode == YT8521_MODE_POLL) {
+-				priv->reg_page = YT8521_RSSR_TO_BE_ARBITRATED;
+-				phydev->port = PORT_NONE;
+-			}
+-		}
+-
+-		phydev->link = 0;
 +		link_utp = 0;
-+	}
+ 	}
 +#endif //(YT8521_PHY_MODE_CURR != YT8521_PHY_MODE_FIBER)
-+
+ 
+-	return 0;
+-}
+-
+-/**
+- * yt8521_modify_bmcr_paged - bits modify a PHY's BMCR register of one page
+- * @phydev: the phy_device struct
+- * @page: The reg page(YT8521_RSSR_FIBER_SPACE/YT8521_RSSR_UTP_SPACE) to operate
+- * @mask: bit mask of bits to clear
+- * @set: bit mask of bits to set
+- *
+- * NOTE: Convenience function which allows a PHY's BMCR register to be
+- * modified as new register value = (old register value & ~mask) | set.
+- * YT8521 has two space (utp/fiber) and three mode (utp/fiber/poll), each space
+- * has MII_BMCR. poll mode combines utp and faber,so need do both.
+- * If it is reset, it will wait for completion.
+- *
+- * returns 0 or negative errno code
+- */
+-static int yt8521_modify_bmcr_paged(struct phy_device *phydev, int page,
+-				    u16 mask, u16 set)
+-{
+-	int max_cnt = 500; /* the max wait time of reset ~ 500 ms */
+-	int old_page;
+-	int ret = 0;
+-
+-	old_page = phy_select_page(phydev, page & YT8521_RSSR_SPACE_MASK);
+-	if (old_page < 0)
+-		goto err_restore_page;
+-
+-	ret = __phy_modify(phydev, MII_BMCR, mask, set);
 +#if (YT8521_PHY_MODE_CURR != YT8521_PHY_MODE_UTP)
 +	/* reading Fiber */
 +	ret = ytphy_write_ext(phydev, 0xa000, 2);
-+	if (ret < 0)
+ 	if (ret < 0)
+-		goto err_restore_page;
+-
+-	/* If it is reset, need to wait for the reset to complete */
+-	if (set == BMCR_RESET) {
+-		while (max_cnt--) {
+-			usleep_range(1000, 1100);
+-			ret = __phy_read(phydev, MII_BMCR);
+-			if (ret < 0)
+-				goto err_restore_page;
+-
+-			if (!(ret & BMCR_RESET))
+-				return phy_restore_page(phydev, old_page, 0);
+-		}
 +		return ret;
 +
 +	val = phy_read(phydev, REG_PHY_SPEC_STATUS);
@@ -816,55 +1953,115 @@ index 000000000..74eef3dfa
 +	{
 +		link = 0;
 +		printk (KERN_INFO "yt8521_read_status, fiber link down detect,latch=%04x,curr=%04x\n", yt8521_fiber_latch_val,yt8521_fiber_curr_val);
-+	}
+ 	}
 +	
 +	if (link) {
 +		link_fiber = 1;
 +		yt8521_adjust_status(phydev, val, 0);
 +		link_mode_8521 = 32; //fiber mode
-+
-+
+ 
+-err_restore_page:
+-	return phy_restore_page(phydev, old_page, ret);
+-}
+ 
+-/**
+- * yt8521_modify_utp_fiber_bmcr - bits modify a PHY's BMCR register
+- * @phydev: the phy_device struct
+- * @mask: bit mask of bits to clear
+- * @set: bit mask of bits to set
+- *
+- * NOTE: Convenience function which allows a PHY's BMCR register to be
+- * modified as new register value = (old register value & ~mask) | set.
+- * YT8521 has two space (utp/fiber) and three mode (utp/fiber/poll), each space
+- * has MII_BMCR. poll mode combines utp and faber,so need do both.
+- *
+- * returns 0 or negative errno code
+- */
+-static int yt8521_modify_utp_fiber_bmcr(struct phy_device *phydev, u16 mask,
+-					u16 set)
+-{
+-	struct yt8521_priv *priv = phydev->priv;
+-	int ret;
 +	} else {
 +		link_fiber = 0;
 +	}
 +#endif //(YT8521_PHY_MODE_CURR != YT8521_PHY_MODE_UTP)
-+
+ 
+-	if (priv->reg_page != YT8521_RSSR_TO_BE_ARBITRATED) {
+-		ret = yt8521_modify_bmcr_paged(phydev, priv->reg_page, mask,
+-					       set);
+-		if (ret < 0)
+-			return ret;
 +	if (link_utp || link_fiber) {
 +		phydev->link = 1;
-+	} else {
+ 	} else {
+-		ret = yt8521_modify_bmcr_paged(phydev, YT8521_RSSR_UTP_SPACE,
+-					       mask, set);
+-		if (ret < 0)
+-			return ret;
 +		phydev->link = 0;
 +		link_mode_8521 = 0;
 +	}
-+
+ 
+-		ret = yt8521_modify_bmcr_paged(phydev, YT8521_RSSR_FIBER_SPACE,
+-					       mask, set);
+-		if (ret < 0)
+-			return ret;
 +#if (YT8521_PHY_MODE_CURR != YT8521_PHY_MODE_FIBER)
 +	if (link_utp) {
 +		ytphy_write_ext(phydev, 0xa000, 0);
-+	}
+ 	}
 +#endif
 +
 +	//printk (KERN_INFO "yzhang..8521 read status call out,link=%d,linkmode=%d\n", phydev->link, link_mode_8521 );
-+	return 0;
-+}
-+
+ 	return 0;
+ }
+ 
+-/**
+- * yt8521_soft_reset() - called to issue a PHY software reset
+- * @phydev: a pointer to a &struct phy_device
+- *
+- * returns 0 or negative errno code
+- */
+-static int yt8521_soft_reset(struct phy_device *phydev)
 +int yt8521_suspend(struct phy_device *phydev)
-+{
+ {
+-	return yt8521_modify_utp_fiber_bmcr(phydev, 0, BMCR_RESET);
+-}
 +#if !(SYS_WAKEUP_BASED_ON_ETH_PKT)				
 +	int value;
-+
+ 
+-/**
+- * yt8521_suspend() - suspend the hardware
+- * @phydev: a pointer to a &struct phy_device
+- *
+- * returns 0 or negative errno code
+- */
+-static int yt8521_suspend(struct phy_device *phydev)
+-{
+-	int wol_config;
 +#if ( LINUX_VERSION_CODE < KERNEL_VERSION(4,0,0) )
 +	mutex_lock(&phydev->lock);
 +#else
 +	/* no need lock in 4.19 */
 +#endif
-+
+ 
+-	/* YTPHY_WOL_CONFIG_REG is common ext reg */
+-	wol_config = ytphy_read_ext_with_lock(phydev, YTPHY_WOL_CONFIG_REG);
+-	if (wol_config < 0)
+-		return wol_config;
 +	ytphy_write_ext(phydev, 0xa000, 0);
 +	value = phy_read(phydev, MII_BMCR);
 +	phy_write(phydev, MII_BMCR, value | BMCR_PDOWN);
-+
+ 
+-	/* if wol enable, do nothing */
+-	if (wol_config & YTPHY_WCR_ENABLE)
+-		return 0;
 +	ytphy_write_ext(phydev, 0xa000, 2);
 +	value = phy_read(phydev, MII_BMCR);
 +	phy_write(phydev, MII_BMCR, value | BMCR_PDOWN);
-+
+ 
+-	return yt8521_modify_utp_fiber_bmcr(phydev, 0, BMCR_PDOWN);
 +	ytphy_write_ext(phydev, 0xa000, 0);
 +
 +#if ( LINUX_VERSION_CODE < KERNEL_VERSION(4,0,0) )
@@ -875,13 +2072,21 @@ index 000000000..74eef3dfa
 +#endif /*!(SYS_WAKEUP_BASED_ON_ETH_PKT)*/				
 +
 +	return 0;
-+}
-+
+ }
+ 
+-/**
+- * yt8521_resume() - resume the hardware
+- * @phydev: a pointer to a &struct phy_device
+- *
+- * returns 0 or negative errno code
+- */
+-static int yt8521_resume(struct phy_device *phydev)
 +int yt8521_resume(struct phy_device *phydev)
-+{
+ {
 +#if !(SYS_WAKEUP_BASED_ON_ETH_PKT)				
 +	int value;
-+	int ret;
+ 	int ret;
+-	int wol_config;
 +	
 +#if ( LINUX_VERSION_CODE < KERNEL_VERSION(4,0,0) )
 +	mutex_lock(&phydev->lock);
@@ -892,17 +2097,30 @@ index 000000000..74eef3dfa
 +	ytphy_write_ext(phydev, 0xa000, 0);
 +	value = phy_read(phydev, MII_BMCR);
 +	phy_write(phydev, MII_BMCR, value & ~BMCR_PDOWN);
-+
-+	/* disable auto sleep */
+ 
+ 	/* disable auto sleep */
+-	ret = ytphy_modify_ext_with_lock(phydev,
+-					 YT8521_EXTREG_SLEEP_CONTROL1_REG,
+-					 YT8521_ESC1R_SLEEP_SW, 0);
 +	value = ytphy_read_ext(phydev, YT8521_EXTREG_SLEEP_CONTROL1);
 +	if (value < 0)
 +		return value;
 +
 +	value &= (~BIT(YT8521_EN_SLEEP_SW_BIT));
 +	ret = ytphy_write_ext(phydev, YT8521_EXTREG_SLEEP_CONTROL1, value);
-+	if (ret < 0)
-+		return ret;
-+
+ 	if (ret < 0)
+ 		return ret;
+ 
+-	wol_config = ytphy_read_ext_with_lock(phydev, YTPHY_WOL_CONFIG_REG);
+-	if (wol_config < 0)
+-		return wol_config;
+-
+-	/* if wol enable, do nothing */
+-	if (wol_config & YTPHY_WCR_ENABLE)
+-		return 0;
+-
+-	return yt8521_modify_utp_fiber_bmcr(phydev, BMCR_PDOWN, 0);
+-}
 +	/* enable RXC clock when no wire plug */
 +	value = ytphy_read_ext(phydev, 0xc);
 +	if (value < 0)
@@ -911,50 +2129,138 @@ index 000000000..74eef3dfa
 +	ret = ytphy_write_ext(phydev, 0xc, value);
 +	if (ret < 0)
 +		return ret;
-+
+ 
+-/**
+- * yt8521_config_init() - called to initialize the PHY
+- * @phydev: a pointer to a &struct phy_device
+- *
+- * returns 0 or negative errno code
+- */
+-static int yt8521_config_init(struct phy_device *phydev)
+-{
+-	struct device_node *node = phydev->mdio.dev.of_node;
+-	int old_page;
+-	int ret = 0;
 +	ytphy_write_ext(phydev, 0xa000, 2);
 +	value = phy_read(phydev, MII_BMCR);
 +	phy_write(phydev, MII_BMCR, value & ~BMCR_PDOWN);
-+
+ 
+-	old_page = phy_select_page(phydev, YT8521_RSSR_UTP_SPACE);
+-	if (old_page < 0)
+-		goto err_restore_page;
 +#if (YT8521_PHY_MODE_CURR != YT8521_PHY_MODE_FIBER)
 +	ytphy_write_ext(phydev, 0xa000, 0);
 +#endif
-+
+ 
+-	/* set rgmii delay mode */
+-	if (phydev->interface != PHY_INTERFACE_MODE_SGMII) {
+-		ret = ytphy_rgmii_clk_delay_config(phydev);
+-		if (ret < 0)
+-			goto err_restore_page;
+-	}
 +#if ( LINUX_VERSION_CODE < KERNEL_VERSION(4,0,0) )
 +	mutex_unlock(&phydev->lock);
 +#else
 +	/* no need lock/unlock in 4.19 */
 +#endif
 +#endif /*!(SYS_WAKEUP_BASED_ON_ETH_PKT)*/				
-+
+ 
+-	if (of_property_read_bool(node, "motorcomm,auto-sleep-disabled")) {
+-		/* disable auto sleep */
+-		ret = ytphy_modify_ext(phydev, YT8521_EXTREG_SLEEP_CONTROL1_REG,
+-				       YT8521_ESC1R_SLEEP_SW, 0);
+-		if (ret < 0)
+-			goto err_restore_page;
+-	}
+-
+-	if (of_property_read_bool(node, "motorcomm,keep-pll-enabled")) {
+-		/* enable RXC clock when no wire plug */
+-		ret = ytphy_modify_ext(phydev, YT8521_CLOCK_GATING_REG,
+-				       YT8521_CGR_RX_CLK_EN, 0);
+-		if (ret < 0)
+-			goto err_restore_page;
+-	}
+-err_restore_page:
+-	return phy_restore_page(phydev, old_page, ret);
 +	return 0;
-+}
-+
+ }
+ 
+-static int yt8531_config_init(struct phy_device *phydev)
 +
 +#if ( LINUX_VERSION_CODE < KERNEL_VERSION(4,0,0) )
 +#else
 +int yt8618_soft_reset(struct phy_device *phydev)
-+{
-+	int ret;
-+
+ {
+-	struct device_node *node = phydev->mdio.dev.of_node;
+ 	int ret;
+ 
+-	ret = ytphy_rgmii_clk_delay_config_with_lock(phydev);
 +	ytphy_write_ext(phydev, 0xa000, 0);
 +	ret = genphy_soft_reset(phydev);
-+	if (ret < 0)
-+		return ret;
-+
-+	return 0;
-+}
-+
+ 	if (ret < 0)
+ 		return ret;
+ 
+-	if (of_property_read_bool(node, "motorcomm,auto-sleep-disabled")) {
+-		/* disable auto sleep */
+-		ret = ytphy_modify_ext_with_lock(phydev,
+-						 YT8521_EXTREG_SLEEP_CONTROL1_REG,
+-						 YT8521_ESC1R_SLEEP_SW, 0);
+-		if (ret < 0)
+-			return ret;
+-	}
+-
+-	if (of_property_read_bool(node, "motorcomm,keep-pll-enabled")) {
+-		/* enable RXC clock when no wire plug */
+-		ret = ytphy_modify_ext_with_lock(phydev,
+-						 YT8521_CLOCK_GATING_REG,
+-						 YT8521_CGR_RX_CLK_EN, 0);
+-		if (ret < 0)
+-			return ret;
+-	}
+-
+ 	return 0;
+ }
+ 
+-/**
+- * yt8531_link_change_notify() - Adjust the tx clock direction according to
+- * the current speed and dts config.
+- * @phydev: a pointer to a &struct phy_device
+- *
+- * NOTE: This function is only used to adapt to VF2 with JH7110 SoC. Please
+- * keep "motorcomm,tx-clk-adj-enabled" not exist in dts when the soc is not
+- * JH7110.
+- */
+-static void yt8531_link_change_notify(struct phy_device *phydev)
 +int yt8614_soft_reset(struct phy_device *phydev)
-+{
-+	int ret;
-+
+ {
+-	struct device_node *node = phydev->mdio.dev.of_node;
+-	bool tx_clk_1000_inverted = false;
+-	bool tx_clk_100_inverted = false;
+-	bool tx_clk_10_inverted = false;
+-	bool tx_clk_adj_enabled = false;
+-	u16 val = 0;
+ 	int ret;
+ 
+-	if (of_property_read_bool(node, "motorcomm,tx-clk-adj-enabled"))
+-		tx_clk_adj_enabled = true;
+-
+-	if (!tx_clk_adj_enabled)
+-		return;
+-
+-	if (of_property_read_bool(node, "motorcomm,tx-clk-10-inverted"))
+-		tx_clk_10_inverted = true;
+-	if (of_property_read_bool(node, "motorcomm,tx-clk-100-inverted"))
+-		tx_clk_100_inverted = true;
+-	if (of_property_read_bool(node, "motorcomm,tx-clk-1000-inverted"))
+-		tx_clk_1000_inverted = true;
 +	/* utp */
 +	ytphy_write_ext(phydev, 0xa000, 0);
 +	ret = genphy_soft_reset(phydev);
 +	if (ret < 0)
 +		return ret;
-+
+ 
+-	if (phydev->speed < 0)
+-		return;
 +	/* qsgmii */
 +	ytphy_write_ext(phydev, 0xa000, 2);
 +	ret = genphy_soft_reset(phydev);
@@ -962,27 +2268,77 @@ index 000000000..74eef3dfa
 +		ytphy_write_ext(phydev, 0xa000, 0); //back to utp mode
 +		return ret;
 +	}
-+
+ 
+-	switch (phydev->speed) {
+-	case SPEED_1000:
+-		if (tx_clk_1000_inverted)
+-			val = YT8521_RC1R_TX_CLK_SEL_INVERTED;
+-		break;
+-	case SPEED_100:
+-		if (tx_clk_100_inverted)
+-			val = YT8521_RC1R_TX_CLK_SEL_INVERTED;
+-		break;
+-	case SPEED_10:
+-		if (tx_clk_10_inverted)
+-			val = YT8521_RC1R_TX_CLK_SEL_INVERTED;
+-		break;
+-	default:
+-		return;
 +	/* sgmii */
 +	ytphy_write_ext(phydev, 0xa000, 3);
 +	ret = genphy_soft_reset(phydev);
 +	if (ret < 0) {
 +		ytphy_write_ext(phydev, 0xa000, 0); //back to utp mode
 +		return ret;
-+	}
-+
+ 	}
+ 
+-	ret = ytphy_modify_ext_with_lock(phydev, YT8521_RGMII_CONFIG1_REG,
+-					 YT8521_RC1R_TX_CLK_SEL_INVERTED, val);
+-	if (ret < 0)
+-		phydev_warn(phydev, "Modify TX_CLK_SEL err:%d\n", ret);
 +	return 0;
-+}
-+
+ }
+ 
+-/**
+- * yt8521_prepare_fiber_features() -  A small helper function that setup
+- * fiber's features.
+- * @phydev: a pointer to a &struct phy_device
+- * @dst: a pointer to store fiber's features
+- */
+-static void yt8521_prepare_fiber_features(struct phy_device *phydev,
+-					  unsigned long *dst)
+-{
+-	linkmode_set_bit(ETHTOOL_LINK_MODE_100baseFX_Full_BIT, dst);
+-	linkmode_set_bit(ETHTOOL_LINK_MODE_1000baseX_Full_BIT, dst);
+-	linkmode_set_bit(ETHTOOL_LINK_MODE_Autoneg_BIT, dst);
+-	linkmode_set_bit(ETHTOOL_LINK_MODE_FIBRE_BIT, dst);
+-}
 +#endif
-+
+ 
+-/**
+- * yt8521_fiber_setup_forced - configures/forces speed from @phydev
+- * @phydev: target phy_device struct
+- *
+- * NOTE:The caller must have taken the MDIO bus lock.
+- *
+- * returns 0 or negative errno code
+- */
+-static int yt8521_fiber_setup_forced(struct phy_device *phydev)
 +static int yt8618_config_init(struct phy_device *phydev)
-+{
-+	int ret;
+ {
+-	u16 val;
+ 	int ret;
 +	int val;
-+
+ 
+-	if (phydev->speed == SPEED_1000)
+-		val = YTPHY_MCR_FIBER_1000BX;
+-	else if (phydev->speed == SPEED_100)
+-		val = YTPHY_MCR_FIBER_100FX;
+-	else
+-		return -EINVAL;
 +	phydev->irq = PHY_POLL;
-+
+ 
+-	ret =  __phy_modify(phydev, MII_BMCR, BMCR_ANENABLE, 0);
 +	if(0xff == yt_mport_base_phy_addr)
 +		/* by default, we think the first phy should be the base phy addr. for mul */
 +#if ( LINUX_VERSION_CODE < KERNEL_VERSION(4,0,0) )
@@ -1005,16 +2361,45 @@ index 000000000..74eef3dfa
 +#else
 +	ret = genphy_config_init(phydev);
 +#endif
-+	if (ret < 0)
-+		return ret;
-+
+ 	if (ret < 0)
+ 		return ret;
+ 
+-	/* disable Fiber auto sensing */
+-	ret =  ytphy_modify_ext(phydev, YT8521_LINK_TIMER_CFG2_REG,
+-				YT8521_LTCR_EN_AUTOSEN, 0);
 +	/* for utp to optimize signal */
 +	ret = ytphy_write_ext(phydev, 0x41, 0x33);
-+	if (ret < 0)
-+		return ret;
+ 	if (ret < 0)
+ 		return ret;
+-
+-	ret =  ytphy_modify_ext(phydev, YTPHY_MISC_CONFIG_REG,
+-				YTPHY_MCR_FIBER_SPEED_MASK, val);
 +	ret = ytphy_write_ext(phydev, 0x42, 0x66);
-+	if (ret < 0)
-+		return ret;
+ 	if (ret < 0)
+ 		return ret;
+-
+-	return ytphy_modify_ext(phydev, YT8521_CHIP_CONFIG_REG,
+-				YT8521_CCR_SW_RST, 0);
+-}
+-
+-/**
+- * ytphy_check_and_restart_aneg - Enable and restart auto-negotiation
+- * @phydev: target phy_device struct
+- * @restart: whether aneg restart is requested
+- *
+- * NOTE:The caller must have taken the MDIO bus lock.
+- *
+- * returns 0 or negative errno code
+- */
+-static int ytphy_check_and_restart_aneg(struct phy_device *phydev, bool restart)
+-{
+-	int ret;
+-
+-	if (!restart) {
+-		/* Advertisement hasn't changed, but maybe aneg was never on to
+-		 * begin with?  Or maybe phy was isolated?
+-		 */
+-		ret = __phy_read(phydev, MII_BMCR);
 +	ret = ytphy_write_ext(phydev, 0x43, 0xaa);
 +	if (ret < 0)
 +		return ret;
@@ -1028,23 +2413,88 @@ index 000000000..74eef3dfa
 +#endif
 +	{
 +		ret = ytphy_write_ext(phydev, 0x44, 0x2929);
-+		if (ret < 0)
-+			return ret;
-+	}
-+
+ 		if (ret < 0)
+ 			return ret;
+-
+-		if (!(ret & BMCR_ANENABLE) || (ret & BMCR_ISOLATE))
+-			restart = true;
+ 	}
+-	/* Enable and Restart Autonegotiation
+-	 * Don't isolate the PHY if we're negotiating
+-	 */
+-	if (restart)
+-		return __phy_modify(phydev, MII_BMCR, BMCR_ISOLATE,
+-				    BMCR_ANENABLE | BMCR_ANRESTART);
+ 
+-	return 0;
 +	val = phy_read(phydev, MII_BMCR);
 +	phy_write(phydev, MII_BMCR, val | BMCR_RESET);
 +
 +	printk (KERN_INFO "yt8618_config_init call out.\n");
 +	return ret;
-+}
-+
+ }
+ 
+-/**
+- * yt8521_fiber_config_aneg - restart auto-negotiation or write
+- * YTPHY_MISC_CONFIG_REG.
+- * @phydev: target phy_device struct
+- *
+- * NOTE:The caller must have taken the MDIO bus lock.
+- *
+- * returns 0 or negative errno code
+- */
+-static int yt8521_fiber_config_aneg(struct phy_device *phydev)
 +static int yt8614_config_init(struct phy_device *phydev)
-+{
+ {
+-	int err, changed = 0;
+-	int bmcr;
+-	u16 adv;
+-
+-	if (phydev->autoneg != AUTONEG_ENABLE)
+-		return yt8521_fiber_setup_forced(phydev);
+-
+-	/* enable Fiber auto sensing */
+-	err =  ytphy_modify_ext(phydev, YT8521_LINK_TIMER_CFG2_REG,
+-				0, YT8521_LTCR_EN_AUTOSEN);
+-	if (err < 0)
+-		return err;
+-
+-	err =  ytphy_modify_ext(phydev, YT8521_CHIP_CONFIG_REG,
+-				YT8521_CCR_SW_RST, 0);
+-	if (err < 0)
+-		return err;
+-
+-	bmcr = __phy_read(phydev, MII_BMCR);
+-	if (bmcr < 0)
+-		return bmcr;
+-
+-	/* When it is coming from fiber forced mode, add bmcr power down
+-	 * and power up to let aneg work fine.
+-	 */
+-	if (!(bmcr & BMCR_ANENABLE)) {
+-		__phy_modify(phydev, MII_BMCR, 0, BMCR_PDOWN);
+-		usleep_range(1000, 1100);
+-		__phy_modify(phydev, MII_BMCR, BMCR_PDOWN, 0);
+-	}
+-
+-	adv = linkmode_adv_to_mii_adv_x(phydev->advertising,
+-					ETHTOOL_LINK_MODE_1000baseX_Full_BIT);
+-
+-	/* Setup fiber advertisement */
+-	err = __phy_modify_changed(phydev, MII_ADVERTISE,
+-				   ADVERTISE_1000XHALF | ADVERTISE_1000XFULL |
+-				   ADVERTISE_1000XPAUSE |
+-				   ADVERTISE_1000XPSE_ASYM,
+-				   adv);
+-	if (err < 0)
+-		return err;
 +	int ret = 0;
-+
+ 
+-	if (err > 0)
+-		changed = 1;
 +	phydev->irq = PHY_POLL;
-+
+ 
+-	return ytphy_check_and_restart_aneg(phydev, changed);
 +	if(0xff == yt_mport_base_phy_addr_8614)
 +		/* by default, we think the first phy should be the base phy addr. for mul */
 +#if ( LINUX_VERSION_CODE < KERNEL_VERSION(4,0,0) )
@@ -1061,22 +2511,112 @@ index 000000000..74eef3dfa
 +	}
 +#endif	
 +	return ret;
-+}
-+
+ }
+ 
+-/**
+- * ytphy_setup_master_slave
+- * @phydev: target phy_device struct
+- *
+- * NOTE: The caller must have taken the MDIO bus lock.
+- *
+- * returns 0 or negative errno code
+- */
+-static int ytphy_setup_master_slave(struct phy_device *phydev)
+-{
+-	u16 ctl = 0;
+-
+-	if (!phydev->is_gigabit_capable)
+-		return 0;
 +#if ( LINUX_VERSION_CODE < KERNEL_VERSION(4,0,0) )
 +#define yt8614_get_port_from_phydev(phydev) ((0xff == yt_mport_base_phy_addr_8614) && (yt_mport_base_phy_addr_8614 <= (phydev)->addr) ? 0 : (unsigned int)((phydev)->addr) - yt_mport_base_phy_addr_8614)
 +#else
 +#define yt8614_get_port_from_phydev(phydev) ((0xff == yt_mport_base_phy_addr_8614) && (yt_mport_base_phy_addr_8614 <= (phydev)->mdio.addr) ? 0 : (unsigned int)((phydev)->mdio.addr) - yt_mport_base_phy_addr_8614)
 +#endif
-+
+ 
+-	switch (phydev->master_slave_set) {
+-	case MASTER_SLAVE_CFG_MASTER_PREFERRED:
+-		ctl |= CTL1000_PREFER_MASTER;
+-		break;
+-	case MASTER_SLAVE_CFG_SLAVE_PREFERRED:
+-		break;
+-	case MASTER_SLAVE_CFG_MASTER_FORCE:
+-		ctl |= CTL1000_AS_MASTER;
+-		fallthrough;
+-	case MASTER_SLAVE_CFG_SLAVE_FORCE:
+-		ctl |= CTL1000_ENABLE_MASTER;
+-		break;
+-	case MASTER_SLAVE_CFG_UNKNOWN:
+-	case MASTER_SLAVE_CFG_UNSUPPORTED:
+-		return 0;
+-	default:
+-		phydev_warn(phydev, "Unsupported Master/Slave mode\n");
+-		return -EOPNOTSUPP;
+-	}
 +int yt8618_aneg_done (struct phy_device *phydev)
 +{
-+
+ 
+-	return __phy_modify_changed(phydev, MII_CTRL1000,
+-				    (CTL1000_ENABLE_MASTER | CTL1000_AS_MASTER |
+-				    CTL1000_PREFER_MASTER), ctl);
 +	return genphy_aneg_done(phydev);
-+}
-+
+ }
+ 
+-/**
+- * ytphy_utp_config_advert - sanitize and advertise auto-negotiation parameters
+- * @phydev: target phy_device struct
+- *
+- * NOTE: Writes MII_ADVERTISE with the appropriate values,
+- * after sanitizing the values to make sure we only advertise
+- * what is supported.  Returns < 0 on error, 0 if the PHY's advertisement
+- * hasn't changed, and > 0 if it has changed.
+- * The caller must have taken the MDIO bus lock.
+- *
+- * returns 0 or negative errno code
+- */
+-static int ytphy_utp_config_advert(struct phy_device *phydev)
 +int yt8614_aneg_done (struct phy_device *phydev)
-+{
+ {
+-	int err, bmsr, changed = 0;
+-	u32 adv;
+-
+-	/* Only allow advertising what this PHY supports */
+-	linkmode_and(phydev->advertising, phydev->advertising,
+-		     phydev->supported);
+-
+-	adv = linkmode_adv_to_mii_adv_t(phydev->advertising);
+-
+-	/* Setup standard advertisement */
+-	err = __phy_modify_changed(phydev, MII_ADVERTISE,
+-				   ADVERTISE_ALL | ADVERTISE_100BASE4 |
+-				   ADVERTISE_PAUSE_CAP | ADVERTISE_PAUSE_ASYM,
+-				   adv);
+-	if (err < 0)
+-		return err;
+-	if (err > 0)
+-		changed = 1;
+-
+-	bmsr = __phy_read(phydev, MII_BMSR);
+-	if (bmsr < 0)
+-		return bmsr;
+-
+-	/* Per 802.3-2008, Section 22.2.4.2.16 Extended status all
+-	 * 1000Mbits/sec capable PHYs shall have the BMSR_ESTATEN bit set to a
+-	 * logical 1.
+-	 */
+-	if (!(bmsr & BMSR_ESTATEN))
+-		return changed;
+-
+-	adv = linkmode_adv_to_mii_ctrl1000_t(phydev->advertising);
+-
+-	err = __phy_modify_changed(phydev, MII_CTRL1000,
+-				   ADVERTISE_1000FULL | ADVERTISE_1000HALF,
+-				   adv);
+-	if (err < 0)
+-		return err;
+-	if (err > 0)
+-		changed = 1;
+-
+-	return changed;
 +	int port = yt8614_get_port_from_phydev(phydev);
 +	
 +	/*it should be used for 8614 fiber*/
@@ -1086,10 +2626,25 @@ index 000000000..74eef3dfa
 +	}
 +
 +	return genphy_aneg_done(phydev);
-+}
-+
+ }
+ 
+-/**
+- * ytphy_utp_config_aneg - restart auto-negotiation or write BMCR
+- * @phydev: target phy_device struct
+- * @changed: whether autoneg is requested
+- *
+- * NOTE: If auto-negotiation is enabled, we configure the
+- * advertising, and then restart auto-negotiation.  If it is not
+- * enabled, then we write the BMCR.
+- * The caller must have taken the MDIO bus lock.
+- *
+- * returns 0 or negative errno code
+- */
+-static int ytphy_utp_config_aneg(struct phy_device *phydev, bool changed)
 +static int yt8614_read_status(struct phy_device *phydev)
-+{
+ {
+-	int err;
+-	u16 ctl;
 +        //int i;
 +	int ret;
 +	volatile int val, yt8614_fiber_latch_val, yt8614_fiber_curr_val;
@@ -1102,11 +2657,18 @@ index 000000000..74eef3dfa
 +	ret = ytphy_write_ext(phydev, 0xa000, 0);
 +	if (ret < 0)
 +		return ret;
-+
+ 
+-	err = ytphy_setup_master_slave(phydev);
+-	if (err < 0)
+-		return err;
+-	else if (err)
+-		changed = true;
 +	val = phy_read(phydev, REG_PHY_SPEC_STATUS);
 +	if (val < 0)
 +		return val;
-+
+ 
+-	if (phydev->autoneg != AUTONEG_ENABLE) {
+-		/* configures/forces speed/duplex from @phydev */
 +	link = val & (BIT(YT8521_LINK_STATUS_BIT));
 +	if (link) {
 +		link_utp = 1;
@@ -1116,13 +2678,16 @@ index 000000000..74eef3dfa
 +		link_utp = 0;
 +	}
 +#endif //(YT8614_PHY_MODE_CURR != YT8521_PHY_MODE_FIBER)
-+
+ 
+-		ctl = mii_bmcr_encode_fixed(phydev->speed, phydev->duplex);
 +#if (YT8614_PHY_MODE_CURR != YT8521_PHY_MODE_UTP)
 +	/* reading Fiber/sgmii */
 +	ret = ytphy_write_ext(phydev, 0xa000, 3);
 +	if (ret < 0)
 +		return ret;
-+
+ 
+-		return __phy_modify(phydev, MII_BMCR, ~(BMCR_LOOPBACK |
+-				    BMCR_ISOLATE | BMCR_PDOWN), ctl);
 +	val = phy_read(phydev, REG_PHY_SPEC_STATUS);
 +	if (val < 0)
 +		return val;
@@ -1137,52 +2702,138 @@ index 000000000..74eef3dfa
 +	{
 +		link = 0;
 +		printk (KERN_INFO "yt8614_read_status, fiber link down detect,latch=%04x,curr=%04x\n", yt8614_fiber_latch_val,yt8614_fiber_curr_val);
-+	}
+ 	}
 +	
 +	if (link) {
 +		link_fiber = 1;
 +		yt8521_adjust_status(phydev, val, 0);
 +		link_mode_8614[port] = 32; //fiber mode
-+
-+
+ 
+-	err = ytphy_utp_config_advert(phydev);
+-	if (err < 0) /* error */
+-		return err;
+-	else if (err)
+-		changed = true;
+-
+-	return ytphy_check_and_restart_aneg(phydev, changed);
+-}
+ 
+-/**
+- * yt8521_config_aneg_paged() - switch reg space then call genphy_config_aneg
+- * of one page
+- * @phydev: a pointer to a &struct phy_device
+- * @page: The reg page(YT8521_RSSR_FIBER_SPACE/YT8521_RSSR_UTP_SPACE) to
+- * operate.
+- *
+- * returns 0 or negative errno code
+- */
+-static int yt8521_config_aneg_paged(struct phy_device *phydev, int page)
+-{
+-	__ETHTOOL_DECLARE_LINK_MODE_MASK(fiber_supported);
+-	struct yt8521_priv *priv = phydev->priv;
+-	int old_page;
+-	int ret = 0;
 +	} else {
 +		link_fiber = 0;
 +	}
 +#endif //(YT8521_PHY_MODE_CURR != YT8521_PHY_MODE_UTP)
-+
+ 
+-	page &= YT8521_RSSR_SPACE_MASK;
+-
+-	old_page = phy_select_page(phydev, page);
+-	if (old_page < 0)
+-		goto err_restore_page;
+-
+-	/* If reg_page is YT8521_RSSR_TO_BE_ARBITRATED,
+-	 * phydev->advertising should be updated.
+-	 */
+-	if (priv->reg_page == YT8521_RSSR_TO_BE_ARBITRATED) {
+-		linkmode_zero(fiber_supported);
+-		yt8521_prepare_fiber_features(phydev, fiber_supported);
+-
+-		/* prepare fiber_supported, then setup advertising. */
+-		if (page == YT8521_RSSR_FIBER_SPACE) {
+-			linkmode_set_bit(ETHTOOL_LINK_MODE_Pause_BIT,
+-					 fiber_supported);
+-			linkmode_set_bit(ETHTOOL_LINK_MODE_Asym_Pause_BIT,
+-					 fiber_supported);
+-			linkmode_and(phydev->advertising,
+-				     priv->combo_advertising, fiber_supported);
+-		} else {
+-			/* ETHTOOL_LINK_MODE_Autoneg_BIT is also used in utp */
+-			linkmode_clear_bit(ETHTOOL_LINK_MODE_Autoneg_BIT,
+-					   fiber_supported);
+-			linkmode_andnot(phydev->advertising,
+-					priv->combo_advertising,
+-					fiber_supported);
+-		}
 +	if (link_utp || link_fiber) {
 +		phydev->link = 1;
 +	} else {
 +		phydev->link = 0;
 +		link_mode_8614[port] = 0;
-+	}
-+
+ 	}
+ 
+-	if (page == YT8521_RSSR_FIBER_SPACE)
+-		ret = yt8521_fiber_config_aneg(phydev);
+-	else
+-		ret = ytphy_utp_config_aneg(phydev, false);
 +#if (YT8614_PHY_MODE_CURR != YT8521_PHY_MODE_FIBER)
 +	if (link_utp) {
 +		ytphy_write_ext(phydev, 0xa000, 0);
 +	}
 +#endif
 +	//printk (KERN_INFO "yt8614_read_status call out,link=%d,linkmode=%d\n", phydev->link, link_mode_8614[port] );
-+
+ 
+-err_restore_page:
+-	return phy_restore_page(phydev, old_page, ret);
 +	return 0;
-+}
-+
+ }
+ 
+-/**
+- * yt8521_config_aneg() - change reg space then call yt8521_config_aneg_paged
+- * @phydev: a pointer to a &struct phy_device
+- *
+- * returns 0 or negative errno code
+- */
+-static int yt8521_config_aneg(struct phy_device *phydev)
 +static int yt8618_read_status(struct phy_device *phydev)
-+{
-+	int ret;
+ {
+-	struct yt8521_priv *priv = phydev->priv;
+ 	int ret;
 +	volatile int val; //maybe for 8614 yt8521_fiber_latch_val, yt8521_fiber_curr_val;
 +	volatile int link;
 +	int link_utp = 0, link_fiber = 0;
-+
+ 
+-	if (priv->reg_page != YT8521_RSSR_TO_BE_ARBITRATED) {
+-		ret = yt8521_config_aneg_paged(phydev, priv->reg_page);
+-		if (ret < 0)
+-			return ret;
+-	} else {
+-		/* If reg_page is YT8521_RSSR_TO_BE_ARBITRATED,
+-		 * phydev->advertising need to be saved at first run.
+-		 * Because it contains the advertising which supported by both
+-		 * mac and yt8521(utp and fiber).
+-		 */
+-		if (linkmode_empty(priv->combo_advertising)) {
+-			linkmode_copy(priv->combo_advertising,
+-				      phydev->advertising);
+-		}
 +	/* switch to utp and reading regs  */
 +	ret = ytphy_write_ext(phydev, 0xa000, 0);
 +	if (ret < 0)
 +		return ret;
-+
+ 
+-		ret = yt8521_config_aneg_paged(phydev, YT8521_RSSR_UTP_SPACE);
+-		if (ret < 0)
+-			return ret;
 +	val = phy_read(phydev, REG_PHY_SPEC_STATUS);
 +	if (val < 0)
 +		return val;
-+
+ 
+-		ret = yt8521_config_aneg_paged(phydev, YT8521_RSSR_FIBER_SPACE);
+-		if (ret < 0)
+-			return ret;
 +	link = val & (BIT(YT8521_LINK_STATUS_BIT));
 +	if (link) {
 +		link_utp = 1;
@@ -1190,18 +2841,46 @@ index 000000000..74eef3dfa
 +	} else {
 +		link_utp = 0;
 +	}
-+
+ 
+-		/* we don't known which will be link, so restore
+-		 * phydev->advertising as default value.
+-		 */
+-		linkmode_copy(phydev->advertising, priv->combo_advertising);
 +	if (link_utp || link_fiber) {
 +		phydev->link = 1;
 +	} else {
 +		phydev->link = 0;
-+	}
+ 	}
 +
-+	return 0;
-+}
-+
+ 	return 0;
+ }
+ 
+-/**
+- * yt8521_aneg_done_paged() - determines the auto negotiation result of one
+- * page.
+- * @phydev: a pointer to a &struct phy_device
+- * @page: The reg page(YT8521_RSSR_FIBER_SPACE/YT8521_RSSR_UTP_SPACE) to
+- * operate.
+- *
+- * returns 0(no link)or 1(fiber or utp link) or negative errno code
+- */
+-static int yt8521_aneg_done_paged(struct phy_device *phydev, int page)
 +int yt8618_suspend(struct phy_device *phydev)
-+{
+ {
+-	int old_page;
+-	int ret = 0;
+-	int link;
+-
+-	old_page = phy_select_page(phydev, page & YT8521_RSSR_SPACE_MASK);
+-	if (old_page < 0)
+-		goto err_restore_page;
+-
+-	ret = __phy_read(phydev, YTPHY_SPECIFIC_STATUS_REG);
+-	if (ret < 0)
+-		goto err_restore_page;
+-
+-	link = !!(ret & YTPHY_SSR_LINK);
+-	ret = link;
 +#if !(SYS_WAKEUP_BASED_ON_ETH_PKT)				
 +	int value;
 +
@@ -1221,12 +2900,44 @@ index 000000000..74eef3dfa
 +	/* no need lock/unlock in 4.19 */
 +#endif
 +#endif /*!(SYS_WAKEUP_BASED_ON_ETH_PKT)*/				
-+
+ 
+-err_restore_page:
+-	return phy_restore_page(phydev, old_page, ret);
 +	return 0;
-+}
-+
+ }
+ 
+-/**
+- * yt8521_aneg_done() - determines the auto negotiation result
+- * @phydev: a pointer to a &struct phy_device
+- *
+- * returns 0(no link)or 1(fiber or utp link) or negative errno code
+- */
+-static int yt8521_aneg_done(struct phy_device *phydev)
 +int yt8618_resume(struct phy_device *phydev)
-+{
+ {
+-	struct yt8521_priv *priv = phydev->priv;
+-	int link_fiber = 0;
+-	int link_utp;
+-	int link;
+-
+-	if (priv->reg_page != YT8521_RSSR_TO_BE_ARBITRATED) {
+-		link = yt8521_aneg_done_paged(phydev, priv->reg_page);
+-	} else {
+-		link_utp = yt8521_aneg_done_paged(phydev,
+-						  YT8521_RSSR_UTP_SPACE);
+-		if (link_utp < 0)
+-			return link_utp;
+-
+-		if (!link_utp) {
+-			link_fiber = yt8521_aneg_done_paged(phydev,
+-							    YT8521_RSSR_FIBER_SPACE);
+-			if (link_fiber < 0)
+-				return link_fiber;
+-		}
+-		link = link_fiber || link_utp;
+-		phydev_info(phydev, "%s, link_fiber: %d, link_utp: %d\n",
+-			    __func__, link_fiber, link_utp);
+-	}
 +#if !(SYS_WAKEUP_BASED_ON_ETH_PKT)				
 +	int value;
 +
@@ -1246,25 +2957,68 @@ index 000000000..74eef3dfa
 +	/* no need lock/unlock in 4.19 */
 +#endif
 +#endif /*!(SYS_WAKEUP_BASED_ON_ETH_PKT)*/				
-+
+ 
+-	return link;
 +	return 0;
-+}
-+
+ }
+ 
+-/**
+- * ytphy_utp_read_abilities - read PHY abilities from Clause 22 registers
+- * @phydev: target phy_device struct
+- *
+- * NOTE: Reads the PHY's abilities and populates
+- * phydev->supported accordingly.
+- * The caller must have taken the MDIO bus lock.
+- *
+- * returns 0 or negative errno code
+- */
+-static int ytphy_utp_read_abilities(struct phy_device *phydev)
 +int yt8614_suspend(struct phy_device *phydev)
-+{
+ {
+-	int val;
 +#if !(SYS_WAKEUP_BASED_ON_ETH_PKT)				
 +	int value;
-+
+ 
+-	linkmode_set_bit_array(phy_basic_ports_array,
+-			       ARRAY_SIZE(phy_basic_ports_array),
+-			       phydev->supported);
 +#if ( LINUX_VERSION_CODE < KERNEL_VERSION(4,0,0) )
 +	mutex_lock(&phydev->lock);
 +#else
 +	/* no need lock in 4.19 */
 +#endif
-+
+ 
+-	val = __phy_read(phydev, MII_BMSR);
+-	if (val < 0)
+-		return val;
 +	ytphy_write_ext(phydev, 0xa000, 0);
 +	value = phy_read(phydev, MII_BMCR);
 +	phy_write(phydev, MII_BMCR, value | BMCR_PDOWN);
-+
+ 
+-	linkmode_mod_bit(ETHTOOL_LINK_MODE_Autoneg_BIT, phydev->supported,
+-			 val & BMSR_ANEGCAPABLE);
+-
+-	linkmode_mod_bit(ETHTOOL_LINK_MODE_100baseT_Full_BIT, phydev->supported,
+-			 val & BMSR_100FULL);
+-	linkmode_mod_bit(ETHTOOL_LINK_MODE_100baseT_Half_BIT, phydev->supported,
+-			 val & BMSR_100HALF);
+-	linkmode_mod_bit(ETHTOOL_LINK_MODE_10baseT_Full_BIT, phydev->supported,
+-			 val & BMSR_10FULL);
+-	linkmode_mod_bit(ETHTOOL_LINK_MODE_10baseT_Half_BIT, phydev->supported,
+-			 val & BMSR_10HALF);
+-
+-	if (val & BMSR_ESTATEN) {
+-		val = __phy_read(phydev, MII_ESTATUS);
+-		if (val < 0)
+-			return val;
+-
+-		linkmode_mod_bit(ETHTOOL_LINK_MODE_1000baseT_Full_BIT,
+-				 phydev->supported, val & ESTATUS_1000_TFULL);
+-		linkmode_mod_bit(ETHTOOL_LINK_MODE_1000baseT_Half_BIT,
+-				 phydev->supported, val & ESTATUS_1000_THALF);
+-		linkmode_mod_bit(ETHTOOL_LINK_MODE_1000baseX_Full_BIT,
+-				 phydev->supported, val & ESTATUS_1000_XFULL);
+-	}
 +	ytphy_write_ext(phydev, 0xa000, 3);
 +	value = phy_read(phydev, MII_BMCR);
 +	phy_write(phydev, MII_BMCR, value | BMCR_PDOWN);
@@ -1277,44 +3031,93 @@ index 000000000..74eef3dfa
 +	/* no need lock/unlock in 4.19 */
 +#endif
 +#endif /*!(SYS_WAKEUP_BASED_ON_ETH_PKT)*/				
-+
-+	return 0;
-+}
-+
+ 
+ 	return 0;
+ }
+ 
+-/**
+- * yt8521_get_features_paged() -  read supported link modes for one page
+- * @phydev: a pointer to a &struct phy_device
+- * @page: The reg page(YT8521_RSSR_FIBER_SPACE/YT8521_RSSR_UTP_SPACE) to
+- * operate.
+- *
+- * returns 0 or negative errno code
+- */
+-static int yt8521_get_features_paged(struct phy_device *phydev, int page)
 +int yt8614_resume(struct phy_device *phydev)
-+{
+ {
+-	int old_page;
+-	int ret = 0;
 +#if !(SYS_WAKEUP_BASED_ON_ETH_PKT)				
 +	int value;
-+
+ 
+-	page &= YT8521_RSSR_SPACE_MASK;
+-	old_page = phy_select_page(phydev, page);
+-	if (old_page < 0)
+-		goto err_restore_page;
 +#if ( LINUX_VERSION_CODE < KERNEL_VERSION(4,0,0) )
 +	mutex_lock(&phydev->lock);
 +#else
 +	/* no need lock/unlock in 4.19 */
 +#endif
-+
+ 
+-	if (page == YT8521_RSSR_FIBER_SPACE) {
+-		linkmode_zero(phydev->supported);
+-		yt8521_prepare_fiber_features(phydev, phydev->supported);
+-	} else {
+-		ret = ytphy_utp_read_abilities(phydev);
+-		if (ret < 0)
+-			goto err_restore_page;
+-	}
 +	ytphy_write_ext(phydev, 0xa000, 0);
 +	value = phy_read(phydev, MII_BMCR);
 +	phy_write(phydev, MII_BMCR, value & ~BMCR_PDOWN);
-+
+ 
+-err_restore_page:
+-	return phy_restore_page(phydev, old_page, ret);
+-}
 +	ytphy_write_ext(phydev, 0xa000, 3);
 +	value = phy_read(phydev, MII_BMCR);
 +	phy_write(phydev, MII_BMCR, value & ~BMCR_PDOWN);
-+
+ 
+-/**
+- * yt8521_get_features - switch reg space then call yt8521_get_features_paged
+- * @phydev: target phy_device struct
+- *
+- * returns 0 or negative errno code
+- */
+-static int yt8521_get_features(struct phy_device *phydev)
+-{
+-	struct yt8521_priv *priv = phydev->priv;
+-	int ret;
 +	ytphy_write_ext(phydev, 0xa000, 0);
-+
+ 
+-	if (priv->reg_page != YT8521_RSSR_TO_BE_ARBITRATED) {
+-		ret = yt8521_get_features_paged(phydev, priv->reg_page);
+-	} else {
+-		ret = yt8521_get_features_paged(phydev,
+-						YT8521_RSSR_UTP_SPACE);
+-		if (ret < 0)
+-			return ret;
 +#if ( LINUX_VERSION_CODE < KERNEL_VERSION(4,0,0) )
 +	mutex_unlock(&phydev->lock);
 +#else
 +	/* no need lock/unlock in 4.19 */
 +#endif
 +#endif /*!(SYS_WAKEUP_BASED_ON_ETH_PKT)*/				
-+
+ 
+-		/* add fiber's features to phydev->supported */
+-		yt8521_prepare_fiber_features(phydev, phydev->supported);
+-	}
+-	return ret;
 +	return 0;
-+}
-+
+ }
+ 
+-static struct phy_driver motorcomm_phy_drvs[] = {
 +
 +static struct phy_driver ytphy_drvs[] = {
-+	{
+ 	{
+-		PHY_ID_MATCH_EXACT(PHY_ID_YT8511),
 +		.phy_id         = PHY_ID_YT8010,
 +		.name           = "YT8010 Automotive Ethernet",
 +		.phy_id_mask    = MOTORCOMM_PHY_ID_MASK,
@@ -1346,7 +3149,7 @@ index 000000000..74eef3dfa
 +		.read_status	= genphy_read_status,
 +	}, {
 +		.phy_id		= PHY_ID_YT8511,
-+		.name		= "YT8511 Gigabit Ethernet",
+ 		.name		= "YT8511 Gigabit Ethernet",
 +		.phy_id_mask	= MOTORCOMM_PHY_ID_MASK,
 +#if ( LINUX_VERSION_CODE < KERNEL_VERSION(5,4,0) )
 +		.features	= PHY_GBIT_FEATURES,
@@ -1354,7 +3157,7 @@ index 000000000..74eef3dfa
 +#endif		
 +		.config_aneg	= genphy_config_aneg,
 +#if GMAC_CLOCK_INPUT_NEEDED
-+		.config_init	= yt8511_config_init,
+ 		.config_init	= yt8511_config_init,
 +#else
 +#if ( LINUX_VERSION_CODE < KERNEL_VERSION(4,0,0) )
 +		.config_init	= ytphy_config_init,
@@ -1363,8 +3166,24 @@ index 000000000..74eef3dfa
 +#endif
 +#endif
 +		.read_status	= genphy_read_status,
-+		.suspend	= genphy_suspend,
-+		.resume		= genphy_resume,
+ 		.suspend	= genphy_suspend,
+ 		.resume		= genphy_resume,
+-		.read_page	= yt8511_read_page,
+-		.write_page	= yt8511_write_page,
+-	},
+-	{
+-		PHY_ID_MATCH_EXACT(PHY_ID_YT8521),
+-		.name		= "YT8521 Gigabit Ethernet",
+-		.get_features	= yt8521_get_features,
+-		.probe		= yt8521_probe,
+-		.read_page	= yt8521_read_page,
+-		.write_page	= yt8521_write_page,
+-		.get_wol	= ytphy_get_wol,
+-		.set_wol	= ytphy_set_wol,
+-		.config_aneg	= yt8521_config_aneg,
+-		.aneg_done	= yt8521_aneg_done,
+-		.config_init	= yt8521_config_init,
+-		.read_status	= yt8521_read_status,
 +	}, {
 +		.phy_id		= PHY_ID_YT8512,
 +		.name		= "YT8512 Ethernet",
@@ -1401,7 +3220,12 @@ index 000000000..74eef3dfa
 +        .flags          = PHY_POLL,
 +#if ( LINUX_VERSION_CODE < KERNEL_VERSION(4,0,0) )
 +#else
-+		.soft_reset	= yt8521_soft_reset,
+ 		.soft_reset	= yt8521_soft_reset,
+-		.suspend	= yt8521_suspend,
+-		.resume		= yt8521_resume,
+-	},
+-	{
+-		PHY_ID_MATCH_EXACT(PHY_ID_YT8531),
 +#endif
 +        .config_aneg    = genphy_config_aneg,
 +#if ( LINUX_VERSION_CODE > KERNEL_VERSION(3,11,0) )
@@ -1443,7 +3267,9 @@ index 000000000..74eef3dfa
 +        }, {
 +        /* same as 8511 */
 +		.phy_id		= PHY_ID_YT8531,
-+		.name		= "YT8531 Gigabit Ethernet",
+ 		.name		= "YT8531 Gigabit Ethernet",
+-		.probe		= yt8531_probe,
+-		.config_init	= yt8531_config_init,
 +		.phy_id_mask	= MOTORCOMM_PHY_ID_MASK,
 +#if ( LINUX_VERSION_CODE < KERNEL_VERSION(5,4,0) )
 +		.features	= PHY_BASIC_FEATURES | PHY_GBIT_FEATURES,
@@ -1456,8 +3282,29 @@ index 000000000..74eef3dfa
 +		.config_init	= genphy_config_init,
 +#endif
 +		.read_status	= genphy_read_status,
-+		.suspend	= genphy_suspend,
-+		.resume		= genphy_resume,
+ 		.suspend	= genphy_suspend,
+ 		.resume		= genphy_resume,
+-		.get_wol	= ytphy_get_wol,
+-		.set_wol	= yt8531_set_wol,
+-		.link_change_notify = yt8531_link_change_notify,
+-	},
+-	{
+-		PHY_ID_MATCH_EXACT(PHY_ID_YT8531S),
+-		.name		= "YT8531S Gigabit Ethernet",
+-		.get_features	= yt8521_get_features,
+-		.probe		= yt8521_probe,
+-		.read_page	= yt8521_read_page,
+-		.write_page	= yt8521_write_page,
+-		.get_wol	= ytphy_get_wol,
+-		.set_wol	= ytphy_set_wol,
+-		.config_aneg	= yt8521_config_aneg,
+-		.aneg_done	= yt8521_aneg_done,
+-		.config_init	= yt8521_config_init,
+-		.read_status	= yt8521_read_status,
+-		.soft_reset	= yt8521_soft_reset,
+-		.suspend	= yt8521_suspend,
+-		.resume		= yt8521_resume,
+-	},
 +#if (YTPHY_ENABLE_WOL)
 +		.get_wol		= &ytphy_get_wol,
 +		.set_wol		= &ytphy_set_wol,
@@ -1503,8 +3350,9 @@ index 000000000..74eef3dfa
 +		.suspend		= yt8614_suspend,
 +		.resume 		= yt8614_resume,
 +		}, 
-+};
-+
+ };
+ 
+-module_phy_driver(motorcomm_phy_drvs);
 +#if ( LINUX_VERSION_CODE < KERNEL_VERSION(4,0,0) )
 +static int ytphy_drivers_register(struct phy_driver* phy_drvs, int size)
 +{
@@ -1529,7 +3377,10 @@ index 000000000..74eef3dfa
 +static void ytphy_drivers_unregister(struct phy_driver* phy_drvs, int size)
 +{
 +	int i;
-+
+ 
+-MODULE_DESCRIPTION("Motorcomm 8511/8521/8531/8531S PHY driver");
+-MODULE_AUTHOR("Peter Geis");
+-MODULE_AUTHOR("Frank");
 +	for (i = 0; i < size; i++) {
 +		phy_driver_unregister(&phy_drvs[i]);
 +	}
@@ -1556,8 +3407,14 @@ index 000000000..74eef3dfa
 +
 +MODULE_DESCRIPTION("Motorcomm PHY driver");
 +MODULE_AUTHOR("Leilei Zhao");
-+MODULE_LICENSE("GPL");
-+
+ MODULE_LICENSE("GPL");
+ 
+-static const struct mdio_device_id __maybe_unused motorcomm_tbl[] = {
+-	{ PHY_ID_MATCH_EXACT(PHY_ID_YT8511) },
+-	{ PHY_ID_MATCH_EXACT(PHY_ID_YT8521) },
+-	{ PHY_ID_MATCH_EXACT(PHY_ID_YT8531) },
+-	{ PHY_ID_MATCH_EXACT(PHY_ID_YT8531S) },
+-	{ /* sentinel */ }
 +static struct mdio_device_id __maybe_unused motorcomm_tbl[] = {
 +	{ PHY_ID_YT8010, MOTORCOMM_PHY_ID_MASK },
 +	{ PHY_ID_YT8510, MOTORCOMM_PHY_ID_MASK },
@@ -1570,14 +3427,14 @@ index 000000000..74eef3dfa
 +	{ PHY_ID_YT8618, MOTORCOMM_MPHY_ID_MASK },
 +	{ PHY_ID_YT8614, MOTORCOMM_MPHY_ID_MASK_8614 },
 +	{ }
-+};
-+
-+MODULE_DEVICE_TABLE(mdio, motorcomm_tbl);
+ };
+ 
+ MODULE_DEVICE_TABLE(mdio, motorcomm_tbl);
 +
 +
 diff --git a/drivers/net/phy/yt8614-phy.h b/drivers/net/phy/yt8614-phy.h
 new file mode 100644
-index 000000000..56a398338
+index 000000000000..56a398338146
 --- /dev/null
 +++ b/drivers/net/phy/yt8614-phy.h
 @@ -0,0 +1,491 @@
@@ -2074,7 +3931,7 @@ index 000000000..56a398338
 +#endif
 diff --git a/include/linux/motorcomm_phy.h b/include/linux/motorcomm_phy.h
 new file mode 100644
-index 000000000..9e01fc205
+index 000000000000..9e01fc205789
 --- /dev/null
 +++ b/include/linux/motorcomm_phy.h
 @@ -0,0 +1,119 @@
@@ -2198,5 +4055,5 @@ index 000000000..9e01fc205
 +
 +
 -- 
-2.25.1
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/add-maker-friendlyarm.patch
+++ b/patch/kernel/archive/rockchip64-6.3/add-maker-friendlyarm.patch
@@ -1,26 +1,23 @@
-From 2fc2cbaaaf0dcebdeffa6e87bbc9ad843a5470dd Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: hmz007 <hmz007@gmail.com>
 Date: Sat, 11 Jan 2020 19:35:03 +0800
-Subject: [PATCH] soc: friendlyelec: Add board info driver
+Subject: soc: friendlyelec: Add board info driver
 
 Change-Id: I122adb4f99c816b5c177f16392fb2df9c10a47be
 Signed-off-by: hmz007 <hmz007@gmail.com>
 ---
- drivers/soc/Kconfig                           |   1 +
- drivers/soc/Makefile                          |   1 +
- drivers/soc/friendlyelec/Kconfig              |  11 ++
- drivers/soc/friendlyelec/Makefile             |   1 +
- drivers/soc/friendlyelec/board.c              | 143 ++++++++++++++++++
- 8 files changed, 161 insertions(+)
- create mode 100644 drivers/soc/friendlyelec/Kconfig
- create mode 100644 drivers/soc/friendlyelec/Makefile
- create mode 100644 drivers/soc/friendlyelec/board.c
+ drivers/soc/Kconfig               |   1 +
+ drivers/soc/Makefile              |   1 +
+ drivers/soc/friendlyelec/Kconfig  |  11 +
+ drivers/soc/friendlyelec/Makefile |   1 +
+ drivers/soc/friendlyelec/board.c  | 143 ++++++++++
+ 5 files changed, 157 insertions(+)
 
 diff --git a/drivers/soc/Kconfig b/drivers/soc/Kconfig
-index 833e04a7835c..9ddbd976395d 100644
+index 4e176280113a..8dabe409f072 100644
 --- a/drivers/soc/Kconfig
 +++ b/drivers/soc/Kconfig
-@@ -21,5 +21,6 @@ source "drivers/soc/ux500/Kconfig"
+@@ -30,5 +30,6 @@ source "drivers/soc/ti/Kconfig"
  source "drivers/soc/ux500/Kconfig"
  source "drivers/soc/versatile/Kconfig"
  source "drivers/soc/xilinx/Kconfig"
@@ -28,10 +25,10 @@ index 833e04a7835c..9ddbd976395d 100644
  
  endmenu
 diff --git a/drivers/soc/Makefile b/drivers/soc/Makefile
-index f678e4d9e..cfc815a7e 100644
+index 3b0f9fb3b5c8..9652d3a514af 100644
 --- a/drivers/soc/Makefile
 +++ b/drivers/soc/Makefile
-@@ -29,3 +29,4 @@ obj-y				+= ti/
+@@ -36,3 +36,4 @@ obj-y				+= ti/
  obj-$(CONFIG_ARCH_U8500)	+= ux500/
  obj-$(CONFIG_PLAT_VERSATILE)	+= versatile/
  obj-y				+= xilinx/
@@ -209,3 +206,6 @@ index 000000000000..886a8e1f7dc0
 +MODULE_AUTHOR("support@friendlyarm.com");
 +MODULE_DESCRIPTION("FriendlyElec NanoPi Series Machine Driver");
 +MODULE_LICENSE("GPL v2");
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/add-rockchip-iep-driver.patch
+++ b/patch/kernel/archive/rockchip64-6.3/add-rockchip-iep-driver.patch
@@ -1,6 +1,80 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paolo <paolo.sabatino@gmail.com>
+Date: Thu, 9 Sep 2021 22:59:12 +0200
+Subject: Rockchip IEP driver
+
+> X-Git-Archeology: - Revision 4425589e15c3b1593731703c379df0fa1b4432fb: https://github.com/armbian/build/commit/4425589e15c3b1593731703c379df0fa1b4432fb
+> X-Git-Archeology:   Date: Thu, 09 Sep 2021 22:59:12 +0200
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rk322x: bump edge kernel to 5.14, u-boot to 2021.07 (#3133)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision a1d044de8e0bb6ca504386bc31f5615a9d169067: https://github.com/armbian/build/commit/a1d044de8e0bb6ca504386bc31f5615a9d169067
+> X-Git-Archeology:   Date: Tue, 12 Oct 2021 15:59:01 +0200
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip: update support for edge kernel 5.14
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 682e4085ab8faa278db21a41ed23a6b12f8868ea: https://github.com/armbian/build/commit/682e4085ab8faa278db21a41ed23a6b12f8868ea
+> X-Git-Archeology:   Date: Thu, 21 Oct 2021 22:55:25 +0200
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip64: add IEP driver (#3215)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e: https://github.com/armbian/build/commit/dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e
+> X-Git-Archeology:   Date: Tue, 09 Nov 2021 18:06:34 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump imx6, xu4, rockchip64 and jetson-nano to 5.15 (#3238)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ Documentation/devicetree/bindings/media/rockchip-iep.yaml |   73 +
+ arch/arm/boot/dts/rk3288.dtsi                             |   13 +-
+ arch/arm64/boot/dts/rockchip/rk3328.dtsi                  |   22 +
+ arch/arm64/boot/dts/rockchip/rk3399.dtsi                  |   13 +
+ drivers/media/platform/rockchip/Kconfig                   |    1 +
+ drivers/media/platform/rockchip/Makefile                  |    1 +
+ drivers/media/platform/rockchip/iep/Kconfig               |   13 +
+ drivers/media/platform/rockchip/iep/Makefile              |    5 +
+ drivers/media/platform/rockchip/iep/iep-regs.h            |  291 +++
+ drivers/media/platform/rockchip/iep/iep.c                 | 1089 ++++++++++
+ drivers/media/platform/rockchip/iep/iep.h                 |  112 +
+ 11 files changed, 1632 insertions(+), 1 deletion(-)
+
 diff --git a/Documentation/devicetree/bindings/media/rockchip-iep.yaml b/Documentation/devicetree/bindings/media/rockchip-iep.yaml
 new file mode 100644
-index 000000000..a9efcda13
+index 000000000000..a9efcda13fc1
 --- /dev/null
 +++ b/Documentation/devicetree/bindings/media/rockchip-iep.yaml
 @@ -0,0 +1,73 @@
@@ -78,11 +152,11 @@ index 000000000..a9efcda13
 +      power-domains = <&power RK3228_PD_VIO>;
 +    };
 diff --git a/arch/arm/boot/dts/rk3288.dtsi b/arch/arm/boot/dts/rk3288.dtsi
-index 9c5a7791a..13db2ac6b 100644
+index 511ca864c1b2..c65f9a6ddafb 100644
 --- a/arch/arm/boot/dts/rk3288.dtsi
 +++ b/arch/arm/boot/dts/rk3288.dtsi
-@@ -983,6 +983,17 @@ crypto: cypto-controller@ff8a0000 {
- 		status = "okay";
+@@ -984,14 +984,25 @@ crypto: crypto@ff8a0000 {
+ 		reset-names = "crypto-rst";
  	};
  
 +	iep: iep@ff90000 {
@@ -99,8 +173,7 @@ index 9c5a7791a..13db2ac6b 100644
  	iep_mmu: iommu@ff900800 {
  		compatible = "rockchip,iommu";
  		reg = <0x0 0xff900800 0x0 0x40>;
-@@ -990,8 +1001,8 @@ iep_mmu: iommu@ff900800 {
- 		interrupt-names = "iep_mmu";
+ 		interrupts = <GIC_SPI 17 IRQ_TYPE_LEVEL_HIGH>;
  		clocks = <&cru ACLK_IEP>, <&cru HCLK_IEP>;
  		clock-names = "aclk", "iface";
 +		power-domains = <&power RK3288_PD_VIO>;
@@ -110,10 +183,10 @@ index 9c5a7791a..13db2ac6b 100644
  
  	isp_mmu: iommu@ff914000 {
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328.dtsi b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
-index 8c0bca75e..162e57936 100644
+index 6d7a7bf72ac7..1121c11abaa1 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3328.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
-@@ -829,6 +829,28 @@ vop_mmu: iommu@ff373f00 {
+@@ -721,6 +721,28 @@ vop_mmu: iommu@ff373f00 {
  		status = "disabled";
  	};
  
@@ -143,10 +216,10 @@ index 8c0bca75e..162e57936 100644
  		compatible = "rockchip,rk3328-dw-hdmi";
  		reg = <0x0 0xff3c0000 0x0 0x20000>;
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399.dtsi b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-index c39408ccc..f35211810 100644
+index 40e7c4a70055..45c8da0e2168 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-@@ -1283,6 +1283,18 @@ vdec_mmu: iommu@ff660480 {
+@@ -1377,12 +1377,25 @@ vdec_mmu: iommu@ff660480 {
  		#iommu-cells = <0>;
  	};
  
@@ -165,17 +238,53 @@ index c39408ccc..f35211810 100644
  	iep_mmu: iommu@ff670800 {
  		compatible = "rockchip,iommu";
  		reg = <0x0 0xff670800 0x0 0x40>;
-@@ -1290,6 +1302,7 @@ iep_mmu: iommu@ff670800 {
- 		interrupt-names = "iep_mmu";
+ 		interrupts = <GIC_SPI 42 IRQ_TYPE_LEVEL_HIGH 0>;
  		clocks = <&cru ACLK_IEP>, <&cru HCLK_IEP>;
  		clock-names = "aclk", "iface";
 +		power-domains = <&power RK3399_PD_IEP>;
  		#iommu-cells = <0>;
  		status = "disabled";
  	};
+diff --git a/drivers/media/platform/rockchip/Kconfig b/drivers/media/platform/rockchip/Kconfig
+index b41d3960c1b4..862590be7916 100644
+--- a/drivers/media/platform/rockchip/Kconfig
++++ b/drivers/media/platform/rockchip/Kconfig
+@@ -4,3 +4,4 @@ comment "Rockchip media platform drivers"
+ 
+ source "drivers/media/platform/rockchip/rga/Kconfig"
+ source "drivers/media/platform/rockchip/rkisp1/Kconfig"
++source "drivers/media/platform/rockchip/iep/Kconfig"
+diff --git a/drivers/media/platform/rockchip/Makefile b/drivers/media/platform/rockchip/Makefile
+index 4f782b876ac9..be8015c6d9e4 100644
+--- a/drivers/media/platform/rockchip/Makefile
++++ b/drivers/media/platform/rockchip/Makefile
+@@ -1,3 +1,4 @@
+ # SPDX-License-Identifier: GPL-2.0-only
+ obj-y += rga/
+ obj-y += rkisp1/
++obj-y += iep/
+diff --git a/drivers/media/platform/rockchip/iep/Kconfig b/drivers/media/platform/rockchip/iep/Kconfig
+new file mode 100644
+index 000000000000..e513fa7f45f2
+--- /dev/null
++++ b/drivers/media/platform/rockchip/iep/Kconfig
+@@ -0,0 +1,13 @@
++config VIDEO_ROCKCHIP_IEP
++	tristate "Rockchip Image Enhancement Processor"
++	depends on VIDEO_DEV && VIDEO_V4L2
++	depends on ARCH_ROCKCHIP || COMPILE_TEST
++	select VIDEOBUF2_DMA_CONTIG
++	select V4L2_MEM2MEM_DEV
++	help
++	  This is a v4l2 driver for Rockchip Image Enhancement Processor (IEP)
++	  found in most Rockchip RK3xxx SoCs.
++	  Rockchip IEP supports various enhancement operations for RGB and YUV
++	  images. The driver currently implements YUV deinterlacing only.
++	  To compile this driver as a module, choose M here: the module
++	  will be called rockchip-iep
 diff --git a/drivers/media/platform/rockchip/iep/Makefile b/drivers/media/platform/rockchip/iep/Makefile
 new file mode 100644
-index 000000000..5c89b3277
+index 000000000000..5c89b3277469
 --- /dev/null
 +++ b/drivers/media/platform/rockchip/iep/Makefile
 @@ -0,0 +1,5 @@
@@ -186,7 +295,7 @@ index 000000000..5c89b3277
 +obj-$(CONFIG_VIDEO_ROCKCHIP_IEP) += rockchip-iep.o
 diff --git a/drivers/media/platform/rockchip/iep/iep-regs.h b/drivers/media/platform/rockchip/iep/iep-regs.h
 new file mode 100644
-index 000000000..a68685ef3
+index 000000000000..a68685ef3604
 --- /dev/null
 +++ b/drivers/media/platform/rockchip/iep/iep-regs.h
 @@ -0,0 +1,291 @@
@@ -483,7 +592,7 @@ index 000000000..a68685ef3
 +#endif
 diff --git a/drivers/media/platform/rockchip/iep/iep.c b/drivers/media/platform/rockchip/iep/iep.c
 new file mode 100644
-index 000000000..f4b932073
+index 000000000000..f4b9320733be
 --- /dev/null
 +++ b/drivers/media/platform/rockchip/iep/iep.c
 @@ -0,0 +1,1089 @@
@@ -1578,7 +1687,7 @@ index 000000000..f4b932073
 +MODULE_LICENSE("GPL v2");
 diff --git a/drivers/media/platform/rockchip/iep/iep.h b/drivers/media/platform/rockchip/iep/iep.h
 new file mode 100644
-index 000000000..7d9fc6162
+index 000000000000..7d9fc61624b6
 --- /dev/null
 +++ b/drivers/media/platform/rockchip/iep/iep.h
 @@ -0,0 +1,112 @@
@@ -1695,42 +1804,5 @@ index 000000000..7d9fc6162
 +
 +#endif
 -- 
-2.30.2
+Armbian
 
-diff --git a/drivers/media/platform/rockchip/iep/Kconfig b/drivers/media/platform/rockchip/iep/Kconfig
-new file mode 100644
-index 00000000000..e513fa7f45f
---- /dev/null
-+++ b/drivers/media/platform/rockchip/iep/Kconfig
-@@ -0,0 +1,13 @@
-+config VIDEO_ROCKCHIP_IEP
-+	tristate "Rockchip Image Enhancement Processor"
-+	depends on VIDEO_DEV && VIDEO_V4L2
-+	depends on ARCH_ROCKCHIP || COMPILE_TEST
-+	select VIDEOBUF2_DMA_CONTIG
-+	select V4L2_MEM2MEM_DEV
-+	help
-+	  This is a v4l2 driver for Rockchip Image Enhancement Processor (IEP)
-+	  found in most Rockchip RK3xxx SoCs.
-+	  Rockchip IEP supports various enhancement operations for RGB and YUV
-+	  images. The driver currently implements YUV deinterlacing only.
-+	  To compile this driver as a module, choose M here: the module
-+	  will be called rockchip-iep
-diff --git a/drivers/media/platform/rockchip/Kconfig b/drivers/media/platform/rockchip/Kconfig
-index b41d3960c1b..862590be791 100644
---- a/drivers/media/platform/rockchip/Kconfig
-+++ b/drivers/media/platform/rockchip/Kconfig
-@@ -4,3 +4,4 @@ comment "Rockchip media platform drivers"
- 
- source "drivers/media/platform/rockchip/rga/Kconfig"
- source "drivers/media/platform/rockchip/rkisp1/Kconfig"
-+source "drivers/media/platform/rockchip/iep/Kconfig"
-diff --git a/drivers/media/platform/rockchip/Makefile b/drivers/media/platform/rockchip/Makefile
-index 4f782b876ac..be8015c6d9e 100644
---- a/drivers/media/platform/rockchip/Makefile
-+++ b/drivers/media/platform/rockchip/Makefile
-@@ -1,3 +1,4 @@
- # SPDX-License-Identifier: GPL-2.0-only
- obj-y += rga/
- obj-y += rkisp1/
-+obj-y += iep/

--- a/patch/kernel/archive/rockchip64-6.3/board-helios64-dts-fix-stability-issues.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-helios64-dts-fix-stability-issues.patch
@@ -1,5 +1,62 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Aditya Prayoga <aprayoga@users.noreply.github.com>
+Date: Thu, 4 Mar 2021 10:39:40 +0700
+Subject: [ARCHEOLOGY] Attempt to improve stability on Helios64 (#2680)
+
+> X-Git-Archeology: > recovered message: > * Adjust the RK808 buck step to improve stability
+> X-Git-Archeology: > recovered message: > * Adjust vdd_log and enable vdd_center init voltage
+> X-Git-Archeology: > recovered message: > For some reason, regulator-init-microvolt property under PMIC does not applied. Set the voltage on board file.
+> X-Git-Archeology: - Revision eefad69215557708b151a5d9244617a4ffd1281c: https://github.com/armbian/build/commit/eefad69215557708b151a5d9244617a4ffd1281c
+> X-Git-Archeology:   Date: Thu, 04 Mar 2021 10:39:40 +0700
+> X-Git-Archeology:   From: Aditya Prayoga <aprayoga@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Attempt to improve stability on Helios64 (#2680)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0cdffb29b07305209efb12cf3b5ac6032d3a1153: https://github.com/armbian/build/commit/0cdffb29b07305209efb12cf3b5ac6032d3a1153
+> X-Git-Archeology:   Date: Wed, 24 Mar 2021 19:01:53 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Renaming DEV branch to EDGE (#2704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts | 1 +
+ 1 file changed, 1 insertion(+)
+
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts b/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts
-index e666bd5ae..df1fc943b 100644
+index ac0da7b7f43c..38bf0f583f44 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts
 @@ -478,6 +478,7 @@ rk808: pmic@1b {
@@ -10,3 +67,6 @@ index e666bd5ae..df1fc943b 100644
  		wakeup-source;
  
  		vcc1-supply = <&vcc5v0_sys>;
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/board-helios64-remove-overclock.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-helios64-remove-overclock.patch
@@ -1,7 +1,7 @@
-From aca2e1df74ae43ddaa3870b31a6eba129148bdcf Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Aditya Prayoga <aditya@kobol.io>
 Date: Mon, 7 Sep 2020 20:29:43 +0700
-Subject: [PATCH] Remove overclock from helios64
+Subject: Remove overclock from helios64
 
 Signed-off-by: Aditya Prayoga <aditya@kobol.io>
 ---
@@ -9,10 +9,10 @@ Signed-off-by: Aditya Prayoga <aditya@kobol.io>
  1 file changed, 9 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts b/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts
-index ba8ff5d4c..c065ba82d 100644
+index 38bf0f583f44..e1994a72e308 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts
-@@ -1078,4 +1078,12 @@
+@@ -1152,4 +1152,12 @@ &vopl {
  
  &vopl_mmu {
  	status = "okay";
@@ -28,5 +28,5 @@ index ba8ff5d4c..c065ba82d 100644
 +	/delete-node/ opp08;
 +};
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/board-helios64-remove-pcie-ep-gpios.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-helios64-remove-pcie-ep-gpios.patch
@@ -1,25 +1,25 @@
-From e7e9a3a959927094d59b67f46ecc1c5d50190ce8 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Aditya Prayoga <aditya@kobol.io>
 Date: Tue, 15 Sep 2020 13:42:02 +0700
-Subject: [PATCH] Remove PCIE ep-gpios from Helios64
+Subject: Remove PCIE ep-gpios from Helios64
 
 Signed-off-by: Aditya Prayoga <aditya@kobol.io>
 ---
- arch/arm64/boot/dts/rockchip/rk3399-helios64.dts | 1 -
+ arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts | 1 -
  1 file changed, 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts b/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts
-index c065ba82d..002c93912 100644
+index e1994a72e308..f4c50e5ce896 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-kobol-helios64.dts
-@@ -721,7 +721,6 @@
+@@ -771,7 +771,6 @@ &io_domains {
  };
-
+ 
  &pcie0 {
 -	ep-gpios = <&gpio2 RK_PD4 GPIO_ACTIVE_HIGH>;
  	num-lanes = <2>;
  	max-link-speed = <2>;
  	pinctrl-names = "default";
---
-Created with Armbian build tools https://github.com/armbian/build
+-- 
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/board-nanopc-t4-add-typec-dp.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-nanopc-t4-add-typec-dp.patch
@@ -1,15 +1,15 @@
-From 5b697589bfd64a14ef1c991cffb5179ccb6cf880 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: tonymac32 <tonymckahan@gmail.com>
 Date: Wed, 17 Feb 2021 00:54:00 -0500
-Subject: [PATCH] Patching something
+Subject: Patching something
 
 Signed-off-by: tonymac32 <tonymckahan@gmail.com>
 ---
- .../boot/dts/rockchip/rk3399-nanopc-t4.dts    | 100 +++++++++++++++++++
- 1 file changed, 98 insertions(+), 12 deletions(-)
+ arch/arm64/boot/dts/rockchip/rk3399-nanopc-t4.dts | 96 ++++++++++
+ 1 file changed, 96 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-nanopc-t4.dts b/arch/arm64/boot/dts/rockchip/rk3399-nanopc-t4.dts
-index e0d75617b..68f1a06fa 100644
+index 3bf8f959e42c..2b1220beabd5 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-nanopc-t4.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopc-t4.dts
 @@ -9,6 +9,7 @@
@@ -82,9 +82,9 @@ index e0d75617b..68f1a06fa 100644
 +};
 +
  &pcie0 {
+ 	ep-gpios = <&gpio2 RK_PA4 GPIO_ACTIVE_HIGH>;
  	num-lanes = <4>;
- 	vpcie3v3-supply = <&vcc3v3_sys>;
-@@ -113,12 +164,57 @@ &sdhci {
+@@ -114,12 +165,57 @@ &sdhci {
  	mmc-hs400-enhanced-strobe;
  };
  
@@ -143,5 +143,5 @@ index e0d75617b..68f1a06fa 100644
  
  &vcc5v0_sys {
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/board-nanopi-m4v2-dts-add-sound-card.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-nanopi-m4v2-dts-add-sound-card.patch
@@ -1,10 +1,91 @@
-diff -u a/arch/arm64/boot/dts/rockchip/rk3399-nanopi4.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-nanopi4.dtsi
---- a/arch/arm64/boot/dts/rockchip/rk3399-nanopi4.dtsi	2019-10-17 23:47:33.000000000 +0300
-+++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi4.dtsi	2019-10-27 22:34:55.988303874 +0300
-@@ -105,6 +105,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Piotr Szczepanik <piter75@gmail.com>
+Date: Thu, 28 Nov 2019 22:29:54 +0000
+Subject: [ARCHEOLOGY] Initial addition of NanoPi M4V2
+
+> X-Git-Archeology: - Revision c4eecbcef0d4dc499baf0155449e71dc774bc7c4: https://github.com/armbian/build/commit/c4eecbcef0d4dc499baf0155449e71dc774bc7c4
+> X-Git-Archeology:   Date: Thu, 28 Nov 2019 22:29:54 +0000
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Initial addition of NanoPi M4V2
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 40a3d4ecb9a75c17183e2129491b7bc03060a315: https://github.com/armbian/build/commit/40a3d4ecb9a75c17183e2129491b7bc03060a315
+> X-Git-Archeology:   Date: Sun, 17 May 2020 18:42:24 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Fixed rt5651 codec probing after its driver was changed to module (#1969)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0cdffb29b07305209efb12cf3b5ac6032d3a1153: https://github.com/armbian/build/commit/0cdffb29b07305209efb12cf3b5ac6032d3a1153
+> X-Git-Archeology:   Date: Wed, 24 Mar 2021 19:01:53 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Renaming DEV branch to EDGE (#2704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e7377248b3cae186e24e2be781cd3365b43246f0: https://github.com/armbian/build/commit/e7377248b3cae186e24e2be781cd3365b43246f0
+> X-Git-Archeology:   Date: Thu, 22 Jul 2021 00:15:54 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Second part of EDGE bumping to 5.13.y (#3045)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 744ea89a589d62cb6f409baab60fc6664520bc39: https://github.com/armbian/build/commit/744ea89a589d62cb6f409baab60fc6664520bc39
+> X-Git-Archeology:   Date: Wed, 08 Sep 2021 17:51:34 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bumping EDGE kernel to 5.14.y (#3125)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e: https://github.com/armbian/build/commit/dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e
+> X-Git-Archeology:   Date: Tue, 09 Nov 2021 18:06:34 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump imx6, xu4, rockchip64 and jetson-nano to 5.15 (#3238)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 401fb1fde426c93121c4639b34a450d8ff551c85: https://github.com/armbian/build/commit/401fb1fde426c93121c4639b34a450d8ff551c85
+> X-Git-Archeology:   Date: Sat, 20 Nov 2021 19:49:22 +0100
+> X-Git-Archeology:   From: simple <991605149@qq.com>
+> X-Git-Archeology:   Subject: Fixed rt5651 codec build module (#3270)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3399-nanopi4.dtsi | 51 ++++++++++
+ sound/soc/rockchip/Kconfig                       |  9 ++
+ 2 files changed, 60 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-nanopi4.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-nanopi4.dtsi
+index b6e082f1f6d9..8b37dcb91864 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-nanopi4.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi4.dtsi
+@@ -132,6 +132,27 @@ status_led: led-0 {
  		};
  	};
-
+ 
 +	rt5651-sound {
 +		compatible = "simple-audio-card";
 +		simple-audio-card,name = "realtek,rt5651-codec";
@@ -29,10 +110,10 @@ diff -u a/arch/arm64/boot/dts/rockchip/rk3399-nanopi4.dtsi b/arch/arm64/boot/dts
  	sdio_pwrseq: sdio-pwrseq {
  		compatible = "mmc-pwrseq-simple";
  		clocks = <&rk808 1>;
-@@ -184,6 +205,10 @@
+@@ -216,6 +237,10 @@ &hdmi_sound {
  	status = "okay";
  };
-
+ 
 +&hdmi_sound {
 +	status = "okay";
 +};
@@ -40,7 +121,7 @@ diff -u a/arch/arm64/boot/dts/rockchip/rk3399-nanopi4.dtsi b/arch/arm64/boot/dts
  &i2c0 {
  	clock-frequency = <400000>;
  	i2c-scl-rising-time-ns = <160>;
-@@ -432,6 +457,16 @@
+@@ -464,6 +489,16 @@ &i2c1 {
  	i2c-scl-rising-time-ns = <150>;
  	i2c-scl-falling-time-ns = <30>;
  	status = "okay";
@@ -55,12 +136,12 @@ diff -u a/arch/arm64/boot/dts/rockchip/rk3399-nanopi4.dtsi b/arch/arm64/boot/dts
 +		#sound-dai-cells = <0>;
 +	};
  };
-
+ 
  &i2c2 {
-@@ -459,6 +494,16 @@
+@@ -495,6 +530,16 @@ &i2s2 {
  	status = "okay";
  };
-
+ 
 +&i2s1 {
 +	rockchip,playback-channels = <8>;
 +	rockchip,capture-channels = <8>;
@@ -74,7 +155,7 @@ diff -u a/arch/arm64/boot/dts/rockchip/rk3399-nanopi4.dtsi b/arch/arm64/boot/dts
  &io_domains {
  	bt656-supply = <&vcc_1v8>;
  	audio-supply = <&vcca1v8_codec>;
-@@ -724,3 +769,9 @@
+@@ -760,3 +805,9 @@ &vopl {
  &vopl_mmu {
  	status = "okay";
  };
@@ -85,13 +166,13 @@ diff -u a/arch/arm64/boot/dts/rockchip/rk3399-nanopi4.dtsi b/arch/arm64/boot/dts
 +	status = "okay";
 +};
 diff --git a/sound/soc/rockchip/Kconfig b/sound/soc/rockchip/Kconfig
-index b43657e6e..fb75c425e 100644
+index f98a2fa85edd..be36e36c8783 100644
 --- a/sound/soc/rockchip/Kconfig
 +++ b/sound/soc/rockchip/Kconfig
-@@ -53,6 +53,15 @@ config SND_SOC_ROCKCHIP_RT5645
+@@ -65,6 +65,15 @@ config SND_SOC_ROCKCHIP_RT5645
  	  Say Y or M here if you want to add support for SoC audio on Rockchip
  	  boards using the RT5645/RT5650 codec, such as Veyron.
-
+ 
 +config SND_SOC_ROCKCHIP_RT5651
 +	tristate "ASoC support for Rockchip boards using a RT5651 codec"
 +	depends on SND_SOC_ROCKCHIP && I2C && GPIOLIB && HAVE_CLK
@@ -103,4 +184,7 @@ index b43657e6e..fb75c425e 100644
 +
  config SND_SOC_RK3288_HDMI_ANALOG
  	tristate "ASoC support multiple codecs for Rockchip RK3288 boards"
- 	depends on SND_SOC_ROCKCHIP && I2C && GPIOLIB && CLKDEV_LOOKUP
+ 	depends on SND_SOC_ROCKCHIP && I2C && GPIOLIB && HAVE_CLK
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/board-nanopi-m4v2-dts-ethernet-tweak.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-nanopi-m4v2-dts-ethernet-tweak.patch
@@ -1,8 +1,78 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Piotr Szczepanik <piter75@gmail.com>
+Date: Sun, 29 Dec 2019 22:13:43 +0100
+Subject: [ARCHEOLOGY] Tweaked rx_delay to 0x16 for NanoPi M4V2 in current/dev
+ (#1698)
+
+> X-Git-Archeology: - Revision 5438468273da3e2af1de167cc72cf56823b8f51d: https://github.com/armbian/build/commit/5438468273da3e2af1de167cc72cf56823b8f51d
+> X-Git-Archeology:   Date: Sun, 29 Dec 2019 22:13:43 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Tweaked rx_delay to 0x16 for NanoPi M4V2 in current/dev (#1698)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0cdffb29b07305209efb12cf3b5ac6032d3a1153: https://github.com/armbian/build/commit/0cdffb29b07305209efb12cf3b5ac6032d3a1153
+> X-Git-Archeology:   Date: Wed, 24 Mar 2021 19:01:53 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Renaming DEV branch to EDGE (#2704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e7377248b3cae186e24e2be781cd3365b43246f0: https://github.com/armbian/build/commit/e7377248b3cae186e24e2be781cd3365b43246f0
+> X-Git-Archeology:   Date: Thu, 22 Jul 2021 00:15:54 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Second part of EDGE bumping to 5.13.y (#3045)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 744ea89a589d62cb6f409baab60fc6664520bc39: https://github.com/armbian/build/commit/744ea89a589d62cb6f409baab60fc6664520bc39
+> X-Git-Archeology:   Date: Wed, 08 Sep 2021 17:51:34 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bumping EDGE kernel to 5.14.y (#3125)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e: https://github.com/armbian/build/commit/dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e
+> X-Git-Archeology:   Date: Tue, 09 Nov 2021 18:06:34 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump imx6, xu4, rockchip64 and jetson-nano to 5.15 (#3238)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3399-nanopi-m4v2.dts | 4 ++++
+ 1 file changed, 4 insertions(+)
+
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-nanopi-m4v2.dts b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-m4v2.dts
-index 60358ab8c..057045ca3 100644
+index 3ac64b5a7b14..2dcaf497c775 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-nanopi-m4v2.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-m4v2.dts
-@@ -48,6 +48,10 @@
+@@ -60,6 +60,10 @@ vdd_log: vdd-log {
  	};
  };
  
@@ -13,3 +83,6 @@ index 60358ab8c..057045ca3 100644
  &vcc3v3_sys {
  	vin-supply = <&vcc5v0_core>;
  };
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/board-nanopi-m4v2-dts-fix-stability-issues.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-nanopi-m4v2-dts-fix-stability-issues.patch
@@ -1,14 +1,81 @@
-By default rk808's buck regulators switch voltage in multiple 100mV jumps.
-This seems to be too much for NanoPi M4V2 and makes it unstable.
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Piotr Szczepanik <piter75@gmail.com>
+Date: Tue, 2 Mar 2021 21:07:22 +0100
+Subject: [ARCHEOLOGY] NanoPi M4V2 stability fix for current and dev (#2663)
 
-Shortening the steps to 50mV (4 multiple of base buck step which is 12.5mV)
-makes the NanoPi M4V2 stable.
-Tested with multiple hours of running memtester without a single failure.
-
-Signed-off-by: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology: > recovered message: > * Explicitly set vdd_log voltage for NanoPi M4V2 - possibly fix stability issues
+> X-Git-Archeology: > recovered message: > * Regulator tweaks for NanoPi M4V2
+> X-Git-Archeology: > recovered message: > * Add vdd_log to kernel and switch vdd_center back to 900mV
+> X-Git-Archeology: > recovered message: > * Switch vdd_center to 0.95
+> X-Git-Archeology: > recovered message: > * Make rk80x bucks voltage steps shorter to make the NanoPi M4V2 stable
+> X-Git-Archeology: > recovered message: > * Tweak u-boot config for NanoPi M4V2
+> X-Git-Archeology: > recovered message: > * Made the rk808 voltage steps configurable and configured 50mV for NanoPi M4V2
+> X-Git-Archeology: - Revision a6ee913fae3afc7ae74bb1fdaf1f571ec30493ac: https://github.com/armbian/build/commit/a6ee913fae3afc7ae74bb1fdaf1f571ec30493ac
+> X-Git-Archeology:   Date: Tue, 02 Mar 2021 21:07:22 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: NanoPi M4V2 stability fix for current and dev (#2663)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0cdffb29b07305209efb12cf3b5ac6032d3a1153: https://github.com/armbian/build/commit/0cdffb29b07305209efb12cf3b5ac6032d3a1153
+> X-Git-Archeology:   Date: Wed, 24 Mar 2021 19:01:53 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Renaming DEV branch to EDGE (#2704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e7377248b3cae186e24e2be781cd3365b43246f0: https://github.com/armbian/build/commit/e7377248b3cae186e24e2be781cd3365b43246f0
+> X-Git-Archeology:   Date: Thu, 22 Jul 2021 00:15:54 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Second part of EDGE bumping to 5.13.y (#3045)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 744ea89a589d62cb6f409baab60fc6664520bc39: https://github.com/armbian/build/commit/744ea89a589d62cb6f409baab60fc6664520bc39
+> X-Git-Archeology:   Date: Wed, 08 Sep 2021 17:51:34 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bumping EDGE kernel to 5.14.y (#3125)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e: https://github.com/armbian/build/commit/dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e
+> X-Git-Archeology:   Date: Tue, 09 Nov 2021 18:06:34 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump imx6, xu4, rockchip64 and jetson-nano to 5.15 (#3238)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3399-nanopi-m4v2.dts | 5 +++++
+ 1 file changed, 5 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-nanopi-m4v2.dts b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-m4v2.dts
-index 2dcaf497c..094440ce3 100644
+index 2dcaf497c775..094440ce38ad 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-nanopi-m4v2.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-m4v2.dts
 @@ -64,6 +64,10 @@ &gmac {
@@ -27,3 +94,6 @@ index 2dcaf497c..094440ce3 100644
  	vin-supply = <&vdd_5v>;
  };
 +
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/board-pbp-add-dp-alt-mode.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-pbp-add-dp-alt-mode.patch
@@ -1,29 +1,29 @@
-From a1bbffd1cbb883be7fe3da1d09c29d57cfbeb2da Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Dan Johansen <strit@manjaro.org>
 Date: Tue, 2 Jun 2020 20:20:29 +0200
-Subject: [PATCH] add-dp-alt-mode-to-PBP
+Subject: add-dp-alt-mode-to-PBP
 
 ---
- .../boot/dts/rockchip/rk3399-pinebook-pro.dts |   5 +
- drivers/phy/rockchip/phy-rockchip-typec.c     |  17 +++
- drivers/usb/typec/altmodes/displayport.c      |  58 +++++++-
- drivers/usb/typec/bus.c                       |   8 +-
- drivers/usb/typec/tcpm/tcpm.c                 | 139 +++++++++++++++++-
- 5 files changed, 221 insertions(+), 6 deletions(-)
+ arch/arm64/boot/dts/rockchip/rk3399-pinebook-pro.dts |   5 +
+ drivers/phy/rockchip/phy-rockchip-typec.c            |  17 ++
+ drivers/usb/typec/altmodes/displayport.c             |  52 +++-
+ drivers/usb/typec/bus.c                              |   8 +-
+ drivers/usb/typec/tcpm/tcpm.c                        | 139 +++++++++-
+ 5 files changed, 217 insertions(+), 4 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-pinebook-pro.dts b/arch/arm64/boot/dts/rockchip/rk3399-pinebook-pro.dts
-index c49982dfd8fc..66cf08e8506f 100644
+index ddd45de97950..9acb8b2029b8 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-pinebook-pro.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-pinebook-pro.dts
-@@ -374,6 +374,7 @@ mains_charger: dc-charger {
+@@ -422,6 +422,7 @@ edp_out_panel: endpoint@0 {
  
- &cdn_dp {
+ &emmc_phy {
  	status = "okay";
 +	extcon = <&fusb0>;
  };
  
- &cpu_b0 {
-@@ -708,6 +709,9 @@ connector {
+ &gpu {
+@@ -706,6 +707,9 @@ connector {
  				<PDO_FIXED(5000, 1400, PDO_FIXED_USB_COMM)>;
  			try-power-role = "sink";
  
@@ -33,7 +33,7 @@ index c49982dfd8fc..66cf08e8506f 100644
  			ports {
  				#address-cells = <1>;
  				#size-cells = <0>;
-@@ -958,6 +962,7 @@ spiflash: flash@0 {
+@@ -972,6 +976,7 @@ spiflash: flash@0 {
  };
  
  &tcphy0 {
@@ -42,7 +42,7 @@ index c49982dfd8fc..66cf08e8506f 100644
  };
  
 diff --git a/drivers/phy/rockchip/phy-rockchip-typec.c b/drivers/phy/rockchip/phy-rockchip-typec.c
-index 24563160197f..f5b497b4b97e 100644
+index 39db8acde61a..4886c6a4321f 100644
 --- a/drivers/phy/rockchip/phy-rockchip-typec.c
 +++ b/drivers/phy/rockchip/phy-rockchip-typec.c
 @@ -40,6 +40,7 @@
@@ -53,7 +53,7 @@ index 24563160197f..f5b497b4b97e 100644
  #include <linux/io.h>
  #include <linux/iopoll.h>
  #include <linux/kernel.h>
-@@ -1160,6 +1161,22 @@ static int rockchip_typec_phy_probe(struct platform_device *pdev)
+@@ -1157,6 +1158,22 @@ static int rockchip_typec_phy_probe(struct platform_device *pdev)
  				dev_err(dev, "Invalid or missing extcon\n");
  			return PTR_ERR(tcphy->extcon);
  		}
@@ -77,7 +77,7 @@ index 24563160197f..f5b497b4b97e 100644
  
  	pm_runtime_enable(dev);
 diff --git a/drivers/usb/typec/altmodes/displayport.c b/drivers/usb/typec/altmodes/displayport.c
-index 0edfb89e04a8..40dd68c20159 100644
+index 8f3e884222ad..afd020120173 100644
 --- a/drivers/usb/typec/altmodes/displayport.c
 +++ b/drivers/usb/typec/altmodes/displayport.c
 @@ -9,6 +9,8 @@
@@ -88,12 +88,17 @@ index 0edfb89e04a8..40dd68c20159 100644
 +#include <linux/extcon-provider.h>
  #include <linux/mutex.h>
  #include <linux/module.h>
- #include <linux/usb/pd_vdo.h>
-diff --git a/drivers/usb/typec/altmodes/displayport.c b/drivers/usb/typec/altmodes/displayport.c
-index ba1387ab5..4d2eaeab1 100644
---- a/drivers/usb/typec/altmodes/displayport.c
-+++ b/drivers/usb/typec/altmodes/displayport.c
-@@ -78,7 +78,9 @@ static int dp_altmode_notify(struct dp_altmode *dp)
+ #include <linux/property.h>
+@@ -68,6 +70,8 @@ struct dp_altmode {
+ 	struct fwnode_handle *connector_fwnode;
+ };
+ 
++void dp_altmode_update_extcon(struct dp_altmode *dp, bool disconnect);
++
+ static int dp_altmode_notify(struct dp_altmode *dp)
+ {
+ 	unsigned long conf;
+@@ -76,7 +80,9 @@ static int dp_altmode_notify(struct dp_altmode *dp)
  	if (dp->data.conf) {
  		state = get_count_order(DP_CONF_GET_PIN_ASSIGN(dp->data.conf));
  		conf = TYPEC_MODAL_STATE(state);
@@ -103,7 +108,7 @@ index ba1387ab5..4d2eaeab1 100644
  		conf = TYPEC_STATE_USB;
  	}
  
-@@ -154,6 +156,40 @@ static int dp_altmode_status_update(struct dp_altmode *dp)
+@@ -157,6 +163,40 @@ static int dp_altmode_status_update(struct dp_altmode *dp)
  	return ret;
  }
  
@@ -144,7 +149,7 @@ index ba1387ab5..4d2eaeab1 100644
  static int dp_altmode_configured(struct dp_altmode *dp)
  {
  	sysfs_notify(&dp->alt->dev.kobj, "displayport", "configuration");
-@@ -210,6 +252,8 @@ static void dp_altmode_work(struct work_struct *work)
+@@ -226,6 +266,8 @@ static void dp_altmode_work(struct work_struct *work)
  	case DP_STATE_EXIT:
  		if (typec_altmode_exit(dp->alt))
  			dev_err(&dp->alt->dev, "Exit Mode Failed!\n");
@@ -153,7 +158,7 @@ index ba1387ab5..4d2eaeab1 100644
  		break;
  	default:
  		break;
-@@ -520,8 +564,14 @@ int dp_altmode_probe(struct typec_altmode *alt)
+@@ -554,8 +596,14 @@ int dp_altmode_probe(struct typec_altmode *alt)
  	if (!(DP_CAP_PIN_ASSIGN_DFP_D(port->vdo) &
  	      DP_CAP_PIN_ASSIGN_UFP_D(alt->vdo)) &&
  	    !(DP_CAP_PIN_ASSIGN_UFP_D(port->vdo) &
@@ -171,10 +176,10 @@ index ba1387ab5..4d2eaeab1 100644
  	ret = sysfs_create_group(&alt->dev.kobj, &dp_altmode_group);
  	if (ret)
 diff --git a/drivers/usb/typec/bus.c b/drivers/usb/typec/bus.c
-index e8ddb81cb6df..cbc01d73739c 100644
+index 098f0efaa58d..19d2a2078c29 100644
 --- a/drivers/usb/typec/bus.c
 +++ b/drivers/usb/typec/bus.c
-@@ -154,8 +154,14 @@ EXPORT_SYMBOL_GPL(typec_altmode_exit);
+@@ -185,8 +185,14 @@ EXPORT_SYMBOL_GPL(typec_altmode_exit);
   */
  void typec_altmode_attention(struct typec_altmode *adev, u32 vdo)
  {
@@ -191,7 +196,7 @@ index e8ddb81cb6df..cbc01d73739c 100644
  		pdev->ops->attention(pdev, vdo);
  }
 diff --git a/drivers/usb/typec/tcpm/tcpm.c b/drivers/usb/typec/tcpm/tcpm.c
-index 82b19ebd7838..6f00b17afc15 100644
+index 1ee774c263f0..d282273c42ce 100644
 --- a/drivers/usb/typec/tcpm/tcpm.c
 +++ b/drivers/usb/typec/tcpm/tcpm.c
 @@ -8,6 +8,7 @@
@@ -202,7 +207,7 @@ index 82b19ebd7838..6f00b17afc15 100644
  #include <linux/hrtimer.h>
  #include <linux/jiffies.h>
  #include <linux/kernel.h>
-@@ -476,6 +477,12 @@ struct tcpm_port {
+@@ -492,6 +493,12 @@ struct tcpm_port {
  	 * transitions.
  	 */
  	bool potential_contaminant;
@@ -215,9 +220,9 @@ index 82b19ebd7838..6f00b17afc15 100644
  #ifdef CONFIG_DEBUG_FS
  	struct dentry *dentry;
  	struct mutex logbuffer_lock;	/* log buffer access lock */
-@@ -607,6 +613,35 @@ static void tcpm_debugfs_exit(const struct tcpm_port *port) { }
- 
- #endif
+@@ -879,6 +886,35 @@ static void tcpm_ams_finish(struct tcpm_port *port)
+ 	port->ams = NONE_AMS;
+ }
  
 +static void tcpm_update_extcon_data(struct tcpm_port *port, bool attached) {
 +#ifdef CONFIG_EXTCON
@@ -251,7 +256,7 @@ index 82b19ebd7838..6f00b17afc15 100644
  static int tcpm_pd_transmit(struct tcpm_port *port,
  			    enum tcpm_transmit_type type,
  			    const struct pd_message *msg)
-@@ -834,6 +869,8 @@ static int tcpm_set_roles(struct tcpm_port *port, bool attached,
+@@ -1091,6 +1127,8 @@ static int tcpm_set_roles(struct tcpm_port *port, bool attached,
  	typec_set_data_role(port->typec_port, data);
  	typec_set_pwr_role(port->typec_port, role);
  
@@ -260,27 +265,25 @@ index 82b19ebd7838..6f00b17afc15 100644
  	return 0;
  }
  
-@@ -1044,7 +1081,7 @@ static void svdm_consume_modes(struct tcpm_port *port, const __le32 *payload,
+@@ -1548,7 +1586,7 @@ static void svdm_consume_modes(struct tcpm_port *port, const u32 *p, int cnt)
  		paltmode->mode = i;
- 		paltmode->vdo = le32_to_cpu(payload[i]);
+ 		paltmode->vdo = p[i];
  
 -		tcpm_log(port, " Alternate mode %d: SVID 0x%04x, VDO %d: 0x%08x",
 +		tcpm_log(port, "Alternate mode %d: SVID 0x%04x, VDO %d: 0x%08x",
  			 pmdata->altmodes, paltmode->svid,
  			 paltmode->mode, paltmode->vdo);
  
-@@ -1064,7 +1101,9 @@ static void tcpm_register_partner_altmodes(struct tcpm_port *port)
+@@ -1569,6 +1607,8 @@ static void tcpm_register_partner_altmodes(struct tcpm_port *port)
  			tcpm_log(port, "Failed to register partner SVID 0x%04x",
  				 modep->altmode_desc[i].svid);
  			altmode = NULL;
--		}
 +		} else {
 +			tcpm_log(port, "Registered altmode 0x%04x", modep->altmode_desc[i].svid);
-+		}
+ 		}
  		port->partner_altmode[i] = altmode;
  	}
- }
-@@ -1167,9 +1207,11 @@ static int tcpm_pd_svdm(struct tcpm_port *port, const __le32 *payload, int cnt,
+@@ -1703,9 +1743,11 @@ static int tcpm_pd_svdm(struct tcpm_port *port, struct typec_altmode *adev,
  			modep->svid_index++;
  			if (modep->svid_index < modep->nsvids) {
  				u16 svid = modep->svids[modep->svid_index];
@@ -292,7 +295,7 @@ index 82b19ebd7838..6f00b17afc15 100644
  				tcpm_register_partner_altmodes(port);
  			}
  			break;
-@@ -2693,6 +2735,7 @@ static int tcpm_src_attach(struct tcpm_port *port)
+@@ -3698,6 +3740,7 @@ static int tcpm_src_attach(struct tcpm_port *port)
  static void tcpm_typec_disconnect(struct tcpm_port *port)
  {
  	if (port->connected) {
@@ -300,8 +303,8 @@ index 82b19ebd7838..6f00b17afc15 100644
  		typec_partner_set_usb_power_delivery(port->partner, NULL);
  		typec_unregister_partner(port->partner);
  		port->partner = NULL;
-@@ -2750,6 +2793,8 @@ static void tcpm_detach(struct tcpm_port *port)
- 		port->hard_reset_count = 0;
+@@ -3784,6 +3827,8 @@ static void tcpm_detach(struct tcpm_port *port)
+ 	}
  
  	tcpm_reset_port(port);
 +
@@ -309,9 +312,9 @@ index 82b19ebd7838..6f00b17afc15 100644
  }
  
  static void tcpm_src_detach(struct tcpm_port *port)
-@@ -4424,6 +4469,64 @@ void tcpm_tcpc_reset(struct tcpm_port *port)
+@@ -6122,6 +6167,64 @@ static int tcpm_port_register_pd(struct tcpm_port *port)
+ 	return ret;
  }
- EXPORT_SYMBOL_GPL(tcpm_tcpc_reset);
  
 +unsigned int default_supported_cables[] = {
 +	EXTCON_NONE
@@ -374,7 +377,7 @@ index 82b19ebd7838..6f00b17afc15 100644
  static int tcpm_fw_get_caps(struct tcpm_port *port,
  			    struct fwnode_handle *fwnode)
  {
-@@ -4434,6 +4537,23 @@ static int tcpm_fw_get_caps(struct tcpm_port *port,
+@@ -6132,6 +6235,23 @@ static int tcpm_fw_get_caps(struct tcpm_port *port,
  	if (!fwnode)
  		return -EINVAL;
  
@@ -398,7 +401,7 @@ index 82b19ebd7838..6f00b17afc15 100644
  	/*
  	 * This fwnode has a "compatible" property, but is never populated as a
  	 * struct device. Instead we simply parse it to read the properties.
-@@ -4766,6 +4886,17 @@ struct tcpm_port *tcpm_register_port(struct device *dev, struct tcpc_dev *tcpc)
+@@ -6564,6 +6684,17 @@ struct tcpm_port *tcpm_register_port(struct device *dev, struct tcpc_dev *tcpc)
  		goto out_destroy_wq;
  
  	port->try_role = port->typec_caps.prefer_role;
@@ -416,9 +419,9 @@ index 82b19ebd7838..6f00b17afc15 100644
  
  	port->typec_caps.fwnode = tcpc->fwnode;
  	port->typec_caps.revision = 0x0120;	/* Type-C spec release 1.2 */
-@@ -4793,6 +4924,12 @@ struct tcpm_port *tcpm_register_port(struct device *dev, struct tcpc_dev *tcpc)
- 		goto out_role_sw_put;
- 	}
+@@ -6604,6 +6735,12 @@ struct tcpm_port *tcpm_register_port(struct device *dev, struct tcpc_dev *tcpc)
+ 				     port->port_altmode, ALTMODE_DISCOVERY_MAX);
+ 	port->registered = true;
  
 +	err = tcpm_fw_get_caps_late(port, tcpc->fwnode);
 +	if (err < 0) {
@@ -430,18 +433,5 @@ index 82b19ebd7838..6f00b17afc15 100644
  	tcpm_init(port);
  	mutex_unlock(&port->lock);
 -- 
-2.26.2
+Armbian
 
-diff --git a/drivers/usb/typec/altmodes/displayport.c b/drivers/usb/typec/altmodes/displayport.c
-index c1d8c23ba..bb08742b3 100644
---- a/drivers/usb/typec/altmodes/displayport.c
-+++ b/drivers/usb/typec/altmodes/displayport.c
-@@ -68,6 +68,8 @@ struct dp_altmode {
- 	struct fwnode_handle *connector_fwnode;
- };
- 
-+void dp_altmode_update_extcon(struct dp_altmode *dp, bool disconnect);
-+
- static int dp_altmode_notify(struct dp_altmode *dp)
- {
- 	unsigned long conf;

--- a/patch/kernel/archive/rockchip64-6.3/board-rk3328-roc-cc-dts-enable-dmc.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-rk3328-roc-cc-dts-enable-dmc.patch
@@ -1,14 +1,14 @@
-From 36934c54b2c8f882b8c4700a69f8b91b5bf4811a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
 Date: Tue, 12 Oct 2021 18:31:28 +0000
-Subject: [PATCH] enable roc-cc dmc
+Subject: enable roc-cc dmc
 
 ---
- .../arm64/boot/dts/rockchip/rk3328-roc-cc.dts | 38 +++++++++++++++++++
+ arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts | 38 ++++++++++
  1 file changed, 38 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts b/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts
-index daa9a0c60..dc6583be5 100644
+index 5d5d9574088c..be5d064d6a93 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts
 @@ -4,6 +4,7 @@
@@ -19,7 +19,7 @@ index daa9a0c60..dc6583be5 100644
  #include "rk3328.dtsi"
  
  / {
-@@ -14,6 +15,32 @@ chosen {
+@@ -19,6 +20,32 @@ chosen {
  		stdout-path = "serial2:1500000n8";
  	};
  
@@ -52,8 +52,8 @@ index daa9a0c60..dc6583be5 100644
  	gmac_clkin: external-gmac-clock {
  		compatible = "fixed-clock";
  		clock-frequency = <125000000>;
-@@ -104,6 +131,17 @@ user_led: led-1 {
- 	};
+@@ -115,6 +142,17 @@ &codec {
+ 	status = "okay";
  };
  
 +&dfi {
@@ -71,5 +71,5 @@ index daa9a0c60..dc6583be5 100644
  	cpu-supply = <&vdd_arm>;
  };
 -- 
-2.30.2
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/board-rk3328-roc-cc-dts-ram-profile.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-rk3328-roc-cc-dts-ram-profile.patch
@@ -1,17 +1,16 @@
-From 036c59ebd2265236880bb156e995af55249726b1 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: tonymac32 <tonymckahan@gmail.com>
 Date: Wed, 7 Oct 2020 23:39:54 -0400
-Subject: [PATCH] board-rk3328-roc-cc-adjust-DMC-opps
+Subject: board-rk3328-roc-cc-adjust-DMC-opps
 
 Signed-off-by: tonymac32 <tonymckahan@gmail.com>
 ---
- .../rockchip/rk3328-dram-renegade-timing.dtsi | 311 ++++++++++++++++++
- 1 file changed, 311 insertions(+), 0 deletion(-)
- create mode 100644 arch/arm64/boot/dts/rockchip/rk3328-dram-renegade-timing.dtsi
+ arch/arm64/boot/dts/rockchip/rk3328-dram-renegade-timing.dtsi | 311 ++++++++++
+ 1 file changed, 311 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328-dram-renegade-timing.dtsi b/arch/arm64/boot/dts/rockchip/rk3328-dram-renegade-timing.dtsi
 new file mode 100644
-index 000000000..303428153
+index 000000000000..303428153094
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-dram-renegade-timing.dtsi
 @@ -0,0 +1,311 @@
@@ -327,5 +326,5 @@ index 000000000..303428153
 +	};
 +};
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/board-rk3328-roc-pc-dts-ram-profile.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-rk3328-roc-pc-dts-ram-profile.patch
@@ -1,6 +1,75 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tony <tonymckahan@gmail.com>
+Date: Thu, 8 Oct 2020 01:56:28 -0400
+Subject: [ARCHEOLOGY] Add files via upload
+
+> X-Git-Archeology: - Revision 8fc20a15b12561e76e92d5bd29b5afd1c62f08ac: https://github.com/armbian/build/commit/8fc20a15b12561e76e92d5bd29b5afd1c62f08ac
+> X-Git-Archeology:   Date: Thu, 08 Oct 2020 01:56:28 -0400
+> X-Git-Archeology:   From: Tony <tonymckahan@gmail.com>
+> X-Git-Archeology:   Subject: Add files via upload
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 2788adccedc25f12fc9e71e01a92863d97683979: https://github.com/armbian/build/commit/2788adccedc25f12fc9e71e01a92863d97683979
+> X-Git-Archeology:   Date: Tue, 26 Jan 2021 21:22:04 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Enable DMC for Station M1 in current and dev (#2575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0cdffb29b07305209efb12cf3b5ac6032d3a1153: https://github.com/armbian/build/commit/0cdffb29b07305209efb12cf3b5ac6032d3a1153
+> X-Git-Archeology:   Date: Wed, 24 Mar 2021 19:01:53 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Renaming DEV branch to EDGE (#2704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e7377248b3cae186e24e2be781cd3365b43246f0: https://github.com/armbian/build/commit/e7377248b3cae186e24e2be781cd3365b43246f0
+> X-Git-Archeology:   Date: Thu, 22 Jul 2021 00:15:54 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Second part of EDGE bumping to 5.13.y (#3045)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 744ea89a589d62cb6f409baab60fc6664520bc39: https://github.com/armbian/build/commit/744ea89a589d62cb6f409baab60fc6664520bc39
+> X-Git-Archeology:   Date: Wed, 08 Sep 2021 17:51:34 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bumping EDGE kernel to 5.14.y (#3125)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3328-roc-pc-dram-timing.dtsi | 223 ++++++++++
+ 1 file changed, 223 insertions(+)
+
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328-roc-pc-dram-timing.dtsi b/arch/arm64/boot/dts/rockchip/rk3328-roc-pc-dram-timing.dtsi
 new file mode 100644
-index 000000000000..0ea270539a23
+index 000000000000..8b2077d086f5
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-roc-pc-dram-timing.dtsi
 @@ -0,0 +1,223 @@
@@ -227,3 +296,6 @@ index 000000000000..0ea270539a23
 +		cs1_dqs3n_tx_de-skew = <9>;
 +	};
 +};
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/board-rock3a-emmc-sfc.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-rock3a-emmc-sfc.patch
@@ -1,8 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jianfeng Liu <liujianfeng1994@gmail.com>
+Date: Wed, 3 Aug 2022 22:22:55 +0200
+Subject: [ARCHEOLOGY] update rockchip64 edge to 5.19 (#4039)
+
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts | 11 ++++++++++
+ 1 file changed, 11 insertions(+)
+
 diff --git a/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts b/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
-index 0813c0c5abde..c6f97a06c370 100644
+index 917f5b2b8aab..8353ca3a70ea 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
-@@ -498,6 +498,17 @@
+@@ -756,6 +756,17 @@ &sdmmc2 {
  	status = "okay";
  };
  
@@ -20,3 +49,6 @@ index 0813c0c5abde..c6f97a06c370 100644
  &tsadc {
  	rockchip,hw-tshut-mode = <1>;
  	rockchip,hw-tshut-polarity = <0>;
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/board-rock3a-usb3.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-rock3a-usb3.patch
@@ -1,8 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jianfeng Liu <liujianfeng1994@gmail.com>
+Date: Wed, 3 Aug 2022 22:22:55 +0200
+Subject: [ARCHEOLOGY] update rockchip64 edge to 5.19 (#4039)
+
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts | 1 +
+ 1 file changed, 1 insertion(+)
+
 diff --git a/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts b/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
-index 0813c0c5abde..d3a10616f3f5 100644
+index 8353ca3a70ea..5e72cc21a6ac 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
-@@ -518,6 +518,7 @@
+@@ -808,6 +808,7 @@ &usb_host0_ohci {
  
  &usb_host0_xhci {
  	extcon = <&usb2phy0>;
@@ -10,3 +39,6 @@ index 0813c0c5abde..d3a10616f3f5 100644
  	status = "okay";
  };
  
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/board-rock64-mail-supply.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-rock64-mail-supply.patch
@@ -1,18 +1,18 @@
-From d0950717ad74ea4c85ccf7bc205b8545758de1df Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: tonymac32 <tonymckahan@gmail.com>
 Date: Sun, 8 Aug 2021 11:49:27 -0400
-Subject: [PATCH] board_rock64_mali-usb-supply
+Subject: board_rock64_mali-usb-supply
 
 Signed-off-by: tonymac32 <tonymckahan@gmail.com>
 ---
- arch/arm64/boot/dts/rockchip/rk3328-rock64.dts | 16 +++++-----------
+ arch/arm64/boot/dts/rockchip/rk3328-rock64.dts | 16 +++-------
  1 file changed, 5 insertions(+), 11 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328-rock64.dts b/arch/arm64/boot/dts/rockchip/rk3328-rock64.dts
-index b5f5513c6..df51ade34 100644
+index f69a38f42d2d..a64a7713b418 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3328-rock64.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-rock64.dts
-@@ -43,17 +43,6 @@ vcc_host_5v: vcc-host-5v-regulator {
+@@ -48,17 +48,6 @@ vcc_host_5v: vcc-host-5v-regulator {
  		vin-supply = <&vcc_sys>;
  	};
  
@@ -30,7 +30,7 @@ index b5f5513c6..df51ade34 100644
  	vcc_sys: vcc-sys {
  		compatible = "regulator-fixed";
  		regulator-name = "vcc_sys";
-@@ -143,6 +132,11 @@ &emmc {
+@@ -145,6 +134,11 @@ &emmc {
  	status = "okay";
  };
  
@@ -43,5 +43,5 @@ index b5f5513c6..df51ade34 100644
  	assigned-clocks = <&cru SCLK_MAC2IO>, <&cru SCLK_MAC2IO_EXT>;
  	assigned-clock-parents = <&gmac_clkin>, <&gmac_clkin>;
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/board-rockpi3-enable-dmc.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-rockpi3-enable-dmc.patch
@@ -1,5 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Wed, 8 Mar 2023 11:12:22 +0100
+Subject: [ARCHEOLOGY] rockchip64: enable dmc on Rock PI E board
+
+> X-Git-Archeology: - Revision 4ea9330e5185e1c6e248af035cc615d23408316d: https://github.com/armbian/build/commit/4ea9330e5185e1c6e248af035cc615d23408316d
+> X-Git-Archeology:   Date: Wed, 08 Mar 2023 11:12:22 +0100
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip64: enable dmc on Rock PI E board
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3328-rock-pi-e.dts | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328-rock-pi-e.dts b/arch/arm64/boot/dts/rockchip/rk3328-rock-pi-e.dts
-index 018a3a5075c..9b3453cece8 100644
+index 018a3a5075c7..9b3453cece85 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3328-rock-pi-e.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-rock-pi-e.dts
 @@ -15,6 +15,7 @@
@@ -20,3 +39,6 @@ index 018a3a5075c..9b3453cece8 100644
 +	center-supply = <&vdd_log>;
 +	ddr_timing = <&ddr_timing>;
 +};
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/board-rockpi4-0003-arm64-dts-pcie.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-rockpi4-0003-arm64-dts-pcie.patch
@@ -1,5 +1,107 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Piotr Szczepanik <piter75@gmail.com>
+Date: Mon, 18 Nov 2019 18:23:10 +0100
+Subject: [ARCHEOLOGY] Rock Pi 4 enable PCIe in device tree for "dev" target
+ (#1624)
+
+> X-Git-Archeology: > recovered message: > * Rock Pi 4 enabled support for PCIe in device tree
+> X-Git-Archeology: > recovered message: > * Rockchip64-dev added possibility to enable PCIe Gen2 speed via overlay
+> X-Git-Archeology: - Revision b3bb9345439250d8247f0e24a8e1ef6290b2c279: https://github.com/armbian/build/commit/b3bb9345439250d8247f0e24a8e1ef6290b2c279
+> X-Git-Archeology:   Date: Mon, 18 Nov 2019 18:23:10 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Rock Pi 4 enable PCIe in device tree for "dev" target (#1624)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 150ac0c2afa147d9e3b036c8ecd8238fe5648cf3: https://github.com/armbian/build/commit/150ac0c2afa147d9e3b036c8ecd8238fe5648cf3
+> X-Git-Archeology:   Date: Tue, 19 Nov 2019 23:25:39 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Remove K<4, change branches, new features (#1586)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 812245def37a695bce9e7ece148b2920d82c8b37: https://github.com/armbian/build/commit/812245def37a695bce9e7ece148b2920d82c8b37
+> X-Git-Archeology:   Date: Sat, 18 Jul 2020 23:07:01 +0200
+> X-Git-Archeology:   From: Werner <EvilOlaf@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Move rockchip/64 current to 5.7.y (#2099)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dfd5cf9692e97774f7f0bfd72227144e36f58070: https://github.com/armbian/build/commit/dfd5cf9692e97774f7f0bfd72227144e36f58070
+> X-Git-Archeology:   Date: Sun, 13 Dec 2020 22:13:03 -0500
+> X-Git-Archeology:   From: tonymac32 <tonymckahan@gmail.com>
+> X-Git-Archeology:   Subject: [ rockchip64 ] Clean up patchset
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 091d91468e383c3d12a03a465be36b76112ce798: https://github.com/armbian/build/commit/091d91468e383c3d12a03a465be36b76112ce798
+> X-Git-Archeology:   Date: Sun, 17 Jan 2021 19:07:59 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switched rockchip64-current to 5.10.y (and synced -dev config/patches) (#2546)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0cdffb29b07305209efb12cf3b5ac6032d3a1153: https://github.com/armbian/build/commit/0cdffb29b07305209efb12cf3b5ac6032d3a1153
+> X-Git-Archeology:   Date: Wed, 24 Mar 2021 19:01:53 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Renaming DEV branch to EDGE (#2704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e7377248b3cae186e24e2be781cd3365b43246f0: https://github.com/armbian/build/commit/e7377248b3cae186e24e2be781cd3365b43246f0
+> X-Git-Archeology:   Date: Thu, 22 Jul 2021 00:15:54 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Second part of EDGE bumping to 5.13.y (#3045)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 744ea89a589d62cb6f409baab60fc6664520bc39: https://github.com/armbian/build/commit/744ea89a589d62cb6f409baab60fc6664520bc39
+> X-Git-Archeology:   Date: Wed, 08 Sep 2021 17:51:34 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bumping EDGE kernel to 5.14.y (#3125)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e: https://github.com/armbian/build/commit/dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e
+> X-Git-Archeology:   Date: Tue, 09 Nov 2021 18:06:34 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump imx6, xu4, rockchip64 and jetson-nano to 5.15 (#3238)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 44c4cdf8653104bc395c504d7611d819906ff69b: https://github.com/armbian/build/commit/44c4cdf8653104bc395c504d7611d819906ff69b
+> X-Git-Archeology:   Date: Fri, 30 Dec 2022 21:17:33 +0100
+> X-Git-Archeology:   From: Konstantin Litvinov <koftikes@gmail.com>
+> X-Git-Archeology:   Subject: Fixed issue with NVMe identification in rk3399-rock-pi-4.dts (#4627)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 44c95b7b0a64486a85f23c5630842ea1b877a695: https://github.com/armbian/build/commit/44c95b7b0a64486a85f23c5630842ea1b877a695
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:01 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: fix unidiff warning from patches of rockchip64-6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi | 4 ++++
+ 1 file changed, 4 insertions(+)
+
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
-index 6ec65b460e2..bd7895553d7 100644
+index 907071d4fe80..3f166847c101 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
 @@ -113,6 +113,8 @@ vcc3v3_pcie: vcc3v3-pcie-regulator {
@@ -11,7 +113,7 @@ index 6ec65b460e2..bd7895553d7 100644
  		vin-supply = <&vcc5v0_sys>;
  	};
  
-@@ -528,8 +530,10 @@ &pcie0 {
+@@ -528,9 +530,11 @@ &pcie0 {
  	num-lanes = <4>;
  	pinctrl-0 = <&pcie_clkreqnb_cpm>;
  	pinctrl-names = "default";
@@ -22,3 +124,7 @@ index 6ec65b460e2..bd7895553d7 100644
 +	bus-scan-delay-ms = <1500>;
  	status = "okay";
  };
+ 
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/board-rockpi4-Add-DT-link-for-backward-compatibility.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-rockpi4-Add-DT-link-for-backward-compatibility.patch
@@ -1,22 +1,21 @@
-From e3ffe88f90644eddd0fa6ee8c9f324d54c3b7c39 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Igor Pecovnik <igor.pecovnik@gmail.com>
 Date: Tue, 4 Aug 2020 19:35:47 +0200
-Subject: [PATCH] Add DT link for backward compatibility
+Subject: Add DT link for backward compatibility
 
 Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
 ---
  arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts | 1 +
- 2 files changed, 2 insertions(+)
- create mode 120000 arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts
+ 1 file changed, 1 insertion(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts
 new file mode 120000
-index 000000000..07e8a11b0
+index 000000000000..aec4f1829147
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dts
 @@ -0,0 +1 @@
 +rk3399-rock-pi-4b.dts
 \ No newline at end of file
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/board-rockpi4-FixMMCFreq.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-rockpi4-FixMMCFreq.patch
@@ -1,6 +1,77 @@
---- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi	2021-01-21 12:54:16.967891868 +0800
-+++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi	2021-01-21 13:04:10.214771523 +0800
-@@ -697,6 +697,7 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zhouzhiwen2000 <zhouzhiwen2000@gmail.com>
+Date: Fri, 22 Jan 2021 13:12:49 +0100
+Subject: [ARCHEOLOGY] fix problems with mmc modules (#2566)
+
+> X-Git-Archeology: - Revision b388750162173a1ebb2a3a5ed3599d66c2cba140: https://github.com/armbian/build/commit/b388750162173a1ebb2a3a5ed3599d66c2cba140
+> X-Git-Archeology:   Date: Fri, 22 Jan 2021 13:12:49 +0100
+> X-Git-Archeology:   From: zhouzhiwen2000 <zhouzhiwen2000@gmail.com>
+> X-Git-Archeology:   Subject: fix problems with mmc modules (#2566)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0cdffb29b07305209efb12cf3b5ac6032d3a1153: https://github.com/armbian/build/commit/0cdffb29b07305209efb12cf3b5ac6032d3a1153
+> X-Git-Archeology:   Date: Wed, 24 Mar 2021 19:01:53 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Renaming DEV branch to EDGE (#2704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e7377248b3cae186e24e2be781cd3365b43246f0: https://github.com/armbian/build/commit/e7377248b3cae186e24e2be781cd3365b43246f0
+> X-Git-Archeology:   Date: Thu, 22 Jul 2021 00:15:54 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Second part of EDGE bumping to 5.13.y (#3045)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 744ea89a589d62cb6f409baab60fc6664520bc39: https://github.com/armbian/build/commit/744ea89a589d62cb6f409baab60fc6664520bc39
+> X-Git-Archeology:   Date: Wed, 08 Sep 2021 17:51:34 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bumping EDGE kernel to 5.14.y (#3125)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e: https://github.com/armbian/build/commit/dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e
+> X-Git-Archeology:   Date: Tue, 09 Nov 2021 18:06:34 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump imx6, xu4, rockchip64 and jetson-nano to 5.15 (#3238)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
+index 3f166847c101..16eaf6587d22 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
+@@ -649,6 +649,7 @@ &saradc {
  };
  
  &sdhci {
@@ -8,3 +79,6 @@
  	bus-width = <8>;
  	mmc-hs400-1_8v;
  	mmc-hs400-enhanced-strobe;
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/board-rockpis-0001-arm64-dts.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-rockpis-0001-arm64-dts.patch
@@ -1,5 +1,30 @@
---- a/arch/arm64/boot/dts/rockchip/rk3308-rock-pi-s.dts	2022-12-19 16:47:52.770160260 -0800
-+++ b/arch/arm64/boot/dts/rockchip/rk3308-rock-pi-s.dts	2022-12-19 17:53:42.503756590 -0800
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: brentr <brent@mbari.org>
+Date: Fri, 23 Dec 2022 21:57:53 +0100
+Subject: [ARCHEOLOGY] Rockpis devtree mainlined (#4603)
+
+> X-Git-Archeology: > recovered message: > * moved rockpro64 patch out of rockpis patch sequence
+> X-Git-Archeology: > recovered message: > It had been misnamed
+> X-Git-Archeology: > recovered message: > * patch new mainline devtree for Rock Pi-S instead of overwritting it.
+> X-Git-Archeology: > recovered message: > Also restores lost bluetooth compatibility items on UART4
+> X-Git-Archeology: - Revision 588c2ec17e709dec19304fa50522459702ebfadd: https://github.com/armbian/build/commit/588c2ec17e709dec19304fa50522459702ebfadd
+> X-Git-Archeology:   Date: Fri, 23 Dec 2022 21:57:53 +0100
+> X-Git-Archeology:   From: brentr <brent@mbari.org>
+> X-Git-Archeology:   Subject: Rockpis devtree mainlined (#4603)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3308-rock-pi-s.dts | 241 +++++++---
+ 1 file changed, 164 insertions(+), 77 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3308-rock-pi-s.dts b/arch/arm64/boot/dts/rockchip/rk3308-rock-pi-s.dts
+index a71f249ed384..0d917658d24a 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3308-rock-pi-s.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3308-rock-pi-s.dts
 @@ -2,6 +2,7 @@
  /*
   * Copyright (c) 2019 Akash Gajjar <akash@openedev.com>
@@ -8,7 +33,7 @@
   */
  
  /dts-v1/;
-@@ -11,12 +12,6 @@
+@@ -11,12 +12,6 @@ / {
  	model = "Radxa ROCK Pi S";
  	compatible = "radxa,rockpis", "rockchip,rk3308";
  
@@ -21,7 +46,7 @@
  	chosen {
  		stdout-path = "serial0:1500000n8";
  	};
-@@ -27,44 +22,102 @@
+@@ -27,44 +22,102 @@ leds {
  		pinctrl-0 = <&green_led_gio>, <&heartbeat_led_gpio>;
  
  		green-led {
@@ -137,7 +162,7 @@
  		vin-supply = <&vcc5v0_sys>;
  	};
  
-@@ -78,50 +131,50 @@
+@@ -78,50 +131,50 @@ vcc_ddr: vcc-ddr {
  		vin-supply = <&vcc5v0_sys>;
  	};
  
@@ -213,7 +238,7 @@
  &cpu0 {
  	cpu-supply = <&vdd_core>;
  };
-@@ -129,23 +182,60 @@
+@@ -129,23 +182,60 @@ &cpu0 {
  &emmc {
  	bus-width = <4>;
  	cap-mmc-highspeed;
@@ -278,7 +303,7 @@
  };
  
  &pinctrl {
-@@ -172,7 +262,9 @@
+@@ -172,7 +262,9 @@ sdio-pwrseq {
  		wifi_enable_h: wifi-enable-h {
  			rockchip,pins = <0 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
  		};
@@ -288,7 +313,7 @@
  		wifi_host_wake: wifi-host-wake {
  			rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_down>;
  		};
-@@ -189,42 +281,29 @@
+@@ -189,42 +281,29 @@ &saradc {
  	status = "okay";
  };
  
@@ -342,7 +367,7 @@
  &uart4 {
  	status = "okay";
  
-@@ -235,19 +314,27 @@
+@@ -235,19 +314,27 @@ bluetooth {
  	};
  };
  
@@ -375,3 +400,6 @@
 +&usb_host_ohci{
  	status = "okay";
  };
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/board-rockpis-0005-arm64-dts-rk3308-Add-gmac-node-at-dtsi-level.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-rockpis-0005-arm64-dts-rk3308-Add-gmac-node-at-dtsi-level.patch
@@ -1,14 +1,14 @@
-From 359945b9f0c743846405b49513cc72606f5e781c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: ashthespy <ashthespy@gmail.com>
 Date: Thu, 16 Jan 2020 21:13:09 +0100
-Subject: [PATCH 05/23] arm64: dts: rk3308: Add mac node at dtsi level
+Subject: arm64: dts: rk3308: Add mac node at dtsi level
 
 ---
- arch/arm64/boot/dts/rockchip/rk3308.dtsi | 23 +++++++++++++++++++++++
- 1 file changed, 23 insertions(+)
+ arch/arm64/boot/dts/rockchip/rk3308.dtsi | 1 +
+ 1 file changed, 1 insertion(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3308.dtsi b/arch/arm64/boot/dts/rockchip/rk3308.dtsi
-index 8bdc66c62975..26af951be980 100644
+index dd228a256a32..9a8edd1c81a0 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3308.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3308.dtsi
 @@ -24,6 +24,7 @@ aliases {
@@ -20,4 +20,5 @@ index 8bdc66c62975..26af951be980 100644
  		serial1 = &uart1;
  		serial2 = &uart2;
 -- 
-2.25.1
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/board-rockpis-0007-arm64-dts-rockchip-add-cpu-s-thermal-config-for-rk33.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-rockpis-0007-arm64-dts-rockchip-add-cpu-s-thermal-config-for-rk33.patch
@@ -1,18 +1,17 @@
-From f7c671915084c850d4a068ebc2c91068de0d3ff2 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: ashthespy <ashthespy@gmail.com>
 Date: Fri, 17 Jan 2020 15:57:53 +0100
-Subject: [PATCH 07/23] arm64: dts: rockchip: add cpu's thermal config for
- rk3308
+Subject: arm64: dts: rockchip: add cpu's thermal config for rk3308
 
 ---
- arch/arm64/boot/dts/rockchip/rk3308.dtsi | 64 ++++++++++++++++++++++++
+ arch/arm64/boot/dts/rockchip/rk3308.dtsi | 64 ++++++++++
  1 file changed, 64 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3308.dtsi b/arch/arm64/boot/dts/rockchip/rk3308.dtsi
-index 26af951be980..d2613ec774c1 100644
+index 9a8edd1c81a0..5b92920426db 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3308.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3308.dtsi
-@@ -517,6 +517,70 @@
+@@ -551,6 +551,70 @@ saradc: saradc@ff1e0000 {
  		status = "disabled";
  	};
  
@@ -84,4 +83,5 @@ index 26af951be980..d2613ec774c1 100644
  		compatible = "arm,pl330", "arm,primecell";
  		reg = <0x0 0xff2c0000 0x0 0x4000>;
 -- 
-2.25.1
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/board-rockpis-0008-thermal-rockchip-add-tsadc-support-for-rk3308.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-rockpis-0008-thermal-rockchip-add-tsadc-support-for-rk3308.patch
@@ -1,25 +1,20 @@
-From 498c9f200325f0397fd03163a98e053430b80aa4 Mon Sep 17 00:00:00 2001
-From: ashthespy <ashthespy@users.noreply.github.com>
-Date: Fri, 17 Jan 2020 15:58:20 +0100
-Subject: [PATCH 08/23] thermal: rockchip: add tsadc support for rk3308
-
-From a231e9c68e5f5e6cf5a82a40828cfd1df4ad1f3e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Rocky Hao <rocky.hao@rock-chips.com>
 Date: Fri, 9 Mar 2018 17:36:39 +0800
-Subject: [PATCH] thermal: rockchip: add tsadc support for rk3308
+Subject: thermal: rockchip: add tsadc support for rk3308
 
 Change-Id: Ibf1782ca471c8ad4b14d6fd64eeb123181903adc
 Signed-off-by: Rocky Hao <rocky.hao@rock-chips.com>
 ---
- .../bindings/thermal/rockchip-thermal.yaml     |  1 +
- drivers/thermal/rockchip_thermal.c            | 28 +++++++++++++++++++
+ Documentation/devicetree/bindings/thermal/rockchip-thermal.yaml |  1 +
+ drivers/thermal/rockchip_thermal.c                              | 28 ++++++++++
  2 files changed, 29 insertions(+)
 
 diff --git a/Documentation/devicetree/bindings/thermal/rockchip-thermal.yaml b/Documentation/devicetree/bindings/thermal/rockchip-thermal.yaml
-index c6aac9bcacf1..3a0a9556680e 100644
+index f6c1be226aaa..f652dd535f1b 100644
 --- a/Documentation/devicetree/bindings/thermal/rockchip-thermal.yaml
 +++ b/Documentation/devicetree/bindings/thermal/rockchip-thermal.yaml
-@@ -15,6 +15,7 @@
+@@ -15,6 +15,7 @@ properties:
        - rockchip,px30-tsadc
        - rockchip,rk3228-tsadc
        - rockchip,rk3288-tsadc
@@ -28,10 +23,10 @@ index c6aac9bcacf1..3a0a9556680e 100644
        - rockchip,rk3368-tsadc
        - rockchip,rk3399-tsadc
 diff --git a/drivers/thermal/rockchip_thermal.c b/drivers/thermal/rockchip_thermal.c
-index 343c2f5c5a25..d4d66724535a 100644
+index 4b7c43f34d1a..8d08b59bc06f 100644
 --- a/drivers/thermal/rockchip_thermal.c
 +++ b/drivers/thermal/rockchip_thermal.c
-@@ -821,6 +821,30 @@ static void rk_tsadcv2_tshut_mode(int chn, void __iomem *regs,
+@@ -924,6 +924,30 @@ static void rk_tsadcv2_tshut_mode(int chn, void __iomem *regs,
  	writel_relaxed(val, regs + TSADCV2_INT_EN);
  }
  
@@ -62,7 +57,7 @@ index 343c2f5c5a25..d4d66724535a 100644
  static const struct rockchip_tsadc_chip px30_tsadc_data = {
  	.chn_id[SENSOR_CPU] = 0, /* cpu sensor is channel 0 */
  	.chn_id[SENSOR_GPU] = 1, /* gpu sensor is channel 1 */
-@@ -1032,6 +1056,10 @@ static const struct of_device_id of_rockchip_thermal_match[] = {
+@@ -1160,6 +1184,10 @@ static const struct of_device_id of_rockchip_thermal_match[] = {
  		.compatible = "rockchip,rk3288-tsadc",
  		.data = (void *)&rk3288_tsadc_data,
  	},
@@ -74,4 +69,5 @@ index 343c2f5c5a25..d4d66724535a 100644
  		.compatible = "rockchip,rk3328-tsadc",
  		.data = (void *)&rk3328_tsadc_data,
 -- 
-2.25.1
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/board-rockpis-0010-arm64-dts-rockchip-add-i2s_8ch-for-rk3308.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-rockpis-0010-arm64-dts-rockchip-add-i2s_8ch-for-rk3308.patch
@@ -1,18 +1,18 @@
-From 3169742f1483d5340bedff8b2f35a210bad5f3ca Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: ashthespy <ashthespy@gmail.com>
 Date: Fri, 17 Jan 2020 16:22:13 +0100
-Subject: [PATCH 10/23] arm64: dts: rockchip: add i2s_8ch for rk3308
+Subject: arm64: dts: rockchip: add i2s_8ch for rk3308
 
 ---
- arch/arm64/boot/dts/rockchip/rk3308.dtsi | 105 ++++++++++++++++++++++-
- 1 file changed, 104 insertions(+), 1 deletion(-)
+ arch/arm64/boot/dts/rockchip/rk3308.dtsi | 103 ++++++++++
+ 1 file changed, 103 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3308.dtsi b/arch/arm64/boot/dts/rockchip/rk3308.dtsi
-index d2613ec774c1..37ffedb99a2d 100644
+index 5b92920426db..1121f2852070 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3308.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3308.dtsi
-@@ -605,6 +605,109 @@ dmac1: dma-controller@ff2d0000 {
- 		};
+@@ -637,6 +637,109 @@ dmac1: dma-controller@ff2d0000 {
+ 		#dma-cells = <1>;
  	};
  
 +	i2s_8ch_0: i2s@ff300000 {
@@ -122,5 +122,5 @@ index d2613ec774c1..37ffedb99a2d 100644
  		compatible = "rockchip,rk3308-i2s", "rockchip,rk3066-i2s";
  		reg = <0x0 0xff350000 0x0 0x1000>;
 -- 
-2.25.1
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/board-rockpis-0012-arm64-dts-rk3308-Add-rk-timer-rtc.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-rockpis-0012-arm64-dts-rk3308-Add-rk-timer-rtc.patch
@@ -1,17 +1,17 @@
-From e329bfefd00a9210b45278acf42fc639c3c54c24 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: ashthespy <ashthespy@gmail.com>
 Date: Fri, 17 Jan 2020 17:12:51 +0100
-Subject: [PATCH 12/23] arm64: dts: rk3308: Add rk-timer-rtc
+Subject: arm64: dts: rk3308: Add rk-timer-rtc
 
 ---
- arch/arm64/boot/dts/rockchip/rk3308.dtsi | 11 ++++++++++-
+ arch/arm64/boot/dts/rockchip/rk3308.dtsi | 11 +++++++++-
  1 file changed, 10 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3308.dtsi b/arch/arm64/boot/dts/rockchip/rk3308.dtsi
-index 37ffedb99a2d..c711c248ce29 100644
+index 1121f2852070..e77bf353e3cb 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3308.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3308.dtsi
-@@ -502,6 +502,15 @@ rktimer: rktimer@ff1a0000 {
+@@ -539,6 +539,15 @@ rktimer: rktimer@ff1a0000 {
  		clock-names = "pclk", "timer";
  	};
  
@@ -27,7 +27,7 @@ index 37ffedb99a2d..c711c248ce29 100644
  	saradc: saradc@ff1e0000 {
  		compatible = "rockchip,rk3308-saradc", "rockchip,rk3399-saradc";
  		reg = <0x0 0xff1e0000 0x0 0x100>;
-@@ -707,7 +716,7 @@ i2s_8ch_3: i2s@ff330000 {
+@@ -739,7 +748,7 @@ i2s_8ch_3: i2s@ff330000 {
  		rockchip,mclk-calibrate;
  		status = "disabled";
  	};
@@ -37,5 +37,5 @@ index 37ffedb99a2d..c711c248ce29 100644
  		compatible = "rockchip,rk3308-i2s", "rockchip,rk3066-i2s";
  		reg = <0x0 0xff350000 0x0 0x1000>;
 -- 
-2.25.1
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/board-rockpis-0018-ASoC-codecs-Add-RK3308-internal-codec-driver.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-rockpis-0018-ASoC-codecs-Add-RK3308-internal-codec-driver.patch
@@ -1,12 +1,7 @@
-From 76f98b4d0be07417ab9bc4a5669d185299f54cdf Mon Sep 17 00:00:00 2001
-From: ashthespy <ashthespy@gmail.com>
-Date: Mon, 3 Feb 2020 17:09:38 +0100
-Subject: [PATCH 18/23] ASoC: codecs: Add RK3308 internal codec driver
-
-From b9d097610177b7117a09ea74ed00476a2105f169 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Xing Zheng <zhengxing@rock-chips.com>
 Date: Sun, 11 Mar 2018 11:37:28 +0800
-Subject: [PATCH] ASoC: codecs: Add RK3308 internal codec driver
+Subject: ASoC: codecs: Add RK3308 internal codec driver
 
 This adds support for the RK3308 audio codec.
 
@@ -15,17 +10,15 @@ Signed-off-by: Xing Zheng <zhengxing@rock-chips.com>
 ---
  sound/soc/codecs/Kconfig        |    5 +
  sound/soc/codecs/Makefile       |    2 +
- sound/soc/codecs/rk3308_codec.c | 1604 +++++++++++++++++++++++++++++++
- sound/soc/codecs/rk3308_codec.h |  960 ++++++++++++++++++
+ sound/soc/codecs/rk3308_codec.c | 1604 ++++++++++
+ sound/soc/codecs/rk3308_codec.h |  960 ++++++
  4 files changed, 2571 insertions(+)
- create mode 100644 sound/soc/codecs/rk3308_codec.c
- create mode 100644 sound/soc/codecs/rk3308_codec.h
 
 diff --git a/sound/soc/codecs/Kconfig b/sound/soc/codecs/Kconfig
-index 030f500f3bc8..1f4675a59014 100644
+index 07747565c3b5..2be7d5017d12 100644
 --- a/sound/soc/codecs/Kconfig
 +++ b/sound/soc/codecs/Kconfig
-@@ -144,6 +144,7 @@ config SND_SOC_ALL_CODECS
+@@ -168,6 +168,7 @@ config SND_SOC_ALL_CODECS
  	imply SND_SOC_PCM512x_I2C
  	imply SND_SOC_PCM512x_SPI
  	imply SND_SOC_PEB2466
@@ -33,9 +26,9 @@ index 030f500f3bc8..1f4675a59014 100644
  	imply SND_SOC_RK3328
  	imply SND_SOC_RK817
  	imply SND_SOC_RT274
-@@ -931,6 +932,10 @@ config SND_SOC_PEB2466
- 	To compile this driver as a module, choose M here: the module
- 	will be called snd-soc-peb2466.
+@@ -1251,6 +1252,10 @@ config SND_SOC_PEB2466
+ 	  To compile this driver as a module, choose M here: the module
+ 	  will be called snd-soc-peb2466.
  
 +config SND_SOC_RK3308
 +	select REGMAP_MMIO
@@ -45,10 +38,10 @@ index 030f500f3bc8..1f4675a59014 100644
  	tristate "Rockchip RK3328 audio CODEC"
  	select REGMAP_MMIO
 diff --git a/sound/soc/codecs/Makefile b/sound/soc/codecs/Makefile
-index ddfd07071925..9a35df4862dc 100644
+index f1ca18f7946c..c2fa502159d8 100644
 --- a/sound/soc/codecs/Makefile
 +++ b/sound/soc/codecs/Makefile
-@@ -148,6 +148,7 @@ snd-soc-pcm5102a-objs := pcm5102a.o
+@@ -188,6 +188,7 @@ snd-soc-pcm512x-objs := pcm512x.o
  snd-soc-pcm512x-i2c-objs := pcm512x-i2c.o
  snd-soc-pcm512x-spi-objs := pcm512x-spi.o
  snd-soc-peb2466-objs := peb2466.o
@@ -56,7 +49,7 @@ index ddfd07071925..9a35df4862dc 100644
  snd-soc-rk3328-objs := rk3328_codec.o
  snd-soc-rk817-objs := rk817_codec.o
  snd-soc-rl6231-objs := rl6231.o
-@@ -437,6 +438,7 @@ obj-$(CONFIG_SND_SOC_PCM5102A)	+= snd-soc-pcm5102a.o
+@@ -550,6 +551,7 @@ obj-$(CONFIG_SND_SOC_PCM512x)	+= snd-soc-pcm512x.o
  obj-$(CONFIG_SND_SOC_PCM512x_I2C)	+= snd-soc-pcm512x-i2c.o
  obj-$(CONFIG_SND_SOC_PCM512x_SPI)	+= snd-soc-pcm512x-spi.o
  obj-$(CONFIG_SND_SOC_PEB2466)	+= snd-soc-peb2466.o
@@ -2641,5 +2634,5 @@ index 000000000000..6cfa69157785
 +
 +#endif /* __RK3308_CODEC_H__ */
 -- 
-2.25.1
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/board-rockpis-0019-Sync-rk3308_codec-to-BSP-tree.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-rockpis-0019-Sync-rk3308_codec-to-BSP-tree.patch
@@ -1,16 +1,14 @@
-From 26d61ff64d9a61425d017846db61e9a06de07286 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: ashthespy <ashthespy@gmail.com>
 Date: Mon, 3 Feb 2020 17:13:59 +0100
-Subject: [PATCH 19/23] Sync `rk3308_codec` to BSP tree
+Subject: Sync `rk3308_codec` to BSP tree
 
 ---
- .../bindings/sound/rockchip,rk3308-codec.txt  |   78 +
- sound/soc/codecs/rk3308_codec.c               | 5687 ++++++++++++++---
- sound/soc/codecs/rk3308_codec.h               |  217 +-
- sound/soc/codecs/rk3308_codec_provider.h      |   28 +
+ Documentation/devicetree/bindings/sound/rockchip,rk3308-codec.txt |   78 +
+ sound/soc/codecs/rk3308_codec.c                                   | 5687 ++++++++--
+ sound/soc/codecs/rk3308_codec.h                                   |  217 +-
+ sound/soc/codecs/rk3308_codec_provider.h                          |   28 +
  4 files changed, 4894 insertions(+), 1116 deletions(-)
- create mode 100644 Documentation/devicetree/bindings/sound/rockchip,rk3308-codec.txt
- create mode 100644 sound/soc/codecs/rk3308_codec_provider.h
 
 diff --git a/Documentation/devicetree/bindings/sound/rockchip,rk3308-codec.txt b/Documentation/devicetree/bindings/sound/rockchip,rk3308-codec.txt
 new file mode 100644
@@ -6736,5 +6734,5 @@ index 000000000000..68042b1328dc
 +
 +#endif /* __RK3308_CODEC_PROVIDER_H__ */
 -- 
-2.25.1
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/board-rockpis-0020-arm64-dts-rockchip-Add-acodec-node-for-rk3308.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-rockpis-0020-arm64-dts-rockchip-Add-acodec-node-for-rk3308.patch
@@ -1,19 +1,19 @@
-From 198cad9a30ea2a5a252ceb97736f3475d7a6b08d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: ashthespy <ashthespy@gmail.com>
 Date: Mon, 3 Feb 2020 17:19:33 +0100
-Subject: [PATCH 20/23] arm64: dts: rockchip: Add acodec node for rk3308
+Subject: arm64: dts: rockchip: Add acodec node for rk3308
 
 Change-Id: I76f4a877711d33620bdef295e9047bdba26d4da4
 Signed-off-by: Xing Zheng <zhengxing@rock-chips.com>
 ---
- arch/arm64/boot/dts/rockchip/rk3308.dtsi | 18 +++++++++++++++++-
+ arch/arm64/boot/dts/rockchip/rk3308.dtsi | 18 +++++++++-
  1 file changed, 17 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3308.dtsi b/arch/arm64/boot/dts/rockchip/rk3308.dtsi
-index c711c248ce29..3863f8cc2517 100644
+index e77bf353e3cb..37fe89b14a40 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3308.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3308.dtsi
-@@ -510,7 +510,7 @@ rk_timer_rtc: rk-timer-rtc@ff1a0020 {
+@@ -547,7 +547,7 @@ rk_timer_rtc: rk-timer-rtc@ff1a0020 {
  		clock-names = "pclk", "timer";
  		status = "disabled";
  	};
@@ -22,7 +22,7 @@ index c711c248ce29..3863f8cc2517 100644
  	saradc: saradc@ff1e0000 {
  		compatible = "rockchip,rk3308-saradc", "rockchip,rk3399-saradc";
  		reg = <0x0 0xff1e0000 0x0 0x100>;
-@@ -837,6 +837,22 @@ cru: clock-controller@ff500000 {
+@@ -932,6 +932,22 @@ cru: clock-controller@ff500000 {
  		assigned-clock-rates = <32768>;
  	};
  
@@ -46,5 +46,5 @@ index c711c248ce29..3863f8cc2517 100644
  		compatible = "arm,gic-400";
  		reg = <0x0 0xff581000 0x0 0x1000>,
 -- 
-2.25.1
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/board-rockpis-0022-ASoC-rk3308_codec-replace-codec-to-component.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-rockpis-0022-ASoC-rk3308_codec-replace-codec-to-component.patch
@@ -1,15 +1,15 @@
-From b882c2185ab561ec88c2540623cfa49e2cb56956 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: ashthespy <ashthespy@gmail.com>
 Date: Mon, 3 Feb 2020 19:35:42 +0100
-Subject: [PATCH 22/23] ASoC: rk3308_codec: replace codec to component
+Subject: ASoC: rk3308_codec: replace codec to component
 
 ---
- sound/soc/codecs/rk3308_codec.c          | 159 ++++++++++++-----------
+ sound/soc/codecs/rk3308_codec.c          | 159 +++++-----
  sound/soc/codecs/rk3308_codec_provider.h |   2 +-
  2 files changed, 84 insertions(+), 77 deletions(-)
 
 diff --git a/sound/soc/codecs/rk3308_codec.c b/sound/soc/codecs/rk3308_codec.c
-index 815e22fc346c..16bfb215586e 100644
+index 815e22fc346c..b6862fc5a3da 100644
 --- a/sound/soc/codecs/rk3308_codec.c
 +++ b/sound/soc/codecs/rk3308_codec.c
 @@ -31,7 +31,7 @@
@@ -455,5 +455,5 @@ index 68042b1328dc..34c1ef86a507 100644
  #endif
  
 -- 
-2.25.1
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/board-rockpis-0027-arm64-dts-rk3308-add-otp-cpuinfo.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-rockpis-0027-arm64-dts-rk3308-add-otp-cpuinfo.patch
@@ -1,6 +1,73 @@
---- a/arch/arm64/boot/dts/rockchip/rk3308.dtsi	2020-12-26 18:07:15.666727654 +0200
-+++ b/arch/arm64/boot/dts/rockchip/rk3308.dtsi	2020-12-26 18:35:42.115701024 +0200
-@@ -139,6 +151,12 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+Date: Wed, 8 Sep 2021 17:51:34 +0200
+Subject: [ARCHEOLOGY] Bumping EDGE kernel to 5.14.y (#3125)
+
+> X-Git-Archeology: > recovered message: > * Bumping EDGE kernel to 5.14.y
+> X-Git-Archeology: > recovered message: > Meson64:
+> X-Git-Archeology: > recovered message: > - removing Odroid reboot shutdown patch since its probably not needed anymore
+> X-Git-Archeology: > recovered message: > Rockchip64:
+> X-Git-Archeology: > recovered message: > - removing Rockpi S. No interest to maintain this any further
+> X-Git-Archeology: > recovered message: > - removing PBP suspend. Doesn't align. Need inspection if some other way was mainstreamed
+> X-Git-Archeology: > recovered message: > - temporally removing Orangepi R1
+> X-Git-Archeology: > recovered message: > * Re-adding rockpis, pbp suspend, HFLPS170 wifi and cleanup
+> X-Git-Archeology: > recovered message: > * Removing deprecated patch, fixing ap6256 wifi
+> X-Git-Archeology: > recovered message: > * Re-enable Opi R1 plus, untest
+> X-Git-Archeology: > recovered message: > * Add and fix Radxa Zero
+> X-Git-Archeology: - Revision 744ea89a589d62cb6f409baab60fc6664520bc39: https://github.com/armbian/build/commit/744ea89a589d62cb6f409baab60fc6664520bc39
+> X-Git-Archeology:   Date: Wed, 08 Sep 2021 17:51:34 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bumping EDGE kernel to 5.14.y (#3125)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e: https://github.com/armbian/build/commit/dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e
+> X-Git-Archeology:   Date: Tue, 09 Nov 2021 18:06:34 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump imx6, xu4, rockchip64 and jetson-nano to 5.15 (#3238)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3308.dtsi | 29 ++++++++++
+ 1 file changed, 29 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3308.dtsi b/arch/arm64/boot/dts/rockchip/rk3308.dtsi
+index 37fe89b14a40..9e5b0977ade6 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3308.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3308.dtsi
+@@ -137,6 +137,12 @@ arm-pmu {
  		interrupt-affinity = <&cpu0>, <&cpu1>, <&cpu2>, <&cpu3>;
  	};
  
@@ -13,7 +80,7 @@
  	mac_clkin: external-mac-clock {
  		compatible = "fixed-clock";
  		clock-frequency = <50000000>;
-@@ -146,6 +164,29 @@
+@@ -144,6 +150,29 @@ mac_clkin: external-mac-clock {
  		#clock-cells = <0>;
  	};
  
@@ -43,3 +110,6 @@
  	psci {
  		compatible = "arm,psci-1.0";
  		method = "smc";
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/board-rockpis-0029-arm64-dts-rk3308-add-reserved-memory-ramoops.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-rockpis-0029-arm64-dts-rk3308-add-reserved-memory-ramoops.patch
@@ -1,6 +1,73 @@
---- a/arch/arm64/boot/dts/rockchip/rk3308.dtsi	2020-12-26 18:07:15.666727654 +0200
-+++ b/arch/arm64/boot/dts/rockchip/rk3308.dtsi	2020-12-26 18:13:13.061143555 +0200
-@@ -148,6 +148,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+Date: Wed, 8 Sep 2021 17:51:34 +0200
+Subject: [ARCHEOLOGY] Bumping EDGE kernel to 5.14.y (#3125)
+
+> X-Git-Archeology: > recovered message: > * Bumping EDGE kernel to 5.14.y
+> X-Git-Archeology: > recovered message: > Meson64:
+> X-Git-Archeology: > recovered message: > - removing Odroid reboot shutdown patch since its probably not needed anymore
+> X-Git-Archeology: > recovered message: > Rockchip64:
+> X-Git-Archeology: > recovered message: > - removing Rockpi S. No interest to maintain this any further
+> X-Git-Archeology: > recovered message: > - removing PBP suspend. Doesn't align. Need inspection if some other way was mainstreamed
+> X-Git-Archeology: > recovered message: > - temporally removing Orangepi R1
+> X-Git-Archeology: > recovered message: > * Re-adding rockpis, pbp suspend, HFLPS170 wifi and cleanup
+> X-Git-Archeology: > recovered message: > * Removing deprecated patch, fixing ap6256 wifi
+> X-Git-Archeology: > recovered message: > * Re-enable Opi R1 plus, untest
+> X-Git-Archeology: > recovered message: > * Add and fix Radxa Zero
+> X-Git-Archeology: - Revision 744ea89a589d62cb6f409baab60fc6664520bc39: https://github.com/armbian/build/commit/744ea89a589d62cb6f409baab60fc6664520bc39
+> X-Git-Archeology:   Date: Wed, 08 Sep 2021 17:51:34 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bumping EDGE kernel to 5.14.y (#3125)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e: https://github.com/armbian/build/commit/dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e
+> X-Git-Archeology:   Date: Tue, 09 Nov 2021 18:06:34 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump imx6, xu4, rockchip64 and jetson-nano to 5.15 (#3238)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3308.dtsi | 20 ++++++++++
+ 1 file changed, 20 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3308.dtsi b/arch/arm64/boot/dts/rockchip/rk3308.dtsi
+index 9e5b0977ade6..acb5f7304065 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3308.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3308.dtsi
+@@ -178,6 +178,26 @@ psci {
  		method = "smc";
  	};
  
@@ -27,3 +94,6 @@
  	timer {
  		compatible = "arm,armv8-timer";
  		interrupts = <GIC_PPI 13 (GIC_CPU_MASK_SIMPLE(4) | IRQ_TYPE_LEVEL_HIGH)>,
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/board-rockpro64-0001-Add-pcie-bus-scan-delay.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-rockpro64-0001-Add-pcie-bus-scan-delay.patch
@@ -1,8 +1,57 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Piotr Szczepanik <piter75@gmail.com>
+Date: Mon, 24 Aug 2020 22:47:03 +0200
+Subject: Rockpro64 add pcie bus scan delay
+
+> X-Git-Archeology: - Revision 42e76b9277ad492e935cc76c2b37c9f6d882a675: https://github.com/armbian/build/commit/42e76b9277ad492e935cc76c2b37c9f6d882a675
+> X-Git-Archeology:   Date: Mon, 24 Aug 2020 22:47:03 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch RockPro64 work led to heartbeat trigger
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 4d4c3f58ffc1cbfbb060cbabc9eb414036a2fda5: https://github.com/armbian/build/commit/4d4c3f58ffc1cbfbb060cbabc9eb414036a2fda5
+> X-Git-Archeology:   Date: Wed, 02 Sep 2020 23:22:09 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switched rockchip64 curent to kernel 5.8.y (#2175)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0cdffb29b07305209efb12cf3b5ac6032d3a1153: https://github.com/armbian/build/commit/0cdffb29b07305209efb12cf3b5ac6032d3a1153
+> X-Git-Archeology:   Date: Wed, 24 Mar 2021 19:01:53 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Renaming DEV branch to EDGE (#2704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e7377248b3cae186e24e2be781cd3365b43246f0: https://github.com/armbian/build/commit/e7377248b3cae186e24e2be781cd3365b43246f0
+> X-Git-Archeology:   Date: Thu, 22 Jul 2021 00:15:54 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Second part of EDGE bumping to 5.13.y (#3045)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 7be9e8b99590e32c0594365d00a2a2cfc3c4bd5a: https://github.com/armbian/build/commit/7be9e8b99590e32c0594365d00a2a2cfc3c4bd5a
+> X-Git-Archeology:   Date: Thu, 16 Dec 2021 05:17:33 -0500
+> X-Git-Archeology:   From: Dan Pasanen <dan.pasanen@gmail.com>
+> X-Git-Archeology:   Subject: rockchip-[current,edge]: add pcie hack and lsi scsi/sas support (#3351)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 588c2ec17e709dec19304fa50522459702ebfadd: https://github.com/armbian/build/commit/588c2ec17e709dec19304fa50522459702ebfadd
+> X-Git-Archeology:   Date: Fri, 23 Dec 2022 21:57:53 +0100
+> X-Git-Archeology:   From: brentr <brent@mbari.org>
+> X-Git-Archeology:   Subject: Rockpis devtree mainlined (#4603)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi | 1 +
+ 1 file changed, 1 insertion(+)
+
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
-index bfd57f6f0..5374753cd 100644
+index bca2b50e0a93..1e7295215b58 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
-@@ -579,6 +579,7 @@ &pcie0 {
+@@ -663,6 +663,7 @@ &pcie0 {
  	pinctrl-0 = <&pcie_perst>;
  	vpcie12v-supply = <&vcc12v_dcin>;
  	vpcie3v3-supply = <&vcc3v3_pcie>;
@@ -10,3 +59,6 @@ index bfd57f6f0..5374753cd 100644
  	status = "okay";
  };
  
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/board-rockpro64-change-rx_delay-for-gmac.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-rockpro64-change-rx_delay-for-gmac.patch
@@ -1,7 +1,7 @@
-From 57825a7190ac09a1e273cab12e797010fcb7a1c9 Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?Kamil=20Trzci=C5=84ski?= <ayufan@ayufan.eu>
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ayufan <ayufan@ayufan.eu>
 Date: Sun, 30 Dec 2018 13:32:47 +0100
-Subject: [PATCH] ayufan: dts: rockpro64: change rx_delay for gmac
+Subject: ayufan: dts: rockpro64: change rx_delay for gmac
 
 Change-Id: Ib3899f684188aa1ed1545717af004bba53fe0e07
 ---
@@ -9,10 +9,10 @@ Change-Id: Ib3899f684188aa1ed1545717af004bba53fe0e07
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
-index cdab3089046c..0db9de46ff16 100644
+index 1e7295215b58..25ee84e06874 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
-@@ -249,7 +249,7 @@
+@@ -307,7 +307,7 @@ &gmac {
  	snps,reset-active-low;
  	snps,reset-delays-us = <0 10000 50000>;
  	tx_delay = <0x28>;
@@ -22,5 +22,5 @@ index cdab3089046c..0db9de46ff16 100644
  };
  
 -- 
-2.20.1
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/board-rockpro64-fix-emmc.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-rockpro64-fix-emmc.patch
@@ -1,16 +1,116 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Martin Ayotte <martinayotte@yahoo.ca>
+Date: Wed, 5 Dec 2018 14:09:24 -0500
+Subject: [ARCHEOLOGY] fix PMIC_INT_L gpio conflicting with I2C8_SCL in
+ RockPro64
+
+> X-Git-Archeology: - Revision 9324bde9b94db6c2f43ff1e75bedb74fbe6e29a1: https://github.com/armbian/build/commit/9324bde9b94db6c2f43ff1e75bedb74fbe6e29a1
+> X-Git-Archeology:   Date: Wed, 05 Dec 2018 14:09:24 -0500
+> X-Git-Archeology:   From: Martin Ayotte <martinayotte@yahoo.ca>
+> X-Git-Archeology:   Subject: fix PMIC_INT_L gpio conflicting with I2C8_SCL in RockPro64
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8f82cb60b958ad235ee91899ab2ca8e4a8a2a33b: https://github.com/armbian/build/commit/8f82cb60b958ad235ee91899ab2ca8e4a8a2a33b
+> X-Git-Archeology:   Date: Mon, 31 Dec 2018 12:29:56 -0500
+> X-Git-Archeology:   From: Martin Ayotte <martinayotte@yahoo.ca>
+> X-Git-Archeology:   Subject: set lower speed for RockPro64 eMMC
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision cbbbf0631969bf0e4578f4b1eef62c1aab115d79: https://github.com/armbian/build/commit/cbbbf0631969bf0e4578f4b1eef62c1aab115d79
+> X-Git-Archeology:   Date: Tue, 01 Jan 2019 19:37:27 -0500
+> X-Git-Archeology:   From: Martin Ayotte <martinayotte@yahoo.ca>
+> X-Git-Archeology:   Subject: fix RockPi-4B naming + fix vcc5v0_host gpio pin
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision a186fd498404fdae7d3a25dec64f014c590027d6: https://github.com/armbian/build/commit/a186fd498404fdae7d3a25dec64f014c590027d6
+> X-Git-Archeology:   Date: Wed, 05 Feb 2020 00:19:00 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switched rockchip64-dev to mainline kernel 5.5.y (#1781)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 5e251dc4148f7a7e3fa61d440c5a268626624de3: https://github.com/armbian/build/commit/5e251dc4148f7a7e3fa61d440c5a268626624de3
+> X-Git-Archeology:   Date: Mon, 06 Apr 2020 19:06:28 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Merged rockpi-s dev info rockchip64-dev and moved to 5.6.y (#1874)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 812245def37a695bce9e7ece148b2920d82c8b37: https://github.com/armbian/build/commit/812245def37a695bce9e7ece148b2920d82c8b37
+> X-Git-Archeology:   Date: Sat, 18 Jul 2020 23:07:01 +0200
+> X-Git-Archeology:   From: Werner <EvilOlaf@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Move rockchip/64 current to 5.7.y (#2099)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dfd5cf9692e97774f7f0bfd72227144e36f58070: https://github.com/armbian/build/commit/dfd5cf9692e97774f7f0bfd72227144e36f58070
+> X-Git-Archeology:   Date: Sun, 13 Dec 2020 22:13:03 -0500
+> X-Git-Archeology:   From: tonymac32 <tonymckahan@gmail.com>
+> X-Git-Archeology:   Subject: [ rockchip64 ] Clean up patchset
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0cdffb29b07305209efb12cf3b5ac6032d3a1153: https://github.com/armbian/build/commit/0cdffb29b07305209efb12cf3b5ac6032d3a1153
+> X-Git-Archeology:   Date: Wed, 24 Mar 2021 19:01:53 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Renaming DEV branch to EDGE (#2704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e7377248b3cae186e24e2be781cd3365b43246f0: https://github.com/armbian/build/commit/e7377248b3cae186e24e2be781cd3365b43246f0
+> X-Git-Archeology:   Date: Thu, 22 Jul 2021 00:15:54 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Second part of EDGE bumping to 5.13.y (#3045)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 744ea89a589d62cb6f409baab60fc6664520bc39: https://github.com/armbian/build/commit/744ea89a589d62cb6f409baab60fc6664520bc39
+> X-Git-Archeology:   Date: Wed, 08 Sep 2021 17:51:34 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bumping EDGE kernel to 5.14.y (#3125)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e: https://github.com/armbian/build/commit/dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e
+> X-Git-Archeology:   Date: Tue, 09 Nov 2021 18:06:34 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump imx6, xu4, rockchip64 and jetson-nano to 5.15 (#3238)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi | 2 ++
+ 1 file changed, 2 insertions(+)
+
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
-index 714616618..b1fb824f3 100644
+index 25ee84e06874..f5f521986d43 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
-@@ -15,6 +15,7 @@
- 	compatible = "pine64,rockpro64", "rockchip,rk3399";
+@@ -17,6 +17,7 @@ aliases {
+ 	};
  
  	chosen {
 +		bootargs = "mmc_cmdqueue=0 earlycon=uart8250,mmio32,0xff1a0000";
  		stdout-path = "serial2:1500000n8";
  	};
  
-@@ -635,6 +636,7 @@
+@@ -815,6 +816,7 @@ &sdmmc {
  
  &sdhci {
  	bus-width = <8>;
@@ -18,3 +118,6 @@ index 714616618..b1fb824f3 100644
  	mmc-hs200-1_8v;
  	non-removable;
  	status = "okay";
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/board-rockpro64-fix-spi1-flash-speed.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-rockpro64-fix-spi1-flash-speed.patch
@@ -1,8 +1,97 @@
-diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts
-index 49050de8c..714616618 100644
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Martin Ayotte <martinayotte@yahoo.ca>
+Date: Sat, 5 Jan 2019 09:50:02 -0500
+Subject: [ARCHEOLOGY] slow SPIFlash to avoid errors
+
+> X-Git-Archeology: - Revision ea20f750bfead37ced7b604a44f8f014e317abad: https://github.com/armbian/build/commit/ea20f750bfead37ced7b604a44f8f014e317abad
+> X-Git-Archeology:   Date: Sat, 05 Jan 2019 09:50:02 -0500
+> X-Git-Archeology:   From: Martin Ayotte <martinayotte@yahoo.ca>
+> X-Git-Archeology:   Subject: slow SPIFlash to avoid errors
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision a186fd498404fdae7d3a25dec64f014c590027d6: https://github.com/armbian/build/commit/a186fd498404fdae7d3a25dec64f014c590027d6
+> X-Git-Archeology:   Date: Wed, 05 Feb 2020 00:19:00 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switched rockchip64-dev to mainline kernel 5.5.y (#1781)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 5e251dc4148f7a7e3fa61d440c5a268626624de3: https://github.com/armbian/build/commit/5e251dc4148f7a7e3fa61d440c5a268626624de3
+> X-Git-Archeology:   Date: Mon, 06 Apr 2020 19:06:28 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Merged rockpi-s dev info rockchip64-dev and moved to 5.6.y (#1874)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 812245def37a695bce9e7ece148b2920d82c8b37: https://github.com/armbian/build/commit/812245def37a695bce9e7ece148b2920d82c8b37
+> X-Git-Archeology:   Date: Sat, 18 Jul 2020 23:07:01 +0200
+> X-Git-Archeology:   From: Werner <EvilOlaf@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Move rockchip/64 current to 5.7.y (#2099)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 40665cde86285060e6bdd5ef7dc33be6c301ec66: https://github.com/armbian/build/commit/40665cde86285060e6bdd5ef7dc33be6c301ec66
+> X-Git-Archeology:   Date: Sun, 13 Dec 2020 23:22:08 -0500
+> X-Git-Archeology:   From: tonymac32 <tonymckahan@gmail.com>
+> X-Git-Archeology:   Subject: [ rockchip64 ] Patch reorg round 2
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0cdffb29b07305209efb12cf3b5ac6032d3a1153: https://github.com/armbian/build/commit/0cdffb29b07305209efb12cf3b5ac6032d3a1153
+> X-Git-Archeology:   Date: Wed, 24 Mar 2021 19:01:53 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Renaming DEV branch to EDGE (#2704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e7377248b3cae186e24e2be781cd3365b43246f0: https://github.com/armbian/build/commit/e7377248b3cae186e24e2be781cd3365b43246f0
+> X-Git-Archeology:   Date: Thu, 22 Jul 2021 00:15:54 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Second part of EDGE bumping to 5.13.y (#3045)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 744ea89a589d62cb6f409baab60fc6664520bc39: https://github.com/armbian/build/commit/744ea89a589d62cb6f409baab60fc6664520bc39
+> X-Git-Archeology:   Date: Wed, 08 Sep 2021 17:51:34 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bumping EDGE kernel to 5.14.y (#3125)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e: https://github.com/armbian/build/commit/dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e
+> X-Git-Archeology:   Date: Tue, 09 Nov 2021 18:06:34 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump imx6, xu4, rockchip64 and jetson-nano to 5.15 (#3238)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
+index f5f521986d43..6eddc07a958f 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
-@@ -646,7 +646,7 @@
+@@ -838,7 +838,7 @@ &spi1 {
  	flash@0 {
  		compatible = "jedec,spi-nor";
  		reg = <0>;
@@ -11,3 +100,6 @@ index 49050de8c..714616618 100644
  	};
  };
  
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/board-rockpro64-work-led-heartbeat.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-rockpro64-work-led-heartbeat.patch
@@ -1,13 +1,95 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Piotr Szczepanik <piter75@gmail.com>
+Date: Mon, 24 Aug 2020 22:47:03 +0200
+Subject: [ARCHEOLOGY] Switch RockPro64 work led to heartbeat trigger
+
+> X-Git-Archeology: - Revision 42e76b9277ad492e935cc76c2b37c9f6d882a675: https://github.com/armbian/build/commit/42e76b9277ad492e935cc76c2b37c9f6d882a675
+> X-Git-Archeology:   Date: Mon, 24 Aug 2020 22:47:03 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch RockPro64 work led to heartbeat trigger
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision d1eb0003854909824d17b529cd513feb542bf228: https://github.com/armbian/build/commit/d1eb0003854909824d17b529cd513feb542bf228
+> X-Git-Archeology:   Date: Mon, 24 Aug 2020 23:11:20 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch RockPro64 work led to heartbeat trigger (in legacy too)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 4d4c3f58ffc1cbfbb060cbabc9eb414036a2fda5: https://github.com/armbian/build/commit/4d4c3f58ffc1cbfbb060cbabc9eb414036a2fda5
+> X-Git-Archeology:   Date: Wed, 02 Sep 2020 23:22:09 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switched rockchip64 curent to kernel 5.8.y (#2175)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0cdffb29b07305209efb12cf3b5ac6032d3a1153: https://github.com/armbian/build/commit/0cdffb29b07305209efb12cf3b5ac6032d3a1153
+> X-Git-Archeology:   Date: Wed, 24 Mar 2021 19:01:53 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Renaming DEV branch to EDGE (#2704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e7377248b3cae186e24e2be781cd3365b43246f0: https://github.com/armbian/build/commit/e7377248b3cae186e24e2be781cd3365b43246f0
+> X-Git-Archeology:   Date: Thu, 22 Jul 2021 00:15:54 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Second part of EDGE bumping to 5.13.y (#3045)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 744ea89a589d62cb6f409baab60fc6664520bc39: https://github.com/armbian/build/commit/744ea89a589d62cb6f409baab60fc6664520bc39
+> X-Git-Archeology:   Date: Wed, 08 Sep 2021 17:51:34 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bumping EDGE kernel to 5.14.y (#3125)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e: https://github.com/armbian/build/commit/dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e
+> X-Git-Archeology:   Date: Tue, 09 Nov 2021 18:06:34 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump imx6, xu4, rockchip64 and jetson-nano to 5.15 (#3238)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
-index 274e72b37..311e5886f 100644
+index 6eddc07a958f..eb1eebadb637 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
-@@ -44,7 +44,7 @@
+@@ -66,7 +66,7 @@ leds {
  
- 		work-led {
+ 		work_led: led-0 {
  			label = "work";
 -			default-state = "on";
 +			linux,default-trigger = "heartbeat";
  			gpios = <&gpio0 RK_PB3 GPIO_ACTIVE_HIGH>;
  		};
  
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/drv-spi-spidev-remove-warnings.patch
+++ b/patch/kernel/archive/rockchip64-6.3/drv-spi-spidev-remove-warnings.patch
@@ -1,17 +1,17 @@
-From 2653defc5e22ba86bd1d455eb01fc7edd2958473 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: The-going <48602507+The-going@users.noreply.github.com>
 Date: Wed, 2 Feb 2022 11:56:51 +0300
-Subject: [PATCH 08/50] drv:spi:spidev remove warnings
+Subject: drv:spi:spidev remove warnings
 
 ---
- drivers/spi/spidev.c | 7 ++++++-
- 1 file changed, 6 insertions(+), 1 deletion(-)
+ drivers/spi/spidev.c | 2 ++
+ 1 file changed, 2 insertions(+)
 
 diff --git a/drivers/spi/spidev.c b/drivers/spi/spidev.c
-index b2775d82d2d7..3c65d3d74559 100644
+index 5a038c667401..86e98cdd2b6d 100644
 --- a/drivers/spi/spidev.c
 +++ b/drivers/spi/spidev.c
-@@ -683,6 +683,7 @@ static const struct file_operations spidev_fops = {
+@@ -703,6 +703,7 @@ static const struct file_operations spidev_fops = {
  static struct class *spidev_class;
  
  static const struct spi_device_id spidev_spi_ids[] = {
@@ -19,7 +19,7 @@ index b2775d82d2d7..3c65d3d74559 100644
  	{ .name = "dh2228fv" },
  	{ .name = "ltc2488" },
  	{ .name = "sx1301" },
-@@ -709,6 +710,7 @@ static int spidev_of_check(struct device *dev)
+@@ -731,6 +732,7 @@ static int spidev_of_check(struct device *dev)
  }
  
  static const struct of_device_id spidev_dt_ids[] = {
@@ -28,4 +28,5 @@ index b2775d82d2d7..3c65d3d74559 100644
  	{ .compatible = "dh,dhcom-board", .data = &spidev_of_check },
  	{ .compatible = "lineartechnology,ltc2488", .data = &spidev_of_check },
 -- 
-2.35.3
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/general-add-miniDP-dt-doc.patch
+++ b/patch/kernel/archive/rockchip64-6.3/general-add-miniDP-dt-doc.patch
@@ -1,3 +1,61 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tony <tonymckahan@gmail.com>
+Date: Wed, 3 Mar 2021 07:59:25 +0100
+Subject: [ARCHEOLOGY] RK3399 Typec DP (#2676)
+
+> X-Git-Archeology: > recovered message: > * RK3399 NanoPC-T4 Add Type-C alt mode DP
+> X-Git-Archeology: > recovered message: > * rk3399 rockpi 4C add mini-DP (WIP)
+> X-Git-Archeology: > recovered message: > * [ rockchip64 ] revert rockPi 4C DP patch
+> X-Git-Archeology: > recovered message: > Add an extension to disable it, but leave for future work.
+> X-Git-Archeology: - Revision 4971535c774a1f49a811baebc083ea028ced0300: https://github.com/armbian/build/commit/4971535c774a1f49a811baebc083ea028ced0300
+> X-Git-Archeology:   Date: Wed, 03 Mar 2021 07:59:25 +0100
+> X-Git-Archeology:   From: Tony <tonymckahan@gmail.com>
+> X-Git-Archeology:   Subject: RK3399 Typec DP (#2676)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0cdffb29b07305209efb12cf3b5ac6032d3a1153: https://github.com/armbian/build/commit/0cdffb29b07305209efb12cf3b5ac6032d3a1153
+> X-Git-Archeology:   Date: Wed, 24 Mar 2021 19:01:53 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Renaming DEV branch to EDGE (#2704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ Documentation/devicetree/bindings/extcon/extcon-usbc-virtual-pd.yaml | 66 ++++++++++
+ 1 file changed, 66 insertions(+)
+
 diff --git a/Documentation/devicetree/bindings/extcon/extcon-usbc-virtual-pd.yaml b/Documentation/devicetree/bindings/extcon/extcon-usbc-virtual-pd.yaml
 new file mode 100644
 index 000000000000..8110fbe2ddc2
@@ -70,4 +128,6 @@ index 000000000000..8110fbe2ddc2
 +        vpd-data-role = "display-port";
 +        vpd-super-speed;
 +    };
+-- 
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/general-add-miniDP-virtual-extcon.patch
+++ b/patch/kernel/archive/rockchip64-6.3/general-add-miniDP-virtual-extcon.patch
@@ -1,10 +1,71 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tony <tonymckahan@gmail.com>
+Date: Wed, 3 Mar 2021 07:59:25 +0100
+Subject: [ARCHEOLOGY] RK3399 Typec DP (#2676)
+
+> X-Git-Archeology: > recovered message: > * RK3399 NanoPC-T4 Add Type-C alt mode DP
+> X-Git-Archeology: > recovered message: > * rk3399 rockpi 4C add mini-DP (WIP)
+> X-Git-Archeology: > recovered message: > * [ rockchip64 ] revert rockPi 4C DP patch
+> X-Git-Archeology: > recovered message: > Add an extension to disable it, but leave for future work.
+> X-Git-Archeology: - Revision 4971535c774a1f49a811baebc083ea028ced0300: https://github.com/armbian/build/commit/4971535c774a1f49a811baebc083ea028ced0300
+> X-Git-Archeology:   Date: Wed, 03 Mar 2021 07:59:25 +0100
+> X-Git-Archeology:   From: Tony <tonymckahan@gmail.com>
+> X-Git-Archeology:   Subject: RK3399 Typec DP (#2676)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0cdffb29b07305209efb12cf3b5ac6032d3a1153: https://github.com/armbian/build/commit/0cdffb29b07305209efb12cf3b5ac6032d3a1153
+> X-Git-Archeology:   Date: Wed, 24 Mar 2021 19:01:53 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Renaming DEV branch to EDGE (#2704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ MAINTAINERS                             |   6 +
+ drivers/extcon/Kconfig                  |  10 +
+ drivers/extcon/Makefile                 |   1 +
+ drivers/extcon/extcon-usbc-virtual-pd.c | 285 ++++++++++
+ 4 files changed, 302 insertions(+)
+
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 68f21d46614c..aeb161b19dae 100644
+index c6545eb54104..f548c7896ab4 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
-@@ -6466,6 +6466,12 @@ T:	git git://git.kernel.org/pub/scm/linux/kernel/git/tytso/ext4.git
- F:	Documentation/filesystems/ext4/
+@@ -7729,6 +7729,12 @@ F:	Documentation/filesystems/ext4/
  F:	fs/ext4/
+ F:	include/trace/events/ext4.h
  
 +EXTCON DRIVER FOR TYPE-C VIRTUAL PD
 +M:	Jagan Teki <jagan@amarulasolutions.com>
@@ -16,12 +77,12 @@ index 68f21d46614c..aeb161b19dae 100644
  M:	Mimi Zohar <zohar@linux.ibm.com>
  L:	linux-integrity@vger.kernel.org
 diff --git a/drivers/extcon/Kconfig b/drivers/extcon/Kconfig
-index aac507bff135..edd6c3c52699 100644
+index 290186e44e6b..ac0b6164d88e 100644
 --- a/drivers/extcon/Kconfig
 +++ b/drivers/extcon/Kconfig
-@@ -186,4 +186,14 @@ config EXTCON_USBC_CROS_EC
- 	  Say Y here to enable USB Type C cable detection extcon support when
- 	  using Chrome OS EC based USB Type-C ports.
+@@ -189,4 +189,14 @@ config EXTCON_USBC_TUSB320
+ 	  Say Y here to enable support for USB Type C cable detection extcon
+ 	  support using a TUSB320.
  
 +config EXTCON_USBC_VIRTUAL_PD
 +	tristate "Virtual Type-C PD EXTCON support"
@@ -35,10 +96,10 @@ index aac507bff135..edd6c3c52699 100644
 +
  endif
 diff --git a/drivers/extcon/Makefile b/drivers/extcon/Makefile
-index 52096fd8a216..c35191eef0e1 100644
+index 1b390d934ca9..57c1e65bfcfd 100644
 --- a/drivers/extcon/Makefile
 +++ b/drivers/extcon/Makefile
-@@ -25,3 +25,4 @@ obj-$(CONFIG_EXTCON_RT8973A)	+= extcon-rt8973a.o
+@@ -25,3 +25,4 @@ obj-$(CONFIG_EXTCON_SM5502)	+= extcon-sm5502.o
  obj-$(CONFIG_EXTCON_USB_GPIO)	+= extcon-usb-gpio.o
  obj-$(CONFIG_EXTCON_USBC_CROS_EC) += extcon-usbc-cros-ec.o
  obj-$(CONFIG_EXTCON_USBC_TUSB320) += extcon-usbc-tusb320.o
@@ -334,4 +395,6 @@ index 000000000000..e0713670e33d
 +MODULE_AUTHOR("Jagan Teki <jagan@amarulasolutions.com>");
 +MODULE_DESCRIPTION("Type-C Virtual PD extcon driver");
 +MODULE_LICENSE("GPL v2");
+-- 
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/general-add-overlay-compilation-support.patch
+++ b/patch/kernel/archive/rockchip64-6.3/general-add-overlay-compilation-support.patch
@@ -1,19 +1,347 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zador-blood-stained <zador-blood-stained@users.noreply.github.com>
+Date: Sat, 11 Feb 2017 20:32:53 +0300
+Subject: [ARCHEOLOGY] Rename, split and improve H3 DT overlays
+
+> X-Git-Archeology: > recovered message: > Fix OPi Zero DT
+> X-Git-Archeology: > recovered message: > Improve DT loading reliability
+> X-Git-Archeology: - Revision bacf56710491e3307e0fb2bc1c828dad828c9f23: https://github.com/armbian/build/commit/bacf56710491e3307e0fb2bc1c828dad828c9f23
+> X-Git-Archeology:   Date: Sat, 11 Feb 2017 20:32:53 +0300
+> X-Git-Archeology:   From: zador-blood-stained <zador-blood-stained@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Rename, split and improve H3 DT overlays
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision c7bbc3257e8dcbf75398301602150fe9f1666c86: https://github.com/armbian/build/commit/c7bbc3257e8dcbf75398301602150fe9f1666c86
+> X-Git-Archeology:   Date: Sun, 26 Feb 2017 19:46:15 +0300
+> X-Git-Archeology:   From: zador-blood-stained <zador-blood-stained@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Initial A20 overlays support for sunxi-next kernel
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision caf4b1b037e7510cae7edd1b5f75482eed41b547: https://github.com/armbian/build/commit/caf4b1b037e7510cae7edd1b5f75482eed41b547
+> X-Git-Archeology:   Date: Mon, 13 Mar 2017 20:32:37 +0300
+> X-Git-Archeology:   From: zador-blood-stained <zador-blood-stained@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Add new A20 overlays
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision b30fcea3f95804175199bc1865a7e39cdf07cf73: https://github.com/armbian/build/commit/b30fcea3f95804175199bc1865a7e39cdf07cf73
+> X-Git-Archeology:   Date: Sun, 14 May 2017 17:59:35 +0300
+> X-Git-Archeology:   From: zador-blood-stained <zador-blood-stained@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Update sunxi-next branch to 4.11
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 20240e9669055030076e69452cf6a1ccb368cc2e: https://github.com/armbian/build/commit/20240e9669055030076e69452cf6a1ccb368cc2e
+> X-Git-Archeology:   Date: Tue, 30 May 2017 21:30:38 -0400
+> X-Git-Archeology:   From: Martin Ayotte <martinayotte@yahoo.ca>
+> X-Git-Archeology:   Subject: add overlays to sunxi-dev
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision b0fcb64aaca589359338a500e7bc07eb7ca1cb71: https://github.com/armbian/build/commit/b0fcb64aaca589359338a500e7bc07eb7ca1cb71
+> X-Git-Archeology:   Date: Thu, 07 Dec 2017 07:09:10 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igor.pecovnik@gmail.com>
+> X-Git-Archeology:   Subject: Temporally disabling broken patches on sunxi DEV branch
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 2123e539ed288e3355ef3d3adc79788a187f62df: https://github.com/armbian/build/commit/2123e539ed288e3355ef3d3adc79788a187f62df
+> X-Git-Archeology:   Date: Thu, 15 Feb 2018 11:21:51 +0200
+> X-Git-Archeology:   From: Stefan Mavrodiev <stefan@olimex.com>
+> X-Git-Archeology:   Subject: Add overlays support for upstream kernel
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 2c08ec8f5a210de35f9482f482ac01ea15381792: https://github.com/armbian/build/commit/2c08ec8f5a210de35f9482f482ac01ea15381792
+> X-Git-Archeology:   Date: Thu, 24 May 2018 13:32:29 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igor.pecovnik@gmail.com>
+> X-Git-Archeology:   Subject: Merge sunxi family into stable
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 1a12994e79b6ef173dc58efe4df8919cb6cc7781: https://github.com/armbian/build/commit/1a12994e79b6ef173dc58efe4df8919cb6cc7781
+> X-Git-Archeology:   Date: Tue, 17 Jul 2018 15:53:30 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Moving sunxi-next to 4.17.y (#1049)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision a57ce78b37f8dd2eb94a3836f4a7f6969f2ffd72: https://github.com/armbian/build/commit/a57ce78b37f8dd2eb94a3836f4a7f6969f2ffd72
+> X-Git-Archeology:   Date: Tue, 21 Aug 2018 10:41:10 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Reverting sunxi/sunxi64 NEXT to 4.14. (#1087)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 871bed1a24e21952f7aeb1981c26ad5fc573be9d: https://github.com/armbian/build/commit/871bed1a24e21952f7aeb1981c26ad5fc573be9d
+> X-Git-Archeology:   Date: Tue, 04 Dec 2018 16:25:53 -0500
+> X-Git-Archeology:   From: Martin Ayotte <martinayotte@yahoo.ca>
+> X-Git-Archeology:   Subject: add overlay-compilation-support to meson64-dev
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 7c5fb27d79d1c737fc2ca92a1069226e9aae2154: https://github.com/armbian/build/commit/7c5fb27d79d1c737fc2ca92a1069226e9aae2154
+> X-Git-Archeology:   Date: Wed, 09 Jan 2019 23:33:47 -0500
+> X-Git-Archeology:   From: Thomas McKahan <tonymckahan@gmail.com>
+> X-Git-Archeology:   Subject: [ meson64-next ] Shift Next to 4.19
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 2fa7c680c29a144214706dda35c2a6afdd708858: https://github.com/armbian/build/commit/2fa7c680c29a144214706dda35c2a6afdd708858
+> X-Git-Archeology:   Date: Thu, 21 Mar 2019 14:57:07 -0400
+> X-Git-Archeology:   From: Martin Ayotte <martinayotte@yahoo.ca>
+> X-Git-Archeology:   Subject: fix overlay patch
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision a040785d4299e10255d87fdfcfa70b56e0b6779f: https://github.com/armbian/build/commit/a040785d4299e10255d87fdfcfa70b56e0b6779f
+> X-Git-Archeology:   Date: Sun, 04 Aug 2019 18:05:50 -0400
+> X-Git-Archeology:   From: chwe17 <weberc18@gmail.com>
+> X-Git-Archeology:   Subject: Tinkerboard camera support (#1482)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 150ac0c2afa147d9e3b036c8ecd8238fe5648cf3: https://github.com/armbian/build/commit/150ac0c2afa147d9e3b036c8ecd8238fe5648cf3
+> X-Git-Archeology:   Date: Tue, 19 Nov 2019 23:25:39 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Remove K<4, change branches, new features (#1586)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 23604e8a0dcdf81ec6c28ccd4b2a64b90816d8e7: https://github.com/armbian/build/commit/23604e8a0dcdf81ec6c28ccd4b2a64b90816d8e7
+> X-Git-Archeology:   Date: Fri, 19 Jun 2020 17:27:27 +0200
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: Introducing Rockchip RK322X SoC support (#2032)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 99afbdfe7e08334bb5dde05c4f3dab536e87224e: https://github.com/armbian/build/commit/99afbdfe7e08334bb5dde05c4f3dab536e87224e
+> X-Git-Archeology:   Date: Fri, 26 Jun 2020 15:53:20 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump meson64 current to 5.7.y (#2069)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 812245def37a695bce9e7ece148b2920d82c8b37: https://github.com/armbian/build/commit/812245def37a695bce9e7ece148b2920d82c8b37
+> X-Git-Archeology:   Date: Sat, 18 Jul 2020 23:07:01 +0200
+> X-Git-Archeology:   From: Werner <EvilOlaf@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Move rockchip/64 current to 5.7.y (#2099)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision caa47bad650f82cb8045d19c384595b1760bd9e1: https://github.com/armbian/build/commit/caa47bad650f82cb8045d19c384595b1760bd9e1
+> X-Git-Archeology:   Date: Sat, 18 Jul 2020 23:08:52 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Move sunxi/64 current to 5.7, legacy to 5.4 (#2098)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 804a6b60d4c2724ada9eb975e3caf2d9753beba9: https://github.com/armbian/build/commit/804a6b60d4c2724ada9eb975e3caf2d9753beba9
+> X-Git-Archeology:   Date: Fri, 28 Aug 2020 18:48:55 +0200
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: Moved rk322x-dev to rk322x-current (current now is 5.7.y) (#2153)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 661371868def63655e46e8c513d8ba0f42cf4066: https://github.com/armbian/build/commit/661371868def63655e46e8c513d8ba0f42cf4066
+> X-Git-Archeology:   Date: Fri, 28 Aug 2020 19:26:08 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Enable overlays for rk3399-legacy (#2144)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 4cdf3c3d0e31fb9fa05d9b818915d54c465dffa0: https://github.com/armbian/build/commit/4cdf3c3d0e31fb9fa05d9b818915d54c465dffa0
+> X-Git-Archeology:   Date: Sun, 18 Oct 2020 14:43:30 -0400
+> X-Git-Archeology:   From: tonymac32 <tonymckahan@gmail.com>
+> X-Git-Archeology:   Subject: [ rockchip ] add overlay compilation support
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0cdffb29b07305209efb12cf3b5ac6032d3a1153: https://github.com/armbian/build/commit/0cdffb29b07305209efb12cf3b5ac6032d3a1153
+> X-Git-Archeology:   Date: Wed, 24 Mar 2021 19:01:53 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Renaming DEV branch to EDGE (#2704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 3b3d85e25c2ecde30df7b5274fc6f1b9c0299ea2: https://github.com/armbian/build/commit/3b3d85e25c2ecde30df7b5274fc6f1b9c0299ea2
+> X-Git-Archeology:   Date: Sat, 22 May 2021 17:08:44 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Upgrade EDGE to 5.12.y (#2825)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e21e82b546d3817e69ec062bb1e56c63c33e9c21: https://github.com/armbian/build/commit/e21e82b546d3817e69ec062bb1e56c63c33e9c21
+> X-Git-Archeology:   Date: Wed, 21 Jul 2021 00:46:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Upgrading sunxi, sunxi64, imx6, jetson-nano, mvebu and mvebu64 EDGE to 5.13 (#3042)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e7377248b3cae186e24e2be781cd3365b43246f0: https://github.com/armbian/build/commit/e7377248b3cae186e24e2be781cd3365b43246f0
+> X-Git-Archeology:   Date: Thu, 22 Jul 2021 00:15:54 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Second part of EDGE bumping to 5.13.y (#3045)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 744ea89a589d62cb6f409baab60fc6664520bc39: https://github.com/armbian/build/commit/744ea89a589d62cb6f409baab60fc6664520bc39
+> X-Git-Archeology:   Date: Wed, 08 Sep 2021 17:51:34 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bumping EDGE kernel to 5.14.y (#3125)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision f15bc37276f8a06c024628b41905a7255934e93b: https://github.com/armbian/build/commit/f15bc37276f8a06c024628b41905a7255934e93b
+> X-Git-Archeology:   Date: Sat, 11 Sep 2021 12:51:28 +0000
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rk322x: add back edge kernel patches lost in the process, hardware cursor dedicated plane
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e: https://github.com/armbian/build/commit/dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e
+> X-Git-Archeology:   Date: Tue, 09 Nov 2021 18:06:34 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump imx6, xu4, rockchip64 and jetson-nano to 5.15 (#3238)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 4c3dcbf4fcd3616999cb91a1dddfa74668eb6de9: https://github.com/armbian/build/commit/4c3dcbf4fcd3616999cb91a1dddfa74668eb6de9
+> X-Git-Archeology:   Date: Tue, 09 Nov 2021 21:58:35 +0100
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: Rockchip 5.15 (#3242)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6b490e16944b30ff69bf9c13678905187df0d9d4: https://github.com/armbian/build/commit/6b490e16944b30ff69bf9c13678905187df0d9d4
+> X-Git-Archeology:   Date: Tue, 11 Jan 2022 15:26:11 +0100
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: move kernel edge to 5.16 (#3387)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 1e37959e5381a0a1d1eaf0629cdc19658f30df9a: https://github.com/armbian/build/commit/1e37959e5381a0a1d1eaf0629cdc19658f30df9a
+> X-Git-Archeology:   Date: Thu, 10 Feb 2022 20:32:58 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bumping sunxi/64, xu4, rockchip and mvebu64 to 5.16.y (#3453)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision f52a4193d02ef88333ba117c68d49486dfd7ff41: https://github.com/armbian/build/commit/f52a4193d02ef88333ba117c68d49486dfd7ff41
+> X-Git-Archeology:   Date: Sun, 20 Mar 2022 22:58:21 +0100
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: Adding Pine64 Quartz64a as WIP target (#3539)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 2fe1ddfe451d3a3dba01e4ba1204d2b9fe7eb44e: https://github.com/armbian/build/commit/2fe1ddfe451d3a3dba01e4ba1204d2b9fe7eb44e
+> X-Git-Archeology:   Date: Sat, 26 Mar 2022 17:59:23 +0000
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip: add tinkerboard overlays for current 5.15 kernel
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0777be9e754c8bd24cff0297226b5158564bbc96: https://github.com/armbian/build/commit/0777be9e754c8bd24cff0297226b5158564bbc96
+> X-Git-Archeology:   Date: Sun, 10 Apr 2022 16:45:06 +0200
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rk322x: move edge flavour to kernel 5.17, adapt patches were necessary
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 49b2aba89124b15a0f6b81ccf44b3792b6b35497: https://github.com/armbian/build/commit/49b2aba89124b15a0f6b81ccf44b3792b6b35497
+> X-Git-Archeology:   Date: Mon, 11 Apr 2022 22:05:28 +0200
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip: copy patch archive from 5.16 to 5.17
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0afe24c95729044910e0b3f84dc5500bcdc6524c: https://github.com/armbian/build/commit/0afe24c95729044910e0b3f84dc5500bcdc6524c
+> X-Git-Archeology:   Date: Sun, 24 Apr 2022 22:33:47 +0200
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: move kernel media edge to 5.17 (#3704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 3c4189e311ca60427d47dae796620a9fc98dc1f3: https://github.com/armbian/build/commit/3c4189e311ca60427d47dae796620a9fc98dc1f3
+> X-Git-Archeology:   Date: Sun, 29 May 2022 17:15:36 +0200
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip: upgrade edge kernel to v5.18 (#3842)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 809ce98a75163e3d37cffae811e1d19fd0758ef4: https://github.com/armbian/build/commit/809ce98a75163e3d37cffae811e1d19fd0758ef4
+> X-Git-Archeology:   Date: Sun, 29 May 2022 17:26:16 +0200
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rk322x: move edge kernel to v5.18 (#3844)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision d064b2dce2a58299bff98e8ccb275fec861777e9: https://github.com/armbian/build/commit/d064b2dce2a58299bff98e8ccb275fec861777e9
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 19:10:25 +0200
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rk322x: advance edge kernel to 5.19
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision c87542aba26b01703746d3db94ac0820575b23b2: https://github.com/armbian/build/commit/c87542aba26b01703746d3db94ac0820575b23b2
+> X-Git-Archeology:   Date: Thu, 04 Aug 2022 11:20:06 +0200
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip: switch edge kernel to v5.19 (#4045)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 73691a9e24440e0a8104b2c25d168ba8947a10ad: https://github.com/armbian/build/commit/73691a9e24440e0a8104b2c25d168ba8947a10ad
+> X-Git-Archeology:   Date: Thu, 04 Aug 2022 21:50:40 +0200
+> X-Git-Archeology:   From: Ricardo Pardini <ricardo@pardini.net>
+> X-Git-Archeology:   Subject: meson64: edge: rework to kernel 5.19 (#3941)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 1b12209ded2c356df514e3dd99bd945c0afd7a32: https://github.com/armbian/build/commit/1b12209ded2c356df514e3dd99bd945c0afd7a32
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 20:38:31 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump meson64 edge to 6.0.y (#4341)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 35db7a3995d0d6e92638a0ed173e7252a927e339: https://github.com/armbian/build/commit/35db7a3995d0d6e92638a0ed173e7252a927e339
+> X-Git-Archeology:   Date: Tue, 15 Nov 2022 20:19:17 +0100
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rk322x: bump kernel to 6.0 (#4443)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ed2c6d3c6764e9da4f54cb3b210e5106864dfa0f: https://github.com/armbian/build/commit/ed2c6d3c6764e9da4f54cb3b210e5106864dfa0f
+> X-Git-Archeology:   Date: Tue, 15 Nov 2022 20:22:47 +0100
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip: advance edge kernel to v6.0 (#4445)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 5b46bd7273909a2a9688efe85c4d45d00d407865: https://github.com/armbian/build/commit/5b46bd7273909a2a9688efe85c4d45d00d407865
+> X-Git-Archeology:   Date: Mon, 12 Dec 2022 08:02:25 +0100
+> X-Git-Archeology:   From: Ricardo Pardini <ricardo@pardini.net>
+> X-Git-Archeology:   Subject: `meson64-6.0` kernel patches: mbox formatting, archeology to find lost authors/descriptions; rebase against 6.0.12; no actual changes (#4546)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision eb7d4a0bd20e56118f9c8c9089c063154c58a239: https://github.com/armbian/build/commit/eb7d4a0bd20e56118f9c8c9089c063154c58a239
+> X-Git-Archeology:   Date: Mon, 12 Dec 2022 08:02:49 +0100
+> X-Git-Archeology:   From: Ricardo Pardini <ricardo@pardini.net>
+> X-Git-Archeology:   Subject: `meson64`: bump `edge` to `6.1-rc8` (#4554)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision c0001d566b3770dae722c47180dcb942bed7006a: https://github.com/armbian/build/commit/c0001d566b3770dae722c47180dcb942bed7006a
+> X-Git-Archeology:   Date: Wed, 14 Dec 2022 01:43:31 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump bcm, imx, mvebu64 and xu4 EDGE to 6.1.y (#4560)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 80dffbc7611bd76d675fcf74d352e1c55ce51f29: https://github.com/armbian/build/commit/80dffbc7611bd76d675fcf74d352e1c55ce51f29
+> X-Git-Archeology:   Date: Tue, 10 Jan 2023 00:31:35 +0100
+> X-Git-Archeology:   From: Ricardo Pardini <ricardo@pardini.net>
+> X-Git-Archeology:   Subject: `meson64`: `edge`: bump to `6.2` - copy patches as-is from 6.1
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0ea5a3547b393059da92da9925a76bccef93631a: https://github.com/armbian/build/commit/0ea5a3547b393059da92da9925a76bccef93631a
+> X-Git-Archeology:   Date: Tue, 10 Jan 2023 00:31:41 +0100
+> X-Git-Archeology:   From: Ricardo Pardini <ricardo@pardini.net>
+> X-Git-Archeology:   Subject: `meson64`: `edge`: bump to `6.2` - rebased patches against tag `v6.2-rc3`
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8652bf3d37c9d9f7d87588dc1f97e82626dac489: https://github.com/armbian/build/commit/8652bf3d37c9d9f7d87588dc1f97e82626dac489
+> X-Git-Archeology:   Date: Sun, 12 Feb 2023 21:20:35 +0100
+> X-Git-Archeology:   From: Joao Assuncao <joao@joaoassuncao.com>
+> X-Git-Archeology:   Subject: Adds SPI, I2C, and PWM DTS overlays for odroid-m1 (#4825)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 3f704692a7933a67b5e8cc6ff690d92ef3a5e735: https://github.com/armbian/build/commit/3f704692a7933a67b5e8cc6ff690d92ef3a5e735
+> X-Git-Archeology:   Date: Fri, 24 Mar 2023 23:12:56 +0100
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip: bump edge kernel to 6.2
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 5930e5e536d6b2f1a1446b8910648d7b0183919e: https://github.com/armbian/build/commit/5930e5e536d6b2f1a1446b8910648d7b0183919e
+> X-Git-Archeology:   Date: Fri, 24 Mar 2023 23:14:09 +0100
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rk322x: move edge kernel to 6.2
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 98b6aec55439c5aa8cee13898451e0969f7df9ce: https://github.com/armbian/build/commit/98b6aec55439c5aa8cee13898451e0969f7df9ce
+> X-Git-Archeology:   Date: Thu, 27 Apr 2023 21:30:02 +0200
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rk322x: bump edge kernel to 6.3
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision da0ab48b7939235608c8fc042c61ae997681e865: https://github.com/armbian/build/commit/da0ab48b7939235608c8fc042c61ae997681e865
+> X-Git-Archeology:   Date: Thu, 27 Apr 2023 21:31:27 +0200
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip: bump edge kernel to 6.3
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 7a5cd0b246d3f0ae5949b6afa5a59081bd2376e9: https://github.com/armbian/build/commit/7a5cd0b246d3f0ae5949b6afa5a59081bd2376e9
+> X-Git-Archeology:   Date: Sat, 29 Apr 2023 07:46:18 +0200
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip: fix dtbs_install step for overlays
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm/boot/.gitignore |  2 +
+ scripts/Makefile.dtbinst | 14 ++++++-
+ scripts/Makefile.lib     | 20 ++++++++++
+ 3 files changed, 35 insertions(+), 1 deletion(-)
+
 diff --git a/arch/arm/boot/.gitignore b/arch/arm/boot/.gitignore
-index 3c79f859..4e5c1d59 100644
+index 8c759326baf4..e6ce8f6ad4b1 100644
 --- a/arch/arm/boot/.gitignore
 +++ b/arch/arm/boot/.gitignore
-@@ -3,3 +3,5 @@ zImage
+@@ -4,3 +4,5 @@ zImage
  xipImage
  bootpImage
  uImage
 +*.dtb*
 +*.scr
 diff --git a/scripts/Makefile.dtbinst b/scripts/Makefile.dtbinst
-index 50d580d77..94bd15617 100644
+index 2ab936e4179d..39a199e5e9b4 100644
 --- a/scripts/Makefile.dtbinst
 +++ b/scripts/Makefile.dtbinst
-@@ -18,9 +18,12 @@ include scripts/Kbuild.include
- include $(src)/Makefile
+@@ -18,9 +18,12 @@ include $(srctree)/scripts/Kbuild.include
+ include $(kbuild-file)
  
  dtbs    := $(addprefix $(dst)/, $(dtb-y) $(if $(CONFIG_OF_ALL_DTBS),$(dtb-)))
 +dtbos   := $(addprefix $(dst)/, $(dtbo-y))
@@ -26,8 +354,8 @@ index 50d580d77..94bd15617 100644
  	@:
  
  quiet_cmd_dtb_install = INSTALL $@
-@@ -29,6 +32,15 @@ quiet_cmd_dtb_install = INSTALL $@
- $(dst)/%.dtb: $(obj)/%.dtb
+@@ -32,6 +35,15 @@ $(dst)/%.dtb: $(obj)/%.dtb
+ $(dst)/%.dtbo: $(obj)/%.dtbo
  	$(call cmd,dtb_install)
  
 +$(dst)/%.dtbo: $(obj)/%.dtbo
@@ -43,23 +371,23 @@ index 50d580d77..94bd15617 100644
  $(subdirs):
  	$(Q)$(MAKE) $(dtbinst)=$@ dst=$(patsubst $(obj)/%,$(dst)/%,$@)
 diff --git a/scripts/Makefile.lib b/scripts/Makefile.lib
-index 58c05e5d..2b95dda9 100644
+index 100a386fcd71..1680499136ee 100644
 --- a/scripts/Makefile.lib
 +++ b/scripts/Makefile.lib
-@@ -278,6 +278,9 @@ cmd_gzip = (cat $(filter-out FORCE,$^) | gzip -n -f -9 > $@) || \
- # ---------------------------------------------------------------------------
- DTC ?= $(objtree)/scripts/dtc/dtc
-
+@@ -343,6 +343,9 @@ DTC ?= $(objtree)/scripts/dtc/dtc
+ DTC_FLAGS += -Wno-interrupt_provider \
+ 	-Wno-unique_unit_address
+ 
 +# Overlay support
 +DTC_FLAGS += -@ -Wno-unit_address_format -Wno-simple_bus_reg
 +
  # Disable noisy checks by default
- ifeq ($(KBUILD_ENABLE_EXTRA_GCC_CHECKS),)
+ ifeq ($(findstring 1,$(KBUILD_EXTRA_WARN)),)
  DTC_FLAGS += -Wno-unit_address_vs_reg \
-@@ -324,6 +327,23 @@ cmd_dtc = mkdir -p $(dir ${dtc-tmp}) ; \
- $(obj)/%.dtb: $(src)/%.dts FORCE
+@@ -424,6 +427,23 @@ $(obj)/%.dtbo: $(src)/%.dts $(DTC) FORCE
+ $(obj)/%.dtbo: $(src)/%.dtso $(DTC) FORCE
  	$(call if_changed_dep,dtc)
-
+ 
 +quiet_cmd_dtco = DTCO    $@
 +cmd_dtco = mkdir -p $(dir ${dtc-tmp}) ; \
 +	$(CPP) $(dtc_cpp_flags) -x assembler-with-cpp -o $(dtc-tmp) $< ; \
@@ -78,5 +406,8 @@ index 58c05e5d..2b95dda9 100644
 +	$(call if_changed,scr)
 +
  dtc-tmp = $(subst $(comma),_,$(dot-target).dts.tmp)
-
+ 
  # Bzip2
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/general-add-overlay-configfs.patch
+++ b/patch/kernel/archive/rockchip64-6.3/general-add-overlay-configfs.patch
@@ -1,7 +1,7 @@
-From 2959948b2a17f92e0ddc2e3cc9742eac7541461d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: schwar3kat <61094841+schwar3kat@users.noreply.github.com>
 Date: Mon, 16 Jan 2023 22:57:26 +1300
-Subject: [PATCH] OF: DT-Overlay configfs interface
+Subject: OF: DT-Overlay configfs interface
 
 Commit message: Clean up mbox format in general-add-overlay-configfs.patch. No diff changes.
 
@@ -29,17 +29,15 @@ Changes since v1:
 Signed-off-by: Pantelis Antoniou <pantelis.antoniou@konsulko.com>
 Signed-off-by: Phil Elwell <phil@raspberrypi.org>
 ---
- .../devicetree/configfs-overlays.txt          |  31 ++
- drivers/of/Kconfig                            |   7 +
- drivers/of/Makefile                           |   1 +
- drivers/of/configfs.c                         | 290 ++++++++++++++++++
+ Documentation/devicetree/configfs-overlays.txt |  31 +
+ drivers/of/Kconfig                             |   7 +
+ drivers/of/Makefile                            |   1 +
+ drivers/of/configfs.c                          | 290 ++++++++++
  4 files changed, 329 insertions(+)
- create mode 100644 Documentation/devicetree/configfs-overlays.txt
- create mode 100644 drivers/of/configfs.c
 
 diff --git a/Documentation/devicetree/configfs-overlays.txt b/Documentation/devicetree/configfs-overlays.txt
 new file mode 100644
-index 000000000..5fa43e064
+index 000000000000..5fa43e064307
 --- /dev/null
 +++ b/Documentation/devicetree/configfs-overlays.txt
 @@ -0,0 +1,31 @@
@@ -75,10 +73,10 @@ index 000000000..5fa43e064
 +intended to be used by hardware managers in the kernel, while the copy interface
 +make sense for developers (since it avoids problems with namespaces).
 diff --git a/drivers/of/Kconfig b/drivers/of/Kconfig
-index 80b5fd44a..14c2ce96e 100644
+index 644386833a7b..622237fd6145 100644
 --- a/drivers/of/Kconfig
 +++ b/drivers/of/Kconfig
-@@ -94,4 +94,11 @@ config OF_DMA_DEFAULT_COHERENT
+@@ -106,4 +106,11 @@ config OF_DMA_DEFAULT_COHERENT
  	# arches should select this if DMA is coherent by default for OF devices
  	bool
  
@@ -91,7 +89,7 @@ index 80b5fd44a..14c2ce96e 100644
 +
  endif # OF
 diff --git a/drivers/of/Makefile b/drivers/of/Makefile
-index e0360a443..90c92ced2 100644
+index e0360a44306e..90c92ced24e6 100644
 --- a/drivers/of/Makefile
 +++ b/drivers/of/Makefile
 @@ -1,6 +1,7 @@
@@ -104,7 +102,7 @@ index e0360a443..90c92ced2 100644
  obj-$(CONFIG_OF_EARLY_FLATTREE) += fdt_address.o
 diff --git a/drivers/of/configfs.c b/drivers/of/configfs.c
 new file mode 100644
-index 000000000..5dd509e8f
+index 000000000000..5dd509e8fc87
 --- /dev/null
 +++ b/drivers/of/configfs.c
 @@ -0,0 +1,290 @@
@@ -399,5 +397,5 @@ index 000000000..5dd509e8f
 +}
 +late_initcall(of_cfs_init);
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/general-add-panel-simple-dsi.patch
+++ b/patch/kernel/archive/rockchip64-6.3/general-add-panel-simple-dsi.patch
@@ -1,18 +1,81 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: simple <991605149@qq.com>
+Date: Sun, 12 Sep 2021 20:06:02 +0200
+Subject: [ARCHEOLOGY] general add panel simple dsi (#3140)
+
+> X-Git-Archeology: > recovered message: > * Backporting patch to 5.10 kernel makes sense. Lets do it.
+> X-Git-Archeology: > recovered message: > Co-authored-by: iamdrq <iamdrq@qq.com>
+> X-Git-Archeology: > recovered message: > Co-authored-by: Igor Pecovnik <igor.pecovnik@gmail.com>
+> X-Git-Archeology: - Revision 15819f00e21238e36ca70f6d8445efd6157fbe66: https://github.com/armbian/build/commit/15819f00e21238e36ca70f6d8445efd6157fbe66
+> X-Git-Archeology:   Date: Sun, 12 Sep 2021 20:06:02 +0200
+> X-Git-Archeology:   From: simple <991605149@qq.com>
+> X-Git-Archeology:   Subject: general add panel simple dsi (#3140)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e: https://github.com/armbian/build/commit/dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e
+> X-Git-Archeology:   Date: Tue, 09 Nov 2021 18:06:34 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump imx6, xu4, rockchip64 and jetson-nano to 5.15 (#3238)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6b490e16944b30ff69bf9c13678905187df0d9d4: https://github.com/armbian/build/commit/6b490e16944b30ff69bf9c13678905187df0d9d4
+> X-Git-Archeology:   Date: Tue, 11 Jan 2022 15:26:11 +0100
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: move kernel edge to 5.16 (#3387)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 3b78b57fe367e60ad874d9e16ff1cd67957f8382: https://github.com/armbian/build/commit/3b78b57fe367e60ad874d9e16ff1cd67957f8382
+> X-Git-Archeology:   Date: Sat, 24 Dec 2022 09:43:51 +0100
+> X-Git-Archeology:   From: simple <991605149@qq.com>
+> X-Git-Archeology:   Subject: Fix general-add-panel-simple-dsi.patch on linux6.1 (#4607)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ drivers/gpu/drm/panel/Makefile           |   1 +
+ drivers/gpu/drm/panel/panel-simple-dsi.c | 772 ++++++++++
+ 2 files changed, 773 insertions(+)
+
 diff --git a/drivers/gpu/drm/panel/Makefile b/drivers/gpu/drm/panel/Makefile
-index 42a7ab542..822999710 100644
+index c05aa9e23907..7bdeb4f8ce3e 100644
 --- a/drivers/gpu/drm/panel/Makefile
 +++ b/drivers/gpu/drm/panel/Makefile
-@@ -8,6 +8,7 @@ obj-$(CONFIG_DRM_PANEL_BOE_TV101WUM_NL6) += panel-boe-tv101wum-nl6.o
+@@ -9,6 +9,7 @@ obj-$(CONFIG_DRM_PANEL_BOE_TV101WUM_NL6) += panel-boe-tv101wum-nl6.o
  obj-$(CONFIG_DRM_PANEL_DSI_CM) += panel-dsi-cm.o
  obj-$(CONFIG_DRM_PANEL_LVDS) += panel-lvds.o
  obj-$(CONFIG_DRM_PANEL_SIMPLE) += panel-simple.o
 +obj-$(CONFIG_DRM_PANEL_SIMPLE) += panel-simple-dsi.o
  obj-$(CONFIG_DRM_PANEL_EDP) += panel-edp.o
+ obj-$(CONFIG_DRM_PANEL_EBBG_FT8719) += panel-ebbg-ft8719.o
  obj-$(CONFIG_DRM_PANEL_ELIDA_KD35T133) += panel-elida-kd35t133.o
- obj-$(CONFIG_DRM_PANEL_FEIXIN_K101_IM2BA02) += panel-feixin-k101-im2ba02.o
 diff --git a/drivers/gpu/drm/panel/panel-simple-dsi.c b/drivers/gpu/drm/panel/panel-simple-dsi.c
 new file mode 100644
-index 000000000..906d40ebe
+index 000000000000..e3c8dcf8cb5e
 --- /dev/null
 +++ b/drivers/gpu/drm/panel/panel-simple-dsi.c
 @@ -0,0 +1,772 @@
@@ -788,3 +851,6 @@ index 000000000..906d40ebe
 +MODULE_AUTHOR("iamdrq <iamdrq@qq.com>");
 +MODULE_DESCRIPTION("DRM Driver for DSI Simple Panels");
 +MODULE_LICENSE("GPL");
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/general-add-pll-hdmi-timings.patch
+++ b/patch/kernel/archive/rockchip64-6.3/general-add-pll-hdmi-timings.patch
@@ -1,5 +1,75 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: paolo <paolo.sabatino@gmail.com>
+Date: Sun, 17 Jan 2021 10:20:21 +0000
+Subject: [ARCHEOLOGY] Adding pll hdmi timing to rockchip64-dev too
+
+> X-Git-Archeology: > recovered message: > Fixed rk3328 mali node, shortening memory range to 0x30000 as per-stated in official documentation
+> X-Git-Archeology: - Revision 3a037e899b06452043e23cd2a17f40fe1a932c5f: https://github.com/armbian/build/commit/3a037e899b06452043e23cd2a17f40fe1a932c5f
+> X-Git-Archeology:   Date: Sun, 17 Jan 2021 10:20:21 +0000
+> X-Git-Archeology:   From: paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: Adding pll hdmi timing to rockchip64-dev too
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0cdffb29b07305209efb12cf3b5ac6032d3a1153: https://github.com/armbian/build/commit/0cdffb29b07305209efb12cf3b5ac6032d3a1153
+> X-Git-Archeology:   Date: Wed, 24 Mar 2021 19:01:53 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Renaming DEV branch to EDGE (#2704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e7377248b3cae186e24e2be781cd3365b43246f0: https://github.com/armbian/build/commit/e7377248b3cae186e24e2be781cd3365b43246f0
+> X-Git-Archeology:   Date: Thu, 22 Jul 2021 00:15:54 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Second part of EDGE bumping to 5.13.y (#3045)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 744ea89a589d62cb6f409baab60fc6664520bc39: https://github.com/armbian/build/commit/744ea89a589d62cb6f409baab60fc6664520bc39
+> X-Git-Archeology:   Date: Wed, 08 Sep 2021 17:51:34 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bumping EDGE kernel to 5.14.y (#3125)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e: https://github.com/armbian/build/commit/dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e
+> X-Git-Archeology:   Date: Tue, 09 Nov 2021 18:06:34 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump imx6, xu4, rockchip64 and jetson-nano to 5.15 (#3238)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ drivers/phy/rockchip/phy-rockchip-inno-hdmi.c | 71 ++++++++++
+ 1 file changed, 71 insertions(+)
+
 diff --git a/drivers/phy/rockchip/phy-rockchip-inno-hdmi.c b/drivers/phy/rockchip/phy-rockchip-inno-hdmi.c
-index 9ca20c947..ca91a01f3 100644
+index 80acca4e9e14..2643de0344d3 100644
 --- a/drivers/phy/rockchip/phy-rockchip-inno-hdmi.c
 +++ b/drivers/phy/rockchip/phy-rockchip-inno-hdmi.c
 @@ -316,6 +316,77 @@ static const struct pre_pll_config pre_pll_cfg_table[] = {
@@ -80,3 +150,6 @@ index 9ca20c947..ca91a01f3 100644
  	{ /* sentinel */ }
  };
  
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/general-add-xtx-spi-nor-chips.patch
+++ b/patch/kernel/archive/rockchip64-6.3/general-add-xtx-spi-nor-chips.patch
@@ -1,7 +1,7 @@
-From 5e308ec7332d01e84a3a5233f4cb8bd5a00026cf Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: microcai <microcaicai@gmail.com>
 Date: Mon, 29 Jun 2020 23:36:40 +0800
-Subject: [PATCH] spi-nor: Add support for xt25f32b/xt25f128b
+Subject: spi-nor: Add support for xt25f32b/xt25f128b
 
 The RockPi4b dev board ship with xt25f32b solded. add these ids so the
 board's spi flash can be accessed within linux.
@@ -9,15 +9,16 @@ board's spi flash can be accessed within linux.
 Signed-off-by: microcai <microcaicai@gmail.com>
 ---
  drivers/mtd/spi-nor/Makefile |  1 +
- drivers/mtd/spi-nor/xtx.c    | 21 +++++++++++++++++++++
- 2 files changed, 22 insertions(+)
- create mode 100644 drivers/mtd/spi-nor/xtx.c
+ drivers/mtd/spi-nor/core.c   |  1 +
+ drivers/mtd/spi-nor/core.h   |  1 +
+ drivers/mtd/spi-nor/xtx.c    | 21 ++++++++++
+ 4 files changed, 24 insertions(+)
 
 diff --git a/drivers/mtd/spi-nor/Makefile b/drivers/mtd/spi-nor/Makefile
-index 653923896..3f7a52d7f 100644
+index e347b435a038..364413da729b 100644
 --- a/drivers/mtd/spi-nor/Makefile
 +++ b/drivers/mtd/spi-nor/Makefile
-@@ -17,6 +17,7 @@ spi-nor-objs			+= sst.o
+@@ -18,6 +18,7 @@ spi-nor-objs			+= winbond.o
  spi-nor-objs			+= xilinx.o
  spi-nor-objs			+= xmc.o
  spi-nor-$(CONFIG_DEBUG_FS)	+= debugfs.o
@@ -26,32 +27,32 @@ index 653923896..3f7a52d7f 100644
  
  obj-$(CONFIG_MTD_SPI_NOR)	+= controllers/
 diff --git a/drivers/mtd/spi-nor/core.c b/drivers/mtd/spi-nor/core.c
-index cc68ea843..a469ba0b2 100644
+index 522d375aeccf..3decd7d254e9 100644
 --- a/drivers/mtd/spi-nor/core.c
 +++ b/drivers/mtd/spi-nor/core.c
-@@ -2024,6 +2024,7 @@ static const struct spi_nor_manufacturer *manufacturers[] = {
+@@ -1632,6 +1632,7 @@ static const struct spi_nor_manufacturer *manufacturers[] = {
  	&spi_nor_winbond,
  	&spi_nor_xilinx,
  	&spi_nor_xmc,
 +	&spi_nor_xtx,
  };
  
- static const struct flash_info *
+ static const struct flash_info spi_nor_generic_flash = {
 diff --git a/drivers/mtd/spi-nor/core.h b/drivers/mtd/spi-nor/core.h
-index 6f2f6b271..cea8c0c25 100644
+index e0cc42a4a0c8..575e37d4dcef 100644
 --- a/drivers/mtd/spi-nor/core.h
 +++ b/drivers/mtd/spi-nor/core.h
-@@ -398,6 +398,7 @@ extern const struct spi_nor_manufacturer spi_nor_sst;
+@@ -626,6 +626,7 @@ extern const struct spi_nor_manufacturer spi_nor_sst;
  extern const struct spi_nor_manufacturer spi_nor_winbond;
  extern const struct spi_nor_manufacturer spi_nor_xilinx;
  extern const struct spi_nor_manufacturer spi_nor_xmc;
 +extern const struct spi_nor_manufacturer spi_nor_xtx;
  
- int spi_nor_write_enable(struct spi_nor *nor);
- int spi_nor_write_disable(struct spi_nor *nor);
+ extern const struct attribute_group *spi_nor_sysfs_groups[];
+ 
 diff --git a/drivers/mtd/spi-nor/xtx.c b/drivers/mtd/spi-nor/xtx.c
 new file mode 100644
-index 000000000000..05f2d69401b2
+index 000000000000..5a7ec40c9701
 --- /dev/null
 +++ b/drivers/mtd/spi-nor/xtx.c
 @@ -0,0 +1,21 @@
@@ -76,3 +77,6 @@ index 000000000000..05f2d69401b2
 + .parts = xtx_parts,
 + .nparts = ARRAY_SIZE(xtx_parts),
 +};
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/general-disable-mtu-validation.patch
+++ b/patch/kernel/archive/rockchip64-6.3/general-disable-mtu-validation.patch
@@ -1,7 +1,7 @@
-From bf80eaa34a1b9f503a779b13deed2fda642a1e87 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Igor Pecovnik <igor.pecovnik@gmail.com>
 Date: Wed, 21 Jul 2021 20:59:39 +0000
-Subject: [PATCH] Disable MTU validation
+Subject: Disable MTU validation
 
 This patch reverts: https://github.com/torvalds/linux/commit/eaf4fac478077d4ed57cbca2c044c4b58a96bd98
 
@@ -11,14 +11,14 @@ It works around following issues:
 Signed-off-by: Piotr Szczepanik <piter75@gmail.com>
 Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
 ---
- drivers/net/ethernet/stmicro/stmmac/stmmac_main.c | 12 ------------
+ drivers/net/ethernet/stmicro/stmmac/stmmac_main.c | 12 ----------
  1 file changed, 12 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index 9083159b9..bbd7e2b8e 100644
+index d7fcab057032..ce8467d6ea02 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-@@ -5564,27 +5564,15 @@ static void stmmac_set_rx_mode(struct net_device *dev)
+@@ -5575,27 +5575,15 @@ static void stmmac_set_rx_mode(struct net_device *dev)
  static int stmmac_change_mtu(struct net_device *dev, int new_mtu)
  {
  	struct stmmac_priv *priv = netdev_priv(dev);
@@ -47,4 +47,5 @@ index 9083159b9..bbd7e2b8e 100644
  		netdev_dbg(priv->dev, "restarting interface to change its MTU\n");
  		/* Try to allocate the new DMA conf with the new mtu */
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/general-fix-es8316-kernel-panic.patch
+++ b/patch/kernel/archive/rockchip64-6.3/general-fix-es8316-kernel-panic.patch
@@ -1,6 +1,97 @@
---- a/sound/soc/codecs/es8316.c	2020-04-09 19:13:08.268473737 +0000
-+++ b/sound/soc/codecs/es8316.c	2020-04-09 19:14:00.535995842 +0000
-@@ -687,7 +687,7 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yannick Adam <yannick.adam@gmail.com>
+Date: Tue, 14 Apr 2020 17:15:09 +0200
+Subject: [ARCHEOLOGY] Enable es8316 on RockPi4 (#1885)
+
+> X-Git-Archeology: - Revision 454038a50d1d24e636626213ad65b3463d632aa0: https://github.com/armbian/build/commit/454038a50d1d24e636626213ad65b3463d632aa0
+> X-Git-Archeology:   Date: Tue, 14 Apr 2020 17:15:09 +0200
+> X-Git-Archeology:   From: Yannick Adam <yannick.adam@gmail.com>
+> X-Git-Archeology:   Subject: Enable es8316 on RockPi4 (#1885)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision bd486c75623e75bdf2bdcaf09dc5a0affe9706c1: https://github.com/armbian/build/commit/bd486c75623e75bdf2bdcaf09dc5a0affe9706c1
+> X-Git-Archeology:   Date: Tue, 14 Apr 2020 20:14:24 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igor.pecovnik@gmail.com>
+> X-Git-Archeology:   Subject: Enable es8316 on RockPi4 for Rockchip64 current too https://github.com/armbian/build/pull/1885
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0cdffb29b07305209efb12cf3b5ac6032d3a1153: https://github.com/armbian/build/commit/0cdffb29b07305209efb12cf3b5ac6032d3a1153
+> X-Git-Archeology:   Date: Wed, 24 Mar 2021 19:01:53 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Renaming DEV branch to EDGE (#2704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e7377248b3cae186e24e2be781cd3365b43246f0: https://github.com/armbian/build/commit/e7377248b3cae186e24e2be781cd3365b43246f0
+> X-Git-Archeology:   Date: Thu, 22 Jul 2021 00:15:54 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Second part of EDGE bumping to 5.13.y (#3045)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 744ea89a589d62cb6f409baab60fc6664520bc39: https://github.com/armbian/build/commit/744ea89a589d62cb6f409baab60fc6664520bc39
+> X-Git-Archeology:   Date: Wed, 08 Sep 2021 17:51:34 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bumping EDGE kernel to 5.14.y (#3125)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e: https://github.com/armbian/build/commit/dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e
+> X-Git-Archeology:   Date: Tue, 09 Nov 2021 18:06:34 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump imx6, xu4, rockchip64 and jetson-nano to 5.15 (#3238)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6b490e16944b30ff69bf9c13678905187df0d9d4: https://github.com/armbian/build/commit/6b490e16944b30ff69bf9c13678905187df0d9d4
+> X-Git-Archeology:   Date: Tue, 11 Jan 2022 15:26:11 +0100
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: move kernel edge to 5.16 (#3387)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision f52a4193d02ef88333ba117c68d49486dfd7ff41: https://github.com/armbian/build/commit/f52a4193d02ef88333ba117c68d49486dfd7ff41
+> X-Git-Archeology:   Date: Sun, 20 Mar 2022 22:58:21 +0100
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: Adding Pine64 Quartz64a as WIP target (#3539)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0afe24c95729044910e0b3f84dc5500bcdc6524c: https://github.com/armbian/build/commit/0afe24c95729044910e0b3f84dc5500bcdc6524c
+> X-Git-Archeology:   Date: Sun, 24 Apr 2022 22:33:47 +0200
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: move kernel media edge to 5.17 (#3704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ sound/soc/codecs/es8316.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sound/soc/codecs/es8316.c b/sound/soc/codecs/es8316.c
+index 056c3082fe02..bdb28209677b 100644
+--- a/sound/soc/codecs/es8316.c
++++ b/sound/soc/codecs/es8316.c
+@@ -696,7 +696,7 @@ static void es8316_disable_jack_detect(struct snd_soc_component *component)
  	snd_soc_component_update_bits(component, ES8316_GPIO_DEBOUNCE,
  				      ES8316_GPIO_ENABLE_INTERRUPT, 0);
  
@@ -9,3 +100,6 @@
  		es8316_disable_micbias_for_mic_gnd_short_detect(component);
  		snd_soc_jack_report(es8316->jack, 0, SND_JACK_BTN_0);
  	}
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/general-fix-inno-usb2-phy-init.patch
+++ b/patch/kernel/archive/rockchip64-6.3/general-fix-inno-usb2-phy-init.patch
@@ -1,17 +1,17 @@
-From e4cd72bcf2b4581122d065c2854fdb6be4b19bc3 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
 Date: Mon, 22 Aug 2022 20:51:22 +0000
-Subject: [PATCH] remove usb2phy extcon initialization causing kernel oops
+Subject: remove usb2phy extcon initialization causing kernel oops
 
 ---
  drivers/phy/rockchip/phy-rockchip-inno-usb2.c | 5 -----
  1 file changed, 5 deletions(-)
 
 diff --git a/drivers/phy/rockchip/phy-rockchip-inno-usb2.c b/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
-index e6ededc51..bfb2546e4 100644
+index a0bc10aa7961..c2405f84e9e8 100644
 --- a/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
 +++ b/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
-@@ -1167,11 +1167,6 @@ static int rockchip_usb2phy_otg_port_init(struct rockchip_usb2phy *rphy,
+@@ -1169,11 +1169,6 @@ static int rockchip_usb2phy_otg_port_init(struct rockchip_usb2phy *rphy,
  			goto out;
  		}
  
@@ -24,5 +24,5 @@ index e6ededc51..bfb2546e4 100644
  
  out:
 -- 
-2.34.1
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/general-fix-mmc-signal-voltage-before-reboot.patch
+++ b/patch/kernel/archive/rockchip64-6.3/general-fix-mmc-signal-voltage-before-reboot.patch
@@ -1,7 +1,7 @@
-From ae85f92289509b44f291d2a95b858a36f7444aaa Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>
 Date: Sun, 17 Feb 2019 22:14:38 +0000
-Subject: [PATCH] mmc: core: set initial signal voltage on power off
+Subject: mmc: core: set initial signal voltage on power off
 
 Some boards have SD card connectors where the power rail cannot be switched
 off by the driver. If the card has not been power cycled, it may still be
@@ -23,10 +23,10 @@ Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
  1 file changed, 8 insertions(+)
 
 diff --git a/drivers/mmc/core/core.c b/drivers/mmc/core/core.c
-index d42037f0f..019dc3555 100644
+index 426c7f66b349..5f491c67e2c9 100644
 --- a/drivers/mmc/core/core.c
 +++ b/drivers/mmc/core/core.c
-@@ -1349,6 +1349,14 @@ void mmc_power_off(struct mmc_host *host)
+@@ -1363,6 +1363,14 @@ void mmc_power_off(struct mmc_host *host)
  	if (host->ios.power_mode == MMC_POWER_OFF)
  		return;
  
@@ -41,3 +41,6 @@ index d42037f0f..019dc3555 100644
  	mmc_pwrseq_power_off(host);
  
  	host->ios.clock = 0;
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/general-increasing_DMA_block_memory_allocation_to_2048.patch
+++ b/patch/kernel/archive/rockchip64-6.3/general-increasing_DMA_block_memory_allocation_to_2048.patch
@@ -1,8 +1,219 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igor.pecovnik@gmail.com>
+Date: Mon, 21 Aug 2017 08:54:53 +0200
+Subject: [ARCHEOLOGY] Increasing DMA block memory allocation to 2048k on all
+ relevant kernels.
+
+> X-Git-Archeology: > recovered message: > https://forum.armbian.com/index.php?/topic/4811-uas-mainline-kernel-coherent-pool-memory-size
+> X-Git-Archeology: - Revision 908bb199ec2defd77f7f05d2016980abf100d627: https://github.com/armbian/build/commit/908bb199ec2defd77f7f05d2016980abf100d627
+> X-Git-Archeology:   Date: Mon, 21 Aug 2017 08:54:53 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igor.pecovnik@gmail.com>
+> X-Git-Archeology:   Subject: Increasing DMA block memory allocation to 2048k on all relevant kernels.
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision a3cf7b74858e1f862db8ca238bd44f6406be6662: https://github.com/armbian/build/commit/a3cf7b74858e1f862db8ca238bd44f6406be6662
+> X-Git-Archeology:   Date: Mon, 21 Aug 2017 17:52:29 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igor.pecovnik@gmail.com>
+> X-Git-Archeology:   Subject: Revert "Increasing DMA block memory allocation to 2048k on all relevant kernels."
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 2be21aad5dc965b3bc67e136a1e1170119d60f74: https://github.com/armbian/build/commit/2be21aad5dc965b3bc67e136a1e1170119d60f74
+> X-Git-Archeology:   Date: Mon, 21 Aug 2017 17:52:48 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igor.pecovnik@gmail.com>
+> X-Git-Archeology:   Subject: Increasing DMA block memory allocation to 2048k on all relevant kernels. https://forum.armbian.com/index.php?/topic/4811-uas-mainline-kernel-coherent-pool-memory-size
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision b3d2bd4864d89ce032344051e6ced2ba9371084b: https://github.com/armbian/build/commit/b3d2bd4864d89ce032344051e6ced2ba9371084b
+> X-Git-Archeology:   Date: Wed, 30 Aug 2017 05:42:08 +0000
+> X-Git-Archeology:   From: Tonymac32 <tonymckahan@gmail.com>
+> X-Git-Archeology:   Subject: Meson64 Dev increase DMA block memory allocation
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 2c59bb9934b749b5df74d4134cd393dc24fd5160: https://github.com/armbian/build/commit/2c59bb9934b749b5df74d4134cd393dc24fd5160
+> X-Git-Archeology:   Date: Mon, 18 Sep 2017 12:06:30 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igor.pecovnik@gmail.com>
+> X-Git-Archeology:   Subject: Lepotato. Added NEXT, added patches from C2 NEXT, au, config update, removed deprecated patches, ...
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 13e94e58f04be27db51d18b7dac1d15a1864b79e: https://github.com/armbian/build/commit/13e94e58f04be27db51d18b7dac1d15a1864b79e
+> X-Git-Archeology:   Date: Fri, 27 Oct 2017 16:14:21 +0300
+> X-Git-Archeology:   From: zador-blood-stained <zador-blood-stained@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Remove random executable bits from patch files
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 2c08ec8f5a210de35f9482f482ac01ea15381792: https://github.com/armbian/build/commit/2c08ec8f5a210de35f9482f482ac01ea15381792
+> X-Git-Archeology:   Date: Thu, 24 May 2018 13:32:29 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igor.pecovnik@gmail.com>
+> X-Git-Archeology:   Subject: Merge sunxi family into stable
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 7d2f3af08f23049c91c88eec5062613bbfbc85d4: https://github.com/armbian/build/commit/7d2f3af08f23049c91c88eec5062613bbfbc85d4
+> X-Git-Archeology:   Date: Thu, 24 May 2018 15:44:15 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igor.pecovnik@gmail.com>
+> X-Git-Archeology:   Subject: Merging Rockchip family
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 99a34c7be1e342247a981f99c7930ee73c144f3e: https://github.com/armbian/build/commit/99a34c7be1e342247a981f99c7930ee73c144f3e
+> X-Git-Archeology:   Date: Tue, 26 Jun 2018 12:47:49 +0000
+> X-Git-Archeology:   From: Igor Pecovnik <igor.pecovnik@gmail.com>
+> X-Git-Archeology:   Subject: Move Odroid C2 from 4.14.y to 4.16.y, added patch for ethernet, DEV to master, both tested ... not perfect but in a better condition.
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision fcb85f17675990514d8fadc905e6ccc3bded7138: https://github.com/armbian/build/commit/fcb85f17675990514d8fadc905e6ccc3bded7138
+> X-Git-Archeology:   Date: Thu, 28 Jun 2018 08:27:08 +0000
+> X-Git-Archeology:   From: Igor Pecovnik <igor.pecovnik@gmail.com>
+> X-Git-Archeology:   Subject: Major Amlogic RFC and cleanup
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision c57ebd663cf1b15ad193d4a761f9c044ba3b2acf: https://github.com/armbian/build/commit/c57ebd663cf1b15ad193d4a761f9c044ba3b2acf
+> X-Git-Archeology:   Date: Tue, 17 Jul 2018 16:11:07 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igor.pecovnik@gmail.com>
+> X-Git-Archeology:   Subject: - attach Odroid XU4 4.14.y back to Hardkernel kernel branch
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision a26ccdee627f1fa27b3285e3840434cddb5aae62: https://github.com/armbian/build/commit/a26ccdee627f1fa27b3285e3840434cddb5aae62
+> X-Git-Archeology:   Date: Wed, 07 Nov 2018 11:11:51 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igor.pecovnik@gmail.com>
+> X-Git-Archeology:   Subject: [odroid xu4] Drop kernel 3.10.y, default -> offical 4.14.y, next = vanilla 4.19.y http://ix.io/1rcZ & dev = n/a
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision a156fddf8f5bb5a6ac28ffc528ba0ec28ff9df81: https://github.com/armbian/build/commit/a156fddf8f5bb5a6ac28ffc528ba0ec28ff9df81
+> X-Git-Archeology:   Date: Fri, 18 Jan 2019 20:10:35 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igor.pecovnik@gmail.com>
+> X-Git-Archeology:   Subject: [ odroidxu4 ] Reverting NEXT back to stock 4.14.y due to many troubles, DEV = 4.19.y
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 79c1c2781915c59bd24576af92b9dbe57da24fac: https://github.com/armbian/build/commit/79c1c2781915c59bd24576af92b9dbe57da24fac
+> X-Git-Archeology:   Date: Fri, 17 May 2019 10:46:57 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igor.pecovnik@gmail.com>
+> X-Git-Archeology:   Subject: [ odroidxu4 dev ] Move to 5.1.y
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e261c6f82835bd9b12e07ba837b55fbf1aaa4327: https://github.com/armbian/build/commit/e261c6f82835bd9b12e07ba837b55fbf1aaa4327
+> X-Git-Archeology:   Date: Wed, 31 Jul 2019 12:51:00 +0200
+> X-Git-Archeology:   From: Aditya Prayoga <aprayoga@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Move mvebu DEFAULT, NEXT and DEV branch to next kernel (LTS) and U-boot #1426 (#1487)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 150ac0c2afa147d9e3b036c8ecd8238fe5648cf3: https://github.com/armbian/build/commit/150ac0c2afa147d9e3b036c8ecd8238fe5648cf3
+> X-Git-Archeology:   Date: Tue, 19 Nov 2019 23:25:39 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Remove K<4, change branches, new features (#1586)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0da16dfc3daacae374ece2778966297783ef004e: https://github.com/armbian/build/commit/0da16dfc3daacae374ece2778966297783ef004e
+> X-Git-Archeology:   Date: Sun, 19 Jan 2020 15:54:02 +0100
+> X-Git-Archeology:   From: Jannis <jannis@imserv.org>
+> X-Git-Archeology:   Subject: [ mvebu ] Update patches to fit new legacy, current, dev
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 4d4c3f58ffc1cbfbb060cbabc9eb414036a2fda5: https://github.com/armbian/build/commit/4d4c3f58ffc1cbfbb060cbabc9eb414036a2fda5
+> X-Git-Archeology:   Date: Wed, 02 Sep 2020 23:22:09 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switched rockchip64 curent to kernel 5.8.y (#2175)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 2fe5e6f7553174c2b2be69d70398145e11af00b6: https://github.com/armbian/build/commit/2fe5e6f7553174c2b2be69d70398145e11af00b6
+> X-Git-Archeology:   Date: Thu, 03 Dec 2020 10:24:27 +0100
+> X-Git-Archeology:   From: Jannis <52237708+heisath@users.noreply.github.com>
+> X-Git-Archeology:   Subject: [AR-558] Switch mvebu current to LK5.9 (based on previous mvebu-dev) (#2405)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision aa3d60f57e84d02887c63cae176bdec96b560e38: https://github.com/armbian/build/commit/aa3d60f57e84d02887c63cae176bdec96b560e38
+> X-Git-Archeology:   Date: Thu, 10 Dec 2020 11:47:33 +0100
+> X-Git-Archeology:   From: Rosen Penev <rosenp@gmail.com>
+> X-Git-Archeology:   Subject: refreshed mvebu with quilt (#2419)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision bd4c2c67f07ec0bcd823332da00cc8d3a7d733d7: https://github.com/armbian/build/commit/bd4c2c67f07ec0bcd823332da00cc8d3a7d733d7
+> X-Git-Archeology:   Date: Fri, 22 Jan 2021 13:20:44 +0100
+> X-Git-Archeology:   From: Jannis <52237708+heisath@users.noreply.github.com>
+> X-Git-Archeology:   Subject: [AR-609] Switch mvebu-current to 5.10.y (reusing config and patches from -dev) (#2547)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0cdffb29b07305209efb12cf3b5ac6032d3a1153: https://github.com/armbian/build/commit/0cdffb29b07305209efb12cf3b5ac6032d3a1153
+> X-Git-Archeology:   Date: Wed, 24 Mar 2021 19:01:53 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Renaming DEV branch to EDGE (#2704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 3b3d85e25c2ecde30df7b5274fc6f1b9c0299ea2: https://github.com/armbian/build/commit/3b3d85e25c2ecde30df7b5274fc6f1b9c0299ea2
+> X-Git-Archeology:   Date: Sat, 22 May 2021 17:08:44 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Upgrade EDGE to 5.12.y (#2825)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e7377248b3cae186e24e2be781cd3365b43246f0: https://github.com/armbian/build/commit/e7377248b3cae186e24e2be781cd3365b43246f0
+> X-Git-Archeology:   Date: Thu, 22 Jul 2021 00:15:54 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Second part of EDGE bumping to 5.13.y (#3045)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 744ea89a589d62cb6f409baab60fc6664520bc39: https://github.com/armbian/build/commit/744ea89a589d62cb6f409baab60fc6664520bc39
+> X-Git-Archeology:   Date: Wed, 08 Sep 2021 17:51:34 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bumping EDGE kernel to 5.14.y (#3125)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 5a8513360cdcca63d26759f51ff9a670cbbcfb71: https://github.com/armbian/build/commit/5a8513360cdcca63d26759f51ff9a670cbbcfb71
+> X-Git-Archeology:   Date: Sun, 10 Oct 2021 21:30:56 +0200
+> X-Git-Archeology:   From: Heisath <jannis@imserv.org>
+> X-Git-Archeology:   Subject: Switch mvebu-edge to kernel 5.14
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e: https://github.com/armbian/build/commit/dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e
+> X-Git-Archeology:   Date: Tue, 09 Nov 2021 18:06:34 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump imx6, xu4, rockchip64 and jetson-nano to 5.15 (#3238)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6b490e16944b30ff69bf9c13678905187df0d9d4: https://github.com/armbian/build/commit/6b490e16944b30ff69bf9c13678905187df0d9d4
+> X-Git-Archeology:   Date: Tue, 11 Jan 2022 15:26:11 +0100
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: move kernel edge to 5.16 (#3387)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 4de4c42e6f641eb6fc8eb02066486a7c42a7f73e: https://github.com/armbian/build/commit/4de4c42e6f641eb6fc8eb02066486a7c42a7f73e
+> X-Git-Archeology:   Date: Fri, 11 Feb 2022 11:00:57 +0100
+> X-Git-Archeology:   From: Heisath <jannis@imserv.org>
+> X-Git-Archeology:   Subject: Bump mvebu-current to 5.15 and mvebu-edge to 5.16
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision f52a4193d02ef88333ba117c68d49486dfd7ff41: https://github.com/armbian/build/commit/f52a4193d02ef88333ba117c68d49486dfd7ff41
+> X-Git-Archeology:   Date: Sun, 20 Mar 2022 22:58:21 +0100
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: Adding Pine64 Quartz64a as WIP target (#3539)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0afe24c95729044910e0b3f84dc5500bcdc6524c: https://github.com/armbian/build/commit/0afe24c95729044910e0b3f84dc5500bcdc6524c
+> X-Git-Archeology:   Date: Sun, 24 Apr 2022 22:33:47 +0200
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: move kernel media edge to 5.17 (#3704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision b619876210d23cc34652b4b4fa15cf7f61703079: https://github.com/armbian/build/commit/b619876210d23cc34652b4b4fa15cf7f61703079
+> X-Git-Archeology:   Date: Wed, 04 Jan 2023 18:37:42 +0100
+> X-Git-Archeology:   From: Jannis <52237708+Heisath@users.noreply.github.com>
+> X-Git-Archeology:   Subject: [AR-1313] Move mvebu edge to 6.1 (#4652)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 46ae5155c52c2d45b2658291831542813a1f1f96: https://github.com/armbian/build/commit/46ae5155c52c2d45b2658291831542813a1f1f96
+> X-Git-Archeology:   Date: Sun, 12 Mar 2023 22:30:56 +0100
+> X-Git-Archeology:   From: Heisath <jannis@imserv.org>
+> X-Git-Archeology:   Subject: Correctly create a new mvebu-6.2 patch folder, update symlink, update/fix patches for mvebu-edge
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ kernel/dma/pool.c | 8 +++-----
+ 1 file changed, 3 insertions(+), 5 deletions(-)
+
 diff --git a/kernel/dma/pool.c b/kernel/dma/pool.c
-index 6bc74a2d5..e3827da51 100644
+index 4d40dcce7604..6af7ecc9a144 100644
 --- a/kernel/dma/pool.c
 +++ b/kernel/dma/pool.c
-@@ -164,13 +164,11 @@ static int __init dma_atomic_pool_init(void)
+@@ -189,13 +189,11 @@ static int __init dma_atomic_pool_init(void)
  	int ret = 0;
  
  	/*
@@ -19,3 +230,6 @@ index 6bc74a2d5..e3827da51 100644
  	}
  	INIT_WORK(&atomic_pool_work, atomic_pool_work_fn);
  
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/general-legacy-rockchip-hwrng.patch
+++ b/patch/kernel/archive/rockchip64-6.3/general-legacy-rockchip-hwrng.patch
@@ -1,8 +1,43 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: brentr <brent@mbari.org>
+Date: Sat, 15 Oct 2022 10:46:04 +0200
+Subject: [ARCHEOLOGY] Restored Hardware Random Number Generator from legacy
+ (4.4) kernel (#4286)
+
+> X-Git-Archeology: > recovered message: > so boot no longer starves for entropy, delaying for up to 15 seconds
+> X-Git-Archeology: > recovered message: > Advances kernel to v5.19.15
+> X-Git-Archeology: - Revision f6f3f1b8b034bf7c1f069e831fc42a46940d2239: https://github.com/armbian/build/commit/f6f3f1b8b034bf7c1f069e831fc42a46940d2239
+> X-Git-Archeology:   Date: Sat, 15 Oct 2022 10:46:04 +0200
+> X-Git-Archeology:   From: brentr <brent@mbari.org>
+> X-Git-Archeology:   Subject: Restored Hardware Random Number Generator from legacy (4.4) kernel (#4286)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3308.dtsi |  15 +
+ drivers/char/hw_random/Kconfig           |  13 +
+ drivers/char/hw_random/Makefile          |   1 +
+ drivers/char/hw_random/rockchip-rng.c    | 330 ++++++++++
+ 4 files changed, 359 insertions(+)
+
 diff --git a/arch/arm64/boot/dts/rockchip/rk3308.dtsi b/arch/arm64/boot/dts/rockchip/rk3308.dtsi
-index fd8685d7c..5d4b1316b 100644
+index acb5f7304065..4ff96497888a 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3308.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3308.dtsi
-@@ -653,6 +653,21 @@ logic_thermal: logic-thermal {
+@@ -654,6 +654,21 @@ logic_thermal: logic-thermal {
  		};
  	};
  
@@ -25,7 +60,7 @@ index fd8685d7c..5d4b1316b 100644
  		compatible = "rockchip,rk3308-tsadc";
  		reg = <0x0 0xff1f0000 0x0 0x100>;
 diff --git a/drivers/char/hw_random/Kconfig b/drivers/char/hw_random/Kconfig
-index b3f2d55dc..90a974257 100644
+index 4fdf07ae3c54..78b15a30d9d4 100644
 --- a/drivers/char/hw_random/Kconfig
 +++ b/drivers/char/hw_random/Kconfig
 @@ -372,6 +372,19 @@ config HW_RANDOM_STM32
@@ -49,7 +84,7 @@ index b3f2d55dc..90a974257 100644
  	tristate "Microchip PIC32 Random Number Generator support"
  	depends on HW_RANDOM && MACH_PIC32
 diff --git a/drivers/char/hw_random/Makefile b/drivers/char/hw_random/Makefile
-index 3e948cf04..852fb42e2 100644
+index 09bde4a0f971..1aa2d1892d21 100644
 --- a/drivers/char/hw_random/Makefile
 +++ b/drivers/char/hw_random/Makefile
 @@ -34,6 +34,7 @@ obj-$(CONFIG_HW_RANDOM_IPROC_RNG200) += iproc-rng200.o
@@ -62,7 +97,7 @@ index 3e948cf04..852fb42e2 100644
  obj-$(CONFIG_HW_RANDOM_CAVIUM) += cavium-rng.o cavium-rng-vf.o
 diff --git a/drivers/char/hw_random/rockchip-rng.c b/drivers/char/hw_random/rockchip-rng.c
 new file mode 100644
-index 000000000..c0121f1f5
+index 000000000000..c0121f1f542e
 --- /dev/null
 +++ b/drivers/char/hw_random/rockchip-rng.c
 @@ -0,0 +1,330 @@
@@ -396,3 +431,6 @@ index 000000000..c0121f1f5
 +MODULE_DESCRIPTION("ROCKCHIP H/W Random Number Generator driver");
 +MODULE_AUTHOR("Lin Jinhan <troy.lin@rock-chips.com>");
 +MODULE_LICENSE("GPL v2");
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/general-legacy-rockchip-hwrng_5.10.patch
+++ b/patch/kernel/archive/rockchip64-6.3/general-legacy-rockchip-hwrng_5.10.patch
@@ -1,5 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: brentr <brent@mbari.org>
+Date: Fri, 25 Nov 2022 18:02:13 +0100
+Subject: [ARCHEOLOGY] Updated v4.4 HW RND driver with that from v5.10 kernel
+ (#4485)
+
+> X-Git-Archeology: - Revision d8fd01bc54d666efc1145920ad5538b050a7ef2c: https://github.com/armbian/build/commit/d8fd01bc54d666efc1145920ad5538b050a7ef2c
+> X-Git-Archeology:   Date: Fri, 25 Nov 2022 18:02:13 +0100
+> X-Git-Archeology:   From: brentr <brent@mbari.org>
+> X-Git-Archeology:   Subject: Updated v4.4 HW RND driver with that from v5.10 kernel (#4485)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ drivers/char/hw_random/rockchip-rng.c | 328 +++++++---
+ 1 file changed, 249 insertions(+), 79 deletions(-)
+
 diff --git a/drivers/char/hw_random/rockchip-rng.c b/drivers/char/hw_random/rockchip-rng.c
-index c0121f1f5..13503c54f 100644
+index c0121f1f542e..13503c54fe62 100644
 --- a/drivers/char/hw_random/rockchip-rng.c
 +++ b/drivers/char/hw_random/rockchip-rng.c
 @@ -21,18 +21,24 @@
@@ -493,3 +518,6 @@ index c0121f1f5..13503c54f 100644
  #endif
  
  static struct platform_driver rk_rng_driver = {
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/general-possibility-of-disabling-rk808-rtc.patch
+++ b/patch/kernel/archive/rockchip64-6.3/general-possibility-of-disabling-rk808-rtc.patch
@@ -1,7 +1,7 @@
-From 2fbbbde230c0c488412f2a376b13adbcbcbae28b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Piotr Szczepanik <piter75@gmail.com>
 Date: Sun, 24 Jan 2021 16:14:06 +0100
-Subject: [PATCH] add possibility of disabling rk808-rtc
+Subject: add possibility of disabling rk808-rtc
 
 To disable rk808-rtc driver from loading for specific board
 add the following stanza to rk808 node in device tree:
@@ -22,10 +22,10 @@ Signed-off-by: Piotr Szczepanik <piter75@gmail.com>
  2 files changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/mfd/mfd-core.c b/drivers/mfd/mfd-core.c
-index fc00aaccb..5c13cc9e2 100644
+index 16d1861e9682..289fc5627484 100644
 --- a/drivers/mfd/mfd-core.c
 +++ b/drivers/mfd/mfd-core.c
-@@ -225,7 +225,7 @@ static int mfd_add_device(struct device *parent, int id,
+@@ -232,7 +232,7 @@ static int mfd_add_device(struct device *parent, int id,
  		}
  
  		if (!pdev->dev.of_node)
@@ -35,17 +35,17 @@ index fc00aaccb..5c13cc9e2 100644
  	}
  
 diff --git a/drivers/mfd/rk808.c b/drivers/mfd/rk808.c
-index d109b9f14..d90c45cd5 100644
+index 0f22ef61e817..f8291b84c95e 100644
 --- a/drivers/mfd/rk808.c
 +++ b/drivers/mfd/rk808.c
-@@ -145,6 +145,7 @@ static const struct mfd_cell rk808s[] = {
- 	{ .name = "rk808-regulator", },
+@@ -158,6 +158,7 @@ static const struct mfd_cell rk808s[] = {
+ 	{ .name = "rk808-regulator", .id = PLATFORM_DEVID_NONE, },
  	{
  		.name = "rk808-rtc",
 +		.of_compatible = "rk808-rtc",
  		.num_resources = ARRAY_SIZE(rtc_resources),
  		.resources = rtc_resources,
- 	},
+ 		.id = PLATFORM_DEVID_NONE,
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/general-rk3328-dtsi-trb-ent-quirk.patch
+++ b/patch/kernel/archive/rockchip64-6.3/general-rk3328-dtsi-trb-ent-quirk.patch
@@ -1,8 +1,54 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: schwar3kat <61094841+schwar3kat@users.noreply.github.com>
+Date: Sat, 7 May 2022 15:51:38 +0200
+Subject: [ARCHEOLOGY] Enable rockchip64: XHCI HCD USB TRB ENT quirk for RK3328
+ (#3763)
+
+> X-Git-Archeology: > recovered message: > This resolves a bug that affects r8153b USB network interface causing the RX interface to hang on load.
+> X-Git-Archeology: > recovered message: > On some xHCI controllers (e.g. Rockchip RK3399/RK3328/RK1808),
+> X-Git-Archeology: > recovered message: > they need to enable the ENT flag in the TRB data structure
+> X-Git-Archeology: > recovered message: > to force xHC to prefetch the next TRB of a TD.
+> X-Git-Archeology: > recovered message: > The quirk patch is already applied to dwc3 xhci usb on rockchip64.
+> X-Git-Archeology: > recovered message: > Enable the quirk on RK3328 through device tree node properties in rk3328.dtsi
+> X-Git-Archeology: - Revision 5e477fd42c734794edc13efd474ad1099d449446: https://github.com/armbian/build/commit/5e477fd42c734794edc13efd474ad1099d449446
+> X-Git-Archeology:   Date: Sat, 07 May 2022 15:51:38 +0200
+> X-Git-Archeology:   From: schwar3kat <61094841+schwar3kat@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Enable rockchip64: XHCI HCD USB TRB ENT quirk for RK3328 (#3763)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3328.dtsi | 1 +
+ 1 file changed, 1 insertion(+)
+
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328.dtsi b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
-index 8f8a097c0..5fec765ab 100644
+index 1121c11abaa1..7a7bf3aafd31 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3328.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
-@@ -1229,6 +1229,7 @@ usbdrd3: usb@ff600000 {
+@@ -1029,6 +1029,7 @@ usbdrd3: usb@ff600000 {
  		snps,dis-del-phy-power-chg-quirk;
  		snps,dis_enblslpm_quirk;
  		snps,dis-tx-ipgap-linecheck-quirk;
@@ -10,3 +56,6 @@ index 8f8a097c0..5fec765ab 100644
  		snps,dis-u2-freeclk-exists-quirk;
  		snps,dis_u2_susphy_quirk;
  		snps,dis_u3_susphy_quirk;
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/general-rk808-configurable-switch-voltage-steps.patch
+++ b/patch/kernel/archive/rockchip64-6.3/general-rk808-configurable-switch-voltage-steps.patch
@@ -1,3 +1,8 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Piotr Szczepanik <piter75@gmail.com>
+Date: Tue, 2 Mar 2021 21:07:22 +0100
+Subject: allows to change the way that BUCK1 and BUCK2 of rk808 PMIC
+
 This patch allows to change the way that BUCK1 and BUCK2 of rk808 PMIC set voltage.
 
 It allows to change the hardcoded max. 100mV per one change
@@ -20,26 +25,112 @@ OPPs of LiTTLE cores of rk3399.
 
 For overclocked LiTTLE cores with base 408MHz @ 0.825V
 and max. 1.5GHz @ 1.2V it will take 7 steps of 50mV (at least 65uS each - caused by i2c),
-the final 25mV step and 1uS to settle: 7 x 65uS + 1uS = 456uS. 
+the final 25mV step and 1uS to settle: 7 x 65uS + 1uS = 456uS.
 
 With default setting it would be 3 steps of 100mV (at least 65uS each - caused by i2c),
 the final 75mV step and 1uS to settle: 3 x 65uS + 1uS = 196uS.
 
 Signed-off-by: Piotr Szczepanik <piter75@gmail.com>
 
+> X-Git-Archeology: > recovered message: > * Explicitly set vdd_log voltage for NanoPi M4V2 - possibly fix stability issues
+> X-Git-Archeology: > recovered message: > * Regulator tweaks for NanoPi M4V2
+> X-Git-Archeology: > recovered message: > * Add vdd_log to kernel and switch vdd_center back to 900mV
+> X-Git-Archeology: > recovered message: > * Switch vdd_center to 0.95
+> X-Git-Archeology: > recovered message: > * Make rk80x bucks voltage steps shorter to make the NanoPi M4V2 stable
+> X-Git-Archeology: > recovered message: > * Tweak u-boot config for NanoPi M4V2
+> X-Git-Archeology: > recovered message: > * Made the rk808 voltage steps configurable and configured 50mV for NanoPi M4V2
+> X-Git-Archeology: - Revision a6ee913fae3afc7ae74bb1fdaf1f571ec30493ac: https://github.com/armbian/build/commit/a6ee913fae3afc7ae74bb1fdaf1f571ec30493ac
+> X-Git-Archeology:   Date: Tue, 02 Mar 2021 21:07:22 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: NanoPi M4V2 stability fix for current and dev (#2663)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0cdffb29b07305209efb12cf3b5ac6032d3a1153: https://github.com/armbian/build/commit/0cdffb29b07305209efb12cf3b5ac6032d3a1153
+> X-Git-Archeology:   Date: Wed, 24 Mar 2021 19:01:53 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Renaming DEV branch to EDGE (#2704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e7377248b3cae186e24e2be781cd3365b43246f0: https://github.com/armbian/build/commit/e7377248b3cae186e24e2be781cd3365b43246f0
+> X-Git-Archeology:   Date: Thu, 22 Jul 2021 00:15:54 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Second part of EDGE bumping to 5.13.y (#3045)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 744ea89a589d62cb6f409baab60fc6664520bc39: https://github.com/armbian/build/commit/744ea89a589d62cb6f409baab60fc6664520bc39
+> X-Git-Archeology:   Date: Wed, 08 Sep 2021 17:51:34 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bumping EDGE kernel to 5.14.y (#3125)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e: https://github.com/armbian/build/commit/dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e
+> X-Git-Archeology:   Date: Tue, 09 Nov 2021 18:06:34 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump imx6, xu4, rockchip64 and jetson-nano to 5.15 (#3238)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6b490e16944b30ff69bf9c13678905187df0d9d4: https://github.com/armbian/build/commit/6b490e16944b30ff69bf9c13678905187df0d9d4
+> X-Git-Archeology:   Date: Tue, 11 Jan 2022 15:26:11 +0100
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: move kernel edge to 5.16 (#3387)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision f52a4193d02ef88333ba117c68d49486dfd7ff41: https://github.com/armbian/build/commit/f52a4193d02ef88333ba117c68d49486dfd7ff41
+> X-Git-Archeology:   Date: Sun, 20 Mar 2022 22:58:21 +0100
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: Adding Pine64 Quartz64a as WIP target (#3539)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0afe24c95729044910e0b3f84dc5500bcdc6524c: https://github.com/armbian/build/commit/0afe24c95729044910e0b3f84dc5500bcdc6524c
+> X-Git-Archeology:   Date: Sun, 24 Apr 2022 22:33:47 +0200
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: move kernel media edge to 5.17 (#3704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ drivers/regulator/rk808-regulator.c | 17 +++++++---
+ 1 file changed, 13 insertions(+), 4 deletions(-)
+
 diff --git a/drivers/regulator/rk808-regulator.c b/drivers/regulator/rk808-regulator.c
-index e926c1a85..cc3ec4803 100644
+index fa9fc1aa1ae3..94f359b88dea 100644
 --- a/drivers/regulator/rk808-regulator.c
 +++ b/drivers/regulator/rk808-regulator.c
-@@ -156,6 +156,7 @@
+@@ -155,6 +155,7 @@
  
  struct rk808_regulator_data {
  	struct gpio_desc *dvs_gpio[2];
 +	unsigned max_buck_steps_per_change;
  };
  
- static const int rk808_buck_config_regs[] = {
-@@ -239,7 +240,8 @@ static int rk808_buck1_2_get_voltage_sel_regmap(struct regulator_dev *rdev)
+ static const struct linear_range rk808_ldo3_voltage_ranges[] = {
+@@ -240,7 +241,8 @@ static int rk808_buck1_2_get_voltage_sel_regmap(struct regulator_dev *rdev)
  }
  
  static int rk808_buck1_2_i2c_set_voltage_sel(struct regulator_dev *rdev,
@@ -49,7 +140,7 @@ index e926c1a85..cc3ec4803 100644
  {
  	int ret, delta_sel;
  	unsigned int old_sel, tmp, val, mask = rdev->desc->vsel_mask;
-@@ -258,8 +260,8 @@ static int rk808_buck1_2_i2c_set_voltage_sel(struct regulator_dev *rdev,
+@@ -259,8 +261,8 @@ static int rk808_buck1_2_i2c_set_voltage_sel(struct regulator_dev *rdev,
  	 * the risk of overshoot. Put it into a multi-step, can effectively
  	 * avoid this problem, a step is 100mv here.
  	 */
@@ -60,7 +151,7 @@ index e926c1a85..cc3ec4803 100644
  		val = old_sel << (ffs(mask) - 1);
  		val |= tmp;
  
-@@ -293,12 +295,13 @@ static int rk808_buck1_2_set_voltage_sel(struct regulator_dev *rdev,
+@@ -294,12 +296,13 @@ static int rk808_buck1_2_set_voltage_sel(struct regulator_dev *rdev,
  	struct rk808_regulator_data *pdata = rdev_get_drvdata(rdev);
  	int id = rdev_get_id(rdev);
  	struct gpio_desc *gpio = pdata->dvs_gpio[id];
@@ -75,7 +166,7 @@ index e926c1a85..cc3ec4803 100644
  
  	gpio_level = gpiod_get_value(gpio);
  	if (gpio_level == 0) {
-@@ -1292,6 +1295,12 @@ static int rk808_regulator_dt_parse_pdata(struct device *dev,
+@@ -1277,6 +1280,12 @@ static int rk808_regulator_dt_parse_pdata(struct device *dev,
  				0 : tmp);
  	}
  
@@ -88,4 +179,6 @@ index e926c1a85..cc3ec4803 100644
  dt_parse_end:
  	of_node_put(np);
  	return ret;
+-- 
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/general-rockchip-overlays.patch
+++ b/patch/kernel/archive/rockchip64-6.3/general-rockchip-overlays.patch
@@ -1,15 +1,202 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Martin Ayotte <martinayotte@yahoo.ca>
+Date: Wed, 5 Dec 2018 15:00:44 -0500
+Subject: [ARCHEOLOGY] add overlays framework for rockchip
+
+> X-Git-Archeology: - Revision 677cf44f4620e11ff573257551c8231eceee1d4b: https://github.com/armbian/build/commit/677cf44f4620e11ff573257551c8231eceee1d4b
+> X-Git-Archeology:   Date: Wed, 05 Dec 2018 15:00:44 -0500
+> X-Git-Archeology:   From: Martin Ayotte <martinayotte@yahoo.ca>
+> X-Git-Archeology:   Subject: add overlays framework for rockchip
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 40ab5ee22b0055e2a67a73bdcda94217d23fe2a0: https://github.com/armbian/build/commit/40ab5ee22b0055e2a67a73bdcda94217d23fe2a0
+> X-Git-Archeology:   Date: Fri, 07 Dec 2018 16:23:35 -0500
+> X-Git-Archeology:   From: Martin Ayotte <martinayotte@yahoo.ca>
+> X-Git-Archeology:   Subject: add W1-GPIO overlay to rockchip64
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 5a7e35d59d385c4adb5c4bfd605211e59e72939e: https://github.com/armbian/build/commit/5a7e35d59d385c4adb5c4bfd605211e59e72939e
+> X-Git-Archeology:   Date: Tue, 05 Mar 2019 20:19:58 -0500
+> X-Git-Archeology:   From: Martin Ayotte <martinayotte@yahoo.ca>
+> X-Git-Archeology:   Subject: add rockchip-spi-spidev overlay
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 4722859bc1da10dc59f38615ef1683f9334412ac: https://github.com/armbian/build/commit/4722859bc1da10dc59f38615ef1683f9334412ac
+> X-Git-Archeology:   Date: Tue, 05 Mar 2019 20:28:25 -0500
+> X-Git-Archeology:   From: Martin Ayotte <martinayotte@yahoo.ca>
+> X-Git-Archeology:   Subject: fix spi-spidev pins in README
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e4e34c7f15b33a3a186033a0c40555c208f035ee: https://github.com/armbian/build/commit/e4e34c7f15b33a3a186033a0c40555c208f035ee
+> X-Git-Archeology:   Date: Wed, 06 Mar 2019 17:34:59 -0500
+> X-Git-Archeology:   From: Martin Ayotte <martinayotte@yahoo.ca>
+> X-Git-Archeology:   Subject: add param_w1_pin management to rockchip-fixup.scr
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 85285a492e203c26cf0704ac8c08dbf7e59127df: https://github.com/armbian/build/commit/85285a492e203c26cf0704ac8c08dbf7e59127df
+> X-Git-Archeology:   Date: Sun, 10 Mar 2019 09:27:53 -0400
+> X-Git-Archeology:   From: Martin Ayotte <martinayotte@yahoo.ca>
+> X-Git-Archeology:   Subject: add I2C7 overlay
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision eda653ae254c43b548889157171ce0873c918426: https://github.com/armbian/build/commit/eda653ae254c43b548889157171ce0873c918426
+> X-Git-Archeology:   Date: Sun, 10 Mar 2019 11:38:07 -0400
+> X-Git-Archeology:   From: Martin Ayotte <martinayotte@yahoo.ca>
+> X-Git-Archeology:   Subject: fix typo in README overlays
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 2e3a338d481b1637b7ff55d52e43612791e6d23a: https://github.com/armbian/build/commit/2e3a338d481b1637b7ff55d52e43612791e6d23a
+> X-Git-Archeology:   Date: Thu, 20 Jun 2019 10:11:25 -0400
+> X-Git-Archeology:   From: Martin Ayotte <martinayotte@yahoo.ca>
+> X-Git-Archeology:   Subject: fix SPIs registers in overlays
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 5ae502fa0af30f1edc089c76ecc698887acc8c5e: https://github.com/armbian/build/commit/5ae502fa0af30f1edc089c76ecc698887acc8c5e
+> X-Git-Archeology:   Date: Sun, 21 Jul 2019 13:24:42 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piotr.szczepanik@allegro.pl>
+> X-Git-Archeology:   Subject: [rockchip64-dev] UART4 activating overlay
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6dceae89ce35a4f7145003ddbcc9a53ed8999ff8: https://github.com/armbian/build/commit/6dceae89ce35a4f7145003ddbcc9a53ed8999ff8
+> X-Git-Archeology:   Date: Mon, 22 Jul 2019 10:08:41 -0400
+> X-Git-Archeology:   From: Martin Ayotte <martinayotte@yahoo.ca>
+> X-Git-Archeology:   Subject: swap fragments order in UART4 overlay
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision f0d3670ff9a2bc148ee4f7762c3ea7a6da04860d: https://github.com/armbian/build/commit/f0d3670ff9a2bc148ee4f7762c3ea7a6da04860d
+> X-Git-Archeology:   Date: Tue, 23 Jul 2019 12:31:18 -0400
+> X-Git-Archeology:   From: Martin Ayotte <martinayotte@yahoo.ca>
+> X-Git-Archeology:   Subject: fix typo in UART4 overlay
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision fadde96f2b0a0221b9e7abe7efe7f94377f3e651: https://github.com/armbian/build/commit/fadde96f2b0a0221b9e7abe7efe7f94377f3e651
+> X-Git-Archeology:   Date: Wed, 24 Jul 2019 17:41:52 -0400
+> X-Git-Archeology:   From: Martin Ayotte <martinayotte@yahoo.ca>
+> X-Git-Archeology:   Subject: fix SPIDEV overlay and add SPI-JEDEC-NOR overlay
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 776a5e7eb265d0fb62f2dec2ae99b684a11db5ea: https://github.com/armbian/build/commit/776a5e7eb265d0fb62f2dec2ae99b684a11db5ea
+> X-Git-Archeology:   Date: Wed, 24 Jul 2019 17:43:52 -0400
+> X-Git-Archeology:   From: Martin Ayotte <martinayotte@yahoo.ca>
+> X-Git-Archeology:   Subject: fix SPI default spi-max-frequency
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision b3bb9345439250d8247f0e24a8e1ef6290b2c279: https://github.com/armbian/build/commit/b3bb9345439250d8247f0e24a8e1ef6290b2c279
+> X-Git-Archeology:   Date: Mon, 18 Nov 2019 18:23:10 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Rock Pi 4 enable PCIe in device tree for "dev" target (#1624)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 150ac0c2afa147d9e3b036c8ecd8238fe5648cf3: https://github.com/armbian/build/commit/150ac0c2afa147d9e3b036c8ecd8238fe5648cf3
+> X-Git-Archeology:   Date: Tue, 19 Nov 2019 23:25:39 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Remove K<4, change branches, new features (#1586)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 812245def37a695bce9e7ece148b2920d82c8b37: https://github.com/armbian/build/commit/812245def37a695bce9e7ece148b2920d82c8b37
+> X-Git-Archeology:   Date: Sat, 18 Jul 2020 23:07:01 +0200
+> X-Git-Archeology:   From: Werner <EvilOlaf@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Move rockchip/64 current to 5.7.y (#2099)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 661371868def63655e46e8c513d8ba0f42cf4066: https://github.com/armbian/build/commit/661371868def63655e46e8c513d8ba0f42cf4066
+> X-Git-Archeology:   Date: Fri, 28 Aug 2020 19:26:08 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Enable overlays for rk3399-legacy (#2144)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e36ce875b025e112127cf8cc2d34825ebfe36569: https://github.com/armbian/build/commit/e36ce875b025e112127cf8cc2d34825ebfe36569
+> X-Git-Archeology:   Date: Tue, 10 Nov 2020 21:43:13 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switched rockchip64-current to linux 5.9.y (#2309)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0cdffb29b07305209efb12cf3b5ac6032d3a1153: https://github.com/armbian/build/commit/0cdffb29b07305209efb12cf3b5ac6032d3a1153
+> X-Git-Archeology:   Date: Wed, 24 Mar 2021 19:01:53 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Renaming DEV branch to EDGE (#2704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e7377248b3cae186e24e2be781cd3365b43246f0: https://github.com/armbian/build/commit/e7377248b3cae186e24e2be781cd3365b43246f0
+> X-Git-Archeology:   Date: Thu, 22 Jul 2021 00:15:54 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Second part of EDGE bumping to 5.13.y (#3045)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 744ea89a589d62cb6f409baab60fc6664520bc39: https://github.com/armbian/build/commit/744ea89a589d62cb6f409baab60fc6664520bc39
+> X-Git-Archeology:   Date: Wed, 08 Sep 2021 17:51:34 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bumping EDGE kernel to 5.14.y (#3125)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e: https://github.com/armbian/build/commit/dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e
+> X-Git-Archeology:   Date: Tue, 09 Nov 2021 18:06:34 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump imx6, xu4, rockchip64 and jetson-nano to 5.15 (#3238)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6b490e16944b30ff69bf9c13678905187df0d9d4: https://github.com/armbian/build/commit/6b490e16944b30ff69bf9c13678905187df0d9d4
+> X-Git-Archeology:   Date: Tue, 11 Jan 2022 15:26:11 +0100
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: move kernel edge to 5.16 (#3387)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 27771d0e8a7f512dbcf10cbca8e88eedd47d1b55: https://github.com/armbian/build/commit/27771d0e8a7f512dbcf10cbca8e88eedd47d1b55
+> X-Git-Archeology:   Date: Thu, 17 Feb 2022 22:06:54 +0100
+> X-Git-Archeology:   From: Leif <akhepcat@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Remove incorrectly duplicated GPIO pins from I2C7, name I2C7/I2C8 bus, from README.rockchip-overlays (#3495)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e7bd9b8f13af9ee054f44a422b2aca19746b9244: https://github.com/armbian/build/commit/e7bd9b8f13af9ee054f44a422b2aca19746b9244
+> X-Git-Archeology:   Date: Sat, 28 May 2022 08:56:19 +0200
+> X-Git-Archeology:   From: Tony <tonymckahan@gmail.com>
+> X-Git-Archeology:   Subject: Add Spidev workarounds and clean patches (WIP) (#3812)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 834fab09d0ca6fd6aa353b294011b8ca9dc00c1c: https://github.com/armbian/build/commit/834fab09d0ca6fd6aa353b294011b8ca9dc00c1c
+> X-Git-Archeology:   Date: Wed, 16 Nov 2022 18:39:47 +0100
+> X-Git-Archeology:   From: Ricardo Pardini <ricardo@pardini.net>
+> X-Git-Archeology:   Subject: `armbian,spi-dev` hacks also for rockchip64-5.18, .19, and 6.0.y (#4450)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/Makefile                           |   2 +
+ arch/arm64/boot/dts/rockchip/overlay/Makefile                   |  22 ++
+ arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays   | 106 ++++++++++
+ arch/arm64/boot/dts/rockchip/overlay/rockchip-dwc3-0-host.dts   |  13 ++
+ arch/arm64/boot/dts/rockchip/overlay/rockchip-fixup.scr-cmd     |  62 ++++++
+ arch/arm64/boot/dts/rockchip/overlay/rockchip-i2c7.dts          |  11 +
+ arch/arm64/boot/dts/rockchip/overlay/rockchip-i2c8.dts          |  11 +
+ arch/arm64/boot/dts/rockchip/overlay/rockchip-pcie-gen2.dts     |  12 ++
+ arch/arm64/boot/dts/rockchip/overlay/rockchip-spi-jedec-nor.dts |  72 +++++++
+ arch/arm64/boot/dts/rockchip/overlay/rockchip-spi-spidev.dts    |  72 +++++++
+ arch/arm64/boot/dts/rockchip/overlay/rockchip-uart4.dts         |  20 ++
+ arch/arm64/boot/dts/rockchip/overlay/rockchip-w1-gpio.dts       |  20 ++
+ scripts/Makefile.lib                                            |   3 +
+ 13 files changed, 426 insertions(+)
+
 diff --git a/arch/arm64/boot/dts/rockchip/Makefile b/arch/arm64/boot/dts/rockchip/Makefile
-index 6a33eff..60fc91a 100644
+index 68b486245580..0f0ec4e77735 100644
 --- a/arch/arm64/boot/dts/rockchip/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/Makefile
-@@ -66,3 +66,5 @@
+@@ -110,3 +110,5 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-edgeble-neu6a-io.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-evb1-v10.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-rock-5b.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588s-rock-5a.dtb
 +
 +subdir-y       := $(dts-dirs) overlay
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts/rockchip/overlay/Makefile
-index e69de29..576e190 100644
+new file mode 100644
+index 000000000000..0fce5206d2bd
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
 @@ -0,0 +1,22 @@
@@ -35,9 +222,9 @@ index e69de29..576e190 100644
 +always         := $(dtbo-y) $(scr-y) $(dtbotxt-y)
 +clean-files    := *.dtbo *.scr
 +
-+
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
-index e69de29..9512445 100644
+new file mode 100644
+index 000000000000..48ca48fc3113
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
 @@ -0,0 +1,106 @@
@@ -147,16 +334,28 @@ index e69de29..9512445 100644
 +Requires an external pull-up resistor on the data pin
 +or enabling the internal pull-up
 +
-+Parameters:
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-dwc3-0-host.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-dwc3-0-host.dts
+new file mode 100644
+index 000000000000..be2f4a2736af
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-dwc3-0-host.dts
+@@ -0,0 +1,13 @@
++/dts-v1/;
++/plugin/;
 +
-+param_w1_pin (pin)
-+	Data pin for 1-Wire master
-+	Optional
-+	Default: PD14
++/ {
++	compatible = "rockchip,rk3399";
 +
++	fragment@0 {
++		target = <&usbdrd_dwc3_0>;
++		__overlay__ {
++			dr_mode = "host";
++		};
++	};
++};
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-fixup.scr-cmd b/arch/arm64/boot/dts/rockchip/overlay/rockchip-fixup.scr-cmd
 new file mode 100644
-index 0000000..d4c39e2
+index 000000000000..8e3d468f4d4b
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-fixup.scr-cmd
 @@ -0,0 +1,62 @@
@@ -224,7 +423,7 @@ index 0000000..d4c39e2
 +
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-i2c7.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-i2c7.dts
 new file mode 100644
-index 0000000..54bc844
+index 000000000000..f8c601550588
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-i2c7.dts
 @@ -0,0 +1,11 @@
@@ -241,7 +440,7 @@ index 0000000..54bc844
 +};
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-i2c8.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-i2c8.dts
 new file mode 100644
-index 0000000..54bc844
+index 000000000000..54bc8449eafd
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-i2c8.dts
 @@ -0,0 +1,11 @@
@@ -258,7 +457,7 @@ index 0000000..54bc844
 +};
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-pcie-gen2.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-pcie-gen2.dts
 new file mode 100644
-index 0000000..54bc844
+index 000000000000..e8a51dca8f67
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-pcie-gen2.dts
 @@ -0,0 +1,12 @@
@@ -276,7 +475,7 @@ index 0000000..54bc844
 +};
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-spi-jedec-nor.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-spi-jedec-nor.dts
 new file mode 100644
-index 0000000..3a2be38
+index 000000000000..c4b1f36f9b09
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-spi-jedec-nor.dts
 @@ -0,0 +1,72 @@
@@ -354,7 +553,7 @@ index 0000000..3a2be38
 +};
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-spi-spidev.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-spi-spidev.dts
 new file mode 100644
-index 0000000..fe8fb14
+index 000000000000..53f074096308
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-spi-spidev.dts
 @@ -0,0 +1,72 @@
@@ -432,7 +631,7 @@ index 0000000..fe8fb14
 +};
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-uart4.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-uart4.dts
 new file mode 100644
-index 0000000..fe8fb14
+index 000000000000..305304ebcbf1
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-uart4.dts
 @@ -0,0 +1,20 @@
@@ -456,28 +655,9 @@ index 0000000..fe8fb14
 +		};
 +	};
 +};
-diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-dwc3-0-host.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-dwc3-0-host.dts
-new file mode 100644
-index 0000000..abcd123
---- /dev/null
-+++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-dwc3-0-host.dts
-@@ -0,0 +1,13 @@
-+/dts-v1/;
-+/plugin/;
-+
-+/ {
-+	compatible = "rockchip,rk3399";
-+
-+	fragment@0 {
-+		target = <&usbdrd_dwc3_0>;
-+		__overlay__ {
-+			dr_mode = "host";
-+		};
-+	};
-+};
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-w1-gpio.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-w1-gpio.dts
 new file mode 100644
-index 0000000..bfbc16a
+index 000000000000..bfbc16adcc9d
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-w1-gpio.dts
 @@ -0,0 +1,20 @@
@@ -502,16 +682,19 @@ index 0000000..bfbc16a
 +	};
 +};
 diff --git a/scripts/Makefile.lib b/scripts/Makefile.lib
-index 26e6af4..65b9435 100644
+index 1680499136ee..9bfbceb659b5 100644
 --- a/scripts/Makefile.lib
 +++ b/scripts/Makefile.lib
-@@ -65,6 +65,9 @@ real-objs-m := $(foreach m, $(obj-m), $(if $(strip $($(m:.o=-objs)) $($(m:.o=-y)
- extra-y				+= $(dtb-y)
- extra-$(CONFIG_OF_ALL_DTBS)	+= $(dtb-)
+@@ -88,6 +88,9 @@ base-dtb-y := $(foreach m, $(multi-dtb-y), $(firstword $(call suffix-search, $m,
+ 
+ always-y			+= $(dtb-y)
  
 +# Overlay targets
 +extra-y				+= $(dtbo-y) $(scr-y) $(dtbotxt-y)
 +
  # Add subdir path
  
- extra-y		:= $(addprefix $(obj)/,$(extra-y))
+ ifneq ($(obj),.)
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/general-rt5651-add-mclk.patch
+++ b/patch/kernel/archive/rockchip64-6.3/general-rt5651-add-mclk.patch
@@ -1,5 +1,75 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Piotr Szczepanik <piter75@gmail.com>
+Date: Sun, 5 Apr 2020 18:15:06 +0200
+Subject: [ARCHEOLOGY] Fixed sound from rt5651 on OrangePi 4 (#1870)
+
+> X-Git-Archeology: - Revision e14a61c229db1216fedc397e351c4bed15df820e: https://github.com/armbian/build/commit/e14a61c229db1216fedc397e351c4bed15df820e
+> X-Git-Archeology:   Date: Sun, 05 Apr 2020 18:15:06 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Fixed sound from rt5651 on OrangePi 4 (#1870)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0cdffb29b07305209efb12cf3b5ac6032d3a1153: https://github.com/armbian/build/commit/0cdffb29b07305209efb12cf3b5ac6032d3a1153
+> X-Git-Archeology:   Date: Wed, 24 Mar 2021 19:01:53 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Renaming DEV branch to EDGE (#2704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e7377248b3cae186e24e2be781cd3365b43246f0: https://github.com/armbian/build/commit/e7377248b3cae186e24e2be781cd3365b43246f0
+> X-Git-Archeology:   Date: Thu, 22 Jul 2021 00:15:54 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Second part of EDGE bumping to 5.13.y (#3045)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 744ea89a589d62cb6f409baab60fc6664520bc39: https://github.com/armbian/build/commit/744ea89a589d62cb6f409baab60fc6664520bc39
+> X-Git-Archeology:   Date: Wed, 08 Sep 2021 17:51:34 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bumping EDGE kernel to 5.14.y (#3125)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e: https://github.com/armbian/build/commit/dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e
+> X-Git-Archeology:   Date: Tue, 09 Nov 2021 18:06:34 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump imx6, xu4, rockchip64 and jetson-nano to 5.15 (#3238)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ sound/soc/codecs/rt5651.c | 16 ++++++++++
+ sound/soc/codecs/rt5651.h |  1 +
+ 2 files changed, 17 insertions(+)
+
 diff --git a/sound/soc/codecs/rt5651.c b/sound/soc/codecs/rt5651.c
-index c506c9305..41a08b320 100644
+index df90af906563..28e5b6fb9d8f 100644
 --- a/sound/soc/codecs/rt5651.c
 +++ b/sound/soc/codecs/rt5651.c
 @@ -24,6 +24,7 @@
@@ -47,7 +117,7 @@ index c506c9305..41a08b320 100644
  
  	snd_soc_component_update_bits(component, RT5651_PWR_ANLG1,
 diff --git a/sound/soc/codecs/rt5651.h b/sound/soc/codecs/rt5651.h
-index 20c33a3ec..17524fa9f 100644
+index 20c33a3ece37..17524fa9fdfc 100644
 --- a/sound/soc/codecs/rt5651.h
 +++ b/sound/soc/codecs/rt5651.h
 @@ -2097,6 +2097,7 @@ struct rt5651_priv {
@@ -58,3 +128,6 @@ index 20c33a3ec..17524fa9f 100644
  };
  
  #endif /* __RT5651_H__ */
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/general-workaround-broadcom-bt-serdev.patch
+++ b/patch/kernel/archive/rockchip64-6.3/general-workaround-broadcom-bt-serdev.patch
@@ -1,18 +1,18 @@
-From e5c9702bd2ffd09e48c118ab40c2764590af7929 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
 Date: Sat, 1 May 2021 12:41:14 +0000
-Subject: [PATCH] Workaround to make several broadcom bluetooth serdev devices
- work even without proper MAC address
+Subject: Workaround to make several broadcom bluetooth serdev devices work
+ even without proper MAC address
 
 ---
  drivers/bluetooth/btbcm.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/bluetooth/btbcm.c b/drivers/bluetooth/btbcm.c
-index 1b9743b7f..b274f1cdd 100644
+index 43e98a598bd9..93c456ce2533 100644
 --- a/drivers/bluetooth/btbcm.c
 +++ b/drivers/bluetooth/btbcm.c
-@@ -87,7 +87,7 @@ int btbcm_check_bdaddr(struct hci_dev *hdev)
+@@ -89,7 +89,7 @@ int btbcm_check_bdaddr(struct hci_dev *hdev)
  	    !bacmp(&bda->bdaddr, BDADDR_BCM43341B)) {
  		bt_dev_info(hdev, "BCM: Using default device address (%pMR)",
  			    &bda->bdaddr);
@@ -22,5 +22,5 @@ index 1b9743b7f..b274f1cdd 100644
  
  	kfree_skb(skb);
 -- 
-2.25.1
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/net-usb-r8152-add-LED-configuration-from-OF.patch
+++ b/patch/kernel/archive/rockchip64-6.3/net-usb-r8152-add-LED-configuration-from-OF.patch
@@ -1,7 +1,7 @@
-From 82985725e071f2a5735052f18e109a32aeac3a0b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: David Bauer <mail@david-bauer.net>
 Date: Sun, 26 Jul 2020 02:38:31 +0200
-Subject: [PATCH] net: usb: r8152: add LED configuration from OF
+Subject: net: usb: r8152: add LED configuration from OF
 
 This adds the ability to configure the LED configuration register using
 OF. This way, the correct value for board specific LED configuration can
@@ -9,9 +9,11 @@ be determined.
 
 Signed-off-by: David Bauer <mail@david-bauer.net>
 ---
- drivers/net/usb/r8152.c | 23 +++++++++++++++++++++++
+ drivers/net/usb/r8152.c | 23 ++++++++++
  1 file changed, 23 insertions(+)
 
+diff --git a/drivers/net/usb/r8152.c b/drivers/net/usb/r8152.c
+index 0fc4b959edc1..2b9bd8ebbc52 100644
 --- a/drivers/net/usb/r8152.c
 +++ b/drivers/net/usb/r8152.c
 @@ -11,6 +11,7 @@
@@ -22,7 +24,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
  #include <linux/crc32.h>
  #include <linux/if_vlan.h>
  #include <linux/uaccess.h>
-@@ -6864,6 +6865,22 @@ static void rtl_tally_reset(struct r8152
+@@ -6871,6 +6872,22 @@ static void rtl_tally_reset(struct r8152 *tp)
  	ocp_write_word(tp, MCU_TYPE_PLA, PLA_RSTTALLY, ocp_data);
  }
  
@@ -45,7 +47,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
  static void r8152b_init(struct r8152 *tp)
  {
  	u32 ocp_data;
-@@ -6905,6 +6922,8 @@ static void r8152b_init(struct r8152 *tp
+@@ -6912,6 +6929,8 @@ static void r8152b_init(struct r8152 *tp)
  	ocp_data = ocp_read_word(tp, MCU_TYPE_USB, USB_USB_CTRL);
  	ocp_data &= ~(RX_AGG_DISABLE | RX_ZERO_EN);
  	ocp_write_word(tp, MCU_TYPE_USB, USB_USB_CTRL, ocp_data);
@@ -54,7 +56,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
  }
  
  static void r8153_init(struct r8152 *tp)
-@@ -7045,6 +7064,8 @@ static void r8153_init(struct r8152 *tp)
+@@ -7052,6 +7071,8 @@ static void r8153_init(struct r8152 *tp)
  		tp->coalesce = COALESCE_SLOW;
  		break;
  	}
@@ -63,7 +65,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
  }
  
  static void r8153b_init(struct r8152 *tp)
-@@ -7127,6 +7148,8 @@ static void r8153b_init(struct r8152 *tp
+@@ -7134,6 +7155,8 @@ static void r8153b_init(struct r8152 *tp)
  	rtl_tally_reset(tp);
  
  	tp->coalesce = 15000;	/* 15 us */
@@ -72,3 +74,6 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
  }
  
  static void r8153c_init(struct r8152 *tp)
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/overlays-00-add-oc-opp-rk3399.patch
+++ b/patch/kernel/archive/rockchip64-6.3/overlays-00-add-oc-opp-rk3399.patch
@@ -1,18 +1,17 @@
-From a9a60c0bccd0c2b9d35594934eae5e25b4a00b53 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: tonymac32 <tonymckahan@gmail.com>
 Date: Wed, 16 Dec 2020 01:32:03 -0500
-Subject: [PATCH] rk3399-add-2ghz-opp-overlay
+Subject: rk3399-add-2ghz-opp-overlay
 
 Signed-off-by: tonymac32 <tonymckahan@gmail.com>
 ---
- arch/arm64/boot/dts/rockchip/overlay/Makefile |  1 +
- .../rockchip/overlay/README.rockchip-overlays |  5 ++++
- .../overlay/rockchip-rk3399-opp-2ghz.dts      | 24 +++++++++++++++++++
+ arch/arm64/boot/dts/rockchip/overlay/Makefile                     |  1 +
+ arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays     |  5 ++
+ arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3399-opp-2ghz.dts | 24 ++++++++++
  3 files changed, 30 insertions(+)
- create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3399-opp-2ghz.dts
 
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts/rockchip/overlay/Makefile
-index 0fce5206d..9bc4942bd 100644
+index 0fce5206d2bd..9bc4942bd0b9 100644
 --- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
 @@ -3,6 +3,7 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
@@ -24,7 +23,7 @@ index 0fce5206d..9bc4942bd 100644
  	rockchip-spi-spidev.dtbo \
  	rockchip-uart4.dtbo \
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
-index 48ca48fc3..ce0b84e00 100644
+index 48ca48fc3113..ce0b84e00a18 100644
 --- a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
 +++ b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
 @@ -29,6 +29,11 @@ I2C8 pins (SCL, SDA): GPIO1-C5, GPIO1-C4
@@ -41,7 +40,7 @@ index 48ca48fc3..ce0b84e00 100644
  Activates MTD support for JEDEC compatible SPI NOR flash chips on SPI bus
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3399-opp-2ghz.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3399-opp-2ghz.dts
 new file mode 100644
-index 000000000..1d7584b60
+index 000000000000..1d7584b60ec6
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3399-opp-2ghz.dts
 @@ -0,0 +1,24 @@
@@ -70,5 +69,5 @@ index 000000000..1d7584b60
 +    };
 +};
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/overlays-01-add-oc-opp-rk3328.patch
+++ b/patch/kernel/archive/rockchip64-6.3/overlays-01-add-oc-opp-rk3328.patch
@@ -1,20 +1,18 @@
-From a053b706be60b3dd13803ece30ff6eb143339bc2 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: tonymac32 <tonymckahan@gmail.com>
 Date: Thu, 17 Dec 2020 01:33:33 -0500
-Subject: [PATCH] rk3328-oc-opps
+Subject: rk3328-oc-opps
 
 Signed-off-by: tonymac32 <tonymckahan@gmail.com>
 ---
- arch/arm64/boot/dts/rockchip/overlay/Makefile     |  2 ++
- .../dts/rockchip/overlay/README.rockchip-overlays | 10 ++++++++++
- .../overlay/rockchip-rk3328-opp-1.4ghz.dts        | 15 +++++++++++++++
- .../overlay/rockchip-rk3328-opp-1.5ghz.dts        | 15 +++++++++++++++
+ arch/arm64/boot/dts/rockchip/overlay/Makefile                       |  2 ++
+ arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays       | 10 +++++++
+ arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-opp-1.4ghz.dts | 15 ++++++++++
+ arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-opp-1.5ghz.dts | 15 ++++++++++
  4 files changed, 42 insertions(+)
- create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-opp-1.4ghz.dts
- create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-opp-1.5ghz.dts
 
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts/rockchip/overlay/Makefile
-index 9bc4942bd..9c07d64a1 100644
+index 9bc4942bd0b9..9c07d64a12c1 100644
 --- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
 @@ -3,6 +3,8 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
@@ -27,7 +25,7 @@ index 9bc4942bd..9c07d64a1 100644
  	rockchip-spi-jedec-nor.dtbo \
  	rockchip-spi-spidev.dtbo \
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
-index ce0b84e00..d6979437a 100644
+index ce0b84e00a18..d6979437a608 100644
 --- a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
 +++ b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
 @@ -29,6 +29,16 @@ I2C8 pins (SCL, SDA): GPIO1-C5, GPIO1-C4
@@ -49,7 +47,7 @@ index ce0b84e00..d6979437a 100644
  Adds the 2GHz big and 1.5 GHz LITTLE opps for overclocking
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-opp-1.4ghz.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-opp-1.4ghz.dts
 new file mode 100644
-index 000000000..a7ad9d572
+index 000000000000..a7ad9d572d28
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-opp-1.4ghz.dts
 @@ -0,0 +1,15 @@
@@ -70,7 +68,7 @@ index 000000000..a7ad9d572
 +};
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-opp-1.5ghz.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-opp-1.5ghz.dts
 new file mode 100644
-index 000000000..3dfd008ab
+index 000000000000..3dfd008abc97
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-opp-1.5ghz.dts
 @@ -0,0 +1,15 @@
@@ -90,5 +88,5 @@ index 000000000..3dfd008ab
 +    };
 +};
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/overlays-02-add-rk3318-box-led-conf1.patch
+++ b/patch/kernel/archive/rockchip64-6.3/overlays-02-add-rk3318-box-led-conf1.patch
@@ -1,18 +1,16 @@
-From c7140e73b84431eb1e8cb31bdfce4c9d8a908de0 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
 Date: Sat, 17 Apr 2021 16:26:46 +0000
-Subject: [PATCH 2/4] rk3318-box: add led configuration for YX_RK3328 boards
- and clones
+Subject: rk3318-box: add led configuration for YX_RK3328 boards and clones
 
 ---
- arch/arm64/boot/dts/rockchip/overlay/Makefile |  3 +-
- .../rockchip/overlay/README.rockchip-overlays |  4 +-
- .../overlay/rockchip-rk3318-box-led-conf1.dts | 54 +++++++++++++++++++
- 3 files changed, 58 insertions(+), 3 deletions(-)
- create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-led-conf1.dts
+ arch/arm64/boot/dts/rockchip/overlay/Makefile                          |  3 +-
+ arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays          |  4 +
+ arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-led-conf1.dts | 49 ++++++++++
+ 3 files changed, 55 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts/rockchip/overlay/Makefile
-index 9c07d64a1..8e9ff2ef1 100644
+index 9c07d64a12c1..8e9ff2ef1f13 100644
 --- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
 @@ -10,7 +10,8 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
@@ -22,9 +20,21 @@ index 9c07d64a1..8e9ff2ef1 100644
 -	rockchip-w1-gpio.dtbo
 +	rockchip-w1-gpio.dtbo \
 +	rockchip-rk3318-box-led-conf1.dtbo
-
+ 
  scr-$(CONFIG_ARCH_ROCKCHIP) += \
         rockchip-fixup.scr
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
+index d6979437a608..1c645a9b8549 100644
+--- a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
++++ b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
+@@ -119,3 +119,7 @@ Activates 1-Wire GPIO master
+ Requires an external pull-up resistor on the data pin
+ or enabling the internal pull-up
+ 
++### rk3318-box-led-conf1
++
++Activates led/gpio configuration for rk3318 tv box boards with signature
++YX_RK3328 and clones
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-led-conf1.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-led-conf1.dts
 new file mode 100644
 index 000000000000..26bfd7c634c0
@@ -80,18 +90,6 @@ index 000000000000..26bfd7c634c0
 +
 +};
 +*/
+-- 
+Armbian
 
-diff --git a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
-index d6979437a..1de0a95e8 100644
---- a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
-+++ b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
-@@ -119,3 +119,7 @@ Activates 1-Wire GPIO master
- Requires an external pull-up resistor on the data pin
- or enabling the internal pull-up
-
-+### rk3318-box-led-conf1
-+
-+Activates led/gpio configuration for rk3318 tv box boards with signature
-+YX_RK3328 and clones
---
-2.25.1

--- a/patch/kernel/archive/rockchip64-6.3/overlays-03-add-rk3318-box-emmc-ddr.patch
+++ b/patch/kernel/archive/rockchip64-6.3/overlays-03-add-rk3318-box-emmc-ddr.patch
@@ -1,18 +1,16 @@
-From 026b39ef85792467bdf1681e5abfca9a5231516f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
 Date: Sat, 17 Apr 2021 16:29:00 +0000
-Subject: [PATCH 3/4] rk3318-box: add eMMC DDR support device tree overlay for
- rk3318-box
+Subject: rk3318-box: add eMMC DDR support device tree overlay for rk3318-box
 
 ---
- arch/arm64/boot/dts/rockchip/overlay/Makefile      |  3 ++-
- .../dts/rockchip/overlay/README.rockchip-overlays  |  6 ++++++
- .../overlay/rockchip-rk3318-box-emmc-ddr.dts       | 14 ++++++++++++++
+ arch/arm64/boot/dts/rockchip/overlay/Makefile                         |  3 +-
+ arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays         |  6 ++++
+ arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-emmc-ddr.dts | 14 ++++++++++
  3 files changed, 22 insertions(+), 1 deletion(-)
- create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-emmc-ddr.dts
 
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts/rockchip/overlay/Makefile
-index 8e9ff2ef1..565ef20ac 100644
+index 8e9ff2ef1f13..565ef20ace15 100644
 --- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
 @@ -11,7 +11,8 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
@@ -25,9 +23,23 @@ index 8e9ff2ef1..565ef20ac 100644
  
  scr-$(CONFIG_ARCH_ROCKCHIP) += \
         rockchip-fixup.scr
+diff --git a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
+index 1c645a9b8549..01fa6f4ee7f8 100644
+--- a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
++++ b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
+@@ -123,3 +123,9 @@ or enabling the internal pull-up
+ 
+ Activates led/gpio configuration for rk3318 tv box boards with signature
+ YX_RK3328 and clones
++
++### rk3318-box-emmc-ddr
++
++Activates eMMC DDR capability for rk3318 tv box boards. Probably all the eMMC chips
++nowadays support DDR mode, but its reliability heavily depends upon the quality
++of board wiring
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-emmc-ddr.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-emmc-ddr.dts
 new file mode 100644
-index 000000000..b8f139099
+index 000000000000..b8f139099871
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-emmc-ddr.dts
 @@ -0,0 +1,14 @@
@@ -46,19 +58,5 @@ index 000000000..b8f139099
 +
 +};
 -- 
-2.25.1
+Armbian
 
-diff --git a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
-index 1c645a9b8..01fa6f4ee 100644
---- a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
-+++ b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
-@@ -123,3 +123,9 @@ or enabling the internal pull-up
- 
- Activates led/gpio configuration for rk3318 tv box boards with signature
- YX_RK3328 and clones
-+
-+### rk3318-box-emmc-ddr
-+
-+Activates eMMC DDR capability for rk3318 tv box boards. Probably all the eMMC chips
-+nowadays support DDR mode, but its reliability heavily depends upon the quality
-+of board wiring

--- a/patch/kernel/archive/rockchip64-6.3/overlays-04-add-rk3318-box-wlan-ap6334.patch
+++ b/patch/kernel/archive/rockchip64-6.3/overlays-04-add-rk3318-box-wlan-ap6334.patch
@@ -1,18 +1,16 @@
-From 918d83519ccba3e540f6a9e0c201fcccf106988f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
 Date: Sat, 17 Apr 2021 16:30:58 +0000
-Subject: [PATCH 4/4] rk3318-box: add device tree overlay to support AP6334 and
- clones
+Subject: rk3318-box: add device tree overlay to support AP6334 and clones
 
 ---
- arch/arm64/boot/dts/rockchip/overlay/Makefile |  3 +-
- .../rockchip/overlay/README.rockchip-overlays |  5 +++
- .../rockchip-rk3318-box-wlan-ap6334.dts       | 31 +++++++++++++++++++
- 3 files changed, 38 insertions(+), 1 deletion(-)
- create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-wlan-ap6334.dts
+ arch/arm64/boot/dts/rockchip/overlay/Makefile                            |   3 +-
+ arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays            |   5 +
+ arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-wlan-ap6334.dts | 117 ++++++++++
+ 3 files changed, 124 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts/rockchip/overlay/Makefile
-index 565ef20ac..be038cc38 100644
+index 565ef20ace15..be038cc380ea 100644
 --- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
 @@ -12,7 +12,8 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
@@ -26,7 +24,7 @@ index 565ef20ac..be038cc38 100644
  scr-$(CONFIG_ARCH_ROCKCHIP) += \
         rockchip-fixup.scr
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
-index 01fa6f4ee..0e7eaeea2 100644
+index 01fa6f4ee7f8..0e7eaeea22e4 100644
 --- a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
 +++ b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
 @@ -129,3 +129,8 @@ YX_RK3328 and clones
@@ -40,7 +38,7 @@ index 01fa6f4ee..0e7eaeea2 100644
 +wifi chip and clones
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-wlan-ap6334.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-wlan-ap6334.dts
 new file mode 100644
-index 000000000..b7befaaeb
+index 000000000000..b7befaaeb4c8
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-wlan-ap6334.dts
 @@ -0,0 +1,117 @@
@@ -161,3 +159,6 @@ index 000000000..b7befaaeb
 +	};
 +
 +};
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/overlays-05-add-rk3318-box-wlan-ext.patch
+++ b/patch/kernel/archive/rockchip64-6.3/overlays-05-add-rk3318-box-wlan-ext.patch
@@ -1,17 +1,16 @@
-From 8b6cf9530ef8923895df798428a9b45534c9fd98 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
 Date: Sun, 18 Apr 2021 10:59:09 +0000
-Subject: [PATCH] rk3318-box: add overlay for wifi over sdmmc_ext
+Subject: rk3318-box: add overlay for wifi over sdmmc_ext
 
 ---
- arch/arm64/boot/dts/rockchip/overlay/Makefile |  3 +-
- .../rockchip/overlay/README.rockchip-overlays |  6 ++++
- .../overlay/rockchip-rk3318-box-wlan-ext.dts  | 29 +++++++++++++++++++
- 3 files changed, 37 insertions(+), 1 deletion(-)
- create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-wlan-ext.dts
+ arch/arm64/boot/dts/rockchip/overlay/Makefile                         |  3 +-
+ arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays         |  6 ++
+ arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-wlan-ext.dts | 33 ++++++++++
+ 3 files changed, 41 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts/rockchip/overlay/Makefile
-index be038cc38..5e3318b57 100644
+index be038cc380ea..5e3318b57ef6 100644
 --- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
 @@ -13,7 +13,8 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
@@ -25,7 +24,7 @@ index be038cc38..5e3318b57 100644
  scr-$(CONFIG_ARCH_ROCKCHIP) += \
         rockchip-fixup.scr
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
-index 0e7eaeea2..b414e3069 100644
+index 0e7eaeea22e4..b414e3069bb5 100644
 --- a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
 +++ b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
 @@ -134,3 +134,9 @@ of board wiring
@@ -40,7 +39,7 @@ index 0e7eaeea2..b414e3069 100644
 +
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-wlan-ext.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-wlan-ext.dts
 new file mode 100644
-index 000000000..7f43fc20f
+index 000000000000..bf8a289d6b40
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-wlan-ext.dts
 @@ -0,0 +1,33 @@
@@ -78,5 +77,5 @@ index 000000000..7f43fc20f
 +
 +};
 -- 
-2.25.1
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/overlays-06-add-rk3318-box-wlan-ap6330.patch
+++ b/patch/kernel/archive/rockchip64-6.3/overlays-06-add-rk3318-box-wlan-ap6330.patch
@@ -1,17 +1,16 @@
-From db8c01c4dc0a1bbbdd35c0021b3975f11ce7a881 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
 Date: Tue, 20 Apr 2021 16:24:58 +0000
-Subject: [PATCH] rk3318-box: add overlay for full support to Ampak AP6330
+Subject: rk3318-box: add overlay for full support to Ampak AP6330
 
 ---
- arch/arm64/boot/dts/rockchip/overlay/Makefile |  3 +-
- .../rockchip/overlay/README.rockchip-overlays |  4 +
- .../rockchip-rk3318-box-wlan-ap6330.dts       | 99 +++++++++++++++++++
- 3 files changed, 105 insertions(+), 1 deletion(-)
- create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-wlan-ap6330.dts
+ arch/arm64/boot/dts/rockchip/overlay/Makefile                            |   3 +-
+ arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays            |   4 +
+ arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-wlan-ap6330.dts | 106 ++++++++++
+ 3 files changed, 112 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts/rockchip/overlay/Makefile
-index 5e3318b57..9bf45a074 100644
+index 5e3318b57ef6..9bf45a0742ba 100644
 --- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
 @@ -14,7 +14,8 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
@@ -25,7 +24,7 @@ index 5e3318b57..9bf45a074 100644
  scr-$(CONFIG_ARCH_ROCKCHIP) += \
         rockchip-fixup.scr
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
-index b414e3069..7b5073498 100644
+index b414e3069bb5..7b5073498869 100644
 --- a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
 +++ b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
 @@ -140,3 +140,7 @@ wifi chip and clones
@@ -38,7 +37,7 @@ index b414e3069..7b5073498 100644
 +wifi + bt chip and clones.
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-wlan-ap6330.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-wlan-ap6330.dts
 new file mode 100644
-index 000000000..9bc02a217
+index 000000000000..9bc02a2173e4
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-wlan-ap6330.dts
 @@ -0,0 +1,106 @@
@@ -148,3 +147,6 @@ index 000000000..9bc02a217
 +	};
 +
 +};
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/overlays-07-add-rk3318-box-cpu-hs.patch
+++ b/patch/kernel/archive/rockchip64-6.3/overlays-07-add-rk3318-box-cpu-hs.patch
@@ -1,18 +1,16 @@
-From 41d39d8f7d7e9c40994750495c6783fbc71348ca Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
 Date: Wed, 21 Apr 2021 10:58:39 +0000
-Subject: [PATCH] rk3318-box: add additional device tree overlay with high
- speed bins
+Subject: rk3318-box: add additional device tree overlay with high speed bins
 
 ---
- arch/arm64/boot/dts/rockchip/overlay/Makefile |  3 ++-
- .../rockchip/overlay/README.rockchip-overlays |  4 ++++
- .../overlay/rockchip-rk3318-box-cpu-hs.dts    | 21 +++++++++++++++++++
- 3 files changed, 27 insertions(+), 1 deletion(-)
- create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-cpu-hs.dts
+ arch/arm64/boot/dts/rockchip/overlay/Makefile                       |  3 +-
+ arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays       |  4 ++
+ arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-cpu-hs.dts | 24 ++++++++++
+ 3 files changed, 30 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts/rockchip/overlay/Makefile
-index 9bf45a074..42b19bd85 100644
+index 9bf45a0742ba..42b19bd856bd 100644
 --- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
 @@ -15,7 +15,8 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
@@ -26,7 +24,7 @@ index 9bf45a074..42b19bd85 100644
  scr-$(CONFIG_ARCH_ROCKCHIP) += \
         rockchip-fixup.scr
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
-index 7b5073498..2fc9b00fe 100644
+index 7b5073498869..2fc9b00fefc8 100644
 --- a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
 +++ b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
 @@ -144,3 +144,7 @@ X88 Pro) which have wifi chip attached to sdmmc_ext controller.
@@ -39,7 +37,7 @@ index 7b5073498..2fc9b00fe 100644
 +Enable additional cpu "high-speed" bins up to 1.3ghz
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-cpu-hs.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-cpu-hs.dts
 new file mode 100644
-index 000000000..e6bc1adec
+index 000000000000..e6bc1adecae2
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-cpu-hs.dts
 @@ -0,0 +1,24 @@
@@ -67,3 +65,6 @@ index 000000000..e6bc1adec
 +	};
 +
 +};
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/overlays-08-add-rk3318-box-emmc-hs200.patch
+++ b/patch/kernel/archive/rockchip64-6.3/overlays-08-add-rk3318-box-emmc-hs200.patch
@@ -1,17 +1,16 @@
-From 0c9a276d459db0c16468cf2bae502eefd379c61b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
 Date: Wed, 21 Apr 2021 11:02:43 +0000
-Subject: [PATCH] rk3318-box: add emmc hs200 device tree overlay
+Subject: rk3318-box: add emmc hs200 device tree overlay
 
 ---
- arch/arm64/boot/dts/rockchip/overlay/Makefile      |  3 ++-
- .../dts/rockchip/overlay/README.rockchip-overlays  |  6 ++++++
- .../overlay/rockchip-rk3318-box-emmc-hs200.dts     | 14 ++++++++++++++
+ arch/arm64/boot/dts/rockchip/overlay/Makefile                           |  3 +-
+ arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays           |  6 ++++
+ arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-emmc-hs200.dts | 14 ++++++++++
  3 files changed, 22 insertions(+), 1 deletion(-)
- create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-emmc-hs200.dts
 
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts/rockchip/overlay/Makefile
-index 42b19bd85..f227d5997 100644
+index 42b19bd856bd..f227d599736c 100644
 --- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
 @@ -16,7 +16,8 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
@@ -25,7 +24,7 @@ index 42b19bd85..f227d5997 100644
  scr-$(CONFIG_ARCH_ROCKCHIP) += \
         rockchip-fixup.scr
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
-index 2fc9b00fe..1b547bea7 100644
+index 2fc9b00fefc8..1b547bea7b0d 100644
 --- a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
 +++ b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
 @@ -130,6 +130,12 @@ Activates eMMC DDR capability for rk3318 tv box boards. Probably all the eMMC ch
@@ -43,7 +42,7 @@ index 2fc9b00fe..1b547bea7 100644
  Set up additional device tree bits to properly support ap6334 (broadcom BCM4334)
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-emmc-hs200.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-emmc-hs200.dts
 new file mode 100644
-index 000000000..55f8f7eb6
+index 000000000000..55f8f7eb6a01
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-emmc-hs200.dts
 @@ -0,0 +1,14 @@
@@ -62,5 +61,5 @@ index 000000000..55f8f7eb6
 +
 +};
 -- 
-2.25.1
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/overlays-09-add-rk3318-box-led-conf2.patch
+++ b/patch/kernel/archive/rockchip64-6.3/overlays-09-add-rk3318-box-led-conf2.patch
@@ -1,17 +1,16 @@
-From 984e45a2fe4643ff96b43e0057c7e019aa8be7d6 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
 Date: Fri, 23 Apr 2021 13:11:51 +0000
-Subject: [PATCH] rk3318-box: add X88_PRO_B led/gpio configuration
+Subject: rk3318-box: add X88_PRO_B led/gpio configuration
 
 ---
- arch/arm64/boot/dts/rockchip/overlay/Makefile |  1 +
- .../rockchip/overlay/README.rockchip-overlays |  5 ++
- .../overlay/rockchip-rk3318-box-led-conf2.dts | 64 +++++++++++++++++++
- 3 files changed, 70 insertions(+)
- create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-led-conf2.dts
+ arch/arm64/boot/dts/rockchip/overlay/Makefile                          |  1 +
+ arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays          |  5 +
+ arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-led-conf2.dts | 63 ++++++++++
+ 3 files changed, 69 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts/rockchip/overlay/Makefile
-index f227d5997..c28c7a5eb 100644
+index f227d599736c..c28c7a5ebd40 100644
 --- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
 @@ -12,6 +12,7 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
@@ -23,24 +22,24 @@ index f227d5997..c28c7a5eb 100644
  	rockchip-rk3318-box-wlan-ap6334.dtbo \
  	rockchip-rk3318-box-wlan-ext.dtbo \
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
-index 1b547bea7..4172bd731 100644
+index 1b547bea7b0d..4172bd73109b 100644
 --- a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
 +++ b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
 @@ -124,6 +124,11 @@ or enabling the internal pull-up
  Activates led/gpio configuration for rk3318 tv box boards with signature
  YX_RK3328 and clones
-
+ 
 +### rk3318-box-led-conf2
 +
 +Activates led/gpio configuration for rk3318 tv box boards withs signature
 +X88_PRO_B and clones
 +
  ### rk3318-box-emmc-ddr
-
+ 
  Activates eMMC DDR capability for rk3318 tv box boards. Probably all the eMMC chips
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-led-conf2.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-led-conf2.dts
 new file mode 100644
-index 000000000000..b8ed044ee52a
+index 000000000000..c5040e6a1f2e
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-led-conf2.dts
 @@ -0,0 +1,63 @@
@@ -107,4 +106,6 @@ index 000000000000..b8ed044ee52a
 +	pinctrl-0 = <&spdifm1_tx>;
 +};
 +
+-- 
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/overlays-10-add-rk3318-box-led-conf3.patch
+++ b/patch/kernel/archive/rockchip64-6.3/overlays-10-add-rk3318-box-led-conf3.patch
@@ -1,18 +1,17 @@
-From 506d63cda173ca0f992bdbf4b4d2f3e1e20f905c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
 Date: Mon, 18 Oct 2021 18:30:28 +0000
-Subject: [PATCH] rk3318-box: add led-conf3 to support MXQ-RK3328-D4 boards
- with RK805 PMIC
+Subject: rk3318-box: add led-conf3 to support MXQ-RK3328-D4 boards with RK805
+ PMIC
 
 ---
- arch/arm64/boot/dts/rockchip/overlay/Makefile |   1 +
- .../rockchip/overlay/README.rockchip-overlays |   7 +
- .../overlay/rockchip-rk3318-box-led-conf3.dts | 279 ++++++++++++++++++
- 3 files changed, 287 insertions(+)
- create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-led-conf3.dts
+ arch/arm64/boot/dts/rockchip/overlay/Makefile                          |   1 +
+ arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays          |   7 +
+ arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-led-conf3.dts | 305 ++++++++++
+ 3 files changed, 313 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts/rockchip/overlay/Makefile
-index c28c7a5eb..f11aa6d57 100644
+index c28c7a5ebd40..f11aa6d57449 100644
 --- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
 @@ -13,6 +13,7 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
@@ -24,13 +23,13 @@ index c28c7a5eb..f11aa6d57 100644
  	rockchip-rk3318-box-wlan-ap6334.dtbo \
  	rockchip-rk3318-box-wlan-ext.dtbo \
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
-index 4172bd731..27f945d38 100644
+index 4172bd73109b..27f945d38e24 100644
 --- a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
 +++ b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
 @@ -129,6 +129,13 @@ YX_RK3328 and clones
  Activates led/gpio configuration for rk3318 tv box boards withs signature
  X88_PRO_B and clones
-
+ 
 +### rk3318-box-led-conf3
 +
 +This device tree overlay is suitable for MXQ-RK3328-D4_A board which
@@ -39,11 +38,11 @@ index 4172bd731..27f945d38 100644
 +system. Also enables gpio leds and keys.
 +
  ### rk3318-box-emmc-ddr
-
+ 
  Activates eMMC DDR capability for rk3318 tv box boards. Probably all the eMMC chips
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-led-conf3.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-led-conf3.dts
 new file mode 100644
-index 000000000000..6e05145a287d
+index 000000000000..a0d51304db8d
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-led-conf3.dts
 @@ -0,0 +1,305 @@
@@ -352,6 +351,6 @@ index 000000000000..6e05145a287d
 +	pinctrl-0 = <&spdifm1_tx>;
 +};
 +
---
-2.30.2
+-- 
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/overlays-11-add-rk3308bs.patch
+++ b/patch/kernel/archive/rockchip64-6.3/overlays-11-add-rk3308bs.patch
@@ -1,5 +1,90 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: brentr <brent@mbari.org>
+Date: Thu, 13 Oct 2022 18:34:43 +0200
+Subject: [ARCHEOLOGY] Rockpis wifi fixes (#4008)
+
+> X-Git-Archeology: > recovered message: > * RockPI-S board has no video I/O
+> X-Git-Archeology: > recovered message: > * udev rule to fix MAC address of iface based on UUID
+> X-Git-Archeology: > recovered message: > Deals with WiFi chip lacking any EEPROM to store its unique Ethernet MAC address
+> X-Git-Archeology: > recovered message: > Generic mechanism -- could be utilized for other boards having similar issues
+> X-Git-Archeology: > recovered message: > * Handy Device Tree overlays for the RockPI S
+> X-Git-Archeology: > recovered message: > Use armbian-add-overlay to install these
+> X-Git-Archeology: > recovered message: > Reduce CPU voltage for the RK3308 B-S
+> X-Git-Archeology: > recovered message: > Option to overclock RK3308 B-S to 1.3Ghz
+> X-Git-Archeology: > recovered message: > Increase SDIO clock rate from 1Mhz to 10Mhz
+> X-Git-Archeology: > recovered message: > This increases WiFi throughput from 300K bytes/s to 2.4M bytes/s
+> X-Git-Archeology: > recovered message: > * corrected comment
+> X-Git-Archeology: > recovered message: > * No longer repeat standard opp's in this dts
+> X-Git-Archeology: > recovered message: > Require that the standard bs dts already be installed
+> X-Git-Archeology: > recovered message: > * User README for adding RockPI-S board variant specific dts overlays
+> X-Git-Archeology: > recovered message: > * "enabled" --> "okay"
+> X-Git-Archeology: > recovered message: > * added mention of sdnand.dts, fixed typo
+> X-Git-Archeology: > recovered message: > * added p2p0 to interfaces whose MAC address should be "fixed"
+> X-Git-Archeology: > recovered message: > * RK3308 CPU serial number in nvmem replaces UUID for derivation of fixed MAC addr
+> X-Git-Archeology: > recovered message: > Restored use of install utility
+> X-Git-Archeology: > recovered message: > * Use RK3308 specific CPU serial number
+> X-Git-Archeology: > recovered message: > rather than rootfs UUID
+> X-Git-Archeology: > recovered message: > * remove generic fixMACaddress
+> X-Git-Archeology: > recovered message: > * Install fixMACaddr file-by-file via install utility
+> X-Git-Archeology: > recovered message: > * Drive SDIO bus signals faster
+> X-Git-Archeology: > recovered message: > setting RK3308_SOC_CON0_VCCIO3 reduces signal rise/fall times to WiFi SDIO chip
+> X-Git-Archeology: > recovered message: > from 30ns to 5ns.
+> X-Git-Archeology: > recovered message: > This odd fix forward ported from legacy kernel.
+> X-Git-Archeology: > recovered message: > Allows Rock Pi-S WiFi to operate at full speed.
+> X-Git-Archeology: > recovered message: > * Set RK3308 I/O voltage domains before SDIO initializes
+> X-Git-Archeology: > recovered message: > This patch moves responibility form the io-domain to the pinctrl driver because
+> X-Git-Archeology: > recovered message: > the io-domain driver is probed after the SDIO devices are discovered.
+> X-Git-Archeology: > recovered message: > This was causing multiple SDIO I/O failures during boot.
+> X-Git-Archeology: > recovered message: > A new pinctrl property is added:
+> X-Git-Archeology: > recovered message: > io-1v8-domains
+> X-Git-Archeology: > recovered message: > is a u32 interpreted as a bit mask where each set bit corresponds to
+> X-Git-Archeology: > recovered message: > a 1.8V I/O domain (as opposed to the default of 3.3V for I/O)
+> X-Git-Archeology: > recovered message: > The mask is writted to the RK3308_SOC_CON0 GRF register
+> X-Git-Archeology: > recovered message: > (once) when the pinctrl driver starts
+> X-Git-Archeology: > recovered message: > The default mask is 0x10 where only I/O domain 4 runs at 1.8V
+> X-Git-Archeology: > recovered message: > This is necessary for the RockPI-S to run the SDIO clock at high (50Mhz) speed
+> X-Git-Archeology: > recovered message: > * align whitespace
+> X-Git-Archeology: > recovered message: > * factored rk3308bs overlays out up sdio speedup patch
+> X-Git-Archeology: > recovered message: > * factored dts for RK3308 iodomains and pinctrl patches out of speedup patch
+> X-Git-Archeology: > recovered message: > * remains of sdio speedup patch merely add iodomains support for rk3308
+> X-Git-Archeology: > recovered message: > * factored rockpis dts modification out from rk3308 io voltage domains
+> X-Git-Archeology: > recovered message: > replaced rk3308 support from iodomains with
+> X-Git-Archeology: > recovered message: > new io-voltage-domains property added to pinctrl
+> X-Git-Archeology: > recovered message: > io-voltage-domains specific to rk3308 for now, others SOCs may be added later.
+> X-Git-Archeology: > recovered message: > * add sequence numbering to names of rk3308 patches
+> X-Git-Archeology: > recovered message: > * corrected tab alignment
+> X-Git-Archeology: - Revision d3a3afe3850861ceaeb44f3631251c764a28cd43: https://github.com/armbian/build/commit/d3a3afe3850861ceaeb44f3631251c764a28cd43
+> X-Git-Archeology:   Date: Thu, 13 Oct 2022 18:34:43 +0200
+> X-Git-Archeology:   From: brentr <brent@mbari.org>
+> X-Git-Archeology:   Subject: Rockpis wifi fixes (#4008)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/overlay/Makefile                 |  6 +-
+ arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays | 41 ++++++++++
+ arch/arm64/boot/dts/rockchip/overlay/rk3308-bs.dts            | 39 +++++++++
+ arch/arm64/boot/dts/rockchip/overlay/rk3308-bs@1.3ghz.dts     | 26 ++++++
+ arch/arm64/boot/dts/rockchip/overlay/rk3308-emmc.dts          | 13 +++
+ arch/arm64/boot/dts/rockchip/overlay/rk3308-sdio@10mhz.dts    | 14 ++++
+ arch/arm64/boot/dts/rockchip/overlay/rk3308-sdio@4mhz.dts     | 14 ++++
+ 7 files changed, 152 insertions(+), 1 deletion(-)
+
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts/rockchip/overlay/Makefile
-index f11aa6d57..badb15519 100644
+index f11aa6d57449..badb15519204 100644
 --- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
 @@ -19,7 +19,11 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
@@ -16,7 +101,7 @@ index f11aa6d57..badb15519 100644
  scr-$(CONFIG_ARCH_ROCKCHIP) += \
         rockchip-fixup.scr
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
-index 27f945d38..d21fed1ff 100644
+index 27f945d38e24..d21fed1ff955 100644
 --- a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
 +++ b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
 @@ -10,6 +10,10 @@ rockchip (Rockchip)
@@ -73,7 +158,7 @@ index 27f945d38..d21fed1ff 100644
 +Note that older mainline kernels cannot drive the SDIO clock faster than 10Mhz.
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/rk3308-bs.dts b/arch/arm64/boot/dts/rockchip/overlay/rk3308-bs.dts
 new file mode 100644
-index 000000000..978f67947
+index 000000000000..978f67947380
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rk3308-bs.dts
 @@ -0,0 +1,39 @@
@@ -118,7 +203,7 @@ index 000000000..978f67947
 +};
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/rk3308-bs@1.3ghz.dts b/arch/arm64/boot/dts/rockchip/overlay/rk3308-bs@1.3ghz.dts
 new file mode 100644
-index 000000000..3fae0dd23
+index 000000000000..3fae0dd2363f
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rk3308-bs@1.3ghz.dts
 @@ -0,0 +1,26 @@
@@ -150,7 +235,7 @@ index 000000000..3fae0dd23
 +};
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/rk3308-emmc.dts b/arch/arm64/boot/dts/rockchip/overlay/rk3308-emmc.dts
 new file mode 100644
-index 000000000..4a4c3804d
+index 000000000000..4a4c3804d1aa
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rk3308-emmc.dts
 @@ -0,0 +1,13 @@
@@ -169,7 +254,7 @@ index 000000000..4a4c3804d
 +};
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/rk3308-sdio@10mhz.dts b/arch/arm64/boot/dts/rockchip/overlay/rk3308-sdio@10mhz.dts
 new file mode 100644
-index 000000000..c7f2e280f
+index 000000000000..c7f2e280f7ae
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rk3308-sdio@10mhz.dts
 @@ -0,0 +1,14 @@
@@ -189,7 +274,7 @@ index 000000000..c7f2e280f
 +};
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/rk3308-sdio@4mhz.dts b/arch/arm64/boot/dts/rockchip/overlay/rk3308-sdio@4mhz.dts
 new file mode 100644
-index 000000000..efcc5c265
+index 000000000000..efcc5c265284
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rk3308-sdio@4mhz.dts
 @@ -0,0 +1,14 @@
@@ -207,3 +292,6 @@ index 000000000..efcc5c265
 +		};
 +	};
 +};
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/overlays-11-add-rk3318-box-led-conf4.patch
+++ b/patch/kernel/archive/rockchip64-6.3/overlays-11-add-rk3318-box-led-conf4.patch
@@ -1,17 +1,16 @@
-From 9e2a9f208da921fa6e72e75d9c4b0d259f0002d9 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
 Date: Sat, 8 Oct 2022 20:20:41 +0000
-Subject: [PATCH] add rk3318-box-led-conf4 overlay
+Subject: add rk3318-box-led-conf4 overlay
 
 ---
- arch/arm64/boot/dts/rockchip/overlay/Makefile |  1 +
- .../rockchip/overlay/README.rockchip-overlays |  4 ++
- .../overlay/rockchip-rk3318-box-led-conf4.dts | 38 +++++++++++++++++++
+ arch/arm64/boot/dts/rockchip/overlay/Makefile                          |  1 +
+ arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays          |  4 +
+ arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-led-conf4.dts | 38 ++++++++++
  3 files changed, 43 insertions(+)
- create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3318-box-led-conf4.dts
 
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts/rockchip/overlay/Makefile
-index f11aa6d57449..340f88be014b 100644
+index badb15519204..3c2264543bef 100644
 --- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
 @@ -14,6 +14,7 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
@@ -23,10 +22,10 @@ index f11aa6d57449..340f88be014b 100644
  	rockchip-rk3318-box-wlan-ap6334.dtbo \
  	rockchip-rk3318-box-wlan-ext.dtbo \
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
-index 27f945d38e24..b3121afd5a63 100644
+index d21fed1ff955..0be01217af7a 100644
 --- a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
 +++ b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
-@@ -136,6 +136,10 @@ has an integrated PMIC (RK805). The dtbo is very important to achieve
+@@ -140,6 +140,10 @@ has an integrated PMIC (RK805). The dtbo is very important to achieve
  1.3 Ghz speed for CPU and stable voltages for other parts of the
  system. Also enables gpio leds and keys.
  
@@ -82,5 +81,5 @@ index 000000000000..5d60f51069d8
 +	status = "disabled";
 +};
 -- 
-2.34.1
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/overlays-12-add-rockpi4cplus-usb-host.patch
+++ b/patch/kernel/archive/rockchip64-6.3/overlays-12-add-rockpi4cplus-usb-host.patch
@@ -1,5 +1,54 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+Date: Wed, 2 Nov 2022 06:58:31 +0100
+Subject: [ARCHEOLOGY] Add Radxa ROCK Pi 4C Plus (#4129)
+
+> X-Git-Archeology: > recovered message: > * Add Rockpi 4C+
+> X-Git-Archeology: > recovered message: > * add newer patches:
+> X-Git-Archeology: > recovered message: > - apply patches from RadxaNaoki <noaki@radxa.com>
+> X-Git-Archeology: > recovered message: > - ref 5652d6f9c2a4e2c50ac1040c0388859381b0616f: arm64: dts: rockchip: add gmac for ROCK 4C+ (#17)
+> X-Git-Archeology: > recovered message: > - apply latest patches from Marcone <marco.nelissen@gmail.com>
+> X-Git-Archeology: > recovered message: > - ref e39da181b099a86f5440ed1c08fc699d4a65aed7: arm64: dts: rockchip: Make Rock Pi 4C+ ethernet actually work
+> X-Git-Archeology: > recovered message: > - ref 8c519612eeb852268371b3c596eec4622460e5bf: arm64: dts: rockchip: add Rock Pi 4C+ LEDs
+> X-Git-Archeology: > recovered message: > - ref 726441afe687ea6059bac37f145ff204b75430f7: arm64: dts: rockchip: enable Rock Pi 4C+ wifi
+> X-Git-Archeology: > recovered message: > - ref caad7bef3b5558e2598480c0a0089e2ac3cedcdd: arm64: dts: rockchip: enable Rock Pi 4C+ nvme
+> X-Git-Archeology: > recovered message: > - ref 6cdc3215d1691bcd2a407a30e88efa0cec179eb2: arm64: dts: rockchip: enable Rock Pi 4C+ OTG
+> X-Git-Archeology: > recovered message: > * default top USB3 port to host mode
+> X-Git-Archeology: > recovered message: > * get 2nd HDMI port to work at least. :)
+> X-Git-Archeology: > recovered message: > * revert OTG USB3.1 port back to otg mode
+> X-Git-Archeology: > recovered message: > * [rockpi4c+] update board def.  add usb host overlay.
+> X-Git-Archeology: > recovered message: > * remove redundant HDMI clocks and voltages
+> X-Git-Archeology: > recovered message: > * enable test builds for Rock PI 4 C+
+> X-Git-Archeology: > recovered message: > * [rockpi4c+] add USB host overlay
+> X-Git-Archeology: > recovered message: > Co-authored-by: Joe Khoobyar <fourheads@gmail.com>
+> X-Git-Archeology: - Revision 9780da320eeb45832ddb680959646fcc5a6a38c3: https://github.com/armbian/build/commit/9780da320eeb45832ddb680959646fcc5a6a38c3
+> X-Git-Archeology:   Date: Wed, 02 Nov 2022 06:58:31 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Add Radxa ROCK Pi 4C Plus (#4129)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision af24261cad8aac0fe13efd57449a82ab1b33e868: https://github.com/armbian/build/commit/af24261cad8aac0fe13efd57449a82ab1b33e868
+> X-Git-Archeology:   Date: Wed, 02 Nov 2022 10:45:35 -0400
+> X-Git-Archeology:   From: Joe Khoobyar <joekhoobyar@users.noreply.github.com>
+> X-Git-Archeology:   Subject: AR-1301: add edge and desktop (#4377)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/overlay/Makefile                           |  1 +
+ arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays           |  5 +++
+ arch/arm64/boot/dts/rockchip/overlay/rockchip-rockpi4cplus-usb-host.dts | 16 ++++++++++
+ 3 files changed, 22 insertions(+)
+
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts/rockchip/overlay/Makefile
-index 340f88be0..e33e98e0d 100644
+index 3c2264543bef..41c323473d50 100644
 --- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
 @@ -6,6 +6,7 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
@@ -11,10 +60,10 @@ index 340f88be0..e33e98e0d 100644
  	rockchip-spi-spidev.dtbo \
  	rockchip-uart4.dtbo \
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
-index d09351b11..2ed50f0f0 100644
+index 0be01217af7a..17b21826c79a 100644
 --- a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
 +++ b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
-@@ -44,6 +44,11 @@ WARNING! Not officially supported by Rockchip!!!
+@@ -48,6 +48,11 @@ WARNING! Not officially supported by Rockchip!!!
  Adds the 2GHz big and 1.5 GHz LITTLE opps for overclocking
  WARNING! Not officially supported by Rockchip!!!
  
@@ -28,7 +77,7 @@ index d09351b11..2ed50f0f0 100644
  Activates MTD support for JEDEC compatible SPI NOR flash chips on SPI bus
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rockpi4cplus-usb-host.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rockpi4cplus-usb-host.dts
 new file mode 100644
-index 000000000..654ae888f
+index 000000000000..654ae888f5c4
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rockpi4cplus-usb-host.dts
 @@ -0,0 +1,16 @@
@@ -48,3 +97,6 @@ index 000000000..654ae888f
 +	};
 +};
 +
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/overlays-13-add-rockpro64-lcd.patch
+++ b/patch/kernel/archive/rockchip64-6.3/overlays-13-add-rockpro64-lcd.patch
@@ -1,5 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: simple <991605149@qq.com>
+Date: Wed, 11 Jan 2023 19:00:44 +0100
+Subject: [ARCHEOLOGY] Add overlays for rockpro64 7'' lcd (#4684)
+
+> X-Git-Archeology: - Revision f9740dbe8c465e53da9fd78d44b6ba1b9325fb32: https://github.com/armbian/build/commit/f9740dbe8c465e53da9fd78d44b6ba1b9325fb32
+> X-Git-Archeology:   Date: Wed, 11 Jan 2023 19:00:44 +0100
+> X-Git-Archeology:   From: simple <991605149@qq.com>
+> X-Git-Archeology:   Subject: Add overlays for rockpro64 7'' lcd (#4684)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/overlay/Makefile                   |  1 +
+ arch/arm64/boot/dts/rockchip/overlay/rockchip-rockpro64-lcd.dts | 58 ++++++++++
+ 2 files changed, 59 insertions(+)
+
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts/rockchip/overlay/Makefile
-index 41c323473d5..25e4e189d97 100644
+index 41c323473d50..25e4e189d97d 100644
 --- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
 @@ -7,6 +7,7 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
@@ -12,7 +32,7 @@ index 41c323473d5..25e4e189d97 100644
  	rockchip-uart4.dtbo \
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rockpro64-lcd.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rockpro64-lcd.dts
 new file mode 100644
-index 00000000000..c9ce8f8b565
+index 000000000000..c9ce8f8b565d
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rockpro64-lcd.dts
 @@ -0,0 +1,58 @@
@@ -74,3 +94,6 @@ index 00000000000..c9ce8f8b565
 +  };
 +};
 +
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/overlays-14-add-rk3328-pcm5102-dac.patch
+++ b/patch/kernel/archive/rockchip64-6.3/overlays-14-add-rk3328-pcm5102-dac.patch
@@ -1,19 +1,18 @@
-From f8874f8d3cefa49ef1613686296462703a5b8c7b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
 Date: Sat, 22 Apr 2023 12:31:45 +0200
-Subject: [PATCH] rk3328: add dtb overlay to enable pcm5102 DAC on i2s1 bus
+Subject: rk3328: add dtb overlay to enable pcm5102 DAC on i2s1 bus
 
 ---
- arch/arm64/boot/dts/rockchip/overlay/Makefile |   1 +
- .../overlay/rockchip-rk3328-i2s1-pcm5102.dts  | 104 ++++++++++++++++++
+ arch/arm64/boot/dts/rockchip/overlay/Makefile                         |   1 +
+ arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2s1-pcm5102.dts | 104 ++++++++++
  2 files changed, 105 insertions(+)
- create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2s1-pcm5102.dts
 
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts/rockchip/overlay/Makefile
-index fe2e3e46e..b0ddfce1a 100644
+index 25e4e189d97d..dafc367c69db 100644
 --- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
-@@ -25,6 +25,7 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
+@@ -23,6 +23,7 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
  	rockchip-rk3318-box-wlan-ap6330.dtbo \
  	rockchip-rk3318-box-cpu-hs.dtbo \
  	rockchip-rk3318-box-emmc-hs200.dtbo \
@@ -23,7 +22,7 @@ index fe2e3e46e..b0ddfce1a 100644
          rk3308-emmc.dtbo
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2s1-pcm5102.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2s1-pcm5102.dts
 new file mode 100644
-index 000000000..5153440c0
+index 000000000000..5153440c0332
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2s1-pcm5102.dts
 @@ -0,0 +1,104 @@
@@ -132,5 +131,5 @@ index 000000000..5153440c0
 +	rockchip,playback-channels = <8>;
 +};
 -- 
-2.34.1
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/regulator-add-fan53200-driver.patch
+++ b/patch/kernel/archive/rockchip64-6.3/regulator-add-fan53200-driver.patch
@@ -1,7 +1,7 @@
-From 43231f566634df693fa20b677a84850750829d3d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Rock Shen <rock_shen@asus.com>
 Date: Tue, 27 Apr 2021 11:13:25 +0800
-Subject: [PATCH] regulator: add fan53200 regulator driver for Tinekr Board 2
+Subject: regulator: add fan53200 regulator driver for Tinkerboard-2
 
 1. Add fan53200 regulator support for vdd_cpu_b & vdd_gpu
 2. By Tinker2 HW design, Vsel gpio pin polarity was reversed, switch
@@ -13,27 +13,26 @@ Signed-off-by: Rock Shen <rock_shen@asus.com>
  arch/arm64/configs/defconfig |   1 +
  drivers/regulator/Kconfig    |  11 +
  drivers/regulator/Makefile   |   1 +
- drivers/regulator/fan53200.c | 519 +++++++++++++++++++++++++++++++++++++++++++
+ drivers/regulator/fan53200.c | 519 ++++++++++
  4 files changed, 532 insertions(+)
- create mode 100644 drivers/regulator/fan53200.c
 
 diff --git a/arch/arm64/configs/defconfig b/arch/arm64/configs/defconfig
-index 5cfe3cf..38cbba4 100644
+index 7790ee42c68a..899aaf767841 100644
 --- a/arch/arm64/configs/defconfig
 +++ b/arch/arm64/configs/defconfig
-@@ -583,6 +583,7 @@ CONFIG_REGULATOR_AXP20X=y
- CONFIG_REGULATOR_BD718XX=y
+@@ -678,6 +678,7 @@ CONFIG_REGULATOR_BD718XX=y
  CONFIG_REGULATOR_BD9571MWV=y
+ CONFIG_REGULATOR_CROS_EC=y
  CONFIG_REGULATOR_FAN53555=y
 +CONFIG_REGULATOR_FAN53200=y
  CONFIG_REGULATOR_GPIO=y
  CONFIG_REGULATOR_HI6421V530=y
  CONFIG_REGULATOR_HI655X=y
 diff --git a/drivers/regulator/Kconfig b/drivers/regulator/Kconfig
-index 020a00d..4ec41c5 100644
+index aae28d0a489c..9c565061bfd9 100644
 --- a/drivers/regulator/Kconfig
 +++ b/drivers/regulator/Kconfig
-@@ -356,6 +356,17 @@ config REGULATOR_FAN53880
+@@ -385,6 +385,17 @@ config REGULATOR_FAN53880
  	  (PMIC), it is controlled by I2C and provides one BUCK, one BOOST
  	  and four LDO outputs.
  
@@ -52,10 +51,10 @@ index 020a00d..4ec41c5 100644
  	tristate "GPIO regulator support"
  	depends on GPIOLIB || COMPILE_TEST
 diff --git a/drivers/regulator/Makefile b/drivers/regulator/Makefile
-index 6ebae51..9d6ea41 100644
+index ee383d8fc835..69bcd7711784 100644
 --- a/drivers/regulator/Makefile
 +++ b/drivers/regulator/Makefile
-@@ -44,6 +44,7 @@ obj-$(CONFIG_REGULATOR_DBX500_PRCMU) += dbx500-prcmu.o
+@@ -46,6 +46,7 @@ obj-$(CONFIG_REGULATOR_DBX500_PRCMU) += dbx500-prcmu.o
  obj-$(CONFIG_REGULATOR_DB8500_PRCMU) += db8500-prcmu.o
  obj-$(CONFIG_REGULATOR_FAN53555) += fan53555.o
  obj-$(CONFIG_REGULATOR_FAN53880) += fan53880.o
@@ -65,7 +64,7 @@ index 6ebae51..9d6ea41 100644
  obj-$(CONFIG_REGULATOR_HI6421V530) += hi6421v530-regulator.o
 diff --git a/drivers/regulator/fan53200.c b/drivers/regulator/fan53200.c
 new file mode 100644
-index 0000000..e40570b
+index 000000000000..19d7b74eb9b0
 --- /dev/null
 +++ b/drivers/regulator/fan53200.c
 @@ -0,0 +1,519 @@
@@ -589,6 +588,5 @@ index 0000000..e40570b
 +MODULE_DESCRIPTION("FAN53200 regulator driver");
 +MODULE_LICENSE("GPL v2");
 -- 
-2.7.4
-
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/rk3308-0001-pinctrl-slew-mux.patch
+++ b/patch/kernel/archive/rockchip64-6.3/rk3308-0001-pinctrl-slew-mux.patch
@@ -1,17 +1,87 @@
-diff --git a/include/linux/pinctrl/pinconf-generic.h b/include/linux/pinctrl/pinconf-generic.h
-index 2422211d6..a8b9b6c2b 100644
---- a/include/linux/pinctrl/pinconf-generic.h
-+++ b/include/linux/pinctrl/pinconf-generic.h
-@@ -137,6 +137,7 @@ enum pin_config_param {
- 	PIN_CONFIG_SKEW_DELAY,
- 	PIN_CONFIG_SLEEP_HARDWARE_STATE,
- 	PIN_CONFIG_SLEW_RATE,
-+	PIN_CONFIG_MUX,
- 	PIN_CONFIG_END = 0x7F,
- 	PIN_CONFIG_MAX = 0xFF,
- };
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: brentr <brent@mbari.org>
+Date: Thu, 13 Oct 2022 18:34:43 +0200
+Subject: [ARCHEOLOGY] Rockpis wifi fixes (#4008)
+
+> X-Git-Archeology: > recovered message: > * RockPI-S board has no video I/O
+> X-Git-Archeology: > recovered message: > * udev rule to fix MAC address of iface based on UUID
+> X-Git-Archeology: > recovered message: > Deals with WiFi chip lacking any EEPROM to store its unique Ethernet MAC address
+> X-Git-Archeology: > recovered message: > Generic mechanism -- could be utilized for other boards having similar issues
+> X-Git-Archeology: > recovered message: > * Handy Device Tree overlays for the RockPI S
+> X-Git-Archeology: > recovered message: > Use armbian-add-overlay to install these
+> X-Git-Archeology: > recovered message: > Reduce CPU voltage for the RK3308 B-S
+> X-Git-Archeology: > recovered message: > Option to overclock RK3308 B-S to 1.3Ghz
+> X-Git-Archeology: > recovered message: > Increase SDIO clock rate from 1Mhz to 10Mhz
+> X-Git-Archeology: > recovered message: > This increases WiFi throughput from 300K bytes/s to 2.4M bytes/s
+> X-Git-Archeology: > recovered message: > * corrected comment
+> X-Git-Archeology: > recovered message: > * No longer repeat standard opp's in this dts
+> X-Git-Archeology: > recovered message: > Require that the standard bs dts already be installed
+> X-Git-Archeology: > recovered message: > * User README for adding RockPI-S board variant specific dts overlays
+> X-Git-Archeology: > recovered message: > * "enabled" --> "okay"
+> X-Git-Archeology: > recovered message: > * added mention of sdnand.dts, fixed typo
+> X-Git-Archeology: > recovered message: > * added p2p0 to interfaces whose MAC address should be "fixed"
+> X-Git-Archeology: > recovered message: > * RK3308 CPU serial number in nvmem replaces UUID for derivation of fixed MAC addr
+> X-Git-Archeology: > recovered message: > Restored use of install utility
+> X-Git-Archeology: > recovered message: > * Use RK3308 specific CPU serial number
+> X-Git-Archeology: > recovered message: > rather than rootfs UUID
+> X-Git-Archeology: > recovered message: > * remove generic fixMACaddress
+> X-Git-Archeology: > recovered message: > * Install fixMACaddr file-by-file via install utility
+> X-Git-Archeology: > recovered message: > * Drive SDIO bus signals faster
+> X-Git-Archeology: > recovered message: > setting RK3308_SOC_CON0_VCCIO3 reduces signal rise/fall times to WiFi SDIO chip
+> X-Git-Archeology: > recovered message: > from 30ns to 5ns.
+> X-Git-Archeology: > recovered message: > This odd fix forward ported from legacy kernel.
+> X-Git-Archeology: > recovered message: > Allows Rock Pi-S WiFi to operate at full speed.
+> X-Git-Archeology: > recovered message: > * Set RK3308 I/O voltage domains before SDIO initializes
+> X-Git-Archeology: > recovered message: > This patch moves responibility form the io-domain to the pinctrl driver because
+> X-Git-Archeology: > recovered message: > the io-domain driver is probed after the SDIO devices are discovered.
+> X-Git-Archeology: > recovered message: > This was causing multiple SDIO I/O failures during boot.
+> X-Git-Archeology: > recovered message: > A new pinctrl property is added:
+> X-Git-Archeology: > recovered message: > io-1v8-domains
+> X-Git-Archeology: > recovered message: > is a u32 interpreted as a bit mask where each set bit corresponds to
+> X-Git-Archeology: > recovered message: > a 1.8V I/O domain (as opposed to the default of 3.3V for I/O)
+> X-Git-Archeology: > recovered message: > The mask is writted to the RK3308_SOC_CON0 GRF register
+> X-Git-Archeology: > recovered message: > (once) when the pinctrl driver starts
+> X-Git-Archeology: > recovered message: > The default mask is 0x10 where only I/O domain 4 runs at 1.8V
+> X-Git-Archeology: > recovered message: > This is necessary for the RockPI-S to run the SDIO clock at high (50Mhz) speed
+> X-Git-Archeology: > recovered message: > * align whitespace
+> X-Git-Archeology: > recovered message: > * factored rk3308bs overlays out up sdio speedup patch
+> X-Git-Archeology: > recovered message: > * factored dts for RK3308 iodomains and pinctrl patches out of speedup patch
+> X-Git-Archeology: > recovered message: > * remains of sdio speedup patch merely add iodomains support for rk3308
+> X-Git-Archeology: > recovered message: > * factored rockpis dts modification out from rk3308 io voltage domains
+> X-Git-Archeology: > recovered message: > replaced rk3308 support from iodomains with
+> X-Git-Archeology: > recovered message: > new io-voltage-domains property added to pinctrl
+> X-Git-Archeology: > recovered message: > io-voltage-domains specific to rk3308 for now, others SOCs may be added later.
+> X-Git-Archeology: > recovered message: > * add sequence numbering to names of rk3308 patches
+> X-Git-Archeology: > recovered message: > * corrected tab alignment
+> X-Git-Archeology: - Revision d3a3afe3850861ceaeb44f3631251c764a28cd43: https://github.com/armbian/build/commit/d3a3afe3850861ceaeb44f3631251c764a28cd43
+> X-Git-Archeology:   Date: Thu, 13 Oct 2022 18:34:43 +0200
+> X-Git-Archeology:   From: brentr <brent@mbari.org>
+> X-Git-Archeology:   Subject: Rockpis wifi fixes (#4008)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ drivers/pinctrl/pinconf-generic.c       |  1 +
+ drivers/pinctrl/pinctrl-rockchip.c      | 95 ++++++++++
+ drivers/pinctrl/pinctrl-rockchip.h      |  3 +
+ include/linux/pinctrl/pinconf-generic.h |  1 +
+ 4 files changed, 100 insertions(+)
+
 diff --git a/drivers/pinctrl/pinconf-generic.c b/drivers/pinctrl/pinconf-generic.c
-index 415d1df8f..45ca3505f 100644
+index 365c4b0ca465..bacc2987c55b 100644
 --- a/drivers/pinctrl/pinconf-generic.c
 +++ b/drivers/pinctrl/pinconf-generic.c
 @@ -51,6 +51,7 @@ static const struct pin_config_item conf_items[] = {
@@ -23,10 +93,10 @@ index 415d1df8f..45ca3505f 100644
  
  static void pinconf_generic_dump_one(struct pinctrl_dev *pctldev,
 diff --git a/drivers/pinctrl/pinctrl-rockchip.c b/drivers/pinctrl/pinctrl-rockchip.c
-index 32e41395f..f1fed12c4 100644
+index 0276b52f3716..dde241eaf07a 100644
 --- a/drivers/pinctrl/pinctrl-rockchip.c
 +++ b/drivers/pinctrl/pinctrl-rockchip.c
-@@ -2213,6 +2213,26 @@ static int rockchip_set_pull(struct rockchip_pin_bank *bank,
+@@ -2534,6 +2534,26 @@ static int rockchip_set_pull(struct rockchip_pin_bank *bank,
  	return ret;
  }
  
@@ -53,7 +123,7 @@ index 32e41395f..f1fed12c4 100644
  #define RK3328_SCHMITT_BITS_PER_PIN		1
  #define RK3328_SCHMITT_PINS_PER_REG		16
  #define RK3328_SCHMITT_BANK_STRIDE		8
-@@ -2326,6 +2346,51 @@ static int rockchip_set_schmitt(struct rockchip_pin_bank *bank,
+@@ -2647,6 +2667,51 @@ static int rockchip_set_schmitt(struct rockchip_pin_bank *bank,
  	return regmap_update_bits(regmap, reg, rmask, data);
  }
  
@@ -105,7 +175,7 @@ index 32e41395f..f1fed12c4 100644
  /*
   * Pinmux_ops handling
   */
-@@ -2544,6 +2609,15 @@ static int rockchip_pinconf_set(struct pinctrl_dev *pctldev, unsigned int pin,
+@@ -2879,6 +2944,15 @@ static int rockchip_pinconf_set(struct pinctrl_dev *pctldev, unsigned int pin,
  			if (rc < 0)
  				return rc;
  			break;
@@ -121,7 +191,7 @@ index 32e41395f..f1fed12c4 100644
  		default:
  			return -ENOTSUPP;
  			break;
-@@ -2618,6 +2692,26 @@ static int rockchip_pinconf_get(struct pinctrl_dev *pctldev, unsigned int pin,
+@@ -2953,6 +3027,26 @@ static int rockchip_pinconf_get(struct pinctrl_dev *pctldev, unsigned int pin,
  		if (rc < 0)
  			return rc;
  
@@ -148,7 +218,7 @@ index 32e41395f..f1fed12c4 100644
  		arg = rc;
  		break;
  	default:
-@@ -3380,6 +3474,7 @@ static struct rockchip_pin_ctrl rk3308_pin_ctrl = {
+@@ -3760,6 +3854,7 @@ static struct rockchip_pin_ctrl rk3308_pin_ctrl = {
  		.pull_calc_reg		= rk3308_calc_pull_reg_and_bit,
  		.drv_calc_reg		= rk3308_calc_drv_reg_and_bit,
  		.schmitt_calc_reg	= rk3308_calc_schmitt_reg_and_bit,
@@ -157,10 +227,10 @@ index 32e41395f..f1fed12c4 100644
  
  static struct rockchip_pin_bank rk3328_pin_banks[] = {
 diff --git a/drivers/pinctrl/pinctrl-rockchip.h b/drivers/pinctrl/pinctrl-rockchip.h
-index ec46f8815..890c1b09e 100644
+index 4759f336941e..785f48791631 100644
 --- a/drivers/pinctrl/pinctrl-rockchip.h
 +++ b/drivers/pinctrl/pinctrl-rockchip.h
-@@ -405,6 +405,9 @@ struct rockchip_pin_ctrl {
+@@ -406,6 +406,9 @@ struct rockchip_pin_ctrl {
  	int	(*schmitt_calc_reg)(struct rockchip_pin_bank *bank,
  				    int pin_num, struct regmap **regmap,
  				    int *reg, u8 *bit);
@@ -170,3 +240,18 @@ index ec46f8815..890c1b09e 100644
  };
  
  struct rockchip_pin_config {
+diff --git a/include/linux/pinctrl/pinconf-generic.h b/include/linux/pinctrl/pinconf-generic.h
+index d74b7a4ea154..87bd22137988 100644
+--- a/include/linux/pinctrl/pinconf-generic.h
++++ b/include/linux/pinctrl/pinconf-generic.h
+@@ -142,6 +142,7 @@ enum pin_config_param {
+ 	PIN_CONFIG_SKEW_DELAY,
+ 	PIN_CONFIG_SLEEP_HARDWARE_STATE,
+ 	PIN_CONFIG_SLEW_RATE,
++	PIN_CONFIG_MUX,
+ 	PIN_CONFIG_END = 0x7F,
+ 	PIN_CONFIG_MAX = 0xFF,
+ };
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/rk3308-0002-iodomains.patch
+++ b/patch/kernel/archive/rockchip64-6.3/rk3308-0002-iodomains.patch
@@ -1,5 +1,84 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: brentr <brent@mbari.org>
+Date: Thu, 13 Oct 2022 18:34:43 +0200
+Subject: [ARCHEOLOGY] Rockpis wifi fixes (#4008)
+
+> X-Git-Archeology: > recovered message: > * RockPI-S board has no video I/O
+> X-Git-Archeology: > recovered message: > * udev rule to fix MAC address of iface based on UUID
+> X-Git-Archeology: > recovered message: > Deals with WiFi chip lacking any EEPROM to store its unique Ethernet MAC address
+> X-Git-Archeology: > recovered message: > Generic mechanism -- could be utilized for other boards having similar issues
+> X-Git-Archeology: > recovered message: > * Handy Device Tree overlays for the RockPI S
+> X-Git-Archeology: > recovered message: > Use armbian-add-overlay to install these
+> X-Git-Archeology: > recovered message: > Reduce CPU voltage for the RK3308 B-S
+> X-Git-Archeology: > recovered message: > Option to overclock RK3308 B-S to 1.3Ghz
+> X-Git-Archeology: > recovered message: > Increase SDIO clock rate from 1Mhz to 10Mhz
+> X-Git-Archeology: > recovered message: > This increases WiFi throughput from 300K bytes/s to 2.4M bytes/s
+> X-Git-Archeology: > recovered message: > * corrected comment
+> X-Git-Archeology: > recovered message: > * No longer repeat standard opp's in this dts
+> X-Git-Archeology: > recovered message: > Require that the standard bs dts already be installed
+> X-Git-Archeology: > recovered message: > * User README for adding RockPI-S board variant specific dts overlays
+> X-Git-Archeology: > recovered message: > * "enabled" --> "okay"
+> X-Git-Archeology: > recovered message: > * added mention of sdnand.dts, fixed typo
+> X-Git-Archeology: > recovered message: > * added p2p0 to interfaces whose MAC address should be "fixed"
+> X-Git-Archeology: > recovered message: > * RK3308 CPU serial number in nvmem replaces UUID for derivation of fixed MAC addr
+> X-Git-Archeology: > recovered message: > Restored use of install utility
+> X-Git-Archeology: > recovered message: > * Use RK3308 specific CPU serial number
+> X-Git-Archeology: > recovered message: > rather than rootfs UUID
+> X-Git-Archeology: > recovered message: > * remove generic fixMACaddress
+> X-Git-Archeology: > recovered message: > * Install fixMACaddr file-by-file via install utility
+> X-Git-Archeology: > recovered message: > * Drive SDIO bus signals faster
+> X-Git-Archeology: > recovered message: > setting RK3308_SOC_CON0_VCCIO3 reduces signal rise/fall times to WiFi SDIO chip
+> X-Git-Archeology: > recovered message: > from 30ns to 5ns.
+> X-Git-Archeology: > recovered message: > This odd fix forward ported from legacy kernel.
+> X-Git-Archeology: > recovered message: > Allows Rock Pi-S WiFi to operate at full speed.
+> X-Git-Archeology: > recovered message: > * Set RK3308 I/O voltage domains before SDIO initializes
+> X-Git-Archeology: > recovered message: > This patch moves responibility form the io-domain to the pinctrl driver because
+> X-Git-Archeology: > recovered message: > the io-domain driver is probed after the SDIO devices are discovered.
+> X-Git-Archeology: > recovered message: > This was causing multiple SDIO I/O failures during boot.
+> X-Git-Archeology: > recovered message: > A new pinctrl property is added:
+> X-Git-Archeology: > recovered message: > io-1v8-domains
+> X-Git-Archeology: > recovered message: > is a u32 interpreted as a bit mask where each set bit corresponds to
+> X-Git-Archeology: > recovered message: > a 1.8V I/O domain (as opposed to the default of 3.3V for I/O)
+> X-Git-Archeology: > recovered message: > The mask is writted to the RK3308_SOC_CON0 GRF register
+> X-Git-Archeology: > recovered message: > (once) when the pinctrl driver starts
+> X-Git-Archeology: > recovered message: > The default mask is 0x10 where only I/O domain 4 runs at 1.8V
+> X-Git-Archeology: > recovered message: > This is necessary for the RockPI-S to run the SDIO clock at high (50Mhz) speed
+> X-Git-Archeology: > recovered message: > * align whitespace
+> X-Git-Archeology: > recovered message: > * factored rk3308bs overlays out up sdio speedup patch
+> X-Git-Archeology: > recovered message: > * factored dts for RK3308 iodomains and pinctrl patches out of speedup patch
+> X-Git-Archeology: > recovered message: > * remains of sdio speedup patch merely add iodomains support for rk3308
+> X-Git-Archeology: > recovered message: > * factored rockpis dts modification out from rk3308 io voltage domains
+> X-Git-Archeology: > recovered message: > replaced rk3308 support from iodomains with
+> X-Git-Archeology: > recovered message: > new io-voltage-domains property added to pinctrl
+> X-Git-Archeology: > recovered message: > io-voltage-domains specific to rk3308 for now, others SOCs may be added later.
+> X-Git-Archeology: > recovered message: > * add sequence numbering to names of rk3308 patches
+> X-Git-Archeology: > recovered message: > * corrected tab alignment
+> X-Git-Archeology: - Revision d3a3afe3850861ceaeb44f3631251c764a28cd43: https://github.com/armbian/build/commit/d3a3afe3850861ceaeb44f3631251c764a28cd43
+> X-Git-Archeology:   Date: Thu, 13 Oct 2022 18:34:43 +0200
+> X-Git-Archeology:   From: brentr <brent@mbari.org>
+> X-Git-Archeology:   Subject: Rockpis wifi fixes (#4008)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ drivers/soc/rockchip/io-domain.c | 45 ++++++++++
+ 1 file changed, 45 insertions(+)
+
 diff --git a/drivers/soc/rockchip/io-domain.c b/drivers/soc/rockchip/io-domain.c
-index 9df513d12..83f5354ba 100644
+index 6619256c2d11..6ffaccd3ed80 100644
 --- a/drivers/soc/rockchip/io-domain.c
 +++ b/drivers/soc/rockchip/io-domain.c
 @@ -39,6 +39,10 @@
@@ -64,7 +143,7 @@ index 9df513d12..83f5354ba 100644
  static const struct rockchip_iodomain_soc_data soc_data_rk3328 = {
  	.grf_offset = 0x410,
  	.supply_names = {
-@@ -512,6 +553,10 @@ static const struct of_device_id rockchip_iodomain_match[] = {
+@@ -528,6 +569,10 @@ static const struct of_device_id rockchip_iodomain_match[] = {
  		.compatible = "rockchip,rk3288-io-voltage-domain",
  		.data = &soc_data_rk3288
  	},
@@ -75,3 +154,6 @@ index 9df513d12..83f5354ba 100644
  	{
  		.compatible = "rockchip,rk3328-io-voltage-domain",
  		.data = &soc_data_rk3328
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/rk3308-0003-pinctrl-io-voltage-domains.patch
+++ b/patch/kernel/archive/rockchip64-6.3/rk3308-0003-pinctrl-io-voltage-domains.patch
@@ -1,5 +1,85 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: brentr <brent@mbari.org>
+Date: Thu, 13 Oct 2022 18:34:43 +0200
+Subject: [ARCHEOLOGY] Rockpis wifi fixes (#4008)
+
+> X-Git-Archeology: > recovered message: > * RockPI-S board has no video I/O
+> X-Git-Archeology: > recovered message: > * udev rule to fix MAC address of iface based on UUID
+> X-Git-Archeology: > recovered message: > Deals with WiFi chip lacking any EEPROM to store its unique Ethernet MAC address
+> X-Git-Archeology: > recovered message: > Generic mechanism -- could be utilized for other boards having similar issues
+> X-Git-Archeology: > recovered message: > * Handy Device Tree overlays for the RockPI S
+> X-Git-Archeology: > recovered message: > Use armbian-add-overlay to install these
+> X-Git-Archeology: > recovered message: > Reduce CPU voltage for the RK3308 B-S
+> X-Git-Archeology: > recovered message: > Option to overclock RK3308 B-S to 1.3Ghz
+> X-Git-Archeology: > recovered message: > Increase SDIO clock rate from 1Mhz to 10Mhz
+> X-Git-Archeology: > recovered message: > This increases WiFi throughput from 300K bytes/s to 2.4M bytes/s
+> X-Git-Archeology: > recovered message: > * corrected comment
+> X-Git-Archeology: > recovered message: > * No longer repeat standard opp's in this dts
+> X-Git-Archeology: > recovered message: > Require that the standard bs dts already be installed
+> X-Git-Archeology: > recovered message: > * User README for adding RockPI-S board variant specific dts overlays
+> X-Git-Archeology: > recovered message: > * "enabled" --> "okay"
+> X-Git-Archeology: > recovered message: > * added mention of sdnand.dts, fixed typo
+> X-Git-Archeology: > recovered message: > * added p2p0 to interfaces whose MAC address should be "fixed"
+> X-Git-Archeology: > recovered message: > * RK3308 CPU serial number in nvmem replaces UUID for derivation of fixed MAC addr
+> X-Git-Archeology: > recovered message: > Restored use of install utility
+> X-Git-Archeology: > recovered message: > * Use RK3308 specific CPU serial number
+> X-Git-Archeology: > recovered message: > rather than rootfs UUID
+> X-Git-Archeology: > recovered message: > * remove generic fixMACaddress
+> X-Git-Archeology: > recovered message: > * Install fixMACaddr file-by-file via install utility
+> X-Git-Archeology: > recovered message: > * Drive SDIO bus signals faster
+> X-Git-Archeology: > recovered message: > setting RK3308_SOC_CON0_VCCIO3 reduces signal rise/fall times to WiFi SDIO chip
+> X-Git-Archeology: > recovered message: > from 30ns to 5ns.
+> X-Git-Archeology: > recovered message: > This odd fix forward ported from legacy kernel.
+> X-Git-Archeology: > recovered message: > Allows Rock Pi-S WiFi to operate at full speed.
+> X-Git-Archeology: > recovered message: > * Set RK3308 I/O voltage domains before SDIO initializes
+> X-Git-Archeology: > recovered message: > This patch moves responibility form the io-domain to the pinctrl driver because
+> X-Git-Archeology: > recovered message: > the io-domain driver is probed after the SDIO devices are discovered.
+> X-Git-Archeology: > recovered message: > This was causing multiple SDIO I/O failures during boot.
+> X-Git-Archeology: > recovered message: > A new pinctrl property is added:
+> X-Git-Archeology: > recovered message: > io-1v8-domains
+> X-Git-Archeology: > recovered message: > is a u32 interpreted as a bit mask where each set bit corresponds to
+> X-Git-Archeology: > recovered message: > a 1.8V I/O domain (as opposed to the default of 3.3V for I/O)
+> X-Git-Archeology: > recovered message: > The mask is writted to the RK3308_SOC_CON0 GRF register
+> X-Git-Archeology: > recovered message: > (once) when the pinctrl driver starts
+> X-Git-Archeology: > recovered message: > The default mask is 0x10 where only I/O domain 4 runs at 1.8V
+> X-Git-Archeology: > recovered message: > This is necessary for the RockPI-S to run the SDIO clock at high (50Mhz) speed
+> X-Git-Archeology: > recovered message: > * align whitespace
+> X-Git-Archeology: > recovered message: > * factored rk3308bs overlays out up sdio speedup patch
+> X-Git-Archeology: > recovered message: > * factored dts for RK3308 iodomains and pinctrl patches out of speedup patch
+> X-Git-Archeology: > recovered message: > * remains of sdio speedup patch merely add iodomains support for rk3308
+> X-Git-Archeology: > recovered message: > * factored rockpis dts modification out from rk3308 io voltage domains
+> X-Git-Archeology: > recovered message: > replaced rk3308 support from iodomains with
+> X-Git-Archeology: > recovered message: > new io-voltage-domains property added to pinctrl
+> X-Git-Archeology: > recovered message: > io-voltage-domains specific to rk3308 for now, others SOCs may be added later.
+> X-Git-Archeology: > recovered message: > * add sequence numbering to names of rk3308 patches
+> X-Git-Archeology: > recovered message: > * corrected tab alignment
+> X-Git-Archeology: - Revision d3a3afe3850861ceaeb44f3631251c764a28cd43: https://github.com/armbian/build/commit/d3a3afe3850861ceaeb44f3631251c764a28cd43
+> X-Git-Archeology:   Date: Thu, 13 Oct 2022 18:34:43 +0200
+> X-Git-Archeology:   From: brentr <brent@mbari.org>
+> X-Git-Archeology:   Subject: Rockpis wifi fixes (#4008)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ drivers/pinctrl/pinctrl-rockchip.c | 24 +++++
+ drivers/soc/rockchip/io-domain.c   | 45 ----------
+ 2 files changed, 24 insertions(+), 45 deletions(-)
+
 diff --git a/drivers/pinctrl/pinctrl-rockchip.c b/drivers/pinctrl/pinctrl-rockchip.c
-index f1fed12c4..36ff5827d 100644
+index dde241eaf07a..ca19decddd44 100644
 --- a/drivers/pinctrl/pinctrl-rockchip.c
 +++ b/drivers/pinctrl/pinctrl-rockchip.c
 @@ -41,6 +41,12 @@
@@ -15,7 +95,7 @@ index f1fed12c4..36ff5827d 100644
  /*
   * Generate a bitmask for setting a value (v) with a write mask bit in hiword
   * register 31:16 area.
-@@ -3177,6 +3183,24 @@ static int rockchip_pinctrl_probe(struct platform_device *pdev)
+@@ -3515,6 +3521,24 @@ static int rockchip_pinctrl_probe(struct platform_device *pdev)
  	if (ret)
  		return ret;
  
@@ -41,7 +121,7 @@ index f1fed12c4..36ff5827d 100644
  
  	ret = of_platform_populate(np, NULL, NULL, &pdev->dev);
 diff --git a/drivers/soc/rockchip/io-domain.c b/drivers/soc/rockchip/io-domain.c
-index 83f5354ba..9df513d12 100644
+index 6ffaccd3ed80..6619256c2d11 100644
 --- a/drivers/soc/rockchip/io-domain.c
 +++ b/drivers/soc/rockchip/io-domain.c
 @@ -39,10 +39,6 @@
@@ -106,7 +186,7 @@ index 83f5354ba..9df513d12 100644
  static const struct rockchip_iodomain_soc_data soc_data_rk3328 = {
  	.grf_offset = 0x410,
  	.supply_names = {
-@@ -553,10 +512,6 @@ static const struct of_device_id rockchip_iodomain_match[] = {
+@@ -569,10 +528,6 @@ static const struct of_device_id rockchip_iodomain_match[] = {
  		.compatible = "rockchip,rk3288-io-voltage-domain",
  		.data = &soc_data_rk3288
  	},
@@ -117,3 +197,6 @@ index 83f5354ba..9df513d12 100644
  	{
  		.compatible = "rockchip,rk3328-io-voltage-domain",
  		.data = &soc_data_rk3328
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/rk3328-add-dmc-driver.patch
+++ b/patch/kernel/archive/rockchip64-6.3/rk3328-add-dmc-driver.patch
@@ -1,30 +1,26 @@
-From 2fe9cfa1de2444f38b13d577a2ce67383ee0ccb6 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
 Date: Tue, 12 Oct 2021 18:45:05 +0000
-Subject: [PATCH] rk3328 dmc driver
+Subject: rk3328 dmc driver
 
 ---
- .../rockchip/rk3328-dram-default-timing.dtsi  | 311 +++++++
- arch/arm64/boot/dts/rockchip/rk3328.dtsi      |  61 ++
- drivers/clk/rockchip/clk-ddr.c                | 131 +++
- drivers/clk/rockchip/clk-rk3328.c             |  13 +-
- drivers/clk/rockchip/clk.h                    |   3 +-
- drivers/devfreq/Kconfig                       |  12 +
- drivers/devfreq/Makefile                      |   1 +
- drivers/devfreq/event/rockchip-dfi.c          | 554 ++++++++++-
- drivers/devfreq/rk3328_dmc.c                  | 863 ++++++++++++++++++
- include/dt-bindings/clock/rockchip-ddr.h      |  63 ++
- include/dt-bindings/memory/rk3328-dram.h      | 159 ++++
- include/soc/rockchip/rockchip_sip.h           |  11 +
- 12 files changed, 2126 insertions(+), 56 deletions(-)
- create mode 100644 arch/arm64/boot/dts/rockchip/rk3328-dram-default-timing.dtsi
- create mode 100644 drivers/devfreq/rk3328_dmc.c
- create mode 100644 include/dt-bindings/clock/rockchip-ddr.h
- create mode 100644 include/dt-bindings/memory/rk3328-dram.h
+ arch/arm64/boot/dts/rockchip/rk3328-dram-default-timing.dtsi | 311 ++++
+ arch/arm64/boot/dts/rockchip/rk3328.dtsi                     |  61 +
+ drivers/clk/rockchip/clk-ddr.c                               | 131 ++
+ drivers/clk/rockchip/clk-rk3328.c                            |  13 +-
+ drivers/clk/rockchip/clk.h                                   |   3 +-
+ drivers/devfreq/Kconfig                                      |  12 +
+ drivers/devfreq/Makefile                                     |   1 +
+ drivers/devfreq/event/rockchip-dfi.c                         | 554 +++++-
+ drivers/devfreq/rk3328_dmc.c                                 | 836 ++++++++++
+ include/dt-bindings/clock/rockchip-ddr.h                     |  63 +
+ include/dt-bindings/memory/rk3328-dram.h                     | 159 ++
+ include/soc/rockchip/rockchip_sip.h                          |  11 +
+ 12 files changed, 2099 insertions(+), 56 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328-dram-default-timing.dtsi b/arch/arm64/boot/dts/rockchip/rk3328-dram-default-timing.dtsi
 new file mode 100644
-index 000000000..a3f5ff4bd
+index 000000000000..a3f5ff4bdc47
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-dram-default-timing.dtsi
 @@ -0,0 +1,311 @@
@@ -340,10 +336,10 @@ index 000000000..a3f5ff4bd
 +	};
 +};
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328.dtsi b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
-index e546c9d1d..3a3a366f1 100644
+index 7a7bf3aafd31..2425ed0e94c4 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3328.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
-@@ -564,6 +564,67 @@ tsadc: tsadc@ff250000 {
+@@ -565,6 +565,67 @@ tsadc: tsadc@ff250000 {
  		status = "disabled";
  	};
  
@@ -412,7 +408,7 @@ index e546c9d1d..3a3a366f1 100644
  		compatible = "rockchip,rk3328-efuse";
  		reg = <0x0 0xff260000 0x0 0x50>;
 diff --git a/drivers/clk/rockchip/clk-ddr.c b/drivers/clk/rockchip/clk-ddr.c
-index 86718c54e..08b313495 100644
+index 86718c54e56b..08b313495e8c 100644
 --- a/drivers/clk/rockchip/clk-ddr.c
 +++ b/drivers/clk/rockchip/clk-ddr.c
 @@ -87,6 +87,134 @@ static const struct clk_ops rockchip_ddrclk_sip_ops = {
@@ -561,10 +557,10 @@ index 86718c54e..08b313495 100644
  		pr_err("%s: unsupported ddrclk type %d\n", __func__, ddr_flag);
  		kfree(ddrclk);
 diff --git a/drivers/clk/rockchip/clk-rk3328.c b/drivers/clk/rockchip/clk-rk3328.c
-index 2429b7c2a..c37fae805 100644
+index 267ab54937d3..aa4afc8a17aa 100644
 --- a/drivers/clk/rockchip/clk-rk3328.c
 +++ b/drivers/clk/rockchip/clk-rk3328.c
-@@ -314,14 +314,15 @@ static struct rockchip_clk_branch rk3328_clk_branches[] __initdata = {
+@@ -315,14 +315,15 @@ static struct rockchip_clk_branch rk3328_clk_branches[] __initdata = {
  			RK3328_CLKGATE_CON(14), 1, GFLAGS),
  
  	/* PD_DDR */
@@ -587,10 +583,10 @@ index 2429b7c2a..c37fae805 100644
  	GATE(0, "clk_ddrmon", "xin24m", CLK_IGNORE_UNUSED,
  			RK3328_CLKGATE_CON(0), 6, GFLAGS),
 diff --git a/drivers/clk/rockchip/clk.h b/drivers/clk/rockchip/clk.h
-index 2271a8412..7405aaf96 100644
+index 758ebaf2236b..fe033ebcb62d 100644
 --- a/drivers/clk/rockchip/clk.h
 +++ b/drivers/clk/rockchip/clk.h
-@@ -362,7 +362,8 @@ struct clk *rockchip_clk_register_mmc(const char *name,
+@@ -486,7 +486,8 @@ struct clk *rockchip_clk_register_mmc(const char *name,
   * DDRCLK flags, including method of setting the rate
   * ROCKCHIP_DDRCLK_SIP: use SIP call to bl31 to change ddrclk rate.
   */
@@ -601,12 +597,12 @@ index 2271a8412..7405aaf96 100644
  struct clk *rockchip_clk_register_ddrclk(const char *name, int flags,
  					 const char *const *parent_names,
 diff --git a/drivers/devfreq/Kconfig b/drivers/devfreq/Kconfig
-index 37dc40d1f..15fedc95a 100644
+index 9754d8b31621..c3380b360c68 100644
 --- a/drivers/devfreq/Kconfig
 +++ b/drivers/devfreq/Kconfig
-@@ -131,6 +131,18 @@ config ARM_TEGRA20_DEVFREQ
- 	  It reads Memory Controller counters and adjusts the operating
- 	  frequencies and voltages with OPP support.
+@@ -130,6 +130,18 @@ config ARM_MEDIATEK_CCI_DEVFREQ
+ 	  buck voltages and update a proper CCI frequency. Use the notification
+ 	  to get the regulator status.
  
 +config ARM_RK3328_DMC_DEVFREQ
 +	tristate "ARM RK3328 DMC DEVFREQ Driver"
@@ -624,19 +620,19 @@ index 37dc40d1f..15fedc95a 100644
  	tristate "ARM RK3399 DMC DEVFREQ Driver"
  	depends on (ARCH_ROCKCHIP && HAVE_ARM_SMCCC) || \
 diff --git a/drivers/devfreq/Makefile b/drivers/devfreq/Makefile
-index 3ca1ad0ec..2fe9340f2 100644
+index bf40d04928d0..08c0738ae439 100644
 --- a/drivers/devfreq/Makefile
 +++ b/drivers/devfreq/Makefile
-@@ -12,6 +12,7 @@ obj-$(CONFIG_ARM_EXYNOS_BUS_DEVFREQ)	+= exynos-bus.o
- obj-$(CONFIG_ARM_IMX_BUS_DEVFREQ)	+= imx-bus.o
+@@ -13,6 +13,7 @@ obj-$(CONFIG_ARM_IMX_BUS_DEVFREQ)	+= imx-bus.o
  obj-$(CONFIG_ARM_IMX8M_DDRC_DEVFREQ)	+= imx8m-ddrc.o
+ obj-$(CONFIG_ARM_MEDIATEK_CCI_DEVFREQ)	+= mtk-cci-devfreq.o
  obj-$(CONFIG_ARM_RK3399_DMC_DEVFREQ)	+= rk3399_dmc.o
 +obj-$(CONFIG_ARM_RK3328_DMC_DEVFREQ)	+= rk3328_dmc.o
  obj-$(CONFIG_ARM_SUN8I_A33_MBUS_DEVFREQ)	+= sun8i-a33-mbus.o
- obj-$(CONFIG_ARM_TEGRA_DEVFREQ)	+= tegra30-devfreq.o
+ obj-$(CONFIG_ARM_TEGRA_DEVFREQ)		+= tegra30-devfreq.o
  
 diff --git a/drivers/devfreq/event/rockchip-dfi.c b/drivers/devfreq/event/rockchip-dfi.c
-index 9a88faaf8..c034df869 100644
+index 39ac069cabc7..7d53fc10c63b 100644
 --- a/drivers/devfreq/event/rockchip-dfi.c
 +++ b/drivers/devfreq/event/rockchip-dfi.c
 @@ -18,25 +18,66 @@
@@ -1187,7 +1183,7 @@ index 9a88faaf8..c034df869 100644
  
  	data->regs = devm_platform_ioremap_resource(pdev, 0);
  	if (IS_ERR(data->regs))
-@@ -202,21 +582,97 @@ static int rockchip_dfi_probe(struct platform_device *pdev)
+@@ -201,21 +581,97 @@ static int rockchip_dfi_probe(struct platform_device *pdev)
  		if (IS_ERR(data->regmap_pmu))
  			return PTR_ERR(data->regmap_pmu);
  	}
@@ -1292,7 +1288,7 @@ index 9a88faaf8..c034df869 100644
  
 diff --git a/drivers/devfreq/rk3328_dmc.c b/drivers/devfreq/rk3328_dmc.c
 new file mode 100644
-index 00000000000..7665526f086
+index 000000000000..7665526f0863
 --- /dev/null
 +++ b/drivers/devfreq/rk3328_dmc.c
 @@ -0,0 +1,836 @@
@@ -2134,7 +2130,7 @@ index 00000000000..7665526f086
 +MODULE_DESCRIPTION("RK3328 dmcfreq driver with devfreq framework");
 diff --git a/include/dt-bindings/clock/rockchip-ddr.h b/include/dt-bindings/clock/rockchip-ddr.h
 new file mode 100644
-index 000000000..b065432e7
+index 000000000000..b065432e7793
 --- /dev/null
 +++ b/include/dt-bindings/clock/rockchip-ddr.h
 @@ -0,0 +1,63 @@
@@ -2203,7 +2199,7 @@ index 000000000..b065432e7
 +#endif
 diff --git a/include/dt-bindings/memory/rk3328-dram.h b/include/dt-bindings/memory/rk3328-dram.h
 new file mode 100644
-index 000000000..171f41c25
+index 000000000000..171f41c256d3
 --- /dev/null
 +++ b/include/dt-bindings/memory/rk3328-dram.h
 @@ -0,0 +1,159 @@
@@ -2367,7 +2363,7 @@ index 000000000..171f41c25
 +
 +#endif /*_DT_BINDINGS_DRAM_ROCKCHIP_RK3328_H*/
 diff --git a/include/soc/rockchip/rockchip_sip.h b/include/soc/rockchip/rockchip_sip.h
-index c46a9ae2a..fa7e0a2d7 100644
+index c46a9ae2a2ab..fa7e0a2d72cc 100644
 --- a/include/soc/rockchip/rockchip_sip.h
 +++ b/include/soc/rockchip/rockchip_sip.h
 @@ -16,5 +16,16 @@
@@ -2388,5 +2384,5 @@ index c46a9ae2a..fa7e0a2d7 100644
  
  #endif
 -- 
-2.30.2
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/rk3328-add-rga-node.patch
+++ b/patch/kernel/archive/rockchip64-6.3/rk3328-add-rga-node.patch
@@ -1,17 +1,17 @@
-From c37d1b1a4ec6f517ba8a8b70d035979c0a9d4966 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
 Date: Thu, 21 Oct 2021 18:04:17 +0000
-Subject: [PATCH] rk3328: add RGA node
+Subject: rk3328: add RGA node
 
 ---
- arch/arm64/boot/dts/rockchip/rk3328.dtsi | 14 ++++++++++++++
+ arch/arm64/boot/dts/rockchip/rk3328.dtsi | 14 ++++++++++
  1 file changed, 14 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328.dtsi b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
-index 162e57936..ecff11781 100644
+index 2425ed0e94c4..e9f0f1e5ba32 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3328.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
-@@ -829,6 +829,20 @@ vop_mmu: iommu@ff373f00 {
+@@ -782,6 +782,20 @@ vop_mmu: iommu@ff373f00 {
  		status = "disabled";
  	};
  
@@ -33,5 +33,5 @@ index 162e57936..ecff11781 100644
  		compatible = "rockchip,rk3328-iep", "rockchip,rk3228-iep";
  		reg = <0x0 0xff3a0000 0x0 0x800>;
 -- 
-2.30.2
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/rk3328-device-tree-overlays-uart1-i2c0.patch
+++ b/patch/kernel/archive/rockchip64-6.3/rk3328-device-tree-overlays-uart1-i2c0.patch
@@ -1,23 +1,21 @@
-From 0a11005a8a39ed8d84c42a0f29636631db621f0a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kat Schwarz <schwar3kat@armbian.com>
 Date: Sun, 22 Jan 2023 21:16:07 +1300
-Subject: [PATCH] add-rk3328-dtbo-uart1-i2c0
+Subject: add-rk3328-dtbo-uart1-i2c0
 
 RK3328 UART1 and I2C0 are available on Orange Pi R1 Plus LTS 13 pin connector.
 Add two device tree overlay files for rk3328 uart1 and i2c0.
 
 Signed-off-by: Kat Schwarz <schwar3kat@armbian.com>
 ---
- arch/arm64/boot/dts/rockchip/overlay/Makefile   |  2 ++
- .../rockchip/overlay/README.rockchip-overlays   | 12 ++++++++++++
- .../rockchip/overlay/rockchip-rk3328-i2c0.dts   | 13 +++++++++++++
- .../rockchip/overlay/rockchip-rk3328-uart1.dts  | 17 +++++++++++++++++
+ arch/arm64/boot/dts/rockchip/overlay/Makefile                  |  2 ++
+ arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays  | 12 +++++++
+ arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2c0.dts  | 13 +++++++
+ arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-uart1.dts | 17 ++++++++++
  4 files changed, 44 insertions(+)
- create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2c0.dts
- create mode 100644 arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-uart1.dts
 
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/Makefile b/arch/arm64/boot/dts/rockchip/overlay/Makefile
-index 7813ae347..53f8412d7 100644
+index dafc367c69db..b0ddfce1a26d 100644
 --- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
 @@ -3,6 +3,8 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
@@ -30,10 +28,10 @@ index 7813ae347..53f8412d7 100644
  	rockchip-rk3328-opp-1.5ghz.dtbo \
  	rockchip-rk3399-opp-2ghz.dtbo \
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
-index 07e79b04d..16942a511 100644
+index 17b21826c79a..15a32759f78d 100644
 --- a/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
 +++ b/arch/arm64/boot/dts/rockchip/overlay/README.rockchip-overlays
-@@ -29,6 +29,18 @@ I2C8 pins (pi-conn) (pi-conn) (SCL, SDA): GPIO1-C5, GPIO1-C4
+@@ -33,6 +33,18 @@ I2C8 pins (SCL, SDA): GPIO1-C5, GPIO1-C4
  Enables PCIe Gen2 link speed on RK3399.
  WARNING! Not officially supported by Rockchip!!!
  
@@ -54,7 +52,7 @@ index 07e79b04d..16942a511 100644
  Adds the 1.4GHz opp for overclocking
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2c0.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2c0.dts
 new file mode 100644
-index 000000000..af2d61ecd
+index 000000000000..af2d61ecd648
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-i2c0.dts
 @@ -0,0 +1,13 @@
@@ -73,7 +71,7 @@ index 000000000..af2d61ecd
 +};
 diff --git a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-uart1.dts b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-uart1.dts
 new file mode 100644
-index 000000000..9ff6a0018
+index 000000000000..9ff6a0018ad2
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3328-uart1.dts
 @@ -0,0 +1,17 @@
@@ -95,5 +93,5 @@ index 000000000..9ff6a0018
 +	};
 +};
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/rk3328-dtsi-mali-opp-table.patch
+++ b/patch/kernel/archive/rockchip64-6.3/rk3328-dtsi-mali-opp-table.patch
@@ -1,19 +1,19 @@
-From 6ad5abe4a75d50cb6abfd1aff35ebba4998336df Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
 Date: Sat, 25 Sep 2021 15:26:41 +0000
-Subject: [PATCH] gpu operating points
+Subject: gpu operating points
 
 ---
- arch/arm64/boot/dts/rockchip/rk3328.dtsi | 25 ++++++++++++++++++++++++
+ arch/arm64/boot/dts/rockchip/rk3328.dtsi | 25 ++++++++++
  1 file changed, 25 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328.dtsi b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
-index c52c2a363..a69e40ee4 100644
+index e9f0f1e5ba32..732e123bb93d 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3328.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
-@@ -646,6 +646,31 @@ gpu: gpu@ff300000 {
+@@ -683,6 +683,31 @@ gpu: gpu@ff300000 {
+ 		clocks = <&cru ACLK_GPU>, <&cru ACLK_GPU>;
  		clock-names = "bus", "core";
- 		power-domains = <&power RK3328_PD_GPU>;
  		resets = <&cru SRST_GPU_A>;
 +		operating-points-v2 = <&gpu_opp_table>;
 +	};
@@ -41,8 +41,8 @@ index c52c2a363..a69e40ee4 100644
 +			opp-microvolt = <1150000 950000 1200000>;
 +		};
  	};
-
+ 
  	h265e_mmu: iommu@ff330200 {
---
-2.30.2
+-- 
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/rk3328-dtsi-mmc-reset-properties.patch
+++ b/patch/kernel/archive/rockchip64-6.3/rk3328-dtsi-mmc-reset-properties.patch
@@ -1,17 +1,17 @@
-From 169dff618823d0764624895413ac7cf0f0306e79 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
 Date: Sat, 25 Sep 2021 13:35:13 +0000
-Subject: [PATCH 2/4] mmc reset properties
+Subject: mmc reset properties
 
 ---
  arch/arm64/boot/dts/rockchip/rk3328.dtsi | 6 ++++++
  1 file changed, 6 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328.dtsi b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
-index a261c8f54..2a9fecc7d 100644
+index 732e123bb93d..c4637f71d325 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3328.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
-@@ -902,6 +902,8 @@ sdmmc: mmc@ff500000 {
+@@ -992,6 +992,8 @@ sdmmc: mmc@ff500000 {
  		clocks = <&cru HCLK_SDMMC>, <&cru SCLK_SDMMC>,
  			 <&cru SCLK_SDMMC_DRV>, <&cru SCLK_SDMMC_SAMPLE>;
  		clock-names = "biu", "ciu", "ciu-drive", "ciu-sample";
@@ -20,7 +20,7 @@ index a261c8f54..2a9fecc7d 100644
  		fifo-depth = <0x100>;
  		max-frequency = <150000000>;
  		status = "disabled";
-@@ -914,6 +916,8 @@ sdio: mmc@ff510000 {
+@@ -1004,6 +1006,8 @@ sdio: mmc@ff510000 {
  		clocks = <&cru HCLK_SDIO>, <&cru SCLK_SDIO>,
  			 <&cru SCLK_SDIO_DRV>, <&cru SCLK_SDIO_SAMPLE>;
  		clock-names = "biu", "ciu", "ciu-drive", "ciu-sample";
@@ -29,7 +29,7 @@ index a261c8f54..2a9fecc7d 100644
  		fifo-depth = <0x100>;
  		max-frequency = <150000000>;
  		status = "disabled";
-@@ -926,6 +930,8 @@ emmc: mmc@ff520000 {
+@@ -1016,6 +1020,8 @@ emmc: mmc@ff520000 {
  		clocks = <&cru HCLK_EMMC>, <&cru SCLK_EMMC>,
  			 <&cru SCLK_EMMC_DRV>, <&cru SCLK_EMMC_SAMPLE>;
  		clock-names = "biu", "ciu", "ciu-drive", "ciu-sample";
@@ -39,5 +39,5 @@ index a261c8f54..2a9fecc7d 100644
  		max-frequency = <150000000>;
  		status = "disabled";
 -- 
-2.30.2
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/rk3328-dtsi-sdmmc-ext-node.patch
+++ b/patch/kernel/archive/rockchip64-6.3/rk3328-dtsi-sdmmc-ext-node.patch
@@ -1,17 +1,17 @@
-From b3a4ba23d01ad2825a1efd013090f6c6bb352679 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
 Date: Sat, 25 Sep 2021 13:36:20 +0000
-Subject: [PATCH 3/4] sdmmc-ext node
+Subject: sdmmc-ext node
 
 ---
- arch/arm64/boot/dts/rockchip/rk3328.dtsi | 14 ++++++++++++++
+ arch/arm64/boot/dts/rockchip/rk3328.dtsi | 14 ++++++++++
  1 file changed, 14 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328.dtsi b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
-index 2a9fecc7d..48b170c63 100644
+index c4637f71d325..2c64c1b6f709 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3328.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
-@@ -937,6 +937,20 @@ emmc: mmc@ff520000 {
+@@ -1027,6 +1027,20 @@ emmc: mmc@ff520000 {
  		status = "disabled";
  	};
  
@@ -33,5 +33,5 @@ index 2a9fecc7d..48b170c63 100644
  		compatible = "rockchip,rk3328-gmac";
  		reg = <0x0 0xff540000 0x0 0x10000>;
 -- 
-2.30.2
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/rk3328-dtsi-spdif.patch
+++ b/patch/kernel/archive/rockchip64-6.3/rk3328-dtsi-spdif.patch
@@ -1,11 +1,70 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Sun, 26 Sep 2021 08:35:58 +0000
+Subject: [ARCHEOLOGY] rockchip64: tidy up rk3328 patches
+
+> X-Git-Archeology: > recovered message: > * remove 0-rever-rk3328.dtsi-.patch
+> X-Git-Archeology: > recovered message: > * split rk3328-dtsi-mmc-vdec-usb3-tweaks.patch into different specific patches (sdmmc-ext, mmc-reset, power domains, usb3 resets)
+> X-Git-Archeology: > recovered message: > * split rk3328-audio-and-renegade-supplies.patch into specific roc-cc audio and supplies patch and general rk3328 spdif patch
+> X-Git-Archeology: > recovered message: > * add "dtsi" infix to rk3328 patches that deal with dtsi files
+> X-Git-Archeology: > recovered message: > * add back mali gpu operating points patch
+> X-Git-Archeology: - Revision a71ef23575940b363e86a143d6ec781f95f1dbde: https://github.com/armbian/build/commit/a71ef23575940b363e86a143d6ec781f95f1dbde
+> X-Git-Archeology:   Date: Sun, 26 Sep 2021 08:35:58 +0000
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip64: tidy up rk3328 patches
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e: https://github.com/armbian/build/commit/dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e
+> X-Git-Archeology:   Date: Tue, 09 Nov 2021 18:06:34 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump imx6, xu4, rockchip64 and jetson-nano to 5.15 (#3238)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3328.dtsi | 27 ++++++++++
+ 1 file changed, 27 insertions(+)
+
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328.dtsi b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
-index eedc25132..5c62f0116 100644
+index 2c64c1b6f709..6c60458d3b03 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3328.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
-@@ -210,6 +210,26 @@
+@@ -194,6 +194,26 @@ psci {
  		method = "smc";
  	};
-
+ 
 +	spdif_out: spdif-out {
 +		compatible = "linux,spdif-dit";
 +		#sound-dai-cells = <0>;
@@ -29,26 +88,26 @@ index eedc25132..5c62f0116 100644
  	timer {
  		compatible = "arm,armv8-timer";
  		interrupts = <GIC_PPI 13 (GIC_CPU_MASK_SIMPLE(4) | IRQ_TYPE_LEVEL_LOW)>,
-@@ -319,6 +339,10 @@
+@@ -301,6 +321,10 @@ power: power-controller {
  			#address-cells = <1>;
  			#size-cells = <0>;
-
+ 
 +			power-domain@RK3328_PD_GPU {
 +				reg = <RK3328_PD_GPU>;
 +				clocks = <&cru ACLK_GPU>;
 +			};
  			power-domain@RK3328_PD_HEVC {
  				reg = <RK3328_PD_HEVC>;
- 			};
-@@ -621,6 +645,7 @@
+ 				#power-domain-cells = <0>;
+@@ -682,6 +706,7 @@ gpu: gpu@ff300000 {
  				  "ppmmu1";
  		clocks = <&cru ACLK_GPU>, <&cru ACLK_GPU>;
  		clock-names = "bus", "core";
 +		power-domains = <&power RK3328_PD_GPU>;
  		resets = <&cru SRST_GPU_A>;
+ 		operating-points-v2 = <&gpu_opp_table>;
  	};
-
-@@ -793,6 +818,7 @@
+@@ -924,6 +949,7 @@ cru: clock-controller@ff440000 {
  			<&cru ACLK_BUS_PRE>, <&cru HCLK_BUS_PRE>,
  			<&cru PCLK_BUS_PRE>, <&cru ACLK_PERI_PRE>,
  			<&cru HCLK_PERI>, <&cru PCLK_PERI>,
@@ -56,11 +115,14 @@ index eedc25132..5c62f0116 100644
  			<&cru SCLK_RTC32K>;
  		assigned-clock-parents =
  			<&cru HDMIPHY>, <&cru PLL_APLL>,
-@@ -814,6 +840,7 @@
+@@ -945,6 +971,7 @@ cru: clock-controller@ff440000 {
  			<150000000>, <75000000>,
  			<75000000>, <150000000>,
  			<75000000>, <75000000>,
 +			<500000000>,
  			<32768>;
  	};
+ 
+-- 
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/rk3328-dtsi-usb3-reset-properties.patch
+++ b/patch/kernel/archive/rockchip64-6.3/rk3328-dtsi-usb3-reset-properties.patch
@@ -1,17 +1,17 @@
-From 2cc5008e97eacc69e4f4d42b733e84caa048ef9f Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
 Date: Sat, 25 Sep 2021 13:39:40 +0000
-Subject: [PATCH 4/4] usb3 reset properties
+Subject: usb3 reset properties
 
 ---
  arch/arm64/boot/dts/rockchip/rk3328.dtsi | 2 ++
  1 file changed, 2 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328.dtsi b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
-index 48b170c63..b79c67df5 100644
+index 6c60458d3b03..f790fd135315 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3328.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
-@@ -1054,6 +1054,8 @@ usbdrd3: usb@ff600000 {
+@@ -1171,6 +1171,8 @@ usbdrd3: usb@ff600000 {
  			 <&cru ACLK_USB3OTG>;
  		clock-names = "ref_clk", "suspend_clk",
  			      "bus_clk";
@@ -21,5 +21,5 @@ index 48b170c63..b79c67df5 100644
  		phy_type = "utmi_wide";
  		snps,dis-del-phy-power-chg-quirk;
 -- 
-2.30.2
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/rk3328-gpu-cooling-target.patch
+++ b/patch/kernel/archive/rockchip64-6.3/rk3328-gpu-cooling-target.patch
@@ -1,18 +1,18 @@
-From 6b9fa5fb3eaa4a0b3ff0babcdeb5f92b8cccb949 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: tonymac32 <tonymckahan@gmail.com>
 Date: Wed, 4 Aug 2021 00:14:33 -0400
-Subject: [PATCH] hjghj
+Subject: rk3328-gpu-cooling-target
 
 Signed-off-by: tonymac32 <tonymckahan@gmail.com>
 ---
- arch/arm64/boot/dts/rockchip/rk3328.dtsi      | 14 +++++++---
- 2 files changed, 24 insertions(+), 17 deletions(-)
+ arch/arm64/boot/dts/rockchip/rk3328.dtsi | 6 ++++++
+ 1 file changed, 6 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328.dtsi b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
-index a576953ec..e6459baa8 100644
+index f790fd135315..01df81f0525b 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3328.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
-@@ -591,6 +591,11 @@ map0 {
+@@ -564,6 +564,11 @@ map0 {
  							 <&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
  					contribution = <4096>;
  				};
@@ -24,14 +24,14 @@ index a576953ec..e6459baa8 100644
  			};
  		};
  
-@@ -675,6 +680,7 @@ gpu: gpu@ff300000 {
+@@ -709,6 +714,7 @@ gpu: gpu@ff300000 {
  		power-domains = <&power RK3328_PD_GPU>;
  		resets = <&cru SRST_GPU_A>;
  		operating-points-v2 = <&gpu_opp_table>;
 +		#cooling-cells = <2>;
  	};
  
- 	h265e_mmu: iommu@ff330200 {
+ 	gpu_opp_table: gpu-opp-table {
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/rk3328-roc-cc-add-missing-nodes.patch
+++ b/patch/kernel/archive/rockchip64-6.3/rk3328-roc-cc-add-missing-nodes.patch
@@ -1,21 +1,21 @@
-From d65d5e5236e48648f993de983e1c7ea8f5c57b32 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: tonymac32 <tonymckahan@gmail.com>
 Date: Sat, 28 Jan 2023 17:07:35 -0500
-Subject: [PATCH] rk3328-roc-cc add missing nodes
+Subject: rk3328-roc-cc add missing nodes
 
 Signed-off-by: tonymac32 <tonymckahan@gmail.com>
 ---
- .../arm64/boot/dts/rockchip/rk3328-roc-cc.dts | 32 +++++++++++++++++++
+ arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts | 32 ++++++++++
  1 file changed, 32 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts b/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts
 old mode 100644
 new mode 100755
-index 6b45a653a82..0a6a3cadc20
+index be5d064d6a93..c5ecfc3e581a
 --- a/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-roc-cc.dts
-@@ -134,6 +134,14 @@ user_led: led-1 {
- 			mode = <0x05>;
+@@ -132,6 +132,14 @@ user_led: led-1 {
+ 			default-state = "off";
  		};
  	};
 +
@@ -29,7 +29,7 @@ index 6b45a653a82..0a6a3cadc20
  };
  
  &analog_sound {
-@@ -204,6 +212,10 @@ &gmac2io {
+@@ -202,6 +210,10 @@ &gmac2io {
  	status = "okay";
  };
  
@@ -40,7 +40,7 @@ index 6b45a653a82..0a6a3cadc20
  &hdmi {
  	status = "okay";
  };
-@@ -346,6 +358,13 @@ &io_domains {
+@@ -344,6 +356,13 @@ &io_domains {
  };
  
  &pinctrl {
@@ -54,7 +54,7 @@ index 6b45a653a82..0a6a3cadc20
  	pmic {
  		pmic_int_l: pmic-int-l {
  			rockchip,pins = <1 RK_PD0 RK_FUNC_GPIO &pcfg_pull_up>;
-@@ -376,6 +395,19 @@ &sdmmc {
+@@ -374,6 +393,19 @@ &sdmmc {
  	status = "okay";
  };
  
@@ -75,5 +75,5 @@ index 6b45a653a82..0a6a3cadc20
  	status = "okay";
  };
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/rk3399-add-sclk-i2sout-src-clock.patch
+++ b/patch/kernel/archive/rockchip64-6.3/rk3399-add-sclk-i2sout-src-clock.patch
@@ -1,8 +1,78 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Piotr Szczepanik <piter75@gmail.com>
+Date: Sun, 5 Apr 2020 18:15:06 +0200
+Subject: [ARCHEOLOGY] Fixed sound from rt5651 on OrangePi 4 (#1870)
+
+> X-Git-Archeology: - Revision e14a61c229db1216fedc397e351c4bed15df820e: https://github.com/armbian/build/commit/e14a61c229db1216fedc397e351c4bed15df820e
+> X-Git-Archeology:   Date: Sun, 05 Apr 2020 18:15:06 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Fixed sound from rt5651 on OrangePi 4 (#1870)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0cdffb29b07305209efb12cf3b5ac6032d3a1153: https://github.com/armbian/build/commit/0cdffb29b07305209efb12cf3b5ac6032d3a1153
+> X-Git-Archeology:   Date: Wed, 24 Mar 2021 19:01:53 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Renaming DEV branch to EDGE (#2704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e7377248b3cae186e24e2be781cd3365b43246f0: https://github.com/armbian/build/commit/e7377248b3cae186e24e2be781cd3365b43246f0
+> X-Git-Archeology:   Date: Thu, 22 Jul 2021 00:15:54 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Second part of EDGE bumping to 5.13.y (#3045)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 744ea89a589d62cb6f409baab60fc6664520bc39: https://github.com/armbian/build/commit/744ea89a589d62cb6f409baab60fc6664520bc39
+> X-Git-Archeology:   Date: Wed, 08 Sep 2021 17:51:34 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bumping EDGE kernel to 5.14.y (#3125)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e: https://github.com/armbian/build/commit/dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e
+> X-Git-Archeology:   Date: Tue, 09 Nov 2021 18:06:34 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump imx6, xu4, rockchip64 and jetson-nano to 5.15 (#3238)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ drivers/clk/rockchip/clk-rk3399.c      | 2 +-
+ include/dt-bindings/clock/rk3399-cru.h | 1 +
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
 diff --git a/drivers/clk/rockchip/clk-rk3399.c b/drivers/clk/rockchip/clk-rk3399.c
-index ce1d2446f..38447441b 100644
+index 306910a3a0d3..aef3fddb842a 100644
 --- a/drivers/clk/rockchip/clk-rk3399.c
 +++ b/drivers/clk/rockchip/clk-rk3399.c
-@@ -620,7 +620,7 @@ static struct rockchip_clk_branch rk3399_clk_branches[] __initdata = {
+@@ -624,7 +624,7 @@ static struct rockchip_clk_branch rk3399_clk_branches[] __initdata = {
  	GATE(SCLK_I2S2_8CH, "clk_i2s2", "clk_i2s2_mux", CLK_SET_RATE_PARENT,
  			RK3399_CLKGATE_CON(8), 11, GFLAGS),
  
@@ -12,7 +82,7 @@ index ce1d2446f..38447441b 100644
  	COMPOSITE_NODIV(SCLK_I2S_8CH_OUT, "clk_i2sout", mux_i2sout_p, CLK_SET_RATE_PARENT,
  			RK3399_CLKSEL_CON(31), 2, 1, MFLAGS,
 diff --git a/include/dt-bindings/clock/rk3399-cru.h b/include/dt-bindings/clock/rk3399-cru.h
-index 44e0a319f..b7b07dfda 100644
+index 39169d94a44e..8207557c1c5d 100644
 --- a/include/dt-bindings/clock/rk3399-cru.h
 +++ b/include/dt-bindings/clock/rk3399-cru.h
 @@ -19,6 +19,7 @@
@@ -23,3 +93,6 @@ index 44e0a319f..b7b07dfda 100644
  #define SCLK_I2C1			65
  #define SCLK_I2C2			66
  #define SCLK_I2C3			67
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/rk3399-dmc-polling-rate.patch
+++ b/patch/kernel/archive/rockchip64-6.3/rk3399-dmc-polling-rate.patch
@@ -1,5 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Wed, 8 Mar 2023 11:12:41 +0100
+Subject: [ARCHEOLOGY] rockchip64: set poll rate 50ms for rk3399 dmc driver
+
+> X-Git-Archeology: - Revision 03a00c5ce49dadd0dd579980114b8595f144b763: https://github.com/armbian/build/commit/03a00c5ce49dadd0dd579980114b8595f144b763
+> X-Git-Archeology:   Date: Wed, 08 Mar 2023 11:12:41 +0100
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip64: set poll rate 50ms for rk3399 dmc driver
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ drivers/devfreq/rk3399_dmc.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
 diff --git a/drivers/devfreq/rk3399_dmc.c b/drivers/devfreq/rk3399_dmc.c
-index daff4070261..62f4804134c 100644
+index daff40702615..62f4804134c2 100644
 --- a/drivers/devfreq/rk3399_dmc.c
 +++ b/drivers/devfreq/rk3399_dmc.c
 @@ -430,7 +430,7 @@ static int rk3399_dmcfreq_probe(struct platform_device *pdev)
@@ -11,3 +30,6 @@ index daff4070261..62f4804134c 100644
  		.target		= rk3399_dmcfreq_target,
  		.get_dev_status	= rk3399_dmcfreq_get_dev_status,
  		.get_cur_freq	= rk3399_dmcfreq_get_cur_freq,
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/rk3399-enable-dwc3-xhci-usb-trb-quirk.patch
+++ b/patch/kernel/archive/rockchip64-6.3/rk3399-enable-dwc3-xhci-usb-trb-quirk.patch
@@ -1,8 +1,104 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Aditya Prayoga <aprayoga@users.noreply.github.com>
+Date: Fri, 22 Jan 2021 13:12:09 +0100
+Subject: [ARCHEOLOGY] Fix 2.5G Ethernet on Helios64 Mainline kernel (#2567)
+
+> X-Git-Archeology: > recovered message: > * rockchip64: Added XHCI HCD USB TRB ENT quirk
+> X-Git-Archeology: > recovered message: > On some xHCI controllers (e.g. Rockchip RK3399/RK3328/RK1808), they need
+> X-Git-Archeology: > recovered message: > to enable the ENT flag in the TRB data structure to force xHC to
+> X-Git-Archeology: > recovered message: > prefetch the next TRB of a TD.
+> X-Git-Archeology: > recovered message: > Enable the quirk on RK3399 through device tree node properties.
+> X-Git-Archeology: > recovered message: > Ported from Rockchip Linux 4.19
+> X-Git-Archeology: > recovered message: > * add to dev branch
+> X-Git-Archeology: - Revision 568d8472b3c2ab406fd3897e6b952c7a71a8165b: https://github.com/armbian/build/commit/568d8472b3c2ab406fd3897e6b952c7a71a8165b
+> X-Git-Archeology:   Date: Fri, 22 Jan 2021 13:12:09 +0100
+> X-Git-Archeology:   From: Aditya Prayoga <aprayoga@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Fix 2.5G Ethernet on Helios64 Mainline kernel (#2567)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0cdffb29b07305209efb12cf3b5ac6032d3a1153: https://github.com/armbian/build/commit/0cdffb29b07305209efb12cf3b5ac6032d3a1153
+> X-Git-Archeology:   Date: Wed, 24 Mar 2021 19:01:53 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Renaming DEV branch to EDGE (#2704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 3b3d85e25c2ecde30df7b5274fc6f1b9c0299ea2: https://github.com/armbian/build/commit/3b3d85e25c2ecde30df7b5274fc6f1b9c0299ea2
+> X-Git-Archeology:   Date: Sat, 22 May 2021 17:08:44 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Upgrade EDGE to 5.12.y (#2825)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e7377248b3cae186e24e2be781cd3365b43246f0: https://github.com/armbian/build/commit/e7377248b3cae186e24e2be781cd3365b43246f0
+> X-Git-Archeology:   Date: Thu, 22 Jul 2021 00:15:54 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Second part of EDGE bumping to 5.13.y (#3045)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 744ea89a589d62cb6f409baab60fc6664520bc39: https://github.com/armbian/build/commit/744ea89a589d62cb6f409baab60fc6664520bc39
+> X-Git-Archeology:   Date: Wed, 08 Sep 2021 17:51:34 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bumping EDGE kernel to 5.14.y (#3125)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e: https://github.com/armbian/build/commit/dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e
+> X-Git-Archeology:   Date: Tue, 09 Nov 2021 18:06:34 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump imx6, xu4, rockchip64 and jetson-nano to 5.15 (#3238)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6b490e16944b30ff69bf9c13678905187df0d9d4: https://github.com/armbian/build/commit/6b490e16944b30ff69bf9c13678905187df0d9d4
+> X-Git-Archeology:   Date: Tue, 11 Jan 2022 15:26:11 +0100
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: move kernel edge to 5.16 (#3387)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision f52a4193d02ef88333ba117c68d49486dfd7ff41: https://github.com/armbian/build/commit/f52a4193d02ef88333ba117c68d49486dfd7ff41
+> X-Git-Archeology:   Date: Sun, 20 Mar 2022 22:58:21 +0100
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: Adding Pine64 Quartz64a as WIP target (#3539)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0afe24c95729044910e0b3f84dc5500bcdc6524c: https://github.com/armbian/build/commit/0afe24c95729044910e0b3f84dc5500bcdc6524c
+> X-Git-Archeology:   Date: Sun, 24 Apr 2022 22:33:47 +0200
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: move kernel media edge to 5.17 (#3704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3399.dtsi | 2 ++
+ 1 file changed, 2 insertions(+)
+
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399.dtsi b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-index bcd31e9d6..91f1aa809 100644
+index 45c8da0e2168..bbdaee4b4872 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-@@ -396,6 +396,7 @@ usbdrd_dwc3_0: usb@fe800000 {
+@@ -461,6 +461,7 @@ usbdrd_dwc3_0: usb@fe800000 {
  			snps,dis_u2_susphy_quirk;
  			snps,dis-del-phy-power-chg-quirk;
  			snps,dis-tx-ipgap-linecheck-quirk;
@@ -10,7 +106,7 @@ index bcd31e9d6..91f1aa809 100644
  			power-domains = <&power RK3399_PD_USB3>;
  			status = "disabled";
  		};
-@@ -461,6 +462,7 @@ usbdrd_dwc3_1: usb@fe900000 {
+@@ -497,6 +498,7 @@ usbdrd_dwc3_1: usb@fe900000 {
  			snps,dis_u2_susphy_quirk;
  			snps,dis-del-phy-power-chg-quirk;
  			snps,dis-tx-ipgap-linecheck-quirk;
@@ -18,3 +114,6 @@ index bcd31e9d6..91f1aa809 100644
  			power-domains = <&power RK3399_PD_USB3>;
  			status = "disabled";
  		};
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/rk3399-rp64-pcie-Reimplement-rockchip-PCIe-bus-scan-delay.patch
+++ b/patch/kernel/archive/rockchip64-6.3/rk3399-rp64-pcie-Reimplement-rockchip-PCIe-bus-scan-delay.patch
@@ -1,8 +1,83 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dan Pasanen <dan.pasanen@gmail.com>
+Date: Thu, 16 Dec 2021 05:17:33 -0500
+Subject: [ARCHEOLOGY] rockchip-[current,edge]: add pcie hack and lsi scsi/sas
+ support (#3351)
+
+> X-Git-Archeology: > recovered message: > * build: kernel: rockchip64-[current,edge]: add pcie bus scan delay patches
+> X-Git-Archeology: > recovered message: > These are needed for cards like the LSI SAS2008 which needs a little
+> X-Git-Archeology: > recovered message: > extra time to initialize or they'll cause a kernel panic.
+> X-Git-Archeology: > recovered message: > References:
+> X-Git-Archeology: > recovered message: > https://gitlab.manjaro.org/manjaro-arm/packages/core/linux/-/blob/master/0013-rk3399-rp64-pcie-Reimplement-rockchip-PCIe-bus-scan-delay.patch
+> X-Git-Archeology: > recovered message: > https://gitlab.manjaro.org/manjaro-arm/packages/core/linux/-/blob/master/0022-arm64-dts-rockchip-Add-pcie-bus-scan-delay-to-rockpr.patch
+> X-Git-Archeology: > recovered message: > * config: linux-rockchip64-[current,edge]: enable lsi sata/sas support
+> X-Git-Archeology: - Revision 7be9e8b99590e32c0594365d00a2a2cfc3c4bd5a: https://github.com/armbian/build/commit/7be9e8b99590e32c0594365d00a2a2cfc3c4bd5a
+> X-Git-Archeology:   Date: Thu, 16 Dec 2021 05:17:33 -0500
+> X-Git-Archeology:   From: Dan Pasanen <dan.pasanen@gmail.com>
+> X-Git-Archeology:   Subject: rockchip-[current,edge]: add pcie hack and lsi scsi/sas support (#3351)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6b490e16944b30ff69bf9c13678905187df0d9d4: https://github.com/armbian/build/commit/6b490e16944b30ff69bf9c13678905187df0d9d4
+> X-Git-Archeology:   Date: Tue, 11 Jan 2022 15:26:11 +0100
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: move kernel edge to 5.16 (#3387)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision f52a4193d02ef88333ba117c68d49486dfd7ff41: https://github.com/armbian/build/commit/f52a4193d02ef88333ba117c68d49486dfd7ff41
+> X-Git-Archeology:   Date: Sun, 20 Mar 2022 22:58:21 +0100
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: Adding Pine64 Quartz64a as WIP target (#3539)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0afe24c95729044910e0b3f84dc5500bcdc6524c: https://github.com/armbian/build/commit/0afe24c95729044910e0b3f84dc5500bcdc6524c
+> X-Git-Archeology:   Date: Sun, 24 Apr 2022 22:33:47 +0200
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: move kernel media edge to 5.17 (#3704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ Documentation/admin-guide/kernel-parameters.txt |  8 +++
+ drivers/pci/controller/pcie-rockchip-host.c     | 25 ++++++++++
+ drivers/pci/controller/pcie-rockchip.c          |  6 +++
+ drivers/pci/controller/pcie-rockchip.h          |  2 +
+ 4 files changed, 41 insertions(+)
+
 diff --git a/Documentation/admin-guide/kernel-parameters.txt b/Documentation/admin-guide/kernel-parameters.txt
-index 1396fd2d9..4d583446c 100644
+index 7016cb12dc4e..6fc40ae5ce10 100644
 --- a/Documentation/admin-guide/kernel-parameters.txt
 +++ b/Documentation/admin-guide/kernel-parameters.txt
-@@ -4079,6 +4079,14 @@
+@@ -4388,6 +4388,14 @@
  		nomsi	Do not use MSI for native PCIe PME signaling (this makes
  			all PCIe root ports use INTx for all services).
  
@@ -18,7 +93,7 @@ index 1396fd2d9..4d583446c 100644
  
  	pd_ignore_unused
 diff --git a/drivers/pci/controller/pcie-rockchip-host.c b/drivers/pci/controller/pcie-rockchip-host.c
-index c52316d0b..a7974007d 100644
+index c96c0f454570..a161b852a5c8 100644
 --- a/drivers/pci/controller/pcie-rockchip-host.c
 +++ b/drivers/pci/controller/pcie-rockchip-host.c
 @@ -24,6 +24,7 @@
@@ -29,7 +104,7 @@ index c52316d0b..a7974007d 100644
  #include <linux/of_address.h>
  #include <linux/of_device.h>
  #include <linux/of_pci.h>
-@@ -39,6 +40,9 @@
+@@ -38,6 +39,9 @@
  #include "../pci.h"
  #include "pcie-rockchip.h"
  
@@ -39,7 +114,7 @@ index c52316d0b..a7974007d 100644
  static void rockchip_pcie_enable_bw_int(struct rockchip_pcie *rockchip)
  {
  	u32 status;
-@@ -935,6 +939,7 @@ static int rockchip_pcie_probe(struct platform_device *pdev)
+@@ -932,6 +936,7 @@ static int rockchip_pcie_probe(struct platform_device *pdev)
  	struct device *dev = &pdev->dev;
  	struct pci_host_bridge *bridge;
  	int err;
@@ -47,7 +122,7 @@ index c52316d0b..a7974007d 100644
  
  	if (!dev->of_node)
  		return -ENODEV;
-@@ -984,6 +989,26 @@ static int rockchip_pcie_probe(struct platform_device *pdev)
+@@ -981,6 +986,26 @@ static int rockchip_pcie_probe(struct platform_device *pdev)
  	bridge->sysdata = rockchip;
  	bridge->ops = &rockchip_pcie_ops;
  
@@ -75,10 +150,10 @@ index c52316d0b..a7974007d 100644
  	if (err)
  		goto err_remove_irq_domain;
 diff --git a/drivers/pci/controller/pcie-rockchip.c b/drivers/pci/controller/pcie-rockchip.c
-index 193d26562..ec6cbaadd 100644
+index 990a00e08bc5..c7ec35afd8ca 100644
 --- a/drivers/pci/controller/pcie-rockchip.c
 +++ b/drivers/pci/controller/pcie-rockchip.c
-@@ -148,6 +148,12 @@ int rockchip_pcie_parse_dt(struct rockchip_pcie *rockchip)
+@@ -149,6 +149,12 @@ int rockchip_pcie_parse_dt(struct rockchip_pcie *rockchip)
  		return PTR_ERR(rockchip->clk_pcie_pm);
  	}
  
@@ -92,10 +167,10 @@ index 193d26562..ec6cbaadd 100644
  }
  EXPORT_SYMBOL_GPL(rockchip_pcie_parse_dt);
 diff --git a/drivers/pci/controller/pcie-rockchip.h b/drivers/pci/controller/pcie-rockchip.h
-index 1650a5087..35a8cf157 100644
+index 32c3a859c26b..87223ba452a4 100644
 --- a/drivers/pci/controller/pcie-rockchip.h
 +++ b/drivers/pci/controller/pcie-rockchip.h
-@@ -300,6 +300,8 @@ struct rockchip_pcie {
+@@ -299,6 +299,8 @@ struct rockchip_pcie {
  	phys_addr_t msg_bus_addr;
  	bool is_rc;
  	struct resource *mem_res;
@@ -104,3 +179,6 @@ index 1650a5087..35a8cf157 100644
  };
  
  static u32 rockchip_pcie_read(struct rockchip_pcie *rockchip, u32 reg)
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/rk3399-rp64-rng.patch
+++ b/patch/kernel/archive/rockchip64-6.3/rk3399-rp64-rng.patch
@@ -1,7 +1,7 @@
-From e3b07969462aa9da51352f9a493b2f71fce73807 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Igor Pecovnik <igor.pecovnik@gmail.com>
 Date: Tue, 25 Oct 2022 09:35:52 +0200
-Subject: [PATCH] RK3399 Add rng bits
+Subject: RK3399 Add rng bits
 
 Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
 ---
@@ -9,10 +9,10 @@ Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
  1 file changed, 10 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399.dtsi b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-index a75abfa5c..58592da35 100644
+index bbdaee4b4872..a167634e1565 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-@@ -2057,6 +2057,16 @@ edp_in_vopl: endpoint@1 {
+@@ -2078,6 +2078,16 @@ edp_in_vopl: endpoint@1 {
  		};
  	};
  
@@ -30,5 +30,5 @@ index a75abfa5c..58592da35 100644
  		compatible = "rockchip,rk3399-mali", "arm,mali-t860";
  		reg = <0x0 0xff9a0000 0x0 0x10000>;
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/rk3399-sd-drive-level-8ma.patch
+++ b/patch/kernel/archive/rockchip64-6.3/rk3399-sd-drive-level-8ma.patch
@@ -1,8 +1,118 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Martin Ayotte <martinayotte@yahoo.ca>
+Date: Thu, 3 Jan 2019 11:04:17 -0500
+Subject: [ARCHEOLOGY] add better strength on SDCard and put back previous
+ speed setting
+
+> X-Git-Archeology: - Revision 211c802f7cfedaac75a35f65d427910011c29242: https://github.com/armbian/build/commit/211c802f7cfedaac75a35f65d427910011c29242
+> X-Git-Archeology:   Date: Thu, 03 Jan 2019 11:04:17 -0500
+> X-Git-Archeology:   From: Martin Ayotte <martinayotte@yahoo.ca>
+> X-Git-Archeology:   Subject: add better strength on SDCard and put back previous speed setting
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision f2e71dbc730eaf7f1e586dfd5951bc149cb827d2: https://github.com/armbian/build/commit/f2e71dbc730eaf7f1e586dfd5951bc149cb827d2
+> X-Git-Archeology:   Date: Fri, 04 Jan 2019 10:04:19 -0500
+> X-Git-Archeology:   From: Martin Ayotte <martinayotte@yahoo.ca>
+> X-Git-Archeology:   Subject: fix sdmmc-bus1 pin
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 005e8cf9fcba2922685f5ee49cef833be1465ec1: https://github.com/armbian/build/commit/005e8cf9fcba2922685f5ee49cef833be1465ec1
+> X-Git-Archeology:   Date: Sun, 27 Jan 2019 15:37:40 -0500
+> X-Git-Archeology:   From: Martin Ayotte <martinayotte@yahoo.ca>
+> X-Git-Archeology:   Subject: fxi SD-CD pullup
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 885111ab0e166f97338df63714ea47a5b554b698: https://github.com/armbian/build/commit/885111ab0e166f97338df63714ea47a5b554b698
+> X-Git-Archeology:   Date: Sat, 13 Jul 2019 11:25:27 -0400
+> X-Git-Archeology:   From: Martin Ayotte <martinayotte@yahoo.ca>
+> X-Git-Archeology:   Subject: switch rockchip64-dev and rk3399-dev to 5.2.y
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 150ac0c2afa147d9e3b036c8ecd8238fe5648cf3: https://github.com/armbian/build/commit/150ac0c2afa147d9e3b036c8ecd8238fe5648cf3
+> X-Git-Archeology:   Date: Tue, 19 Nov 2019 23:25:39 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Remove K<4, change branches, new features (#1586)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 4d4c3f58ffc1cbfbb060cbabc9eb414036a2fda5: https://github.com/armbian/build/commit/4d4c3f58ffc1cbfbb060cbabc9eb414036a2fda5
+> X-Git-Archeology:   Date: Wed, 02 Sep 2020 23:22:09 +0200
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switched rockchip64 curent to kernel 5.8.y (#2175)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0cdffb29b07305209efb12cf3b5ac6032d3a1153: https://github.com/armbian/build/commit/0cdffb29b07305209efb12cf3b5ac6032d3a1153
+> X-Git-Archeology:   Date: Wed, 24 Mar 2021 19:01:53 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Renaming DEV branch to EDGE (#2704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e7377248b3cae186e24e2be781cd3365b43246f0: https://github.com/armbian/build/commit/e7377248b3cae186e24e2be781cd3365b43246f0
+> X-Git-Archeology:   Date: Thu, 22 Jul 2021 00:15:54 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Second part of EDGE bumping to 5.13.y (#3045)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 744ea89a589d62cb6f409baab60fc6664520bc39: https://github.com/armbian/build/commit/744ea89a589d62cb6f409baab60fc6664520bc39
+> X-Git-Archeology:   Date: Wed, 08 Sep 2021 17:51:34 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bumping EDGE kernel to 5.14.y (#3125)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e: https://github.com/armbian/build/commit/dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e
+> X-Git-Archeology:   Date: Tue, 09 Nov 2021 18:06:34 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump imx6, xu4, rockchip64 and jetson-nano to 5.15 (#3238)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6b490e16944b30ff69bf9c13678905187df0d9d4: https://github.com/armbian/build/commit/6b490e16944b30ff69bf9c13678905187df0d9d4
+> X-Git-Archeology:   Date: Tue, 11 Jan 2022 15:26:11 +0100
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: move kernel edge to 5.16 (#3387)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision f52a4193d02ef88333ba117c68d49486dfd7ff41: https://github.com/armbian/build/commit/f52a4193d02ef88333ba117c68d49486dfd7ff41
+> X-Git-Archeology:   Date: Sun, 20 Mar 2022 22:58:21 +0100
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: Adding Pine64 Quartz64a as WIP target (#3539)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0afe24c95729044910e0b3f84dc5500bcdc6524c: https://github.com/armbian/build/commit/0afe24c95729044910e0b3f84dc5500bcdc6524c
+> X-Git-Archeology:   Date: Sun, 24 Apr 2022 22:33:47 +0200
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: move kernel media edge to 5.17 (#3704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3399.dtsi | 16 +++++-----
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399.dtsi b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-index 6eb9dda..d6fc676 100644
+index a167634e1565..065d2644da66 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-@@ -2285,35 +2285,35 @@
+@@ -2541,25 +2541,25 @@ sdio0_int: sdio0-int {
  		sdmmc {
  			sdmmc_bus1: sdmmc-bus1 {
  				rockchip,pins =
@@ -35,10 +145,7 @@ index 6eb9dda..d6fc676 100644
  			};
  
  			sdmmc_cd: sdmmc-cd {
- 				rockchip,pins =
--					<0 RK_PA7 1 &pcfg_pull_up>;
-+					<0 RK_PA7 1 &pcfg_pull_up>;
- 			};
+@@ -2569,7 +2569,7 @@ sdmmc_cd: sdmmc-cd {
  
  			sdmmc_wp: sdmmc-wp {
  				rockchip,pins =
@@ -47,3 +154,6 @@ index 6eb9dda..d6fc676 100644
  			};
  		};
  
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/rk3399-unlock-temperature.patch
+++ b/patch/kernel/archive/rockchip64-6.3/rk3399-unlock-temperature.patch
@@ -1,8 +1,107 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: ThomasKaiser <github@kaiser-edv.de>
+Date: Sat, 13 Oct 2018 16:35:07 +0200
+Subject: [ARCHEOLOGY] Increase performance with rk3399-dev
+
+> X-Git-Archeology: - Revision b28fa47aa8b9864ccae8b90ebb3d46ae55103d6e: https://github.com/armbian/build/commit/b28fa47aa8b9864ccae8b90ebb3d46ae55103d6e
+> X-Git-Archeology:   Date: Sat, 13 Oct 2018 16:35:07 +0200
+> X-Git-Archeology:   From: ThomasKaiser <github@kaiser-edv.de>
+> X-Git-Archeology:   Subject: Increase performance with rk3399-dev
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision f18360d1ef5d6487392ff4079301bca97945e704: https://github.com/armbian/build/commit/f18360d1ef5d6487392ff4079301bca97945e704
+> X-Git-Archeology:   Date: Wed, 24 Oct 2018 17:03:35 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igor.pecovnik@gmail.com>
+> X-Git-Archeology:   Subject: [rk3399-dev] Merging rk3399-DEV with rockchip64-DEV on sources, patches and config level. Leave family intact, add 1.5 OPP for RK3328, add upstream patch for rk3399-default
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 150ac0c2afa147d9e3b036c8ecd8238fe5648cf3: https://github.com/armbian/build/commit/150ac0c2afa147d9e3b036c8ecd8238fe5648cf3
+> X-Git-Archeology:   Date: Tue, 19 Nov 2019 23:25:39 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Remove K<4, change branches, new features (#1586)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dfd5cf9692e97774f7f0bfd72227144e36f58070: https://github.com/armbian/build/commit/dfd5cf9692e97774f7f0bfd72227144e36f58070
+> X-Git-Archeology:   Date: Sun, 13 Dec 2020 22:13:03 -0500
+> X-Git-Archeology:   From: tonymac32 <tonymckahan@gmail.com>
+> X-Git-Archeology:   Subject: [ rockchip64 ] Clean up patchset
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0cdffb29b07305209efb12cf3b5ac6032d3a1153: https://github.com/armbian/build/commit/0cdffb29b07305209efb12cf3b5ac6032d3a1153
+> X-Git-Archeology:   Date: Wed, 24 Mar 2021 19:01:53 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Renaming DEV branch to EDGE (#2704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e7377248b3cae186e24e2be781cd3365b43246f0: https://github.com/armbian/build/commit/e7377248b3cae186e24e2be781cd3365b43246f0
+> X-Git-Archeology:   Date: Thu, 22 Jul 2021 00:15:54 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Second part of EDGE bumping to 5.13.y (#3045)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 744ea89a589d62cb6f409baab60fc6664520bc39: https://github.com/armbian/build/commit/744ea89a589d62cb6f409baab60fc6664520bc39
+> X-Git-Archeology:   Date: Wed, 08 Sep 2021 17:51:34 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bumping EDGE kernel to 5.14.y (#3125)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e: https://github.com/armbian/build/commit/dd51f9f2afcbc83a3e10b32eb6a5061d91d1558e
+> X-Git-Archeology:   Date: Tue, 09 Nov 2021 18:06:34 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump imx6, xu4, rockchip64 and jetson-nano to 5.15 (#3238)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6b490e16944b30ff69bf9c13678905187df0d9d4: https://github.com/armbian/build/commit/6b490e16944b30ff69bf9c13678905187df0d9d4
+> X-Git-Archeology:   Date: Tue, 11 Jan 2022 15:26:11 +0100
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: move kernel edge to 5.16 (#3387)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision ac8fc4385594d59257ee9dffd9efa85e3497fa7d: https://github.com/armbian/build/commit/ac8fc4385594d59257ee9dffd9efa85e3497fa7d
+> X-Git-Archeology:   Date: Sat, 26 Feb 2022 07:46:44 +0100
+> X-Git-Archeology:   From: Piotr Szczepanik <piter75@gmail.com>
+> X-Git-Archeology:   Subject: Switch rockchip64 current to linux 5.15.y (#3489)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision f52a4193d02ef88333ba117c68d49486dfd7ff41: https://github.com/armbian/build/commit/f52a4193d02ef88333ba117c68d49486dfd7ff41
+> X-Git-Archeology:   Date: Sun, 20 Mar 2022 22:58:21 +0100
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: Adding Pine64 Quartz64a as WIP target (#3539)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0afe24c95729044910e0b3f84dc5500bcdc6524c: https://github.com/armbian/build/commit/0afe24c95729044910e0b3f84dc5500bcdc6524c
+> X-Git-Archeology:   Date: Sun, 24 Apr 2022 22:33:47 +0200
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: move kernel media edge to 5.17 (#3704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 897674aa74bce0326ed7fe06f5336bf4709a8a1f: https://github.com/armbian/build/commit/897674aa74bce0326ed7fe06f5336bf4709a8a1f
+> X-Git-Archeology:   Date: Tue, 03 May 2022 08:27:32 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump and freeze kernel at last known working versions (#3736)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/rockchip/rk3399.dtsi | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399.dtsi b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-index 8a8cf0e..6cef1e3 100644
+index 065d2644da66..459a977f4e35 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-@@ -722,17 +722,17 @@
+@@ -831,17 +831,17 @@ cpu_thermal: cpu-thermal {
  
  			trips {
  				cpu_alert0: cpu_alert0 {
@@ -23,3 +122,6 @@ index 8a8cf0e..6cef1e3 100644
  					hysteresis = <2000>;
  					type = "critical";
  				};
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/rk356x-rga.patch
+++ b/patch/kernel/archive/rockchip64-6.3/rk356x-rga.patch
@@ -1,3 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jianfeng Liu <liujianfeng1994@gmail.com>
+Date: Sat, 28 May 2022 07:56:22 +0200
+Subject: [ARCHEOLOGY] update rockchip64-edge to 5.18 (#3814)
+
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ Documentation/devicetree/bindings/media/rockchip-rga.yaml |  2 ++
+ arch/arm64/boot/dts/rockchip/rk356x.dtsi                  | 11 ++++++++++
+ drivers/media/platform/rockchip/rga/rga.c                 |  3 +++
+ 3 files changed, 16 insertions(+)
+
 diff --git a/Documentation/devicetree/bindings/media/rockchip-rga.yaml b/Documentation/devicetree/bindings/media/rockchip-rga.yaml
 index dd645ddccb07..8adb18245187 100644
 --- a/Documentation/devicetree/bindings/media/rockchip-rga.yaml
@@ -15,11 +51,11 @@ index dd645ddccb07..8adb18245187 100644
    reg:
      maxItems: 1
 diff --git a/arch/arm64/boot/dts/rockchip/rk356x.dtsi b/arch/arm64/boot/dts/rockchip/rk356x.dtsi
-index 1042e68602de..5db9e055678d 100644
+index eed0059a68b8..43b49220b77d 100644
 --- a/arch/arm64/boot/dts/rockchip/rk356x.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk356x.dtsi
-@@ -569,6 +569,17 @@
- 		status = "disabled";
+@@ -633,6 +633,17 @@ vepu_mmu: iommu@fdee0800 {
+ 		#iommu-cells = <0>;
  	};
  
 +	rga: rga@fdeb0000 {
@@ -37,10 +73,10 @@ index 1042e68602de..5db9e055678d 100644
  		compatible = "rockchip,rk3568-dw-mshc", "rockchip,rk3288-dw-mshc";
  		reg = <0x0 0xfe000000 0x0 0x4000>;
 diff --git a/drivers/media/platform/rockchip/rga/rga.c b/drivers/media/platform/rockchip/rga/rga.c
-index 3d3d1062e212..4af5a8d00718 100644
+index 61b25fcf826e..b14844105788 100644
 --- a/drivers/media/platform/rockchip/rga/rga.c
 +++ b/drivers/media/platform/rockchip/rga/rga.c
-@@ -977,6 +977,9 @@ static const struct of_device_id rockchip_rga_match[] = {
+@@ -979,6 +979,9 @@ static const struct of_device_id rockchip_rga_match[] = {
  	{
  		.compatible = "rockchip,rk3399-rga",
  	},
@@ -50,3 +86,6 @@ index 3d3d1062e212..4af5a8d00718 100644
  	{},
  };
  
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.3/rk356x-vop2-support.patch
+++ b/patch/kernel/archive/rockchip64-6.3/rk356x-vop2-support.patch
@@ -1,5 +1,152 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Miouyouyou <myy@miouyouyou.fr>
+Date: Sun, 24 May 2020 23:08:01 +0200
+Subject: [ARCHEOLOGY] [RFC] RK3288 : Add HDMI resolutions (#1887)
+
+> X-Git-Archeology: > recovered message: > * patch: kernel: rockchip-dev: Handle more resolutions with HDMI (b)
+> X-Git-Archeology: > recovered message: > The added patch add more PLL configurations, in order to satisfy
+> X-Git-Archeology: > recovered message: > more HDMI frequencies requirements.
+> X-Git-Archeology: > recovered message: > This should allow users to benefit from more resolutions.
+> X-Git-Archeology: > recovered message: > However, this is fairly untested. I only tested it on my 1080p
+> X-Git-Archeology: > recovered message: > screen and, yeah, it works but so does the kernel without this
+> X-Git-Archeology: > recovered message: > patch.
+> X-Git-Archeology: > recovered message: > Signed-off-by: Miouyouyou (Myy) <myy@miouyouyou.fr>
+> X-Git-Archeology: > recovered message: > * patch: kernel: rockchip-dev: Handle more resolutions with HDMI (b)
+> X-Git-Archeology: > recovered message: > Now with proper patches names.
+> X-Git-Archeology: > recovered message: > Anyway :
+> X-Git-Archeology: > recovered message: > The added patch add more PLL configurations, in order to satisfy
+> X-Git-Archeology: > recovered message: > more HDMI frequencies requirements.
+> X-Git-Archeology: > recovered message: > This should allow users to benefit from more resolutions.
+> X-Git-Archeology: > recovered message: > However, this is fairly untested. I only tested it on my 1080p
+> X-Git-Archeology: > recovered message: > screen and, yeah, it works but it also does without this
+> X-Git-Archeology: > recovered message: > patch.
+> X-Git-Archeology: > recovered message: > So could anyone test this with the following configurations ?
+> X-Git-Archeology: > recovered message: > * [ ] A HDMI 4K screen
+> X-Git-Archeology: > recovered message: > * [ ] A HDMI 1366x768 screen resolution
+> X-Git-Archeology: > recovered message: > * [ ] A VGA screen with a VGA to HDMI adapter
+> X-Git-Archeology: > recovered message: > * [ ] A DVI screen with a DVI to HDMI adapter
+> X-Git-Archeology: > recovered message: > Signed-off-by: Miouyouyou (Myy) <myy@miouyouyou.fr>
+> X-Git-Archeology: > recovered message: > * Using the patches provided by @Kwiboo for HDMI
+> X-Git-Archeology: > recovered message: > This provides me way more resolutions, including interlaced modes.
+> X-Git-Archeology: > recovered message: > I don't see 4K modes, though the screen attached can't do it,
+> X-Git-Archeology: > recovered message: > so I still don't know if that can help provided 4K modes on mainline
+> X-Git-Archeology: > recovered message: > kernels.
+> X-Git-Archeology: > recovered message: > Signed-off-by: Miouyouyou (Myy) <myy@miouyouyou.fr>
+> X-Git-Archeology: > recovered message: > * Support for 4K screens
+> X-Git-Archeology: > recovered message: > Using fixes provided by @czak
+> X-Git-Archeology: > recovered message: > Tested and approved by @czak too !
+> X-Git-Archeology: > recovered message: > Signed-off-by: Miouyouyou (Myy) <myy@miouyouyou.fr>
+> X-Git-Archeology: - Revision 5ffefd40ab337dacb1d0c801081253962c54bb25: https://github.com/armbian/build/commit/5ffefd40ab337dacb1d0c801081253962c54bb25
+> X-Git-Archeology:   Date: Sun, 24 May 2020 23:08:01 +0200
+> X-Git-Archeology:   From: Miouyouyou <myy@miouyouyou.fr>
+> X-Git-Archeology:   Subject: [RFC] RK3288 : Add HDMI resolutions (#1887)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 812245def37a695bce9e7ece148b2920d82c8b37: https://github.com/armbian/build/commit/812245def37a695bce9e7ece148b2920d82c8b37
+> X-Git-Archeology:   Date: Sat, 18 Jul 2020 23:07:01 +0200
+> X-Git-Archeology:   From: Werner <EvilOlaf@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Move rockchip/64 current to 5.7.y (#2099)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 62c27823a637698e88284bc0c0f0d31342ed9641: https://github.com/armbian/build/commit/62c27823a637698e88284bc0c0f0d31342ed9641
+> X-Git-Archeology:   Date: Wed, 25 Nov 2020 19:50:47 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Move Rockchip 32b to 5.9.y (#2339)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 2b627cb36b67d8d3c9ddc6f1b49ddf8516a2b26d: https://github.com/armbian/build/commit/2b627cb36b67d8d3c9ddc6f1b49ddf8516a2b26d
+> X-Git-Archeology:   Date: Fri, 18 Dec 2020 18:50:47 +0100
+> X-Git-Archeology:   From: q4a <q4arus@ya.ru>
+> X-Git-Archeology:   Subject: rockchip-current: return hdmi patches and rework it for 5.9.y kernel (#2471)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 0cdffb29b07305209efb12cf3b5ac6032d3a1153: https://github.com/armbian/build/commit/0cdffb29b07305209efb12cf3b5ac6032d3a1153
+> X-Git-Archeology:   Date: Wed, 24 Mar 2021 19:01:53 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Renaming DEV branch to EDGE (#2704)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6b490e16944b30ff69bf9c13678905187df0d9d4: https://github.com/armbian/build/commit/6b490e16944b30ff69bf9c13678905187df0d9d4
+> X-Git-Archeology:   Date: Tue, 11 Jan 2022 15:26:11 +0100
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: move kernel edge to 5.16 (#3387)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 188d6d0a8ac547e25ffff28ae72b0d37e46b80cb: https://github.com/armbian/build/commit/188d6d0a8ac547e25ffff28ae72b0d37e46b80cb
+> X-Git-Archeology:   Date: Tue, 01 Feb 2022 22:53:43 +0100
+> X-Git-Archeology:   From: catalinii <catalinii@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Support edge kernel for Rock 3A and rk35xx (#3371)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 88464cc41251c76de4fc87e8da67d19ac7ce364c: https://github.com/armbian/build/commit/88464cc41251c76de4fc87e8da67d19ac7ce364c
+> X-Git-Archeology:   Date: Sat, 19 Mar 2022 07:10:37 -0400
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: Radxa rock3a gpu support (#3547)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision f52a4193d02ef88333ba117c68d49486dfd7ff41: https://github.com/armbian/build/commit/f52a4193d02ef88333ba117c68d49486dfd7ff41
+> X-Git-Archeology:   Date: Sun, 20 Mar 2022 22:58:21 +0100
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: Adding Pine64 Quartz64a as WIP target (#3539)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 03115888c3bfda3c001e678d37b3c986030c08c6: https://github.com/armbian/build/commit/03115888c3bfda3c001e678d37b3c986030c08c6
+> X-Git-Archeology:   Date: Thu, 24 Mar 2022 12:44:58 -0700
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: fix radxa rock3a usb regulator and clean useless info in patches (#3559)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 03ef96715ed7fd348268506c5098800f7f64f228: https://github.com/armbian/build/commit/03ef96715ed7fd348268506c5098800f7f64f228
+> X-Git-Archeology:   Date: Fri, 25 Mar 2022 20:51:03 +0100
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: fix emmc nano-pc-t4 (#3557)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision dad2d913f158af9602b233ce99389de0273254e4: https://github.com/armbian/build/commit/dad2d913f158af9602b233ce99389de0273254e4
+> X-Git-Archeology:   Date: Fri, 01 Apr 2022 21:11:55 -0700
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: change rk35xx edge to 5.17.y (#3614)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision eb54a13b05996777789f5e9b8f8058eca65fb6c9: https://github.com/armbian/build/commit/eb54a13b05996777789f5e9b8f8058eca65fb6c9
+> X-Git-Archeology:   Date: Tue, 05 Apr 2022 16:18:38 +0200
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: update kernel 5.17.1 station-p2-edge (#3637)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 57428044ec6ee099f6d67eebbcb9ce94c439b017: https://github.com/armbian/build/commit/57428044ec6ee099f6d67eebbcb9ce94c439b017
+> X-Git-Archeology:   Date: Mon, 02 May 2022 11:36:59 +0200
+> X-Git-Archeology:   From: Oleg <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: move kernel media-current to 5.17 and media-edge to 5.18 (#3726)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision fc66f374e843f3b57b6896ac1db98dbc1cba7ccb: https://github.com/armbian/build/commit/fc66f374e843f3b57b6896ac1db98dbc1cba7ccb
+> X-Git-Archeology:   Date: Sat, 07 May 2022 15:51:11 +0200
+> X-Git-Archeology:   From: catalinii <catalinii@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Merge rk35xx-edge into rockchip64-edge (#3765)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 597d2dac11f00d9070a4e49d6bad1b2244e36cb3: https://github.com/armbian/build/commit/597d2dac11f00d9070a4e49d6bad1b2244e36cb3
+> X-Git-Archeology:   Date: Sat, 28 May 2022 07:56:22 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64-edge to 5.18 (#3814)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 2e1b4eed739d6ea81c3a7ba7e94d1bcab5cbbb6c: https://github.com/armbian/build/commit/2e1b4eed739d6ea81c3a7ba7e94d1bcab5cbbb6c
+> X-Git-Archeology:   Date: Mon, 04 Jul 2022 16:18:31 +0300
+> X-Git-Archeology:   From: balbes150 <balbes-150@yandex.ru>
+> X-Git-Archeology:   Subject: move kernel media to current 5.18 and edge 5.19
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 8c6641e7b79f0d50acdc306d140e586a4e923cf0: https://github.com/armbian/build/commit/8c6641e7b79f0d50acdc306d140e586a4e923cf0
+> X-Git-Archeology:   Date: Wed, 03 Aug 2022 22:22:55 +0200
+> X-Git-Archeology:   From: Jianfeng Liu <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: update rockchip64 edge to 5.19 (#4039)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 6765f734cc4a22aeaa9f99a3ad28c8c322de26f6: https://github.com/armbian/build/commit/6765f734cc4a22aeaa9f99a3ad28c8c322de26f6
+> X-Git-Archeology:   Date: Tue, 25 Oct 2022 11:26:51 +0200
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Bump rockchip64 edge to 6.0.y (#4337)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 92f1a22d76b987afa7ba555d5b509adc51d689e7: https://github.com/armbian/build/commit/92f1a22d76b987afa7ba555d5b509adc51d689e7
+> X-Git-Archeology:   Date: Fri, 16 Dec 2022 13:38:13 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Re-add rockchip64 6.0 patches (#4575)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 34ae84fac5d0b66a1ab2d1e51534b7beb13ef245: https://github.com/armbian/build/commit/34ae84fac5d0b66a1ab2d1e51534b7beb13ef245
+> X-Git-Archeology:   Date: Fri, 05 May 2023 14:22:00 +0200
+> X-Git-Archeology:   From: amazingfate <liujianfeng1994@gmail.com>
+> X-Git-Archeology:   Subject: bump rockchip64 edge to v6.3
+> X-Git-Archeology:
+---
+ drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c | 149 +++++-----
+ 1 file changed, 73 insertions(+), 76 deletions(-)
+
 diff --git a/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c b/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c
-index fe4f9556239ac..cb43e7b47157d 100644
+index 2f4b8f64cbad..320f6bbf1365 100644
 --- a/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c
 +++ b/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c
 @@ -91,80 +91,88 @@ static struct rockchip_hdmi *to_rockchip_hdmi(struct drm_encoder *encoder)
@@ -152,24 +299,7 @@ index fe4f9556239ac..cb43e7b47157d 100644
  		},
  	}
  };
-diff --git a/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c b/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c
-index cb43e7b47157d..a77a46a709809 100644
---- a/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c
-+++ b/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c
-@@ -259,7 +259,7 @@ dw_hdmi_rockchip_mode_valid(struct dw_hdmi *hdmi, void *data,
- 	int i;
- 
- 	for (i = 0; mpll_cfg[i].mpixelclock != (~0UL); i++) {
--		if (pclk == mpll_cfg[i].mpixelclock) {
-+		if (pclk <= mpll_cfg[i].mpixelclock) {
- 			valid = true;
- 			break;
- 		}
-diff --git a/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c b/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c
-index a77a46a709809..ed480f6548f0e 100644
---- a/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c
-+++ b/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c
-@@ -180,20 +180,8 @@ static const struct dw_hdmi_mpll_config rockchip_mpll_cfg[] = {
+@@ -172,20 +180,8 @@ static const struct dw_hdmi_mpll_config rockchip_mpll_cfg[] = {
  static const struct dw_hdmi_curr_ctrl rockchip_cur_ctr[] = {
  	/*      pixelclk    bpp8    bpp10   bpp12 */
  	{
@@ -192,11 +322,7 @@ index a77a46a709809..ed480f6548f0e 100644
  		~0UL,      { 0x0000, 0x0000, 0x0000},
  	}
  };
-diff --git a/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c b/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c
-index ed480f6548f0e..de8720fd7d5d6 100644
---- a/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c
-+++ b/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c
-@@ -191,6 +191,7 @@ static const struct dw_hdmi_phy_config rockchip_phy_config[] = {
+@@ -195,6 +191,7 @@ static const struct dw_hdmi_phy_config rockchip_phy_config[] = {
  	{ 74250000,  0x8009, 0x0004, 0x0272},
  	{ 148500000, 0x802b, 0x0004, 0x028d},
  	{ 297000000, 0x8039, 0x0005, 0x028d},
@@ -204,3 +330,15 @@ index ed480f6548f0e..de8720fd7d5d6 100644
  	{ ~0UL,	     0x0000, 0x0000, 0x0000}
  };
  
+@@ -251,7 +248,7 @@ dw_hdmi_rockchip_mode_valid(struct dw_hdmi *hdmi, void *data,
+ 	int i;
+ 
+ 	for (i = 0; mpll_cfg[i].mpixelclock != (~0UL); i++) {
+-		if (pclk == mpll_cfg[i].mpixelclock) {
++		if (pclk <= mpll_cfg[i].mpixelclock) {
+ 			valid = true;
+ 			break;
+ 		}
+-- 
+Armbian
+

--- a/patch/misc/wireless-driver-for-uwe5622-allwinner-bugfix-v6.3.patch
+++ b/patch/misc/wireless-driver-for-uwe5622-allwinner-bugfix-v6.3.patch
@@ -1,7 +1,7 @@
-From b8d7374fd401d0d0de9647922f5288fdc99103b3 Mon Sep 17 00:00:00 2001
-From: orangepi-xunlong <258384131@qq.com>
-Date: Wed, 18 May 2022 09:38:39 +0800
-Subject: [PATCH] wireless: update uwe5622
+From 90dc2bf4b9243830a9d2951518e95116dd3fbb43 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Sun, 7 May 2023 15:07:06 +0200
+Subject: [PATCH 2/2] apply bugfixes for uwe5622 driver
 
 ---
  drivers/net/wireless/uwe5622/tty-sdio/tty.c   |  72 +--
@@ -27,8 +27,8 @@ Subject: [PATCH] wireless: update uwe5622
  .../uwe5622/unisocwcn/sdio/sdiohal_common.c   | 201 ++++---
  .../uwe5622/unisocwcn/sdio/sdiohal_ctl.c      |   9 +-
  .../uwe5622/unisocwcn/sdio/sdiohal_main.c     |   1 -
- .../uwe5622/unisocwcn/sdio/sdiohal_rx.c       |  54 +-
- .../uwe5622/unisocwcn/sdio/sdiohal_tx.c       |  10 +-
+ .../uwe5622/unisocwcn/sdio/sdiohal_rx.c       |  52 +-
+ .../uwe5622/unisocwcn/sdio/sdiohal_tx.c       |   8 +-
  .../uwe5622/unisocwcn/sleep/sdio_int.c        |  11 +-
  .../uwe5622/unisocwcn/sleep/sdio_int.h        |   4 +-
  .../uwe5622/unisocwcn/sleep/slp_mgr.c         |  10 +-
@@ -52,7 +52,7 @@ Subject: [PATCH] wireless: update uwe5622
  drivers/net/wireless/uwe5622/unisocwifi/msg.c |   6 +-
  drivers/net/wireless/uwe5622/unisocwifi/msg.h |   2 +
  drivers/net/wireless/uwe5622/unisocwifi/nan.c |   2 +-
- drivers/net/wireless/uwe5622/unisocwifi/npi.c |  22 +-
+ drivers/net/wireless/uwe5622/unisocwifi/npi.c |  20 +-
  drivers/net/wireless/uwe5622/unisocwifi/qos.c |  63 ++-
  drivers/net/wireless/uwe5622/unisocwifi/qos.h |   5 +-
  .../wireless/uwe5622/unisocwifi/reg_domain.c  |   8 +-
@@ -72,11 +72,11 @@ Subject: [PATCH] wireless: update uwe5622
  .../net/wireless/uwe5622/unisocwifi/wl_intf.c | 234 ++++----
  .../net/wireless/uwe5622/unisocwifi/wl_intf.h |   1 +
  .../net/wireless/uwe5622/unisocwifi/work.c    |  28 +-
- 68 files changed, 2158 insertions(+), 1587 deletions(-)
+ 68 files changed, 2155 insertions(+), 1584 deletions(-)
  create mode 100755 drivers/net/wireless/uwe5622/unisocwifi/wcn_wrapper.h
 
 diff --git a/drivers/net/wireless/uwe5622/tty-sdio/tty.c b/drivers/net/wireless/uwe5622/tty-sdio/tty.c
-index 0f90a758b7..6498272fc1 100755
+index 0f90a758b7bc..6498272fc192 100644
 --- a/drivers/net/wireless/uwe5622/tty-sdio/tty.c
 +++ b/drivers/net/wireless/uwe5622/tty-sdio/tty.c
 @@ -113,17 +113,6 @@ static ssize_t dumpmem_store(struct device *dev,
@@ -208,7 +208,7 @@ index 0f90a758b7..6498272fc1 100755
  	sprdwcn_bus_chn_init(&bt_tx_ops);
  	sema_init(&sem_id, BT_TX_POOL_SIZE - 1);
 diff --git a/drivers/net/wireless/uwe5622/tty-sdio/woble.c b/drivers/net/wireless/uwe5622/tty-sdio/woble.c
-index 1df3f37fd6..578108e7a7 100755
+index 1df3f37fd6be..578108e7a78a 100644
 --- a/drivers/net/wireless/uwe5622/tty-sdio/woble.c
 +++ b/drivers/net/wireless/uwe5622/tty-sdio/woble.c
 @@ -22,13 +22,13 @@
@@ -254,7 +254,7 @@ index 1df3f37fd6..578108e7a7 100755
  	hci_cmd.opcode = 0;
  
 diff --git a/drivers/net/wireless/uwe5622/unisocwcn/Makefile b/drivers/net/wireless/uwe5622/unisocwcn/Makefile
-index b62652f63a..f9c5957475 100755
+index b62652f63acb..f9c595747547 100644
 --- a/drivers/net/wireless/uwe5622/unisocwcn/Makefile
 +++ b/drivers/net/wireless/uwe5622/unisocwcn/Makefile
 @@ -50,6 +50,7 @@ endif
@@ -454,7 +454,7 @@ index b62652f63a..f9c5957475 100755
  KDIR ?= $(ANDROID_PRODUCT_OUT)/obj/KERNEL_OBJ
  ARCH ?= arm
 diff --git a/drivers/net/wireless/uwe5622/unisocwcn/boot/wcn_integrate_boot.c b/drivers/net/wireless/uwe5622/unisocwcn/boot/wcn_integrate_boot.c
-index c544d63cfa..9f713386ca 100755
+index c544d63cfa7d..9f713386ca60 100644
 --- a/drivers/net/wireless/uwe5622/unisocwcn/boot/wcn_integrate_boot.c
 +++ b/drivers/net/wireless/uwe5622/unisocwcn/boot/wcn_integrate_boot.c
 @@ -19,7 +19,6 @@
@@ -466,7 +466,7 @@ index c544d63cfa..9f713386ca 100755
  static struct mutex marlin_lock;
  static struct wifi_calibration wifi_data;
 diff --git a/drivers/net/wireless/uwe5622/unisocwcn/include/marlin_platform.h b/drivers/net/wireless/uwe5622/unisocwcn/include/marlin_platform.h
-index ae8daac466..7a78181a45 100755
+index ae8daac46644..7a78181a4586 100644
 --- a/drivers/net/wireless/uwe5622/unisocwcn/include/marlin_platform.h
 +++ b/drivers/net/wireless/uwe5622/unisocwcn/include/marlin_platform.h
 @@ -83,7 +83,8 @@ enum marlin_wake_host_en {
@@ -480,7 +480,7 @@ index ae8daac466..7a78181a45 100755
  
  enum wcn_hw_type wcn_get_hw_if_type(void);
 diff --git a/drivers/net/wireless/uwe5622/unisocwcn/include/uwe562x_glb.h b/drivers/net/wireless/uwe5622/unisocwcn/include/uwe562x_glb.h
-index ca7feadb54..275a464eb0 100755
+index ca7feadb5460..275a464eb05d 100644
 --- a/drivers/net/wireless/uwe5622/unisocwcn/include/uwe562x_glb.h
 +++ b/drivers/net/wireless/uwe5622/unisocwcn/include/uwe562x_glb.h
 @@ -245,16 +245,15 @@ static inline unsigned int reg_value(unsigned int marlin3reg,
@@ -506,7 +506,7 @@ index ca7feadb54..275a464eb0 100755
  #define GNSS_CHIPID_REG 0x603003fc
  
 diff --git a/drivers/net/wireless/uwe5622/unisocwcn/platform/bufring.c b/drivers/net/wireless/uwe5622/unisocwcn/platform/bufring.c
-index b8459b914c..7cb79f2f2d 100755
+index b8459b914cb1..7cb79f2f2d0c 100644
 --- a/drivers/net/wireless/uwe5622/unisocwcn/platform/bufring.c
 +++ b/drivers/net/wireless/uwe5622/unisocwcn/platform/bufring.c
 @@ -117,7 +117,6 @@ void mdbg_ring_destroy(struct mdbg_ring_t *ring)
@@ -518,7 +518,7 @@ index b8459b914c..7cb79f2f2d 100755
  }
  
 diff --git a/drivers/net/wireless/uwe5622/unisocwcn/platform/gnss/gnss_common.h b/drivers/net/wireless/uwe5622/unisocwcn/platform/gnss/gnss_common.h
-index 5999726f54..34de085bb0 100755
+index 5999726f543c..34de085bb05c 100644
 --- a/drivers/net/wireless/uwe5622/unisocwcn/platform/gnss/gnss_common.h
 +++ b/drivers/net/wireless/uwe5622/unisocwcn/platform/gnss/gnss_common.h
 @@ -20,44 +20,76 @@
@@ -624,7 +624,7 @@ index 5999726f54..34de085bb0 100755
  
  #endif
 diff --git a/drivers/net/wireless/uwe5622/unisocwcn/platform/gnss/gnss_common_ctl.c b/drivers/net/wireless/uwe5622/unisocwcn/platform/gnss/gnss_common_ctl.c
-index c9831c1d38..0fe9e1aded 100755
+index c9831c1d38cc..0fe9e1aded81 100644
 --- a/drivers/net/wireless/uwe5622/unisocwcn/platform/gnss/gnss_common_ctl.c
 +++ b/drivers/net/wireless/uwe5622/unisocwcn/platform/gnss/gnss_common_ctl.c
 @@ -76,18 +76,21 @@ enum gnss_cp_status_subtype {
@@ -823,7 +823,7 @@ index c9831c1d38..0fe9e1aded 100755
  MODULE_AUTHOR("Jun.an<jun.an@spreadtrum.com>");
 +#endif
 diff --git a/drivers/net/wireless/uwe5622/unisocwcn/platform/gnss/gnss_dbg.c b/drivers/net/wireless/uwe5622/unisocwcn/platform/gnss/gnss_dbg.c
-index 5d21799337..b1c2b9408c 100755
+index 5d21799337fd..b1c2b9408cd4 100644
 --- a/drivers/net/wireless/uwe5622/unisocwcn/platform/gnss/gnss_dbg.c
 +++ b/drivers/net/wireless/uwe5622/unisocwcn/platform/gnss/gnss_dbg.c
 @@ -109,7 +109,6 @@ static void gnss_ring_destroy(struct gnss_ring_t *pring)
@@ -917,7 +917,7 @@ index 5d21799337..b1c2b9408c 100755
  MODULE_LICENSE("GPL");
 +#endif
 diff --git a/drivers/net/wireless/uwe5622/unisocwcn/platform/gnss/gnss_dump.c b/drivers/net/wireless/uwe5622/unisocwcn/platform/gnss/gnss_dump.c
-index 44afbf6ec7..48da71449d 100755
+index 44afbf6ec70f..48da71449d89 100644
 --- a/drivers/net/wireless/uwe5622/unisocwcn/platform/gnss/gnss_dump.c
 +++ b/drivers/net/wireless/uwe5622/unisocwcn/platform/gnss/gnss_dump.c
 @@ -18,7 +18,9 @@
@@ -996,7 +996,7 @@ index 44afbf6ec7..48da71449d 100755
  	ret = gnss_creat_gnss_dump_file();
  	if (ret == -1) {
 diff --git a/drivers/net/wireless/uwe5622/unisocwcn/platform/gnss/gnss_pmnotify_ctl.c b/drivers/net/wireless/uwe5622/unisocwcn/platform/gnss/gnss_pmnotify_ctl.c
-index 84412f9160..6bf78a2bd9 100755
+index 84412f9160dd..6bf78a2bd9c1 100644
 --- a/drivers/net/wireless/uwe5622/unisocwcn/platform/gnss/gnss_pmnotify_ctl.c
 +++ b/drivers/net/wireless/uwe5622/unisocwcn/platform/gnss/gnss_pmnotify_ctl.c
 @@ -32,6 +32,7 @@
@@ -1043,7 +1043,7 @@ index 84412f9160..6bf78a2bd9 100755
 +#endif
 \ No newline at end of file
 diff --git a/drivers/net/wireless/uwe5622/unisocwcn/platform/rdc_debug.c b/drivers/net/wireless/uwe5622/unisocwcn/platform/rdc_debug.c
-index 015c9020e9..86fa3b103a 100755
+index 015c9020e913..86fa3b103ad3 100644
 --- a/drivers/net/wireless/uwe5622/unisocwcn/platform/rdc_debug.c
 +++ b/drivers/net/wireless/uwe5622/unisocwcn/platform/rdc_debug.c
 @@ -31,8 +31,6 @@
@@ -1075,7 +1075,7 @@ index 015c9020e9..86fa3b103a 100755
  	"/data",		/* amlogic s905w... */
  	"/mnt/UDISK"		/* allwinner r328... */
 diff --git a/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_boot.c b/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_boot.c
-index 57cf1a898f..fca777c802 100755
+index 57cf1a898fb9..fca777c80200 100644
 --- a/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_boot.c
 +++ b/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_boot.c
 @@ -10,7 +10,7 @@
@@ -1527,7 +1527,7 @@ index 57cf1a898f..fca777c802 100755
  	platform_driver_unregister(&marlin_driver);
  
 diff --git a/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_op.h b/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_op.h
-index 391280910f..7121823e7a 100755
+index 391280910f84..7121823e7af8 100644
 --- a/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_op.h
 +++ b/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_op.h
 @@ -1,12 +1,6 @@
@@ -1544,7 +1544,7 @@ index 391280910f..7121823e7a 100755
  void wcn_op_exit(void);
  
 diff --git a/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_parn_parser.c b/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_parn_parser.c
-index fe6cd44fb1..0a61282f4c 100755
+index fe6cd44fb178..0a61282f4cb1 100644
 --- a/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_parn_parser.c
 +++ b/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_parn_parser.c
 @@ -48,9 +48,6 @@
@@ -1558,7 +1558,7 @@ index fe6cd44fb1..0a61282f4c 100755
  static char fstab_name[128];
  static char fstab_dir[FSTAB_PATH_NUM][32] = {
 diff --git a/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_procfs.c b/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_procfs.c
-index 2edb7903d8..8be7131e1a 100755
+index b179f2398b1f..77b4ec259e3d 100644
 --- a/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_procfs.c
 +++ b/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_procfs.c
 @@ -23,7 +23,7 @@
@@ -1683,7 +1683,7 @@ index 2edb7903d8..8be7131e1a 100755
  
  static int mdbg_proc_open(struct inode *inode, struct file *filp)
  {
-@@ -752,6 +760,12 @@ static ssize_t mdbg_proc_write(struct file *filp,
+@@ -756,6 +764,12 @@ static ssize_t mdbg_proc_write(struct file *filp,
  		return count;
  	}
  
@@ -1696,7 +1696,7 @@ index 2edb7903d8..8be7131e1a 100755
  
  	/* unit of loglimitsize is MByte. */
  	if (strncmp(mdbg_proc->write_buf, "loglimitsize=",
-@@ -1007,13 +1021,23 @@ static unsigned int mdbg_proc_poll(struct file *filp, poll_table *wait)
+@@ -1011,13 +1025,23 @@ static unsigned int mdbg_proc_poll(struct file *filp, poll_table *wait)
  	return mask;
  }
  
@@ -1726,7 +1726,7 @@ index 2edb7903d8..8be7131e1a 100755
  int mdbg_memory_alloc(void)
  {
 diff --git a/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_txrx.c b/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_txrx.c
-index 8b19305ca1..2fd7f39888 100755
+index 8b19305ca192..2fd7f39888a4 100644
 --- a/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_txrx.c
 +++ b/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_txrx.c
 @@ -114,7 +114,7 @@ static long int mdbg_comm_write(char *buf,
@@ -1806,7 +1806,7 @@ index 8b19305ca1..2fd7f39888 100755
  	mdbg_dev->ring_dev = NULL;
  	kfree(ring_dev);
 diff --git a/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_txrx.h b/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_txrx.h
-index 9e74b7176a..3e1dc9f422 100755
+index 9e74b7176ae0..3e1dc9f42258 100644
 --- a/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_txrx.h
 +++ b/drivers/net/wireless/uwe5622/unisocwcn/platform/wcn_txrx.h
 @@ -18,8 +18,6 @@
@@ -1830,7 +1830,7 @@ index 9e74b7176a..3e1dc9f422 100755
  	struct mutex mdbg_read_mutex;
  	struct list_head	rx_head;
 diff --git a/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal.h b/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal.h
-index 55eda73261..c26bfb3251 100755
+index 55eda732610b..c26bfb3251b4 100644
 --- a/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal.h
 +++ b/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal.h
 @@ -15,7 +15,7 @@
@@ -1882,7 +1882,7 @@ index 55eda73261..c26bfb3251 100755
  int sdiohal_misc_init(void);
  void sdiohal_misc_deinit(void);
 diff --git a/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal_common.c b/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal_common.c
-index 8896272a95..8dbf21437b 100755
+index 8896272a950f..8dbf21437b57 100644
 --- a/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal_common.c
 +++ b/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal_common.c
 @@ -3,7 +3,7 @@
@@ -2398,7 +2398,7 @@ index 8896272a95..8dbf21437b 100755
  
  	return 0;
 diff --git a/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal_ctl.c b/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal_ctl.c
-index ceb34a487e..b426bf89cd 100755
+index ceb34a487e69..b426bf89cd9a 100644
 --- a/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal_ctl.c
 +++ b/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal_ctl.c
 @@ -55,9 +55,6 @@
@@ -2439,7 +2439,7 @@ index ceb34a487e..b426bf89cd 100755
  	if (count > SDIOHAL_WRITE_SIZE) {
  		sdiohal_err("%s write size > %d\n",
 diff --git a/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal_main.c b/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal_main.c
-index 920645b2b6..2f093e403d 100755
+index 42fb0a2b38a8..0f67a7f35c30 100644
 --- a/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal_main.c
 +++ b/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal_main.c
 @@ -1971,7 +1971,6 @@ static int sdiohal_probe(struct sdio_func *func,
@@ -2451,7 +2451,7 @@ index 920645b2b6..2f093e403d 100755
  	sdiohal_info("probe ok\n");
  
 diff --git a/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal_rx.c b/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal_rx.c
-index 287d17c959..e968c09b23 100755
+index 287d17c959db..2a64dac7af55 100644
 --- a/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal_rx.c
 +++ b/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal_rx.c
 @@ -99,8 +99,8 @@ static int sdiohal_rx_list_parser(struct sdiohal_list_t *data_list,
@@ -2590,7 +2590,7 @@ index 287d17c959..e968c09b23 100755
  		}
  
 diff --git a/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal_tx.c b/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal_tx.c
-index 540a589770..b3b000e951 100755
+index 540a589770b4..c0790f6cdd13 100644
 --- a/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal_tx.c
 +++ b/drivers/net/wireless/uwe5622/unisocwcn/sdio/sdiohal_tx.c
 @@ -33,8 +33,8 @@ static void sdiohal_tx_retrybuf_left(unsigned int suc_pac_cnt)
@@ -2623,7 +2623,7 @@ index 540a589770..b3b000e951 100755
  		}
  
 diff --git a/drivers/net/wireless/uwe5622/unisocwcn/sleep/sdio_int.c b/drivers/net/wireless/uwe5622/unisocwcn/sleep/sdio_int.c
-index 6a14855a91..f3dec551e9 100755
+index 6a14855a91e7..f3dec551e97e 100644
 --- a/drivers/net/wireless/uwe5622/unisocwcn/sleep/sdio_int.c
 +++ b/drivers/net/wireless/uwe5622/unisocwcn/sleep/sdio_int.c
 @@ -58,7 +58,7 @@ void sdio_wait_pub_int_done(void)
@@ -2675,7 +2675,7 @@ index 6a14855a91..f3dec551e9 100755
  	wakeup_source_destroy(sdio_int.pub_int_ws);
  
 diff --git a/drivers/net/wireless/uwe5622/unisocwcn/sleep/sdio_int.h b/drivers/net/wireless/uwe5622/unisocwcn/sleep/sdio_int.h
-index b4ed05fd5e..2a1bbf2486 100755
+index b4ed05fd5efa..2a1bbf24864f 100644
 --- a/drivers/net/wireless/uwe5622/unisocwcn/sleep/sdio_int.h
 +++ b/drivers/net/wireless/uwe5622/unisocwcn/sleep/sdio_int.h
 @@ -2,8 +2,6 @@
@@ -2698,7 +2698,7 @@ index b4ed05fd5e..2a1bbf2486 100755
  	unsigned int pub_int_num;
  	/* 1: power on, 0: power off */
 diff --git a/drivers/net/wireless/uwe5622/unisocwcn/sleep/slp_mgr.c b/drivers/net/wireless/uwe5622/unisocwcn/sleep/slp_mgr.c
-index 3c173c2604..65f37abc43 100755
+index 3c173c260444..65f37abc4399 100644
 --- a/drivers/net/wireless/uwe5622/unisocwcn/sleep/slp_mgr.c
 +++ b/drivers/net/wireless/uwe5622/unisocwcn/sleep/slp_mgr.c
 @@ -29,6 +29,7 @@
@@ -2750,7 +2750,7 @@ index 3c173c2604..65f37abc43 100755
  				mutex_unlock(&(slp_mgr.wakeup_lock));
  				return -1;
 diff --git a/drivers/net/wireless/uwe5622/unisocwcn/wcn_bus.c b/drivers/net/wireless/uwe5622/unisocwcn/wcn_bus.c
-index 0277de6665..231718d773 100755
+index 0277de66659e..231718d77364 100644
 --- a/drivers/net/wireless/uwe5622/unisocwcn/wcn_bus.c
 +++ b/drivers/net/wireless/uwe5622/unisocwcn/wcn_bus.c
 @@ -17,8 +17,6 @@
@@ -2806,7 +2806,7 @@ index 0277de6665..231718d773 100755
  
  	/* pr_info("[-]%s(%d)\n", __func__, ops->channel); */
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/Kconfig b/drivers/net/wireless/uwe5622/unisocwifi/Kconfig
-index 060c584f5d..fce21d35d0 100755
+index 060c584f5da3..fce21d35d06c 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/Kconfig
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/Kconfig
 @@ -1,3 +1,8 @@
@@ -2826,7 +2826,7 @@ index 060c584f5d..fce21d35d0 100755
 +          Sprd UWE5622 Wi-Fi Driver Power Save.
  
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/Makefile b/drivers/net/wireless/uwe5622/unisocwifi/Makefile
-index 966e74eeeb..f9047ecd5a 100755
+index 966e74eeeb2c..f9047ecd5a37 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/Makefile
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/Makefile
 @@ -1,8 +1,6 @@
@@ -2915,7 +2915,7 @@ index 966e74eeeb..f9047ecd5a 100755
  all: $(all_dependencies)
  driver: $(driver_dependencies)
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/api_version.c b/drivers/net/wireless/uwe5622/unisocwifi/api_version.c
-index 79f0b5706d..91bcfee46f 100755
+index 79f0b5706d13..91bcfee46fb8 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/api_version.c
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/api_version.c
 @@ -407,7 +407,7 @@ void sprdwl_fill_drv_api_version(struct sprdwl_priv *priv,
@@ -2970,7 +2970,7 @@ index 79f0b5706d..91bcfee46f 100755
  	}
  }
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/cfg80211.c b/drivers/net/wireless/uwe5622/unisocwifi/cfg80211.c
-index daef880ae3..3d0f12ce37 100755
+index 47d60f30c2e6..490797f8fc42 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/cfg80211.c
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/cfg80211.c
 @@ -238,38 +238,38 @@ sprdwl_mgmt_stypes[NUM_NL80211_IFTYPES] = {
@@ -3239,7 +3239,7 @@ index daef880ae3..3d0f12ce37 100755
  	kfree(mgmt);
  
  #ifdef DFS_MASTER
-@@ -999,14 +999,14 @@ static int sprdwl_cfg80211_stop_ap(struct wiphy *wiphy, struct net_device *ndev)
+@@ -1003,14 +1003,14 @@ static int sprdwl_cfg80211_stop_ap(struct wiphy *wiphy, struct net_device *ndev)
  }
  
  static int sprdwl_cfg80211_add_station(struct wiphy *wiphy,
@@ -3257,7 +3257,7 @@ index daef880ae3..3d0f12ce37 100755
  #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 83)
  					   struct station_del_parameters *params
  #else
-@@ -1042,16 +1042,16 @@ static int sprdwl_cfg80211_del_station(struct wiphy *wiphy,
+@@ -1046,16 +1046,16 @@ static int sprdwl_cfg80211_del_station(struct wiphy *wiphy,
  
  static int
  sprdwl_cfg80211_change_station(struct wiphy *wiphy,
@@ -3278,7 +3278,7 @@ index daef880ae3..3d0f12ce37 100755
  {
  	struct sprdwl_vif *vif = netdev_priv(ndev);
  	struct sprdwl_cmd_get_station sta;
-@@ -1122,8 +1122,8 @@ static int sprdwl_cfg80211_get_station(struct wiphy *wiphy,
+@@ -1126,8 +1126,8 @@ static int sprdwl_cfg80211_get_station(struct wiphy *wiphy,
  
  #else
  static int sprdwl_cfg80211_get_station(struct wiphy *wiphy,
@@ -3289,7 +3289,7 @@ index daef880ae3..3d0f12ce37 100755
  {
  	struct sprdwl_vif *vif = netdev_priv(ndev);
  	struct sprdwl_cmd_get_station sta;
-@@ -1176,8 +1176,8 @@ static int sprdwl_cfg80211_get_station(struct wiphy *wiphy,
+@@ -1180,8 +1180,8 @@ static int sprdwl_cfg80211_get_station(struct wiphy *wiphy,
  #endif
  
  static int sprdwl_cfg80211_set_channel(struct wiphy *wiphy,
@@ -3300,7 +3300,7 @@ index daef880ae3..3d0f12ce37 100755
  {
  	struct sprdwl_vif *vif = netdev_priv(ndev);
  
-@@ -1217,7 +1217,7 @@ void sprdwl_report_softap(struct sprdwl_vif *vif, u8 is_connect, u8 *addr,
+@@ -1221,7 +1221,7 @@ void sprdwl_report_softap(struct sprdwl_vif *vif, u8 is_connect, u8 *addr,
  	} else {
  		cfg80211_del_sta(vif->ndev, addr, GFP_KERNEL);
  		wl_ndev_log(L_DBG, vif->ndev, "The station (%pM) disconnected\n",
@@ -3309,7 +3309,7 @@ index daef880ae3..3d0f12ce37 100755
  		trace_deauth_reason(vif->mode, 0, REMOTE_EVENT);
  	}
  }
-@@ -1259,7 +1259,7 @@ void sprdwl_cancel_scan(struct sprdwl_vif *vif)
+@@ -1263,7 +1263,7 @@ void sprdwl_cancel_scan(struct sprdwl_vif *vif)
  #endif
  			else
  				wl_err("%s, %d, error, scan_request freed",
@@ -3318,7 +3318,7 @@ index daef880ae3..3d0f12ce37 100755
  			priv->scan_request = NULL;
  			priv->scan_vif = NULL;
  		}
-@@ -1319,7 +1319,7 @@ void sprdwl_scan_done(struct sprdwl_vif *vif, bool abort)
+@@ -1323,7 +1323,7 @@ void sprdwl_scan_done(struct sprdwl_vif *vif, bool abort)
  #endif
  			} else {
  				wl_err("%s, %d, error, scan_request freed",
@@ -3327,7 +3327,7 @@ index daef880ae3..3d0f12ce37 100755
  			}
  			priv->scan_request = NULL;
  			priv->scan_vif = NULL;
-@@ -1344,7 +1344,7 @@ void sprdwl_sched_scan_done(struct sprdwl_vif *vif, bool abort)
+@@ -1348,7 +1348,7 @@ void sprdwl_sched_scan_done(struct sprdwl_vif *vif, bool abort)
  			cfg80211_sched_scan_results(vif->wdev.wiphy);
  #endif
  			wl_ndev_log(L_DBG, priv->sched_scan_vif->ndev,
@@ -3336,7 +3336,7 @@ index daef880ae3..3d0f12ce37 100755
  			priv->sched_scan_request = NULL;
  			priv->sched_scan_vif = NULL;
  		}
-@@ -1389,7 +1389,7 @@ static int sprdwl_cfg80211_scan(struct wiphy *wiphy,
+@@ -1393,7 +1393,7 @@ static int sprdwl_cfg80211_scan(struct wiphy *wiphy,
  {
  	struct sprdwl_priv *priv = wiphy_priv(wiphy);
  	struct sprdwl_vif *vif =
@@ -3345,7 +3345,7 @@ index daef880ae3..3d0f12ce37 100755
  	struct cfg80211_ssid *ssids = request->ssids;
  	struct sprdwl_scan_ssid *scan_ssids;
  	u8 *ssids_ptr = NULL;
-@@ -1417,11 +1417,11 @@ static int sprdwl_cfg80211_scan(struct wiphy *wiphy,
+@@ -1421,11 +1421,11 @@ static int sprdwl_cfg80211_scan(struct wiphy *wiphy,
  #endif
  
  	wl_ndev_log(L_DBG, vif->ndev, "%s n_channels %u\n", __func__,
@@ -3359,7 +3359,7 @@ index daef880ae3..3d0f12ce37 100755
  		ret = -EOPNOTSUPP;
  		goto err;
  	}
-@@ -1439,7 +1439,7 @@ static int sprdwl_cfg80211_scan(struct wiphy *wiphy,
+@@ -1443,7 +1443,7 @@ static int sprdwl_cfg80211_scan(struct wiphy *wiphy,
  		if (flags & (1<<3)) {
  			random_mac_flag = 1;
  			wl_info("Random MAC support==set value:%d\n",
@@ -3368,7 +3368,7 @@ index daef880ae3..3d0f12ce37 100755
  			wl_info("random mac addr: %pM\n", rand_addr);
  		} else {
  			wl_info("random mac feature disabled\n");
-@@ -1448,7 +1448,7 @@ static int sprdwl_cfg80211_scan(struct wiphy *wiphy,
+@@ -1452,7 +1452,7 @@ static int sprdwl_cfg80211_scan(struct wiphy *wiphy,
  		if (random_mac_flag != old_mac_flag) {
  			old_mac_flag = random_mac_flag;
  			wlan_cmd_set_rand_mac(vif->priv, vif->ctx_id,
@@ -3377,7 +3377,7 @@ index daef880ae3..3d0f12ce37 100755
  		}
  	}
  #endif
-@@ -1463,7 +1463,7 @@ static int sprdwl_cfg80211_scan(struct wiphy *wiphy,
+@@ -1467,7 +1467,7 @@ static int sprdwl_cfg80211_scan(struct wiphy *wiphy,
  		}
  
  		ret = sprdwl_set_ie(priv, vif->ctx_id, SPRDWL_IE_PROBE_REQ,
@@ -3386,7 +3386,7 @@ index daef880ae3..3d0f12ce37 100755
  		if (ret)
  			goto err;
  	}
-@@ -1506,7 +1506,7 @@ static int sprdwl_cfg80211_scan(struct wiphy *wiphy,
+@@ -1510,7 +1510,7 @@ static int sprdwl_cfg80211_scan(struct wiphy *wiphy,
  			info->beacon_num = 0;
  			info->channel = NULL;
  			list_add_tail(&info->survey_list,
@@ -3395,7 +3395,7 @@ index daef880ae3..3d0f12ce37 100755
  		}
  #endif /* ACS_SUPPORT */
  	}
-@@ -1532,7 +1532,7 @@ static int sprdwl_cfg80211_scan(struct wiphy *wiphy,
+@@ -1536,7 +1536,7 @@ static int sprdwl_cfg80211_scan(struct wiphy *wiphy,
  			scan_ssids_len += (ssids[i].ssid_len
  					   + sizeof(scan_ssids->len));
  			scan_ssids = (struct sprdwl_scan_ssid *)
@@ -3404,7 +3404,7 @@ index daef880ae3..3d0f12ce37 100755
  		}
  	} else {
  #ifndef ACS_SUPPORT
-@@ -1568,9 +1568,9 @@ static int sprdwl_cfg80211_scan(struct wiphy *wiphy,
+@@ -1572,9 +1572,9 @@ static int sprdwl_cfg80211_scan(struct wiphy *wiphy,
  }
  
  static int sprdwl_cfg80211_sched_scan_start(struct wiphy *wiphy,
@@ -3417,7 +3417,7 @@ index daef880ae3..3d0f12ce37 100755
  {
  	struct sprdwl_priv *priv = wiphy_priv(wiphy);
  #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 83)
-@@ -1592,7 +1592,7 @@ static int sprdwl_cfg80211_sched_scan_start(struct wiphy *wiphy,
+@@ -1596,7 +1596,7 @@ static int sprdwl_cfg80211_sched_scan_start(struct wiphy *wiphy,
  	/*scan not allowed if closed*/
  	if (vif->priv->fw_stat[vif->mode] == SPRDWL_INTF_CLOSE) {
  		wl_err("%s, %d, error!mode%d scan after closed not allowed\n",
@@ -3426,7 +3426,7 @@ index daef880ae3..3d0f12ce37 100755
  		return -ENOMEM;
  	}
  
-@@ -1603,23 +1603,23 @@ static int sprdwl_cfg80211_sched_scan_start(struct wiphy *wiphy,
+@@ -1607,23 +1607,23 @@ static int sprdwl_cfg80211_sched_scan_start(struct wiphy *wiphy,
  	/*to protect the size of struct sprdwl_sched_scan_buf*/
  	if (request->n_channels > TOTAL_2G_5G_CHANNEL_NUM) {
  		wl_err("%s, %d, error! request->n_channels=%d\n",
@@ -3454,7 +3454,7 @@ index daef880ae3..3d0f12ce37 100755
  	scan_plans = request->scan_plans;
  	sscan_buf->interval = scan_plans->interval;
  #else
-@@ -1644,8 +1644,8 @@ static int sprdwl_cfg80211_sched_scan_start(struct wiphy *wiphy,
+@@ -1648,8 +1648,8 @@ static int sprdwl_cfg80211_sched_scan_start(struct wiphy *wiphy,
  
  		if (ch == 0) {
  			wl_ndev_log(L_DBG, ndev, "%s  unknown frequency %dMhz\n",
@@ -3465,7 +3465,7 @@ index daef880ae3..3d0f12ce37 100755
  			continue;
  		}
  
-@@ -1721,6 +1721,20 @@ static int sprdwl_cfg80211_sched_scan_stop(struct wiphy *wiphy,
+@@ -1725,6 +1725,20 @@ static int sprdwl_cfg80211_sched_scan_stop(struct wiphy *wiphy,
  #ifdef SYNC_DISCONNECT
  void sprdwl_disconnect_handle(struct sprdwl_vif *vif)
  {
@@ -3486,7 +3486,7 @@ index daef880ae3..3d0f12ce37 100755
  	vif->sm_state = SPRDWL_DISCONNECTED;
  
  	/* Clear bssid & ssid */
-@@ -1742,24 +1756,22 @@ void sprdwl_disconnect_handle(struct sprdwl_vif *vif)
+@@ -1746,24 +1760,22 @@ void sprdwl_disconnect_handle(struct sprdwl_vif *vif)
  }
  #endif
  static int sprdwl_cfg80211_disconnect(struct wiphy *wiphy,
@@ -3513,7 +3513,7 @@ index daef880ae3..3d0f12ce37 100755
  
  	vif->sm_state = SPRDWL_DISCONNECTING;
  
-@@ -1772,17 +1784,19 @@ static int sprdwl_cfg80211_disconnect(struct wiphy *wiphy,
+@@ -1776,17 +1788,19 @@ static int sprdwl_cfg80211_disconnect(struct wiphy *wiphy,
  		goto out;
  	}
  #ifdef SYNC_DISCONNECT
@@ -3536,7 +3536,7 @@ index daef880ae3..3d0f12ce37 100755
  #endif
  	trace_deauth_reason(vif->mode, reason_code, LOCAL_EVENT);
  out:
-@@ -1799,14 +1813,14 @@ static int sprdwl_cfg80211_connect(struct wiphy *wiphy, struct net_device *ndev,
+@@ -1803,14 +1817,14 @@ static int sprdwl_cfg80211_connect(struct wiphy *wiphy, struct net_device *ndev,
  	struct sprdwl_cmd_connect con;
  	enum sm_state old_state = vif->sm_state;
  	int is_wep = (sme->crypto.cipher_group == WLAN_CIPHER_SUITE_WEP40) ||
@@ -3553,7 +3553,7 @@ index daef880ae3..3d0f12ce37 100755
  		goto err;
  	}
  
-@@ -1814,7 +1828,7 @@ static int sprdwl_cfg80211_connect(struct wiphy *wiphy, struct net_device *ndev,
+@@ -1818,7 +1832,7 @@ static int sprdwl_cfg80211_connect(struct wiphy *wiphy, struct net_device *ndev,
  		if (vif->has_rand_mac) {
  			 random_mac_flag = SPRDWL_CONNECT_RANDOM_ADDR;
  			 ret = wlan_cmd_set_rand_mac(vif->priv, vif->ctx_id,
@@ -3562,7 +3562,7 @@ index daef880ae3..3d0f12ce37 100755
  			 if (ret)
  				 netdev_info(ndev, "Set random mac failed!\n");
  		}
-@@ -1832,7 +1846,7 @@ static int sprdwl_cfg80211_connect(struct wiphy *wiphy, struct net_device *ndev,
+@@ -1836,7 +1850,7 @@ static int sprdwl_cfg80211_connect(struct wiphy *wiphy, struct net_device *ndev,
  	if (sme->ie_len > 0) {
  		wl_ndev_log(L_DBG, ndev, "set assoc req ie, len %zx\n", sme->ie_len);
  		ret = sprdwl_set_ie(vif->priv, vif->ctx_id, SPRDWL_IE_ASSOC_REQ,
@@ -3571,7 +3571,7 @@ index daef880ae3..3d0f12ce37 100755
  		if (ret)
  			goto err;
  	}
-@@ -1844,7 +1858,7 @@ static int sprdwl_cfg80211_connect(struct wiphy *wiphy, struct net_device *ndev,
+@@ -1848,7 +1862,7 @@ static int sprdwl_cfg80211_connect(struct wiphy *wiphy, struct net_device *ndev,
  
  	wl_ndev_log(L_DBG, ndev, "auth type %#x\n", sme->auth_type);
  	if ((sme->auth_type == NL80211_AUTHTYPE_OPEN_SYSTEM) ||
@@ -3580,7 +3580,7 @@ index daef880ae3..3d0f12ce37 100755
  		con.auth_type = SPRDWL_AUTH_OPEN;
  	else if ((sme->auth_type == NL80211_AUTHTYPE_SHARED_KEY) ||
  		 ((sme->auth_type == NL80211_AUTHTYPE_AUTOMATIC) && is_wep))
-@@ -1853,11 +1867,11 @@ static int sprdwl_cfg80211_connect(struct wiphy *wiphy, struct net_device *ndev,
+@@ -1857,11 +1871,11 @@ static int sprdwl_cfg80211_connect(struct wiphy *wiphy, struct net_device *ndev,
  	/* Set pairewise cipher */
  	if (sme->crypto.n_ciphers_pairwise) {
  		vif->prwise_crypto =
@@ -3594,7 +3594,7 @@ index daef880ae3..3d0f12ce37 100755
  			con.pairwise_cipher = vif->prwise_crypto;
  			con.pairwise_cipher |= SPRDWL_VALID_CONFIG;
  		}
-@@ -1870,7 +1884,7 @@ static int sprdwl_cfg80211_connect(struct wiphy *wiphy, struct net_device *ndev,
+@@ -1874,7 +1888,7 @@ static int sprdwl_cfg80211_connect(struct wiphy *wiphy, struct net_device *ndev,
  	vif->grp_crypto = sprdwl_parse_cipher(sme->crypto.cipher_group);
  	if (vif->grp_crypto != SPRDWL_CIPHER_NONE) {
  		wl_ndev_log(L_DBG, ndev, "group cipher %#x\n",
@@ -3603,7 +3603,7 @@ index daef880ae3..3d0f12ce37 100755
  		con.group_cipher = vif->grp_crypto;
  		con.group_cipher |= SPRDWL_VALID_CONFIG;
  	}
-@@ -1878,7 +1892,7 @@ static int sprdwl_cfg80211_connect(struct wiphy *wiphy, struct net_device *ndev,
+@@ -1882,7 +1896,7 @@ static int sprdwl_cfg80211_connect(struct wiphy *wiphy, struct net_device *ndev,
  	/* Set auth key management (akm) */
  	if (sme->crypto.n_akm_suites) {
  		wl_ndev_log(L_DBG, ndev, "akm suites %#x\n",
@@ -3612,7 +3612,7 @@ index daef880ae3..3d0f12ce37 100755
  		con.key_mgmt = sprdwl_parse_akm(sme->crypto.akm_suites[0]);
  		con.key_mgmt |= SPRDWL_VALID_CONFIG;
  	} else {
-@@ -1888,17 +1902,17 @@ static int sprdwl_cfg80211_connect(struct wiphy *wiphy, struct net_device *ndev,
+@@ -1892,17 +1906,17 @@ static int sprdwl_cfg80211_connect(struct wiphy *wiphy, struct net_device *ndev,
  	/* Set PSK */
  	if (sme->key_len) {
  		if (sme->crypto.cipher_group == WLAN_CIPHER_SUITE_WEP40 ||
@@ -3637,7 +3637,7 @@ index daef880ae3..3d0f12ce37 100755
  						  sme->crypto.
  						  ciphers_pairwise[0],
  						  NULL, NULL);
-@@ -1927,7 +1941,7 @@ static int sprdwl_cfg80211_connect(struct wiphy *wiphy, struct net_device *ndev,
+@@ -1931,7 +1945,7 @@ static int sprdwl_cfg80211_connect(struct wiphy *wiphy, struct net_device *ndev,
  			u16 center_freq = sme->channel_hint->center_freq;
  
  			con.channel =
@@ -3646,7 +3646,7 @@ index daef880ae3..3d0f12ce37 100755
  			wl_ndev_log(L_DBG, ndev, "channel_hint %d\n", con.channel);
  #ifdef STA_SOFTAP_SCC_MODE
  			if (sme->channel_hint->flags != IEEE80211_CHAN_RADAR)
-@@ -1940,7 +1954,7 @@ static int sprdwl_cfg80211_connect(struct wiphy *wiphy, struct net_device *ndev,
+@@ -1944,7 +1958,7 @@ static int sprdwl_cfg80211_connect(struct wiphy *wiphy, struct net_device *ndev,
  		}
  	} else {
  		con.channel =
@@ -3655,7 +3655,7 @@ index daef880ae3..3d0f12ce37 100755
  		wl_ndev_log(L_DBG, ndev, "channel %d\n", con.channel);
  #ifdef STA_SOFTAP_SCC_MODE
  		if (sme->channel->flags != IEEE80211_CHAN_RADAR)
-@@ -1963,14 +1977,14 @@ static int sprdwl_cfg80211_connect(struct wiphy *wiphy, struct net_device *ndev,
+@@ -1967,14 +1981,14 @@ static int sprdwl_cfg80211_connect(struct wiphy *wiphy, struct net_device *ndev,
  
  	/* Special process for WEP(WEP key must be set before essid) */
  	if (sme->crypto.cipher_group == WLAN_CIPHER_SUITE_WEP40 ||
@@ -3672,7 +3672,7 @@ index daef880ae3..3d0f12ce37 100755
  				wl_ndev_log(L_ERR, ndev, "%s invalid WEP key length!\n",
  					   __func__);
  				ret = -EINVAL;
-@@ -2033,38 +2047,38 @@ static int sprdwl_cfg80211_set_wiphy_params(struct wiphy *wiphy, u32 changed)
+@@ -2037,38 +2051,38 @@ static int sprdwl_cfg80211_set_wiphy_params(struct wiphy *wiphy, u32 changed)
  }
  
  static int sprdwl_cfg80211_set_pmksa(struct wiphy *wiphy,
@@ -3719,7 +3719,7 @@ index daef880ae3..3d0f12ce37 100755
  }
  
  void sprdwl_report_fake_probe(struct wiphy *wiphy, u8 *ie, size_t ielen)
-@@ -2155,14 +2169,18 @@ void signal_level_enhance(struct sprdwl_vif *vif,
+@@ -2159,14 +2173,18 @@ void signal_level_enhance(struct sprdwl_vif *vif,
  }
  
  void sprdwl_report_scan_result(struct sprdwl_vif *vif, u16 chan, s16 rssi,
@@ -3739,7 +3739,7 @@ index daef880ae3..3d0f12ce37 100755
  	u16 capability, beacon_interval;
  	u32 freq;
  	s32 signal;
-@@ -2200,7 +2218,7 @@ void sprdwl_report_scan_result(struct sprdwl_vif *vif, u16 chan, s16 rssi,
+@@ -2204,7 +2222,7 @@ void sprdwl_report_scan_result(struct sprdwl_vif *vif, u16 chan, s16 rssi,
  
  	if ((rssi * 100) != signal)
  		wl_debug("old signal level:%d,new signal level:%d\n",
@@ -3748,7 +3748,7 @@ index daef880ae3..3d0f12ce37 100755
  
  #ifdef ACS_SUPPORT
  	if (vif->mode == SPRDWL_MODE_AP)
-@@ -2210,13 +2228,18 @@ void sprdwl_report_scan_result(struct sprdwl_vif *vif, u16 chan, s16 rssi,
+@@ -2214,13 +2232,18 @@ void sprdwl_report_scan_result(struct sprdwl_vif *vif, u16 chan, s16 rssi,
  	ie = mgmt->u.probe_resp.variable;
  	ielen = len - offsetof(struct ieee80211_mgmt, u.probe_resp.variable);
  	/* framework use system bootup time */
@@ -3770,7 +3770,7 @@ index daef880ae3..3d0f12ce37 100755
  
  	bss = cfg80211_inform_bss(wiphy, channel,
  #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 18, 0))
-@@ -2226,8 +2249,9 @@ void sprdwl_report_scan_result(struct sprdwl_vif *vif, u16 chan, s16 rssi,
+@@ -2230,8 +2253,9 @@ void sprdwl_report_scan_result(struct sprdwl_vif *vif, u16 chan, s16 rssi,
  				  ie, ielen, signal, GFP_KERNEL);
  
  	if (unlikely(!bss))
@@ -3782,7 +3782,7 @@ index daef880ae3..3d0f12ce37 100755
  	cfg80211_put_bss(wiphy, bss);
  
  	/*check log mac flag and call report fake probe*/
-@@ -2236,14 +2260,14 @@ void sprdwl_report_scan_result(struct sprdwl_vif *vif, u16 chan, s16 rssi,
+@@ -2240,14 +2264,14 @@ void sprdwl_report_scan_result(struct sprdwl_vif *vif, u16 chan, s16 rssi,
  
  	if (vif->beacon_loss) {
  		bss = cfg80211_get_bss(wiphy, NULL, vif->bssid,
@@ -3802,7 +3802,7 @@ index daef880ae3..3d0f12ce37 100755
  			vif->beacon_loss = 0;
  		}
  	}
-@@ -2258,7 +2282,11 @@ void sprdwl_report_connection(struct sprdwl_vif *vif,
+@@ -2262,7 +2286,11 @@ void sprdwl_report_connection(struct sprdwl_vif *vif,
  	struct ieee80211_channel *channel;
  	struct ieee80211_mgmt *mgmt;
  	struct cfg80211_bss *bss = NULL;
@@ -3814,7 +3814,7 @@ index daef880ae3..3d0f12ce37 100755
  #ifdef WMMAC_WFA_CERTIFICATION
  	struct wmm_params_element *wmm_params;
  	int i;
-@@ -2273,19 +2301,19 @@ void sprdwl_report_connection(struct sprdwl_vif *vif,
+@@ -2277,19 +2305,19 @@ void sprdwl_report_connection(struct sprdwl_vif *vif,
  #endif
  
  	if (vif->sm_state != SPRDWL_CONNECTING &&
@@ -3839,7 +3839,7 @@ index daef880ae3..3d0f12ce37 100755
  		goto err;
  #endif /* IBSS_SUPPORT */
  	if (!conn_info->bssid) {
-@@ -2321,20 +2349,25 @@ void sprdwl_report_connection(struct sprdwl_vif *vif,
+@@ -2325,20 +2353,25 @@ void sprdwl_report_connection(struct sprdwl_vif *vif,
  
  		mgmt = (struct ieee80211_mgmt *)conn_info->bea_ie;
  		wl_ndev_log(L_DBG, vif->ndev, "%s update BSS %s\n", __func__,
@@ -3871,7 +3871,7 @@ index daef880ae3..3d0f12ce37 100755
  		beacon_interval = le16_to_cpu(mgmt->u.probe_resp.beacon_int);
  		capability = le16_to_cpu(mgmt->u.probe_resp.capab_info);
  		wl_ndev_log(L_DBG, vif->ndev, "%s, %pM, signal: %d\n",
-@@ -2350,15 +2383,16 @@ void sprdwl_report_connection(struct sprdwl_vif *vif,
+@@ -2354,15 +2387,16 @@ void sprdwl_report_connection(struct sprdwl_vif *vif,
  					  capability, beacon_interval,
  					  ie, ielen, conn_info->signal, GFP_KERNEL);
  		if (unlikely(!bss))
@@ -3892,7 +3892,7 @@ index daef880ae3..3d0f12ce37 100755
  		cfg80211_connect_result(vif->ndev,
  					conn_info->bssid, conn_info->req_ie, conn_info->req_ie_len,
  					conn_info->resp_ie, conn_info->resp_ie_len,
-@@ -2376,7 +2410,7 @@ void sprdwl_report_connection(struct sprdwl_vif *vif,
+@@ -2380,7 +2414,7 @@ void sprdwl_report_connection(struct sprdwl_vif *vif,
  		cfg80211_roamed(vif->ndev, &roam_info, GFP_KERNEL);
  #else
  		cfg80211_roamed_bss(vif->ndev, bss, conn_info->req_ie, conn_info->req_ie_len,
@@ -3901,7 +3901,7 @@ index daef880ae3..3d0f12ce37 100755
  #endif
  	}
  #ifdef IBSS_SUPPORT
-@@ -2433,7 +2467,7 @@ void sprdwl_report_connection(struct sprdwl_vif *vif,
+@@ -2437,7 +2471,7 @@ void sprdwl_report_connection(struct sprdwl_vif *vif,
  	vif->sm_state = SPRDWL_CONNECTED;
  	memcpy(vif->bssid, conn_info->bssid, sizeof(vif->bssid));
  	wl_ndev_log(L_DBG, vif->ndev, "%s %s to %s (%pM)\n", __func__,
@@ -3910,7 +3910,7 @@ index daef880ae3..3d0f12ce37 100755
  			"connect" : "roam", vif->ssid, vif->bssid);
  	return;
  err:
-@@ -2464,11 +2498,11 @@ void sprdwl_report_disconnection(struct sprdwl_vif *vif, u16 reason_code)
+@@ -2468,11 +2502,11 @@ void sprdwl_report_disconnection(struct sprdwl_vif *vif, u16 reason_code)
  #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 83)
  				NULL, 0, false, GFP_KERNEL);
  #else
@@ -3925,7 +3925,7 @@ index daef880ae3..3d0f12ce37 100755
  	} else {
  		wl_ndev_log(L_ERR, vif->ndev, "%s Unexpected event!\n", __func__);
  		return;
-@@ -2500,13 +2534,13 @@ void sprdwl_report_disconnection(struct sprdwl_vif *vif, u16 reason_code)
+@@ -2504,13 +2538,13 @@ void sprdwl_report_disconnection(struct sprdwl_vif *vif, u16 reason_code)
  void sprdwl_report_mic_failure(struct sprdwl_vif *vif, u8 is_mcast, u8 key_id)
  {
  	wl_ndev_log(L_DBG, vif->ndev,
@@ -3944,7 +3944,7 @@ index daef880ae3..3d0f12ce37 100755
  }
  
  static char type_name[16][32] = {
-@@ -2577,10 +2611,10 @@ void sprdwl_cfg80211_dump_frame_prot_info(int send, int freq,
+@@ -2581,10 +2615,10 @@ void sprdwl_cfg80211_dump_frame_prot_info(int send, int freq,
  
  	if (type == IEEE80211_FTYPE_MGMT) {
  		idx += sprintf(p + idx, "%dMHz, %s, ",
@@ -3957,7 +3957,7 @@ index daef880ae3..3d0f12ce37 100755
  	}
  
  	if (subtype == ACTION_TYPE) {
-@@ -2588,10 +2622,10 @@ void sprdwl_cfg80211_dump_frame_prot_info(int send, int freq,
+@@ -2592,10 +2626,10 @@ void sprdwl_cfg80211_dump_frame_prot_info(int send, int freq,
  		action_subtype = *(buf + ACTION_SUBTYPE_OFFSET);
  		if (action == PUB_ACTION)
  			idx += sprintf(p + idx, "PUB:%s ",
@@ -3970,7 +3970,7 @@ index daef880ae3..3d0f12ce37 100755
  		else
  			idx += sprintf(p + idx, "Unknown ACTION(0x%x)", action);
  	}
-@@ -2602,9 +2636,9 @@ void sprdwl_cfg80211_dump_frame_prot_info(int send, int freq,
+@@ -2606,9 +2640,9 @@ void sprdwl_cfg80211_dump_frame_prot_info(int send, int freq,
  
  /* P2P related stuff */
  static int sprdwl_cfg80211_remain_on_channel(struct wiphy *wiphy,
@@ -3983,7 +3983,7 @@ index daef880ae3..3d0f12ce37 100755
  {
  	struct sprdwl_vif *vif = container_of(wdev, struct sprdwl_vif, wdev);
  	enum nl80211_channel_type channel_type = 0;
-@@ -2613,7 +2647,7 @@ static int sprdwl_cfg80211_remain_on_channel(struct wiphy *wiphy,
+@@ -2617,7 +2651,7 @@ static int sprdwl_cfg80211_remain_on_channel(struct wiphy *wiphy,
  
  	*cookie = vif->listen_cookie = ++remain_index;
  	wl_ndev_log(L_DBG, wdev->netdev, "%s %d for %dms, cookie %lld\n",
@@ -3992,7 +3992,7 @@ index daef880ae3..3d0f12ce37 100755
  	memcpy(&vif->listen_channel, chan, sizeof(struct ieee80211_channel));
  
  	ret = sprdwl_remain_chan(vif->priv, vif->ctx_id, chan,
-@@ -2627,8 +2661,8 @@ static int sprdwl_cfg80211_remain_on_channel(struct wiphy *wiphy,
+@@ -2631,8 +2665,8 @@ static int sprdwl_cfg80211_remain_on_channel(struct wiphy *wiphy,
  }
  
  static int sprdwl_cfg80211_cancel_remain_on_channel(struct wiphy *wiphy,
@@ -4003,7 +4003,7 @@ index daef880ae3..3d0f12ce37 100755
  {
  	struct sprdwl_vif *vif = container_of(wdev, struct sprdwl_vif, wdev);
  
-@@ -2668,9 +2702,9 @@ static int sprdwl_cfg80211_mgmt_tx(struct wiphy *wiphy,
+@@ -2672,9 +2706,9 @@ static int sprdwl_cfg80211_mgmt_tx(struct wiphy *wiphy,
  	/* send tx mgmt */
  	if (len > 0) {
  		ret = sprdwl_tx_mgmt(vif->priv, vif->ctx_id,
@@ -4016,7 +4016,7 @@ index daef880ae3..3d0f12ce37 100755
  		if (ret)
  			if (!dont_wait_for_ack)
  				cfg80211_mgmt_tx_status(wdev, *cookie, buf, len,
-@@ -2688,9 +2722,10 @@ static void sprdwl_cfg80211_mgmt_frame_register(struct wiphy *wiphy,
+@@ -2692,9 +2726,10 @@ static void sprdwl_cfg80211_mgmt_frame_register(struct wiphy *wiphy,
  	struct sprdwl_work *misc_work;
  	struct sprdwl_reg_mgmt *reg_mgmt;
  	u16 mgmt_type;
@@ -4029,7 +4029,7 @@ index daef880ae3..3d0f12ce37 100755
  #endif
  
  	if (vif->mode == SPRDWL_MODE_NONE)
-@@ -2698,7 +2733,7 @@ static void sprdwl_cfg80211_mgmt_frame_register(struct wiphy *wiphy,
+@@ -2702,7 +2737,7 @@ static void sprdwl_cfg80211_mgmt_frame_register(struct wiphy *wiphy,
  
  	mgmt_type = (frame_type & IEEE80211_FCTL_STYPE) >> 4;
  	if ((reg && test_and_set_bit(mgmt_type, &vif->mgmt_reg)) ||
@@ -4038,7 +4038,7 @@ index daef880ae3..3d0f12ce37 100755
  		wl_ndev_log(L_DBG, wdev->netdev, "%s  mgmt %d has %sreg\n", __func__,
  			   frame_type, reg ? "" : "un");
  		return;
-@@ -2745,9 +2780,9 @@ void sprdwl_report_rx_mgmt(struct sprdwl_vif *vif, u8 chan, const u8 *buf,
+@@ -2749,9 +2784,9 @@ void sprdwl_report_rx_mgmt(struct sprdwl_vif *vif, u8 chan, const u8 *buf,
  	int freq;
  #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 7, 0)
  	freq = ieee80211_channel_to_frequency(chan,
@@ -4051,7 +4051,7 @@ index daef880ae3..3d0f12ce37 100755
  #else
  	freq = ieee80211_channel_to_frequency(chan,
  						chan <= CH_MAX_2G_CHANNEL ?
-@@ -2767,7 +2802,7 @@ void sprdwl_report_rx_mgmt(struct sprdwl_vif *vif, u8 chan, const u8 *buf,
+@@ -2771,7 +2806,7 @@ void sprdwl_report_rx_mgmt(struct sprdwl_vif *vif, u8 chan, const u8 *buf,
  }
  
  void sprdwl_report_mgmt_deauth(struct sprdwl_vif *vif, const u8 *buf,
@@ -4060,7 +4060,7 @@ index daef880ae3..3d0f12ce37 100755
  {
  	struct sprdwl_work *misc_work;
  
-@@ -2803,7 +2838,7 @@ void sprdwl_report_mgmt_disassoc(struct sprdwl_vif *vif, const u8 *buf,
+@@ -2807,7 +2842,7 @@ void sprdwl_report_mgmt_disassoc(struct sprdwl_vif *vif, const u8 *buf,
  }
  
  static int sprdwl_cfg80211_start_p2p_device(struct wiphy *wiphy,
@@ -4069,7 +4069,7 @@ index daef880ae3..3d0f12ce37 100755
  {
  	struct sprdwl_vif *vif = container_of(wdev, struct sprdwl_vif, wdev);
  
-@@ -2813,7 +2848,7 @@ static int sprdwl_cfg80211_start_p2p_device(struct wiphy *wiphy,
+@@ -2817,7 +2852,7 @@ static int sprdwl_cfg80211_start_p2p_device(struct wiphy *wiphy,
  }
  
  static void sprdwl_cfg80211_stop_p2p_device(struct wiphy *wiphy,
@@ -4078,7 +4078,7 @@ index daef880ae3..3d0f12ce37 100755
  {
  	struct sprdwl_vif *vif = container_of(wdev, struct sprdwl_vif, wdev);
  
-@@ -2826,10 +2861,10 @@ static void sprdwl_cfg80211_stop_p2p_device(struct wiphy *wiphy,
+@@ -2830,10 +2865,10 @@ static void sprdwl_cfg80211_stop_p2p_device(struct wiphy *wiphy,
  }
  
  static int sprdwl_cfg80211_tdls_mgmt(struct wiphy *wiphy,
@@ -4093,7 +4093,7 @@ index daef880ae3..3d0f12ce37 100755
  {
  	struct sprdwl_vif *vif = netdev_priv(ndev);
  	struct sk_buff *tdls_skb;
-@@ -2839,7 +2874,7 @@ static int sprdwl_cfg80211_tdls_mgmt(struct wiphy *wiphy,
+@@ -2843,7 +2878,7 @@ static int sprdwl_cfg80211_tdls_mgmt(struct wiphy *wiphy,
  	int ret = 0;
  
  	wl_ndev_log(L_DBG, ndev, "%s action_code=%d(%pM)\n", __func__,
@@ -4102,7 +4102,7 @@ index daef880ae3..3d0f12ce37 100755
  
  	datalen = sizeof(*p) + len + sizeof(end);
  	ielen = len + sizeof(end);
-@@ -2917,8 +2952,8 @@ static int sprdwl_cfg80211_tdls_mgmt(struct wiphy *wiphy,
+@@ -2921,8 +2956,8 @@ static int sprdwl_cfg80211_tdls_mgmt(struct wiphy *wiphy,
  }
  
  static int sprdwl_cfg80211_tdls_oper(struct wiphy *wiphy,
@@ -4113,7 +4113,7 @@ index daef880ae3..3d0f12ce37 100755
  {
  	struct sprdwl_vif *vif = netdev_priv(ndev);
  	int ret;
-@@ -2943,7 +2978,7 @@ static int sprdwl_cfg80211_tdls_oper(struct wiphy *wiphy,
+@@ -2947,7 +2982,7 @@ static int sprdwl_cfg80211_tdls_oper(struct wiphy *wiphy,
  		for (i = 0; i < MAX_LUT_NUM; i++) {
  			if ((0 == memcmp(intf->peer_entry[i].tx.da,
  					 peer, ETH_ALEN)) &&
@@ -4122,7 +4122,7 @@ index daef880ae3..3d0f12ce37 100755
  				wl_info("%s, %d, lut_index=%d\n",
  					__func__, __LINE__,
  					intf->peer_entry[i].lut_index);
-@@ -2957,9 +2992,9 @@ static int sprdwl_cfg80211_tdls_oper(struct wiphy *wiphy,
+@@ -2961,9 +2996,9 @@ static int sprdwl_cfg80211_tdls_oper(struct wiphy *wiphy,
  
  #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0)
  static int sprdwl_cfg80211_tdls_chan_switch(struct wiphy *wiphy,
@@ -4135,7 +4135,7 @@ index daef880ae3..3d0f12ce37 100755
  {
  	struct sprdwl_vif *vif = netdev_priv(ndev);
  	u8 chan, band;
-@@ -2973,8 +3008,8 @@ static int sprdwl_cfg80211_tdls_chan_switch(struct wiphy *wiphy,
+@@ -2977,8 +3012,8 @@ static int sprdwl_cfg80211_tdls_chan_switch(struct wiphy *wiphy,
  }
  
  static void sprdwl_cfg80211_tdls_cancel_chan_switch(struct wiphy *wiphy,
@@ -4146,7 +4146,7 @@ index daef880ae3..3d0f12ce37 100755
  {
  	struct sprdwl_vif *vif = netdev_priv(ndev);
  
-@@ -3000,7 +3035,7 @@ int sprdwl_cfg80211_set_cqm_rssi_config(struct wiphy *wiphy,
+@@ -3004,7 +3039,7 @@ int sprdwl_cfg80211_set_cqm_rssi_config(struct wiphy *wiphy,
  	struct sprdwl_vif *vif = netdev_priv(ndev);
  
  	wl_ndev_log(L_DBG, ndev, "%s rssi_thold %d rssi_hyst %d",
@@ -4155,7 +4155,7 @@ index daef880ae3..3d0f12ce37 100755
  
  	return sprdwl_set_cqm_rssi(vif->priv, vif->ctx_id,
  				   rssi_thold, rssi_hyst);
-@@ -3024,13 +3059,13 @@ int sprdwl_cfg80211_update_ft_ies(struct wiphy *wiphy, struct net_device *ndev,
+@@ -3028,13 +3063,13 @@ int sprdwl_cfg80211_update_ft_ies(struct wiphy *wiphy, struct net_device *ndev,
  	wl_ndev_log(L_DBG, ndev, "%s\n", __func__);
  
  	return sprdwl_set_roam_offload(vif->priv, vif->ctx_id,
@@ -4173,7 +4173,7 @@ index daef880ae3..3d0f12ce37 100755
  {
  	struct sprdwl_vif *vif = netdev_priv(ndev);
  
-@@ -3041,9 +3076,9 @@ static int sprdwl_cfg80211_set_qos_map(struct wiphy *wiphy,
+@@ -3045,9 +3080,9 @@ static int sprdwl_cfg80211_set_qos_map(struct wiphy *wiphy,
  
  #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 18, 0)
  static int sprdwl_cfg80211_add_tx_ts(struct wiphy *wiphy,
@@ -4186,7 +4186,7 @@ index daef880ae3..3d0f12ce37 100755
  {
  	struct sprdwl_vif *vif = netdev_priv(ndev);
  
-@@ -3054,8 +3089,8 @@ static int sprdwl_cfg80211_add_tx_ts(struct wiphy *wiphy,
+@@ -3058,8 +3093,8 @@ static int sprdwl_cfg80211_add_tx_ts(struct wiphy *wiphy,
  }
  
  static int sprdwl_cfg80211_del_tx_ts(struct wiphy *wiphy,
@@ -4197,7 +4197,7 @@ index daef880ae3..3d0f12ce37 100755
  {
  	struct sprdwl_vif *vif = netdev_priv(ndev);
  
-@@ -3066,8 +3101,8 @@ static int sprdwl_cfg80211_del_tx_ts(struct wiphy *wiphy,
+@@ -3070,8 +3105,8 @@ static int sprdwl_cfg80211_del_tx_ts(struct wiphy *wiphy,
  #endif
  
  static int sprdwl_cfg80211_set_mac_acl(struct wiphy *wiphy,
@@ -4208,7 +4208,7 @@ index daef880ae3..3d0f12ce37 100755
  {
  	struct sprdwl_vif *vif = netdev_priv(ndev);
  	int index, num;
-@@ -3075,7 +3110,7 @@ static int sprdwl_cfg80211_set_mac_acl(struct wiphy *wiphy,
+@@ -3079,7 +3114,7 @@ static int sprdwl_cfg80211_set_mac_acl(struct wiphy *wiphy,
  	unsigned char *mac_addr = NULL;
  
  	if (!acl || !acl->n_acl_entries) {
@@ -4217,7 +4217,7 @@ index daef880ae3..3d0f12ce37 100755
  		return 0;
  	}
  
-@@ -3099,18 +3134,18 @@ static int sprdwl_cfg80211_set_mac_acl(struct wiphy *wiphy,
+@@ -3103,18 +3138,18 @@ static int sprdwl_cfg80211_set_mac_acl(struct wiphy *wiphy,
  
  	for (index = 0; index < num; index++) {
  		wl_ndev_log(L_DBG, ndev, "%s  MAC: %pM\n", __func__,
@@ -4241,7 +4241,7 @@ index daef880ae3..3d0f12ce37 100755
  }
  
  int sprdwl_cfg80211_set_power_mgmt(struct wiphy *wiphy, struct net_device *ndev,
-@@ -3126,7 +3161,7 @@ int sprdwl_cfg80211_set_power_mgmt(struct wiphy *wiphy, struct net_device *ndev,
+@@ -3130,7 +3165,7 @@ int sprdwl_cfg80211_set_power_mgmt(struct wiphy *wiphy, struct net_device *ndev,
  #ifdef ACS_SUPPORT
  static int
  sprdwl_cfg80211_dump_survey(struct wiphy *wiphy, struct net_device *ndev,
@@ -4250,7 +4250,7 @@ index daef880ae3..3d0f12ce37 100755
  {
  	struct sprdwl_vif *vif = netdev_priv(ndev);
  	struct sprdwl_survey_info *info = NULL;
-@@ -3176,7 +3211,7 @@ sprdwl_cfg80211_dump_survey(struct wiphy *wiphy, struct net_device *ndev,
+@@ -3180,7 +3215,7 @@ sprdwl_cfg80211_dump_survey(struct wiphy *wiphy, struct net_device *ndev,
  		/* There are no more survey info in list */
  		err = -ENOENT;
  		wl_ndev_log(L_DBG, vif->ndev, "%s report %d surveys\n",
@@ -4259,7 +4259,7 @@ index daef880ae3..3d0f12ce37 100755
  		survey_count = 0;
  	}
  
-@@ -3247,6 +3282,7 @@ static struct cfg80211_ops sprdwl_cfg80211_ops = {
+@@ -3251,6 +3286,7 @@ static struct cfg80211_ops sprdwl_cfg80211_ops = {
  	.remain_on_channel = sprdwl_cfg80211_remain_on_channel,
  	.cancel_remain_on_channel = sprdwl_cfg80211_cancel_remain_on_channel,
  	.mgmt_tx = sprdwl_cfg80211_mgmt_tx,
@@ -4267,7 +4267,7 @@ index daef880ae3..3d0f12ce37 100755
  	.update_mgmt_frame_registrations = sprdwl_cfg80211_mgmt_frame_register,
  	.set_power_mgmt = sprdwl_cfg80211_set_power_mgmt,
  	.set_cqm_rssi_config = sprdwl_cfg80211_set_cqm_rssi_config,
-@@ -3322,7 +3358,7 @@ void sprdwl_save_ch_info(struct sprdwl_priv *priv, u32 band, u32 flags, int cent
+@@ -3326,7 +3362,7 @@ void sprdwl_save_ch_info(struct sprdwl_priv *priv, u32 band, u32 flags, int cent
  
  #if defined(CONFIG_CFG80211_INTERNAL_REGDB) && !defined(CUSTOM_REGDOMAIN)
  static void sprdwl_reg_notify(struct wiphy *wiphy,
@@ -4276,7 +4276,7 @@ index daef880ae3..3d0f12ce37 100755
  {
  	struct sprdwl_priv *priv = wiphy_priv(wiphy);
  	struct sprdwl_intf *intf = (struct sprdwl_intf *)priv->hw_priv;
-@@ -3359,7 +3395,7 @@ static void sprdwl_reg_notify(struct wiphy *wiphy,
+@@ -3363,7 +3399,7 @@ static void sprdwl_reg_notify(struct wiphy *wiphy,
  			chan = &sband->channels[channel];
  
  			reg_rule =
@@ -4285,7 +4285,7 @@ index daef880ae3..3d0f12ce37 100755
  			if (IS_ERR(reg_rule))
  				continue;
  
-@@ -3375,12 +3411,12 @@ static void sprdwl_reg_notify(struct wiphy *wiphy,
+@@ -3379,12 +3415,12 @@ static void sprdwl_reg_notify(struct wiphy *wiphy,
  	}
  
  	rd_size = sizeof(struct sprdwl_ieee80211_regdomain) +
@@ -4300,7 +4300,7 @@ index daef880ae3..3d0f12ce37 100755
  		return;
  	}
  
-@@ -3408,17 +3444,17 @@ static void sprdwl_reg_notify(struct wiphy *wiphy,
+@@ -3412,17 +3448,17 @@ static void sprdwl_reg_notify(struct wiphy *wiphy,
  				intf->sta_home_channel = 0;
  #endif
  			reg_rule =
@@ -4321,7 +4321,7 @@ index daef880ae3..3d0f12ce37 100755
  				i++;
  
  				wl_info(
-@@ -3432,7 +3468,7 @@ static void sprdwl_reg_notify(struct wiphy *wiphy,
+@@ -3436,7 +3472,7 @@ static void sprdwl_reg_notify(struct wiphy *wiphy,
  	}
  
  	print_hex_dump_debug("regdom:", DUMP_PREFIX_OFFSET, 16, 1,
@@ -4330,7 +4330,7 @@ index daef880ae3..3d0f12ce37 100755
  	if (sprdwl_set_regdom(priv, (u8 *)rd, rd_size))
  		wl_err("%s failed to set regdomain!\n", __func__);
  	if (rd != NULL) {
-@@ -3442,7 +3478,7 @@ static void sprdwl_reg_notify(struct wiphy *wiphy,
+@@ -3446,7 +3482,7 @@ static void sprdwl_reg_notify(struct wiphy *wiphy,
  }
  #else
  void sprdwl_reg_notify(struct wiphy *wiphy,
@@ -4339,7 +4339,7 @@ index daef880ae3..3d0f12ce37 100755
  {
  	struct sprdwl_priv *priv = wiphy_priv(wiphy);
  #ifdef STA_SOFTAP_SCC_MODE
-@@ -3500,7 +3536,7 @@ void sprdwl_reg_notify(struct wiphy *wiphy,
+@@ -3504,7 +3540,7 @@ void sprdwl_reg_notify(struct wiphy *wiphy,
  			chan = &sband->channels[channel];
  
  			reg_rule =
@@ -4348,7 +4348,7 @@ index daef880ae3..3d0f12ce37 100755
  			if (IS_ERR(reg_rule)) {
  				wl_debug("%s, %d, chan=%d\n", __func__, __LINE__, (int)(chan->center_freq));
  				continue;
-@@ -3519,15 +3555,15 @@ void sprdwl_reg_notify(struct wiphy *wiphy,
+@@ -3523,15 +3559,15 @@ void sprdwl_reg_notify(struct wiphy *wiphy,
  
  	rd_size = sizeof(struct sprdwl_ieee80211_regdomain) +
  #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 15, 0))
@@ -4367,7 +4367,7 @@ index daef880ae3..3d0f12ce37 100755
  		return;
  	}
  
-@@ -3556,17 +3592,17 @@ void sprdwl_reg_notify(struct wiphy *wiphy,
+@@ -3560,17 +3596,17 @@ void sprdwl_reg_notify(struct wiphy *wiphy,
  #endif
  
  			reg_rule =
@@ -4388,7 +4388,7 @@ index daef880ae3..3d0f12ce37 100755
  #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 15, 0))
  				rd->reg_rules[i].dfs_cac_ms = 0;
  #endif
-@@ -3583,7 +3619,7 @@ void sprdwl_reg_notify(struct wiphy *wiphy,
+@@ -3587,7 +3623,7 @@ void sprdwl_reg_notify(struct wiphy *wiphy,
  	}
  
  	wl_hex_dump(L_DBG, "regdom:", DUMP_PREFIX_OFFSET, 16, 1,
@@ -4397,7 +4397,7 @@ index daef880ae3..3d0f12ce37 100755
  	if (sprdwl_set_regdom(priv, (u8 *)rd, rd_size))
  		wl_err("%s failed to set regdomain!\n", __func__);
  
-@@ -3638,8 +3674,8 @@ void sprdwl_setup_wiphy(struct wiphy *wiphy, struct sprdwl_priv *priv)
+@@ -3642,8 +3678,8 @@ void sprdwl_setup_wiphy(struct wiphy *wiphy, struct sprdwl_priv *priv)
  
  	wiphy->mgmt_stypes = sprdwl_mgmt_stypes;
  	wiphy->interface_modes =
@@ -4408,7 +4408,7 @@ index daef880ae3..3d0f12ce37 100755
  #ifndef CONFIG_P2P_INTF
  	wiphy->interface_modes |= BIT(NL80211_IFTYPE_P2P_DEVICE);
  #endif
-@@ -3784,9 +3820,9 @@ void sprdwl_setup_wiphy(struct wiphy *wiphy, struct sprdwl_priv *priv)
+@@ -3788,9 +3824,9 @@ void sprdwl_setup_wiphy(struct wiphy *wiphy, struct sprdwl_priv *priv)
  
  #if !defined (CONFIG_CFG80211_INTERNAL_REGDB) || defined(CUSTOM_REGDOMAIN)
  #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0))
@@ -4420,7 +4420,7 @@ index daef880ae3..3d0f12ce37 100755
  #endif
  		alpha2[0] = '0';
  		alpha2[1] = '0';
-@@ -3805,9 +3841,9 @@ void sprdwl_setup_wiphy(struct wiphy *wiphy, struct sprdwl_priv *priv)
+@@ -3809,9 +3845,9 @@ void sprdwl_setup_wiphy(struct wiphy *wiphy, struct sprdwl_priv *priv)
  	} else {
  		wl_info("\tSCC supported\n");
  		wiphy->software_iftypes =
@@ -4433,7 +4433,7 @@ index daef880ae3..3d0f12ce37 100755
  #ifndef CONFIG_P2P_INTF
  		wiphy->software_iftypes |= BIT(NL80211_IFTYPE_P2P_DEVICE);
  #endif
-@@ -3825,7 +3861,7 @@ void sprdwl_setup_wiphy(struct wiphy *wiphy, struct sprdwl_priv *priv)
+@@ -3829,7 +3865,7 @@ void sprdwl_setup_wiphy(struct wiphy *wiphy, struct sprdwl_priv *priv)
  	}
  #if 0
  	if (priv->fw_capa & SPRDWL_CAPA_PMK_OKC_OFFLOAD &&
@@ -4442,7 +4442,7 @@ index daef880ae3..3d0f12ce37 100755
  		wl_info("\tRoaming offload supported\n");
  		wiphy->flags |= WIPHY_FLAG_SUPPORTS_FW_ROAM;
  	}
-@@ -3876,7 +3912,7 @@ static void sprdwl_check_intf_ops(struct sprdwl_if_ops *ops)
+@@ -3880,7 +3916,7 @@ static void sprdwl_check_intf_ops(struct sprdwl_if_ops *ops)
  }
  
  struct sprdwl_priv *sprdwl_core_create(enum sprdwl_hw_type type,
@@ -4451,7 +4451,7 @@ index daef880ae3..3d0f12ce37 100755
  {
  	struct wiphy *wiphy;
  	struct sprdwl_priv *priv;
-@@ -3897,7 +3933,7 @@ struct sprdwl_priv *sprdwl_core_create(enum sprdwl_hw_type type,
+@@ -3901,7 +3937,7 @@ struct sprdwl_priv *sprdwl_core_create(enum sprdwl_hw_type type,
  	wl_info("hw_type:%d\n", priv->hw_type);
  
  	priv->skb_head_len = sizeof(struct sprdwl_data_hdr) + NET_IP_ALIGN +
@@ -4460,7 +4460,7 @@ index daef880ae3..3d0f12ce37 100755
  
  	priv->if_ops = ops;
  
-@@ -3905,7 +3941,7 @@ struct sprdwl_priv *sprdwl_core_create(enum sprdwl_hw_type type,
+@@ -3909,7 +3945,7 @@ struct sprdwl_priv *sprdwl_core_create(enum sprdwl_hw_type type,
  	timer_setup(&priv->scan_timer, sprdwl_scan_timeout, 0);
  #else
  	setup_timer(&priv->scan_timer, sprdwl_scan_timeout,
@@ -4470,7 +4470,7 @@ index daef880ae3..3d0f12ce37 100755
  
  #ifdef WMMAC_WFA_CERTIFICATION
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/cfg80211.h b/drivers/net/wireless/uwe5622/unisocwifi/cfg80211.h
-index d4ffe10244..380e7da5f4 100755
+index d4ffe102447c..380e7da5f442 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/cfg80211.h
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/cfg80211.h
 @@ -21,15 +21,6 @@
@@ -4490,7 +4490,7 @@ index d4ffe10244..380e7da5f4 100755
  #define NL80211_SCAN_FLAG_RANDOM_ADDR          (1<<3)
  
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/cmdevt.c b/drivers/net/wireless/uwe5622/unisocwifi/cmdevt.c
-index e81619b12e..19e59b6f24 100755
+index 8a3081fb819c..55c76b74195a 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/cmdevt.c
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/cmdevt.c
 @@ -257,7 +257,11 @@ int sprdwl_cmd_init(void)
@@ -5570,7 +5570,7 @@ index e81619b12e..19e59b6f24 100755
  		sprdwl_unboost();
  	}
  
-@@ -3382,8 +3512,8 @@ unsigned short sprdwl_rx_event_process(struct sprdwl_priv *priv, u8 *msg)
+@@ -3386,8 +3516,8 @@ unsigned short sprdwl_rx_event_process(struct sprdwl_priv *priv, u8 *msg)
  	plen = SPRDWL_GET_LE16(hdr->plen);
  	if (!priv) {
  		wl_err("%s priv is NULL [%u]ctx_id %d recv[%s]len: %d\n",
@@ -5581,7 +5581,7 @@ index e81619b12e..19e59b6f24 100755
  		return plen;
  	}
  
-@@ -3392,7 +3522,7 @@ unsigned short sprdwl_rx_event_process(struct sprdwl_priv *priv, u8 *msg)
+@@ -3396,7 +3526,7 @@ unsigned short sprdwl_rx_event_process(struct sprdwl_priv *priv, u8 *msg)
  		evt2str(hdr->cmd_id), plen);
  
  	wl_hex_dump(L_DBG, "EVENT: ", DUMP_PREFIX_OFFSET, 16, 1,
@@ -5590,7 +5590,7 @@ index e81619b12e..19e59b6f24 100755
  
  	len = plen - sizeof(*hdr);
  	vif = ctx_id_to_vif(priv, ctx_id);
-@@ -3466,9 +3596,11 @@ unsigned short sprdwl_rx_event_process(struct sprdwl_priv *priv, u8 *msg)
+@@ -3470,9 +3600,11 @@ unsigned short sprdwl_rx_event_process(struct sprdwl_priv *priv, u8 *msg)
  		sprdwl_event_nan(vif, data, len);
  		break;
  #endif /* NAN_SUPPORT */
@@ -5602,7 +5602,7 @@ index e81619b12e..19e59b6f24 100755
  	case WIFI_EVENT_BA:
  		sprdwl_event_ba_mgmt(vif, data, len);
  		break;
-@@ -3588,8 +3720,8 @@ int sprdwl_sync_disconnect_event(struct sprdwl_vif *vif, unsigned int timeout)
+@@ -3592,8 +3724,8 @@ int sprdwl_sync_disconnect_event(struct sprdwl_vif *vif, unsigned int timeout)
  #endif
  
  int sprdwl_set_packet_offload(struct sprdwl_priv *priv, u8 vif_ctx_id,
@@ -5614,7 +5614,7 @@ index e81619b12e..19e59b6f24 100755
  	struct sprdwl_msg_buf *msg;
  	struct sprdwl_cmd_packet_offload *p;
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/cmdevt.h b/drivers/net/wireless/uwe5622/unisocwifi/cmdevt.h
-index 8dd59bc2c8..ce8c774e89 100755
+index 8dd59bc2c841..ce8c774e8968 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/cmdevt.h
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/cmdevt.h
 @@ -907,6 +907,7 @@ struct sprdwl_tlv_data {
@@ -5626,7 +5626,7 @@ index 8dd59bc2c8..ce8c774e89 100755
  struct ap_version_tlv_elmt {
  #define NOTIFY_AP_VERSION_USER 0
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/dbg_ini_util.c b/drivers/net/wireless/uwe5622/unisocwifi/dbg_ini_util.c
-index 70415e79b3..264e9f7559 100755
+index 70415e79b311..264e9f7559ab 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/dbg_ini_util.c
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/dbg_ini_util.c
 @@ -264,9 +264,9 @@ int sprdwl_dbg_new_beacon_tail(const u8 *beacon_tail, int tail_len, u8 *new_tail
@@ -5643,7 +5643,7 @@ index 70415e79b3..264e9f7559 100755
  
  	while (tail_len > 2) {
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/debug.c b/drivers/net/wireless/uwe5622/unisocwifi/debug.c
-index 5f25f078ff..84fe30f7e7 100755
+index 5f25f078ff5c..84fe30f7e70e 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/debug.c
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/debug.c
 @@ -175,12 +175,12 @@ void adjust_ts_cnt_debug(char *buf, unsigned char offset)
@@ -5663,7 +5663,7 @@ index 5f25f078ff..84fe30f7e7 100755
  		spin_unlock_bh(&debug_ctrl.debug_ctrl_lock);
  	}
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/defrag.c b/drivers/net/wireless/uwe5622/unisocwifi/defrag.c
-index 0b3cfb7676..816940b47d 100755
+index 0b3cfb767681..816940b47dca 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/defrag.c
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/defrag.c
 @@ -26,11 +26,11 @@ static struct rx_defrag_node
@@ -5756,7 +5756,7 @@ index 0b3cfb7676..816940b47d 100755
  	struct rx_msdu_desc *msdu_desc = (struct rx_msdu_desc *)pskb->data;
  	struct sk_buff *skb = NULL;
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/edma_test.c b/drivers/net/wireless/uwe5622/unisocwifi/edma_test.c
-index 5a320b6b55..f45bc8043f 100755
+index 5a320b6b55e1..f45bc8043f9c 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/edma_test.c
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/edma_test.c
 @@ -23,7 +23,7 @@
@@ -5825,7 +5825,7 @@ index 5a320b6b55..f45bc8043f 100755
  	}
  
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/ibss.c b/drivers/net/wireless/uwe5622/unisocwifi/ibss.c
-index d335635bc2..822a17c6bb 100755
+index d335635bc262..822a17c6bb47 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/ibss.c
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/ibss.c
 @@ -28,8 +28,8 @@
@@ -5879,7 +5879,7 @@ index d335635bc2..822a17c6bb 100755
  	struct sprdwl_vif *vif = netdev_priv(ndev);
  	enum sm_state old_state = vif->sm_state;
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/intf.h b/drivers/net/wireless/uwe5622/unisocwifi/intf.h
-index 41b9bd5a3f..c17356251e 100755
+index 41b9bd5a3fe9..c17356251e02 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/intf.h
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/intf.h
 @@ -24,17 +24,35 @@ struct sprdwl_priv;
@@ -5920,7 +5920,7 @@ index 41b9bd5a3f..c17356251e 100755
  };
  
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/intf_ops.h b/drivers/net/wireless/uwe5622/unisocwifi/intf_ops.h
-index c580b30402..3844b0b067 100755
+index c580b3040260..3844b0b06767 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/intf_ops.h
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/intf_ops.h
 @@ -28,7 +28,11 @@ inline struct sprdwl_msg_buf *sprdwl_intf_get_msg_buf(struct sprdwl_priv *priv,
@@ -5983,7 +5983,7 @@ index c580b30402..3844b0b067 100755
  
  static inline int sprdwl_get_ini_status(struct sprdwl_priv *priv)
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/main.c b/drivers/net/wireless/uwe5622/unisocwifi/main.c
-index 21efdf4e08..46b9039519 100755
+index 21efdf4e0855..46b9039519cd 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/main.c
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/main.c
 @@ -24,10 +24,13 @@
@@ -6403,7 +6403,7 @@ index 21efdf4e08..46b9039519 100755
  	sprdwl_vendor_deinit(priv->wiphy);
  	wiphy_unregister(priv->wiphy);
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/mm.c b/drivers/net/wireless/uwe5622/unisocwifi/mm.c
-index eaf6554f23..f33d87185d 100755
+index eaf6554f2310..f33d87185de3 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/mm.c
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/mm.c
 @@ -30,7 +30,7 @@
@@ -6636,7 +6636,7 @@ index eaf6554f23..f33d87185d 100755
  		kfree(mm_entry->hdr);
  		mm_entry->hdr = NULL;
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/msg.c b/drivers/net/wireless/uwe5622/unisocwifi/msg.c
-index 511baf91f5..f71a687961 100755
+index 511baf91f5de..f71a6879615d 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/msg.c
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/msg.c
 @@ -17,7 +17,7 @@
@@ -6672,7 +6672,7 @@ index 511baf91f5..f71a687961 100755
 +#endif
  
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/msg.h b/drivers/net/wireless/uwe5622/unisocwifi/msg.h
-index dd57521ae7..67a4b474e7 100755
+index dd57521ae708..67a4b474e74e 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/msg.h
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/msg.h
 @@ -215,5 +215,7 @@ void sprdwl_dequeue_msg_buf(struct sprdwl_msg_buf *msg_buf,
@@ -6684,7 +6684,7 @@ index dd57521ae7..67a4b474e7 100755
  #endif
 +#endif
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/nan.c b/drivers/net/wireless/uwe5622/unisocwifi/nan.c
-index a08a3c0769..740ea0ad38 100755
+index a08a3c076964..740ea0ad38a2 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/nan.c
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/nan.c
 @@ -43,7 +43,7 @@ int sprdwl_vendor_nan_cmds(struct wiphy *wiphy,
@@ -6697,18 +6697,9 @@ index a08a3c0769..740ea0ad38 100755
  	if (!ret && rsp_len)
  		sprdwl_event_nan(vif, rsp, rsp_len);
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/npi.c b/drivers/net/wireless/uwe5622/unisocwifi/npi.c
-index ca599c8945..90b333b701 100755
+index 00908c1a862f..42fe960c8289 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/npi.c
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/npi.c
-@@ -105,7 +105,7 @@ static int sprdwl_cmd_set_psm_cap(struct sprdwl_vif *vif)
- }
- 
- static int sprdwl_npi_pre_doit(const struct genl_ops *ops,
--			       struct sk_buff *skb, struct genl_info *info)
-+				   struct sk_buff *skb, struct genl_info *info)
- {
- 	struct net_device *ndev;
- 	struct sprdwl_vif *vif;
 @@ -148,7 +148,7 @@ static bool sprdwl_npi_cmd_is_start(void *buf)
  
  	msg = (struct sprdwl_npi_cmd_hdr *)buf;
@@ -6778,7 +6769,7 @@ index ca599c8945..90b333b701 100755
  #endif
  		.doit = sprdwl_nl_get_info_handler,
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/qos.c b/drivers/net/wireless/uwe5622/unisocwifi/qos.c
-index c01d88fba3..d0e42a882c 100755
+index c01d88fba346..d0e42a882cb4 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/qos.c
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/qos.c
 @@ -192,7 +192,7 @@ void qos_set_dscp2up_table(unsigned char *dscp2up_table,
@@ -6917,7 +6908,7 @@ index c01d88fba3..d0e42a882c 100755
  unsigned int change_priority_if(struct sprdwl_priv *priv, unsigned char *tid, unsigned char *tos, u16 len)
  {
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/qos.h b/drivers/net/wireless/uwe5622/unisocwifi/qos.h
-index 2a99178bce..3d69d1c573 100755
+index 2a99178bcea4..3d69d1c5730a 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/qos.h
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/qos.h
 @@ -79,6 +79,7 @@ struct qos_map_set {
@@ -6944,7 +6935,7 @@ index 2a99178bce..3d69d1c573 100755
  const u8 *get_wmm_ie(u8 *res, u16 ie_len, u8 ie, uint oui, uint oui_type);
  #endif
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/reg_domain.c b/drivers/net/wireless/uwe5622/unisocwifi/reg_domain.c
-index 5a9857757f..fb15045e17 100755
+index 5a9857757f53..fb15045e1764 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/reg_domain.c
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/reg_domain.c
 @@ -253,7 +253,7 @@ void ShowChannel(struct wiphy *pWiphy)
@@ -6984,7 +6975,7 @@ index 5a9857757f..fb15045e17 100755
  
  	return false;
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/reorder.c b/drivers/net/wireless/uwe5622/unisocwifi/reorder.c
-index 1cb3f9178e..c6c77648dd 100755
+index 1cb3f9178eeb..c6c77648ddde 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/reorder.c
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/reorder.c
 @@ -49,7 +49,7 @@ set_ba_node_desc(struct rx_ba_node_desc *ba_node_desc,
@@ -7350,7 +7341,7 @@ index 1cb3f9178e..c6c77648dd 100755
  
  	spin_lock_bh(&ba_node->ba_node_lock);
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/rf_marlin3.c b/drivers/net/wireless/uwe5622/unisocwifi/rf_marlin3.c
-index a2f6cc394c..ca307f12ac 100755
+index a2f6cc394ce1..ca307f12ac99 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/rf_marlin3.c
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/rf_marlin3.c
 @@ -181,9 +181,9 @@ static struct nvm_name_table g_config_table[] = {
@@ -7366,7 +7357,7 @@ index a2f6cc394c..ca307f12ac 100755
  	CF_TAB("Chain1_161", tx_scale.chain1[37][0], 1),
  	CF_TAB("Chain0_165", tx_scale.chain0[38][0], 1),
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/rtt.c b/drivers/net/wireless/uwe5622/unisocwifi/rtt.c
-index 69d6965638..9f0e9f2d3d 100755
+index 69d6965638fb..9f0e9f2d3dd0 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/rtt.c
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/rtt.c
 @@ -203,8 +203,8 @@ static u8 sprdwl_ftm_get_channel(struct wiphy *wiphy,
@@ -7700,7 +7691,7 @@ index 69d6965638..9f0e9f2d3d 100755
  	struct sprdwl_msg_buf *msg;
  	struct sprdwl_cmd_rtt *cmd;
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/rx_msg.c b/drivers/net/wireless/uwe5622/unisocwifi/rx_msg.c
-index b6604ee547..b51207d19c 100755
+index b6604ee547ce..b51207d19c89 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/rx_msg.c
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/rx_msg.c
 @@ -31,8 +31,8 @@
@@ -7859,7 +7850,7 @@ index b6604ee547..b51207d19c 100755
  	}
  #endif
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/softap_hook.c b/drivers/net/wireless/uwe5622/unisocwifi/softap_hook.c
-index 5cdc8eff9d..4a859e724e 100755
+index 5cdc8eff9df5..4a859e724ed8 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/softap_hook.c
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/softap_hook.c
 @@ -76,7 +76,7 @@ static int sprdwl_get_softap_chan(u8 *path)
@@ -7903,7 +7894,7 @@ index 5cdc8eff9d..4a859e724e 100755
  	*ds_param_ch = oper->primary_chan = channel;
  }
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/sprdwl.h b/drivers/net/wireless/uwe5622/unisocwifi/sprdwl.h
-index e430bfbace..a1b2f8544e 100755
+index e430bfbace8f..a1b2f8544ec4 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/sprdwl.h
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/sprdwl.h
 @@ -35,6 +35,7 @@
@@ -7924,7 +7915,7 @@ index e430bfbace..a1b2f8544e 100755
  #endif
  
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/tcp_ack.c b/drivers/net/wireless/uwe5622/unisocwifi/tcp_ack.c
-index d360f9f579..4db766fbac 100755
+index d360f9f57990..4db766fbac3b 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/tcp_ack.c
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/tcp_ack.c
 @@ -26,7 +26,7 @@ static void sprdwl_tcp_ack_timeout(unsigned long data)
@@ -8057,7 +8048,7 @@ index d360f9f579..4db766fbac 100755
  	struct sprdwl_tcp_ack_info *ack_info;
  	struct sprdwl_tcp_ack_manage *ack_m = &priv->ack_m;
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/tx_msg.c b/drivers/net/wireless/uwe5622/unisocwifi/tx_msg.c
-index 7be652187b..40d51a7130 100755
+index 7be652187be2..40d51a7130d9 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/tx_msg.c
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/tx_msg.c
 @@ -109,7 +109,7 @@ struct sprdwl_msg_buf *sprdwl_get_msg_buf(void *pdev,
@@ -8334,7 +8325,7 @@ index 7be652187b..40d51a7130 100755
  			(*b_cmd_path) = true;
  		}
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/txrx.c b/drivers/net/wireless/uwe5622/unisocwifi/txrx.c
-index b0a24a3615..227339ada7 100755
+index b0a24a3615ba..227339ada73f 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/txrx.c
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/txrx.c
 @@ -23,7 +23,9 @@
@@ -8452,7 +8443,7 @@ index b0a24a3615..227339ada7 100755
  	return 0;
  }
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/vendor.c b/drivers/net/wireless/uwe5622/unisocwifi/vendor.c
-index 733591184c..6fba95b60d 100755
+index 733591184c17..6fba95b60d62 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/vendor.c
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/vendor.c
 @@ -17,7 +17,6 @@
@@ -9514,7 +9505,7 @@ index 733591184c..6fba95b60d 100755
  	u8 control;
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/wcn_wrapper.h b/drivers/net/wireless/uwe5622/unisocwifi/wcn_wrapper.h
 new file mode 100755
-index 0000000000..31042f86d6
+index 000000000000..31042f86d6b1
 --- /dev/null
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/wcn_wrapper.h
 @@ -0,0 +1,20 @@
@@ -9539,7 +9530,7 @@ index 0000000000..31042f86d6
 +#endif
 +#endif//__WCN_WRAPPER_H__
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/wl_core.c b/drivers/net/wireless/uwe5622/unisocwifi/wl_core.c
-index a4ef854b62..042a4df016 100755
+index a4ef854b62e6..042a4df0161e 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/wl_core.c
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/wl_core.c
 @@ -18,7 +18,6 @@
@@ -9863,7 +9854,7 @@ index a4ef854b62..042a4df016 100755
  
  module_init(unisoc_wlan_init);
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/wl_core.h b/drivers/net/wireless/uwe5622/unisocwifi/wl_core.h
-index 8bad5a5fd5..0d039c18e2 100755
+index 8bad5a5fd538..0d039c18e226 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/wl_core.h
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/wl_core.h
 @@ -17,7 +17,7 @@
@@ -9876,7 +9867,7 @@ index 8bad5a5fd5..0d039c18e2 100755
  #include <linux/wait.h>
  #include <linux/spinlock.h>
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/wl_intf.c b/drivers/net/wireless/uwe5622/unisocwifi/wl_intf.c
-index b05a576782..a6def0e068 100755
+index b05a57678264..a6def0e0682d 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/wl_intf.c
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/wl_intf.c
 @@ -24,9 +24,6 @@
@@ -10486,7 +10477,7 @@ index b05a576782..a6def0e068 100755
  	}
  	wl_debug("disconnect, flush qoslist, %s, %d\n", __func__, __LINE__);
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/wl_intf.h b/drivers/net/wireless/uwe5622/unisocwifi/wl_intf.h
-index e55a35a66b..b159c685a5 100755
+index e55a35a66b63..b159c685a5e0 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/wl_intf.h
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/wl_intf.h
 @@ -299,4 +299,5 @@ void sprdwl_boost(void);
@@ -10496,7 +10487,7 @@ index e55a35a66b..b159c685a5 100755
 +void sprdwl_bus_deinit(void);
  #endif /* __SPRDWL_INTF_SDIO_SC2355_H__ */
 diff --git a/drivers/net/wireless/uwe5622/unisocwifi/work.c b/drivers/net/wireless/uwe5622/unisocwifi/work.c
-index b7c0c8bbbf..4d7e016ea6 100755
+index b7c0c8bbbf99..4d7e016ea686 100644
 --- a/drivers/net/wireless/uwe5622/unisocwifi/work.c
 +++ b/drivers/net/wireless/uwe5622/unisocwifi/work.c
 @@ -44,7 +44,7 @@ static struct sprdwl_work *sprdwl_get_work(struct sprdwl_priv *priv)
@@ -10571,3 +10562,6 @@ index b7c0c8bbbf..4d7e016ea6 100755
  {
  	spin_lock_bh(&priv->work_lock);
  	list_add_tail(&sprdwl_work->list, &priv->work_list);
+-- 
+2.34.1
+


### PR DESCRIPTION
#### `rockchip64`/`edge`/`6.3`: rebase/rewrite patches against `v6.3.1`; do archeology for mbox-less patches; materialize overwrites

> After the work done by @amazingfate on #5140 it is now viable to rebase all rockchip64 edge patches.
> This "admits" all the overwrites (full replacement) as actual patches -- it does not change the contents. 
> Wifi patches need more work...

- materialized overwrites:
  - `add-board-helios64.patch`
  - `add-board-orangepi-r1-plus.patch`
  - `add-driver-for-Motorcomm-YT85xx+PHYs.patch`
  - `add-board-rk3328-roc-pc.patch`
- not touched: wifi patches, those still require work before rebase is consistent.
  - `wifi-4003-uwe5622-adjust-for-rockchip.patch`
    - this patch is done on top of the wifi drivers patches exclusively, and fails to apply out of tree.
    - we should probably consider moving this into the wifi drivers patch harness, not in the rockchip tree.

tl;dr: this changes this:
- https://rpardini.github.io/linux/armbian-next-rockchip64-6.3-20230505.html
- `kernel patching: 119 total patches; 119 applied; 95 with problems; 4 overwrites; 54 not_mbox; 73 needs_rebase `

into this:
- https://rpardini.github.io/linux/armbian-next-rockchip64-6.3-20230506a.html
- `kernel patching: 119 total patches; 119 applied; 2 with problems; 2 needs_rebase`
