### PR TITLE
Drop HOST OS that don't support crust compilation

### DIFF
--- a/config/sources/families/include/crust_firmware.inc
+++ b/config/sources/families/include/crust_firmware.inc
@@ -19,17 +19,3 @@ declare -g CRUST_TARGET_MAP="scp;;build/scp/scp.bin"
 
 # Use a different BOOTDIR so that we don't leave scp.bin behind for non crust builds
 [[ -n "${CRUSTCONFIG}" ]] && BOOTDIR="u-boot-crust"
-
-# complain about system not being supported for building crust image
-function add_host_dependencies__dont_try_to_build_crust_on_unsupported_systems() {
-    if [[ -n "${CRUSTCONFIG}" ]] ; then
-        if [[ -z $HOSTRELEASE || "bookworm sid jammy kinetic lunar vanessa vera" != *"$HOSTRELEASE"* ]] ; then
-            if [[ $NO_HOST_RELEASE_CHECK == yes ]]; then
-                display_alert "You are running on an unsupported system" "${HOSTRELEASE:-(unknown)}" "wrn"
-                display_alert "Do not report any errors, warnings or other issues encountered beyond this point" "" "wrn"
-            else
-                exit_with_error "Unsupported build system for images with crust-firmware: '${HOSTRELEASE:-(unknown)}'"
-            fi
-        fi
-    fi
-}

--- a/extensions/sunxi-tools.sh
+++ b/extensions/sunxi-tools.sh
@@ -9,10 +9,8 @@ function add_host_dependencies__sunxi_add_32_bit_c_compiler() {
 
 # Install gcc-or1k-elf for crust compilation
 function add_host_dependencies__sunxi_add_or1k_c_compiler() {
-        if [[ -n "$HOSTRELEASE" && "bookworm sid jammy kinetic lunar vanessa vera" == *"$HOSTRELEASE"* ]] ; then
-                display_alert "Adding or1k C compiler to host dependencies" "for sunxi bootloader compile" "debug"
-                declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} gcc-or1k-elf"
-        fi
+	display_alert "Adding or1k C compiler to host dependencies" "for sunxi bootloader compile" "debug"
+	declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} gcc-or1k-elf"
 }
 
 function fetch_sources_tools__sunxi_tools() {

--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -121,8 +121,6 @@ function docker_cli_prepare() {
 	# declare -g DOCKER_ARMBIAN_BASE_IMAGE="${DOCKER_ARMBIAN_BASE_IMAGE:-"debian:trixie"}"
 	# declare -g DOCKER_ARMBIAN_BASE_IMAGE="${DOCKER_ARMBIAN_BASE_IMAGE:-"debian:bookworm"}"
 	# declare -g DOCKER_ARMBIAN_BASE_IMAGE="${DOCKER_ARMBIAN_BASE_IMAGE:-"debian:sid"}"
-	# declare -g DOCKER_ARMBIAN_BASE_IMAGE="${DOCKER_ARMBIAN_BASE_IMAGE:-"debian:bullseye"}"
-	# declare -g DOCKER_ARMBIAN_BASE_IMAGE="${DOCKER_ARMBIAN_BASE_IMAGE:-"ubuntu:focal"}"
 	# declare -g DOCKER_ARMBIAN_BASE_IMAGE="${DOCKER_ARMBIAN_BASE_IMAGE:-"ubuntu:kinetic"}"
 	declare -g DOCKER_ARMBIAN_BASE_IMAGE="${DOCKER_ARMBIAN_BASE_IMAGE:-"ubuntu:jammy"}"
 	declare -g DOCKER_ARMBIAN_TARGET_PATH="${DOCKER_ARMBIAN_TARGET_PATH:-"/armbian"}"

--- a/lib/functions/host/host-release.sh
+++ b/lib/functions/host/host-release.sh
@@ -33,7 +33,7 @@ function obtain_and_check_host_release_and_arch() {
 	#
 	# NO_HOST_RELEASE_CHECK overrides the check for a supported host system
 	# Disable host OS check at your own risk. Any issues reported with unsupported releases will be closed without discussion
-	if [[ -z $HOSTRELEASE || "bullseye bookworm trixie sid focal impish hirsute jammy kinetic lunar ulyana ulyssa uma una vanessa vera victoria" != *"$HOSTRELEASE"* ]]; then
+	if [[ -z $HOSTRELEASE || "bookworm trixie sid jammy kinetic lunar vanessa vera victoria" != *"$HOSTRELEASE"* ]]; then
 		if [[ $NO_HOST_RELEASE_CHECK == yes ]]; then
 			display_alert "You are running on an unsupported system" "${HOSTRELEASE:-(unknown)}" "wrn"
 			display_alert "Do not report any errors, warnings or other issues encountered beyond this point" "" "wrn"


### PR DESCRIPTION
# Description

Dropped support for host OSes that can not build crust

Jira reference number [AR-1811]

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1811]: https://armbian.atlassian.net/browse/AR-1811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ