### PR TITLE
`Automatic` board configs status synchronise

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,7 +41,7 @@ config/boards/khadas-vim1s.wip		@rpardini @viraniac
 config/boards/khadas-vim2.conf		@igorpecovnik
 config/boards/khadas-vim3.conf		@NicoD-SBC @rpardini
 config/boards/khadas-vim3l.conf		@rpardini
-config/boards/khadas-vim4.wip		@rpardini
+config/boards/khadas-vim4.wip		@rpardini @viraniac
 config/boards/lafrite.conf		@Tonymac32
 config/boards/lepotato.conf		@Tonymac32
 config/boards/licheepi-4a.wip		@chainsx

--- a/config/boards/khadas-vim1s.wip
+++ b/config/boards/khadas-vim1s.wip
@@ -2,7 +2,7 @@
 BOARD_NAME="Khadas VIM1S" # don't confuse with VIM1 (S905X)
 BOARDFAMILY="meson-s4t7"
 KERNEL_TARGET="legacy"
-BOARD_MAINTAINER="rpardini viraniac"
+BOARD_MAINTAINER="viraniac rpardini"
 SERIALCON="ttyS0" # for vendor kernel
 # BOOT_FDT_FILE="amlogic/kvim1s.dtb" # unset on purpose: uboot auto-determines the DTB to use
 

--- a/config/boards/khadas-vim4.wip
+++ b/config/boards/khadas-vim4.wip
@@ -2,7 +2,7 @@
 BOARD_NAME="Khadas VIM4"
 BOARDFAMILY="meson-s4t7"
 KERNEL_TARGET="legacy"
-BOARD_MAINTAINER="rpardini"
+BOARD_MAINTAINER="viraniac rpardini"
 SERIALCON="ttyS0" # for vendor kernel
 # BOOT_FDT_FILE="amlogic/kvim4.dtb" # not set on purpose; u-boot auto-selects kvim4.dtb or kvim4n.dtb for "new VIM4"
 


### PR DESCRIPTION
Update maintainers and board status

- synced status from the database
- rename to .`csc` where we don't have anyone

If you want to become a board maintainer, [adjust data here](https://www.armbian.com/update-data/).

Ref: [Board Maintainers Procedures and Guidelines](https://docs.armbian.com/Board_Maintainers_Procedures_and_Guidelines/)