### PR TITLE
K3: Build first stage bootloader before normal U-Boot

### DIFF
--- a/config/sources/families/k3.conf
+++ b/config/sources/families/k3.conf
@@ -57,7 +57,7 @@ function compile_k3_bootgen() {
 	popd
 }
 
-function uboot_custom_postprocess() {
+function pre_config_uboot_target__build_first_stage() {
 	# Compile first stage bootloader
 	compile_k3_bootgen
 


### PR DESCRIPTION
# Description

The causes the first-stage bootloader to be generated before the normal U-Boot allowing the later build to use the firmware fetched during the first-stage build.

# How Has This Been Tested?

- [x] Boot SK-AM62B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
