### PR TITLE
Allwinner: current, edge: Bump kernel and u-boot

### DIFF
--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -12,7 +12,7 @@ declare -g ATF_TARGET_MAP="PLAT=$ATF_PLAT DEBUG=1 bl31;;build/$ATF_PLAT/debug/bl
 declare -g ATFBRANCH="tag:v2.9.0"
 declare -g BOOTDELAY=1
 declare -g BOOTPATCHDIR="${BOOTPATCHDIR:-"u-boot-sunxi"}"
-declare -g BOOTBRANCH="${BOOTBRANCH:-"tag:v2023.07"}"
+declare -g BOOTBRANCH="${BOOTBRANCH:-"tag:v2023.07.02"}"
 declare -g BOOTENV_FILE='sunxi.txt'
 UBOOT_TARGET_MAP="${UBOOT_TARGET_MAP:-BINMAN_ALLOW_MISSING=1;;u-boot-sunxi-with-spl.bin}"
 declare -g BOOTSCRIPT='boot-sun50i-next.cmd:boot.cmd'
@@ -29,12 +29,12 @@ case $BRANCH in
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.1.38"
+		declare -g KERNELBRANCH="tag:v6.1.39"
 		;;
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.4" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.4.2"
+		declare -g KERNELBRANCH="tag:v6.4.4"
 		;;
 esac
 

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -10,7 +10,7 @@ enable_extension "sunxi-tools"
 declare -g ARCH=armhf
 declare -g BOOTDELAY=1
 declare -g BOOTPATCHDIR="${BOOTPATCHDIR:-"u-boot-sunxi"}"
-declare -g BOOTBRANCH="${BOOTBRANCH:-"tag:v2023.07"}"
+declare -g BOOTBRANCH="${BOOTBRANCH:-"tag:v2023.07.02"}"
 UBOOT_TARGET_MAP="${UBOOT_TARGET_MAP:-;;u-boot-sunxi-with-spl.bin}"
 declare -g BOOTSCRIPT="boot-sunxi.cmd:boot.cmd"
 declare -g BOOTENV_FILE='sunxi.txt'
@@ -30,12 +30,12 @@ case $BRANCH in
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.1.38"
+		declare -g KERNELBRANCH="tag:v6.1.39"
 		;;
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.4" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.4.2"
+		declare -g KERNELBRANCH="tag:v6.4.4"
 		;;
 esac
 

--- a/patch/kernel/archive/sunxi-6.1/patches.megous/thermal-sun8i-Be-loud-when-probe-fails.patch
+++ b/patch/kernel/archive/sunxi-6.1/patches.megous/thermal-sun8i-Be-loud-when-probe-fails.patch
@@ -1,7 +1,7 @@
-From 244b5d23ff96457031d6c5985844c6c3d815cbb1 Mon Sep 17 00:00:00 2001
+From 6f93fd0c592ac63ee7e6c037248d52ab398c0fe0 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ond=C5=99ej=20Jirman?= <megi@xff.cz>
 Date: Wed, 8 Jul 2020 12:21:14 +0200
-Subject: [PATCH 235/389] thermal: sun8i: Be loud when probe fails
+Subject: [PATCH] thermal: sun8i: Be loud when probe fails
 
 I noticed several mobile Linux distributions failing to enable the
 thermal regulation correctly, because the kernel is silent
@@ -15,10 +15,10 @@ Signed-off-by: Ondrej Jirman <megi@xff.cz>
  1 file changed, 29 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/thermal/sun8i_thermal.c b/drivers/thermal/sun8i_thermal.c
-index e64d06d1328c..85b38fb62dce 100644
+index b17fd7c7ca58..42b1d8112ee6 100644
 --- a/drivers/thermal/sun8i_thermal.c
 +++ b/drivers/thermal/sun8i_thermal.c
-@@ -288,8 +288,13 @@ static int sun8i_ths_calibrate(struct ths_device *tmdev)
+@@ -379,8 +379,13 @@ static int sun8i_ths_calibrate(struct ths_device *tmdev)
  
  	calcell = devm_nvmem_cell_get(dev, "calibration");
  	if (IS_ERR(calcell)) {
@@ -32,7 +32,7 @@ index e64d06d1328c..85b38fb62dce 100644
  		/*
  		 * Even if the external calibration data stored in sid is
  		 * not accessible, the THS hardware can still work, although
-@@ -309,6 +314,8 @@ static int sun8i_ths_calibrate(struct ths_device *tmdev)
+@@ -400,6 +405,8 @@ static int sun8i_ths_calibrate(struct ths_device *tmdev)
  	caldata = nvmem_cell_read(calcell, &callen);
  	if (IS_ERR(caldata)) {
  		ret = PTR_ERR(caldata);
@@ -41,7 +41,7 @@ index e64d06d1328c..85b38fb62dce 100644
  		goto out;
  	}
  
-@@ -331,23 +338,33 @@ static int sun8i_ths_resource_init(struct ths_device *tmdev)
+@@ -427,13 +434,17 @@ static int sun8i_ths_resource_init(struct ths_device *tmdev)
  		return PTR_ERR(base);
  
  	tmdev->regmap = devm_regmap_init_mmio(dev, base, &config);
@@ -59,7 +59,12 @@ index e64d06d1328c..85b38fb62dce 100644
  			return PTR_ERR(tmdev->reset);
 +		}
  
- 		tmdev->bus_clk = devm_clk_get(&pdev->dev, "bus");
+ 		ret = reset_control_deassert(tmdev->reset);
+ 		if (ret)
+@@ -445,14 +456,20 @@ static int sun8i_ths_resource_init(struct ths_device *tmdev)
+ 			return ret;
+ 
+ 		tmdev->bus_clk = devm_clk_get_enabled(&pdev->dev, "bus");
 -		if (IS_ERR(tmdev->bus_clk))
 +		if (IS_ERR(tmdev->bus_clk)) {
 +			dev_err(dev, "Failed to get bus clock (%pe)\n",
@@ -69,7 +74,7 @@ index e64d06d1328c..85b38fb62dce 100644
  	}
  
  	if (tmdev->chip->has_mod_clk) {
- 		tmdev->mod_clk = devm_clk_get(&pdev->dev, "mod");
+ 		tmdev->mod_clk = devm_clk_get_enabled(&pdev->dev, "mod");
 -		if (IS_ERR(tmdev->mod_clk))
 +		if (IS_ERR(tmdev->mod_clk)) {
 +			dev_err(dev, "Failed to get mod clock (%pe)\n",
@@ -78,8 +83,8 @@ index e64d06d1328c..85b38fb62dce 100644
 +		}
  	}
  
- 	ret = reset_control_deassert(tmdev->reset);
-@@ -472,8 +489,12 @@ static int sun8i_ths_register(struct ths_device *tmdev)
+ 	ret = clk_set_rate(tmdev->mod_clk, 24000000);
+@@ -580,8 +597,12 @@ static int sun8i_ths_register(struct ths_device *tmdev)
  						      i,
  						      &tmdev->sensor[i],
  						      &ths_ops);
@@ -93,7 +98,7 @@ index e64d06d1328c..85b38fb62dce 100644
  
  		if (devm_thermal_add_hwmon_sysfs(tmdev->sensor[i].tzd))
  			dev_warn(tmdev->dev,
-@@ -524,8 +545,10 @@ static int sun8i_ths_probe(struct platform_device *pdev)
+@@ -632,8 +653,10 @@ static int sun8i_ths_probe(struct platform_device *pdev)
  	ret = devm_request_threaded_irq(dev, irq, NULL,
  					sun8i_irq_thread,
  					IRQF_ONESHOT, "ths", tmdev);
@@ -106,5 +111,5 @@ index e64d06d1328c..85b38fb62dce 100644
  	return 0;
  }
 -- 
-2.35.3
+2.34.1
 

--- a/patch/kernel/archive/sunxi-6.1/series.conf
+++ b/patch/kernel/archive/sunxi-6.1/series.conf
@@ -195,7 +195,7 @@
 	patches.megous/drm-sun4i-Unify-sun8i_-_layer-structs.patch
 	patches.megous/drm-sun4i-Add-more-parameters-to-sunxi_engine-commit-callback.patch
 	patches.megous/drm-sun4i-Fix-layer-zpos-change-atomic-modesetting.patch
-	patches.megous/drm-sun4i-Fix-wrong-location-of-clk_prepare_enable.patch
+-	patches.megous/drm-sun4i-Fix-wrong-location-of-clk_prepare_enable.patch
 	patches.megous/drm-sun4i-Mark-one-of-the-UI-planes-as-a-cursor-one.patch
 	patches.megous/drm-sun4i-decouple-TCON_DCLK_DIV-value-from-pll_mipi-dotclock-r.patch
 	patches.megous/drm-sun4i-Implement-gamma-correction.patch

--- a/patch/kernel/archive/sunxi-6.1/series.megous
+++ b/patch/kernel/archive/sunxi-6.1/series.megous
@@ -195,7 +195,7 @@
 	patches.megous/drm-sun4i-Unify-sun8i_-_layer-structs.patch
 	patches.megous/drm-sun4i-Add-more-parameters-to-sunxi_engine-commit-callback.patch
 	patches.megous/drm-sun4i-Fix-layer-zpos-change-atomic-modesetting.patch
-	patches.megous/drm-sun4i-Fix-wrong-location-of-clk_prepare_enable.patch
+-	patches.megous/drm-sun4i-Fix-wrong-location-of-clk_prepare_enable.patch
 	patches.megous/drm-sun4i-Mark-one-of-the-UI-planes-as-a-cursor-one.patch
 	patches.megous/drm-sun4i-decouple-TCON_DCLK_DIV-value-from-pll_mipi-dotclock-r.patch
 	patches.megous/drm-sun4i-Implement-gamma-correction.patch

--- a/patch/kernel/archive/sunxi-6.4/patches.megous/thermal-sun8i-Be-loud-when-probe-fails.patch
+++ b/patch/kernel/archive/sunxi-6.4/patches.megous/thermal-sun8i-Be-loud-when-probe-fails.patch
@@ -1,7 +1,7 @@
-From 6d96012fc35de928a82701875603301c1fda4659 Mon Sep 17 00:00:00 2001
+From f266e103e5ec3023a0b947cc9faf568e0867199c Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ond=C5=99ej=20Jirman?= <megi@xff.cz>
 Date: Wed, 8 Jul 2020 12:21:14 +0200
-Subject: [PATCH 237/469] thermal: sun8i: Be loud when probe fails
+Subject: [PATCH] thermal: sun8i: Be loud when probe fails
 
 I noticed several mobile Linux distributions failing to enable the
 thermal regulation correctly, because the kernel is silent
@@ -11,14 +11,14 @@ to probe.
 
 Signed-off-by: Ondrej Jirman <megi@xff.cz>
 ---
- drivers/thermal/sun8i_thermal.c | 35 +++++++++++++++++++++++++++------
- 1 file changed, 29 insertions(+), 6 deletions(-)
+ drivers/thermal/sun8i_thermal.c | 36 +++++++++++++++++++++++++++------
+ 1 file changed, 30 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/thermal/sun8i_thermal.c b/drivers/thermal/sun8i_thermal.c
-index 793ddce72132..b27bd799061a 100644
+index 58943ea6b656..d4d3fb86d861 100644
 --- a/drivers/thermal/sun8i_thermal.c
 +++ b/drivers/thermal/sun8i_thermal.c
-@@ -288,8 +288,13 @@ static int sun8i_ths_calibrate(struct ths_device *tmdev)
+@@ -352,8 +352,13 @@ static int sun8i_ths_calibrate(struct ths_device *tmdev)
  
  	calcell = devm_nvmem_cell_get(dev, "calibration");
  	if (IS_ERR(calcell)) {
@@ -32,7 +32,7 @@ index 793ddce72132..b27bd799061a 100644
  		/*
  		 * Even if the external calibration data stored in sid is
  		 * not accessible, the THS hardware can still work, although
-@@ -309,6 +314,8 @@ static int sun8i_ths_calibrate(struct ths_device *tmdev)
+@@ -373,6 +378,8 @@ static int sun8i_ths_calibrate(struct ths_device *tmdev)
  	caldata = nvmem_cell_read(calcell, &callen);
  	if (IS_ERR(caldata)) {
  		ret = PTR_ERR(caldata);
@@ -41,7 +41,7 @@ index 793ddce72132..b27bd799061a 100644
  		goto out;
  	}
  
-@@ -331,23 +338,33 @@ static int sun8i_ths_resource_init(struct ths_device *tmdev)
+@@ -400,13 +407,17 @@ static int sun8i_ths_resource_init(struct ths_device *tmdev)
  		return PTR_ERR(base);
  
  	tmdev->regmap = devm_regmap_init_mmio(dev, base, &config);
@@ -59,7 +59,12 @@ index 793ddce72132..b27bd799061a 100644
  			return PTR_ERR(tmdev->reset);
 +		}
  
- 		tmdev->bus_clk = devm_clk_get(&pdev->dev, "bus");
+ 		ret = reset_control_deassert(tmdev->reset);
+ 		if (ret)
+@@ -418,14 +429,21 @@ static int sun8i_ths_resource_init(struct ths_device *tmdev)
+ 			return ret;
+ 
+ 		tmdev->bus_clk = devm_clk_get_enabled(&pdev->dev, "bus");
 -		if (IS_ERR(tmdev->bus_clk))
 +		if (IS_ERR(tmdev->bus_clk)) {
 +			dev_err(dev, "Failed to get bus clock (%pe)\n",
@@ -69,8 +74,9 @@ index 793ddce72132..b27bd799061a 100644
  	}
  
  	if (tmdev->chip->has_mod_clk) {
- 		tmdev->mod_clk = devm_clk_get(&pdev->dev, "mod");
+ 		tmdev->mod_clk = devm_clk_get_enabled(&pdev->dev, "mod");
 -		if (IS_ERR(tmdev->mod_clk))
++		tmdev->mod_clk = devm_clk_get(&pdev->dev, "mod");
 +		if (IS_ERR(tmdev->mod_clk)) {
 +			dev_err(dev, "Failed to get mod clock (%pe)\n",
 +				tmdev->mod_clk);
@@ -78,8 +84,8 @@ index 793ddce72132..b27bd799061a 100644
 +		}
  	}
  
- 	ret = reset_control_deassert(tmdev->reset);
-@@ -472,8 +489,12 @@ static int sun8i_ths_register(struct ths_device *tmdev)
+ 	ret = clk_set_rate(tmdev->mod_clk, 24000000);
+@@ -553,8 +571,12 @@ static int sun8i_ths_register(struct ths_device *tmdev)
  						      i,
  						      &tmdev->sensor[i],
  						      &ths_ops);
@@ -93,7 +99,7 @@ index 793ddce72132..b27bd799061a 100644
  
  		if (devm_thermal_add_hwmon_sysfs(tmdev->dev, tmdev->sensor[i].tzd))
  			dev_warn(tmdev->dev,
-@@ -524,8 +545,10 @@ static int sun8i_ths_probe(struct platform_device *pdev)
+@@ -605,8 +627,10 @@ static int sun8i_ths_probe(struct platform_device *pdev)
  	ret = devm_request_threaded_irq(dev, irq, NULL,
  					sun8i_irq_thread,
  					IRQF_ONESHOT, "ths", tmdev);

--- a/patch/kernel/archive/sunxi-6.4/series.conf
+++ b/patch/kernel/archive/sunxi-6.4/series.conf
@@ -228,7 +228,7 @@
 	patches.megous/drm-sun4i-Unify-sun8i_-_layer-structs.patch
 	patches.megous/drm-sun4i-Add-more-parameters-to-sunxi_engine-commit-callback.patch
 	patches.megous/drm-sun4i-Fix-layer-zpos-change-atomic-modesetting.patch
-	patches.megous/drm-sun4i-Fix-wrong-location-of-clk_prepare_enable.patch
+-	patches.megous/drm-sun4i-Fix-wrong-location-of-clk_prepare_enable.patch
 	patches.megous/drm-sun4i-Mark-one-of-the-UI-planes-as-a-cursor-one.patch
 	patches.megous/drm-sun4i-decouple-TCON_DCLK_DIV-value-from-pll_mipi-dotclock-r.patch
 	patches.megous/drm-sun4i-Implement-gamma-correction.patch
@@ -309,10 +309,10 @@
 	patches.megous/mfd-rk8xx-add-rk806-support.patch
 	patches.megous/pinctrl-rk805-add-rk806-pinctrl-support.patch
 	patches.megous/regulator-expose-regulator_find_closest_bigger.patch
-	patches.megous/regulator-rk808-fix-asynchronous-probing.patch
-	patches.megous/regulator-rk808-cleanup-parent-device-usage.patch
-	patches.megous/regulator-rk808-revert-to-synchronous-probing.patch
-	patches.megous/regulator-rk808-add-rk806-support.patch
+-	patches.megous/regulator-rk808-fix-asynchronous-probing.patch
+-	patches.megous/regulator-rk808-cleanup-parent-device-usage.patch
+-	patches.megous/regulator-rk808-revert-to-synchronous-probing.patch
+-	patches.megous/regulator-rk808-add-rk806-support.patch
 	patches.megous/arm64-defconfig-update-RK8XX-MFD-config.patch
 	patches.megous/ARM-multi_v7_defconfig-update-MFD_RK808-name.patch
 -	patches.megous/clk-rk3399-Export-SCLK_CIF_OUT_SRC-to-device-tree.patch
@@ -454,8 +454,8 @@
 -	patches.megous/nvmem-rockchip-otp-Improve-probe-error-handling.patch
 -	patches.megous/nvmem-rockchip-otp-Add-support-for-RK3588.patch
 -	patches.megous/arm64-dts-rockchip-Add-rk3588-OTP-node.patch
-	patches.megous/ASoC-es8316-Increment-max-value-for-ALC-Capture-Target-Volume-c.patch
-	patches.megous/ASoC-es8316-Do-not-set-rate-constraints-for-unsupported-MCLKs.patch
+-	patches.megous/ASoC-es8316-Increment-max-value-for-ALC-Capture-Target-Volume-c.patch
+-	patches.megous/ASoC-es8316-Do-not-set-rate-constraints-for-unsupported-MCLKs.patch
 -	patches.megous/arm64-defconfig-Enable-Rockchip-OTP-memory-driver.patch
 -	patches.megous/dt-bindings-iio-rockchip-Fix-oneOf-condition-failed-warning.patch
 -	patches.megous/dt-bindings-phy-add-rockchip-usbdp-combo-phy-document.patch

--- a/patch/kernel/archive/sunxi-6.4/series.megous
+++ b/patch/kernel/archive/sunxi-6.4/series.megous
@@ -228,7 +228,7 @@
 	patches.megous/drm-sun4i-Unify-sun8i_-_layer-structs.patch
 	patches.megous/drm-sun4i-Add-more-parameters-to-sunxi_engine-commit-callback.patch
 	patches.megous/drm-sun4i-Fix-layer-zpos-change-atomic-modesetting.patch
-	patches.megous/drm-sun4i-Fix-wrong-location-of-clk_prepare_enable.patch
+-	patches.megous/drm-sun4i-Fix-wrong-location-of-clk_prepare_enable.patch
 	patches.megous/drm-sun4i-Mark-one-of-the-UI-planes-as-a-cursor-one.patch
 	patches.megous/drm-sun4i-decouple-TCON_DCLK_DIV-value-from-pll_mipi-dotclock-r.patch
 	patches.megous/drm-sun4i-Implement-gamma-correction.patch
@@ -309,10 +309,10 @@
 	patches.megous/mfd-rk8xx-add-rk806-support.patch
 	patches.megous/pinctrl-rk805-add-rk806-pinctrl-support.patch
 	patches.megous/regulator-expose-regulator_find_closest_bigger.patch
-	patches.megous/regulator-rk808-fix-asynchronous-probing.patch
-	patches.megous/regulator-rk808-cleanup-parent-device-usage.patch
-	patches.megous/regulator-rk808-revert-to-synchronous-probing.patch
-	patches.megous/regulator-rk808-add-rk806-support.patch
+-	patches.megous/regulator-rk808-fix-asynchronous-probing.patch
+-	patches.megous/regulator-rk808-cleanup-parent-device-usage.patch
+-	patches.megous/regulator-rk808-revert-to-synchronous-probing.patch
+-	patches.megous/regulator-rk808-add-rk806-support.patch
 	patches.megous/arm64-defconfig-update-RK8XX-MFD-config.patch
 	patches.megous/ARM-multi_v7_defconfig-update-MFD_RK808-name.patch
 -	patches.megous/clk-rk3399-Export-SCLK_CIF_OUT_SRC-to-device-tree.patch
@@ -454,8 +454,8 @@
 -	patches.megous/nvmem-rockchip-otp-Improve-probe-error-handling.patch
 -	patches.megous/nvmem-rockchip-otp-Add-support-for-RK3588.patch
 -	patches.megous/arm64-dts-rockchip-Add-rk3588-OTP-node.patch
-	patches.megous/ASoC-es8316-Increment-max-value-for-ALC-Capture-Target-Volume-c.patch
-	patches.megous/ASoC-es8316-Do-not-set-rate-constraints-for-unsupported-MCLKs.patch
+-	patches.megous/ASoC-es8316-Increment-max-value-for-ALC-Capture-Target-Volume-c.patch
+-	patches.megous/ASoC-es8316-Do-not-set-rate-constraints-for-unsupported-MCLKs.patch
 -	patches.megous/arm64-defconfig-Enable-Rockchip-OTP-memory-driver.patch
 -	patches.megous/dt-bindings-iio-rockchip-Fix-oneOf-condition-failed-warning.patch
 -	patches.megous/dt-bindings-phy-add-rockchip-usbdp-combo-phy-document.patch


### PR DESCRIPTION
# Description

Bumped kernel versions

Current: 6.1.38 -> 6.1.39
Edge: 6.4.2 -> 6.4.4

- Modified thermal-sun8i-Be-loud-when-probe-fails.patch to fix patch application failure
- Disabled drm-sun4i-Fix-wrong-location-of-clk_prepare_enable.patch to fix patch failure and as its not needed after the upstream change
- Rest of the disabled patches for 6.4.4 are upstreamed

U-boot: 2023.07 -> 2023.07.02. This is very trivial bump. It only removes the -rc6 extra version from the Makefile which was not removed when 2023.07 was released.

Jira reference number [AR-9999]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Booted current and edge images on Orange Pi Prime (sun50i H5)
- [X] Booted current and edge images on NanoPi Duo2 (sun8i H3)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
