### PR TITLE
uefi edge 6.6: bump to `6.6-rc6`; rebase patches

### DIFF
--- a/config/sources/families/include/uefi_common.inc
+++ b/config/sources/families/include/uefi_common.inc
@@ -42,7 +42,7 @@ case "${BRANCH}" in
 		declare -g LINUXCONFIG="linux-uefi-${LINUXFAMILY}-${BRANCH}"
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel.
 		#declare -g KERNELBRANCH='branch:linux-6.6.y'
-		declare -g KERNELBRANCH='tag:v6.6-rc4'
+		declare -g KERNELBRANCH='tag:v6.6-rc6'
 		declare -g KERNELPATCHDIR="uefi-${LINUXFAMILY}-${BRANCH}" # Might be empty.
 		;;
 esac
@@ -54,7 +54,7 @@ if [[ "${QEMU_UBOOT_BOOTCONFIG}" != "" ]]; then
 	declare -g ATF_COMPILE="no"
 
 	declare -g BOOTDIR="qemu-uboot-${LINUXFAMILY}"
-	declare -g BOOTBRANCH='tag:v2023.10-rc4'
+	declare -g BOOTBRANCH='tag:v2023.10'
 	declare -g BOOTSOURCE='https://github.com/u-boot/u-boot' # Gotta set this again, it is unset by grub extension
 
 	declare -g BOOTCONFIG="${QEMU_UBOOT_BOOTCONFIG}"

--- a/patch/kernel/archive/uefi-arm64-6.6/driver-phytium-stmmac-acpi.patch
+++ b/patch/kernel/archive/uefi-arm64-6.6/driver-phytium-stmmac-acpi.patch
@@ -338,7 +338,7 @@ index 000000000000..e6ad44b80a10
 +MODULE_DESCRIPTION("Glue driver for Phytium DWMAC");
 +MODULE_LICENSE("GPL v2");
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index 83c567a89a46..9d0842b59c5c 100644
+index ed1a5a31a491..17a7c6629b3c 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 @@ -14,6 +14,7 @@
@@ -350,7 +350,7 @@ index 83c567a89a46..9d0842b59c5c 100644
  #include <linux/kernel.h>
  #include <linux/interrupt.h>
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
-index 0f28795e581c..1552acf6c2b8 100644
+index 2f0678f15fb7..24e9b1a818c5 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 @@ -9,6 +9,9 @@

--- a/patch/kernel/archive/uefi-arm64-6.6/fix-stmmac-acpi-glue-for-Feiteng-on-6.6.y.patch
+++ b/patch/kernel/archive/uefi-arm64-6.6/fix-stmmac-acpi-glue-for-Feiteng-on-6.6.y.patch
@@ -34,7 +34,7 @@ index e6ad44b80a10..733f5ea20d0c 100644
  	/* Set the maxmtu to a default of JUMBO_LEN in case the
  	 * parameter is not present.
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
-index 1552acf6c2b8..e1e63e51530e 100644
+index 24e9b1a818c5..f93078ebcdad 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_platform.c
 @@ -848,7 +848,7 @@ stmmac_probe_config_acpi(struct platform_device *pdev, u8 *mac)


### PR DESCRIPTION
#### uefi edge 6.6: bump to `6.6-rc6`; rebase patches

- uefi edge 6.6: bump to `6.6-rc6`; rebase patches
  - also bump `qemu-uboot` variant's uboot from 23.10-rc4 to final 23.10