### PR TITLE
artifacts: fix hashing for u-boot and kernel

### DIFF
--- a/lib/functions/artifacts/artifact-kernel.sh
+++ b/lib/functions/artifacts/artifact-kernel.sh
@@ -97,7 +97,11 @@ function artifact_kernel_prepare_version() {
 	declare patches_hash="undetermined"
 	declare hash_files="undetermined"
 	display_alert "User patches directory for kernel" "${USERPATCHES_PATH}/kernel/${KERNELPATCHDIR}" "info"
-	calculate_hash_for_all_files_in_dirs "${SRC}/patch/kernel/${KERNELPATCHDIR}" "${USERPATCHES_PATH}/kernel/${KERNELPATCHDIR}"
+	declare -a kernel_patch_dirs=()
+	for patch_dir in ${KERNELPATCHDIR} ; do
+		kernel_patch_dirs+=( "${SRC}/patch/kernel/${patch_dir}" "${USERPATCHES_PATH}/kernel/${patch_dir}" )
+	done
+	calculate_hash_for_all_files_in_dirs "${kernel_patch_dirs[@]}"
 	patches_hash="${hash_files}"
 	declare kernel_patches_hash_short="${patches_hash:0:${short_hash_size}}"
 

--- a/lib/functions/artifacts/artifact-uboot.sh
+++ b/lib/functions/artifacts/artifact-uboot.sh
@@ -55,7 +55,20 @@ function artifact_uboot_prepare_version() {
 	# @TODO: this is even more grave in case of u-boot: v2022.10 has patches for many boards inside, gotta resolve.
 	declare patches_hash="undetermined"
 	declare hash_files="undetermined"
-	calculate_hash_for_all_files_in_dirs "${SRC}/patch/u-boot/${BOOTPATCHDIR}" "${USERPATCHES_PATH}/u-boot/${BOOTPATCHDIR}"
+	declare -a uboot_patch_dirs=()
+	for patch_dir in ${BOOTPATCHDIR} ; do
+		uboot_patch_dirs+=( "${SRC}/patch/u-boot/${patch_dir}" "${USERPATCHES_PATH}/u-boot/${patch_dir}" )
+	done
+
+	if [[ -n "${ATFSOURCE}" && "${ATFSOURCE}" != "none" ]]; then
+		uboot_patch_dirs+=( "${SRC}/patch/atf/${ATFPATCHDIR}" "${USERPATCHES_PATH}/atf/${ATFPATCHDIR}" )
+	fi
+
+	if [[ -n "${CRUSTCONFIG}" ]]; then
+		uboot_patch_dirs+=( "${SRC}/patch/crust/${CRUSTPATCHDIR}" "${USERPATCHES_PATH}/crust/${CRUSTPATCHDIR}" )
+	fi
+
+	calculate_hash_for_all_files_in_dirs "${uboot_patch_dirs[@]}"
 	patches_hash="${hash_files}"
 	declare uboot_patches_hash_short="${patches_hash:0:${short_hash_size}}"
 


### PR DESCRIPTION
# Description

The BOOTPATCHDIR and KERNELPATCHDIR variables can contain multiple directories names separated by spaces as explained in lib/functions/compilation/uboot-patching.sh and lib/functions/compilation/kernel-patching.sh respectively but when calculating hash we were treating it as a single directory name. Also as ATF and crust gets bundled in u-boot, the hash of their patches must also be considered to determine if we need to rebuild u-boot

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested by adding removing patches in patch/u-boot/u-boot-sunxi, patch/u-boot/u-boot-sunxi-crust and patch/crust directories and then compiling u-boot for nanopiduo2. U-boot recompiles as expected, which is not the current behavior.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
