### PR TITLE
vim1s: fix armbian-bsp-cli package upgrade causes boot failure

### DIFF
--- a/config/sources/families/meson-s4t7.conf
+++ b/config/sources/families/meson-s4t7.conf
@@ -99,8 +99,12 @@ function post_family_tweaks_bsp__disable_uinitrd_generation() {
 	fi
 }
 
-function pre_update_initramfs__change_initrd_compression() {
-	run_host_command_logged sed -i 's/COMPRESS=.*/COMPRESS=xz/g' $MOUNT/etc/initramfs-tools/initramfs.conf
+function meson_s4t7_change_initrd_compression() {
+	sed -i 's/COMPRESS=.*/COMPRESS=xz/g' /etc/initramfs-tools/initramfs.conf
+}
+
+function post_family_tweaks_bsp__add_postinst_function() {
+	postinst_functions+=('meson_s4t7_change_initrd_compression')
 }
 
 function image_specific_armbian_env_ready__force_16x9_display() {


### PR DESCRIPTION
# Description

For some weird reason, vim1s's kernel is extremely sensitive to gzipped initramfs image and it fails to load the same. For this reason, we had a pre_update_initramfs hook to change the initramfs compression algorithm from gzip to xz. But it turns out armbian-bsp-cli package has a well hidden pre-install script that changes compression to gzip if armbian-bsp-cli package is upgraded.

This PR moves the compression change logic from previously added pre_update_initramfs hook to postinst script of armbian-bsp-cli. This way we can provide the value from getting overwritten and hence fix the upgrade failure.

Jira reference number [AR-1976]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Created a new armbian-bsp-cli package and uses that to upgrade pre-installed armbian-bsp-cli package. Checked COMPRESS value in /etc/initramfs-tools/initramfs.conf to make sure it is set to xz.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1976]: https://armbian.atlassian.net/browse/AR-1976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ