### PR TITLE
switched from using ifconfig to ip command to set mac address of wlan

### DIFF
--- a/packages/bsp/rockpis/etc/udev/lib/udev/fixEtherAddr
+++ b/packages/bsp/rockpis/etc/udev/lib/udev/fixEtherAddr
@@ -17,5 +17,6 @@ cpuSerialNum() {
   /bin/flock -w2 $nvmem /bin/od -An -vtx1 -j $serNumOffset -N 5 $nvmem
 }
 
-Id=`cpuSerialNum` || exit #fail if Rockchip nvmem not available
-/sbin/ifconfig $1 hw ether $2:`echo $Id | tr ' ' :`
+Id=`cpuSerialNum` && { #fail if Rockchip nvmem not available
+  /sbin/ip link set $1 address $2:`echo $Id | tr ' ' :`
+}


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Jira reference number [AR-1754]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- booted and verified that wlan0's MAC was being derived from the CPU's serial number again

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1754]: https://armbian.atlassian.net/browse/AR-1754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ