### PR TITLE
rk322x family: disable `addgroup` calls that are intended for image (chroot) but are running on host

### DIFF
--- a/config/sources/families/rk322x.conf
+++ b/config/sources/families/rk322x.conf
@@ -148,8 +148,11 @@ family_tweaks_bsp() {
 	install -m 755 $SRC/packages/bsp/rockchip/hdmi-hotplug $destination/usr/local/bin
 
 	# Peripheral access for specific groups
-	addgroup --system --quiet --gid 997 gpio
-	addgroup --system --quiet --gid 998 i2c
+	# @TODO: move this to image hook; it creates groups ON THE BUILD HOST, not in the image,
+	# FIXME: if host already has those it will fail; commented out
+	#addgroup --system --quiet --gid 997 gpio
+	#addgroup --system --quiet --gid 998 i2c
+
 	cp $SRC/packages/bsp/rockchip/70-gpio.rules $destination/etc/udev/rules.d
 	cp $SRC/packages/bsp/rockchip/71-i2c.rules $destination/etc/udev/rules.d
 


### PR DESCRIPTION
#### rk322x family: disable `addgroup` calls that are intended for image (chroot) but are running on host

- rk322x family: disable `addgroup` calls that are intended for image (chroot) but are running on host
  - fixes building rk322x-box on bare metal / non-Docker