### PR TITLE
kernel: sunxi: disable patch that prevents host mode on otg port

### DIFF
--- a/patch/kernel/archive/sunxi-6.1/series.conf
+++ b/patch/kernel/archive/sunxi-6.1/series.conf
@@ -114,7 +114,7 @@
 	patches.megous/arm64-dts-sun50i-a64-pinephone-Add-mount-matrix-for-PinePhone-m.patch
 	patches.megous/arm64-dts-sun50i-a64-pinephone-Add-support-for-Pinephone-keyboa.patch
 	patches.megous/arm64-dts-sun50i-a64-pinephone-Enable-Pinephone-Keyboard-power-.patch
-	patches.megous/usb-musb-sunxi-Avoid-enabling-host-side-code-on-SoCs-where-it-s.patch
+-	patches.megous/usb-musb-sunxi-Avoid-enabling-host-side-code-on-SoCs-where-it-s.patch
 	patches.megous/arm64-dts-sun50i-a64-Add-missing-trip-points-for-GPU.patch
 	patches.megous/arm64-dts-allwinner-sun50i-a64-pinephone-Add-support-for-Pineph.patch
 -	patches.megous/8723cs-Add-a-new-driver-v5.12.2-7-g2de5ec386.20201013_beta.patch

--- a/patch/kernel/archive/sunxi-6.1/series.megous
+++ b/patch/kernel/archive/sunxi-6.1/series.megous
@@ -114,7 +114,7 @@
 	patches.megous/arm64-dts-sun50i-a64-pinephone-Add-mount-matrix-for-PinePhone-m.patch
 	patches.megous/arm64-dts-sun50i-a64-pinephone-Add-support-for-Pinephone-keyboa.patch
 	patches.megous/arm64-dts-sun50i-a64-pinephone-Enable-Pinephone-Keyboard-power-.patch
-	patches.megous/usb-musb-sunxi-Avoid-enabling-host-side-code-on-SoCs-where-it-s.patch
+-	patches.megous/usb-musb-sunxi-Avoid-enabling-host-side-code-on-SoCs-where-it-s.patch
 	patches.megous/arm64-dts-sun50i-a64-Add-missing-trip-points-for-GPU.patch
 	patches.megous/arm64-dts-allwinner-sun50i-a64-pinephone-Add-support-for-Pineph.patch
 -	patches.megous/8723cs-Add-a-new-driver-v5.12.2-7-g2de5ec386.20201013_beta.patch

--- a/patch/kernel/archive/sunxi-6.6/series.conf
+++ b/patch/kernel/archive/sunxi-6.6/series.conf
@@ -185,7 +185,7 @@
 	patches.megous/arm64-dts-sun50i-a64-pinephone-Add-mount-matrix-for-PinePhone-m.patch
 	patches.megous/arm64-dts-sun50i-a64-pinephone-Add-support-for-Pinephone-keyboa.patch
 	patches.megous/arm64-dts-sun50i-a64-pinephone-Enable-Pinephone-Keyboard-power-.patch
-	patches.megous/usb-musb-sunxi-Avoid-enabling-host-side-code-on-SoCs-where-it-s.patch
+-	patches.megous/usb-musb-sunxi-Avoid-enabling-host-side-code-on-SoCs-where-it-s.patch
 	patches.megous/arm64-dts-sun50i-a64-Add-missing-trip-points-for-GPU.patch
 	patches.megous/arm64-dts-allwinner-sun50i-a64-pinephone-Add-support-for-Pineph.patch
 -	patches.megous/Revert-input-goodix-Don-t-disable-regulators-during-suspend.patch

--- a/patch/kernel/archive/sunxi-6.6/series.megous
+++ b/patch/kernel/archive/sunxi-6.6/series.megous
@@ -185,7 +185,7 @@
 	patches.megous/arm64-dts-sun50i-a64-pinephone-Add-mount-matrix-for-PinePhone-m.patch
 	patches.megous/arm64-dts-sun50i-a64-pinephone-Add-support-for-Pinephone-keyboa.patch
 	patches.megous/arm64-dts-sun50i-a64-pinephone-Enable-Pinephone-Keyboard-power-.patch
-	patches.megous/usb-musb-sunxi-Avoid-enabling-host-side-code-on-SoCs-where-it-s.patch
+-	patches.megous/usb-musb-sunxi-Avoid-enabling-host-side-code-on-SoCs-where-it-s.patch
 	patches.megous/arm64-dts-sun50i-a64-Add-missing-trip-points-for-GPU.patch
 	patches.megous/arm64-dts-allwinner-sun50i-a64-pinephone-Add-support-for-Pineph.patch
 -	patches.megous/Revert-input-goodix-Don-t-disable-regulators-during-suspend.patch


### PR DESCRIPTION
# Description

A lot of people has been asking on the forums for host mode not working on the otg port in 6.1+ kernel. It seems to be caused by `patches.megous/usb-musb-sunxi-Avoid-enabling-host-side-code-on-SoCs-where-it-s.patch`. The patch claims to solve sleep issue (rtcwake not working) on pinephone. As we don't support pinephone, I don't see any issue disabling the same.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested host mode works on otg port on Orange Pi Zero (H3) and NanoPi Duo2 (H3)
- [X] Tested rtcwake continues to work on NanoPi Duo2 (H3), Orange Pi Prime (H5) and Orange Pi 3 LTS (H6)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
