### PR TITLE
`Automatic` board configs status synchronise

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -65,6 +65,8 @@ config/boards/olimex-teres-a64.conf		@Kreyren
 config/boards/onecloud.conf		@hzyitc
 config/boards/orangepi-r1.conf		@schwar3kat
 config/boards/orangepi-r1plus-lts.conf		@schwar3kat
+config/boards/orangepi3-lts.csc		@viraniac
+config/boards/orangepi3.csc		@viraniac
 config/boards/orangepi4-lts.conf		@paolosabatino
 config/boards/orangepi4.csc		@paolosabatino
 config/boards/orangepi5-plus.conf		@efectn


### PR DESCRIPTION
Update maintainers and board status

- synced status from the database
- rename to .`csc` where we don't have anyone

If you want to become a board maintainer, [adjust data here](https://www.armbian.com/update-data/).

Ref: [Board Maintainers Procedures and Guidelines](https://docs.armbian.com/Board_Maintainers_Procedures_and_Guidelines/)