### PR TITLE
extensions: Fix dump_extension_method_sources_functions() to iterate

### DIFF
--- a/lib/functions/general/extensions.sh
+++ b/lib/functions/general/extensions.sh
@@ -59,7 +59,7 @@ function call_extension_method() {
 	done
 }
 
-function dump_extension_method_sources_functions() {
+function dump_extension_method_sources_function() {
 	declare hook_name="${1}"
 	declare dump_source_hook_function="dump_custom_sources_extension_hooks_${hook_name}"
 
@@ -84,6 +84,13 @@ function dump_extension_method_sources_functions() {
 
 	unset dump_body_sans_function_header_or_trailer
 	return 0 # always success
+}
+
+function dump_extension_method_sources_functions() {
+	for hook_name in "${@}"; do
+		display_alert "Extensions hook to expand source" "${hook_name}" "debug"
+		dump_extension_method_sources_function ${hook_name}
+	done
 }
 
 function dump_extension_method_sources_body() {


### PR DESCRIPTION
# Description

Seems updates to all but the first extension hooks were not causing a rebuild, looks like the hash function dumper only looks at the first argument, but it is passed in a list of functions to dump in every call site.

@rpardini , Does this look right? My BASH skills still need some work :smile: 

# How Has This Been Tested?

- [x] Before this patch, make change to extension function (like fetch_custom_uboot) see that U-Boot is not regenerated
- [x] Make same change after applying this patch and see it now does get regenerated

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
