### PR TITLE
bootscript: meson-s4t7: fix booting on ubuntu

### DIFF
--- a/config/bootscripts/boot-meson-s4t7.cmd
+++ b/config/bootscripts/boot-meson-s4t7.cmd
@@ -88,8 +88,15 @@ else
 	fi
 fi
 
-load ${devtype} ${devnum} ${kernel_addr_r} /vmlinuz
-load ${devtype} ${devnum} ${ramdisk_addr_r} /initrd.img
+# The symlinks for kernel and initrd.img are at different locations in debian and ubuntu
+# Check and load from a location that exists
+if test -e ${devtype} ${devnum} /vmlinuz; then
+	load ${devtype} ${devnum} ${kernel_addr_r} /vmlinuz
+	load ${devtype} ${devnum} ${ramdisk_addr_r} /initrd.img
+else
+	load ${devtype} ${devnum} ${kernel_addr_r} ${prefix}vmlinuz
+	load ${devtype} ${devnum} ${ramdisk_addr_r} ${prefix}initrd.img
+fi
 booti ${kernel_addr_r} ${ramdisk_addr_r}:${filesize} ${fdt_addr_r}
 
 # Recompile with:


### PR DESCRIPTION
# Description

I thought display is broken on ubuntu images for meson-t4s7 (vim4 and vim1s), but turns out we fail to load the kernel and initrd as the symlinks are in different location on ubuntu (inside /boot) and debian (inside /).  Fixing the bootscript to allow booting on the ubuntu image as well.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Wiped emmc so that we won't fall back to it. Created and booted ubuntu and debian image from sdcard on vim4. Both booted fine and display worked fine as well.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
