### PR TITLE
Add extension to perform major kernel upgrade for allwinner kernels

### DIFF
--- a/extensions/allwinner-kernel-bump.sh
+++ b/extensions/allwinner-kernel-bump.sh
@@ -1,0 +1,96 @@
+#
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (c) 2023 Gunjan Gupta <gunjan@armbian.com>
+# This file is a part of the Armbian Build Framework https://github.com/armbian/build/
+#
+
+PREV_KERNEL_PATCH_DIR=none
+
+function extension_prepare_config__prepare_kernel_patches() {
+	if [[ ! ${LINUXFAMILY} == sunxi* ]] || [[ "${BRANCH}" != "edge" ]]; then
+		exit_with_error "allwinner-kernel-bump extension must only be used with allwinner boards with edge kernel"
+	fi
+
+	if [[ ${ARMBIAN_RELAUNCHED} == "yes" ]]; then
+		display_alert "allwinner-kernel-bump" "Checking new kernel version" "info"
+		PREV_KERNEL_PATCH_DIR=${SRC}/patch/kernel/${KERNELPATCHDIR}
+		declare -g KERNELBRANCH="branch:master"
+		declare -A AKB_GIT_INFO=([GIT_SOURCE]="${KERNELSOURCE}" [GIT_REF]="${KERNELBRANCH}")
+		run_memoized AKB_GIT_INFO "git2info" memoized_git_ref_to_info "include_makefile_body"
+		declare -g KERNEL_MAJOR_MINOR=${AKB_GIT_INFO[MAKEFILE_FULL_VERSION]%.*}
+		declare -g KERNELPATCHDIR="archive/sunxi-${KERNEL_MAJOR_MINOR}"
+		display_alert "allwinner-kernel-bump" "New kernel version ${KERNEL_MAJOR_MINOR}" "info"
+	fi
+}
+
+function extension_finish_config__prepare_megous_patches() {
+	if [[ ${ARMBIAN_RELAUNCHED} == "yes" ]]; then
+		declare bare_tree_done_marker_file=".git/armbian-bare-tree-done"
+		declare kernel_git_bare_tree
+		declare git_bundles_dir
+		declare git_kernel_ball_fn
+		declare git_kernel_oras_ref
+		declare kernel_work_dir="${SRC}/cache/sources/${LINUXSOURCEDIR}"
+		patch_dir_base="${SRC}/patch/kernel/${KERNELPATCHDIR}"
+		patch_dir_megous="${patch_dir_base}/patches.megous"
+		patch_dir_tmp="${patch_dir_base}/patches.megi"
+
+		if [[ -d ${patch_dir_base} ]]; then
+			display_alert "allwinner-kernel-bump" "Found existing kernel patch directory" "info"
+			if [[ "${OVERWRITE_PATCHDIR:-no}" == "yes"  ]]; then
+				display_alert "allwinner-kernel-bump" "Removing as requested. Any manual changes will get overwritten" "info"
+				rm -rf ${patch_dir_base}
+			else
+				display_alert "allwinner-kernel-bump" "Skipping kernel patch directory creation" "info"
+				return 0
+			fi
+		fi
+
+		display_alert "allwinner-kernel-bump" "Preparing kernel git tree" "info"
+		kernel_prepare_bare_repo_decide_shallow_or_full
+		kernel_prepare_bare_repo_from_oras_gitball
+		kernel_prepare_git
+		kernel_maybe_clean
+
+		bundle_file="${git_bundles_dir}/linux-megous.bundle"
+		bundle_url="https://xff.cz/kernels/git/orange-pi-active.bundle"
+
+		display_alert "allwinner-kernel-bump" "Applying megous git bundle on kernel git tree" "info"
+		run_host_command_logged mkdir -pv "${git_bundles_dir}"
+		run_host_command_logged rm "${bundle_file}" || true
+		do_with_retries 5 axel "--output=${bundle_file}" "${bundle_url}"
+		run_host_command_logged git -C ${kernel_work_dir} fetch ${bundle_file} '+refs/heads/*:refs/remotes/megous/*'
+
+		display_alert "allwinner-kernel-bump" "Initializing kernel patch directory using previous kernel patch dir" "info"
+		run_host_command_logged cp -aR ${PREV_KERNEL_PATCH_DIR} ${patch_dir_base}
+
+		# Removing older copy of megous patches and series.conf file
+		run_host_command_logged rm -rf ${patch_dir_base}/patches.megous/*
+		run_host_command_logged rm -f ${patch_dir_base}/series.{conf,megous}
+
+		display_alert "allwinner-kernel-bump" "Extracting latest Megous patches" "info"
+		megous_trees=( "a83t-suspend" "af8133j" "anx" "audio" "axp" "cam" "drm"
+			"err" "fixes" "mbus" "modem" "opi3" "pb" "pinetab" "pp" "ppkb" "samuel"
+			"speed" "tbs-a711" "ths" )
+
+		run_host_command_logged mkdir -p ${patch_dir_megous} ${patch_dir_tmp}
+
+		for tree in ${megous_trees[@]}; do
+			run_host_command_logged "${SRC}"/tools/mk_format_patch ${kernel_work_dir} master..megous/${tree}-${KERNEL_MAJOR_MINOR} ${patch_dir_megous} sufix=megi
+			run_host_command_logged cp ${patch_dir_megous}/* ${patch_dir_tmp}
+			run_host_command_logged cat ${patch_dir_base}/series.megous ">>" ${patch_dir_base}/series.megi
+		done
+
+		run_host_command_logged cp ${patch_dir_tmp}/* ${patch_dir_megous}
+		run_host_command_logged mv ${patch_dir_base}/series.megi ${patch_dir_base}/series.megous
+		run_host_command_logged rm -rf ${patch_dir_tmp} ${patch_dir_base}/series.megi
+
+		# Disable previously disabled patches
+		grep '^-' ${PREV_KERNEL_PATCH_DIR}/series.megous | awk -F / '{print $NF}' | xargs -I {} sed -i "/\/{}/s/^/-/g" ${patch_dir_base}/series.megous
+
+		display_alert "allwinner-kernel-bump" "Generating series.conf file" "info"
+		run_host_command_logged cat ${patch_dir_base}/series.megous ">>" ${patch_dir_base}/series.conf
+		run_host_command_logged cat ${patch_dir_base}/series.fixes ">>" ${patch_dir_base}/series.conf
+		run_host_command_logged cat ${patch_dir_base}/series.armbian ">>" ${patch_dir_base}/series.conf
+	fi
+}

--- a/tools/mk_format_patch
+++ b/tools/mk_format_patch
@@ -65,8 +65,7 @@ mk_patch_series ()
 	echo -e "numbered =: [\033[1;31m${numbered}\033[0m]\n"
 
 	[ -d $url_t ] || mess+="  bad url [$url_t]\n"
-	[ "$(git -C $url_t rev-parse --git-dir 2>/dev/null)" != ".git" ] && \
-	mess+="  It's NOT git\n"
+	git -C $url_t rev-parse --git-dir 2>/dev/null || mess+="  It's NOT git\n"
 
 	[ $(git -C $url_t rev-list ${range%..*} -1 2>/dev/null) ] || \
 	mess+="  bad first tag [${range%..*}]\n"
@@ -153,7 +152,7 @@ then
 
 		echo -e "\t\tAll generated patches: [$(ls $tmp_dir | wc -l)]"
 		$(cd $tmp_dir
-			for pt in $(ls)
+			for pt in $(git -C $url_t log --graph --no-merges --pretty=%H $range | awk '{print $2}' | tac | xargs -I {} grep -l {} *)
 			do
 				if test -s $pt
 				then
@@ -177,7 +176,7 @@ then
 
 		echo -e "\t\tAll generated patches: [$(cd $tmp_dir/$target_name; ls | wc -l)]"
 		$(cd $tmp_dir/$target_name
-			for pt in $(ls)
+			for pt in $(git -C $url_t log --graph --no-merges --pretty=%H $range | awk '{print $2}' | tac | xargs -I {} grep -l {} *)
 			do
 				if test -s $pt
 				then


### PR DESCRIPTION
# Description

This extension can help when bumping major allwinner kernel version. I have designed the extension with following workflow in mind for bumping allwinner kernels:
1. Run `./compile.sh BOARD=orangepizero BRANCH=edge ENABLE_EXTENSION=allwinner-kernel-bump kernel`. This will determine whats the new kernel version going to be, initialize the kernel patch directory using previous edge kernel patches and by fetching new megous patches from megous kernel tree (https://xff.cz/git/linux). Once kernel patch directory is created, it will continue to patch kernel and then will compile the same thereby testing the created patches.
2. If there are any patch application failure or compilation failure noted from previous command, fix the same. Failed patches can be commented out by the maintainer and then they can run `./compile.sh BOARD=orangepizero BRANCH=edge ENABLE_EXTENSION=allwinner-kernel-bump kernel-patch` to get into the kernel tree and try fixing the failed patches
3. Once kernel is compiling fine, update config/sources/families/include/sunxi_common.inc and config/sources/families/include/sunxi64_common.inc to switch to new kernel version.Also update the patch/kernel/sunxi-edge symlink
4. Optionally also run `./compile.sh BOARD=orangepizero BRANCH=edge rewrite-kernel-config` and `./compile.sh BOARD=orangepizero BRANCH=edge rewrite-kernel-patches`

There are two minor fixes made to tools/mk_format_patch
- I noticed that even though we specify the linux git directory path, it was giving me error stating its not a valid git repository unless I was running the command from the root of that repository. Hence modify the git repository check
- Also modified the sequence that patch gets listed in series file to make sure patch are applied more consistently and are not tried to be applied based on the commit timestamp.

Jira reference number [AR-1505]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested with `./compile.sh BOARD=orangepizero BRANCH=edge ENABLE_EXTENSION=allwinner-kernel-bump kernel`. This created the patch directory for 6.7 kernel with all the patches present and with updated series.conf file.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1505]: https://armbian.atlassian.net/browse/AR-1505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ