### PR TITLE
Remove TOC as its generated automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,20 +9,6 @@
 <a href=https://github.com/armbian/build/commits/main><img alt="GitHub last commit (branch)" src="https://img.shields.io/github/last-commit/armbian/build/main?logo=github&label=Last%20commit&style=for-the-badge&branch=main&logoColor=white"></a>
 </p>
 
-## Table of contents
-
-- [What does this project do?](#what-does-this-project-do)
-- [Getting started](#getting-started)
-- [Compared with industry standards](#compared-with-industry-standards)
-- [Download prebuilt images](#download-prebuilt-images)
-- [Project structure](#project-structure)
-- [Contribution](#contribution)
-- [Support](#support)
-- [Contact](#contact)
-- [Contributors](#contributors)
-- [Partners](#armbian-partners)
-- [License](#license)
-
 ## What does this project do?
 
 - Builds custom **kernel**, **image** or a **distribution** optimized for low-resource hardware,
@@ -40,7 +26,7 @@
 
 ### Start with the build script
 
-#### Development branch:
+##### Development branch:
 
 ```bash
 apt-get -y install git
@@ -49,7 +35,7 @@ cd build
 ./compile.sh
 ```
 
-#### Stable branch:
+##### Stable branch:
 
 ```bash
 apt-get -y install git
@@ -198,7 +184,7 @@ Function | Armbian | Yocto | Buildroot |
 
 ### You don't need to be a programmer to help!
 
-The easiest way to help is by "Starring" our repository - it helps more people find our code. 
+The easiest way to help is by "Starring" our repository - it helps more people find our code.
 
 - [Check out our list of volunteer positions](https://forum.armbian.com/staffapplications/) and choose what you want to do ❤️
 - [Mirror our download infrastructure](https://github.com/armbian/mirror/)  ❤️
@@ -221,8 +207,8 @@ To help with development, review [this document](CONTRIBUTING.md) and move strai
 For commercial or prioritized assistance:
  - Book an hour of [professional consultation](https://calendly.com/armbian/consultation)
  - Consider becoming a [project partner](https://forum.armbian.com/subscriptions/)
- - [Contact us](https://armbian.com/contact)! 
- 
+ - [Contact us](https://armbian.com/contact)!
+
 Free support:
 
  Find free support via [general project search engine](https://www.armbian.com/search), [documentation](https://docs.armbian.com), [community forums](https://forum.armbian.com/) or [IRC/Discord](https://docs.armbian.com/Community_IRC/). Remember that our awesome community members mainly provide this in a **best-effort** manner, so there are no guaranteed solutions.


### PR DESCRIPTION
# Description

TOC is generated by GitHub, so we don't need to expose it.

![image](https://github.com/armbian/build/assets/6281704/62bb8fbd-f412-47f8-b40b-b2796ff66a1b)

# Checklist:

- [x] My code follows the style guidelines of this project