### PR TITLE
radxa-zero2: bump u-boot to v2023.10

### DIFF
--- a/config/boards/radxa-zero2.wip
+++ b/config/boards/radxa-zero2.wip
@@ -9,6 +9,8 @@ BOOT_LOGO="desktop"
 ASOUND_STATE="asound.state.radxa-zero2"
 BOOT_FDT_FILE="amlogic/meson-g12b-radxa-zero2.dtb"
 
-# Newer u-boot for the Zero; Radxa's patches with new DT, Makefile and defconfig in v2022.10/board_radxa-zero2 dir
-BOOTBRANCH_BOARD="tag:v2022.10"
-BOOTPATCHDIR="v2022.10"
+# Newer u-boot for the Zero2
+# 2022.10: Radxa's patches with new DT, Makefile and defconfig in v2022.10/board_radxa-zero2 dir; common to 22.10's meson64 boot-usb-first
+# v2023.10: board-specific boot-usb-first patch; zero2 landed in upstream u-boot v2023.07-rc1
+BOOTBRANCH_BOARD="tag:v2023.10"
+BOOTPATCHDIR="v2023.10"

--- a/patch/u-boot/v2022.10/board_radxa-zero2/0001-WIP-ARM-dts-add-support-for-Radxa-Zero2.patch
+++ b/patch/u-boot/v2022.10/board_radxa-zero2/0001-WIP-ARM-dts-add-support-for-Radxa-Zero2.patch
@@ -1,25 +1,23 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Christian Hewitt <christianshewitt@gmail.com>
 Date: Sat, 15 Jan 2022 06:17:23 +0000
-Subject: [PATCH] WIP: ARM: dts: add support for Radxa Zero2
+Subject: WIP: ARM: dts: add support for Radxa Zero2
 
 Import the initial dts (WIP) from chewitt/amlogic-5.16.y
 
 Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
 Signed-off-by: Yuntian Zhang <yt@radxa.com>
 ---
- arch/arm/dts/Makefile                         |   1 +
- .../dts/meson-g12b-radxa-zero2-u-boot.dtsi    |   7 +
- arch/arm/dts/meson-g12b-radxa-zero2.dts       | 574 ++++++++++++++++++
+ arch/arm/dts/Makefile                           |   1 +
+ arch/arm/dts/meson-g12b-radxa-zero2-u-boot.dtsi |   7 +
+ arch/arm/dts/meson-g12b-radxa-zero2.dts         | 574 ++++++++++
  3 files changed, 582 insertions(+)
- create mode 100644 arch/arm/dts/meson-g12b-radxa-zero2-u-boot.dtsi
- create mode 100644 arch/arm/dts/meson-g12b-radxa-zero2.dts
 
 diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
-index c752d2bd18..44241fafee 100644
+index 965895bc2a3..717be756d60 100644
 --- a/arch/arm/dts/Makefile
 +++ b/arch/arm/dts/Makefile
-@@ -194,6 +194,7 @@ dtb-$(CONFIG_ARCH_MESON) += \
+@@ -200,6 +200,7 @@ dtb-$(CONFIG_ARCH_MESON) += \
  	meson-g12b-gsking-x.dtb \
  	meson-g12b-odroid-n2.dtb \
  	meson-g12b-odroid-n2-plus.dtb \
@@ -29,7 +27,7 @@ index c752d2bd18..44241fafee 100644
  	meson-sm1-odroid-c4.dtb \
 diff --git a/arch/arm/dts/meson-g12b-radxa-zero2-u-boot.dtsi b/arch/arm/dts/meson-g12b-radxa-zero2-u-boot.dtsi
 new file mode 100644
-index 0000000000..236f2468dc
+index 00000000000..236f2468dc2
 --- /dev/null
 +++ b/arch/arm/dts/meson-g12b-radxa-zero2-u-boot.dtsi
 @@ -0,0 +1,7 @@
@@ -42,7 +40,7 @@ index 0000000000..236f2468dc
 +#include "meson-g12-common-u-boot.dtsi"
 diff --git a/arch/arm/dts/meson-g12b-radxa-zero2.dts b/arch/arm/dts/meson-g12b-radxa-zero2.dts
 new file mode 100644
-index 0000000000..f0c9ef8592
+index 00000000000..f7da62ccf0d
 --- /dev/null
 +++ b/arch/arm/dts/meson-g12b-radxa-zero2.dts
 @@ -0,0 +1,574 @@
@@ -621,5 +619,5 @@ index 0000000000..f0c9ef8592
 +	phy-supply = <&typec2_vbus>;
 +};
 -- 
-2.35.1
+Armbian
 

--- a/patch/u-boot/v2022.10/board_radxa-zero2/0002-WIP-boards-amlogic-add-Radxa-Zero2-defconfig.patch
+++ b/patch/u-boot/v2022.10/board_radxa-zero2/0002-WIP-boards-amlogic-add-Radxa-Zero2-defconfig.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Christian Hewitt <christianshewitt@gmail.com>
 Date: Sat, 15 Jan 2022 06:23:29 +0000
-Subject: [PATCH] WIP: boards: amlogic: add Radxa Zero2 defconfig
+Subject: WIP: boards: amlogic: add Radxa Zero2 defconfig
 
 Add a defconfig for the Radxa Zero2 SBC, using an Amlogic A311D chip.
 
@@ -9,15 +9,14 @@ Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
 Signed-off-by: Yuntian Zhang <yt@radxa.com>
 ---
  board/amlogic/w400/MAINTAINERS |  1 +
- configs/radxa-zero2_defconfig  | 69 ++++++++++++++++++++++++++++++++++
- 2 files changed, 70 insertions(+)
- create mode 100644 configs/radxa-zero2_defconfig
+ configs/radxa-zero2_defconfig  | 68 ++++++++++
+ 2 files changed, 69 insertions(+)
 
 diff --git a/board/amlogic/w400/MAINTAINERS b/board/amlogic/w400/MAINTAINERS
-index 991590d9f2..8587f67b46 100644
+index 96ccda20011..caad41577df 100644
 --- a/board/amlogic/w400/MAINTAINERS
 +++ b/board/amlogic/w400/MAINTAINERS
-@@ -3,4 +3,5 @@ M:	Neil Armstrong <narmstrong@baylibre.com>
+@@ -3,4 +3,5 @@ M:	Neil Armstrong <neil.armstrong@linaro.org>
  S:	Maintained
  L:	u-boot-amlogic@groups.io
  F:	board/amlogic/w400/
@@ -25,7 +24,7 @@ index 991590d9f2..8587f67b46 100644
  F:	doc/board/amlogic/w400.rst
 diff --git a/configs/radxa-zero2_defconfig b/configs/radxa-zero2_defconfig
 new file mode 100644
-index 000000000..65f5a3bfe
+index 00000000000..65f5a3bfe6d
 --- /dev/null
 +++ b/configs/radxa-zero2_defconfig
 @@ -0,0 +1,68 @@
@@ -98,5 +97,5 @@ index 000000000..65f5a3bfe
 +CONFIG_SPLASH_SCREEN_ALIGN=y
 +CONFIG_OF_LIBFDT_OVERLAY=y
 -- 
-2.35.1
+Armbian
 

--- a/patch/u-boot/v2022.10/meson64-boot-usb-nvme-scsi-first.patch
+++ b/patch/u-boot/v2022.10/meson64-boot-usb-nvme-scsi-first.patch
@@ -1,6 +1,17 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ricardo Pardini <ricardo@pardini.net>
+Date: Mon, 14 Nov 2022 14:59:45 +0100
+Subject: meson64 u-boot v2022.10: change `BOOT_TARGET_DEVICES to try to boot
+ USB, NVME and SCSI before SD, MMC, PXE, DHCP
+
+---
+ include/configs/meson64.h | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
 diff --git a/include/configs/meson64.h b/include/configs/meson64.h
---- a/include/configs/meson64.h	(revision 4debc57a3da6c3f4d3f89a637e99206f4cea0a96)
-+++ b/include/configs/meson64.h	(date 1668345216008)
+index 40803ee9da1..af7b764da6a 100644
+--- a/include/configs/meson64.h
++++ b/include/configs/meson64.h
 @@ -64,12 +64,12 @@
  #ifndef BOOT_TARGET_DEVICES
  #define BOOT_TARGET_DEVICES(func) \
@@ -17,3 +28,6 @@ diff --git a/include/configs/meson64.h b/include/configs/meson64.h
  	func(PXE, pxe, na) \
  	func(DHCP, dhcp, na)
  #endif
+-- 
+Armbian
+

--- a/patch/u-boot/v2023.10/board_radxa-zero2/meson64-boot-usb-nvme-scsi-first.patch
+++ b/patch/u-boot/v2023.10/board_radxa-zero2/meson64-boot-usb-nvme-scsi-first.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ricardo Pardini <ricardo@pardini.net>
+Date: Mon, 14 Nov 2022 14:59:45 +0100
+Subject: meson64: change `BOOT_TARGET_DEVICES` to try to boot USB, NVME and
+ SCSI before SD, MMC, PXE, DHCP
+
+meson64: change `BOOT_TARGET_DEVICES` to try to boot USB, NVME and SCSI before SD, MMC, PXE, DHCP
+---
+ include/configs/meson64.h | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/include/configs/meson64.h b/include/configs/meson64.h
+index 801cdae4708..927919ef17a 100644
+--- a/include/configs/meson64.h
++++ b/include/configs/meson64.h
+@@ -74,12 +74,12 @@
+ #ifndef BOOT_TARGET_DEVICES
+ #define BOOT_TARGET_DEVICES(func) \
+ 	func(ROMUSB, romusb, na)  \
+-	func(MMC, mmc, 0) \
+-	func(MMC, mmc, 1) \
+-	func(MMC, mmc, 2) \
+ 	BOOT_TARGET_DEVICES_USB(func) \
+ 	BOOT_TARGET_NVME(func) \
+ 	BOOT_TARGET_SCSI(func) \
++	func(MMC, mmc, 0) \
++	func(MMC, mmc, 1) \
++	func(MMC, mmc, 2) \
+ 	func(PXE, pxe, na) \
+ 	func(DHCP, dhcp, na)
+ #endif
+-- 
+Armbian
+


### PR DESCRIPTION
#### radxa-zero2: bump u-boot to v2023.10

- radxa-zero2: rewrite u-boot 2022.10 patches, no changes
- radxa-zero2: bump u-boot to v2023.10