### PR TITLE
update rk35xx-legacy to 5.10 rkr4

### DIFF
--- a/config/sources/families/rk35xx.conf
+++ b/config/sources/families/rk35xx.conf
@@ -20,7 +20,7 @@ case $BRANCH in
 		UBOOT_USE_GCC='< 8.0'
 		BOOTDIR='u-boot-rockchip64'
 		KERNELSOURCE='https://github.com/armbian/linux-rockchip.git'
-		KERNELBRANCH='branch:rockchip-5.10'
+		KERNELBRANCH='branch:rk-5.10-rkr4'
 		declare -g KERNEL_MAJOR_MINOR="5.10" # Major and minor versions of this kernel.
 		KERNELDIR='linux-rockchip64'
 		KERNELPATCHDIR='rk35xx-legacy'


### PR DESCRIPTION
# Description

Also update rk35xx to 5.10 rkr4 for rk356x boards.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Build legacy image for rock3a
- [x] Image works on rock3a

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
