### PR TITLE
`uboot`: introduce hook `post_config_uboot_target`

### DIFF
--- a/lib/functions/artifacts/artifact-uboot.sh
+++ b/lib/functions/artifacts/artifact-uboot.sh
@@ -63,6 +63,7 @@ function artifact_uboot_prepare_version() {
 	declare -a extension_hooks_to_hash=(
 		"post_uboot_custom_postprocess" "fetch_custom_uboot" "build_custom_uboot"
 		"pre_config_uboot_target" "post_uboot_custom_postprocess" "post_uboot_custom_postprocess"
+		"post_config_uboot_target"
 	)
 	declare -a extension_hooks_hashed=("$(dump_extension_method_sources_functions "${extension_hooks_to_hash[@]}")")
 	declare hash_hooks="undetermined"

--- a/lib/functions/compilation/uboot.sh
+++ b/lib/functions/compilation/uboot.sh
@@ -147,6 +147,13 @@ function compile_uboot_target() {
 
 	fi
 
+	# Hook time, for extra post-processing
+	call_extension_method "post_config_uboot_target" <<- 'POST_CONFIG_UBOOT_TARGET'
+		*allow extensions prepare after configuring but before compiling an u-boot target*
+		Some u-boot targets require extra configuration or pre-processing before compiling.
+		Last chance to change .config for u-boot before compiling.
+	POST_CONFIG_UBOOT_TARGET
+
 	if [[ "${UBOOT_CONFIGURE:-"no"}" == "yes" ]]; then
 		display_alert "Configuring u-boot" "UBOOT_CONFIGURE=yes; experimental" "warn"
 		run_host_command_dialog make menuconfig


### PR DESCRIPTION
#### `uboot`: introduce hook `post_config_uboot_target`

- `uboot`: introduce hook `post_config_uboot_target`
  - runs after other configuration changes, but before actually compiling a target
  - useful to hack into `.config` for a specific target