### PR TITLE
hashed-OCI-revisioned-debs: introduce "reversioning" of .deb packages (fixed+resubmitted for `main`)

### DIFF
--- a/lib/functions/artifacts/artifact-armbian-base-files.sh
+++ b/lib/functions/artifacts/artifact-armbian-base-files.sh
@@ -53,8 +53,8 @@ function artifact_armbian-base-files_prepare_version() {
 	artifact_name="armbian-base-files-${RELEASE}-${ARCH}"
 	declare deb_name="base-files" # the artifact_name is only Armbian's reference; the deb_name is still base_files
 	artifact_type="deb"
-	artifact_base_dir="${DEB_STORAGE}/${RELEASE}"
-	artifact_final_file="${DEB_STORAGE}/${RELEASE}/${deb_name}_${artifact_version}_${ARCH}.deb"
+	artifact_base_dir="${PACKAGES_HASHED_STORAGE}/${RELEASE}"
+	artifact_final_file="${PACKAGES_HASHED_STORAGE}/${RELEASE}/${deb_name}_${artifact_version}_${ARCH}.deb"
 
 	artifact_map_packages=(["armbian-base-files"]="${deb_name}")
 
@@ -181,8 +181,7 @@ function compile_armbian-base-files() {
 	rm -f "${destination}"/etc/os-release.orig "${destination}"/etc/issue.orig "${destination}"/etc/issue.net.orig "${destination}"/DEBIAN/conffiles.orig
 
 	# Done, pack it.
-	mkdir -p "${DEB_STORAGE}/${RELEASE}"
-	fakeroot_dpkg_deb_build "${destination}" "${DEB_STORAGE}/${RELEASE}"
+	fakeroot_dpkg_deb_build "${destination}"
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 }

--- a/lib/functions/artifacts/artifact-armbian-base-files.sh
+++ b/lib/functions/artifacts/artifact-armbian-base-files.sh
@@ -17,7 +17,6 @@ function artifact_armbian-base-files_config_dump() {
 }
 
 function artifact_armbian-base-files_prepare_version() {
-	: "${artifact_prefix_version:?artifact_prefix_version is not set}"
 	: "${RELEASE:?RELEASE is not set}"
 	: "${ARCH:?ARCH is not set}"
 
@@ -25,7 +24,7 @@ function artifact_armbian-base-files_prepare_version() {
 	artifact_version_reason="undetermined" # outer scope
 
 	declare short_hash_size=4
-	declare fake_unchanging_base_version="${RELEASE}-1armbian1"
+	declare fake_unchanging_base_version="1-${RELEASE}-1armbian1"
 
 	declare found_package_version="undetermined" found_package_filename="undetermined" found_package_down_url="undetermined"
 	sleep_seconds="15" do_with_retries 10 apt_find_upstream_package_version_and_download_url "base-files"
@@ -45,7 +44,7 @@ function artifact_armbian-base-files_prepare_version() {
 	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
 
 	# outer scope
-	artifact_version="${artifact_prefix_version}${fake_unchanging_base_version}-B${bash_hash_short}"
+	artifact_version="${fake_unchanging_base_version}-B${bash_hash_short}"
 
 	declare -a reasons=("Armbian armbian-base-files" "original ${RELEASE} version \"${base_files_wanted_upstream_version}\"" "framework bash hash \"${bash_hash}\"")
 

--- a/lib/functions/artifacts/artifact-armbian-bsp-cli.sh
+++ b/lib/functions/artifacts/artifact-armbian-bsp-cli.sh
@@ -14,7 +14,6 @@ function artifact_armbian-bsp-cli_config_dump() {
 }
 
 function artifact_armbian-bsp-cli_prepare_version() {
-	: "${artifact_prefix_version:?artifact_prefix_version is not set}"
 	: "${BRANCH:?BRANCH is not set}"
 	: "${BOARD:?BOARD is not set}"
 
@@ -87,7 +86,7 @@ function artifact_armbian-bsp-cli_prepare_version() {
 	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
 
 	# outer scope
-	artifact_version="${artifact_prefix_version}${fake_unchanging_base_version}-PC${packages_config_hash_short}-V${var_config_hash_short}-H${hash_hooks_short}-B${bash_hash_short}"
+	artifact_version="${fake_unchanging_base_version}-PC${packages_config_hash_short}-V${var_config_hash_short}-H${hash_hooks_short}-B${bash_hash_short}"
 
 	declare -a reasons=(
 		"Armbian package armbian-bsp-cli"
@@ -124,7 +123,7 @@ function artifact_armbian-bsp-cli_prepare_version() {
 }
 
 function artifact_armbian-bsp-cli_build_from_sources() {
-	# Generate transitional package when needed. 
+	# Generate transitional package when needed.
 	if artifact_armbian-bsp-cli_needs_transitional_package ; then
 		LOG_SECTION="compile_armbian-bsp-cli" do_with_logging compile_armbian-bsp-cli-transitional
 	fi

--- a/lib/functions/artifacts/artifact-armbian-bsp-cli.sh
+++ b/lib/functions/artifacts/artifact-armbian-bsp-cli.sh
@@ -103,8 +103,8 @@ function artifact_armbian-bsp-cli_prepare_version() {
 
 	artifact_name="armbian-bsp-cli-${BOARD}-${BRANCH}${EXTRA_BSP_NAME}"
 	artifact_type="deb-tar"
-	artifact_base_dir="${DEB_STORAGE}"
-	artifact_final_file="${DEB_STORAGE}/${artifact_name}_${artifact_version}_${ARCH}.tar"
+	artifact_base_dir="${PACKAGES_HASHED_STORAGE}"
+	artifact_final_file="${PACKAGES_HASHED_STORAGE}/${artifact_name}_${artifact_version}_${ARCH}.tar"
 
 	artifact_map_packages=(
 		["armbian-bsp-cli"]="${artifact_name}"

--- a/lib/functions/artifacts/artifact-armbian-bsp-cli.sh
+++ b/lib/functions/artifacts/artifact-armbian-bsp-cli.sh
@@ -101,22 +101,20 @@ function artifact_armbian-bsp-cli_prepare_version() {
 
 	artifact_version_reason="${reasons[*]}" # outer scope
 
+	artifact_deb_repo="global"  # "global" meaning: release-independent repo. could be '${RELEASE}' for a release-specific package.
+	artifact_deb_arch="${ARCH}" # arch-specific package, or 'all' for arch-independent package.
 	artifact_name="armbian-bsp-cli-${BOARD}-${BRANCH}${EXTRA_BSP_NAME}"
 	artifact_type="deb-tar"
-	artifact_base_dir="${PACKAGES_HASHED_STORAGE}"
-	artifact_final_file="${PACKAGES_HASHED_STORAGE}/${artifact_name}_${artifact_version}_${ARCH}.tar"
 
-	artifact_map_packages=(
-		["armbian-bsp-cli"]="${artifact_name}"
-	)
+	artifact_map_packages=(["armbian-bsp-cli"]="${artifact_name}")
 
-	artifact_map_debs=(
-		["armbian-bsp-cli"]="${artifact_name}_${artifact_version}_${ARCH}.deb"
-	)
+	# Register the function used to re-version the _contents_ of the bsp-cli deb file (non-transitional)
+	artifact_debs_reversion_functions+=("reversion_armbian-bsp-cli_deb_contents")
 
-	if artifact_armbian-bsp-cli_needs_transitional_package ; then
+	if artifact_armbian-bsp-cli_needs_transitional_package; then
 		artifact_map_packages+=(["armbian-bsp-cli-transitional"]="armbian-bsp-cli-${BOARD}${EXTRA_BSP_NAME}")
-		artifact_map_debs+=(["armbian-bsp-cli-transitional"]="armbian-bsp-cli-${BOARD}${EXTRA_BSP_NAME}_${artifact_version}_${ARCH}.deb")
+		# Register the function used to re-version the _contents_ of the bsp-cli deb file (transitional)
+		artifact_debs_reversion_functions+=("reversion_armbian-bsp-cli-transitional_deb_contents")
 	fi
 
 	return 0
@@ -124,7 +122,7 @@ function artifact_armbian-bsp-cli_prepare_version() {
 
 function artifact_armbian-bsp-cli_build_from_sources() {
 	# Generate transitional package when needed.
-	if artifact_armbian-bsp-cli_needs_transitional_package ; then
+	if artifact_armbian-bsp-cli_needs_transitional_package; then
 		LOG_SECTION="compile_armbian-bsp-cli" do_with_logging compile_armbian-bsp-cli-transitional
 	fi
 
@@ -164,11 +162,11 @@ function artifact_armbian-bsp-cli_deploy_to_remote_cache() {
 }
 
 function artifact_armbian-bsp-cli_needs_transitional_package() {
-	if [[ "${KERNEL_TARGET}" == "${BRANCH}" ]] ; then
+	if [[ "${KERNEL_TARGET}" == "${BRANCH}" ]]; then
 		return 0
-	elif [[ "${BRANCH}" == "current" ]] ; then
+	elif [[ "${BRANCH}" == "current" ]]; then
 		return 0
-	elif [[ "${KERNEL_TARGET}" != *current* && "${BRANCH}" == "legacy" ]] ; then
+	elif [[ "${KERNEL_TARGET}" != *current* && "${BRANCH}" == "legacy" ]]; then
 		return 0
 	else
 		return 1

--- a/lib/functions/artifacts/artifact-armbian-bsp-cli.sh
+++ b/lib/functions/artifacts/artifact-armbian-bsp-cli.sh
@@ -64,7 +64,8 @@ function artifact_armbian-bsp-cli_prepare_version() {
 	)
 	declare hash_variables="undetermined" # will be set by calculate_hash_for_variables(), which normalizes the input
 	calculate_hash_for_variables "${vars_to_hash[@]}"
-	declare var_config_hash_short="${hash_variables:0:${short_hash_size}}"
+	declare vars_config_hash="${hash_variables}"
+	declare var_config_hash_short="${vars_config_hash:0:${short_hash_size}}"
 
 	declare -a dirs_to_hash=(
 		"${SRC}/packages/bsp/common" # common stuff

--- a/lib/functions/artifacts/artifact-armbian-bsp-desktop.sh
+++ b/lib/functions/artifacts/artifact-armbian-bsp-desktop.sh
@@ -18,7 +18,6 @@ function artifact_armbian-bsp-desktop_config_dump() {
 }
 
 function artifact_armbian-bsp-desktop_prepare_version() {
-	: "${artifact_prefix_version:?artifact_prefix_version is not set}"
 	: "${BRANCH:?BRANCH is not set}"
 	: "${BOARD:?BOARD is not set}"
 	: "${RELEASE:?RELEASE is not set}"
@@ -43,7 +42,7 @@ function artifact_armbian-bsp-desktop_prepare_version() {
 	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
 
 	# outer scope
-	artifact_version="${artifact_prefix_version}${fake_unchanging_base_version}-B${bash_hash_short}"
+	artifact_version="${fake_unchanging_base_version}-B${bash_hash_short}"
 
 	declare -a reasons=(
 		"Armbian armbian-bsp-desktop"

--- a/lib/functions/artifacts/artifact-armbian-bsp-desktop.sh
+++ b/lib/functions/artifacts/artifact-armbian-bsp-desktop.sh
@@ -53,8 +53,8 @@ function artifact_armbian-bsp-desktop_prepare_version() {
 
 	artifact_name="armbian-bsp-desktop-${BOARD}-${BRANCH}"
 	artifact_type="deb"
-	artifact_base_dir="${DEB_STORAGE}/${RELEASE}"
-	artifact_final_file="${DEB_STORAGE}/${RELEASE}/${artifact_name}_${artifact_version}_${ARCH}.deb"
+	artifact_base_dir="${PACKAGES_HASHED_STORAGE}/${RELEASE}"
+	artifact_final_file="${PACKAGES_HASHED_STORAGE}/${RELEASE}/${artifact_name}_${artifact_version}_${ARCH}.deb"
 
 	artifact_map_packages=(
 		["armbian-bsp-desktop"]="${artifact_name}"

--- a/lib/functions/artifacts/artifact-armbian-bsp-desktop.sh
+++ b/lib/functions/artifacts/artifact-armbian-bsp-desktop.sh
@@ -53,16 +53,10 @@ function artifact_armbian-bsp-desktop_prepare_version() {
 
 	artifact_name="armbian-bsp-desktop-${BOARD}-${BRANCH}"
 	artifact_type="deb"
-	artifact_base_dir="${PACKAGES_HASHED_STORAGE}/${RELEASE}"
-	artifact_final_file="${PACKAGES_HASHED_STORAGE}/${RELEASE}/${artifact_name}_${artifact_version}_${ARCH}.deb"
+	artifact_deb_repo="${RELEASE}"
+	artifact_deb_arch="${ARCH}"
 
-	artifact_map_packages=(
-		["armbian-bsp-desktop"]="${artifact_name}"
-	)
-
-	artifact_map_debs=(
-		["armbian-bsp-desktop"]="${RELEASE}/${artifact_name}_${artifact_version}_${ARCH}.deb"
-	)
+	artifact_map_packages=(["armbian-bsp-desktop"]="${artifact_name}")
 
 	return 0
 }

--- a/lib/functions/artifacts/artifact-armbian-config.sh
+++ b/lib/functions/artifacts/artifact-armbian-config.sh
@@ -50,18 +50,12 @@ function artifact_armbian-config_prepare_version() {
 
 	artifact_version_reason="${reasons[*]}" # outer scope
 
-	artifact_map_packages=(
-		["armbian-config"]="armbian-config"
-	)
-
-	artifact_map_debs=(
-		["armbian-config"]="armbian-config_${artifact_version}_all.deb"
-	)
+	artifact_map_packages=(["armbian-config"]="armbian-config")
 
 	artifact_name="armbian-config"
 	artifact_type="deb"
-	artifact_base_dir="${PACKAGES_HASHED_STORAGE}"
-	artifact_final_file="${PACKAGES_HASHED_STORAGE}/armbian-config_${artifact_version}_all.deb"
+	artifact_deb_repo="global"
+	artifact_deb_arch="all"
 
 	return 0
 }

--- a/lib/functions/artifacts/artifact-armbian-config.sh
+++ b/lib/functions/artifacts/artifact-armbian-config.sh
@@ -60,8 +60,8 @@ function artifact_armbian-config_prepare_version() {
 
 	artifact_name="armbian-config"
 	artifact_type="deb"
-	artifact_base_dir="${DEB_STORAGE}"
-	artifact_final_file="${DEB_STORAGE}/armbian-config_${artifact_version}_all.deb"
+	artifact_base_dir="${PACKAGES_HASHED_STORAGE}"
+	artifact_final_file="${PACKAGES_HASHED_STORAGE}/armbian-config_${artifact_version}_all.deb"
 
 	return 0
 }

--- a/lib/functions/artifacts/artifact-armbian-config.sh
+++ b/lib/functions/artifacts/artifact-armbian-config.sh
@@ -41,7 +41,7 @@ function artifact_armbian-config_prepare_version() {
 	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
 
 	# outer scope
-	artifact_version="${artifact_prefix_version}${fake_unchanging_base_version}-SA${short_sha1}-B${bash_hash_short}"
+	artifact_version="${fake_unchanging_base_version}-SA${short_sha1}-B${bash_hash_short}"
 
 	declare -a reasons=(
 		"Armbian armbian-config git revision \"${GIT_INFO_ARMBIAN_CONFIG[SHA1]}\""

--- a/lib/functions/artifacts/artifact-armbian-desktop.sh
+++ b/lib/functions/artifacts/artifact-armbian-desktop.sh
@@ -59,8 +59,8 @@ function artifact_armbian-desktop_prepare_version() {
 
 	artifact_name="armbian-${RELEASE}-desktop-${DESKTOP_ENVIRONMENT}"
 	artifact_type="deb"
-	artifact_base_dir="${DEB_STORAGE}/${RELEASE}"
-	artifact_final_file="${DEB_STORAGE}/${RELEASE}/${artifact_name}_${artifact_version}_all.deb"
+	artifact_base_dir="${PACKAGES_HASHED_STORAGE}/${RELEASE}"
+	artifact_final_file="${PACKAGES_HASHED_STORAGE}/${RELEASE}/${artifact_name}_${artifact_version}_all.deb"
 
 	artifact_map_packages=(
 		["armbian-desktop"]="${artifact_name}"

--- a/lib/functions/artifacts/artifact-armbian-desktop.sh
+++ b/lib/functions/artifacts/artifact-armbian-desktop.sh
@@ -18,7 +18,6 @@ function artifact_armbian-desktop_config_dump() {
 }
 
 function artifact_armbian-desktop_prepare_version() {
-	: "${artifact_prefix_version:?artifact_prefix_version is not set}"
 	: "${RELEASE:?RELEASE is not set}"
 
 	: "${DESKTOP_ENVIRONMENT:?DESKTOP_ENVIRONMENT is not set}"
@@ -48,7 +47,7 @@ function artifact_armbian-desktop_prepare_version() {
 	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
 
 	# outer scope
-	artifact_version="${artifact_prefix_version}${fake_unchanging_base_version}-V${var_config_hash_short}-B${bash_hash_short}"
+	artifact_version="${fake_unchanging_base_version}-V${var_config_hash_short}-B${bash_hash_short}"
 
 	declare -a reasons=(
 		"Armbian armbian-desktop"

--- a/lib/functions/artifacts/artifact-armbian-desktop.sh
+++ b/lib/functions/artifacts/artifact-armbian-desktop.sh
@@ -59,16 +59,10 @@ function artifact_armbian-desktop_prepare_version() {
 
 	artifact_name="armbian-${RELEASE}-desktop-${DESKTOP_ENVIRONMENT}"
 	artifact_type="deb"
-	artifact_base_dir="${PACKAGES_HASHED_STORAGE}/${RELEASE}"
-	artifact_final_file="${PACKAGES_HASHED_STORAGE}/${RELEASE}/${artifact_name}_${artifact_version}_all.deb"
+	artifact_deb_repo="${RELEASE}"
+	artifact_deb_arch="all"
 
-	artifact_map_packages=(
-		["armbian-desktop"]="${artifact_name}"
-	)
-
-	artifact_map_debs=(
-		["armbian-desktop"]="${RELEASE}/${artifact_name}_${artifact_version}_all.deb"
-	)
+	artifact_map_packages=(["armbian-desktop"]="${artifact_name}")
 
 	return 0
 }

--- a/lib/functions/artifacts/artifact-armbian-plymouth-theme.sh
+++ b/lib/functions/artifacts/artifact-armbian-plymouth-theme.sh
@@ -36,18 +36,12 @@ function artifact_armbian-plymouth-theme_prepare_version() {
 
 	artifact_version_reason="${reasons[*]}" # outer scope
 
-	artifact_map_packages=(
-		["armbian-plymouth-theme"]="armbian-plymouth-theme"
-	)
-
-	artifact_map_debs=(
-		["armbian-plymouth-theme"]="armbian-plymouth-theme_${artifact_version}_all.deb"
-	)
+	artifact_map_packages=(["armbian-plymouth-theme"]="armbian-plymouth-theme")
 
 	artifact_name="armbian-plymouth-theme"
 	artifact_type="deb"
-	artifact_base_dir="${PACKAGES_HASHED_STORAGE}"
-	artifact_final_file="${PACKAGES_HASHED_STORAGE}/armbian-plymouth-theme_${artifact_version}_all.deb"
+	artifact_deb_repo="global"
+	artifact_deb_arch="all"
 
 	return 0
 }

--- a/lib/functions/artifacts/artifact-armbian-plymouth-theme.sh
+++ b/lib/functions/artifacts/artifact-armbian-plymouth-theme.sh
@@ -27,7 +27,7 @@ function artifact_armbian-plymouth-theme_prepare_version() {
 	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
 
 	# outer scope
-	artifact_version="${artifact_prefix_version}-B${bash_hash_short}"
+	artifact_version="${fake_unchanging_base_version}-B${bash_hash_short}"
 
 	declare -a reasons=(
 		"Armbian armbian-plymouth-theme"

--- a/lib/functions/artifacts/artifact-armbian-plymouth-theme.sh
+++ b/lib/functions/artifacts/artifact-armbian-plymouth-theme.sh
@@ -46,8 +46,8 @@ function artifact_armbian-plymouth-theme_prepare_version() {
 
 	artifact_name="armbian-plymouth-theme"
 	artifact_type="deb"
-	artifact_base_dir="${DEB_STORAGE}"
-	artifact_final_file="${DEB_STORAGE}/armbian-plymouth-theme_${artifact_version}_all.deb"
+	artifact_base_dir="${PACKAGES_HASHED_STORAGE}"
+	artifact_final_file="${PACKAGES_HASHED_STORAGE}/armbian-plymouth-theme_${artifact_version}_all.deb"
 
 	return 0
 }

--- a/lib/functions/artifacts/artifact-armbian-zsh.sh
+++ b/lib/functions/artifacts/artifact-armbian-zsh.sh
@@ -51,18 +51,12 @@ function artifact_armbian-zsh_prepare_version() {
 
 	artifact_version_reason="${reasons[*]}" # outer scope
 
-	artifact_map_packages=(
-		["armbian-zsh"]="armbian-zsh"
-	)
-
-	artifact_map_debs=(
-		["armbian-zsh"]="armbian-zsh_${artifact_version}_all.deb"
-	)
+	artifact_map_packages=(["armbian-zsh"]="armbian-zsh")
 
 	artifact_name="armbian-zsh"
 	artifact_type="deb"
-	artifact_base_dir="${PACKAGES_HASHED_STORAGE}"
-	artifact_final_file="${PACKAGES_HASHED_STORAGE}/armbian-zsh_${artifact_version}_all.deb"
+	artifact_deb_repo="global"
+	artifact_deb_arch="all"
 
 	return 0
 }

--- a/lib/functions/artifacts/artifact-armbian-zsh.sh
+++ b/lib/functions/artifacts/artifact-armbian-zsh.sh
@@ -61,8 +61,8 @@ function artifact_armbian-zsh_prepare_version() {
 
 	artifact_name="armbian-zsh"
 	artifact_type="deb"
-	artifact_base_dir="${DEB_STORAGE}"
-	artifact_final_file="${DEB_STORAGE}/armbian-zsh_${artifact_version}_all.deb"
+	artifact_base_dir="${PACKAGES_HASHED_STORAGE}"
+	artifact_final_file="${PACKAGES_HASHED_STORAGE}/armbian-zsh_${artifact_version}_all.deb"
 
 	return 0
 }

--- a/lib/functions/artifacts/artifact-armbian-zsh.sh
+++ b/lib/functions/artifacts/artifact-armbian-zsh.sh
@@ -42,7 +42,7 @@ function artifact_armbian-zsh_prepare_version() {
 	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
 
 	# outer scope
-	artifact_version="${artifact_prefix_version}${fake_unchanging_base_version}-SA${short_sha1}-B${bash_hash_short}"
+	artifact_version="${fake_unchanging_base_version}-SA${short_sha1}-B${bash_hash_short}"
 
 	declare -a reasons=(
 		"Armbian armbian-zsh git revision \"${GIT_INFO_ARMBIAN_ZSH[SHA1]}\""

--- a/lib/functions/artifacts/artifact-fake-ubuntu-advantage-tools.sh
+++ b/lib/functions/artifacts/artifact-fake-ubuntu-advantage-tools.sh
@@ -27,7 +27,7 @@ function artifact_fake_ubuntu_advantage_tools_prepare_version() {
 	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
 
 	# outer scope
-	artifact_version="${artifact_prefix_version}${fake_unchanging_base_version}-B${bash_hash_short}"
+	artifact_version="${fake_unchanging_base_version}-B${bash_hash_short}"
 
 	declare -a reasons=(
 		"Armbian fake-ubuntu-advantage-tools"

--- a/lib/functions/artifacts/artifact-fake-ubuntu-advantage-tools.sh
+++ b/lib/functions/artifacts/artifact-fake-ubuntu-advantage-tools.sh
@@ -46,8 +46,8 @@ function artifact_fake_ubuntu_advantage_tools_prepare_version() {
 
 	artifact_name="fake-ubuntu-advantage-tools"
 	artifact_type="deb"
-	artifact_base_dir="${DEB_STORAGE}"
-	artifact_final_file="${DEB_STORAGE}/fake-ubuntu-advantage-tools_${artifact_version}_all.deb"
+	artifact_base_dir="${PACKAGES_HASHED_STORAGE}"
+	artifact_final_file="${PACKAGES_HASHED_STORAGE}/fake-ubuntu-advantage-tools_${artifact_version}_all.deb"
 
 	return 0
 }

--- a/lib/functions/artifacts/artifact-fake-ubuntu-advantage-tools.sh
+++ b/lib/functions/artifacts/artifact-fake-ubuntu-advantage-tools.sh
@@ -36,18 +36,12 @@ function artifact_fake_ubuntu_advantage_tools_prepare_version() {
 
 	artifact_version_reason="${reasons[*]}" # outer scope
 
-	artifact_map_packages=(
-		["fake-ubuntu-advantage-tools"]="fake-ubuntu-advantage-tools"
-	)
-
-	artifact_map_debs=(
-		["fake-ubuntu-advantage-tools"]="fake-ubuntu-advantage-tools_${artifact_version}_all.deb"
-	)
+	artifact_map_packages=(["fake-ubuntu-advantage-tools"]="fake-ubuntu-advantage-tools")
 
 	artifact_name="fake-ubuntu-advantage-tools"
 	artifact_type="deb"
-	artifact_base_dir="${PACKAGES_HASHED_STORAGE}"
-	artifact_final_file="${PACKAGES_HASHED_STORAGE}/fake-ubuntu-advantage-tools_${artifact_version}_all.deb"
+	artifact_deb_repo="global"
+	artifact_deb_arch="all"
 
 	return 0
 }

--- a/lib/functions/artifacts/artifact-firmware.sh
+++ b/lib/functions/artifacts/artifact-firmware.sh
@@ -42,7 +42,7 @@ function artifact_firmware_prepare_version() {
 	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
 
 	# outer scope
-	artifact_version="${artifact_prefix_version}${fake_unchanging_base_version}-SA${short_sha1}-B${bash_hash_short}"
+	artifact_version="${fake_unchanging_base_version}-SA${short_sha1}-B${bash_hash_short}"
 
 	declare -a reasons=(
 		"Armbian firmware git revision \"${GIT_INFO_ARMBIAN_FIRMWARE[SHA1]}\""

--- a/lib/functions/artifacts/artifact-firmware.sh
+++ b/lib/functions/artifacts/artifact-firmware.sh
@@ -61,8 +61,8 @@ function artifact_firmware_prepare_version() {
 
 	artifact_name="armbian-firmware"
 	artifact_type="deb"
-	artifact_base_dir="${DEB_STORAGE}"
-	artifact_final_file="${DEB_STORAGE}/armbian-firmware_${artifact_version}_all.deb"
+	artifact_base_dir="${PACKAGES_HASHED_STORAGE}"
+	artifact_final_file="${PACKAGES_HASHED_STORAGE}/armbian-firmware_${artifact_version}_all.deb"
 
 	return 0
 }

--- a/lib/functions/artifacts/artifact-firmware.sh
+++ b/lib/functions/artifacts/artifact-firmware.sh
@@ -51,18 +51,12 @@ function artifact_firmware_prepare_version() {
 
 	artifact_version_reason="${reasons[*]}" # outer scope
 
-	artifact_map_packages=(
-		["armbian-firmware"]="armbian-firmware"
-	)
-
-	artifact_map_debs=(
-		["armbian-firmware"]="armbian-firmware_${artifact_version}_all.deb"
-	)
+	artifact_map_packages=(["armbian-firmware"]="armbian-firmware")
 
 	artifact_name="armbian-firmware"
 	artifact_type="deb"
-	artifact_base_dir="${PACKAGES_HASHED_STORAGE}"
-	artifact_final_file="${PACKAGES_HASHED_STORAGE}/armbian-firmware_${artifact_version}_all.deb"
+	artifact_deb_repo="global"
+	artifact_deb_arch="all"
 
 	return 0
 }

--- a/lib/functions/artifacts/artifact-full_firmware.sh
+++ b/lib/functions/artifacts/artifact-full_firmware.sh
@@ -15,7 +15,6 @@ function artifact_full_firmware_config_dump() {
 function artifact_full_firmware_prepare_version() {
 	artifact_version="undetermined"        # outer scope
 	artifact_version_reason="undetermined" # outer scope
-	[[ -z "${artifact_prefix_version}" ]] && exit_with_error "artifact_prefix_version is not set"
 
 	local ARMBIAN_FIRMWARE_SOURCE="${ARMBIAN_FIRMWARE_GIT_SOURCE:-"https://github.com/armbian/firmware"}"
 	local ARMBIAN_FIRMWARE_BRANCH="branch:${ARMBIAN_FIRMWARE_GIT_BRANCH:-"master"}"
@@ -52,7 +51,7 @@ function artifact_full_firmware_prepare_version() {
 	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
 
 	# outer scope
-	artifact_version="${artifact_prefix_version}${fake_unchanging_base_version}-SA${short_sha1}-SM${short_sha1_mainline}-B${bash_hash_short}"
+	artifact_version="${fake_unchanging_base_version}-SA${short_sha1}-SM${short_sha1_mainline}-B${bash_hash_short}"
 
 	declare -a reasons=(
 		"Armbian firmware git revision \"${GIT_INFO_ARMBIAN_FIRMWARE[SHA1]}\""

--- a/lib/functions/artifacts/artifact-full_firmware.sh
+++ b/lib/functions/artifacts/artifact-full_firmware.sh
@@ -71,8 +71,8 @@ function artifact_full_firmware_prepare_version() {
 
 	artifact_name="armbian-firmware-full"
 	artifact_type="deb"
-	artifact_base_dir="${DEB_STORAGE}"
-	artifact_final_file="${DEB_STORAGE}/armbian-firmware-full_${artifact_version}_all.deb"
+	artifact_base_dir="${PACKAGES_HASHED_STORAGE}"
+	artifact_final_file="${PACKAGES_HASHED_STORAGE}/armbian-firmware-full_${artifact_version}_all.deb"
 
 	return 0
 }

--- a/lib/functions/artifacts/artifact-full_firmware.sh
+++ b/lib/functions/artifacts/artifact-full_firmware.sh
@@ -61,18 +61,12 @@ function artifact_full_firmware_prepare_version() {
 
 	artifact_version_reason="${reasons[*]}" # outer scope
 
-	artifact_map_packages=(
-		["armbian-firmware-full"]="armbian-firmware-full"
-	)
-
-	artifact_map_debs=(
-		["armbian-firmware-full"]="armbian-firmware-full_${artifact_version}_all.deb"
-	)
+	artifact_map_packages=(["armbian-firmware-full"]="armbian-firmware-full")
 
 	artifact_name="armbian-firmware-full"
 	artifact_type="deb"
-	artifact_base_dir="${PACKAGES_HASHED_STORAGE}"
-	artifact_final_file="${PACKAGES_HASHED_STORAGE}/armbian-firmware-full_${artifact_version}_all.deb"
+	artifact_deb_repo="global"
+	artifact_deb_arch="all"
 
 	return 0
 }

--- a/lib/functions/artifacts/artifact-kernel.sh
+++ b/lib/functions/artifacts/artifact-kernel.sh
@@ -212,8 +212,8 @@ function artifact_kernel_prepare_version() {
 
 	artifact_name="kernel-${LINUXFAMILY}-${BRANCH}"
 	artifact_type="deb-tar" # this triggers processing of .deb files in the maps to produce a tarball
-	artifact_base_dir="${DEB_STORAGE}"
-	artifact_final_file="${DEB_STORAGE}/kernel-${LINUXFAMILY}-${BRANCH}_${artifact_version}.tar"
+	artifact_base_dir="${PACKAGES_HASHED_STORAGE}"
+	artifact_final_file="${PACKAGES_HASHED_STORAGE}/kernel-${LINUXFAMILY}-${BRANCH}_${artifact_version}.tar"
 
 	return 0
 }

--- a/lib/functions/artifacts/artifact-kernel.sh
+++ b/lib/functions/artifacts/artifact-kernel.sh
@@ -26,7 +26,6 @@ function artifact_kernel_config_dump() {
 function artifact_kernel_prepare_version() {
 	artifact_version="undetermined"        # outer scope
 	artifact_version_reason="undetermined" # outer scope
-	[[ -z "${artifact_prefix_version}" ]] && exit_with_error "artifact_prefix_version is not set"
 
 	# - Given KERNELSOURCE and KERNELBRANCH, get:
 	#    - SHA1 of the commit (this is generic... and used for other pkgs)
@@ -63,7 +62,6 @@ function artifact_kernel_prepare_version() {
 	debug_var BOARDFAMILY        # Heh.
 	debug_var KERNEL_MAJOR_MINOR # Double heh. transitional stuff, from when armbian-next began. 🤣
 	debug_var BRANCH
-	debug_var REVISION
 	debug_var KERNELSOURCE
 	debug_var KERNELBRANCH
 	debug_var LINUXFAMILY
@@ -175,9 +173,9 @@ function artifact_kernel_prepare_version() {
 
 	# outer scope
 	if [[ "${KERNEL_SKIP_MAKEFILE_VERSION:-"no"}" == "yes" ]]; then
-		artifact_version="${artifact_prefix_version}${common_version_suffix}"
+		artifact_version="${common_version_suffix}"
 	else
-		artifact_version="${artifact_prefix_version}${GIT_INFO_KERNEL[MAKEFILE_VERSION]}-${common_version_suffix}"
+		artifact_version="${GIT_INFO_KERNEL[MAKEFILE_VERSION]}-${common_version_suffix}"
 	fi
 
 	declare -a reasons=(

--- a/lib/functions/artifacts/artifact-kernel.sh
+++ b/lib/functions/artifacts/artifact-kernel.sh
@@ -173,7 +173,7 @@ function artifact_kernel_prepare_version() {
 
 	# outer scope
 	if [[ "${KERNEL_SKIP_MAKEFILE_VERSION:-"no"}" == "yes" ]]; then
-		artifact_version="${common_version_suffix}"
+		artifact_version="1-${common_version_suffix}" # "1-" prefix, since we need to start with a digit
 	else
 		artifact_version="${GIT_INFO_KERNEL[MAKEFILE_VERSION]}-${common_version_suffix}"
 	fi

--- a/lib/functions/artifacts/artifact-kernel.sh
+++ b/lib/functions/artifacts/artifact-kernel.sh
@@ -196,24 +196,21 @@ function artifact_kernel_prepare_version() {
 
 	# linux-image is always produced...
 	artifact_map_packages=(["linux-image"]="linux-image-${BRANCH}-${LINUXFAMILY}")
-	artifact_map_debs=(["linux-image"]="linux-image-${BRANCH}-${LINUXFAMILY}_${artifact_version}_${ARCH}.deb")
 
 	# some/most kernels have also working headers...
 	if [[ "${KERNEL_HAS_WORKING_HEADERS:-"no"}" == "yes" ]]; then
 		artifact_map_packages+=(["linux-headers"]="linux-headers-${BRANCH}-${LINUXFAMILY}")
-		artifact_map_debs+=(["linux-headers"]="linux-headers-${BRANCH}-${LINUXFAMILY}_${artifact_version}_${ARCH}.deb")
 	fi
 
 	# x86, specially, does not have working dtbs...
 	if [[ "${KERNEL_BUILD_DTBS:-"yes"}" == "yes" ]]; then
 		artifact_map_packages+=(["linux-dtb"]="linux-dtb-${BRANCH}-${LINUXFAMILY}")
-		artifact_map_debs+=(["linux-dtb"]="linux-dtb-${BRANCH}-${LINUXFAMILY}_${artifact_version}_${ARCH}.deb")
 	fi
 
 	artifact_name="kernel-${LINUXFAMILY}-${BRANCH}"
 	artifact_type="deb-tar" # this triggers processing of .deb files in the maps to produce a tarball
-	artifact_base_dir="${PACKAGES_HASHED_STORAGE}"
-	artifact_final_file="${PACKAGES_HASHED_STORAGE}/kernel-${LINUXFAMILY}-${BRANCH}_${artifact_version}.tar"
+	artifact_deb_repo="global"
+	artifact_deb_arch="${ARCH}"
 
 	return 0
 }
@@ -222,7 +219,7 @@ function artifact_kernel_build_from_sources() {
 	compile_kernel
 
 	if [[ "${ARTIFACT_WILL_NOT_BUILD}" != "yes" ]]; then # true if kernel-patch, kernel-config, etc.
-		display_alert "Kernel build finished" "${artifact_version_reason}" "info"
+		display_alert "Kernel build finished" "${artifact_version}" "info"
 	fi
 }
 

--- a/lib/functions/artifacts/artifact-kernel.sh
+++ b/lib/functions/artifacts/artifact-kernel.sh
@@ -152,7 +152,8 @@ function artifact_kernel_prepare_version() {
 	)
 	declare hash_variables="undetermined" # will be set by calculate_hash_for_variables(), which normalizes the input
 	calculate_hash_for_variables "${vars_to_hash[@]}"
-	declare var_config_hash_short="${hash_variables:0:${short_hash_size}}"
+	declare vars_config_hash="${hash_variables}"
+	declare var_config_hash_short="${vars_config_hash:0:${short_hash_size}}"
 
 	# Hash the extension hooks
 	declare -a extension_hooks_to_hash=("pre_package_kernel_image")

--- a/lib/functions/artifacts/artifact-rootfs.sh
+++ b/lib/functions/artifacts/artifact-rootfs.sh
@@ -24,7 +24,6 @@ function artifact_rootfs_config_dump() {
 function artifact_rootfs_prepare_version() {
 	artifact_version="undetermined"        # outer scope
 	artifact_version_reason="undetermined" # outer scope
-	[[ -z "${artifact_prefix_version}" ]] && exit_with_error "artifact_prefix_version is not set"
 
 	assert_requires_aggregation # Bombs if aggregation has not run
 
@@ -48,8 +47,7 @@ function artifact_rootfs_prepare_version() {
 		reasons+=("desktop_appgroups_selected \"${DESKTOP_APPGROUPS_SELECTED}\"")
 	fi
 
-	# rootfs does NOT include ${artifact_prefix_version} -- there's no reason to, since rootfs is not in an apt repo
-	# instead, we use YYYYMM to make a new rootfs cache version per-month, even if nothing else changes.
+	# we use YYYYMM to make a new rootfs cache version per-month, even if nothing else changes.
 	declare yyyymm="undetermined"
 	yyyymm="$(date +%Y%m)"
 

--- a/lib/functions/artifacts/artifact-uboot.sh
+++ b/lib/functions/artifacts/artifact-uboot.sh
@@ -55,16 +55,16 @@ function artifact_uboot_prepare_version() {
 	declare patches_hash="undetermined"
 	declare hash_files="undetermined"
 	declare -a uboot_patch_dirs=()
-	for patch_dir in ${BOOTPATCHDIR} ; do
-		uboot_patch_dirs+=( "${SRC}/patch/u-boot/${patch_dir}" "${USERPATCHES_PATH}/u-boot/${patch_dir}" )
+	for patch_dir in ${BOOTPATCHDIR}; do
+		uboot_patch_dirs+=("${SRC}/patch/u-boot/${patch_dir}" "${USERPATCHES_PATH}/u-boot/${patch_dir}")
 	done
 
 	if [[ -n "${ATFSOURCE}" && "${ATFSOURCE}" != "none" ]]; then
-		uboot_patch_dirs+=( "${SRC}/patch/atf/${ATFPATCHDIR}" "${USERPATCHES_PATH}/atf/${ATFPATCHDIR}" )
+		uboot_patch_dirs+=("${SRC}/patch/atf/${ATFPATCHDIR}" "${USERPATCHES_PATH}/atf/${ATFPATCHDIR}")
 	fi
 
 	if [[ -n "${CRUSTCONFIG}" ]]; then
-		uboot_patch_dirs+=( "${SRC}/patch/crust/${CRUSTPATCHDIR}" "${USERPATCHES_PATH}/crust/${CRUSTPATCHDIR}" )
+		uboot_patch_dirs+=("${SRC}/patch/crust/${CRUSTPATCHDIR}" "${USERPATCHES_PATH}/crust/${CRUSTPATCHDIR}")
 	fi
 
 	calculate_hash_for_all_files_in_dirs "${uboot_patch_dirs[@]}"
@@ -122,20 +122,12 @@ function artifact_uboot_prepare_version() {
 		"framework bash hash \"${bash_hash}\""
 	)
 
+	artifact_deb_repo="global"
+	artifact_deb_arch="${ARCH}"
 	artifact_version_reason="${reasons[*]}" # outer scope
-
-	artifact_map_packages=(
-		["uboot"]="linux-u-boot-${BOARD}-${BRANCH}"
-	)
-
-	artifact_map_debs=(
-		["uboot"]="linux-u-boot-${BOARD}-${BRANCH}_${artifact_version}_${ARCH}.deb"
-	)
-
+	artifact_map_packages=(["uboot"]="linux-u-boot-${BOARD}-${BRANCH}")
 	artifact_name="uboot-${BOARD}-${BRANCH}"
 	artifact_type="deb"
-	artifact_base_dir="${PACKAGES_HASHED_STORAGE}"
-	artifact_final_file="${PACKAGES_HASHED_STORAGE}/linux-u-boot-${BOARD}-${BRANCH}_${artifact_version}_${ARCH}.deb"
 
 	return 0
 }

--- a/lib/functions/artifacts/artifact-uboot.sh
+++ b/lib/functions/artifacts/artifact-uboot.sh
@@ -19,7 +19,6 @@ function artifact_uboot_config_dump() {
 function artifact_uboot_prepare_version() {
 	artifact_version="undetermined"        # outer scope
 	artifact_version_reason="undetermined" # outer scope
-	[[ -z "${artifact_prefix_version}" ]] && exit_with_error "artifact_prefix_version is not set"
 
 	# Prepare the version, "sans-repos": just the armbian/build repo contents are available.
 	# It is OK to reach out to the internet for a curl or ls-remote, but not for a git clone/fetch.
@@ -111,7 +110,7 @@ function artifact_uboot_prepare_version() {
 	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
 
 	# outer scope
-	artifact_version="${artifact_prefix_version}${GIT_INFO_UBOOT[MAKEFILE_VERSION]}-S${short_sha1}-P${uboot_patches_hash_short}-H${hash_hooks_and_functions_short}-V${var_config_hash_short}-B${bash_hash_short}"
+	artifact_version="${GIT_INFO_UBOOT[MAKEFILE_VERSION]}-S${short_sha1}-P${uboot_patches_hash_short}-H${hash_hooks_and_functions_short}-V${var_config_hash_short}-B${bash_hash_short}"
 
 	declare -a reasons=(
 		"version \"${GIT_INFO_UBOOT[MAKEFILE_FULL_VERSION]}\""

--- a/lib/functions/artifacts/artifact-uboot.sh
+++ b/lib/functions/artifacts/artifact-uboot.sh
@@ -134,8 +134,8 @@ function artifact_uboot_prepare_version() {
 
 	artifact_name="uboot-${BOARD}-${BRANCH}"
 	artifact_type="deb"
-	artifact_base_dir="${DEB_STORAGE}"
-	artifact_final_file="${DEB_STORAGE}/linux-u-boot-${BOARD}-${BRANCH}_${artifact_version}_${ARCH}.deb"
+	artifact_base_dir="${PACKAGES_HASHED_STORAGE}"
+	artifact_final_file="${PACKAGES_HASHED_STORAGE}/linux-u-boot-${BOARD}-${BRANCH}_${artifact_version}_${ARCH}.deb"
 
 	return 0
 }

--- a/lib/functions/artifacts/artifact-uboot.sh
+++ b/lib/functions/artifacts/artifact-uboot.sh
@@ -101,7 +101,8 @@ function artifact_uboot_prepare_version() {
 	)
 	declare hash_variables="undetermined" # will be set by calculate_hash_for_variables(), which normalizes the input
 	calculate_hash_for_variables "${vars_to_hash[@]}"
-	declare var_config_hash_short="${hash_variables:0:${short_hash_size}}"
+	declare vars_config_hash="${hash_variables}"
+	declare var_config_hash_short="${vars_config_hash:0:${short_hash_size}}"
 
 	# get the hashes of the lib/ bash sources involved...
 	declare hash_files="undetermined"

--- a/lib/functions/artifacts/artifacts-obtain.sh
+++ b/lib/functions/artifacts/artifacts-obtain.sh
@@ -68,8 +68,6 @@ function initialize_artifact() {
 }
 
 function obtain_complete_artifact() {
-	: "${artifact_prefix_version:?artifact_prefix_version is not set}"
-
 	declare -g artifact_name="undetermined"
 	declare -g artifact_type="undetermined"
 	declare -g artifact_version="undetermined"
@@ -80,9 +78,6 @@ function obtain_complete_artifact() {
 	declare -g artifact_full_oci_target="undetermined"
 	declare -A -g artifact_map_packages=()
 	declare -A -g artifact_map_debs=()
-
-	# Check if REVISION is set, otherwise exit_with_error
-	[[ "x${REVISION}x" == "xx" ]] && exit_with_error "REVISION is not set"
 
 	# Contentious; it might be that prepare_version is complex enough to warrant more than 1 logging section.
 	LOG_SECTION="artifact_prepare_version" do_with_logging artifact_prepare_version
@@ -104,9 +99,9 @@ function obtain_complete_artifact() {
 	[[ "x${artifact_base_dir}x" == "xx" || "${artifact_base_dir}" == "undetermined" ]] && exit_with_error "artifact_base_dir is not set after artifact_prepare_version"
 	[[ "x${artifact_final_file}x" == "xx" || "${artifact_final_file}" == "undetermined" ]] && exit_with_error "artifact_final_file is not set after artifact_prepare_version"
 
-	# validate artifact_version begins with artifact_prefix_version when building deb packages (or deb-tar)
+	# validate artifact_version begins with a digit when building deb packages (or deb-tar); dpkg requires it
 	if [[ "${artifact_type}" != "tar.zst" ]]; then
-		[[ "${artifact_version}" =~ ^${artifact_prefix_version} ]] || exit_with_error "artifact_version '${artifact_version}' does not begin with artifact_prefix_version '${artifact_prefix_version}'"
+		[[ "${artifact_version}" =~ ^[0-9] ]] || exit_with_error "${artifact_type}: artifact_version '${artifact_version}' does not begin with a digit"
 	fi
 
 	declare -a artifact_map_debs_values=() artifact_map_packages_values=() artifact_map_debs_keys=() artifact_map_packages_keys=()

--- a/lib/functions/artifacts/artifacts-obtain.sh
+++ b/lib/functions/artifacts/artifacts-obtain.sh
@@ -364,6 +364,12 @@ function upload_artifact_to_oci() {
 
 	display_alert "Pushing to OCI" "'${artifact_final_file}' -> '${artifact_full_oci_target}'" "info"
 	oras_push_artifact_file "${artifact_full_oci_target}" "${artifact_final_file}" "${artifact_name} - ${artifact_version} - ${artifact_version_reason} - type: ${artifact_type}"
+
+	# If this is a deb-tar, delete the .tar after the upload. We won't ever need it again.
+	if [[ "${artifact_type}" == "deb-tar" ]]; then
+		display_alert "Deleting deb-tar after OCI deploy" "deb-tar: ${artifact_final_file_basename}" "warn" # @TODO
+		run_host_command_logged rm -fv "${artifact_final_file}"
+	fi
 }
 
 function is_artifact_available_in_local_cache() {

--- a/lib/functions/artifacts/artifacts-obtain.sh
+++ b/lib/functions/artifacts/artifacts-obtain.sh
@@ -137,10 +137,14 @@ function obtain_complete_artifact() {
 			declare single_deb_hashed_rel_path
 			for one_artifact_deb_id in "${!artifact_map_packages[@]}"; do
 				one_artifact_deb_package="${artifact_map_packages["${one_artifact_deb_id}"]}"
-				# @TODO: might be "${artifact_name}/${artifact_version}/" in the middle can be beneficial for cleaning, later?
+
 				single_deb_hashed_rel_path="${artifact_deb_repo}/${one_artifact_deb_package}_${artifact_version}_${artifact_deb_arch}.deb"
 				artifact_map_debs+=(["${one_artifact_deb_id}"]="${single_deb_hashed_rel_path}")
-				artifact_map_debs_reversioned+=(["${one_artifact_deb_id}"]="${REVISION}/${artifact_deb_repo}/${artifact_name}/${artifact_version}/${one_artifact_deb_package}_${artifact_final_version_reversioned}_${artifact_deb_arch}.deb")
+
+				declare artifact_deb_repo_prefix=""
+				[[ "${artifact_deb_repo}" != "global" ]] && artifact_deb_repo_prefix="${artifact_deb_repo}/"
+
+				artifact_map_debs_reversioned+=(["${one_artifact_deb_id}"]="${artifact_deb_repo_prefix}${one_artifact_deb_package}_${artifact_final_version_reversioned}_${artifact_deb_arch}__${artifact_version}.deb")
 				debs_counter+=1
 			done
 

--- a/lib/functions/artifacts/artifacts-reversion.sh
+++ b/lib/functions/artifacts/artifacts-reversion.sh
@@ -1,0 +1,156 @@
+#
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (c) 2023 Ricardo Pardini <ricardo@pardini.net>
+# This file is a part of the Armbian Build Framework https://github.com/armbian/build/
+#
+
+function artifact_reversion_for_deployment() {
+	standard_artifact_reversion_for_deployment "${artifact_debs_reversion_functions[@]}"
+}
+
+function artifact_calculate_reversioning_hash() {
+	declare hash_functions="undetermined"
+	declare -a all_functions=("standard_artifact_reversion_for_deployment" "standard_artifact_reversion_for_deployment_one_deb")
+	all_functions+=("artifact_deb_reversion_unpack_data_deb" "artifact_deb_reversion_repack_data_deb")
+	all_functions+=("${artifact_debs_reversion_functions[@]}")
+	calculate_hash_for_function_bodies "${all_functions[@]}" # sets hash_functions
+	artifact_reversioning_hash="${hash_functions}"           # outer scope
+	return 0
+}
+
+function standard_artifact_reversion_for_deployment() {
+	display_alert "Reversioning package" "re-version '${artifact_name}(${artifact_type})::${artifact_version}' to '${artifact_final_version_reversioned}'" "info"
+
+	declare artifact_mapped_deb one_artifact_deb_package
+	for one_artifact_deb_package in "${!artifact_map_packages[@]}"; do
+		declare artifact_mapped_deb="${artifact_map_debs["${one_artifact_deb_package}"]}"
+		declare hashed_storage_deb_full_path="${PACKAGES_HASHED_STORAGE}/${artifact_mapped_deb}"
+		if [[ ! -f "${hashed_storage_deb_full_path}" ]]; then
+			exit_with_error "hashed storage does not have ${hashed_storage_deb_full_path}"
+		fi
+
+		display_alert "Found hashed storage file" "'${artifact_mapped_deb}': ${hashed_storage_deb_full_path}" "debug"
+
+		# find the target dir and full path to the reversioned file
+		declare deb_versioned_rel_path="${artifact_map_debs_reversioned["${one_artifact_deb_package}"]}"
+		declare deb_versioned_full_path="${DEB_STORAGE}/${deb_versioned_rel_path}"
+		declare deb_versioned_dirname
+		deb_versioned_dirname="$(dirname "${deb_versioned_full_path}")"
+
+		run_host_command_logged mkdir -p "${deb_versioned_dirname}"
+
+		# since the full versioned path includes the original hash, if the file already exists, we can trust
+		# it's the correct one, and skip reversioning.
+		if [[ -f "${deb_versioned_full_path}" ]]; then
+			display_alert "Skipping reversioning" "deb: ${deb_versioned_full_path} already exists" "debug"
+			continue
+		fi
+
+		# call function for each deb, pass parameters
+		standard_artifact_reversion_for_deployment_one_deb "${@}"
+
+		# make sure reversioning produced the expected file
+		if [[ ! -f "${deb_versioned_full_path}" ]]; then
+			exit_with_error "reversioning did not produce the expected file: ${deb_versioned_full_path}"
+		fi
+	done
+
+	return 0
+}
+
+function standard_artifact_reversion_for_deployment_one_deb() {
+	display_alert "Will repack" "one_artifact_deb_package: ${one_artifact_deb_package}" "debug"
+	display_alert "Will repack" "hashed_storage_deb_full_path: ${hashed_storage_deb_full_path}" "debug"
+	display_alert "Will repack" "deb_versioned_full_path: ${deb_versioned_full_path}" "debug"
+	display_alert "Will repack" "artifact_version: ${artifact_version}" "debug"
+
+	declare cleanup_id="" unpack_dir=""
+	prepare_temp_dir_in_workdir_and_schedule_cleanup "reversion-${artifact_name}" cleanup_id unpack_dir # namerefs
+
+	declare deb_contents_dir="${unpack_dir}/deb-contents"
+	mkdir -p "${deb_contents_dir}"
+
+	# unpack the hashed_storage_deb_full_path .deb, which is just an "ar" file, to the deb_contents_dir
+	run_host_command_logged ar x "${hashed_storage_deb_full_path}" --output="${deb_contents_dir}"
+
+	# find out if compressed or not, and store for future recompressing
+	control_compressed=""
+	if [[ -f "${deb_contents_dir}/control.tar.xz" ]]; then
+		control_compressed=".xz"
+		run_host_command_logged xz -d "${deb_contents_dir}/control.tar.xz" # decompress
+	fi
+
+	# untar the control into its own specific dir
+	declare control_dir="${unpack_dir}/control"
+	mkdir -p "${control_dir}"
+	run_host_command_logged tar -xf "${deb_contents_dir}/control.tar" --directory="${control_dir}"
+
+	# prepare for unpacking the data tarball as well
+	declare data_dir="${unpack_dir}/data"
+	mkdir -p "${data_dir}"
+	declare data_compressed=""
+	if [[ -f "${deb_contents_dir}/data.tar.xz" ]]; then
+		data_compressed=".xz"
+	fi
+
+	# Hack at the control file...
+	declare control_file="${control_dir}/control"
+	declare control_file_new="${control_dir}/control.new"
+
+	# Replace "Version: " field with our own
+	sed -e "s/^Version: .*/Version: ${artifact_final_version_reversioned}/" "${control_file}" > "${control_file_new}"
+	echo "Armbian-Original-Hash: ${artifact_version}" >> "${control_file_new}" # non-standard field.
+
+	for one_reversion_function_name in "${@}"; do
+		display_alert "reversioning" "call custom function: '${one_reversion_function_name}'" "debug"
+		"${one_reversion_function_name}" "${one_artifact_deb_package}"
+	done
+
+	# Show a nice diff using batcat if debugging
+	if [[ "${SHOW_DEBUG}" == "yes" ]]; then
+		diff -u "${control_file}" "${control_file_new}" > "${unpack_dir}/control.diff" || true
+		run_tool_batcat "${unpack_dir}/control.diff"
+	fi
+
+	# Move new control on top of old
+	run_host_command_logged mv "${control_file_new}" "${control_file}"
+
+	run_host_command_logged rm "${deb_contents_dir}/control.tar"
+
+	cd "${control_dir}" || exit_with_error "cray-cray about control_dir ${control_dir}"
+	run_host_command_logged tar cf "${deb_contents_dir}/control.tar" .
+
+	# if it was compressed to begin with, recompress...
+	if [[ "${control_compressed}" == ".xz" ]]; then
+		run_host_command_logged xz "${deb_contents_dir}/control.tar"
+	fi
+
+	# re-ar the whole .deb back in place, using the new version for filename.
+	run_host_command_logged ar rcs "${deb_versioned_full_path}" \
+		"${deb_contents_dir}/debian-binary" \
+		"${deb_contents_dir}/control.tar${control_compressed}" \
+		"${deb_contents_dir}/data.tar${data_compressed}"
+
+	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
+
+	return 0
+}
+
+function artifact_deb_reversion_unpack_data_deb() {
+	if [[ "${data_compressed}" == ".xz" ]]; then
+		run_host_command_logged xz -d "${deb_contents_dir}/data.tar.xz" # decompress
+	fi
+
+	run_host_command_logged tar -xf "${deb_contents_dir}/data.tar" --directory="${data_dir}"
+}
+
+function artifact_deb_reversion_repack_data_deb() {
+	run_host_command_logged rm "${deb_contents_dir}/data.tar"
+	cd "${data_dir}" || exit_with_error "cray-cray about data_dir ${data_dir}"
+	run_host_command_logged tar cf "${deb_contents_dir}/data.tar" .
+
+	# if it was compressed to begin with, recompress...
+	if [[ "${data_compressed}" == ".xz" ]]; then
+		run_host_command_logged xz "${deb_contents_dir}/data.tar"
+	fi
+}

--- a/lib/functions/bsp/armbian-bsp-cli-deb.sh
+++ b/lib/functions/bsp/armbian-bsp-cli-deb.sh
@@ -35,7 +35,7 @@ function compile_armbian-bsp-cli-transitional() {
 	EOF
 
 	# Build / close the package. This will run shellcheck / show the generated files if debugging
-	fakeroot_dpkg_deb_build "${destination}" "${DEB_STORAGE}/"
+	fakeroot_dpkg_deb_build "${destination}"
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 
@@ -210,7 +210,7 @@ function compile_armbian-bsp-cli() {
 	fi
 
 	# Build / close the package. This will run shellcheck / show the generated files if debugging
-	fakeroot_dpkg_deb_build "${destination}" "${DEB_STORAGE}/"
+	fakeroot_dpkg_deb_build "${destination}"
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 

--- a/lib/functions/bsp/armbian-bsp-cli-deb.sh
+++ b/lib/functions/bsp/armbian-bsp-cli-deb.sh
@@ -34,15 +34,6 @@ function compile_armbian-bsp-cli-transitional() {
 		Description: Armbian CLI BSP for board '${BOARD}' - transitional package
 	EOF
 
-	# generate minimal DEBIAN/changelog
-	cat <<- EOF > "${destination}"/DEBIAN/changelog
-		armbian-bsp-cli-${BOARD} (${artifact_version}) armbian-repo-name; urgency=low
-
-		  * A fake changelog entry.
-
-		 -- $MAINTAINER <$MAINTAINERMAIL>  $(date -R)
-	EOF
-
 	# Build / close the package. This will run shellcheck / show the generated files if debugging
 	fakeroot_dpkg_deb_build "${destination}" "${DEB_STORAGE}/"
 
@@ -93,15 +84,6 @@ function compile_armbian-bsp-cli() {
 		Breaks: armbian-bsp-cli-${BOARD}${EXTRA_BSP_NAME} (<< ${artifact_version})
 		Recommends: bsdutils, parted, util-linux, toilet
 		Description: Armbian CLI BSP for board '${BOARD}' branch '${BRANCH}' ${extra_description[@]}
-	EOF
-
-	# generate minimal DEBIAN/changelog
-	cat <<- EOF > "${destination}"/DEBIAN/changelog
-		${artifact_name} (${artifact_version}) armbian-repo-name; urgency=low
-
-		  * A fake changelog entry.
-
-		 -- $MAINTAINER <$MAINTAINERMAIL>  $(date -R)
 	EOF
 
 	# armhwinfo, firstrun, armbianmonitor, etc. config file; also sourced in postinst

--- a/lib/functions/bsp/armbian-bsp-cli-deb.sh
+++ b/lib/functions/bsp/armbian-bsp-cli-deb.sh
@@ -30,16 +30,28 @@ function compile_armbian-bsp-cli-transitional() {
 		Maintainer: $MAINTAINER <$MAINTAINERMAIL>
 		Section: oldlibs
 		Priority: optional
-		Depends: ${artifact_name} (= ${artifact_version})
 		Description: Armbian CLI BSP for board '${BOARD}' - transitional package
 	EOF
 
 	# Build / close the package. This will run shellcheck / show the generated files if debugging
-	fakeroot_dpkg_deb_build "${destination}"
+	fakeroot_dpkg_deb_build "${destination}" "armbian-bsp-cli-transitional"
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 
 	display_alert "Done building BSP CLI transitional package" "${destination}" "debug"
+}
+
+function reversion_armbian-bsp-cli-transitional_deb_contents() {
+	if [[ "${1}" != "armbian-bsp-cli-transitional" ]]; then
+		return 0 # Not our deb, nothing to do.
+	fi
+	display_alert "Reversion" "reversion_armbian-bsp-cli-transitional_deb_contents: '$*'" "debug"
+
+	# Depends on the new package
+	cat <<- EOF >> "${control_file_new}"
+		Depends: ${artifact_name} (= ${REVISION})
+	EOF
+
 }
 
 function compile_armbian-bsp-cli() {
@@ -63,14 +75,6 @@ function compile_armbian-bsp-cli() {
 	declare -a extra_description=()
 	[[ "${EXTRA_BSP_NAME}" != "" ]] && extra_description+=("(variant '${EXTRA_BSP_NAME}')")
 
-	# Replaces: base-files is needed to replace /etc/update-motd.d/ files on Xenial
-	# Depends: linux-base is needed for "linux-version" command in initrd cleanup script
-	# Depends: fping is needed for armbianmonitor to upload armbian-hardware-monitor.log
-	# Depends: base-files (>= ${REVISION}) is to force usage of our base-files package (not the original Distro's).
-	declare depends_base_files=", base-files (>= ${REVISION})"
-	if [[ "${KEEP_ORIGINAL_OS_RELEASE:-"no"}" == "yes" ]]; then
-		depends_base_files=""
-	fi
 	cat <<- EOF > "${destination}"/DEBIAN/control
 		Package: ${artifact_name}
 		Version: ${artifact_version}
@@ -78,10 +82,7 @@ function compile_armbian-bsp-cli() {
 		Maintainer: $MAINTAINER <$MAINTAINERMAIL>
 		Section: kernel
 		Priority: optional
-		Depends: bash, linux-base, u-boot-tools, initramfs-tools, lsb-release, fping${depends_base_files}
 		Suggests: armbian-config
-		Replaces: zram-config, armbian-bsp-cli-${BOARD}${EXTRA_BSP_NAME} (<< ${artifact_version})
-		Breaks: armbian-bsp-cli-${BOARD}${EXTRA_BSP_NAME} (<< ${artifact_version})
 		Recommends: bsdutils, parted, util-linux, toilet
 		Description: Armbian CLI BSP for board '${BOARD}' branch '${BRANCH}' ${extra_description[@]}
 	EOF
@@ -95,7 +96,6 @@ function compile_armbian-bsp-cli() {
 		BOARDFAMILY=${BOARDFAMILY}
 		BUILD_REPOSITORY_URL=${BUILD_REPOSITORY_URL}
 		BUILD_REPOSITORY_COMMIT=${BUILD_REPOSITORY_COMMIT}
-		VERSION=${REVISION}
 		LINUXFAMILY=$LINUXFAMILY
 		ARCH=$ARCHITECTURE
 		IMAGE_TYPE=$IMAGE_TYPE
@@ -104,7 +104,6 @@ function compile_armbian-bsp-cli() {
 		KERNEL_IMAGE_TYPE=$KERNEL_IMAGE_TYPE
 		FORCE_BOOTSCRIPT_UPDATE=$FORCE_BOOTSCRIPT_UPDATE
 		VENDOR=$VENDOR
-		REVISION=$REVISION
 	EOF
 
 	# copy general overlay from packages/bsp-cli
@@ -210,11 +209,51 @@ function compile_armbian-bsp-cli() {
 	fi
 
 	# Build / close the package. This will run shellcheck / show the generated files if debugging
-	fakeroot_dpkg_deb_build "${destination}"
+	fakeroot_dpkg_deb_build "${destination}" "armbian-bsp-cli"
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 
 	display_alert "Done building BSP CLI package" "${destination}" "debug"
+}
+
+# Reversion function is called with the following parameters:
+# ${1} == deb_id
+function reversion_armbian-bsp-cli_deb_contents() {
+	if [[ "${1}" != "armbian-bsp-cli" ]]; then
+		return 0 # Not our deb, nothing to do.
+	fi
+	display_alert "Reversion" "reversion_armbian-bsp-cli_deb_contents: '$*'" "debug"
+
+	# Replaces: base-files is needed to replace /etc/update-motd.d/ files on Xenial
+	# Depends: linux-base is needed for "linux-version" command in initrd cleanup script
+	# Depends: fping is needed for armbianmonitor to upload armbian-hardware-monitor.log
+	# Depends: base-files (>= ${REVISION}) is to force usage of our base-files package (not the original Distro's).
+	declare depends_base_files=", base-files (>= ${REVISION})"
+	if [[ "${KEEP_ORIGINAL_OS_RELEASE:-"no"}" == "yes" ]]; then
+		depends_base_files=""
+	fi
+	cat <<- EOF >> "${control_file_new}"
+		Depends: bash, linux-base, u-boot-tools, initramfs-tools, lsb-release, fping${depends_base_files}
+		Replaces: zram-config, armbian-bsp-cli-${BOARD}${EXTRA_BSP_NAME} (<< ${REVISION})
+		Breaks: armbian-bsp-cli-${BOARD}${EXTRA_BSP_NAME} (<< ${REVISION})
+	EOF
+
+	artifact_deb_reversion_unpack_data_deb
+	: "${data_dir:?data_dir is not set}"
+
+	cat <<- EOF >> "${data_dir}"/etc/armbian-release
+		VERSION=${REVISION}
+		REVISION=$REVISION
+	EOF
+
+	# Show results if debugging
+	if [[ "${SHOW_DEBUG}" == "yes" ]]; then
+		run_tool_batcat --file-name "armbian-release.sh" "${data_dir}"/etc/armbian-release
+	fi
+
+	artifact_deb_reversion_repack_data_deb
+
+	return 0
 }
 
 function get_bootscript_info() {

--- a/lib/functions/bsp/armbian-bsp-desktop-deb.sh
+++ b/lib/functions/bsp/armbian-bsp-desktop-deb.sh
@@ -59,7 +59,7 @@ function compile_armbian-bsp-desktop() {
 	eval "${AGGREGATED_DESKTOP_BSP_PREPARE}"
 	display_alert "Done with bsp-desktop -specific aggregated prepare script" "AGGREGATED_DESKTOP_BSP_PREPARE" "debug"
 
-	fakeroot_dpkg_deb_build "${destination}"
+	fakeroot_dpkg_deb_build "${destination}" "armbian-bsp-desktop"
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 }

--- a/lib/functions/bsp/armbian-bsp-desktop-deb.sh
+++ b/lib/functions/bsp/armbian-bsp-desktop-deb.sh
@@ -59,8 +59,7 @@ function compile_armbian-bsp-desktop() {
 	eval "${AGGREGATED_DESKTOP_BSP_PREPARE}"
 	display_alert "Done with bsp-desktop -specific aggregated prepare script" "AGGREGATED_DESKTOP_BSP_PREPARE" "debug"
 
-	mkdir -p "${DEB_STORAGE}/${RELEASE}"
-	fakeroot_dpkg_deb_build "${destination}" "${DEB_STORAGE}/${RELEASE}"
+	fakeroot_dpkg_deb_build "${destination}"
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 }

--- a/lib/functions/cli/cli-artifact.sh
+++ b/lib/functions/cli/cli-artifact.sh
@@ -84,7 +84,7 @@ function cli_artifact_run() {
 	esac
 
 	# Force artifacts download we need to populate repository
-	if [[ "${FORCE_ARTIFACTS_DOWNLOAD}" == "yes" ]]; then
+	if [[ "${FORCE_ARTIFACTS_DOWNLOAD}" == "yes" ]]; then # @TODO should we remove this, Igor?
 		skip_unpack_if_found_in_caches="no"
 	fi
 
@@ -93,8 +93,13 @@ function cli_artifact_run() {
 
 	if [[ "${ARTIFACT_BUILD_INTERACTIVE}" == "yes" ]]; then # Set by `kernel-config`, `kernel-patch`, `uboot-config`, `uboot-patch`, etc.
 		display_alert "Running artifact build in interactive mode" "log file will be incomplete" "info"
-		do_with_default_build obtain_complete_artifact
+		do_with_default_build cli_obtain_complete_artifact
 	else
-		do_with_default_build obtain_complete_artifact < /dev/null
+		do_with_default_build cli_obtain_complete_artifact < /dev/null
 	fi
+}
+
+function cli_obtain_complete_artifact() {
+	obtain_complete_artifact
+	artifact_reversion_for_deployment
 }

--- a/lib/functions/cli/cli-artifact.sh
+++ b/lib/functions/cli/cli-artifact.sh
@@ -11,7 +11,8 @@ function cli_artifact_pre_run() {
 	case "${ARMBIAN_COMMAND}" in
 		download-artifact)
 			display_alert "download-only mode:" "won't build '${WHAT}'" "info"
-			DONT_BUILD_ARTIFACTS="${WHAT}"
+			declare -g DONT_BUILD_ARTIFACTS="${WHAT}"
+			declare -g KEEP_HASHED_DEB_ARTIFACTS="yes"
 			;;
 	esac
 
@@ -39,67 +40,30 @@ function cli_artifact_run() {
 		obtain_hostrelease_only # Sets HOSTRELEASE
 	fi
 
-	# When run in GHA, assume we're checking/updating the remote cache only.
-	# Local cache is ignored, and if found, it's not unpacked, either from local or remote.
-	# If remote cache is found, does nothing.
-	declare default_update_remote_only="no"
-	if [[ "${CI}" == "true" ]] && [[ "${GITHUB_ACTIONS}" == "true" ]]; then
-		display_alert "Running in GitHub Actions, assuming we're updating remote cache only" "GHA remote-only" "info"
-		default_update_remote_only="yes"
-	fi
-
-	declare skip_unpack_if_found_in_caches="${skip_unpack_if_found_in_caches:-"${default_update_remote_only}"}"
-	declare ignore_local_cache="${ignore_local_cache:-"${default_update_remote_only}"}"
-	declare deploy_to_remote="${deploy_to_remote:-"${default_update_remote_only}"}"
+	declare deploy_to_remote="no"
 
 	case "${ARMBIAN_COMMAND}" in
 		download-artifact)
 			display_alert "Running in download-artifact mode" "download-artifact" "ext"
-			skip_unpack_if_found_in_caches="no"
-			ignore_local_cache="no"
-			deploy_to_remote="no"
 			;;
 		*)
-			# @TODO: rpardini: i'm braindead. I really can't make sense of my own code!
-			# If OCI_TARGET_BASE is explicitly set, ignore local, skip if found in remote, and deploy to remote after build.
-			if [[ -n "${OCI_TARGET_BASE}" ]]; then
-				skip_unpack_if_found_in_caches="yes"
-				ignore_local_cache="yes"
-				deploy_to_remote="yes"
+			# Warn of deprecation...
+			if [[ "${ARTIFACT_USE_CACHE}" == "yes" ]]; then
+				display_alert "deprecated!" "ARTIFACT_USE_CACHE=yes is deprecated, its behaviour is now the default." "warn"
+			fi
 
-				# Pass ARTIFACT_USE_CACHE=yes to actually use the cache versions, but don't deploy to remote.
-				# @TODO this is confusing. each op should be individually controlled...
-				# what we want is:
-				# 1: - check remote, if not found, check local, if not found, build, then deploy to remote
-				#      - if remote found, do nothing.
-				#      - if local found, deploy it to remote (for switching targets)
-				# 2: - get from remote -> get local -> build, then DON'T deploy to remote
-				if [[ "${ARTIFACT_USE_CACHE}" == "yes" ]]; then
-					skip_unpack_if_found_in_caches="no"
-					ignore_local_cache="no"
-					deploy_to_remote="no"
-				fi
+			# If UPLOAD_TO_OCI_ONLY=yes is explicitly set; deploy to remote.
+			if [[ "${UPLOAD_TO_OCI_ONLY}" == "yes" ]]; then
+				display_alert "UPLOAD_TO_OCI_ONLY=yes is set" "UPLOAD_TO_OCI_ONLY=yes; ignoring local cache and deploying to remote" "info"
+				deploy_to_remote="yes"
 			fi
 			;;
 	esac
 
-	# Force artifacts download we need to populate repository
-	if [[ "${FORCE_ARTIFACTS_DOWNLOAD}" == "yes" ]]; then # @TODO should we remove this, Igor?
-		skip_unpack_if_found_in_caches="no"
-	fi
-
-	# display a summary of the 3 vars above: skip_unpack_if_found_in_caches, ignore_local_cache, deploy_to_remote
-	display_alert "CLI Artifact summary" "skip_unpack_if_found_in_caches=${skip_unpack_if_found_in_caches}, ignore_local_cache=${ignore_local_cache}, deploy_to_remote=${deploy_to_remote}" "info"
-
 	if [[ "${ARTIFACT_BUILD_INTERACTIVE}" == "yes" ]]; then # Set by `kernel-config`, `kernel-patch`, `uboot-config`, `uboot-patch`, etc.
 		display_alert "Running artifact build in interactive mode" "log file will be incomplete" "info"
-		do_with_default_build cli_obtain_complete_artifact
+		do_with_default_build obtain_complete_artifact
 	else
-		do_with_default_build cli_obtain_complete_artifact < /dev/null
+		do_with_default_build obtain_complete_artifact < /dev/null
 	fi
-}
-
-function cli_obtain_complete_artifact() {
-	obtain_complete_artifact
-	artifact_reversion_for_deployment
 }

--- a/lib/functions/cli/cli-jsoninfo.sh
+++ b/lib/functions/cli/cli-jsoninfo.sh
@@ -145,9 +145,12 @@ function cli_json_info_run() {
 		if [[ ! -f "${TARGETS_OUTPUT_FILE}" ]]; then
 			display_alert "Generating targets inventory" "targets-compositor" "info"
 			export TARGETS_BETA="${BETA}"                             # Read by the Python script, and injected into every target as "BETA=" param.
+			export TARGETS_REVISION="${REVISION}"                     # Read by the Python script, and injected into every target as "REVISION=" param.
 			export TARGETS_FILTER_INCLUDE="${TARGETS_FILTER_INCLUDE}" # Read by the Python script; used to "only include" targets that match the given string.
 			run_host_command_logged "${PYTHON3_VARS[@]}" "${PYTHON3_INFO[BIN]}" "${INFO_TOOLS_DIR}"/targets-compositor.py "${ALL_BOARDS_ALL_BRANCHES_INVENTORY_FILE}" "not_yet_releases.json" "${TARGETS_FILE}" ">" "${TARGETS_OUTPUT_FILE}"
 			unset TARGETS_BETA
+			unset TARGETS_REVISION
+			unset TARGETS_FILTER_INCLUDE
 		fi
 
 		### Images.
@@ -217,6 +220,7 @@ function cli_json_info_run() {
 		# 1) getting the artifact from OCI only (not build it)
 		# 2) getting the list of .deb's to be published to the repo for that artifact
 		display_alert "Generating deb-to-repo JSON output" "output-debs-to-repo-json" "info"
+		# This produces debs-to-repo-info.json
 		run_host_command_logged "${PYTHON3_VARS[@]}" "${PYTHON3_INFO[BIN]}" "${INFO_TOOLS_DIR}"/output-debs-to-repo-json.py "${BASE_INFO_OUTPUT_DIR}" "${OUTDATED_ARTIFACTS_IMAGES_FILE}"
 		if [[ "${ARMBIAN_COMMAND}" == "debs-to-repo-json" ]]; then
 			display_alert "Done with" "output-debs-to-repo-json" "ext"

--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -231,7 +231,9 @@ function kernel_package_callback_linux_image() {
 	run_host_command_logged rm -v -f "${package_directory}/lib/modules/${kernel_version_family}/build" "${package_directory}/lib/modules/${kernel_version_family}/source"
 
 	display_alert "Showing contents of Kbuild produced modules" "linux-image" "debug"
-	run_host_command_logged tree -C --du -h -d -L 1 "${package_directory}/lib/modules/${kernel_version_family}/kernel" "|| true" # do not fail
+	if [[ -d "${package_directory}/lib/modules/${kernel_version_family}/kernel" ]]; then
+		run_host_command_logged tree -C --du -h -d -L 1 "${package_directory}/lib/modules/${kernel_version_family}/kernel" "|| true" # do not fail
+	fi
 
 	if [[ -d "${tmp_kernel_install_dirs[INSTALL_DTBS_PATH]}" ]]; then
 		# /usr/lib/linux-image-${kernel_version_family} is wanted by flash-kernel, u-boot-menu, and other standard Debian/Ubuntu utilities

--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -41,7 +41,6 @@ if_enabled_echo() {
 
 function prepare_kernel_packaging_debs() {
 	: "${artifact_version:?artifact_version is not set}"
-	: "${kernel_debs_temp_dir:?kernel_debs_temp_dir is not set}"
 
 	declare kernel_work_dir="${1}"
 	declare kernel_dest_install_dir="${2}"
@@ -86,7 +85,6 @@ function prepare_kernel_packaging_debs() {
 }
 
 function create_kernel_deb() {
-	: "${kernel_debs_temp_dir:?kernel_debs_temp_dir is not set}"
 	declare package_name="${1}"
 	declare deb_output_dir="${2}"
 	declare callback_function="${3}"
@@ -140,7 +138,7 @@ function create_kernel_deb() {
 	#display_alert "Package dir" "for package ${package_name}" "debug"
 	#run_host_command_logged tree -C -h -d --du "${package_directory}"
 
-	fakeroot_dpkg_deb_build "${package_directory}" "${kernel_debs_temp_dir}/"
+	fakeroot_dpkg_deb_build "${package_directory}"
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 }

--- a/lib/functions/compilation/kernel.sh
+++ b/lib/functions/compilation/kernel.sh
@@ -144,15 +144,8 @@ function kernel_prepare_build_and_package() {
 	# Fire off the build & package
 	LOG_SECTION="kernel_build" do_with_logging do_with_hooks kernel_build
 
-	# prepare a target dir for the shared, produced kernel .debs, across image/dtb/headers
-	declare cleanup_id_debs="" kernel_debs_temp_dir=""
-	prepare_temp_dir_in_workdir_and_schedule_cleanup "kernel_debs_temp_dir" cleanup_id_debs kernel_debs_temp_dir # namerefs
-
 	LOG_SECTION="kernel_package" do_with_logging do_with_hooks kernel_package
 
-	LOG_SECTION="kernel_deploy_pkg" do_with_logging do_with_hooks kernel_deploy_pkg
-
-	done_with_temp_dir "${cleanup_id_debs}" # changes cwd to "${SRC}" and fires the cleanup function early
 	done_with_temp_dir "${cleanup_id}"      # changes cwd to "${SRC}" and fires the cleanup function early
 }
 
@@ -170,14 +163,9 @@ function kernel_build() {
 
 function kernel_package() {
 	local ts=${SECONDS}
-	cd "${kernel_debs_temp_dir}" || exit_with_error "Can't cd to kernel_debs_temp_dir: ${kernel_debs_temp_dir}"
 	cd "${kernel_work_dir}" || exit_with_error "Can't cd to kernel_work_dir: ${kernel_work_dir}"
 	display_alert "Packaging kernel" "${LINUXFAMILY} ${LINUXCONFIG}" "info"
 	prepare_kernel_packaging_debs "${kernel_work_dir}" "${kernel_dest_install_dir}" "${version}" kernel_install_dirs
 	display_alert "Kernel packaged in" "$((SECONDS - ts)) seconds - ${version}-${LINUXFAMILY}" "info"
 }
 
-function kernel_deploy_pkg() {
-	: "${kernel_debs_temp_dir:?kernel_debs_temp_dir is not set}"
-	run_host_command_logged rsync -v --remove-source-files -r "${kernel_debs_temp_dir}"/*.deb "${DEB_STORAGE}/" # @TODO this stuff... shouldn't it be directly where they should?
-}

--- a/lib/functions/compilation/kernel.sh
+++ b/lib/functions/compilation/kernel.sh
@@ -150,7 +150,6 @@ function kernel_prepare_build_and_package() {
 
 	LOG_SECTION="kernel_package" do_with_logging do_with_hooks kernel_package
 
-	# This deploys to DEB_STORAGE...
 	LOG_SECTION="kernel_deploy_pkg" do_with_logging do_with_hooks kernel_deploy_pkg
 
 	done_with_temp_dir "${cleanup_id_debs}" # changes cwd to "${SRC}" and fires the cleanup function early
@@ -180,5 +179,5 @@ function kernel_package() {
 
 function kernel_deploy_pkg() {
 	: "${kernel_debs_temp_dir:?kernel_debs_temp_dir is not set}"
-	run_host_command_logged rsync -v --remove-source-files -r "${kernel_debs_temp_dir}"/*.deb "${DEB_STORAGE}/"
+	run_host_command_logged rsync -v --remove-source-files -r "${kernel_debs_temp_dir}"/*.deb "${DEB_STORAGE}/" # @TODO this stuff... shouldn't it be directly where they should?
 }

--- a/lib/functions/compilation/packages/armbian-config-deb.sh
+++ b/lib/functions/compilation/packages/armbian-config-deb.sh
@@ -68,7 +68,7 @@ compile_armbian-config() {
 	ln -sf /usr/sbin/armbian-config "${tmp_dir}/${armbian_config_dir}"/usr/bin/armbian-config
 	ln -sf /usr/sbin/softy "${tmp_dir}/${armbian_config_dir}"/usr/bin/softy
 
-	fakeroot_dpkg_deb_build "${tmp_dir}/${armbian_config_dir}"
+	fakeroot_dpkg_deb_build "${tmp_dir}/${armbian_config_dir}" "armbian-config"
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 

--- a/lib/functions/compilation/packages/armbian-config-deb.sh
+++ b/lib/functions/compilation/packages/armbian-config-deb.sh
@@ -68,7 +68,7 @@ compile_armbian-config() {
 	ln -sf /usr/sbin/armbian-config "${tmp_dir}/${armbian_config_dir}"/usr/bin/armbian-config
 	ln -sf /usr/sbin/softy "${tmp_dir}/${armbian_config_dir}"/usr/bin/softy
 
-	fakeroot_dpkg_deb_build "${tmp_dir}/${armbian_config_dir}" "${DEB_STORAGE}"
+	fakeroot_dpkg_deb_build "${tmp_dir}/${armbian_config_dir}"
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 

--- a/lib/functions/compilation/packages/armbian-desktop-deb.sh
+++ b/lib/functions/compilation/packages/armbian-desktop-deb.sh
@@ -58,8 +58,7 @@ function compile_armbian-desktop() {
 	eval "${AGGREGATED_DESKTOP_CREATE_DESKTOP_PACKAGE}"
 	display_alert "Running desktop-specific aggregated prepare script" "AGGREGATED_DESKTOP_CREATE_DESKTOP_PACKAGE" "debug"
 
-	mkdir -p "${DEB_STORAGE}/${RELEASE}"
-	fakeroot_dpkg_deb_build "${destination}" "${DEB_STORAGE}/${RELEASE}"
+	fakeroot_dpkg_deb_build "${destination}"
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 }

--- a/lib/functions/compilation/packages/armbian-desktop-deb.sh
+++ b/lib/functions/compilation/packages/armbian-desktop-deb.sh
@@ -58,7 +58,7 @@ function compile_armbian-desktop() {
 	eval "${AGGREGATED_DESKTOP_CREATE_DESKTOP_PACKAGE}"
 	display_alert "Running desktop-specific aggregated prepare script" "AGGREGATED_DESKTOP_CREATE_DESKTOP_PACKAGE" "debug"
 
-	fakeroot_dpkg_deb_build "${destination}"
+	fakeroot_dpkg_deb_build "${destination}" "armbian-desktop"
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 }

--- a/lib/functions/compilation/packages/armbian-plymouth-theme-deb.sh
+++ b/lib/functions/compilation/packages/armbian-plymouth-theme-deb.sh
@@ -55,7 +55,7 @@ compile_armbian-plymouth-theme() {
 	run_host_command_logged cp "${SRC}"/packages/plymouth-theme-armbian/armbian.plymouth \
 		"${tmp_dir}/${plymouth_theme_armbian_dir}"/usr/share/plymouth/themes/armbian/
 
-	fakeroot_dpkg_deb_build "${tmp_dir}/${plymouth_theme_armbian_dir}" "${DEB_STORAGE}"
+	fakeroot_dpkg_deb_build "${tmp_dir}/${plymouth_theme_armbian_dir}"
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 }

--- a/lib/functions/compilation/packages/armbian-plymouth-theme-deb.sh
+++ b/lib/functions/compilation/packages/armbian-plymouth-theme-deb.sh
@@ -55,7 +55,7 @@ compile_armbian-plymouth-theme() {
 	run_host_command_logged cp "${SRC}"/packages/plymouth-theme-armbian/armbian.plymouth \
 		"${tmp_dir}/${plymouth_theme_armbian_dir}"/usr/share/plymouth/themes/armbian/
 
-	fakeroot_dpkg_deb_build "${tmp_dir}/${plymouth_theme_armbian_dir}"
+	fakeroot_dpkg_deb_build "${tmp_dir}/${plymouth_theme_armbian_dir}" "armbian-plymouth-theme"
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 }

--- a/lib/functions/compilation/packages/armbian-zsh-deb.sh
+++ b/lib/functions/compilation/packages/armbian-zsh-deb.sh
@@ -80,7 +80,7 @@ compile_armbian-zsh() {
 
 	chmod 755 "${tmp_dir}/${armbian_zsh_dir}"/DEBIAN/postinst
 
-	fakeroot_dpkg_deb_build "${tmp_dir}/${armbian_zsh_dir}"
+	fakeroot_dpkg_deb_build "${tmp_dir}/${armbian_zsh_dir}" "armbian-zsh"
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 }

--- a/lib/functions/compilation/packages/armbian-zsh-deb.sh
+++ b/lib/functions/compilation/packages/armbian-zsh-deb.sh
@@ -80,7 +80,7 @@ compile_armbian-zsh() {
 
 	chmod 755 "${tmp_dir}/${armbian_zsh_dir}"/DEBIAN/postinst
 
-	fakeroot_dpkg_deb_build "${tmp_dir}/${armbian_zsh_dir}" "${DEB_STORAGE}"
+	fakeroot_dpkg_deb_build "${tmp_dir}/${armbian_zsh_dir}"
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 }

--- a/lib/functions/compilation/packages/fake_ubuntu_advantage_tools-deb.sh
+++ b/lib/functions/compilation/packages/fake_ubuntu_advantage_tools-deb.sh
@@ -45,9 +45,7 @@ function compile_fake_ubuntu_advantage_tools() {
 
 	cd "${fw_temp_dir}" || exit_with_error "can't change directory"
 
-	# package, directly to DEB_STORAGE; full version might be very big for tmpfs.
-	display_alert "Building fake Ubuntu advantage tools package" "fake_ubuntu_advantage_tools" "info"
-	fakeroot_dpkg_deb_build "fake_ubuntu_advantage_tools" "${DEB_STORAGE}"
+	fakeroot_dpkg_deb_build "fake_ubuntu_advantage_tools"
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 }

--- a/lib/functions/compilation/packages/fake_ubuntu_advantage_tools-deb.sh
+++ b/lib/functions/compilation/packages/fake_ubuntu_advantage_tools-deb.sh
@@ -43,9 +43,7 @@ function compile_fake_ubuntu_advantage_tools() {
 	END
 	chmod 755 DEBIAN/postinst
 
-	cd "${fw_temp_dir}" || exit_with_error "can't change directory"
-
-	fakeroot_dpkg_deb_build "fake_ubuntu_advantage_tools"
+	fakeroot_dpkg_deb_build "${fw_temp_dir}/${fw_dir}" "fake-ubuntu-advantage-tools"
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 }

--- a/lib/functions/compilation/packages/firmware-deb.sh
+++ b/lib/functions/compilation/packages/firmware-deb.sh
@@ -71,9 +71,7 @@ function compile_firmware() {
 
 	cd "${fw_temp_dir}" || exit_with_error "can't change directory"
 
-	# package, directly to DEB_STORAGE; full version might be very big for tmpfs.
-	display_alert "Building firmware package" "armbian-firmware${FULL}" "info"
-	fakeroot_dpkg_deb_build "armbian-firmware${FULL}" "${DEB_STORAGE}"
+	fakeroot_dpkg_deb_build "armbian-firmware${FULL}"
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 }

--- a/lib/functions/compilation/packages/firmware-deb.sh
+++ b/lib/functions/compilation/packages/firmware-deb.sh
@@ -71,7 +71,7 @@ function compile_firmware() {
 
 	cd "${fw_temp_dir}" || exit_with_error "can't change directory"
 
-	fakeroot_dpkg_deb_build "armbian-firmware${FULL}"
+	fakeroot_dpkg_deb_build "armbian-firmware${FULL}" "armbian-firmware${FULL}"
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 }

--- a/lib/functions/compilation/packages/utils-dpkgdeb.sh
+++ b/lib/functions/compilation/packages/utils-dpkgdeb.sh
@@ -7,49 +7,67 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 
-# for RAW deb building. does a bunch of magic to "DEBIAN" directory. Argument is the open package directory. Target is always artifact_base_dir
+# for RAW deb building. does a bunch of magic to "DEBIAN" directory. Arguments are the open package directory and the artifact_deb_id
 function fakeroot_dpkg_deb_build() {
 	# check artifact_name and artifact_version is set otherwise exit_with_error
 	[[ -z "${artifact_name}" ]] && exit_with_error "fakeroot_dpkg_deb_build: artifact_name is not set"
 	[[ -z "${artifact_version}" ]] && exit_with_error "fakeroot_dpkg_deb_build: artifact_version is not set"
-	[[ -z "${artifact_base_dir}" ]] && exit_with_error "fakeroot_dpkg_deb_build: artifact_base_dir is not set"
+	[[ -z "${artifact_deb_repo}" ]] && exit_with_error "fakeroot_dpkg_deb_build: artifact_deb_repo is not set"
 
 	display_alert "Building .deb package" "${artifact_name}: $*" "debug"
 
-	declare first_arg="${1}"
+	declare package_directory="${1}"
+	declare artifact_deb_id="${2}"
 
-	if [[ ! -d "${first_arg}" ]]; then
-		exit_with_error "fakeroot_dpkg_deb_build: can't find source package directory: ${first_arg}"
+	if [[ ! -d "${package_directory}" ]]; then
+		exit_with_error "fakeroot_dpkg_deb_build: can't find source package directory: ${package_directory}"
 	fi
 
-	# Get the basename of the dir
-	declare pkg_name
-	pkg_name=$(basename "${first_arg}")
+	# Check artifact_deb_id is set and not empty
+	if [[ -z "${artifact_deb_id}" ]]; then
+		exit_with_error "fakeroot_dpkg_deb_build: artifact_deb_id (2nd parameter) is not set, called with package_directory: '${package_directory}'"
+	fi
+
+	# Obtain from the globals
+	declare -A -g artifact_map_packages
+	declare -A -g artifact_map_debs
+	debug_dict artifact_map_packages
+	debug_dict artifact_map_debs
+	declare artifact_deb_package="${artifact_map_packages[${artifact_deb_id}]}"
+	declare artifact_deb_rel_path="${artifact_map_debs[${artifact_deb_id}]}"
+
+	# If either is empty, bomb
+	if [[ -z "${artifact_deb_package}" ]]; then
+		exit_with_error "fakeroot_dpkg_deb_build: artifact_deb_package (artifact_map_packages) is not set or found for '${artifact_deb_id}'"
+	fi
+	if [[ -z "${artifact_deb_rel_path}" ]]; then
+		exit_with_error "fakeroot_dpkg_deb_build: artifact_deb_rel_path (artifact_map_debs) is not set or found for '${artifact_deb_id}'"
+	fi
 
 	# Show the total human size of the source package directory.
-	display_alert "Source package size" "${first_arg}: $(du -sh "${first_arg}" | cut -f1)" "debug"
+	display_alert "Source package size" "${package_directory}: $(du -sh "${package_directory}" | cut -f1)" "debug"
 
 	# Lets fix all packages with Installed-Size:
 	# get the size of the package in bytes
 	declare -i pkg_size_bytes
-	pkg_size_bytes=$(du -s -b "${first_arg}" | cut -f1)
+	pkg_size_bytes=$(du -s -b "${package_directory}" | cut -f1)
 	# edit DEBIAN/control, removed any Installed-Size: line
-	sed -i '/^Installed-Size:/d' "${first_arg}/DEBIAN/control"
+	sed -i '/^Installed-Size:/d' "${package_directory}/DEBIAN/control"
 	# add the new Installed-Size: line. The disk space is given as the integer value of the estimated installed size in bytes, divided by 1024 and rounded up.
 	declare -i installed_size
 	installed_size=$(((pkg_size_bytes + 1023) / 1024))
-	echo "Installed-Size: ${installed_size}" >> "${first_arg}/DEBIAN/control"
+	echo "Installed-Size: ${installed_size}" >> "${package_directory}/DEBIAN/control"
 
-	# Lets create DEBIAN/md5sums, for all the files in ${first_arg}. Do not include the paths in the md5sums file. Don't include the DEBIAN/* files.
-	find "${first_arg}" -type f -not -path "${first_arg}/DEBIAN/*" -print0 | xargs -0 md5sum | sed "s|${first_arg}/||g" > "${first_arg}/DEBIAN/md5sums"
+	# Lets create DEBIAN/md5sums, for all the files in ${package_directory}. Do not include the paths in the md5sums file. Don't include the DEBIAN/* files.
+	find "${package_directory}" -type f -not -path "${package_directory}/DEBIAN/*" -print0 | xargs -0 md5sum | sed "s|${package_directory}/||g" > "${package_directory}/DEBIAN/md5sums"
 
 	# Parse the DEBIAN/control and get the real package name...
 	declare control_package_name
-	control_package_name=$(grep -E "^Package:" "${first_arg}/DEBIAN/control" | cut -d' ' -f2)
+	control_package_name=$(grep -E "^Package:" "${package_directory}/DEBIAN/control" | cut -d' ' -f2)
 
 	# generate minimal DEBIAN/changelog
-	cat <<- EOF > "${first_arg}"/DEBIAN/changelog
-		${control_package_name} (${artifact_version}) armbian-repo-name; urgency=low
+	cat <<- EOF > "${package_directory}"/DEBIAN/changelog
+		${control_package_name} (${artifact_version}) ${artifact_deb_repo}; urgency=low
 
 		  * Initial changelog entry for ${control_package_name} package hash ${artifact_version}
 
@@ -57,38 +75,42 @@ function fakeroot_dpkg_deb_build() {
 	EOF
 
 	# Also a usr/share/doc/${control_package_name}/changelog.gz
-	mkdir -p "${first_arg}/usr/share/doc/${control_package_name}"
-	gzip -9 -c "${first_arg}/DEBIAN/changelog" > "${first_arg}/usr/share/doc/${control_package_name}/changelog.gz"
+	mkdir -p "${package_directory}/usr/share/doc/${control_package_name}"
+	gzip -9 -c "${package_directory}/DEBIAN/changelog" > "${package_directory}/usr/share/doc/${control_package_name}/changelog.gz"
 
 	# find the DEBIAN scripts (postinst, prerm, etc) and run shellcheck on them.
-	dpkg_deb_run_shellcheck_on_scripts "${first_arg}"
+	dpkg_deb_run_shellcheck_on_scripts "${package_directory}"
 
 	# Debug, dump the generated postrm/preinst/postinst
 	if [[ "${SHOW_DEBUG}" == "yes" || "${SHOW_DEBIAN}" == "yes" ]]; then
 		# Dump the CONTROL file to the log
-		run_tool_batcat --file-name "${artifact_name}/DEBIAN/control" "${first_arg}/DEBIAN/control"
+		run_tool_batcat --file-name "${artifact_name}/DEBIAN/control" "${package_directory}/DEBIAN/control"
 
-		if [[ -f "${first_arg}/DEBIAN/changelog" ]]; then
-			run_tool_batcat --file-name "${artifact_name}/DEBIAN/changelog" "${first_arg}/DEBIAN/changelog"
+		if [[ -f "${package_directory}/DEBIAN/changelog" ]]; then
+			run_tool_batcat --file-name "${artifact_name}/DEBIAN/changelog" "${package_directory}/DEBIAN/changelog"
 		fi
 
-		if [[ -f "${first_arg}/DEBIAN/postrm" ]]; then
-			run_tool_batcat --file-name "${artifact_name}/DEBIAN/postrm.sh" "${first_arg}/DEBIAN/postrm"
+		if [[ -f "${package_directory}/DEBIAN/postrm" ]]; then
+			run_tool_batcat --file-name "${artifact_name}/DEBIAN/postrm.sh" "${package_directory}/DEBIAN/postrm"
 		fi
 
-		if [[ -f "${first_arg}/DEBIAN/preinst" ]]; then
-			run_tool_batcat --file-name "${artifact_name}/DEBIAN/preinst.sh" "${first_arg}/DEBIAN/preinst"
+		if [[ -f "${package_directory}/DEBIAN/preinst" ]]; then
+			run_tool_batcat --file-name "${artifact_name}/DEBIAN/preinst.sh" "${package_directory}/DEBIAN/preinst"
 		fi
 
-		if [[ -f "${first_arg}/DEBIAN/postinst" ]]; then
-			run_tool_batcat --file-name "${artifact_name}/DEBIAN/postinst.sh" "${first_arg}/DEBIAN/postinst"
+		if [[ -f "${package_directory}/DEBIAN/postinst" ]]; then
+			run_tool_batcat --file-name "${artifact_name}/DEBIAN/postinst.sh" "${package_directory}/DEBIAN/postinst"
 		fi
 
-		run_tool_batcat --file-name "${artifact_name}/DEBIAN/md5sums" "${first_arg}/DEBIAN/md5sums"
+		run_tool_batcat --file-name "${artifact_name}/DEBIAN/md5sums" "${package_directory}/DEBIAN/md5sums"
 	fi
 
-	mkdir -p "${artifact_base_dir}"
-	run_host_command_logged_raw fakeroot dpkg-deb -b "-Z${DEB_COMPRESS}" "${first_arg}" "${artifact_base_dir}/"
+	declare deb_final_filename="${PACKAGES_HASHED_STORAGE}/${artifact_deb_rel_path}"
+	declare deb_final_dir
+	deb_final_dir=$(dirname "${deb_final_filename}")
+
+	mkdir -p "${deb_final_dir}"
+	run_host_command_logged_raw fakeroot dpkg-deb -b "-Z${DEB_COMPRESS}" "${package_directory}" "${deb_final_filename}"
 }
 
 function dpkg_deb_run_shellcheck_on_scripts() {

--- a/lib/functions/compilation/uboot.sh
+++ b/lib/functions/compilation/uboot.sh
@@ -414,7 +414,8 @@ function compile_uboot() {
 		Provides: armbian-u-boot
 		Replaces: armbian-u-boot
 		Conflicts: armbian-u-boot, u-boot-sunxi
-		Description: Das U-Boot for ${BOARD} ${artifact_version_reason:-"${version}"}
+		Description: Das U-Boot for ${BOARD}
+		 ${artifact_version_reason:-"${version}"}
 	EOF
 
 	# copy license files, config, etc.
@@ -424,7 +425,7 @@ function compile_uboot() {
 	[[ -n $atftempdir && -f $atftempdir/license.md ]] && run_host_command_logged cp "${atftempdir}/license.md" "$uboottempdir/usr/lib/u-boot/LICENSE.atf"
 
 	display_alert "Building u-boot deb" "(version: ${artifact_version})"
-	fakeroot_dpkg_deb_build "$uboottempdir"
+	fakeroot_dpkg_deb_build "$uboottempdir" "uboot"
 
 	[[ -n $atftempdir ]] && rm -rf "${atftempdir:?}" # @TODO: intricate cleanup; u-boot's pkg uses ATF's tempdir...
 

--- a/lib/functions/compilation/uboot.sh
+++ b/lib/functions/compilation/uboot.sh
@@ -424,7 +424,7 @@ function compile_uboot() {
 	[[ -n $atftempdir && -f $atftempdir/license.md ]] && run_host_command_logged cp "${atftempdir}/license.md" "$uboottempdir/${uboot_name}/usr/lib/u-boot/LICENSE.atf"
 
 	display_alert "Building u-boot deb" "(version: ${artifact_version})"
-	fakeroot_dpkg_deb_build "$uboottempdir/${uboot_name}" "${DEB_STORAGE}"
+	fakeroot_dpkg_deb_build "$uboottempdir/${uboot_name}"
 
 	[[ -n $atftempdir ]] && rm -rf "${atftempdir:?}" # @TODO: intricate cleanup; u-boot's pkg uses ATF's tempdir...
 

--- a/lib/functions/compilation/uboot.sh
+++ b/lib/functions/compilation/uboot.sh
@@ -280,7 +280,7 @@ function deploy_built_uboot_bins_for_one_target_to_packaging_area() {
 		fi
 		display_alert "${uboot_prefix}Deploying u-boot binary target" "${version} ${target_make} :: ${f_dst}"
 		[[ ! -f $f_src ]] && exit_with_error "U-boot artifact not found" "$(basename "${f_src}")"
-		run_host_command_logged cp -v "${f_src}" "${uboottempdir}/${uboot_name}/usr/lib/${uboot_name}/${f_dst}"
+		run_host_command_logged cp -v "${f_src}" "${uboottempdir}/usr/lib/${uboot_name}/${f_dst}"
 		#display_alert "Done with binary target" "${version} ${target_make} :: ${f_dst}"
 	done
 }
@@ -337,13 +337,13 @@ function compile_uboot() {
 	display_alert "Compiler version" "${UBOOT_COMPILER}gcc '${gcc_version_main}'" "info"
 	[[ -n $toolchain2 ]] && display_alert "Additional compiler version" "${toolchain2_type}gcc $(eval env PATH="${toolchain}:${toolchain2}:${PATH}" "${toolchain2_type}gcc" -dumpfullversion -dumpversion)" "info"
 
-	local uboot_name="${CHOSEN_UBOOT}_${REVISION}_${ARCH}" # @TODO: get rid of CHOSEN_UBOOT
+	local uboot_name="linux-u-boot-${BRANCH}-${BOARD}"
 
 	# create directory structure for the .deb package
 	declare cleanup_id="" uboottempdir=""
 	prepare_temp_dir_in_workdir_and_schedule_cleanup "uboot" cleanup_id uboottempdir # namerefs
 
-	mkdir -p "$uboottempdir/$uboot_name/usr/lib/u-boot" "$uboottempdir/$uboot_name/usr/lib/$uboot_name" "$uboottempdir/$uboot_name/DEBIAN"
+	mkdir -p "$uboottempdir/usr/lib/u-boot" "$uboottempdir/usr/lib/$uboot_name" "$uboottempdir/DEBIAN"
 
 	# Allow extension-based u-boot bulding. We call the hook, and if EXTENSION_BUILT_UBOOT="yes" afterwards, we skip our own compilation.
 	# This is to make it easy to build vendor/downstream uboot with their own quirks.
@@ -370,7 +370,7 @@ function compile_uboot() {
 
 	# set up postinstall script # @todo: extract into a tinkerboard extension
 	if [[ $BOARD == tinkerboard ]]; then
-		cat <<- EOF > "$uboottempdir/${uboot_name}/DEBIAN/postinst"
+		cat <<- EOF > "$uboottempdir/DEBIAN/postinst"
 			#!/bin/bash
 			source /usr/lib/u-boot/platform_install.sh
 			[[ \$DEVICE == /dev/null ]] && exit 0
@@ -390,11 +390,11 @@ function compile_uboot() {
 			fi
 			exit 0
 		EOF
-		chmod 755 "$uboottempdir/${uboot_name}/DEBIAN/postinst"
+		chmod 755 "$uboottempdir/DEBIAN/postinst"
 	fi
 
 	# declare -f on non-defined function does not do anything (but exits with errors, so ignore them with "|| true")
-	cat <<- EOF > "$uboottempdir/${uboot_name}/usr/lib/u-boot/platform_install.sh"
+	cat <<- EOF > "$uboottempdir/usr/lib/u-boot/platform_install.sh"
 		DIR=/usr/lib/$uboot_name
 		$(declare -f write_uboot_platform || true)
 		$(declare -f write_uboot_platform_mtd || true)
@@ -404,7 +404,7 @@ function compile_uboot() {
 	display_alert "Das U-Boot .deb package version" "${artifact_version}" "info"
 
 	# set up control file
-	cat <<- EOF > "$uboottempdir/${uboot_name}/DEBIAN/control"
+	cat <<- EOF > "$uboottempdir/DEBIAN/control"
 		Package: linux-u-boot-${BOARD}-${BRANCH}
 		Version: ${artifact_version}
 		Architecture: $ARCH
@@ -418,13 +418,13 @@ function compile_uboot() {
 	EOF
 
 	# copy license files, config, etc.
-	[[ -f .config && -n $BOOTCONFIG ]] && run_host_command_logged cp .config "$uboottempdir/${uboot_name}/usr/lib/u-boot/${BOOTCONFIG}"
-	[[ -f COPYING ]] && run_host_command_logged cp COPYING "$uboottempdir/${uboot_name}/usr/lib/u-boot/LICENSE"
-	[[ -f Licenses/README ]] && run_host_command_logged cp Licenses/README "$uboottempdir/${uboot_name}/usr/lib/u-boot/LICENSE"
-	[[ -n $atftempdir && -f $atftempdir/license.md ]] && run_host_command_logged cp "${atftempdir}/license.md" "$uboottempdir/${uboot_name}/usr/lib/u-boot/LICENSE.atf"
+	[[ -f .config && -n $BOOTCONFIG ]] && run_host_command_logged cp .config "$uboottempdir/usr/lib/u-boot/${BOOTCONFIG}"
+	[[ -f COPYING ]] && run_host_command_logged cp COPYING "$uboottempdir/usr/lib/u-boot/LICENSE"
+	[[ -f Licenses/README ]] && run_host_command_logged cp Licenses/README "$uboottempdir/usr/lib/u-boot/LICENSE"
+	[[ -n $atftempdir && -f $atftempdir/license.md ]] && run_host_command_logged cp "${atftempdir}/license.md" "$uboottempdir/usr/lib/u-boot/LICENSE.atf"
 
 	display_alert "Building u-boot deb" "(version: ${artifact_version})"
-	fakeroot_dpkg_deb_build "$uboottempdir/${uboot_name}"
+	fakeroot_dpkg_deb_build "$uboottempdir"
 
 	[[ -n $atftempdir ]] && rm -rf "${atftempdir:?}" # @TODO: intricate cleanup; u-boot's pkg uses ATF's tempdir...
 

--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -33,9 +33,6 @@ function do_main_configuration() {
 	declare -g -r REVISION="${REVISION}"
 	display_alert "Using revision from" "${revision_from}: '${REVISION}'" "info"
 
-	# This is the prefix used by all artifacts. Readonly. It's just $REVISION and a double dash.
-	declare -r -g artifact_prefix_version="${REVISION}--"
-
 	[[ -z $VENDOR ]] && VENDOR="Armbian"
 	[[ -z $VENDORURL ]] && VENDORURL="https://www.armbian.com"
 	[[ -z $VENDORSUPPORT ]] && VENDORSUPPORT="https://forum.armbian.com"

--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -80,6 +80,7 @@ function do_main_configuration() {
 	fi
 	display_alert ".deb compression" "DEB_COMPRESS=${DEB_COMPRESS}" "debug"
 
+	declare -g -r PACKAGES_HASHED_STORAGE="${DEST}/packages-hashed"
 	if [[ $BETA == yes ]]; then
 		DEB_STORAGE=$DEST/debs-beta
 	else

--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -21,17 +21,22 @@ function do_main_configuration() {
 	declare -g -r PACKAGE_LIST_DESKTOP
 
 	# common options
-	declare revision_from="undetermined"
-	if [ -f "${USERPATCHES_PATH}"/VERSION ]; then
-		REVISION=$(cat "${USERPATCHES_PATH}"/VERSION)
-		revision_from="userpatches VERSION file"
-	else
-		REVISION=$(cat "${SRC}"/VERSION)
-		revision_from="main VERSION file"
+	declare revision_from="set in env or command-line parameter"
+	if [[ "${REVISION}" == "" ]]; then
+		if [ -f "${USERPATCHES_PATH}"/VERSION ]; then
+			REVISION=$(cat "${USERPATCHES_PATH}"/VERSION)
+			revision_from="userpatches VERSION file"
+		else
+			REVISION=$(cat "${SRC}"/VERSION)
+			revision_from="main VERSION file"
+		fi
 	fi
 
 	declare -g -r REVISION="${REVISION}"
-	display_alert "Using revision from" "${revision_from}: '${REVISION}'" "info"
+	display_alert "Using REVISION from" "${revision_from}: '${REVISION}'" "info"
+	if [[ ! "${REVISION}" =~ ^[0-9] ]]; then
+		exit_with_error "REVISION must begin with a digit, got '${REVISION}'"
+	fi
 
 	[[ -z $VENDOR ]] && VENDOR="Armbian"
 	[[ -z $VENDORURL ]] && VENDORURL="https://www.armbian.com"

--- a/lib/functions/host/mktemp-utils.sh
+++ b/lib/functions/host/mktemp-utils.sh
@@ -22,7 +22,7 @@ function prepare_temp_dir_in_workdir_and_schedule_cleanup() {
 
 	# if no WORKDIR set, or not an existing directory, bail with error
 	if [[ -z "${WORKDIR}" ]] || [[ ! -d "${WORKDIR}" ]]; then
-		exit_with_error "prepare_temp_dir_in_workdir_and_schedule_cleanup: WORKDIR is not set or not a directory: ${temp_dir_id}"
+		exit_with_error "prepare_temp_dir_in_workdir_and_schedule_cleanup: WORKDIR ('${WORKDIR}') is not set or not a directory: ${temp_dir_id}"
 	fi
 
 	nameref_temp_dir="$(mktemp -d --tmpdir "${temp_dir_id}-XXXXX")" # subject to TMPDIR/WORKDIR

--- a/lib/functions/image/rootfs-to-image.sh
+++ b/lib/functions/image/rootfs-to-image.sh
@@ -93,9 +93,9 @@ function create_image_from_sdcard_rootfs() {
 	display_alert "Mount point" "$(echo -e "$freespace" | awk -v mp="${MOUNT}" '$6==mp {print $5}')" "info"
 
 	# stage: write u-boot, unless BOOTCONFIG=none
-	declare -g -A image_artifacts_debs
+	declare -g -A image_artifacts_debs_reversioned
 	if [[ "${BOOTCONFIG}" != "none" ]]; then
-		write_uboot_to_loop_image "${LOOP}" "${DEB_STORAGE}/${image_artifacts_debs["uboot"]}"
+		write_uboot_to_loop_image "${LOOP}" "${DEB_STORAGE}/${image_artifacts_debs_reversioned["uboot"]}"
 	fi
 
 	# fix wrong / permissions

--- a/lib/functions/logging/trap-logging.sh
+++ b/lib/functions/logging/trap-logging.sh
@@ -18,9 +18,9 @@ function trap_handler_cleanup_logging() {
 	# `pwd` might not even be valid anymore. Move back to ${SRC}
 	cd "${SRC}" || exit_with_error "cray-cray about SRC: ${SRC}"
 
-	# Just delete LOGDIR if in CONFIG_DEFS_ONLY mode.
-	if [[ "${CONFIG_DEFS_ONLY}" == "yes" ]]; then
-		display_alert "Discarding logs" "CONFIG_DEFS_ONLY=${CONFIG_DEFS_ONLY}" "debug"
+	# Just delete LOGDIR if in CONFIG_DEFS_ONLY mode, or if ANSI_COLOR is "none".
+	if [[ "${CONFIG_DEFS_ONLY}" == "yes" || "${ANSI_COLOR}" == "none" ]]; then
+		display_alert "Discarding logs" "CONFIG_DEFS_ONLY=${CONFIG_DEFS_ONLY};ANSI_COLOR=${ANSI_COLOR}" "debug"
 		discard_logs_tmp_dir
 		return 0
 	fi

--- a/lib/functions/main/build-packages.sh
+++ b/lib/functions/main/build-packages.sh
@@ -96,6 +96,8 @@ function main_default_build_packages() {
 	declare -g -A image_artifacts_packages_version_reversioned=()
 	declare -g -A image_artifacts_debs=()
 	declare -g -A image_artifacts_debs_reversioned=()
+	declare -A -g image_artifacts_debs_installed=()
+
 	declare one_artifact one_artifact_package
 	for one_artifact in "${artifacts_to_build[@]}"; do
 		declare -A artifact_map_packages=()
@@ -113,12 +115,14 @@ function main_default_build_packages() {
 			image_artifacts_debs_reversioned["${one_artifact_package}"]="${artifact_map_debs_reversioned[${one_artifact_package}]}"
 			image_artifacts_packages_version["${artifact_map_packages[${one_artifact_package}]}"]="${artifact_version}"
 			image_artifacts_packages_version_reversioned["${artifact_map_packages[${one_artifact_package}]}"]="${artifact_final_version_reversioned}"
+			image_artifacts_debs_installed["${one_artifact_package}"]="no" # initialize, install_artifact_deb_chroot() will set to "yes" when installed.
 		done
 	done
 
 	debug_dict image_artifacts_packages
 	debug_dict image_artifacts_debs
 	debug_dict image_artifacts_packages_version
+	debug_dict image_artifacts_debs_installed
 
 	overlayfs_wrapper "cleanup"
 	reset_uid_owner "${DEB_STORAGE}"

--- a/lib/functions/main/build-packages.sh
+++ b/lib/functions/main/build-packages.sh
@@ -93,11 +93,14 @@ function main_default_build_packages() {
 	declare -g -a image_artifacts_all=()
 	declare -g -A image_artifacts_packages=()
 	declare -g -A image_artifacts_packages_version=()
+	declare -g -A image_artifacts_packages_version_reversioned=()
 	declare -g -A image_artifacts_debs=()
+	declare -g -A image_artifacts_debs_reversioned=()
 	declare one_artifact one_artifact_package
 	for one_artifact in "${artifacts_to_build[@]}"; do
 		declare -A artifact_map_packages=()
 		declare -A artifact_map_debs=()
+		declare -A artifact_map_debs_reversioned=()
 		declare artifact_version
 
 		WHAT="${one_artifact}" build_artifact_for_image
@@ -107,7 +110,9 @@ function main_default_build_packages() {
 			image_artifacts_all+=("${one_artifact_package}")
 			image_artifacts_packages["${one_artifact_package}"]="${artifact_map_packages[${one_artifact_package}]}"
 			image_artifacts_debs["${one_artifact_package}"]="${artifact_map_debs[${one_artifact_package}]}"
+			image_artifacts_debs_reversioned["${one_artifact_package}"]="${artifact_map_debs_reversioned[${one_artifact_package}]}"
 			image_artifacts_packages_version["${artifact_map_packages[${one_artifact_package}]}"]="${artifact_version}"
+			image_artifacts_packages_version_reversioned["${artifact_map_packages[${one_artifact_package}]}"]="${artifact_final_version_reversioned}"
 		done
 	done
 

--- a/lib/functions/main/config-prepare.sh
+++ b/lib/functions/main/config-prepare.sh
@@ -211,8 +211,6 @@ function config_post_main() {
 		CRUSTSOURCEDIR="${CRUSTDIR}/$(branch2dir "${CRUSTBRANCH}")"
 	fi
 
-	declare -g CHOSEN_UBOOT=linux-u-boot-${BRANCH}-${BOARD}
-
 	# So for kernel full cached rebuilds.
 	# We wanna be able to rebuild kernels very fast. so it only makes sense to use a dir for each built kernel.
 	# That is the "default" layout; there will be as many source dirs as there are built kernel debs.

--- a/lib/functions/main/rootfs-image.sh
+++ b/lib/functions/main/rootfs-image.sh
@@ -100,15 +100,24 @@ function list_installed_packages() {
 	# This is a sanity check, to make sure that the packages we installed are the ones we expected to install.
 	# Things that might disrupt this: apt repos containing random versions that are then apt upgraded, forced install, crazy customize, wrong pinning, etc.
 	declare -g -A image_artifacts_packages_version # global scope, set in main_default_build_packages()
-	declare pkg_name pkg_wanted_version
-	for pkg_name in "${!image_artifacts_packages_version[@]}"; do
-		[[ "${pkg_name}" =~ ^linux-headers ]] && continue                     # linux-headers is a special case, since its always built with kernel, but not always installed (deb-tar)
+	declare -g -A image_artifacts_debs_installed   # global scope, set in main_default_build_packages()
+	declare -g -A image_artifacts_packages         # global scope, set in main_default_build_packages()
+
+	declare artifact_deb_id pkg_name pkg_wanted_version
+	for artifact_deb_id in "${!image_artifacts_debs_installed[@]}"; do
+		declare deb_is_installed_in_image="${image_artifacts_debs_installed["${artifact_deb_id}"]}"
+		if [[ "${deb_is_installed_in_image}" != "yes" ]]; then
+			continue # skip packages that are not actually installed (eg: kernel-headers, transitional bsp-cli, etc)
+		fi
+		pkg_name="${image_artifacts_packages["${artifact_deb_id}"]}"
 		pkg_wanted_version="${image_artifacts_packages_version[${pkg_name}]}" # this is the hash-version
 		display_alert "Checking installed version of package" "${pkg_name}=${pkg_wanted_version}" "debug"
 		declare actual_version
-		actual_version=$(chroot "${SDCARD}" dpkg-query -W -f='${Status} ${Package} ${Armbian-Original-Hash}\n' "${pkg_name}" | grep "install ok installed" | cut -d " " -f 5)
+		actual_version=$(chroot "${SDCARD}" dpkg-query -W -f='${Status} ${Package} ${Armbian-Original-Hash}\n' "${pkg_name}" | grep " ok installed" | cut -d " " -f 5)
 		if [[ "${actual_version}" != "${pkg_wanted_version}" ]]; then
-			display_alert "Installed hash of package does not match wanted hash. Check for inconsistent repo, customize.sh/hooks, extensions, or upgrades installing wrong version" "${pkg_name} :: actual:'${actual_version}' wanted:'${pkg_wanted_version}'" "warn"
+			declare dpkg_status
+			dpkg_status=$(chroot "${SDCARD}" dpkg-query -W -f='${Status} ${Package} ${Armbian-Original-Hash}\n' "${pkg_name}" || true)
+			display_alert "Installed hash of package does not match wanted hash. Check for inconsistent repo, customize.sh/hooks, extensions, or upgrades installing wrong version" "${pkg_name} :: actual:'${actual_version}' wanted:'${pkg_wanted_version}'; status: '${dpkg_status}'" "warn"
 		else
 			display_alert "Image installed package hash" "✅ ${pkg_name} = ${actual_version}" "info"
 		fi

--- a/lib/functions/main/rootfs-image.sh
+++ b/lib/functions/main/rootfs-image.sh
@@ -102,15 +102,15 @@ function list_installed_packages() {
 	declare -g -A image_artifacts_packages_version # global scope, set in main_default_build_packages()
 	declare pkg_name pkg_wanted_version
 	for pkg_name in "${!image_artifacts_packages_version[@]}"; do
-		[[ "${pkg_name}" =~ ^linux-headers ]] && continue # linux-headers is a special case, since its always built with kernel, but not always installed (deb-tar)
-		pkg_wanted_version="${image_artifacts_packages_version[${pkg_name}]}"
+		[[ "${pkg_name}" =~ ^linux-headers ]] && continue                     # linux-headers is a special case, since its always built with kernel, but not always installed (deb-tar)
+		pkg_wanted_version="${image_artifacts_packages_version[${pkg_name}]}" # this is the hash-version
 		display_alert "Checking installed version of package" "${pkg_name}=${pkg_wanted_version}" "debug"
 		declare actual_version
-		actual_version=$(chroot "${SDCARD}" dpkg-query -W -f='${Status} ${Package} ${Version}\n' "${pkg_name}" | grep "install ok installed" | cut -d " " -f 5)
+		actual_version=$(chroot "${SDCARD}" dpkg-query -W -f='${Status} ${Package} ${Armbian-Original-Hash}\n' "${pkg_name}" | grep "install ok installed" | cut -d " " -f 5)
 		if [[ "${actual_version}" != "${pkg_wanted_version}" ]]; then
-			display_alert "Installed version of package does not match wanted version. Check for inconsistent repo, customize.sh/hooks, extensions, or upgrades installing wrong version" "${pkg_name} :: actual:'${actual_version}' wanted:'${pkg_wanted_version}'" "warn"
+			display_alert "Installed hash of package does not match wanted hash. Check for inconsistent repo, customize.sh/hooks, extensions, or upgrades installing wrong version" "${pkg_name} :: actual:'${actual_version}' wanted:'${pkg_wanted_version}'" "warn"
 		else
-			display_alert "Image installed package version" "✅ ${pkg_name} = ${actual_version}" "info"
+			display_alert "Image installed package hash" "✅ ${pkg_name} = ${actual_version}" "info"
 		fi
 	done
 }

--- a/lib/functions/main/start-end.sh
+++ b/lib/functions/main/start-end.sh
@@ -14,9 +14,7 @@ function main_default_start_build() {
 	produce_repeat_args_array
 	display_alert "Repeat Build Options (early)" "${repeat_args[*]}" "ext"
 
-	if [[ "${PRE_PREPARED_HOST:-"no"}" != "yes" ]]; then
-		prepare_host_init # this has its own logging sections, and is possibly interactive.
-	fi
+	prepare_host_init # this has its own logging sections, and is possibly interactive.
 
 	# Prepare ccache, cthreads, etc for the build
 	LOG_SECTION="prepare_compilation_vars" do_with_logging prepare_compilation_vars
@@ -33,6 +31,9 @@ function main_default_start_build() {
 }
 
 function prepare_host_init() {
+	declare -g start_timestamp # global timestamp; read below by main_default_end_build()
+	start_timestamp=$(date +%s)
+
 	wait_for_disk_sync "before starting build" # fsync, wait for disk to sync, and then continue. alert user if takes too long.
 
 	# Check that WORKDIR_BASE_TMP exists; if not, create it.
@@ -55,32 +56,14 @@ function prepare_host_init() {
 	declare -g -x CCACHE_TEMPDIR="${WORKDIR}/ccache_tmp" # Export CCACHE_TEMPDIR, under Workdir, which is hopefully under tmpfs. Thanks @the-Going for this.
 	declare -g -x XDG_RUNTIME_DIR="${WORKDIR}/xdg_tmp"   # XDG_RUNTIME_DIR is used by the likes of systemd/freedesktop centric apps.
 
-	declare -g start_timestamp # global timestamp; read below by main_default_end_build()
-	start_timestamp=$(date +%s)
+	if [[ "${PRE_PREPARED_HOST:-"no"}" != "yes" ]]; then
+		### Write config summary # @TODO: or not? this is a bit useless
+		LOG_SECTION="config_summary" do_with_logging write_config_summary_output_file
 
-	### Write config summary # @TODO: or not? this is a bit useless
-	LOG_SECTION="config_summary" do_with_logging write_config_summary_output_file
-
-	# Check and install dependencies, directory structure and settings
-	prepare_host # this has its own logging sections, and is possibly interactive.
-
-	# Create a directory inside WORKDIR with a "python" symlink to "/usr/bin/python2"; add it to PATH first.
-	# -> what if there is no python2? bookworm/sid, currently. not long until more
-	# ---> just try to use python3 and hope it works. it probably won't.
-	BIN_WORK_DIR="${WORKDIR}/bin"
-	# No cleanup of this is necessary, since it's inside WORKDIR.
-	mkdir -p "${BIN_WORK_DIR}"
-	if [[ -f "/usr/bin/python2" ]]; then
-		display_alert "Found python2" "symlinking to ${BIN_WORK_DIR}/python" "debug"
-		ln -s "/usr/bin/python2" "${BIN_WORK_DIR}/python"
-	elif [[ -f "/usr/bin/python3" ]]; then
-		display_alert "Found python3" "symlinking to ${BIN_WORK_DIR}/python and ${BIN_WORK_DIR}/python2" "debug"
-		ln -s "/usr/bin/python3" "${BIN_WORK_DIR}/python"
-		ln -s "/usr/bin/python3" "${BIN_WORK_DIR}/python2"
-	else
-		display_alert "No python2 or python3 found" "this is a problem" "error"
+		# Check and install dependencies, directory structure and settings
+		prepare_host # this has its own logging sections, and is possibly interactive.
 	fi
-	declare -g PATH="${BIN_WORK_DIR}:${PATH}"
+
 }
 
 function main_default_end_build() {

--- a/lib/functions/main/start-end.sh
+++ b/lib/functions/main/start-end.sh
@@ -64,6 +64,25 @@ function prepare_host_init() {
 		prepare_host # this has its own logging sections, and is possibly interactive.
 	fi
 
+	# Create a directory inside WORKDIR with a "python" symlink to "/usr/bin/python2"; add it to PATH first.
+	# -> what if there is no python2? bookworm/sid, currently. not long until more
+	# ---> just try to use python3 and hope it works. it probably won't.
+	BIN_WORK_DIR="${WORKDIR}/bin"
+	# No cleanup of this is necessary, since it's inside WORKDIR.
+	mkdir -p "${BIN_WORK_DIR}"
+	if [[ -f "/usr/bin/python2" ]]; then
+		display_alert "Found python2" "symlinking to ${BIN_WORK_DIR}/python" "debug"
+		ln -s "/usr/bin/python2" "${BIN_WORK_DIR}/python"
+	elif [[ -f "/usr/bin/python3" ]]; then
+		display_alert "Found python3" "symlinking to ${BIN_WORK_DIR}/python and ${BIN_WORK_DIR}/python2" "debug"
+		ln -s "/usr/bin/python3" "${BIN_WORK_DIR}/python"
+		ln -s "/usr/bin/python3" "${BIN_WORK_DIR}/python2"
+	else
+		display_alert "No python2 or python3 found" "this is a problem" "error"
+	fi
+	declare -g PATH="${BIN_WORK_DIR}:${PATH}"
+
+	return 0
 }
 
 function main_default_end_build() {

--- a/lib/functions/rootfs/apt-install.sh
+++ b/lib/functions/rootfs/apt-install.sh
@@ -109,3 +109,14 @@ function install_deb_chroot() {
 	# IMPORTANT! Do not use short-circuit above as last statement in a function, since it determines the result of the function.
 	return 0
 }
+
+function install_artifact_deb_chroot() {
+	declare deb_name="$1"
+	declare -A -g image_artifacts_debs_reversioned # global associative array
+	declare revisioned_deb_rel_path="${image_artifacts_debs_reversioned["${deb_name}"]}"
+	if [[ -z "${revisioned_deb_rel_path}" ]]; then
+		exit_with_error "No revisioned deb path found for '${deb_name}'"
+	fi
+	display_alert "Installing artifact deb" "${deb_name} :: ${revisioned_deb_rel_path}" "debug"
+	install_deb_chroot "${DEB_STORAGE}/${revisioned_deb_rel_path}"
+}

--- a/lib/functions/rootfs/apt-install.sh
+++ b/lib/functions/rootfs/apt-install.sh
@@ -106,13 +106,6 @@ function install_deb_chroot() {
 	DONT_MAINTAIN_APT_CACHE="yes" chroot_sdcard_apt_get --no-install-recommends install "${install_target}" # don't auto-maintain apt cache when installing from packages.
 	unset extra_apt_envs
 
-	# @TODO: mysterious. store installed/downloaded packages in deb storage. only used for u-boot deb. why?
-	# this is some contrived way to get the uboot.deb when installing from repo; image builder needs the deb to be able to deploy uboot  later, even though it is already installed inside the chroot, it needs deb to be in host to reuse code later
-	if [[ ${variant} == remote && ${transfer} == yes ]]; then
-		display_alert "install_deb_chroot called with" "transfer=yes, copy WHOLE CACHE back to DEB_STORAGE, this is probably a bug" "warn"
-		run_host_command_logged rsync -r "${SDCARD}"/var/cache/apt/archives/*.deb "${DEB_STORAGE}"/
-	fi
-
 	# IMPORTANT! Do not use short-circuit above as last statement in a function, since it determines the result of the function.
 	return 0
 }

--- a/lib/functions/rootfs/apt-install.sh
+++ b/lib/functions/rootfs/apt-install.sh
@@ -119,4 +119,9 @@ function install_artifact_deb_chroot() {
 	fi
 	display_alert "Installing artifact deb" "${deb_name} :: ${revisioned_deb_rel_path}" "debug"
 	install_deb_chroot "${DEB_STORAGE}/${revisioned_deb_rel_path}"
+
+	# Mark the deb as installed in the global associative array.
+	declare -A -g image_artifacts_debs_installed
+	image_artifacts_debs_installed["${deb_name}"]="yes"
+	debug_dict image_artifacts_debs_installed
 }

--- a/lib/functions/rootfs/distro-specific.sh
+++ b/lib/functions/rootfs/distro-specific.sh
@@ -51,8 +51,7 @@ function install_distribution_specific() {
 			disable_systemd_service_sdcard ondemand.service
 
 			# Remove Ubuntu APT spamming
-			declare -g -A image_artifacts_debs
-			install_deb_chroot "${DEB_STORAGE}/${image_artifacts_debs["fake-ubuntu-advantage-tools"]}"
+			install_artifact_deb_chroot "fake-ubuntu-advantage-tools"
 			truncate --size=0 "${SDCARD}"/etc/apt/apt.conf.d/20apt-esm-hook.conf
 
 			;;
@@ -60,7 +59,7 @@ function install_distribution_specific() {
 
 	# install our base-files package (this replaces the original from Debian/Ubuntu)
 	if [[ "${KEEP_ORIGINAL_OS_RELEASE:-"no"}" != "yes" ]]; then
-		install_deb_chroot "${DEB_STORAGE}/${image_artifacts_debs["armbian-base-files"]}"
+		install_artifact_deb_chroot "armbian-base-files"
 	fi
 
 	# Basic Netplan config. Let NetworkManager/networkd manage all devices on this system

--- a/lib/library-functions.sh
+++ b/lib/library-functions.sh
@@ -141,6 +141,15 @@ source "${SRC}"/lib/functions/artifacts/artifacts-registry.sh
 #set -o nounset   ## set -u : exit the script if you try to use an uninitialised variable - one day will be enabled
 set -o errtrace # trace ERR through - enabled
 set -o errexit  ## set -e : exit the script if any statement returns a non-true return value - enabled
+### lib/functions/artifacts/artifacts-reversion.sh
+# shellcheck source=lib/functions/artifacts/artifacts-reversion.sh
+source "${SRC}"/lib/functions/artifacts/artifacts-reversion.sh
+
+# no errors tolerated. invoked before each sourced file to make sure.
+#set -o pipefail  # trace ERR through pipes - will be enabled "soon"
+#set -o nounset   ## set -u : exit the script if you try to use an uninitialised variable - one day will be enabled
+set -o errtrace # trace ERR through - enabled
+set -o errexit  ## set -e : exit the script if any statement returns a non-true return value - enabled
 ### lib/functions/bsp/armbian-bsp-cli-deb.sh
 # shellcheck source=lib/functions/bsp/armbian-bsp-cli-deb.sh
 source "${SRC}"/lib/functions/bsp/armbian-bsp-cli-deb.sh

--- a/lib/tools/info/output-debs-to-repo-json.py
+++ b/lib/tools/info/output-debs-to-repo-json.py
@@ -36,6 +36,8 @@ def generate_deb_summary(info):
 		out = artifact["out"]
 		artifact_type = out["artifact_type"]
 		artifact_version = out["artifact_version"]
+		artifact_final_version_reversioned = out["artifact_final_version_reversioned"]
+		artifact_deb_repo = out["artifact_deb_repo"]
 
 		if not (artifact_type == "deb" or artifact_type == "deb-tar"):
 			continue
@@ -67,13 +69,16 @@ def generate_deb_summary(info):
 				log.error(f"Error: artifact {artifact_id} has duplicated key {key} in the map: {artifact}")
 				continue
 
-			relative_deb_path = artifact_map_debs_reversioned_values[i]
-			first_part = relative_deb_path.split("/")[1]  # 0 = $REVISION, 1 = repo_target, 2 = artifact_name, 3 = hash, 4 = filename
-			if first_part == "global":
+			if artifact_deb_repo == "global":
 				repo_target = "armbian"
 			else:
-				repo_target = f'armbian-{first_part}'
-			all_debs[key] = {"relative_deb_path": relative_deb_path, "package_name": (artifact_map_packages_values[i]), "repo_target": repo_target}
+				repo_target = f'armbian-{artifact_deb_repo}'
+
+			all_debs[key] = {
+				"relative_deb_path": (artifact_map_debs_reversioned_values[i]),
+				"package_name": (artifact_map_packages_values[i]),
+				"repo_target": repo_target
+			}
 
 		# Aggregate all repo_targets from their debs. There can be only one. Eg: each artifact can only be in one repo_target, no matter how many debs.
 		repo_targets = set()
@@ -90,7 +95,12 @@ def generate_deb_summary(info):
 		invocation = (["download-artifact"] + armbian_utils.map_to_armbian_params(inputs["vars"], False) + inputs["configs"])
 
 		item = {
-			"id": artifact_id, "desc": desc, "artifact_name": artifact_name, "artifact_type": artifact_type, "artifact_version": artifact_version,
+			"id": artifact_id, "desc": desc,
+			"artifact_name": artifact_name,
+			"artifact_type": artifact_type,
+			"artifact_version": artifact_version,
+			"artifact_final_version_reversioned": artifact_final_version_reversioned,
+			"artifact_deb_repo": artifact_deb_repo,
 			"repo_target": repo_target,
 			"download_invocation": invocation,
 			"debs": all_debs

--- a/lib/tools/info/output-debs-to-repo-json.py
+++ b/lib/tools/info/output-debs-to-repo-json.py
@@ -46,14 +46,17 @@ def generate_deb_summary(info):
 		artifact_map_debs_values = out["artifact_map_debs_values_ARRAY"]
 		artifact_map_packages_keys = out["artifact_map_packages_keys_ARRAY"]
 		artifact_map_packages_values = out["artifact_map_packages_values_ARRAY"]
+		artifact_map_debs_reversioned_keys = out["artifact_map_debs_reversioned_keys_ARRAY"]
+		artifact_map_debs_reversioned_values = out["artifact_map_debs_reversioned_values_ARRAY"]
 
 		# Sanity check: all those array should have the same amount of elements.
-		if not (len(artifact_map_debs_keys) == len(artifact_map_debs_values) == len(artifact_map_packages_keys) == len(artifact_map_packages_values)):
+		if not (len(artifact_map_debs_keys) == len(artifact_map_debs_values) == len(artifact_map_packages_keys) ==
+				len(artifact_map_packages_values) == len(artifact_map_debs_reversioned_keys) == len(artifact_map_debs_reversioned_values)):
 			log.error(f"Error: artifact {artifact_id} has different amount of keys and values in the map: {artifact}")
 			continue
 
-		# Sanity check: artifact_map_debs_keys and artifact_map_packages_keys should be the same
-		if not (artifact_map_debs_keys == artifact_map_packages_keys):
+		# Sanity check: all keys should be the same
+		if not (artifact_map_debs_keys == artifact_map_packages_keys == artifact_map_debs_reversioned_keys):
 			log.error(f"Error: artifact {artifact_id} has different keys in the map: {artifact}")
 			continue
 
@@ -64,12 +67,11 @@ def generate_deb_summary(info):
 				log.error(f"Error: artifact {artifact_id} has duplicated key {key} in the map: {artifact}")
 				continue
 
-			relative_deb_path = artifact_map_debs_values[i]
-			repo_target = "armbian"
-			# if the relative_deb_path has a slash "/"...
-			if "/" in relative_deb_path:
-				# ...then it's a repo target
-				first_part = relative_deb_path.split("/")[0]
+			relative_deb_path = artifact_map_debs_reversioned_values[i]
+			first_part = relative_deb_path.split("/")[1]  # 0 = $REVISION, 1 = repo_target, 2 = artifact_name, 3 = hash, 4 = filename
+			if first_part == "global":
+				repo_target = "armbian"
+			else:
 				repo_target = f'armbian-{first_part}'
 			all_debs[key] = {"relative_deb_path": relative_deb_path, "package_name": (artifact_map_packages_values[i]), "repo_target": repo_target}
 

--- a/lib/tools/info/repo-reprepro.py
+++ b/lib/tools/info/repo-reprepro.py
@@ -88,6 +88,8 @@ log.info(f"Wrote {reprepro_conf_options_fn}")
 # Prepare the reprepro-invoking bash script
 bash_lines = [
 	"#!/bin/bash",
+	'set -e',
+	'set -o pipefail',
 	'mkdir -p "${REPO_CONF_LOCATION}"',
 	'cp -rv "${REPREPRO_INFO_DIR}/conf"/* "${REPO_CONF_LOCATION}"/',
 	# run clearvanished

--- a/lib/tools/info/targets-compositor.py
+++ b/lib/tools/info/targets-compositor.py
@@ -119,6 +119,8 @@ for target_name in targets["targets"]:
 			one_invocation_vars.update(item)
 			# Special case for BETA, read this from TARGETS_BETA environment and force it.
 			one_invocation_vars.update({"BETA": os.environ.get("TARGETS_BETA", "")})
+			# Special case for REVISION, read this from TARGETS_REVISION environment and force it.
+			one_invocation_vars.update({"REVISION": os.environ.get("TARGETS_REVISION", "")})
 			expanded = {"vars": one_invocation_vars, "configs": one_expansion["configs"], "pipeline": one_expansion["pipeline"]}
 			invocations_dict.append(expanded)
 


### PR DESCRIPTION
#### hashed-OCI-revisioned-debs: introduce "reversioning" of .deb packages

- trap-logging: just discard logs dir when ANSI_COLOR=none
- repo-reprepro.py: set -e & pipefail
- prepare_host: handle `PRE_PREPARED_HOST` inside `prepare_host_init()` so WORKDIR etc is always available
- kernel-debs: avoid showing `tree` of kernel modules if they've not been built
  - for example `EXT=nomod` causes no modules to be built
- debs: all produced debs now get a placeholder DEBIAN/changelog and a usr/share/doc .gz changelog with hash
- artifacts: don't keep deb-tar's .tar after uploading to OCI
  - they won't ever be used after this, and just accumulate trash for no reason
- hashed-OCI-revisioned-debs: get completely rid of `artifact_prefix_version`
- hashed-OCI-revisioned-debs: build debs in PACKAGES_HASHED_STORAGE, not DEB_STORAGE (temp commit, will be rewritten by a later commit)
  - fakeroot_dpkg_deb_build() now only takes a single argument, the unpacked package dir
- kernel/tmpfs: remove usage of the kernel-specific tmpfs for temporary kernel .deb's, now build directly to packages-hashed dir
- uboot: drop CHOSEN_UBOOT, change deployment directory, remove uboot_name as temp_dir prefix
  - change deployment dir to not include REVISION or ARCH
  - get rid uboot's CHOSEN_UBOOT, REVISION and ARCH in the directory name.
  - no two u-boot debs can be installed in the same machine anyway
- pipeline: output-debs-to-repo-json.py: adapt to new reversioned JSON info
- hashed-OCI-revisioned-debs: introduce "reversioning" of .deb packages
  > tl-dr:
  > - maximize OCI cache hit ratio across nightlies/releases/PRs/etc;
  > - publish simple `Version:`'s that don't include a crazy hash in repo and images
  > - introduce `output/packages-hashed` directory
  > - radically change the `output/debs` directory structure
  - simplify artifact's `prepare_version()` method for `deb` and `deb-tar` artifacts:
    - `artifact_base_dir` and `artifact_final_file` will now be auto-calculated; thus removed from each artifact (except `rootfs`)
    - `artifact_deb_repo` ("global", "jammy", "bookworm") is now required; "global" means common across all RELEASES
    - `artifact_deb_arch` is now required, "all" is arch-independent, otherwise use `${ARCH}`
    - `artifact_map_debs` is now auto-calculated based on the above, and shouldn't be specified manually
    - `artifact_final_version_reversioned` is optional, and can force the final version of the artifact (specific for the `base-files` case)
    - artifacts that need special handling for reversioning can add function names to `artifact_debs_reversion_functions` array (`base-files` and `bsp-cli` cases)
    - artifacts `prepare_version()` should set `artifact_version`, but _never_ include it in other variables; `artifact_version` is now changed by framework after `prepare_version()` returns
  - no longer use/refer/mention `${REVISION}` when building packages. All packages should be `${REVISION}`-agnostic.
  - `${REVISION}` (actually, `artifact_final_version_reversioned`) will be automatically swapped in the `control` file during reversioning
  - `fakeroot_dpkg_deb_build()` now takes exactly two arguments: the directory to pack, and the deb ID (key of `artifact_map_packages` dict); add this change in all the artifact's code for this
  - `obtain_complete_artifact()`:
    - automatically adds `-Rxxxx` "revisioning-hash" to `artifact_version`, by hashing the revisioning functions and any `artifact_debs_reversion_functions` set
    - calculates more complex subdirectory paths for both the `output/packages-hashed` and `output/debs`/`output/debs-beta` directories
      - with the new subdirectories we can be sure a re-version is already done correctly and can skip it (eg, for partial `download-debs` re-runs)
      - in the future we can automatically clean/remove old versions that are no longer relevant based on the dir structure
      - exports a lot more information to JSON, including the new subdirectory paths
    - comment-out code that implemented `skip_unpack_if_found_in_caches`, I'm very unsure why we had this in the first place
  - `obtain_artifact_from_remote_cache()`
    - for `deb` type artifacts, OCI won't preserve the subdirectory structure, so move downloaded files to the correct subdirectory manually
    - this is not needed for `deb-tar`, since that can preserve the dir structure itself
  - introduce `artifacts-reversion.sh` and its main function `artifact_reversion_for_deployment()`
    - this has the logic for reversioning .deb's, by `ar`-unpacking them, changing `control.tar` (and possibly `data.tar`), handling `.xz` compression, etc.
    - also handles hashing those functions, for consistency. Any changes in reversioning code actually change the artifact itself so we're not caught by surprise
    - by default, it changes `control` file only:
      - replace `Version:` (which is the hash-version originally) with `artifact_final_version_reversioned` (which is mostly just `${REVISION}`)
      - add a custom field `Armbian-Original-Hash:` with the original hash-version
    - `artifact_reversion_for_deployment()` is called by
      - new CLI wrapper `cli_obtain_complete_artifact()`, used for CLI building of specific artifact, but also for `download-artifact`
      - `build_artifact_for_image()` used during image build
  - `armbian-bsp-cli-deb.sh`: move `${REVISION}` related stuff from the main package build to new reversioning functions.
  - `artifact-armbian-base-files.sh`: move `${REVISION}` related stuff from the main package build to new reversioning functions.
  - `kernel`:
    - add some custom fields to `DEBIAN/control`:
      - `Armbian-Kernel-Version:` / `Armbian-Kernel-Version-Family:` (for future use: cleanup of usage of `Source: ` field which should be removed)
    - declutter the `Description:` field, moving long description out of the first line
    - obtain `IMAGE_INSTALLED_KERNEL_VERSION` from the reversioned deb (this is still a hack and has not been fixed)
  - `uboot`:
    - declutter the `Description:` field, moving long description out of the first line
    - use the reversioned .deb when deploying u-boot to the image
  - `main_default_build_packages()` now stores reversioned values and complete paths to reversioned .deb's
  - `list_installed_packages()` now compares custom field `Armbian-Original-Hash: `, and not the `Version:` to make sure debs in the image are the ones we want
  - `install_artifact_deb_chroot()` is a new wrapper around `install_deb_chroot()` for easy handling of reversioned debs
    - use it everywhere `install_deb_chroot()` was used in `distro-agnostic.sh` and `distro-specific.sh`
- main-config: allow using `REVISION` from env or command-line param; ensure it begins with digit
- pipeline: force compositor to include `REVISION=` just like it already did for `BETA=`
  - this way the prepare step's REVISION (possibly passed via CLI parameter) is always sovereign
- pipeline: streamline output-debs-to-repo-json to pass down info and avoid parsing paths completely
- artifacts: obtain: back to using flat `output/debs` structure, include revisioned and hashed in filename, but no subdirectories
  - handle the `global` artifact_deb_repo case specially (they go in the root, not subdir)
- adapt `obtain_complete_artifact()` and friends to new reversioned scheme; introduce `UPLOAD_TO_OCI_ONLY=yes` for deploying to remote cache
  > tl-dr: only deploys to remote OCI if `UPLOAD_TO_OCI_ONLY=yes`; stop leaving junk behind in local cache in many situations
  - simplify CLI artifact building parameters and behaviour
      - `ARTIFACT_USE_CACHE` is now deprecated, and its behaviour is the default
      - for _any_ uploading to OCI to occur, `UPLOAD_TO_OCI_ONLY=yes` **must** be present; in this case, reversioning is not done
      - `FORCE_ARTIFACTS_DOWNLOAD` is completely removed (use `download-artifact` instead)
      - `cli_obtain_complete_artifact()`'s and `build_artifact_for_image()`'s reversioning is now moved to common `obtain_complete_artifact()`
  - `standard_artifact_reversion_for_deployment()`:
      - check for hashed deb existence only if reversioned does not exist
      - touch the reversioned file if it already exists; helps to clean up junk later
      - delete hashed version after reversioning, so we don't leave trash behind
          - unless in `download-artifact` mode, which `touch`es the hashed version
          - we can later delete old files from packages-hashed to keep junk under control
  - refactor `obtain_complete_artifact()`
      - extract function `artifact_dump_json_info()` since obtain is large enough already
      - when deploying to remote, always ignore all local and remote caches
      - introduce `artifact_is_available_in_revisioned_local_cache()`
          - if not deploying to remote, and revisioned cache exists, use it directly
          - if deploying to remote, reversioned is not checked and not created
      - if deploying to remote, force `DEB_COMPRESS=xz`
      - if deploying to remote, completely remove the local cache base dir after upload is done (no more junk leftover)
- store dict of artifacts actually installed in image; use it to freeze (`BSPFREEZE=yes`) and check hashes without spurious errors
  - eg: `linux-headers` might, or might not, be installed; same with bsp-cli transitional
  - accidentally fixes [AR-1802]
- start-end: undo unintentional damage done to `python`/`python2` compatibility symlinks inside the `BIN_WORK_DIR`
- kernel: fix: when `KERNEL_SKIP_MAKEFILE_VERSION=yes`, use `1-` prefix for artifact_version (eg `odroidxu4`)
- artifact-{bsp-cli,kernel,uboot}: fix missing `vars_config_hash` "variables hash" in artifact_version_reason

[AR-1802]: https://armbian.atlassian.net/browse/AR-1802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ