### PR TITLE
`mekotronics`: `post_family_config()` hook is too late to change `DDR_BLOB` and `BL31_BLOB`, move to board-scope variables

### DIFF
--- a/config/sources/vendors/mekotronics/mekotronics-rk3588.conf.sh
+++ b/config/sources/vendors/mekotronics/mekotronics-rk3588.conf.sh
@@ -20,3 +20,8 @@ declare -g BOOT_SCENARIO="spl-blobs"                    # so we don't depend on 
 declare -g BOOT_SOC="rk3588"                            # so we don't depend on defconfig naming convention
 declare -g BOOTCONFIG="rk3588_meko_defconfig" # generic ebv plus distro dtb hacks
 declare -g IMAGE_PARTITION_TABLE="gpt"
+
+# newer blobs from rockchip. tested to work.
+# set as variables, early, so they're picked up by `prepare_boot_configuration()`
+declare -g DDR_BLOB='rk35/rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.11.bin'
+declare -g BL31_BLOB='rk35/rk3588_bl31_v1.38.elf'

--- a/config/sources/vendors/mekotronics/mekotronics-rk3588.hooks.sh
+++ b/config/sources/vendors/mekotronics/mekotronics-rk3588.hooks.sh
@@ -4,13 +4,6 @@
 # This file is a part of the Armbian Build Framework https://github.com/armbian/build/
 #
 
-# Newer, tested-to-work rkbins.
-function post_family_config__blobs_mekotronics() {
-	display_alert "$BOARD" "Configuring Mekotronics ($BOARD) blobs" "info"
-	declare -g DDR_BLOB='rk35/rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.11.bin'
-	declare -g BL31_BLOB='rk35/rk3588_bl31_v1.38.elf'
-}
-
 # Vendor u-boot, standard rockchip, plus patches.
 function post_family_config__uboot_mekotronics() {
 	display_alert "$BOARD" "Configuring Mekotronics R58 ($BOARD) u-boot" "info"


### PR DESCRIPTION
#### `mekotronics`: `post_family_config()` hook is too late to change `DDR_BLOB` and `BL31_BLOB`, move to board-scope variables

- `mekotronics`: `post_family_config()` hook is too late to change `DDR_BLOB` and `BL31_BLOB`, move to board-scope variables
  - thanks @efectn for spotting this;
  - I had tested the blobs in other ways, before deciding to refactor their change into a hook, which never worked.