### PR TITLE
Helios64: Update armbian-hardware-optimization (it's rockchip64, not rk3399 anymore)

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
+++ b/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
@@ -213,6 +213,18 @@ prepare_board() {
 			for i in $(awk -F":" "/xhci/ {print \$1}" < /proc/interrupts | sed 's/\ //g'); do
 				echo 4 > /proc/irq/$i/smp_affinity
 			done
+			case ${BOARD_NAME} in
+				"Helios64")
+					for i in $(awk -F":" "/xhci/ {print \$1}" < /proc/interrupts | sed 's/\ //g'); do
+						echo 10 > /proc/irq/$i/smp_affinity
+					done
+					for i in $(awk -F":" "/ahci/ {print \$1}" < /proc/interrupts | sed 's/\ //g'); do
+						echo 30 > /proc/irq/$i/smp_affinity
+					done
+					;;
+				*)
+					;;
+			esac
 
 			# Wait (up to 5s) until eth0 brought up
 			for i in {1..5}; do
@@ -260,14 +272,6 @@ prepare_board() {
 				echo performance > /sys/bus/platform/drivers/rockchip-dmc/dmc/devfreq/dmc/governor
 			fi
 			case ${BOARD_NAME} in
-				"Helios64")
-					for i in $(awk -F":" "/xhci/ {print \$1}" < /proc/interrupts | sed 's/\ //g'); do
-						echo 10 > /proc/irq/$i/smp_affinity
-					done
-					for i in $(awk -F":" "/ahci/ {print \$1}" < /proc/interrupts | sed 's/\ //g'); do
-						echo 30 > /proc/irq/$i/smp_affinity
-					done
-					;;
 				"Pinebook Pro")
 					echo s2idle > /sys/power/mem_sleep
 					;;

--- a/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
+++ b/packages/bsp/common/usr/lib/armbian/armbian-hardware-optimization
@@ -213,6 +213,8 @@ prepare_board() {
 			for i in $(awk -F":" "/xhci/ {print \$1}" < /proc/interrupts | sed 's/\ //g'); do
 				echo 4 > /proc/irq/$i/smp_affinity
 			done
+			# Most boards get eth0 as main ethernet interface name, but Helios64 doesn't, see below
+			_rockchip64_ethernet_interface_name=eth0
 			case ${BOARD_NAME} in
 				"Helios64")
 					for i in $(awk -F":" "/xhci/ {print \$1}" < /proc/interrupts | sed 's/\ //g'); do
@@ -221,21 +223,23 @@ prepare_board() {
 					for i in $(awk -F":" "/ahci/ {print \$1}" < /proc/interrupts | sed 's/\ //g'); do
 						echo 30 > /proc/irq/$i/smp_affinity
 					done
+					_rockchip64_ethernet_interface_name=end0
 					;;
 				*)
 					;;
 			esac
 
-			# Wait (up to 5s) until eth0 brought up
+
+			# Wait (up to 5s) until eth0/end0 brought up
 			for i in {1..5}; do
-				grep -q "eth0" /proc/interrupts && break
+				grep -q "$_rockchip64_ethernet_interface_name" /proc/interrupts && break
 				sleep 1
 			done
 
-			echo 8 > /proc/irq/$(awk -F":" "/eth0/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity
-			echo 7 > /sys/class/net/eth0/queues/rx-0/rps_cpus
+			echo 8 > /proc/irq/$(awk -F":" "/${_rockchip64_ethernet_interface_name}/ {print \$1}" < /proc/interrupts | sed 's/\ //g')/smp_affinity
+			echo 7 > /sys/class/net/${_rockchip64_ethernet_interface_name}/queues/rx-0/rps_cpus
 			echo 32768 > /proc/sys/net/core/rps_sock_flow_entries
-			echo 32768 > /sys/class/net/eth0/queues/rx-0/rps_flow_cnt
+			echo 32768 > /sys/class/net/${_rockchip64_ethernet_interface_name}/queues/rx-0/rps_flow_cnt
 			;;
 		rk3399)
 			for i in $(awk -F':' '/gpu/{print $1}' < /proc/interrupts | sed 's/\ //g'); do


### PR DESCRIPTION
See the discussion in https://forum.armbian.com/topic/30074-helios64-armbian-2308-bookworm-issues-solved/page/3/#comment-179040

# Description

The Helios64-specific changes get moved to rockchip64, as https://github.com/armbian/build/blob/main/config/boards/helios64.csc#L3 says that it's not rk3399 anymore.

# How Has This Been Tested?

See discussion in https://forum.armbian.com/topic/30074-helios64-armbian-2308-bookworm-issues-solved

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
