### PR TITLE
Disable transmission on Debian Trixie as its not present

### DIFF
--- a/config/desktop/trixie
+++ b/config/desktop/trixie
@@ -1,1 +1,0 @@
-bookworm

--- a/config/desktop/trixie/appgroups/3dsupport
+++ b/config/desktop/trixie/appgroups/3dsupport
@@ -1,0 +1,1 @@
+../../buster/appgroups/3dsupport

--- a/config/desktop/trixie/appgroups/browsers
+++ b/config/desktop/trixie/appgroups/browsers
@@ -1,0 +1,1 @@
+../../bullseye/appgroups/browsers

--- a/config/desktop/trixie/appgroups/chat
+++ b/config/desktop/trixie/appgroups/chat
@@ -1,0 +1,1 @@
+../../buster/appgroups/chat

--- a/config/desktop/trixie/appgroups/desktop_tools
+++ b/config/desktop/trixie/appgroups/desktop_tools
@@ -1,0 +1,1 @@
+../../buster/appgroups/desktop_tools

--- a/config/desktop/trixie/appgroups/editors
+++ b/config/desktop/trixie/appgroups/editors
@@ -1,0 +1,1 @@
+../../buster/appgroups/editors

--- a/config/desktop/trixie/appgroups/internet/packages
+++ b/config/desktop/trixie/appgroups/internet/packages
@@ -1,0 +1,3 @@
+filezilla
+putty
+qbittorrent

--- a/config/desktop/trixie/appgroups/multimedia
+++ b/config/desktop/trixie/appgroups/multimedia
@@ -1,0 +1,1 @@
+../../buster/appgroups/multimedia

--- a/config/desktop/trixie/appgroups/office
+++ b/config/desktop/trixie/appgroups/office
@@ -1,0 +1,1 @@
+../../bullseye/appgroups/office

--- a/config/desktop/trixie/appgroups/programming
+++ b/config/desktop/trixie/appgroups/programming
@@ -1,0 +1,1 @@
+../../buster/appgroups/programming

--- a/config/desktop/trixie/appgroups/remote_desktop
+++ b/config/desktop/trixie/appgroups/remote_desktop
@@ -1,0 +1,1 @@
+../../buster/appgroups/remote_desktop

--- a/config/desktop/trixie/environments
+++ b/config/desktop/trixie/environments
@@ -1,0 +1,1 @@
+../bullseye/environments


### PR DESCRIPTION
# Description

Unlink Debian Trixie packages list in order to disable broken Transmission.

# How Has This Been Tested?

- [x] Manual cache assembly

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
