### PR TITLE
Revert "config: rockchip64_common: fix wrong M0 toolchain prefix"

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -159,8 +159,8 @@ prepare_boot_configuration() {
 		ATFDIR='arm-trusted-firmware'
 		ATFBRANCH='tag:v2.6'
 		ATF_USE_GCC='> 6.3'
-		ATF_TARGET_MAP="M0_CROSS_COMPILE=arm-none-eabi- PLAT=$BOOT_SOC bl31;;build/$BOOT_SOC/release/bl31/bl31.elf:bl31.elf"
-		ATF_TOOLCHAIN2="arm-none-eabi-:< 10.0"
+		ATF_TARGET_MAP="M0_CROSS_COMPILE=arm-linux-gnueabi- PLAT=$BOOT_SOC bl31;;build/$BOOT_SOC/release/bl31/bl31.elf:bl31.elf"
+		ATF_TOOLCHAIN2="arm-linux-gnueabi-:< 10.0"
 
 		[[ $BOOT_SCENARIO == "tpl-blob-atf-mainline" ]] && UBOOT_TARGET_MAP="BL31=bl31.elf idbloader.img u-boot.itb;;idbloader.img u-boot.itb"
 


### PR DESCRIPTION
# Description

This reverts commit 78aa57982efe523da9b52c15b2f3a423f8246390 as it breaks somewhere.