### PR TITLE
rtw88: 6.4.7: `drivers/net/wireless/realtek/rtw88/sdio.c`

### DIFF
--- a/patch/misc/rtw88/6.4/001-drivers-net-wireless-realtek-rtw88-upstream-wireless.patch
+++ b/patch/misc/rtw88/6.4/001-drivers-net-wireless-realtek-rtw88-upstream-wireless.patch
@@ -607,49 +607,6 @@ index a356318a5c15..3642a2c7f80c 100644
  	};
  };
  
-diff --git a/drivers/net/wireless/realtek/rtw88/sdio.c b/drivers/net/wireless/realtek/rtw88/sdio.c
-index 06fce7c3adda..2c1fb2dabd40 100644
---- a/drivers/net/wireless/realtek/rtw88/sdio.c
-+++ b/drivers/net/wireless/realtek/rtw88/sdio.c
-@@ -998,9 +998,9 @@ static void rtw_sdio_rxfifo_recv(struct rtw_dev *rtwdev, u32 rx_len)
- 
- static void rtw_sdio_rx_isr(struct rtw_dev *rtwdev)
- {
--	u32 rx_len, total_rx_bytes = 0;
-+	u32 rx_len, hisr, total_rx_bytes = 0;
- 
--	while (total_rx_bytes < SZ_64K) {
-+	do {
- 		if (rtw_chip_wcpu_11n(rtwdev))
- 			rx_len = rtw_read16(rtwdev, REG_SDIO_RX0_REQ_LEN);
- 		else
-@@ -1012,7 +1012,25 @@ static void rtw_sdio_rx_isr(struct rtw_dev *rtwdev)
- 		rtw_sdio_rxfifo_recv(rtwdev, rx_len);
- 
- 		total_rx_bytes += rx_len;
--	}
-+
-+		if (rtw_chip_wcpu_11n(rtwdev)) {
-+			/* Stop if no more RX requests are pending, even if
-+			 * rx_len could be greater than zero in the next
-+			 * iteration. This is needed because the RX buffer may
-+			 * already contain data while either HW or FW are not
-+			 * done filling that buffer yet. Still reading the
-+			 * buffer can result in packets where
-+			 * rtw_rx_pkt_stat.pkt_len is zero or points beyond the
-+			 * end of the buffer.
-+			 */
-+			hisr = rtw_read32(rtwdev, REG_SDIO_HISR);
-+		} else {
-+			/* RTW_WCPU_11AC chips have improved hardware or
-+			 * firmware and can use rx_len unconditionally.
-+			 */
-+			hisr = REG_SDIO_HISR_RX_REQUEST;
-+		}
-+	} while (total_rx_bytes < SZ_64K && hisr & REG_SDIO_HISR_RX_REQUEST);
- }
- 
- static void rtw_sdio_handle_interrupt(struct sdio_func *sdio_func)
 diff --git a/drivers/net/wireless/realtek/rtw88/tx.c b/drivers/net/wireless/realtek/rtw88/tx.c
 index bb5c7492c98b..2821119dc930 100644
 --- a/drivers/net/wireless/realtek/rtw88/tx.c


### PR DESCRIPTION
The following patch has landed in linux-6.4.7 and can be removed. https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/diff/drivers/net/wireless/realtek/rtw88/sdio.c?id=v6.4.7&id2=v6.4.6

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
