### PR TITLE
Enable FriendlyElec T6 build config

### DIFF
--- a/config/boards/nanopct6.wip
+++ b/config/boards/nanopct6.wip
@@ -1,0 +1,23 @@
+# Rockchip RK3588S octa core 8GB RAM SoC eMMC USB3 USB2 1x GbE 2x 2.5GbE
+BOARD_NAME="NanoPC T6"
+BOARDFAMILY="rockchip-rk3588"
+BOOTCONFIG="nanopi-r6s-rk3588s_defconfig" # vendor name, not standard, see hook below, set BOOT_SOC below to compensate
+BOOT_SOC="rk3588"
+KERNEL_TARGET="legacy"
+FULL_DESKTOP="yes"
+BOOT_LOGO="desktop"
+BOOT_FDT_FILE="rockchip/rk3588-nanopc-t6.dtb"
+BOOT_SCENARIO="spl-blobs"
+WIREGUARD="no"
+IMAGE_PARTITION_TABLE="gpt"
+SKIP_BOOTSPLASH="yes" # Skip boot splash patch, conflicts with CONFIG_VT=yes
+BOOTFS_TYPE="fat"
+
+function post_family_tweaks__nanopct6_naming_audios() {
+	display_alert "$BOARD" "Renaming nanopct6 audio" "info"
+
+	mkdir -p $SDCARD/etc/udev/rules.d/
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-hdmi0-sound", ENV{SOUND_DESCRIPTION}="HDMI0 Audio"' >$SDCARD/etc/udev/rules.d/90-naming-audios.rules
+
+	return 0
+}


### PR DESCRIPTION
# Description

As it was added to the kernel:
https://github.com/armbian/linux-rockchip/commit/29e755772b77ac9d3f181d8cb98428c934a1e199

Jira reference number [AR-1763]

# How Has This Been Tested?

- [x] No HW, just build test.

- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1763]: https://armbian.atlassian.net/browse/AR-1763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ