### PR TITLE
Fix error when building for Allwinner boards without crust support

### DIFF
--- a/config/sources/families/include/crust_firmware.inc
+++ b/config/sources/families/include/crust_firmware.inc
@@ -8,14 +8,16 @@
 #
 declare -g CRUST_TARGET_MAP="scp;;build/scp/scp.bin"
 
-[[ -n "${CRUSTCONFIG}" && -z $CRUSTSOURCE ]] && CRUSTSOURCE='https://github.com/crust-firmware/crust'
-[[ -n "${CRUSTCONFIG}" && -z $CRUSTDIR ]] && CRUSTDIR='crust-sunxi-mainline'
-[[ -n "${CRUSTCONFIG}" && -z $CRUSTBRANCH ]] && CRUSTBRANCH='commit:c308a504853e7fdb47169796c9a832796410ece8'
-[[ -n "${CRUSTCONFIG}" && -z $CRUST_USE_GCC ]] && CRUST_USE_GCC='> 9.1.0'
-[[ -n "${CRUSTCONFIG}" && -z $CRUST_COMPILER ]] && CRUST_COMPILER='or1k-elf-'
+if [[ -n "${CRUSTCONFIG}" ]]; then
+    [[ -z $CRUSTSOURCE ]] && CRUSTSOURCE='https://github.com/crust-firmware/crust'
+    [[ -z $CRUSTDIR ]] && CRUSTDIR='crust-sunxi-mainline'
+    [[ -z $CRUSTBRANCH ]] && CRUSTBRANCH='commit:c308a504853e7fdb47169796c9a832796410ece8'
+    [[ -z $CRUST_USE_GCC ]] && CRUST_USE_GCC='> 9.1.0'
+    [[ -z $CRUST_COMPILER ]] && CRUST_COMPILER='or1k-elf-'
 
-# Apply crust patches if crust is enabled
-[[ -n "${CRUSTCONFIG}" ]] && BOOTPATCHDIR="${BOOTPATCHDIR} u-boot-sunxi-crust"
+    # Apply crust patches if crust is enabled
+    BOOTPATCHDIR="${BOOTPATCHDIR} u-boot-sunxi-crust"
 
-# Use a different BOOTDIR so that we don't leave scp.bin behind for non crust builds
-[[ -n "${CRUSTCONFIG}" ]] && BOOTDIR="u-boot-crust"
+    # Use a different BOOTDIR so that we don't leave scp.bin behind for non crust builds
+    BOOTDIR="u-boot-crust"
+fi


### PR DESCRIPTION
# Description

Fix build error when building for Allwinner boards without crust support. This was an unintended regression due to #5628 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Checked build succeeds when building with and without crust

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
