### PR TITLE
`Automatic` board configs status synchronise

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,17 +35,19 @@ config/boards/jethubj80.conf		@adeepn
 config/boards/jetson-nano.conf		@150balbes
 config/boards/khadas-edge2.conf		@igorpecovnik
 config/boards/khadas-vim1.conf		@igorpecovnik
+config/boards/khadas-vim1s.wip		@rpardini @viraniac
 config/boards/khadas-vim2.conf		@igorpecovnik
 config/boards/khadas-vim3.conf		@NicoD-SBC @rpardini
 config/boards/khadas-vim3l.conf		@rpardini
+config/boards/khadas-vim4.wip		@rpardini
 config/boards/lafrite.conf		@Tonymac32
 config/boards/lepotato.conf		@Tonymac32
+config/boards/licheepi-4a.wip		@chainsx
 config/boards/mangopi-mq.wip		@Zinput
 config/boards/mekotronics-r58-minipc.wip		@monkaBlyat
 config/boards/mekotronics-r58x-4g.wip		@monkaBlyat
 config/boards/mekotronics-r58x.wip		@monkaBlyat
 config/boards/mixtile-blade3.wip		@rpardini
-config/boards/nanopct4.conf		@150balbes
 config/boards/nanopct6.wip		@Tonymac32
 config/boards/nanopi-r4s.conf		@Manouchehri
 config/boards/nanopi-r6s.conf		@efectn
@@ -106,6 +108,7 @@ config/kernel/linux-d1-*.config		@Zinput
 config/kernel/linux-k3-*.config		@glneo
 config/kernel/linux-media-*.config		@150balbes
 config/kernel/linux-meson-*.config		@hzyitc
+config/kernel/linux-meson-s4t7-*.config		@rpardini @viraniac
 config/kernel/linux-meson64-*.config		@NicoD-SBC @SteeManMI @Tonymac32 @adeepn @bretmlw @clee @engineer-80 @igorpecovnik @jeanrhum @monkaBlyat @pyavitz @rpardini @teknoid
 config/kernel/linux-mvebu-*.config		@Heisath
 config/kernel/linux-mvebu64-*.config		@ManoftheSea
@@ -120,11 +123,13 @@ config/kernel/linux-sun50iw9-*.config		@AGM1968 @krachlatte
 config/kernel/linux-sun50iw9-btt-*.config		@bigtreetech
 config/kernel/linux-sunxi-*.config		@AaronNGray @StephenGraf @Tonymac32 @lbmendes @schwar3kat @sgjava @teknoid @viraniac
 config/kernel/linux-sunxi64-*.config		@AGM1968 @Kreyren @PanderMusubi @Tonymac32 @bigtreetech @devdotnetorg @eliasbakken @joshaspinall @krachlatte @schwar3kat @teknoid @viraniac
+config/kernel/linux-thead-*.config		@chainsx
 config/kernel/linux-uefi-arm64-*.config		@rpardini
 config/kernel/linux-uefi-x86-*.config		@rpardini
 patch/kernel/NEED-*/		@bigtreetech
 patch/kernel/archive/bcm2711-*/		@PanderMusubi @teknoid
 patch/kernel/archive/meson-*/		@hzyitc
+patch/kernel/archive/meson-s4t7-*/		@rpardini @viraniac
 patch/kernel/archive/meson64-*/		@NicoD-SBC @SteeManMI @Tonymac32 @adeepn @bretmlw @clee @engineer-80 @igorpecovnik @jeanrhum @monkaBlyat @pyavitz @rpardini @teknoid
 patch/kernel/archive/mvebu-*/		@Heisath
 patch/kernel/archive/odroidxu4-*/		@joekhoobyar
@@ -152,6 +157,7 @@ patch/kernel/rockchip-rk3588-*/		@Tonymac32 @amazingfate @efectn @lanefu @linhz0
 patch/kernel/rockchip64-*/		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @schwar3kat @vamzii
 patch/kernel/rockpis-*/		@brentr
 patch/kernel/sun50iw9-*/		@AGM1968 @krachlatte
+patch/kernel/thead-*/		@chainsx
 patch/kernel/uefi-arm64-*/		@rpardini
 patch/kernel/uefi-x86-*/		@rpardini
 sources/families/arm64.conf		@rpardini
@@ -159,6 +165,7 @@ sources/families/bcm2711.conf		@PanderMusubi @teknoid
 sources/families/d1.conf		@Zinput
 sources/families/k3.conf		@glneo
 sources/families/media.conf		@150balbes
+sources/families/meson-s4t7.conf		@rpardini @viraniac
 sources/families/meson.conf		@hzyitc
 sources/families/meson64.conf		@NicoD-SBC @SteeManMI @Tonymac32 @adeepn @bretmlw @clee @engineer-80 @igorpecovnik @jeanrhum @monkaBlyat @pyavitz @rpardini @teknoid
 sources/families/mvebu.conf		@Heisath
@@ -174,4 +181,5 @@ sources/families/sun50iw9-btt.conf		@bigtreetech
 sources/families/sun50iw9.conf		@AGM1968 @krachlatte
 sources/families/sunxi.conf		@AaronNGray @StephenGraf @Tonymac32 @lbmendes @schwar3kat @sgjava @teknoid @viraniac
 sources/families/sunxi64.conf		@AGM1968 @Kreyren @PanderMusubi @Tonymac32 @bigtreetech @devdotnetorg @eliasbakken @joshaspinall @krachlatte @schwar3kat @teknoid @viraniac
+sources/families/thead.conf		@chainsx
 sources/families/x86.conf		@rpardini

--- a/config/boards/licheepi-4a.wip
+++ b/config/boards/licheepi-4a.wip
@@ -1,7 +1,7 @@
 # RISC-V LicheePi 4A
 BOARD_NAME="LicheePi 4A"
 BOARDFAMILY="thead"
-BOARD_MAINTAINER=""
+BOARD_MAINTAINER="chainsx"
 KERNEL_TARGET="legacy"
 BOOT_FDT_FILE="thead/light-lpi4a.dtb"
 SRC_EXTLINUX="yes"


### PR DESCRIPTION
Update maintainers and board status

- synced status from the database
- rename to .`csc` where we don't have anyone

If you want to become a board maintainer, [adjust data here](https://www.armbian.com/update-data/).

Ref: [Board Maintainers Procedures and Guidelines](https://docs.armbian.com/Board_Maintainers_Procedures_and_Guidelines/)