### PR TITLE
khadas-vim3: bump to u-boot v2024.01; boot-usb-first patch in board folder

### DIFF
--- a/config/boards/khadas-vim3.conf
+++ b/config/boards/khadas-vim3.conf
@@ -11,8 +11,8 @@ BOOT_LOGO="desktop"
 BOOT_FDT_FILE="amlogic/meson-g12b-a311d-khadas-vim3.dtb" # there is also a s922x dtb, but vim3 is a311d only
 ASOUND_STATE="asound.state.khadas-vim3"
 
-BOOTBRANCH_BOARD="tag:v2023.10"
-BOOTPATCHDIR="v2023.10" # this has 'board_khadas-vim3' which has a patch to boot USB/NVMe/SCSI first
+BOOTBRANCH_BOARD="tag:v2024.01"
+BOOTPATCHDIR="v2024.01" # this has 'board_khadas-vim3' which has a patch to boot USB/NVMe/SCSI first
 
 declare -g KHADAS_OOWOW_BOARD_ID="VIM3" # for use with EXT=output-image-oowow
 

--- a/patch/u-boot/v2024.01/board_khadas-vim3/meson64-boot-usb-nvme-scsi-first.patch
+++ b/patch/u-boot/v2024.01/board_khadas-vim3/meson64-boot-usb-nvme-scsi-first.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ricardo Pardini <ricardo@pardini.net>
+Date: Sun, 14 Jan 2024 13:44:58 +0100
+Subject: meson64: change `BOOT_TARGET_DEVICES` to try to boot USB, NVME and
+ SCSI before SD, MMC, PXE, DHCP
+
+---
+ include/configs/meson64.h | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/include/configs/meson64.h b/include/configs/meson64.h
+index efab9a624dc..32c25098e67 100644
+--- a/include/configs/meson64.h
++++ b/include/configs/meson64.h
+@@ -99,12 +99,12 @@
+ #define BOOT_TARGET_DEVICES(func) \
+ 	func(ROMUSB, romusb, na)  \
+ 	func(USB_DFU, usbdfu, na)  \
+-	func(MMC, mmc, 0) \
+-	func(MMC, mmc, 1) \
+-	func(MMC, mmc, 2) \
+ 	BOOT_TARGET_DEVICES_USB(func) \
+ 	BOOT_TARGET_NVME(func) \
+ 	BOOT_TARGET_SCSI(func) \
++	func(MMC, mmc, 0) \
++	func(MMC, mmc, 1) \
++	func(MMC, mmc, 2) \
+ 	func(PXE, pxe, na) \
+ 	func(DHCP, dhcp, na)
+ #endif
+-- 
+Armbian
+


### PR DESCRIPTION
#### khadas-vim3: bump to u-boot v2024.01; boot-usb-first patch in board folder

- khadas-vim3: bump to u-boot v2024.01; boot-usb-first patch in board folder
  - patch is slightly different for 2024.01