### PR TITLE
Check if kaslrseed exists before running it

### DIFF
--- a/config/bootscripts/boot-rockchip64.cmd
+++ b/config/bootscripts/boot-rockchip64.cmd
@@ -71,7 +71,11 @@ else
 		source ${load_addr}
 	fi
 fi
-kaslrseed
+if command -v kaslrseed > /dev/null 2>&1; then
+	kaslrseed
+else
+	echo "kaslrseed command not found, skipping..."
+fi
 booti ${kernel_addr_r} ${ramdisk_addr_r} ${fdt_addr_r}
 
 # Recompile with:


### PR DESCRIPTION
# Description

In #4352 the `kaslrseed` command is added. This results in "Unknown command ' kaslrseed ' - try 'help'"; but does continue with booting. This is not the cleanest message; rather check for the command before executing.

# How Has This Been Tested?

N/A

- [ ] Test A

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
