### PR TITLE
kernel: sun50i: h5: Fix thermal monitoring in 6.1 kernel

### DIFF
--- a/patch/kernel/archive/sunxi-5.15/patches.armbian/arm64-dts-sun50i-h5-enable-power-button-for-orangepi-prime.patch
+++ b/patch/kernel/archive/sunxi-5.15/patches.armbian/arm64-dts-sun50i-h5-enable-power-button-for-orangepi-prime.patch
@@ -1,0 +1,28 @@
+From 63d288e380269ce6bfd95e04a1e2e9a8abacecca Mon Sep 17 00:00:00 2001
+From: Gunjan Gupta <viraniac@gmail.com>
+Date: Sat, 15 Jul 2023 17:06:17 +0000
+Subject: [PATCH] arm64: dts: sun50i: h5: enable power button for orangepi
+ prime
+
+---
+ arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-prime.dts | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-prime.dts b/arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-prime.dts
+index f430acd85..35e090985 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-prime.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-prime.dts
+@@ -63,8 +63,9 @@ gpio-keys {
+ 
+ 		key-sw4 {
+ 			label = "sw4";
+-			linux,code = <BTN_0>;
++			linux,code = <KEY_POWER>;
+ 			gpios = <&r_pio 0 3 GPIO_ACTIVE_LOW>;
++			wakeup-source;
+ 		};
+ 	};
+ 
+-- 
+2.34.1
+

--- a/patch/kernel/archive/sunxi-5.15/series.armbian
+++ b/patch/kernel/archive/sunxi-5.15/series.armbian
@@ -190,3 +190,4 @@
 	patches.armbian/arm-dts-sun8i-v40-bananapi-m2-berry-enable-audio-codec.patch
 	patches.armbian/arm-dts-sun8i-h3-nanopi-duo2-enable-powerbutton-and-ethernet.patch
 	patches.armbian/arm-dts-sun8i-h3-reduce-opp-microvolt-to-prevent-not.patch
+	patches.armbian/arm64-dts-sun50i-h5-enable-power-button-for-orangepi-prime.patch

--- a/patch/kernel/archive/sunxi-5.15/series.conf
+++ b/patch/kernel/archive/sunxi-5.15/series.conf
@@ -658,3 +658,4 @@
 	patches.armbian/arm-dts-sun8i-v40-bananapi-m2-berry-enable-audio-codec.patch
 	patches.armbian/arm-dts-sun8i-h3-nanopi-duo2-enable-powerbutton-and-ethernet.patch
 	patches.armbian/arm-dts-sun8i-h3-reduce-opp-microvolt-to-prevent-not.patch
+	patches.armbian/arm64-dts-sun50i-h5-enable-power-button-for-orangepi-prime.patch

--- a/patch/kernel/archive/sunxi-6.1/patches.armbian/arm64-dts-sun50i-h5-Add-missing-GPU-trip-point.patch
+++ b/patch/kernel/archive/sunxi-6.1/patches.armbian/arm64-dts-sun50i-h5-Add-missing-GPU-trip-point.patch
@@ -1,0 +1,35 @@
+From 9a1a4de7a7076e3b5802310c14f50f93aed5225a Mon Sep 17 00:00:00 2001
+From: Ondrej Jirman <megi@xff.cz>
+Date: Mon, 13 Mar 2023 06:02:46 +0100
+Subject: [PATCH 191/469] arm64: dts: sun50i-h5: Add missing GPU trip point
+
+Without this, thermal sensor driver fails to probe.
+
+Signed-off-by: Ondrej Jirman <megi@xff.cz>
+---
+ arch/arm64/boot/dts/allwinner/sun50i-h5.dtsi | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h5.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h5.dtsi
+index 2159fa336d75..3b2bd698e9c1 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h5.dtsi
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h5.dtsi
+@@ -227,6 +227,15 @@ gpu-thermal {
+ 			polling-delay-passive = <0>;
+ 			polling-delay = <0>;
+ 			thermal-sensors = <&ths 1>;
++
++			trips {
++				gpu_crit: gpu-crit {
++					/* milliCelsius */
++					temperature = <110000>;
++					hysteresis = <2000>;
++					type = "critical";
++				};
++			};
+ 		};
+ 	};
+ };
+-- 
+2.34.1
+

--- a/patch/kernel/archive/sunxi-6.1/patches.armbian/arm64-dts-sun50i-h5-enable-power-button-for-orangepi-prime.patch
+++ b/patch/kernel/archive/sunxi-6.1/patches.armbian/arm64-dts-sun50i-h5-enable-power-button-for-orangepi-prime.patch
@@ -1,0 +1,28 @@
+From 63d288e380269ce6bfd95e04a1e2e9a8abacecca Mon Sep 17 00:00:00 2001
+From: Gunjan Gupta <viraniac@gmail.com>
+Date: Sat, 15 Jul 2023 17:06:17 +0000
+Subject: [PATCH] arm64: dts: sun50i: h5: enable power button for orangepi
+ prime
+
+---
+ arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-prime.dts | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-prime.dts b/arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-prime.dts
+index f430acd85..35e090985 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-prime.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-prime.dts
+@@ -63,8 +63,9 @@ gpio-keys {
+ 
+ 		key-sw4 {
+ 			label = "sw4";
+-			linux,code = <BTN_0>;
++			linux,code = <KEY_POWER>;
+ 			gpios = <&r_pio 0 3 GPIO_ACTIVE_LOW>;
++			wakeup-source;
+ 		};
+ 	};
+ 
+-- 
+2.34.1
+

--- a/patch/kernel/archive/sunxi-6.1/series.armbian
+++ b/patch/kernel/archive/sunxi-6.1/series.armbian
@@ -179,3 +179,4 @@
 	patches.armbian/arm-dts-sun8i-h3-nanopi-duo2-enable-powerbutton-and-ethernet.patch
 	patches.armbian/arm-dts-sun8i-h3-reduce-opp-microvolt-to-prevent-not.patch
 	patches.armbian/arm64-dts-sun50i-h5-enable-power-button-for-orangepi-prime.patch
+	patches.armbian/arm64-dts-sun50i-h5-Add-missing-GPU-trip-point.patch

--- a/patch/kernel/archive/sunxi-6.1/series.armbian
+++ b/patch/kernel/archive/sunxi-6.1/series.armbian
@@ -178,3 +178,4 @@
 	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1.patch
 	patches.armbian/arm-dts-sun8i-h3-nanopi-duo2-enable-powerbutton-and-ethernet.patch
 	patches.armbian/arm-dts-sun8i-h3-reduce-opp-microvolt-to-prevent-not.patch
+	patches.armbian/arm64-dts-sun50i-h5-enable-power-button-for-orangepi-prime.patch

--- a/patch/kernel/archive/sunxi-6.1/series.conf
+++ b/patch/kernel/archive/sunxi-6.1/series.conf
@@ -583,3 +583,4 @@
 	patches.armbian/arm-dts-sun8i-h3-nanopi-duo2-enable-powerbutton-and-ethernet.patch
 	patches.armbian/arm-dts-sun8i-h3-reduce-opp-microvolt-to-prevent-not.patch
 	patches.armbian/arm64-dts-sun50i-h5-enable-power-button-for-orangepi-prime.patch
+	patches.armbian/arm64-dts-sun50i-h5-Add-missing-GPU-trip-point.patch

--- a/patch/kernel/archive/sunxi-6.1/series.conf
+++ b/patch/kernel/archive/sunxi-6.1/series.conf
@@ -582,3 +582,4 @@
 	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1.patch
 	patches.armbian/arm-dts-sun8i-h3-nanopi-duo2-enable-powerbutton-and-ethernet.patch
 	patches.armbian/arm-dts-sun8i-h3-reduce-opp-microvolt-to-prevent-not.patch
+	patches.armbian/arm64-dts-sun50i-h5-enable-power-button-for-orangepi-prime.patch

--- a/patch/kernel/archive/sunxi-6.4/patches.armbian/arm64-dts-sun50i-h5-enable-power-button-for-orangepi-prime.patch
+++ b/patch/kernel/archive/sunxi-6.4/patches.armbian/arm64-dts-sun50i-h5-enable-power-button-for-orangepi-prime.patch
@@ -1,0 +1,28 @@
+From 63d288e380269ce6bfd95e04a1e2e9a8abacecca Mon Sep 17 00:00:00 2001
+From: Gunjan Gupta <viraniac@gmail.com>
+Date: Sat, 15 Jul 2023 17:06:17 +0000
+Subject: [PATCH] arm64: dts: sun50i: h5: enable power button for orangepi
+ prime
+
+---
+ arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-prime.dts | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-prime.dts b/arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-prime.dts
+index f430acd85..35e090985 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-prime.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h5-orangepi-prime.dts
+@@ -63,8 +63,9 @@ gpio-keys {
+ 
+ 		key-sw4 {
+ 			label = "sw4";
+-			linux,code = <BTN_0>;
++			linux,code = <KEY_POWER>;
+ 			gpios = <&r_pio 0 3 GPIO_ACTIVE_LOW>;
++			wakeup-source;
+ 		};
+ 	};
+ 
+-- 
+2.34.1
+

--- a/patch/kernel/archive/sunxi-6.4/series.armbian
+++ b/patch/kernel/archive/sunxi-6.4/series.armbian
@@ -184,3 +184,4 @@
 	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1.patch
 	patches.armbian/arm-dts-sun8i-h3-nanopi-duo2-enable-powerbutton-and-ethernet.patch
 	patches.armbian/arm-dts-sun8i-h3-reduce-opp-microvolt-to-prevent-not.patch
+	patches.armbian/arm64-dts-sun50i-h5-enable-power-button-for-orangepi-prime.patch

--- a/patch/kernel/archive/sunxi-6.4/series.conf
+++ b/patch/kernel/archive/sunxi-6.4/series.conf
@@ -664,3 +664,4 @@
 	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1.patch
 	patches.armbian/arm-dts-sun8i-h3-nanopi-duo2-enable-powerbutton-and-ethernet.patch
 	patches.armbian/arm-dts-sun8i-h3-reduce-opp-microvolt-to-prevent-not.patch
+	patches.armbian/arm64-dts-sun50i-h5-enable-power-button-for-orangepi-prime.patch


### PR DESCRIPTION
# Description

Fixed thermal monitoring in 6.1 kernel caused by missing GPU trips. Also configured sw4 switch as power button for suspend/resume support for Orange Pi Prime.

Jira reference number [AR-1804]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Booted on Orange Pi Prime and checked that armbianmonitor -M reports back the temperature
- [X] Booted all three kernels on Orange PI Prime and ensured that button is working fine for rebooting or resuming the board

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1804]: https://armbian.atlassian.net/browse/AR-1804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ