### PR TITLE
tritium-h5: Change to using Armbian default DRAM CLK value using hook

### DIFF
--- a/config/boards/tritium-h5.conf
+++ b/config/boards/tritium-h5.conf
@@ -9,3 +9,9 @@ SERIALCON="ttyS0,ttyGS0"
 KERNEL_TARGET="legacy,current,edge"
 FULL_DESKTOP="yes"
 CRUSTCONFIG="h5_defconfig"
+
+function post_config_uboot_target__lower_DRAM_freq_for_Tritium_H5() {
+	display_alert "$BOARD" "The defconfig file of Tritium H5 explicitly defines DRAM_CLK as 672." "info"
+	display_alert "$BOARD" "Change to match default value used for H5 SoC in Armbian" "info"
+	run_host_command_logged scripts/config --set-val CONFIG_DRAM_CLK "648"
+}


### PR DESCRIPTION
# Description

Converting #5898 to use hook instead of patch

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] U-boot compiles. Also .config shows 648 as the default dram clk value.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
