### PR TITLE
`tmpfs`: introduce `USE_TMPFS=no` to disable tmpfs usage for WORKDIR and package-specific working dirs; actually use `$temp_dir_id` for mktemp; see #5502

### DIFF
--- a/lib/functions/compilation/kernel.sh
+++ b/lib/functions/compilation/kernel.sh
@@ -111,7 +111,7 @@ function kernel_prepare_build_and_package() {
 	build_targets=("all") # "All" builds the vmlinux/Image/Image.gz default for the ${ARCH}
 	build_targets+=("${KERNEL_IMAGE_TYPE}")
 	declare cleanup_id="" kernel_dest_install_dir=""
-	prepare_temp_dir_in_workdir_and_schedule_cleanup "k" cleanup_id kernel_dest_install_dir # namerefs
+	prepare_temp_dir_in_workdir_and_schedule_cleanup "kernel_dest_install_dir" cleanup_id kernel_dest_install_dir # namerefs
 
 	# define dict with vars passed and target directories
 	declare -A kernel_install_dirs=(
@@ -146,7 +146,7 @@ function kernel_prepare_build_and_package() {
 
 	# prepare a target dir for the shared, produced kernel .debs, across image/dtb/headers
 	declare cleanup_id_debs="" kernel_debs_temp_dir=""
-	prepare_temp_dir_in_workdir_and_schedule_cleanup "kd" cleanup_id_debs kernel_debs_temp_dir # namerefs
+	prepare_temp_dir_in_workdir_and_schedule_cleanup "kernel_debs_temp_dir" cleanup_id_debs kernel_debs_temp_dir # namerefs
 
 	LOG_SECTION="kernel_package" do_with_logging do_with_hooks kernel_package
 

--- a/lib/functions/host/mktemp-utils.sh
+++ b/lib/functions/host/mktemp-utils.sh
@@ -25,7 +25,7 @@ function prepare_temp_dir_in_workdir_and_schedule_cleanup() {
 		exit_with_error "prepare_temp_dir_in_workdir_and_schedule_cleanup: WORKDIR is not set or not a directory: ${temp_dir_id}"
 	fi
 
-	nameref_temp_dir="$(mktemp -d)" # subject to TMPDIR/WORKDIR
+	nameref_temp_dir="$(mktemp -d --tmpdir "${temp_dir_id}-XXXXX")" # subject to TMPDIR/WORKDIR
 	display_alert "prepare_temp_dir_in_workdir_and_schedule_cleanup: created temp dir" "${nameref_temp_dir}" "cleanup"
 
 	chmod 700 "${nameref_temp_dir}" # does every usage need this? why?

--- a/lib/functions/host/tmpfs-utils.sh
+++ b/lib/functions/host/tmpfs-utils.sh
@@ -39,6 +39,9 @@ function prepare_tmpfs_for() {
 	elif [[ "${ARMBIAN_INSIDE_DOCKERFILE_BUILD}" == "yes" ]]; then
 		display_alert "prepare_tmpfs_for: inside Dockerfile build, skipping" "${tmpfs_name}" "cleanup"
 		cleanup_params+=("no_umount_tmpfs")
+	elif [[ "${USE_TMPFS}" == "no" ]]; then
+		display_alert "prepare_tmpfs_for:" "USE_TMPFS=no, skipping: '${tmpfs_name}'" "warning"
+		cleanup_params+=("no_umount_tmpfs")
 	else
 		display_alert "prepare_tmpfs_for: on Linux and root, MOUNTING TMPFS" "${tmpfs_name}" "cleanup"
 		# mount tmpfs on it


### PR DESCRIPTION
#### `tmpfs`: introduce `USE_TMPFS=no` to disable tmpfs usage for WORKDIR and package-specific working dirs; actually use `$temp_dir_id` for mktemp; see #5502

- `tmpfs`: introduce `USE_TMPFS=no` to disable tmpfs usage for WORKDIR and package-specific working dirs; actually use `$temp_dir_id` for mktemp; see #5502
  - `USE_TMPFS=no` disables usage of generic tmpfs mechanism (still possibly used for rootfs/image building, which is unrelated), for last-resort cases
  - use better/more descriptive `temp_dir_id`'s for kernel build than `k` (now `kernel_dest_install_dir`) and `kd` (now `kernel_debs_temp_dir`)
    - specific image/dtb/headers packaging already had decent names, same for other .deb's
  - replace `mktemp -d` with `mktemp -d --tmpdir "${temp_dir_id}-XXXXX"` in `prepare_temp_dir_in_workdir_and_schedule_cleanup()`, so we know what's using what in tmpfs