### PR TITLE
opi5: add mainline uboot support

### DIFF
--- a/config/boards/orangepi5.conf
+++ b/config/boards/orangepi5.conf
@@ -24,6 +24,10 @@ declare -g BLUETOOTH_HCIATTACH_PARAMS="-s 115200 /dev/ttyS9 bcm43xx 1500000" # F
 enable_extension "bluetooth-hciattach"                                       # Enable the bluetooth-hciattach extension
 
 function post_family_tweaks_bsp__orangepi5_copy_usb2_service() {
+	if [[ $BRANCH == "edge" ]]; then
+		return
+	fi
+
 	display_alert "Installing BSP firmware and fixups"
 
 	# Add USB2 init service. Otherwise, USB2 and TYPE-C won't work by default
@@ -33,6 +37,10 @@ function post_family_tweaks_bsp__orangepi5_copy_usb2_service() {
 }
 
 function post_family_tweaks__orangepi5_enable_usb2_service() {
+	if [[ $BRANCH == "edge" ]]; then
+		return
+	fi
+
 	display_alert "$BOARD" "Installing board tweaks" "info"
 
 	# enable usb2 init service
@@ -42,6 +50,10 @@ function post_family_tweaks__orangepi5_enable_usb2_service() {
 }
 
 function post_family_tweaks__orangepi5_naming_audios() {
+	if [[ $BRANCH == "edge" ]]; then
+		return
+	fi
+
 	display_alert "$BOARD" "Renaming orangepi5 audios" "info"
 
 	mkdir -p $SDCARD/etc/udev/rules.d/
@@ -61,7 +73,34 @@ function post_family_config_branch_legacy__orangepi5_uboot_add_sata_target() {
 	"
 }
 
+function post_family_config_branch_edge__uboot_config() {
+	display_alert "$BOARD" "u-boot ${BOOTBRANCH_BOARD} edge overrides" "info"
+	UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin u-boot.itb idbloader.img idbloader-spi.img"
+	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # disable stuff from rockchip64_common; we're using binman here which does all the work already
+
+	# Just use the binman-provided u-boot-rockchip.bin, which is ready-to-go
+	function write_uboot_platform() {
+		dd if=${1}/u-boot-rockchip.bin of=${2} bs=32k seek=1 conv=fsync
+	}
+
+	# Smarter/faster/better to-spi writer using flashcp (hopefully with --partition), using the binman-provided 'u-boot-rockchip-spi.bin'
+	function write_uboot_platform_mtd() {
+		declare -a extra_opts_flashcp=("--verbose")
+		if flashcp -h | grep -q -e '--partition'; then
+			echo "Confirmed flashcp supports --partition -- read and write only changed blocks." >&2
+			extra_opts_flashcp+=("--partition")
+		else
+			echo "flashcp does not support --partition, will write full SPI flash blocks." >&2
+		fi
+		flashcp "${extra_opts_flashcp[@]}" "${1}/u-boot-rockchip-spi.bin" /dev/mtd0
+	}
+}
+
 function post_uboot_custom_postprocess__create_sata_spi_image() {
+	if [[ $BRANCH == "edge" ]]; then
+		return
+	fi
+
 	display_alert "$BOARD" "Create rkspi_loader_sata.img" "info"
 
 	dd if=/dev/zero of=rkspi_loader_sata.img bs=1M count=0 seek=16
@@ -77,9 +116,23 @@ function post_uboot_custom_postprocess__create_sata_spi_image() {
 	dd if=u-boot.itb of=rkspi_loader_sata.img seek=16384 conv=notrunc
 }
 
+function add_host_dependencies__mainline_uboot_wants_python3_orangepi5() {
+	if [[ $BRANCH == "edge" ]]; then
+		declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} python3-pyelftools" # @TODO: convert to array later
+	fi
+}
+
 # Override family config for this board; let's avoid conditionals in family config.
 function post_family_config__orangepi5_use_vendor_uboot() {
-	BOOTSOURCE='https://github.com/orangepi-xunlong/u-boot-orangepi.git'
-	BOOTBRANCH='branch:v2017.09-rk3588'
-	BOOTPATCHDIR="legacy"
+	if [[ $BRANCH == "edge" ]]; then
+		BOOTCONFIG="orangepi-5-rk3588s_defconfig"
+		BOOTSOURCE="https://github.com/u-boot/u-boot.git"
+		BOOTBRANCH="commit:2f0282922b2c458eea7f85c500a948a587437b63"
+		BOOTDIR="u-boot-${BOARD}"
+		BOOTPATCHDIR="v2024.01-orangepi5"
+	else
+		BOOTSOURCE='https://github.com/orangepi-xunlong/u-boot-orangepi.git'
+		BOOTBRANCH='branch:v2017.09-rk3588'
+		BOOTPATCHDIR="legacy"
+	fi
 }

--- a/patch/u-boot/v2024.01-orangepi5/0010-Fix-SPI-Boot.patch
+++ b/patch/u-boot/v2024.01-orangepi5/0010-Fix-SPI-Boot.patch
@@ -1,0 +1,165 @@
+From fc2bcb2ffcba7923db49cde0ccda4dc48ca102b0 Mon Sep 17 00:00:00 2001
+From: John Clark <inindev@gmail.com>
+Date: Fri, 17 Nov 2023 23:24:35 +0000
+Subject: [PATCH 1/4] rockchip: rk3588-nanopc-t6: Build SPI image
+
+Enable building of the SPI image, u-boot-rockchip-spi.bin, now that we
+know what bootsource id values BootRom use for SPI flash on RK3588.
+
+Fixes: b0b8086898f8 ("board: rockchip: add FriendlyElec NanoPC-T6 rk3588 board")
+Signed-off-by: John Clark <inindev@gmail.com>
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+---
+ configs/nanopc-t6-rk3588_defconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/configs/nanopc-t6-rk3588_defconfig b/configs/nanopc-t6-rk3588_defconfig
+index 070399ce2a..daa13a4fff 100644
+--- a/configs/nanopc-t6-rk3588_defconfig
++++ b/configs/nanopc-t6-rk3588_defconfig
+@@ -14,6 +14,7 @@ CONFIG_SF_DEFAULT_MODE=0x2000
+ CONFIG_DEFAULT_DEVICE_TREE="rk3588-nanopc-t6"
+ CONFIG_ROCKCHIP_RK3588=y
+ CONFIG_SPL_ROCKCHIP_COMMON_BOARD=y
++CONFIG_ROCKCHIP_SPI_IMAGE=y
+ CONFIG_SPL_SERIAL=y
+ CONFIG_SPL_STACK_R_ADDR=0x600000
+ CONFIG_TARGET_NANOPCT6_RK3588=y
+-- 
+2.43.0
+
+
+From 860b70c5137e408d31e0dd93b5d803d600ff8172 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Fri, 17 Nov 2023 23:24:34 +0000
+Subject: [PATCH 2/4] rockchip: rk3588: Fix boot from SPI flash
+
+The commit fd6e425be243 ("rockchip: rk3588-rock-5b: Enable boot from SPI
+NOR flash") added a new BROM_BOOTSOURCE_SPINOR_RK3588 with value 6.
+
+At the time the reason for this new bootsource id value 6 was unknown.
+
+We now know that the BootRom on RK3588 use different bootsource id
+values depending on the iomux used by the flash spi controller, and not
+by the type of spi nor or spi nand flash used.
+
+Add the following enum values and use them for RK3588 boot_devices.
+
+- BROM_BOOTSOURCE_FSPI_M0 = 3
+- BROM_BOOTSOURCE_FSPI_M1 = 4
+- BROM_BOOTSOURCE_FSPI_M2 = 6
+
+Fixes: fd6e425be243 ("rockchip: rk3588-rock-5b: Enable boot from SPI NOR flash")
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+Tested-by: Slawomir Stepien <sst@poczta.fm>
+---
+ arch/arm/include/asm/arch-rockchip/bootrom.h |  1 -
+ arch/arm/mach-rockchip/rk3588/rk3588.c       | 16 ++++++++++++++--
+ 2 files changed, 14 insertions(+), 3 deletions(-)
+
+diff --git a/arch/arm/include/asm/arch-rockchip/bootrom.h b/arch/arm/include/asm/arch-rockchip/bootrom.h
+index 7dab18fbc3..4276a0f681 100644
+--- a/arch/arm/include/asm/arch-rockchip/bootrom.h
++++ b/arch/arm/include/asm/arch-rockchip/bootrom.h
+@@ -48,7 +48,6 @@ enum {
+ 	BROM_BOOTSOURCE_SPINOR = 3,
+ 	BROM_BOOTSOURCE_SPINAND = 4,
+ 	BROM_BOOTSOURCE_SD = 5,
+-	BROM_BOOTSOURCE_SPINOR_RK3588 = 6,
+ 	BROM_BOOTSOURCE_USB = 10,
+ 	BROM_LAST_BOOTSOURCE = BROM_BOOTSOURCE_USB
+ };
+diff --git a/arch/arm/mach-rockchip/rk3588/rk3588.c b/arch/arm/mach-rockchip/rk3588/rk3588.c
+index b1f535fad5..91c9d32e49 100644
+--- a/arch/arm/mach-rockchip/rk3588/rk3588.c
++++ b/arch/arm/mach-rockchip/rk3588/rk3588.c
+@@ -37,11 +37,23 @@ DECLARE_GLOBAL_DATA_PTR;
+ #define BUS_IOC_GPIO2D_IOMUX_SEL_H	0x5c
+ #define BUS_IOC_GPIO3A_IOMUX_SEL_L	0x60
+ 
++/**
++ * Boot-device identifiers used by the BROM on RK3588 when device is booted
++ * from SPI flash. IOMUX used for SPI flash affect the value used by the BROM
++ * and not the type of SPI flash used.
++ */
++enum {
++	BROM_BOOTSOURCE_FSPI_M0 = 3,
++	BROM_BOOTSOURCE_FSPI_M1 = 4,
++	BROM_BOOTSOURCE_FSPI_M2 = 6,
++};
++
+ const char * const boot_devices[BROM_LAST_BOOTSOURCE + 1] = {
+ 	[BROM_BOOTSOURCE_EMMC] = "/mmc@fe2e0000",
+-	[BROM_BOOTSOURCE_SPINOR] = "/spi@fe2b0000/flash@0",
++	[BROM_BOOTSOURCE_FSPI_M0] = "/spi@fe2b0000/flash@0",
++	[BROM_BOOTSOURCE_FSPI_M1] = "/spi@fe2b0000/flash@0",
++	[BROM_BOOTSOURCE_FSPI_M2] = "/spi@fe2b0000/flash@0",
+ 	[BROM_BOOTSOURCE_SD] = "/mmc@fe2c0000",
+-	[BROM_BOOTSOURCE_SPINOR_RK3588] = "/spi@fe2b0000/flash@0",
+ };
+ 
+ static struct mm_region rk3588_mem_map[] = {
+-- 
+2.43.0
+
+
+From ae8eccb653a0eccfff2be0825a912cca62da549a Mon Sep 17 00:00:00 2001
+From: Slawomir Stepien <sst@poczta.fm>
+Date: Fri, 17 Nov 2023 23:24:36 +0000
+Subject: [PATCH 3/4] rockchip: rk3588-orangepi-5-plus: Build SPI image
+
+Enable building of the SPI image, u-boot-rockchip-spi.bin, now that we
+know what bootsource id values BootRom use for SPI flash on RK3588.
+
+Fixes: b51cf8bb09b6 ("board: rockchip: Add Xunlong Orange Pi 5 Plus")
+Signed-off-by: Slawomir Stepien <sst@poczta.fm>
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+---
+ configs/orangepi-5-plus-rk3588_defconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/configs/orangepi-5-plus-rk3588_defconfig b/configs/orangepi-5-plus-rk3588_defconfig
+index 0473699621..e1cd753a6d 100644
+--- a/configs/orangepi-5-plus-rk3588_defconfig
++++ b/configs/orangepi-5-plus-rk3588_defconfig
+@@ -14,6 +14,7 @@ CONFIG_SF_DEFAULT_MODE=0x2000
+ CONFIG_DEFAULT_DEVICE_TREE="rk3588-orangepi-5-plus"
+ CONFIG_ROCKCHIP_RK3588=y
+ CONFIG_SPL_ROCKCHIP_COMMON_BOARD=y
++CONFIG_ROCKCHIP_SPI_IMAGE=y
+ CONFIG_SPL_SERIAL=y
+ CONFIG_SPL_STACK_R_ADDR=0x600000
+ CONFIG_TARGET_EVB_RK3588=y
+-- 
+2.43.0
+
+
+From 29e21eefce1d2fab21c4dfec5953f651d1be5393 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Fri, 17 Nov 2023 23:24:37 +0000
+Subject: [PATCH 4/4] rockchip: rk3588s-orangepi-5: Build SPI image
+
+Enable building of the SPI image, u-boot-rockchip-spi.bin, now that we
+know what bootsource id values BootRom use for SPI flash on RK3588.
+
+Fixes: 28c5f941edf7 ("board: rockchip: Add Xunlong Orange Pi 5")
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+---
+ configs/orangepi-5-rk3588s_defconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/configs/orangepi-5-rk3588s_defconfig b/configs/orangepi-5-rk3588s_defconfig
+index feb45a5385..1e33c832ec 100644
+--- a/configs/orangepi-5-rk3588s_defconfig
++++ b/configs/orangepi-5-rk3588s_defconfig
+@@ -13,6 +13,7 @@ CONFIG_SF_DEFAULT_MODE=0x2000
+ CONFIG_DEFAULT_DEVICE_TREE="rk3588s-orangepi-5"
+ CONFIG_ROCKCHIP_RK3588=y
+ CONFIG_SPL_ROCKCHIP_COMMON_BOARD=y
++CONFIG_ROCKCHIP_SPI_IMAGE=y
+ CONFIG_SPL_SERIAL=y
+ CONFIG_SPL_STACK_R_ADDR=0x600000
+ CONFIG_TARGET_EVB_RK3588=y
+-- 
+2.43.0
+


### PR DESCRIPTION
# Description

Reapply https://github.com/armbian/build/commit/305886b111ff76a53693a3c171751a8830d106c5 and fix compilation & spi image booting

Jira reference number [AR-9999]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Build and boot

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
