### PR TITLE
Temporally disable broken wireless / bluetooth driver

### DIFF
--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -21,12 +21,12 @@ case $BRANCH in
 
 	legacy)
 		declare -g KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v5.15.112"
+		declare -g KERNELBRANCH="tag:v5.15.113"
 		;;
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.1.29"
+		declare -g KERNELBRANCH="tag:v6.1.30"
 		;;
 
 	edge)

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -22,12 +22,12 @@ case $BRANCH in
 
 	legacy)
 		declare -g KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v5.15.112"
+		declare -g KERNELBRANCH="tag:v5.15.113"
 		;;
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.1.29"
+		declare -g KERNELBRANCH="tag:v6.1.30"
 		;;
 
 	edge)

--- a/lib/functions/compilation/patch/drivers-harness.sh
+++ b/lib/functions/compilation/patch/drivers-harness.sh
@@ -87,7 +87,7 @@ function kernel_drivers_prepare_harness() {
 		driver_rtl8723DU
 		driver_rtl8822BS
 		driver_uwe5622_allwinner
-#		driver_rtl8723cs
+		driver_rtl8723cs
 	)
 
 	# change cwd to the kernel working dir

--- a/lib/functions/compilation/patch/drivers-harness.sh
+++ b/lib/functions/compilation/patch/drivers-harness.sh
@@ -87,7 +87,7 @@ function kernel_drivers_prepare_harness() {
 		driver_rtl8723DU
 		driver_rtl8822BS
 		driver_uwe5622_allwinner
-		driver_rtl8723cs
+#		driver_rtl8723cs
 	)
 
 	# change cwd to the kernel working dir

--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -669,7 +669,7 @@ patch_drivers_network() {
 	driver_rtl8723DU
 	driver_rtl8822BS
 	driver_uwe5622_allwinner
-	driver_rtl8723cs
+#	driver_rtl8723cs
 
 	display_alert "Network related drivers patched" "" "info"
 }

--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -637,8 +637,10 @@ driver_rtl8723cs() {
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/8723cs-Port-to-6.1.patch" "applying"
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/8723cs-Port-to-6.1-rc1.patch" "applying"
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/dt-bindings-net-bluetooth-Add-rtl8723bs-bluetooth.patch" "applying"
-		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/bluetooth-btrtl-quirk-local-ext-features.patch" "applying"
-		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/Bluetooth-btrtl-add-support-for-the-RTL8723CS.patch" "applying"
+		if linux-version compare "${version}" lt 6.1; then
+			process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/bluetooth-btrtl-quirk-local-ext-features.patch" "applying"
+			process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/Bluetooth-btrtl-add-support-for-the-RTL8723CS.patch" "applying"
+		fi
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/Bluetooth-hci_h5-Add-support-for-binding-RTL8723CS-with-device-.patch" "applying"
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/bluetooth-h5-Don-t-re-initialize-rtl8723cs-on-resume.patch" "applying"
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/bluetooth-btrtl-add-rtl8703bs.patch" "applying"
@@ -669,7 +671,7 @@ patch_drivers_network() {
 	driver_rtl8723DU
 	driver_rtl8822BS
 	driver_uwe5622_allwinner
-#	driver_rtl8723cs
+	driver_rtl8723cs
 
 	display_alert "Network related drivers patched" "" "info"
 }


### PR DESCRIPTION
# Description

```--> (43) INFO: * applying patch/misc/wireless-rtl8723cs/dt-bindings-net-bluetooth-Add-rtl8723bs-bluetooth.patch
   1 out of 1 hunk FAILED
--> (43) WARNING: * applying patch/misc/wireless-rtl8723cs/bluetooth-btrtl-quirk-local-ext-features.patch [ failed ]
   10 out of 14 hunks FAILED
   Reversed (or previously applied) patch detected!  Skipping patch.
   1 out of 1 hunk ignored
--> (43) WARNING: * applying patch/misc/wireless-rtl8723cs/Bluetooth-btrtl-add-support-for-the-RTL8723CS.patch [ failed ]
```

Ass per title.  https://paste.next.armbian.com/girevorico

@paolosabatino

Also bump Allwinner

Jira reference number [AR-9999]

# How Has This Been Tested?

- [x] Compiling current meson64 kernel

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
