### PR TITLE
BPI-CM4: `Waveshare`: CM4-IO-BASE-B: `Fan support`

### DIFF
--- a/patch/kernel/archive/meson64-6.1/add-board-waveshare-cm4-io-base-b.patch
+++ b/patch/kernel/archive/meson64-6.1/add-board-waveshare-cm4-io-base-b.patch
@@ -1,22 +1,26 @@
-From ae66ecb93473ab39aff1d838bf9a24dcc2da9157 Mon Sep 17 00:00:00 2001
+From 220f0e430938ad10a7c54372a9b44b2baa6dabda Mon Sep 17 00:00:00 2001
 From: Patrick Yavitz <pyavitz@xxxxx.com>
-Date: Thu, 21 Sep 2023 07:19:43 -0400
-Subject: [PATCH] arch: arm64: dts: amlogic: meson-g12b-waveshare-cm4-io-base-b
+Date: Wed, 11 Oct 2023 09:04:11 -0400
+Subject: [PATCH] v2: arch: arm64: dts: amlogic: meson-g12b-waveshare-cm4-io-base-b
 
 https://www.waveshare.com/wiki/CM4-IO-BASE-B
+
+Fan, RTC and USB support
+RTC requires rtc pcf85063 driver
+Fan requires hwmon emc2305 driver
 
 Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
 ---
  arch/arm64/boot/dts/amlogic/Makefile          |  1 +
- .../meson-g12b-waveshare-cm4-io-base-b.dts    | 29 +++++++++++++++++++
- 2 files changed, 30 insertions(+)
+ .../meson-g12b-waveshare-cm4-io-base-b.dts    | 65 +++++++++++++++++++
+ 2 files changed, 66 insertions(+)
  create mode 100644 arch/arm64/boot/dts/amlogic/meson-g12b-waveshare-cm4-io-base-b.dts
 
 diff --git a/arch/arm64/boot/dts/amlogic/Makefile b/arch/arm64/boot/dts/amlogic/Makefile
-index ba9d7292f4a3..8a90b7869878 100644
+index 1e83933a11ab..f9e43e0d0464 100644
 --- a/arch/arm64/boot/dts/amlogic/Makefile
 +++ b/arch/arm64/boot/dts/amlogic/Makefile
-@@ -20,6 +20,7 @@ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-radxa-zero2.dtb
+@@ -20,6 +20,7 @@ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-odroid-n2l.dtb
  dtb-$(CONFIG_ARCH_MESON) += meson-g12b-s922x-bananapi-m2s.dtb
  dtb-$(CONFIG_ARCH_MESON) += meson-g12b-s922x-khadas-vim3.dtb
  dtb-$(CONFIG_ARCH_MESON) += meson-g12b-ugoos-am6.dtb
@@ -26,10 +30,10 @@ index ba9d7292f4a3..8a90b7869878 100644
  dtb-$(CONFIG_ARCH_MESON) += meson-gxbb-nexbox-a95x.dtb
 diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-waveshare-cm4-io-base-b.dts b/arch/arm64/boot/dts/amlogic/meson-g12b-waveshare-cm4-io-base-b.dts
 new file mode 100644
-index 000000000000..3a65d7c9c1dc
+index 000000000000..5739e480df82
 --- /dev/null
 +++ b/arch/arm64/boot/dts/amlogic/meson-g12b-waveshare-cm4-io-base-b.dts
-@@ -0,0 +1,29 @@
+@@ -0,0 +1,65 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2023 Patrick Yavitz <pyavitz@xxxxx.com>
@@ -53,6 +57,42 @@ index 000000000000..3a65d7c9c1dc
 +		compatible = "nxp,pcf85063a";
 +		reg = <0x51>;
 +		wakeup-source;
++	};
++
++	fanctrl: emc2305@2f {
++		reg = <0x2f>;
++		compatible = "smsc,emc2305";
++		#address-cells = <1>;
++		#size-cells = <0>;
++		#cooling-cells = <0x02>;
++	};
++};
++
++&cpu_thermal {
++	trips {
++		fanmid0: fanmid0 {
++			temperature = <60000>;
++			hysteresis = <2000>;
++			type = "active";
++		};
++	
++		fanmax0: fanmax0 {
++			temperature = <70000>;
++			hysteresis = <2000>;
++			type = "active";
++		};
++	};
++
++	cooling-maps {
++		map0 {
++			trip = <&fanmid0>;
++			cooling-device = <&fanctrl 2 6>;
++		};
++
++		map1 {
++			trip = <&fanmax0>;
++			cooling-device = <&fanctrl 7 THERMAL_NO_LIMIT>;
++		};
 +	};
 +};
 +

--- a/patch/kernel/archive/meson64-6.1/add-board-waveshare-cm4-io-base-b.patch
+++ b/patch/kernel/archive/meson64-6.1/add-board-waveshare-cm4-io-base-b.patch
@@ -1,6 +1,6 @@
-From 220f0e430938ad10a7c54372a9b44b2baa6dabda Mon Sep 17 00:00:00 2001
+From 0541667e097b302fd97b4fce606336f4c7cab67f Mon Sep 17 00:00:00 2001
 From: Patrick Yavitz <pyavitz@xxxxx.com>
-Date: Wed, 11 Oct 2023 09:04:11 -0400
+Date: Wed, 11 Oct 2023 11:34:54 -0400
 Subject: [PATCH] v2: arch: arm64: dts: amlogic: meson-g12b-waveshare-cm4-io-base-b
 
 https://www.waveshare.com/wiki/CM4-IO-BASE-B
@@ -12,8 +12,8 @@ Fan requires hwmon emc2305 driver
 Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
 ---
  arch/arm64/boot/dts/amlogic/Makefile          |  1 +
- .../meson-g12b-waveshare-cm4-io-base-b.dts    | 65 +++++++++++++++++++
- 2 files changed, 66 insertions(+)
+ .../meson-g12b-waveshare-cm4-io-base-b.dts    | 66 +++++++++++++++++++
+ 2 files changed, 67 insertions(+)
  create mode 100644 arch/arm64/boot/dts/amlogic/meson-g12b-waveshare-cm4-io-base-b.dts
 
 diff --git a/arch/arm64/boot/dts/amlogic/Makefile b/arch/arm64/boot/dts/amlogic/Makefile
@@ -30,10 +30,10 @@ index 1e83933a11ab..f9e43e0d0464 100644
  dtb-$(CONFIG_ARCH_MESON) += meson-gxbb-nexbox-a95x.dtb
 diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-waveshare-cm4-io-base-b.dts b/arch/arm64/boot/dts/amlogic/meson-g12b-waveshare-cm4-io-base-b.dts
 new file mode 100644
-index 000000000000..5739e480df82
+index 000000000000..2c988290d48a
 --- /dev/null
 +++ b/arch/arm64/boot/dts/amlogic/meson-g12b-waveshare-cm4-io-base-b.dts
-@@ -0,0 +1,65 @@
+@@ -0,0 +1,66 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2023 Patrick Yavitz <pyavitz@xxxxx.com>
@@ -65,6 +65,7 @@ index 000000000000..5739e480df82
 +		#address-cells = <1>;
 +		#size-cells = <0>;
 +		#cooling-cells = <0x02>;
++		wakeup-source;
 +	};
 +};
 +

--- a/patch/kernel/archive/meson64-6.1/hwmon-emc2305-fixups-for-driver.patch
+++ b/patch/kernel/archive/meson64-6.1/hwmon-emc2305-fixups-for-driver.patch
@@ -1,0 +1,212 @@
+From f6894c2a869e72a414cef2434d4f1f41197b1356 Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@xxxxx.com>
+Date: Tue, 10 Oct 2023 18:51:22 -0400
+Subject: [PATCH] hwmon: emc2305: fixups for driver
+
+BPI-CM4 fan control
+
+hwmon: emc2305: fixups for driver
+The driver had a number of issues, checkpatch warnings/errors,
+and other limitations, so fix these up to make it usable.
+hwmon: emc2305: Change OF properties pwm-min & pwm-max to u8 
+hwmon: emc2305: Add calls to initialize cooling maps
+https://github.com/raspberrypi/linux/commits/233096b8a9023f7e02960543c85447d46af81e81/drivers/hwmon/emc2305.c
+
+Tested-on: CM4-IO-BASE-B: https://www.waveshare.com/wiki/CM4-IO-BASE-B
+Signed-off-by: Phil Elwell <phil@raspberrypi.com>
+Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>
+Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
+---
+ drivers/hwmon/emc2305.c | 96 +++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 88 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/hwmon/emc2305.c b/drivers/hwmon/emc2305.c
+index e42ae43f3de4..de976a7521b3 100644
+--- a/drivers/hwmon/emc2305.c
++++ b/drivers/hwmon/emc2305.c
+@@ -15,12 +15,13 @@
+ static const unsigned short
+ emc2305_normal_i2c[] = { 0x27, 0x2c, 0x2d, 0x2e, 0x2f, 0x4c, 0x4d, I2C_CLIENT_END };
+ 
++#define EMC2305_REG_FAN_STATUS		0x24
++#define EMC2305_REG_FAN_STALL_STATUS	0x25
+ #define EMC2305_REG_DRIVE_FAIL_STATUS	0x27
+ #define EMC2305_REG_VENDOR		0xfe
+ #define EMC2305_FAN_MAX			0xff
+ #define EMC2305_FAN_MIN			0x00
+ #define EMC2305_FAN_MAX_STATE		10
+-#define EMC2305_DEVICE			0x34
+ #define EMC2305_VENDOR			0x5d
+ #define EMC2305_REG_PRODUCT_ID		0xfd
+ #define EMC2305_TACH_REGS_UNUSE_BITS	3
+@@ -39,6 +40,7 @@ emc2305_normal_i2c[] = { 0x27, 0x2c, 0x2d, 0x2e, 0x2f, 0x4c, 0x4d, I2C_CLIENT_EN
+ #define EMC2305_RPM_FACTOR		3932160
+ 
+ #define EMC2305_REG_FAN_DRIVE(n)	(0x30 + 0x10 * (n))
++#define EMC2305_REG_FAN_CFG(n)		(0x32 + 0x10 * (n))
+ #define EMC2305_REG_FAN_MIN_DRIVE(n)	(0x38 + 0x10 * (n))
+ #define EMC2305_REG_FAN_TACH(n)		(0x3e + 0x10 * (n))
+ 
+@@ -58,6 +60,16 @@ static const struct i2c_device_id emc2305_ids[] = {
+ };
+ MODULE_DEVICE_TABLE(i2c, emc2305_ids);
+ 
++static const struct of_device_id emc2305_dt_ids[] = {
++	{ .compatible = "smsc,emc2305" },
++	{ .compatible = "microchip,emc2305" },
++	{ .compatible = "microchip,emc2303" },
++	{ .compatible = "microchip,emc2302" },
++	{ .compatible = "microchip,emc2301" },
++	{ }
++};
++MODULE_DEVICE_TABLE(of, emc2305_dt_ids);
++
+ /**
+  * @cdev: cooling device;
+  * @curr_state: cooling current state;
+@@ -101,6 +113,7 @@ struct emc2305_data {
+ 	u8 pwm_num;
+ 	bool pwm_separate;
+ 	u8 pwm_min[EMC2305_PWM_MAX];
++	u8 pwm_max;
+ 	struct emc2305_cdev_data cdev_data[EMC2305_PWM_MAX];
+ };
+ 
+@@ -273,7 +286,7 @@ static int emc2305_set_pwm(struct device *dev, long val, int channel)
+ 	struct i2c_client *client = data->client;
+ 	int ret;
+ 
+-	if (val < data->pwm_min[channel] || val > EMC2305_FAN_MAX)
++	if (val < data->pwm_min[channel] || val > data->pwm_max)
+ 		return -EINVAL;
+ 
+ 	ret = i2c_smbus_write_byte_data(client, EMC2305_REG_FAN_DRIVE(channel), val);
+@@ -284,6 +297,49 @@ static int emc2305_set_pwm(struct device *dev, long val, int channel)
+ 	return 0;
+ }
+ 
++static int emc2305_get_tz_of(struct device *dev)
++{
++	struct device_node *np = dev->of_node;
++	struct emc2305_data *data = dev_get_drvdata(dev);
++	int ret = 0;
++	u8 val;
++	int i;
++
++	/* OF parameters are optional - overwrite default setting
++	 * if some of them are provided.
++	 */
++
++	ret = of_property_read_u8(np, "emc2305,cooling-levels", &val);
++	if (!ret)
++		data->max_state = val;
++	else if (ret != -EINVAL)
++		return ret;
++
++	ret = of_property_read_u8(np, "emc2305,pwm-max", &val);
++	if (!ret)
++		data->pwm_max = val;
++	else if (ret != -EINVAL)
++		return ret;
++
++	ret = of_property_read_u8(np, "emc2305,pwm-min", &val);
++	if (!ret)
++		for (i = 0; i < EMC2305_PWM_MAX; i++)
++			data->pwm_min[i] = val;
++	else if (ret != -EINVAL)
++		return ret;
++
++	/* Not defined or 0 means one thermal zone over all cooling devices.
++	 * Otherwise - separated thermal zones for each PWM channel.
++	 */
++	ret = of_property_read_u8(np, "emc2305,pwm-channel", &val);
++	if (!ret)
++		data->pwm_separate = (val != 0);
++	else if (ret != -EINVAL)
++		return ret;
++
++	return 0;
++}
++
+ static int emc2305_set_single_tz(struct device *dev, int idx)
+ {
+ 	struct emc2305_data *data = dev_get_drvdata(dev);
+@@ -293,9 +349,17 @@ static int emc2305_set_single_tz(struct device *dev, int idx)
+ 	cdev_idx = (idx) ? idx - 1 : 0;
+ 	pwm = data->pwm_min[cdev_idx];
+ 
+-	data->cdev_data[cdev_idx].cdev =
+-		thermal_cooling_device_register(emc2305_fan_name[idx], data,
+-						&emc2305_cooling_ops);
++	if (dev->of_node)
++		data->cdev_data[cdev_idx].cdev =
++			devm_thermal_of_cooling_device_register(dev, dev->of_node,
++								emc2305_fan_name[idx],
++								data,
++								&emc2305_cooling_ops);
++	else
++		data->cdev_data[cdev_idx].cdev =
++			thermal_cooling_device_register(emc2305_fan_name[idx],
++							data,
++							&emc2305_cooling_ops);
+ 
+ 	if (IS_ERR(data->cdev_data[cdev_idx].cdev)) {
+ 		dev_err(dev, "Failed to register cooling device %s\n", emc2305_fan_name[idx]);
+@@ -348,9 +412,11 @@ static void emc2305_unset_tz(struct device *dev)
+ 	int i;
+ 
+ 	/* Unregister cooling device. */
+-	for (i = 0; i < EMC2305_PWM_MAX; i++)
+-		if (data->cdev_data[i].cdev)
+-			thermal_cooling_device_unregister(data->cdev_data[i].cdev);
++	if (!dev->of_node) {
++		for (i = 0; i < EMC2305_PWM_MAX; i++)
++			if (data->cdev_data[i].cdev)
++				thermal_cooling_device_unregister(data->cdev_data[i].cdev);
++	}
+ }
+ 
+ static umode_t
+@@ -572,11 +638,18 @@ static int emc2305_probe(struct i2c_client *client, const struct i2c_device_id *
+ 		data->pwm_separate = pdata->pwm_separate;
+ 		for (i = 0; i < EMC2305_PWM_MAX; i++)
+ 			data->pwm_min[i] = pdata->pwm_min[i];
++		data->pwm_max = EMC2305_FAN_MAX;
+ 	} else {
+ 		data->max_state = EMC2305_FAN_MAX_STATE;
+ 		data->pwm_separate = false;
+ 		for (i = 0; i < EMC2305_PWM_MAX; i++)
+ 			data->pwm_min[i] = EMC2305_FAN_MIN;
++		data->pwm_max = EMC2305_FAN_MAX;
++		if (dev->of_node) {
++			ret = emc2305_get_tz_of(dev);
++			if (ret < 0)
++				return ret;
++		}
+ 	}
+ 
+ 	data->hwmon_dev = devm_hwmon_device_register_with_info(dev, "emc2305", data,
+@@ -597,6 +670,12 @@ static int emc2305_probe(struct i2c_client *client, const struct i2c_device_id *
+ 			return ret;
+ 	}
+ 
++	/* Acknowledge any existing faults. Stops the device responding on the
++	 * SMBus alert address.
++	 */
++	i2c_smbus_read_byte_data(client, EMC2305_REG_FAN_STALL_STATUS);
++	i2c_smbus_read_byte_data(client, EMC2305_REG_FAN_STATUS);
++
+ 	return 0;
+ }
+ 
+@@ -612,6 +691,7 @@ static struct i2c_driver emc2305_driver = {
+ 	.class  = I2C_CLASS_HWMON,
+ 	.driver = {
+ 		.name = "emc2305",
++		.of_match_table = emc2305_dt_ids,
+ 	},
+ 	.probe    = emc2305_probe,
+ 	.remove	  = emc2305_remove,
+-- 
+2.39.2
+

--- a/patch/kernel/archive/meson64-6.5/dt/meson-g12b-waveshare-cm4-io-base-b.dts
+++ b/patch/kernel/archive/meson64-6.5/dt/meson-g12b-waveshare-cm4-io-base-b.dts
@@ -29,6 +29,7 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 		#cooling-cells = <0x02>;
+		wakeup-source;
 	};
 };
 

--- a/patch/kernel/archive/meson64-6.5/dt/meson-g12b-waveshare-cm4-io-base-b.dts
+++ b/patch/kernel/archive/meson64-6.5/dt/meson-g12b-waveshare-cm4-io-base-b.dts
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 /*
  * Copyright (c) 2023 Patrick Yavitz <pyavitz@xxxxx.com>
- * See https://www.waveshare.com/wiki/CM4-IO-BASE-B
  */
 
 /dts-v1/;
@@ -22,6 +21,42 @@
 		compatible = "nxp,pcf85063a";
 		reg = <0x51>;
 		wakeup-source;
+	};
+
+	fanctrl: emc2305@2f {
+		reg = <0x2f>;
+		compatible = "smsc,emc2305";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		#cooling-cells = <0x02>;
+	};
+};
+
+&cpu_thermal {
+	trips {
+		fanmid0: fanmid0 {
+			temperature = <60000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+	
+		fanmax0: fanmax0 {
+			temperature = <70000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+	};
+
+	cooling-maps {
+		map0 {
+			trip = <&fanmid0>;
+			cooling-device = <&fanctrl 2 6>;
+		};
+
+		map1 {
+			trip = <&fanmax0>;
+			cooling-device = <&fanctrl 7 THERMAL_NO_LIMIT>;
+		};
 	};
 };
 

--- a/patch/kernel/archive/meson64-6.5/hwmon-emc2305-fixups-for-driver.patch
+++ b/patch/kernel/archive/meson64-6.5/hwmon-emc2305-fixups-for-driver.patch
@@ -1,0 +1,212 @@
+From 6f3753690d5117fc5893ee9a6cff69d6019d4bea Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@xxxxx.com>
+Date: Tue, 10 Oct 2023 18:54:22 -0400
+Subject: [PATCH] hwmon: emc2305: fixups for driver
+
+BPI-CM4 fan control
+
+hwmon: emc2305: fixups for driver
+The driver had a number of issues, checkpatch warnings/errors,
+and other limitations, so fix these up to make it usable.
+hwmon: emc2305: Change OF properties pwm-min & pwm-max to u8 
+hwmon: emc2305: Add calls to initialize cooling maps
+https://github.com/raspberrypi/linux/commits/233096b8a9023f7e02960543c85447d46af81e81/drivers/hwmon/emc2305.c
+
+Tested-on: CM4-IO-BASE-B: https://www.waveshare.com/wiki/CM4-IO-BASE-B
+Signed-off-by: Phil Elwell <phil@raspberrypi.com>
+Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>
+Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
+---
+ drivers/hwmon/emc2305.c | 96 +++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 88 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/hwmon/emc2305.c b/drivers/hwmon/emc2305.c
+index 29f0e4945f19..2581166cb978 100644
+--- a/drivers/hwmon/emc2305.c
++++ b/drivers/hwmon/emc2305.c
+@@ -15,12 +15,13 @@
+ static const unsigned short
+ emc2305_normal_i2c[] = { 0x27, 0x2c, 0x2d, 0x2e, 0x2f, 0x4c, 0x4d, I2C_CLIENT_END };
+ 
++#define EMC2305_REG_FAN_STATUS		0x24
++#define EMC2305_REG_FAN_STALL_STATUS	0x25
+ #define EMC2305_REG_DRIVE_FAIL_STATUS	0x27
+ #define EMC2305_REG_VENDOR		0xfe
+ #define EMC2305_FAN_MAX			0xff
+ #define EMC2305_FAN_MIN			0x00
+ #define EMC2305_FAN_MAX_STATE		10
+-#define EMC2305_DEVICE			0x34
+ #define EMC2305_VENDOR			0x5d
+ #define EMC2305_REG_PRODUCT_ID		0xfd
+ #define EMC2305_TACH_REGS_UNUSE_BITS	3
+@@ -39,6 +40,7 @@ emc2305_normal_i2c[] = { 0x27, 0x2c, 0x2d, 0x2e, 0x2f, 0x4c, 0x4d, I2C_CLIENT_EN
+ #define EMC2305_RPM_FACTOR		3932160
+ 
+ #define EMC2305_REG_FAN_DRIVE(n)	(0x30 + 0x10 * (n))
++#define EMC2305_REG_FAN_CFG(n)		(0x32 + 0x10 * (n))
+ #define EMC2305_REG_FAN_MIN_DRIVE(n)	(0x38 + 0x10 * (n))
+ #define EMC2305_REG_FAN_TACH(n)		(0x3e + 0x10 * (n))
+ 
+@@ -58,6 +60,16 @@ static const struct i2c_device_id emc2305_ids[] = {
+ };
+ MODULE_DEVICE_TABLE(i2c, emc2305_ids);
+ 
++static const struct of_device_id emc2305_dt_ids[] = {
++	{ .compatible = "smsc,emc2305" },
++	{ .compatible = "microchip,emc2305" },
++	{ .compatible = "microchip,emc2303" },
++	{ .compatible = "microchip,emc2302" },
++	{ .compatible = "microchip,emc2301" },
++	{ }
++};
++MODULE_DEVICE_TABLE(of, emc2305_dt_ids);
++
+ /**
+  * struct emc2305_cdev_data - device-specific cooling device state
+  * @cdev: cooling device
+@@ -103,6 +115,7 @@ struct emc2305_data {
+ 	u8 pwm_num;
+ 	bool pwm_separate;
+ 	u8 pwm_min[EMC2305_PWM_MAX];
++	u8 pwm_max;
+ 	struct emc2305_cdev_data cdev_data[EMC2305_PWM_MAX];
+ };
+ 
+@@ -275,7 +288,7 @@ static int emc2305_set_pwm(struct device *dev, long val, int channel)
+ 	struct i2c_client *client = data->client;
+ 	int ret;
+ 
+-	if (val < data->pwm_min[channel] || val > EMC2305_FAN_MAX)
++	if (val < data->pwm_min[channel] || val > data->pwm_max)
+ 		return -EINVAL;
+ 
+ 	ret = i2c_smbus_write_byte_data(client, EMC2305_REG_FAN_DRIVE(channel), val);
+@@ -286,6 +299,49 @@ static int emc2305_set_pwm(struct device *dev, long val, int channel)
+ 	return 0;
+ }
+ 
++static int emc2305_get_tz_of(struct device *dev)
++{
++	struct device_node *np = dev->of_node;
++	struct emc2305_data *data = dev_get_drvdata(dev);
++	int ret = 0;
++	u8 val;
++	int i;
++
++	/* OF parameters are optional - overwrite default setting
++	 * if some of them are provided.
++	 */
++
++	ret = of_property_read_u8(np, "emc2305,cooling-levels", &val);
++	if (!ret)
++		data->max_state = val;
++	else if (ret != -EINVAL)
++		return ret;
++
++	ret = of_property_read_u8(np, "emc2305,pwm-max", &val);
++	if (!ret)
++		data->pwm_max = val;
++	else if (ret != -EINVAL)
++		return ret;
++
++	ret = of_property_read_u8(np, "emc2305,pwm-min", &val);
++	if (!ret)
++		for (i = 0; i < EMC2305_PWM_MAX; i++)
++			data->pwm_min[i] = val;
++	else if (ret != -EINVAL)
++		return ret;
++
++	/* Not defined or 0 means one thermal zone over all cooling devices.
++	 * Otherwise - separated thermal zones for each PWM channel.
++	 */
++	ret = of_property_read_u8(np, "emc2305,pwm-channel", &val);
++	if (!ret)
++		data->pwm_separate = (val != 0);
++	else if (ret != -EINVAL)
++		return ret;
++
++	return 0;
++}
++
+ static int emc2305_set_single_tz(struct device *dev, int idx)
+ {
+ 	struct emc2305_data *data = dev_get_drvdata(dev);
+@@ -295,9 +351,17 @@ static int emc2305_set_single_tz(struct device *dev, int idx)
+ 	cdev_idx = (idx) ? idx - 1 : 0;
+ 	pwm = data->pwm_min[cdev_idx];
+ 
+-	data->cdev_data[cdev_idx].cdev =
+-		thermal_cooling_device_register(emc2305_fan_name[idx], data,
+-						&emc2305_cooling_ops);
++	if (dev->of_node)
++		data->cdev_data[cdev_idx].cdev =
++			devm_thermal_of_cooling_device_register(dev, dev->of_node,
++								emc2305_fan_name[idx],
++								data,
++								&emc2305_cooling_ops);
++	else
++		data->cdev_data[cdev_idx].cdev =
++			thermal_cooling_device_register(emc2305_fan_name[idx],
++							data,
++							&emc2305_cooling_ops);
+ 
+ 	if (IS_ERR(data->cdev_data[cdev_idx].cdev)) {
+ 		dev_err(dev, "Failed to register cooling device %s\n", emc2305_fan_name[idx]);
+@@ -350,9 +414,11 @@ static void emc2305_unset_tz(struct device *dev)
+ 	int i;
+ 
+ 	/* Unregister cooling device. */
+-	for (i = 0; i < EMC2305_PWM_MAX; i++)
+-		if (data->cdev_data[i].cdev)
+-			thermal_cooling_device_unregister(data->cdev_data[i].cdev);
++	if (!dev->of_node) {
++		for (i = 0; i < EMC2305_PWM_MAX; i++)
++			if (data->cdev_data[i].cdev)
++				thermal_cooling_device_unregister(data->cdev_data[i].cdev);
++	}
+ }
+ 
+ static umode_t
+@@ -574,11 +640,18 @@ static int emc2305_probe(struct i2c_client *client)
+ 		data->pwm_separate = pdata->pwm_separate;
+ 		for (i = 0; i < EMC2305_PWM_MAX; i++)
+ 			data->pwm_min[i] = pdata->pwm_min[i];
++		data->pwm_max = EMC2305_FAN_MAX;
+ 	} else {
+ 		data->max_state = EMC2305_FAN_MAX_STATE;
+ 		data->pwm_separate = false;
+ 		for (i = 0; i < EMC2305_PWM_MAX; i++)
+ 			data->pwm_min[i] = EMC2305_FAN_MIN;
++		data->pwm_max = EMC2305_FAN_MAX;
++		if (dev->of_node) {
++			ret = emc2305_get_tz_of(dev);
++			if (ret < 0)
++				return ret;
++		}
+ 	}
+ 
+ 	data->hwmon_dev = devm_hwmon_device_register_with_info(dev, "emc2305", data,
+@@ -599,6 +672,12 @@ static int emc2305_probe(struct i2c_client *client)
+ 			return ret;
+ 	}
+ 
++	/* Acknowledge any existing faults. Stops the device responding on the
++	 * SMBus alert address.
++	 */
++	i2c_smbus_read_byte_data(client, EMC2305_REG_FAN_STALL_STATUS);
++	i2c_smbus_read_byte_data(client, EMC2305_REG_FAN_STATUS);
++
+ 	return 0;
+ }
+ 
+@@ -614,6 +693,7 @@ static struct i2c_driver emc2305_driver = {
+ 	.class  = I2C_CLASS_HWMON,
+ 	.driver = {
+ 		.name = "emc2305",
++		.of_match_table = emc2305_dt_ids,
+ 	},
+ 	.probe = emc2305_probe,
+ 	.remove	  = emc2305_remove,
+-- 
+2.39.2
+

--- a/patch/kernel/archive/meson64-6.6/dt/meson-g12b-waveshare-cm4-io-base-b.dts
+++ b/patch/kernel/archive/meson64-6.6/dt/meson-g12b-waveshare-cm4-io-base-b.dts
@@ -29,6 +29,7 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 		#cooling-cells = <0x02>;
+		wakeup-source;
 	};
 };
 

--- a/patch/kernel/archive/meson64-6.6/dt/meson-g12b-waveshare-cm4-io-base-b.dts
+++ b/patch/kernel/archive/meson64-6.6/dt/meson-g12b-waveshare-cm4-io-base-b.dts
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 /*
  * Copyright (c) 2023 Patrick Yavitz <pyavitz@xxxxx.com>
- * See https://www.waveshare.com/wiki/CM4-IO-BASE-B
  */
 
 /dts-v1/;
@@ -22,6 +21,42 @@
 		compatible = "nxp,pcf85063a";
 		reg = <0x51>;
 		wakeup-source;
+	};
+
+	fanctrl: emc2305@2f {
+		reg = <0x2f>;
+		compatible = "smsc,emc2305";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		#cooling-cells = <0x02>;
+	};
+};
+
+&cpu_thermal {
+	trips {
+		fanmid0: fanmid0 {
+			temperature = <60000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+	
+		fanmax0: fanmax0 {
+			temperature = <70000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+	};
+
+	cooling-maps {
+		map0 {
+			trip = <&fanmid0>;
+			cooling-device = <&fanctrl 2 6>;
+		};
+
+		map1 {
+			trip = <&fanmax0>;
+			cooling-device = <&fanctrl 7 THERMAL_NO_LIMIT>;
+		};
 	};
 };
 

--- a/patch/kernel/archive/meson64-6.6/hwmon-emc2305-fixups-for-driver.patch
+++ b/patch/kernel/archive/meson64-6.6/hwmon-emc2305-fixups-for-driver.patch
@@ -1,0 +1,212 @@
+From 6f3753690d5117fc5893ee9a6cff69d6019d4bea Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@xxxxx.com>
+Date: Tue, 10 Oct 2023 18:54:22 -0400
+Subject: [PATCH] hwmon: emc2305: fixups for driver
+
+BPI-CM4 fan control
+
+hwmon: emc2305: fixups for driver
+The driver had a number of issues, checkpatch warnings/errors,
+and other limitations, so fix these up to make it usable.
+hwmon: emc2305: Change OF properties pwm-min & pwm-max to u8 
+hwmon: emc2305: Add calls to initialize cooling maps
+https://github.com/raspberrypi/linux/commits/233096b8a9023f7e02960543c85447d46af81e81/drivers/hwmon/emc2305.c
+
+Tested-on: CM4-IO-BASE-B: https://www.waveshare.com/wiki/CM4-IO-BASE-B
+Signed-off-by: Phil Elwell <phil@raspberrypi.com>
+Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>
+Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
+---
+ drivers/hwmon/emc2305.c | 96 +++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 88 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/hwmon/emc2305.c b/drivers/hwmon/emc2305.c
+index 29f0e4945f19..2581166cb978 100644
+--- a/drivers/hwmon/emc2305.c
++++ b/drivers/hwmon/emc2305.c
+@@ -15,12 +15,13 @@
+ static const unsigned short
+ emc2305_normal_i2c[] = { 0x27, 0x2c, 0x2d, 0x2e, 0x2f, 0x4c, 0x4d, I2C_CLIENT_END };
+ 
++#define EMC2305_REG_FAN_STATUS		0x24
++#define EMC2305_REG_FAN_STALL_STATUS	0x25
+ #define EMC2305_REG_DRIVE_FAIL_STATUS	0x27
+ #define EMC2305_REG_VENDOR		0xfe
+ #define EMC2305_FAN_MAX			0xff
+ #define EMC2305_FAN_MIN			0x00
+ #define EMC2305_FAN_MAX_STATE		10
+-#define EMC2305_DEVICE			0x34
+ #define EMC2305_VENDOR			0x5d
+ #define EMC2305_REG_PRODUCT_ID		0xfd
+ #define EMC2305_TACH_REGS_UNUSE_BITS	3
+@@ -39,6 +40,7 @@ emc2305_normal_i2c[] = { 0x27, 0x2c, 0x2d, 0x2e, 0x2f, 0x4c, 0x4d, I2C_CLIENT_EN
+ #define EMC2305_RPM_FACTOR		3932160
+ 
+ #define EMC2305_REG_FAN_DRIVE(n)	(0x30 + 0x10 * (n))
++#define EMC2305_REG_FAN_CFG(n)		(0x32 + 0x10 * (n))
+ #define EMC2305_REG_FAN_MIN_DRIVE(n)	(0x38 + 0x10 * (n))
+ #define EMC2305_REG_FAN_TACH(n)		(0x3e + 0x10 * (n))
+ 
+@@ -58,6 +60,16 @@ static const struct i2c_device_id emc2305_ids[] = {
+ };
+ MODULE_DEVICE_TABLE(i2c, emc2305_ids);
+ 
++static const struct of_device_id emc2305_dt_ids[] = {
++	{ .compatible = "smsc,emc2305" },
++	{ .compatible = "microchip,emc2305" },
++	{ .compatible = "microchip,emc2303" },
++	{ .compatible = "microchip,emc2302" },
++	{ .compatible = "microchip,emc2301" },
++	{ }
++};
++MODULE_DEVICE_TABLE(of, emc2305_dt_ids);
++
+ /**
+  * struct emc2305_cdev_data - device-specific cooling device state
+  * @cdev: cooling device
+@@ -103,6 +115,7 @@ struct emc2305_data {
+ 	u8 pwm_num;
+ 	bool pwm_separate;
+ 	u8 pwm_min[EMC2305_PWM_MAX];
++	u8 pwm_max;
+ 	struct emc2305_cdev_data cdev_data[EMC2305_PWM_MAX];
+ };
+ 
+@@ -275,7 +288,7 @@ static int emc2305_set_pwm(struct device *dev, long val, int channel)
+ 	struct i2c_client *client = data->client;
+ 	int ret;
+ 
+-	if (val < data->pwm_min[channel] || val > EMC2305_FAN_MAX)
++	if (val < data->pwm_min[channel] || val > data->pwm_max)
+ 		return -EINVAL;
+ 
+ 	ret = i2c_smbus_write_byte_data(client, EMC2305_REG_FAN_DRIVE(channel), val);
+@@ -286,6 +299,49 @@ static int emc2305_set_pwm(struct device *dev, long val, int channel)
+ 	return 0;
+ }
+ 
++static int emc2305_get_tz_of(struct device *dev)
++{
++	struct device_node *np = dev->of_node;
++	struct emc2305_data *data = dev_get_drvdata(dev);
++	int ret = 0;
++	u8 val;
++	int i;
++
++	/* OF parameters are optional - overwrite default setting
++	 * if some of them are provided.
++	 */
++
++	ret = of_property_read_u8(np, "emc2305,cooling-levels", &val);
++	if (!ret)
++		data->max_state = val;
++	else if (ret != -EINVAL)
++		return ret;
++
++	ret = of_property_read_u8(np, "emc2305,pwm-max", &val);
++	if (!ret)
++		data->pwm_max = val;
++	else if (ret != -EINVAL)
++		return ret;
++
++	ret = of_property_read_u8(np, "emc2305,pwm-min", &val);
++	if (!ret)
++		for (i = 0; i < EMC2305_PWM_MAX; i++)
++			data->pwm_min[i] = val;
++	else if (ret != -EINVAL)
++		return ret;
++
++	/* Not defined or 0 means one thermal zone over all cooling devices.
++	 * Otherwise - separated thermal zones for each PWM channel.
++	 */
++	ret = of_property_read_u8(np, "emc2305,pwm-channel", &val);
++	if (!ret)
++		data->pwm_separate = (val != 0);
++	else if (ret != -EINVAL)
++		return ret;
++
++	return 0;
++}
++
+ static int emc2305_set_single_tz(struct device *dev, int idx)
+ {
+ 	struct emc2305_data *data = dev_get_drvdata(dev);
+@@ -295,9 +351,17 @@ static int emc2305_set_single_tz(struct device *dev, int idx)
+ 	cdev_idx = (idx) ? idx - 1 : 0;
+ 	pwm = data->pwm_min[cdev_idx];
+ 
+-	data->cdev_data[cdev_idx].cdev =
+-		thermal_cooling_device_register(emc2305_fan_name[idx], data,
+-						&emc2305_cooling_ops);
++	if (dev->of_node)
++		data->cdev_data[cdev_idx].cdev =
++			devm_thermal_of_cooling_device_register(dev, dev->of_node,
++								emc2305_fan_name[idx],
++								data,
++								&emc2305_cooling_ops);
++	else
++		data->cdev_data[cdev_idx].cdev =
++			thermal_cooling_device_register(emc2305_fan_name[idx],
++							data,
++							&emc2305_cooling_ops);
+ 
+ 	if (IS_ERR(data->cdev_data[cdev_idx].cdev)) {
+ 		dev_err(dev, "Failed to register cooling device %s\n", emc2305_fan_name[idx]);
+@@ -350,9 +414,11 @@ static void emc2305_unset_tz(struct device *dev)
+ 	int i;
+ 
+ 	/* Unregister cooling device. */
+-	for (i = 0; i < EMC2305_PWM_MAX; i++)
+-		if (data->cdev_data[i].cdev)
+-			thermal_cooling_device_unregister(data->cdev_data[i].cdev);
++	if (!dev->of_node) {
++		for (i = 0; i < EMC2305_PWM_MAX; i++)
++			if (data->cdev_data[i].cdev)
++				thermal_cooling_device_unregister(data->cdev_data[i].cdev);
++	}
+ }
+ 
+ static umode_t
+@@ -574,11 +640,18 @@ static int emc2305_probe(struct i2c_client *client)
+ 		data->pwm_separate = pdata->pwm_separate;
+ 		for (i = 0; i < EMC2305_PWM_MAX; i++)
+ 			data->pwm_min[i] = pdata->pwm_min[i];
++		data->pwm_max = EMC2305_FAN_MAX;
+ 	} else {
+ 		data->max_state = EMC2305_FAN_MAX_STATE;
+ 		data->pwm_separate = false;
+ 		for (i = 0; i < EMC2305_PWM_MAX; i++)
+ 			data->pwm_min[i] = EMC2305_FAN_MIN;
++		data->pwm_max = EMC2305_FAN_MAX;
++		if (dev->of_node) {
++			ret = emc2305_get_tz_of(dev);
++			if (ret < 0)
++				return ret;
++		}
+ 	}
+ 
+ 	data->hwmon_dev = devm_hwmon_device_register_with_info(dev, "emc2305", data,
+@@ -599,6 +672,12 @@ static int emc2305_probe(struct i2c_client *client)
+ 			return ret;
+ 	}
+ 
++	/* Acknowledge any existing faults. Stops the device responding on the
++	 * SMBus alert address.
++	 */
++	i2c_smbus_read_byte_data(client, EMC2305_REG_FAN_STALL_STATUS);
++	i2c_smbus_read_byte_data(client, EMC2305_REG_FAN_STATUS);
++
+ 	return 0;
+ }
+ 
+@@ -614,6 +693,7 @@ static struct i2c_driver emc2305_driver = {
+ 	.class  = I2C_CLASS_HWMON,
+ 	.driver = {
+ 		.name = "emc2305",
++		.of_match_table = emc2305_dt_ids,
+ 	},
+ 	.probe = emc2305_probe,
+ 	.remove	  = emc2305_remove,
+-- 
+2.39.2
+


### PR DESCRIPTION
* v2: arch: arm64: dts: amlogic: meson-g12b-waveshare-cm4-io-base-b 
```
Fan, RTC and USB support
RTC requires rtc pcf85063 driver
Fan requires hwmon emc2305 driver (new addition)
```
* hwmon: emc2305: fixups for driver 
```
The driver had a number of issues, checkpatch warnings/errors,
and other limitations, so fix these up to make it usable.

Additional:
hwmon: emc2305: Change OF properties pwm-min & pwm-max to u8
hwmon: emc2305: Add calls to initialize cooling maps
```
How was it tested? Built a new image with the following changes and booted to make sure it works as it should.

Inactive:
```
== Waveshare CM4-IO-BASE-B with BPI-CM4 Module (6.1.57-current-meson64)
CPU usage:   0
Processors:  Cortex-A53 @ 2016MHz 51°C, Cortex-A73 @ 2400MHz 53°C
Cur freq:    1000MHz 2400MHz
Fan:         0 RPM (0) <-- FAN INACTIVE
Online:      0-5
Governor:    ondemand
Memory:      3.7G 331M
Entropy:     256
Uptime:      14:12:26 up 18 min, 4 users, load average: 0.01, 0.24, 0.31
```

Active:
```
== Waveshare CM4-IO-BASE-B with BPI-CM4 Module (6.1.57-current-meson64)
CPU usage:   90
Processors:  Cortex-A53 @ 2016MHz 82°C, Cortex-A73 @ 2400MHz 82°C
Cur freq:    2016MHz 2400MHz
Fan:         3368 RPM (255) <-- FAN ACTIVE
Online:      0-5
Governor:    ondemand
Memory:      3.7G 430M
Entropy:     256
Uptime:      14:19:09 up 25 min, 4 users, load average: 1.76, 1.06, 0.64
```
NOTE: The temps are not as they should be as they sent me a 12V instead of a 5V fan. I decided to keep the 12V to do the testing with, as I wait for the 5V to arrive. The difference between them shouldn't change the basic functionality, only the quality of the cooling.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
