### PR TITLE
uboot: sunxi: fix compilation failure on orangepizero2 and Bigtreetech cb1

### DIFF
--- a/patch/u-boot/u-boot-sunxi/board_bigtreetech-cb1/bigtreetech-cb1-dts-add-deconfig.patch
+++ b/patch/u-boot/u-boot-sunxi/board_bigtreetech-cb1/bigtreetech-cb1-dts-add-deconfig.patch
@@ -6,8 +6,8 @@ Subject: [PATCH 06/11] Add: add BigTreeTech CB1 dts & deconfig files
 ---
  arch/arm/dts/sun50i-h616-bigtreetech-cb1.dts | 219 +++++++++++++++++++
  arch/arm/dts/sun50i-h616.dtsi                |   6 +-
- configs/bigtreetech_cb1_defconfig            |  25 +++
- 3 files changed, 247 insertions(+), 3 deletions(-)
+ configs/bigtreetech_cb1_defconfig            |  28 +++
+ 3 files changed, 250 insertions(+), 3 deletions(-)
  create mode 100644 arch/arm/dts/sun50i-h616-bigtreetech-cb1.dts
  create mode 100644 configs/bigtreetech_cb1_defconfig
 
@@ -272,7 +272,7 @@ new file mode 100644
 index 0000000000..96c5c17cff
 --- /dev/null
 +++ b/configs/bigtreetech_cb1_defconfig
-@@ -0,0 +1,27 @@
+@@ -0,0 +1,28 @@
 +CONFIG_ARM=y
 +CONFIG_ARCH_SUNXI=y
 +CONFIG_DEFAULT_DEVICE_TREE="sun50i-h616-bigtreetech-cb1"
@@ -282,6 +282,7 @@ index 0000000000..96c5c17cff
 +CONFIG_DRAM_SUN50I_H616_CA_DRI=0x0e0e
 +CONFIG_DRAM_SUN50I_H616_TPR10=0xf83438
 +CONFIG_MACH_SUN50I_H616=y
++CONFIG_SUNXI_DRAM_H616_DDR3_1333=y
 +CONFIG_R_I2C_ENABLE=y
 +CONFIG_SPL_SPI_SUNXI=y
 +# CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set

--- a/patch/u-boot/u-boot-sunxi/board_orangepizero2/orangepizero2_light_red_led_on.patch
+++ b/patch/u-boot/u-boot-sunxi/board_orangepizero2/orangepizero2_light_red_led_on.patch
@@ -1,4 +1,4 @@
-From b2750ef240a92a06d0531d4b7d3d4820c7c45ad2 Mon Sep 17 00:00:00 2001
+From 00317cc991c0b4f14502bf65c6e0bd788dfa9322 Mon Sep 17 00:00:00 2001
 From: orangepi-xunlong <258384131@qq.com>
 Date: Mon, 18 Apr 2022 10:43:17 +0800
 Subject: [PATCH] sunxi: orangepizero2: light up red led
@@ -10,10 +10,10 @@ Subject: [PATCH] sunxi: orangepizero2: light up red led
  3 files changed, 17 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm/mach-sunxi/Kconfig b/arch/arm/mach-sunxi/Kconfig
-index 08cfc581cb..03743f03fb 100644
+index e1698f4027b..8d6c10fab11 100644
 --- a/arch/arm/mach-sunxi/Kconfig
 +++ b/arch/arm/mach-sunxi/Kconfig
-@@ -652,6 +652,13 @@ config MACPWR
+@@ -702,6 +702,13 @@ config MACPWR
  	  Set the pin used to power the MAC. This takes a string in the format
  	  understood by sunxi_name_to_gpio, e.g. PH1 for pin 1 of port H.
  
@@ -28,7 +28,7 @@ index 08cfc581cb..03743f03fb 100644
  	bool "Pins for mmc1 are on Port H"
  	depends on MACH_SUN4I || MACH_SUN7I || MACH_SUN8I_R40
 diff --git a/board/sunxi/board.c b/board/sunxi/board.c
-index 3079ac0002..1dad128a85 100644
+index fd317a7d480..152e764d72f 100644
 --- a/board/sunxi/board.c
 +++ b/board/sunxi/board.c
 @@ -187,7 +187,7 @@ enum env_location env_get_location(enum env_operation op, int prio)
@@ -56,13 +56,13 @@ index 3079ac0002..1dad128a85 100644
  	/*
  	 * The bit[16] of register reg[0x03000000] must be zero for the THS
 diff --git a/configs/orangepi_zero2_defconfig b/configs/orangepi_zero2_defconfig
-index 72fc419ca7..63e6ec9f46 100644
+index f13735e91c7..c88cd095205 100644
 --- a/configs/orangepi_zero2_defconfig
 +++ b/configs/orangepi_zero2_defconfig
-@@ -19,3 +19,4 @@ CONFIG_SPI_FLASH_MACRONIX=y
- CONFIG_PHY_REALTEK=y
- CONFIG_SUN8I_EMAC=y
- CONFIG_SPI=y
+@@ -23,3 +23,4 @@ CONFIG_SPI=y
+ CONFIG_USB_EHCI_HCD=y
+ CONFIG_USB_OHCI_HCD=y
+ CONFIG_USB_MUSB_GADGET=y
 +CONFIG_PWRLED="PC12"
 -- 
 2.34.1


### PR DESCRIPTION
# Description

Fixes compilation issue introduced by u-boot bump. Not sure why this was not caught in the test as I ran building of all allwinner u-boots in a loop. Anyways, now these are getting built correctly

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested u-boot builds for orangepizero2
- [X] Tested u-boot builds for Bigtreetech cb1

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
