### PR TITLE
ROCK5B: overlay enable spi flash based on Googulator device tree

### DIFF
--- a/patch/kernel/rockchip-rk3588-edge/overlay/Makefile
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/Makefile
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0
 dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
-	rockchip-rk3588-sata2.dtbo
+	rockchip-rk3588-sata2.dtbo \
+	rockchip-rk3588-rock5b-spi-flash.dtbo
 
 targets += $(dtbo-y)
 

--- a/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-rock5b-spi-flash.dts
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-rock5b-spi-flash.dts
@@ -1,0 +1,29 @@
+/dts-v1/;
+/plugin/;
+
+&sfc {
+	status = "okay";
+
+		spi_flash: spi-flash@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "jedec,spi-nor";
+		reg = <0x0>;
+		spi-max-frequency = <50000000>;
+		spi-tx-bus-width = <1>;
+		spi-rx-bus-width = <4>;
+		status = "okay";
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			loader@0 {
+				label = "loader";
+				reg = <0x0 0x1000000>;
+			};
+		};
+	};
+
+};


### PR DESCRIPTION
# Description

made overlay to enable spi flash on rock5b based on https://github.com/Googulator/linux-rk3588-midstream/blob/adbadbf32e87b308688136aa55c03b1bed6f7e03/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts#L704C1-L724C4

```
root@rock-5b:~# lsblk
NAME        MAJ:MIN RM   SIZE RO TYPE MOUNTPOINTS
mtdblock0    31:0    0    16M  0 disk
mmcblk1     179:0    0  59.7G  0 disk
├─mmcblk1p1 179:1    0   256M  0 part /boot
└─mmcblk1p2 179:2    0  58.8G  0 part /var/log.hdd
                                      /
zram0       251:0    0   3.8G  0 disk [SWAP]
zram1       251:1    0    50M  0 disk /var/log
zram2       251:2    0     0B  0 disk
nvme0n1     259:0    0 238.5G  0 disk
└─nvme0n1p1 259:1    0 238.5G  0 part
root@rock-5b:~# dmesg|fgrep -i spi
[    0.000000] GICv3: 480 SPIs implemented
[    0.000000] GICv3: 0 Extended SPIs implemented
[    0.891760] spi spi0.0: Fixed dependency cycle(s) with /spi@feb20000/pmic@0/regulators/dcdc-reg7
[    0.892578] spi spi0.0: Fixed dependency cycle(s) with /spi@feb20000/pmic@0/dvs3-null-pins
[    0.893311] spi spi0.0: Fixed dependency cycle(s) with /spi@feb20000/pmic@0/dvs2-null-pins
[    0.894043] spi spi0.0: Fixed dependency cycle(s) with /spi@feb20000/pmic@0/dvs1-null-pins
[    0.896499] spi-nor spi1.0: mx25u12835f (16384 Kbytes)
[    1.761968] 1 fixed-partitions partitions found on MTD device spi1.0
[    1.762534] Creating 1 MTD partitions on "spi1.0":
```