### PR TITLE
artifact-kernel: log what is the actual `${USERPATCHES_PATH}/kernel/${KERNELPATCHDIR}` so people can find it

### DIFF
--- a/lib/functions/artifacts/artifact-kernel.sh
+++ b/lib/functions/artifacts/artifact-kernel.sh
@@ -96,6 +96,7 @@ function artifact_kernel_prepare_version() {
 	# @TODO: why not just delegate this to the python patching, with some "dry-run" / hash-only option?
 	declare patches_hash="undetermined"
 	declare hash_files="undetermined"
+	display_alert "User patches directory for kernel" "${USERPATCHES_PATH}/kernel/${KERNELPATCHDIR}" "info"
 	calculate_hash_for_all_files_in_dirs "${SRC}/patch/kernel/${KERNELPATCHDIR}" "${USERPATCHES_PATH}/kernel/${KERNELPATCHDIR}"
 	patches_hash="${hash_files}"
 	declare kernel_patches_hash_short="${patches_hash:0:${short_hash_size}}"


### PR DESCRIPTION
#### artifact-kernel: log what is the actual `${USERPATCHES_PATH}/kernel/${KERNELPATCHDIR}` so people can find it

- artifact-kernel: log what is the actual `${USERPATCHES_PATH}/kernel/${KERNELPATCHDIR}` so people can find it
  - case in point: some families point `KERNELPATCHDIR` to something like `archive/sunxi-5.15` which makes it harder to find than `sunxi-legacy`