### PR TITLE
rk3318-box: Enable uboot BTRFS support

### DIFF
--- a/patch/u-boot/u-boot-rockchip64/board_rk3318-box/rk3318-box-add-defconfig.patch
+++ b/patch/u-boot/u-boot-rockchip64/board_rk3318-box/rk3318-box-add-defconfig.patch
@@ -3,7 +3,7 @@ new file mode 100644
 index 00000000..b6a038f7
 --- /dev/null
 +++ b/configs/rk3318-box_defconfig
-@@ -0,0 +1,117 @@
+@@ -0,0 +1,118 @@
 +CONFIG_ARM=y
 +CONFIG_ARCH_ROCKCHIP=y
 +CONFIG_SYS_TEXT_BASE=0x00200000
@@ -121,3 +121,4 @@ index 00000000..b6a038f7
 +CONFIG_SPL_TINY_MEMSET=y
 +CONFIG_TPL_TINY_MEMSET=y
 +CONFIG_ERRNO_STR=y
++CONFIG_CMD_BTRFS=y


### PR DESCRIPTION
# Description

This would enable uboot BTRFS support to allow booting from a sole BTRFS root/boot partition.
With this feature u-boot.itb file size increase from 826K to 902K. AFAIK this size increase is not an issue given that we have almost 8MB space for uboot before the first partition.  

# How Has This Been Tested?

- [x] Compile
- [x] Boot rk3318 box with sole BTRFS root partition

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
