### PR TITLE
nanopir5s: add friendly interface names and enable front LEDS

### DIFF
--- a/config/boards/nanopi-r5s.csc
+++ b/config/boards/nanopi-r5s.csc
@@ -17,6 +17,8 @@ BOOTPATCHDIR="v2023.10"
 BOOTCONFIG="nanopi-r5s-rk3568_defconfig"
 BOOTDIR="u-boot-${BOARD}" # do not share u-boot directory
 
+DEFAULT_OVERLAYS="nanopi-r5s-leds"
+
 # Newer blobs...
 RKBIN_GIT_URL="https://github.com/rpardini/armbian-rkbin.git"
 RKBIN_GIT_BRANCH="update-3568-blobs"
@@ -33,3 +35,14 @@ function add_host_dependencies__new_uboot_wants_python3() {
 	declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} python3-pyelftools" # @TODO: convert to array later
 }
 
+function post_family_tweaks__nanopir5s_udev_network_interfaces() {
+	display_alert "$BOARD" "Renaming interfaces WAN LAN1 LAN2" "info"
+
+	mkdir -p $SDCARD/etc/udev/rules.d/
+	cat << EOF > "${SDCARD}/etc/udev/rules.d/70-persistent-net.rules"
+SUBSYSTEM=="net", ACTION=="add", KERNELS=="fe2a0000.ethernet", NAME:="wan"
+SUBSYSTEM=="net", ACTION=="add", KERNELS=="0000:01:00.0", NAME:="lan1"
+SUBSYSTEM=="net", ACTION=="add", KERNELS=="0001:01:00.0", NAME:="lan2"
+EOF
+
+}

--- a/patch/kernel/archive/rk3568-odroid-6.5/overlay/Makefile
+++ b/patch/kernel/archive/rk3568-odroid-6.5/overlay/Makefile
@@ -8,7 +8,8 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	rockchip-pwm2.dtbo \
 	rockchip-pwm9.dtbo \
 	rockchip-i2c0.dtbo \
-	rockchip-i2c1.dtbo
+	rockchip-i2c1.dtbo \
+        rockchip-nanopi-r5s-leds.dtbo
 
 scr-$(CONFIG_ARCH_ROCKCHIP) += \
        rockchip-fixup.scr

--- a/patch/kernel/archive/rk3568-odroid-6.5/overlay/rockchip-nanopi-r5s-leds.dts
+++ b/patch/kernel/archive/rk3568-odroid-6.5/overlay/rockchip-nanopi-r5s-leds.dts
@@ -1,0 +1,15 @@
+/dts-v1/;
+/plugin/;
+
+
+&{/gpio-leds/led-wan} {
+        linux,default-trigger = "stmmac-0:01:link";
+};
+
+&{/gpio-leds/led-lan1} {
+        linux,default-trigger = "r8169-0-100:00:link";
+};
+
+&{/gpio-leds/led-lan2} {
+        linux,default-trigger = "r8169-1-100:00:link";
+};


### PR DESCRIPTION
# Description

Created udev config for renaming interfaces to WAN, LAN1, LAN2

Created device tree overlay `rockchip-nanopi-r5s-leds` for enabling front panel status LED's for NICs.  enabled by default


# How Has This Been Tested?
Built image.  Leds work when cable plugged in.  interface names are friendly

```
root@nanopi-r5s:~# ip link
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
2: wan: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc mq state DOWN mode DEFAULT group default qlen 1000
    link/ether 12:ad:f7:2a:2f:a3 brd ff:ff:ff:ff:ff:ff
    altname end0
3: lan1: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc pfifo_fast state DOWN mode DEFAULT group default qlen 1000
    link/ether c2:3b:8d:34:73:49 brd ff:ff:ff:ff:ff:ff
    altname enp1s0
4: lan2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP mode DEFAULT group default qlen 1000
    link/ether a6:5c:a3:ad:4c:33 brd ff:ff:ff:ff:ff:ff
    altname enP1p1s0
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
