### PR TITLE
rk3399: fix again OrangePi 4 LTS sdcard detection

### DIFF
--- a/patch/kernel/archive/rockchip64-6.1/add-board-orangepi-4-lts.patch
+++ b/patch/kernel/archive/rockchip64-6.1/add-board-orangepi-4-lts.patch
@@ -1,9 +1,19 @@
+From 4af18a7595fc0bf36b91867217ac1bfbb7e5503f Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Sun, 21 May 2023 17:35:55 +0200
+Subject: [PATCH] rk3399: add Orange Pi 4 LTS device tree
+
+---
+ .../dts/rockchip/rk3399-orangepi-4-lts.dts    | 1244 +++++++++++++++++
+ 1 file changed, 1244 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3399-orangepi-4-lts.dts
+
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4-lts.dts b/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4-lts.dts
 new file mode 100644
-index 00000000000..43f081ec1ab
+index 000000000000..0a4abf995e4b
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4-lts.dts
-@@ -0,0 +1,1254 @@
+@@ -0,0 +1,1244 @@
 +/*
 + * SPDX-License-Identifier: (GPL-2.0+ or MIT)
 + * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd.
@@ -123,7 +133,7 @@ index 00000000000..43f081ec1ab
 +		enable-active-high;
 +		gpio = <&gpio0 RK_PA1 GPIO_ACTIVE_HIGH>;
 +		pinctrl-names = "default";
-+		pinctrl-0 = <&sdmmc0_pwr_h>;
++		pinctrl-0 = <&sdmmc_pwr>;
 +		regulator-name = "vcc3v0_sd";
 +		regulator-always-on;
 +		regulator-min-microvolt = <3000000>;
@@ -955,7 +965,7 @@ index 00000000000..43f081ec1ab
 +	disable-wp;
 +	max-frequency = <150000000>;
 +	pinctrl-names = "default";
-+	pinctrl-0 = <&sdmmc_bus4 &sdmmc_clk &sdmmc_cmd &sdmmc0_det_l>;
++	pinctrl-0 = <&sdmmc_bus4 &sdmmc_clk &sdmmc_cmd &sdmmc_cd>;
 +	sd-uhs-sdr104;
 +	vmmc-supply = <&vcc3v0_sd>;
 +	vqmmc-supply = <&vcc_sdio>;
@@ -1113,16 +1123,6 @@ index 00000000000..43f081ec1ab
 +		};
 +	};
 +
-+	sdmmc {
-+		sdmmc0_det_l: sdmmc0-det-l {
-+			rockchip,pins = <0 RK_PA7 RK_FUNC_GPIO &pcfg_pull_up>;
-+		};
-+
-+		sdmmc0_pwr_h: sdmmc0-pwr-h {
-+			rockchip,pins = <0 RK_PA1 RK_FUNC_GPIO &pcfg_pull_up>;
-+		};
-+	};
-+
 +	usb-typec {
 +		vcc5v0_typec_en: vcc5v0_typec_en {
 +			rockchip,pins = <2 RK_PB4 RK_FUNC_GPIO &pcfg_pull_up>;
@@ -1258,3 +1258,6 @@ index 00000000000..43f081ec1ab
 +&dfi {
 +	status = "okay";
 +};
+-- 
+2.34.1
+

--- a/patch/kernel/archive/rockchip64-6.1/rk3399-sd-pwr-pinctrl.patch
+++ b/patch/kernel/archive/rockchip64-6.1/rk3399-sd-pwr-pinctrl.patch
@@ -1,0 +1,28 @@
+From b64beb18f2beb3d1188dd19fb0411687065a35ea Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Sun, 21 May 2023 13:14:26 +0200
+Subject: [PATCH] rk3399: add sd power pin to pinctrl node
+
+---
+ arch/arm64/boot/dts/rockchip/rk3399.dtsi | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399.dtsi b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
+index 59858f2dc8b9..b4ec5ffdbf8a 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
+@@ -2526,6 +2526,11 @@ sdmmc_wp: sdmmc-wp {
+ 				rockchip,pins =
+ 					<0 RK_PB0 1 &pcfg_pull_up>;
+ 			};
++
++			sdmmc_pwr: sdmmc-pwr {
++				rockchip,pins =
++					<0 RK_PA1 1 &pcfg_pull_up>;
++			};
+ 		};
+ 
+ 		suspend {
+-- 
+2.34.1
+


### PR DESCRIPTION
# Description

Fix (again) Orange Pi 4 LTS detection at boot.
This PR adds a `sdmmc-pwr` node in rk3399 base device tree and removes the `sdmmc0-*` nodes from the board dts.

For some reason, the alternate function RK_FUNC_GPIO (which evaluates to 0) from legacy kernel has to become 1 (one) on mainline device tree.

This should not interfere with other boards, since a node is added in the base rk3399 device tree

Jira reference number [AR-1742]

# How Has This Been Tested?

- [x] Compilation of kernel/dtb package
- [x] Test automatic reboot on living system for several hours, didn't miss a reboot :pray: 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1742]: https://armbian.atlassian.net/browse/AR-1742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ