### PR TITLE
`Automatic` board configs status synchronise

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -70,6 +70,7 @@ config/boards/orangepi5.conf		@efectn
 config/boards/orangepione.conf		@StephenGraf
 config/boards/orangepipc.conf		@lbmendes
 config/boards/orangepiprime.conf		@viraniac
+config/boards/orangepizero.conf		@viraniac
 config/boards/orangepizero2.conf		@AGM1968 @krachlatte
 config/boards/orangepizeroplus.conf		@schwar3kat
 config/boards/pine64.conf		@PanderMusubi @joshaspinall


### PR DESCRIPTION
Update maintainers and board status

- synced status from the database
- rename to .`csc` where we don't have anyone

If you want to become a board maintainer, [adjust data here](https://www.armbian.com/update-data/).

Ref: [Board Maintainers Procedures and Guidelines](https://docs.armbian.com/Board_Maintainers_Procedures_and_Guidelines/)