### PR TITLE
Raspberry Pi EDGE compilation breaks. Moving to 6.7.y, perhaps temporally

### DIFF
--- a/config/sources/families/bcm2711.conf
+++ b/config/sources/families/bcm2711.conf
@@ -44,8 +44,8 @@ case "${BRANCH}" in
 	edge)
 		declare -g RASPI_DISTRO_KERNEL=no
 		declare -g KERNELSOURCE='https://github.com/raspberrypi/linux'
-		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel. For mainline caching.
-		declare -g KERNELBRANCH="branch:rpi-6.6.y"
+		declare -g KERNEL_MAJOR_MINOR="6.7" # Major and minor versions of this kernel. For mainline caching.
+		declare -g KERNELBRANCH="branch:rpi-6.7.y"
 		declare -g KERNELPATCHDIR="${LINUXFAMILY}-${BRANCH}"
 		declare -g LINUXCONFIG="linux-${LINUXFAMILY}-${BRANCH}"
 		;;


### PR DESCRIPTION
# Description

In tittle.

# How Has This Been Tested?

Not tested, but according to RPi CI, 6.6.y breaks the same way as ours, 6.7.y not.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
