### PR TITLE
rockchip64: Fix "Load kernel from the same bootpart boot.scr was loaded from"

### DIFF
--- a/config/bootscripts/boot-rockchip64.cmd
+++ b/config/bootscripts/boot-rockchip64.cmd
@@ -14,7 +14,7 @@ setenv rootfstype "ext4"
 setenv docker_optimizations "on"
 setenv earlycon "off"
 
-env exists distro_bootpart || setenv distro_bootpart 1
+test -n "${distro_bootpart}" || distro_bootpart=1
 
 echo "Boot script loaded from ${devtype} ${devnum}:${distro_bootpart}"
 


### PR DESCRIPTION

# Description

Small followup fix https://github.com/armbian/build/pull/6006

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x]  Compile and boot rk3318-box from second partition

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
