### PR TITLE
extensions: abl: add mkbootimg to host dep

### DIFF
--- a/extensions/image-output-abl.sh
+++ b/extensions/image-output-abl.sh
@@ -1,3 +1,7 @@
+function add_host_dependencies__abl_host_deps() {
+	declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} mkbootimg"
+}
+
 function post_build_image__900_convert_to_abl_img() {
 	[[ -z $version ]] && exit_with_error "version is not set"
 
@@ -28,7 +32,7 @@ function post_build_image__900_convert_to_abl_img() {
 		for dtb_name in "${ABL_DTB_LIST[@]}"; do
 			display_alert "Creatng abl kernel boot image with dtb ${dtb_name}" "${EXTENSION}" "info"
 			cat ${DESTIMG}/Image.gz ${new_rootfs_image_mount_dir}/usr/lib/linux-image-*/qcom/${dtb_name}.dtb > ${DESTIMG}/Image.gz-${dtb_name}
-			${new_rootfs_image_mount_dir}/usr/bin/mkbootimg \
+			/usr/bin/mkbootimg \
 				--kernel ${DESTIMG}/Image.gz-${dtb_name} \
 				--ramdisk ${new_rootfs_image_mount_dir}/boot/initrd.img-*-* \
 				--base 0x0 \


### PR DESCRIPTION
# Description

We use mkbootimg in rootfs which is installed only for jammy before. It's better to use mkbootimg from build host because this is a python script and may not run if build host and target rootfs are not the same release.
This commit only make build for debian pass, but debian images won't work because of lacking packages.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] `./compile.sh build BOARD=xiaomi-elish BRANCH=sm8250 BUILD_DESKTOP=no BUILD_MINIMAL=yes DEB_COMPRESS=xz EXPERT=yes GITHUB_MIRROR=ghproxy KERNEL_CONFIGURE=no KERNEL_GIT=shallow MAINLINE_MIRROR=tuna RELEASE=trixie`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
