### PR TITLE
Allwinner: minor kernel bumps

### DIFF
--- a/config/kernel/linux-sunxi-current.config
+++ b/config/kernel/linux-sunxi-current.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.1.65 Kernel Configuration
+# Linux/arm 6.1.69 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-linux-gnueabihf-gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0"
 CONFIG_CC_IS_GCC=y

--- a/config/kernel/linux-sunxi-edge.config
+++ b/config/kernel/linux-sunxi-edge.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 6.6.4 Kernel Configuration
+# Linux/arm 6.6.8 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-linux-gnueabihf-gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0"
 CONFIG_CC_IS_GCC=y
@@ -8677,8 +8677,6 @@ CONFIG_STACKTRACE=y
 # CONFIG_DEBUG_NOTIFIERS is not set
 CONFIG_DEBUG_MAPLE_TREE=y
 # end of Debug kernel data structures
-
-# CONFIG_DEBUG_CREDENTIALS is not set
 
 #
 # RCU Debugging

--- a/config/kernel/linux-sunxi-legacy.config
+++ b/config/kernel/linux-sunxi-legacy.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 5.15.141 Kernel Configuration
+# Linux/arm 5.15.144 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="arm-linux-gnueabihf-gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0"
 CONFIG_CC_IS_GCC=y

--- a/config/kernel/linux-sunxi64-current.config
+++ b/config/kernel/linux-sunxi64-current.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.1.65 Kernel Configuration
+# Linux/arm64 6.1.69 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0"
 CONFIG_CC_IS_GCC=y

--- a/config/kernel/linux-sunxi64-edge.config
+++ b/config/kernel/linux-sunxi64-edge.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.6.4 Kernel Configuration
+# Linux/arm64 6.6.8 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0"
 CONFIG_CC_IS_GCC=y

--- a/config/kernel/linux-sunxi64-legacy.config
+++ b/config/kernel/linux-sunxi64-legacy.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.15.141 Kernel Configuration
+# Linux/arm64 5.15.144 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0"
 CONFIG_CC_IS_GCC=y

--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -24,17 +24,17 @@ case $BRANCH in
 
 	legacy)
 		declare -g KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v5.15.143"
+		declare -g KERNELBRANCH="tag:v5.15.144"
 		;;
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.1.68"
+		declare -g KERNELBRANCH="tag:v6.1.69"
 		;;
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.6.7"
+		declare -g KERNELBRANCH="tag:v6.6.8"
 		;;
 esac
 

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -25,17 +25,17 @@ case $BRANCH in
 
 	legacy)
 		declare -g KERNEL_MAJOR_MINOR="5.15" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v5.15.143"
+		declare -g KERNELBRANCH="tag:v5.15.144"
 		;;
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.1.68"
+		declare -g KERNELBRANCH="tag:v6.1.69"
 		;;
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.6.7"
+		declare -g KERNELBRANCH="tag:v6.6.8"
 		;;
 esac
 


### PR DESCRIPTION
# Description

Minor kernel bumps
Legacy - 5.15.143 -> 5.15.144
Current - 6.1.68 -> 6.1.69
Edge - 6.6.7 -> 6.6.8

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested booting on Orange Pi Zero (sun8i H3)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
