### PR TITLE
general: extra: meson64 overlays

### DIFF
--- a/patch/kernel/archive/meson64-6.1/general-xtra-meson64-overlays.patch
+++ b/patch/kernel/archive/meson64-6.1/general-xtra-meson64-overlays.patch
@@ -1,0 +1,132 @@
+From aaecedc8d3a92722755c264fd5c75740b5f5136f Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@xxxxx.com>
+Date: Sat, 29 Jul 2023 06:52:56 -0400
+Subject: [PATCH] general: extra: meson64 overlays
+
+meson-g12a-radxa-zero-gpio-10-led.dtbo (rev 1.51 enable led)
+meson-g12a-radxa-zero-gpio-8-led.dtbo (rev 1.4 enable led)
+meson-g12b-odroid-n2-spi.dtbo (SPI-NOR enable via overlay)
+
+Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
+---
+ arch/arm64/boot/dts/amlogic/overlay/Makefile  |  5 +++-
+ .../meson-g12a-radxa-zero-gpio-10-led.dts     | 26 +++++++++++++++++++
+ .../meson-g12a-radxa-zero-gpio-8-led.dts      | 26 +++++++++++++++++++
+ .../overlay/meson-g12b-odroid-n2-spi.dts      | 23 ++++++++++++++++
+ 4 files changed, 79 insertions(+), 1 deletion(-)
+ create mode 100644 arch/arm64/boot/dts/amlogic/overlay/meson-g12a-radxa-zero-gpio-10-led.dts
+ create mode 100644 arch/arm64/boot/dts/amlogic/overlay/meson-g12a-radxa-zero-gpio-8-led.dts
+ create mode 100644 arch/arm64/boot/dts/amlogic/overlay/meson-g12b-odroid-n2-spi.dts
+
+diff --git a/arch/arm64/boot/dts/amlogic/overlay/Makefile b/arch/arm64/boot/dts/amlogic/overlay/Makefile
+index 9d5c727602d1..4511a76d483c 100644
+--- a/arch/arm64/boot/dts/amlogic/overlay/Makefile
++++ b/arch/arm64/boot/dts/amlogic/overlay/Makefile
+@@ -6,7 +6,10 @@ dtbo-$(CONFIG_ARCH_MESON) += \
+ 	meson-uartC.dtbo \
+ 	meson-w1-gpio.dtbo \
+ 	meson-w1AB-gpio.dtbo \
+-	meson-g12-gxl-cma-pool-896MB.dtbo
++	meson-g12-gxl-cma-pool-896MB.dtbo \
++	meson-g12a-radxa-zero-gpio-8-led.dtbo \
++	meson-g12a-radxa-zero-gpio-10-led.dtbo \
++	meson-g12b-odroid-n2-spi.dtbo
+ 
+ scr-$(CONFIG_ARCH_MESON) += \
+        meson-fixup.scr
+diff --git a/arch/arm64/boot/dts/amlogic/overlay/meson-g12a-radxa-zero-gpio-10-led.dts b/arch/arm64/boot/dts/amlogic/overlay/meson-g12a-radxa-zero-gpio-10-led.dts
+new file mode 100644
+index 000000000000..d76430328955
+--- /dev/null
++++ b/arch/arm64/boot/dts/amlogic/overlay/meson-g12a-radxa-zero-gpio-10-led.dts
+@@ -0,0 +1,26 @@
++/dts-v1/;
++/plugin/;
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/gpio/meson-g12a-gpio.h>
++
++/ {
++	compatible = "radxa,zero", "amlogic,g12a";
++
++	fragment@0 {
++		target-path = "/";
++			__overlay__ {
++
++			leds {
++				compatible = "gpio-leds";
++
++				led-green {
++					label = "radxa-zero:green";
++					gpios = <&gpio_ao GPIOAO_10 GPIO_ACTIVE_HIGH>;
++					linux,default-trigger = "heartbeat";
++					default-state = "on";
++				};
++			};
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/amlogic/overlay/meson-g12a-radxa-zero-gpio-8-led.dts b/arch/arm64/boot/dts/amlogic/overlay/meson-g12a-radxa-zero-gpio-8-led.dts
+new file mode 100644
+index 000000000000..9b294e97f79f
+--- /dev/null
++++ b/arch/arm64/boot/dts/amlogic/overlay/meson-g12a-radxa-zero-gpio-8-led.dts
+@@ -0,0 +1,26 @@
++/dts-v1/;
++/plugin/;
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/gpio/meson-g12a-gpio.h>
++
++/ {
++	compatible = "radxa,zero", "amlogic,g12a";
++
++	fragment@0 {
++		target-path = "/";
++			__overlay__ {
++
++			leds {
++				compatible = "gpio-leds";
++
++				led-green {
++					label = "radxa-zero:green";
++					gpios = <&gpio_ao GPIOAO_8 GPIO_ACTIVE_HIGH>;
++					linux,default-trigger = "heartbeat";
++					default-state = "on";
++				};
++			};
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/amlogic/overlay/meson-g12b-odroid-n2-spi.dts b/arch/arm64/boot/dts/amlogic/overlay/meson-g12b-odroid-n2-spi.dts
+new file mode 100644
+index 000000000000..658afb1fb58d
+--- /dev/null
++++ b/arch/arm64/boot/dts/amlogic/overlay/meson-g12b-odroid-n2-spi.dts
+@@ -0,0 +1,23 @@
++/dts-v1/;
++/plugin/;
++
++#include <dt-bindings/interrupt-controller/irq.h>
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/gpio/meson-g12a-gpio.h>
++
++/ {
++	fragment@0 {
++		target = <&sd_emmc_c>;
++		__overlay__ {
++			pinctrl-0 = <&emmc_ctrl_pins>, <&emmc_data_4b_pins>, <&emmc_ds_pins>;
++			bus-width = <4>;
++		};
++	};
++
++	fragment@1 {
++		target = <&spifc>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};
+-- 
+2.39.2
+

--- a/patch/kernel/archive/meson64-6.4/overlay/Makefile
+++ b/patch/kernel/archive/meson64-6.4/overlay/Makefile
@@ -6,7 +6,11 @@ dtbo-$(CONFIG_ARCH_MESON) += \
 	meson-uartC.dtbo \
 	meson-w1-gpio.dtbo \
 	meson-w1AB-gpio.dtbo \
-	meson-g12-gxl-cma-pool-896MB.dtbo
+	meson-g12-gxl-cma-pool-896MB.dtbo \
+	meson-g12a-radxa-zero-gpio-8-led.dtbo \
+	meson-g12a-radxa-zero-gpio-10-led.dtbo \
+	meson-g12b-odroid-n2-spi.dtbo
+	
 
 scr-$(CONFIG_ARCH_MESON) += \
        meson-fixup.scr

--- a/patch/kernel/archive/meson64-6.4/overlay/Makefile
+++ b/patch/kernel/archive/meson64-6.4/overlay/Makefile
@@ -9,8 +9,7 @@ dtbo-$(CONFIG_ARCH_MESON) += \
 	meson-g12-gxl-cma-pool-896MB.dtbo \
 	meson-g12a-radxa-zero-gpio-8-led.dtbo \
 	meson-g12a-radxa-zero-gpio-10-led.dtbo \
-	meson-g12b-odroid-n2-spi.dtbo
-	
+	meson-g12b-odroid-n2-spi.dtbo	
 
 scr-$(CONFIG_ARCH_MESON) += \
        meson-fixup.scr

--- a/patch/kernel/archive/meson64-6.4/overlay/meson-g12a-radxa-zero-gpio-10-led.dts
+++ b/patch/kernel/archive/meson64-6.4/overlay/meson-g12a-radxa-zero-gpio-10-led.dts
@@ -1,0 +1,26 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/gpio/meson-g12a-gpio.h>
+
+/ {
+	compatible = "radxa,zero", "amlogic,g12a";
+
+	fragment@0 {
+		target-path = "/";
+			__overlay__ {
+
+			leds {
+				compatible = "gpio-leds";
+
+				led-green {
+					label = "radxa-zero:green";
+					gpios = <&gpio_ao GPIOAO_10 GPIO_ACTIVE_HIGH>;
+					linux,default-trigger = "heartbeat";
+					default-state = "on";
+				};
+			};
+		};
+	};
+};

--- a/patch/kernel/archive/meson64-6.4/overlay/meson-g12a-radxa-zero-gpio-8-led.dts
+++ b/patch/kernel/archive/meson64-6.4/overlay/meson-g12a-radxa-zero-gpio-8-led.dts
@@ -1,0 +1,26 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/gpio/meson-g12a-gpio.h>
+
+/ {
+	compatible = "radxa,zero", "amlogic,g12a";
+
+	fragment@0 {
+		target-path = "/";
+			__overlay__ {
+
+			leds {
+				compatible = "gpio-leds";
+
+				led-green {
+					label = "radxa-zero:green";
+					gpios = <&gpio_ao GPIOAO_8 GPIO_ACTIVE_HIGH>;
+					linux,default-trigger = "heartbeat";
+					default-state = "on";
+				};
+			};
+		};
+	};
+};

--- a/patch/kernel/archive/meson64-6.4/overlay/meson-g12b-odroid-n2-spi.dts
+++ b/patch/kernel/archive/meson64-6.4/overlay/meson-g12b-odroid-n2-spi.dts
@@ -1,0 +1,23 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/gpio/meson-g12a-gpio.h>
+
+/ {
+	fragment@0 {
+		target = <&sd_emmc_c>;
+		__overlay__ {
+			pinctrl-0 = <&emmc_ctrl_pins>, <&emmc_data_4b_pins>, <&emmc_ds_pins>;
+			bus-width = <4>;
+		};
+	};
+
+	fragment@1 {
+		target = <&spifc>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};


### PR DESCRIPTION
Linux 6.1.y (current) / Linux 6.4.y (edge)

meson-g12a-radxa-zero-gpio-10-led.dtbo (rev 1.51 enable led)
meson-g12a-radxa-zero-gpio-8-led.dtbo (rev 1.4 enable led)
meson-g12b-odroid-n2-spi.dtbo (SPI-NOR enable via overlay)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
