### PR TITLE
Re-enable resolv.conf during deboostrap process 

### DIFF
--- a/lib/functions/rootfs/rootfs-create.sh
+++ b/lib/functions/rootfs/rootfs-create.sh
@@ -178,6 +178,10 @@ function create_new_rootfs_cache_via_debootstrap() {
 	# Now do the install, all packages should have been downloaded by now
 	chroot_sdcard_apt_get_install "${AGGREGATED_PACKAGES_ROOTFS[@]}"
 
+	# Systemd resolver is not working yet
+	run_host_command_logged rm -v "${SDCARD}"/etc/resolv.conf
+	run_host_command_logged echo "nameserver $NAMESERVER" ">" "${SDCARD}"/etc/resolv.conf
+
 	if [[ $BUILD_DESKTOP == "yes" ]]; then
 		# how how many items in AGGREGATED_PACKAGES_DESKTOP array
 		display_alert "Installing ${#AGGREGATED_PACKAGES_DESKTOP[@]} desktop packages" "${RELEASE} ${DESKTOP_ENVIRONMENT}" "info"


### PR DESCRIPTION
# Description

After introducing systemd-resolved many rootfs variants were unable to build. It seems its related to desktop variants / network manager install. Network manager seems to break DNS, so re-enabling a hack later in the process resolves it.

Jira reference number [AR-1657]

# How Has This Been Tested?

- [x] Generated and boot Odroid M1 Gnome desktop image

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings

[AR-1657]: https://armbian.atlassian.net/browse/AR-1657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ