### PR TITLE
sunxi: u-boot: lower DRAM freq for Tritium H5

### DIFF
--- a/patch/u-boot/u-boot-sunxi/allwinner-lower-default-DRAM-freq-A64-H5.patch
+++ b/patch/u-boot/u-boot-sunxi/allwinner-lower-default-DRAM-freq-A64-H5.patch
@@ -11,3 +11,15 @@ index dbe6005daa..41e19ba102 100644
  	default 744 if MACH_SUN50I_H6
  	default 720 if MACH_SUN50I_H616
  	---help---
+diff --git a/configs/libretech_all_h3_cc_h5_defconfig b/configs/libretech_all_h3_cc_h5_defconfig
+index 96274019499..3e25fad73cf 100644
+--- a/configs/libretech_all_h3_cc_h5_defconfig
++++ b/configs/libretech_all_h3_cc_h5_defconfig
+@@ -3,7 +3,6 @@ CONFIG_ARCH_SUNXI=y
+ CONFIG_DEFAULT_DEVICE_TREE="sun50i-h5-libretech-all-h3-cc"
+ CONFIG_SPL=y
+ CONFIG_MACH_SUN50I_H5=y
+-CONFIG_DRAM_CLK=672
+ CONFIG_MMC_SUNXI_SLOT_EXTRA=2
+ # CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
+ CONFIG_SUN8I_EMAC=y


### PR DESCRIPTION
# Description

This tries to lower the DRAM frequency of Tritium H5 like what is done on other H5 boards, because I met stability issues when running Klipper on it.

# How Has This Been Tested?

I built a U-Boot deb and flashed it to my Tritium H5, and the stability enhances.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
