### PR TITLE
For getting a PR SHA, action needs to be executed from PR

### DIFF
--- a/.github/workflows/build-artifacts-pr.yml
+++ b/.github/workflows/build-artifacts-pr.yml
@@ -1,12 +1,12 @@
 name: Generate artifacts on PR
 #
-# If you comment "/build" to the PR comment this action will run compilation on PR
+# Limited If you comment "/build" to the PR comment this action will run compilation on PR
 # but only if you are a member of "Release manager" team. As additional security feature
 #
 
 on:
-  issue_comment:
-    types: [created]
+  pull_request:
+    types: [opened, reopened, edited, synchronize, review_requested]
   workflow_dispatch:
 
 concurrency:
@@ -19,8 +19,9 @@ jobs:
     permissions:
       pull-requests: read
 
-    name: "Permission to run compilation"
-    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/build')
+    name: "Verify if compilation can be executed"
+    if: |
+      contains(github.event.issue.labels.*.name, 'Build')
     runs-on: Linux
     outputs:
       member: ${{ steps.checkUserMember.outputs.isTeamMember }}

--- a/.github/workflows/build-artifacts-pr.yml
+++ b/.github/workflows/build-artifacts-pr.yml
@@ -1,13 +1,11 @@
 name: Generate artifacts on PR
 #
-# Limited If you comment "/build" to the PR comment this action will run compilation on PR
-# but only if you are a member of "Release manager" team. As additional security feature
+# If PR is labeled with "Build" and you are a member of "Release manager" team it will start (additional security feature)
 #
 
 on:
   pull_request:
-    types: [opened, reopened, edited, synchronize, review_requested]
-  workflow_dispatch:
+    types: [opened, reopened, edited, synchronize, review_requested, labeled]
 
 concurrency:
   group: pipeline-pr-${{github.event.pull_request.number}}
@@ -19,9 +17,8 @@ jobs:
     permissions:
       pull-requests: read
 
-    name: "Verify if compilation can be executed"
-    if: |
-      contains(github.event.issue.labels.*.name, 'Build')
+    name: "verify if compilation can be executed"
+    if: contains(github.event.pull_request.labels.*.name, 'Build')
     runs-on: Linux
     outputs:
       member: ${{ steps.checkUserMember.outputs.isTeamMember }}


### PR DESCRIPTION
# Description

Bug fixes for Action scripts. For getting a PR SHA, action needs to be executed from PR. Triggering with label "Build" also seems to be a better way of handling this. If submitter doesn't have rights, its skipped.