### PR TITLE
feat: enable rkisp module for rockchip64

### DIFF
--- a/config/kernel/linux-rockchip64-edge.config
+++ b/config/kernel/linux-rockchip64-edge.config
@@ -5273,11 +5273,12 @@ CONFIG_USB_SI4713=m
 CONFIG_PLATFORM_SI4713=m
 CONFIG_I2C_SI4713=m
 CONFIG_MEDIA_PLATFORM_DRIVERS=y
-# CONFIG_V4L_PLATFORM_DRIVERS is not set
+CONFIG_V4L_PLATFORM_DRIVERS=y
 CONFIG_SDR_PLATFORM_DRIVERS=y
 CONFIG_DVB_PLATFORM_DRIVERS=y
 CONFIG_V4L_MEM2MEM_DRIVERS=y
 # CONFIG_VIDEO_MEM2MEM_DEINTERLACE is not set
+# CONFIG_VIDEO_MUX is not set
 
 #
 # Allegro DVT media platform drivers
@@ -5316,6 +5317,7 @@ CONFIG_V4L_MEM2MEM_DRIVERS=y
 #
 # Marvell media platform drivers
 #
+# CONFIG_VIDEO_CAFE_CCIC is not set
 
 #
 # Mediatek media platform drivers
@@ -5345,6 +5347,7 @@ CONFIG_V4L_MEM2MEM_DRIVERS=y
 # Rockchip media platform drivers
 #
 CONFIG_VIDEO_ROCKCHIP_RGA=m
+CONFIG_VIDEO_ROCKCHIP_ISP1=m
 
 #
 # Samsung media platform drivers
@@ -5375,6 +5378,7 @@ CONFIG_VIDEO_HANTRO_ROCKCHIP=y
 #
 # Xilinx media platform drivers
 #
+# CONFIG_VIDEO_XILINX is not set
 
 #
 # MMC/SDIO DVB adapters


### PR DESCRIPTION
# Description

Enable rockchip `rkisp` module for rockchip64 boards in edge. There has been driver support upstreamed into the kernel but it is not compiled for the `rockchip64` kernels.

https://docs.kernel.org/admin-guide/media/rkisp1.html

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Compiled edge 6.4.12 on rockpi 4c with modules enabled and it boots. Modules have not been enabled in device trees yet (I haven't done the work yet but hope to PR these)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
