### PR TITLE
Disable md5 packages check on unsupported distributions

### DIFF
--- a/lib/functions/rootfs/rootfs-create.sh
+++ b/lib/functions/rootfs/rootfs-create.sh
@@ -198,9 +198,12 @@ function create_new_rootfs_cache_via_debootstrap() {
 	fi
 
 	# stage: check md5 sum of installed packages. Just in case. @TODO: rpardini: this should also be done when a cache is used, not only when it is created
-	display_alert "Checking MD5 sum of installed packages" "debsums" "info"
-	declare -g if_error_detail_message="Check MD5 sum of installed packages failed"
-	chroot_sdcard debsums --silent
+	# lets check only for supported targets only unless forced
+	if [[ "${DISTRIBUTION_STATUS}" == "supported" || "${FORCE_CHECK_MD5_PACKAGES:-"no"}" == "yes" ]]; then
+		display_alert "Checking MD5 sum of installed packages" "debsums" "info"
+		declare -g if_error_detail_message="Check MD5 sum of installed packages failed"
+		chroot_sdcard debsums --silent
+	fi
 
 	# # Remove packages from packages.uninstall
 	# # @TODO: aggregation.py handling of this... if we wanted it removed in rootfs cache, why did we install it in the first place?


### PR DESCRIPTION
# Description
Unstable / testing packages sometimes contain hacks that are patching files. Fixing this in Debian Sid / Trixie

Not sure why this happens, but we certainly don't need this check in rolling releases.

```
  [🐳|🌱] Checking MD5 sum of installed packages [ debsums ]
  [🐳|🔨]   debsums: changed file /usr/sbin/start-stop-daemon (from dpkg package)
  [🐳|💥] Error 2 occurred in main shell [ at /armbian/lib/functions/logging/runners.sh:211
```

# How Has This Been Tested?

- [x] Manual run

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
