### PR TITLE
arm64: dts: amlogic: add missing cache properties

### DIFF
--- a/patch/kernel/archive/meson64-6.4/meson-dts-add-missing-cache-properties.patch
+++ b/patch/kernel/archive/meson64-6.4/meson-dts-add-missing-cache-properties.patch
@@ -1,0 +1,71 @@
+From 79d5517c23a079c5f9cf128485301fa89577b962 Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@xxxxx.com>
+Date: Wed, 26 Jul 2023 01:34:30 -0400
+Subject: [PATCH] arm64: dts: amlogic: add missing cache properties
+
+As all level 2 and level 3 caches are unified, add required
+cache-unified properties to fix warnings like:
+
+  meson-a1-ad401.dtb: l2-cache0: 'cache-unified' is a required property
+
+https://lore.kernel.org/lkml/20230421223211.115612-1-krzysztof.kozlowski@linaro.org/T/
+
+Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
+---
+ arch/arm64/boot/dts/amlogic/meson-g12a.dtsi | 1 +
+ arch/arm64/boot/dts/amlogic/meson-g12b.dtsi | 1 +
+ arch/arm64/boot/dts/amlogic/meson-gx.dtsi   | 1 +
+ arch/arm64/boot/dts/amlogic/meson-sm1.dtsi  | 1 +
+ 4 files changed, 4 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12a.dtsi b/arch/arm64/boot/dts/amlogic/meson-g12a.dtsi
+index f58fd2a6fe61..543e70669df5 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-g12a.dtsi
++++ b/arch/arm64/boot/dts/amlogic/meson-g12a.dtsi
+@@ -51,6 +51,7 @@ cpu3: cpu@3 {
+ 		l2: l2-cache0 {
+ 			compatible = "cache";
+ 			cache-level = <2>;
++			cache-unified;
+ 		};
+ 	};
+ 
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi b/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi
+index 431572b384db..86e6ceb31d5e 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi
++++ b/arch/arm64/boot/dts/amlogic/meson-g12b.dtsi
+@@ -106,6 +106,7 @@ cpu103: cpu@103 {
+ 		l2: l2-cache0 {
+ 			compatible = "cache";
+ 			cache-level = <2>;
++			cache-unified;
+ 		};
+ 	};
+ };
+diff --git a/arch/arm64/boot/dts/amlogic/meson-gx.dtsi b/arch/arm64/boot/dts/amlogic/meson-gx.dtsi
+index 11f89bfecb56..2673f0dbafe7 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-gx.dtsi
++++ b/arch/arm64/boot/dts/amlogic/meson-gx.dtsi
+@@ -133,6 +133,7 @@ cpu3: cpu@3 {
+ 		l2: l2-cache0 {
+ 			compatible = "cache";
+ 			cache-level = <2>;
++			cache-unified;
+ 		};
+ 	};
+ 
+diff --git a/arch/arm64/boot/dts/amlogic/meson-sm1.dtsi b/arch/arm64/boot/dts/amlogic/meson-sm1.dtsi
+index 617d322af0df..643f94d9d08e 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-sm1.dtsi
++++ b/arch/arm64/boot/dts/amlogic/meson-sm1.dtsi
+@@ -89,6 +89,7 @@ cpu3: cpu@3 {
+ 		l2: l2-cache0 {
+ 			compatible = "cache";
+ 			cache-level = <2>;
++			cache-unified;
+ 		};
+ 	};
+ 
+-- 
+2.39.2
+


### PR DESCRIPTION
As all level 2 and level 3 caches are unified, add required cache-unified properties to fix warnings like:

meson-a1-ad401.dtb: l2-cache0: 'cache-unified' is a required property

https://lore.kernel.org/lkml/20230421223211.115612-1-krzysztof.kozlowski@linaro.org/T/

# How Has This Been Tested?
Built image with said patch:
```sh
patrick@bananapicm4io:~$ dmesg | grep model; dmesg | grep "Linux version"; dmesg | grep CPU; cat /etc/os-release | grep "PRETTY_NAME"
[    0.000000] Machine model: BananaPi BPI-CM4IO Baseboard with BPI-CM4 Module
[    0.000000] Linux version 6.4.7-meson64 (armbian@next) (aarch64-linux-gnu-gcc (Ubuntu 11.3.0-1ubuntu1~22.04.1) 11.3.0, GNU ld (GNU Binutils for Ubuntu) 2.38) #1 SMP PREEMPT Thu Jul 27 02:57:07 EDT 2023
[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd034]
[    0.000000] Detected VIPT I-cache on CPU0
[    0.000000] CPU features: detected: ARM erratum 845719
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=6, Nodes=1
[    0.000000] rcu: 	RCU restricting CPUs from NR_CPUS=256 to nr_cpu_ids=6.
[    0.006705] smp: Bringing up secondary CPUs ...
[    0.007416] Detected VIPT I-cache on CPU1
[    0.007534] CPU1: Booted secondary processor 0x0000000001 [0x410fd034]
[    0.008863] CPU features: detected: Spectre-v2
[    0.008876] CPU features: detected: Spectre-v4
[    0.008881] CPU features: detected: Spectre-BHB
[    0.008885] CPU features: detected: ARM erratum 858921
[    0.008892] Detected VIPT I-cache on CPU2
[    0.008978] arch_timer: CPU2: Trapping CNTVCT access
[    0.008989] CPU2: Booted secondary processor 0x0000000100 [0x410fd092]
[    0.009686] Detected VIPT I-cache on CPU3
[    0.009736] arch_timer: CPU3: Trapping CNTVCT access
[    0.009742] CPU3: Booted secondary processor 0x0000000101 [0x410fd092]
[    0.010422] Detected VIPT I-cache on CPU4
[    0.010474] arch_timer: CPU4: Trapping CNTVCT access
[    0.010480] CPU4: Booted secondary processor 0x0000000102 [0x410fd092]
[    0.011155] Detected VIPT I-cache on CPU5
[    0.011209] arch_timer: CPU5: Trapping CNTVCT access
[    0.011216] CPU5: Booted secondary processor 0x0000000103 [0x410fd092]
[    0.011288] smp: Brought up 1 node, 6 CPUs
[    0.011322] CPU features: detected: 32-bit EL0 Support
[    0.011326] CPU features: detected: 32-bit EL1 Support
[    0.011332] CPU features: detected: CRC32 instructions
[    0.011418] CPU: All CPU(s) started at EL2
[    0.753971] cpufreq: cpufreq_online: CPU2: Running at unlisted initial frequency: 999999 KHz, changing to: 1000000 KHz
[    0.757855] ledtrig-cpu: registered to indicate activity on CPUs
PRETTY_NAME="Armbian 23.08.0-trunk bookworm"
ARMBIAN_PRETTY_NAME="Armbian 23.08.0-trunk bookworm"
```
# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
