### PR TITLE
PARTIAL REVERT: `re-add rtw88 linux-6.2 / 6.3`

### DIFF
--- a/patch/misc/rtw88/6.2/001-drivers-net-wireless-realtek-rtw88-upstream-wireless.patch
+++ b/patch/misc/rtw88/6.2/001-drivers-net-wireless-realtek-rtw88-upstream-wireless.patch
@@ -1,0 +1,4248 @@
+From d1bf4f3c75e71f744841473a6f55284f814d52e2 Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@xxxxx.com>
+Date: Sat, 22 Jul 2023 04:30:58 -0400
+Subject: [PATCH] drivers: net: wireless: realtek: rtw88: upstream wireless
+
+linux-next backport: linux-6.2.y
+
+Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
+---
+ drivers/net/wireless/realtek/rtw88/Kconfig    |  47 +++++
+ drivers/net/wireless/realtek/rtw88/Makefile   |  15 ++
+ drivers/net/wireless/realtek/rtw88/bf.c       |  13 +-
+ drivers/net/wireless/realtek/rtw88/debug.c    |  59 ++++--
+ drivers/net/wireless/realtek/rtw88/debug.h    |   1 +
+ drivers/net/wireless/realtek/rtw88/fw.c       |  88 ++++++++-
+ drivers/net/wireless/realtek/rtw88/fw.h       |  15 +-
+ drivers/net/wireless/realtek/rtw88/mac.c      |  74 +++++--
+ drivers/net/wireless/realtek/rtw88/mac.h      |   1 -
+ drivers/net/wireless/realtek/rtw88/mac80211.c |  67 +++++--
+ drivers/net/wireless/realtek/rtw88/main.c     | 187 +++++++++++++++++-
+ drivers/net/wireless/realtek/rtw88/main.h     |  27 ++-
+ drivers/net/wireless/realtek/rtw88/pci.c      |  63 ++----
+ drivers/net/wireless/realtek/rtw88/ps.c       |  46 ++++-
+ drivers/net/wireless/realtek/rtw88/ps.h       |   2 +
+ drivers/net/wireless/realtek/rtw88/reg.h      |  14 ++
+ drivers/net/wireless/realtek/rtw88/rtw8723d.c |  16 +-
+ drivers/net/wireless/realtek/rtw88/rtw8723d.h |   6 +
+ drivers/net/wireless/realtek/rtw88/rtw8821c.c |  32 ++-
+ drivers/net/wireless/realtek/rtw88/rtw8821c.h |   6 +
+ drivers/net/wireless/realtek/rtw88/rtw8822b.c |  10 +
+ drivers/net/wireless/realtek/rtw88/rtw8822b.h |   8 +-
+ drivers/net/wireless/realtek/rtw88/rtw8822c.c |  10 +
+ drivers/net/wireless/realtek/rtw88/rtw8822c.h |   8 +-
+ drivers/net/wireless/realtek/rtw88/tx.c       | 135 +++++++++----
+ drivers/net/wireless/realtek/rtw88/tx.h       | 127 ++++++------
+ drivers/net/wireless/realtek/rtw88/usb.c      |  20 +-
+ drivers/net/wireless/realtek/rtw88/usb.h      |   2 +-
+ include/linux/mmc/sdio_ids.h                  |  10 +
+ 29 files changed, 870 insertions(+), 239 deletions(-)
+
+diff --git a/drivers/net/wireless/realtek/rtw88/Kconfig b/drivers/net/wireless/realtek/rtw88/Kconfig
+index 651ab56d9c6b..cffad1c01249 100644
+--- a/drivers/net/wireless/realtek/rtw88/Kconfig
++++ b/drivers/net/wireless/realtek/rtw88/Kconfig
+@@ -16,6 +16,9 @@ config RTW88_CORE
+ config RTW88_PCI
+ 	tristate
+ 
++config RTW88_SDIO
++	tristate
++
+ config RTW88_USB
+ 	tristate
+ 
+@@ -42,6 +45,17 @@ config RTW88_8822BE
+ 
+ 	  802.11ac PCIe wireless network adapter
+ 
++config RTW88_8822BS
++	tristate "Realtek 8822BS SDIO wireless network adapter"
++	depends on MMC
++	select RTW88_CORE
++	select RTW88_SDIO
++	select RTW88_8822B
++	help
++	  Select this option will enable support for 8822BS chipset
++
++	  802.11ac SDIO wireless network adapter
++
+ config RTW88_8822BU
+ 	tristate "Realtek 8822BU USB wireless network adapter"
+ 	depends on USB
+@@ -64,6 +78,17 @@ config RTW88_8822CE
+ 
+ 	  802.11ac PCIe wireless network adapter
+ 
++config RTW88_8822CS
++	tristate "Realtek 8822CS SDIO wireless network adapter"
++	depends on MMC
++	select RTW88_CORE
++	select RTW88_SDIO
++	select RTW88_8822C
++	help
++	  Select this option will enable support for 8822CS chipset
++
++	  802.11ac SDIO wireless network adapter
++
+ config RTW88_8822CU
+ 	tristate "Realtek 8822CU USB wireless network adapter"
+ 	depends on USB
+@@ -86,6 +111,17 @@ config RTW88_8723DE
+ 
+ 	  802.11n PCIe wireless network adapter
+ 
++config RTW88_8723DS
++	tristate "Realtek 8723DS SDIO wireless network adapter"
++	depends on MMC
++	select RTW88_CORE
++	select RTW88_SDIO
++	select RTW88_8723D
++	help
++	  Select this option will enable support for 8723DS chipset
++
++	  802.11n SDIO wireless network adapter
++
+ config RTW88_8723DU
+ 	tristate "Realtek 8723DU USB wireless network adapter"
+ 	depends on USB
+@@ -108,6 +144,17 @@ config RTW88_8821CE
+ 
+ 	  802.11ac PCIe wireless network adapter
+ 
++config RTW88_8821CS
++	tristate "Realtek 8821CS SDIO wireless network adapter"
++	depends on MMC
++	select RTW88_CORE
++	select RTW88_SDIO
++	select RTW88_8821C
++	help
++	  Select this option will enable support for 8821CS chipset
++
++	  802.11ac SDIO wireless network adapter
++
+ config RTW88_8821CU
+ 	tristate "Realtek 8821CU USB wireless network adapter"
+ 	depends on USB
+diff --git a/drivers/net/wireless/realtek/rtw88/Makefile b/drivers/net/wireless/realtek/rtw88/Makefile
+index fe7293ee87b4..fd212c09d88a 100644
+--- a/drivers/net/wireless/realtek/rtw88/Makefile
++++ b/drivers/net/wireless/realtek/rtw88/Makefile
+@@ -26,6 +26,9 @@ rtw88_8822b-objs		:= rtw8822b.o rtw8822b_table.o
+ obj-$(CONFIG_RTW88_8822BE)	+= rtw88_8822be.o
+ rtw88_8822be-objs		:= rtw8822be.o
+ 
++obj-$(CONFIG_RTW88_8822BS)	+= rtw88_8822bs.o
++rtw88_8822bs-objs		:= rtw8822bs.o
++
+ obj-$(CONFIG_RTW88_8822BU)	+= rtw88_8822bu.o
+ rtw88_8822bu-objs		:= rtw8822bu.o
+ 
+@@ -35,6 +38,9 @@ rtw88_8822c-objs		:= rtw8822c.o rtw8822c_table.o
+ obj-$(CONFIG_RTW88_8822CE)	+= rtw88_8822ce.o
+ rtw88_8822ce-objs		:= rtw8822ce.o
+ 
++obj-$(CONFIG_RTW88_8822CS)	+= rtw88_8822cs.o
++rtw88_8822cs-objs		:= rtw8822cs.o
++
+ obj-$(CONFIG_RTW88_8822CU)	+= rtw88_8822cu.o
+ rtw88_8822cu-objs		:= rtw8822cu.o
+ 
+@@ -44,6 +50,9 @@ rtw88_8723d-objs		:= rtw8723d.o rtw8723d_table.o
+ obj-$(CONFIG_RTW88_8723DE)	+= rtw88_8723de.o
+ rtw88_8723de-objs		:= rtw8723de.o
+ 
++obj-$(CONFIG_RTW88_8723DS)	+= rtw88_8723ds.o
++rtw88_8723ds-objs		:= rtw8723ds.o
++
+ obj-$(CONFIG_RTW88_8723DU)	+= rtw88_8723du.o
+ rtw88_8723du-objs		:= rtw8723du.o
+ 
+@@ -53,11 +62,17 @@ rtw88_8821c-objs		:= rtw8821c.o rtw8821c_table.o
+ obj-$(CONFIG_RTW88_8821CE)	+= rtw88_8821ce.o
+ rtw88_8821ce-objs		:= rtw8821ce.o
+ 
++obj-$(CONFIG_RTW88_8821CS)	+= rtw88_8821cs.o
++rtw88_8821cs-objs		:= rtw8821cs.o
++
+ obj-$(CONFIG_RTW88_8821CU)	+= rtw88_8821cu.o
+ rtw88_8821cu-objs		:= rtw8821cu.o
+ 
+ obj-$(CONFIG_RTW88_PCI)		+= rtw88_pci.o
+ rtw88_pci-objs			:= pci.o
+ 
++obj-$(CONFIG_RTW88_SDIO)	+= rtw88_sdio.o
++rtw88_sdio-objs			:= sdio.o
++
+ obj-$(CONFIG_RTW88_USB)		+= rtw88_usb.o
+ rtw88_usb-objs			:= usb.o
+diff --git a/drivers/net/wireless/realtek/rtw88/bf.c b/drivers/net/wireless/realtek/rtw88/bf.c
+index 038a30b170ef..c827c4a2814b 100644
+--- a/drivers/net/wireless/realtek/rtw88/bf.c
++++ b/drivers/net/wireless/realtek/rtw88/bf.c
+@@ -49,19 +49,23 @@ void rtw_bf_assoc(struct rtw_dev *rtwdev, struct ieee80211_vif *vif,
+ 
+ 	sta = ieee80211_find_sta(vif, bssid);
+ 	if (!sta) {
++		rcu_read_unlock();
++
+ 		rtw_warn(rtwdev, "failed to find station entry for bss %pM\n",
+ 			 bssid);
+-		goto out_unlock;
++		return;
+ 	}
+ 
+ 	ic_vht_cap = &hw->wiphy->bands[NL80211_BAND_5GHZ]->vht_cap;
+ 	vht_cap = &sta->deflink.vht_cap;
+ 
++	rcu_read_unlock();
++
+ 	if ((ic_vht_cap->cap & IEEE80211_VHT_CAP_MU_BEAMFORMEE_CAPABLE) &&
+ 	    (vht_cap->cap & IEEE80211_VHT_CAP_MU_BEAMFORMER_CAPABLE)) {
+ 		if (bfinfo->bfer_mu_cnt >= chip->bfer_mu_max_num) {
+ 			rtw_dbg(rtwdev, RTW_DBG_BF, "mu bfer number over limit\n");
+-			goto out_unlock;
++			return;
+ 		}
+ 
+ 		ether_addr_copy(bfee->mac_addr, bssid);
+@@ -75,7 +79,7 @@ void rtw_bf_assoc(struct rtw_dev *rtwdev, struct ieee80211_vif *vif,
+ 		   (vht_cap->cap & IEEE80211_VHT_CAP_SU_BEAMFORMER_CAPABLE)) {
+ 		if (bfinfo->bfer_su_cnt >= chip->bfer_su_max_num) {
+ 			rtw_dbg(rtwdev, RTW_DBG_BF, "su bfer number over limit\n");
+-			goto out_unlock;
++			return;
+ 		}
+ 
+ 		sound_dim = vht_cap->cap &
+@@ -98,9 +102,6 @@ void rtw_bf_assoc(struct rtw_dev *rtwdev, struct ieee80211_vif *vif,
+ 
+ 		rtw_chip_config_bfee(rtwdev, rtwvif, bfee, true);
+ 	}
+-
+-out_unlock:
+-	rcu_read_unlock();
+ }
+ 
+ void rtw_bf_init_bfer_entry_mu(struct rtw_dev *rtwdev,
+diff --git a/drivers/net/wireless/realtek/rtw88/debug.c b/drivers/net/wireless/realtek/rtw88/debug.c
+index fa3d73b333ba..f8ba133baff0 100644
+--- a/drivers/net/wireless/realtek/rtw88/debug.c
++++ b/drivers/net/wireless/realtek/rtw88/debug.c
+@@ -183,8 +183,8 @@ static int rtw_debugfs_copy_from_user(char tmp[], int size,
+ 
+ 	tmp_len = (count > size - 1 ? size - 1 : count);
+ 
+-	if (!buffer || copy_from_user(tmp, buffer, tmp_len))
+-		return count;
++	if (copy_from_user(tmp, buffer, tmp_len))
++		return -EFAULT;
+ 
+ 	tmp[tmp_len] = '\0';
+ 
+@@ -201,13 +201,16 @@ static ssize_t rtw_debugfs_set_read_reg(struct file *filp,
+ 	char tmp[32 + 1];
+ 	u32 addr, len;
+ 	int num;
++	int ret;
+ 
+-	rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 2);
++	ret = rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 2);
++	if (ret)
++		return ret;
+ 
+ 	num = sscanf(tmp, "%x %x", &addr, &len);
+ 
+ 	if (num !=  2)
+-		return count;
++		return -EINVAL;
+ 
+ 	if (len != 1 && len != 2 && len != 4) {
+ 		rtw_warn(rtwdev, "read reg setting wrong len\n");
+@@ -288,8 +291,11 @@ static ssize_t rtw_debugfs_set_rsvd_page(struct file *filp,
+ 	char tmp[32 + 1];
+ 	u32 offset, page_num;
+ 	int num;
++	int ret;
+ 
+-	rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 2);
++	ret = rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 2);
++	if (ret)
++		return ret;
+ 
+ 	num = sscanf(tmp, "%d %d", &offset, &page_num);
+ 
+@@ -314,8 +320,11 @@ static ssize_t rtw_debugfs_set_single_input(struct file *filp,
+ 	char tmp[32 + 1];
+ 	u32 input;
+ 	int num;
++	int ret;
+ 
+-	rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 1);
++	ret = rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 1);
++	if (ret)
++		return ret;
+ 
+ 	num = kstrtoint(tmp, 0, &input);
+ 
+@@ -338,14 +347,17 @@ static ssize_t rtw_debugfs_set_write_reg(struct file *filp,
+ 	char tmp[32 + 1];
+ 	u32 addr, val, len;
+ 	int num;
++	int ret;
+ 
+-	rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 3);
++	ret = rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 3);
++	if (ret)
++		return ret;
+ 
+ 	/* write BB/MAC register */
+ 	num = sscanf(tmp, "%x %x %x", &addr, &val, &len);
+ 
+ 	if (num !=  3)
+-		return count;
++		return -EINVAL;
+ 
+ 	switch (len) {
+ 	case 1:
+@@ -381,8 +393,11 @@ static ssize_t rtw_debugfs_set_h2c(struct file *filp,
+ 	char tmp[32 + 1];
+ 	u8 param[8];
+ 	int num;
++	int ret;
+ 
+-	rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 3);
++	ret = rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 3);
++	if (ret)
++		return ret;
+ 
+ 	num = sscanf(tmp, "%hhx,%hhx,%hhx,%hhx,%hhx,%hhx,%hhx,%hhx",
+ 		     &param[0], &param[1], &param[2], &param[3],
+@@ -408,14 +423,17 @@ static ssize_t rtw_debugfs_set_rf_write(struct file *filp,
+ 	char tmp[32 + 1];
+ 	u32 path, addr, mask, val;
+ 	int num;
++	int ret;
+ 
+-	rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 4);
++	ret = rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 4);
++	if (ret)
++		return ret;
+ 
+ 	num = sscanf(tmp, "%x %x %x %x", &path, &addr, &mask, &val);
+ 
+ 	if (num !=  4) {
+ 		rtw_warn(rtwdev, "invalid args, [path] [addr] [mask] [val]\n");
+-		return count;
++		return -EINVAL;
+ 	}
+ 
+ 	mutex_lock(&rtwdev->mutex);
+@@ -438,14 +456,17 @@ static ssize_t rtw_debugfs_set_rf_read(struct file *filp,
+ 	char tmp[32 + 1];
+ 	u32 path, addr, mask;
+ 	int num;
++	int ret;
+ 
+-	rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 3);
++	ret = rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 3);
++	if (ret)
++		return ret;
+ 
+ 	num = sscanf(tmp, "%x %x %x", &path, &addr, &mask);
+ 
+ 	if (num !=  3) {
+ 		rtw_warn(rtwdev, "invalid args, [path] [addr] [mask] [val]\n");
+-		return count;
++		return -EINVAL;
+ 	}
+ 
+ 	debugfs_priv->rf_path = path;
+@@ -467,7 +488,9 @@ static ssize_t rtw_debugfs_set_fix_rate(struct file *filp,
+ 	char tmp[32 + 1];
+ 	int ret;
+ 
+-	rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 1);
++	ret = rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 1);
++	if (ret)
++		return ret;
+ 
+ 	ret = kstrtou8(tmp, 0, &fix_rate);
+ 	if (ret) {
+@@ -860,7 +883,9 @@ static ssize_t rtw_debugfs_set_coex_enable(struct file *filp,
+ 	bool enable;
+ 	int ret;
+ 
+-	rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 1);
++	ret = rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 1);
++	if (ret)
++		return ret;
+ 
+ 	ret = kstrtobool(tmp, &enable);
+ 	if (ret) {
+@@ -930,7 +955,9 @@ static ssize_t rtw_debugfs_set_fw_crash(struct file *filp,
+ 	bool input;
+ 	int ret;
+ 
+-	rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 1);
++	ret = rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 1);
++	if (ret)
++		return ret;
+ 
+ 	ret = kstrtobool(tmp, &input);
+ 	if (ret)
+diff --git a/drivers/net/wireless/realtek/rtw88/debug.h b/drivers/net/wireless/realtek/rtw88/debug.h
+index 066792dd96af..a9149c6c2b48 100644
+--- a/drivers/net/wireless/realtek/rtw88/debug.h
++++ b/drivers/net/wireless/realtek/rtw88/debug.h
+@@ -24,6 +24,7 @@ enum rtw_debug_mask {
+ 	RTW_DBG_ADAPTIVITY	= 0x00008000,
+ 	RTW_DBG_HW_SCAN		= 0x00010000,
+ 	RTW_DBG_STATE		= 0x00020000,
++	RTW_DBG_SDIO		= 0x00040000,
+ 
+ 	RTW_DBG_ALL		= 0xffffffff
+ };
+diff --git a/drivers/net/wireless/realtek/rtw88/fw.c b/drivers/net/wireless/realtek/rtw88/fw.c
+index 82295ac6402e..567bbedd8ee0 100644
+--- a/drivers/net/wireless/realtek/rtw88/fw.c
++++ b/drivers/net/wireless/realtek/rtw88/fw.c
+@@ -308,6 +308,57 @@ void rtw_fw_c2h_cmd_isr(struct rtw_dev *rtwdev)
+ }
+ EXPORT_SYMBOL(rtw_fw_c2h_cmd_isr);
+ 
++static void rtw_fw_send_h2c_command_register(struct rtw_dev *rtwdev,
++					     struct rtw_h2c_register *h2c)
++{
++	u32 box_reg, box_ex_reg;
++	u8 box_state, box;
++	int ret;
++
++	rtw_dbg(rtwdev, RTW_DBG_FW, "send H2C content %08x %08x\n", h2c->w0,
++		h2c->w1);
++
++	lockdep_assert_held(&rtwdev->mutex);
++
++	box = rtwdev->h2c.last_box_num;
++	switch (box) {
++	case 0:
++		box_reg = REG_HMEBOX0;
++		box_ex_reg = REG_HMEBOX0_EX;
++		break;
++	case 1:
++		box_reg = REG_HMEBOX1;
++		box_ex_reg = REG_HMEBOX1_EX;
++		break;
++	case 2:
++		box_reg = REG_HMEBOX2;
++		box_ex_reg = REG_HMEBOX2_EX;
++		break;
++	case 3:
++		box_reg = REG_HMEBOX3;
++		box_ex_reg = REG_HMEBOX3_EX;
++		break;
++	default:
++		WARN(1, "invalid h2c mail box number\n");
++		return;
++	}
++
++	ret = read_poll_timeout_atomic(rtw_read8, box_state,
++				       !((box_state >> box) & 0x1), 100, 3000,
++				       false, rtwdev, REG_HMETFR);
++
++	if (ret) {
++		rtw_err(rtwdev, "failed to send h2c command\n");
++		return;
++	}
++
++	rtw_write32(rtwdev, box_ex_reg, h2c->w1);
++	rtw_write32(rtwdev, box_reg, h2c->w0);
++
++	if (++rtwdev->h2c.last_box_num >= 4)
++		rtwdev->h2c.last_box_num = 0;
++}
++
+ static void rtw_fw_send_h2c_command(struct rtw_dev *rtwdev,
+ 				    u8 *h2c)
+ {
+@@ -468,6 +519,23 @@ void rtw_fw_query_bt_info(struct rtw_dev *rtwdev)
+ 	rtw_fw_send_h2c_command(rtwdev, h2c_pkt);
+ }
+ 
++void rtw_fw_default_port(struct rtw_dev *rtwdev, struct rtw_vif *rtwvif)
++{
++	struct rtw_h2c_register h2c = {};
++
++	if (rtwvif->net_type != RTW_NET_MGD_LINKED)
++		return;
++
++	/* Leave LPS before default port H2C so FW timer is correct */
++	rtw_leave_lps(rtwdev);
++
++	h2c.w0 = u32_encode_bits(H2C_CMD_DEFAULT_PORT, RTW_H2C_W0_CMDID) |
++		 u32_encode_bits(rtwvif->port, RTW_H2C_DEFAULT_PORT_W0_PORTID) |
++		 u32_encode_bits(rtwvif->mac_id, RTW_H2C_DEFAULT_PORT_W0_MACID);
++
++	rtw_fw_send_h2c_command_register(rtwdev, &h2c);
++}
++
+ void rtw_fw_wl_ch_info(struct rtw_dev *rtwdev, u8 link, u8 ch, u8 bw)
+ {
+ 	u8 h2c_pkt[H2C_PKT_SIZE] = {0};
+@@ -1393,6 +1461,10 @@ static void rtw_build_rsvd_page_iter(void *data, u8 *mac,
+ 	struct rtw_vif *rtwvif = (struct rtw_vif *)vif->drv_priv;
+ 	struct rtw_rsvd_page *rsvd_pkt;
+ 
++	/* AP not yet started, don't gather its rsvd pages */
++	if (vif->type == NL80211_IFTYPE_AP && !rtwdev->ap_active)
++		return;
++
+ 	list_for_each_entry(rsvd_pkt, &rtwvif->rsvd_page_list, vif_list) {
+ 		if (rsvd_pkt->type == RSVD_BEACON)
+ 			list_add(&rsvd_pkt->build_list,
+@@ -1614,6 +1686,7 @@ void rtw_fw_update_beacon_work(struct work_struct *work)
+ 
+ 	mutex_lock(&rtwdev->mutex);
+ 	rtw_fw_download_rsvd_page(rtwdev);
++	rtw_send_rsvd_page_h2c(rtwdev);
+ 	mutex_unlock(&rtwdev->mutex);
+ }
+ 
+@@ -2155,11 +2228,19 @@ int rtw_hw_scan_offload(struct rtw_dev *rtwdev, struct ieee80211_vif *vif,
+ 	}
+ 	rtw_fw_set_scan_offload(rtwdev, &cs_option, rtwvif, &chan_list);
+ out:
++	if (rtwdev->ap_active) {
++		ret = rtw_download_beacon(rtwdev);
++		if (ret)
++			rtw_err(rtwdev, "HW scan download beacon failed\n");
++	}
++
+ 	return ret;
+ }
+ 
+-void rtw_hw_scan_abort(struct rtw_dev *rtwdev, struct ieee80211_vif *vif)
++void rtw_hw_scan_abort(struct rtw_dev *rtwdev)
+ {
++	struct ieee80211_vif *vif = rtwdev->scan_info.scanning_vif;
++
+ 	if (!rtw_fw_feature_check(&rtwdev->fw, FW_FEATURE_SCAN_OFFLOAD))
+ 		return;
+ 
+@@ -2244,6 +2325,7 @@ void rtw_hw_scan_chan_switch(struct rtw_dev *rtwdev, struct sk_buff *skb)
+ 		if (rtw_is_op_chan(rtwdev, chan)) {
+ 			rtw_store_op_chan(rtwdev, false);
+ 			ieee80211_wake_queues(rtwdev->hw);
++			rtw_core_enable_beacon(rtwdev, true);
+ 		}
+ 	} else if (id == RTW_SCAN_NOTIFY_ID_PRESWITCH) {
+ 		if (IS_CH_5G_BAND(chan)) {
+@@ -2262,8 +2344,10 @@ void rtw_hw_scan_chan_switch(struct rtw_dev *rtwdev, struct sk_buff *skb)
+ 		 * if next channel is non-op channel.
+ 		 */
+ 		if (!rtw_is_op_chan(rtwdev, chan) &&
+-		    rtw_is_op_chan(rtwdev, hal->current_channel))
++		    rtw_is_op_chan(rtwdev, hal->current_channel)) {
++			rtw_core_enable_beacon(rtwdev, false);
+ 			ieee80211_stop_queues(rtwdev->hw);
++		}
+ 	}
+ 
+ 	rtw_dbg(rtwdev, RTW_DBG_HW_SCAN,
+diff --git a/drivers/net/wireless/realtek/rtw88/fw.h b/drivers/net/wireless/realtek/rtw88/fw.h
+index 0a386e6d6e0d..43ccdf9965ac 100644
+--- a/drivers/net/wireless/realtek/rtw88/fw.h
++++ b/drivers/net/wireless/realtek/rtw88/fw.h
+@@ -81,6 +81,17 @@ struct rtw_c2h_adaptivity {
+ 	u8 option;
+ } __packed;
+ 
++struct rtw_h2c_register {
++	u32 w0;
++	u32 w1;
++} __packed;
++
++#define RTW_H2C_W0_CMDID		GENMASK(7, 0)
++
++/* H2C_CMD_DEFAULT_PORT command */
++#define RTW_H2C_DEFAULT_PORT_W0_PORTID	GENMASK(15, 8)
++#define RTW_H2C_DEFAULT_PORT_W0_MACID	GENMASK(23, 16)
++
+ struct rtw_h2c_cmd {
+ 	__le32 msg;
+ 	__le32 msg_ext;
+@@ -530,6 +541,7 @@ static inline void rtw_h2c_pkt_set_header(u8 *h2c_pkt, u8 sub_id)
+ #define H2C_CMD_MEDIA_STATUS_RPT	0x01
+ #define H2C_CMD_SET_PWR_MODE		0x20
+ #define H2C_CMD_LPS_PG_INFO		0x2b
++#define H2C_CMD_DEFAULT_PORT		0x2c
+ #define H2C_CMD_RA_INFO			0x40
+ #define H2C_CMD_RSSI_MONITOR		0x42
+ #define H2C_CMD_BCN_FILTER_OFFLOAD_P0	0x56
+@@ -801,6 +813,7 @@ void rtw_fw_c2h_cmd_rx_irqsafe(struct rtw_dev *rtwdev, u32 pkt_offset,
+ void rtw_fw_c2h_cmd_handle(struct rtw_dev *rtwdev, struct sk_buff *skb);
+ void rtw_fw_send_general_info(struct rtw_dev *rtwdev);
+ void rtw_fw_send_phydm_info(struct rtw_dev *rtwdev);
++void rtw_fw_default_port(struct rtw_dev *rtwdev, struct rtw_vif *rtwvif);
+ 
+ void rtw_fw_do_iqk(struct rtw_dev *rtwdev, struct rtw_iqk_para *para);
+ void rtw_fw_inform_rfk_status(struct rtw_dev *rtwdev, bool start);
+@@ -868,5 +881,5 @@ int rtw_hw_scan_offload(struct rtw_dev *rtwdev, struct ieee80211_vif *vif,
+ 			bool enable);
+ void rtw_hw_scan_status_report(struct rtw_dev *rtwdev, struct sk_buff *skb);
+ void rtw_hw_scan_chan_switch(struct rtw_dev *rtwdev, struct sk_buff *skb);
+-void rtw_hw_scan_abort(struct rtw_dev *rtwdev, struct ieee80211_vif *vif);
++void rtw_hw_scan_abort(struct rtw_dev *rtwdev);
+ #endif
+diff --git a/drivers/net/wireless/realtek/rtw88/mac.c b/drivers/net/wireless/realtek/rtw88/mac.c
+index 8625a0a1430a..298663b03580 100644
+--- a/drivers/net/wireless/realtek/rtw88/mac.c
++++ b/drivers/net/wireless/realtek/rtw88/mac.c
+@@ -7,6 +7,7 @@
+ #include "reg.h"
+ #include "fw.h"
+ #include "debug.h"
++#include "sdio.h"
+ 
+ void rtw_set_channel_mac(struct rtw_dev *rtwdev, u8 channel, u8 bw,
+ 			 u8 primary_ch_idx)
+@@ -60,6 +61,7 @@ EXPORT_SYMBOL(rtw_set_channel_mac);
+ 
+ static int rtw_mac_pre_system_cfg(struct rtw_dev *rtwdev)
+ {
++	unsigned int retry;
+ 	u32 value32;
+ 	u8 value8;
+ 
+@@ -77,6 +79,28 @@ static int rtw_mac_pre_system_cfg(struct rtw_dev *rtwdev)
+ 	case RTW_HCI_TYPE_PCIE:
+ 		rtw_write32_set(rtwdev, REG_HCI_OPT_CTRL, BIT_USB_SUS_DIS);
+ 		break;
++	case RTW_HCI_TYPE_SDIO:
++		rtw_write8_clr(rtwdev, REG_SDIO_HSUS_CTRL, BIT_HCI_SUS_REQ);
++
++		for (retry = 0; retry < RTW_PWR_POLLING_CNT; retry++) {
++			if (rtw_read8(rtwdev, REG_SDIO_HSUS_CTRL) & BIT_HCI_RESUME_RDY)
++				break;
++
++			usleep_range(10, 50);
++		}
++
++		if (retry == RTW_PWR_POLLING_CNT) {
++			rtw_err(rtwdev, "failed to poll REG_SDIO_HSUS_CTRL[1]");
++			return -ETIMEDOUT;
++		}
++
++		if (rtw_sdio_is_sdio30_supported(rtwdev))
++			rtw_write8_set(rtwdev, REG_HCI_OPT_CTRL + 2,
++				       BIT_SDIO_PAD_E5 >> 16);
++		else
++			rtw_write8_clr(rtwdev, REG_HCI_OPT_CTRL + 2,
++				       BIT_SDIO_PAD_E5 >> 16);
++		break;
+ 	case RTW_HCI_TYPE_USB:
+ 		break;
+ 	default:
+@@ -217,10 +241,13 @@ static int rtw_pwr_seq_parser(struct rtw_dev *rtwdev,
+ 	cut_mask = cut_version_to_mask(cut);
+ 	switch (rtw_hci_type(rtwdev)) {
+ 	case RTW_HCI_TYPE_PCIE:
+-		intf_mask = BIT(2);
++		intf_mask = RTW_PWR_INTF_PCI_MSK;
+ 		break;
+ 	case RTW_HCI_TYPE_USB:
+-		intf_mask = BIT(1);
++		intf_mask = RTW_PWR_INTF_USB_MSK;
++		break;
++	case RTW_HCI_TYPE_SDIO:
++		intf_mask = RTW_PWR_INTF_SDIO_MSK;
+ 		break;
+ 	default:
+ 		return -EINVAL;
+@@ -245,6 +272,7 @@ static int rtw_mac_power_switch(struct rtw_dev *rtwdev, bool pwr_on)
+ {
+ 	const struct rtw_chip_info *chip = rtwdev->chip;
+ 	const struct rtw_pwr_seq_cmd **pwr_seq;
++	u32 imr = 0;
+ 	u8 rpwm;
+ 	bool cur_pwr;
+ 	int ret;
+@@ -270,17 +298,24 @@ static int rtw_mac_power_switch(struct rtw_dev *rtwdev, bool pwr_on)
+ 	if (pwr_on == cur_pwr)
+ 		return -EALREADY;
+ 
++	if (rtw_hci_type(rtwdev) == RTW_HCI_TYPE_SDIO) {
++		imr = rtw_read32(rtwdev, REG_SDIO_HIMR);
++		rtw_write32(rtwdev, REG_SDIO_HIMR, 0);
++	}
++
++	if (!pwr_on)
++		clear_bit(RTW_FLAG_POWERON, rtwdev->flags);
++
+ 	pwr_seq = pwr_on ? chip->pwr_on_seq : chip->pwr_off_seq;
+ 	ret = rtw_pwr_seq_parser(rtwdev, pwr_seq);
+-	if (ret)
+-		return ret;
+ 
+-	if (pwr_on)
++	if (rtw_hci_type(rtwdev) == RTW_HCI_TYPE_SDIO)
++		rtw_write32(rtwdev, REG_SDIO_HIMR, imr);
++
++	if (!ret && pwr_on)
+ 		set_bit(RTW_FLAG_POWERON, rtwdev->flags);
+-	else
+-		clear_bit(RTW_FLAG_POWERON, rtwdev->flags);
+ 
+-	return 0;
++	return ret;
+ }
+ 
+ static int __rtw_mac_init_system_cfg(struct rtw_dev *rtwdev)
+@@ -451,6 +486,9 @@ static void download_firmware_reg_backup(struct rtw_dev *rtwdev,
+ 	rtw_write16(rtwdev, REG_FIFOPAGE_INFO_1, 0x200);
+ 	rtw_write32(rtwdev, REG_RQPN_CTRL_2, bckp[bckp_idx - 1].val);
+ 
++	if (rtw_hci_type(rtwdev) == RTW_HCI_TYPE_SDIO)
++		rtw_read32(rtwdev, REG_SDIO_FREE_TXPG);
++
+ 	/* Disable beacon related functions */
+ 	tmp = rtw_read8(rtwdev, REG_BCN_CTRL);
+ 	bckp[bckp_idx].len = 1;
+@@ -756,8 +794,10 @@ static int __rtw_download_firmware(struct rtw_dev *rtwdev,
+ 
+ 	wlan_cpu_enable(rtwdev, true);
+ 
+-	if (!ltecoex_reg_write(rtwdev, 0x38, ltecoex_bckp))
+-		return -EBUSY;
++	if (!ltecoex_reg_write(rtwdev, 0x38, ltecoex_bckp)) {
++		ret = -EBUSY;
++		goto dlfw_fail;
++	}
+ 
+ 	ret = download_firmware_validate(rtwdev);
+ 	if (ret)
+@@ -1042,6 +1082,9 @@ static int txdma_queue_mapping(struct rtw_dev *rtwdev)
+ 		else
+ 			return -EINVAL;
+ 		break;
++	case RTW_HCI_TYPE_SDIO:
++		rqpn = &chip->rqpn_table[0];
++		break;
+ 	default:
+ 		return -EINVAL;
+ 	}
+@@ -1060,8 +1103,12 @@ static int txdma_queue_mapping(struct rtw_dev *rtwdev)
+ 	if (rtw_chip_wcpu_11ac(rtwdev))
+ 		rtw_write32(rtwdev, REG_H2CQ_CSR, BIT_H2CQ_FULL);
+ 
+-	if (rtw_hci_type(rtwdev) == RTW_HCI_TYPE_USB)
++	if (rtw_hci_type(rtwdev) == RTW_HCI_TYPE_SDIO) {
++		rtw_read32(rtwdev, REG_SDIO_FREE_TXPG);
++		rtw_write32(rtwdev, REG_SDIO_TX_CTRL, 0);
++	} else if (rtw_hci_type(rtwdev) == RTW_HCI_TYPE_USB) {
+ 		rtw_write8_set(rtwdev, REG_TXDMA_PQ_MAP, BIT_RXDMA_ARBBW_EN);
++	}
+ 
+ 	return 0;
+ }
+@@ -1074,7 +1121,7 @@ static int set_trx_fifo_info(struct rtw_dev *rtwdev)
+ 	u8 csi_buf_pg_num = chip->csi_buf_pg_num;
+ 
+ 	/* config rsvd page num */
+-	fifo->rsvd_drv_pg_num = 8;
++	fifo->rsvd_drv_pg_num = chip->rsvd_drv_pg_num;
+ 	fifo->txff_pg_num = chip->txff_size >> 7;
+ 	if (rtw_chip_wcpu_11n(rtwdev))
+ 		fifo->rsvd_pg_num = fifo->rsvd_drv_pg_num;
+@@ -1204,6 +1251,9 @@ static int priority_queue_cfg(struct rtw_dev *rtwdev)
+ 		else
+ 			return -EINVAL;
+ 		break;
++	case RTW_HCI_TYPE_SDIO:
++		pg_tbl = &chip->page_table[0];
++		break;
+ 	default:
+ 		return -EINVAL;
+ 	}
+diff --git a/drivers/net/wireless/realtek/rtw88/mac.h b/drivers/net/wireless/realtek/rtw88/mac.h
+index 3172aa5ac4de..58c3dccc14bb 100644
+--- a/drivers/net/wireless/realtek/rtw88/mac.h
++++ b/drivers/net/wireless/realtek/rtw88/mac.h
+@@ -7,7 +7,6 @@
+ 
+ #define RTW_HW_PORT_NUM		5
+ #define cut_version_to_mask(cut) (0x1 << ((cut) + 1))
+-#define SDIO_LOCAL_OFFSET	0x10250000
+ #define DDMA_POLLING_COUNT	1000
+ #define C2H_PKT_BUF		256
+ #define REPORT_BUF		128
+diff --git a/drivers/net/wireless/realtek/rtw88/mac80211.c b/drivers/net/wireless/realtek/rtw88/mac80211.c
+index 3b92ac611d3f..a99b53d44267 100644
+--- a/drivers/net/wireless/realtek/rtw88/mac80211.c
++++ b/drivers/net/wireless/realtek/rtw88/mac80211.c
+@@ -43,7 +43,11 @@ static void rtw_ops_wake_tx_queue(struct ieee80211_hw *hw,
+ 		list_add_tail(&rtwtxq->list, &rtwdev->txqs);
+ 	spin_unlock_bh(&rtwdev->txq_lock);
+ 
+-	queue_work(rtwdev->tx_wq, &rtwdev->tx_work);
++	/* ensure to dequeue EAPOL (4/4) at the right time */
++	if (txq->ac == IEEE80211_AC_VO)
++		__rtw_tx_work(rtwdev);
++	else
++		queue_work(rtwdev->tx_wq, &rtwdev->tx_work);
+ }
+ 
+ static int rtw_ops_start(struct ieee80211_hw *hw)
+@@ -88,15 +92,6 @@ static int rtw_ops_config(struct ieee80211_hw *hw, u32 changed)
+ 		}
+ 	}
+ 
+-	if (changed & IEEE80211_CONF_CHANGE_PS) {
+-		if (hw->conf.flags & IEEE80211_CONF_PS) {
+-			rtwdev->ps_enabled = true;
+-		} else {
+-			rtwdev->ps_enabled = false;
+-			rtw_leave_lps(rtwdev);
+-		}
+-	}
+-
+ 	if (changed & IEEE80211_CONF_CHANGE_CHANNEL)
+ 		rtw_set_channel(rtwdev);
+ 
+@@ -155,25 +150,32 @@ static int rtw_ops_add_interface(struct ieee80211_hw *hw,
+ 	struct rtw_vif *rtwvif = (struct rtw_vif *)vif->drv_priv;
+ 	enum rtw_net_type net_type;
+ 	u32 config = 0;
+-	u8 port = 0;
++	u8 port;
+ 	u8 bcn_ctrl = 0;
+ 
+ 	if (rtw_fw_feature_check(&rtwdev->fw, FW_FEATURE_BCN_FILTER))
+ 		vif->driver_flags |= IEEE80211_VIF_BEACON_FILTER |
+ 				     IEEE80211_VIF_SUPPORTS_CQM_RSSI;
+-	rtwvif->port = port;
+ 	rtwvif->stats.tx_unicast = 0;
+ 	rtwvif->stats.rx_unicast = 0;
+ 	rtwvif->stats.tx_cnt = 0;
+ 	rtwvif->stats.rx_cnt = 0;
+ 	rtwvif->scan_req = NULL;
+ 	memset(&rtwvif->bfee, 0, sizeof(struct rtw_bfee));
+-	rtwvif->conf = &rtw_vif_port[port];
+ 	rtw_txq_init(rtwdev, vif->txq);
+ 	INIT_LIST_HEAD(&rtwvif->rsvd_page_list);
+ 
+ 	mutex_lock(&rtwdev->mutex);
+ 
++	port = find_first_zero_bit(rtwdev->hw_port, RTW_PORT_NUM);
++	if (port >= RTW_PORT_NUM) {
++		mutex_unlock(&rtwdev->mutex);
++		return -EINVAL;
++	}
++	set_bit(port, rtwdev->hw_port);
++
++	rtwvif->port = port;
++	rtwvif->conf = &rtw_vif_port[port];
+ 	rtw_leave_lps_deep(rtwdev);
+ 
+ 	switch (vif->type) {
+@@ -195,6 +197,7 @@ static int rtw_ops_add_interface(struct ieee80211_hw *hw,
+ 		break;
+ 	default:
+ 		WARN_ON(1);
++		clear_bit(rtwvif->port, rtwdev->hw_port);
+ 		mutex_unlock(&rtwdev->mutex);
+ 		return -EINVAL;
+ 	}
+@@ -206,6 +209,8 @@ static int rtw_ops_add_interface(struct ieee80211_hw *hw,
+ 	rtwvif->bcn_ctrl = bcn_ctrl;
+ 	config |= PORT_SET_BCN_CTRL;
+ 	rtw_vif_port_config(rtwdev, rtwvif, config);
++	rtw_core_port_switch(rtwdev, vif);
++	rtw_recalc_lps(rtwdev, vif);
+ 
+ 	mutex_unlock(&rtwdev->mutex);
+ 
+@@ -236,6 +241,8 @@ static void rtw_ops_remove_interface(struct ieee80211_hw *hw,
+ 	rtwvif->bcn_ctrl = 0;
+ 	config |= PORT_SET_BCN_CTRL;
+ 	rtw_vif_port_config(rtwdev, rtwvif, config);
++	clear_bit(rtwvif->port, rtwdev->hw_port);
++	rtw_recalc_lps(rtwdev, NULL);
+ 
+ 	mutex_unlock(&rtwdev->mutex);
+ }
+@@ -375,6 +382,7 @@ static void rtw_ops_bss_info_changed(struct ieee80211_hw *hw,
+ 
+ 			rtw_fw_download_rsvd_page(rtwdev);
+ 			rtw_send_rsvd_page_h2c(rtwdev);
++			rtw_fw_default_port(rtwdev, rtwvif);
+ 			rtw_coex_media_status_notify(rtwdev, vif->cfg.assoc);
+ 			if (rtw_bf_support)
+ 				rtw_bf_assoc(rtwdev, vif, conf);
+@@ -385,7 +393,8 @@ static void rtw_ops_bss_info_changed(struct ieee80211_hw *hw,
+ 			 * when disconnected by peer
+ 			 */
+ 			if (test_bit(RTW_FLAG_SCANNING, rtwdev->flags))
+-				rtw_hw_scan_abort(rtwdev, vif);
++				rtw_hw_scan_abort(rtwdev);
++
+ 		}
+ 
+ 		config |= PORT_SET_NET_TYPE;
+@@ -395,7 +404,7 @@ static void rtw_ops_bss_info_changed(struct ieee80211_hw *hw,
+ 	if (changed & BSS_CHANGED_BSSID) {
+ 		ether_addr_copy(rtwvif->bssid, conf->bssid);
+ 		config |= PORT_SET_BSSID;
+-		if (is_zero_ether_addr(rtwvif->bssid))
++		if (!rtw_core_check_sta_active(rtwdev))
+ 			rtw_clear_op_chan(rtwdev);
+ 		else
+ 			rtw_store_op_chan(rtwdev, true);
+@@ -409,6 +418,7 @@ static void rtw_ops_bss_info_changed(struct ieee80211_hw *hw,
+ 	if (changed & BSS_CHANGED_BEACON) {
+ 		rtw_set_dtim_period(rtwdev, conf->dtim_period);
+ 		rtw_fw_download_rsvd_page(rtwdev);
++		rtw_send_rsvd_page_h2c(rtwdev);
+ 	}
+ 
+ 	if (changed & BSS_CHANGED_BEACON_ENABLED) {
+@@ -428,6 +438,9 @@ static void rtw_ops_bss_info_changed(struct ieee80211_hw *hw,
+ 	if (changed & BSS_CHANGED_ERP_SLOT)
+ 		rtw_conf_tx(rtwdev, rtwvif);
+ 
++	if (changed & BSS_CHANGED_PS)
++		rtw_recalc_lps(rtwdev, NULL);
++
+ 	rtw_vif_port_config(rtwdev, rtwvif, config);
+ 
+ 	mutex_unlock(&rtwdev->mutex);
+@@ -441,12 +454,29 @@ static int rtw_ops_start_ap(struct ieee80211_hw *hw,
+ 	const struct rtw_chip_info *chip = rtwdev->chip;
+ 
+ 	mutex_lock(&rtwdev->mutex);
++	rtw_write32_set(rtwdev, REG_TCR, BIT_TCR_UPDATE_HGQMD);
++	rtwdev->ap_active = true;
++	rtw_store_op_chan(rtwdev, true);
+ 	chip->ops->phy_calibration(rtwdev);
+ 	mutex_unlock(&rtwdev->mutex);
+ 
+ 	return 0;
+ }
+ 
++static void rtw_ops_stop_ap(struct ieee80211_hw *hw,
++			    struct ieee80211_vif *vif,
++			    struct ieee80211_bss_conf *link_conf)
++{
++	struct rtw_dev *rtwdev = hw->priv;
++
++	mutex_lock(&rtwdev->mutex);
++	rtw_write32_clr(rtwdev, REG_TCR, BIT_TCR_UPDATE_HGQMD);
++	rtwdev->ap_active = false;
++	if (!rtw_core_check_sta_active(rtwdev))
++		rtw_clear_op_chan(rtwdev);
++	mutex_unlock(&rtwdev->mutex);
++}
++
+ static int rtw_ops_conf_tx(struct ieee80211_hw *hw,
+ 			   struct ieee80211_vif *vif,
+ 			   unsigned int link_id, u16 ac,
+@@ -849,7 +879,7 @@ static int rtw_ops_hw_scan(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
+ 	rtw_hw_scan_start(rtwdev, vif, req);
+ 	ret = rtw_hw_scan_offload(rtwdev, vif, true);
+ 	if (ret) {
+-		rtw_hw_scan_abort(rtwdev, vif);
++		rtw_hw_scan_abort(rtwdev);
+ 		rtw_err(rtwdev, "HW scan failed with status: %d\n", ret);
+ 	}
+ 	mutex_unlock(&rtwdev->mutex);
+@@ -869,7 +899,7 @@ static void rtw_ops_cancel_hw_scan(struct ieee80211_hw *hw,
+ 		return;
+ 
+ 	mutex_lock(&rtwdev->mutex);
+-	rtw_hw_scan_abort(rtwdev, vif);
++	rtw_hw_scan_abort(rtwdev);
+ 	mutex_unlock(&rtwdev->mutex);
+ }
+ 
+@@ -893,7 +923,7 @@ static void rtw_ops_sta_rc_update(struct ieee80211_hw *hw,
+ 	struct rtw_sta_info *si = (struct rtw_sta_info *)sta->drv_priv;
+ 
+ 	if (changed & IEEE80211_RC_BW_CHANGED)
+-		rtw_update_sta_info(rtwdev, si, true);
++		ieee80211_queue_work(rtwdev->hw, &si->rc_work);
+ }
+ 
+ const struct ieee80211_ops rtw_ops = {
+@@ -908,6 +938,7 @@ const struct ieee80211_ops rtw_ops = {
+ 	.configure_filter	= rtw_ops_configure_filter,
+ 	.bss_info_changed	= rtw_ops_bss_info_changed,
+ 	.start_ap		= rtw_ops_start_ap,
++	.stop_ap		= rtw_ops_stop_ap,
+ 	.conf_tx		= rtw_ops_conf_tx,
+ 	.sta_add		= rtw_ops_sta_add,
+ 	.sta_remove		= rtw_ops_sta_remove,
+diff --git a/drivers/net/wireless/realtek/rtw88/main.c b/drivers/net/wireless/realtek/rtw88/main.c
+index b2e78737bd5d..c853e2f2d448 100644
+--- a/drivers/net/wireless/realtek/rtw88/main.c
++++ b/drivers/net/wireless/realtek/rtw88/main.c
+@@ -18,6 +18,7 @@
+ #include "debug.h"
+ #include "bf.h"
+ #include "sar.h"
++#include "sdio.h"
+ 
+ bool rtw_disable_lps_deep_mode;
+ EXPORT_SYMBOL(rtw_disable_lps_deep_mode);
+@@ -102,6 +103,26 @@ static struct ieee80211_rate rtw_ratetable[] = {
+ 	{.bitrate = 540, .hw_value = 0x0b,},
+ };
+ 
++static const struct ieee80211_iface_limit rtw_iface_limits[] = {
++	{
++		.max = 1,
++		.types = BIT(NL80211_IFTYPE_STATION),
++	},
++	{
++		.max = 1,
++		.types = BIT(NL80211_IFTYPE_AP),
++	}
++};
++
++static const struct ieee80211_iface_combination rtw_iface_combs[] = {
++	{
++		.limits = rtw_iface_limits,
++		.n_limits = ARRAY_SIZE(rtw_iface_limits),
++		.max_interfaces = 2,
++		.num_different_channels = 1,
++	}
++};
++
+ u16 rtw_desc_to_bitrate(u8 desc_rate)
+ {
+ 	struct ieee80211_rate rate;
+@@ -250,13 +271,13 @@ static void rtw_watch_dog_work(struct work_struct *work)
+ 	 * more than two stations associated to the AP, then we can not enter
+ 	 * lps, because fw does not handle the overlapped beacon interval
+ 	 *
+-	 * mac80211 should iterate vifs and determine if driver can enter
+-	 * ps by passing IEEE80211_CONF_PS to us, all we need to do is to
++	 * rtw_recalc_lps() iterate vifs and determine if driver can enter
++	 * ps by vif->type and vif->cfg.ps, all we need to do here is to
+ 	 * get that vif and check if device is having traffic more than the
+ 	 * threshold.
+ 	 */
+ 	if (rtwdev->ps_enabled && data.rtwvif && !ps_active &&
+-	    !rtwdev->beacon_loss)
++	    !rtwdev->beacon_loss && !rtwdev->ap_active)
+ 		rtw_enter_lps(rtwdev, data.rtwvif->port);
+ 
+ 	rtwdev->watch_dog_cnt++;
+@@ -298,22 +319,38 @@ static u8 rtw_acquire_macid(struct rtw_dev *rtwdev)
+ 	return mac_id;
+ }
+ 
++static void rtw_sta_rc_work(struct work_struct *work)
++{
++	struct rtw_sta_info *si = container_of(work, struct rtw_sta_info,
++					       rc_work);
++	struct rtw_dev *rtwdev = si->rtwdev;
++
++	mutex_lock(&rtwdev->mutex);
++	rtw_update_sta_info(rtwdev, si, true);
++	mutex_unlock(&rtwdev->mutex);
++}
++
+ int rtw_sta_add(struct rtw_dev *rtwdev, struct ieee80211_sta *sta,
+ 		struct ieee80211_vif *vif)
+ {
+ 	struct rtw_sta_info *si = (struct rtw_sta_info *)sta->drv_priv;
++	struct rtw_vif *rtwvif = (struct rtw_vif *)vif->drv_priv;
+ 	int i;
+ 
+ 	si->mac_id = rtw_acquire_macid(rtwdev);
+ 	if (si->mac_id >= RTW_MAX_MAC_ID_NUM)
+ 		return -ENOSPC;
+ 
++	if (vif->type == NL80211_IFTYPE_STATION && vif->cfg.assoc == 0)
++		rtwvif->mac_id = si->mac_id;
++	si->rtwdev = rtwdev;
+ 	si->sta = sta;
+ 	si->vif = vif;
+ 	si->init_ra_lv = 1;
+ 	ewma_rssi_init(&si->avg_rssi);
+ 	for (i = 0; i < ARRAY_SIZE(sta->txq); i++)
+ 		rtw_txq_init(rtwdev, sta->txq[i]);
++	INIT_WORK(&si->rc_work, rtw_sta_rc_work);
+ 
+ 	rtw_update_sta_info(rtwdev, si, true);
+ 	rtw_fw_media_status_report(rtwdev, si->mac_id, true);
+@@ -332,6 +369,8 @@ void rtw_sta_remove(struct rtw_dev *rtwdev, struct ieee80211_sta *sta,
+ 	struct rtw_sta_info *si = (struct rtw_sta_info *)sta->drv_priv;
+ 	int i;
+ 
++	cancel_work_sync(&si->rc_work);
++
+ 	rtw_release_macid(rtwdev, si->mac_id);
+ 	if (fw_exist)
+ 		rtw_fw_media_status_report(rtwdev, si->mac_id, false);
+@@ -609,6 +648,7 @@ static void __fw_recovery_work(struct rtw_dev *rtwdev)
+ 	rcu_read_unlock();
+ 	rtw_iterate_stas_atomic(rtwdev, rtw_reset_sta_iter, rtwdev);
+ 	rtw_iterate_vifs_atomic(rtwdev, rtw_reset_vif_iter, rtwdev);
++	bitmap_zero(rtwdev->hw_port, RTW_PORT_NUM);
+ 	rtw_enter_ips(rtwdev);
+ }
+ 
+@@ -828,6 +868,9 @@ void rtw_set_channel(struct rtw_dev *rtwdev)
+ 
+ 	rtw_update_channel(rtwdev, center_chan, primary_chan, band, bandwidth);
+ 
++	if (rtwdev->scan_info.op_chan)
++		rtw_store_op_chan(rtwdev, true);
++
+ 	chip->ops->set_channel(rtwdev, center_chan, bandwidth,
+ 			       hal->current_primary_channel_index);
+ 
+@@ -1785,6 +1828,10 @@ static int rtw_chip_parameter_setup(struct rtw_dev *rtwdev)
+ 		rtwdev->hci.rpwm_addr = 0x03d9;
+ 		rtwdev->hci.cpwm_addr = 0x03da;
+ 		break;
++	case RTW_HCI_TYPE_SDIO:
++		rtwdev->hci.rpwm_addr = REG_SDIO_HRPWM1;
++		rtwdev->hci.cpwm_addr = REG_SDIO_HCPWM1_V2;
++		break;
+ 	case RTW_HCI_TYPE_USB:
+ 		rtwdev->hci.rpwm_addr = 0xfe58;
+ 		rtwdev->hci.cpwm_addr = 0xfe57;
+@@ -1979,7 +2026,7 @@ static int rtw_chip_board_info_setup(struct rtw_dev *rtwdev)
+ 	if (!rfe_def)
+ 		return -ENODEV;
+ 
+-	rtw_phy_setup_phy_cond(rtwdev, 0);
++	rtw_phy_setup_phy_cond(rtwdev, hal->pkg_type);
+ 
+ 	rtw_phy_init_tx_power(rtwdev);
+ 	if (rfe_def->agc_btg_tbl)
+@@ -2158,9 +2205,11 @@ int rtw_register_hw(struct rtw_dev *rtwdev, struct ieee80211_hw *hw)
+ 	int max_tx_headroom = 0;
+ 	int ret;
+ 
+-	/* TODO: USB & SDIO may need extra room? */
+ 	max_tx_headroom = rtwdev->chip->tx_pkt_desc_sz;
+ 
++	if (rtw_hci_type(rtwdev) == RTW_HCI_TYPE_SDIO)
++		max_tx_headroom += RTW_SDIO_DATA_PTR_ALIGN;
++
+ 	hw->extra_tx_headroom = max_tx_headroom;
+ 	hw->queues = IEEE80211_NUM_ACS;
+ 	hw->txq_data_size = sizeof(struct rtw_txq);
+@@ -2194,6 +2243,11 @@ int rtw_register_hw(struct rtw_dev *rtwdev, struct ieee80211_hw *hw)
+ 	hw->wiphy->max_scan_ssids = RTW_SCAN_MAX_SSIDS;
+ 	hw->wiphy->max_scan_ie_len = rtw_get_max_scan_ie_len(rtwdev);
+ 
++	if (rtwdev->chip->id == RTW_CHIP_TYPE_8822C) {
++		hw->wiphy->iface_combinations = rtw_iface_combs;
++		hw->wiphy->n_iface_combinations = ARRAY_SIZE(rtw_iface_combs);
++	}
++
+ 	wiphy_ext_feature_set(hw->wiphy, NL80211_EXT_FEATURE_CAN_REPLACE_PTK0);
+ 	wiphy_ext_feature_set(hw->wiphy, NL80211_EXT_FEATURE_SCAN_RANDOM_SN);
+ 	wiphy_ext_feature_set(hw->wiphy, NL80211_EXT_FEATURE_SET_SCAN_DWELL);
+@@ -2243,6 +2297,129 @@ void rtw_unregister_hw(struct rtw_dev *rtwdev, struct ieee80211_hw *hw)
+ }
+ EXPORT_SYMBOL(rtw_unregister_hw);
+ 
++static
++void rtw_swap_reg_nbytes(struct rtw_dev *rtwdev, const struct rtw_hw_reg *reg1,
++			 const struct rtw_hw_reg *reg2, u8 nbytes)
++{
++	u8 i;
++
++	for (i = 0; i < nbytes; i++) {
++		u8 v1 = rtw_read8(rtwdev, reg1->addr + i);
++		u8 v2 = rtw_read8(rtwdev, reg2->addr + i);
++
++		rtw_write8(rtwdev, reg1->addr + i, v2);
++		rtw_write8(rtwdev, reg2->addr + i, v1);
++	}
++}
++
++static
++void rtw_swap_reg_mask(struct rtw_dev *rtwdev, const struct rtw_hw_reg *reg1,
++		       const struct rtw_hw_reg *reg2)
++{
++	u32 v1, v2;
++
++	v1 = rtw_read32_mask(rtwdev, reg1->addr, reg1->mask);
++	v2 = rtw_read32_mask(rtwdev, reg2->addr, reg2->mask);
++	rtw_write32_mask(rtwdev, reg2->addr, reg2->mask, v1);
++	rtw_write32_mask(rtwdev, reg1->addr, reg1->mask, v2);
++}
++
++struct rtw_iter_port_switch_data {
++	struct rtw_dev *rtwdev;
++	struct rtw_vif *rtwvif_ap;
++};
++
++static void rtw_port_switch_iter(void *data, u8 *mac, struct ieee80211_vif *vif)
++{
++	struct rtw_iter_port_switch_data *iter_data = data;
++	struct rtw_dev *rtwdev = iter_data->rtwdev;
++	struct rtw_vif *rtwvif_target = (struct rtw_vif *)vif->drv_priv;
++	struct rtw_vif *rtwvif_ap = iter_data->rtwvif_ap;
++	const struct rtw_hw_reg *reg1, *reg2;
++
++	if (rtwvif_target->port != RTW_PORT_0)
++		return;
++
++	rtw_dbg(rtwdev, RTW_DBG_STATE, "AP port switch from %d -> %d\n",
++		rtwvif_ap->port, rtwvif_target->port);
++
++	/* Leave LPS so the value swapped are not in PS mode */
++	rtw_leave_lps(rtwdev);
++
++	reg1 = &rtwvif_ap->conf->net_type;
++	reg2 = &rtwvif_target->conf->net_type;
++	rtw_swap_reg_mask(rtwdev, reg1, reg2);
++
++	reg1 = &rtwvif_ap->conf->mac_addr;
++	reg2 = &rtwvif_target->conf->mac_addr;
++	rtw_swap_reg_nbytes(rtwdev, reg1, reg2, ETH_ALEN);
++
++	reg1 = &rtwvif_ap->conf->bssid;
++	reg2 = &rtwvif_target->conf->bssid;
++	rtw_swap_reg_nbytes(rtwdev, reg1, reg2, ETH_ALEN);
++
++	reg1 = &rtwvif_ap->conf->bcn_ctrl;
++	reg2 = &rtwvif_target->conf->bcn_ctrl;
++	rtw_swap_reg_nbytes(rtwdev, reg1, reg2, 1);
++
++	swap(rtwvif_target->port, rtwvif_ap->port);
++	swap(rtwvif_target->conf, rtwvif_ap->conf);
++
++	rtw_fw_default_port(rtwdev, rtwvif_target);
++}
++
++void rtw_core_port_switch(struct rtw_dev *rtwdev, struct ieee80211_vif *vif)
++{
++	struct rtw_vif *rtwvif = (struct rtw_vif *)vif->drv_priv;
++	struct rtw_iter_port_switch_data iter_data;
++
++	if (vif->type != NL80211_IFTYPE_AP || rtwvif->port == RTW_PORT_0)
++		return;
++
++	iter_data.rtwdev = rtwdev;
++	iter_data.rtwvif_ap = rtwvif;
++	rtw_iterate_vifs(rtwdev, rtw_port_switch_iter, &iter_data);
++}
++
++static void rtw_check_sta_active_iter(void *data, u8 *mac,
++				      struct ieee80211_vif *vif)
++{
++	struct rtw_vif *rtwvif = (struct rtw_vif *)vif->drv_priv;
++	bool *active = data;
++
++	if (*active)
++		return;
++
++	if (vif->type != NL80211_IFTYPE_STATION)
++		return;
++
++	if (vif->cfg.assoc || !is_zero_ether_addr(rtwvif->bssid))
++		*active = true;
++}
++
++bool rtw_core_check_sta_active(struct rtw_dev *rtwdev)
++{
++	bool sta_active = false;
++
++	rtw_iterate_vifs(rtwdev, rtw_check_sta_active_iter, &sta_active);
++
++	return rtwdev->ap_active || sta_active;
++}
++
++void rtw_core_enable_beacon(struct rtw_dev *rtwdev, bool enable)
++{
++	if (!rtwdev->ap_active)
++		return;
++
++	if (enable) {
++		rtw_write32_set(rtwdev, REG_BCN_CTRL, BIT_EN_BCN_FUNCTION);
++		rtw_write32_clr(rtwdev, REG_TXPAUSE, BIT_HIGH_QUEUE);
++	} else {
++		rtw_write32_clr(rtwdev, REG_BCN_CTRL, BIT_EN_BCN_FUNCTION);
++		rtw_write32_set(rtwdev, REG_TXPAUSE, BIT_HIGH_QUEUE);
++	}
++}
++
+ MODULE_AUTHOR("Realtek Corporation");
+ MODULE_DESCRIPTION("Realtek 802.11ac wireless core module");
+ MODULE_LICENSE("Dual BSD/GPL");
+diff --git a/drivers/net/wireless/realtek/rtw88/main.h b/drivers/net/wireless/realtek/rtw88/main.h
+index d4a53d556745..f9dd2ab941c8 100644
+--- a/drivers/net/wireless/realtek/rtw88/main.h
++++ b/drivers/net/wireless/realtek/rtw88/main.h
+@@ -88,7 +88,7 @@ enum rtw_supported_band {
+ 	RTW_BAND_60G = BIT(NL80211_BAND_60GHZ),
+ };
+ 
+-/* now, support upto 80M bw */
++/* now, support up to 80M bw */
+ #define RTW_MAX_CHANNEL_WIDTH RTW_CHANNEL_WIDTH_80
+ 
+ enum rtw_bandwidth {
+@@ -395,6 +395,15 @@ enum rtw_snr {
+ 	RTW_SNR_NUM
+ };
+ 
++enum rtw_port {
++	RTW_PORT_0 = 0,
++	RTW_PORT_1 = 1,
++	RTW_PORT_2 = 2,
++	RTW_PORT_3 = 3,
++	RTW_PORT_4 = 4,
++	RTW_PORT_NUM
++};
++
+ enum rtw_wow_flags {
+ 	RTW_WOW_FLAG_EN_MAGIC_PKT,
+ 	RTW_WOW_FLAG_EN_REKEY_PKT,
+@@ -734,6 +743,7 @@ struct rtw_txq {
+ DECLARE_EWMA(rssi, 10, 16);
+ 
+ struct rtw_sta_info {
++	struct rtw_dev *rtwdev;
+ 	struct ieee80211_sta *sta;
+ 	struct ieee80211_vif *vif;
+ 
+@@ -758,6 +768,8 @@ struct rtw_sta_info {
+ 
+ 	bool use_cfg_mask;
+ 	struct cfg80211_bitrate_mask *mask;
++
++	struct work_struct rc_work;
+ };
+ 
+ enum rtw_bfee_role {
+@@ -791,6 +803,7 @@ struct rtw_bf_info {
+ struct rtw_vif {
+ 	enum rtw_net_type net_type;
+ 	u16 aid;
++	u8 mac_id; /* for STA mode only */
+ 	u8 mac_addr[ETH_ALEN];
+ 	u8 bssid[ETH_ALEN];
+ 	u8 port;
+@@ -1168,6 +1181,7 @@ struct rtw_chip_info {
+ 	u32 txff_size;
+ 	u32 rxff_size;
+ 	u32 fw_rxff_size;
++	u16 rsvd_drv_pg_num;
+ 	u8 band;
+ 	u8 page_size;
+ 	u8 csi_buf_pg_num;
+@@ -1871,7 +1885,7 @@ enum rtw_sar_bands {
+ 	RTW_SAR_BAND_NR,
+ };
+ 
+-/* the union is reserved for other knids of SAR sources
++/* the union is reserved for other kinds of SAR sources
+  * which might not re-use same format with array common.
+  */
+ union rtw_sar_cfg {
+@@ -1890,7 +1904,9 @@ struct rtw_hal {
+ 	u8 cut_version;
+ 	u8 mp_chip;
+ 	u8 oem_id;
++	u8 pkg_type;
+ 	struct rtw_phy_cond phy_cond;
++	bool rfe_btg;
+ 
+ 	u8 ps_mode;
+ 	u8 current_channel;
+@@ -2020,7 +2036,7 @@ struct rtw_dev {
+ 	struct rtw_tx_report tx_report;
+ 
+ 	struct {
+-		/* incicate the mail box to use with fw */
++		/* indicate the mail box to use with fw */
+ 		u8 last_box_num;
+ 		u32 seq;
+ 	} h2c;
+@@ -2036,6 +2052,7 @@ struct rtw_dev {
+ 	u8 sta_cnt;
+ 	u32 rts_threshold;
+ 
++	DECLARE_BITMAP(hw_port, RTW_PORT_NUM);
+ 	DECLARE_BITMAP(mac_id_map, RTW_MAX_MAC_ID_NUM);
+ 	DECLARE_BITMAP(flags, NUM_OF_RTW_FLAGS);
+ 
+@@ -2047,6 +2064,7 @@ struct rtw_dev {
+ 
+ 	bool need_rfk;
+ 	struct completion fw_scan_density;
++	bool ap_active;
+ 
+ 	/* hci related data, must be last */
+ 	u8 priv[] __aligned(sizeof(void *));
+@@ -2188,4 +2206,7 @@ void rtw_set_txrx_1ss(struct rtw_dev *rtwdev, bool config_1ss);
+ void rtw_update_channel(struct rtw_dev *rtwdev, u8 center_channel,
+ 			u8 primary_channel, enum rtw_supported_band band,
+ 			enum rtw_bandwidth bandwidth);
++void rtw_core_port_switch(struct rtw_dev *rtwdev, struct ieee80211_vif *vif);
++bool rtw_core_check_sta_active(struct rtw_dev *rtwdev);
++void rtw_core_enable_beacon(struct rtw_dev *rtwdev, bool enable);
+ #endif
+diff --git a/drivers/net/wireless/realtek/rtw88/pci.c b/drivers/net/wireless/realtek/rtw88/pci.c
+index 0975d27240e4..44a8fff34cdd 100644
+--- a/drivers/net/wireless/realtek/rtw88/pci.c
++++ b/drivers/net/wireless/realtek/rtw88/pci.c
+@@ -30,7 +30,8 @@ static u32 rtw_pci_tx_queue_idx_addr[] = {
+ 	[RTW_TX_QUEUE_H2C]	= RTK_PCI_TXBD_IDX_H2CQ,
+ };
+ 
+-static u8 rtw_pci_get_tx_qsel(struct sk_buff *skb, u8 queue)
++static u8 rtw_pci_get_tx_qsel(struct sk_buff *skb,
++			      enum rtw_tx_queue_type queue)
+ {
+ 	switch (queue) {
+ 	case RTW_TX_QUEUE_BCN:
+@@ -88,13 +89,6 @@ static void rtw_pci_write32(struct rtw_dev *rtwdev, u32 addr, u32 val)
+ 	writel(val, rtwpci->mmap + addr);
+ }
+ 
+-static inline void *rtw_pci_get_tx_desc(struct rtw_pci_tx_ring *tx_ring, u8 idx)
+-{
+-	int offset = tx_ring->r.desc_size * idx;
+-
+-	return tx_ring->r.head + offset;
+-}
+-
+ static void rtw_pci_free_tx_ring_skbs(struct rtw_dev *rtwdev,
+ 				      struct rtw_pci_tx_ring *tx_ring)
+ {
+@@ -542,7 +536,7 @@ static int rtw_pci_setup(struct rtw_dev *rtwdev)
+ static void rtw_pci_dma_release(struct rtw_dev *rtwdev, struct rtw_pci *rtwpci)
+ {
+ 	struct rtw_pci_tx_ring *tx_ring;
+-	u8 queue;
++	enum rtw_tx_queue_type queue;
+ 
+ 	rtw_pci_reset_trx_ring(rtwdev);
+ 	for (queue = 0; queue < RTK_MAX_TX_QUEUE_NUM; queue++) {
+@@ -608,8 +602,8 @@ static void rtw_pci_deep_ps_enter(struct rtw_dev *rtwdev)
+ {
+ 	struct rtw_pci *rtwpci = (struct rtw_pci *)rtwdev->priv;
+ 	struct rtw_pci_tx_ring *tx_ring;
++	enum rtw_tx_queue_type queue;
+ 	bool tx_empty = true;
+-	u8 queue;
+ 
+ 	if (rtw_fw_feature_check(&rtwdev->fw, FW_FEATURE_TX_WAKE))
+ 		goto enter_deep_ps;
+@@ -669,37 +663,6 @@ static void rtw_pci_deep_ps(struct rtw_dev *rtwdev, bool enter)
+ 	spin_unlock_bh(&rtwpci->irq_lock);
+ }
+ 
+-static u8 ac_to_hwq[] = {
+-	[IEEE80211_AC_VO] = RTW_TX_QUEUE_VO,
+-	[IEEE80211_AC_VI] = RTW_TX_QUEUE_VI,
+-	[IEEE80211_AC_BE] = RTW_TX_QUEUE_BE,
+-	[IEEE80211_AC_BK] = RTW_TX_QUEUE_BK,
+-};
+-
+-static_assert(ARRAY_SIZE(ac_to_hwq) == IEEE80211_NUM_ACS);
+-
+-static u8 rtw_hw_queue_mapping(struct sk_buff *skb)
+-{
+-	struct ieee80211_hdr *hdr = (struct ieee80211_hdr *)skb->data;
+-	__le16 fc = hdr->frame_control;
+-	u8 q_mapping = skb_get_queue_mapping(skb);
+-	u8 queue;
+-
+-	if (unlikely(ieee80211_is_beacon(fc)))
+-		queue = RTW_TX_QUEUE_BCN;
+-	else if (unlikely(ieee80211_is_mgmt(fc) || ieee80211_is_ctl(fc)))
+-		queue = RTW_TX_QUEUE_MGMT;
+-	else if (is_broadcast_ether_addr(hdr->addr1) ||
+-		 is_multicast_ether_addr(hdr->addr1))
+-		queue = RTW_TX_QUEUE_HI0;
+-	else if (WARN_ON_ONCE(q_mapping >= ARRAY_SIZE(ac_to_hwq)))
+-		queue = ac_to_hwq[IEEE80211_AC_BE];
+-	else
+-		queue = ac_to_hwq[q_mapping];
+-
+-	return queue;
+-}
+-
+ static void rtw_pci_release_rsvd_page(struct rtw_pci *rtwpci,
+ 				      struct rtw_pci_tx_ring *ring)
+ {
+@@ -775,8 +738,9 @@ static void __rtw_pci_flush_queues(struct rtw_dev *rtwdev, u32 pci_queues,
+ 	u8 q;
+ 
+ 	for (q = 0; q < RTK_MAX_TX_QUEUE_NUM; q++) {
+-		/* It may be not necessary to flush BCN and H2C tx queues. */
+-		if (q == RTW_TX_QUEUE_BCN || q == RTW_TX_QUEUE_H2C)
++		/* Unnecessary to flush BCN, H2C and HI tx queues. */
++		if (q == RTW_TX_QUEUE_BCN || q == RTW_TX_QUEUE_H2C ||
++		    q == RTW_TX_QUEUE_HI0)
+ 			continue;
+ 
+ 		if (pci_queues & BIT(q))
+@@ -797,13 +761,14 @@ static void rtw_pci_flush_queues(struct rtw_dev *rtwdev, u32 queues, bool drop)
+ 	} else {
+ 		for (i = 0; i < rtwdev->hw->queues; i++)
+ 			if (queues & BIT(i))
+-				pci_queues |= BIT(ac_to_hwq[i]);
++				pci_queues |= BIT(rtw_tx_ac_to_hwq(i));
+ 	}
+ 
+ 	__rtw_pci_flush_queues(rtwdev, pci_queues, drop);
+ }
+ 
+-static void rtw_pci_tx_kick_off_queue(struct rtw_dev *rtwdev, u8 queue)
++static void rtw_pci_tx_kick_off_queue(struct rtw_dev *rtwdev,
++				      enum rtw_tx_queue_type queue)
+ {
+ 	struct rtw_pci *rtwpci = (struct rtw_pci *)rtwdev->priv;
+ 	struct rtw_pci_tx_ring *ring;
+@@ -822,7 +787,7 @@ static void rtw_pci_tx_kick_off_queue(struct rtw_dev *rtwdev, u8 queue)
+ static void rtw_pci_tx_kick_off(struct rtw_dev *rtwdev)
+ {
+ 	struct rtw_pci *rtwpci = (struct rtw_pci *)rtwdev->priv;
+-	u8 queue;
++	enum rtw_tx_queue_type queue;
+ 
+ 	for (queue = 0; queue < RTK_MAX_TX_QUEUE_NUM; queue++)
+ 		if (test_and_clear_bit(queue, rtwpci->tx_queued))
+@@ -831,7 +796,8 @@ static void rtw_pci_tx_kick_off(struct rtw_dev *rtwdev)
+ 
+ static int rtw_pci_tx_write_data(struct rtw_dev *rtwdev,
+ 				 struct rtw_tx_pkt_info *pkt_info,
+-				 struct sk_buff *skb, u8 queue)
++				 struct sk_buff *skb,
++				 enum rtw_tx_queue_type queue)
+ {
+ 	struct rtw_pci *rtwpci = (struct rtw_pci *)rtwdev->priv;
+ 	const struct rtw_chip_info *chip = rtwdev->chip;
+@@ -949,9 +915,9 @@ static int rtw_pci_tx_write(struct rtw_dev *rtwdev,
+ 			    struct rtw_tx_pkt_info *pkt_info,
+ 			    struct sk_buff *skb)
+ {
++	enum rtw_tx_queue_type queue = rtw_tx_queue_mapping(skb);
+ 	struct rtw_pci *rtwpci = (struct rtw_pci *)rtwdev->priv;
+ 	struct rtw_pci_tx_ring *ring;
+-	u8 queue = rtw_hw_queue_mapping(skb);
+ 	int ret;
+ 
+ 	ret = rtw_pci_tx_write_data(rtwdev, pkt_info, skb, queue);
+@@ -1580,7 +1546,6 @@ static int rtw_pci_claim(struct rtw_dev *rtwdev, struct pci_dev *pdev)
+ 
+ static void rtw_pci_declaim(struct rtw_dev *rtwdev, struct pci_dev *pdev)
+ {
+-	pci_clear_master(pdev);
+ 	pci_disable_device(pdev);
+ }
+ 
+diff --git a/drivers/net/wireless/realtek/rtw88/ps.c b/drivers/net/wireless/realtek/rtw88/ps.c
+index 996365575f44..43e80a3a8136 100644
+--- a/drivers/net/wireless/realtek/rtw88/ps.c
++++ b/drivers/net/wireless/realtek/rtw88/ps.c
+@@ -18,6 +18,7 @@ static int rtw_ips_pwr_up(struct rtw_dev *rtwdev)
+ 	if (ret)
+ 		rtw_err(rtwdev, "leave idle state failed\n");
+ 
++	rtw_coex_ips_notify(rtwdev, COEX_IPS_LEAVE);
+ 	rtw_set_channel(rtwdev);
+ 
+ 	return ret;
+@@ -63,8 +64,6 @@ int rtw_leave_ips(struct rtw_dev *rtwdev)
+ 
+ 	rtw_iterate_vifs(rtwdev, rtw_restore_port_cfg_iter, rtwdev);
+ 
+-	rtw_coex_ips_notify(rtwdev, COEX_IPS_LEAVE);
+-
+ 	return 0;
+ }
+ 
+@@ -299,3 +298,46 @@ void rtw_leave_lps_deep(struct rtw_dev *rtwdev)
+ 
+ 	__rtw_leave_lps_deep(rtwdev);
+ }
++
++struct rtw_vif_recalc_lps_iter_data {
++	struct rtw_dev *rtwdev;
++	struct ieee80211_vif *found_vif;
++	int count;
++};
++
++static void __rtw_vif_recalc_lps(struct rtw_vif_recalc_lps_iter_data *data,
++				 struct ieee80211_vif *vif)
++{
++	if (data->count < 0)
++		return;
++
++	if (vif->type != NL80211_IFTYPE_STATION) {
++		data->count = -1;
++		return;
++	}
++
++	data->count++;
++	data->found_vif = vif;
++}
++
++static void rtw_vif_recalc_lps_iter(void *data, u8 *mac,
++				    struct ieee80211_vif *vif)
++{
++	__rtw_vif_recalc_lps(data, vif);
++}
++
++void rtw_recalc_lps(struct rtw_dev *rtwdev, struct ieee80211_vif *new_vif)
++{
++	struct rtw_vif_recalc_lps_iter_data data = { .rtwdev = rtwdev };
++
++	if (new_vif)
++		__rtw_vif_recalc_lps(&data, new_vif);
++	rtw_iterate_vifs(rtwdev, rtw_vif_recalc_lps_iter, &data);
++
++	if (data.count == 1 && data.found_vif->cfg.ps) {
++		rtwdev->ps_enabled = true;
++	} else {
++		rtwdev->ps_enabled = false;
++		rtw_leave_lps(rtwdev);
++	}
++}
+diff --git a/drivers/net/wireless/realtek/rtw88/ps.h b/drivers/net/wireless/realtek/rtw88/ps.h
+index c194386f6db5..5ae83d2526cf 100644
+--- a/drivers/net/wireless/realtek/rtw88/ps.h
++++ b/drivers/net/wireless/realtek/rtw88/ps.h
+@@ -23,4 +23,6 @@ void rtw_enter_lps(struct rtw_dev *rtwdev, u8 port_id);
+ void rtw_leave_lps(struct rtw_dev *rtwdev);
+ void rtw_leave_lps_deep(struct rtw_dev *rtwdev);
+ enum rtw_lps_deep_mode rtw_get_lps_deep_mode(struct rtw_dev *rtwdev);
++void rtw_recalc_lps(struct rtw_dev *rtwdev, struct ieee80211_vif *new_vif);
++
+ #endif
+diff --git a/drivers/net/wireless/realtek/rtw88/reg.h b/drivers/net/wireless/realtek/rtw88/reg.h
+index 8852b24d6c2a..7c6c11d50ff3 100644
+--- a/drivers/net/wireless/realtek/rtw88/reg.h
++++ b/drivers/net/wireless/realtek/rtw88/reg.h
+@@ -87,6 +87,7 @@
+ #define BIT_LTE_MUX_CTRL_PATH	BIT(26)
+ #define REG_HCI_OPT_CTRL	0x0074
+ #define BIT_USB_SUS_DIS		BIT(8)
++#define BIT_SDIO_PAD_E5		BIT(18)
+ 
+ #define REG_AFE_CTRL_4		0x0078
+ #define BIT_CK320M_AFE_EN	BIT(4)
+@@ -185,6 +186,9 @@
+ 	(((x) & BIT_MASK_TXDMA_VIQ_MAP) << BIT_SHIFT_TXDMA_VIQ_MAP)
+ #define REG_TXDMA_PQ_MAP	0x010C
+ #define BIT_RXDMA_ARBBW_EN	BIT(0)
++#define BIT_RXSHFT_EN		BIT(1)
++#define BIT_RXDMA_AGG_EN	BIT(2)
++#define BIT_TXDMA_BW_EN		BIT(3)
+ #define BIT_SHIFT_TXDMA_BEQ_MAP	8
+ #define BIT_MASK_TXDMA_BEQ_MAP	0x3
+ #define BIT_TXDMA_BEQ_MAP(x)                                                   \
+@@ -283,10 +287,18 @@
+ #define REG_H2C_TAIL		0x0248
+ #define REG_H2C_READ_ADDR	0x024C
+ #define REG_H2C_INFO		0x0254
++#define REG_RXDMA_AGG_PG_TH	0x0280
++#define BIT_RXDMA_AGG_PG_TH	GENMASK(7, 0)
++#define BIT_DMA_AGG_TO_V1	GENMASK(15, 8)
++#define BIT_EN_PRE_CALC		BIT(29)
+ #define REG_RXPKT_NUM		0x0284
+ #define BIT_RXDMA_REQ		BIT(19)
+ #define BIT_RW_RELEASE		BIT(18)
+ #define BIT_RXDMA_IDLE		BIT(17)
++#define REG_RXDMA_STATUS	0x0288
++#define REG_RXDMA_DPR		0x028C
++#define REG_RXDMA_MODE		0x0290
++#define BIT_DMA_MODE		BIT(1)
+ #define REG_RXPKTNUM		0x02B0
+ 
+ #define REG_INT_MIG		0x0304
+@@ -366,6 +378,7 @@
+ #define BIT_SIFS_BK_EN		BIT(12)
+ #define REG_TXPAUSE		0x0522
+ #define BIT_AC_QUEUE		GENMASK(7, 0)
++#define BIT_HIGH_QUEUE		BIT(5)
+ #define REG_RD_CTRL		0x0524
+ #define BIT_EDCCA_MSK_CNTDOWN_EN BIT(11)
+ #define BIT_DIS_TXOP_CFE	BIT(10)
+@@ -398,6 +411,7 @@
+ #define REG_TCR			0x0604
+ #define BIT_PWRMGT_HWDATA_EN	BIT(7)
+ #define BIT_TCR_UPDATE_TIMIE	BIT(5)
++#define BIT_TCR_UPDATE_HGQMD	BIT(4)
+ #define REG_RCR			0x0608
+ #define BIT_APP_FCS		BIT(31)
+ #define BIT_APP_MIC		BIT(30)
+diff --git a/drivers/net/wireless/realtek/rtw88/rtw8723d.c b/drivers/net/wireless/realtek/rtw88/rtw8723d.c
+index 2d2f768bae2e..c575476a0020 100644
+--- a/drivers/net/wireless/realtek/rtw88/rtw8723d.c
++++ b/drivers/net/wireless/realtek/rtw88/rtw8723d.c
+@@ -216,6 +216,12 @@ static void rtw8723du_efuse_parsing(struct rtw_efuse *efuse,
+ 	ether_addr_copy(efuse->addr, map->u.mac_addr);
+ }
+ 
++static void rtw8723ds_efuse_parsing(struct rtw_efuse *efuse,
++				    struct rtw8723d_efuse *map)
++{
++	ether_addr_copy(efuse->addr, map->s.mac_addr);
++}
++
+ static int rtw8723d_read_efuse(struct rtw_dev *rtwdev, u8 *log_map)
+ {
+ 	struct rtw_efuse *efuse = &rtwdev->efuse;
+@@ -248,6 +254,9 @@ static int rtw8723d_read_efuse(struct rtw_dev *rtwdev, u8 *log_map)
+ 	case RTW_HCI_TYPE_USB:
+ 		rtw8723du_efuse_parsing(efuse, map);
+ 		break;
++	case RTW_HCI_TYPE_SDIO:
++		rtw8723ds_efuse_parsing(efuse, map);
++		break;
+ 	default:
+ 		/* unsupported now */
+ 		return -ENOTSUPP;
+@@ -1961,15 +1970,17 @@ static void rtw8723d_fill_txdesc_checksum(struct rtw_dev *rtwdev,
+ 	size_t words = 32 / 2; /* calculate the first 32 bytes (16 words) */
+ 	__le16 chksum = 0;
+ 	__le16 *data = (__le16 *)(txdesc);
++	struct rtw_tx_desc *tx_desc = (struct rtw_tx_desc *)txdesc;
+ 
+-	SET_TX_DESC_TXDESC_CHECKSUM(txdesc, 0x0000);
++	le32p_replace_bits(&tx_desc->w7, 0, RTW_TX_DESC_W7_TXDESC_CHECKSUM);
+ 
+ 	while (words--)
+ 		chksum ^= *data++;
+ 
+ 	chksum = ~chksum;
+ 
+-	SET_TX_DESC_TXDESC_CHECKSUM(txdesc, __le16_to_cpu(chksum));
++	le32p_replace_bits(&tx_desc->w7, __le16_to_cpu(chksum),
++			   RTW_TX_DESC_W7_TXDESC_CHECKSUM);
+ }
+ 
+ static struct rtw_chip_ops rtw8723d_ops = {
+@@ -2743,6 +2754,7 @@ const struct rtw_chip_info rtw8723d_hw_spec = {
+ 	.ptct_efuse_size = 96 + 1,
+ 	.txff_size = 32768,
+ 	.rxff_size = 16384,
++	.rsvd_drv_pg_num = 8,
+ 	.txgi_factor = 1,
+ 	.is_pwr_by_rate_dec = true,
+ 	.max_power_index = 0x3f,
+diff --git a/drivers/net/wireless/realtek/rtw88/rtw8723d.h b/drivers/net/wireless/realtek/rtw88/rtw8723d.h
+index a356318a5c15..3642a2c7f80c 100644
+--- a/drivers/net/wireless/realtek/rtw88/rtw8723d.h
++++ b/drivers/net/wireless/realtek/rtw88/rtw8723d.h
+@@ -49,6 +49,11 @@ struct rtw8723du_efuse {
+ 	u8 mac_addr[ETH_ALEN];          /* 0x107 */
+ };
+ 
++struct rtw8723ds_efuse {
++	u8 res4[0x4a];			/* 0xd0 */
++	u8 mac_addr[ETH_ALEN];		/* 0x11a */
++};
++
+ struct rtw8723d_efuse {
+ 	__le16 rtl_id;
+ 	u8 rsvd[2];
+@@ -80,6 +85,7 @@ struct rtw8723d_efuse {
+ 	union {
+ 		struct rtw8723de_efuse e;
+ 		struct rtw8723du_efuse u;
++		struct rtw8723ds_efuse s;
+ 	};
+ };
+ 
+diff --git a/drivers/net/wireless/realtek/rtw88/rtw8821c.c b/drivers/net/wireless/realtek/rtw88/rtw8821c.c
+index 67efa58dd78e..adf224618a2a 100644
+--- a/drivers/net/wireless/realtek/rtw88/rtw8821c.c
++++ b/drivers/net/wireless/realtek/rtw88/rtw8821c.c
+@@ -32,6 +32,12 @@ static void rtw8821cu_efuse_parsing(struct rtw_efuse *efuse,
+ 	ether_addr_copy(efuse->addr, map->u.mac_addr);
+ }
+ 
++static void rtw8821cs_efuse_parsing(struct rtw_efuse *efuse,
++				    struct rtw8821c_efuse *map)
++{
++	ether_addr_copy(efuse->addr, map->s.mac_addr);
++}
++
+ enum rtw8821ce_rf_set {
+ 	SWITCH_TO_BTG,
+ 	SWITCH_TO_WLG,
+@@ -41,6 +47,7 @@ enum rtw8821ce_rf_set {
+ 
+ static int rtw8821c_read_efuse(struct rtw_dev *rtwdev, u8 *log_map)
+ {
++	struct rtw_hal *hal = &rtwdev->hal;
+ 	struct rtw_efuse *efuse = &rtwdev->efuse;
+ 	struct rtw8821c_efuse *map;
+ 	int i;
+@@ -64,6 +71,19 @@ static int rtw8821c_read_efuse(struct rtw_dev *rtwdev, u8 *log_map)
+ 	efuse->tx_bb_swing_setting_2g = map->tx_bb_swing_setting_2g;
+ 	efuse->tx_bb_swing_setting_5g = map->tx_bb_swing_setting_5g;
+ 
++	hal->pkg_type = map->rfe_option & BIT(5) ? 1 : 0;
++
++	switch (efuse->rfe_option) {
++	case 0x2:
++	case 0x4:
++	case 0x7:
++	case 0xa:
++	case 0xc:
++	case 0xf:
++		hal->rfe_btg = true;
++		break;
++	}
++
+ 	for (i = 0; i < 4; i++)
+ 		efuse->txpwr_idx_table[i] = map->txpwr_idx_table[i];
+ 
+@@ -77,6 +97,9 @@ static int rtw8821c_read_efuse(struct rtw_dev *rtwdev, u8 *log_map)
+ 	case RTW_HCI_TYPE_USB:
+ 		rtw8821cu_efuse_parsing(efuse, map);
+ 		break;
++	case RTW_HCI_TYPE_SDIO:
++		rtw8821cs_efuse_parsing(efuse, map);
++		break;
+ 	default:
+ 		/* unsupported now */
+ 		return -ENOTSUPP;
+@@ -286,6 +309,7 @@ static void rtw8821c_switch_rf_set(struct rtw_dev *rtwdev, u8 rf_set)
+ 
+ static void rtw8821c_set_channel_rf(struct rtw_dev *rtwdev, u8 channel, u8 bw)
+ {
++	struct rtw_hal *hal = &rtwdev->hal;
+ 	u32 rf_reg18;
+ 
+ 	rf_reg18 = rtw_read_rf(rtwdev, RF_PATH_A, 0x18, RFREG_MASK);
+@@ -317,11 +341,10 @@ static void rtw8821c_set_channel_rf(struct rtw_dev *rtwdev, u8 channel, u8 bw)
+ 	}
+ 
+ 	if (channel <= 14) {
+-		if (rtwdev->efuse.rfe_option == 0)
+-			rtw8821c_switch_rf_set(rtwdev, SWITCH_TO_WLG);
+-		else if (rtwdev->efuse.rfe_option == 2 ||
+-			 rtwdev->efuse.rfe_option == 4)
++		if (hal->rfe_btg)
+ 			rtw8821c_switch_rf_set(rtwdev, SWITCH_TO_BTG);
++		else
++			rtw8821c_switch_rf_set(rtwdev, SWITCH_TO_WLG);
+ 		rtw_write_rf(rtwdev, RF_PATH_A, RF_LUTDBG, BIT(6), 0x1);
+ 		rtw_write_rf(rtwdev, RF_PATH_A, 0x64, 0xf, 0xf);
+ 	} else {
+@@ -1910,6 +1933,7 @@ const struct rtw_chip_info rtw8821c_hw_spec = {
+ 	.ptct_efuse_size = 96,
+ 	.txff_size = 65536,
+ 	.rxff_size = 16384,
++	.rsvd_drv_pg_num = 8,
+ 	.txgi_factor = 1,
+ 	.is_pwr_by_rate_dec = true,
+ 	.max_power_index = 0x3f,
+diff --git a/drivers/net/wireless/realtek/rtw88/rtw8821c.h b/drivers/net/wireless/realtek/rtw88/rtw8821c.h
+index 1c81260f3a54..fcff31688c45 100644
+--- a/drivers/net/wireless/realtek/rtw88/rtw8821c.h
++++ b/drivers/net/wireless/realtek/rtw88/rtw8821c.h
+@@ -65,6 +65,11 @@ struct rtw8821ce_efuse {
+ 	u8 res7;
+ };
+ 
++struct rtw8821cs_efuse {
++	u8 res4[0x4a];			/* 0xd0 */
++	u8 mac_addr[ETH_ALEN];		/* 0x11a */
++} __packed;
++
+ struct rtw8821c_efuse {
+ 	__le16 rtl_id;
+ 	u8 res0[0x0e];
+@@ -94,6 +99,7 @@ struct rtw8821c_efuse {
+ 	union {
+ 		struct rtw8821ce_efuse e;
+ 		struct rtw8821cu_efuse u;
++		struct rtw8821cs_efuse s;
+ 	};
+ };
+ 
+diff --git a/drivers/net/wireless/realtek/rtw88/rtw8822b.c b/drivers/net/wireless/realtek/rtw88/rtw8822b.c
+index 74dfb89b2c94..3017a9760da8 100644
+--- a/drivers/net/wireless/realtek/rtw88/rtw8822b.c
++++ b/drivers/net/wireless/realtek/rtw88/rtw8822b.c
+@@ -32,6 +32,12 @@ static void rtw8822bu_efuse_parsing(struct rtw_efuse *efuse,
+ 	ether_addr_copy(efuse->addr, map->u.mac_addr);
+ }
+ 
++static void rtw8822bs_efuse_parsing(struct rtw_efuse *efuse,
++				    struct rtw8822b_efuse *map)
++{
++	ether_addr_copy(efuse->addr, map->s.mac_addr);
++}
++
+ static int rtw8822b_read_efuse(struct rtw_dev *rtwdev, u8 *log_map)
+ {
+ 	struct rtw_efuse *efuse = &rtwdev->efuse;
+@@ -65,6 +71,9 @@ static int rtw8822b_read_efuse(struct rtw_dev *rtwdev, u8 *log_map)
+ 	case RTW_HCI_TYPE_USB:
+ 		rtw8822bu_efuse_parsing(efuse, map);
+ 		break;
++	case RTW_HCI_TYPE_SDIO:
++		rtw8822bs_efuse_parsing(efuse, map);
++		break;
+ 	default:
+ 		/* unsupported now */
+ 		return -ENOTSUPP;
+@@ -2531,6 +2540,7 @@ const struct rtw_chip_info rtw8822b_hw_spec = {
+ 	.txff_size = 262144,
+ 	.rxff_size = 24576,
+ 	.fw_rxff_size = 12288,
++	.rsvd_drv_pg_num = 8,
+ 	.txgi_factor = 1,
+ 	.is_pwr_by_rate_dec = true,
+ 	.max_power_index = 0x3f,
+diff --git a/drivers/net/wireless/realtek/rtw88/rtw8822b.h b/drivers/net/wireless/realtek/rtw88/rtw8822b.h
+index 01d3644e0c94..2dc3a6660f06 100644
+--- a/drivers/net/wireless/realtek/rtw88/rtw8822b.h
++++ b/drivers/net/wireless/realtek/rtw88/rtw8822b.h
+@@ -65,6 +65,11 @@ struct rtw8822be_efuse {
+ 	u8 res7;
+ };
+ 
++struct rtw8822bs_efuse {
++	u8 res4[0x4a];			/* 0xd0 */
++	u8 mac_addr[ETH_ALEN];		/* 0x11a */
++} __packed;
++
+ struct rtw8822b_efuse {
+ 	__le16 rtl_id;
+ 	u8 res0[0x0e];
+@@ -92,8 +97,9 @@ struct rtw8822b_efuse {
+ 	u8 country_code[2];
+ 	u8 res[3];
+ 	union {
+-		struct rtw8822bu_efuse u;
+ 		struct rtw8822be_efuse e;
++		struct rtw8822bu_efuse u;
++		struct rtw8822bs_efuse s;
+ 	};
+ };
+ 
+diff --git a/drivers/net/wireless/realtek/rtw88/rtw8822c.c b/drivers/net/wireless/realtek/rtw88/rtw8822c.c
+index 964e27887fe2..cd965edc29ce 100644
+--- a/drivers/net/wireless/realtek/rtw88/rtw8822c.c
++++ b/drivers/net/wireless/realtek/rtw88/rtw8822c.c
+@@ -35,6 +35,12 @@ static void rtw8822cu_efuse_parsing(struct rtw_efuse *efuse,
+ 	ether_addr_copy(efuse->addr, map->u.mac_addr);
+ }
+ 
++static void rtw8822cs_efuse_parsing(struct rtw_efuse *efuse,
++				    struct rtw8822c_efuse *map)
++{
++	ether_addr_copy(efuse->addr, map->s.mac_addr);
++}
++
+ static int rtw8822c_read_efuse(struct rtw_dev *rtwdev, u8 *log_map)
+ {
+ 	struct rtw_efuse *efuse = &rtwdev->efuse;
+@@ -67,6 +73,9 @@ static int rtw8822c_read_efuse(struct rtw_dev *rtwdev, u8 *log_map)
+ 	case RTW_HCI_TYPE_USB:
+ 		rtw8822cu_efuse_parsing(efuse, map);
+ 		break;
++	case RTW_HCI_TYPE_SDIO:
++		rtw8822cs_efuse_parsing(efuse, map);
++		break;
+ 	default:
+ 		/* unsupported now */
+ 		return -ENOTSUPP;
+@@ -5349,6 +5358,7 @@ const struct rtw_chip_info rtw8822c_hw_spec = {
+ 	.txff_size = 262144,
+ 	.rxff_size = 24576,
+ 	.fw_rxff_size = 12288,
++	.rsvd_drv_pg_num = 16,
+ 	.txgi_factor = 2,
+ 	.is_pwr_by_rate_dec = false,
+ 	.max_power_index = 0x7f,
+diff --git a/drivers/net/wireless/realtek/rtw88/rtw8822c.h b/drivers/net/wireless/realtek/rtw88/rtw8822c.h
+index 479d5d769c52..1bc0e7f5d6bb 100644
+--- a/drivers/net/wireless/realtek/rtw88/rtw8822c.h
++++ b/drivers/net/wireless/realtek/rtw88/rtw8822c.h
+@@ -16,6 +16,11 @@ struct rtw8822cu_efuse {
+ 	u8 res2[0x3d];
+ };
+ 
++struct rtw8822cs_efuse {
++	u8 res0[0x4a];			/* 0x120 */
++	u8 mac_addr[ETH_ALEN];		/* 0x16a */
++} __packed;
++
+ struct rtw8822ce_efuse {
+ 	u8 mac_addr[ETH_ALEN];		/* 0x120 */
+ 	u8 vender_id[2];
+@@ -91,8 +96,9 @@ struct rtw8822c_efuse {
+ 	u8 res9;
+ 	u8 res10[0x42];
+ 	union {
+-		struct rtw8822cu_efuse u;
+ 		struct rtw8822ce_efuse e;
++		struct rtw8822cu_efuse u;
++		struct rtw8822cs_efuse s;
+ 	};
+ };
+ 
+diff --git a/drivers/net/wireless/realtek/rtw88/tx.c b/drivers/net/wireless/realtek/rtw88/tx.c
+index ab39245e9c2f..2821119dc930 100644
+--- a/drivers/net/wireless/realtek/rtw88/tx.c
++++ b/drivers/net/wireless/realtek/rtw88/tx.c
+@@ -34,43 +34,57 @@ void rtw_tx_stats(struct rtw_dev *rtwdev, struct ieee80211_vif *vif,
+ 
+ void rtw_tx_fill_tx_desc(struct rtw_tx_pkt_info *pkt_info, struct sk_buff *skb)
+ {
+-	__le32 *txdesc = (__le32 *)skb->data;
+-
+-	SET_TX_DESC_TXPKTSIZE(txdesc,  pkt_info->tx_pkt_size);
+-	SET_TX_DESC_OFFSET(txdesc, pkt_info->offset);
+-	SET_TX_DESC_PKT_OFFSET(txdesc, pkt_info->pkt_offset);
+-	SET_TX_DESC_QSEL(txdesc, pkt_info->qsel);
+-	SET_TX_DESC_BMC(txdesc, pkt_info->bmc);
+-	SET_TX_DESC_RATE_ID(txdesc, pkt_info->rate_id);
+-	SET_TX_DESC_DATARATE(txdesc, pkt_info->rate);
+-	SET_TX_DESC_DISDATAFB(txdesc, pkt_info->dis_rate_fallback);
+-	SET_TX_DESC_USE_RATE(txdesc, pkt_info->use_rate);
+-	SET_TX_DESC_SEC_TYPE(txdesc, pkt_info->sec_type);
+-	SET_TX_DESC_DATA_BW(txdesc, pkt_info->bw);
+-	SET_TX_DESC_SW_SEQ(txdesc, pkt_info->seq);
+-	SET_TX_DESC_MAX_AGG_NUM(txdesc, pkt_info->ampdu_factor);
+-	SET_TX_DESC_AMPDU_DENSITY(txdesc, pkt_info->ampdu_density);
+-	SET_TX_DESC_DATA_STBC(txdesc, pkt_info->stbc);
+-	SET_TX_DESC_DATA_LDPC(txdesc, pkt_info->ldpc);
+-	SET_TX_DESC_AGG_EN(txdesc, pkt_info->ampdu_en);
+-	SET_TX_DESC_LS(txdesc, pkt_info->ls);
+-	SET_TX_DESC_DATA_SHORT(txdesc, pkt_info->short_gi);
+-	SET_TX_DESC_SPE_RPT(txdesc, pkt_info->report);
+-	SET_TX_DESC_SW_DEFINE(txdesc, pkt_info->sn);
+-	SET_TX_DESC_USE_RTS(txdesc, pkt_info->rts);
++	struct rtw_tx_desc *tx_desc = (struct rtw_tx_desc *)skb->data;
++	bool more_data = false;
++
++	if (pkt_info->qsel == TX_DESC_QSEL_HIGH)
++		more_data = true;
++
++	tx_desc->w0 = le32_encode_bits(pkt_info->tx_pkt_size, RTW_TX_DESC_W0_TXPKTSIZE) |
++		      le32_encode_bits(pkt_info->offset, RTW_TX_DESC_W0_OFFSET) |
++		      le32_encode_bits(pkt_info->bmc, RTW_TX_DESC_W0_BMC) |
++		      le32_encode_bits(pkt_info->ls, RTW_TX_DESC_W0_LS) |
++		      le32_encode_bits(pkt_info->dis_qselseq, RTW_TX_DESC_W0_DISQSELSEQ);
++
++	tx_desc->w1 = le32_encode_bits(pkt_info->qsel, RTW_TX_DESC_W1_QSEL) |
++		      le32_encode_bits(pkt_info->rate_id, RTW_TX_DESC_W1_RATE_ID) |
++		      le32_encode_bits(pkt_info->sec_type, RTW_TX_DESC_W1_SEC_TYPE) |
++		      le32_encode_bits(pkt_info->pkt_offset, RTW_TX_DESC_W1_PKT_OFFSET) |
++		      le32_encode_bits(more_data, RTW_TX_DESC_W1_MORE_DATA);
++
++	tx_desc->w2 = le32_encode_bits(pkt_info->ampdu_en, RTW_TX_DESC_W2_AGG_EN) |
++		      le32_encode_bits(pkt_info->report, RTW_TX_DESC_W2_SPE_RPT) |
++		      le32_encode_bits(pkt_info->ampdu_density, RTW_TX_DESC_W2_AMPDU_DEN) |
++		      le32_encode_bits(pkt_info->bt_null, RTW_TX_DESC_W2_BT_NULL);
++
++	tx_desc->w3 = le32_encode_bits(pkt_info->hw_ssn_sel, RTW_TX_DESC_W3_HW_SSN_SEL) |
++		      le32_encode_bits(pkt_info->use_rate, RTW_TX_DESC_W3_USE_RATE) |
++		      le32_encode_bits(pkt_info->dis_rate_fallback, RTW_TX_DESC_W3_DISDATAFB) |
++		      le32_encode_bits(pkt_info->rts, RTW_TX_DESC_W3_USE_RTS) |
++		      le32_encode_bits(pkt_info->nav_use_hdr, RTW_TX_DESC_W3_NAVUSEHDR) |
++		      le32_encode_bits(pkt_info->ampdu_factor, RTW_TX_DESC_W3_MAX_AGG_NUM);
++
++	tx_desc->w4 = le32_encode_bits(pkt_info->rate, RTW_TX_DESC_W4_DATARATE);
++
++	tx_desc->w5 = le32_encode_bits(pkt_info->short_gi, RTW_TX_DESC_W5_DATA_SHORT) |
++		      le32_encode_bits(pkt_info->bw, RTW_TX_DESC_W5_DATA_BW) |
++		      le32_encode_bits(pkt_info->ldpc, RTW_TX_DESC_W5_DATA_LDPC) |
++		      le32_encode_bits(pkt_info->stbc, RTW_TX_DESC_W5_DATA_STBC);
++
++	tx_desc->w6 = le32_encode_bits(pkt_info->sn, RTW_TX_DESC_W6_SW_DEFINE);
++
++	tx_desc->w8 = le32_encode_bits(pkt_info->en_hwseq, RTW_TX_DESC_W8_EN_HWSEQ);
++
++	tx_desc->w9 = le32_encode_bits(pkt_info->seq, RTW_TX_DESC_W9_SW_SEQ);
++
+ 	if (pkt_info->rts) {
+-		SET_TX_DESC_RTSRATE(txdesc, DESC_RATE24M);
+-		SET_TX_DESC_DATA_RTS_SHORT(txdesc, 1);
+-	}
+-	SET_TX_DESC_DISQSELSEQ(txdesc, pkt_info->dis_qselseq);
+-	SET_TX_DESC_EN_HWSEQ(txdesc, pkt_info->en_hwseq);
+-	SET_TX_DESC_HW_SSN_SEL(txdesc, pkt_info->hw_ssn_sel);
+-	SET_TX_DESC_NAVUSEHDR(txdesc, pkt_info->nav_use_hdr);
+-	SET_TX_DESC_BT_NULL(txdesc, pkt_info->bt_null);
+-	if (pkt_info->tim_offset) {
+-		SET_TX_DESC_TIM_EN(txdesc, 1);
+-		SET_TX_DESC_TIM_OFFSET(txdesc, pkt_info->tim_offset);
++		tx_desc->w4 |= le32_encode_bits(DESC_RATE24M, RTW_TX_DESC_W4_RTSRATE);
++		tx_desc->w5 |= le32_encode_bits(1, RTW_TX_DESC_W5_DATA_RTS_SHORT);
+ 	}
++
++	if (pkt_info->tim_offset)
++		tx_desc->w9 |= le32_encode_bits(1, RTW_TX_DESC_W9_TIM_EN) |
++			       le32_encode_bits(pkt_info->tim_offset, RTW_TX_DESC_W9_TIM_OFFSET);
+ }
+ EXPORT_SYMBOL(rtw_tx_fill_tx_desc);
+ 
+@@ -635,9 +649,8 @@ static void rtw_txq_push(struct rtw_dev *rtwdev,
+ 	rcu_read_unlock();
+ }
+ 
+-void rtw_tx_work(struct work_struct *w)
++void __rtw_tx_work(struct rtw_dev *rtwdev)
+ {
+-	struct rtw_dev *rtwdev = container_of(w, struct rtw_dev, tx_work);
+ 	struct rtw_txq *rtwtxq, *tmp;
+ 
+ 	spin_lock_bh(&rtwdev->txq_lock);
+@@ -658,6 +671,13 @@ void rtw_tx_work(struct work_struct *w)
+ 	spin_unlock_bh(&rtwdev->txq_lock);
+ }
+ 
++void rtw_tx_work(struct work_struct *w)
++{
++	struct rtw_dev *rtwdev = container_of(w, struct rtw_dev, tx_work);
++
++	__rtw_tx_work(rtwdev);
++}
++
+ void rtw_txq_init(struct rtw_dev *rtwdev, struct ieee80211_txq *txq)
+ {
+ 	struct rtw_txq *rtwtxq;
+@@ -682,3 +702,44 @@ void rtw_txq_cleanup(struct rtw_dev *rtwdev, struct ieee80211_txq *txq)
+ 		list_del_init(&rtwtxq->list);
+ 	spin_unlock_bh(&rtwdev->txq_lock);
+ }
++
++static const enum rtw_tx_queue_type ac_to_hwq[] = {
++	[IEEE80211_AC_VO] = RTW_TX_QUEUE_VO,
++	[IEEE80211_AC_VI] = RTW_TX_QUEUE_VI,
++	[IEEE80211_AC_BE] = RTW_TX_QUEUE_BE,
++	[IEEE80211_AC_BK] = RTW_TX_QUEUE_BK,
++};
++
++static_assert(ARRAY_SIZE(ac_to_hwq) == IEEE80211_NUM_ACS);
++
++enum rtw_tx_queue_type rtw_tx_ac_to_hwq(enum ieee80211_ac_numbers ac)
++{
++	if (WARN_ON(unlikely(ac >= IEEE80211_NUM_ACS)))
++		return RTW_TX_QUEUE_BE;
++
++	return ac_to_hwq[ac];
++}
++EXPORT_SYMBOL(rtw_tx_ac_to_hwq);
++
++enum rtw_tx_queue_type rtw_tx_queue_mapping(struct sk_buff *skb)
++{
++	struct ieee80211_hdr *hdr = (struct ieee80211_hdr *)skb->data;
++	__le16 fc = hdr->frame_control;
++	u8 q_mapping = skb_get_queue_mapping(skb);
++	enum rtw_tx_queue_type queue;
++
++	if (unlikely(ieee80211_is_beacon(fc)))
++		queue = RTW_TX_QUEUE_BCN;
++	else if (unlikely(ieee80211_is_mgmt(fc) || ieee80211_is_ctl(fc)))
++		queue = RTW_TX_QUEUE_MGMT;
++	else if (is_broadcast_ether_addr(hdr->addr1) ||
++		 is_multicast_ether_addr(hdr->addr1))
++		queue = RTW_TX_QUEUE_HI0;
++	else if (WARN_ON_ONCE(q_mapping >= ARRAY_SIZE(ac_to_hwq)))
++		queue = ac_to_hwq[IEEE80211_AC_BE];
++	else
++		queue = ac_to_hwq[q_mapping];
++
++	return queue;
++}
++EXPORT_SYMBOL(rtw_tx_queue_mapping);
+diff --git a/drivers/net/wireless/realtek/rtw88/tx.h b/drivers/net/wireless/realtek/rtw88/tx.h
+index a2f3ac326041..324189606257 100644
+--- a/drivers/net/wireless/realtek/rtw88/tx.h
++++ b/drivers/net/wireless/realtek/rtw88/tx.h
+@@ -9,76 +9,53 @@
+ 
+ #define RTW_TX_PROBE_TIMEOUT		msecs_to_jiffies(500)
+ 
+-#define SET_TX_DESC_TXPKTSIZE(txdesc, value)                                   \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x00, value, GENMASK(15, 0))
+-#define SET_TX_DESC_OFFSET(txdesc, value)                                      \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x00, value, GENMASK(23, 16))
+-#define SET_TX_DESC_PKT_OFFSET(txdesc, value)                                  \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x01, value, GENMASK(28, 24))
+-#define SET_TX_DESC_QSEL(txdesc, value)                                        \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x01, value, GENMASK(12, 8))
+-#define SET_TX_DESC_BMC(txdesc, value)                                         \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x00, value, BIT(24))
+-#define SET_TX_DESC_RATE_ID(txdesc, value)                                     \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x01, value, GENMASK(20, 16))
+-#define SET_TX_DESC_DATARATE(txdesc, value)                                    \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x04, value, GENMASK(6, 0))
+-#define SET_TX_DESC_DISDATAFB(txdesc, value)                                   \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x03, value, BIT(10))
+-#define SET_TX_DESC_USE_RATE(txdesc, value)                                    \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x03, value, BIT(8))
+-#define SET_TX_DESC_SEC_TYPE(txdesc, value)                                    \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x01, value, GENMASK(23, 22))
+-#define SET_TX_DESC_DATA_BW(txdesc, value)                                     \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x05, value, GENMASK(6, 5))
+-#define SET_TX_DESC_SW_SEQ(txdesc, value)                                      \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x09, value, GENMASK(23, 12))
+-#define SET_TX_DESC_TIM_EN(txdesc, value)                                      \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x09, value, BIT(7))
+-#define SET_TX_DESC_TIM_OFFSET(txdesc, value)                                  \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x09, value, GENMASK(6, 0))
+-#define SET_TX_DESC_MAX_AGG_NUM(txdesc, value)                                 \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x03, value, GENMASK(21, 17))
+-#define SET_TX_DESC_USE_RTS(tx_desc, value)                                    \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x03, value, BIT(12))
+-#define SET_TX_DESC_RTSRATE(txdesc, value)                                     \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x04, value, GENMASK(28, 24))
+-#define SET_TX_DESC_DATA_RTS_SHORT(txdesc, value)                              \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x05, value, BIT(12))
+-#define SET_TX_DESC_AMPDU_DENSITY(txdesc, value)                               \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x02, value, GENMASK(22, 20))
+-#define SET_TX_DESC_DATA_STBC(txdesc, value)                                   \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x05, value, GENMASK(9, 8))
+-#define SET_TX_DESC_DATA_LDPC(txdesc, value)                                   \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x05, value, BIT(7))
+-#define SET_TX_DESC_AGG_EN(txdesc, value)                                      \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x02, value, BIT(12))
+-#define SET_TX_DESC_LS(txdesc, value)                                          \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x00, value, BIT(26))
+-#define SET_TX_DESC_DATA_SHORT(txdesc, value)				       \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x05, value, BIT(4))
+-#define SET_TX_DESC_SPE_RPT(tx_desc, value)                                    \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x02, value, BIT(19))
+-#define SET_TX_DESC_SW_DEFINE(tx_desc, value)                                  \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x06, value, GENMASK(11, 0))
+-#define SET_TX_DESC_DISQSELSEQ(txdesc, value)                                 \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x00, value, BIT(31))
+-#define SET_TX_DESC_EN_HWSEQ(txdesc, value)                                   \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x08, value, BIT(15))
+-#define SET_TX_DESC_HW_SSN_SEL(txdesc, value)                                 \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x03, value, GENMASK(7, 6))
+-#define SET_TX_DESC_NAVUSEHDR(txdesc, value)				       \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x03, value, BIT(15))
+-#define SET_TX_DESC_BT_NULL(txdesc, value)				       \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x02, value, BIT(23))
+-#define SET_TX_DESC_TXDESC_CHECKSUM(txdesc, value)				\
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x07, value, GENMASK(15, 0))
+-#define SET_TX_DESC_DMA_TXAGG_NUM(txdesc, value)				\
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x07, value, GENMASK(31, 24))
+-#define GET_TX_DESC_PKT_OFFSET(txdesc)						\
+-	le32_get_bits(*((__le32 *)(txdesc) + 0x01), GENMASK(28, 24))
+-#define GET_TX_DESC_QSEL(txdesc)						\
+-	le32_get_bits(*((__le32 *)(txdesc) + 0x01), GENMASK(12, 8))
++struct rtw_tx_desc {
++	__le32 w0;
++	__le32 w1;
++	__le32 w2;
++	__le32 w3;
++	__le32 w4;
++	__le32 w5;
++	__le32 w6;
++	__le32 w7;
++	__le32 w8;
++	__le32 w9;
++} __packed;
++
++#define RTW_TX_DESC_W0_TXPKTSIZE GENMASK(15, 0)
++#define RTW_TX_DESC_W0_OFFSET GENMASK(23, 16)
++#define RTW_TX_DESC_W0_BMC BIT(24)
++#define RTW_TX_DESC_W0_LS BIT(26)
++#define RTW_TX_DESC_W0_DISQSELSEQ BIT(31)
++#define RTW_TX_DESC_W1_QSEL GENMASK(12, 8)
++#define RTW_TX_DESC_W1_RATE_ID GENMASK(20, 16)
++#define RTW_TX_DESC_W1_SEC_TYPE GENMASK(23, 22)
++#define RTW_TX_DESC_W1_PKT_OFFSET GENMASK(28, 24)
++#define RTW_TX_DESC_W1_MORE_DATA BIT(29)
++#define RTW_TX_DESC_W2_AGG_EN BIT(12)
++#define RTW_TX_DESC_W2_SPE_RPT BIT(19)
++#define RTW_TX_DESC_W2_AMPDU_DEN GENMASK(22, 20)
++#define RTW_TX_DESC_W2_BT_NULL BIT(23)
++#define RTW_TX_DESC_W3_HW_SSN_SEL GENMASK(7, 6)
++#define RTW_TX_DESC_W3_USE_RATE BIT(8)
++#define RTW_TX_DESC_W3_DISDATAFB BIT(10)
++#define RTW_TX_DESC_W3_USE_RTS BIT(12)
++#define RTW_TX_DESC_W3_NAVUSEHDR BIT(15)
++#define RTW_TX_DESC_W3_MAX_AGG_NUM GENMASK(21, 17)
++#define RTW_TX_DESC_W4_DATARATE GENMASK(6, 0)
++#define RTW_TX_DESC_W4_RTSRATE GENMASK(28, 24)
++#define RTW_TX_DESC_W5_DATA_SHORT BIT(4)
++#define RTW_TX_DESC_W5_DATA_BW GENMASK(6, 5)
++#define RTW_TX_DESC_W5_DATA_LDPC BIT(7)
++#define RTW_TX_DESC_W5_DATA_STBC GENMASK(9, 8)
++#define RTW_TX_DESC_W5_DATA_RTS_SHORT BIT(12)
++#define RTW_TX_DESC_W6_SW_DEFINE GENMASK(11, 0)
++#define RTW_TX_DESC_W7_TXDESC_CHECKSUM GENMASK(15, 0)
++#define RTW_TX_DESC_W7_DMA_TXAGG_NUM GENMASK(31, 24)
++#define RTW_TX_DESC_W8_EN_HWSEQ BIT(15)
++#define RTW_TX_DESC_W9_SW_SEQ GENMASK(23, 12)
++#define RTW_TX_DESC_W9_TIM_EN BIT(7)
++#define RTW_TX_DESC_W9_TIM_OFFSET GENMASK(6, 0)
+ 
+ enum rtw_tx_desc_queue_select {
+ 	TX_DESC_QSEL_TID0	= 0,
+@@ -111,6 +88,7 @@ void rtw_tx(struct rtw_dev *rtwdev,
+ void rtw_txq_init(struct rtw_dev *rtwdev, struct ieee80211_txq *txq);
+ void rtw_txq_cleanup(struct rtw_dev *rtwdev, struct ieee80211_txq *txq);
+ void rtw_tx_work(struct work_struct *w);
++void __rtw_tx_work(struct rtw_dev *rtwdev);
+ void rtw_tx_pkt_info_update(struct rtw_dev *rtwdev,
+ 			    struct rtw_tx_pkt_info *pkt_info,
+ 			    struct ieee80211_sta *sta,
+@@ -131,18 +109,23 @@ rtw_tx_write_data_h2c_get(struct rtw_dev *rtwdev,
+ 			  struct rtw_tx_pkt_info *pkt_info,
+ 			  u8 *buf, u32 size);
+ 
++enum rtw_tx_queue_type rtw_tx_ac_to_hwq(enum ieee80211_ac_numbers ac);
++enum rtw_tx_queue_type rtw_tx_queue_mapping(struct sk_buff *skb);
++
+ static inline
+ void fill_txdesc_checksum_common(u8 *txdesc, size_t words)
+ {
+ 	__le16 chksum = 0;
+ 	__le16 *data = (__le16 *)(txdesc);
++	struct rtw_tx_desc *tx_desc = (struct rtw_tx_desc *)txdesc;
+ 
+-	SET_TX_DESC_TXDESC_CHECKSUM(txdesc, 0x0000);
++	le32p_replace_bits(&tx_desc->w7, 0, RTW_TX_DESC_W7_TXDESC_CHECKSUM);
+ 
+ 	while (words--)
+ 		chksum ^= *data++;
+ 
+-	SET_TX_DESC_TXDESC_CHECKSUM(txdesc, __le16_to_cpu(chksum));
++	le32p_replace_bits(&tx_desc->w7, __le16_to_cpu(chksum),
++			   RTW_TX_DESC_W7_TXDESC_CHECKSUM);
+ }
+ 
+ static inline void rtw_tx_fill_txdesc_checksum(struct rtw_dev *rtwdev,
+diff --git a/drivers/net/wireless/realtek/rtw88/usb.c b/drivers/net/wireless/realtek/rtw88/usb.c
+index a10d6fef4ffa..4a57efdba97b 100644
+--- a/drivers/net/wireless/realtek/rtw88/usb.c
++++ b/drivers/net/wireless/realtek/rtw88/usb.c
+@@ -24,11 +24,12 @@ struct rtw_usb_txcb {
+ static void rtw_usb_fill_tx_checksum(struct rtw_usb *rtwusb,
+ 				     struct sk_buff *skb, int agg_num)
+ {
++	struct rtw_tx_desc *tx_desc = (struct rtw_tx_desc *)skb->data;
+ 	struct rtw_dev *rtwdev = rtwusb->rtwdev;
+ 	struct rtw_tx_pkt_info pkt_info;
+ 
+-	SET_TX_DESC_DMA_TXAGG_NUM(skb->data, agg_num);
+-	pkt_info.pkt_offset = GET_TX_DESC_PKT_OFFSET(skb->data);
++	le32p_replace_bits(&tx_desc->w7, agg_num, RTW_TX_DESC_W7_DMA_TXAGG_NUM);
++	pkt_info.pkt_offset = le32_get_bits(tx_desc->w1, RTW_TX_DESC_W1_PKT_OFFSET);
+ 	rtw_tx_fill_txdesc_checksum(rtwdev, &pkt_info, skb->data);
+ }
+ 
+@@ -306,11 +307,13 @@ static int rtw_usb_write_port(struct rtw_dev *rtwdev, u8 qsel, struct sk_buff *s
+ static bool rtw_usb_tx_agg_skb(struct rtw_usb *rtwusb, struct sk_buff_head *list)
+ {
+ 	struct rtw_dev *rtwdev = rtwusb->rtwdev;
++	struct rtw_tx_desc *tx_desc;
+ 	struct rtw_usb_txcb *txcb;
+ 	struct sk_buff *skb_head;
+ 	struct sk_buff *skb_iter;
+ 	int agg_num = 0;
+ 	unsigned int align_next = 0;
++	u8 qsel;
+ 
+ 	if (skb_queue_empty(list))
+ 		return false;
+@@ -363,9 +366,10 @@ static bool rtw_usb_tx_agg_skb(struct rtw_usb *rtwusb, struct sk_buff_head *list
+ 
+ queue:
+ 	skb_queue_tail(&txcb->tx_ack_queue, skb_head);
++	tx_desc = (struct rtw_tx_desc *)skb_head->data;
++	qsel = le32_get_bits(tx_desc->w1, RTW_TX_DESC_W1_QSEL);
+ 
+-	rtw_usb_write_port(rtwdev, GET_TX_DESC_QSEL(skb_head->data), skb_head,
+-			   rtw_usb_write_port_tx_complete, txcb);
++	rtw_usb_write_port(rtwdev, qsel, skb_head, rtw_usb_write_port_tx_complete, txcb);
+ 
+ 	return true;
+ }
+@@ -465,6 +469,9 @@ static u8 rtw_usb_tx_queue_mapping_to_qsel(struct sk_buff *skb)
+ 
+ 	if (unlikely(ieee80211_is_mgmt(fc) || ieee80211_is_ctl(fc)))
+ 		qsel = TX_DESC_QSEL_MGMT;
++	else if (is_broadcast_ether_addr(hdr->addr1) ||
++		 is_multicast_ether_addr(hdr->addr1))
++		qsel = TX_DESC_QSEL_HIGH;
+ 	else if (skb_get_queue_mapping(skb) <= IEEE80211_AC_BK)
+ 		qsel = skb->priority;
+ 	else
+@@ -535,7 +542,7 @@ static void rtw_usb_rx_handler(struct work_struct *work)
+ 		}
+ 
+ 		if (skb_queue_len(&rtwusb->rx_queue) >= RTW_USB_MAX_RXQ_LEN) {
+-			rtw_err(rtwdev, "failed to get rx_queue, overflow\n");
++			dev_dbg_ratelimited(rtwdev->dev, "failed to get rx_queue, overflow\n");
+ 			dev_kfree_skb_any(skb);
+ 			continue;
+ 		}
+@@ -804,6 +811,7 @@ static void rtw_usb_intf_deinit(struct rtw_dev *rtwdev,
+ 	struct rtw_usb *rtwusb = rtw_get_usb_priv(rtwdev);
+ 
+ 	usb_put_dev(rtwusb->udev);
++	kfree(rtwusb->usb_data);
+ 	usb_set_intfdata(intf, NULL);
+ }
+ 
+@@ -832,7 +840,7 @@ int rtw_usb_probe(struct usb_interface *intf, const struct usb_device_id *id)
+ 
+ 	ret = rtw_usb_alloc_rx_bufs(rtwusb);
+ 	if (ret)
+-		return ret;
++		goto err_release_hw;
+ 
+ 	ret = rtw_core_init(rtwdev);
+ 	if (ret)
+diff --git a/drivers/net/wireless/realtek/rtw88/usb.h b/drivers/net/wireless/realtek/rtw88/usb.h
+index 30647f0dd61c..ad1d7955c6a5 100644
+--- a/drivers/net/wireless/realtek/rtw88/usb.h
++++ b/drivers/net/wireless/realtek/rtw88/usb.h
+@@ -78,7 +78,7 @@ struct rtw_usb {
+ 	u8 pipe_interrupt;
+ 	u8 pipe_in;
+ 	u8 out_ep[RTW_USB_EP_MAX];
+-	u8 qsel_to_ep[TX_DESC_QSEL_MAX];
++	int qsel_to_ep[TX_DESC_QSEL_MAX];
+ 	u8 usb_txagg_num;
+ 
+ 	struct workqueue_struct *txwq, *rxwq;
+diff --git a/include/linux/mmc/sdio_ids.h b/include/linux/mmc/sdio_ids.h
+index f0cf9c5d6502..9041b8b1f465 100644
+--- a/include/linux/mmc/sdio_ids.h
++++ b/include/linux/mmc/sdio_ids.h
+@@ -114,6 +114,16 @@
+ #define SDIO_VENDOR_ID_MICROCHIP_WILC		0x0296
+ #define SDIO_DEVICE_ID_MICROCHIP_WILC1000	0x5347
+ 
++#define SDIO_VENDOR_ID_REALTEK			0x024c
++#define SDIO_DEVICE_ID_REALTEK_RTW8723BS	0xb723
++#define SDIO_DEVICE_ID_REALTEK_RTW8821BS	0xb821
++#define SDIO_DEVICE_ID_REALTEK_RTW8822BS	0xb822
++#define SDIO_DEVICE_ID_REALTEK_RTW8821CS	0xc821
++#define SDIO_DEVICE_ID_REALTEK_RTW8822CS	0xc822
++#define SDIO_DEVICE_ID_REALTEK_RTW8723DS_2ANT	0xd723
++#define SDIO_DEVICE_ID_REALTEK_RTW8723DS_1ANT	0xd724
++#define SDIO_DEVICE_ID_REALTEK_RTW8821DS	0xd821
++
+ #define SDIO_VENDOR_ID_SIANO			0x039a
+ #define SDIO_DEVICE_ID_SIANO_NOVA_B0		0x0201
+ #define SDIO_DEVICE_ID_SIANO_NICE		0x0202
+-- 
+2.39.2
+
+From 64e7de206a859ae0ef1f60439a93a22fab0b4dca Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@xxxxx.com>
+Date: Sat, 22 Jul 2023 04:31:58 -0400
+Subject: [PATCH] drivers: net: wireless: realtek: rtw88: upstream wireless
+
+linux-next backport: linux-6.2.y
+
+Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
+---
+ .../net/wireless/realtek/rtw88/rtw8723ds.c    |   41 +
+ .../net/wireless/realtek/rtw88/rtw8821cs.c    |   36 +
+ .../net/wireless/realtek/rtw88/rtw8822bs.c    |   36 +
+ .../net/wireless/realtek/rtw88/rtw8822cs.c    |   36 +
+ drivers/net/wireless/realtek/rtw88/sdio.c     | 1416 +++++++++++++++++
+ drivers/net/wireless/realtek/rtw88/sdio.h     |  178 +++
+ 6 files changed, 1743 insertions(+)
+ create mode 100644 drivers/net/wireless/realtek/rtw88/rtw8723ds.c
+ create mode 100644 drivers/net/wireless/realtek/rtw88/rtw8821cs.c
+ create mode 100644 drivers/net/wireless/realtek/rtw88/rtw8822bs.c
+ create mode 100644 drivers/net/wireless/realtek/rtw88/rtw8822cs.c
+ create mode 100644 drivers/net/wireless/realtek/rtw88/sdio.c
+ create mode 100644 drivers/net/wireless/realtek/rtw88/sdio.h
+
+diff --git a/drivers/net/wireless/realtek/rtw88/rtw8723ds.c b/drivers/net/wireless/realtek/rtw88/rtw8723ds.c
+new file mode 100644
+index 000000000000..e5b6960ba0a0
+--- /dev/null
++++ b/drivers/net/wireless/realtek/rtw88/rtw8723ds.c
+@@ -0,0 +1,41 @@
++// SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
++/* Copyright(c) Martin Blumenstingl <martin.blumenstingl@googlemail.com>
++ */
++
++#include <linux/mmc/sdio_func.h>
++#include <linux/mmc/sdio_ids.h>
++#include <linux/module.h>
++#include "main.h"
++#include "rtw8723d.h"
++#include "sdio.h"
++
++static const struct sdio_device_id rtw_8723ds_id_table[] =  {
++	{
++		SDIO_DEVICE(SDIO_VENDOR_ID_REALTEK,
++			    SDIO_DEVICE_ID_REALTEK_RTW8723DS_1ANT),
++		.driver_data = (kernel_ulong_t)&rtw8723d_hw_spec,
++	},
++	{
++		SDIO_DEVICE(SDIO_VENDOR_ID_REALTEK,
++			    SDIO_DEVICE_ID_REALTEK_RTW8723DS_2ANT),
++		.driver_data = (kernel_ulong_t)&rtw8723d_hw_spec,
++	},
++	{}
++};
++MODULE_DEVICE_TABLE(sdio, rtw_8723ds_id_table);
++
++static struct sdio_driver rtw_8723ds_driver = {
++	.name = "rtw_8723ds",
++	.probe = rtw_sdio_probe,
++	.remove = rtw_sdio_remove,
++	.id_table = rtw_8723ds_id_table,
++	.drv = {
++		.pm = &rtw_sdio_pm_ops,
++		.shutdown = rtw_sdio_shutdown,
++	}
++};
++module_sdio_driver(rtw_8723ds_driver);
++
++MODULE_AUTHOR("Martin Blumenstingl <martin.blumenstingl@googlemail.com>");
++MODULE_DESCRIPTION("Realtek 802.11n wireless 8723ds driver");
++MODULE_LICENSE("Dual BSD/GPL");
+diff --git a/drivers/net/wireless/realtek/rtw88/rtw8821cs.c b/drivers/net/wireless/realtek/rtw88/rtw8821cs.c
+new file mode 100644
+index 000000000000..a359413369a4
+--- /dev/null
++++ b/drivers/net/wireless/realtek/rtw88/rtw8821cs.c
+@@ -0,0 +1,36 @@
++// SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
++/* Copyright(c) Martin Blumenstingl <martin.blumenstingl@googlemail.com>
++ */
++
++#include <linux/mmc/sdio_func.h>
++#include <linux/mmc/sdio_ids.h>
++#include <linux/module.h>
++#include "main.h"
++#include "rtw8821c.h"
++#include "sdio.h"
++
++static const struct sdio_device_id rtw_8821cs_id_table[] =  {
++	{
++		SDIO_DEVICE(SDIO_VENDOR_ID_REALTEK,
++			    SDIO_DEVICE_ID_REALTEK_RTW8821CS),
++		.driver_data = (kernel_ulong_t)&rtw8821c_hw_spec,
++	},
++	{}
++};
++MODULE_DEVICE_TABLE(sdio, rtw_8821cs_id_table);
++
++static struct sdio_driver rtw_8821cs_driver = {
++	.name = "rtw_8821cs",
++	.probe = rtw_sdio_probe,
++	.remove = rtw_sdio_remove,
++	.id_table = rtw_8821cs_id_table,
++	.drv = {
++		.pm = &rtw_sdio_pm_ops,
++		.shutdown = rtw_sdio_shutdown,
++	}
++};
++module_sdio_driver(rtw_8821cs_driver);
++
++MODULE_AUTHOR("Martin Blumenstingl <martin.blumenstingl@googlemail.com>");
++MODULE_DESCRIPTION("Realtek 802.11ac wireless 8821cs driver");
++MODULE_LICENSE("Dual BSD/GPL");
+diff --git a/drivers/net/wireless/realtek/rtw88/rtw8822bs.c b/drivers/net/wireless/realtek/rtw88/rtw8822bs.c
+new file mode 100644
+index 000000000000..31d8645f83bd
+--- /dev/null
++++ b/drivers/net/wireless/realtek/rtw88/rtw8822bs.c
+@@ -0,0 +1,36 @@
++// SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
++/* Copyright(c) Jernej Skrabec <jernej.skrabec@gmail.com>
++ */
++
++#include <linux/mmc/sdio_func.h>
++#include <linux/mmc/sdio_ids.h>
++#include <linux/module.h>
++#include "main.h"
++#include "rtw8822b.h"
++#include "sdio.h"
++
++static const struct sdio_device_id rtw_8822bs_id_table[] =  {
++	{
++		SDIO_DEVICE(SDIO_VENDOR_ID_REALTEK,
++			    SDIO_DEVICE_ID_REALTEK_RTW8822BS),
++		.driver_data = (kernel_ulong_t)&rtw8822b_hw_spec,
++	},
++	{}
++};
++MODULE_DEVICE_TABLE(sdio, rtw_8822bs_id_table);
++
++static struct sdio_driver rtw_8822bs_driver = {
++	.name = "rtw_8822bs",
++	.probe = rtw_sdio_probe,
++	.remove = rtw_sdio_remove,
++	.id_table = rtw_8822bs_id_table,
++	.drv = {
++		.pm = &rtw_sdio_pm_ops,
++		.shutdown = rtw_sdio_shutdown,
++	}
++};
++module_sdio_driver(rtw_8822bs_driver);
++
++MODULE_AUTHOR("Jernej Skrabec <jernej.skrabec@gmail.com>");
++MODULE_DESCRIPTION("Realtek 802.11ac wireless 8822bs driver");
++MODULE_LICENSE("Dual BSD/GPL");
+diff --git a/drivers/net/wireless/realtek/rtw88/rtw8822cs.c b/drivers/net/wireless/realtek/rtw88/rtw8822cs.c
+new file mode 100644
+index 000000000000..975e81c824f2
+--- /dev/null
++++ b/drivers/net/wireless/realtek/rtw88/rtw8822cs.c
+@@ -0,0 +1,36 @@
++// SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
++/* Copyright(c) Martin Blumenstingl <martin.blumenstingl@googlemail.com>
++ */
++
++#include <linux/mmc/sdio_func.h>
++#include <linux/mmc/sdio_ids.h>
++#include <linux/module.h>
++#include "main.h"
++#include "rtw8822c.h"
++#include "sdio.h"
++
++static const struct sdio_device_id rtw_8822cs_id_table[] =  {
++	{
++		SDIO_DEVICE(SDIO_VENDOR_ID_REALTEK,
++			    SDIO_DEVICE_ID_REALTEK_RTW8822CS),
++		.driver_data = (kernel_ulong_t)&rtw8822c_hw_spec,
++	},
++	{}
++};
++MODULE_DEVICE_TABLE(sdio, rtw_8822cs_id_table);
++
++static struct sdio_driver rtw_8822cs_driver = {
++	.name = "rtw_8822cs",
++	.probe = rtw_sdio_probe,
++	.remove = rtw_sdio_remove,
++	.id_table = rtw_8822cs_id_table,
++	.drv = {
++		.pm = &rtw_sdio_pm_ops,
++		.shutdown = rtw_sdio_shutdown,
++	}
++};
++module_sdio_driver(rtw_8822cs_driver);
++
++MODULE_AUTHOR("Martin Blumenstingl <martin.blumenstingl@googlemail.com>");
++MODULE_DESCRIPTION("Realtek 802.11ac wireless 8822cs driver");
++MODULE_LICENSE("Dual BSD/GPL");
+diff --git a/drivers/net/wireless/realtek/rtw88/sdio.c b/drivers/net/wireless/realtek/rtw88/sdio.c
+new file mode 100644
+index 000000000000..b19262ec5d8c
+--- /dev/null
++++ b/drivers/net/wireless/realtek/rtw88/sdio.c
+@@ -0,0 +1,1416 @@
++// SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
++/* Copyright (C) 2021 Martin Blumenstingl <martin.blumenstingl@googlemail.com>
++ * Copyright (C) 2021 Jernej Skrabec <jernej.skrabec@gmail.com>
++ *
++ * Based on rtw88/pci.c:
++ *   Copyright(c) 2018-2019  Realtek Corporation
++ */
++
++#include <linux/module.h>
++#include <linux/mmc/host.h>
++#include <linux/mmc/sdio_func.h>
++#include "main.h"
++#include "debug.h"
++#include "fw.h"
++#include "ps.h"
++#include "reg.h"
++#include "rx.h"
++#include "sdio.h"
++#include "tx.h"
++
++#define RTW_SDIO_INDIRECT_RW_RETRIES			50
++
++static bool rtw_sdio_is_bus_addr(u32 addr)
++{
++	return !!(addr & RTW_SDIO_BUS_MSK);
++}
++
++static bool rtw_sdio_bus_claim_needed(struct rtw_sdio *rtwsdio)
++{
++	return !rtwsdio->irq_thread ||
++	       rtwsdio->irq_thread != current;
++}
++
++static u32 rtw_sdio_to_bus_offset(struct rtw_dev *rtwdev, u32 addr)
++{
++	switch (addr & RTW_SDIO_BUS_MSK) {
++	case WLAN_IOREG_OFFSET:
++		addr &= WLAN_IOREG_REG_MSK;
++		addr |= FIELD_PREP(REG_SDIO_CMD_ADDR_MSK,
++				   REG_SDIO_CMD_ADDR_MAC_REG);
++		break;
++	case SDIO_LOCAL_OFFSET:
++		addr &= SDIO_LOCAL_REG_MSK;
++		addr |= FIELD_PREP(REG_SDIO_CMD_ADDR_MSK,
++				   REG_SDIO_CMD_ADDR_SDIO_REG);
++		break;
++	default:
++		rtw_warn(rtwdev, "Cannot convert addr 0x%08x to bus offset",
++			 addr);
++	}
++
++	return addr;
++}
++
++static bool rtw_sdio_use_memcpy_io(struct rtw_dev *rtwdev, u32 addr,
++				   u8 alignment)
++{
++	return IS_ALIGNED(addr, alignment) &&
++	       test_bit(RTW_FLAG_POWERON, rtwdev->flags);
++}
++
++static void rtw_sdio_writel(struct rtw_dev *rtwdev, u32 val, u32 addr,
++			    int *err_ret)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	u8 buf[4];
++	int i;
++
++	if (rtw_sdio_use_memcpy_io(rtwdev, addr, 4)) {
++		sdio_writel(rtwsdio->sdio_func, val, addr, err_ret);
++		return;
++	}
++
++	*(__le32 *)buf = cpu_to_le32(val);
++
++	for (i = 0; i < 4; i++) {
++		sdio_writeb(rtwsdio->sdio_func, buf[i], addr + i, err_ret);
++		if (*err_ret)
++			return;
++	}
++}
++
++static void rtw_sdio_writew(struct rtw_dev *rtwdev, u16 val, u32 addr,
++			    int *err_ret)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	u8 buf[2];
++	int i;
++
++	*(__le16 *)buf = cpu_to_le16(val);
++
++	for (i = 0; i < 2; i++) {
++		sdio_writeb(rtwsdio->sdio_func, buf[i], addr + i, err_ret);
++		if (*err_ret)
++			return;
++	}
++}
++
++static u32 rtw_sdio_readl(struct rtw_dev *rtwdev, u32 addr, int *err_ret)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	u8 buf[4];
++	int i;
++
++	if (rtw_sdio_use_memcpy_io(rtwdev, addr, 4))
++		return sdio_readl(rtwsdio->sdio_func, addr, err_ret);
++
++	for (i = 0; i < 4; i++) {
++		buf[i] = sdio_readb(rtwsdio->sdio_func, addr + i, err_ret);
++		if (*err_ret)
++			return 0;
++	}
++
++	return le32_to_cpu(*(__le32 *)buf);
++}
++
++static u16 rtw_sdio_readw(struct rtw_dev *rtwdev, u32 addr, int *err_ret)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	u8 buf[2];
++	int i;
++
++	for (i = 0; i < 2; i++) {
++		buf[i] = sdio_readb(rtwsdio->sdio_func, addr + i, err_ret);
++		if (*err_ret)
++			return 0;
++	}
++
++	return le16_to_cpu(*(__le16 *)buf);
++}
++
++static u32 rtw_sdio_to_io_address(struct rtw_dev *rtwdev, u32 addr,
++				  bool direct)
++{
++	if (!direct)
++		return addr;
++
++	if (!rtw_sdio_is_bus_addr(addr))
++		addr |= WLAN_IOREG_OFFSET;
++
++	return rtw_sdio_to_bus_offset(rtwdev, addr);
++}
++
++static bool rtw_sdio_use_direct_io(struct rtw_dev *rtwdev, u32 addr)
++{
++	return !rtw_sdio_is_sdio30_supported(rtwdev) ||
++		rtw_sdio_is_bus_addr(addr);
++}
++
++static int rtw_sdio_indirect_reg_cfg(struct rtw_dev *rtwdev, u32 addr, u32 cfg)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	unsigned int retry;
++	u32 reg_cfg;
++	int ret;
++	u8 tmp;
++
++	reg_cfg = rtw_sdio_to_bus_offset(rtwdev, REG_SDIO_INDIRECT_REG_CFG);
++
++	rtw_sdio_writel(rtwdev, addr | cfg | BIT_SDIO_INDIRECT_REG_CFG_UNK20,
++			reg_cfg, &ret);
++	if (ret)
++		return ret;
++
++	for (retry = 0; retry < RTW_SDIO_INDIRECT_RW_RETRIES; retry++) {
++		tmp = sdio_readb(rtwsdio->sdio_func, reg_cfg + 2, &ret);
++		if (!ret && (tmp & BIT(4)))
++			return 0;
++	}
++
++	return -ETIMEDOUT;
++}
++
++static u8 rtw_sdio_indirect_read8(struct rtw_dev *rtwdev, u32 addr,
++				  int *err_ret)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	u32 reg_data;
++
++	*err_ret = rtw_sdio_indirect_reg_cfg(rtwdev, addr,
++					     BIT_SDIO_INDIRECT_REG_CFG_READ);
++	if (*err_ret)
++		return 0;
++
++	reg_data = rtw_sdio_to_bus_offset(rtwdev, REG_SDIO_INDIRECT_REG_DATA);
++	return sdio_readb(rtwsdio->sdio_func, reg_data, err_ret);
++}
++
++static int rtw_sdio_indirect_read_bytes(struct rtw_dev *rtwdev, u32 addr,
++					u8 *buf, int count)
++{
++	int i, ret = 0;
++
++	for (i = 0; i < count; i++) {
++		buf[i] = rtw_sdio_indirect_read8(rtwdev, addr + i, &ret);
++		if (ret)
++			break;
++	}
++
++	return ret;
++}
++
++static u16 rtw_sdio_indirect_read16(struct rtw_dev *rtwdev, u32 addr,
++				    int *err_ret)
++{
++	u32 reg_data;
++	u8 buf[2];
++
++	if (!IS_ALIGNED(addr, 2)) {
++		*err_ret = rtw_sdio_indirect_read_bytes(rtwdev, addr, buf, 2);
++		if (*err_ret)
++			return 0;
++
++		return le16_to_cpu(*(__le16 *)buf);
++	}
++
++	*err_ret = rtw_sdio_indirect_reg_cfg(rtwdev, addr,
++					     BIT_SDIO_INDIRECT_REG_CFG_READ);
++	if (*err_ret)
++		return 0;
++
++	reg_data = rtw_sdio_to_bus_offset(rtwdev, REG_SDIO_INDIRECT_REG_DATA);
++	return rtw_sdio_readw(rtwdev, reg_data, err_ret);
++}
++
++static u32 rtw_sdio_indirect_read32(struct rtw_dev *rtwdev, u32 addr,
++				    int *err_ret)
++{
++	u32 reg_data;
++	u8 buf[4];
++
++	if (!IS_ALIGNED(addr, 4)) {
++		*err_ret = rtw_sdio_indirect_read_bytes(rtwdev, addr, buf, 4);
++		if (*err_ret)
++			return 0;
++
++		return le32_to_cpu(*(__le32 *)buf);
++	}
++
++	*err_ret = rtw_sdio_indirect_reg_cfg(rtwdev, addr,
++					     BIT_SDIO_INDIRECT_REG_CFG_READ);
++	if (*err_ret)
++		return 0;
++
++	reg_data = rtw_sdio_to_bus_offset(rtwdev, REG_SDIO_INDIRECT_REG_DATA);
++	return rtw_sdio_readl(rtwdev, reg_data, err_ret);
++}
++
++static u8 rtw_sdio_read8(struct rtw_dev *rtwdev, u32 addr)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	bool direct, bus_claim;
++	int ret;
++	u8 val;
++
++	direct = rtw_sdio_use_direct_io(rtwdev, addr);
++	addr = rtw_sdio_to_io_address(rtwdev, addr, direct);
++	bus_claim = rtw_sdio_bus_claim_needed(rtwsdio);
++
++	if (bus_claim)
++		sdio_claim_host(rtwsdio->sdio_func);
++
++	if (direct)
++		val = sdio_readb(rtwsdio->sdio_func, addr, &ret);
++	else
++		val = rtw_sdio_indirect_read8(rtwdev, addr, &ret);
++
++	if (bus_claim)
++		sdio_release_host(rtwsdio->sdio_func);
++
++	if (ret)
++		rtw_warn(rtwdev, "sdio read8 failed (0x%x): %d", addr, ret);
++
++	return val;
++}
++
++static u16 rtw_sdio_read16(struct rtw_dev *rtwdev, u32 addr)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	bool direct, bus_claim;
++	int ret;
++	u16 val;
++
++	direct = rtw_sdio_use_direct_io(rtwdev, addr);
++	addr = rtw_sdio_to_io_address(rtwdev, addr, direct);
++	bus_claim = rtw_sdio_bus_claim_needed(rtwsdio);
++
++	if (bus_claim)
++		sdio_claim_host(rtwsdio->sdio_func);
++
++	if (direct)
++		val = rtw_sdio_readw(rtwdev, addr, &ret);
++	else
++		val = rtw_sdio_indirect_read16(rtwdev, addr, &ret);
++
++	if (bus_claim)
++		sdio_release_host(rtwsdio->sdio_func);
++
++	if (ret)
++		rtw_warn(rtwdev, "sdio read16 failed (0x%x): %d", addr, ret);
++
++	return val;
++}
++
++static u32 rtw_sdio_read32(struct rtw_dev *rtwdev, u32 addr)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	bool direct, bus_claim;
++	u32 val;
++	int ret;
++
++	direct = rtw_sdio_use_direct_io(rtwdev, addr);
++	addr = rtw_sdio_to_io_address(rtwdev, addr, direct);
++	bus_claim = rtw_sdio_bus_claim_needed(rtwsdio);
++
++	if (bus_claim)
++		sdio_claim_host(rtwsdio->sdio_func);
++
++	if (direct)
++		val = rtw_sdio_readl(rtwdev, addr, &ret);
++	else
++		val = rtw_sdio_indirect_read32(rtwdev, addr, &ret);
++
++	if (bus_claim)
++		sdio_release_host(rtwsdio->sdio_func);
++
++	if (ret)
++		rtw_warn(rtwdev, "sdio read32 failed (0x%x): %d", addr, ret);
++
++	return val;
++}
++
++static void rtw_sdio_indirect_write8(struct rtw_dev *rtwdev, u8 val, u32 addr,
++				     int *err_ret)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	u32 reg_data;
++
++	reg_data = rtw_sdio_to_bus_offset(rtwdev, REG_SDIO_INDIRECT_REG_DATA);
++	sdio_writeb(rtwsdio->sdio_func, val, reg_data, err_ret);
++	if (*err_ret)
++		return;
++
++	*err_ret = rtw_sdio_indirect_reg_cfg(rtwdev, addr,
++					     BIT_SDIO_INDIRECT_REG_CFG_WRITE);
++}
++
++static void rtw_sdio_indirect_write16(struct rtw_dev *rtwdev, u16 val, u32 addr,
++				      int *err_ret)
++{
++	u32 reg_data;
++
++	if (!IS_ALIGNED(addr, 2)) {
++		addr = rtw_sdio_to_io_address(rtwdev, addr, true);
++		rtw_sdio_writew(rtwdev, val, addr, err_ret);
++		return;
++	}
++
++	reg_data = rtw_sdio_to_bus_offset(rtwdev, REG_SDIO_INDIRECT_REG_DATA);
++	rtw_sdio_writew(rtwdev, val, reg_data, err_ret);
++	if (*err_ret)
++		return;
++
++	*err_ret = rtw_sdio_indirect_reg_cfg(rtwdev, addr,
++					     BIT_SDIO_INDIRECT_REG_CFG_WRITE |
++					     BIT_SDIO_INDIRECT_REG_CFG_WORD);
++}
++
++static void rtw_sdio_indirect_write32(struct rtw_dev *rtwdev, u32 val,
++				      u32 addr, int *err_ret)
++{
++	u32 reg_data;
++
++	if (!IS_ALIGNED(addr, 4)) {
++		addr = rtw_sdio_to_io_address(rtwdev, addr, true);
++		rtw_sdio_writel(rtwdev, val, addr, err_ret);
++		return;
++	}
++
++	reg_data = rtw_sdio_to_bus_offset(rtwdev, REG_SDIO_INDIRECT_REG_DATA);
++	rtw_sdio_writel(rtwdev, val, reg_data, err_ret);
++
++	*err_ret = rtw_sdio_indirect_reg_cfg(rtwdev, addr,
++					     BIT_SDIO_INDIRECT_REG_CFG_WRITE |
++					     BIT_SDIO_INDIRECT_REG_CFG_DWORD);
++}
++
++static void rtw_sdio_write8(struct rtw_dev *rtwdev, u32 addr, u8 val)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	bool direct, bus_claim;
++	int ret;
++
++	direct = rtw_sdio_use_direct_io(rtwdev, addr);
++	addr = rtw_sdio_to_io_address(rtwdev, addr, direct);
++	bus_claim = rtw_sdio_bus_claim_needed(rtwsdio);
++
++	if (bus_claim)
++		sdio_claim_host(rtwsdio->sdio_func);
++
++	if (direct)
++		sdio_writeb(rtwsdio->sdio_func, val, addr, &ret);
++	else
++		rtw_sdio_indirect_write8(rtwdev, val, addr, &ret);
++
++	if (bus_claim)
++		sdio_release_host(rtwsdio->sdio_func);
++
++	if (ret)
++		rtw_warn(rtwdev, "sdio write8 failed (0x%x): %d", addr, ret);
++}
++
++static void rtw_sdio_write16(struct rtw_dev *rtwdev, u32 addr, u16 val)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	bool direct, bus_claim;
++	int ret;
++
++	direct = rtw_sdio_use_direct_io(rtwdev, addr);
++	addr = rtw_sdio_to_io_address(rtwdev, addr, direct);
++	bus_claim = rtw_sdio_bus_claim_needed(rtwsdio);
++
++	if (bus_claim)
++		sdio_claim_host(rtwsdio->sdio_func);
++
++	if (direct)
++		rtw_sdio_writew(rtwdev, val, addr, &ret);
++	else
++		rtw_sdio_indirect_write16(rtwdev, val, addr, &ret);
++
++	if (bus_claim)
++		sdio_release_host(rtwsdio->sdio_func);
++
++	if (ret)
++		rtw_warn(rtwdev, "sdio write16 failed (0x%x): %d", addr, ret);
++}
++
++static void rtw_sdio_write32(struct rtw_dev *rtwdev, u32 addr, u32 val)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	bool direct, bus_claim;
++	int ret;
++
++	direct = rtw_sdio_use_direct_io(rtwdev, addr);
++	addr = rtw_sdio_to_io_address(rtwdev, addr, direct);
++	bus_claim = rtw_sdio_bus_claim_needed(rtwsdio);
++
++	if (bus_claim)
++		sdio_claim_host(rtwsdio->sdio_func);
++
++	if (direct)
++		rtw_sdio_writel(rtwdev, val, addr, &ret);
++	else
++		rtw_sdio_indirect_write32(rtwdev, val, addr, &ret);
++
++	if (bus_claim)
++		sdio_release_host(rtwsdio->sdio_func);
++
++	if (ret)
++		rtw_warn(rtwdev, "sdio write32 failed (0x%x): %d", addr, ret);
++}
++
++static u32 rtw_sdio_get_tx_addr(struct rtw_dev *rtwdev, size_t size,
++				enum rtw_tx_queue_type queue)
++{
++	u32 txaddr;
++
++	switch (queue) {
++	case RTW_TX_QUEUE_BCN:
++	case RTW_TX_QUEUE_H2C:
++	case RTW_TX_QUEUE_HI0:
++		txaddr = FIELD_PREP(REG_SDIO_CMD_ADDR_MSK,
++				    REG_SDIO_CMD_ADDR_TXFF_HIGH);
++		break;
++	case RTW_TX_QUEUE_VI:
++	case RTW_TX_QUEUE_VO:
++		txaddr = FIELD_PREP(REG_SDIO_CMD_ADDR_MSK,
++				    REG_SDIO_CMD_ADDR_TXFF_NORMAL);
++		break;
++	case RTW_TX_QUEUE_BE:
++	case RTW_TX_QUEUE_BK:
++		txaddr = FIELD_PREP(REG_SDIO_CMD_ADDR_MSK,
++				    REG_SDIO_CMD_ADDR_TXFF_LOW);
++		break;
++	case RTW_TX_QUEUE_MGMT:
++		txaddr = FIELD_PREP(REG_SDIO_CMD_ADDR_MSK,
++				    REG_SDIO_CMD_ADDR_TXFF_EXTRA);
++		break;
++	default:
++		rtw_warn(rtwdev, "Unsupported queue for TX addr: 0x%02x\n",
++			 queue);
++		return 0;
++	}
++
++	txaddr += DIV_ROUND_UP(size, 4);
++
++	return txaddr;
++};
++
++static int rtw_sdio_read_port(struct rtw_dev *rtwdev, u8 *buf, size_t count)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	struct mmc_host *host = rtwsdio->sdio_func->card->host;
++	bool bus_claim = rtw_sdio_bus_claim_needed(rtwsdio);
++	u32 rxaddr = rtwsdio->rx_addr++;
++	size_t bytes;
++	int ret;
++
++	if (bus_claim)
++		sdio_claim_host(rtwsdio->sdio_func);
++
++	while (count > 0) {
++		bytes = min_t(size_t, host->max_req_size, count);
++
++		ret = sdio_memcpy_fromio(rtwsdio->sdio_func, buf,
++					 RTW_SDIO_ADDR_RX_RX0FF_GEN(rxaddr),
++					 bytes);
++		if (ret) {
++			rtw_warn(rtwdev,
++				 "Failed to read %zu byte(s) from SDIO port 0x%08x",
++				 bytes, rxaddr);
++			break;
++		}
++
++		count -= bytes;
++		buf += bytes;
++	}
++
++	if (bus_claim)
++		sdio_release_host(rtwsdio->sdio_func);
++
++	return ret;
++}
++
++static int rtw_sdio_check_free_txpg(struct rtw_dev *rtwdev, u8 queue,
++				    size_t count)
++{
++	unsigned int pages_free, pages_needed;
++
++	if (rtw_chip_wcpu_11n(rtwdev)) {
++		u32 free_txpg;
++
++		free_txpg = rtw_sdio_read32(rtwdev, REG_SDIO_FREE_TXPG);
++
++		switch (queue) {
++		case RTW_TX_QUEUE_BCN:
++		case RTW_TX_QUEUE_H2C:
++		case RTW_TX_QUEUE_HI0:
++		case RTW_TX_QUEUE_MGMT:
++			/* high */
++			pages_free = free_txpg & 0xff;
++			break;
++		case RTW_TX_QUEUE_VI:
++		case RTW_TX_QUEUE_VO:
++			/* normal */
++			pages_free = (free_txpg >> 8) & 0xff;
++			break;
++		case RTW_TX_QUEUE_BE:
++		case RTW_TX_QUEUE_BK:
++			/* low */
++			pages_free = (free_txpg >> 16) & 0xff;
++			break;
++		default:
++			rtw_warn(rtwdev, "Unknown mapping for queue %u\n", queue);
++			return -EINVAL;
++		}
++
++		/* add the pages from the public queue */
++		pages_free += (free_txpg >> 24) & 0xff;
++	} else {
++		u32 free_txpg[3];
++
++		free_txpg[0] = rtw_sdio_read32(rtwdev, REG_SDIO_FREE_TXPG);
++		free_txpg[1] = rtw_sdio_read32(rtwdev, REG_SDIO_FREE_TXPG + 4);
++		free_txpg[2] = rtw_sdio_read32(rtwdev, REG_SDIO_FREE_TXPG + 8);
++
++		switch (queue) {
++		case RTW_TX_QUEUE_BCN:
++		case RTW_TX_QUEUE_H2C:
++		case RTW_TX_QUEUE_HI0:
++			/* high */
++			pages_free = free_txpg[0] & 0xfff;
++			break;
++		case RTW_TX_QUEUE_VI:
++		case RTW_TX_QUEUE_VO:
++			/* normal */
++			pages_free = (free_txpg[0] >> 16) & 0xfff;
++			break;
++		case RTW_TX_QUEUE_BE:
++		case RTW_TX_QUEUE_BK:
++			/* low */
++			pages_free = free_txpg[1] & 0xfff;
++			break;
++		case RTW_TX_QUEUE_MGMT:
++			/* extra */
++			pages_free = free_txpg[2] & 0xfff;
++			break;
++		default:
++			rtw_warn(rtwdev, "Unknown mapping for queue %u\n", queue);
++			return -EINVAL;
++		}
++
++		/* add the pages from the public queue */
++		pages_free += (free_txpg[1] >> 16) & 0xfff;
++	}
++
++	pages_needed = DIV_ROUND_UP(count, rtwdev->chip->page_size);
++
++	if (pages_needed > pages_free) {
++		rtw_dbg(rtwdev, RTW_DBG_SDIO,
++			"Not enough free pages (%u needed, %u free) in queue %u for %zu bytes\n",
++			pages_needed, pages_free, queue, count);
++		return -EBUSY;
++	}
++
++	return 0;
++}
++
++static int rtw_sdio_write_port(struct rtw_dev *rtwdev, struct sk_buff *skb,
++			       enum rtw_tx_queue_type queue)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	bool bus_claim;
++	size_t txsize;
++	u32 txaddr;
++	int ret;
++
++	txaddr = rtw_sdio_get_tx_addr(rtwdev, skb->len, queue);
++	if (!txaddr)
++		return -EINVAL;
++
++	txsize = sdio_align_size(rtwsdio->sdio_func, skb->len);
++
++	ret = rtw_sdio_check_free_txpg(rtwdev, queue, txsize);
++	if (ret)
++		return ret;
++
++	if (!IS_ALIGNED((unsigned long)skb->data, RTW_SDIO_DATA_PTR_ALIGN))
++		rtw_warn(rtwdev, "Got unaligned SKB in %s() for queue %u\n",
++			 __func__, queue);
++
++	bus_claim = rtw_sdio_bus_claim_needed(rtwsdio);
++
++	if (bus_claim)
++		sdio_claim_host(rtwsdio->sdio_func);
++
++	ret = sdio_memcpy_toio(rtwsdio->sdio_func, txaddr, skb->data, txsize);
++
++	if (bus_claim)
++		sdio_release_host(rtwsdio->sdio_func);
++
++	if (ret)
++		rtw_warn(rtwdev,
++			 "Failed to write %zu byte(s) to SDIO port 0x%08x",
++			 txsize, txaddr);
++
++	return ret;
++}
++
++static void rtw_sdio_init(struct rtw_dev *rtwdev)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++
++	rtwsdio->irq_mask = REG_SDIO_HIMR_RX_REQUEST | REG_SDIO_HIMR_CPWM1;
++}
++
++static void rtw_sdio_enable_rx_aggregation(struct rtw_dev *rtwdev)
++{
++	u8 size, timeout;
++
++	if (rtw_chip_wcpu_11n(rtwdev)) {
++		size = 0x6;
++		timeout = 0x6;
++	} else {
++		size = 0xff;
++		timeout = 0x1;
++	}
++
++	/* Make the firmware honor the size limit configured below */
++	rtw_write32_set(rtwdev, REG_RXDMA_AGG_PG_TH, BIT_EN_PRE_CALC);
++
++	rtw_write8_set(rtwdev, REG_TXDMA_PQ_MAP, BIT_RXDMA_AGG_EN);
++
++	rtw_write16(rtwdev, REG_RXDMA_AGG_PG_TH,
++		    FIELD_PREP(BIT_RXDMA_AGG_PG_TH, size) |
++		    FIELD_PREP(BIT_DMA_AGG_TO_V1, timeout));
++
++	rtw_write8_set(rtwdev, REG_RXDMA_MODE, BIT_DMA_MODE);
++}
++
++static void rtw_sdio_enable_interrupt(struct rtw_dev *rtwdev)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++
++	rtw_write32(rtwdev, REG_SDIO_HIMR, rtwsdio->irq_mask);
++}
++
++static void rtw_sdio_disable_interrupt(struct rtw_dev *rtwdev)
++{
++	rtw_write32(rtwdev, REG_SDIO_HIMR, 0x0);
++}
++
++static u8 rtw_sdio_get_tx_qsel(struct rtw_dev *rtwdev, struct sk_buff *skb,
++			       u8 queue)
++{
++	switch (queue) {
++	case RTW_TX_QUEUE_BCN:
++		return TX_DESC_QSEL_BEACON;
++	case RTW_TX_QUEUE_H2C:
++		return TX_DESC_QSEL_H2C;
++	case RTW_TX_QUEUE_MGMT:
++		if (rtw_chip_wcpu_11n(rtwdev))
++			return TX_DESC_QSEL_HIGH;
++		else
++			return TX_DESC_QSEL_MGMT;
++	case RTW_TX_QUEUE_HI0:
++		return TX_DESC_QSEL_HIGH;
++	default:
++		return skb->priority;
++	}
++}
++
++static int rtw_sdio_setup(struct rtw_dev *rtwdev)
++{
++	/* nothing to do */
++	return 0;
++}
++
++static int rtw_sdio_start(struct rtw_dev *rtwdev)
++{
++	rtw_sdio_enable_rx_aggregation(rtwdev);
++	rtw_sdio_enable_interrupt(rtwdev);
++
++	return 0;
++}
++
++static void rtw_sdio_stop(struct rtw_dev *rtwdev)
++{
++	rtw_sdio_disable_interrupt(rtwdev);
++}
++
++static void rtw_sdio_deep_ps_enter(struct rtw_dev *rtwdev)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	bool tx_empty = true;
++	u8 queue;
++
++	if (!rtw_fw_feature_check(&rtwdev->fw, FW_FEATURE_TX_WAKE)) {
++		/* Deep PS state is not allowed to TX-DMA */
++		for (queue = 0; queue < RTK_MAX_TX_QUEUE_NUM; queue++) {
++			/* BCN queue is rsvd page, does not have DMA interrupt
++			 * H2C queue is managed by firmware
++			 */
++			if (queue == RTW_TX_QUEUE_BCN ||
++			    queue == RTW_TX_QUEUE_H2C)
++				continue;
++
++			/* check if there is any skb DMAing */
++			if (skb_queue_len(&rtwsdio->tx_queue[queue])) {
++				tx_empty = false;
++				break;
++			}
++		}
++	}
++
++	if (!tx_empty) {
++		rtw_dbg(rtwdev, RTW_DBG_PS,
++			"TX path not empty, cannot enter deep power save state\n");
++		return;
++	}
++
++	set_bit(RTW_FLAG_LEISURE_PS_DEEP, rtwdev->flags);
++	rtw_power_mode_change(rtwdev, true);
++}
++
++static void rtw_sdio_deep_ps_leave(struct rtw_dev *rtwdev)
++{
++	if (test_and_clear_bit(RTW_FLAG_LEISURE_PS_DEEP, rtwdev->flags))
++		rtw_power_mode_change(rtwdev, false);
++}
++
++static void rtw_sdio_deep_ps(struct rtw_dev *rtwdev, bool enter)
++{
++	if (enter && !test_bit(RTW_FLAG_LEISURE_PS_DEEP, rtwdev->flags))
++		rtw_sdio_deep_ps_enter(rtwdev);
++
++	if (!enter && test_bit(RTW_FLAG_LEISURE_PS_DEEP, rtwdev->flags))
++		rtw_sdio_deep_ps_leave(rtwdev);
++}
++
++static void rtw_sdio_tx_kick_off(struct rtw_dev *rtwdev)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++
++	queue_work(rtwsdio->txwq, &rtwsdio->tx_handler_data->work);
++}
++
++static void rtw_sdio_link_ps(struct rtw_dev *rtwdev, bool enter)
++{
++	/* nothing to do */
++}
++
++static void rtw_sdio_interface_cfg(struct rtw_dev *rtwdev)
++{
++	u32 val;
++
++	rtw_read32(rtwdev, REG_SDIO_FREE_TXPG);
++
++	val = rtw_read32(rtwdev, REG_SDIO_TX_CTRL);
++	val &= 0xfff8;
++	rtw_write32(rtwdev, REG_SDIO_TX_CTRL, val);
++}
++
++static struct rtw_sdio_tx_data *rtw_sdio_get_tx_data(struct sk_buff *skb)
++{
++	struct ieee80211_tx_info *info = IEEE80211_SKB_CB(skb);
++
++	BUILD_BUG_ON(sizeof(struct rtw_sdio_tx_data) >
++		     sizeof(info->status.status_driver_data));
++
++	return (struct rtw_sdio_tx_data *)info->status.status_driver_data;
++}
++
++static void rtw_sdio_tx_skb_prepare(struct rtw_dev *rtwdev,
++				    struct rtw_tx_pkt_info *pkt_info,
++				    struct sk_buff *skb,
++				    enum rtw_tx_queue_type queue)
++{
++	const struct rtw_chip_info *chip = rtwdev->chip;
++	unsigned long data_addr, aligned_addr;
++	size_t offset;
++	u8 *pkt_desc;
++
++	pkt_desc = skb_push(skb, chip->tx_pkt_desc_sz);
++
++	data_addr = (unsigned long)pkt_desc;
++	aligned_addr = ALIGN(data_addr, RTW_SDIO_DATA_PTR_ALIGN);
++
++	if (data_addr != aligned_addr) {
++		/* Ensure that the start of the pkt_desc is always aligned at
++		 * RTW_SDIO_DATA_PTR_ALIGN.
++		 */
++		offset = RTW_SDIO_DATA_PTR_ALIGN - (aligned_addr - data_addr);
++
++		pkt_desc = skb_push(skb, offset);
++
++		/* By inserting padding to align the start of the pkt_desc we
++		 * need to inform the firmware that the actual data starts at
++		 * a different offset than normal.
++		 */
++		pkt_info->offset += offset;
++	}
++
++	memset(pkt_desc, 0, chip->tx_pkt_desc_sz);
++
++	pkt_info->qsel = rtw_sdio_get_tx_qsel(rtwdev, skb, queue);
++
++	rtw_tx_fill_tx_desc(pkt_info, skb);
++	rtw_tx_fill_txdesc_checksum(rtwdev, pkt_info, pkt_desc);
++}
++
++static int rtw_sdio_write_data(struct rtw_dev *rtwdev,
++			       struct rtw_tx_pkt_info *pkt_info,
++			       struct sk_buff *skb,
++			       enum rtw_tx_queue_type queue)
++{
++	int ret;
++
++	rtw_sdio_tx_skb_prepare(rtwdev, pkt_info, skb, queue);
++
++	ret = rtw_sdio_write_port(rtwdev, skb, queue);
++	dev_kfree_skb_any(skb);
++
++	return ret;
++}
++
++static int rtw_sdio_write_data_rsvd_page(struct rtw_dev *rtwdev, u8 *buf,
++					 u32 size)
++{
++	struct rtw_tx_pkt_info pkt_info = {};
++	struct sk_buff *skb;
++
++	skb = rtw_tx_write_data_rsvd_page_get(rtwdev, &pkt_info, buf, size);
++	if (!skb)
++		return -ENOMEM;
++
++	return rtw_sdio_write_data(rtwdev, &pkt_info, skb, RTW_TX_QUEUE_BCN);
++}
++
++static int rtw_sdio_write_data_h2c(struct rtw_dev *rtwdev, u8 *buf, u32 size)
++{
++	struct rtw_tx_pkt_info pkt_info = {};
++	struct sk_buff *skb;
++
++	skb = rtw_tx_write_data_h2c_get(rtwdev, &pkt_info, buf, size);
++	if (!skb)
++		return -ENOMEM;
++
++	return rtw_sdio_write_data(rtwdev, &pkt_info, skb, RTW_TX_QUEUE_H2C);
++}
++
++static int rtw_sdio_tx_write(struct rtw_dev *rtwdev,
++			     struct rtw_tx_pkt_info *pkt_info,
++			     struct sk_buff *skb)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	enum rtw_tx_queue_type queue = rtw_tx_queue_mapping(skb);
++	struct rtw_sdio_tx_data *tx_data;
++
++	rtw_sdio_tx_skb_prepare(rtwdev, pkt_info, skb, queue);
++
++	tx_data = rtw_sdio_get_tx_data(skb);
++	tx_data->sn = pkt_info->sn;
++
++	skb_queue_tail(&rtwsdio->tx_queue[queue], skb);
++
++	return 0;
++}
++
++static void rtw_sdio_tx_err_isr(struct rtw_dev *rtwdev)
++{
++	u32 val = rtw_read32(rtwdev, REG_TXDMA_STATUS);
++
++	rtw_write32(rtwdev, REG_TXDMA_STATUS, val);
++}
++
++static void rtw_sdio_rx_skb(struct rtw_dev *rtwdev, struct sk_buff *skb,
++			    u32 pkt_offset, struct rtw_rx_pkt_stat *pkt_stat,
++			    struct ieee80211_rx_status *rx_status)
++{
++	*IEEE80211_SKB_RXCB(skb) = *rx_status;
++
++	if (pkt_stat->is_c2h) {
++		skb_put(skb, pkt_stat->pkt_len + pkt_offset);
++		rtw_fw_c2h_cmd_rx_irqsafe(rtwdev, pkt_offset, skb);
++		return;
++	}
++
++	skb_put(skb, pkt_stat->pkt_len);
++	skb_reserve(skb, pkt_offset);
++
++	rtw_rx_stats(rtwdev, pkt_stat->vif, skb);
++
++	ieee80211_rx_irqsafe(rtwdev->hw, skb);
++}
++
++static void rtw_sdio_rxfifo_recv(struct rtw_dev *rtwdev, u32 rx_len)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	const struct rtw_chip_info *chip = rtwdev->chip;
++	u32 pkt_desc_sz = chip->rx_pkt_desc_sz;
++	struct ieee80211_rx_status rx_status;
++	struct rtw_rx_pkt_stat pkt_stat;
++	struct sk_buff *skb, *split_skb;
++	u32 pkt_offset, curr_pkt_len;
++	size_t bufsz;
++	u8 *rx_desc;
++	int ret;
++
++	bufsz = sdio_align_size(rtwsdio->sdio_func, rx_len);
++
++	skb = dev_alloc_skb(bufsz);
++	if (!skb)
++		return;
++
++	ret = rtw_sdio_read_port(rtwdev, skb->data, bufsz);
++	if (ret) {
++		dev_kfree_skb_any(skb);
++		return;
++	}
++
++	while (true) {
++		rx_desc = skb->data;
++		chip->ops->query_rx_desc(rtwdev, rx_desc, &pkt_stat,
++					 &rx_status);
++		pkt_offset = pkt_desc_sz + pkt_stat.drv_info_sz +
++			     pkt_stat.shift;
++
++		curr_pkt_len = ALIGN(pkt_offset + pkt_stat.pkt_len,
++				     RTW_SDIO_DATA_PTR_ALIGN);
++
++		if ((curr_pkt_len + pkt_desc_sz) >= rx_len) {
++			/* Use the original skb (with it's adjusted offset)
++			 * when processing the last (or even the only) entry to
++			 * have it's memory freed automatically.
++			 */
++			rtw_sdio_rx_skb(rtwdev, skb, pkt_offset, &pkt_stat,
++					&rx_status);
++			break;
++		}
++
++		split_skb = dev_alloc_skb(curr_pkt_len);
++		if (!split_skb) {
++			rtw_sdio_rx_skb(rtwdev, skb, pkt_offset, &pkt_stat,
++					&rx_status);
++			break;
++		}
++
++		skb_copy_header(split_skb, skb);
++		memcpy(split_skb->data, skb->data, curr_pkt_len);
++
++		rtw_sdio_rx_skb(rtwdev, split_skb, pkt_offset, &pkt_stat,
++				&rx_status);
++
++		/* Move to the start of the next RX descriptor */
++		skb_reserve(skb, curr_pkt_len);
++		rx_len -= curr_pkt_len;
++	}
++}
++
++static void rtw_sdio_rx_isr(struct rtw_dev *rtwdev)
++{
++	u32 rx_len, hisr, total_rx_bytes = 0;
++
++	do {
++		if (rtw_chip_wcpu_11n(rtwdev))
++			rx_len = rtw_read16(rtwdev, REG_SDIO_RX0_REQ_LEN);
++		else
++			rx_len = rtw_read32(rtwdev, REG_SDIO_RX0_REQ_LEN);
++
++		if (!rx_len)
++			break;
++
++		rtw_sdio_rxfifo_recv(rtwdev, rx_len);
++
++		total_rx_bytes += rx_len;
++
++		if (rtw_chip_wcpu_11n(rtwdev)) {
++			/* Stop if no more RX requests are pending, even if
++			 * rx_len could be greater than zero in the next
++			 * iteration. This is needed because the RX buffer may
++			 * already contain data while either HW or FW are not
++			 * done filling that buffer yet. Still reading the
++			 * buffer can result in packets where
++			 * rtw_rx_pkt_stat.pkt_len is zero or points beyond the
++			 * end of the buffer.
++			 */
++			hisr = rtw_read32(rtwdev, REG_SDIO_HISR);
++		} else {
++			/* RTW_WCPU_11AC chips have improved hardware or
++			 * firmware and can use rx_len unconditionally.
++			 */
++			hisr = REG_SDIO_HISR_RX_REQUEST;
++		}
++	} while (total_rx_bytes < SZ_64K && hisr & REG_SDIO_HISR_RX_REQUEST);
++}
++
++static void rtw_sdio_handle_interrupt(struct sdio_func *sdio_func)
++{
++	struct ieee80211_hw *hw = sdio_get_drvdata(sdio_func);
++	struct rtw_sdio *rtwsdio;
++	struct rtw_dev *rtwdev;
++	u32 hisr;
++
++	rtwdev = hw->priv;
++	rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++
++	rtwsdio->irq_thread = current;
++
++	hisr = rtw_read32(rtwdev, REG_SDIO_HISR);
++
++	if (hisr & REG_SDIO_HISR_TXERR)
++		rtw_sdio_tx_err_isr(rtwdev);
++	if (hisr & REG_SDIO_HISR_RX_REQUEST) {
++		hisr &= ~REG_SDIO_HISR_RX_REQUEST;
++		rtw_sdio_rx_isr(rtwdev);
++	}
++
++	rtw_write32(rtwdev, REG_SDIO_HISR, hisr);
++
++	rtwsdio->irq_thread = NULL;
++}
++
++static int __maybe_unused rtw_sdio_suspend(struct device *dev)
++{
++	struct sdio_func *func = dev_to_sdio_func(dev);
++	struct ieee80211_hw *hw = dev_get_drvdata(dev);
++	struct rtw_dev *rtwdev = hw->priv;
++	int ret;
++
++	ret = sdio_set_host_pm_flags(func, MMC_PM_KEEP_POWER);
++	if (ret)
++		rtw_err(rtwdev, "Failed to host PM flag MMC_PM_KEEP_POWER");
++
++	return ret;
++}
++
++static int __maybe_unused rtw_sdio_resume(struct device *dev)
++{
++	return 0;
++}
++
++SIMPLE_DEV_PM_OPS(rtw_sdio_pm_ops, rtw_sdio_suspend, rtw_sdio_resume);
++EXPORT_SYMBOL(rtw_sdio_pm_ops);
++
++static int rtw_sdio_claim(struct rtw_dev *rtwdev, struct sdio_func *sdio_func)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	int ret;
++
++	sdio_claim_host(sdio_func);
++
++	ret = sdio_enable_func(sdio_func);
++	if (ret) {
++		rtw_err(rtwdev, "Failed to enable SDIO func");
++		goto err_release_host;
++	}
++
++	ret = sdio_set_block_size(sdio_func, RTW_SDIO_BLOCK_SIZE);
++	if (ret) {
++		rtw_err(rtwdev, "Failed to set SDIO block size to 512");
++		goto err_disable_func;
++	}
++
++	rtwsdio->sdio_func = sdio_func;
++
++	rtwsdio->sdio3_bus_mode = mmc_card_uhs(sdio_func->card);
++
++	sdio_set_drvdata(sdio_func, rtwdev->hw);
++	SET_IEEE80211_DEV(rtwdev->hw, &sdio_func->dev);
++
++	sdio_release_host(sdio_func);
++
++	return 0;
++
++err_disable_func:
++	sdio_disable_func(sdio_func);
++err_release_host:
++	sdio_release_host(sdio_func);
++	return ret;
++}
++
++static void rtw_sdio_declaim(struct rtw_dev *rtwdev,
++			     struct sdio_func *sdio_func)
++{
++	sdio_claim_host(sdio_func);
++	sdio_disable_func(sdio_func);
++	sdio_release_host(sdio_func);
++}
++
++static struct rtw_hci_ops rtw_sdio_ops = {
++	.tx_write = rtw_sdio_tx_write,
++	.tx_kick_off = rtw_sdio_tx_kick_off,
++	.setup = rtw_sdio_setup,
++	.start = rtw_sdio_start,
++	.stop = rtw_sdio_stop,
++	.deep_ps = rtw_sdio_deep_ps,
++	.link_ps = rtw_sdio_link_ps,
++	.interface_cfg = rtw_sdio_interface_cfg,
++
++	.read8 = rtw_sdio_read8,
++	.read16 = rtw_sdio_read16,
++	.read32 = rtw_sdio_read32,
++	.write8 = rtw_sdio_write8,
++	.write16 = rtw_sdio_write16,
++	.write32 = rtw_sdio_write32,
++	.write_data_rsvd_page = rtw_sdio_write_data_rsvd_page,
++	.write_data_h2c = rtw_sdio_write_data_h2c,
++};
++
++static int rtw_sdio_request_irq(struct rtw_dev *rtwdev,
++				struct sdio_func *sdio_func)
++{
++	int ret;
++
++	sdio_claim_host(sdio_func);
++	ret = sdio_claim_irq(sdio_func, &rtw_sdio_handle_interrupt);
++	sdio_release_host(sdio_func);
++
++	if (ret) {
++		rtw_err(rtwdev, "failed to claim SDIO IRQ");
++		return ret;
++	}
++
++	return 0;
++}
++
++static void rtw_sdio_indicate_tx_status(struct rtw_dev *rtwdev,
++					struct sk_buff *skb)
++{
++	struct rtw_sdio_tx_data *tx_data = rtw_sdio_get_tx_data(skb);
++	struct ieee80211_tx_info *info = IEEE80211_SKB_CB(skb);
++	struct ieee80211_hw *hw = rtwdev->hw;
++
++	/* enqueue to wait for tx report */
++	if (info->flags & IEEE80211_TX_CTL_REQ_TX_STATUS) {
++		rtw_tx_report_enqueue(rtwdev, skb, tx_data->sn);
++		return;
++	}
++
++	/* always ACK for others, then they won't be marked as drop */
++	ieee80211_tx_info_clear_status(info);
++	if (info->flags & IEEE80211_TX_CTL_NO_ACK)
++		info->flags |= IEEE80211_TX_STAT_NOACK_TRANSMITTED;
++	else
++		info->flags |= IEEE80211_TX_STAT_ACK;
++
++	ieee80211_tx_status_irqsafe(hw, skb);
++}
++
++static void rtw_sdio_process_tx_queue(struct rtw_dev *rtwdev,
++				      enum rtw_tx_queue_type queue)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	struct sk_buff *skb;
++	int ret;
++
++	skb = skb_dequeue(&rtwsdio->tx_queue[queue]);
++	if (!skb)
++		return;
++
++	ret = rtw_sdio_write_port(rtwdev, skb, queue);
++	if (ret) {
++		skb_queue_head(&rtwsdio->tx_queue[queue], skb);
++		return;
++	}
++
++	if (queue <= RTW_TX_QUEUE_VO)
++		rtw_sdio_indicate_tx_status(rtwdev, skb);
++	else
++		dev_kfree_skb_any(skb);
++}
++
++static void rtw_sdio_tx_handler(struct work_struct *work)
++{
++	struct rtw_sdio_work_data *work_data =
++		container_of(work, struct rtw_sdio_work_data, work);
++	struct rtw_sdio *rtwsdio;
++	struct rtw_dev *rtwdev;
++	int limit, queue;
++
++	rtwdev = work_data->rtwdev;
++	rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++
++	if (!rtw_fw_feature_check(&rtwdev->fw, FW_FEATURE_TX_WAKE))
++		rtw_sdio_deep_ps_leave(rtwdev);
++
++	for (queue = RTK_MAX_TX_QUEUE_NUM - 1; queue >= 0; queue--) {
++		for (limit = 0; limit < 1000; limit++) {
++			rtw_sdio_process_tx_queue(rtwdev, queue);
++
++			if (skb_queue_empty(&rtwsdio->tx_queue[queue]))
++				break;
++		}
++	}
++}
++
++static void rtw_sdio_free_irq(struct rtw_dev *rtwdev,
++			      struct sdio_func *sdio_func)
++{
++	sdio_claim_host(sdio_func);
++	sdio_release_irq(sdio_func);
++	sdio_release_host(sdio_func);
++}
++
++static int rtw_sdio_init_tx(struct rtw_dev *rtwdev)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	int i;
++
++	rtwsdio->txwq = create_singlethread_workqueue("rtw88_sdio: tx wq");
++	if (!rtwsdio->txwq) {
++		rtw_err(rtwdev, "failed to create TX work queue\n");
++		return -ENOMEM;
++	}
++
++	for (i = 0; i < RTK_MAX_TX_QUEUE_NUM; i++)
++		skb_queue_head_init(&rtwsdio->tx_queue[i]);
++	rtwsdio->tx_handler_data = kmalloc(sizeof(*rtwsdio->tx_handler_data),
++					   GFP_KERNEL);
++	if (!rtwsdio->tx_handler_data)
++		goto err_destroy_wq;
++
++	rtwsdio->tx_handler_data->rtwdev = rtwdev;
++	INIT_WORK(&rtwsdio->tx_handler_data->work, rtw_sdio_tx_handler);
++
++	return 0;
++
++err_destroy_wq:
++	destroy_workqueue(rtwsdio->txwq);
++	return -ENOMEM;
++}
++
++static void rtw_sdio_deinit_tx(struct rtw_dev *rtwdev)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	int i;
++
++	for (i = 0; i < RTK_MAX_TX_QUEUE_NUM; i++)
++		skb_queue_purge(&rtwsdio->tx_queue[i]);
++
++	flush_workqueue(rtwsdio->txwq);
++	destroy_workqueue(rtwsdio->txwq);
++	kfree(rtwsdio->tx_handler_data);
++}
++
++int rtw_sdio_probe(struct sdio_func *sdio_func,
++		   const struct sdio_device_id *id)
++{
++	struct ieee80211_hw *hw;
++	struct rtw_dev *rtwdev;
++	int drv_data_size;
++	int ret;
++
++	drv_data_size = sizeof(struct rtw_dev) + sizeof(struct rtw_sdio);
++	hw = ieee80211_alloc_hw(drv_data_size, &rtw_ops);
++	if (!hw) {
++		dev_err(&sdio_func->dev, "failed to allocate hw");
++		return -ENOMEM;
++	}
++
++	rtwdev = hw->priv;
++	rtwdev->hw = hw;
++	rtwdev->dev = &sdio_func->dev;
++	rtwdev->chip = (struct rtw_chip_info *)id->driver_data;
++	rtwdev->hci.ops = &rtw_sdio_ops;
++	rtwdev->hci.type = RTW_HCI_TYPE_SDIO;
++
++	ret = rtw_core_init(rtwdev);
++	if (ret)
++		goto err_release_hw;
++
++	rtw_dbg(rtwdev, RTW_DBG_SDIO,
++		"rtw88 SDIO probe: vendor=0x%04x device=%04x class=%02x",
++		id->vendor, id->device, id->class);
++
++	ret = rtw_sdio_claim(rtwdev, sdio_func);
++	if (ret) {
++		rtw_err(rtwdev, "failed to claim SDIO device");
++		goto err_deinit_core;
++	}
++
++	rtw_sdio_init(rtwdev);
++
++	ret = rtw_sdio_init_tx(rtwdev);
++	if (ret) {
++		rtw_err(rtwdev, "failed to init SDIO TX queue\n");
++		goto err_sdio_declaim;
++	}
++
++	ret = rtw_chip_info_setup(rtwdev);
++	if (ret) {
++		rtw_err(rtwdev, "failed to setup chip information");
++		goto err_destroy_txwq;
++	}
++
++	ret = rtw_sdio_request_irq(rtwdev, sdio_func);
++	if (ret)
++		goto err_destroy_txwq;
++
++	ret = rtw_register_hw(rtwdev, hw);
++	if (ret) {
++		rtw_err(rtwdev, "failed to register hw");
++		goto err_free_irq;
++	}
++
++	return 0;
++
++err_free_irq:
++	rtw_sdio_free_irq(rtwdev, sdio_func);
++err_destroy_txwq:
++	rtw_sdio_deinit_tx(rtwdev);
++err_sdio_declaim:
++	rtw_sdio_declaim(rtwdev, sdio_func);
++err_deinit_core:
++	rtw_core_deinit(rtwdev);
++err_release_hw:
++	ieee80211_free_hw(hw);
++
++	return ret;
++}
++EXPORT_SYMBOL(rtw_sdio_probe);
++
++void rtw_sdio_remove(struct sdio_func *sdio_func)
++{
++	struct ieee80211_hw *hw = sdio_get_drvdata(sdio_func);
++	struct rtw_dev *rtwdev;
++
++	if (!hw)
++		return;
++
++	rtwdev = hw->priv;
++
++	rtw_unregister_hw(rtwdev, hw);
++	rtw_sdio_disable_interrupt(rtwdev);
++	rtw_sdio_free_irq(rtwdev, sdio_func);
++	rtw_sdio_declaim(rtwdev, sdio_func);
++	rtw_sdio_deinit_tx(rtwdev);
++	rtw_core_deinit(rtwdev);
++	ieee80211_free_hw(hw);
++}
++EXPORT_SYMBOL(rtw_sdio_remove);
++
++void rtw_sdio_shutdown(struct device *dev)
++{
++	struct sdio_func *sdio_func = dev_to_sdio_func(dev);
++	const struct rtw_chip_info *chip;
++	struct ieee80211_hw *hw;
++	struct rtw_dev *rtwdev;
++
++	hw = sdio_get_drvdata(sdio_func);
++	if (!hw)
++		return;
++
++	rtwdev = hw->priv;
++	chip = rtwdev->chip;
++
++	if (chip->ops->shutdown)
++		chip->ops->shutdown(rtwdev);
++}
++EXPORT_SYMBOL(rtw_sdio_shutdown);
++
++MODULE_AUTHOR("Martin Blumenstingl");
++MODULE_AUTHOR("Jernej Skrabec");
++MODULE_DESCRIPTION("Realtek 802.11ac wireless SDIO driver");
++MODULE_LICENSE("Dual BSD/GPL");
+diff --git a/drivers/net/wireless/realtek/rtw88/sdio.h b/drivers/net/wireless/realtek/rtw88/sdio.h
+new file mode 100644
+index 000000000000..3c659ed180f0
+--- /dev/null
++++ b/drivers/net/wireless/realtek/rtw88/sdio.h
+@@ -0,0 +1,178 @@
++/* SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause */
++/* Copyright (C) 2021 Martin Blumenstingl <martin.blumenstingl@googlemail.com>
++ * Copyright (C) 2021 Jernej Skrabec <jernej.skrabec@gmail.com>
++ */
++
++#ifndef __REG_SDIO_H_
++#define __REG_SDIO_H_
++
++/* I/O bus domain address mapping */
++#define SDIO_LOCAL_OFFSET			0x10250000
++#define WLAN_IOREG_OFFSET			0x10260000
++#define FIRMWARE_FIFO_OFFSET			0x10270000
++#define TX_HIQ_OFFSET				0x10310000
++#define TX_MIQ_OFFSET				0x10320000
++#define TX_LOQ_OFFSET				0x10330000
++#define TX_EPQ_OFFSET				0x10350000
++#define RX_RX0FF_OFFSET				0x10340000
++
++#define RTW_SDIO_BUS_MSK			0xffff0000
++#define SDIO_LOCAL_REG_MSK			0x00000fff
++#define WLAN_IOREG_REG_MSK			0x0000ffff
++
++/* SDIO Tx Control */
++#define REG_SDIO_TX_CTRL			(SDIO_LOCAL_OFFSET + 0x0000)
++
++/*SDIO status timeout*/
++#define REG_SDIO_TIMEOUT			(SDIO_LOCAL_OFFSET + 0x0002)
++
++/* SDIO Host Interrupt Mask */
++#define REG_SDIO_HIMR				(SDIO_LOCAL_OFFSET + 0x0014)
++#define REG_SDIO_HIMR_RX_REQUEST		BIT(0)
++#define REG_SDIO_HIMR_AVAL			BIT(1)
++#define REG_SDIO_HIMR_TXERR			BIT(2)
++#define REG_SDIO_HIMR_RXERR			BIT(3)
++#define REG_SDIO_HIMR_TXFOVW			BIT(4)
++#define REG_SDIO_HIMR_RXFOVW			BIT(5)
++#define REG_SDIO_HIMR_TXBCNOK			BIT(6)
++#define REG_SDIO_HIMR_TXBCNERR			BIT(7)
++#define REG_SDIO_HIMR_BCNERLY_INT		BIT(16)
++#define REG_SDIO_HIMR_C2HCMD			BIT(17)
++#define REG_SDIO_HIMR_CPWM1			BIT(18)
++#define REG_SDIO_HIMR_CPWM2			BIT(19)
++#define REG_SDIO_HIMR_HSISR_IND			BIT(20)
++#define REG_SDIO_HIMR_GTINT3_IND		BIT(21)
++#define REG_SDIO_HIMR_GTINT4_IND		BIT(22)
++#define REG_SDIO_HIMR_PSTIMEOUT			BIT(23)
++#define REG_SDIO_HIMR_OCPINT			BIT(24)
++#define REG_SDIO_HIMR_ATIMEND			BIT(25)
++#define REG_SDIO_HIMR_ATIMEND_E			BIT(26)
++#define REG_SDIO_HIMR_CTWEND			BIT(27)
++/* the following two are RTL8188 SDIO Specific */
++#define REG_SDIO_HIMR_MCU_ERR			BIT(28)
++#define REG_SDIO_HIMR_TSF_BIT32_TOGGLE		BIT(29)
++
++/* SDIO Host Interrupt Service Routine */
++#define REG_SDIO_HISR				(SDIO_LOCAL_OFFSET + 0x0018)
++#define REG_SDIO_HISR_RX_REQUEST		BIT(0)
++#define REG_SDIO_HISR_AVAL			BIT(1)
++#define REG_SDIO_HISR_TXERR			BIT(2)
++#define REG_SDIO_HISR_RXERR			BIT(3)
++#define REG_SDIO_HISR_TXFOVW			BIT(4)
++#define REG_SDIO_HISR_RXFOVW			BIT(5)
++#define REG_SDIO_HISR_TXBCNOK			BIT(6)
++#define REG_SDIO_HISR_TXBCNERR			BIT(7)
++#define REG_SDIO_HISR_BCNERLY_INT		BIT(16)
++#define REG_SDIO_HISR_C2HCMD			BIT(17)
++#define REG_SDIO_HISR_CPWM1			BIT(18)
++#define REG_SDIO_HISR_CPWM2			BIT(19)
++#define REG_SDIO_HISR_HSISR_IND			BIT(20)
++#define REG_SDIO_HISR_GTINT3_IND		BIT(21)
++#define REG_SDIO_HISR_GTINT4_IND		BIT(22)
++#define REG_SDIO_HISR_PSTIMEOUT			BIT(23)
++#define REG_SDIO_HISR_OCPINT			BIT(24)
++#define REG_SDIO_HISR_ATIMEND			BIT(25)
++#define REG_SDIO_HISR_ATIMEND_E			BIT(26)
++#define REG_SDIO_HISR_CTWEND			BIT(27)
++/* the following two are RTL8188 SDIO Specific */
++#define REG_SDIO_HISR_MCU_ERR			BIT(28)
++#define REG_SDIO_HISR_TSF_BIT32_TOGGLE		BIT(29)
++
++/* HCI Current Power Mode */
++#define REG_SDIO_HCPWM				(SDIO_LOCAL_OFFSET + 0x0019)
++/* RXDMA Request Length */
++#define REG_SDIO_RX0_REQ_LEN			(SDIO_LOCAL_OFFSET + 0x001C)
++/* OQT Free Page */
++#define REG_SDIO_OQT_FREE_PG			(SDIO_LOCAL_OFFSET + 0x001E)
++/* Free Tx Buffer Page */
++#define REG_SDIO_FREE_TXPG			(SDIO_LOCAL_OFFSET + 0x0020)
++/* HCI Current Power Mode 1 */
++#define REG_SDIO_HCPWM1				(SDIO_LOCAL_OFFSET + 0x0024)
++/* HCI Current Power Mode 2 */
++#define REG_SDIO_HCPWM2				(SDIO_LOCAL_OFFSET + 0x0026)
++/* Free Tx Page Sequence */
++#define REG_SDIO_FREE_TXPG_SEQ			(SDIO_LOCAL_OFFSET + 0x0028)
++/* HTSF Information */
++#define REG_SDIO_HTSFR_INFO			(SDIO_LOCAL_OFFSET + 0x0030)
++#define REG_SDIO_HCPWM1_V2			(SDIO_LOCAL_OFFSET + 0x0038)
++/* H2C */
++#define REG_SDIO_H2C				(SDIO_LOCAL_OFFSET + 0x0060)
++/* HCI Request Power Mode 1 */
++#define REG_SDIO_HRPWM1				(SDIO_LOCAL_OFFSET + 0x0080)
++/* HCI Request Power Mode 2 */
++#define REG_SDIO_HRPWM2				(SDIO_LOCAL_OFFSET + 0x0082)
++/* HCI Power Save Clock */
++#define REG_SDIO_HPS_CLKR			(SDIO_LOCAL_OFFSET + 0x0084)
++/* SDIO HCI Suspend Control */
++#define REG_SDIO_HSUS_CTRL			(SDIO_LOCAL_OFFSET + 0x0086)
++#define BIT_HCI_SUS_REQ				BIT(0)
++#define BIT_HCI_RESUME_RDY			BIT(1)
++/* SDIO Host Extension Interrupt Mask Always */
++#define REG_SDIO_HIMR_ON			(SDIO_LOCAL_OFFSET + 0x0090)
++/* SDIO Host Extension Interrupt Status Always */
++#define REG_SDIO_HISR_ON			(SDIO_LOCAL_OFFSET + 0x0091)
++
++#define REG_SDIO_INDIRECT_REG_CFG		(SDIO_LOCAL_OFFSET + 0x0040)
++#define BIT_SDIO_INDIRECT_REG_CFG_WORD		BIT(16)
++#define BIT_SDIO_INDIRECT_REG_CFG_DWORD		BIT(17)
++#define BIT_SDIO_INDIRECT_REG_CFG_WRITE		BIT(18)
++#define BIT_SDIO_INDIRECT_REG_CFG_READ		BIT(19)
++#define BIT_SDIO_INDIRECT_REG_CFG_UNK20		BIT(20)
++#define REG_SDIO_INDIRECT_REG_DATA		(SDIO_LOCAL_OFFSET + 0x0044)
++
++/* Sdio Address for SDIO Local Reg, TRX FIFO, MAC Reg */
++#define REG_SDIO_CMD_ADDR_MSK			GENMASK(16, 13)
++#define REG_SDIO_CMD_ADDR_SDIO_REG		0
++#define REG_SDIO_CMD_ADDR_MAC_REG		8
++#define REG_SDIO_CMD_ADDR_TXFF_HIGH		4
++#define REG_SDIO_CMD_ADDR_TXFF_LOW		6
++#define REG_SDIO_CMD_ADDR_TXFF_NORMAL		5
++#define REG_SDIO_CMD_ADDR_TXFF_EXTRA		7
++#define REG_SDIO_CMD_ADDR_RXFF			7
++
++#define RTW_SDIO_BLOCK_SIZE			512
++#define RTW_SDIO_ADDR_RX_RX0FF_GEN(_id)		(0x0e000 | ((_id) & 0x3))
++
++#define RTW_SDIO_DATA_PTR_ALIGN			8
++
++struct sdio_func;
++struct sdio_device_id;
++
++struct rtw_sdio_tx_data {
++	u8 sn;
++};
++
++struct rtw_sdio_work_data {
++	struct work_struct work;
++	struct rtw_dev *rtwdev;
++};
++
++struct rtw_sdio {
++	struct sdio_func *sdio_func;
++
++	u32 irq_mask;
++	u8 rx_addr;
++	bool sdio3_bus_mode;
++
++	void *irq_thread;
++
++	struct workqueue_struct *txwq;
++	struct rtw_sdio_work_data *tx_handler_data;
++	struct sk_buff_head tx_queue[RTK_MAX_TX_QUEUE_NUM];
++};
++
++extern const struct dev_pm_ops rtw_sdio_pm_ops;
++
++int rtw_sdio_probe(struct sdio_func *sdio_func,
++		   const struct sdio_device_id *id);
++void rtw_sdio_remove(struct sdio_func *sdio_func);
++void rtw_sdio_shutdown(struct device *dev);
++
++static inline bool rtw_sdio_is_sdio30_supported(struct rtw_dev *rtwdev)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++
++	return rtwsdio->sdio3_bus_mode;
++}
++
++#endif
+-- 
+2.39.2
+

--- a/patch/misc/rtw88/6.3/001-drivers-net-wireless-realtek-rtw88-upstream-wireless.patch
+++ b/patch/misc/rtw88/6.3/001-drivers-net-wireless-realtek-rtw88-upstream-wireless.patch
@@ -1,0 +1,3832 @@
+From fb6b66c22c1104925d6fdba796e7f35b610c3222 Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@xxxxx.com>
+Date: Sat, 22 Jul 2023 04:27:05 -0400
+Subject: [PATCH] drivers: net: wireless: realtek: rtw88: upstream wireless
+
+linux-next backport: linux-6.3.y
+
+Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
+---
+ drivers/net/wireless/realtek/rtw88/Kconfig    |  47 +++++
+ drivers/net/wireless/realtek/rtw88/Makefile   |  15 ++
+ drivers/net/wireless/realtek/rtw88/debug.c    |  59 ++++--
+ drivers/net/wireless/realtek/rtw88/debug.h    |   1 +
+ drivers/net/wireless/realtek/rtw88/fw.c       |  88 ++++++++-
+ drivers/net/wireless/realtek/rtw88/fw.h       |  15 +-
+ drivers/net/wireless/realtek/rtw88/mac.c      |  70 ++++++--
+ drivers/net/wireless/realtek/rtw88/mac.h      |   1 -
+ drivers/net/wireless/realtek/rtw88/mac80211.c |  51 +++++-
+ drivers/net/wireless/realtek/rtw88/main.c     | 168 +++++++++++++++++-
+ drivers/net/wireless/realtek/rtw88/main.h     |  24 ++-
+ drivers/net/wireless/realtek/rtw88/pci.c      |  13 +-
+ drivers/net/wireless/realtek/rtw88/ps.c       |   3 +-
+ drivers/net/wireless/realtek/rtw88/reg.h      |  14 ++
+ drivers/net/wireless/realtek/rtw88/rtw8723d.c |  16 +-
+ drivers/net/wireless/realtek/rtw88/rtw8723d.h |   6 +
+ drivers/net/wireless/realtek/rtw88/rtw8821c.c |  32 +++-
+ drivers/net/wireless/realtek/rtw88/rtw8821c.h |   6 +
+ drivers/net/wireless/realtek/rtw88/rtw8822b.c |  10 ++
+ drivers/net/wireless/realtek/rtw88/rtw8822b.h |   8 +-
+ drivers/net/wireless/realtek/rtw88/rtw8822c.c |  10 ++
+ drivers/net/wireless/realtek/rtw88/rtw8822c.h |   8 +-
+ drivers/net/wireless/realtek/rtw88/tx.c       |  94 ++++++----
+ drivers/net/wireless/realtek/rtw88/tx.h       | 124 ++++++-------
+ drivers/net/wireless/realtek/rtw88/usb.c      |  15 +-
+ include/linux/mmc/sdio_ids.h                  |  10 ++
+ 26 files changed, 731 insertions(+), 177 deletions(-)
+
+diff --git a/drivers/net/wireless/realtek/rtw88/Kconfig b/drivers/net/wireless/realtek/rtw88/Kconfig
+index 651ab56d9c6b..cffad1c01249 100644
+--- a/drivers/net/wireless/realtek/rtw88/Kconfig
++++ b/drivers/net/wireless/realtek/rtw88/Kconfig
+@@ -16,6 +16,9 @@ config RTW88_CORE
+ config RTW88_PCI
+ 	tristate
+ 
++config RTW88_SDIO
++	tristate
++
+ config RTW88_USB
+ 	tristate
+ 
+@@ -42,6 +45,17 @@ config RTW88_8822BE
+ 
+ 	  802.11ac PCIe wireless network adapter
+ 
++config RTW88_8822BS
++	tristate "Realtek 8822BS SDIO wireless network adapter"
++	depends on MMC
++	select RTW88_CORE
++	select RTW88_SDIO
++	select RTW88_8822B
++	help
++	  Select this option will enable support for 8822BS chipset
++
++	  802.11ac SDIO wireless network adapter
++
+ config RTW88_8822BU
+ 	tristate "Realtek 8822BU USB wireless network adapter"
+ 	depends on USB
+@@ -64,6 +78,17 @@ config RTW88_8822CE
+ 
+ 	  802.11ac PCIe wireless network adapter
+ 
++config RTW88_8822CS
++	tristate "Realtek 8822CS SDIO wireless network adapter"
++	depends on MMC
++	select RTW88_CORE
++	select RTW88_SDIO
++	select RTW88_8822C
++	help
++	  Select this option will enable support for 8822CS chipset
++
++	  802.11ac SDIO wireless network adapter
++
+ config RTW88_8822CU
+ 	tristate "Realtek 8822CU USB wireless network adapter"
+ 	depends on USB
+@@ -86,6 +111,17 @@ config RTW88_8723DE
+ 
+ 	  802.11n PCIe wireless network adapter
+ 
++config RTW88_8723DS
++	tristate "Realtek 8723DS SDIO wireless network adapter"
++	depends on MMC
++	select RTW88_CORE
++	select RTW88_SDIO
++	select RTW88_8723D
++	help
++	  Select this option will enable support for 8723DS chipset
++
++	  802.11n SDIO wireless network adapter
++
+ config RTW88_8723DU
+ 	tristate "Realtek 8723DU USB wireless network adapter"
+ 	depends on USB
+@@ -108,6 +144,17 @@ config RTW88_8821CE
+ 
+ 	  802.11ac PCIe wireless network adapter
+ 
++config RTW88_8821CS
++	tristate "Realtek 8821CS SDIO wireless network adapter"
++	depends on MMC
++	select RTW88_CORE
++	select RTW88_SDIO
++	select RTW88_8821C
++	help
++	  Select this option will enable support for 8821CS chipset
++
++	  802.11ac SDIO wireless network adapter
++
+ config RTW88_8821CU
+ 	tristate "Realtek 8821CU USB wireless network adapter"
+ 	depends on USB
+diff --git a/drivers/net/wireless/realtek/rtw88/Makefile b/drivers/net/wireless/realtek/rtw88/Makefile
+index fe7293ee87b4..fd212c09d88a 100644
+--- a/drivers/net/wireless/realtek/rtw88/Makefile
++++ b/drivers/net/wireless/realtek/rtw88/Makefile
+@@ -26,6 +26,9 @@ rtw88_8822b-objs		:= rtw8822b.o rtw8822b_table.o
+ obj-$(CONFIG_RTW88_8822BE)	+= rtw88_8822be.o
+ rtw88_8822be-objs		:= rtw8822be.o
+ 
++obj-$(CONFIG_RTW88_8822BS)	+= rtw88_8822bs.o
++rtw88_8822bs-objs		:= rtw8822bs.o
++
+ obj-$(CONFIG_RTW88_8822BU)	+= rtw88_8822bu.o
+ rtw88_8822bu-objs		:= rtw8822bu.o
+ 
+@@ -35,6 +38,9 @@ rtw88_8822c-objs		:= rtw8822c.o rtw8822c_table.o
+ obj-$(CONFIG_RTW88_8822CE)	+= rtw88_8822ce.o
+ rtw88_8822ce-objs		:= rtw8822ce.o
+ 
++obj-$(CONFIG_RTW88_8822CS)	+= rtw88_8822cs.o
++rtw88_8822cs-objs		:= rtw8822cs.o
++
+ obj-$(CONFIG_RTW88_8822CU)	+= rtw88_8822cu.o
+ rtw88_8822cu-objs		:= rtw8822cu.o
+ 
+@@ -44,6 +50,9 @@ rtw88_8723d-objs		:= rtw8723d.o rtw8723d_table.o
+ obj-$(CONFIG_RTW88_8723DE)	+= rtw88_8723de.o
+ rtw88_8723de-objs		:= rtw8723de.o
+ 
++obj-$(CONFIG_RTW88_8723DS)	+= rtw88_8723ds.o
++rtw88_8723ds-objs		:= rtw8723ds.o
++
+ obj-$(CONFIG_RTW88_8723DU)	+= rtw88_8723du.o
+ rtw88_8723du-objs		:= rtw8723du.o
+ 
+@@ -53,11 +62,17 @@ rtw88_8821c-objs		:= rtw8821c.o rtw8821c_table.o
+ obj-$(CONFIG_RTW88_8821CE)	+= rtw88_8821ce.o
+ rtw88_8821ce-objs		:= rtw8821ce.o
+ 
++obj-$(CONFIG_RTW88_8821CS)	+= rtw88_8821cs.o
++rtw88_8821cs-objs		:= rtw8821cs.o
++
+ obj-$(CONFIG_RTW88_8821CU)	+= rtw88_8821cu.o
+ rtw88_8821cu-objs		:= rtw8821cu.o
+ 
+ obj-$(CONFIG_RTW88_PCI)		+= rtw88_pci.o
+ rtw88_pci-objs			:= pci.o
+ 
++obj-$(CONFIG_RTW88_SDIO)	+= rtw88_sdio.o
++rtw88_sdio-objs			:= sdio.o
++
+ obj-$(CONFIG_RTW88_USB)		+= rtw88_usb.o
+ rtw88_usb-objs			:= usb.o
+diff --git a/drivers/net/wireless/realtek/rtw88/debug.c b/drivers/net/wireless/realtek/rtw88/debug.c
+index fa3d73b333ba..f8ba133baff0 100644
+--- a/drivers/net/wireless/realtek/rtw88/debug.c
++++ b/drivers/net/wireless/realtek/rtw88/debug.c
+@@ -183,8 +183,8 @@ static int rtw_debugfs_copy_from_user(char tmp[], int size,
+ 
+ 	tmp_len = (count > size - 1 ? size - 1 : count);
+ 
+-	if (!buffer || copy_from_user(tmp, buffer, tmp_len))
+-		return count;
++	if (copy_from_user(tmp, buffer, tmp_len))
++		return -EFAULT;
+ 
+ 	tmp[tmp_len] = '\0';
+ 
+@@ -201,13 +201,16 @@ static ssize_t rtw_debugfs_set_read_reg(struct file *filp,
+ 	char tmp[32 + 1];
+ 	u32 addr, len;
+ 	int num;
++	int ret;
+ 
+-	rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 2);
++	ret = rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 2);
++	if (ret)
++		return ret;
+ 
+ 	num = sscanf(tmp, "%x %x", &addr, &len);
+ 
+ 	if (num !=  2)
+-		return count;
++		return -EINVAL;
+ 
+ 	if (len != 1 && len != 2 && len != 4) {
+ 		rtw_warn(rtwdev, "read reg setting wrong len\n");
+@@ -288,8 +291,11 @@ static ssize_t rtw_debugfs_set_rsvd_page(struct file *filp,
+ 	char tmp[32 + 1];
+ 	u32 offset, page_num;
+ 	int num;
++	int ret;
+ 
+-	rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 2);
++	ret = rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 2);
++	if (ret)
++		return ret;
+ 
+ 	num = sscanf(tmp, "%d %d", &offset, &page_num);
+ 
+@@ -314,8 +320,11 @@ static ssize_t rtw_debugfs_set_single_input(struct file *filp,
+ 	char tmp[32 + 1];
+ 	u32 input;
+ 	int num;
++	int ret;
+ 
+-	rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 1);
++	ret = rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 1);
++	if (ret)
++		return ret;
+ 
+ 	num = kstrtoint(tmp, 0, &input);
+ 
+@@ -338,14 +347,17 @@ static ssize_t rtw_debugfs_set_write_reg(struct file *filp,
+ 	char tmp[32 + 1];
+ 	u32 addr, val, len;
+ 	int num;
++	int ret;
+ 
+-	rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 3);
++	ret = rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 3);
++	if (ret)
++		return ret;
+ 
+ 	/* write BB/MAC register */
+ 	num = sscanf(tmp, "%x %x %x", &addr, &val, &len);
+ 
+ 	if (num !=  3)
+-		return count;
++		return -EINVAL;
+ 
+ 	switch (len) {
+ 	case 1:
+@@ -381,8 +393,11 @@ static ssize_t rtw_debugfs_set_h2c(struct file *filp,
+ 	char tmp[32 + 1];
+ 	u8 param[8];
+ 	int num;
++	int ret;
+ 
+-	rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 3);
++	ret = rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 3);
++	if (ret)
++		return ret;
+ 
+ 	num = sscanf(tmp, "%hhx,%hhx,%hhx,%hhx,%hhx,%hhx,%hhx,%hhx",
+ 		     &param[0], &param[1], &param[2], &param[3],
+@@ -408,14 +423,17 @@ static ssize_t rtw_debugfs_set_rf_write(struct file *filp,
+ 	char tmp[32 + 1];
+ 	u32 path, addr, mask, val;
+ 	int num;
++	int ret;
+ 
+-	rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 4);
++	ret = rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 4);
++	if (ret)
++		return ret;
+ 
+ 	num = sscanf(tmp, "%x %x %x %x", &path, &addr, &mask, &val);
+ 
+ 	if (num !=  4) {
+ 		rtw_warn(rtwdev, "invalid args, [path] [addr] [mask] [val]\n");
+-		return count;
++		return -EINVAL;
+ 	}
+ 
+ 	mutex_lock(&rtwdev->mutex);
+@@ -438,14 +456,17 @@ static ssize_t rtw_debugfs_set_rf_read(struct file *filp,
+ 	char tmp[32 + 1];
+ 	u32 path, addr, mask;
+ 	int num;
++	int ret;
+ 
+-	rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 3);
++	ret = rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 3);
++	if (ret)
++		return ret;
+ 
+ 	num = sscanf(tmp, "%x %x %x", &path, &addr, &mask);
+ 
+ 	if (num !=  3) {
+ 		rtw_warn(rtwdev, "invalid args, [path] [addr] [mask] [val]\n");
+-		return count;
++		return -EINVAL;
+ 	}
+ 
+ 	debugfs_priv->rf_path = path;
+@@ -467,7 +488,9 @@ static ssize_t rtw_debugfs_set_fix_rate(struct file *filp,
+ 	char tmp[32 + 1];
+ 	int ret;
+ 
+-	rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 1);
++	ret = rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 1);
++	if (ret)
++		return ret;
+ 
+ 	ret = kstrtou8(tmp, 0, &fix_rate);
+ 	if (ret) {
+@@ -860,7 +883,9 @@ static ssize_t rtw_debugfs_set_coex_enable(struct file *filp,
+ 	bool enable;
+ 	int ret;
+ 
+-	rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 1);
++	ret = rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 1);
++	if (ret)
++		return ret;
+ 
+ 	ret = kstrtobool(tmp, &enable);
+ 	if (ret) {
+@@ -930,7 +955,9 @@ static ssize_t rtw_debugfs_set_fw_crash(struct file *filp,
+ 	bool input;
+ 	int ret;
+ 
+-	rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 1);
++	ret = rtw_debugfs_copy_from_user(tmp, sizeof(tmp), buffer, count, 1);
++	if (ret)
++		return ret;
+ 
+ 	ret = kstrtobool(tmp, &input);
+ 	if (ret)
+diff --git a/drivers/net/wireless/realtek/rtw88/debug.h b/drivers/net/wireless/realtek/rtw88/debug.h
+index 066792dd96af..a9149c6c2b48 100644
+--- a/drivers/net/wireless/realtek/rtw88/debug.h
++++ b/drivers/net/wireless/realtek/rtw88/debug.h
+@@ -24,6 +24,7 @@ enum rtw_debug_mask {
+ 	RTW_DBG_ADAPTIVITY	= 0x00008000,
+ 	RTW_DBG_HW_SCAN		= 0x00010000,
+ 	RTW_DBG_STATE		= 0x00020000,
++	RTW_DBG_SDIO		= 0x00040000,
+ 
+ 	RTW_DBG_ALL		= 0xffffffff
+ };
+diff --git a/drivers/net/wireless/realtek/rtw88/fw.c b/drivers/net/wireless/realtek/rtw88/fw.c
+index 82295ac6402e..567bbedd8ee0 100644
+--- a/drivers/net/wireless/realtek/rtw88/fw.c
++++ b/drivers/net/wireless/realtek/rtw88/fw.c
+@@ -308,6 +308,57 @@ void rtw_fw_c2h_cmd_isr(struct rtw_dev *rtwdev)
+ }
+ EXPORT_SYMBOL(rtw_fw_c2h_cmd_isr);
+ 
++static void rtw_fw_send_h2c_command_register(struct rtw_dev *rtwdev,
++					     struct rtw_h2c_register *h2c)
++{
++	u32 box_reg, box_ex_reg;
++	u8 box_state, box;
++	int ret;
++
++	rtw_dbg(rtwdev, RTW_DBG_FW, "send H2C content %08x %08x\n", h2c->w0,
++		h2c->w1);
++
++	lockdep_assert_held(&rtwdev->mutex);
++
++	box = rtwdev->h2c.last_box_num;
++	switch (box) {
++	case 0:
++		box_reg = REG_HMEBOX0;
++		box_ex_reg = REG_HMEBOX0_EX;
++		break;
++	case 1:
++		box_reg = REG_HMEBOX1;
++		box_ex_reg = REG_HMEBOX1_EX;
++		break;
++	case 2:
++		box_reg = REG_HMEBOX2;
++		box_ex_reg = REG_HMEBOX2_EX;
++		break;
++	case 3:
++		box_reg = REG_HMEBOX3;
++		box_ex_reg = REG_HMEBOX3_EX;
++		break;
++	default:
++		WARN(1, "invalid h2c mail box number\n");
++		return;
++	}
++
++	ret = read_poll_timeout_atomic(rtw_read8, box_state,
++				       !((box_state >> box) & 0x1), 100, 3000,
++				       false, rtwdev, REG_HMETFR);
++
++	if (ret) {
++		rtw_err(rtwdev, "failed to send h2c command\n");
++		return;
++	}
++
++	rtw_write32(rtwdev, box_ex_reg, h2c->w1);
++	rtw_write32(rtwdev, box_reg, h2c->w0);
++
++	if (++rtwdev->h2c.last_box_num >= 4)
++		rtwdev->h2c.last_box_num = 0;
++}
++
+ static void rtw_fw_send_h2c_command(struct rtw_dev *rtwdev,
+ 				    u8 *h2c)
+ {
+@@ -468,6 +519,23 @@ void rtw_fw_query_bt_info(struct rtw_dev *rtwdev)
+ 	rtw_fw_send_h2c_command(rtwdev, h2c_pkt);
+ }
+ 
++void rtw_fw_default_port(struct rtw_dev *rtwdev, struct rtw_vif *rtwvif)
++{
++	struct rtw_h2c_register h2c = {};
++
++	if (rtwvif->net_type != RTW_NET_MGD_LINKED)
++		return;
++
++	/* Leave LPS before default port H2C so FW timer is correct */
++	rtw_leave_lps(rtwdev);
++
++	h2c.w0 = u32_encode_bits(H2C_CMD_DEFAULT_PORT, RTW_H2C_W0_CMDID) |
++		 u32_encode_bits(rtwvif->port, RTW_H2C_DEFAULT_PORT_W0_PORTID) |
++		 u32_encode_bits(rtwvif->mac_id, RTW_H2C_DEFAULT_PORT_W0_MACID);
++
++	rtw_fw_send_h2c_command_register(rtwdev, &h2c);
++}
++
+ void rtw_fw_wl_ch_info(struct rtw_dev *rtwdev, u8 link, u8 ch, u8 bw)
+ {
+ 	u8 h2c_pkt[H2C_PKT_SIZE] = {0};
+@@ -1393,6 +1461,10 @@ static void rtw_build_rsvd_page_iter(void *data, u8 *mac,
+ 	struct rtw_vif *rtwvif = (struct rtw_vif *)vif->drv_priv;
+ 	struct rtw_rsvd_page *rsvd_pkt;
+ 
++	/* AP not yet started, don't gather its rsvd pages */
++	if (vif->type == NL80211_IFTYPE_AP && !rtwdev->ap_active)
++		return;
++
+ 	list_for_each_entry(rsvd_pkt, &rtwvif->rsvd_page_list, vif_list) {
+ 		if (rsvd_pkt->type == RSVD_BEACON)
+ 			list_add(&rsvd_pkt->build_list,
+@@ -1614,6 +1686,7 @@ void rtw_fw_update_beacon_work(struct work_struct *work)
+ 
+ 	mutex_lock(&rtwdev->mutex);
+ 	rtw_fw_download_rsvd_page(rtwdev);
++	rtw_send_rsvd_page_h2c(rtwdev);
+ 	mutex_unlock(&rtwdev->mutex);
+ }
+ 
+@@ -2155,11 +2228,19 @@ int rtw_hw_scan_offload(struct rtw_dev *rtwdev, struct ieee80211_vif *vif,
+ 	}
+ 	rtw_fw_set_scan_offload(rtwdev, &cs_option, rtwvif, &chan_list);
+ out:
++	if (rtwdev->ap_active) {
++		ret = rtw_download_beacon(rtwdev);
++		if (ret)
++			rtw_err(rtwdev, "HW scan download beacon failed\n");
++	}
++
+ 	return ret;
+ }
+ 
+-void rtw_hw_scan_abort(struct rtw_dev *rtwdev, struct ieee80211_vif *vif)
++void rtw_hw_scan_abort(struct rtw_dev *rtwdev)
+ {
++	struct ieee80211_vif *vif = rtwdev->scan_info.scanning_vif;
++
+ 	if (!rtw_fw_feature_check(&rtwdev->fw, FW_FEATURE_SCAN_OFFLOAD))
+ 		return;
+ 
+@@ -2244,6 +2325,7 @@ void rtw_hw_scan_chan_switch(struct rtw_dev *rtwdev, struct sk_buff *skb)
+ 		if (rtw_is_op_chan(rtwdev, chan)) {
+ 			rtw_store_op_chan(rtwdev, false);
+ 			ieee80211_wake_queues(rtwdev->hw);
++			rtw_core_enable_beacon(rtwdev, true);
+ 		}
+ 	} else if (id == RTW_SCAN_NOTIFY_ID_PRESWITCH) {
+ 		if (IS_CH_5G_BAND(chan)) {
+@@ -2262,8 +2344,10 @@ void rtw_hw_scan_chan_switch(struct rtw_dev *rtwdev, struct sk_buff *skb)
+ 		 * if next channel is non-op channel.
+ 		 */
+ 		if (!rtw_is_op_chan(rtwdev, chan) &&
+-		    rtw_is_op_chan(rtwdev, hal->current_channel))
++		    rtw_is_op_chan(rtwdev, hal->current_channel)) {
++			rtw_core_enable_beacon(rtwdev, false);
+ 			ieee80211_stop_queues(rtwdev->hw);
++		}
+ 	}
+ 
+ 	rtw_dbg(rtwdev, RTW_DBG_HW_SCAN,
+diff --git a/drivers/net/wireless/realtek/rtw88/fw.h b/drivers/net/wireless/realtek/rtw88/fw.h
+index 0a386e6d6e0d..43ccdf9965ac 100644
+--- a/drivers/net/wireless/realtek/rtw88/fw.h
++++ b/drivers/net/wireless/realtek/rtw88/fw.h
+@@ -81,6 +81,17 @@ struct rtw_c2h_adaptivity {
+ 	u8 option;
+ } __packed;
+ 
++struct rtw_h2c_register {
++	u32 w0;
++	u32 w1;
++} __packed;
++
++#define RTW_H2C_W0_CMDID		GENMASK(7, 0)
++
++/* H2C_CMD_DEFAULT_PORT command */
++#define RTW_H2C_DEFAULT_PORT_W0_PORTID	GENMASK(15, 8)
++#define RTW_H2C_DEFAULT_PORT_W0_MACID	GENMASK(23, 16)
++
+ struct rtw_h2c_cmd {
+ 	__le32 msg;
+ 	__le32 msg_ext;
+@@ -530,6 +541,7 @@ static inline void rtw_h2c_pkt_set_header(u8 *h2c_pkt, u8 sub_id)
+ #define H2C_CMD_MEDIA_STATUS_RPT	0x01
+ #define H2C_CMD_SET_PWR_MODE		0x20
+ #define H2C_CMD_LPS_PG_INFO		0x2b
++#define H2C_CMD_DEFAULT_PORT		0x2c
+ #define H2C_CMD_RA_INFO			0x40
+ #define H2C_CMD_RSSI_MONITOR		0x42
+ #define H2C_CMD_BCN_FILTER_OFFLOAD_P0	0x56
+@@ -801,6 +813,7 @@ void rtw_fw_c2h_cmd_rx_irqsafe(struct rtw_dev *rtwdev, u32 pkt_offset,
+ void rtw_fw_c2h_cmd_handle(struct rtw_dev *rtwdev, struct sk_buff *skb);
+ void rtw_fw_send_general_info(struct rtw_dev *rtwdev);
+ void rtw_fw_send_phydm_info(struct rtw_dev *rtwdev);
++void rtw_fw_default_port(struct rtw_dev *rtwdev, struct rtw_vif *rtwvif);
+ 
+ void rtw_fw_do_iqk(struct rtw_dev *rtwdev, struct rtw_iqk_para *para);
+ void rtw_fw_inform_rfk_status(struct rtw_dev *rtwdev, bool start);
+@@ -868,5 +881,5 @@ int rtw_hw_scan_offload(struct rtw_dev *rtwdev, struct ieee80211_vif *vif,
+ 			bool enable);
+ void rtw_hw_scan_status_report(struct rtw_dev *rtwdev, struct sk_buff *skb);
+ void rtw_hw_scan_chan_switch(struct rtw_dev *rtwdev, struct sk_buff *skb);
+-void rtw_hw_scan_abort(struct rtw_dev *rtwdev, struct ieee80211_vif *vif);
++void rtw_hw_scan_abort(struct rtw_dev *rtwdev);
+ #endif
+diff --git a/drivers/net/wireless/realtek/rtw88/mac.c b/drivers/net/wireless/realtek/rtw88/mac.c
+index eda05a5d9cff..298663b03580 100644
+--- a/drivers/net/wireless/realtek/rtw88/mac.c
++++ b/drivers/net/wireless/realtek/rtw88/mac.c
+@@ -7,6 +7,7 @@
+ #include "reg.h"
+ #include "fw.h"
+ #include "debug.h"
++#include "sdio.h"
+ 
+ void rtw_set_channel_mac(struct rtw_dev *rtwdev, u8 channel, u8 bw,
+ 			 u8 primary_ch_idx)
+@@ -60,6 +61,7 @@ EXPORT_SYMBOL(rtw_set_channel_mac);
+ 
+ static int rtw_mac_pre_system_cfg(struct rtw_dev *rtwdev)
+ {
++	unsigned int retry;
+ 	u32 value32;
+ 	u8 value8;
+ 
+@@ -77,6 +79,28 @@ static int rtw_mac_pre_system_cfg(struct rtw_dev *rtwdev)
+ 	case RTW_HCI_TYPE_PCIE:
+ 		rtw_write32_set(rtwdev, REG_HCI_OPT_CTRL, BIT_USB_SUS_DIS);
+ 		break;
++	case RTW_HCI_TYPE_SDIO:
++		rtw_write8_clr(rtwdev, REG_SDIO_HSUS_CTRL, BIT_HCI_SUS_REQ);
++
++		for (retry = 0; retry < RTW_PWR_POLLING_CNT; retry++) {
++			if (rtw_read8(rtwdev, REG_SDIO_HSUS_CTRL) & BIT_HCI_RESUME_RDY)
++				break;
++
++			usleep_range(10, 50);
++		}
++
++		if (retry == RTW_PWR_POLLING_CNT) {
++			rtw_err(rtwdev, "failed to poll REG_SDIO_HSUS_CTRL[1]");
++			return -ETIMEDOUT;
++		}
++
++		if (rtw_sdio_is_sdio30_supported(rtwdev))
++			rtw_write8_set(rtwdev, REG_HCI_OPT_CTRL + 2,
++				       BIT_SDIO_PAD_E5 >> 16);
++		else
++			rtw_write8_clr(rtwdev, REG_HCI_OPT_CTRL + 2,
++				       BIT_SDIO_PAD_E5 >> 16);
++		break;
+ 	case RTW_HCI_TYPE_USB:
+ 		break;
+ 	default:
+@@ -222,6 +246,9 @@ static int rtw_pwr_seq_parser(struct rtw_dev *rtwdev,
+ 	case RTW_HCI_TYPE_USB:
+ 		intf_mask = RTW_PWR_INTF_USB_MSK;
+ 		break;
++	case RTW_HCI_TYPE_SDIO:
++		intf_mask = RTW_PWR_INTF_SDIO_MSK;
++		break;
+ 	default:
+ 		return -EINVAL;
+ 	}
+@@ -245,6 +272,7 @@ static int rtw_mac_power_switch(struct rtw_dev *rtwdev, bool pwr_on)
+ {
+ 	const struct rtw_chip_info *chip = rtwdev->chip;
+ 	const struct rtw_pwr_seq_cmd **pwr_seq;
++	u32 imr = 0;
+ 	u8 rpwm;
+ 	bool cur_pwr;
+ 	int ret;
+@@ -270,17 +298,24 @@ static int rtw_mac_power_switch(struct rtw_dev *rtwdev, bool pwr_on)
+ 	if (pwr_on == cur_pwr)
+ 		return -EALREADY;
+ 
++	if (rtw_hci_type(rtwdev) == RTW_HCI_TYPE_SDIO) {
++		imr = rtw_read32(rtwdev, REG_SDIO_HIMR);
++		rtw_write32(rtwdev, REG_SDIO_HIMR, 0);
++	}
++
++	if (!pwr_on)
++		clear_bit(RTW_FLAG_POWERON, rtwdev->flags);
++
+ 	pwr_seq = pwr_on ? chip->pwr_on_seq : chip->pwr_off_seq;
+ 	ret = rtw_pwr_seq_parser(rtwdev, pwr_seq);
+-	if (ret)
+-		return ret;
+ 
+-	if (pwr_on)
++	if (rtw_hci_type(rtwdev) == RTW_HCI_TYPE_SDIO)
++		rtw_write32(rtwdev, REG_SDIO_HIMR, imr);
++
++	if (!ret && pwr_on)
+ 		set_bit(RTW_FLAG_POWERON, rtwdev->flags);
+-	else
+-		clear_bit(RTW_FLAG_POWERON, rtwdev->flags);
+ 
+-	return 0;
++	return ret;
+ }
+ 
+ static int __rtw_mac_init_system_cfg(struct rtw_dev *rtwdev)
+@@ -451,6 +486,9 @@ static void download_firmware_reg_backup(struct rtw_dev *rtwdev,
+ 	rtw_write16(rtwdev, REG_FIFOPAGE_INFO_1, 0x200);
+ 	rtw_write32(rtwdev, REG_RQPN_CTRL_2, bckp[bckp_idx - 1].val);
+ 
++	if (rtw_hci_type(rtwdev) == RTW_HCI_TYPE_SDIO)
++		rtw_read32(rtwdev, REG_SDIO_FREE_TXPG);
++
+ 	/* Disable beacon related functions */
+ 	tmp = rtw_read8(rtwdev, REG_BCN_CTRL);
+ 	bckp[bckp_idx].len = 1;
+@@ -756,8 +794,10 @@ static int __rtw_download_firmware(struct rtw_dev *rtwdev,
+ 
+ 	wlan_cpu_enable(rtwdev, true);
+ 
+-	if (!ltecoex_reg_write(rtwdev, 0x38, ltecoex_bckp))
+-		return -EBUSY;
++	if (!ltecoex_reg_write(rtwdev, 0x38, ltecoex_bckp)) {
++		ret = -EBUSY;
++		goto dlfw_fail;
++	}
+ 
+ 	ret = download_firmware_validate(rtwdev);
+ 	if (ret)
+@@ -1042,6 +1082,9 @@ static int txdma_queue_mapping(struct rtw_dev *rtwdev)
+ 		else
+ 			return -EINVAL;
+ 		break;
++	case RTW_HCI_TYPE_SDIO:
++		rqpn = &chip->rqpn_table[0];
++		break;
+ 	default:
+ 		return -EINVAL;
+ 	}
+@@ -1060,8 +1103,12 @@ static int txdma_queue_mapping(struct rtw_dev *rtwdev)
+ 	if (rtw_chip_wcpu_11ac(rtwdev))
+ 		rtw_write32(rtwdev, REG_H2CQ_CSR, BIT_H2CQ_FULL);
+ 
+-	if (rtw_hci_type(rtwdev) == RTW_HCI_TYPE_USB)
++	if (rtw_hci_type(rtwdev) == RTW_HCI_TYPE_SDIO) {
++		rtw_read32(rtwdev, REG_SDIO_FREE_TXPG);
++		rtw_write32(rtwdev, REG_SDIO_TX_CTRL, 0);
++	} else if (rtw_hci_type(rtwdev) == RTW_HCI_TYPE_USB) {
+ 		rtw_write8_set(rtwdev, REG_TXDMA_PQ_MAP, BIT_RXDMA_ARBBW_EN);
++	}
+ 
+ 	return 0;
+ }
+@@ -1074,7 +1121,7 @@ static int set_trx_fifo_info(struct rtw_dev *rtwdev)
+ 	u8 csi_buf_pg_num = chip->csi_buf_pg_num;
+ 
+ 	/* config rsvd page num */
+-	fifo->rsvd_drv_pg_num = 8;
++	fifo->rsvd_drv_pg_num = chip->rsvd_drv_pg_num;
+ 	fifo->txff_pg_num = chip->txff_size >> 7;
+ 	if (rtw_chip_wcpu_11n(rtwdev))
+ 		fifo->rsvd_pg_num = fifo->rsvd_drv_pg_num;
+@@ -1204,6 +1251,9 @@ static int priority_queue_cfg(struct rtw_dev *rtwdev)
+ 		else
+ 			return -EINVAL;
+ 		break;
++	case RTW_HCI_TYPE_SDIO:
++		pg_tbl = &chip->page_table[0];
++		break;
+ 	default:
+ 		return -EINVAL;
+ 	}
+diff --git a/drivers/net/wireless/realtek/rtw88/mac.h b/drivers/net/wireless/realtek/rtw88/mac.h
+index 3172aa5ac4de..58c3dccc14bb 100644
+--- a/drivers/net/wireless/realtek/rtw88/mac.h
++++ b/drivers/net/wireless/realtek/rtw88/mac.h
+@@ -7,7 +7,6 @@
+ 
+ #define RTW_HW_PORT_NUM		5
+ #define cut_version_to_mask(cut) (0x1 << ((cut) + 1))
+-#define SDIO_LOCAL_OFFSET	0x10250000
+ #define DDMA_POLLING_COUNT	1000
+ #define C2H_PKT_BUF		256
+ #define REPORT_BUF		128
+diff --git a/drivers/net/wireless/realtek/rtw88/mac80211.c b/drivers/net/wireless/realtek/rtw88/mac80211.c
+index 0bf6882d18f1..a99b53d44267 100644
+--- a/drivers/net/wireless/realtek/rtw88/mac80211.c
++++ b/drivers/net/wireless/realtek/rtw88/mac80211.c
+@@ -43,7 +43,11 @@ static void rtw_ops_wake_tx_queue(struct ieee80211_hw *hw,
+ 		list_add_tail(&rtwtxq->list, &rtwdev->txqs);
+ 	spin_unlock_bh(&rtwdev->txq_lock);
+ 
+-	queue_work(rtwdev->tx_wq, &rtwdev->tx_work);
++	/* ensure to dequeue EAPOL (4/4) at the right time */
++	if (txq->ac == IEEE80211_AC_VO)
++		__rtw_tx_work(rtwdev);
++	else
++		queue_work(rtwdev->tx_wq, &rtwdev->tx_work);
+ }
+ 
+ static int rtw_ops_start(struct ieee80211_hw *hw)
+@@ -146,25 +150,32 @@ static int rtw_ops_add_interface(struct ieee80211_hw *hw,
+ 	struct rtw_vif *rtwvif = (struct rtw_vif *)vif->drv_priv;
+ 	enum rtw_net_type net_type;
+ 	u32 config = 0;
+-	u8 port = 0;
++	u8 port;
+ 	u8 bcn_ctrl = 0;
+ 
+ 	if (rtw_fw_feature_check(&rtwdev->fw, FW_FEATURE_BCN_FILTER))
+ 		vif->driver_flags |= IEEE80211_VIF_BEACON_FILTER |
+ 				     IEEE80211_VIF_SUPPORTS_CQM_RSSI;
+-	rtwvif->port = port;
+ 	rtwvif->stats.tx_unicast = 0;
+ 	rtwvif->stats.rx_unicast = 0;
+ 	rtwvif->stats.tx_cnt = 0;
+ 	rtwvif->stats.rx_cnt = 0;
+ 	rtwvif->scan_req = NULL;
+ 	memset(&rtwvif->bfee, 0, sizeof(struct rtw_bfee));
+-	rtwvif->conf = &rtw_vif_port[port];
+ 	rtw_txq_init(rtwdev, vif->txq);
+ 	INIT_LIST_HEAD(&rtwvif->rsvd_page_list);
+ 
+ 	mutex_lock(&rtwdev->mutex);
+ 
++	port = find_first_zero_bit(rtwdev->hw_port, RTW_PORT_NUM);
++	if (port >= RTW_PORT_NUM) {
++		mutex_unlock(&rtwdev->mutex);
++		return -EINVAL;
++	}
++	set_bit(port, rtwdev->hw_port);
++
++	rtwvif->port = port;
++	rtwvif->conf = &rtw_vif_port[port];
+ 	rtw_leave_lps_deep(rtwdev);
+ 
+ 	switch (vif->type) {
+@@ -186,6 +197,7 @@ static int rtw_ops_add_interface(struct ieee80211_hw *hw,
+ 		break;
+ 	default:
+ 		WARN_ON(1);
++		clear_bit(rtwvif->port, rtwdev->hw_port);
+ 		mutex_unlock(&rtwdev->mutex);
+ 		return -EINVAL;
+ 	}
+@@ -197,6 +209,7 @@ static int rtw_ops_add_interface(struct ieee80211_hw *hw,
+ 	rtwvif->bcn_ctrl = bcn_ctrl;
+ 	config |= PORT_SET_BCN_CTRL;
+ 	rtw_vif_port_config(rtwdev, rtwvif, config);
++	rtw_core_port_switch(rtwdev, vif);
+ 	rtw_recalc_lps(rtwdev, vif);
+ 
+ 	mutex_unlock(&rtwdev->mutex);
+@@ -228,6 +241,7 @@ static void rtw_ops_remove_interface(struct ieee80211_hw *hw,
+ 	rtwvif->bcn_ctrl = 0;
+ 	config |= PORT_SET_BCN_CTRL;
+ 	rtw_vif_port_config(rtwdev, rtwvif, config);
++	clear_bit(rtwvif->port, rtwdev->hw_port);
+ 	rtw_recalc_lps(rtwdev, NULL);
+ 
+ 	mutex_unlock(&rtwdev->mutex);
+@@ -368,6 +382,7 @@ static void rtw_ops_bss_info_changed(struct ieee80211_hw *hw,
+ 
+ 			rtw_fw_download_rsvd_page(rtwdev);
+ 			rtw_send_rsvd_page_h2c(rtwdev);
++			rtw_fw_default_port(rtwdev, rtwvif);
+ 			rtw_coex_media_status_notify(rtwdev, vif->cfg.assoc);
+ 			if (rtw_bf_support)
+ 				rtw_bf_assoc(rtwdev, vif, conf);
+@@ -378,7 +393,8 @@ static void rtw_ops_bss_info_changed(struct ieee80211_hw *hw,
+ 			 * when disconnected by peer
+ 			 */
+ 			if (test_bit(RTW_FLAG_SCANNING, rtwdev->flags))
+-				rtw_hw_scan_abort(rtwdev, vif);
++				rtw_hw_scan_abort(rtwdev);
++
+ 		}
+ 
+ 		config |= PORT_SET_NET_TYPE;
+@@ -388,7 +404,7 @@ static void rtw_ops_bss_info_changed(struct ieee80211_hw *hw,
+ 	if (changed & BSS_CHANGED_BSSID) {
+ 		ether_addr_copy(rtwvif->bssid, conf->bssid);
+ 		config |= PORT_SET_BSSID;
+-		if (is_zero_ether_addr(rtwvif->bssid))
++		if (!rtw_core_check_sta_active(rtwdev))
+ 			rtw_clear_op_chan(rtwdev);
+ 		else
+ 			rtw_store_op_chan(rtwdev, true);
+@@ -402,6 +418,7 @@ static void rtw_ops_bss_info_changed(struct ieee80211_hw *hw,
+ 	if (changed & BSS_CHANGED_BEACON) {
+ 		rtw_set_dtim_period(rtwdev, conf->dtim_period);
+ 		rtw_fw_download_rsvd_page(rtwdev);
++		rtw_send_rsvd_page_h2c(rtwdev);
+ 	}
+ 
+ 	if (changed & BSS_CHANGED_BEACON_ENABLED) {
+@@ -437,12 +454,29 @@ static int rtw_ops_start_ap(struct ieee80211_hw *hw,
+ 	const struct rtw_chip_info *chip = rtwdev->chip;
+ 
+ 	mutex_lock(&rtwdev->mutex);
++	rtw_write32_set(rtwdev, REG_TCR, BIT_TCR_UPDATE_HGQMD);
++	rtwdev->ap_active = true;
++	rtw_store_op_chan(rtwdev, true);
+ 	chip->ops->phy_calibration(rtwdev);
+ 	mutex_unlock(&rtwdev->mutex);
+ 
+ 	return 0;
+ }
+ 
++static void rtw_ops_stop_ap(struct ieee80211_hw *hw,
++			    struct ieee80211_vif *vif,
++			    struct ieee80211_bss_conf *link_conf)
++{
++	struct rtw_dev *rtwdev = hw->priv;
++
++	mutex_lock(&rtwdev->mutex);
++	rtw_write32_clr(rtwdev, REG_TCR, BIT_TCR_UPDATE_HGQMD);
++	rtwdev->ap_active = false;
++	if (!rtw_core_check_sta_active(rtwdev))
++		rtw_clear_op_chan(rtwdev);
++	mutex_unlock(&rtwdev->mutex);
++}
++
+ static int rtw_ops_conf_tx(struct ieee80211_hw *hw,
+ 			   struct ieee80211_vif *vif,
+ 			   unsigned int link_id, u16 ac,
+@@ -845,7 +879,7 @@ static int rtw_ops_hw_scan(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
+ 	rtw_hw_scan_start(rtwdev, vif, req);
+ 	ret = rtw_hw_scan_offload(rtwdev, vif, true);
+ 	if (ret) {
+-		rtw_hw_scan_abort(rtwdev, vif);
++		rtw_hw_scan_abort(rtwdev);
+ 		rtw_err(rtwdev, "HW scan failed with status: %d\n", ret);
+ 	}
+ 	mutex_unlock(&rtwdev->mutex);
+@@ -865,7 +899,7 @@ static void rtw_ops_cancel_hw_scan(struct ieee80211_hw *hw,
+ 		return;
+ 
+ 	mutex_lock(&rtwdev->mutex);
+-	rtw_hw_scan_abort(rtwdev, vif);
++	rtw_hw_scan_abort(rtwdev);
+ 	mutex_unlock(&rtwdev->mutex);
+ }
+ 
+@@ -904,6 +938,7 @@ const struct ieee80211_ops rtw_ops = {
+ 	.configure_filter	= rtw_ops_configure_filter,
+ 	.bss_info_changed	= rtw_ops_bss_info_changed,
+ 	.start_ap		= rtw_ops_start_ap,
++	.stop_ap		= rtw_ops_stop_ap,
+ 	.conf_tx		= rtw_ops_conf_tx,
+ 	.sta_add		= rtw_ops_sta_add,
+ 	.sta_remove		= rtw_ops_sta_remove,
+diff --git a/drivers/net/wireless/realtek/rtw88/main.c b/drivers/net/wireless/realtek/rtw88/main.c
+index fc51acc9a599..c853e2f2d448 100644
+--- a/drivers/net/wireless/realtek/rtw88/main.c
++++ b/drivers/net/wireless/realtek/rtw88/main.c
+@@ -18,6 +18,7 @@
+ #include "debug.h"
+ #include "bf.h"
+ #include "sar.h"
++#include "sdio.h"
+ 
+ bool rtw_disable_lps_deep_mode;
+ EXPORT_SYMBOL(rtw_disable_lps_deep_mode);
+@@ -102,6 +103,26 @@ static struct ieee80211_rate rtw_ratetable[] = {
+ 	{.bitrate = 540, .hw_value = 0x0b,},
+ };
+ 
++static const struct ieee80211_iface_limit rtw_iface_limits[] = {
++	{
++		.max = 1,
++		.types = BIT(NL80211_IFTYPE_STATION),
++	},
++	{
++		.max = 1,
++		.types = BIT(NL80211_IFTYPE_AP),
++	}
++};
++
++static const struct ieee80211_iface_combination rtw_iface_combs[] = {
++	{
++		.limits = rtw_iface_limits,
++		.n_limits = ARRAY_SIZE(rtw_iface_limits),
++		.max_interfaces = 2,
++		.num_different_channels = 1,
++	}
++};
++
+ u16 rtw_desc_to_bitrate(u8 desc_rate)
+ {
+ 	struct ieee80211_rate rate;
+@@ -256,7 +277,7 @@ static void rtw_watch_dog_work(struct work_struct *work)
+ 	 * threshold.
+ 	 */
+ 	if (rtwdev->ps_enabled && data.rtwvif && !ps_active &&
+-	    !rtwdev->beacon_loss)
++	    !rtwdev->beacon_loss && !rtwdev->ap_active)
+ 		rtw_enter_lps(rtwdev, data.rtwvif->port);
+ 
+ 	rtwdev->watch_dog_cnt++;
+@@ -313,12 +334,15 @@ int rtw_sta_add(struct rtw_dev *rtwdev, struct ieee80211_sta *sta,
+ 		struct ieee80211_vif *vif)
+ {
+ 	struct rtw_sta_info *si = (struct rtw_sta_info *)sta->drv_priv;
++	struct rtw_vif *rtwvif = (struct rtw_vif *)vif->drv_priv;
+ 	int i;
+ 
+ 	si->mac_id = rtw_acquire_macid(rtwdev);
+ 	if (si->mac_id >= RTW_MAX_MAC_ID_NUM)
+ 		return -ENOSPC;
+ 
++	if (vif->type == NL80211_IFTYPE_STATION && vif->cfg.assoc == 0)
++		rtwvif->mac_id = si->mac_id;
+ 	si->rtwdev = rtwdev;
+ 	si->sta = sta;
+ 	si->vif = vif;
+@@ -624,6 +648,7 @@ static void __fw_recovery_work(struct rtw_dev *rtwdev)
+ 	rcu_read_unlock();
+ 	rtw_iterate_stas_atomic(rtwdev, rtw_reset_sta_iter, rtwdev);
+ 	rtw_iterate_vifs_atomic(rtwdev, rtw_reset_vif_iter, rtwdev);
++	bitmap_zero(rtwdev->hw_port, RTW_PORT_NUM);
+ 	rtw_enter_ips(rtwdev);
+ }
+ 
+@@ -843,6 +868,9 @@ void rtw_set_channel(struct rtw_dev *rtwdev)
+ 
+ 	rtw_update_channel(rtwdev, center_chan, primary_chan, band, bandwidth);
+ 
++	if (rtwdev->scan_info.op_chan)
++		rtw_store_op_chan(rtwdev, true);
++
+ 	chip->ops->set_channel(rtwdev, center_chan, bandwidth,
+ 			       hal->current_primary_channel_index);
+ 
+@@ -1800,6 +1828,10 @@ static int rtw_chip_parameter_setup(struct rtw_dev *rtwdev)
+ 		rtwdev->hci.rpwm_addr = 0x03d9;
+ 		rtwdev->hci.cpwm_addr = 0x03da;
+ 		break;
++	case RTW_HCI_TYPE_SDIO:
++		rtwdev->hci.rpwm_addr = REG_SDIO_HRPWM1;
++		rtwdev->hci.cpwm_addr = REG_SDIO_HCPWM1_V2;
++		break;
+ 	case RTW_HCI_TYPE_USB:
+ 		rtwdev->hci.rpwm_addr = 0xfe58;
+ 		rtwdev->hci.cpwm_addr = 0xfe57;
+@@ -1994,7 +2026,7 @@ static int rtw_chip_board_info_setup(struct rtw_dev *rtwdev)
+ 	if (!rfe_def)
+ 		return -ENODEV;
+ 
+-	rtw_phy_setup_phy_cond(rtwdev, 0);
++	rtw_phy_setup_phy_cond(rtwdev, hal->pkg_type);
+ 
+ 	rtw_phy_init_tx_power(rtwdev);
+ 	if (rfe_def->agc_btg_tbl)
+@@ -2173,9 +2205,11 @@ int rtw_register_hw(struct rtw_dev *rtwdev, struct ieee80211_hw *hw)
+ 	int max_tx_headroom = 0;
+ 	int ret;
+ 
+-	/* TODO: USB & SDIO may need extra room? */
+ 	max_tx_headroom = rtwdev->chip->tx_pkt_desc_sz;
+ 
++	if (rtw_hci_type(rtwdev) == RTW_HCI_TYPE_SDIO)
++		max_tx_headroom += RTW_SDIO_DATA_PTR_ALIGN;
++
+ 	hw->extra_tx_headroom = max_tx_headroom;
+ 	hw->queues = IEEE80211_NUM_ACS;
+ 	hw->txq_data_size = sizeof(struct rtw_txq);
+@@ -2209,6 +2243,11 @@ int rtw_register_hw(struct rtw_dev *rtwdev, struct ieee80211_hw *hw)
+ 	hw->wiphy->max_scan_ssids = RTW_SCAN_MAX_SSIDS;
+ 	hw->wiphy->max_scan_ie_len = rtw_get_max_scan_ie_len(rtwdev);
+ 
++	if (rtwdev->chip->id == RTW_CHIP_TYPE_8822C) {
++		hw->wiphy->iface_combinations = rtw_iface_combs;
++		hw->wiphy->n_iface_combinations = ARRAY_SIZE(rtw_iface_combs);
++	}
++
+ 	wiphy_ext_feature_set(hw->wiphy, NL80211_EXT_FEATURE_CAN_REPLACE_PTK0);
+ 	wiphy_ext_feature_set(hw->wiphy, NL80211_EXT_FEATURE_SCAN_RANDOM_SN);
+ 	wiphy_ext_feature_set(hw->wiphy, NL80211_EXT_FEATURE_SET_SCAN_DWELL);
+@@ -2258,6 +2297,129 @@ void rtw_unregister_hw(struct rtw_dev *rtwdev, struct ieee80211_hw *hw)
+ }
+ EXPORT_SYMBOL(rtw_unregister_hw);
+ 
++static
++void rtw_swap_reg_nbytes(struct rtw_dev *rtwdev, const struct rtw_hw_reg *reg1,
++			 const struct rtw_hw_reg *reg2, u8 nbytes)
++{
++	u8 i;
++
++	for (i = 0; i < nbytes; i++) {
++		u8 v1 = rtw_read8(rtwdev, reg1->addr + i);
++		u8 v2 = rtw_read8(rtwdev, reg2->addr + i);
++
++		rtw_write8(rtwdev, reg1->addr + i, v2);
++		rtw_write8(rtwdev, reg2->addr + i, v1);
++	}
++}
++
++static
++void rtw_swap_reg_mask(struct rtw_dev *rtwdev, const struct rtw_hw_reg *reg1,
++		       const struct rtw_hw_reg *reg2)
++{
++	u32 v1, v2;
++
++	v1 = rtw_read32_mask(rtwdev, reg1->addr, reg1->mask);
++	v2 = rtw_read32_mask(rtwdev, reg2->addr, reg2->mask);
++	rtw_write32_mask(rtwdev, reg2->addr, reg2->mask, v1);
++	rtw_write32_mask(rtwdev, reg1->addr, reg1->mask, v2);
++}
++
++struct rtw_iter_port_switch_data {
++	struct rtw_dev *rtwdev;
++	struct rtw_vif *rtwvif_ap;
++};
++
++static void rtw_port_switch_iter(void *data, u8 *mac, struct ieee80211_vif *vif)
++{
++	struct rtw_iter_port_switch_data *iter_data = data;
++	struct rtw_dev *rtwdev = iter_data->rtwdev;
++	struct rtw_vif *rtwvif_target = (struct rtw_vif *)vif->drv_priv;
++	struct rtw_vif *rtwvif_ap = iter_data->rtwvif_ap;
++	const struct rtw_hw_reg *reg1, *reg2;
++
++	if (rtwvif_target->port != RTW_PORT_0)
++		return;
++
++	rtw_dbg(rtwdev, RTW_DBG_STATE, "AP port switch from %d -> %d\n",
++		rtwvif_ap->port, rtwvif_target->port);
++
++	/* Leave LPS so the value swapped are not in PS mode */
++	rtw_leave_lps(rtwdev);
++
++	reg1 = &rtwvif_ap->conf->net_type;
++	reg2 = &rtwvif_target->conf->net_type;
++	rtw_swap_reg_mask(rtwdev, reg1, reg2);
++
++	reg1 = &rtwvif_ap->conf->mac_addr;
++	reg2 = &rtwvif_target->conf->mac_addr;
++	rtw_swap_reg_nbytes(rtwdev, reg1, reg2, ETH_ALEN);
++
++	reg1 = &rtwvif_ap->conf->bssid;
++	reg2 = &rtwvif_target->conf->bssid;
++	rtw_swap_reg_nbytes(rtwdev, reg1, reg2, ETH_ALEN);
++
++	reg1 = &rtwvif_ap->conf->bcn_ctrl;
++	reg2 = &rtwvif_target->conf->bcn_ctrl;
++	rtw_swap_reg_nbytes(rtwdev, reg1, reg2, 1);
++
++	swap(rtwvif_target->port, rtwvif_ap->port);
++	swap(rtwvif_target->conf, rtwvif_ap->conf);
++
++	rtw_fw_default_port(rtwdev, rtwvif_target);
++}
++
++void rtw_core_port_switch(struct rtw_dev *rtwdev, struct ieee80211_vif *vif)
++{
++	struct rtw_vif *rtwvif = (struct rtw_vif *)vif->drv_priv;
++	struct rtw_iter_port_switch_data iter_data;
++
++	if (vif->type != NL80211_IFTYPE_AP || rtwvif->port == RTW_PORT_0)
++		return;
++
++	iter_data.rtwdev = rtwdev;
++	iter_data.rtwvif_ap = rtwvif;
++	rtw_iterate_vifs(rtwdev, rtw_port_switch_iter, &iter_data);
++}
++
++static void rtw_check_sta_active_iter(void *data, u8 *mac,
++				      struct ieee80211_vif *vif)
++{
++	struct rtw_vif *rtwvif = (struct rtw_vif *)vif->drv_priv;
++	bool *active = data;
++
++	if (*active)
++		return;
++
++	if (vif->type != NL80211_IFTYPE_STATION)
++		return;
++
++	if (vif->cfg.assoc || !is_zero_ether_addr(rtwvif->bssid))
++		*active = true;
++}
++
++bool rtw_core_check_sta_active(struct rtw_dev *rtwdev)
++{
++	bool sta_active = false;
++
++	rtw_iterate_vifs(rtwdev, rtw_check_sta_active_iter, &sta_active);
++
++	return rtwdev->ap_active || sta_active;
++}
++
++void rtw_core_enable_beacon(struct rtw_dev *rtwdev, bool enable)
++{
++	if (!rtwdev->ap_active)
++		return;
++
++	if (enable) {
++		rtw_write32_set(rtwdev, REG_BCN_CTRL, BIT_EN_BCN_FUNCTION);
++		rtw_write32_clr(rtwdev, REG_TXPAUSE, BIT_HIGH_QUEUE);
++	} else {
++		rtw_write32_clr(rtwdev, REG_BCN_CTRL, BIT_EN_BCN_FUNCTION);
++		rtw_write32_set(rtwdev, REG_TXPAUSE, BIT_HIGH_QUEUE);
++	}
++}
++
+ MODULE_AUTHOR("Realtek Corporation");
+ MODULE_DESCRIPTION("Realtek 802.11ac wireless core module");
+ MODULE_LICENSE("Dual BSD/GPL");
+diff --git a/drivers/net/wireless/realtek/rtw88/main.h b/drivers/net/wireless/realtek/rtw88/main.h
+index cdbcea28802d..f9dd2ab941c8 100644
+--- a/drivers/net/wireless/realtek/rtw88/main.h
++++ b/drivers/net/wireless/realtek/rtw88/main.h
+@@ -88,7 +88,7 @@ enum rtw_supported_band {
+ 	RTW_BAND_60G = BIT(NL80211_BAND_60GHZ),
+ };
+ 
+-/* now, support upto 80M bw */
++/* now, support up to 80M bw */
+ #define RTW_MAX_CHANNEL_WIDTH RTW_CHANNEL_WIDTH_80
+ 
+ enum rtw_bandwidth {
+@@ -395,6 +395,15 @@ enum rtw_snr {
+ 	RTW_SNR_NUM
+ };
+ 
++enum rtw_port {
++	RTW_PORT_0 = 0,
++	RTW_PORT_1 = 1,
++	RTW_PORT_2 = 2,
++	RTW_PORT_3 = 3,
++	RTW_PORT_4 = 4,
++	RTW_PORT_NUM
++};
++
+ enum rtw_wow_flags {
+ 	RTW_WOW_FLAG_EN_MAGIC_PKT,
+ 	RTW_WOW_FLAG_EN_REKEY_PKT,
+@@ -794,6 +803,7 @@ struct rtw_bf_info {
+ struct rtw_vif {
+ 	enum rtw_net_type net_type;
+ 	u16 aid;
++	u8 mac_id; /* for STA mode only */
+ 	u8 mac_addr[ETH_ALEN];
+ 	u8 bssid[ETH_ALEN];
+ 	u8 port;
+@@ -1171,6 +1181,7 @@ struct rtw_chip_info {
+ 	u32 txff_size;
+ 	u32 rxff_size;
+ 	u32 fw_rxff_size;
++	u16 rsvd_drv_pg_num;
+ 	u8 band;
+ 	u8 page_size;
+ 	u8 csi_buf_pg_num;
+@@ -1874,7 +1885,7 @@ enum rtw_sar_bands {
+ 	RTW_SAR_BAND_NR,
+ };
+ 
+-/* the union is reserved for other knids of SAR sources
++/* the union is reserved for other kinds of SAR sources
+  * which might not re-use same format with array common.
+  */
+ union rtw_sar_cfg {
+@@ -1893,7 +1904,9 @@ struct rtw_hal {
+ 	u8 cut_version;
+ 	u8 mp_chip;
+ 	u8 oem_id;
++	u8 pkg_type;
+ 	struct rtw_phy_cond phy_cond;
++	bool rfe_btg;
+ 
+ 	u8 ps_mode;
+ 	u8 current_channel;
+@@ -2023,7 +2036,7 @@ struct rtw_dev {
+ 	struct rtw_tx_report tx_report;
+ 
+ 	struct {
+-		/* incicate the mail box to use with fw */
++		/* indicate the mail box to use with fw */
+ 		u8 last_box_num;
+ 		u32 seq;
+ 	} h2c;
+@@ -2039,6 +2052,7 @@ struct rtw_dev {
+ 	u8 sta_cnt;
+ 	u32 rts_threshold;
+ 
++	DECLARE_BITMAP(hw_port, RTW_PORT_NUM);
+ 	DECLARE_BITMAP(mac_id_map, RTW_MAX_MAC_ID_NUM);
+ 	DECLARE_BITMAP(flags, NUM_OF_RTW_FLAGS);
+ 
+@@ -2050,6 +2064,7 @@ struct rtw_dev {
+ 
+ 	bool need_rfk;
+ 	struct completion fw_scan_density;
++	bool ap_active;
+ 
+ 	/* hci related data, must be last */
+ 	u8 priv[] __aligned(sizeof(void *));
+@@ -2191,4 +2206,7 @@ void rtw_set_txrx_1ss(struct rtw_dev *rtwdev, bool config_1ss);
+ void rtw_update_channel(struct rtw_dev *rtwdev, u8 center_channel,
+ 			u8 primary_channel, enum rtw_supported_band band,
+ 			enum rtw_bandwidth bandwidth);
++void rtw_core_port_switch(struct rtw_dev *rtwdev, struct ieee80211_vif *vif);
++bool rtw_core_check_sta_active(struct rtw_dev *rtwdev);
++void rtw_core_enable_beacon(struct rtw_dev *rtwdev, bool enable);
+ #endif
+diff --git a/drivers/net/wireless/realtek/rtw88/pci.c b/drivers/net/wireless/realtek/rtw88/pci.c
+index b4bd831c9845..44a8fff34cdd 100644
+--- a/drivers/net/wireless/realtek/rtw88/pci.c
++++ b/drivers/net/wireless/realtek/rtw88/pci.c
+@@ -89,13 +89,6 @@ static void rtw_pci_write32(struct rtw_dev *rtwdev, u32 addr, u32 val)
+ 	writel(val, rtwpci->mmap + addr);
+ }
+ 
+-static inline void *rtw_pci_get_tx_desc(struct rtw_pci_tx_ring *tx_ring, u8 idx)
+-{
+-	int offset = tx_ring->r.desc_size * idx;
+-
+-	return tx_ring->r.head + offset;
+-}
+-
+ static void rtw_pci_free_tx_ring_skbs(struct rtw_dev *rtwdev,
+ 				      struct rtw_pci_tx_ring *tx_ring)
+ {
+@@ -745,8 +738,9 @@ static void __rtw_pci_flush_queues(struct rtw_dev *rtwdev, u32 pci_queues,
+ 	u8 q;
+ 
+ 	for (q = 0; q < RTK_MAX_TX_QUEUE_NUM; q++) {
+-		/* It may be not necessary to flush BCN and H2C tx queues. */
+-		if (q == RTW_TX_QUEUE_BCN || q == RTW_TX_QUEUE_H2C)
++		/* Unnecessary to flush BCN, H2C and HI tx queues. */
++		if (q == RTW_TX_QUEUE_BCN || q == RTW_TX_QUEUE_H2C ||
++		    q == RTW_TX_QUEUE_HI0)
+ 			continue;
+ 
+ 		if (pci_queues & BIT(q))
+@@ -1552,7 +1546,6 @@ static int rtw_pci_claim(struct rtw_dev *rtwdev, struct pci_dev *pdev)
+ 
+ static void rtw_pci_declaim(struct rtw_dev *rtwdev, struct pci_dev *pdev)
+ {
+-	pci_clear_master(pdev);
+ 	pci_disable_device(pdev);
+ }
+ 
+diff --git a/drivers/net/wireless/realtek/rtw88/ps.c b/drivers/net/wireless/realtek/rtw88/ps.c
+index 53933fb38a33..43e80a3a8136 100644
+--- a/drivers/net/wireless/realtek/rtw88/ps.c
++++ b/drivers/net/wireless/realtek/rtw88/ps.c
+@@ -18,6 +18,7 @@ static int rtw_ips_pwr_up(struct rtw_dev *rtwdev)
+ 	if (ret)
+ 		rtw_err(rtwdev, "leave idle state failed\n");
+ 
++	rtw_coex_ips_notify(rtwdev, COEX_IPS_LEAVE);
+ 	rtw_set_channel(rtwdev);
+ 
+ 	return ret;
+@@ -63,8 +64,6 @@ int rtw_leave_ips(struct rtw_dev *rtwdev)
+ 
+ 	rtw_iterate_vifs(rtwdev, rtw_restore_port_cfg_iter, rtwdev);
+ 
+-	rtw_coex_ips_notify(rtwdev, COEX_IPS_LEAVE);
+-
+ 	return 0;
+ }
+ 
+diff --git a/drivers/net/wireless/realtek/rtw88/reg.h b/drivers/net/wireless/realtek/rtw88/reg.h
+index 8852b24d6c2a..7c6c11d50ff3 100644
+--- a/drivers/net/wireless/realtek/rtw88/reg.h
++++ b/drivers/net/wireless/realtek/rtw88/reg.h
+@@ -87,6 +87,7 @@
+ #define BIT_LTE_MUX_CTRL_PATH	BIT(26)
+ #define REG_HCI_OPT_CTRL	0x0074
+ #define BIT_USB_SUS_DIS		BIT(8)
++#define BIT_SDIO_PAD_E5		BIT(18)
+ 
+ #define REG_AFE_CTRL_4		0x0078
+ #define BIT_CK320M_AFE_EN	BIT(4)
+@@ -185,6 +186,9 @@
+ 	(((x) & BIT_MASK_TXDMA_VIQ_MAP) << BIT_SHIFT_TXDMA_VIQ_MAP)
+ #define REG_TXDMA_PQ_MAP	0x010C
+ #define BIT_RXDMA_ARBBW_EN	BIT(0)
++#define BIT_RXSHFT_EN		BIT(1)
++#define BIT_RXDMA_AGG_EN	BIT(2)
++#define BIT_TXDMA_BW_EN		BIT(3)
+ #define BIT_SHIFT_TXDMA_BEQ_MAP	8
+ #define BIT_MASK_TXDMA_BEQ_MAP	0x3
+ #define BIT_TXDMA_BEQ_MAP(x)                                                   \
+@@ -283,10 +287,18 @@
+ #define REG_H2C_TAIL		0x0248
+ #define REG_H2C_READ_ADDR	0x024C
+ #define REG_H2C_INFO		0x0254
++#define REG_RXDMA_AGG_PG_TH	0x0280
++#define BIT_RXDMA_AGG_PG_TH	GENMASK(7, 0)
++#define BIT_DMA_AGG_TO_V1	GENMASK(15, 8)
++#define BIT_EN_PRE_CALC		BIT(29)
+ #define REG_RXPKT_NUM		0x0284
+ #define BIT_RXDMA_REQ		BIT(19)
+ #define BIT_RW_RELEASE		BIT(18)
+ #define BIT_RXDMA_IDLE		BIT(17)
++#define REG_RXDMA_STATUS	0x0288
++#define REG_RXDMA_DPR		0x028C
++#define REG_RXDMA_MODE		0x0290
++#define BIT_DMA_MODE		BIT(1)
+ #define REG_RXPKTNUM		0x02B0
+ 
+ #define REG_INT_MIG		0x0304
+@@ -366,6 +378,7 @@
+ #define BIT_SIFS_BK_EN		BIT(12)
+ #define REG_TXPAUSE		0x0522
+ #define BIT_AC_QUEUE		GENMASK(7, 0)
++#define BIT_HIGH_QUEUE		BIT(5)
+ #define REG_RD_CTRL		0x0524
+ #define BIT_EDCCA_MSK_CNTDOWN_EN BIT(11)
+ #define BIT_DIS_TXOP_CFE	BIT(10)
+@@ -398,6 +411,7 @@
+ #define REG_TCR			0x0604
+ #define BIT_PWRMGT_HWDATA_EN	BIT(7)
+ #define BIT_TCR_UPDATE_TIMIE	BIT(5)
++#define BIT_TCR_UPDATE_HGQMD	BIT(4)
+ #define REG_RCR			0x0608
+ #define BIT_APP_FCS		BIT(31)
+ #define BIT_APP_MIC		BIT(30)
+diff --git a/drivers/net/wireless/realtek/rtw88/rtw8723d.c b/drivers/net/wireless/realtek/rtw88/rtw8723d.c
+index 2d2f768bae2e..c575476a0020 100644
+--- a/drivers/net/wireless/realtek/rtw88/rtw8723d.c
++++ b/drivers/net/wireless/realtek/rtw88/rtw8723d.c
+@@ -216,6 +216,12 @@ static void rtw8723du_efuse_parsing(struct rtw_efuse *efuse,
+ 	ether_addr_copy(efuse->addr, map->u.mac_addr);
+ }
+ 
++static void rtw8723ds_efuse_parsing(struct rtw_efuse *efuse,
++				    struct rtw8723d_efuse *map)
++{
++	ether_addr_copy(efuse->addr, map->s.mac_addr);
++}
++
+ static int rtw8723d_read_efuse(struct rtw_dev *rtwdev, u8 *log_map)
+ {
+ 	struct rtw_efuse *efuse = &rtwdev->efuse;
+@@ -248,6 +254,9 @@ static int rtw8723d_read_efuse(struct rtw_dev *rtwdev, u8 *log_map)
+ 	case RTW_HCI_TYPE_USB:
+ 		rtw8723du_efuse_parsing(efuse, map);
+ 		break;
++	case RTW_HCI_TYPE_SDIO:
++		rtw8723ds_efuse_parsing(efuse, map);
++		break;
+ 	default:
+ 		/* unsupported now */
+ 		return -ENOTSUPP;
+@@ -1961,15 +1970,17 @@ static void rtw8723d_fill_txdesc_checksum(struct rtw_dev *rtwdev,
+ 	size_t words = 32 / 2; /* calculate the first 32 bytes (16 words) */
+ 	__le16 chksum = 0;
+ 	__le16 *data = (__le16 *)(txdesc);
++	struct rtw_tx_desc *tx_desc = (struct rtw_tx_desc *)txdesc;
+ 
+-	SET_TX_DESC_TXDESC_CHECKSUM(txdesc, 0x0000);
++	le32p_replace_bits(&tx_desc->w7, 0, RTW_TX_DESC_W7_TXDESC_CHECKSUM);
+ 
+ 	while (words--)
+ 		chksum ^= *data++;
+ 
+ 	chksum = ~chksum;
+ 
+-	SET_TX_DESC_TXDESC_CHECKSUM(txdesc, __le16_to_cpu(chksum));
++	le32p_replace_bits(&tx_desc->w7, __le16_to_cpu(chksum),
++			   RTW_TX_DESC_W7_TXDESC_CHECKSUM);
+ }
+ 
+ static struct rtw_chip_ops rtw8723d_ops = {
+@@ -2743,6 +2754,7 @@ const struct rtw_chip_info rtw8723d_hw_spec = {
+ 	.ptct_efuse_size = 96 + 1,
+ 	.txff_size = 32768,
+ 	.rxff_size = 16384,
++	.rsvd_drv_pg_num = 8,
+ 	.txgi_factor = 1,
+ 	.is_pwr_by_rate_dec = true,
+ 	.max_power_index = 0x3f,
+diff --git a/drivers/net/wireless/realtek/rtw88/rtw8723d.h b/drivers/net/wireless/realtek/rtw88/rtw8723d.h
+index a356318a5c15..3642a2c7f80c 100644
+--- a/drivers/net/wireless/realtek/rtw88/rtw8723d.h
++++ b/drivers/net/wireless/realtek/rtw88/rtw8723d.h
+@@ -49,6 +49,11 @@ struct rtw8723du_efuse {
+ 	u8 mac_addr[ETH_ALEN];          /* 0x107 */
+ };
+ 
++struct rtw8723ds_efuse {
++	u8 res4[0x4a];			/* 0xd0 */
++	u8 mac_addr[ETH_ALEN];		/* 0x11a */
++};
++
+ struct rtw8723d_efuse {
+ 	__le16 rtl_id;
+ 	u8 rsvd[2];
+@@ -80,6 +85,7 @@ struct rtw8723d_efuse {
+ 	union {
+ 		struct rtw8723de_efuse e;
+ 		struct rtw8723du_efuse u;
++		struct rtw8723ds_efuse s;
+ 	};
+ };
+ 
+diff --git a/drivers/net/wireless/realtek/rtw88/rtw8821c.c b/drivers/net/wireless/realtek/rtw88/rtw8821c.c
+index 67efa58dd78e..adf224618a2a 100644
+--- a/drivers/net/wireless/realtek/rtw88/rtw8821c.c
++++ b/drivers/net/wireless/realtek/rtw88/rtw8821c.c
+@@ -32,6 +32,12 @@ static void rtw8821cu_efuse_parsing(struct rtw_efuse *efuse,
+ 	ether_addr_copy(efuse->addr, map->u.mac_addr);
+ }
+ 
++static void rtw8821cs_efuse_parsing(struct rtw_efuse *efuse,
++				    struct rtw8821c_efuse *map)
++{
++	ether_addr_copy(efuse->addr, map->s.mac_addr);
++}
++
+ enum rtw8821ce_rf_set {
+ 	SWITCH_TO_BTG,
+ 	SWITCH_TO_WLG,
+@@ -41,6 +47,7 @@ enum rtw8821ce_rf_set {
+ 
+ static int rtw8821c_read_efuse(struct rtw_dev *rtwdev, u8 *log_map)
+ {
++	struct rtw_hal *hal = &rtwdev->hal;
+ 	struct rtw_efuse *efuse = &rtwdev->efuse;
+ 	struct rtw8821c_efuse *map;
+ 	int i;
+@@ -64,6 +71,19 @@ static int rtw8821c_read_efuse(struct rtw_dev *rtwdev, u8 *log_map)
+ 	efuse->tx_bb_swing_setting_2g = map->tx_bb_swing_setting_2g;
+ 	efuse->tx_bb_swing_setting_5g = map->tx_bb_swing_setting_5g;
+ 
++	hal->pkg_type = map->rfe_option & BIT(5) ? 1 : 0;
++
++	switch (efuse->rfe_option) {
++	case 0x2:
++	case 0x4:
++	case 0x7:
++	case 0xa:
++	case 0xc:
++	case 0xf:
++		hal->rfe_btg = true;
++		break;
++	}
++
+ 	for (i = 0; i < 4; i++)
+ 		efuse->txpwr_idx_table[i] = map->txpwr_idx_table[i];
+ 
+@@ -77,6 +97,9 @@ static int rtw8821c_read_efuse(struct rtw_dev *rtwdev, u8 *log_map)
+ 	case RTW_HCI_TYPE_USB:
+ 		rtw8821cu_efuse_parsing(efuse, map);
+ 		break;
++	case RTW_HCI_TYPE_SDIO:
++		rtw8821cs_efuse_parsing(efuse, map);
++		break;
+ 	default:
+ 		/* unsupported now */
+ 		return -ENOTSUPP;
+@@ -286,6 +309,7 @@ static void rtw8821c_switch_rf_set(struct rtw_dev *rtwdev, u8 rf_set)
+ 
+ static void rtw8821c_set_channel_rf(struct rtw_dev *rtwdev, u8 channel, u8 bw)
+ {
++	struct rtw_hal *hal = &rtwdev->hal;
+ 	u32 rf_reg18;
+ 
+ 	rf_reg18 = rtw_read_rf(rtwdev, RF_PATH_A, 0x18, RFREG_MASK);
+@@ -317,11 +341,10 @@ static void rtw8821c_set_channel_rf(struct rtw_dev *rtwdev, u8 channel, u8 bw)
+ 	}
+ 
+ 	if (channel <= 14) {
+-		if (rtwdev->efuse.rfe_option == 0)
+-			rtw8821c_switch_rf_set(rtwdev, SWITCH_TO_WLG);
+-		else if (rtwdev->efuse.rfe_option == 2 ||
+-			 rtwdev->efuse.rfe_option == 4)
++		if (hal->rfe_btg)
+ 			rtw8821c_switch_rf_set(rtwdev, SWITCH_TO_BTG);
++		else
++			rtw8821c_switch_rf_set(rtwdev, SWITCH_TO_WLG);
+ 		rtw_write_rf(rtwdev, RF_PATH_A, RF_LUTDBG, BIT(6), 0x1);
+ 		rtw_write_rf(rtwdev, RF_PATH_A, 0x64, 0xf, 0xf);
+ 	} else {
+@@ -1910,6 +1933,7 @@ const struct rtw_chip_info rtw8821c_hw_spec = {
+ 	.ptct_efuse_size = 96,
+ 	.txff_size = 65536,
+ 	.rxff_size = 16384,
++	.rsvd_drv_pg_num = 8,
+ 	.txgi_factor = 1,
+ 	.is_pwr_by_rate_dec = true,
+ 	.max_power_index = 0x3f,
+diff --git a/drivers/net/wireless/realtek/rtw88/rtw8821c.h b/drivers/net/wireless/realtek/rtw88/rtw8821c.h
+index 1c81260f3a54..fcff31688c45 100644
+--- a/drivers/net/wireless/realtek/rtw88/rtw8821c.h
++++ b/drivers/net/wireless/realtek/rtw88/rtw8821c.h
+@@ -65,6 +65,11 @@ struct rtw8821ce_efuse {
+ 	u8 res7;
+ };
+ 
++struct rtw8821cs_efuse {
++	u8 res4[0x4a];			/* 0xd0 */
++	u8 mac_addr[ETH_ALEN];		/* 0x11a */
++} __packed;
++
+ struct rtw8821c_efuse {
+ 	__le16 rtl_id;
+ 	u8 res0[0x0e];
+@@ -94,6 +99,7 @@ struct rtw8821c_efuse {
+ 	union {
+ 		struct rtw8821ce_efuse e;
+ 		struct rtw8821cu_efuse u;
++		struct rtw8821cs_efuse s;
+ 	};
+ };
+ 
+diff --git a/drivers/net/wireless/realtek/rtw88/rtw8822b.c b/drivers/net/wireless/realtek/rtw88/rtw8822b.c
+index 74dfb89b2c94..3017a9760da8 100644
+--- a/drivers/net/wireless/realtek/rtw88/rtw8822b.c
++++ b/drivers/net/wireless/realtek/rtw88/rtw8822b.c
+@@ -32,6 +32,12 @@ static void rtw8822bu_efuse_parsing(struct rtw_efuse *efuse,
+ 	ether_addr_copy(efuse->addr, map->u.mac_addr);
+ }
+ 
++static void rtw8822bs_efuse_parsing(struct rtw_efuse *efuse,
++				    struct rtw8822b_efuse *map)
++{
++	ether_addr_copy(efuse->addr, map->s.mac_addr);
++}
++
+ static int rtw8822b_read_efuse(struct rtw_dev *rtwdev, u8 *log_map)
+ {
+ 	struct rtw_efuse *efuse = &rtwdev->efuse;
+@@ -65,6 +71,9 @@ static int rtw8822b_read_efuse(struct rtw_dev *rtwdev, u8 *log_map)
+ 	case RTW_HCI_TYPE_USB:
+ 		rtw8822bu_efuse_parsing(efuse, map);
+ 		break;
++	case RTW_HCI_TYPE_SDIO:
++		rtw8822bs_efuse_parsing(efuse, map);
++		break;
+ 	default:
+ 		/* unsupported now */
+ 		return -ENOTSUPP;
+@@ -2531,6 +2540,7 @@ const struct rtw_chip_info rtw8822b_hw_spec = {
+ 	.txff_size = 262144,
+ 	.rxff_size = 24576,
+ 	.fw_rxff_size = 12288,
++	.rsvd_drv_pg_num = 8,
+ 	.txgi_factor = 1,
+ 	.is_pwr_by_rate_dec = true,
+ 	.max_power_index = 0x3f,
+diff --git a/drivers/net/wireless/realtek/rtw88/rtw8822b.h b/drivers/net/wireless/realtek/rtw88/rtw8822b.h
+index 01d3644e0c94..2dc3a6660f06 100644
+--- a/drivers/net/wireless/realtek/rtw88/rtw8822b.h
++++ b/drivers/net/wireless/realtek/rtw88/rtw8822b.h
+@@ -65,6 +65,11 @@ struct rtw8822be_efuse {
+ 	u8 res7;
+ };
+ 
++struct rtw8822bs_efuse {
++	u8 res4[0x4a];			/* 0xd0 */
++	u8 mac_addr[ETH_ALEN];		/* 0x11a */
++} __packed;
++
+ struct rtw8822b_efuse {
+ 	__le16 rtl_id;
+ 	u8 res0[0x0e];
+@@ -92,8 +97,9 @@ struct rtw8822b_efuse {
+ 	u8 country_code[2];
+ 	u8 res[3];
+ 	union {
+-		struct rtw8822bu_efuse u;
+ 		struct rtw8822be_efuse e;
++		struct rtw8822bu_efuse u;
++		struct rtw8822bs_efuse s;
+ 	};
+ };
+ 
+diff --git a/drivers/net/wireless/realtek/rtw88/rtw8822c.c b/drivers/net/wireless/realtek/rtw88/rtw8822c.c
+index 964e27887fe2..cd965edc29ce 100644
+--- a/drivers/net/wireless/realtek/rtw88/rtw8822c.c
++++ b/drivers/net/wireless/realtek/rtw88/rtw8822c.c
+@@ -35,6 +35,12 @@ static void rtw8822cu_efuse_parsing(struct rtw_efuse *efuse,
+ 	ether_addr_copy(efuse->addr, map->u.mac_addr);
+ }
+ 
++static void rtw8822cs_efuse_parsing(struct rtw_efuse *efuse,
++				    struct rtw8822c_efuse *map)
++{
++	ether_addr_copy(efuse->addr, map->s.mac_addr);
++}
++
+ static int rtw8822c_read_efuse(struct rtw_dev *rtwdev, u8 *log_map)
+ {
+ 	struct rtw_efuse *efuse = &rtwdev->efuse;
+@@ -67,6 +73,9 @@ static int rtw8822c_read_efuse(struct rtw_dev *rtwdev, u8 *log_map)
+ 	case RTW_HCI_TYPE_USB:
+ 		rtw8822cu_efuse_parsing(efuse, map);
+ 		break;
++	case RTW_HCI_TYPE_SDIO:
++		rtw8822cs_efuse_parsing(efuse, map);
++		break;
+ 	default:
+ 		/* unsupported now */
+ 		return -ENOTSUPP;
+@@ -5349,6 +5358,7 @@ const struct rtw_chip_info rtw8822c_hw_spec = {
+ 	.txff_size = 262144,
+ 	.rxff_size = 24576,
+ 	.fw_rxff_size = 12288,
++	.rsvd_drv_pg_num = 16,
+ 	.txgi_factor = 2,
+ 	.is_pwr_by_rate_dec = false,
+ 	.max_power_index = 0x7f,
+diff --git a/drivers/net/wireless/realtek/rtw88/rtw8822c.h b/drivers/net/wireless/realtek/rtw88/rtw8822c.h
+index 479d5d769c52..1bc0e7f5d6bb 100644
+--- a/drivers/net/wireless/realtek/rtw88/rtw8822c.h
++++ b/drivers/net/wireless/realtek/rtw88/rtw8822c.h
+@@ -16,6 +16,11 @@ struct rtw8822cu_efuse {
+ 	u8 res2[0x3d];
+ };
+ 
++struct rtw8822cs_efuse {
++	u8 res0[0x4a];			/* 0x120 */
++	u8 mac_addr[ETH_ALEN];		/* 0x16a */
++} __packed;
++
+ struct rtw8822ce_efuse {
+ 	u8 mac_addr[ETH_ALEN];		/* 0x120 */
+ 	u8 vender_id[2];
+@@ -91,8 +96,9 @@ struct rtw8822c_efuse {
+ 	u8 res9;
+ 	u8 res10[0x42];
+ 	union {
+-		struct rtw8822cu_efuse u;
+ 		struct rtw8822ce_efuse e;
++		struct rtw8822cu_efuse u;
++		struct rtw8822cs_efuse s;
+ 	};
+ };
+ 
+diff --git a/drivers/net/wireless/realtek/rtw88/tx.c b/drivers/net/wireless/realtek/rtw88/tx.c
+index bb5c7492c98b..2821119dc930 100644
+--- a/drivers/net/wireless/realtek/rtw88/tx.c
++++ b/drivers/net/wireless/realtek/rtw88/tx.c
+@@ -34,43 +34,57 @@ void rtw_tx_stats(struct rtw_dev *rtwdev, struct ieee80211_vif *vif,
+ 
+ void rtw_tx_fill_tx_desc(struct rtw_tx_pkt_info *pkt_info, struct sk_buff *skb)
+ {
+-	__le32 *txdesc = (__le32 *)skb->data;
+-
+-	SET_TX_DESC_TXPKTSIZE(txdesc,  pkt_info->tx_pkt_size);
+-	SET_TX_DESC_OFFSET(txdesc, pkt_info->offset);
+-	SET_TX_DESC_PKT_OFFSET(txdesc, pkt_info->pkt_offset);
+-	SET_TX_DESC_QSEL(txdesc, pkt_info->qsel);
+-	SET_TX_DESC_BMC(txdesc, pkt_info->bmc);
+-	SET_TX_DESC_RATE_ID(txdesc, pkt_info->rate_id);
+-	SET_TX_DESC_DATARATE(txdesc, pkt_info->rate);
+-	SET_TX_DESC_DISDATAFB(txdesc, pkt_info->dis_rate_fallback);
+-	SET_TX_DESC_USE_RATE(txdesc, pkt_info->use_rate);
+-	SET_TX_DESC_SEC_TYPE(txdesc, pkt_info->sec_type);
+-	SET_TX_DESC_DATA_BW(txdesc, pkt_info->bw);
+-	SET_TX_DESC_SW_SEQ(txdesc, pkt_info->seq);
+-	SET_TX_DESC_MAX_AGG_NUM(txdesc, pkt_info->ampdu_factor);
+-	SET_TX_DESC_AMPDU_DENSITY(txdesc, pkt_info->ampdu_density);
+-	SET_TX_DESC_DATA_STBC(txdesc, pkt_info->stbc);
+-	SET_TX_DESC_DATA_LDPC(txdesc, pkt_info->ldpc);
+-	SET_TX_DESC_AGG_EN(txdesc, pkt_info->ampdu_en);
+-	SET_TX_DESC_LS(txdesc, pkt_info->ls);
+-	SET_TX_DESC_DATA_SHORT(txdesc, pkt_info->short_gi);
+-	SET_TX_DESC_SPE_RPT(txdesc, pkt_info->report);
+-	SET_TX_DESC_SW_DEFINE(txdesc, pkt_info->sn);
+-	SET_TX_DESC_USE_RTS(txdesc, pkt_info->rts);
++	struct rtw_tx_desc *tx_desc = (struct rtw_tx_desc *)skb->data;
++	bool more_data = false;
++
++	if (pkt_info->qsel == TX_DESC_QSEL_HIGH)
++		more_data = true;
++
++	tx_desc->w0 = le32_encode_bits(pkt_info->tx_pkt_size, RTW_TX_DESC_W0_TXPKTSIZE) |
++		      le32_encode_bits(pkt_info->offset, RTW_TX_DESC_W0_OFFSET) |
++		      le32_encode_bits(pkt_info->bmc, RTW_TX_DESC_W0_BMC) |
++		      le32_encode_bits(pkt_info->ls, RTW_TX_DESC_W0_LS) |
++		      le32_encode_bits(pkt_info->dis_qselseq, RTW_TX_DESC_W0_DISQSELSEQ);
++
++	tx_desc->w1 = le32_encode_bits(pkt_info->qsel, RTW_TX_DESC_W1_QSEL) |
++		      le32_encode_bits(pkt_info->rate_id, RTW_TX_DESC_W1_RATE_ID) |
++		      le32_encode_bits(pkt_info->sec_type, RTW_TX_DESC_W1_SEC_TYPE) |
++		      le32_encode_bits(pkt_info->pkt_offset, RTW_TX_DESC_W1_PKT_OFFSET) |
++		      le32_encode_bits(more_data, RTW_TX_DESC_W1_MORE_DATA);
++
++	tx_desc->w2 = le32_encode_bits(pkt_info->ampdu_en, RTW_TX_DESC_W2_AGG_EN) |
++		      le32_encode_bits(pkt_info->report, RTW_TX_DESC_W2_SPE_RPT) |
++		      le32_encode_bits(pkt_info->ampdu_density, RTW_TX_DESC_W2_AMPDU_DEN) |
++		      le32_encode_bits(pkt_info->bt_null, RTW_TX_DESC_W2_BT_NULL);
++
++	tx_desc->w3 = le32_encode_bits(pkt_info->hw_ssn_sel, RTW_TX_DESC_W3_HW_SSN_SEL) |
++		      le32_encode_bits(pkt_info->use_rate, RTW_TX_DESC_W3_USE_RATE) |
++		      le32_encode_bits(pkt_info->dis_rate_fallback, RTW_TX_DESC_W3_DISDATAFB) |
++		      le32_encode_bits(pkt_info->rts, RTW_TX_DESC_W3_USE_RTS) |
++		      le32_encode_bits(pkt_info->nav_use_hdr, RTW_TX_DESC_W3_NAVUSEHDR) |
++		      le32_encode_bits(pkt_info->ampdu_factor, RTW_TX_DESC_W3_MAX_AGG_NUM);
++
++	tx_desc->w4 = le32_encode_bits(pkt_info->rate, RTW_TX_DESC_W4_DATARATE);
++
++	tx_desc->w5 = le32_encode_bits(pkt_info->short_gi, RTW_TX_DESC_W5_DATA_SHORT) |
++		      le32_encode_bits(pkt_info->bw, RTW_TX_DESC_W5_DATA_BW) |
++		      le32_encode_bits(pkt_info->ldpc, RTW_TX_DESC_W5_DATA_LDPC) |
++		      le32_encode_bits(pkt_info->stbc, RTW_TX_DESC_W5_DATA_STBC);
++
++	tx_desc->w6 = le32_encode_bits(pkt_info->sn, RTW_TX_DESC_W6_SW_DEFINE);
++
++	tx_desc->w8 = le32_encode_bits(pkt_info->en_hwseq, RTW_TX_DESC_W8_EN_HWSEQ);
++
++	tx_desc->w9 = le32_encode_bits(pkt_info->seq, RTW_TX_DESC_W9_SW_SEQ);
++
+ 	if (pkt_info->rts) {
+-		SET_TX_DESC_RTSRATE(txdesc, DESC_RATE24M);
+-		SET_TX_DESC_DATA_RTS_SHORT(txdesc, 1);
+-	}
+-	SET_TX_DESC_DISQSELSEQ(txdesc, pkt_info->dis_qselseq);
+-	SET_TX_DESC_EN_HWSEQ(txdesc, pkt_info->en_hwseq);
+-	SET_TX_DESC_HW_SSN_SEL(txdesc, pkt_info->hw_ssn_sel);
+-	SET_TX_DESC_NAVUSEHDR(txdesc, pkt_info->nav_use_hdr);
+-	SET_TX_DESC_BT_NULL(txdesc, pkt_info->bt_null);
+-	if (pkt_info->tim_offset) {
+-		SET_TX_DESC_TIM_EN(txdesc, 1);
+-		SET_TX_DESC_TIM_OFFSET(txdesc, pkt_info->tim_offset);
++		tx_desc->w4 |= le32_encode_bits(DESC_RATE24M, RTW_TX_DESC_W4_RTSRATE);
++		tx_desc->w5 |= le32_encode_bits(1, RTW_TX_DESC_W5_DATA_RTS_SHORT);
+ 	}
++
++	if (pkt_info->tim_offset)
++		tx_desc->w9 |= le32_encode_bits(1, RTW_TX_DESC_W9_TIM_EN) |
++			       le32_encode_bits(pkt_info->tim_offset, RTW_TX_DESC_W9_TIM_OFFSET);
+ }
+ EXPORT_SYMBOL(rtw_tx_fill_tx_desc);
+ 
+@@ -635,9 +649,8 @@ static void rtw_txq_push(struct rtw_dev *rtwdev,
+ 	rcu_read_unlock();
+ }
+ 
+-void rtw_tx_work(struct work_struct *w)
++void __rtw_tx_work(struct rtw_dev *rtwdev)
+ {
+-	struct rtw_dev *rtwdev = container_of(w, struct rtw_dev, tx_work);
+ 	struct rtw_txq *rtwtxq, *tmp;
+ 
+ 	spin_lock_bh(&rtwdev->txq_lock);
+@@ -658,6 +671,13 @@ void rtw_tx_work(struct work_struct *w)
+ 	spin_unlock_bh(&rtwdev->txq_lock);
+ }
+ 
++void rtw_tx_work(struct work_struct *w)
++{
++	struct rtw_dev *rtwdev = container_of(w, struct rtw_dev, tx_work);
++
++	__rtw_tx_work(rtwdev);
++}
++
+ void rtw_txq_init(struct rtw_dev *rtwdev, struct ieee80211_txq *txq)
+ {
+ 	struct rtw_txq *rtwtxq;
+diff --git a/drivers/net/wireless/realtek/rtw88/tx.h b/drivers/net/wireless/realtek/rtw88/tx.h
+index 197d5868c8ad..324189606257 100644
+--- a/drivers/net/wireless/realtek/rtw88/tx.h
++++ b/drivers/net/wireless/realtek/rtw88/tx.h
+@@ -9,76 +9,53 @@
+ 
+ #define RTW_TX_PROBE_TIMEOUT		msecs_to_jiffies(500)
+ 
+-#define SET_TX_DESC_TXPKTSIZE(txdesc, value)                                   \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x00, value, GENMASK(15, 0))
+-#define SET_TX_DESC_OFFSET(txdesc, value)                                      \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x00, value, GENMASK(23, 16))
+-#define SET_TX_DESC_PKT_OFFSET(txdesc, value)                                  \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x01, value, GENMASK(28, 24))
+-#define SET_TX_DESC_QSEL(txdesc, value)                                        \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x01, value, GENMASK(12, 8))
+-#define SET_TX_DESC_BMC(txdesc, value)                                         \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x00, value, BIT(24))
+-#define SET_TX_DESC_RATE_ID(txdesc, value)                                     \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x01, value, GENMASK(20, 16))
+-#define SET_TX_DESC_DATARATE(txdesc, value)                                    \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x04, value, GENMASK(6, 0))
+-#define SET_TX_DESC_DISDATAFB(txdesc, value)                                   \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x03, value, BIT(10))
+-#define SET_TX_DESC_USE_RATE(txdesc, value)                                    \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x03, value, BIT(8))
+-#define SET_TX_DESC_SEC_TYPE(txdesc, value)                                    \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x01, value, GENMASK(23, 22))
+-#define SET_TX_DESC_DATA_BW(txdesc, value)                                     \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x05, value, GENMASK(6, 5))
+-#define SET_TX_DESC_SW_SEQ(txdesc, value)                                      \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x09, value, GENMASK(23, 12))
+-#define SET_TX_DESC_TIM_EN(txdesc, value)                                      \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x09, value, BIT(7))
+-#define SET_TX_DESC_TIM_OFFSET(txdesc, value)                                  \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x09, value, GENMASK(6, 0))
+-#define SET_TX_DESC_MAX_AGG_NUM(txdesc, value)                                 \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x03, value, GENMASK(21, 17))
+-#define SET_TX_DESC_USE_RTS(tx_desc, value)                                    \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x03, value, BIT(12))
+-#define SET_TX_DESC_RTSRATE(txdesc, value)                                     \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x04, value, GENMASK(28, 24))
+-#define SET_TX_DESC_DATA_RTS_SHORT(txdesc, value)                              \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x05, value, BIT(12))
+-#define SET_TX_DESC_AMPDU_DENSITY(txdesc, value)                               \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x02, value, GENMASK(22, 20))
+-#define SET_TX_DESC_DATA_STBC(txdesc, value)                                   \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x05, value, GENMASK(9, 8))
+-#define SET_TX_DESC_DATA_LDPC(txdesc, value)                                   \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x05, value, BIT(7))
+-#define SET_TX_DESC_AGG_EN(txdesc, value)                                      \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x02, value, BIT(12))
+-#define SET_TX_DESC_LS(txdesc, value)                                          \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x00, value, BIT(26))
+-#define SET_TX_DESC_DATA_SHORT(txdesc, value)				       \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x05, value, BIT(4))
+-#define SET_TX_DESC_SPE_RPT(tx_desc, value)                                    \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x02, value, BIT(19))
+-#define SET_TX_DESC_SW_DEFINE(tx_desc, value)                                  \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x06, value, GENMASK(11, 0))
+-#define SET_TX_DESC_DISQSELSEQ(txdesc, value)                                 \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x00, value, BIT(31))
+-#define SET_TX_DESC_EN_HWSEQ(txdesc, value)                                   \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x08, value, BIT(15))
+-#define SET_TX_DESC_HW_SSN_SEL(txdesc, value)                                 \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x03, value, GENMASK(7, 6))
+-#define SET_TX_DESC_NAVUSEHDR(txdesc, value)				       \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x03, value, BIT(15))
+-#define SET_TX_DESC_BT_NULL(txdesc, value)				       \
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x02, value, BIT(23))
+-#define SET_TX_DESC_TXDESC_CHECKSUM(txdesc, value)				\
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x07, value, GENMASK(15, 0))
+-#define SET_TX_DESC_DMA_TXAGG_NUM(txdesc, value)				\
+-	le32p_replace_bits((__le32 *)(txdesc) + 0x07, value, GENMASK(31, 24))
+-#define GET_TX_DESC_PKT_OFFSET(txdesc)						\
+-	le32_get_bits(*((__le32 *)(txdesc) + 0x01), GENMASK(28, 24))
+-#define GET_TX_DESC_QSEL(txdesc)						\
+-	le32_get_bits(*((__le32 *)(txdesc) + 0x01), GENMASK(12, 8))
++struct rtw_tx_desc {
++	__le32 w0;
++	__le32 w1;
++	__le32 w2;
++	__le32 w3;
++	__le32 w4;
++	__le32 w5;
++	__le32 w6;
++	__le32 w7;
++	__le32 w8;
++	__le32 w9;
++} __packed;
++
++#define RTW_TX_DESC_W0_TXPKTSIZE GENMASK(15, 0)
++#define RTW_TX_DESC_W0_OFFSET GENMASK(23, 16)
++#define RTW_TX_DESC_W0_BMC BIT(24)
++#define RTW_TX_DESC_W0_LS BIT(26)
++#define RTW_TX_DESC_W0_DISQSELSEQ BIT(31)
++#define RTW_TX_DESC_W1_QSEL GENMASK(12, 8)
++#define RTW_TX_DESC_W1_RATE_ID GENMASK(20, 16)
++#define RTW_TX_DESC_W1_SEC_TYPE GENMASK(23, 22)
++#define RTW_TX_DESC_W1_PKT_OFFSET GENMASK(28, 24)
++#define RTW_TX_DESC_W1_MORE_DATA BIT(29)
++#define RTW_TX_DESC_W2_AGG_EN BIT(12)
++#define RTW_TX_DESC_W2_SPE_RPT BIT(19)
++#define RTW_TX_DESC_W2_AMPDU_DEN GENMASK(22, 20)
++#define RTW_TX_DESC_W2_BT_NULL BIT(23)
++#define RTW_TX_DESC_W3_HW_SSN_SEL GENMASK(7, 6)
++#define RTW_TX_DESC_W3_USE_RATE BIT(8)
++#define RTW_TX_DESC_W3_DISDATAFB BIT(10)
++#define RTW_TX_DESC_W3_USE_RTS BIT(12)
++#define RTW_TX_DESC_W3_NAVUSEHDR BIT(15)
++#define RTW_TX_DESC_W3_MAX_AGG_NUM GENMASK(21, 17)
++#define RTW_TX_DESC_W4_DATARATE GENMASK(6, 0)
++#define RTW_TX_DESC_W4_RTSRATE GENMASK(28, 24)
++#define RTW_TX_DESC_W5_DATA_SHORT BIT(4)
++#define RTW_TX_DESC_W5_DATA_BW GENMASK(6, 5)
++#define RTW_TX_DESC_W5_DATA_LDPC BIT(7)
++#define RTW_TX_DESC_W5_DATA_STBC GENMASK(9, 8)
++#define RTW_TX_DESC_W5_DATA_RTS_SHORT BIT(12)
++#define RTW_TX_DESC_W6_SW_DEFINE GENMASK(11, 0)
++#define RTW_TX_DESC_W7_TXDESC_CHECKSUM GENMASK(15, 0)
++#define RTW_TX_DESC_W7_DMA_TXAGG_NUM GENMASK(31, 24)
++#define RTW_TX_DESC_W8_EN_HWSEQ BIT(15)
++#define RTW_TX_DESC_W9_SW_SEQ GENMASK(23, 12)
++#define RTW_TX_DESC_W9_TIM_EN BIT(7)
++#define RTW_TX_DESC_W9_TIM_OFFSET GENMASK(6, 0)
+ 
+ enum rtw_tx_desc_queue_select {
+ 	TX_DESC_QSEL_TID0	= 0,
+@@ -111,6 +88,7 @@ void rtw_tx(struct rtw_dev *rtwdev,
+ void rtw_txq_init(struct rtw_dev *rtwdev, struct ieee80211_txq *txq);
+ void rtw_txq_cleanup(struct rtw_dev *rtwdev, struct ieee80211_txq *txq);
+ void rtw_tx_work(struct work_struct *w);
++void __rtw_tx_work(struct rtw_dev *rtwdev);
+ void rtw_tx_pkt_info_update(struct rtw_dev *rtwdev,
+ 			    struct rtw_tx_pkt_info *pkt_info,
+ 			    struct ieee80211_sta *sta,
+@@ -139,13 +117,15 @@ void fill_txdesc_checksum_common(u8 *txdesc, size_t words)
+ {
+ 	__le16 chksum = 0;
+ 	__le16 *data = (__le16 *)(txdesc);
++	struct rtw_tx_desc *tx_desc = (struct rtw_tx_desc *)txdesc;
+ 
+-	SET_TX_DESC_TXDESC_CHECKSUM(txdesc, 0x0000);
++	le32p_replace_bits(&tx_desc->w7, 0, RTW_TX_DESC_W7_TXDESC_CHECKSUM);
+ 
+ 	while (words--)
+ 		chksum ^= *data++;
+ 
+-	SET_TX_DESC_TXDESC_CHECKSUM(txdesc, __le16_to_cpu(chksum));
++	le32p_replace_bits(&tx_desc->w7, __le16_to_cpu(chksum),
++			   RTW_TX_DESC_W7_TXDESC_CHECKSUM);
+ }
+ 
+ static inline void rtw_tx_fill_txdesc_checksum(struct rtw_dev *rtwdev,
+diff --git a/drivers/net/wireless/realtek/rtw88/usb.c b/drivers/net/wireless/realtek/rtw88/usb.c
+index 976eafa739a2..4a57efdba97b 100644
+--- a/drivers/net/wireless/realtek/rtw88/usb.c
++++ b/drivers/net/wireless/realtek/rtw88/usb.c
+@@ -24,11 +24,12 @@ struct rtw_usb_txcb {
+ static void rtw_usb_fill_tx_checksum(struct rtw_usb *rtwusb,
+ 				     struct sk_buff *skb, int agg_num)
+ {
++	struct rtw_tx_desc *tx_desc = (struct rtw_tx_desc *)skb->data;
+ 	struct rtw_dev *rtwdev = rtwusb->rtwdev;
+ 	struct rtw_tx_pkt_info pkt_info;
+ 
+-	SET_TX_DESC_DMA_TXAGG_NUM(skb->data, agg_num);
+-	pkt_info.pkt_offset = GET_TX_DESC_PKT_OFFSET(skb->data);
++	le32p_replace_bits(&tx_desc->w7, agg_num, RTW_TX_DESC_W7_DMA_TXAGG_NUM);
++	pkt_info.pkt_offset = le32_get_bits(tx_desc->w1, RTW_TX_DESC_W1_PKT_OFFSET);
+ 	rtw_tx_fill_txdesc_checksum(rtwdev, &pkt_info, skb->data);
+ }
+ 
+@@ -306,11 +307,13 @@ static int rtw_usb_write_port(struct rtw_dev *rtwdev, u8 qsel, struct sk_buff *s
+ static bool rtw_usb_tx_agg_skb(struct rtw_usb *rtwusb, struct sk_buff_head *list)
+ {
+ 	struct rtw_dev *rtwdev = rtwusb->rtwdev;
++	struct rtw_tx_desc *tx_desc;
+ 	struct rtw_usb_txcb *txcb;
+ 	struct sk_buff *skb_head;
+ 	struct sk_buff *skb_iter;
+ 	int agg_num = 0;
+ 	unsigned int align_next = 0;
++	u8 qsel;
+ 
+ 	if (skb_queue_empty(list))
+ 		return false;
+@@ -363,9 +366,10 @@ static bool rtw_usb_tx_agg_skb(struct rtw_usb *rtwusb, struct sk_buff_head *list
+ 
+ queue:
+ 	skb_queue_tail(&txcb->tx_ack_queue, skb_head);
++	tx_desc = (struct rtw_tx_desc *)skb_head->data;
++	qsel = le32_get_bits(tx_desc->w1, RTW_TX_DESC_W1_QSEL);
+ 
+-	rtw_usb_write_port(rtwdev, GET_TX_DESC_QSEL(skb_head->data), skb_head,
+-			   rtw_usb_write_port_tx_complete, txcb);
++	rtw_usb_write_port(rtwdev, qsel, skb_head, rtw_usb_write_port_tx_complete, txcb);
+ 
+ 	return true;
+ }
+@@ -465,6 +469,9 @@ static u8 rtw_usb_tx_queue_mapping_to_qsel(struct sk_buff *skb)
+ 
+ 	if (unlikely(ieee80211_is_mgmt(fc) || ieee80211_is_ctl(fc)))
+ 		qsel = TX_DESC_QSEL_MGMT;
++	else if (is_broadcast_ether_addr(hdr->addr1) ||
++		 is_multicast_ether_addr(hdr->addr1))
++		qsel = TX_DESC_QSEL_HIGH;
+ 	else if (skb_get_queue_mapping(skb) <= IEEE80211_AC_BK)
+ 		qsel = skb->priority;
+ 	else
+diff --git a/include/linux/mmc/sdio_ids.h b/include/linux/mmc/sdio_ids.h
+index bf3c95d8eb8a..7fada7a714fe 100644
+--- a/include/linux/mmc/sdio_ids.h
++++ b/include/linux/mmc/sdio_ids.h
+@@ -115,6 +115,16 @@
+ #define SDIO_VENDOR_ID_MICROCHIP_WILC		0x0296
+ #define SDIO_DEVICE_ID_MICROCHIP_WILC1000	0x5347
+ 
++#define SDIO_VENDOR_ID_REALTEK			0x024c
++#define SDIO_DEVICE_ID_REALTEK_RTW8723BS	0xb723
++#define SDIO_DEVICE_ID_REALTEK_RTW8821BS	0xb821
++#define SDIO_DEVICE_ID_REALTEK_RTW8822BS	0xb822
++#define SDIO_DEVICE_ID_REALTEK_RTW8821CS	0xc821
++#define SDIO_DEVICE_ID_REALTEK_RTW8822CS	0xc822
++#define SDIO_DEVICE_ID_REALTEK_RTW8723DS_2ANT	0xd723
++#define SDIO_DEVICE_ID_REALTEK_RTW8723DS_1ANT	0xd724
++#define SDIO_DEVICE_ID_REALTEK_RTW8821DS	0xd821
++
+ #define SDIO_VENDOR_ID_SIANO			0x039a
+ #define SDIO_DEVICE_ID_SIANO_NOVA_B0		0x0201
+ #define SDIO_DEVICE_ID_SIANO_NICE		0x0202
+-- 
+2.39.2
+
+From b75999653fd7dacfc8484b9d46f55927a6fcab60 Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@xxxxx.com>
+Date: Sat, 22 Jul 2023 04:28:16 -0400
+Subject: [PATCH] drivers: net: wireless: realtek: rtw88: upstream wireless
+
+linux-next backport: linux-6.3.y
+
+Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
+---
+ .../net/wireless/realtek/rtw88/rtw8723ds.c    |   41 +
+ .../net/wireless/realtek/rtw88/rtw8821cs.c    |   36 +
+ .../net/wireless/realtek/rtw88/rtw8822bs.c    |   36 +
+ .../net/wireless/realtek/rtw88/rtw8822cs.c    |   36 +
+ drivers/net/wireless/realtek/rtw88/sdio.c     | 1416 +++++++++++++++++
+ drivers/net/wireless/realtek/rtw88/sdio.h     |  178 +++
+ 6 files changed, 1743 insertions(+)
+ create mode 100644 drivers/net/wireless/realtek/rtw88/rtw8723ds.c
+ create mode 100644 drivers/net/wireless/realtek/rtw88/rtw8821cs.c
+ create mode 100644 drivers/net/wireless/realtek/rtw88/rtw8822bs.c
+ create mode 100644 drivers/net/wireless/realtek/rtw88/rtw8822cs.c
+ create mode 100644 drivers/net/wireless/realtek/rtw88/sdio.c
+ create mode 100644 drivers/net/wireless/realtek/rtw88/sdio.h
+
+diff --git a/drivers/net/wireless/realtek/rtw88/rtw8723ds.c b/drivers/net/wireless/realtek/rtw88/rtw8723ds.c
+new file mode 100644
+index 000000000000..e5b6960ba0a0
+--- /dev/null
++++ b/drivers/net/wireless/realtek/rtw88/rtw8723ds.c
+@@ -0,0 +1,41 @@
++// SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
++/* Copyright(c) Martin Blumenstingl <martin.blumenstingl@googlemail.com>
++ */
++
++#include <linux/mmc/sdio_func.h>
++#include <linux/mmc/sdio_ids.h>
++#include <linux/module.h>
++#include "main.h"
++#include "rtw8723d.h"
++#include "sdio.h"
++
++static const struct sdio_device_id rtw_8723ds_id_table[] =  {
++	{
++		SDIO_DEVICE(SDIO_VENDOR_ID_REALTEK,
++			    SDIO_DEVICE_ID_REALTEK_RTW8723DS_1ANT),
++		.driver_data = (kernel_ulong_t)&rtw8723d_hw_spec,
++	},
++	{
++		SDIO_DEVICE(SDIO_VENDOR_ID_REALTEK,
++			    SDIO_DEVICE_ID_REALTEK_RTW8723DS_2ANT),
++		.driver_data = (kernel_ulong_t)&rtw8723d_hw_spec,
++	},
++	{}
++};
++MODULE_DEVICE_TABLE(sdio, rtw_8723ds_id_table);
++
++static struct sdio_driver rtw_8723ds_driver = {
++	.name = "rtw_8723ds",
++	.probe = rtw_sdio_probe,
++	.remove = rtw_sdio_remove,
++	.id_table = rtw_8723ds_id_table,
++	.drv = {
++		.pm = &rtw_sdio_pm_ops,
++		.shutdown = rtw_sdio_shutdown,
++	}
++};
++module_sdio_driver(rtw_8723ds_driver);
++
++MODULE_AUTHOR("Martin Blumenstingl <martin.blumenstingl@googlemail.com>");
++MODULE_DESCRIPTION("Realtek 802.11n wireless 8723ds driver");
++MODULE_LICENSE("Dual BSD/GPL");
+diff --git a/drivers/net/wireless/realtek/rtw88/rtw8821cs.c b/drivers/net/wireless/realtek/rtw88/rtw8821cs.c
+new file mode 100644
+index 000000000000..a359413369a4
+--- /dev/null
++++ b/drivers/net/wireless/realtek/rtw88/rtw8821cs.c
+@@ -0,0 +1,36 @@
++// SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
++/* Copyright(c) Martin Blumenstingl <martin.blumenstingl@googlemail.com>
++ */
++
++#include <linux/mmc/sdio_func.h>
++#include <linux/mmc/sdio_ids.h>
++#include <linux/module.h>
++#include "main.h"
++#include "rtw8821c.h"
++#include "sdio.h"
++
++static const struct sdio_device_id rtw_8821cs_id_table[] =  {
++	{
++		SDIO_DEVICE(SDIO_VENDOR_ID_REALTEK,
++			    SDIO_DEVICE_ID_REALTEK_RTW8821CS),
++		.driver_data = (kernel_ulong_t)&rtw8821c_hw_spec,
++	},
++	{}
++};
++MODULE_DEVICE_TABLE(sdio, rtw_8821cs_id_table);
++
++static struct sdio_driver rtw_8821cs_driver = {
++	.name = "rtw_8821cs",
++	.probe = rtw_sdio_probe,
++	.remove = rtw_sdio_remove,
++	.id_table = rtw_8821cs_id_table,
++	.drv = {
++		.pm = &rtw_sdio_pm_ops,
++		.shutdown = rtw_sdio_shutdown,
++	}
++};
++module_sdio_driver(rtw_8821cs_driver);
++
++MODULE_AUTHOR("Martin Blumenstingl <martin.blumenstingl@googlemail.com>");
++MODULE_DESCRIPTION("Realtek 802.11ac wireless 8821cs driver");
++MODULE_LICENSE("Dual BSD/GPL");
+diff --git a/drivers/net/wireless/realtek/rtw88/rtw8822bs.c b/drivers/net/wireless/realtek/rtw88/rtw8822bs.c
+new file mode 100644
+index 000000000000..31d8645f83bd
+--- /dev/null
++++ b/drivers/net/wireless/realtek/rtw88/rtw8822bs.c
+@@ -0,0 +1,36 @@
++// SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
++/* Copyright(c) Jernej Skrabec <jernej.skrabec@gmail.com>
++ */
++
++#include <linux/mmc/sdio_func.h>
++#include <linux/mmc/sdio_ids.h>
++#include <linux/module.h>
++#include "main.h"
++#include "rtw8822b.h"
++#include "sdio.h"
++
++static const struct sdio_device_id rtw_8822bs_id_table[] =  {
++	{
++		SDIO_DEVICE(SDIO_VENDOR_ID_REALTEK,
++			    SDIO_DEVICE_ID_REALTEK_RTW8822BS),
++		.driver_data = (kernel_ulong_t)&rtw8822b_hw_spec,
++	},
++	{}
++};
++MODULE_DEVICE_TABLE(sdio, rtw_8822bs_id_table);
++
++static struct sdio_driver rtw_8822bs_driver = {
++	.name = "rtw_8822bs",
++	.probe = rtw_sdio_probe,
++	.remove = rtw_sdio_remove,
++	.id_table = rtw_8822bs_id_table,
++	.drv = {
++		.pm = &rtw_sdio_pm_ops,
++		.shutdown = rtw_sdio_shutdown,
++	}
++};
++module_sdio_driver(rtw_8822bs_driver);
++
++MODULE_AUTHOR("Jernej Skrabec <jernej.skrabec@gmail.com>");
++MODULE_DESCRIPTION("Realtek 802.11ac wireless 8822bs driver");
++MODULE_LICENSE("Dual BSD/GPL");
+diff --git a/drivers/net/wireless/realtek/rtw88/rtw8822cs.c b/drivers/net/wireless/realtek/rtw88/rtw8822cs.c
+new file mode 100644
+index 000000000000..975e81c824f2
+--- /dev/null
++++ b/drivers/net/wireless/realtek/rtw88/rtw8822cs.c
+@@ -0,0 +1,36 @@
++// SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
++/* Copyright(c) Martin Blumenstingl <martin.blumenstingl@googlemail.com>
++ */
++
++#include <linux/mmc/sdio_func.h>
++#include <linux/mmc/sdio_ids.h>
++#include <linux/module.h>
++#include "main.h"
++#include "rtw8822c.h"
++#include "sdio.h"
++
++static const struct sdio_device_id rtw_8822cs_id_table[] =  {
++	{
++		SDIO_DEVICE(SDIO_VENDOR_ID_REALTEK,
++			    SDIO_DEVICE_ID_REALTEK_RTW8822CS),
++		.driver_data = (kernel_ulong_t)&rtw8822c_hw_spec,
++	},
++	{}
++};
++MODULE_DEVICE_TABLE(sdio, rtw_8822cs_id_table);
++
++static struct sdio_driver rtw_8822cs_driver = {
++	.name = "rtw_8822cs",
++	.probe = rtw_sdio_probe,
++	.remove = rtw_sdio_remove,
++	.id_table = rtw_8822cs_id_table,
++	.drv = {
++		.pm = &rtw_sdio_pm_ops,
++		.shutdown = rtw_sdio_shutdown,
++	}
++};
++module_sdio_driver(rtw_8822cs_driver);
++
++MODULE_AUTHOR("Martin Blumenstingl <martin.blumenstingl@googlemail.com>");
++MODULE_DESCRIPTION("Realtek 802.11ac wireless 8822cs driver");
++MODULE_LICENSE("Dual BSD/GPL");
+diff --git a/drivers/net/wireless/realtek/rtw88/sdio.c b/drivers/net/wireless/realtek/rtw88/sdio.c
+new file mode 100644
+index 000000000000..b19262ec5d8c
+--- /dev/null
++++ b/drivers/net/wireless/realtek/rtw88/sdio.c
+@@ -0,0 +1,1416 @@
++// SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
++/* Copyright (C) 2021 Martin Blumenstingl <martin.blumenstingl@googlemail.com>
++ * Copyright (C) 2021 Jernej Skrabec <jernej.skrabec@gmail.com>
++ *
++ * Based on rtw88/pci.c:
++ *   Copyright(c) 2018-2019  Realtek Corporation
++ */
++
++#include <linux/module.h>
++#include <linux/mmc/host.h>
++#include <linux/mmc/sdio_func.h>
++#include "main.h"
++#include "debug.h"
++#include "fw.h"
++#include "ps.h"
++#include "reg.h"
++#include "rx.h"
++#include "sdio.h"
++#include "tx.h"
++
++#define RTW_SDIO_INDIRECT_RW_RETRIES			50
++
++static bool rtw_sdio_is_bus_addr(u32 addr)
++{
++	return !!(addr & RTW_SDIO_BUS_MSK);
++}
++
++static bool rtw_sdio_bus_claim_needed(struct rtw_sdio *rtwsdio)
++{
++	return !rtwsdio->irq_thread ||
++	       rtwsdio->irq_thread != current;
++}
++
++static u32 rtw_sdio_to_bus_offset(struct rtw_dev *rtwdev, u32 addr)
++{
++	switch (addr & RTW_SDIO_BUS_MSK) {
++	case WLAN_IOREG_OFFSET:
++		addr &= WLAN_IOREG_REG_MSK;
++		addr |= FIELD_PREP(REG_SDIO_CMD_ADDR_MSK,
++				   REG_SDIO_CMD_ADDR_MAC_REG);
++		break;
++	case SDIO_LOCAL_OFFSET:
++		addr &= SDIO_LOCAL_REG_MSK;
++		addr |= FIELD_PREP(REG_SDIO_CMD_ADDR_MSK,
++				   REG_SDIO_CMD_ADDR_SDIO_REG);
++		break;
++	default:
++		rtw_warn(rtwdev, "Cannot convert addr 0x%08x to bus offset",
++			 addr);
++	}
++
++	return addr;
++}
++
++static bool rtw_sdio_use_memcpy_io(struct rtw_dev *rtwdev, u32 addr,
++				   u8 alignment)
++{
++	return IS_ALIGNED(addr, alignment) &&
++	       test_bit(RTW_FLAG_POWERON, rtwdev->flags);
++}
++
++static void rtw_sdio_writel(struct rtw_dev *rtwdev, u32 val, u32 addr,
++			    int *err_ret)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	u8 buf[4];
++	int i;
++
++	if (rtw_sdio_use_memcpy_io(rtwdev, addr, 4)) {
++		sdio_writel(rtwsdio->sdio_func, val, addr, err_ret);
++		return;
++	}
++
++	*(__le32 *)buf = cpu_to_le32(val);
++
++	for (i = 0; i < 4; i++) {
++		sdio_writeb(rtwsdio->sdio_func, buf[i], addr + i, err_ret);
++		if (*err_ret)
++			return;
++	}
++}
++
++static void rtw_sdio_writew(struct rtw_dev *rtwdev, u16 val, u32 addr,
++			    int *err_ret)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	u8 buf[2];
++	int i;
++
++	*(__le16 *)buf = cpu_to_le16(val);
++
++	for (i = 0; i < 2; i++) {
++		sdio_writeb(rtwsdio->sdio_func, buf[i], addr + i, err_ret);
++		if (*err_ret)
++			return;
++	}
++}
++
++static u32 rtw_sdio_readl(struct rtw_dev *rtwdev, u32 addr, int *err_ret)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	u8 buf[4];
++	int i;
++
++	if (rtw_sdio_use_memcpy_io(rtwdev, addr, 4))
++		return sdio_readl(rtwsdio->sdio_func, addr, err_ret);
++
++	for (i = 0; i < 4; i++) {
++		buf[i] = sdio_readb(rtwsdio->sdio_func, addr + i, err_ret);
++		if (*err_ret)
++			return 0;
++	}
++
++	return le32_to_cpu(*(__le32 *)buf);
++}
++
++static u16 rtw_sdio_readw(struct rtw_dev *rtwdev, u32 addr, int *err_ret)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	u8 buf[2];
++	int i;
++
++	for (i = 0; i < 2; i++) {
++		buf[i] = sdio_readb(rtwsdio->sdio_func, addr + i, err_ret);
++		if (*err_ret)
++			return 0;
++	}
++
++	return le16_to_cpu(*(__le16 *)buf);
++}
++
++static u32 rtw_sdio_to_io_address(struct rtw_dev *rtwdev, u32 addr,
++				  bool direct)
++{
++	if (!direct)
++		return addr;
++
++	if (!rtw_sdio_is_bus_addr(addr))
++		addr |= WLAN_IOREG_OFFSET;
++
++	return rtw_sdio_to_bus_offset(rtwdev, addr);
++}
++
++static bool rtw_sdio_use_direct_io(struct rtw_dev *rtwdev, u32 addr)
++{
++	return !rtw_sdio_is_sdio30_supported(rtwdev) ||
++		rtw_sdio_is_bus_addr(addr);
++}
++
++static int rtw_sdio_indirect_reg_cfg(struct rtw_dev *rtwdev, u32 addr, u32 cfg)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	unsigned int retry;
++	u32 reg_cfg;
++	int ret;
++	u8 tmp;
++
++	reg_cfg = rtw_sdio_to_bus_offset(rtwdev, REG_SDIO_INDIRECT_REG_CFG);
++
++	rtw_sdio_writel(rtwdev, addr | cfg | BIT_SDIO_INDIRECT_REG_CFG_UNK20,
++			reg_cfg, &ret);
++	if (ret)
++		return ret;
++
++	for (retry = 0; retry < RTW_SDIO_INDIRECT_RW_RETRIES; retry++) {
++		tmp = sdio_readb(rtwsdio->sdio_func, reg_cfg + 2, &ret);
++		if (!ret && (tmp & BIT(4)))
++			return 0;
++	}
++
++	return -ETIMEDOUT;
++}
++
++static u8 rtw_sdio_indirect_read8(struct rtw_dev *rtwdev, u32 addr,
++				  int *err_ret)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	u32 reg_data;
++
++	*err_ret = rtw_sdio_indirect_reg_cfg(rtwdev, addr,
++					     BIT_SDIO_INDIRECT_REG_CFG_READ);
++	if (*err_ret)
++		return 0;
++
++	reg_data = rtw_sdio_to_bus_offset(rtwdev, REG_SDIO_INDIRECT_REG_DATA);
++	return sdio_readb(rtwsdio->sdio_func, reg_data, err_ret);
++}
++
++static int rtw_sdio_indirect_read_bytes(struct rtw_dev *rtwdev, u32 addr,
++					u8 *buf, int count)
++{
++	int i, ret = 0;
++
++	for (i = 0; i < count; i++) {
++		buf[i] = rtw_sdio_indirect_read8(rtwdev, addr + i, &ret);
++		if (ret)
++			break;
++	}
++
++	return ret;
++}
++
++static u16 rtw_sdio_indirect_read16(struct rtw_dev *rtwdev, u32 addr,
++				    int *err_ret)
++{
++	u32 reg_data;
++	u8 buf[2];
++
++	if (!IS_ALIGNED(addr, 2)) {
++		*err_ret = rtw_sdio_indirect_read_bytes(rtwdev, addr, buf, 2);
++		if (*err_ret)
++			return 0;
++
++		return le16_to_cpu(*(__le16 *)buf);
++	}
++
++	*err_ret = rtw_sdio_indirect_reg_cfg(rtwdev, addr,
++					     BIT_SDIO_INDIRECT_REG_CFG_READ);
++	if (*err_ret)
++		return 0;
++
++	reg_data = rtw_sdio_to_bus_offset(rtwdev, REG_SDIO_INDIRECT_REG_DATA);
++	return rtw_sdio_readw(rtwdev, reg_data, err_ret);
++}
++
++static u32 rtw_sdio_indirect_read32(struct rtw_dev *rtwdev, u32 addr,
++				    int *err_ret)
++{
++	u32 reg_data;
++	u8 buf[4];
++
++	if (!IS_ALIGNED(addr, 4)) {
++		*err_ret = rtw_sdio_indirect_read_bytes(rtwdev, addr, buf, 4);
++		if (*err_ret)
++			return 0;
++
++		return le32_to_cpu(*(__le32 *)buf);
++	}
++
++	*err_ret = rtw_sdio_indirect_reg_cfg(rtwdev, addr,
++					     BIT_SDIO_INDIRECT_REG_CFG_READ);
++	if (*err_ret)
++		return 0;
++
++	reg_data = rtw_sdio_to_bus_offset(rtwdev, REG_SDIO_INDIRECT_REG_DATA);
++	return rtw_sdio_readl(rtwdev, reg_data, err_ret);
++}
++
++static u8 rtw_sdio_read8(struct rtw_dev *rtwdev, u32 addr)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	bool direct, bus_claim;
++	int ret;
++	u8 val;
++
++	direct = rtw_sdio_use_direct_io(rtwdev, addr);
++	addr = rtw_sdio_to_io_address(rtwdev, addr, direct);
++	bus_claim = rtw_sdio_bus_claim_needed(rtwsdio);
++
++	if (bus_claim)
++		sdio_claim_host(rtwsdio->sdio_func);
++
++	if (direct)
++		val = sdio_readb(rtwsdio->sdio_func, addr, &ret);
++	else
++		val = rtw_sdio_indirect_read8(rtwdev, addr, &ret);
++
++	if (bus_claim)
++		sdio_release_host(rtwsdio->sdio_func);
++
++	if (ret)
++		rtw_warn(rtwdev, "sdio read8 failed (0x%x): %d", addr, ret);
++
++	return val;
++}
++
++static u16 rtw_sdio_read16(struct rtw_dev *rtwdev, u32 addr)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	bool direct, bus_claim;
++	int ret;
++	u16 val;
++
++	direct = rtw_sdio_use_direct_io(rtwdev, addr);
++	addr = rtw_sdio_to_io_address(rtwdev, addr, direct);
++	bus_claim = rtw_sdio_bus_claim_needed(rtwsdio);
++
++	if (bus_claim)
++		sdio_claim_host(rtwsdio->sdio_func);
++
++	if (direct)
++		val = rtw_sdio_readw(rtwdev, addr, &ret);
++	else
++		val = rtw_sdio_indirect_read16(rtwdev, addr, &ret);
++
++	if (bus_claim)
++		sdio_release_host(rtwsdio->sdio_func);
++
++	if (ret)
++		rtw_warn(rtwdev, "sdio read16 failed (0x%x): %d", addr, ret);
++
++	return val;
++}
++
++static u32 rtw_sdio_read32(struct rtw_dev *rtwdev, u32 addr)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	bool direct, bus_claim;
++	u32 val;
++	int ret;
++
++	direct = rtw_sdio_use_direct_io(rtwdev, addr);
++	addr = rtw_sdio_to_io_address(rtwdev, addr, direct);
++	bus_claim = rtw_sdio_bus_claim_needed(rtwsdio);
++
++	if (bus_claim)
++		sdio_claim_host(rtwsdio->sdio_func);
++
++	if (direct)
++		val = rtw_sdio_readl(rtwdev, addr, &ret);
++	else
++		val = rtw_sdio_indirect_read32(rtwdev, addr, &ret);
++
++	if (bus_claim)
++		sdio_release_host(rtwsdio->sdio_func);
++
++	if (ret)
++		rtw_warn(rtwdev, "sdio read32 failed (0x%x): %d", addr, ret);
++
++	return val;
++}
++
++static void rtw_sdio_indirect_write8(struct rtw_dev *rtwdev, u8 val, u32 addr,
++				     int *err_ret)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	u32 reg_data;
++
++	reg_data = rtw_sdio_to_bus_offset(rtwdev, REG_SDIO_INDIRECT_REG_DATA);
++	sdio_writeb(rtwsdio->sdio_func, val, reg_data, err_ret);
++	if (*err_ret)
++		return;
++
++	*err_ret = rtw_sdio_indirect_reg_cfg(rtwdev, addr,
++					     BIT_SDIO_INDIRECT_REG_CFG_WRITE);
++}
++
++static void rtw_sdio_indirect_write16(struct rtw_dev *rtwdev, u16 val, u32 addr,
++				      int *err_ret)
++{
++	u32 reg_data;
++
++	if (!IS_ALIGNED(addr, 2)) {
++		addr = rtw_sdio_to_io_address(rtwdev, addr, true);
++		rtw_sdio_writew(rtwdev, val, addr, err_ret);
++		return;
++	}
++
++	reg_data = rtw_sdio_to_bus_offset(rtwdev, REG_SDIO_INDIRECT_REG_DATA);
++	rtw_sdio_writew(rtwdev, val, reg_data, err_ret);
++	if (*err_ret)
++		return;
++
++	*err_ret = rtw_sdio_indirect_reg_cfg(rtwdev, addr,
++					     BIT_SDIO_INDIRECT_REG_CFG_WRITE |
++					     BIT_SDIO_INDIRECT_REG_CFG_WORD);
++}
++
++static void rtw_sdio_indirect_write32(struct rtw_dev *rtwdev, u32 val,
++				      u32 addr, int *err_ret)
++{
++	u32 reg_data;
++
++	if (!IS_ALIGNED(addr, 4)) {
++		addr = rtw_sdio_to_io_address(rtwdev, addr, true);
++		rtw_sdio_writel(rtwdev, val, addr, err_ret);
++		return;
++	}
++
++	reg_data = rtw_sdio_to_bus_offset(rtwdev, REG_SDIO_INDIRECT_REG_DATA);
++	rtw_sdio_writel(rtwdev, val, reg_data, err_ret);
++
++	*err_ret = rtw_sdio_indirect_reg_cfg(rtwdev, addr,
++					     BIT_SDIO_INDIRECT_REG_CFG_WRITE |
++					     BIT_SDIO_INDIRECT_REG_CFG_DWORD);
++}
++
++static void rtw_sdio_write8(struct rtw_dev *rtwdev, u32 addr, u8 val)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	bool direct, bus_claim;
++	int ret;
++
++	direct = rtw_sdio_use_direct_io(rtwdev, addr);
++	addr = rtw_sdio_to_io_address(rtwdev, addr, direct);
++	bus_claim = rtw_sdio_bus_claim_needed(rtwsdio);
++
++	if (bus_claim)
++		sdio_claim_host(rtwsdio->sdio_func);
++
++	if (direct)
++		sdio_writeb(rtwsdio->sdio_func, val, addr, &ret);
++	else
++		rtw_sdio_indirect_write8(rtwdev, val, addr, &ret);
++
++	if (bus_claim)
++		sdio_release_host(rtwsdio->sdio_func);
++
++	if (ret)
++		rtw_warn(rtwdev, "sdio write8 failed (0x%x): %d", addr, ret);
++}
++
++static void rtw_sdio_write16(struct rtw_dev *rtwdev, u32 addr, u16 val)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	bool direct, bus_claim;
++	int ret;
++
++	direct = rtw_sdio_use_direct_io(rtwdev, addr);
++	addr = rtw_sdio_to_io_address(rtwdev, addr, direct);
++	bus_claim = rtw_sdio_bus_claim_needed(rtwsdio);
++
++	if (bus_claim)
++		sdio_claim_host(rtwsdio->sdio_func);
++
++	if (direct)
++		rtw_sdio_writew(rtwdev, val, addr, &ret);
++	else
++		rtw_sdio_indirect_write16(rtwdev, val, addr, &ret);
++
++	if (bus_claim)
++		sdio_release_host(rtwsdio->sdio_func);
++
++	if (ret)
++		rtw_warn(rtwdev, "sdio write16 failed (0x%x): %d", addr, ret);
++}
++
++static void rtw_sdio_write32(struct rtw_dev *rtwdev, u32 addr, u32 val)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	bool direct, bus_claim;
++	int ret;
++
++	direct = rtw_sdio_use_direct_io(rtwdev, addr);
++	addr = rtw_sdio_to_io_address(rtwdev, addr, direct);
++	bus_claim = rtw_sdio_bus_claim_needed(rtwsdio);
++
++	if (bus_claim)
++		sdio_claim_host(rtwsdio->sdio_func);
++
++	if (direct)
++		rtw_sdio_writel(rtwdev, val, addr, &ret);
++	else
++		rtw_sdio_indirect_write32(rtwdev, val, addr, &ret);
++
++	if (bus_claim)
++		sdio_release_host(rtwsdio->sdio_func);
++
++	if (ret)
++		rtw_warn(rtwdev, "sdio write32 failed (0x%x): %d", addr, ret);
++}
++
++static u32 rtw_sdio_get_tx_addr(struct rtw_dev *rtwdev, size_t size,
++				enum rtw_tx_queue_type queue)
++{
++	u32 txaddr;
++
++	switch (queue) {
++	case RTW_TX_QUEUE_BCN:
++	case RTW_TX_QUEUE_H2C:
++	case RTW_TX_QUEUE_HI0:
++		txaddr = FIELD_PREP(REG_SDIO_CMD_ADDR_MSK,
++				    REG_SDIO_CMD_ADDR_TXFF_HIGH);
++		break;
++	case RTW_TX_QUEUE_VI:
++	case RTW_TX_QUEUE_VO:
++		txaddr = FIELD_PREP(REG_SDIO_CMD_ADDR_MSK,
++				    REG_SDIO_CMD_ADDR_TXFF_NORMAL);
++		break;
++	case RTW_TX_QUEUE_BE:
++	case RTW_TX_QUEUE_BK:
++		txaddr = FIELD_PREP(REG_SDIO_CMD_ADDR_MSK,
++				    REG_SDIO_CMD_ADDR_TXFF_LOW);
++		break;
++	case RTW_TX_QUEUE_MGMT:
++		txaddr = FIELD_PREP(REG_SDIO_CMD_ADDR_MSK,
++				    REG_SDIO_CMD_ADDR_TXFF_EXTRA);
++		break;
++	default:
++		rtw_warn(rtwdev, "Unsupported queue for TX addr: 0x%02x\n",
++			 queue);
++		return 0;
++	}
++
++	txaddr += DIV_ROUND_UP(size, 4);
++
++	return txaddr;
++};
++
++static int rtw_sdio_read_port(struct rtw_dev *rtwdev, u8 *buf, size_t count)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	struct mmc_host *host = rtwsdio->sdio_func->card->host;
++	bool bus_claim = rtw_sdio_bus_claim_needed(rtwsdio);
++	u32 rxaddr = rtwsdio->rx_addr++;
++	size_t bytes;
++	int ret;
++
++	if (bus_claim)
++		sdio_claim_host(rtwsdio->sdio_func);
++
++	while (count > 0) {
++		bytes = min_t(size_t, host->max_req_size, count);
++
++		ret = sdio_memcpy_fromio(rtwsdio->sdio_func, buf,
++					 RTW_SDIO_ADDR_RX_RX0FF_GEN(rxaddr),
++					 bytes);
++		if (ret) {
++			rtw_warn(rtwdev,
++				 "Failed to read %zu byte(s) from SDIO port 0x%08x",
++				 bytes, rxaddr);
++			break;
++		}
++
++		count -= bytes;
++		buf += bytes;
++	}
++
++	if (bus_claim)
++		sdio_release_host(rtwsdio->sdio_func);
++
++	return ret;
++}
++
++static int rtw_sdio_check_free_txpg(struct rtw_dev *rtwdev, u8 queue,
++				    size_t count)
++{
++	unsigned int pages_free, pages_needed;
++
++	if (rtw_chip_wcpu_11n(rtwdev)) {
++		u32 free_txpg;
++
++		free_txpg = rtw_sdio_read32(rtwdev, REG_SDIO_FREE_TXPG);
++
++		switch (queue) {
++		case RTW_TX_QUEUE_BCN:
++		case RTW_TX_QUEUE_H2C:
++		case RTW_TX_QUEUE_HI0:
++		case RTW_TX_QUEUE_MGMT:
++			/* high */
++			pages_free = free_txpg & 0xff;
++			break;
++		case RTW_TX_QUEUE_VI:
++		case RTW_TX_QUEUE_VO:
++			/* normal */
++			pages_free = (free_txpg >> 8) & 0xff;
++			break;
++		case RTW_TX_QUEUE_BE:
++		case RTW_TX_QUEUE_BK:
++			/* low */
++			pages_free = (free_txpg >> 16) & 0xff;
++			break;
++		default:
++			rtw_warn(rtwdev, "Unknown mapping for queue %u\n", queue);
++			return -EINVAL;
++		}
++
++		/* add the pages from the public queue */
++		pages_free += (free_txpg >> 24) & 0xff;
++	} else {
++		u32 free_txpg[3];
++
++		free_txpg[0] = rtw_sdio_read32(rtwdev, REG_SDIO_FREE_TXPG);
++		free_txpg[1] = rtw_sdio_read32(rtwdev, REG_SDIO_FREE_TXPG + 4);
++		free_txpg[2] = rtw_sdio_read32(rtwdev, REG_SDIO_FREE_TXPG + 8);
++
++		switch (queue) {
++		case RTW_TX_QUEUE_BCN:
++		case RTW_TX_QUEUE_H2C:
++		case RTW_TX_QUEUE_HI0:
++			/* high */
++			pages_free = free_txpg[0] & 0xfff;
++			break;
++		case RTW_TX_QUEUE_VI:
++		case RTW_TX_QUEUE_VO:
++			/* normal */
++			pages_free = (free_txpg[0] >> 16) & 0xfff;
++			break;
++		case RTW_TX_QUEUE_BE:
++		case RTW_TX_QUEUE_BK:
++			/* low */
++			pages_free = free_txpg[1] & 0xfff;
++			break;
++		case RTW_TX_QUEUE_MGMT:
++			/* extra */
++			pages_free = free_txpg[2] & 0xfff;
++			break;
++		default:
++			rtw_warn(rtwdev, "Unknown mapping for queue %u\n", queue);
++			return -EINVAL;
++		}
++
++		/* add the pages from the public queue */
++		pages_free += (free_txpg[1] >> 16) & 0xfff;
++	}
++
++	pages_needed = DIV_ROUND_UP(count, rtwdev->chip->page_size);
++
++	if (pages_needed > pages_free) {
++		rtw_dbg(rtwdev, RTW_DBG_SDIO,
++			"Not enough free pages (%u needed, %u free) in queue %u for %zu bytes\n",
++			pages_needed, pages_free, queue, count);
++		return -EBUSY;
++	}
++
++	return 0;
++}
++
++static int rtw_sdio_write_port(struct rtw_dev *rtwdev, struct sk_buff *skb,
++			       enum rtw_tx_queue_type queue)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	bool bus_claim;
++	size_t txsize;
++	u32 txaddr;
++	int ret;
++
++	txaddr = rtw_sdio_get_tx_addr(rtwdev, skb->len, queue);
++	if (!txaddr)
++		return -EINVAL;
++
++	txsize = sdio_align_size(rtwsdio->sdio_func, skb->len);
++
++	ret = rtw_sdio_check_free_txpg(rtwdev, queue, txsize);
++	if (ret)
++		return ret;
++
++	if (!IS_ALIGNED((unsigned long)skb->data, RTW_SDIO_DATA_PTR_ALIGN))
++		rtw_warn(rtwdev, "Got unaligned SKB in %s() for queue %u\n",
++			 __func__, queue);
++
++	bus_claim = rtw_sdio_bus_claim_needed(rtwsdio);
++
++	if (bus_claim)
++		sdio_claim_host(rtwsdio->sdio_func);
++
++	ret = sdio_memcpy_toio(rtwsdio->sdio_func, txaddr, skb->data, txsize);
++
++	if (bus_claim)
++		sdio_release_host(rtwsdio->sdio_func);
++
++	if (ret)
++		rtw_warn(rtwdev,
++			 "Failed to write %zu byte(s) to SDIO port 0x%08x",
++			 txsize, txaddr);
++
++	return ret;
++}
++
++static void rtw_sdio_init(struct rtw_dev *rtwdev)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++
++	rtwsdio->irq_mask = REG_SDIO_HIMR_RX_REQUEST | REG_SDIO_HIMR_CPWM1;
++}
++
++static void rtw_sdio_enable_rx_aggregation(struct rtw_dev *rtwdev)
++{
++	u8 size, timeout;
++
++	if (rtw_chip_wcpu_11n(rtwdev)) {
++		size = 0x6;
++		timeout = 0x6;
++	} else {
++		size = 0xff;
++		timeout = 0x1;
++	}
++
++	/* Make the firmware honor the size limit configured below */
++	rtw_write32_set(rtwdev, REG_RXDMA_AGG_PG_TH, BIT_EN_PRE_CALC);
++
++	rtw_write8_set(rtwdev, REG_TXDMA_PQ_MAP, BIT_RXDMA_AGG_EN);
++
++	rtw_write16(rtwdev, REG_RXDMA_AGG_PG_TH,
++		    FIELD_PREP(BIT_RXDMA_AGG_PG_TH, size) |
++		    FIELD_PREP(BIT_DMA_AGG_TO_V1, timeout));
++
++	rtw_write8_set(rtwdev, REG_RXDMA_MODE, BIT_DMA_MODE);
++}
++
++static void rtw_sdio_enable_interrupt(struct rtw_dev *rtwdev)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++
++	rtw_write32(rtwdev, REG_SDIO_HIMR, rtwsdio->irq_mask);
++}
++
++static void rtw_sdio_disable_interrupt(struct rtw_dev *rtwdev)
++{
++	rtw_write32(rtwdev, REG_SDIO_HIMR, 0x0);
++}
++
++static u8 rtw_sdio_get_tx_qsel(struct rtw_dev *rtwdev, struct sk_buff *skb,
++			       u8 queue)
++{
++	switch (queue) {
++	case RTW_TX_QUEUE_BCN:
++		return TX_DESC_QSEL_BEACON;
++	case RTW_TX_QUEUE_H2C:
++		return TX_DESC_QSEL_H2C;
++	case RTW_TX_QUEUE_MGMT:
++		if (rtw_chip_wcpu_11n(rtwdev))
++			return TX_DESC_QSEL_HIGH;
++		else
++			return TX_DESC_QSEL_MGMT;
++	case RTW_TX_QUEUE_HI0:
++		return TX_DESC_QSEL_HIGH;
++	default:
++		return skb->priority;
++	}
++}
++
++static int rtw_sdio_setup(struct rtw_dev *rtwdev)
++{
++	/* nothing to do */
++	return 0;
++}
++
++static int rtw_sdio_start(struct rtw_dev *rtwdev)
++{
++	rtw_sdio_enable_rx_aggregation(rtwdev);
++	rtw_sdio_enable_interrupt(rtwdev);
++
++	return 0;
++}
++
++static void rtw_sdio_stop(struct rtw_dev *rtwdev)
++{
++	rtw_sdio_disable_interrupt(rtwdev);
++}
++
++static void rtw_sdio_deep_ps_enter(struct rtw_dev *rtwdev)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	bool tx_empty = true;
++	u8 queue;
++
++	if (!rtw_fw_feature_check(&rtwdev->fw, FW_FEATURE_TX_WAKE)) {
++		/* Deep PS state is not allowed to TX-DMA */
++		for (queue = 0; queue < RTK_MAX_TX_QUEUE_NUM; queue++) {
++			/* BCN queue is rsvd page, does not have DMA interrupt
++			 * H2C queue is managed by firmware
++			 */
++			if (queue == RTW_TX_QUEUE_BCN ||
++			    queue == RTW_TX_QUEUE_H2C)
++				continue;
++
++			/* check if there is any skb DMAing */
++			if (skb_queue_len(&rtwsdio->tx_queue[queue])) {
++				tx_empty = false;
++				break;
++			}
++		}
++	}
++
++	if (!tx_empty) {
++		rtw_dbg(rtwdev, RTW_DBG_PS,
++			"TX path not empty, cannot enter deep power save state\n");
++		return;
++	}
++
++	set_bit(RTW_FLAG_LEISURE_PS_DEEP, rtwdev->flags);
++	rtw_power_mode_change(rtwdev, true);
++}
++
++static void rtw_sdio_deep_ps_leave(struct rtw_dev *rtwdev)
++{
++	if (test_and_clear_bit(RTW_FLAG_LEISURE_PS_DEEP, rtwdev->flags))
++		rtw_power_mode_change(rtwdev, false);
++}
++
++static void rtw_sdio_deep_ps(struct rtw_dev *rtwdev, bool enter)
++{
++	if (enter && !test_bit(RTW_FLAG_LEISURE_PS_DEEP, rtwdev->flags))
++		rtw_sdio_deep_ps_enter(rtwdev);
++
++	if (!enter && test_bit(RTW_FLAG_LEISURE_PS_DEEP, rtwdev->flags))
++		rtw_sdio_deep_ps_leave(rtwdev);
++}
++
++static void rtw_sdio_tx_kick_off(struct rtw_dev *rtwdev)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++
++	queue_work(rtwsdio->txwq, &rtwsdio->tx_handler_data->work);
++}
++
++static void rtw_sdio_link_ps(struct rtw_dev *rtwdev, bool enter)
++{
++	/* nothing to do */
++}
++
++static void rtw_sdio_interface_cfg(struct rtw_dev *rtwdev)
++{
++	u32 val;
++
++	rtw_read32(rtwdev, REG_SDIO_FREE_TXPG);
++
++	val = rtw_read32(rtwdev, REG_SDIO_TX_CTRL);
++	val &= 0xfff8;
++	rtw_write32(rtwdev, REG_SDIO_TX_CTRL, val);
++}
++
++static struct rtw_sdio_tx_data *rtw_sdio_get_tx_data(struct sk_buff *skb)
++{
++	struct ieee80211_tx_info *info = IEEE80211_SKB_CB(skb);
++
++	BUILD_BUG_ON(sizeof(struct rtw_sdio_tx_data) >
++		     sizeof(info->status.status_driver_data));
++
++	return (struct rtw_sdio_tx_data *)info->status.status_driver_data;
++}
++
++static void rtw_sdio_tx_skb_prepare(struct rtw_dev *rtwdev,
++				    struct rtw_tx_pkt_info *pkt_info,
++				    struct sk_buff *skb,
++				    enum rtw_tx_queue_type queue)
++{
++	const struct rtw_chip_info *chip = rtwdev->chip;
++	unsigned long data_addr, aligned_addr;
++	size_t offset;
++	u8 *pkt_desc;
++
++	pkt_desc = skb_push(skb, chip->tx_pkt_desc_sz);
++
++	data_addr = (unsigned long)pkt_desc;
++	aligned_addr = ALIGN(data_addr, RTW_SDIO_DATA_PTR_ALIGN);
++
++	if (data_addr != aligned_addr) {
++		/* Ensure that the start of the pkt_desc is always aligned at
++		 * RTW_SDIO_DATA_PTR_ALIGN.
++		 */
++		offset = RTW_SDIO_DATA_PTR_ALIGN - (aligned_addr - data_addr);
++
++		pkt_desc = skb_push(skb, offset);
++
++		/* By inserting padding to align the start of the pkt_desc we
++		 * need to inform the firmware that the actual data starts at
++		 * a different offset than normal.
++		 */
++		pkt_info->offset += offset;
++	}
++
++	memset(pkt_desc, 0, chip->tx_pkt_desc_sz);
++
++	pkt_info->qsel = rtw_sdio_get_tx_qsel(rtwdev, skb, queue);
++
++	rtw_tx_fill_tx_desc(pkt_info, skb);
++	rtw_tx_fill_txdesc_checksum(rtwdev, pkt_info, pkt_desc);
++}
++
++static int rtw_sdio_write_data(struct rtw_dev *rtwdev,
++			       struct rtw_tx_pkt_info *pkt_info,
++			       struct sk_buff *skb,
++			       enum rtw_tx_queue_type queue)
++{
++	int ret;
++
++	rtw_sdio_tx_skb_prepare(rtwdev, pkt_info, skb, queue);
++
++	ret = rtw_sdio_write_port(rtwdev, skb, queue);
++	dev_kfree_skb_any(skb);
++
++	return ret;
++}
++
++static int rtw_sdio_write_data_rsvd_page(struct rtw_dev *rtwdev, u8 *buf,
++					 u32 size)
++{
++	struct rtw_tx_pkt_info pkt_info = {};
++	struct sk_buff *skb;
++
++	skb = rtw_tx_write_data_rsvd_page_get(rtwdev, &pkt_info, buf, size);
++	if (!skb)
++		return -ENOMEM;
++
++	return rtw_sdio_write_data(rtwdev, &pkt_info, skb, RTW_TX_QUEUE_BCN);
++}
++
++static int rtw_sdio_write_data_h2c(struct rtw_dev *rtwdev, u8 *buf, u32 size)
++{
++	struct rtw_tx_pkt_info pkt_info = {};
++	struct sk_buff *skb;
++
++	skb = rtw_tx_write_data_h2c_get(rtwdev, &pkt_info, buf, size);
++	if (!skb)
++		return -ENOMEM;
++
++	return rtw_sdio_write_data(rtwdev, &pkt_info, skb, RTW_TX_QUEUE_H2C);
++}
++
++static int rtw_sdio_tx_write(struct rtw_dev *rtwdev,
++			     struct rtw_tx_pkt_info *pkt_info,
++			     struct sk_buff *skb)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	enum rtw_tx_queue_type queue = rtw_tx_queue_mapping(skb);
++	struct rtw_sdio_tx_data *tx_data;
++
++	rtw_sdio_tx_skb_prepare(rtwdev, pkt_info, skb, queue);
++
++	tx_data = rtw_sdio_get_tx_data(skb);
++	tx_data->sn = pkt_info->sn;
++
++	skb_queue_tail(&rtwsdio->tx_queue[queue], skb);
++
++	return 0;
++}
++
++static void rtw_sdio_tx_err_isr(struct rtw_dev *rtwdev)
++{
++	u32 val = rtw_read32(rtwdev, REG_TXDMA_STATUS);
++
++	rtw_write32(rtwdev, REG_TXDMA_STATUS, val);
++}
++
++static void rtw_sdio_rx_skb(struct rtw_dev *rtwdev, struct sk_buff *skb,
++			    u32 pkt_offset, struct rtw_rx_pkt_stat *pkt_stat,
++			    struct ieee80211_rx_status *rx_status)
++{
++	*IEEE80211_SKB_RXCB(skb) = *rx_status;
++
++	if (pkt_stat->is_c2h) {
++		skb_put(skb, pkt_stat->pkt_len + pkt_offset);
++		rtw_fw_c2h_cmd_rx_irqsafe(rtwdev, pkt_offset, skb);
++		return;
++	}
++
++	skb_put(skb, pkt_stat->pkt_len);
++	skb_reserve(skb, pkt_offset);
++
++	rtw_rx_stats(rtwdev, pkt_stat->vif, skb);
++
++	ieee80211_rx_irqsafe(rtwdev->hw, skb);
++}
++
++static void rtw_sdio_rxfifo_recv(struct rtw_dev *rtwdev, u32 rx_len)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	const struct rtw_chip_info *chip = rtwdev->chip;
++	u32 pkt_desc_sz = chip->rx_pkt_desc_sz;
++	struct ieee80211_rx_status rx_status;
++	struct rtw_rx_pkt_stat pkt_stat;
++	struct sk_buff *skb, *split_skb;
++	u32 pkt_offset, curr_pkt_len;
++	size_t bufsz;
++	u8 *rx_desc;
++	int ret;
++
++	bufsz = sdio_align_size(rtwsdio->sdio_func, rx_len);
++
++	skb = dev_alloc_skb(bufsz);
++	if (!skb)
++		return;
++
++	ret = rtw_sdio_read_port(rtwdev, skb->data, bufsz);
++	if (ret) {
++		dev_kfree_skb_any(skb);
++		return;
++	}
++
++	while (true) {
++		rx_desc = skb->data;
++		chip->ops->query_rx_desc(rtwdev, rx_desc, &pkt_stat,
++					 &rx_status);
++		pkt_offset = pkt_desc_sz + pkt_stat.drv_info_sz +
++			     pkt_stat.shift;
++
++		curr_pkt_len = ALIGN(pkt_offset + pkt_stat.pkt_len,
++				     RTW_SDIO_DATA_PTR_ALIGN);
++
++		if ((curr_pkt_len + pkt_desc_sz) >= rx_len) {
++			/* Use the original skb (with it's adjusted offset)
++			 * when processing the last (or even the only) entry to
++			 * have it's memory freed automatically.
++			 */
++			rtw_sdio_rx_skb(rtwdev, skb, pkt_offset, &pkt_stat,
++					&rx_status);
++			break;
++		}
++
++		split_skb = dev_alloc_skb(curr_pkt_len);
++		if (!split_skb) {
++			rtw_sdio_rx_skb(rtwdev, skb, pkt_offset, &pkt_stat,
++					&rx_status);
++			break;
++		}
++
++		skb_copy_header(split_skb, skb);
++		memcpy(split_skb->data, skb->data, curr_pkt_len);
++
++		rtw_sdio_rx_skb(rtwdev, split_skb, pkt_offset, &pkt_stat,
++				&rx_status);
++
++		/* Move to the start of the next RX descriptor */
++		skb_reserve(skb, curr_pkt_len);
++		rx_len -= curr_pkt_len;
++	}
++}
++
++static void rtw_sdio_rx_isr(struct rtw_dev *rtwdev)
++{
++	u32 rx_len, hisr, total_rx_bytes = 0;
++
++	do {
++		if (rtw_chip_wcpu_11n(rtwdev))
++			rx_len = rtw_read16(rtwdev, REG_SDIO_RX0_REQ_LEN);
++		else
++			rx_len = rtw_read32(rtwdev, REG_SDIO_RX0_REQ_LEN);
++
++		if (!rx_len)
++			break;
++
++		rtw_sdio_rxfifo_recv(rtwdev, rx_len);
++
++		total_rx_bytes += rx_len;
++
++		if (rtw_chip_wcpu_11n(rtwdev)) {
++			/* Stop if no more RX requests are pending, even if
++			 * rx_len could be greater than zero in the next
++			 * iteration. This is needed because the RX buffer may
++			 * already contain data while either HW or FW are not
++			 * done filling that buffer yet. Still reading the
++			 * buffer can result in packets where
++			 * rtw_rx_pkt_stat.pkt_len is zero or points beyond the
++			 * end of the buffer.
++			 */
++			hisr = rtw_read32(rtwdev, REG_SDIO_HISR);
++		} else {
++			/* RTW_WCPU_11AC chips have improved hardware or
++			 * firmware and can use rx_len unconditionally.
++			 */
++			hisr = REG_SDIO_HISR_RX_REQUEST;
++		}
++	} while (total_rx_bytes < SZ_64K && hisr & REG_SDIO_HISR_RX_REQUEST);
++}
++
++static void rtw_sdio_handle_interrupt(struct sdio_func *sdio_func)
++{
++	struct ieee80211_hw *hw = sdio_get_drvdata(sdio_func);
++	struct rtw_sdio *rtwsdio;
++	struct rtw_dev *rtwdev;
++	u32 hisr;
++
++	rtwdev = hw->priv;
++	rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++
++	rtwsdio->irq_thread = current;
++
++	hisr = rtw_read32(rtwdev, REG_SDIO_HISR);
++
++	if (hisr & REG_SDIO_HISR_TXERR)
++		rtw_sdio_tx_err_isr(rtwdev);
++	if (hisr & REG_SDIO_HISR_RX_REQUEST) {
++		hisr &= ~REG_SDIO_HISR_RX_REQUEST;
++		rtw_sdio_rx_isr(rtwdev);
++	}
++
++	rtw_write32(rtwdev, REG_SDIO_HISR, hisr);
++
++	rtwsdio->irq_thread = NULL;
++}
++
++static int __maybe_unused rtw_sdio_suspend(struct device *dev)
++{
++	struct sdio_func *func = dev_to_sdio_func(dev);
++	struct ieee80211_hw *hw = dev_get_drvdata(dev);
++	struct rtw_dev *rtwdev = hw->priv;
++	int ret;
++
++	ret = sdio_set_host_pm_flags(func, MMC_PM_KEEP_POWER);
++	if (ret)
++		rtw_err(rtwdev, "Failed to host PM flag MMC_PM_KEEP_POWER");
++
++	return ret;
++}
++
++static int __maybe_unused rtw_sdio_resume(struct device *dev)
++{
++	return 0;
++}
++
++SIMPLE_DEV_PM_OPS(rtw_sdio_pm_ops, rtw_sdio_suspend, rtw_sdio_resume);
++EXPORT_SYMBOL(rtw_sdio_pm_ops);
++
++static int rtw_sdio_claim(struct rtw_dev *rtwdev, struct sdio_func *sdio_func)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	int ret;
++
++	sdio_claim_host(sdio_func);
++
++	ret = sdio_enable_func(sdio_func);
++	if (ret) {
++		rtw_err(rtwdev, "Failed to enable SDIO func");
++		goto err_release_host;
++	}
++
++	ret = sdio_set_block_size(sdio_func, RTW_SDIO_BLOCK_SIZE);
++	if (ret) {
++		rtw_err(rtwdev, "Failed to set SDIO block size to 512");
++		goto err_disable_func;
++	}
++
++	rtwsdio->sdio_func = sdio_func;
++
++	rtwsdio->sdio3_bus_mode = mmc_card_uhs(sdio_func->card);
++
++	sdio_set_drvdata(sdio_func, rtwdev->hw);
++	SET_IEEE80211_DEV(rtwdev->hw, &sdio_func->dev);
++
++	sdio_release_host(sdio_func);
++
++	return 0;
++
++err_disable_func:
++	sdio_disable_func(sdio_func);
++err_release_host:
++	sdio_release_host(sdio_func);
++	return ret;
++}
++
++static void rtw_sdio_declaim(struct rtw_dev *rtwdev,
++			     struct sdio_func *sdio_func)
++{
++	sdio_claim_host(sdio_func);
++	sdio_disable_func(sdio_func);
++	sdio_release_host(sdio_func);
++}
++
++static struct rtw_hci_ops rtw_sdio_ops = {
++	.tx_write = rtw_sdio_tx_write,
++	.tx_kick_off = rtw_sdio_tx_kick_off,
++	.setup = rtw_sdio_setup,
++	.start = rtw_sdio_start,
++	.stop = rtw_sdio_stop,
++	.deep_ps = rtw_sdio_deep_ps,
++	.link_ps = rtw_sdio_link_ps,
++	.interface_cfg = rtw_sdio_interface_cfg,
++
++	.read8 = rtw_sdio_read8,
++	.read16 = rtw_sdio_read16,
++	.read32 = rtw_sdio_read32,
++	.write8 = rtw_sdio_write8,
++	.write16 = rtw_sdio_write16,
++	.write32 = rtw_sdio_write32,
++	.write_data_rsvd_page = rtw_sdio_write_data_rsvd_page,
++	.write_data_h2c = rtw_sdio_write_data_h2c,
++};
++
++static int rtw_sdio_request_irq(struct rtw_dev *rtwdev,
++				struct sdio_func *sdio_func)
++{
++	int ret;
++
++	sdio_claim_host(sdio_func);
++	ret = sdio_claim_irq(sdio_func, &rtw_sdio_handle_interrupt);
++	sdio_release_host(sdio_func);
++
++	if (ret) {
++		rtw_err(rtwdev, "failed to claim SDIO IRQ");
++		return ret;
++	}
++
++	return 0;
++}
++
++static void rtw_sdio_indicate_tx_status(struct rtw_dev *rtwdev,
++					struct sk_buff *skb)
++{
++	struct rtw_sdio_tx_data *tx_data = rtw_sdio_get_tx_data(skb);
++	struct ieee80211_tx_info *info = IEEE80211_SKB_CB(skb);
++	struct ieee80211_hw *hw = rtwdev->hw;
++
++	/* enqueue to wait for tx report */
++	if (info->flags & IEEE80211_TX_CTL_REQ_TX_STATUS) {
++		rtw_tx_report_enqueue(rtwdev, skb, tx_data->sn);
++		return;
++	}
++
++	/* always ACK for others, then they won't be marked as drop */
++	ieee80211_tx_info_clear_status(info);
++	if (info->flags & IEEE80211_TX_CTL_NO_ACK)
++		info->flags |= IEEE80211_TX_STAT_NOACK_TRANSMITTED;
++	else
++		info->flags |= IEEE80211_TX_STAT_ACK;
++
++	ieee80211_tx_status_irqsafe(hw, skb);
++}
++
++static void rtw_sdio_process_tx_queue(struct rtw_dev *rtwdev,
++				      enum rtw_tx_queue_type queue)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	struct sk_buff *skb;
++	int ret;
++
++	skb = skb_dequeue(&rtwsdio->tx_queue[queue]);
++	if (!skb)
++		return;
++
++	ret = rtw_sdio_write_port(rtwdev, skb, queue);
++	if (ret) {
++		skb_queue_head(&rtwsdio->tx_queue[queue], skb);
++		return;
++	}
++
++	if (queue <= RTW_TX_QUEUE_VO)
++		rtw_sdio_indicate_tx_status(rtwdev, skb);
++	else
++		dev_kfree_skb_any(skb);
++}
++
++static void rtw_sdio_tx_handler(struct work_struct *work)
++{
++	struct rtw_sdio_work_data *work_data =
++		container_of(work, struct rtw_sdio_work_data, work);
++	struct rtw_sdio *rtwsdio;
++	struct rtw_dev *rtwdev;
++	int limit, queue;
++
++	rtwdev = work_data->rtwdev;
++	rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++
++	if (!rtw_fw_feature_check(&rtwdev->fw, FW_FEATURE_TX_WAKE))
++		rtw_sdio_deep_ps_leave(rtwdev);
++
++	for (queue = RTK_MAX_TX_QUEUE_NUM - 1; queue >= 0; queue--) {
++		for (limit = 0; limit < 1000; limit++) {
++			rtw_sdio_process_tx_queue(rtwdev, queue);
++
++			if (skb_queue_empty(&rtwsdio->tx_queue[queue]))
++				break;
++		}
++	}
++}
++
++static void rtw_sdio_free_irq(struct rtw_dev *rtwdev,
++			      struct sdio_func *sdio_func)
++{
++	sdio_claim_host(sdio_func);
++	sdio_release_irq(sdio_func);
++	sdio_release_host(sdio_func);
++}
++
++static int rtw_sdio_init_tx(struct rtw_dev *rtwdev)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	int i;
++
++	rtwsdio->txwq = create_singlethread_workqueue("rtw88_sdio: tx wq");
++	if (!rtwsdio->txwq) {
++		rtw_err(rtwdev, "failed to create TX work queue\n");
++		return -ENOMEM;
++	}
++
++	for (i = 0; i < RTK_MAX_TX_QUEUE_NUM; i++)
++		skb_queue_head_init(&rtwsdio->tx_queue[i]);
++	rtwsdio->tx_handler_data = kmalloc(sizeof(*rtwsdio->tx_handler_data),
++					   GFP_KERNEL);
++	if (!rtwsdio->tx_handler_data)
++		goto err_destroy_wq;
++
++	rtwsdio->tx_handler_data->rtwdev = rtwdev;
++	INIT_WORK(&rtwsdio->tx_handler_data->work, rtw_sdio_tx_handler);
++
++	return 0;
++
++err_destroy_wq:
++	destroy_workqueue(rtwsdio->txwq);
++	return -ENOMEM;
++}
++
++static void rtw_sdio_deinit_tx(struct rtw_dev *rtwdev)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++	int i;
++
++	for (i = 0; i < RTK_MAX_TX_QUEUE_NUM; i++)
++		skb_queue_purge(&rtwsdio->tx_queue[i]);
++
++	flush_workqueue(rtwsdio->txwq);
++	destroy_workqueue(rtwsdio->txwq);
++	kfree(rtwsdio->tx_handler_data);
++}
++
++int rtw_sdio_probe(struct sdio_func *sdio_func,
++		   const struct sdio_device_id *id)
++{
++	struct ieee80211_hw *hw;
++	struct rtw_dev *rtwdev;
++	int drv_data_size;
++	int ret;
++
++	drv_data_size = sizeof(struct rtw_dev) + sizeof(struct rtw_sdio);
++	hw = ieee80211_alloc_hw(drv_data_size, &rtw_ops);
++	if (!hw) {
++		dev_err(&sdio_func->dev, "failed to allocate hw");
++		return -ENOMEM;
++	}
++
++	rtwdev = hw->priv;
++	rtwdev->hw = hw;
++	rtwdev->dev = &sdio_func->dev;
++	rtwdev->chip = (struct rtw_chip_info *)id->driver_data;
++	rtwdev->hci.ops = &rtw_sdio_ops;
++	rtwdev->hci.type = RTW_HCI_TYPE_SDIO;
++
++	ret = rtw_core_init(rtwdev);
++	if (ret)
++		goto err_release_hw;
++
++	rtw_dbg(rtwdev, RTW_DBG_SDIO,
++		"rtw88 SDIO probe: vendor=0x%04x device=%04x class=%02x",
++		id->vendor, id->device, id->class);
++
++	ret = rtw_sdio_claim(rtwdev, sdio_func);
++	if (ret) {
++		rtw_err(rtwdev, "failed to claim SDIO device");
++		goto err_deinit_core;
++	}
++
++	rtw_sdio_init(rtwdev);
++
++	ret = rtw_sdio_init_tx(rtwdev);
++	if (ret) {
++		rtw_err(rtwdev, "failed to init SDIO TX queue\n");
++		goto err_sdio_declaim;
++	}
++
++	ret = rtw_chip_info_setup(rtwdev);
++	if (ret) {
++		rtw_err(rtwdev, "failed to setup chip information");
++		goto err_destroy_txwq;
++	}
++
++	ret = rtw_sdio_request_irq(rtwdev, sdio_func);
++	if (ret)
++		goto err_destroy_txwq;
++
++	ret = rtw_register_hw(rtwdev, hw);
++	if (ret) {
++		rtw_err(rtwdev, "failed to register hw");
++		goto err_free_irq;
++	}
++
++	return 0;
++
++err_free_irq:
++	rtw_sdio_free_irq(rtwdev, sdio_func);
++err_destroy_txwq:
++	rtw_sdio_deinit_tx(rtwdev);
++err_sdio_declaim:
++	rtw_sdio_declaim(rtwdev, sdio_func);
++err_deinit_core:
++	rtw_core_deinit(rtwdev);
++err_release_hw:
++	ieee80211_free_hw(hw);
++
++	return ret;
++}
++EXPORT_SYMBOL(rtw_sdio_probe);
++
++void rtw_sdio_remove(struct sdio_func *sdio_func)
++{
++	struct ieee80211_hw *hw = sdio_get_drvdata(sdio_func);
++	struct rtw_dev *rtwdev;
++
++	if (!hw)
++		return;
++
++	rtwdev = hw->priv;
++
++	rtw_unregister_hw(rtwdev, hw);
++	rtw_sdio_disable_interrupt(rtwdev);
++	rtw_sdio_free_irq(rtwdev, sdio_func);
++	rtw_sdio_declaim(rtwdev, sdio_func);
++	rtw_sdio_deinit_tx(rtwdev);
++	rtw_core_deinit(rtwdev);
++	ieee80211_free_hw(hw);
++}
++EXPORT_SYMBOL(rtw_sdio_remove);
++
++void rtw_sdio_shutdown(struct device *dev)
++{
++	struct sdio_func *sdio_func = dev_to_sdio_func(dev);
++	const struct rtw_chip_info *chip;
++	struct ieee80211_hw *hw;
++	struct rtw_dev *rtwdev;
++
++	hw = sdio_get_drvdata(sdio_func);
++	if (!hw)
++		return;
++
++	rtwdev = hw->priv;
++	chip = rtwdev->chip;
++
++	if (chip->ops->shutdown)
++		chip->ops->shutdown(rtwdev);
++}
++EXPORT_SYMBOL(rtw_sdio_shutdown);
++
++MODULE_AUTHOR("Martin Blumenstingl");
++MODULE_AUTHOR("Jernej Skrabec");
++MODULE_DESCRIPTION("Realtek 802.11ac wireless SDIO driver");
++MODULE_LICENSE("Dual BSD/GPL");
+diff --git a/drivers/net/wireless/realtek/rtw88/sdio.h b/drivers/net/wireless/realtek/rtw88/sdio.h
+new file mode 100644
+index 000000000000..3c659ed180f0
+--- /dev/null
++++ b/drivers/net/wireless/realtek/rtw88/sdio.h
+@@ -0,0 +1,178 @@
++/* SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause */
++/* Copyright (C) 2021 Martin Blumenstingl <martin.blumenstingl@googlemail.com>
++ * Copyright (C) 2021 Jernej Skrabec <jernej.skrabec@gmail.com>
++ */
++
++#ifndef __REG_SDIO_H_
++#define __REG_SDIO_H_
++
++/* I/O bus domain address mapping */
++#define SDIO_LOCAL_OFFSET			0x10250000
++#define WLAN_IOREG_OFFSET			0x10260000
++#define FIRMWARE_FIFO_OFFSET			0x10270000
++#define TX_HIQ_OFFSET				0x10310000
++#define TX_MIQ_OFFSET				0x10320000
++#define TX_LOQ_OFFSET				0x10330000
++#define TX_EPQ_OFFSET				0x10350000
++#define RX_RX0FF_OFFSET				0x10340000
++
++#define RTW_SDIO_BUS_MSK			0xffff0000
++#define SDIO_LOCAL_REG_MSK			0x00000fff
++#define WLAN_IOREG_REG_MSK			0x0000ffff
++
++/* SDIO Tx Control */
++#define REG_SDIO_TX_CTRL			(SDIO_LOCAL_OFFSET + 0x0000)
++
++/*SDIO status timeout*/
++#define REG_SDIO_TIMEOUT			(SDIO_LOCAL_OFFSET + 0x0002)
++
++/* SDIO Host Interrupt Mask */
++#define REG_SDIO_HIMR				(SDIO_LOCAL_OFFSET + 0x0014)
++#define REG_SDIO_HIMR_RX_REQUEST		BIT(0)
++#define REG_SDIO_HIMR_AVAL			BIT(1)
++#define REG_SDIO_HIMR_TXERR			BIT(2)
++#define REG_SDIO_HIMR_RXERR			BIT(3)
++#define REG_SDIO_HIMR_TXFOVW			BIT(4)
++#define REG_SDIO_HIMR_RXFOVW			BIT(5)
++#define REG_SDIO_HIMR_TXBCNOK			BIT(6)
++#define REG_SDIO_HIMR_TXBCNERR			BIT(7)
++#define REG_SDIO_HIMR_BCNERLY_INT		BIT(16)
++#define REG_SDIO_HIMR_C2HCMD			BIT(17)
++#define REG_SDIO_HIMR_CPWM1			BIT(18)
++#define REG_SDIO_HIMR_CPWM2			BIT(19)
++#define REG_SDIO_HIMR_HSISR_IND			BIT(20)
++#define REG_SDIO_HIMR_GTINT3_IND		BIT(21)
++#define REG_SDIO_HIMR_GTINT4_IND		BIT(22)
++#define REG_SDIO_HIMR_PSTIMEOUT			BIT(23)
++#define REG_SDIO_HIMR_OCPINT			BIT(24)
++#define REG_SDIO_HIMR_ATIMEND			BIT(25)
++#define REG_SDIO_HIMR_ATIMEND_E			BIT(26)
++#define REG_SDIO_HIMR_CTWEND			BIT(27)
++/* the following two are RTL8188 SDIO Specific */
++#define REG_SDIO_HIMR_MCU_ERR			BIT(28)
++#define REG_SDIO_HIMR_TSF_BIT32_TOGGLE		BIT(29)
++
++/* SDIO Host Interrupt Service Routine */
++#define REG_SDIO_HISR				(SDIO_LOCAL_OFFSET + 0x0018)
++#define REG_SDIO_HISR_RX_REQUEST		BIT(0)
++#define REG_SDIO_HISR_AVAL			BIT(1)
++#define REG_SDIO_HISR_TXERR			BIT(2)
++#define REG_SDIO_HISR_RXERR			BIT(3)
++#define REG_SDIO_HISR_TXFOVW			BIT(4)
++#define REG_SDIO_HISR_RXFOVW			BIT(5)
++#define REG_SDIO_HISR_TXBCNOK			BIT(6)
++#define REG_SDIO_HISR_TXBCNERR			BIT(7)
++#define REG_SDIO_HISR_BCNERLY_INT		BIT(16)
++#define REG_SDIO_HISR_C2HCMD			BIT(17)
++#define REG_SDIO_HISR_CPWM1			BIT(18)
++#define REG_SDIO_HISR_CPWM2			BIT(19)
++#define REG_SDIO_HISR_HSISR_IND			BIT(20)
++#define REG_SDIO_HISR_GTINT3_IND		BIT(21)
++#define REG_SDIO_HISR_GTINT4_IND		BIT(22)
++#define REG_SDIO_HISR_PSTIMEOUT			BIT(23)
++#define REG_SDIO_HISR_OCPINT			BIT(24)
++#define REG_SDIO_HISR_ATIMEND			BIT(25)
++#define REG_SDIO_HISR_ATIMEND_E			BIT(26)
++#define REG_SDIO_HISR_CTWEND			BIT(27)
++/* the following two are RTL8188 SDIO Specific */
++#define REG_SDIO_HISR_MCU_ERR			BIT(28)
++#define REG_SDIO_HISR_TSF_BIT32_TOGGLE		BIT(29)
++
++/* HCI Current Power Mode */
++#define REG_SDIO_HCPWM				(SDIO_LOCAL_OFFSET + 0x0019)
++/* RXDMA Request Length */
++#define REG_SDIO_RX0_REQ_LEN			(SDIO_LOCAL_OFFSET + 0x001C)
++/* OQT Free Page */
++#define REG_SDIO_OQT_FREE_PG			(SDIO_LOCAL_OFFSET + 0x001E)
++/* Free Tx Buffer Page */
++#define REG_SDIO_FREE_TXPG			(SDIO_LOCAL_OFFSET + 0x0020)
++/* HCI Current Power Mode 1 */
++#define REG_SDIO_HCPWM1				(SDIO_LOCAL_OFFSET + 0x0024)
++/* HCI Current Power Mode 2 */
++#define REG_SDIO_HCPWM2				(SDIO_LOCAL_OFFSET + 0x0026)
++/* Free Tx Page Sequence */
++#define REG_SDIO_FREE_TXPG_SEQ			(SDIO_LOCAL_OFFSET + 0x0028)
++/* HTSF Information */
++#define REG_SDIO_HTSFR_INFO			(SDIO_LOCAL_OFFSET + 0x0030)
++#define REG_SDIO_HCPWM1_V2			(SDIO_LOCAL_OFFSET + 0x0038)
++/* H2C */
++#define REG_SDIO_H2C				(SDIO_LOCAL_OFFSET + 0x0060)
++/* HCI Request Power Mode 1 */
++#define REG_SDIO_HRPWM1				(SDIO_LOCAL_OFFSET + 0x0080)
++/* HCI Request Power Mode 2 */
++#define REG_SDIO_HRPWM2				(SDIO_LOCAL_OFFSET + 0x0082)
++/* HCI Power Save Clock */
++#define REG_SDIO_HPS_CLKR			(SDIO_LOCAL_OFFSET + 0x0084)
++/* SDIO HCI Suspend Control */
++#define REG_SDIO_HSUS_CTRL			(SDIO_LOCAL_OFFSET + 0x0086)
++#define BIT_HCI_SUS_REQ				BIT(0)
++#define BIT_HCI_RESUME_RDY			BIT(1)
++/* SDIO Host Extension Interrupt Mask Always */
++#define REG_SDIO_HIMR_ON			(SDIO_LOCAL_OFFSET + 0x0090)
++/* SDIO Host Extension Interrupt Status Always */
++#define REG_SDIO_HISR_ON			(SDIO_LOCAL_OFFSET + 0x0091)
++
++#define REG_SDIO_INDIRECT_REG_CFG		(SDIO_LOCAL_OFFSET + 0x0040)
++#define BIT_SDIO_INDIRECT_REG_CFG_WORD		BIT(16)
++#define BIT_SDIO_INDIRECT_REG_CFG_DWORD		BIT(17)
++#define BIT_SDIO_INDIRECT_REG_CFG_WRITE		BIT(18)
++#define BIT_SDIO_INDIRECT_REG_CFG_READ		BIT(19)
++#define BIT_SDIO_INDIRECT_REG_CFG_UNK20		BIT(20)
++#define REG_SDIO_INDIRECT_REG_DATA		(SDIO_LOCAL_OFFSET + 0x0044)
++
++/* Sdio Address for SDIO Local Reg, TRX FIFO, MAC Reg */
++#define REG_SDIO_CMD_ADDR_MSK			GENMASK(16, 13)
++#define REG_SDIO_CMD_ADDR_SDIO_REG		0
++#define REG_SDIO_CMD_ADDR_MAC_REG		8
++#define REG_SDIO_CMD_ADDR_TXFF_HIGH		4
++#define REG_SDIO_CMD_ADDR_TXFF_LOW		6
++#define REG_SDIO_CMD_ADDR_TXFF_NORMAL		5
++#define REG_SDIO_CMD_ADDR_TXFF_EXTRA		7
++#define REG_SDIO_CMD_ADDR_RXFF			7
++
++#define RTW_SDIO_BLOCK_SIZE			512
++#define RTW_SDIO_ADDR_RX_RX0FF_GEN(_id)		(0x0e000 | ((_id) & 0x3))
++
++#define RTW_SDIO_DATA_PTR_ALIGN			8
++
++struct sdio_func;
++struct sdio_device_id;
++
++struct rtw_sdio_tx_data {
++	u8 sn;
++};
++
++struct rtw_sdio_work_data {
++	struct work_struct work;
++	struct rtw_dev *rtwdev;
++};
++
++struct rtw_sdio {
++	struct sdio_func *sdio_func;
++
++	u32 irq_mask;
++	u8 rx_addr;
++	bool sdio3_bus_mode;
++
++	void *irq_thread;
++
++	struct workqueue_struct *txwq;
++	struct rtw_sdio_work_data *tx_handler_data;
++	struct sk_buff_head tx_queue[RTK_MAX_TX_QUEUE_NUM];
++};
++
++extern const struct dev_pm_ops rtw_sdio_pm_ops;
++
++int rtw_sdio_probe(struct sdio_func *sdio_func,
++		   const struct sdio_device_id *id);
++void rtw_sdio_remove(struct sdio_func *sdio_func);
++void rtw_sdio_shutdown(struct device *dev);
++
++static inline bool rtw_sdio_is_sdio30_supported(struct rtw_dev *rtwdev)
++{
++	struct rtw_sdio *rtwsdio = (struct rtw_sdio *)rtwdev->priv;
++
++	return rtwsdio->sdio3_bus_mode;
++}
++
++#endif
+-- 
+2.39.2
+


### PR DESCRIPTION
Re-add rtw88 patches for kernels 6.2 and 6.3 as they are still used.

001 and 002 have been merged into one patch to match the changes made in PR: https://github.com/armbian/build/pull/5697

Resolves: https://github.com/armbian/build/pull/5699

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
