### PR TITLE
Disale wireless driver for private kernel

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -400,7 +400,7 @@ driver_rtl88x2bu() {
 }
 
 driver_rtw88() {
-	if [[ "$LINUXFAMILY" == d1 || "$BRANCH" == midstream ]]; then
+	if [[ "$LINUXFAMILY" == d1 || "$BRANCH" == midstream || "$LINUXFAMILY" == sun50iw9-btt ]]; then
 		# "D1" is using an old 6.1 which can't take this.
 		# "midstream" a half monster kernel, a cross between sre mainline and downstream rk kernel
 		return 0


### PR DESCRIPTION
# Description

Disable rtw88 patches for another kernel fork.

# How Has This Been Tested?

- [x] Build test

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
