### PR TITLE
vim3: blacklist simpledrm kernel module, as it conflicts with panfrost

### DIFF
--- a/config/boards/khadas-vim3.conf
+++ b/config/boards/khadas-vim3.conf
@@ -4,6 +4,7 @@ BOARDFAMILY="meson-g12b"
 BOARD_MAINTAINER="rpardini NicoD-SBC"
 BOOTCONFIG="khadas-vim3_defconfig"
 KERNEL_TARGET="current,edge"
+MODULES_BLACKLIST="simpledrm" # SimpleDRM conflicts with Panfrost on the VIM3
 FULL_DESKTOP="yes"
 SERIALCON="ttyAML0"
 BOOT_LOGO="desktop"


### PR DESCRIPTION
# Description

Some high-resolution monitors (QHD/4K) will not output the desktop, and will enter sleep mode, directly after booting up an Armbian 23.8.1 desktop image and completing the initial setup questions.

When such a monitor is attached, the kernel will auto-detect the SimpleDRM graphics driver, which is then prioritized over the Panfrost graphics driver. However, SimpleDRM outputs to a virtual output, while Panfrost outputs to the actual HDMI port. This causes the monitor to not receive any data.

By blacklisting the `simpledrm` kernel module, Panfrost will take care of accelerated graphics (for any monitor) by default. Advanced users can still access `simpledrm` if required.

Jira reference number [[AR-1908](https://armbian.atlassian.net/jira/software/c/projects/AR/issues/AR-1908)]

# How Has This Been Tested?

An Armbian image with a Cinnamon desktop has been build using the default options. That image has been written to a SD-card and tested on both a QHD monitor (that had the initial problem) and an older Full HD monitor (that worked fine before as well). In both test cases, the `simpledrm` kernel module was not loaded. The desktop was visible on the HDMI output both on initial boot and after subsequent reboots.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [N/A] Any dependent changes have been merged and published in downstream modules


[AR-1908]: https://armbian.atlassian.net/browse/AR-1908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ