### PR TITLE
kernel: sunxi: bump legacy, current and edge

### DIFF
--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -24,17 +24,17 @@ case $BRANCH in
 
 	legacy)
 		declare -g KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v5.15.126"
+		declare -g KERNELBRANCH="tag:v5.15.127"
 		;;
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.1.45"
+		declare -g KERNELBRANCH="tag:v6.1.46"
 		;;
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.4" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.4.10"
+		declare -g KERNELBRANCH="tag:v6.4.11"
 		;;
 esac
 

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -25,17 +25,17 @@ case $BRANCH in
 
 	legacy)
 		declare -g KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v5.15.126"
+		declare -g KERNELBRANCH="tag:v5.15.127"
 		;;
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.1.45"
+		declare -g KERNELBRANCH="tag:v6.1.46"
 		;;
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.4" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.4.10"
+		declare -g KERNELBRANCH="tag:v6.4.11"
 		;;
 esac
 


### PR DESCRIPTION
# Description

legacy - 5.15.126 -> 5.15.127
current - 6.1.45 -> 6.1.46
edge - 6.4.10 -> 6.4.11

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X]  Booted legacy, current and edge images on Orange Pi Prime (sun50i H5)
- [X]  Booted legacy, current and edge images on NanoPi Duo2 (sun8i H3)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
