### PR TITLE
meson-s4t7: Add option to force 16x9 display resolution

### DIFF
--- a/config/bootscripts/boot-meson-s4t7.cmd
+++ b/config/bootscripts/boot-meson-s4t7.cmd
@@ -9,6 +9,8 @@ setenv verbosity "1"
 setenv earlycon "off"
 setenv bootlogo "false"
 setenv earlyconuart "0xfe078000"
+setenv displaymode "1080p60hz"
+setenv force_16x9_display "false"
 
 if test "${board_name}" = "kvim1s"; then setenv earlyconuart "0xfe07a000"; fi
 
@@ -35,7 +37,21 @@ else
 	setenv consoleargs "splash=verbose ${consoleargs}"
 fi
 
-setenv displayargs "logo=${display_layer},loaded,${fb_addr} vout=${outputmode},${vout_init} panel_type=${panel_type} hdmitx=${cecconfig},${colorattribute} hdmimode=${hdmimode} hdmichecksum=${hdmichecksum} dolby_vision_on=${dolby_vision_on} hdr_policy=${hdr_policy} hdr_priority=${hdr_priority} frac_rate_policy=${frac_rate_policy} hdmi_read_edid=${hdmi_read_edid} cvbsmode=${cvbsmode} osd_reverse=${osd_reverse} video_reverse=${video_reverse}"
+if test -n "${hdmimode}" ; then
+	if test ${display_height} -ge 2160 ; then
+		setenv displaymode "2160p60hz"
+	elif test ${display_height} -ge 1080 ; then
+		setenv displaymode "1080p60hz"
+	else
+		setenv displaymode "720p60hz"
+	fi
+fi
+
+if test "${force_16x9_display}" = "true"; then
+	setenv hdmimode ${displaymode}
+fi
+
+setenv displayargs "logo=${display_layer},loaded,${fb_addr} vout=${hdmimode},${vout_init} panel_type=${panel_type} hdmitx=${cecconfig},${colorattribute} hdmimode=${hdmimode} hdmichecksum=${hdmichecksum} dolby_vision_on=${dolby_vision_on} hdr_policy=${hdr_policy} hdr_priority=${hdr_priority} frac_rate_policy=${frac_rate_policy} hdmi_read_edid=${hdmi_read_edid} cvbsmode=${cvbsmode} osd_reverse=${osd_reverse} video_reverse=${video_reverse}"
 
 setenv bootargs "root=${rootdev} rootwait rootfstype=${rootfstype} ${consoleargs} no_console_suspend ${displayargs} loglevel=${verbosity} mac=${eth_mac} khadas.serial=${usid} partition_type=generic ${extraargs} ${extraboardargs}"
 

--- a/config/sources/families/meson-s4t7.conf
+++ b/config/sources/families/meson-s4t7.conf
@@ -99,3 +99,10 @@ function post_family_tweaks_bsp__disable_uinitrd_generation() {
 function pre_update_initramfs__change_initrd_compression() {
 	run_host_command_logged sed -i 's/COMPRESS=.*/COMPRESS=xz/g' $MOUNT/etc/initramfs-tools/initramfs.conf
 }
+
+function image_specific_armbian_env_ready__force_16x9_display() {
+	if [[ ${BRANCH} == "legacy" ]]; then
+		display_alert "Forcing 16x9 display"
+		run_host_command_logged echo "force_16x9_display=true" >>${SDCARD}/boot/armbianEnv.txt
+	fi
+}


### PR DESCRIPTION
# Description

Khadas's 5.4 kernel has a broken hdmi subsystem that can result into a monitor not working even if it supports one of the required display resolution. Hence adding a workaround that will force use of one of the 3 16x9 resolutions supporting most of the HD-ready, full-HD and 4K monitors.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested all 3 of my monitors, 2 of which were not working before out of the box. Now all my monitor works with both vim1s and vim4

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
