### PR TITLE
`Automatic` board configs status synchronise

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,6 +33,7 @@ config/boards/indiedroid-nova.csc		@lanefu
 config/boards/jethubj100.conf		@adeepn
 config/boards/jethubj80.conf		@adeepn
 config/boards/jetson-nano.csc		@150balbes
+config/boards/jp-tvbox-3566.tvb		@tdleiyao
 config/boards/khadas-edge2.conf		@igorpecovnik
 config/boards/khadas-vim1.conf		@igorpecovnik
 config/boards/khadas-vim1s.conf		@rpardini @viraniac
@@ -122,7 +123,7 @@ config/kernel/linux-rk3568-odroid-*.config		@rpardini @utlark
 config/kernel/linux-rk35xx-*.config		@Tonymac32 @ZazaBR @amazingfate @catalinii @efectn @igorpecovnik @krachlatte @lanefu @linhz0hz @mahdichi @monkaBlyat @rpardini @sputnik2019 @vamzii
 config/kernel/linux-rockchip-*.config		@paolosabatino
 config/kernel/linux-rockchip-rk3588-*.config		@Tonymac32 @amazingfate @efectn @igorpecovnik @lanefu @linhz0hz
-config/kernel/linux-rockchip64-*.config		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @schwar3kat @vamzii
+config/kernel/linux-rockchip64-*.config		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @schwar3kat @tdleiyao @vamzii
 config/kernel/linux-rockpis-*.config		@brentr
 config/kernel/linux-sun50iw9-*.config		@AGM1968 @krachlatte
 config/kernel/linux-sun50iw9-btt-*.config		@bigtreetech
@@ -139,7 +140,7 @@ patch/kernel/archive/odroidxu4-*/		@joekhoobyar
 patch/kernel/archive/rk3568-odroid-*/		@rpardini @utlark
 patch/kernel/archive/rk35xx-*/		@Tonymac32 @ZazaBR @amazingfate @catalinii @efectn @igorpecovnik @krachlatte @lanefu @linhz0hz @mahdichi @monkaBlyat @rpardini @sputnik2019 @vamzii
 patch/kernel/archive/rockchip-*/		@paolosabatino
-patch/kernel/archive/rockchip64-*/		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @schwar3kat @vamzii
+patch/kernel/archive/rockchip64-*/		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @schwar3kat @tdleiyao @vamzii
 patch/kernel/archive/rockpis-*/		@brentr
 patch/kernel/archive/sm8250-*/		@amazingfate
 patch/kernel/archive/sun50iw9-*/		@AGM1968 @krachlatte
@@ -156,7 +157,7 @@ patch/kernel/odroidxu4-*/		@joekhoobyar
 patch/kernel/rk35xx-*/		@Tonymac32 @ZazaBR @amazingfate @catalinii @efectn @igorpecovnik @krachlatte @lanefu @linhz0hz @mahdichi @monkaBlyat @rpardini @sputnik2019 @vamzii
 patch/kernel/rockchip-*/		@paolosabatino
 patch/kernel/rockchip-rk3588-*/		@Tonymac32 @amazingfate @efectn @igorpecovnik @lanefu @linhz0hz
-patch/kernel/rockchip64-*/		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @schwar3kat @vamzii
+patch/kernel/rockchip64-*/		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @schwar3kat @tdleiyao @vamzii
 patch/kernel/rockpis-*/		@brentr
 patch/kernel/sun50iw9-*/		@AGM1968 @krachlatte
 patch/kernel/thead-*/		@chainsx
@@ -175,7 +176,7 @@ sources/families/rk3568-odroid.conf		@rpardini @utlark
 sources/families/rk35xx.conf		@Tonymac32 @ZazaBR @amazingfate @catalinii @efectn @igorpecovnik @krachlatte @lanefu @linhz0hz @mahdichi @monkaBlyat @rpardini @sputnik2019 @vamzii
 sources/families/rockchip-rk3588.conf		@Tonymac32 @amazingfate @efectn @igorpecovnik @lanefu @linhz0hz
 sources/families/rockchip.conf		@paolosabatino
-sources/families/rockchip64.conf		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @schwar3kat @vamzii
+sources/families/rockchip64.conf		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @schwar3kat @tdleiyao @vamzii
 sources/families/rockpis.conf		@brentr
 sources/families/sun50iw9-btt.conf		@bigtreetech
 sources/families/sun50iw9.conf		@AGM1968 @krachlatte

--- a/config/boards/khadas-vim1s.conf
+++ b/config/boards/khadas-vim1s.conf
@@ -2,7 +2,7 @@
 BOARD_NAME="Khadas VIM1S" # don't confuse with VIM1 (S905X)
 BOARDFAMILY="meson-s4t7"
 KERNEL_TARGET="legacy"
-BOARD_MAINTAINER="viraniac rpardini"
+BOARD_MAINTAINER="rpardini viraniac"
 SERIALCON="ttyS0" # for vendor kernel
 # BOOT_FDT_FILE="amlogic/kvim1s.dtb" # unset on purpose: uboot auto-determines the DTB to use
 

--- a/config/boards/khadas-vim3.conf
+++ b/config/boards/khadas-vim3.conf
@@ -1,7 +1,7 @@
 # Amlogic A311D 2/4GB RAM eMMC GBE USB3 M.2
 BOARD_NAME="Khadas VIM3"
 BOARDFAMILY="meson-g12b"
-BOARD_MAINTAINER="NicoD-SBC rpardini"
+BOARD_MAINTAINER="rpardini NicoD-SBC"
 BOOTCONFIG="khadas-vim3_defconfig"
 KERNEL_TARGET="current,edge"
 MODULES_BLACKLIST="simpledrm" # SimpleDRM conflicts with Panfrost on the VIM3

--- a/config/boards/khadas-vim4.conf
+++ b/config/boards/khadas-vim4.conf
@@ -2,7 +2,7 @@
 BOARD_NAME="Khadas VIM4"
 BOARDFAMILY="meson-s4t7"
 KERNEL_TARGET="legacy"
-BOARD_MAINTAINER="echatzip viraniac rpardini"
+BOARD_MAINTAINER="rpardini echatzip viraniac"
 SERIALCON="ttyS0" # for vendor kernel
 # BOOT_FDT_FILE="amlogic/kvim4.dtb" # not set on purpose; u-boot auto-selects kvim4.dtb or kvim4n.dtb for "new VIM4"
 


### PR DESCRIPTION
Update maintainers and board status

- synced status from the database
- rename to .`csc` where we don't have anyone

If you want to become a board maintainer, [adjust data here](https://www.armbian.com/update-data/).

Ref: [Board Maintainers Procedures and Guidelines](https://docs.armbian.com/Board_Maintainers_Procedures_and_Guidelines/)