### PR TITLE
`Automatic` board configs status synchronise

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,6 +29,7 @@ config/boards/espressobin.csc		@ManoftheSea
 config/boards/firefly-rk3399.csc		@150balbes
 config/boards/fxblox-rk1.wip		@mahdichi
 config/boards/hinlink-h28k.csc		@sputnik2019
+config/boards/hinlink-ht2.csc		@hoochiwetech
 config/boards/indiedroid-nova.csc		@lanefu
 config/boards/jethubj100.conf		@adeepn
 config/boards/jethubj80.conf		@adeepn
@@ -92,7 +93,7 @@ config/boards/rockpi-4a.conf		@clee
 config/boards/rockpi-e.conf		@krachlatte
 config/boards/rockpi-s.csc		@brentr
 config/boards/rockpro64.conf		@joekhoobyar
-config/boards/rpi4b.conf		@PanderMusubi @teknoid
+config/boards/rpi4b.conf		@PanderMusubi @teknoid @viraniac
 config/boards/sk-am62b.conf		@glneo
 config/boards/sk-am64b.conf		@glneo
 config/boards/sk-tda4vm.conf		@glneo
@@ -111,7 +112,7 @@ config/boards/wsl2-arm64.csc		@rpardini
 config/boards/wsl2-x86.csc		@rpardini
 config/boards/xiaomi-elish.conf		@amazingfate
 config/kernel/linux-arm64-*.config		@amazingfate @rpardini
-config/kernel/linux-bcm2711-*.config		@PanderMusubi @teknoid
+config/kernel/linux-bcm2711-*.config		@PanderMusubi @teknoid @viraniac
 config/kernel/linux-k3-*.config		@glneo
 config/kernel/linux-media-*.config		@150balbes
 config/kernel/linux-meson-*.config		@hzyitc
@@ -119,11 +120,11 @@ config/kernel/linux-meson-s4t7-*.config		@echatzip @rpardini @viraniac
 config/kernel/linux-meson64-*.config		@NicoD-SBC @SteeManMI @Tonymac32 @adeepn @bretmlw @clee @engineer-80 @igorpecovnik @jeanrhum @monkaBlyat @pyavitz @rpardini @teknoid
 config/kernel/linux-mvebu64-*.config		@ManoftheSea
 config/kernel/linux-odroidxu4-*.config		@joekhoobyar
-config/kernel/linux-rk3568-odroid-*.config		@rpardini @utlark
-config/kernel/linux-rk35xx-*.config		@Tonymac32 @ZazaBR @amazingfate @catalinii @efectn @igorpecovnik @krachlatte @lanefu @linhz0hz @mahdichi @monkaBlyat @rpardini @sputnik2019 @vamzii
+config/kernel/linux-rk3568-odroid-*.config		@utlark
+config/kernel/linux-rk35xx-*.config		@Tonymac32 @ZazaBR @amazingfate @catalinii @efectn @hoochiwetech @igorpecovnik @krachlatte @lanefu @linhz0hz @mahdichi @monkaBlyat @rpardini @sputnik2019 @vamzii
 config/kernel/linux-rockchip-*.config		@paolosabatino
 config/kernel/linux-rockchip-rk3588-*.config		@Tonymac32 @amazingfate @efectn @igorpecovnik @lanefu @linhz0hz
-config/kernel/linux-rockchip64-*.config		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @schwar3kat @tdleiyao @vamzii
+config/kernel/linux-rockchip64-*.config		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @rpardini @schwar3kat @tdleiyao @vamzii
 config/kernel/linux-rockpis-*.config		@brentr
 config/kernel/linux-sun50iw9-*.config		@AGM1968 @krachlatte
 config/kernel/linux-sun50iw9-btt-*.config		@bigtreetech
@@ -136,35 +137,34 @@ patch/kernel/NEED-*/		@bigtreetech
 patch/kernel/archive/meson-*/		@hzyitc
 patch/kernel/archive/meson-s4t7-*/		@echatzip @rpardini @viraniac
 patch/kernel/archive/meson64-*/		@NicoD-SBC @SteeManMI @Tonymac32 @adeepn @bretmlw @clee @engineer-80 @igorpecovnik @jeanrhum @monkaBlyat @pyavitz @rpardini @teknoid
-patch/kernel/archive/odroidxu4-*/		@joekhoobyar
-patch/kernel/archive/rk3568-odroid-*/		@rpardini @utlark
-patch/kernel/archive/rk35xx-*/		@Tonymac32 @ZazaBR @amazingfate @catalinii @efectn @igorpecovnik @krachlatte @lanefu @linhz0hz @mahdichi @monkaBlyat @rpardini @sputnik2019 @vamzii
+patch/kernel/archive/rk35xx-*/		@Tonymac32 @ZazaBR @amazingfate @catalinii @efectn @hoochiwetech @igorpecovnik @krachlatte @lanefu @linhz0hz @mahdichi @monkaBlyat @rpardini @sputnik2019 @vamzii
 patch/kernel/archive/rockchip-*/		@paolosabatino
-patch/kernel/archive/rockchip64-*/		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @schwar3kat @tdleiyao @vamzii
+patch/kernel/archive/rockchip64-*/		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @rpardini @schwar3kat @tdleiyao @vamzii
 patch/kernel/archive/rockpis-*/		@brentr
 patch/kernel/archive/sm8250-*/		@amazingfate
 patch/kernel/archive/sun50iw9-*/		@AGM1968 @krachlatte
 patch/kernel/archive/sunxi-*/		@1ubuntuuser @AGM1968 @AaronNGray @DylanHP @Kreyren @PanderMusubi @StephenGraf @Tonymac32 @bigtreetech @devdotnetorg @eliasbakken @joshaspinall @krachlatte @lbmendes @schwar3kat @sgjava @teknoid @viraniac
 patch/kernel/archive/uefi-arm64-*/		@150balbes @rpardini
 patch/kernel/arm64-*/		@amazingfate @rpardini
-patch/kernel/bcm2711-*/		@PanderMusubi @teknoid
+patch/kernel/bcm2711-*/		@PanderMusubi @teknoid @viraniac
 patch/kernel/k3-*/		@glneo
 patch/kernel/media-*/		@150balbes
 patch/kernel/meson-*/		@hzyitc
 patch/kernel/meson64-*/		@NicoD-SBC @SteeManMI @Tonymac32 @adeepn @bretmlw @clee @engineer-80 @igorpecovnik @jeanrhum @monkaBlyat @pyavitz @rpardini @teknoid
 patch/kernel/mvebu64-*/		@ManoftheSea
 patch/kernel/odroidxu4-*/		@joekhoobyar
-patch/kernel/rk35xx-*/		@Tonymac32 @ZazaBR @amazingfate @catalinii @efectn @igorpecovnik @krachlatte @lanefu @linhz0hz @mahdichi @monkaBlyat @rpardini @sputnik2019 @vamzii
+patch/kernel/rk3568-odroid-*/		@utlark
+patch/kernel/rk35xx-*/		@Tonymac32 @ZazaBR @amazingfate @catalinii @efectn @hoochiwetech @igorpecovnik @krachlatte @lanefu @linhz0hz @mahdichi @monkaBlyat @rpardini @sputnik2019 @vamzii
 patch/kernel/rockchip-*/		@paolosabatino
 patch/kernel/rockchip-rk3588-*/		@Tonymac32 @amazingfate @efectn @igorpecovnik @lanefu @linhz0hz
-patch/kernel/rockchip64-*/		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @schwar3kat @tdleiyao @vamzii
+patch/kernel/rockchip64-*/		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @rpardini @schwar3kat @tdleiyao @vamzii
 patch/kernel/rockpis-*/		@brentr
 patch/kernel/sun50iw9-*/		@AGM1968 @krachlatte
 patch/kernel/thead-*/		@chainsx
 patch/kernel/uefi-arm64-*/		@150balbes @rpardini
 patch/kernel/uefi-x86-*/		@rpardini
 sources/families/arm64.conf		@150balbes @amazingfate @rpardini
-sources/families/bcm2711.conf		@PanderMusubi @teknoid
+sources/families/bcm2711.conf		@PanderMusubi @teknoid @viraniac
 sources/families/k3.conf		@glneo
 sources/families/media.conf		@150balbes
 sources/families/meson-s4t7.conf		@echatzip @rpardini @viraniac
@@ -172,11 +172,11 @@ sources/families/meson.conf		@hzyitc
 sources/families/meson64.conf		@NicoD-SBC @SteeManMI @Tonymac32 @adeepn @bretmlw @clee @engineer-80 @igorpecovnik @jeanrhum @monkaBlyat @pyavitz @rpardini @teknoid
 sources/families/mvebu64.conf		@ManoftheSea
 sources/families/odroidxu4.conf		@joekhoobyar
-sources/families/rk3568-odroid.conf		@rpardini @utlark
-sources/families/rk35xx.conf		@Tonymac32 @ZazaBR @amazingfate @catalinii @efectn @igorpecovnik @krachlatte @lanefu @linhz0hz @mahdichi @monkaBlyat @rpardini @sputnik2019 @vamzii
+sources/families/rk3568-odroid.conf		@utlark
+sources/families/rk35xx.conf		@Tonymac32 @ZazaBR @amazingfate @catalinii @efectn @hoochiwetech @igorpecovnik @krachlatte @lanefu @linhz0hz @mahdichi @monkaBlyat @rpardini @sputnik2019 @vamzii
 sources/families/rockchip-rk3588.conf		@Tonymac32 @amazingfate @efectn @igorpecovnik @lanefu @linhz0hz
 sources/families/rockchip.conf		@paolosabatino
-sources/families/rockchip64.conf		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @schwar3kat @tdleiyao @vamzii
+sources/families/rockchip64.conf		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @rpardini @schwar3kat @tdleiyao @vamzii
 sources/families/rockpis.conf		@brentr
 sources/families/sun50iw9-btt.conf		@bigtreetech
 sources/families/sun50iw9.conf		@AGM1968 @krachlatte

--- a/config/boards/khadas-vim1s.conf
+++ b/config/boards/khadas-vim1s.conf
@@ -2,7 +2,7 @@
 BOARD_NAME="Khadas VIM1S" # don't confuse with VIM1 (S905X)
 BOARDFAMILY="meson-s4t7"
 KERNEL_TARGET="legacy"
-BOARD_MAINTAINER="rpardini viraniac"
+BOARD_MAINTAINER="viraniac rpardini"
 SERIALCON="ttyS0" # for vendor kernel
 # BOOT_FDT_FILE="amlogic/kvim1s.dtb" # unset on purpose: uboot auto-determines the DTB to use
 

--- a/config/boards/khadas-vim4.conf
+++ b/config/boards/khadas-vim4.conf
@@ -2,7 +2,7 @@
 BOARD_NAME="Khadas VIM4"
 BOARDFAMILY="meson-s4t7"
 KERNEL_TARGET="legacy"
-BOARD_MAINTAINER="rpardini echatzip viraniac"
+BOARD_MAINTAINER="viraniac rpardini echatzip"
 SERIALCON="ttyS0" # for vendor kernel
 # BOOT_FDT_FILE="amlogic/kvim4.dtb" # not set on purpose; u-boot auto-selects kvim4.dtb or kvim4n.dtb for "new VIM4"
 

--- a/config/boards/rpi4b.conf
+++ b/config/boards/rpi4b.conf
@@ -1,7 +1,7 @@
 # Broadcom BCM2711 quad core 1-8Gb RAM SoC USB3 GBE USB-C WiFi/BT
 declare -g BOARD_NAME="Raspberry Pi 4"
 declare -g BOARDFAMILY="bcm2711"
-declare -g BOARD_MAINTAINER="teknoid PanderMusubi"
+declare -g BOARD_MAINTAINER="viraniac teknoid PanderMusubi"
 declare -g KERNEL_TARGET="legacy,current,edge"
 declare -g FK__MACHINE_MODEL="Raspberry Pi 4 Model B" # flash kernel (FK) configuration
 declare -g ASOUND_STATE="asound.state.rpi"


### PR DESCRIPTION
Update maintainers and board status

- synced status from the database
- rename to .`csc` where we don't have anyone

If you want to become a board maintainer, [adjust data here](https://www.armbian.com/update-data/).

Ref: [Board Maintainers Procedures and Guidelines](https://docs.armbian.com/Board_Maintainers_Procedures_and_Guidelines/)