### PR TITLE
arm64: dts: amlogic: meson-sm1-bananapi-m2-pro: `add uart_A`

### DIFF
--- a/patch/kernel/archive/meson64-6.1/board-bananapism1-add-uart_AO_B-and-uart_B.patch
+++ b/patch/kernel/archive/meson64-6.1/board-bananapism1-add-uart_AO_B-and-uart_B.patch
@@ -64,3 +64,41 @@ index ea4784a190da..7072d0e7bd4a 100644
 -- 
 2.39.2
 
+From ce5cc12ce8e33f9089c2c9b6ab6deb7cf2759cb2 Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@xxxxx.com>
+Date: Fri, 4 Aug 2023 05:36:52 -0400
+Subject: [PATCH] arm64: dts: amlogic: meson-sm1-bananapi-m2-pro: add uart_A
+
+Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
+---
+ .../boot/dts/amlogic/meson-sm1-bananapi-m2-pro.dts     | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-sm1-bananapi-m2-pro.dts b/arch/arm64/boot/dts/amlogic/meson-sm1-bananapi-m2-pro.dts
+index 586034316ec3..5ccdc91ac276 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-sm1-bananapi-m2-pro.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-sm1-bananapi-m2-pro.dts
+@@ -13,6 +13,10 @@ / {
+ 	compatible = "bananapi,bpi-m2-pro", "amlogic,sm1";
+ 	model = "Banana Pi BPI-M2-PRO";
+ 
++	aliases {
++		serial1 = &uart_A;
++	};
++
+ 	sound {
+ 		compatible = "amlogic,axg-sound-card";
+ 		model = "BPI-M2-PRO";
+@@ -95,3 +99,9 @@ &tdmout_b {
+ &tohdmitx {
+ 	status = "okay";
+ };
++
++&uart_A {
++	status = "disabled";
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart_a_pins>;
++};
+-- 
+2.39.2
+

--- a/patch/kernel/archive/meson64-6.1/general-xtra-meson64-overlays.patch
+++ b/patch/kernel/archive/meson64-6.1/general-xtra-meson64-overlays.patch
@@ -150,7 +150,7 @@ index 000000000000..ea2f401786e6
 +/plugin/;
 +
 +/ {
-+	compatible = "bananapi,bpi-m5", "amlogic,sm1";
++	compatible = "bananapi,bpi-m5", "bananapi,bpi-m2-pro", "amlogic,sm1";
 +
 +	fragment@0 {
 +		target = <&uart_A>;

--- a/patch/kernel/archive/meson64-6.4/board-bananapism1-add-uart_AO_B-and-uart_B.patch
+++ b/patch/kernel/archive/meson64-6.4/board-bananapism1-add-uart_AO_B-and-uart_B.patch
@@ -64,3 +64,41 @@ index 7e80151874f1..e42c35868fc7 100644
 -- 
 2.39.2
 
+From 5011768f6f31aa33ce3fcd65d14778fc17fe256c Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@xxxxx.com>
+Date: Fri, 4 Aug 2023 05:42:36 -0400
+Subject: [PATCH] arm64: dts: amlogic: meson-sm1-bananapi-m2-pro: add uart_A
+
+Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
+---
+ .../boot/dts/amlogic/meson-sm1-bananapi-m2-pro.dts     | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-sm1-bananapi-m2-pro.dts b/arch/arm64/boot/dts/amlogic/meson-sm1-bananapi-m2-pro.dts
+index 586034316ec3..5ccdc91ac276 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-sm1-bananapi-m2-pro.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-sm1-bananapi-m2-pro.dts
+@@ -13,6 +13,10 @@ / {
+ 	compatible = "bananapi,bpi-m2-pro", "amlogic,sm1";
+ 	model = "Banana Pi BPI-M2-PRO";
+ 
++	aliases {
++		serial1 = &uart_A;
++	};
++
+ 	sound {
+ 		compatible = "amlogic,axg-sound-card";
+ 		model = "BPI-M2-PRO";
+@@ -95,3 +99,9 @@ &tdmout_b {
+ &tohdmitx {
+ 	status = "okay";
+ };
++
++&uart_A {
++	status = "disabled";
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart_a_pins>;
++};
+-- 
+2.39.2
+

--- a/patch/kernel/archive/meson64-6.4/overlay/meson-sm1-bananapi-uartA.dts
+++ b/patch/kernel/archive/meson64-6.4/overlay/meson-sm1-bananapi-uartA.dts
@@ -2,7 +2,7 @@
 /plugin/;
 
 / {
-	compatible = "bananapi,bpi-m5", "amlogic,sm1";
+	compatible = "bananapi,bpi-m5", "bananapi,bpi-m2-pro", "amlogic,sm1";
 
 	fragment@0 {
 		target = <&uart_A>;


### PR DESCRIPTION
Add `uart_A` to the  meson-sm1-bananapi-m2-pro DTS.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
