### PR TITLE
patching_utils: fix error when running with PATCHES_TO_GIT=yes REWRITE_PATCHES=yes

### DIFF
--- a/lib/tools/common/patching_utils.py
+++ b/lib/tools/common/patching_utils.py
@@ -238,7 +238,7 @@ class PatchFileInDir:
 		# The original file is overwritten.
 		output_file = self.full_file_path()
 		log.info(f"Rewriting {output_file} with new patches...")
-		with open(output_file, "w") as f:
+		with open(output_file, "wb") as f:
 			for patch in patches:
 				log.info(f"Writing patch {patch.counter} to {output_file}...")
 				f.write(patch.rewritten_patch)
@@ -797,7 +797,7 @@ def export_commit_as_patch(repo: git.Repo, commit: str):
 		stderr=subprocess.PIPE,
 		check=False)
 	# read the output of the patch command
-	stdout_output = proc.stdout.decode("utf-8")
+	stdout_output = proc.stdout
 	stderr_output = proc.stderr.decode("utf-8")
 	# Check if the exit code is not zero and bomb
 	if proc.returncode != 0:


### PR DESCRIPTION
# Description

Some of the wireless patches contain non-utf-8 compliant characters which makes patching_utils to fail when running with `PATCHES_TO_GIT=yes REWRITE_PATCHES=yes`. Treat format-patch output as binary output thereby fixing the error.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Ran `./compile.sh kernel-patch BOARD=nanopiduo2 BRANCH=edge PATCHES_TO_GIT=yes REWRITE_PATCHES=yes` and made sure it succeeds

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
