### PR TITLE
patching: accept a sha1 in BASE_GIT_TAG (as well as branch or tag)

### DIFF
--- a/lib/tools/patching.py
+++ b/lib/tools/patching.py
@@ -276,7 +276,14 @@ if apply_patches:
 				try:
 					BASE_GIT_REVISION = git_repo.branches[BASE_GIT_TAG].commit.hexsha
 				except IndexError:
-					raise Exception(f"BASE_GIT_TAG={BASE_GIT_TAG} is neither a tag nor a branch")
+					# not a branch either, try as a hexsha:
+					try:
+						# see if the sha1 exists in the repo
+						commit = git_repo.commit(BASE_GIT_TAG)
+						log.debug(f"Found commit '{commit}' for BASE_GIT_TAG={BASE_GIT_TAG}")
+						BASE_GIT_REVISION = BASE_GIT_TAG
+					except:
+						raise Exception(f"BASE_GIT_TAG={BASE_GIT_TAG} is neither a tag nor a branch nor a SHA1")
 
 			log.debug(f"Found BASE_GIT_REVISION={BASE_GIT_REVISION} for BASE_GIT_TAG={BASE_GIT_TAG}")
 


### PR DESCRIPTION
#### patching: accept a sha1 in BASE_GIT_TAG (as well as branch or tag)

- patching: accept a sha1 in BASE_GIT_TAG (as well as branch or tag)
  - just for convenience