### PR TITLE
Only install gcc-or1k-bin package when building images with crust-firmware

### DIFF
--- a/config/sources/families/include/crust_firmware.inc
+++ b/config/sources/families/include/crust_firmware.inc
@@ -1,0 +1,32 @@
+#
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (c) 2013-2023 Igor Pecovnik, igor@armbian.com
+#
+# This file is a part of the Armbian Build Framework
+# https://github.com/armbian/build/
+#
+declare -g CRUST_TARGET_MAP="scp;;build/scp/scp.bin"
+
+[[ -n "${CRUSTCONFIG}" && -z $CRUSTSOURCE ]] && CRUSTSOURCE='https://github.com/crust-firmware/crust'
+[[ -n "${CRUSTCONFIG}" && -z $CRUSTDIR ]] && CRUSTDIR='crust-sunxi-mainline'
+[[ -n "${CRUSTCONFIG}" && -z $CRUSTBRANCH ]] && CRUSTBRANCH='commit:c308a504853e7fdb47169796c9a832796410ece8'
+[[ -n "${CRUSTCONFIG}" && -z $CRUST_USE_GCC ]] && CRUST_USE_GCC='> 9.1.0'
+[[ -n "${CRUSTCONFIG}" && -z $CRUST_COMPILER ]] && CRUST_COMPILER='or1k-elf-'
+
+# Apply crust patches if crust is enabled
+[[ -n "${CRUSTCONFIG}" ]] && BOOTPATCHDIR="${BOOTPATCHDIR} u-boot-sunxi-crust"
+
+# complain about system not being supported for building crust image
+function add_host_dependencies__dont_try_to_build_crust_on_unsupported_systems() {
+    if [[ -n "${CRUSTCONFIG}" ]] ; then
+        if [[ -z $HOSTRELEASE || "bookworm sid jammy kinetic lunar vanessa vera" != *"$HOSTRELEASE"* ]] ; then
+            if [[ $NO_HOST_RELEASE_CHECK == yes ]]; then
+                display_alert "You are running on an unsupported system" "${HOSTRELEASE:-(unknown)}" "wrn"
+                display_alert "Do not report any errors, warnings or other issues encountered beyond this point" "" "wrn"
+            else
+                exit_with_error "Unsupported build system for images with crust-firmware: '${HOSTRELEASE:-(unknown)}'"
+            fi
+        fi
+    fi
+}

--- a/config/sources/families/include/crust_firmware.inc
+++ b/config/sources/families/include/crust_firmware.inc
@@ -17,6 +17,9 @@ declare -g CRUST_TARGET_MAP="scp;;build/scp/scp.bin"
 # Apply crust patches if crust is enabled
 [[ -n "${CRUSTCONFIG}" ]] && BOOTPATCHDIR="${BOOTPATCHDIR} u-boot-sunxi-crust"
 
+# Use a different BOOTDIR so that we don't leave scp.bin behind for non crust builds
+[[ -n "${CRUSTCONFIG}" ]] && BOOTDIR="u-boot-crust"
+
 # complain about system not being supported for building crust image
 function add_host_dependencies__dont_try_to_build_crust_on_unsupported_systems() {
     if [[ -n "${CRUSTCONFIG}" ]] ; then

--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -16,16 +16,8 @@ declare -g BOOTENV_FILE='sunxi.txt'
 UBOOT_TARGET_MAP="${UBOOT_TARGET_MAP:-;;u-boot-sunxi-with-spl.bin}"
 declare -g BOOTSCRIPT='boot-sun50i-next.cmd:boot.cmd'
 declare -g LINUXFAMILY=sunxi64
-declare -g CRUST_TARGET_MAP="scp;;build/scp/scp.bin"
 
-[[ -n "${CRUSTCONFIG}" && -z $CRUSTSOURCE ]] && CRUSTSOURCE='https://github.com/crust-firmware/crust'
-[[ -n "${CRUSTCONFIG}" && -z $CRUSTDIR ]] && CRUSTDIR='crust-sunxi-mainline'
-[[ -n "${CRUSTCONFIG}" && -z $CRUSTBRANCH ]] && CRUSTBRANCH='commit:c308a504853e7fdb47169796c9a832796410ece8'
-[[ -n "${CRUSTCONFIG}" && -z $CRUST_USE_GCC ]] && CRUST_USE_GCC='> 9.1.0'
-[[ -n "${CRUSTCONFIG}" && -z $CRUST_COMPILER ]] && CRUST_COMPILER='or1k-elf-'
-
-# Apply crust patches if crust is enabled
-[[ -n "${CRUSTCONFIG}" ]] && BOOTPATCHDIR="${BOOTPATCHDIR} u-boot-sunxi-crust"
+source "${BASH_SOURCE%/*}/crust_firmware.inc"
 
 case $BRANCH in
 

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -18,16 +18,8 @@ declare -g LINUXFAMILY=sunxi
 declare -g UBOOT_FW_ENV='0x88000,0x20000' # /etc/fw_env.config offset and env size
 declare -g ASOUND_STATE='asound.state.sunxi-next'
 declare -g GOVERNOR=ondemand
-declare -g CRUST_TARGET_MAP="scp;;build/scp/scp.bin"
 
-[[ -n "${CRUSTCONFIG}" && -z $CRUSTSOURCE ]] && CRUSTSOURCE='https://github.com/crust-firmware/crust'
-[[ -n "${CRUSTCONFIG}" && -z $CRUSTDIR ]] && CRUSTDIR='crust-sunxi-mainline'
-[[ -n "${CRUSTCONFIG}" && -z $CRUSTBRANCH ]] && CRUSTBRANCH='commit:c308a504853e7fdb47169796c9a832796410ece8'
-[[ -n "${CRUSTCONFIG}" && -z $CRUST_USE_GCC ]] && CRUST_USE_GCC='> 9.1.0'
-[[ -n "${CRUSTCONFIG}" && -z $CRUST_COMPILER ]] && CRUST_COMPILER='or1k-elf-'
-
-# Apply crust patches if crust is enabled
-[[ -n "${CRUSTCONFIG}" ]] && BOOTPATCHDIR="${BOOTPATCHDIR} u-boot-sunxi-crust"
+source "${BASH_SOURCE%/*}/crust_firmware.inc"
 
 case $BRANCH in
 

--- a/extensions/sunxi-tools.sh
+++ b/extensions/sunxi-tools.sh
@@ -9,8 +9,10 @@ function add_host_dependencies__sunxi_add_32_bit_c_compiler() {
 
 # Install gcc-or1k-elf for crust compilation
 function add_host_dependencies__sunxi_add_or1k_c_compiler() {
-        display_alert "Adding or1k C compiler to host dependencies" "for sunxi bootloader compile" "debug"
-        declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} gcc-or1k-elf"
+        if [[ -n "$HOSTRELEASE" && "bookworm sid jammy kinetic lunar vanessa vera" == *"$HOSTRELEASE"* ]] ; then
+                display_alert "Adding or1k C compiler to host dependencies" "for sunxi bootloader compile" "debug"
+                declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} gcc-or1k-elf"
+        fi
 }
 
 function fetch_sources_tools__sunxi_tools() {


### PR DESCRIPTION
# Description

Only install gcc-or1k-bin package on host os that has the package. Also consolidated crust related configuration into a separate file.

Jira reference number [AR-1786]

# How Has This Been Tested?

- [X] `./compile.sh DOCKER_ARMBIAN_BASE_IMAGE="debian:bullseye" BOARD=nanopineo` works as it doesn't need crust support
- [X] `./compile.sh DOCKER_ARMBIAN_BASE_IMAGE="debian:bullseye" BOARD=nanopiduo2` fails as it bullseye doesn't include gcc-or1k-bin package and hence reported as unsupported system
- [X] `./compile.sh BOARD=nanopiduo2` works as default release is jammy that has the required package

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1786]: https://armbian.atlassian.net/browse/AR-1786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ