### PR TITLE
SK-TDA4VM support

### DIFF
--- a/config/boards/sk-tda4vm.conf
+++ b/config/boards/sk-tda4vm.conf
@@ -1,0 +1,15 @@
+# TI TDA4VM dual core 4GB GBE USB3 OSPI DisplayPort HDMI
+
+BOARD_NAME="SK-TDA4VM"
+BOARDFAMILY="k3"
+BOARD_MAINTAINER="glneo"
+BOOTCONFIG="j721e_evm_a72_defconfig"
+BOOTFS_TYPE="fat"
+BOOT_FDT_FILE="ti/k3-j721e-sk.dts"
+TIBOOT3_BOOTCONFIG="j721e_evm_r5_defconfig"
+TIBOOT3_FILE="tiboot3-j721e-gp-evm.bin"
+SYSFW_FILE="sysfw-j721e-gp-evm.itb"
+DEFAULT_CONSOLE="serial"
+KERNEL_TARGET="current,edge"
+SERIALCON="ttyS2"
+ATF_BOARD="generic"


### PR DESCRIPTION
# Description

Hello all,

This PR adds support for the Texas Instruments SK-TDA4VM. Features,
schematics, and purchase links can be found on the board page[0].

Notable features:
 * 4GB LPDDR4‐4266 with support for inline ECC
 * DisplayPort (v1.4) 4K resolution with MST support and HDMI
 * Two CSI-2 ports compatible with Raspberry Pi
 * 8 TOPS deep learning performance and hardware-accelerated edge AI
 * Three USB 3.0 Type A ports, one USB 3.0 Type C port
 * Gigabit Ethernet and 4x CAN-FD Headers
 * M.2 Key E and M.2 Key M connectors

Thanks!

[0] https://www.ti.com/tool/SK-TDA4VM

Depends on #5686

# How Has This Been Tested?

- [x] Build/Boot tested Bookworm CLI/Minimal on Current(v6.1) and Edge(v6.5) kernels
- [x] Build/Boot tested Jammy CLI/Minimal on Current(v6.1) and Edge(v6.5) kernels
- [x] Gbit Ethernet works
- [x] HDMI works
- [x] USB 3.0 ports work

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
