### PR TITLE
`odroidm1`: set `OVERLAY_PREFIX`; `rockchip64`: default, but don't override, `OVERLAY_PREFIX`

### DIFF
--- a/config/boards/odroidm1.conf
+++ b/config/boards/odroidm1.conf
@@ -21,6 +21,9 @@ BOOTDIR="u-boot-${BOARD}" # do not share u-boot directory
 DDR_BLOB="rk35/rk3568_ddr_1560MHz_v1.18.bin"
 BL31_BLOB="rk35/rk3568_bl31_v1.43.elf"
 
+# The overlays for this board are prefixed by 'rockchip-rk3568-hk' (see for example patch/kernel/archive/rockchip64-6.x/overlay/rockchip-rk3328-i2c0.dts)
+OVERLAY_PREFIX="rockchip-rk3568-hk"
+
 # HK's SPI partition on MTD:
 # mtd0: start 0         size 917.504   end 917.504    : SPL          == start 0x0      size 0xe0000  : SPL
 # mtd1: start 917.504   size 131.072   end 1.048.576  : U-Boot Env   == start 0xe0000  size 0x20000  : U-Boot Env

--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -13,7 +13,7 @@ BOOTSCRIPT='boot-rockchip64.cmd:boot.cmd'
 BOOTENV_FILE='rockchip64.txt'
 UBOOT_TARGET_MAP=";;idbloader.bin uboot.img trust.bin"
 BOOTDELAY=0
-OVERLAY_PREFIX='rockchip'
+OVERLAY_PREFIX="${OVERLAY_PREFIX:-"rockchip"}" # default to 'rockchip' if not set by board
 SERIALCON=${SERIALCON:=$([ "${BRANCH}" == "legacy" ] && echo "ttyFIQ0:1500000" || echo "ttyS2:1500000")}
 GOVERNOR="ondemand"
 ATFPATCHDIR='atf-rockchip64'


### PR DESCRIPTION
#### `odroidm1`: set `OVERLAY_PREFIX`; `rockchip64`: default, but don't override, `OVERLAY_PREFIX`

- `odroidm1`: set `OVERLAY_PREFIX`; `rockchip64`: default, but don't override, `OVERLAY_PREFIX`