### PR TITLE
add support for building linux-next kernel

### DIFF
--- a/lib/functions/compilation/utils-compilation.sh
+++ b/lib/functions/compilation/utils-compilation.sh
@@ -27,7 +27,8 @@ grab_version() {
 	ver[1]=$(grep "^PATCHLEVEL" "${1}"/Makefile | head -1 | awk '{print $(NF)}' | grep -oE '^[[:digit:]]+' || true)
 	ver[2]=$(grep "^SUBLEVEL" "${1}"/Makefile | head -1 | awk '{print $(NF)}' | grep -oE '^[[:digit:]]+' || true)
 	ver[3]=$(grep "^EXTRAVERSION" "${1}"/Makefile | head -1 | awk '{print $(NF)}' | grep -oE '^-rc[[:digit:]]+' || true)
-	echo "${ver[0]:-0}${ver[1]:+.${ver[1]}}${ver[2]:+.${ver[2]}}${ver[3]}"
+	ver[4]=$(if [ -f localversion-next ];then echo $(cat localversion-next); fi || true)
+	echo "${ver[0]:-0}${ver[1]:+.${ver[1]}}${ver[2]:+.${ver[2]}}${ver[3]}${ver[4]}"
 	return 0
 }
 


### PR DESCRIPTION
# Description

Current kernel deb package script ignores localversion of linux-next like `-next-20231222`, which will not pass deb building. This commit will add this localversion when grabbing kernel version.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] `./compile.sh kernel BOARD=rock-5b BRANCH=edge DEB_COMPRESS=xz KERNEL_GIT=shallow`, tested with KERNELSOURCE changed to https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git.
- [x] Built kernel runs normally.
- [x] Normal non-next kernel source tested

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
