### PR TITLE
git/docker: bsp-cli: fix `BUILD_REPOSITORY_URL` and `BUILD_REPOSITORY_COMMIT` under Docker

### DIFF
--- a/lib/functions/bsp/armbian-bsp-cli-deb.sh
+++ b/lib/functions/bsp/armbian-bsp-cli-deb.sh
@@ -179,6 +179,10 @@ function compile_armbian-bsp-cli() {
 	find "${destination}" -print0 2> /dev/null | xargs -0r chown --no-dereference 0:0
 	find "${destination}" ! -type l -print0 2> /dev/null | xargs -0r chmod 'go=rX,u+rw,a-s'
 
+	if [[ "${SHOW_DEBUG}" == "yes" ]]; then
+		run_tool_batcat --file-name "/etc/armbian-release.sh" "${destination}"/etc/armbian-release
+	fi
+
 	# Build / close the package. This will run shellcheck / show the generated files if debugging
 	fakeroot_dpkg_deb_build "${destination}" "${DEB_STORAGE}/"
 

--- a/lib/functions/cli/cli-docker.sh
+++ b/lib/functions/cli/cli-docker.sh
@@ -35,6 +35,11 @@ function cli_docker_run() {
 	declare -g GIT_INFO_ANSI
 	GIT_INFO_ANSI="$(prepare_ansi_git_info_log_header)"
 
+	# Same stuff for BUILD_REPOSITORY_URL and BUILD_REPOSITORY_COMMIT.
+	if [[ -d "${SRC}/.git" && "${CONFIG_DEFS_ONLY}" != "yes" ]]; then # don't waste time if only gathering config defs
+		set_git_build_repo_url_and_commit_vars "docker launcher"
+	fi
+
 	LOG_SECTION="docker_cli_prepare" do_with_logging docker_cli_prepare
 
 	# @TODO: and can be very well said that in CI, we always want FAST_DOCKER=yes, unless we're building the Docker image itself.

--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -420,6 +420,16 @@ function docker_cli_prepare_launch() {
 		DOCKER_ARGS+=("--env" "GIT_INFO_ANSI=${GIT_INFO_ANSI}")
 	fi
 
+	if [[ -n "${BUILD_REPOSITORY_URL}" ]]; then
+		display_alert "Git info" "Passing down BUILD_REPOSITORY_URL as an env var..." "debug"
+		DOCKER_ARGS+=("--env" "BUILD_REPOSITORY_URL=${BUILD_REPOSITORY_URL}")
+	fi
+
+	if [[ -n "${BUILD_REPOSITORY_COMMIT}" ]]; then
+		display_alert "Git info" "Passing down BUILD_REPOSITORY_COMMIT as an env var..." "debug"
+		DOCKER_ARGS+=("--env" "BUILD_REPOSITORY_COMMIT=${BUILD_REPOSITORY_COMMIT}")
+	fi
+
 	if [[ "${DOCKER_PASS_SSH_AGENT}" == "yes" ]]; then
 		declare ssh_socket_path="${SSH_AUTH_SOCK}"
 		if [[ "${OSTYPE}" == "darwin"* ]]; then                     # but probably only Docker Inc, not Rancher...


### PR DESCRIPTION
#### git/docker: bsp-cli: fix `BUILD_REPOSITORY_URL` and `BUILD_REPOSITORY_COMMIT` under Docker

> The docker container does not have `.git` inside it, jump through hoops/env vars to pass it down.

fixes [AR-1750]


[AR-1750]: https://armbian.atlassian.net/browse/AR-1750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ