### PR TITLE
kernel image files use standard flavor

### DIFF
--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -50,7 +50,7 @@ function prepare_kernel_packaging_debs() {
 	declare debs_target_dir="${kernel_work_dir}/.."
 
 	# Some variables and settings used throughout the script
-	declare kernel_version_family="${kernel_version}-${LINUXFAMILY}"
+	declare kernel_version_family="${kernel_version}-${BRANCH}-${LINUXFAMILY}"
 
 	# Package version. Affects users upgrading from repo!
 	display_alert "Kernel .deb package version" "${artifact_version}" "info"

--- a/lib/functions/compilation/kernel-make.sh
+++ b/lib/functions/compilation/kernel-make.sh
@@ -40,7 +40,7 @@ function run_kernel_make_internal() {
 		"${DISTCC_MAKE_J_PARALLEL[@]}" # Parallel compile, "-j X" for X cpus; determined by distcc, or is just "$CTHREADS" if distcc is not enabled.
 
 		"ARCH=${ARCHITECTURE}"         # Key param. Everything depends on this.
-		"LOCALVERSION=-${LINUXFAMILY}" # Change the internal kernel version to include the family. Changing this causes recompiles # @TODO change hack at .config; that might handles mtime better
+		"LOCALVERSION=-${BRANCH}-${LINUXFAMILY}" # Change the internal kernel version to include the family. Changing this causes recompiles # @TODO change hack at .config; that might handles mtime better
 
 		"CROSS_COMPILE=${CCACHE} ${DISTCC_CROSS_COMPILE_PREFIX[@]} ${KERNEL_COMPILER}"                    # added as prefix to every compiler invocation by make
 		"KCFLAGS=-fdiagnostics-color=always -Wno-error=misleading-indentation ${KERNEL_EXTRA_CFLAGS:-""}" # Force GCC colored messages, downgrade misleading indentation to warning


### PR DESCRIPTION
# Description

We package kernel debs with package name like `linux-image-legacy-rk35xx`. In general people treat `legacy-rk35xx` as the `flavor`. Debian's live-build will use it to generate grub config: https://salsa.debian.org/live-team/live-build/-/blob/master/scripts/build/binary_grub_cfg#L117. And ubiquity which is ubuntu's desktop installer also looks for it. So it's better to change our kernel filename to standard like `vmlinuz-*${flavor}`.

Jira reference number [AR-9999]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Build success for rk35xx legacy kernel
- [x] Kenel boots on rock5b

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
