### PR TITLE
[WIP]orangepi3b: add bluetooth support

### DIFF
--- a/config/boards/orangepi3b.csc
+++ b/config/boards/orangepi3b.csc
@@ -55,3 +55,20 @@ function post_family_config__orangepi3b_use_mainline_uboot() {
 function add_host_dependencies__new_uboot_wants_python3_orangepi3b() {
 	declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} python3-pyelftools" # @TODO: convert to array later
 }
+
+function post_family_tweaks_bsp__orangepi3b() {
+	display_alert "$BOARD" "Installing sprd-bluetooth.service" "info"
+
+	# Bluetooth on orangepi3b board is handled by a Spreadtrum (sprd) chip and requires
+	# a custom hciattach_opi binary, plus a systemd service to run it at boot time
+	install -m 755 $SRC/packages/bsp/rk3399/hciattach_opi $destination/usr/bin
+	cp $SRC/packages/bsp/rk3399/sprd-bluetooth.service $destination/lib/systemd/system/
+
+	return 0
+}
+
+function post_family_tweaks__orangepi3b_enable_services() {
+	display_alert "$BOARD" "Enabling sprd-bluetooth.service" "info"
+	chroot_sdcard systemctl enable sprd-bluetooth.service
+	return 0
+}

--- a/patch/kernel/archive/rockchip64-6.5/dt/rk3566-orangepi-3b.dts
+++ b/patch/kernel/archive/rockchip64-6.5/dt/rk3566-orangepi-3b.dts
@@ -94,15 +94,20 @@
 		reset-gpios = <&gpio0 RK_PD3 GPIO_ACTIVE_LOW>;
 	};
 
+	sprd-mtty {
+		compatible = "sprd,mtty";
+		sprd,name = "ttyBT";
+	};
+
 	unisoc_uwe_bsp: uwe-bsp {
 		compatible = "unisoc,uwe_bsp";
 		wl-reg-on = <&gpio0 RK_PD3 GPIO_ACTIVE_HIGH>;
 		bt-reg-on = <&gpio2 RK_PB7 GPIO_ACTIVE_HIGH>;
 		wl-wake-host-gpio = <&gpio0 RK_PD6 GPIO_ACTIVE_HIGH>;
+		bt-wake-host;
 		bt-wake-host-gpio = <&gpio2 RK_PC0 GPIO_ACTIVE_HIGH>;
 		sdio-ext-int-gpio = <&gpio2 RK_PC1 GPIO_ACTIVE_HIGH>;
 		unisoc,btwf-file-name = "/lib/firmware/wcnmodem.bin";
-		data-irq;
 		blksz-512;
 		keep-power-on;
 	};
@@ -659,12 +664,6 @@
 		};
 	};
 
-	wireless-bluetooth {
-		uart8_gpios: uart8-gpios {
-			rockchip,pins = <2 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;
-		};
-	};
-
 	work-led {
 		leds_gpio: leds-gpio {
 			rockchip,pins = <0 RK_PC0 RK_FUNC_GPIO &pcfg_pull_none>;
@@ -792,7 +791,8 @@
 &uart1 {
 	status = "okay";
 	pinctrl-names = "default";
-	pinctrl-0 = <&uart1m0_xfer &uart1m0_ctsn>;
+	pinctrl-0 = <&uart1m0_xfer &uart1m0_ctsn &uart1m0_rtsn>;
+	uart-has-rtscts;
 };
 
 /* (debug) uart2 has connectors near the usb-c power, but also on the 40-pin pins 6 (tx) and 8 (rx) - don't wire both */


### PR DESCRIPTION
# Description

Add node `sprd-mtty` to mainline devicetree. And add userspace binary `hciattach_opi` to enable uart bluetooth.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
