### PR TITLE
meson64 general asound.state fix; Khadas VIM3/VIM3L asound.state fixes for HDMI audio

### DIFF
--- a/config/sources/families/meson-g12a.conf
+++ b/config/sources/families/meson-g12a.conf
@@ -7,7 +7,7 @@
 # https://github.com/armbian/build/
 #
 source "${BASH_SOURCE%/*}/include/meson64_common.inc"
-ASOUND_STATE="asound.state.meson64"
+ASOUND_STATE="${ASOUND_STATE:-"asound.state.meson64"}"
 
 CPUMIN=1000000
 CPUMAX=1800000

--- a/config/sources/families/meson-g12b.conf
+++ b/config/sources/families/meson-g12b.conf
@@ -7,7 +7,7 @@
 # https://github.com/armbian/build/
 #
 source "${BASH_SOURCE%/*}/include/meson64_common.inc"
-ASOUND_STATE="asound.state.meson64"
+ASOUND_STATE="${ASOUND_STATE:-"asound.state.meson64"}"
 
 # Mainline u-boot, everything is done by meson64_common.inc, we just need to handle FIP blobs
 

--- a/config/sources/families/meson-sm1.conf
+++ b/config/sources/families/meson-sm1.conf
@@ -7,7 +7,7 @@
 # https://github.com/armbian/build/
 #
 source "${BASH_SOURCE%/*}/include/meson64_common.inc"
-ASOUND_STATE="asound.state.meson64"
+ASOUND_STATE="${ASOUND_STATE:-"asound.state.meson64"}"
 CPUMIN=667000
 CPUMAX=2100000
 GOVERNOR=ondemand

--- a/lib/functions/rootfs/distro-agnostic.sh
+++ b/lib/functions/rootfs/distro-agnostic.sh
@@ -507,7 +507,10 @@ function install_distribution_agnostic() {
 
 	# install initial asound.state if defined
 	mkdir -p "${SDCARD}"/var/lib/alsa/
-	[[ -n $ASOUND_STATE ]] && cp "${SRC}/packages/blobs/asound.state/${ASOUND_STATE}" "${SDCARD}"/var/lib/alsa/asound.state
+	if [[ -n ${ASOUND_STATE} ]]; then
+		display_alert "Installing initial asound.state" "${ASOUND_STATE} for board ${BOARD}" "info"
+		run_host_command_logged cp -v "${SRC}/packages/blobs/asound.state/${ASOUND_STATE}" "${SDCARD}"/var/lib/alsa/asound.state
+	fi
 
 	# save initial armbian-release state
 	cp "${SDCARD}"/etc/armbian-release "${SDCARD}"/etc/armbian-image-release

--- a/packages/blobs/asound.state/asound.state.khadas-vim3
+++ b/packages/blobs/asound.state/asound.state.khadas-vim3
@@ -59,7 +59,7 @@ state.KHADASVIM3 {
 	}
 	control.6 {
 		iface PCM
-		device 5
+		device 8
 		name 'Playback Channel Map'
 		value.0 0
 		value.1 0
@@ -78,16 +78,38 @@ state.KHADASVIM3 {
 	}
 	control.7 {
 		iface PCM
-		device 5
+		device 8
+		name 'IEC958 Playback Mask'
+		value ffffffffffffffffffffffffffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+		comment {
+			access read
+			type IEC958
+			count 1
+		}
+	}
+	control.8 {
+		iface PCM
+		device 8
+		name 'IEC958 Playback Default'
+		value '0400000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+		comment {
+			access 'read write'
+			type IEC958
+			count 1
+		}
+	}
+	control.9 {
+		iface PCM
+		device 8
 		name ELD
-		value '100008006a10000100000000000000004cf45601416f58696e5975616e200907070000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+		value '100008006b100001000000000000000010aca8a044454c4c2055333431355709070700000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
 		comment {
 			access 'read volatile'
 			type BYTES
 			count 128
 		}
 	}
-	control.8 {
+	control.10 {
 		iface MIXER
 		name 'FRDDR_A SRC 1 EN Switch'
 		value true
@@ -97,17 +119,17 @@ state.KHADASVIM3 {
 			count 1
 		}
 	}
-	control.9 {
+	control.11 {
 		iface MIXER
 		name 'FRDDR_A SRC 2 EN Switch'
-		value false
+		value true
 		comment {
 			access 'read write'
 			type BOOLEAN
 			count 1
 		}
 	}
-	control.10 {
+	control.12 {
 		iface MIXER
 		name 'FRDDR_A SRC 3 EN Switch'
 		value false
@@ -117,7 +139,7 @@ state.KHADASVIM3 {
 			count 1
 		}
 	}
-	control.11 {
+	control.13 {
 		iface MIXER
 		name 'FRDDR_A SINK 1 SEL'
 		value 'OUT 0'
@@ -135,10 +157,10 @@ state.KHADASVIM3 {
 			item.7 'OUT 7'
 		}
 	}
-	control.12 {
+	control.14 {
 		iface MIXER
 		name 'FRDDR_A SINK 2 SEL'
-		value 'OUT 0'
+		value 'OUT 1'
 		comment {
 			access 'read write'
 			type ENUMERATED
@@ -153,10 +175,10 @@ state.KHADASVIM3 {
 			item.7 'OUT 7'
 		}
 	}
-	control.13 {
+	control.15 {
 		iface MIXER
 		name 'FRDDR_A SINK 3 SEL'
-		value 'OUT 0'
+		value 'OUT 2'
 		comment {
 			access 'read write'
 			type ENUMERATED
@@ -171,7 +193,7 @@ state.KHADASVIM3 {
 			item.7 'OUT 7'
 		}
 	}
-	control.14 {
+	control.16 {
 		iface MIXER
 		name 'FRDDR_B SRC 1 EN Switch'
 		value true
@@ -181,7 +203,7 @@ state.KHADASVIM3 {
 			count 1
 		}
 	}
-	control.15 {
+	control.17 {
 		iface MIXER
 		name 'FRDDR_B SRC 2 EN Switch'
 		value false
@@ -191,7 +213,7 @@ state.KHADASVIM3 {
 			count 1
 		}
 	}
-	control.16 {
+	control.18 {
 		iface MIXER
 		name 'FRDDR_B SRC 3 EN Switch'
 		value false
@@ -201,10 +223,10 @@ state.KHADASVIM3 {
 			count 1
 		}
 	}
-	control.17 {
+	control.19 {
 		iface MIXER
 		name 'FRDDR_B SINK 1 SEL'
-		value 'OUT 0'
+		value 'OUT 3'
 		comment {
 			access 'read write'
 			type ENUMERATED
@@ -219,7 +241,7 @@ state.KHADASVIM3 {
 			item.7 'OUT 7'
 		}
 	}
-	control.18 {
+	control.20 {
 		iface MIXER
 		name 'FRDDR_B SINK 2 SEL'
 		value 'OUT 0'
@@ -237,7 +259,7 @@ state.KHADASVIM3 {
 			item.7 'OUT 7'
 		}
 	}
-	control.19 {
+	control.21 {
 		iface MIXER
 		name 'FRDDR_B SINK 3 SEL'
 		value 'OUT 0'
@@ -255,17 +277,17 @@ state.KHADASVIM3 {
 			item.7 'OUT 7'
 		}
 	}
-	control.20 {
+	control.22 {
 		iface MIXER
 		name 'FRDDR_C SRC 1 EN Switch'
-		value true
+		value false
 		comment {
 			access 'read write'
 			type BOOLEAN
 			count 1
 		}
 	}
-	control.21 {
+	control.23 {
 		iface MIXER
 		name 'FRDDR_C SRC 2 EN Switch'
 		value false
@@ -275,7 +297,7 @@ state.KHADASVIM3 {
 			count 1
 		}
 	}
-	control.22 {
+	control.24 {
 		iface MIXER
 		name 'FRDDR_C SRC 3 EN Switch'
 		value false
@@ -285,7 +307,7 @@ state.KHADASVIM3 {
 			count 1
 		}
 	}
-	control.23 {
+	control.25 {
 		iface MIXER
 		name 'FRDDR_C SINK 1 SEL'
 		value 'OUT 0'
@@ -303,7 +325,7 @@ state.KHADASVIM3 {
 			item.7 'OUT 7'
 		}
 	}
-	control.24 {
+	control.26 {
 		iface MIXER
 		name 'FRDDR_C SINK 2 SEL'
 		value 'OUT 0'
@@ -321,7 +343,7 @@ state.KHADASVIM3 {
 			item.7 'OUT 7'
 		}
 	}
-	control.25 {
+	control.27 {
 		iface MIXER
 		name 'FRDDR_C SINK 3 SEL'
 		value 'OUT 0'
@@ -339,7 +361,61 @@ state.KHADASVIM3 {
 			item.7 'OUT 7'
 		}
 	}
-	control.26 {
+	control.28 {
+		iface MIXER
+		name 'TODDR_A SRC SEL'
+		value 'IN 0'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'IN 0'
+			item.1 'IN 1'
+			item.2 'IN 2'
+			item.3 'IN 3'
+			item.4 'IN 4'
+			item.5 'IN 5'
+			item.6 'IN 6'
+			item.7 'IN 7'
+		}
+	}
+	control.29 {
+		iface MIXER
+		name 'TODDR_B SRC SEL'
+		value 'IN 0'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'IN 0'
+			item.1 'IN 1'
+			item.2 'IN 2'
+			item.3 'IN 3'
+			item.4 'IN 4'
+			item.5 'IN 5'
+			item.6 'IN 6'
+			item.7 'IN 7'
+		}
+	}
+	control.30 {
+		iface MIXER
+		name 'TODDR_C SRC SEL'
+		value 'IN 0'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'IN 0'
+			item.1 'IN 1'
+			item.2 'IN 2'
+			item.3 'IN 3'
+			item.4 'IN 4'
+			item.5 'IN 5'
+			item.6 'IN 6'
+			item.7 'IN 7'
+		}
+	}
+	control.31 {
 		iface MIXER
 		name 'TOHDMITX I2S SRC'
 		value 'I2S A'
@@ -352,7 +428,7 @@ state.KHADASVIM3 {
 			item.2 'I2S C'
 		}
 	}
-	control.27 {
+	control.32 {
 		iface MIXER
 		name 'TOHDMITX Switch'
 		value true
@@ -362,7 +438,7 @@ state.KHADASVIM3 {
 			count 1
 		}
 	}
-	control.28 {
+	control.33 {
 		iface MIXER
 		name 'TOHDMITX SPDIF SRC'
 		value 'SPDIF A'
@@ -374,7 +450,7 @@ state.KHADASVIM3 {
 			item.1 'SPDIF B'
 		}
 	}
-	control.29 {
+	control.34 {
 		iface MIXER
 		name 'TDMOUT_A SRC SEL'
 		value 'IN 0'
@@ -387,387 +463,10 @@ state.KHADASVIM3 {
 			item.2 'IN 2'
 		}
 	}
-}
-state.G12BKHADASVIM3 {
-	control.1 {
+	control.35 {
 		iface MIXER
-		name 'TDMOUT_A Lane 0 Volume'
-		value.0 255
-		value.1 255
-		comment {
-			access 'read write'
-			type INTEGER
-			count 2
-			range '0 - 255'
-		}
-	}
-	control.2 {
-		iface MIXER
-		name 'TDMOUT_A Lane 1 Volume'
-		value.0 255
-		value.1 255
-		comment {
-			access 'read write'
-			type INTEGER
-			count 2
-			range '0 - 255'
-		}
-	}
-	control.3 {
-		iface MIXER
-		name 'TDMOUT_A Lane 2 Volume'
-		value.0 255
-		value.1 255
-		comment {
-			access 'read write'
-			type INTEGER
-			count 2
-			range '0 - 255'
-		}
-	}
-	control.4 {
-		iface MIXER
-		name 'TDMOUT_A Lane 3 Volume'
-		value.0 255
-		value.1 255
-		comment {
-			access 'read write'
-			type INTEGER
-			count 2
-			range '0 - 255'
-		}
-	}
-	control.5 {
-		iface MIXER
-		name 'TDMOUT_A Gain Enable Switch'
-		value false
-		comment {
-			access 'read write'
-			type BOOLEAN
-			count 1
-		}
-	}
-	control.6 {
-		iface PCM
-		device 5
-		name 'Playback Channel Map'
-		value.0 0
-		value.1 0
-		value.2 0
-		value.3 0
-		value.4 0
-		value.5 0
-		value.6 0
-		value.7 0
-		comment {
-			access read
-			type INTEGER
-			count 8
-			range '0 - 36'
-		}
-	}
-	control.7 {
-		iface PCM
-		device 5
-		name ELD
-		value '0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
-		comment {
-			access 'read volatile'
-			type BYTES
-			count 128
-		}
-	}
-	control.8 {
-		iface MIXER
-		name 'FRDDR_A SRC 1 EN Switch'
-		value true
-		comment {
-			access 'read write'
-			type BOOLEAN
-			count 1
-		}
-	}
-	control.9 {
-		iface MIXER
-		name 'FRDDR_A SRC 2 EN Switch'
-		value false
-		comment {
-			access 'read write'
-			type BOOLEAN
-			count 1
-		}
-	}
-	control.10 {
-		iface MIXER
-		name 'FRDDR_A SRC 3 EN Switch'
-		value false
-		comment {
-			access 'read write'
-			type BOOLEAN
-			count 1
-		}
-	}
-	control.11 {
-		iface MIXER
-		name 'FRDDR_A SINK 1 SEL'
-		value 'OUT 1'
-		comment {
-			access 'read write'
-			type ENUMERATED
-			count 1
-			item.0 'OUT 0'
-			item.1 'OUT 1'
-			item.2 'OUT 2'
-			item.3 'OUT 3'
-			item.4 'OUT 4'
-			item.5 'OUT 5'
-			item.6 'OUT 6'
-			item.7 'OUT 7'
-		}
-	}
-	control.12 {
-		iface MIXER
-		name 'FRDDR_A SINK 2 SEL'
-		value 'OUT 1'
-		comment {
-			access 'read write'
-			type ENUMERATED
-			count 1
-			item.0 'OUT 0'
-			item.1 'OUT 1'
-			item.2 'OUT 2'
-			item.3 'OUT 3'
-			item.4 'OUT 4'
-			item.5 'OUT 5'
-			item.6 'OUT 6'
-			item.7 'OUT 7'
-		}
-	}
-	control.13 {
-		iface MIXER
-		name 'FRDDR_A SINK 3 SEL'
-		value 'OUT 1'
-		comment {
-			access 'read write'
-			type ENUMERATED
-			count 1
-			item.0 'OUT 0'
-			item.1 'OUT 1'
-			item.2 'OUT 2'
-			item.3 'OUT 3'
-			item.4 'OUT 4'
-			item.5 'OUT 5'
-			item.6 'OUT 6'
-			item.7 'OUT 7'
-		}
-	}
-	control.14 {
-		iface MIXER
-		name 'FRDDR_B SRC 1 EN Switch'
-		value true
-		comment {
-			access 'read write'
-			type BOOLEAN
-			count 1
-		}
-	}
-	control.15 {
-		iface MIXER
-		name 'FRDDR_B SRC 2 EN Switch'
-		value false
-		comment {
-			access 'read write'
-			type BOOLEAN
-			count 1
-		}
-	}
-	control.16 {
-		iface MIXER
-		name 'FRDDR_B SRC 3 EN Switch'
-		value false
-		comment {
-			access 'read write'
-			type BOOLEAN
-			count 1
-		}
-	}
-	control.17 {
-		iface MIXER
-		name 'FRDDR_B SINK 1 SEL'
-		value 'OUT 1'
-		comment {
-			access 'read write'
-			type ENUMERATED
-			count 1
-			item.0 'OUT 0'
-			item.1 'OUT 1'
-			item.2 'OUT 2'
-			item.3 'OUT 3'
-			item.4 'OUT 4'
-			item.5 'OUT 5'
-			item.6 'OUT 6'
-			item.7 'OUT 7'
-		}
-	}
-	control.18 {
-		iface MIXER
-		name 'FRDDR_B SINK 2 SEL'
-		value 'OUT 1'
-		comment {
-			access 'read write'
-			type ENUMERATED
-			count 1
-			item.0 'OUT 0'
-			item.1 'OUT 1'
-			item.2 'OUT 2'
-			item.3 'OUT 3'
-			item.4 'OUT 4'
-			item.5 'OUT 5'
-			item.6 'OUT 6'
-			item.7 'OUT 7'
-		}
-	}
-	control.19 {
-		iface MIXER
-		name 'FRDDR_B SINK 3 SEL'
-		value 'OUT 1'
-		comment {
-			access 'read write'
-			type ENUMERATED
-			count 1
-			item.0 'OUT 0'
-			item.1 'OUT 1'
-			item.2 'OUT 2'
-			item.3 'OUT 3'
-			item.4 'OUT 4'
-			item.5 'OUT 5'
-			item.6 'OUT 6'
-			item.7 'OUT 7'
-		}
-	}
-	control.20 {
-		iface MIXER
-		name 'FRDDR_C SRC 1 EN Switch'
-		value false
-		comment {
-			access 'read write'
-			type BOOLEAN
-			count 1
-		}
-	}
-	control.21 {
-		iface MIXER
-		name 'FRDDR_C SRC 2 EN Switch'
-		value false
-		comment {
-			access 'read write'
-			type BOOLEAN
-			count 1
-		}
-	}
-	control.22 {
-		iface MIXER
-		name 'FRDDR_C SRC 3 EN Switch'
-		value false
-		comment {
-			access 'read write'
-			type BOOLEAN
-			count 1
-		}
-	}
-	control.23 {
-		iface MIXER
-		name 'FRDDR_C SINK 1 SEL'
-		value 'OUT 1'
-		comment {
-			access 'read write'
-			type ENUMERATED
-			count 1
-			item.0 'OUT 0'
-			item.1 'OUT 1'
-			item.2 'OUT 2'
-			item.3 'OUT 3'
-			item.4 'OUT 4'
-			item.5 'OUT 5'
-			item.6 'OUT 6'
-			item.7 'OUT 7'
-		}
-	}
-	control.24 {
-		iface MIXER
-		name 'FRDDR_C SINK 2 SEL'
-		value 'OUT 1'
-		comment {
-			access 'read write'
-			type ENUMERATED
-			count 1
-			item.0 'OUT 0'
-			item.1 'OUT 1'
-			item.2 'OUT 2'
-			item.3 'OUT 3'
-			item.4 'OUT 4'
-			item.5 'OUT 5'
-			item.6 'OUT 6'
-			item.7 'OUT 7'
-		}
-	}
-	control.25 {
-		iface MIXER
-		name 'FRDDR_C SINK 3 SEL'
-		value 'OUT 1'
-		comment {
-			access 'read write'
-			type ENUMERATED
-			count 1
-			item.0 'OUT 0'
-			item.1 'OUT 1'
-			item.2 'OUT 2'
-			item.3 'OUT 3'
-			item.4 'OUT 4'
-			item.5 'OUT 5'
-			item.6 'OUT 6'
-			item.7 'OUT 7'
-		}
-	}
-	control.26 {
-		iface MIXER
-		name 'TOHDMITX I2S SRC'
-		value 'I2S A'
-		comment {
-			access 'read write'
-			type ENUMERATED
-			count 1
-			item.0 'I2S A'
-			item.1 'I2S B'
-			item.2 'I2S C'
-		}
-	}
-	control.27 {
-		iface MIXER
-		name 'TOHDMITX Switch'
-		value true
-		comment {
-			access 'read write'
-			type BOOLEAN
-			count 1
-		}
-	}
-	control.28 {
-		iface MIXER
-		name 'TOHDMITX SPDIF SRC'
-		value 'SPDIF A'
-		comment {
-			access 'read write'
-			type ENUMERATED
-			count 1
-			item.0 'SPDIF A'
-			item.1 'SPDIF B'
-		}
-	}
-	control.29 {
-		iface MIXER
-		name 'TDMOUT_A SRC SEL'
-		value 'IN 1'
+		name 'TDMIN_A SRC SEL'
+		value 'IN 0'
 		comment {
 			access 'read write'
 			type ENUMERATED
@@ -775,6 +474,19 @@ state.G12BKHADASVIM3 {
 			item.0 'IN 0'
 			item.1 'IN 1'
 			item.2 'IN 2'
+			item.3 'IN 3'
+			item.4 'IN 4'
+			item.5 'IN 5'
+			item.6 'IN 6'
+			item.7 'IN 7'
+			item.8 'IN 8'
+			item.9 'IN 9'
+			item.10 'IN 10'
+			item.11 'IN 11'
+			item.12 'IN 12'
+			item.13 'IN 13'
+			item.14 'IN 14'
+			item.15 'IN 15'
 		}
 	}
 }

--- a/packages/blobs/asound.state/asound.state.khadas-vim3l
+++ b/packages/blobs/asound.state/asound.state.khadas-vim3l
@@ -1,4 +1,4 @@
-state.KHADASVIM3 {
+state.G12BKHADASVIM3L {
 	control.1 {
 		iface MIXER
 		name 'TDMOUT_A Lane 0 Volume'
@@ -59,7 +59,7 @@ state.KHADASVIM3 {
 	}
 	control.6 {
 		iface PCM
-		device 5
+		device 8
 		name 'Playback Channel Map'
 		value.0 0
 		value.1 0
@@ -78,16 +78,38 @@ state.KHADASVIM3 {
 	}
 	control.7 {
 		iface PCM
-		device 5
+		device 8
+		name 'IEC958 Playback Mask'
+		value ffffffffffffffffffffffffffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+		comment {
+			access read
+			type IEC958
+			count 1
+		}
+	}
+	control.8 {
+		iface PCM
+		device 8
+		name 'IEC958 Playback Default'
+		value '0400000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+		comment {
+			access 'read write'
+			type IEC958
+			count 1
+		}
+	}
+	control.9 {
+		iface PCM
+		device 8
 		name ELD
-		value '100008006a10000100000000000000004cf45601416f58696e5975616e200907070000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+		value '100007006910000100000000000000004a8b544c33325633482d483641090707000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
 		comment {
 			access 'read volatile'
 			type BYTES
 			count 128
 		}
 	}
-	control.8 {
+	control.10 {
 		iface MIXER
 		name 'FRDDR_A SRC 1 EN Switch'
 		value true
@@ -97,17 +119,17 @@ state.KHADASVIM3 {
 			count 1
 		}
 	}
-	control.9 {
+	control.11 {
 		iface MIXER
 		name 'FRDDR_A SRC 2 EN Switch'
-		value false
+		value true
 		comment {
 			access 'read write'
 			type BOOLEAN
 			count 1
 		}
 	}
-	control.10 {
+	control.12 {
 		iface MIXER
 		name 'FRDDR_A SRC 3 EN Switch'
 		value false
@@ -117,7 +139,7 @@ state.KHADASVIM3 {
 			count 1
 		}
 	}
-	control.11 {
+	control.13 {
 		iface MIXER
 		name 'FRDDR_A SINK 1 SEL'
 		value 'OUT 0'
@@ -135,10 +157,10 @@ state.KHADASVIM3 {
 			item.7 'OUT 7'
 		}
 	}
-	control.12 {
+	control.14 {
 		iface MIXER
 		name 'FRDDR_A SINK 2 SEL'
-		value 'OUT 0'
+		value 'OUT 1'
 		comment {
 			access 'read write'
 			type ENUMERATED
@@ -153,10 +175,10 @@ state.KHADASVIM3 {
 			item.7 'OUT 7'
 		}
 	}
-	control.13 {
+	control.15 {
 		iface MIXER
 		name 'FRDDR_A SINK 3 SEL'
-		value 'OUT 0'
+		value 'OUT 2'
 		comment {
 			access 'read write'
 			type ENUMERATED
@@ -171,7 +193,7 @@ state.KHADASVIM3 {
 			item.7 'OUT 7'
 		}
 	}
-	control.14 {
+	control.16 {
 		iface MIXER
 		name 'FRDDR_B SRC 1 EN Switch'
 		value true
@@ -181,7 +203,7 @@ state.KHADASVIM3 {
 			count 1
 		}
 	}
-	control.15 {
+	control.17 {
 		iface MIXER
 		name 'FRDDR_B SRC 2 EN Switch'
 		value false
@@ -191,7 +213,7 @@ state.KHADASVIM3 {
 			count 1
 		}
 	}
-	control.16 {
+	control.18 {
 		iface MIXER
 		name 'FRDDR_B SRC 3 EN Switch'
 		value false
@@ -201,10 +223,10 @@ state.KHADASVIM3 {
 			count 1
 		}
 	}
-	control.17 {
+	control.19 {
 		iface MIXER
 		name 'FRDDR_B SINK 1 SEL'
-		value 'OUT 0'
+		value 'OUT 3'
 		comment {
 			access 'read write'
 			type ENUMERATED
@@ -219,7 +241,7 @@ state.KHADASVIM3 {
 			item.7 'OUT 7'
 		}
 	}
-	control.18 {
+	control.20 {
 		iface MIXER
 		name 'FRDDR_B SINK 2 SEL'
 		value 'OUT 0'
@@ -237,7 +259,7 @@ state.KHADASVIM3 {
 			item.7 'OUT 7'
 		}
 	}
-	control.19 {
+	control.21 {
 		iface MIXER
 		name 'FRDDR_B SINK 3 SEL'
 		value 'OUT 0'
@@ -255,17 +277,17 @@ state.KHADASVIM3 {
 			item.7 'OUT 7'
 		}
 	}
-	control.20 {
+	control.22 {
 		iface MIXER
 		name 'FRDDR_C SRC 1 EN Switch'
-		value true
+		value false
 		comment {
 			access 'read write'
 			type BOOLEAN
 			count 1
 		}
 	}
-	control.21 {
+	control.23 {
 		iface MIXER
 		name 'FRDDR_C SRC 2 EN Switch'
 		value false
@@ -275,7 +297,7 @@ state.KHADASVIM3 {
 			count 1
 		}
 	}
-	control.22 {
+	control.24 {
 		iface MIXER
 		name 'FRDDR_C SRC 3 EN Switch'
 		value false
@@ -285,7 +307,7 @@ state.KHADASVIM3 {
 			count 1
 		}
 	}
-	control.23 {
+	control.25 {
 		iface MIXER
 		name 'FRDDR_C SINK 1 SEL'
 		value 'OUT 0'
@@ -303,7 +325,7 @@ state.KHADASVIM3 {
 			item.7 'OUT 7'
 		}
 	}
-	control.24 {
+	control.26 {
 		iface MIXER
 		name 'FRDDR_C SINK 2 SEL'
 		value 'OUT 0'
@@ -321,7 +343,7 @@ state.KHADASVIM3 {
 			item.7 'OUT 7'
 		}
 	}
-	control.25 {
+	control.27 {
 		iface MIXER
 		name 'FRDDR_C SINK 3 SEL'
 		value 'OUT 0'
@@ -339,7 +361,85 @@ state.KHADASVIM3 {
 			item.7 'OUT 7'
 		}
 	}
-	control.26 {
+	control.28 {
+		iface MIXER
+		name 'TODDR_A SRC SEL'
+		value 'IN 0'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'IN 0'
+			item.1 'IN 1'
+			item.2 'IN 2'
+			item.3 'IN 3'
+			item.4 'IN 4'
+			item.5 'IN 5'
+			item.6 'IN 6'
+			item.7 'IN 7'
+			item.8 'IN 8'
+			item.9 'IN 9'
+			item.10 'IN 10'
+			item.11 'IN 11'
+			item.12 'IN 12'
+			item.13 'IN 13'
+			item.14 'IN 14'
+			item.15 'IN 15'
+		}
+	}
+	control.29 {
+		iface MIXER
+		name 'TODDR_B SRC SEL'
+		value 'IN 0'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'IN 0'
+			item.1 'IN 1'
+			item.2 'IN 2'
+			item.3 'IN 3'
+			item.4 'IN 4'
+			item.5 'IN 5'
+			item.6 'IN 6'
+			item.7 'IN 7'
+			item.8 'IN 8'
+			item.9 'IN 9'
+			item.10 'IN 10'
+			item.11 'IN 11'
+			item.12 'IN 12'
+			item.13 'IN 13'
+			item.14 'IN 14'
+			item.15 'IN 15'
+		}
+	}
+	control.30 {
+		iface MIXER
+		name 'TODDR_C SRC SEL'
+		value 'IN 0'
+		comment {
+			access 'read write'
+			type ENUMERATED
+			count 1
+			item.0 'IN 0'
+			item.1 'IN 1'
+			item.2 'IN 2'
+			item.3 'IN 3'
+			item.4 'IN 4'
+			item.5 'IN 5'
+			item.6 'IN 6'
+			item.7 'IN 7'
+			item.8 'IN 8'
+			item.9 'IN 9'
+			item.10 'IN 10'
+			item.11 'IN 11'
+			item.12 'IN 12'
+			item.13 'IN 13'
+			item.14 'IN 14'
+			item.15 'IN 15'
+		}
+	}
+	control.31 {
 		iface MIXER
 		name 'TOHDMITX I2S SRC'
 		value 'I2S A'
@@ -352,7 +452,7 @@ state.KHADASVIM3 {
 			item.2 'I2S C'
 		}
 	}
-	control.27 {
+	control.32 {
 		iface MIXER
 		name 'TOHDMITX Switch'
 		value true
@@ -362,7 +462,7 @@ state.KHADASVIM3 {
 			count 1
 		}
 	}
-	control.28 {
+	control.33 {
 		iface MIXER
 		name 'TOHDMITX SPDIF SRC'
 		value 'SPDIF A'
@@ -374,7 +474,7 @@ state.KHADASVIM3 {
 			item.1 'SPDIF B'
 		}
 	}
-	control.29 {
+	control.34 {
 		iface MIXER
 		name 'TDMOUT_A SRC SEL'
 		value 'IN 0'
@@ -385,389 +485,14 @@ state.KHADASVIM3 {
 			item.0 'IN 0'
 			item.1 'IN 1'
 			item.2 'IN 2'
+			item.3 'IN 3'
+			item.4 'IN 4'
 		}
 	}
-}
-state.G12BKHADASVIM3 {
-	control.1 {
+	control.35 {
 		iface MIXER
-		name 'TDMOUT_A Lane 0 Volume'
-		value.0 255
-		value.1 255
-		comment {
-			access 'read write'
-			type INTEGER
-			count 2
-			range '0 - 255'
-		}
-	}
-	control.2 {
-		iface MIXER
-		name 'TDMOUT_A Lane 1 Volume'
-		value.0 255
-		value.1 255
-		comment {
-			access 'read write'
-			type INTEGER
-			count 2
-			range '0 - 255'
-		}
-	}
-	control.3 {
-		iface MIXER
-		name 'TDMOUT_A Lane 2 Volume'
-		value.0 255
-		value.1 255
-		comment {
-			access 'read write'
-			type INTEGER
-			count 2
-			range '0 - 255'
-		}
-	}
-	control.4 {
-		iface MIXER
-		name 'TDMOUT_A Lane 3 Volume'
-		value.0 255
-		value.1 255
-		comment {
-			access 'read write'
-			type INTEGER
-			count 2
-			range '0 - 255'
-		}
-	}
-	control.5 {
-		iface MIXER
-		name 'TDMOUT_A Gain Enable Switch'
-		value false
-		comment {
-			access 'read write'
-			type BOOLEAN
-			count 1
-		}
-	}
-	control.6 {
-		iface PCM
-		device 5
-		name 'Playback Channel Map'
-		value.0 0
-		value.1 0
-		value.2 0
-		value.3 0
-		value.4 0
-		value.5 0
-		value.6 0
-		value.7 0
-		comment {
-			access read
-			type INTEGER
-			count 8
-			range '0 - 36'
-		}
-	}
-	control.7 {
-		iface PCM
-		device 5
-		name ELD
-		value '0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
-		comment {
-			access 'read volatile'
-			type BYTES
-			count 128
-		}
-	}
-	control.8 {
-		iface MIXER
-		name 'FRDDR_A SRC 1 EN Switch'
-		value true
-		comment {
-			access 'read write'
-			type BOOLEAN
-			count 1
-		}
-	}
-	control.9 {
-		iface MIXER
-		name 'FRDDR_A SRC 2 EN Switch'
-		value false
-		comment {
-			access 'read write'
-			type BOOLEAN
-			count 1
-		}
-	}
-	control.10 {
-		iface MIXER
-		name 'FRDDR_A SRC 3 EN Switch'
-		value false
-		comment {
-			access 'read write'
-			type BOOLEAN
-			count 1
-		}
-	}
-	control.11 {
-		iface MIXER
-		name 'FRDDR_A SINK 1 SEL'
-		value 'OUT 1'
-		comment {
-			access 'read write'
-			type ENUMERATED
-			count 1
-			item.0 'OUT 0'
-			item.1 'OUT 1'
-			item.2 'OUT 2'
-			item.3 'OUT 3'
-			item.4 'OUT 4'
-			item.5 'OUT 5'
-			item.6 'OUT 6'
-			item.7 'OUT 7'
-		}
-	}
-	control.12 {
-		iface MIXER
-		name 'FRDDR_A SINK 2 SEL'
-		value 'OUT 1'
-		comment {
-			access 'read write'
-			type ENUMERATED
-			count 1
-			item.0 'OUT 0'
-			item.1 'OUT 1'
-			item.2 'OUT 2'
-			item.3 'OUT 3'
-			item.4 'OUT 4'
-			item.5 'OUT 5'
-			item.6 'OUT 6'
-			item.7 'OUT 7'
-		}
-	}
-	control.13 {
-		iface MIXER
-		name 'FRDDR_A SINK 3 SEL'
-		value 'OUT 1'
-		comment {
-			access 'read write'
-			type ENUMERATED
-			count 1
-			item.0 'OUT 0'
-			item.1 'OUT 1'
-			item.2 'OUT 2'
-			item.3 'OUT 3'
-			item.4 'OUT 4'
-			item.5 'OUT 5'
-			item.6 'OUT 6'
-			item.7 'OUT 7'
-		}
-	}
-	control.14 {
-		iface MIXER
-		name 'FRDDR_B SRC 1 EN Switch'
-		value true
-		comment {
-			access 'read write'
-			type BOOLEAN
-			count 1
-		}
-	}
-	control.15 {
-		iface MIXER
-		name 'FRDDR_B SRC 2 EN Switch'
-		value false
-		comment {
-			access 'read write'
-			type BOOLEAN
-			count 1
-		}
-	}
-	control.16 {
-		iface MIXER
-		name 'FRDDR_B SRC 3 EN Switch'
-		value false
-		comment {
-			access 'read write'
-			type BOOLEAN
-			count 1
-		}
-	}
-	control.17 {
-		iface MIXER
-		name 'FRDDR_B SINK 1 SEL'
-		value 'OUT 1'
-		comment {
-			access 'read write'
-			type ENUMERATED
-			count 1
-			item.0 'OUT 0'
-			item.1 'OUT 1'
-			item.2 'OUT 2'
-			item.3 'OUT 3'
-			item.4 'OUT 4'
-			item.5 'OUT 5'
-			item.6 'OUT 6'
-			item.7 'OUT 7'
-		}
-	}
-	control.18 {
-		iface MIXER
-		name 'FRDDR_B SINK 2 SEL'
-		value 'OUT 1'
-		comment {
-			access 'read write'
-			type ENUMERATED
-			count 1
-			item.0 'OUT 0'
-			item.1 'OUT 1'
-			item.2 'OUT 2'
-			item.3 'OUT 3'
-			item.4 'OUT 4'
-			item.5 'OUT 5'
-			item.6 'OUT 6'
-			item.7 'OUT 7'
-		}
-	}
-	control.19 {
-		iface MIXER
-		name 'FRDDR_B SINK 3 SEL'
-		value 'OUT 1'
-		comment {
-			access 'read write'
-			type ENUMERATED
-			count 1
-			item.0 'OUT 0'
-			item.1 'OUT 1'
-			item.2 'OUT 2'
-			item.3 'OUT 3'
-			item.4 'OUT 4'
-			item.5 'OUT 5'
-			item.6 'OUT 6'
-			item.7 'OUT 7'
-		}
-	}
-	control.20 {
-		iface MIXER
-		name 'FRDDR_C SRC 1 EN Switch'
-		value false
-		comment {
-			access 'read write'
-			type BOOLEAN
-			count 1
-		}
-	}
-	control.21 {
-		iface MIXER
-		name 'FRDDR_C SRC 2 EN Switch'
-		value false
-		comment {
-			access 'read write'
-			type BOOLEAN
-			count 1
-		}
-	}
-	control.22 {
-		iface MIXER
-		name 'FRDDR_C SRC 3 EN Switch'
-		value false
-		comment {
-			access 'read write'
-			type BOOLEAN
-			count 1
-		}
-	}
-	control.23 {
-		iface MIXER
-		name 'FRDDR_C SINK 1 SEL'
-		value 'OUT 1'
-		comment {
-			access 'read write'
-			type ENUMERATED
-			count 1
-			item.0 'OUT 0'
-			item.1 'OUT 1'
-			item.2 'OUT 2'
-			item.3 'OUT 3'
-			item.4 'OUT 4'
-			item.5 'OUT 5'
-			item.6 'OUT 6'
-			item.7 'OUT 7'
-		}
-	}
-	control.24 {
-		iface MIXER
-		name 'FRDDR_C SINK 2 SEL'
-		value 'OUT 1'
-		comment {
-			access 'read write'
-			type ENUMERATED
-			count 1
-			item.0 'OUT 0'
-			item.1 'OUT 1'
-			item.2 'OUT 2'
-			item.3 'OUT 3'
-			item.4 'OUT 4'
-			item.5 'OUT 5'
-			item.6 'OUT 6'
-			item.7 'OUT 7'
-		}
-	}
-	control.25 {
-		iface MIXER
-		name 'FRDDR_C SINK 3 SEL'
-		value 'OUT 1'
-		comment {
-			access 'read write'
-			type ENUMERATED
-			count 1
-			item.0 'OUT 0'
-			item.1 'OUT 1'
-			item.2 'OUT 2'
-			item.3 'OUT 3'
-			item.4 'OUT 4'
-			item.5 'OUT 5'
-			item.6 'OUT 6'
-			item.7 'OUT 7'
-		}
-	}
-	control.26 {
-		iface MIXER
-		name 'TOHDMITX I2S SRC'
-		value 'I2S A'
-		comment {
-			access 'read write'
-			type ENUMERATED
-			count 1
-			item.0 'I2S A'
-			item.1 'I2S B'
-			item.2 'I2S C'
-		}
-	}
-	control.27 {
-		iface MIXER
-		name 'TOHDMITX Switch'
-		value true
-		comment {
-			access 'read write'
-			type BOOLEAN
-			count 1
-		}
-	}
-	control.28 {
-		iface MIXER
-		name 'TOHDMITX SPDIF SRC'
-		value 'SPDIF A'
-		comment {
-			access 'read write'
-			type ENUMERATED
-			count 1
-			item.0 'SPDIF A'
-			item.1 'SPDIF B'
-		}
-	}
-	control.29 {
-		iface MIXER
-		name 'TDMOUT_A SRC SEL'
-		value 'IN 1'
+		name 'TDMIN_A SRC SEL'
+		value 'IN 0'
 		comment {
 			access 'read write'
 			type ENUMERATED
@@ -775,6 +500,19 @@ state.G12BKHADASVIM3 {
 			item.0 'IN 0'
 			item.1 'IN 1'
 			item.2 'IN 2'
+			item.3 'IN 3'
+			item.4 'IN 4'
+			item.5 'IN 5'
+			item.6 'IN 6'
+			item.7 'IN 7'
+			item.8 'IN 8'
+			item.9 'IN 9'
+			item.10 'IN 10'
+			item.11 'IN 11'
+			item.12 'IN 12'
+			item.13 'IN 13'
+			item.14 'IN 14'
+			item.15 'IN 15'
 		}
 	}
 }


### PR DESCRIPTION
#### meson64 general asound.state fix; Khadas VIM3/VIM3L asound.state fixes for HDMI audio

- `meson-{sm1|g12a|g12b}`: default, but don't override, `ASOUND_STATE`; this way board-specific asound.state's are honored
  - add logging during actual deployment so we know what is happening
- `khadas-vim3`: update `asound.state` enabling HDMI out
- `khadas-vim3l`: update `asound.state` with correct card name and enable HDMI output