### PR TITLE
armbian-kernel: don't force =`n` for `DEBUG_INFO_DWARF5` and `DEBUG_INFO_BTF`

### DIFF
--- a/lib/functions/compilation/armbian-kernel.sh
+++ b/lib/functions/compilation/armbian-kernel.sh
@@ -28,11 +28,9 @@ function armbian_kernel_config__disable_module_compression() {
 		kernel_config_set_string CONFIG_LOCALVERSION '""' # Must be empty; make is later invoked with LOCALVERSION and it adds up
 
 		# DONE: Disable: debug option
-		kernel_config_set_n DEBUG_INFO_DWARF5 # Armbian doesn't know how to package a debug kernel.
-		kernel_config_set_n DEBUG_KERNEL      # ditto
-		kernel_config_set_n DEBUG_INFO        # ditto
-		kernel_config_set_n DEBUG_INFO_BTF    # ditto
-		kernel_config_set_n GDB_SCRIPTS       # ditto
+		kernel_config_set_n DEBUG_KERNEL # Armbian doesn't know how to package a debug kernel.
+		kernel_config_set_n DEBUG_INFO   # ditto
+		kernel_config_set_n GDB_SCRIPTS  # ditto
 
 		# @TODO: Enable the options for the extrawifi/drivers; so we don't need to worry about them when updating configs
 	fi


### PR DESCRIPTION
#### armbian-kernel: don't force =`n` for `DEBUG_INFO_DWARF5` and `DEBUG_INFO_BTF`

- armbian-kernel: don't force =`n` for `DEBUG_INFO_DWARF5` and `DEBUG_INFO_BTF`
  - really can't remember why I added those, and they cause trouble for BTF
    - See https://www.kernel.org/doc/html/next/bpf/btf.html
    - `CONFIG_DEBUG_INFO_BTF: Generate BTF typeinfo`
      - _Generate deduplicated BTF type information from DWARF debug info. Turning this on expects presence of pahole tool, which will convert DWARF type info into equivalent deduplicated BTF type info._