### PR TITLE
kernel: allwinner: bump legacy, current and edge

### DIFF
--- a/config/kernel/linux-sunxi-current.config
+++ b/config/kernel/linux-sunxi-current.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.1.64 Kernel Configuration
+# Linux/arm 6.1.65 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-linux-gnueabihf-gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0"
 CONFIG_CC_IS_GCC=y
@@ -8130,7 +8130,7 @@ CONFIG_SYMBOLIC_ERRNAME=y
 CONFIG_DEBUG_BUGVERBOSE=y
 # end of printk and dmesg options
 
-CONFIG_DEBUG_KERNEL=y
+# CONFIG_DEBUG_KERNEL is not set
 CONFIG_DEBUG_MISC=y
 
 #
@@ -8422,3 +8422,5 @@ CONFIG_ARCH_USE_MEMTEST=y
 #
 # end of Rust hacking
 # end of Kernel hacking
+# CONFIG_DEBUG_INFO is not set
+# CONFIG_GDB_SCRIPTS is not set

--- a/config/kernel/linux-sunxi-edge.config
+++ b/config/kernel/linux-sunxi-edge.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.6.2 Kernel Configuration
+# Linux/arm 6.6.4 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-linux-gnueabihf-gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0"
 CONFIG_CC_IS_GCC=y
@@ -8536,7 +8536,7 @@ CONFIG_SYMBOLIC_ERRNAME=y
 CONFIG_DEBUG_BUGVERBOSE=y
 # end of printk and dmesg options
 
-CONFIG_DEBUG_KERNEL=y
+# CONFIG_DEBUG_KERNEL is not set
 CONFIG_DEBUG_MISC=y
 
 #
@@ -8834,3 +8834,5 @@ CONFIG_ARCH_USE_MEMTEST=y
 #
 # end of Rust hacking
 # end of Kernel hacking
+# CONFIG_DEBUG_INFO is not set
+# CONFIG_GDB_SCRIPTS is not set

--- a/config/kernel/linux-sunxi-legacy.config
+++ b/config/kernel/linux-sunxi-legacy.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 5.15.139 Kernel Configuration
+# Linux/arm 5.15.141 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-linux-gnueabihf-gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0"
 CONFIG_CC_IS_GCC=y
@@ -8012,7 +8012,7 @@ CONFIG_HAVE_ARCH_KGDB=y
 CONFIG_HAVE_KCSAN_COMPILER=y
 # end of Generic Kernel Debugging Instruments
 
-CONFIG_DEBUG_KERNEL=y
+# CONFIG_DEBUG_KERNEL is not set
 CONFIG_DEBUG_MISC=y
 
 #
@@ -8243,3 +8243,4 @@ CONFIG_ARCH_USE_MEMTEST=y
 # CONFIG_MEMTEST is not set
 # end of Kernel Testing and Coverage
 # end of Kernel hacking
+# CONFIG_GDB_SCRIPTS is not set

--- a/config/kernel/linux-sunxi64-current.config
+++ b/config/kernel/linux-sunxi64-current.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.1.63 Kernel Configuration
+# Linux/arm64 6.1.65 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0"
 CONFIG_CC_IS_GCC=y
@@ -8569,3 +8569,5 @@ CONFIG_ARCH_USE_MEMTEST=y
 #
 # end of Rust hacking
 # end of Kernel hacking
+# CONFIG_DEBUG_INFO is not set
+# CONFIG_GDB_SCRIPTS is not set

--- a/config/kernel/linux-sunxi64-edge.config
+++ b/config/kernel/linux-sunxi64-edge.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.6.2 Kernel Configuration
+# Linux/arm64 6.6.4 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0"
 CONFIG_CC_IS_GCC=y
@@ -124,6 +124,7 @@ CONFIG_TASK_DELAY_ACCT=y
 CONFIG_TASK_XACCT=y
 CONFIG_TASK_IO_ACCOUNTING=y
 CONFIG_PSI=y
+# CONFIG_PSI_DEFAULT_DISABLED is not set
 # end of CPU/Task time and stats accounting
 
 CONFIG_CPU_ISOLATION=y
@@ -7566,6 +7567,7 @@ CONFIG_RAS=y
 CONFIG_ANDROID_BINDER_IPC=y
 CONFIG_ANDROID_BINDERFS=y
 CONFIG_ANDROID_BINDER_DEVICES="binder,hwbinder,vndbinder,anbox-binder,anbox-hwbinder,anbox-vndbinder"
+# CONFIG_ANDROID_BINDER_IPC_SELFTEST is not set
 # end of Android
 
 # CONFIG_LIBNVDIMM is not set
@@ -8763,7 +8765,5 @@ CONFIG_ARCH_USE_MEMTEST=y
 #
 # end of Rust hacking
 # end of Kernel hacking
-# CONFIG_DEBUG_INFO_DWARF5 is not set
 # CONFIG_DEBUG_INFO is not set
-# CONFIG_DEBUG_INFO_BTF is not set
 # CONFIG_GDB_SCRIPTS is not set

--- a/config/kernel/linux-sunxi64-legacy.config
+++ b/config/kernel/linux-sunxi64-legacy.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.15.139 Kernel Configuration
+# Linux/arm64 5.15.141 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0"
 CONFIG_CC_IS_GCC=y
@@ -8067,3 +8067,5 @@ CONFIG_ARCH_USE_MEMTEST=y
 # CONFIG_MEMTEST is not set
 # end of Kernel Testing and Coverage
 # end of Kernel hacking
+# CONFIG_DEBUG_INFO is not set
+# CONFIG_GDB_SCRIPTS is not set

--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -24,17 +24,17 @@ case $BRANCH in
 
 	legacy)
 		declare -g KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v5.15.140"
+		declare -g KERNELBRANCH="tag:v5.15.141"
 		;;
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.1.64"
+		declare -g KERNELBRANCH="tag:v6.1.65"
 		;;
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.6.3"
+		declare -g KERNELBRANCH="tag:v6.6.4"
 		;;
 esac
 

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -25,17 +25,17 @@ case $BRANCH in
 
 	legacy)
 		declare -g KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v5.15.140"
+		declare -g KERNELBRANCH="tag:v5.15.141"
 		;;
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.1.64"
+		declare -g KERNELBRANCH="tag:v6.1.65"
 		;;
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.6.3"
+		declare -g KERNELBRANCH="tag:v6.6.4"
 		;;
 esac
 


### PR DESCRIPTION
# Description

Legacy - 5.15.140 -> 5.15.141
Current - 6.1.64 -> 6.1.65
Edge - 6.6.3 -> 6.6.4

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] All 32-bit and 64-bit Allwinner kernels builds fine
- [X] Tested 32-bit kernels on Orange Pi Zero (sun8i H3) and they seem to work fine.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
