### PR TITLE
Add pwm-fan support to nanopi r4s

### DIFF
--- a/patch/kernel/archive/rockchip64-6.1/board-nanopi-r4s-pwmfan.patch
+++ b/patch/kernel/archive/rockchip64-6.1/board-nanopi-r4s-pwmfan.patch
@@ -1,0 +1,50 @@
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts
+index fe5b52610..a73767594 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts
+@@ -60,10 +60,45 @@ vdd_5v: vdd-5v {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vdd_5v";
+ 		regulator-always-on;
+ 		regulator-boot-on;
+ 	};
++
++	fan: pwm-fan {
++		compatible = "pwm-fan";
++		cooling-levels = <0 18 102 170 255>;
++		fan-supply = <&vdd_5v>;
++		pwms = <&pwm1 0 50000 0>;
++	};
++};
++
++&cpu_thermal {
++	trips {
++		cpu_warm: cpu_warm {
++			temperature = <55000>;
++			hysteresis = <2000>;
++			type = "active";
++		};
++
++		cpu_hot: cpu_hot {
++			temperature = <65000>;
++			hysteresis = <2000>;
++			type = "active";
++		};
++	};
++
++	cooling-maps {
++		map2 {
++			trip = <&cpu_warm>;
++			cooling-device = <&fan THERMAL_NO_LIMIT 1>;
++		};
++
++		map3 {
++			trip = <&cpu_hot>;
++			cooling-device = <&fan 2 THERMAL_NO_LIMIT>;
++		};
++	};
+ };
+ 
+ &emmc_phy {
+ 	status = "disabled";
+ };

--- a/patch/kernel/archive/rockchip64-6.3/board-nanopi-r4s-pwmfan.patch
+++ b/patch/kernel/archive/rockchip64-6.3/board-nanopi-r4s-pwmfan.patch
@@ -1,0 +1,50 @@
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts
+index fe5b52610..a73767594 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts
+@@ -60,10 +60,45 @@ vdd_5v: vdd-5v {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vdd_5v";
+ 		regulator-always-on;
+ 		regulator-boot-on;
+ 	};
++
++	fan: pwm-fan {
++		compatible = "pwm-fan";
++		cooling-levels = <0 18 102 170 255>;
++		fan-supply = <&vdd_5v>;
++		pwms = <&pwm1 0 50000 0>;
++	};
++};
++
++&cpu_thermal {
++	trips {
++		cpu_warm: cpu_warm {
++			temperature = <55000>;
++			hysteresis = <2000>;
++			type = "active";
++		};
++
++		cpu_hot: cpu_hot {
++			temperature = <65000>;
++			hysteresis = <2000>;
++			type = "active";
++		};
++	};
++
++	cooling-maps {
++		map2 {
++			trip = <&cpu_warm>;
++			cooling-device = <&fan THERMAL_NO_LIMIT 1>;
++		};
++
++		map3 {
++			trip = <&cpu_hot>;
++			cooling-device = <&fan 2 THERMAL_NO_LIMIT>;
++		};
++	};
+ };
+ 
+ &emmc_phy {
+ 	status = "disabled";
+ };


### PR DESCRIPTION
# Description

Add pwm fan support to NanoPi R4S. 

Document from FriendlyElec: https://wiki.friendlyelec.com/wiki/index.php/NanoPi_R4S#How_to_Control_Fan_Speed_for_Cooling

And reference code: https://github.com/friendlyarm/kernel-rockchip/commit/f74ac319f02e2d22cdd33227e7f167e4232809f9


# How Has This Been Tested?

build and run on R4SE hardware.
- [x] fan works
- [x] /sys/devices/virtual/thermal/thermal_zone0/trip_point_[3/4]_temp controls two speed of the fan

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
