### PR TITLE
RK OC overlays for 6.4 update

### DIFF
--- a/patch/kernel/archive/rockchip64-6.4/overlay/rockchip-rk3328-opp-1.4ghz.dts
+++ b/patch/kernel/archive/rockchip64-6.4/overlay/rockchip-rk3328-opp-1.4ghz.dts
@@ -3,7 +3,7 @@
 / {
     compatible = "rockchip,rk3328";
     fragment@0 {
-        target-path = "/opp_table0";
+        target-path = "/opp-table-0";
         __overlay__ {
 		opp-1392000000 {
 			opp-hz = /bits/ 64 <1392000000>;

--- a/patch/kernel/archive/rockchip64-6.4/overlay/rockchip-rk3328-opp-1.5ghz.dts
+++ b/patch/kernel/archive/rockchip64-6.4/overlay/rockchip-rk3328-opp-1.5ghz.dts
@@ -3,7 +3,7 @@
 / {
     compatible = "rockchip,rk3328";
     fragment@0 {
-        target-path = "/opp_table0";
+        target-path = "/opp-table-0";
         __overlay__ {
 		opp-1512000000 {
 			opp-hz = /bits/ 64 <1512000000>;

--- a/patch/kernel/archive/rockchip64-6.4/overlay/rockchip-rk3399-opp-2ghz.dts
+++ b/patch/kernel/archive/rockchip64-6.4/overlay/rockchip-rk3399-opp-2ghz.dts
@@ -3,7 +3,7 @@
 / {
     compatible = "rockchip,rk3399";
     fragment@0 {
-        target-path = "/opp-table0";
+        target-path = "/opp-table-0";
         __overlay__ {
 		opp06 {
 			opp-hz = /bits/ 64 <1512000000>;
@@ -13,7 +13,7 @@
     };
 
     fragment@1 {
-        target-path = "/opp-table1";
+        target-path = "/opp-table-1";
         __overlay__ {
 		opp08 {
 			opp-hz = /bits/ 64 <2016000000>;


### PR DESCRIPTION
# Description

I thought edge would carry the fixes forward, missed 6.4 folder.

# How Has This Been Tested?

Carryover from 6.3

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
