### PR TITLE
display-alert: strip newlines as well as ANSI colors if `ANSI_COLOR=none`

### DIFF
--- a/lib/functions/logging/display-alert.sh
+++ b/lib/functions/logging/display-alert.sh
@@ -15,7 +15,8 @@ function display_alert() {
 		if [[ "${POOR_MAN_PROFILER}" == "yes" ]]; then
 			poor_man_profiler
 		fi
-		echo -e "${extra_profiler}${3}::${1} ${2}" | sed 's/\x1b\[[0-9;]*m//g' >&2
+		echo -e "${extra_profiler}${3}::${1} ${2}" | sed 's/\x1b\[[0-9;]*m//g' | sed -z 's|\n|\\n|g' >&2 # remove ANSI colors and newlines
+		echo "" >&2                                                                                       # newline
 		return 0
 	fi
 


### PR DESCRIPTION
#### display-alert: strip newlines as well as ANSI colors if `ANSI_COLOR=none`

- display-alert: strip newlines as well as ANSI colors if `ANSI_COLOR=none`
  - `ANSI_COLOR=none` is used when we're driving compile.sh from Python
  - some debugging messages had newlines in them, thus making Python mark those as `[LEAKED]`