### PR TITLE
armbianmonitor: update cpuminer and remove arm only limit

### DIFF
--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -466,7 +466,7 @@ ProcessStats() {
 		SoftIrqStat=${procStatLine[6]}
 
 		Total=0
-		for eachstat in ${procStatLine[@]}; do
+		for eachstat in "${procStatLine[@]}"; do
 			Total=$(( Total + eachstat ))
 		done
 

--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -231,15 +231,15 @@ ParseOptions() {
 			;;
 		p|P)
 			# Installs cpuminer on 32-bit platforms
-			dpkg --print-architecture | grep -q armhf || (echo -e "Functionality currently not supported on 64-bit platforms. Exiting\n" >&2 ; exit 1)
 			fping armbian.com 2>/dev/null | grep -q alive || \
 				(echo "Network/firewall problem detected. Please fix this prior to installing cpuminer." >&2 ; exit 1)
 			cd /usr/local/src/
-			wget http://downloads.sourceforge.net/project/cpuminer/pooler-cpuminer-2.4.5.tar.gz
-			tar xf pooler-cpuminer-2.4.5.tar.gz && rm pooler-cpuminer-2.4.5.tar.gz
-			cd cpuminer-2.4.5/
+			wget http://downloads.sourceforge.net/project/cpuminer/pooler-cpuminer-2.5.1.tar.gz
+			tar xf pooler-cpuminer-2.5.1.tar.gz && rm pooler-cpuminer-2.5.1.tar.gz
+			cd cpuminer-2.5.1/
 			apt-get -f -qq -y install libcurl4-gnutls-dev
-			./configure CFLAGS="-O3 -mfpu=neon"
+			autoreconf --force --install --verbose
+			./configure CFLAGS="-O3"
 			make && make install
 			echo -e "\n\nNow you can use /usr/local/bin/minerd to do automated benchmarking.\nIn case you also installed RPi-Monitor you can do a"
 			echo -e "\n    touch /root/.cpuminer\n\nto ensure minerd is running after reboot and results are recorded\nwith RPi-Monitor"


### PR DESCRIPTION
# Description

Updated cpuminer and fixed the compilation on arm64. The previous test for system architecture never worked, it tried to compile and install anyways even with the condition and failed compilation.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested installing cpuminer with armbianmonitor -P on Orange Pi Prime (Allwinner H5)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
