### PR TITLE
rk322x: add emmc and sdmmc pwrseq

### DIFF
--- a/patch/kernel/archive/rk322x-6.3/general-add-overlays.patch
+++ b/patch/kernel/archive/rk322x-6.3/general-add-overlays.patch
@@ -1,7 +1,7 @@
-From 330824ee7a46474f18d44d247633469e63675afa Mon Sep 17 00:00:00 2001
+From ab5e5edb1ec91e4154e416c7189e385005b73cd4 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
-Date: Tue, 4 Oct 2022 15:15:19 +0000
-Subject: [PATCH] rk322x device tree overlays
+Date: Sun, 7 May 2023 17:50:51 +0200
+Subject: [PATCH] add rk322x overlays
 
 ---
  arch/arm/boot/dts/overlay/Makefile            |  39 +++++++
@@ -17,7 +17,7 @@ Subject: [PATCH] rk322x device tree overlays
  .../dts/overlay/rk322x-emmc-ddr-ph180.dts     |  14 +++
  .../boot/dts/overlay/rk322x-emmc-ddr-ph45.dts |  14 +++
  .../boot/dts/overlay/rk322x-emmc-hs200.dts    |  13 +++
- .../arm/boot/dts/overlay/rk322x-emmc-pins.dts |  22 ++++
+ .../arm/boot/dts/overlay/rk322x-emmc-pins.dts |  34 ++++++
  arch/arm/boot/dts/overlay/rk322x-emmc.dts     |  20 ++++
  .../arm/boot/dts/overlay/rk322x-fixup.scr-cmd |   4 +
  .../dts/overlay/rk322x-led-conf-default.dts   |  22 ++++
@@ -31,7 +31,7 @@ Subject: [PATCH] rk322x device tree overlays
  arch/arm/boot/dts/overlay/rk322x-nand.dts     |  22 ++++
  .../dts/overlay/rk322x-usb-otg-peripheral.dts |  11 ++
  .../dts/overlay/rk322x-wlan-alt-wiring.dts    |  67 +++++++++++
- 27 files changed, 1204 insertions(+)
+ 27 files changed, 1216 insertions(+)
  create mode 100755 arch/arm/boot/dts/overlay/Makefile
  create mode 100755 arch/arm/boot/dts/overlay/README.rk322x-overlays
  create mode 100644 arch/arm/boot/dts/overlay/rk322x-bt-8723cs.dts
@@ -589,31 +589,43 @@ index 000000000000..6ea81f5e74b0
 +};
 diff --git a/arch/arm/boot/dts/overlay/rk322x-emmc-pins.dts b/arch/arm/boot/dts/overlay/rk322x-emmc-pins.dts
 new file mode 100644
-index 000000000000..0074d029ac84
+index 000000000000..62097a8f3e85
 --- /dev/null
 +++ b/arch/arm/boot/dts/overlay/rk322x-emmc-pins.dts
-@@ -0,0 +1,22 @@
+@@ -0,0 +1,34 @@
 +/dts-v1/;
 +/plugin/;
 +
-+/ {
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/pinctrl/rockchip.h>
 +
-+	fragment@0 {
-+		target = <&emmc>;
-+		__overlay__ {
-+			status = "okay";
-+			pinctrl-names = "default";
-+			pinctrl-0 = <&emmc_clk &emmc_cmd &emmc_bus8 &emmc_pwr &emmc_rst>;
-+		};
++&{/} {
++
++	emmc_pwrseq: emmc-pwrseq {
++		compatible = "mmc-pwrseq-emmc";
++		reset-gpios = <&gpio2 RK_PA5 GPIO_ACTIVE_LOW>;
 +	};
 +
-+	fragment@1 {
-+		target = <&nfc>;
-+		__overlay__ {
-+			status = "disabled";
-+		};
++	sdmmc_pwrseq: sdmmc-pwrseq {
++		compatible = "mmc-pwrseq-emmc";
++		reset-gpios = <&gpio1 RK_PB6 GPIO_ACTIVE_LOW>;
 +	};
 +
++};
++
++&emmc {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&emmc_clk &emmc_cmd &emmc_bus8 &emmc_pwr &emmc_rst>;
++	mmc-pwrseq = <&emmc_pwrseq>;
++};
++
++&sdmmc {
++	mmc-pwrseq = <&sdmmc_pwrseq>;
++};
++
++&nfc {
++	status = "disabled";
 +};
 diff --git a/arch/arm/boot/dts/overlay/rk322x-emmc.dts b/arch/arm/boot/dts/overlay/rk322x-emmc.dts
 new file mode 100755


### PR DESCRIPTION
# Description

Minor change to emmc-pins overlay: add power sequence for both emmc and sdcard. May provide some better  compatibility.

# How Has This Been Tested?

- [x] Tested on several tvbox boards, none of them regressed

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
