### PR TITLE
Helios64: the chip temperature sensor is really a National lm75

### DIFF
--- a/patch/kernel/archive/rk3399-4.4/helios64-add-board.patch
+++ b/patch/kernel/archive/rk3399-4.4/helios64-add-board.patch
@@ -762,7 +762,7 @@ index 000000000..ef95aa489
 +	};
 +
 +	temp@4c {
-+		compatible = "onnn,lm75";
++		compatible = "national,lm75";
 +		reg = <0x4c>;
 +		vcc-supply = <&vcc3v3_sys_s0>;
 +	};

--- a/patch/kernel/archive/rockchip64-5.10/add-board-helios64.patch
+++ b/patch/kernel/archive/rockchip64-5.10/add-board-helios64.patch
@@ -703,7 +703,7 @@ index 000000000..fae17f416
 +	};
 +
 +	temp@4c {
-+		compatible = "onnn,lm75";
++		compatible = "national,lm75";
 +		reg = <0x4c>;
 +	};
 +};

--- a/patch/kernel/archive/rockchip64-5.15/add-board-helios64.patch
+++ b/patch/kernel/archive/rockchip64-5.15/add-board-helios64.patch
@@ -703,7 +703,7 @@ index 000000000..fae17f416
 +	};
 +
 +	temp@4c {
-+		compatible = "onnn,lm75";
++		compatible = "national,lm75";
 +		reg = <0x4c>;
 +	};
 +};

--- a/patch/kernel/archive/rockchip64-6.1/add-board-helios64.patch
+++ b/patch/kernel/archive/rockchip64-6.1/add-board-helios64.patch
@@ -703,7 +703,7 @@ index 000000000..fae17f416
 +	};
 +
 +	temp@4c {
-+		compatible = "onnn,lm75";
++		compatible = "national,lm75";
 +		reg = <0x4c>;
 +	};
 +};

--- a/patch/kernel/archive/rockchip64-6.5/add-board-helios64.patch
+++ b/patch/kernel/archive/rockchip64-6.5/add-board-helios64.patch
@@ -810,8 +810,7 @@ index 1eb287a3f8c0..ac0da7b7f43c 100644
 +	};
 +
  	temp@4c {
--		compatible = "national,lm75";
-+		compatible = "onnn,lm75";
+ 		compatible = "national,lm75";
  		reg = <0x4c>;
  	};
  };

--- a/patch/kernel/archive/rockchip64-6.6/add-board-helios64.patch
+++ b/patch/kernel/archive/rockchip64-6.6/add-board-helios64.patch
@@ -810,8 +810,7 @@ index 1eb287a3f8c0..ac0da7b7f43c 100644
 +	};
 +
  	temp@4c {
--		compatible = "national,lm75";
-+		compatible = "onnn,lm75";
+ 		compatible = "national,lm75";
  		reg = <0x4c>;
  	};
  };

--- a/patch/u-boot/u-boot-media/0010-add-board-helios64.patch
+++ b/patch/u-boot/u-boot-media/0010-add-board-helios64.patch
@@ -880,7 +880,7 @@ index 00000000..9d067505
 +	};
 +
 +	temp@4c {
-+		compatible = "onnn,lm75";
++		compatible = "national,lm75";
 +		reg = <0x4c>;
 +		vcc-supply = <&vcc3v3_sys_s0>;
 +	};

--- a/patch/u-boot/u-boot-rockchip64-v2022.04/add-board-helios64.patch
+++ b/patch/u-boot/u-boot-rockchip64-v2022.04/add-board-helios64.patch
@@ -870,7 +870,7 @@ index 0000000000..32061b84da
 +	};
 +
 +	temp@4c {
-+		compatible = "onnn,lm75";
++		compatible = "national,lm75";
 +		reg = <0x4c>;
 +		vcc-supply = <&vcc3v3_sys_s0>;
 +	};

--- a/patch/u-boot/u-boot-rockchip64/add-board-helios64.patch
+++ b/patch/u-boot/u-boot-rockchip64/add-board-helios64.patch
@@ -880,7 +880,7 @@ index 00000000..9d067505
 +	};
 +
 +	temp@4c {
-+		compatible = "onnn,lm75";
++		compatible = "national,lm75";
 +		reg = <0x4c>;
 +		vcc-supply = <&vcc3v3_sys_s0>;
 +	};


### PR DESCRIPTION
# Description

The lm75 sensor was defined in the dts as "onnn,lm75". Set it to "national,lm75" as is set in the upstream dts. (there is no such thing as "onnn,lm75").

Later on (or maybe I should include it there) we should remove the `lm75` module from MODULES and MODULES8lEGACY in config/boards/helios64.csc, as the DTS already loads it.
(which makes me think "onnn,lm75" as a DTS node never was recognized by a kernel, thus the need to explicitly load lm75).

# How Has This Been Tested?

- [x] remove lm57 from the config (I believe it was /etc/modules but is long gone) and reboot with new dts


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
