### PR TITLE
artifact-uboot: fix hashing for uboot_custom_postprocess old-timey non-hook

### DIFF
--- a/lib/functions/artifacts/artifact-uboot.sh
+++ b/lib/functions/artifacts/artifact-uboot.sh
@@ -74,8 +74,7 @@ function artifact_uboot_prepare_version() {
 	# Hash the extension hooks
 	declare -a extension_hooks_to_hash=(
 		"post_uboot_custom_postprocess" "fetch_custom_uboot" "build_custom_uboot"
-		"pre_config_uboot_target" "post_uboot_custom_postprocess" "post_uboot_custom_postprocess"
-		"post_config_uboot_target"
+		"pre_config_uboot_target" "post_config_uboot_target"
 	)
 	declare -a extension_hooks_hashed=("$(dump_extension_method_sources_functions "${extension_hooks_to_hash[@]}")")
 	declare hash_hooks="undetermined"
@@ -83,7 +82,7 @@ function artifact_uboot_prepare_version() {
 
 	# Hash the old-timey hooks
 	declare hash_functions="undetermined"
-	calculate_hash_for_function_bodies "write_uboot_platform" "write_uboot_platform_mtd" "setup_write_uboot_platform"
+	calculate_hash_for_function_bodies "uboot_custom_postprocess" "write_uboot_platform" "write_uboot_platform_mtd" "setup_write_uboot_platform"
 	declare hash_uboot_functions="${hash_functions}"
 
 	# Hash those two together


### PR DESCRIPTION
#### artifact-uboot: fix hashing for uboot_custom_postprocess old-timey non-hook

- artifact-uboot: fix hashing for uboot_custom_postprocess old-timey non-hook
  - also, for extension style hook `post_uboot_custom_postprocess`, don't do it 3 times, just once
  - this commit will cause rebuild of all u-boots
    - and that's a good thing, many custom changes in family code (eg ddr change in rk322x) were being ignored
    - thanks @paolosabatino