### PR TITLE
thinkpad-x13s: bump to steev's `lenovo-x13s-linux-6.6.y` (currently 6.6.0)

### DIFF
--- a/config/boards/thinkpad-x13s.wip
+++ b/config/boards/thinkpad-x13s.wip
@@ -30,7 +30,7 @@ declare -g BOARD_FIRMWARE_INSTALL="-full"
 # The 6.4 branch is incompatible with x13s Concept's alsa-ucm-conf package, so keep it at 6.3.y for now. @TODO what about 6.6
 function post_family_config_branch_sc8280xp__steevs_66y_kernel() {
 	declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel.
-	declare -g KERNELBRANCH='branch:lenovo-x13s-v6.6.0-rc5'
+	declare -g KERNELBRANCH='branch:lenovo-x13s-linux-6.6.y'
 	declare -g KERNELSOURCE='https://github.com/steev/linux.git'
 	display_alert "Set up steev's kernel ${KERNELBRANCH} for" "${BOARD}" "info"
 }


### PR DESCRIPTION
#### thinkpad-x13s: bump to steev's `lenovo-x13s-linux-6.6.y` (currently 6.6.0)

- thinkpad-x13s: bump to steev's `lenovo-x13s-linux-6.6.y` (currently 6.6.0)