### PR TITLE
`Automatic` board configs status synchronise

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,6 +51,7 @@ config/boards/mekotronics-r58x.wip		@monkaBlyat
 config/boards/mixtile-blade3.wip		@rpardini
 config/boards/nanopct6.wip		@Tonymac32
 config/boards/nanopi-r4s.conf		@Manouchehri
+config/boards/nanopi-r5s.csc		@utlark
 config/boards/nanopi-r6s.conf		@efectn
 config/boards/nanopiduo.conf		@sgjava
 config/boards/nanopiduo2.conf		@viraniac
@@ -115,7 +116,7 @@ config/kernel/linux-meson64-*.config		@NicoD-SBC @SteeManMI @Tonymac32 @adeepn @
 config/kernel/linux-mvebu-*.config		@Heisath
 config/kernel/linux-mvebu64-*.config		@ManoftheSea
 config/kernel/linux-odroidxu4-*.config		@joekhoobyar
-config/kernel/linux-rk3568-odroid-*.config		@rpardini
+config/kernel/linux-rk3568-odroid-*.config		@rpardini @utlark
 config/kernel/linux-rk35xx-*.config		@Tonymac32 @ZazaBR @amazingfate @catalinii @efectn @igorpecovnik @krachlatte @lanefu @linhz0hz @mahdichi @monkaBlyat @rpardini @sputnik2019 @vamzii
 config/kernel/linux-rockchip-*.config		@paolosabatino
 config/kernel/linux-rockchip-rk3588-*.config		@Tonymac32 @amazingfate @efectn @lanefu @linhz0hz
@@ -135,7 +136,7 @@ patch/kernel/archive/meson-s4t7-*/		@rpardini @viraniac
 patch/kernel/archive/meson64-*/		@NicoD-SBC @SteeManMI @Tonymac32 @adeepn @bretmlw @clee @engineer-80 @igorpecovnik @jeanrhum @monkaBlyat @pyavitz @rpardini @teknoid
 patch/kernel/archive/mvebu-*/		@Heisath
 patch/kernel/archive/odroidxu4-*/		@joekhoobyar
-patch/kernel/archive/rk3568-odroid-*/		@rpardini
+patch/kernel/archive/rk3568-odroid-*/		@rpardini @utlark
 patch/kernel/archive/rk35xx-*/		@Tonymac32 @ZazaBR @amazingfate @catalinii @efectn @igorpecovnik @krachlatte @lanefu @linhz0hz @mahdichi @monkaBlyat @rpardini @sputnik2019 @vamzii
 patch/kernel/archive/rockchip-*/		@paolosabatino
 patch/kernel/archive/rockchip64-*/		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @schwar3kat @vamzii
@@ -172,7 +173,7 @@ sources/families/meson64.conf		@NicoD-SBC @SteeManMI @Tonymac32 @adeepn @bretmlw
 sources/families/mvebu.conf		@Heisath
 sources/families/mvebu64.conf		@ManoftheSea
 sources/families/odroidxu4.conf		@joekhoobyar
-sources/families/rk3568-odroid.conf		@rpardini
+sources/families/rk3568-odroid.conf		@rpardini @utlark
 sources/families/rk35xx.conf		@Tonymac32 @ZazaBR @amazingfate @catalinii @efectn @igorpecovnik @krachlatte @lanefu @linhz0hz @mahdichi @monkaBlyat @rpardini @sputnik2019 @vamzii
 sources/families/rockchip-rk3588.conf		@Tonymac32 @amazingfate @efectn @lanefu @linhz0hz
 sources/families/rockchip.conf		@paolosabatino

--- a/config/boards/nanopi-r5s.csc
+++ b/config/boards/nanopi-r5s.csc
@@ -1,7 +1,7 @@
 # Rockchip RK3568 quad core 4GB eMMC USB3 USB2 1x GbE 2x 2.5GbE NVME
 BOARD_NAME="NanoPi R5S"
 BOARDFAMILY="rk3568-odroid" # Mooching rk3568-odroid family for freshness for now. Uses rockchip64_common for most stuff.
-BOARD_MAINTAINER=""
+BOARD_MAINTAINER="utlark"
 BOOT_SOC="rk3568"
 KERNEL_TARGET="edge"
 BOOT_FDT_FILE="rockchip/rk3568-nanopi-r5s.dtb"


### PR DESCRIPTION
Update maintainers and board status

- synced status from the database
- rename to .`csc` where we don't have anyone

If you want to become a board maintainer, [adjust data here](https://www.armbian.com/update-data/).

Ref: [Board Maintainers Procedures and Guidelines](https://docs.armbian.com/Board_Maintainers_Procedures_and_Guidelines/)