### PR TITLE
Move dosfstools to base packages so its available in minimal images too

### DIFF
--- a/config/cli/common/main/packages
+++ b/config/cli/common/main/packages
@@ -11,6 +11,7 @@ dialog
 debconf-utils
 debsums
 device-tree-compiler
+dosfstools
 ethtool
 fake-hwclock
 fdisk

--- a/config/cli/common/main/packages.additional
+++ b/config/cli/common/main/packages.additional
@@ -9,7 +9,6 @@ btrfs-progs
 build-essential
 cracklib-runtime
 dkms
-dosfstools
 evtest
 expect
 f2fs-tools


### PR DESCRIPTION
# Description

UEFI minimal images were broken because of this.

Jira reference number [AR-1835]

# How Has This Been Tested?

- [x] Manual test on minimal image

[AR-1835]: https://armbian.atlassian.net/browse/AR-1835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ