### PR TITLE
`odroidn2l`: add board file for ODROID N2L; on `meson64` `edge`; add N2L-specific FIP handling to g12b

### DIFF
--- a/config/boards/odroidn2l.csc
+++ b/config/boards/odroidn2l.csc
@@ -1,0 +1,15 @@
+# Amlogic S922X hexa core 2GB/4GB RAM SoC 1.8-2.4Ghz eMMC GBE USB3 SPI RTC
+BOARD_NAME="Odroid N2L"
+BOARDFAMILY="meson-g12b"
+BOARD_MAINTAINER=""
+KERNEL_TARGET="edge" # @TODO: DTB for N2L is only in 6.3+; add current when we bump it to 6.3 or newer.
+FULL_DESKTOP="yes"
+BOOT_LOGO="desktop"
+BOOTCONFIG="odroid-n2l_defconfig"
+BOOTBRANCH_BOARD="tag:v2023.07.02"
+BOOTPATCHDIR="v2023.07" # Thus boots USB/NVMe/SCSI first. N2L only has USB.
+
+# U-boot has detection code for the ODROID boards, but NOT for the n2l, at least until 23.10-rc2.
+# See https://github.com/u-boot/u-boot/blob/v2023.10-rc2/board/amlogic/odroid-n2/odroid-n2.c
+# Thus we need to set BOOT_FDT_FILE explicitly.
+BOOT_FDT_FILE="amlogic/meson-g12b-odroid-n2l.dtb"

--- a/config/sources/families/meson-g12b.conf
+++ b/config/sources/families/meson-g12b.conf
@@ -14,7 +14,10 @@ ASOUND_STATE="${ASOUND_STATE:-"asound.state.meson64"}"
 # Handling of FIP blobs
 function uboot_custom_postprocess() {
 	# @TODO: these should come from FIP_TREE_BOARD/FIP_TREE_FAMILY vars in board.conf instead of hardcoded here
-	if [[ $BOARD == odroidn2* ]]; then
+	if [[ $BOARD == odroidn2l ]]; then
+		# The N2L (1608Mhz) has its own blobs.
+		uboot_g12_postprocess "$SRC"/cache/sources/amlogic-boot-fip/odroid-n2l g12b
+	elif [[ $BOARD == odroidn2* ]]; then
 		# FIP trees 'odroid-n2-plus' and 'odroid-n2' are identical.
 		uboot_g12_postprocess "$SRC"/cache/sources/amlogic-boot-fip/odroid-n2 g12b
 	elif [[ $BOARD == khadas-vim3 ]]; then


### PR DESCRIPTION
#### `odroidn2l`: add board file for ODROID N2L; on `meson64` `edge`; add N2L-specific FIP handling to g12b

- `odroidn2l`: add board file for ODROID N2L; on `meson64` `edge`; add N2L-specific FIP handling to g12b
  - current (6.1) does not yet carry the DTB
  - u-boot (up to at least 2023.10-rc2) does NOT have ADC detection for N2L, so force the DTB
  - `meson-g12b.conf`: add a specific if for `odroidn2l` _before_ the `odroidn2*` for FIP blobs