### PR TITLE
general: extra: meson64 overlays

### DIFF
--- a/patch/kernel/archive/meson64-6.1/general-xtra-meson64-overlays.patch
+++ b/patch/kernel/archive/meson64-6.1/general-xtra-meson64-overlays.patch
@@ -1,38 +1,42 @@
-From fc6857f815ed8454f16da6b273dc5026cd9c769c Mon Sep 17 00:00:00 2001
+From 6179f0113224e7d4e87dfc741fa4033911f4282c Mon Sep 17 00:00:00 2001
 From: Patrick Yavitz <pyavitz@xxxxx.com>
-Date: Wed, 2 Aug 2023 07:51:52 -0400
+Date: Fri, 18 Aug 2023 11:22:03 -0400
 Subject: [PATCH] general: extra: meson64 overlays
 
 meson-g12a-radxa-zero-gpio-10-led.dtbo (rev 1.51 enable led)
 meson-g12a-radxa-zero-gpio-8-led.dtbo (rev 1.4 enable led)
 meson-g12b-odroid-n2-spi.dtbo (SPI-NOR enable via overlay)
 
-meson-sm1-bananapi-uartA.dtbo (bpi-m5 bluetooth) *
-meson-sm1-bananapi-uartAO_B.dtbo (serial 4) *
-meson-sm1-bananapi-uartB.dtbo (serial 2) *
+meson-sm1-bananapi-uartA.dtbo
+meson-sm1-bananapi-uartAO_B.dtbo (serial 4)
+meson-sm1-bananapi-uartB.dtbo (serial 2)
+
+meson-sm1-bananapi-rtl8822cs.dtbo *
 
 Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
 ---
- arch/arm64/boot/dts/amlogic/overlay/Makefile  |  8 +++++-
+ arch/arm64/boot/dts/amlogic/overlay/Makefile  |  9 ++++++-
  .../meson-g12a-radxa-zero-gpio-10-led.dts     | 26 +++++++++++++++++++
  .../meson-g12a-radxa-zero-gpio-8-led.dts      | 26 +++++++++++++++++++
  .../overlay/meson-g12b-odroid-n2-spi.dts      | 23 ++++++++++++++++
+ .../overlay/meson-sm1-bananapi-rtl8822cs.dts  | 23 ++++++++++++++++
  .../overlay/meson-sm1-bananapi-uartA.dts      | 15 +++++++++++
  .../overlay/meson-sm1-bananapi-uartAO_B.dts   | 14 ++++++++++
  .../overlay/meson-sm1-bananapi-uartB.dts      | 15 +++++++++++
- 7 files changed, 126 insertions(+), 1 deletion(-)
+ 8 files changed, 150 insertions(+), 1 deletion(-)
  create mode 100644 arch/arm64/boot/dts/amlogic/overlay/meson-g12a-radxa-zero-gpio-10-led.dts
  create mode 100644 arch/arm64/boot/dts/amlogic/overlay/meson-g12a-radxa-zero-gpio-8-led.dts
  create mode 100644 arch/arm64/boot/dts/amlogic/overlay/meson-g12b-odroid-n2-spi.dts
+ create mode 100644 arch/arm64/boot/dts/amlogic/overlay/meson-sm1-bananapi-rtl8822cs.dts
  create mode 100644 arch/arm64/boot/dts/amlogic/overlay/meson-sm1-bananapi-uartA.dts
  create mode 100644 arch/arm64/boot/dts/amlogic/overlay/meson-sm1-bananapi-uartAO_B.dts
  create mode 100644 arch/arm64/boot/dts/amlogic/overlay/meson-sm1-bananapi-uartB.dts
 
 diff --git a/arch/arm64/boot/dts/amlogic/overlay/Makefile b/arch/arm64/boot/dts/amlogic/overlay/Makefile
-index 9d5c727602d1..8db9145ac471 100644
+index 9d5c727602d1..aa1be0fb1844 100644
 --- a/arch/arm64/boot/dts/amlogic/overlay/Makefile
 +++ b/arch/arm64/boot/dts/amlogic/overlay/Makefile
-@@ -6,7 +6,13 @@ dtbo-$(CONFIG_ARCH_MESON) += \
+@@ -6,7 +6,14 @@ dtbo-$(CONFIG_ARCH_MESON) += \
  	meson-uartC.dtbo \
  	meson-w1-gpio.dtbo \
  	meson-w1AB-gpio.dtbo \
@@ -41,6 +45,7 @@ index 9d5c727602d1..8db9145ac471 100644
 +	meson-g12a-radxa-zero-gpio-8-led.dtbo \
 +	meson-g12a-radxa-zero-gpio-10-led.dtbo \
 +	meson-g12b-odroid-n2-spi.dtbo \
++	meson-sm1-bananapi-rtl8822cs.dtbo \
 +	meson-sm1-bananapi-uartA.dtbo \
 +	meson-sm1-bananapi-uartAO_B.dtbo \
 +	meson-sm1-bananapi-uartB.dtbo
@@ -135,6 +140,35 @@ index 000000000000..658afb1fb58d
 +
 +	fragment@1 {
 +		target = <&spifc>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/amlogic/overlay/meson-sm1-bananapi-rtl8822cs.dts b/arch/arm64/boot/dts/amlogic/overlay/meson-sm1-bananapi-rtl8822cs.dts
+new file mode 100644
+index 000000000000..f9d014f03789
+--- /dev/null
++++ b/arch/arm64/boot/dts/amlogic/overlay/meson-sm1-bananapi-rtl8822cs.dts
+@@ -0,0 +1,23 @@
++/dts-v1/;
++/plugin/;
++
++/ {
++	/* Banana Pi M2S/M5 */
++	compatible = "bananapi,bpi-m2s", "bananapi,bpi-m5";
++
++	/* RTL8822CS SDIO WIFI */
++	fragment@0 {
++		target = <&sd_emmc_a>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++
++	/* RTL8822CS BLUETOOTH */
++	fragment@1 {
++		target = <&uart_A>;
 +		__overlay__ {
 +			status = "okay";
 +		};

--- a/patch/kernel/archive/meson64-6.4/overlay/Makefile
+++ b/patch/kernel/archive/meson64-6.4/overlay/Makefile
@@ -10,6 +10,7 @@ dtbo-$(CONFIG_ARCH_MESON) += \
 	meson-g12a-radxa-zero-gpio-8-led.dtbo \
 	meson-g12a-radxa-zero-gpio-10-led.dtbo \
 	meson-g12b-odroid-n2-spi.dtbo \
+	meson-sm1-bananapi-rtl8822cs.dtbo \
 	meson-sm1-bananapi-uartA.dtbo \
 	meson-sm1-bananapi-uartAO_B.dtbo \
 	meson-sm1-bananapi-uartB.dtbo

--- a/patch/kernel/archive/meson64-6.4/overlay/meson-sm1-bananapi-rtl8822cs.dts
+++ b/patch/kernel/archive/meson64-6.4/overlay/meson-sm1-bananapi-rtl8822cs.dts
@@ -1,0 +1,23 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	/* Banana Pi M2S/M5 */
+	compatible = "bananapi,bpi-m2s", "bananapi,bpi-m5";
+
+	/* RTL8822CS SDIO WIFI */
+	fragment@0 {
+		target = <&sd_emmc_a>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	/* RTL8822CS BLUETOOTH */
+	fragment@1 {
+		target = <&uart_A>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};


### PR DESCRIPTION
meson-sm1-bananapi-rtl8822cs.dtbo

Add support for the RTL8822CS expansion board.
https://wiki.banana-pi.org/Banana_Pi_BPI-M5#Wifi_.26_BT_support_via_expansion_board

Although the exp board target is for the M5 it also works on the BananaPi M2S. Tested on the BPI-M2S.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
