### PR TITLE
rk322x: update esp8089 driver to allow unloading

### DIFF
--- a/patch/kernel/archive/rk322x-6.1/wifi-4004-esp8089-kernel-driver.patch
+++ b/patch/kernel/archive/rk322x-6.1/wifi-4004-esp8089-kernel-driver.patch
@@ -633,7 +633,7 @@ index 000000000000..56b40db272f3
 +To load the module.
 diff --git a/drivers/net/wireless/esp8089/esp_ctrl.c b/drivers/net/wireless/esp8089/esp_ctrl.c
 new file mode 100644
-index 000000000000..ee64fab67a3b
+index 000000000000..a19d2437dd82
 --- /dev/null
 +++ b/drivers/net/wireless/esp8089/esp_ctrl.c
 @@ -0,0 +1,801 @@
@@ -3539,7 +3539,7 @@ index 000000000000..6c5c01aad4e5
 +}
 diff --git a/drivers/net/wireless/esp8089/esp_mac80211.c b/drivers/net/wireless/esp8089/esp_mac80211.c
 new file mode 100644
-index 000000000000..3c8a5ab9444f
+index 000000000000..14186365fdd4
 --- /dev/null
 +++ b/drivers/net/wireless/esp8089/esp_mac80211.c
 @@ -0,0 +1,1727 @@
@@ -5597,7 +5597,7 @@ index 000000000000..1ceb14bc3b15
 +#endif				/* _ESP_PATH_H_ */
 diff --git a/drivers/net/wireless/esp8089/esp_pub.h b/drivers/net/wireless/esp8089/esp_pub.h
 new file mode 100644
-index 000000000000..830dcac0a89b
+index 000000000000..0d3ad3655cf4
 --- /dev/null
 +++ b/drivers/net/wireless/esp8089/esp_pub.h
 @@ -0,0 +1,222 @@
@@ -6038,10 +6038,10 @@ index 000000000000..2d49f2bc8035
 +#endif				/* _ESP_SIF_H_ */
 diff --git a/drivers/net/wireless/esp8089/esp_sip.c b/drivers/net/wireless/esp8089/esp_sip.c
 new file mode 100644
-index 000000000000..7aaad88b942d
+index 000000000000..6602a1e22ab1
 --- /dev/null
 +++ b/drivers/net/wireless/esp8089/esp_sip.c
-@@ -0,0 +1,2418 @@
+@@ -0,0 +1,2420 @@
 +/*
 + * Copyright (c) 2009 - 2014 Espressif System.
 + *
@@ -8002,6 +8002,7 @@ index 000000000000..7aaad88b942d
 +	if (sip == NULL)
 +		return;
 +
++	esp_dbg(ESP_DBG_TRACE, "sip_detach: sip_free_init_ctrl_buf()");
 +	sip_free_init_ctrl_buf(sip);
 +
 +	if (atomic_read(&sip->state) == SIP_RUN) {
@@ -8016,7 +8017,7 @@ index 000000000000..7aaad88b942d
 +
 +		skb_queue_purge(&sip->rxq);
 +		mutex_destroy(&sip->rx_mtx);
-+		cancel_work_sync(&sip->epub->sendup_work);
++		cancel_work(&sip->epub->sendup_work); // Must be non-sync
 +		skb_queue_purge(&sip->epub->rxq);
 +
 +#ifdef ESP_NO_MAC80211
@@ -8048,6 +8049,7 @@ index 000000000000..7aaad88b942d
 +
 +		sif_disable_target_interrupt(sip->epub);
 +		atomic_set(&sip->state, SIP_STOP);
++
 +		sif_disable_irq(sip->epub);
 +
 +		if (sip->rawbuf)
@@ -9337,10 +9339,10 @@ index 000000000000..0dd35c82a001
 +   limitations under the License.
 diff --git a/drivers/net/wireless/esp8089/sdio_sif_esp.c b/drivers/net/wireless/esp8089/sdio_sif_esp.c
 new file mode 100644
-index 000000000000..97718f42e1a6
+index 000000000000..2bd2c63f5388
 --- /dev/null
 +++ b/drivers/net/wireless/esp8089/sdio_sif_esp.c
-@@ -0,0 +1,811 @@
+@@ -0,0 +1,824 @@
 +/*
 + * Copyright (c) 2010 -2013 Espressif System.
 + *
@@ -9370,6 +9372,7 @@ index 000000000000..97718f42e1a6
 +#include <net/mac80211.h>
 +#include <linux/time.h>
 +#include <linux/pm.h>
++#include <linux/delay.h>
 +
 +#include "esp_pub.h"
 +#include "esp_sif.h"
@@ -9978,6 +9981,7 @@ index 000000000000..97718f42e1a6
 +		sdio_claim_host(func);
 +		mmc_sw_reset(func->card);
 +		sdio_release_host(func);
++		msleep(10);
 +	}
 +
 +	return err;
@@ -10062,6 +10066,17 @@ index 000000000000..97718f42e1a6
 +	} while (0);
 +
 +	sdio_set_drvdata(func, NULL);
++
++	/*
++	 * Reset on sdio remove to leave the hardware in cold state,
++	 * so a new module insertion will be possible
++	 */
++	if (epub->sdio_state == ESP_SDIO_STATE_SECOND_INIT) {
++		sdio_claim_host(func);
++		mmc_hw_reset(func->card);
++		sdio_release_host(func);
++		mdelay(10);
++	}
 +
 +	esp_dbg(ESP_DBG_TRACE, "eagle sdio remove complete\n");
 +}

--- a/patch/kernel/archive/rk322x-6.3/wifi-4004-esp8089-kernel-driver.patch
+++ b/patch/kernel/archive/rk322x-6.3/wifi-4004-esp8089-kernel-driver.patch
@@ -633,7 +633,7 @@ index 000000000000..56b40db272f3
 +To load the module.
 diff --git a/drivers/net/wireless/esp8089/esp_ctrl.c b/drivers/net/wireless/esp8089/esp_ctrl.c
 new file mode 100644
-index 000000000000..ee64fab67a3b
+index 000000000000..a19d2437dd82
 --- /dev/null
 +++ b/drivers/net/wireless/esp8089/esp_ctrl.c
 @@ -0,0 +1,801 @@
@@ -3539,7 +3539,7 @@ index 000000000000..6c5c01aad4e5
 +}
 diff --git a/drivers/net/wireless/esp8089/esp_mac80211.c b/drivers/net/wireless/esp8089/esp_mac80211.c
 new file mode 100644
-index 000000000000..3c8a5ab9444f
+index 000000000000..14186365fdd4
 --- /dev/null
 +++ b/drivers/net/wireless/esp8089/esp_mac80211.c
 @@ -0,0 +1,1728 @@
@@ -5598,7 +5598,7 @@ index 000000000000..1ceb14bc3b15
 +#endif				/* _ESP_PATH_H_ */
 diff --git a/drivers/net/wireless/esp8089/esp_pub.h b/drivers/net/wireless/esp8089/esp_pub.h
 new file mode 100644
-index 000000000000..830dcac0a89b
+index 000000000000..0d3ad3655cf4
 --- /dev/null
 +++ b/drivers/net/wireless/esp8089/esp_pub.h
 @@ -0,0 +1,222 @@
@@ -6039,10 +6039,10 @@ index 000000000000..2d49f2bc8035
 +#endif				/* _ESP_SIF_H_ */
 diff --git a/drivers/net/wireless/esp8089/esp_sip.c b/drivers/net/wireless/esp8089/esp_sip.c
 new file mode 100644
-index 000000000000..7aaad88b942d
+index 000000000000..6602a1e22ab1
 --- /dev/null
 +++ b/drivers/net/wireless/esp8089/esp_sip.c
-@@ -0,0 +1,2418 @@
+@@ -0,0 +1,2420 @@
 +/*
 + * Copyright (c) 2009 - 2014 Espressif System.
 + *
@@ -8003,6 +8003,7 @@ index 000000000000..7aaad88b942d
 +	if (sip == NULL)
 +		return;
 +
++	esp_dbg(ESP_DBG_TRACE, "sip_detach: sip_free_init_ctrl_buf()");
 +	sip_free_init_ctrl_buf(sip);
 +
 +	if (atomic_read(&sip->state) == SIP_RUN) {
@@ -8017,7 +8018,7 @@ index 000000000000..7aaad88b942d
 +
 +		skb_queue_purge(&sip->rxq);
 +		mutex_destroy(&sip->rx_mtx);
-+		cancel_work_sync(&sip->epub->sendup_work);
++		cancel_work(&sip->epub->sendup_work); // Must be non-sync
 +		skb_queue_purge(&sip->epub->rxq);
 +
 +#ifdef ESP_NO_MAC80211
@@ -8049,6 +8050,7 @@ index 000000000000..7aaad88b942d
 +
 +		sif_disable_target_interrupt(sip->epub);
 +		atomic_set(&sip->state, SIP_STOP);
++
 +		sif_disable_irq(sip->epub);
 +
 +		if (sip->rawbuf)
@@ -9338,10 +9340,10 @@ index 000000000000..0dd35c82a001
 +   limitations under the License.
 diff --git a/drivers/net/wireless/esp8089/sdio_sif_esp.c b/drivers/net/wireless/esp8089/sdio_sif_esp.c
 new file mode 100644
-index 000000000000..97718f42e1a6
+index 000000000000..2bd2c63f5388
 --- /dev/null
 +++ b/drivers/net/wireless/esp8089/sdio_sif_esp.c
-@@ -0,0 +1,811 @@
+@@ -0,0 +1,824 @@
 +/*
 + * Copyright (c) 2010 -2013 Espressif System.
 + *
@@ -9371,6 +9373,7 @@ index 000000000000..97718f42e1a6
 +#include <net/mac80211.h>
 +#include <linux/time.h>
 +#include <linux/pm.h>
++#include <linux/delay.h>
 +
 +#include "esp_pub.h"
 +#include "esp_sif.h"
@@ -9979,6 +9982,7 @@ index 000000000000..97718f42e1a6
 +		sdio_claim_host(func);
 +		mmc_sw_reset(func->card);
 +		sdio_release_host(func);
++		msleep(10);
 +	}
 +
 +	return err;
@@ -10063,6 +10067,17 @@ index 000000000000..97718f42e1a6
 +	} while (0);
 +
 +	sdio_set_drvdata(func, NULL);
++
++	/*
++	 * Reset on sdio remove to leave the hardware in cold state,
++	 * so a new module insertion will be possible
++	 */
++	if (epub->sdio_state == ESP_SDIO_STATE_SECOND_INIT) {
++		sdio_claim_host(func);
++		mmc_hw_reset(func->card);
++		sdio_release_host(func);
++		mdelay(10);
++	}
 +
 +	esp_dbg(ESP_DBG_TRACE, "eagle sdio remove complete\n");
 +}


### PR DESCRIPTION
# Description

As per subject, fixes the esp8089 driver to allow module remove without errors and leave the hardware in cold state to allow further module insertion.

Not a great deal, can even wait after release, but only deal with CSC boards so should not be too worrisome.

# How Has This Been Tested?

- [x] Module has been tested 
- [x] Current kernel debian packages compile
- [x] Edge kernel debian packages compile

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
