### PR TITLE
Resolve u-boot infinite boot loop for Banana Pi M5 when usb ssd/hard disk attached

### DIFF
--- a/config/boards/bananapim2s.wip
+++ b/config/boards/bananapim2s.wip
@@ -8,6 +8,6 @@ SERIALCON="ttyAML0"
 BOOT_LOGO="desktop"
 BOOT_FDT_FILE="amlogic/meson-g12b-a311d-bananapi-m2s.dtb"
 
-# Newer u-boot; new DT, Makefile and defconfig in patch/u-boot/v2022.10/board_bananapi-m2s
+# Newer u-boot; new DT, Makefile and defconfig in patch/u-boot/v2022.10/board_bananapim2s
 BOOTBRANCH_BOARD="tag:v2022.10"
-BOOTPATCHDIR="v2022.10"
+BOOTPATCHDIR="v2022.10/board_bananapim2s" # this avoid the "USB first" patch in the v2022.10 folder

--- a/config/boards/bananapim5.conf
+++ b/config/boards/bananapim5.conf
@@ -8,4 +8,4 @@ FULL_DESKTOP="yes"
 SERIALCON="ttyAML0"
 BOOT_LOGO="desktop"
 BOOTBRANCH_BOARD="tag:v2022.10"
-BOOTPATCHDIR="v2022.10"
+BOOTPATCHDIR="v2022.10/board_bananapim5" # this avoid the "USB first" patch in the v2022.10 folder

--- a/patch/u-boot/v2022.10/board_bananapim2s/meson64-boot-nvme-scsi-first.patch
+++ b/patch/u-boot/v2022.10/board_bananapim2s/meson64-boot-nvme-scsi-first.patch
@@ -1,0 +1,19 @@
+diff --git a/include/configs/meson64.h b/include/configs/meson64.h
+index 9244601284..cdfc605ed5 100644
+--- a/include/configs/meson64.h
++++ b/include/configs/meson64.h
+@@ -71,12 +71,12 @@
+ #ifndef BOOT_TARGET_DEVICES
+ #define BOOT_TARGET_DEVICES(func) \
+ 	func(ROMUSB, romusb, na)  \
++	BOOT_TARGET_NVME(func) \
++	BOOT_TARGET_SCSI(func) \
+ 	func(MMC, mmc, 0) \
+ 	func(MMC, mmc, 1) \
+ 	func(MMC, mmc, 2) \
+ 	BOOT_TARGET_DEVICES_USB(func) \
+-	BOOT_TARGET_NVME(func) \
+-	BOOT_TARGET_SCSI(func) \
+ 	func(PXE, pxe, na) \
+ 	func(DHCP, dhcp, na)
+ #endif

--- a/patch/u-boot/v2022.10/board_bananapim5/meson64-boot-nvme-scsi-first.patch
+++ b/patch/u-boot/v2022.10/board_bananapim5/meson64-boot-nvme-scsi-first.patch
@@ -1,0 +1,19 @@
+diff --git a/include/configs/meson64.h b/include/configs/meson64.h
+index 9244601284..cdfc605ed5 100644
+--- a/include/configs/meson64.h
++++ b/include/configs/meson64.h
+@@ -71,12 +71,12 @@
+ #ifndef BOOT_TARGET_DEVICES
+ #define BOOT_TARGET_DEVICES(func) \
+ 	func(ROMUSB, romusb, na)  \
++	BOOT_TARGET_NVME(func) \
++	BOOT_TARGET_SCSI(func) \
+ 	func(MMC, mmc, 0) \
+ 	func(MMC, mmc, 1) \
+ 	func(MMC, mmc, 2) \
+ 	BOOT_TARGET_DEVICES_USB(func) \
+-	BOOT_TARGET_NVME(func) \
+-	BOOT_TARGET_SCSI(func) \
+ 	func(PXE, pxe, na) \
+ 	func(DHCP, dhcp, na)
+ #endif


### PR DESCRIPTION
# Description

U-boot will go into boot loop when SSD is attached to the USB 3 port. There is a conflict in the patch [patch/u-boot/v2022.10/meson64-boot-usb-nvme-scsi-first.patch](https://github.com/armbian/build/compare/main...sidzwans:armbian_build:main#diff-aa67f5741c5760bc98c06c863ff287c8d44589a2225fbd6bcffe6585258dc2e1). The boot loop has been resolved by removing the patch or by placing the priority of USB below MMC.

# How Has This Been Tested?
By compiling u-boot.bin  from trunk (linux-u-boot-bananapim5-current_23.05.0-trunk) for u-boot v2022.10 and v2023.4 and testing it on Bpi-M5. 

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Test A - Removing patch/u-boot/v2022.10/meson64-boot-usb-nvme-scsi-first.patch
- [x] Test B - Reordering the Priority of USB to be below MMC.

By executing Test A, BPi-M5 can boot successfully. It shows that the current patch to give higher order priority to usb/nvme/scsi  create conflict to the booting process. 

Test B reorder the USB to lower priority. The BPi-M5 can still boot successfully without any errors. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
