### PR TITLE
bcm2711: don't force `SKIP_ARMBIAN_REPO=no`; include bootloader fw in bsp-cli if set to `yes`

### DIFF
--- a/config/sources/families/bcm2711.conf
+++ b/config/sources/families/bcm2711.conf
@@ -8,17 +8,16 @@
 #
 declare -g LINUXFAMILY=bcm2711
 declare -g ARCH=arm64
-declare -g UEFI_FS_LABEL="RPICFG"               # Windows/Mac users will see this if they mount the SD card. Configurable, but should be uppercase always
-declare -g SKIP_BOOTSPLASH="yes"                # video is init-ed before us
-declare -g SKIP_ARMBIAN_REPO=no                 # rpi specific packages are inside armbian repository
+declare -g UEFI_FS_LABEL="RPICFG" # Windows/Mac users will see this if they mount the SD card. Configurable, but should be uppercase always
+declare -g SKIP_BOOTSPLASH="yes"  # video is init-ed before us
 declare -g CPUMIN=500000
 declare -g CPUMAX=2900000
 declare -g GOVERNOR=ondemand
 declare -g INSTALL_ARMBIAN_FIRMWARE=no
-declare -g UEFISIZE=256                         # in MiB. Not really UEFI, but partition layout is the same.
-declare -g BOOTSIZE=0                           # No separate /boot, flash-kernel will "flash" the kernel+initrd to the firmware part.
-declare -g BOOTCONFIG=none                      # We are currently not using U-boot for Raspberry Pi boards
-declare -g UEFI_MOUNT_POINT="/boot/firmware"    # mount uefi partition at /boot/firmware
+declare -g UEFISIZE=256                      # in MiB. Not really UEFI, but partition layout is the same.
+declare -g BOOTSIZE=0                        # No separate /boot, flash-kernel will "flash" the kernel+initrd to the firmware part.
+declare -g BOOTCONFIG=none                   # We are currently not using U-boot for Raspberry Pi boards
+declare -g UEFI_MOUNT_POINT="/boot/firmware" # mount uefi partition at /boot/firmware
 
 case "${BRANCH}" in
 
@@ -48,10 +47,21 @@ case "${BRANCH}" in
 		;;
 esac
 
+function post_family_config__mark_bsp_as_firmware_containing() {
+	if [[ "${SKIP_ARMBIAN_REPO}" != "yes" ]]; then
+		declare -g -r RASPI_FIRMWARE_DIR="/usr/lib/linux-firmware-raspi"
+		display_alert "SKIP_ARMBIAN_REPO is set to" "${SKIP_ARMBIAN_REPO} - not adding rpi firmware to bsp" "info"
+		return 0
+	fi
+	display_alert "Marking BSP name as firmware-containing" "bcm2711" "info"
+	declare -g EXTRA_BSP_NAME="${EXTRA_BSP_NAME}-raspifw" # Unique bsp name.
+	declare -g -r RASPI_FIRMWARE_DIR="/usr/lib/armbian-firmware-raspi"
+}
+
 function post_family_config__add_rpi_packages() {
 	display_alert "Preparing bcm2711" "${RELEASE}" "info"
-	unset BOOTSOURCE                                            # To try and convince lib/ to not build or install u-boot.
-	declare -g SERIALCON="${RASPI_SERIALCON:-tty1}"             # HDMI etc, not serial. most people don't have UART on rpi
+	unset BOOTSOURCE                                # To try and convince lib/ to not build or install u-boot.
+	declare -g SERIALCON="${RASPI_SERIALCON:-tty1}" # HDMI etc, not serial. most people don't have UART on rpi
 
 	# those older releases are not working as we don't provide binaries for libraspberrypi-bin
 	local not_usable_releases="bullseye|buster|focal"
@@ -68,14 +78,15 @@ function post_family_config__add_rpi_packages() {
 function post_family_tweaks_bsp__add_hooks_to_move_kernel_initrd_and_dtb() {
 	run_host_command_logged mkdir -p "${destination}"/etc/kernel/post{inst,rm}.d
 
-	# Copy new files to /boot/firmware
-	run_host_command_logged cat <<- 'z50-raspi-firmware' > "${destination}"/etc/kernel/postinst.d/z50-raspi-firmware
+	# Copy new files to /boot/firmware; RASPI_FIRMWARE_DIR determines where they come from (at build time only!)
+	display_alert "Setting up z50-raspi-firmware" "bcm2711 - from ${RASPI_FIRMWARE_DIR}" "info"
+	run_host_command_logged cat <<- z50-raspi-firmware > "${destination}"/etc/kernel/postinst.d/z50-raspi-firmware
 		#!/bin/bash -e
 
 		# We are using same name as the debian's raspi-firmware script, but we
 		# only need to run this script on ubuntu. Debian's package has a postinst
 		# section capable of copying files, but Ubuntu relies on flash-kernel
-		[[ -d /usr/lib/linux-firmware-raspi ]] || exit 0
+		[[ -d ${RASPI_FIRMWARE_DIR} ]] || exit 0
 
 		# Play nice when run under debconf.
 		exec </dev/null >&2
@@ -83,11 +94,11 @@ function post_family_tweaks_bsp__add_hooks_to_move_kernel_initrd_and_dtb() {
 		# Ensure the target directory exists.
 		mkdir -p /boot/firmware
 
-		for file in /usr/lib/linux-firmware-raspi/*
+		for file in ${RASPI_FIRMWARE_DIR}/*
 		do
-			file=$( basename "$file" )
-			cp "/usr/lib/linux-firmware-raspi/$file" "/boot/firmware/$file"
-			sync -f "/boot/firmware/$file" || true
+			file=\$( basename "\$file" )
+			cp "${RASPI_FIRMWARE_DIR}/\$file" "/boot/firmware/\$file"
+			sync -f "/boot/firmware/\$file" || true
 		done
 
 		exit 0
@@ -171,22 +182,57 @@ function post_family_tweaks_bsp__add_x11_config() {
 function post_family_tweaks__populate_boot_firmware_directory() {
 	# We install kernel before we install bsp package. This means hooks present in bsp are not executed.
 	# Running the hooks from bsp to populate /boot/firmware directory.
+	display_alert "Populating /boot/firmware directory" "bcm2711" "info"
 	modules_dir="$(find "${SDCARD}/lib/modules"/ -maxdepth 1 -type d -name "*${IMAGE_INSTALLED_KERNEL_VERSION}*")"
 	kern_ver="$(basename "$modules_dir")"
 	run_host_command_logged mkdir -p "${SDCARD}"/boot/firmware
 	chroot_sdcard /etc/kernel/postinst.d/z50-raspi-firmware "${kern_ver}"
 	chroot_sdcard /etc/kernel/postinst.d/zzz-copy-new-files "${kern_ver}"
+	display_alert "Populating /boot/firmware directory" "bcm2711 - done" "info"
+}
+
+function post_family_tweaks_bsp__rpi_firmware_in_bsp() {
+	if [[ "${SKIP_ARMBIAN_REPO}" != "yes" ]]; then
+		display_alert "SKIP_ARMBIAN_REPO is set to" "${SKIP_ARMBIAN_REPO} - not adding rpi firmware to bsp" "info"
+		return 0
+	fi
+
+	display_alert "Using in-BSP firmware files for" "bcm2711::${BOARD}" "info"
+	declare firmware_commit_sha1="9cafcd85f8aed1ec0c0f609b98af591fae367ba2" # Keep this inside this file, so hashing detect changes and bumps the version of the bsp package
+
+	declare destdir="${destination}/usr/lib/armbian-firmware-raspi"
+	run_host_command_logged mkdir -p "${destdir}"
+	# Get the firmware files from the Debian git repo
+	fetch_from_repo "https://salsa.debian.org/debian/raspi-firmware.git" "debian-raspi-firmware" "commit:${firmware_commit_sha1}" "yes"
+	declare srcdir="${SRC}/cache/sources/debian-raspi-firmware/${firmware_commit_sha1}"
+	# Copy the files from the git repo boot dir to the destdir
+	run_host_command_logged cp -prv "${srcdir}/boot/"* "${destdir}"/
 }
 
 function pre_install_distribution_specific__add_rpi_packages() {
-	# we store Rpi firmware packages in our repository
-	# https://github.com/armbian/os/wiki/Import-3rd-party-packages
-	display_alert "Enable Armbian repository to fetch Rpi packages" "" "info"
-	mv "${SDCARD}"/etc/apt/sources.list.d/armbian.list.disabled "${SDCARD}"/etc/apt/sources.list.d/armbian.list
-	do_with_retries 3 chroot_sdcard_apt_get_update
-	chroot_sdcard_apt_get_install rpi-eeprom linux-firmware-raspi pi-bluetooth libraspberrypi-bin busybox raspi-config
-	# disable armbian repository
-	mv "${SDCARD}"/etc/apt/sources.list.d/armbian.list "${SDCARD}"/etc/apt/sources.list.d/armbian.list.disabled
+	# If we're skipping the Armbian repo, and on Debian, we'll install Debian version of Wifi/BT-related firmware.
+	if [[ "${SKIP_ARMBIAN_REPO}" == "yes" ]]; then
+		display_alert "SKIP_ARMBIAN_REPO is set to" "${SKIP_ARMBIAN_REPO} - no Armbian repo packages will be installed" "info"
+		if [[ "${DISTRIBUTION}" == "Debian" ]]; then
+			display_alert "Installing Debian-sourced Wifi/BT firmware packages" "Debian::bcm2711::${BOARD}" "info"
+			do_with_retries 3 chroot_sdcard_apt_get_update
+			chroot_sdcard_apt_get_install firmware-brcm80211 firmware-misc-nonfree bluez-firmware bluetooth
+		fi
+		if [[ "${DISTRIBUTION}" == "Ubuntu" ]]; then
+			display_alert "Installing Ubuntu-sourced Wifi/BT firmware packages plus raspi-config and raspi-eeprom" "Ubuntu::bcm2711::${BOARD}" "info"
+			do_with_retries 3 chroot_sdcard_apt_get_update
+			chroot_sdcard_apt_get_install rpi-eeprom pi-bluetooth busybox raspi-config bluetooth
+		fi
+	else
+		# we store Rpi firmware packages in our repository
+		# https://github.com/armbian/os/wiki/Import-3rd-party-packages
+		display_alert "Enable Armbian repository to fetch Rpi packages" "" "info"
+		mv "${SDCARD}"/etc/apt/sources.list.d/armbian.list.disabled "${SDCARD}"/etc/apt/sources.list.d/armbian.list
+		do_with_retries 3 chroot_sdcard_apt_get_update
+		chroot_sdcard_apt_get_install rpi-eeprom linux-firmware-raspi pi-bluetooth libraspberrypi-bin busybox raspi-config
+		## disable armbian repository
+		mv "${SDCARD}"/etc/apt/sources.list.d/armbian.list "${SDCARD}"/etc/apt/sources.list.d/armbian.list.disabled
+	fi
 }
 
 # Our default paritioning system is leaving esp on. Rpi3 is the only board that have issues with this.
@@ -254,4 +300,9 @@ function pre_umount_final_image__write_raspi_cmdline() {
 	cat <<- EOD > "${MOUNT}"/boot/firmware/cmdline.txt
 		console=serial0,115200 console=tty1 loglevel=1 root=LABEL=${ROOT_FS_LABEL} rootfstype=${ROOTFS_TYPE} fsck.repair=yes rootwait logo.nologo
 	EOD
+
+	if [[ "${SHOW_DEBUG}" == "yes" ]]; then
+		display_alert "Showing /boot/firmware as mounted" "bcm2711" "debug"
+		run_host_command_logged tree "${MOUNT}"/boot/firmware
+	fi
 }


### PR DESCRIPTION
#### bcm2711: don't force `SKIP_ARMBIAN_REPO=no`; include bootloader fw in bsp-cli if set to `yes`

- bcm2711: don't force `SKIP_ARMBIAN_REPO=no`; include bootloader fw in bsp-cli if set to `yes`
  - do not force `SKIP_ARMBIAN_REPO=no` anymore
  - instead, if `SKIP_ARMBIAN_REPO=yes`:
    - include the bootloader "fw" in bsp package, from Debian's raspi-firmware git source
    - add Debian/Ubuntu-specific packages for Wifi/BT firmware
      - For Ubuntu, include raspi-eeprom and raspi-config too (not available on Debian)
  - tested on rpi4b (bookworm/mantic) - untested on rpi5b (I don't have/want one)