### PR TITLE
rk3399: adjust opi4lts thermal trip points

### DIFF
--- a/patch/kernel/archive/rockchip64-6.1/add-board-orangepi-4-lts.patch
+++ b/patch/kernel/archive/rockchip64-6.1/add-board-orangepi-4-lts.patch
@@ -10,10 +10,10 @@ Subject: [PATCH] rk3399: add Orange Pi 4 LTS device tree
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4-lts.dts b/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4-lts.dts
 new file mode 100644
-index 000000000000..0a4abf995e4b
+index 000000000000..6d6bee12a453
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-orangepi-4-lts.dts
-@@ -0,0 +1,1244 @@
+@@ -0,0 +1,1304 @@
 +/*
 + * SPDX-License-Identifier: (GPL-2.0+ or MIT)
 + * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd.
@@ -1235,6 +1235,8 @@ index 000000000000..0a4abf995e4b
 +};
 +
 +&dmc {
++	#cooling-cells = <2>; /* min followed by max */
++
 +	status = "okay";
 +	center-supply = <&vdd_log>;
 +	operating-points-v2 = <&dmc_opp_table>;
@@ -1258,6 +1260,63 @@ index 000000000000..0a4abf995e4b
 +&dfi {
 +	status = "okay";
 +};
++
++/*
++ * Redefine some parameters for the thermal trip points for Opi4 LTS.
++ * First of all, the Soc does not like getting over 90°C. My sample
++ * froze at 94.4°C, so we lower the critical temprature to 90°C, hopefully
++ * giving enough room for safe reboot of the device.
++ * Big cores are getting throttled a bit when reaching 82°C, then at 85°C
++ * we aggressively throttle all the cores and even the memory controller.
++ * The GPU is handled by existing trip points in the base device tree, here
++ * we just set the same critical temperature as CPU.
++ */
++&cpu_alert0 {
++	temperature = <82000>;
++};
++
++&cpu_alert1 {
++	temperature = <85000>;
++};
++
++&cpu_crit {
++	temperatue = <90000>;
++};
++
++&gpu_crit {
++	temperatue = <90000>;
++};
++
++&cpu_thermal {
++
++	cooling-maps {
++
++		map0 {
++			trip = <&cpu_alert0>;
++			cooling-device =
++				<&cpu_b0 THERMAL_NO_LIMIT 3>,
++				<&cpu_b1 THERMAL_NO_LIMIT 3>;
++		};
++
++		map1 {
++			trip = <&cpu_alert1>;
++			cooling-device =
++				<&cpu_l0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++				<&cpu_l1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++				<&cpu_l2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++				<&cpu_l3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++				<&cpu_b0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++				<&cpu_b1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++		};
++
++		map2 {
++			trip = <&cpu_alert1>;
++			cooling-device =
++				<&dmc THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++		};
++
++	};
++
++};
 -- 
 2.34.1
-

--- a/patch/kernel/archive/rockchip64-6.4/dt/rk3399-orangepi-4-lts.dts
+++ b/patch/kernel/archive/rockchip64-6.4/dt/rk3399-orangepi-4-lts.dts
@@ -1249,6 +1249,8 @@
 };
 
 &dmc {
+	#cooling-cells = <2>; /* min followed by max */
+
 	status = "okay";
 	center-supply = <&vdd_log>;
 	operating-points-v2 = <&dmc_opp_table>;
@@ -1271,4 +1273,62 @@
 
 &dfi {
 	status = "okay";
+};
+
+/*
+ * Redefine some parameters for the thermal trip points for Opi4 LTS.
+ * First of all, the Soc does not like getting over 90°C. My sample
+ * froze at 94.4°C, so we lower the critical temprature to 90°C, hopefully
+ * giving enough room for safe reboot of the device.
+ * Big cores are getting throttled a bit when reaching 82°C, then at 85°C
+ * we aggressively throttle all the cores and even the memory controller.
+ * The GPU is handled by existing trip points in the base device tree, here
+ * we just set the same critical temperature as CPU.
+ */
+&cpu_alert0 {
+	temperature = <82000>;
+};
+
+&cpu_alert1 {
+	temperature = <85000>;
+};
+
+&cpu_crit {
+	temperatue = <90000>;
+};
+
+&gpu_crit {
+	temperatue = <90000>;
+};
+
+&cpu_thermal {
+
+	cooling-maps {
+
+		map0 {
+			trip = <&cpu_alert0>;
+			cooling-device =
+				<&cpu_b0 THERMAL_NO_LIMIT 3>,
+				<&cpu_b1 THERMAL_NO_LIMIT 3>;
+		};
+
+		map1 {
+			trip = <&cpu_alert1>;
+			cooling-device =
+				<&cpu_l0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+				<&cpu_l1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+				<&cpu_l2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+				<&cpu_l3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+				<&cpu_b0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+				<&cpu_b1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+		};
+
+		map2 {
+			trip = <&cpu_alert1>;
+			cooling-device =
+				<&dmc THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+		};
+
+	};
+
 };


### PR DESCRIPTION
# Description

One user on the forum (see https://forum.armbian.com/topic/27798-orange-pi-4-lts-default-thermal-trip-point-issues/) found issues with Orange PI 4 LTS thermal trip points. 

Looking into the problem, it is related to a [patch](https://github.com/armbian/build/blob/main/patch/kernel/archive/rockchip64-6.4/rk3399-unlock-temperature.patch) introduced long time ago that changed the thermal trip points away from the vendor (and mainline kernel too) supplied ones.

After some stress testing with **openssl** and **mbw** combined, my board froze and I had to shutdown it manually, let it cool and restart to have again a working system. It happens that, at least on my and forum user cases, the trip points are not doing what they expect to do.

This patch corrects the trip points for Opi4 LTS: after repeating the same stress test, the kernel is capable of keeping the temperature under control without freezes

Jira reference number [AR-1812]

# How Has This Been Tested?

- [x] Tested device tree with trip points on live system
- [x] Patch applies correctly for rockchip64 current 6.1 kernel and does not break compilation
- [x] current kernel deb packages installed on live system with success

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1812]: https://armbian.atlassian.net/browse/AR-1812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ