### PR TITLE
armhf also supports i3wm desktop

### DIFF
--- a/config/desktop/focal/environments/i3-wm/architectures
+++ b/config/desktop/focal/environments/i3-wm/architectures
@@ -1,1 +1,1 @@
-arm64, amd64
+armhf, arm64, amd64


### PR DESCRIPTION
# Description

Enable i3wm also on armhf architecture. It works.

Jira reference number [AR-1708]

# How Has This Been Tested?

- [x] Build Jammy bananapi i3
- [x] Build bookworm banana i3

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1708]: https://armbian.atlassian.net/browse/AR-1708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ