### PR TITLE
Remove cpufrequtils from trixie as its not / will not be present anymore

### DIFF
--- a/config/cli/common/main/packages
+++ b/config/cli/common/main/packages
@@ -4,6 +4,7 @@ bridge-utils
 chrony
 command-not-found
 console-setup
+cpufrequtils
 cron
 curl
 dbus-user-session

--- a/config/optional/architectures/amd64/_config/cli/_all_distributions/main/packages
+++ b/config/optional/architectures/amd64/_config/cli/_all_distributions/main/packages
@@ -1,3 +1,2 @@
 gpiod
-cpufrequtils
 nocache

--- a/config/optional/architectures/arm64/_config/cli/_all_distributions/main/packages
+++ b/config/optional/architectures/arm64/_config/cli/_all_distributions/main/packages
@@ -1,4 +1,3 @@
 gpiod
-cpufrequtils
 mtd-utils
 nocache

--- a/config/optional/architectures/armhf/_config/cli/_all_distributions/main/packages
+++ b/config/optional/architectures/armhf/_config/cli/_all_distributions/main/packages
@@ -1,4 +1,3 @@
 gpiod
-cpufrequtils
 mtd-utils
 nocache

--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -281,6 +281,8 @@ function do_main_configuration() {
 	declare -g -r PACKAGE_LIST_FAMILY="${PACKAGE_LIST_FAMILY}"
 	declare -g -r PACKAGE_LIST_FAMILY_REMOVE="${PACKAGE_LIST_FAMILY_REMOVE}"
 
+	if [[ $RELEASE == trixie ]]; then remove_packages "cpufrequtils"; fi # this will remove from rootfs as well
+
 	display_alert "Done with do_main_configuration" "do_main_configuration" "debug"
 }
 

--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -281,7 +281,7 @@ function do_main_configuration() {
 	declare -g -r PACKAGE_LIST_FAMILY="${PACKAGE_LIST_FAMILY}"
 	declare -g -r PACKAGE_LIST_FAMILY_REMOVE="${PACKAGE_LIST_FAMILY_REMOVE}"
 
-	if [[ $RELEASE == trixie ]]; then remove_packages "cpufrequtils"; fi # this will remove from rootfs as well
+	if [[ $RELEASE == trixie || $ARCH == riscv64 ]]; then remove_packages "cpufrequtils"; fi # this will remove from rootfs as well
 
 	display_alert "Done with do_main_configuration" "do_main_configuration" "debug"
 }


### PR DESCRIPTION
# Description

- cpufrequtils is due to removal. Its not present in trixie anymore ...
- refactor riscv64 hack

# How Has This Been Tested?

- [x] Build armhf image / rootfs

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
