### PR TITLE
Allwinner: bump legacy and current kernels

### DIFF
--- a/config/kernel/linux-sunxi-current.config
+++ b/config/kernel/linux-sunxi-current.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.1.57 Kernel Configuration
+# Linux/arm 6.1.60 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-linux-gnueabihf-gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0"
 CONFIG_CC_IS_GCC=y

--- a/config/kernel/linux-sunxi-legacy.config
+++ b/config/kernel/linux-sunxi-legacy.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 5.15.135 Kernel Configuration
+# Linux/arm 5.15.137 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-linux-gnueabihf-gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0"
 CONFIG_CC_IS_GCC=y

--- a/config/kernel/linux-sunxi64-current.config
+++ b/config/kernel/linux-sunxi64-current.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.1.57 Kernel Configuration
+# Linux/arm64 6.1.60 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0"
 CONFIG_CC_IS_GCC=y

--- a/config/kernel/linux-sunxi64-legacy.config
+++ b/config/kernel/linux-sunxi64-legacy.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.15.135 Kernel Configuration
+# Linux/arm64 5.15.137 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0"
 CONFIG_CC_IS_GCC=y

--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -24,12 +24,12 @@ case $BRANCH in
 
 	legacy)
 		declare -g KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v5.15.135"
+		declare -g KERNELBRANCH="tag:v5.15.137"
 		;;
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.1.57"
+		declare -g KERNELBRANCH="tag:v6.1.60"
 		;;
 
 	edge)

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -25,12 +25,12 @@ case $BRANCH in
 
 	legacy)
 		declare -g KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v5.15.135"
+		declare -g KERNELBRANCH="tag:v5.15.137"
 		;;
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.1.57"
+		declare -g KERNELBRANCH="tag:v6.1.60"
 		;;
 
 	edge)


### PR DESCRIPTION
# Description

Legacy - 5.15.135 -> 5.15.137
Current - 6.1.57 -> 6.1.60

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Both 32-bit and 64-bit Kernel builds
- [X] Booted on Orange Pi Zero, Orange Pi 3-LTS

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
