### PR TITLE
`Automatic` board configs status synchronise

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -120,11 +120,10 @@ config/kernel/linux-meson-s4t7-*.config		@echatzip @rpardini @viraniac
 config/kernel/linux-meson64-*.config		@NicoD-SBC @SteeManMI @Tonymac32 @adeepn @bretmlw @clee @engineer-80 @igorpecovnik @jeanrhum @monkaBlyat @pyavitz @rpardini @teknoid
 config/kernel/linux-mvebu64-*.config		@ManoftheSea
 config/kernel/linux-odroidxu4-*.config		@joekhoobyar
-config/kernel/linux-rk3568-odroid-*.config		@utlark
 config/kernel/linux-rk35xx-*.config		@Tonymac32 @ZazaBR @amazingfate @catalinii @efectn @hoochiwetech @igorpecovnik @krachlatte @lanefu @linhz0hz @mahdichi @monkaBlyat @rpardini @sputnik2019 @vamzii
 config/kernel/linux-rockchip-*.config		@paolosabatino
 config/kernel/linux-rockchip-rk3588-*.config		@Tonymac32 @amazingfate @efectn @igorpecovnik @lanefu @linhz0hz
-config/kernel/linux-rockchip64-*.config		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @rpardini @schwar3kat @tdleiyao @vamzii
+config/kernel/linux-rockchip64-*.config		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @rpardini @schwar3kat @tdleiyao @utlark @vamzii
 config/kernel/linux-rockpis-*.config		@brentr
 config/kernel/linux-sun50iw9-*.config		@AGM1968 @krachlatte
 config/kernel/linux-sun50iw9-btt-*.config		@bigtreetech
@@ -139,7 +138,7 @@ patch/kernel/archive/meson-s4t7-*/		@echatzip @rpardini @viraniac
 patch/kernel/archive/meson64-*/		@NicoD-SBC @SteeManMI @Tonymac32 @adeepn @bretmlw @clee @engineer-80 @igorpecovnik @jeanrhum @monkaBlyat @pyavitz @rpardini @teknoid
 patch/kernel/archive/rk35xx-*/		@Tonymac32 @ZazaBR @amazingfate @catalinii @efectn @hoochiwetech @igorpecovnik @krachlatte @lanefu @linhz0hz @mahdichi @monkaBlyat @rpardini @sputnik2019 @vamzii
 patch/kernel/archive/rockchip-*/		@paolosabatino
-patch/kernel/archive/rockchip64-*/		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @rpardini @schwar3kat @tdleiyao @vamzii
+patch/kernel/archive/rockchip64-*/		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @rpardini @schwar3kat @tdleiyao @utlark @vamzii
 patch/kernel/archive/rockpis-*/		@brentr
 patch/kernel/archive/sm8250-*/		@amazingfate
 patch/kernel/archive/sun50iw9-*/		@AGM1968 @krachlatte
@@ -153,11 +152,10 @@ patch/kernel/meson-*/		@hzyitc
 patch/kernel/meson64-*/		@NicoD-SBC @SteeManMI @Tonymac32 @adeepn @bretmlw @clee @engineer-80 @igorpecovnik @jeanrhum @monkaBlyat @pyavitz @rpardini @teknoid
 patch/kernel/mvebu64-*/		@ManoftheSea
 patch/kernel/odroidxu4-*/		@joekhoobyar
-patch/kernel/rk3568-odroid-*/		@utlark
 patch/kernel/rk35xx-*/		@Tonymac32 @ZazaBR @amazingfate @catalinii @efectn @hoochiwetech @igorpecovnik @krachlatte @lanefu @linhz0hz @mahdichi @monkaBlyat @rpardini @sputnik2019 @vamzii
 patch/kernel/rockchip-*/		@paolosabatino
 patch/kernel/rockchip-rk3588-*/		@Tonymac32 @amazingfate @efectn @igorpecovnik @lanefu @linhz0hz
-patch/kernel/rockchip64-*/		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @rpardini @schwar3kat @tdleiyao @vamzii
+patch/kernel/rockchip64-*/		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @rpardini @schwar3kat @tdleiyao @utlark @vamzii
 patch/kernel/rockpis-*/		@brentr
 patch/kernel/sun50iw9-*/		@AGM1968 @krachlatte
 patch/kernel/thead-*/		@chainsx
@@ -172,11 +170,10 @@ sources/families/meson.conf		@hzyitc
 sources/families/meson64.conf		@NicoD-SBC @SteeManMI @Tonymac32 @adeepn @bretmlw @clee @engineer-80 @igorpecovnik @jeanrhum @monkaBlyat @pyavitz @rpardini @teknoid
 sources/families/mvebu64.conf		@ManoftheSea
 sources/families/odroidxu4.conf		@joekhoobyar
-sources/families/rk3568-odroid.conf		@utlark
 sources/families/rk35xx.conf		@Tonymac32 @ZazaBR @amazingfate @catalinii @efectn @hoochiwetech @igorpecovnik @krachlatte @lanefu @linhz0hz @mahdichi @monkaBlyat @rpardini @sputnik2019 @vamzii
 sources/families/rockchip-rk3588.conf		@Tonymac32 @amazingfate @efectn @igorpecovnik @lanefu @linhz0hz
 sources/families/rockchip.conf		@paolosabatino
-sources/families/rockchip64.conf		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @rpardini @schwar3kat @tdleiyao @vamzii
+sources/families/rockchip64.conf		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @rpardini @schwar3kat @tdleiyao @utlark @vamzii
 sources/families/rockpis.conf		@brentr
 sources/families/sun50iw9-btt.conf		@bigtreetech
 sources/families/sun50iw9.conf		@AGM1968 @krachlatte


### PR DESCRIPTION
Update maintainers and board status

- synced status from the database
- rename to .`csc` where we don't have anyone

If you want to become a board maintainer, [adjust data here](https://www.armbian.com/update-data/).

Ref: [Board Maintainers Procedures and Guidelines](https://docs.armbian.com/Board_Maintainers_Procedures_and_Guidelines/)