### PR TITLE
`meson64` `edge` 6.4: bump from 6.4-rc5 tag to `linux-6.4.y` branch

### DIFF
--- a/config/sources/families/include/meson64_common.inc
+++ b/config/sources/families/include/meson64_common.inc
@@ -46,7 +46,7 @@ case $BRANCH in
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.4" # Major and minor versions of this kernel. For mainline caching.
-		KERNELBRANCH='tag:v6.4-rc5'
+		KERNELBRANCH='branch:linux-6.4.y'
 		KERNELPATCHDIR='meson64-edge'
 		;;
 

--- a/patch/kernel/archive/meson64-6.4/general-meson-mmc-1-arm64-amlogic-mmc-meson-gx-Add-core-tx-rx-eMMC-SD-SD.patch
+++ b/patch/kernel/archive/meson64-6.4/general-meson-mmc-1-arm64-amlogic-mmc-meson-gx-Add-core-tx-rx-eMMC-SD-SD.patch
@@ -16,7 +16,7 @@ Signed-off-by: Vyacheslav Bocharov <adeep@lexina.in>
  2 files changed, 48 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/mmc/host/meson-gx-mmc.c b/drivers/mmc/host/meson-gx-mmc.c
-index b8514d9d5e73..88748cc9771b 100644
+index ee9a25b900ae..3f1550d9c0c5 100644
 --- a/drivers/mmc/host/meson-gx-mmc.c
 +++ b/drivers/mmc/host/meson-gx-mmc.c
 @@ -27,6 +27,7 @@


### PR DESCRIPTION
#### `meson64` `edge` 6.4: bump from 6.4-rc5 tag to `linux-6.4.y` branch

- `meson64` `edge` 6.4: bump from 6.4-rc5 tag to `linux-6.4.y` branch
  - rebase one patch