### PR TITLE
initrd: if debugging, don't filter update-initramfs output (errors might be lurking in there)

### DIFF
--- a/lib/functions/image/initrd.sh
+++ b/lib/functions/image/initrd.sh
@@ -29,7 +29,8 @@ update_initramfs() {
 	local logging_filter=""
 	if [[ "${SHOW_DEBUG}" == "yes" ]]; then
 		initrd_debug="v"
-		logging_filter="2>&1 | { grep --line-buffered -v -e '.xz' -e 'ORDER ignored' -e 'Adding binary ' -e 'Adding module ' -e 'Adding firmware ' -e 'microcode bundle' -e ', pf_mask' || true ; }"
+		# disabled; if debugging, we want the full output, even if it is huge.
+		# logging_filter="2>&1 | { grep --line-buffered -v -e '.xz' -e 'ORDER ignored' -e 'Adding binary ' -e 'Adding module ' -e 'Adding firmware ' -e 'microcode bundle' -e ', pf_mask' || true ; }"
 	fi
 	if [ "$target_dir" != "" ]; then
 		initrd_kern_ver="$(basename "$target_dir")"


### PR DESCRIPTION
#### initrd: if debugging, don't filter update-initramfs output (errors might be lurking in there)

- initrd: if debugging, don't filter update-initramfs output (errors might be lurking in there)