### PR TITLE
extensions: `image-output-oowow`: creates Khadas oowow compatible images

### DIFF
--- a/config/boards/khadas-edge2.conf
+++ b/config/boards/khadas-edge2.conf
@@ -10,6 +10,8 @@ declare -g BOOT_FDT_FILE="rockchip/rk3588s-khadas-edge2.dtb" # Specific to this 
 declare -g BLUETOOTH_HCIATTACH_PARAMS="-s 115200 /dev/ttyS9 bcm43xx 1500000" # For the bluetooth-hciattach extension
 enable_extension "bluetooth-hciattach"                                       # Enable the bluetooth-hciattach extension
 
+declare -g KHADAS_OOWOW_BOARD_ID="Edge2" # for use with EXT=output-image-oowow
+
 # for the kedge2, we're counting on the blobs+u-boot in SPI working, as it comes from factory. It does not support bootscripts.
 function post_family_config_branch_legacy__uboot_kedge2() {
 	display_alert "$BOARD" "Configuring ($BOARD) non-u-boot" "info"

--- a/config/boards/khadas-vim1s.wip
+++ b/config/boards/khadas-vim1s.wip
@@ -10,5 +10,7 @@ SERIALCON="ttyS0" # for vendor kernel
 BOOTCONFIG="kvim1s_defconfig"
 KHADAS_BOARD_ID="kvim1s" # used to compile the fip blobs
 
+declare -g KHADAS_OOWOW_BOARD_ID="VIM1S" # for use with EXT=output-image-oowow
+
 # Use extlinux and u-boot-menu extension
 SRC_CMDLINE="console=tty0 console=ttyS0,921600 no_console_suspend earlycon=aml-uart,0xfe078000 meson-gx-mmc.caps2_quirks=mmc-hs400 mac=\\\${eth_mac} khadas.serial=\\\${usid} partition_type=generic"

--- a/config/boards/khadas-vim3.conf
+++ b/config/boards/khadas-vim3.conf
@@ -13,6 +13,8 @@ ASOUND_STATE="asound.state.khadas-vim3"
 BOOTBRANCH_BOARD="tag:v2023.07-rc4"
 BOOTPATCHDIR="v2023.07"
 
+declare -g KHADAS_OOWOW_BOARD_ID="VIM3" # for use with EXT=output-image-oowow
+
 # To enable the SPI NOR the -spi .dtb is required, because eMMC shares a pin with SPI on the VIM3. To use it:
 # fdtfile=amlogic/meson-g12b-a311d-khadas-vim3-spinor.dtb # in armbianEnv.txt and reboot, then run armbian-install
 # After deploying to SPI-NOR/MTD, return back to the normal DTB, otherwise eMMC speed is impaired.

--- a/config/boards/khadas-vim3l.conf
+++ b/config/boards/khadas-vim3l.conf
@@ -13,6 +13,8 @@ ASOUND_STATE="asound.state.khadas-vim3l"
 BOOTBRANCH_BOARD="tag:v2023.07-rc4"
 BOOTPATCHDIR="v2023.07"
 
+declare -g KHADAS_OOWOW_BOARD_ID="VIM3L" # for use with EXT=output-image-oowow
+
 # To enable the SPI NOR the -spi .dtb is required, because eMMC shares a pin with SPI on the VIM3. To use it:
 # fdtfile=amlogic/meson-sm1-khadas-vim3l-spinor.dtb # in armbianEnv.txt and reboot, then run armbian-install
 # After deploying to SPI-NOR/MTD, return back to the normal DTB, otherwise eMMC speed is impaired.

--- a/config/boards/khadas-vim4.wip
+++ b/config/boards/khadas-vim4.wip
@@ -10,5 +10,7 @@ SERIALCON="ttyS0" # for vendor kernel
 BOOTCONFIG="kvim4_defconfig"
 KHADAS_BOARD_ID="kvim4" # used to compile the fip blobs
 
+declare -g KHADAS_OOWOW_BOARD_ID="VIM4" # for use with EXT=output-image-oowow
+
 # Use extlinux and u-boot-menu extension
 SRC_CMDLINE="console=tty0 console=ttyS0,921600 no_console_suspend earlycon=aml-uart,0xfe078000 mac=\\\${eth_mac} khadas.serial=\\\${usid} partition_type=generic"

--- a/extensions/image-output-oowow.sh
+++ b/extensions/image-output-oowow.sh
@@ -1,0 +1,81 @@
+#
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (c) 2023 Ricardo Pardini <ricardo@pardini.net>
+# This file is a part of the Armbian Build Framework https://github.com/armbian/build/
+#
+
+# This converts the output image to the Khadas OOWOW format.
+# This format is already compressed with special xz parameters, so COMPRESS_OUTPUTIMAGE is forced to "none".
+
+function extension_prepare_config__prepare_oowow_config() {
+	display_alert "Preparing config" "${EXTENSION}" "info"
+
+	# Disable compression, but keep sha sum if specified;
+	if [[ "${COMPRESS_OUTPUTIMAGE}" == *sha* ]]; then
+		declare -g COMPRESS_OUTPUTIMAGE="sha"
+	else
+		declare -g COMPRESS_OUTPUTIMAGE="none"
+	fi
+
+	# make sure we have the board parameters needed to convert to oowow
+	if [[ "${KHADAS_OOWOW_BOARD_ID}" == "" ]]; then
+		exit_with_error "KHADAS_OOWOW_BOARD_ID is not set, can't use ${EXTENSION}"
+	else
+		display_alert "Configured" "${EXTENSION} for Khadas board ID '${KHADAS_OOWOW_BOARD_ID}'" "info"
+	fi
+
+	return 0
+}
+
+function post_build_image__900_convert_to_oowow() {
+	[[ -z $version ]] && exit_with_error "version is not set"
+
+	declare original_image_file="${DESTIMG}/${version}.img"
+	declare oowow_final_output_file="${DESTIMG}/${version}.oowow.img.xz" # Can't change ${version} prefix
+
+	# Get xze script from Khadas.
+	declare xze_revision="e24a30d2780f3c772ae80ac9495d91273d63b95e" # update this if/when Khadas releases new version
+	declare xze_raw_url="https://raw.githubusercontent.com/khadas/krescue/${xze_revision}/tools/xze"
+	declare xze_tool_dir="${SRC}/cache/khadas-xze"
+	declare xze_tool="${xze_tool_dir}/xze-${xze_revision}"
+	if [[ ! -f "${xze_tool}" ]]; then
+		display_alert "Downloading xze tool" "from Khadas" "info"
+		run_host_command_logged mkdir -p "${xze_tool_dir}"
+		run_host_command_logged wget -O "${xze_tool}" "${xze_raw_url}"
+		run_host_command_logged chmod +x "${xze_tool}"
+	fi
+
+	declare xze_params=(
+		"--meta"
+		"label=Armbian"
+		"builder=Armbian"
+		"date=$(LANG=C TZ='' date)"
+		"match=BOARD=${KHADAS_OOWOW_BOARD_ID}"
+		"link=https://www.armbian.com/"
+		"duration=60"
+		"desc=Armbian ${BOARD} ${RELEASE} ${BRANCH} ${REVISION}"
+	)
+
+	display_alert "Converting image to Khadas OOWOW format" "${EXTENSION} :: ${KHADAS_OOWOW_BOARD_ID}" "info"
+	cd "${DESTIMG}" || exit_with_error "Could not cd to ${DESTIMG}"
+	# xze is pretty confused about fd 1, so we need to pass "IN" and "OUT" env vars
+	run_host_command_logged "IN=${original_image_file}" "OUT=${oowow_final_output_file}" bash "${xze_tool}" "-3" "${original_image_file}" "${xze_params[@]@Q}" # @Q to double escape for runner; -3 for fast compression
+	cd "${SRC}" || exit_with_error "Could not cd to ${SRC}"
+
+	if [[ ! -f "${oowow_final_output_file}" ]]; then
+		exit_with_error "xze did not produce the expected output file: ${oowow_final_output_file}"
+	fi
+
+	# Remove the original, uncompressed file.
+	display_alert "Discarding original .img image after" "conversion to oowow" "info"
+	run_host_command_logged rm -vf "${original_image_file}"
+
+	# Show the final metadata and compression info.
+	display_alert "Final produced oowow image" "compression and meta info" "info"
+	run_host_command_logged bash "${xze_tool}" "${oowow_final_output_file}"
+
+	# Alert about the prefix requirement for removable media.
+	display_alert "To use oowow with removable media" "rename file on media to '${KHADAS_OOWOW_BOARD_ID,,}-${version}.oowow.img.xz'"
+
+	return 0
+}


### PR DESCRIPTION
#### extensions: `image-output-oowow`: creates Khadas oowow compatible images

- extensions: `image-output-oowow`: creates Khadas oowow compatible images
  - requires `KHADAS_OOWOW_BOARD_ID` set in board file (see next commit)
  - always produces xz-compressed images, so this automatically disables `COMPRESS_OUTPUTIMAGE`
  - uses `xze` script from Khadas, forcing `IN` and `OUT` env vars so it's not confused by fd 1
  - to use, add `EXT=image-output-oowow` parameter to build
  - to get into oowow:
      - VIM3/VIM3L:
          - download oowow SD card image from Khadas:
              - VIM3: https://dl.khadas.com/products/oowow/system/vim3-oowow-latest-sd.img.gz
              - VIM3L: https://dl.khadas.com/products/oowow/system/vim3l-oowow-latest-sd.img.gz
          - write image to SD card, use BalenaEtcher or similar
          - insert SD card into board (and remove NVMe if present and bootable)
          - boot board into Upgrade mode, see https://docs.khadas.com/products/sbc/vim3/install-os/boot-into-upgrade-mode
          - oowow should be running now
          - recommended: go into Advanced and reset to factory defaults, so MCU, PCIe/USB3 etc is reset to defaults
      - VIM4/VIM4N/VIM1S/Edge2: those have oowow in SPI from factory, check out the manual
  - there's a few ways to use these images with oowow:
      - Using External media
          - prepare media (USB), format it with ext4 or fat, copy produced oowow.img.xz to it
              - for ease of use, rename the image file, so it begins with the board-id (`vim1s-/vim4-/edge2-` etc)
          - boot board into oowow  (see oowow's manual)
          - insert media into board
          - exit wizard, use "Write image to eMMC", browse to "../"
              - change from "XXXX only" to "All" if you didn't rename the image
          - choose image file and write
          - (remove SD card if using one) and reboot
      - Via network (Ethernet or Wi-Fi)
          - boot board into oowow
          - plug in Ethernet cable or connect to Wi-Fi (see oowow's manual)
          - set the firewall mode to "allow" in oowow's Network Settings (see oowow's manual)
          - obtain the IP address of the board in oowow (usually shown on top of the screen, or see manual)
          - from a remote machine, use curl to upload and write the image to oowow's eMMC, example:
              - `curl -L <ip_address>/shell/write | sh -s - <image_filename>.oowow.img.xz`
          - reboot board
      - From the Internet (one day)
          - when Khadas publishes Armbian oowow images to their HTTP server
- khadas boards: VIM1S/3/3L/4/Edge2: add `KHADAS_OOWOW_BOARD_ID` definition for use with oowow (`EXT=image-output-oowow`)