### PR TITLE
Fixup kernel 6.3.13 build - stale kickoff removal in wireless regulator API

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -395,6 +395,9 @@ driver_rtl88x2bu() {
 		# fix compilation for kernels >= 6.3
 		process_patch_file "${SRC}/patch/misc/wireless-rtl88x2bu-6.3.0.patch" "applying"
 
+		# fix compilation for kernels >= 6.3.13 < 6.4 and >= 6.5
+		process_patch_file "${SRC}/patch/misc/wireless-rtl88x2bu-wireless-ignore-stale-kickoff-removal.patch" "applying"
+
 	fi
 
 }

--- a/patch/misc/wireless-rtl88x2bu-wireless-ignore-stale-kickoff-removal.patch
+++ b/patch/misc/wireless-rtl88x2bu-wireless-ignore-stale-kickoff-removal.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alban Browaeys <alban.browaeys@gmail.com>
+Date: Sun, 16 Jul 2023 21:21:12 +0000
+Subject: Fixup for stale kickoff removal in wireless regulator API
+
+Cope with the fix in stable 6.3.13 bf353116d1bf and 6.5-rc1 e8c2af660ba0
+"wifi: cfg80211: fix regulatory disconnect with OCB/NAN".
+That is the removal of REGULATORY_IGNORE_STALE_KICKOFF
+from the wireless regulator internal API to fix any driver
+that allowed OCB/NAN.
+
+Note this code will need to be expanded once and if 6.4 include the
+above fixup.
+
+---
+ drivers/net/wireless/rtl88x2bu/os_dep/linux/wifi_regd.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/wireless/rtl88x2bu/os_dep/linux/wifi_regd.c b/drivers/net/wireless/rtl88x2bu/os_dep/linux/wifi_regd.c
+index 81e1dc75e5fb..04dc056f8d69 100644
+--- a/drivers/net/wireless/rtl88x2bu/os_dep/linux/wifi_regd.c
++++ b/drivers/net/wireless/rtl88x2bu/os_dep/linux/wifi_regd.c
+@@ -403,11 +403,14 @@ int rtw_regd_init(struct wiphy *wiphy)
+ #else
+ 	wiphy->regulatory_flags &= ~REGULATORY_STRICT_REG;
+ 	wiphy->regulatory_flags &= ~REGULATORY_DISABLE_BEACON_HINTS;
+ #endif
+ 
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0))
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0)) \
++	&& ((LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 13)) \
++		|| (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0))) \
++	&& (LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0))
+ 	wiphy->regulatory_flags |= REGULATORY_IGNORE_STALE_KICKOFF;
+ #endif
+ 
+ 	return 0;
+ }
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+


### PR DESCRIPTION
# Description
The kernel build fails with:
```
[🐳|🔨]   drivers/net/wireless/rtl88x2bu/os_dep/linux/wifi_regd.c: In function 'rtw_regd_init':
[🐳|🔨]   drivers/net/wireless/rtl88x2bu/os_dep/linux/wifi_regd.c:409:36: error: 'REGULATORY_IGNORE_STALE_KICKOFF' undeclared (first use in this function)
[🐳|🔨]     409 |         wiphy->regulatory_flags |= REGULATORY_IGNORE_STALE_KICKOFF;
[🐳|🔨]         |                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[🐳|🔨]   drivers/net/wireless/rtl88x2bu/os_dep/linux/wifi_regd.c:409:36: note: each undeclared identifier is reported only once for each function it appears in
[🐳|🔨]   make[6]: *** [scripts/Makefile.build:252: drivers/net/wireless/rtl88x2bu/os_dep/linux/wifi_regd.o] Error 1
```
note that this bug only affect >= 6.3.13 < 6.4 and >=6.5-rc1 as of the 16th of July 2023.

Cope with the fix in stable 6.3.13 bf353116d1bf and 6.5-rc1 e8c2af660ba0 "wifi: cfg80211: fix regulatory disconnect with OCB/NAN". That is the removal of REGULATORY_IGNORE_STALE_KICKOFF from the wireless regulator internal API to fix any driver that allowed OCB/NAN.

This code will need to be expanded once and if 6.4 include the above fixup.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Jira reference number [AR-9999]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] ` ./compile.sh kernel BOARD=helios64 BRANCH=edge RELEASE=bookworm BUILD_ONLY="kernel" KERNEL_CONFIGURE=no BUILD_KSRC=no`

No runtime tested. My hardware is currently in a test so I cannot reboot in the new kernel. Also I do not have this wireless device so I cannot test this driver code works correctly either way.


# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
