### PR TITLE
add xorg.conf.d/01-armbian-defaults.conf to conffiles

### DIFF
--- a/lib/functions/bsp/armbian-bsp-cli-deb.sh
+++ b/lib/functions/bsp/armbian-bsp-cli-deb.sh
@@ -153,6 +153,7 @@ function compile_armbian-bsp-cli() {
 	# Keeping armbian-apt-updates as a configuration, solve the problem
 	cat <<- EOF > "${destination}"/DEBIAN/conffiles
 		/usr/lib/armbian/armbian-apt-updates
+		/etc/X11/xorg.conf.d/01-armbian-defaults.conf
 	EOF
 
 	# trigger uInitrd creation after installation, to apply


### PR DESCRIPTION
# Description

I was accidentally burned when updating my BSP package this week. I had inadvertently left some important xorg config in `01-armbian-defaults.conf`, and this file was overwritten during the upgrade.

I came to the conclusion that either:
1. the comment in `01-armbian-defaults.conf` should be updated to indicate to users that the file may be overwritten and should not be edited, or
2. `01-armbian-defaults.conf` should be placed in the `conffiles` list so that an end-user can review any potential changes to the file as part of the package upgrade process.

I contend that option (2) is better, because even if a user hasn't edited this file, they should still get some notice if it change. This way they can verify those changes and if their xorg suddenly stops working after an upgrade, they have some indication of the cause.

# How Has This Been Tested?

Did not test it.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
