### PR TITLE
drivers_network: fix bluetooth stuff landed in 6.1.30/6.3.4 but not in 6.2.y

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -524,7 +524,7 @@ driver_rtl8723DU() {
 		# fix compilation for kernels >= 5.4
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723du-Fix-VFS-import.patch" "applying"
 
-		# fix compilation for kernels >= 6.3
+		# fix compilation for kernels >=  6.3
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723du-6.3.patch" "applying"
 
 	fi
@@ -637,8 +637,12 @@ driver_rtl8723cs() {
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/8723cs-Port-to-6.1.patch" "applying"
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/8723cs-Port-to-6.1-rc1.patch" "applying"
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/dt-bindings-net-bluetooth-Add-rtl8723bs-bluetooth.patch" "applying"
-		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/bluetooth-btrtl-quirk-local-ext-features.patch" "applying"
-		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/Bluetooth-btrtl-add-support-for-the-RTL8723CS.patch" "applying"
+
+		if linux-version compare "${version}" ge 6.2 && linux-version compare "${version}" lt 6.3; then # landed in 6.1.30/6.3.4 # keep for 6.2
+			process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/bluetooth-btrtl-quirk-local-ext-features.patch" "applying"
+			process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/Bluetooth-btrtl-add-support-for-the-RTL8723CS.patch" "applying"
+		fi
+
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/Bluetooth-hci_h5-Add-support-for-binding-RTL8723CS-with-device-.patch" "applying"
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/bluetooth-h5-Don-t-re-initialize-rtl8723cs-on-resume.patch" "applying"
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/bluetooth-btrtl-add-rtl8703bs.patch" "applying"
@@ -647,7 +651,7 @@ driver_rtl8723cs() {
 	if linux-version compare "${version}" ge 6.3; then
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/8723cs-Port-to-6.3.patch" "applying"
 	fi
-	
+
 }
 
 patch_drivers_network() {

--- a/patch/kernel/archive/rockchip64-6.1/general-workaround-broadcom-bt-serdev.patch
+++ b/patch/kernel/archive/rockchip64-6.1/general-workaround-broadcom-bt-serdev.patch
@@ -1,26 +1,26 @@
-From e5c9702bd2ffd09e48c118ab40c2764590af7929 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
 Date: Sat, 1 May 2021 12:41:14 +0000
-Subject: [PATCH] Workaround to make several broadcom bluetooth serdev devices
- work even without proper MAC address
+Subject: Workaround to make several broadcom bluetooth serdev devices work
+ even without proper MAC address
 
 ---
  drivers/bluetooth/btbcm.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/bluetooth/btbcm.c b/drivers/bluetooth/btbcm.c
-index 1b9743b7f..b274f1cdd 100644
+index de2ea589aa49..df197c3a7894 100644
 --- a/drivers/bluetooth/btbcm.c
 +++ b/drivers/bluetooth/btbcm.c
-@@ -87,7 +87,7 @@ int btbcm_check_bdaddr(struct hci_dev *hdev)
- 	    !bacmp(&bda->bdaddr, BDADDR_BCM43341B)) {
- 		bt_dev_info(hdev, "BCM: Using default device address (%pMR)",
- 			    &bda->bdaddr);
--		set_bit(HCI_QUIRK_INVALID_BDADDR, &hdev->quirks);
-+		//set_bit(HCI_QUIRK_INVALID_BDADDR, &hdev->quirks);
+@@ -129,7 +129,7 @@ int btbcm_check_bdaddr(struct hci_dev *hdev)
+ 		if (btbcm_set_bdaddr_from_efi(hdev) != 0) {
+ 			bt_dev_info(hdev, "BCM: Using default device address (%pMR)",
+ 				    &bda->bdaddr);
+-			set_bit(HCI_QUIRK_INVALID_BDADDR, &hdev->quirks);
++			//set_bit(HCI_QUIRK_INVALID_BDADDR, &hdev->quirks);
+ 		}
  	}
  
- 	kfree_skb(skb);
 -- 
-2.25.1
+Armbian
 

--- a/patch/kernel/archive/rockchip64-6.3/general-workaround-broadcom-bt-serdev.patch
+++ b/patch/kernel/archive/rockchip64-6.3/general-workaround-broadcom-bt-serdev.patch
@@ -9,18 +9,18 @@ Subject: Workaround to make several broadcom bluetooth serdev devices work
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/bluetooth/btbcm.c b/drivers/bluetooth/btbcm.c
-index 43e98a598bd9..93c456ce2533 100644
+index de2ea589aa49..df197c3a7894 100644
 --- a/drivers/bluetooth/btbcm.c
 +++ b/drivers/bluetooth/btbcm.c
-@@ -89,7 +89,7 @@ int btbcm_check_bdaddr(struct hci_dev *hdev)
- 	    !bacmp(&bda->bdaddr, BDADDR_BCM43341B)) {
- 		bt_dev_info(hdev, "BCM: Using default device address (%pMR)",
- 			    &bda->bdaddr);
--		set_bit(HCI_QUIRK_INVALID_BDADDR, &hdev->quirks);
-+		//set_bit(HCI_QUIRK_INVALID_BDADDR, &hdev->quirks);
+@@ -129,7 +129,7 @@ int btbcm_check_bdaddr(struct hci_dev *hdev)
+ 		if (btbcm_set_bdaddr_from_efi(hdev) != 0) {
+ 			bt_dev_info(hdev, "BCM: Using default device address (%pMR)",
+ 				    &bda->bdaddr);
+-			set_bit(HCI_QUIRK_INVALID_BDADDR, &hdev->quirks);
++			//set_bit(HCI_QUIRK_INVALID_BDADDR, &hdev->quirks);
+ 		}
  	}
  
- 	kfree_skb(skb);
 -- 
 Armbian
 

--- a/patch/misc/wireless-driver-for-uwe5622-park-link-v6.1-post.patch
+++ b/patch/misc/wireless-driver-for-uwe5622-park-link-v6.1-post.patch
@@ -10,10 +10,9 @@ Subject: [PATCH] fix spreadtrum (sprd) bluetooth broken park link status
  3 files changed, 13 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/bluetooth/hci_ldisc.c b/drivers/bluetooth/hci_ldisc.c
-index 865112e96ff..61ccf31ee71 100644
---- a/drivers/bluetooth/hci_ldisc.c
-+++ b/drivers/bluetooth/hci_ldisc.c
-@@ -658,6 +658,12 @@ static int hci_uart_register_dev(struct hci_uart *hu)
+--- a/drivers/bluetooth/hci_ldisc.c	(revision 58aa050aa57333b34b358234002121c59fb3af26)
++++ b/drivers/bluetooth/hci_ldisc.c	(revision bf8ab2f58b21494ffde96979431a3da931deb48b)
+@@ -658,6 +658,12 @@
  	hdev->setup = hci_uart_setup;
  	SET_HCIDEV_DEV(hdev, hu->tty->dev);
  
@@ -27,27 +26,26 @@ index 865112e96ff..61ccf31ee71 100644
  		set_bit(HCI_QUIRK_RAW_DEVICE, &hdev->quirks);
  
 diff --git a/include/net/bluetooth/hci.h b/include/net/bluetooth/hci.h
-index 9f6f52d368a..b69f6be67d3 100644
---- a/include/net/bluetooth/hci.h
-+++ b/include/net/bluetooth/hci.h
-@@ -301,6 +301,12 @@ enum {
- 	 * during the hdev->setup vendor callback.
+--- a/include/net/bluetooth/hci.h	(revision 58aa050aa57333b34b358234002121c59fb3af26)
++++ b/include/net/bluetooth/hci.h	(revision bf8ab2f58b21494ffde96979431a3da931deb48b)
+@@ -309,6 +309,13 @@
+ 	 * to support it.
  	 */
- 	HCI_QUIRK_BROKEN_MWS_TRANSPORT_CONFIG,
+ 	HCI_QUIRK_BROKEN_SET_RPA_TIMEOUT,
 +	
 +	/*
 +	 * Device declares that support Park link status, but it really
 +	 * does not support it and fails to initialize
 +	 */
-+	HCI_QUIRK_BROKEN_PARK_LINK_STATUS
++	HCI_QUIRK_BROKEN_PARK_LINK_STATUS,
++	
  };
  
  /* HCI device flags */
 diff --git a/net/bluetooth/hci_sync.c b/net/bluetooth/hci_sync.c
-index 8d6c8cbfe1d..9a743e597bb 100644
---- a/net/bluetooth/hci_sync.c
-+++ b/net/bluetooth/hci_sync.c
-@@ -3760,7 +3760,7 @@ static int hci_setup_link_policy_sync(struct hci_dev *hdev)
+--- a/net/bluetooth/hci_sync.c	(revision 58aa050aa57333b34b358234002121c59fb3af26)
++++ b/net/bluetooth/hci_sync.c	(revision bf8ab2f58b21494ffde96979431a3da931deb48b)
+@@ -3804,7 +3804,7 @@
  		link_policy |= HCI_LP_HOLD;
  	if (lmp_sniff_capable(hdev))
  		link_policy |= HCI_LP_SNIFF;


### PR DESCRIPTION
#### drivers_network: fix bluetooth stuff landed in 6.1.30/6.3.4 but not in 6.2.y

- drivers_network: wireless-driver-for-uwe5622-park-link-v6.1-post: fix for 6.1.30
-  drivers_network: rtl8723cs bt: disable landed patches in 6.1.30/6.3.4; keep for 6.2, which is EOL
- `rockchip64`/`current` 6.1.y: fix broadcom bt serdev hack for 6.1.30
- `rockchip64`/`edge` 6.3.y: fix broadcom bt serdev hack for 6.3.4

> Only after doing this I saw https://github.com/armbian/build/pull/5240 -- sorry