### PR TITLE
Add extension for patching Deboostrap to support Ubuntu Noble

### DIFF
--- a/extensions/ubuntu-noble.sh
+++ b/extensions/ubuntu-noble.sh
@@ -1,0 +1,15 @@
+function add_host_dependencies__patch_deboostrap(){
+
+	echo "Patching Debootstrap to support Ubuntu Noble"
+	NOBLE_SYMLINK=/usr/share/debootstrap/scripts/noble
+	if [ -L ${NOBLE_SYMLINK} ] && [ -e ${NOBLE_SYMLINK} ]; then
+		:
+	else
+		if ! command -v sudo &> /dev/null; then
+			run_host_command_logged ln -s gutsy ${NOBLE_SYMLINK}
+		else
+			run_host_command_logged sudo ln -s gutsy ${NOBLE_SYMLINK}
+		fi
+	fi
+
+}


### PR DESCRIPTION
# Description

Ubuntu Noble is not yet in Jammy deboostrap. Lets patch the system with an extensions, so we con't mess up with a framework itself. This will eventually become deprecated anyway.

Jira reference number [AR-2004]

# How Has This Been Tested?

- [x] Manual run `./compile.sh ENABLE_EXTENSIONS="ubuntu-noble"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-2004]: https://armbian.atlassian.net/browse/AR-2004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ