### PR TITLE
`Automatic` board configs status synchronise

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -58,8 +58,8 @@ config/boards/nanopiduo.conf		@sgjava
 config/boards/nanopiduo2.conf		@viraniac
 config/boards/nanopineoplus2.csc		@teknoid
 config/boards/odroidc2.conf		@teknoid
-config/boards/odroidm1.wip		@rpardini
-config/boards/odroidn2.csc		@NicoD-SBC
+config/boards/odroidm1.conf		@rpardini
+config/boards/odroidn2.conf		@NicoD-SBC
 config/boards/odroidxu4.conf		@joekhoobyar
 config/boards/olimex-teres-a64.conf		@Kreyren
 config/boards/onecloud.conf		@hzyitc
@@ -94,6 +94,7 @@ config/boards/rockpi-e.conf		@krachlatte
 config/boards/rockpi-s.csc		@brentr
 config/boards/rockpro64.conf		@joekhoobyar
 config/boards/rpi4b.conf		@PanderMusubi @teknoid @viraniac
+config/boards/rpi5b.conf		@viraniac
 config/boards/sk-am62b.conf		@glneo
 config/boards/sk-am64b.conf		@glneo
 config/boards/sk-tda4vm.conf		@glneo


### PR DESCRIPTION
Update maintainers and board status

- synced status from the database
- rename to .`csc` where we don't have anyone

If you want to become a board maintainer, [adjust data here](https://www.armbian.com/update-data/).

Ref: [Board Maintainers Procedures and Guidelines](https://docs.armbian.com/Board_Maintainers_Procedures_and_Guidelines/)