### PR TITLE
rtw88: usb: kill and free rx urbs on probe failure

### DIFF
--- a/patch/misc/rtw88/6.1/002-drivers-net-wireless-realtek-rtw88-upstream-wireless.patch
+++ b/patch/misc/rtw88/6.1/002-drivers-net-wireless-realtek-rtw88-upstream-wireless.patch
@@ -3109,3 +3109,55 @@ index 000000000000..ad1d7955c6a5
 -- 
 2.39.2
 
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From:   Sascha Hauer <s.hauer@pengutronix.de>
+To:     linux-wireless@vger.kernel.org
+Date:   Wed, 23 Aug 2023 09:50:21 +0200
+Subject: [PATCH] wifi: rtw88: usb: kill and free rx urbs on probe failure
+
+After rtw_usb_alloc_rx_bufs() has been called rx urbs have been
+allocated and must be freed in the error path. After rtw_usb_init_rx()
+has been called they are submitted, so they also must be killed.
+
+Add these forgotten steps to the probe error path.
+
+Besides the lost memory this also fixes a problem when the driver
+fails to download the firmware in rtw_chip_info_setup(). In this
+case it can happen that the completion of the rx urbs handler runs
+at a time when we already freed our data structures resulting in
+a kernel crash.
+
+Fixes: a82dfd33d1237 ("wifi: rtw88: Add common USB chip support")
+Cc: stable@vger.kernel.org
+Reported-by: Ilgaz Öcal <ilgaz@ilgaz.gen.tr>
+Signed-off-by: Sascha Hauer <s.hauer@pengutronix.de>
+---
+ drivers/net/wireless/realtek/rtw88/usb.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/wireless/realtek/rtw88/usb.c b/drivers/net/wireless/realtek/rtw88/usb.c
+index 4a57efdba97bb..875a61c9c80d4 100644
+--- a/drivers/net/wireless/realtek/rtw88/usb.c
++++ b/drivers/net/wireless/realtek/rtw88/usb.c
+@@ -844,7 +844,7 @@ int rtw_usb_probe(struct usb_interface *intf, const struct usb_device_id *id)
+ 
+ 	ret = rtw_core_init(rtwdev);
+ 	if (ret)
+-		goto err_release_hw;
++		goto err_free_rx_bufs;
+ 
+ 	ret = rtw_usb_intf_init(rtwdev, intf);
+ 	if (ret) {
+@@ -890,6 +890,9 @@ int rtw_usb_probe(struct usb_interface *intf, const struct usb_device_id *id)
+ err_deinit_core:
+ 	rtw_core_deinit(rtwdev);
+ 
++err_free_rx_bufs:
++	rtw_usb_free_rx_bufs(rtwusb);
++
+ err_release_hw:
+ 	ieee80211_free_hw(hw);
+ 
+-- 
+2.39.2
+

--- a/patch/misc/rtw88/6.4/002-drivers-net-wireless-realtek-rtw88-upstream-wireless.patch
+++ b/patch/misc/rtw88/6.4/002-drivers-net-wireless-realtek-rtw88-upstream-wireless.patch
@@ -149,3 +149,56 @@ index 2c1fb2dabd40..b19262ec5d8c 100644
  		sdio_release_host(rtwsdio->sdio_func);
 -- 
 2.41.0
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From:   Sascha Hauer <s.hauer@pengutronix.de>
+To:     linux-wireless@vger.kernel.org
+Date:   Wed, 23 Aug 2023 09:50:21 +0200
+Subject: [PATCH] wifi: rtw88: usb: kill and free rx urbs on probe failure
+
+After rtw_usb_alloc_rx_bufs() has been called rx urbs have been
+allocated and must be freed in the error path. After rtw_usb_init_rx()
+has been called they are submitted, so they also must be killed.
+
+Add these forgotten steps to the probe error path.
+
+Besides the lost memory this also fixes a problem when the driver
+fails to download the firmware in rtw_chip_info_setup(). In this
+case it can happen that the completion of the rx urbs handler runs
+at a time when we already freed our data structures resulting in
+a kernel crash.
+
+Fixes: a82dfd33d1237 ("wifi: rtw88: Add common USB chip support")
+Cc: stable@vger.kernel.org
+Reported-by: Ilgaz Öcal <ilgaz@ilgaz.gen.tr>
+Signed-off-by: Sascha Hauer <s.hauer@pengutronix.de>
+---
+ drivers/net/wireless/realtek/rtw88/usb.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/wireless/realtek/rtw88/usb.c b/drivers/net/wireless/realtek/rtw88/usb.c
+index 4a57efdba97bb..875a61c9c80d4 100644
+--- a/drivers/net/wireless/realtek/rtw88/usb.c
++++ b/drivers/net/wireless/realtek/rtw88/usb.c
+@@ -844,7 +844,7 @@ int rtw_usb_probe(struct usb_interface *intf, const struct usb_device_id *id)
+ 
+ 	ret = rtw_core_init(rtwdev);
+ 	if (ret)
+-		goto err_release_hw;
++		goto err_free_rx_bufs;
+ 
+ 	ret = rtw_usb_intf_init(rtwdev, intf);
+ 	if (ret) {
+@@ -890,6 +890,9 @@ int rtw_usb_probe(struct usb_interface *intf, const struct usb_device_id *id)
+ err_deinit_core:
+ 	rtw_core_deinit(rtwdev);
+ 
++err_free_rx_bufs:
++	rtw_usb_free_rx_bufs(rtwusb);
++
+ err_release_hw:
+ 	ieee80211_free_hw(hw);
+ 
+-- 
+2.39.2
+


### PR DESCRIPTION
After rtw_usb_alloc_rx_bufs() has been called rx urbs have been allocated and must be freed in the error path. After rtw_usb_init_rx() has been called they are submitted, so they also must be killed.

Add these forgotten steps to the probe error path.

Besides the lost memory this also fixes a problem when the driver fails to download the firmware in rtw_chip_info_setup(). In this case it can happen that the completion of the rx urbs handler runs at a time when we already freed our data structures resulting in a kernel crash.

This has been applied to wireless-next
https://lore.kernel.org/linux-wireless/8b4b4228bfd140119665417137a087ea@realtek.com/T/#t

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
