### PR TITLE
use GHPROXY_ADDRESS to customize ghproxy url

### DIFF
--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -218,7 +218,8 @@ function do_main_configuration() {
 			GITHUB_SOURCE='https://hub.fastgit.xyz'
 			;;
 		ghproxy)
-			GITHUB_SOURCE='https://ghproxy.com/https://github.com'
+			[[ -z $GHPROXY_ADDRESS ]] && GHPROXY_ADDRESS=ghproxy.com
+			GITHUB_SOURCE="https://${GHPROXY_ADDRESS}/https://github.com"
 			;;
 		gitclone)
 			GITHUB_SOURCE='https://gitclone.com/github.com'

--- a/lib/functions/general/git-ref2info.sh
+++ b/lib/functions/general/git-ref2info.sh
@@ -44,7 +44,7 @@ function memoized_git_ref_to_info() {
 					"ghproxy")
 						case "${MEMO_DICT[GIT_SOURCE]}" in
 							"https://github.com/"*)
-								sha1="$(git ls-remote --exit-code "https://ghproxy.com/${MEMO_DICT[GIT_SOURCE]}" "${to_try}" | cut -f1)"
+								sha1="$(git ls-remote --exit-code "https://${GHPROXY_ADDRESS}/${MEMO_DICT[GIT_SOURCE]}" "${to_try}" | cut -f1)"
 								;;
 							*)
 								sha1="$(git ls-remote --exit-code "${MEMO_DICT[GIT_SOURCE]}" "${to_try}" | cut -f1)"
@@ -106,7 +106,7 @@ function memoized_git_ref_to_info() {
 					org_and_repo="${org_and_repo%.git}" # remove .git if present
 					case "${GITHUB_MIRROR}" in
 						"ghproxy")
-							url="https://ghproxy.com/https://raw.githubusercontent.com/${org_and_repo}/${sha1}/Makefile"
+							url="https://${GHPROXY_ADDRESS}/https://raw.githubusercontent.com/${org_and_repo}/${sha1}/Makefile"
 							;;
 						*)
 							url="https://raw.githubusercontent.com/${org_and_repo}/${sha1}/Makefile"


### PR DESCRIPTION
# Description

Sadly ghproxy.com is down. But this site is based on https://github.com/hunshcn/gh-proxy and has many candidates. I did create one with a cloudflare accout: `gitboost.haguro.workers.dev`. So add `GHPROXY_ADDRESS` to let user choose their own proxy url. Default url is still ghproxy.com if `GHPROXY_ADDRESS` is not set.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] build with extra args `GITHUB_MIRROR=ghproxy GHPROXY_ADDRESS=gitboost.haguro.workers.dev`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
