### PR TITLE
arm64-dts-allwinner-h616-Add-efuse_xlate-cpu-frequency-scaling-v1_6_2

### DIFF
--- a/patch/kernel/archive/sunxi-6.2/patches.armbian/arm64-dts-allwinner-h616-Add-efuse_xlate-cpu-frequency-scaling-v1_6_2.patch
+++ b/patch/kernel/archive/sunxi-6.2/patches.armbian/arm64-dts-allwinner-h616-Add-efuse_xlate-cpu-frequency-scaling-v1_6_2.patch
@@ -1,0 +1,338 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: AGM1968 <AGM1968@users.noreply.github.com>
+Date: Tue, 23 May 2023 16:43:00 +0000
+Subject: arm64-dts-allwinner-h616-Add-efuse_xlate-cpu-frequency-scaling-v1_6_2
+ arch/arm64/boot/dts/allwinner/sun50i-h616-cpu-opp.dtsi
+ arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts
+ drivers/cpufreq/cpufreq-dt-platdev.c drivers/cpufreq/sun50i-cpufreq-nvmem.c
+
+Signed-off-by: AGM1968 <AGM1968@users.noreply.github.com>
+---
+ arch/arm64/boot/dts/allwinner/sun50i-h616-cpu-opp.dtsi       | 75 ++++++++
+ arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts |  6 +
+ drivers/cpufreq/cpufreq-dt-platdev.c                         |  1 +
+ drivers/cpufreq/sun50i-cpufreq-nvmem.c                       | 91 +++++++---
+ 4 files changed, 149 insertions(+), 24 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616-cpu-opp.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616-cpu-opp.dtsi
+new file mode 100644
+index 000000000000..36f2950367c6
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-cpu-opp.dtsi
+@@ -0,0 +1,75 @@
++//SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++//Testing Version 1  from: AGM1968 <AGM1968@users.noreply.github.com>
++//Noted: PLL_CPUX = 24 MHz*N/P (WIP)
++
++/ {
++	cpu_opp_table: opp-table-cpu {
++		compatible = "allwinner,sun50i-h616-operating-points";
++		nvmem-cells = <&cpu_speed_grade>;
++		opp-shared;
++ 
++		opp-480000000 {
++			clock-latency-ns = <244144>; /* 8 32k periods */
++			opp-hz = /bits/ 64 <480000000>;
++			opp-microvolt-speed0 = <820000 820000 1100000>; 
++			opp-microvolt-speed1 = <880000 880000 1100000>;
++			opp-microvolt-speed2 = <880000 880000 1100000>;
++		};
++	
++		opp-600000000 {
++			clock-latency-ns = <244144>; /* 8 32k periods */
++			opp-hz = /bits/ 64 <600000000>;
++			opp-microvolt-speed0 = <820000 820000 1100000>;
++			opp-microvolt-speed1 = <880000 880000 1100000>;
++			opp-microvolt-speed2 = <880000 880000 1100000>;
++		};
++
++		opp-792000000 {
++			clock-latency-ns = <244144>; /* 8 32k periods */
++			opp-hz = /bits/ 64 <792000000>;
++		        opp-microvolt-speed0 = <860000 860000 1100000>;
++			opp-microvolt-speed1 = <940000 940000 1100000>;
++			opp-microvolt-speed2 = <940000 940000 1100000>;
++		};
++
++		opp-1008000000 {
++			clock-latency-ns = <244144>; /* 8 32k periods */
++			opp-hz = /bits/ 64 <1008000000>;
++			opp-microvolt-speed0 = <900000 900000 1100000>;
++			opp-microvolt-speed1 = <1020000 1020000 1100000>;
++			opp-microvolt-speed2 = <1020000 1020000 1100000>;
++		};
++
++		opp-1200000000 {
++			clock-latency-ns = <244144>; /* 8 32k periods */
++			opp-hz = /bits/ 64 <1200000000>;
++			opp-microvolt-speed0 = <960000 960000 1100000>;
++			opp-microvolt-speed1 = <1100000 1100000 1100000>;
++			opp-microvolt-speed2 = <1100000 1100000 1100000>;
++		};
++
++		opp-1512000000 {
++			clock-latency-ns = <244144>; /* 8 32k periods */
++			opp-hz = /bits/ 64 <1512000000>;
++			opp-microvolt-speed0 = <1100000 1100000 1100000>;
++			opp-microvolt-speed1 = <1100000 1100000 1100000>;
++			opp-microvolt-speed2 = <1100000 1100000 1100000>;
++		};
++	};
++};
++
++&cpu0 {
++	operating-points-v2 = <&cpu_opp_table>;
++};
++ 
++&cpu1 {
++	operating-points-v2 = <&cpu_opp_table>;
++};
++ 
++&cpu2 {
++	operating-points-v2 = <&cpu_opp_table>;
++};
++ 
++&cpu3 {
++	operating-points-v2 = <&cpu_opp_table>;
++};
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts b/arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts
+index 0a24b8571a50..defb8b71f872 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts
+@@ -4,10 +4,11 @@
+  */
+ 
+ /dts-v1/;
+ 
+ #include "sun50i-h616.dtsi"
++#include "sun50i-h616-cpu-opp.dtsi"
+ 
+ #include <dt-bindings/gpio/gpio.h>
+ #include <dt-bindings/interrupt-controller/arm-gic.h>
+ #include <dt-bindings/leds/common.h>
+ 
+@@ -216,10 +217,15 @@ &pio {
+ 	vcc-pg-supply = <&reg_bldo1>;
+ 	vcc-ph-supply = <&reg_aldo1>;
+ 	vcc-pi-supply = <&reg_aldo1>;
+ };
+ 
++&cpu0  {
++	cpu-supply = <&reg_dcdca>;
++	status = "okay";
++};
++
+ &spi0  {
+ 	status = "okay";
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&spi0_pins>, <&spi0_cs0_pin>;
+ 
+diff --git a/drivers/cpufreq/cpufreq-dt-platdev.c b/drivers/cpufreq/cpufreq-dt-platdev.c
+index e85703651098..e4fa483c8a84 100644
+--- a/drivers/cpufreq/cpufreq-dt-platdev.c
++++ b/drivers/cpufreq/cpufreq-dt-platdev.c
+@@ -100,10 +100,11 @@ static const struct of_device_id allowlist[] __initconst = {
+  * Machines for which the cpufreq device is *not* created, mostly used for
+  * platforms using "operating-points-v2" property.
+  */
+ static const struct of_device_id blocklist[] __initconst = {
+ 	{ .compatible = "allwinner,sun50i-h6", },
++	{ .compatible = "allwinner,sun50i-h616", },
+ 
+ 	{ .compatible = "apple,arm-platform", },
+ 
+ 	{ .compatible = "arm,vexpress", },
+ 
+diff --git a/drivers/cpufreq/sun50i-cpufreq-nvmem.c b/drivers/cpufreq/sun50i-cpufreq-nvmem.c
+index 1acec58c33c3..f8d5c30e56d0 100644
+--- a/drivers/cpufreq/sun50i-cpufreq-nvmem.c
++++ b/drivers/cpufreq/sun50i-cpufreq-nvmem.c
+@@ -4,10 +4,13 @@
+  *
+  * The sun50i-cpufreq-nvmem driver reads the efuse value from the SoC to
+  * provide the OPP framework with required information.
+  *
+  * Copyright (C) 2019 Yangtao Li <tiny.windzz@gmail.com>
++ *
++ * ADD efuse_xlate to extract SoC version so that h6 and h616 can coexist.
++ * Version 1 AGM1968 <AGM1968@users.noreply.github.com>
+  */
+ 
+ #define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
+ 
+ #include <linux/module.h>
+@@ -17,41 +20,77 @@
+ #include <linux/pm_opp.h>
+ #include <linux/slab.h>
+ 
+ #define MAX_NAME_LEN	7
+ 
+-#define NVMEM_MASK	0x7
+-#define NVMEM_SHIFT	5
++#define SUN50I_H616_NVMEM_MASK 0x22
++#define SUN50I_H616_NVMEM_SHIFT 5
++#define SUN50I_H6_NVMEM_MASK 0x7
++#define SUN50I_H6_NVMEM_SHIFT 5
++
++struct sunxi_cpufreq_soc_data {
++	u32 (*efuse_xlate) (void *efuse);
++};
+ 
+ static struct platform_device *cpufreq_dt_pdev, *sun50i_cpufreq_pdev;
+ 
++static u32 sun50i_h616_efuse_xlate(void *efuse)
++{
++   u32 efuse_value = (*(u32 *)efuse >> SUN50I_H616_NVMEM_SHIFT) &
++             SUN50I_H616_NVMEM_MASK;
++
++   /* Tested as V1 h616 soc. Expected efuse values are 1 - 3,
++      slowest to fastest */
++   if (efuse_value >=1 && efuse_value <= 3)
++       return efuse_value - 1;
++   else
++       return 0;
++};
++
++static u32 sun50i_h6_efuse_xlate(void *efuse)
++{
++   u32 efuse_value = (*(u32 *)efuse >> SUN50I_H6_NVMEM_SHIFT) &
++             SUN50I_H6_NVMEM_MASK;
++
++   /*
++    * We treat unexpected efuse values as if the SoC was from
++    * the slowest bin. Expected efuse values are 1 - 3, slowest
++    * to fastest.
++   */
++   if (efuse_value >= 1 && efuse_value <= 3)
++       return efuse_value - 1;
++   else
++       return 0;
++};
++
++
+ /**
+  * sun50i_cpufreq_get_efuse() - Determine speed grade from efuse value
++ * @soc_data: pointer to sunxi_cpufreq_soc_data context
+  * @versions: Set to the value parsed from efuse
+  *
+  * Returns 0 if success.
+  */
+-static int sun50i_cpufreq_get_efuse(u32 *versions)
++static int sun50i_cpufreq_get_efuse(const struct sunxi_cpufreq_soc_data *soc_data,
++		u32 *versions)
+ {
+ 	struct nvmem_cell *speedbin_nvmem;
+ 	struct device_node *np;
+ 	struct device *cpu_dev;
+-	u32 *speedbin, efuse_value;
++	u32 *speedbin;
+ 	size_t len;
+-	int ret;
+ 
+ 	cpu_dev = get_cpu_device(0);
+ 	if (!cpu_dev)
+ 		return -ENODEV;
+ 
+ 	np = dev_pm_opp_of_get_opp_desc_node(cpu_dev);
+ 	if (!np)
+ 		return -ENOENT;
+-
+-	ret = of_device_is_compatible(np,
+-				      "allwinner,sun50i-h6-operating-points");
+-	if (!ret) {
++	if (of_device_is_compatible(np, "allwinner,sun50i-h6-operating-points")) {}
++	else if (of_device_is_compatible(np, "allwinner,sun50i-h616-operating-points")) {}
++	else {
+ 		of_node_put(np);
+ 		return -ENOENT;
+ 	}
+ 
+ 	speedbin_nvmem = of_nvmem_cell_get(np, NULL);
+@@ -63,40 +102,35 @@ static int sun50i_cpufreq_get_efuse(u32 *versions)
+ 	speedbin = nvmem_cell_read(speedbin_nvmem, &len);
+ 	nvmem_cell_put(speedbin_nvmem);
+ 	if (IS_ERR(speedbin))
+ 		return PTR_ERR(speedbin);
+ 
+-	efuse_value = (*speedbin >> NVMEM_SHIFT) & NVMEM_MASK;
+-
+-	/*
+-	 * We treat unexpected efuse values as if the SoC was from
+-	 * the slowest bin. Expected efuse values are 1-3, slowest
+-	 * to fastest.
+-	 */
+-	if (efuse_value >= 1 && efuse_value <= 3)
+-		*versions = efuse_value - 1;
+-	else
+-		*versions = 0;
++	*versions = soc_data->efuse_xlate(speedbin);
+ 
+ 	kfree(speedbin);
+ 	return 0;
+ };
+ 
+ static int sun50i_cpufreq_nvmem_probe(struct platform_device *pdev)
+ {
++	const struct of_device_id *match;
+ 	int *opp_tokens;
+ 	char name[MAX_NAME_LEN];
+ 	unsigned int cpu;
+ 	u32 speed = 0;
+ 	int ret;
+ 
++	match = dev_get_platdata(&pdev->dev);
++	if (!match)
++		return -EINVAL;
++
+ 	opp_tokens = kcalloc(num_possible_cpus(), sizeof(*opp_tokens),
+ 			     GFP_KERNEL);
+ 	if (!opp_tokens)
+ 		return -ENOMEM;
+ 
+-	ret = sun50i_cpufreq_get_efuse(&speed);
++	ret = sun50i_cpufreq_get_efuse(match-> data, &speed);
+ 	if (ret) {
+ 		kfree(opp_tokens);
+ 		return ret;
+ 	}
+ 
+@@ -158,12 +192,21 @@ static struct platform_driver sun50i_cpufreq_driver = {
+ 	.driver = {
+ 		.name = "sun50i-cpufreq-nvmem",
+ 	},
+ };
+ 
++static const struct sunxi_cpufreq_soc_data sun50i_h616_data = {
++    .efuse_xlate = sun50i_h616_efuse_xlate,
++};
++
++static const struct sunxi_cpufreq_soc_data sun50i_h6_data = {
++    .efuse_xlate = sun50i_h6_efuse_xlate,
++};
++
+ static const struct of_device_id sun50i_cpufreq_match_list[] = {
+-	{ .compatible = "allwinner,sun50i-h6" },
++	{ .compatible = "allwinner,sun50i-h6", .data = &sun50i_h6_data },
++        { .compatible = "allwinner,sun50i-h616", .data = &sun50i_h616_data },
+ 	{}
+ };
+ MODULE_DEVICE_TABLE(of, sun50i_cpufreq_match_list);
+ 
+ static const struct of_device_id *sun50i_cpufreq_match_node(void)
+@@ -195,12 +238,12 @@ static int __init sun50i_cpufreq_init(void)
+ 	ret = platform_driver_register(&sun50i_cpufreq_driver);
+ 	if (unlikely(ret < 0))
+ 		return ret;
+ 
+ 	sun50i_cpufreq_pdev =
+-		platform_device_register_simple("sun50i-cpufreq-nvmem",
+-						-1, NULL, 0);
++		platform_device_register_data(NULL,
++		"sun50i-cpufreq-nvmem", -1, match, sizeof(*match));
+ 	ret = PTR_ERR_OR_ZERO(sun50i_cpufreq_pdev);
+ 	if (ret == 0)
+ 		return 0;
+ 
+ 	platform_driver_unregister(&sun50i_cpufreq_driver);
+-- 
+Created with Armbian build tools https://github.com/armbian/build

--- a/patch/kernel/archive/sunxi-6.2/series.armbian
+++ b/patch/kernel/archive/sunxi-6.2/series.armbian
@@ -104,6 +104,7 @@
 	patches.armbian/arm64-dts-sun50i-h616-x96-mate-T95-eth-sd-card-hack.patch
 	patches.armbian/arm64-dts-sun50i-h616-x96-mate-add-hdmi.patch
 	patches.armbian/arm64-dts-allwinner-h616-Add-device-node-for-SID.patch
+	patches.armbian/arm64-dts-allwinner-h616-Add-efuse_xlate-cpu-frequency-scaling-v1_6_2.patch
 	patches.armbian/arm64-dts-allwinner-h616-Add-thermal-sensor-and-thermal-zones.patch
 	patches.armbian/arm64-dts-allwinner-h616-Fix-thermal-zones-missing-trips.patch
 ###################

--- a/patch/kernel/archive/sunxi-6.2/series.conf
+++ b/patch/kernel/archive/sunxi-6.2/series.conf
@@ -500,6 +500,7 @@
 	patches.armbian/arm64-dts-sun50i-h616-x96-mate-T95-eth-sd-card-hack.patch
 	patches.armbian/arm64-dts-sun50i-h616-x96-mate-add-hdmi.patch
 	patches.armbian/arm64-dts-allwinner-h616-Add-device-node-for-SID.patch
+	patches.armbian/arm64-dts-allwinner-h616-Add-efuse_xlate-cpu-frequency-scaling-v1_6_2.patch
 	patches.armbian/arm64-dts-allwinner-h616-Add-thermal-sensor-and-thermal-zones.patch
 	patches.armbian/arm64-dts-allwinner-h616-Fix-thermal-zones-missing-trips.patch
 ###################


### PR DESCRIPTION
# Description

Add cpu-frequency to orangepizero2, allwinner h616 6.x.y kernels

Follow up Jira reference number [AR-1683]

# How Has This Been Tested?

SBC-bench as with 5.19.17.

additional well presented results to be viewed further @
https://github.com/mdziekon/armbian-build/pull/2
```
Armbian 23.05.0-trunk Bullseye ttyS0

orangepizero2 login: alistair
Password:
  ___  ____  _   _____             ____
 / _ \|  _ \(_) |__  /___ _ __ ___|___ \
| | | | |_) | |   / // _ \ '__/ _ \ __) |
| |_| |  __/| |  / /|  __/ | | (_) / __/
 \___/|_|   |_| /____\___|_|  \___/_____|

Welcome to Armbian 23.05.0-trunk Bullseye with bleeding edge Linux 6.2.16-sunxi64

No end-user support: built from trunk

System load:   13%              Up time:       0 min
Memory usage:  8% of 984M       IP:            10.0.0.12
CPU temp:      42°C             Usage of /:    5% of 29G

[ Menu-driven system configuration (beta): sudo apt update && sudo apt install armbian-config ]

alistair@orangepizero2:~$ dmesg | grep cpu*
[    0.000000] percpu: Embedded 19 pages/cpu s38760 r8192 d30872 u77824
[    0.000000] pcpu-alloc: s38760 r8192 d30872 u77824 alloc=19*4096
[    0.000000] pcpu-alloc: [0] 0 [0] 1 [0] 2 [0] 3
[    0.000000] printk: log_buf_len individual max cpu contribution: 4096 bytes
[    0.000000] printk: log_buf_len total cpu_extra contributions: 12288 bytes
[    0.000000] rcu:     RCU restricting CPUs from NR_CPUS=8 to nr_cpu_ids=4.
[    0.000000] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=4
[    0.000000] arch_timer: cp15 timer(s) running at 24.00MHz (phys).
[    0.041807] cpuidle: using governor menu
[    0.062518] cryptd: max_cpu_qlen set to 1000
[    0.700973] tcp_listen_portaddr_hash hash table entries: 512 (order: 1, 8192 bytes, linear)
[    0.875685] ledtrig-cpu: registered to indicate activity on CPUs
[    2.053265] sun50i_cpufreq_nvmem: Using CPU speed bin speed0
[    8.995945] cpufreq: cpufreq_online: CPU0: Running at unlisted initial frequency: 408000 KHz, changing to: 480000 KHz

```

- [x] Test A BUILD
       compiled and booted

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1683]: https://armbian.atlassian.net/browse/AR-1683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ