### PR TITLE
Add support option to the new issues options

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Need framework support?
+    url: https://github.com/armbian/build#support
+    about: Explore free and prioritized paid support options
   - name: Armbian OS Bug Report
     url: https://www.armbian.com/bugs/
     about: Use our bug reporting wizzard to file your bug in the correct place


### PR DESCRIPTION
# Description

This might help diverting users from abusing issue tracker for seeking support.

# How Has This Been Tested?

UX / guide change.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
