### PR TITLE
Remove deprecated KERNEL_ONLY from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ BRANCH=current \
 RELEASE=focal \
 BUILD_MINIMAL=yes \
 BUILD_DESKTOP=no \
-KERNEL_ONLY=no \
 KERNEL_CONFIGURE=no \
 CARD_DEVICE="/dev/sdX"
 ```


### PR DESCRIPTION
Looks like this got missed when removing KERNEL_ONLY. Having it here in the first example causes that example to fail, Remove it.

- [x] Test build with KERNEL_ONLY fails
- [x] Test build without KERNEL_ONLY passes

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
