### PR TITLE
lib: functions: compilation: Make it possible to toggle EXTRAWIFI

### DIFF
--- a/lib/functions/compilation/patch/drivers-harness.sh
+++ b/lib/functions/compilation/patch/drivers-harness.sh
@@ -12,6 +12,11 @@ function kernel_drivers_create_patches_hash_only() {
 }
 
 function kernel_drivers_create_patches() {
+	if [[ "${EXTRAWIFI}" == "no" ]] ; then
+		display_alert "Skipping driver harness as requested" "EXTRAWIFI = ${EXTRAWIFI} - returning" "debug"
+		return 0
+	fi
+
 	kernel_drivers_patch_hash="undetermined" # outer scope
 	kernel_drivers_patch_file="undetermined" # outer scope
 
@@ -126,7 +131,6 @@ function kernel_drivers_prepare_harness() {
 		declare kernel_git_revision="${2}"
 		# for compatibility with `master`-based code
 		declare kerneldir="${kernel_work_dir}"
-		declare EXTRAWIFI="yes" # forced! @TODO not really?
 
 		# change cwd to the kernel working dir
 		cd "${kernel_work_dir}" || exit_with_error "Failed to change directory to ${kernel_work_dir}"

--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -11,7 +11,7 @@ function driver_generic_bring_back_ipx() {
 	#
 	# Returning headers needed for some wireless drivers
 	#
-	if linux-version compare "${version}" ge 5.4 && [ $EXTRAWIFI == yes ]; then
+	if linux-version compare "${version}" ge 5.4 ; then
 		display_alert "Reverting upstream-removed" "IPX stuff needed for Wireless Drivers" "info"
 		process_patch_file "${SRC}/patch/misc/wireless-bring-back-headers.patch" "applying"
 	fi
@@ -19,7 +19,7 @@ function driver_generic_bring_back_ipx() {
 
 driver_rtl8152_rtl8153() {
 	# Updated USB network drivers for RTL8152/RTL8153 based dongles that also support 2.5Gbs variants
-	if linux-version compare "${version}" ge 5.4 && linux-version compare "${version}" le 5.12 && [ "$LINUXFAMILY" != mvebu64 ] && [ "$LINUXFAMILY" != rk322x ] && [ "$LINUXFAMILY" != odroidxu4 ] && [ "$EXTRAWIFI" == yes ]; then
+	if linux-version compare "${version}" ge 5.4 && linux-version compare "${version}" le 5.12 && [ "$LINUXFAMILY" != mvebu64 ] && [ "$LINUXFAMILY" != rk322x ] && [ "$LINUXFAMILY" != odroidxu4 ] ; then
 
 		# attach to specifics tag or branch
 		local rtl8152ver="branch:master"
@@ -35,7 +35,7 @@ driver_rtl8152_rtl8153() {
 driver_rtl8189ES() {
 	# Wireless drivers for Realtek 8189ES chipsets
 
-	if linux-version compare "${version}" ge 3.14 && [ "$EXTRAWIFI" == yes ]; then
+	if linux-version compare "${version}" ge 3.14 ; then
 
 		# attach to specifics tag or branch
 		local rtl8189esver="branch:master"
@@ -79,7 +79,7 @@ driver_rtl8189FS() {
 
 	# Wireless drivers for Realtek 8189FS chipsets
 
-	if linux-version compare "${version}" ge 3.14 && [ "$EXTRAWIFI" == yes ]; then
+	if linux-version compare "${version}" ge 3.14 ; then
 
 		# attach to specifics tag or branch
 		local rtl8189fsver="branch:rtl8189fs"
@@ -124,7 +124,7 @@ driver_rtl8192EU() {
 
 	# Wireless drivers for Realtek 8192EU chipsets
 
-	if linux-version compare "${version}" ge 3.14 && [ "$EXTRAWIFI" == yes ]; then
+	if linux-version compare "${version}" ge 3.14 ; then
 
 		# attach to specifics tag or branch
 		local rtl8192euver="branch:realtek-4.4.x"
@@ -163,7 +163,7 @@ driver_rtl8811_rtl8812_rtl8814_rtl8821() {
 
 	# Wireless drivers for Realtek 8811, 8812, 8814 and 8821 chipsets
 
-	if linux-version compare "${version}" ge 3.14 && [ "$EXTRAWIFI" == yes ]; then
+	if linux-version compare "${version}" ge 3.14 ; then
 
 		# attach to specifics tag or branch
 		local rtl8812auver="commit:450db78f7bd23f0c611553eb475fa5b5731d6497"
@@ -213,7 +213,7 @@ driver_xradio_xr819() {
 
 	# Wireless drivers for Xradio XR819 chipsets
 	if linux-version compare "${version}" ge 4.19 && linux-version compare "${version}" le 5.19 &&
-		[[ "$LINUXFAMILY" == sunxi* ]] && [[ "$EXTRAWIFI" == yes ]]; then
+		[[ "$LINUXFAMILY" == sunxi* ]] ; then
 
 		display_alert "Adding" "Wireless drivers for Xradio XR819 chipsets" "info"
 
@@ -254,7 +254,7 @@ driver_xradio_xr819() {
 driver_rtl8811CU_rtl8821C() {
 	# Wireless drivers for Realtek RTL8811CU and RTL8821C chipsets
 
-	if linux-version compare "${version}" ge 3.14 && [ "$EXTRAWIFI" == yes ]; then
+	if linux-version compare "${version}" ge 3.14 ; then
 
 		# attach to specifics tag or branch
 		local rtl8811cuver="commit:69c903b75bde36293c66b25c051916a74dbadf58"
@@ -307,8 +307,7 @@ driver_rtl8188EU_rtl8188ETV() {
 	# Wireless drivers for Realtek 8188EU 8188EUS and 8188ETV chipsets
 
 	if linux-version compare "${version}" ge 3.14 &&
-		linux-version compare "${version}" lt 5.15 &&
-		[ "$EXTRAWIFI" == yes ]; then
+		linux-version compare "${version}" lt 5.15 ; then
 
 		# attach to specifics tag or branch
 		local rtl8188euver="branch:v5.7.6.1"
@@ -355,7 +354,7 @@ driver_rtl88x2bu() {
 
 	# Wireless drivers for Realtek 88x2bu chipsets
 
-	if linux-version compare "${version}" ge 5.0 && [ "$EXTRAWIFI" == yes ]; then
+	if linux-version compare "${version}" ge 5.0 ; then
 
 		# attach to specifics tag or branch
 		local rtl88x2buver="commit:2590672d717e2516dd2e96ed66f1037a6815bced"
@@ -406,7 +405,7 @@ driver_rtw88() {
 	# Quite a few kernel families have KERNEL_DRIVERS_SKIP listing this driver. If so, this won't even be called.
 
 	# Upstream wireless RTW88 drivers (wireless-next-2023-06-22)
-	if [[ "$version" == "6.1" || "$version" == "6.2" || "$version" == "6.3" || "$version" == "6.4" ]] && [ $EXTRAWIFI == yes ]; then
+	if [[ "$version" == "6.1" || "$version" == "6.2" || "$version" == "6.3" || "$version" == "6.4" ]] ; then
 		display_alert "Adding" "Upstream wireless RTW88 drivers" "info"
 		process_patch_file "${SRC}/patch/misc/rtw88/${version}/001-rtw88-linux-next.patch" "applying"
 		process_patch_file "${SRC}/patch/misc/rtw88/${version}/002-rtw88-linux-next.patch" "applying"
@@ -420,7 +419,7 @@ driver_rtl88x2cs() {
 
 	# Wireless drivers for Realtek 88x2cs chipsets
 
-	if linux-version compare "${version}" ge 5.9 && [ "$EXTRAWIFI" == no ]; then
+	if linux-version compare "${version}" ge 5.9 && linux-version compare "${version}" lt 6.1 ; then
 
 		# attach to specifics tag or branch
 		local rtl88x2csver="branch:tune_for_jethub"
@@ -477,7 +476,7 @@ driver_rtl8822cs_bt() {
 driver_rtl8723DS() {
 	# Wireless drivers for Realtek 8723DS chipsets
 
-	if linux-version compare "${version}" ge 5.0 && [[ "$EXTRAWIFI" == yes ]]; then
+	if linux-version compare "${version}" ge 5.0 ; then
 
 		# attach to specifics tag or branch
 		local rtl8723dsver="branch:master"
@@ -520,7 +519,7 @@ driver_rtl8723DU() {
 
 	# Wireless drivers for Realtek 8723DU chipsets
 
-	if linux-version compare "${version}" ge 5.0 && [ "$EXTRAWIFI" == yes ]; then
+	if linux-version compare "${version}" ge 5.0 ; then
 
 		local rtl8723duver="branch:master"
 
@@ -562,7 +561,7 @@ driver_rtl8723DU() {
 driver_rtl8822BS() {
 	# Wireless drivers for Realtek 8822BS chipsets
 
-	if linux-version compare "${version}" ge 4.4 && linux-version compare "${version}" le 5.16 && [ "$EXTRAWIFI" == yes ]; then
+	if linux-version compare "${version}" ge 4.4 && linux-version compare "${version}" le 5.16 ; then
 
 		# attach to specifics tag or branch
 		display_alert "Adding" "Wireless drivers for Realtek 8822BS chipsets ${rtl8822bsver}" "info"


### PR DESCRIPTION
# Description

Make it possible to toggle EXTRAWIFI as a way to disable all extra network patches. For patches for one or more chipsets, user can use KERNEL_DRIVERS_SKIP

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Build with EXTRAWIFI=no and EXTRAWIFI=yes, checked that patches gets skipped when EXTRAWIFI=no is set to no and gets applied by default or when EXTRAWIFI=yes

# Checklist:

- [X] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
