### PR TITLE
by popular demand: bring back `KERNEL_CONFIGURE=yes` *during image build*

### DIFF
--- a/lib/functions/artifacts/artifacts-obtain.sh
+++ b/lib/functions/artifacts/artifacts-obtain.sh
@@ -280,7 +280,13 @@ function build_artifact_for_image() {
 	# Make sure ORAS tooling is installed before starting.
 	run_tool_oras
 
-	obtain_complete_artifact
+	# Detour: if building kernel, and KERNEL_CONFIGURE=yes, ignore artifact cache.
+	if [[ "${WHAT}" == "kernel" && "${KERNEL_CONFIGURE}" == "yes" ]]; then
+		display_alert "Ignoring artifact cache for kernel" "KERNEL_CONFIGURE=yes" "info"
+		ARTIFACT_IGNORE_CACHE="yes" obtain_complete_artifact
+	else
+		obtain_complete_artifact
+	fi
 
 	return 0
 }

--- a/lib/functions/cli/cli-patch.sh
+++ b/lib/functions/cli/cli-patch.sh
@@ -32,6 +32,7 @@ function cli_patch_kernel_run() {
 	declare -g GIT_ARCHEOLOGY=yes  # do archeology
 	declare -g FAST_ARCHEOLOGY=yes # do archeology, but only for the exact path we need.
 	#declare -g REWRITE_PATCHES=yes # rewrite the patches after git commiting. Very cheap compared to the rest.
+	declare -g KERNEL_CONFIGURE=no # no menuconfig
 	declare -g RELEASE=jammy       # or whatever, not relevant, just fool the configuration
 	declare -g SHOW_LOG=yes        # show the log
 	prep_conf_main_build_single

--- a/lib/functions/compilation/kernel.sh
+++ b/lib/functions/compilation/kernel.sh
@@ -75,8 +75,9 @@ function compile_kernel() {
 
 	kernel_config # has it's own logging sections inside
 
-	# Stop after configuring kernel.
-	if [[ "${KERNEL_CONFIGURE}" == yes ]]; then
+	# Stop after configuring kernel, but only if using a specific CLI command ("kernel-config").
+	# Normal "KERNEL_CONFIGURE=yes" (during image build) is still allowed.
+	if [[ "${KERNEL_CONFIGURE}" == yes && "${ARMBIAN_COMMAND}" == "kernel-config" ]]; then
 		display_alert "Stopping after configuring kernel" "" "cachehit"
 		return 0
 	fi

--- a/lib/functions/configuration/interactive.sh
+++ b/lib/functions/configuration/interactive.sh
@@ -41,6 +41,21 @@ function interactive_finish() {
 	unset SHOW_WARNING
 }
 
+function interactive_config_ask_kernel() {
+	interactive_config_ask_kernel_configure
+}
+
+function interactive_config_ask_kernel_configure() {
+	[[ -n ${KERNEL_CONFIGURE} ]] && return 0
+	options+=("no" "Do not change the kernel configuration")
+	options+=("yes" "Show a kernel configuration menu before compilation")
+	#options+=("prebuilt" "Use precompiled packages (maintained hardware only)") # @TODO armbian-next does not support this, I think.
+	dialog_if_terminal_set_vars --title "Choose an option" --backtitle "$backtitle" --no-tags --menu "Select the kernel configuration" $TTY_Y $TTY_X $((TTY_Y - 8)) "${options[@]}"
+	set_interactive_config_value KERNEL_CONFIGURE "${DIALOG_RESULT}"
+	[[ ${DIALOG_EXIT_CODE} != 0 ]] && exit_with_error "You cancelled interactive during kernel configuration" "Build cancelled"
+	unset options
+}
+
 # Required usage:
 # declare -a arr_all_board_names=() arr_all_board_options=()                                                                                              # arrays
 # declare -A dict_all_board_types=() dict_all_board_source_files=() dict_all_board_descriptions=()                                                        # dictionaries

--- a/lib/functions/main/config-interactive.sh
+++ b/lib/functions/main/config-interactive.sh
@@ -7,8 +7,11 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 
-function config_possibly_interactive_board() {
-	# if BOARD is not set, display selection menu
+function config_possibly_interactive_kernel_board() {
+	# if KERNEL_CONFIGURE, BOARD, BRANCH or RELEASE are not set, display selection menu
+
+	interactive_config_ask_kernel
+	[[ -z $KERNEL_CONFIGURE ]] && exit_with_error "No option selected: KERNEL_CONFIGURE"
 
 	interactive_config_ask_board_list # this uses get_list_of_all_buildable_boards
 	[[ -z $BOARD ]] && exit_with_error "No board selected: BOARD"

--- a/lib/functions/main/config-prepare.sh
+++ b/lib/functions/main/config-prepare.sh
@@ -18,7 +18,7 @@ function prep_conf_main_build_single() {
 
 	# those are possibly interactive. interactive (dialog) and logging don't mix, for obvious reasons.
 	interactive_config_prepare_terminal # init vars used for interactive
-	config_possibly_interactive_board
+	config_possibly_interactive_kernel_board
 
 	LOG_SECTION="config_source_board_file" do_with_conditional_logging config_source_board_file
 

--- a/lib/functions/main/default-build.sh
+++ b/lib/functions/main/default-build.sh
@@ -11,10 +11,9 @@
 function full_build_packages_rootfs_and_image() {
 	error_if_kernel_only_set
 
-	# Detour, stop if KERNEL_CONFIGURE=yes
+	# Detour, warn the user about KERNEL_CONFIGURE=yes if it is set.
 	if [[ "${KERNEL_CONFIGURE}" == "yes" ]]; then
-		display_alert "KERNEL_CONFIGURE=yes during image build is not supported anymore." "First, run './compile.sh BOARD=${BOARD} BRANCH=${BRANCH} kernel-config'; then commit your changes; then build the image as normal. This workflow ensures consistent hashing results." "wrn"
-		exit_with_error "KERNEL_CONFIGURE=yes during image build is not supported anymore. Please use the new 'kernel-config' CLI command."
+		display_alert "KERNEL_CONFIGURE=yes during image build is deprecated." "It still works, but please prefer the new way. First, run './compile.sh BOARD=${BOARD} BRANCH=${BRANCH} kernel-config'; then commit your changes; then build the image as normal. This workflow ensures consistent hashing results." "wrn"
 	fi
 
 	# Detour, stop if UBOOT_CONFIGURE=yes


### PR DESCRIPTION
#### by popular demand: bring back `KERNEL_CONFIGURE=yes` *during image build*

> It seems I was once again terribly wrong. People love `KERNEL_CONFIGURE=yes` and specially the ability to select in `dialog`, and specially the one-step config+build all at once. Sorry for inconvenience caused...

- partially revert 6ef394d95de6a113099caf3d31b668c04dda3862 (thus bring back the TUI/dialog for selecting KERNEL_CONFIGURE=yes/no)
- partially revert d890b418c7107af183b5f1f2a9304923537766c4 (thus bring back the capacity to config & build image in one go)
- stop after configuring kernel, but only if command is `kernel-config`, not regular image-build KERNEL_CONFIGURE=yes
