### PR TITLE
RTW88: `linux 6.4 / 6.5 adjustments`

### DIFF
--- a/patch/misc/rtw88/6.4/002-drivers-net-wireless-realtek-rtw88-upstream-wireless.patch
+++ b/patch/misc/rtw88/6.4/002-drivers-net-wireless-realtek-rtw88-upstream-wireless.patch
@@ -88,3 +88,45 @@ index 2c1fb2dabd40..b19262ec5d8c 100644
 -- 
 2.41.0
 
+From 248429fc23232f218d5bd81120eafad70038bd5f Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@xxxxx.com>
+Date: Wed, 6 Sep 2023 21:42:18 -0400
+Subject: [PATCH] drivers: net: wireless: realtek: rtw88: usb-c
+
+Remove duplicate label and correct goto err_release_hw placement.
+
+drivers/net/wireless/realtek/rtw88/usb.c: In function ‘rtw_usb_probe’:
+drivers/net/wireless/realtek/rtw88/usb.c:878:1: error: duplicate label ‘err_free_rx_bufs’
+  878 | err_free_rx_bufs:
+
+Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
+---
+ drivers/net/wireless/realtek/rtw88/usb.c | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/drivers/net/wireless/realtek/rtw88/usb.c b/drivers/net/wireless/realtek/rtw88/usb.c
+index 7f98668cf084..d879d7e3dc81 100644
+--- a/drivers/net/wireless/realtek/rtw88/usb.c
++++ b/drivers/net/wireless/realtek/rtw88/usb.c
+@@ -822,7 +822,7 @@ int rtw_usb_probe(struct usb_interface *intf, const struct usb_device_id *id)
+ 
+ 	ret = rtw_usb_alloc_rx_bufs(rtwusb);
+ 	if (ret)
+-		goto err_free_rx_bufs;
++		goto err_release_hw;
+ 
+ 	ret = rtw_core_init(rtwdev);
+ 	if (ret)
+@@ -875,9 +875,6 @@ int rtw_usb_probe(struct usb_interface *intf, const struct usb_device_id *id)
+ err_free_rx_bufs:
+ 	rtw_usb_free_rx_bufs(rtwusb);
+ 
+-err_free_rx_bufs:
+-	rtw_usb_free_rx_bufs(rtwusb);
+-
+ err_release_hw:
+ 	ieee80211_free_hw(hw);
+ 
+-- 
+2.39.2
+

--- a/patch/misc/rtw88/6.5/002-drivers-net-wireless-realtek-rtw88-upstream-wireless.patch
+++ b/patch/misc/rtw88/6.5/002-drivers-net-wireless-realtek-rtw88-upstream-wireless.patch
@@ -88,3 +88,45 @@ index 2c1fb2dabd40..b19262ec5d8c 100644
 -- 
 2.41.0
 
+From 248429fc23232f218d5bd81120eafad70038bd5f Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@xxxxx.com>
+Date: Wed, 6 Sep 2023 21:42:18 -0400
+Subject: [PATCH] drivers: net: wireless: realtek: rtw88: usb-c
+
+Remove duplicate label and correct goto err_release_hw placement.
+
+drivers/net/wireless/realtek/rtw88/usb.c: In function ‘rtw_usb_probe’:
+drivers/net/wireless/realtek/rtw88/usb.c:878:1: error: duplicate label ‘err_free_rx_bufs’
+  878 | err_free_rx_bufs:
+
+Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
+---
+ drivers/net/wireless/realtek/rtw88/usb.c | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/drivers/net/wireless/realtek/rtw88/usb.c b/drivers/net/wireless/realtek/rtw88/usb.c
+index 7f98668cf084..d879d7e3dc81 100644
+--- a/drivers/net/wireless/realtek/rtw88/usb.c
++++ b/drivers/net/wireless/realtek/rtw88/usb.c
+@@ -822,7 +822,7 @@ int rtw_usb_probe(struct usb_interface *intf, const struct usb_device_id *id)
+ 
+ 	ret = rtw_usb_alloc_rx_bufs(rtwusb);
+ 	if (ret)
+-		goto err_free_rx_bufs;
++		goto err_release_hw;
+ 
+ 	ret = rtw_core_init(rtwdev);
+ 	if (ret)
+@@ -875,9 +875,6 @@ int rtw_usb_probe(struct usb_interface *intf, const struct usb_device_id *id)
+ err_free_rx_bufs:
+ 	rtw_usb_free_rx_bufs(rtwusb);
+ 
+-err_free_rx_bufs:
+-	rtw_usb_free_rx_bufs(rtwusb);
+-
+ err_release_hw:
+ 	ieee80211_free_hw(hw);
+ 
+-- 
+2.39.2
+


### PR DESCRIPTION
Linux 6.4.15 / 6.5.2

Remove duplicate label and correct goto err_release_hw placement.

drivers/net/wireless/realtek/rtw88/usb.c: In function ‘rtw_usb_probe’: drivers/net/wireless/realtek/rtw88/usb.c:878:1: error: duplicate label ‘err_free_rx_bufs’
  878 | err_free_rx_bufs:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
