### PR TITLE
`rpi4b`/`bcm2711`: introduce `RPI_DEBUG_CONSOLE=yes` which at once disables bt, enables uart, and adds ttyAMA0

### DIFF
--- a/config/boards/rpi4b.conf
+++ b/config/boards/rpi4b.conf
@@ -14,9 +14,16 @@ pre_umount_final_image__remove_esp() {
 
 # configure stuff at the appropriate time in flash-kernel
 pre_initramfs_flash_kernel__write_raspi_config() {
-	# for serial console, there is also 'BOOT_UART=1' in 'rpi-eeprom-config' but that is for an earlier stage.
-	# look at with it rpi-eeprom-config, change with 'EDITOR=nano rpi-eeprom-config --edit'
-	cat <<-EOD >"${FIRMWARE_DIR}/config.txt"
+	declare comment_if_debug=""
+	declare not_comment_if_debug="#"
+	if [[ "${RPI_DEBUG_CONSOLE}" != "yes" ]]; then
+		comment_if_debug="#"
+		not_comment_if_debug=""
+		# for serial console, there is also 'BOOT_UART=1' in 'rpi-eeprom-config' but that is for an earlier stage.
+		# look at with it rpi-eeprom-config, change with 'EDITOR=nano rpi-eeprom-config --edit'
+	fi
+
+	cat <<- EOD > "${FIRMWARE_DIR}/config.txt"
 		[pi4]
 		max_framebuffers=2
 		over_voltage=2
@@ -35,7 +42,7 @@ pre_initramfs_flash_kernel__write_raspi_config() {
 		dtparam=audio=on
 
 		# bootloader logs to serial, second stage
-		# enable_uart=1
+		${not_comment_if_debug}enable_uart=1
 
 		# overclock. requires decent thermals. COMMENT OUT IF DON'T USE A GREAT COOLER OR HEATSINK.
 		# over_voltage=6
@@ -43,7 +50,7 @@ pre_initramfs_flash_kernel__write_raspi_config() {
 
 		# uncomment to disable wifi or bt.
 		#dtoverlay=disable-wifi
-		#dtoverlay=disable-bt
+		${comment_if_debug}dtoverlay=disable-bt
 
 		# gpu and 3d stuff.
 		gpu_mem=256

--- a/config/sources/families/bcm2711.conf
+++ b/config/sources/families/bcm2711.conf
@@ -52,9 +52,15 @@ case "${BRANCH}" in
 esac
 
 pre_initramfs_flash_kernel__write_raspi_cmdline() {
-	cat <<- EOD > "${FIRMWARE_DIR}/cmdline.txt"
-		root=LABEL=${ROOT_FS_LABEL} rootfstype=ext4 rootwait fixrtc cgroup_enable=memory cgroup_memory=1 console=tty1 logo.nologo loglevel=1
-	EOD
+	if [[ "${RPI_DEBUG_CONSOLE}" == "yes" ]]; then
+		cat <<- EOD > "${FIRMWARE_DIR}/cmdline.txt"
+			root=LABEL=${ROOT_FS_LABEL} rootfstype=ext4 rootwait fixrtc cgroup_enable=memory cgroup_memory=1 console=tty1 console=ttyAMA0 loglevel=7 splash=verbose
+		EOD
+	else
+		cat <<- EOD > "${FIRMWARE_DIR}/cmdline.txt"
+			root=LABEL=${ROOT_FS_LABEL} rootfstype=ext4 rootwait fixrtc cgroup_enable=memory cgroup_memory=1 console=tty1 logo.nologo loglevel=1 splash=verbose
+		EOD
+	fi
 }
 
 pre_flash_kernel__symlink_dtb_and_kernel() {


### PR DESCRIPTION
#### `rpi4b`/`bcm2711`: introduce `RPI_DEBUG_CONSOLE=yes` which at once disables bt, enables uart, and adds ttyAMA0

> Enabling uart debug on rpi4b requires a bunch of seemingly unrelated changes. The UART stuff on bcm is a bit cuckoo. 