### PR TITLE
Fix compilation within docker-shell

### DIFF
--- a/lib/functions/cli/cli-docker.sh
+++ b/lib/functions/cli/cli-docker.sh
@@ -60,6 +60,17 @@ function cli_docker_run() {
 	ARMBIAN_CLI_RELAUNCH_PARAMS+=(["ARMBIAN_BUILD_UUID"]="${ARMBIAN_BUILD_UUID}") # pass down our uuid to the docker instance
 	ARMBIAN_CLI_RELAUNCH_PARAMS+=(["SKIP_LOG_ARCHIVE"]="yes")                     # launched docker instance will not cleanup logs.
 
+	# Produce the re-launch params.
+	declare -g ARMBIAN_CLI_FINAL_RELAUNCH_ARGS=()
+	declare -g ARMBIAN_CLI_FINAL_RELAUNCH_ENVS=()
+	produce_relaunch_parameters # produces ARMBIAN_CLI_FINAL_RELAUNCH_ARGS and ARMBIAN_CLI_FINAL_RELAUNCH_ENVS
+
+	# Add the relaunch envs to DOCKER_ARGS.
+	for env in "${ARMBIAN_CLI_FINAL_RELAUNCH_ENVS[@]}"; do
+		display_alert "Adding Docker env" "${env}" "debug"
+		DOCKER_ARGS+=("--env" "${env}")
+	done
+
 	case "${DOCKER_SUBCMD}" in
 		shell)
 			display_alert "Launching Docker shell" "docker-shell" "info"

--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -568,17 +568,6 @@ function docker_cli_launch() {
 		run_host_command_logged find "${SRC}/userpatches" -name ".DS_Store" -type f -delete "||" true
 	fi
 
-	# Produce the re-launch params.
-	declare -g ARMBIAN_CLI_FINAL_RELAUNCH_ARGS=()
-	declare -g ARMBIAN_CLI_FINAL_RELAUNCH_ENVS=()
-	produce_relaunch_parameters # produces ARMBIAN_CLI_FINAL_RELAUNCH_ARGS and ARMBIAN_CLI_FINAL_RELAUNCH_ENVS
-
-	# Add the relaunch envs to DOCKER_ARGS.
-	for env in "${ARMBIAN_CLI_FINAL_RELAUNCH_ENVS[@]}"; do
-		display_alert "Adding Docker env" "${env}" "debug"
-		DOCKER_ARGS+=("--env" "${env}")
-	done
-
 	display_alert "-----------------Relaunching in Docker after ${SECONDS}s------------------" "here comes the 🐳" "info"
 
 	local -i docker_build_result


### PR DESCRIPTION
# Description

Running ./compile.sh from inside of docker shell is known to be broken. The reason seems to be that armbian relaunch parameters are not exported to docker environment. Hence moving the code to set relaunch arguments from docker_cli_launch to its caller function. This seems to fix the issue. 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Ran `./compile.sh BOARD=khadas-vim4 BRANCH=legacy KERNEL_CONFIGURE=no BUILD_MINIMAL=no BUILD_DESKTOP=no RELEASE=trixie` from within docker-shell

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
