### PR TITLE
Fix #6186 - update armbianEnv.txt for Rock Pi 4C+.

### DIFF
--- a/config/boards/rockpi-4cplus.csc
+++ b/config/boards/rockpi-4cplus.csc
@@ -6,6 +6,6 @@ BOOTCONFIG="rock-pi-4c-rk3399_defconfig"
 KERNEL_TARGET="current,edge"
 FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
-BOOT_FDT_FILE="rockchip/rk3399-rock-pi-4c-plus.dtb"
+BOOT_FDT_FILE="rockchip/rk3399-rock-4c-plus.dtb"
 BOOT_SCENARIO="tpl-spl-blob"
 BOOT_SUPPORT_SPI=yes


### PR DESCRIPTION
# Description

This fixes #6186 

Jira reference number [AR-2031]

# How Has This Been Tested?

I built images and checked the contents of armbianEnv.txt in every image.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-2031]: https://armbian.atlassian.net/browse/AR-2031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ