### PR TITLE
squash some warnings (found during all-artifacts+all-images builds on CI)

### DIFF
--- a/lib/functions/artifacts/artifact-rootfs.sh
+++ b/lib/functions/artifacts/artifact-rootfs.sh
@@ -121,11 +121,11 @@ function artifact_rootfs_cli_adapter_config_prep() {
 
 	# If BOARD is set, use it to convert to an ARCH.
 	if [[ -n ${BOARD} ]]; then
-		display_alert "BOARD is set, converting to ARCH for rootfs building" "'BOARD=${BOARD}'" "warn"
+		display_alert "BOARD is set, converting to ARCH for rootfs building" "'BOARD=${BOARD}'" "info"
 		# Convert BOARD to ARCH; source the BOARD and FAMILY stuff
 		LOG_SECTION="config_source_board_file" do_with_conditional_logging config_source_board_file
 		LOG_SECTION="source_family_config_and_arch" do_with_conditional_logging source_family_config_and_arch
-		display_alert "Done sourcing board file" "'${BOARD}' - arch: '${ARCH}'" "warn"
+		display_alert "Done sourcing board file" "'${BOARD}' - arch: '${ARCH}'" "info"
 	fi
 
 	declare -a vars_need_to_be_set=("RELEASE" "ARCH")

--- a/lib/functions/cli/cli-jsoninfo.sh
+++ b/lib/functions/cli/cli-jsoninfo.sh
@@ -189,6 +189,9 @@ function cli_json_info_run() {
 			display_alert "Generating GHA matrix for images" "output-gha-matrix :: images" "info"
 			declare GHA_ALL_IMAGES_JSON_MATRIX_FILE="${BASE_INFO_OUTPUT_DIR}/gha-all-images-matrix.json"
 			if [[ ! -f "${GHA_ALL_IMAGES_JSON_MATRIX_FILE}" ]]; then
+				# export env vars used by the Python script.
+				export SKIP_IMAGES="${SKIP_IMAGES:-"no"}"
+				export IMAGES_ONLY_OUTDATED_ARTIFACTS="${IMAGES_ONLY_OUTDATED_ARTIFACTS:-"no"}"
 				run_host_command_logged "${PYTHON3_VARS[@]}" "${PYTHON3_INFO[BIN]}" "${INFO_TOOLS_DIR}"/output-gha-matrix.py images "${OUTDATED_ARTIFACTS_IMAGES_FILE}" "${MATRIX_IMAGE_CHUNKS}" ">" "${GHA_ALL_IMAGES_JSON_MATRIX_FILE}"
 			fi
 			github_actions_add_output "image-matrix" "$(cat "${GHA_ALL_IMAGES_JSON_MATRIX_FILE}")"

--- a/lib/functions/host/host-utils.sh
+++ b/lib/functions/host/host-utils.sh
@@ -174,6 +174,7 @@ function local_apt_deb_cache_prepare() {
 				sdcard_var_cache_apt_size_mb=$(du -sm "${sdcard_var_cache_apt_dir}" | cut -f1)
 				if [[ "${sdcard_var_cache_apt_size_mb}" -gt 0 ]]; then
 					display_alert "WARNING: SDCARD /var/cache/apt dir is not empty" "${when_used} :: ${sdcard_var_cache_apt_dir} (${sdcard_var_cache_apt_size_mb} MB)" "wrn"
+					run_host_command_logged ls -lahtR "${sdcard_var_cache_apt_dir}" # list the contents so we can try and identify what is polluting it
 				fi
 			fi
 		fi
@@ -186,6 +187,7 @@ function local_apt_deb_cache_prepare() {
 				sdcard_var_lib_apt_lists_size_mb=$(du -sm "${sdcard_var_lib_apt_lists_dir}" | cut -f1)
 				if [[ "${sdcard_var_lib_apt_lists_size_mb}" -gt 0 ]]; then
 					display_alert "WARNING: SDCARD /var/lib/apt/lists dir is not empty" "${when_used} :: ${sdcard_var_lib_apt_lists_dir} (${sdcard_var_lib_apt_lists_size_mb} MB)" "wrn"
+					run_host_command_logged ls -lahtR "${sdcard_var_lib_apt_lists_dir}" # list the contents so we can try and identify what is polluting it
 				fi
 			fi
 		fi

--- a/lib/functions/host/host-utils.sh
+++ b/lib/functions/host/host-utils.sh
@@ -170,10 +170,10 @@ function local_apt_deb_cache_prepare() {
 		declare sdcard_var_cache_apt_dir="${SDCARD}/var/cache/apt"
 		if [[ -d "${sdcard_var_cache_apt_dir}" ]]; then
 			if ! mountpoint -q "${sdcard_var_cache_apt_dir}"; then
-				declare -i sdcard_var_cache_apt_size_mb
-				sdcard_var_cache_apt_size_mb=$(du -sm "${sdcard_var_cache_apt_dir}" | cut -f1)
-				if [[ "${sdcard_var_cache_apt_size_mb}" -gt 0 ]]; then
-					display_alert "WARNING: SDCARD /var/cache/apt dir is not empty" "${when_used} :: ${sdcard_var_cache_apt_dir} (${sdcard_var_cache_apt_size_mb} MB)" "wrn"
+				declare -i sdcard_var_cache_apt_files_count
+				sdcard_var_cache_apt_files_count=$(find "${sdcard_var_cache_apt_dir}" -type f | wc -l)
+				if [[ "${sdcard_var_cache_apt_files_count}" -gt 0 ]]; then
+					display_alert "WARNING: SDCARD /var/cache/apt dir is not empty" "${when_used} :: ${sdcard_var_cache_apt_dir} (${sdcard_var_cache_apt_files_count} files)" "wrn"
 					run_host_command_logged ls -lahtR "${sdcard_var_cache_apt_dir}" # list the contents so we can try and identify what is polluting it
 				fi
 			fi
@@ -183,10 +183,10 @@ function local_apt_deb_cache_prepare() {
 		declare sdcard_var_lib_apt_lists_dir="${SDCARD}/var/lib/apt/lists"
 		if [[ -d "${sdcard_var_lib_apt_lists_dir}" ]]; then
 			if ! mountpoint -q "${sdcard_var_lib_apt_lists_dir}"; then
-				declare -i sdcard_var_lib_apt_lists_size_mb
-				sdcard_var_lib_apt_lists_size_mb=$(du -sm "${sdcard_var_lib_apt_lists_dir}" | cut -f1)
-				if [[ "${sdcard_var_lib_apt_lists_size_mb}" -gt 0 ]]; then
-					display_alert "WARNING: SDCARD /var/lib/apt/lists dir is not empty" "${when_used} :: ${sdcard_var_lib_apt_lists_dir} (${sdcard_var_lib_apt_lists_size_mb} MB)" "wrn"
+				declare -i sdcard_var_lib_apt_lists_files_count
+				sdcard_var_lib_apt_lists_files_count=$(find "${sdcard_var_lib_apt_lists_dir}" -type f | wc -l)
+				if [[ "${sdcard_var_lib_apt_lists_files_count}" -gt 0 ]]; then
+					display_alert "WARNING: SDCARD /var/lib/apt/lists dir is not empty" "${when_used} :: ${sdcard_var_lib_apt_lists_dir} (${sdcard_var_lib_apt_lists_files_count} files)" "wrn"
 					run_host_command_logged ls -lahtR "${sdcard_var_lib_apt_lists_dir}" # list the contents so we can try and identify what is polluting it
 				fi
 			fi

--- a/lib/functions/image/partitioning.sh
+++ b/lib/functions/image/partitioning.sh
@@ -364,7 +364,7 @@ function prepare_partitions() {
 	# complement extlinux config if it exists; remove armbianEnv in this case.
 	if [[ -f $SDCARD/boot/extlinux/extlinux.conf ]]; then
 		echo "  append root=$rootfs $SRC_CMDLINE $MAIN_CMDLINE" >> $SDCARD/boot/extlinux/extlinux.conf
-		display_alert "extlinux.conf exists" "removing armbianEnv.txt" "warn"
+		display_alert "extlinux.conf exists" "removing armbianEnv.txt" "info"
 		[[ -f $SDCARD/boot/armbianEnv.txt ]] && run_host_command_logged rm -v $SDCARD/boot/armbianEnv.txt
 	fi
 

--- a/lib/functions/rootfs/distro-agnostic.sh
+++ b/lib/functions/rootfs/distro-agnostic.sh
@@ -153,7 +153,7 @@ function install_distribution_agnostic() {
 	if [[ "${KEEP_ORIGINAL_OS_RELEASE:-"no"}" != "yes" ]]; then
 		sed -i "s/^PRETTY_NAME=.*/PRETTY_NAME=\"${VENDOR} ${IMAGE_VERSION:-"${REVISION}"} ${RELEASE^}\"/" "${SDCARD}"/etc/os-release
 	else
-		display_alert "distro-agnostic: KEEP_ORIGINAL_OS_RELEASE" "Keeping original /etc/os-release's PRETTY_NAME as original" "warn"
+		display_alert "distro-agnostic: KEEP_ORIGINAL_OS_RELEASE" "Keeping original /etc/os-release's PRETTY_NAME as original" "info"
 	fi
 
 	# enable few bash aliases enabled in Ubuntu by default to make it even

--- a/lib/functions/rootfs/distro-specific.sh
+++ b/lib/functions/rootfs/distro-specific.sh
@@ -34,7 +34,7 @@ function install_distribution_specific() {
 				if [[ -f "${SDCARD}"/etc/systemd/resolved.conf ]]; then
 					sed -i "s/#DNS=.*/DNS=$NAMESERVER/g" "${SDCARD}"/etc/systemd/resolved.conf
 				else
-					display_alert "DNS fix" "/etc/systemd/resolved.conf not found: ${DISTRIBUTION} ${RELEASE}" "wrn"
+					display_alert "DNS fix" "/etc/systemd/resolved.conf not found: ${DISTRIBUTION} ${RELEASE}" "info"
 				fi
 			fi
 

--- a/lib/functions/rootfs/trap-rootfs.sh
+++ b/lib/functions/rootfs/trap-rootfs.sh
@@ -25,7 +25,7 @@ function prepare_rootfs_build_params_and_trap() {
 
 	# @TODO: well those are very... arbitrary numbers. At least when using cached rootfs, we can be more precise.
 	# predicting the size of tmpfs is hard/impossible, so would be nice to show the used size at the end so we can tune.
-	declare -i tmpfs_estimated_size=2000                     # MiB
+	declare -i tmpfs_estimated_size=2300                     # MiB - bumped from 2000, empirically
 	[[ $BUILD_DESKTOP == yes ]] && tmpfs_estimated_size=5000 # MiB
 
 	declare use_tmpfs=no                      # by default

--- a/lib/tools/common/gha.py
+++ b/lib/tools/common/gha.py
@@ -11,7 +11,7 @@ def wrap_with_gha_expression(value):
 
 def set_gha_output(name, value):
 	if os.environ.get('GITHUB_OUTPUT') is None:
-		log.warning(f"Environment variable GITHUB_OUTPUT is not set. Cannot set output '{name}' to '{value}'")
+		log.debug(f"Environment variable GITHUB_OUTPUT is not set. Cannot set output '{name}' to '{value}'")
 		return
 
 	with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:

--- a/lib/tools/info/output-gha-matrix.py
+++ b/lib/tools/info/output-gha-matrix.py
@@ -76,9 +76,10 @@ def generate_matrix_images(info) -> list[dict]:
 		image = info["images"][image_id]
 
 		if armbian_utils.get_from_env("IMAGES_ONLY_OUTDATED_ARTIFACTS") == "yes":
+			log.info(f"IMAGES_ONLY_OUTDATED_ARTIFACTS is set: outdated artifacts: {image['outdated_artifacts_count']} for image {image_id}")
 			skip = image["outdated_artifacts_count"] == 0
 			if skip:
-				log.info(f"Skipping image {image_id} because it has no outdated artifacts")
+				log.warning(f"Skipping image {image_id} because it has no outdated artifacts")
 				continue
 
 		if armbian_utils.get_from_env("SKIP_IMAGES") == "yes":


### PR DESCRIPTION
#### squash some warnings (found during all-artifacts+all-images builds on CI)

> When building "all" the things, these kind of innofensive WARNs pile up. Clean them up a bit.
> Raises the estimate of 2000MiB to 2300MiB for CLI images. This was determined empirically.

- `binfmts`: don't raise warning if qemu-arm failed to load under aarch64 (some are native, some are emulated, all are good)
  - reported by @igorpecovnik on Discord, during massive CI build, when armhf builds landed on arm64 builders
- logging: squash undue warnings rootfs/aptcache
  - rootfs is built with BOARD= so just live with it (idea about this warn was that families might hook rootfs build process)
  - count, instead of du, apt caches. seems some empty dirs are reported as "1Mb" by du?
- `host-utils`: more logging for when junk is found in image apt caches
- logging: curb some warnings into info's
- `rootfs`: bump non-desktop `tmpfs_estimated_size` from 2000mb to 2300mb (determined empirically, after building all images)
- pipeline: `gha`: fix `IMAGES_ONLY_OUTDATED_ARTIFACTS` and `SKIP_IMAGES` by exporting them so Python can see; tune logging

