### PR TITLE
patch: misc: rtw88: 6.4: `upstream wireless`

### DIFF
--- a/patch/misc/rtw88/6.4/001-rtw88-linux-next.patch
+++ b/patch/misc/rtw88/6.4/001-rtw88-linux-next.patch
@@ -307,8 +307,8 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/Kconfig b/drivers/net/wireless/r
  	tristate "Realtek 8723DU USB wireless network adapter"
  	depends on USB
 diff -Naur a/drivers/net/wireless/realtek/rtw88/mac80211.c b/drivers/net/wireless/realtek/rtw88/mac80211.c
---- a/drivers/net/wireless/realtek/rtw88/mac80211.c	2023-06-18 17:06:27.000000000 -0400
-+++ b/drivers/net/wireless/realtek/rtw88/mac80211.c	2023-06-22 13:52:09.000000000 -0400
+--- a/drivers/net/wireless/realtek/rtw88/mac80211.c	2023-07-19 10:37:03.000000000 -0400
++++ b/drivers/net/wireless/realtek/rtw88/mac80211.c	2023-07-19 15:52:13.130110125 -0400
 @@ -43,7 +43,11 @@
  		list_add_tail(&rtwtxq->list, &rtwdev->txqs);
  	spin_unlock_bh(&rtwdev->txq_lock);
@@ -322,19 +322,7 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/mac80211.c b/drivers/net/wireles
  }
  
  static int rtw_ops_start(struct ieee80211_hw *hw)
-@@ -164,8 +168,10 @@
- 	mutex_lock(&rtwdev->mutex);
- 
- 	port = find_first_zero_bit(rtwdev->hw_port, RTW_PORT_NUM);
--	if (port >= RTW_PORT_NUM)
-+	if (port >= RTW_PORT_NUM) {
-+		mutex_unlock(&rtwdev->mutex);
- 		return -EINVAL;
-+	}
- 	set_bit(port, rtwdev->hw_port);
- 
- 	rtwvif->port = port;
-@@ -376,6 +382,7 @@
+@@ -378,6 +382,7 @@
  
  			rtw_fw_download_rsvd_page(rtwdev);
  			rtw_send_rsvd_page_h2c(rtwdev);
@@ -342,7 +330,7 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/mac80211.c b/drivers/net/wireles
  			rtw_coex_media_status_notify(rtwdev, vif->cfg.assoc);
  			if (rtw_bf_support)
  				rtw_bf_assoc(rtwdev, vif, conf);
-@@ -447,6 +454,7 @@
+@@ -449,6 +454,7 @@
  	const struct rtw_chip_info *chip = rtwdev->chip;
  
  	mutex_lock(&rtwdev->mutex);
@@ -350,7 +338,7 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/mac80211.c b/drivers/net/wireles
  	rtwdev->ap_active = true;
  	rtw_store_op_chan(rtwdev, true);
  	chip->ops->phy_calibration(rtwdev);
-@@ -462,6 +470,7 @@
+@@ -464,6 +470,7 @@
  	struct rtw_dev *rtwdev = hw->priv;
  
  	mutex_lock(&rtwdev->mutex);
@@ -891,8 +879,8 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/tx.h b/drivers/net/wireless/real
  
  static inline void rtw_tx_fill_txdesc_checksum(struct rtw_dev *rtwdev,
 diff -Naur a/drivers/net/wireless/realtek/rtw88/usb.c b/drivers/net/wireless/realtek/rtw88/usb.c
---- a/drivers/net/wireless/realtek/rtw88/usb.c	2023-06-18 17:06:27.000000000 -0400
-+++ b/drivers/net/wireless/realtek/rtw88/usb.c	2023-06-22 13:52:09.000000000 -0400
+--- a/drivers/net/wireless/realtek/rtw88/usb.c	2023-07-19 10:37:03.000000000 -0400
++++ b/drivers/net/wireless/realtek/rtw88/usb.c	2023-07-19 15:52:13.134110080 -0400
 @@ -24,11 +24,12 @@
  static void rtw_usb_fill_tx_checksum(struct rtw_usb *rtwusb,
  				     struct sk_buff *skb, int agg_num)
@@ -945,15 +933,6 @@ diff -Naur a/drivers/net/wireless/realtek/rtw88/usb.c b/drivers/net/wireless/rea
  	else if (skb_get_queue_mapping(skb) <= IEEE80211_AC_BK)
  		qsel = skb->priority;
  	else
-@@ -535,7 +542,7 @@
- 		}
- 
- 		if (skb_queue_len(&rtwusb->rx_queue) >= RTW_USB_MAX_RXQ_LEN) {
--			rtw_err(rtwdev, "failed to get rx_queue, overflow\n");
-+			dev_dbg_ratelimited(rtwdev->dev, "failed to get rx_queue, overflow\n");
- 			dev_kfree_skb_any(skb);
- 			continue;
- 		}
 diff -Naur a/include/linux/mmc/sdio_ids.h b/include/linux/mmc/sdio_ids.h
 --- a/include/linux/mmc/sdio_ids.h	2023-06-18 17:06:27.000000000 -0400
 +++ b/include/linux/mmc/sdio_ids.h	2023-06-22 13:52:09.000000000 -0400


### PR DESCRIPTION
Adjusted patching in `drivers/net/wireless/realtek/rtw88/mac80211.c` and `drivers/net/wireless/realtek/rtw88/usb.c` to reflect update in Linux 6.4.4

https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/diff/drivers/net/wireless/realtek/rtw88/mac80211.c?id=v6.4.4&id2=v6.4.3
https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/diff/drivers/net/wireless/realtek/rtw88/usb.c?id=v6.4.4&id2=v6.4.3
# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
