### PR TITLE
Add compatibility to package kernel-debs that use a localversion-X file

### DIFF
--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -45,12 +45,14 @@ function prepare_kernel_packaging_debs() {
 
 	declare kernel_work_dir="${1}"
 	declare kernel_dest_install_dir="${2}"
+	# This needs to use the `kernelrelease` make command instead of grab_version so that localversion
+	# files introduced by kernel patches in the patching step are honored
 	declare kernel_version="${3}"
 	declare -n tmp_kernel_install_dirs="${4}" # nameref to 	declare -n kernel_install_dirs dictionary
 	declare debs_target_dir="${kernel_work_dir}/.."
 
 	# Some variables and settings used throughout the script
-	declare kernel_version_family="${kernel_version}-${LINUXFAMILY}"
+	declare kernel_version_family="${kernel_version}"
 
 	# Package version. Affects users upgrading from repo!
 	display_alert "Kernel .deb package version" "${artifact_version}" "info"

--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -47,12 +47,9 @@ function prepare_kernel_packaging_debs() {
 	declare kernel_dest_install_dir="${2}"
 	# This needs to use the `kernelrelease` make command instead of grab_version so that localversion
 	# files introduced by kernel patches in the patching step are honored
-	declare kernel_version="${3}"
+	declare kernel_version_family="${3}"
 	declare -n tmp_kernel_install_dirs="${4}" # nameref to 	declare -n kernel_install_dirs dictionary
 	declare debs_target_dir="${kernel_work_dir}/.."
-
-	# Some variables and settings used throughout the script
-	declare kernel_version_family="${kernel_version}"
 
 	# Package version. Affects users upgrading from repo!
 	display_alert "Kernel .deb package version" "${artifact_version}" "info"
@@ -247,7 +244,7 @@ function kernel_package_callback_linux_image() {
 	cat <<- CONTROL_FILE > "${package_DEBIAN_dir}/control"
 		Package: ${package_name}
 		Version: ${artifact_version}
-		Source: linux-${kernel_version}
+		Source: linux-${kernel_version_family}
 		Architecture: ${ARCH}
 		Maintainer: ${MAINTAINER} <${MAINTAINERMAIL}>
 		Section: kernel


### PR DESCRIPTION
# Description

The current kernel.sh build system uses the `grab_version()` function in utils-compilation.sh to determine the version string of the kernel and locate the build artifacts after `make` has completed.

grab_version is a simple implementation that parses the makefile to guess the final kernel version, but if a userpatch has been applied to the kernel that includes a localversion-xx file (the PREEMPT_RT patch does this, for example), the returned value will be wrong (`grab_version` returns `5.10.110` when the true value used to name the vmlinuz image is `5.10.110-rt53-rockchip-rk3588`)

Thank you to @rpardini on Discord for helping me identify a fix for this issue.

This patch switches kernel.sh to use the built in `make kernelrelease` command to return the kernel version, which takes into account any localversion-xx files in the kernel tree, as well as the `LOCALVERSION=-${LINUXFAMILY}` value appended by the armbian kernel-make.sh code.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Compile kernel on current HEAD with localversion-rt file present. Expected result: build failure
Packaging fails at `kernel_package_callback_linux_image() --> lib/functions/compilation/kernel-debs.sh:213`
which is `run_host_command_logged ls -la "${kernel_pre_package_path}" "${kernel_image_pre_package_path}"`
This fails because `kernel_image_pre_package_path` is derived from `grab_version`
- [x] Compile kernel with this patch and **no localverison-rt** files:
vmlinuz filenames are unchanged from current functionality and correctly located by kernel-debs.sh to be built into .deb files.
Output from  `run_host_command_logged ls -la "${kernel_pre_package_path}" "${kernel_image_pre_package_path}"`:
```
-rw-rw-r-- 1 root root   215715 May 10 19:33 config-5.10.110-rockchip-rk3588
-rw-rw-r-- 1 root root  7779350 May 10 19:33 System.map-5.10.110-rockchip-rk3588
-rw-rw-r-- 1 root root 34013696 May 10 19:33 vmlinuz-5.10.110-rockchip-rk3588
```
.deb creation is correct:
```
linux-image-legacy-rockchip-rk3588_23.05.0-trunk--5.10.110-Sad1f-D4008-Pbb66-Cc2a1Hfe66-HK01ba-Vc222-B049d_arm64.deb
linux-headers-legacy-rockchip-rk3588_23.05.0-trunk--5.10.110-Sad1f-D4008-Pbb66-Cc2a1Hfe66-HK01ba-Vc222-B049d_arm64.deb
linux-dtb-legacy-rockchip-rk3588_23.05.0-trunk--5.10.110-Sad1f-D4008-Pbb66-Cc2a1Hfe66-HK01ba-Vc222-B049d_arm64.deb
```
- [x] Compile kernel with this patch and **localverison-rt** files:
vmlinuz files are correctly named with both the localversion-xx file and the armbian localversion appended in kernel-make.sh.
Output from  `run_host_command_logged ls -la "${kernel_pre_package_path}" "${kernel_image_pre_package_path}"`:
```
-rw-rw-r-- 1 root root   210209 May 10 19:48 config-5.10.110-rt53-rockchip-rk3588
-rw-rw-r-- 1 root root  7777472 May 10 19:48 System.map-5.10.110-rt53-rockchip-rk3588
-rw-rw-r-- 1 root root 33714688 May 10 19:48 vmlinuz-5.10.110-rt53-rockchip-rk3588
```
.debs are created as expected:
```
linux-image-legacy-rockchip-rk3588_23.05.0-trunk--5.10.110-Scbae-D4008-Pbb66-C3f61Hfe66-HK01ba-Vc222-B049d_arm64.deb
linux-headers-legacy-rockchip-rk3588_23.05.0-trunk--5.10.110-Scbae-D4008-Pbb66-C3f61Hfe66-HK01ba-Vc222-B049d_arm64.deb
linux-dtb-legacy-rockchip-rk3588_23.05.0-trunk--5.10.110-Scbae-D4008-Pbb66-C3f61Hfe66-HK01ba-Vc222-B049d_arm64.deb
```


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
