### PR TITLE
Khadas Vim1s: Fix display output

### DIFF
--- a/config/bootscripts/boot-meson-s4t7.cmd
+++ b/config/bootscripts/boot-meson-s4t7.cmd
@@ -35,7 +35,9 @@ else
 	setenv consoleargs "splash=verbose ${consoleargs}"
 fi
 
-setenv bootargs "root=${rootdev} rootwait rootfstype=${rootfstype} ${consoleargs} no_console_suspend loglevel=${verbosity} mac=${eth_mac} khadas.serial=${usid} partition_type=generic ${extraargs} ${extraboardargs}"
+setenv displayargs "logo=${display_layer},loaded,${fb_addr} vout=${outputmode},${vout_init} panel_type=${panel_type} hdmitx=${cecconfig},${colorattribute} hdmimode=${hdmimode} hdmichecksum=${hdmichecksum} dolby_vision_on=${dolby_vision_on} hdr_policy=${hdr_policy} hdr_priority=${hdr_priority} frac_rate_policy=${frac_rate_policy} hdmi_read_edid=${hdmi_read_edid} cvbsmode=${cvbsmode} osd_reverse=${osd_reverse} video_reverse=${video_reverse}"
+
+setenv bootargs "root=${rootdev} rootwait rootfstype=${rootfstype} ${consoleargs} no_console_suspend ${displayargs} loglevel=${verbosity} mac=${eth_mac} khadas.serial=${usid} partition_type=generic ${extraargs} ${extraboardargs}"
 
 load ${devtype} ${devnum} ${fdt_addr_r} ${prefix}dtb/${fdtfile}
 fdt addr ${fdt_addr_r}


### PR DESCRIPTION
# Description

This however only works for selected monitors with 1920x1080 and 4K resolutions. Also display seems to render extremely slowly. If the monitor is turned off and then on or is disconnected and reconnected while Armbian is running, monitor is not detected until a device reboot is performed. All of these however seems to be Khadas's kernel/u-boot limitations

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested attaching vim1s to samsung's 1920x1080 monitor
- [X] Rpardini tested on 4k display

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
