### PR TITLE
`Automatic` board configs status synchronise

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,27 +19,27 @@ tools/			@iav @neheb @hzyitc @mhoffrog
 config/boards/aml-s9xx-box.tvb		@SteeManMI
 config/boards/bananapi.csc		@DylanHP
 config/boards/bananapicm4io.conf		@pyavitz
-config/boards/bananapim2pro.csc		@bretmlw
+config/boards/bananapim2pro.conf		@bretmlw
 config/boards/bananapim2s.conf		@jeanrhum @pyavitz
-config/boards/bananapim3.conf		@AaronNGray
+config/boards/bananapim3.csc		@AaronNGray
 config/boards/bananapim5.conf		@bretmlw
-config/boards/bananapim64.conf		@devdotnetorg
+config/boards/bananapim64.csc		@devdotnetorg
 config/boards/bigtreetech-cb1.conf		@bigtreetech
-config/boards/espressobin.conf		@ManoftheSea
-config/boards/firefly-rk3399.conf		@150balbes
+config/boards/espressobin.csc		@ManoftheSea
+config/boards/firefly-rk3399.csc		@150balbes
 config/boards/fxblox-rk1.wip		@mahdichi
 config/boards/hinlink-h28k.csc		@sputnik2019
 config/boards/indiedroid-nova.csc		@lanefu
 config/boards/jethubj100.conf		@adeepn
 config/boards/jethubj80.conf		@adeepn
-config/boards/jetson-nano.conf		@150balbes
+config/boards/jetson-nano.csc		@150balbes
 config/boards/khadas-edge2.conf		@igorpecovnik
 config/boards/khadas-vim1.conf		@igorpecovnik
-config/boards/khadas-vim1s.wip		@rpardini @viraniac
+config/boards/khadas-vim1s.conf		@rpardini @viraniac
 config/boards/khadas-vim2.conf		@igorpecovnik
 config/boards/khadas-vim3.conf		@NicoD-SBC @rpardini
 config/boards/khadas-vim3l.conf		@rpardini
-config/boards/khadas-vim4.wip		@echatzip @rpardini @viraniac
+config/boards/khadas-vim4.conf		@echatzip @rpardini @viraniac
 config/boards/lafrite.conf		@Tonymac32
 config/boards/lepotato.conf		@Tonymac32
 config/boards/licheepi-4a.wip		@chainsx
@@ -49,12 +49,12 @@ config/boards/mekotronics-r58x.wip		@monkaBlyat
 config/boards/mixtile-blade3.wip		@rpardini
 config/boards/nanopct6.wip		@Tonymac32
 config/boards/nanopi-r4s.conf		@Manouchehri
-config/boards/nanopi-r5s.csc		@utlark
+config/boards/nanopi-r5s.wip		@utlark
 config/boards/nanopi-r6s.conf		@efectn
 config/boards/nanopiair.csc		@1ubuntuuser
 config/boards/nanopiduo.conf		@sgjava
 config/boards/nanopiduo2.conf		@viraniac
-config/boards/nanopineoplus2.conf		@teknoid
+config/boards/nanopineoplus2.csc		@teknoid
 config/boards/odroidc2.conf		@teknoid
 config/boards/odroidm1.wip		@rpardini
 config/boards/odroidn2.csc		@NicoD-SBC
@@ -64,17 +64,17 @@ config/boards/onecloud.conf		@hzyitc
 config/boards/orangepi-r1.conf		@schwar3kat
 config/boards/orangepi-r1plus-lts.conf		@schwar3kat
 config/boards/orangepi4-lts.conf		@paolosabatino
-config/boards/orangepi4.conf		@paolosabatino
+config/boards/orangepi4.csc		@paolosabatino
 config/boards/orangepi5-plus.conf		@efectn
 config/boards/orangepi5.conf		@efectn
 config/boards/orangepione.conf		@StephenGraf
-config/boards/orangepipc.conf		@lbmendes
+config/boards/orangepipc.csc		@lbmendes
 config/boards/orangepiprime.conf		@viraniac
 config/boards/orangepizero.conf		@viraniac
 config/boards/orangepizero2.conf		@AGM1968 @krachlatte
 config/boards/orangepizeroplus.conf		@schwar3kat
 config/boards/pine64.conf		@PanderMusubi @joshaspinall
-config/boards/pine64so.conf		@joshaspinall
+config/boards/pine64so.csc		@joshaspinall
 config/boards/pinebook-pro.conf		@TRSx80 @ahoneybun
 config/boards/qemu-uboot-arm64.wip		@rpardini
 config/boards/qemu-uboot-x86.wip		@rpardini
@@ -86,20 +86,20 @@ config/boards/renegade.conf		@Tonymac32
 config/boards/rock-3a.conf		@ZazaBR @amazingfate @catalinii @vamzii
 config/boards/rock-5a.wip		@amazingfate
 config/boards/rock-5b.conf		@amazingfate @linhz0hz
-config/boards/rock64.conf		@clee
+config/boards/rock64.csc		@clee
 config/boards/rockpi-4a.conf		@clee
 config/boards/rockpi-e.conf		@krachlatte
-config/boards/rockpi-s.conf		@brentr
+config/boards/rockpi-s.csc		@brentr
 config/boards/rockpro64.conf		@joekhoobyar
 config/boards/rpi4b.conf		@PanderMusubi @teknoid
 config/boards/sk-am62b.conf		@glneo
 config/boards/sk-am64b.conf		@glneo
 config/boards/sk-tda4vm.conf		@glneo
-config/boards/station-m1.conf		@150balbes
-config/boards/station-m2.conf		@150balbes
-config/boards/station-m3.conf		@150balbes
-config/boards/station-p1.conf		@150balbes
-config/boards/station-p2.conf		@150balbes
+config/boards/station-m1.csc		@150balbes
+config/boards/station-m2.csc		@150balbes
+config/boards/station-m3.csc		@150balbes
+config/boards/station-p1.csc		@150balbes
+config/boards/station-p2.csc		@150balbes
 config/boards/thinkpad-x13s.wip		@rpardini
 config/boards/tinkerboard.conf		@paolosabatino
 config/boards/tritium-h3.conf		@Tonymac32
@@ -127,10 +127,9 @@ config/kernel/linux-sun50iw9-btt-*.config		@bigtreetech
 config/kernel/linux-sunxi-*.config		@1ubuntuuser @AaronNGray @DylanHP @StephenGraf @Tonymac32 @lbmendes @schwar3kat @sgjava @viraniac
 config/kernel/linux-sunxi64-*.config		@AGM1968 @Kreyren @PanderMusubi @Tonymac32 @bigtreetech @devdotnetorg @eliasbakken @joshaspinall @krachlatte @schwar3kat @teknoid @viraniac
 config/kernel/linux-thead-*.config		@chainsx
-config/kernel/linux-uefi-arm64-*.config		@rpardini
+config/kernel/linux-uefi-arm64-*.config		@150balbes @rpardini
 config/kernel/linux-uefi-x86-*.config		@rpardini
 patch/kernel/NEED-*/		@bigtreetech
-patch/kernel/archive/bcm2711-*/		@PanderMusubi @teknoid
 patch/kernel/archive/meson-*/		@hzyitc
 patch/kernel/archive/meson-s4t7-*/		@echatzip @rpardini @viraniac
 patch/kernel/archive/meson64-*/		@NicoD-SBC @SteeManMI @Tonymac32 @adeepn @bretmlw @clee @engineer-80 @igorpecovnik @jeanrhum @monkaBlyat @pyavitz @rpardini @teknoid
@@ -143,7 +142,7 @@ patch/kernel/archive/rockpis-*/		@brentr
 patch/kernel/archive/sm8250-*/		@amazingfate
 patch/kernel/archive/sun50iw9-*/		@AGM1968 @krachlatte
 patch/kernel/archive/sunxi-*/		@1ubuntuuser @AGM1968 @AaronNGray @DylanHP @Kreyren @PanderMusubi @StephenGraf @Tonymac32 @bigtreetech @devdotnetorg @eliasbakken @joshaspinall @krachlatte @lbmendes @schwar3kat @sgjava @teknoid @viraniac
-patch/kernel/archive/uefi-arm64-*/		@rpardini
+patch/kernel/archive/uefi-arm64-*/		@150balbes @rpardini
 patch/kernel/arm64-*/		@amazingfate @rpardini
 patch/kernel/bcm2711-*/		@PanderMusubi @teknoid
 patch/kernel/k3-*/		@glneo
@@ -159,9 +158,9 @@ patch/kernel/rockchip64-*/		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @
 patch/kernel/rockpis-*/		@brentr
 patch/kernel/sun50iw9-*/		@AGM1968 @krachlatte
 patch/kernel/thead-*/		@chainsx
-patch/kernel/uefi-arm64-*/		@rpardini
+patch/kernel/uefi-arm64-*/		@150balbes @rpardini
 patch/kernel/uefi-x86-*/		@rpardini
-sources/families/arm64.conf		@amazingfate @rpardini
+sources/families/arm64.conf		@150balbes @amazingfate @rpardini
 sources/families/bcm2711.conf		@PanderMusubi @teknoid
 sources/families/k3.conf		@glneo
 sources/families/media.conf		@150balbes


### PR DESCRIPTION
Update maintainers and board status

- synced status from the database
- rename to .`csc` where we don't have anyone

If you want to become a board maintainer, [adjust data here](https://www.armbian.com/update-data/).

Ref: [Board Maintainers Procedures and Guidelines](https://docs.armbian.com/Board_Maintainers_Procedures_and_Guidelines/)