### PR TITLE
debs: remove `Installed-Size: 1` from control files; `Installed-Size` is properly calculated at `fakeroot_dpkg_deb_build()` for all packages

### DIFF
--- a/lib/functions/bsp/armbian-bsp-cli-deb.sh
+++ b/lib/functions/bsp/armbian-bsp-cli-deb.sh
@@ -41,7 +41,6 @@ function compile_armbian-bsp-cli() {
 		Version: ${artifact_version}
 		Architecture: $ARCH
 		Maintainer: $MAINTAINER <$MAINTAINERMAIL>
-		Installed-Size: 1
 		Section: kernel
 		Priority: optional
 		Depends: bash, linux-base, u-boot-tools, initramfs-tools, lsb-release, fping${depends_base_files}

--- a/lib/functions/bsp/armbian-bsp-desktop-deb.sh
+++ b/lib/functions/bsp/armbian-bsp-desktop-deb.sh
@@ -45,7 +45,6 @@ function compile_armbian-bsp-desktop() {
 		Version: ${artifact_version}
 		Architecture: $ARCH
 		Maintainer: $MAINTAINER <$MAINTAINERMAIL>
-		Installed-Size: 1
 		Section: xorg
 		Priority: optional
 		Provides: armbian-bsp-desktop, armbian-bsp-desktop-${BOARD}

--- a/lib/functions/compilation/packages/armbian-desktop-deb.sh
+++ b/lib/functions/compilation/packages/armbian-desktop-deb.sh
@@ -42,7 +42,6 @@ function compile_armbian-desktop() {
 		Version: ${artifact_version}
 		Architecture: all
 		Maintainer: $MAINTAINER <$MAINTAINERMAIL>
-		Installed-Size: 1
 		Section: xorg
 		Priority: optional
 		Recommends: ${AGGREGATED_PACKAGES_DESKTOP_COMMA}, armbian-bsp-desktop

--- a/lib/functions/compilation/packages/fake_ubuntu_advantage_tools-deb.sh
+++ b/lib/functions/compilation/packages/fake_ubuntu_advantage_tools-deb.sh
@@ -27,7 +27,6 @@ function compile_fake_ubuntu_advantage_tools() {
 		Version: ${artifact_version}
 		Architecture: all
 		Maintainer: $MAINTAINER <$MAINTAINERMAIL>
-		Installed-Size: 1
 		Conflicts: ubuntu-advantage-tools
 		Breaks: ubuntu-advantage-tools
 		Provides: ubuntu-advantage-tools (= 65535)

--- a/lib/functions/compilation/packages/firmware-deb.sh
+++ b/lib/functions/compilation/packages/firmware-deb.sh
@@ -62,7 +62,6 @@ function compile_firmware() {
 		Version: ${artifact_version}
 		Architecture: all
 		Maintainer: $MAINTAINER <$MAINTAINERMAIL>
-		Installed-Size: 1
 		Conflicts: linux-firmware, firmware-brcm80211, firmware-ralink, firmware-samsung, firmware-realtek, armbian-firmware${REPLACE}${extra_conflicts_comma}
 		Provides: linux-firmware, firmware-brcm80211, firmware-ralink, firmware-samsung, firmware-realtek, armbian-firmware${REPLACE}${extra_conflicts_comma}
 		Section: kernel

--- a/lib/functions/compilation/uboot.sh
+++ b/lib/functions/compilation/uboot.sh
@@ -410,7 +410,6 @@ function compile_uboot() {
 		Version: ${artifact_version}
 		Architecture: $ARCH
 		Maintainer: $MAINTAINER <$MAINTAINERMAIL>
-		Installed-Size: 1
 		Section: kernel
 		Priority: optional
 		Provides: armbian-u-boot


### PR DESCRIPTION
#### debs: remove `Installed-Size: 1` from control files; `Installed-Size` is properly calculated at `fakeroot_dpkg_deb_build()` for all packages

- debs: remove `Installed-Size: 1` from control files; `Installed-Size` is properly calculated at `fakeroot_dpkg_deb_build()` for all packages