### PR TITLE
pipeline: don't bomb when logging int value's length (GHA outputs)

### DIFF
--- a/lib/tools/common/gha.py
+++ b/lib/tools/common/gha.py
@@ -17,7 +17,8 @@ def set_gha_output(name, value):
 	with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
 		print(f'{name}={value}', file=fh)
 
-	log.info(f"Set GHA output '{name}' to ({len(value)} bytes) '{value}'")
+	length = len(f"{value}")
+	log.info(f"Set GHA output '{name}' to ({length} bytes) '{value}'")
 
 
 def set_multiline_gha_output(name, value):


### PR DESCRIPTION
#### pipeline: don't bomb when logging int value's length (GHA outputs)

- pipeline: don't bomb when logging int value's length (GHA outputs)