### PR TITLE
Move to primary pastebin service.

### DIFF
--- a/lib/functions/logging/export-logs.sh
+++ b/lib/functions/logging/export-logs.sh
@@ -170,7 +170,7 @@ function export_ansi_logs() {
 		display_alert "ANSI log file built; inspect it by running:" "less -RS ${target_relative_to_src}"
 
 		# @TODO: compress...
-		declare paste_url="${PASTE_URL:-"https://paste.next.armbian.com/log"}"
+		declare paste_url="${PASTE_URL:-"https://paste.armbian.com/log"}"
 		if [[ "${SHARE_LOG:-"no"}" == "yes" ]]; then
 			display_alert "SHARE_LOG=yes, uploading log" "uploading logs" "info"
 			declare logs_url="undetermined"


### PR DESCRIPTION
# Description

We are storing logs at our pastebin server(s). Switching back to primary as secondary is failing.

`paste.next.armbian.com -> paste.armbian.com`

# How Has This Been Tested?

Made one test build with SHARE_LOG=yes which generated logs on paste bin server.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings