### PR TITLE
Add sata spi image to Orange Pi 5

### DIFF
--- a/config/boards/orangepi5.conf
+++ b/config/boards/orangepi5.conf
@@ -3,6 +3,7 @@ BOARD_NAME="Orange Pi 5"
 BOARDFAMILY="rockchip-rk3588"
 BOARD_MAINTAINER="efectn"
 BOOTCONFIG="orangepi_5_defconfig" # vendor name, not standard, see hook below, set BOOT_SOC below to compensate
+BOOTCONFIG_SATA="orangepi_5_sata_defconfig"
 BOOT_SOC="rk3588"
 KERNEL_TARGET="legacy"
 FULL_DESKTOP="yes"
@@ -44,10 +45,19 @@ function post_family_tweaks__orangepi5_naming_audios() {
 	return 0
 }
 
+function post_family_config_branch_legacy__orangepi5_uboot_add_sata_target() {
+	display_alert "$BOARD" "Configuring ($BOARD) standard and sata uboot target map" "info"
+	UBOOT_TARGET_MAP="
+	BL31=$RKBIN_DIR/$BL31_BLOB $BOOTCONFIG spl/u-boot-spl.bin u-boot.dtb u-boot.itb;;idbloader.img u-boot.itb rkspi_loader.img
+	BL31=$RKBIN_DIR/$BL31_BLOB $BOOTCONFIG_SATA spl/u-boot-spl.bin u-boot.dtb u-boot.itb;; rkspi_loader_sata.img
+	"
+}
+
 # Override family config for this board; let's avoid conditionals in family config.
 function post_family_config__orangepi5_use_vendor_uboot() {
 	BOOTSOURCE='https://github.com/orangepi-xunlong/u-boot-orangepi.git'
 	BOOTBRANCH='branch:v2017.09-rk3588'
 	BOOTPATCHDIR="legacy"
 }
+
 


### PR DESCRIPTION
# Description
Add sata spi image to uboot dir that must be written to mtd when to want to boot OPI using a sata device.

Jira reference number [AR-9999]

# How Has This Been Tested?
- [x] Built it

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
