### PR TITLE
config: rockchip64_common: fix wrong M0 toolchain prefix

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -159,8 +159,8 @@ prepare_boot_configuration() {
 		ATFDIR='arm-trusted-firmware'
 		ATFBRANCH='tag:v2.6'
 		ATF_USE_GCC='> 6.3'
-		ATF_TARGET_MAP="M0_CROSS_COMPILE=arm-linux-gnueabi- PLAT=$BOOT_SOC bl31;;build/$BOOT_SOC/release/bl31/bl31.elf:bl31.elf"
-		ATF_TOOLCHAIN2="arm-linux-gnueabi-:< 10.0"
+		ATF_TARGET_MAP="M0_CROSS_COMPILE=arm-none-eabi- PLAT=$BOOT_SOC bl31;;build/$BOOT_SOC/release/bl31/bl31.elf:bl31.elf"
+		ATF_TOOLCHAIN2="arm-none-eabi-:< 10.0"
 
 		[[ $BOOT_SCENARIO == "tpl-blob-atf-mainline" ]] && UBOOT_TARGET_MAP="BL31=bl31.elf idbloader.img u-boot.itb;;idbloader.img u-boot.itb"
 


### PR DESCRIPTION
rockchip ATF M0 code should use "arm-none-eabi-" toolchain to compile. "arm-linux-gnueabi-" toolchain causes LD error.

# Description

When building rk3399 ATF, following error pops up when linking M0 codes.
`error: PHDR segment not covered by LOAD segment`

# How Has This Been Tested?

After this change,  rk3399 ATF build passes.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
