### PR TITLE
RFC: `rockpro64`: blobless with 2.8.5 ATF, 2023.01 u-boot

### DIFF
--- a/config/boards/rockpro64.conf
+++ b/config/boards/rockpro64.conf
@@ -6,7 +6,32 @@ BOOTCONFIG="rockpro64-rk3399_defconfig"
 KERNEL_TARGET="legacy,current,edge"
 FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
-BOOT_SCENARIO="tpl-spl-blob"
+BOOT_SCENARIO="blobless"
 BOOT_SUPPORT_SPI=yes
-BOOTBRANCH_BOARD="tag:v2022.04"
-BOOTPATCHDIR="u-boot-rockchip64-v2022.04"
+
+# u-boot 2023.01 for rockpro64
+BOOTBRANCH_BOARD="tag:v2023.01"
+BOOTPATCHDIR="v2023.01"
+
+function add_host_dependencies__new_uboot_wants_python3_rockpro64() {
+	declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} python3-pyelftools" # @TODO: convert to array later
+}
+
+function post_family_config__hacks_for_new_uboot_rockpro64() {
+	display_alert "$BOARD" "using ATF (blobless) for 2023.01 u-boot" "info"
+	# Use latest lts 2.8 ATF
+	ATFBRANCH='tag:lts-v2.8.6'
+	ATFPATCHDIR="atf-rockchip64" # patches for logging etc
+	# With recent-enough u-boot and ATF.
+	# bl31.elf is copied directly from ATF build dir to uboot dir anyway.
+	UBOOT_TARGET_MAP="BL31=bl31.elf;;idbloader.img u-boot.itb tpl/u-boot-tpl.bin spl/u-boot-spl.bin u-boot.itb rkspi_loader.img"
+}
+
+function post_config_uboot_target__extra_configs_for_rockpro64() {
+	# Taken from https://gitlab.manjaro.org/manjaro-arm/packages/core/uboot-rockpro64/-/blob/master/PKGBUILD
+	display_alert "$BOARD" "u-boot configs for 2023.01 u-boot config" "info"
+	run_host_command_logged scripts/config --set-val CONFIG_OF_LIBFDT_OVERLAY "y"
+	run_host_command_logged scripts/config --set-val CONFIG_SPL_MMC_SDHCI_SDMA "n"
+	run_host_command_logged scripts/config --set-val CONFIG_MMC_HS400_SUPPORT "y"
+	run_host_command_logged scripts/config --set-val CONFIG_USE_PREBOOT "n"
+}

--- a/patch/u-boot/v2023.01/board_rockpro64/mmc-sdhci-allow-disabling-sdma-in-spl.patch
+++ b/patch/u-boot/v2023.01/board_rockpro64/mmc-sdhci-allow-disabling-sdma-in-spl.patch
@@ -1,0 +1,67 @@
+From: Peter Geis <pgwipeout@gmail.com>
+To: Peng Fan <peng.fan@nxp.com>, Jaehoon Chung <jh80.chung@samsung.com>
+Cc: Peter Geis <pgwipeout@gmail.com>, u-boot@lists.denx.de
+Subject: [PATCH v1 02/11] mmc: sdhci: allow disabling sdma in spl
+Date: Mon, 21 Feb 2022 20:31:21 -0500
+
+Rockchip emmc devices have a similar issue to Rockchip dwmmc devices,
+where performing dma to sram causes errors with suspend/resume.
+Allow us to toggle sdma in spl for sdhci similar to adma support, so we
+can ensure dma is not used when loading the sram code.
+
+Signed-off-by: Peter Geis <pgwipeout@gmail.com>
+Reviewed-by: Jaehoon Chung <jh80.chung@samsung.com>
+---
+ drivers/mmc/Kconfig | 7 +++++++
+ drivers/mmc/sdhci.c | 6 +++---
+ 2 files changed, 10 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/mmc/Kconfig b/drivers/mmc/Kconfig
+index f04cc44e1973..1e4342285ce7 100644
+--- a/drivers/mmc/Kconfig
++++ b/drivers/mmc/Kconfig
+@@ -468,6 +468,13 @@ config MMC_SDHCI_SDMA
+ 	  This enables support for the SDMA (Single Operation DMA) defined
+ 	  in the SD Host Controller Standard Specification Version 1.00 .
+ 
++config SPL_MMC_SDHCI_SDMA
++	bool "Support SDHCI SDMA in SPL"
++	depends on MMC_SDHCI
++	help
++	  This enables support for the SDMA (Single Operation DMA) defined
++	  in the SD Host Controller Standard Specification Version 1.00 in SPL.
++
+ config MMC_SDHCI_ADMA
+ 	bool "Support SDHCI ADMA2"
+ 	depends on MMC_SDHCI
+diff --git a/drivers/mmc/sdhci.c b/drivers/mmc/sdhci.c
+index 766e4a6b0c5e..6285e53d12a2 100644
+--- a/drivers/mmc/sdhci.c
++++ b/drivers/mmc/sdhci.c
+@@ -70,7 +70,7 @@ static void sdhci_transfer_pio(struct sdhci_host *host, struct mmc_data *data)
+ 	}
+ }
+ 
+-#if (defined(CONFIG_MMC_SDHCI_SDMA) || CONFIG_IS_ENABLED(MMC_SDHCI_ADMA))
++#if (CONFIG_IS_ENABLED(MMC_SDHCI_SDMA) || CONFIG_IS_ENABLED(MMC_SDHCI_ADMA))
+ static void sdhci_prepare_dma(struct sdhci_host *host, struct mmc_data *data,
+ 			      int *is_aligned, int trans_bytes)
+ {
+@@ -177,7 +177,7 @@ static int sdhci_transfer_data(struct sdhci_host *host, struct mmc_data *data)
+ 		}
+ 	} while (!(stat & SDHCI_INT_DATA_END));
+ 
+-#if (defined(CONFIG_MMC_SDHCI_SDMA) || CONFIG_IS_ENABLED(MMC_SDHCI_ADMA))
++#if (CONFIG_IS_ENABLED(MMC_SDHCI_SDMA) || CONFIG_IS_ENABLED(MMC_SDHCI_ADMA))
+ 	dma_unmap_single(host->start_addr, data->blocks * data->blocksize,
+ 			 mmc_get_dma_dir(data));
+ #endif
+@@ -836,7 +836,7 @@ int sdhci_setup_cfg(struct mmc_config *cfg, struct sdhci_host *host,
+ #endif
+ 	debug("%s, caps: 0x%x\n", __func__, caps);
+ 
+-#ifdef CONFIG_MMC_SDHCI_SDMA
++#if CONFIG_IS_ENABLED(MMC_SDHCI_SDMA)
+ 	if ((caps & SDHCI_CAN_DO_SDMA)) {
+ 		host->flags |= USE_SDMA;
+ 	} else {


### PR DESCRIPTION
#### RFC: `rockpro64`: blobless with 2.8.5 ATF, 2023.01 u-boot

- RFC: `rockpro64`: blobless with 2.8.5 ATF, 2023.01 u-boot
  - `2023.04` fails during USB init, thus using 23.01 (23.07 untested)
  - `blobless` with newer 2.8.5 ATF
  - the previous problems with PCIe are _not_ totally solved by this