### PR TITLE
`Automatic` board configs status synchronise

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -106,6 +106,8 @@ config/boards/tritium-h3.conf		@Tonymac32
 config/boards/tritium-h5.conf		@Tonymac32
 config/boards/uefi-arm64.conf		@rpardini
 config/boards/uefi-x86.conf		@rpardini
+config/boards/wsl2-arm64.csc		@rpardini
+config/boards/wsl2-x86.csc		@rpardini
 config/boards/xiaomi-elish.conf		@amazingfate
 config/kernel/linux-arm64-*.config		@amazingfate @rpardini
 config/kernel/linux-bcm2711-*.config		@PanderMusubi @teknoid


### PR DESCRIPTION
Update maintainers and board status

- synced status from the database
- rename to .`csc` where we don't have anyone

If you want to become a board maintainer, [adjust data here](https://www.armbian.com/update-data/).

Ref: [Board Maintainers Procedures and Guidelines](https://docs.armbian.com/Board_Maintainers_Procedures_and_Guidelines/)