### PR TITLE
allwinner: bump current to 6.1.33

### DIFF
--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -26,7 +26,7 @@ case $BRANCH in
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.1.30"
+		declare -g KERNELBRANCH="tag:v6.1.33"
 		;;
 
 	edge)

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -28,7 +28,7 @@ case $BRANCH in
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.1.30"
+		declare -g KERNELBRANCH="tag:v6.1.33"
 		;;
 
 	edge)

--- a/patch/kernel/archive/sunxi-6.1/patches.armbian/arm-dts-sun8i-h3-fix-thermal-read.patch
+++ b/patch/kernel/archive/sunxi-6.1/patches.armbian/arm-dts-sun8i-h3-fix-thermal-read.patch
@@ -1,8 +1,8 @@
 diff --git a/drivers/thermal/sun8i_thermal.c b/drivers/thermal/sun8i_thermal.c
+index 89e27f34a..1687497dc 100644
 --- a/drivers/thermal/sun8i_thermal.c
 +++ b/drivers/thermal/sun8i_thermal.c
-+++ sun8i_thermal.c.new	2023-04-15 13:35:22.362606946 +0200
-@@ -81,7 +81,8 @@
+@@ -81,7 +81,8 @@ struct ths_thermal_chip {
  };
  
  struct ths_device {
@@ -12,7 +12,7 @@ diff --git a/drivers/thermal/sun8i_thermal.c b/drivers/thermal/sun8i_thermal.c
  	struct device				*dev;
  	struct regmap				*regmap;
  	struct reset_control			*reset;
-@@ -229,6 +230,32 @@
+@@ -223,6 +224,32 @@ static int sun8i_h3_ths_calibrate(struct ths_device *tmdev,
  	return 0;
  }
  
@@ -45,7 +45,7 @@ diff --git a/drivers/thermal/sun8i_thermal.c b/drivers/thermal/sun8i_thermal.c
  static int sun50i_h6_ths_calibrate(struct ths_device *tmdev,
  				   u16 *caldata, int callen)
  {
-@@ -751,14 +778,15 @@
+@@ -663,14 +690,15 @@ static const struct ths_thermal_chip sun8i_a83t_ths = {
  	.calc_temp = sun8i_ths_calc_temp,
  };
  

--- a/patch/kernel/archive/sunxi-6.1/patches.armbian/arm-dts-sun8i-h3-orangepizero-add_tve.patch
+++ b/patch/kernel/archive/sunxi-6.1/patches.armbian/arm-dts-sun8i-h3-orangepizero-add_tve.patch
@@ -7,11 +7,118 @@ Merged:
 3. sunxi-6.1/zzzz3-tv.patch : more additions to the "dts" and "dtsi" (like C include files), which I noticed were included in "yam" patch, but missing from the LibreElec patch
     https://github.com/robertojguerra/orangepi-zero-full-setup/blob/main/sunxi-6.1/zzzz3-tv.patch
 
+diff --git a/arch/arm/boot/dts/overlay/Makefile b/arch/arm/boot/dts/overlay/Makefile
+index 23f8c2048..b3bd27351 100644
+--- a/arch/arm/boot/dts/overlay/Makefile
++++ b/arch/arm/boot/dts/overlay/Makefile
+@@ -80,6 +80,7 @@ dtbo-$(CONFIG_MACH_SUN8I) += \
+ 	sun8i-h3-usbhost2.dtbo \
+ 	sun8i-h3-usbhost3.dtbo \
+ 	sun8i-h3-w1-gpio.dtbo \
++        sun8i-h3-tve.dtbo \
+ 	sun8i-r40-i2c2.dtbo \
+ 	sun8i-r40-i2c3.dtbo \
+ 	sun8i-r40-spi-spidev0.dtbo \
+diff --git a/arch/arm/boot/dts/overlay/README.sun8i-h3-overlays b/arch/arm/boot/dts/overlay/README.sun8i-h3-overlays
+index 302973491..a347fe7b0 100644
+--- a/arch/arm/boot/dts/overlay/README.sun8i-h3-overlays
++++ b/arch/arm/boot/dts/overlay/README.sun8i-h3-overlays
+@@ -34,6 +34,7 @@ adding fixed software (GPIO) chip selects is possible with a separate overlay
+ - usbhost2
+ - usbhost3
+ - w1-gpio
++- tve
+ 
+ ### Overlay details:
+ 
+@@ -248,3 +249,12 @@ param_w1_pin_int_pullup (bool)
+ 	Set to 1 to enable the pull-up
+ 	This option should not be used with multiple devices, parasite power setup
+ 		or long wires -	please use external pull-up resistor instead
++
++### tve
++
++Activates Composite TV Encoder
++
++Parameters:
++	Unknown at this stage. 
++	Maybe none. 
++	Not sure how to change the mode between PAL/NTSC.
+diff --git a/arch/arm/boot/dts/overlay/sun8i-h3-tve.dts b/arch/arm/boot/dts/overlay/sun8i-h3-tve.dts
+new file mode 100644
+index 000000000..07ba7ba71
+--- /dev/null
++++ b/arch/arm/boot/dts/overlay/sun8i-h3-tve.dts
+@@ -0,0 +1,34 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "allwinner,sun8i-h3";
++	
++	fragment@0 {
++		target = <&de>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++
++	fragment@1 {
++		target = <&mixer1>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++
++	fragment@2 {
++		target = <&tcon1>;
++		 __overlay__ {
++			status = "okay";
++		};
++	};
++
++	fragment@3 {
++		target = <&tve>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm/boot/dts/sun8i-h2-plus-orangepi-zero.dts b/arch/arm/boot/dts/sun8i-h2-plus-orangepi-zero.dts
+index 7b42ab8b5..330a79390 100644
+--- a/arch/arm/boot/dts/sun8i-h2-plus-orangepi-zero.dts
++++ b/arch/arm/boot/dts/sun8i-h2-plus-orangepi-zero.dts
+@@ -180,6 +180,10 @@ flash@0 {
+ 	};
+ };
+ 
++&tve {
++        status = "okay";
++};
++
+ &uart0 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&uart0_pa_pins>;
+diff --git a/arch/arm/boot/dts/sun8i-h3-orangepi-pc.dts b/arch/arm/boot/dts/sun8i-h3-orangepi-pc.dts
+index 624e248e3..01c3a7f76 100644
+--- a/arch/arm/boot/dts/sun8i-h3-orangepi-pc.dts
++++ b/arch/arm/boot/dts/sun8i-h3-orangepi-pc.dts
+@@ -214,6 +214,10 @@ &sound_hdmi {
+ 	status = "okay";
+ };
+ 
++&tve {
++	status = "okay";
++};
++
+ &uart0 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&uart0_pa_pins>;
 diff --git a/arch/arm/boot/dts/sun8i-h3.dtsi b/arch/arm/boot/dts/sun8i-h3.dtsi
-index 448dd325f8c3..d896dc5502f5 100644
+index 1b02a4c3f..5b1158c7a 100644
 --- a/arch/arm/boot/dts/sun8i-h3.dtsi
 +++ b/arch/arm/boot/dts/sun8i-h3.dtsi
-@@ -252,6 +252,20 @@ ths: thermal-sensor@1c25000 {
+@@ -294,6 +294,20 @@ ths: thermal-sensor@1c25000 {
  			nvmem-cell-names = "calibration";
  			#thermal-sensor-cells = <0>;
  		};
@@ -32,7 +139,7 @@ index 448dd325f8c3..d896dc5502f5 100644
  	};
  
  	thermal-zones {
-@@ -299,6 +313,10 @@ &mbus {
+@@ -383,6 +397,10 @@ &mbus {
  	compatible = "allwinner,sun8i-h3-mbus";
  };
  
@@ -43,7 +150,7 @@ index 448dd325f8c3..d896dc5502f5 100644
  &mmc0 {
  	compatible = "allwinner,sun7i-a20-mmc";
  	clocks = <&ccu CLK_BUS_MMC0>,
-@@ -346,3 +364,7 @@ &rtc {
+@@ -430,3 +448,7 @@ &rtc {
  &sid {
  	compatible = "allwinner,sun8i-h3-sid";
  };
@@ -52,10 +159,10 @@ index 448dd325f8c3..d896dc5502f5 100644
 +	remote-endpoint = <&tve_in_tcon1>;
 +};
 diff --git a/arch/arm/boot/dts/sunxi-h3-h5.dtsi b/arch/arm/boot/dts/sunxi-h3-h5.dtsi
-index 3d37a6a586b6..152029413784 100644
+index 7946699f4..cb6eb5d71 100644
 --- a/arch/arm/boot/dts/sunxi-h3-h5.dtsi
 +++ b/arch/arm/boot/dts/sunxi-h3-h5.dtsi
-@@ -119,7 +119,7 @@ osc32k: osc32k_clk {
+@@ -102,7 +102,7 @@ osc32k: osc32k_clk {
  
  	de: display-engine {
  		compatible = "allwinner,sun8i-h3-display-engine";
@@ -64,7 +171,7 @@ index 3d37a6a586b6..152029413784 100644
  		status = "disabled";
  	};
  
-@@ -163,11 +163,50 @@ ports {
+@@ -160,11 +160,50 @@ ports {
  				#size-cells = <0>;
  
  				mixer0_out: port@1 {
@@ -116,7 +223,7 @@ index 3d37a6a586b6..152029413784 100644
  				};
  			};
  		};
-@@ -196,11 +235,19 @@ ports {
+@@ -193,11 +232,19 @@ ports {
  				#size-cells = <0>;
  
  				tcon0_in: port@0 {
@@ -137,7 +244,7 @@ index 3d37a6a586b6..152029413784 100644
  				};
  
  				tcon0_out: port@1 {
-@@ -216,6 +263,48 @@ tcon0_out_hdmi: endpoint@1 {
+@@ -213,6 +260,48 @@ tcon0_out_hdmi: endpoint@1 {
  			};
  		};
  
@@ -187,10 +294,10 @@ index 3d37a6a586b6..152029413784 100644
  			/* compatible and clocks are in per SoC .dtsi file */
  			reg = <0x01c0f000 0x1000>;
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h5.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h5.dtsi
-index 4f00ae227cce..d30c85948ac5 100644
+index f6d970d9b..3df8abe0d 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h5.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h5.dtsi
-@@ -197,6 +197,20 @@ ths: thermal-sensor@1c25000 {
+@@ -203,6 +203,20 @@ ths: thermal-sensor@1c25000 {
  			nvmem-cell-names = "calibration";
  			#thermal-sensor-cells = <1>;
  		};
@@ -211,7 +318,7 @@ index 4f00ae227cce..d30c85948ac5 100644
  	};
  
  	thermal-zones {
-@@ -250,6 +264,10 @@ &mbus {
+@@ -298,6 +312,10 @@ &mbus {
  	compatible = "allwinner,sun50i-h5-mbus";
  };
  
@@ -222,7 +329,7 @@ index 4f00ae227cce..d30c85948ac5 100644
  &mmc0 {
  	compatible = "allwinner,sun50i-h5-mmc",
  		     "allwinner,sun50i-a64-mmc";
-@@ -285,3 +303,7 @@ &rtc {
+@@ -333,3 +351,7 @@ &rtc {
  &sid {
  	compatible = "allwinner,sun50i-h5-sid";
  };
@@ -231,10 +338,10 @@ index 4f00ae227cce..d30c85948ac5 100644
 +	remote-endpoint = <&tve_in_tcon1>;
 +};
 diff --git a/drivers/clk/sunxi-ng/ccu-sun8i-h3.c b/drivers/clk/sunxi-ng/ccu-sun8i-h3.c
-index e058cf691aea..0b0df6d6bc9c 100644
+index 4ec8d3ffa..5f689fe10 100644
 --- a/drivers/clk/sunxi-ng/ccu-sun8i-h3.c
 +++ b/drivers/clk/sunxi-ng/ccu-sun8i-h3.c
-@@ -458,8 +458,18 @@ static SUNXI_CCU_M_WITH_MUX_GATE(tcon_clk, "tcon", tcon_parents,
+@@ -464,8 +464,18 @@ static SUNXI_CCU_M_WITH_MUX_GATE(tcon_clk, "tcon", tcon_parents,
  				 CLK_SET_RATE_PARENT);
  
  static const char * const tve_parents[] = { "pll-de", "pll-periph1" };
@@ -256,10 +363,10 @@ index e058cf691aea..0b0df6d6bc9c 100644
  static const char * const deinterlace_parents[] = { "pll-periph0", "pll-periph1" };
  static SUNXI_CCU_M_WITH_MUX_GATE(deinterlace_clk, "deinterlace", deinterlace_parents,
 diff --git a/drivers/gpu/drm/sun4i/Makefile b/drivers/gpu/drm/sun4i/Makefile
-index 0d04f2447b01..7b151994e904 100644
+index 492bfd28a..721eddd6a 100644
 --- a/drivers/gpu/drm/sun4i/Makefile
 +++ b/drivers/gpu/drm/sun4i/Makefile
-@@ -16,7 +16,7 @@ sun8i-drm-hdmi-y		+= sun8i_hdmi_phy_clk.o
+@@ -19,7 +19,7 @@ sun8i-drm-hdmi-y		+= sun8i_hdmi_phy_clk.o
  
  sun8i-mixer-y			+= sun8i_mixer.o sun8i_ui_layer.o \
  				   sun8i_vi_layer.o sun8i_ui_scaler.o \
@@ -269,7 +376,7 @@ index 0d04f2447b01..7b151994e904 100644
  sun4i-tcon-y			+= sun4i_crtc.o
  sun4i-tcon-y			+= sun4i_dotclock.o
 diff --git a/drivers/gpu/drm/sun4i/sun4i_tv.c b/drivers/gpu/drm/sun4i/sun4i_tv.c
-index 94883abe0dfd..9c7090a0d52a 100644
+index c65f0a89b..e19f26df4 100644
 --- a/drivers/gpu/drm/sun4i/sun4i_tv.c
 +++ b/drivers/gpu/drm/sun4i/sun4i_tv.c
 @@ -10,6 +10,7 @@
@@ -280,7 +387,7 @@ index 94883abe0dfd..9c7090a0d52a 100644
  #include <linux/platform_device.h>
  #include <linux/regmap.h>
  #include <linux/reset.h>
-@@ -167,6 +168,11 @@ struct tv_mode {
+@@ -168,6 +169,11 @@ struct tv_mode {
  	const struct resync_parameters	*resync_params;
  };
  
@@ -292,7 +399,7 @@ index 94883abe0dfd..9c7090a0d52a 100644
  struct sun4i_tv {
  	struct drm_connector	connector;
  	struct drm_encoder	encoder;
-@@ -527,7 +533,7 @@ static const struct regmap_config sun4i_tv_regmap_config = {
+@@ -504,7 +510,7 @@ static const struct regmap_config sun4i_tv_regmap_config = {
  	.reg_bits	= 32,
  	.val_bits	= 32,
  	.reg_stride	= 4,
@@ -301,7 +408,7 @@ index 94883abe0dfd..9c7090a0d52a 100644
  	.name		= "tv-encoder",
  };
  
-@@ -537,13 +543,19 @@ static int sun4i_tv_bind(struct device *dev, struct device *master,
+@@ -514,13 +520,19 @@ static int sun4i_tv_bind(struct device *dev, struct device *master,
  	struct platform_device *pdev = to_platform_device(dev);
  	struct drm_device *drm = data;
  	struct sun4i_drv *drv = drm->dev_private;
@@ -321,7 +428,7 @@ index 94883abe0dfd..9c7090a0d52a 100644
  	tv->drv = drv;
  	dev_set_drvdata(dev, tv);
  
-@@ -580,6 +592,11 @@ static int sun4i_tv_bind(struct device *dev, struct device *master,
+@@ -557,6 +569,11 @@ static int sun4i_tv_bind(struct device *dev, struct device *master,
  	}
  	clk_prepare_enable(tv->clk);
  
@@ -333,7 +440,7 @@ index 94883abe0dfd..9c7090a0d52a 100644
  	drm_encoder_helper_add(&tv->encoder,
  			       &sun4i_tv_helper_funcs);
  	ret = drm_simple_encoder_init(drm, &tv->encoder,
-@@ -648,8 +665,22 @@ static int sun4i_tv_remove(struct platform_device *pdev)
+@@ -626,8 +643,22 @@ static int sun4i_tv_remove(struct platform_device *pdev)
  	return 0;
  }
  
@@ -358,12 +465,12 @@ index 94883abe0dfd..9c7090a0d52a 100644
  };
  MODULE_DEVICE_TABLE(of, sun4i_tv_of_table);
 diff --git a/drivers/gpu/drm/sun4i/sun8i_mixer.c b/drivers/gpu/drm/sun4i/sun8i_mixer.c
-index f5291170bf5e..490e8e74450f 100644
+index 9c17bb410..675d8a075 100644
 --- a/drivers/gpu/drm/sun4i/sun8i_mixer.c
 +++ b/drivers/gpu/drm/sun4i/sun8i_mixer.c
-@@ -32,6 +32,12 @@ struct de2_fmt_info {
- 	u32	de2_fmt;
- };
+@@ -35,6 +35,12 @@ struct de2_fmt_info {
+ 
+ static bool hw_preconfigured;
  
 +static const u32 sun8i_rgb2yuv_coef[12] = {
 +	0x00000107, 0x00000204, 0x00000064, 0x00004200,
@@ -374,7 +481,7 @@ index f5291170bf5e..490e8e74450f 100644
  static const struct de2_fmt_info de2_formats[] = {
  	{
  		.drm_fmt = DRM_FORMAT_ARGB8888,
-@@ -327,10 +333,29 @@ static void sun8i_mixer_mode_set(struct sunxi_engine *engine,
+@@ -435,10 +441,29 @@ static void sun8i_mixer_mode_set(struct sunxi_engine *engine,
  			 interlaced ? "on" : "off");
  }
  
@@ -406,8 +513,8 @@ index f5291170bf5e..490e8e74450f 100644
 +	.disable_color_correction	= sun8i_mixer_disable_color_correction,
  };
  
- static bool sun8i_mixer_volatile_reg(struct device *dev, unsigned int reg)
-@@ -746,8 +746,9 @@
+ static const struct regmap_config sun8i_mixer_regmap_config = {
+@@ -721,8 +746,9 @@ static const struct sun8i_mixer_cfg sun8i_h3_mixer0_cfg = {
  static const struct sun8i_mixer_cfg sun8i_h3_mixer1_cfg = {
  	.ccsc		= CCSC_MIXER1_LAYOUT,
  	.mod_rate	= 432000000,
@@ -420,10 +527,10 @@ index f5291170bf5e..490e8e74450f 100644
  };
  
 diff --git a/drivers/gpu/drm/sun4i/sun8i_mixer.h b/drivers/gpu/drm/sun4i/sun8i_mixer.h
-index 85c94884fb9a..28cdaf0044d9 100644
+index 68e2741b0..7bc8efca6 100644
 --- a/drivers/gpu/drm/sun4i/sun8i_mixer.h
 +++ b/drivers/gpu/drm/sun4i/sun8i_mixer.h
-@@ -118,6 +118,10 @@
+@@ -119,6 +119,10 @@
  /* format 20 is packed YVU444 10-bit */
  /* format 21 is packed YUV444 10-bit */
  
@@ -434,7 +541,7 @@ index 85c94884fb9a..28cdaf0044d9 100644
  /*
   * Sub-engines listed bellow are unused for now. The EN registers are here only
   * to be used to disable these sub-engines.
-@@ -128,7 +132,6 @@
+@@ -129,7 +133,6 @@
  #define SUN8I_MIXER_PEAK_EN			0xa6000
  #define SUN8I_MIXER_ASE_EN			0xa8000
  #define SUN8I_MIXER_FCC_EN			0xaa000
@@ -442,112 +549,3 @@ index 85c94884fb9a..28cdaf0044d9 100644
  
  #define SUN50I_MIXER_FCE_EN			0x70000
  #define SUN50I_MIXER_PEAK_EN			0x70800
--- 
-2.37.3
-diff --git a/arch/arm/boot/dts/overlay/Makefile b/arch/arm/boot/dts/overlay/Makefile
-index 23f8c2048..b3bd27351 100644
---- a/arch/arm/boot/dts/overlay/Makefile
-+++ b/arch/arm/boot/dts/overlay/Makefile
-@@ -80,6 +80,7 @@ dtbo-$(CONFIG_MACH_SUN8I) += \
- 	sun8i-h3-usbhost2.dtbo \
- 	sun8i-h3-usbhost3.dtbo \
- 	sun8i-h3-w1-gpio.dtbo \
-+        sun8i-h3-tve.dtbo \
- 	sun8i-r40-i2c2.dtbo \
- 	sun8i-r40-i2c3.dtbo \
- 	sun8i-r40-spi-spidev0.dtbo \
-diff --git a/arch/arm/boot/dts/overlay/README.sun8i-h3-overlays b/arch/arm/boot/dts/overlay/README.sun8i-h3-overlays
-index 302973491..a347fe7b0 100644
---- a/arch/arm/boot/dts/overlay/README.sun8i-h3-overlays
-+++ b/arch/arm/boot/dts/overlay/README.sun8i-h3-overlays
-@@ -34,6 +34,7 @@ adding fixed software (GPIO) chip selects is possible with a separate overlay
- - usbhost2
- - usbhost3
- - w1-gpio
-+- tve
- 
- ### Overlay details:
- 
-@@ -248,3 +249,12 @@ param_w1_pin_int_pullup (bool)
- 	Set to 1 to enable the pull-up
- 	This option should not be used with multiple devices, parasite power setup
- 		or long wires -	please use external pull-up resistor instead
-+
-+### tve
-+
-+Activates Composite TV Encoder
-+
-+Parameters:
-+	Unknown at this stage. 
-+	Maybe none. 
-+	Not sure how to change the mode between PAL/NTSC.
-diff --git a/arch/arm/boot/dts/sun8i-h3-orangepi-pc.dts b/arch/arm/boot/dts/sun8i-h3-orangepi-pc.dts
-index 5aff8ecc66cbb..6626d2ced840c 100644
---- a/arch/arm/boot/dts/sun8i-h3-orangepi-pc.dts
-+++ b/arch/arm/boot/dts/sun8i-h3-orangepi-pc.dts
-@@ -204,6 +204,10 @@
- 	status = "okay";
- };
- 
-+&tve {
-+	status = "okay";
-+};
-+
- &uart0 {
- 	pinctrl-names = "default";
- 	pinctrl-0 = <&uart0_pa_pins>;
-diff --git a/arch/arm/boot/dts/overlay/sun8i-h3-tve.dts b/arch/arm/boot/dts/overlay/sun8i-h3-tve.dts
-new file mode 100644
-index 000000000..07ba7ba71
---- /dev/null
-+++ b/arch/arm/boot/dts/overlay/sun8i-h3-tve.dts
-@@ -0,0 +1,34 @@
-+/dts-v1/;
-+/plugin/;
-+
-+/ {
-+	compatible = "allwinner,sun8i-h3";
-+	
-+	fragment@0 {
-+		target = <&de>;
-+		__overlay__ {
-+			status = "okay";
-+		};
-+	};
-+
-+	fragment@1 {
-+		target = <&mixer1>;
-+		__overlay__ {
-+			status = "okay";
-+		};
-+	};
-+
-+	fragment@2 {
-+		target = <&tcon1>;
-+		 __overlay__ {
-+			status = "okay";
-+		};
-+	};
-+
-+	fragment@3 {
-+		target = <&tve>;
-+		__overlay__ {
-+			status = "okay";
-+		};
-+	};
-+};
-diff --git a/arch/arm/boot/dts/sun8i-h2-plus-orangepi-zero.dts b/arch/arm/boot/dts/sun8i-h2-plus-orangepi-zero.dts
-index 4120437a1..4e10c8cfa 100644
---- a/arch/arm/boot/dts/sun8i-h2-plus-orangepi-zero.dts
-+++ b/arch/arm/boot/dts/sun8i-h2-plus-orangepi-zero.dts
-@@ -180,6 +180,10 @@ flash@0 {
- 	};
- };
- 
-+&tve {
-+        status = "okay";
-+};
-+
- &uart0 {
- 	pinctrl-names = "default";
- 	pinctrl-0 = <&uart0_pa_pins>;

--- a/patch/kernel/archive/sunxi-6.1/patches.armbian/arm64-dts-sun50i-a64-pinephone-wowlan.patch
+++ b/patch/kernel/archive/sunxi-6.1/patches.armbian/arm64-dts-sun50i-a64-pinephone-wowlan.patch
@@ -1,8 +1,8 @@
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi
-index 53f4c1f66..1a5c51182 100644
+index 2f73f937a..f4be42902 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi
-@@ -468,6 +468,7 @@ &cpu3 {
+@@ -496,6 +496,7 @@ &cpu3 {
  &csi {
  	pinctrl-0 = <&csi_pins>, <&csi_mclk_pin>;
  	status = "okay";

--- a/patch/kernel/archive/sunxi-6.1/patches.armbian/drv-rtc-sun6i-support-RTCs-without-external-LOSCs.patch
+++ b/patch/kernel/archive/sunxi-6.1/patches.armbian/drv-rtc-sun6i-support-RTCs-without-external-LOSCs.patch
@@ -1,7 +1,7 @@
-From 1f36d7797c50fb7caa8e644dd7bf318927a7e925 Mon Sep 17 00:00:00 2001
+From 4b8894829753da0821970e0679e77a02b85186dd Mon Sep 17 00:00:00 2001
 From: Andre Przywara <andre.przywara@arm.com>
 Date: Mon, 14 Jun 2021 23:02:45 +0100
-Subject: [PATCH 011/170] drv:rtc:sun6i: support RTCs without external LOSCs
+Subject: [PATCH] drv:rtc:sun6i: support RTCs without external LOSCs
 
 Some newer Allwinner RTCs (for instance the one in the H616 SoC) lack
 a pin for an external 32768 Hz oscillator. As a consequence, this LOSC
@@ -19,18 +19,18 @@ Acked-by: Jernej Skrabec <jernej.skrabec@gmail.com>
  1 file changed, 11 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/rtc/rtc-sun6i.c b/drivers/rtc/rtc-sun6i.c
-index 57d06084a..ae9f502f2 100644
+index e4db445b7..055d2503c 100644
 --- a/drivers/rtc/rtc-sun6i.c
 +++ b/drivers/rtc/rtc-sun6i.c
-@@ -139,6 +139,7 @@ struct sun6i_rtc_clk_data {
- 	unsigned int export_iosc : 1;
+@@ -138,6 +138,7 @@ struct sun6i_rtc_clk_data {
+ 	unsigned int has_out_clk : 1;
  	unsigned int has_losc_en : 1;
  	unsigned int has_auto_swt : 1;
 +	unsigned int no_ext_losc : 1;
  };
  
  #define RTC_LINEAR_DAY	BIT(0)
-@@ -261,7 +262,7 @@ static void __init sun6i_rtc_clk_init(struct device_node *node,
+@@ -260,7 +261,7 @@ static void __init sun6i_rtc_clk_init(struct device_node *node,
  	}
  
  	/* Switch to the external, more precise, oscillator, if present */
@@ -39,7 +39,7 @@ index 57d06084a..ae9f502f2 100644
  		reg |= SUN6I_LOSC_CTRL_EXT_OSC;
  		if (rtc->data->has_losc_en)
  			reg |= SUN6I_LOSC_CTRL_EXT_LOSC_EN;
-@@ -287,14 +288,19 @@ static void __init sun6i_rtc_clk_init(struct device_node *node,
+@@ -284,14 +285,19 @@ static void __init sun6i_rtc_clk_init(struct device_node *node,
  	}
  
  	parents[0] = clk_hw_get_name(rtc->int_osc);
@@ -64,5 +64,5 @@ index 57d06084a..ae9f502f2 100644
  				      &init.name);
  
 -- 
-2.35.3
+2.34.1
 

--- a/patch/kernel/archive/sunxi-6.1/patches.megous/usb-dwc3-Add-support-for-snps-usb3-phy-reset-quirk.patch
+++ b/patch/kernel/archive/sunxi-6.1/patches.megous/usb-dwc3-Add-support-for-snps-usb3-phy-reset-quirk.patch
@@ -1,7 +1,7 @@
-From bd87780b9dbbe420679e97a00b1ef4200c0f01ae Mon Sep 17 00:00:00 2001
+From f4882eaf87ef7c1928cd41b205e7545060f36d59 Mon Sep 17 00:00:00 2001
 From: Ondrej Jirman <megi@xff.cz>
 Date: Mon, 27 Jun 2022 18:43:47 +0200
-Subject: [PATCH 378/388] usb: dwc3: Add support for snps,usb3-phy-reset-quirk
+Subject: [PATCH] usb: dwc3: Add support for snps,usb3-phy-reset-quirk
 
 RK3399 TypeC PHY needs to be powered off and powered on again
 for it to apply the correct Type-C plug orientation setting from
@@ -40,7 +40,7 @@ Signed-off-by: Ondrej Jirman <megi@xff.cz>
  3 files changed, 73 insertions(+), 15 deletions(-)
 
 diff --git a/drivers/usb/dwc3/core.c b/drivers/usb/dwc3/core.c
-index 5655569b5..c3c2f0e90 100644
+index f9b720e2d..038a459e4 100644
 --- a/drivers/usb/dwc3/core.c
 +++ b/drivers/usb/dwc3/core.c
 @@ -110,7 +110,7 @@ void dwc3_set_prtcap(struct dwc3 *dwc, u32 mode)
@@ -118,7 +118,7 @@ index 5655569b5..c3c2f0e90 100644
  
  	dwc->lpm_nyet_threshold = lpm_nyet_threshold;
  	dwc->tx_de_emphasis = tx_de_emphasis;
-@@ -2035,6 +2066,7 @@ static int dwc3_suspend_common(struct dwc3 *dwc, pm_message_t msg)
+@@ -2032,6 +2063,7 @@ static int dwc3_suspend_common(struct dwc3 *dwc, pm_message_t msg)
  
  	switch (dwc->current_dr_role) {
  	case DWC3_GCTL_PRTCAP_DEVICE:
@@ -126,7 +126,7 @@ index 5655569b5..c3c2f0e90 100644
  		if (pm_runtime_suspended(dwc->dev))
  			break;
  		dwc3_gadget_suspend(dwc);
-@@ -2093,11 +2125,12 @@ static int dwc3_resume_common(struct dwc3 *dwc, pm_message_t msg)
+@@ -2090,11 +2122,12 @@ static int dwc3_resume_common(struct dwc3 *dwc, pm_message_t msg)
  
  	switch (dwc->current_dr_role) {
  	case DWC3_GCTL_PRTCAP_DEVICE:
@@ -140,7 +140,7 @@ index 5655569b5..c3c2f0e90 100644
  		dwc3_gadget_resume(dwc);
  		break;
  	case DWC3_GCTL_PRTCAP_HOST:
-@@ -2154,6 +2187,7 @@ static int dwc3_runtime_checks(struct dwc3 *dwc)
+@@ -2151,6 +2184,7 @@ static int dwc3_runtime_checks(struct dwc3 *dwc)
  {
  	switch (dwc->current_dr_role) {
  	case DWC3_GCTL_PRTCAP_DEVICE:
@@ -148,7 +148,7 @@ index 5655569b5..c3c2f0e90 100644
  		if (dwc->connected)
  			return -EBUSY;
  		break;
-@@ -2192,6 +2226,7 @@ static int dwc3_runtime_resume(struct device *dev)
+@@ -2189,6 +2223,7 @@ static int dwc3_runtime_resume(struct device *dev)
  
  	switch (dwc->current_dr_role) {
  	case DWC3_GCTL_PRTCAP_DEVICE:
@@ -156,7 +156,7 @@ index 5655569b5..c3c2f0e90 100644
  		dwc3_gadget_process_pending_events(dwc);
  		break;
  	case DWC3_GCTL_PRTCAP_HOST:
-@@ -2211,6 +2246,7 @@ static int dwc3_runtime_idle(struct device *dev)
+@@ -2208,6 +2243,7 @@ static int dwc3_runtime_idle(struct device *dev)
  
  	switch (dwc->current_dr_role) {
  	case DWC3_GCTL_PRTCAP_DEVICE:
@@ -165,7 +165,7 @@ index 5655569b5..c3c2f0e90 100644
  			return -EBUSY;
  		break;
 diff --git a/drivers/usb/dwc3/core.h b/drivers/usb/dwc3/core.h
-index 189b436a9..0cfff15f8 100644
+index 26ba2104b..60929c8b7 100644
 --- a/drivers/usb/dwc3/core.h
 +++ b/drivers/usb/dwc3/core.h
 @@ -244,6 +244,12 @@
@@ -181,10 +181,10 @@ index 189b436a9..0cfff15f8 100644
  
  #define DWC3_GCTL_CORESOFTRESET		BIT(11)
  #define DWC3_GCTL_SOFITPSYNC		BIT(10)
-@@ -1110,6 +1116,10 @@ struct dwc3_scratchpad_array {
-  *	3	- Reserved
+@@ -1111,6 +1117,10 @@ struct dwc3_scratchpad_array {
   * @dis_metastability_quirk: set to disable metastability quirk.
   * @dis_split_quirk: set to disable split boundary.
+  * @suspended: set to track suspend event due to U3/L2.
 + * @usb3_phy_reset_quirk: set to power cycle the USB3 PHY during mode
 + *                        changes. Useful on RK3399 that needs this
 + *                        to apply Type-C orientation changes in
@@ -192,9 +192,9 @@ index 189b436a9..0cfff15f8 100644
   * @imod_interval: set the interrupt moderation interval in 250ns
   *			increments or 0 to disable.
   * @max_cfg_eps: current max number of IN eps used across all USB configs.
-@@ -1328,6 +1338,8 @@ struct dwc3 {
- 	unsigned		dis_split_quirk:1;
+@@ -1331,6 +1341,8 @@ struct dwc3 {
  	unsigned		async_callbacks:1;
+ 	unsigned		suspended:1;
  
 +	unsigned		usb3_phy_reset_quirk:1;
 +
@@ -263,5 +263,5 @@ index 039bf2417..1284575d5 100644
  			dev_err(dwc->dev, "couldn't register cable notifier\n");
  			return ret;
 -- 
-2.35.3
+2.34.1
 

--- a/patch/kernel/archive/sunxi-6.1/series.conf
+++ b/patch/kernel/archive/sunxi-6.1/series.conf
@@ -169,15 +169,15 @@
 	patches.megous/mmc-sunxi-mmc-Remove-runtime-PM.patch
 	patches.megous/usb-quirks-Add-USB_QUIRK_RESET-for-Quectel-EG25G-Modem.patch
 	patches.megous/arm64-dts-pinephone-Add-reboot-mode-driver.patch
-	patches.megous/arm64-dts-rk3399-pinebook-pro-Fix-USB-PD-charging.patch
-	patches.megous/arm64-dts-rk3399-pinebook-pro-Improve-Type-C-support-on-Pineboo.patch
-	patches.megous/arm64-dts-rk3399-pinebook-pro-Remove-redundant-pinctrl-properti.patch
-	patches.megous/arm64-dts-rk3399-pinebook-pro-Remove-unused-features.patch
-	patches.megous/arm64-dts-rk3399-pinebook-pro-Don-t-allow-usb2-phy-driver-to-up.patch
-	patches.megous/arm64-dts-rockchip-rk3399-pinebook-pro-Support-both-Type-C-plug.patch
+-	patches.megous/arm64-dts-rk3399-pinebook-pro-Fix-USB-PD-charging.patch
+-	patches.megous/arm64-dts-rk3399-pinebook-pro-Improve-Type-C-support-on-Pineboo.patch
+-	patches.megous/arm64-dts-rk3399-pinebook-pro-Remove-redundant-pinctrl-properti.patch
+-	patches.megous/arm64-dts-rk3399-pinebook-pro-Remove-unused-features.patch
+-	patches.megous/arm64-dts-rk3399-pinebook-pro-Don-t-allow-usb2-phy-driver-to-up.patch
+-	patches.megous/arm64-dts-rockchip-rk3399-pinebook-pro-Support-both-Type-C-plug.patch
 	patches.megous/ASoC-codec-es8316-DAC-Soft-Ramp-Rate-is-just-a-2-bit-control.patch
 	patches.megous/misc-modem-power-Power-manager-for-modems.patch
-	patches.megous/arm64-dts-rk3399-pinebook-pro-Fix-codec-frequency-after-boot.patch
+-	patches.megous/arm64-dts-rk3399-pinebook-pro-Fix-codec-frequency-after-boot.patch
 	patches.megous/media-cedrus-Fix-missing-cleanup-in-error-path.patch
 	patches.megous/media-cedrus-Fix-failure-to-clean-up-hardware-on-probe-failure.patch
 	patches.megous/Revert-drm-sun4i-lvds-Invert-the-LVDS-polarity.patch
@@ -188,9 +188,9 @@
 -	patches.megous/Bluetooth-Add-new-quirk-for-broken-local-ext-features-max_page.patch
 	patches.megous/rtw89-Fix-crash-by-loading-compressed-firmware-file.patch
 -	patches.megous/Bluetooth-btrtl-add-support-for-the-RTL8723CS.patch
-	patches.megous/drm-rockchip-Fix-panic-on-reboot-when-DRM-device-fails-to-bind.patch
+-	patches.megous/drm-rockchip-Fix-panic-on-reboot-when-DRM-device-fails-to-bind.patch
 -	patches.megous/Bluetooth-hci_h5-Add-support-for-binding-RTL8723CS-with-device-.patch
-	patches.megous/arm64-dts-rockchip-rk356x-Fix-PCIe-register-map-and-ranges.patch
+-	patches.megous/arm64-dts-rockchip-rk356x-Fix-PCIe-register-map-and-ranges.patch
 -	patches.megous/bluetooth-h5-Don-t-re-initialize-rtl8723cs-on-resume.patch
 	patches.megous/drm-sun4i-Unify-sun8i_-_layer-structs.patch
 	patches.megous/drm-sun4i-Add-more-parameters-to-sunxi_engine-commit-callback.patch
@@ -270,44 +270,44 @@
 	patches.megous/Make-microbuttons-on-Orange-Pi-PC-and-PC-2-work-as-power-off-bu.patch
 	patches.megous/arm64-allwinner-dts-a64-enable-K101-IM2BYL02-panel-for-PineTab.patch
 	patches.megous/ARM-dts-sun8i-a83t-Add-MBUS-node.patch
-	patches.megous/arm64-dts-rk3399-Disable-debug-nodes.patch
-	patches.megous/arm64-dts-rk3399-Add-reboot-mode-driver.patch
-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-support-for-volume-keys.patch
-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-support-for-vibrator.patch
-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-support-for-LEDs.patch
-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-SPI-flash.patch
-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-internal-display-support.patch
-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-BSP-battery-driver-support.patch
+-	patches.megous/arm64-dts-rk3399-Disable-debug-nodes.patch
+-	patches.megous/arm64-dts-rk3399-Add-reboot-mode-driver.patch
+-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-support-for-volume-keys.patch
+-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-support-for-vibrator.patch
+-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-support-for-LEDs.patch
+-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-SPI-flash.patch
+-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-internal-display-support.patch
+-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-BSP-battery-driver-support.patch
 	patches.megous/Add-support-for-my-private-Sapomat-device.patch
-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-WiFi-Bluetooth-support.patch
+-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-WiFi-Bluetooth-support.patch
 -	patches.megous/Add-README.md-with-information-and-u-boot-patches.patch
-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-5V-power-supply.patch
+-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-5V-power-supply.patch
 	patches.megous/ARM-dts-sun8i-h3-orange-pi-one-Enable-all-gpio-header-UARTs.patch
-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-sound-support.patch
+-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-sound-support.patch
 	patches.megous/Defconfigs-for-all-my-devices.patch
-	patches.megous/arm64-dts-pinephone-pro-Add-Type-C-port-support.patch
-	patches.megous/arm64-dts-pinephone-pro-Add-camera-support.patch
-	patches.megous/arm64-dts-pinephone-pro-Add-modem-support.patch
-	patches.megous/arm64-dts-pinephone-pro-Add-light-proximity-sensor-support.patch
-	patches.megous/clk-rk3399-Export-SCLK_CIF_OUT_SRC-to-device-tree.patch
-	patches.megous/arm64-dts-pinephone-pro-Add-accelerometer-sensor-support.patch
-	patches.megous/clk-rk3399-Allow-to-set-rate-of-clk_i2s0_frac-s-parent.patch
-	patches.megous/arm64-dts-pinephone-pro-Add-magnetometer-sensor-support.patch
-	patches.megous/clk-rockchip-rk3399-Don-t-allow-to-reparent-dclk_vop0-to-frac-c.patch
-	patches.megous/arm64-dts-pinephone-pro-Enable-POGO-pins-I2C.patch
+-	patches.megous/arm64-dts-pinephone-pro-Add-Type-C-port-support.patch
+-	patches.megous/arm64-dts-pinephone-pro-Add-camera-support.patch
+-	patches.megous/arm64-dts-pinephone-pro-Add-modem-support.patch
+-	patches.megous/arm64-dts-pinephone-pro-Add-light-proximity-sensor-support.patch
+-	patches.megous/clk-rk3399-Export-SCLK_CIF_OUT_SRC-to-device-tree.patch
+-	patches.megous/arm64-dts-pinephone-pro-Add-accelerometer-sensor-support.patch
+-	patches.megous/clk-rk3399-Allow-to-set-rate-of-clk_i2s0_frac-s-parent.patch
+-	patches.megous/arm64-dts-pinephone-pro-Add-magnetometer-sensor-support.patch
+-	patches.megous/clk-rockchip-rk3399-Don-t-allow-to-reparent-dclk_vop0-to-frac-c.patch
+-	patches.megous/arm64-dts-pinephone-pro-Enable-POGO-pins-I2C.patch
 	patches.megous/sdhci-arasan-Add-runtime-PM-support.patch
-	patches.megous/arm64-dts-pinephone-pro-Add-pinephone-keyboard-support.patch
-	patches.megous/mmc-dw-mmc-rockchip-fix-sdmmc-after-soft-reboot.patch
-	patches.megous/arm64-dts-rk3399-pinephone-pro-Use-unused-GPLL-for-VOPs-DCLK.patch
+-	patches.megous/arm64-dts-pinephone-pro-Add-pinephone-keyboard-support.patch
+-	patches.megous/mmc-dw-mmc-rockchip-fix-sdmmc-after-soft-reboot.patch
+-	patches.megous/arm64-dts-rk3399-pinephone-pro-Use-unused-GPLL-for-VOPs-DCLK.patch
 	patches.megous/mtd-spi-nor-gigadevice-add-support-for-gd25lq128e.patch
-	patches.megous/spi-rockchip-Fix-runtime-PM-and-other-issues.patch
-	patches.megous/drm-rockchip-dw-mipi-dsi-Fix-data-rate-calculation.patch
+-	patches.megous/spi-rockchip-Fix-runtime-PM-and-other-issues.patch
+-	patches.megous/drm-rockchip-dw-mipi-dsi-Fix-data-rate-calculation.patch
 	patches.megous/drm-bridge-dw-mipi-dsi-Fix-enable-disable-of-dsi-controller.patch
 	patches.megous/drm-panel-hx8394-Add-driver-for-HX8394-based-HannStar-HSD060BHW.patch
 	patches.megous/drm-panel-hx8394-Improve-the-panel-driver-make-it-work-with-DSI.patch
 	patches.megous/drm-panel-hx8394-Fix-mode-to-have-refresh-rate-of-60-Hz.patch
 	patches.megous/drm-panel-hx8394-Add-mode-init-sequence-update-via-firmware-loa.patch
-	patches.megous/drm-rockchip-cdn-dp-Disable-CDN-DP-on-disconnect.patch
+-	patches.megous/drm-rockchip-cdn-dp-Disable-CDN-DP-on-disconnect.patch
 	patches.megous/input-touchscreen-goodix-Respect-IRQ-flags-from-DT-when-asked-t.patch
 	patches.megous/power-rk818-Configure-rk808-clkout2-function.patch
 	patches.megous/power-supply-rk818-battery-Add-battery-driver-for-RK818.patch
@@ -365,8 +365,8 @@
 	patches.megous/media-i2c-ov8858-Add-support-for-digital-gain-control.patch
 	patches.megous/media-i2c-ov8858-Use-default-subdev-name.patch
 	patches.megous/media-rkisp1-Allow-higher-input-resolution.patch
-	patches.megous/phy-phy-rockchip-inno-usb2-Decrease-delay-between-port-init-and.patch
-	patches.megous/phy-rockchip-inno-usb2-More-robust-charger-detection-extcon-upd.patch
+-	patches.megous/phy-phy-rockchip-inno-usb2-Decrease-delay-between-port-init-and.patch
+-	patches.megous/phy-rockchip-inno-usb2-More-robust-charger-detection-extcon-upd.patch
 	patches.megous/usb-typec-altmodes-displayport-Respect-DP_CAP_RECEPTACLE-bit.patch
 	patches.megous/usb-typec-fusb302-Slightly-increase-wait-time-for-BC1.2-result.patch
 	patches.megous/usb-typec-fusb302-Set-the-current-before-enabling-pullups.patch
@@ -383,16 +383,16 @@
 	patches.megous/leds-sgm3140-Add-missing-timer-cleanup-and-flash-gpio-control.patch
 	patches.megous/usb-dwc3-Track-the-power-state-of-usb3_generic_phy.patch
 	patches.megous/usb-dwc3-Add-support-for-snps-usb3-phy-reset-quirk.patch
-	patches.megous/ASoC-rockchip-Fix-doubling-of-playback-speed-after-system-sleep.patch
+-	patches.megous/ASoC-rockchip-Fix-doubling-of-playback-speed-after-system-sleep.patch
 	patches.megous/usb-typec-tcpm-Unregister-altmodes-before-registering-new-ones.patch
-	patches.megous/drm-rockchip-Don-t-require-MIPI-DSI-device-when-it-s-used-for-I.patch
+-	patches.megous/drm-rockchip-Don-t-require-MIPI-DSI-device-when-it-s-used-for-I.patch
 	patches.megous/ASoC-rt5640-Allow-configuration-of-LOUT-to-mono-differential-mo.patch
 	patches.megous/dt-bindings-sound-rt5640-Allow-to-describe-how-LOUT-is-wired.patch
 	patches.megous/ASoC-codec-rt5640-Fix-output-mixer-input-channel-list.patch
 	patches.megous/ASoC-codec-rt5640-Fix-hpout-restore-when-lout-is-enabled.patch
 	patches.megous/ASoC-codec-rt5640-Resolve-failure-to-set-DMIC-clock-after-playb.patch
 	patches.megous/media-ov5640-Fix-sensor-probe-with-the-anti-click-patch.patch
-	patches.megous/arm64-dts-rockchip-rk3399-pinebook-pro-Fix-VDO-display-output.patch
+-	patches.megous/arm64-dts-rockchip-rk3399-pinebook-pro-Fix-VDO-display-output.patch
 
 ###########        Fixes applied after megous patches        ###################
 #


### PR DESCRIPTION
# Description

Bumped current kernel to 6.1.33. Also disabled some Rockchip patches thats gets applied on the sunxi kernel.

# How Has This Been Tested?

- [X] Compiled an image and booted it on Nanopiduo2

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
