### PR TITLE
patch: misc: rtw88: 6.3: `upstream wireless`

### DIFF
--- a/patch/misc/rtw88/6.3/001-rtw88-linux-next.patch
+++ b/patch/misc/rtw88/6.3/001-rtw88-linux-next.patch
@@ -1884,8 +1884,8 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/tx.h b/drivers/net/wireless/real
  
  static inline void rtw_tx_fill_txdesc_checksum(struct rtw_dev *rtwdev,
 diff -Naur a/drivers/net/wireless/realtek/rtw88/usb.c b/drivers/net/wireless/realtek/rtw88/usb.c
---- a/drivers/net/wireless/realtek/rtw88/usb.c	2023-06-21 10:02:19.000000000 -0400
-+++ b/drivers/net/wireless/realtek/rtw88/usb.c	2023-06-22 13:52:09.000000000 -0400
+--- a/drivers/net/wireless/realtek/rtw88/usb.c	2023-07-11 13:39:51.000000000 -0400
++++ b/drivers/net/wireless/realtek/rtw88/usb.c	2023-07-11 19:36:51.686164114 -0400
 @@ -24,11 +24,12 @@
  static void rtw_usb_fill_tx_checksum(struct rtw_usb *rtwusb,
  				     struct sk_buff *skb, int agg_num)
@@ -1938,15 +1938,6 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/usb.c b/drivers/net/wireless/rea
  	else if (skb_get_queue_mapping(skb) <= IEEE80211_AC_BK)
  		qsel = skb->priority;
  	else
-@@ -535,7 +542,7 @@
- 		}
- 
- 		if (skb_queue_len(&rtwusb->rx_queue) >= RTW_USB_MAX_RXQ_LEN) {
--			rtw_err(rtwdev, "failed to get rx_queue, overflow\n");
-+			dev_dbg_ratelimited(rtwdev->dev, "failed to get rx_queue, overflow\n");
- 			dev_kfree_skb_any(skb);
- 			continue;
- 		}
 diff -Naur a/include/linux/mmc/sdio_ids.h b/include/linux/mmc/sdio_ids.h
 --- a/include/linux/mmc/sdio_ids.h	2023-06-09 04:48:26.000000000 -0400
 +++ b/include/linux/mmc/sdio_ids.h	2023-06-11 07:28:33.845740907 -0400


### PR DESCRIPTION
Adjusted patching in `drivers/net/wireless/realtek/rtw88/usb.c` to reflect update in Linux 6.3.13 (EOL) https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/diff/drivers/net/wireless/realtek/rtw88/usb.c?id=v6.3.13&id2=v6.3.12

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
