### PR TITLE
`Automatic` board configs status synchronise

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,7 +45,6 @@ config/boards/khadas-vim4.wip		@rpardini
 config/boards/lafrite.conf		@Tonymac32
 config/boards/lepotato.conf		@Tonymac32
 config/boards/licheepi-4a.wip		@chainsx
-config/boards/mangopi-mq.wip		@Zinput
 config/boards/mekotronics-r58-minipc.wip		@monkaBlyat
 config/boards/mekotronics-r58x-4g.wip		@monkaBlyat
 config/boards/mekotronics-r58x.wip		@monkaBlyat
@@ -107,7 +106,6 @@ config/boards/uefi-arm64.conf		@rpardini
 config/boards/uefi-x86.conf		@rpardini
 config/kernel/linux-arm64-*.config		@rpardini
 config/kernel/linux-bcm2711-*.config		@PanderMusubi @teknoid
-config/kernel/linux-d1-*.config		@Zinput
 config/kernel/linux-k3-*.config		@glneo
 config/kernel/linux-media-*.config		@150balbes
 config/kernel/linux-meson-*.config		@hzyitc
@@ -146,7 +144,6 @@ patch/kernel/archive/sunxi-*/		@AGM1968 @AaronNGray @DylanHP @Kreyren @PanderMus
 patch/kernel/archive/uefi-arm64-*/		@rpardini
 patch/kernel/arm64-*/		@rpardini
 patch/kernel/bcm2711-*/		@PanderMusubi @teknoid
-patch/kernel/d1-*/		@Zinput
 patch/kernel/k3-*/		@glneo
 patch/kernel/media-*/		@150balbes
 patch/kernel/meson-*/		@hzyitc
@@ -165,7 +162,6 @@ patch/kernel/uefi-arm64-*/		@rpardini
 patch/kernel/uefi-x86-*/		@rpardini
 sources/families/arm64.conf		@rpardini
 sources/families/bcm2711.conf		@PanderMusubi @teknoid
-sources/families/d1.conf		@Zinput
 sources/families/k3.conf		@glneo
 sources/families/media.conf		@150balbes
 sources/families/meson-s4t7.conf		@rpardini @viraniac

--- a/config/boards/mangopi-mq.csc
+++ b/config/boards/mangopi-mq.csc
@@ -1,7 +1,7 @@
 # RISC-V Mangopi-MQ D1
 BOARD_NAME="Mangopi-MQ"
 BOARDFAMILY="d1"
-BOARD_MAINTAINER="Zinput"
+BOARD_MAINTAINER=""
 KERNEL_TARGET="edge"
 BOOT_FDT_FILE="allwinner/sun20i-d1-nezha.dtb"
 SRC_EXTLINUX="yes"


### PR DESCRIPTION
Update maintainers and board status

- synced status from the database
- rename to .`csc` where we don't have anyone

If you want to become a board maintainer, [adjust data here](https://www.armbian.com/update-data/).

Ref: [Board Maintainers Procedures and Guidelines](https://docs.armbian.com/Board_Maintainers_Procedures_and_Guidelines/)