### PR TITLE
tools: patching: don't rewrite auto-generated patches (eg, drivers)

### DIFF
--- a/lib/tools/common/patching_utils.py
+++ b/lib/tools/common/patching_utils.py
@@ -240,8 +240,11 @@ class PatchFileInDir:
 		log.info(f"Rewriting {output_file} with new patches...")
 		with open(output_file, "w") as f:
 			for patch in patches:
-				log.info(f"Writing patch {patch.counter} to {output_file}...")
-				f.write(patch.rewritten_patch)
+				if patch.parent.patch_dir.is_autogen_dir:
+					log.debug(f"Skipping autogen patch {patch.counter} in file {output_file}...")
+				else:
+					log.info(f"Writing patch {patch.counter} to {output_file}...")
+					f.write(patch.rewritten_patch)
 
 
 # Placeholder for future manual work

--- a/lib/tools/patching.py
+++ b/lib/tools/patching.py
@@ -315,7 +315,7 @@ if apply_patches:
 				commit_hash = committed['commit_hash']
 				one_patch.git_commit_hash = commit_hash
 
-				if rewrite_patches_in_place:
+				if rewrite_patches_in_place and not (one_patch.parent.patch_dir.is_autogen_dir):
 					rewritten_patch = patching_utils.export_commit_as_patch(git_repo, commit_hash)
 					one_patch.rewritten_patch = rewritten_patch
 


### PR DESCRIPTION
#### tools: patching: don't rewrite auto-generated patches (eg, drivers)

- tools: patching: don't rewrite auto-generated patches (eg, drivers)