### PR TITLE
Add iw to default packages

### DIFF
--- a/config/cli/bullseye/main/packages.additional
+++ b/config/cli/bullseye/main/packages.additional
@@ -1,6 +1,7 @@
 curl
 htop
 i2c-tools
+iw
 jq
 libcrack2
 lsof

--- a/config/cli/buster/main/packages.additional
+++ b/config/cli/buster/main/packages.additional
@@ -1,6 +1,7 @@
 curl
 htop
 i2c-tools
+iw
 jq
 libcrack2
 lsof

--- a/config/cli/focal/main/packages.additional
+++ b/config/cli/focal/main/packages.additional
@@ -1,6 +1,7 @@
 curl
 htop
 i2c-tools
+iw
 jq
 libcrack2
 lsof

--- a/config/cli/jammy/main/packages.additional
+++ b/config/cli/jammy/main/packages.additional
@@ -1,6 +1,7 @@
 curl
 htop
 i2c-tools
+iw
 jq
 libcrack2
 lsof


### PR DESCRIPTION
# Description

Requirement for commit c83b11cf1486ade72cfb92447e9212e654b43d8f so iw command is available on the default images.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
