### PR TITLE
Add iw to default packages

### DIFF
--- a/config/cli/common/main/packages
+++ b/config/cli/common/main/packages
@@ -19,6 +19,7 @@ htop
 inetutils-ping
 init
 initramfs-tools
+iw
 jq
 logrotate
 less


### PR DESCRIPTION

# Description

Requirement for commit c83b11cf1486ade72cfb92447e9212e654b43d8f so iw command is available on the default images.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
