### PR TITLE
Add maintainer for Orange Pi Prime board

### DIFF
--- a/config/boards/orangepiprime.conf
+++ b/config/boards/orangepiprime.conf
@@ -1,12 +1,12 @@
 # Allwinner H5 quad core 2GB RAM Wi-Fi/BT
 BOARD_NAME="Orange Pi Prime"
 BOARDFAMILY="sun50iw2"
-BOARD_MAINTAINER=""
+BOARD_MAINTAINER="viraniac"
 BOOTCONFIG="orangepi_prime_defconfig"
 DEFAULT_OVERLAYS="analog-codec"
 KERNEL_TARGET="legacy,current,edge"
 FULL_DESKTOP="yes"
-CRUSTCONFIG="h5_defconfig"
+CRUSTCONFIG="orangepi_pc2_defconfig"
 
 function post_family_tweaks_bsp__orangepiprime_BSP() {
     display_alert "Installing BSP firmware and fixups"


### PR DESCRIPTION
# Description

Adding myself as the maintainer for  Orange Pi Prime board. Also changed crust config for this board to be more board specific.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Booted on Orange Pi Prime

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
