### PR TITLE
drivers_network: uwe5622: recover `park-link-v6.2-only.patch` only for 6.2.y sunxi

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -596,7 +596,11 @@ driver_uwe5622_allwinner() {
 		fi
 
 		if linux-version compare "${version}" ge 6.1; then
-			process_patch_file "${SRC}/patch/misc/wireless-driver-for-uwe5622-park-link-v6.1-post.patch" "applying"
+			if linux-version compare "${version}" ge 6.2 && linux-version compare "${version}" lt 6.3; then # only for 6.2.y
+				process_patch_file "${SRC}/patch/misc/wireless-driver-for-uwe5622-park-link-v6.2-only.patch" "applying"
+			else # assume 6.1.y y > 30
+				process_patch_file "${SRC}/patch/misc/wireless-driver-for-uwe5622-park-link-v6.1-post.patch" "applying"
+			fi
 			process_patch_file "${SRC}/patch/misc/wireless-driver-for-uwe5622-v6.1.patch" "applying"
 		fi
 	fi

--- a/patch/misc/wireless-driver-for-uwe5622-park-link-v6.2-only.patch
+++ b/patch/misc/wireless-driver-for-uwe5622-park-link-v6.2-only.patch
@@ -1,0 +1,61 @@
+From 67b790ecbeab3f5493dc8306e87e503e1bb7bcdc Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Sun, 29 Jan 2023 13:43:27 +0000
+Subject: [PATCH] fix spreadtrum (sprd) bluetooth broken park link status
+
+---
+ drivers/bluetooth/hci_ldisc.c | 6 ++++++
+ include/net/bluetooth/hci.h   | 6 ++++++
+ net/bluetooth/hci_sync.c      | 2 +-
+ 3 files changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/bluetooth/hci_ldisc.c b/drivers/bluetooth/hci_ldisc.c
+index 865112e96ff..61ccf31ee71 100644
+--- a/drivers/bluetooth/hci_ldisc.c
++++ b/drivers/bluetooth/hci_ldisc.c
+@@ -658,6 +658,12 @@ static int hci_uart_register_dev(struct hci_uart *hu)
+ 	hdev->setup = hci_uart_setup;
+ 	SET_HCIDEV_DEV(hdev, hu->tty->dev);
+ 
++	// Set the broken Park link status quirk, specific for spreadtrum (sprd)
++	// bluetooth devices
++	if (hdev->manufacturer == 0xffff && hu->tty->driver &&
++		strncmp(hu->tty->driver->name, "ttyBT", 5) == 0)
++		set_bit(HCI_QUIRK_BROKEN_PARK_LINK_STATUS, &hdev->quirks);
++
+ 	if (test_bit(HCI_UART_RAW_DEVICE, &hu->hdev_flags))
+ 		set_bit(HCI_QUIRK_RAW_DEVICE, &hdev->quirks);
+ 
+diff --git a/include/net/bluetooth/hci.h b/include/net/bluetooth/hci.h
+index 9f6f52d368a..b69f6be67d3 100644
+--- a/include/net/bluetooth/hci.h
++++ b/include/net/bluetooth/hci.h
+@@ -301,6 +301,12 @@ enum {
+ 	 * during the hdev->setup vendor callback.
+ 	 */
+ 	HCI_QUIRK_BROKEN_MWS_TRANSPORT_CONFIG,
++	
++	/*
++	 * Device declares that support Park link status, but it really
++	 * does not support it and fails to initialize
++	 */
++	HCI_QUIRK_BROKEN_PARK_LINK_STATUS
+ };
+ 
+ /* HCI device flags */
+diff --git a/net/bluetooth/hci_sync.c b/net/bluetooth/hci_sync.c
+index 8d6c8cbfe1d..9a743e597bb 100644
+--- a/net/bluetooth/hci_sync.c
++++ b/net/bluetooth/hci_sync.c
+@@ -3760,7 +3760,7 @@ static int hci_setup_link_policy_sync(struct hci_dev *hdev)
+ 		link_policy |= HCI_LP_HOLD;
+ 	if (lmp_sniff_capable(hdev))
+ 		link_policy |= HCI_LP_SNIFF;
+-	if (lmp_park_capable(hdev))
++	if (lmp_park_capable(hdev) && !test_bit(HCI_QUIRK_BROKEN_PARK_LINK_STATUS, &hdev->quirks))
+ 		link_policy |= HCI_LP_PARK;
+ 
+ 	cp.policy = cpu_to_le16(link_policy);
+-- 
+2.34.1
+


### PR DESCRIPTION
😢  still fallout from yesterday's 6.1.30 / 6.3.4 chaos and we're 6.2.16 in the middle EOL