### PR TITLE
`Automatic` board configs status synchronise

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -96,7 +96,7 @@ config/boards/rock-5b.conf		@amazingfate @linhz0hz
 config/boards/rock64.csc		@clee
 config/boards/rockpi-4a.conf		@clee
 config/boards/rockpi-e.conf		@krachlatte
-config/boards/rockpi-s.csc		@brentr
+config/boards/rockpi-s.conf		@brentr
 config/boards/rockpro64.conf		@joekhoobyar
 config/boards/rpi4b.conf		@PanderMusubi @teknoid @viraniac
 config/boards/rpi5b.conf		@viraniac


### PR DESCRIPTION
Update maintainers and board status

- synced status from the database
- rename to .`csc` where we don't have anyone

If you want to become a board maintainer, [adjust data here](https://www.armbian.com/update-data/).

Ref: [Board Maintainers Procedures and Guidelines](https://docs.armbian.com/Board_Maintainers_Procedures_and_Guidelines/)