### PR TITLE
`rockchip64`/`current` 6.1.y: fix broken Radxa E25 patch from #5165

### DIFF
--- a/patch/kernel/archive/rockchip64-6.1/add-board-radxa-e25.patch
+++ b/patch/kernel/archive/rockchip64-6.1/add-board-radxa-e25.patch
@@ -1,22 +1,18 @@
 diff --git a/arch/arm64/boot/dts/rockchip/Makefile b/arch/arm64/boot/dts/rockchip/Makefile
-index 3308238fd356..5057a61bd92c 100644
---- a/arch/arm64/boot/dts/rockchip/Makefile
-+++ b/arch/arm64/boot/dts/rockchip/Makefile
-@@ -89,8 +89,9 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-quartz64-a.dtb
- dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-quartz64-b.dtb
- dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-roc-pc.dtb
+--- a/arch/arm64/boot/dts/rockchip/Makefile	(revision 4c1c8a78a1bfc84404d088c5a34dd3625f6b3f40)
++++ b/arch/arm64/boot/dts/rockchip/Makefile	(revision a45c446e458e82465be126710c57677c6237d914)
+@@ -92,6 +92,7 @@
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-soquartz-cm4.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-bpi-r2-pro.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-evb1-v10.dtb
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-radxa-e25.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-rock-3a.dtb
-
+ 
  subdir-y       := $(dts-dirs) overlay
 diff --git a/arch/arm64/boot/dts/rockchip/rk3568-radxa-cm3i.dtsi b/arch/arm64/boot/dts/rockchip/rk3568-radxa-cm3i.dtsi
 new file mode 100644
-index 000000000000..b9d317cab48b
---- /dev/null
-+++ b/arch/arm64/boot/dts/rockchip/rk3568-radxa-cm3i.dtsi
+--- /dev/null	(revision a45c446e458e82465be126710c57677c6237d914)
++++ b/arch/arm64/boot/dts/rockchip/rk3568-radxa-cm3i.dtsi	(revision a45c446e458e82465be126710c57677c6237d914)
 @@ -0,0 +1,429 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +
@@ -449,9 +445,8 @@ index 000000000000..b9d317cab48b
 +};
 diff --git a/arch/arm64/boot/dts/rockchip/rk3568-radxa-e25.dts b/arch/arm64/boot/dts/rockchip/rk3568-radxa-e25.dts
 new file mode 100644
-index 000000000000..38caecb1ef67
---- /dev/null
-+++ b/arch/arm64/boot/dts/rockchip/rk3568-radxa-e25.dts
+--- /dev/null	(revision a45c446e458e82465be126710c57677c6237d914)
++++ b/arch/arm64/boot/dts/rockchip/rk3568-radxa-e25.dts	(revision a45c446e458e82465be126710c57677c6237d914)
 @@ -0,0 +1,230 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +
@@ -683,91 +678,3 @@ index 000000000000..38caecb1ef67
 +       phy-supply = <&vcc3v3_ngff>;
 +       status = "okay";
 +};
-diff --git a/arch/arm64/boot/dts/rockchip/rk356x.dtsi b/arch/arm64/boot/dts/rockchip/rk356x.dtsi
-index cb5d87f4510c..43b49220b77d 100644
---- a/arch/arm64/boot/dts/rockchip/rk356x.dtsi
-+++ b/arch/arm64/boot/dts/rockchip/rk356x.dtsi
-@@ -1060,24 +1060,10 @@ sdhci: mmc@fe310000 {
-                         <&cru TCLK_EMMC>;
-                clock-names = "core", "bus", "axi", "block", "timer";
-                status = "disabled";
-        };
-
--       spdif: spdif@fe460000 {
--               compatible = "rockchip,rk3568-spdif";
--               reg = <0x0 0xfe460000 0x0 0x1000>;
--               interrupts = <GIC_SPI 102 IRQ_TYPE_LEVEL_HIGH>;
--               clock-names = "mclk", "hclk";
--               clocks = <&cru MCLK_SPDIF_8CH>, <&cru HCLK_SPDIF_8CH>;
--               dmas = <&dmac1 1>;
--               dma-names = "tx";
--               pinctrl-names = "default";
--               pinctrl-0 = <&spdifm0_tx>;
--               #sound-dai-cells = <0>;
--               status = "disabled";
--       };
--
-        i2s0_8ch: i2s@fe400000 {
-                compatible = "rockchip,rk3568-i2s-tdm";
-                reg = <0x0 0xfe400000 0x0 0x1000>;
-                interrupts = <GIC_SPI 52 IRQ_TYPE_LEVEL_HIGH>;
-                assigned-clocks = <&cru CLK_I2S0_8CH_TX_SRC>, <&cru CLK_I2S0_8CH_RX_SRC>;
-@@ -1116,10 +1102,32 @@ &i2s1m0_sdo0   &i2s1m0_sdo1
-                             &i2s1m0_sdo2   &i2s1m0_sdo3>;
-                #sound-dai-cells = <0>;
-                status = "disabled";
-        };
-
-+       i2s2_2ch: i2s@fe420000 {
-+               compatible = "rockchip,rk3568-i2s-tdm";
-+               reg = <0x0 0xfe420000 0x0 0x1000>;
-+               interrupts = <GIC_SPI 54 IRQ_TYPE_LEVEL_HIGH>;
-+               assigned-clocks = <&cru CLK_I2S2_2CH_SRC>;
-+               assigned-clock-rates = <1188000000>;
-+               clocks = <&cru MCLK_I2S2_2CH>, <&cru MCLK_I2S2_2CH>, <&cru HCLK_I2S2_2CH>;
-+               clock-names = "mclk_tx", "mclk_rx", "hclk";
-+               dmas = <&dmac1 4>, <&dmac1 5>;
-+               dma-names = "tx", "rx";
-+               resets = <&cru SRST_M_I2S2_2CH>;
-+               reset-names = "m";
-+               rockchip,grf = <&grf>;
-+               pinctrl-names = "default";
-+               pinctrl-0 = <&i2s2m0_sclktx
-+                               &i2s2m0_lrcktx
-+                               &i2s2m0_sdi
-+                               &i2s2m0_sdo>;
-+               #sound-dai-cells = <0>;
-+               status = "disabled";
-+       };
-+
-        i2s3_2ch: i2s@fe430000 {
-                compatible = "rockchip,rk3568-i2s-tdm";
-                reg = <0x0 0xfe430000 0x0 0x1000>;
-                interrupts = <GIC_SPI 55 IRQ_TYPE_LEVEL_HIGH>;
-                clocks = <&cru MCLK_I2S3_2CH_TX>, <&cru MCLK_I2S3_2CH_RX>,
-@@ -1153,10 +1161,24 @@ &pdmm0_sdi2
-                reset-names = "pdm-m";
-                #sound-dai-cells = <0>;
-                status = "disabled";
-        };
-
-+       spdif: spdif@fe460000 {
-+               compatible = "rockchip,rk3568-spdif";
-+               reg = <0x0 0xfe460000 0x0 0x1000>;
-+               interrupts = <GIC_SPI 102 IRQ_TYPE_LEVEL_HIGH>;
-+               clock-names = "mclk", "hclk";
-+               clocks = <&cru MCLK_SPDIF_8CH>, <&cru HCLK_SPDIF_8CH>;
-+               dmas = <&dmac1 1>;
-+               dma-names = "tx";
-+               pinctrl-names = "default";
-+               pinctrl-0 = <&spdifm0_tx>;
-+               #sound-dai-cells = <0>;
-+               status = "disabled";
-+       };
-+
-        dmac0: dma-controller@fe530000 {
-                compatible = "arm,pl330", "arm,primecell";
-                reg = <0x0 0xfe530000 0x0 0x4000>;
-                interrupts = <GIC_SPI 14 IRQ_TYPE_LEVEL_HIGH>,
-                             <GIC_SPI 13 IRQ_TYPE_LEVEL_HIGH>;
---


### PR DESCRIPTION
#### `rockchip64`/`current` 6.1.y: fix broken Radxa E25 patch from #5165

- drop the common dtsi changes