### PR TITLE
Keep the VENDOR in motd after the update

### DIFF
--- a/lib/functions/bsp/armbian-bsp-cli-deb.sh
+++ b/lib/functions/bsp/armbian-bsp-cli-deb.sh
@@ -108,7 +108,6 @@ function compile_armbian-bsp-cli() {
 		VENDORURL="$VENDORURL"
 		VENDORSUPPORT="$VENDORSUPPORT"
 		VENDORBUGS="$VENDORBUGS"
-
 	EOF
 
 	# copy general overlay from packages/bsp-cli

--- a/packages/bsp/common/etc/update-motd.d/10-armbian-header
+++ b/packages/bsp/common/etc/update-motd.d/10-armbian-header
@@ -12,7 +12,16 @@
 THIS_SCRIPT="header"
 MOTD_DISABLE=""
 
+# Read image configuration
+[[ -f /etc/armbian-image-release ]] && . /etc/armbian-image-release
+VENDORTEMP="${VENDOR}"
+
+# Read update configuration
 [[ -f /etc/armbian-release ]] && . /etc/armbian-release
+
+# Keep the VENDOR from image if its defined there
+[[ -n "${VENDORTEMP}" && "${VENDORTEMP}" != "${VENDOR}" ]] && VENDOR="${VENDORTEMP}"
+
 if [[ -f /etc/armbian-distribution-status ]]; then
 	. /etc/armbian-distribution-status
 	[[ -f /etc/lsb-release ]] && DISTRIBUTION_CODENAME=$(grep CODENAME /etc/lsb-release | cut -d"=" -f2)


### PR DESCRIPTION
# Description

On images with changed vendor, when update comes from Armbian repository, VENDOR is overwritten. This change keeps the VENDOR variable from image.

# How Has This Been Tested?

- [x] Manual run

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
