### PR TITLE
armbian-desktop: remove "Conflicts: gdm3"; some sddm support

### DIFF
--- a/lib/functions/compilation/packages/armbian-desktop-deb.sh
+++ b/lib/functions/compilation/packages/armbian-desktop-deb.sh
@@ -46,7 +46,6 @@ function compile_armbian-desktop() {
 		Priority: optional
 		Recommends: ${AGGREGATED_PACKAGES_DESKTOP_COMMA}, armbian-bsp-desktop
 		Provides: armbian-${RELEASE}-desktop
-		Conflicts: gdm3
 		Description: Armbian desktop for ${DISTRIBUTION} ${RELEASE} ${DESKTOP_ENVIRONMENT}
 	EOF
 

--- a/lib/functions/rootfs/rootfs-desktop.sh
+++ b/lib/functions/rootfs/rootfs-desktop.sh
@@ -13,6 +13,7 @@ function desktop_postinstall() {
 	# disable display manager for the first run
 	disable_systemd_service_sdcard lightdm.service
 	disable_systemd_service_sdcard gdm3.service
+	disable_systemd_service_sdcard sddm.service
 
 	# @TODO: why?
 	display_alert "Updating package lists" "for desktop" "info"

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -15,9 +15,7 @@
 
 . /etc/armbian-release
 
-
-check_abort()
-{
+check_abort() {
 
 	echo -e "\nDisabling user account creation procedure\n"
 	rm -f /root/.not_logged_in_yet
@@ -29,9 +27,7 @@ check_abort()
 
 }
 
-
-read_password()
-{
+read_password() {
 
 	unset password
 	unset charcount
@@ -40,26 +36,22 @@ read_password()
 	stty -echo
 
 	charcount=0
-	while IFS= read -p "$prompt" -r -s -n 1 char
-	do
-		if [[ $char == $'\0' ]]
-		then
+	while IFS= read -p "$prompt" -r -s -n 1 char; do
+		if [[ $char == $'\0' ]]; then
 			break
 		fi
 
 		# Handle backspace
-		if [[ $char == $'\177' ]]
-		then
-			if [ $charcount -gt 0 ]
-			then
-				charcount=$((charcount-1))
+		if [[ $char == $'\177' ]]; then
+			if [ $charcount -gt 0 ]; then
+				charcount=$((charcount - 1))
 				prompt=$'\b \b'
 				password="${password%?}"
 			else
 				prompt=''
 			fi
 		else
-			charcount=$((charcount+1))
+			charcount=$((charcount + 1))
 			prompt='*'
 			password+="$char"
 		fi
@@ -69,31 +61,37 @@ read_password()
 
 }
 
+set_shell() {
 
-set_shell()
-{
-
-	readarray -t optionsAudits <<<"$(grep "zsh\|/bash" /etc/shells | sed 's/\/bin\///g' | sed 's/\/usr//g' | uniq)"
+	readarray -t optionsAudits <<< "$(grep "zsh\|/bash" /etc/shells | sed 's/\/bin\///g' | sed 's/\/usr//g' | uniq)"
 	USER_SHELL="bash"
 
 	if [[ "${#optionsAudits[@]}" -gt 1 ]]; then
-		while :
-			do
-				while [[ ! "${reply}" =~ ^(1|2)$ ]]; do
-					i=1
-					echo -e "\nChoose default system command shell:\n"
-					for o in  "${optionsAudits[@]}"; do
-						echo "$i) $o"
-						(( i++ )) || true
-					done
-					read -r reply
+		while :; do
+			while [[ ! "${reply}" =~ ^(1|2)$ ]]; do
+				i=1
+				echo -e "\nChoose default system command shell:\n"
+				for o in "${optionsAudits[@]}"; do
+					echo "$i) $o"
+					((i++)) || true
 				done
-				case $reply in
-					"1"|"${optionsAudits[0]}") USER_SHELL="${optionsAudits[0]}"; break;;
-					"2"|"${optionsAudits[1]}") USER_SHELL="${optionsAudits[1]}"; break;;
-					*) USER_SHELL="${optionsAudits[0]}"; break;;
-				esac
+				read -r reply
 			done
+			case $reply in
+				"1" | "${optionsAudits[0]}")
+					USER_SHELL="${optionsAudits[0]}"
+					break
+					;;
+				"2" | "${optionsAudits[1]}")
+					USER_SHELL="${optionsAudits[1]}"
+					break
+					;;
+				*)
+					USER_SHELL="${optionsAudits[0]}"
+					break
+					;;
+			esac
+		done
 	fi
 	SHELL_PATH=$(grep "/$USER_SHELL$" /etc/shells | tail -1)
 
@@ -106,14 +104,13 @@ set_shell()
 
 }
 
-set_timezone_and_locales()
-{
+set_timezone_and_locales() {
 
 	# Grab this machine's public IP address
 	PUBLIC_IP=$(curl --max-time 5 -s https://ipinfo.io/ip)
 
 	# Check if we have wireless adaptor
-	WIFI_DEVICE=$(LC_ALL=C nmcli dev status | grep  " wifi " 2>/dev/null)
+	WIFI_DEVICE=$(LC_ALL=C nmcli dev status | grep " wifi " 2> /dev/null)
 
 	if [ -z "$PUBLIC_IP" ]; then
 
@@ -139,13 +136,13 @@ set_timezone_and_locales()
 
 	# Call the geolocation API and capture the output
 	RES=$(
-		curl --max-time 5 -s "http://ipwhois.app/json/${PUBLIC_IP}" | \
-			jq '.timezone, .country, .country_code' | \
+		curl --max-time 5 -s "http://ipwhois.app/json/${PUBLIC_IP}" |
+			jq '.timezone, .country, .country_code' |
 			while read -r TIMEZONE; do
 				read -r COUNTRY
 				echo "${TIMEZONE},${COUNTRY},${COUNTRYCODE}" | tr --delete '"\n'
 			done
-		)
+	)
 
 	TZDATA=$(echo "${RES}" | cut -d"," -f1)
 	CCODE=$(echo "${RES}" | cut -d"," -f3 | xargs)
@@ -162,13 +159,13 @@ set_timezone_and_locales()
 		unset CCODE TZDATA
 	fi
 
-	LOCALES=$(grep territory /usr/share/i18n/locales/* | grep _"$CCODE" | cut -d ":" -f 1 | cut -d "/" -f 6 |  \
-	xargs -I{} grep {} /usr/share/i18n/SUPPORTED | grep "\.UTF-8" | cut -d " " -f 1)
+	LOCALES=$(grep territory /usr/share/i18n/locales/* | grep _"$CCODE" | cut -d ":" -f 1 | cut -d "/" -f 6 |
+		xargs -I{} grep {} /usr/share/i18n/SUPPORTED | grep "\.UTF-8" | cut -d " " -f 1)
 	# UTF8 is not present everywhere so check again in case it returns empty value
-	[[ -z "$LOCALES" ]] && LOCALES=$(grep territory /usr/share/i18n/locales/* | grep _"$CCODE" | cut -d ":" -f 1 | cut -d "/" -f 6 |  \
-	xargs -I{} grep {} /usr/share/i18n/SUPPORTED | cut -d " " -f 1)
+	[[ -z "$LOCALES" ]] && LOCALES=$(grep territory /usr/share/i18n/locales/* | grep _"$CCODE" | cut -d ":" -f 1 | cut -d "/" -f 6 |
+		xargs -I{} grep {} /usr/share/i18n/SUPPORTED | cut -d " " -f 1)
 
-	readarray -t options <<<"${LOCALES}"
+	readarray -t options <<< "${LOCALES}"
 
 	# when having more locales, prompt for choosing one
 	if [[ "${#options[@]}" -gt 1 ]]; then
@@ -176,13 +173,12 @@ set_timezone_and_locales()
 		options+=("Skip generating locales")
 		echo -e "\nAt your location, more locales are possible:\n"
 		PS3='Please enter your choice:'
-		select opt in "${options[@]}"
-			do
-				if [[ " ${options[*]} " == *" ${opt} "* ]]; then
-					LOCALES=${opt}
-					break
-				fi
-			done
+		select opt in "${options[@]}"; do
+			if [[ " ${options[*]} " == *" ${opt} "* ]]; then
+				LOCALES=${opt}
+				break
+			fi
+		done
 	fi
 
 	if [[ "${LOCALES}" != *Skip* ]]; then
@@ -216,17 +212,13 @@ set_timezone_and_locales()
 	fi
 }
 
-
-
-
-add_profile_sync_settings()
-{
-	/usr/bin/psd >/dev/null 2>&1
+add_profile_sync_settings() {
+	/usr/bin/psd > /dev/null 2>&1
 	config_file="${HOME}/.config/psd/psd.conf"
 	if [ -f "${config_file}" ]; then
 		# test for overlayfs
 		sed -i 's/#USE_OVERLAYFS=.*/USE_OVERLAYFS="yes"/' "${config_file}"
-		case $(/usr/bin/psd p 2>/dev/null | grep Overlayfs) in
+		case $(/usr/bin/psd p 2> /dev/null | grep Overlayfs) in
 			*active*)
 				echo -e "\nConfigured profile sync daemon with overlayfs."
 				;;
@@ -236,30 +228,24 @@ add_profile_sync_settings()
 				;;
 		esac
 	fi
-	systemctl --user enable psd.service >/dev/null 2>&1
-	systemctl --user start psd.service >/dev/null 2>&1
+	systemctl --user enable psd.service > /dev/null 2>&1
+	systemctl --user start psd.service > /dev/null 2>&1
 }
 
-
-
-
-
-add_user()
-{
+add_user() {
 	read -r -t 0 _
 	REPEATS=3
 	while [ -f "/root/.not_logged_in_yet" ]; do
 		echo -e "\nPlease provide a username (eg. your first name): \c"
 		read -r -e username
-		if ! grep '^[a-zA-Z][a-zA-Z0-9]*$' <<< "$username" > /dev/null ; then
+		if ! grep '^[a-zA-Z][a-zA-Z0-9]*$' <<< "$username" > /dev/null; then
 			echo -e "\n\x1B[91mError\x1B[0m: illegal characters in username"
 			return
 		fi
 
-
 		RealUserName="$(echo "$username" | tr '[:upper:]' '[:lower:]' | tr -d -c '[:alnum:]')"
 		[ -z "$RealUserName" ] && return
-		if ! id "$RealUserName" >/dev/null 2>&1; then break; else echo -e "Username \e[0;31m$RealUserName\x1B[0m already exists on the system."; fi
+		if ! id "$RealUserName" > /dev/null 2>&1; then break; else echo -e "Username \e[0;31m$RealUserName\x1B[0m already exists on the system."; fi
 	done
 
 	while [ -f "/root/.not_logged_in_yet" ]; do
@@ -271,9 +257,9 @@ add_user()
 		echo ""
 		if [[ "$first_input" == "$second_input" ]]; then
 			# minimal images might not have this
-			if command -v cracklib-check >/dev/null 2>&1; then
-				result="$(cracklib-check <<<"$password")"
-				okay="$(awk -F': ' '{ print $2}' <<<"$result")"
+			if command -v cracklib-check > /dev/null 2>&1; then
+				result="$(cracklib-check <<< "$password")"
+				okay="$(awk -F': ' '{ print $2}' <<< "$result")"
 				if [[ "$okay" != "OK" ]]; then
 					echo -e "\n\e[0;31mWarning:\x1B[0m Weak password, $okay \b!"
 				fi
@@ -283,25 +269,28 @@ add_user()
 
 			adduser --quiet --disabled-password --home /home/"$RealUserName" --gecos "$RealName" "$RealUserName"
 			if [[ -n "$first_input" ]]; then
-				(echo "$first_input";echo "$second_input";) | passwd "$RealUserName" >/dev/null 2>&1
+				(
+					echo "$first_input"
+					echo "$second_input"
+				) | passwd "$RealUserName" > /dev/null 2>&1
 			else
-				passwd -d "$RealUserName" >/dev/null 2>&1
+				passwd -d "$RealUserName" > /dev/null 2>&1
 			fi
 			for additionalgroup in sudo netdev audio video disk tty users games dialout plugdev input bluetooth systemd-journal ssh; do
-				usermod -aG "${additionalgroup}" "${RealUserName}" 2>/dev/null
+				usermod -aG "${additionalgroup}" "${RealUserName}" 2> /dev/null
 			done
 
 			# fix for gksu in Xenial
 			touch /home/"$RealUserName"/.Xauthority
 			chown "$RealUserName":"$RealUserName" /home/"$RealUserName"/.Xauthority
-			RealName="$(awk -F":" "/^${RealUserName}:/ {print \$5}" </etc/passwd | cut -d',' -f1)"
+			RealName="$(awk -F":" "/^${RealUserName}:/ {print \$5}" < /etc/passwd | cut -d',' -f1)"
 			[ -z "$RealName" ] && RealName="$RealUserName"
 			echo -e "\nDear \e[0;92m${RealName}\x1B[0m, your account \e[0;92m${RealUserName}\x1B[0m has been created and is sudo enabled."
 			echo -e "Please use this account for your daily work from now on.\n"
 			rm -f /root/.not_logged_in_yet
 			chmod +x /etc/update-motd.d/*
 			# set up profile sync daemon on desktop systems
-			if command -v psd >/dev/null 2>&1; then
+			if command -v psd > /dev/null 2>&1; then
 				echo -e "${RealUserName} ALL=(ALL) NOPASSWD: /usr/bin/psd-overlay-helper" >> /etc/sudoers
 				touch /home/"${RealUserName}"/.activate_psd
 				chown "$RealUserName":"$RealUserName" /home/"${RealUserName}"/.activate_psd
@@ -323,12 +312,12 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 	systemctl daemon-reload
 
 	# detect display manager
-	desktop_lightdm=$(dpkg-query -W -f='${db:Status-Abbrev}\n' lightdm 2>/dev/null)
-	desktop_gdm3=$(dpkg-query -W -f='${db:Status-Abbrev}\n' gdm3 2>/dev/null)
+	desktop_lightdm=$(dpkg-query -W -f='${db:Status-Abbrev}\n' lightdm 2> /dev/null)
+	desktop_gdm3=$(dpkg-query -W -f='${db:Status-Abbrev}\n' gdm3 2> /dev/null)
 
 	echo -e "\nWaiting for system to finish booting ..."
 
-	systemctl is-system-running --wait >/dev/null
+	systemctl is-system-running --wait > /dev/null
 
 	# enable hiDPI support
 	if [[ "$(cut -d, -f1 < /sys/class/graphics/fb0/virtual_size 2> /dev/null)" -gt 1920 ]]; then
@@ -363,14 +352,17 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 		echo ""
 		if [[ "$first_input" == "$second_input" ]]; then
 			# minimal might not have this
-			if command -v cracklib-check >/dev/null 2>&1; then
-				result="$(cracklib-check <<<"$password")"
-				okay="$(awk -F': ' '{ print $2}' <<<"$result")"
+			if command -v cracklib-check > /dev/null 2>&1; then
+				result="$(cracklib-check <<< "$password")"
+				okay="$(awk -F': ' '{ print $2}' <<< "$result")"
 				if [[ "$okay" != "OK" ]]; then
 					echo -e "\n\e[0;31mWarning:\x1B[0m Weak password, $okay \b!"
 				fi
 			fi
-			(echo "$first_input";echo "$second_input";) | passwd root >/dev/null 2>&1
+			(
+				echo "$first_input"
+				echo "$second_input"
+			) | passwd root > /dev/null 2>&1
 			break
 		elif [[ -n $password ]]; then
 			echo -e "Rejected - \e[0;31mpasswords do not match.\x1B[0m Try again [${REPEATS}]."
@@ -391,12 +383,12 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 		fi
 	else
 
-	echo -e "\e[0;31m\nWARNING!\x1B[0m\n\nYou are using an \e[0;31mautomated build\x1B[0m meant only for developers to provide"
-	echo -e	"constructive feedback to improve build system, OS settings or UX.\n"
+		echo -e "\e[0;31m\nWARNING!\x1B[0m\n\nYou are using an \e[0;31mautomated build\x1B[0m meant only for developers to provide"
+		echo -e "constructive feedback to improve build system, OS settings or UX.\n"
 
-	echo -e "If this does not apply to you, \e[0;31mSTOP NOW!\x1B[0m  Especially don't use this "
-	echo -e "image for production since things might not work as expected or at "
-	echo -e "all. They may  break anytime with next update."
+		echo -e "If this does not apply to you, \e[0;31mSTOP NOW!\x1B[0m  Especially don't use this "
+		echo -e "image for production since things might not work as expected or at "
+		echo -e "all. They may  break anytime with next update."
 
 	fi
 
@@ -424,121 +416,119 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 	fi
 
 	# check whether desktop environment has to be considered
-	if [ -n "$desktop_lightdm" ] && [ -n "$RealName" ] ; then
+	if [ -n "$desktop_lightdm" ] && [ -n "$RealName" ]; then
 
-			# 1st run goes without login
-			mkdir -p /etc/lightdm/lightdm.conf.d
-			cat <<-EOF > /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
+		# 1st run goes without login
+		mkdir -p /etc/lightdm/lightdm.conf.d
+		cat <<- EOF > /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
 			[Seat:*]
 			autologin-user=$RealUserName
 			autologin-user-timeout=0
 			user-session=xfce
-			EOF
+		EOF
 
-			# select gnome session (has to be first or it breaks budgie/cinnamon desktop autologin and user-session)
-			[[ -x $(command -v gnome-session) ]] && sed -i "s/user-session.*/user-session=ubuntu/" /etc/lightdm/lightdm.conf.d/11-armbian.conf
-			[[ -x $(command -v gnome-session) ]] && sed -i "s/user-session.*/user-session=ubuntu/" /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
+		# select gnome session (has to be first or it breaks budgie/cinnamon desktop autologin and user-session)
+		[[ -x $(command -v gnome-session) ]] && sed -i "s/user-session.*/user-session=ubuntu/" /etc/lightdm/lightdm.conf.d/11-armbian.conf
+		[[ -x $(command -v gnome-session) ]] && sed -i "s/user-session.*/user-session=ubuntu/" /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
 
-			# select awesome session
-			[[ -x $(command -v awesome) ]] && sed -i "s/user-session.*/user-session=awesome/" /etc/lightdm/lightdm.conf.d/11-armbian.conf
-			[[ -x $(command -v awesome) ]] && sed -i "s/user-session.*/user-session=awesome/" /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
+		# select awesome session
+		[[ -x $(command -v awesome) ]] && sed -i "s/user-session.*/user-session=awesome/" /etc/lightdm/lightdm.conf.d/11-armbian.conf
+		[[ -x $(command -v awesome) ]] && sed -i "s/user-session.*/user-session=awesome/" /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
 
-			# select budgie session
-			[[ -x $(command -v budgie-desktop) ]] && sed -i "s/user-session.*/user-session=budgie-desktop/" /etc/lightdm/lightdm.conf.d/11-armbian.conf
-			[[ -x $(command -v budgie-desktop) ]] && sed -i "s/user-session.*/user-session=budgie-desktop/" /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
+		# select budgie session
+		[[ -x $(command -v budgie-desktop) ]] && sed -i "s/user-session.*/user-session=budgie-desktop/" /etc/lightdm/lightdm.conf.d/11-armbian.conf
+		[[ -x $(command -v budgie-desktop) ]] && sed -i "s/user-session.*/user-session=budgie-desktop/" /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
 
-			# select cinnamon session
-			[[ -x $(command -v cinnamon) ]] && sed -i "s/user-session.*/user-session=cinnamon/" /etc/lightdm/lightdm.conf.d/11-armbian.conf
-			[[ -x $(command -v cinnamon) ]] && sed -i "s/user-session.*/user-session=cinnamon/" /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
+		# select cinnamon session
+		[[ -x $(command -v cinnamon) ]] && sed -i "s/user-session.*/user-session=cinnamon/" /etc/lightdm/lightdm.conf.d/11-armbian.conf
+		[[ -x $(command -v cinnamon) ]] && sed -i "s/user-session.*/user-session=cinnamon/" /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
 
-			# select deepin session
-			[[ -x $(command -v deepin-wm) ]] && sed -i "s/user-session.*/user-session=deepin/" /etc/lightdm/lightdm.conf.d/11-armbian.conf
-			[[ -x $(command -v deepin-wm) ]] && sed -i "s/user-session.*/user-session=deepin/" /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
+		# select deepin session
+		[[ -x $(command -v deepin-wm) ]] && sed -i "s/user-session.*/user-session=deepin/" /etc/lightdm/lightdm.conf.d/11-armbian.conf
+		[[ -x $(command -v deepin-wm) ]] && sed -i "s/user-session.*/user-session=deepin/" /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
 
-			# select ice-wm session
-			[[ -x $(command -v icewm-session) ]] && sed -i "s/user-session.*/user-session=icewm-session/" /etc/lightdm/lightdm.conf.d/11-armbian.conf
-			[[ -x $(command -v icewm-session) ]] && sed -i "s/user-session.*/user-session=icewm-session/" /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
+		# select ice-wm session
+		[[ -x $(command -v icewm-session) ]] && sed -i "s/user-session.*/user-session=icewm-session/" /etc/lightdm/lightdm.conf.d/11-armbian.conf
+		[[ -x $(command -v icewm-session) ]] && sed -i "s/user-session.*/user-session=icewm-session/" /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
 
-			# select i3 session
-			[[ -x $(command -v i3) ]] && sed -i "s/user-session.*/user-session=i3/" /etc/lightdm/lightdm.conf.d/11-armbian.conf
-			[[ -x $(command -v i3) ]] && sed -i "s/user-session.*/user-session=i3/" /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
+		# select i3 session
+		[[ -x $(command -v i3) ]] && sed -i "s/user-session.*/user-session=i3/" /etc/lightdm/lightdm.conf.d/11-armbian.conf
+		[[ -x $(command -v i3) ]] && sed -i "s/user-session.*/user-session=i3/" /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
 
-			# select lxde session
-			[[ -x $(command -v startlxde) ]] && sed -i "s/user-session.*/user-session=LXDE/" /etc/lightdm/lightdm.conf.d/11-armbian.conf
-			[[ -x $(command -v startlxde) ]] && sed -i "s/user-session.*/user-session=LXDE/" /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
+		# select lxde session
+		[[ -x $(command -v startlxde) ]] && sed -i "s/user-session.*/user-session=LXDE/" /etc/lightdm/lightdm.conf.d/11-armbian.conf
+		[[ -x $(command -v startlxde) ]] && sed -i "s/user-session.*/user-session=LXDE/" /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
 
-			# select lxqt session
-			[[ -x $(command -v startlxqt) ]] && sed -i "s/user-session.*/user-session=lxqt/" /etc/lightdm/lightdm.conf.d/11-armbian.conf
-			[[ -x $(command -v startlxqt) ]] && sed -i "s/user-session.*/user-session=lxqt/" /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
+		# select lxqt session
+		[[ -x $(command -v startlxqt) ]] && sed -i "s/user-session.*/user-session=lxqt/" /etc/lightdm/lightdm.conf.d/11-armbian.conf
+		[[ -x $(command -v startlxqt) ]] && sed -i "s/user-session.*/user-session=lxqt/" /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
 
-			# select mate session
-			[[ -x $(command -v mate-wm) ]] && sed -i "s/user-session.*/user-session=mate/" /etc/lightdm/lightdm.conf.d/11-armbian.conf
-			[[ -x $(command -v mate-wm) ]] && sed -i "s/user-session.*/user-session=mate/" /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
+		# select mate session
+		[[ -x $(command -v mate-wm) ]] && sed -i "s/user-session.*/user-session=mate/" /etc/lightdm/lightdm.conf.d/11-armbian.conf
+		[[ -x $(command -v mate-wm) ]] && sed -i "s/user-session.*/user-session=mate/" /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
 
-			# select plasma wayland session
-			[[ -x $(command -v plasmashell) ]] && sed -i "s/user-session.*/user-session=plasmawayland/" /etc/lightdm/lightdm.conf.d/11-armbian.conf
-			[[ -x $(command -v plasmashell) ]] && sed -i "s/user-session.*/user-session=plasmawayland/" /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
+		# select plasma wayland session
+		[[ -x $(command -v plasmashell) ]] && sed -i "s/user-session.*/user-session=plasmawayland/" /etc/lightdm/lightdm.conf.d/11-armbian.conf
+		[[ -x $(command -v plasmashell) ]] && sed -i "s/user-session.*/user-session=plasmawayland/" /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
 
-			# select sway wayland session
-			[[ -x $(command -v sway) ]] && sed -i "s/user-session.*/user-session=sway/" /etc/lightdm/lightdm.conf.d/11-armbian.conf
-			[[ -x $(command -v sway) ]] && sed -i "s/user-session.*/user-session=sway/" /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
+		# select sway wayland session
+		[[ -x $(command -v sway) ]] && sed -i "s/user-session.*/user-session=sway/" /etc/lightdm/lightdm.conf.d/11-armbian.conf
+		[[ -x $(command -v sway) ]] && sed -i "s/user-session.*/user-session=sway/" /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
 
-			# select xmonad session
-			[[ -x $(command -v xmonad) ]] && sed -i "s/user-session.*/user-session=xmonad/" /etc/lightdm/lightdm.conf.d/11-armbian.conf
-			[[ -x $(command -v xmonad) ]] && sed -i "s/user-session.*/user-session=xmonad/" /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
+		# select xmonad session
+		[[ -x $(command -v xmonad) ]] && sed -i "s/user-session.*/user-session=xmonad/" /etc/lightdm/lightdm.conf.d/11-armbian.conf
+		[[ -x $(command -v xmonad) ]] && sed -i "s/user-session.*/user-session=xmonad/" /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
 
-			ln -sf /lib/systemd/system/lightdm.service /etc/systemd/system/display-manager.service
+		ln -sf /lib/systemd/system/lightdm.service /etc/systemd/system/display-manager.service
 
-			if [[ -f /var/run/resize2fs-reboot ]]; then
-				# Let the user reboot now otherwise start desktop environment
-				printf "\n\n\e[0;91mWarning: a reboot is needed to finish resizing the filesystem \x1B[0m \n"
-				printf "\e[0;91mPlease reboot the system now \x1B[0m \n\n"
+		if [[ -f /var/run/resize2fs-reboot ]]; then
+			# Let the user reboot now otherwise start desktop environment
+			printf "\n\n\e[0;91mWarning: a reboot is needed to finish resizing the filesystem \x1B[0m \n"
+			printf "\e[0;91mPlease reboot the system now \x1B[0m \n\n"
+		else
+			echo -e "\n\e[1m\e[39mNow starting desktop environment...\x1B[0m\n"
+			sleep 1
+			service lightdm start 2> /dev/null
+			if [ -f /root/.desktop_autologin ]; then
+				rm /root/.desktop_autologin
 			else
-				echo -e "\n\e[1m\e[39mNow starting desktop environment...\x1B[0m\n"
-				sleep 1
-				service lightdm start 2>/dev/null
-				if [ -f /root/.desktop_autologin ]; then
-					rm /root/.desktop_autologin
-				else
-					systemctl -q enable armbian-disable-autologin.timer
-					systemctl start armbian-disable-autologin.timer
-				fi
-				# logout if logged at console
-				who -la | grep root | grep -q tty1 && exit 1
+				systemctl -q enable armbian-disable-autologin.timer
+				systemctl start armbian-disable-autologin.timer
 			fi
+			# logout if logged at console
+			who -la | grep root | grep -q tty1 && exit 1
+		fi
 
-	elif [ -n "$desktop_gdm3" ] && [ -n "$RealName" ] ; then
-
-			# 1st run goes without login
-			mkdir -p /etc/gdm3
-			cat <<-EOF > /etc/gdm3/custom.conf
+	elif [ -n "$desktop_gdm3" ] && [ -n "$RealName" ]; then
+		# 1st run goes without login
+		mkdir -p /etc/gdm3
+		cat <<- EOF > /etc/gdm3/custom.conf
 			[daemon]
 			AutomaticLoginEnable = true
 			AutomaticLogin = $RealUserName
-			EOF
+		EOF
 
-			ln -sf /lib/systemd/system/gdm3.service /etc/systemd/system/display-manager.service
+		ln -sf /lib/systemd/system/gdm3.service /etc/systemd/system/display-manager.service
 
-				if [[ -f /var/run/resize2fs-reboot ]]; then
-
-					# Let the user reboot now otherwise start desktop environment
-					printf "\n\n\e[0;91mWarning: a reboot is needed to finish resizing the filesystem \x1B[0m \n"
-					printf "\e[0;91mPlease reboot the system now \x1B[0m \n\n"
-
-				else
-
-					echo -e "\n\e[1m\e[39mNow starting desktop environment...\x1B[0m\n"
-					sleep 1
-					service gdm3 start 2>/dev/null
-					if [ -f /root/.desktop_autologin ]; then
-						rm /root/.desktop_autologin
-					else
-						(sleep 20; sed -i "s/AutomaticLoginEnable.*/AutomaticLoginEnable = false/" /etc/gdm3/custom.conf) &
-					fi
-					# logout if logged at console
-					who -la | grep root | grep -q tty1 && exit 1
-
-				fi
+		if [[ -f /var/run/resize2fs-reboot ]]; then
+			# Let the user reboot now otherwise start desktop environment
+			printf "\n\n\e[0;91mWarning: a reboot is needed to finish resizing the filesystem \x1B[0m \n"
+			printf "\e[0;91mPlease reboot the system now \x1B[0m \n\n"
+		else
+			echo -e "\n\e[1m\e[39mNow starting desktop environment...\x1B[0m\n"
+			sleep 1
+			service gdm3 start 2> /dev/null
+			if [ -f /root/.desktop_autologin ]; then
+				rm /root/.desktop_autologin
+			else
+				(
+					sleep 20
+					sed -i "s/AutomaticLoginEnable.*/AutomaticLoginEnable = false/" /etc/gdm3/custom.conf
+				) &
+			fi
+			# logout if logged at console
+			who -la | grep root | grep -q tty1 && exit 1
+		fi
 
 	else
 

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -213,6 +213,10 @@ set_timezone_and_locales() {
 }
 
 add_profile_sync_settings() {
+	if [[ ! -f /usr/bin/psd ]]; then
+		return 0
+	fi
+
 	/usr/bin/psd > /dev/null 2>&1
 	config_file="${HOME}/.config/psd/psd.conf"
 	if [ -f "${config_file}" ]; then
@@ -311,12 +315,22 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 	rm -f /etc/systemd/system/serial-getty@.service.d/override.conf
 	systemctl daemon-reload
 
-	# detect display manager
-	desktop_lightdm=$(dpkg-query -W -f='${db:Status-Abbrev}\n' lightdm 2> /dev/null)
-	desktop_gdm3=$(dpkg-query -W -f='${db:Status-Abbrev}\n' gdm3 2> /dev/null)
+	declare desktop_dm="none"
+	declare -i desktop_is_sddm=0 desktop_is_lightdm=0 desktop_is_gdm3=0
+	if [[ -f /usr/bin/sddm ]]; then
+		desktop_dm="sddm"
+		desktop_is_sddm=1
+	fi
+	if [[ -f /usr/sbin/lightdm ]]; then
+		desktop_dm="lightdm"
+		desktop_is_lightdm=1
+	fi
+	if [[ -f /usr/sbin/gdm3 ]]; then
+		desktop_dm="gdm3"
+		desktop_is_gdm3=1
+	fi
 
 	echo -e "\nWaiting for system to finish booting ..."
-
 	systemctl is-system-running --wait > /dev/null
 
 	# enable hiDPI support
@@ -325,6 +339,8 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 		[[ -f /etc/lightdm/slick-greeter.conf ]] && echo "enable-hidpi = on" >> /etc/lightdm/slick-greeter.conf
 		# xfce
 		[[ -f /etc/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml ]] && sed -i 's|<property name="WindowScalingFactor" type="int" value=".*|<property name="WindowScalingFactor" type="int" value="2">|g' /etc/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml
+
+		# framebuffer console larger font
 		setfont /usr/share/consolefonts/Uni3-TerminusBold32x16.psf.gz
 	fi
 
@@ -401,7 +417,7 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 
 	while [ -f "/root/.not_logged_in_yet" ]; do
 		echo -e "\nCreating a new user account. Press <Ctrl-C> to abort"
-		[ -n "$desktop_lightdm" ] && echo -e "\n\e[0;31mDesktop environment will not be enabled if you abort the new user creation\x1B[0m"
+		[[ "${desktop_dm}" != "none" ]] && echo -e "\n\e[0;31mDesktop environment will not be enabled if you abort the new user creation\x1B[0m"
 		add_user
 	done
 	trap - INT TERM EXIT
@@ -415,8 +431,8 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 		printf "\nYou selected \e[0;91mZSH\x1B[0m as your default shell. If you want to use it right away, please logout and login! \n\n"
 	fi
 
-	# check whether desktop environment has to be considered
-	if [ -n "$desktop_lightdm" ] && [ -n "$RealName" ]; then
+	# rpardini: hacks per-dm, very much legacy stuff that works by a miracle
+	if [[ "${desktop_dm}" == "lightdm" ]] && [ -n "$RealName" ]; then
 
 		# 1st run goes without login
 		mkdir -p /etc/lightdm/lightdm.conf.d
@@ -428,6 +444,7 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 		EOF
 
 		# select gnome session (has to be first or it breaks budgie/cinnamon desktop autologin and user-session)
+		# @TODO: remove this, gnome should use gdm3, not lightdm
 		[[ -x $(command -v gnome-session) ]] && sed -i "s/user-session.*/user-session=ubuntu/" /etc/lightdm/lightdm.conf.d/11-armbian.conf
 		[[ -x $(command -v gnome-session) ]] && sed -i "s/user-session.*/user-session=ubuntu/" /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
 
@@ -467,7 +484,7 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 		[[ -x $(command -v mate-wm) ]] && sed -i "s/user-session.*/user-session=mate/" /etc/lightdm/lightdm.conf.d/11-armbian.conf
 		[[ -x $(command -v mate-wm) ]] && sed -i "s/user-session.*/user-session=mate/" /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
 
-		# select plasma wayland session
+		# select plasma wayland session # @TODO: rpardini: dead code? kde-plasma desktop should use sddm, not lightdm.
 		[[ -x $(command -v plasmashell) ]] && sed -i "s/user-session.*/user-session=plasmawayland/" /etc/lightdm/lightdm.conf.d/11-armbian.conf
 		[[ -x $(command -v plasmashell) ]] && sed -i "s/user-session.*/user-session=plasmawayland/" /etc/lightdm/lightdm.conf.d/22-armbian-autologin.conf
 
@@ -499,7 +516,7 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 			who -la | grep root | grep -q tty1 && exit 1
 		fi
 
-	elif [ -n "$desktop_gdm3" ] && [ -n "$RealName" ]; then
+	elif [[ "${desktop_dm}" == "gdm3" ]] && [ -n "$RealName" ]; then
 		# 1st run goes without login
 		mkdir -p /etc/gdm3
 		cat <<- EOF > /etc/gdm3/custom.conf
@@ -529,15 +546,16 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 			# logout if logged at console
 			who -la | grep root | grep -q tty1 && exit 1
 		fi
-
+	elif [[ "${desktop_dm}" == "sddm" ]] && [ -n "$RealName" ]; then
+		# No hacks for sddm. User will have to input password again, and have  chance to choose session wayland
+		echo -e "\n\e[1m\e[39mNow starting desktop environment via ${desktop_dm}...\x1B[0m\n"
+		systemctl enable --now sddm
 	else
-
+		# no display manager detected
 		# Display reboot recommendation if necessary
 		if [[ -f /var/run/resize2fs-reboot ]]; then
 			printf "\n\n\e[0;91mWarning: a reboot is needed to finish resizing the filesystem \x1B[0m \n"
 			printf "\e[0;91mPlease reboot the system now \x1B[0m \n\n"
 		fi
-
 	fi
-
 fi


### PR DESCRIPTION
#### armbian-desktop: remove "Conflicts: gdm3"; some sddm support

- rootfs-desktop: disable `sddm` as well as `lightdm` and `gdm3` in `desktop_postinstall()`
  - lightdm, gdm3 already had this
- armbian-firstlogin: shellfmt, no changes
- armbian-firstlogin: better dm detection + add simple no-op sddm support + gdm3 fixes
- armbian-desktop: remove "Conflicts: gdm3"
  - if you installed gdm3 (even if you don't use it), you lose Armbian wallpapers