### PR TITLE
[DRAFT] artifacts: Don't use REVISION prefix for OCI cache

### DIFF
--- a/lib/functions/artifacts/artifact-armbian-base-files.sh
+++ b/lib/functions/artifacts/artifact-armbian-base-files.sh
@@ -46,6 +46,7 @@ function artifact_armbian-base-files_prepare_version() {
 
 	# outer scope
 	artifact_version="${artifact_prefix_version}${fake_unchanging_base_version}-B${bash_hash_short}"
+	artifact_oci_strip_prefix="no"	# don't strip artifact_prefix_version from oci tag
 
 	declare -a reasons=("Armbian armbian-base-files" "original ${RELEASE} version \"${base_files_wanted_upstream_version}\"" "framework bash hash \"${bash_hash}\"")
 

--- a/lib/functions/artifacts/artifact-armbian-plymouth-theme.sh
+++ b/lib/functions/artifacts/artifact-armbian-plymouth-theme.sh
@@ -27,7 +27,7 @@ function artifact_armbian-plymouth-theme_prepare_version() {
 	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
 
 	# outer scope
-	artifact_version="${artifact_prefix_version}-B${bash_hash_short}"
+	artifact_version="${artifact_prefix_version}${fake_unchanging_base_version}-B${bash_hash_short}"
 
 	declare -a reasons=(
 		"Armbian armbian-plymouth-theme"


### PR DESCRIPTION
# Description

This set of changes tries to handle the requirement of reducing cache misses by removing the REVISION prefix from the tag of the OCI cache. It works by making use of a tag that doesn't include the version prefix. Once the artifact is fetched, if the filename is not what we expect, then the file is renamed to the expected file name. This can be required in cases when REVISION is bumped but no changes are done for the artifact. In that case, for example, we might be looking for a artifact with version 23.08.1-trunk prefix while the artifact thats available and is identical to the needed artifact might have version starting with 23.08.0-trunk. 

Only the OCI tags are changed and files are renamed when needed, deb files are not modified in anyways in this solution. Also quick testing shows that it works fine. But I am going to do some more testing tomorrow and then will remove the WIP prefix.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Removed all debs and docker volumes. Then compiled an image followed by uploading of the artifact to OCI using ./compile.sh <artifact_name> OCI_TARGET_BASE=172.17.0.2:5000/. Then removed all debs and changed VERSION file. Then rebuilt the image and checked that artifacts are fetched from OCI cache

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
