### PR TITLE
Fix 32-bit allwinner hang issue 

### DIFF
--- a/patch/kernel/archive/sunxi-6.1/patches.armbian/net-phy-Support-yt8531c.patch
+++ b/patch/kernel/archive/sunxi-6.1/patches.armbian/net-phy-Support-yt8531c.patch
@@ -4,99 +4,13 @@ Date: Fri, 25 Mar 2022 20:20:34 +0000
 Subject: [PATCH 148/158] net: phy: Support yt8531c
 
 ---
- .../net/ethernet/stmicro/stmmac/stmmac_main.c |   60 +
  drivers/net/phy/motorcomm.c                   | 1561 ++++++++++++++++-
  drivers/net/phy/yt8614-phy.h                  |  491 ++++++
  include/linux/motorcomm_phy.h                 |  119 ++
- 4 files changed, 2152 insertions(+), 79 deletions(-)
+ 3 files changed, 2092 insertions(+), 79 deletions(-)
  create mode 100644 drivers/net/phy/yt8614-phy.h
  create mode 100644 include/linux/motorcomm_phy.h
 
-diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index 84e1740b1..b281ae5fb 100644
---- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-+++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-@@ -146,6 +146,9 @@ static void stmmac_exit_fs(struct net_device *dev);
- 
- #define STMMAC_COAL_TIMER(x) (ns_to_ktime((x) * NSEC_PER_USEC))
- 
-+#define RTL_8211E_PHY_ID  0x001cc915
-+#define RTL_8211F_PHY_ID  0x001cc916
-+
- int stmmac_bus_clks_config(struct stmmac_priv *priv, bool enabled)
- {
- 	int ret = 0;
-@@ -7040,6 +7043,54 @@ void stmmac_fpe_handshake(struct stmmac_priv *priv, bool enable)
- 	}
- }
- 
-+static int phy_rtl8211e_led_fixup(struct phy_device *phydev)
-+{
-+       //int val;
-+
-+       printk("%s in\n", __func__);
-+
-+       /*switch to extension page44*/
-+       phy_write(phydev, 31, 0x07);
-+       phy_write(phydev, 30, 0x2c);
-+
-+       /*set led1(yellow) act
-+       val = phy_read(phydev, 26);
-+       val &= (~(1<<4));// bit4=0
-+       val |= (1<<5);// bit5=1
-+       val &= (~(1<<6));// bit6=0*/
-+       phy_write(phydev, 26, 0x20);
-+
-+       /*set led0(green) link
-+       val = phy_read(phydev, 28);
-+       val |= (7<<0);// bit0,1,2=1
-+       val &= (~(7<<4));// bit4,5,6=0
-+       val &= (~(7<<8));// bit8,9,10=0*/
-+       phy_write(phydev, 28, 0x07);
-+
-+       /*switch back to page0*/
-+       phy_write(phydev,31,0x00);
-+
-+       return 0;
-+}
-+
-+static int phy_rtl8211f_led_fixup(struct phy_device *phydev)
-+{
-+       printk("%s in\n", __func__);
-+
-+       /*switch to extension page44*/
-+       phy_write(phydev, 31, 0xd04);
-+
-+       /*set led1(yellow) act */
-+       /*set led2(green) link*/
-+       phy_write(phydev, 16, 0xae00);
-+
-+       phy_write(phydev, 17, 0);
-+       /*switch back to page0*/
-+       phy_write(phydev,31,0x00);
-+
-+       return 0;
-+}
-+
- /**
-  * stmmac_dvr_probe
-  * @device: device pointer
-@@ -7300,6 +7351,15 @@ int stmmac_dvr_probe(struct device *device,
- 		goto error_phy_setup;
- 	}
- 
-+	/* register the PHY board fixup */
-+	ret = phy_register_fixup_for_uid(RTL_8211E_PHY_ID, 0xffffffff, phy_rtl8211e_led_fixup);
-+	if (ret)
-+		pr_warn("Cannot register PHY board fixup.\n");
-+
-+	ret = phy_register_fixup_for_uid(RTL_8211F_PHY_ID, 0xffffffff, phy_rtl8211f_led_fixup);
-+	if (ret)
-+		pr_warn("Cannot register PHY board fixup.\n");
-+
- 	ret = register_netdev(ndev);
- 	if (ret) {
- 		dev_err(priv->device, "%s: ERROR %i registering the device\n",
 diff --git a/drivers/net/phy/motorcomm.c b/drivers/net/phy/motorcomm.c
 index 7e6ac2c5e..c6876bd08 100644
 --- a/drivers/net/phy/motorcomm.c

--- a/patch/kernel/archive/sunxi-6.2/patches.armbian/net-phy-Support-yt8531c.patch
+++ b/patch/kernel/archive/sunxi-6.2/patches.armbian/net-phy-Support-yt8531c.patch
@@ -4,99 +4,13 @@ Date: Fri, 25 Mar 2022 20:20:34 +0000
 Subject: [PATCH 161/170] net: phy: Support yt8531c
 
 ---
- .../net/ethernet/stmicro/stmmac/stmmac_main.c |   60 +
  drivers/net/phy/motorcomm.c                   | 1561 ++++++++++++++++-
  drivers/net/phy/yt8614-phy.h                  |  491 ++++++
  include/linux/motorcomm_phy.h                 |  119 ++
- 4 files changed, 2152 insertions(+), 79 deletions(-)
+ 3 files changed, 2092 insertions(+), 79 deletions(-)
  create mode 100644 drivers/net/phy/yt8614-phy.h
  create mode 100644 include/linux/motorcomm_phy.h
 
-diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index c5f33630e..9f0a33e21 100644
---- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-+++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-@@ -143,6 +143,9 @@ static void stmmac_exit_fs(struct net_device *dev);
- 
- #define STMMAC_COAL_TIMER(x) (ns_to_ktime((x) * NSEC_PER_USEC))
- 
-+#define RTL_8211E_PHY_ID  0x001cc915
-+#define RTL_8211F_PHY_ID  0x001cc916
-+
- int stmmac_bus_clks_config(struct stmmac_priv *priv, bool enabled)
- {
- 	int ret = 0;
-@@ -6891,6 +6894,54 @@ void stmmac_fpe_handshake(struct stmmac_priv *priv, bool enable)
- 	}
- }
- 
-+static int phy_rtl8211e_led_fixup(struct phy_device *phydev)
-+{
-+       //int val;
-+
-+       printk("%s in\n", __func__);
-+
-+       /*switch to extension page44*/
-+       phy_write(phydev, 31, 0x07);
-+       phy_write(phydev, 30, 0x2c);
-+
-+       /*set led1(yellow) act
-+       val = phy_read(phydev, 26);
-+       val &= (~(1<<4));// bit4=0
-+       val |= (1<<5);// bit5=1
-+       val &= (~(1<<6));// bit6=0*/
-+       phy_write(phydev, 26, 0x20);
-+
-+       /*set led0(green) link
-+       val = phy_read(phydev, 28);
-+       val |= (7<<0);// bit0,1,2=1
-+       val &= (~(7<<4));// bit4,5,6=0
-+       val &= (~(7<<8));// bit8,9,10=0*/
-+       phy_write(phydev, 28, 0x07);
-+
-+       /*switch back to page0*/
-+       phy_write(phydev,31,0x00);
-+
-+       return 0;
-+}
-+
-+static int phy_rtl8211f_led_fixup(struct phy_device *phydev)
-+{
-+       printk("%s in\n", __func__);
-+
-+       /*switch to extension page44*/
-+       phy_write(phydev, 31, 0xd04);
-+
-+       /*set led1(yellow) act */
-+       /*set led2(green) link*/
-+       phy_write(phydev, 16, 0xae00);
-+
-+       phy_write(phydev, 17, 0);
-+       /*switch back to page0*/
-+       phy_write(phydev,31,0x00);
-+
-+       return 0;
-+}
-+
- /**
-  * stmmac_dvr_probe
-  * @device: device pointer
-@@ -7150,6 +7201,15 @@ int stmmac_dvr_probe(struct device *device,
- 		goto error_phy_setup;
- 	}
- 
-+	/* register the PHY board fixup */
-+	ret = phy_register_fixup_for_uid(RTL_8211E_PHY_ID, 0xffffffff, phy_rtl8211e_led_fixup);
-+	if (ret)
-+		pr_warn("Cannot register PHY board fixup.\n");
-+
-+	ret = phy_register_fixup_for_uid(RTL_8211F_PHY_ID, 0xffffffff, phy_rtl8211f_led_fixup);
-+	if (ret)
-+		pr_warn("Cannot register PHY board fixup.\n");
-+
- 	ret = register_netdev(ndev);
- 	if (ret) {
- 		dev_err(priv->device, "%s: ERROR %i registering the device\n",
 diff --git a/drivers/net/phy/motorcomm.c b/drivers/net/phy/motorcomm.c
 index 7e6ac2c5e..c6876bd08 100644
 --- a/drivers/net/phy/motorcomm.c


### PR DESCRIPTION
Remove stmmac change from net-phy-Support-yt8531c.patch as its causing 32-bit allwinner boards to hang on boot

# Description

The 32-bit allwinner boards are known to hang with 6.1.30 kernel. On investigation, I was able to narrow the issue down to the above mentioned patch. The patch is supposed to add support for yt8531c, but it was also modifying stmmac ethernet driver to add a fix for realtek chip. Removing that code solved the issue.

Jira reference number [AR-1764]

# How Has This Been Tested?

Created an bookworm current image for nanopi duo2 with and without stmmac part removed.

- [X] Removing the stmmac part of the patch results into board booting successfully
- [X] Restoring the stmmac part of the patch causes the board to hang


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules


[AR-1764]: https://armbian.atlassian.net/browse/AR-1764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ