### PR TITLE
move nanoPC-t4 to CSC status and standard rockchip64 kernel

### DIFF
--- a/config/boards/nanopct4.csc
+++ b/config/boards/nanopct4.csc
@@ -1,9 +1,8 @@
 # Rockchip RK3399 hexa core 4GB RAM SoC GBE USB3 USB-C WiFi/BT eMMC NVMe
 BOARD_NAME="NanoPC T4"
-BOARDFAMILY="media"
-BOARD_MAINTAINER="150balbes"
+BOARDFAMILY="rockchip64"
 BOOTCONFIG="nanopc-t4-rk3399_defconfig"
-KERNEL_TARGET="legacy,current,edge"
+KERNEL_TARGET="current,edge"
 FULL_DESKTOP="yes"
 ASOUND_STATE="asound.state.rt5651"
 BOOT_LOGO="desktop"


### PR DESCRIPTION
Maintainer has stepped away from supporting device under Armbian.

moving nanopc-t4 to CSC status...  updating to use standard rockchip64 current and edge kernels... verified both work fine.