### PR TITLE
meson-s4t7: add systemd service to enable fan in automatic mode

### DIFF
--- a/config/boards/khadas-vim4.wip
+++ b/config/boards/khadas-vim4.wip
@@ -25,3 +25,10 @@ function post_family_tweaks_bsp__kvim4_isp_modprobe() {
 		softdep iv009_isp pre: iv009_isp_iq iv009_isp_lens iv009_isp_sensor
 	EOD
 }
+
+function post_family_tweaks_bsp__enable_fan_service() {
+	if [[ ${BRANCH} = "legacy" ]]; then
+		run_host_command_logged mkdir -p "${destination}"/etc/systemd/system/mutli-user.target.wants
+		run_host_command_logged ln -sf /etc/systemd/system/fan.service "${destination}"/etc/systemd/system/mutli-user.target.wants/fan.service
+	fi
+}

--- a/config/sources/families/meson-s4t7.conf
+++ b/config/sources/families/meson-s4t7.conf
@@ -106,3 +106,10 @@ function image_specific_armbian_env_ready__force_16x9_display() {
 		run_host_command_logged echo "force_16x9_display=true" >>${SDCARD}/boot/armbianEnv.txt
 	fi
 }
+
+function post_family_tweaks_bsp__add_fan_service() {
+	if [[ ${BRANCH} = "legacy" ]]; then
+		run_host_command_logged mkdir -p "${destination}"/etc/systemd/system
+		run_host_command_logged cp "${SRC}"/packages/bsp/meson-s4t7/fan.service "${destination}"/etc/systemd/system
+	fi
+}

--- a/packages/bsp/meson-s4t7/fan.service
+++ b/packages/bsp/meson-s4t7/fan.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Automatic Fan Control Service
+
+[Service]
+Type=oneshot
+RemainAfterExit=Yes
+ExecStart=/bin/sh -c "echo 1 > /sys/class/fan/mode"
+ExecStart=/bin/sh -c "echo 1 > /sys/class/fan/enable"
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
# Description

The service is only enabled by default on Vim4 as that board heats a lot and a fan is absolutely necessary. Service will be available on vim1s as well and if someone has purchased the fan for it, they would be able to enable it themselves.

The service is only added for legacy kernel right now as I am not sure if the upcoming 5.15 kernel will have same sysfs interface for fan as that of 5.4 kernel.

Jira reference number [AR-1887]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested on vim4. Fan starts at 50C, switches to medium speed on 60C and gets on full speed at 70C

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1887]: https://armbian.atlassian.net/browse/AR-1887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ