### PR TITLE
rockchip64_common: default, but do not overwrite, `BL31_BLOB` and `MINILOADER_BLOB` (fixed!)

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -75,55 +75,55 @@ declare -g BOOT_SOC_MKIMAGE="${BOOT_SOC}"
 if [[ $BOOT_SOC == rk3328 ]]; then
 
 	BOOT_SCENARIO="${BOOT_SCENARIO:=only-blobs}"
-	DDR_BLOB="${DDR_BLOB:=rk33/rk3328_ddr_333MHz_v1.16.bin}"
-	MINILOADER_BLOB="${MINILOADER_BLOB:-'rk33/rk322xh_miniloader_v2.50.bin'}"
-	BL31_BLOB="${BL31_BLOB:-'rk33/rk322xh_bl31_v1.44.elf'}"
+	DDR_BLOB="${DDR_BLOB:-"rk33/rk3328_ddr_333MHz_v1.16.bin"}"
+	MINILOADER_BLOB="${MINILOADER_BLOB:-"rk33/rk322xh_miniloader_v2.50.bin"}"
+	BL31_BLOB="${BL31_BLOB:-"rk33/rk322xh_bl31_v1.44.elf"}"
 
 elif [[ $BOOT_SOC == rk3399 ]]; then
 
 	BOOT_SCENARIO="${BOOT_SCENARIO:=only-blobs}"
-	DDR_BLOB="${DDR_BLOB:='rk33/rk3399_ddr_933MHz_v1.25.bin'}"
-	MINILOADER_BLOB="${MINILOADER_BLOB:-'rk33/rk3399_miniloader_v1.26.bin'}"
-	BL31_BLOB="${BL31_BLOB:-'rk33/rk3399_bl31_v1.35.elf'}"
+	DDR_BLOB="${DDR_BLOB:-"rk33/rk3399_ddr_933MHz_v1.25.bin"}"
+	MINILOADER_BLOB="${MINILOADER_BLOB:-"rk33/rk3399_miniloader_v1.26.bin"}"
+	BL31_BLOB="${BL31_BLOB:-"rk33/rk3399_bl31_v1.35.elf"}"
 
 elif [[ $BOOT_SOC == rk3399pro ]]; then
 
 	BOOT_SCENARIO="${BOOT_SCENARIO:=only-blobs}"
-	DDR_BLOB="${DDR_BLOB:=rk33/rk3399pro_npu_ddr_933MHz_v1.02.bin}"
-	MINILOADER_BLOB="${MINILOADER_BLOB:-'rk33/rk3399pro_miniloader_v1.26.bin'}"
-	BL31_BLOB="${BL31_BLOB:-'rk33/rk3399pro_bl31_v1.35.elf'}"
+	DDR_BLOB="${DDR_BLOB:-"rk33/rk3399pro_npu_ddr_933MHz_v1.02.bin"}"
+	MINILOADER_BLOB="${MINILOADER_BLOB:-"rk33/rk3399pro_miniloader_v1.26.bin"}"
+	BL31_BLOB="${BL31_BLOB:-"rk33/rk3399pro_bl31_v1.35.elf"}"
 
 elif [[ $BOOT_SOC == rk3566 ]]; then
 
 	BOOT_SCENARIO="${BOOT_SCENARIO:=spl-blobs}"
-	DDR_BLOB="${DDR_BLOB:=rk35/rk3566_ddr_1056MHz_v1.10.bin}"
-	BL31_BLOB="${BL31_BLOB:-'rk35/rk3568_bl31_v1.29.elf'}"
+	DDR_BLOB="${DDR_BLOB:-"rk35/rk3566_ddr_1056MHz_v1.10.bin"}"
+	BL31_BLOB="${BL31_BLOB:-"rk35/rk3568_bl31_v1.29.elf"}"
 	BOOT_SOC_MKIMAGE="rk3568" # mkimage does not know about rk3566, and rk3568 works.
 
 elif [[ $BOOT_SOC == rk3568 ]]; then
 
 	BOOT_SCENARIO="${BOOT_SCENARIO:=spl-blobs}"
-	DDR_BLOB="${DDR_BLOB:=rk35/rk3568_ddr_1560MHz_v1.13.bin}"
-	BL31_BLOB="${BL31_BLOB:-'rk35/rk3568_bl31_v1.32.elf'}"
+	DDR_BLOB="${DDR_BLOB:-"rk35/rk3568_ddr_1560MHz_v1.13.bin"}"
+	BL31_BLOB="${BL31_BLOB:-"rk35/rk3568_bl31_v1.32.elf"}"
 
 elif [[ $BOOT_SOC == rk3588 ]]; then
 
 	BOOT_SCENARIO="${BOOT_SCENARIO:=spl-blobs}"
-	DDR_BLOB="${DDR_BLOB:=rk35/rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.08.bin}"
-	BL31_BLOB="${BL31_BLOB:-'rk35/rk3588_bl31_v1.28.elf'}"
+	DDR_BLOB="${DDR_BLOB:-"rk35/rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.08.bin"}"
+	BL31_BLOB="${BL31_BLOB:-"rk35/rk3588_bl31_v1.28.elf"}"
 
 elif [[ $BOARD == rockpi-s ]]; then
 
 	BOOT_SCENARIO="${BOOT_SCENARIO:=only-blobs}"
 	BOOT_SOC=rk3308
-	DDR_BLOB="${DDR_BLOB:=rk33/rk3308_ddr_589MHz_uart2_m1_v1.30.bin}"
-	MINILOADER_BLOB="${MINILOADER_BLOB:-'rk33/rk3308_miniloader_v1.22.bin'}"
-	BL31_BLOB="${BL31_BLOB:-'rk33/rk3308_bl31_v2.22.elf'}"
+	DDR_BLOB="${DDR_BLOB:-"rk33/rk3308_ddr_589MHz_uart2_m1_v1.30.bin"}"
+	MINILOADER_BLOB="${MINILOADER_BLOB:-"rk33/rk3308_miniloader_v1.22.bin"}"
+	BL31_BLOB="${BL31_BLOB:-"rk33/rk3308_bl31_v2.22.elf"}"
 
 	if [[ ${BRANCH} == legacy ]]; then
-		DDR_BLOB='rk33/rk3308_ddr_589MHz_uart2_m0_v1.26.bin'
-		MINILOADER_BLOB="${MINILOADER_BLOB:-'rk33/rk3308_miniloader_sd_nand_v1.13.bin'}"
-		BL31_BLOB="${BL31_BLOB:-'rk33/rk3308_bl31_v2.10.elf'}"
+		DDR_BLOB="${DDR_BLOB:-"rk33/rk3308_ddr_589MHz_uart2_m0_v1.26.bin"}"
+		MINILOADER_BLOB="${MINILOADER_BLOB:-"rk33/rk3308_miniloader_sd_nand_v1.13.bin"}"
+		BL31_BLOB="${BL31_BLOB:-"rk33/rk3308_bl31_v2.10.elf"}"
 	fi
 fi
 


### PR DESCRIPTION
#### rockchip64_common: default, but do not overwrite, `BL31_BLOB` and `MINILOADER_BLOB` (fixed!)

- rockchip64_common: default, but do not overwrite, `BL31_BLOB` and `MINILOADER_BLOB` (fixed!)
  - fixes 3c51abcd689c4da30687504c0859c660a911e21f