### PR TITLE
Change the weird 1500000 baudrate to 115200

### DIFF
--- a/config/bootscripts/boot-rk3588-legacy.cmd
+++ b/config/bootscripts/boot-rk3588-legacy.cmd
@@ -29,7 +29,7 @@ fi
 if test "${logo}" = "disabled"; then setenv logo "logo.nologo"; fi
 
 if test "${console}" = "display" || test "${console}" = "both"; then setenv consoleargs "console=tty1"; fi
-if test "${console}" = "serial" || test "${console}" = "both"; then setenv consoleargs "console=ttyS2,1500000 ${consoleargs}"; fi
+if test "${console}" = "serial" || test "${console}" = "both"; then setenv consoleargs "console=ttyS2,115200 ${consoleargs}"; fi
 if test "${earlycon}" = "on"; then setenv consoleargs "earlycon ${consoleargs}"; fi
 if test "${bootlogo}" = "true"; then
 	setenv consoleargs "splash plymouth.ignore-serial-consoles ${consoleargs}"

--- a/config/bootscripts/boot-rockchip64-vendor.cmd
+++ b/config/bootscripts/boot-rockchip64-vendor.cmd
@@ -23,7 +23,7 @@ fi
 if test "${logo}" = "disabled"; then setenv logo "logo.nologo"; fi
 
 if test "${console}" = "display" || test "${console}" = "both"; then setenv consoleargs "console=tty1"; fi
-if test "${console}" = "serial" || test "${console}" = "both"; then setenv consoleargs "console=ttyS2,1500000 ${consoleargs}"; fi
+if test "${console}" = "serial" || test "${console}" = "both"; then setenv consoleargs "console=ttyS2,115200 ${consoleargs}"; fi
 if test "${earlycon}" = "on"; then setenv consoleargs "earlycon ${consoleargs}"; fi
 if test "${bootlogo}" = "true"; then
 	setenv consoleargs "splash plymouth.ignore-serial-consoles ${consoleargs}"

--- a/config/bootscripts/boot-rockchip64.cmd
+++ b/config/bootscripts/boot-rockchip64.cmd
@@ -24,7 +24,7 @@ fi
 if test "${logo}" = "disabled"; then setenv logo "logo.nologo"; fi
 
 if test "${console}" = "display" || test "${console}" = "both"; then setenv consoleargs "console=tty1"; fi
-if test "${console}" = "serial" || test "${console}" = "both"; then setenv consoleargs "console=ttyS2,1500000 ${consoleargs}"; fi
+if test "${console}" = "serial" || test "${console}" = "both"; then setenv consoleargs "console=ttyS2,115200 ${consoleargs}"; fi
 if test "${earlycon}" = "on"; then setenv consoleargs "earlycon ${consoleargs}"; fi
 if test "${bootlogo}" = "true"; then
 	setenv consoleargs "splash plymouth.ignore-serial-consoles ${consoleargs}"

--- a/patch/kernel/archive/rockchip64-5.15/add-board-tinker-board-2.patch
+++ b/patch/kernel/archive/rockchip64-5.15/add-board-tinker-board-2.patch
@@ -32,7 +32,7 @@ index 000000000..dc337bee0
 +	compatible = "rockchip,rk3399-evb", "rockchip,rk3399";
 +
 +	chosen {
-+		stdout-path = "serial2:1500000n8";
++		stdout-path = "serial2:115200n8";
 +	};
 +	
 +	board_info: board-info {

--- a/patch/kernel/archive/rockchip64-5.17/add-board-tinker-board-2.patch
+++ b/patch/kernel/archive/rockchip64-5.17/add-board-tinker-board-2.patch
@@ -32,7 +32,7 @@ index 000000000..dc337bee0
 +	compatible = "rockchip,rk3399-evb", "rockchip,rk3399";
 +
 +	chosen {
-+		stdout-path = "serial2:1500000n8";
++		stdout-path = "serial2:115200n8";
 +	};
 +	
 +	board_info: board-info {

--- a/patch/kernel/archive/rockchip64-5.18/add-board-tinker-board-2.patch
+++ b/patch/kernel/archive/rockchip64-5.18/add-board-tinker-board-2.patch
@@ -32,7 +32,7 @@ index 000000000..dc337bee0
 +	compatible = "rockchip,rk3399-evb", "rockchip,rk3399";
 +
 +	chosen {
-+		stdout-path = "serial2:1500000n8";
++		stdout-path = "serial2:115200n8";
 +	};
 +	
 +	board_info: board-info {

--- a/patch/kernel/archive/rockchip64-5.19/add-board-tinker-board-2.patch
+++ b/patch/kernel/archive/rockchip64-5.19/add-board-tinker-board-2.patch
@@ -32,7 +32,7 @@ index 000000000..dc337bee0
 +	compatible = "rockchip,rk3399-evb", "rockchip,rk3399";
 +
 +	chosen {
-+		stdout-path = "serial2:1500000n8";
++		stdout-path = "serial2:115200n8";
 +	};
 +	
 +	board_info: board-info {

--- a/patch/kernel/archive/rockchip64-6.0/add-board-tinker-board-2.patch
+++ b/patch/kernel/archive/rockchip64-6.0/add-board-tinker-board-2.patch
@@ -32,7 +32,7 @@ index 000000000..dc337bee0
 +	compatible = "rockchip,rk3399-evb", "rockchip,rk3399";
 +
 +	chosen {
-+		stdout-path = "serial2:1500000n8";
++		stdout-path = "serial2:115200n8";
 +	};
 +	
 +	board_info: board-info {

--- a/patch/kernel/archive/rockchip64-6.1/add-board-tinker-board-2.patch
+++ b/patch/kernel/archive/rockchip64-6.1/add-board-tinker-board-2.patch
@@ -32,7 +32,7 @@ index 000000000..dc337bee0
 +	compatible = "rockchip,rk3399-evb", "rockchip,rk3399";
 +
 +	chosen {
-+		stdout-path = "serial2:1500000n8";
++		stdout-path = "serial2:115200n8";
 +	};
 +	
 +	board_info: board-info {

--- a/patch/kernel/archive/rockchip64-6.3/dt/rk3399-tinker-2.dts
+++ b/patch/kernel/archive/rockchip64-6.3/dt/rk3399-tinker-2.dts
@@ -15,7 +15,7 @@
 	compatible = "rockchip,rk3399-evb", "rockchip,rk3399";
 
 	chosen {
-		stdout-path = "serial2:1500000n8";
+		stdout-path = "serial2:115200n8";
 	};
 	
 	board_info: board-info {

--- a/patch/u-boot/legacy/u-boot-tinkerboard2/add-board-tinker-board-2.patch
+++ b/patch/u-boot/legacy/u-boot-tinkerboard2/add-board-tinker-board-2.patch
@@ -125,7 +125,7 @@ index 00000000..7372f25a
 +	compatible = "rockchip,rk3399-evb", "rockchip,rk3399";
 +
 +	chosen {
-+		stdout-path = "serial2:1500000n8";
++		stdout-path = "serial2:115200n8";
 +	};
 +
 +	clkin_gmac: external-gmac-clock {
@@ -804,7 +804,7 @@ index 00000000..de9c2692
 +CONFIG_PWM_ROCKCHIP=y
 +CONFIG_RAM_RK3399_LPDDR4=y
 +CONFIG_DM_RESET=y
-+CONFIG_BAUDRATE=1500000
++CONFIG_BAUDRATE=115200
 +CONFIG_DEBUG_UART_SHIFT=2
 +CONFIG_SYSRESET=y
 +CONFIG_USB=y

--- a/patch/u-boot/u-boot-media/0060-add-board-tinker-board-2.patch
+++ b/patch/u-boot/u-boot-media/0060-add-board-tinker-board-2.patch
@@ -125,7 +125,7 @@ index 00000000..7372f25a
 +	compatible = "rockchip,rk3399-evb", "rockchip,rk3399";
 +
 +	chosen {
-+		stdout-path = "serial2:1500000n8";
++		stdout-path = "serial2:115200n8";
 +	};
 +	
 +	clkin_gmac: external-gmac-clock {
@@ -802,7 +802,7 @@ index 00000000..de9c2692
 +CONFIG_PWM_ROCKCHIP=y
 +CONFIG_RAM_RK3399_LPDDR4=y
 +CONFIG_DM_RESET=y
-+CONFIG_BAUDRATE=1500000
++CONFIG_BAUDRATE=115200
 +CONFIG_DEBUG_UART_SHIFT=2
 +CONFIG_SYSRESET=y
 +CONFIG_USB=y


### PR DESCRIPTION
# Description

Tinkerboard 2 SOC uses the weird baudrate 1500000 for debug uart. and the1500000 is not supported by most of the serial terminal application. 
Here change the baudrate from 1500000 to 115200 which is the most common baudrate for debug uart

# How Has This Been Tested?
tested with tinkerboard 2s, and able to see the correct bootloader console message.