### PR TITLE
helios4: Fix pwm patch

### DIFF
--- a/patch/kernel/archive/mvebu-6.1/92-mvebu-gpio-remove-hardcoded-timer-assignment.patch
+++ b/patch/kernel/archive/mvebu-6.1/92-mvebu-gpio-remove-hardcoded-timer-assignment.patch
@@ -8,7 +8,6 @@ Original patch by helios4 team, updated to work on LK5.11+
 
 Signed-off-by: Heisath <jannis@imserv.org>
 ---
-
 diff --git a/drivers/gpio/gpio-mvebu.c b/drivers/gpio/gpio-mvebu.c
 index bad399e3f..d3fdaf177 100644
 --- a/drivers/gpio/gpio-mvebu.c
@@ -177,10 +176,8 @@ index bad399e3f..d3fdaf177 100644
 +	spin_unlock_irqrestore(&mvpwm->controller.lock, flags);
  }
  
- static void mvebu_pwm_get_state(struct pwm_chip *chip,
-@@ -693,29 +759,36 @@ static void mvebu_pwm_get_state(struct pwm_chip *chip,
- 				struct pwm_state *state) {
- 
+ static int mvebu_pwm_get_state(struct pwm_chip *chip,
+@@ -693,27 +759,34 @@ static int mvebu_pwm_get_state(struct pwm_chip *chip,
  	struct mvebu_pwm *mvpwm = to_mvebu_pwm(chip);
 +	struct mvebu_pwm_chip_drv *chip_data = (struct mvebu_pwm_chip_drv*) pwm->chip_data;
 +	struct mvebu_pwmchip *controller;
@@ -220,12 +217,14 @@ index bad399e3f..d3fdaf177 100644
  
  	regmap_read(mvchip->regs, GPIO_BLINK_EN_OFF + mvchip->offset, &u);
  	if (u)
-@@ -796,13 +796,15 @@ static void mvebu_pwm_get_state(struct pwm_chip *chip,
+@@ -796,15 +796,17 @@ static int mvebu_pwm_get_state(struct pwm_chip *chip,
  	else
  		state->enabled = false;
  
 -	spin_unlock_irqrestore(&mvpwm->lock, flags);
 +	spin_unlock_irqrestore(&controller->lock, flags);
+
+ 	return 0;
  }
  
  static int mvebu_pwm_apply(struct pwm_chip *chip, struct pwm_device *pwm,
@@ -237,6 +236,8 @@ index bad399e3f..d3fdaf177 100644
  	struct mvebu_gpio_chip *mvchip = mvpwm->mvchip;
  	unsigned long long val;
  	unsigned long flags;
+--- a/drivers/gpio/gpio-mvebu.c
++++ b/drivers/gpio/gpio-mvebu.c
 @@ -811,7 +813,12 @@ static int mvebu_pwm_apply(struct pwm_chip *chip, struct pwm_device *pwm,
  	if (state->polarity != PWM_POLARITY_NORMAL)
  		return -EINVAL;
@@ -404,8 +405,8 @@ index bad399e3f..d3fdaf177 100644
  		return -EINVAL;
  	}
 @@ -907,7 +968,10 @@ static int mvebu_pwm_probe(struct platform_device *pdev,
- 	 */
- 	mvpwm->chip.base = -1;
+ 	mvpwm->chip.ops = &mvebu_pwm_ops;
+ 	mvpwm->chip.npwm = mvchip->chip.ngpio;
  
 -	spin_lock_init(&mvpwm->lock);
 +	spin_lock_init(&mvpwm->controller.lock);


### PR DESCRIPTION
# Description

This fixes the (once again) broken PWM patch on helios4.
https://forum.armbian.com/topic/23824-fancontrol-service-fails-to-start-with-kernel-version-51572/#comment-166926


# How Has This Been Tested?

Built, Burned, Tested on HW

