### PR TITLE
xiaomi-elish: add typec pd support

### DIFF
--- a/patch/kernel/archive/sm8250-6.7/0031-arm64-dts-qcom-sm8250-xiaomi-elish-add-tcpm-pd-suppo.patch
+++ b/patch/kernel/archive/sm8250-6.7/0031-arm64-dts-qcom-sm8250-xiaomi-elish-add-tcpm-pd-suppo.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: amazingfate <liujianfeng1994@gmail.com>
+Date: Mon, 27 Nov 2023 12:04:32 +0800
+Subject: arm64: dts: qcom: sm8250-xiaomi-elish: add tcpm pd support
+
+---
+ arch/arm64/boot/dts/qcom/sm8250-xiaomi-elish-common.dtsi | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/qcom/sm8250-xiaomi-elish-common.dtsi b/arch/arm64/boot/dts/qcom/sm8250-xiaomi-elish-common.dtsi
+index 31031e919..1ef3ded4d 100644
+--- a/arch/arm64/boot/dts/qcom/sm8250-xiaomi-elish-common.dtsi
++++ b/arch/arm64/boot/dts/qcom/sm8250-xiaomi-elish-common.dtsi
+@@ -815,8 +815,10 @@ pm8150b_role_switch_in: endpoint {
+ 	connector {
+ 		compatible = "usb-c-connector";
+ 
+-		power-role = "source";
++		power-role = "dual";
+ 		data-role = "dual";
++		try-power-role = "sink";
++		op-sink-microwatt = <10000000>;
+ 		self-powered;
+ 
+ 		source-pdos = <PDO_FIXED(5000, 3000,
+@@ -824,6 +826,8 @@ PDO_FIXED_DUAL_ROLE |
+ 					 PDO_FIXED_USB_COMM |
+ 					 PDO_FIXED_DATA_SWAP)>;
+ 
++		sink-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)
++			     PDO_VAR(5000, 12000, 5000)>;
+ 		ports {
+ 			#address-cells = <1>;
+ 			#size-cells = <0>;
+-- 
+Armbian
+


### PR DESCRIPTION
# Description

Xiaomi Pad 5 pro is using pm8150b to support typec pd with volt up to 13.2V and current up to 6A, so I set the max negotiation to 12V5A.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] xiaomi-elish kernel build success
- [x] I can negotiate 12V2A.
```
$ sensors tcpm_source_psy_c440000.spmi:pmic@2:typec@1500-isa-0000
tcpm_source_psy_c440000.spmi:pmic@2:typec@1500-isa-0000
Adapter: ISA adapter
in0:          12.00 V  (min = +12.00 V, max = +12.00 V)
curr1:         2.00 A  (max =  +2.00 A)
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
