### PR TITLE
Allwinner: update crust to v0.6

### DIFF
--- a/config/sources/families/include/crust_firmware.inc
+++ b/config/sources/families/include/crust_firmware.inc
@@ -11,7 +11,7 @@ declare -g CRUST_TARGET_MAP="scp;;build/scp/scp.bin"
 if [[ -n "${CRUSTCONFIG}" ]]; then
     [[ -z $CRUSTSOURCE ]] && CRUSTSOURCE='https://github.com/crust-firmware/crust'
     [[ -z $CRUSTDIR ]] && CRUSTDIR='crust-sunxi-mainline'
-    [[ -z $CRUSTBRANCH ]] && CRUSTBRANCH='commit:c308a504853e7fdb47169796c9a832796410ece8'
+    [[ -z $CRUSTBRANCH ]] && CRUSTBRANCH='tag:v0.6'
     [[ -z $CRUST_USE_GCC ]] && CRUST_USE_GCC='> 9.1.0'
     [[ -z $CRUST_COMPILER ]] && CRUST_COMPILER='or1k-elf-'
 


### PR DESCRIPTION
# Description

Bump crust to v0.6. Doesn't change anything for us other than version shown on serial console and dmesg log as the commits that went in from what we were using only includes 2 defconfig changes and some changes in readme file.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested that crust builds and works as expected on Nanopiduo2

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
