### PR TITLE
meson64 edge 6.6: bump to `6.6-rc6`; rebase patches

### DIFF
--- a/config/sources/families/include/meson64_common.inc
+++ b/config/sources/families/include/meson64_common.inc
@@ -47,7 +47,7 @@ case $BRANCH in
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel. For mainline caching.
 		#KERNELBRANCH='branch:linux-6.6.y'
-		KERNELBRANCH='tag:v6.6-rc4'
+		KERNELBRANCH='tag:v6.6-rc6'
 		KERNELPATCHDIR='meson64-edge'
 		;;
 

--- a/patch/kernel/archive/meson64-6.6/board-odroidc2-usb-hub-disable-autosuspend-for-Genesys-Logic-.patch
+++ b/patch/kernel/archive/meson64-6.6/board-odroidc2-usb-hub-disable-autosuspend-for-Genesys-Logic-.patch
@@ -16,10 +16,10 @@ Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/usb/core/hub.c b/drivers/usb/core/hub.c
-index 3c54b218301c..7eabb238e24d 100644
+index 0ff47eeffb49..fd94382c3fcc 100644
 --- a/drivers/usb/core/hub.c
 +++ b/drivers/usb/core/hub.c
-@@ -5884,7 +5884,7 @@ static const struct usb_device_id hub_id_table[] = {
+@@ -5903,7 +5903,7 @@ static const struct usb_device_id hub_id_table[] = {
  			| USB_DEVICE_ID_MATCH_INT_CLASS,
        .idVendor = USB_VENDOR_GENESYS_LOGIC,
        .bInterfaceClass = USB_CLASS_HUB,

--- a/patch/kernel/archive/meson64-6.6/general-hdmi-codec-reorder-channel-allocation-list.patch
+++ b/patch/kernel/archive/meson64-6.6/general-hdmi-codec-reorder-channel-allocation-list.patch
@@ -24,7 +24,7 @@ Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
  1 file changed, 77 insertions(+), 63 deletions(-)
 
 diff --git a/sound/soc/codecs/hdmi-codec.c b/sound/soc/codecs/hdmi-codec.c
-index 13689e718d36..f6c665a58436 100644
+index 09eef6042aad..f2de713d17be 100644
 --- a/sound/soc/codecs/hdmi-codec.c
 +++ b/sound/soc/codecs/hdmi-codec.c
 @@ -184,84 +184,97 @@ static const struct snd_pcm_chmap_elem hdmi_codec_8ch_chmaps[] = {

--- a/patch/kernel/archive/meson64-6.6/general-input-touchscreen-Add-D-WAV-Multitouch.patch
+++ b/patch/kernel/archive/meson64-6.6/general-input-touchscreen-Add-D-WAV-Multitouch.patch
@@ -13,10 +13,10 @@ Change-Id: Ia1c8c29d3f69c6ba5d630279c4cc98119b68ab71
  5 files changed, 574 insertions(+)
 
 diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
-index 7e499992a793..6977b38f61a1 100644
+index e4d2dfd5d253..28543327a2df 100644
 --- a/drivers/hid/hid-ids.h
 +++ b/drivers/hid/hid-ids.h
-@@ -1456,4 +1456,10 @@
+@@ -1457,4 +1457,10 @@
  #define USB_VENDOR_ID_SIGNOTEC			0x2133
  #define USB_DEVICE_ID_SIGNOTEC_VIEWSONIC_PD1011	0x0018
  

--- a/patch/kernel/archive/meson64-6.6/general-usb-core-improve-handling-of-hubs-with-no-ports.patch
+++ b/patch/kernel/archive/meson64-6.6/general-usb-core-improve-handling-of-hubs-with-no-ports.patch
@@ -33,10 +33,10 @@ Signed-off-by: Heiner Kallweit <hkallweit1@gmail.com>
  1 file changed, 2 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/usb/core/hub.c b/drivers/usb/core/hub.c
-index 7eabb238e24d..090fa719365f 100644
+index fd94382c3fcc..52f776430d32 100644
 --- a/drivers/usb/core/hub.c
 +++ b/drivers/usb/core/hub.c
-@@ -1450,9 +1450,8 @@ static int hub_configure(struct usb_hub *hub,
+@@ -1458,9 +1458,8 @@ static int hub_configure(struct usb_hub *hub,
  		ret = -ENODEV;
  		goto fail;
  	} else if (hub->descriptor->bNbrPorts == 0) {

--- a/patch/kernel/archive/meson64-6.6/hwmon-emc2305-fixups-for-driver.patch
+++ b/patch/kernel/archive/meson64-6.6/hwmon-emc2305-fixups-for-driver.patch
@@ -1,14 +1,14 @@
-From 6f3753690d5117fc5893ee9a6cff69d6019d4bea Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Patrick Yavitz <pyavitz@xxxxx.com>
 Date: Tue, 10 Oct 2023 18:54:22 -0400
-Subject: [PATCH] hwmon: emc2305: fixups for driver
+Subject: hwmon: emc2305: fixups for driver
 
 BPI-CM4 fan control
 
 hwmon: emc2305: fixups for driver
 The driver had a number of issues, checkpatch warnings/errors,
 and other limitations, so fix these up to make it usable.
-hwmon: emc2305: Change OF properties pwm-min & pwm-max to u8 
+hwmon: emc2305: Change OF properties pwm-min & pwm-max to u8
 hwmon: emc2305: Add calls to initialize cooling maps
 https://github.com/raspberrypi/linux/commits/233096b8a9023f7e02960543c85447d46af81e81/drivers/hwmon/emc2305.c
 
@@ -17,7 +17,7 @@ Signed-off-by: Phil Elwell <phil@raspberrypi.com>
 Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>
 Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
 ---
- drivers/hwmon/emc2305.c | 96 +++++++++++++++++++++++++++++++++++++----
+ drivers/hwmon/emc2305.c | 96 +++++++++-
  1 file changed, 88 insertions(+), 8 deletions(-)
 
 diff --git a/drivers/hwmon/emc2305.c b/drivers/hwmon/emc2305.c
@@ -208,5 +208,5 @@ index 29f0e4945f19..2581166cb978 100644
  	.probe = emc2305_probe,
  	.remove	  = emc2305_remove,
 -- 
-2.39.2
+Armbian
 


### PR DESCRIPTION
#### meson64 edge 6.6: bump to `6.6-rc6`; rebase patches

- meson64 edge 6.6: bump to `6.6-rc6`; rebase patches