### PR TITLE
Add compatibility for non-FHS 3.0 systems

### DIFF
--- a/lib/functions/cli/entrypoint.sh
+++ b/lib/functions/cli/entrypoint.sh
@@ -94,7 +94,7 @@ function cli_entrypoint() {
 	if [[ "${ARMBIAN_BUILD_UUID}" != "" ]]; then
 		display_alert "Using passed-in ARMBIAN_BUILD_UUID" "${ARMBIAN_BUILD_UUID}" "debug"
 	else
-		if [[ -f /usr/bin/uuidgen ]]; then
+		if command -v uuidgen 1>/dev/null; then
 			ARMBIAN_BUILD_UUID="$(uuidgen)"
 		else
 			display_alert "uuidgen not found" "uuidgen not installed yet" "info"

--- a/lib/functions/logging/runners.sh
+++ b/lib/functions/logging/runners.sh
@@ -120,13 +120,13 @@ function chroot_sdcard_apt_get() {
 # please, please, unify around this function.
 function chroot_sdcard() {
 	raw_command="$*" raw_extra="chroot_sdcard" TMPDIR="" \
-		run_host_command_logged_raw chroot "${SDCARD}" /bin/bash -e -o pipefail -c "$*"
+		run_host_command_logged_raw chroot "${SDCARD}" /usr/bin/env bash -e -o pipefail -c "$*"
 }
 
 # please, please, unify around this function.
 function chroot_mount() {
 	raw_command="$*" raw_extra="chroot_mount" TMPDIR="" \
-		run_host_command_logged_raw chroot "${MOUNT}" /bin/bash -e -o pipefail -c "$*"
+		run_host_command_logged_raw chroot "${MOUNT}" /usr/bin/env bash -e -o pipefail -c "$*"
 }
 
 # This should be used if you need to capture the stdout produced by the command. It is NOT logged, and NOT run thru bash, and NOT quoted.
@@ -137,13 +137,13 @@ function chroot_sdcard_with_stdout() {
 function chroot_custom_long_running() { # any pipe causes the left-hand side to subshell and caos ensues. it's just like chroot_custom()
 	local target=$1
 	shift
-	raw_command="$*" raw_extra="chroot_custom_long_running" TMPDIR="" run_host_command_logged_raw chroot "${target}" /bin/bash -e -o pipefail -c "$*"
+	raw_command="$*" raw_extra="chroot_custom_long_running" TMPDIR="" run_host_command_logged_raw chroot "${target}" /usr/bin/env bash -e -o pipefail -c "$*"
 }
 
 function chroot_custom() {
 	local target=$1
 	shift
-	raw_command="$*" raw_extra="chroot_custom" TMPDIR="" run_host_command_logged_raw chroot "${target}" /bin/bash -e -o pipefail -c "$*"
+	raw_command="$*" raw_extra="chroot_custom" TMPDIR="" run_host_command_logged_raw chroot "${target}" /usr/bin/env bash -e -o pipefail -c "$*"
 }
 
 # For installing packages host-side. Not chroot!
@@ -185,17 +185,17 @@ function run_host_x86_binary_logged() {
 
 # Run simple and exit with it's code. Exactly the same as run_host_command_logged(). Used to have pv pipe, but that causes chaos.
 function run_host_command_logged_long_running() {
-	raw_command="${raw_command:-"$*"}" run_host_command_logged_raw /bin/bash -e -o pipefail -c "$*"
+	raw_command="${raw_command:-"$*"}" run_host_command_logged_raw /usr/bin/env bash -e -o pipefail -c "$*"
 }
 
 # run_host_command_logged is the very basic, should be used for everything, but, please use helpers above, this is very low-level.
 function run_host_command_logged() {
-	raw_command="${raw_command:-"$*"}" run_host_command_logged_raw /bin/bash -e -o pipefail -c "$*"
+	raw_command="${raw_command:-"$*"}" run_host_command_logged_raw /usr/bin/env bash -e -o pipefail -c "$*"
 }
 
 # for interactive, dialog-like host-side invocations. no redirections performed, but same bash usage and expansion, for consistency.
 function run_host_command_dialog() {
-	/bin/bash -e -o pipefail -c "$*"
+	/usr/bin/env bash -e -o pipefail -c "$*"
 }
 
 # do NOT use directly, it does NOT expand the way it should (through bash)

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,8 @@
+# Configuration file for Nix(OS) to provide a temporary development enviroment
+
+{ pkgs ? import <nixpkgs> {} }:
+  pkgs.mkShell {
+    nativeBuildInputs = with pkgs.buildPackages; [
+      util-linux # Needed for uuidgen
+    ];
+}


### PR DESCRIPTION
* Added `shell.nix` definition for temporary development environment for Nix(OS)
* Set uuidgen and other binaries check to not rely on hard-codded paths

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Jira reference number [AR-9999]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] On NixOS

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
