### PR TITLE
Rockchip64 PCIE PHY reset on probe

### DIFF
--- a/patch/kernel/archive/rockchip64-6.1/rk3399-fix-pci-phy.patch
+++ b/patch/kernel/archive/rockchip64-6.1/rk3399-fix-pci-phy.patch
@@ -1,0 +1,47 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrey Safonov <andrey.safonov@gmail.com>
+Date: Sat, 16 Dec 2023 22:46:35 +0300
+Subject: rk3399 PCIE PHY reset on probe
+
+Signed-off-by: Andrey Safonov <andrey.safonov@gmail.com>
+---
+ drivers/phy/rockchip/phy-rockchip-pcie.c | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/drivers/phy/rockchip/phy-rockchip-pcie.c b/drivers/phy/rockchip/phy-rockchip-pcie.c
+index 8234b83fdd88..aa5ca6db0563 100644
+--- a/drivers/phy/rockchip/phy-rockchip-pcie.c
++++ b/drivers/phy/rockchip/phy-rockchip-pcie.c
+@@ -344,6 +344,20 @@ static const struct of_device_id rockchip_pcie_phy_dt_ids[] = {
+ 
+ MODULE_DEVICE_TABLE(of, rockchip_pcie_phy_dt_ids);
+ 
++static void rockchip_pcie_phy_reset(struct rockchip_pcie_phy *rk_phy)
++{
++	int i;
++
++	for (i = 0; i < PHY_MAX_LANE_NUM; i++)
++		regmap_write(rk_phy->reg_base,
++			     rk_phy->phy_data->pcie_laneoff,
++			     HIWORD_UPDATE(PHY_LANE_IDLE_OFF,
++					   PHY_LANE_IDLE_MASK,
++					   PHY_LANE_IDLE_A_SHIFT + i));
++
++	reset_control_assert(rk_phy->phy_rst);
++}
++
+ static int rockchip_pcie_phy_probe(struct platform_device *pdev)
+ {
+ 	struct device *dev = &pdev->dev;
+@@ -394,6 +408,8 @@ static int rockchip_pcie_phy_probe(struct platform_device *pdev)
+ 	phy_num = (phy_num == 0) ? 1 : PHY_MAX_LANE_NUM;
+ 	dev_dbg(dev, "phy number is %d\n", phy_num);
+ 
++	rockchip_pcie_phy_reset(rk_phy);
++
+ 	for (i = 0; i < phy_num; i++) {
+ 		rk_phy->phys[i].phy = devm_phy_create(dev, dev->of_node, &ops);
+ 		if (IS_ERR(rk_phy->phys[i].phy)) {
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip64-6.6/rk3399-fix-pci-phy.patch
+++ b/patch/kernel/archive/rockchip64-6.6/rk3399-fix-pci-phy.patch
@@ -1,0 +1,47 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrey Safonov <andrey.safonov@gmail.com>
+Date: Sat, 16 Dec 2023 22:46:35 +0300
+Subject: rk3399 PCIE PHY reset on probe
+
+Signed-off-by: Andrey Safonov <andrey.safonov@gmail.com>
+---
+ drivers/phy/rockchip/phy-rockchip-pcie.c | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/drivers/phy/rockchip/phy-rockchip-pcie.c b/drivers/phy/rockchip/phy-rockchip-pcie.c
+index 8234b83fdd88..aa5ca6db0563 100644
+--- a/drivers/phy/rockchip/phy-rockchip-pcie.c
++++ b/drivers/phy/rockchip/phy-rockchip-pcie.c
+@@ -344,6 +344,20 @@ static const struct of_device_id rockchip_pcie_phy_dt_ids[] = {
+ 
+ MODULE_DEVICE_TABLE(of, rockchip_pcie_phy_dt_ids);
+ 
++static void rockchip_pcie_phy_reset(struct rockchip_pcie_phy *rk_phy)
++{
++	int i;
++
++	for (i = 0; i < PHY_MAX_LANE_NUM; i++)
++		regmap_write(rk_phy->reg_base,
++			     rk_phy->phy_data->pcie_laneoff,
++			     HIWORD_UPDATE(PHY_LANE_IDLE_OFF,
++					   PHY_LANE_IDLE_MASK,
++					   PHY_LANE_IDLE_A_SHIFT + i));
++
++	reset_control_assert(rk_phy->phy_rst);
++}
++
+ static int rockchip_pcie_phy_probe(struct platform_device *pdev)
+ {
+ 	struct device *dev = &pdev->dev;
+@@ -394,6 +408,8 @@ static int rockchip_pcie_phy_probe(struct platform_device *pdev)
+ 	phy_num = (phy_num == 0) ? 1 : PHY_MAX_LANE_NUM;
+ 	dev_dbg(dev, "phy number is %d\n", phy_num);
+ 
++	rockchip_pcie_phy_reset(rk_phy);
++
+ 	for (i = 0; i < phy_num; i++) {
+ 		rk_phy->phys[i].phy = devm_phy_create(dev, dev->of_node, &ops);
+ 		if (IS_ERR(rk_phy->phys[i].phy)) {
+-- 
+Armbian
+


### PR DESCRIPTION
# Description

This patch PCIE initialization error after warm reboot. Typical error log after warm reboot:
```
[    2.510082] rockchip-pcie f8000000.pcie: host bridge /pcie@f8000000 ranges:
[    2.510139] rockchip-pcie f8000000.pcie:      MEM 0x00fa000000..0x00fbdfffff -> 0x00fa000000
[    2.510160] rockchip-pcie f8000000.pcie:       IO 0x00fbe00000..0x00fbefffff -> 0x00fbe00000
[    2.510748] rockchip-pcie f8000000.pcie: no bus scan delay, default to 0 ms
[    2.510795] rockchip-pcie f8000000.pcie: no vpcie12v regulator found
[    3.011274] rockchip-pcie f8000000.pcie: PCIe link training gen1 timeout!
[    3.011373] rockchip-pcie: probe of f8000000.pcie failed with error -110
```
The root of cause is when device is booted after power on PHY stay in "factory" state. After warm boot PHY stay in previous state and prevent any training and PCIE init fail. Log after fix PHY:
```
[    2.296993] rockchip-pcie f8000000.pcie: host bridge /pcie@f8000000 ranges:
[    2.297064] rockchip-pcie f8000000.pcie:      MEM 0x00fa000000..0x00fbdfffff -> 0x00fa000000
[    2.297100] rockchip-pcie f8000000.pcie:       IO 0x00fbe00000..0x00fbefffff -> 0x00fbe00000
[    2.298098] rockchip-pcie f8000000.pcie: no bus scan delay, default to 0 ms
[    2.298169] rockchip-pcie f8000000.pcie: no vpcie12v regulator found
[    2.324717] rockchip-pcie f8000000.pcie: wait 0 ms (from device tree) before bus scan
[    2.325477] rockchip-pcie f8000000.pcie: PCI host bridge to bus 0000:00
[    2.325499] pci_bus 0000:00: root bus resource [bus 00-1f]
[    2.325518] pci_bus 0000:00: root bus resource [mem 0xfa000000-0xfbdfffff]
[    2.325537] pci_bus 0000:00: root bus resource [io  0x0000-0xfffff] (bus address [0xfbe00000-0xfbefffff])
```

# How Has This Been Tested?

- [X] Tested on NanoPI R4S with current kernel - OK.
- [X] Tested on NanoPI R4S with edge kernel - OK.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
