### PR TITLE
Labeler workflow fails due to insufficient permissions

### DIFF
--- a/.github/workflows/labels-from-yml.yml
+++ b/.github/workflows/labels-from-yml.yml
@@ -12,6 +12,10 @@ on:
 
 jobs:
   labeler:
+    permissions:
+      contents: read  # for actions/labeler to determine modified files
+      pull-requests: write  # for actions/labeler to add labels to PRs
+      issues: write # for actions/labeler to add labels to issues
     if: ${{ github.repository_owner == 'Armbian' }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Description

GitHub Actions security feature.
https://github.com/crazy-max/ghaction-github-labeler/issues/184

# How Has This Been Tested?

We use this way on armbian/os https://github.com/armbian/os/blob/main/.github/workflows/labeler.yml