### PR TITLE
`Automatic` board configs status synchronise

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,7 @@ tools/			@iav @neheb @hzyitc @mhoffrog
 config/boards/aml-s9xx-box.tvb		@SteeManMI
 config/boards/bananapi.csc		@DylanHP
 config/boards/bananapicm4io.conf		@pyavitz
+config/boards/bananapim2pro.csc		@bretmlw
 config/boards/bananapim2s.conf		@jeanrhum @pyavitz
 config/boards/bananapim3.conf		@AaronNGray
 config/boards/bananapim5.conf		@bretmlw

--- a/config/boards/bananapim2pro.csc
+++ b/config/boards/bananapim2pro.csc
@@ -1,7 +1,7 @@
 # Amlogic S905X3 quad core 2-4GB RAM SoC eMMC GBE USB3 SPI Wifi
 BOARD_NAME="Banana Pi M2Pro"
 BOARDFAMILY="meson-sm1"
-BOARD_MAINTAINER=""
+BOARD_MAINTAINER="bretmlw"
 BOOTCONFIG="bananapi-m2-pro_defconfig"
 BOOT_FDT_FILE="amlogic/meson-sm1-bananapi-m2-pro.dtb"
 KERNEL_TARGET="current,edge"


### PR DESCRIPTION
Update maintainers and board status

- synced status from the database
- rename to .`csc` where we don't have anyone

If you want to become a board maintainer, [adjust data here](https://www.armbian.com/update-data/).

Ref: [Board Maintainers Procedures and Guidelines](https://docs.armbian.com/Board_Maintainers_Procedures_and_Guidelines/)