### PR TITLE
nanopc t4: set BOOT_SCENARIO to "spl-blobs"

### DIFF
--- a/config/boards/nanopct4.csc
+++ b/config/boards/nanopct4.csc
@@ -7,6 +7,7 @@ FULL_DESKTOP="yes"
 ASOUND_STATE="asound.state.rt5651"
 BOOT_LOGO="desktop"
 BOOT_FDT_FILE="rockchip/rk3399-nanopc-t4.dtb"
+BOOT_SCENARIO="spl-blobs"
 SRC_EXTLINUX="yes"
 SRC_CMDLINE="console=ttyS2,1500000 console=tty0"
 


### PR DESCRIPTION
# Description

Some sd cards are unable to access in uboot when using miniloader.
These cards are able to access when using spl instead.
Spl is not related to DDR initialization so it is unlikely to introduce DDR problems.

# How Has This Been Tested?

- [x] System boots
- [x] 5 minutes stress test

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
