### PR TITLE
handle kernel.org forks

### DIFF
--- a/lib/functions/general/git-ref2info.sh
+++ b/lib/functions/general/git-ref2info.sh
@@ -90,8 +90,8 @@ function memoized_git_ref_to_info() {
 			declare url="undetermined"
 			case "${git_source}" in
 
-				"https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git")
-					url="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/plain/Makefile?h=${sha1}"
+				"https://git.kernel.org/pub/scm/linux/kernel/"*)
+					url="${git_source}/plain/Makefile?h=${sha1}"
 					;;
 
 					# @TODO: urgently add support for Google Mirror


### PR DESCRIPTION
fixes #5381

allows building other git.kernel.org-hosted forks, e.g.
`KERNELSOURCE='https://git.kernel.org/pub/scm/linux/kernel/git/mtd/linux.git'`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
