### PR TITLE
sunxi-6.2 h616 orangepi-zero2: Enable expansion board USB ports

### DIFF
--- a/patch/kernel/archive/sunxi-6.2/patches.armbian/arm64-dts-allwinner-h616-orangepi-zero2-Enable-expansion-board-USB-ports.patch
+++ b/patch/kernel/archive/sunxi-6.2/patches.armbian/arm64-dts-allwinner-h616-orangepi-zero2-Enable-expansion-board-USB-ports.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20Dzieko=C5=84ski?=
+ <michal.dziekonski+github@gmail.com>
+Date: Sun, 28 May 2023 00:26:43 +0000
+Subject: arm64: dts: allwinner: h616 orangepi zero2: Enable expansion board
+ USB ports
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Michał Dziekoński <michal.dziekonski+github@gmail.com>
+---
+ arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts b/arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts
+index b78941d29..565cd51e2 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts
+@@ -64,10 +64,19 @@ reg_usb1_vbus: usb1-vbus {
+ 
+ &ehci1 {
+ 	status = "okay";
+ };
+ 
++
++/* USB 2 & 3 are on headers used by expansion board */
++&ehci2 {
++	status = "okay";
++};
++&ehci3 {
++	status = "okay";
++};
++
+ &gpu {
+ 	mali-supply = <&reg_dcdcc>;
+ 	status = "okay";
+ };
+ 
+-- 
+Created with Armbian build tools https://github.com/armbian/build

--- a/patch/kernel/archive/sunxi-6.2/series.armbian
+++ b/patch/kernel/archive/sunxi-6.2/series.armbian
@@ -112,6 +112,7 @@
 	patches.armbian/drv-touchscreen-tsc2007-polling.patch
 	patches.armbian/drv-rgb-add-ws2812.patch
 	patches.armbian/arm64-dts-allwinner-h616-LED-green_power_on-red_status_heartbeat.patch
+	patches.armbian/arm64-dts-allwinner-h616-orangepi-zero2-Enable-expansion-board-USB-ports.patch
 ###################
 	patches.armbian/arm64-dts-sun50i-a64-pine64-enable-Bluetooth.patch
 	patches.armbian/arm64-dts-sun50i-a64-sopine-baseboard-enable-Bluetooth.patch

--- a/patch/kernel/archive/sunxi-6.2/series.conf
+++ b/patch/kernel/archive/sunxi-6.2/series.conf
@@ -508,6 +508,7 @@
 	patches.armbian/drv-touchscreen-tsc2007-polling.patch
 	patches.armbian/drv-rgb-add-ws2812.patch
 	patches.armbian/arm64-dts-allwinner-h616-LED-green_power_on-red_status_heartbeat.patch
+	patches.armbian/arm64-dts-allwinner-h616-orangepi-zero2-Enable-expansion-board-USB-ports.patch
 ###################
 	patches.armbian/arm64-dts-sun50i-a64-pine64-enable-Bluetooth.patch
 	patches.armbian/arm64-dts-sun50i-a64-sopine-baseboard-enable-Bluetooth.patch


### PR DESCRIPTION
# Description

This PR enabled USB port present on the expansion board for the OrangePi Zero 2 sbc. 
This change applies to the current `edge` variant of the OS for this board (Kernel `6.2.y`).

# How Has This Been Tested?

Requirements:
- Any USB stick with basic file system present (eg. `exFAT`) and some files / folders on it
- Logged in as `root` or as a user with `sudo` priviledges

- [x] Test A: make sure the change does not break the board when used WITHOUT the expansion board
  - Boot up the board
  - Check whether the base USB port still works correctly
    - `lsusb` shows the USB stick when plugged into the port
    - `mount /dev/sda1 /media/<mountpoint>` is able to mount the USB stick plugged into the port 
- [x] Test B: check whether the ports work when expansion board is plugged in
  - Plug a USB stick into one of the additional ports
  - Check whether the tested port works correctly
    - `lsusb` shows the USB stick when plugged into the port
    - `mount /dev/sda1 /media/<mountpoint>` is able to mount the USB stick plugged into the port 
    - `ls /media/<mountpoint>` properly enumerates files / folders on the stick
    - `umount /media/<mountpoint>` is able to unmount the USB stick
  - Repeat for the other port on the expansion board

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
