### PR TITLE
Disable debugging on packages install

### DIFF
--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -174,7 +174,7 @@ function kernel_package_hook_helper() {
 			return 1
 		}
 
-		set -x # Debugging
+		#set -x # Debugging
 
 		$(cat "${contents}")
 

--- a/lib/functions/compilation/packages/utils-dpkgdeb.sh
+++ b/lib/functions/compilation/packages/utils-dpkgdeb.sh
@@ -132,7 +132,7 @@ function generic_artifact_package_hook_helper() {
 		#!/bin/bash
 		echo "Armbian '${artifact_name:?}' for '${artifact_version:?}': '${script}' starting."
 		set +e # NO ERROR CONTROL, for compatibility with legacy Armbian scripts.
-		set -x # Debugging
+		#set -e # Debugging
 
 		$(echo "${contents}")
 


### PR DESCRIPTION
# Description

Disable excessive debug on packages install. Not really something that we need in production.

Jira reference number [AR-1717]

# How Has This Been Tested?

- [x] Generate image without using pre-cached packages.

[AR-1717]: https://armbian.atlassian.net/browse/AR-1717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ