### PR TITLE
`rk35xx`+`rockchip-rk3588`/`legacy`: switch to `rk-5.10-rkr6` branch

### DIFF
--- a/config/sources/families/rk35xx.conf
+++ b/config/sources/families/rk35xx.conf
@@ -20,8 +20,9 @@ case $BRANCH in
 		UBOOT_USE_GCC='< 8.0'
 		BOOTDIR='u-boot-rockchip64'
 		KERNELSOURCE='https://github.com/armbian/linux-rockchip.git'
-		KERNELBRANCH='branch:rk-5.10-rkr5.1'
-		declare -g KERNEL_MAJOR_MINOR="5.10" # Major and minor versions of this kernel.
+		KERNELBRANCH='branch:rk-5.10-rkr6'
+		declare -g -i KERNEL_GIT_CACHE_TTL=120 # 2 minutes; this is a high-traffic repo
+		declare -g KERNEL_MAJOR_MINOR="5.10"   # Major and minor versions of this kernel.
 		KERNELDIR='linux-rockchip64'
 		KERNELPATCHDIR='rk35xx-legacy'
 

--- a/config/sources/families/rockchip-rk3588.conf
+++ b/config/sources/families/rockchip-rk3588.conf
@@ -22,9 +22,10 @@ case $BRANCH in
 		UBOOT_USE_GCC='< 8.0'
 		BOOTDIR='u-boot-rockchip64'
 		KERNELDIR='linux-rockchip64'
-		KERNELSOURCE='https://github.com/armbian/linux-rockchip'
-		declare -g KERNEL_MAJOR_MINOR="5.10" # Major and minor versions of this kernel.
-		KERNELBRANCH='branch:rk-5.10-rkr5.1'
+		KERNELSOURCE='https://github.com/armbian/linux-rockchip.git'
+		declare -g KERNEL_MAJOR_MINOR="5.10"   # Major and minor versions of this kernel.
+		declare -g -i KERNEL_GIT_CACHE_TTL=120 # 2 minutes; this is a high-traffic repo
+		KERNELBRANCH='branch:rk-5.10-rkr6'
 		KERNELPATCHDIR='rk35xx-legacy'
 		LINUXFAMILY=rk35xx
 		;;


### PR DESCRIPTION
#### `rk35xx`+`rockchip-rk3588`/`legacy`: switch to `rk-5.10-rkr6` branch

- `rk35xx`+`rockchip-rk3588`/`legacy`: switch to `rk-5.10-rkr6` branch
  - also set `KERNEL_GIT_CACHE_TTL=120` to lower cache TTL from 1 hour to 2 minutes