### PR TITLE
patch: misc: rtw88: 6.1: `backport updates`

### DIFF
--- a/patch/misc/rtw88/6.1/001-rtw88-linux-next.patch
+++ b/patch/misc/rtw88/6.1/001-rtw88-linux-next.patch
@@ -156,8 +156,8 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/debug.h b/drivers/net/wireless/r
  	RTW_DBG_ALL		= 0xffffffff
  };
 diff -Naur a/drivers/net/wireless/realtek/rtw88/fw.c b/drivers/net/wireless/realtek/rtw88/fw.c
---- a/drivers/net/wireless/realtek/rtw88/fw.c	2023-05-24 12:32:53.000000000 -0400
-+++ b/drivers/net/wireless/realtek/rtw88/fw.c	2023-05-26 05:23:16.006634263 -0400
+--- a/drivers/net/wireless/realtek/rtw88/fw.c	2023-06-05 03:26:22.000000000 -0400
++++ b/drivers/net/wireless/realtek/rtw88/fw.c	2023-06-06 04:57:49.608769980 -0400
 @@ -311,10 +311,10 @@
  static void rtw_fw_send_h2c_command(struct rtw_dev *rtwdev,
  				    u8 *h2c)
@@ -228,9 +228,26 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/fw.c b/drivers/net/wireless/real
  }
  
  void
+@@ -823,6 +816,16 @@
+ 
+ 	rtw_fw_send_h2c_command(rtwdev, h2c_pkt);
+ }
++
++void rtw_fw_set_recover_bt_device(struct rtw_dev *rtwdev)
++{
++	u8 h2c_pkt[H2C_PKT_SIZE] = {0};
++
++	SET_H2C_CMD_ID_CLASS(h2c_pkt, H2C_CMD_RECOVER_BT_DEV);
++	SET_RECOVER_BT_DEV_EN(h2c_pkt, 1);
++
++	rtw_fw_send_h2c_command(rtwdev, h2c_pkt);
++}
+ 
+ void rtw_fw_set_pg_info(struct rtw_dev *rtwdev)
+ {
 diff -Naur a/drivers/net/wireless/realtek/rtw88/fw.h b/drivers/net/wireless/realtek/rtw88/fw.h
---- a/drivers/net/wireless/realtek/rtw88/fw.h	2023-05-24 12:32:53.000000000 -0400
-+++ b/drivers/net/wireless/realtek/rtw88/fw.h	2023-05-26 05:23:16.001634342 -0400
+--- a/drivers/net/wireless/realtek/rtw88/fw.h	2023-06-05 03:26:22.000000000 -0400
++++ b/drivers/net/wireless/realtek/rtw88/fw.h	2023-06-06 04:57:49.609769974 -0400
 @@ -81,6 +81,11 @@
  	u8 option;
  } __packed;
@@ -243,6 +260,33 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/fw.h b/drivers/net/wireless/real
  enum rtw_rsvd_packet_type {
  	RSVD_BEACON,
  	RSVD_DUMMY,
+@@ -550,6 +555,8 @@
+ #define H2C_CMD_AOAC_GLOBAL_INFO	0x82
+ #define H2C_CMD_NLO_INFO		0x8C
+ 
++#define H2C_CMD_RECOVER_BT_DEV		0xD1
++
+ #define SET_H2C_CMD_ID_CLASS(h2c_pkt, value)				       \
+ 	le32p_replace_bits((__le32 *)(h2c_pkt) + 0x00, value, GENMASK(7, 0))
+ 
+@@ -749,6 +756,9 @@
+ #define SET_NLO_LOC_NLO_INFO(h2c_pkt, value)                                   \
+ 	le32p_replace_bits((__le32 *)(h2c_pkt) + 0x00, value, GENMASK(23, 16))
+ 
++#define SET_RECOVER_BT_DEV_EN(h2c_pkt, value)				       \
++	le32p_replace_bits((__le32 *)(h2c_pkt) + 0x00, value, BIT(8))
++
+ #define GET_FW_DUMP_LEN(_header)					\
+ 	le32_get_bits(*((__le32 *)(_header) + 0x00), GENMASK(15, 0))
+ #define GET_FW_DUMP_SEQ(_header)					\
+@@ -838,6 +848,7 @@
+ 				     u8 group_key_enc);
+ 
+ void rtw_fw_set_nlo_info(struct rtw_dev *rtwdev, bool enable);
++void rtw_fw_set_recover_bt_device(struct rtw_dev *rtwdev);
+ void rtw_fw_update_pkt_probe_req(struct rtw_dev *rtwdev,
+ 				 struct cfg80211_ssid *ssid);
+ void rtw_fw_channel_switch(struct rtw_dev *rtwdev, bool enable);
 diff -Naur a/drivers/net/wireless/realtek/rtw88/hci.h b/drivers/net/wireless/realtek/rtw88/hci.h
 --- a/drivers/net/wireless/realtek/rtw88/hci.h	2023-05-24 12:32:53.000000000 -0400
 +++ b/drivers/net/wireless/realtek/rtw88/hci.h	2023-05-26 05:23:16.041633711 -0400
@@ -450,8 +494,8 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/mac80211.c b/drivers/net/wireles
  	return 0;
  }
 diff -Naur a/drivers/net/wireless/realtek/rtw88/mac.c b/drivers/net/wireless/realtek/rtw88/mac.c
---- a/drivers/net/wireless/realtek/rtw88/mac.c	2023-05-24 12:32:53.000000000 -0400
-+++ b/drivers/net/wireless/realtek/rtw88/mac.c	2023-05-26 05:23:16.060633411 -0400
+--- a/drivers/net/wireless/realtek/rtw88/mac.c	2023-06-05 03:26:22.000000000 -0400
++++ b/drivers/net/wireless/realtek/rtw88/mac.c	2023-06-06 04:57:49.609769974 -0400
 @@ -7,6 +7,7 @@
  #include "reg.h"
  #include "fw.h"
@@ -519,7 +563,7 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/mac.c b/drivers/net/wireless/rea
  	u8 rpwm;
  	bool cur_pwr;
  	int ret;
-@@ -270,16 +296,28 @@
+@@ -270,16 +296,31 @@
  	if (pwr_on == cur_pwr)
  		return -EALREADY;
  
@@ -533,12 +577,11 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/mac.c b/drivers/net/wireless/rea
 +	rtw_write32(rtwdev, REG_SDIO_HIMR, 0);
 +
  	pwr_seq = pwr_on ? chip->pwr_on_seq : chip->pwr_off_seq;
--	ret = rtw_pwr_seq_parser(rtwdev, pwr_seq);
+ 	ret = rtw_pwr_seq_parser(rtwdev, pwr_seq);
 -	if (ret)
--		return ret;
-+	if (rtw_pwr_seq_parser(rtwdev, pwr_seq)) {
++	if (ret) {
 +		rtw_write32(rtwdev, REG_SDIO_HIMR, imr);
-+ 		return -EINVAL;
+ 		return ret;
 +	}
  
  	if (pwr_on)
@@ -548,10 +591,12 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/mac.c b/drivers/net/wireless/rea
  
 +	rtw_hci_power_switch(rtwdev, pwr_on);
 +
++	rtw_write32(rtwdev, REG_SDIO_HIMR, imr);
++
  	return 0;
  }
  
-@@ -451,6 +489,9 @@
+@@ -451,6 +492,9 @@
  	rtw_write16(rtwdev, REG_FIFOPAGE_INFO_1, 0x200);
  	rtw_write32(rtwdev, REG_RQPN_CTRL_2, bckp[bckp_idx - 1].val);
  
@@ -561,7 +606,39 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/mac.c b/drivers/net/wireless/rea
  	/* Disable beacon related functions */
  	tmp = rtw_read8(rtwdev, REG_BCN_CTRL);
  	bckp[bckp_idx].len = 1;
-@@ -1026,6 +1067,9 @@
+@@ -918,7 +962,8 @@
+ 	return ret;
+ }
+ 
+-int rtw_download_firmware(struct rtw_dev *rtwdev, struct rtw_fw_state *fw)
++static
++int _rtw_download_firmware(struct rtw_dev *rtwdev, struct rtw_fw_state *fw)
+ {
+ 	if (rtw_chip_wcpu_11n(rtwdev))
+ 		return __rtw_download_firmware_legacy(rtwdev, fw);
+@@ -926,6 +971,21 @@
+ 	return __rtw_download_firmware(rtwdev, fw);
+ }
+ 
++int rtw_download_firmware(struct rtw_dev *rtwdev, struct rtw_fw_state *fw)
++{
++	int ret;
++
++	ret = _rtw_download_firmware(rtwdev, fw);
++	if (ret)
++		return ret;
++
++	if (rtw_hci_type(rtwdev) == RTW_HCI_TYPE_PCIE &&
++	    rtwdev->chip->id == RTW_CHIP_TYPE_8821C)
++		rtw_fw_set_recover_bt_device(rtwdev);
++
++	return 0;
++}
++
+ static u32 get_priority_queues(struct rtw_dev *rtwdev, u32 queues)
+ {
+ 	const struct rtw_rqpn *rqpn = rtwdev->fifo.rqpn;
+@@ -1026,6 +1086,9 @@
  		else
  			return -EINVAL;
  		break;
@@ -571,13 +648,10 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/mac.c b/drivers/net/wireless/rea
  	default:
  		return -EINVAL;
  	}
-@@ -1044,6 +1088,16 @@
+@@ -1044,6 +1107,13 @@
  	if (rtw_chip_wcpu_11ac(rtwdev))
  		rtw_write32(rtwdev, REG_H2CQ_CSR, BIT_H2CQ_FULL);
  
-+	if (rtw_hci_type(rtwdev) == RTW_HCI_TYPE_USB)
-+		rtw_write8_set(rtwdev, REG_TXDMA_PQ_MAP, BIT_RXDMA_ARBBW_EN);
-+
 +	if (rtw_hci_type(rtwdev) == RTW_HCI_TYPE_SDIO) {
 +		rtw_read32(rtwdev, REG_SDIO_FREE_TXPG);
 +		rtw_write32(rtwdev, REG_SDIO_TX_CTRL, 0);
@@ -588,7 +662,7 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/mac.c b/drivers/net/wireless/rea
  	return 0;
  }
  
-@@ -1185,6 +1239,9 @@
+@@ -1185,6 +1255,9 @@
  		else
  			return -EINVAL;
  		break;
@@ -610,8 +684,8 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/mac.h b/drivers/net/wireless/rea
  #define C2H_PKT_BUF		256
  #define REPORT_BUF		128
 diff -Naur a/drivers/net/wireless/realtek/rtw88/main.c b/drivers/net/wireless/realtek/rtw88/main.c
---- a/drivers/net/wireless/realtek/rtw88/main.c	2023-05-24 12:32:53.000000000 -0400
-+++ b/drivers/net/wireless/realtek/rtw88/main.c	2023-05-26 05:40:07.697049796 -0400
+--- a/drivers/net/wireless/realtek/rtw88/main.c	2023-06-05 03:26:22.000000000 -0400
++++ b/drivers/net/wireless/realtek/rtw88/main.c	2023-06-06 04:57:49.610769968 -0400
 @@ -18,6 +18,7 @@
  #include "debug.h"
  #include "bf.h"
@@ -620,34 +694,7 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/main.c b/drivers/net/wireless/re
  
  bool rtw_disable_lps_deep_mode;
  EXPORT_SYMBOL(rtw_disable_lps_deep_mode);
-@@ -102,6 +103,26 @@
- 	{.bitrate = 540, .hw_value = 0x0b,},
- };
- 
-+static const struct ieee80211_iface_limit rtw_iface_limits[] = {
-+	{
-+		.max = 1,
-+		.types = BIT(NL80211_IFTYPE_STATION),
-+	},
-+	{
-+		.max = 1,
-+		.types = BIT(NL80211_IFTYPE_AP),
-+	}
-+};
-+
-+static const struct ieee80211_iface_combination rtw_iface_combs[] = {
-+	{
-+		.limits = rtw_iface_limits,
-+		.n_limits = ARRAY_SIZE(rtw_iface_limits),
-+		.max_interfaces = 2,
-+		.num_different_channels = 1,
-+	}
-+};
-+
- u16 rtw_desc_to_bitrate(u8 desc_rate)
- {
- 	struct ieee80211_rate rate;
-@@ -241,8 +262,10 @@
+@@ -241,8 +242,10 @@
  	rtw_phy_dynamic_mechanism(rtwdev);
  
  	data.rtwdev = rtwdev;
@@ -660,7 +707,7 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/main.c b/drivers/net/wireless/re
  
  	/* fw supports only one station associated to enter lps, if there are
  	 * more than two stations associated to the AP, then we can not enter
-@@ -1746,7 +1769,8 @@
+@@ -1746,7 +1749,8 @@
  	update_firmware_info(rtwdev, fw);
  	complete_all(&fw->completion);
  
@@ -670,7 +717,7 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/main.c b/drivers/net/wireless/re
  		 fw->version, fw->sub_version, fw->sub_index, fw->h2c_version);
  }
  
-@@ -1772,6 +1796,7 @@
+@@ -1772,6 +1776,7 @@
  		return -ENOENT;
  	}
  
@@ -678,7 +725,7 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/main.c b/drivers/net/wireless/re
  	fw->rtwdev = rtwdev;
  	init_completion(&fw->completion);
  
-@@ -1796,6 +1821,14 @@
+@@ -1796,6 +1801,14 @@
  		rtwdev->hci.rpwm_addr = 0x03d9;
  		rtwdev->hci.cpwm_addr = 0x03da;
  		break;
@@ -693,7 +740,7 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/main.c b/drivers/net/wireless/re
  	default:
  		rtw_err(rtwdev, "unsupported hci type\n");
  		return -EINVAL;
-@@ -2080,13 +2113,10 @@
+@@ -2080,13 +2093,10 @@
  	skb_queue_head_init(&rtwdev->coex.queue);
  	skb_queue_head_init(&rtwdev->tx_report.queue);
  
@@ -707,7 +754,7 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/main.c b/drivers/net/wireless/re
  	mutex_init(&rtwdev->hal.tx_power_mutex);
  
  	init_waitqueue_head(&rtwdev->coex.wait);
-@@ -2158,7 +2188,6 @@
+@@ -2158,7 +2168,6 @@
  	}
  
  	mutex_destroy(&rtwdev->mutex);
@@ -715,7 +762,7 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/main.c b/drivers/net/wireless/re
  	mutex_destroy(&rtwdev->hal.tx_power_mutex);
  }
  EXPORT_SYMBOL(rtw_core_deinit);
-@@ -2169,9 +2198,11 @@
+@@ -2169,9 +2178,11 @@
  	int max_tx_headroom = 0;
  	int ret;
  
@@ -728,18 +775,6 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/main.c b/drivers/net/wireless/re
  	hw->extra_tx_headroom = max_tx_headroom;
  	hw->queues = IEEE80211_NUM_ACS;
  	hw->txq_data_size = sizeof(struct rtw_txq);
-@@ -2205,6 +2236,11 @@
- 	hw->wiphy->max_scan_ssids = RTW_SCAN_MAX_SSIDS;
- 	hw->wiphy->max_scan_ie_len = rtw_get_max_scan_ie_len(rtwdev);
- 
-+	if (rtwdev->chip->id == RTW_CHIP_TYPE_8822C) {
-+		hw->wiphy->iface_combinations = rtw_iface_combs;
-+		hw->wiphy->n_iface_combinations = ARRAY_SIZE(rtw_iface_combs);
-+	}
-+
- 	wiphy_ext_feature_set(hw->wiphy, NL80211_EXT_FEATURE_CAN_REPLACE_PTK0);
- 	wiphy_ext_feature_set(hw->wiphy, NL80211_EXT_FEATURE_SCAN_RANDOM_SN);
- 	wiphy_ext_feature_set(hw->wiphy, NL80211_EXT_FEATURE_SET_SCAN_DWELL);
 diff -Naur a/drivers/net/wireless/realtek/rtw88/main.h b/drivers/net/wireless/realtek/rtw88/main.h
 --- a/drivers/net/wireless/realtek/rtw88/main.h	2023-05-24 12:32:53.000000000 -0400
 +++ b/drivers/net/wireless/realtek/rtw88/main.h	2023-05-26 05:23:16.016634105 -0400
@@ -1137,8 +1172,8 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/rtw8723d.h b/drivers/net/wireles
  
  extern const struct rtw_chip_info rtw8723d_hw_spec;
 diff -Naur a/drivers/net/wireless/realtek/rtw88/rtw8821c.c b/drivers/net/wireless/realtek/rtw88/rtw8821c.c
---- a/drivers/net/wireless/realtek/rtw88/rtw8821c.c	2023-05-24 12:32:53.000000000 -0400
-+++ b/drivers/net/wireless/realtek/rtw88/rtw8821c.c	2023-05-26 05:23:16.038633758 -0400
+--- a/drivers/net/wireless/realtek/rtw88/rtw8821c.c	2023-06-05 03:26:22.000000000 -0400
++++ b/drivers/net/wireless/realtek/rtw88/rtw8821c.c	2023-06-06 04:57:49.611769961 -0400
 @@ -26,6 +26,18 @@
  	ether_addr_copy(efuse->addr, map->e.mac_addr);
  }
@@ -1185,15 +1220,7 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/rtw8821c.c b/drivers/net/wireles
  static struct rtw_pwr_seq_cmd trans_carddis_to_cardemu_8821c[] = {
  	{0x0086,
  	 RTW_PWR_CUT_ALL_MSK,
-@@ -1521,6 +1546,7 @@
- 	[2] = RTW_DEF_RFE_EXT(8821c, 0, 0, 2),
- 	[4] = RTW_DEF_RFE_EXT(8821c, 0, 0, 2),
- 	[6] = RTW_DEF_RFE(8821c, 0, 0),
-+	[34] = RTW_DEF_RFE(8821c, 0, 0),
- };
- 
- static struct rtw_hw_reg rtw8821c_dig[] = {
-@@ -1595,6 +1621,7 @@
+@@ -1595,6 +1620,7 @@
  	.config_bfee		= rtw8821c_bf_config_bfee,
  	.set_gid_table		= rtw_bf_set_gid_table,
  	.cfg_csi_rate		= rtw_bf_cfg_csi_rate,

--- a/patch/misc/rtw88/6.1/001-rtw88-linux-next.patch
+++ b/patch/misc/rtw88/6.1/001-rtw88-linux-next.patch
@@ -685,7 +685,7 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/mac.h b/drivers/net/wireless/rea
  #define REPORT_BUF		128
 diff -Naur a/drivers/net/wireless/realtek/rtw88/main.c b/drivers/net/wireless/realtek/rtw88/main.c
 --- a/drivers/net/wireless/realtek/rtw88/main.c	2023-06-05 03:26:22.000000000 -0400
-+++ b/drivers/net/wireless/realtek/rtw88/main.c	2023-06-06 04:57:49.610769968 -0400
++++ b/drivers/net/wireless/realtek/rtw88/main.c	2023-06-07 11:00:57.910794536 -0400
 @@ -18,6 +18,7 @@
  #include "debug.h"
  #include "bf.h"
@@ -694,7 +694,34 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/main.c b/drivers/net/wireless/re
  
  bool rtw_disable_lps_deep_mode;
  EXPORT_SYMBOL(rtw_disable_lps_deep_mode);
-@@ -241,8 +242,10 @@
+@@ -102,6 +103,26 @@
+ 	{.bitrate = 540, .hw_value = 0x0b,},
+ };
+ 
++static const struct ieee80211_iface_limit rtw_iface_limits[] = {
++	{
++		.max = 1,
++		.types = BIT(NL80211_IFTYPE_STATION),
++	},
++	{
++		.max = 1,
++		.types = BIT(NL80211_IFTYPE_AP),
++	}
++};
++
++static const struct ieee80211_iface_combination rtw_iface_combs[] = {
++	{
++		.limits = rtw_iface_limits,
++		.n_limits = ARRAY_SIZE(rtw_iface_limits),
++		.max_interfaces = 2,
++		.num_different_channels = 1,
++	}
++};
++
+ u16 rtw_desc_to_bitrate(u8 desc_rate)
+ {
+ 	struct ieee80211_rate rate;
+@@ -241,8 +262,10 @@
  	rtw_phy_dynamic_mechanism(rtwdev);
  
  	data.rtwdev = rtwdev;
@@ -707,7 +734,7 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/main.c b/drivers/net/wireless/re
  
  	/* fw supports only one station associated to enter lps, if there are
  	 * more than two stations associated to the AP, then we can not enter
-@@ -1746,7 +1749,8 @@
+@@ -1746,7 +1769,8 @@
  	update_firmware_info(rtwdev, fw);
  	complete_all(&fw->completion);
  
@@ -717,7 +744,7 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/main.c b/drivers/net/wireless/re
  		 fw->version, fw->sub_version, fw->sub_index, fw->h2c_version);
  }
  
-@@ -1772,6 +1776,7 @@
+@@ -1772,6 +1796,7 @@
  		return -ENOENT;
  	}
  
@@ -725,7 +752,7 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/main.c b/drivers/net/wireless/re
  	fw->rtwdev = rtwdev;
  	init_completion(&fw->completion);
  
-@@ -1796,6 +1801,14 @@
+@@ -1796,6 +1821,14 @@
  		rtwdev->hci.rpwm_addr = 0x03d9;
  		rtwdev->hci.cpwm_addr = 0x03da;
  		break;
@@ -740,7 +767,7 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/main.c b/drivers/net/wireless/re
  	default:
  		rtw_err(rtwdev, "unsupported hci type\n");
  		return -EINVAL;
-@@ -2080,13 +2093,10 @@
+@@ -2080,13 +2113,10 @@
  	skb_queue_head_init(&rtwdev->coex.queue);
  	skb_queue_head_init(&rtwdev->tx_report.queue);
  
@@ -754,7 +781,7 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/main.c b/drivers/net/wireless/re
  	mutex_init(&rtwdev->hal.tx_power_mutex);
  
  	init_waitqueue_head(&rtwdev->coex.wait);
-@@ -2158,7 +2168,6 @@
+@@ -2158,7 +2188,6 @@
  	}
  
  	mutex_destroy(&rtwdev->mutex);
@@ -762,7 +789,7 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/main.c b/drivers/net/wireless/re
  	mutex_destroy(&rtwdev->hal.tx_power_mutex);
  }
  EXPORT_SYMBOL(rtw_core_deinit);
-@@ -2169,9 +2178,11 @@
+@@ -2169,9 +2198,11 @@
  	int max_tx_headroom = 0;
  	int ret;
  
@@ -775,6 +802,18 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/main.c b/drivers/net/wireless/re
  	hw->extra_tx_headroom = max_tx_headroom;
  	hw->queues = IEEE80211_NUM_ACS;
  	hw->txq_data_size = sizeof(struct rtw_txq);
+@@ -2205,6 +2236,11 @@
+ 	hw->wiphy->max_scan_ssids = RTW_SCAN_MAX_SSIDS;
+ 	hw->wiphy->max_scan_ie_len = rtw_get_max_scan_ie_len(rtwdev);
+ 
++	if (rtwdev->chip->id == RTW_CHIP_TYPE_8822C) {
++		hw->wiphy->iface_combinations = rtw_iface_combs;
++		hw->wiphy->n_iface_combinations = ARRAY_SIZE(rtw_iface_combs);
++	}
++
+ 	wiphy_ext_feature_set(hw->wiphy, NL80211_EXT_FEATURE_CAN_REPLACE_PTK0);
+ 	wiphy_ext_feature_set(hw->wiphy, NL80211_EXT_FEATURE_SCAN_RANDOM_SN);
+ 	wiphy_ext_feature_set(hw->wiphy, NL80211_EXT_FEATURE_SET_SCAN_DWELL);
 diff -Naur a/drivers/net/wireless/realtek/rtw88/main.h b/drivers/net/wireless/realtek/rtw88/main.h
 --- a/drivers/net/wireless/realtek/rtw88/main.h	2023-05-24 12:32:53.000000000 -0400
 +++ b/drivers/net/wireless/realtek/rtw88/main.h	2023-05-26 05:23:16.016634105 -0400

--- a/patch/misc/rtw88/6.1/002-rtw88-linux-next.patch
+++ b/patch/misc/rtw88/6.1/002-rtw88-linux-next.patch
@@ -2304,7 +2304,7 @@
 +		}
 +
 +		if (skb_queue_len(&rtwusb->rx_queue) >= RTW_USB_MAX_RXQ_LEN) {
-+			rtw_err(rtwdev, "failed to get rx_queue, overflow\n");
++			dev_dbg_ratelimited(rtwdev->dev, "failed to get rx_queue, overflow\n");
 +			dev_kfree_skb_any(skb);
 +			continue;
 +		}

--- a/patch/misc/rtw88/6.1/002-rtw88-linux-next.patch
+++ b/patch/misc/rtw88/6.1/002-rtw88-linux-next.patch
@@ -1764,8 +1764,8 @@
 +}
 +
 +#endif
---- /dev/null	2023-05-21 09:58:01.101444638 -0400
-+++ b/drivers/net/wireless/realtek/rtw88/usb.c	2023-05-26 07:03:00.974728227 -0400
+--- /dev/null	2023-06-05 14:08:32.045359457 -0400
++++ b/drivers/net/wireless/realtek/rtw88/usb.c	2023-06-06 04:57:49.611769961 -0400
 @@ -0,0 +1,924 @@
 +// SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
 +/* Copyright(c) 2018-2019  Realtek Corporation
@@ -2602,7 +2602,7 @@
 +
 +	ret = rtw_usb_alloc_rx_bufs(rtwusb);
 +	if (ret)
-+		return ret;
++		goto err_release_hw;
 +
 +	ret = rtw_core_init(rtwdev);
 +	if (ret)
@@ -2691,8 +2691,8 @@
 +MODULE_AUTHOR("Realtek Corporation");
 +MODULE_DESCRIPTION("Realtek 802.11ac wireless USB driver");
 +MODULE_LICENSE("Dual BSD/GPL");
---- /dev/null	2023-05-21 09:58:01.101444638 -0400
-+++ b/drivers/net/wireless/realtek/rtw88/usb.h	2023-05-26 05:23:16.017634089 -0400
+--- /dev/null	2023-06-05 14:08:32.045359457 -0400
++++ b/drivers/net/wireless/realtek/rtw88/usb.h	2023-06-06 04:57:49.611769961 -0400
 @@ -0,0 +1,107 @@
 +/* SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause */
 +/* Copyright(c) 2018-2019  Realtek Corporation
@@ -2774,7 +2774,7 @@
 +	u8 pipe_interrupt;
 +	u8 pipe_in;
 +	u8 out_ep[RTW_USB_EP_MAX];
-+	u8 qsel_to_ep[TX_DESC_QSEL_MAX];
++	int qsel_to_ep[TX_DESC_QSEL_MAX];
 +	u8 usb_txagg_num;
 +
 +	struct workqueue_struct *txwq, *rxwq;


### PR DESCRIPTION
Backport updates from Linux 6.3. In my testing this has no ill effects on `SDIO 8822CS` and fixes `USB 8821CU`

```sh
dmesg | grep rtw
[    8.684999] rtw_8821cu 4-1:1.0: Firmware version 24.11.0, H2C version 12
[    9.426555] usbcore: registered new interface driver rtw_8821cu
lsmod | grep rtw88
rtw88_8821cu           16384  0
rtw88_8821c            81920  1 rtw88_8821cu
rtw88_usb              20480  1 rtw88_8821cu
rtw88_core            131072  2 rtw88_usb,rtw88_8821c
mac80211              458752  2 rtw88_core,rtw88_usb
cfg80211              331776  2 rtw88_core,mac80211
```

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
