### PR TITLE
artifacts: introduce `calculate_hash_for_variables()` which normalizes the input; use in kernel/uboot/etc

### DIFF
--- a/lib/functions/artifacts/artifact-armbian-bsp-cli.sh
+++ b/lib/functions/artifacts/artifact-armbian-bsp-cli.sh
@@ -52,10 +52,9 @@ function artifact_armbian-bsp-cli_prepare_version() {
 		"${KERNEL_IMAGE_TYPE}"              # /etc/armbian-release
 		"${VENDOR}"                         # /etc/armbian-release
 	)
-	declare hash_vars="undetermined"
-	hash_vars="$(echo "${vars_to_hash[@]}" | sha256sum | cut -d' ' -f1)"
-	vars_config_hash="${hash_vars}"
-	declare var_config_hash_short="${vars_config_hash:0:${short_hash_size}}"
+	declare hash_variables="undetermined" # will be set by calculate_hash_for_variables(), which normalizes the input
+	calculate_hash_for_variables "${vars_to_hash[@]}"
+	declare var_config_hash_short="${hash_variables:0:${short_hash_size}}"
 
 	declare -a dirs_to_hash=(
 		"${SRC}/packages/bsp/common" # common stuff

--- a/lib/functions/artifacts/artifact-armbian-desktop.sh
+++ b/lib/functions/artifacts/artifact-armbian-desktop.sh
@@ -10,6 +10,11 @@
 function artifact_armbian-desktop_config_dump() {
 	artifact_input_variables[RELEASE]="${RELEASE}"
 	artifact_input_variables[DESKTOP_ENVIRONMENT]="${DESKTOP_ENVIRONMENT}"
+
+	# Include a hash of the results of aggregation.
+	declare aggregation_hash="undetermined"
+	aggregation_hash="$(echo "${AGGREGATED_DESKTOP_POSTINST} ${AGGREGATED_DESKTOP_CREATE_DESKTOP_PACKAGE} ${AGGREGATED_PACKAGES_DESKTOP_COMMA}" | sha256sum | cut -d' ' -f1)"
+	artifact_input_variables[DESKTOP_AGGREGATION_RESULTS]="${aggregation_hash}"
 }
 
 function artifact_armbian-desktop_prepare_version() {
@@ -32,10 +37,9 @@ function artifact_armbian-desktop_prepare_version() {
 		"${AGGREGATED_DESKTOP_CREATE_DESKTOP_PACKAGE}"
 		"${AGGREGATED_PACKAGES_DESKTOP_COMMA}"
 	)
-	declare hash_vars="undetermined"
-	hash_vars="$(echo "${vars_to_hash[@]}" | sha256sum | cut -d' ' -f1)"
-	vars_config_hash="${hash_vars}"
-	declare var_config_hash_short="${vars_config_hash:0:${short_hash_size}}"
+	declare hash_variables="undetermined"                                        # will be set by calculate_hash_for_variables()...
+	do_normalize_src_path="no" calculate_hash_for_variables "${vars_to_hash[@]}" # ... where do_normalize_src_path="yes" is the default
+	declare var_config_hash_short="${hash_variables:0:${short_hash_size}}"
 
 	# get the hashes of the lib/ bash sources involved...
 	declare hash_files="undetermined"

--- a/lib/functions/artifacts/artifact-kernel.sh
+++ b/lib/functions/artifacts/artifact-kernel.sh
@@ -138,10 +138,9 @@ function artifact_kernel_prepare_version() {
 		"${NAME_KERNEL}"
 		"${SRC_LOADADDR}"
 	)
-	declare hash_vars="undetermined"
-	hash_vars="$(echo "${vars_to_hash[@]}" | sha256sum | cut -d' ' -f1)"
-	vars_config_hash="${hash_vars}"
-	declare var_config_hash_short="${vars_config_hash:0:${short_hash_size}}"
+	declare hash_variables="undetermined" # will be set by calculate_hash_for_variables(), which normalizes the input
+	calculate_hash_for_variables "${vars_to_hash[@]}"
+	declare var_config_hash_short="${hash_variables:0:${short_hash_size}}"
 
 	# Hash the extension hooks
 	declare -a extension_hooks_to_hash=("pre_package_kernel_image")

--- a/lib/functions/artifacts/artifact-uboot.sh
+++ b/lib/functions/artifacts/artifact-uboot.sh
@@ -80,12 +80,13 @@ function artifact_uboot_prepare_version() {
 
 	# Hash variables that affect the build and package of u-boot
 	declare -a vars_to_hash=(
-		"${BOOTDELAY}" "${UBOOT_DEBUGGING}" "${UBOOT_TARGET_MAP}"
+		"${BOOTDELAY}" "${UBOOT_DEBUGGING}" "${UBOOT_TARGET_MAP}" # general for all families
+		"${BOOT_SCENARIO}" "${BOOT_SUPPORT_SPI}" "${BOOT_SOC}"    # rockchip stuff, sorry.
+		"${ATF_COMPILE}" "${ATFBRANCH}" "${ATFPATCHDIR}"          # arm-trusted-firmware stuff
 	)
-	declare hash_vars="undetermined"
-	hash_vars="$(echo "${vars_to_hash[@]}" | sha256sum | cut -d' ' -f1)"
-	declare vars_config_hash="${hash_vars}"
-	declare var_config_hash_short="${vars_config_hash:0:${short_hash_size}}"
+	declare hash_variables="undetermined" # will be set by calculate_hash_for_variables(), which normalizes the input
+	calculate_hash_for_variables "${vars_to_hash[@]}"
+	declare var_config_hash_short="${hash_variables:0:${short_hash_size}}"
 
 	# get the hashes of the lib/ bash sources involved...
 	declare hash_files="undetermined"

--- a/lib/functions/general/hash-files.sh
+++ b/lib/functions/general/hash-files.sh
@@ -99,3 +99,22 @@ function calculate_hash_for_function_bodies() {
 	fi
 	return 0
 }
+
+# helper, for calculating hash of variables.
+# such variables might contain paths, so we need to relativize them to SRC.
+# outer scope: declare hash_variables="undetermined"
+function calculate_hash_for_variables() {
+	hash_variables="undetermined" # outer scope
+	declare -a values_to_hash=("$@")
+
+	declare all_values="${values_to_hash[*]}" # expand...
+	if [[ "${do_normalize_src_path:-"yes"}" == "yes" ]]; then
+		all_values="${all_values//${SRC}/}" # remove all occurences of ${SRC} from all_values
+	fi
+
+	hash_variables="$(echo "${all_values}" | sha256sum | cut -d' ' -f1)" # outer scope
+	display_alert "calculate_hash_for_variables normalized" "${all_values}" "debug"
+	display_alert "calculate_hash_for_variables hashed" "${hash_variables}" "debug"
+
+	return 0
+}


### PR DESCRIPTION
#### artifacts: introduce `calculate_hash_for_variables()` which normalizes the input; use in kernel/uboot/etc

> Does not look like it, but this is a **bugfix** -- UBOOT_TARGET_MAP might contain $SRC (due to BL31=, etc) and that is hashed into something only ever matches by accident
> Also fixes artifact-armbian-desktop vs appgroups/config_base differences

- some hashed variables might contain "${SRC}", so hashes never match, unless built in Docker
  - this strips away SRC from all vars and adds debugging so we can detect more later.
- `artifact-uboot`: include more variables into hash, for ATF & rk stuff 
- `artifact-armbian-desktop`:
  - hashed vars actually contain /armbian in different context, skip normalization in this case
  - include results of relevant aggregation into artifact_input_variables
    - otherwise: desktops with different appgroups/configs lead to build failures in pipeline
    - will cause warnings in JSON preparation step, if more than one appgroups/config combo is targeted, since repo can only have one