### PR TITLE
patch: misc: rtw88: 6.1: `6.1.63 fixups`

### DIFF
--- a/patch/misc/rtw88/6.1/001-drivers-net-wireless-realtek-rtw88-upstream-wireless.patch
+++ b/patch/misc/rtw88/6.1/001-drivers-net-wireless-realtek-rtw88-upstream-wireless.patch
@@ -1,6 +1,6 @@
-From 9255e64129b3bdeec16e17645b4e7a793f73b586 Mon Sep 17 00:00:00 2001
+From 38fa9757a42c9f5e94ecc17888c7a8e1f87339df Mon Sep 17 00:00:00 2001
 From: Patrick Yavitz <pyavitz@xxxxx.com>
-Date: Sun, 8 Oct 2023 09:41:11 -0400
+Date: Mon, 20 Nov 2023 06:27:29 -0500
 Subject: [PATCH] drivers: net: wireless: realtek: rtw88: upstream wireless
 
 wireless-next: 2023-10-06: backport: linux-6.1.y
@@ -11,7 +11,7 @@ Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
  drivers/net/wireless/realtek/rtw88/Makefile   |   30 +
  drivers/net/wireless/realtek/rtw88/bf.c       |   13 +-
  drivers/net/wireless/realtek/rtw88/coex.c     |    3 +-
- drivers/net/wireless/realtek/rtw88/debug.c    |   78 +-
+ drivers/net/wireless/realtek/rtw88/debug.c    |   74 +-
  drivers/net/wireless/realtek/rtw88/debug.h    |    1 +
  drivers/net/wireless/realtek/rtw88/fw.c       |  121 +-
  drivers/net/wireless/realtek/rtw88/fw.h       |   26 +-
@@ -50,7 +50,7 @@ Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
  drivers/net/wireless/realtek/rtw88/util.c     |  100 ++
  drivers/net/wireless/realtek/rtw88/util.h     |   11 +-
  include/linux/mmc/sdio_ids.h                  |   10 +
- 43 files changed, 4162 insertions(+), 277 deletions(-)
+ 43 files changed, 4160 insertions(+), 275 deletions(-)
  create mode 100644 drivers/net/wireless/realtek/rtw88/rtw8723ds.c
  create mode 100644 drivers/net/wireless/realtek/rtw88/rtw8723du.c
  create mode 100644 drivers/net/wireless/realtek/rtw88/rtw8821cs.c
@@ -326,7 +326,7 @@ index a82476f47a7c..86467d2f8888 100644
  }
  
 diff --git a/drivers/net/wireless/realtek/rtw88/debug.c b/drivers/net/wireless/realtek/rtw88/debug.c
-index 9ebe544e51d0..35bc37a3c469 100644
+index abd750c3c28e..35bc37a3c469 100644
 --- a/drivers/net/wireless/realtek/rtw88/debug.c
 +++ b/drivers/net/wireless/realtek/rtw88/debug.c
 @@ -144,7 +144,9 @@ static int rtw_debugfs_get_rf_read(struct seq_file *m, void *v)
@@ -561,18 +561,6 @@ index 9ebe544e51d0..35bc37a3c469 100644
  }
  
  static int rtw_debugfs_get_dm_cap(struct seq_file *m, void *v)
-@@ -1191,9 +1233,9 @@ static struct rtw_debugfs_priv rtw_debug_priv_dm_cap = {
- #define rtw_debugfs_add_core(name, mode, fopname, parent)		\
- 	do {								\
- 		rtw_debug_priv_ ##name.rtwdev = rtwdev;			\
--		if (!debugfs_create_file(#name, mode,			\
-+		if (IS_ERR(debugfs_create_file(#name, mode,		\
- 					 parent, &rtw_debug_priv_ ##name,\
--					 &file_ops_ ##fopname))		\
-+					 &file_ops_ ##fopname)))	\
- 			pr_debug("Unable to initialize debugfs:%s\n",	\
- 			       #name);					\
- 	} while (0)
 diff --git a/drivers/net/wireless/realtek/rtw88/debug.h b/drivers/net/wireless/realtek/rtw88/debug.h
 index 066792dd96af..a9149c6c2b48 100644
 --- a/drivers/net/wireless/realtek/rtw88/debug.h
@@ -6172,6 +6160,7 @@ index 74f9d9a6d330..f30a4e564754 100644
  #define SDIO_DEVICE_ID_SIANO_NICE		0x0202
 -- 
 2.39.2
+
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From:   Martin Blumenstingl <martin.blumenstingl@googlemail.com>


### PR DESCRIPTION
A small section of `drivers/net/wireless/realtek/rtw88/debug.c` was backported into `6.1.63`. The PR updates the patch to reflect the change.

https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/diff/drivers/net/wireless/realtek/rtw88/debug.c?id=v6.1.63&id2=v6.1.62

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
