### PR TITLE
Disable RTW88 on midstream kernel as it breaks building

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -400,7 +400,9 @@ driver_rtl88x2bu() {
 }
 
 driver_rtw88() {
-	if [[ "$LINUXFAMILY" == d1 ]]; then # "D1" is using an old 6.1 which can't take this.
+	if [[ "$LINUXFAMILY" == d1 || "$BRANCH" == midstream ]]; then
+		# "D1" is using an old 6.1 which can't take this.
+		# "midstream" a half monster kernel, a cross between sre mainline and downstream rk kernel
 		return 0
 	fi
 


### PR DESCRIPTION
# Description

As per tittle.

# How Has This Been Tested?

- [ ] Build test

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings