### PR TITLE
Radxa Zero: `set aliases for serial i2c and spi`

### DIFF
--- a/patch/kernel/archive/meson64-6.1/board-radxa-zero-dts-add-aliases-for-serial-i2c-and-spi.patch
+++ b/patch/kernel/archive/meson64-6.1/board-radxa-zero-dts-add-aliases-for-serial-i2c-and-spi.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@xxxxx.com>
+Date: Tue, 24 Oct 2023 08:17:17 -0400
+Subject: [PATCH] arm64: dts: Radxa Zero: set aliases for serial, i2c and spi
+
+Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
+---
+ .../arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
+index cf0a9be83fc4..384f39afeba8 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
+@@ -15,6 +15,18 @@ / {
+ 
+ 	aliases {
+ 		serial0 = &uart_AO;
++		serial1 = &uart_AO_B;
++		serial2 = &uart_A;
++		serial3 = &uart_B;
++		serial4 = &uart_C;
++		i2c0 = &i2c0;
++		i2c1 = &i2c1;
++		i2c2 = &i2c2;
++		i2c3 = &i2c3;
++		i2c4 = &i2c_AO;
++		spi0 = &spicc0;
++		spi1 = &spicc1;
++		spi2 = &spifc;
+ 	};
+ 
+ 	chosen {
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.1/board-radxa-zero-dts-add-support-for-the-usb-c-controller.patch
+++ b/patch/kernel/archive/meson64-6.1/board-radxa-zero-dts-add-support-for-the-usb-c-controller.patch
@@ -19,14 +19,14 @@ Suggested-by: Neil Armstrong <narmstrong@baylibre.com>
 Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
 Signed-off-by: Yuntian Zhang <yt@radxa.com>
 ---
- arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts | 48 ++++++++++
+ .../dts/amlogic/meson-g12a-radxa-zero.dts     | 48 +++++++++++++++++++
  1 file changed, 48 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
-index e3bb6df42ff3..28eaaa83a00e 100644
+index 384f39afeba8..6b20a3932547 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
 +++ b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
-@@ -60,6 +60,14 @@ sdio_pwrseq: sdio-pwrseq {
+@@ -72,6 +72,14 @@ sdio_pwrseq: sdio-pwrseq {
  		clock-names = "ext_clock";
  	};
  
@@ -41,7 +41,7 @@ index e3bb6df42ff3..28eaaa83a00e 100644
  	ao_5v: regulator-ao_5v {
  		compatible = "regulator-fixed";
  		regulator-name = "AO_5V";
-@@ -191,6 +199,18 @@ wifi32k: wifi32k {
+@@ -203,6 +211,18 @@ wifi32k: wifi32k {
  	};
  };
  
@@ -60,7 +60,7 @@ index e3bb6df42ff3..28eaaa83a00e 100644
  &arb {
  	status = "okay";
  };
-@@ -278,6 +298,26 @@ &ir {
+@@ -290,6 +310,26 @@ &ir {
  	pinctrl-names = "default";
  };
  
@@ -87,9 +87,9 @@ index e3bb6df42ff3..28eaaa83a00e 100644
  &pwm_AO_cd {
  	pinctrl-0 = <&pwm_ao_d_e_pins>;
  	pinctrl-names = "default";
-@@ -403,3 +443,11 @@ &usb {
+@@ -414,3 +454,11 @@ &uart_AO {
+ &usb {
  	status = "okay";
- 	dr_mode = "host";
  };
 +
 +&usb2_phy0 {

--- a/patch/kernel/archive/meson64-6.1/board-radxa-zero-dts-slow-down-sdio-for-working-wifi.patch
+++ b/patch/kernel/archive/meson64-6.1/board-radxa-zero-dts-slow-down-sdio-for-working-wifi.patch
@@ -3,18 +3,19 @@ From: Yuntian Zhang <yt@radxa.com>
 Date: Mon, 27 Jun 2022 15:06:32 +0800
 Subject: VENDOR: Radxa Zero Wi-Fi fix
 
-Credit: c0rnelius from Armbian
+Credit: pyavitz from Armbian
 
 Signed-off-by: Yuntian Zhang <yt@radxa.com>
+Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
 ---
  arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
-index 29cfcc045bea..4e7781f87867 100644
+index 6b20a3932547..796a7ec617d6 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
 +++ b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
-@@ -350,7 +350,7 @@ &sd_emmc_a {
+@@ -362,7 +362,7 @@ &sd_emmc_a {
  
  	bus-width = <4>;
  	cap-sd-highspeed;

--- a/patch/kernel/archive/meson64-6.5/board-radxa-zero-dts-add-aliases-for-serial-i2c-and-spi.patch
+++ b/patch/kernel/archive/meson64-6.5/board-radxa-zero-dts-add-aliases-for-serial-i2c-and-spi.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@xxxxx.com>
+Date: Tue, 24 Oct 2023 08:17:17 -0400
+Subject: [PATCH] arm64: dts: Radxa Zero: set aliases for serial, i2c and spi
+
+Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
+---
+ .../arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
+index cf0a9be83fc4..384f39afeba8 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
+@@ -15,6 +15,18 @@ / {
+ 
+ 	aliases {
+ 		serial0 = &uart_AO;
++		serial1 = &uart_AO_B;
++		serial2 = &uart_A;
++		serial3 = &uart_B;
++		serial4 = &uart_C;
++		i2c0 = &i2c0;
++		i2c1 = &i2c1;
++		i2c2 = &i2c2;
++		i2c3 = &i2c3;
++		i2c4 = &i2c_AO;
++		spi0 = &spicc0;
++		spi1 = &spicc1;
++		spi2 = &spifc;
+ 	};
+ 
+ 	chosen {
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.5/board-radxa-zero-dts-add-support-for-the-usb-c-controller.patch
+++ b/patch/kernel/archive/meson64-6.5/board-radxa-zero-dts-add-support-for-the-usb-c-controller.patch
@@ -19,14 +19,14 @@ Suggested-by: Neil Armstrong <narmstrong@baylibre.com>
 Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
 Signed-off-by: Yuntian Zhang <yt@radxa.com>
 ---
- arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts | 48 ++++++++++
+ .../dts/amlogic/meson-g12a-radxa-zero.dts     | 48 +++++++++++++++++++
  1 file changed, 48 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
-index cf0a9be83fc4..29cfcc045bea 100644
+index 384f39afeba8..6b20a3932547 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
 +++ b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
-@@ -60,6 +60,14 @@ sdio_pwrseq: sdio-pwrseq {
+@@ -72,6 +72,14 @@ sdio_pwrseq: sdio-pwrseq {
  		clock-names = "ext_clock";
  	};
  
@@ -41,7 +41,7 @@ index cf0a9be83fc4..29cfcc045bea 100644
  	ao_5v: regulator-ao_5v {
  		compatible = "regulator-fixed";
  		regulator-name = "AO_5V";
-@@ -191,6 +199,18 @@ wifi32k: wifi32k {
+@@ -203,6 +211,18 @@ wifi32k: wifi32k {
  	};
  };
  
@@ -60,7 +60,7 @@ index cf0a9be83fc4..29cfcc045bea 100644
  &arb {
  	status = "okay";
  };
-@@ -278,6 +298,26 @@ &ir {
+@@ -290,6 +310,26 @@ &ir {
  	pinctrl-names = "default";
  };
  
@@ -87,7 +87,7 @@ index cf0a9be83fc4..29cfcc045bea 100644
  &pwm_AO_cd {
  	pinctrl-0 = <&pwm_ao_d_e_pins>;
  	pinctrl-names = "default";
-@@ -402,3 +442,11 @@ &uart_AO {
+@@ -414,3 +454,11 @@ &uart_AO {
  &usb {
  	status = "okay";
  };

--- a/patch/kernel/archive/meson64-6.5/board-radxa-zero-dts-slow-down-sdio-for-working-wifi.patch
+++ b/patch/kernel/archive/meson64-6.5/board-radxa-zero-dts-slow-down-sdio-for-working-wifi.patch
@@ -3,18 +3,19 @@ From: Yuntian Zhang <yt@radxa.com>
 Date: Mon, 27 Jun 2022 15:06:32 +0800
 Subject: VENDOR: Radxa Zero Wi-Fi fix
 
-Credit: c0rnelius from Armbian
+Credit: pyavitz from Armbian
 
 Signed-off-by: Yuntian Zhang <yt@radxa.com>
+Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
 ---
  arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
-index 29cfcc045bea..4e7781f87867 100644
+index 6b20a3932547..796a7ec617d6 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
 +++ b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
-@@ -350,7 +350,7 @@ &sd_emmc_a {
+@@ -362,7 +362,7 @@ &sd_emmc_a {
  
  	bus-width = <4>;
  	cap-sd-highspeed;

--- a/patch/kernel/archive/meson64-6.6/board-radxa-zero-dts-add-aliases-for-serial-i2c-and-spi.patch
+++ b/patch/kernel/archive/meson64-6.6/board-radxa-zero-dts-add-aliases-for-serial-i2c-and-spi.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@xxxxx.com>
+Date: Tue, 24 Oct 2023 08:17:17 -0400
+Subject: [PATCH] arm64: dts: Radxa Zero: set aliases for serial, i2c and spi
+
+Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
+---
+ .../arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
+index cf0a9be83fc4..384f39afeba8 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
+@@ -15,6 +15,18 @@ / {
+ 
+ 	aliases {
+ 		serial0 = &uart_AO;
++		serial1 = &uart_AO_B;
++		serial2 = &uart_A;
++		serial3 = &uart_B;
++		serial4 = &uart_C;
++		i2c0 = &i2c0;
++		i2c1 = &i2c1;
++		i2c2 = &i2c2;
++		i2c3 = &i2c3;
++		i2c4 = &i2c_AO;
++		spi0 = &spicc0;
++		spi1 = &spicc1;
++		spi2 = &spifc;
+ 	};
+ 
+ 	chosen {
+-- 
+Armbian
+

--- a/patch/kernel/archive/meson64-6.6/board-radxa-zero-dts-add-support-for-the-usb-c-controller.patch
+++ b/patch/kernel/archive/meson64-6.6/board-radxa-zero-dts-add-support-for-the-usb-c-controller.patch
@@ -19,14 +19,14 @@ Suggested-by: Neil Armstrong <narmstrong@baylibre.com>
 Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
 Signed-off-by: Yuntian Zhang <yt@radxa.com>
 ---
- arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts | 48 ++++++++++
+ .../dts/amlogic/meson-g12a-radxa-zero.dts     | 48 +++++++++++++++++++
  1 file changed, 48 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
-index fcd7e1d8e16f..8bb2fa568a5a 100644
+index 2e4646e255ad..9dd5e6c2583d 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
 +++ b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
-@@ -60,6 +60,14 @@ sdio_pwrseq: sdio-pwrseq {
+@@ -72,6 +72,14 @@ sdio_pwrseq: sdio-pwrseq {
  		clock-names = "ext_clock";
  	};
  
@@ -41,7 +41,7 @@ index fcd7e1d8e16f..8bb2fa568a5a 100644
  	ao_5v: regulator-ao_5v {
  		compatible = "regulator-fixed";
  		regulator-name = "AO_5V";
-@@ -190,6 +198,18 @@ wifi32k: wifi32k {
+@@ -202,6 +210,18 @@ wifi32k: wifi32k {
  	};
  };
  
@@ -60,7 +60,7 @@ index fcd7e1d8e16f..8bb2fa568a5a 100644
  &arb {
  	status = "okay";
  };
-@@ -277,6 +297,26 @@ &ir {
+@@ -289,6 +309,26 @@ &ir {
  	pinctrl-names = "default";
  };
  
@@ -87,7 +87,7 @@ index fcd7e1d8e16f..8bb2fa568a5a 100644
  &pwm_AO_cd {
  	pinctrl-0 = <&pwm_ao_d_e_pins>;
  	pinctrl-names = "default";
-@@ -401,3 +441,11 @@ &uart_AO {
+@@ -413,3 +453,11 @@ &uart_AO {
  &usb {
  	status = "okay";
  };

--- a/patch/kernel/archive/meson64-6.6/board-radxa-zero-dts-slow-down-sdio-for-working-wifi.patch
+++ b/patch/kernel/archive/meson64-6.6/board-radxa-zero-dts-slow-down-sdio-for-working-wifi.patch
@@ -3,18 +3,19 @@ From: Yuntian Zhang <yt@radxa.com>
 Date: Mon, 27 Jun 2022 15:06:32 +0800
 Subject: VENDOR: Radxa Zero Wi-Fi fix
 
-Credit: c0rnelius from Armbian
+Credit: pyavitz from Armbian
 
 Signed-off-by: Yuntian Zhang <yt@radxa.com>
+Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
 ---
  arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
-index 8bb2fa568a5a..11da96ddc89a 100644
+index 9dd5e6c2583d..65a49891466f 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
 +++ b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
-@@ -349,7 +349,7 @@ &sd_emmc_a {
+@@ -361,7 +361,7 @@ &sd_emmc_a {
  
  	bus-width = <4>;
  	cap-sd-highspeed;


### PR DESCRIPTION
Set aliases for serial, i2c and spi
https://github.com/radxa/kernel/commit/09f243e8d3a7a0d06c54ec6909a1b291f20b7a57
https://github.com/radxa/kernel/commit/ca5ed41ff23216d95c7dd5fce6e2d5d7577c7c02

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
