### PR TITLE
Orange Pi R1 Plus LTS 6.1/6.6 longer boot time net tweak.

### DIFF
--- a/config/boards/orangepi-r1plus-lts.conf
+++ b/config/boards/orangepi-r1plus-lts.conf
@@ -57,17 +57,17 @@ if [[ $BRANCH == legacy ]]; then
 
 fi
 
-# add a network rule to work-around Debian issues with two NICs on one network.
-display_alert "Creating board support network rename rule to work-around Debian issues for orangepi-r1-plus-lts"
+# add a network rule to work-around RTL8153B initialization issue.
+display_alert "Creating board support network rename rule to work-around RTL8153B initialization issue for orangepi-r1-plus-lts"
 mkdir -p "${destination}"/etc/udev/rules.d/
 cat <<- EOF > "${destination}"/etc/udev/rules.d/70-rename-lan.rules
     SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", KERNEL=="end*", NAME="eth0"
 	SUBSYSTEM=="net", ACTION=="add", DRIVERS=="r8152", KERNEL=="e*", NAME="lan0", \
 	RUN+="/usr/sbin/ip link set lan0 down", \
 	RUN+="/usr/sbin/ip link set eth0 down", \
-	RUN+="/usr/bin/sleep 7s ", \
+	RUN+="/usr/bin/sleep 5s ", \
 	RUN+="/usr/sbin/ip link set eth0 up", \
-	RUN+="/usr/bin/sleep 11s ", \
+	RUN+="/usr/bin/sleep 25s ", \
 	RUN+="/usr/sbin/ip link set lan0 up"
 EOF
 }


### PR DESCRIPTION
# Description
RTL8153B - does not initialize correctly on boot.  Reboot is okay.
Start delay work-around in the board file needs tweaking for longer boot time.

Jira reference number [AR-1910]

# How Has This Been Tested?
- [x] Kernel 6.1y tested on Orange Pi R1 Plus LTS 
- [x] Kernel 6.6y tested on Orange Pi R1 Plus LTS 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1910]: https://armbian.atlassian.net/browse/AR-1910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ