### PR TITLE
bump rk3588 edge to rc4

### DIFF
--- a/config/sources/families/rockchip-rk3588.conf
+++ b/config/sources/families/rockchip-rk3588.conf
@@ -35,7 +35,7 @@ case $BRANCH in
 		LINUXFAMILY=rockchip-rk3588
 		LINUXCONFIG='linux-rockchip-rk3588-'$BRANCH
 		KERNEL_MAJOR_MINOR="6.7" # Major and minor versions of this kernel.
-		KERNELBRANCH='tag:v6.7-rc3'
+		KERNELBRANCH='tag:v6.7-rc4'
 		KERNELPATCHDIR='rockchip-rk3588-edge'
 		;;
 


### PR DESCRIPTION
# Description

version bump for rockchip-rk3588 edge from 6.7-rc3 to rc4.

Jira reference number [-]

# How Has This Been Tested?

- [x] built on aarch64 for OPi5

From a quick look it does not seem that there are a lot of changes related to the board or even arm64 architecture in general.
Therefore booting was not tested.
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/diff/?id=v6.7-rc4&id2=v6.7-rc3&dt=2

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
