### PR TITLE
kernel:sunxi: Add tve encoder for H5 boards as well

### DIFF
--- a/patch/kernel/archive/sunxi-6.1/patches.armbian/arm-dts-sunxi-h3-h5-add_tve.patch
+++ b/patch/kernel/archive/sunxi-6.1/patches.armbian/arm-dts-sunxi-h3-h5-add_tve.patch
@@ -549,3 +549,78 @@ index 68e2741b0..7bc8efca6 100644
  
  #define SUN50I_MIXER_FCE_EN			0x70000
  #define SUN50I_MIXER_PEAK_EN			0x70800
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/Makefile b/arch/arm64/boot/dts/allwinner/overlay/Makefile
+index e19b987e3b03..f3e4c89f8617 100644
+--- a/arch/arm64/boot/dts/allwinner/overlay/Makefile
++++ b/arch/arm64/boot/dts/allwinner/overlay/Makefile
+@@ -27,6 +27,7 @@ dtbo-$(CONFIG_ARCH_SUNXI) += \
+ 	sun50i-h5-spi-add-cs1.dtbo \
+ 	sun50i-h5-spi-jedec-nor.dtbo \
+ 	sun50i-h5-spi-spidev.dtbo \
++	sun50i-h5-tve.dtbo \
+ 	sun50i-h5-uart1.dtbo \
+ 	sun50i-h5-uart2.dtbo \
+ 	sun50i-h5-uart3.dtbo \
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/README.sun50i-h5-overlays b/arch/arm64/boot/dts/allwinner/overlay/README.sun50i-h5-overlays
+index 1ac7fbcf62d1..a2ef4427c65b 100644
+--- a/arch/arm64/boot/dts/allwinner/overlay/README.sun50i-h5-overlays
++++ b/arch/arm64/boot/dts/allwinner/overlay/README.sun50i-h5-overlays
+@@ -26,6 +26,7 @@ adding fixed software (GPIO) chip selects is possible with a separate overlay
+ - spi-add-cs1
+ - spi-jedec-nor
+ - spi-spidev
++- tve
+ - uart1
+ - uart2
+ - uart3
+@@ -170,6 +171,10 @@ param_spidev_max_freq (int)
+ 	Default: 1000000
+ 	Range: 3000 - 100000000
+ 
++### tve
++
++Activates Composite TV Encoder
++
+ ### uart1
+ 
+ Activates serial port 1 (/dev/ttyS1)
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-tve.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-tve.dts
+new file mode 100644
+index 000000000000..73e6e1215a5a
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-tve.dts
+@@ -0,0 +1,34 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "allwinner,sun8i-h5";
++
++	fragment@0 {
++		target = <&de>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++
++	fragment@1 {
++		target = <&mixer1>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++
++	fragment@2 {
++		target = <&tcon1>;
++		 __overlay__ {
++			status = "okay";
++		};
++	};
++
++	fragment@3 {
++		target = <&tve>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};

--- a/patch/kernel/archive/sunxi-6.1/series.armbian
+++ b/patch/kernel/archive/sunxi-6.1/series.armbian
@@ -173,7 +173,7 @@
 	patches.armbian/net-usb-r8152-add-LED-configuration-from-OF.patch
 	patches.armbian/arm64-dts-sun50i-h6-orangepi.dtsi-Rollback-r_rsb-to-r_i2c.patch
 	patches.armbian/mfd-sunxi-ac200-fix-error-initialization.patch
-	patches.armbian/arm-dts-sun8i-h3-orangepizero-add_tve.patch
+	patches.armbian/arm-dts-sunxi-h3-h5-add_tve.patch
 	patches.armbian/arm-dts-sun8i-h3-fix-thermal-read.patch
 	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1.patch
 	patches.armbian/arm-dts-sun8i-h3-nanopi-duo2-enable-powerbutton-and-ethernet.patch

--- a/patch/kernel/archive/sunxi-6.1/series.conf
+++ b/patch/kernel/archive/sunxi-6.1/series.conf
@@ -577,7 +577,7 @@
 	patches.armbian/net-usb-r8152-add-LED-configuration-from-OF.patch
 	patches.armbian/arm64-dts-sun50i-h6-orangepi.dtsi-Rollback-r_rsb-to-r_i2c.patch
 	patches.armbian/mfd-sunxi-ac200-fix-error-initialization.patch
-	patches.armbian/arm-dts-sun8i-h3-orangepizero-add_tve.patch
+	patches.armbian/arm-dts-sunxi-h3-h5-add_tve.patch
 	patches.armbian/arm-dts-sun8i-h3-fix-thermal-read.patch
 	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1.patch
 	patches.armbian/arm-dts-sun8i-h3-nanopi-duo2-enable-powerbutton-and-ethernet.patch

--- a/patch/kernel/archive/sunxi-6.4/patches.armbian/arm-dts-sunxi-h3-h5-add_tve.patch
+++ b/patch/kernel/archive/sunxi-6.4/patches.armbian/arm-dts-sunxi-h3-h5-add_tve.patch
@@ -1,0 +1,626 @@
+Credits to sorce https://github.com/robertojguerra/orangepi-zero-full-setup/blob/main/README2.md
+Merged:
+1. sunxi-6.1/0036-wip-h3-h5-cvbs-armbian.patch : makes additions to the "dts", which tells the kernel where are the new devices. Adds kernel code to interact with the tv encoder. With my modifications, now it is applicable to Armbian (this patch came from the LibreElec github).
+    https://github.com/robertojguerra/orangepi-zero-full-setup/blob/main/sunxi-6.1/0036-wip-h3-h5-cvbs-armbian.patch
+2. sunxi-6.1/zzzz2-tv.patch : by Armbian user "gleam2003", adds directives to make sure that the dtbo (device tree binary overlay) is compiled
+    https://github.com/robertojguerra/orangepi-zero-full-setup/blob/main/sunxi-6.1/zzzz2-tv.patch
+3. sunxi-6.1/zzzz3-tv.patch : more additions to the "dts" and "dtsi" (like C include files), which I noticed were included in "yam" patch, but missing from the LibreElec patch
+    https://github.com/robertojguerra/orangepi-zero-full-setup/blob/main/sunxi-6.1/zzzz3-tv.patch
+
+diff --git a/arch/arm/boot/dts/overlay/Makefile b/arch/arm/boot/dts/overlay/Makefile
+index 23f8c2048..b3bd27351 100644
+--- a/arch/arm/boot/dts/overlay/Makefile
++++ b/arch/arm/boot/dts/overlay/Makefile
+@@ -80,6 +80,7 @@ dtbo-$(CONFIG_MACH_SUN8I) += \
+ 	sun8i-h3-usbhost2.dtbo \
+ 	sun8i-h3-usbhost3.dtbo \
+ 	sun8i-h3-w1-gpio.dtbo \
++        sun8i-h3-tve.dtbo \
+ 	sun8i-r40-i2c2.dtbo \
+ 	sun8i-r40-i2c3.dtbo \
+ 	sun8i-r40-spi-spidev0.dtbo \
+diff --git a/arch/arm/boot/dts/overlay/README.sun8i-h3-overlays b/arch/arm/boot/dts/overlay/README.sun8i-h3-overlays
+index 302973491..a347fe7b0 100644
+--- a/arch/arm/boot/dts/overlay/README.sun8i-h3-overlays
++++ b/arch/arm/boot/dts/overlay/README.sun8i-h3-overlays
+@@ -34,6 +34,7 @@ adding fixed software (GPIO) chip selects is possible with a separate overlay
+ - usbhost2
+ - usbhost3
+ - w1-gpio
++- tve
+ 
+ ### Overlay details:
+ 
+@@ -248,3 +249,12 @@ param_w1_pin_int_pullup (bool)
+ 	Set to 1 to enable the pull-up
+ 	This option should not be used with multiple devices, parasite power setup
+ 		or long wires -	please use external pull-up resistor instead
++
++### tve
++
++Activates Composite TV Encoder
++
++Parameters:
++	Unknown at this stage. 
++	Maybe none. 
++	Not sure how to change the mode between PAL/NTSC.
+diff --git a/arch/arm/boot/dts/overlay/sun8i-h3-tve.dts b/arch/arm/boot/dts/overlay/sun8i-h3-tve.dts
+new file mode 100644
+index 000000000..07ba7ba71
+--- /dev/null
++++ b/arch/arm/boot/dts/overlay/sun8i-h3-tve.dts
+@@ -0,0 +1,34 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "allwinner,sun8i-h3";
++	
++	fragment@0 {
++		target = <&de>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++
++	fragment@1 {
++		target = <&mixer1>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++
++	fragment@2 {
++		target = <&tcon1>;
++		 __overlay__ {
++			status = "okay";
++		};
++	};
++
++	fragment@3 {
++		target = <&tve>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm/boot/dts/sun8i-h2-plus-orangepi-zero.dts b/arch/arm/boot/dts/sun8i-h2-plus-orangepi-zero.dts
+index 7b42ab8b5..330a79390 100644
+--- a/arch/arm/boot/dts/sun8i-h2-plus-orangepi-zero.dts
++++ b/arch/arm/boot/dts/sun8i-h2-plus-orangepi-zero.dts
+@@ -180,6 +180,10 @@ flash@0 {
+ 	};
+ };
+ 
++&tve {
++        status = "okay";
++};
++
+ &uart0 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&uart0_pa_pins>;
+diff --git a/arch/arm/boot/dts/sun8i-h3-orangepi-pc.dts b/arch/arm/boot/dts/sun8i-h3-orangepi-pc.dts
+index 624e248e3..01c3a7f76 100644
+--- a/arch/arm/boot/dts/sun8i-h3-orangepi-pc.dts
++++ b/arch/arm/boot/dts/sun8i-h3-orangepi-pc.dts
+@@ -214,6 +214,10 @@ &sound_hdmi {
+ 	status = "okay";
+ };
+ 
++&tve {
++	status = "okay";
++};
++
+ &uart0 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&uart0_pa_pins>;
+diff --git a/arch/arm/boot/dts/sun8i-h3.dtsi b/arch/arm/boot/dts/sun8i-h3.dtsi
+index 1b02a4c3f..5b1158c7a 100644
+--- a/arch/arm/boot/dts/sun8i-h3.dtsi
++++ b/arch/arm/boot/dts/sun8i-h3.dtsi
+@@ -294,6 +294,20 @@ ths: thermal-sensor@1c25000 {
+ 			nvmem-cell-names = "calibration";
+ 			#thermal-sensor-cells = <0>;
+ 		};
++
++		tve: tv-encoder@1e00000 {
++			compatible = "allwinner,sun8i-h3-tv-encoder";
++			reg = <0x01e00000 0x1000>;
++			clocks = <&ccu CLK_BUS_TVE>;
++			resets = <&ccu RST_BUS_TVE>;
++			status = "disabled";
++
++			port {
++				tve_in_tcon1: endpoint {
++					remote-endpoint = <&tcon1_out_tve>;
++				};
++			};
++		};
+ 	};
+ 
+ 	thermal-zones {
+@@ -383,6 +397,10 @@ &mbus {
+ 	compatible = "allwinner,sun8i-h3-mbus";
+ };
+ 
++&mixer1 {
++	resets = <&display_clocks RST_WB>;
++};
++
+ &mmc0 {
+ 	compatible = "allwinner,sun7i-a20-mmc";
+ 	clocks = <&ccu CLK_BUS_MMC0>,
+@@ -430,3 +448,7 @@ &rtc {
+ &sid {
+ 	compatible = "allwinner,sun8i-h3-sid";
+ };
++
++&tcon1_out_tve {
++	remote-endpoint = <&tve_in_tcon1>;
++};
+diff --git a/arch/arm/boot/dts/sunxi-h3-h5.dtsi b/arch/arm/boot/dts/sunxi-h3-h5.dtsi
+index 7946699f4..cb6eb5d71 100644
+--- a/arch/arm/boot/dts/sunxi-h3-h5.dtsi
++++ b/arch/arm/boot/dts/sunxi-h3-h5.dtsi
+@@ -102,7 +102,7 @@ osc32k: osc32k_clk {
+ 
+ 	de: display-engine {
+ 		compatible = "allwinner,sun8i-h3-display-engine";
+-		allwinner,pipelines = <&mixer0>;
++		allwinner,pipelines = <&mixer0>, <&mixer1>;
+ 		status = "disabled";
+ 	};
+ 
+@@ -160,11 +160,50 @@ ports {
+ 				#size-cells = <0>;
+ 
+ 				mixer0_out: port@1 {
++					#address-cells = <1>;
++					#size-cells = <0>;
+ 					reg = <1>;
+ 
+-					mixer0_out_tcon0: endpoint {
++					mixer0_out_tcon0: endpoint@0 {
++						reg = <0>;
+ 						remote-endpoint = <&tcon0_in_mixer0>;
+ 					};
++
++					mixer0_out_tcon1: endpoint@1 {
++						reg = <1>;
++						remote-endpoint = <&tcon1_in_mixer0>;
++					};
++				};
++			};
++		};
++
++		mixer1: mixer@1200000 {
++			compatible = "allwinner,sun8i-h3-de2-mixer-1";
++			reg = <0x01200000 0x100000>;
++			clocks = <&display_clocks CLK_BUS_MIXER1>,
++				 <&display_clocks CLK_MIXER1>;
++			clock-names = "bus",
++				      "mod";
++			/* reset is added by SoC dtsi */
++
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				mixer1_out: port@1 {
++					#address-cells = <1>;
++					#size-cells = <0>;
++					reg = <1>;
++
++					mixer1_out_tcon0: endpoint@0 {
++						reg = <0>;
++						remote-endpoint = <&tcon0_in_mixer1>;
++					};
++
++					mixer1_out_tcon1: endpoint@1 {
++						reg = <1>;
++						remote-endpoint = <&tcon1_in_mixer1>;
++					};
+ 				};
+ 			};
+ 		};
+@@ -193,11 +232,19 @@ ports {
+ 				#size-cells = <0>;
+ 
+ 				tcon0_in: port@0 {
++					#address-cells = <1>;
++					#size-cells = <0>;
+ 					reg = <0>;
+ 
+-					tcon0_in_mixer0: endpoint {
++					tcon0_in_mixer0: endpoint@0 {
++						reg = <0>;
+ 						remote-endpoint = <&mixer0_out_tcon0>;
+ 					};
++
++					tcon0_in_mixer1: endpoint@1 {
++						reg = <1>;
++						remote-endpoint = <&mixer1_out_tcon0>;
++					};
+ 				};
+ 
+ 				tcon0_out: port@1 {
+@@ -213,6 +260,48 @@ tcon0_out_hdmi: endpoint@1 {
+ 			};
+ 		};
+ 
++		tcon1: lcd-controller@1c0d000 {
++			compatible = "allwinner,sun8i-h3-tcon-tv",
++				     "allwinner,sun8i-a83t-tcon-tv";
++			reg = <0x01c0d000 0x1000>;
++			interrupts = <GIC_SPI 87 IRQ_TYPE_LEVEL_HIGH>;
++			clocks = <&ccu CLK_BUS_TCON1>, <&ccu CLK_TVE>;
++			clock-names = "ahb", "tcon-ch1";
++			resets = <&ccu RST_BUS_TCON1>;
++			reset-names = "lcd";
++
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				tcon1_in: port@0 {
++					#address-cells = <1>;
++					#size-cells = <0>;
++					reg = <0>;
++
++					tcon1_in_mixer0: endpoint@0 {
++						reg = <0>;
++						remote-endpoint = <&mixer0_out_tcon1>;
++					};
++
++					tcon1_in_mixer1: endpoint@1 {
++						reg = <1>;
++						remote-endpoint = <&mixer1_out_tcon1>;
++					};
++				};
++
++				tcon1_out: port@1 {
++					#address-cells = <1>;
++					#size-cells = <0>;
++					reg = <1>;
++
++					tcon1_out_tve: endpoint@1 {
++						reg = <1>;
++					};
++				};
++			};
++		};
++
+ 		mmc0: mmc@1c0f000 {
+ 			/* compatible and clocks are in per SoC .dtsi file */
+ 			reg = <0x01c0f000 0x1000>;
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h5.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h5.dtsi
+index f6d970d9b..3df8abe0d 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h5.dtsi
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h5.dtsi
+@@ -203,6 +203,20 @@ ths: thermal-sensor@1c25000 {
+ 			nvmem-cell-names = "calibration";
+ 			#thermal-sensor-cells = <1>;
+ 		};
++
++		tve: tv-encoder@1e40000 {
++			compatible = "allwinner,sun50i-h5-tv-encoder";
++			reg = <0x01e40000 0x1000>;
++			clocks = <&ccu CLK_BUS_TVE>;
++			resets = <&ccu RST_BUS_TVE>;
++			status = "disabled";
++
++			port {
++				tve_in_tcon1: endpoint {
++					remote-endpoint = <&tcon1_out_tve>;
++				};
++			};
++		};
+ 	};
+ 
+ 	thermal-zones {
+@@ -298,6 +312,10 @@ &mbus {
+ 	compatible = "allwinner,sun50i-h5-mbus";
+ };
+ 
++&mixer1 {
++	resets = <&display_clocks RST_MIXER1>;
++};
++
+ &mmc0 {
+ 	compatible = "allwinner,sun50i-h5-mmc",
+ 		     "allwinner,sun50i-a64-mmc";
+@@ -333,3 +351,7 @@ &rtc {
+ &sid {
+ 	compatible = "allwinner,sun50i-h5-sid";
+ };
++
++&tcon1_out_tve {
++	remote-endpoint = <&tve_in_tcon1>;
++};
+diff --git a/drivers/clk/sunxi-ng/ccu-sun8i-h3.c b/drivers/clk/sunxi-ng/ccu-sun8i-h3.c
+index 4ec8d3ffa..5f689fe10 100644
+--- a/drivers/clk/sunxi-ng/ccu-sun8i-h3.c
++++ b/drivers/clk/sunxi-ng/ccu-sun8i-h3.c
+@@ -464,8 +464,18 @@ static SUNXI_CCU_M_WITH_MUX_GATE(tcon_clk, "tcon", tcon_parents,
+ 				 CLK_SET_RATE_PARENT);
+ 
+ static const char * const tve_parents[] = { "pll-de", "pll-periph1" };
+-static SUNXI_CCU_M_WITH_MUX_GATE(tve_clk, "tve", tve_parents,
+-				 0x120, 0, 4, 24, 3, BIT(31), 0);
++struct ccu_div tve_clk = {
++	.enable	= BIT(31),
++	.div	= _SUNXI_CCU_DIV(0, 4),
++	.mux	= _SUNXI_CCU_MUX(24, 3),
++	.fixed_post_div = 16,
++	.common	= {
++		.reg		= 0x120,
++		.features	= CCU_FEATURE_FIXED_POSTDIV,
++		.hw.init	= CLK_HW_INIT_PARENTS("tve", tve_parents,
++						      &ccu_div_ops, 0),
++	},
++};
+ 
+ static const char * const deinterlace_parents[] = { "pll-periph0", "pll-periph1" };
+ static SUNXI_CCU_M_WITH_MUX_GATE(deinterlace_clk, "deinterlace", deinterlace_parents,
+diff --git a/drivers/gpu/drm/sun4i/Makefile b/drivers/gpu/drm/sun4i/Makefile
+index 492bfd28a..721eddd6a 100644
+--- a/drivers/gpu/drm/sun4i/Makefile
++++ b/drivers/gpu/drm/sun4i/Makefile
+@@ -19,7 +19,7 @@ sun8i-drm-hdmi-y		+= sun8i_hdmi_phy_clk.o
+ 
+ sun8i-mixer-y			+= sun8i_mixer.o sun8i_ui_layer.o \
+ 				   sun8i_vi_layer.o sun8i_ui_scaler.o \
+-				   sun8i_vi_scaler.o sun8i_csc.o
++				   sun8i_vi_scaler.o sun8i_csc.o sun4i_tv.o
+ 
+ sun4i-tcon-y			+= sun4i_crtc.o
+ sun4i-tcon-y			+= sun4i_dotclock.o
+diff --git a/drivers/gpu/drm/sun4i/sun4i_tv.c b/drivers/gpu/drm/sun4i/sun4i_tv.c
+index c65f0a89b..e19f26df4 100644
+--- a/drivers/gpu/drm/sun4i/sun4i_tv.c
++++ b/drivers/gpu/drm/sun4i/sun4i_tv.c
+@@ -10,6 +10,7 @@
+ #include <linux/component.h>
+ #include <linux/module.h>
+ #include <linux/of_address.h>
++#include <linux/of_device.h>
+ #include <linux/platform_device.h>
+ #include <linux/regmap.h>
+ #include <linux/reset.h>
+@@ -168,6 +169,11 @@ struct tv_mode {
+ 	const struct resync_parameters	*resync_params;
+ };
+ 
++struct sun4i_tv_quirks {
++	unsigned int calibration;
++	unsigned int unknown : 1;
++};
++
+ struct sun4i_tv {
+ 	struct drm_connector	connector;
+ 	struct drm_encoder	encoder;
+@@ -504,7 +510,7 @@ static const struct regmap_config sun4i_tv_regmap_config = {
+ 	.reg_bits	= 32,
+ 	.val_bits	= 32,
+ 	.reg_stride	= 4,
+-	.max_register	= SUN4I_TVE_WSS_DATA2_REG,
++	.max_register	= 0x400,
+ 	.name		= "tv-encoder",
+ };
+ 
+@@ -514,13 +520,19 @@ static int sun4i_tv_bind(struct device *dev, struct device *master,
+ 	struct platform_device *pdev = to_platform_device(dev);
+ 	struct drm_device *drm = data;
+ 	struct sun4i_drv *drv = drm->dev_private;
++	const struct sun4i_tv_quirks *quirks;
+ 	struct sun4i_tv *tv;
+ 	void __iomem *regs;
+ 	int ret;
+ 
++	quirks = of_device_get_match_data(dev);
++	if (!quirks)
++		return -EINVAL;
++
+ 	tv = devm_kzalloc(dev, sizeof(*tv), GFP_KERNEL);
+ 	if (!tv)
+ 		return -ENOMEM;
++
+ 	tv->drv = drv;
+ 	dev_set_drvdata(dev, tv);
+ 
+@@ -557,6 +569,11 @@ static int sun4i_tv_bind(struct device *dev, struct device *master,
+ 	}
+ 	clk_prepare_enable(tv->clk);
+ 
++	if (quirks->calibration)
++		regmap_write(tv->regs, 0x304, quirks->calibration);
++	if (quirks->unknown)
++		regmap_write(tv->regs, 0x30c, 0x00101110);
++
+ 	drm_encoder_helper_add(&tv->encoder,
+ 			       &sun4i_tv_helper_funcs);
+ 	ret = drm_simple_encoder_init(drm, &tv->encoder,
+@@ -626,8 +643,22 @@ static int sun4i_tv_remove(struct platform_device *pdev)
+ 	return 0;
+ }
+ 
++static const struct sun4i_tv_quirks a10_quirks = {
++};
++
++static const struct sun4i_tv_quirks h3_quirks = {
++	.calibration = 0x02000c00,
++};
++
++static const struct sun4i_tv_quirks h5_quirks = {
++	.calibration = 0x02850000,
++	.unknown = 1,
++};
++
+ static const struct of_device_id sun4i_tv_of_table[] = {
+-	{ .compatible = "allwinner,sun4i-a10-tv-encoder" },
++	{ .compatible = "allwinner,sun4i-a10-tv-encoder", .data = &a10_quirks },
++	{ .compatible = "allwinner,sun8i-h3-tv-encoder", .data = &h3_quirks },
++	{ .compatible = "allwinner,sun50i-h5-tv-encoder", .data = &h5_quirks },
+ 	{ }
+ };
+ MODULE_DEVICE_TABLE(of, sun4i_tv_of_table);
+diff --git a/drivers/gpu/drm/sun4i/sun8i_mixer.c b/drivers/gpu/drm/sun4i/sun8i_mixer.c
+index 9c17bb410..675d8a075 100644
+--- a/drivers/gpu/drm/sun4i/sun8i_mixer.c
++++ b/drivers/gpu/drm/sun4i/sun8i_mixer.c
+@@ -35,6 +35,12 @@ struct de2_fmt_info {
+ 
+ static bool hw_preconfigured;
+ 
++static const u32 sun8i_rgb2yuv_coef[12] = {
++	0x00000107, 0x00000204, 0x00000064, 0x00004200,
++	0x00001f68, 0x00001ed6, 0x000001c2, 0x00020200,
++	0x000001c2, 0x00001e87, 0x00001fb7, 0x00020200,
++};
++
+ static const struct de2_fmt_info de2_formats[] = {
+ 	{
+ 		.drm_fmt = DRM_FORMAT_ARGB8888,
+@@ -435,10 +441,29 @@ static void sun8i_mixer_mode_set(struct sunxi_engine *engine,
+ 			 interlaced ? "on" : "off");
+ }
+ 
++static void sun8i_mixer_apply_color_correction(struct sunxi_engine *engine)
++{
++	DRM_DEBUG_DRIVER("Applying RGB to YUV color correction\n");
++
++	regmap_bulk_write(engine->regs, SUN8I_MIXER_DCSC_COEF_REG(0),
++			  sun8i_rgb2yuv_coef, 12);
++	regmap_write(engine->regs, SUN8I_MIXER_DCSC_EN, 1);
++}
++
++static void sun8i_mixer_disable_color_correction(struct sunxi_engine *engine)
++{
++	DRM_DEBUG_DRIVER("Disabling color correction\n");
++
++	/* Disable color correction */
++	regmap_write(engine->regs, SUN8I_MIXER_DCSC_EN, 0);
++}
++
+ static const struct sunxi_engine_ops sun8i_engine_ops = {
+-	.commit		= sun8i_mixer_commit,
+-	.layers_init	= sun8i_layers_init,
+-	.mode_set	= sun8i_mixer_mode_set,
++	.commit				= sun8i_mixer_commit,
++	.layers_init			= sun8i_layers_init,
++	.mode_set			= sun8i_mixer_mode_set,
++	.apply_color_correction		= sun8i_mixer_apply_color_correction,
++	.disable_color_correction	= sun8i_mixer_disable_color_correction,
+ };
+ 
+ static const struct regmap_config sun8i_mixer_regmap_config = {
+@@ -721,8 +746,9 @@ static const struct sun8i_mixer_cfg sun8i_h3_mixer0_cfg = {
+ static const struct sun8i_mixer_cfg sun8i_h3_mixer1_cfg = {
+ 	.ccsc		= CCSC_MIXER1_LAYOUT,
+ 	.mod_rate	= 432000000,
+-	.scaler_mask	= 0xf,
+-	.ui_num		= 3,
++	.scaler_mask	= 0x3,
++	.scanline_yuv	= 2048,
++	.ui_num		= 1,
+ 	.vi_num		= 1,
+ };
+ 
+diff --git a/drivers/gpu/drm/sun4i/sun8i_mixer.h b/drivers/gpu/drm/sun4i/sun8i_mixer.h
+index 68e2741b0..7bc8efca6 100644
+--- a/drivers/gpu/drm/sun4i/sun8i_mixer.h
++++ b/drivers/gpu/drm/sun4i/sun8i_mixer.h
+@@ -119,6 +119,10 @@
+ /* format 20 is packed YVU444 10-bit */
+ /* format 21 is packed YUV444 10-bit */
+ 
++/* The DCSC sub-engine is used to do color space conversation */
++#define SUN8I_MIXER_DCSC_EN			0xb0000
++#define SUN8I_MIXER_DCSC_COEF_REG(x)		(0xb0010 + 0x4 * (x))
++
+ /*
+  * Sub-engines listed bellow are unused for now. The EN registers are here only
+  * to be used to disable these sub-engines.
+@@ -129,7 +133,6 @@
+ #define SUN8I_MIXER_PEAK_EN			0xa6000
+ #define SUN8I_MIXER_ASE_EN			0xa8000
+ #define SUN8I_MIXER_FCC_EN			0xaa000
+-#define SUN8I_MIXER_DCSC_EN			0xb0000
+ 
+ #define SUN50I_MIXER_FCE_EN			0x70000
+ #define SUN50I_MIXER_PEAK_EN			0x70800
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/Makefile b/arch/arm64/boot/dts/allwinner/overlay/Makefile
+index e19b987e3b03..f3e4c89f8617 100644
+--- a/arch/arm64/boot/dts/allwinner/overlay/Makefile
++++ b/arch/arm64/boot/dts/allwinner/overlay/Makefile
+@@ -27,6 +27,7 @@ dtbo-$(CONFIG_ARCH_SUNXI) += \
+ 	sun50i-h5-spi-add-cs1.dtbo \
+ 	sun50i-h5-spi-jedec-nor.dtbo \
+ 	sun50i-h5-spi-spidev.dtbo \
++	sun50i-h5-tve.dtbo \
+ 	sun50i-h5-uart1.dtbo \
+ 	sun50i-h5-uart2.dtbo \
+ 	sun50i-h5-uart3.dtbo \
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/README.sun50i-h5-overlays b/arch/arm64/boot/dts/allwinner/overlay/README.sun50i-h5-overlays
+index 1ac7fbcf62d1..a2ef4427c65b 100644
+--- a/arch/arm64/boot/dts/allwinner/overlay/README.sun50i-h5-overlays
++++ b/arch/arm64/boot/dts/allwinner/overlay/README.sun50i-h5-overlays
+@@ -26,6 +26,7 @@ adding fixed software (GPIO) chip selects is possible with a separate overlay
+ - spi-add-cs1
+ - spi-jedec-nor
+ - spi-spidev
++- tve
+ - uart1
+ - uart2
+ - uart3
+@@ -170,6 +171,10 @@ param_spidev_max_freq (int)
+ 	Default: 1000000
+ 	Range: 3000 - 100000000
+ 
++### tve
++
++Activates Composite TV Encoder
++
+ ### uart1
+ 
+ Activates serial port 1 (/dev/ttyS1)
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-tve.dts b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-tve.dts
+new file mode 100644
+index 000000000000..73e6e1215a5a
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h5-tve.dts
+@@ -0,0 +1,34 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "allwinner,sun8i-h5";
++
++	fragment@0 {
++		target = <&de>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++
++	fragment@1 {
++		target = <&mixer1>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++
++	fragment@2 {
++		target = <&tcon1>;
++		 __overlay__ {
++			status = "okay";
++		};
++	};
++
++	fragment@3 {
++		target = <&tve>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};

--- a/patch/kernel/archive/sunxi-6.4/series.armbian
+++ b/patch/kernel/archive/sunxi-6.4/series.armbian
@@ -185,3 +185,4 @@
 	patches.armbian/arm-dts-sun8i-h3-nanopi-duo2-enable-powerbutton-and-ethernet.patch
 	patches.armbian/arm-dts-sun8i-h3-reduce-opp-microvolt-to-prevent-not.patch
 	patches.armbian/arm64-dts-sun50i-h5-enable-power-button-for-orangepi-prime.patch
+	patches.armbian/arm-dts-sunxi-h3-h5-add_tve.patch

--- a/patch/kernel/archive/sunxi-6.4/series.conf
+++ b/patch/kernel/archive/sunxi-6.4/series.conf
@@ -665,3 +665,4 @@
 	patches.armbian/arm-dts-sun8i-h3-nanopi-duo2-enable-powerbutton-and-ethernet.patch
 	patches.armbian/arm-dts-sun8i-h3-reduce-opp-microvolt-to-prevent-not.patch
 	patches.armbian/arm64-dts-sun50i-h5-enable-power-button-for-orangepi-prime.patch
+	patches.armbian/arm-dts-sunxi-h3-h5-add_tve.patch


### PR DESCRIPTION
# Description

Found we had cvbs support for allwinner H3 for current kernel. It had bits to make it working for H5 as well with only thing missing was the overlay to enable the it. Hence added the overlay for H5. Also as the patch was missing in edge kernel, added the same.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Created a server image for OrangePi Prime and attached a CVBS/AV display to it. The console was also shown on the AV monitor.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
