### PR TITLE
`Automatic` board configs status synchronise

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -87,6 +87,7 @@ config/boards/rockpi-e.conf		@krachlatte
 config/boards/rockpi-s.conf		@brentr
 config/boards/rockpro64.conf		@joekhoobyar
 config/boards/rpi4b.conf		@PanderMusubi @teknoid
+config/boards/sk-am62b.conf		@glneo
 config/boards/sk-am64b.conf		@glneo
 config/boards/station-m1.conf		@150balbes
 config/boards/station-m2.conf		@150balbes


### PR DESCRIPTION
Update maintainers and board status

- synced status from the database
- rename to .`csc` where we don't have anyone

If you want to become a board maintainer, [adjust data here](https://www.armbian.com/update-data/).

Ref: [Board Maintainers Procedures and Guidelines](https://docs.armbian.com/Board_Maintainers_Procedures_and_Guidelines/)