### PR TITLE
Remove sunxi-mainline postfix from default ARM64 generic ATFDIR

### DIFF
--- a/config/sources/arm64.conf
+++ b/config/sources/arm64.conf
@@ -38,7 +38,7 @@ else
 fi
 
 [[ $ATF_COMPILE != "no" && -z $ATFSOURCE ]] && ATFSOURCE='https://github.com/ARM-software/arm-trusted-firmware'
-[[ $ATF_COMPILE != "no" && -z $ATFDIR ]] && ATFDIR='arm-trusted-firmware-sunxi-mainline'
+[[ $ATF_COMPILE != "no" && -z $ATFDIR ]] && ATFDIR='arm-trusted-firmware'
 [[ $ATF_COMPILE != "no" && -z $ATFBRANCH ]] && ATFBRANCH='commit:af220ebbe467aa580e6b9ba554676f78ffec930f'
 [[ $ATF_COMPILE != "no" && -z $ATF_USE_GCC ]] && ATF_USE_GCC='> 8.0'
 


### PR DESCRIPTION
# Description

This is the generic default and should not have this postfix.

# How Has This Been Tested?

- [x] When ATFDIR is not set, the default directory is called simply "arm-trusted-firmware"

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
