### PR TITLE
Allwinner: bump legacy, current and edge kernels

### DIFF
--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -24,17 +24,17 @@ case $BRANCH in
 
 	legacy)
 		declare -g KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v5.15.131"
+		declare -g KERNELBRANCH="tag:v5.15.132"
 		;;
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.1.53"
+		declare -g KERNELBRANCH="tag:v6.1.54"
 		;;
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.5" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.5.3"
+		declare -g KERNELBRANCH="tag:v6.5.4"
 		;;
 esac
 

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -25,17 +25,17 @@ case $BRANCH in
 
 	legacy)
 		declare -g KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v5.15.131"
+		declare -g KERNELBRANCH="tag:v5.15.132"
 		;;
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.1.53"
+		declare -g KERNELBRANCH="tag:v6.1.54"
 		;;
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.5" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.5.3"
+		declare -g KERNELBRANCH="tag:v6.5.4"
 		;;
 esac
 


### PR DESCRIPTION
# Description

Legacy - 5.15.131 -> 5.15.132
Current - 6.1.53 -> 6.1.54
Edge - 6.5.3 -> 6.5.4

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Booted on Orange Pi Zero (sun8i H3)
- [X] Booted on Orange Pi Prime (sun50i H5)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
