### PR TITLE
cli: introduce `rewrite-kernel-patches`; fix `kernel-patches-to-git`; refactor `obtain_kernel_git_info_and_makefile()`

### DIFF
--- a/lib/functions/artifacts/artifact-kernel.sh
+++ b/lib/functions/artifacts/artifact-kernel.sh
@@ -72,26 +72,7 @@ function artifact_kernel_prepare_version() {
 	declare short_hash_size=4
 
 	declare -A GIT_INFO_KERNEL=([GIT_SOURCE]="${KERNELSOURCE}" [GIT_REF]="${KERNELBRANCH}")
-
-	declare -i kernel_git_cache_ttl_seconds=3600 # by default
-	if [[ "${KERNEL_GIT_CACHE_TTL}" != "" ]]; then
-		kernel_git_cache_ttl_seconds="${KERNEL_GIT_CACHE_TTL}"
-		display_alert "Setting kernel git cache TTL to" "${kernel_git_cache_ttl_seconds}" "warn" # @TODO: info?
-	fi
-
-	if [[ "${KERNEL_SKIP_MAKEFILE_VERSION:-"no"}" == "yes" ]]; then
-		display_alert "Skipping Makefile version for kernel" "due to KERNEL_SKIP_MAKEFILE_VERSION=yes" "info"
-		memoize_cache_ttl=$kernel_git_cache_ttl_seconds run_memoized GIT_INFO_KERNEL "git2info" memoized_git_ref_to_info
-	else
-		memoize_cache_ttl=$kernel_git_cache_ttl_seconds run_memoized GIT_INFO_KERNEL "git2info" memoized_git_ref_to_info "include_makefile_body"
-	fi
-	debug_dict GIT_INFO_KERNEL
-
-	# Sanity check, the SHA1 gotta be sane.
-	[[ "${GIT_INFO_KERNEL[SHA1]}" =~ ^[0-9a-f]{40}$ ]] || exit_with_error "SHA1 is not sane: '${GIT_INFO_KERNEL[SHA1]}'"
-
-	# Set a readonly global with the kernel SHA1. Will be used later for the drivers cache_key.
-	declare -g -r KERNEL_GIT_SHA1="${GIT_INFO_KERNEL[SHA1]}"
+	obtain_kernel_git_info_and_makefile # this populates GIT_INFO_KERNEL and sets KERNEL_GIT_SHA1 readonly global
 
 	declare short_sha1="${GIT_INFO_KERNEL[SHA1]:0:${short_hash_size}}"
 
@@ -220,6 +201,29 @@ function artifact_kernel_prepare_version() {
 	artifact_deb_arch="${ARCH}"
 
 	return 0
+}
+
+# Input: associative array GIT_INFO_KERNEL, with GIT_SOURCE and GIT_REF members
+function obtain_kernel_git_info_and_makefile() {
+	declare -i kernel_git_cache_ttl_seconds=3600 # by default
+	if [[ "${KERNEL_GIT_CACHE_TTL}" != "" ]]; then
+		kernel_git_cache_ttl_seconds="${KERNEL_GIT_CACHE_TTL}"
+		display_alert "Setting kernel git cache TTL to" "${kernel_git_cache_ttl_seconds}" "warn" # @TODO: info?
+	fi
+
+	if [[ "${KERNEL_SKIP_MAKEFILE_VERSION:-"no"}" == "yes" ]]; then
+		display_alert "Skipping Makefile version for kernel" "due to KERNEL_SKIP_MAKEFILE_VERSION=yes" "info"
+		memoize_cache_ttl=$kernel_git_cache_ttl_seconds run_memoized GIT_INFO_KERNEL "git2info" memoized_git_ref_to_info
+	else
+		memoize_cache_ttl=$kernel_git_cache_ttl_seconds run_memoized GIT_INFO_KERNEL "git2info" memoized_git_ref_to_info "include_makefile_body"
+	fi
+	debug_dict GIT_INFO_KERNEL
+
+	# Sanity check, the SHA1 gotta be sane.
+	[[ "${GIT_INFO_KERNEL[SHA1]}" =~ ^[0-9a-f]{40}$ ]] || exit_with_error "SHA1 is not sane: '${GIT_INFO_KERNEL[SHA1]}'"
+
+	# Set a readonly global with the kernel SHA1. Will be used later for the drivers cache_key.
+	declare -g -r KERNEL_GIT_SHA1="${GIT_INFO_KERNEL[SHA1]}"
 }
 
 function artifact_kernel_build_from_sources() {

--- a/lib/functions/cli/cli-patch.sh
+++ b/lib/functions/cli/cli-patch.sh
@@ -23,19 +23,22 @@ function cli_patch_kernel_pre_run() {
 }
 
 function cli_patch_kernel_run() {
-	display_alert "Patching kernel" "$BRANCH" "info"
-	declare -g SYNC_CLOCK=no       # don't waste time syncing the clock
-	declare -g JUST_KERNEL=yes     # only for kernel.
-	declare -g PATCHES_TO_GIT=yes  # commit to git.
-	declare -g PATCH_ONLY=yes      # stop after patching.
-	declare -g DEBUG_PATCHING=yes  # debug patching.
-	declare -g GIT_ARCHEOLOGY=yes  # do archeology
-	declare -g FAST_ARCHEOLOGY=yes # do archeology, but only for the exact path we need.
-	#declare -g REWRITE_PATCHES=yes # rewrite the patches after git commiting. Very cheap compared to the rest.
-	declare -g KERNEL_CONFIGURE=no # no menuconfig
-	declare -g RELEASE=jammy       # or whatever, not relevant, just fool the configuration
-	declare -g SHOW_LOG=yes        # show the log
+	display_alert "Patching kernel" "$BRANCH - rewrite: ${REWRITE_PATCHES:-"no"} " "info"
+	declare -g SYNC_CLOCK=no                 # don't waste time syncing the clock
+	declare -g PATCHES_TO_GIT=yes            # commit to git.
+	declare -g PATCH_ONLY=yes                # stop after patching.
+	declare -g GIT_ARCHEOLOGY=yes            # do archeology
+	declare -g FAST_ARCHEOLOGY=yes           # do archeology, but only for the exact path we need.
+	declare -g KERNEL_CONFIGURE=no           # no menuconfig
+	declare -g RELEASE="${RELEASE:-"jammy"}" # or whatever, not relevant, just fool the configuration
+
+	# initialize the config
 	prep_conf_main_build_single
+
+	# <prepare the git sha1>
+	declare -A GIT_INFO_KERNEL=([GIT_SOURCE]="${KERNELSOURCE}" [GIT_REF]="${KERNELBRANCH}")
+	obtain_kernel_git_info_and_makefile # this populates GIT_INFO_KERNEL and sets KERNEL_GIT_SHA1 readonly global
+	# </prepare the git sha1>
 
 	declare ymd vendor_lc target_repo_url summary_url
 	ymd="$(date +%Y%m%d)"

--- a/lib/functions/cli/commands.sh
+++ b/lib/functions/cli/commands.sh
@@ -38,7 +38,8 @@ function armbian_register_commands() {
 		["debs-to-repo-download"]="json_info" # implemented in cli_json_info_pre_run and cli_json_info_run
 		["debs-to-repo-reprepro"]="json_info" # implemented in cli_json_info_pre_run and cli_json_info_run
 
-		["kernel-patches-to-git"]="patch_kernel" # implemented in cli_patch_kernel_pre_run and cli_patch_kernel_run
+		["kernel-patches-to-git"]="patch_kernel"  # implemented in cli_patch_kernel_pre_run and cli_patch_kernel_run
+		["rewrite-kernel-patches"]="patch_kernel" # implemented in cli_patch_kernel_pre_run and cli_patch_kernel_run
 
 		["build"]="standard_build" # implemented in cli_standard_build_pre_run and cli_standard_build_run
 		["distccd"]="distccd"      # implemented in cli_distccd_pre_run and cli_distccd_run
@@ -100,6 +101,9 @@ function armbian_register_commands() {
 		# repo pipeline stuff is usually run on saved/restored artifacts for output/info, so don't clean them by default
 		["debs-to-repo-download"]="CLEAN_MATRIX='no' CLEAN_INFO='no'"
 		["debs-to-repo-reprepro"]="CLEAN_MATRIX='no' CLEAN_INFO='no'"
+
+		# patching
+		["rewrite-kernel-patches"]="REWRITE_PATCHES=yes" # rewrite the patches after round-tripping to git: "rebase patches"
 
 		# artifact shortcuts
 		["rootfs"]="WHAT='rootfs' ${common_cli_artifact_vars}"


### PR DESCRIPTION
#### cli: introduce `rewrite-kernel-patches`; fix `kernel-patches-to-git`; refactor `obtain_kernel_git_info_and_makefile()`

- cli: introduce `rewrite-kernel-patches`; fix `kernel-patches-to-git`; refactor `obtain_kernel_git_info_and_makefile()`
  - `kernel-patches-to-git` wasn't providing the needed `KERNEL_GIT_SHA1` for kernel drivers
    - refactor `obtain_kernel_git_info_and_makefile()` out of `artifact_kernel_prepare_version()` so we can reuse
  - introduce `rewrite-kernel-patches`, which is just an alias to `kernel-patches-to-git` with `REWRITE_PATCHES=yes`