### PR TITLE
fix rockchip 32 bit families patches for kernel 6.3

### DIFF
--- a/patch/kernel/archive/rk322x-6.3/01-linux-1000-drm-rockchip.patch
+++ b/patch/kernel/archive/rk322x-6.3/01-linux-1000-drm-rockchip.patch
@@ -1514,15 +1514,15 @@ index 66fee351f4a7..d6d8f3335813 100644
  err_bind:
  	drm_encoder_cleanup(encoder);
  err_disable_clk:
-@@ -719,7 +763,7 @@ static void dw_hdmi_rockchip_unbind(struct device *dev, struct device *master,
+@@ -639,7 +870,7 @@ static void dw_hdmi_rockchip_unbind(struct device *dev, struct device *master,
  {
  	struct rockchip_hdmi *hdmi = dev_get_drvdata(dev);
  
 -	dw_hdmi_unbind(hdmi->hdmi);
 +	dw_hdmi_remove(hdmi->hdmi);
+ 	drm_encoder_cleanup(&hdmi->encoder.encoder);
  	clk_disable_unprepare(hdmi->ref_clk);
  
- 	regulator_disable(hdmi->avdd_1v8);
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>

--- a/patch/kernel/archive/rockchip-6.3/01-linux-1000-drm-rockchip.patch
+++ b/patch/kernel/archive/rockchip-6.3/01-linux-1000-drm-rockchip.patch
@@ -1514,15 +1514,15 @@ index 66fee351f4a7..d6d8f3335813 100644
  err_bind:
  	drm_encoder_cleanup(encoder);
  err_disable_clk:
-@@ -719,7 +763,7 @@ static void dw_hdmi_rockchip_unbind(struct device *dev, struct device *master,
+@@ -639,7 +870,7 @@ static void dw_hdmi_rockchip_unbind(struct device *dev, struct device *master,
  {
  	struct rockchip_hdmi *hdmi = dev_get_drvdata(dev);
  
 -	dw_hdmi_unbind(hdmi->hdmi);
 +	dw_hdmi_remove(hdmi->hdmi);
+ 	drm_encoder_cleanup(&hdmi->encoder.encoder);
  	clk_disable_unprepare(hdmi->ref_clk);
  
- 	regulator_disable(hdmi->avdd_1v8);
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jonas Karlman <jonas@kwiboo.se>

--- a/patch/kernel/archive/rockchip-6.3/4016-workaround-broadcom-bt-serdev.patch
+++ b/patch/kernel/archive/rockchip-6.3/4016-workaround-broadcom-bt-serdev.patch
@@ -12,15 +12,16 @@ diff --git a/drivers/bluetooth/btbcm.c b/drivers/bluetooth/btbcm.c
 index 1b9743b7f..b274f1cdd 100644
 --- a/drivers/bluetooth/btbcm.c
 +++ b/drivers/bluetooth/btbcm.c
-@@ -87,7 +87,7 @@ int btbcm_check_bdaddr(struct hci_dev *hdev)
- 	    !bacmp(&bda->bdaddr, BDADDR_BCM43341B)) {
- 		bt_dev_info(hdev, "BCM: Using default device address (%pMR)",
- 			    &bda->bdaddr);
--		set_bit(HCI_QUIRK_INVALID_BDADDR, &hdev->quirks);
-+		//set_bit(HCI_QUIRK_INVALID_BDADDR, &hdev->quirks);
+@@ -129,7 +129,7 @@ int btbcm_check_bdaddr(struct hci_dev *hdev)
+ 		if (btbcm_set_bdaddr_from_efi(hdev) != 0) {
+ 			bt_dev_info(hdev, "BCM: Using default device address (%pMR)",
+ 				    &bda->bdaddr);
+-			set_bit(HCI_QUIRK_INVALID_BDADDR, &hdev->quirks);
++			//set_bit(HCI_QUIRK_INVALID_BDADDR, &hdev->quirks);
+ 		}
  	}
  
- 	kfree_skb(skb);
+
 -- 
 2.25.1
 


### PR DESCRIPTION
# Description

Same fixes for rockchip 32 bit and rk322x families applied to patches for kernel 6.1 [here](https://github.com/armbian/build/pull/5241), but for edge kernel 6.3 to let it compile happily.

Can wait next release, but it should be no harm in any case

# How Has This Been Tested?

- [x] Compiled kernel deb packages for rk322x
- [x] Compiled kernel deb packages for rockchip 32 bit

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
