### PR TITLE
opi5: remove type-c/usb2 mode service

### DIFF
--- a/config/boards/orangepi5.conf
+++ b/config/boards/orangepi5.conf
@@ -21,24 +21,6 @@ BL31_BLOB='rk35/rk3588_bl31_v1.38.elf'
 declare -g BLUETOOTH_HCIATTACH_PARAMS="-s 115200 /dev/ttyS9 bcm43xx 1500000" # For the bluetooth-hciattach extension
 enable_extension "bluetooth-hciattach"                                       # Enable the bluetooth-hciattach extension
 
-function post_family_tweaks_bsp__orangepi5_copy_usb2_service() {
-    display_alert "Installing BSP firmware and fixups"
-
-	# Add USB2 init service. Otherwise, USB2 and TYPE-C won't work by default
-	cp $SRC/packages/bsp/orangepi5/orangepi5-usb2-init.service $destination/lib/systemd/system/
-
-	return 0
-}
-
-function post_family_tweaks__orangepi5_enable_usb2_service() {
-    display_alert "$BOARD" "Installing board tweaks" "info"
-
-	# enable usb2 init service
-	chroot $SDCARD /bin/bash -c "systemctl --no-reload enable orangepi5-usb2-init.service >/dev/null 2>&1"
-
-	return 0
-}
-
 function post_family_tweaks__orangepi5_naming_audios() {
 	display_alert "$BOARD" "Renaming orangepi5 audios" "info"
 

--- a/packages/bsp/orangepi5/orangepi5-usb2-init.service
+++ b/packages/bsp/orangepi5/orangepi5-usb2-init.service
@@ -1,9 +1,0 @@
-[Unit]
-Description=Init USB2 for Orange Pi 5
-
-[Service]
-ExecStart=/usr/bin/sh -c "echo host > /sys/kernel/debug/usb/fc000000.usb/mode"
-Type=oneshot
-
-[Install]
-WantedBy=default.target


### PR DESCRIPTION
# Description
It depends on https://github.com/armbian/linux-rockchip/pull/76

https://github.com/armbian/build/pull/5519#pullrequestreview-1549880906

Jira reference number [AR-9999]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
