### PR TITLE
`rock-5a`: add support for Rock-5A, WiP, using `rockchip-rk3588` - by @amazingfate

### DIFF
--- a/config/boards/rock-5a.wip
+++ b/config/boards/rock-5a.wip
@@ -1,0 +1,26 @@
+# Rockchip RK3588s SoC octa core 4-16GB SoC eMMC USB3 NvME
+BOARD_NAME="Rock 5A"
+BOARDFAMILY="rockchip-rk3588"
+BOOTCONFIG="rock-5a-rk3588s_defconfig"
+KERNEL_TARGET="legacy,edge"
+FULL_DESKTOP="yes"
+BOOT_LOGO="desktop"
+BOOT_FDT_FILE="rockchip/rk3588s-rock-5a.dtb"
+BOOT_SCENARIO="spl-blobs"
+BOOT_SOC="rk3588"
+WIREGUARD="no"
+BOOT_SUPPORT_SPI="yes"
+BOOT_SPI_RKSPI_LOADER="yes"
+IMAGE_PARTITION_TABLE="gpt"
+SKIP_BOOTSPLASH="yes" # Skip boot splash patch, conflicts with CONFIG_VT=yes
+
+function post_family_tweaks__rock5a_naming_audios() {
+	display_alert "$BOARD" "Renaming rock5a audios" "info"
+
+	mkdir -p $SDCARD/etc/udev/rules.d/
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-hdmi0-sound", ENV{SOUND_DESCRIPTION}="HDMI0 Audio"' > $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-dp0-sound", ENV{SOUND_DESCRIPTION}="DP0 Audio"' >> $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-es8316-sound", ENV{SOUND_DESCRIPTION}="ES8316 Audio"' >> $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+
+	return 0
+}


### PR DESCRIPTION
#### `rock-5a`: add support for Rock-5A, WiP, using `rockchip-rk3588` - by @amazingfate

- Split-off from https://github.com/armbian/build/pull/5230
- Board file straight from https://github.com/amazingfate/armbian-rock5b-images/blob/master/rock-5a.conf

