### PR TITLE
VIM1S/VIM4: Add bluetooth support

### DIFF
--- a/config/boards/khadas-vim1s.wip
+++ b/config/boards/khadas-vim1s.wip
@@ -19,3 +19,10 @@ function image_specific_armbian_env_ready__set_vim1s_specific_parameters() {
     run_host_command_logged echo "earlycon=on" >>${SDCARD}/boot/armbianEnv.txt
     run_host_command_logged echo "extraboardargs=meson-gx-mmc.caps2_quirks=mmc-hs400" >>${SDCARD}/boot/armbianEnv.txt
 }
+
+function post_family_tweaks_bsp__populate_etc_firmware() {
+	# The hciattach command needs firmware to be placed in /etc/firmware directory.
+	# Populate the same.
+	run_host_command_logged mkdir -p "${destination}"/etc/firmware/brcm
+	run_host_command_logged ln -sf /lib/firmware/brcm/BCM4345C5.hcd "${destination}"/etc/firmware/brcm/BCM4345C5.hcd
+}

--- a/config/boards/khadas-vim4.wip
+++ b/config/boards/khadas-vim4.wip
@@ -32,3 +32,11 @@ function post_family_tweaks_bsp__enable_fan_service() {
 		run_host_command_logged ln -sf /etc/systemd/system/fan.service "${destination}"/etc/systemd/system/mutli-user.target.wants/fan.service
 	fi
 }
+
+function post_family_tweaks_bsp__use_correct_bluetooth_firmware() {
+	# We already had a BCM4362A2.hcd file, but that was not compatible with vim4.
+	# Hence added vim4 compatible file in armbian/firmare and adding symlink to
+	# make sure that is used on vim4
+	run_host_command_logged mkdir -p "${destination}"/etc/firmware/brcm
+	run_host_command_logged ln -sf /lib/firmware/brcm/BCM4362A2-khadas-vim4.hcd "${destination}"/etc/firmware/brcm/BCM4362A2.hcd
+}

--- a/config/sources/families/meson-s4t7.conf
+++ b/config/sources/families/meson-s4t7.conf
@@ -8,6 +8,9 @@ declare -g LINUXFAMILY="meson-s4t7"
 declare -g ARCH="arm64"
 declare -g ATF_COMPILE="no"
 
+declare -g BLUETOOTH_HCIATTACH_PARAMS="-s 115200 /dev/ttyS1 bcm43xx 2000000" # For the bluetooth-hciattach extension
+enable_extension "bluetooth-hciattach"                                       # Enable the bluetooth-hciattach extension
+
 # Determine kernel
 case $BRANCH in
 


### PR DESCRIPTION
# Description

Add bluetooth support for Khadas VIM1S and VIM4. 

Jira reference number [AR-1917]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested scanning for nearby bluetooth devices works on VIM1S
- [X] Tested scanning for nearby bluetooth devices works on VIM4

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules


[AR-1917]: https://armbian.atlassian.net/browse/AR-1917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ