### PR TITLE
Do not set incorrect mac80211 flags

### DIFF
--- a/patch/kernel/archive/rk322x-6.1/wifi-4003-ssv-6051-driver.patch
+++ b/patch/kernel/archive/rk322x-6.1/wifi-4003-ssv-6051-driver.patch
@@ -46840,12 +46840,12 @@ index 000000000000..9c3574285364
 +	rc_rate = &ssv_rc->rc_table[hw_rate_idx];
 +#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 +	if (rc_rate->rc_flags & RC_FLAG_HT) {
-+		rxs->flag |= RC_FLAG_HT;
++		// rxs->flag |= RC_FLAG_HT;
 +		if (rc_rate->rc_flags & RC_FLAG_HT_SGI)
-+			rxs->flag |= RX_ENC_FLAG_SHORT_GI;
++			rxs->enc_flags |= RX_ENC_FLAG_SHORT_GI;
 +	} else {
 +		if (rc_rate->rc_flags & RC_FLAG_SHORT_PREAMBLE)
-+			rxs->flag |= RX_ENC_FLAG_SHORTPRE;
++			rxs->enc_flags |= RX_ENC_FLAG_SHORTPRE;
 +	}
 +#else
 +	if (rc_rate->rc_flags & RC_FLAG_HT) {

--- a/patch/kernel/archive/rk322x-6.3/wifi-4003-ssv-6051-driver.patch
+++ b/patch/kernel/archive/rk322x-6.3/wifi-4003-ssv-6051-driver.patch
@@ -46841,12 +46841,12 @@ index 000000000000..9c3574285364
 +	rc_rate = &ssv_rc->rc_table[hw_rate_idx];
 +#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 +	if (rc_rate->rc_flags & RC_FLAG_HT) {
-+		rxs->flag |= RC_FLAG_HT;
++		// rxs->flag |= RC_FLAG_HT;
 +		if (rc_rate->rc_flags & RC_FLAG_HT_SGI)
-+			rxs->flag |= RX_ENC_FLAG_SHORT_GI;
++			rxs->enc_flags |= RX_ENC_FLAG_SHORT_GI;
 +	} else {
 +		if (rc_rate->rc_flags & RC_FLAG_SHORT_PREAMBLE)
-+			rxs->flag |= RX_ENC_FLAG_SHORTPRE;
++			rxs->enc_flags |= RX_ENC_FLAG_SHORTPRE;
 +	}
 +#else
 +	if (rc_rate->rc_flags & RC_FLAG_HT) {

--- a/patch/kernel/archive/rockchip64-6.1/wifi-4003-ssv-6051-driver.patch
+++ b/patch/kernel/archive/rockchip64-6.1/wifi-4003-ssv-6051-driver.patch
@@ -46840,12 +46840,12 @@ index 000000000000..9c3574285364
 +	rc_rate = &ssv_rc->rc_table[hw_rate_idx];
 +#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 +	if (rc_rate->rc_flags & RC_FLAG_HT) {
-+		rxs->flag |= RC_FLAG_HT;
++		// rxs->flag |= RC_FLAG_HT;
 +		if (rc_rate->rc_flags & RC_FLAG_HT_SGI)
-+			rxs->flag |= RX_ENC_FLAG_SHORT_GI;
++			rxs->enc_flags |= RX_ENC_FLAG_SHORT_GI;
 +	} else {
 +		if (rc_rate->rc_flags & RC_FLAG_SHORT_PREAMBLE)
-+			rxs->flag |= RX_ENC_FLAG_SHORTPRE;
++			rxs->enc_flags |= RX_ENC_FLAG_SHORTPRE;
 +	}
 +#else
 +	if (rc_rate->rc_flags & RC_FLAG_HT) {

--- a/patch/kernel/archive/rockchip64-6.3/wifi-4003-ssv-6051-driver.patch
+++ b/patch/kernel/archive/rockchip64-6.3/wifi-4003-ssv-6051-driver.patch
@@ -46782,12 +46782,12 @@ index 000000000000..9c3574285364
 +	rc_rate = &ssv_rc->rc_table[hw_rate_idx];
 +#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 +	if (rc_rate->rc_flags & RC_FLAG_HT) {
-+		rxs->flag |= RC_FLAG_HT;
++		// rxs->flag |= RC_FLAG_HT;
 +		if (rc_rate->rc_flags & RC_FLAG_HT_SGI)
-+			rxs->flag |= RX_ENC_FLAG_SHORT_GI;
++			rxs->enc_flags |= RX_ENC_FLAG_SHORT_GI;
 +	} else {
 +		if (rc_rate->rc_flags & RC_FLAG_SHORT_PREAMBLE)
-+			rxs->flag |= RX_ENC_FLAG_SHORTPRE;
++			rxs->enc_flags |= RX_ENC_FLAG_SHORTPRE;
 +	}
 +#else
 +	if (rc_rate->rc_flags & RC_FLAG_HT) {


### PR DESCRIPTION
# Description

Code for ssv6051 wifi driver sometimes set RX_ENC_xxx flags in the 'flag' field in the ieee80211_rx_status object. These flags belong in the 'enc_flags' field. Setting them in 'flag' clashed with the RXX_FLAG_MMIC_ERROR bit, and caused the supplicant to report a spurious michael mic error and close the connection.

# How Has This Been Tested?

Connects to my wireless access point now: did not do so before

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
