### PR TITLE
Upstream wireless RTW88: Both 6.6 and 6.7 got patch integrated

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -416,7 +416,7 @@ driver_rtw88() {
 	# Upstream wireless RTW88 drivers (wireless-next-2023-08-25)
 	if linux-version compare "${version}" ge 6.1; then
 		display_alert "Adding" "Upstream wireless RTW88 drivers" "info"
-		if linux-version compare "${version}" ge 6.1 && linux-version compare "${version}" lt 6.8; then
+		if linux-version compare "${version}" ge 6.1 && linux-version compare "${version}" lt 6.6; then # came in with 6.6.14 and 6.7.2
 			process_patch_file "${SRC}/patch/misc/rtw88/${version}/001-drivers-net-wireless-realtek-rtw88-upstream-wireless.patch" "applying"
 		fi
 		process_patch_file "${SRC}/patch/misc/rtw88/hack/002-rtw88-usb-make-work-queues-high-priority.patch" "applying"


### PR DESCRIPTION
# Description

As per tittle. Don't apply it for 6.6 and up.

# How Has This Been Tested?

- [x] Patching test

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
