### PR TITLE
Add efi=noruntime to Jetson Nano kernel parameters.

### DIFF
--- a/config/boards/jetson-nano.csc
+++ b/config/boards/jetson-nano.csc
@@ -6,6 +6,6 @@ declare -g KERNEL_TARGET="current,edge"
 
 declare -g BOOT_LOGO=desktop
 
-declare -g GRUB_CMDLINE_LINUX_DEFAULT="console=ttyS0,115200n8"
+declare -g GRUB_CMDLINE_LINUX_DEFAULT="efi=noruntime console=ttyS0,115200n8"
 declare -g BOOT_FDT_FILE="nvidia/tegra210-p3450-0000.dtb"
 enable_extension "grub-with-dtb"


### PR DESCRIPTION
# Description

Fixes board not properly powering off and rebooting.

# How Has This Been Tested?

- [x] Reboots again
- [x] Powers off again

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
