### PR TITLE
Allwinner: bump legacy, current and edge kernels

### DIFF
--- a/config/kernel/linux-sunxi-current.config
+++ b/config/kernel/linux-sunxi-current.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.1.60 Kernel Configuration
+# Linux/arm 6.1.63 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-linux-gnueabihf-gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0"
 CONFIG_CC_IS_GCC=y

--- a/config/kernel/linux-sunxi-edge.config
+++ b/config/kernel/linux-sunxi-edge.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.6.0 Kernel Configuration
+# Linux/arm 6.6.2 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-linux-gnueabihf-gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0"
 CONFIG_CC_IS_GCC=y

--- a/config/kernel/linux-sunxi-legacy.config
+++ b/config/kernel/linux-sunxi-legacy.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 5.15.137 Kernel Configuration
+# Linux/arm 5.15.139 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-linux-gnueabihf-gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0"
 CONFIG_CC_IS_GCC=y

--- a/config/kernel/linux-sunxi64-current.config
+++ b/config/kernel/linux-sunxi64-current.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.1.60 Kernel Configuration
+# Linux/arm64 6.1.63 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0"
 CONFIG_CC_IS_GCC=y

--- a/config/kernel/linux-sunxi64-edge.config
+++ b/config/kernel/linux-sunxi64-edge.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.6.0 Kernel Configuration
+# Linux/arm64 6.6.2 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0"
 CONFIG_CC_IS_GCC=y

--- a/config/kernel/linux-sunxi64-legacy.config
+++ b/config/kernel/linux-sunxi64-legacy.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.15.137 Kernel Configuration
+# Linux/arm64 5.15.139 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0"
 CONFIG_CC_IS_GCC=y

--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -24,17 +24,17 @@ case $BRANCH in
 
 	legacy)
 		declare -g KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v5.15.137"
+		declare -g KERNELBRANCH="tag:v5.15.139"
 		;;
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.1.62"
+		declare -g KERNELBRANCH="tag:v6.1.63"
 		;;
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.6.1"
+		declare -g KERNELBRANCH="tag:v6.6.2"
 		;;
 esac
 

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -25,17 +25,17 @@ case $BRANCH in
 
 	legacy)
 		declare -g KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v5.15.137"
+		declare -g KERNELBRANCH="tag:v5.15.139"
 		;;
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.1.62"
+		declare -g KERNELBRANCH="tag:v6.1.63"
 		;;
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.6.1"
+		declare -g KERNELBRANCH="tag:v6.6.2"
 		;;
 esac
 

--- a/patch/kernel/archive/sunxi-6.1/patches.megous/media-ov5640-Fix-sensor-probe-with-the-anti-click-patch.patch
+++ b/patch/kernel/archive/sunxi-6.1/patches.megous/media-ov5640-Fix-sensor-probe-with-the-anti-click-patch.patch
@@ -22,7 +22,7 @@ index 86c9ec111b80..47524fdc94f7 100644
 -	ret = ov5640_sensor_resume(dev);
 -	if (ret) {
 -		dev_err(dev, "failed to power on\n");
--		goto entity_cleanup;
+-		goto free_ctrls;
 -	}
 -
 -	pm_runtime_get_noresume(dev);

--- a/patch/kernel/archive/sunxi-6.6/patches.megous/media-ov5640-Don-t-powerup-the-sensor-during-driver-probe.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.megous/media-ov5640-Don-t-powerup-the-sensor-during-driver-probe.patch
@@ -67,14 +67,14 @@ index 44643687f467..2b0878468394 100644
  static int ov5640_probe(struct i2c_client *client)
  {
  	struct device *dev = &client->dev;
-@@ -3934,36 +3920,18 @@ static int ov5640_probe(struct i2c_client *client)
+@@ -3934,36 +3920,17 @@ static int ov5640_probe(struct i2c_client *client)
  	if (ret)
  		goto entity_cleanup;
  
 -	ret = ov5640_sensor_resume(dev);
 -	if (ret) {
 -		dev_err(dev, "failed to power on\n");
--		goto entity_cleanup;
+-		goto free_ctrls;
 -	}
 -
 -	pm_runtime_set_active(dev);
@@ -88,7 +88,7 @@ index 44643687f467..2b0878468394 100644
  	ret = v4l2_async_register_subdev_sensor(&sensor->sd);
  	if (ret)
 -		goto err_pm_runtime;
-+		goto err_controls;
++		goto free_ctrls;
  
 +	pm_runtime_enable(dev);
  	pm_runtime_set_autosuspend_delay(dev, 1000);
@@ -101,9 +101,9 @@ index 44643687f467..2b0878468394 100644
 -err_pm_runtime:
 -	pm_runtime_put_noidle(dev);
 -	pm_runtime_disable(dev);
-+err_controls:
- 	v4l2_ctrl_handler_free(&sensor->ctrls.handler);
 -	ov5640_sensor_suspend(dev);
+ free_ctrls:
+ 	v4l2_ctrl_handler_free(&sensor->ctrls.handler);
  entity_cleanup:
  	media_entity_cleanup(&sensor->sd.entity);
  	mutex_destroy(&sensor->lock);

--- a/patch/kernel/archive/sunxi-6.6/patches.megous/media-ov5640-Improve-error-reporting.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.megous/media-ov5640-Improve-error-reporting.patch
@@ -33,7 +33,7 @@ index b624153dc057..4ccd92b728d8 100644
 -	if (ret)
 +	if (ret) {
 +		dev_err_probe(dev, ret, "Failed to register sensor\n");
- 		goto err_controls;
+ 		goto free_ctrls;
 +	}
  
  	pm_runtime_enable(dev);


### PR DESCRIPTION
# Description

Bumped Allwinner kernels. 

legacy - 5.15.137 -> 5.15.139
current - 6.1.62 -> 6.1.63
edge - 6.6.1 -> 6.6.2

Updated ov5640 camera patches to fix patch application failure. Also rebased the config files. 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Both 32-bit and 64-bit kernel builds fine. 
- [X] Tested 32-bit kernel on NanoPi Duo2(H3). All 3 kernels seems to work fine.
- [X] Tested ov5640 camera with current and edge kernels. Autofocus didn't worked for me, but its possible that I might have damaged my camera by placing something on it. Have to retest with an older kernel later to make sure. But video capture worked fine.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
