### PR TITLE
RTW88: 6.5: Upstream wireless: `2023-09-23`

### DIFF
--- a/patch/misc/rtw88/6.5/001-drivers-net-wireless-realtek-rtw88-upstream-wireless.patch
+++ b/patch/misc/rtw88/6.5/001-drivers-net-wireless-realtek-rtw88-upstream-wireless.patch
@@ -1,23 +1,23 @@
-From 42d4fe9bfc6f43bb60898e845c6dea14f596ada8 Mon Sep 17 00:00:00 2001
+From fe3d1e82595fbc8f431cf5ff46c4fee1fc97b803 Mon Sep 17 00:00:00 2001
 From: Patrick Yavitz <pyavitz@xxxxx.com>
-Date: Sun, 27 Aug 2023 20:37:22 -0400
+Date: Sat, 23 Sep 2023 07:22:17 -0400
 Subject: [PATCH] drivers: net: wireless: realtek: rtw88: upstream wireless
 
 wireless-next: 2023-08-25: backport: linux-6.5.y
 
+Updated-on: 2023-09-23
 Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
 ---
  drivers/net/wireless/realtek/rtw88/fw.c   |  2 +-
- drivers/net/wireless/realtek/rtw88/main.c | 13 ++++++------
- drivers/net/wireless/realtek/rtw88/main.h |  9 --------
- drivers/net/wireless/realtek/rtw88/pci.c  |  2 +-
+ drivers/net/wireless/realtek/rtw88/main.c |  9 +++------
+ drivers/net/wireless/realtek/rtw88/main.h |  9 ---------
  drivers/net/wireless/realtek/rtw88/ps.c   |  6 ++----
  drivers/net/wireless/realtek/rtw88/tx.c   |  2 --
- drivers/net/wireless/realtek/rtw88/usb.c  | 25 +++++------------------
+ drivers/net/wireless/realtek/rtw88/usb.c  | 20 +-------------------
  drivers/net/wireless/realtek/rtw88/usb.h  |  7 -------
  drivers/net/wireless/realtek/rtw88/util.c |  7 ++-----
  drivers/net/wireless/realtek/rtw88/util.h |  3 +--
- 10 files changed, 18 insertions(+), 58 deletions(-)
+ 9 files changed, 10 insertions(+), 55 deletions(-)
 
 diff --git a/drivers/net/wireless/realtek/rtw88/fw.c b/drivers/net/wireless/realtek/rtw88/fw.c
 index 567bbedd8ee0..a1b674e3caaa 100644
@@ -33,7 +33,7 @@ index 567bbedd8ee0..a1b674e3caaa 100644
  {
  	struct rtw_beacon_filter_iter_data *iter_data = data;
 diff --git a/drivers/net/wireless/realtek/rtw88/main.c b/drivers/net/wireless/realtek/rtw88/main.c
-index c853e2f2d448..4a33d2e47f33 100644
+index c2ddb4d382af..4a33d2e47f33 100644
 --- a/drivers/net/wireless/realtek/rtw88/main.c
 +++ b/drivers/net/wireless/realtek/rtw88/main.c
 @@ -185,8 +185,7 @@ static void rtw_dynamic_csi_rate(struct rtw_dev *rtwdev, struct rtw_vif *rtwvif)
@@ -54,21 +54,7 @@ index c853e2f2d448..4a33d2e47f33 100644
  	si->sgi_enable = is_support_sgi;
  	si->vht_enable = is_vht_enable;
  	si->ra_mask = ra_mask;
-@@ -2183,10 +2181,12 @@ void rtw_core_deinit(struct rtw_dev *rtwdev)
- 		release_firmware(wow_fw->firmware);
- 
- 	destroy_workqueue(rtwdev->tx_wq);
-+	timer_delete_sync(&rtwdev->tx_report.purge_timer);
- 	spin_lock_irqsave(&rtwdev->tx_report.q_lock, flags);
- 	skb_queue_purge(&rtwdev->tx_report.queue);
--	skb_queue_purge(&rtwdev->coex.queue);
- 	spin_unlock_irqrestore(&rtwdev->tx_report.q_lock, flags);
-+	skb_queue_purge(&rtwdev->coex.queue);
-+	skb_queue_purge(&rtwdev->c2h_queue);
- 
- 	list_for_each_entry_safe(rsvd_pkt, tmp, &rtwdev->rsvd_page_list,
- 				 build_list) {
-@@ -2329,7 +2329,7 @@ struct rtw_iter_port_switch_data {
+@@ -2331,7 +2329,7 @@ struct rtw_iter_port_switch_data {
  	struct rtw_vif *rtwvif_ap;
  };
  
@@ -77,7 +63,7 @@ index c853e2f2d448..4a33d2e47f33 100644
  {
  	struct rtw_iter_port_switch_data *iter_data = data;
  	struct rtw_dev *rtwdev = iter_data->rtwdev;
-@@ -2381,8 +2381,7 @@ void rtw_core_port_switch(struct rtw_dev *rtwdev, struct ieee80211_vif *vif)
+@@ -2383,8 +2381,7 @@ void rtw_core_port_switch(struct rtw_dev *rtwdev, struct ieee80211_vif *vif)
  	rtw_iterate_vifs(rtwdev, rtw_port_switch_iter, &iter_data);
  }
  
@@ -122,17 +108,6 @@ index f9dd2ab941c8..c42ef8294d59 100644
  	u8 stbc_en:2;
  	u8 ldpc_en:2;
  	bool sgi_enable;
-diff --git a/drivers/net/wireless/realtek/rtw88/pci.c b/drivers/net/wireless/realtek/rtw88/pci.c
-index 44a8fff34cdd..2bfc0e822b8d 100644
---- a/drivers/net/wireless/realtek/rtw88/pci.c
-+++ b/drivers/net/wireless/realtek/rtw88/pci.c
-@@ -1828,5 +1828,5 @@ void rtw_pci_shutdown(struct pci_dev *pdev)
- EXPORT_SYMBOL(rtw_pci_shutdown);
- 
- MODULE_AUTHOR("Realtek Corporation");
--MODULE_DESCRIPTION("Realtek 802.11ac wireless PCI driver");
-+MODULE_DESCRIPTION("Realtek PCI 802.11ac wireless driver");
- MODULE_LICENSE("Dual BSD/GPL");
 diff --git a/drivers/net/wireless/realtek/rtw88/ps.c b/drivers/net/wireless/realtek/rtw88/ps.c
 index 43e80a3a8136..07e8cbd436cd 100644
 --- a/drivers/net/wireless/realtek/rtw88/ps.c
@@ -171,7 +146,7 @@ index 2821119dc930..f63900b6621d 100644
  }
  
 diff --git a/drivers/net/wireless/realtek/rtw88/usb.c b/drivers/net/wireless/realtek/rtw88/usb.c
-index 4a57efdba97b..d879d7e3dc81 100644
+index c279a500b4bd..091fec5c3c59 100644
 --- a/drivers/net/wireless/realtek/rtw88/usb.c
 +++ b/drivers/net/wireless/realtek/rtw88/usb.c
 @@ -142,7 +142,6 @@ static int rtw_usb_parse(struct rtw_dev *rtwdev,
@@ -213,32 +188,15 @@ index 4a57efdba97b..d879d7e3dc81 100644
  		rxcb->rtwdev = rtwusb->rtwdev;
  		rxcb->rx_urb = usb_alloc_urb(0, GFP_KERNEL);
  		if (!rxcb->rx_urb)
-@@ -844,7 +826,7 @@ int rtw_usb_probe(struct usb_interface *intf, const struct usb_device_id *id)
+@@ -840,7 +822,7 @@ int rtw_usb_probe(struct usb_interface *intf, const struct usb_device_id *id)
  
- 	ret = rtw_core_init(rtwdev);
+ 	ret = rtw_usb_alloc_rx_bufs(rtwusb);
  	if (ret)
 -		goto err_release_hw;
 +		goto err_free_rx_bufs;
  
- 	ret = rtw_usb_intf_init(rtwdev, intf);
- 	if (ret) {
-@@ -890,6 +872,9 @@ int rtw_usb_probe(struct usb_interface *intf, const struct usb_device_id *id)
- err_deinit_core:
- 	rtw_core_deinit(rtwdev);
- 
-+err_free_rx_bufs:
-+	rtw_usb_free_rx_bufs(rtwusb);
-+
- err_release_hw:
- 	ieee80211_free_hw(hw);
- 
-@@ -927,5 +912,5 @@ void rtw_usb_disconnect(struct usb_interface *intf)
- EXPORT_SYMBOL(rtw_usb_disconnect);
- 
- MODULE_AUTHOR("Realtek Corporation");
--MODULE_DESCRIPTION("Realtek 802.11ac wireless USB driver");
-+MODULE_DESCRIPTION("Realtek USB 802.11ac wireless driver");
- MODULE_LICENSE("Dual BSD/GPL");
+ 	ret = rtw_core_init(rtwdev);
+ 	if (ret)
 diff --git a/drivers/net/wireless/realtek/rtw88/usb.h b/drivers/net/wireless/realtek/rtw88/usb.h
 index ad1d7955c6a5..86697a5c0103 100644
 --- a/drivers/net/wireless/realtek/rtw88/usb.h
@@ -325,6 +283,36 @@ index dc8965525400..f8399128a9a3 100644
  		      void *data);
  void rtw_iterate_stas(struct rtw_dev *rtwdev,
  		      void (*iterator)(void *data,
+-- 
+2.39.2
+
+From c3e9aa8a14a350ffa2ed5a68e378a42da79b468c Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@xxxxx.com>
+Date: Sat, 23 Sep 2023 08:18:35 -0400
+Subject: [PATCH] drivers: net: wireless: realtek: rtw88: usb.c
+
+drivers/net/wireless/realtek/rtw88/usb.c: In function ‘rtw_usb_probe’:
+drivers/net/wireless/realtek/rtw88/usb.c:829:17: error: label ‘err_free_rx_bufs’ used but not defined
+  829 |                 goto err_free_rx_bufs;
+
+Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
+---
+ drivers/net/wireless/realtek/rtw88/usb.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/wireless/realtek/rtw88/usb.c b/drivers/net/wireless/realtek/rtw88/usb.c
+index 091fec5c3c59..7cdb6b548c6f 100644
+--- a/drivers/net/wireless/realtek/rtw88/usb.c
++++ b/drivers/net/wireless/realtek/rtw88/usb.c
+@@ -826,7 +826,7 @@ int rtw_usb_probe(struct usb_interface *intf, const struct usb_device_id *id)
+ 
+ 	ret = rtw_core_init(rtwdev);
+ 	if (ret)
+-		goto err_free_rx_bufs;
++		goto err_release_hw;
+ 
+ 	ret = rtw_usb_intf_init(rtwdev, intf);
+ 	if (ret) {
 -- 
 2.39.2
 
@@ -417,46 +405,4 @@ index 2c1fb2dabd40..b19262ec5d8c 100644
  		sdio_release_host(rtwsdio->sdio_func);
 -- 
 2.41.0
-
-From 248429fc23232f218d5bd81120eafad70038bd5f Mon Sep 17 00:00:00 2001
-From: Patrick Yavitz <pyavitz@xxxxx.com>
-Date: Wed, 6 Sep 2023 21:42:18 -0400
-Subject: [PATCH] drivers: net: wireless: realtek: rtw88: usb-c
-
-Remove duplicate label and correct goto err_release_hw placement.
-
-drivers/net/wireless/realtek/rtw88/usb.c: In function ‘rtw_usb_probe’:
-drivers/net/wireless/realtek/rtw88/usb.c:878:1: error: duplicate label ‘err_free_rx_bufs’
-  878 | err_free_rx_bufs:
-
-Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
----
- drivers/net/wireless/realtek/rtw88/usb.c | 5 +----
- 1 file changed, 1 insertion(+), 4 deletions(-)
-
-diff --git a/drivers/net/wireless/realtek/rtw88/usb.c b/drivers/net/wireless/realtek/rtw88/usb.c
-index 7f98668cf084..d879d7e3dc81 100644
---- a/drivers/net/wireless/realtek/rtw88/usb.c
-+++ b/drivers/net/wireless/realtek/rtw88/usb.c
-@@ -822,7 +822,7 @@ int rtw_usb_probe(struct usb_interface *intf, const struct usb_device_id *id)
- 
- 	ret = rtw_usb_alloc_rx_bufs(rtwusb);
- 	if (ret)
--		goto err_free_rx_bufs;
-+		goto err_release_hw;
- 
- 	ret = rtw_core_init(rtwdev);
- 	if (ret)
-@@ -875,9 +875,6 @@ int rtw_usb_probe(struct usb_interface *intf, const struct usb_device_id *id)
- err_free_rx_bufs:
- 	rtw_usb_free_rx_bufs(rtwusb);
- 
--err_free_rx_bufs:
--	rtw_usb_free_rx_bufs(rtwusb);
--
- err_release_hw:
- 	ieee80211_free_hw(hw);
- 
--- 
-2.39.2
 


### PR DESCRIPTION
Upstream code has trickled down into 6.5.y, so adjust patching accordingly.

NOTE: It is advised that maintainers, if they are using RTW88 and Linux 6.5.y, `UPDATE` edge kernels to `6.5.5`.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
