### PR TITLE
Nilfs2 fs support

### DIFF
--- a/extensions/fs-nilfs2-support.sh
+++ b/extensions/fs-nilfs2-support.sh
@@ -1,0 +1,18 @@
+# Enable this extension to include the required dependencies for building.
+# This is automatically enabled if ROOTFS_TYPE is set to nilfs2 in main-config.sh.
+
+function extension_prepare_config__add_to_image_nilfs-tools() {
+	display_alert "Adding nilfs-tools extra package..." "${EXTENSION}" "info"
+	add_packages_to_image nilfs-tools
+}
+
+function add_host_dependencies__add_nilfs_tools() {
+	display_alert "Adding NILFS tools to host dependencies..." "${EXTENSION}" "debug"
+	EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} nilfs-tools" # @TODO: convert to array later
+}
+
+function pre_update_initramfs__add_module_into_initramfs_config() {
+	echo "nilfs2" >> "$MOUNT"/etc/initramfs-tools/modules
+	return 0
+}
+

--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -114,6 +114,9 @@ function do_main_configuration() {
 			[[ -z $BTRFS_COMPRESSION ]] && BTRFS_COMPRESSION=zlib # default btrfs filesystem compression method is zlib
 			[[ ! $BTRFS_COMPRESSION =~ zlib|lzo|zstd|none ]] && exit_with_error "Unknown btrfs compression method" "$BTRFS_COMPRESSION"
 			;;
+		nilfs2)
+			enable_extension "fs-nilfs2-support"
+			;;
 		*)
 			exit_with_error "Unknown rootfs type: ROOTFS_TYPE='${ROOTFS_TYPE}'"
 			;;

--- a/lib/functions/image/partitioning.sh
+++ b/lib/functions/image/partitioning.sh
@@ -20,7 +20,7 @@ function prepare_partitions() {
 
 	# possible partition combinations
 	# /boot: none, ext4, ext2, fat (BOOTFS_TYPE)
-	# root: ext4, btrfs, f2fs, nfs (ROOTFS_TYPE)
+	# root: ext4, btrfs, f2fs, nilfs2, nfs (ROOTFS_TYPE)
 
 	# declare makes local variables by default if used inside a function
 	# NOTE: mountopts string should always start with comma if not empty
@@ -34,6 +34,7 @@ function prepare_partitions() {
 	parttype[fat]=fat16
 	parttype[f2fs]=ext4 # not a copy-paste error
 	parttype[btrfs]=btrfs
+	parttype[nilfs2]=nilfs2
 	parttype[xfs]=xfs
 	# parttype[nfs] is empty
 
@@ -45,6 +46,7 @@ function prepare_partitions() {
 	mkopts[ext2]=''
 	# mkopts[f2fs] is empty
 	mkopts[btrfs]='-m dup'
+	# mkopts[nilfs2] is empty
 	# mkopts[xfs] is empty
 	# mkopts[nfs] is empty
 
@@ -53,6 +55,7 @@ function prepare_partitions() {
 	mkopts_label[fat]='-n '
 	mkopts_label[f2fs]='-l '
 	mkopts_label[btrfs]='-L '
+	mkopts_label[nilfs2]='-L '
 	mkopts_label[xfs]='-L '
 	# mkopts_label[nfs] is empty
 
@@ -61,6 +64,7 @@ function prepare_partitions() {
 	mkfs[fat]=vfat
 	mkfs[f2fs]=f2fs
 	mkfs[btrfs]=btrfs
+	mkfs[nilfs2]=nilfs2
 	mkfs[xfs]=xfs
 	# mkfs[nfs] is empty
 
@@ -69,6 +73,7 @@ function prepare_partitions() {
 	# mountopts[fat] is empty
 	# mountopts[f2fs] is empty
 	mountopts[btrfs]=',commit=600'
+	# mountopts[nilfs2] is empty
 	# mountopts[xfs] is empty
 	# mountopts[nfs] is empty
 

--- a/lib/functions/image/rootfs-to-image.sh
+++ b/lib/functions/image/rootfs-to-image.sh
@@ -34,10 +34,12 @@ function create_image_from_sdcard_rootfs() {
 	declare calculated_image_version="undetermined"
 	calculate_image_version
 	declare -r -g version="${calculated_image_version}" # global readonly from here
-
+	declare rsync_ea=" -X "
+	# nilfs2 fs does not have extended attributes support, and have to be ignored on copy
+	if [[ $ROOTFS_TYPE == nilfs2 ]]; then rsync_ea=""; fi
 	if [[ $ROOTFS_TYPE != nfs ]]; then
 		display_alert "Copying files via rsync to" "/ (MOUNT root)"
-		run_host_command_logged rsync -aHWXh \
+		run_host_command_logged rsync -aHWh $rsync_ea \
 			--exclude="/boot" \
 			--exclude="/dev/*" \
 			--exclude="/proc/*" \

--- a/packages/bsp/common/usr/lib/armbian/armbian-resize-filesystem
+++ b/packages/bsp/common/usr/lib/armbian/armbian-resize-filesystem
@@ -221,6 +221,10 @@ do_expand_filesystem()
 			echo "Running 'btrfs filesystem resize max $mountpoint' now..."
 			btrfs filesystem resize max $mountpoint
 			;;
+		nilfs2)
+			echo "Running 'nilfs2 filesystem resize max $mountpoint' now..."
+			nilfs-resize -v -y $partdev
+			;;
 		*)
 			echo "Unsupported filesystem: $fstype"
 			echo "Trying to run 'resize2fs $partdev' now..."


### PR DESCRIPTION
Add possibility of nilfs2 fs based image generation.
nilfs2 automatically does snapshots and allow to restore any file to state back in time until it purged.

# How Has This Been Tested?

Build rockpi-4a image `BOARD=rockpi-4a ROOTFS_TYPE=nilfs2`  for ubuntu jammy
- [x] ubuntu jammy
- [x] ubuntu lunar
- [x] debian bookworm
- [x] debian sid

# Checklist:

- [X] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
