### PR TITLE
BigTreeTech: Use different family for edge kernel to avoid artifact conflict

### DIFF
--- a/config/sources/families/sun50iw9-btt.conf
+++ b/config/sources/families/sun50iw9-btt.conf
@@ -43,6 +43,7 @@ case $BRANCH in
 
 		# Stick to 6.2.16 kernel for edge until ws2812 driver is fixed
 		if [[ "$BRANCH" == "edge" ]]; then
+			LINUXFAMILY=sun50iw9-btt
 			KERNEL_MAJOR_MINOR="6.2"
 			KERNELBRANCH="tag:v6.2.16"
 			KERNELPATCHDIR="archive/sunxi-${KERNEL_MAJOR_MINOR}"


### PR DESCRIPTION
# Description

Changed Linux family for BigTreeTech CB1 for edge kernel as its causing artifact conflict

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
