### PR TITLE
JetHome: Update /dev/serial/rs485 symlink names

### DIFF
--- a/packages/bsp/jethub/jethubj100/90-jethub-rs485-aliases.rules
+++ b/packages/bsp/jethub/jethubj100/90-jethub-rs485-aliases.rules
@@ -16,7 +16,7 @@ ENV{ID_USB_INTERFACE_NUM}=="", GOTO="serial_end"
 # CP2105, rev >1.8
 ENV{ID_PATH}=="platform-xhci-hcd.0.auto-usb-0:1.1:1.*", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea70", SYMLINK+="serial/rs485/ttyRS485-$env{ID_USB_INTERFACE_NUM}"
 # CP2104, rev <=1.8
-ENV{ID_PATH}=="platform-xhci-hcd.0.auto-usb-0:1.1:1.0", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", SYMLINK+="serial/rs485/ttyRS485-0"
-ENV{ID_PATH}=="platform-xhci-hcd.0.auto-usb-0:1.2:1.0", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", SYMLINK+="serial/rs485/ttyRS485-1"
+ENV{ID_PATH}=="platform-xhci-hcd.0.auto-usb-0:1.1:1.0", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", SYMLINK+="serial/rs485/ttyRS485-00"
+ENV{ID_PATH}=="platform-xhci-hcd.0.auto-usb-0:1.2:1.0", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", SYMLINK+="serial/rs485/ttyRS485-01"
 
 LABEL="serial_end"


### PR DESCRIPTION
# Description

Update for AR-1553: Update symlink names for RS485 Adapters on JetHub D1/D1+.
Simple change.

Jira reference number [AR-1553]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1553]: https://armbian.atlassian.net/browse/AR-1553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ