### PR TITLE
Disable external wireless drivers on mt7623 legacy

### DIFF
--- a/config/sources/families/mt7623.conf
+++ b/config/sources/families/mt7623.conf
@@ -13,6 +13,7 @@ BOOTPATCHDIR='legacy'
 BOOTBRANCH='tag:v2023.04'
 ARCH=armhf
 ATF_COMPILE="no"
+EXTRAWIFI="no"
 
 case $BRANCH in
 


### PR DESCRIPTION
# Description

As per description. Maintainer on vacations / legacy kernel.

# How Has This Been Tested?

- [x] Build test

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
