### PR TITLE
Only try to patch debootstrap after we relaunch

### DIFF
--- a/extensions/ubuntu-noble.sh
+++ b/extensions/ubuntu-noble.sh
@@ -1,15 +1,15 @@
 function add_host_dependencies__patch_deboostrap(){
-
-	echo "Patching Debootstrap to support Ubuntu Noble"
-	NOBLE_SYMLINK=/usr/share/debootstrap/scripts/noble
-	if [ -L ${NOBLE_SYMLINK} ] && [ -e ${NOBLE_SYMLINK} ]; then
-		:
-	else
-		if ! command -v sudo &> /dev/null; then
-			run_host_command_logged ln -s gutsy ${NOBLE_SYMLINK}
+	if [[ ${ARMBIAN_RELAUNCHED} == "yes" ]]; then
+		echo "Patching Debootstrap to support Ubuntu Noble"
+		NOBLE_SYMLINK=/usr/share/debootstrap/scripts/noble
+		if [ -L ${NOBLE_SYMLINK} ] && [ -e ${NOBLE_SYMLINK} ]; then
+			:
 		else
-			run_host_command_logged sudo ln -s gutsy ${NOBLE_SYMLINK}
+			if ! command -v sudo &> /dev/null; then
+				run_host_command_logged ln -s gutsy ${NOBLE_SYMLINK}
+			else
+				run_host_command_logged sudo ln -s gutsy ${NOBLE_SYMLINK}
+			fi
 		fi
 	fi
-
 }


### PR DESCRIPTION
# Description

Even though git shows a lot of changes, only change is putting the code in if block to make sure that we try to patch the system after we relaunch. Without this I got a password prompt on my MacBook as the system was trying to patch the MacOS.

This can be closed if #6076 is ready

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
