### PR TITLE
meson64 / rockchip64 / uefi / rk3568-odroid: edge 6.6: bump to 6.6-rc7; rebase/rewrite patches for 6.6-rc7

### DIFF
--- a/config/sources/families/include/meson64_common.inc
+++ b/config/sources/families/include/meson64_common.inc
@@ -47,7 +47,7 @@ case $BRANCH in
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel. For mainline caching.
 		#KERNELBRANCH='branch:linux-6.6.y'
-		KERNELBRANCH='tag:v6.6-rc6'
+		KERNELBRANCH='tag:v6.6-rc7'
 		KERNELPATCHDIR='meson64-edge'
 		;;
 

--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -155,7 +155,7 @@ case $BRANCH in
 		KERNELPATCHDIR='rockchip64-'$BRANCH
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel.
 		#KERNELBRANCH="branch:linux-6.6.y"
-		KERNELBRANCH='tag:v6.6-rc6'
+		KERNELBRANCH='tag:v6.6-rc7'
 		LINUXFAMILY=rockchip64
 		LINUXCONFIG='linux-rockchip64-'$BRANCH
 

--- a/config/sources/families/include/uefi_common.inc
+++ b/config/sources/families/include/uefi_common.inc
@@ -42,7 +42,7 @@ case "${BRANCH}" in
 		declare -g LINUXCONFIG="linux-uefi-${LINUXFAMILY}-${BRANCH}"
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel.
 		#declare -g KERNELBRANCH='branch:linux-6.6.y'
-		declare -g KERNELBRANCH='tag:v6.6-rc6'
+		declare -g KERNELBRANCH='tag:v6.6-rc7'
 		declare -g KERNELPATCHDIR="uefi-${LINUXFAMILY}-${BRANCH}" # Might be empty.
 		;;
 esac

--- a/config/sources/families/rk3568-odroid.conf
+++ b/config/sources/families/rk3568-odroid.conf
@@ -18,7 +18,7 @@ case $BRANCH in
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel (for armbian-next)
 		#declare -g KERNELBRANCH='branch:linux-6.6.y'
-		KERNELBRANCH='tag:v6.6-rc6'
+		KERNELBRANCH='tag:v6.6-rc7'
 		KERNELPATCHDIR='archive/rk3568-odroid-6.6' # @TODO fix # patches for overlays et al
 		;;
 

--- a/patch/kernel/archive/meson64-6.6/board-odroidc2-enable-SPI.patch
+++ b/patch/kernel/archive/meson64-6.6/board-odroidc2-enable-SPI.patch
@@ -11,7 +11,7 @@ Odroid C2 enable SPI
  1 file changed, 26 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts b/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts
-index c6a38d890db5..09b6b2bea02b 100644
+index c6a38d890db5..73ad65fad0d7 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts
 +++ b/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts
 @@ -176,6 +176,32 @@ hdmi_connector_in: endpoint {

--- a/patch/kernel/archive/meson64-6.6/board-odroidc2-enable-scpi-dvfs.patch
+++ b/patch/kernel/archive/meson64-6.6/board-odroidc2-enable-scpi-dvfs.patch
@@ -9,7 +9,7 @@ Enable odroidc2-dev DVFS (#763)
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts b/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts
-index 09b6b2bea02b..b4862f5f6347 100644
+index 73ad65fad0d7..f99f8414d8e0 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts
 +++ b/arch/arm64/boot/dts/amlogic/meson-gxbb-odroidc2.dts
 @@ -360,7 +360,8 @@ &saradc {

--- a/patch/kernel/archive/meson64-6.6/board-radxa-zero-dts-add-aliases-for-serial-i2c-and-spi.patch
+++ b/patch/kernel/archive/meson64-6.6/board-radxa-zero-dts-add-aliases-for-serial-i2c-and-spi.patch
@@ -1,15 +1,15 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Patrick Yavitz <pyavitz@xxxxx.com>
 Date: Tue, 24 Oct 2023 08:17:17 -0400
-Subject: [PATCH] arm64: dts: Radxa Zero: set aliases for serial, i2c and spi
+Subject: arm64: dts: Radxa Zero: set aliases for serial, i2c and spi
 
 Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
 ---
- .../arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts | 12 ++++++++++++
+ arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts | 12 ++++++++++
  1 file changed, 12 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
-index cf0a9be83fc4..384f39afeba8 100644
+index fcd7e1d8e16f..2e4646e255ad 100644
 --- a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
 +++ b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts
 @@ -15,6 +15,18 @@ / {

--- a/patch/kernel/archive/meson64-6.6/board-radxa-zero-dts-add-support-for-the-usb-c-controller.patch
+++ b/patch/kernel/archive/meson64-6.6/board-radxa-zero-dts-add-support-for-the-usb-c-controller.patch
@@ -19,7 +19,7 @@ Suggested-by: Neil Armstrong <narmstrong@baylibre.com>
 Signed-off-by: Christian Hewitt <christianshewitt@gmail.com>
 Signed-off-by: Yuntian Zhang <yt@radxa.com>
 ---
- .../dts/amlogic/meson-g12a-radxa-zero.dts     | 48 +++++++++++++++++++
+ arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts | 48 ++++++++++
  1 file changed, 48 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts b/arch/arm64/boot/dts/amlogic/meson-g12a-radxa-zero.dts

--- a/patch/kernel/archive/rk3568-odroid-6.6/5001-montjoie-crypto-rk35xx.patch
+++ b/patch/kernel/archive/rk3568-odroid-6.6/5001-montjoie-crypto-rk35xx.patch
@@ -97,35 +97,6 @@ index 000000000000..fbe1e1b33dab
 -- 
 Armbian
 
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Corentin Labbe <clabbe.montjoie@gmail.com>
-Date: Mon, 26 Sep 2022 13:38:25 +0200
-Subject: MAINTAINERS: add new dt-binding doc to the right entry
-
-Rockchip crypto driver have a new file to be added.
-
-Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>
----
- MAINTAINERS | 1 +
- 1 file changed, 1 insertion(+)
-
-diff --git a/MAINTAINERS b/MAINTAINERS
-index 208cfcc1aee3..03e47802653a 100644
---- a/MAINTAINERS
-+++ b/MAINTAINERS
-@@ -18617,6 +18617,7 @@ M:	Corentin Labbe <clabbe@baylibre.com>
- L:	linux-crypto@vger.kernel.org
- S:	Maintained
- F:	Documentation/devicetree/bindings/crypto/rockchip,rk3288-crypto.yaml
-+F:	Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml
- F:	drivers/crypto/rockchip/
- 
- ROCKCHIP I2S TDM DRIVER
--- 
-Armbian
-
-
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Corentin Labbe <clabbe.montjoie@gmail.com>
 Date: Wed, 20 Sep 2023 16:04:18 +0200
@@ -164,7 +135,6 @@ index 5544f66c6ff4..ffffe084a966 100644
  		reg = <0x0 0xfe470000 0x0 0x1000>;
 -- 
 Armbian
-
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Corentin Labbe <clabbe.montjoie@gmail.com>
@@ -205,7 +175,6 @@ index abee88911982..b9cbab2246e2 100644
  		reg = <0x0 0xfe400000 0x0 0x1000>;
 -- 
 Armbian
-
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Corentin Labbe <clabbe.montjoie@gmail.com>
@@ -364,7 +333,6 @@ index d4264db2a07f..c0d08ae78cd5 100644
  #endif
 -- 
 Armbian
-
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Corentin Labbe <clabbe.montjoie@gmail.com>
@@ -2380,7 +2348,6 @@ index 000000000000..9b6cc29847d7
 +}
 -- 
 Armbian
-
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Corentin Labbe <clabbe.montjoie@gmail.com>


### PR DESCRIPTION
#### meson64 / rockchip64 / uefi / rk3568-odroid: edge 6.6: bump to 6.6-rc7; rebase/rewrite patches for 6.6-rc7

- meson64 / rockchip64 / uefi / rk3568-odroid: edge 6.6: bump to 6.6-rc7; rebase/rewrite patches for 6.6-rc7