### PR TITLE
Radxa Zero: u-boot-v2023.07.02: `eMMC boot fixup`

### DIFF
--- a/patch/u-boot/v2023.07.02/board_radxa-zero/002-configs-radxa-zero_defconfig-enable-preboot.patch
+++ b/patch/u-boot/v2023.07.02/board_radxa-zero/002-configs-radxa-zero_defconfig-enable-preboot.patch
@@ -1,0 +1,27 @@
+From aaf00ce5ed077cc36a089bce62a2dac2281ce728 Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@xxxxx.com>
+Date: Sat, 20 Jan 2024 05:39:52 -0500
+Subject: [PATCH] configs: radxa-zero_defconfig: enable preboot
+
+CONFIG_USE_PREBOOT=y
+
+Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
+---
+ configs/radxa-zero_defconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/configs/radxa-zero_defconfig b/configs/radxa-zero_defconfig
+index 23f30f6b11..b3392825b7 100644
+--- a/configs/radxa-zero_defconfig
++++ b/configs/radxa-zero_defconfig
+@@ -17,6 +17,7 @@ CONFIG_SYS_LOAD_ADDR=0x1000000
+ CONFIG_DEBUG_UART=y
+ CONFIG_REMAKE_ELF=y
+ CONFIG_OF_BOARD_SETUP=y
++CONFIG_USE_PREBOOT=y
+ # CONFIG_DISPLAY_CPUINFO is not set
+ CONFIG_MISC_INIT_R=y
+ CONFIG_SYS_MAXARGS=32
+-- 
+2.39.2
+


### PR DESCRIPTION
In my initial commit I assumed CONFIG_USE_PREBOOT=y was enabled by default. I was wrong.

As reported by MicroLinux (Salva) on DISCORD the unit was still having issues booting. I sent him a patch I use which enables preboot and he reported back that "It boots fine now".

NOTES: The patch he tested also had boot logo support enabled. In my testing boot logo support is not required. If for some reason in the future there are still eMMC boot issues, than maybe adding a slight delay "sleep 2" to preboot would suffice.

https://github.com/armbian/build/pull/5858

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
