### PR TITLE
RK3588-edge: add SATA1 overlay for rock5b

### DIFF
--- a/patch/kernel/rockchip-rk3588-edge/overlay/Makefile
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/Makefile
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0
 dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
+	rockchip-rk3588-sata1.dtbo \
 	rockchip-rk3588-sata2.dtbo
 
 targets += $(dtbo-y)

--- a/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-sata1.dts
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-sata1.dts
@@ -1,0 +1,20 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&pcie2x1l0>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target = <&sata1>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};


### PR DESCRIPTION
# Description

duplicated existing SATA2 overlay for SATA1 used on Rock5b and probably others.

I know in the legacy kernel [the equivalent patch ](https://github.com/armbian/linux-rockchip/blame/rk-5.10-rkr6/arch/arm64/boot/dts/rockchip/overlay/rock-5b-sata.dts)is board specific, but will stay generic for now.. plus I didn't see where to disable wifi or BT interrupts in current device tree.

working with port multiplier

```
root@rock-5b:~# uname -a
Linux rock-5b 6.7.0-rc8-edge-rockchip-rk3588 #4 SMP PREEMPT Sun Dec 31 20:51:25 UTC 2023 aarch64 GNU/Linux
root@rock-5b:~# dmesg|fgrep -i sata
[    0.890642] ahci-dwc fe220000.sata: supply ahci not found, using dummy regulator
[    0.891363] ahci-dwc fe220000.sata: supply phy not found, using dummy regulator
[    0.892281] platform fe220000.sata:sata-port@0: supply target not found, using dummy regulator
[    0.893198] ahci-dwc fe220000.sata: PMPn is limited up to 5 ports
[    0.893787] ahci-dwc fe220000.sata: forcing port_map 0x0 -> 0x1
[    0.894308] ahci-dwc fe220000.sata: masking port_map 0x1 -> 0x1
[    0.894848] ahci-dwc fe220000.sata: AHCI 0001.0300 32 slots 1 ports 6 Gbps 0x1 impl platform mode
[    0.895641] ahci-dwc fe220000.sata: flags: ncq sntf pm led clo only pmp fbs pio slum part ccc apst
[    0.897897] ata1: SATA max UDMA/133 mmio [mem 0xfe220000-0xfe220fff] port 0x100 irq 44 lpm-pol 0
[    1.368703] ata1: SATA link up 6.0 Gbps (SStatus 133 SControl 300)
[    1.376249] ahci-dwc fe220000.sata: FBS is enabled
[    1.693186] ahci-dwc fe220000.sata: FBS is disabled
[    1.851976] ahci-dwc fe220000.sata: FBS is enabled
[    1.853741] ata1.00: SATA link up 3.0 Gbps (SStatus 123 SControl 330)
[    2.167231] ahci-dwc fe220000.sata: FBS is disabled
[    2.325286] ahci-dwc fe220000.sata: FBS is enabled
[    2.326584] ata1.01: SATA link up 3.0 Gbps (SStatus 123 SControl 330)
[    2.643041] ahci-dwc fe220000.sata: FBS is disabled
[    2.801950] ahci-dwc fe220000.sata: FBS is enabled
[    2.803625] ata1.02: SATA link up 3.0 Gbps (SStatus 123 SControl 330)
[    3.119206] ahci-dwc fe220000.sata: FBS is disabled
[    3.275283] ahci-dwc fe220000.sata: FBS is enabled
[    3.276958] ata1.03: SATA link up 6.0 Gbps (SStatus 133 SControl 330)
[    3.593076] ahci-dwc fe220000.sata: FBS is disabled
[    3.751950] ahci-dwc fe220000.sata: FBS is enabled
[    3.753535] ata1.04: SATA link up 3.0 Gbps (SStatus 123 SControl 330)
```
