### PR TITLE
Delay fetching khadas common drivers to fix gha matrix failure

### DIFF
--- a/config/sources/families/meson-s4t7.conf
+++ b/config/sources/families/meson-s4t7.conf
@@ -16,16 +16,17 @@ case $BRANCH in
 
 	legacy)
 		declare -g KERNEL_MAJOR_MINOR="5.15"                           # Major and minor versions of this kernel. For mainline caching.
-		declare -g KERNELSOURCE="https://github.com/khadas/linux.git" # Khadas kernel
+		declare -g KERNELSOURCE="${GITHUB_SOURCE}/khadas/linux.git" # Khadas kernel
 		declare -g KERNELBRANCH="branch:khadas-vims-5.15.y"            # Branch or tag to build from. It should match MAJOR_MINOR
 		declare -g KERNELPATCHDIR="archive/meson-s4t7-5.15"
+		declare -g COMMON_DRIVERS_SOURCE="${GITHUB_SOURCE}/khadas/common_drivers"
 		declare -g EXTRAWIFI=no
 		;;
 
 esac
 
 # Lets build uboot from source
-BOOTSOURCE="https://github.com/khadas/u-boot.git"
+BOOTSOURCE="${GITHUB_SOURCE}/khadas/u-boot.git"
 BOOTBRANCH="tag:khadas-vims-u-boot-2019.01-v1.6-release"
 BOOTPATCHDIR="u-boot-meson-s4t7"
 BOOTENV_FILE='meson.txt'
@@ -110,22 +111,44 @@ function post_uboot_custom_postprocess__build_fip() {
 }
 
 function armbian_kernel_config__add_khadas_common_drivers() {
-	common_driver_source_loc="${SRC}/cache/sources/khadas_common_drivers/${KERNELBRANCH#*:}"
 	if [[ ! -f .config ]]; then
-		display_alert "$BOARD" "Fetching khadas common drivers" "info"
-		fetch_from_repo "https://github.com/khadas/common_drivers" "khadas_common_drivers" "${KERNELBRANCH}" "yes"
-		common_drivers_hash=$(git -C ${common_driver_source_loc} rev-parse HEAD)
+		display_alert "$BOARD" "Fetching khadas common drivers git info" "info"
+
+		common_drivers_cache_ttl_seconds=3600
+		declare -A GIT_INFO_COMMON_DRIVERS=([GIT_SOURCE]="${COMMON_DRIVERS_SOURCE}" [GIT_REF]="${KERNELBRANCH}")
+
+		if [[ "${KERNEL_GIT_CACHE_TTL}" != "" ]]; then
+			common_drivers_cache_ttl_seconds="${KERNEL_GIT_CACHE_TTL}"
+		fi
+
+		memoize_cache_ttl=$common_drivers_cache_ttl_seconds run_memoized GIT_INFO_COMMON_DRIVERS "git2info" memoized_git_ref_to_info
+
 		# Hack to ensure that we will recreate kernel if common_drivers source changes
-		kernel_config_modifying_hashes+=( "khadas_common_drivers=${common_drivers_hash}" )
+		kernel_config_modifying_hashes+=( "khadas_common_drivers=${GIT_INFO_COMMON_DRIVERS[SHA1]}" )
 	fi
 }
 
 function kernel_copy_extra_sources__khadas_common_drivers() {
 	display_alert "$BOARD" "Copying khadas common drivers" "info"
-	common_driver_source_loc="${SRC}/cache/sources/khadas_common_drivers/${KERNELBRANCH#*:}"
-	[[ -d common_drivers ]] && rm -rf common_drivers
-	mkdir common_drivers
-	cp -aR ${common_driver_source_loc}/* common_drivers/
+
+	common_drivers_git_bare_tree="${SRC}/cache/git-bare/khadas_common_drivers"
+	declare common_drivers_git_bare_tree_done_marker="${common_drivers_git_bare_tree}/.git/armbian-bare-tree-done"
+
+	if [[ ! -d "${common_drivers_git_bare_tree}" || ! -f "${common_drivers_git_bare_tree_done_marker}" ]]; then
+		if [[ -d "${common_drivers_git_bare_tree}" ]]; then
+			rm -rf "${common_drivers_git_bare_tree}"
+		fi
+
+		run_host_command_logged git clone --bare "${COMMON_DRIVERS_SOURCE}" \
+			"${common_drivers_git_bare_tree}"
+
+		touch "${common_drivers_git_bare_tree_done_marker}"
+	fi
+
+	GIT_FIXED_WORKDIR="${LINUXSOURCEDIR}/common_drivers" \
+		GIT_BARE_REPO_FOR_WORKTREE="${common_drivers_git_bare_tree}" \
+		GIT_BARE_REPO_INITIAL_BRANCH="${KERNELBRANCH#*:}" \
+		fetch_from_repo "${COMMON_DRIVERS_SOURCE}" "common_drivers:${KERNEL_MAJOR_MINOR}" "${KERNELBRANCH}" "yes"
 }
 
 function pre_package_kernel_image__copy_meson_s4t7_overlays() {

--- a/patch/kernel/archive/meson-s4t7-5.15/Makefile-don-t-try-to-modify-git-hooks.patch
+++ b/patch/kernel/archive/meson-s4t7-5.15/Makefile-don-t-try-to-modify-git-hooks.patch
@@ -1,0 +1,33 @@
+From e2de477ae718ae0cefcb2ad7ee65743b33bea999 Mon Sep 17 00:00:00 2001
+From: Gunjan Gupta <viraniac@gmail.com>
+Date: Fri, 26 Jan 2024 23:19:30 +0000
+Subject: [PATCH] Makefile: don't try to modify git hooks
+
+---
+ Makefile | 8 -----------
+ 1 file changed, 8 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 5fdf7c5ca5cd..a95777682e60 100644
+--- a/Makefile
++++ b/Makefile
+@@ -2106,16 +2106,8 @@ endif # config-build
+ endif # mixed-build
+ endif # need-sub-make
+ 
+-ifdef CONFIG_AMLOGIC_DRIVER
+ PHONY += FORCE
+ FORCE:
+-	$(Q)-cp $(srctree)/scripts/amlogic/commit-msg $(srctree)/.git/hooks/
+-	$(Q)-cp $(srctree)/scripts/amlogic/commit-msg $(srctree)/$(COMMON_DRIVERS_DIR)/.git/hooks/
+-	$(Q)-chmod +x $(srctree)/.git/hooks/commit-msg $(srctree)/$(COMMON_DRIVERS_DIR)/.git/hooks/commit-msg
+-else
+-PHONY += FORCE
+-FORCE:
+-endif
+ 
+ # Declare the contents of the PHONY variable as phony.  We keep that
+ # information in a variable so we can use it in if_changed and friends.
+-- 
+2.34.1
+


### PR DESCRIPTION
# Description

Delay fetching khadas common drivers to fix gha matrix failure. Also fixed a cosmetic error when compiling kernel about not able to modify kernel git hooks

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] built kernel for vim1s. Made sure common drivers are getting compiled.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
