### PR TITLE
add mangopi m28k board

### DIFF
--- a/config/boards/mangopi-m28k.csc
+++ b/config/boards/mangopi-m28k.csc
@@ -1,5 +1,5 @@
 # Rockchip RK3528 quad core 1-8GB SoC GBe eMMC PCIE Wifi Bt
-BOARD_NAME="Mangopi-M28K"
+BOARD_NAME="Mangopi M28K"
 BOARDFAMILY="rk35xx"
 BOOTCONFIG="hinlink_rk3528_defconfig"
 BOARD_MAINTAINER="sputnik2019"

--- a/config/boards/mangopi-m28k.csc
+++ b/config/boards/mangopi-m28k.csc
@@ -1,0 +1,19 @@
+# Rockchip RK3528 quad core 1-8GB SoC GBe eMMC PCIE Wifi Bt
+BOARD_NAME="Mangopi-M28K"
+BOARDFAMILY="rk35xx"
+BOOTCONFIG="hinlink_rk3528_defconfig"
+BOARD_MAINTAINER="sputnik2019"
+KERNEL_TARGET="legacy"
+FULL_DESKTOP="yes"
+BOOT_LOGO="desktop"
+BOOT_FDT_FILE="rockchip/rk3528-mangopi-m28k.dtb"
+BOOT_SCENARIO="spl-blobs"
+WIREGUARD="no"
+IMAGE_PARTITION_TABLE="gpt"
+BOOTFS_TYPE="ext4"
+# Override family config for this board; let's avoid conditionals in family config.
+function post_family_config__hinlink-h28k_use_vendor_uboot() {
+	BOOTSOURCE='https://github.com/rockchip-linux/u-boot.git'
+	BOOTBRANCH='commit:32640b0ada9344f91e7a407576568782907161cd'
+	BOOTPATCHDIR="legacy/board_hinlink-h28k"
+}


### PR DESCRIPTION
mangopi-m28k is rk3528 new mini sbc box. The following hardware features are supported：
1.Two Gb ethernet（one gmac another is pcie）
2.Two usb 2.0 type A connecter
3.wifi6 aic8800
4.lpddr4（1-4GB）emmc（8-32）TF
5.micro hdmi connecter
6.IR Receiver
7.user uart/spi/iic extended interfaces
8.pd power