### PR TITLE
meson64: fix usb on odroid c2

### DIFF
--- a/patch/kernel/archive/meson64-6.1/board-odroidc2-usb-hub-disable-autosuspend-for-Genesys-Logic-.patch
+++ b/patch/kernel/archive/meson64-6.1/board-odroidc2-usb-hub-disable-autosuspend-for-Genesys-Logic-.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Christian Hewitt <christianshewitt@gmail.com>
+Date: Mon, 3 Jan 2022 10:44:17 +0000
+Subject: LOCAL: usb: hub: disable autosuspend for Genesys Logic Hubs
+
+Disable autosuspend in Genesys Logic hubs to allow USB devices on the
+Odroid C2 board to be used. The alternative to this patch is setting
+usbcore.autosuspend=-1 in boot params.
+
+This patch only impacts GXBB devices as GXL/GXM onwards use the newer
+dwc3 core which does not have the problem.
+
+Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
+---
+ drivers/usb/core/hub.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/usb/core/hub.c b/drivers/usb/core/hub.c
+index 97a0f8faea6e..5991cf2a63a3 100644
+--- a/drivers/usb/core/hub.c
++++ b/drivers/usb/core/hub.c
+@@ -5855,7 +5855,7 @@ static const struct usb_device_id hub_id_table[] = {
+ 			| USB_DEVICE_ID_MATCH_INT_CLASS,
+       .idVendor = USB_VENDOR_GENESYS_LOGIC,
+       .bInterfaceClass = USB_CLASS_HUB,
+-      .driver_info = HUB_QUIRK_CHECK_PORT_AUTOSUSPEND},
++      .driver_info = HUB_QUIRK_DISABLE_AUTOSUSPEND},
+     { .match_flags = USB_DEVICE_ID_MATCH_VENDOR
+ 			| USB_DEVICE_ID_MATCH_PRODUCT,
+       .idVendor = USB_VENDOR_TEXAS_INSTRUMENTS,
+-- 
+Armbian
+


### PR DESCRIPTION
# Description

Thanks to NicoD giving me a kick, identified/implemented fix present in 6.2+ builds to keep the hub from going to suspend.

# How Has This Been Tested?

Boot and USB OK

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
