### PR TITLE
include (clean/real) apt lists and xapian cache in built images (*not* in rootfs cache)

### DIFF
--- a/lib/functions/main/rootfs-image.sh
+++ b/lib/functions/main/rootfs-image.sh
@@ -42,6 +42,16 @@ function build_rootfs_and_image() {
 	# remove packages that are no longer needed. rootfs cache + uninstall might have leftovers.
 	LOG_SECTION="apt_purge_unneeded_packages_and_clean_apt_caches" do_with_logging apt_purge_unneeded_packages_and_clean_apt_caches
 
+	# for IMAGES (not the rootfs cache!), we wanna ship a valid /var/lib/apt/lists.
+	# copy it over from the host-side cache into the image, and run a final apt-get update+clean, to clean off what is not needed for this specific image.
+	LOG_SECTION="apt_lists_copy_from_host_to_image_and_update" do_with_logging apt_lists_copy_from_host_to_image_and_update
+
+	# creating xapian index that synaptic runs faster
+	if [[ "${BUILD_DESKTOP}" == yes ]]; then
+		display_alert "Recreating Synaptic search index" "Please wait - updating Xapian index for image" "info"
+		chroot_sdcard "[[ -f /usr/sbin/update-apt-xapian-index ]] && /usr/sbin/update-apt-xapian-index -u"
+	fi
+
 	# for reference, debugging / sanity checking
 	LOG_SECTION="list_installed_packages" do_with_logging list_installed_packages
 

--- a/lib/functions/rootfs/rootfs-create.sh
+++ b/lib/functions/rootfs/rootfs-create.sh
@@ -112,7 +112,7 @@ function create_new_rootfs_cache_via_debootstrap() {
 
 	# Done with debootstrap. Clean-up it's litterbox.
 	display_alert "Cleaning up after debootstrap" "debootstrap cleanup" "info"
-	run_host_command_logged rm -rf "${SDCARD}/var/cache/apt"
+	run_host_command_logged rm -rf "${SDCARD}/var/cache/apt" "${SDCARD}/var/lib/apt/lists"
 
 	local_apt_deb_cache_prepare "after debootstrap second stage" # just for size reference in logs
 
@@ -226,12 +226,6 @@ function create_new_rootfs_cache_via_debootstrap() {
 	local free_space
 	free_space=$(LC_ALL=C df -h)
 	display_alert "Free disk space on rootfs" "SDCARD: $(echo -e "${free_space}" | awk -v mp="${SDCARD}" '$6==mp {print $5}')" "info"
-
-	# creating xapian index that synaptic runs faster # @TODO: yes, but better done board-side on first run
-	if [[ $BUILD_DESKTOP == yes ]]; then
-		display_alert "Recreating Synaptic search index" "Please wait" "info"
-		chroot_sdcard "[[ -f /usr/sbin/update-apt-xapian-index ]] && /usr/sbin/update-apt-xapian-index -u || true"
-	fi
 
 	# this is needed for the build process later since resolvconf generated file in /run is not saved
 	run_host_command_logged rm -v "${SDCARD}"/etc/resolv.conf


### PR DESCRIPTION
#### include (clean/real) apt lists and xapian cache in built images (*not* in rootfs cache)

> include (clean/real) apt lists in built images; update xapian index during image build, not rootfs; don't leave junk in the rootfs cache

- revert #5139 Revert "Apt lists is needed for synpatic index generation"
  - This reverts commit 63e9bd3baad4f6faa8e6e6f6c82e46716b89acf7
  - this actually only left junk in rootfs cache for the future to find

Now when building images, at the end:

![image](https://user-images.githubusercontent.com/639959/236624342-b26501a8-7c98-4ed0-90ad-cf6c66393dd3.png)

Notice how "53" lists where copied (from host-side cache) into the image, and then updated & cleaned, resulting in "32" lists at the end. This is a clean, junk-free, and updated apt lists. On top of this clean apt lists, `xapian` index is updated, thus resulting in a clean/good index.

Note: this has the added benefit of including whatever was (possibly/optionally) done in the "customize" phase into both the lists and the xapian cache.

This _does not change_ the fact that users most probably will need to `apt update` anyway if images are booted, say, a few months after they were built.