### PR TITLE
rockchip-rk3588: add `-Wno-error=address` to u-boot CFLAGS so it builds with gcc 12+

### DIFF
--- a/config/sources/families/rockchip-rk3588.conf
+++ b/config/sources/families/rockchip-rk3588.conf
@@ -76,16 +76,22 @@ family_tweaks_bsp() {
 	:
 }
 
-# rockchip/radxa u-boot wont' build with gcc 13 due to enum-int-mismatch
-function post_config_uboot_target__downgrade_errors_to_warnings_for_gcc13() {
+function post_config_uboot_target__downgrade_gcc_errors_to_warnings() {
 	declare -i gcc_major_version=0
 	gcc_major_version=$(gcc -dumpversion | cut -d. -f1)
 	display_alert "$BOARD" "gcc major version: ${gcc_major_version}" "debug"
 
-	# add to cflags array if gcc major version is 13 or higher
+	# rockchip/radxa u-boot wont' build with gcc 13 due to enum-int-mismatch
 	if [[ ${gcc_major_version} -ge 13 ]]; then
-		display_alert "$BOARD" "Extra CFLAGS for vendor u-boot building with gcc 13+" "vendor"
+		display_alert "$BOARD" "Extra CFLAGS for vendor u-boot building with gcc 13+" "info"
 		uboot_cflags_array+=("-Wno-error=enum-int-mismatch")
 	fi
+
+	# orangepi u-boot wont' build with gcc 12 due to 'the comparison will always evaluate as ‘true’ for the address of ‘clk’ will never be NULL [-Werror=address]'
+	if [[ ${gcc_major_version} -ge 12 ]]; then
+		display_alert "$BOARD" "Extra CFLAGS for vendor u-boot building with gcc 12+" "info"
+		uboot_cflags_array+=("-Wno-error=address")
+	fi
+
 	return 0
 }


### PR DESCRIPTION
#### rockchip-rk3588: add `-Wno-error=address` to u-boot CFLAGS so it builds with gcc 12+

- rockchip-rk3588: add `-Wno-error=address` to u-boot CFLAGS so it builds with gcc 12+
  - this applies to all u-boots in this family
  - this is in addition to the the `-Wno-error=enum-int-mismatch` needed for gcc 13+