### PR TITLE
rockchip64-edge: update rk35xx crypto patch

### DIFF
--- a/patch/kernel/archive/rockchip64-6.7/rk35xx-montjoie-crypto-v2-rk35xx.patch
+++ b/patch/kernel/archive/rockchip64-6.7/rk35xx-montjoie-crypto-v2-rk35xx.patch
@@ -1,22 +1,22 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Corentin Labbe <clabbe.montjoie@gmail.com>
-Date: Sun, 25 Sep 2022 16:08:17 +0200
+From: Corentin Labbe <clabbe@baylibre.com>
+Date: Tue, 7 Nov 2023 15:55:27 +0000
 Subject: dt-bindings: crypto: add support for rockchip,crypto-rk3588
 
 Add device tree binding documentation for the Rockchip cryptographic
 offloader V2.
 
-Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>
+Signed-off-by: Corentin Labbe <clabbe@baylibre.com>
 ---
- Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml | 77 ++++++++++
- 1 file changed, 77 insertions(+)
+ Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml | 65 ++++++++++
+ 1 file changed, 65 insertions(+)
 
 diff --git a/Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml b/Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml
 new file mode 100644
-index 000000000000..fbe1e1b33dab
+index 000000000000..c01963413260
 --- /dev/null
 +++ b/Documentation/devicetree/bindings/crypto/rockchip,rk3588-crypto.yaml
-@@ -0,0 +1,77 @@
+@@ -0,0 +1,65 @@
 +# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
 +%YAML 1.2
 +---
@@ -41,11 +41,13 @@ index 000000000000..fbe1e1b33dab
 +    maxItems: 1
 +
 +  clocks:
-+    minItems: 1
++    minItems: 3
 +
 +  clock-names:
 +    items:
 +      - const: core
++      - const: a
++      - const: h
 +
 +  resets:
 +    minItems: 1
@@ -74,47 +76,33 @@ index 000000000000..fbe1e1b33dab
 +      compatible = "rockchip,rk3588-crypto";
 +      reg = <0xfe370000 0x4000>;
 +      interrupts = <GIC_SPI 209 IRQ_TYPE_LEVEL_HIGH 0>;
-+      clocks = <&scmi_clk SCMI_CRYPTO_CORE>;
-+      clock-names = "core";
++      clocks = <&scmi_clk SCMI_CRYPTO_CORE>, <&scmi_clk SCMI_ACLK_SECURE_NS>,
++               <&scmi_clk SCMI_HCLK_SECURE_NS>;
++      clock-names = "core", "a", "h";
 +      resets = <&scmi_reset SRST_CRYPTO_CORE>;
 +      reset-names = "core";
-+    };
-+  - |
-+    #include <dt-bindings/interrupt-controller/arm-gic.h>
-+    #include <dt-bindings/clock/rockchip,rk3568-cru.h>
-+    #include <dt-bindings/reset/rockchip,rk3568-cru.h>
-+    crypto@fe380000 {
-+      compatible = "rockchip,rk3568-crypto";
-+      reg = <0xfe380000 0x4000>;
-+      interrupts = <GIC_SPI 4 IRQ_TYPE_LEVEL_HIGH>;
-+      clocks = <&cru ACLK_CRYPTO_NS>, <&cru HCLK_CRYPTO_NS>,
-+               <&cru CLK_CRYPTO_NS_CORE>;
-+      clock-names = "aclk", "hclk", "core";
-+      resets = <&cru SRST_CRYPTO_NS_CORE>, <&cru SRST_A_CRYPTO_NS>,
-+               <&cru SRST_H_CRYPTO_NS>;
-+      reset-names = "core", "a", "h";
 +    };
 -- 
 Armbian
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Corentin Labbe <clabbe.montjoie@gmail.com>
-Date: Wed, 20 Sep 2023 16:04:18 +0200
+From: Corentin Labbe <clabbe@baylibre.com>
+Date: Tue, 7 Nov 2023 15:55:29 +0000
 Subject: ARM64: dts: rk3588: add crypto node
 
 The rk3588 has a crypto IP handled by the rk3588 crypto driver so adds a
 node for it.
 
-Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>
+Signed-off-by: Corentin Labbe <clabbe@baylibre.com>
 ---
  arch/arm64/boot/dts/rockchip/rk3588s.dtsi | 12 ++++++++++
  1 file changed, 12 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588s.dtsi b/arch/arm64/boot/dts/rockchip/rk3588s.dtsi
-index 5544f66c6ff4..ffffe084a966 100644
+index 75e279781cf6..ca2078f72801 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s.dtsi
-@@ -1475,6 +1475,18 @@ sdhci: mmc@fe2e0000 {
+@@ -2038,6 +2038,18 @@ sdhci: mmc@fe2e0000 {
  		status = "disabled";
  	};
  
@@ -137,24 +125,24 @@ index 5544f66c6ff4..ffffe084a966 100644
 Armbian
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Corentin Labbe <clabbe.montjoie@gmail.com>
-Date: Thu, 22 Sep 2022 19:38:13 +0200
+From: Corentin Labbe <clabbe@baylibre.com>
+Date: Tue, 7 Nov 2023 15:55:30 +0000
 Subject: ARM64: dts: rk356x: add crypto node
 
 Both RK3566 and RK3568 have a crypto IP handled by the rk3588 crypto driver so adds a
 node for it.
 
 Tested-by: Ricardo Pardini <ricardo@pardini.net>
-Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>
+Signed-off-by: Corentin Labbe <clabbe@baylibre.com>
 ---
  arch/arm64/boot/dts/rockchip/rk356x.dtsi | 12 ++++++++++
  1 file changed, 12 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk356x.dtsi b/arch/arm64/boot/dts/rockchip/rk356x.dtsi
-index abee88911982..b9cbab2246e2 100644
+index c19c0f1b3778..d2764659d21b 100644
 --- a/arch/arm64/boot/dts/rockchip/rk356x.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk356x.dtsi
-@@ -1063,6 +1063,18 @@ sdhci: mmc@fe310000 {
+@@ -1070,6 +1070,18 @@ sdhci: mmc@fe310000 {
  		status = "disabled";
  	};
  
@@ -177,8 +165,8 @@ index abee88911982..b9cbab2246e2 100644
 Armbian
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Corentin Labbe <clabbe.montjoie@gmail.com>
-Date: Wed, 20 Sep 2023 16:06:43 +0200
+From: Corentin Labbe <clabbe@baylibre.com>
+Date: Tue, 7 Nov 2023 15:55:31 +0000
 Subject: reset: rockchip: secure reset must be used by SCMI
 
 While working on the rk3588 crypto driver, I loose lot of time
@@ -187,7 +175,7 @@ This is due to RK3588_SECURECRU_RESET_OFFSET being in the secure world,
 so impossible to operate on it from the kernel.
 All resets in this block must be handled via SCMI call.
 
-Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>
+Signed-off-by: Corentin Labbe <clabbe@baylibre.com>
 ---
  drivers/clk/rockchip/rst-rk3588.c               | 42 ------
  include/dt-bindings/reset/rockchip,rk3588-cru.h | 68 +++++-----
@@ -335,36 +323,28 @@ index d4264db2a07f..c0d08ae78cd5 100644
 Armbian
 
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Corentin Labbe <clabbe.montjoie@gmail.com>
-Date: Wed, 20 Sep 2023 15:53:17 +0200
+From: Corentin Labbe <clabbe@baylibre.com>
+Date: Tue, 7 Nov 2023 15:55:32 +0000
 Subject: crypto: rockchip: add rk3588 driver
 
 RK3588 have a new crypto IP, this patch adds basic support for it.
 Only hashes and cipher are handled for the moment.
 
-Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>
+Signed-off-by: Corentin Labbe <clabbe@baylibre.com>
 ---
- drivers/crypto/Kconfig                           |  28 +
- drivers/crypto/rockchip/Makefile                 |   5 +
- drivers/crypto/rockchip/rk3588_crypto.c          | 745 ++++++++++
- drivers/crypto/rockchip/rk3588_crypto.h          | 246 +++
- drivers/crypto/rockchip/rk3588_crypto_ahash.c    | 344 +++++
- drivers/crypto/rockchip/rk3588_crypto_skcipher.c | 576 +++++++
- 6 files changed, 1944 insertions(+)
+ drivers/crypto/Kconfig                        |  29 +
+ drivers/crypto/rockchip/Makefile              |   5 +
+ drivers/crypto/rockchip/rk2_crypto.c          | 739 ++++++++++
+ drivers/crypto/rockchip/rk2_crypto.h          | 246 +++
+ drivers/crypto/rockchip/rk2_crypto_ahash.c    | 344 +++++
+ drivers/crypto/rockchip/rk2_crypto_skcipher.c | 576 ++++++++
+ 6 files changed, 1939 insertions(+)
 
 diff --git a/drivers/crypto/Kconfig b/drivers/crypto/Kconfig
-index c761952f0dc6..9777040be739 100644
+index 79c3bb9c99c3..b6a2027b1f9a 100644
 --- a/drivers/crypto/Kconfig
 +++ b/drivers/crypto/Kconfig
-@@ -642,6 +642,7 @@ config CRYPTO_DEV_ROCKCHIP
- 	select CRYPTO_MD5
- 	select CRYPTO_SHA1
- 	select CRYPTO_SHA256
-+	select CRYPTO_SM3
- 	select CRYPTO_HASH
- 	select CRYPTO_SKCIPHER
- 
-@@ -659,6 +660,33 @@ config CRYPTO_DEV_ROCKCHIP_DEBUG
+@@ -660,6 +660,35 @@ config CRYPTO_DEV_ROCKCHIP_DEBUG
  	  the number of requests per algorithm and other internal stats.
  
  
@@ -378,6 +358,8 @@ index c761952f0dc6..9777040be739 100644
 +	select CRYPTO_MD5
 +	select CRYPTO_SHA1
 +	select CRYPTO_SHA256
++	select CRYPTO_SHA512
++	select CRYPTO_SM3_GENERIC
 +	select CRYPTO_HASH
 +	select CRYPTO_SKCIPHER
 +	select CRYPTO_ENGINE
@@ -399,7 +381,7 @@ index c761952f0dc6..9777040be739 100644
  	tristate "Support for Xilinx ZynqMP AES hw accelerator"
  	depends on ZYNQMP_FIRMWARE || COMPILE_TEST
 diff --git a/drivers/crypto/rockchip/Makefile b/drivers/crypto/rockchip/Makefile
-index 785277aca71e..2132d8326223 100644
+index 785277aca71e..452a12ff6538 100644
 --- a/drivers/crypto/rockchip/Makefile
 +++ b/drivers/crypto/rockchip/Makefile
 @@ -3,3 +3,8 @@ obj-$(CONFIG_CRYPTO_DEV_ROCKCHIP) += rk_crypto.o
@@ -408,23 +390,23 @@ index 785277aca71e..2132d8326223 100644
  		  rk3288_crypto_ahash.o
 +
 +obj-$(CONFIG_CRYPTO_DEV_ROCKCHIP2) += rk_crypto2.o
-+rk_crypto2-objs := rk3588_crypto.o \
-+		  rk3588_crypto_skcipher.o \
-+		  rk3588_crypto_ahash.o
-diff --git a/drivers/crypto/rockchip/rk3588_crypto.c b/drivers/crypto/rockchip/rk3588_crypto.c
++rk_crypto2-objs := rk2_crypto.o \
++		  rk2_crypto_skcipher.o \
++		  rk2_crypto_ahash.o
+diff --git a/drivers/crypto/rockchip/rk2_crypto.c b/drivers/crypto/rockchip/rk2_crypto.c
 new file mode 100644
-index 000000000000..ae74847d618d
+index 000000000000..79ed697d8ec5
 --- /dev/null
-+++ b/drivers/crypto/rockchip/rk3588_crypto.c
-@@ -0,0 +1,745 @@
++++ b/drivers/crypto/rockchip/rk2_crypto.c
+@@ -0,0 +1,739 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * hardware cryptographic offloader for RK3568/RK3588 SoC
 + *
-+ * Copyright (c) 2022-2023, Corentin Labbe <clabbe.montjoie@gmail.com>
++ * Copyright (c) 2022-2023, Corentin Labbe <clabbe@baylibre.com>
 + */
 +
-+#include "rk3588_crypto.h"
++#include "rk2_crypto.h"
 +#include <linux/clk.h>
 +#include <linux/crypto.h>
 +#include <linux/dma-mapping.h>
@@ -579,7 +561,7 @@ index 000000000000..ae74847d618d
 +	return IRQ_HANDLED;
 +}
 +
-+static struct rk2_crypto_template rk2_cipher_algs[] = {
++static struct rk2_crypto_template rk2_crypto_algs[] = {
 +	{
 +		.type = CRYPTO_ALG_TYPE_SKCIPHER,
 +		.rk2_mode = RK2_CRYPTO_AES_ECB,
@@ -680,9 +662,8 @@ index 000000000000..ae74847d618d
 +					.cra_priority = 300,
 +					.cra_flags = CRYPTO_ALG_ASYNC |
 +						CRYPTO_ALG_NEED_FALLBACK,
-+					.cra_blocksize = SHA1_BLOCK_SIZE,
++					.cra_blocksize = MD5_HMAC_BLOCK_SIZE,
 +					.cra_ctxsize = sizeof(struct rk2_ahash_ctx),
-+					.cra_alignmask = 3,
 +					.cra_module = THIS_MODULE,
 +				}
 +			}
@@ -716,7 +697,6 @@ index 000000000000..ae74847d618d
 +						CRYPTO_ALG_NEED_FALLBACK,
 +					.cra_blocksize = SHA1_BLOCK_SIZE,
 +					.cra_ctxsize = sizeof(struct rk2_ahash_ctx),
-+					.cra_alignmask = 3,
 +					.cra_module = THIS_MODULE,
 +				}
 +			}
@@ -749,7 +729,6 @@ index 000000000000..ae74847d618d
 +						CRYPTO_ALG_NEED_FALLBACK,
 +					.cra_blocksize = SHA256_BLOCK_SIZE,
 +					.cra_ctxsize = sizeof(struct rk2_ahash_ctx),
-+					.cra_alignmask = 3,
 +					.cra_module = THIS_MODULE,
 +				}
 +			}
@@ -782,7 +761,6 @@ index 000000000000..ae74847d618d
 +						CRYPTO_ALG_NEED_FALLBACK,
 +					.cra_blocksize = SHA384_BLOCK_SIZE,
 +					.cra_ctxsize = sizeof(struct rk2_ahash_ctx),
-+					.cra_alignmask = 3,
 +					.cra_module = THIS_MODULE,
 +				}
 +			}
@@ -815,7 +793,6 @@ index 000000000000..ae74847d618d
 +						CRYPTO_ALG_NEED_FALLBACK,
 +					.cra_blocksize = SHA512_BLOCK_SIZE,
 +					.cra_ctxsize = sizeof(struct rk2_ahash_ctx),
-+					.cra_alignmask = 3,
 +					.cra_module = THIS_MODULE,
 +				}
 +			}
@@ -848,7 +825,6 @@ index 000000000000..ae74847d618d
 +						CRYPTO_ALG_NEED_FALLBACK,
 +					.cra_blocksize = SM3_BLOCK_SIZE,
 +					.cra_ctxsize = sizeof(struct rk2_ahash_ctx),
-+					.cra_alignmask = 3,
 +					.cra_module = THIS_MODULE,
 +				}
 +			}
@@ -873,27 +849,27 @@ index 000000000000..ae74847d618d
 +	}
 +	spin_unlock(&rocklist.lock);
 +
-+	for (i = 0; i < ARRAY_SIZE(rk2_cipher_algs); i++) {
-+		if (!rk2_cipher_algs[i].dev)
++	for (i = 0; i < ARRAY_SIZE(rk2_crypto_algs); i++) {
++		if (!rk2_crypto_algs[i].dev)
 +			continue;
-+		switch (rk2_cipher_algs[i].type) {
++		switch (rk2_crypto_algs[i].type) {
 +		case CRYPTO_ALG_TYPE_SKCIPHER:
 +			seq_printf(seq, "%s %s reqs=%lu fallback=%lu\n",
-+				   rk2_cipher_algs[i].alg.skcipher.base.base.cra_driver_name,
-+				   rk2_cipher_algs[i].alg.skcipher.base.base.cra_name,
-+				   rk2_cipher_algs[i].stat_req, rk2_cipher_algs[i].stat_fb);
++				   rk2_crypto_algs[i].alg.skcipher.base.base.cra_driver_name,
++				   rk2_crypto_algs[i].alg.skcipher.base.base.cra_name,
++				   rk2_crypto_algs[i].stat_req, rk2_crypto_algs[i].stat_fb);
 +			seq_printf(seq, "\tfallback due to length: %lu\n",
-+				   rk2_cipher_algs[i].stat_fb_len);
++				   rk2_crypto_algs[i].stat_fb_len);
 +			seq_printf(seq, "\tfallback due to alignment: %lu\n",
-+				   rk2_cipher_algs[i].stat_fb_align);
++				   rk2_crypto_algs[i].stat_fb_align);
 +			seq_printf(seq, "\tfallback due to SGs: %lu\n",
-+				   rk2_cipher_algs[i].stat_fb_sgdiff);
++				   rk2_crypto_algs[i].stat_fb_sgdiff);
 +			break;
 +		case CRYPTO_ALG_TYPE_AHASH:
 +			seq_printf(seq, "%s %s reqs=%lu fallback=%lu\n",
-+				   rk2_cipher_algs[i].alg.hash.base.halg.base.cra_driver_name,
-+				   rk2_cipher_algs[i].alg.hash.base.halg.base.cra_name,
-+				   rk2_cipher_algs[i].stat_req, rk2_cipher_algs[i].stat_fb);
++				   rk2_crypto_algs[i].alg.hash.base.halg.base.cra_driver_name,
++				   rk2_crypto_algs[i].alg.hash.base.halg.base.cra_name,
++				   rk2_crypto_algs[i].stat_req, rk2_crypto_algs[i].stat_fb);
 +			break;
 +		}
 +	}
@@ -946,7 +922,7 @@ index 000000000000..ae74847d618d
 +{
 +#ifdef CONFIG_CRYPTO_DEV_ROCKCHIP2_DEBUG
 +	/* Ignore error of debugfs */
-+	rocklist.dbgfs_dir = debugfs_create_dir("rk3588_crypto", NULL);
++	rocklist.dbgfs_dir = debugfs_create_dir("rk2_crypto", NULL);
 +	rocklist.dbgfs_stats = debugfs_create_file("stats", 0440,
 +						   rocklist.dbgfs_dir,
 +						   &rocklist,
@@ -963,20 +939,20 @@ index 000000000000..ae74847d618d
 +	unsigned int i, k;
 +	int err = 0;
 +
-+	for (i = 0; i < ARRAY_SIZE(rk2_cipher_algs); i++) {
-+		rk2_cipher_algs[i].dev = rkc;
-+		switch (rk2_cipher_algs[i].type) {
++	for (i = 0; i < ARRAY_SIZE(rk2_crypto_algs); i++) {
++		rk2_crypto_algs[i].dev = rkc;
++		switch (rk2_crypto_algs[i].type) {
 +		case CRYPTO_ALG_TYPE_SKCIPHER:
 +			dev_info(rkc->dev, "Register %s as %s\n",
-+				 rk2_cipher_algs[i].alg.skcipher.base.base.cra_name,
-+				 rk2_cipher_algs[i].alg.skcipher.base.base.cra_driver_name);
-+			err = crypto_engine_register_skcipher(&rk2_cipher_algs[i].alg.skcipher);
++				 rk2_crypto_algs[i].alg.skcipher.base.base.cra_name,
++				 rk2_crypto_algs[i].alg.skcipher.base.base.cra_driver_name);
++			err = crypto_engine_register_skcipher(&rk2_crypto_algs[i].alg.skcipher);
 +			break;
 +		case CRYPTO_ALG_TYPE_AHASH:
-+			dev_info(rkc->dev, "Register %s as %s\n",
-+				 rk2_cipher_algs[i].alg.hash.base.halg.base.cra_name,
-+				 rk2_cipher_algs[i].alg.hash.base.halg.base.cra_driver_name);
-+			err = crypto_engine_register_ahash(&rk2_cipher_algs[i].alg.hash);
++			dev_info(rkc->dev, "Register %s as %s %d\n",
++				 rk2_crypto_algs[i].alg.hash.base.halg.base.cra_name,
++				 rk2_crypto_algs[i].alg.hash.base.halg.base.cra_driver_name, i);
++			err = crypto_engine_register_ahash(&rk2_crypto_algs[i].alg.hash);
 +			break;
 +		default:
 +			dev_err(rkc->dev, "unknown algorithm\n");
@@ -988,10 +964,10 @@ index 000000000000..ae74847d618d
 +
 +err_cipher_algs:
 +	for (k = 0; k < i; k++) {
-+		if (rk2_cipher_algs[i].type == CRYPTO_ALG_TYPE_SKCIPHER)
-+			crypto_engine_unregister_skcipher(&rk2_cipher_algs[k].alg.skcipher);
++		if (rk2_crypto_algs[k].type == CRYPTO_ALG_TYPE_SKCIPHER)
++			crypto_engine_unregister_skcipher(&rk2_crypto_algs[k].alg.skcipher);
 +		else
-+			crypto_engine_unregister_ahash(&rk2_cipher_algs[i].alg.hash);
++			crypto_engine_unregister_ahash(&rk2_crypto_algs[k].alg.hash);
 +	}
 +	return err;
 +}
@@ -1000,11 +976,11 @@ index 000000000000..ae74847d618d
 +{
 +	unsigned int i;
 +
-+	for (i = 0; i < ARRAY_SIZE(rk2_cipher_algs); i++) {
-+		if (rk2_cipher_algs[i].type == CRYPTO_ALG_TYPE_SKCIPHER)
-+			crypto_engine_unregister_skcipher(&rk2_cipher_algs[i].alg.skcipher);
++	for (i = 0; i < ARRAY_SIZE(rk2_crypto_algs); i++) {
++		if (rk2_crypto_algs[i].type == CRYPTO_ALG_TYPE_SKCIPHER)
++			crypto_engine_unregister_skcipher(&rk2_crypto_algs[i].alg.skcipher);
 +		else
-+			crypto_engine_unregister_ahash(&rk2_cipher_algs[i].alg.hash);
++			crypto_engine_unregister_ahash(&rk2_crypto_algs[i].alg.hash);
 +	}
 +}
 +
@@ -1151,7 +1127,7 @@ index 000000000000..ae74847d618d
 +	.probe		= rk2_crypto_probe,
 +	.remove		= rk2_crypto_remove,
 +	.driver		= {
-+		.name	= "rk3588-crypto",
++		.name	= "rk2-crypto",
 +		.pm		= &rk2_crypto_pm_ops,
 +		.of_match_table	= crypto_of_id_table,
 +	},
@@ -1161,12 +1137,12 @@ index 000000000000..ae74847d618d
 +
 +MODULE_DESCRIPTION("Rockchip Crypto Engine cryptographic offloader");
 +MODULE_LICENSE("GPL");
-+MODULE_AUTHOR("Corentin Labbe <clabbe.montjoie@gmail.com>");
-diff --git a/drivers/crypto/rockchip/rk3588_crypto.h b/drivers/crypto/rockchip/rk3588_crypto.h
++MODULE_AUTHOR("Corentin Labbe <clabbe@baylibre.com>");
+diff --git a/drivers/crypto/rockchip/rk2_crypto.h b/drivers/crypto/rockchip/rk2_crypto.h
 new file mode 100644
 index 000000000000..59cd8be59f70
 --- /dev/null
-+++ b/drivers/crypto/rockchip/rk3588_crypto.h
++++ b/drivers/crypto/rockchip/rk2_crypto.h
 @@ -0,0 +1,246 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +
@@ -1414,11 +1390,11 @@ index 000000000000..59cd8be59f70
 +int rk2_ahash_digest(struct ahash_request *req);
 +int rk2_hash_init_tfm(struct crypto_ahash *tfm);
 +void rk2_hash_exit_tfm(struct crypto_ahash *tfm);
-diff --git a/drivers/crypto/rockchip/rk3588_crypto_ahash.c b/drivers/crypto/rockchip/rk3588_crypto_ahash.c
+diff --git a/drivers/crypto/rockchip/rk2_crypto_ahash.c b/drivers/crypto/rockchip/rk2_crypto_ahash.c
 new file mode 100644
-index 000000000000..4af1ab5a4b0d
+index 000000000000..75b8d9893447
 --- /dev/null
-+++ b/drivers/crypto/rockchip/rk3588_crypto_ahash.c
++++ b/drivers/crypto/rockchip/rk2_crypto_ahash.c
 @@ -0,0 +1,344 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +/*
@@ -1428,7 +1404,7 @@ index 000000000000..4af1ab5a4b0d
 + */
 +#include <asm/unaligned.h>
 +#include <linux/iopoll.h>
-+#include "rk3588_crypto.h"
++#include "rk2_crypto.h"
 +
 +static bool rk2_ahash_need_fallback(struct ahash_request *areq)
 +{
@@ -1764,11 +1740,11 @@ index 000000000000..4af1ab5a4b0d
 +
 +	crypto_free_ahash(tctx->fallback_tfm);
 +}
-diff --git a/drivers/crypto/rockchip/rk3588_crypto_skcipher.c b/drivers/crypto/rockchip/rk3588_crypto_skcipher.c
+diff --git a/drivers/crypto/rockchip/rk2_crypto_skcipher.c b/drivers/crypto/rockchip/rk2_crypto_skcipher.c
 new file mode 100644
-index 000000000000..9b6cc29847d7
+index 000000000000..3e8e44d84b47
 --- /dev/null
-+++ b/drivers/crypto/rockchip/rk3588_crypto_skcipher.c
++++ b/drivers/crypto/rockchip/rk2_crypto_skcipher.c
 @@ -0,0 +1,576 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
@@ -1777,7 +1753,7 @@ index 000000000000..9b6cc29847d7
 + * Copyright (c) 2022-2023 Corentin Labbe <clabbe@baylibre.com>
 + */
 +#include <crypto/scatterwalk.h>
-+#include "rk3588_crypto.h"
++#include "rk2_crypto.h"
 +
 +static void rk2_print(struct rk2_crypto_dev *rkc)
 +{
@@ -2346,38 +2322,6 @@ index 000000000000..9b6cc29847d7
 +	memzero_explicit(ctx->key, ctx->keylen);
 +	crypto_free_skcipher(ctx->fallback_tfm);
 +}
--- 
-Armbian
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Corentin Labbe <clabbe.montjoie@gmail.com>
-Date: Wed, 4 Oct 2023 12:24:35 +0200
-Subject: SM3 fix
-
----
- drivers/crypto/Kconfig | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/drivers/crypto/Kconfig b/drivers/crypto/Kconfig
-index 9777040be739..deb313a33b14 100644
---- a/drivers/crypto/Kconfig
-+++ b/drivers/crypto/Kconfig
-@@ -642,7 +642,6 @@ config CRYPTO_DEV_ROCKCHIP
- 	select CRYPTO_MD5
- 	select CRYPTO_SHA1
- 	select CRYPTO_SHA256
--	select CRYPTO_SM3
- 	select CRYPTO_HASH
- 	select CRYPTO_SKCIPHER
- 
-@@ -670,6 +669,7 @@ config CRYPTO_DEV_ROCKCHIP2
- 	select CRYPTO_MD5
- 	select CRYPTO_SHA1
- 	select CRYPTO_SHA256
-+	select CRYPTO_SM3
- 	select CRYPTO_HASH
- 	select CRYPTO_SKCIPHER
- 	select CRYPTO_ENGINE
 -- 
 Armbian
 


### PR DESCRIPTION
# Description

Was having boot issues with RK3568 on edge 6.7....  Per @amazingfate 's advise.. updating montjoie's Rk35xx crypto patch from our Rk3588 patchset resolved the issue.


Tested on:

RK3568 - nanopi-r5s
RK3399 - nanopc-t4 