### PR TITLE
Timezone select is too closed on status of the countries

### DIFF
--- a/lib/functions/rootfs/post-tweaks.sh
+++ b/lib/functions/rootfs/post-tweaks.sh
@@ -10,6 +10,9 @@
 function post_debootstrap_tweaks() {
 	display_alert "Applying post-tweaks" "post_debootstrap_tweaks" "debug"
 
+	# adjust tzselect to improve political correctness
+	sed -i "s/Please select a country/Please select a country or a region/g" "${SDCARD}"/usr/bin/tzselect
+
 	# activate systemd-resolved, if not using NetworkManager
 	if [[ ! -f "${SDCARD}"/etc/NetworkManager/NetworkManager.conf ]]; then
 		if [[ -d "${SDCARD}"/etc/systemd/network ]]; then


### PR DESCRIPTION
# Description

Patch tzselect text to be more neutral. 

Jira reference number [AR-1826]

# How Has This Been Tested?

Text change only. Manual test of execution.

# Checklist:

- [x] My code follows the style guidelines of this project

[AR-1826]: https://armbian.atlassian.net/browse/AR-1826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ