### PR TITLE
`uefi-arm64`/`edge`: bump to 6.6-rc4

### DIFF
--- a/config/sources/families/include/uefi_common.inc
+++ b/config/sources/families/include/uefi_common.inc
@@ -40,8 +40,9 @@ case "${BRANCH}" in
 
 		declare -g DISTRO_GENERIC_KERNEL=no
 		declare -g LINUXCONFIG="linux-uefi-${LINUXFAMILY}-${BRANCH}"
-		declare -g KERNEL_MAJOR_MINOR="6.5" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH='branch:linux-6.5.y'
+		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel.
+		#declare -g KERNELBRANCH='branch:linux-6.6.y'
+		declare -g KERNELBRANCH='tag:v6.6-rc4'
 		declare -g KERNELPATCHDIR="uefi-${LINUXFAMILY}-${BRANCH}" # Might be empty.
 		;;
 esac

--- a/patch/kernel/archive/uefi-arm64-6.6/board-hikey960-usb.patch
+++ b/patch/kernel/archive/uefi-arm64-6.6/board-hikey960-usb.patch
@@ -1,0 +1,77 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kevin Schmidt <kevin.patrick.schmidt@googlemail.com>
+Date: Thu, 31 Aug 2023 11:41:14 +0200
+Subject: [ARCHEOLOGY] Add board: HiKey960
+
+> X-Git-Archeology: - Revision d8200e5c383c1c77569596bfd2b8886ef8258c3f: https://github.com/armbian/build/commit/d8200e5c383c1c77569596bfd2b8886ef8258c3f
+> X-Git-Archeology:   Date: Thu, 31 Aug 2023 11:41:14 +0200
+> X-Git-Archeology:   From: Kevin Schmidt <kevin.patrick.schmidt@googlemail.com>
+> X-Git-Archeology:   Subject: Add board: HiKey960
+> X-Git-Archeology:
+---
+ arch/arm64/boot/dts/hisilicon/hi3660-hikey960.dts | 35 +++++++++-
+ 1 file changed, 33 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/hisilicon/hi3660-hikey960.dts b/arch/arm64/boot/dts/hisilicon/hi3660-hikey960.dts
+index 3f13a960f34e..f05edfe378e6 100644
+--- a/arch/arm64/boot/dts/hisilicon/hi3660-hikey960.dts
++++ b/arch/arm64/boot/dts/hisilicon/hi3660-hikey960.dts
+@@ -197,6 +197,37 @@ optee {
+ 			method = "smc";
+ 		};
+ 	};
++
++	usb_hub_vdd: usb_hub_vdd {
++		compatible = "regulator-fixed";
++		regulator-name = "hub-vdd";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		gpio = <&gpio5 6 0>;
++		enable-active-high;
++	};
++
++	usb-hub {
++		compatible = "hisilicon,usbhub";
++		typec-vbus-gpios = <&gpio25 2 GPIO_ACTIVE_HIGH>;
++		otg-switch-gpios = <&gpio25 6 GPIO_ACTIVE_HIGH>;
++		hub-vdd-supply = <&usb_hub_vdd>;
++		usb-role-switch;
++
++		port {
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			hikey_usb_ep0: endpoint@0 {
++				reg = <0>;
++				remote-endpoint = <&dwc3_role_switch>;
++			};
++			hikey_usb_ep1: endpoint@1 {
++				reg = <1>;
++				remote-endpoint = <&rt1711h_ep>;
++			};
++		};
++	};
+ };
+ 
+ /*
+@@ -564,7 +595,7 @@ port {
+ 
+ 			rt1711h_ep: endpoint@0 {
+ 				reg = <0>;
+-				remote-endpoint = <&dwc3_role_switch>;
++				remote-endpoint = <&hikey_usb_ep1>;
+ 			};
+ 		};
+ 	};
+@@ -686,7 +717,7 @@ port {
+ 		#size-cells = <0>;
+ 		dwc3_role_switch: endpoint@0 {
+ 			reg = <0>;
+-			remote-endpoint = <&rt1711h_ep>;
++			remote-endpoint = <&hikey_usb_ep0>;
+ 		};
+ 
+ 		dwc3_ss: endpoint@1 {
+-- 
+Armbian
+

--- a/patch/kernel/archive/uefi-arm64-6.6/driver-phytium-stmmac-acpi.patch
+++ b/patch/kernel/archive/uefi-arm64-6.6/driver-phytium-stmmac-acpi.patch
@@ -1,0 +1,700 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ricardo Pardini <ricardo@pardini.net>
+Date: Thu, 4 Aug 2022 21:49:10 +0200
+Subject: Phytium onboard ethernet drivers for 6.x
+
+ My board has two eths; only eth1 has an actual PHY and works.
+ From https://gitee.com/atzlinux/atzlinux-kernel/tree/master/debian/patch
+ rpardini hammered:
+ - small api change in upstream around 5.19
+ - hand-merged for 6.5
+   - use `.remove_new` due to "net: stmmac: Make stmmac_pltfr_remove() return void"
+ - Remove Kconfig deps from Feiteng stuff not in mainline
+ - Default Kconfig to module
+ Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
+---
+ drivers/net/ethernet/stmicro/stmmac/Kconfig           |  10 +
+ drivers/net/ethernet/stmicro/stmmac/Makefile          |   1 +
+ drivers/net/ethernet/stmicro/stmmac/dwmac-generic.c   |  19 +
+ drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c   | 222 ++++++++
+ drivers/net/ethernet/stmicro/stmmac/stmmac_main.c     |   1 +
+ drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c | 254 +++++++++-
+ drivers/net/ethernet/stmicro/stmmac/stmmac_platform.h |   2 +
+ drivers/net/phy/at803x.c                              |  23 +
+ 8 files changed, 531 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ethernet/stmicro/stmmac/Kconfig b/drivers/net/ethernet/stmicro/stmmac/Kconfig
+index 5583f0b055ec..96c72e4b3218 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/Kconfig
++++ b/drivers/net/ethernet/stmicro/stmmac/Kconfig
+@@ -132,6 +132,16 @@ config DWMAC_OXNAS
+ 	  This selects the Oxford Semiconductor OXNASSoC glue layer support for
+ 	  the stmmac device driver. This driver is used for OX820.
+ 
++config DWMAC_PHYTIUM
++	tristate "Phytium DWMAC support"
++	default m
++	depends on ACPI
++	help
++	  Support for Ethernet controllers on Phytium SoCs.
++
++	  This selects the Phytium DWMAC glue layer support for the stmmac
++	  device driver.
++
+ config DWMAC_QCOM_ETHQOS
+ 	tristate "Qualcomm ETHQOS support"
+ 	default ARCH_QCOM
+diff --git a/drivers/net/ethernet/stmicro/stmmac/Makefile b/drivers/net/ethernet/stmicro/stmmac/Makefile
+index 7dd3d388068b..79df9e87cbad 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/Makefile
++++ b/drivers/net/ethernet/stmicro/stmmac/Makefile
+@@ -20,6 +20,7 @@ obj-$(CONFIG_DWMAC_LPC18XX)	+= dwmac-lpc18xx.o
+ obj-$(CONFIG_DWMAC_MEDIATEK)	+= dwmac-mediatek.o
+ obj-$(CONFIG_DWMAC_MESON)	+= dwmac-meson.o dwmac-meson8b.o
+ obj-$(CONFIG_DWMAC_OXNAS)	+= dwmac-oxnas.o
++obj-$(CONFIG_DWMAC_PHYTIUM)	+= dwmac-phytium.o
+ obj-$(CONFIG_DWMAC_QCOM_ETHQOS)	+= dwmac-qcom-ethqos.o
+ obj-$(CONFIG_DWMAC_ROCKCHIP)	+= dwmac-rk.o
+ obj-$(CONFIG_DWMAC_SOCFPGA)	+= dwmac-altr-socfpga.o
+diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-generic.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-generic.c
+index 20fc455b3337..0fb965b4cd4c 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/dwmac-generic.c
++++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-generic.c
+@@ -9,6 +9,7 @@
+  * warranty of any kind, whether express or implied.
+  */
+ 
++#include <linux/acpi.h>
+ #include <linux/module.h>
+ #include <linux/of.h>
+ #include <linux/platform_device.h>
+@@ -32,6 +33,12 @@ static int dwmac_generic_probe(struct platform_device *pdev)
+ 			dev_err(&pdev->dev, "dt configuration failed\n");
+ 			return PTR_ERR(plat_dat);
+ 		}
++	} else if (has_acpi_companion(&pdev->dev)) {
++		plat_dat = stmmac_probe_config_acpi(pdev, stmmac_res.mac);
++		if (!plat_dat) {
++			dev_err(&pdev->dev, "acpi configuration failed\n");
++			return  -EINVAL;
++		}
+ 	} else {
+ 		plat_dat = dev_get_platdata(&pdev->dev);
+ 		if (!plat_dat) {
+@@ -75,6 +82,17 @@ static const struct of_device_id dwmac_generic_match[] = {
+ };
+ MODULE_DEVICE_TABLE(of, dwmac_generic_match);
+ 
++#ifdef CONFIG_ACPI
++static const struct acpi_device_id dwmac_acpi_ids[] = {
++	{ .id = "PHYT0004" },
++	{},
++};
++
++MODULE_DEVICE_TABLE(acpi, dwmac_acpi_ids);
++#else
++#define dwmac_acpi_ids NULL
++#endif
++
+ static struct platform_driver dwmac_generic_driver = {
+ 	.probe  = dwmac_generic_probe,
+ 	.remove_new = stmmac_pltfr_remove,
+@@ -82,6 +100,7 @@ static struct platform_driver dwmac_generic_driver = {
+ 		.name           = STMMAC_RESOURCE_NAME,
+ 		.pm		= &stmmac_pltfr_pm_ops,
+ 		.of_match_table = dwmac_generic_match,
++		.acpi_match_table = ACPI_PTR(dwmac_acpi_ids),
+ 	},
+ };
+ module_platform_driver(dwmac_generic_driver);
+diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
+new file mode 100644
+index 000000000000..e6ad44b80a10
+--- /dev/null
++++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
+@@ -0,0 +1,222 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ * Phytium DWMAC platform glue driver
++ *
++ * Copyright (C) 2022 Icenowy Zheng <uwu@icenowy.me>
++ */
++
++#include <linux/acpi.h>
++#include <linux/clk-provider.h>
++#include <linux/clkdev.h>
++#include <linux/module.h>
++#include <linux/platform_device.h>
++
++#include "stmmac.h"
++#include "stmmac_platform.h"
++
++/**
++ * Acquire Phytium DWMAC resources from ACPI
++ */
++int dwmac_phytium_get_resources(struct platform_device *pdev,
++				struct stmmac_resources *stmmac_res)
++{
++	memset(stmmac_res, 0, sizeof(*stmmac_res));
++
++	stmmac_res->irq = platform_get_irq(pdev, 0);
++	if (stmmac_res->irq < 0)
++		return stmmac_res->irq;
++
++	stmmac_res->addr = devm_platform_ioremap_resource(pdev, 0);
++	stmmac_res->wol_irq = stmmac_res->irq;
++	stmmac_res->lpi_irq = -ENOENT;
++
++	return PTR_ERR_OR_ZERO(stmmac_res->addr);
++}
++
++/**
++ * Parse Phytium ACPI properties
++ */
++static struct plat_stmmacenet_data *
++dwmac_phytium_parse_config_acpi(struct platform_device *pdev, const char *mac)
++{
++	struct device *dev = &pdev->dev;
++	struct fwnode_handle *np;
++	struct plat_stmmacenet_data *plat;
++	struct stmmac_dma_cfg *dma_cfg;
++	struct stmmac_axi *axi;
++	struct clk_hw *clk_hw;
++	u64 clk_freq;
++	int ret;
++
++	plat = devm_kzalloc(dev, sizeof(*plat), GFP_KERNEL);
++	if (!plat)
++		return ERR_PTR(-ENOMEM);
++
++	np = dev_fwnode(dev);
++
++	plat->phy_interface = fwnode_get_phy_mode(np);
++	plat->interface = plat->phy_interface;
++
++	/* Get max speed of operation from properties */
++	if (fwnode_property_read_u32(np, "max-speed", &plat->max_speed))
++		plat->max_speed = 1000;
++
++	if (fwnode_property_read_u32(np, "bus_id", &plat->bus_id))
++		plat->bus_id = 2;
++
++	/* Default to PHY auto-detection */
++	plat->phy_addr = -1;
++
++	plat->mdio_bus_data = devm_kzalloc(dev,
++					   sizeof(struct stmmac_mdio_bus_data),
++					   GFP_KERNEL);
++
++	fwnode_property_read_u32(np, "tx-fifo-depth", &plat->tx_fifo_size);
++	fwnode_property_read_u32(np, "rx-fifo-depth", &plat->rx_fifo_size);
++	if (plat->tx_fifo_size == 0)
++		plat->tx_fifo_size = 0x10000;
++	if (plat->rx_fifo_size == 0)
++		plat->rx_fifo_size = 0x10000;
++
++	plat->force_sf_dma_mode =
++		fwnode_property_read_bool(np, "snps,force_sf_dma_mode");
++	plat->en_tx_lpi_clockgating =
++		fwnode_property_read_bool(np, "snps,en-tx-lpi-clockgating");
++
++	/* Set the maxmtu to a default of JUMBO_LEN in case the
++	 * parameter is not present.
++	 */
++	plat->maxmtu = JUMBO_LEN;
++
++	/* Set default value for multicast hash bins */
++	plat->multicast_filter_bins = HASH_TABLE_SIZE;
++
++	/* Set default value for unicast filter entries */
++	plat->unicast_filter_entries = 1;
++
++	fwnode_property_read_u32(np, "max-frame-size", &plat->maxmtu);
++	plat->has_gmac = 1;
++	plat->pmt = 1;
++
++	dma_cfg = devm_kzalloc(dev, sizeof(*dma_cfg), GFP_KERNEL);
++	if (!dma_cfg)
++		return ERR_PTR(-ENOMEM);
++	plat->dma_cfg = dma_cfg;
++
++	fwnode_property_read_u32(np, "snps,pbl", &dma_cfg->pbl);
++	if (!dma_cfg->pbl)
++		dma_cfg->pbl = DEFAULT_DMA_PBL;
++
++	fwnode_property_read_u32(np, "snps,txpbl", &dma_cfg->txpbl);
++	fwnode_property_read_u32(np, "snps,rxpbl", &dma_cfg->rxpbl);
++	dma_cfg->pblx8 = !fwnode_property_read_bool(np, "snps,no-pbl-x8");
++
++	dma_cfg->aal = fwnode_property_read_bool(np, "snps,aal");
++	dma_cfg->fixed_burst = fwnode_property_read_bool(np, "snps,fixed-burst");
++	dma_cfg->mixed_burst = fwnode_property_read_bool(np, "snps,mixed-burst");
++
++	plat->force_thresh_dma_mode = fwnode_property_read_bool(np, "snps,force_thresh_dma_mode");
++	if (plat->force_thresh_dma_mode)
++		plat->force_sf_dma_mode = 0;
++
++	fwnode_property_read_u32(np, "snps,ps-speed", &plat->mac_port_sel_speed);
++
++	axi = devm_kzalloc(&pdev->dev, sizeof(*axi), GFP_KERNEL);
++	if (!axi)
++		return ERR_PTR(-ENOMEM);
++	plat->axi = axi;
++
++	axi->axi_wr_osr_lmt = 1;
++	axi->axi_rd_osr_lmt = 1;
++
++	plat->rx_queues_to_use = 1;
++	plat->tx_queues_to_use = 1;
++
++	/**
++	 * First Queue must always be in DCB mode. As MTL_QUEUE_DCB=1 we need
++	 * to always set this, otherwise Queue will be classified as AVB
++	 * (because MTL_QUEUE_AVB = 0).
++	 */
++	plat->rx_queues_cfg[0].mode_to_use = MTL_QUEUE_DCB;
++	plat->tx_queues_cfg[0].mode_to_use = MTL_QUEUE_DCB;
++
++	plat->rx_queues_cfg[0].use_prio = true;
++
++	plat->rx_queues_cfg[0].pkt_route = 0x0;
++
++	plat->rx_sched_algorithm = MTL_RX_ALGORITHM_SP;
++	plat->tx_sched_algorithm = MTL_TX_ALGORITHM_SP;
++
++	ret = fwnode_property_read_u64(np, "clock-frequency", &clk_freq);
++	if (ret < 0)
++		clk_freq = 125000000; /* default to 125MHz */
++
++	clk_hw = clk_hw_register_fixed_rate(dev, dev_name(dev), NULL,
++					    0, clk_freq);
++	if (IS_ERR(clk_hw))
++		return ERR_PTR(PTR_ERR(clk_hw));
++	ret = devm_clk_hw_register_clkdev(dev, clk_hw, dev_name(dev),
++					  dev_name(dev));
++	if (ret)
++		return ERR_PTR(ret);
++	plat->stmmac_clk = clk_hw->clk;
++	clk_prepare_enable(plat->stmmac_clk);
++
++	return plat;
++}
++
++static int dwmac_phytium_probe(struct platform_device *pdev)
++{
++	struct plat_stmmacenet_data *plat_dat;
++	struct stmmac_resources stmmac_res;
++	int ret;
++
++	ret = dwmac_phytium_get_resources(pdev, &stmmac_res);
++	if (ret)
++		return ret;
++
++	if (has_acpi_companion(&pdev->dev)) {
++		plat_dat = dwmac_phytium_parse_config_acpi(pdev, stmmac_res.mac);
++		if (IS_ERR(plat_dat)) {
++			dev_err(&pdev->dev, "ACPI configuration failed\n");
++			return PTR_ERR(plat_dat);
++		}
++	} else {
++		dev_err(&pdev->dev, "no ACPI properties\n");
++		return -EINVAL;
++	}
++
++	ret = stmmac_dvr_probe(&pdev->dev, plat_dat, &stmmac_res);
++	if (ret)
++		goto err_exit;
++
++	return 0;
++
++err_exit:
++	if (plat_dat->exit)
++		plat_dat->exit(pdev, plat_dat->bsp_priv);
++
++	return ret;
++}
++
++static const struct acpi_device_id dwmac_phytium_acpi_match[] = {
++	{
++		.id = "PHYT0004",
++	},
++	{}
++};
++MODULE_DEVICE_TABLE(acpi, dwmac_phytium_acpi_match);
++
++static struct platform_driver dwmac_phytium_driver = {
++	.probe  = dwmac_phytium_probe,
++	.remove_new = stmmac_pltfr_remove,
++	.driver = {
++		.name           = "dwmac-phytium",
++		.pm		= &stmmac_pltfr_pm_ops,
++		.acpi_match_table = ACPI_PTR(dwmac_phytium_acpi_match),
++	},
++};
++module_platform_driver(dwmac_phytium_driver);
++
++MODULE_DESCRIPTION("Glue driver for Phytium DWMAC");
++MODULE_LICENSE("GPL v2");
+diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
+index 4727f7be4f86..0595591b85bd 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
++++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
+@@ -14,6 +14,7 @@
+ 	https://bugzilla.stlinux.com/
+ *******************************************************************************/
+ 
++#include <linux/acpi.h>
+ #include <linux/clk.h>
+ #include <linux/kernel.h>
+ #include <linux/interrupt.h>
+diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
+index 231152ee5a32..696c1faef2be 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
++++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
+@@ -9,6 +9,9 @@
+ *******************************************************************************/
+ 
+ #include <linux/device.h>
++#include <linux/acpi.h>
++#include <linux/clk-provider.h>
++#include <linux/clkdev.h>
+ #include <linux/platform_device.h>
+ #include <linux/pm_runtime.h>
+ #include <linux/module.h>
+@@ -700,6 +703,248 @@ EXPORT_SYMBOL_GPL(stmmac_probe_config_dt);
+ EXPORT_SYMBOL_GPL(devm_stmmac_probe_config_dt);
+ EXPORT_SYMBOL_GPL(stmmac_remove_config_dt);
+ 
++#ifdef CONFIG_ACPI
++/*
++ * Parse ACPI _DSD to setup AXI register
++ */
++static struct stmmac_axi * stmmac_axi_setup_acpi(struct platform_device *pdev)
++{
++	struct fwnode_handle *np = dev_fwnode(&(pdev->dev));
++	struct stmmac_axi * axi;
++
++	axi = devm_kzalloc(&pdev->dev, sizeof(*axi), GFP_KERNEL);
++	if (!axi)
++		return ERR_PTR(-ENOMEM);
++
++	axi->axi_lpi_en = fwnode_property_read_bool(np, "snps,lpi_en");
++	axi->axi_xit_frm = fwnode_property_read_bool(np, "snps,xit_frm");
++	axi->axi_kbbe = fwnode_property_read_bool(np, "snps,axi_kbbe");
++	axi->axi_fb = fwnode_property_read_bool(np, "snps,axi_fb");
++	axi->axi_mb = fwnode_property_read_bool(np, "snps,axi_mb");
++	axi->axi_rb = fwnode_property_read_bool(np, "snps,axi_rb");
++
++	if (fwnode_property_read_u32(np, "snps,wr_osr_lmt", &axi->axi_wr_osr_lmt))
++		axi->axi_wr_osr_lmt = 1;
++	if (fwnode_property_read_u32(np, "snps,rd_osr_lmt", &axi->axi_rd_osr_lmt))
++		axi->axi_rd_osr_lmt = 1;
++	fwnode_property_read_u32_array(np, "snps,blen", axi->axi_blen, AXI_BLEN);
++
++	return axi;
++}
++
++/**
++ * Parse ACPI _DSD parameters for multiple queues configuration
++ */
++static void stmmac_mtl_setup_acpi(struct platform_device *pdev,
++				  struct plat_stmmacenet_data *plat)
++{
++	plat->rx_queues_to_use = 1;
++	plat->tx_queues_to_use = 1;
++
++	/**
++	 * First Queue must always be in DCB mode. As MTL_QUEUE_DCB=1 we need
++	 * to always set this, otherwise Queue will be classified as AVB
++	 * (because MTL_QUEUE_AVB = 0).
++	 */
++	plat->rx_queues_cfg[0].mode_to_use = MTL_QUEUE_DCB;
++	plat->tx_queues_cfg[0].mode_to_use = MTL_QUEUE_DCB;
++
++	plat->rx_queues_cfg[0].use_prio = true;
++
++	plat->rx_queues_cfg[0].pkt_route = 0x0;
++
++	plat->rx_sched_algorithm = MTL_RX_ALGORITHM_SP;
++	plat->tx_sched_algorithm = MTL_TX_ALGORITHM_SP;
++
++	plat->tx_queues_cfg[0].use_prio = true;
++}
++
++static int stmmac_acpi_phy(struct plat_stmmacenet_data *plat,
++			   struct fwnode_handle *np, struct device *dev)
++{
++	plat->mdio_bus_data = devm_kzalloc(dev,
++					   sizeof(struct stmmac_mdio_bus_data),
++					   GFP_KERNEL);
++
++	return 0;
++}
++
++int fw_get_phy_mode(struct fwnode_handle *np)
++{
++	const char *pm;
++	int err, i;
++
++	err = fwnode_property_read_string(np, "phy-mode", &pm);
++	if (err < 0)
++		err = fwnode_property_read_string(np, "phy-connection-mode", &pm);
++	if (err < 0)
++		return err;
++
++	for (i = 0; i < PHY_INTERFACE_MODE_MAX; i++) {
++		if (!strcasecmp(pm, phy_modes(i)))
++			return i;
++	}
++
++	return -ENODEV;
++}
++
++int stmmac_acpi_clock_setup(struct plat_stmmacenet_data *plat,
++			    struct platform_device *pdev)
++{
++	struct fwnode_handle *np = dev_fwnode(&(pdev->dev));
++	struct device * dev = &pdev->dev;
++	struct clk *clk = ERR_PTR(-ENODEV);
++	u64 clk_freq = 0;
++	int err;
++
++	err = fwnode_property_read_u64(np, "clock-frequency", &clk_freq);
++	if (err < 0)
++		clk_freq = 125000000; /* default to 125MHz */
++
++	plat->stmmac_clk = devm_clk_get(dev, dev_name(dev));
++	if (IS_ERR(plat->stmmac_clk)) {
++		clk = clk_register_fixed_rate(dev, dev_name(dev), NULL, 0, clk_freq);
++		if (IS_ERR(clk))
++			return -1;
++		if (clk_register_clkdev(clk, dev_name(dev), dev_name(dev)))
++			return -1;
++		plat->stmmac_clk = clk;
++	}
++	clk_prepare_enable(plat->stmmac_clk);
++
++	plat->pclk = devm_clk_get(dev, "pclk");
++	if (IS_ERR(plat->pclk))
++		plat->pclk = NULL;
++	clk_prepare_enable(plat->pclk);
++
++	plat->clk_ptp_ref = devm_clk_get(dev, "ptp_ref");
++	if (IS_ERR(plat->clk_ptp_ref)) {
++		plat->clk_ptp_rate = clk_get_rate(plat->stmmac_clk);
++		plat->clk_ptp_ref = NULL;
++	}
++
++	plat->stmmac_rst = devm_reset_control_get(dev,STMMAC_RESOURCE_NAME);
++	if (IS_ERR(plat->stmmac_rst)) {
++		dev_info(dev, "no reset control found\n");
++		plat->stmmac_rst = NULL;
++	}
++
++	return 0;
++}
++
++/**
++ * Parse ACPI driver parameters
++ */
++struct plat_stmmacenet_data *
++stmmac_probe_config_acpi(struct platform_device *pdev, u8 *mac)
++{
++	struct fwnode_handle *np;
++	struct plat_stmmacenet_data *plat;
++	struct stmmac_dma_cfg *dma_cfg;
++
++	plat = devm_kzalloc(&pdev->dev, sizeof(*plat), GFP_KERNEL);
++	if (!plat)
++		return ERR_PTR(-ENOMEM);
++
++	np = dev_fwnode(&(pdev->dev));
++
++	plat->interface = fw_get_phy_mode(np);
++
++	/* Get max speed of operation from device tree */
++	if (fwnode_property_read_u32(np, "max-speed", &plat->max_speed))
++		plat->max_speed = -1;
++
++	if (fwnode_property_read_u32(np, "bus_id", &plat->bus_id))
++		plat->bus_id = 2;
++
++	/* Default to PHY auto-detection */
++	plat->phy_addr = -1;
++
++	/* "snps,phy-addr" is not a standard property. Mark it as deprecated
++	 * and warn of its use. Remove this when PHY node support is added.
++         */
++	if (fwnode_property_read_u32(np, "snps,phy-addr", &plat->phy_addr) == 0)
++		dev_warn(&pdev->dev, "snps,phy-addr property is deprecated\n");
++
++	if (stmmac_acpi_phy(plat, np, &pdev->dev))
++		return ERR_PTR(-ENODEV);
++
++	fwnode_property_read_u32(np, "tx-fifo-depth", &plat->tx_fifo_size);
++	fwnode_property_read_u32(np, "rx-fifo-depth", &plat->rx_fifo_size);
++	if (plat->tx_fifo_size == 0)
++		plat->tx_fifo_size = 0x10000;
++	if (plat->rx_fifo_size == 0)
++		plat->rx_fifo_size = 0x10000;
++
++	plat->force_sf_dma_mode =
++		fwnode_property_read_bool(np, "snps,force_sf_dma_mode");
++	plat->en_tx_lpi_clockgating =
++		fwnode_property_read_bool(np, "snps,en-tx-lpi-clockgating");
++
++	/* Set the maxmtu to a default of JUMBO_LEN in case the
++	 * parameter is not present.
++	 */
++	plat->maxmtu = JUMBO_LEN;
++
++	/* Set default value for multicast hash bins */
++	plat->multicast_filter_bins = HASH_TABLE_SIZE;
++
++	/* Set default value for unicast filter entries */
++	plat->unicast_filter_entries = 1;
++
++	/* Only to "snps,dwmac" */
++	fwnode_property_read_u32(np, "max-frame-size", &plat->maxmtu);
++	fwnode_property_read_u32(np, "snps,multicast-filter-bins",
++				 &plat->multicast_filter_bins);
++	fwnode_property_read_u32(np, "snps,perfect-filter-entries",
++				 &plat->unicast_filter_entries);
++	plat->unicast_filter_entries = dwmac1000_validate_ucast_entries(
++						&pdev->dev, plat->unicast_filter_entries);
++	plat->multicast_filter_bins = dwmac1000_validate_mcast_bins(
++						&pdev->dev, plat->multicast_filter_bins);
++	plat->has_gmac = 1;
++	plat->pmt = 1;
++
++	dma_cfg = devm_kzalloc(&pdev->dev, sizeof(*dma_cfg), GFP_KERNEL);
++	if (!dma_cfg)
++		return ERR_PTR(-ENOMEM);
++	plat->dma_cfg = dma_cfg;
++
++	fwnode_property_read_u32(np, "snps,pbl", &dma_cfg->pbl);
++	if (!dma_cfg->pbl)
++		dma_cfg->pbl = DEFAULT_DMA_PBL;
++
++	fwnode_property_read_u32(np, "snps,txpbl", &dma_cfg->txpbl);
++	fwnode_property_read_u32(np, "snps,rxpbl", &dma_cfg->rxpbl);
++	dma_cfg->pblx8 = !fwnode_property_read_bool(np, "snps,no-pbl-x8");
++
++	dma_cfg->aal = fwnode_property_read_bool(np, "snps,aal");
++	dma_cfg->fixed_burst = fwnode_property_read_bool(np, "snps,fixed-burst");
++	dma_cfg->mixed_burst = fwnode_property_read_bool(np, "snps,mixed-burst");
++
++	plat->force_thresh_dma_mode = fwnode_property_read_bool(np, "snps,force_thresh_dma_mode");
++	if (plat->force_thresh_dma_mode)
++		plat->force_sf_dma_mode = 0;
++
++	fwnode_property_read_u32(np, "snps,ps-speed", &plat->mac_port_sel_speed);
++
++	plat->axi = stmmac_axi_setup_acpi(pdev);
++
++	stmmac_mtl_setup_acpi(pdev, plat);
++
++	stmmac_acpi_clock_setup(plat,pdev);
++
++	return plat;
++}
++#else
++struct plat_stmmacenet_data *
++stmmac_probe_config_acpi(struct platform_device *pdev, u8 *mac)
++{
++	return ERR_PTR(-EINVAL);
++}
++#endif /* CONFIG_ACPI */
++EXPORT_SYMBOL_GPL(stmmac_probe_config_acpi);
++
+ int stmmac_get_platform_resources(struct platform_device *pdev,
+ 				  struct stmmac_resources *stmmac_res)
+ {
+@@ -707,8 +952,14 @@ int stmmac_get_platform_resources(struct platform_device *pdev,
+ 
+ 	/* Get IRQ information early to have an ability to ask for deferred
+ 	 * probe if needed before we went too far with resource allocation.
++     * For ACPI _byname does not work, so we have to trust, that the
++     * first interrupt is the right one
+ 	 */
+-	stmmac_res->irq = platform_get_irq_byname(pdev, "macirq");
++    if (has_acpi_companion(&pdev->dev)) {
++	    stmmac_res->irq = platform_get_irq(pdev, 0);
++    } else {
++	    stmmac_res->irq = platform_get_irq_byname(pdev, "macirq");
++    }
+ 	if (stmmac_res->irq < 0)
+ 		return stmmac_res->irq;
+ 
+@@ -726,6 +977,7 @@ int stmmac_get_platform_resources(struct platform_device *pdev,
+ 			return -EPROBE_DEFER;
+ 		dev_info(&pdev->dev, "IRQ eth_wake_irq not found\n");
+ 		stmmac_res->wol_irq = stmmac_res->irq;
++		stmmac_res->lpi_irq = -1;
+ 	}
+ 
+ 	stmmac_res->lpi_irq =
+diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.h b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.h
+index c5565b2a70ac..783d23487612 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.h
++++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.h
+@@ -15,6 +15,8 @@ struct plat_stmmacenet_data *
+ stmmac_probe_config_dt(struct platform_device *pdev, u8 *mac);
+ struct plat_stmmacenet_data *
+ devm_stmmac_probe_config_dt(struct platform_device *pdev, u8 *mac);
++struct plat_stmmacenet_data *
++stmmac_probe_config_acpi(struct platform_device *pdev, u8 *mac);
+ void stmmac_remove_config_dt(struct platform_device *pdev,
+ 			     struct plat_stmmacenet_data *plat);
+ 
+diff --git a/drivers/net/phy/at803x.c b/drivers/net/phy/at803x.c
+index 8a77ec33b417..4d1dd1db48ea 100644
+--- a/drivers/net/phy/at803x.c
++++ b/drivers/net/phy/at803x.c
+@@ -111,6 +111,11 @@
+ #define AT803X_DEBUG_SYSTEM_CTRL_MODE		0x05
+ #define AT803X_DEBUG_TX_CLK_DLY_EN		BIT(8)
+ 
++#define AT803X_DEBUG_REG_B                      0x0B
++#define AT803X_DEBUG_REG_B_HIBERNATION_ENABLE	0x1
++#define AT803X_DEBUG_REG_B_HIBERNATION_OFFSET	15
++
++
+ #define AT803X_DEBUG_REG_HIB_CTRL		0x0b
+ #define   AT803X_DEBUG_HIB_CTRL_SEL_RST_80U	BIT(10)
+ #define   AT803X_DEBUG_HIB_CTRL_EN_ANY_CHANGE	BIT(13)
+@@ -390,6 +395,20 @@ static int at803x_enable_rx_delay(struct phy_device *phydev)
+ 				     AT803X_DEBUG_RX_CLK_DLY_EN);
+ }
+ 
++static inline int at803x_disable_hibernate(struct phy_device *phydev)
++{
++	int ret = 0;
++	u16 val = 0;
++
++	ret = at803x_debug_reg_read(phydev, AT803X_DEBUG_REG_B);
++	if (ret < 0)
++		return ret;
++
++	val = ret & 0xffff;
++	val &= (~(AT803X_DEBUG_REG_B_HIBERNATION_ENABLE << AT803X_DEBUG_REG_B_HIBERNATION_OFFSET));
++	return phy_write(phydev, AT803X_DEBUG_DATA, val);
++}
++
+ static int at803x_enable_tx_delay(struct phy_device *phydev)
+ {
+ 	return at803x_debug_reg_mask(phydev, AT803X_DEBUG_SYSTEM_CTRL_MODE, 0,
+@@ -1039,6 +1058,10 @@ static int at803x_config_init(struct phy_device *phydev)
+ 		ret = at803x_disable_rx_delay(phydev);
+ 	if (ret < 0)
+ 		return ret;
++	else
++		ret = at803x_disable_hibernate(phydev);
++	if (ret < 0)
++		return ret;
+ 
+ 	if (phydev->interface == PHY_INTERFACE_MODE_RGMII_ID ||
+ 	    phydev->interface == PHY_INTERFACE_MODE_RGMII_TXID)
+-- 
+Armbian
+

--- a/patch/kernel/archive/uefi-arm64-6.6/driver-phytium-stmmac-acpi.patch
+++ b/patch/kernel/archive/uefi-arm64-6.6/driver-phytium-stmmac-acpi.patch
@@ -9,6 +9,8 @@ Subject: Phytium onboard ethernet drivers for 6.x
  - small api change in upstream around 5.19
  - hand-merged for 6.5
    - use `.remove_new` due to "net: stmmac: Make stmmac_pltfr_remove() return void"
+ - hand-merged for 6.6:
+   - OXNAS is no more, Makefile lost reference, fix manually
  - Remove Kconfig deps from Feiteng stuff not in mainline
  - Default Kconfig to module
  Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
@@ -24,12 +26,12 @@ Subject: Phytium onboard ethernet drivers for 6.x
  8 files changed, 531 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/Kconfig b/drivers/net/ethernet/stmicro/stmmac/Kconfig
-index 5583f0b055ec..96c72e4b3218 100644
+index 06c6871f8788..b8b8d6ee5d9f 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/Kconfig
 +++ b/drivers/net/ethernet/stmicro/stmmac/Kconfig
-@@ -132,6 +132,16 @@ config DWMAC_OXNAS
- 	  This selects the Oxford Semiconductor OXNASSoC glue layer support for
- 	  the stmmac device driver. This driver is used for OX820.
+@@ -121,6 +121,16 @@ config DWMAC_MESON
+ 	  the stmmac device driver. This driver is used for Meson6,
+ 	  Meson8, Meson8b and GXBB SoCs.
  
 +config DWMAC_PHYTIUM
 +	tristate "Phytium DWMAC support"
@@ -45,13 +47,13 @@ index 5583f0b055ec..96c72e4b3218 100644
  	tristate "Qualcomm ETHQOS support"
  	default ARCH_QCOM
 diff --git a/drivers/net/ethernet/stmicro/stmmac/Makefile b/drivers/net/ethernet/stmicro/stmmac/Makefile
-index 7dd3d388068b..79df9e87cbad 100644
+index 5b57aee19267..91b1cf9bc81c 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/Makefile
 +++ b/drivers/net/ethernet/stmicro/stmmac/Makefile
-@@ -20,6 +20,7 @@ obj-$(CONFIG_DWMAC_LPC18XX)	+= dwmac-lpc18xx.o
+@@ -19,6 +19,7 @@ obj-$(CONFIG_DWMAC_IPQ806X)	+= dwmac-ipq806x.o
+ obj-$(CONFIG_DWMAC_LPC18XX)	+= dwmac-lpc18xx.o
  obj-$(CONFIG_DWMAC_MEDIATEK)	+= dwmac-mediatek.o
  obj-$(CONFIG_DWMAC_MESON)	+= dwmac-meson.o dwmac-meson8b.o
- obj-$(CONFIG_DWMAC_OXNAS)	+= dwmac-oxnas.o
 +obj-$(CONFIG_DWMAC_PHYTIUM)	+= dwmac-phytium.o
  obj-$(CONFIG_DWMAC_QCOM_ETHQOS)	+= dwmac-qcom-ethqos.o
  obj-$(CONFIG_DWMAC_ROCKCHIP)	+= dwmac-rk.o
@@ -336,7 +338,7 @@ index 000000000000..e6ad44b80a10
 +MODULE_DESCRIPTION("Glue driver for Phytium DWMAC");
 +MODULE_LICENSE("GPL v2");
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index 4727f7be4f86..0595591b85bd 100644
+index 83c567a89a46..9d0842b59c5c 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 @@ -14,6 +14,7 @@
@@ -348,7 +350,7 @@ index 4727f7be4f86..0595591b85bd 100644
  #include <linux/kernel.h>
  #include <linux/interrupt.h>
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
-index 231152ee5a32..696c1faef2be 100644
+index 0f28795e581c..1552acf6c2b8 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 @@ -9,6 +9,9 @@
@@ -648,7 +650,7 @@ index c5565b2a70ac..783d23487612 100644
  			     struct plat_stmmacenet_data *plat);
  
 diff --git a/drivers/net/phy/at803x.c b/drivers/net/phy/at803x.c
-index 8a77ec33b417..4d1dd1db48ea 100644
+index 37fb033e1c29..bf6ba5e81a95 100644
 --- a/drivers/net/phy/at803x.c
 +++ b/drivers/net/phy/at803x.c
 @@ -111,6 +111,11 @@
@@ -663,7 +665,7 @@ index 8a77ec33b417..4d1dd1db48ea 100644
  #define AT803X_DEBUG_REG_HIB_CTRL		0x0b
  #define   AT803X_DEBUG_HIB_CTRL_SEL_RST_80U	BIT(10)
  #define   AT803X_DEBUG_HIB_CTRL_EN_ANY_CHANGE	BIT(13)
-@@ -390,6 +395,20 @@ static int at803x_enable_rx_delay(struct phy_device *phydev)
+@@ -397,6 +402,20 @@ static int at803x_enable_rx_delay(struct phy_device *phydev)
  				     AT803X_DEBUG_RX_CLK_DLY_EN);
  }
  
@@ -684,7 +686,7 @@ index 8a77ec33b417..4d1dd1db48ea 100644
  static int at803x_enable_tx_delay(struct phy_device *phydev)
  {
  	return at803x_debug_reg_mask(phydev, AT803X_DEBUG_SYSTEM_CTRL_MODE, 0,
-@@ -1039,6 +1058,10 @@ static int at803x_config_init(struct phy_device *phydev)
+@@ -1037,6 +1056,10 @@ static int at803x_config_init(struct phy_device *phydev)
  		ret = at803x_disable_rx_delay(phydev);
  	if (ret < 0)
  		return ret;

--- a/patch/kernel/archive/uefi-arm64-6.6/fix-stmmac-acpi-glue-for-Feiteng-on-6.6.y.patch
+++ b/patch/kernel/archive/uefi-arm64-6.6/fix-stmmac-acpi-glue-for-Feiteng-on-6.6.y.patch
@@ -1,0 +1,63 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ricardo Pardini <ricardo@pardini.net>
+Date: Mon, 2 Oct 2023 17:49:13 +0200
+Subject: fix stmmac acpi glue for Feiteng on 6.6.y
+
+---
+ drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c   | 7 ++++---
+ drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c | 7 ++++---
+ 2 files changed, 8 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
+index e6ad44b80a10..733f5ea20d0c 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
++++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-phytium.c
+@@ -55,7 +55,7 @@ dwmac_phytium_parse_config_acpi(struct platform_device *pdev, const char *mac)
+ 	np = dev_fwnode(dev);
+ 
+ 	plat->phy_interface = fwnode_get_phy_mode(np);
+-	plat->interface = plat->phy_interface;
++	plat->mac_interface = plat->phy_interface;
+ 
+ 	/* Get max speed of operation from properties */
+ 	if (fwnode_property_read_u32(np, "max-speed", &plat->max_speed))
+@@ -80,8 +80,9 @@ dwmac_phytium_parse_config_acpi(struct platform_device *pdev, const char *mac)
+ 
+ 	plat->force_sf_dma_mode =
+ 		fwnode_property_read_bool(np, "snps,force_sf_dma_mode");
+-	plat->en_tx_lpi_clockgating =
+-		fwnode_property_read_bool(np, "snps,en-tx-lpi-clockgating");
++
++	if (fwnode_property_read_bool(np, "snps,en-tx-lpi-clockgating"))
++		plat->flags |= STMMAC_FLAG_EN_TX_LPI_CLOCKGATING;
+ 
+ 	/* Set the maxmtu to a default of JUMBO_LEN in case the
+ 	 * parameter is not present.
+diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
+index 1552acf6c2b8..e1e63e51530e 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
++++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
+@@ -848,7 +848,7 @@ stmmac_probe_config_acpi(struct platform_device *pdev, u8 *mac)
+ 
+ 	np = dev_fwnode(&(pdev->dev));
+ 
+-	plat->interface = fw_get_phy_mode(np);
++	plat->mac_interface = fw_get_phy_mode(np);
+ 
+ 	/* Get max speed of operation from device tree */
+ 	if (fwnode_property_read_u32(np, "max-speed", &plat->max_speed))
+@@ -878,8 +878,9 @@ stmmac_probe_config_acpi(struct platform_device *pdev, u8 *mac)
+ 
+ 	plat->force_sf_dma_mode =
+ 		fwnode_property_read_bool(np, "snps,force_sf_dma_mode");
+-	plat->en_tx_lpi_clockgating =
+-		fwnode_property_read_bool(np, "snps,en-tx-lpi-clockgating");
++
++	if (fwnode_property_read_bool(np, "snps,en-tx-lpi-clockgating"))
++		plat->flags |= STMMAC_FLAG_EN_TX_LPI_CLOCKGATING;
+ 
+ 	/* Set the maxmtu to a default of JUMBO_LEN in case the
+ 	 * parameter is not present.
+-- 
+Armbian
+

--- a/patch/kernel/uefi-arm64-edge
+++ b/patch/kernel/uefi-arm64-edge
@@ -1,1 +1,1 @@
-archive/uefi-arm64-6.5
+archive/uefi-arm64-6.6


### PR DESCRIPTION
#### `uefi-arm64`/`edge`: bump to 6.6-rc4

- `uefi-arm64`/`edge`: bump to 6.6-rc4 - initial copy from 6.5
- `uefi-arm64`/`edge` 6.6.y: bump to 6.6-rc4 - fix phytium stmmac acpi patch for 6.6
- `uefi-arm64`/`edge` 6.6.y: futher fix for phytium stmmac acpi glue