### PR TITLE
meson64: bananapicm4io/m2s: u-boot v2024.01 and WS dts fixup

### DIFF
--- a/config/boards/bananapicm4io.conf
+++ b/config/boards/bananapicm4io.conf
@@ -9,8 +9,8 @@ FULL_DESKTOP="yes"
 SERIALCON="ttyAML0"
 BOOT_LOGO="desktop"
 BOOT_FDT_FILE="amlogic/meson-g12b-bananapi-cm4-cm4io.dtb"
-BOOTBRANCH_BOARD="tag:v2023.07.02"
-BOOTPATCHDIR="v2023.07.02"
+BOOTBRANCH_BOARD="tag:v2024.01"
+BOOTPATCHDIR="v2024.01"
 
 function post_family_tweaks_bsp__bananapi_rtl_bt() {
 	if [[ -d "$SRC/packages/bsp/bananapi/rtl_bt" ]]; then

--- a/config/boards/bananapim2s.conf
+++ b/config/boards/bananapim2s.conf
@@ -9,8 +9,8 @@ FULL_DESKTOP="yes"
 SERIALCON="ttyAML0"
 BOOT_LOGO="desktop"
 BOOT_FDT_FILE="amlogic/meson-g12b-a311d-bananapi-m2s.dtb"
-BOOTBRANCH_BOARD="tag:v2023.07.02"
-BOOTPATCHDIR="v2023.07.02"
+BOOTBRANCH_BOARD="tag:v2024.01"
+BOOTPATCHDIR="v2024.01"
 
 function post_family_tweaks_bsp__bananapi_rtl_bt() {
 	if [[ -d "$SRC/packages/bsp/bananapi/rtl_bt" ]]; then

--- a/patch/kernel/archive/meson64-6.6/dt/meson-g12b-waveshare-cm4-io-base-b.dts
+++ b/patch/kernel/archive/meson64-6.6/dt/meson-g12b-waveshare-cm4-io-base-b.dts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 /*
- * Copyright (c) 2023 Patrick Yavitz <pyavitz@xxxxx.com>
+ * Copyright (c) 2024 Patrick Yavitz <pyavitz@xxxxx.com>
  */
 
 /dts-v1/;
@@ -26,8 +26,6 @@
 	fanctrl: emc2305@2f {
 		compatible = "smsc,emc2305";
 		reg = <0x2f>;
-		#address-cells = <1>;
-		#size-cells = <0>;
 		#cooling-cells = <0x02>;
 		wakeup-source;
 	};

--- a/patch/kernel/archive/meson64-6.7/dt/meson-g12b-waveshare-cm4-io-base-b.dts
+++ b/patch/kernel/archive/meson64-6.7/dt/meson-g12b-waveshare-cm4-io-base-b.dts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 /*
- * Copyright (c) 2023 Patrick Yavitz <pyavitz@xxxxx.com>
+ * Copyright (c) 2024 Patrick Yavitz <pyavitz@xxxxx.com>
  */
 
 /dts-v1/;
@@ -26,8 +26,6 @@
 	fanctrl: emc2305@2f {
 		compatible = "smsc,emc2305";
 		reg = <0x2f>;
-		#address-cells = <1>;
-		#size-cells = <0>;
 		#cooling-cells = <0x02>;
 		wakeup-source;
 	};

--- a/patch/u-boot/v2024.01/board_bananapicm4io/001-configs-bananapi-cm4-cm4io_defconfig-nvme-support.patch
+++ b/patch/u-boot/v2024.01/board_bananapicm4io/001-configs-bananapi-cm4-cm4io_defconfig-nvme-support.patch
@@ -1,0 +1,35 @@
+From 9e4305436135989881f289800bef31fd3d689fc4 Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@xxxxx.com>
+Date: Tue, 30 Jan 2024 06:06:27 -0500
+Subject: [PATCH] configs: bananapi-cm4-cm4io_defconfig: nvme support
+
+Enable NVME PCI SUPPORT.
+
+Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
+---
+ configs/bananapi-cm4-cm4io_defconfig | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/configs/bananapi-cm4-cm4io_defconfig b/configs/bananapi-cm4-cm4io_defconfig
+index 116147fc9a..2016b94bce 100644
+--- a/configs/bananapi-cm4-cm4io_defconfig
++++ b/configs/bananapi-cm4-cm4io_defconfig
+@@ -24,6 +24,7 @@ CONFIG_LEGACY_IMAGE_FORMAT=y
+ CONFIG_OF_BOARD_SETUP=y
+ # CONFIG_DISPLAY_CPUINFO is not set
+ CONFIG_MISC_INIT_R=y
++CONFIG_PCI_INIT_R=y
+ CONFIG_SYS_MAXARGS=32
+ # CONFIG_CMD_BDI is not set
+ # CONFIG_CMD_IMI is not set
+@@ -49,6 +50,7 @@ CONFIG_DM_MDIO=y
+ CONFIG_DM_MDIO_MUX=y
+ CONFIG_ETH_DESIGNWARE_MESON8B=y
+ CONFIG_MDIO_MUX_MESON_G12A=y
++CONFIG_NVME_PCI=y
+ CONFIG_PCIE_DW_MESON=y
+ CONFIG_MESON_G12A_USB_PHY=y
+ CONFIG_PINCTRL=y
+-- 
+2.39.2
+

--- a/patch/u-boot/v2024.01/board_bananapicm4io/002-configs-bananapi-cm4-cm4io_defconfig-sata-support.patch
+++ b/patch/u-boot/v2024.01/board_bananapicm4io/002-configs-bananapi-cm4-cm4io_defconfig-sata-support.patch
@@ -1,0 +1,60 @@
+From bdf6fe2c9236ff49284eaf54defa78c547fa43b9 Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@xxxxx.com>
+Date: Tue, 30 Jan 2024 06:10:07 -0500
+Subject: [PATCH] configs: bananapi-cm4-cm4io_defconfig: sata support
+
+Enable SATA BOOT SUPPORT.
+
+Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
+---
+ configs/bananapi-cm4-cm4io_defconfig | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/configs/bananapi-cm4-cm4io_defconfig b/configs/bananapi-cm4-cm4io_defconfig
+index d552f5b640..6ceb460ec1 100644
+--- a/configs/bananapi-cm4-cm4io_defconfig
++++ b/configs/bananapi-cm4-cm4io_defconfig
+@@ -17,11 +17,13 @@ CONFIG_SYS_LOAD_ADDR=0x1000000
+ CONFIG_PCI=y
+ CONFIG_DEBUG_UART=y
+ CONFIG_REMAKE_ELF=y
++CONFIG_AHCI=y
+ CONFIG_FIT=y
+ CONFIG_FIT_SIGNATURE=y
+ CONFIG_FIT_VERBOSE=y
+ CONFIG_LEGACY_IMAGE_FORMAT=y
+ CONFIG_OF_BOARD_SETUP=y
++CONFIG_SATA_BOOT=y
+ CONFIG_USE_PREBOOT=y
+ # CONFIG_DISPLAY_CPUINFO is not set
+ CONFIG_MISC_INIT_R=y
+@@ -34,6 +36,7 @@ CONFIG_CMD_GPIO=y
+ # CONFIG_CMD_LOADS is not set
+ CONFIG_CMD_MMC=y
+ CONFIG_CMD_PCI=y
++CONFIG_CMD_SATA=y
+ CONFIG_CMD_USB=y
+ CONFIG_CMD_USB_MASS_STORAGE=y
+ # CONFIG_CMD_SETEXPR is not set
+@@ -42,6 +45,9 @@ CONFIG_OF_CONTROL=y
+ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
+ CONFIG_ADC=y
+ CONFIG_SARADC_MESON=y
++CONFIG_SATA=y
++CONFIG_SCSI_AHCI=y
++CONFIG_AHCI_PCI=y
+ CONFIG_BUTTON=y
+ CONFIG_BUTTON_ADC=y
+ CONFIG_DFU_RAM=y
+@@ -60,6 +66,8 @@ CONFIG_POWER_DOMAIN=y
+ CONFIG_MESON_EE_POWER_DOMAIN=y
+ CONFIG_DM_REGULATOR=y
+ CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_SCSI=y
++CONFIG_DM_SCSI=y
+ CONFIG_DEBUG_UART_ANNOUNCE=y
+ CONFIG_DEBUG_UART_SKIP_INIT=y
+ CONFIG_MESON_SERIAL=y
+-- 
+2.39.2
+

--- a/patch/u-boot/v2024.01/board_bananapicm4io/003-HACK-meson64-boot-target-nvme.patch
+++ b/patch/u-boot/v2024.01/board_bananapicm4io/003-HACK-meson64-boot-target-nvme.patch
@@ -1,0 +1,30 @@
+From 293427d2bc690ec4a656e57f0d6d8c8c68db14aa Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@xxxxx.com>
+Date: Tue, 30 Jan 2024 06:11:13 -0500
+Subject: [PATCH] HACK: meson64 boot target nvme
+
+Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
+---
+ include/configs/meson64.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/configs/meson64.h b/include/configs/meson64.h
+index efab9a624d..57ac2e8b1a 100644
+--- a/include/configs/meson64.h
++++ b/include/configs/meson64.h
+@@ -99,11 +99,11 @@
+ #define BOOT_TARGET_DEVICES(func) \
+ 	func(ROMUSB, romusb, na)  \
+ 	func(USB_DFU, usbdfu, na)  \
++	BOOT_TARGET_NVME(func) \
+ 	func(MMC, mmc, 0) \
+ 	func(MMC, mmc, 1) \
+ 	func(MMC, mmc, 2) \
+ 	BOOT_TARGET_DEVICES_USB(func) \
+-	BOOT_TARGET_NVME(func) \
+ 	BOOT_TARGET_SCSI(func) \
+ 	func(PXE, pxe, na) \
+ 	func(DHCP, dhcp, na)
+-- 
+2.39.2
+

--- a/patch/u-boot/v2024.01/board_bananapim2s/001-bananapi-m2s-support-fixup.patch
+++ b/patch/u-boot/v2024.01/board_bananapim2s/001-bananapi-m2s-support-fixup.patch
@@ -1,0 +1,53 @@
+From 0da3cd83c43f6dc06f58326410d90b66722459d8 Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@xxxxx.com>
+Date: Tue, 30 Jan 2024 06:27:38 -0500
+Subject: [PATCH] bananapi m2s support fixup
+
+Allow meson-g12b-s922x-bananapi-m2s.dtb to be compiled.
+
+HDMI doesn't come up until handing off to the kernel, at
+which point it only displays in green and magenta. Removing
+the default *-u-boot.dtsi and adding one specific to each variant
+corrects the issue.
+
+Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
+---
+ arch/arm/dts/Makefile                                      | 1 +
+ ...boot.dtsi => meson-g12b-a311d-bananapi-m2s-u-boot.dtsi} | 0
+ arch/arm/dts/meson-g12b-s922x-bananapi-m2s-u-boot.dtsi     | 7 +++++++
+ 3 files changed, 8 insertions(+)
+ rename arch/arm/dts/{meson-g12b-bananapi-u-boot.dtsi => meson-g12b-a311d-bananapi-m2s-u-boot.dtsi} (100%)
+ create mode 100644 arch/arm/dts/meson-g12b-s922x-bananapi-m2s-u-boot.dtsi
+
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index 9d28a485be..8559c70810 100644
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -245,6 +245,7 @@ dtb-$(CONFIG_ARCH_MESON) += \
+ 	meson-g12b-odroid-n2l.dtb \
+ 	meson-g12b-odroid-n2-plus.dtb \
+ 	meson-g12b-radxa-zero2.dtb \
++	meson-g12b-s922x-bananapi-m2s.dtb \
+ 	meson-sm1-bananapi-m2-pro.dtb \
+ 	meson-sm1-bananapi-m5.dtb \
+ 	meson-sm1-khadas-vim3l.dtb \
+diff --git a/arch/arm/dts/meson-g12b-bananapi-u-boot.dtsi b/arch/arm/dts/meson-g12b-a311d-bananapi-m2s-u-boot.dtsi
+similarity index 100%
+rename from arch/arm/dts/meson-g12b-bananapi-u-boot.dtsi
+rename to arch/arm/dts/meson-g12b-a311d-bananapi-m2s-u-boot.dtsi
+diff --git a/arch/arm/dts/meson-g12b-s922x-bananapi-m2s-u-boot.dtsi b/arch/arm/dts/meson-g12b-s922x-bananapi-m2s-u-boot.dtsi
+new file mode 100644
+index 0000000000..236f2468dc
+--- /dev/null
++++ b/arch/arm/dts/meson-g12b-s922x-bananapi-m2s-u-boot.dtsi
+@@ -0,0 +1,7 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2019 BayLibre, SAS.
++ * Author: Neil Armstrong <narmstrong@baylibre.com>
++ */
++
++#include "meson-g12-common-u-boot.dtsi"
+-- 
+2.39.2
+


### PR DESCRIPTION
BananaPi CM4/M2S

Update to u-boot v2024.01
Fixup meson-g12b-waveshare-cm4-io-base-b.dts

Removed from 'fanctrl' node:
```
#address-cells = <1>;
#size-cells = <0>;
```

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
