### PR TITLE
board: licheepi-4a: disable audio auto buffer

### DIFF
--- a/config/boards/licheepi-4a.wip
+++ b/config/boards/licheepi-4a.wip
@@ -5,7 +5,7 @@ BOARD_MAINTAINER="chainsx"
 KERNEL_TARGET="legacy,edge"
 BOOT_FDT_FILE="thead/th1520-lichee-pi-4a.dtb"
 SRC_EXTLINUX="yes"
-SRC_CMDLINE="console=ttyS0,115200 rootwait rw earlycon clk_ignore_unused loglevel=7 eth=\$ethaddr rootrwoptions=rw,noatime rootrwreset=yes"
+SRC_CMDLINE="console=ttyS0,115200 rootwait rw earlycon clk_ignore_unused loglevel=7 eth=\$ethaddr tsched=0 rootrwoptions=rw,noatime rootrwreset=yes"
 BOOTCONFIG="light_lpi4a_defconfig"
 SKIP_BOOTSPLASH="yes"
 BOOTFS_TYPE="ext4"
@@ -18,6 +18,6 @@ function post_family_tweaks__licheepi4a() {
 	cp -v "$SRC/packages/blobs/riscv64/thead/fw_dynamic.bin" "$SDCARD/boot/fw_dynamic.bin"
 
     display_alert "Temp add HDMI audio output on Volume control"
-    	mkdir -p $SDCARD/etc/pulse/
+	mkdir -p $SDCARD/etc/pulse/
 	echo "load-module module-alsa-sink device=hw:0,2" >> "$SDCARD/etc/pulse/default.pa"
 }


### PR DESCRIPTION
# Description

Due to the legacy kernel update from T-Head, it is necessary to add tsched=0 to the cmdline in order to disable automatic buffering and ensure proper audio functionality.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
