### PR TITLE
`Automatic` board configs status synchronise

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,6 +46,7 @@ config/boards/khadas-vim4.conf		@echatzip @rpardini @viraniac
 config/boards/lafrite.conf		@Tonymac32
 config/boards/lepotato.conf		@Tonymac32
 config/boards/licheepi-4a.wip		@chainsx
+config/boards/mangopi-m28k.csc		@sputnik2019
 config/boards/mekotronics-r58-minipc.wip		@monkaBlyat
 config/boards/mekotronics-r58x-4g.wip		@monkaBlyat
 config/boards/mekotronics-r58x.wip		@monkaBlyat
@@ -77,8 +78,9 @@ config/boards/orangepipc.csc		@lbmendes
 config/boards/orangepiprime.conf		@viraniac
 config/boards/orangepizero.conf		@viraniac
 config/boards/orangepizero2.conf		@AGM1968 @krachlatte
+config/boards/orangepizero3.wip		@viraniac
 config/boards/orangepizeroplus.conf		@schwar3kat
-config/boards/pine64.conf		@PanderMusubi @joshaspinall
+config/boards/pine64.conf		@PanderMusubi
 config/boards/pine64so.csc		@joshaspinall
 config/boards/pinebook-pro.conf		@TRSx80 @ahoneybun
 config/boards/qemu-uboot-arm64.wip		@rpardini
@@ -114,7 +116,7 @@ config/boards/uefi-x86.conf		@rpardini
 config/boards/wsl2-arm64.csc		@rpardini
 config/boards/wsl2-x86.csc		@rpardini
 config/boards/xiaomi-elish.conf		@amazingfate
-config/kernel/linux-arm64-*.config		@amazingfate @rpardini
+config/kernel/linux-arm64-*.config		@amazingfate
 config/kernel/linux-bcm2711-*.config		@PanderMusubi @teknoid @viraniac
 config/kernel/linux-k3-*.config		@glneo
 config/kernel/linux-media-*.config		@150balbes
@@ -125,7 +127,7 @@ config/kernel/linux-mvebu64-*.config		@ManoftheSea
 config/kernel/linux-odroidxu4-*.config		@joekhoobyar
 config/kernel/linux-rk35xx-*.config		@Tonymac32 @Z-Keven @ZazaBR @amazingfate @catalinii @efectn @hoochiwetech @igorpecovnik @krachlatte @lanefu @linhz0hz @mahdichi @monkaBlyat @rpardini @sputnik2019 @vamzii
 config/kernel/linux-rockchip-*.config		@paolosabatino
-config/kernel/linux-rockchip-rk3588-*.config		@Tonymac32 @amazingfate @efectn @igorpecovnik @lanefu @linhz0hz
+config/kernel/linux-rockchip-rk3588-*.config		@Tonymac32 @amazingfate @efectn @igorpecovnik @lanefu @linhz0hz @rpardini
 config/kernel/linux-rockchip64-*.config		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @rpardini @schwar3kat @tdleiyao @utlark @vamzii
 config/kernel/linux-rockpis-*.config		@brentr
 config/kernel/linux-sun50iw9-*.config		@AGM1968 @krachlatte
@@ -136,18 +138,14 @@ config/kernel/linux-thead-*.config		@chainsx
 config/kernel/linux-uefi-arm64-*.config		@150balbes @rpardini
 config/kernel/linux-uefi-x86-*.config		@rpardini
 patch/kernel/NEED-*/		@bigtreetech
-patch/kernel/archive/meson-*/		@hzyitc
 patch/kernel/archive/meson-s4t7-*/		@echatzip @rpardini @viraniac
-patch/kernel/archive/meson64-*/		@NicoD-SBC @SteeManMI @Tonymac32 @adeepn @bretmlw @clee @engineer-80 @igorpecovnik @jeanrhum @monkaBlyat @pyavitz @rpardini @teknoid
-patch/kernel/archive/rk35xx-*/		@Tonymac32 @Z-Keven @ZazaBR @amazingfate @catalinii @efectn @hoochiwetech @igorpecovnik @krachlatte @lanefu @linhz0hz @mahdichi @monkaBlyat @rpardini @sputnik2019 @vamzii
-patch/kernel/archive/rockchip-*/		@paolosabatino
-patch/kernel/archive/rockchip64-*/		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @rpardini @schwar3kat @tdleiyao @utlark @vamzii
 patch/kernel/archive/rockpis-*/		@brentr
 patch/kernel/archive/sm8250-*/		@amazingfate
 patch/kernel/archive/sun50iw9-*/		@AGM1968 @krachlatte
 patch/kernel/archive/sunxi-*/		@1ubuntuuser @AGM1968 @AaronNGray @DylanHP @Kreyren @PanderMusubi @StephenGraf @Tonymac32 @bigtreetech @devdotnetorg @eliasbakken @joshaspinall @krachlatte @lbmendes @schwar3kat @sgjava @teknoid @viraniac
 patch/kernel/archive/uefi-arm64-*/		@150balbes @rpardini
-patch/kernel/arm64-*/		@amazingfate @rpardini
+patch/kernel/archive/uefi-x86-*/		@rpardini
+patch/kernel/arm64-*/		@amazingfate
 patch/kernel/bcm2711-*/		@PanderMusubi @teknoid @viraniac
 patch/kernel/k3-*/		@glneo
 patch/kernel/media-*/		@150balbes
@@ -157,13 +155,11 @@ patch/kernel/mvebu64-*/		@ManoftheSea
 patch/kernel/odroidxu4-*/		@joekhoobyar
 patch/kernel/rk35xx-*/		@Tonymac32 @Z-Keven @ZazaBR @amazingfate @catalinii @efectn @hoochiwetech @igorpecovnik @krachlatte @lanefu @linhz0hz @mahdichi @monkaBlyat @rpardini @sputnik2019 @vamzii
 patch/kernel/rockchip-*/		@paolosabatino
-patch/kernel/rockchip-rk3588-*/		@Tonymac32 @amazingfate @efectn @igorpecovnik @lanefu @linhz0hz
+patch/kernel/rockchip-rk3588-*/		@Tonymac32 @amazingfate @efectn @igorpecovnik @lanefu @linhz0hz @rpardini
 patch/kernel/rockchip64-*/		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @rpardini @schwar3kat @tdleiyao @utlark @vamzii
 patch/kernel/rockpis-*/		@brentr
 patch/kernel/sun50iw9-*/		@AGM1968 @krachlatte
 patch/kernel/thead-*/		@chainsx
-patch/kernel/uefi-arm64-*/		@150balbes @rpardini
-patch/kernel/uefi-x86-*/		@rpardini
 sources/families/arm64.conf		@150balbes @amazingfate @rpardini
 sources/families/bcm2711.conf		@PanderMusubi @teknoid @viraniac
 sources/families/k3.conf		@glneo
@@ -174,7 +170,7 @@ sources/families/meson64.conf		@NicoD-SBC @SteeManMI @Tonymac32 @adeepn @bretmlw
 sources/families/mvebu64.conf		@ManoftheSea
 sources/families/odroidxu4.conf		@joekhoobyar
 sources/families/rk35xx.conf		@Tonymac32 @Z-Keven @ZazaBR @amazingfate @catalinii @efectn @hoochiwetech @igorpecovnik @krachlatte @lanefu @linhz0hz @mahdichi @monkaBlyat @rpardini @sputnik2019 @vamzii
-sources/families/rockchip-rk3588.conf		@Tonymac32 @amazingfate @efectn @igorpecovnik @lanefu @linhz0hz
+sources/families/rockchip-rk3588.conf		@Tonymac32 @amazingfate @efectn @igorpecovnik @lanefu @linhz0hz @rpardini
 sources/families/rockchip.conf		@paolosabatino
 sources/families/rockchip64.conf		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @rpardini @schwar3kat @tdleiyao @utlark @vamzii
 sources/families/rockpis.conf		@brentr

--- a/config/boards/pine64.conf
+++ b/config/boards/pine64.conf
@@ -1,7 +1,7 @@
 # Allwinner A64 quad core 512MB-2GB RAM SoC GBE
 BOARD_NAME="Pine64"
 BOARDFAMILY="sun50iw1"
-BOARD_MAINTAINER="joshaspinall PanderMusubi"
+BOARD_MAINTAINER="PanderMusubi"
 BOOTCONFIG="pine64_plus_defconfig"
 KERNEL_TARGET="legacy,current,edge"
 FULL_DESKTOP="yes"


### PR DESCRIPTION
Update maintainers and board status

- synced status from the database
- rename to .`csc` where we don't have anyone

If you want to become a board maintainer, [adjust data here](https://www.armbian.com/update-data/).

Ref: [Board Maintainers Procedures and Guidelines](https://docs.armbian.com/Board_Maintainers_Procedures_and_Guidelines/)