### PR TITLE
`Automatic` board configs status synchronise

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,6 +27,7 @@ config/boards/bigtreetech-cb1.conf		@bigtreetech
 config/boards/clearfogpro.conf		@Heisath
 config/boards/espressobin.conf		@ManoftheSea
 config/boards/firefly-rk3399.conf		@150balbes
+config/boards/fxblox-rk1.wip		@mahdichi
 config/boards/helios4.conf		@Heisath
 config/boards/indiedroid-nova.csc		@lanefu
 config/boards/jethubj100.conf		@adeepn
@@ -109,7 +110,7 @@ config/kernel/linux-mvebu-*.config		@Heisath
 config/kernel/linux-mvebu64-*.config		@ManoftheSea
 config/kernel/linux-odroidxu4-*.config		@joekhoobyar
 config/kernel/linux-rk3568-odroid-*.config		@rpardini
-config/kernel/linux-rk35xx-*.config		@Tonymac32 @ZazaBR @amazingfate @catalinii @efectn @igorpecovnik @krachlatte @lanefu @linhz0hz @monkaBlyat @rpardini @vamzii
+config/kernel/linux-rk35xx-*.config		@Tonymac32 @ZazaBR @amazingfate @catalinii @efectn @igorpecovnik @krachlatte @lanefu @linhz0hz @mahdichi @monkaBlyat @rpardini @vamzii
 config/kernel/linux-rockchip-*.config		@paolosabatino
 config/kernel/linux-rockchip-rk3588-*.config		@Tonymac32 @amazingfate @efectn @lanefu @linhz0hz
 config/kernel/linux-rockchip64-*.config		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @schwar3kat @vamzii
@@ -127,7 +128,7 @@ patch/kernel/archive/meson64-*/		@NicoD-SBC @SteeManMI @Tonymac32 @adeepn @bretm
 patch/kernel/archive/mvebu-*/		@Heisath
 patch/kernel/archive/odroidxu4-*/		@joekhoobyar
 patch/kernel/archive/rk3568-odroid-*/		@rpardini
-patch/kernel/archive/rk35xx-*/		@Tonymac32 @ZazaBR @amazingfate @catalinii @efectn @igorpecovnik @krachlatte @lanefu @linhz0hz @monkaBlyat @rpardini @vamzii
+patch/kernel/archive/rk35xx-*/		@Tonymac32 @ZazaBR @amazingfate @catalinii @efectn @igorpecovnik @krachlatte @lanefu @linhz0hz @mahdichi @monkaBlyat @rpardini @vamzii
 patch/kernel/archive/rockchip-*/		@paolosabatino
 patch/kernel/archive/rockchip64-*/		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @schwar3kat @vamzii
 patch/kernel/archive/rockpis-*/		@brentr
@@ -144,7 +145,7 @@ patch/kernel/meson64-*/		@NicoD-SBC @SteeManMI @Tonymac32 @adeepn @bretmlw @clee
 patch/kernel/mvebu-*/		@Heisath
 patch/kernel/mvebu64-*/		@ManoftheSea
 patch/kernel/odroidxu4-*/		@joekhoobyar
-patch/kernel/rk35xx-*/		@Tonymac32 @ZazaBR @amazingfate @catalinii @efectn @igorpecovnik @krachlatte @lanefu @linhz0hz @monkaBlyat @rpardini @vamzii
+patch/kernel/rk35xx-*/		@Tonymac32 @ZazaBR @amazingfate @catalinii @efectn @igorpecovnik @krachlatte @lanefu @linhz0hz @mahdichi @monkaBlyat @rpardini @vamzii
 patch/kernel/rockchip-*/		@paolosabatino
 patch/kernel/rockchip-rk3588-*/		@Tonymac32 @amazingfate @efectn @lanefu @linhz0hz
 patch/kernel/rockchip64-*/		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @schwar3kat @vamzii
@@ -163,7 +164,7 @@ sources/families/mvebu.conf		@Heisath
 sources/families/mvebu64.conf		@ManoftheSea
 sources/families/odroidxu4.conf		@joekhoobyar
 sources/families/rk3568-odroid.conf		@rpardini
-sources/families/rk35xx.conf		@Tonymac32 @ZazaBR @amazingfate @catalinii @efectn @igorpecovnik @krachlatte @lanefu @linhz0hz @monkaBlyat @rpardini @vamzii
+sources/families/rk35xx.conf		@Tonymac32 @ZazaBR @amazingfate @catalinii @efectn @igorpecovnik @krachlatte @lanefu @linhz0hz @mahdichi @monkaBlyat @rpardini @vamzii
 sources/families/rockchip-rk3588.conf		@Tonymac32 @amazingfate @efectn @lanefu @linhz0hz
 sources/families/rockchip.conf		@paolosabatino
 sources/families/rockchip64.conf		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @schwar3kat @vamzii

--- a/config/boards/fxblox-rk1.wip
+++ b/config/boards/fxblox-rk1.wip
@@ -1,7 +1,7 @@
 # Rockchip RK3588 SoC octa core 8-32GB SoC eMMC USB-C DP NvME SATA M2
 BOARD_NAME="FxBlox RK1"
 BOARDFAMILY="rockchip-rk3588"
-BOARD_MAINTAINER="mahdi"
+BOARD_MAINTAINER="mahdichi"
 BOOTCONFIG="fxblox-rk1-rk3588_defconfig"
 BOOT_SOC="rk3588"
 KERNEL_TARGET="legacy"


### PR DESCRIPTION
Update maintainers and board status

- synced status from the database
- rename to .`csc` where we don't have anyone

If you want to become a board maintainer, [adjust data here](https://www.armbian.com/update-data/).

Ref: [Board Maintainers Procedures and Guidelines](https://docs.armbian.com/Board_Maintainers_Procedures_and_Guidelines/)