### PR TITLE
Fix rpi image creation broken since to #6087

### DIFF
--- a/lib/functions/main/rootfs-image.sh
+++ b/lib/functions/main/rootfs-image.sh
@@ -42,6 +42,12 @@ function build_rootfs_and_image() {
 	# Deploy the full apt lists, including the Armbian repo.
 	create_sources_list_and_deploy_repo_key "image-late" "${RELEASE}" "${SDCARD}/"
 
+	# We call this above method too many times. @TODO: find out why and fix the same
+	# We may have a armbian.list.disabled file lying around. Remove the same
+	if [[ -e "${SDCARD}"/etc/apt/sources.list.d/armbian.list.disabled ]]; then
+		rm "${SDCARD}"/etc/apt/sources.list.d/armbian.list.disabled
+	fi
+
 	# remove packages that are no longer needed. rootfs cache + uninstall might have leftovers.
 	LOG_SECTION="apt_purge_unneeded_packages_and_clean_apt_caches" do_with_logging apt_purge_unneeded_packages_and_clean_apt_caches
 

--- a/lib/functions/rootfs/distro-specific.sh
+++ b/lib/functions/rootfs/distro-specific.sh
@@ -210,24 +210,22 @@ function create_sources_list_and_deploy_repo_key() {
 	components+=("${RELEASE}-utils")   # utils contains packages Igor picks from other repos
 	components+=("${RELEASE}-desktop") # desktop contains packages Igor picks from other repos
 
-	if [[ "${when}" != "image-early" ]]; then # only add armbian.list when==image-late
-		# stage: add armbian repository and install key
-		if [[ $DOWNLOAD_MIRROR == "china" ]]; then
-			echo "deb ${SIGNED_BY}https://mirrors.tuna.tsinghua.edu.cn/armbian $RELEASE ${components[*]}" > "${basedir}"/etc/apt/sources.list.d/armbian.list
-		elif [[ $DOWNLOAD_MIRROR == "bfsu" ]]; then
-			echo "deb ${SIGNED_BY}http://mirrors.bfsu.edu.cn/armbian $RELEASE ${components[*]}" > "${basedir}"/etc/apt/sources.list.d/armbian.list
-		else
-			echo "deb ${SIGNED_BY}http://$([[ $BETA == yes ]] && echo "beta" || echo "apt").armbian.com $RELEASE ${components[*]}" > "${basedir}"/etc/apt/sources.list.d/armbian.list
-		fi
+	# stage: add armbian repository and install key
+	if [[ $DOWNLOAD_MIRROR == "china" ]]; then
+		echo "deb ${SIGNED_BY}https://mirrors.tuna.tsinghua.edu.cn/armbian $RELEASE ${components[*]}" > "${basedir}"/etc/apt/sources.list.d/armbian.list
+	elif [[ $DOWNLOAD_MIRROR == "bfsu" ]]; then
+		echo "deb ${SIGNED_BY}http://mirrors.bfsu.edu.cn/armbian $RELEASE ${components[*]}" > "${basedir}"/etc/apt/sources.list.d/armbian.list
+	else
+		echo "deb ${SIGNED_BY}http://$([[ $BETA == yes ]] && echo "beta" || echo "apt").armbian.com $RELEASE ${components[*]}" > "${basedir}"/etc/apt/sources.list.d/armbian.list
+	fi
 
-		# replace local package server if defined. Suitable for development
-		[[ -n $LOCAL_MIRROR ]] && echo "deb ${SIGNED_BY}http://$LOCAL_MIRROR $RELEASE ${components[*]}" > "${basedir}"/etc/apt/sources.list.d/armbian.list
+	# replace local package server if defined. Suitable for development
+	[[ -n $LOCAL_MIRROR ]] && echo "deb ${SIGNED_BY}http://$LOCAL_MIRROR $RELEASE ${components[*]}" > "${basedir}"/etc/apt/sources.list.d/armbian.list
 
-		# disable repo if SKIP_ARMBIAN_REPO==yes, or if when==image-early.
-		if [[ "${SKIP_ARMBIAN_REPO}" == "yes" ]]; then
-			display_alert "Disabling Armbian repo" "${ARCH}-${RELEASE} :: skip:${SKIP_ARMBIAN_REPO:-"no"} when:${when}" "info"
-			mv "${SDCARD}"/etc/apt/sources.list.d/armbian.list "${SDCARD}"/etc/apt/sources.list.d/armbian.list.disabled
-		fi
+	# disable repo if SKIP_ARMBIAN_REPO==yes, or if when==image-early.
+	if [[ "${when}" == "image-early" || "${SKIP_ARMBIAN_REPO}" == "yes" ]]; then
+		display_alert "Disabling Armbian repo" "${ARCH}-${RELEASE} :: skip:${SKIP_ARMBIAN_REPO:-"no"} when:${when}" "info"
+		mv "${SDCARD}"/etc/apt/sources.list.d/armbian.list "${SDCARD}"/etc/apt/sources.list.d/armbian.list.disabled
 	fi
 
 	declare CUSTOM_REPO_WHEN="${when}"


### PR DESCRIPTION
# Description

The raspberry pi images were broken since #6087 as armbian.list was no longer available to install the required packages. As the description for #6087 mentioned that the change was just to remove the dormant armbian.list.disabled file, this PR does the same simply by removing the file if its present after image-late.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested creating Raspberry pi images and also verifying that there is no leftover armbian.list.disabled file.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
