### PR TITLE
u-boot: allwinner: nanopineo: Bring back patches for nanopineo

### DIFF
--- a/patch/u-boot/u-boot-sunxi/board_nanopineo/add-emmc_support_to_neo1_and_2.patch
+++ b/patch/u-boot/u-boot-sunxi/board_nanopineo/add-emmc_support_to_neo1_and_2.patch
@@ -1,0 +1,20 @@
+diff --git a/configs/nanopi_neo2_defconfig b/configs/nanopi_neo2_defconfig
+index fc3465a..a885a85
+--- a/configs/nanopi_neo2_defconfig
++++ b/configs/nanopi_neo2_defconfig
+@@ -14,3 +14,4 @@ CONFIG_SPL=y
+ CONFIG_SUN8I_EMAC=y
+ CONFIG_USB_EHCI_HCD=y
+ CONFIG_USB_OHCI_HCD=y
++CONFIG_MMC_SUNXI_SLOT_EXTRA=2
+\ No newline at end of file
+diff --git a/configs/nanopi_neo_defconfig b/configs/nanopi_neo_defconfig
+index f87148c..9c8689b
+--- a/configs/nanopi_neo_defconfig
++++ b/configs/nanopi_neo_defconfig
+@@ -18,3 +18,4 @@ CONFIG_SYS_CLK_FREQ=480000000
+ CONFIG_SUN8I_EMAC=y
+ CONFIG_USB_EHCI_HCD=y
+ CONFIG_USB_OHCI_HCD=y
++CONFIG_MMC_SUNXI_SLOT_EXTRA=2
+\ No newline at end of file

--- a/patch/u-boot/u-boot-sunxi/board_nanopineo/add-nanopi-neo-core.patch
+++ b/patch/u-boot/u-boot-sunxi/board_nanopineo/add-nanopi-neo-core.patch
@@ -1,0 +1,21 @@
+diff --git a/arch/arm/dts/sun8i-h3-nanopi-neo.dts b/arch/arm/dts/sun8i-h3-nanopi-neo.dts
+index 9f33f6f..4a56e6a 100644
+--- a/arch/arm/dts/sun8i-h3-nanopi-neo.dts
++++ b/arch/arm/dts/sun8i-h3-nanopi-neo.dts
+@@ -58,6 +58,16 @@
+ 	status = "okay";
+ };
+ 
++&mmc2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mmc2_8bit_pins>;
++	vmmc-supply = <&reg_vcc3v3>;
++	bus-width = <8>;
++	non-removable;
++	cap-mmc-hw-reset;
++	status = "okay";
++};
++
+ &ohci0 {
+ 	status = "okay";
+ };

--- a/patch/u-boot/u-boot-sunxi/board_nanopineo/adjust-small-boards-cpufreq.patch
+++ b/patch/u-boot/u-boot-sunxi/board_nanopineo/adjust-small-boards-cpufreq.patch
@@ -1,0 +1,11 @@
+diff --git a/configs/nanopi_neo_defconfig b/configs/nanopi_neo_defconfig
+index ed30708f90..f87148c7e6 100644
+--- a/configs/nanopi_neo_defconfig
++++ b/configs/nanopi_neo_defconfig
+@@ -9,5 +9,6 @@ CONFIG_DEFAULT_DEVICE_TREE="sun8i-h3-nanopi-neo"
+ CONFIG_DEFAULT_DEVICE_TREE="sun8i-h3-nanopi-neo"
+ # CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
+ CONFIG_CONSOLE_MUX=y
++CONFIG_SYS_CLK_FREQ=480000000
+ CONFIG_SUN8I_EMAC=y
+ CONFIG_USB_EHCI_HCD=y


### PR DESCRIPTION
# Description

These patches went missing sometime during development cycle of this release. Looks like they are needed for emmc support on nanopi neo core

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Checked that u-boot builds and patches gets applied correctly

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
