### PR TITLE
utils-dpkgdeb: Add alert for compressing

### DIFF
--- a/lib/functions/compilation/packages/utils-dpkgdeb.sh
+++ b/lib/functions/compilation/packages/utils-dpkgdeb.sh
@@ -110,7 +110,7 @@ function fakeroot_dpkg_deb_build() {
 	deb_final_dir=$(dirname "${deb_final_filename}")
 
 	mkdir -p "${deb_final_dir}"
-	display_alert "Building package '${deb_final_filename/*\//}', this might take a while.." info
+ 	display_alert "Building package, this might take a while.." "${deb_final_filename/*\//}" info
 	run_host_command_logged_raw fakeroot dpkg-deb -b "-Z${DEB_COMPRESS}" "${package_directory}" "${deb_final_filename}"
 }
 

--- a/lib/functions/compilation/packages/utils-dpkgdeb.sh
+++ b/lib/functions/compilation/packages/utils-dpkgdeb.sh
@@ -110,6 +110,7 @@ function fakeroot_dpkg_deb_build() {
 	deb_final_dir=$(dirname "${deb_final_filename}")
 
 	mkdir -p "${deb_final_dir}"
+	display_alert "Compressing package directories, this make take some time.."
 	run_host_command_logged_raw fakeroot dpkg-deb -b "-Z${DEB_COMPRESS}" "${package_directory}" "${deb_final_filename}"
 }
 

--- a/lib/functions/compilation/packages/utils-dpkgdeb.sh
+++ b/lib/functions/compilation/packages/utils-dpkgdeb.sh
@@ -110,7 +110,7 @@ function fakeroot_dpkg_deb_build() {
 	deb_final_dir=$(dirname "${deb_final_filename}")
 
 	mkdir -p "${deb_final_dir}"
-	display_alert "Compressing package directories, this make take some time.."
+	display_alert "Building package '${deb_final_filename/*\//}', this might take a while.." info
 	run_host_command_logged_raw fakeroot dpkg-deb -b "-Z${DEB_COMPRESS}" "${package_directory}" "${deb_final_filename}"
 }
 


### PR DESCRIPTION
# Description

The command takes long time to continue and it makes it seem like the build halted, so this adds an alert to mitigate this

![image](https://github.com/armbian/build/assets/11302521/9ac663ef-0d12-4c9e-b262-d60aef94208d)

```
--> (3) COMMAND: fakeroot dpkg-deb -b -Znone /armbian/.tmp/work-cfd2d6ad-1f9b-473e-80e7-cbcf9d157c68/uboot-Bd1Ms /armbian/output/packages-hashed/gl>
dpkg-deb: building package 'linux-u-boot-sipeed-lichee-pi-4a-current' in '/armbian/output/packages-hashed/global/linux-u-boot-sipeed-lichee-pi-4>
--> (372) INFO: Built u-boot deb OK [ linux-u-boot-sipeed-lichee-pi-4a-current 2022.07-Se092-P0000-H6f49-V9cb9-B9963-R448a ]
```

Jira reference number [AR-9999]

# How Has This Been Tested?

Builds on my end

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
