### PR TITLE
rpardini's bag-of-stuff incl fixes - early June/'23

### DIFF
--- a/extensions/nicod-armbian-gaming.sh
+++ b/extensions/nicod-armbian-gaming.sh
@@ -1,0 +1,34 @@
+#
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (c) 2023 Ricardo Pardini <ricardo@pardini.net>
+# This file is a part of the Armbian Build Framework https://github.com/armbian/build/
+#
+
+# Creates a launcher script for NicoD's armbian-gaming project.
+# Script will clone (or pull if already cloned) from NicoD's repo and run his script.
+
+function extension_prepare_config__800_nicod_launcher() {
+	EXTRA_IMAGE_SUFFIXES+=("-gaming") # global array; '800' hook is pretty much at the end
+	return 0
+}
+
+function pre_customize_image__add_nicod_launcher() {
+	display_alert "Adding NicoD's armbian-gaming launcher" "${EXTENSION}" "info"
+
+	local launcher_dir="${SDCARD}/usr/local/bin"
+	local launcher_file="${launcher_dir}/nicod-armbian-gaming"
+	run_host_command_logged mkdir -pv "${launcher_dir}"
+
+	cat <<- 'NICOD_GAMING_LAUNCHER_SCRIPT' > "${launcher_file}"
+		#!/usr/bin/env bash
+		if [[ ! -d ~/armbian-gaming ]]; then
+			git clone https://github.com/NicoD-SBC/armbian-gaming.git ~/armbian-gaming
+		fi
+		cd ~/armbian-gaming
+		git pull || true
+		bash armbian-gaming.sh "$@"
+	NICOD_GAMING_LAUNCHER_SCRIPT
+
+	run_host_command_logged chmod -v +x "${launcher_file}"
+	display_alert "Added NicoD's armbian-gaming launcher" "${EXTENSION}" "info"
+}

--- a/lib/functions/artifacts/artifact-uboot.sh
+++ b/lib/functions/artifacts/artifact-uboot.sh
@@ -63,6 +63,7 @@ function artifact_uboot_prepare_version() {
 	declare -a extension_hooks_to_hash=(
 		"post_uboot_custom_postprocess" "fetch_custom_uboot" "build_custom_uboot"
 		"pre_config_uboot_target" "post_uboot_custom_postprocess" "post_uboot_custom_postprocess"
+		"post_config_uboot_target"
 	)
 	declare -a extension_hooks_hashed=("$(dump_extension_method_sources_functions "${extension_hooks_to_hash[@]}")")
 	declare hash_hooks="undetermined"

--- a/lib/functions/compilation/patch/patching.sh
+++ b/lib/functions/compilation/patch/patching.sh
@@ -99,8 +99,8 @@ process_patch_file() {
 	patch --batch -p1 -N --input="${patch}" --quiet --reject-file=- && { # "-" discards rejects
 		display_alert "* $status ${relative_patch}" "" "info"
 	} || {
-		display_alert "* $status ${relative_patch}" "failed" "wrn"
-		[[ $EXIT_PATCHING_ERROR == yes ]] && exit_with_error "Aborting due to" "EXIT_PATCHING_ERROR"
+		display_alert "* $status ${relative_patch}" "failed" "err"
+		exit_with_error "Patching error, exiting."
 	}
 
 	return 0 # short-circuit above, avoid exiting with error

--- a/lib/functions/compilation/uboot.sh
+++ b/lib/functions/compilation/uboot.sh
@@ -147,6 +147,13 @@ function compile_uboot_target() {
 
 	fi
 
+	# Hook time, for extra post-processing
+	call_extension_method "post_config_uboot_target" <<- 'POST_CONFIG_UBOOT_TARGET'
+		*allow extensions prepare after configuring but before compiling an u-boot target*
+		Some u-boot targets require extra configuration or pre-processing before compiling.
+		Last chance to change .config for u-boot before compiling.
+	POST_CONFIG_UBOOT_TARGET
+
 	if [[ "${UBOOT_CONFIGURE:-"no"}" == "yes" ]]; then
 		display_alert "Configuring u-boot" "UBOOT_CONFIGURE=yes; experimental" "warn"
 		run_host_command_dialog make menuconfig

--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -377,6 +377,10 @@ function install_host_dependencies() {
 function check_host_has_enough_disk_space() {
 	declare -a dirs_to_check=("${DEST}" "${SRC}/cache")
 	for dir in "${dirs_to_check[@]}"; do
+		if [[ ! -d "${dir}" ]]; then
+			display_alert "Directory not found" "Skipping disk space check for '${dir}'" "debug"
+			continue
+		fi
 		check_dir_has_enough_disk_space "${dir}" 10 || exit_if_countdown_not_aborted 10 "Low free disk space left in '${dir}'"
 	done
 }

--- a/lib/functions/main/rootfs-image.sh
+++ b/lib/functions/main/rootfs-image.sh
@@ -39,6 +39,9 @@ function build_rootfs_and_image() {
 	# NOTE: installing too many packages may fill tmpfs mount
 	LOG_SECTION="customize_image" do_with_logging customize_image
 
+	# Deploy the full apt lists, including the Armbian repo.
+	create_sources_list_and_deploy_repo_key "image-late" "${RELEASE}" "${SDCARD}/"
+
 	# remove packages that are no longer needed. rootfs cache + uninstall might have leftovers.
 	LOG_SECTION="apt_purge_unneeded_packages_and_clean_apt_caches" do_with_logging apt_purge_unneeded_packages_and_clean_apt_caches
 

--- a/lib/functions/rootfs/create-cache.sh
+++ b/lib/functions/rootfs/create-cache.sh
@@ -125,8 +125,8 @@ function extract_rootfs_artifact() {
 	run_host_command_logged echo "nameserver ${NAMESERVER}" ">" "${SDCARD}"/etc/resolv.conf
 
 	# all sources etc.
-	# armbian repo is fully included, inclusive the components that have debs produced by armbian/build.
-	create_sources_list_and_deploy_repo_key "image" "${RELEASE}" "${SDCARD}/"
+	# armbian repo is NOT yet included here, since we'll be building the image, and don't want the repo interferring.
+	create_sources_list_and_deploy_repo_key "image-early" "${RELEASE}" "${SDCARD}/"
 
 	return 0
 }

--- a/lib/functions/rootfs/distro-agnostic.sh
+++ b/lib/functions/rootfs/distro-agnostic.sh
@@ -442,7 +442,9 @@ function install_distribution_agnostic() {
 	run_host_command_logged cp -v "${SRC}"/packages/bsp/armbian_first_run.txt.template "${SDCARD}"/boot/armbian_first_run.txt.template
 
 	# switch to beta repository at this stage if building nightly images
-	[[ $IMAGE_TYPE == nightly ]] && sed -i 's/apt/beta/' "${SDCARD}"/etc/apt/sources.list.d/armbian.list
+	if [[ $IMAGE_TYPE == nightly && -f "${SDCARD}"/etc/apt/sources.list.d/armbian.list ]]; then
+		sed -i 's/apt/beta/' "${SDCARD}"/etc/apt/sources.list.d/armbian.list
+	fi
 
 	# fix for https://bugs.launchpad.net/ubuntu/+source/blueman/+bug/1542723 @TODO: from ubuntu 15. maybe gone?
 	chroot_sdcard chown root:messagebus /usr/lib/dbus-1.0/dbus-daemon-launch-helper

--- a/lib/tools/info/repo-reprepro.py
+++ b/lib/tools/info/repo-reprepro.py
@@ -78,7 +78,6 @@ log.info(f"Wrote {reprepro_conf_distributions_fn}")
 
 options: list[str] = []
 options.append("verbose")
-# options.append(f"basedir /armbian/output/repos/single-dir")
 
 # create the reprerepo options file for the target
 with open(reprepro_conf_options_fn, "w") as f:
@@ -89,13 +88,17 @@ log.info(f"Wrote {reprepro_conf_options_fn}")
 # Prepare the reprepro-invoking bash script
 bash_lines = [
 	"#!/bin/bash",
-	"set",
-	'ls -laR "${INCOMING_DEBS_DIR}"'
+	'mkdir -p "${REPO_CONF_LOCATION}"',
+	'cp -rv "${REPREPRO_INFO_DIR}/conf"/* "${REPO_CONF_LOCATION}"/',
+	# run clearvanished
+	'echo "reprepro clearvanished..."',
+	'reprepro -b "${REPO_LOCATION}" --delete clearvanished || echo "clearvanished failed"',
+	# run reprepro check
+	'echo "reprepro initial check..."',
+	'reprepro -b "${REPO_LOCATION}" check || echo "initial check failed"'
 ]
 
 # Copy the config files to the repo dir (from REPREPRO_INFO_DIR/conf to REPO_CONF_LOCATION script-side)
-bash_lines.append('mkdir -p "${REPO_CONF_LOCATION}"')
-bash_lines.append('cp -rv "${REPREPRO_INFO_DIR}/conf"/* "${REPO_CONF_LOCATION}"/')
 
 for one_repo_target in repo_targets:
 	artifacts = repo_targets[one_repo_target]


### PR DESCRIPTION
#### rpardini's bag-of-stuff incl fixes - early June/'23

> I'm back at it, fixing and breaking stuff.
> Fixing: 

- prepare-host: `check_host_has_enough_disk_space()`: don't check if dir does not exist; fixes #5246
- distro-agnostic: don't assume `armbian.list` exists when `sed`ing for beta
- pipeline: repo-reprepro: run clearvanished & check before adding to repo

> Breaking: 

- BREAKING CHANGE: patches failing to apply now break the build. fixes #4958
  - also break on legacy `process_patch_file()` failure, remove `EXIT_PATCHING_ERROR`

- repo: split `image` apt .list deployment into `image-early` (after rootfs extract, before building) and `image-late` (after building)
  - rationale: having the repo enabled during the image build can cause 'apt upgrade' and others to do inconsistent stuff depending on the (possibly random) state of the repo

> Other stuff

- `armbian-gaming` customize launcher for @NicoD-SBC (v2)
  - add image suffix `-gaming`
- uboot: introduce hook `post_config_uboot_target`, runs after other configuration changes, but before actually compiling a target

