### PR TITLE
`thinkpad-x13s`: firmware PR has landed, remove usage of rogue fw fork

### DIFF
--- a/config/boards/thinkpad-x13s.wip
+++ b/config/boards/thinkpad-x13s.wip
@@ -18,13 +18,6 @@ function post_family_config_branch_sc8280xp__doit() {
 	declare -g KERNELSOURCE='https://github.com/steev/linux.git'
 }
 
-# @TODO: drop this when https://github.com/armbian/firmware/pull/54 lands
-function post_family_config_branch_sc8280xp__custom_firmware() {
-	display_alert "Setting up custom firmware for" "${BOARD}" "warn"
-	declare -g ARMBIAN_FIRMWARE_GIT_SOURCE="https://github.com/rpardini/armbian-firmware.git"
-	declare -g ARMBIAN_FIRMWARE_GIT_BRANCH="add-thinkpad-x13s-firmware"
-}
-
 function pre_customize_image__add_x13s_firmware_and_modules_to_initrd() {
 	display_alert "Adding x13s" "firmware in initrd" "warn"
 	mkdir -p "${SDCARD}/etc/initramfs-tools/hooks"


### PR DESCRIPTION
#### `thinkpad-x13s`: firmware PR has landed, remove usage of rogue fw fork

- `thinkpad-x13s`: firmware PR has landed, remove usage of rogue fw fork