### PR TITLE
kernel / drivers-harness: use the kernel git SHA1 (`$KERNEL_GIT_SHA1`) instead of `$KERNEL_MAJOR_MINOR` for drivers cache key

### DIFF
--- a/lib/functions/artifacts/artifact-kernel.sh
+++ b/lib/functions/artifacts/artifact-kernel.sh
@@ -86,6 +86,9 @@ function artifact_kernel_prepare_version() {
 	# Sanity check, the SHA1 gotta be sane.
 	[[ "${GIT_INFO_KERNEL[SHA1]}" =~ ^[0-9a-f]{40}$ ]] || exit_with_error "SHA1 is not sane: '${GIT_INFO_KERNEL[SHA1]}'"
 
+	# Set a readonly global with the kernel SHA1. Will be used later for the drivers cache_key.
+	declare -g -r KERNEL_GIT_SHA1="${GIT_INFO_KERNEL[SHA1]}"
+
 	declare short_sha1="${GIT_INFO_KERNEL[SHA1]:0:${short_hash_size}}"
 
 	# get the drivers hash... or "0000000000000000" if EXTRAWIFI=no


### PR DESCRIPTION
#### kernel / drivers-harness: use the kernel git SHA1 (`$KERNEL_GIT_SHA1`) instead of `$KERNEL_MAJOR_MINOR` for drivers cache key

- kernel / drivers-harness: use the kernel git SHA1 (`$KERNEL_GIT_SHA1`) instead of `$KERNEL_MAJOR_MINOR` for drivers cache key
  - this should avoid (late) patching errors that might happen during a point release bump like `6.4.5` -> `6.4.6` cos we'd be using the wrong cached drivers patch
  - using the SHA1 will instead (possibly) trigger the "real patching failure", during drivers-harness when building a new driver patch cache
  - also try to cleanup old caches in the old format so we've not many leftovers -- each patch is ~150mb