### PR TITLE
`git-ref2info`: `source.denx.de` is a GitLab instance, add it to the selector

### DIFF
--- a/lib/functions/general/git-ref2info.sh
+++ b/lib/functions/general/git-ref2info.sh
@@ -113,7 +113,7 @@ function memoized_git_ref_to_info() {
 					esac
 					;;
 
-				"https://gitlab.com/"*)
+				"https://gitlab.com/"* | "https://source.denx.de/"*)
 					# GitLab is more complex than GitHub, there can be more levels.
 					# This code is incomplete... but it works for now.
 					# Example: input:  https://gitlab.com/rk3588_linux/rk/kernel.git


### PR DESCRIPTION
#### git-ref2info: `source.denx.de` is a GitLab instance, add it to the selector

See #5168 