### PR TITLE
build uboot for rock5a with spi flash support

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -197,6 +197,13 @@ prepare_boot_configuration() {
 		fi
 
 	fi
+
+	if [[ "$BOARD" == "rock-5a" ]];then
+		UBOOT_TARGET_MAP="
+		BL31=$RKBIN_DIR/$BL31_BLOB rock-5a-spi-rk3588s_defconfig spl/u-boot-spl.bin u-boot.itb;;rkspi_loader.img
+		BL31=$RKBIN_DIR/$BL31_BLOB rock-5a-rk3588s_defconfig spl/u-boot-spl.bin u-boot.itb;;idbloader.img u-boot.itb
+		"
+	fi
 }
 
 uboot_custom_postprocess() {


### PR DESCRIPTION
# Description

Rock5a has emmc and spi flash sharing the same pin, so we can't support them in the same devicetree. I've added a new uboot defconfig supporting spi flash: https://github.com/radxa/u-boot/pull/23. We have to build uboot twice for rock5a, the first time supporting spi flash, the second time supporting emmc.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Build image for rock5a and flash it to emmc, boot fine.
- [x] Flash rkspi_loader.img to spi flash, booting image flashed to nvme SSD, boot fine.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
