### PR TITLE
bpi-r2-pro: move to the rockchip64 family and update to upstream u-boot

### DIFF
--- a/config/boards/bananapir2pro.csc
+++ b/config/boards/bananapir2pro.csc
@@ -1,13 +1,24 @@
 # Rockchip RK3568 quad core 2GB-4GB 5GBE eMMC SATA USB3 Mini PCIE M.2 key-e
 BOARD_NAME="Banana Pi R2 Pro"
-BOARDFAMILY="media"
+BOARDFAMILY="rockchip64"
 BOARD_MAINTAINER=""
-BOOTCONFIG="bpi-r2pro-rk3568_defconfig"
+BOOTCONFIG="bpi-r2-pro-rk3568_defconfig"
 KERNEL_TARGET="current,edge"
 FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
 BOOT_FDT_FILE="rockchip/rk3568-bpi-r2-pro.dtb"
+BOOTBRANCH_BOARD="tag:v2024.01"
+BOOTPATCHDIR="v2024.01"
 SRC_EXTLINUX="yes"
 SRC_CMDLINE="console=ttyS02,1500000 console=tty0"
 ASOUND_STATE="asound.state.station-p2"
 IMAGE_PARTITION_TABLE="gpt"
+
+function post_family_config___mainline_uboot() {
+	declare -g UBOOT_TARGET_MAP="ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB} BL31=$RKBIN_DIR/$BL31_BLOB spl/u-boot-spl u-boot.bin flash.bin;;idbloader.img u-boot.itb"
+}
+
+function add_host_dependencies__uboot_deps() {
+	display_alert "Adding python3-pyelftools for brute force mainline uboot" "${EXTENSION}" "info"
+	declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} python3-pyelftools"
+}

--- a/config/sources/families/media.conf
+++ b/config/sources/families/media.conf
@@ -8,7 +8,7 @@
 #
 source "${BASH_SOURCE%/*}/include/rockchip64_common.inc"
 
-if [[ $BOARD == station-p2 || $BOARD == station-m2 || $BOARD == bananapir2pro ]]; then
+if [[ $BOARD == station-p2 || $BOARD == station-m2 ]]; then
 	BOOTSOURCE='https://github.com/150balbes/u-boot-rk'
 	BOOTBRANCH='branch:rk356x'
 	BOOTPATCHDIR="u-boot-station-p2"


### PR DESCRIPTION
# Description

Migrate the Banana Pi R2 Pro from the media family to the rockchip64 family.
Also migrate to upstream u-boot which added support for this board in its latest release.

# How Has This Been Tested?

Compiled a desktop image, wrote it on an sdcard, booted and tested everything is functional on the bpi-r2-pro.

```
./compile.sh BOARD=bananapir2pro BRANCH=edge RELEASE=trixie BUILD_MINIMAL=no BUILD_DESKTOP=yes DESKTOP_ENVIRONMENT=xfce DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base DESKTOP_APPGROUPS_SELECTED=none KERNEL_CONFIGURE=no
```

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
