### PR TITLE
fixed indentation on cloud-init extension

### DIFF
--- a/extensions/cloud-init/cloud-init.sh
+++ b/extensions/cloud-init/cloud-init.sh
@@ -22,51 +22,51 @@ function extension_prepare_config__ci_image_suffix() {
 }
 
 function extension_prepare_config__prepare_ci() { 
-  # Cloud Init related packages selected from Ubuntu RPI distirbution
-  add_packages_to_image cloud-init cloud-initramfs-dyn-netconf
+	# Cloud Init related packages selected from Ubuntu RPI distirbution
+	add_packages_to_image cloud-init cloud-initramfs-dyn-netconf
 }
 
 function extension_prepare_config__ci_compatibility_check(){
-  # We require fat boot partition, will change and if the user provided another type, will fail.
-  if [[ -z "${BOOTFS_TYPE}" ]]; then
-    declare -g BOOTFS_TYPE="fat"
-    display_alert "Changing BOOTFS_TYPE" "cloud_init requires a fat partition" "warn"    
-  fi
+	# We require fat boot partition, will change and if the user provided another type, will fail.
+	if [[ -z "${BOOTFS_TYPE}" ]]; then
+		declare -g BOOTFS_TYPE="fat"
+		display_alert "Changing BOOTFS_TYPE" "cloud_init requires a fat partition" "warn"
+	fi
 
-  if [[ "${BOOTFS_TYPE}" != "fat" ]]; then
-    exit_with_error "BOOTFS_TYPE ${BOOTFS_TYPE} not compatible with cloud-init"    
-  fi
+	if [[ "${BOOTFS_TYPE}" != "fat" ]]; then
+		exit_with_error "BOOTFS_TYPE ${BOOTFS_TYPE} not compatible with cloud-init"
+	fi
 }
 
 function pre_customize_image__inject_cloud_init_config() {
-    # Copy the NoCLoud Cloud-Init Configuration
+		# Copy the NoCLoud Cloud-Init Configuration
 	display_alert "Configuring" "cloud-init" "info"
 	local config_src="${EXTENSION_DIR}/config"
 	local config_dst="${SDCARD}/etc/cloud/cloud.cfg.d"
-    run_host_command_logged cp ${config_src}/* $config_dst
+		run_host_command_logged cp ${config_src}/* $config_dst
 
-    # Provide default cloud-init files
+		# Provide default cloud-init files
 	display_alert "Defaults" "cloud-init" "info"
 	local defaults_src="${EXTENSION_DIR}/defaults"
 	local defaults_dst="${SDCARD}/boot"
-    run_host_command_logged cp ${defaults_src}/* $defaults_dst    
+		run_host_command_logged cp ${defaults_src}/* $defaults_dst
 	return 0
 }
 
 
 # @TODO: would be better to have "armbian first run" as an extension that can be disabled
 function pre_customize_image__disable_armbian_first_run() {
-  display_alert "Disabling" "armbian first run" "info"
+	display_alert "Disabling" "armbian first run" "info"
 
-  # Clean up default profile and network
-  rm -f ${SDCARD}/etc/profile.d/armbian-check-first-*
-  rm -f ${SDCARD}/etc/netplan/armbian-*
+	# Clean up default profile and network
+	rm -f ${SDCARD}/etc/profile.d/armbian-check-first-*
+	rm -f ${SDCARD}/etc/netplan/armbian-*
 
-  # remove any networkd config leftover from armbian build
-  rm -f "${SDCARD}"/etc/systemd/network/*.network || true
+	# remove any networkd config leftover from armbian build
+	rm -f "${SDCARD}"/etc/systemd/network/*.network || true
 
-  # cleanup -- cloud-init makes some Armbian stuff actually get in the way
-  [[ -f "${SDCARD}/boot/armbian_first_run.txt.template" ]] && rm -f "${SDCARD}/boot/armbian_first_run.txt.template"
-  [[ -f "${SDCARD}/root/.not_logged_in_yet" ]] && rm -f "${SDCARD}/root/.not_logged_in_yet"
+	# cleanup -- cloud-init makes some Armbian stuff actually get in the way
+	[[ -f "${SDCARD}/boot/armbian_first_run.txt.template" ]] && rm -f "${SDCARD}/boot/armbian_first_run.txt.template"
+	[[ -f "${SDCARD}/root/.not_logged_in_yet" ]] && rm -f "${SDCARD}/root/.not_logged_in_yet"
 
 }

--- a/extensions/cloud-init/cloud-init.sh
+++ b/extensions/cloud-init/cloud-init.sh
@@ -39,17 +39,17 @@ function extension_prepare_config__ci_compatibility_check(){
 }
 
 function pre_customize_image__inject_cloud_init_config() {
-		# Copy the NoCLoud Cloud-Init Configuration
+	# Copy the NoCLoud Cloud-Init Configuration
 	display_alert "Configuring" "cloud-init" "info"
 	local config_src="${EXTENSION_DIR}/config"
 	local config_dst="${SDCARD}/etc/cloud/cloud.cfg.d"
-		run_host_command_logged cp ${config_src}/* $config_dst
+	run_host_command_logged cp ${config_src}/* $config_dst
 
-		# Provide default cloud-init files
+	# Provide default cloud-init files
 	display_alert "Defaults" "cloud-init" "info"
 	local defaults_src="${EXTENSION_DIR}/defaults"
 	local defaults_dst="${SDCARD}/boot"
-		run_host_command_logged cp ${defaults_src}/* $defaults_dst
+	run_host_command_logged cp ${defaults_src}/* $defaults_dst
 	return 0
 }
 

--- a/extensions/cloud-init/defaults/network-config
+++ b/extensions/cloud-init/defaults/network-config
@@ -4,4 +4,4 @@ ethernets:
     dhcp4: true
     optional: true
     match:
-    name: "en*,eth*"
+      name: "en*,eth*"

--- a/extensions/cloud-init/defaults/network-config.template
+++ b/extensions/cloud-init/defaults/network-config.template
@@ -13,7 +13,7 @@ ethernets:
     dhcp4: true
     optional: true
     match:
-    name: "en*,eth*"
+      name: "en*,eth*"
 
   # Static Ethernet Example
 


### PR DESCRIPTION
# Description

Minor formatting fix. extensions should use tabs as indentation as @viraniac pointed. Definitely not mixed space/tabs. Also minor fix in examples to fully comply with spec. 