### PR TITLE
Khadas Vim1s: Fix monitor not detected after its turned off and on again

### DIFF
--- a/patch/kernel/archive/meson-s4t7-5.4/0001-vim1s-Port-hotplug-fix-from-hdmitx21-to-hdmi_tx_20.patch
+++ b/patch/kernel/archive/meson-s4t7-5.4/0001-vim1s-Port-hotplug-fix-from-hdmitx21-to-hdmi_tx_20.patch
@@ -1,0 +1,40 @@
+From f2655b7411f3c4f0bb6efc7f1f4ebd9c15a30df5 Mon Sep 17 00:00:00 2001
+From: Gunjan Gupta <viraniac@gmail.com>
+Date: Wed, 6 Sep 2023 08:30:29 +0000
+Subject: [PATCH 1/2] vim1s: Port hotplug fix from hdmitx21 to hdmi_tx_20
+
+Based on 69d6ec4d3228db1b5d82b308b668e913beeda6a9
+---
+ .../amlogic/media/vout/hdmitx/hdmi_tx_20/hdmi_tx_main.c  | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hdmi_tx_main.c b/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hdmi_tx_main.c
+index af24acb190df..6ca181b6c79a 100644
+--- a/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hdmi_tx_main.c
++++ b/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hdmi_tx_main.c
+@@ -5830,7 +5830,9 @@ static int hdmitx_set_current_vmode(enum vmode_e mode, void *data)
+ 		recalc_vinfo_sync_duration(vinfo,
+ 					   hdmitx_device.frac_rate_policy);
+ 
+-	if (!(mode & VMODE_INIT_BIT_MASK)) {
++	if (!(mode & VMODE_INIT_BIT_MASK) || !hdmitx_device.hpd_state) {
++		pr_info("HDMI display force init (%d)\n", hdmitx_device.hpd_state);
++		edidinfo_attach_to_vinfo(&hdmitx_device);
+ 		set_disp_mode_auto();
+ 	} else {
+ 		pr_info("alread display in uboot\n");
+@@ -6331,6 +6333,11 @@ static void hdmitx_hpd_plugin_handler(struct work_struct *work)
+ 	/*notify to drm hdmi*/
+ 	if (hdmitx_device.drm_hpd_cb.callback)
+ 		hdmitx_device.drm_hpd_cb.callback(hdmitx_device.drm_hpd_cb.data);
++
++	if (info && info->mode == VMODE_HDMI) {
++		pr_info("HDMI display force refresh\n");
++		set_disp_mode_auto();
++	}
+ }
+ 
+ static void clear_rx_vinfo(struct hdmitx_dev *hdev)
+-- 
+2.34.1
+


### PR DESCRIPTION
# Description

This fixes montior not working after its turned off and on again. This also helps getting the monitors working that doesn't work by default by setting `hdmimode=1080p60hz` and `outputmode=1080p60hz` in boot/armbianEnv.txt file. The fix is based on [hdmitx21 commit](https://github.com/khadas/linux/commit/69d6ec4d3228db1b5d82b308b668e913beeda6a9) used on vim4. The same change was missing for hdmitx20 that is used on vim1s.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested on vim1s. Monitor hotplug works. Non-working monitor now works with manual configuration 

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
