### PR TITLE
rkbin-tools: allow using custom rkbin `RKBIN_GIT_BRANCH` as well as `RKBIN_GIT_URL`

### DIFF
--- a/extensions/rkbin-tools.sh
+++ b/extensions/rkbin-tools.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 function fetch_sources_tools__rkbin_tools() {
-	fetch_from_repo "${RKBIN_GIT_URL:-"https://github.com/armbian/rkbin"}" "rkbin-tools" "branch:master"
+	fetch_from_repo "${RKBIN_GIT_URL:-"https://github.com/armbian/rkbin"}" "rkbin-tools" "branch:${RKBIN_GIT_BRANCH:-"master"}"
 }
 
 function build_host_tools__install_rkbin_tools() {


### PR DESCRIPTION
#### rkbin-tools: allow using custom rkbin `RKBIN_GIT_BRANCH` as well as `RKBIN_GIT_URL`

- rkbin-tools: allow using custom rkbin `RKBIN_GIT_BRANCH` as well as `RKBIN_GIT_URL`
  - notice: the rkbin repo or the bins themselves are not hashed or included in the u-boot version (yet)
  - make sure to avoid caching when building with those custom git/branch (`ARTIFACT_IGNORE_CACHE=yes CLEAN_LEVEL=make-uboot`)