### PR TITLE
Try to be more helpful when `BRANCH=` is unset or wrong

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -14,7 +14,7 @@ BOOTENV_FILE='rockchip64.txt'
 UBOOT_TARGET_MAP=";;idbloader.bin uboot.img trust.bin"
 BOOTDELAY=0
 OVERLAY_PREFIX='rockchip'
-SERIALCON=${SERIALCON:=$([ $BRANCH == "legacy" ] && echo "ttyFIQ0:1500000" || echo "ttyS2:1500000")}
+SERIALCON=${SERIALCON:=$([ "${BRANCH}" == "legacy" ] && echo "ttyFIQ0:1500000" || echo "ttyS2:1500000")}
 GOVERNOR="ondemand"
 ATFPATCHDIR='atf-rockchip64'
 BOOTPATCHDIR="${BOOTPATCHDIR:-"u-boot-rockchip64"}"

--- a/lib/functions/main/config-prepare.sh
+++ b/lib/functions/main/config-prepare.sh
@@ -214,7 +214,17 @@ function config_post_main() {
 	if [[ "${skip_kernel:-"no"}" != "yes" ]]; then
 		if [[ -n "${KERNELSOURCE}" ]]; then
 			if [[ "x${KERNEL_MAJOR_MINOR}x" == "xx" ]]; then
-				exit_with_error "BAD config, missing" "KERNEL_MAJOR_MINOR" "err"
+				display_alert "Problem: after configuration, there's not enough kernel info" "Might happen if you used the wrong BRANCH. Make sure 'BRANCH=${BRANCH}' is valid." "err"
+				# if we have KERNEL_TARGET set.
+				if [[ -n "${KERNEL_TARGET}" ]]; then
+					# Split KERNEL_TARGET by commas, and display each one.
+					declare -a KERNEL_TARGET_ARRAY=()
+					IFS=',' read -ra KERNEL_TARGET_ARRAY <<< "${KERNEL_TARGET}"
+					for i in "${KERNEL_TARGET_ARRAY[@]}"; do
+						display_alert "Valid branches for current board" "BOARD=${BOARD} BRANCH=${i}" "info"
+					done
+				fi
+				exit_with_error "BAD config, missing" "KERNEL_MAJOR_MINOR; check BOARD and BRANCH combination" "err"
 			fi
 			# assume the worst, and all surprises will be happy ones
 			declare -g KERNEL_HAS_WORKING_HEADERS="no"


### PR DESCRIPTION
#### Try to be more helpful when `BRANCH=` is unset or wrong in early configuration

- `rockchip64_common.inc`: fix escaping for test in subshell
  - this emits errors (but exits with 0 in subshell) early if BRANCH is not
- `config-prepare`: `config_pre_main()`: try to be more helpful when BRANCH is unset or wrong instead of just "bad KERNEL_MAJOR_MINOR" 
