### PR TITLE
odroidhc4: Fix U-Boot not recognizing disks mounted in SATA ports during boot process

### DIFF
--- a/patch/u-boot/v2023.01/board_odroidhc4/0001-HACK-configs-meson64-prevent-stdout-stderr-on-videoconsole.patch
+++ b/patch/u-boot/v2023.01/board_odroidhc4/0001-HACK-configs-meson64-prevent-stdout-stderr-on-videoconsole.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jihoon Han <rapid_renard@renard.kr>
+Date: Mon, 11 Dec 2023 04:47:08 +0900
+Subject: [PATCH] HACK: configs: meson64: prevent stdout/stderr on
+ videoconsole
+
+Several devices have CONFIG_DM_VIDEO enabled which causes stdout/stderr
+to appear on videoconsole, so remove videoconsole from STDOUT so that
+early u-boot boot remains silent unless using the uart/serial console.
+
+Signed-off-by: Jihoon Han <rapid_renard@renard.kr>
+---
+ include/configs/meson64.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/configs/meson64.h b/include/configs/meson64.h
+index d21899c335..2ac866c9ca 100644
+--- a/include/configs/meson64.h
++++ b/include/configs/meson64.h
+@@ -23,11 +23,11 @@
+ 		230400, 250000, 460800, 500000, 1000000, 2000000, 4000000, \
+ 		8000000 }
+ 
+ /* For splashscreen */
+ #ifdef CONFIG_VIDEO
+-#define STDOUT_CFG "vidconsole,serial"
++#define STDOUT_CFG "serial"
+ #else
+ #define STDOUT_CFG "serial"
+ #endif
+ 
+ #ifdef CONFIG_USB_KEYBOARD
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+


### PR DESCRIPTION
# Description

Recently, I accidentally erased an SPI flash with an bootloader installed and tried to reinstall the latest bootloader.
But it did not recognize the attached disks and proceeded to TFTP Boot.

Only by stopping autoboot and hot-swapping or reattaching the disks did the bootloader recognize it, and I was then able to boot with the manual command.

I investigated and found that the problem occured after U-Boot was updated to v2023.01.
This issue has been resolved by applying a patch that was previously used in v2022.07.

# How Has This Been Tested?

By compiling U-Boot from trunk (linux-u-boot-odroidhc4-current_24.2.0-trunk) for v2023.01, v2023.04, v2023.07, v2023.10 and testing those on ODROID-HC4.

- [X] Test A - Compiling U-Boot without patch and trying to boot in v2023.01 and later versions

```
U-Boot 2023.01 (Dec 10 2023 - 18:25:52 +0900) odroid-hc4

Model: Hardkernel ODROID-HC4
SoC:   Amlogic Meson SM1 (S905X3) Revision 2b:c (10:2)
DRAM:  1 GiB (effective 3.8 GiB)
Core:  392 devices, 32 uclasses, devicetree: separate
MMC:   sd@ffe05000: 0
Loading Environment from nowhere... OK
In:    serial
Out:   serial
Err:   serial
Board variant: hc4
Net:   eth0: ethernet@ff3f0000
PCIE-0: Link up (Gen2-x1, Bus0)
starting USB...
Bus usb@ff500000: Register 3000140 NbrPorts 3
Starting the controller
USB XHCI 1.10
scanning bus usb@ff500000 for devices... 1 USB Device(s) found
       scanning usb for storage devices... 0 Storage Device(s) found
Hit any key to stop autoboot:  2  1  0 

Device 0: unknown device
scanning bus for devices...
SATA link 0 timeout.
SATA link 1 timeout.
AHCI 0001.0200 32 slots 2 ports 6 Gbps 0x3 impl SATA mode
flags: 64bit ncq stag led clo pmp pio slum part ccc sxs 

Device 0: unknown device
Card did not respond to voltage select! : -110
MMC Device 1 not found
no mmc device at slot 1
MMC Device 2 not found
no mmc device at slot 2
Speed: 1000, full duplex
BOOTP broadcast 1
DHCP client bound to address 192.168.0.4 (7 ms)
*** Warning: no boot file name; using 'C0A80004.img'
Using ethernet@ff3f0000 device
TFTP from server 192.168.0.1; our IP address is 192.168.0.4
Filename 'C0A80004.img'.
Load address: 0x1000000
```

- [x] Test B - Compiling U-Boot with applying patch and trying to boot in v2023.01 and later versions

```
U-Boot 2023.01 (Dec 10 2023 - 22:20:23 +0900) odroid-hc4

Model: Hardkernel ODROID-HC4
SoC:   Amlogic Meson SM1 (S905X3) Revision 2b:c (10:2)
DRAM:  1 GiB (effective 3.8 GiB)
Core:  389 devices, 30 uclasses, devicetree: separate
MMC:   sd@ffe05000: 0
Loading Environment from nowhere... OK
In:    serial
Out:   serial
Err:   serial
Board variant: hc4
Net:   eth0: ethernet@ff3f0000
PCIE-0: Link up (Gen2-x1, Bus0)
starting USB...
Bus usb@ff500000: Register 3000140 NbrPorts 3
Starting the controller
USB XHCI 1.10
scanning bus usb@ff500000 for devices... 1 USB Device(s) found
       scanning usb for storage devices... 0 Storage Device(s) found
Hit any key to stop autoboot:  2  1  0 

Device 0: unknown device
scanning bus for devices...
Target spinup took 0 ms.
Target spinup took 0 ms.
AHCI 0001.0200 32 slots 2 ports 6 Gbps 0x3 impl SATA mode
flags: 64bit ncq stag led clo pmp pio slum part ccc sxs 
  Device 0: (0:0) Vendor: ATA Prod.: Samsung SSD 860 Rev: RVT0
            Type: Hard Disk
            Capacity: 953869.7 MB = 931.5 GB (1953525168 x 512)
  Device 1: (1:0) Vendor: ATA Prod.: Samsung SSD 860 Rev: RVT0
            Type: Hard Disk
            Capacity: 953869.7 MB = 931.5 GB (1953525168 x 512)

Device 0: (0:0) Vendor: ATA Prod.: Samsung SSD 860 Rev: RVT0
            Type: Hard Disk
            Capacity: 953869.7 MB = 931.5 GB (1953525168 x 512)
... is now current device
Scanning scsi 0:1...
Found U-Boot script /boot/boot.scr
8147 bytes read in 2 ms (3.9 MiB/s)
## Executing script at 08000000
U-boot default fdtfile: amlogic/meson-sm1-odroid-hc4.dtb
Current variant: hc4
226 bytes read in 1 ms (220.7 KiB/s)
Current fdtfile after armbianEnv: amlogic/meson-sm1-odroid-hc4.dtb
Mainline bootargs: root=UUID=masked rootwait rootfstype=ext4 splash=verbose console=ttyAML0,115200 console=tty1 consoleblank=0 coherent_pool=2M loglevel=7 ubootpart= libata.force=noncq usb-storage.quirks=0x2537:0x1066:u,0x2537:0x1068:u  net.ifnames=0  cgroup_enable=memory swapaccount=1
19016823 bytes read in 298 ms (60.9 MiB/s)
27433472 bytes read in 426 ms (61.4 MiB/s)
76314 bytes read in 13 ms (5.6 MiB/s)
Working FDT set to 4080000
232 bytes read in 4 ms (56.6 KiB/s)
Applying kernel provided DT fixup script (meson-fixup.scr)
## Executing script at 32000000
## Loading init Ramdisk from Legacy Image at 13000000 ...
   Image Name:   uInitrd
   Image Type:   AArch64 Linux RAMDisk Image (gzip compressed)
   Data Size:    19016759 Bytes = 18.1 MiB
   Load Address: 00000000
   Entry Point:  00000000
   Verifying Checksum ... OK
## Flattened Device Tree blob at 04080000
   Booting using the fdt blob at 0x4080000
Working FDT set to 4080000
   Loading Ramdisk to 3eddd000, end 3ffffc37 ... OK
   Loading Device Tree to 000000003ed62000, end 000000003eddcfff ... OK
Working FDT set to 3ed62000

Starting kernel ...
```

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
