### PR TITLE
pipeline: add hard 17*30 limit to number of total matrix jobs

### DIFF
--- a/lib/tools/common/gha.py
+++ b/lib/tools/common/gha.py
@@ -17,7 +17,7 @@ def set_gha_output(name, value):
 	with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
 		print(f'{name}={value}', file=fh)
 
-	log.info(f"Set GHA output '{name}' to '{value}'")
+	log.info(f"Set GHA output '{name}' to ({len(value)} bytes) '{value}'")
 
 
 def set_multiline_gha_output(name, value):

--- a/lib/tools/info/output-gha-matrix.py
+++ b/lib/tools/info/output-gha-matrix.py
@@ -161,6 +161,12 @@ else:
 	num_chunks = int(len(matrix) / ideal_chunk_size) + 1
 	log.warning(f"Number of chunks: {num_chunks}")
 
+matrix_hard_limit = 17 * 30  # @TODO: maybe 17*50 later
+# if over the limit, just slice to the limit, add warning about lost jobs
+if len(matrix) > matrix_hard_limit:
+	log.warning(f"Matrix size is over the hard limit of {matrix_hard_limit}, slicing to that limit. Matrix is incomplete.")
+	matrix = matrix[:matrix_hard_limit]
+
 # distribute the matrix items equally along the chunks. try to keep every chunk the same size.
 chunks = []
 for i in range(num_chunks):


### PR DESCRIPTION
#### pipeline: add hard 17*30 limit to number of total matrix jobs

- pipeline: add hard 17*30 limit to number of total matrix jobs
  - show size of each GHA output in logs