### PR TITLE
rock-5b edge: fix emmc, temp sensor and power off

### DIFF
--- a/patch/kernel/rockchip-rk3588-edge/0032-arm64-dts-rock-5b-Slow-down-emmc-to-hs200-and-add-ts.patch
+++ b/patch/kernel/rockchip-rk3588-edge/0032-arm64-dts-rock-5b-Slow-down-emmc-to-hs200-and-add-ts.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: amazingfate <liujianfeng1994@gmail.com>
+Date: Wed, 27 Dec 2023 15:03:57 +0800
+Subject: arm64: dts: rock-5b: Slow down emmc to hs200 and add tsadc node
+
+---
+ arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+index 1b741b5ca81b..2103f1677251 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+@@ -450,8 +450,7 @@ &sdhci {
+ 	no-sdio;
+ 	no-sd;
+ 	non-removable;
+-	mmc-hs400-1_8v;
+-	mmc-hs400-enhanced-strobe;
++	mmc-hs200-1_8v;
+ 	status = "okay";
+ };
+ 
+@@ -491,6 +490,10 @@ &sdio {
+ 	status = "okay";
+ };
+ 
++&tsadc {
++	status = "okay";
++};
++
+ &uart6 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&uart6m1_xfer &uart6m1_ctsn &uart6m1_rtsn>;
+-- 
+Armbian
+

--- a/patch/kernel/rockchip-rk3588-edge/0033-arm64-dts-rockchip-support-poweroff-on-the-rock-5b.patch
+++ b/patch/kernel/rockchip-rk3588-edge/0033-arm64-dts-rockchip-support-poweroff-on-the-rock-5b.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: John Clark <inindev@gmail.com>
+Date: Mon, 25 Dec 2023 22:28:19 +0000
+Subject: arm64: dts: rockchip: support poweroff on the rock-5b
+
+Allow the rock-5b to poweroff its pmic. When issuing a "shutdown -h now"
+on the rock-5b it reboots instead. Defining 'system-power-controller'
+allows the rk806 to power down.
+
+Commit c699fbfdfd54 ("arm64: dts: rockchip: Support poweroff on
+NanoPC-T6") similarly resolves this issue for the nanopc-t6.
+
+Signed-off-by: John Clark <inindev@gmail.com>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+index 2103f1677251..a08ccc204158 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+@@ -520,6 +520,8 @@ pmic@0 {
+ 		pinctrl-0 = <&pmic_pins>, <&rk806_dvs1_null>,
+ 			    <&rk806_dvs2_null>, <&rk806_dvs3_null>;
+ 
++		system-power-controller;
++
+ 		vcc1-supply = <&vcc5v0_sys>;
+ 		vcc2-supply = <&vcc5v0_sys>;
+ 		vcc3-supply = <&vcc5v0_sys>;
+-- 
+Armbian
+


### PR DESCRIPTION
We need to slow down to HS200 for stable emmc.
Add tsadc node for temp sensor.
Add power off fix from mail list

# Description

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] `./compile.sh kernel BOARD=rock-5b BRANCH=edge DEB_COMPRESS=xz KERNEL_GIT=shallow`
- [x] emmc is stable, cpu temp is shown from command `sensors`, and command `poweroff` is working.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
