### PR TITLE
update compatible string for Odroid C2 Spidev

### DIFF
--- a/patch/kernel/archive/meson64-6.1/board-odroidc2-enable-SPI.patch
+++ b/patch/kernel/archive/meson64-6.1/board-odroidc2-enable-SPI.patch
@@ -33,12 +33,12 @@ index b2cb12fb46fd..c252de8e4b17 100644
 +
 +		/* clients */
 +		spidev0@0 {
-+			compatible = "spidev";
++			compatible = "armbian,spi-dev";
 +			reg = <0>;
 +			spi-max-frequency = <500000>;
 +		};
 +		spidev0@1 {
-+			compatible = "spidev";
++			compatible = "armbian,spi-dev";
 +			reg = <1>;
 +			spi-max-frequency = <500000>;
 +		};

--- a/patch/kernel/archive/meson64-6.6/board-odroidc2-enable-SPI.patch
+++ b/patch/kernel/archive/meson64-6.6/board-odroidc2-enable-SPI.patch
@@ -33,12 +33,12 @@ index c6a38d890db5..09b6b2bea02b 100644
 +
 +		/* clients */
 +		spidev0@0 {
-+			compatible = "spidev";
++			compatible = "armbian,spi-dev";
 +			reg = <0>;
 +			spi-max-frequency = <500000>;
 +		};
 +		spidev0@1 {
-+			compatible = "spidev";
++			compatible = "armbian,spi-dev";
 +			reg = <1>;
 +			spi-max-frequency = <500000>;
 +		};


### PR DESCRIPTION
# Description

Reported by mboehmer on the forums

Kernel update made direct spidev in dts an error rather than warning, this patch didn't get updated post-break.  Use "armbian,spi-dev" compatible defined in another patch.

# How Has This Been Tested?

Builds OK

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
