### PR TITLE
JetHome: Add dts kernel patch for support onboard eeprom in JetHub D1+

### DIFF
--- a/patch/kernel/archive/meson64-6.1/jethome-0002-arm64-dts-jethub-j1xx-add-eeprom-node.patch
+++ b/patch/kernel/archive/meson64-6.1/jethome-0002-arm64-dts-jethub-j1xx-add-eeprom-node.patch
@@ -1,0 +1,54 @@
+From b2551c258d19c06a8d946338a7f79395f12870c4 Mon Sep 17 00:00:00 2001
+From: Viacheslav Bocharov <adeep@lexina.in>
+Date: Fri, 20 Oct 2023 14:06:58 +0300
+Subject: [PATCH] arm64: dts: jethub-j1xx: add eeprom node
+
+Add node for eeprom on baseboard in JetHub D1+ device
+---
+ .../amlogic/meson-axg-jethome-jethub-j110-rev-2.dts  | 12 ++++++++++++
+ .../amlogic/meson-axg-jethome-jethub-j110-rev-3.dts  | 12 ++++++++++++
+ 2 files changed, 24 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j110-rev-2.dts b/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j110-rev-2.dts
+index 0062667c4f65..140c724c57fb 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j110-rev-2.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j110-rev-2.dts
+@@ -35,3 +35,15 @@ bluetooth {
+ 		device-wake-gpios = <&gpio GPIOZ_6 GPIO_ACTIVE_HIGH>;
+ 	};
+ };
++
++&i2c_AO {
++	/* EEPROM on base board */
++	eeprompd: eeprom@56 {
++                compatible = "atmel,24c64";
++                reg = <0x56>;
++                pagesize = <0x20>;
++		label = "eeprompd";
++		address-width = <0x10>;
++                vcc-supply = <&vddao_3v3>;
++        };
++};
+diff --git a/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j110-rev-3.dts b/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j110-rev-3.dts
+index c2d22b00c1cd..6a5664d908d5 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j110-rev-3.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j110-rev-3.dts
+@@ -25,3 +25,15 @@ memory@0 {
+ &sd_emmc_b {
+ 	broken-cd;/* cd-gpios = <&gpio_ao GPIOAO_3 GPIO_ACTIVE_LOW>;*/
+ };
++
++&i2c_AO {
++	/* EEPROM on base board */
++	eeprompd: eeprom@56 {
++                compatible = "atmel,24c64";
++                reg = <0x56>;
++                pagesize = <0x20>;
++		label = "eeprompd";
++		address-width = <0x10>;
++                vcc-supply = <&vddao_3v3>;
++        };
++};
+-- 
+2.34.1
+

--- a/patch/kernel/archive/meson64-6.6/jethome-0002-arm64-dts-jethub-j1xx-add-eeprom-node.patch
+++ b/patch/kernel/archive/meson64-6.6/jethome-0002-arm64-dts-jethub-j1xx-add-eeprom-node.patch
@@ -1,0 +1,54 @@
+From b2551c258d19c06a8d946338a7f79395f12870c4 Mon Sep 17 00:00:00 2001
+From: Viacheslav Bocharov <adeep@lexina.in>
+Date: Fri, 20 Oct 2023 14:06:58 +0300
+Subject: [PATCH] arm64: dts: jethub-j1xx: add eeprom node
+
+Add node for eeprom on baseboard in JetHub D1+ device
+---
+ .../amlogic/meson-axg-jethome-jethub-j110-rev-2.dts  | 12 ++++++++++++
+ .../amlogic/meson-axg-jethome-jethub-j110-rev-3.dts  | 12 ++++++++++++
+ 2 files changed, 24 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j110-rev-2.dts b/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j110-rev-2.dts
+index 0062667c4f65..140c724c57fb 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j110-rev-2.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j110-rev-2.dts
+@@ -35,3 +35,15 @@ bluetooth {
+ 		device-wake-gpios = <&gpio GPIOZ_6 GPIO_ACTIVE_HIGH>;
+ 	};
+ };
++
++&i2c_AO {
++	/* EEPROM on base board */
++	eeprompd: eeprom@56 {
++                compatible = "atmel,24c64";
++                reg = <0x56>;
++                pagesize = <0x20>;
++		label = "eeprompd";
++		address-width = <0x10>;
++                vcc-supply = <&vddao_3v3>;
++        };
++};
+diff --git a/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j110-rev-3.dts b/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j110-rev-3.dts
+index c2d22b00c1cd..6a5664d908d5 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j110-rev-3.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-axg-jethome-jethub-j110-rev-3.dts
+@@ -25,3 +25,15 @@ memory@0 {
+ &sd_emmc_b {
+ 	broken-cd;/* cd-gpios = <&gpio_ao GPIOAO_3 GPIO_ACTIVE_LOW>;*/
+ };
++
++&i2c_AO {
++	/* EEPROM on base board */
++	eeprompd: eeprom@56 {
++                compatible = "atmel,24c64";
++                reg = <0x56>;
++                pagesize = <0x20>;
++		label = "eeprompd";
++		address-width = <0x10>;
++                vcc-supply = <&vddao_3v3>;
++        };
++};
+-- 
+2.34.1
+


### PR DESCRIPTION
# Description

Add support for onboard eeprom in JetHub D1+ devices.

Jira reference number [AR-1907]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] current/edge build
- [ ] Test B

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
