### PR TITLE
repo: split `image` apt .list deployment into `image-early` and `image-late`

### DIFF
--- a/lib/functions/main/rootfs-image.sh
+++ b/lib/functions/main/rootfs-image.sh
@@ -39,6 +39,9 @@ function build_rootfs_and_image() {
 	# NOTE: installing too many packages may fill tmpfs mount
 	LOG_SECTION="customize_image" do_with_logging customize_image
 
+	# Deploy the full apt lists, including the Armbian repo.
+	create_sources_list_and_deploy_repo_key "image-late" "${RELEASE}" "${SDCARD}/"
+
 	# remove packages that are no longer needed. rootfs cache + uninstall might have leftovers.
 	LOG_SECTION="apt_purge_unneeded_packages_and_clean_apt_caches" do_with_logging apt_purge_unneeded_packages_and_clean_apt_caches
 

--- a/lib/functions/rootfs/create-cache.sh
+++ b/lib/functions/rootfs/create-cache.sh
@@ -125,8 +125,8 @@ function extract_rootfs_artifact() {
 	run_host_command_logged echo "nameserver ${NAMESERVER}" ">" "${SDCARD}"/etc/resolv.conf
 
 	# all sources etc.
-	# armbian repo is fully included, inclusive the components that have debs produced by armbian/build.
-	create_sources_list_and_deploy_repo_key "image" "${RELEASE}" "${SDCARD}/"
+	# armbian repo is NOT yet included here, since we'll be building the image, and don't want the repo interferring.
+	create_sources_list_and_deploy_repo_key "image-early" "${RELEASE}" "${SDCARD}/"
 
 	return 0
 }


### PR DESCRIPTION
#### repo: split `image` apt .list deployment into `image-early` and `image-late`

- repo: split `image` apt .list deployment into `image-early` and `image-late`
  - split `image` apt .list deployment into `image-early` (after rootfs extract, before building) and `image-late` (after building)
  - rationale: having the repo enabled during the image build can cause 'apt upgrade' and others to do inconsistent stuff depending on the (possibly random) state of the repo