### PR TITLE
allwinner: h3: h5: disable uart0 pinctrl when crust is enabled

### DIFF
--- a/patch/u-boot/u-boot-sunxi-crust/h3-h5-fix-pinctrl-err-19.patch
+++ b/patch/u-boot/u-boot-sunxi-crust/h3-h5-fix-pinctrl-err-19.patch
@@ -1,0 +1,314 @@
+From 14fceecc3dff39717a6d19b3db1238bac3a202f9 Mon Sep 17 00:00:00 2001
+From: Gunjan Gupta <viraniac@gmail.com>
+Date: Sat, 1 Jul 2023 14:39:12 +0000
+Subject: [PATCH] Fix error shown on boot by u-boot spl
+
+Since we added support for crust, u-boot spl shows the following
+error while booting
+
+ns16550_serial serial@1c28000: pinctrl_select_state_full: uclass_get_device_by_phandle_id: err=-19
+
+The error is benign and doesn't impact the functioning of the device.
+It happens because both crust and u-boot tries set pinctrl for uart0.
+This patch disables use of pinctrl by uboot for uart0 hence preventing
+the error
+---
+ arch/arm/dts/sun50i-h5-nanopi-neo-plus2.dts    | 2 --
+ arch/arm/dts/sun50i-h5-nanopi-neo2.dts         | 2 --
+ arch/arm/dts/sun50i-h5-nanopi-r1s-h5.dts       | 2 --
+ arch/arm/dts/sun50i-h5-orangepi-pc2.dts        | 2 --
+ arch/arm/dts/sun50i-h5-orangepi-prime.dts      | 2 --
+ arch/arm/dts/sun50i-h5-orangepi-zero-plus.dts  | 2 --
+ arch/arm/dts/sun50i-h5-orangepi-zero-plus2.dts | 2 --
+ arch/arm/dts/sun8i-h3-beelink-x2.dts           | 2 --
+ arch/arm/dts/sun8i-h3-mapleboard-mp130.dts     | 2 --
+ arch/arm/dts/sun8i-h3-nanopi-duo2.dts          | 2 --
+ arch/arm/dts/sun8i-h3-nanopi-neo-air.dts       | 2 --
+ arch/arm/dts/sun8i-h3-nanopi.dtsi              | 2 --
+ arch/arm/dts/sun8i-h3-orangepi-2.dts           | 2 --
+ arch/arm/dts/sun8i-h3-orangepi-lite.dts        | 2 --
+ arch/arm/dts/sun8i-h3-orangepi-one.dts         | 2 --
+ arch/arm/dts/sun8i-h3-orangepi-pc.dts          | 2 --
+ arch/arm/dts/sun8i-h3-orangepi-zero-plus2.dts  | 2 --
+ arch/arm/dts/sun8i-h3-rervision-dvk.dts        | 2 --
+ arch/arm/dts/sunxi-h3-h5-emlid-neutis.dtsi     | 2 --
+ arch/arm/dts/sunxi-libretech-all-h3-cc.dtsi    | 2 --
+ arch/arm/dts/sunxi-libretech-all-h3-it.dtsi    | 2 --
+ 21 files changed, 42 deletions(-)
+
+diff --git a/arch/arm/dts/sun50i-h5-nanopi-neo-plus2.dts b/arch/arm/dts/sun50i-h5-nanopi-neo-plus2.dts
+index 4c3921ac23..c3b59754d0 100644
+--- a/arch/arm/dts/sun50i-h5-nanopi-neo-plus2.dts
++++ b/arch/arm/dts/sun50i-h5-nanopi-neo-plus2.dts
+@@ -147,8 +147,6 @@
+ };
+ 
+ &uart0 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&uart0_pa_pins>;
+ 	status = "okay";
+ };
+ 
+diff --git a/arch/arm/dts/sun50i-h5-nanopi-neo2.dts b/arch/arm/dts/sun50i-h5-nanopi-neo2.dts
+index 05486cccee..9861485b73 100644
+--- a/arch/arm/dts/sun50i-h5-nanopi-neo2.dts
++++ b/arch/arm/dts/sun50i-h5-nanopi-neo2.dts
+@@ -102,8 +102,6 @@
+ };
+ 
+ &uart0 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&uart0_pa_pins>;
+ 	status = "okay";
+ };
+ 
+diff --git a/arch/arm/dts/sun50i-h5-nanopi-r1s-h5.dts b/arch/arm/dts/sun50i-h5-nanopi-r1s-h5.dts
+index a3e040da38..49f7ede681 100644
+--- a/arch/arm/dts/sun50i-h5-nanopi-r1s-h5.dts
++++ b/arch/arm/dts/sun50i-h5-nanopi-r1s-h5.dts
+@@ -184,8 +184,6 @@
+ };
+ 
+ &uart0 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&uart0_pa_pins>;
+ 	status = "okay";
+ };
+ 
+diff --git a/arch/arm/dts/sun50i-h5-orangepi-pc2.dts b/arch/arm/dts/sun50i-h5-orangepi-pc2.dts
+index ce3ae19e72..ce6d7830bf 100644
+--- a/arch/arm/dts/sun50i-h5-orangepi-pc2.dts
++++ b/arch/arm/dts/sun50i-h5-orangepi-pc2.dts
+@@ -203,8 +203,6 @@
+ };
+ 
+ &uart0 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&uart0_pa_pins>;
+ 	status = "okay";
+ };
+ 
+diff --git a/arch/arm/dts/sun50i-h5-orangepi-prime.dts b/arch/arm/dts/sun50i-h5-orangepi-prime.dts
+index d7f8bad6bb..115d7ce3c7 100644
+--- a/arch/arm/dts/sun50i-h5-orangepi-prime.dts
++++ b/arch/arm/dts/sun50i-h5-orangepi-prime.dts
+@@ -183,8 +183,6 @@
+ };
+ 
+ &uart0 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&uart0_pa_pins>;
+ 	status = "okay";
+ };
+ 
+diff --git a/arch/arm/dts/sun50i-h5-orangepi-zero-plus.dts b/arch/arm/dts/sun50i-h5-orangepi-zero-plus.dts
+index 7ec5ac850a..0017d4a9d5 100644
+--- a/arch/arm/dts/sun50i-h5-orangepi-zero-plus.dts
++++ b/arch/arm/dts/sun50i-h5-orangepi-zero-plus.dts
+@@ -123,8 +123,6 @@
+ };
+ 
+ &uart0 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&uart0_pa_pins>;
+ 	status = "okay";
+ };
+ 
+diff --git a/arch/arm/dts/sun50i-h5-orangepi-zero-plus2.dts b/arch/arm/dts/sun50i-h5-orangepi-zero-plus2.dts
+index 22530ace12..c932c79646 100644
+--- a/arch/arm/dts/sun50i-h5-orangepi-zero-plus2.dts
++++ b/arch/arm/dts/sun50i-h5-orangepi-zero-plus2.dts
+@@ -116,8 +116,6 @@
+ };
+ 
+ &uart0 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&uart0_pa_pins>;
+ 	status = "okay";
+ };
+ 
+diff --git a/arch/arm/dts/sun8i-h3-beelink-x2.dts b/arch/arm/dts/sun8i-h3-beelink-x2.dts
+index a6d38ecee1..0cf00e4ef8 100644
+--- a/arch/arm/dts/sun8i-h3-beelink-x2.dts
++++ b/arch/arm/dts/sun8i-h3-beelink-x2.dts
+@@ -220,8 +220,6 @@
+ };
+ 
+ &uart0 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&uart0_pa_pins>;
+ 	status = "okay";
+ };
+ 
+diff --git a/arch/arm/dts/sun8i-h3-mapleboard-mp130.dts b/arch/arm/dts/sun8i-h3-mapleboard-mp130.dts
+index f5c8ccc5b8..859daba1bd 100644
+--- a/arch/arm/dts/sun8i-h3-mapleboard-mp130.dts
++++ b/arch/arm/dts/sun8i-h3-mapleboard-mp130.dts
+@@ -118,8 +118,6 @@
+ };
+ 
+ &uart0 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&uart0_pa_pins>;
+ 	status = "okay";
+ };
+ 
+diff --git a/arch/arm/dts/sun8i-h3-nanopi-duo2.dts b/arch/arm/dts/sun8i-h3-nanopi-duo2.dts
+index 343b02b971..2edeba151c 100644
+--- a/arch/arm/dts/sun8i-h3-nanopi-duo2.dts
++++ b/arch/arm/dts/sun8i-h3-nanopi-duo2.dts
+@@ -138,8 +138,6 @@
+ };
+ 
+ &uart0 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&uart0_pa_pins>;
+ 	status = "okay";
+ };
+ 
+diff --git a/arch/arm/dts/sun8i-h3-nanopi-neo-air.dts b/arch/arm/dts/sun8i-h3-nanopi-neo-air.dts
+index 9e1a33f94c..b6c4218250 100644
+--- a/arch/arm/dts/sun8i-h3-nanopi-neo-air.dts
++++ b/arch/arm/dts/sun8i-h3-nanopi-neo-air.dts
+@@ -114,8 +114,6 @@
+ };
+ 
+ &uart0 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&uart0_pa_pins>;
+ 	status = "okay";
+ };
+ 
+diff --git a/arch/arm/dts/sun8i-h3-nanopi.dtsi b/arch/arm/dts/sun8i-h3-nanopi.dtsi
+index cf8413fba6..6cb3c37cff 100644
+--- a/arch/arm/dts/sun8i-h3-nanopi.dtsi
++++ b/arch/arm/dts/sun8i-h3-nanopi.dtsi
+@@ -101,8 +101,6 @@
+ };
+ 
+ &uart0 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&uart0_pa_pins>;
+ 	status = "okay";
+ };
+ 
+diff --git a/arch/arm/dts/sun8i-h3-orangepi-2.dts b/arch/arm/dts/sun8i-h3-orangepi-2.dts
+index f1f9dbead3..6b72d94aad 100644
+--- a/arch/arm/dts/sun8i-h3-orangepi-2.dts
++++ b/arch/arm/dts/sun8i-h3-orangepi-2.dts
+@@ -180,8 +180,6 @@
+ };
+ 
+ &uart0 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&uart0_pa_pins>;
+ 	status = "okay";
+ };
+ 
+diff --git a/arch/arm/dts/sun8i-h3-orangepi-lite.dts b/arch/arm/dts/sun8i-h3-orangepi-lite.dts
+index 305b34a321..b7dec4a38a 100644
+--- a/arch/arm/dts/sun8i-h3-orangepi-lite.dts
++++ b/arch/arm/dts/sun8i-h3-orangepi-lite.dts
+@@ -157,8 +157,6 @@
+ };
+ 
+ &uart0 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&uart0_pa_pins>;
+ 	status = "okay";
+ };
+ 
+diff --git a/arch/arm/dts/sun8i-h3-orangepi-one.dts b/arch/arm/dts/sun8i-h3-orangepi-one.dts
+index 59f6f6d5e7..85f48a92be 100644
+--- a/arch/arm/dts/sun8i-h3-orangepi-one.dts
++++ b/arch/arm/dts/sun8i-h3-orangepi-one.dts
+@@ -167,8 +167,6 @@
+ };
+ 
+ &uart0 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&uart0_pa_pins>;
+ 	status = "okay";
+ };
+ 
+diff --git a/arch/arm/dts/sun8i-h3-orangepi-pc.dts b/arch/arm/dts/sun8i-h3-orangepi-pc.dts
+index b96e015f54..36629fa215 100644
+--- a/arch/arm/dts/sun8i-h3-orangepi-pc.dts
++++ b/arch/arm/dts/sun8i-h3-orangepi-pc.dts
+@@ -206,8 +206,6 @@
+ };
+ 
+ &uart0 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&uart0_pa_pins>;
+ 	status = "okay";
+ };
+ 
+diff --git a/arch/arm/dts/sun8i-h3-orangepi-zero-plus2.dts b/arch/arm/dts/sun8i-h3-orangepi-zero-plus2.dts
+index 561ea1d2f8..b75b303783 100644
+--- a/arch/arm/dts/sun8i-h3-orangepi-zero-plus2.dts
++++ b/arch/arm/dts/sun8i-h3-orangepi-zero-plus2.dts
+@@ -156,8 +156,6 @@
+ };
+ 
+ &uart0 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&uart0_pa_pins>;
+ 	status = "okay";
+ };
+ 
+diff --git a/arch/arm/dts/sun8i-h3-rervision-dvk.dts b/arch/arm/dts/sun8i-h3-rervision-dvk.dts
+index 4738f3a9ef..9f1f54d7b7 100644
+--- a/arch/arm/dts/sun8i-h3-rervision-dvk.dts
++++ b/arch/arm/dts/sun8i-h3-rervision-dvk.dts
+@@ -99,8 +99,6 @@
+ };
+ 
+ &uart0 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&uart0_pa_pins>;
+ 	status = "okay";
+ };
+ 
+diff --git a/arch/arm/dts/sunxi-h3-h5-emlid-neutis.dtsi b/arch/arm/dts/sunxi-h3-h5-emlid-neutis.dtsi
+index 60804b0e6c..c3b8ba4df5 100644
+--- a/arch/arm/dts/sunxi-h3-h5-emlid-neutis.dtsi
++++ b/arch/arm/dts/sunxi-h3-h5-emlid-neutis.dtsi
+@@ -110,8 +110,6 @@
+ };
+ 
+ &uart0 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&uart0_pa_pins>;
+ 	status = "okay";
+ };
+ 
+diff --git a/arch/arm/dts/sunxi-libretech-all-h3-cc.dtsi b/arch/arm/dts/sunxi-libretech-all-h3-cc.dtsi
+index 89731bb34c..3f243a07f9 100644
+--- a/arch/arm/dts/sunxi-libretech-all-h3-cc.dtsi
++++ b/arch/arm/dts/sunxi-libretech-all-h3-cc.dtsi
+@@ -217,8 +217,6 @@
+ };
+ 
+ &uart0 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&uart0_pa_pins>;
+ 	status = "okay";
+ };
+ 
+diff --git a/arch/arm/dts/sunxi-libretech-all-h3-it.dtsi b/arch/arm/dts/sunxi-libretech-all-h3-it.dtsi
+index 50d328c2a8..84820443e2 100644
+--- a/arch/arm/dts/sunxi-libretech-all-h3-it.dtsi
++++ b/arch/arm/dts/sunxi-libretech-all-h3-it.dtsi
+@@ -164,8 +164,6 @@
+ };
+ 
+ &uart0 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&uart0_pa_pins>;
+ 	status = "okay";
+ };
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
# Description

When crust is enabled on H3 and H5 boards, when booting, the following error is displayed during u-boot spl stage.

```
ns16550_serial serial@1c28000: pinctrl_select_state_full: uclass_get_device_by_phandle_id: err=-19
```
The error is quite benign and doesn't impact functionality in any way. Still for user experience sake, this PR fixes the same.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Booted on Nanopiduo2 and verified that error is no longer produced

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
