### PR TITLE
Nanopi-r1: fix boot from eMMC

### DIFF
--- a/config/boards/nanopi-r1.csc
+++ b/config/boards/nanopi-r1.csc
@@ -2,7 +2,7 @@
 BOARD_NAME="NanoPi R1"
 BOARDFAMILY="sun8i"
 BOARD_MAINTAINER=""
-BOOTCONFIG="nanopi_neo_defconfig"
+BOOTCONFIG="nanopi_r1_defconfig"
 MODULES="g_serial"
 MODULES_BLACKLIST="lima"
 DEFAULT_OVERLAYS="usbhost0 usbhost1 uart1"

--- a/patch/u-boot/u-boot-sunxi/board_nanopi-r1/add-nanopi-r1-emmc.patch
+++ b/patch/u-boot/u-boot-sunxi/board_nanopi-r1/add-nanopi-r1-emmc.patch
@@ -1,0 +1,19 @@
+diff --git a/configs/nanopi_r1_defconfig b/configs/nanopi_r1_defconfig
+new file mode 100644
+index 0000000000..9ce1fdd937
+--- /dev/null
++++ b/configs/nanopi_r1_defconfig
+@@ -0,0 +1,13 @@
++CONFIG_ARM=y
++CONFIG_ARCH_SUNXI=y
++CONFIG_DEFAULT_DEVICE_TREE="sun8i-h3-nanopi-r1"
++CONFIG_SPL=y
++CONFIG_MACH_SUN8I_H3=y
++CONFIG_DRAM_CLK=408
++# CONFIG_VIDEO_DE2 is not set
++# CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
++CONFIG_CONSOLE_MUX=y
++CONFIG_SUN8I_EMAC=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_OHCI_HCD=y
++CONFIG_MMC_SUNXI_SLOT_EXTRA=2


### PR DESCRIPTION
# Description

Fixed the problem that nanopi r1 cannot boot from emmc.
The reason is that uboot uses nanopineo's defconfig and dts when compiling so that it lacks the mmc2 definition.

A topic on the forum about this issues:
https://forum.armbian.com/topic/28704-nanopi-r1-emmc-install-fails-to-start

# How Has This Been Tested?

- Build and update u-boot

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
