### PR TITLE
cli: add command to rewrite/refresh kernel configs

### DIFF
--- a/lib/functions/artifacts/artifact-kernel.sh
+++ b/lib/functions/artifacts/artifact-kernel.sh
@@ -244,7 +244,7 @@ function artifact_kernel_cli_adapter_pre_run() {
 function artifact_kernel_cli_adapter_config_prep() {
 	# Sanity check / cattle guard
 	# If KERNEL_CONFIGURE=yes, or CREATE_PATCHES=yes, user must have used the correct CLI commands, and only add those params.
-	if [[ "${KERNEL_CONFIGURE}" == "yes" && "${ARMBIAN_COMMAND}" != "kernel-config" ]]; then
+	if [[ "${KERNEL_CONFIGURE}" == "yes" && "${ARMBIAN_COMMAND}" != *kernel-config ]]; then
 		exit_with_error "KERNEL_CONFIGURE=yes is not supported anymore. Please use the new 'kernel-config' CLI command. Current command: '${ARMBIAN_COMMAND}'"
 	fi
 

--- a/lib/functions/cli/commands.sh
+++ b/lib/functions/cli/commands.sh
@@ -59,6 +59,7 @@ function armbian_register_commands() {
 		["kernel"]="artifact"
 		["kernel-patch"]="artifact"
 		["kernel-config"]="artifact"
+		["rewrite-kernel-config"]="artifact"
 
 		["uboot"]="artifact"
 		["uboot-patch"]="artifact"
@@ -110,6 +111,7 @@ function armbian_register_commands() {
 
 		["kernel"]="WHAT='kernel' ${common_cli_artifact_vars}"
 		["kernel-config"]="WHAT='kernel' KERNEL_CONFIGURE='yes' ${common_cli_artifact_interactive_vars} ${common_cli_artifact_vars}"
+		["rewrite-kernel-config"]="WHAT='kernel' KERNEL_CONFIGURE='yes' ARTIFACT_WILL_NOT_BUILD='yes' ARTIFACT_IGNORE_CACHE='yes' ${common_cli_artifact_vars}"
 		["kernel-patch"]="WHAT='kernel' CREATE_PATCHES='yes' ${common_cli_artifact_interactive_vars} ${common_cli_artifact_vars}"
 
 		["uboot"]="WHAT='uboot' ${common_cli_artifact_vars}"

--- a/lib/functions/compilation/kernel-config.sh
+++ b/lib/functions/compilation/kernel-config.sh
@@ -33,9 +33,11 @@ function kernel_config() {
 	LOG_SECTION="kernel_config_initialize" do_with_logging do_with_hooks kernel_config_initialize
 
 	if [[ "${KERNEL_CONFIGURE}" == "yes" ]]; then
-		# This piece is interactive, no logging
-		display_alert "Starting (interactive) kernel ${KERNEL_MENUCONFIG:-menuconfig}" "${LINUXCONFIG}" "debug"
-		run_kernel_make_dialog "${KERNEL_MENUCONFIG:-menuconfig}"
+		if [[ "${ARMBIAN_COMMAND}" == "kernel-config" ]]; then
+			# This piece is interactive, no logging
+			display_alert "Starting (interactive) kernel ${KERNEL_MENUCONFIG:-menuconfig}" "${LINUXCONFIG}" "debug"
+			run_kernel_make_dialog "${KERNEL_MENUCONFIG:-menuconfig}"
+		fi
 
 		# Export, but log about it too.
 		LOG_SECTION="kernel_config_export" do_with_logging do_with_hooks kernel_config_export

--- a/lib/functions/compilation/kernel.sh
+++ b/lib/functions/compilation/kernel.sh
@@ -77,7 +77,7 @@ function compile_kernel() {
 
 	# Stop after configuring kernel, but only if using a specific CLI command ("kernel-config").
 	# Normal "KERNEL_CONFIGURE=yes" (during image build) is still allowed.
-	if [[ "${KERNEL_CONFIGURE}" == yes && "${ARMBIAN_COMMAND}" == "kernel-config" ]]; then
+	if [[ "${KERNEL_CONFIGURE}" == yes && "${ARMBIAN_COMMAND}" == *kernel-config ]]; then
 		display_alert "Stopping after configuring kernel" "" "cachehit"
 		return 0
 	fi


### PR DESCRIPTION
# Description

Adding a command that can be used to refresh kernel configs without launching menuconfig interface. This can be helpful to refresh kernel configs  when doing kernel upgrades for all kernels being bumped by running in a for loop and can be also be used in some automation to periodically refresh kernel configs

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested by running `./compile.sh BOARD=khadas-vim4 BRANCH=legacy rewrite-kernel-config`. It refreshed and updated `config/kernel/linux-meson-s4t7-legacy.config` file based on the needed updates which in this case was mostly compiler and toolchain versions as this file has not been refreshed for sometime now.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
