### PR TITLE
patch: u-boot: Enabled power led on H5 boards

### DIFF
--- a/patch/u-boot/u-boot-sunxi/allwinner-h3-h5-enable-power-led.patch
+++ b/patch/u-boot/u-boot-sunxi/allwinner-h3-h5-enable-power-led.patch
@@ -6,8 +6,8 @@ index 827e545032..7d343a93b2 100644
  		status_led_init();
  #endif
  
-+#ifdef CONFIG_MACH_SUN8I_H3
-+	/* turn on power LED (PL10) on H3 boards */
++#ifdef CONFIG_MACH_SUNXI_H3_H5
++	/* turn on power LED (PL10) on H3 and H5 boards */
 +	gpio_direction_output(SUNXI_GPL(10), 1);
 +#endif
 +


### PR DESCRIPTION
# Description

Enable power led in u-boot on H5 based boards.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Booted on Orange Pi Prime

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
