### PR TITLE
add v4l2 patches to rockchip64 for chromium

### DIFF
--- a/patch/kernel/archive/rockchip64-6.6/media-0001-dma-mapping-let-dma_alloc_noncontiguous-allow-DMA_AT.patch
+++ b/patch/kernel/archive/rockchip64-6.6/media-0001-dma-mapping-let-dma_alloc_noncontiguous-allow-DMA_AT.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: amazingfate <liujianfeng1994@gmail.com>
+Date: Fri, 3 Nov 2023 18:04:43 +0800
+Subject: dma-mapping: let dma_alloc_noncontiguous allow
+ DMA_ATTR_NO_KERNEL_MAPPING
+
+---
+ kernel/dma/mapping.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/kernel/dma/mapping.c b/kernel/dma/mapping.c
+index e323ca48f7f2..2468d0d25ca1 100644
+--- a/kernel/dma/mapping.c
++++ b/kernel/dma/mapping.c
+@@ -649,7 +649,7 @@ struct sg_table *dma_alloc_noncontiguous(struct device *dev, size_t size,
+ 	const struct dma_map_ops *ops = get_dma_ops(dev);
+ 	struct sg_table *sgt;
+ 
+-	if (WARN_ON_ONCE(attrs & ~DMA_ATTR_ALLOC_SINGLE_PAGES))
++	if (WARN_ON_ONCE((attrs & ~DMA_ATTR_ALLOC_SINGLE_PAGES) && (attrs & ~(DMA_ATTR_ALLOC_SINGLE_PAGES | DMA_ATTR_NO_KERNEL_MAPPING))))
+ 		return NULL;
+ 	if (WARN_ON_ONCE(gfp & __GFP_COMP))
+ 		return NULL;
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.6/media-0002-Enable-non-coherent-dst-bufs-for-Hantro-V4L2-driver.patch
+++ b/patch/kernel/archive/rockchip64-6.6/media-0002-Enable-non-coherent-dst-bufs-for-Hantro-V4L2-driver.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: amazingfate <liujianfeng1994@gmail.com>
+Date: Fri, 3 Nov 2023 18:07:04 +0800
+Subject: Enable non-coherent dst bufs for Hantro V4L2 driver
+
+---
+ drivers/media/platform/verisilicon/hantro_drv.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/media/platform/verisilicon/hantro_drv.c b/drivers/media/platform/verisilicon/hantro_drv.c
+index 423fc85d79ee..df093026da52 100644
+--- a/drivers/media/platform/verisilicon/hantro_drv.c
++++ b/drivers/media/platform/verisilicon/hantro_drv.c
+@@ -245,6 +245,7 @@ queue_init(void *priv, struct vb2_queue *src_vq, struct vb2_queue *dst_vq)
+ 	dst_vq->timestamp_flags = V4L2_BUF_FLAG_TIMESTAMP_COPY;
+ 	dst_vq->lock = &ctx->dev->vpu_mutex;
+ 	dst_vq->dev = ctx->dev->v4l2_dev.dev;
++	dst_vq->allow_cache_hints = 1;
+ 
+ 	return vb2_queue_init(dst_vq);
+ }
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.6/media-0003-Enable-non-coherent-dst-bufs-for-Rkvdec-V4L2-driver.patch
+++ b/patch/kernel/archive/rockchip64-6.6/media-0003-Enable-non-coherent-dst-bufs-for-Rkvdec-V4L2-driver.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: amazingfate <liujianfeng1994@gmail.com>
+Date: Fri, 3 Nov 2023 18:07:24 +0800
+Subject: Enable non-coherent dst bufs for Rkvdec V4L2 driver
+
+---
+ drivers/staging/media/rkvdec/rkvdec.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/staging/media/rkvdec/rkvdec.c b/drivers/staging/media/rkvdec/rkvdec.c
+index 84a41792cb4b..b35f7e1b8a20 100644
+--- a/drivers/staging/media/rkvdec/rkvdec.c
++++ b/drivers/staging/media/rkvdec/rkvdec.c
+@@ -755,6 +755,7 @@ static int rkvdec_queue_init(void *priv,
+ 	dst_vq->timestamp_flags = V4L2_BUF_FLAG_TIMESTAMP_COPY;
+ 	dst_vq->lock = &rkvdec->vdev_lock;
+ 	dst_vq->dev = rkvdec->v4l2_dev.dev;
++	dst_vq->allow_cache_hints = 1;
+ 
+ 	return vb2_queue_init(dst_vq);
+ }
+-- 
+Armbian
+


### PR DESCRIPTION
# Description

Add patches as [Justin Green mentioned](https://groups.google.com/a/chromium.org/g/chromium-dev/c/AOPuSQVz9Gs/m/IeuME5eFBAAJ?pli=1) to enable DMA buffer caching on hantro and rkvdec driver. Hantro and rkvdec driver have set `dst_vq->dma_attrs` to `DMA_ATTR_ALLOC_SINGLE_PAGES | DMA_ATTR_NO_KERNEL_MAPPING` and it will not pass [check in `dma_alloc_noncontiguous`](https://github.com/torvalds/linux/blob/v6.6/kernel/dma/mapping.c#L652), so I add a patch to deal with it.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] rockchip64-edge build success
- [x] chromium v4l2 decoder works on orangepi3b.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
