### PR TITLE
Internal: repository management parallel execution support

### DIFF
--- a/tools/repository/repo
+++ b/tools/repository/repo
@@ -67,6 +67,7 @@ for release in "${distributions[@]}"; do
 	local forceoverwrite=""
 
 	ADDING_PACKAGES="false"
+# shellcheck disable=SC2207,2199
 	[[ " ${DISTROS[@]} " =~ " ${release} " ]] && ADDING_PACKAGES="true"
 
 	# let's drop from publish if exits
@@ -334,10 +335,6 @@ do
   esac
 done
 
-# define job name
-[[ $(cat /var/run/repomanagement 2>/dev/null) == "$output" ]] && echo "Running. Try again later" && exit 0
-echo "${output}" | sudo tee /var/run/repomanagement &>/dev/null
-
 # redefine output folder in Aptly
 TempDir="$(mktemp -d || exit 1)"
 sed 's|"rootDir": ".*"|"rootDir": "'$output'"|g' tools/repository/aptly.conf > "${TempDir}"/aptly.conf
@@ -346,5 +343,4 @@ CONFIG="${TempDir}/aptly.conf"
 # main
 repo-manipulate "$input" "$output" "$command" "$password" "$releases"
 RETURN=$?
-sudo rm /var/run/repomanagement
 exit $RETURN


### PR DESCRIPTION
# Description

Move executing check from the script. It breaks if script runs for beta and stable at the same machine. Which will be the case.

# Checklist:

- [x] My changes generate no new warnings