### PR TITLE
BPI-CM4 IO: `Use the sdio-pwrseq to reset GPIOX_19`

### DIFF
--- a/patch/kernel/archive/meson64-6.1/add-board-bananapi-cm4-cm4io.patch
+++ b/patch/kernel/archive/meson64-6.1/add-board-bananapi-cm4-cm4io.patch
@@ -294,7 +294,7 @@ index 000000000000..97e522921b06
 +
 +	sdio_pwrseq: sdio-pwrseq {
 +		compatible = "mmc-pwrseq-simple";
-+		reset-gpios = <&gpio GPIOAO_6 GPIO_ACTIVE_LOW>;
++		reset-gpios = <&gpio GPIOAO_6 GPIO_ACTIVE_LOW>, <&gpio GPIOX_19 GPIO_ACTIVE_LOW>;
 +		clocks = <&wifi32k>;
 +		clock-names = "ext_clock";
 +	};

--- a/patch/kernel/archive/meson64-6.2/add-board-bananapi-cm4-cm4io.patch
+++ b/patch/kernel/archive/meson64-6.2/add-board-bananapi-cm4-cm4io.patch
@@ -294,7 +294,7 @@ index 000000000000..97e522921b06
 +
 +	sdio_pwrseq: sdio-pwrseq {
 +		compatible = "mmc-pwrseq-simple";
-+		reset-gpios = <&gpio GPIOAO_6 GPIO_ACTIVE_LOW>;
++		reset-gpios = <&gpio GPIOAO_6 GPIO_ACTIVE_LOW>, <&gpio GPIOX_19 GPIO_ACTIVE_LOW>;
 +		clocks = <&wifi32k>;
 +		clock-names = "ext_clock";
 +	};


### PR DESCRIPTION
This will reset bluetooth `host-wake-gpios`, enabling it to come back upon reboots.

Jira reference number [AR-1724]

# How Has This Been Tested?
- [X] On cold boot and reboot.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1724]: https://armbian.atlassian.net/browse/AR-1724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ