### PR TITLE
help message conventions.

### DIFF
--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -289,26 +289,30 @@ ParseOptions() {
 } # ParseOptions
 
 DisplayUsage() {
-	echo -e "Usage: ${BOLD}${0##*/} [-h] [-b] [-c \$path] [-d \$device] [-D] [-m] [-p] [-r] [-u]${NC}\n"
-	echo -e "############################################################################"
-	if [ ${FullUsage} ]; then
-		echo -e "\nDetailed Description:"
-		grep "^#" "$0" | grep -v "^#\!/bin/bash" | sed 's/^#//'
-	fi
-	echo -e "\n Use ${BOLD}armbianmonitor${NC} for the following tasks:\n"
-	echo -e " armbianmonitor ${BOLD}-c /path/to/test${NC} performs disk health/performance tests"
-	echo -e " armbianmonitor ${BOLD}-d${NC} monitors writes to \$device"
-	echo -e " armbianmonitor ${BOLD}-D${NC} tries to upload debug disk info to improve armbianmonitor"
-	echo -e " armbianmonitor ${BOLD}-m${NC} provides simple CLI monitoring - scrolling output"
-	echo -e " armbianmonitor ${BOLD}-M${NC} provides simple CLI monitoring - fixed-line output"
-	echo -e " armbianmonitor ${BOLD}-n${NC} provides simple CLI network monitoring - scrolling output"
-	echo -e " armbianmonitor ${BOLD}-N${NC} provides simple CLI network monitoring - fixed-line output"
-	echo -e " armbianmonitor ${BOLD}-p${NC} tries to install cpuminer for performance measurements"
-	echo -e " armbianmonitor ${BOLD}-r${NC} tries to install RPi-Monitor"
-	echo -e " armbianmonitor ${BOLD}-u${NC} tries to upload armbian-hardware-monitor.log for support purposes"
-	echo -e " armbianmonitor ${BOLD}-v${NC} tries to verify installed package integrity"
-	echo -e " armbianmonitor ${BOLD}-z${NC} runs a quick 7-zip benchmark to estimate CPU performance\n"
-	echo -e "############################################################################\n"
+
+# Kept for referance.
+#	if [ ${FullUsage} ]; then
+#		echo -e "\nDetailed Description:"
+#		grep "^#" "$0" | grep -v "^#\!/bin/bash" | sed 's/^#//'
+#	fi
+    echo 
+    echo "Usage: $(basename $0) [-h] [-b] [-c \$path] [-d \$device] [-D] [-m] [-p] [-r] [-u]"
+    echo
+    echo "Options:"
+    echo "  -c /path/to/test   Performs disk health/performance tests"
+    echo "  -d                 Monitors writes to \$device"
+    echo "  -D                 Tries to upload debug disk info to improve armbianmonitor"
+    echo "  -m                 Provides simple CLI monitoring - scrolling output"
+    echo "  -M                 Provides simple CLI monitoring - fixed-line output"
+    echo "  -n                 Provides simple CLI network monitoring - scrolling output"
+    echo "  -N                 Provides simple CLI network monitoring - fixed-line output"
+    echo "  -p                 Tries to install cpuminer for performance measurements"
+    echo "  -r                 Tries to install RPi-Monitor"
+    echo "  -u                 Tries to upload armbian-hardware-monitor.log for support purposes"
+    echo "  -v                 Tries to verify installed package integrity"
+    echo "  -z                 Runs a quick 7-zip benchmark to estimate CPU performance"
+    echo 
+    
 } # DisplayUsage
 
 MonitorMode() {


### PR DESCRIPTION
# Description
#### Previous help message
```bash
armbianmonitor -h
Usage: armbianmonitor [-h] [-b] [-c $path] [-d $device] [-D] [-m] [-p] [-r] [-u]

############################################################################

 Use armbianmonitor for the following tasks:

 armbianmonitor -c /path/to/test performs disk health/performance tests
 armbianmonitor -d monitors writes to $device
 armbianmonitor -D tries to upload debug disk info to improve armbianmonitor
 armbianmonitor -m provides simple CLI monitoring - scrolling output
 armbianmonitor -M provides simple CLI monitoring - fixed-line output
 armbianmonitor -n provides simple CLI network monitoring - scrolling output
 armbianmonitor -N provides simple CLI network monitoring - fixed-line output
 armbianmonitor -p tries to install cpuminer for performance measurements
 armbianmonitor -r tries to install RPi-Monitor
 armbianmonitor -u tries to upload armbian-hardware-monitor.log for support purposes
 armbianmonitor -v tries to verify installed package integrity
 armbianmonitor -z runs a quick 7-zip benchmark to estimate CPU performance

############################################################################
```
#### proposed change, attemts to follow the conventions commonly used for displaying a help message.  
```bash 
armbianmonitor.sh" -h

Usage: armbianmonitor.sh [-h] [-b] [-c $path] [-d $device] [-D] [-m] [-p] [-r] [-u]

Options:
  -c /path/to/test   Performs disk health/performance tests
  -d                 Monitors writes to $device
  -D                 Tries to upload debug disk info to improve armbianmonitor
  -m                 Provides simple CLI monitoring - scrolling output
  -M                 Provides simple CLI monitoring - fixed-line output
  -n                 Provides simple CLI network monitoring - scrolling output
  -N                 Provides simple CLI network monitoring - fixed-line output
  -p                 Tries to install cpuminer for performance measurements
  -r                 Tries to install RPi-Monitor
  -u                 Tries to upload armbian-hardware-monitor.log for support purposes
  -v                 Tries to verify installed package integrity
  -z                 Runs a quick 7-zip benchmark to estimate CPU performance
```
no expected chaneg in behavero other then help output 
funtions -z was tested

# Checklist:

- [ ??] My code follows the style guidelines of this project
- [ Y] I have performed a self-review of my own code
- [ Y] I have commented my code, particularly in hard-to-understand areas
- [ NA] I have made corresponding changes to the documentation
- [ No] My changes generate no new warnings
- [ NA] Any dependent changes have been merged and published in downstream modules
