### PR TITLE
`sunxi`/`sunxi64` `edge` 6.5.y: fix lost accreditation/description and date formats of a few patches

### DIFF
--- a/patch/kernel/archive/sunxi-6.5/patches.armbian/arm-dts-sunxi-h3-h5-add_tve.patch
+++ b/patch/kernel/archive/sunxi-6.5/patches.armbian/arm-dts-sunxi-h3-h5-add_tve.patch
@@ -1,8 +1,21 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: None <None>
-Date: Thu, 28 Sep 2023 11:29:17 +0000
-Subject: None
+From: Radoslav <radoslavv@centrum.sk>
+Date: Sat, 15 Apr 2023 22:47:26 +0200
+Subject: enable TV Output on OrangePi Zero LTE
 
+Credits to sorce https://github.com/robertojguerra/orangepi-zero-full-setup/blob/main/README2.md
+Merged:
+1. sunxi-6.1/0036-wip-h3-h5-cvbs-armbian.patch : makes additions to the "dts", which tells the kernel where are the new devices. Adds kernel code to interact with the tv encoder. With my modifications, now it is applicable to Armbian (this patch came from the LibreElec github).
+    https://github.com/robertojguerra/orangepi-zero-full-setup/blob/main/sunxi-6.1/0036-wip-h3-h5-cvbs-armbian.patch
+2. sunxi-6.1/zzzz2-tv.patch : by Armbian user "gleam2003", adds directives to make sure that the dtbo (device tree binary overlay) is compiled
+    https://github.com/robertojguerra/orangepi-zero-full-setup/blob/main/sunxi-6.1/zzzz2-tv.patch
+3. sunxi-6.1/zzzz3-tv.patch : more additions to the "dts" and "dtsi" (like C include files), which I noticed were included in "yam" patch, but missing from the LibreElec patch
+    https://github.com/robertojguerra/orangepi-zero-full-setup/blob/main/sunxi-6.1/zzzz3-tv.patch
+
+> X-Git-Archeology: - Revision 41260ac309b487d241fec97ffbdeced730bc2d04: https://github.com/armbian/build/commit/41260ac309b487d241fec97ffbdeced730bc2d04
+> X-Git-Archeology:   Date: Sat, 15 Apr 2023 22:47:26 +0200
+> X-Git-Archeology:   From: Radoslav <radoslavv@centrum.sk>
+> X-Git-Archeology:   Subject: h3-tve (arm-dts-sun8i-h3-orangepizero-add_tve.patch)
 ---
  arch/arm/boot/dts/allwinner/overlay/Makefile                    |  1 +
  arch/arm/boot/dts/allwinner/overlay/README.sun8i-h3-overlays    | 10 +

--- a/patch/kernel/archive/sunxi-6.5/patches.armbian/arm64-dts-allwinner-h616-Add-device-node-for-SID.patch
+++ b/patch/kernel/archive/sunxi-6.5/patches.armbian/arm64-dts-allwinner-h616-Add-device-node-for-SID.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kali Prasad <kprasadvnsi@protonmail.com>
-Date: Sun, 19 Sep 2021 14:23:08 +0583
+Date: Sun, 19 Sep 2021 08:02:27 +0000
 Subject: arm64: dts: allwinner: h616: Add device node for SID
 
 The device tree binding for H616's SID controller.

--- a/patch/kernel/archive/sunxi-6.5/patches.armbian/arm64-dts-allwinner-h616-Add-thermal-sensor-and-thermal-zones.patch
+++ b/patch/kernel/archive/sunxi-6.5/patches.armbian/arm64-dts-allwinner-h616-Add-thermal-sensor-and-thermal-zones.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kali Prasad <kprasadvnsi@protonmail.com>
-Date: Sun, 19 Sep 2021 14:31:20 +0583
+Date: Sun, 19 Sep 2021 08:02:27 +0000
 Subject: arm64: dts: allwinner: h616: Add thermal sensor and thermal zones
 
 There are four sensors, CPU, GPU, VE, and DDR.

--- a/patch/kernel/archive/sunxi-6.5/patches.armbian/drv-nvmem-sunxi_sid-Support-SID-on-H616.patch
+++ b/patch/kernel/archive/sunxi-6.5/patches.armbian/drv-nvmem-sunxi_sid-Support-SID-on-H616.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kali Prasad <kprasadvnsi@protonmail.com>
-Date: Sun, 19 Sep 2021 14:21:10 +0583
+Date: Sun, 19 Sep 2021 08:02:27 +0000
 Subject: drv:nvmem:sunxi_sid: Support SID on H616
 
 Add support for H616's SID controller. It supports 4K-bit

--- a/patch/kernel/archive/sunxi-6.5/patches.armbian/drv-thermal-sun8i_thermal-Add-for-H616.patch
+++ b/patch/kernel/archive/sunxi-6.5/patches.armbian/drv-thermal-sun8i_thermal-Add-for-H616.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kali Prasad <kprasadvnsi@protonmail.com>
-Date: Sun, 19 Sep 2021 14:25:27 +0583
+Date: Sun, 19 Sep 2021 08:02:27 +0000
 Subject: drv:thermal:sun8i_thermal Add for H616
 
 Thermal driver for H616 SoC. Compared to H6, it has


### PR DESCRIPTION
#### `sunxi`/`sunxi64` `edge` 6.5.y: fix lost accreditation/description and date formats of a few patches

- `sunxi`/`sunxi64` `edge` 6.5.y: fix lost accreditation/description and date formats of a few patches
  Fixes: bb78fac2fadb40a43a9ccb36266dbd21746c2eb6