### PR TITLE
docker: use `${SRC}` as `DOCKER_ARMBIAN_TARGET_PATH` instead of hardcoded `/armbian`

### DIFF
--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -124,7 +124,7 @@ function docker_cli_prepare() {
 	# declare -g DOCKER_ARMBIAN_BASE_IMAGE="${DOCKER_ARMBIAN_BASE_IMAGE:-"ubuntu:focal"}"
 	# declare -g DOCKER_ARMBIAN_BASE_IMAGE="${DOCKER_ARMBIAN_BASE_IMAGE:-"ubuntu:kinetic"}"
 	declare -g DOCKER_ARMBIAN_BASE_IMAGE="${DOCKER_ARMBIAN_BASE_IMAGE:-"ubuntu:jammy"}"
-	declare -g DOCKER_ARMBIAN_TARGET_PATH="${DOCKER_ARMBIAN_TARGET_PATH:-"/armbian"}"
+	declare -g DOCKER_ARMBIAN_TARGET_PATH="${DOCKER_ARMBIAN_TARGET_PATH:-"${SRC}"}" # this used to be '/armbian', but now matches the host path.
 
 	declare wanted_os_tag="${DOCKER_ARMBIAN_BASE_IMAGE%%:*}"
 	declare wanted_release_tag="${DOCKER_ARMBIAN_BASE_IMAGE##*:}"


### PR DESCRIPTION
#### docker: use `${SRC}` as `DOCKER_ARMBIAN_TARGET_PATH` instead of hardcoded `/armbian`

- docker: use `${SRC}` as `DOCKER_ARMBIAN_TARGET_PATH` instead of hardcoded `/armbian`
  - this way host-side and Docker-side `SRC` are now the same path
    - messages containing the path to a file will now match across Docker and actual host