### PR TITLE
armbian-firstlogin: fix locale list to include missing locales

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -160,7 +160,7 @@ set_timezone_and_locales() {
 	fi
 
 	LOCALES=$(grep territory /usr/share/i18n/locales/* | grep _"$CCODE" | cut -d ":" -f 1 | cut -d "/" -f 6 |
-		xargs -I{} grep {} /usr/share/i18n/SUPPORTED | grep "\.UTF-8" | cut -d " " -f 1)
+		xargs -I{} grep {} /usr/share/i18n/SUPPORTED | grep "UTF-8$" | cut -d " " -f 1)
 	# UTF8 is not present everywhere so check again in case it returns empty value
 	[[ -z "$LOCALES" ]] && LOCALES=$(grep territory /usr/share/i18n/locales/* | grep _"$CCODE" | cut -d ":" -f 1 | cut -d "/" -f 6 |
 		xargs -I{} grep {} /usr/share/i18n/SUPPORTED | cut -d " " -f 1)


### PR DESCRIPTION
# Description

I noticed that I was not seeing many locales that were supposed to be shown during first login like en_IN for English India. I was only getting the following 3 options when choosing to get locales based on my location

```
At your location, more locales are possible:

1) bhb_IN.UTF-8
2) tcy_IN.UTF-8
3) Skip generating locales

Please enter your choice:
```

This is because we were looking for `.UTF-8` suffix in the locale names. But not all UTF-8 locales have that suffix. All UTF-8 locales do end with UTF-8 at the end. So now we are using the same. With the fix, I am now getting much better result. Here is the list after the fix for comparison

```
At your location, more locales are possible:

1) anp_IN		      8) brx_IN			  15) kok_IN		       22) ml_IN		    29) sat_IN			 36) ur_IN
2) ar_IN		      9) doi_IN			  16) ks_IN		       23) mni_IN		    30) sd_IN			 37) Skip generating locales
3) as_IN		     10) en_IN			  17) ks_IN@devanagari	       24) mr_IN		    31) sd_IN@devanagari
4) bhb_IN.UTF-8		     11) gu_IN			  18) ks_IN@devanagari	       25) or_IN		    32) sd_IN@devanagari
5) bho_IN		     12) hi_IN			  19) mag_IN		       26) pa_IN		    33) ta_IN
6) bn_IN		     13) hne_IN			  20) mai_IN		       27) raj_IN		    34) tcy_IN.UTF-8
7) bo_IN		     14) kn_IN			  21) mjw_IN		       28) sa_IN		    35) te_IN
Please enter your choice:
```

Note: we now have ~320 locales offered to be selected when not filtering by location. Before we were only showing 153.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Created image with the fix and went through the first run process on Orange Pi 3 LTS

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
