### PR TITLE
uwe5622: Fix kernel warning for incorrect netdev-dev_addr

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -673,6 +673,10 @@ driver_uwe5622_allwinner() {
 		if linux-version compare "${version}" ge 6.6; then
 			process_patch_file "${SRC}/patch/misc/wireless-driver-for-uwe5622-v6.6-fix-tty-sdio.patch" "applying"
 		fi
+
+		if [[ "$LINUXFAMILY" == sunxi* ]]; then
+			process_patch_file "${SRC}/patch/misc/wireless-driver-for-uwe5622-fix-setting-mac-address-for-netdev.patch" "applying"
+		fi
 	fi
 }
 

--- a/patch/misc/wireless-driver-for-uwe5622-fix-setting-mac-address-for-netdev.patch
+++ b/patch/misc/wireless-driver-for-uwe5622-fix-setting-mac-address-for-netdev.patch
@@ -1,0 +1,35 @@
+From 9211a92d07e9a43fce104f87f9d45e890257b699 Mon Sep 17 00:00:00 2001
+From: pbiel <pbiel7@gmail.com>
+Date: Tue, 7 Mar 2023 20:28:44 +0100
+Subject: [PATCH] wireless: fix setting mac address for netdev in uwe5622
+ unisocwifi driver
+
+---
+ drivers/net/wireless/uwe5622/unisocwifi/main.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/wireless/uwe5622/unisocwifi/main.c b/drivers/net/wireless/uwe5622/unisocwifi/main.c
+index 21efdf4e0..566a9a7f3 100644
+--- a/drivers/net/wireless/uwe5622/unisocwifi/main.c
++++ b/drivers/net/wireless/uwe5622/unisocwifi/main.c
+@@ -1356,6 +1356,7 @@ static struct sprdwl_vif *sprdwl_register_netdev(struct sprdwl_priv *priv,
+ 	struct wireless_dev *wdev;
+ 	struct sprdwl_vif *vif;
+ 	int ret;
++	u8 target_mac_addr[ETH_ALEN] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+ 
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 17, 0))
+ 	ndev = alloc_netdev(sizeof(*vif), name, NET_NAME_UNKNOWN, ether_setup);
+@@ -1411,7 +1412,8 @@ static struct sprdwl_vif *sprdwl_register_netdev(struct sprdwl_priv *priv,
+ 	ndev->features |= NETIF_F_SG;
+ 	SET_NETDEV_DEV(ndev, wiphy_dev(priv->wiphy));
+ 
+-	sprdwl_set_mac_addr(vif, addr, ndev->dev_addr);
++	sprdwl_set_mac_addr(vif, addr, target_mac_addr);
++	dev_addr_set(ndev, target_mac_addr);
+ 
+ #ifdef CONFIG_P2P_INTF
+ 	if (type == NL80211_IFTYPE_P2P_DEVICE)
+-- 
+2.34.1
+


### PR DESCRIPTION
# Description

On devices using uwe5622 wireless, a kernel warn message and corresponding stacktrace is shown in dmesg for incorrect netdev-dev_addr. 

```
[   12.904586] ------------[ cut here ]------------
[   12.904589] netdevice: wlan0: Incorrect netdev->dev_addr
[   12.904645] WARNING: CPU: 2 PID: 734 at net/core/dev_addr_lists.c:519 dev_addr_check+0xb0/0x140
[   12.904663] Modules linked in: algif_hash algif_skcipher af_alg bnep hci_uart btqca btrtl btbcm btintel bluetooth ecdh_generic ecc sprdwl_ng sunxi_addr cfg80211 lz4hc lz4 zram binfmt_misc snd_soc_hdmi_codec sun9i_hdmi_audio polyval_ce polyval_generic sunxi_cedrus(C) sunxi_cir rc_core dw_hdmi_i2s_audio dw_hdmi_cec snd_soc_ac200 v4l2_mem2mem videobuf2_dma_contig videobuf2_memops sun4i_i2s videobuf2_v4l2 videodev videobuf2_common panfrost gpu_sched drm_shmem_helper mc dump_reg display_connector snd_soc_simple_card snd_soc_simple_card_utils cpufreq_dt sprdbt_tty uwe5622_bsp_sdio rfkill fuse dm_mod ac200 dwmac_sun8i mdio_mux pwm_sun4i
[   12.904795] CPU: 2 PID: 734 Comm: NetworkManager Tainted: G         C         6.5.4-edge-sunxi64 #1
[   12.904803] Hardware name: OrangePi 3 LTS (DT)
[   12.904807] pstate: 60000005 (nZCv daif -PAN -UAO -TCO -DIT -SSBS BTYPE=--)
[   12.904813] pc : dev_addr_check+0xb0/0x140
[   12.904820] lr : dev_addr_check+0xb0/0x140
[   12.904826] sp : ffff80008325b510
[   12.904829] x29: ffff80008325b510 x28: ffff800080f13708 x27: 0000000000000000
[   12.904839] x26: ffff800079888250 x25: ffff00000684ef90 x24: 0000000000000001
[   12.904848] x23: 0000000000001002 x22: ffff80008325b9b0 x21: ffff800081045108
[   12.904857] x20: ffff0000042f8000 x19: ffff0000042f8000 x18: 0000000000000001
[   12.904867] x17: 0000000000000000 x16: 0000000000000000 x15: ffffffffffffc43f
[   12.904876] x14: ffffffffffffffff x13: 00000000000002b4 x12: 00000000ffffffea
[   12.904885] x11: 00000000fffffbff x10: 00000000fffffbff x9 : ffff00007fb4ebc0
[   12.904894] x8 : 0000000000005fe8 x7 : c0000000fffffbff x6 : 0000000000000001
[   12.904903] x5 : ffff00007fb86908 x4 : 0000000000000000 x3 : 0000000000000027
[   12.904912] x2 : 0000000000000000 x1 : 0000000000000000 x0 : ffff000006300e00
[   12.904921] Call trace:
[   12.904925]  dev_addr_check+0xb0/0x140
[   12.904933]  __dev_open+0x40/0x1e0
[   12.904940]  __dev_change_flags+0x1dc/0x234
[   12.904946]  dev_change_flags+0x24/0x6c
[   12.904952]  do_setlink+0x224/0xe24
[   12.904960]  __rtnl_newlink+0x494/0x8c0
[   12.904966]  rtnl_newlink+0x50/0x7c
[   12.904972]  rtnetlink_rcv_msg+0x2b0/0x384
[   12.904978]  netlink_rcv_skb+0x5c/0x128
[   12.904986]  rtnetlink_rcv+0x18/0x24
[   12.904992]  netlink_unicast+0x2bc/0x324
[   12.904997]  netlink_sendmsg+0x1d4/0x438
[   12.905003]  sock_sendmsg+0x54/0x60
[   12.905011]  ____sys_sendmsg+0x27c/0x2e0
[   12.905017]  ___sys_sendmsg+0x80/0xdc
[   12.905024]  __sys_sendmsg+0x68/0xc4
[   12.905032]  __arm64_sys_sendmsg+0x24/0x30
[   12.905039]  invoke_syscall+0x48/0x114
[   12.905049]  el0_svc_common.constprop.0+0x44/0xec
[   12.905056]  do_el0_svc+0x3c/0xa8
[   12.905062]  el0_svc+0x2c/0x84
[   12.905071]  el0t_64_sync_handler+0x13c/0x158
[   12.905076]  el0t_64_sync+0x190/0x194
[   12.905082] ---[ end trace 0000000000000000 ]---
```
The wireless works with the warning as well. The warning is caused by change in kernel api's in 5.15+ kernels and it seems uwe5622 driver code was not updated for the same. This PR gets rid of the warning message, so that the dmesg stays clean.

Patch being included is picked from meta-sunxi repository.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested that warning message is gone on Orange Pi 3 LTS when booted with a kernel with this patch applied and that wireless continues to work fine.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
