### PR TITLE
export-logs: introduce `PASTE_URL` to make easy to change paste service used

### DIFF
--- a/lib/functions/logging/export-logs.sh
+++ b/lib/functions/logging/export-logs.sh
@@ -170,15 +170,16 @@ function export_ansi_logs() {
 		display_alert "ANSI log file built; inspect it by running:" "less -RS ${target_relative_to_src}"
 
 		# @TODO: compress...
+		declare paste_url="${PASTE_URL:-"https://paste.next.armbian.com/log"}"
 		if [[ "${SHARE_LOG:-"no"}" == "yes" ]]; then
 			display_alert "SHARE_LOG=yes, uploading log" "uploading logs" "info"
 			declare logs_url="undetermined"
-			logs_url=$(curl --silent --data-binary "@${target_relative_to_src}" "https://paste.next.armbian.com/log" | xargs echo -n || true) # don't fail
+			logs_url=$(curl --silent --data-binary "@${target_relative_to_src}" "${paste_url}" | xargs echo -n || true) # don't fail
 			display_alert "Log uploaded, share URL:" "${logs_url}" ""
 			# set output for GitHub Actions
 			github_actions_add_output logs_url "${logs_url}"
 		else
-			display_alert "Share log manually (or SHARE_LOG=yes):" "curl --data-binary @${target_relative_to_src} https://paste.next.armbian.com/log"
+			display_alert "Share log manually (or SHARE_LOG=yes):" "curl --data-binary @${target_relative_to_src} ${paste_url}"
 		fi
 	fi
 


### PR DESCRIPTION
#### export-logs: introduce `PASTE_URL` to make easy to change paste service used

- export-logs: introduce `PASTE_URL` to make easy to change paste service used