### PR TITLE
artifact-uboot.sh: add a fake variable to hash, so all u-boots are rebuilt

### DIFF
--- a/lib/functions/artifacts/artifact-uboot.sh
+++ b/lib/functions/artifacts/artifact-uboot.sh
@@ -92,6 +92,7 @@ function artifact_uboot_prepare_version() {
 
 	# Hash variables that affect the build and package of u-boot
 	declare -a vars_to_hash=(
+		"BASE_VAR_REBUILD_2"                                      # Change this to force a full rebuild of all uboot's
 		"${BOOTDELAY}" "${UBOOT_DEBUGGING}" "${UBOOT_TARGET_MAP}" # general for all families
 		"${BOOT_SCENARIO}" "${BOOT_SUPPORT_SPI}" "${BOOT_SOC}"    # rockchip stuff, sorry.
 		"${DDR_BLOB}" "${BL31_BLOB}" "${MINILOADER_BLOB}"         # More rockchip stuff, even more sorry.


### PR DESCRIPTION
#### artifact-uboot.sh: add a fake variable to hash, so all u-boots are rebuilt

- artifact-uboot.sh: add a fake variable to hash, so all u-boots are rebuilt