### PR TITLE
allwinner: patch: kernel: series files cleanup

### DIFF
--- a/patch/kernel/archive/sunxi-5.15/series.armbian
+++ b/patch/kernel/archive/sunxi-5.15/series.armbian
@@ -5,7 +5,7 @@
 ############################################################################
 	patches.armbian/drv-bluetooth-btrtl-Add-rtl8822cs-hci-ver-0008.patch
 	patches.armbian/drv-bluetooth-hci_h5-power-reset-via-gpio-in-h5_btrt.patch
-	patches.armbian/Revert-net-Remove-net-ipx.h-and-uapi-linux-ipx.h-hea.patch
+-	patches.armbian/Revert-net-Remove-net-ipx.h-and-uapi-linux-ipx.h-hea.patch
 	patches.armbian/Doc-dt-bindings-rtc-sun6i-Add-H616-compatible-string.patch
 	patches.armbian/Doc-dt-bindings-net-sun8i-emac-Add-H616-compatible-s.patch
 	patches.armbian/Doc-dt-bindings-arm-sunxi-Add-OrangePi-Zero2-binding.patch

--- a/patch/kernel/archive/sunxi-5.15/series.conf
+++ b/patch/kernel/archive/sunxi-5.15/series.conf
@@ -475,7 +475,7 @@
 ############################################################################
 	patches.armbian/drv-bluetooth-btrtl-Add-rtl8822cs-hci-ver-0008.patch
 	patches.armbian/drv-bluetooth-hci_h5-power-reset-via-gpio-in-h5_btrt.patch
-	patches.armbian/Revert-net-Remove-net-ipx.h-and-uapi-linux-ipx.h-hea.patch
+-	patches.armbian/Revert-net-Remove-net-ipx.h-and-uapi-linux-ipx.h-hea.patch
 	patches.armbian/Doc-dt-bindings-rtc-sun6i-Add-H616-compatible-string.patch
 	patches.armbian/Doc-dt-bindings-net-sun8i-emac-Add-H616-compatible-s.patch
 	patches.armbian/Doc-dt-bindings-arm-sunxi-Add-OrangePi-Zero2-binding.patch

--- a/patch/kernel/archive/sunxi-6.1/series.armbian
+++ b/patch/kernel/archive/sunxi-6.1/series.armbian
@@ -4,7 +4,7 @@
 #	git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git
 #
 	patches.armbian/drv-bluetooth-btrtl-Add-rtl8822cs-hci-ver-0008.patch
-	patches.armbian/Revert-net-Remove-net-ipx.h-and-uapi-linux-ipx.h-header-files.patch
+-	patches.armbian/Revert-net-Remove-net-ipx.h-and-uapi-linux-ipx.h-header-files.patch
 	patches.armbian/Doc-dt-bindings-usb-add-binding-for-DWC3-controller-on-Allwinne.patch
 	patches.armbian/drv-mfd-Add-support-for-AC200.patch
 	patches.armbian/drv-pinctrl-pinctrl-sun50i-a64-disable_strict_mode.patch

--- a/patch/kernel/archive/sunxi-6.1/series.conf
+++ b/patch/kernel/archive/sunxi-6.1/series.conf
@@ -408,7 +408,7 @@
 #
 ################################################################################
 	patches.armbian/drv-bluetooth-btrtl-Add-rtl8822cs-hci-ver-0008.patch
-	patches.armbian/Revert-net-Remove-net-ipx.h-and-uapi-linux-ipx.h-header-files.patch
+-	patches.armbian/Revert-net-Remove-net-ipx.h-and-uapi-linux-ipx.h-header-files.patch
 	patches.armbian/Doc-dt-bindings-usb-add-binding-for-DWC3-controller-on-Allwinne.patch
 	patches.armbian/drv-mfd-Add-support-for-AC200.patch
 	patches.armbian/drv-pinctrl-pinctrl-sun50i-a64-disable_strict_mode.patch

--- a/patch/kernel/archive/sunxi-6.1/series.megous
+++ b/patch/kernel/archive/sunxi-6.1/series.megous
@@ -57,11 +57,11 @@
 	patches.megous/media-ov5640-Don-t-powerup-the-sensor-during-driver-probe.patch
 	patches.megous/media-ov5640-set-default-ae-target-lower.patch
 	patches.megous/media-ov5640-Improve-error-reporting.patch
-	patches.megous/media-ov5640-Implement-autofocus.patch
+-	patches.megous/media-ov5640-Implement-autofocus.patch
 	patches.megous/net-stmmac-sun8i-Use-devm_regulator_get-for-PHY-regulator.patch
-	patches.megous/media-ov5640-Improve-firmware-load-time.patch
+-	patches.megous/media-ov5640-Improve-firmware-load-time.patch
 	patches.megous/net-stmmac-sun8i-Rename-PHY-regulator-variable-to-regulator_phy.patch
-	patches.megous/media-ov5640-Fix-focus-commands-blocking-until-complete.patch
+-	patches.megous/media-ov5640-Fix-focus-commands-blocking-until-complete.patch
 	patches.megous/iio-adc-sun4i-gpadc-iio-Allow-to-use-sun5i-a13-gpadc-iio-from-D.patch
 	patches.megous/mtd-spi-nor-Add-regulator-support.patch
 	patches.megous/input-cyttsp4-De-obfuscate-platform-data-for-keys.patch
@@ -169,15 +169,15 @@
 	patches.megous/mmc-sunxi-mmc-Remove-runtime-PM.patch
 	patches.megous/usb-quirks-Add-USB_QUIRK_RESET-for-Quectel-EG25G-Modem.patch
 	patches.megous/arm64-dts-pinephone-Add-reboot-mode-driver.patch
-	patches.megous/arm64-dts-rk3399-pinebook-pro-Fix-USB-PD-charging.patch
-	patches.megous/arm64-dts-rk3399-pinebook-pro-Improve-Type-C-support-on-Pineboo.patch
-	patches.megous/arm64-dts-rk3399-pinebook-pro-Remove-redundant-pinctrl-properti.patch
-	patches.megous/arm64-dts-rk3399-pinebook-pro-Remove-unused-features.patch
-	patches.megous/arm64-dts-rk3399-pinebook-pro-Don-t-allow-usb2-phy-driver-to-up.patch
-	patches.megous/arm64-dts-rockchip-rk3399-pinebook-pro-Support-both-Type-C-plug.patch
+-	patches.megous/arm64-dts-rk3399-pinebook-pro-Fix-USB-PD-charging.patch
+-	patches.megous/arm64-dts-rk3399-pinebook-pro-Improve-Type-C-support-on-Pineboo.patch
+-	patches.megous/arm64-dts-rk3399-pinebook-pro-Remove-redundant-pinctrl-properti.patch
+-	patches.megous/arm64-dts-rk3399-pinebook-pro-Remove-unused-features.patch
+-	patches.megous/arm64-dts-rk3399-pinebook-pro-Don-t-allow-usb2-phy-driver-to-up.patch
+-	patches.megous/arm64-dts-rockchip-rk3399-pinebook-pro-Support-both-Type-C-plug.patch
 	patches.megous/ASoC-codec-es8316-DAC-Soft-Ramp-Rate-is-just-a-2-bit-control.patch
 	patches.megous/misc-modem-power-Power-manager-for-modems.patch
-	patches.megous/arm64-dts-rk3399-pinebook-pro-Fix-codec-frequency-after-boot.patch
+-	patches.megous/arm64-dts-rk3399-pinebook-pro-Fix-codec-frequency-after-boot.patch
 	patches.megous/media-cedrus-Fix-missing-cleanup-in-error-path.patch
 	patches.megous/media-cedrus-Fix-failure-to-clean-up-hardware-on-probe-failure.patch
 	patches.megous/Revert-drm-sun4i-lvds-Invert-the-LVDS-polarity.patch
@@ -188,9 +188,9 @@
 -	patches.megous/Bluetooth-Add-new-quirk-for-broken-local-ext-features-max_page.patch
 	patches.megous/rtw89-Fix-crash-by-loading-compressed-firmware-file.patch
 -	patches.megous/Bluetooth-btrtl-add-support-for-the-RTL8723CS.patch
-	patches.megous/drm-rockchip-Fix-panic-on-reboot-when-DRM-device-fails-to-bind.patch
+-	patches.megous/drm-rockchip-Fix-panic-on-reboot-when-DRM-device-fails-to-bind.patch
 -	patches.megous/Bluetooth-hci_h5-Add-support-for-binding-RTL8723CS-with-device-.patch
-	patches.megous/arm64-dts-rockchip-rk356x-Fix-PCIe-register-map-and-ranges.patch
+-	patches.megous/arm64-dts-rockchip-rk356x-Fix-PCIe-register-map-and-ranges.patch
 -	patches.megous/bluetooth-h5-Don-t-re-initialize-rtl8723cs-on-resume.patch
 	patches.megous/drm-sun4i-Unify-sun8i_-_layer-structs.patch
 	patches.megous/drm-sun4i-Add-more-parameters-to-sunxi_engine-commit-callback.patch
@@ -270,44 +270,44 @@
 	patches.megous/Make-microbuttons-on-Orange-Pi-PC-and-PC-2-work-as-power-off-bu.patch
 	patches.megous/arm64-allwinner-dts-a64-enable-K101-IM2BYL02-panel-for-PineTab.patch
 	patches.megous/ARM-dts-sun8i-a83t-Add-MBUS-node.patch
-	patches.megous/arm64-dts-rk3399-Disable-debug-nodes.patch
-	patches.megous/arm64-dts-rk3399-Add-reboot-mode-driver.patch
-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-support-for-volume-keys.patch
-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-support-for-vibrator.patch
-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-support-for-LEDs.patch
-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-SPI-flash.patch
-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-internal-display-support.patch
-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-BSP-battery-driver-support.patch
+-	patches.megous/arm64-dts-rk3399-Disable-debug-nodes.patch
+-	patches.megous/arm64-dts-rk3399-Add-reboot-mode-driver.patch
+-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-support-for-volume-keys.patch
+-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-support-for-vibrator.patch
+-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-support-for-LEDs.patch
+-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-SPI-flash.patch
+-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-internal-display-support.patch
+-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-BSP-battery-driver-support.patch
 	patches.megous/Add-support-for-my-private-Sapomat-device.patch
-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-WiFi-Bluetooth-support.patch
-	patches.megous/Add-README.md-with-information-and-u-boot-patches.patch
-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-5V-power-supply.patch
+-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-WiFi-Bluetooth-support.patch
+-	patches.megous/Add-README.md-with-information-and-u-boot-patches.patch
+-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-5V-power-supply.patch
 	patches.megous/ARM-dts-sun8i-h3-orange-pi-one-Enable-all-gpio-header-UARTs.patch
-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-sound-support.patch
+-	patches.megous/arm64-dts-rk3399-pinephone-pro-Add-sound-support.patch
 	patches.megous/Defconfigs-for-all-my-devices.patch
-	patches.megous/arm64-dts-pinephone-pro-Add-Type-C-port-support.patch
-	patches.megous/arm64-dts-pinephone-pro-Add-camera-support.patch
-	patches.megous/arm64-dts-pinephone-pro-Add-modem-support.patch
-	patches.megous/arm64-dts-pinephone-pro-Add-light-proximity-sensor-support.patch
-	patches.megous/clk-rk3399-Export-SCLK_CIF_OUT_SRC-to-device-tree.patch
-	patches.megous/arm64-dts-pinephone-pro-Add-accelerometer-sensor-support.patch
-	patches.megous/clk-rk3399-Allow-to-set-rate-of-clk_i2s0_frac-s-parent.patch
-	patches.megous/arm64-dts-pinephone-pro-Add-magnetometer-sensor-support.patch
-	patches.megous/clk-rockchip-rk3399-Don-t-allow-to-reparent-dclk_vop0-to-frac-c.patch
-	patches.megous/arm64-dts-pinephone-pro-Enable-POGO-pins-I2C.patch
+-	patches.megous/arm64-dts-pinephone-pro-Add-Type-C-port-support.patch
+-	patches.megous/arm64-dts-pinephone-pro-Add-camera-support.patch
+-	patches.megous/arm64-dts-pinephone-pro-Add-modem-support.patch
+-	patches.megous/arm64-dts-pinephone-pro-Add-light-proximity-sensor-support.patch
+-	patches.megous/clk-rk3399-Export-SCLK_CIF_OUT_SRC-to-device-tree.patch
+-	patches.megous/arm64-dts-pinephone-pro-Add-accelerometer-sensor-support.patch
+-	patches.megous/clk-rk3399-Allow-to-set-rate-of-clk_i2s0_frac-s-parent.patch
+-	patches.megous/arm64-dts-pinephone-pro-Add-magnetometer-sensor-support.patch
+-	patches.megous/clk-rockchip-rk3399-Don-t-allow-to-reparent-dclk_vop0-to-frac-c.patch
+-	patches.megous/arm64-dts-pinephone-pro-Enable-POGO-pins-I2C.patch
 	patches.megous/sdhci-arasan-Add-runtime-PM-support.patch
-	patches.megous/arm64-dts-pinephone-pro-Add-pinephone-keyboard-support.patch
-	patches.megous/mmc-dw-mmc-rockchip-fix-sdmmc-after-soft-reboot.patch
-	patches.megous/arm64-dts-rk3399-pinephone-pro-Use-unused-GPLL-for-VOPs-DCLK.patch
+-	patches.megous/arm64-dts-pinephone-pro-Add-pinephone-keyboard-support.patch
+-	patches.megous/mmc-dw-mmc-rockchip-fix-sdmmc-after-soft-reboot.patch
+-	patches.megous/arm64-dts-rk3399-pinephone-pro-Use-unused-GPLL-for-VOPs-DCLK.patch
 	patches.megous/mtd-spi-nor-gigadevice-add-support-for-gd25lq128e.patch
-	patches.megous/spi-rockchip-Fix-runtime-PM-and-other-issues.patch
-	patches.megous/drm-rockchip-dw-mipi-dsi-Fix-data-rate-calculation.patch
+-	patches.megous/spi-rockchip-Fix-runtime-PM-and-other-issues.patch
+-	patches.megous/drm-rockchip-dw-mipi-dsi-Fix-data-rate-calculation.patch
 	patches.megous/drm-bridge-dw-mipi-dsi-Fix-enable-disable-of-dsi-controller.patch
 	patches.megous/drm-panel-hx8394-Add-driver-for-HX8394-based-HannStar-HSD060BHW.patch
 	patches.megous/drm-panel-hx8394-Improve-the-panel-driver-make-it-work-with-DSI.patch
 	patches.megous/drm-panel-hx8394-Fix-mode-to-have-refresh-rate-of-60-Hz.patch
 	patches.megous/drm-panel-hx8394-Add-mode-init-sequence-update-via-firmware-loa.patch
-	patches.megous/drm-rockchip-cdn-dp-Disable-CDN-DP-on-disconnect.patch
+-	patches.megous/drm-rockchip-cdn-dp-Disable-CDN-DP-on-disconnect.patch
 	patches.megous/input-touchscreen-goodix-Respect-IRQ-flags-from-DT-when-asked-t.patch
 	patches.megous/power-rk818-Configure-rk808-clkout2-function.patch
 	patches.megous/power-supply-rk818-battery-Add-battery-driver-for-RK818.patch
@@ -365,8 +365,8 @@
 	patches.megous/media-i2c-ov8858-Add-support-for-digital-gain-control.patch
 	patches.megous/media-i2c-ov8858-Use-default-subdev-name.patch
 	patches.megous/media-rkisp1-Allow-higher-input-resolution.patch
-	patches.megous/phy-phy-rockchip-inno-usb2-Decrease-delay-between-port-init-and.patch
-	patches.megous/phy-rockchip-inno-usb2-More-robust-charger-detection-extcon-upd.patch
+-	patches.megous/phy-phy-rockchip-inno-usb2-Decrease-delay-between-port-init-and.patch
+-	patches.megous/phy-rockchip-inno-usb2-More-robust-charger-detection-extcon-upd.patch
 	patches.megous/usb-typec-altmodes-displayport-Respect-DP_CAP_RECEPTACLE-bit.patch
 	patches.megous/usb-typec-fusb302-Slightly-increase-wait-time-for-BC1.2-result.patch
 	patches.megous/usb-typec-fusb302-Set-the-current-before-enabling-pullups.patch
@@ -383,13 +383,13 @@
 	patches.megous/leds-sgm3140-Add-missing-timer-cleanup-and-flash-gpio-control.patch
 	patches.megous/usb-dwc3-Track-the-power-state-of-usb3_generic_phy.patch
 	patches.megous/usb-dwc3-Add-support-for-snps-usb3-phy-reset-quirk.patch
-	patches.megous/ASoC-rockchip-Fix-doubling-of-playback-speed-after-system-sleep.patch
+-	patches.megous/ASoC-rockchip-Fix-doubling-of-playback-speed-after-system-sleep.patch
 	patches.megous/usb-typec-tcpm-Unregister-altmodes-before-registering-new-ones.patch
-	patches.megous/drm-rockchip-Don-t-require-MIPI-DSI-device-when-it-s-used-for-I.patch
+-	patches.megous/drm-rockchip-Don-t-require-MIPI-DSI-device-when-it-s-used-for-I.patch
 	patches.megous/ASoC-rt5640-Allow-configuration-of-LOUT-to-mono-differential-mo.patch
 	patches.megous/dt-bindings-sound-rt5640-Allow-to-describe-how-LOUT-is-wired.patch
 	patches.megous/ASoC-codec-rt5640-Fix-output-mixer-input-channel-list.patch
 	patches.megous/ASoC-codec-rt5640-Fix-hpout-restore-when-lout-is-enabled.patch
 	patches.megous/ASoC-codec-rt5640-Resolve-failure-to-set-DMIC-clock-after-playb.patch
 	patches.megous/media-ov5640-Fix-sensor-probe-with-the-anti-click-patch.patch
-	patches.megous/arm64-dts-rockchip-rk3399-pinebook-pro-Fix-VDO-display-output.patch
+-	patches.megous/arm64-dts-rockchip-rk3399-pinebook-pro-Fix-VDO-display-output.patch

--- a/patch/kernel/archive/sunxi-6.2/series.armbian
+++ b/patch/kernel/archive/sunxi-6.2/series.armbian
@@ -1,19 +1,10 @@
-#
-###########        Fixes applied after megous patches        ###################
-#
-	patches.fixes/Fix-ISO-C90-forbids-mixed-declarations.patch
-	patches.fixes/Fix-warning-multi-line-comment.patch
-	patches.fixes/Fix-warning-unused-variable-delay_us.patch
-	patches.fixes/Fix-depends-only-ARM-eInk-display-FB.patch
-	patches.fixes/Fix-duplicate-nodes-for-sun50i-h5-orangepi-pc2.patch
-
 ################################################################################
 #
 #                  Armbian patches
 #
 ################################################################################
 	patches.armbian/drv-bluetooth-btrtl-Add-rtl8822cs-hci-ver-0008.patch
-	patches.armbian/Revert-net-Remove-net-ipx.h-and-uapi-linux-ipx.h-header-files.patch
+-	patches.armbian/Revert-net-Remove-net-ipx.h-and-uapi-linux-ipx.h-header-files.patch
 	patches.armbian/Doc-dt-bindings-usb-add-binding-for-DWC3-controller-on-Allwinne.patch
 	patches.armbian/drv-mfd-Add-support-for-AC200.patch
 	patches.armbian/drv-pinctrl-pinctrl-sun50i-a64-disable_strict_mode.patch

--- a/patch/kernel/archive/sunxi-6.2/series.conf
+++ b/patch/kernel/archive/sunxi-6.2/series.conf
@@ -409,7 +409,7 @@
 #
 ################################################################################
 	patches.armbian/drv-bluetooth-btrtl-Add-rtl8822cs-hci-ver-0008.patch
-	patches.armbian/Revert-net-Remove-net-ipx.h-and-uapi-linux-ipx.h-header-files.patch
+-	patches.armbian/Revert-net-Remove-net-ipx.h-and-uapi-linux-ipx.h-header-files.patch
 	patches.armbian/Doc-dt-bindings-usb-add-binding-for-DWC3-controller-on-Allwinne.patch
 	patches.armbian/drv-mfd-Add-support-for-AC200.patch
 	patches.armbian/drv-pinctrl-pinctrl-sun50i-a64-disable_strict_mode.patch

--- a/patch/kernel/archive/sunxi-6.2/series.megous
+++ b/patch/kernel/archive/sunxi-6.2/series.megous
@@ -49,9 +49,9 @@
 	patches.megous/media-ov5640-Don-t-powerup-the-sensor-during-driver-probe.patch
 	patches.megous/media-ov5640-set-default-ae-target-lower.patch
 	patches.megous/media-ov5640-Improve-error-reporting.patch
-	patches.megous/media-ov5640-Implement-autofocus.patch
-	patches.megous/media-ov5640-Improve-firmware-load-time.patch
-	patches.megous/media-ov5640-Fix-focus-commands-blocking-until-complete.patch
+-	patches.megous/media-ov5640-Implement-autofocus.patch
+-	patches.megous/media-ov5640-Improve-firmware-load-time.patch
+-	patches.megous/media-ov5640-Fix-focus-commands-blocking-until-complete.patch
 -	patches.megous/media-ov5640-Report-analogue-gain-as-supported-for-libcamera.patch
 	patches.megous/media-ov5640-Add-read-only-property-for-vblank.patch
 	patches.megous/media-sun6i-csi-capture-Use-subdev-operation-to-access-bridge-f.patch
@@ -145,9 +145,9 @@
 -	patches.megous/8723cs-Adapt-to-API-changes-in-stable-5.19.2-and-6.0.patch
 -	patches.megous/8723cs-Port-to-6.0.patch
 -	patches.megous/8723cs-Port-to-6.1.patch
+-	patches.megous/8723cs-Port-to-6.1-rc1.patch
 	patches.megous/tty-serial-8250-dw-Use-fifo-size-from-DTS.patch
 	patches.megous/arm64-dts-sun50i-a64-Set-fifo-size-for-uarts.patch
--	patches.megous/8723cs-Port-to-6.1-rc1.patch
 	patches.megous/ARM-dts-sun8i-a83t-Set-fifo-size-for-uarts.patch
 	patches.megous/Mark-some-slow-drivers-for-async-probe-with-PROBE_PREFER_ASYNCH.patch
 	patches.megous/arm64-xor-Select-32regs-without-benchmark-to-speed-up-boot.patch

--- a/patch/kernel/archive/sunxi-6.3/series.armbian
+++ b/patch/kernel/archive/sunxi-6.3/series.armbian
@@ -1,19 +1,10 @@
-#
-###########        Fixes applied after megous patches        ###################
-#
-	patches.fixes/Fix-ISO-C90-forbids-mixed-declarations.patch
-	patches.fixes/Fix-warning-multi-line-comment.patch
-	patches.fixes/Fix-warning-unused-variable-delay_us.patch
-	patches.fixes/Fix-depends-only-ARM-eInk-display-FB.patch
-	patches.fixes/Fix-duplicate-nodes-for-sun50i-h5-orangepi-pc2.patch
-
 ################################################################################
 #
 #                  Armbian patches
 #
 ################################################################################
 	patches.armbian/drv-bluetooth-btrtl-Add-rtl8822cs-hci-ver-0008.patch
-	patches.armbian/Revert-net-Remove-net-ipx.h-and-uapi-linux-ipx.h-header-files.patch
+-	patches.armbian/Revert-net-Remove-net-ipx.h-and-uapi-linux-ipx.h-header-files.patch
 	patches.armbian/Doc-dt-bindings-usb-add-binding-for-DWC3-controller-on-Allwinne.patch
 	patches.armbian/drv-mfd-Add-support-for-AC200.patch
 	patches.armbian/drv-pinctrl-pinctrl-sun50i-a64-disable_strict_mode.patch

--- a/patch/kernel/archive/sunxi-6.3/series.conf
+++ b/patch/kernel/archive/sunxi-6.3/series.conf
@@ -421,7 +421,7 @@
 #
 ################################################################################
 	patches.armbian/drv-bluetooth-btrtl-Add-rtl8822cs-hci-ver-0008.patch
-	patches.armbian/Revert-net-Remove-net-ipx.h-and-uapi-linux-ipx.h-header-files.patch
+-	patches.armbian/Revert-net-Remove-net-ipx.h-and-uapi-linux-ipx.h-header-files.patch
 	patches.armbian/Doc-dt-bindings-usb-add-binding-for-DWC3-controller-on-Allwinne.patch
 	patches.armbian/drv-mfd-Add-support-for-AC200.patch
 	patches.armbian/drv-pinctrl-pinctrl-sun50i-a64-disable_strict_mode.patch

--- a/patch/kernel/archive/sunxi-6.4/series.armbian
+++ b/patch/kernel/archive/sunxi-6.4/series.armbian
@@ -1,19 +1,10 @@
-#
-###########        Fixes applied after megous patches        ###################
-#
-	patches.fixes/Fix-ISO-C90-forbids-mixed-declarations.patch
-	patches.fixes/Fix-warning-multi-line-comment.patch
-	patches.fixes/Fix-warning-unused-variable-delay_us.patch
-	patches.fixes/Fix-depends-only-ARM-eInk-display-FB.patch
-	patches.fixes/Fix-duplicate-nodes-for-sun50i-h5-orangepi-pc2.patch
-
 ################################################################################
 #
 #                  Armbian patches
 #
 ################################################################################
 	patches.armbian/drv-bluetooth-btrtl-Add-rtl8822cs-hci-ver-0008.patch
-	patches.armbian/Revert-net-Remove-net-ipx.h-and-uapi-linux-ipx.h-header-files.patch
+-	patches.armbian/Revert-net-Remove-net-ipx.h-and-uapi-linux-ipx.h-header-files.patch
 	patches.armbian/Doc-dt-bindings-usb-add-binding-for-DWC3-controller-on-Allwinne.patch
 	patches.armbian/drv-mfd-Add-support-for-AC200.patch
 	patches.armbian/drv-pinctrl-pinctrl-sun50i-a64-disable_strict_mode.patch

--- a/patch/kernel/archive/sunxi-6.4/series.conf
+++ b/patch/kernel/archive/sunxi-6.4/series.conf
@@ -484,7 +484,7 @@
 #
 ################################################################################
 	patches.armbian/drv-bluetooth-btrtl-Add-rtl8822cs-hci-ver-0008.patch
-	patches.armbian/Revert-net-Remove-net-ipx.h-and-uapi-linux-ipx.h-header-files.patch
+-	patches.armbian/Revert-net-Remove-net-ipx.h-and-uapi-linux-ipx.h-header-files.patch
 	patches.armbian/Doc-dt-bindings-usb-add-binding-for-DWC3-controller-on-Allwinne.patch
 	patches.armbian/drv-mfd-Add-support-for-AC200.patch
 	patches.armbian/drv-pinctrl-pinctrl-sun50i-a64-disable_strict_mode.patch


### PR DESCRIPTION
# Description

Does following cleanup for series.* files from `patch/kernel/archive/sunxi-*/`
- Disabled `Revert-net-Remove-net-ipx.h-and-uapi-linux-ipx.h-header-files.patch` as its also applied from patch/misc
- For 6.2+, series.armbian file also had list of patches from patches.fixes directory. As we have series.fixes file for that, removed the same from series. armbian
- Some patches were disabled in series.conf file, but were not disabled in the corresponding series.* files. Synced the same so that concatenating series.megous, series.fixes and series.armbian file produces matching series.conf file.

These are just cosmetic fixes/cleanup, doesn't change anything on code level or functionality wise

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
