### PR TITLE
u-boot-radxa-rk3588: give SD higher boot priority than NVME

### DIFF
--- a/patch/u-boot/legacy/u-boot-radxa-rk3588/change-nvme-boot-order.patch
+++ b/patch/u-boot/legacy/u-boot-radxa-rk3588/change-nvme-boot-order.patch
@@ -1,0 +1,74 @@
+From 2c60c1515cc42da767ddc652ef6ca592331339c2 Mon Sep 17 00:00:00 2001
+From: amazingfate <liujianfeng1994@gmail.com>
+Date: Sat, 20 May 2023 00:19:57 +0800
+Subject: [PATCH] give SD higher boot priority than NVME
+
+---
+ include/configs/rockchip-common.h | 28 ++++++++++++++--------------
+ 1 file changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/include/configs/rockchip-common.h b/include/configs/rockchip-common.h
+index c0402b1faba..f57545826ce 100644
+--- a/include/configs/rockchip-common.h
++++ b/include/configs/rockchip-common.h
+@@ -58,13 +58,20 @@
+ 	BOOT_TARGET_DEVICES_references_MTD_without_CONFIG_CMD_MTD_BLK
+ #endif
+ 
+-/* First try to boot from SD (index 1), then eMMC (index 0) */
++/* First try to boot from SD (index 1), then NVME (if CMD_NVME is enabled), then eMMC (index 0) */
+ #if CONFIG_IS_ENABLED(CMD_MMC)
+-	#define BOOT_TARGET_MMC(func) \
++#if CONFIG_IS_ENABLED(CMD_NVME)
++	#define BOOT_TARGET_NVME_MMC(func) \
++		func(MMC, mmc, 1) \
++		func(NVME, nvme, 0) \
++		func(MMC, mmc, 0)
++#else
++	#define BOOT_TARGET_NVME_MMC(func) \
+ 		func(MMC, mmc, 1) \
+ 		func(MMC, mmc, 0)
++#endif
+ #else
+-	#define BOOT_TARGET_MMC(func)
++	#define BOOT_TARGET_NVME_MMC(func)
+ #endif
+ 
+ #if CONFIG_IS_ENABLED(CMD_MTD_BLK)
+@@ -82,12 +89,6 @@
+ 	#define BOOT_TARGET_RKNAND(func)
+ #endif
+ 
+-#if CONFIG_IS_ENABLED(CMD_NVME)
+-	#define BOOT_TARGET_NVME(func) func(NVME, nvme, 0)
+-#else
+-	#define BOOT_TARGET_NVME(func)
+-#endif
+-
+ #if CONFIG_IS_ENABLED(CMD_USB)
+ 	#define BOOT_TARGET_USB(func) func(USB, usb, 0)
+ #else
+@@ -107,8 +108,7 @@
+ #endif
+ 
+ #define BOOT_TARGET_DEVICES(func) \
+-	BOOT_TARGET_NVME(func) \
+-	BOOT_TARGET_MMC(func) \
++	BOOT_TARGET_NVME_MMC(func) \
+ 	BOOT_TARGET_MTD(func) \
+ 	BOOT_TARGET_RKNAND(func) \
+ 	BOOT_TARGET_USB(func) \
+@@ -156,10 +156,10 @@
+ 
+ #define RKIMG_DET_BOOTDEV \
+ 	"rkimg_bootdev=" \
+-	"if nvme dev 0; then " \
+-		"setenv devtype nvme; setenv devnum 0; echo Boot from nvme;" \
+-	"elif mmc dev 1 && rkimgtest mmc 1; then " \
++	"if mmc dev 1 && rkimgtest mmc 1; then " \
+ 		"setenv devtype mmc; setenv devnum 1; echo Boot from SDcard;" \
++	"elif nvme dev 0; then " \
++		"setenv devtype nvme; setenv devnum 0; echo Boot from nvme;" \
+ 	"elif mmc dev 0; then " \
+ 		"setenv devtype mmc; setenv devnum 0;" \
+ 	"elif mtd_blk dev 0; then " \


### PR DESCRIPTION
# Description

Now NVME has the highest boot priority in uboot. But I think SD card should have higher boot priority than NVME SSD because SD card is much easier to plug in/out than NVME SSD. This patch is from https://github.com/radxa/u-boot/pull/25. We can add it to armbian whe it's not merged upstream.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] uboot build successfully
- [x] Armbian on SD card boots when NVME SSD is installed.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
