### PR TITLE
armbian-kernel: further insist on disabling kernel debug, since DEBUG_INFO is auto-enabled by DEBUG_INFO_DWARF5 and others

### DIFF
--- a/lib/functions/compilation/armbian-kernel.sh
+++ b/lib/functions/compilation/armbian-kernel.sh
@@ -27,7 +27,13 @@ function armbian_kernel_config__disable_module_compression() {
 		kernel_config_set_n CONFIG_LOCALVERSION_AUTO # This causes a mismatch between what Armbian wants and what make produces.
 
 		# DONE: Disable: debug option
-		kernel_config_set_n DEBUG_INFO # Armbian doesn't know how to package a debug kernel.
+		kernel_config_set_n DEBUG_INFO_DWARF5 # Armbian doesn't know how to package a debug kernel.
+		kernel_config_set_n DEBUG_KERNEL      # ditto
+		kernel_config_set_n DEBUG_MISC        # ditto
+		kernel_config_set_n DEBUG_INFO        # ditto
+		kernel_config_set_n DEBUG_INFO_BTF    # ditto
+		kernel_config_set_n GDB_SCRIPTS       # ditto
+		kernel_config_set_n SLUB_DEBUG        # ditto
 
 		# @TODO: Enable the options for the extrawifi/drivers; so we don't need to worry about them when updating configs
 	fi


### PR DESCRIPTION
#### armbian-kernel: further insist on disabling kernel debug, since DEBUG_INFO is auto-enabled by DEBUG_INFO_DWARF5 and others

- armbian-kernel: further insist on disabling kernel debug, since DEBUG_INFO is auto-enabled by DEBUG_INFO_DWARF5 and others