### PR TITLE
rockchip64: fix ssv6051 driver

### DIFF
--- a/patch/kernel/archive/rockchip64-6.7/wifi-4003-ssv-6051-driver.patch
+++ b/patch/kernel/archive/rockchip64-6.7/wifi-4003-ssv-6051-driver.patch
@@ -1,73 +1,131 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 3f30a652fb3e6ead83f65312d0240d5c9ea8c340 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
 Date: Wed, 2 Nov 2022 15:40:06 +0000
-Subject: add ssv6xxx wifi driver
+Subject: [PATCH] add ssv6xxx wifi driver
 
 ---
- drivers/net/wireless/Kconfig                                 |     1 +
- drivers/net/wireless/Makefile                                |     1 +
- drivers/net/wireless/ssv6051/Kconfig                         |    11 +
- drivers/net/wireless/ssv6051/Makefile                        |    26 +
- drivers/net/wireless/ssv6051/Makefile.bak                    |   107 +
- drivers/net/wireless/ssv6051/firmware/ssv6051-wifi.cfg       |    91 +
- drivers/net/wireless/ssv6051/hci/hctrl.h                     |   178 +
- drivers/net/wireless/ssv6051/hci/ssv_hci.c                   |   967 +
- drivers/net/wireless/ssv6051/hci/ssv_hci.h                   |    77 +
- drivers/net/wireless/ssv6051/hwif/hwif.h                     |    84 +
- drivers/net/wireless/ssv6051/hwif/sdio/sdio.c                |  1254 +
- drivers/net/wireless/ssv6051/hwif/sdio/sdio_def.h            |    80 +
- drivers/net/wireless/ssv6051/include/cabrio.h                |    28 +
- drivers/net/wireless/ssv6051/include/ssv6200.h               |    76 +
- drivers/net/wireless/ssv6051/include/ssv6200_aux.h           | 18221 ++++++++++
- drivers/net/wireless/ssv6051/include/ssv6200_common.h        |   452 +
- drivers/net/wireless/ssv6051/include/ssv6200_configuration.h |   317 +
- drivers/net/wireless/ssv6051/include/ssv6200_reg.h           |  9694 +++++
- drivers/net/wireless/ssv6051/include/ssv6200_reg_sim.h       |   176 +
- drivers/net/wireless/ssv6051/include/ssv_cfg.h               |    60 +
- drivers/net/wireless/ssv6051/include/ssv_firmware_version.h  |    25 +
- drivers/net/wireless/ssv6051/include/ssv_version.h           |    12 +
- drivers/net/wireless/ssv6051/platform-config.mak             |    97 +
- drivers/net/wireless/ssv6051/rules.mak                       |    19 +
- drivers/net/wireless/ssv6051/smac/ampdu.c                    |  2111 ++
- drivers/net/wireless/ssv6051/smac/ampdu.h                    |   215 +
- drivers/net/wireless/ssv6051/smac/ap.c                       |   598 +
- drivers/net/wireless/ssv6051/smac/ap.h                       |    41 +
- drivers/net/wireless/ssv6051/smac/dev.c                      |  3880 ++
- drivers/net/wireless/ssv6051/smac/dev.h                      |   445 +
- drivers/net/wireless/ssv6051/smac/dev_tbl.h                  |   141 +
- drivers/net/wireless/ssv6051/smac/drv_comm.h                 |    61 +
- drivers/net/wireless/ssv6051/smac/efuse.c                    |   334 +
- drivers/net/wireless/ssv6051/smac/efuse.h                    |    40 +
- drivers/net/wireless/ssv6051/smac/init.c                     |  1347 +
- drivers/net/wireless/ssv6051/smac/init.h                     |    23 +
- drivers/net/wireless/ssv6051/smac/lib.c                      |    33 +
- drivers/net/wireless/ssv6051/smac/lib.h                      |    23 +
- drivers/net/wireless/ssv6051/smac/linux_80211.h              |    24 +
- drivers/net/wireless/ssv6051/smac/p2p.c                      |   305 +
- drivers/net/wireless/ssv6051/smac/p2p.h                      |    58 +
- drivers/net/wireless/ssv6051/smac/sar.c                      |   208 +
- drivers/net/wireless/ssv6051/smac/sar.h                      |    63 +
- drivers/net/wireless/ssv6051/smac/sec.h                      |    52 +
- drivers/net/wireless/ssv6051/smac/smartlink.c                |   340 +
- drivers/net/wireless/ssv6051/smac/ssv6xxx_debugfs.c          |   223 +
- drivers/net/wireless/ssv6051/smac/ssv6xxx_debugfs.h          |    27 +
- drivers/net/wireless/ssv6051/smac/ssv_cfgvendor.c            |  1384 +
- drivers/net/wireless/ssv6051/smac/ssv_cfgvendor.h            |   247 +
- drivers/net/wireless/ssv6051/smac/ssv_ht_rc.c                |   546 +
- drivers/net/wireless/ssv6051/smac/ssv_ht_rc.h                |    31 +
- drivers/net/wireless/ssv6051/smac/ssv_pm.c                   |    19 +
- drivers/net/wireless/ssv6051/smac/ssv_pm.h                   |    20 +
- drivers/net/wireless/ssv6051/smac/ssv_rc.c                   |  1716 +
- drivers/net/wireless/ssv6051/smac/ssv_rc.h                   |    50 +
- drivers/net/wireless/ssv6051/smac/ssv_rc_common.h            |   175 +
- drivers/net/wireless/ssv6051/ssv6051-generic-wlan.c          |    76 +
- drivers/net/wireless/ssv6051/ssvdevice/ssv_cmd.c             |  1765 +
- drivers/net/wireless/ssv6051/ssvdevice/ssv_cmd.h             |    50 +
- drivers/net/wireless/ssv6051/ssvdevice/ssvdevice.c           |   256 +
- 60 files changed, 48981 insertions(+)
+ drivers/net/wireless/Kconfig                  |     1 +
+ drivers/net/wireless/Makefile                 |     1 +
+ drivers/net/wireless/ssv6051/Kconfig          |    11 +
+ drivers/net/wireless/ssv6051/Makefile         |    26 +
+ drivers/net/wireless/ssv6051/Makefile.bak     |   107 +
+ .../ssv6051/firmware/ssv6051-wifi.cfg         |    91 +
+ drivers/net/wireless/ssv6051/hci/hctrl.h      |   178 +
+ drivers/net/wireless/ssv6051/hci/ssv_hci.c    |   967 +
+ drivers/net/wireless/ssv6051/hci/ssv_hci.h    |    77 +
+ drivers/net/wireless/ssv6051/hwif/hwif.h      |    84 +
+ drivers/net/wireless/ssv6051/hwif/sdio/sdio.c |  1254 ++
+ .../net/wireless/ssv6051/hwif/sdio/sdio_def.h |    80 +
+ drivers/net/wireless/ssv6051/include/cabrio.h |    28 +
+ .../net/wireless/ssv6051/include/ssv6200.h    |    76 +
+ .../wireless/ssv6051/include/ssv6200_aux.h    | 18221 ++++++++++++++++
+ .../wireless/ssv6051/include/ssv6200_common.h |   452 +
+ .../ssv6051/include/ssv6200_configuration.h   |   317 +
+ .../wireless/ssv6051/include/ssv6200_reg.h    |  9694 ++++++++
+ .../ssv6051/include/ssv6200_reg_sim.h         |   176 +
+ .../net/wireless/ssv6051/include/ssv_cfg.h    |    60 +
+ .../ssv6051/include/ssv_firmware_version.h    |    25 +
+ .../wireless/ssv6051/include/ssv_version.h    |    12 +
+ .../net/wireless/ssv6051/platform-config.mak  |    97 +
+ drivers/net/wireless/ssv6051/rules.mak        |    19 +
+ drivers/net/wireless/ssv6051/smac/ampdu.c     |  2111 ++
+ drivers/net/wireless/ssv6051/smac/ampdu.h     |   215 +
+ drivers/net/wireless/ssv6051/smac/ap.c        |   598 +
+ drivers/net/wireless/ssv6051/smac/ap.h        |    41 +
+ drivers/net/wireless/ssv6051/smac/dev.c       |  3880 ++++
+ drivers/net/wireless/ssv6051/smac/dev.h       |   445 +
+ drivers/net/wireless/ssv6051/smac/dev_tbl.h   |   141 +
+ drivers/net/wireless/ssv6051/smac/drv_comm.h  |    61 +
+ drivers/net/wireless/ssv6051/smac/efuse.c     |   334 +
+ drivers/net/wireless/ssv6051/smac/efuse.h     |    40 +
+ drivers/net/wireless/ssv6051/smac/init.c      |  1347 ++
+ drivers/net/wireless/ssv6051/smac/init.h      |    23 +
+ drivers/net/wireless/ssv6051/smac/lib.c       |    33 +
+ drivers/net/wireless/ssv6051/smac/lib.h       |    23 +
+ .../net/wireless/ssv6051/smac/linux_80211.h   |    24 +
+ drivers/net/wireless/ssv6051/smac/p2p.c       |   305 +
+ drivers/net/wireless/ssv6051/smac/p2p.h       |    58 +
+ drivers/net/wireless/ssv6051/smac/sar.c       |   208 +
+ drivers/net/wireless/ssv6051/smac/sar.h       |    63 +
+ drivers/net/wireless/ssv6051/smac/sec.h       |    52 +
+ drivers/net/wireless/ssv6051/smac/smartlink.c |   340 +
+ .../wireless/ssv6051/smac/ssv6xxx_debugfs.c   |   223 +
+ .../wireless/ssv6051/smac/ssv6xxx_debugfs.h   |    27 +
+ .../net/wireless/ssv6051/smac/ssv_cfgvendor.c |  1384 ++
+ .../net/wireless/ssv6051/smac/ssv_cfgvendor.h |   247 +
+ drivers/net/wireless/ssv6051/smac/ssv_ht_rc.c |   546 +
+ drivers/net/wireless/ssv6051/smac/ssv_ht_rc.h |    31 +
+ drivers/net/wireless/ssv6051/smac/ssv_pm.c    |    19 +
+ drivers/net/wireless/ssv6051/smac/ssv_pm.h    |    20 +
+ drivers/net/wireless/ssv6051/smac/ssv_rc.c    |  1716 ++
+ drivers/net/wireless/ssv6051/smac/ssv_rc.h    |    50 +
+ .../net/wireless/ssv6051/smac/ssv_rc_common.h |   175 +
+ .../wireless/ssv6051/ssv6051-generic-wlan.c   |    76 +
+ .../net/wireless/ssv6051/ssvdevice/ssv_cmd.c  |  1765 ++
+ .../net/wireless/ssv6051/ssvdevice/ssv_cmd.h  |    50 +
+ .../wireless/ssv6051/ssvdevice/ssvdevice.c    |   256 +
+ 60 files changed, 48983 insertions(+)
+ create mode 100644 drivers/net/wireless/ssv6051/Kconfig
+ create mode 100644 drivers/net/wireless/ssv6051/Makefile
+ create mode 100644 drivers/net/wireless/ssv6051/Makefile.bak
+ create mode 100644 drivers/net/wireless/ssv6051/firmware/ssv6051-wifi.cfg
+ create mode 100644 drivers/net/wireless/ssv6051/hci/hctrl.h
+ create mode 100644 drivers/net/wireless/ssv6051/hci/ssv_hci.c
+ create mode 100644 drivers/net/wireless/ssv6051/hci/ssv_hci.h
+ create mode 100644 drivers/net/wireless/ssv6051/hwif/hwif.h
+ create mode 100644 drivers/net/wireless/ssv6051/hwif/sdio/sdio.c
+ create mode 100644 drivers/net/wireless/ssv6051/hwif/sdio/sdio_def.h
+ create mode 100644 drivers/net/wireless/ssv6051/include/cabrio.h
+ create mode 100644 drivers/net/wireless/ssv6051/include/ssv6200.h
+ create mode 100644 drivers/net/wireless/ssv6051/include/ssv6200_aux.h
+ create mode 100644 drivers/net/wireless/ssv6051/include/ssv6200_common.h
+ create mode 100644 drivers/net/wireless/ssv6051/include/ssv6200_configuration.h
+ create mode 100644 drivers/net/wireless/ssv6051/include/ssv6200_reg.h
+ create mode 100644 drivers/net/wireless/ssv6051/include/ssv6200_reg_sim.h
+ create mode 100644 drivers/net/wireless/ssv6051/include/ssv_cfg.h
+ create mode 100644 drivers/net/wireless/ssv6051/include/ssv_firmware_version.h
+ create mode 100644 drivers/net/wireless/ssv6051/include/ssv_version.h
+ create mode 100644 drivers/net/wireless/ssv6051/platform-config.mak
+ create mode 100644 drivers/net/wireless/ssv6051/rules.mak
+ create mode 100644 drivers/net/wireless/ssv6051/smac/ampdu.c
+ create mode 100644 drivers/net/wireless/ssv6051/smac/ampdu.h
+ create mode 100644 drivers/net/wireless/ssv6051/smac/ap.c
+ create mode 100644 drivers/net/wireless/ssv6051/smac/ap.h
+ create mode 100644 drivers/net/wireless/ssv6051/smac/dev.c
+ create mode 100644 drivers/net/wireless/ssv6051/smac/dev.h
+ create mode 100644 drivers/net/wireless/ssv6051/smac/dev_tbl.h
+ create mode 100644 drivers/net/wireless/ssv6051/smac/drv_comm.h
+ create mode 100644 drivers/net/wireless/ssv6051/smac/efuse.c
+ create mode 100644 drivers/net/wireless/ssv6051/smac/efuse.h
+ create mode 100644 drivers/net/wireless/ssv6051/smac/init.c
+ create mode 100644 drivers/net/wireless/ssv6051/smac/init.h
+ create mode 100644 drivers/net/wireless/ssv6051/smac/lib.c
+ create mode 100644 drivers/net/wireless/ssv6051/smac/lib.h
+ create mode 100644 drivers/net/wireless/ssv6051/smac/linux_80211.h
+ create mode 100644 drivers/net/wireless/ssv6051/smac/p2p.c
+ create mode 100644 drivers/net/wireless/ssv6051/smac/p2p.h
+ create mode 100644 drivers/net/wireless/ssv6051/smac/sar.c
+ create mode 100644 drivers/net/wireless/ssv6051/smac/sar.h
+ create mode 100644 drivers/net/wireless/ssv6051/smac/sec.h
+ create mode 100644 drivers/net/wireless/ssv6051/smac/smartlink.c
+ create mode 100644 drivers/net/wireless/ssv6051/smac/ssv6xxx_debugfs.c
+ create mode 100644 drivers/net/wireless/ssv6051/smac/ssv6xxx_debugfs.h
+ create mode 100644 drivers/net/wireless/ssv6051/smac/ssv_cfgvendor.c
+ create mode 100644 drivers/net/wireless/ssv6051/smac/ssv_cfgvendor.h
+ create mode 100644 drivers/net/wireless/ssv6051/smac/ssv_ht_rc.c
+ create mode 100644 drivers/net/wireless/ssv6051/smac/ssv_ht_rc.h
+ create mode 100644 drivers/net/wireless/ssv6051/smac/ssv_pm.c
+ create mode 100644 drivers/net/wireless/ssv6051/smac/ssv_pm.h
+ create mode 100644 drivers/net/wireless/ssv6051/smac/ssv_rc.c
+ create mode 100644 drivers/net/wireless/ssv6051/smac/ssv_rc.h
+ create mode 100644 drivers/net/wireless/ssv6051/smac/ssv_rc_common.h
+ create mode 100644 drivers/net/wireless/ssv6051/ssv6051-generic-wlan.c
+ create mode 100644 drivers/net/wireless/ssv6051/ssvdevice/ssv_cmd.c
+ create mode 100644 drivers/net/wireless/ssv6051/ssvdevice/ssv_cmd.h
+ create mode 100644 drivers/net/wireless/ssv6051/ssvdevice/ssvdevice.c
 
 diff --git a/drivers/net/wireless/Kconfig b/drivers/net/wireless/Kconfig
-index 1351192eb9e0..408b25079882 100644
+index de5e37846397..aa2cac9abdd3 100644
 --- a/drivers/net/wireless/Kconfig
 +++ b/drivers/net/wireless/Kconfig
 @@ -18,6 +18,7 @@ menuconfig WLAN
@@ -79,7 +137,7 @@ index 1351192eb9e0..408b25079882 100644
  source "drivers/net/wireless/ath/Kconfig"
  source "drivers/net/wireless/atmel/Kconfig"
 diff --git a/drivers/net/wireless/Makefile b/drivers/net/wireless/Makefile
-index 3154f8c57544..2853cdf2c09b 100644
+index 92ffd2cef51c..8b56a42e97a6 100644
 --- a/drivers/net/wireless/Makefile
 +++ b/drivers/net/wireless/Makefile
 @@ -3,6 +3,7 @@
@@ -1681,7 +1739,7 @@ index 000000000000..6b5263d157d8
 +#endif
 diff --git a/drivers/net/wireless/ssv6051/hwif/sdio/sdio.c b/drivers/net/wireless/ssv6051/hwif/sdio/sdio.c
 new file mode 100644
-index 000000000000..e32c092277e8
+index 000000000000..273777cd0485
 --- /dev/null
 +++ b/drivers/net/wireless/ssv6051/hwif/sdio/sdio.c
 @@ -0,0 +1,1254 @@
@@ -32148,7 +32206,7 @@ index 000000000000..99be5354f783
 +#endif
 diff --git a/drivers/net/wireless/ssv6051/platform-config.mak b/drivers/net/wireless/ssv6051/platform-config.mak
 new file mode 100644
-index 000000000000..37c569b68bf3
+index 000000000000..b1b6f0510d28
 --- /dev/null
 +++ b/drivers/net/wireless/ssv6051/platform-config.mak
 @@ -0,0 +1,97 @@
@@ -33039,7 +33097,7 @@ index 000000000000..846830f3d209
 +			break;
 +		if (aggregated_mpdu)
 +			skb_pull(skb, AMPDU_DELIMITER_LEN);
-+		ieee80211_tx_status(hw, skb);
++		ieee80211_tx_status_skb(hw, skb);
 +	}
 +}
 +
@@ -33410,7 +33468,7 @@ index 000000000000..846830f3d209
 +		dev_err(sc->dev, "create TX skb copy failed!\n");
 +		return false;
 +	}
-+	ieee80211_tx_status(sc->hw, tx_skb);
++	ieee80211_tx_status_skb(sc->hw, tx_skb);
 +	skb = copy_skb;
 +#endif
 +	{
@@ -33809,7 +33867,7 @@ index 000000000000..846830f3d209
 +		dev_kfree_skb_any(ampdu_skb);
 +#else
 +#if defined(USE_THREAD_RX) && !defined(IRQ_PROC_TX_DATA)
-+		ieee80211_tx_status(hw, ampdu_skb);
++		ieee80211_tx_status_skb(hw, ampdu_skb);
 +#else
 +		ieee80211_tx_status_irqsafe(hw, ampdu_skb);
 +#endif
@@ -34615,7 +34673,7 @@ index 000000000000..faa61c4f9297
 +#endif
 diff --git a/drivers/net/wireless/ssv6051/smac/ap.c b/drivers/net/wireless/ssv6051/smac/ap.c
 new file mode 100644
-index 000000000000..c2650210159a
+index 000000000000..0f2ba6a31a05
 --- /dev/null
 +++ b/drivers/net/wireless/ssv6051/smac/ap.c
 @@ -0,0 +1,598 @@
@@ -35266,10 +35324,10 @@ index 000000000000..93b5275715b5
 +#endif
 diff --git a/drivers/net/wireless/ssv6051/smac/dev.c b/drivers/net/wireless/ssv6051/smac/dev.c
 new file mode 100644
-index 000000000000..6e05b7416646
+index 000000000000..214e93fae460
 --- /dev/null
 +++ b/drivers/net/wireless/ssv6051/smac/dev.c
-@@ -0,0 +1,3880 @@
+@@ -0,0 +1,3881 @@
 +/*
 + * Copyright (c) 2015 South Silicon Valley Microelectronics Inc.
 + * Copyright (c) 2015 iComm Corporation
@@ -36838,7 +36896,7 @@ index 000000000000..6e05b7416646
 +#ifdef REPORT_TX_DONE_IN_IRQ
 +		ieee80211_tx_status_irqsafe(sc->hw, skb);
 +#else
-+		ieee80211_tx_status(sc->hw, skb);
++		ieee80211_tx_status_skb(sc->hw, skb);
 +		if (skb_queue_len(&sc->rx_skb_q))
 +			break;
 +#endif
@@ -38452,6 +38510,7 @@ index 000000000000..6e05b7416646
 +	.set_tim = ssv6200_set_tim,
 +	.conf_tx = ssv6200_conf_tx,
 +	.ampdu_action = ssv6200_ampdu_action,
++	.wake_tx_queue = ieee80211_handle_wake_tx_queue,
 +#ifdef CONFIG_PM
 +	.suspend = ssv6xxx_suspend,
 +	.resume = ssv6xxx_resume,
@@ -45290,7 +45349,7 @@ index 000000000000..9be260dd904e
 +#endif
 diff --git a/drivers/net/wireless/ssv6051/smac/ssv_rc.c b/drivers/net/wireless/ssv6051/smac/ssv_rc.c
 new file mode 100644
-index 000000000000..f90e352bdf0c
+index 000000000000..9c3574285364
 --- /dev/null
 +++ b/drivers/net/wireless/ssv6051/smac/ssv_rc.c
 @@ -0,0 +1,1716 @@
@@ -49419,5 +49478,5 @@ index 000000000000..eb848553798f
 +EXPORT_SYMBOL(ssvdevice_init);
 +EXPORT_SYMBOL(ssvdevice_exit);
 -- 
-Armbian
+2.34.1
 


### PR DESCRIPTION
# Description

Driver does not compile on kernel 6.7 due to minor changes in kernel API.
The PR just fixes the changes.

# How Has This Been Tested?

- [x] Compiled rockchip64 edge 6.7 kernel

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
