### PR TITLE
patching: set commit index length to 12 when rewriting patches

### DIFF
--- a/lib/tools/common/patching_utils.py
+++ b/lib/tools/common/patching_utils.py
@@ -805,6 +805,7 @@ def export_commit_as_patch(repo: git.Repo, commit: str):
 		'--zero-commit',  # do not use the git revision, instead 000000...0000
 		'--stat=120',  # 'wider' stat output; default is 80
 		'--stat-graph-width=10',  # shorten the diffgraph graph part, it's too long
+        '--abbrev=12', # force index length to 12
 		"-1", "--stdout", commit
 	],
 		cwd=repo.working_tree_dir,


### PR DESCRIPTION
# Description

I'm rewriting patches with command `PREFER_DOCKER=no ./compile.sh rewrite-kernel-patches BOARD=rock-5b BRANCH=edge` on armbian jammy, but I get all commit index length changed from 12 to 13.
Maybe that's because envirmonts are different between docker and bare metal.
So add `--abbrev=12` to always get commit index length 12.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] `PREFER_DOCKER=no ./compile.sh rewrite-kernel-patches BOARD=rock-5b BRANCH=edge`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
