### PR TITLE
fixes and squash warnings, mid May/'23: All `not-eos` artifacts & boards now build OK

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -42,7 +42,9 @@ RKBIN_DIR="$SRC/cache/sources/rkbin-tools"
 BOOT_SOC=${BOOT_SOC:=$(expr $BOOTCONFIG : '.*\(rk[[:digit:]]\+.*\)_.*' || true)}
 
 if [[ "a${BOOT_SOC}a" == "aa" ]]; then
-	display_alert "Could not determine BOOT_SOC from BOOTCONFIG" "BOOTCONFIG: '${BOOTCONFIG}'" "warning"
+	if [[ "${BOOTCONFIG}" != "" && "${BOOTCONFIG}" != " none" ]]; then # only warn if BOOTCONFIG set and not 'none'
+		display_alert "Could not determine BOOT_SOC from BOOTCONFIG" "BOOTCONFIG: '${BOOTCONFIG}'" "warning"
+	fi
 else
 	display_alert "Determined BOOT_SOC from BOOTCONFIG" "BOOT_SOC: '${BOOT_SOC}'; BOOTCONFIG: '${BOOTCONFIG}'" "info"
 fi

--- a/config/sources/families/mt7623.conf
+++ b/config/sources/families/mt7623.conf
@@ -62,8 +62,3 @@ family_tweaks() {
 	cp $SRC/packages/bsp/mt7623/10* $SDCARD/etc/systemd/network/
 	cp $SRC/packages/blobs/mt7623n/wireless/{stp_uart_launcher,wmt_loader,wmt_loopback} $SDCARD/usr/local/bin
 }
-
-family_tweaks_bsp() {
-	# mmc-utils is needed for nand-sata-install
-	install -m 755 $SRC/packages/extras-buildpkgs/mmc-utils/debian/rules $destination/usr/bin/
-}

--- a/config/sources/families/odroidxu4.conf
+++ b/config/sources/families/odroidxu4.conf
@@ -42,7 +42,7 @@ SERIALCON=ttySAC2
 function custom_kernel_config__hack_odroidxu4_firmware() {
 	kernel_config_modifying_hashes+=("odroidxu4_firmware")
 	if [[ -f .config ]]; then
-		display_alert "Copying firmware files" "odroidxu4 VENDOR KERNEL?" "warn"
+		display_alert "Copying firmware files" "odroidxu4 VENDOR KERNEL" "info"
 		# check $kernel_work_dir is set and exists, or bail
 		[[ -z "${kernel_work_dir}" ]] && exit_with_error "kernel_work_dir is not set"
 		[[ ! -d "${kernel_work_dir}" ]] && exit_with_error "kernel_work_dir does not exist: ${kernel_work_dir}"

--- a/config/sources/families/sun50iw9.conf
+++ b/config/sources/families/sun50iw9.conf
@@ -29,7 +29,7 @@ case $BRANCH in
 		# This (legacy/vendor) kernel requires uImage manual conversion; do it via a 'pre_package_kernel_image' hook.
 		declare -g NAME_KERNEL="uImage" # Even though that's a lie.
 		function pre_package_kernel_image__orangepi_legacy_uImage_manual_conversion() {
-			display_alert "Converting" "${BOARDFAMILY} - ${LINUXFAMILY} :: legacy :: uImage" "warn"
+			display_alert "Converting" "${BOARDFAMILY} - ${LINUXFAMILY} :: legacy :: uImage" "info"
 			if [[ -z "${kernel_image_pre_package_path}" || ! -f "${kernel_image_pre_package_path}" ]]; then
 				exit_with_error "kernel_image_pre_package_path ('${kernel_image_pre_package_path}') is not set or does not exist"
 			fi

--- a/lib/functions/artifacts/artifact-rootfs.sh
+++ b/lib/functions/artifacts/artifact-rootfs.sh
@@ -17,7 +17,7 @@ function artifact_rootfs_config_dump() {
 	artifact_input_variables[DESKTOP_APPGROUPS_SELECTED]="${DESKTOP_APPGROUPS_SELECTED:-"no_DESKTOP_APPGROUPS_SELECTED_set"}"
 	# Hash of the packages added/removed by extensions
 	declare pkgs_hash="undetermined"
-	pkgs_hash="$(echo "${REMOVE_PACKAGES[*]} ${EXTRA_PACKAGES_ROOTFS[*]}" | sha256sum | cut -d' ' -f1)"
+	pkgs_hash="$(echo "${REMOVE_PACKAGES[*]} ${EXTRA_PACKAGES_ROOTFS[*]} ${PACKAGE_LIST_BOARD_REMOVE} ${PACKAGE_LIST_FAMILY_REMOVE}" | sha256sum | cut -d' ' -f1)"
 	artifact_input_variables[EXTRA_PKG_ADD_REMOVE_HASH]="${pkgs_hash}"
 }
 

--- a/lib/functions/bsp/armbian-bsp-cli-deb.sh
+++ b/lib/functions/bsp/armbian-bsp-cli-deb.sh
@@ -218,7 +218,7 @@ function get_bootscript_info() {
 		fi
 	elif [[ $SRC_EXTLINUX == yes ]]; then
 		bootscript_info[has_extlinux]="yes"
-		display_alert "Using extlinux, regular bootscripts ignored" "SRC_EXTLINUX=${SRC_EXTLINUX}" "warn"
+		display_alert "Using extlinux, regular bootscripts ignored" "SRC_EXTLINUX=${SRC_EXTLINUX}" "info"
 	fi
 
 	debug_dict bootscript_info

--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -81,7 +81,7 @@ function prepare_kernel_packaging_debs() {
 		display_alert "Packaging linux-headers" "${LINUXFAMILY} ${LINUXCONFIG}" "info"
 		create_kernel_deb "linux-headers-${BRANCH}-${LINUXFAMILY}" "${debs_target_dir}" kernel_package_callback_linux_headers
 	else
-		display_alert "Skipping linux-headers package" "for ${KERNEL_MAJOR_MINOR} kernel version" "warn"
+		display_alert "Skipping linux-headers package" "for ${KERNEL_MAJOR_MINOR} kernel version" "info"
 	fi
 }
 

--- a/lib/functions/configuration/aggregation.sh
+++ b/lib/functions/configuration/aggregation.sh
@@ -96,6 +96,7 @@ function aggregate_all_packages_python() {
 		"PACKAGE_LIST_BOARD=${PACKAGE_LIST_BOARD}"
 
 		# Those are processed by Python, but not part of rootfs / main packages; results in AGGREGATED_PACKAGES_IMAGE_UNINSTALL
+		# TODO: rpardini: the above statement is untrue; those result in removal _from the rootfs_ and not the image. See also artifact_rootfs_config_dump()
 		# These two vars are made readonly after sourcing the board / family config, so can't be used in extensions and such.
 		"PACKAGE_LIST_BOARD_REMOVE=${PACKAGE_LIST_BOARD_REMOVE}"
 		"PACKAGE_LIST_FAMILY_REMOVE=${PACKAGE_LIST_FAMILY_REMOVE}"

--- a/lib/functions/general/retry.sh
+++ b/lib/functions/general/retry.sh
@@ -30,7 +30,8 @@ function do_with_retries() {
 		if [[ "${silent_retry}" == "yes" ]]; then
 			: # do nothing
 		else
-			display_alert "Command failed, retrying in ${sleep_seconds}s" "$*" "warn"
+			# skip_ci_special="yes": don't write this warning to CI/GHA summary. retries are normal in GHA and pollute the Summary view
+			skip_ci_special="yes" display_alert "Command failed, retrying in ${sleep_seconds}s" "$*" "warn"
 		fi
 		unset IS_A_RETRY
 		unset RETRY_RUNS

--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -578,7 +578,8 @@ function docker_cli_launch() {
 		display_alert "-------------Docker run finished after ${SECONDS}s------------------------" "🐳 successfull" "info"
 	else
 		docker_build_result=$? # capture exit code of test done 4 lines above.
-		display_alert "-------------Docker run failed after ${SECONDS}s--------------------------" "🐳 failed" "err"
+		# No use polluting GHA/CI with notices about Docker failure (real failure, inside Docker, generated enough errors already) skip_ci_special="yes"
+		skip_ci_special="yes" display_alert "-------------Docker run failed after ${SECONDS}s--------------------------" "🐳 failed" "err"
 	fi
 
 	# Find and show the path to the log file for the ARMBIAN_BUILD_UUID.

--- a/lib/functions/host/host-utils.sh
+++ b/lib/functions/host/host-utils.sh
@@ -172,7 +172,7 @@ function local_apt_deb_cache_prepare() {
 			if ! mountpoint -q "${sdcard_var_cache_apt_dir}"; then
 				declare -i sdcard_var_cache_apt_files_count
 				sdcard_var_cache_apt_files_count=$(find "${sdcard_var_cache_apt_dir}" -type f | wc -l)
-				if [[ "${sdcard_var_cache_apt_files_count}" -gt 0 ]]; then
+				if [[ "${sdcard_var_cache_apt_files_count}" -gt 1 ]]; then # 1 cos of lockfile that might or not be there
 					display_alert "WARNING: SDCARD /var/cache/apt dir is not empty" "${when_used} :: ${sdcard_var_cache_apt_dir} (${sdcard_var_cache_apt_files_count} files)" "wrn"
 					run_host_command_logged ls -lahtR "${sdcard_var_cache_apt_dir}" # list the contents so we can try and identify what is polluting it
 				fi
@@ -185,7 +185,7 @@ function local_apt_deb_cache_prepare() {
 			if ! mountpoint -q "${sdcard_var_lib_apt_lists_dir}"; then
 				declare -i sdcard_var_lib_apt_lists_files_count
 				sdcard_var_lib_apt_lists_files_count=$(find "${sdcard_var_lib_apt_lists_dir}" -type f | wc -l)
-				if [[ "${sdcard_var_lib_apt_lists_files_count}" -gt 0 ]]; then
+				if [[ "${sdcard_var_lib_apt_lists_files_count}" -gt 1 ]]; then # 1 cos of lockfile that might or not be there
 					display_alert "WARNING: SDCARD /var/lib/apt/lists dir is not empty" "${when_used} :: ${sdcard_var_lib_apt_lists_dir} (${sdcard_var_lib_apt_lists_files_count} files)" "wrn"
 					run_host_command_logged ls -lahtR "${sdcard_var_lib_apt_lists_dir}" # list the contents so we can try and identify what is polluting it
 				fi

--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -174,7 +174,7 @@ function prepare_host_noninteractive() {
 						display_alert "Updating binfmts" "update-binfmts --enable qemu-${wanted_arch}" "debug"
 						if [[ "${host_arch}" == "aarch64" && "${wanted_arch}" == "arm" ]]; then
 							display_alert "Trying to update binfmts - aarch64 (sometimes) does 32-bit sans emulation" "update-binfmts --enable qemu-${wanted_arch}" "debug"
-							run_host_command_logged update-binfmts --enable "qemu-${wanted_arch}" "||" "true" # don't fail.
+							run_host_command_logged update-binfmts --enable "qemu-${wanted_arch}" "&>" "/dev/null" "||" "true" # don't fail nor produce output, which can be misleading.
 						else
 							run_host_command_logged update-binfmts --enable "qemu-${wanted_arch}" || display_alert "Failed to update binfmts" "update-binfmts --enable qemu-${wanted_arch}" "err" # log & continue on failure
 						fi

--- a/lib/functions/logging/display-alert.sh
+++ b/lib/functions/logging/display-alert.sh
@@ -198,7 +198,7 @@ function display_alert() {
 	echo -e "${normal_color}${left_marker:-}${padding:-}${level_indicator}${padding}${normal_color}${right_marker:-}${timing_info}${pids_info}${bashopts_info} ${normal_color}${message}${extra}${normal_color}" >&2
 
 	# Now write to CI, if we're running on it. Remove ANSI escapes which confuse GitHub Actions.
-	if [[ "${CI}" == "true" ]] && [[ "${ci_log}" != "" ]]; then
+	if [[ "${CI}" == "true" ]] && [[ "${ci_log}" != "" ]] && [[ "${skip_ci_special:-"no"}" != "yes" ]]; then
 		echo -e "::${ci_log} ::" "${1} ${2}" | sed 's/\x1b\[[0-9;]*m//g' >&2
 	fi
 

--- a/lib/functions/logging/traps.sh
+++ b/lib/functions/logging/traps.sh
@@ -108,7 +108,8 @@ function run_cleanup_handlers() {
 		return 0 # No handlers set, just return.
 	else
 		if [[ ${cleanup_exit_code:-0} -gt 0 ]]; then
-			display_alert "Cleaning up" "please wait for cleanups to finish" "error"
+			# No use polluting GHA/CI with notices about cleanup, if we're already failing. skip_ci_special="yes"
+			skip_ci_special="yes" display_alert "Cleaning up" "please wait for cleanups to finish" "error"
 		else
 			display_alert "Cleaning up" "please wait for cleanups to finish" "info"
 		fi

--- a/lib/functions/rootfs/apt-install.sh
+++ b/lib/functions/rootfs/apt-install.sh
@@ -14,35 +14,30 @@ function apt_purge_unneeded_packages_and_clean_apt_caches() {
 
 	declare dir_var_lib_apt_lists="/var/lib/apt/lists"
 	declare dir_var_cache_apt="/var/cache/apt"
-	declare -i dir_var_cache_apt_size_mb dir_var_cache_apt_size_after_cleaning_mb dir_var_lib_apt_lists_size_mb
+	declare -i dir_var_cache_apt_file_count dir_var_lib_apt_lists_file_count
 
 	# Now, let's list what is under ${SDCARD}/var/cache/apt -- it should be empty. If it isn't, warn, and clean it up.
-	dir_var_cache_apt_size_mb="$(du -sm "${SDCARD}${dir_var_cache_apt}" | cut -f1)"
-	if [[ "${dir_var_cache_apt_size_mb}" -gt 0 ]]; then
-		display_alert "SDCARD ${dir_var_cache_apt} is not empty" "${dir_var_cache_apt} :: ${dir_var_cache_apt_size_mb}MB" "wrn"
-		# list the contents
+	dir_var_cache_apt_file_count="$(find "${SDCARD}${dir_var_cache_apt}" -type f | wc -l)"
+	if [[ "${dir_var_cache_apt_file_count}" -gt 1 ]]; then # there is sometimes at least one file, the lock file
+		display_alert "SDCARD ${dir_var_cache_apt} is not empty" "${dir_var_cache_apt} :: ${dir_var_cache_apt_file_count} files" "wrn"
 		run_host_command_logged ls -lahtR "${SDCARD}${dir_var_cache_apt}"
 		wait_for_disk_sync "after listing ${SDCARD}${dir_var_cache_apt}"
 	else
-		display_alert "SDCARD ${dir_var_cache_apt} is empty" "${dir_var_cache_apt} :: ${dir_var_cache_apt_size_mb}MB" "debug"
+		display_alert "SDCARD ${dir_var_cache_apt} is empty" "${dir_var_cache_apt} :: ${dir_var_cache_apt_file_count} files" "debug"
 	fi
 
 	# attention: this is _very different_ from `chroot_sdcard_apt_get clean` (which would clean the cache)
 	chroot_sdcard apt-get clean
 	wait_for_disk_sync "after apt-get clean"
 
-	dir_var_cache_apt_size_after_cleaning_mb="$(du -sm "${SDCARD}${dir_var_cache_apt}" | cut -f1)"
-	display_alert "SDCARD ${dir_var_cache_apt} size after cleaning" "${dir_var_cache_apt} :: ${dir_var_cache_apt_size_after_cleaning_mb}MB" "debug"
-
 	# Also clean ${SDCARD}/var/lib/apt/lists; this is where the package lists are stored.
-	dir_var_lib_apt_lists_size_mb="$(du -sm "${SDCARD}${dir_var_lib_apt_lists}" | cut -f1)"
-	if [[ "${dir_var_lib_apt_lists_size_mb}" -gt 0 ]]; then
-		display_alert "SDCARD ${dir_var_lib_apt_lists} is not empty" "${dir_var_lib_apt_lists} :: ${dir_var_lib_apt_lists_size_mb}MB" "wrn"
-		# list the contents
+	dir_var_lib_apt_lists_file_count="$(find "${SDCARD}${dir_var_lib_apt_lists}" -type f | wc -l)"
+	if [[ "${dir_var_lib_apt_lists_file_count}" -gt 1 ]]; then # there is sometimes at least one file, the lock file
+		display_alert "SDCARD ${dir_var_lib_apt_lists} is not empty" "${dir_var_lib_apt_lists} :: ${dir_var_lib_apt_lists_file_count} files" "wrn"
 		run_host_command_logged ls -lahtR "${SDCARD}${dir_var_lib_apt_lists}"
 		wait_for_disk_sync "after listing ${SDCARD}${dir_var_cache_apt}"
 	else
-		display_alert "SDCARD ${dir_var_lib_apt_lists} is empty" "${dir_var_lib_apt_lists} :: ${dir_var_lib_apt_lists_size_mb}MB" "debug"
+		display_alert "SDCARD ${dir_var_lib_apt_lists} is empty" "${dir_var_lib_apt_lists} :: ${dir_var_lib_apt_lists_file_count} files" "debug"
 	fi
 
 	# Either way, clean it away, we don't wanna ship those lists on images or rootfs.


### PR DESCRIPTION
#### fixes and squash warnings, mid May/'23: All `not-eos` artifacts & boards now build OK

> Board/family fixes for non-building stuff

- `mt7623`: remove `packages/extras-buildpkgs/mmc-utils/debian/rules` install that does not exist anymore (should fix `bananapir2`)
  - no idea where this went... ❓ 
- rootfs/aggregation/`helios64`: fix: include `PACKAGE_LIST_BOARD_REMOVE` (and FAMILY version) into rootfs' `artifact_input_variables`
  - `PACKAGE_LIST_BOARD_REMOVE` is used only in `helios64` board
  - the fact is `PACKAGE_LIST_BOARD_REMOVE` removes the packages _from the rootfs_ and not _from the image_ (this is a breaking, unwanted, change in aggregation that happened during _armbian_next_, that should be fixed later)
  - this only accounts for that fact, but in the future we should actually change how this works

> Generally curb WARNings that are either unuseful, unneeded, actually-debugging, or just too much for CI/GHA

- logging/retries: curb CI/GHA warning emitted _for each retry_
- `binfmts`: hide output when loading qemu-arm under aarch64 (some are native, some are emulated, all are good, errors can be ignored) [part 2/2]
- logging/`rockchip64_common`: curb warning about BOOT_SOC vs BOOTCONFIG if BOOTCONFIG is empty or 'none'
  - we've enough warnings already
- logging: curb warning that always came up when `SRC_EXTLINUX=yes`
  - `SRC_EXTLINUX` is quite prevalent, no use warning, it was more a debugging marker
- logging: curb CI/GHA special errors for cascading errors during build failure
  - otherwise we get 4 errors for each "error" in CI
    - one for the real error
    - one for "wait for cleanups"
    - one for "Docker build failed"
    - one from GHA itself since command failed (we can't get rid of this)
- `apt_purge_unneeded_packages_and_clean_apt_caches()`: count files, don't use `du`: avoid WARNs when not needed; tolerate 1 file
  - 'lock' might or not be there, tolerate 1 file (not 0)
- squash more warnings: 
  - `odroidxu4`'s firmware hook for vendor kernel. such is life, no use warning. 
  - `sun50iw9`: vendor kernel with extension, proven working, stop warning -
  -  old kernels don't have working headers, it's a fact of life, remove warning
