### PR TITLE
update rk3588 blobs for opi5 and nanopi r6s

### DIFF
--- a/config/boards/nanopi-r6s.conf
+++ b/config/boards/nanopi-r6s.conf
@@ -12,6 +12,8 @@ BOOT_SCENARIO="spl-blobs"
 IMAGE_PARTITION_TABLE="gpt"
 SKIP_BOOTSPLASH="yes" # Skip boot splash patch, conflicts with CONFIG_VT=yes
 BOOTFS_TYPE="fat"
+DDR_BLOB='rk35/rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.11.bin'
+BL31_BLOB='rk35/rk3588_bl31_v1.38.elf'
 
 function post_family_tweaks__nanopir6s_naming_audios() {
 	display_alert "$BOARD" "Renaming nanopir6s audio" "info"

--- a/config/boards/orangepi5.conf
+++ b/config/boards/orangepi5.conf
@@ -15,6 +15,8 @@ BOOT_SPI_RKSPI_LOADER="yes"
 IMAGE_PARTITION_TABLE="gpt"
 SKIP_BOOTSPLASH="yes" # Skip boot splash patch, conflicts with CONFIG_VT=yes
 BOOTFS_TYPE="fat"
+DDR_BLOB='rk35/rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.11.bin'
+BL31_BLOB='rk35/rk3588_bl31_v1.38.elf'
 
 declare -g BLUETOOTH_HCIATTACH_PARAMS="-s 115200 /dev/ttyS9 bcm43xx 1500000" # For the bluetooth-hciattach extension
 enable_extension "bluetooth-hciattach"                                       # Enable the bluetooth-hciattach extension
@@ -79,5 +81,3 @@ function post_family_config__orangepi5_use_vendor_uboot() {
 	BOOTBRANCH='branch:v2017.09-rk3588'
 	BOOTPATCHDIR="legacy"
 }
-
-


### PR DESCRIPTION
# Description
Update ddr and bl31 blobs for opi5 and nanopi r6s

Jira reference number [AR-9999]

# How Has This Been Tested?
- [x] Built and booted R6S fine
- [x] Orange Pi 5 was already working fine with https://github.com/armbian/build/commit/084fba8524937298a05fea55076ced540924cd22

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
