### PR TITLE
add settings & updater for KDE

### DIFF
--- a/config/desktop/bullseye/environments/kde-plasma/config_base/packages
+++ b/config/desktop/bullseye/environments/kde-plasma/config_base/packages
@@ -32,11 +32,9 @@ fonts-opensymbol
 fonts-stix
 fonts-symbola
 fonts-ubuntu
-fonts-ubuntu-font-family-console
 foomatic-db-compressed-ppds
 gdebi
 ghostscript-x
-gnome-orca
 gnome-disk-utility
 gnome-screenshot
 gstreamer1.0-packagekit
@@ -86,6 +84,7 @@ pasystray
 pavucontrol
 pavucontrol-qt
 pavumeter
+plasma-discover
 policykit-1
 printer-driver-all
 profile-sync-daemon
@@ -96,6 +95,7 @@ slick-greeter
 smbclient
 software-properties-gtk
 spice-vdagent
+systemsettings
 system-config-printer
 system-config-printer-common
 terminator


### PR DESCRIPTION
# Description

When generating KDE desktop environment beyond Jammy, some essential items are missing like systemsettings. The plasma-discover package manager was also missing. In bookworm, some gname packages are also not available any more and have been removed.

Jira reference number [AR-1897]

# How Has This Been Tested?

- [ ] Generated a uefi_x86 version for current/bullseye/KDE and testing in in VirtualBox
- [ ] Generated a uefi_x86 version for current/bookworm/KDE and testing in in VirtualBox

[AR-1897]: https://armbian.atlassian.net/browse/AR-1897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ