### PR TITLE
Keep rockchip64 family for current and edge as default

### DIFF
--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -27,11 +27,13 @@ case $BRANCH in
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.1"
+		declare -g LINUXFAMILY=rockchip64
 		declare -g LINUXCONFIG='linux-rockchip64-'$BRANCH
 		;;
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.6"
+		declare -g LINUXFAMILY=rockchip64
 		declare -g LINUXCONFIG='linux-rockchip64-'$BRANCH
 		;;
 esac

--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -27,10 +27,12 @@ case $BRANCH in
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.1"
+		declare -g LINUXCONFIG='linux-rockchip64-'$BRANCH
 		;;
 
 	edge)
 		declare -g KERNEL_MAJOR_MINOR="6.6"
+		declare -g LINUXCONFIG='linux-rockchip64-'$BRANCH
 		;;
 esac
 


### PR DESCRIPTION
# Description

Bugfix due to a bit [too aggressive cleaning](https://github.com/armbian/build/pull/6135). Re-add defs