### PR TITLE
patch: uboot: v2023.07.02: bananapicm4: `nvme boot support`

### DIFF
--- a/config/boards/bananapicm4io.conf
+++ b/config/boards/bananapicm4io.conf
@@ -8,8 +8,8 @@ FULL_DESKTOP="yes"
 SERIALCON="ttyAML0"
 BOOT_LOGO="desktop"
 BOOT_FDT_FILE="amlogic/meson-g12b-bananapi-cm4-cm4io.dtb"
-BOOTBRANCH_BOARD="tag:v2023.01"
-BOOTPATCHDIR="v2023.01"
+BOOTBRANCH_BOARD="tag:v2023.07.02"
+BOOTPATCHDIR="v2023.07.02"
 
 function post_family_tweaks_bsp__bananapi_rtl_bt() {
 	if [[ -d "$SRC/packages/bsp/bananapi/rtl_bt" ]]; then

--- a/patch/u-boot/v2023.07.02/board_bananapicm4io/0001-configs-bananapi-cm4-cm4io_defconfig-nvme-support.patch
+++ b/patch/u-boot/v2023.07.02/board_bananapicm4io/0001-configs-bananapi-cm4-cm4io_defconfig-nvme-support.patch
@@ -1,0 +1,35 @@
+From 7bb76be10f204d422a766ff08fc5e9cfc24eab88 Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@xxxxx.com>
+Date: Sun, 15 Oct 2023 09:22:12 -0400
+Subject: [PATCH] configs: bananapi-cm4-cm4io_defconfig: nvme support
+
+Enable NVME PCI SUPPORT.
+
+Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
+---
+ configs/bananapi-cm4-cm4io_defconfig | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/configs/bananapi-cm4-cm4io_defconfig b/configs/bananapi-cm4-cm4io_defconfig
+index bb43cc41e5..066c5dca4a 100644
+--- a/configs/bananapi-cm4-cm4io_defconfig
++++ b/configs/bananapi-cm4-cm4io_defconfig
+@@ -20,6 +20,7 @@ CONFIG_REMAKE_ELF=y
+ CONFIG_OF_BOARD_SETUP=y
+ # CONFIG_DISPLAY_CPUINFO is not set
+ CONFIG_MISC_INIT_R=y
++CONFIG_PCI_INIT_R=y
+ CONFIG_SYS_MAXARGS=32
+ # CONFIG_CMD_BDI is not set
+ # CONFIG_CMD_IMI is not set
+@@ -43,6 +44,7 @@ CONFIG_DM_MDIO=y
+ CONFIG_DM_MDIO_MUX=y
+ CONFIG_ETH_DESIGNWARE_MESON8B=y
+ CONFIG_MDIO_MUX_MESON_G12A=y
++CONFIG_NVME_PCI=y
+ CONFIG_PCIE_DW_MESON=y
+ CONFIG_MESON_G12A_USB_PHY=y
+ CONFIG_PINCTRL=y
+-- 
+2.39.2
+

--- a/patch/u-boot/v2023.07.02/board_bananapicm4io/0002-HACK-include-configs-meson64-boot-target-nvme.patch
+++ b/patch/u-boot/v2023.07.02/board_bananapicm4io/0002-HACK-include-configs-meson64-boot-target-nvme.patch
@@ -1,0 +1,30 @@
+From c70fd3829e8625898b493ac083ab41adcc875946 Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@xxxxx.com>
+Date: Sun, 15 Oct 2023 09:08:48 -0400
+Subject: [PATCH] meson64 boot target nvme
+
+Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
+---
+ include/configs/meson64.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/configs/meson64.h b/include/configs/meson64.h
+index 801cdae470..0c3fc676dd 100644
+--- a/include/configs/meson64.h
++++ b/include/configs/meson64.h
+@@ -74,11 +74,11 @@
+ #ifndef BOOT_TARGET_DEVICES
+ #define BOOT_TARGET_DEVICES(func) \
+ 	func(ROMUSB, romusb, na)  \
++	BOOT_TARGET_NVME(func) \
+ 	func(MMC, mmc, 0) \
+ 	func(MMC, mmc, 1) \
+ 	func(MMC, mmc, 2) \
+ 	BOOT_TARGET_DEVICES_USB(func) \
+-	BOOT_TARGET_NVME(func) \
+ 	BOOT_TARGET_SCSI(func) \
+ 	func(PXE, pxe, na) \
+ 	func(DHCP, dhcp, na)
+-- 
+2.39.2
+


### PR DESCRIPTION
HACK: BOOT ORDER: NVMe SDCARD eMMC.

NOTES:
In my testing there has been no false starts or hangs up. Meaning the boot process has been stable.

The downside to this in my opinion is that if there is an OS on the NVMe it will always take boot priority. The drive would need to be pulled or DD'd in order for SD eMMC boot to kick in.

This has been tested by pulling the NVMe and booting from the drive and killing it; `dd if=/dev/zero of=/dev/nvme0n1 bs=32768 count=32768`

Tested-on: Waveshare CM4-IO-BASE-B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
