### PR TITLE
`rock-5a`: fix broken u-boot build + move from family to board file

### DIFF
--- a/config/boards/rock-5a.wip
+++ b/config/boards/rock-5a.wip
@@ -24,3 +24,11 @@ function post_family_tweaks__rock5a_naming_audios() {
 
 	return 0
 }
+
+function post_family_config_branch_legacy__dual_uboot_for_rock5a() {
+	display_alert "$BOARD" "Configuring ($BOARD) normal/SPI uboot target map" "info"
+	UBOOT_TARGET_MAP="
+	BL31=$RKBIN_DIR/$BL31_BLOB rock-5a-spi-rk3588s_defconfig spl/u-boot-spl.bin u-boot.dtb u-boot.itb;;rkspi_loader.img
+	BL31=$RKBIN_DIR/$BL31_BLOB rock-5a-rk3588s_defconfig spl/u-boot-spl.bin u-boot.dtb u-boot.itb;;idbloader.img u-boot.itb
+	"
+}

--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -200,8 +200,8 @@ prepare_boot_configuration() {
 
 	if [[ "$BOARD" == "rock-5a" ]];then
 		UBOOT_TARGET_MAP="
-		BL31=$RKBIN_DIR/$BL31_BLOB rock-5a-spi-rk3588s_defconfig spl/u-boot-spl.bin u-boot.itb;;rkspi_loader.img
-		BL31=$RKBIN_DIR/$BL31_BLOB rock-5a-rk3588s_defconfig spl/u-boot-spl.bin u-boot.itb;;idbloader.img u-boot.itb
+		BL31=$RKBIN_DIR/$BL31_BLOB rock-5a-spi-rk3588s_defconfig spl/u-boot-spl.bin u-boot.dtb u-boot.itb;;rkspi_loader.img
+		BL31=$RKBIN_DIR/$BL31_BLOB rock-5a-rk3588s_defconfig spl/u-boot-spl.bin u-boot.dtb u-boot.itb;;idbloader.img u-boot.itb
 		"
 	fi
 }

--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -198,12 +198,6 @@ prepare_boot_configuration() {
 
 	fi
 
-	if [[ "$BOARD" == "rock-5a" ]];then
-		UBOOT_TARGET_MAP="
-		BL31=$RKBIN_DIR/$BL31_BLOB rock-5a-spi-rk3588s_defconfig spl/u-boot-spl.bin u-boot.dtb u-boot.itb;;rkspi_loader.img
-		BL31=$RKBIN_DIR/$BL31_BLOB rock-5a-rk3588s_defconfig spl/u-boot-spl.bin u-boot.dtb u-boot.itb;;idbloader.img u-boot.itb
-		"
-	fi
 }
 
 uboot_custom_postprocess() {


### PR DESCRIPTION
#### `rock-5a`: fix broken u-boot build + move from family to board file

- rock-5a: fix broken u-boot build by forcing build of `u-boot.dtb` before `u-boot.itb`
- rock-5a: move board-specific code from family file to board file with `post_family_config_branch_legacy` hook 