### PR TITLE
Orange Pi: Allwinner: remove rk3399 bluetooth service

### DIFF
--- a/config/boards/orangepi-r1.conf
+++ b/config/boards/orangepi-r1.conf
@@ -10,17 +10,3 @@ HAS_VIDEO_OUTPUT="no"
 DEFAULT_CONSOLE="serial"
 SERIALCON="ttyS0,ttyGS0"
 KERNEL_TARGET="current,edge"
-
-function post_family_tweaks_bsp__orangepi-r1_BSP() {
-    display_alert "Installing BSP firmware and fixups"
-
-	if [[ $BRANCH == legacy ]]; then
-
-		# Bluetooth for most of others (custom patchram is needed only in legacy)
-		install -m 755 $SRC/packages/bsp/rk3399/brcm_patchram_plus_rk3399 $destination/usr/bin
-		cp $SRC/packages/bsp/rk3399/rk3399-bluetooth.service $destination/lib/systemd/system/
-
-	fi
-
-	return 0
-}

--- a/config/boards/orangepi.eos
+++ b/config/boards/orangepi.eos
@@ -4,17 +4,3 @@ BOARDFAMILY="sun7i"
 BOARD_MAINTAINER=""
 BOOTCONFIG="Orangepi_defconfig"
 KERNEL_TARGET="legacy,current,edge"
-
-function post_family_tweaks_bsp__orangepi_BSP() {
-    display_alert "Installing BSP firmware and fixups"
-
-	if [[ $BRANCH == legacy ]]; then
-
-		# Bluetooth for most of others (custom patchram is needed only in legacy)
-		install -m 755 $SRC/packages/bsp/rk3399/brcm_patchram_plus_rk3399 $destination/usr/bin
-		cp $SRC/packages/bsp/rk3399/rk3399-bluetooth.service $destination/lib/systemd/system/
-
-	fi
-
-	return 0
-}

--- a/config/boards/orangepi2.csc
+++ b/config/boards/orangepi2.csc
@@ -4,17 +4,3 @@ BOARDFAMILY="sun8i"
 BOARD_MAINTAINER=""
 BOOTCONFIG="orangepi_2_defconfig"
 KERNEL_TARGET="legacy,current,edge"
-
-function post_family_tweaks_bsp__orangepi2_BSP() {
-    display_alert "Installing BSP firmware and fixups"
-
-	if [[ $BRANCH == legacy ]]; then
-
-		# Bluetooth for most of others (custom patchram is needed only in legacy)
-		install -m 755 $SRC/packages/bsp/rk3399/brcm_patchram_plus_rk3399 $destination/usr/bin
-		cp $SRC/packages/bsp/rk3399/rk3399-bluetooth.service $destination/lib/systemd/system/
-
-	fi
-
-	return 0
-}

--- a/config/boards/orangepi3-lts.csc
+++ b/config/boards/orangepi3-lts.csc
@@ -7,17 +7,3 @@ KERNEL_TARGET="current,edge"
 MODULES="sprdbt_tty sprdwl_ng"
 MODULES_BLACKLIST_LEGACY="bcmdhd"
 CRUSTCONFIG="h6_defconfig"
-
-function post_family_tweaks_bsp__orangepi3-lts_BSP() {
-    display_alert "Installing BSP firmware and fixups"
-
-	if [[ $BRANCH == legacy ]]; then
-
-		# Bluetooth for most of others (custom patchram is needed only in legacy)
-		install -m 755 $SRC/packages/bsp/rk3399/brcm_patchram_plus_rk3399 $destination/usr/bin
-		cp $SRC/packages/bsp/rk3399/rk3399-bluetooth.service $destination/lib/systemd/system/
-
-	fi
-
-	return 0
-}

--- a/config/boards/orangepi3.csc
+++ b/config/boards/orangepi3.csc
@@ -6,17 +6,3 @@ BOOTCONFIG="orangepi_3_defconfig"
 KERNEL_TARGET="legacy,current,edge"
 FULL_DESKTOP="yes"
 CRUSTCONFIG="h6_defconfig"
-
-function post_family_tweaks_bsp__orangepi3_BSP() {
-    display_alert "Installing BSP firmware and fixups"
-
-	if [[ $BRANCH == legacy ]]; then
-
-		# Bluetooth for most of others (custom patchram is needed only in legacy)
-		install -m 755 $SRC/packages/bsp/rk3399/brcm_patchram_plus_rk3399 $destination/usr/bin
-		cp $SRC/packages/bsp/rk3399/rk3399-bluetooth.service $destination/lib/systemd/system/
-
-	fi
-
-	return 0
-}

--- a/config/boards/orangepilite.csc
+++ b/config/boards/orangepilite.csc
@@ -6,17 +6,3 @@ BOOTCONFIG="orangepi_lite_defconfig"
 MODULES_LEGACY="g_serial"
 MODULES_CURRENT="g_serial"
 KERNEL_TARGET="legacy,current,edge"
-
-function post_family_tweaks_bsp__orangepilite_BSP() {
-    display_alert "Installing BSP firmware and fixups"
-
-	if [[ $BRANCH == legacy ]]; then
-
-		# Bluetooth for most of others (custom patchram is needed only in legacy)
-		install -m 755 $SRC/packages/bsp/rk3399/brcm_patchram_plus_rk3399 $destination/usr/bin
-		cp $SRC/packages/bsp/rk3399/rk3399-bluetooth.service $destination/lib/systemd/system/
-
-	fi
-
-	return 0
-}

--- a/config/boards/orangepilite2.csc
+++ b/config/boards/orangepilite2.csc
@@ -5,17 +5,3 @@ BOARD_MAINTAINER=""
 BOOTCONFIG="orangepi_lite2_defconfig"
 KERNEL_TARGET="legacy,current,edge"
 CRUSTCONFIG="h6_defconfig"
-
-function post_family_tweaks_bsp__orangepilite2_BSP() {
-    display_alert "Installing BSP firmware and fixups"
-
-	if [[ $BRANCH == legacy ]]; then
-
-		# Bluetooth for most of others (custom patchram is needed only in legacy)
-		install -m 755 $SRC/packages/bsp/rk3399/brcm_patchram_plus_rk3399 $destination/usr/bin
-		cp $SRC/packages/bsp/rk3399/rk3399-bluetooth.service $destination/lib/systemd/system/
-
-	fi
-
-	return 0
-}

--- a/config/boards/orangepimini.eos
+++ b/config/boards/orangepimini.eos
@@ -4,17 +4,3 @@ BOARDFAMILY="sun7i"
 BOARD_MAINTAINER=""
 BOOTCONFIG="Orangepi_mini_defconfig"
 KERNEL_TARGET="legacy,current,edge"
-
-function post_family_tweaks_bsp__orangepimini_BSP() {
-    display_alert "Installing BSP firmware and fixups"
-
-	if [[ $BRANCH == legacy ]]; then
-
-		# Bluetooth for most of others (custom patchram is needed only in legacy)
-		install -m 755 $SRC/packages/bsp/rk3399/brcm_patchram_plus_rk3399 $destination/usr/bin
-		cp $SRC/packages/bsp/rk3399/rk3399-bluetooth.service $destination/lib/systemd/system/
-
-	fi
-
-	return 0
-}

--- a/config/boards/orangepione.conf
+++ b/config/boards/orangepione.conf
@@ -4,17 +4,3 @@ BOARDFAMILY="sun8i"
 BOARD_MAINTAINER="StephenGraf"
 BOOTCONFIG="orangepi_one_defconfig"
 KERNEL_TARGET="legacy,current,edge"
-
-function post_family_tweaks_bsp__orangepione_BSP() {
-    display_alert "Installing BSP firmware and fixups"
-
-	if [[ $BRANCH == legacy ]]; then
-
-		# Bluetooth for most of others (custom patchram is needed only in legacy)
-		install -m 755 $SRC/packages/bsp/rk3399/brcm_patchram_plus_rk3399 $destination/usr/bin
-		cp $SRC/packages/bsp/rk3399/rk3399-bluetooth.service $destination/lib/systemd/system/
-
-	fi
-
-	return 0
-}

--- a/config/boards/orangepioneplus.csc
+++ b/config/boards/orangepioneplus.csc
@@ -5,17 +5,3 @@ BOARD_MAINTAINER=""
 BOOTCONFIG="orangepi_one_plus_defconfig"
 KERNEL_TARGET="legacy,current,edge"
 CRUSTCONFIG="h6_defconfig"
-
-function post_family_tweaks_bsp__orangepioneplus_BSP() {
-    display_alert "Installing BSP firmware and fixups"
-
-	if [[ $BRANCH == legacy ]]; then
-
-		# Bluetooth for most of others (custom patchram is needed only in legacy)
-		install -m 755 $SRC/packages/bsp/rk3399/brcm_patchram_plus_rk3399 $destination/usr/bin
-		cp $SRC/packages/bsp/rk3399/rk3399-bluetooth.service $destination/lib/systemd/system/
-
-	fi
-
-	return 0
-}

--- a/config/boards/orangepipc.conf
+++ b/config/boards/orangepipc.conf
@@ -4,17 +4,3 @@ BOARDFAMILY="sun8i"
 BOARD_MAINTAINER="lbmendes"
 BOOTCONFIG="orangepi_pc_defconfig"
 KERNEL_TARGET="legacy,current,edge"
-
-function post_family_tweaks_bsp__orangepipc_BSP() {
-    display_alert "Installing BSP firmware and fixups"
-
-	if [[ $BRANCH == legacy ]]; then
-
-		# Bluetooth for most of others (custom patchram is needed only in legacy)
-		install -m 755 $SRC/packages/bsp/rk3399/brcm_patchram_plus_rk3399 $destination/usr/bin
-		cp $SRC/packages/bsp/rk3399/rk3399-bluetooth.service $destination/lib/systemd/system/
-
-	fi
-
-	return 0
-}

--- a/config/boards/orangepipc2.csc
+++ b/config/boards/orangepipc2.csc
@@ -6,17 +6,3 @@ BOOTCONFIG="orangepi_pc2_defconfig"
 KERNEL_TARGET="legacy,current,edge"
 FULL_DESKTOP="yes"
 CRUSTCONFIG="h5_defconfig"
-
-function post_family_tweaks_bsp__orangepipc2_BSP() {
-    display_alert "Installing BSP firmware and fixups"
-
-	if [[ $BRANCH == legacy ]]; then
-
-		# Bluetooth for most of others (custom patchram is needed only in legacy)
-		install -m 755 $SRC/packages/bsp/rk3399/brcm_patchram_plus_rk3399 $destination/usr/bin
-		cp $SRC/packages/bsp/rk3399/rk3399-bluetooth.service $destination/lib/systemd/system/
-
-	fi
-
-	return 0
-}

--- a/config/boards/orangepipcplus.csc
+++ b/config/boards/orangepipcplus.csc
@@ -4,17 +4,3 @@ BOARDFAMILY="sun8i"
 BOARD_MAINTAINER=""
 BOOTCONFIG="orangepi_pc_plus_defconfig"
 KERNEL_TARGET="legacy,current,edge"
-
-function post_family_tweaks_bsp__orangepipcplus_BSP() {
-    display_alert "Installing BSP firmware and fixups"
-
-	if [[ $BRANCH == legacy ]]; then
-
-		# Bluetooth for most of others (custom patchram is needed only in legacy)
-		install -m 755 $SRC/packages/bsp/rk3399/brcm_patchram_plus_rk3399 $destination/usr/bin
-		cp $SRC/packages/bsp/rk3399/rk3399-bluetooth.service $destination/lib/systemd/system/
-
-	fi
-
-	return 0
-}

--- a/config/boards/orangepiplus.csc
+++ b/config/boards/orangepiplus.csc
@@ -4,17 +4,3 @@ BOARDFAMILY="sun8i"
 BOARD_MAINTAINER=""
 BOOTCONFIG="orangepi_plus_defconfig"
 KERNEL_TARGET="legacy,current,edge"
-
-function post_family_tweaks_bsp__orangepiplus_BSP() {
-    display_alert "Installing BSP firmware and fixups"
-
-	if [[ $BRANCH == legacy ]]; then
-
-		# Bluetooth for most of others (custom patchram is needed only in legacy)
-		install -m 755 $SRC/packages/bsp/rk3399/brcm_patchram_plus_rk3399 $destination/usr/bin
-		cp $SRC/packages/bsp/rk3399/rk3399-bluetooth.service $destination/lib/systemd/system/
-
-	fi
-
-	return 0
-}

--- a/config/boards/orangepiplus2e.csc
+++ b/config/boards/orangepiplus2e.csc
@@ -5,17 +5,3 @@ BOARD_MAINTAINER=""
 BOOTCONFIG="orangepi_plus2e_defconfig"
 KERNEL_TARGET="legacy,current,edge"
 FULL_DESKTOP="yes"
-
-function post_family_tweaks_bsp__orangepiplus2e_BSP() {
-	display_alert "Installing BSP firmware and fixups"
-
-	if [[ $BRANCH == legacy ]]; then
-
-		# Bluetooth for most of others (custom patchram is needed only in legacy)
-		install -m 755 $SRC/packages/bsp/rk3399/brcm_patchram_plus_rk3399 $destination/usr/bin
-		cp $SRC/packages/bsp/rk3399/rk3399-bluetooth.service $destination/lib/systemd/system/
-
-	fi
-
-	return 0
-}

--- a/config/boards/orangepiprime.conf
+++ b/config/boards/orangepiprime.conf
@@ -7,17 +7,3 @@ DEFAULT_OVERLAYS="analog-codec"
 KERNEL_TARGET="legacy,current,edge"
 FULL_DESKTOP="yes"
 CRUSTCONFIG="orangepi_pc2_defconfig"
-
-function post_family_tweaks_bsp__orangepiprime_BSP() {
-    display_alert "Installing BSP firmware and fixups"
-
-	if [[ $BRANCH == legacy ]]; then
-
-		# Bluetooth for most of others (custom patchram is needed only in legacy)
-		install -m 755 $SRC/packages/bsp/rk3399/brcm_patchram_plus_rk3399 $destination/usr/bin
-		cp $SRC/packages/bsp/rk3399/rk3399-bluetooth.service $destination/lib/systemd/system/
-
-	fi
-
-	return 0
-}

--- a/config/boards/orangepiwin.csc
+++ b/config/boards/orangepiwin.csc
@@ -5,17 +5,3 @@ BOARD_MAINTAINER=""
 BOOTCONFIG="orangepi_win_defconfig"
 KERNEL_TARGET="legacy,current,edge"
 CRUSTCONFIG="a64_defconfig"
-
-function post_family_tweaks_bsp__orangepiwin_BSP() {
-    display_alert "Installing BSP firmware and fixups"
-
-	if [[ $BRANCH == legacy ]]; then
-
-		# Bluetooth for most of others (custom patchram is needed only in legacy)
-		install -m 755 $SRC/packages/bsp/rk3399/brcm_patchram_plus_rk3399 $destination/usr/bin
-		cp $SRC/packages/bsp/rk3399/rk3399-bluetooth.service $destination/lib/systemd/system/
-
-	fi
-
-	return 0
-}

--- a/config/boards/orangepizero.csc
+++ b/config/boards/orangepizero.csc
@@ -10,17 +10,3 @@ DEFAULT_CONSOLE="both"
 HAS_VIDEO_OUTPUT="yes"
 SERIALCON="ttyS0,ttyGS0"
 KERNEL_TARGET="legacy,current,edge"
-
-function post_family_tweaks_bsp__orangepizero_BSP() {
-    display_alert "Installing BSP firmware and fixups"
-
-	if [[ $BRANCH == legacy ]]; then
-
-		# Bluetooth for most of others (custom patchram is needed only in legacy)
-		install -m 755 $SRC/packages/bsp/rk3399/brcm_patchram_plus_rk3399 $destination/usr/bin
-		cp $SRC/packages/bsp/rk3399/rk3399-bluetooth.service $destination/lib/systemd/system/
-
-	fi
-
-	return 0
-}

--- a/config/boards/orangepizero2.conf
+++ b/config/boards/orangepizero2.conf
@@ -11,16 +11,3 @@ SERIALCON="ttyS0"
 KERNEL_TARGET="legacy,current,edge"
 PACKAGE_LIST_BOARD="rfkill bluetooth bluez bluez-tools"
 FORCE_BOOTSCRIPT_UPDATE="yes"
-
-function post_family_tweaks_bsp__orangepizero2_BSP() {
-	display_alert "Installing BSP firmware and fixups"
-	: "${destination:?}"
-
-	if [[ $BRANCH == legacy ]]; then
-		# Bluetooth for most of others (custom patchram is needed only in legacy)
-		install -m 755 $SRC/packages/bsp/rk3399/brcm_patchram_plus_rk3399 $destination/usr/bin
-		cp $SRC/packages/bsp/rk3399/rk3399-bluetooth.service $destination/lib/systemd/system/
-	fi
-
-	return 0
-}

--- a/config/boards/orangepizeroplus.conf
+++ b/config/boards/orangepizeroplus.conf
@@ -11,17 +11,3 @@ DEFAULT_OVERLAYS="usbhost2 usbhost3"
 HAS_VIDEO_OUTPUT="no"
 KERNEL_TARGET="legacy,current,edge"
 CRUSTCONFIG="h5_defconfig"
-
-function post_family_tweaks_bsp__orangepizeroplus_BSP() {
-    display_alert "Installing BSP firmware and fixups"
-
-	if [[ $BRANCH == legacy ]]; then
-
-		# Bluetooth for most of others (custom patchram is needed only in legacy)
-		install -m 755 $SRC/packages/bsp/rk3399/brcm_patchram_plus_rk3399 $destination/usr/bin
-		cp $SRC/packages/bsp/rk3399/rk3399-bluetooth.service $destination/lib/systemd/system/
-
-	fi
-
-	return 0
-}

--- a/config/boards/orangepizeroplus2-h3.csc
+++ b/config/boards/orangepizeroplus2-h3.csc
@@ -8,17 +8,3 @@ MODULES_CURRENT="g_serial"
 DEFAULT_OVERLAYS="usbhost2 usbhost3"
 SERIALCON="ttyS0,ttyGS0"
 KERNEL_TARGET="legacy,current,edge"
-
-function post_family_tweaks_bsp__orangepizeroplus2_BSP() {
-    display_alert "Installing BSP firmware and fixups"
-
-	if [[ $BRANCH == legacy ]]; then
-
-		# Bluetooth for most of others (custom patchram is needed only in legacy)
-		install -m 755 $SRC/packages/bsp/rk3399/brcm_patchram_plus_rk3399 $destination/usr/bin
-		cp $SRC/packages/bsp/rk3399/rk3399-bluetooth.service $destination/lib/systemd/system/
-
-	fi
-
-	return 0
-}

--- a/config/boards/orangepizeroplus2-h5.csc
+++ b/config/boards/orangepizeroplus2-h5.csc
@@ -10,17 +10,3 @@ HAS_VIDEO_OUTPUT="no"
 SERIALCON="ttyS0,ttyGS0"
 KERNEL_TARGET="legacy,current,edge"
 CRUSTCONFIG="h5_defconfig"
-
-function post_family_tweaks_bsp__orangepizeroplus2-h5_BSP() {
-    display_alert "Installing BSP firmware and fixups"
-
-	if [[ $BRANCH == legacy ]]; then
-
-		# Bluetooth for most of others (custom patchram is needed only in legacy)
-		install -m 755 $SRC/packages/bsp/rk3399/brcm_patchram_plus_rk3399 $destination/usr/bin
-		cp $SRC/packages/bsp/rk3399/rk3399-bluetooth.service $destination/lib/systemd/system/
-
-	fi
-
-	return 0
-}


### PR DESCRIPTION
# Description

Removed rk3399 bluetooth service from Allwinner boards. The service is installed but not enabled. Starting the service messes up uart and other functions in allwinner boards. Hence removing the same as it doesn't belong in any of the Allwinner board images.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
