### PR TITLE
bullseye/trixie: desktop gnome: drop package 'gnome-packagekit'

### DIFF
--- a/config/desktop/bullseye/environments/gnome/config_base/packages
+++ b/config/desktop/bullseye/environments/gnome/config_base/packages
@@ -22,7 +22,6 @@ gnome-screenshot
 gnome-disk-utility
 gnome-system-monitor
 gnome-terminal
-gnome-packagekit
 gnome-session
 gnome-shell
 gnome-shell-extension-appindicator


### PR DESCRIPTION
#### bullseye/trixie: desktop gnome: drop package 'gnome-packagekit'

- bullseye/trixie: desktop gnome: drop package 'gnome-packagekit'