### PR TITLE
rk3318-box: add openvfd node to DT

### DIFF
--- a/patch/kernel/archive/rockchip64-6.6/dt/rk3318-box.dts
+++ b/patch/kernel/archive/rockchip64-6.6/dt/rk3318-box.dts
@@ -289,6 +289,12 @@
 		status = "okay";
 	};
 
+	openvfd {
+		compatible = "open,vfd";
+		dev_name = "openvfd";
+		status = "okay";
+	};
+
 	analog-sound {
 		compatible = "simple-audio-card";
 		simple-audio-card,format = "i2s";

--- a/patch/kernel/archive/rockchip64-6.7/dt/rk3318-box.dts
+++ b/patch/kernel/archive/rockchip64-6.7/dt/rk3318-box.dts
@@ -289,6 +289,12 @@
 		status = "okay";
 	};
 
+	openvfd {
+		compatible = "open,vfd";
+		dev_name = "openvfd";
+		status = "okay";
+	};
+
 	analog-sound {
 		compatible = "simple-audio-card";
 		simple-audio-card,format = "i2s";


### PR DESCRIPTION
# Description

Add [openvfd](https://github.com/arthur-liberman/linux_openvfd) node to device tree to allow loading if LCD display driver.
GPIO pin numbers left blank in DT as it differs on different devices and could be specified at runtime in module params.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Load LCD driver and display something

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
