### PR TITLE
Update armbian-ramlog

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-ramlog
+++ b/packages/bsp/common/usr/lib/armbian/armbian-ramlog
@@ -147,7 +147,7 @@ case "$1" in
 		;;
 	postrotate)
 		cd /var/log.hdd/
-		find . -type f -print | grep -E -v "(\.gz|\.xz|\.[0-9]|armbian-ramlog)" | while IFS= read -r  file
+		find . -type f -print | grep -E -v "(\.gz|\.xz|\.[0-9]|armbian-ramlog)|\.journal" | while IFS= read -r  file
 		do
 	    		dest="/var/log/$file"
 	    		cat $file > $dest	    


### PR DESCRIPTION
Original version destroyed journal on command postrotate as files in /var/log.hdd/journal are overwritten by cat. With the patch journal is not damaged anymore.

# Description
 
In original version in postrotate files in /var/log.hdd/journal are deleted by the command

dest="/var/log/$file"
cat $file > $dest 

as /var/log/journal is a symling to /var/log.hdd/journal files are cated on themselves which ends up with an empty file.

# How Has This Been Tested?

check journal by journactl. There is no data earlier than today 0:00.
Also "journalctl --verify" shows that journal is damaged.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
