### PR TITLE
rk3588: experimental UEFI edk2 support

### DIFF
--- a/config/boards/hinlink-h88k.csc
+++ b/config/boards/hinlink-h88k.csc
@@ -9,7 +9,8 @@ BOOT_LOGO="desktop"
 BOOT_FDT_FILE="rockchip/rk3588-hinlink-h88k.dtb"
 BOOT_SCENARIO="spl-blobs"
 IMAGE_PARTITION_TABLE="gpt"
-SKIP_BOOTSPLASH="yes" # Skip boot splash patch, conflicts with CONFIG_VT=yes
+SKIP_BOOTSPLASH="yes"                # Skip boot splash patch, conflicts with CONFIG_VT=yes
+declare -g UEFI_EDK2_BOARD_ID="h88k" # This _only_ used for uefi-edk2-rk3588 extension
 
 function post_family_tweaks__hinlink_h88k_naming_audios() {
 	display_alert "$BOARD" "Renaming hinlink-h88k audios" "info"

--- a/config/boards/indiedroid-nova.csc
+++ b/config/boards/indiedroid-nova.csc
@@ -16,6 +16,7 @@ declare -g BOOTFS_TYPE="fat"
 declare -g SRC_EXTLINUX="no" # going back to standard uboot for now
 declare -g BL31_BLOB='rk35/rk3588_bl31_v1.38.elf'
 declare -g DDR_BLOB='rk35/rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.11.bin'
+declare -g UEFI_EDK2_BOARD_ID="indiedroid-nova" # This _only_ used for uefi-edk2-rk3588 extension
 
 ## only applies to extlinux so not used
 declare -g SRC_CMDLINE="console=ttyS0,115200n8 console=tty1 console=both net.ifnames=0 rootflags=data=writeback"

--- a/config/boards/khadas-edge2.conf
+++ b/config/boards/khadas-edge2.conf
@@ -11,6 +11,7 @@ declare -g BLUETOOTH_HCIATTACH_PARAMS="-s 115200 /dev/ttyS9 bcm43xx 1500000" # F
 enable_extension "bluetooth-hciattach"                                       # Enable the bluetooth-hciattach extension
 
 declare -g KHADAS_OOWOW_BOARD_ID="Edge2" # for use with EXT=output-image-oowow
+declare -g UEFI_EDK2_BOARD_ID="edge2"    # This _only_ used for uefi-edk2-rk3588 extension
 
 # for the kedge2, we're counting on the blobs+u-boot in SPI working, as it comes from factory. It does not support bootscripts.
 function post_family_config_branch_legacy__uboot_kedge2() {

--- a/config/boards/mekotronics-r58-minipc.wip
+++ b/config/boards/mekotronics-r58-minipc.wip
@@ -4,6 +4,7 @@ declare -g BOARDFAMILY="rockchip-rk3588"
 declare -g BOARD_MAINTAINER="monkaBlyat"
 declare -g KERNEL_TARGET="legacy"
 declare -g BOOT_FDT_FILE="rockchip/rk3588-blueberry-minipc-linux.dtb" # Specific to this board
+declare -g UEFI_EDK2_BOARD_ID="r58-mini"                              # This _only_ used for uefi-edk2-rk3588 extension
 
 # Source vendor-specific configuration
 source "${SRC}/config/sources/vendors/mekotronics/mekotronics-rk3588.conf.sh"

--- a/config/boards/mekotronics-r58x-4g.wip
+++ b/config/boards/mekotronics-r58x-4g.wip
@@ -4,6 +4,7 @@ declare -g BOARDFAMILY="rockchip-rk3588"
 declare -g BOARD_MAINTAINER="monkaBlyat"
 declare -g KERNEL_TARGET="legacy"
 declare -g BOOT_FDT_FILE="rockchip/rk3588-blueberry-edge-v12-linux.dtb" # Specific to this board
+declare -g UEFI_EDK2_BOARD_ID="r58x"                                    # This _only_ used for uefi-edk2-rk3588 extension
 
 # Source vendor-specific configuration
 source "${SRC}/config/sources/vendors/mekotronics/mekotronics-rk3588.conf.sh"

--- a/config/boards/mekotronics-r58x-pro.csc
+++ b/config/boards/mekotronics-r58x-pro.csc
@@ -4,6 +4,7 @@ declare -g BOARDFAMILY="rockchip-rk3588"
 declare -g BOARD_MAINTAINER=""
 declare -g KERNEL_TARGET="legacy"
 declare -g BOOT_FDT_FILE="rockchip/rk3588-blueberry-edge-v12-maizhuo-linux.dtb" # Specific to this board
+declare -g UEFI_EDK2_BOARD_ID="r58x"                                            # This _only_ used for uefi-edk2-rk3588 extension
 
 # Source vendor-specific configuration
 source "${SRC}/config/sources/vendors/mekotronics/mekotronics-rk3588.conf.sh"

--- a/config/boards/mekotronics-r58x.wip
+++ b/config/boards/mekotronics-r58x.wip
@@ -4,6 +4,7 @@ declare -g BOARDFAMILY="rockchip-rk3588"
 declare -g BOARD_MAINTAINER="monkaBlyat"
 declare -g KERNEL_TARGET="legacy"
 declare -g BOOT_FDT_FILE="rockchip/rk3588-blueberry-edge-v10-linux.dtb" # Specific to this board
+declare -g UEFI_EDK2_BOARD_ID="r58x"                                    # This _only_ used for uefi-edk2-rk3588 extension
 
 # Source vendor-specific configuration
 source "${SRC}/config/sources/vendors/mekotronics/mekotronics-rk3588.conf.sh"

--- a/config/boards/mixtile-blade3.wip
+++ b/config/boards/mixtile-blade3.wip
@@ -9,6 +9,7 @@ declare -g BOOT_SCENARIO="spl-blobs" # so we don't depend on defconfig naming co
 declare -g BOOT_SOC="rk3588"         # so we don't depend on defconfig naming convention
 declare -g BOOTCONFIG="blade3_defconfig"
 declare -g IMAGE_PARTITION_TABLE="gpt"
+declare -g UEFI_EDK2_BOARD_ID="blade3" # This _only_ used for uefi-edk2-rk3588 extension
 
 # newer blobs from rockchip. tested to work.
 # set as variables, early, so they're picked up by `prepare_boot_configuration()`

--- a/config/boards/nanopct6.wip
+++ b/config/boards/nanopct6.wip
@@ -14,12 +14,13 @@ BOOT_SPI_RKSPI_LOADER="yes"
 IMAGE_PARTITION_TABLE="gpt"
 SKIP_BOOTSPLASH="yes" # Skip boot splash patch, conflicts with CONFIG_VT=yes
 BOOTFS_TYPE="fat"
+declare -g UEFI_EDK2_BOARD_ID="nanopc-t6" # This _only_ used for uefi-edk2-rk3588 extension
 
 function post_family_tweaks__nanopct6_naming_audios() {
 	display_alert "$BOARD" "Renaming nanopct6 audio" "info"
 
 	mkdir -p $SDCARD/etc/udev/rules.d/
-	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-hdmi0-sound", ENV{SOUND_DESCRIPTION}="HDMI0 Audio"' >$SDCARD/etc/udev/rules.d/90-naming-audios.rules
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-hdmi0-sound", ENV{SOUND_DESCRIPTION}="HDMI0 Audio"' > $SDCARD/etc/udev/rules.d/90-naming-audios.rules
 
 	return 0
 }

--- a/config/boards/nanopi-r6s.conf
+++ b/config/boards/nanopi-r6s.conf
@@ -14,12 +14,13 @@ SKIP_BOOTSPLASH="yes" # Skip boot splash patch, conflicts with CONFIG_VT=yes
 BOOTFS_TYPE="fat"
 DDR_BLOB='rk35/rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.11.bin'
 BL31_BLOB='rk35/rk3588_bl31_v1.38.elf'
+declare -g UEFI_EDK2_BOARD_ID="nanopi-r6s" # This _only_ used for uefi-edk2-rk3588 extension
 
 function post_family_tweaks__nanopir6s_naming_audios() {
 	display_alert "$BOARD" "Renaming nanopir6s audio" "info"
 
 	mkdir -p $SDCARD/etc/udev/rules.d/
-	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-hdmi0-sound", ENV{SOUND_DESCRIPTION}="HDMI0 Audio"' >$SDCARD/etc/udev/rules.d/90-naming-audios.rules
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-hdmi0-sound", ENV{SOUND_DESCRIPTION}="HDMI0 Audio"' > $SDCARD/etc/udev/rules.d/90-naming-audios.rules
 
 	return 0
 }

--- a/config/boards/orangepi5-plus.conf
+++ b/config/boards/orangepi5-plus.conf
@@ -15,7 +15,7 @@ BOOT_SPI_RKSPI_LOADER="yes"
 IMAGE_PARTITION_TABLE="gpt"
 SKIP_BOOTSPLASH="yes" # Skip boot splash patch, conflicts with CONFIG_VT=yes
 BOOTFS_TYPE="ext4"
-
+declare -g UEFI_EDK2_BOARD_ID="orangepi-5plus" # This _only_ used for uefi-edk2-rk3588 extension
 
 function post_family_tweaks__orangepi5plus_naming_audios() {
 	display_alert "$BOARD" "Renaming orangepi5 audios" "info"

--- a/config/boards/orangepi5.conf
+++ b/config/boards/orangepi5.conf
@@ -18,12 +18,13 @@ SKIP_BOOTSPLASH="yes" # Skip boot splash patch, conflicts with CONFIG_VT=yes
 BOOTFS_TYPE="fat"
 DDR_BLOB='rk35/rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.11.bin'
 BL31_BLOB='rk35/rk3588_bl31_v1.38.elf'
+declare -g UEFI_EDK2_BOARD_ID="orangepi-5" # This _only_ used for uefi-edk2-rk3588 extension
 
 declare -g BLUETOOTH_HCIATTACH_PARAMS="-s 115200 /dev/ttyS9 bcm43xx 1500000" # For the bluetooth-hciattach extension
 enable_extension "bluetooth-hciattach"                                       # Enable the bluetooth-hciattach extension
 
 function post_family_tweaks_bsp__orangepi5_copy_usb2_service() {
-    display_alert "Installing BSP firmware and fixups"
+	display_alert "Installing BSP firmware and fixups"
 
 	# Add USB2 init service. Otherwise, USB2 and TYPE-C won't work by default
 	cp $SRC/packages/bsp/orangepi5/orangepi5-usb2-init.service $destination/lib/systemd/system/
@@ -32,7 +33,7 @@ function post_family_tweaks_bsp__orangepi5_copy_usb2_service() {
 }
 
 function post_family_tweaks__orangepi5_enable_usb2_service() {
-    display_alert "$BOARD" "Installing board tweaks" "info"
+	display_alert "$BOARD" "Installing board tweaks" "info"
 
 	# enable usb2 init service
 	chroot $SDCARD /bin/bash -c "systemctl --no-reload enable orangepi5-usb2-init.service >/dev/null 2>&1"

--- a/config/boards/rock-5a.wip
+++ b/config/boards/rock-5a.wip
@@ -12,7 +12,8 @@ BOOT_SOC="rk3588"
 BOOT_SUPPORT_SPI="yes"
 BOOT_SPI_RKSPI_LOADER="yes"
 IMAGE_PARTITION_TABLE="gpt"
-SKIP_BOOTSPLASH="yes" # Skip boot splash patch, conflicts with CONFIG_VT=yes
+SKIP_BOOTSPLASH="yes"                   # Skip boot splash patch, conflicts with CONFIG_VT=yes
+declare -g UEFI_EDK2_BOARD_ID="rock-5a" # This _only_ used for uefi-edk2-rk3588 extension
 
 function post_family_tweaks__rock5a_naming_audios() {
 	display_alert "$BOARD" "Renaming rock5a audios" "info"

--- a/config/boards/rock-5b.conf
+++ b/config/boards/rock-5b.conf
@@ -14,6 +14,7 @@ BOOT_SPI_RKSPI_LOADER="yes"
 IMAGE_PARTITION_TABLE="gpt"
 SKIP_BOOTSPLASH="yes" # Skip boot splash patch, conflicts with CONFIG_VT=yes
 BOOTFS_TYPE="ext4"
+declare -g UEFI_EDK2_BOARD_ID="rock-5b" # This _only_ used for uefi-edk2-rk3588 extension
 
 function post_family_tweaks__rock5b_naming_audios() {
 	display_alert "$BOARD" "Renaming rock5b audios" "info"

--- a/extensions/initramfs-usb-gadget-ums/init-premount/usb-gadget-ums.sh
+++ b/extensions/initramfs-usb-gadget-ums/init-premount/usb-gadget-ums.sh
@@ -1,0 +1,173 @@
+#!/bin/sh
+
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (c) 2023 Ricardo Pardini <ricardo@pardini.net>
+# This file is a part of the Armbian Build Framework https://github.com/armbian/build/
+
+echo ""
+echo "Armbian initramfs USB Gadget UMS: ums-initramfs.sh starting..."
+
+# First, check if /proc/cmdline contains "ums=yes", otherwise exit
+if ! grep -q "ums=yes" /proc/cmdline; then
+	echo "Armbian initramfs USB Gadget UMS: ums=yes not found in /proc/cmdline, exiting normally."
+	exit 0
+fi
+
+echo "Armbian initramfs USB Gadget UMS: ums=yes found in /proc/cmdline, continuing..."
+sleep 1
+
+deviceinfo_name="Armbian on %%BOARD%%"
+deviceinfo_manufacturer="Armbian on %%BOARD%%"
+usb_idVendor="0x1d6b" # Linux Foundation
+usb_idProduct="0x104" # Multifunction Composite Gadget.
+usb_serialnumber="Armbian %%BOARD%%"
+
+echo "Armbian initramfs USB Gadget UMS: found UDC: $(ls /sys/class/udc) for %%BOARD%%"
+
+modprobe g_ffs || echo "Armbian initramfs USB Gadget UMS: Failed to modprobe g_ffs"
+
+mkdir -p /config
+mount -t configfs -o nodev,noexec,nosuid configfs /config
+
+CONFIGFS=/config/usb_gadget
+GADGET=${CONFIGFS}/g1
+CONFIG=${GADGET}/configs/c.1
+FUNCTIONS=${GADGET}/functions
+
+if [ -d "${GADGET}" ]; then
+	echo "Armbian initramfs USB Gadget UMS: Found existing gadget, removing"
+	echo "" > ${GADGET}/UDC
+
+	rm -v ${CONFIG}/mass_storage.usb*
+
+	rmdir -v ${CONFIG}/strings/0x409
+	rmdir -v ${CONFIG}
+
+	rmdir -v ${FUNCTIONS}/mass_storage.usb*
+
+	rmdir -v ${GADGET}/strings/0x409
+
+	rmdir -v "${GADGET}"
+
+	echo "Done removing gadget"
+
+	if [ -d "${GADGET}" ]; then
+		echo "Gadget still exists... ${GADGET}"
+	fi
+	exit 0
+fi
+
+echo "  Setting up an USB gadget through configfs"
+mkdir ${GADGET} || echo "  Couldn't create ${GADGET}"
+echo "$usb_idVendor" > "${GADGET}/idVendor"
+echo "$usb_idProduct" > "${GADGET}/idProduct"
+
+# Create english (0x409) strings
+mkdir ${GADGET}/strings/0x409 || echo "  Couldn't create ${GADGET}/strings/0x409"
+
+echo "$deviceinfo_manufacturer" > "${GADGET}/strings/0x409/manufacturer"
+echo "$usb_serialnumber" > "${GADGET}/strings/0x409/serialnumber"
+echo "$deviceinfo_name" > "${GADGET}/strings/0x409/product"
+
+# Create configuration instance
+mkdir ${CONFIG} || echo "  Couldn't create ${CONFIG}"
+
+counter=0
+all_devices=""
+
+for one_block in /sys/class/block/*; do
+	partition="${one_block}/partition"
+	if [ -f "$partition" ]; then
+		continue # we don't wanna expose partitions
+	fi
+	size_file="${one_block}/size"
+	if [ ! -f "$size_file" ]; then
+		continue # we don't wanna expose non-block devices
+	fi
+	size=$(cat "$size_file")
+	if [ "$size" -eq 0 ]; then
+		continue # we don't wanna expose zero-sized devices
+	fi
+	# we don't wanna expose devices that smaller than 1Gb (avoids mmcblk0boot0 etc)
+	if [ "$size" -lt 1953125 ]; then
+		continue
+	fi
+
+	ro_file="${one_block}/ro"
+	if [ ! -f "$ro_file" ]; then
+		continue # we don't wanna expose devices that can't tell if they're read-only
+	fi
+	ro=$(cat -v "$ro_file")
+	if [ "$ro" -ne 0 ]; then
+		continue # we don't wanna expose read-only devices
+	fi
+	phys_block_size_file="${one_block}/queue/physical_block_size"
+	if [ ! -f "$phys_block_size_file" ]; then
+		continue # we don't wanna expose devices that can't tell us their physical block size
+	fi
+	phys_block_size=$(cat "$phys_block_size_file")
+	if [ "$phys_block_size" -ne 512 ]; then
+		continue # we don't wanna expose devices that don't have a 512-byte physical block size
+	fi
+
+	# lets guess the real device name...
+	basename_device=$(basename "$one_block")
+	device_in_dash_dev="/dev/${basename_device}"
+	if [ ! -b "$device_in_dash_dev" ]; then
+		continue # we don't wanna expose devices that don't have a /dev/ entry
+	fi
+
+	description="Armbian${counter} ${basename_device}"
+
+	model_file="${one_block}/device/model"
+	if [ -f "$model_file" ]; then
+		model=$(cat "$model_file")
+		model=$(echo "$model" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+		description="${description} ${model}"
+	fi
+
+	# hack, skip this
+	#if [ "$basename_device" = "mmcblk0" ]; then
+	#	continue
+	#fi
+
+	echo "one block [${counter}]: $one_block one_block: $one_block size: ${size} ro: ${ro} phys_block_size: ${phys_block_size} basename_device: ${basename_device} device_in_dash_dev: ${device_in_dash_dev} model: '${model}' description: '${description}'"
+
+	# add to all_devices
+	all_devices="${all_devices} '${counter}:${description}' "
+
+	# increment counter
+	counter=$((counter + 1))
+
+	echo "Create Mass Storage device ${counter} for ${device_in_dash_dev} desc '${description}'"
+	MASS_STORAGE_FUNCTION="${FUNCTIONS}/mass_storage.usb${counter}"
+	mkdir -p "${MASS_STORAGE_FUNCTION}" || echo "  Couldn't create ${MASS_STORAGE_FUNCTION}"
+	echo 1 > "${MASS_STORAGE_FUNCTION}"/stall       # allow bulk EPs
+	echo 0 > "${MASS_STORAGE_FUNCTION}"/lun.0/cdrom # don't emulate CD-ROm
+	#echo 0 > "${MASS_STORAGE_FUNCTION}"/ro          # write access - disabled for now
+	echo 0 > "${MASS_STORAGE_FUNCTION}"/lun.0/nofua # enable Force Unit Access (FUA)
+	echo 0 > "${MASS_STORAGE_FUNCTION}"/lun.0/removable
+	echo "${description}" > "${MASS_STORAGE_FUNCTION}"/lun.0/inquiry_string
+	echo "${device_in_dash_dev}" > "${MASS_STORAGE_FUNCTION}"/lun.0/file
+
+	# Link the function to the config
+	ln -s "${MASS_STORAGE_FUNCTION}" "${CONFIG}" || echo "  Couldn't symlink mass_storage.usb${counter}"
+
+done
+
+echo "Done creating functions and configs, enabling UDC.."
+
+echo "$(ls /sys/class/udc)" > ${GADGET}/UDC || echo "  Couldn't write UDC"
+
+#umount /config
+
+echo "Armbian initramfs USB Gadget UMS: done USB Gadget mode."
+
+while true; do
+	echo "Armbian initramfs USB Gadget UMS: Board: %%BOARD%%"
+	echo "Armbian initramfs USB Gadget UMS: Machine will hang here forever; connect your USB OTG cable and write to disks!"
+	echo "Armbian initramfs USB Gadget UMS: UMS devices: ${all_devices}"
+	echo "Armbian initramfs USB Gadget UMS: UMS UDC: $(ls /sys/class/udc)"
+	echo "Armbian initramfs USB Gadget UMS: Now: $(date)"
+	sleep 30
+done

--- a/extensions/initramfs-usb-gadget-ums/initramfs-usb-gadget-ums.sh
+++ b/extensions/initramfs-usb-gadget-ums/initramfs-usb-gadget-ums.sh
@@ -1,0 +1,31 @@
+#
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (c) 2023 Ricardo Pardini <ricardo@pardini.net>
+# This file is a part of the Armbian Build Framework https://github.com/armbian/build/
+
+# This includes a very early script in the initramfs, which checks the kernel command line
+# for the presence of "ums=yes", and if found, sets up a USB gadget for UMS (USB Mass Storage)
+# exposing all the block devices found in the system.
+# After setting this up, it loops forever, so the initramfs doesn't proceed to boot the system.
+# This allows the user to connect the board to a host computer, and use it as a USB storage device,
+# to flash the eMMC/SD/NVMe/USB/whatever storage device simply using BalenaEtcher or similar tools.
+
+function extension_prepare_config__check_sanity_usb_gadget_ums() {
+	display_alert "Checking sanity for" "${EXTENSION} in dir ${EXTENSION_DIR}" "info"
+	local script_file_src="${EXTENSION_DIR}/init-premount/usb-gadget-ums.sh"
+	if [[ ! -f "${script_file_src}" ]]; then
+		exit_with_error "Could not find '${script_file_src}'"
+	fi
+}
+
+
+# @TODO: maybe include this in the bsp-cli, so it can be updated later
+function pre_customize_image__inject_initramfs_usb_gadget_ums() {
+	display_alert "Enabling" "usb-gadget-ums into initramfs" "info"
+	local script_file_src="${EXTENSION_DIR}/init-premount/usb-gadget-ums.sh"
+	local script_file_dst="${SDCARD}/etc/initramfs-tools/scripts/init-premount/usb-gadget-ums.sh"
+	run_host_command_logged cat "${script_file_src}" "|" sed -e "'s|%%BOARD%%|${BOARD}|g'" ">" "${script_file_dst}"
+	run_host_command_logged chmod -v +x "${script_file_dst}"
+	return 0
+}
+

--- a/extensions/uefi-edk2-rk3588.sh
+++ b/extensions/uefi-edk2-rk3588.sh
@@ -1,0 +1,76 @@
+#
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (c) 2023 Ricardo Pardini <ricardo@pardini.net>
+# This file is a part of the Armbian Build Framework https://github.com/armbian/build/
+
+enable_extension "grub-with-dtb"
+enable_extension "initramfs-usb-gadget-ums"
+
+function extension_prepare_config__config_uefi_edk2_rk3588() {
+	display_alert "Configuring UEFI EDK2 for RK3588" "${BOARD} - edk2 '${UEFI_EDK2_BOARD_ID}'" "info"
+
+	declare -g GRUB_CMDLINE_LINUX_DEFAULT="${GRUB_CMDLINE_LINUX_DEFAULT:-"acpi=off"}" # default to acpi=off
+	declare -g UEFI_GRUB_TIMEOUT=${UEFI_GRUB_TIMEOUT:-3}                              # Default 3-seconds timeout for GRUB menu.
+	declare -g UEFI_GRUB_TERMINAL="gfxterm serial console"                            # gfxterm is a long shot.
+
+	# Check that UEFI_EDK2_BOARD_ID is set, or bomb
+	if [[ -z "${UEFI_EDK2_BOARD_ID}" ]]; then
+		exit_with_error "UEFI_EDK2_BOARD_ID is not set. Please set it to the correct value for your board."
+	fi
+
+	# Check that the image is a GPT image.
+	if [[ "${IMAGE_PARTITION_TABLE}" != "gpt" ]]; then
+		display_alert "Changing partition table to GPT" "original image partition table was ${IMAGE_PARTITION_TABLE}" "warn"
+		declare -g IMAGE_PARTITION_TABLE="gpt"
+	fi
+
+	# If BOOTFS_TYPE is set, warn and unset it.
+	if [[ -n "${BOOTFS_TYPE}" ]]; then
+		display_alert "Unsetting BOOTFS_TYPE" "UEFI EDK2 requires BOOTFS_TYPE to be unset, but is set to '${BOOTFS_TYPE}'" "warn"
+		unset BOOTFS_TYPE
+	fi
+
+	# Add a suffix to the image version, so people know what is is in it.
+	EXTRA_IMAGE_SUFFIXES+=("-edk2")
+
+	return 0
+}
+
+# This writes the edk2 img to the image, hopefully without destroying the GPT. See https://github.com/edk2-porting/edk2-rk3588#updating-the-firmware
+function post_umount_final_image__write_edk2_to_image() {
+	display_alert "Finding edk2 latest version" "from GitHub" "info"
+
+	# Find the latest version of edk2-porting from GitHub, using JSON API, curl and jq.
+	declare api_url="https://api.github.com/repos/edk2-porting/edk2-rk3588/releases/latest"
+	declare latest_version
+	latest_version=$(curl -s "${api_url}" | jq -r '.tag_name')
+	display_alert "Latest version of edk2-porting is" "${latest_version}" "info"
+
+	# Prepare the cache dir
+	declare edk2_cache_dir="${SRC}/cache/edk2-rk3588"
+	mkdir -p "${edk2_cache_dir}"
+
+	declare edk2_img_filename="${UEFI_EDK2_BOARD_ID}_UEFI_Release_${latest_version}.img"
+	declare -g -r edk2_img_path="${edk2_cache_dir}/${edk2_img_filename}" # global readonly
+	display_alert "UEFI EDK2 image path" "${edk2_img_path}" "info"
+
+	declare download_url="https://github.com/edk2-porting/edk2-rk3588/releases/download/${latest_version}/${edk2_img_filename}"
+
+	# Download the image (with wget) if it doesn't exist; download to a temporary file first, then move to the final path.
+	if [[ ! -f "${edk2_img_path}" ]]; then
+		display_alert "Downloading UEFI EDK2 image" "${download_url}" "info"
+		declare tmp_edk2_img_path="${edk2_img_path}.tmp"
+		run_host_command_logged wget -O "${tmp_edk2_img_path}" "${download_url}"
+		run_host_command_logged mv -v "${tmp_edk2_img_path}" "${edk2_img_path}"
+	else
+		display_alert "UEFI EDK2 image already downloaded, using it" "${edk2_img_path}" "info"
+	fi
+
+	display_alert " Writing UEFI EDK2 image" "${edk2_img_path} to ${LOOP}" "info"
+	# Write the whole uefi image, but skip the GPT...
+	dd if="${edk2_img_path}" of="${LOOP}" bs=512 conv=notrunc skip=64 seek=64
+
+	# ... Use parted to create "uboot" GPT partition pointing to the FIT image, so SPL finds it
+	display_alert "Creating uboot partition" "on ${LOOP}" "info"
+	/sbin/parted -s "${LOOP}" unit s mkpart uboot 2048 18431
+}

--- a/lib/functions/general/extensions.sh
+++ b/lib/functions/general/extensions.sh
@@ -505,7 +505,9 @@ function enable_extension() {
 
 	# iterate over defined functions, store them in global associative array extension_function_info
 	for newly_defined_function in ${new_function_list}; do
-		#echo "func: ${newly_defined_function} has DIR: ${extension_dir}"
+		# Check if "${newly_defined_function}" is already defined in the extension_function_info array, if not, add it
+		# This is to address the recursive case messing up references
+		[[ -v extension_function_info["${newly_defined_function}"] ]] && continue
 		extension_function_info["${newly_defined_function}"]="EXTENSION=\"${extension_name}\" EXTENSION_DIR=\"${extension_dir}\" EXTENSION_FILE=\"${extension_file}\" EXTENSION_ADDED_BY=\"${stacktrace}\""
 	done
 

--- a/packages/blobs/grub/09_linux_with_dtb.sh
+++ b/packages/blobs/grub/09_linux_with_dtb.sh
@@ -503,6 +503,10 @@ while [ "x$list" != "x" ]; do
 			"${GRUB_CMDLINE_LINUX_RECOVERY} ${GRUB_CMDLINE_LINUX}"
 	fi
 
+	if [ -f /etc/initramfs-tools/scripts/init-premount/usb-gadget-ums.sh ]; then
+		linux_entry "${OS}" "${version}" init-ums "initrd=ums ums=yes ${GRUB_CMDLINE_LINUX}"
+	fi
+
 	list=$(echo $list | tr ' ' '\n' | fgrep -vx "$linux" | tr '\n' ' ')
 done
 


### PR DESCRIPTION
#### rk3588: experimental UEFI edk2 support

- core extensions: fix: don't redefine extension_function_info when recursing
  - otherwise when there's a chain of enable_extension() we lose the original info
- extensions: `grub-with-dtb`: add UMS menu entry to GRUB if initramfs ums hook is detected
  - this allows user to enter UMS mode from GRUB
  - for usage with the `initramfs-usb-gadget-ums` extension
  - has no effect unless `initramfs-usb-gadget-ums` extension is enabled together with `grub-with-dtb`
- extensions: `initramfs-usb-gadget-ums`: kernel cmdline enables initramfs UMS of all block devices
  - this optional extension adds an initramfs script that:
    - enumerates and filters all block devices
    - exposes each device as an UMS (USB Mass Storage) in an USB Gadget
    - loops forever with info (board never boots)
  - the idea here is to compensate for UEFI's lack of "ums" or "rockusb" mode that's present in u-boot
  - it also allows to expose USB/NVMe devices that might or not be detected by bootloader, if the kernel works
- extensions: `uefi-edk2-rk3588`: deploy edk2 (not u-boot) for rk3588 boards
  - this extension is _100% optional_ and shouldn't adversely affect any builds if not enabled
  - requires `UEFI_EDK2_BOARD_ID` to be set in board file, so we know which UEFI/edk2 build to use
  - it finds the latest edk2 version from GitHub automatically (currently `v0.9.1`)
  - it downloads (and caches) the correct edk2 build image automatically
  - if forces certain aspects of the image:
    - must use GPT partitioning
    - must NOT use a separate /boot partition
  - it _disables_ the building and deploying of u-boot _completely_ (thus blobs etc are from edk2)
  - it creates a GPT `"uboot"` partition pointing to edk2's FIT, required by SPL
  - this extension:
    - automatically enables 'grub-with-dtb'
    - automatically enable 'initramfs-usb-gadget-ums', to compensate for lack of ums/rockusb since we dont have u-boot anymore
- rk3588: configure UEFI_EDK2_BOARD_ID for all UEFI-supported boards
  - From https://github.com/edk2-porting/edk2-rk3588/releases/tag/v0.9.1
    - For example, for `rock-5b_UEFI_Release_v0.9.1.img`
      - `UEFI_EDK2_BOARD_ID` is `rock-5b`
  - **Important**: this has no effect unless optional extension is enabled
  - to test this out:
    - make sure to read carefully the instructions at https://github.com/edk2-porting/edk2-rk3588/blob/master/README.md
    - suppose you previously built the regular u-boot version with:
      - `./compile.sh BOARD=rock-5b BRANCH=legacy RELEASE=jammy`
    - now you can build the UEFI version with:
      - `./compile.sh BOARD=rock-5b BRANCH=legacy RELEASE=jammy EXT=uefi-edk2-rk3588`
    - write the produced image to SD or eMMC and boot it
    - use normally, or enter "UMS" mode by selecting that option in the grub menu
      - You can write image to eMMC, boot it, enter UMS, write it again to NVMe, reboot, press <ESC> in UEFI and boot from NVMe
      - Also works if .img is written to eg USB stick, and UEFI edk2 is separately deployed to SPI flash
  - **Important**: make _absolutely_ sure you are able to force Maskrom mode (by shorting pins, pressing buttons, etc) before writing an UEFI image to eMMC; UEFI has no RockUSB ("Loader mode" support) at all. The new "initramfs-usb-gadget-ums" extension hopes to address this, but it is not guaranteed to work.