### PR TITLE
dts: amlogic: meson-g12b-bananapi-cm4: switch to enable-gpios 

### DIFF
--- a/patch/kernel/archive/meson64-6.1/board-bananapi-cm4-switch-to-enable-gpios.patch
+++ b/patch/kernel/archive/meson64-6.1/board-bananapi-cm4-switch-to-enable-gpios.patch
@@ -1,0 +1,30 @@
+From mboxrd@z Thu Jan  1 00:00:00 1970
+From: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
+Subject: [PATCH] arm64: dts: amlogic: meson-g12b-bananapi: switch to enable-gpios
+Date: Tue, 25 Jul 2023 16:27:03 +0200
+
+The recommended name for enable GPIOs property in regulator-gpio is
+enable-gpios.  This is also required by bindings:
+
+  meson-g12b-bananapi-cm4-cm4io.dtb: regulator-vddio-c: Unevaluated properties are not allowed ('enable-gpio' was unexpected)
+
+Signed-off-by: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
+---
+ arch/arm64/boot/dts/amlogic/meson-g12b-bananapi-cm4.dtsi | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-bananapi-cm4.dtsi b/arch/arm64/boot/dts/amlogic/meson-g12b-bananapi-cm4.dtsi
+index 97e522921b06..86adc1423385 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-g12b-bananapi-cm4.dtsi
++++ b/arch/arm64/boot/dts/amlogic/meson-g12b-bananapi-cm4.dtsi
+@@ -56,7 +56,7 @@ vddio_c: regulator-vddio-c {
+ 		regulator-min-microvolt = <1800000>;
+ 		regulator-max-microvolt = <3300000>;
+ 
+-		enable-gpio = <&gpio_ao GPIOAO_3 GPIO_OPEN_DRAIN>;
++		enable-gpios = <&gpio_ao GPIOAO_3 GPIO_OPEN_DRAIN>;
+ 		enable-active-high;
+ 		regulator-always-on;
+ 
+-- 
+2.34.1

--- a/patch/kernel/archive/meson64-6.1/board-bananapi-cm4-switch-to-enable-gpios.patch
+++ b/patch/kernel/archive/meson64-6.1/board-bananapi-cm4-switch-to-enable-gpios.patch
@@ -1,7 +1,7 @@
-From mboxrd@z Thu Jan  1 00:00:00 1970
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
-Subject: [PATCH] arm64: dts: amlogic: meson-g12b-bananapi: switch to enable-gpios
 Date: Tue, 25 Jul 2023 16:27:03 +0200
+Subject: [PATCH] arm64: dts: amlogic: meson-g12b-bananapi: switch to enable-gpios
 
 The recommended name for enable GPIOs property in regulator-gpio is
 enable-gpios.  This is also required by bindings:

--- a/patch/kernel/archive/meson64-6.4/board-bananapi-cm4-switch-to-enable-gpios.patch
+++ b/patch/kernel/archive/meson64-6.4/board-bananapi-cm4-switch-to-enable-gpios.patch
@@ -1,0 +1,30 @@
+From mboxrd@z Thu Jan  1 00:00:00 1970
+From: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
+Subject: [PATCH] arm64: dts: amlogic: meson-g12b-bananapi: switch to enable-gpios
+Date: Tue, 25 Jul 2023 16:27:03 +0200
+
+The recommended name for enable GPIOs property in regulator-gpio is
+enable-gpios.  This is also required by bindings:
+
+  meson-g12b-bananapi-cm4-cm4io.dtb: regulator-vddio-c: Unevaluated properties are not allowed ('enable-gpio' was unexpected)
+
+Signed-off-by: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
+---
+ arch/arm64/boot/dts/amlogic/meson-g12b-bananapi-cm4.dtsi | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-bananapi-cm4.dtsi b/arch/arm64/boot/dts/amlogic/meson-g12b-bananapi-cm4.dtsi
+index 97e522921b06..86adc1423385 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-g12b-bananapi-cm4.dtsi
++++ b/arch/arm64/boot/dts/amlogic/meson-g12b-bananapi-cm4.dtsi
+@@ -56,7 +56,7 @@ vddio_c: regulator-vddio-c {
+ 		regulator-min-microvolt = <1800000>;
+ 		regulator-max-microvolt = <3300000>;
+ 
+-		enable-gpio = <&gpio_ao GPIOAO_3 GPIO_OPEN_DRAIN>;
++		enable-gpios = <&gpio_ao GPIOAO_3 GPIO_OPEN_DRAIN>;
+ 		enable-active-high;
+ 		regulator-always-on;
+ 
+-- 
+2.34.1

--- a/patch/kernel/archive/meson64-6.4/board-bananapi-cm4-switch-to-enable-gpios.patch
+++ b/patch/kernel/archive/meson64-6.4/board-bananapi-cm4-switch-to-enable-gpios.patch
@@ -1,7 +1,7 @@
-From mboxrd@z Thu Jan  1 00:00:00 1970
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
-Subject: [PATCH] arm64: dts: amlogic: meson-g12b-bananapi: switch to enable-gpios
 Date: Tue, 25 Jul 2023 16:27:03 +0200
+Subject: [PATCH] arm64: dts: amlogic: meson-g12b-bananapi: switch to enable-gpios
 
 The recommended name for enable GPIOs property in regulator-gpio is
 enable-gpios.  This is also required by bindings:


### PR DESCRIPTION
The recommended name for enable GPIOs property in regulator-gpio is enable-gpios.

This is also required by bindings:
  meson-g12b-bananapi-cm4-cm4io.dtb: regulator-vddio-c: Unevaluated properties are not allowed ('enable-gpio' was unexpected)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
