### PR TITLE
pipeline: add userspace inventory capabilities

### DIFF
--- a/config/sources/families/bcm2711.conf
+++ b/config/sources/families/bcm2711.conf
@@ -96,7 +96,7 @@ extension_prepare_config__prepare_rpi_flash_kernel() {
 				fi
 			fi
 		else
-			exit_with_error "Can't use release '${RELEASE}' for ${BOARD}. Try: '${usable_releases}'" "'${RELEASE}' not supported"
+			exit_with_target_not_supported_error "Can't use release '${RELEASE}' for ${BOARD}. Try: '${usable_releases}'" "'${RELEASE}' not supported"
 		fi
 	fi
 }

--- a/lib/functions/cli/cli-jsoninfo.sh
+++ b/lib/functions/cli/cli-jsoninfo.sh
@@ -106,6 +106,7 @@ function cli_json_info_run() {
 
 		### --- inventory --- ###
 
+		declare ALL_USERSPACE_INVENTORY_FILE="${BASE_INFO_OUTPUT_DIR}/all_userspace_inventory.json"
 		declare ALL_BOARDS_ALL_BRANCHES_INVENTORY_FILE="${BASE_INFO_OUTPUT_DIR}/all_boards_all_branches.json"
 		declare TARGETS_OUTPUT_FILE="${BASE_INFO_OUTPUT_DIR}/all-targets.json"
 		declare IMAGE_INFO_FILE="${BASE_INFO_OUTPUT_DIR}/image-info.json"
@@ -115,18 +116,17 @@ function cli_json_info_run() {
 		declare ARTIFACTS_INFO_UPTODATE_FILE="${BASE_INFO_OUTPUT_DIR}/artifacts-info-uptodate.json"
 		declare OUTDATED_ARTIFACTS_IMAGES_FILE="${BASE_INFO_OUTPUT_DIR}/outdated-artifacts-images.json"
 
+		# Userspace inventory: RELEASES, and DESKTOPS and their possible ARCH'es, names, and support status.
+		if [[ ! -f "${ALL_USERSPACE_INVENTORY_FILE}" ]]; then
+			display_alert "Generating userspace inventory" "all_userspace_inventory.json" "info"
+			run_host_command_logged "${PYTHON3_VARS[@]}" "${PYTHON3_INFO[BIN]}" "${INFO_TOOLS_DIR}"/userspace-inventory.py ">" "${ALL_USERSPACE_INVENTORY_FILE}"
+		fi
+
 		# Board/branch inventory.
 		if [[ ! -f "${ALL_BOARDS_ALL_BRANCHES_INVENTORY_FILE}" ]]; then
 			display_alert "Generating board/branch inventory" "all_boards_all_branches.json" "info"
 			run_host_command_logged "${PYTHON3_VARS[@]}" "${PYTHON3_INFO[BIN]}" "${INFO_TOOLS_DIR}"/board-inventory.py ">" "${ALL_BOARDS_ALL_BRANCHES_INVENTORY_FILE}"
 		fi
-
-		# @TODO: Release/rootfs inventory?
-
-		# A simplistic all-boards-all-branches target file, for the all-boards-all-branches-targets.json.
-		# Then just use the same info-gatherer-image to get the image info.
-		# This will be used as database for the targets-compositor, for example to get "all boards+branches that have kernel < 5.0" or "all boards+branches of meson64 family" etc.
-		# @TODO: this is a bit heavy; only do it if out-of-date (compared to config/, lib/, extensions/, userpatches/ file mtimes...)
 
 		if [[ "${ARMBIAN_COMMAND}" == "inventory" ]]; then
 			display_alert "Done with" "inventory" "info"
@@ -147,10 +147,15 @@ function cli_json_info_run() {
 			export TARGETS_BETA="${BETA}"                             # Read by the Python script, and injected into every target as "BETA=" param.
 			export TARGETS_REVISION="${REVISION}"                     # Read by the Python script, and injected into every target as "REVISION=" param.
 			export TARGETS_FILTER_INCLUDE="${TARGETS_FILTER_INCLUDE}" # Read by the Python script; used to "only include" targets that match the given string.
-			run_host_command_logged "${PYTHON3_VARS[@]}" "${PYTHON3_INFO[BIN]}" "${INFO_TOOLS_DIR}"/targets-compositor.py "${ALL_BOARDS_ALL_BRANCHES_INVENTORY_FILE}" "not_yet_releases.json" "${TARGETS_FILE}" ">" "${TARGETS_OUTPUT_FILE}"
+			run_host_command_logged "${PYTHON3_VARS[@]}" "${PYTHON3_INFO[BIN]}" "${INFO_TOOLS_DIR}"/targets-compositor.py "${ALL_BOARDS_ALL_BRANCHES_INVENTORY_FILE}" "${ALL_USERSPACE_INVENTORY_FILE}" "${TARGETS_FILE}" ">" "${TARGETS_OUTPUT_FILE}"
 			unset TARGETS_BETA
 			unset TARGETS_REVISION
 			unset TARGETS_FILTER_INCLUDE
+		fi
+
+		if [[ "${ARMBIAN_COMMAND}" == "targets-composed" ]]; then
+			display_alert "Done with" "targets-dashboard" "info"
+			return 0
 		fi
 
 		### Images.

--- a/lib/functions/cli/commands.sh
+++ b/lib/functions/cli/commands.sh
@@ -28,6 +28,7 @@ function armbian_register_commands() {
 		["inventory"]="json_info"         # implemented in cli_json_info_pre_run and cli_json_info_run
 		["targets"]="json_info"           # implemented in cli_json_info_pre_run and cli_json_info_run
 		["targets-dashboard"]="json_info" # implemented in cli_json_info_pre_run and cli_json_info_run
+		["targets-composed"]="json_info"  # implemented in cli_json_info_pre_run and cli_json_info_run
 		["debs-to-repo-json"]="json_info" # implemented in cli_json_info_pre_run and cli_json_info_run
 		["gha-matrix"]="json_info"        # implemented in cli_json_info_pre_run and cli_json_info_run
 		["gha-workflow"]="json_info"      # implemented in cli_json_info_pre_run and cli_json_info_run

--- a/lib/functions/logging/traps.sh
+++ b/lib/functions/logging/traps.sh
@@ -194,3 +194,19 @@ function exit_with_error() {
 
 	exit 43
 }
+
+# terminate build with a specific error code (44), meaning "target not supported".
+# this is exactly like exit_with_error, but will be handled differently by the build pipeline.
+function exit_with_target_not_supported_error() {
+	# Log the error and exit.
+	# Everything else will be done by shared trap handling, above.
+	local _file="${BASH_SOURCE[1]}"
+	local _function=${FUNCNAME[1]}
+	local _line="${BASH_LINENO[0]}"
+
+	display_alert "target not supported! " "${1} ${2}" "err"
+
+	overlayfs_wrapper "cleanup"
+
+	exit 44
+}

--- a/lib/functions/main/config-prepare.sh
+++ b/lib/functions/main/config-prepare.sh
@@ -274,6 +274,9 @@ function config_post_main() {
 		declare -g ARMBIAN_WILL_BUILD_UBOOT=no
 	fi
 
+	# Do some sanity checks for userspace stuff, if RELEASE/DESKTOP_ENVIRONMENT is set.
+	check_config_userspace_release_and_desktop
+
 	display_alert "Extensions: finish configuration" "extension_finish_config" "debug"
 	call_extension_method "extension_finish_config" <<- 'EXTENSION_FINISH_CONFIG'
 		*allow extensions a last chance at configuration just before it is done*
@@ -297,6 +300,59 @@ function set_distribution_status() {
 	[[ "${DISTRIBUTION_STATUS}" != "supported" ]] && [[ "${EXPERT}" != "yes" ]] && exit_with_error "Armbian ${RELEASE} is unsupported and, therefore, only available to experts (EXPERT=yes)"
 
 	return 0 # due to last stmt above being a shortcircuit conditional
+}
+
+function check_config_userspace_release_and_desktop() {
+	# Do some sanity checks for userspace stuff.
+	# If RELEASE is set, it must be a valid release.
+	# We'll also check that the RELEASE supports the ARCH.
+	# Then we'll do the same for RELEASE+DESKTOP_ENVIRONMENT and the ARCH.
+	if [[ "${RELEASE}" != "" ]]; then
+		declare release_distro_dir="${SRC}/config/distributions/${RELEASE}"
+		declare release_distro_arches_file="${release_distro_dir}/architectures"
+
+		if [[ ! -d "${release_distro_dir}" ]]; then
+			exit_with_target_not_supported_error "RELEASE '${RELEASE}' is not supported; there is no '${release_distro_dir}' directory."
+		fi
+
+		if [[ ! -f "${release_distro_arches_file}" ]]; then
+			exit_with_target_not_supported_error "RELEASE '${RELEASE}' does not have file ${release_distro_arches_file}"
+		fi
+
+		if grep -q "${ARCH}" "${release_distro_arches_file}"; then
+			display_alert "RELEASE '${RELEASE}' supports ARCH '${ARCH}'" "RELEASE=${RELEASE} ARCH=${ARCH}; see ${release_distro_arches_file}" "debug"
+		else
+			exit_with_target_not_supported_error "RELEASE '${RELEASE}' does not support ARCH '${ARCH}'; see ${release_distro_arches_file}"
+		fi
+
+		# Desktop sanity checks, in the same vein.
+		if [[ "${DESKTOP_ENVIRONMENT}" != "" ]]; then
+
+			# If DESKTOP_ENVIRONMENT is set, but BUILD_DESKTOP is not, then we have a problem.
+			if [[ "${BUILD_DESKTOP}" != "yes" ]]; then
+				exit_with_error "DESKTOP_ENVIRONMENT is set, but BUILD_DESKTOP is not ==yes - please fix your parameters."
+			fi
+
+			declare desktop_release_distro_dir="${SRC}/config/desktop/${RELEASE}/environments/${DESKTOP_ENVIRONMENT}"
+			declare desktop_release_distro_arches_file="${release_distro_dir}/architectures"
+
+			if [[ ! -d "${desktop_release_distro_dir}" ]]; then
+				exit_with_target_not_supported_error "RELEASE '${RELEASE}' and Desktop Environment '${DESKTOP_ENVIRONMENT}' combination is not supported; there is no '${desktop_release_distro_dir}' directory."
+			fi
+
+			if [[ ! -f "${desktop_release_distro_arches_file}" ]]; then
+				exit_with_target_not_supported_error "RELEASE '${RELEASE}' and Desktop Environment '${DESKTOP_ENVIRONMENT}' combination is not supported; there is no '${desktop_release_distro_arches_file}' file."
+			fi
+
+			if grep -q "${ARCH}" "${desktop_release_distro_arches_file}"; then
+				display_alert "RELEASE '${RELEASE}' and Desktop Environment '${DESKTOP_ENVIRONMENT}' combination is supported" "RELEASE=${RELEASE} ARCH=${ARCH}; see ${desktop_release_distro_arches_file}" "debug"
+			else
+				exit_with_target_not_supported_error "RELEASE '${RELEASE}' and Desktop Environment '${DESKTOP_ENVIRONMENT}' combination is not supported; see ${desktop_release_distro_arches_file}"
+			fi
+		fi
+	fi
+
+	return 0
 }
 
 # Some utility functions

--- a/lib/tools/common/armbian_utils.py
+++ b/lib/tools/common/armbian_utils.py
@@ -202,12 +202,100 @@ def find_armbian_src_path():
 	if not os.path.exists(core_boards_path):
 		raise Exception("Can't find config/boards")
 
+	# userspace stuff
+	core_distributions_path = os.path.realpath(os.path.join(armbian_src_path, "config", "distributions"))
+	log.debug(f"Real path to core distributions '{core_distributions_path}'")
+	# Make sure it exists
+	if not os.path.exists(core_distributions_path):
+		raise Exception("Can't find config/distributions")
+
+	core_desktop_path = os.path.realpath(os.path.join(armbian_src_path, "config", "desktop"))
+	log.debug(f"Real path to core desktop '{core_desktop_path}'")
+	# Make sure it exists
+	if not os.path.exists(core_desktop_path):
+		raise Exception("Can't find config/desktop")
+
 	userpatches_boards_path = os.path.realpath(os.path.join(armbian_src_path, "userpatches", "config", "boards"))
 	log.debug(f"Real path to userpatches boards '{userpatches_boards_path}'")
 	has_userpatches_path = os.path.exists(userpatches_boards_path)
 
-	return {"armbian_src_path": armbian_src_path, "compile_sh_full_path": compile_sh_full_path, "core_boards_path": core_boards_path,
-			"userpatches_boards_path": userpatches_boards_path, "has_userpatches_path": has_userpatches_path}
+	return {
+		"armbian_src_path": armbian_src_path, "compile_sh_full_path": compile_sh_full_path, "core_boards_path": core_boards_path,
+		"core_distributions_path": core_distributions_path, "core_desktop_path": core_desktop_path,
+		"userpatches_boards_path": userpatches_boards_path, "has_userpatches_path": has_userpatches_path
+	}
+
+
+def read_one_distro_config_file(filename):
+	# Read the contents of filename passed in and return it as string, trimmed
+	with open(filename, 'r') as file_handle:
+		file_contents = file_handle.read()
+		return file_contents.strip()
+
+
+def split_commas_and_clean_into_list(string):
+	ret = []
+	for item in string.split(","):
+		item = item.strip()
+		if item != "":
+			ret.append(item)
+	return ret
+
+
+def get_desktop_inventory_for_distro(distro, armbian_paths):
+	ret = []
+	desktops_path = armbian_paths["core_desktop_path"]
+	envs_path_for_distro = os.path.join(desktops_path, distro, "environments")
+	if not os.path.exists(envs_path_for_distro):
+		log.warning(f"Can't find desktop environments for distro '{distro}' at '{envs_path_for_distro}'")
+		return ret
+	for env in os.listdir(envs_path_for_distro):
+		one_env_path = os.path.join(envs_path_for_distro, env)
+		if not os.path.isdir(one_env_path):
+			continue
+		log.debug(f"Processing desktop '{env}' for distro '{distro}'")
+		support_file_path = os.path.join(one_env_path, "support")
+		arches_file_path = os.path.join(one_env_path, "architectures")
+		if not os.path.exists(support_file_path):
+			log.warning(f"Can't find desktop support file for distro '{distro}' and environment '{env}' at '{support_file_path}'")
+			continue
+		if not os.path.exists(arches_file_path):
+			log.warning(f"Can't find desktop arches file for distro '{distro}' and environment '{env}' at '{arches_file_path}'")
+			continue
+
+		env_main_info = {
+			"id": env,
+			"support": read_one_distro_config_file(support_file_path),
+			"arches": split_commas_and_clean_into_list(read_one_distro_config_file(arches_file_path))
+		}
+		ret.append(env_main_info)
+
+	return ret
+
+
+def armbian_get_all_userspace_inventory():
+	armbian_paths = find_armbian_src_path()
+	distros_path = armbian_paths["core_distributions_path"]
+	all_distros = []
+	# find and loop over every directory in distros_path, including symlinks
+	for distro in os.listdir(distros_path):
+		one_distro_path = os.path.join(distros_path, distro)
+		if not os.path.isdir(one_distro_path):
+			continue
+		log.debug(f"Processing distro '{distro}'")
+		support_file_path = os.path.join(one_distro_path, "support")
+		arches_file_path = os.path.join(one_distro_path, "architectures")
+		name_file_path = os.path.join(one_distro_path, "name")
+		distro_main_info = {
+			"id": distro,
+			"name": read_one_distro_config_file(name_file_path),
+			"support": read_one_distro_config_file(support_file_path),
+			"arches": split_commas_and_clean_into_list(read_one_distro_config_file(arches_file_path)),
+			"desktops": get_desktop_inventory_for_distro(distro, armbian_paths)
+		}
+		all_distros.append(distro_main_info)
+
+	return all_distros
 
 
 def armbian_get_all_boards_inventory():

--- a/lib/tools/common/armbian_utils.py
+++ b/lib/tools/common/armbian_utils.py
@@ -426,7 +426,7 @@ def gather_json_output_from_armbian(command: str, targets: list[dict]):
 		counter = 0
 		total = len(targets)
 		# get the number of processor cores on this machine
-		max_workers = multiprocessing.cpu_count() * 2  # use double the number of cpu cores, that's the sweet spot
+		max_workers = multiprocessing.cpu_count() * 4  # use four times the number of cpu cores, that's the sweet spot
 		log.info(f"Using {max_workers} workers for parallel processing.")
 		with concurrent.futures.ProcessPoolExecutor(max_workers=max_workers) as executor:
 			every_future = []

--- a/lib/tools/info/artifact-reducer.py
+++ b/lib/tools/info/artifact-reducer.py
@@ -27,8 +27,11 @@ all_artifacts: list[dict] = []
 
 # loop over the build infos. for each, construct a structure with the artifacts.
 for build_info in build_infos:
-	if build_info["config_ok"] == False:
-		log.warning(f"Skipping failed config '{build_info['in']}'...")
+	if build_info["config_ok"] is False:
+		if ("target_not_supported" in build_info) and (build_info["target_not_supported"] is True):
+			log.debug(f"Skipping 'target not supported' config '{build_info['in']}'...")
+		else:
+			log.warning(f"Skipping *failed* config '{build_info['in']}'...")
 		continue
 
 	outvars = build_info["out"]
@@ -52,17 +55,17 @@ for build_info in build_infos:
 			pipeline = build_info["in"]["pipeline"]
 			if "build-artifacts" in pipeline:
 				if pipeline["build-artifacts"] == False:
-					log.warning(f"Skipping artifact '{artifact_name}' (pipeline build-artifacts '{pipeline['build-artifacts']}' config)...")
+					log.debug(f"Skipping artifact '{artifact_name}' (pipeline build-artifacts '{pipeline['build-artifacts']}' config)...")
 					continue
 				else:
-					log.warning(f"Keeping artifact '{artifact_name}' (pipeline build-artifacts '{pipeline['build-artifacts']}' config)...")
+					log.debug(f"Keeping artifact '{artifact_name}' (pipeline build-artifacts '{pipeline['build-artifacts']}' config)...")
 			if "only-artifacts" in pipeline:
 				only_artifacts = pipeline["only-artifacts"]
 				if artifact_name not in only_artifacts:
-					log.warning(f"Skipping artifact '{artifact_name}' (pipeline only-artifacts '{','.join(only_artifacts)}' config)...")
+					log.debug(f"Skipping artifact '{artifact_name}' (pipeline only-artifacts '{','.join(only_artifacts)}' config)...")
 					continue
 				else:
-					log.warning(f"Keeping artifact '{artifact_name}' (pipeline only-artifacts '{','.join(only_artifacts)}' config)...")
+					log.debug(f"Keeping artifact '{artifact_name}' (pipeline only-artifacts '{','.join(only_artifacts)}' config)...")
 
 		inputs: dict[str, str] = {}
 		for input_raw in inputs_raw_array:

--- a/lib/tools/info/outdated-artifact-image-reducer.py
+++ b/lib/tools/info/outdated-artifact-image-reducer.py
@@ -57,7 +57,7 @@ for oci_name in tags_by_oci_name:
 	if len(tags) > 1:
 		list_tags_escaped_quoted = ', '.join([f"'{tag}'" for tag in tags])
 		log.warning(
-			f"Artifact '{oci_name}' has {len(tags)} different tags: {list_tags_escaped_quoted} - this is certainly a problem, go fix the artifact.")
+			f"Artifact '{oci_name}' has {len(tags)} different tags: {list_tags_escaped_quoted}")
 
 # map images to in.target_id
 images_by_target_id = {}
@@ -107,10 +107,10 @@ for target_id, image in images_by_target_id.items():
 	if "pipeline" in image["in"]:
 		if "build-image" in image["in"]["pipeline"]:
 			if not image["in"]["pipeline"]["build-image"]:
-				log.warning(f"Image {image['in']['target_id']} has a pipeline build-image false, skipping")
+				log.debug(f"Image {image['in']['target_id']} has a pipeline build-image false, skipping")
 				continue
 			else:
-				log.warning(f"Image {image['in']['target_id']} has a pipeline build-image true, processing")
+				log.debug(f"Image {image['in']['target_id']} has a pipeline build-image true, processing")
 
 	if target_id not in artifacts_by_target_id:
 		continue

--- a/lib/tools/info/userspace-inventory.py
+++ b/lib/tools/info/userspace-inventory.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+# ‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹
+#  SPDX-License-Identifier: GPL-2.0
+#  Copyright (c) 2023 Ricardo Pardini <ricardo@pardini.net>
+#  This file is a part of the Armbian Build Framework https://github.com/armbian/build/
+# ‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹‹
+import json
+import logging
+import os
+
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from common import armbian_utils
+
+# Prepare logging
+armbian_utils.setup_logging()
+log: logging.Logger = logging.getLogger("userspace-inventory")
+
+all = armbian_utils.armbian_get_all_userspace_inventory()
+log.info(f"Inventoried {len(all)} userspace combinations.")
+print(json.dumps(all, indent=4, sort_keys=True))


### PR DESCRIPTION
#### pipeline: add userspace inventory capabilities

- `config_post_main`: sanity checks for `RELEASE` (vs `ARCH`) and `RELEASE+DESKTOP_ENVIRONMENT` (vs `ARCH`)
  - the interactive menus didn't allow interactive users to select invalid combinations...
  - ... but if specified directly on cmdline, no checks were done at all.
  - introduce `exit_with_target_not_supported_error()`, which is just `exit_with_error` (code 43) but with code 44
    - this way the targets pipeline can just warn instead of break;
    - sometimes it's easier multiplying matrixes and skipping the few that can't be built
- `rpi4b`: use `exit_with_target_not_supported_error()` instead of `exit_with_error()` if RELEASE is not supported
- pipeline: add userspace inventory capabilities
  - digs into config/distributions and config/desktops for info
  - this produces `output/info/all_userspace_inventory.json`
    - this is now passed down to the `targets-compositor` in `cli-jsoninfo`
  - `targets-compositor` now accepts `userspace:` as `items-from-inventory`
  - extra: add `targets-composed` CLI command, to stop after targets-compositor
- pipeline: handle `exit_with_target_not_supported_error()` (retcode 44) as warning and not error
  - split errors and warnings into multiple lines, so a bit easier to see in the logs what the real error was
  - also turn down a few spurious warnings to debugs
- pipeline: use ncores * 4 for info gathering