### PR TITLE
Disable EXTRA wireless on RPi EDGE kernel

### DIFF
--- a/config/sources/families/bcm2711.conf
+++ b/config/sources/families/bcm2711.conf
@@ -43,6 +43,7 @@ case "${BRANCH}" in
 
 	edge)
 		declare -g RASPI_DISTRO_KERNEL=no
+		declare -g EXTRAWIFI="no"
 		declare -g KERNELSOURCE='https://github.com/raspberrypi/linux'
 		declare -g KERNEL_MAJOR_MINOR="6.7" # Major and minor versions of this kernel. For mainline caching.
 		declare -g KERNELBRANCH="branch:rpi-6.7.y"


### PR DESCRIPTION
# Description

Several wireless drivers needs adaptation to 6.7.y compatibility.

# How Has This Been Tested?

- [x] Build test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings