### PR TITLE
odroidn2l: bump to u-boot v2023.10; boot-usb-first patch now only in board folder

### DIFF
--- a/config/boards/odroidn2l.csc
+++ b/config/boards/odroidn2l.csc
@@ -6,8 +6,9 @@ KERNEL_TARGET="edge" # @TODO: DTB for N2L is only in 6.3+; add current when we b
 FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
 BOOTCONFIG="odroid-n2l_defconfig"
-BOOTBRANCH_BOARD="tag:v2023.07.02"
-BOOTPATCHDIR="v2023.07" # Thus boots USB/NVMe/SCSI first. N2L only has USB.
+
+BOOTBRANCH_BOARD="tag:v2023.10"
+BOOTPATCHDIR="v2023.10" # this has 'board_odroidn2l' which has a patch to boot USB/NVMe/SCSI first
 
 # U-boot has detection code for the ODROID boards, but NOT for the n2l, at least until 23.10-rc2.
 # See https://github.com/u-boot/u-boot/blob/v2023.10-rc2/board/amlogic/odroid-n2/odroid-n2.c

--- a/patch/u-boot/v2023.10/board_odroidn2l/meson64-boot-usb-nvme-scsi-first.patch
+++ b/patch/u-boot/v2023.10/board_odroidn2l/meson64-boot-usb-nvme-scsi-first.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ricardo Pardini <ricardo@pardini.net>
+Date: Mon, 14 Nov 2022 14:59:45 +0100
+Subject: meson64: change `BOOT_TARGET_DEVICES` to try to boot USB, NVME and
+ SCSI before SD, MMC, PXE, DHCP
+
+meson64: change `BOOT_TARGET_DEVICES` to try to boot USB, NVME and SCSI before SD, MMC, PXE, DHCP
+---
+ include/configs/meson64.h | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/include/configs/meson64.h b/include/configs/meson64.h
+index 801cdae4708..927919ef17a 100644
+--- a/include/configs/meson64.h
++++ b/include/configs/meson64.h
+@@ -74,12 +74,12 @@
+ #ifndef BOOT_TARGET_DEVICES
+ #define BOOT_TARGET_DEVICES(func) \
+ 	func(ROMUSB, romusb, na)  \
+-	func(MMC, mmc, 0) \
+-	func(MMC, mmc, 1) \
+-	func(MMC, mmc, 2) \
+ 	BOOT_TARGET_DEVICES_USB(func) \
+ 	BOOT_TARGET_NVME(func) \
+ 	BOOT_TARGET_SCSI(func) \
++	func(MMC, mmc, 0) \
++	func(MMC, mmc, 1) \
++	func(MMC, mmc, 2) \
+ 	func(PXE, pxe, na) \
+ 	func(DHCP, dhcp, na)
+ #endif
+-- 
+Armbian
+


### PR DESCRIPTION
#### odroidn2l: bump to u-boot v2023.10; boot-usb-first patch now only in board folder

- odroidn2l: bump to u-boot v2023.10; boot-usb-first patch now only in board folder
  - with this, there are no more boards with `v2023.07`