### PR TITLE
Move Makefile section from patch

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -691,6 +691,10 @@ driver_rtl8723cs() {
 	fi
 
 	if linux-version compare "${version}" ge 6.1; then
+
+                # Add to section Makefile
+                echo "obj-\$(CONFIG_RTL8723CS)                += rtl8723cs/" >> "$kerneldir/drivers/net/wireless/Makefile"
+
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/8723cs-Add-a-new-driver-v5.12.2-7-g2de5ec386.20201013_beta.patch" "applying"
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/8723cs-Make-the-driver-compile-and-probe-drop-rockchip-platform.patch" "applying"
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/8723cs-Enable-OOB-interrupt.patch" "applying"


### PR DESCRIPTION
# Description

There are many changes in this file and its impossible to cover this with a patch for now current and all kernels back We are using same hack in UWE drivers.

This fixes compilation breaking for kernel 6.7.y

# How Has This Been Tested?

- [x] Patch test
- [x] Build test