### PR TITLE
`orangepi3b`: `rockchip64`/`edge` 6.5: enable i2c3 (m0) on 40 pin 27/sda and 28/scl

### DIFF
--- a/patch/kernel/archive/rockchip64-6.5/dt/rk3566-orangepi-3b.dts
+++ b/patch/kernel/archive/rockchip64-6.5/dt/rk3566-orangepi-3b.dts
@@ -557,6 +557,15 @@
 	};
 };
 
+/*
+ * i2c3_m0 is exposed on the 40-pin (green connectors)
+ * pin 27 - i2c3_sda_m0
+ * pin 28 - i2c3_scl_m0
+ */
+&i2c3 {
+	status = "okay";
+};
+
 &i2s0_8ch {
 	status = "okay";
 };


### PR DESCRIPTION
#### `orangepi3b`: `rockchip64`/`edge` 6.5: enable i2c3 (m0) on 40 pin 27/sda and 28/scl

- `orangepi3b`: `rockchip64`/`edge` 6.5: enable i2c3 (m0) on 40 pin 27/sda and 28/scl