### PR TITLE
pr-size-labeler: add permissions to fix failure

### DIFF
--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -6,6 +6,9 @@ on:
 jobs:
 
   size-label:
+    permissions:
+      contents: read  # to determine modified files
+      pull-requests: write  # to add labels to PRs
     runs-on: ubuntu-latest
     steps:
       - name: size-label


### PR DESCRIPTION
# Description

The size labeler is failing on PRs. Adding permissions to fix the same.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
