### PR TITLE
rpardini's mid-may/`23 pipeline fixes, debs-to-repo, rootfs-repo de-chicken-egg-ize

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -44,7 +44,7 @@ logging_init
 traps_init
 
 # make sure git considers our build system dir as a safe dir (only if actually building)
-[[ "${CONFIG_DEFS_ONLY}" != "yes" ]] && git_ensure_safe_directory "${SRC}"
+[[ "${CONFIG_DEFS_ONLY}" != "yes" && "${PRE_PREPARED_HOST}" != "yes" ]] && git_ensure_safe_directory "${SRC}"
 
 # Execute the main CLI entrypoint.
 cli_entrypoint "$@"

--- a/lib/functions/artifacts/artifact-armbian-bsp-cli.sh
+++ b/lib/functions/artifacts/artifact-armbian-bsp-cli.sh
@@ -72,7 +72,7 @@ function artifact_armbian-bsp-cli_prepare_version() {
 
 	# get the hashes of the lib/ bash sources involved...
 	declare hash_files="undetermined"
-	calculate_hash_for_files "${SRC}"/lib/functions/bsp/armbian-bsp-cli-deb.sh
+	calculate_hash_for_bash_deb_artifact "bsp/armbian-bsp-cli-deb.sh"
 	declare bash_hash="${hash_files}"
 	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
 

--- a/lib/functions/artifacts/artifact-armbian-bsp-desktop.sh
+++ b/lib/functions/artifacts/artifact-armbian-bsp-desktop.sh
@@ -38,7 +38,7 @@ function artifact_armbian-bsp-desktop_prepare_version() {
 
 	# get the hashes of the lib/ bash sources involved...
 	declare hash_files="undetermined"
-	calculate_hash_for_files "${SRC}"/lib/functions/bsp/armbian-bsp-desktop-deb.sh
+	calculate_hash_for_bash_deb_artifact "bsp/armbian-bsp-desktop-deb.sh"
 	declare bash_hash="${hash_files}"
 	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
 

--- a/lib/functions/artifacts/artifact-armbian-config.sh
+++ b/lib/functions/artifacts/artifact-armbian-config.sh
@@ -36,7 +36,7 @@ function artifact_armbian-config_prepare_version() {
 
 	# get the hashes of the lib/ bash sources involved...
 	declare hash_files="undetermined"
-	calculate_hash_for_files "${SRC}"/lib/functions/compilation/packages/armbian-config-deb.sh
+	calculate_hash_for_bash_deb_artifact "compilation/packages/armbian-config-deb.sh"
 	declare bash_hash="${hash_files}"
 	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
 

--- a/lib/functions/artifacts/artifact-armbian-desktop.sh
+++ b/lib/functions/artifacts/artifact-armbian-desktop.sh
@@ -39,7 +39,7 @@ function artifact_armbian-desktop_prepare_version() {
 
 	# get the hashes of the lib/ bash sources involved...
 	declare hash_files="undetermined"
-	calculate_hash_for_files "${SRC}"/lib/functions/compilation/packages/armbian-desktop-deb.sh
+	calculate_hash_for_bash_deb_artifact "compilation/packages/armbian-desktop-deb.sh"
 	declare bash_hash="${hash_files}"
 	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
 

--- a/lib/functions/artifacts/artifact-armbian-plymouth-theme.sh
+++ b/lib/functions/artifacts/artifact-armbian-plymouth-theme.sh
@@ -22,7 +22,7 @@ function artifact_armbian-plymouth-theme_prepare_version() {
 
 	# get the hashes of the lib/ bash sources involved...
 	declare hash_files="undetermined"
-	calculate_hash_for_files "${SRC}"/lib/functions/compilation/packages/armbian-plymouth-theme-deb.sh
+	calculate_hash_for_bash_deb_artifact "compilation/packages/armbian-plymouth-theme-deb.sh"
 	declare bash_hash="${hash_files}"
 	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
 

--- a/lib/functions/artifacts/artifact-armbian-zsh.sh
+++ b/lib/functions/artifacts/artifact-armbian-zsh.sh
@@ -37,7 +37,7 @@ function artifact_armbian-zsh_prepare_version() {
 
 	# get the hashes of the lib/ bash sources involved...
 	declare hash_files="undetermined"
-	calculate_hash_for_files "${SRC}"/lib/functions/compilation/packages/armbian-zsh-deb.sh
+	calculate_hash_for_bash_deb_artifact "compilation/packages/armbian-zsh-deb.sh"
 	declare bash_hash="${hash_files}"
 	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
 

--- a/lib/functions/artifacts/artifact-fake-ubuntu-advantage-tools.sh
+++ b/lib/functions/artifacts/artifact-fake-ubuntu-advantage-tools.sh
@@ -22,7 +22,7 @@ function artifact_fake_ubuntu_advantage_tools_prepare_version() {
 
 	# get the hashes of the lib/ bash sources involved...
 	declare hash_files="undetermined"
-	calculate_hash_for_files "${SRC}"/lib/functions/compilation/packages/fake_ubuntu_advantage_tools-deb.sh
+	calculate_hash_for_bash_deb_artifact "compilation/packages/fake_ubuntu_advantage_tools-deb.sh"
 	declare bash_hash="${hash_files}"
 	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
 

--- a/lib/functions/artifacts/artifact-firmware.sh
+++ b/lib/functions/artifacts/artifact-firmware.sh
@@ -37,7 +37,7 @@ function artifact_firmware_prepare_version() {
 
 	# get the hashes of the lib/ bash sources involved...
 	declare hash_files="undetermined"
-	calculate_hash_for_files "${SRC}"/lib/functions/compilation/packages/firmware-deb.sh
+	calculate_hash_for_bash_deb_artifact "compilation/packages/firmware-deb.sh"
 	declare bash_hash="${hash_files}"
 	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
 

--- a/lib/functions/artifacts/artifact-full_firmware.sh
+++ b/lib/functions/artifacts/artifact-full_firmware.sh
@@ -47,7 +47,7 @@ function artifact_full_firmware_prepare_version() {
 
 	# get the hashes of the lib/ bash sources involved...
 	declare hash_files="undetermined"
-	calculate_hash_for_files "${SRC}"/lib/functions/compilation/packages/firmware-deb.sh
+	calculate_hash_for_bash_deb_artifact "compilation/packages/firmware-deb.sh"
 	declare bash_hash="${hash_files}"
 	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
 

--- a/lib/functions/artifacts/artifact-kernel.sh
+++ b/lib/functions/artifacts/artifact-kernel.sh
@@ -154,7 +154,7 @@ function artifact_kernel_prepare_version() {
 
 	# get the hashes of the lib/ bash sources involved...
 	declare hash_files="undetermined"
-	calculate_hash_for_files "${SRC}"/lib/functions/compilation/kernel*.sh
+	calculate_hash_for_bash_deb_artifact "${SRC}"/lib/functions/compilation/kernel*.sh # expansion
 	declare bash_hash="${hash_files}"
 	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
 

--- a/lib/functions/artifacts/artifact-rootfs.sh
+++ b/lib/functions/artifacts/artifact-rootfs.sh
@@ -32,7 +32,7 @@ function artifact_rootfs_prepare_version() {
 
 	calculate_rootfs_cache_id # sets rootfs_cache_id
 
-	display_alert "Going to build rootfs" "packages_hash: '${packages_hash:-}' cache_type: '${cache_type:-}' rootfs_cache_id: '${rootfs_cache_id}'" "info"
+	display_alert "rootfs version" "packages_hash: '${packages_hash:-}' cache_type: '${cache_type:-}' rootfs_cache_id: '${rootfs_cache_id}'" "info"
 
 	declare -a reasons=(
 		"arch \"${ARCH}\""

--- a/lib/functions/artifacts/artifact-uboot.sh
+++ b/lib/functions/artifacts/artifact-uboot.sh
@@ -89,7 +89,7 @@ function artifact_uboot_prepare_version() {
 
 	# get the hashes of the lib/ bash sources involved...
 	declare hash_files="undetermined"
-	calculate_hash_for_files "${SRC}"/lib/functions/compilation/uboot*.sh
+	calculate_hash_for_bash_deb_artifact "${SRC}"/lib/functions/compilation/uboot*.sh # expansion
 	declare bash_hash="${hash_files}"
 	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
 

--- a/lib/functions/cli/cli-artifact.sh
+++ b/lib/functions/cli/cli-artifact.sh
@@ -8,6 +8,13 @@
 # https://github.com/armbian/build/
 
 function cli_artifact_pre_run() {
+	case "${ARMBIAN_COMMAND}" in
+		download-artifact)
+			display_alert "download-only mode:" "won't build '${WHAT}'" "info"
+			DONT_BUILD_ARTIFACTS="${WHAT}"
+			;;
+	esac
+
 	initialize_artifact "${WHAT}"
 	# Run the pre run adapter
 	artifact_cli_adapter_pre_run
@@ -45,30 +52,44 @@ function cli_artifact_run() {
 	declare ignore_local_cache="${ignore_local_cache:-"${default_update_remote_only}"}"
 	declare deploy_to_remote="${deploy_to_remote:-"${default_update_remote_only}"}"
 
-	# If OCI_TARGET_BASE is explicitly set, ignore local, skip if found in remote, and deploy to remote after build.
-	if [[ -n "${OCI_TARGET_BASE}" ]]; then
-		skip_unpack_if_found_in_caches="yes"
-		ignore_local_cache="yes"
-		deploy_to_remote="yes"
-
-		# Pass ARTIFACT_USE_CACHE=yes to actually use the cache versions, but don't deploy to remote.
-		# @TODO this is confusing. each op should be individually controlled...
-		# what we want is:
-		# 1: - check remote, if not found, check local, if not found, build, then deploy to remote
-		#      - if remote found, do nothing.
-		#      - if local found, deploy it to remote (for switching targets)
-		# 2: - get from remote -> get local -> build, then DON'T deploy to remote
-		if [[ "${ARTIFACT_USE_CACHE}" == "yes" ]]; then
+	case "${ARMBIAN_COMMAND}" in
+		download-artifact)
+			display_alert "Running in download-artifact mode" "download-artifact" "ext"
 			skip_unpack_if_found_in_caches="no"
 			ignore_local_cache="no"
 			deploy_to_remote="no"
-		fi
-	fi
+			;;
+		*)
+			# @TODO: rpardini: i'm braindead. I really can't make sense of my own code!
+			# If OCI_TARGET_BASE is explicitly set, ignore local, skip if found in remote, and deploy to remote after build.
+			if [[ -n "${OCI_TARGET_BASE}" ]]; then
+				skip_unpack_if_found_in_caches="yes"
+				ignore_local_cache="yes"
+				deploy_to_remote="yes"
+
+				# Pass ARTIFACT_USE_CACHE=yes to actually use the cache versions, but don't deploy to remote.
+				# @TODO this is confusing. each op should be individually controlled...
+				# what we want is:
+				# 1: - check remote, if not found, check local, if not found, build, then deploy to remote
+				#      - if remote found, do nothing.
+				#      - if local found, deploy it to remote (for switching targets)
+				# 2: - get from remote -> get local -> build, then DON'T deploy to remote
+				if [[ "${ARTIFACT_USE_CACHE}" == "yes" ]]; then
+					skip_unpack_if_found_in_caches="no"
+					ignore_local_cache="no"
+					deploy_to_remote="no"
+				fi
+			fi
+			;;
+	esac
 
 	# Force artifacts download we need to populate repository
 	if [[ "${FORCE_ARTIFACTS_DOWNLOAD}" == "yes" ]]; then
 		skip_unpack_if_found_in_caches="no"
 	fi
+
+	# display a summary of the 3 vars above: skip_unpack_if_found_in_caches, ignore_local_cache, deploy_to_remote
+	display_alert "CLI Artifact summary" "skip_unpack_if_found_in_caches=${skip_unpack_if_found_in_caches}, ignore_local_cache=${ignore_local_cache}, deploy_to_remote=${deploy_to_remote}" "info"
 
 	if [[ "${ARTIFACT_BUILD_INTERACTIVE}" == "yes" ]]; then # Set by `kernel-config`, `kernel-patch`, `uboot-config`, `uboot-patch`, etc.
 		display_alert "Running artifact build in interactive mode" "log file will be incomplete" "info"

--- a/lib/functions/cli/commands.sh
+++ b/lib/functions/cli/commands.sh
@@ -25,11 +25,16 @@ function armbian_register_commands() {
 		["config-dump-json"]="config_dump_json"    # implemented in cli_config_dump_json_pre_run and cli_config_dump_json_run
 		["config-dump-no-json"]="config_dump_json" # implemented in cli_config_dump_json_pre_run and cli_config_dump_json_run
 
-		["inventory"]="json_info"    # implemented in cli_json_info_pre_run and cli_json_info_run
-		["targets"]="json_info"      # implemented in cli_json_info_pre_run and cli_json_info_run
-		["gha-matrix"]="json_info"   # implemented in cli_json_info_pre_run and cli_json_info_run
-		["gha-workflow"]="json_info" # implemented in cli_json_info_pre_run and cli_json_info_run
-		["gha-template"]="json_info" # implemented in cli_json_info_pre_run and cli_json_info_run
+		["inventory"]="json_info"             # implemented in cli_json_info_pre_run and cli_json_info_run
+		["targets"]="json_info"               # implemented in cli_json_info_pre_run and cli_json_info_run
+		["debs-to-repo-json"]="json_info"     # implemented in cli_json_info_pre_run and cli_json_info_run
+		["gha-matrix"]="json_info"            # implemented in cli_json_info_pre_run and cli_json_info_run
+		["gha-workflow"]="json_info"          # implemented in cli_json_info_pre_run and cli_json_info_run
+		["gha-template"]="json_info"          # implemented in cli_json_info_pre_run and cli_json_info_run
+
+		# These probably should be in their own separate CLI commands file, but for now they're together in jsoninfo.
+		["debs-to-repo-download"]="json_info" # implemented in cli_json_info_pre_run and cli_json_info_run
+		["debs-to-repo-reprepro"]="json_info" # implemented in cli_json_info_pre_run and cli_json_info_run
 
 		["kernel-patches-to-git"]="patch_kernel" # implemented in cli_patch_kernel_pre_run and cli_patch_kernel_run
 

--- a/lib/functions/cli/commands.sh
+++ b/lib/functions/cli/commands.sh
@@ -43,6 +43,7 @@ function armbian_register_commands() {
 		# all-around artifact wrapper
 		["artifact"]="artifact"                  # implemented in cli_artifact_pre_run and cli_artifact_run
 		["artifact-config-dump-json"]="artifact" # implemented in cli_artifact_pre_run and cli_artifact_run
+		["download-artifact"]="artifact"         # implemented in cli_artifact_pre_run and cli_artifact_run
 
 		# shortcuts, see vars set below. the use legacy single build, and try to control it via variables
 		["rootfs"]="artifact"

--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -249,6 +249,7 @@ function kernel_package_callback_linux_image() {
 		Architecture: ${ARCH}
 		Maintainer: ${MAINTAINER} <${MAINTAINERMAIL}>
 		Section: kernel
+		Priority: optional
 		Provides: linux-image, linux-image-armbian, armbian-$BRANCH
 		Description: Armbian Linux $BRANCH kernel image ${artifact_version_reason:-"${kernel_version_family}"}
 		 This package contains the Linux kernel, modules and corresponding other
@@ -325,6 +326,7 @@ function kernel_package_callback_linux_dtb() {
 		Section: kernel
 		Package: ${package_name}
 		Architecture: ${ARCH}
+		Priority: optional
 		Provides: linux-dtb, linux-dtb-armbian, armbian-$BRANCH
 		Description: Armbian Linux $BRANCH DTBs ${artifact_version_reason:-"${kernel_version_family}"} in /boot/dtb-${kernel_version_family}
 		 This package contains device blobs from the Linux kernel, version ${kernel_version_family}
@@ -455,6 +457,7 @@ function kernel_package_callback_linux_headers() {
 		Section: devel
 		Package: ${package_name}
 		Architecture: ${ARCH}
+		Priority: optional
 		Provides: linux-headers, linux-headers-armbian, armbian-$BRANCH
 		Depends: make, gcc, libc6-dev, bison, flex, libssl-dev, libelf-dev
 		Description: Armbian Linux $BRANCH headers ${artifact_version_reason:-"${kernel_version_family}"}

--- a/lib/functions/compilation/packages/fake_ubuntu_advantage_tools-deb.sh
+++ b/lib/functions/compilation/packages/fake_ubuntu_advantage_tools-deb.sh
@@ -31,6 +31,8 @@ function compile_fake_ubuntu_advantage_tools() {
 		Conflicts: ubuntu-advantage-tools
 		Breaks: ubuntu-advantage-tools
 		Provides: ubuntu-advantage-tools (= 65535)
+		Priority: optional
+		Section: admin
 		Description: Ban ubuntu-advantage-tools while satisfying ubuntu-minimal dependency
 	END
 

--- a/lib/functions/general/github-actions.sh
+++ b/lib/functions/general/github-actions.sh
@@ -23,5 +23,5 @@ function github_actions_add_output() {
 	local output_value="$*"
 
 	echo "${output_name}=${output_value}" >> "${GITHUB_OUTPUT}"
-	display_alert "Added GHA output" "'${output_name}'='${output_value}'" "debug"
+	display_alert "Added GHA output" "'${output_name}'='${output_value}'" "ext"
 }

--- a/lib/functions/general/hash-files.sh
+++ b/lib/functions/general/hash-files.sh
@@ -27,6 +27,24 @@ function calculate_hash_for_all_files_in_dirs() {
 	calculate_hash_for_files "${files_to_hash[@]}"
 }
 
+# helper for artifacts that use "bash hash", eg, most of them.
+function calculate_hash_for_bash_deb_artifact() {
+	# the same as calculate_hash_for_files, but:
+	# - each param is automatically prefixed with "${SRC}/lib/functions" if it does not start with a slash
+	# - "compilation/packages/utils-dpkgdeb.sh" is automatically added
+	declare -a deb_bash_arr=()
+	for one in "$@"; do
+		# if the param does not start with a slash, prefix it with "${SRC}/lib/functions", for convenience
+		if [[ "${one}" != /* ]]; then
+			one="${SRC}/lib/functions/${one}"
+		fi
+		deb_bash_arr+=("${one}")
+	done
+	deb_bash_arr+=("${SRC}/lib/functions/compilation/packages/utils-dpkgdeb.sh")
+	calculate_hash_for_files "${deb_bash_arr[@]}"
+	return 0
+}
+
 function calculate_hash_for_files() {
 	hash_files="undetermined" # outer scope
 

--- a/lib/functions/general/oci-oras.sh
+++ b/lib/functions/general/oci-oras.sh
@@ -79,7 +79,7 @@ function run_tool_oras() {
 	# Run oras, possibly with retries...
 	if [[ "${retries:-1}" -gt 1 ]]; then
 		display_alert "Calling ORAS with retries ${retries}" "$*" "debug"
-		do_with_retries ${retries} "${ORAS_BIN}" "$@"
+		sleep_seconds="30" do_with_retries "${retries}" "${ORAS_BIN}" "$@"
 	else
 		# If any parameters passed, call ORAS, otherwise exit. We call it this way (sans-parameters) early to prepare ORAS tooling.
 		if [[ $# -eq 0 ]]; then
@@ -133,7 +133,7 @@ function oras_push_artifact_file() {
 	display_alert "upload_file_name: ${upload_file_name}" "ORAS upload" "debug"
 
 	pushd "${upload_file_base_path}" &> /dev/null || exit_with_error "Failed to pushd to ${upload_file_base_path} - ORAS upload"
-	retries=5 run_tool_oras push "${extra_params[@]}" "${image_full_oci}" "${upload_file_name}:application/vnd.unknown.layer.v1+tar"
+	retries=10 run_tool_oras push "${extra_params[@]}" "${image_full_oci}" "${upload_file_name}:application/vnd.unknown.layer.v1+tar"
 	popd &> /dev/null || exit_with_error "Failed to popd" "ORAS upload"
 	return 0
 }

--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -593,35 +593,10 @@ function docker_cli_launch() {
 		display_alert "Docker Log file for this run" "not found" "err"
 	fi
 
-	# Show and help user understand space usage in Docker volumes.
-	# This is done in a loop; `docker df` fails sometimes (for no good reason).
-	# @TODO: this is very, very slow when the volumes are full. disable.
-	# docker_cli_show_armbian_volumes_disk_usage
-
 	docker_exit_code="${docker_build_result}" # set outer scope variable -- do NOT exit with error.
 
 	# return ${docker_build_result}
 	return 0 # always exit with success. caller (CLI) will handle the exit code
-}
-
-function docker_cli_show_armbian_volumes_disk_usage() {
-	display_alert "Gathering docker volumes disk usage" "docker system df, wait..." "debug"
-	sleep_seconds="1" silent_retry="yes" do_with_retries 5 docker_cli_show_armbian_volumes_disk_usage_internal || {
-		display_alert "Could not get Docker volumes disk usage" "docker failed to report disk usage" "warn"
-		return 0 # not really a problem, just move on.
-	}
-	local docker_volume_usage
-	docker_volume_usage="$(docker system df -v | grep -e "^armbian-" | grep -v "\b0B" | tr -s " " | cut -d " " -f 1,3 | tr " " ":" | xargs echo || true)"
-	display_alert "Docker Armbian volume usage" "${docker_volume_usage}" "info"
-}
-
-function docker_cli_show_armbian_volumes_disk_usage_internal() {
-	# This fails sometimes, for no reason. Test it.
-	if docker system df -v &> /dev/null; then
-		return 0
-	else
-		return 1
-	fi
 }
 
 function docker_purge_deprecated_volumes() {

--- a/lib/functions/rootfs/rootfs-create.sh
+++ b/lib/functions/rootfs/rootfs-create.sh
@@ -145,8 +145,9 @@ function create_new_rootfs_cache_via_debootstrap() {
 		chroot_sdcard LC_ALL=C LANG=C setupcon --save --force
 	fi
 
-	# stage: create apt-get sources list (basic Debian/Ubuntu apt sources, no external nor PPAS)
-	create_sources_list "$RELEASE" "$SDCARD/"
+	# stage: create apt-get sources list (basic Debian/Ubuntu apt sources, no external nor PPAS).
+	# for the Armbian repo, only the components which are _not_ produced by armbian/build are included (-desktop and -utils)
+	create_sources_list_and_deploy_repo_key "root" "$RELEASE" "$SDCARD/"
 
 	# optionally add armhf arhitecture to arm64, if asked to do so.
 	if [[ "a${ARMHF_ARCH}" == "ayes" ]]; then

--- a/lib/tools/common/armbian_utils.py
+++ b/lib/tools/common/armbian_utils.py
@@ -218,6 +218,7 @@ def armbian_run_command_and_parse_json_from_stdout(exec_cmd: list[str], params: 
 	result = None
 	logs = []
 	try:
+		log.debug(f"Start calling Armbian command: {' '.join(exec_cmd)}")
 		result = subprocess.run(
 			exec_cmd,
 			stdout=subprocess.PIPE,

--- a/lib/tools/info/download-debs.py
+++ b/lib/tools/info/download-debs.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+# ‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹
+#  SPDX-License-Identifier: GPL-2.0
+#  Copyright (c) 2023 Ricardo Pardini <ricardo@pardini.net>
+#  This file is a part of the Armbian Build Framework https://github.com/armbian/build/
+# ‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹
+import json
+import logging
+import os
+import subprocess
+
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from common import armbian_utils
+
+# Prepare logging
+armbian_utils.setup_logging()
+log: logging.Logger = logging.getLogger("download-debs")
+
+
+def download_using_armbian(exec_cmd: list[str], params: dict):
+	result = None
+	logs = []
+	try:
+		log.debug(f"Start calling Armbian command: {' '.join(exec_cmd)}")
+		result = subprocess.run(
+			exec_cmd,
+			stdout=subprocess.PIPE,
+			check=True,
+			universal_newlines=False,  # universal_newlines messes up bash encoding, don't use, instead decode utf8 manually;
+			bufsize=-1,  # full buffering
+			# Early (pre-param-parsing) optimizations for those in Armbian bash code, so use an ENV (not PARAM)
+			env={
+				"ANSI_COLOR": "none",  # Do not use ANSI colors in logging output, don't write to log files
+				"WRITE_EXTENSIONS_METADATA": "no",  # Not interested in ext meta here
+				"ALLOW_ROOT": "yes",  # We're gonna be calling it as root, so allow it @TODO not the best option
+				"PRE_PREPARED_HOST": "yes"  # We're gonna be calling it as root, so allow it @TODO not the best option
+			},
+			stderr=subprocess.PIPE
+		)
+	except subprocess.CalledProcessError as e:
+		# decode utf8 manually, universal_newlines messes up bash encoding
+		logs = armbian_utils.parse_log_lines_from_stderr(e.stderr)
+		log.error(f"Error calling Armbian command: {' '.join(exec_cmd)}")
+		log.error(f"Error details: params: {params} - return code: {e.returncode} - stderr: {'; '.join(logs)}")
+		return {"in": params, "logs": logs, "download_ok": False}
+
+	if result is not None:
+		if result.stderr:
+			logs = armbian_utils.parse_log_lines_from_stderr(result.stderr)
+
+	info = {"in": params, "download_ok": True}
+	info["logs"] = logs
+	return info
+
+
+# This is called like this:
+# /usr/bin/python3 /armbian/lib/tools/info/download-debs.py /armbian/output/info/debs-to-repo-info.json /armbian/output/debs
+
+debs_info_json_path = sys.argv[1]
+debs_output_dir = sys.argv[2]
+
+# read the json file
+with open(debs_info_json_path) as f:
+	artifact_debs = json.load(f)
+
+log.info("Downloading debs...")
+# loop over the debs. if we're missing any, download them.
+missing_debs = []
+missing_invocations = []
+for artifact in artifact_debs:
+	is_missing_deb = False
+	for key in artifact["debs"]:
+		deb = artifact["debs"][key]
+		relative_deb_path = deb["relative_deb_path"]
+		deb_path = os.path.join(debs_output_dir, relative_deb_path)
+		if not os.path.isfile(deb_path):
+			log.info(f"Missing deb: {deb_path}")
+			missing_debs.append(deb_path)
+			is_missing_deb = True
+	if is_missing_deb:
+		missing_invocations.append(artifact["download_invocation"])
+
+log.info(f"Missing debs: {len(missing_debs)}")
+log.info(f"Missing invocations: {len(missing_invocations)}")
+
+# only actually invoke anything if we're in a container
+# run ./compile.sh <invocation> for each missing invocation
+for invocation in missing_invocations:
+	cmds = ["/armbian/compile.sh"] + invocation
+	log.info(f"Running: {' '.join(cmds)}")
+	if armbian_utils.get_from_env("ARMBIAN_RUNNING_IN_CONTAINER") == "yes":
+		dl_info = download_using_armbian(cmds, {"missing": "deb"})
+		log.info(f"Download info: {dl_info}")

--- a/lib/tools/info/output-debs-to-repo-json.py
+++ b/lib/tools/info/output-debs-to-repo-json.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+
+# ‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹
+#  SPDX-License-Identifier: GPL-2.0
+#  Copyright (c) 2023 Ricardo Pardini <ricardo@pardini.net>
+#  This file is a part of the Armbian Build Framework https://github.com/armbian/build/
+# ‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹
+import json
+import logging
+import os
+
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from common import armbian_utils
+
+# Prepare logging
+armbian_utils.setup_logging()
+log: logging.Logger = logging.getLogger("output-debs-to-repo-json")
+
+
+def generate_deb_summary(info):
+	ret = []
+	for artifact_id in info["artifacts"]:
+		artifact = info["artifacts"][artifact_id]
+
+		# skip = not not artifact["oci"]["up-to-date"]
+		# if skip:
+		#	continue
+
+		artifact_name = artifact['in']['artifact_name']
+
+		desc = f"{artifact['out']['artifact_name']}={artifact['out']['artifact_version']}"
+
+		out = artifact["out"]
+		artifact_type = out["artifact_type"]
+		artifact_version = out["artifact_version"]
+
+		if not (artifact_type == "deb" or artifact_type == "deb-tar"):
+			continue
+
+		all_debs: dict[str, dict] = {}
+
+		artifact_map_debs_keys = out["artifact_map_debs_keys_ARRAY"]
+		artifact_map_debs_values = out["artifact_map_debs_values_ARRAY"]
+		artifact_map_packages_keys = out["artifact_map_packages_keys_ARRAY"]
+		artifact_map_packages_values = out["artifact_map_packages_values_ARRAY"]
+
+		# Sanity check: all those array should have the same amount of elements.
+		if not (len(artifact_map_debs_keys) == len(artifact_map_debs_values) == len(artifact_map_packages_keys) == len(artifact_map_packages_values)):
+			log.error(f"Error: artifact {artifact_id} has different amount of keys and values in the map: {artifact}")
+			continue
+
+		# Sanity check: artifact_map_debs_keys and artifact_map_packages_keys should be the same
+		if not (artifact_map_debs_keys == artifact_map_packages_keys):
+			log.error(f"Error: artifact {artifact_id} has different keys in the map: {artifact}")
+			continue
+
+		for i in range(len(artifact_map_debs_keys)):
+			key = artifact_map_debs_keys[i]
+			# add to all_debs, but check if it's already there
+			if key in all_debs:
+				log.error(f"Error: artifact {artifact_id} has duplicated key {key} in the map: {artifact}")
+				continue
+
+			relative_deb_path = artifact_map_debs_values[i]
+			repo_target = "armbian"
+			# if the relative_deb_path has a slash "/"...
+			if "/" in relative_deb_path:
+				# ...then it's a repo target
+				first_part = relative_deb_path.split("/")[0]
+				repo_target = f'armbian-{first_part}'
+			all_debs[key] = {"relative_deb_path": relative_deb_path, "package_name": (artifact_map_packages_values[i]), "repo_target": repo_target}
+
+		# Aggregate all repo_targets from their debs. There can be only one. Eg: each artifact can only be in one repo_target, no matter how many debs.
+		repo_targets = set()
+		for key in all_debs:
+			repo_targets.add(all_debs[key]["repo_target"])
+		if len(repo_targets) > 1:
+			log.error(f"Error: artifact {artifact_id} has debs in different repo_targets: {artifact}")
+			continue
+
+		repo_target = repo_targets.pop()
+
+		inputs = artifact["in"]["original_inputs"]
+		# get the invocation, in array format. "what do I run to download the debs" for this artifact. args are NOT quoted.
+		invocation = (["download-artifact"] + armbian_utils.map_to_armbian_params(inputs["vars"], False) + inputs["configs"])
+
+		item = {
+			"id": artifact_id, "desc": desc, "artifact_name": artifact_name, "artifact_type": artifact_type, "artifact_version": artifact_version,
+			"repo_target": repo_target,
+			"download_invocation": invocation,
+			"debs": all_debs
+		}
+		ret.append(item)
+	return ret
+
+
+# This is called like this:
+# /usr/bin/python3 /armbian/lib/tools/info/output-debs-to-repo.py /armbian/output/info /armbian/output/info/outdated-artifacts-images.json
+
+# first arg the output directory (output/info)
+info_output_dir = sys.argv[1]
+output_json_file = os.path.join(info_output_dir, "debs-to-repo-info.json")
+outdated_artifacts_image_json_filepath = sys.argv[2]
+
+# read the json file passed as second argument as a json object
+with open(outdated_artifacts_image_json_filepath) as f:
+	info = json.load(f)
+
+artifact_debs = generate_deb_summary(info)
+
+# dump the json to a debs-to-repo-info.json file in the output directory
+with open(output_json_file, "w") as f:
+	json.dump(artifact_debs, f, indent=4)
+
+log.info(f"Done writing {output_json_file}")

--- a/lib/tools/info/output-gha-matrix.py
+++ b/lib/tools/info/output-gha-matrix.py
@@ -112,7 +112,7 @@ def generate_matrix_artifacts(info):
 
 		artifact_name = artifact['in']['artifact_name']
 
-		desc = f"{artifact['out']['artifact_final_file_basename']}"
+		desc = f"{artifact['out']['artifact_name']}={artifact['out']['artifact_version']}"
 
 		inputs = artifact['in']['original_inputs']
 

--- a/lib/tools/info/repo-reprepro.py
+++ b/lib/tools/info/repo-reprepro.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+
+# ‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹
+#  SPDX-License-Identifier: GPL-2.0
+#  Copyright (c) 2023 Ricardo Pardini <ricardo@pardini.net>
+#  This file is a part of the Armbian Build Framework https://github.com/armbian/build/
+# ‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹
+import json
+import logging
+import os
+
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from common import armbian_utils
+
+# Prepare logging
+armbian_utils.setup_logging()
+log: logging.Logger = logging.getLogger("repo-reprepro")
+
+# This is called like this:
+# /usr/bin/python3 /armbian/lib/tools/info/repo-reprero.py /armbian/output/info/debs-to-repo-info.json /armbian/output/info/reprepro /armbian/output/info/reprepro/conf
+
+debs_info_json_path = sys.argv[1]
+reprepro_script_output_dir = sys.argv[2]
+reprepro_conf_output_dir = sys.argv[3]
+
+reprepro_conf_distributions_fn = os.path.join(reprepro_conf_output_dir, f"distributions")
+reprepro_conf_options_fn = os.path.join(reprepro_conf_output_dir, f"options")
+reprepro_output_script_fn = os.path.join(reprepro_script_output_dir, f"reprepro.sh")
+
+# From the environment...
+gpg_keyid = armbian_utils.get_from_env("REPO_GPG_KEYID")
+
+# read the json file
+with open(debs_info_json_path) as f:
+	artifact_debs = json.load(f)
+
+# Now aggregate all repo_targets and their artifacts.
+# This will be used to generate the reprepro config file.
+repo_targets: dict[str, list] = {}
+for artifact in artifact_debs:
+	one_repo_target = artifact["repo_target"]
+	if one_repo_target not in repo_targets:
+		repo_targets[one_repo_target] = []
+	repo_targets[one_repo_target].append(artifact)
+
+# for each target
+log.info(f"Generating repo config...")
+
+all_distro_lines: list[str] = []
+for one_repo_target in repo_targets:
+	distro_dict: dict[str, str] = {}
+	distro_dict["Origin"] = f"Armbian  origin {one_repo_target}"
+	distro_dict["Label"] = f"Armbian label {one_repo_target}"
+	distro_dict["Codename"] = f"{one_repo_target}"
+	distro_dict["Suite"] = f"{one_repo_target}"
+	distro_dict["Architectures"] = "amd64 armhf arm64 riscv64"
+	distro_dict["Components"] = "main"
+	distro_dict["Description"] = f"Apt repository for Armbian"
+	if (gpg_keyid is not None) and (gpg_keyid != ""):
+		log.warning(f'Using REPO_GPG_KEYID from environment: {gpg_keyid}')
+		distro_dict["SignWith"] = gpg_keyid
+	else:
+		log.warning(f"Didn't get REPO_GPG_KEYID from environment. Will not sign the repo.")
+
+	for key in distro_dict:
+		all_distro_lines.append(f"{key}: {distro_dict[key]}")
+	all_distro_lines.append("")
+
+# create the reprerepo distributions file for the target
+with open(reprepro_conf_distributions_fn, "w") as f:
+	for line in all_distro_lines:
+		log.info(f"| {line}")
+		f.write(f"{line}\n")
+log.info(f"Wrote {reprepro_conf_distributions_fn}")
+
+options: list[str] = []
+options.append("verbose")
+# options.append(f"basedir /armbian/output/repos/single-dir")
+
+# create the reprerepo options file for the target
+with open(reprepro_conf_options_fn, "w") as f:
+	for option in options:
+		f.write(f"{option}\n")
+log.info(f"Wrote {reprepro_conf_options_fn}")
+
+# Prepare the reprepro-invoking bash script
+bash_lines = [
+	"#!/bin/bash",
+	"set",
+	'ls -laR "${INCOMING_DEBS_DIR}"'
+]
+
+# Copy the config files to the repo dir (from REPREPRO_INFO_DIR/conf to REPO_CONF_LOCATION script-side)
+bash_lines.append('mkdir -p "${REPO_CONF_LOCATION}"')
+bash_lines.append('cp -rv "${REPREPRO_INFO_DIR}/conf"/* "${REPO_CONF_LOCATION}"/')
+
+for one_repo_target in repo_targets:
+	artifacts = repo_targets[one_repo_target]
+	log.info(f"Artifacts for target '{one_repo_target}': {len(artifacts)}")
+	all_debs_to_include: list[str] = []
+	# for each artifact
+	for artifact in artifacts:
+		# for each deb
+		for key in artifact["debs"]:
+			deb = artifact["debs"][key]
+			relative_deb_path = deb["relative_deb_path"]
+			all_debs_to_include.append(relative_deb_path)
+
+	all_debs_to_include_quoted = ['"${INCOMING_DEBS_DIR}/' + x + '"' for x in all_debs_to_include]
+
+	if len(all_debs_to_include) > 0:
+		# add all debs to the repop
+		cmds = ["reprepro", "-b", '"${REPO_LOCATION}"', "--component", "main", "includedeb", one_repo_target] + all_debs_to_include_quoted
+		bash_lines.append(f"echo 'reprepro importing {len(all_debs_to_include_quoted)} debs for target {one_repo_target}...' ")
+		bash_lines.append(" ".join(cmds))
+
+# Always export at the end
+export_cmds = ["reprepro", "-b", '"${REPO_LOCATION}"', "export"]
+bash_lines.append(f"echo 'reprepro exporting...' ")
+bash_lines.append(" ".join(export_cmds))
+
+with open(reprepro_output_script_fn, "w") as f:
+	for line in bash_lines:
+		f.write(f"{line}\n")
+
+log.info(f"Wrote {reprepro_output_script_fn}")


### PR DESCRIPTION
#### rpardini's mid-may/`23 pipeline fixes, debs-to-repo, rootfs-repo de-chicken-egg-ize

> General fixes for GHA/pipelines, produced debs, etc

- export-logs: add GHA output for logs_url (when SHARE_LOG=yes)
- github-actions: more logging for GHA actions outputs
- oci-oras: retry harder, and sleep for more time, if push failed
- artifacts(debs): include `DEBIAN/md5sums` and a correct `Installed-Size:` field in `DEBIAN/control` (for _all_ debs)
- artifacts(debs): rationalize "bash hash" creation with new `calculate_hash_for_bash_deb_artifact()` helper
- kernel-debs: include "Priority: optional" in all kernel debs (all other packages have it...)
  - also for `fake_ubuntu_advantage_tools`
    - also include "Section: " missing for advantage
- artifacts-obtain: deb-tar: don't download .tar again if .debs are in-disk; delete .tar after extracting
- artifacts: include the artifact maps info (debs/packages) both as keys and values in the artifact JSON info
  - this is valuable for the debs-to-repo process; we can now know which exact .debs are produced, and all the ways we can refer to them
- docker: remove dead code

> `debs-to-repo` and `download-artifacts`; those are mostly ready, but might need to be made parallel for speedyness. Not required, also not impacting. Works with reprepro for now

- pipeline: `debs-to-repo` (v7, working with reprepro)
  - pipeline: artifacts: use better description for artifacts (artifact_name+artifact_version instead of artifact_final_file_basename)
- artifacts: `download-artifact` CLI. makes sure to only used local .deb, or download from OCI, never build

> Remove chicken-egg from rootfs vs repo

- rootfs/image: introduce new hook `custom_apt_repo()` (hashed into rootfs version); deploy different repo components/custom repos depending on rootfs or image
  - rationale: we don't want an eternal chicken-egg problem with rootfs vs repo.
    - but, desktop rootfs require some parts of repo. case in point: `system-monitoring-center`
      - so only add certain components of repo (-desktop, -utils) to rootfs so that is honored
  - introduce `custom_apt_repo()` hook for extensions to add their repos as well
    - same chicken-egg-avoiding is possible via param `CUSTOM_REPO_WHEN`
