### PR TITLE
rk3318-box: revert ddrbin to 333mhz

### DIFF
--- a/config/boards/rk3318-box.tvb
+++ b/config/boards/rk3318-box.tvb
@@ -7,7 +7,7 @@ BOOT_FDT_FILE="rockchip/rk3318-box.dtb"
 KERNEL_TARGET="legacy,current,edge"
 MODULES_BLACKLIST="analogix_dp bcmdhd"
 BOOT_SCENARIO="tpl-blob-atf-mainline"
-DDR_BLOB="rk33/rk3318_ddr_666Mhz_v1.16.bin"
+DDR_BLOB="rk33/rk3318_ddr_333Mhz_v1.16.bin"
 BOOT_SOC="rk3328"
 
 function post_family_tweaks_bsp__rk3318-box() {


### PR DESCRIPTION
# Description

Some people is complaining in the forums, thus it is better to revert this back to 333mhz

# How Has This Been Tested?

- [x] kernel and image compilation works

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
