### PR TITLE
Update symlink for bluetooth firmware on JetHub D1

### DIFF
--- a/config/sources/families/jethub.conf
+++ b/config/sources/families/jethub.conf
@@ -159,7 +159,7 @@ buildjethomecmds() {
 		# Wifi & Bluetooth
 		run_host_command_logged mkdir -pv --mode=755 "$destination/lib/firmware/" || exit_with_error "Unable to mkdir firmware"
 		run_host_command_logged mkdir -v --mode=775 "$destination/lib/firmware/brcm/" || exit_with_error "Unable to mkdir brcm"
-		run_host_command_logged ln -s "../BCM4345C0.hcd" "$destination/lib/firmware/brcm/BCM4345C0.hcd"
+		run_host_command_logged ln -s "../BCM4345C0.hcd" "$destination/lib/firmware/brcm/BCM4345C0.jethome,jethub-j100.hcd"
 		run_host_command_logged ln -s "brcmfmac43455-sdio.bin" "$destination/lib/firmware/brcm/brcmfmac43455-sdio.jethome,jethub-j100.bin"
 		run_host_command_logged ln -s "brcmfmac43455-sdio.txt" "$destination/lib/firmware/brcm/brcmfmac43455-sdio.jethome,jethub-j100.txt"
 		run_host_command_logged ln -s "brcmfmac43456-sdio.bin" "$destination/lib/firmware/brcm/brcmfmac43456-sdio.jethome,jethub-j100.bin"


### PR DESCRIPTION
# Description

Update symlink for bluetooth firmware on JetHub D1

Jira reference number [AR-2022]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] JetHub D1 build and run ok

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-2022]: https://armbian.atlassian.net/browse/AR-2022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ