### PR TITLE
`Automatic` board configs status synchronise

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -104,7 +104,8 @@ config/boards/tritium-h3.conf		@Tonymac32
 config/boards/tritium-h5.conf		@Tonymac32
 config/boards/uefi-arm64.conf		@rpardini
 config/boards/uefi-x86.conf		@rpardini
-config/kernel/linux-arm64-*.config		@rpardini
+config/boards/xiaomi-elish.conf		@amazingfate
+config/kernel/linux-arm64-*.config		@amazingfate @rpardini
 config/kernel/linux-bcm2711-*.config		@PanderMusubi @teknoid
 config/kernel/linux-k3-*.config		@glneo
 config/kernel/linux-media-*.config		@150balbes
@@ -139,10 +140,11 @@ patch/kernel/archive/rk35xx-*/		@Tonymac32 @ZazaBR @amazingfate @catalinii @efec
 patch/kernel/archive/rockchip-*/		@paolosabatino
 patch/kernel/archive/rockchip64-*/		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @schwar3kat @vamzii
 patch/kernel/archive/rockpis-*/		@brentr
+patch/kernel/archive/sm8250-*/		@amazingfate
 patch/kernel/archive/sun50iw9-*/		@AGM1968 @krachlatte
 patch/kernel/archive/sunxi-*/		@AGM1968 @AaronNGray @DylanHP @Kreyren @PanderMusubi @StephenGraf @Tonymac32 @bigtreetech @devdotnetorg @eliasbakken @joshaspinall @krachlatte @lbmendes @schwar3kat @sgjava @teknoid @viraniac
 patch/kernel/archive/uefi-arm64-*/		@rpardini
-patch/kernel/arm64-*/		@rpardini
+patch/kernel/arm64-*/		@amazingfate @rpardini
 patch/kernel/bcm2711-*/		@PanderMusubi @teknoid
 patch/kernel/k3-*/		@glneo
 patch/kernel/media-*/		@150balbes
@@ -160,7 +162,7 @@ patch/kernel/sun50iw9-*/		@AGM1968 @krachlatte
 patch/kernel/thead-*/		@chainsx
 patch/kernel/uefi-arm64-*/		@rpardini
 patch/kernel/uefi-x86-*/		@rpardini
-sources/families/arm64.conf		@rpardini
+sources/families/arm64.conf		@amazingfate @rpardini
 sources/families/bcm2711.conf		@PanderMusubi @teknoid
 sources/families/k3.conf		@glneo
 sources/families/media.conf		@150balbes

--- a/config/boards/armsom-w3.csc
+++ b/config/boards/armsom-w3.csc
@@ -1,7 +1,7 @@
 # Rockchip RK3588 SoC octa core 8-32GB SoC 2.5GBe PoE eMMC USB3 NvME
 BOARD_NAME="ArmSoM W3"
 BOARDFAMILY="rockchip-rk3588"
-BOARD_MAINTAINER="armsom-team"
+BOARD_MAINTAINER=""
 BOOTCONFIG="armsom-w3-rk3588_defconfig"
 KERNEL_TARGET="legacy"
 KERNEL_TEST_TARGET="legacy" # in case different then kernel target

--- a/config/boards/mekotronics-r58x-pro.csc
+++ b/config/boards/mekotronics-r58x-pro.csc
@@ -1,7 +1,7 @@
 # Rockchip RK3588 SoC octa core 4-16GB SoC 2x1GBe eMMC USB3 NVMe SATA WiFi/BT HDMI DP HDMI-In RS232 RS485 LCD RotaryEncoder
 declare -g BOARD_NAME="Mekotronics R58X-Pro"
 declare -g BOARDFAMILY="rockchip-rk3588"
-declare -g BOARD_MAINTAINER="monkaBlyat"
+declare -g BOARD_MAINTAINER=""
 declare -g KERNEL_TARGET="legacy"
 declare -g BOOT_FDT_FILE="rockchip/rk3588-blueberry-edge-v12-maizhuo-linux.dtb" # Specific to this board
 

--- a/config/boards/rock-3a.conf
+++ b/config/boards/rock-3a.conf
@@ -1,7 +1,7 @@
 # Rockchip RK3568 quad core 1-8GB SoC GBe eMMC USB3
 BOARD_NAME="Rock 3A"
 BOARDFAMILY="rk35xx"
-BOARD_MAINTAINER="ZazaBR amazingfate vamzii catalinii"
+BOARD_MAINTAINER="amazingfate ZazaBR vamzii catalinii"
 BOOTCONFIG="rock-3a-rk3568_defconfig"
 KERNEL_TARGET="legacy,current,edge"
 FULL_DESKTOP="yes"


### PR DESCRIPTION
Update maintainers and board status

- synced status from the database
- rename to .`csc` where we don't have anyone

If you want to become a board maintainer, [adjust data here](https://www.armbian.com/update-data/).

Ref: [Board Maintainers Procedures and Guidelines](https://docs.armbian.com/Board_Maintainers_Procedures_and_Guidelines/)