### PR TITLE
`rk3568-odroid`/`edge`: bump to 6.5.y from `-rc6`; rebase all patches vs `v6.5`(.0)

### DIFF
--- a/config/sources/families/rk3568-odroid.conf
+++ b/config/sources/families/rk3568-odroid.conf
@@ -17,7 +17,7 @@ case $BRANCH in
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.5" # Major and minor versions of this kernel (for armbian-next)
-		KERNELBRANCH='tag:v6.5-rc6'
+		declare -g KERNELBRANCH='branch:linux-6.5.y'
 		KERNELPATCHDIR='archive/rk3568-odroid-6.5' # patches for overlays et al
 		;;
 

--- a/patch/kernel/archive/rk3568-odroid-6.5/board-odroidm1-spi-uart-pwm.patch
+++ b/patch/kernel/archive/rk3568-odroid-6.5/board-odroidm1-spi-uart-pwm.patch
@@ -10,10 +10,10 @@ rpardini: this prepares base nodes for overlays
  1 file changed, 34 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3568-odroid-m1.dts b/arch/arm64/boot/dts/rockchip/rk3568-odroid-m1.dts
-index 59ecf868dbd0..a0d227fdd86d 100644
+index a337f547caf5..2cb03c95a0f4 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3568-odroid-m1.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3568-odroid-m1.dts
-@@ -742,3 +742,37 @@ vp0_out_hdmi: endpoint@ROCKCHIP_VOP2_EP_HDMI0 {
+@@ -739,3 +739,37 @@ vp0_out_hdmi: endpoint@ROCKCHIP_VOP2_EP_HDMI0 {
  		remote-endpoint = <&hdmi_in_vp0>;
  	};
  };


### PR DESCRIPTION
#### `rk3568-odroid`/`edge`: bump to 6.5.y from `-rc6`; rebase all patches vs `v6.5`(.0)

- `rk3568-odroid`/`edge`: bump to 6.5.y from `-rc6`; rebase all patches vs `v6.5`(.0)