### PR TITLE
rockchip64_common: default, but do not overwrite, `BL31_BLOB` and `MINILOADER_BLOB`

### DIFF
--- a/config/boards/tinkerboard-2.wip
+++ b/config/boards/tinkerboard-2.wip
@@ -1,14 +1,15 @@
 # Rockchip RK3399 hexa core 2GB SoC GBe eMMC USB3 WiFi/BT
 BOARD_NAME="Tinker Board 2"
 BOARDFAMILY="rockchip64"
-BOARD_MAINTAINER=""
+BOARD_MAINTAINER="rpardini"
 BOOTCONFIG="tinker-2-rk3399_defconfig"
 KERNEL_TARGET="current,edge"
 FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
 BOOT_FDT_FILE="rockchip/rk3399-tinker-2.dtb"
 SERIALCON="ttyS2"
-BOOT_SCENARIO="spl-blobs"                 # 'blobless' also works; but some RAM issues found; see rk33/rk3399_ddr_800MHz_v1.27.bin in rockchip64_common.inc
-BOARD_FIRMWARE_INSTALL="-full"            # Install full firmware, for rtl8822ce firmware and others
-BOOTBRANCH="tag:v2021.07"                 # v2021.07 ...
-BOOTPATCHDIR='legacy/u-boot-tinkerboard2' # ...  with _only_ the patches we need for TB2, not the default rockchip64
+BOOT_SCENARIO="spl-blobs"                   # 'blobless' also works; but some RAM issues found; see rk33/rk3399_ddr_800MHz_v1.27.bin in rockchip64_common.inc
+BOARD_FIRMWARE_INSTALL="-full"              # Install full firmware, for rtl8822ce firmware and others
+BOOTBRANCH="tag:v2021.07"                   # v2021.07 ...
+BOOTPATCHDIR='legacy/u-boot-tinkerboard2'   # ...  with _only_ the patches we need for TB2, not the default rockchip64
+DDR_BLOB="rk33/rk3399_ddr_800MHz_v1.27.bin" # Different blob for TB2

--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -82,11 +82,7 @@ if [[ $BOOT_SOC == rk3328 ]]; then
 elif [[ $BOOT_SOC == rk3399 ]]; then
 
 	BOOT_SCENARIO="${BOOT_SCENARIO:=only-blobs}"
-	if [[ $BOARD_NAME == "Tinker Board 2" ]]; then
-		DDR_BLOB="${DDR_BLOB:=rk33/rk3399_ddr_800MHz_v1.27.bin}"
-	else
-		DDR_BLOB="${DDR_BLOB:=rk33/rk3399_ddr_933MHz_v1.25.bin}"
-	fi
+	DDR_BLOB="${DDR_BLOB:='rk33/rk3399_ddr_933MHz_v1.25.bin'}"
 	MINILOADER_BLOB="${MINILOADER_BLOB:-'rk33/rk3399_miniloader_v1.26.bin'}"
 	BL31_BLOB="${BL31_BLOB:-'rk33/rk3399_bl31_v1.35.elf'}"
 

--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -76,8 +76,8 @@ if [[ $BOOT_SOC == rk3328 ]]; then
 
 	BOOT_SCENARIO="${BOOT_SCENARIO:=only-blobs}"
 	DDR_BLOB="${DDR_BLOB:=rk33/rk3328_ddr_333MHz_v1.16.bin}"
-	MINILOADER_BLOB='rk33/rk322xh_miniloader_v2.50.bin'
-	BL31_BLOB='rk33/rk322xh_bl31_v1.44.elf'
+	MINILOADER_BLOB="${MINILOADER_BLOB:-'rk33/rk322xh_miniloader_v2.50.bin'}"
+	BL31_BLOB="${BL31_BLOB:-'rk33/rk322xh_bl31_v1.44.elf'}"
 
 elif [[ $BOOT_SOC == rk3399 ]]; then
 
@@ -87,47 +87,47 @@ elif [[ $BOOT_SOC == rk3399 ]]; then
 	else
 		DDR_BLOB="${DDR_BLOB:=rk33/rk3399_ddr_933MHz_v1.25.bin}"
 	fi
-	MINILOADER_BLOB='rk33/rk3399_miniloader_v1.26.bin'
-	BL31_BLOB='rk33/rk3399_bl31_v1.35.elf'
+	MINILOADER_BLOB="${MINILOADER_BLOB:-'rk33/rk3399_miniloader_v1.26.bin'}"
+	BL31_BLOB="${BL31_BLOB:-'rk33/rk3399_bl31_v1.35.elf'}"
 
 elif [[ $BOOT_SOC == rk3399pro ]]; then
 
 	BOOT_SCENARIO="${BOOT_SCENARIO:=only-blobs}"
 	DDR_BLOB="${DDR_BLOB:=rk33/rk3399pro_npu_ddr_933MHz_v1.02.bin}"
-	MINILOADER_BLOB='rk33/rk3399pro_miniloader_v1.26.bin'
-	BL31_BLOB='rk33/rk3399pro_bl31_v1.35.elf'
+	MINILOADER_BLOB="${MINILOADER_BLOB:-'rk33/rk3399pro_miniloader_v1.26.bin'}"
+	BL31_BLOB="${BL31_BLOB:-'rk33/rk3399pro_bl31_v1.35.elf'}"
 
 elif [[ $BOOT_SOC == rk3566 ]]; then
 
 	BOOT_SCENARIO="${BOOT_SCENARIO:=spl-blobs}"
 	DDR_BLOB="${DDR_BLOB:=rk35/rk3566_ddr_1056MHz_v1.10.bin}"
-	BL31_BLOB='rk35/rk3568_bl31_v1.29.elf'
+	BL31_BLOB="${BL31_BLOB:-'rk35/rk3568_bl31_v1.29.elf'}"
 	BOOT_SOC_MKIMAGE="rk3568" # mkimage does not know about rk3566, and rk3568 works.
 
 elif [[ $BOOT_SOC == rk3568 ]]; then
 
 	BOOT_SCENARIO="${BOOT_SCENARIO:=spl-blobs}"
 	DDR_BLOB="${DDR_BLOB:=rk35/rk3568_ddr_1560MHz_v1.13.bin}"
-	BL31_BLOB='rk35/rk3568_bl31_v1.32.elf'
+	BL31_BLOB="${BL31_BLOB:-'rk35/rk3568_bl31_v1.32.elf'}"
 
 elif [[ $BOOT_SOC == rk3588 ]]; then
 
 	BOOT_SCENARIO="${BOOT_SCENARIO:=spl-blobs}"
 	DDR_BLOB="${DDR_BLOB:=rk35/rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.08.bin}"
-	BL31_BLOB='rk35/rk3588_bl31_v1.28.elf'
+	BL31_BLOB="${BL31_BLOB:-'rk35/rk3588_bl31_v1.28.elf'}"
 
 elif [[ $BOARD == rockpi-s ]]; then
 
 	BOOT_SCENARIO="${BOOT_SCENARIO:=only-blobs}"
 	BOOT_SOC=rk3308
 	DDR_BLOB="${DDR_BLOB:=rk33/rk3308_ddr_589MHz_uart2_m1_v1.30.bin}"
-	MINILOADER_BLOB='rk33/rk3308_miniloader_v1.22.bin'
-	BL31_BLOB='rk33/rk3308_bl31_v2.22.elf'
+	MINILOADER_BLOB="${MINILOADER_BLOB:-'rk33/rk3308_miniloader_v1.22.bin'}"
+	BL31_BLOB="${BL31_BLOB:-'rk33/rk3308_bl31_v2.22.elf'}"
 
 	if [[ ${BRANCH} == legacy ]]; then
 		DDR_BLOB='rk33/rk3308_ddr_589MHz_uart2_m0_v1.26.bin'
-		MINILOADER_BLOB='rk33/rk3308_miniloader_sd_nand_v1.13.bin'
-		BL31_BLOB='rk33/rk3308_bl31_v2.10.elf'
+		MINILOADER_BLOB="${MINILOADER_BLOB:-'rk33/rk3308_miniloader_sd_nand_v1.13.bin'}"
+		BL31_BLOB="${BL31_BLOB:-'rk33/rk3308_bl31_v2.10.elf'}"
 	fi
 fi
 


### PR DESCRIPTION
#### rockchip64_common: default, but do not overwrite, `BL31_BLOB` and `MINILOADER_BLOB`

- rockchip64_common: default, but do not overwrite, `BL31_BLOB` and `MINILOADER_BLOB`
- rockchip64_common: move the TB2's special `DDR_BLOB` out from family file into board file