### PR TITLE
NanoPi Duo2: enable powerbutton and ethernet

### DIFF
--- a/patch/kernel/archive/sunxi-6.1/patches.armbian/arm-dts-sun8i-h3-nanopi-duo2-enable-powerbutton-and-ethernet.patch
+++ b/patch/kernel/archive/sunxi-6.1/patches.armbian/arm-dts-sun8i-h3-nanopi-duo2-enable-powerbutton-and-ethernet.patch
@@ -1,0 +1,63 @@
+From f6f0b76bcfcb1163e304c262207aeb714d16307b Mon Sep 17 00:00:00 2001
+From: Gunjan Gupta <viraniac@gmail.com>
+Date: Mon, 26 Jun 2023 13:29:46 +0000
+Subject: [PATCH 1/2] ARM: dts: sun8i: nanopiduo2: Use key-0 as power button
+
+The onboard button key-0 was not marked as power button. This meant
+that once the board was suspended, there was no way to bring it back
+to life. Mark key-0 as power button so that it can be used to bring
+the board back to life
+---
+ arch/arm/boot/dts/sun8i-h3-nanopi-duo2.dts | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm/boot/dts/sun8i-h3-nanopi-duo2.dts b/arch/arm/boot/dts/sun8i-h3-nanopi-duo2.dts
+index 343b02b97..4878d27ba 100644
+--- a/arch/arm/boot/dts/sun8i-h3-nanopi-duo2.dts
++++ b/arch/arm/boot/dts/sun8i-h3-nanopi-duo2.dts
+@@ -42,8 +42,9 @@ gpio-keys {
+ 
+ 		key-0 {
+ 			label = "k1";
+-			linux,code = <BTN_0>;
++			linux,code = <KEY_POWER>;
+ 			gpios = <&r_pio 0 3 GPIO_ACTIVE_LOW>; /* PL3 */
++			wakeup-source;
+ 		};
+ 	};
+ 
+-- 
+2.34.1
+
+
+From 51af316406c82571be4a30665fbf93cab9caf080 Mon Sep 17 00:00:00 2001
+From: Gunjan Gupta <viraniac@gmail.com>
+Date: Mon, 26 Jun 2023 13:53:14 +0000
+Subject: [PATCH 2/2] ARM: dts: sun8i: nanopiduo2: enable ethernet
+
+NanoPi Duo2 has pinout for ethernet. Lets enable the same in dts
+---
+ arch/arm/boot/dts/sun8i-h3-nanopi-duo2.dts | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/arch/arm/boot/dts/sun8i-h3-nanopi-duo2.dts b/arch/arm/boot/dts/sun8i-h3-nanopi-duo2.dts
+index 4878d27ba..8669fd087 100644
+--- a/arch/arm/boot/dts/sun8i-h3-nanopi-duo2.dts
++++ b/arch/arm/boot/dts/sun8i-h3-nanopi-duo2.dts
+@@ -105,6 +105,13 @@ &ehci0 {
+ 	status = "okay";
+ };
+ 
++&emac {
++	phy-handle = <&int_mii_phy>;
++	phy-mode = "mii";
++	allwinner,leds-active-low;
++	status = "okay";
++};
++
+ &mmc0 {
+ 	bus-width = <4>;
+ 	cd-gpios = <&pio 5 6 GPIO_ACTIVE_LOW>; /* PF6 */
+-- 
+2.34.1
+

--- a/patch/kernel/archive/sunxi-6.1/series.armbian
+++ b/patch/kernel/archive/sunxi-6.1/series.armbian
@@ -178,3 +178,4 @@
 	patches.armbian/arm-dts-sun8i-h3-orangepizero-add_tve.patch
 	patches.armbian/arm-dts-sun8i-h3-fix-thermal-read.patch
 	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1.patch
+	patches.armbian/arm-dts-sun8i-h3-nanopi-duo2-enable-powerbutton-and-ethernet.patch

--- a/patch/kernel/archive/sunxi-6.1/series.conf
+++ b/patch/kernel/archive/sunxi-6.1/series.conf
@@ -582,3 +582,4 @@
 	patches.armbian/arm-dts-sun8i-h3-orangepizero-add_tve.patch
 	patches.armbian/arm-dts-sun8i-h3-fix-thermal-read.patch
 	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1.patch
+	patches.armbian/arm-dts-sun8i-h3-nanopi-duo2-enable-powerbutton-and-ethernet.patch

--- a/patch/kernel/archive/sunxi-6.2/patches.armbian/arm-dts-sun8i-h3-nanopi-duo2-enable-powerbutton-and-ethernet.patch
+++ b/patch/kernel/archive/sunxi-6.2/patches.armbian/arm-dts-sun8i-h3-nanopi-duo2-enable-powerbutton-and-ethernet.patch
@@ -1,0 +1,63 @@
+From f6f0b76bcfcb1163e304c262207aeb714d16307b Mon Sep 17 00:00:00 2001
+From: Gunjan Gupta <viraniac@gmail.com>
+Date: Mon, 26 Jun 2023 13:29:46 +0000
+Subject: [PATCH 1/2] ARM: dts: sun8i: nanopiduo2: Use key-0 as power button
+
+The onboard button key-0 was not marked as power button. This meant
+that once the board was suspended, there was no way to bring it back
+to life. Mark key-0 as power button so that it can be used to bring
+the board back to life
+---
+ arch/arm/boot/dts/sun8i-h3-nanopi-duo2.dts | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm/boot/dts/sun8i-h3-nanopi-duo2.dts b/arch/arm/boot/dts/sun8i-h3-nanopi-duo2.dts
+index 343b02b97..4878d27ba 100644
+--- a/arch/arm/boot/dts/sun8i-h3-nanopi-duo2.dts
++++ b/arch/arm/boot/dts/sun8i-h3-nanopi-duo2.dts
+@@ -42,8 +42,9 @@ gpio-keys {
+ 
+ 		key-0 {
+ 			label = "k1";
+-			linux,code = <BTN_0>;
++			linux,code = <KEY_POWER>;
+ 			gpios = <&r_pio 0 3 GPIO_ACTIVE_LOW>; /* PL3 */
++			wakeup-source;
+ 		};
+ 	};
+ 
+-- 
+2.34.1
+
+
+From 51af316406c82571be4a30665fbf93cab9caf080 Mon Sep 17 00:00:00 2001
+From: Gunjan Gupta <viraniac@gmail.com>
+Date: Mon, 26 Jun 2023 13:53:14 +0000
+Subject: [PATCH 2/2] ARM: dts: sun8i: nanopiduo2: enable ethernet
+
+NanoPi Duo2 has pinout for ethernet. Lets enable the same in dts
+---
+ arch/arm/boot/dts/sun8i-h3-nanopi-duo2.dts | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/arch/arm/boot/dts/sun8i-h3-nanopi-duo2.dts b/arch/arm/boot/dts/sun8i-h3-nanopi-duo2.dts
+index 4878d27ba..8669fd087 100644
+--- a/arch/arm/boot/dts/sun8i-h3-nanopi-duo2.dts
++++ b/arch/arm/boot/dts/sun8i-h3-nanopi-duo2.dts
+@@ -105,6 +105,13 @@ &ehci0 {
+ 	status = "okay";
+ };
+ 
++&emac {
++	phy-handle = <&int_mii_phy>;
++	phy-mode = "mii";
++	allwinner,leds-active-low;
++	status = "okay";
++};
++
+ &mmc0 {
+ 	bus-width = <4>;
+ 	cd-gpios = <&pio 5 6 GPIO_ACTIVE_LOW>; /* PF6 */
+-- 
+2.34.1
+

--- a/patch/kernel/archive/sunxi-6.2/series.armbian
+++ b/patch/kernel/archive/sunxi-6.2/series.armbian
@@ -193,3 +193,4 @@
 	patches.armbian/arm64-dts-sun50i-h6-orangepi.dtsi-Rollback-r_rsb-to-r_i2c.patch
 	patches.armbian/mfd-sunxi-ac200-fix-error-initialization.patch
 	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1.patch
+	patches.armbian/arm-dts-sun8i-h3-nanopi-duo2-enable-powerbutton-and-ethernet.patch

--- a/patch/kernel/archive/sunxi-6.2/series.conf
+++ b/patch/kernel/archive/sunxi-6.2/series.conf
@@ -589,3 +589,4 @@
 	patches.armbian/arm64-dts-sun50i-h6-orangepi.dtsi-Rollback-r_rsb-to-r_i2c.patch
 	patches.armbian/mfd-sunxi-ac200-fix-error-initialization.patch
 	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1.patch
+	patches.armbian/arm-dts-sun8i-h3-nanopi-duo2-enable-powerbutton-and-ethernet.patch


### PR DESCRIPTION
# Description

This PR configures onboard button as power button on NanoPi Duo2 so that the board can be brought back from suspended state or can be rebooted after shutdown. Also enables ethernet as request on the [forum](https://forum.armbian.com/topic/28911-nanopi-duo2-wired-ethernet-fix-bookworm-6130-tested/)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Booted on NanoPi Duo2 and tested button works at sleep and poweroff

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
