### PR TITLE
rk322x family: use run_host_command_logged() for u-boot postprocessing (so DDR blob used shows in debug logs)

### DIFF
--- a/config/sources/families/rk322x.conf
+++ b/config/sources/families/rk322x.conf
@@ -123,9 +123,9 @@ uboot_custom_postprocess() {
 	# 	tools/mkimage -n rk322x -T rksd -d tpl/u-boot-tpl.bin u-boot-rk322x-with-spl.bin
 	#
 
-	tools/mkimage -n rk322x -T rksd -d $SRC/packages/blobs/rockchip/rk322x_ddr_333MHz_v1.11_2t.bin u-boot-rk322x-with-spl.bin
-	cat spl/u-boot-spl.bin >> u-boot-rk322x-with-spl.bin
-	dd if=u-boot.itb of=u-boot-rk322x-with-spl.bin seek=$((0x200 - 0x40)) conv=notrunc
+	run_host_command_logged tools/mkimage -n rk322x -T rksd -d $SRC/packages/blobs/rockchip/rk322x_ddr_333MHz_v1.11_2t.bin u-boot-rk322x-with-spl.bin
+	run_host_command_logged cat spl/u-boot-spl.bin ">>" u-boot-rk322x-with-spl.bin
+	run_host_command_logged dd if=u-boot.itb of=u-boot-rk322x-with-spl.bin seek=$((0x200 - 0x40)) conv=notrunc
 
 }
 


### PR DESCRIPTION
#### rk322x family: use run_host_command_logged() for u-boot postprocessing (so DDR blob used shows in debug logs)

- rk322x family: use run_host_command_logged() for u-boot postprocessing (so DDR blob used shows in debug logs)
  - cosmetical change for future clarity