### PR TITLE
`riscv64` Removing deprecated exceptions for Debian Sid

### DIFF
--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -338,11 +338,6 @@ function do_extra_configuration() {
 		fi
 	fi
 
-	# Debian needs the ports repo when strapping riscv64 - revise after bookworm release
-	if [[ "${ARCH}" == "riscv64" ]] && [[ $DISTRIBUTION == Debian ]]; then
-		DEBIAN_MIRROR='deb.debian.org/debian-ports'
-	fi
-
 	# Control aria2c's usage of ipv6.
 	[[ -z $DISABLE_IPV6 ]] && DISABLE_IPV6="true"
 

--- a/lib/functions/general/apt-utils.sh
+++ b/lib/functions/general/apt-utils.sh
@@ -12,7 +12,6 @@ function apt_find_upstream_package_version_and_download_url() {
 	declare -a package_info_download_urls=()
 	declare first_letter_of_sought_package_name="${sought_package_name:0:1}"
 	declare mirror_with_slash="undetermined/"
-	declare pool_name_extension=""
 
 	case "${DISTRIBUTION}" in
 		Ubuntu) # try both the jammy-updates and jammy repos, use whatever returns first
@@ -24,7 +23,6 @@ function apt_find_upstream_package_version_and_download_url() {
 		Debian)
 			package_info_download_urls+=("https://packages.debian.org/${RELEASE}/${ARCH}/${sought_package_name}/download")
 			mirror_with_slash="${DEBIAN_MIRROR}"
-			[[ "${ARCH}" == riscv64 ]] && pool_name_extension="-riscv64"
 			;;
 
 		*)
@@ -37,10 +35,7 @@ function apt_find_upstream_package_version_and_download_url() {
 		mirror_with_slash="${mirror_with_slash}/"
 	fi
 
-	# riscv64 under Debian needs exception
-
-
-	declare base_down_url="http://${mirror_with_slash}pool${pool_name_extension}/main/${first_letter_of_sought_package_name}/${sought_package_name}"
+	declare base_down_url="http://${mirror_with_slash}pool/main/${first_letter_of_sought_package_name}/${sought_package_name}"
 
 	declare index package_info_download_url
 	# loop over the package_info_download_urls with index and value

--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -322,7 +322,7 @@ function adaptative_prepare_host_dependencies() {
 
 	if [[ "${wanted_arch}" == "riscv64" || "${wanted_arch}" == "all" ]]; then
 		host_dependencies+=("gcc-riscv64-linux-gnu")        # crossbuild-essential-riscv64 is not even available "yet"
-		host_dependencies+=("debian-ports-archive-keyring") # Debian Ports keyring needed, as riscv64 is not released yet
+		host_dependencies+=("debian-archive-keyring")
 	fi
 
 	if [[ "${wanted_arch}" != "amd64" ]]; then

--- a/lib/functions/rootfs/distro-specific.sh
+++ b/lib/functions/rootfs/distro-specific.sh
@@ -159,6 +159,12 @@ function create_sources_list_and_deploy_repo_key() {
 				deb http://${DEBIAN_MIRROR} unstable main contrib non-free non-free-firmware
 				#deb-src http://${DEBIAN_MIRROR} unstable main contrib non-free non-free-firmware
 			EOF
+
+				# Exception: with riscv64 not everything was moved from ports
+				# https://lists.debian.org/debian-riscv/2023/07/msg00053.html
+				if [[ "${ARCH}" == riscv64 ]]; then
+					echo "deb http://deb.debian.org/debian-ports/ sid main " >> "${basedir}"/etc/apt/sources.list
+				fi
 			;;
 
 		focal | jammy | kinetic | lunar)

--- a/lib/functions/rootfs/rootfs-create.sh
+++ b/lib/functions/rootfs/rootfs-create.sh
@@ -80,20 +80,6 @@ function create_new_rootfs_cache_via_debootstrap() {
 
 	deboostrap_arguments+=("--foreign") # release name
 
-	# Debian does not carry riscv64 in their main repo, needs ports, which needs a specific keyring in the host.
-	# that's done in prepare-host.sh when by adding debian-ports-archive-keyring hostdep, but there's an if anyway.
-	# debian-ports-archive-keyring is also included in-image by: config/optional/architectures/riscv64/_config/cli/_all_distributions/main/packages
-	# Revise this after bookworm release.
-	# @TODO: rpardini: this clearly shows a need for hooks for debootstrap
-	if [[ "${ARCH}" == "riscv64" ]] && [[ $DISTRIBUTION == Debian ]]; then
-		if [[ -f /usr/share/keyrings/debian-ports-archive-keyring.gpg ]]; then
-			display_alert "Adding ports keyring for Debian debootstrap" "riscv64" "info"
-			deboostrap_arguments+=("--keyring" "/usr/share/keyrings/debian-ports-archive-keyring.gpg")
-		else
-			exit_with_error "Debian debootstrap for riscv64 needs debian-ports-archive-keyring hostdep"
-		fi
-	fi
-
 	deboostrap_arguments+=("${RELEASE}" "${SDCARD}/" "${debootstrap_apt_mirror}") # release, path and mirror; always last, positional arguments.
 
 	run_host_command_logged debootstrap "${deboostrap_arguments[@]}" || {


### PR DESCRIPTION
# Description

Debian moved riscv64 into 1st class so exceptions are not needed. But ports repository is still needed in the lists file as they didn't manage to move everything.

Jira reference number [AR-1824]

# How Has This Been Tested?

- [x] Generated image with clean rootfs `Armbian_23.08.0-trunk_Star64_sid_edge_5.15.0.img`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1824]: https://armbian.atlassian.net/browse/AR-1824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ