### PR TITLE
kernel: sunxi: bring back autofocus support for ov5640 camera

### DIFF
--- a/patch/kernel/archive/sunxi-6.1/patches.megous/media-ov5640-Implement-autofocus.patch
+++ b/patch/kernel/archive/sunxi-6.1/patches.megous/media-ov5640-Implement-autofocus.patch
@@ -1,7 +1,7 @@
-From b6c98399cac94f59477c35104a4af805a52693af Mon Sep 17 00:00:00 2001
+From 393ae4e2d3e384e007feb365f3a256a94fad9fb0 Mon Sep 17 00:00:00 2001
 From: Ondrej Jirman <megi@xff.cz>
 Date: Sun, 7 Aug 2022 15:17:09 +0200
-Subject: [PATCH 053/389] media: ov5640: Implement autofocus
+Subject: [PATCH] media: ov5640: Implement autofocus
 
 The autofocus functionality needs a firmware blob loaded into the
 internal microcontroller.
@@ -15,7 +15,7 @@ Signed-off-by: Martijn Braam <martijn@brixit.nl>
  1 file changed, 278 insertions(+)
 
 diff --git a/drivers/media/i2c/ov5640.c b/drivers/media/i2c/ov5640.c
-index d42650739c78..a5b1ce8eb047 100644
+index cc3a1dda0b8f..14a0fb60a9be 100644
 --- a/drivers/media/i2c/ov5640.c
 +++ b/drivers/media/i2c/ov5640.c
 @@ -9,6 +9,7 @@
@@ -26,7 +26,7 @@ index d42650739c78..a5b1ce8eb047 100644
  #include <linux/device.h>
  #include <linux/gpio/consumer.h>
  #include <linux/i2c.h>
-@@ -118,6 +119,38 @@
+@@ -119,6 +120,38 @@
  #define OV5640_REG_SDE_CTRL5		0x5585
  #define OV5640_REG_AVG_READOUT		0x56a1
  
@@ -65,7 +65,7 @@ index d42650739c78..a5b1ce8eb047 100644
  enum ov5640_mode_id {
  	OV5640_MODE_QQVGA_160_120 = 0,
  	OV5640_MODE_QCIF_176_144,
-@@ -430,6 +463,12 @@ struct ov5640_ctrls {
+@@ -431,6 +464,12 @@ struct ov5640_ctrls {
  		struct v4l2_ctrl *auto_gain;
  		struct v4l2_ctrl *gain;
  	};
@@ -78,7 +78,7 @@ index d42650739c78..a5b1ce8eb047 100644
  	struct v4l2_ctrl *brightness;
  	struct v4l2_ctrl *light_freq;
  	struct v4l2_ctrl *saturation;
-@@ -472,6 +511,8 @@ struct ov5640_dev {
+@@ -473,6 +512,8 @@ struct ov5640_dev {
  
  	bool pending_mode_change;
  	bool streaming;
@@ -87,8 +87,8 @@ index d42650739c78..a5b1ce8eb047 100644
  };
  
  static inline struct ov5640_dev *to_ov5640_dev(struct v4l2_subdev *sd)
-@@ -2469,6 +2510,118 @@ static void ov5640_reset(struct ov5640_dev *sensor)
- 	usleep_range(20000, 25000);
+@@ -2494,6 +2535,118 @@ static void ov5640_powerup_sequence(struct ov5640_dev *sensor)
+ 			 OV5640_REG_SYS_CTRL0_SW_PWDN);
  }
  
 +static int ov5640_copy_fw_to_device(struct ov5640_dev *sensor,
@@ -206,16 +206,16 @@ index d42650739c78..a5b1ce8eb047 100644
  static int ov5640_set_power_on(struct ov5640_dev *sensor)
  {
  	struct i2c_client *client = sensor->i2c_client;
-@@ -2490,6 +2643,8 @@ static int ov5640_set_power_on(struct ov5640_dev *sensor)
+@@ -2515,6 +2668,8 @@ static int ov5640_set_power_on(struct ov5640_dev *sensor)
  		goto xclk_off;
  	}
  
 +	sensor->af_initialized = 0;
 +
- 	ov5640_reset(sensor);
- 	ov5640_power(sensor, true);
+ 	ov5640_powerup_sequence(sensor);
  
-@@ -3093,6 +3248,35 @@ static int ov5640_set_framefmt(struct ov5640_dev *sensor,
+ 	ret = ov5640_init_slave_id(sensor);
+@@ -3117,6 +3272,35 @@ static int ov5640_set_framefmt(struct ov5640_dev *sensor,
  			      is_jpeg ? (BIT(5) | BIT(3)) : 0);
  }
  
@@ -251,7 +251,7 @@ index d42650739c78..a5b1ce8eb047 100644
  /*
   * Sensor Controls.
   */
-@@ -3209,6 +3393,41 @@ static int ov5640_set_ctrl_exposure(struct ov5640_dev *sensor,
+@@ -3233,6 +3417,41 @@ static int ov5640_set_ctrl_exposure(struct ov5640_dev *sensor,
  	return ret;
  }
  
@@ -293,7 +293,7 @@ index d42650739c78..a5b1ce8eb047 100644
  static int ov5640_set_ctrl_gain(struct ov5640_dev *sensor, bool auto_gain)
  {
  	struct ov5640_ctrls *ctrls = &sensor->ctrls;
-@@ -3324,6 +3543,32 @@ static int ov5640_set_ctrl_vblank(struct ov5640_dev *sensor, int value)
+@@ -3348,6 +3567,32 @@ static int ov5640_set_ctrl_vblank(struct ov5640_dev *sensor, int value)
  				  mode->height + value);
  }
  
@@ -326,7 +326,7 @@ index d42650739c78..a5b1ce8eb047 100644
  static int ov5640_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
  {
  	struct v4l2_subdev *sd = ctrl_to_sd(ctrl);
-@@ -3348,6 +3593,12 @@ static int ov5640_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
+@@ -3372,6 +3617,12 @@ static int ov5640_g_volatile_ctrl(struct v4l2_ctrl *ctrl)
  			return val;
  		sensor->ctrls.exposure->val = val;
  		break;
@@ -339,7 +339,7 @@ index d42650739c78..a5b1ce8eb047 100644
  	}
  
  	pm_runtime_put_autosuspend(&sensor->i2c_client->dev);
-@@ -3396,6 +3647,18 @@ static int ov5640_s_ctrl(struct v4l2_ctrl *ctrl)
+@@ -3420,6 +3671,18 @@ static int ov5640_s_ctrl(struct v4l2_ctrl *ctrl)
  	case V4L2_CID_AUTO_WHITE_BALANCE:
  		ret = ov5640_set_ctrl_white_balance(sensor, ctrl->val);
  		break;
@@ -358,8 +358,8 @@ index d42650739c78..a5b1ce8eb047 100644
  	case V4L2_CID_HUE:
  		ret = ov5640_set_ctrl_hue(sensor, ctrl->val);
  		break;
-@@ -3495,6 +3758,20 @@ static int ov5640_init_controls(struct ov5640_dev *sensor)
- 	ctrls->gain = v4l2_ctrl_new_std(hdl, ops, V4L2_CID_GAIN,
+@@ -3519,6 +3782,20 @@ static int ov5640_init_controls(struct ov5640_dev *sensor)
+ 	ctrls->gain = v4l2_ctrl_new_std(hdl, ops, V4L2_CID_ANALOGUE_GAIN,
  					0, 1023, 1, 0);
  
 +	/* Autofocus */
@@ -379,7 +379,7 @@ index d42650739c78..a5b1ce8eb047 100644
  	ctrls->saturation = v4l2_ctrl_new_std(hdl, ops, V4L2_CID_SATURATION,
  					      0, 255, 1, 64);
  	ctrls->hue = v4l2_ctrl_new_std(hdl, ops, V4L2_CID_HUE,
-@@ -3541,6 +3818,7 @@ static int ov5640_init_controls(struct ov5640_dev *sensor)
+@@ -3565,6 +3842,7 @@ static int ov5640_init_controls(struct ov5640_dev *sensor)
  	v4l2_ctrl_auto_cluster(3, &ctrls->auto_wb, 0, false);
  	v4l2_ctrl_auto_cluster(2, &ctrls->auto_gain, 0, true);
  	v4l2_ctrl_auto_cluster(2, &ctrls->auto_exp, 1, true);
@@ -388,5 +388,5 @@ index d42650739c78..a5b1ce8eb047 100644
  	sensor->sd.ctrl_handler = hdl;
  	return 0;
 -- 
-2.35.3
+2.34.1
 

--- a/patch/kernel/archive/sunxi-6.1/series.conf
+++ b/patch/kernel/archive/sunxi-6.1/series.conf
@@ -57,11 +57,11 @@
 	patches.megous/media-ov5640-Don-t-powerup-the-sensor-during-driver-probe.patch
 	patches.megous/media-ov5640-set-default-ae-target-lower.patch
 	patches.megous/media-ov5640-Improve-error-reporting.patch
--	patches.megous/media-ov5640-Implement-autofocus.patch
+	patches.megous/media-ov5640-Implement-autofocus.patch
 	patches.megous/net-stmmac-sun8i-Use-devm_regulator_get-for-PHY-regulator.patch
--	patches.megous/media-ov5640-Improve-firmware-load-time.patch
+	patches.megous/media-ov5640-Improve-firmware-load-time.patch
 	patches.megous/net-stmmac-sun8i-Rename-PHY-regulator-variable-to-regulator_phy.patch
--	patches.megous/media-ov5640-Fix-focus-commands-blocking-until-complete.patch
+	patches.megous/media-ov5640-Fix-focus-commands-blocking-until-complete.patch
 	patches.megous/iio-adc-sun4i-gpadc-iio-Allow-to-use-sun5i-a13-gpadc-iio-from-D.patch
 	patches.megous/mtd-spi-nor-Add-regulator-support.patch
 	patches.megous/input-cyttsp4-De-obfuscate-platform-data-for-keys.patch

--- a/patch/kernel/archive/sunxi-6.1/series.megous
+++ b/patch/kernel/archive/sunxi-6.1/series.megous
@@ -57,11 +57,11 @@
 	patches.megous/media-ov5640-Don-t-powerup-the-sensor-during-driver-probe.patch
 	patches.megous/media-ov5640-set-default-ae-target-lower.patch
 	patches.megous/media-ov5640-Improve-error-reporting.patch
--	patches.megous/media-ov5640-Implement-autofocus.patch
+	patches.megous/media-ov5640-Implement-autofocus.patch
 	patches.megous/net-stmmac-sun8i-Use-devm_regulator_get-for-PHY-regulator.patch
--	patches.megous/media-ov5640-Improve-firmware-load-time.patch
+	patches.megous/media-ov5640-Improve-firmware-load-time.patch
 	patches.megous/net-stmmac-sun8i-Rename-PHY-regulator-variable-to-regulator_phy.patch
--	patches.megous/media-ov5640-Fix-focus-commands-blocking-until-complete.patch
+	patches.megous/media-ov5640-Fix-focus-commands-blocking-until-complete.patch
 	patches.megous/iio-adc-sun4i-gpadc-iio-Allow-to-use-sun5i-a13-gpadc-iio-from-D.patch
 	patches.megous/mtd-spi-nor-Add-regulator-support.patch
 	patches.megous/input-cyttsp4-De-obfuscate-platform-data-for-keys.patch

--- a/patch/kernel/archive/sunxi-6.4/series.conf
+++ b/patch/kernel/archive/sunxi-6.4/series.conf
@@ -46,9 +46,9 @@
 	patches.megous/media-ov5640-Don-t-powerup-the-sensor-during-driver-probe.patch
 	patches.megous/media-ov5640-set-default-ae-target-lower.patch
 	patches.megous/media-ov5640-Improve-error-reporting.patch
--	patches.megous/media-ov5640-Implement-autofocus.patch
--	patches.megous/media-ov5640-Improve-firmware-load-time.patch
--	patches.megous/media-ov5640-Fix-focus-commands-blocking-until-complete.patch
+	patches.megous/media-ov5640-Implement-autofocus.patch
+	patches.megous/media-ov5640-Improve-firmware-load-time.patch
+	patches.megous/media-ov5640-Fix-focus-commands-blocking-until-complete.patch
 	patches.megous/media-ov5640-Add-read-only-property-for-vblank.patch
 	patches.megous/media-sun6i-csi-capture-Use-subdev-operation-to-access-bridge-f.patch
 	patches.megous/media-sun6i-csi-subdev-Use-subdev-active-state-to-store-active-.patch

--- a/patch/kernel/archive/sunxi-6.4/series.megous
+++ b/patch/kernel/archive/sunxi-6.4/series.megous
@@ -46,9 +46,9 @@
 	patches.megous/media-ov5640-Don-t-powerup-the-sensor-during-driver-probe.patch
 	patches.megous/media-ov5640-set-default-ae-target-lower.patch
 	patches.megous/media-ov5640-Improve-error-reporting.patch
--	patches.megous/media-ov5640-Implement-autofocus.patch
--	patches.megous/media-ov5640-Improve-firmware-load-time.patch
--	patches.megous/media-ov5640-Fix-focus-commands-blocking-until-complete.patch
+	patches.megous/media-ov5640-Implement-autofocus.patch
+	patches.megous/media-ov5640-Improve-firmware-load-time.patch
+	patches.megous/media-ov5640-Fix-focus-commands-blocking-until-complete.patch
 	patches.megous/media-ov5640-Add-read-only-property-for-vblank.patch
 	patches.megous/media-sun6i-csi-capture-Use-subdev-operation-to-access-bridge-f.patch
 	patches.megous/media-sun6i-csi-subdev-Use-subdev-active-state-to-store-active-.patch


### PR DESCRIPTION
# Description

We had autofocus patches for ov5640 camera in allwinner current and edge kernel that were disabled due to patch application failure. This PR fixes the patch application failure and re-enables the same

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Checked that patches applies on 6.4 kernel
- [X] Checked that patches applies on 6.4 kernel
- [X] Tested that autofocus works with 6.1 kernel on NanoPi Duo2

The following procedure was used to test autofocus with 6.1 kernel
1) Compiled and enabled device tree overlay for ov5640 camera taken from the [forum post](https://forum.armbian.com/topic/29580-duo2-6134-sunxi-ov5640-video-capture-kernel-oops/)
2) Took the [ov5640_af_2.bin](https://github.com/dragan-simic/ov5640-autofocus-firmware/raw/main/firmware/ov5640_af_2.bin) autofocus firmware and placed it in /lib/firmware directory with filename ov5640_af.bin
3) Ran the following commands to start a camera stream
```
# v4l2-ctl --device /dev/video1 --set-fmt-video=width=640,height=480,pixelformat=YUYV
# media-ctl --device /dev/media1 --set-v4l2 '"ov5640 0-003c":0[fmt:YUYV8_2X8/640x480]'
# ffmpeg -i /dev/video1 -q 10 -pix_fmt yuv420p -video_size 640x480 -r 5 -listen 1 -f avi http://192.168.29.128:8080/stream&
# v4l2-ctl --device /dev/v4l-subdev0 -c auto_focus_start=1
```
4) Verified that autofocus firmware loaded successfully from dmesg output
```
# dmesg | grep ov5640
[    8.022346] ov5640 0-003c: supply DOVDD not found, using dummy regulator
[    8.022698] ov5640 0-003c: supply AVDD not found, using dummy regulator
[    8.022928] ov5640 0-003c: supply DVDD not found, using dummy regulator
[ 2808.787047] ov5640 0-003c: firmware upload success
[ 2808.787609] ov5640 0-003c: fw started after 0 ms
```
5) verified that camera lens moves to focus when moving the subject

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
