### PR TITLE
added cloud-init support

### DIFF
--- a/extensions/cloud-init/cloud-init.sh
+++ b/extensions/cloud-init/cloud-init.sh
@@ -1,0 +1,72 @@
+#
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (c) 2024 Rafel del Valle <rvalle@privaz.io>, Ricardo Pardini <ricardo@pardini.net>
+# This file is a part of the Armbian Build Framework https://github.com/armbian/build/
+#
+
+# Minimalistic implementation of Cloud-Init for Armbian
+# Functionaly equivalent to the implementation by Ubuntu for the Raspberri PI distribution
+
+# Implementaiton is based on the NoCLoud data source that will use
+# the FAT partition with armbi_boot label to source the configuration from
+
+# The Cloud init files in the boot partition are meant to be replaced with user provided ones, they are empty 
+# of configurations except for setting hostname and DHCP on ethernet adapters.
+
+# This extension also disables armbian-first-run
+
+# Cloud-Init image marker
+function extension_prepare_config__ci_image_suffix() {
+	# Add to image suffix. 
+	EXTRA_IMAGE_SUFFIXES+=("-ci") 
+}
+
+function extension_prepare_config__prepare_ci() { 
+  # Cloud Init related packages selected from Ubuntu RPI distirbution
+  add_packages_to_image cloud-init cloud-initramfs-copymods cloud-initramfs-dyn-netconf
+}
+
+function extension_prepare_config__ci_compatibility_check(){
+  # We require fat boot partition, will change and if the user provided another type, will fail.
+  if [[ -z "${BOOTFS_TYPE}" ]]; then
+    declare -g BOOTFS_TYPE="fat"
+    display_alert "Changing BOOTFS_TYPE" "cloud_init requires a fat partition" "warn"    
+  fi
+
+  if [[ "${BOOTFS_TYPE}" != "fat" ]]; then
+    exit_with_error "BOOTFS_TYPE ${BOOTFS_TYPE} not compatible with cloud-init"    
+  fi
+}
+
+function pre_customize_image__inject_cloud_init_config() {
+    # Copy the NoCLoud Cloud-Init Configuration
+	display_alert "Configuring" "cloud-init" "info"
+	local config_src="${EXTENSION_DIR}/config"
+	local config_dst="${SDCARD}/etc/cloud/cloud.cfg.d"
+    run_host_command_logged cp ${config_src}/* $config_dst
+
+    # Provide default cloud-init files
+	display_alert "Defaults" "cloud-init" "info"
+	local defaults_src="${EXTENSION_DIR}/defaults"
+	local defaults_dst="${SDCARD}/boot"
+    run_host_command_logged cp ${defaults_src}/* $defaults_dst    
+	return 0
+}
+
+
+# @TODO: would be better to have "armbian first run" as an extension that can be disabled
+function pre_customize_image__disable_armbian_first_run() {
+  display_alert "Disabling" "armbian first run" "info"
+
+  # Clean up default profile and network
+  rm -f ${SDCARD}/etc/profile.d/armbian-check-first-*
+  rm -f ${SDCARD}/etc/netplan/armbian-*
+
+  # remove any networkd config leftover from armbian build
+  rm -f "${SDCARD}"/etc/systemd/network/*.network || true
+
+  # cleanup -- cloud-init makes some Armbian stuff actually get in the way
+  [[ -f "${SDCARD}/boot/armbian_first_run.txt.template" ]] && rm -f "${SDCARD}/boot/armbian_first_run.txt.template"
+  [[ -f "${SDCARD}/root/.not_logged_in_yet" ]] && rm -f "${SDCARD}/root/.not_logged_in_yet"
+
+}

--- a/extensions/cloud-init/cloud-init.sh
+++ b/extensions/cloud-init/cloud-init.sh
@@ -23,7 +23,7 @@ function extension_prepare_config__ci_image_suffix() {
 
 function extension_prepare_config__prepare_ci() { 
   # Cloud Init related packages selected from Ubuntu RPI distirbution
-  add_packages_to_image cloud-init cloud-initramfs-copymods cloud-initramfs-dyn-netconf
+  add_packages_to_image cloud-init cloud-initramfs-dyn-netconf
 }
 
 function extension_prepare_config__ci_compatibility_check(){

--- a/extensions/cloud-init/config/99-fake_cloud.cfg
+++ b/extensions/cloud-init/config/99-fake_cloud.cfg
@@ -1,0 +1,5 @@
+# configure cloud-init for NoCloud
+datasource_list: [ NoCloud, None ]
+datasource:
+  NoCloud:
+    fs_label: armbi_boot

--- a/extensions/cloud-init/defaults/meta-data
+++ b/extensions/cloud-init/defaults/meta-data
@@ -1,0 +1,1 @@
+instance_id: armbian

--- a/extensions/cloud-init/defaults/network-config
+++ b/extensions/cloud-init/defaults/network-config
@@ -1,0 +1,7 @@
+version: 2
+ethernets:
+  all-ethernets:
+    dhcp4: true
+	optional: true
+	match:
+	  name: "en*,eth*"

--- a/extensions/cloud-init/defaults/network-config
+++ b/extensions/cloud-init/defaults/network-config
@@ -2,6 +2,6 @@ version: 2
 ethernets:
   all-ethernets:
     dhcp4: true
-	optional: true
-	match:
-	  name: "en*,eth*"
+    optional: true
+    match:
+    name: "en*,eth*"

--- a/extensions/cloud-init/defaults/network-config.template
+++ b/extensions/cloud-init/defaults/network-config.template
@@ -1,0 +1,37 @@
+
+# This template file includes some examples of how cloud-init can configure your network
+# The applicable documentation is https://cloudinit.readthedocs.io/en/latest/reference/network-config-format-v2.html#network-config-v2
+# This configuration is used by the NoCloud cloud-init module to configure your network
+# It essentially passes the configuration directly to netplan.
+
+version: 2
+ethernets:
+
+  # Will match all ethernet adapters and configure them by DHCP
+
+  all-ethernets:
+    dhcp4: true
+    optional: true
+    match:
+    name: "en*,eth*"
+
+  # Static Ethernet Example
+
+  static-eth:
+    match: 
+      # Will identify the adpter by MAC
+      macaddress: "11:22:33:aa:bb:ff"
+      addresses:
+        - 192.168.14.2/24
+      gateway4: 192.168.14.1
+
+wifis:
+
+  # Wifi Adapter Example
+  
+  wlan0:
+    dhcp4: true
+    optional: true
+    access-points:
+      MYAPN:
+        password: "MYPASSWORD"

--- a/extensions/cloud-init/defaults/user-data
+++ b/extensions/cloud-init/defaults/user-data
@@ -1,0 +1,3 @@
+#cloud-config
+
+hostname: armbian

--- a/extensions/cloud-init/defaults/user-data.template
+++ b/extensions/cloud-init/defaults/user-data.template
@@ -34,7 +34,7 @@ runcmd:
 package_update: true
 package_upgrade: true
 
-# Or Adding specific packates
+# Or Adding specific packages
 
 packages:
   - git

--- a/extensions/cloud-init/defaults/user-data.template
+++ b/extensions/cloud-init/defaults/user-data.template
@@ -1,0 +1,40 @@
+#cloud-config
+
+# This template file includes some examples of how cloud-init can configure your system
+# You can also check the documentation here: https://cloudinit.readthedocs.io/en/latest/reference/examples.html
+# Cloud Init is very complete, can configure anything. 
+
+# Configure the host
+
+hostname: armbian
+
+users:
+
+  # Create an user, password disabled, sudo without password and set the SSH KEY
+
+  - name: armbian
+    gecos: Armbian Ops User
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: users, admin
+    lock_passwd: true
+    ssh_authorized_keys:
+      - ssh-rsa AAAA********* my@publicKey
+
+
+# Running specific commands on first boot, for example, to extend a partition
+# Even to extend LVM objects when LVM is used
+
+runcmd:
+- [ cloud-init-per, once, resize_part, growpart, /dev/mmcblk0, '2' ]
+- [ cloud-init-per, once, resize_pv, pvresize, /dev/mmcblk0p2 ]
+- [ cloud-init-per, once, resize_root, lvresize, --size,5GB,-r,vg/root ]
+
+# You can also start by updating your APT repository and installing updates
+
+package_update: true
+package_upgrade: true
+
+# Or Adding specific packates
+
+packages:
+  - git


### PR DESCRIPTION
# Description

Adds minimalist cloud-init support functionally equivalent to the Ubuntu implementation for the Raspberry PI. addresses issue #6197 

Jira reference number [AR-2035](https://armbian.atlassian.net/browse/AR-2035)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

[AR-2035]: https://armbian.atlassian.net/browse/AR-2035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ