### PR TITLE
rootfs-create: better output for debsums

### DIFF
--- a/lib/functions/rootfs/rootfs-create.sh
+++ b/lib/functions/rootfs/rootfs-create.sh
@@ -188,7 +188,17 @@ function create_new_rootfs_cache_via_debootstrap() {
 	# stage: check md5 sum of installed packages. Just in case. @TODO: rpardini: this should also be done when a cache is used, not only when it is created
 	display_alert "Checking MD5 sum of installed packages" "debsums" "info"
 	declare -g if_error_detail_message="Check MD5 sum of installed packages failed"
-	chroot_sdcard debsums --silent
+
+	# debsums outputs huge amount of data when called, these flags are used to manage that for better output:
+	## --silent: Silences the OK outputs
+	## --changed: Warn about changed files
+	## --list-missing: List missing files
+	## --report-missmatches: Report which file failed the check
+	chroot_sdcard debsums \
+		--silent \
+		--changed \
+		--list-missing \
+		--report-mismatches
 
 	# # Remove packages from packages.uninstall
 	# # @TODO: aggregation.py handling of this... if we wanted it removed in rootfs cache, why did we install it in the first place?


### PR DESCRIPTION
Currently it doesn't provide any data to what failed, this attempts to address it

---

*[If you appreciate my contributions to open-source projects, you might just find a way to bring a smile to Monero-chan's face, while also helping to keep the tea brewing on rainy days~ :p](https://github.com/Kreyren/kreyren/blob/master/README.md#donate)*