### PR TITLE
`odroidm1`: _really_ fix `flashcp --partition` non-usage for old mtd-utils (bullseye etc)

### DIFF
--- a/config/boards/odroidm1.wip
+++ b/config/boards/odroidm1.wip
@@ -39,17 +39,17 @@ function post_family_config__uboot_config() {
 	# We don't use u-boot-rockchip-spi.bin here; instead, write SPL and u-boot individually
 	# If we're deinfesting from Petitboot, clear the environment too; PREBOOT will save a new one for mainline
 	function write_uboot_platform_mtd() {
-		declare extra_opts_flashcp="-p" # -p is: "read the flash and only write blocks that are actually different"
-		# if on bullseye, flashcp/mtd-utils is old, and doesn't have --partition/-p
+		declare -a extra_opts_flashcp=("--verbose")
+		# -p is: "read the flash and only write blocks that are actually different"
+		# if on bullseye et al, flashcp/mtd-utils is old, and doesn't have --partition/-p
 		if flashcp -h | grep -q -e '--partition'; then
-			echo "Confirmed flashcp supports --partition/-p -- read and write only changed blocks." >&2
+			echo "Confirmed flashcp supports --partition -- read and write only changed blocks." >&2
+			extra_opts_flashcp+=("--partition")
 		else
-			extra_opts_flashcp=""
-			echo "flashcp does not support --partition/-p, will write full SPI flash blocks." >&2
+			echo "flashcp does not support --partition, will write full SPI flash blocks." >&2
 		fi
-
-		flashcp -v "${extra_opts_flashcp}" "${1}/idbloader-spi.img" /dev/mtd0 # write SPL
-		flashcp -v "${extra_opts_flashcp}" "${1}/u-boot.itb" /dev/mtd2        # write u-boot
+		flashcp "${extra_opts_flashcp[@]}" "${1}/idbloader-spi.img" /dev/mtd0 # write SPL
+		flashcp "${extra_opts_flashcp[@]}" "${1}/u-boot.itb" /dev/mtd2        # write u-boot
 		if fw_printenv | grep -q -i petitboot; then                           # Petitboot leaves a horrible env behind, clear it off if so
 			echo "Found traces of Petitboot in SPI u-boot environment, clearing SPI environment..." >&2
 			flash_erase /dev/mtd1 0 0 # clear u-boot env


### PR DESCRIPTION
#### `odroidm1`: _really_ fix `flashcp --partition` non-usage for old mtd-utils (bullseye etc)

- `odroidm1`: _really_ fix `flashcp --partition` non-usage for old mtd-utils (bullseye etc)
  - we should probably refactor this into a shared library's functions...
    - `flashcp --partition` is much more efficient than just `dd`'ing to mtdblockX
    - but only supported on bookworm+ / jammy+