### PR TITLE
meson64: overlays: `additions and modifications`

### DIFF
--- a/patch/kernel/archive/meson64-6.6/overlay/Makefile
+++ b/patch/kernel/archive/meson64-6.6/overlay/Makefile
@@ -7,6 +7,7 @@ dtbo-$(CONFIG_ARCH_MESON) += \
 	meson-w1-gpio.dtbo \
 	meson-w1AB-gpio.dtbo \
 	meson-g12-gxl-cma-pool-896MB.dtbo \
+	meson-g12-pwm-gpiox-5-fan.dtbo \
 	meson-g12a-radxa-zero-gpio-8-led.dtbo \
 	meson-g12a-radxa-zero-gpio-10-led.dtbo \
 	meson-g12a-radxa-zero-i2c-ao-m0-gpioao-2-gpioao-3.dtbo \
@@ -20,6 +21,7 @@ dtbo-$(CONFIG_ARCH_MESON) += \
 	meson-g12a-radxa-zero-uart-ao-b-on-gpioao-2-gpioao-3.dtbo \
 	meson-g12a-radxa-zero-uart-ao-b-on-gpioao-8-gpioao-9.dtbo \
 	meson-g12a-radxa-zero-uart-ee-c.dtbo \
+	meson-g12b-bananapi-cm4-pwm-gpioh-5-fan.dtbo \
 	meson-g12b-bananapi-m2s-rtl8822cs.dtbo \
 	meson-g12b-odroid-n2-spi.dtbo \
 	meson-g12b-waveshare-cm4-io-base-usb.dtbo \

--- a/patch/kernel/archive/meson64-6.6/overlay/meson-g12-pwm-gpiox-5-fan.dts
+++ b/patch/kernel/archive/meson64-6.6/overlay/meson-g12-pwm-gpiox-5-fan.dts
@@ -1,0 +1,43 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/gpio/meson-g12a-gpio.h>
+#include <dt-bindings/thermal/thermal.h>
+
+/ {
+	compatible = "amlogic,a311d", "amlogic,g12a", "amlogic,g12b", "amlogic,sm1";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			fan: gpio-fan {
+				compatible = "gpio-fan";
+				gpios = <&gpio GPIOX_5 GPIO_ACTIVE_HIGH>;
+				gpio-fan,speed-map = <0 0>, <5000 1>;
+				#cooling-cells = <2>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&cpu_thermal>;
+		polling-delay = <2000>;
+		__overlay__ {
+			trips {
+				cpu_active: cpu-active {
+					temperature = <55000>;
+					hysteresis = <10000>;
+					type = "active";
+				};
+			};
+
+			cooling-maps {
+				map {
+					trip = <&cpu_active>;
+					cooling-device = <&fan THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+				};
+			};
+		};
+	};
+};

--- a/patch/kernel/archive/meson64-6.6/overlay/meson-g12b-bananapi-cm4-pwm-gpioh-5-fan.dts
+++ b/patch/kernel/archive/meson64-6.6/overlay/meson-g12b-bananapi-cm4-pwm-gpioh-5-fan.dts
@@ -1,0 +1,63 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/gpio/meson-g12a-gpio.h>
+#include <dt-bindings/thermal/thermal.h>
+
+/ {
+	compatible = "bananapi,bpi-cm4io", "bananapi,bpi-cm4", "amlogic,a311d", "amlogic,g12b";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			fan: gpio-fan {
+				compatible = "gpio-fan";
+				gpios = <&gpio GPIOH_5 GPIO_ACTIVE_HIGH>;
+				gpio-fan,speed-map = <0 0>, <5000 1>;
+				#cooling-cells = <2>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&cpu_thermal>;
+		polling-delay = <2000>;
+		__overlay__ {
+			trips {
+				cpu_active: cpu-active {
+					temperature = <55000>;
+					hysteresis = <10000>;
+					type = "active";
+				};
+			};
+
+			cooling-maps {
+				map {
+					trip = <&cpu_active>;
+					cooling-device = <&fan THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+				};
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&ddr_thermal>;
+		__overlay__ {
+			trips {
+				ddr_active: ddr-active {
+					temperature = <55000>;
+					hysteresis = <10000>;
+					type = "active";
+				};
+			};
+
+			cooling-maps {
+				map {
+					trip = <&ddr_active>;
+					cooling-device = <&fan THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+				};
+			};
+		};
+	};
+};

--- a/patch/kernel/archive/meson64-6.6/overlay/meson-g12b-bananapi-m2s-rtl8822cs.dts
+++ b/patch/kernel/archive/meson64-6.6/overlay/meson-g12b-bananapi-m2s-rtl8822cs.dts
@@ -2,8 +2,7 @@
 /plugin/;
 
 / {
-	/* Banana Pi M2S/M5 */
-	compatible = "bananapi,bpi-m2s", "bananapi,bpi-m5";
+	compatible = "bananapi,bpi-m2s", "amlogic,a311d", "amlogic,g12b";
 
 	/* RTL8822CS SDIO WIFI */
 	fragment@0 {

--- a/patch/kernel/archive/meson64-6.6/overlay/meson-sm1-bananapi-m5-rtl8822cs.dts
+++ b/patch/kernel/archive/meson64-6.6/overlay/meson-sm1-bananapi-m5-rtl8822cs.dts
@@ -2,8 +2,7 @@
 /plugin/;
 
 / {
-	/* Banana Pi M2S/M5 */
-	compatible = "bananapi,bpi-m2s", "bananapi,bpi-m5";
+	compatible = "bananapi,bpi-m5", "amlogic,sm1";
 
 	/* RTL8822CS SDIO WIFI */
 	fragment@0 {

--- a/patch/kernel/archive/meson64-6.7/overlay/Makefile
+++ b/patch/kernel/archive/meson64-6.7/overlay/Makefile
@@ -7,6 +7,7 @@ dtbo-$(CONFIG_ARCH_MESON) += \
 	meson-w1-gpio.dtbo \
 	meson-w1AB-gpio.dtbo \
 	meson-g12-gxl-cma-pool-896MB.dtbo \
+	meson-g12-pwm-gpiox-5-fan.dtbo \
 	meson-g12a-radxa-zero-gpio-8-led.dtbo \
 	meson-g12a-radxa-zero-gpio-10-led.dtbo \
 	meson-g12a-radxa-zero-i2c-ao-m0-gpioao-2-gpioao-3.dtbo \
@@ -20,6 +21,7 @@ dtbo-$(CONFIG_ARCH_MESON) += \
 	meson-g12a-radxa-zero-uart-ao-b-on-gpioao-2-gpioao-3.dtbo \
 	meson-g12a-radxa-zero-uart-ao-b-on-gpioao-8-gpioao-9.dtbo \
 	meson-g12a-radxa-zero-uart-ee-c.dtbo \
+	meson-g12b-bananapi-cm4-pwm-gpioh-5-fan.dtbo \
 	meson-g12b-bananapi-m2s-rtl8822cs.dtbo \
 	meson-g12b-odroid-n2-spi.dtbo \
 	meson-g12b-waveshare-cm4-io-base-usb.dtbo \

--- a/patch/kernel/archive/meson64-6.7/overlay/meson-g12-pwm-gpiox-5-fan.dts
+++ b/patch/kernel/archive/meson64-6.7/overlay/meson-g12-pwm-gpiox-5-fan.dts
@@ -1,0 +1,43 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/gpio/meson-g12a-gpio.h>
+#include <dt-bindings/thermal/thermal.h>
+
+/ {
+	compatible = "amlogic,a311d", "amlogic,g12a", "amlogic,g12b", "amlogic,sm1";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			fan: gpio-fan {
+				compatible = "gpio-fan";
+				gpios = <&gpio GPIOX_5 GPIO_ACTIVE_HIGH>;
+				gpio-fan,speed-map = <0 0>, <5000 1>;
+				#cooling-cells = <2>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&cpu_thermal>;
+		polling-delay = <2000>;
+		__overlay__ {
+			trips {
+				cpu_active: cpu-active {
+					temperature = <55000>;
+					hysteresis = <10000>;
+					type = "active";
+				};
+			};
+
+			cooling-maps {
+				map {
+					trip = <&cpu_active>;
+					cooling-device = <&fan THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+				};
+			};
+		};
+	};
+};

--- a/patch/kernel/archive/meson64-6.7/overlay/meson-g12b-bananapi-cm4-pwm-gpioh-5-fan.dts
+++ b/patch/kernel/archive/meson64-6.7/overlay/meson-g12b-bananapi-cm4-pwm-gpioh-5-fan.dts
@@ -1,0 +1,63 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/gpio/meson-g12a-gpio.h>
+#include <dt-bindings/thermal/thermal.h>
+
+/ {
+	compatible = "bananapi,bpi-cm4io", "bananapi,bpi-cm4", "amlogic,a311d", "amlogic,g12b";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			fan: gpio-fan {
+				compatible = "gpio-fan";
+				gpios = <&gpio GPIOH_5 GPIO_ACTIVE_HIGH>;
+				gpio-fan,speed-map = <0 0>, <5000 1>;
+				#cooling-cells = <2>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&cpu_thermal>;
+		polling-delay = <2000>;
+		__overlay__ {
+			trips {
+				cpu_active: cpu-active {
+					temperature = <55000>;
+					hysteresis = <10000>;
+					type = "active";
+				};
+			};
+
+			cooling-maps {
+				map {
+					trip = <&cpu_active>;
+					cooling-device = <&fan THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+				};
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&ddr_thermal>;
+		__overlay__ {
+			trips {
+				ddr_active: ddr-active {
+					temperature = <55000>;
+					hysteresis = <10000>;
+					type = "active";
+				};
+			};
+
+			cooling-maps {
+				map {
+					trip = <&ddr_active>;
+					cooling-device = <&fan THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+				};
+			};
+		};
+	};
+};

--- a/patch/kernel/archive/meson64-6.7/overlay/meson-g12b-bananapi-m2s-rtl8822cs.dts
+++ b/patch/kernel/archive/meson64-6.7/overlay/meson-g12b-bananapi-m2s-rtl8822cs.dts
@@ -2,8 +2,7 @@
 /plugin/;
 
 / {
-	/* Banana Pi M2S/M5 */
-	compatible = "bananapi,bpi-m2s", "bananapi,bpi-m5";
+	compatible = "bananapi,bpi-m2s", "amlogic,a311d", "amlogic,g12b";
 
 	/* RTL8822CS SDIO WIFI */
 	fragment@0 {

--- a/patch/kernel/archive/meson64-6.7/overlay/meson-sm1-bananapi-m5-rtl8822cs.dts
+++ b/patch/kernel/archive/meson64-6.7/overlay/meson-sm1-bananapi-m5-rtl8822cs.dts
@@ -2,8 +2,7 @@
 /plugin/;
 
 / {
-	/* Banana Pi M2S/M5 */
-	compatible = "bananapi,bpi-m2s", "bananapi,bpi-m5";
+	compatible = "bananapi,bpi-m5", "amlogic,sm1";
 
 	/* RTL8822CS SDIO WIFI */
 	fragment@0 {


### PR DESCRIPTION
PWM controllable fan (G12A/B/SM1)

Commit provides two new overlays. One for the BananaPi CM4IO Baseboard "GPIOH_5" and another for general use "GPIOX_5".

CM4IO HEADER PINS: 5V "4"; GND "6"; PWM "7"

On other units the location of the PWM HEADER PIN may vary, so users will need to either review the wiki or schematic of said unit.

Fan used in testing:
https://a.co/d/hasnLtj

Modifications: M2S/M5 RTL8822CS
Modded the overlays to be specific to the unit they were made to be used on.

Tested-on: BananaPi BPI-CM4IO Baseboard with BPI-CM4 Module

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
