### PR TITLE
patch: misc: rtw88: `decrease the log level of tx report`

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -409,6 +409,7 @@ driver_rtw88() {
 		process_patch_file "${SRC}/patch/misc/rtw88/${version}/002-rtw88-linux-next.patch" "applying"
 		process_patch_file "${SRC}/patch/misc/rtw88/hack/001-revert-rtw88-sdio-size-and-timout-to-rfc-v1.patch" "applying"
 		process_patch_file "${SRC}/patch/misc/rtw88/hack/002-rtw88-usb-make-work-queues-high-priority.patch" "applying"
+		process_patch_file "${SRC}/patch/misc/rtw88/hack/003-rtw88-decrease-the-log-level-of-tx-report.patch" "applying"
 	fi
 }
 

--- a/patch/misc/rtw88/hack/003-rtw88-decrease-the-log-level-of-tx-report.patch
+++ b/patch/misc/rtw88/hack/003-rtw88-decrease-the-log-level-of-tx-report.patch
@@ -1,0 +1,34 @@
+From: Patrick Yavitz <pyavitz@gmail.com>
+Subject: v2: rtw88: decrease the log level of tx report
+
+Reduce 'failed to get tx report from firmware' dmesg spam.
+
+https://lore.kernel.org/linux-wireless/20210713104524.47101-1-pkshih@realtek.com/
+https://cgit.freebsd.org/src/commit/?id=e140d551b78670fbf99c83a59438cb13de50420f
+
+Signed-off-by: Patrick Yavitz <pyavitz@gxxx.com>
+diff -Naur a/drivers/net/wireless/realtek/rtw88/tx.c b/drivers/net/wireless/realtek/rtw88/tx.c
+--- a/drivers/net/wireless/realtek/rtw88/tx.c	2023-06-30 13:28:40.396914119 -0400
++++ b/drivers/net/wireless/realtek/rtw88/tx.c	2023-06-30 16:57:33.868259352 -0400
+@@ -177,14 +177,16 @@
+ 	struct rtw_tx_report *tx_report = &rtwdev->tx_report;
+ 	unsigned long flags;
+ 
+-	if (skb_queue_len(&tx_report->queue) == 0)
+-		return;
+-
+-	rtw_warn(rtwdev, "failed to get tx report from firmware\n");
++	uint32_t qlen;
+ 
+ 	spin_lock_irqsave(&tx_report->q_lock, flags);
+-	skb_queue_purge(&tx_report->queue);
++	qlen = skb_queue_len(&tx_report->queue);
++	if (qlen > 0)
++		skb_queue_purge(&tx_report->queue);
+ 	spin_unlock_irqrestore(&tx_report->q_lock, flags);
++
++	rtw_dbg(rtwdev, RTW_DBG_TX, "failed to get tx report from firmware: "
++		"txreport qlen %u\n", qlen);
+ }
+ 
+ void rtw_tx_report_enqueue(struct rtw_dev *rtwdev, struct sk_buff *skb, u8 sn)


### PR DESCRIPTION
Reduce `failed to get tx report from firmware` dmesg spam.

https://lore.kernel.org/linux-wireless/20210713104524.47101-1-pkshih@realtek.com/
https://cgit.freebsd.org/src/commit/?id=e140d551b78670fbf99c83a59438cb13de50420f

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
