### PR TITLE
We don't need to restart kernel recompilation upon PR text changes

### DIFF
--- a/.github/workflows/build-artifacts-pr.yml
+++ b/.github/workflows/build-artifacts-pr.yml
@@ -5,7 +5,7 @@ name: Generate artifacts on PR
 
 on:
   pull_request:
-    types: [opened, reopened, edited, synchronize, review_requested, labeled]
+    types: [opened, reopened, synchronize, review_requested, labeled]
 
 concurrency:
   group: pipeline-pr-${{github.event.pull_request.number}}


### PR DESCRIPTION
# Description

As per tittle.

# How Has This Been Tested?

Changing action execution defaults. Not needed.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings