### PR TITLE
`orangepi3b`: `rockchip64`/`edge` 6.5: enable uart2 (debug pins and 40-pin pins 6/8)

### DIFF
--- a/patch/kernel/archive/rockchip64-6.5/dt/rk3566-orangepi-3b.dts
+++ b/patch/kernel/archive/rockchip64-6.5/dt/rk3566-orangepi-3b.dts
@@ -151,7 +151,7 @@
 		regulator-max-microvolt = <3300000>;
 		vin-supply = <&vcc12v_dcin>;
 	};
-		
+
 	vcc3v3_sys: vcc3v3-sys {
 		compatible = "regulator-fixed";
 		regulator-name = "vcc3v3_sys";
@@ -786,12 +786,17 @@
 	pinctrl-0 = <&uart1m0_xfer &uart1m0_ctsn>;
 };
 
+/* (debug) uart2 has connectors near the usb-c power, but also on the 40-pin pins 6 (tx) and 8 (rx) - don't wire both */
+&uart2 {
+	status = "okay";
+};
+
 &usb2phy0 {
 	status = "okay";
 };
 
 &usb2phy0_host {
-	phy-supply = <&vbus>;	
+	phy-supply = <&vbus>;
 	status = "okay";
 };
 


### PR DESCRIPTION
#### `orangepi3b`: `rockchip64`/`edge` 6.5: enable uart2 (debug pins and 40-pin pins 6/8)

- `orangepi3b`: `rockchip64`/`edge` 6.5: enable uart2 (debug pins and 40-pin pins 6/8)
  - (debug) uart2 has connectors near the usb-c power, but also on the 40-pin pins 6 (tx) and 8 (rx) - don't wire both