### PR TITLE
Freeze mainline kernel version for 23.11 release

### DIFF
--- a/config/sources/families/imx6.conf
+++ b/config/sources/families/imx6.conf
@@ -19,14 +19,14 @@ case $BRANCH in
 	legacy)
 
 		declare -g KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
-		KERNELBRANCH='branch:linux-5.15.y'
+		KERNELBRANCH='tag:v5.15.139'
 
 		;;
 
 	current)
 
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		KERNELBRANCH='branch:linux-6.1.y'
+		KERNELBRANCH='tag:v6.1.63'
 
 		;;
 

--- a/config/sources/families/include/meson64_common.inc
+++ b/config/sources/families/include/meson64_common.inc
@@ -40,13 +40,13 @@ case $BRANCH in
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel. For mainline caching.
-		KERNELBRANCH='branch:linux-6.1.y'
+		KERNELBRANCH='tag:v6.1.63'
 		KERNELPATCHDIR='meson64-current'
 		;;
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel. For mainline caching.
-		KERNELBRANCH='branch:linux-6.6.y'
+		KERNELBRANCH='tag:v6.6.2'
 		KERNELPATCHDIR='meson64-edge'
 		;;
 

--- a/config/sources/families/include/meson_common.inc
+++ b/config/sources/families/include/meson_common.inc
@@ -47,7 +47,7 @@ case $BRANCH in
 	current)
 
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		KERNELBRANCH="branch:linux-6.1.y"
+		KERNELBRANCH="tag:v6.1.63"
 		KERNELPATCHDIR='meson-'$BRANCH
 
 		;;
@@ -55,7 +55,7 @@ case $BRANCH in
 	edge)
 
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel.
-		KERNELBRANCH="branch:linux-6.6.y"
+		KERNELBRANCH="tag:v6.6.2"
 		KERNELPATCHDIR='meson-'$BRANCH
 
 		;;

--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -144,7 +144,7 @@ case $BRANCH in
 	current)
 
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		KERNELBRANCH="branch:linux-6.1.y"
+		KERNELBRANCH="tag:v6.1.63"
 		KERNELPATCHDIR='rockchip64-'$BRANCH
 		LINUXFAMILY=rockchip64
 		LINUXCONFIG='linux-rockchip64-'$BRANCH
@@ -154,7 +154,7 @@ case $BRANCH in
 
 		KERNELPATCHDIR='rockchip64-'$BRANCH
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel.
-		KERNELBRANCH="branch:linux-6.6.y"
+		KERNELBRANCH="tag:v6.6.2"
 		LINUXFAMILY=rockchip64
 		LINUXCONFIG='linux-rockchip64-'$BRANCH
 

--- a/config/sources/families/include/uefi_common.inc
+++ b/config/sources/families/include/uefi_common.inc
@@ -23,7 +23,7 @@ case "${BRANCH}" in
 		declare -g DISTRO_GENERIC_KERNEL=no
 		declare -g LINUXCONFIG="linux-uefi-${LINUXFAMILY}-${BRANCH}"
 		declare -g KERNEL_MAJOR_MINOR="5.15"                      # Major and minor versions of this kernel. For mainline caching.
-		declare -g KERNELBRANCH="branch:linux-5.15.y"             # Branch or tag to build from. It should match MAJOR_MINOR
+		declare -g KERNELBRANCH="tag:v5.15.139"             # Branch or tag to build from. It should match MAJOR_MINOR
 		declare -g KERNELPATCHDIR="uefi-${LINUXFAMILY}-${BRANCH}" # Might be empty.
 		;;
 
@@ -32,7 +32,7 @@ case "${BRANCH}" in
 		declare -g DISTRO_GENERIC_KERNEL=no
 		declare -g LINUXCONFIG="linux-uefi-${LINUXFAMILY}-${BRANCH}"
 		declare -g KERNEL_MAJOR_MINOR="6.1"                       # Major and minor versions of this kernel. For mainline caching.
-		declare -g KERNELBRANCH="branch:linux-6.1.y"              # Branch or tag to build from. It should match MAJOR_MINOR
+		declare -g KERNELBRANCH="tag:v6.1.63"              # Branch or tag to build from. It should match MAJOR_MINOR
 		declare -g KERNELPATCHDIR="uefi-${LINUXFAMILY}-${BRANCH}" # Might be empty.
 		;;
 
@@ -41,7 +41,7 @@ case "${BRANCH}" in
 		declare -g DISTRO_GENERIC_KERNEL=no
 		declare -g LINUXCONFIG="linux-uefi-${LINUXFAMILY}-${BRANCH}"
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH='branch:linux-6.6.y'
+		declare -g KERNELBRANCH='tag:v6.6.2'
 		declare -g KERNELPATCHDIR="uefi-${LINUXFAMILY}-${BRANCH}" # Might be empty.
 		;;
 esac

--- a/config/sources/families/k3.conf
+++ b/config/sources/families/k3.conf
@@ -20,13 +20,13 @@ case "${BRANCH}" in
 	current)
 
 		declare -g KERNEL_MAJOR_MINOR="6.1"
-		declare -g KERNELBRANCH="branch:linux-6.1.y"
+		declare -g KERNELBRANCH="tag:v6.1.63"
 		;;
 
 	edge)
 
 		declare -g KERNEL_MAJOR_MINOR="6.5"
-		declare -g KERNELBRANCH='branch:linux-6.5.y'
+		declare -g KERNELBRANCH='tag:v6.5.12'
 		EXTRAWIFI="no"
 		;;
 

--- a/config/sources/families/media.conf
+++ b/config/sources/families/media.conf
@@ -42,7 +42,7 @@ case $BRANCH in
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		KERNELBRANCH="branch:linux-6.1.y"
+		KERNELBRANCH="tag:v6.1.63"
 		LINUXCONFIG='linux-media-'$BRANCH
 		KERNELPATCHDIR='media-'$BRANCH
 		LINUXFAMILY=media

--- a/config/sources/families/mvebu.conf
+++ b/config/sources/families/mvebu.conf
@@ -21,7 +21,7 @@ case $BRANCH in
 	current)
 
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		KERNELBRANCH='branch:linux-6.1.y'
+		KERNELBRANCH='tag:v6.1.63'
 
 		;;
 

--- a/config/sources/families/mvebu64.conf
+++ b/config/sources/families/mvebu64.conf
@@ -57,13 +57,13 @@ case $BRANCH in
 	current)
 
 		declare -g KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
-		KERNELBRANCH='branch:linux-5.15.y'
+		KERNELBRANCH='tag:v5.15.139'
 
 		;;
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel.
-		KERNELBRANCH='branch:linux-6.6.y'
+		KERNELBRANCH='tag:v6.6.2'
 		;;
 
 esac

--- a/config/sources/families/odroidxu4.conf
+++ b/config/sources/families/odroidxu4.conf
@@ -28,7 +28,7 @@ case $BRANCH in
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		KERNELBRANCH='branch:linux-6.1.y'
+		KERNELBRANCH='tag:v6.1.63'
 		KERNELDIR='linux-odroidxu4'
 		;;
 

--- a/config/sources/families/rk322x.conf
+++ b/config/sources/families/rk322x.conf
@@ -30,14 +30,14 @@ case $BRANCH in
 	current)
 
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		KERNELBRANCH='branch:linux-6.1.y'
+		KERNELBRANCH='tag:v6.1.63'
 
 		;;
 
 	edge)
 
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel.
-		KERNELBRANCH='branch:linux-6.6.y'
+		KERNELBRANCH='tag:v6.6.2'
 
 		;;
 

--- a/config/sources/families/rk3568-odroid.conf
+++ b/config/sources/families/rk3568-odroid.conf
@@ -17,7 +17,7 @@ case $BRANCH in
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel (for armbian-next)
-		declare -g KERNELBRANCH='branch:linux-6.6.y'
+		declare -g KERNELBRANCH='tag:v6.6.2'
 		KERNELPATCHDIR='archive/rk3568-odroid-6.6' # @TODO fix # patches for overlays et al
 		;;
 

--- a/config/sources/families/rockchip.conf
+++ b/config/sources/families/rockchip.conf
@@ -28,14 +28,14 @@ case $BRANCH in
 	current)
 
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		KERNELBRANCH='branch:linux-6.1.y'
+		KERNELBRANCH='tag:v6.1.63'
 
 		;;
 
 	edge)
 
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel.
-		KERNELBRANCH='branch:linux-6.6.y'
+		KERNELBRANCH='tag:v6.6.2'
 		;;
 
 esac

--- a/config/sources/families/starfive.conf
+++ b/config/sources/families/starfive.conf
@@ -15,7 +15,7 @@ case "${BRANCH}" in
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel. For mainline caching.
-		declare -g KERNELBRANCH='branch:linux-6.1.y'
+		declare -g KERNELBRANCH='tag:v6.1.63'
 
 		;;
 

--- a/config/sources/families/virtual.conf
+++ b/config/sources/families/virtual.conf
@@ -9,7 +9,7 @@
 BOOTBRANCH='tag:v2021.04'
 
 declare -g KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
-KERNELBRANCH='branch:linux-5.15.y'
+KERNELBRANCH='tag:v5.15.139'
 
 ARCH=arm64
 #UBOOT_TARGET_MAP=";;u-boot.bin"

--- a/config/sources/vendors/microsoft/wsl2.hooks.sh
+++ b/config/sources/vendors/microsoft/wsl2.hooks.sh
@@ -10,14 +10,14 @@ function post_family_config__wsl2() {
 
 function post_family_config_branch_current__wsl2() {
 	declare -g KERNEL_MAJOR_MINOR="6.1"                                      # Major and minor versions of this kernel. For mainline caching.
-	declare -g KERNELBRANCH="branch:linux-6.1.y"                             # Branch or tag to build from. It should match MAJOR_MINOR
+	declare -g KERNELBRANCH="tag:v6.1.63"                             # Branch or tag to build from. It should match MAJOR_MINOR
 	declare -g KERNELPATCHDIR="archive/${LINUXFAMILY}-${KERNEL_MAJOR_MINOR}" # Microsoft patches
 	display_alert "Using mainline kernel ${KERNELBRANCH} for" "${BOARD}" "info"
 }
 
 function post_family_config_branch_edge__wsl2() {
 	declare -g KERNEL_MAJOR_MINOR="6.6"                                      # Major and minor versions of this kernel. For mainline caching.
-	declare -g KERNELBRANCH="branch:linux-6.6.y"                             # Branch or tag to build from. It should match MAJOR_MINOR
+	declare -g KERNELBRANCH="tag:v6.6.2"                             # Branch or tag to build from. It should match MAJOR_MINOR
 	declare -g KERNELPATCHDIR="archive/${LINUXFAMILY}-${KERNEL_MAJOR_MINOR}" # Microsoft patches
 	display_alert "Using mainline kernel ${KERNELBRANCH} for" "${BOARD}" "info"
 }


### PR DESCRIPTION
# Description

Freezing mainline kernel version for release

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
