### PR TITLE
NanoPC-T6 Collabora:  add PCIe 3

### DIFF
--- a/patch/kernel/rockchip-rk3588-collabora/dt/rk3588-nanopc-t6.dts
+++ b/patch/kernel/rockchip-rk3588-collabora/dt/rk3588-nanopc-t6.dts
@@ -77,6 +77,18 @@
 		vin-supply = <&vcc_3v3_s3>;
 	};
 
+	vcc3v3_pcie30: vcc3v3-pcie30 {
+		compatible = "regulator-fixed";
+		enable-active-high;
+		gpios = <&gpio2 RK_PC5 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&pcie_m2_0_pwren>;
+		regulator-name = "vcc3v3_pcie30";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		vin-supply = <&vcc5v0_sys>;
+	};
+
 	vdd_mpcie_3v3: vdd-mpcie-3v3 {
 		compatible = "regulator-fixed";
 		enable-active-high;
@@ -262,6 +274,17 @@
 		};
 	};
 };
+
+&pcie30phy {
+	status = "okay";
+};
+
+&pcie3x4 {
+	reset-gpios = <&gpio4 RK_PB6 GPIO_ACTIVE_HIGH>;
+	vpcie3v3-supply = <&vcc3v3_pcie30>;
+	status = "okay";
+};
+
 
 &pinctrl {
 


### PR DESCRIPTION
# Description

Collabora has added PCIe 3 support, enable in NanoPC-T6

# How Has This Been Tested?

NVMe detected/functional

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
