### PR TITLE
`rockchip64` + `rk3568-odroid` / `edge` 6.6: update montjoie's rk crypto v2 patches to crypto-rk3588-03-10-2023

### DIFF
--- a/patch/kernel/archive/rk3568-odroid-6.6/5001-montjoie-crypto-rk35xx.patch
+++ b/patch/kernel/archive/rk3568-odroid-6.6/5001-montjoie-crypto-rk35xx.patch
@@ -8,15 +8,15 @@ offloader V2.
 
 Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>
 ---
- Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml | 61 ++++++++++
- 1 file changed, 61 insertions(+)
+ Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml | 77 ++++++++++
+ 1 file changed, 77 insertions(+)
 
 diff --git a/Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml b/Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml
 new file mode 100644
-index 000000000000..73e7b7003936
+index 000000000000..fbe1e1b33dab
 --- /dev/null
 +++ b/Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml
-@@ -0,0 +1,61 @@
+@@ -0,0 +1,77 @@
 +# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
 +%YAML 1.2
 +---
@@ -31,6 +31,7 @@ index 000000000000..73e7b7003936
 +properties:
 +  compatible:
 +    enum:
++      - rockchip,rk3568-crypto
 +      - rockchip,rk3588-crypto
 +
 +  reg:
@@ -78,8 +79,52 @@ index 000000000000..73e7b7003936
 +      resets = <&scmi_reset SRST_CRYPTO_CORE>;
 +      reset-names = "core";
 +    };
++  - |
++    #include <dt-bindings/interrupt-controller/arm-gic.h>
++    #include <dt-bindings/clock/rockchip,rk3568-cru.h>
++    #include <dt-bindings/reset/rockchip,rk3568-cru.h>
++    crypto@fe380000 {
++      compatible = "rockchip,rk3568-crypto";
++      reg = <0xfe380000 0x4000>;
++      interrupts = <GIC_SPI 4 IRQ_TYPE_LEVEL_HIGH>;
++      clocks = <&cru ACLK_CRYPTO_NS>, <&cru HCLK_CRYPTO_NS>,
++               <&cru CLK_CRYPTO_NS_CORE>;
++      clock-names = "aclk", "hclk", "core";
++      resets = <&cru SRST_CRYPTO_NS_CORE>, <&cru SRST_A_CRYPTO_NS>,
++               <&cru SRST_H_CRYPTO_NS>;
++      reset-names = "core", "a", "h";
++    };
 -- 
 Armbian
+
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Corentin Labbe <clabbe.montjoie@gmail.com>
+Date: Mon, 26 Sep 2022 13:38:25 +0200
+Subject: MAINTAINERS: add new dt-binding doc to the right entry
+
+Rockchip crypto driver have a new file to be added.
+
+Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>
+---
+ MAINTAINERS | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/MAINTAINERS b/MAINTAINERS
+index 208cfcc1aee3..03e47802653a 100644
+--- a/MAINTAINERS
++++ b/MAINTAINERS
+@@ -18617,6 +18617,7 @@ M:	Corentin Labbe <clabbe@baylibre.com>
+ L:	linux-crypto@vger.kernel.org
+ S:	Maintained
+ F:	Documentation/devicetree/bindings/crypto/rockchip,rk3288-crypto.yaml
++F:	Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml
+ F:	drivers/crypto/rockchip/
+ 
+ ROCKCHIP I2S TDM DRIVER
+-- 
+Armbian
+
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Corentin Labbe <clabbe.montjoie@gmail.com>
@@ -91,14 +136,14 @@ node for it.
 
 Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>
 ---
- arch/arm64/boot/dts/rockchip/rk3588s.dtsi | 11 ++++++++++
- 1 file changed, 11 insertions(+)
+ arch/arm64/boot/dts/rockchip/rk3588s.dtsi | 12 ++++++++++
+ 1 file changed, 12 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588s.dtsi b/arch/arm64/boot/dts/rockchip/rk3588s.dtsi
-index 5544f66c6ff4..911e22d75963 100644
+index 5544f66c6ff4..ffffe084a966 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s.dtsi
-@@ -1475,6 +1475,17 @@ sdhci: mmc@fe2e0000 {
+@@ -1475,6 +1475,18 @@ sdhci: mmc@fe2e0000 {
  		status = "disabled";
  	};
  
@@ -106,8 +151,9 @@ index 5544f66c6ff4..911e22d75963 100644
 +		compatible = "rockchip,rk3588-crypto";
 +		reg = <0x0 0xfe370000 0x0 0x2000>;
 +		interrupts = <GIC_SPI 209 IRQ_TYPE_LEVEL_HIGH 0>;
-+		clocks = <&scmi_clk SCMI_CRYPTO_CORE>;
-+		clock-names = "core";
++		clocks = <&scmi_clk SCMI_CRYPTO_CORE>, <&scmi_clk SCMI_ACLK_SECURE_NS>,
++			 <&scmi_clk SCMI_HCLK_SECURE_NS>;
++		clock-names = "core", "aclk", "hclk";
 +		resets = <&scmi_reset SRST_CRYPTO_CORE>;
 +		reset-names = "core";
 +		status = "okay";
@@ -119,25 +165,27 @@ index 5544f66c6ff4..911e22d75963 100644
 -- 
 Armbian
 
+
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Corentin Labbe <clabbe.montjoie@gmail.com>
 Date: Thu, 22 Sep 2022 19:38:13 +0200
-Subject: ARM64: dts: rk3568: add crypto node
+Subject: ARM64: dts: rk356x: add crypto node
 
-The rk3568 has a crypto IP handled by the rk3588 crypto driver so adds a
+Both RK3566 and RK3568 have a crypto IP handled by the rk3588 crypto driver so adds a
 node for it.
 
+Tested-by: Ricardo Pardini <ricardo@pardini.net>
 Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>
 ---
- arch/arm64/boot/dts/rockchip/rk3568.dtsi | 13 ++++++++++
- 1 file changed, 13 insertions(+)
+ arch/arm64/boot/dts/rockchip/rk356x.dtsi | 12 ++++++++++
+ 1 file changed, 12 insertions(+)
 
-diff --git a/arch/arm64/boot/dts/rockchip/rk3568.dtsi b/arch/arm64/boot/dts/rockchip/rk3568.dtsi
-index f1be76a54ceb..ff9691404db3 100644
---- a/arch/arm64/boot/dts/rockchip/rk3568.dtsi
-+++ b/arch/arm64/boot/dts/rockchip/rk3568.dtsi
-@@ -213,6 +213,19 @@ gmac0_mtl_tx_setup: tx-queues-config {
- 		};
+diff --git a/arch/arm64/boot/dts/rockchip/rk356x.dtsi b/arch/arm64/boot/dts/rockchip/rk356x.dtsi
+index abee88911982..b9cbab2246e2 100644
+--- a/arch/arm64/boot/dts/rockchip/rk356x.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk356x.dtsi
+@@ -1063,6 +1063,18 @@ sdhci: mmc@fe310000 {
+ 		status = "disabled";
  	};
  
 +	crypto: crypto@fe380000 {
@@ -147,17 +195,17 @@ index f1be76a54ceb..ff9691404db3 100644
 +		clocks = <&cru ACLK_CRYPTO_NS>, <&cru HCLK_CRYPTO_NS>,
 +			 <&cru CLK_CRYPTO_NS_CORE>;
 +		clock-names = "aclk", "hclk", "core";
-+		resets = <&cru SRST_CRYPTO_NS_CORE>, <&cru SRST_A_CRYPTO_NS>,
-+			<&cru SRST_H_CRYPTO_NS>;
-+		reset-names = "core", "a", "h";
++		resets = <&cru SRST_CRYPTO_NS_CORE>;
++		reset-names = "core";
 +		status = "okay";
 +	};
 +
- 	combphy0: phy@fe820000 {
- 		compatible = "rockchip,rk3568-naneng-combphy";
- 		reg = <0x0 0xfe820000 0x0 0x100>;
+ 	i2s0_8ch: i2s@fe400000 {
+ 		compatible = "rockchip,rk3568-i2s-tdm";
+ 		reg = <0x0 0xfe400000 0x0 0x1000>;
 -- 
 Armbian
+
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Corentin Labbe <clabbe.montjoie@gmail.com>
@@ -317,6 +365,7 @@ index d4264db2a07f..c0d08ae78cd5 100644
 -- 
 Armbian
 
+
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Corentin Labbe <clabbe.montjoie@gmail.com>
 Date: Wed, 20 Sep 2023 15:53:17 +0200
@@ -327,19 +376,27 @@ Only hashes and cipher are handled for the moment.
 
 Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>
 ---
- drivers/crypto/Kconfig                           |  27 +
+ drivers/crypto/Kconfig                           |  28 +
  drivers/crypto/rockchip/Makefile                 |   5 +
- drivers/crypto/rockchip/rk3588_crypto.c          | 738 ++++++++++
- drivers/crypto/rockchip/rk3588_crypto.h          | 246 ++++
+ drivers/crypto/rockchip/rk3588_crypto.c          | 745 ++++++++++
+ drivers/crypto/rockchip/rk3588_crypto.h          | 246 +++
  drivers/crypto/rockchip/rk3588_crypto_ahash.c    | 344 +++++
- drivers/crypto/rockchip/rk3588_crypto_skcipher.c | 576 ++++++++
- 6 files changed, 1936 insertions(+)
+ drivers/crypto/rockchip/rk3588_crypto_skcipher.c | 576 +++++++
+ 6 files changed, 1944 insertions(+)
 
 diff --git a/drivers/crypto/Kconfig b/drivers/crypto/Kconfig
-index c761952f0dc6..1c5cb46c41ac 100644
+index c761952f0dc6..9777040be739 100644
 --- a/drivers/crypto/Kconfig
 +++ b/drivers/crypto/Kconfig
-@@ -659,6 +659,33 @@ config CRYPTO_DEV_ROCKCHIP_DEBUG
+@@ -642,6 +642,7 @@ config CRYPTO_DEV_ROCKCHIP
+ 	select CRYPTO_MD5
+ 	select CRYPTO_SHA1
+ 	select CRYPTO_SHA256
++	select CRYPTO_SM3
+ 	select CRYPTO_HASH
+ 	select CRYPTO_SKCIPHER
+ 
+@@ -659,6 +660,33 @@ config CRYPTO_DEV_ROCKCHIP_DEBUG
  	  the number of requests per algorithm and other internal stats.
  
  
@@ -359,7 +416,7 @@ index c761952f0dc6..1c5cb46c41ac 100644
 +
 +	help
 +	  This driver interfaces with the hardware crypto offloader present
-+	  on RK3568 and RK3588.
++	  on RK3566, RK3568 and RK3588.
 +
 +config CRYPTO_DEV_ROCKCHIP2_DEBUG
 +	bool "Enable Rockchip V2 crypto stats"
@@ -388,10 +445,10 @@ index 785277aca71e..2132d8326223 100644
 +		  rk3588_crypto_ahash.o
 diff --git a/drivers/crypto/rockchip/rk3588_crypto.c b/drivers/crypto/rockchip/rk3588_crypto.c
 new file mode 100644
-index 000000000000..3f0a37c7fbbd
+index 000000000000..ae74847d618d
 --- /dev/null
 +++ b/drivers/crypto/rockchip/rk3588_crypto.c
-@@ -0,0 +1,738 @@
+@@ -0,0 +1,745 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * hardware cryptographic offloader for RK3568/RK3588 SoC
@@ -426,8 +483,12 @@ index 000000000000..3f0a37c7fbbd
 +	return first;
 +}
 +
++static const struct rk2_variant rk3568_variant = {
++	.num_clks = 3,
++};
++
 +static const struct rk2_variant rk3588_variant = {
-+	.num_clks = 1,
++	.num_clks = 3,
 +};
 +
 +static int rk2_crypto_get_clks(struct rk2_crypto_dev *dev)
@@ -980,6 +1041,9 @@ index 000000000000..3f0a37c7fbbd
 +}
 +
 +static const struct of_device_id crypto_of_id_table[] = {
++	{ .compatible = "rockchip,rk3568-crypto",
++	  .data = &rk3568_variant,
++	},
 +	{ .compatible = "rockchip,rk3588-crypto",
 +	  .data = &rk3588_variant,
 +	},
@@ -2317,124 +2381,36 @@ index 000000000000..9b6cc29847d7
 -- 
 Armbian
 
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Corentin Labbe <clabbe.montjoie@gmail.com>
-Date: Mon, 2 Oct 2023 10:38:35 +0200
-Subject: crypto: rockchip: add support for rk3568
-
-Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>
----
- drivers/crypto/rockchip/rk3588_crypto.c | 7 +++++++
- 1 file changed, 7 insertions(+)
-
-diff --git a/drivers/crypto/rockchip/rk3588_crypto.c b/drivers/crypto/rockchip/rk3588_crypto.c
-index 3f0a37c7fbbd..0dbafa58faae 100644
---- a/drivers/crypto/rockchip/rk3588_crypto.c
-+++ b/drivers/crypto/rockchip/rk3588_crypto.c
-@@ -32,6 +32,10 @@ struct rk2_crypto_dev *get_rk2_crypto(void)
- 	return first;
- }
- 
-+static const struct rk2_variant rk3568_variant = {
-+	.num_clks = 3,
-+};
-+
- static const struct rk2_variant rk3588_variant = {
- 	.num_clks = 1,
- };
-@@ -586,6 +590,9 @@ static void rk2_crypto_unregister(void)
- }
- 
- static const struct of_device_id crypto_of_id_table[] = {
-+	{ .compatible = "rockchip,rk3568-crypto",
-+	  .data = &rk3568_variant,
-+	},
- 	{ .compatible = "rockchip,rk3588-crypto",
- 	  .data = &rk3588_variant,
- 	},
--- 
-Armbian
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Corentin Labbe <clabbe.montjoie@gmail.com>
-Date: Mon, 2 Oct 2023 11:28:55 +0200
-Subject: dt-bindings: crypto: add support for rockchip,crypto-rk3568
+Date: Wed, 4 Oct 2023 12:24:35 +0200
+Subject: SM3 fix
 
-Add necessary bindings change for supporting rockchip,crypto-rk3568
-
-Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>
 ---
- Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml | 16 ++++++++++
- 1 file changed, 16 insertions(+)
+ drivers/crypto/Kconfig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml b/Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml
-index 73e7b7003936..fbe1e1b33dab 100644
---- a/Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml
-+++ b/Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml
-@@ -12,6 +12,7 @@ maintainers:
- properties:
-   compatible:
-     enum:
-+      - rockchip,rk3568-crypto
-       - rockchip,rk3588-crypto
+diff --git a/drivers/crypto/Kconfig b/drivers/crypto/Kconfig
+index 9777040be739..deb313a33b14 100644
+--- a/drivers/crypto/Kconfig
++++ b/drivers/crypto/Kconfig
+@@ -642,7 +642,6 @@ config CRYPTO_DEV_ROCKCHIP
+ 	select CRYPTO_MD5
+ 	select CRYPTO_SHA1
+ 	select CRYPTO_SHA256
+-	select CRYPTO_SM3
+ 	select CRYPTO_HASH
+ 	select CRYPTO_SKCIPHER
  
-   reg:
-@@ -59,3 +60,18 @@ examples:
-       resets = <&scmi_reset SRST_CRYPTO_CORE>;
-       reset-names = "core";
-     };
-+  - |
-+    #include <dt-bindings/interrupt-controller/arm-gic.h>
-+    #include <dt-bindings/clock/rockchip,rk3568-cru.h>
-+    #include <dt-bindings/reset/rockchip,rk3568-cru.h>
-+    crypto@fe380000 {
-+      compatible = "rockchip,rk3568-crypto";
-+      reg = <0xfe380000 0x4000>;
-+      interrupts = <GIC_SPI 4 IRQ_TYPE_LEVEL_HIGH>;
-+      clocks = <&cru ACLK_CRYPTO_NS>, <&cru HCLK_CRYPTO_NS>,
-+               <&cru CLK_CRYPTO_NS_CORE>;
-+      clock-names = "aclk", "hclk", "core";
-+      resets = <&cru SRST_CRYPTO_NS_CORE>, <&cru SRST_A_CRYPTO_NS>,
-+               <&cru SRST_H_CRYPTO_NS>;
-+      reset-names = "core", "a", "h";
-+    };
--- 
-Armbian
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Corentin Labbe <clabbe.montjoie@gmail.com>
-Date: Mon, 2 Oct 2023 12:49:59 +0200
-Subject: arm64: dts: rk3566 TODO
-
-Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>
----
- arch/arm64/boot/dts/rockchip/rk356x.dtsi | 13 ++++++++++
- 1 file changed, 13 insertions(+)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk356x.dtsi b/arch/arm64/boot/dts/rockchip/rk356x.dtsi
-index abee88911982..5c436f054794 100644
---- a/arch/arm64/boot/dts/rockchip/rk356x.dtsi
-+++ b/arch/arm64/boot/dts/rockchip/rk356x.dtsi
-@@ -1063,6 +1063,19 @@ sdhci: mmc@fe310000 {
- 		status = "disabled";
- 	};
- 
-+	crypto: crypto@fe380000 {
-+		compatible = "rockchip,rk3568-crypto";
-+		reg = <0x0 0xfe380000 0x0 0x2000>;
-+		interrupts = <GIC_SPI 4 IRQ_TYPE_LEVEL_HIGH>;
-+		clocks = <&cru ACLK_CRYPTO_NS>, <&cru HCLK_CRYPTO_NS>,
-+			 <&cru CLK_CRYPTO_NS_CORE>;
-+		clock-names = "aclk", "hclk", "core";
-+		resets = <&cru SRST_CRYPTO_NS_CORE>, <&cru SRST_A_CRYPTO_NS>,
-+			<&cru SRST_H_CRYPTO_NS>;
-+		reset-names = "core", "a", "h";
-+		status = "okay";
-+	};
-+
- 	i2s0_8ch: i2s@fe400000 {
- 		compatible = "rockchip,rk3568-i2s-tdm";
- 		reg = <0x0 0xfe400000 0x0 0x1000>;
+@@ -670,6 +669,7 @@ config CRYPTO_DEV_ROCKCHIP2
+ 	select CRYPTO_MD5
+ 	select CRYPTO_SHA1
+ 	select CRYPTO_SHA256
++	select CRYPTO_SM3
+ 	select CRYPTO_HASH
+ 	select CRYPTO_SKCIPHER
+ 	select CRYPTO_ENGINE
 -- 
 Armbian
 

--- a/patch/kernel/archive/rockchip64-6.6/rk35xx-montjoie-crypto-v2-rk35xx.patch
+++ b/patch/kernel/archive/rockchip64-6.6/rk35xx-montjoie-crypto-v2-rk35xx.patch
@@ -8,15 +8,15 @@ offloader V2.
 
 Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>
 ---
- Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml | 61 ++++++++++
- 1 file changed, 61 insertions(+)
+ Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml | 77 ++++++++++
+ 1 file changed, 77 insertions(+)
 
 diff --git a/Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml b/Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml
 new file mode 100644
-index 000000000000..73e7b7003936
+index 000000000000..fbe1e1b33dab
 --- /dev/null
 +++ b/Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml
-@@ -0,0 +1,61 @@
+@@ -0,0 +1,77 @@
 +# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
 +%YAML 1.2
 +---
@@ -31,6 +31,7 @@ index 000000000000..73e7b7003936
 +properties:
 +  compatible:
 +    enum:
++      - rockchip,rk3568-crypto
 +      - rockchip,rk3588-crypto
 +
 +  reg:
@@ -78,8 +79,52 @@ index 000000000000..73e7b7003936
 +      resets = <&scmi_reset SRST_CRYPTO_CORE>;
 +      reset-names = "core";
 +    };
++  - |
++    #include <dt-bindings/interrupt-controller/arm-gic.h>
++    #include <dt-bindings/clock/rockchip,rk3568-cru.h>
++    #include <dt-bindings/reset/rockchip,rk3568-cru.h>
++    crypto@fe380000 {
++      compatible = "rockchip,rk3568-crypto";
++      reg = <0xfe380000 0x4000>;
++      interrupts = <GIC_SPI 4 IRQ_TYPE_LEVEL_HIGH>;
++      clocks = <&cru ACLK_CRYPTO_NS>, <&cru HCLK_CRYPTO_NS>,
++               <&cru CLK_CRYPTO_NS_CORE>;
++      clock-names = "aclk", "hclk", "core";
++      resets = <&cru SRST_CRYPTO_NS_CORE>, <&cru SRST_A_CRYPTO_NS>,
++               <&cru SRST_H_CRYPTO_NS>;
++      reset-names = "core", "a", "h";
++    };
 -- 
 Armbian
+
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Corentin Labbe <clabbe.montjoie@gmail.com>
+Date: Mon, 26 Sep 2022 13:38:25 +0200
+Subject: MAINTAINERS: add new dt-binding doc to the right entry
+
+Rockchip crypto driver have a new file to be added.
+
+Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>
+---
+ MAINTAINERS | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/MAINTAINERS b/MAINTAINERS
+index 208cfcc1aee3..03e47802653a 100644
+--- a/MAINTAINERS
++++ b/MAINTAINERS
+@@ -18617,6 +18617,7 @@ M:	Corentin Labbe <clabbe@baylibre.com>
+ L:	linux-crypto@vger.kernel.org
+ S:	Maintained
+ F:	Documentation/devicetree/bindings/crypto/rockchip,rk3288-crypto.yaml
++F:	Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml
+ F:	drivers/crypto/rockchip/
+ 
+ ROCKCHIP I2S TDM DRIVER
+-- 
+Armbian
+
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Corentin Labbe <clabbe.montjoie@gmail.com>
@@ -91,14 +136,14 @@ node for it.
 
 Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>
 ---
- arch/arm64/boot/dts/rockchip/rk3588s.dtsi | 11 ++++++++++
- 1 file changed, 11 insertions(+)
+ arch/arm64/boot/dts/rockchip/rk3588s.dtsi | 12 ++++++++++
+ 1 file changed, 12 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588s.dtsi b/arch/arm64/boot/dts/rockchip/rk3588s.dtsi
-index 5544f66c6ff4..911e22d75963 100644
+index 5544f66c6ff4..ffffe084a966 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s.dtsi
-@@ -1475,6 +1475,17 @@ sdhci: mmc@fe2e0000 {
+@@ -1475,6 +1475,18 @@ sdhci: mmc@fe2e0000 {
  		status = "disabled";
  	};
  
@@ -106,8 +151,9 @@ index 5544f66c6ff4..911e22d75963 100644
 +		compatible = "rockchip,rk3588-crypto";
 +		reg = <0x0 0xfe370000 0x0 0x2000>;
 +		interrupts = <GIC_SPI 209 IRQ_TYPE_LEVEL_HIGH 0>;
-+		clocks = <&scmi_clk SCMI_CRYPTO_CORE>;
-+		clock-names = "core";
++		clocks = <&scmi_clk SCMI_CRYPTO_CORE>, <&scmi_clk SCMI_ACLK_SECURE_NS>,
++			 <&scmi_clk SCMI_HCLK_SECURE_NS>;
++		clock-names = "core", "aclk", "hclk";
 +		resets = <&scmi_reset SRST_CRYPTO_CORE>;
 +		reset-names = "core";
 +		status = "okay";
@@ -119,25 +165,27 @@ index 5544f66c6ff4..911e22d75963 100644
 -- 
 Armbian
 
+
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Corentin Labbe <clabbe.montjoie@gmail.com>
 Date: Thu, 22 Sep 2022 19:38:13 +0200
-Subject: ARM64: dts: rk3568: add crypto node
+Subject: ARM64: dts: rk356x: add crypto node
 
-The rk3568 has a crypto IP handled by the rk3588 crypto driver so adds a
+Both RK3566 and RK3568 have a crypto IP handled by the rk3588 crypto driver so adds a
 node for it.
 
+Tested-by: Ricardo Pardini <ricardo@pardini.net>
 Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>
 ---
- arch/arm64/boot/dts/rockchip/rk3568.dtsi | 13 ++++++++++
- 1 file changed, 13 insertions(+)
+ arch/arm64/boot/dts/rockchip/rk356x.dtsi | 12 ++++++++++
+ 1 file changed, 12 insertions(+)
 
-diff --git a/arch/arm64/boot/dts/rockchip/rk3568.dtsi b/arch/arm64/boot/dts/rockchip/rk3568.dtsi
-index f1be76a54ceb..ff9691404db3 100644
---- a/arch/arm64/boot/dts/rockchip/rk3568.dtsi
-+++ b/arch/arm64/boot/dts/rockchip/rk3568.dtsi
-@@ -213,6 +213,19 @@ gmac0_mtl_tx_setup: tx-queues-config {
- 		};
+diff --git a/arch/arm64/boot/dts/rockchip/rk356x.dtsi b/arch/arm64/boot/dts/rockchip/rk356x.dtsi
+index abee88911982..b9cbab2246e2 100644
+--- a/arch/arm64/boot/dts/rockchip/rk356x.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk356x.dtsi
+@@ -1063,6 +1063,18 @@ sdhci: mmc@fe310000 {
+ 		status = "disabled";
  	};
  
 +	crypto: crypto@fe380000 {
@@ -147,17 +195,17 @@ index f1be76a54ceb..ff9691404db3 100644
 +		clocks = <&cru ACLK_CRYPTO_NS>, <&cru HCLK_CRYPTO_NS>,
 +			 <&cru CLK_CRYPTO_NS_CORE>;
 +		clock-names = "aclk", "hclk", "core";
-+		resets = <&cru SRST_CRYPTO_NS_CORE>, <&cru SRST_A_CRYPTO_NS>,
-+			<&cru SRST_H_CRYPTO_NS>;
-+		reset-names = "core", "a", "h";
++		resets = <&cru SRST_CRYPTO_NS_CORE>;
++		reset-names = "core";
 +		status = "okay";
 +	};
 +
- 	combphy0: phy@fe820000 {
- 		compatible = "rockchip,rk3568-naneng-combphy";
- 		reg = <0x0 0xfe820000 0x0 0x100>;
+ 	i2s0_8ch: i2s@fe400000 {
+ 		compatible = "rockchip,rk3568-i2s-tdm";
+ 		reg = <0x0 0xfe400000 0x0 0x1000>;
 -- 
 Armbian
+
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Corentin Labbe <clabbe.montjoie@gmail.com>
@@ -317,6 +365,7 @@ index d4264db2a07f..c0d08ae78cd5 100644
 -- 
 Armbian
 
+
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Corentin Labbe <clabbe.montjoie@gmail.com>
 Date: Wed, 20 Sep 2023 15:53:17 +0200
@@ -327,19 +376,27 @@ Only hashes and cipher are handled for the moment.
 
 Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>
 ---
- drivers/crypto/Kconfig                           |  27 +
+ drivers/crypto/Kconfig                           |  28 +
  drivers/crypto/rockchip/Makefile                 |   5 +
- drivers/crypto/rockchip/rk3588_crypto.c          | 738 ++++++++++
- drivers/crypto/rockchip/rk3588_crypto.h          | 246 ++++
+ drivers/crypto/rockchip/rk3588_crypto.c          | 745 ++++++++++
+ drivers/crypto/rockchip/rk3588_crypto.h          | 246 +++
  drivers/crypto/rockchip/rk3588_crypto_ahash.c    | 344 +++++
- drivers/crypto/rockchip/rk3588_crypto_skcipher.c | 576 ++++++++
- 6 files changed, 1936 insertions(+)
+ drivers/crypto/rockchip/rk3588_crypto_skcipher.c | 576 +++++++
+ 6 files changed, 1944 insertions(+)
 
 diff --git a/drivers/crypto/Kconfig b/drivers/crypto/Kconfig
-index c761952f0dc6..1c5cb46c41ac 100644
+index c761952f0dc6..9777040be739 100644
 --- a/drivers/crypto/Kconfig
 +++ b/drivers/crypto/Kconfig
-@@ -659,6 +659,33 @@ config CRYPTO_DEV_ROCKCHIP_DEBUG
+@@ -642,6 +642,7 @@ config CRYPTO_DEV_ROCKCHIP
+ 	select CRYPTO_MD5
+ 	select CRYPTO_SHA1
+ 	select CRYPTO_SHA256
++	select CRYPTO_SM3
+ 	select CRYPTO_HASH
+ 	select CRYPTO_SKCIPHER
+ 
+@@ -659,6 +660,33 @@ config CRYPTO_DEV_ROCKCHIP_DEBUG
  	  the number of requests per algorithm and other internal stats.
  
  
@@ -359,7 +416,7 @@ index c761952f0dc6..1c5cb46c41ac 100644
 +
 +	help
 +	  This driver interfaces with the hardware crypto offloader present
-+	  on RK3568 and RK3588.
++	  on RK3566, RK3568 and RK3588.
 +
 +config CRYPTO_DEV_ROCKCHIP2_DEBUG
 +	bool "Enable Rockchip V2 crypto stats"
@@ -388,10 +445,10 @@ index 785277aca71e..2132d8326223 100644
 +		  rk3588_crypto_ahash.o
 diff --git a/drivers/crypto/rockchip/rk3588_crypto.c b/drivers/crypto/rockchip/rk3588_crypto.c
 new file mode 100644
-index 000000000000..3f0a37c7fbbd
+index 000000000000..ae74847d618d
 --- /dev/null
 +++ b/drivers/crypto/rockchip/rk3588_crypto.c
-@@ -0,0 +1,738 @@
+@@ -0,0 +1,745 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * hardware cryptographic offloader for RK3568/RK3588 SoC
@@ -426,8 +483,12 @@ index 000000000000..3f0a37c7fbbd
 +	return first;
 +}
 +
++static const struct rk2_variant rk3568_variant = {
++	.num_clks = 3,
++};
++
 +static const struct rk2_variant rk3588_variant = {
-+	.num_clks = 1,
++	.num_clks = 3,
 +};
 +
 +static int rk2_crypto_get_clks(struct rk2_crypto_dev *dev)
@@ -980,6 +1041,9 @@ index 000000000000..3f0a37c7fbbd
 +}
 +
 +static const struct of_device_id crypto_of_id_table[] = {
++	{ .compatible = "rockchip,rk3568-crypto",
++	  .data = &rk3568_variant,
++	},
 +	{ .compatible = "rockchip,rk3588-crypto",
 +	  .data = &rk3588_variant,
 +	},
@@ -2317,124 +2381,36 @@ index 000000000000..9b6cc29847d7
 -- 
 Armbian
 
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Corentin Labbe <clabbe.montjoie@gmail.com>
-Date: Mon, 2 Oct 2023 10:38:35 +0200
-Subject: crypto: rockchip: add support for rk3568
-
-Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>
----
- drivers/crypto/rockchip/rk3588_crypto.c | 7 +++++++
- 1 file changed, 7 insertions(+)
-
-diff --git a/drivers/crypto/rockchip/rk3588_crypto.c b/drivers/crypto/rockchip/rk3588_crypto.c
-index 3f0a37c7fbbd..0dbafa58faae 100644
---- a/drivers/crypto/rockchip/rk3588_crypto.c
-+++ b/drivers/crypto/rockchip/rk3588_crypto.c
-@@ -32,6 +32,10 @@ struct rk2_crypto_dev *get_rk2_crypto(void)
- 	return first;
- }
- 
-+static const struct rk2_variant rk3568_variant = {
-+	.num_clks = 3,
-+};
-+
- static const struct rk2_variant rk3588_variant = {
- 	.num_clks = 1,
- };
-@@ -586,6 +590,9 @@ static void rk2_crypto_unregister(void)
- }
- 
- static const struct of_device_id crypto_of_id_table[] = {
-+	{ .compatible = "rockchip,rk3568-crypto",
-+	  .data = &rk3568_variant,
-+	},
- 	{ .compatible = "rockchip,rk3588-crypto",
- 	  .data = &rk3588_variant,
- 	},
--- 
-Armbian
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Corentin Labbe <clabbe.montjoie@gmail.com>
-Date: Mon, 2 Oct 2023 11:28:55 +0200
-Subject: dt-bindings: crypto: add support for rockchip,crypto-rk3568
+Date: Wed, 4 Oct 2023 12:24:35 +0200
+Subject: SM3 fix
 
-Add necessary bindings change for supporting rockchip,crypto-rk3568
-
-Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>
 ---
- Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml | 16 ++++++++++
- 1 file changed, 16 insertions(+)
+ drivers/crypto/Kconfig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml b/Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml
-index 73e7b7003936..fbe1e1b33dab 100644
---- a/Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml
-+++ b/Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml
-@@ -12,6 +12,7 @@ maintainers:
- properties:
-   compatible:
-     enum:
-+      - rockchip,rk3568-crypto
-       - rockchip,rk3588-crypto
+diff --git a/drivers/crypto/Kconfig b/drivers/crypto/Kconfig
+index 9777040be739..deb313a33b14 100644
+--- a/drivers/crypto/Kconfig
++++ b/drivers/crypto/Kconfig
+@@ -642,7 +642,6 @@ config CRYPTO_DEV_ROCKCHIP
+ 	select CRYPTO_MD5
+ 	select CRYPTO_SHA1
+ 	select CRYPTO_SHA256
+-	select CRYPTO_SM3
+ 	select CRYPTO_HASH
+ 	select CRYPTO_SKCIPHER
  
-   reg:
-@@ -59,3 +60,18 @@ examples:
-       resets = <&scmi_reset SRST_CRYPTO_CORE>;
-       reset-names = "core";
-     };
-+  - |
-+    #include <dt-bindings/interrupt-controller/arm-gic.h>
-+    #include <dt-bindings/clock/rockchip,rk3568-cru.h>
-+    #include <dt-bindings/reset/rockchip,rk3568-cru.h>
-+    crypto@fe380000 {
-+      compatible = "rockchip,rk3568-crypto";
-+      reg = <0xfe380000 0x4000>;
-+      interrupts = <GIC_SPI 4 IRQ_TYPE_LEVEL_HIGH>;
-+      clocks = <&cru ACLK_CRYPTO_NS>, <&cru HCLK_CRYPTO_NS>,
-+               <&cru CLK_CRYPTO_NS_CORE>;
-+      clock-names = "aclk", "hclk", "core";
-+      resets = <&cru SRST_CRYPTO_NS_CORE>, <&cru SRST_A_CRYPTO_NS>,
-+               <&cru SRST_H_CRYPTO_NS>;
-+      reset-names = "core", "a", "h";
-+    };
--- 
-Armbian
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Corentin Labbe <clabbe.montjoie@gmail.com>
-Date: Mon, 2 Oct 2023 12:49:59 +0200
-Subject: arm64: dts: rk3566 TODO
-
-Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>
----
- arch/arm64/boot/dts/rockchip/rk356x.dtsi | 13 ++++++++++
- 1 file changed, 13 insertions(+)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk356x.dtsi b/arch/arm64/boot/dts/rockchip/rk356x.dtsi
-index abee88911982..5c436f054794 100644
---- a/arch/arm64/boot/dts/rockchip/rk356x.dtsi
-+++ b/arch/arm64/boot/dts/rockchip/rk356x.dtsi
-@@ -1063,6 +1063,19 @@ sdhci: mmc@fe310000 {
- 		status = "disabled";
- 	};
- 
-+	crypto: crypto@fe380000 {
-+		compatible = "rockchip,rk3568-crypto";
-+		reg = <0x0 0xfe380000 0x0 0x2000>;
-+		interrupts = <GIC_SPI 4 IRQ_TYPE_LEVEL_HIGH>;
-+		clocks = <&cru ACLK_CRYPTO_NS>, <&cru HCLK_CRYPTO_NS>,
-+			 <&cru CLK_CRYPTO_NS_CORE>;
-+		clock-names = "aclk", "hclk", "core";
-+		resets = <&cru SRST_CRYPTO_NS_CORE>, <&cru SRST_A_CRYPTO_NS>,
-+			<&cru SRST_H_CRYPTO_NS>;
-+		reset-names = "core", "a", "h";
-+		status = "okay";
-+	};
-+
- 	i2s0_8ch: i2s@fe400000 {
- 		compatible = "rockchip,rk3568-i2s-tdm";
- 		reg = <0x0 0xfe400000 0x0 0x1000>;
+@@ -670,6 +669,7 @@ config CRYPTO_DEV_ROCKCHIP2
+ 	select CRYPTO_MD5
+ 	select CRYPTO_SHA1
+ 	select CRYPTO_SHA256
++	select CRYPTO_SM3
+ 	select CRYPTO_HASH
+ 	select CRYPTO_SKCIPHER
+ 	select CRYPTO_ENGINE
 -- 
 Armbian
 


### PR DESCRIPTION
#### `rockchip64` + `rk3568-odroid` / `edge` 6.6: update montjoie's rk crypto v2 patches to crypto-rk3588-03-10-2023

- `rockchip64` + `rk3568-odroid` / `edge` 6.6: update montjoie's rk crypto v2 patches to crypto-rk3588-03-10-2023