### PR TITLE
Remove deprecated bits in patches that prevent compilation

### DIFF
--- a/patch/kernel/archive/rk322x-6.1/01-linux-1001-v4l2-rockchip.patch
+++ b/patch/kernel/archive/rk322x-6.1/01-linux-1001-v4l2-rockchip.patch
@@ -343,31 +343,6 @@ index b9e219438bc9..f02f79c405f0 100644
  
  struct rkvdec_ctx {
 
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Alex Bee <knaerzche@gmail.com>
-Date: Tue, 18 Aug 2020 11:38:04 +0200
-Subject: [PATCH] WIP: arm64: dts: add resets to vdec for RK3399
-
----
- arch/arm64/boot/dts/rockchip/rk3399.dtsi | 10 +++++++++-
- 1 file changed, 9 insertions(+), 1 deletion(-)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3399.dtsi b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-index 980b12cb0a49..6e3149e587c5 100644
---- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-+++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-@@ -1062,7 +1062,10 @@ power-domain@RK3399_PD_VCODEC {
- 			power-domain@RK3399_PD_VDU {
- 				reg = <RK3399_PD_VDU>;
- 				clocks = <&cru ACLK_VDU>,
--					 <&cru HCLK_VDU>;
-+					 <&cru HCLK_VDU>,
-+					 <&cru SCLK_VDU_CA>,
-+					 <&cru SCLK_VDU_CORE>;
-+
- 				pm_qos = <&qos_video_m1_r>,
- 					 <&qos_video_m1_w>;
- 				#power-domain-cells = <0>;
 @@ -1345,6 +1348,11 @@ vdec: video-codec@ff660000 {
  		clock-names = "axi", "ahb", "cabac", "core";
  		iommus = <&vdec_mmu>;
@@ -380,30 +355,6 @@ index 980b12cb0a49..6e3149e587c5 100644
  	};
  
  	vdec_mmu: iommu@ff660480 {
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Alex Bee <knaerzche@gmail.com>
-Date: Fri, 1 Jan 2021 12:11:12 +0200
-Subject: [PATCH] arm64: dts: rockchip: fix RK3399 vdec register witdh
-
-Signed-off-by: Alex Bee <knaerzche@gmail.com>
----
- arch/arm64/boot/dts/rockchip/rk3399.dtsi | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3399.dtsi b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-index 6e3149e587c5..093ebe070775 100644
---- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-+++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-@@ -1341,7 +1341,7 @@ vpu_mmu: iommu@ff650800 {
- 
- 	vdec: video-codec@ff660000 {
- 		compatible = "rockchip,rk3399-vdec";
--		reg = <0x0 0xff660000 0x0 0x400>;
-+		reg = <0x0 0xff660000 0x0 0x480>;
- 		interrupts = <GIC_SPI 116 IRQ_TYPE_LEVEL_HIGH 0>;
- 		clocks = <&cru ACLK_VDU>, <&cru HCLK_VDU>,
- 			 <&cru SCLK_VDU_CA>, <&cru SCLK_VDU_CORE>;
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Alex Bee <knaerzche@gmail.com>

--- a/patch/kernel/archive/rk322x-6.6/01-linux-1001-v4l2-rockchip.patch
+++ b/patch/kernel/archive/rk322x-6.6/01-linux-1001-v4l2-rockchip.patch
@@ -343,31 +343,6 @@ index b9e219438bc9..f02f79c405f0 100644
  
  struct rkvdec_ctx {
 
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Alex Bee <knaerzche@gmail.com>
-Date: Tue, 18 Aug 2020 11:38:04 +0200
-Subject: [PATCH] WIP: arm64: dts: add resets to vdec for RK3399
-
----
- arch/arm64/boot/dts/rockchip/rk3399.dtsi | 10 +++++++++-
- 1 file changed, 9 insertions(+), 1 deletion(-)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3399.dtsi b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-index 980b12cb0a49..6e3149e587c5 100644
---- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-+++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-@@ -1062,7 +1062,10 @@ power-domain@RK3399_PD_VCODEC {
- 			power-domain@RK3399_PD_VDU {
- 				reg = <RK3399_PD_VDU>;
- 				clocks = <&cru ACLK_VDU>,
--					 <&cru HCLK_VDU>;
-+					 <&cru HCLK_VDU>,
-+					 <&cru SCLK_VDU_CA>,
-+					 <&cru SCLK_VDU_CORE>;
-+
- 				pm_qos = <&qos_video_m1_r>,
- 					 <&qos_video_m1_w>;
- 				#power-domain-cells = <0>;
 @@ -1345,6 +1348,11 @@ vdec: video-codec@ff660000 {
  		clock-names = "axi", "ahb", "cabac", "core";
  		iommus = <&vdec_mmu>;
@@ -380,30 +355,6 @@ index 980b12cb0a49..6e3149e587c5 100644
  	};
  
  	vdec_mmu: iommu@ff660480 {
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Alex Bee <knaerzche@gmail.com>
-Date: Fri, 1 Jan 2021 12:11:12 +0200
-Subject: [PATCH] arm64: dts: rockchip: fix RK3399 vdec register witdh
-
-Signed-off-by: Alex Bee <knaerzche@gmail.com>
----
- arch/arm64/boot/dts/rockchip/rk3399.dtsi | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3399.dtsi b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-index 6e3149e587c5..093ebe070775 100644
---- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-+++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-@@ -1341,7 +1341,7 @@ vpu_mmu: iommu@ff650800 {
- 
- 	vdec: video-codec@ff660000 {
- 		compatible = "rockchip,rk3399-vdec";
--		reg = <0x0 0xff660000 0x0 0x400>;
-+		reg = <0x0 0xff660000 0x0 0x480>;
- 		interrupts = <GIC_SPI 116 IRQ_TYPE_LEVEL_HIGH 0>;
- 		clocks = <&cru ACLK_VDU>, <&cru HCLK_VDU>,
- 			 <&cru SCLK_VDU_CA>, <&cru SCLK_VDU_CORE>;
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Alex Bee <knaerzche@gmail.com>

--- a/patch/kernel/archive/rockchip-6.1/01-linux-1001-v4l2-rockchip.patch
+++ b/patch/kernel/archive/rockchip-6.1/01-linux-1001-v4l2-rockchip.patch
@@ -343,31 +343,6 @@ index b9e219438bc9..f02f79c405f0 100644
  
  struct rkvdec_ctx {
 
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Alex Bee <knaerzche@gmail.com>
-Date: Tue, 18 Aug 2020 11:38:04 +0200
-Subject: [PATCH] WIP: arm64: dts: add resets to vdec for RK3399
-
----
- arch/arm64/boot/dts/rockchip/rk3399.dtsi | 10 +++++++++-
- 1 file changed, 9 insertions(+), 1 deletion(-)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3399.dtsi b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-index 980b12cb0a49..6e3149e587c5 100644
---- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-+++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-@@ -1062,7 +1062,10 @@ power-domain@RK3399_PD_VCODEC {
- 			power-domain@RK3399_PD_VDU {
- 				reg = <RK3399_PD_VDU>;
- 				clocks = <&cru ACLK_VDU>,
--					 <&cru HCLK_VDU>;
-+					 <&cru HCLK_VDU>,
-+					 <&cru SCLK_VDU_CA>,
-+					 <&cru SCLK_VDU_CORE>;
-+
- 				pm_qos = <&qos_video_m1_r>,
- 					 <&qos_video_m1_w>;
- 				#power-domain-cells = <0>;
 @@ -1345,6 +1348,11 @@ vdec: video-codec@ff660000 {
  		clock-names = "axi", "ahb", "cabac", "core";
  		iommus = <&vdec_mmu>;
@@ -380,30 +355,6 @@ index 980b12cb0a49..6e3149e587c5 100644
  	};
  
  	vdec_mmu: iommu@ff660480 {
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Alex Bee <knaerzche@gmail.com>
-Date: Fri, 1 Jan 2021 12:11:12 +0200
-Subject: [PATCH] arm64: dts: rockchip: fix RK3399 vdec register witdh
-
-Signed-off-by: Alex Bee <knaerzche@gmail.com>
----
- arch/arm64/boot/dts/rockchip/rk3399.dtsi | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3399.dtsi b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-index 6e3149e587c5..093ebe070775 100644
---- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-+++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-@@ -1341,7 +1341,7 @@ vpu_mmu: iommu@ff650800 {
- 
- 	vdec: video-codec@ff660000 {
- 		compatible = "rockchip,rk3399-vdec";
--		reg = <0x0 0xff660000 0x0 0x400>;
-+		reg = <0x0 0xff660000 0x0 0x480>;
- 		interrupts = <GIC_SPI 116 IRQ_TYPE_LEVEL_HIGH 0>;
- 		clocks = <&cru ACLK_VDU>, <&cru HCLK_VDU>,
- 			 <&cru SCLK_VDU_CA>, <&cru SCLK_VDU_CORE>;
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Alex Bee <knaerzche@gmail.com>

--- a/patch/kernel/archive/rockchip-6.6/01-linux-1001-v4l2-rockchip.patch
+++ b/patch/kernel/archive/rockchip-6.6/01-linux-1001-v4l2-rockchip.patch
@@ -343,31 +343,6 @@ index b9e219438bc9..f02f79c405f0 100644
  
  struct rkvdec_ctx {
 
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Alex Bee <knaerzche@gmail.com>
-Date: Tue, 18 Aug 2020 11:38:04 +0200
-Subject: [PATCH] WIP: arm64: dts: add resets to vdec for RK3399
-
----
- arch/arm64/boot/dts/rockchip/rk3399.dtsi | 10 +++++++++-
- 1 file changed, 9 insertions(+), 1 deletion(-)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3399.dtsi b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-index 980b12cb0a49..6e3149e587c5 100644
---- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-+++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-@@ -1062,7 +1062,10 @@ power-domain@RK3399_PD_VCODEC {
- 			power-domain@RK3399_PD_VDU {
- 				reg = <RK3399_PD_VDU>;
- 				clocks = <&cru ACLK_VDU>,
--					 <&cru HCLK_VDU>;
-+					 <&cru HCLK_VDU>,
-+					 <&cru SCLK_VDU_CA>,
-+					 <&cru SCLK_VDU_CORE>;
-+
- 				pm_qos = <&qos_video_m1_r>,
- 					 <&qos_video_m1_w>;
- 				#power-domain-cells = <0>;
 @@ -1345,6 +1348,11 @@ vdec: video-codec@ff660000 {
  		clock-names = "axi", "ahb", "cabac", "core";
  		iommus = <&vdec_mmu>;
@@ -380,30 +355,6 @@ index 980b12cb0a49..6e3149e587c5 100644
  	};
  
  	vdec_mmu: iommu@ff660480 {
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Alex Bee <knaerzche@gmail.com>
-Date: Fri, 1 Jan 2021 12:11:12 +0200
-Subject: [PATCH] arm64: dts: rockchip: fix RK3399 vdec register witdh
-
-Signed-off-by: Alex Bee <knaerzche@gmail.com>
----
- arch/arm64/boot/dts/rockchip/rk3399.dtsi | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3399.dtsi b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-index 6e3149e587c5..093ebe070775 100644
---- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-+++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-@@ -1341,7 +1341,7 @@ vpu_mmu: iommu@ff650800 {
- 
- 	vdec: video-codec@ff660000 {
- 		compatible = "rockchip,rk3399-vdec";
--		reg = <0x0 0xff660000 0x0 0x400>;
-+		reg = <0x0 0xff660000 0x0 0x480>;
- 		interrupts = <GIC_SPI 116 IRQ_TYPE_LEVEL_HIGH 0>;
- 		clocks = <&cru ACLK_VDU>, <&cru HCLK_VDU>,
- 			 <&cru SCLK_VDU_CA>, <&cru SCLK_VDU_CORE>;
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Alex Bee <knaerzche@gmail.com>

--- a/patch/kernel/media-current/00184-linux-1001-v4l2-rockchip.patch
+++ b/patch/kernel/media-current/00184-linux-1001-v4l2-rockchip.patch
@@ -343,31 +343,6 @@ index b9e219438bc9..f02f79c405f0 100644
  
  struct rkvdec_ctx {
 
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Alex Bee <knaerzche@gmail.com>
-Date: Tue, 18 Aug 2020 11:38:04 +0200
-Subject: [PATCH] WIP: arm64: dts: add resets to vdec for RK3399
-
----
- arch/arm64/boot/dts/rockchip/rk3399.dtsi | 10 +++++++++-
- 1 file changed, 9 insertions(+), 1 deletion(-)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3399.dtsi b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-index 980b12cb0a49..6e3149e587c5 100644
---- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-+++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-@@ -1062,7 +1062,10 @@ power-domain@RK3399_PD_VCODEC {
- 			power-domain@RK3399_PD_VDU {
- 				reg = <RK3399_PD_VDU>;
- 				clocks = <&cru ACLK_VDU>,
--					 <&cru HCLK_VDU>;
-+					 <&cru HCLK_VDU>,
-+					 <&cru SCLK_VDU_CA>,
-+					 <&cru SCLK_VDU_CORE>;
-+
- 				pm_qos = <&qos_video_m1_r>,
- 					 <&qos_video_m1_w>;
- 				#power-domain-cells = <0>;
 @@ -1345,6 +1348,11 @@ vdec: video-codec@ff660000 {
  		clock-names = "axi", "ahb", "cabac", "core";
  		iommus = <&vdec_mmu>;
@@ -380,30 +355,6 @@ index 980b12cb0a49..6e3149e587c5 100644
  	};
  
  	vdec_mmu: iommu@ff660480 {
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Alex Bee <knaerzche@gmail.com>
-Date: Fri, 1 Jan 2021 12:11:12 +0200
-Subject: [PATCH] arm64: dts: rockchip: fix RK3399 vdec register witdh
-
-Signed-off-by: Alex Bee <knaerzche@gmail.com>
----
- arch/arm64/boot/dts/rockchip/rk3399.dtsi | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/arch/arm64/boot/dts/rockchip/rk3399.dtsi b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-index 6e3149e587c5..093ebe070775 100644
---- a/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-+++ b/arch/arm64/boot/dts/rockchip/rk3399.dtsi
-@@ -1341,7 +1341,7 @@ vpu_mmu: iommu@ff650800 {
- 
- 	vdec: video-codec@ff660000 {
- 		compatible = "rockchip,rk3399-vdec";
--		reg = <0x0 0xff660000 0x0 0x400>;
-+		reg = <0x0 0xff660000 0x0 0x480>;
- 		interrupts = <GIC_SPI 116 IRQ_TYPE_LEVEL_HIGH 0>;
- 		clocks = <&cru ACLK_VDU>, <&cru HCLK_VDU>,
- 			 <&cru SCLK_VDU_CA>, <&cru SCLK_VDU_CORE>;
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Alex Bee <knaerzche@gmail.com>


### PR DESCRIPTION
# Description

Clean deprecated parts in patches.

# How Has This Been Tested?

- [x] Build test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
