### PR TITLE
armbian-zsh: use fixed commit for ohmyzsh; was using very high traffic 'master' branch

### DIFF
--- a/lib/functions/artifacts/artifact-armbian-zsh.sh
+++ b/lib/functions/artifacts/artifact-armbian-zsh.sh
@@ -16,8 +16,8 @@ function artifact_armbian-zsh_prepare_version() {
 	artifact_version="undetermined"        # outer scope
 	artifact_version_reason="undetermined" # outer scope
 
-	local ARMBIAN_ZSH_SOURCE="${ARMBIAN_ZSH_SOURCE:-"https://github.com/ohmyzsh/ohmyzsh"}"
-	local ARMBIAN_ZSH_BRANCH="branch:${ARMBIAN_ZSH_BRANCH:-"master"}"
+	declare -g ARMBIAN_ZSH_SOURCE="${ARMBIAN_ZSH_SOURCE:-"https://github.com/ohmyzsh/ohmyzsh"}"
+	declare -g ARMBIAN_ZSH_BRANCH="commit:bfeeda1491b5366aa5798a86cf6f3621536b171c" # 2023-05-21, update this once in a while
 
 	debug_var ARMBIAN_ZSH_SOURCE
 	debug_var ARMBIAN_ZSH_BRANCH

--- a/lib/functions/compilation/packages/armbian-zsh-deb.sh
+++ b/lib/functions/compilation/packages/armbian-zsh-deb.sh
@@ -9,6 +9,7 @@
 
 compile_armbian-zsh() {
 	: "${artifact_version:?artifact_version is not set}"
+	: "${ARMBIAN_ZSH_BRANCH:?ARMBIAN_ZSH_BRANCH is not set}"
 
 	declare cleanup_id="" tmp_dir=""
 	prepare_temp_dir_in_workdir_and_schedule_cleanup "deb-zsh" cleanup_id tmp_dir # namerefs
@@ -16,7 +17,7 @@ compile_armbian-zsh() {
 	declare armbian_zsh_dir="armbian-zsh"
 	mkdir -p "${tmp_dir}/${armbian_zsh_dir}"
 
-	fetch_from_repo "$GITHUB_SOURCE/ohmyzsh/ohmyzsh" "oh-my-zsh" "branch:master"
+	fetch_from_repo "$GITHUB_SOURCE/ohmyzsh/ohmyzsh" "oh-my-zsh" "${ARMBIAN_ZSH_BRANCH}"
 	fetch_from_repo "$GITHUB_SOURCE/mroth/evalcache" "evalcache" "branch:master"
 
 	mkdir -p "${tmp_dir}/${armbian_zsh_dir}"/{DEBIAN,etc/skel/,etc/oh-my-zsh/,/etc/skel/.oh-my-zsh/cache}


### PR DESCRIPTION
#### armbian-zsh: use fixed commit for ohmyzsh; was using very high traffic 'master' branch

- upstream has no branches, no tags, only way to quiesce this is via `commit:<sha1>`