### PR TITLE
patch: uboot: v2023.07.02: bananapicm4: sata boot support

### DIFF
--- a/patch/u-boot/v2023.07.02/board_bananapicm4io/0003-configs-bananapi-cm4-cm4io_defconfig-sata-support.patch
+++ b/patch/u-boot/v2023.07.02/board_bananapicm4io/0003-configs-bananapi-cm4-cm4io_defconfig-sata-support.patch
@@ -1,0 +1,54 @@
+From e8a4d76bcb33bcaebfc6a3b552338eb3af47603d Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@xxxxx.com>
+Date: Tue, 9 Jan 2024 16:22:12 -0500
+Subject: [PATCH] configs: bananapi-cm4-cm4io_defconfig: sata support
+
+Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
+---
+ configs/bananapi-cm4-cm4io_defconfig | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/configs/bananapi-cm4-cm4io_defconfig b/configs/bananapi-cm4-cm4io_defconfig
+index 066c5dca4a..876e37f714 100644
+--- a/configs/bananapi-cm4-cm4io_defconfig
++++ b/configs/bananapi-cm4-cm4io_defconfig
+@@ -17,7 +17,9 @@ CONFIG_SYS_LOAD_ADDR=0x1000000
+ CONFIG_PCI=y
+ CONFIG_DEBUG_UART=y
+ CONFIG_REMAKE_ELF=y
++CONFIG_AHCI=y
+ CONFIG_OF_BOARD_SETUP=y
++CONFIG_SATA_BOOT=y
+ # CONFIG_DISPLAY_CPUINFO is not set
+ CONFIG_MISC_INIT_R=y
+ CONFIG_PCI_INIT_R=y
+@@ -28,6 +30,7 @@ CONFIG_CMD_GPIO=y
+ # CONFIG_CMD_LOADS is not set
+ CONFIG_CMD_MMC=y
+ CONFIG_CMD_PCI=y
++CONFIG_CMD_SATA=y
+ CONFIG_CMD_USB=y
+ CONFIG_CMD_USB_MASS_STORAGE=y
+ # CONFIG_CMD_SETEXPR is not set
+@@ -36,6 +39,9 @@ CONFIG_OF_CONTROL=y
+ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
+ CONFIG_ADC=y
+ CONFIG_SARADC_MESON=y
++CONFIG_SATA=y
++CONFIG_SCSI_AHCI=y
++CONFIG_AHCI_PCI=y
+ CONFIG_BUTTON=y
+ CONFIG_BUTTON_ADC=y
+ CONFIG_MMC_MESON_GX=y
+@@ -53,6 +59,8 @@ CONFIG_POWER_DOMAIN=y
+ CONFIG_MESON_EE_POWER_DOMAIN=y
+ CONFIG_DM_REGULATOR=y
+ CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_SCSI=y
++CONFIG_DM_SCSI=y
+ CONFIG_DEBUG_UART_ANNOUNCE=y
+ CONFIG_DEBUG_UART_SKIP_INIT=y
+ CONFIG_MESON_SERIAL=y
+-- 
+2.39.2
+


### PR DESCRIPTION
This does not change the current boot order and requires additional hardware.

### Hardware used in my testing:
BananaPi BPI-CM4IO Baseboard with BPI-CM4 Module

Mini PCI-E PCI Express to SATA 3.0 Dual Ports Adapter Converter Hard Drive Extension Card
https://a.co/d/0G679qW

Kingston 120GB A400 SATA 3 2.5" Internal SSD
https://a.co/d/fB2qf3r

External power supply for Hard Drive 2.5" 3.5"
https://www.ebay.com/itm/114620135743

```
bananapi: ~  $ lspci
00:00.0 PCI bridge: Synopsys, Inc. DWC_usb3 / PCIe bridge (rev 01)
01:00.0 SATA controller: ASMedia Technology Inc. ASM1062 Serial ATA Controller (rev 02)

bananapi: ~  $ sudo blkid
/dev/mmcblk1p1: LABEL="EMMC" UUID="67ea5c62-c9cb-498e-91ff-3e60d71bd1ab" BLOCK_SIZE="512" TYPE="xfs" PARTUUID="0a8751c2-01"
/dev/sda2: LABEL="ROOTFS" UUID="39d23eae-ba3a-4b28-acba-8f45ff8eed1c" BLOCK_SIZE="512" TYPE="xfs" PARTUUID="e6053ca6-02"
/dev/sda1: LABEL="BOOT" UUID="d540a625-98a8-4c73-a5a3-7a905d5bbb98" BLOCK_SIZE="4096" TYPE="ext4" PARTUUID="e6053ca6-01"
/dev/zram0: UUID="ee6d34f4-fda2-4207-8dc9-b8a4b83cd759" TYPE="swap"

bananapi: ~  $ lsblk
NAME         MAJ:MIN RM   SIZE RO TYPE MOUNTPOINTS
sda            8:0    0 111.8G  0 disk 
├─sda1         8:1    0   508M  0 part /boot
└─sda2         8:2    0 111.3G  0 part /
mmcblk1      179:0    0  14.6G  0 disk 
└─mmcblk1p1  179:1    0  14.6G  0 part 
mmcblk1boot0 179:32   0     4M  1 disk 
mmcblk1boot1 179:64   0     4M  1 disk 
zram0        253:0    0     1G  0 disk [SWAP]
```


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
