### PR TITLE
On Mantic firstrun would throw out an error to console

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstrun
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstrun
@@ -59,7 +59,7 @@ case "$1" in
 	rm -f /etc/ssh/ssh_host*
 	read entropy_before </proc/sys/kernel/random/entropy_avail
 	dpkg-reconfigure openssh-server >/dev/null 2>&1
-	service sshd restart
+	service ssh restart
 	read entropy_after </proc/sys/kernel/random/entropy_avail
 	echo -e "\n### [firstrun] Recreated SSH keys (entropy: ${entropy_before} ${entropy_after})" >>${Log}
 


### PR DESCRIPTION
# Description

Not sure if others are symlinked or they fail silently. 

`Failed to restart sshd.service: Unit sshd.service not found`

# How Has This Been Tested?

- [x] Tested on Jammy, Mantic, Bookworm

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings