### PR TITLE
Fix armbian lightdm wallpaper path

### DIFF
--- a/packages/blobs/desktop/lightdm/slick-greeter.conf
+++ b/packages/blobs/desktop/lightdm/slick-greeter.conf
@@ -1,5 +1,5 @@
 [Greeter]
-background = /usr/share/backgrounds/lightdm/armbian03-Dre0x-Minum-dark-blurred-3840x2160.jpg
+background = /usr/share/backgrounds/armbian-lightdm/armbian03-Dre0x-Minum-dark-blurred-3840x2160.jpg
 theme-name = Numix
 icon-theme-name = Numix
 font-name = Sans 11


### PR DESCRIPTION
# Description

Fix missing lightdm wallpaper. I noticed that the directory path in slick-greeter.conf is not correct. Our wallpapers are in armbian-lightdm directory. When checked in xfce image for vim4, /usr/share/backgrounds/lightdm was missing. 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Created XFCE Jammy image for VIM4. Lightdm wallpaper is displayed correctly

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
