### PR TITLE
sanity check: warn if any deb artifacts' actually-installed version does not match artifact-built version

### DIFF
--- a/lib/functions/main/build-packages.sh
+++ b/lib/functions/main/build-packages.sh
@@ -92,11 +92,13 @@ function main_default_build_packages() {
 	# Store info about all artifacts in the process, for later use (eg during package installation in distro-agnostic).
 	declare -g -a image_artifacts_all=()
 	declare -g -A image_artifacts_packages=()
+	declare -g -A image_artifacts_packages_version=()
 	declare -g -A image_artifacts_debs=()
 	declare one_artifact one_artifact_package
 	for one_artifact in "${artifacts_to_build[@]}"; do
 		declare -A artifact_map_packages=()
 		declare -A artifact_map_debs=()
+		declare artifact_version
 
 		WHAT="${one_artifact}" build_artifact_for_image
 
@@ -105,11 +107,13 @@ function main_default_build_packages() {
 			image_artifacts_all+=("${one_artifact_package}")
 			image_artifacts_packages["${one_artifact_package}"]="${artifact_map_packages[${one_artifact_package}]}"
 			image_artifacts_debs["${one_artifact_package}"]="${artifact_map_debs[${one_artifact_package}]}"
+			image_artifacts_packages_version["${artifact_map_packages[${one_artifact_package}]}"]="${artifact_version}"
 		done
 	done
 
 	debug_dict image_artifacts_packages
 	debug_dict image_artifacts_debs
+	debug_dict image_artifacts_packages_version
 
 	overlayfs_wrapper "cleanup"
 	reset_uid_owner "${DEB_STORAGE}"


### PR DESCRIPTION
#### image: sanity check: warn if any deb artifacts' actually-installed version does not match artifact-built version

> - this catches problems with outdated/crazy repos, customize doing wrong things, wrong pinning, etc

To be clear: this only adds _warnings_ so we can know when crazy stuff is happening.