### PR TITLE
Waveshare CM4-IO-BASE-B with BPI-CM4 Module

### DIFF
--- a/patch/kernel/archive/meson64-6.1/add-board-waveshare-cm4-io-base-b.patch
+++ b/patch/kernel/archive/meson64-6.1/add-board-waveshare-cm4-io-base-b.patch
@@ -60,8 +60,8 @@ index 000000000000..2c988290d48a
 +	};
 +
 +	fanctrl: emc2305@2f {
-+		reg = <0x2f>;
 +		compatible = "smsc,emc2305";
++		reg = <0x2f>;
 +		#address-cells = <1>;
 +		#size-cells = <0>;
 +		#cooling-cells = <0x02>;
@@ -78,7 +78,7 @@ index 000000000000..2c988290d48a
 +		};
 +	
 +		fanmax0: fanmax0 {
-+			temperature = <70000>;
++			temperature = <65000>;
 +			hysteresis = <2000>;
 +			type = "active";
 +		};

--- a/patch/kernel/archive/meson64-6.5/dt/meson-g12b-waveshare-cm4-io-base-b.dts
+++ b/patch/kernel/archive/meson64-6.5/dt/meson-g12b-waveshare-cm4-io-base-b.dts
@@ -24,8 +24,8 @@
 	};
 
 	fanctrl: emc2305@2f {
-		reg = <0x2f>;
 		compatible = "smsc,emc2305";
+		reg = <0x2f>;
 		#address-cells = <1>;
 		#size-cells = <0>;
 		#cooling-cells = <0x02>;
@@ -42,7 +42,7 @@
 		};
 	
 		fanmax0: fanmax0 {
-			temperature = <70000>;
+			temperature = <65000>;
 			hysteresis = <2000>;
 			type = "active";
 		};

--- a/patch/kernel/archive/meson64-6.6/dt/meson-g12b-waveshare-cm4-io-base-b.dts
+++ b/patch/kernel/archive/meson64-6.6/dt/meson-g12b-waveshare-cm4-io-base-b.dts
@@ -24,8 +24,8 @@
 	};
 
 	fanctrl: emc2305@2f {
-		reg = <0x2f>;
 		compatible = "smsc,emc2305";
+		reg = <0x2f>;
 		#address-cells = <1>;
 		#size-cells = <0>;
 		#cooling-cells = <0x02>;
@@ -42,7 +42,7 @@
 		};
 	
 		fanmax0: fanmax0 {
-			temperature = <70000>;
+			temperature = <65000>;
 			hysteresis = <2000>;
 			type = "active";
 		};


### PR DESCRIPTION
Set fan max speed to kick in at 65*C. This keeps the unit roughly at 70*C or lower, when pusing all cores for an extended period of time.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
