### PR TITLE
fix armbian-firstrun-config

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstrun-config
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstrun-config
@@ -69,35 +69,9 @@ do_firstrun_automated_user_configuration()
 		#-----------------------------------------------------------------------------
 		# Set Network
 		if [[ $FR_net_change_defaults == 1 ]]; then
-			# - Get 1st index of available wlan and eth adapters
-			local fp_ifconfig_tmp='/tmp/.ifconfig'
-			ifconfig -a | sed 's/[ \t].*//;/^\(lo\|\|bond0\|sit0\|ip6tnl0\)$/d' > "$fp_ifconfig_tmp" #export to file, should be quicker in loop than calling ifconfig each time.
-
-			# find eth[0-9]
-			for ((i=0; i<=9; i++))
-			do
-				if (( $(grep -ci -m1 "eth$i" "$fp_ifconfig_tmp") )); then
-					eth_index=eth${i}
-					break
-				fi
-			done
-
-			# Predictable Network Interface Names
-			[[ -z $eth_index ]] && eth_index=$(grep -m1 "en" "$fp_ifconfig_tmp" | cut -f1 -d":" | head -1)
-
-			# find wlan[0-9]
-			for ((i=0; i<=9; i++))
-			do
-				if (( $(grep -ci -m1 "wlan$i" "$fp_ifconfig_tmp") )); then
-					wlan_index=wlan${i}
-					break
-				fi
-			done
-
-			# Predictable Network Interface Names
-			[[ -z $wlan_index ]] && wlan_index=$(grep -m1 "wl" "$fp_ifconfig_tmp" | cut -f1 -d":" | head -1)
-
-			rm "$fp_ifconfig_tmp"
+			# - Get name of 1st available ethernet and wifi adapter
+			eth_index="$(nmcli d | grep ethernet | cut -d ' ' -f 1 | head -n 1)"
+			wlan_index="$(nmcli d | grep wifi | cut -d ' ' -f 1 | head -n 1)"
 
 			# for static IP we only append settings
 			if [[ $FR_net_use_static == 1 ]]; then


### PR DESCRIPTION
# Description

`armbian-firstrun-config` will silently fail in Armbian Bookworm when getting the list of network adapters due to `ifconfig` no longer being included by default. Fixed by replacing `ifconfig -a` with `nmcli device`.

# How Has This Been Tested?

- [x] Tested on fresh install of Debian Bookworm on an Orange Pi PC Plus 2E

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
