### PR TITLE
batch of rk3588 boards/fixes (`khadas-edge2`, `mekotronics`'s) - late May/23

### DIFF
--- a/config/boards/khadas-edge2.wip
+++ b/config/boards/khadas-edge2.wip
@@ -1,20 +1,18 @@
 # Rockchip RK3588s 2GB-16GB GBE eMMC NVMe SATA USB3 WiFi
-BOARD_NAME="Khadas EDGE2"
-BOARDFAMILY="media"
-BOOT_SOC="rk3588"
-BOOTCONFIG="khadas-edge2-rk3588s_defconfig"
-KERNEL_TARGET="legacy"
-FULL_DESKTOP="yes"
-BOOT_LOGO="desktop"
-BOOT_FDT_FILE="rockchip/rk3588s-khadas-edge2.dtb"
-SRC_EXTLINUX="yes"
-SRC_CMDLINE="console=ttyS02,1500000 console=tty0"
-IMAGE_PARTITION_TABLE="gpt"
+declare -g BOARD_NAME="Khadas Edge2"
+declare -g BOARDFAMILY="rockchip-rk3588"
+declare -g BOOT_SOC="rk3588" # Just to avoid errors in rockchip64_commmon
+declare -g KERNEL_TARGET="legacy"
+declare -g IMAGE_PARTITION_TABLE="gpt"
+declare -g BOOT_FDT_FILE="rockchip/rk3588s-khadas-edge2.dtb" # Specific to this board
 
-function post_family_tweaks__khadas-edge-2-firmware() {
-    display_alert "$BOARD" "Installing board tweaks" "info"
+declare -g BLUETOOTH_HCIATTACH_PARAMS="-s 115200 /dev/ttyS9 bcm43xx 1500000" # For the bluetooth-hciattach extension
+enable_extension "bluetooth-hciattach"                                       # Enable the bluetooth-hciattach extension
 
-	cp -R $SRC/packages/blobs/station/firmware/* $SDCARD/lib/firmware/
-
-	return 0
+# for the kedge2, we're counting on the blobs+u-boot in SPI working, as it comes from factory. It does not support bootscripts.
+function post_family_config_branch_legacy__uboot_kedge2() {
+	display_alert "$BOARD" "Configuring ($BOARD) non-u-boot" "info"
+	unset BOOTSOURCE
+	declare -g BOOTCONFIG='none'
+	declare -g SRC_EXTLINUX="yes" # For now, use extlinux. Thanks Monka
 }

--- a/config/boards/mekotronics-r58-minipc.wip
+++ b/config/boards/mekotronics-r58-minipc.wip
@@ -7,12 +7,15 @@ declare -g BOOT_FDT_FILE="rockchip/rk3588-blueberry-minipc-linux.dtb" # Specific
 declare -g BOOT_SCENARIO="spl-blobs"                                  # so we don't depend on defconfig naming convention
 declare -g BOOTCONFIG="mekotronics-r58-rk3588_defconfig"              # patched-in in BOOTPATCHDIR, set below.
 
+declare -g BLUETOOTH_HCIATTACH_PARAMS="-s 115200 /dev/ttyS6 bcm43xx 1500000" # For the bluetooth-hciattach extension
+enable_extension "bluetooth-hciattach"                                       # Enable the bluetooth-hciattach extension
+
 # post_family_config which only runs when branch is legacy. a shortcut, to avoid if's. you're welcome.
 function post_family_config_branch_legacy__uboot_mekotronics() {
 	display_alert "$BOARD" "Configuring Mekotronics R58 ($BOARD) u-boot" "info"
 	declare -g BOOTSOURCE='https://github.com/radxa/u-boot.git'
 	declare -g BOOTBRANCH='branch:stable-5.10-rock5'
 	declare -g OVERLAY_PREFIX='rockchip-rk3588'
-	declare -g BOOTDIR="u-boot-${BOARD}"                    # do not share u-boot directory
-	declare -g BOOTDELAY=1                                  # build injects this into u-boot config. we can then get into UMS mode and avoid the whole rockusb/rkdeveloptool thing
+	declare -g BOOTDIR="u-boot-${BOARD}" # do not share u-boot directory
+	declare -g BOOTDELAY=1               # build injects this into u-boot config. we can then get into UMS mode and avoid the whole rockusb/rkdeveloptool thing
 }

--- a/config/boards/mekotronics-r58x-4g.wip
+++ b/config/boards/mekotronics-r58x-4g.wip
@@ -7,12 +7,15 @@ declare -g BOOT_FDT_FILE="rockchip/rk3588-blueberry-edge-v12-linux.dtb" # Specif
 declare -g BOOT_SCENARIO="spl-blobs"                                    # so we don't depend on defconfig naming convention
 declare -g BOOTCONFIG="mekotronics-r58-rk3588_defconfig"                # patched-in in BOOTPATCHDIR, set below.
 
+declare -g BLUETOOTH_HCIATTACH_PARAMS="-s 115200 /dev/ttyS6 bcm43xx 1500000" # For the bluetooth-hciattach extension
+enable_extension "bluetooth-hciattach"                                       # Enable the bluetooth-hciattach extension
+
 # post_family_config which only runs when branch is legacy. a shortcut, to avoid if's. you're welcome.
 function post_family_config_branch_legacy__uboot_mekotronics() {
 	display_alert "$BOARD" "Configuring Mekotronics R58 ($BOARD) u-boot" "info"
 	declare -g BOOTSOURCE='https://github.com/radxa/u-boot.git'
 	declare -g BOOTBRANCH='branch:stable-5.10-rock5'
 	declare -g OVERLAY_PREFIX='rockchip-rk3588'
-	declare -g BOOTDIR="u-boot-${BOARD}"                    # do not share u-boot directory
-	declare -g BOOTDELAY=1                                  # build injects this into u-boot config. we can then get into UMS mode and avoid the whole rockusb/rkdeveloptool thing
+	declare -g BOOTDIR="u-boot-${BOARD}" # do not share u-boot directory
+	declare -g BOOTDELAY=1               # build injects this into u-boot config. we can then get into UMS mode and avoid the whole rockusb/rkdeveloptool thing
 }

--- a/config/boards/mekotronics-r58x.wip
+++ b/config/boards/mekotronics-r58x.wip
@@ -7,12 +7,15 @@ declare -g BOOT_FDT_FILE="rockchip/rk3588-blueberry-edge-v10-linux.dtb" # Specif
 declare -g BOOT_SCENARIO="spl-blobs"                                    # so we don't depend on defconfig naming convention
 declare -g BOOTCONFIG="mekotronics-r58-rk3588_defconfig"                # patched-in in BOOTPATCHDIR, set below.
 
+declare -g BLUETOOTH_HCIATTACH_PARAMS="-s 115200 /dev/ttyS6 bcm43xx 1500000" # For the bluetooth-hciattach extension
+enable_extension "bluetooth-hciattach"                                       # Enable the bluetooth-hciattach extension
+
 # post_family_config which only runs when branch is legacy. a shortcut, to avoid if's. you're welcome.
 function post_family_config_branch_legacy__uboot_mekotronics() {
 	display_alert "$BOARD" "Configuring Mekotronics R58 ($BOARD) u-boot" "info"
 	declare -g BOOTSOURCE='https://github.com/radxa/u-boot.git'
 	declare -g BOOTBRANCH='branch:stable-5.10-rock5'
 	declare -g OVERLAY_PREFIX='rockchip-rk3588'
-	declare -g BOOTDIR="u-boot-${BOARD}"                    # do not share u-boot directory
-	declare -g BOOTDELAY=1                                  # build injects this into u-boot config. we can then get into UMS mode and avoid the whole rockusb/rkdeveloptool thing
+	declare -g BOOTDIR="u-boot-${BOARD}" # do not share u-boot directory
+	declare -g BOOTDELAY=1               # build injects this into u-boot config. we can then get into UMS mode and avoid the whole rockusb/rkdeveloptool thing
 }

--- a/extensions/bluetooth-hciattach.sh
+++ b/extensions/bluetooth-hciattach.sh
@@ -1,0 +1,69 @@
+#
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (c) 2023 Ricardo Pardini <ricardo@pardini.net>
+# This file is a part of the Armbian Build Framework https://github.com/armbian/build/
+#
+
+# Some boards needs a special treatment for bluetooth, running hciattach manually.
+# To use, enable_extension bluetooth-hciattach, and set BLUETOOTH_HCIATTACH_PARAMS and BLUETOOTH_HCIATTACH_RKFILL_NUM.
+
+function extension_prepare_config__bluetooth_hciattach() {
+	display_alert "${EXTENSION} ${BOARD}" "initializing config" "info"
+
+	# Bomb if BLUETOOTH_HCIATTACH_PARAMS is not set.
+	if [[ -z "${BLUETOOTH_HCIATTACH_PARAMS}" ]]; then
+		exit_with_error "${EXTENSION} ${BOARD} - BLUETOOTH_HCIATTACH_PARAMS is not set - please set in the board file."
+	fi
+
+	# Default BLUETOOTH_HCIATTACH_RKFILL_NUM to 0 if not set.
+	if [[ -z "${BLUETOOTH_HCIATTACH_RKFILL_NUM}" ]]; then
+		declare -g BLUETOOTH_HCIATTACH_RKFILL_NUM=0
+	fi
+}
+
+# Add bluetooth packages to the image (not rootfs cache)
+function post_family_config__bluetooth_hciattach_add_bluetooth_packages() {
+	display_alert "${EXTENSION} ${BOARD}" "adding bluetooth packages to image" "info"
+	add_packages_to_image rfkill bluetooth bluez bluez-tools
+}
+
+# Deploy the script and the systemd service in the BSP. It'll be enabled below in the image.
+function post_family_tweaks_bsp__bluetooth_hciattach_add_systemd_service() {
+	display_alert "${EXTENSION} ${BOARD}" "adding bluetooth hciattach service to BSP" "info"
+	: "${destination:?destination is not set}"
+
+	declare script_dir="/usr/local/sbin"
+	run_host_command_logged mkdir -pv "${destination}${script_dir}"
+	declare script_path="${script_dir}/bluetooth-hciattach.sh"
+
+	cat <<- BT_HCIATTACH_SCRIPT > "${destination}${script_path}"
+		#!/bin/bash
+		rfkill unblock ${BLUETOOTH_HCIATTACH_RKFILL_NUM}
+		hciattach -n ${BLUETOOTH_HCIATTACH_PARAMS}
+	BT_HCIATTACH_SCRIPT
+	run_host_command_logged chmod -v +x "${destination}${script_path}" # Make it executable
+
+	cat <<- BT_HCIATTACH_SYSTEMD_SERVICE > "$destination"/lib/systemd/system/bluetooth-hciattach.service
+		[Unit]
+		Description=${BOARD} Bluetooth HCIAttach fix
+		After=network.target
+		StartLimitIntervalSec=0
+		[Service]
+		Type=simple
+		ExecStart=${script_path}
+
+		[Install]
+		WantedBy=multi-user.target
+	BT_HCIATTACH_SYSTEMD_SERVICE
+
+	return 0
+}
+
+# Enable the service created in the BSP above.
+function post_family_tweaks__bluetooth_hciattach_enable_bt_service_in_image() {
+	display_alert "${EXTENSION} ${BOARD}" "enabling bluetooth hciattach service in the image" "info"
+
+	chroot_sdcard systemctl --no-reload enable "bluetooth-hciattach.service"
+
+	return 0
+}


### PR DESCRIPTION
> New boards & fixes; this de-`media`-fies the `khadas-edge2`

- `khadas-edge2`: switch to `rockchip-rk3588` `legacy` kernel
  - add `bluetooth-hciattach` for working bluetooth
  - most of the work done by @monkaBlyat

- `mekotronics` (all boards): use new `bluetooth-hciattach` extension for out-of-the-box working bluetooth

- `bluetooth-hciattach`: new generic extension to facilitate adding hciattach systemd service, given the correct params
  - this is not specific to rk3588 and can be reused by others


(`rock-5a` was dropped from this PR and will be sent separately)