### PR TITLE
opi5: edge: mainline uboot & dt for opi5b

### DIFF
--- a/config/boards/orangepi5.conf
+++ b/config/boards/orangepi5.conf
@@ -24,6 +24,10 @@ declare -g BLUETOOTH_HCIATTACH_PARAMS="-s 115200 /dev/ttyS9 bcm43xx 1500000" # F
 enable_extension "bluetooth-hciattach"                                       # Enable the bluetooth-hciattach extension
 
 function post_family_tweaks_bsp__orangepi5_copy_usb2_service() {
+	if [[ $BRANCH == "edge" ]]; then
+		return
+	fi
+
 	display_alert "Installing BSP firmware and fixups"
 
 	# Add USB2 init service. Otherwise, USB2 and TYPE-C won't work by default
@@ -33,6 +37,10 @@ function post_family_tweaks_bsp__orangepi5_copy_usb2_service() {
 }
 
 function post_family_tweaks__orangepi5_enable_usb2_service() {
+	if [[ $BRANCH == "edge" ]]; then
+		return
+	fi
+
 	display_alert "$BOARD" "Installing board tweaks" "info"
 
 	# enable usb2 init service
@@ -42,6 +50,10 @@ function post_family_tweaks__orangepi5_enable_usb2_service() {
 }
 
 function post_family_tweaks__orangepi5_naming_audios() {
+	if [[ $BRANCH == "edge" ]]; then
+		return
+	fi
+
 	display_alert "$BOARD" "Renaming orangepi5 audios" "info"
 
 	mkdir -p $SDCARD/etc/udev/rules.d/
@@ -62,6 +74,10 @@ function post_family_config_branch_legacy__orangepi5_uboot_add_sata_target() {
 }
 
 function post_uboot_custom_postprocess__create_sata_spi_image() {
+	if [[ $BRANCH == "edge" ]]; then
+		return
+	fi
+
 	display_alert "$BOARD" "Create rkspi_loader_sata.img" "info"
 
 	dd if=/dev/zero of=rkspi_loader_sata.img bs=1M count=0 seek=16
@@ -77,9 +93,23 @@ function post_uboot_custom_postprocess__create_sata_spi_image() {
 	dd if=u-boot.itb of=rkspi_loader_sata.img seek=16384 conv=notrunc
 }
 
+function add_host_dependencies__mainline_uboot_wants_python3_orangepi5() {
+	if [[ $BRANCH == "edge" ]]; then
+		declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} python3-pyelftools" # @TODO: convert to array later
+	fi
+}
+
 # Override family config for this board; let's avoid conditionals in family config.
 function post_family_config__orangepi5_use_vendor_uboot() {
-	BOOTSOURCE='https://github.com/orangepi-xunlong/u-boot-orangepi.git'
-	BOOTBRANCH='branch:v2017.09-rk3588'
-	BOOTPATCHDIR="legacy"
+	if [[ $BRANCH == "edge" ]]; then
+		BOOTCONFIG="orangepi-5-rk3588s_defconfig"
+		BOOTSOURCE="https://github.com/u-boot/u-boot.git"
+		BOOTBRANCH="commit:2f0282922b2c458eea7f85c500a948a587437b63"
+		BOOTDIR="u-boot-${BOARD}"
+		BOOTPATCHDIR="v2024.01-orangepi5"
+	else
+		BOOTSOURCE='https://github.com/orangepi-xunlong/u-boot-orangepi.git'
+		BOOTBRANCH='branch:v2017.09-rk3588'
+		BOOTPATCHDIR="legacy"
+	fi
 }

--- a/patch/kernel/rockchip-rk3588-edge/0026-Add-missing-nodes-to-Orange-Pi-5.patch
+++ b/patch/kernel/rockchip-rk3588-edge/0026-Add-missing-nodes-to-Orange-Pi-5.patch
@@ -1,14 +1,14 @@
-From da15e8eb421ad3dc0834a5fca9a8086785d1100f Mon Sep 17 00:00:00 2001
+From ebb2c6d43396961abcadab85de3189de9b4a7497 Mon Sep 17 00:00:00 2001
 From: Muhammed Efe Cetin <efectn@protonmail.com>
 Date: Thu, 16 Nov 2023 18:09:07 +0300
-Subject: [PATCH 2/3] arm64: dts: Add missing nodes to Orange Pi 5
+Subject: [PATCH 1/2] arm64: dts: Add missing nodes to Orange Pi 5
 
 ---
- .../boot/dts/rockchip/rk3588s-orangepi-5.dts  | 234 +++++++++++++++++-
- 1 file changed, 233 insertions(+), 1 deletion(-)
+ .../boot/dts/rockchip/rk3588s-orangepi-5.dts  | 228 +++++++++++++++++-
+ 1 file changed, 227 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dts b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dts
-index 8f399c4317bd..25125993132e 100644
+index 8f399c4317bd..8ccfbf25fbe2 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dts
 @@ -6,6 +6,8 @@
@@ -20,7 +20,7 @@ index 8f399c4317bd..25125993132e 100644
  #include "rk3588s.dtsi"
  
  / {
-@@ -47,6 +49,57 @@ led-1 {
+@@ -47,6 +49,51 @@ led-1 {
  		};
  	};
  
@@ -36,14 +36,8 @@ index 8f399c4317bd..25125993132e 100644
 +		simple-audio-card,mclk-fs = <256>;
 +		simple-audio-card,pin-switches = "Headphones", "Speaker";
 +		simple-audio-card,routing =
-+			"Speaker Amplifier INL", "LOUT2",
-+			"Speaker Amplifier INR", "ROUT2",
-+			"Speaker", "Speaker Amplifier OUTL",
-+			"Speaker", "Speaker Amplifier OUTR",
-+			"Headphones Amplifier INL", "LOUT1",
-+			"Headphones Amplifier INR", "ROUT1",
-+			"Headphones", "Headphones Amplifier OUTL",
-+			"Headphones", "Headphones Amplifier OUTR",
++			"Headphones", "LOUT1",
++			"Headphones", "ROUT1",
 +			"LINPUT1", "Onboard Microphone",
 +			"RINPUT1", "Onboard Microphone",
 +			"LINPUT2", "Microphone Jack",
@@ -78,7 +72,7 @@ index 8f399c4317bd..25125993132e 100644
  	vbus_typec: vbus-typec-regulator {
  		compatible = "regulator-fixed";
  		enable-active-high;
-@@ -102,34 +155,42 @@ &combphy2_psu {
+@@ -102,34 +149,42 @@ &combphy2_psu {
  
  &cpu_b0 {
  	cpu-supply = <&vdd_cpu_big0_s0>;
@@ -121,7 +115,7 @@ index 8f399c4317bd..25125993132e 100644
  };
  
  &gmac1 {
-@@ -223,6 +284,75 @@ hym8563: rtc@51 {
+@@ -223,6 +278,75 @@ hym8563: rtc@51 {
  		interrupts = <RK_PB0 IRQ_TYPE_LEVEL_LOW>;
  		wakeup-source;
  	};
@@ -153,8 +147,8 @@ index 8f399c4317bd..25125993132e 100644
 +			power-role = "dual";
 +			try-power-role = "source";
 +			op-sink-microwatt = <1000000>;
-+			sink-pdos = <PDO_FIXED(5000, 2000, PDO_FIXED_USB_COMM)>;
-+			source-pdos = <PDO_FIXED(5000, 1500, PDO_FIXED_USB_COMM)>;
++			sink-pdos = <PDO_FIXED(5000, 1000, PDO_FIXED_USB_COMM)>;
++			source-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>;
 +
 +			ports {
 +				#address-cells = <1>;
@@ -197,7 +191,7 @@ index 8f399c4317bd..25125993132e 100644
  };
  
  &mdio1 {
-@@ -263,6 +393,12 @@ typec5v_pwren: typec5v-pwren {
+@@ -263,6 +387,12 @@ typec5v_pwren: typec5v-pwren {
  			rockchip,pins = <3 RK_PC0 RK_FUNC_GPIO &pcfg_pull_none>;
  		};
  	};
@@ -210,7 +204,7 @@ index 8f399c4317bd..25125993132e 100644
  };
  
  &saradc {
-@@ -363,7 +499,7 @@ regulator-state-mem {
+@@ -363,7 +493,7 @@ regulator-state-mem {
  				};
  			};
  
@@ -219,7 +213,7 @@ index 8f399c4317bd..25125993132e 100644
  				regulator-name = "vdd_cpu_lit_s0";
  				regulator-always-on;
  				regulator-boot-on;
-@@ -624,6 +760,14 @@ &tsadc {
+@@ -624,6 +754,14 @@ &tsadc {
  	status = "okay";
  };
  
@@ -234,7 +228,7 @@ index 8f399c4317bd..25125993132e 100644
  &u2phy2 {
  	status = "okay";
  };
-@@ -649,10 +793,56 @@ &usb_host0_ehci {
+@@ -649,10 +787,56 @@ &usb_host0_ehci {
  	status = "okay";
  };
  
@@ -291,7 +285,7 @@ index 8f399c4317bd..25125993132e 100644
  &usb_host1_ehci {
  	status = "okay";
  };
-@@ -660,3 +850,45 @@ &usb_host1_ehci {
+@@ -660,3 +844,45 @@ &usb_host1_ehci {
  &usb_host1_ohci {
  	status = "okay";
  };
@@ -339,5 +333,5 @@ index 8f399c4317bd..25125993132e 100644
 +};
 \ No newline at end of file
 -- 
-2.42.1
+2.43.0
 

--- a/patch/kernel/rockchip-rk3588-edge/dt/rk3588s-orangepi-5b.dts
+++ b/patch/kernel/rockchip-rk3588-edge/dt/rk3588s-orangepi-5b.dts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+
+/dts-v1/;
+
+#include "rk3588s-orangepi-5.dts"
+
+/ {
+	model = "Xunlong Orange Pi 5B";
+	compatible = "xunlong,orangepi-5b", "rockchip,rk3588s";
+
+	aliases {
+		mmc0 = &sdmmc;
+		mmc1 = &sdhci;
+	};
+};
+
+&sdhci {
+	bus-width = <8>;
+	no-sdio;
+	no-sd;
+	non-removable;
+	/* HS400 doesn't work properly -> https://github.com/torvalds/linux/commit/cee572756aa2cb46e959e9797ad4b730b78a050b */
+	mmc-hs200-1_8v;
+	max-frequency = <200000000>;
+	status = "okay";
+};
+
+&sfc {
+	status = "disabled";
+};


### PR DESCRIPTION
# Description
This PR fixes ES8388 audio on OPi5, add opi5b devicetree and add mainline uboot support.

Jira reference number [AR-9999]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Boots well with 2024.01-rc4 uboot
- [x] There are no es8388 errors in dmesg output

It would be nice if someone tests SPI flash boot + nvme ssd. I've not tried it because i don't have free M2 ssd rn. 
[rkspi_loader.zip](https://github.com/armbian/build/files/13629163/rkspi_loader.zip)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
