### PR TITLE
rockchip-rk3588: add `-Wno-error=enum-int-mismatch` to u-boot CFLAGS so it builds with gcc 13+

### DIFF
--- a/config/sources/families/rockchip-rk3588.conf
+++ b/config/sources/families/rockchip-rk3588.conf
@@ -75,3 +75,17 @@ function add_host_dependencies__collabora_kernel() {
 family_tweaks_bsp() {
 	:
 }
+
+# rockchip/radxa u-boot wont' build with gcc 13 due to enum-int-mismatch
+function post_config_uboot_target__downgrade_errors_to_warnings_for_gcc13() {
+	declare -i gcc_major_version=0
+	gcc_major_version=$(gcc -dumpversion | cut -d. -f1)
+	display_alert "$BOARD" "gcc major version: ${gcc_major_version}" "debug"
+
+	# add to cflags array if gcc major version is 13 or higher
+	if [[ ${gcc_major_version} -ge 13 ]]; then
+		display_alert "$BOARD" "Extra CFLAGS for vendor u-boot building with gcc 13+" "vendor"
+		uboot_cflags_array+=("-Wno-error=enum-int-mismatch")
+	fi
+	return 0
+}


### PR DESCRIPTION
#### rockchip-rk3588: add `-Wno-error=enum-int-mismatch` to u-boot CFLAGS so it builds with gcc 13+

- rockchip-rk3588: add `-Wno-error=enum-int-mismatch` to u-boot CFLAGS so it builds with gcc 13+
  - this applies to all u-boots in this family