### PR TITLE
Orange Pi 3 LTS: Fix ethernet broken for some users on 6.x kernel

### DIFF
--- a/patch/kernel/archive/sunxi-6.1/patches.armbian/add-initial-support-for-orangepi3-lts.patch
+++ b/patch/kernel/archive/sunxi-6.1/patches.armbian/add-initial-support-for-orangepi3-lts.patch
@@ -99,7 +99,7 @@ index 000000000..cc5a73026
 +		regulator-name = "vcc-gmac-3v3";
 +		regulator-min-microvolt = <3300000>;
 +		regulator-max-microvolt = <3300000>;
-+		startup-delay-us = <100000>;
++		startup-delay-us = <150000>;
 +		gpio = <&pio 3 6 GPIO_ACTIVE_HIGH>;
 +		enable-active-high;
 +	};
@@ -209,7 +209,7 @@ index 000000000..cc5a73026
 +	ext_rgmii_phy: ethernet-phy@1 {
 +		compatible = "ethernet-phy-ieee802.3-c22";
 +		reg = <1>;
-+
++		motorcomm,clk-out-frequency-hz = <125000000>;
 +		reset-gpios = <&pio 3 14 GPIO_ACTIVE_LOW>; /* PD14 */
 +		reset-assert-us = <15000>;
 +		reset-deassert-us = <40000>;

--- a/patch/kernel/archive/sunxi-6.5/patches.armbian/add-initial-support-for-orangepi3-lts.patch
+++ b/patch/kernel/archive/sunxi-6.5/patches.armbian/add-initial-support-for-orangepi3-lts.patch
@@ -99,7 +99,7 @@ index 000000000..cc5a73026
 +		regulator-name = "vcc-gmac-3v3";
 +		regulator-min-microvolt = <3300000>;
 +		regulator-max-microvolt = <3300000>;
-+		startup-delay-us = <100000>;
++		startup-delay-us = <150000>;
 +		gpio = <&pio 3 6 GPIO_ACTIVE_HIGH>;
 +		enable-active-high;
 +	};
@@ -209,7 +209,7 @@ index 000000000..cc5a73026
 +	ext_rgmii_phy: ethernet-phy@1 {
 +		compatible = "ethernet-phy-ieee802.3-c22";
 +		reg = <1>;
-+
++		motorcomm,clk-out-frequency-hz = <125000000>;
 +		reset-gpios = <&pio 3 14 GPIO_ACTIVE_LOW>; /* PD14 */
 +		reset-assert-us = <15000>;
 +		reset-deassert-us = <40000>;


### PR DESCRIPTION
# Description

Fixes ethernet broken for some users on 6.x kernels. It was working fine for me on 6.x kernels. For @AGM1968, it was working fine only on cold boot, while for some users from forum it was not working at all. Hence this PR is raised to fix the same by increasing the startup frequency and specifying clock frequency for motorcomm chip

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested by @AGM1968 and also by user on forum that this fixes the broken ethernet
- [X] In my case, ethernet continues to work fine with this fix as it was working before.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
