### PR TITLE
Add openssh-client as a dependency when building with CRYPTROOT=yes

### DIFF
--- a/extensions/fs-cryptroot-support.sh
+++ b/extensions/fs-cryptroot-support.sh
@@ -4,5 +4,5 @@
 
 function add_host_dependencies__add_cryptroot_tooling() {
 	display_alert "Adding cryptroot to host dependencies" "cryptsetup LUKS" "debug"
-	EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} cryptsetup" # @TODO: convert to array later
+	EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} cryptsetup openssh-client" # @TODO: convert to array later
 }


### PR DESCRIPTION
# Description

We call [ssh-keygen](https://github.com/armbian/build/blob/e284a94f6a363f57ffad5f719717a784a942bdd5/lib/functions/rootfs/distro-agnostic.sh#L55) when building with CRYPTROOT=yes, but openssh-client is not mentioned into `EXTRA_BUILD_DEPS` in [extensions/fs-cryptroot-support.sh](https://github.com/armbian/build/compare/main...viraniac:armbian_build:main#diff-96ce16948ff8afa0a666af1cda1ac081e527cabcfa9431544b22d2967fd7d0f7) which can make the build to fail. This PR fixes the same

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Created a build with CRYPTROOT=yes and ARTIFACT_IGNORE_CACHE=yes and made sure it no longer fails because of missing ssh-keygen in docker image

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
