### PR TITLE
dpkg-deb: don't use fakeroot, we're already root; don't add fakeroot dep either

### DIFF
--- a/lib/functions/artifacts/artifact-armbian-base-files.sh
+++ b/lib/functions/artifacts/artifact-armbian-base-files.sh
@@ -183,7 +183,7 @@ function compile_armbian-base-files() {
 	rm -f "${destination}"/etc/os-release.orig "${destination}"/etc/issue.orig "${destination}"/etc/issue.net.orig "${destination}"/DEBIAN/conffiles.orig
 
 	# Done, pack it.
-	fakeroot_dpkg_deb_build "${destination}" "armbian-base-files"
+	dpkg_deb_build "${destination}" "armbian-base-files"
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 }

--- a/lib/functions/bsp/armbian-bsp-cli-deb.sh
+++ b/lib/functions/bsp/armbian-bsp-cli-deb.sh
@@ -34,7 +34,7 @@ function compile_armbian-bsp-cli-transitional() {
 	EOF
 
 	# Build / close the package. This will run shellcheck / show the generated files if debugging
-	fakeroot_dpkg_deb_build "${destination}" "armbian-bsp-cli-transitional"
+	dpkg_deb_build "${destination}" "armbian-bsp-cli-transitional"
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 
@@ -213,7 +213,7 @@ function compile_armbian-bsp-cli() {
 	fi
 
 	# Build / close the package. This will run shellcheck / show the generated files if debugging
-	fakeroot_dpkg_deb_build "${destination}" "armbian-bsp-cli"
+	dpkg_deb_build "${destination}" "armbian-bsp-cli"
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 

--- a/lib/functions/bsp/armbian-bsp-desktop-deb.sh
+++ b/lib/functions/bsp/armbian-bsp-desktop-deb.sh
@@ -59,7 +59,7 @@ function compile_armbian-bsp-desktop() {
 	eval "${AGGREGATED_DESKTOP_BSP_PREPARE}"
 	display_alert "Done with bsp-desktop -specific aggregated prepare script" "AGGREGATED_DESKTOP_BSP_PREPARE" "debug"
 
-	fakeroot_dpkg_deb_build "${destination}" "armbian-bsp-desktop"
+	dpkg_deb_build "${destination}" "armbian-bsp-desktop"
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 }

--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -139,7 +139,7 @@ function create_kernel_deb() {
 	#display_alert "Package dir" "for package ${package_name}" "debug"
 	#run_host_command_logged tree -C -h -d --du "${package_directory}"
 
-	fakeroot_dpkg_deb_build "${package_directory}" "${artifact_deb_id}"
+	dpkg_deb_build "${package_directory}" "${artifact_deb_id}"
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 }

--- a/lib/functions/compilation/packages/armbian-config-deb.sh
+++ b/lib/functions/compilation/packages/armbian-config-deb.sh
@@ -68,7 +68,7 @@ compile_armbian-config() {
 	ln -sf /usr/sbin/armbian-config "${tmp_dir}/${armbian_config_dir}"/usr/bin/armbian-config
 	ln -sf /usr/sbin/softy "${tmp_dir}/${armbian_config_dir}"/usr/bin/softy
 
-	fakeroot_dpkg_deb_build "${tmp_dir}/${armbian_config_dir}" "armbian-config"
+	dpkg_deb_build "${tmp_dir}/${armbian_config_dir}" "armbian-config"
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 

--- a/lib/functions/compilation/packages/armbian-desktop-deb.sh
+++ b/lib/functions/compilation/packages/armbian-desktop-deb.sh
@@ -58,7 +58,7 @@ function compile_armbian-desktop() {
 	eval "${AGGREGATED_DESKTOP_CREATE_DESKTOP_PACKAGE}"
 	display_alert "Running desktop-specific aggregated prepare script" "AGGREGATED_DESKTOP_CREATE_DESKTOP_PACKAGE" "debug"
 
-	fakeroot_dpkg_deb_build "${destination}" "armbian-desktop"
+	dpkg_deb_build "${destination}" "armbian-desktop"
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 }

--- a/lib/functions/compilation/packages/armbian-plymouth-theme-deb.sh
+++ b/lib/functions/compilation/packages/armbian-plymouth-theme-deb.sh
@@ -55,7 +55,7 @@ compile_armbian-plymouth-theme() {
 	run_host_command_logged cp "${SRC}"/packages/plymouth-theme-armbian/armbian.plymouth \
 		"${tmp_dir}/${plymouth_theme_armbian_dir}"/usr/share/plymouth/themes/armbian/
 
-	fakeroot_dpkg_deb_build "${tmp_dir}/${plymouth_theme_armbian_dir}" "armbian-plymouth-theme"
+	dpkg_deb_build "${tmp_dir}/${plymouth_theme_armbian_dir}" "armbian-plymouth-theme"
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 }

--- a/lib/functions/compilation/packages/armbian-zsh-deb.sh
+++ b/lib/functions/compilation/packages/armbian-zsh-deb.sh
@@ -80,7 +80,7 @@ compile_armbian-zsh() {
 
 	chmod 755 "${tmp_dir}/${armbian_zsh_dir}"/DEBIAN/postinst
 
-	fakeroot_dpkg_deb_build "${tmp_dir}/${armbian_zsh_dir}" "armbian-zsh"
+	dpkg_deb_build "${tmp_dir}/${armbian_zsh_dir}" "armbian-zsh"
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 }

--- a/lib/functions/compilation/packages/fake_ubuntu_advantage_tools-deb.sh
+++ b/lib/functions/compilation/packages/fake_ubuntu_advantage_tools-deb.sh
@@ -43,7 +43,7 @@ function compile_fake_ubuntu_advantage_tools() {
 	END
 	chmod 755 DEBIAN/postinst
 
-	fakeroot_dpkg_deb_build "${fw_temp_dir}/${fw_dir}" "fake-ubuntu-advantage-tools"
+	dpkg_deb_build "${fw_temp_dir}/${fw_dir}" "fake-ubuntu-advantage-tools"
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 }

--- a/lib/functions/compilation/packages/firmware-deb.sh
+++ b/lib/functions/compilation/packages/firmware-deb.sh
@@ -71,7 +71,7 @@ function compile_firmware() {
 
 	cd "${fw_temp_dir}" || exit_with_error "can't change directory"
 
-	fakeroot_dpkg_deb_build "armbian-firmware${FULL}" "armbian-firmware${FULL}"
+	dpkg_deb_build "armbian-firmware${FULL}" "armbian-firmware${FULL}"
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 }

--- a/lib/functions/compilation/packages/utils-dpkgdeb.sh
+++ b/lib/functions/compilation/packages/utils-dpkgdeb.sh
@@ -111,7 +111,7 @@ function fakeroot_dpkg_deb_build() {
 
 	mkdir -p "${deb_final_dir}"
 	display_alert "Building package, this might take a while.." "${deb_final_filename/*\//}" info
-	run_host_command_logged_raw fakeroot dpkg-deb -b "-Z${DEB_COMPRESS}" "${package_directory}" "${deb_final_filename}"
+	run_host_command_logged_raw dpkg-deb -b "-Z${DEB_COMPRESS}" "${package_directory}" "${deb_final_filename}"
 }
 
 function dpkg_deb_run_shellcheck_on_scripts() {

--- a/lib/functions/compilation/packages/utils-dpkgdeb.sh
+++ b/lib/functions/compilation/packages/utils-dpkgdeb.sh
@@ -8,11 +8,11 @@
 # https://github.com/armbian/build/
 
 # for RAW deb building. does a bunch of magic to "DEBIAN" directory. Arguments are the open package directory and the artifact_deb_id
-function fakeroot_dpkg_deb_build() {
+function dpkg_deb_build() {
 	# check artifact_name and artifact_version is set otherwise exit_with_error
-	[[ -z "${artifact_name}" ]] && exit_with_error "fakeroot_dpkg_deb_build: artifact_name is not set"
-	[[ -z "${artifact_version}" ]] && exit_with_error "fakeroot_dpkg_deb_build: artifact_version is not set"
-	[[ -z "${artifact_deb_repo}" ]] && exit_with_error "fakeroot_dpkg_deb_build: artifact_deb_repo is not set"
+	[[ -z "${artifact_name}" ]] && exit_with_error "dpkg_deb_build: artifact_name is not set"
+	[[ -z "${artifact_version}" ]] && exit_with_error "dpkg_deb_build: artifact_version is not set"
+	[[ -z "${artifact_deb_repo}" ]] && exit_with_error "dpkg_deb_build: artifact_deb_repo is not set"
 
 	display_alert "Building .deb package" "${artifact_name}: $*" "debug"
 
@@ -20,12 +20,12 @@ function fakeroot_dpkg_deb_build() {
 	declare artifact_deb_id="${2}"
 
 	if [[ ! -d "${package_directory}" ]]; then
-		exit_with_error "fakeroot_dpkg_deb_build: can't find source package directory: ${package_directory}"
+		exit_with_error "dpkg_deb_build: can't find source package directory: ${package_directory}"
 	fi
 
 	# Check artifact_deb_id is set and not empty
 	if [[ -z "${artifact_deb_id}" ]]; then
-		exit_with_error "fakeroot_dpkg_deb_build: artifact_deb_id (2nd parameter) is not set, called with package_directory: '${package_directory}'"
+		exit_with_error "dpkg_deb_build: artifact_deb_id (2nd parameter) is not set, called with package_directory: '${package_directory}'"
 	fi
 
 	# Obtain from the globals
@@ -38,10 +38,10 @@ function fakeroot_dpkg_deb_build() {
 
 	# If either is empty, bomb
 	if [[ -z "${artifact_deb_package}" ]]; then
-		exit_with_error "fakeroot_dpkg_deb_build: artifact_deb_package (artifact_map_packages) is not set or found for '${artifact_deb_id}'"
+		exit_with_error "dpkg_deb_build: artifact_deb_package (artifact_map_packages) is not set or found for '${artifact_deb_id}'"
 	fi
 	if [[ -z "${artifact_deb_rel_path}" ]]; then
-		exit_with_error "fakeroot_dpkg_deb_build: artifact_deb_rel_path (artifact_map_debs) is not set or found for '${artifact_deb_id}'"
+		exit_with_error "dpkg_deb_build: artifact_deb_rel_path (artifact_map_debs) is not set or found for '${artifact_deb_id}'"
 	fi
 
 	# Show the total human size of the source package directory.

--- a/lib/functions/compilation/uboot.sh
+++ b/lib/functions/compilation/uboot.sh
@@ -425,7 +425,7 @@ function compile_uboot() {
 	[[ -n $atftempdir && -f $atftempdir/license.md ]] && run_host_command_logged cp "${atftempdir}/license.md" "$uboottempdir/usr/lib/u-boot/LICENSE.atf"
 
 	display_alert "Building u-boot deb" "(version: ${artifact_version})"
-	fakeroot_dpkg_deb_build "$uboottempdir" "uboot"
+	dpkg_deb_build "$uboottempdir" "uboot"
 
 	[[ -n $atftempdir ]] && rm -rf "${atftempdir:?}" # @TODO: intricate cleanup; u-boot's pkg uses ATF's tempdir...
 

--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -256,7 +256,7 @@ function adaptative_prepare_host_dependencies() {
 		ca-certificates ccache cpio
 		debootstrap device-tree-compiler dialog dirmngr dosfstools
 		dwarves # dwarves has been replaced by "pahole" and is now a transitional package
-		fakeroot flex
+		flex
 		gawk gnupg gpg
 		imagemagick # required for boot_logo, plymouth: converting images / spinners
 		jq          # required for parsing JSON, specially rootfs-caching related.


### PR DESCRIPTION
#### dpkg-deb: don't use fakeroot, we're already root; don't add fakeroot dep either

- dpkg-deb: don't use fakeroot, we're already root; don't add fakeroot dep either
- dpkg-deb: rename `fakeroot_dpkg_deb_build` -> `dpkg_deb_build`