### PR TITLE
`khadas-vim4`: add modprobe config to avoid kernel panic during ISP firmware loading

### DIFF
--- a/config/boards/khadas-vim4.wip
+++ b/config/boards/khadas-vim4.wip
@@ -13,3 +13,15 @@ KHADAS_BOARD_ID="kvim4" # used to compile the fip blobs
 declare -g KHADAS_OOWOW_BOARD_ID="VIM4" # for use with EXT=output-image-oowow
 
 OVERLAY_PREFIX='t7-a311d2'
+
+# Add modprobe configuration for the ISP, see https://github.com/khadas/fenix/blob/master/archives/filesystem/special/VIM4/etc/modprobe.d/isp.conf
+# This avoids a kernel panic related to the ISP firmware; see https://armbian.atlassian.net/browse/AR-1801?focusedCommentId=11995
+function post_family_tweaks_bsp__kvim4_isp_modprobe() {
+	: "${destination:?}"
+	display_alert "${BOARD}" "Adding modprobe configuration for the ISP" "info"
+	mkdir -p "${destination}"/etc/modprobe.d
+	cat <<- EOD > "${destination}"/etc/modprobe.d/isp.conf
+		options iv009_isp dcam=2
+		softdep iv009_isp pre: iv009_isp_iq iv009_isp_lens iv009_isp_sensor
+	EOD
+}


### PR DESCRIPTION
#### `khadas-vim4`: add modprobe config to avoid kernel panic during ISP firmware loading

- `khadas-vim4`: add modprobe config to avoid kernel panic during ISP firmware loading
  - See https://armbian.atlassian.net/browse/AR-1801?focusedCommentId=11995