### PR TITLE
kernel: drivers: `wireless-rtl8723du-6.3.patch`: don't patch the same thing twice

### DIFF
--- a/patch/misc/wireless-rtl8723du-6.3.patch
+++ b/patch/misc/wireless-rtl8723du-6.3.patch
@@ -19,23 +19,3 @@ index ae4aca0162ce..e57e3ca45d33 100644
  #endif
  #endif
  
-diff --git a/drivers/net/wireless/rtl8723du/os_dep/ioctl_cfg80211.c b/drivers/net/wireless/rtl8723du/os_dep/ioctl_cfg80211.c
-index e57e3ca45d33..01303d253971 100644
---- a/drivers/net/wireless/rtl8723du/os_dep/ioctl_cfg80211.c
-+++ b/drivers/net/wireless/rtl8723du/os_dep/ioctl_cfg80211.c
-@@ -171,10 +171,12 @@ u8 rtw_cfg80211_ch_switch_notify(struct adapter *adapter, u8 ch, u8 bw, u8 offse
- 	if (ret != _SUCCESS)
- 		goto exit;
- 
--#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 2)
--	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef);
--#else
-+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
-+	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef, 0, 0);
-+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5, 19, 2)
- 	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef, 0);
-+#else
-+	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef);
- #endif
- 
- #else


### PR DESCRIPTION
#### kernel: drivers: `wireless-rtl8723du-6.3.patch`: don't patch the same thing twice

> Can't really tell how this happened. Am I missing something, @paolosabatino?

This removes second identical patch in the same file...
