### PR TITLE
LED-green_power_on-red_status_heartbeat

### DIFF
--- a/patch/kernel/archive/sunxi-6.2/patches.armbian/arm64-dts-allwinner-h616-LED-green_power_on-red_status_heartbeat.patch
+++ b/patch/kernel/archive/sunxi-6.2/patches.armbian/arm64-dts-allwinner-h616-LED-green_power_on-red_status_heartbeat.patch
@@ -1,0 +1,39 @@
+From e88d105d8051a8f90e6103969858debf7a0946eb Mon Sep 17 00:00:00 2001
+From: AGM1968 <AGM1968@users.noreply.github.com>
+Date: Wed, 31 May 2023 08:12:00 +0000
+Subject: [PATCH] LED-green_power_on-red_status_heartbeat
+ arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts
+
+Signed-off-by: AGM1968 <AGM1968@users.noreply.github.com>
+---
+ .../boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts      | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts b/arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts
+index defb8b71f872..ddb5e387d1f4 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts
+@@ -29,16 +29,17 @@ leds {
+ 		compatible = "gpio-leds";
+ 
+ 		led-0 {
+-			function = LED_FUNCTION_POWER;
++			function = LED_FUNCTION_STATUS;
+ 			color = <LED_COLOR_ID_RED>;
+ 			gpios = <&pio 2 12 GPIO_ACTIVE_HIGH>; /* PC12 */
+-			default-state = "on";
++			linux,default-trigger = "heartbeat";
+ 		};
+ 
+ 		led-1 {
+-			function = LED_FUNCTION_STATUS;
++			function = LED_FUNCTION_POWER;
+ 			color = <LED_COLOR_ID_GREEN>;
+ 			gpios = <&pio 2 13 GPIO_ACTIVE_HIGH>; /* PC13 */
++			default-state = "on";
+ 		};
+ 	};
+ 
+-- 
+2.34.1
+

--- a/patch/kernel/archive/sunxi-6.2/series.armbian
+++ b/patch/kernel/archive/sunxi-6.2/series.armbian
@@ -107,6 +107,7 @@
 	patches.armbian/arm64-dts-allwinner-h616-Add-efuse_xlate-cpu-frequency-scaling-v1_6_2.patch
 	patches.armbian/arm64-dts-allwinner-h616-Add-thermal-sensor-and-thermal-zones.patch
 	patches.armbian/arm64-dts-allwinner-h616-Fix-thermal-zones-missing-trips.patch
+	patches.armbian/arm64-dts-allwinner-h616-LED-green_power_on-red_status_heartbeat.patch
 ###################
 	patches.armbian/arm64-dts-sun50i-a64-pine64-enable-Bluetooth.patch
 	patches.armbian/arm64-dts-sun50i-a64-sopine-baseboard-enable-Bluetooth.patch

--- a/patch/kernel/archive/sunxi-6.2/series.conf
+++ b/patch/kernel/archive/sunxi-6.2/series.conf
@@ -503,6 +503,7 @@
 	patches.armbian/arm64-dts-allwinner-h616-Add-efuse_xlate-cpu-frequency-scaling-v1_6_2.patch
 	patches.armbian/arm64-dts-allwinner-h616-Add-thermal-sensor-and-thermal-zones.patch
 	patches.armbian/arm64-dts-allwinner-h616-Fix-thermal-zones-missing-trips.patch
+	patches.armbian/arm64-dts-allwinner-h616-LED-green_power_on-red_status_heartbeat.patch
 ###################
 	patches.armbian/arm64-dts-sun50i-a64-pine64-enable-Bluetooth.patch
 	patches.armbian/arm64-dts-sun50i-a64-sopine-baseboard-enable-Bluetooth.patch


### PR DESCRIPTION
# Description

Simple change to h616 OrangepiZero2 LED's functioning.

Resembles Legacy kernel behavior, symbolically signifies more active development OrangepiZero2


# How Has This Been Tested?

- [x] Test A
compiled and booted with expected result
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
