### PR TITLE
rockchip64: fix uboot zstd decompression

### DIFF
--- a/patch/u-boot/u-boot-rockchip64/general-fix-zstd-max-window-size.patch
+++ b/patch/u-boot/u-boot-rockchip64/general-fix-zstd-max-window-size.patch
@@ -1,0 +1,54 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alex Shumsky <alexthreed@gmail.com>
+Date: Mon, 27 Nov 2023 18:24:13 +0000
+Subject: Fix invalid maxWindowSize in zstd_decompress
+
+Signed-off-by: Alex Shumsky <alexthreed@gmail.com>
+---
+ lib/zstd/zstd.c | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/lib/zstd/zstd.c b/lib/zstd/zstd.c
+index bf9cd19cfa..fa40473254 100644
+--- a/lib/zstd/zstd.c
++++ b/lib/zstd/zstd.c
+@@ -8,29 +8,34 @@
+ #include <common.h>
+ #include <abuf.h>
+ #include <log.h>
+ #include <malloc.h>
+ #include <linux/zstd.h>
++#include "zstd_internal.h" // MAX
+ 
+ int zstd_decompress(struct abuf *in, struct abuf *out)
+ {
+ 	ZSTD_DStream *dstream;
+ 	ZSTD_inBuffer in_buf;
+ 	ZSTD_outBuffer out_buf;
+ 	void *workspace;
+ 	size_t wsize;
+ 	int ret;
++	size_t maxWindowSize;
+ 
+-	wsize = ZSTD_DStreamWorkspaceBound(abuf_size(in));
++	// compressed data size seems to be totally irrelevant as measure 
++	// of maxWindowSize, but leave it here for safety 
++	maxWindowSize = MAX(abuf_size(in), 128*1024);
++	wsize = ZSTD_DStreamWorkspaceBound(maxWindowSize);
+ 	workspace = malloc(wsize);
+ 	if (!workspace) {
+ 		debug("%s: cannot allocate workspace of size %zu\n", __func__,
+ 			wsize);
+ 		return -ENOMEM;
+ 	}
+ 
+-	dstream = ZSTD_initDStream(abuf_size(in), workspace, wsize);
++	dstream = ZSTD_initDStream(maxWindowSize, workspace, wsize);
+ 	if (!dstream) {
+ 		log_err("%s: ZSTD_initDStream failed\n", __func__);
+ 		ret = -EPERM;
+ 		goto do_free;
+ 	}
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+


### PR DESCRIPTION
# Description

Fix uboot booting from zstd compressed BTRFS.

uboot logs before fix:
```
Found U-Boot script /boot/boot.scr
ZSTD_decompressStream error 7
3252 bytes read in 41 ms (77.1 KiB/s)
...
SCRIPT FAILED: continuing...
```

Error 7 means "frame parameter window too large". It looks like uboot's max window size specification on decompressor init is totally wrong (compressed data size is used as max window size). 
Zstd default max window size is 128MB, but I'm unsure is it good idea to malloc 128MB in uboot on each BTRFS extent decompression.
So I have capped minimum window size to 128KB - it should be sufficient for BTRFS as max compressed extent size is 128KB.

# How Has This Been Tested?

- [x] Compile
- [x] Boot ZSTD compressed BTRFS

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
