### PR TITLE
Disable rtl8723cs for bcm2711 family 

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -606,7 +606,8 @@ driver_rtl8723cs() {
 	# Realtek rtl8723cs wireless support.
 	# Driver has been borrowed from sunxi 6.1 megous patch archive.
 	# Applies only from linux 6.1 onwards, so older kernel archives does not require to be altered
-	if linux-version compare "${version}" ge 6.1; then
+	# It was disabled from bcm2711 as that kernel is not fully in sync with mainline and as its probably not needed there anyway
+	if linux-version compare "${version}" ge 6.1 && [[ "$LINUXFAMILY" != bcm2711 ]]; then
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/8723cs-Add-a-new-driver-v5.12.2-7-g2de5ec386.20201013_beta.patch" "applying"
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/8723cs-Make-the-driver-compile-and-probe-drop-rockchip-platform.patch" "applying"
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/8723cs-Enable-OOB-interrupt.patch" "applying"


### PR DESCRIPTION
# Description

It is currently broken and as its not needed there anyway.