### PR TITLE
change radxa uboot branch to next-dev

### DIFF
--- a/config/sources/families/rockchip-rk3588.conf
+++ b/config/sources/families/rockchip-rk3588.conf
@@ -9,7 +9,7 @@
 source "${BASH_SOURCE%/*}/include/rockchip64_common.inc"
 
 BOOTSOURCE='https://github.com/radxa/u-boot.git'
-BOOTBRANCH='branch:stable-5.10-rock5'
+BOOTBRANCH='branch:next-dev'
 BOOTPATCHDIR="legacy/u-boot-radxa-rk3588"
 OVERLAY_PREFIX='rockchip-rk3588'
 ROCKUSB_BLOB="rk35/rk3588_spl_loader_v1.08.111.bin"


### PR DESCRIPTION
# Description

The old branch https://github.com/radxa/u-boot/tree/stable-5.10-rock5 is not updated since Feb 2023, and radxa changes to a new branch [next-dev](https://github.com/radxa/u-boot/tree/next-dev) which has merged a lot of commits from rockchip. Radxa is now working at next-dev for rk3588 devices.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Build and test on rock5b

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
