### PR TITLE
fix gitee mirror

### DIFF
--- a/lib/functions/general/git-ref2info.sh
+++ b/lib/functions/general/git-ref2info.sh
@@ -99,6 +99,14 @@ function memoized_git_ref_to_info() {
 					url="https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/plain/Makefile?h=${sha1}"
 					;;
 
+				"https://gitee.com/"*)
+					# parse org/repo from https://gitee.com/org/repo
+					declare org_and_repo=""
+					org_and_repo="$(echo "${git_source}" | cut -d/ -f4-5)"
+					org_and_repo="${org_and_repo%.git}" # remove .git if present
+					url="https://gitee.com/${org_and_repo}/raw/${sha1}/Makefile"
+					;;
+
 				"https://github.com/"*)
 					# parse org/repo from https://github.com/org/repo
 					declare org_and_repo=""


### PR DESCRIPTION
# Description

We have an arg `UBOOT_MIRROR` and it can be set to `gitee` to use mirror `https://gitee.com/mirrors/u-boot.git`. We have to fix Makefile url for it.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] `PREFER_DOCKER=no ./compile.sh uboot BOARD=fl700n BRANCH=edge UBOOT_MIRROR=gitee`. fl700n is a board using uboot config `firefly-rk3288_defconfig` I am playing these days.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
