### PR TITLE
armbian-kernel: was too hungry in disabling kernel debug, let `DEBUG_MISC` & `SLUB_DEBUG` alone

### DIFF
--- a/lib/functions/compilation/armbian-kernel.sh
+++ b/lib/functions/compilation/armbian-kernel.sh
@@ -29,11 +29,9 @@ function armbian_kernel_config__disable_module_compression() {
 		# DONE: Disable: debug option
 		kernel_config_set_n DEBUG_INFO_DWARF5 # Armbian doesn't know how to package a debug kernel.
 		kernel_config_set_n DEBUG_KERNEL      # ditto
-		kernel_config_set_n DEBUG_MISC        # ditto
 		kernel_config_set_n DEBUG_INFO        # ditto
 		kernel_config_set_n DEBUG_INFO_BTF    # ditto
 		kernel_config_set_n GDB_SCRIPTS       # ditto
-		kernel_config_set_n SLUB_DEBUG        # ditto
 
 		# @TODO: Enable the options for the extrawifi/drivers; so we don't need to worry about them when updating configs
 	fi


### PR DESCRIPTION
#### armbian-kernel: was too hungry in disabling kernel debug, let `DEBUG_MISC` & `SLUB_DEBUG` alone

- armbian-kernel: was too hungry in disabling kernel debug, let `DEBUG_MISC` & `SLUB_DEBUG` alone