### PR TITLE
rockchip64 / edge 6.6: add rk3566-orangepi-3b-sata DTB

### DIFF
--- a/patch/kernel/archive/rockchip64-6.6/dt/rk3566-orangepi-3b-sata.dts
+++ b/patch/kernel/archive/rockchip64-6.6/dt/rk3566-orangepi-3b-sata.dts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+
+/dts-v1/;
+
+#include "rk3566-orangepi-3b.dts"
+
+/ {
+	model = "Rockchip RK3566 OPi 3B with SATA instead of PCIe";
+};
+
+&pcie2x1 {
+	status = "disabled";
+};
+
+&sata2 {
+	status = "okay";
+};

--- a/patch/kernel/archive/rockchip64-6.6/overlay/Makefile
+++ b/patch/kernel/archive/rockchip64-6.6/overlay/Makefile
@@ -28,7 +28,8 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	rockchip-rk3399-spi-jedec-nor.dtbo \
 	rockchip-rk3399-spi-spidev.dtbo \
 	rockchip-rk3399-uart4.dtbo \
-	rockchip-rk3399-w1-gpio.dtbo
+	rockchip-rk3399-w1-gpio.dtbo \
+	rockchip-rk3566-sata2.dtbo
 
 scr-$(CONFIG_ARCH_ROCKCHIP) += \
        rockchip-fixup.scr

--- a/patch/kernel/archive/rockchip64-6.6/overlay/rockchip-rk3566-sata2.dts
+++ b/patch/kernel/archive/rockchip64-6.6/overlay/rockchip-rk3566-sata2.dts
@@ -1,0 +1,20 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&pcie2x1>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target = <&sata2>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};


### PR DESCRIPTION
#### rockchip64 / edge 6.6: add rk3566-orangepi-3b-sata DTB

- rockchip64 / edge 6.6: add rk3566-orangepi-3b-sata DTB
- rockchip64 / edge 6.6: add overlay rockchip-rk3566-sata2.dts
  - this would also apply to 3568