### PR TITLE
URL for riscv64 is different then expected

### DIFF
--- a/lib/functions/general/apt-utils.sh
+++ b/lib/functions/general/apt-utils.sh
@@ -12,6 +12,7 @@ function apt_find_upstream_package_version_and_download_url() {
 	declare -a package_info_download_urls=()
 	declare first_letter_of_sought_package_name="${sought_package_name:0:1}"
 	declare mirror_with_slash="undetermined/"
+	declare pool_name_extension=""
 
 	case "${DISTRIBUTION}" in
 		Ubuntu) # try both the jammy-updates and jammy repos, use whatever returns first
@@ -23,6 +24,7 @@ function apt_find_upstream_package_version_and_download_url() {
 		Debian)
 			package_info_download_urls+=("https://packages.debian.org/${RELEASE}/${ARCH}/${sought_package_name}/download")
 			mirror_with_slash="${DEBIAN_MIRROR}"
+			[[ "${ARCH}" == riscv64 ]] && pool_name_extension="-riscv64"
 			;;
 
 		*)
@@ -35,7 +37,10 @@ function apt_find_upstream_package_version_and_download_url() {
 		mirror_with_slash="${mirror_with_slash}/"
 	fi
 
-	declare base_down_url="http://${mirror_with_slash}pool/main/${first_letter_of_sought_package_name}/${sought_package_name}"
+	# riscv64 under Debian needs exception
+
+
+	declare base_down_url="http://${mirror_with_slash}pool${pool_name_extension}/main/${first_letter_of_sought_package_name}/${sought_package_name}"
 
 	declare index package_info_download_url
 	# loop over the package_info_download_urls with index and value


### PR DESCRIPTION
# Description

beaglev, edge, sid, cli, ubuntu-latest
error! Could not download 'http://deb.debian.org/debian-ports/pool/main/b/base-files/base-files_12.4_riscv64.deb'

https://deb.debian.org/debian-ports/pool -> pool-riscv64

Jira reference number [AR-1733]

# How Has This Been Tested?

- [x] Manual rebuild

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1733]: https://armbian.atlassian.net/browse/AR-1733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ