### PR TITLE
meson64 / rockchip64 / uefi / rk3568-odroid: edge 6.6: bump to 6.6.y; rebase patches to v6.6(.0)

### DIFF
--- a/config/sources/families/include/meson64_common.inc
+++ b/config/sources/families/include/meson64_common.inc
@@ -46,8 +46,7 @@ case $BRANCH in
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel. For mainline caching.
-		#KERNELBRANCH='branch:linux-6.6.y'
-		KERNELBRANCH='tag:v6.6-rc7'
+		KERNELBRANCH='branch:linux-6.6.y'
 		KERNELPATCHDIR='meson64-edge'
 		;;
 

--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -154,8 +154,7 @@ case $BRANCH in
 
 		KERNELPATCHDIR='rockchip64-'$BRANCH
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel.
-		#KERNELBRANCH="branch:linux-6.6.y"
-		KERNELBRANCH='tag:v6.6-rc7'
+		KERNELBRANCH="branch:linux-6.6.y"
 		LINUXFAMILY=rockchip64
 		LINUXCONFIG='linux-rockchip64-'$BRANCH
 

--- a/config/sources/families/include/uefi_common.inc
+++ b/config/sources/families/include/uefi_common.inc
@@ -41,8 +41,7 @@ case "${BRANCH}" in
 		declare -g DISTRO_GENERIC_KERNEL=no
 		declare -g LINUXCONFIG="linux-uefi-${LINUXFAMILY}-${BRANCH}"
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel.
-		#declare -g KERNELBRANCH='branch:linux-6.6.y'
-		declare -g KERNELBRANCH='tag:v6.6-rc7'
+		declare -g KERNELBRANCH='branch:linux-6.6.y'
 		declare -g KERNELPATCHDIR="uefi-${LINUXFAMILY}-${BRANCH}" # Might be empty.
 		;;
 esac

--- a/config/sources/families/rk3568-odroid.conf
+++ b/config/sources/families/rk3568-odroid.conf
@@ -17,8 +17,7 @@ case $BRANCH in
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel (for armbian-next)
-		#declare -g KERNELBRANCH='branch:linux-6.6.y'
-		KERNELBRANCH='tag:v6.6-rc7'
+		declare -g KERNELBRANCH='branch:linux-6.6.y'
 		KERNELPATCHDIR='archive/rk3568-odroid-6.6' # @TODO fix # patches for overlays et al
 		;;
 

--- a/patch/kernel/archive/rockchip64-6.6/add-rockchip-iep-driver.patch
+++ b/patch/kernel/archive/rockchip64-6.6/add-rockchip-iep-driver.patch
@@ -216,7 +216,7 @@ index e729e7a22b23..4e30c5279ac6 100644
  		compatible = "rockchip,rk3328-dw-hdmi";
  		reg = <0x0 0xff3c0000 0x0 0x20000>;
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399.dtsi b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-index 9da0b6d77c8d..8e781efbf143 100644
+index 5bc2d4faeea6..8aa038f5657a 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
 @@ -1404,12 +1404,25 @@ vdec_mmu: iommu@ff660480 {

--- a/patch/kernel/archive/rockchip64-6.6/board-rockpi4-0003-arm64-dts-pcie.patch
+++ b/patch/kernel/archive/rockchip64-6.6/board-rockpi4-0003-arm64-dts-pcie.patch
@@ -101,7 +101,7 @@ Subject: [ARCHEOLOGY] Rock Pi 4 enable PCIe in device tree for "dev" target
  1 file changed, 4 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
-index 7dccbe8a9393..c89bbe5b1034 100644
+index f2279aa6ca9e..9d1b2129431c 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
 @@ -112,6 +112,8 @@ vcc3v3_pcie: vcc3v3-pcie-regulator {
@@ -113,7 +113,7 @@ index 7dccbe8a9393..c89bbe5b1034 100644
  		vin-supply = <&vcc5v0_sys>;
  	};
  
-@@ -527,9 +529,11 @@ &pcie0 {
+@@ -528,9 +530,11 @@ &pcie0 {
  	num-lanes = <4>;
  	pinctrl-0 = <&pcie_clkreqnb_cpm>;
  	pinctrl-names = "default";

--- a/patch/kernel/archive/rockchip64-6.6/general-disable-mtu-validation.patch
+++ b/patch/kernel/archive/rockchip64-6.6/general-disable-mtu-validation.patch
@@ -15,10 +15,10 @@ Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
  1 file changed, 12 deletions(-)
 
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index ed1a5a31a491..127245df017d 100644
+index 5801f4d50f95..6f9b14164fc8 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-@@ -5668,27 +5668,15 @@ static void stmmac_set_rx_mode(struct net_device *dev)
+@@ -5676,27 +5676,15 @@ static void stmmac_set_rx_mode(struct net_device *dev)
  static int stmmac_change_mtu(struct net_device *dev, int new_mtu)
  {
  	struct stmmac_priv *priv = netdev_priv(dev);

--- a/patch/kernel/archive/rockchip64-6.6/net-usb-r8152-add-LED-configuration-from-OF.patch
+++ b/patch/kernel/archive/rockchip64-6.6/net-usb-r8152-add-LED-configuration-from-OF.patch
@@ -13,7 +13,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
  1 file changed, 23 insertions(+)
 
 diff --git a/drivers/net/usb/r8152.c b/drivers/net/usb/r8152.c
-index 0c13d9950cd8..b7a300572a05 100644
+index afb20c0ed688..f2fa63b5ad05 100644
 --- a/drivers/net/usb/r8152.c
 +++ b/drivers/net/usb/r8152.c
 @@ -11,6 +11,7 @@
@@ -24,7 +24,7 @@ index 0c13d9950cd8..b7a300572a05 100644
  #include <linux/crc32.h>
  #include <linux/if_vlan.h>
  #include <linux/uaccess.h>
-@@ -6879,6 +6880,22 @@ static void rtl_tally_reset(struct r8152 *tp)
+@@ -6980,6 +6981,22 @@ static void rtl_tally_reset(struct r8152 *tp)
  	ocp_write_word(tp, MCU_TYPE_PLA, PLA_RSTTALLY, ocp_data);
  }
  
@@ -47,7 +47,7 @@ index 0c13d9950cd8..b7a300572a05 100644
  static void r8152b_init(struct r8152 *tp)
  {
  	u32 ocp_data;
-@@ -6920,6 +6937,8 @@ static void r8152b_init(struct r8152 *tp)
+@@ -7021,6 +7038,8 @@ static void r8152b_init(struct r8152 *tp)
  	ocp_data = ocp_read_word(tp, MCU_TYPE_USB, USB_USB_CTRL);
  	ocp_data &= ~(RX_AGG_DISABLE | RX_ZERO_EN);
  	ocp_write_word(tp, MCU_TYPE_USB, USB_USB_CTRL, ocp_data);
@@ -56,7 +56,7 @@ index 0c13d9950cd8..b7a300572a05 100644
  }
  
  static void r8153_init(struct r8152 *tp)
-@@ -7060,6 +7079,8 @@ static void r8153_init(struct r8152 *tp)
+@@ -7161,6 +7180,8 @@ static void r8153_init(struct r8152 *tp)
  		tp->coalesce = COALESCE_SLOW;
  		break;
  	}
@@ -65,7 +65,7 @@ index 0c13d9950cd8..b7a300572a05 100644
  }
  
  static void r8153b_init(struct r8152 *tp)
-@@ -7142,6 +7163,8 @@ static void r8153b_init(struct r8152 *tp)
+@@ -7243,6 +7264,8 @@ static void r8153b_init(struct r8152 *tp)
  	rtl_tally_reset(tp);
  
  	tp->coalesce = 15000;	/* 15 us */

--- a/patch/kernel/archive/rockchip64-6.6/rk3399-enable-dwc3-xhci-usb-trb-quirk.patch
+++ b/patch/kernel/archive/rockchip64-6.6/rk3399-enable-dwc3-xhci-usb-trb-quirk.patch
@@ -95,7 +95,7 @@ Subject: [ARCHEOLOGY] Fix 2.5G Ethernet on Helios64 Mainline kernel (#2567)
  1 file changed, 2 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399.dtsi b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-index 8e781efbf143..7c0ce9be1376 100644
+index 8aa038f5657a..90905af1a702 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
 @@ -488,6 +488,7 @@ usbdrd_dwc3_0: usb@fe800000 {

--- a/patch/kernel/archive/rockchip64-6.6/rk3399-rp64-rng.patch
+++ b/patch/kernel/archive/rockchip64-6.6/rk3399-rp64-rng.patch
@@ -9,7 +9,7 @@ Signed-off-by: Igor Pecovnik <igor.pecovnik@gmail.com>
  1 file changed, 10 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399.dtsi b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-index 7c0ce9be1376..9364f495cdeb 100644
+index 90905af1a702..1eb5c63b468e 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
 @@ -2119,6 +2119,16 @@ edp_out: port@1 {

--- a/patch/kernel/archive/rockchip64-6.6/rk3399-sd-drive-level-8ma.patch
+++ b/patch/kernel/archive/rockchip64-6.6/rk3399-sd-drive-level-8ma.patch
@@ -109,10 +109,10 @@ Subject: [ARCHEOLOGY] add better strength on SDCard and put back previous
  1 file changed, 8 insertions(+), 8 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399.dtsi b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-index 9364f495cdeb..7eafff9bdeef 100644
+index 1eb5c63b468e..867a9f893b24 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-@@ -2582,25 +2582,25 @@ sdio0_int: sdio0-int {
+@@ -2592,25 +2592,25 @@ sdio0_int: sdio0-int {
  		sdmmc {
  			sdmmc_bus1: sdmmc-bus1 {
  				rockchip,pins =
@@ -145,7 +145,7 @@ index 9364f495cdeb..7eafff9bdeef 100644
  			};
  
  			sdmmc_cd: sdmmc-cd {
-@@ -2610,7 +2610,7 @@ sdmmc_cd: sdmmc-cd {
+@@ -2620,7 +2620,7 @@ sdmmc_cd: sdmmc-cd {
  
  			sdmmc_wp: sdmmc-wp {
  				rockchip,pins =

--- a/patch/kernel/archive/rockchip64-6.6/rk3399-sd-pwr-pinctrl.patch
+++ b/patch/kernel/archive/rockchip64-6.6/rk3399-sd-pwr-pinctrl.patch
@@ -8,10 +8,10 @@ Subject: rk3399: add sd power pin to pinctrl node
  1 file changed, 5 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399.dtsi b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-index 7eafff9bdeef..b8e847e8aae6 100644
+index 867a9f893b24..76239a58ab0b 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-@@ -2577,6 +2577,11 @@ sdio0_int: sdio0-int {
+@@ -2587,6 +2587,11 @@ sdio0_int: sdio0-int {
  				rockchip,pins =
  					<0 RK_PA4 1 &pcfg_pull_up>;
  			};

--- a/patch/kernel/archive/rockchip64-6.6/rk3399-unlock-temperature.patch
+++ b/patch/kernel/archive/rockchip64-6.6/rk3399-unlock-temperature.patch
@@ -98,7 +98,7 @@ Subject: [ARCHEOLOGY] Increase performance with rk3399-dev
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3399.dtsi b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-index b8e847e8aae6..cde74afa556f 100644
+index 76239a58ab0b..a0441f640791 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
 @@ -858,17 +858,17 @@ cpu_thermal: cpu-thermal {

--- a/patch/kernel/archive/uefi-arm64-6.6/driver-phytium-stmmac-acpi.patch
+++ b/patch/kernel/archive/uefi-arm64-6.6/driver-phytium-stmmac-acpi.patch
@@ -338,7 +338,7 @@ index 000000000000..e6ad44b80a10
 +MODULE_DESCRIPTION("Glue driver for Phytium DWMAC");
 +MODULE_LICENSE("GPL v2");
 diff --git a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-index ed1a5a31a491..17a7c6629b3c 100644
+index 5801f4d50f95..429fd08f11c5 100644
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 @@ -14,6 +14,7 @@


### PR DESCRIPTION
#### meson64 / rockchip64 / uefi / rk3568-odroid: edge 6.6: bump to 6.6.y; rebase patches to v6.6(.0)

- meson64 / rockchip64 / uefi / rk3568-odroid: edge 6.6: bump to 6.6.y; rebase patches to v6.6(.0)