### PR TITLE
Allwinner: bump kernel versions

### DIFF
--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -24,17 +24,17 @@ case $BRANCH in
 
 	legacy)
 		declare -g KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v5.15.121"
+		declare -g KERNELBRANCH="tag:v5.15.123"
 		;;
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.1.40"
+		declare -g KERNELBRANCH="tag:v6.1.42"
 		;;
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.4" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.4.5"
+		declare -g KERNELBRANCH="tag:v6.4.7"
 		;;
 esac
 

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -25,7 +25,7 @@ case $BRANCH in
 
 	legacy)
 		declare -g KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v5.15.121"
+		declare -g KERNELBRANCH="tag:v5.15.123"
 		;;
 
 	current)
@@ -35,7 +35,7 @@ case $BRANCH in
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.4" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.4.5"
+		declare -g KERNELBRANCH="tag:v6.4.7"
 		;;
 esac
 


### PR DESCRIPTION
# Description

Bumped kernel versions as follows
sunxi & sunxi64:
legacy - 5.15.121 -> 5.15.123
edge - 6.4.5 -> 6.4.7

sunxi64 only:
current - 6.1.40 -> 6.1.42

The sunxi current kernel is kept back as 6.1.42 is currently not booting on 32-bit allwinner boards.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Booted updated sunxi images on NanoPi Duo2 (sun8i H3)
- [X] Booted updated sunxi64 images on Orange Pi Prime (sun50i H5)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
