### PR TITLE
Fixing wrong Makefile location when adjusting wireless driver rtl8723cs

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -693,7 +693,7 @@ driver_rtl8723cs() {
 	if linux-version compare "${version}" ge 6.1; then
 
                 # Add to section Makefile
-                echo "obj-\$(CONFIG_RTL8723CS)                += rtl8723cs/" >> "$kerneldir/drivers/net/wireless/Makefile"
+                echo "obj-\$(CONFIG_RTL8723CS)                += rtl8723cs/" >> "$kerneldir/drivers/staging/Makefile"
 
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/8723cs-Add-a-new-driver-v5.12.2-7-g2de5ec386.20201013_beta.patch" "applying"
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/8723cs-Make-the-driver-compile-and-probe-drop-rockchip-platform.patch" "applying"


### PR DESCRIPTION
# Description

Copy / paste error fix. https://github.com/armbian/build/pull/5909
