### PR TITLE
`debian`: desktop `gnome`: drop package `gconf2`

### DIFF
--- a/config/desktop/bullseye/environments/gnome/config_base/packages
+++ b/config/desktop/bullseye/environments/gnome/config_base/packages
@@ -12,7 +12,6 @@ fonts-noto-cjk
 fonts-ubuntu
 fonts-ubuntu-console
 gdebi
-gconf2
 gnome-control-center
 gnome-disk-utility
 gnome-desktop3-data


### PR DESCRIPTION
#### `debian`: desktop `gnome`: drop package `gconf2`

- `debian`: desktop `gnome`: drop package `gconf2`
  - deprecated in `bullseye`: _This package is for legacy applications and no longer used by GNOME._
    - https://packages.debian.org/bullseye/gconf2
  - removed in `trixie` and `sid`
  - `bullseye` is the father of all symlinks, so yeah, call me lazy