### PR TITLE
Use GITHUB_SOURCE to accelerate download file from github

### DIFF
--- a/lib/functions/general/bat-cat.sh
+++ b/lib/functions/general/bat-cat.sh
@@ -54,7 +54,7 @@ function run_tool_batcat() {
 
 	declare BATCAT_FN="bat-v${BATCAT_VERSION}-${BATCAT_ARCH_OS}"
 	declare BATCAT_FN_TARXZ="${BATCAT_FN}.tar.gz"
-	declare DOWN_URL="https://github.com/sharkdp/bat/releases/download/v${BATCAT_VERSION}/${BATCAT_FN_TARXZ}"
+	declare DOWN_URL="${GITHUB_SOURCE}/sharkdp/bat/releases/download/v${BATCAT_VERSION}/${BATCAT_FN_TARXZ}"
 	declare BATCAT_BIN="${DIR_BATCAT}/${BATCAT_FN}-bin"
 	declare ACTUAL_VERSION
 
@@ -116,7 +116,7 @@ function try_download_batcat_tooling() {
 	run_host_command_logged rm -rf "${BATCAT_BIN}.tar.gz"
 
 	# EXTRA: get more syntaxes for batcat. We need Debian syntax for CONTROL files, etc.
-	run_host_command_logged wget --no-verbose --progress=dot:giga -O "${DIR_BATCAT}/sublime-debian.tar.gz.tmp" "https://github.com/barnumbirr/sublime-debian/archive/refs/heads/master.tar.gz"
+	run_host_command_logged wget --no-verbose --progress=dot:giga -O "${DIR_BATCAT}/sublime-debian.tar.gz.tmp" "${GITHUB_SOURCE}/barnumbirr/sublime-debian/archive/refs/heads/master.tar.gz"
 	run_host_command_logged mkdir -p "${DIR_BATCAT}/temp-debian-syntax"
 	run_host_command_logged tar -xzf "${DIR_BATCAT}/sublime-debian.tar.gz.tmp" -C "${DIR_BATCAT}/temp-debian-syntax" sublime-debian-master/Syntaxes
 

--- a/lib/functions/general/oci-oras.sh
+++ b/lib/functions/general/oci-oras.sh
@@ -55,7 +55,7 @@ function run_tool_oras() {
 
 	declare ORAS_FN="oras_${ORAS_VERSION}_${ORAS_OS}_${ORAS_ARCH}"
 	declare ORAS_FN_TARXZ="${ORAS_FN}.tar.gz"
-	declare DOWN_URL="https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/${ORAS_FN_TARXZ}"
+	declare DOWN_URL="${GITHUB_SOURCE}/oras-project/oras/releases/download/v${ORAS_VERSION}/${ORAS_FN_TARXZ}"
 	declare ORAS_BIN="${DIR_ORAS}/${ORAS_FN}"
 	declare ACTUAL_VERSION
 

--- a/lib/functions/general/shellcheck.sh
+++ b/lib/functions/general/shellcheck.sh
@@ -94,7 +94,7 @@ function run_tool_shellcheck() {
 
 	declare SHELLCHECK_FN="shellcheck-v${SHELLCHECK_VERSION}.${SHELLCHECK_OS}.${SHELLCHECK_ARCH}"
 	declare SHELLCHECK_FN_TARXZ="${SHELLCHECK_FN}.tar.xz"
-	declare DOWN_URL="https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/${SHELLCHECK_FN_TARXZ}"
+	declare DOWN_URL="${GITHUB_SOURCE}/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/${SHELLCHECK_FN_TARXZ}"
 	declare SHELLCHECK_BIN="${DIR_SHELLCHECK}/${SHELLCHECK_FN}"
 	declare ACTUAL_VERSION
 

--- a/lib/tools/shellcheck.sh
+++ b/lib/tools/shellcheck.sh
@@ -43,7 +43,7 @@ esac
 
 SHELLCHECK_FN="shellcheck-v${SHELLCHECK_VERSION}.${SHELLCHECK_OS}.${SHELLCHECK_ARCH}"
 SHELLCHECK_FN_TARXZ="${SHELLCHECK_FN}.tar.xz"
-DOWN_URL="https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/${SHELLCHECK_FN_TARXZ}"
+DOWN_URL="${GITHUB_SOURCE:-https://github.com}/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/${SHELLCHECK_FN_TARXZ}"
 SHELLCHECK_BIN="${DIR_SHELLCHECK}/${SHELLCHECK_FN}"
 
 if [[ ! -f "${SHELLCHECK_BIN}" ]]; then

--- a/lib/tools/shellfmt.sh
+++ b/lib/tools/shellfmt.sh
@@ -38,7 +38,7 @@ case "$MACHINE" in
 esac
 
 SHELLFMT_FN="shfmt_v${SHELLFMT_VERSION}_${SHELLFMT_OS}_${SHELLFMT_ARCH}"
-DOWN_URL="https://github.com/mvdan/sh/releases/download/v${SHELLFMT_VERSION}/${SHELLFMT_FN}"
+DOWN_URL="${GITHUB_SOURCE:-https://github.com}/mvdan/sh/releases/download/v${SHELLFMT_VERSION}/${SHELLFMT_FN}"
 SHELLFMT_BIN="${DIR_SHELLFMT}/${SHELLFMT_FN}"
 
 echo "MACHINE: ${MACHINE}"


### PR DESCRIPTION
# Description

This patch to slove the issue when download releate files (batcat, oras, shellcheck ...) from github.com in china during building.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] test with command ``./compile.sh build GITHUB_MIRROR=ghproxy REGIONAL_MIRROR=china BOARD=licheepi-4a BRANCH=legacy BUILD_DESKTOP=no BUILD_MINIMAL=yes KERNEL_CONFIGURE=yes RELEASE=jammy SKIP_EXTERNAL_TOOLCHAINS=no``,can download releate package success as:
```
[🐸] wget --no-verbose --progress=dot:giga -O /home/red/Codes_of_pro/ai_light_brain/misc/build/cache/tools/batcat/bat-v0.23.0-x86_64-unknown-linux-gnu-bin.tar.gz.tmp https://ghproxy.com/https://github.com/sharkdp
/bat/releases/download/v0.23.0/bat-v0.23.0-x86_64-unknown-linux-gnu.tar.gz
[🔨]   2023-10-06 09:43:05 URL:https://ghproxy.com/https://github.com/sharkdp/bat/releases/download/v0.23.0/bat-v0.23.0-x86_64-unknown-linux-gnu.tar.gz [2806915/2806915] -> "/home/red/Codes_of_pro/ai_light_brain/
misc/build/cache/tools/batcat/bat-v0.23.0-x86_64-unknown-linux-gnu-bin.tar.gz.tmp" [1]
[🐸] mv /home/red/Codes_of_pro/ai_light_brain/misc/build/cache/tools/batcat/bat-v0.23.0-x86_64-unknown-linux-gnu-bin.tar.gz.tmp /home/red/Codes_of_pro/ai_light_brain/misc/build/cache/tools/batcat/bat-v0.23.0-x86_
64-unknown-linux-gnu-bin.tar.gz
[🐸] tar -xf /home/red/Codes_of_pro/ai_light_brain/misc/build/cache/tools/batcat/bat-v0.23.0-x86_64-unknown-linux-gnu-bin.tar.gz -C /home/red/Codes_of_pro/ai_light_brain/misc/build/cache/tools/batcat bat-v0.23.0-
x86_64-unknown-linux-gnu/bat
[🐸] rm -rf /home/red/Codes_of_pro/ai_light_brain/misc/build/cache/tools/batcat/bat-v0.23.0-x86_64-unknown-linux-gnu-bin.tar.gz
[🐸] wget --no-verbose --progress=dot:giga -O /home/red/Codes_of_pro/ai_light_brain/misc/build/cache/tools/batcat/sublime-debian.tar.gz.tmp https://ghproxy.com/https://github.com/barnumbirr/sublime-debian/archive
/refs/heads/master.tar.gz
[🔨]   2023-10-06 09:43:06 URL:https://ghproxy.com/https://github.com/barnumbirr/sublime-debian/archive/refs/heads/master.tar.gz [28188/28188] -> "/home/red/Codes_of_pro/ai_light_brain/misc/build/cache/tools/batc
at/sublime-debian.tar.gz.tmp" [1]

...

[🐛] Down URL: https://ghproxy.com/https://github.com/oras-project/oras/releases/download/v0.16.0/oras_0.16.0_linux_amd64.tar.gz [ ORAS ]
[🐛] ORAS_BIN: /home/red/Codes_of_pro/ai_light_brain/misc/build/cache/tools/oras/oras_0.16.0_linux_amd64 [ ORAS ]
[🌱] Downloading required [ ORAS tooling ]
[🐸] wget --no-verbose --progress=dot:giga -O /home/red/Codes_of_pro/ai_light_brain/misc/build/cache/tools/oras/oras_0.16.0_linux_amd64.tar.gz.tmp https://ghproxy.com/https://github.com/oras-project/oras/releases
/download/v0.16.0/oras_0.16.0_linux_amd64.tar.gz
2023-10-06 09:43:10 URL:https://ghproxy.com/https://github.com/oras-project/oras/releases/download/v0.16.0/oras_0.16.0_linux_amd64.tar.gz [3377400/3377400] -> "/home/red/Codes_of_pro/ai_light_brain/misc/build/cac
he/tools/oras/oras_0.16.0_linux_amd64.tar.gz.tmp" [1]
[🐸] mv /home/red/Codes_of_pro/ai_light_brain/misc/build/cache/tools/oras/oras_0.16.0_linux_amd64.tar.gz.tmp /home/red/Codes_of_pro/ai_light_brain/misc/build/cache/tools/oras/oras_0.16.0_linux_amd64.tar.gz
[🐸] tar -xf /home/red/Codes_of_pro/ai_light_brain/misc/build/cache/tools/oras/oras_0.16.0_linux_amd64.tar.gz -C /home/red/Codes_of_pro/ai_light_brain/misc/build/cache/tools/oras oras

```
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
