### PR TITLE
Re-add (Gnome) calculator to XFCE and Gnome desktops

### DIFF
--- a/config/desktop/bullseye/environments/gnome/config_base/packages
+++ b/config/desktop/bullseye/environments/gnome/config_base/packages
@@ -12,6 +12,7 @@ fonts-noto-cjk
 fonts-ubuntu
 fonts-ubuntu-console
 gdebi
+gnome-calculator
 gnome-control-center
 gnome-disk-utility
 gnome-desktop3-data

--- a/config/desktop/buster/environments/xfce/config_base/packages
+++ b/config/desktop/buster/environments/xfce/config_base/packages
@@ -24,6 +24,7 @@ fonts-ubuntu-console
 foomatic-db-compressed-ppds
 gdebi
 ghostscript-x
+gnome-calculator
 gnome-font-viewer
 gnome-disk-utility
 gnome-screenshot

--- a/config/desktop/jammy/environments/gnome/config_base/packages
+++ b/config/desktop/jammy/environments/gnome/config_base/packages
@@ -13,6 +13,7 @@ fonts-ubuntu
 fonts-ubuntu-console
 gdebi
 gconf2
+gnome-calculator
 gnome-control-center
 gnome-disk-utility
 gnome-desktop3-data

--- a/config/desktop/jammy/environments/xfce/config_base/packages
+++ b/config/desktop/jammy/environments/xfce/config_base/packages
@@ -24,6 +24,7 @@ fonts-ubuntu-console
 foomatic-db-compressed-ppds
 gdebi
 ghostscript-x
+gnome-calculator
 gnome-font-viewer
 gnome-disk-utility
 gnome-screenshot

--- a/config/desktop/kinetic/environments/xfce/config_base/packages
+++ b/config/desktop/kinetic/environments/xfce/config_base/packages
@@ -24,6 +24,7 @@ fonts-ubuntu-console
 foomatic-db-compressed-ppds
 gdebi
 ghostscript-x
+gnome-calculator
 gnome-font-viewer
 gnome-disk-utility
 gnome-screenshot

--- a/config/desktop/sid/environments/xfce/config_base/packages
+++ b/config/desktop/sid/environments/xfce/config_base/packages
@@ -24,6 +24,7 @@ fonts-ubuntu-console
 foomatic-db-compressed-ppds
 gdebi
 ghostscript-x
+gnome-calculator
 gnome-font-viewer
 gnome-disk-utility
 gnome-screenshot


### PR DESCRIPTION
# Description

Simple calculator is must have desktop utility.

Jira reference number [AR-1834]

# How Has This Been Tested?

Adding simple package which seems to be present everywhere.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1834]: https://armbian.atlassian.net/browse/AR-1834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ