### PR TITLE
rk3568-odroid edge 6.6: bump to `6.6-rc6`

### DIFF
--- a/config/sources/families/rk3568-odroid.conf
+++ b/config/sources/families/rk3568-odroid.conf
@@ -18,7 +18,7 @@ case $BRANCH in
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel (for armbian-next)
 		#declare -g KERNELBRANCH='branch:linux-6.6.y'
-		KERNELBRANCH='tag:v6.6-rc4'
+		KERNELBRANCH='tag:v6.6-rc6'
 		KERNELPATCHDIR='archive/rk3568-odroid-6.6' # @TODO fix # patches for overlays et al
 		;;
 


### PR DESCRIPTION
#### rk3568-odroid edge 6.6: bump to `6.6-rc6`

- rk3568-odroid edge 6.6: bump to `6.6-rc6`