### PR TITLE
Jethub: apt hook: rtl_bt/rtl8822cs: `downstream firmware`

### DIFF
--- a/config/boards/jethubj80.conf
+++ b/config/boards/jethubj80.conf
@@ -5,3 +5,9 @@ BOOTCONFIG="jethub_j80_defconfig"
 KERNEL_TARGET="current,edge"
 PACKAGE_LIST_BOARD="libubootenv-tool apparmor rfkill bluetooth bluez bluez-tools python3-pip watchdog python3-serial python3-intelhex python3-intelhex"
 DEFAULT_CONSOLE="serial"
+
+function post_family_tweaks_bsp__add_apt_hook_for_jethub() {
+  mkdir -p "${destination}"/etc/apt/apt.conf.d
+  echo 'DPkg::Pre-Invoke {"/usr/lib/armbian/jethub-pre-hook";};' > "${destination}"/etc/apt/apt.conf.d/80jethub-apthook
+  echo 'DPkg::Post-Invoke {"/usr/lib/armbian/jethub-post-hook";};' >> "${destination}"/etc/apt/apt.conf.d/80jethub-apthook
+}

--- a/config/sources/families/jethub.conf
+++ b/config/sources/families/jethub.conf
@@ -141,6 +141,10 @@ buildjethomecmds() {
 
 		run_host_command_logged install -m 755 "$SRC/packages/bsp/jethub/$BOARD/bluetooth/jethub-rtk-hciattach-starter" "$destination/usr/lib/armbian/" || exit_with_error "Unable to install jethub-rtk-hciattach-starter"
 
+		# Pre & post apt hooks
+		run_host_command_logged install -m 755 "$SRC/packages/bsp/jethub/$BOARD/bluetooth/jethub-pre-hook" "$destination/usr/lib/armbian/" || exit_with_error "Unable to install jethub-pre-hook"
+		run_host_command_logged install -m 755 "$SRC/packages/bsp/jethub/$BOARD/bluetooth/jethub-post-hook" "$destination/usr/lib/armbian/" || exit_with_error "Unable to install jethub-post-hook"
+
 		# Board eth led setup
 		run_host_command_logged env PATH="${toolchain}:${PATH}" "$gcc" "$SRC/packages/bsp/jethub/$BOARD/jethub_set_eth_leds.c" -o "$destination/usr/sbin/jethub_set-eth_leds" || exit_with_error "Unable to compile jethub_set_eth_leds.c"
 		# Board identifiers

--- a/packages/bsp/jethub/jethubj80/bluetooth/jethub-post-hook
+++ b/packages/bsp/jethub/jethubj80/bluetooth/jethub-post-hook
@@ -1,0 +1,16 @@
+#!/bin/bash
+# REALTEK 8822CS DOWN STREAM BLUETOOTH FIRMWARE POST APT HOOK SCRIPT
+
+RTL_BT="/lib/firmware/rtl_bt"
+if [[ -f "${RTL_BT}/rtl8822cs_config.bin" ]] && [[ -f "${RTL_BT}/rtl8822cs_config.bin-downstream" ]]; then
+	cp -f ${RTL_BT}/rtl8822cs_config.bin ${RTL_BT}/rtl8822cs_config.bin-bak
+	rm -f ${RTL_BT}/rtl8822cs_config.bin
+	ln -s ${RTL_BT}/rtl8822cs_config.bin-downstream ${RTL_BT}/rtl8822cs_config.bin
+fi
+if [[ -f "${RTL_BT}/rtl8822cs_fw.bin" ]] && [[ -f "${RTL_BT}/rtl8822cs_fw.bin-downstream" ]]; then
+	cp -f ${RTL_BT}/rtl8822cs_fw.bin ${RTL_BT}/rtl8822cs_fw.bin-bak
+	rm -f ${RTL_BT}/rtl8822cs_fw.bin
+	ln -s ${RTL_BT}/rtl8822cs_fw.bin-downstream ${RTL_BT}/rtl8822cs_fw.bin
+fi
+
+exit 0

--- a/packages/bsp/jethub/jethubj80/bluetooth/jethub-pre-hook
+++ b/packages/bsp/jethub/jethubj80/bluetooth/jethub-pre-hook
@@ -1,0 +1,14 @@
+#!/bin/bash
+# REALTEK 8822CS DOWN STREAM BLUETOOTH FIRMWARE PRE APT HOOK SCRIPT
+
+RTL_BT="/lib/firmware/rtl_bt"
+if [[ -f "${RTL_BT}/rtl8822cs_config.bin-bak" ]]; then
+	rm -f ${RTL_BT}/rtl8822cs_config.bin
+	mv -f ${RTL_BT}/rtl8822cs_config.bin-bak ${RTL_BT}/rtl8822cs_config.bin
+fi
+if [[ -f "${RTL_BT}/rtl8822cs_fw.bin-bak" ]]; then
+	rm -f ${RTL_BT}/rtl8822cs_fw.bin
+	mv ${RTL_BT}/rtl8822cs_fw.bin-bak ${RTL_BT}/rtl8822cs_fw.bin
+fi
+
+exit 0


### PR DESCRIPTION
@adeepn @rpardini

As discussed here: https://github.com/armbian/build/pull/5315

In order to update to the latest rtl8822cs BT firmware for the G12/SM1 family of boards and still provide the downstream firmware for the AXG/GXL family, I created an apt hook to ensure the proper firmware stays in place.

I unfortunately can’t test this beyond creating an IMG as I don’t own the unit and the firmware isn’t currently committed. In order to test, someone would need to boot an IMG built from this commit, add the latest firmware to the booted unit and install a package to see if the apt hook works.

Firmware commit: https://github.com/pyavitz/armbian-firmware/commit/a7bf7c7cc8a85dbbc28c1c409e09b11917ebc2b6

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
