### PR TITLE
Kernel: Allwinner: Bump legacy, current and edge kernel

### DIFF
--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -24,17 +24,17 @@ case $BRANCH in
 
 	legacy)
 		declare -g KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v5.15.120"
+		declare -g KERNELBRANCH="tag:v5.15.121"
 		;;
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.1.39"
+		declare -g KERNELBRANCH="tag:v6.1.40"
 		;;
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.4" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.4.4"
+		declare -g KERNELBRANCH="tag:v6.4.5"
 		;;
 esac
 

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -25,17 +25,17 @@ case $BRANCH in
 
 	legacy)
 		declare -g KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v5.15.120"
+		declare -g KERNELBRANCH="tag:v5.15.121"
 		;;
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.1.39"
+		declare -g KERNELBRANCH="tag:v6.1.40"
 		;;
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.4" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.4.4"
+		declare -g KERNELBRANCH="tag:v6.4.5"
 		;;
 esac
 

--- a/patch/kernel/archive/sunxi-5.15/patches.megous/thermal-sun8i-Be-loud-when-probe-fails.patch
+++ b/patch/kernel/archive/sunxi-5.15/patches.megous/thermal-sun8i-Be-loud-when-probe-fails.patch
@@ -1,7 +1,7 @@
-From 7c839c85144b311fcc072560f3452c03800a27d3 Mon Sep 17 00:00:00 2001
+From caa68e2028b819ccef9ca3996a19c62e6e927723 Mon Sep 17 00:00:00 2001
 From: Ondrej Jirman <megous@megous.com>
 Date: Wed, 8 Jul 2020 12:21:14 +0200
-Subject: [PATCH 386/478] thermal: sun8i: Be loud when probe fails
+Subject: [PATCH] thermal: sun8i: Be loud when probe fails
 
 I noticed several mobile Linux distributions failing to enable the
 thermal regulation correctly, because the kernel is silent
@@ -15,10 +15,10 @@ Signed-off-by: Ondrej Jirman <megous@megous.com>
  1 file changed, 29 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/thermal/sun8i_thermal.c b/drivers/thermal/sun8i_thermal.c
-index d9cd23cbb671..f1abc459e283 100644
+index b2a711913193..d74152ce5fe3 100644
 --- a/drivers/thermal/sun8i_thermal.c
 +++ b/drivers/thermal/sun8i_thermal.c
-@@ -288,8 +288,13 @@ static int sun8i_ths_calibrate(struct ths_device *tmdev)
+@@ -352,8 +352,13 @@ static int sun8i_ths_calibrate(struct ths_device *tmdev)
  
  	calcell = devm_nvmem_cell_get(dev, "calibration");
  	if (IS_ERR(calcell)) {
@@ -32,7 +32,7 @@ index d9cd23cbb671..f1abc459e283 100644
  		/*
  		 * Even if the external calibration data stored in sid is
  		 * not accessible, the THS hardware can still work, although
-@@ -309,6 +314,8 @@ static int sun8i_ths_calibrate(struct ths_device *tmdev)
+@@ -373,6 +378,8 @@ static int sun8i_ths_calibrate(struct ths_device *tmdev)
  	caldata = nvmem_cell_read(calcell, &callen);
  	if (IS_ERR(caldata)) {
  		ret = PTR_ERR(caldata);
@@ -41,7 +41,7 @@ index d9cd23cbb671..f1abc459e283 100644
  		goto out;
  	}
  
-@@ -331,23 +338,33 @@ static int sun8i_ths_resource_init(struct ths_device *tmdev)
+@@ -400,13 +407,17 @@ static int sun8i_ths_resource_init(struct ths_device *tmdev)
  		return PTR_ERR(base);
  
  	tmdev->regmap = devm_regmap_init_mmio(dev, base, &config);
@@ -59,7 +59,12 @@ index d9cd23cbb671..f1abc459e283 100644
  			return PTR_ERR(tmdev->reset);
 +		}
  
- 		tmdev->bus_clk = devm_clk_get(&pdev->dev, "bus");
+ 		ret = reset_control_deassert(tmdev->reset);
+ 		if (ret)
+@@ -418,14 +429,20 @@ static int sun8i_ths_resource_init(struct ths_device *tmdev)
+ 			return ret;
+ 
+ 		tmdev->bus_clk = devm_clk_get_enabled(&pdev->dev, "bus");
 -		if (IS_ERR(tmdev->bus_clk))
 +		if (IS_ERR(tmdev->bus_clk)) {
 +			dev_err(dev, "Failed to get bus clock (%pe)\n",
@@ -69,7 +74,7 @@ index d9cd23cbb671..f1abc459e283 100644
  	}
  
  	if (tmdev->chip->has_mod_clk) {
- 		tmdev->mod_clk = devm_clk_get(&pdev->dev, "mod");
+ 		tmdev->mod_clk = devm_clk_get_enabled(&pdev->dev, "mod");
 -		if (IS_ERR(tmdev->mod_clk))
 +		if (IS_ERR(tmdev->mod_clk)) {
 +			dev_err(dev, "Failed to get mod clock (%pe)\n",
@@ -78,8 +83,8 @@ index d9cd23cbb671..f1abc459e283 100644
 +		}
  	}
  
- 	ret = reset_control_deassert(tmdev->reset);
-@@ -472,8 +489,12 @@ static int sun8i_ths_register(struct ths_device *tmdev)
+ 	ret = clk_set_rate(tmdev->mod_clk, 24000000);
+@@ -553,8 +570,12 @@ static int sun8i_ths_register(struct ths_device *tmdev)
  							     i,
  							     &tmdev->sensor[i],
  							     &ths_ops);
@@ -93,7 +98,7 @@ index d9cd23cbb671..f1abc459e283 100644
  
  		if (devm_thermal_add_hwmon_sysfs(tmdev->sensor[i].tzd))
  			dev_warn(tmdev->dev,
-@@ -524,8 +545,10 @@ static int sun8i_ths_probe(struct platform_device *pdev)
+@@ -605,8 +626,10 @@ static int sun8i_ths_probe(struct platform_device *pdev)
  	ret = devm_request_threaded_irq(dev, irq, NULL,
  					sun8i_irq_thread,
  					IRQF_ONESHOT, "ths", tmdev);
@@ -106,5 +111,5 @@ index d9cd23cbb671..f1abc459e283 100644
  	return 0;
  }
 -- 
-2.35.3
+2.34.1
 

--- a/patch/kernel/archive/sunxi-5.15/series.conf
+++ b/patch/kernel/archive/sunxi-5.15/series.conf
@@ -298,7 +298,7 @@
 	patches.megous/mfd-rk808-Drop-reset-handlers-for-rk805-rk808-and-rk818.patch
 	patches.megous/arm64-dts-rk3399-pinebook-pro-Fix-USB-PD-charging.patch
 	patches.megous/usb-quirks-Add-USB_QUIRK_RESET-for-Quectel-EG25G-Modem.patch
-	patches.megous/drm-sun4i-Fix-wrong-location-of-clk_prepare_enable.patch
+-	patches.megous/drm-sun4i-Fix-wrong-location-of-clk_prepare_enable.patch
 	patches.megous/drm-panel-st7703-Improve-the-power-up-sequence-of-the-panel.patch
 	patches.megous/2-drm-panel-st7703-Improve-the-power-up-sequence-of-the-panel.patch
 	patches.megous/drm-sun4i-Implement-gamma-correction.patch

--- a/patch/kernel/archive/sunxi-5.15/series.megous
+++ b/patch/kernel/archive/sunxi-5.15/series.megous
@@ -301,7 +301,7 @@
 	patches.megous/arm64-dts-rk3399-pinebook-pro-Fix-USB-PD-charging.patch
 -	patches.megous/pinctrl-sunxi-Fix-misleading-lockdep-deadlock-warning.patch
 	patches.megous/usb-quirks-Add-USB_QUIRK_RESET-for-Quectel-EG25G-Modem.patch
-	patches.megous/drm-sun4i-Fix-wrong-location-of-clk_prepare_enable.patch
+-	patches.megous/drm-sun4i-Fix-wrong-location-of-clk_prepare_enable.patch
 	patches.megous/drm-panel-st7703-Improve-the-power-up-sequence-of-the-panel.patch
 	patches.megous/2-drm-panel-st7703-Improve-the-power-up-sequence-of-the-panel.patch
 	patches.megous/drm-sun4i-Implement-gamma-correction.patch


### PR DESCRIPTION
# Description

Bumped Allwinner kernels

Legacy: 5.15.120 -> 5.15.121
Current: 6.1.39 -> 6.1.40
Edge: 6.4.4 -> 6.4.5

5.15.121 needed same patch fixes as done for 6.1.39 in PR #5494 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Booted legacy, current and edge images on Orange Pi Prime (sun50i H5)
- [X] Booted legacy, current and edge images on NanoPi Duo2 (sun8i H3)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
