### PR TITLE
Fixed ethernet for Orange Pi 3 and Orange Pi One Plus

### DIFF
--- a/patch/atf/atf-sunxi64/board_orangepi3/sunxi-Don-t-enable-referenced-regulators.patch
+++ b/patch/atf/atf-sunxi64/board_orangepi3/sunxi-Don-t-enable-referenced-regulators.patch
@@ -1,0 +1,22 @@
+From 89a2da7c8bae95cf9225015489736e2fc434f4d9 Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@siol.net>
+Date: Sat, 2 Jan 2021 16:35:31 +0100
+Subject: [PATCH] sunxi: Don't enable referenced regulators
+
+This break certain devices which need appropriate power on sequence.
+---
+ drivers/allwinner/axp/common.c | 3 ---
+ 1 file changed, 3 deletions(-)
+
+--- a/drivers/allwinner/axp/common.c
++++ b/drivers/allwinner/axp/common.c
+@@ -112,9 +112,6 @@ static bool should_enable_regulator(const void *fdt,
+ 	if (is_node_disabled(fdt, node)) {
+ 		return false;
+ 	}
+-	if (fdt_getprop(fdt, node, "phandle", NULL) != NULL) {
+-		return true;
+-	}
+ 	if (fdt_getprop(fdt, node, "regulator-always-on", NULL) != NULL) {
+ 		return true;
+ 	}

--- a/patch/atf/atf-sunxi64/board_orangepioneplus/sunxi-Don-t-enable-referenced-regulators.patch
+++ b/patch/atf/atf-sunxi64/board_orangepioneplus/sunxi-Don-t-enable-referenced-regulators.patch
@@ -1,0 +1,22 @@
+From 89a2da7c8bae95cf9225015489736e2fc434f4d9 Mon Sep 17 00:00:00 2001
+From: Jernej Skrabec <jernej.skrabec@siol.net>
+Date: Sat, 2 Jan 2021 16:35:31 +0100
+Subject: [PATCH] sunxi: Don't enable referenced regulators
+
+This break certain devices which need appropriate power on sequence.
+---
+ drivers/allwinner/axp/common.c | 3 ---
+ 1 file changed, 3 deletions(-)
+
+--- a/drivers/allwinner/axp/common.c
++++ b/drivers/allwinner/axp/common.c
+@@ -112,9 +112,6 @@ static bool should_enable_regulator(const void *fdt,
+ 	if (is_node_disabled(fdt, node)) {
+ 		return false;
+ 	}
+-	if (fdt_getprop(fdt, node, "phandle", NULL) != NULL) {
+-		return true;
+-	}
+ 	if (fdt_getprop(fdt, node, "regulator-always-on", NULL) != NULL) {
+ 		return true;
+ 	}


### PR DESCRIPTION
# Description

As per the title. This uses a patch for ATF from CoreElec's repository.

Jira reference number [AR-1813]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested on Orange Pi 3 and Orange Pi One Plus

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1813]: https://armbian.atlassian.net/browse/AR-1813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ