### PR TITLE
Set gdm3 for gnome based DE, sddm for KDE

### DIFF
--- a/config/desktop/bullseye/environments/budgie/config_base/packages
+++ b/config/desktop/bullseye/environments/budgie/config_base/packages
@@ -98,8 +98,7 @@ libu2f-udev
 libwmf0.2-7-gtk
 libxapp1
 libxcursor1
-lightdm
-lightdm-settings
+gdm3
 mesa-utils
 mousepad
 mousetweaks

--- a/config/desktop/bullseye/environments/gnome/config_base/packages
+++ b/config/desktop/bullseye/environments/gnome/config_base/packages
@@ -31,7 +31,7 @@ libasound2
 libasound2-plugins
 libnotify-bin
 libpulsedsp
-lightdm
+gdm3
 lm-sensors
 nautilus
 network-manager-gnome

--- a/config/desktop/bullseye/environments/kde-plasma/config_base/packages
+++ b/config/desktop/bullseye/environments/kde-plasma/config_base/packages
@@ -69,8 +69,7 @@ libproxy1-plugin-networkmanager
 libu2f-udev
 libwmf0.2-7-gtk
 libxcursor1
-lightdm
-lightdm-settings
+sddm
 mesa-utils
 mousepad
 mousetweaks

--- a/config/desktop/buster/environments/gnome/config_base/packages
+++ b/config/desktop/buster/environments/gnome/config_base/packages
@@ -31,7 +31,7 @@ libasound2
 libasound2-plugins
 libnotify-bin
 libpulsedsp
-lightdm
+gdm3
 lm-sensors
 nautilus
 network-manager-gnome

--- a/config/desktop/focal/environments/budgie/config_base/packages
+++ b/config/desktop/focal/environments/budgie/config_base/packages
@@ -114,8 +114,7 @@ libproxy1-plugin-networkmanager
 libu2f-udev
 libwmf0.2-7-gtk
 libxcursor1
-lightdm
-lightdm-settings
+gdm3
 mesa-utils
 mousepad
 mousetweaks

--- a/config/desktop/focal/environments/enlightenment/config_base/packages
+++ b/config/desktop/focal/environments/enlightenment/config_base/packages
@@ -92,7 +92,6 @@ libu2f-udev
 libwmf0.2-7-gtk
 libxcursor1
 lightdm
-lightdm-settings
 lxtask
 mesa-utils
 mousepad

--- a/config/desktop/focal/environments/gnome/config_base/packages
+++ b/config/desktop/focal/environments/gnome/config_base/packages
@@ -31,7 +31,7 @@ libasound2
 libasound2-plugins
 libnotify-bin
 libpulsedsp
-lightdm
+gdm3
 lm-sensors
 nautilus
 network-manager-gnome

--- a/config/desktop/focal/environments/kde-plasma/config_base/packages
+++ b/config/desktop/focal/environments/kde-plasma/config_base/packages
@@ -87,8 +87,7 @@ libproxy1-plugin-networkmanager
 libu2f-udev
 libwmf0.2-7-gtk
 libxcursor1
-lightdm
-lightdm-settings
+sddm
 mesa-utils
 mousepad
 mousetweaks

--- a/config/desktop/jammy/environments/budgie/config_base/packages
+++ b/config/desktop/jammy/environments/budgie/config_base/packages
@@ -113,8 +113,7 @@ libu2f-udev
 libwmf0.2-7-gtk
 libxapp1
 libxcursor1
-lightdm
-lightdm-settings
+gdm3
 mesa-utils
 mousepad
 mousetweaks

--- a/config/desktop/jammy/environments/gnome/config_base/packages
+++ b/config/desktop/jammy/environments/gnome/config_base/packages
@@ -32,7 +32,7 @@ libasound2
 libasound2-plugins
 libnotify-bin
 libpulsedsp
-lightdm
+gdm3
 lm-sensors
 nautilus
 network-manager-gnome

--- a/config/desktop/jammy/environments/kde-plasma/config_base/packages
+++ b/config/desktop/jammy/environments/kde-plasma/config_base/packages
@@ -89,8 +89,7 @@ libu2f-udev
 libwmf0.2-7-gtk
 libxapp1
 libxcursor1
-lightdm
-lightdm-settings
+sddm
 mesa-utils
 mousepad
 mousetweaks

--- a/config/desktop/sid/environments/budgie/config_base/packages
+++ b/config/desktop/sid/environments/budgie/config_base/packages
@@ -93,8 +93,7 @@ libu2f-udev
 libwmf0.2-7-gtk
 libxapp1
 libxcursor1
-lightdm
-lightdm-settings
+gdm3
 mesa-utils
 mousepad
 mousetweaks

--- a/config/desktop/sid/environments/kde-plasma/config_base/packages
+++ b/config/desktop/sid/environments/kde-plasma/config_base/packages
@@ -67,8 +67,7 @@ libproxy1-plugin-networkmanager
 libu2f-udev
 libwmf0.2-7-gtk
 libxcursor1
-lightdm
-lightdm-settings
+sddm
 mesa-utils
 mousepad
 mousetweaks


### PR DESCRIPTION
# Description

... and leave the rest with lightdm. Its matching display manager with DE.

Related:
https://github.com/armbian/build/pull/5810

Jira reference number [AR-9999]

# How Has This Been Tested?

- [x] Ubuntu Jammy Gnome works.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
