### PR TITLE
Fix uwe5622 driver patch

### DIFF
--- a/patch/misc/wireless-driver-for-uwe5622-park-link-v6.1-post.patch
+++ b/patch/misc/wireless-driver-for-uwe5622-park-link-v6.1-post.patch
@@ -28,20 +28,19 @@ diff --git a/drivers/bluetooth/hci_ldisc.c b/drivers/bluetooth/hci_ldisc.c
 diff --git a/include/net/bluetooth/hci.h b/include/net/bluetooth/hci.h
 --- a/include/net/bluetooth/hci.h	(revision 58aa050aa57333b34b358234002121c59fb3af26)
 +++ b/include/net/bluetooth/hci.h	(revision bf8ab2f58b21494ffde96979431a3da931deb48b)
-@@ -309,6 +309,13 @@
- 	 * to support it.
- 	 */
- 	HCI_QUIRK_BROKEN_SET_RPA_TIMEOUT,
-+	
+@@ -309,6 +309,12 @@
+ 
+ /* HCI device quirks */
+ enum {
 +	/*
 +	 * Device declares that support Park link status, but it really
 +	 * does not support it and fails to initialize
 +	 */
 +	HCI_QUIRK_BROKEN_PARK_LINK_STATUS,
-+	
- };
- 
- /* HCI device flags */
++
+ 	/* When this quirk is set, the HCI Reset command is send when
+ 	 * closing the transport instead of when opening it.
+ 	 *
 diff --git a/net/bluetooth/hci_sync.c b/net/bluetooth/hci_sync.c
 --- a/net/bluetooth/hci_sync.c	(revision 58aa050aa57333b34b358234002121c59fb3af26)
 +++ b/net/bluetooth/hci_sync.c	(revision bf8ab2f58b21494ffde96979431a3da931deb48b)


### PR DESCRIPTION
# Description

New BT quirk entry rendered our patch into broken one. 

# How Has This Been Tested?

- [x] Tested on 6.5
- [x] Tested on 6.1

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
