### PR TITLE
Revert wifi driver from rtw88 to vendor rtl88x2cs for meson64 family (JetHub H1/D1/D1+)

### DIFF
--- a/config/sources/families/jethub.conf
+++ b/config/sources/families/jethub.conf
@@ -1,7 +1,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0
 #
-# Copyright (c) 2019-2023 JetHome
+# Copyright (c) 2019-2024 JetHome
 # Author: Viacheslav Bocharov <vb@jethome.ru>
 #
 # This file is a part of the Armbian Build Framework
@@ -24,6 +24,18 @@ elif [[ "$BOARD" == "jethubj100" ]]; then
 	CPUMAX=1416000
 	OFFSET=126
 fi
+
+
+if [[ "$BOARD" == "jethubj80" ]] || [[ "$BOARD" == "jethubj100" ]] ; then
+	function family_tweaks__blacklistrtw88() {
+		if [[ "$BOARD" == jethubj80 ]] || [[ "$BOARD" == jethubj100 ]]; then
+			mkdir -p "${destination}"/etc/modprobe.d
+			echo "blacklist rtw88_8822cs" > "${destination}"/etc/modprobe.d/rtw88_8822cs.conf
+		fi
+		display_alert "Added rtw88_8822cs to blacklist" "${BOARD}" "info"
+	}
+fi
+
 
 # JetHub builds userspace tooling with c++ (gpp) toolchain in buildjethomecmds() below.
 # The C++ compiler is no longer included by default in the Armbian build system.

--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -424,6 +424,16 @@ driver_rtw88() {
 	fi
 }
 
+function armbian_kernel_config__enable_rtl88x2cs_driver() {
+	if [[ "${LINUXFAMILY}" == "meson64" ]]; then
+		kernel_config_modifying_hashes+=("CONFIG_RTL8822CS=m")
+		if [[ -f .config ]]; then
+			display_alert "Enabling rtl88x2cs driver in kernel config" "armbian-kernel" "wrn"
+			kernel_config_set_m CONFIG_RTL8822CS
+		fi
+	fi
+}
+
 driver_rtl88x2cs() {
 
 	# Wireless drivers for Realtek 88x2cs chipsets

--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -428,10 +428,10 @@ driver_rtl88x2cs() {
 
 	# Wireless drivers for Realtek 88x2cs chipsets
 
-	if linux-version compare "${version}" ge 5.9 && linux-version compare "${version}" lt 6.1; then
+	if linux-version compare "${version}" ge 5.9; then
 
 		# attach to specifics tag or branch
-		local rtl88x2csver='commit:b77a5cf442fbc01c1220b8174ee2227a8f71e204' # was "branch:tune_for_jethub"
+		local rtl88x2csver='commit:10f39b61c51fa0302062059e00e9b5440dd3c7a6' # track "branch:tune_for_jethub"
 
 		display_alert "Adding" "Wireless drivers for Realtek 88x2cs chipsets ${rtl88x2csver}" "info"
 


### PR DESCRIPTION
# Description

RTW88 driver has some problems (no working AP mode, wifi connection fails after 2-3 days, speed problems) on RTL8822CS SDIO modules. So:
- update rtl88x2cs commit sha to latest version
- add armbian_kernel_config hook to enable driver in kernel config (only for meson64 family)
- add jethub boards hook to blacklist rtw88 module in image (by default rtw88 loads first)

Jira reference number [AR-2033]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] JetHub family WiFi works
- [ ] Need to be tested on other family boards

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-2033]: https://armbian.atlassian.net/browse/AR-2033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ