### PR TITLE
`sun50iw9-btt`: keep using `linux-sunxi64-edge.config` for `LINUXFAMILY=sun50iw9-btt`

### DIFF
--- a/config/sources/families/sun50iw9-btt.conf
+++ b/config/sources/families/sun50iw9-btt.conf
@@ -43,7 +43,8 @@ case $BRANCH in
 
 		# Stick to 6.2.16 kernel for edge until ws2812 driver is fixed
 		if [[ "$BRANCH" == "edge" ]]; then
-			LINUXFAMILY=sun50iw9-btt
+			LINUXFAMILY="sun50iw9-btt"       # Use a separate kernel deb
+			LINUXCONFIG="linux-sunxi64-edge" # But the same kernel config, will be modified below in armbian_kernel_config__enable_ws2812_driver
 			KERNEL_MAJOR_MINOR="6.2"
 			KERNELBRANCH="tag:v6.2.16"
 			KERNELPATCHDIR="archive/sunxi-${KERNEL_MAJOR_MINOR}"


### PR DESCRIPTION
#### `sun50iw9-btt`: keep using `linux-sunxi64-edge.config` for `LINUXFAMILY=sun50iw9-btt`

- `sun50iw9-btt`: keep using `linux-sunxi64-edge.config` for `LINUXFAMILY=sun50iw9-btt`