### PR TITLE
`Internal` Add functionality to delete packages from a list

### DIFF
--- a/tools/repository/repo
+++ b/tools/repository/repo
@@ -164,7 +164,7 @@ fi
 # $3: Command
 # $4: GPG password
 # $5: jammy,sid
-#
+# $6: list of packages to delete
 repo-manipulate() {
 
 # read comma delimited distros into array
@@ -193,6 +193,18 @@ case $3 in
 		cat tools/repository/footer.html
 		return 0
 	;;
+
+        delete)
+                for release in "${DISTROS[@]}"; do
+                        echo "Deleting $6 from $release"
+                        aptly -config="${CONFIG}" repo remove "${release}" "$6"
+                        echo "Deleting $6 from $release-utils"
+                        aptly -config="${CONFIG}" repo remove "${release}-utils" "$6"
+                        echo "Deleting $6 from $release-desktop"
+                        aptly -config="${CONFIG}" repo remove "${release}-desktop" "$6"
+                done
+                return 0
+        ;;
 
 	show)
 
@@ -279,6 +291,7 @@ Usage: $0 [ -short | --long ]
 -o --output [output folder]
 -p --password [GPG password]
 -r --repository [jammy,sid,bullseye,...]
+-l --list [\"Name (% linux*)|armbian-config\"]
 -c --command
 
           [show] displays packages in each repository
@@ -286,12 +299,13 @@ Usage: $0 [ -short | --long ]
           [serve] serve repository - useful for local diagnostics
           [unique] manually select which package should be removed from all repositories
           [update] search for packages in input folder
+          [delete] delete package from -l LIST of packages
 	"
     exit 2
 }
 
-SHORT=i:,o:,c:,p:,r:,h
-LONG=input:,output:,command:,password:,releases:,help
+SHORT=i:,l:,o:,c:,p:,r:,h
+LONG=input:,list:,output:,command:,password:,releases:,help
 OPTS=$(getopt -a -n repo --options $SHORT --longoptions $LONG -- "$@")
 
 VALID_ARGUMENTS=$# # Returns the count of arguments that are in short or long options
@@ -321,6 +335,10 @@ do
       releases="$2"
       shift 2
       ;;
+    -l | --list )
+      list="$2"
+      shift 2
+      ;;
     -h | --help)
       help
       ;;
@@ -341,6 +359,6 @@ sed 's|"rootDir": ".*"|"rootDir": "'$output'"|g' tools/repository/aptly.conf > "
 CONFIG="${TempDir}/aptly.conf"
 
 # main
-repo-manipulate "$input" "$output" "$command" "$password" "$releases"
+repo-manipulate "$input" "$output" "$command" "$password" "$releases" "$list"
 RETURN=$?
 exit $RETURN


### PR DESCRIPTION
# Description

Expanding repository manipulation wrapper to delete a list of packages from all pools. Comes handy in some cases.

# How Has This Been Tested?

- [x] Manual run

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings