### PR TITLE
Radxa Zero: `u-boot-v2023.07.02`

### DIFF
--- a/config/boards/radxa-zero.conf
+++ b/config/boards/radxa-zero.conf
@@ -13,5 +13,5 @@ ASOUND_STATE="asound.state.radxa-zero"
 BOOT_FDT_FILE="amlogic/meson-g12a-radxa-zero.dtb"
 
 # Newer u-boot for the Zero
-BOOTBRANCH_BOARD="tag:v2022.10"
-BOOTPATCHDIR="v2022.10"
+BOOTBRANCH_BOARD="tag:v2023.07.02"
+BOOTPATCHDIR="v2023.07.02"

--- a/patch/u-boot/v2023.07.02/board_radxa-zero/001-HACK-mmc-meson-gx-limit-to-24MHz.patch
+++ b/patch/u-boot/v2023.07.02/board_radxa-zero/001-HACK-mmc-meson-gx-limit-to-24MHz.patch
@@ -1,0 +1,26 @@
+From b55ab13244c8c175447fb1becdd25690e011b6c3 Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@xxxxx.com>
+Date: Fri, 28 Jul 2023 13:32:12 -0400
+Subject: [PATCH] HACK: mmc-meson-gx limit to 24MHz
+
+Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
+---
+ drivers/mmc/meson_gx_mmc.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/mmc/meson_gx_mmc.c b/drivers/mmc/meson_gx_mmc.c
+index fcf4f03d1e..6ded4b619b 100644
+--- a/drivers/mmc/meson_gx_mmc.c
++++ b/drivers/mmc/meson_gx_mmc.c
+@@ -279,7 +279,7 @@ static int meson_mmc_probe(struct udevice *dev)
+ 	cfg->host_caps = MMC_MODE_8BIT | MMC_MODE_4BIT |
+ 			MMC_MODE_HS_52MHz | MMC_MODE_HS;
+ 	cfg->f_min = DIV_ROUND_UP(SD_EMMC_CLKSRC_24M, CLK_MAX_DIV);
+-	cfg->f_max = 100000000; /* 100 MHz */
++	cfg->f_max = SD_EMMC_CLKSRC_24M;
+ 	cfg->b_max = 511; /* max 512 - 1 blocks */
+ 	cfg->name = dev->name;
+ 
+-- 
+2.39.2
+


### PR DESCRIPTION
Update Das U-Boot to v2023.07.02
Patch: HACK: mmc: meson-gx: limit to 24MHz
https://github.com/radxa/u-boot/commit/db6738fed924d7febb8bac927e30526f81408eeb

In my testing the patch is required for stable boot on REV 1.51. It is not required on REV 1.4, but has no ill effects on boot.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
