### PR TITLE
rtl8811cu, rtl8723cs: Fix module build failure on 6.5 kernel

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -274,7 +274,7 @@ driver_rtl8811CU_rtl8821C() {
 	if linux-version compare "${version}" ge 3.14; then
 
 		# attach to specifics tag or branch
-		local rtl8811cuver="commit:69c903b75bde36293c66b25c051916a74dbadf58"
+		local rtl8811cuver="commit:9e2772540f66a69170f43864a6560d0d190d97b1"
 
 		display_alert "Adding" "Wireless drivers for Realtek RTL8811CU and RTL8821C chipsets ${rtl8811cuver}" "info"
 
@@ -311,9 +311,6 @@ driver_rtl8811CU_rtl8821C() {
 
 		# fix compilation for kernels >= 5.4
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8811cu-Fix-VFS-import.patch" "applying"
-
-		# fix compilation for kernels >= 6.3
-		process_patch_file "${SRC}/patch/misc/wireless-rtl8811cu-6.3.patch" "applying"
 
 	fi
 
@@ -706,10 +703,15 @@ driver_rtl8723cs() {
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/Bluetooth-hci_h5-Add-support-for-binding-RTL8723CS-with-device-.patch" "applying"
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/bluetooth-h5-Don-t-re-initialize-rtl8723cs-on-resume.patch" "applying"
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/bluetooth-btrtl-add-rtl8703bs.patch" "applying"
+		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/8723cs-Fix-symbol-conflicts-with-rtw88-driver.patch" "applying"
 	fi
 
 	if linux-version compare "${version}" ge 6.3; then
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/8723cs-Port-to-6.3.patch" "applying"
+	fi
+
+	if linux-version compare "${version}" ge 6.5; then
+		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/8723cs-Port-to-6.5.patch" "applying"
 	fi
 
 }

--- a/patch/misc/wireless-rtl8723cs/8723cs-Fix-symbol-conflicts-with-rtw88-driver.patch
+++ b/patch/misc/wireless-rtl8723cs/8723cs-Fix-symbol-conflicts-with-rtw88-driver.patch
@@ -1,0 +1,81 @@
+From 588a510278e13b5eeb379797c22956e39ea183ac Mon Sep 17 00:00:00 2001
+From: Ondrej Jirman <megi@xff.cz>
+Date: Tue, 18 Jul 2023 18:53:01 +0200
+Subject: [PATCH 150/464] 8723cs: Fix symbol conflicts with rtw88 driver
+
+Signed-off-by: Ondrej Jirman <megi@xff.cz>
+---
+ drivers/staging/rtl8723cs/hal/hal_com.c                 | 2 +-
+ drivers/staging/rtl8723cs/include/hal_com.h             | 2 +-
+ drivers/staging/rtl8723cs/os_dep/linux/ioctl_cfg80211.c | 2 +-
+ drivers/staging/rtl8723cs/os_dep/linux/wifi_regd.c      | 2 +-
+ drivers/staging/rtl8723cs/os_dep/linux/wifi_regd.h      | 2 +-
+ 5 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/staging/rtl8723cs/hal/hal_com.c b/drivers/staging/rtl8723cs/hal/hal_com.c
+index a0f15958a778..94728558b50a 100644
+--- a/drivers/staging/rtl8723cs/hal/hal_com.c
++++ b/drivers/staging/rtl8723cs/hal/hal_com.c
+@@ -2318,7 +2318,7 @@ u32 rtw_sec_read_cam(_adapter *adapter, u8 addr)
+ 	return rdata;
+ }
+ 
+-void rtw_sec_write_cam(_adapter *adapter, u8 addr, u32 wdata)
++static void rtw_sec_write_cam(_adapter *adapter, u8 addr, u32 wdata)
+ {
+ 	_mutex *mutex = &adapter_to_dvobj(adapter)->cam_ctl.sec_cam_access_mutex;
+ 	u32 cnt = 0;
+diff --git a/drivers/staging/rtl8723cs/include/hal_com.h b/drivers/staging/rtl8723cs/include/hal_com.h
+index dcafbafd8b1b..ea3b94fce7b1 100644
+--- a/drivers/staging/rtl8723cs/include/hal_com.h
++++ b/drivers/staging/rtl8723cs/include/hal_com.h
+@@ -386,7 +386,7 @@ void rtw_hal_update_sta_ra_info(PADAPTER padapter, struct sta_info *psta);
+ 
+ /* access HW only */
+ u32 rtw_sec_read_cam(_adapter *adapter, u8 addr);
+-void rtw_sec_write_cam(_adapter *adapter, u8 addr, u32 wdata);
++//void rtw_sec_write_cam(_adapter *adapter, u8 addr, u32 wdata);
+ void rtw_sec_read_cam_ent(_adapter *adapter, u8 id, u8 *ctrl, u8 *mac, u8 *key);
+ void rtw_sec_write_cam_ent(_adapter *adapter, u8 id, u16 ctrl, u8 *mac, u8 *key);
+ void rtw_sec_clr_cam_ent(_adapter *adapter, u8 id);
+diff --git a/drivers/staging/rtl8723cs/os_dep/linux/ioctl_cfg80211.c b/drivers/staging/rtl8723cs/os_dep/linux/ioctl_cfg80211.c
+index 7eea58711252..e170700f3ae0 100644
+--- a/drivers/staging/rtl8723cs/os_dep/linux/ioctl_cfg80211.c
++++ b/drivers/staging/rtl8723cs/os_dep/linux/ioctl_cfg80211.c
+@@ -10531,7 +10531,7 @@ int rtw_wiphy_register(struct wiphy *wiphy)
+ 	rtw_cfgvendor_attach(wiphy);
+ #endif
+ 
+-	rtw_regd_init(wiphy);
++	rtw_regd_init_8723cs(wiphy);
+ 
+ 	return wiphy_register(wiphy);
+ }
+diff --git a/drivers/staging/rtl8723cs/os_dep/linux/wifi_regd.c b/drivers/staging/rtl8723cs/os_dep/linux/wifi_regd.c
+index b4b0bcd5114d..bad1545640e3 100644
+--- a/drivers/staging/rtl8723cs/os_dep/linux/wifi_regd.c
++++ b/drivers/staging/rtl8723cs/os_dep/linux/wifi_regd.c
+@@ -389,7 +389,7 @@ static int rtw_reg_notifier_return(struct wiphy *wiphy, struct regulatory_reques
+ }
+ #endif
+ 
+-int rtw_regd_init(struct wiphy *wiphy)
++int rtw_regd_init_8723cs(struct wiphy *wiphy)
+ {
+ #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 9, 0))
+ 	wiphy->reg_notifier = rtw_reg_notifier_return;
+diff --git a/drivers/staging/rtl8723cs/os_dep/linux/wifi_regd.h b/drivers/staging/rtl8723cs/os_dep/linux/wifi_regd.h
+index 4e147fc51dbc..b9f6d0d7b4ef 100644
+--- a/drivers/staging/rtl8723cs/os_dep/linux/wifi_regd.h
++++ b/drivers/staging/rtl8723cs/os_dep/linux/wifi_regd.h
+@@ -22,6 +22,6 @@ struct _RT_CHANNEL_INFO;
+ u8 rtw_os_init_channel_set(_adapter *padapter, struct _RT_CHANNEL_INFO *channel_set);
+ s16 rtw_os_get_total_txpwr_regd_lmt_mbm(_adapter *adapter, u8 cch, enum channel_width bw);
+ #endif
+-int rtw_regd_init(struct wiphy *wiphy);
++int rtw_regd_init_8723cs(struct wiphy *wiphy);
+ 
+ #endif /* __WIFI_REGD_H__ */
+-- 
+2.34.1
+

--- a/patch/misc/wireless-rtl8723cs/8723cs-Port-to-6.5.patch
+++ b/patch/misc/wireless-rtl8723cs/8723cs-Port-to-6.5.patch
@@ -1,0 +1,49 @@
+From 802c37124dac4cc415b4bc8a4357672341a54d09 Mon Sep 17 00:00:00 2001
+From: Ondrej Jirman <megi@xff.cz>
+Date: Mon, 24 Jul 2023 01:28:49 +0200
+Subject: [PATCH 151/464] 8723cs: Port to 6.5
+
+Signed-off-by: Ondrej Jirman <megi@xff.cz>
+---
+ .../rtl8723cs/os_dep/linux/ioctl_cfg80211.c   | 25 +++++--------------
+ 1 file changed, 6 insertions(+), 19 deletions(-)
+
+diff --git a/drivers/staging/rtl8723cs/os_dep/linux/ioctl_cfg80211.c b/drivers/staging/rtl8723cs/os_dep/linux/ioctl_cfg80211.c
+index e170700f3ae0..c1e6e9eff9b3 100644
+--- a/drivers/staging/rtl8723cs/os_dep/linux/ioctl_cfg80211.c
++++ b/drivers/staging/rtl8723cs/os_dep/linux/ioctl_cfg80211.c
+@@ -8357,25 +8357,12 @@ static void cfg80211_rtw_update_mgmt_frame_register(
+ }
+ #endif
+ 
+-#if defined(CONFIG_TDLS) && (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 2, 0))
+-static int cfg80211_rtw_tdls_mgmt(struct wiphy *wiphy,
+-	struct net_device *ndev,
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 16, 0))
+-	const u8 *peer,
+-#else
+-	u8 *peer,
+-#endif
+-	u8 action_code,
+-	u8 dialog_token,
+-	u16 status_code,
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 15, 0))
+-	u32 peer_capability,
+-#endif
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 17, 0))
+-	bool initiator,
+-#endif
+-	const u8 *buf,
+-	size_t len)
++#if defined(CONFIG_TDLS)
++static int cfg80211_rtw_tdls_mgmt(struct wiphy *wiphy, struct net_device *ndev,
++	const u8 *peer, int link_id,
++	u8 action_code, u8 dialog_token, u16 status_code,
++	u32 peer_capability, bool initiator,
++	const u8 *buf, size_t len)
+ {
+ 	_adapter *padapter = (_adapter *)rtw_netdev_priv(ndev);
+ 	struct mlme_ext_priv	*pmlmeext = &padapter->mlmeextpriv;
+-- 
+2.34.1
+


### PR DESCRIPTION
# Description

Fixed driver compilation for RTL8811CU and RTL8723CS on 6.5 kernel

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested creating build for nanopiduo2 with 6.1, 6.4 and 6.5 kernels to make sure build succeeds

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
