### PR TITLE
update NanoPI R2C dts for edge kernel

### DIFF
--- a/patch/kernel/archive/rockchip64-6.6/dt/rk3328-nanopi-r2-rev06.dts
+++ b/patch/kernel/archive/rockchip64-6.6/dt/rk3328-nanopi-r2-rev06.dts
@@ -80,9 +80,12 @@
 			compatible = "ethernet-phy-id0000.011a",
 				     "ethernet-phy-ieee802.3-c22";
 			reg = <3>;
-                       interrupt-parent = <&gpio2>;
+			interrupt-parent = <&gpio2>;
 			interrupts = <RK_PC4 IRQ_TYPE_EDGE_FALLING>;
 			//reset-gpios = <&gpio1 RK_PC2 GPIO_ACTIVE_LOW>;
+			motorcomm,clk-out-frequency-hz = <125000000>; // enable gmac clock
+			motorcomm,keep-pll-enabled; // keep pll run without link
+			motorcomm,auto-sleep-disabled; // disable sleep without link
 			keep-clkout-on;
 		};
 	};


### PR DESCRIPTION
# Description

WAN ethernet does not work on NanoPI R2C on edge because GMAC_CLK pin on PHY not provides output clock (for GMAC) by default. This updated device tree fix this issue. ```current``` and ```legacy``` branches have different (out of kernel) driver and don't need this dts fix.

```
[    2.902617] rk_gmac-dwmac ff540000.ethernet: IRQ eth_wake_irq not found
[    2.902640] rk_gmac-dwmac ff540000.ethernet: IRQ eth_lpi not found
[    2.902793] rk_gmac-dwmac ff540000.ethernet: PTP uses main clock
[    2.903026] rk_gmac-dwmac ff540000.ethernet: clock input or output? (input). <- this clock MUST be provided by PHY
[    2.903049] rk_gmac-dwmac ff540000.ethernet: TX delay(0x22).
[    2.903059] rk_gmac-dwmac ff540000.ethernet: RX delay(0x12).
[    2.903078] rk_gmac-dwmac ff540000.ethernet: integrated PHY? (no).
[    2.903136] rk_gmac-dwmac ff540000.ethernet: clock input from PHY
[    2.908159] rk_gmac-dwmac ff540000.ethernet: init for RGMII
[    2.910080] rk_gmac-dwmac ff540000.ethernet: User ID: 0x10, Synopsys ID: 0x35
[    2.910108] rk_gmac-dwmac ff540000.ethernet: 	DWMAC1000
[    2.910116] rk_gmac-dwmac ff540000.ethernet: DMA HW capability register supported
[    2.910123] rk_gmac-dwmac ff540000.ethernet: RX Checksum Offload Engine supported
[    2.910129] rk_gmac-dwmac ff540000.ethernet: COE Type 2
[    2.910135] rk_gmac-dwmac ff540000.ethernet: TX Checksum insertion supported
[    2.910141] rk_gmac-dwmac ff540000.ethernet: Wake-Up On Lan supported
[    2.910236] rk_gmac-dwmac ff540000.ethernet: Normal descriptors
[    2.910245] rk_gmac-dwmac ff540000.ethernet: Ring mode enabled
[    2.910252] rk_gmac-dwmac ff540000.ethernet: Enable RX Mitigation via HW Watchdog Timer
[   22.330038] rk_gmac-dwmac ff540000.ethernet eth0: Register MEM_TYPE_PAGE_POOL RxQ-0
[   22.340509] rk_gmac-dwmac ff540000.ethernet eth0: PHY [stmmac-0:03] driver [YT8521 Gigabit Ethernet] (irq=POLL)
[   22.348004] rk_gmac-dwmac ff540000.ethernet eth0: No Safety Features support found
[   22.348040] rk_gmac-dwmac ff540000.ethernet eth0: PTP not supported by HW
[   22.351173] rk_gmac-dwmac ff540000.ethernet eth0: configuring for phy/rgmii link mode
```

# How Has This Been Tested?

- [X] Build patched image and test on target device.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
