### PR TITLE
rock-5b: enable spi flash patch

### DIFF
--- a/patch/kernel/rockchip-rk3588-edge/board-rock-5b-arm64-dts-enable-spi-flash.patch
+++ b/patch/kernel/rockchip-rk3588-edge/board-rock-5b-arm64-dts-enable-spi-flash.patch
@@ -1,0 +1,56 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: lanefu <lane@lane-fu.com>
+Date: Sat, 20 Jan 2024 17:16:20 +0000
+Subject: rock-5b enable SPI flash in device tree
+ arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+
+Signed-off-by: lanefu <lane@lane-fu.com>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts | 27 ++++++++++
+ 1 file changed, 27 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+index a08ccc204158..a50a35409392 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+@@ -498,10 +498,37 @@ &uart6 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&uart6m1_xfer &uart6m1_ctsn &uart6m1_rtsn>;
+ 	status = "okay";
+ };
+ 
++&sfc {
++	status = "okay";
++
++		spi_flash: spi-flash@0 {
++		#address-cells = <1>;
++		#size-cells = <0>;
++		compatible = "jedec,spi-nor";
++		reg = <0x0>;
++		spi-max-frequency = <50000000>;
++		spi-tx-bus-width = <1>;
++		spi-rx-bus-width = <4>;
++		status = "okay";
++
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			loader@0 {
++				label = "loader";
++				reg = <0x0 0x1000000>;
++			};
++		};
++	};
++
++};
++
+ &spi2 {
+ 	status = "okay";
+ 	assigned-clocks = <&cru CLK_SPI2>;
+ 	assigned-clock-rates = <200000000>;
+ 	pinctrl-names = "default";
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+


### PR DESCRIPTION
# Description

* Enables spi flash on Rock-5b
* Recreated as a patch based on discussion in #6137

will take me some time to setup and do the big-boy pants stuff to submit to mainline but I'll def work on it.