### PR TITLE
rootfs-to-image: find, warn, and remove dangling symlinks in FAT32 `/boot`

### DIFF
--- a/lib/functions/image/rootfs-to-image.sh
+++ b/lib/functions/image/rootfs-to-image.sh
@@ -59,9 +59,19 @@ function create_image_from_sdcard_rootfs() {
 	# stage: rsync /boot
 	display_alert "Copying files to" "/boot (MOUNT /boot)"
 	if [[ $(findmnt --noheadings --output FSTYPE --target "$MOUNT/boot" --uniq) == vfat ]]; then
+		# FAT filesystems can't have symlinks; rsync, below, will replace them with copies (-L)...
+		# ... unless they're dangling symlinks, in which case rsync will fail.
+		# Find dangling symlinks in "$MOUNT/boot", warn, and remove them.
+		display_alert "Checking for dangling symlinks" "in FAT32 /boot" "info"
+		declare -a dangling_symlinks=()
+		while IFS= read -r -d '' symlink; do
+			dangling_symlinks+=("$symlink")
+		done < <(find "$SDCARD/boot" -xtype l -print0)
+		if [[ ${#dangling_symlinks[@]} -gt 0 ]]; then
+			display_alert "Dangling symlinks in /boot" "$(printf '%s ' "${dangling_symlinks[@]}")" "warning"
+			run_host_command_logged rm -fv "${dangling_symlinks[@]}"
+		fi
 		run_host_command_logged rsync -rLtWh --info=progress0,stats1 "$SDCARD/boot" "$MOUNT" # fat32
-		# @TODO: -L causes symlinks to be replaced with copies, but what if they don't exist?
-		# Also: what's the sense in replacing symlinks with copies?
 	else
 		run_host_command_logged rsync -aHWXh --info=progress0,stats1 "$SDCARD/boot" "$MOUNT" # ext4
 	fi


### PR DESCRIPTION
#### rootfs-to-image: find, warn, and remove dangling symlinks in FAT32 `/boot`

> otherwise rsync gags.
> it should _not_  happen, but if it does, we get a nice warning now