### PR TITLE
support xiaomi-elish for debian

### DIFF
--- a/config/boards/xiaomi-elish.conf
+++ b/config/boards/xiaomi-elish.conf
@@ -20,6 +20,8 @@ function post_family_config_branch_sm8250__pmos_kernel() {
 
 function xiaomi-elish_is_userspace_supported() {
 	[[ "${RELEASE}" == "jammy" ]] && return 0
+	[[ "${RELEASE}" == "trixie" ]] && return 0
+	[[ "${RELEASE}" == "noble" ]] && return 0
 	return 1
 }
 
@@ -54,11 +56,22 @@ function post_family_tweaks__xiaomi-elish_enable_services() {
 		return 0
 	fi
 
-	display_alert "Adding qcom-mainline PPA" "${BOARD}" "info"
-	do_with_retries 3 chroot_sdcard add-apt-repository ppa:liujianfeng1994/qcom-mainline --yes --no-update
+	if [[ "${RELEASE}" == "jammy" ]];then
+		display_alert "Adding qcom-mainline PPA" "${BOARD}" "info"
+		do_with_retries 3 chroot_sdcard add-apt-repository ppa:liujianfeng1994/qcom-mainline --yes --no-update
+	fi
+
+	# we need unudhcpd from armbian repo, so enable it
+	mv "${SDCARD}"/etc/apt/sources.list.d/armbian.list.disabled "${SDCARD}"/etc/apt/sources.list.d/armbian.list
+
 	do_with_retries 3 chroot_sdcard_apt_get_update
 	display_alert "$BOARD" "Installing board tweaks" "info"
-	do_with_retries 3 chroot_sdcard_apt_get_install alsa-ucm-conf qbootctl qrtr-tools pd-mapper tqftpserv unudhcpd mkbootimg
+	do_with_retries 3 chroot_sdcard_apt_get_install alsa-ucm-conf qbootctl qrtr-tools protection-domain-mapper tqftpserv unudhcpd mkbootimg
+
+	# disable armbian repo back
+	mv "${SDCARD}"/etc/apt/sources.list.d/armbian.list "${SDCARD}"/etc/apt/sources.list.d/armbian.list.disabled
+	do_with_retries 3 chroot_sdcard_apt_get_update
+
 	chroot_sdcard systemctl enable qbootctl.service
 	chroot_sdcard systemctl enable usbgadget-rndis.service
 	chroot_sdcard systemctl enable pd-mapper.service

--- a/extensions/image-output-abl.sh
+++ b/extensions/image-output-abl.sh
@@ -28,16 +28,17 @@ function post_build_image__900_convert_to_abl_img() {
 
 	if [ ${#ABL_DTB_LIST[@]} -ne 0 ]; then
 		display_alert "Going to create abl kernel boot image" "${EXTENSION}" "info"
+		source ${new_rootfs_image_mount_dir}/boot/armbianEnv.txt
 		gzip -c ${new_rootfs_image_mount_dir}/boot/vmlinuz-*-* > ${DESTIMG}/Image.gz
 		for dtb_name in "${ABL_DTB_LIST[@]}"; do
-			display_alert "Creatng abl kernel boot image with dtb ${dtb_name}" "${EXTENSION}" "info"
+			display_alert "Creatng abl kernel boot image with dtb ${dtb_name} and cmdline root=UUID=${new_rootfs_image_uuid} slot_suffix=${abl_boot_partition_label#boot}" "${EXTENSION}" "info"
 			cat ${DESTIMG}/Image.gz ${new_rootfs_image_mount_dir}/usr/lib/linux-image-*/qcom/${dtb_name}.dtb > ${DESTIMG}/Image.gz-${dtb_name}
 			/usr/bin/mkbootimg \
 				--kernel ${DESTIMG}/Image.gz-${dtb_name} \
 				--ramdisk ${new_rootfs_image_mount_dir}/boot/initrd.img-*-* \
 				--base 0x0 \
 				--second_offset 0x00f00000 \
-				--cmdline "root=UUID=${new_rootfs_image_uuid}" \
+				--cmdline "root=UUID=${new_rootfs_image_uuid} slot_suffix=${abl_boot_partition_label#boot}" \
 				--kernel_offset 0x8000 \
 				--ramdisk_offset 0x1000000 \
 				--tags_offset 0x100 \

--- a/packages/bsp/xiaomi-elish/zz-update-abl-kernel
+++ b/packages/bsp/xiaomi-elish/zz-update-abl-kernel
@@ -18,12 +18,13 @@ gzip -c /boot/vmlinuz-*-sm8250-arm64 > /tmp/Image.gz
 
 cat /tmp/Image.gz /usr/lib/linux-image-*-sm8250-arm64/qcom/sm8250-xiaomi-elish-${panel_type}.dtb > /tmp/Image.gz-dtb-${panel_type}
 
+source /boot/armbianEnv.txt
 /usr/bin/mkbootimg \
         --kernel /tmp/Image.gz-dtb-${panel_type} \
         --ramdisk /boot/initrd.img-*-sm8250-arm64 \
         --base 0x0 \
         --second_offset 0x00f00000 \
-        --cmdline "root=UUID=${new_rootfs_image_uuid}" \
+        --cmdline "root=UUID=${new_rootfs_image_uuid} slot_suffix=${abl_boot_partition_label#boot}" \
         --kernel_offset 0x8000 \
         --ramdisk_offset 0x1000000 \
         --tags_offset 0x100 \
@@ -31,7 +32,6 @@ cat /tmp/Image.gz /usr/lib/linux-image-*-sm8250-arm64/qcom/sm8250-xiaomi-elish-$
         -o /boot/armbian-kernel-${panel_type}.img
 rm -f /tmp/Image.gz /tmp/Image.gz-dtb-${panel_type}
 
-source /boot/armbianEnv.txt
 if [ -n "$abl_boot_partition_label" ];then
 	echo abl boot partition label is $abl_boot_partition_label
 	dd if=/boot/armbian-kernel-${panel_type}.img of=/dev/disk/by-partlabel/${abl_boot_partition_label}


### PR DESCRIPTION
# Description

- Add support for trixie and noble. noble is not supported by armbian at the moment but I adding it should be okay.
- `unudhcpd` is imported to armbian's repo, but at the stage when `post_family_tweaks` is running, armbian's repo is disabled, so I enable it for a moment and disable it after packages are installed.
- Also add slot_suffix arg to kernel cmdline because qbootctl need  it to get current slot.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] `./compile.sh BOARD=xiaomi-elish BRANCH=sm8250 DEB_COMPRESS=xz KERNEL_GIT=shallow DEB_COMPRESS=xz RELEASE=jammy EXPERT=yes BUILD_DESKTOP=no BUILD_MINIMAL=no KERNEL_CONFIGURE=no`
- [x] `./compile.sh BOARD=xiaomi-elish BRANCH=sm8250 DEB_COMPRESS=xz KERNEL_GIT=shallow DEB_COMPRESS=xz RELEASE=trixie EXPERT=yes BUILD_DESKTOP=no BUILD_MINIMAL=yes KERNEL_CONFIGURE=no`
- [x] I haven't flashed the built images, but jammy image should work because this change doesn't harm jammy
- [x] trixie image is just built with all necessary packages, but there is one issue: qbootctl service can't get enabled because of an upstream issue: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1056714. I may fix it upstream in the future.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
