### PR TITLE
`sunxi` `6.1` and `6.2`: disable broken `ov5640` patches

### DIFF
--- a/patch/kernel/archive/sunxi-6.1/series.conf
+++ b/patch/kernel/archive/sunxi-6.1/series.conf
@@ -57,11 +57,11 @@
 	patches.megous/media-ov5640-Don-t-powerup-the-sensor-during-driver-probe.patch
 	patches.megous/media-ov5640-set-default-ae-target-lower.patch
 	patches.megous/media-ov5640-Improve-error-reporting.patch
-	patches.megous/media-ov5640-Implement-autofocus.patch
+-	patches.megous/media-ov5640-Implement-autofocus.patch
 	patches.megous/net-stmmac-sun8i-Use-devm_regulator_get-for-PHY-regulator.patch
-	patches.megous/media-ov5640-Improve-firmware-load-time.patch
+-	patches.megous/media-ov5640-Improve-firmware-load-time.patch
 	patches.megous/net-stmmac-sun8i-Rename-PHY-regulator-variable-to-regulator_phy.patch
-	patches.megous/media-ov5640-Fix-focus-commands-blocking-until-complete.patch
+-	patches.megous/media-ov5640-Fix-focus-commands-blocking-until-complete.patch
 	patches.megous/iio-adc-sun4i-gpadc-iio-Allow-to-use-sun5i-a13-gpadc-iio-from-D.patch
 	patches.megous/mtd-spi-nor-Add-regulator-support.patch
 	patches.megous/input-cyttsp4-De-obfuscate-platform-data-for-keys.patch

--- a/patch/kernel/archive/sunxi-6.2/series.conf
+++ b/patch/kernel/archive/sunxi-6.2/series.conf
@@ -50,9 +50,9 @@
 	patches.megous/media-ov5640-set-default-ae-target-lower.patch
 	patches.megous/media-ov5640-Improve-error-reporting.patch
 -	patches.megous/media-ov5640-Implement-autofocus.patch
-	patches.megous/media-ov5640-Improve-firmware-load-time.patch
-	patches.megous/media-ov5640-Fix-focus-commands-blocking-until-complete.patch
-	patches.megous/media-ov5640-Report-analogue-gain-as-supported-for-libcamera.patch
+-	patches.megous/media-ov5640-Improve-firmware-load-time.patch
+-	patches.megous/media-ov5640-Fix-focus-commands-blocking-until-complete.patch
+-	patches.megous/media-ov5640-Report-analogue-gain-as-supported-for-libcamera.patch
 	patches.megous/media-ov5640-Add-read-only-property-for-vblank.patch
 	patches.megous/media-sun6i-csi-capture-Use-subdev-operation-to-access-bridge-f.patch
 	patches.megous/media-sun6i-csi-subdev-Use-subdev-active-state-to-store-active-.patch


### PR DESCRIPTION
#### `sunxi` `6.1` and `6.2`: disable broken `ov5640` patches 

> (some kind of camera?...)

- most of those were already disabled on 6.2, now some more patches on top also broke.
- it works up to 6.1.15, but 6.1.16 broke it; `megi`'s tree is still at 6.1.12.