### PR TITLE
Add a patch that breaks compilation of wifi driver 8723ds on a kernel 6.6

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -511,7 +511,7 @@ driver_rtl8723DS() {
 	if linux-version compare "${version}" ge 5.0; then
 
 		# attach to specifics tag or branch
-		local rtl8723dsver="branch:master"
+		local rtl8723dsver="commit:d89bde02d0d10d1d6b264392d99a3ea65d7b132c"
 
 		display_alert "Adding" "Wireless drivers for Realtek 8723DS chipsets ${rtl8723dsver}" "info"
 
@@ -544,6 +544,8 @@ driver_rtl8723DS() {
 
 		# fix compilation for kernels >= 5.4
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723ds-Fix-VFS-import.patch" "applying"
+		# fix compilation for kernels >= 6.7
+		process_patch_file "${SRC}/patch/misc/wireless-rtl8723ds-6.7.patch" "applying"
 	fi
 }
 

--- a/patch/misc/wireless-rtl8723ds-6.7.patch
+++ b/patch/misc/wireless-rtl8723ds-6.7.patch
@@ -1,0 +1,22 @@
+From 2906e202e84c05abeb480e94a93d5ae52d9ae3c2 Mon Sep 17 00:00:00 2001
+From: Jookia <contact@jookia.org>
+Date: Tue, 14 Nov 2023 22:18:15 +1100
+Subject: [PATCH] Fix version check for change_beacon it should be 6.7
+
+---
+ drivers/net/wireless/rtl8723ds/os_dep/linux/ioctl_cfg80211.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/wireless/rtl8723ds/os_dep/linux/ioctl_cfg80211.c b/drivers/net/wireless/rtl8723ds/os_dep/linux/ioctl_cfg80211.c
+index 3d07daf..53ccef4 100644
+--- a/drivers/net/wireless/rtl8723ds/os_dep/linux/ioctl_cfg80211.c
++++ b/drivers/net/wireless/rtl8723ds/os_dep/linux/ioctl_cfg80211.c
+@@ -4188,7 +4188,7 @@ static int cfg80211_rtw_start_ap(struct wiphy *wiphy, struct net_device *ndev,
+ 	return ret;
+ }
+ 
+-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0))
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0))
+ static int cfg80211_rtw_change_beacon(struct wiphy *wiphy, struct net_device *ndev,
+ 		struct cfg80211_ap_update *params)
+ {


### PR DESCRIPTION
# Description

As per title + attach sources to commit ID

# How Has This Been Tested?

- [x] Build test

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
