### PR TITLE
Disable u-boot generation also for EDGE branch

### DIFF
--- a/config/boards/khadas-edge2.conf
+++ b/config/boards/khadas-edge2.conf
@@ -14,7 +14,7 @@ declare -g KHADAS_OOWOW_BOARD_ID="Edge2" # for use with EXT=output-image-oowow
 declare -g UEFI_EDK2_BOARD_ID="edge2"    # This _only_ used for uefi-edk2-rk3588 extension
 
 # for the kedge2, we're counting on the blobs+u-boot in SPI working, as it comes from factory. It does not support bootscripts.
-function post_family_config_branch_legacy__uboot_kedge2() {
+function post_family_config__uboot_kedge2() {
 	display_alert "$BOARD" "Configuring ($BOARD) non-u-boot" "info"
 	unset BOOTSOURCE
 	declare -g BOOTCONFIG='none'


### PR DESCRIPTION
# Description

It breaks EDGE compilation as define was done only for legacy.

# How Has This Been Tested?

Manual build.
