### PR TITLE
rk3588: edge: add vop2, hdmi support to rock5 series and fix hdmi0 reset gpio on opi5

### DIFF
--- a/patch/kernel/rockchip-rk3588-edge/0026-Add-missing-nodes-to-Orange-Pi-5.patch
+++ b/patch/kernel/rockchip-rk3588-edge/0026-Add-missing-nodes-to-Orange-Pi-5.patch
@@ -1,14 +1,14 @@
-From dce71679978d83ae7fec725abed08110b3fc4a16 Mon Sep 17 00:00:00 2001
+From da15e8eb421ad3dc0834a5fca9a8086785d1100f Mon Sep 17 00:00:00 2001
 From: Muhammed Efe Cetin <efectn@protonmail.com>
 Date: Thu, 16 Nov 2023 18:09:07 +0300
-Subject: [PATCH] arm64: dts: Add missing nodes to Orange Pi 5
+Subject: [PATCH 2/3] arm64: dts: Add missing nodes to Orange Pi 5
 
 ---
  .../boot/dts/rockchip/rk3588s-orangepi-5.dts  | 234 +++++++++++++++++-
  1 file changed, 233 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dts b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dts
-index 8f399c4317bd..7f10d1b1db7e 100644
+index 8f399c4317bd..25125993132e 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dts
 @@ -6,6 +6,8 @@
@@ -302,7 +302,7 @@ index 8f399c4317bd..7f10d1b1db7e 100644
 +};
 +
 +&hdmi0 {
-+	enable-gpios = <&gpio4 RK_PB1 GPIO_ACTIVE_HIGH>;
++	enable-gpios = <&gpio4 RK_PB6 GPIO_ACTIVE_HIGH>;
 +	status = "okay";
 +};
 +

--- a/patch/kernel/rockchip-rk3588-edge/0030-Add-HDMI-and-VOP2-to-Rock-5-series.patch
+++ b/patch/kernel/rockchip-rk3588-edge/0030-Add-HDMI-and-VOP2-to-Rock-5-series.patch
@@ -1,0 +1,155 @@
+From 1b9b1f115e406040222be6fbdeff3ca91dd9576e Mon Sep 17 00:00:00 2001
+From: Muhammed Efe Cetin <efectn@protonmail.com>
+Date: Sat, 2 Dec 2023 12:32:54 +0300
+Subject: [PATCH] Add HDMI and VOP2 to Rock 5 series
+
+---
+ .../boot/dts/rockchip/rk3588-rock-5b.dts      | 49 +++++++++++++++++++
+ .../boot/dts/rockchip/rk3588s-rock-5a.dts     | 49 +++++++++++++++++++
+ 2 files changed, 98 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+index 9ee415e6f498..1b741b5ca81b 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+@@ -5,6 +5,7 @@
+ #include <dt-bindings/gpio/gpio.h>
+ #include <dt-bindings/leds/common.h>
+ #include <dt-bindings/usb/pd.h>
++#include <dt-bindings/soc/rockchip,vop2.h>
+ #include "rk3588.dtsi"
+ 
+ / {
+@@ -60,6 +61,17 @@ fan: pwm-fan {
+ 		#cooling-cells = <2>;
+ 	};
+ 
++	hdmi-con {
++		compatible = "hdmi-connector";
++		type = "a";
++
++		port {
++			hdmi_con_in: endpoint {
++				remote-endpoint = <&hdmi0_out_con>;
++			};
++		};
++	};
++
+ 	vcc12v_dcin: vcc12v-dcin-regulator {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vcc12v_dcin";
+@@ -920,3 +932,40 @@ &usb_host1_xhci {
+ &usb_host2_xhci {
+ 	status = "okay";
+ };
++
++&hdmi0 {
++	enable-gpios = <&gpio4 RK_PB1 GPIO_ACTIVE_HIGH>;
++	status = "okay";
++};
++
++
++&hdptxphy_hdmi0 {
++	status = "okay";
++};
++
++&vop_mmu {
++	status = "okay";
++};
++
++&hdmi0_in {
++	hdmi0_in_vp0: endpoint {
++		remote-endpoint = <&vp0_out_hdmi0>;
++	};
++};
++
++&hdmi0_out {
++	hdmi0_out_con: endpoint {
++		remote-endpoint = <&hdmi_con_in>;
++	};
++};
++
++&vop {
++	status = "okay";
++};
++
++&vp0 {
++	vp0_out_hdmi0: endpoint@ROCKCHIP_VOP2_EP_HDMI0 {
++		reg = <ROCKCHIP_VOP2_EP_HDMI0>;
++		remote-endpoint = <&hdmi0_in_vp0>;
++	};
++};
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
+index 58c58ec03a7f..783a11493cd2 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
+@@ -5,6 +5,7 @@
+ #include <dt-bindings/gpio/gpio.h>
+ #include <dt-bindings/leds/common.h>
+ #include <dt-bindings/pinctrl/rockchip.h>
++#include <dt-bindings/soc/rockchip,vop2.h>
+ #include "rk3588s.dtsi"
+ 
+ / {
+@@ -56,6 +57,17 @@ fan: pwm-fan {
+ 		#cooling-cells = <2>;
+ 	};
+ 
++	hdmi-con {
++		compatible = "hdmi-connector";
++		type = "a";
++
++		port {
++			hdmi_con_in: endpoint {
++				remote-endpoint = <&hdmi0_out_con>;
++			};
++		};
++	};
++
+ 	vcc12v_dcin: vcc12v-dcin-regulator {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vcc12v_dcin";
+@@ -772,3 +784,40 @@ &usb_host1_ohci {
+ &usb_host2_xhci {
+ 	status = "okay";
+ };
++
++&hdmi0 {
++	enable-gpios = <&gpio4 RK_PB6 GPIO_ACTIVE_HIGH>;
++	status = "okay";
++};
++
++
++&hdptxphy_hdmi0 {
++	status = "okay";
++};
++
++&vop_mmu {
++	status = "okay";
++};
++
++&hdmi0_in {
++	hdmi0_in_vp0: endpoint {
++		remote-endpoint = <&vp0_out_hdmi0>;
++	};
++};
++
++&hdmi0_out {
++	hdmi0_out_con: endpoint {
++		remote-endpoint = <&hdmi_con_in>;
++	};
++};
++
++&vop {
++	status = "okay";
++};
++
++&vp0 {
++	vp0_out_hdmi0: endpoint@ROCKCHIP_VOP2_EP_HDMI0 {
++		reg = <ROCKCHIP_VOP2_EP_HDMI0>;
++		remote-endpoint = <&hdmi0_in_vp0>;
++	};
++};
+-- 
+2.42.1
+


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Jira reference number [AR-9999]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Someone tested with rock5

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
