### PR TITLE
bugfix: dts: rk3328 and rk3399 oc overlays

### DIFF
--- a/patch/kernel/archive/rockchip64-6.1/overlays-00-add-oc-opp-rk3399.patch
+++ b/patch/kernel/archive/rockchip64-6.1/overlays-00-add-oc-opp-rk3399.patch
@@ -50,7 +50,7 @@ index 000000000..1d7584b60
 +/ {
 +    compatible = "rockchip,rk3399";
 +    fragment@0 {
-+        target-path = "/opp-table0";
++        target-path = "/opp-table-0";
 +        __overlay__ {
 +		opp06 {
 +			opp-hz = /bits/ 64 <1512000000>;
@@ -60,7 +60,7 @@ index 000000000..1d7584b60
 +    };
 +
 +    fragment@1 {
-+        target-path = "/opp-table1";
++        target-path = "/opp-table-1";
 +        __overlay__ {
 +		opp08 {
 +			opp-hz = /bits/ 64 <2016000000>;

--- a/patch/kernel/archive/rockchip64-6.1/overlays-01-add-oc-opp-rk3328.patch
+++ b/patch/kernel/archive/rockchip64-6.1/overlays-01-add-oc-opp-rk3328.patch
@@ -58,7 +58,7 @@ index 000000000..a7ad9d572
 +/ {
 +    compatible = "rockchip,rk3328";
 +    fragment@0 {
-+        target-path = "/opp_table0";
++        target-path = "/opp-table-0";
 +        __overlay__ {
 +		opp-1392000000 {
 +			opp-hz = /bits/ 64 <1392000000>;
@@ -79,7 +79,7 @@ index 000000000..3dfd008ab
 +/ {
 +    compatible = "rockchip,rk3328";
 +    fragment@0 {
-+        target-path = "/opp_table0";
++        target-path = "/opp-table-0";
 +        __overlay__ {
 +		opp-1512000000 {
 +			opp-hz = /bits/ 64 <1512000000>;

--- a/patch/kernel/archive/rockchip64-6.3/overlay/rockchip-rk3328-opp-1.4ghz.dts
+++ b/patch/kernel/archive/rockchip64-6.3/overlay/rockchip-rk3328-opp-1.4ghz.dts
@@ -3,7 +3,7 @@
 / {
     compatible = "rockchip,rk3328";
     fragment@0 {
-        target-path = "/opp_table0";
+        target-path = "/opp-table-0";
         __overlay__ {
 		opp-1392000000 {
 			opp-hz = /bits/ 64 <1392000000>;

--- a/patch/kernel/archive/rockchip64-6.3/overlay/rockchip-rk3328-opp-1.5ghz.dts
+++ b/patch/kernel/archive/rockchip64-6.3/overlay/rockchip-rk3328-opp-1.5ghz.dts
@@ -3,7 +3,7 @@
 / {
     compatible = "rockchip,rk3328";
     fragment@0 {
-        target-path = "/opp_table0";
+        target-path = "/opp-table-0";
         __overlay__ {
 		opp-1512000000 {
 			opp-hz = /bits/ 64 <1512000000>;

--- a/patch/kernel/archive/rockchip64-6.3/overlay/rockchip-rk3399-opp-2ghz.dts
+++ b/patch/kernel/archive/rockchip64-6.3/overlay/rockchip-rk3399-opp-2ghz.dts
@@ -3,7 +3,7 @@
 / {
     compatible = "rockchip,rk3399";
     fragment@0 {
-        target-path = "/opp-table0";
+        target-path = "/opp-table-0";
         __overlay__ {
 		opp06 {
 			opp-hz = /bits/ 64 <1512000000>;
@@ -13,7 +13,7 @@
     };
 
     fragment@1 {
-        target-path = "/opp-table1";
+        target-path = "/opp-table-1";
         __overlay__ {
 		opp08 {
 			opp-hz = /bits/ 64 <2016000000>;


### PR DESCRIPTION
# Description

Mainline updated the opp table handles to match the schema, this broke the overlays. 

https://github.com/torvalds/linux/commit/a30f3d90e2d2f4d0452c0f6f77693d0e9bba3b1e

Overlays updated with corrected handle names.

reported-by: @neofeo


# How Has This Been Tested?

rk3399 successful application of overlays

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
