### PR TITLE
u-boot: sunxi: bumped to 2023.10

### DIFF
--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -12,7 +12,7 @@ declare -g ATF_TARGET_MAP="PLAT=$ATF_PLAT DEBUG=1 bl31;;build/$ATF_PLAT/debug/bl
 declare -g ATFBRANCH="tag:v2.9.0"
 declare -g BOOTDELAY=1
 declare -g BOOTPATCHDIR="${BOOTPATCHDIR:-"u-boot-sunxi"}"
-declare -g BOOTBRANCH="${BOOTBRANCH:-"tag:v2023.07.02"}"
+declare -g BOOTBRANCH="${BOOTBRANCH:-"tag:v2023.10"}"
 declare -g BOOTENV_FILE='sunxi.txt'
 UBOOT_TARGET_MAP="${UBOOT_TARGET_MAP:-BINMAN_ALLOW_MISSING=1;;u-boot-sunxi-with-spl.bin}"
 declare -g BOOTSCRIPT='boot-sun50i-next.cmd:boot.cmd'

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -10,7 +10,7 @@ enable_extension "sunxi-tools"
 declare -g ARCH=armhf
 declare -g BOOTDELAY=1
 declare -g BOOTPATCHDIR="${BOOTPATCHDIR:-"u-boot-sunxi"}"
-declare -g BOOTBRANCH="${BOOTBRANCH:-"tag:v2023.07.02"}"
+declare -g BOOTBRANCH="${BOOTBRANCH:-"tag:v2023.10"}"
 UBOOT_TARGET_MAP="${UBOOT_TARGET_MAP:-;;u-boot-sunxi-with-spl.bin}"
 declare -g BOOTSCRIPT="boot-sunxi.cmd:boot.cmd"
 declare -g BOOTENV_FILE='sunxi.txt'

--- a/patch/u-boot/u-boot-sunxi/allwinner-boot-splash.patch
+++ b/patch/u-boot/u-boot-sunxi/allwinner-boot-splash.patch
@@ -1,4 +1,4 @@
-From a35a53fd1e4b82dc1bf441b6986fffa87c30400d Mon Sep 17 00:00:00 2001
+From f0df8777f6d406d5022eaec8ac3ec20f5b12aa3c Mon Sep 17 00:00:00 2001
 From: The Going <48602507+The-going@users.noreply.github.com>
 Date: Fri, 1 Apr 2022 22:57:09 +0300
 Subject: [PATCH] sunxi boot splash
@@ -10,22 +10,22 @@ Subject: [PATCH] sunxi boot splash
  3 files changed, 40 insertions(+)
 
 diff --git a/cmd/Kconfig b/cmd/Kconfig
-index b2d7598717..ccd585bb24 100644
+index 43ca10f69cc..9051800d6d1 100644
 --- a/cmd/Kconfig
 +++ b/cmd/Kconfig
-@@ -1912,6 +1912,7 @@ menu "Misc commands"
- config CMD_BMP
+@@ -2017,6 +2017,7 @@ config CMD_BMP
  	bool "Enable 'bmp' command"
  	depends on VIDEO
+ 	select BMP
 +	default y
  	help
  	  This provides a way to obtain information about a BMP-format image
  	  and to display it. BMP (which presumably stands for BitMaP) is a
 diff --git a/include/config_distro_bootcmd.h b/include/config_distro_bootcmd.h
-index c3a2414b91..3f75840f27 100644
+index 2a136b96a6d..fac28ceb155 100644
 --- a/include/config_distro_bootcmd.h
 +++ b/include/config_distro_bootcmd.h
-@@ -469,6 +469,15 @@
+@@ -492,6 +492,15 @@
  	BOOTENV_SHARED_VIRTIO \
  	BOOTENV_SHARED_EXTENSION \
  	"boot_prefixes=/ /boot/\0" \
@@ -42,10 +42,10 @@ index c3a2414b91..3f75840f27 100644
  	"boot_script_dhcp=boot.scr.uimg\0" \
  	BOOTENV_BOOT_TARGETS \
 diff --git a/include/configs/sunxi-common.h b/include/configs/sunxi-common.h
-index e89ad42ce8..54fee64bcc 100644
+index d2d70f0fc23..b318baf17c4 100644
 --- a/include/configs/sunxi-common.h
 +++ b/include/configs/sunxi-common.h
-@@ -106,6 +106,30 @@
+@@ -97,6 +97,30 @@
  #define LOW_LEVEL_SRAM_STACK		0x00008000	/* End of sram */
  #endif
  
@@ -76,7 +76,7 @@ index e89ad42ce8..54fee64bcc 100644
  /* Ethernet support */
  
  #ifdef CONFIG_ARM64
-@@ -286,8 +310,14 @@
+@@ -277,8 +301,14 @@
  #include <config_distro_bootcmd.h>
  
  #ifdef CONFIG_USB_KEYBOARD


### PR DESCRIPTION
# Description

Bumped u-boot for allwinner to 2023.10

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] All patches gets applied
- [X] U-boot build for all of the allwinner boards

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
