### PR TITLE
Enhance default boot partition size for installer

### DIFF
--- a/packages/bsp/common/usr/sbin/armbian-install
+++ b/packages/bsp/common/usr/sbin/armbian-install
@@ -572,7 +572,7 @@ format_emmc()
 		fi
 
 		# default boot partition size, in MiB
-		DEFAULT_BOOTSIZE=256
+		DEFAULT_BOOTSIZE=512
 
 		# (convert to sectors for partitioning)
 		DEFAULT_BOOTSIZE_SECTORS=$(((${DEFAULT_BOOTSIZE} * 1024 * 1024) / 512))


### PR DESCRIPTION
# Description

This will prevent running into "No space left on device" pretty soon.

# How Has This Been Tested?

Just config value change.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
