### PR TITLE
Fix menuconfig dialog not appearing when building image with KERNEL_CONFIGURE=yes

### DIFF
--- a/lib/functions/compilation/kernel-config.sh
+++ b/lib/functions/compilation/kernel-config.sh
@@ -33,7 +33,7 @@ function kernel_config() {
 	LOG_SECTION="kernel_config_initialize" do_with_logging do_with_hooks kernel_config_initialize
 
 	if [[ "${KERNEL_CONFIGURE}" == "yes" ]]; then
-		if [[ "${ARMBIAN_COMMAND}" == "kernel-config" ]]; then
+		if [[ "${ARMBIAN_COMMAND}" != "rewrite-kernel-config" ]]; then
 			# This piece is interactive, no logging
 			display_alert "Starting (interactive) kernel ${KERNEL_MENUCONFIG:-menuconfig}" "${LINUXCONFIG}" "debug"
 			run_kernel_make_dialog "${KERNEL_MENUCONFIG:-menuconfig}"


### PR DESCRIPTION
# Description

This a fix for regression that I caused when I introduced rewrite-kernel-config command. The issue that got introduced is, if user selects to change kernel config either from the build dialog or by passing KERNEL_CONFIGURE=yes, the menuconfig interface was not getting shown any more. Just fixing the same.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested that menuconfig interface appears when building with KERNEL_CONFIGURE=yes

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
