### PR TITLE
add mainline kernel mirror support

### DIFF
--- a/lib/functions/general/git-ref2info.sh
+++ b/lib/functions/general/git-ref2info.sh
@@ -94,9 +94,10 @@ function memoized_git_ref_to_info() {
 					url="${git_source}/plain/Makefile?h=${sha1}"
 					;;
 
-					# @TODO: urgently add support for Google Mirror
-					# @TODO: china mirror etc.
-					# @TODO: mirrors might need to be resolved before/during/after this, refactor
+				"https://kernel.googlesource.com/pub/scm/linux/kernel/git/stable/linux-stable" | "https://mirrors.tuna.tsinghua.edu.cn/git/linux-stable.git" | "https://mirrors.bfsu.edu.cn/git/linux-stable.git")
+					# for mainline kernel source, only the origin source support curl
+					url="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/plain/Makefile?h=${sha1}"
+					;;
 
 				"https://github.com/"*)
 					# parse org/repo from https://github.com/org/repo


### PR DESCRIPTION
# Description

Mainline mirror is not supported since armbian-next. Current code support `google`, `tuna` and `bfsu` as mainline kernel source: https://github.com/armbian/build/blob/main/lib/functions/configuration/main-config.sh#L170-L187. We have to use kernel source from `git.kernel.org` to support curl.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Build with `MAINLINE_MIRROR=tuna`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
