### PR TITLE
Set dpkg vendor to Armbian in all images

### DIFF
--- a/lib/functions/artifacts/artifact-armbian-base-files.sh
+++ b/lib/functions/artifacts/artifact-armbian-base-files.sh
@@ -137,6 +137,10 @@ function compile_armbian-base-files() {
 		Bugs: ${VENDORBUGS}
 		Parent: ${DISTRIBUTION}
 	EOD
+	# Fix symlinking in postinst for Debian and Ubuntu. They have to point towards Armbian
+	sed -i "s|ln -sf ubuntu /etc/dpkg/origins/default|ln -sf armbian /etc/dpkg/origins/default|g" "${destination}"/DEBIAN/postinst
+	sed -i "s|ln -sf debian \"\$DPKG_ROOT/etc/dpkg/origins/default\"|ln -sf armbian \"\$DPKG_ROOT/etc/dpkg/origins/default\"|g" "${destination}"/DEBIAN/postinst
+
 	sed -i "s|^HOME_URL=.*|HOME_URL=\"${VENDORURL}\"|" "${destination}"/etc/os-release
 	sed -i "s|^SUPPORT_URL=.*|SUPPORT_URL=\"${VENDORSUPPORT}\"|" "${destination}"/etc/os-release
 	sed -i "s|^BUG_REPORT_URL=.*|BUG_REPORT_URL=\"${VENDORBUGS}\"|" "${destination}"/etc/os-release

--- a/lib/functions/artifacts/artifact-armbian-base-files.sh
+++ b/lib/functions/artifacts/artifact-armbian-base-files.sh
@@ -137,9 +137,29 @@ function compile_armbian-base-files() {
 		Bugs: ${VENDORBUGS}
 		Parent: ${DISTRIBUTION}
 	EOD
-	# Fix symlinking in postinst for Debian and Ubuntu. They have to point towards Armbian
+	# Add armbian to the package conf files.
+	sed -i '/\/etc\/dpkg\/origins\/debian/a \/etc\/dpkg\/origins\/armbian' "${destination}"/DEBIAN/conffiles
+
+	# Fix symlinking in postinst for Debian and Ubuntu. They have to point towards Armbian, Armbian parent is Debian or Ubuntu -> Debian
 	sed -i "s|ln -sf ubuntu /etc/dpkg/origins/default|ln -sf armbian /etc/dpkg/origins/default|g" "${destination}"/DEBIAN/postinst
 	sed -i "s|ln -sf debian \"\$DPKG_ROOT/etc/dpkg/origins/default\"|ln -sf armbian \"\$DPKG_ROOT/etc/dpkg/origins/default\"|g" "${destination}"/DEBIAN/postinst
+	# Create preinst file if not exists (Debian)
+	if [[ ! -e "${destination}"/DEBIAN/preinst ]]; then
+		cat <<- EOD >> "${destination}"/DEBIAN/preinst
+		#!/bin/sh
+		set -e
+		# Start of automatically added by ${VENDOR}
+		rm -f /etc/dpkg/origins/default # reset default link
+		# End of automatically added by ${VENDOR}
+		EOD
+		chmod 0755 "${destination}"/DEBIAN/preinst
+	else
+		cat <<- EOD >> "${destination}"/DEBIAN/preinst
+		# Start of automatically added by ${VENDOR}
+		rm -f /etc/dpkg/origins/default # reset default link
+		# End of automatically added by ${VENDOR}
+		EOD
+	fi
 
 	sed -i "s|^HOME_URL=.*|HOME_URL=\"${VENDORURL}\"|" "${destination}"/etc/os-release
 	sed -i "s|^SUPPORT_URL=.*|SUPPORT_URL=\"${VENDORSUPPORT}\"|" "${destination}"/etc/os-release


### PR DESCRIPTION
# Description

We already set to Armbian, but we didn't set default link. This fixes it for both, Debian and Ubuntu.

Jira reference number [AR-2012] Close https://github.com/armbian/build/issues/6118

# How Has This Been Tested?

- [x] check if base files are updated correctly
- [x] Make an upgrade and see if it get fixed.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-2012]: https://armbian.atlassian.net/browse/AR-2012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ