### PR TITLE
Add support for Inovato Quadra

### DIFF
--- a/config/boards/inovato-quadra.csc
+++ b/config/boards/inovato-quadra.csc
@@ -1,0 +1,14 @@
+# Allwinner H6 quad core 2GB SoC WiFi eMMC
+BOARD_NAME="Inovato Quadra"
+BOARDFAMILY="sun50iw6"
+BOARD_MAINTAINER=""
+BOOTCONFIG="tanix_tx6_defconfig"
+CRUSTCONFIG="tanix_tx6_defconfig"
+BOOT_FDT_FILE="allwinner/sun50i-h6-inovato-quadra.dtb"
+KERNEL_TARGET="current,edge"
+KERNEL_TEST_TARGET="current,edge"
+BOOT_LOGO="desktop"
+FULL_DESKTOP="yes"
+SRC_EXTLINUX="yes"
+SRC_CMDLINE="console=ttyS0,115200 console=tty0 mem=2048M video=HDMI-A-1:e"
+OFFSET=16

--- a/patch/kernel/archive/sunxi-6.1/patches.armbian/arm64-dts-add-wifi-nodes-for-Inovato-Quadra.patch
+++ b/patch/kernel/archive/sunxi-6.1/patches.armbian/arm64-dts-add-wifi-nodes-for-Inovato-Quadra.patch
@@ -1,0 +1,88 @@
+From 40ec552ecc7efdd9056dde65fa7429e917ff6c5b Mon Sep 17 00:00:00 2001
+From: Gunjan Gupta <viraniac@gmail.com>
+Date: Tue, 19 Sep 2023 11:06:01 +0000
+Subject: [PATCH] Add wifi nodes for Inovato Quadra
+
+---
+ arch/arm64/boot/dts/allwinner/Makefile        |  1 +
+ .../allwinner/sun50i-h6-inovato-quadra.dts   | 56 +++++++++++++++++++
+ 2 files changed, 57 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h6-innovato-quadra.dts
+
+diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
+index 4d0c4843b21c..0275884b73e1 100644
+--- a/arch/arm64/boot/dts/allwinner/Makefile
++++ b/arch/arm64/boot/dts/allwinner/Makefile
+@@ -52,6 +52,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-orangepi-one-plus.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-pine-h64.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-pine-h64-model-b.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6.dtb
++dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-inovato-quadra.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6-mini.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-orangepi-zero2.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-x96-mate.dtb
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h6-inovato-quadra.dts b/arch/arm64/boot/dts/allwinner/sun50i-h6-inovato-quadra.dts
+new file mode 100644
+index 000000000000..1036e9896ff9
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h6-inovato-quadra.dts
+@@ -0,0 +1,56 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++// Copyright (c) 2023 Gunjan Gupta <gunjan@armbian.com>
++
++/dts-v1/;
++
++#include "sun50i-h6-tanix.dtsi"
++
++/ {
++	model = "Inovato Quadra";
++	compatible = "oranth,inovato-quadra", "allwinner,sun50i-h6";
++
++	aliases {
++		ethernet1 = &xr819;
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led-0 {
++			label = "red";
++			gpios = <&r_pio 0 4 GPIO_ACTIVE_HIGH>; /* PL4 */
++		};
++
++		led-1 {
++			label = "blue";
++			gpios = <&r_pio 0 7 GPIO_ACTIVE_HIGH>; /* PL7 */
++			default-state = "on";
++		};
++	};
++};
++
++&i2s1 {
++	status = "okay";
++};
++
++&mmc1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mmc1_pins>;
++
++	xr819: sdio_wifi@1 {
++		compatible = "xradio,xr819";
++		interrupt-names = "host-wake";
++		interrupt-parent = <&r_pio>;
++		interrupts = <1 0 IRQ_TYPE_EDGE_RISING>;
++		local-mac-address = [dc 44 6d c0 ff ee];
++		reg = <1>;
++	};
++};
++
++&sound_hdmi {
++	status = "okay";
++};
++
++&wifi_pwrseq {
++	post-power-on-delay-ms = <0xc8>;
++};
+-- 
+2.34.1
+

--- a/patch/kernel/archive/sunxi-6.1/series.armbian
+++ b/patch/kernel/archive/sunxi-6.1/series.armbian
@@ -186,3 +186,4 @@
 	patches.armbian/add-nodes-for-sunxi-info-addr-dump-reg.patch
 	patches.armbian/add-initial-support-for-orangepi3-lts.patch
 	patches.armbian/drivers-input-axp20x-pek-allow-wakeup-after-shutdown.patch
+	patches.armbian/arm64-dts-add-wifi-nodes-for-Inovato-Quadra.patch

--- a/patch/kernel/archive/sunxi-6.1/series.conf
+++ b/patch/kernel/archive/sunxi-6.1/series.conf
@@ -590,3 +590,4 @@
 	patches.armbian/add-nodes-for-sunxi-info-addr-dump-reg.patch
 	patches.armbian/add-initial-support-for-orangepi3-lts.patch
 	patches.armbian/drivers-input-axp20x-pek-allow-wakeup-after-shutdown.patch
+	patches.armbian/arm64-dts-add-wifi-nodes-for-Inovato-Quadra.patch

--- a/patch/kernel/archive/sunxi-6.5/patches.armbian/arm64-dts-add-wifi-nodes-for-Inovato-Quadra.patch
+++ b/patch/kernel/archive/sunxi-6.5/patches.armbian/arm64-dts-add-wifi-nodes-for-Inovato-Quadra.patch
@@ -1,0 +1,88 @@
+From 40ec552ecc7efdd9056dde65fa7429e917ff6c5b Mon Sep 17 00:00:00 2001
+From: Gunjan Gupta <viraniac@gmail.com>
+Date: Tue, 19 Sep 2023 11:06:01 +0000
+Subject: [PATCH] Add wifi nodes for Inovato Quadra
+
+---
+ arch/arm64/boot/dts/allwinner/Makefile        |  1 +
+ .../allwinner/sun50i-h6-inovato-quadra.dts   | 56 +++++++++++++++++++
+ 2 files changed, 57 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h6-innovato-quadra.dts
+
+diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
+index 4d0c4843b21c..0275884b73e1 100644
+--- a/arch/arm64/boot/dts/allwinner/Makefile
++++ b/arch/arm64/boot/dts/allwinner/Makefile
+@@ -52,6 +52,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-orangepi-one-plus.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-pine-h64.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-pine-h64-model-b.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6.dtb
++dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-inovato-quadra.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6-mini.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-orangepi-zero2.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-x96-mate.dtb
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h6-inovato-quadra.dts b/arch/arm64/boot/dts/allwinner/sun50i-h6-inovato-quadra.dts
+new file mode 100644
+index 000000000000..1036e9896ff9
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h6-inovato-quadra.dts
+@@ -0,0 +1,56 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++// Copyright (c) 2023 Gunjan Gupta <gunjan@armbian.com>
++
++/dts-v1/;
++
++#include "sun50i-h6-tanix.dtsi"
++
++/ {
++	model = "Inovato Quadra";
++	compatible = "oranth,inovato-quadra", "allwinner,sun50i-h6";
++
++	aliases {
++		ethernet1 = &xr819;
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led-0 {
++			label = "red";
++			gpios = <&r_pio 0 4 GPIO_ACTIVE_HIGH>; /* PL4 */
++		};
++
++		led-1 {
++			label = "blue";
++			gpios = <&r_pio 0 7 GPIO_ACTIVE_HIGH>; /* PL7 */
++			default-state = "on";
++		};
++	};
++};
++
++&i2s1 {
++	status = "okay";
++};
++
++&mmc1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mmc1_pins>;
++
++	xr819: sdio_wifi@1 {
++		compatible = "xradio,xr819";
++		interrupt-names = "host-wake";
++		interrupt-parent = <&r_pio>;
++		interrupts = <1 0 IRQ_TYPE_EDGE_RISING>;
++		local-mac-address = [dc 44 6d c0 ff ee];
++		reg = <1>;
++	};
++};
++
++&sound_hdmi {
++	status = "okay";
++};
++
++&wifi_pwrseq {
++	post-power-on-delay-ms = <0xc8>;
++};
+-- 
+2.34.1
+

--- a/patch/kernel/archive/sunxi-6.5/series.armbian
+++ b/patch/kernel/archive/sunxi-6.5/series.armbian
@@ -190,3 +190,4 @@
 	patches.armbian/add-nodes-for-sunxi-info-addr-dump-reg.patch
 	patches.armbian/add-initial-support-for-orangepi3-lts.patch
 	patches.armbian/drivers-input-axp20x-pek-allow-wakeup-after-shutdown.patch
+	patches.armbian/arm64-dts-add-wifi-nodes-for-Inovato-Quadra.patch

--- a/patch/kernel/archive/sunxi-6.5/series.conf
+++ b/patch/kernel/archive/sunxi-6.5/series.conf
@@ -668,3 +668,4 @@
 	patches.armbian/add-nodes-for-sunxi-info-addr-dump-reg.patch
 	patches.armbian/add-initial-support-for-orangepi3-lts.patch
 	patches.armbian/drivers-input-axp20x-pek-allow-wakeup-after-shutdown.patch
+	patches.armbian/arm64-dts-add-wifi-nodes-for-Inovato-Quadra.patch


### PR DESCRIPTION
# Description

This PR tries to add support for Inovato Quadra. Comparing the DT of Inovato Quadra with Tanix TX6 DT from our tree shows that they are almost identical. Only missing thing was DT node for xr819 wifi that is being added by a patch here. 

Jira reference number [AR-1487]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tenkawa tested the functionality on Inovato Quadra. Boots, display, sound, ethernet and wireless works. 

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1487]: https://armbian.atlassian.net/browse/AR-1487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ