### PR TITLE
kernel: sunxi: current: drop g_parm support patch as it causes kernel oops

### DIFF
--- a/patch/kernel/archive/sunxi-6.1/series.conf
+++ b/patch/kernel/archive/sunxi-6.1/series.conf
@@ -34,7 +34,7 @@
 	patches.megous/ARM-dts-sun8i-a83t-tbs-a711-Add-flash-led-support.patch
 	patches.megous/media-sun6i-csi-Add-support-for-RGB565-and-RGB555.patch
 	patches.megous/media-sun6i-csi-Add-support-for-missing-16bit-color-formats.patch
-	patches.megous/media-sun6i-csi-Pass-on-g_parm-s_parm-to-the-subdev.patch
+-	patches.megous/media-sun6i-csi-Pass-on-g_parm-s_parm-to-the-subdev.patch
 	patches.megous/mailbox-Allow-to-run-mailbox-while-timekeeping-is-suspended.patch
 	patches.megous/media-sun6i-csi-Make-the-video-device-respect-user-passed-bytes.patch
 	patches.megous/ARM-sunxi-Add-experimental-suspend-to-memory-implementation-for.patch

--- a/patch/kernel/archive/sunxi-6.1/series.megous
+++ b/patch/kernel/archive/sunxi-6.1/series.megous
@@ -34,7 +34,7 @@
 	patches.megous/ARM-dts-sun8i-a83t-tbs-a711-Add-flash-led-support.patch
 	patches.megous/media-sun6i-csi-Add-support-for-RGB565-and-RGB555.patch
 	patches.megous/media-sun6i-csi-Add-support-for-missing-16bit-color-formats.patch
-	patches.megous/media-sun6i-csi-Pass-on-g_parm-s_parm-to-the-subdev.patch
+-	patches.megous/media-sun6i-csi-Pass-on-g_parm-s_parm-to-the-subdev.patch
 	patches.megous/mailbox-Allow-to-run-mailbox-while-timekeeping-is-suspended.patch
 	patches.megous/media-sun6i-csi-Make-the-video-device-respect-user-passed-bytes.patch
 	patches.megous/ARM-sunxi-Add-experimental-suspend-to-memory-implementation-for.patch


### PR DESCRIPTION
# Description

Dropping patches.megous/media-sun6i-csi-Pass-on-g_parm-s_parm-to-the-subdev.patch patch for 6.1 kernel as it causes kernel oops when trying to use ov5640 camera. The issue was reported on the [NanoPi Duo2 forum](https://forum.armbian.com/topic/29580-duo2-6134-sunxi-ov5640-video-capture-kernel-oops/) 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested that camera works on NanoPi Duo2 with 6.1 kernel 

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
