### PR TITLE
kernel drivers: introduce `KERNEL_DRIVERS_SKIP` array to allow families to skip certain kernel drivers

### DIFF
--- a/config/sources/families/d1.conf
+++ b/config/sources/families/d1.conf
@@ -24,6 +24,7 @@ case "${BRANCH}" in
 		KERNELBRANCH="branch:riscv/d1-wip"
 		KERNELPATCHDIR="d1-${BRANCH}"
 		LINUXCONFIG="linux-d1-${BRANCH}"
+		KERNEL_DRIVERS_SKIP+=(driver_rtw88) # This is custom 6.1 driver, skip rtw88 to avoid patching failures
 		;;
 
 esac

--- a/config/sources/families/rockchip-rk3588.conf
+++ b/config/sources/families/rockchip-rk3588.conf
@@ -47,6 +47,7 @@ case $BRANCH in
 		KERNELPATCHDIR='rockchip-rk3588-midstream' # Empty/nonexisting, so zero patches, hopefully
 		KERNELSOURCE='https://github.com/Googulator/linux-rk3588-midstream.git'
 		KERNELBRANCH='branch:midstream'
+		KERNEL_DRIVERS_SKIP+=(driver_rtw88) # This is a 6.2-rcX kernel, while the rtw88 driver patching expects 6.2.0+
 		;;
 
 esac

--- a/config/sources/families/sun50iw9-btt.conf
+++ b/config/sources/families/sun50iw9-btt.conf
@@ -31,7 +31,7 @@ case $BRANCH in
 		ATF_PLAT="sun50i_h616"
 		ATF_TARGET_MAP='PLAT=sun50i_h616 DEBUG=1 bl31;;build/sun50i_h616/debug/bl31.bin'
 		BOOTSCRIPT='boot-sun50i-next.cmd:boot.cmd'
-
+		KERNEL_DRIVERS_SKIP+=(driver_rtw88) # This is custom 6.1 driver, skip rtw88 to avoid patching failures
 		;;
 
 	current | edge)

--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -400,11 +400,7 @@ driver_rtl88x2bu() {
 }
 
 driver_rtw88() {
-	if [[ "$LINUXFAMILY" == d1 || "$BRANCH" == midstream || "$LINUXFAMILY" == sun50iw9-btt ]]; then
-		# "D1" is using an old 6.1 which can't take this.
-		# "midstream" a half monster kernel, a cross between sre mainline and downstream rk kernel
-		return 0
-	fi
+	# Quite a few kernel families have KERNEL_DRIVERS_SKIP listing this driver. If so, this won't even be called.
 
 	# Upstream wireless RTW88 drivers (wireless-next-2023-06-22)
 	if [[ "$version" == "6.1" || "$version" == "6.2" || "$version" == "6.3" || "$version" == "6.4" ]] && [ $EXTRAWIFI == yes ]; then

--- a/lib/functions/main/config-prepare.sh
+++ b/lib/functions/main/config-prepare.sh
@@ -160,6 +160,8 @@ function config_early_init() {
 
 	display_alert "Starting single build process" "${BOARD:-"no BOARD set"}" "info"
 
+	declare -g -a KERNEL_DRIVERS_SKIP=() # Prepare array to be filled in by board/family/extensions
+
 	return 0 # protect against eventual shortcircuit above
 }
 


### PR DESCRIPTION
#### kernel drivers: introduce `KERNEL_DRIVERS_SKIP` array to allow families to skip certain kernel drivers

- kernel drivers: introduce `KERNEL_DRIVERS_SKIP` array to allow families to skip certain kernel drivers
  - move rtw88's skip's from drivers_network.sh to their own family definitions