### PR TITLE
patching: Patching Summary and Patching Failures tables using Python's Rich + auto patchers: bare dts, bare overlays, DT Makefile

### DIFF
--- a/lib/functions/compilation/kernel-patching.sh
+++ b/lib/functions/compilation/kernel-patching.sh
@@ -30,6 +30,9 @@ function kernel_main_patching_python() {
 		"USERPATCHES_PATH=${USERPATCHES_PATH}"                # Needed to find the userpatches.
 		#"BOARD="                                             # BOARD is needed for the patchset selection logic; mostly for u-boot. empty for kernel.
 		#"TARGET="                                            # TARGET is need for u-boot's SPI/SATA etc selection logic. empty for kernel
+		# For table generation to fit into the screen, or being large when in GHA.
+		"COLUMNS=${COLUMNS}"
+		"GITHUB_ACTIONS=${GITHUB_ACTIONS}"
 		# Needed so git can find the global .gitconfig, and Python can parse the PATH to determine which git to use.
 		"PATH=${PATH}"
 		"HOME=${HOME}"

--- a/lib/functions/compilation/patch/patching.sh
+++ b/lib/functions/compilation/patch/patching.sh
@@ -99,8 +99,8 @@ process_patch_file() {
 	patch --batch -p1 -N --input="${patch}" --quiet --reject-file=- && { # "-" discards rejects
 		display_alert "* $status ${relative_patch}" "" "info"
 	} || {
-		display_alert "* $status ${relative_patch}" "failed" "wrn"
-		[[ $EXIT_PATCHING_ERROR == yes ]] && exit_with_error "Aborting due to" "EXIT_PATCHING_ERROR"
+		display_alert "* $status ${relative_patch}" "failed" "err"
+		exit_with_error "Patching error, exiting."
 	}
 
 	return 0 # short-circuit above, avoid exiting with error

--- a/lib/functions/compilation/uboot-patching.sh
+++ b/lib/functions/compilation/uboot-patching.sh
@@ -25,6 +25,9 @@ function uboot_main_patching_python() {
 		"BOARD=${BOARD}"                                      # BOARD is needed for the patchset selection logic; mostly for u-boot.
 		"TARGET=${target_patchdir}"                           # TARGET is need for u-boot's SPI/SATA etc selection logic
 		"USERPATCHES_PATH=${USERPATCHES_PATH}"                # Needed to find the userpatches.
+		# For table generation to fit into the screen, or being large when in GHA.
+		"COLUMNS=${COLUMNS}"
+		"GITHUB_ACTIONS=${GITHUB_ACTIONS}"
 		# Needed so git can find the global .gitconfig, and Python can parse the PATH to determine which git to use.
 		"PATH=${PATH}"
 		"HOME=${HOME}"

--- a/lib/functions/general/python-tools.sh
+++ b/lib/functions/general/python-tools.sh
@@ -21,6 +21,7 @@ function early_prepare_pip3_dependencies_for_python_tools() {
 		"PyYAML==6.0"         # for parsing/writing YAML
 		"oras==0.1.17"        # for OCI stuff in mapper-oci-update
 		"Jinja2==3.1.2"       # for templating
+		"rich==13.4.1"        # for rich text formatting
 	)
 	return 0
 }

--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -379,8 +379,9 @@ function docker_cli_prepare_launch() {
 		# Change the ccache directory to the named volume or bind created. @TODO: this needs more love. it works for Docker, but not sudo
 		"--env" "CCACHE_DIR=${DOCKER_ARMBIAN_TARGET_PATH}/cache/ccache"
 
-		# Pass down the TERM
+		# Pass down the TERM and the COLUMNS
 		"--env" "TERM=${TERM}"
+		"--env" "COLUMNS=${COLUMNS}"
 
 		# Pass down the CI env var (GitHub Actions, Jenkins, etc)
 		"--env" "CI=${CI}"                         # All CI's, hopefully

--- a/lib/tools/autopatch-devicetree-makefile.py
+++ b/lib/tools/autopatch-devicetree-makefile.py
@@ -1,0 +1,30 @@
+# ‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹
+#  SPDX-License-Identifier: GPL-2.0
+#  Copyright (c) 2023 Ricardo Pardini <ricardo@pardini.net>
+#  This file is a part of the Armbian Build Framework https://github.com/armbian/build/
+# ‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹
+
+# So this thing takes
+# - an absolute path to a kernel check-ed out git tree (GIT_WORK_DIR=/Volumes/LinuxDev/mainline-kernel-3rd-party-rebase)
+# - the relative path to a Device Tree directory (DT_REL_DIR=arch/arm64/boot/dts/amlogic)
+# and will for the DT_REL_DIR:
+# - find all the .dts files
+# - find the Makefile
+# It will then regex-parse the Makefile for the CONFIG_ARCH_xxx variable, find the preamble and postamble, and insert the DT files in between.
+
+import logging
+
+import common.armbian_utils as armbian_utils
+import common.dt_makefile_patcher as dt_makefile_patcher
+
+# Prepare logging
+armbian_utils.setup_logging()
+log: logging.Logger = logging.getLogger("patching")
+
+# Show the environment variables we've been called with
+armbian_utils.show_incoming_environment()
+
+GIT_WORK_DIR = armbian_utils.get_from_env("GIT_WORK_DIR", "/Volumes/LinuxDev/mainline-kernel-3rd-party-rebase")
+DT_REL_DIR = armbian_utils.get_from_env("DT_REL_DIR", "arch/arm64/boot/dts/amlogic")
+
+dt_makefile_patcher.auto_patch_dt_makefile(GIT_WORK_DIR, DT_REL_DIR)

--- a/lib/tools/common/armbian_utils.py
+++ b/lib/tools/common/armbian_utils.py
@@ -38,8 +38,8 @@ def parse_env_for_tokens(env_name):
 	return [token for token in [token.strip() for token in (tokens)] if token != ""]
 
 
-def get_from_env(env_name):
-	value = os.environ.get(env_name, None)
+def get_from_env(env_name, default=None):
+	value = os.environ.get(env_name, default)
 	if value is not None:
 		value = value.strip()
 	return value

--- a/lib/tools/common/dt_makefile_patcher.py
+++ b/lib/tools/common/dt_makefile_patcher.py
@@ -1,0 +1,191 @@
+# ‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹
+#  SPDX-License-Identifier: GPL-2.0
+#  Copyright (c) 2023 Ricardo Pardini <ricardo@pardini.net>
+#  This file is a part of the Armbian Build Framework https://github.com/armbian/build/
+# ‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹
+
+import logging
+import os
+import re
+import shutil
+
+import git
+from git import Actor
+
+from common.patching_config import PatchingConfig
+from common.patching_utils import PatchRootDir
+
+log: logging.Logger = logging.getLogger("dt_makefile_patcher")
+
+
+class AutoPatcherParams:
+	def __init__(
+		self,
+		pconfig: PatchingConfig,
+		git_work_dir: str,
+		root_types_order: list[str],
+		root_dirs_by_root_type: dict[str, list[PatchRootDir]],
+		apply_patches_to_git: bool,
+		git_repo: git.Repo):
+		self.pconfig = pconfig
+		self.git_work_dir = git_work_dir
+		self.root_types_order = root_types_order
+		self.root_dirs_by_root_type = root_dirs_by_root_type
+		self.apply_patches_to_git = apply_patches_to_git
+		self.git_repo = git_repo
+
+
+def auto_patch_dt_makefile(git_work_dir: str, dt_rel_dir: str) -> dict[str, str]:
+	ret: dict[str, str] = {}
+	dt_path = os.path.join(git_work_dir, dt_rel_dir)
+	# Bomb if it does not exist or is not a directory
+	if not os.path.isdir(dt_path):
+		raise ValueError(f"DT_PATH={dt_path} is not a directory")
+	makefile_path = os.path.join(dt_path, "Makefile")
+	# Bomb if it does not exist or is not a file
+	if not os.path.isfile(makefile_path):
+		raise ValueError(f"MAKEFILE_PATH={makefile_path} is not a file")
+
+	ret["MAKEFILE_PATH"] = makefile_path
+
+	# Grab the contents of the Makefile
+	with open(makefile_path, "r") as f:
+		makefile_contents = f.read()
+	log.info(f"Read {len(makefile_contents)} bytes from {makefile_path}")
+	log.debug(f"Contents:\n{makefile_contents}")
+	# Parse it into a list of lines
+	makefile_lines = makefile_contents.splitlines()
+	log.info(f"Read {len(makefile_lines)} lines from {makefile_path}")
+	regex = r"^dtb-\$\(([a-zA-Z_]+)\)\s+\+=\s+([a-zA-Z0-9-_]+)\.dtb"
+	# For each line, check if it matches the regex, extract the groups
+	line_counter = 0
+	line_first_match = 0
+	line_last_match = 0
+	config_var_dict: set[str] = set()
+	for line in makefile_lines:
+		line_counter += 1
+		match = re.match(regex, line)
+		if match:
+			line_first_match = line_counter if line_first_match == 0 else line_first_match
+			line_last_match = line_counter
+			config_var_dict.add(match.group(1))
+	# Sanity check, make sure config_var_dict is not empty and has only one element
+	if len(config_var_dict) != 1:
+		raise ValueError(f"config_var_dict={config_var_dict} -- found too few or too many CONFIG_ARCH_xx variables in {makefile_path}")
+	config_var = config_var_dict.pop()
+	log.info(f"Found '{config_var}' in Makefile lines {line_first_match} to {line_last_match}")
+	# Now compute the preambles and the postamble
+	preamble_lines = makefile_lines[:line_first_match - 1]
+	postamble_lines = makefile_lines[line_last_match:]
+	# Find all .dts files in DT_PATH (not subdirectories), but add to the list without .dts suffix
+	dts_files = []
+	listdir: list[str] = os.listdir(dt_path)
+	for file in listdir:
+		if file.endswith(".dts"):
+			dts_files.append(file[:-4])
+	# sort the list. alpha-sort: `meson-sm1-a95xf3-air-gbit` should come sooner than `meson-sm1-a95xf3-air`? why?
+	dts_files.sort()
+	log.info(f"Found {len(dts_files)} .dts files in {dt_path}")
+	# Show them all
+	for dts_file in dts_files:
+		log.debug(f"Found {dts_file}")
+	# Create the mid-amble, which is the list of .dtb files to be built
+	midamble_lines = []
+	for dts_file in dts_files:
+		midamble_lines.append(f"dtb-$({config_var}) += {dts_file}.dtb")
+
+	# Late to the game: if DT_DIR/overlay/Makefile exists, add it.
+	overlay_lines = []
+	DT_OVERLAY_PATH = os.path.join(dt_path, "overlay")
+	DT_OVERLAY_MAKEFILE_PATH = os.path.join(DT_OVERLAY_PATH, "Makefile")
+	if os.path.isfile(DT_OVERLAY_MAKEFILE_PATH):
+		ret["DT_OVERLAY_MAKEFILE_PATH"] = DT_OVERLAY_MAKEFILE_PATH
+		ret["DT_OVERLAY_PATH"] = DT_OVERLAY_PATH
+		overlay_lines.append("")
+		overlay_lines.append("subdir-y       := $(dts-dirs) overlay")
+
+	# Now join the preambles, midamble, postamble and overlay stuff into a single list
+	new_makefile_lines = preamble_lines + midamble_lines + postamble_lines + overlay_lines
+	# Rewrite the Makefile with the new contents
+	with open(makefile_path, "w") as f:
+		f.write("\n".join(new_makefile_lines))
+	log.info(f"Wrote {len(new_makefile_lines)} lines to {makefile_path}")
+
+	return ret
+
+
+def copy_bare_files(autopatcher_params: AutoPatcherParams, type: str):
+	# group the pconfig.dts_directories by target dir
+	dts_dirs_by_target = {}
+	if type == "dt":
+		config_dirs = autopatcher_params.pconfig.dts_directories
+	elif type == "overlay":
+		config_dirs = autopatcher_params.pconfig.overlay_directories
+	else:
+		raise ValueError(f"Unknown copy_bare_files::type {type}")
+
+	for one_dts_dir in config_dirs:
+		if one_dts_dir.target not in dts_dirs_by_target:
+			dts_dirs_by_target[one_dts_dir.target] = []
+		dts_dirs_by_target[one_dts_dir.target].append(one_dts_dir.source)
+
+	# for each target....
+	for target_dir in dts_dirs_by_target:
+		all_files_to_copy = []
+		dts_source_dirs = dts_dirs_by_target[target_dir]
+		full_path_target_dir = os.path.join(autopatcher_params.git_work_dir, target_dir)
+		if not os.path.exists(full_path_target_dir):
+			os.makedirs(full_path_target_dir)
+
+		for one_dts_dir in dts_source_dirs:
+			for type_in_order in autopatcher_params.root_types_order:
+				root_dirs = autopatcher_params.root_dirs_by_root_type[type_in_order]
+				for root_dir in root_dirs:
+					full_path_source = os.path.join(root_dir.abs_dir, one_dts_dir)
+					log.warning(f"Would copy {full_path_source} to {full_path_target_dir}...")
+					if not os.path.isdir(full_path_source):
+						continue
+					# get a list of regular files in the source directory
+					files_to_copy = [
+						os.path.join(full_path_source, f) for f in os.listdir(full_path_source)
+						if os.path.isfile(os.path.join(full_path_source, f))
+					]
+					all_files_to_copy.extend(files_to_copy)
+		# Create a dict of base filename -> list of full paths; this way userpatches with same name take precedence
+		all_files_to_copy_dict = {}
+		for one_file in all_files_to_copy:
+			base_filename = os.path.basename(one_file)
+			all_files_to_copy_dict[base_filename] = one_file
+		# do the actual copy
+		all_copied_files = []
+		for one_file in all_files_to_copy_dict:
+			log.warning(f"Copy '{one_file}' (from {all_files_to_copy_dict[one_file]}) to '{full_path_target_dir}'...")
+			full_path_target_file = os.path.join(full_path_target_dir, one_file)
+			shutil.copyfile(all_files_to_copy_dict[one_file], full_path_target_file)
+			all_copied_files.append(full_path_target_file)
+
+		# If more than 0 files were copied, commit them if we're doing commits
+		if autopatcher_params.apply_patches_to_git and len(all_copied_files) > 0:
+			autopatcher_params.git_repo.git.add(all_copied_files)
+			maintainer_actor: Actor = Actor(f"Armbian Bare {type.upper()} AutoPatcher", "patching@armbian.com")
+			commit = autopatcher_params.git_repo.index.commit(
+				message=f"Armbian Bare Device Tree files for {target_dir}"
+				, author=maintainer_actor, committer=maintainer_actor, skip_hooks=True
+			)
+			log.info(f"Committed Bare {type.upper()} changes to git: {commit.hexsha} for {target_dir}")
+			log.info(f"Done with Bare {type.upper()} autopatch commit for {target_dir}.")
+
+
+def auto_patch_all_dt_makefiles(autopatcher_params: AutoPatcherParams):
+	for one_autopatch_config in autopatcher_params.pconfig.autopatch_makefile_dt_configs:
+		log.warning(f"Autopatching DT Makefile in {one_autopatch_config.directory}...")
+		autopatch_makefile_info = auto_patch_dt_makefile(autopatcher_params.git_work_dir, one_autopatch_config.directory)
+		if autopatcher_params.apply_patches_to_git:
+			autopatcher_params.git_repo.git.add(autopatch_makefile_info["MAKEFILE_PATH"])
+			maintainer_actor: Actor = Actor("Armbian DT Makefile AutoPatcher", "patching@armbian.com")
+			commit = autopatcher_params.git_repo.index.commit(
+				message=f"Armbian automatic DT Makefile patch for {one_autopatch_config.directory}",
+				author=maintainer_actor, committer=maintainer_actor, skip_hooks=True
+			)
+			log.info(f"Committed changes to git: {commit.hexsha} for {one_autopatch_config.directory}")
+			log.info(f"Done with Makefile autopatch commit for {one_autopatch_config.directory}.")

--- a/lib/tools/common/md_asset_log.py
+++ b/lib/tools/common/md_asset_log.py
@@ -47,23 +47,21 @@ class SummarizedMarkdownWriter:
 	def write(self, text):
 		self.contents += text
 
-	# see https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-collapsed-sections
-	def get_summarized_markdown(self):
+	def validate(self):
 		if len(self.title) == 0:
 			raise Exception("Markdown Summary Title not set")
 		if len(self.summary) == 0:
 			raise Exception("Markdown Summary not set")
 		if self.contents == "":
 			raise Exception("Markdown Contents not set")
+
+	# see https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-collapsed-sections
+	def get_summarized_markdown(self):
+		self.validate()
 		return f"<details><summary>{self.title}: {'; '.join(self.summary)}</summary>\n<p>\n\n{self.contents}\n\n</p></details>\n"
 
 	def get_readme_markdown(self):
-		if len(self.title) == 0:
-			raise Exception("Markdown Summary Title not set")
-		if len(self.summary) == 0:
-			raise Exception("Markdown Summary not set")
-		if self.contents == "":
-			raise Exception("Markdown Contents not set")
+		self.validate()
 		return f"#### {self.title}: {'; '.join(self.summary)}\n\n{self.contents}\n\n"
 
 
@@ -88,7 +86,7 @@ jobs:
         run: |
           curl -s https://raw.githubusercontent.com/${{ github.repository }}/${BRANCH_NAME}/README.md > README.md
           ls -la README.md
-      
+
       # install grip via pip, https://github.com/joeyespo/grip; rpardini's fork https://github.com/rpardini/grip
       - name: Install grip
         run: |

--- a/lib/tools/common/patching_config.py
+++ b/lib/tools/common/patching_config.py
@@ -1,0 +1,84 @@
+# ‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹
+#  SPDX-License-Identifier: GPL-2.0
+#  Copyright (c) 2023 Ricardo Pardini <ricardo@pardini.net>
+#  This file is a part of the Armbian Build Framework https://github.com/armbian/build/
+# ‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹
+
+import logging
+
+import yaml
+
+log: logging.Logger = logging.getLogger("patching_config")
+
+
+class PatchingAutoPatchMakefileDTConfig:
+
+	def __init__(self, data: dict):
+		self.config_var: str = data.get("config-var", None)
+		self.directory: str = data.get("directory", None)
+
+	def __str__(self):
+		return f"PatchingAutoPatchMakefileDTConfig(config-var={self.config_var}, directory={self.directory})"
+
+
+class PatchingDTSDirectoryConfig:
+	def __init__(self, data: dict):
+		self.source: str = data.get("source", None)
+		self.target: str = data.get("target", None)
+
+	def __str__(self):
+		return f"PatchingDTSDirectoryConfig(source={self.source}, target={self.target})"
+
+
+class PatchingOverlayDirectoryConfig:
+	def __init__(self, data: dict):
+		self.source: str = data.get("source", None)
+		self.target: str = data.get("target", None)
+
+	def __str__(self):
+		return f"PatchingOverlayDirectoryConfig(source={self.source}, target={self.target})"
+
+
+class PatchingToGitConfig:
+	def __init__(self, data: dict):
+		self.do_not_commit_files: list[str] = data.get("do-not-commit-files", [])
+		self.do_not_commit_regexes: list[str] = data.get("do-not-commit-regexes", [])
+
+	def __str__(self):
+		return f"PatchingToGitConfig(do_not_commit_files={self.do_not_commit_files}, do_not_commit_regexes={self.do_not_commit_regexes})"
+
+
+class PatchingConfig:
+	def __init__(self, yaml_config_file_paths: list[str]):
+		self.yaml_config_file_paths = yaml_config_file_paths
+		if len(yaml_config_file_paths) == 0:
+			self.yaml_config = {}
+		else:
+			# I'm lazy, single one for now.
+			self.yaml_config = self.read_yaml_config(yaml_config_file_paths[0])["config"]
+
+		self.patches_to_git_config: PatchingToGitConfig = PatchingToGitConfig(self.yaml_config.get("patches-to-git", {}))
+
+		# Parse out the different parts of the config
+		# DT Makefile auto-patch config
+		self.autopatch_makefile_dt_configs: list[PatchingAutoPatchMakefileDTConfig] = [
+			PatchingAutoPatchMakefileDTConfig(data) for data in self.yaml_config.get("auto-patch-dt-makefile", [])
+		]
+		self.has_autopatch_makefile_dt_configs: bool = len(self.autopatch_makefile_dt_configs) > 0
+
+		# DTS directories to copy config
+		self.dts_directories: list[PatchingDTSDirectoryConfig] = [
+			PatchingDTSDirectoryConfig(data) for data in self.yaml_config.get("dts-directories", [])
+		]
+		self.has_dts_directories: bool = len(self.dts_directories) > 0
+
+		# Overlay directories to copy config
+		self.overlay_directories: list[PatchingOverlayDirectoryConfig] = [
+			PatchingOverlayDirectoryConfig(data) for data in self.yaml_config.get("overlay-directories", [])
+		]
+		self.has_overlay_directories: bool = len(self.overlay_directories) > 0
+
+	def read_yaml_config(self, yaml_config_file_path):
+		with open(yaml_config_file_path) as f:
+			yaml_config = yaml.load(f, Loader=yaml.FullLoader)
+		return yaml_config

--- a/lib/tools/patching.py
+++ b/lib/tools/patching.py
@@ -10,6 +10,7 @@
 import logging
 import os
 
+import rich.box
 # Let's use GitPython to query and manipulate the git repo
 from git import Actor
 from git import GitCmdObjectDB
@@ -58,6 +59,9 @@ GIT_WORK_DIR = armbian_utils.get_from_env("GIT_WORK_DIR")
 BOARD = armbian_utils.get_from_env("BOARD")
 TARGET = armbian_utils.get_from_env("TARGET")
 USERPATCHES_PATH = armbian_utils.get_from_env("USERPATCHES_PATH")
+
+# The exit exception, if any.
+exit_with_exception: "Exception | None" = None
 
 # Some path possibilities
 CONST_PATCH_ROOT_DIRS = []
@@ -214,6 +218,9 @@ if apply_patches_to_git and git_archeology:
 # Now, we need to apply the patches.
 git_repo: "git.Repo | None" = None
 total_patches = len(VALID_PATCHES)
+any_failed_to_apply = False
+failed_to_apply_list = []
+
 if apply_patches:
 	log.debug("Cleaning target git directory...")
 	git_repo = Repo(GIT_WORK_DIR, odbt=GitCmdObjectDB)
@@ -231,7 +238,16 @@ if apply_patches:
 			raise Exception("BASE_GIT_REVISION or BASE_GIT_TAG must be set")
 		else:
 			log.debug(f"Getting revision of BASE_GIT_TAG={BASE_GIT_TAG}")
-			BASE_GIT_REVISION = git_repo.tags[BASE_GIT_TAG].commit.hexsha
+			# first, try as a tag:
+			try:
+				BASE_GIT_REVISION = git_repo.tags[BASE_GIT_TAG].commit.hexsha
+			except IndexError:
+				# not a tag, try as a branch:
+				try:
+					BASE_GIT_REVISION = git_repo.branches[BASE_GIT_TAG].commit.hexsha
+				except IndexError:
+					raise Exception(f"BASE_GIT_TAG={BASE_GIT_TAG} is neither a tag nor a branch")
+
 			log.debug(f"Found BASE_GIT_REVISION={BASE_GIT_REVISION} for BASE_GIT_TAG={BASE_GIT_TAG}")
 
 	patching_utils.prepare_clean_git_tree_for_patching(git_repo, BASE_GIT_REVISION, BRANCH_FOR_PATCHES)
@@ -240,8 +256,9 @@ if apply_patches:
 	log.info(f"Applying {total_patches} patches {patch_file_desc}...")
 	# Grab the date of the root Makefile; that is the minimum date for the patched files.
 	root_makefile = os.path.join(GIT_WORK_DIR, "Makefile")
-	apply_options["root_makefile_date"] = os.path.getmtime(root_makefile)
-	log.debug(f"- Root Makefile '{root_makefile}' date: '{os.path.getmtime(root_makefile)}'")
+	root_makefile_mtime = os.path.getmtime(root_makefile)
+	apply_options["root_makefile_date"] = root_makefile_mtime
+	log.debug(f"- Root Makefile '{root_makefile}' date: '{root_makefile_mtime}'")
 	chars_total = len(str(total_patches))
 	counter = 0
 	for one_patch in VALID_PATCHES:
@@ -255,6 +272,8 @@ if apply_patches:
 			one_patch.applied_ok = True
 		except Exception as e:
 			log.error(f"Problem with {one_patch}: {e}")
+			any_failed_to_apply = True
+			failed_to_apply_list.append(one_patch)
 
 		if one_patch.applied_ok and apply_patches_to_git:
 			committed = one_patch.commit_changes_to_git(git_repo, (not rewrite_patches_in_place), split_patches)
@@ -267,6 +286,11 @@ if apply_patches:
 					rewritten_patch = patching_utils.export_commit_as_patch(
 						git_repo, commit_hash)
 					one_patch.rewritten_patch = rewritten_patch
+
+	if (not apply_patches_to_git) and (not rewrite_patches_in_place) and any_failed_to_apply:
+		log.error(
+			f"Failed to apply {len(failed_to_apply_list)} patches: {','.join([failed_patch.__str__() for failed_patch in failed_to_apply_list])}")
+		exit_with_exception = Exception(f"Failed to apply {len(failed_to_apply_list)} patches.")
 
 	if rewrite_patches_in_place:
 		# Now; we need to write the patches to files.
@@ -348,3 +372,48 @@ if apply_patches_to_git and readme_markdown is not None and git_repo is not None
 	)
 	log.info(f"Committed changes to git: {commit.hexsha}")
 	log.info("Done with summary commit.")
+
+# Use Rich.
+from rich.console import Console
+from rich.table import Table
+from rich.syntax import Syntax
+
+# console width is COLUMNS env var minus 12, or just 160 if GITHUB_ACTIONS env is not empty
+console_width = (int(os.environ.get("COLUMNS", 160)) - 12) if os.environ.get("GITHUB_ACTIONS", "") == "" else 160
+console = Console(color_system="standard", width=console_width, highlight=False)
+
+# Use Rich to print a summary of the patches
+if True:
+	summary_table = Table(title=f"Summary of {PATCH_TYPE} patches", show_header=True, show_lines=True, box=rich.box.ROUNDED)
+	summary_table.add_column("Patch / Status", overflow="fold", min_width=25, max_width=35)
+	summary_table.add_column("Diffstat / files", max_width=35)
+	summary_table.add_column("Author / Subject", overflow="ellipsis")
+	for one_patch in VALID_PATCHES:
+		summary_table.add_row(
+			# (one_patch.markdown_name(skip_markdown=True)),  # + " " + one_patch.markdown_problems()
+			one_patch.rich_name_status(),
+			(one_patch.text_diffstats() + " " + one_patch.text_files()),
+			(one_patch.text_author() + ": " + one_patch.text_subject())
+		)
+	console.print(summary_table)
+
+# Use Rich to print a summary of the failed patches and their rejects
+if any_failed_to_apply:
+	summary_table = Table(title="Summary of failed patches", show_header=True, show_lines=True, box=rich.box.ROUNDED)
+	summary_table.add_column("Patch", overflow="fold", min_width=5, max_width=20)
+	summary_table.add_column("Patching output", overflow="fold", min_width=20, max_width=40)
+	summary_table.add_column("Rejects")
+	for one_patch in failed_to_apply_list:
+		reject_compo = "No rejects"
+		if one_patch.rejects is not None:
+			reject_compo = Syntax(one_patch.rejects, "diff", line_numbers=False, word_wrap=True)
+
+		summary_table.add_row(
+			one_patch.rich_name_status(),
+			one_patch.rich_patch_output(),
+			reject_compo
+		)
+	console.print(summary_table)
+
+if exit_with_exception is not None:
+	raise exit_with_exception


### PR DESCRIPTION
#### patching: Patching Summary and Patching Failures tables using Python's Rich + auto patchers: bare dts, bare overlays, DT Makefile

- patching: Patching Summary and Patching Failures tables using Python's Rich
  - even Rich'er patch output by colorizing certain strings green/yellow/red
  - BASE_GIT_TAG now very sneakily also accepts a branch name
  - IMPORTANT: this includes: BREAKING CHANGE: patches failing to apply now break the build. fixes #4958
    - also break on legacy `process_patch_file()` failure, remove `EXIT_PATCHING_ERROR`
- patching: auto patchers: bare dts, bare overlays, DT Makefile