### PR TITLE
rtl8723cs: fix driver compilation on kernel 6.7

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -732,4 +732,8 @@ driver_rtl8723cs() {
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/8723cs-Port-to-6.5.patch" "applying"
 	fi
 
+	if linux-version compare "${version}" ge 6.7; then
+		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/8723cs-Port-to-6.7.patch" "applying"
+	fi
+
 }

--- a/patch/misc/wireless-rtl8723cs/8723cs-Port-to-6.7.patch
+++ b/patch/misc/wireless-rtl8723cs/8723cs-Port-to-6.7.patch
@@ -1,0 +1,34 @@
+From 62ad3a8e79901b90be578d11e0aee8c5e1bd72bc Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Thu, 11 Jan 2024 20:13:20 +0100
+Subject: [PATCH] rtl8723cs: fix for kernel 6.7
+
+---
+ drivers/staging/rtl8723cs/os_dep/linux/ioctl_cfg80211.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/staging/rtl8723cs/os_dep/linux/ioctl_cfg80211.c b/drivers/staging/rtl8723cs/os_dep/linux/ioctl_cfg80211.c
+index 130e1a66886a..ba9816460f5a 100644
+--- a/drivers/staging/rtl8723cs/os_dep/linux/ioctl_cfg80211.c
++++ b/drivers/staging/rtl8723cs/os_dep/linux/ioctl_cfg80211.c
+@@ -5320,14 +5320,15 @@ static int cfg80211_rtw_start_ap(struct wiphy *wiphy, struct net_device *ndev,
+ }
+ 
+ static int cfg80211_rtw_change_beacon(struct wiphy *wiphy, struct net_device *ndev,
+-		struct cfg80211_beacon_data *info)
++		struct cfg80211_ap_update *info)
+ {
+ 	int ret = 0;
++	struct cfg80211_beacon_data *beacon = &info->beacon;
+ 	_adapter *adapter = (_adapter *)rtw_netdev_priv(ndev);
+ 
+ 	RTW_INFO(FUNC_NDEV_FMT"\n", FUNC_NDEV_ARG(ndev));
+ 
+-	ret = rtw_add_beacon(adapter, info->head, info->head_len, info->tail, info->tail_len);
++	ret = rtw_add_beacon(adapter, beacon->head, beacon->head_len, beacon->tail, beacon->tail_len);
+ 
+ 	return ret;
+ }
+-- 
+2.34.1
+


### PR DESCRIPTION
# Description

rtl8723cs driver need some little changes to compile on kernel 6.7; it was breaking rockchip and allwinner families
This pull request contains those changes.

Jira reference number [AR-2025]

# How Has This Been Tested?

- [x] Patch applies correclty on kernel 6.7
- [x] Kernel deb packages correctly built 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-2025]: https://armbian.atlassian.net/browse/AR-2025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ