### PR TITLE
Add bluetooth-hciattach extension to Orange Pi 5

### DIFF
--- a/config/boards/orangepi5.conf
+++ b/config/boards/orangepi5.conf
@@ -15,6 +15,9 @@ IMAGE_PARTITION_TABLE="gpt"
 SKIP_BOOTSPLASH="yes" # Skip boot splash patch, conflicts with CONFIG_VT=yes
 BOOTFS_TYPE="fat"
 
+declare -g BLUETOOTH_HCIATTACH_PARAMS="-s 115200 /dev/ttyS9 bcm43xx 1500000" # For the bluetooth-hciattach extension
+enable_extension "bluetooth-hciattach"                                       # Enable the bluetooth-hciattach extension
+
 function post_family_tweaks_bsp__orangepi5_copy_usb2_service() {
     display_alert "Installing BSP firmware and fixups"
 


### PR DESCRIPTION
# Description
Add missing bluetooth service like meko and khadas edge 2

Jira reference number [AR-9999]

# How Has This Been Tested?
- [x] Got a feedback from the forum

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
