### PR TITLE
Fix git_ensure_safe_directory function again

### DIFF
--- a/lib/functions/general/git.sh
+++ b/lib/functions/general/git.sh
@@ -55,9 +55,9 @@ function improved_git_fetch() {
 function git_ensure_safe_directory() {
 	if [[ -n "$(command -v git)" ]]; then
 		local git_dir="$1"
-		if regular_git -C "$1" -C rev-parse --git-dir > /dev/null 2>&1; then
+		if [[ -e "$1/.git" ]]; then
 			display_alert "git: Marking all directories as safe, which should include" "$git_dir" "debug"
-			regular_git -C "$1" config --local --get safe.directory "$1" > /dev/null || regular_git -C "$1" config --local --add safe.directory "$1"
+			regular_git config --global --get safe.directory "$1" > /dev/null || regular_git config --global --add safe.directory "$1"
 		fi
 	else
 		display_alert "git not installed" "a true wonder how you got this far without git - it will be installed for you" "warn"


### PR DESCRIPTION
# Description

The command added to check whether the directory is git or not was having syntax error. Fixed the same. Also it seems adding safe-directory with local doesn't really work which actually makes sense. hence reverting to using global instead. Its still safer than before as we are not adding * and are adding the actual path of the directory

Fixes following error in the logs
```
--> (9) COMMAND: git --no-pager -C /home/flash/build-fork/cache/git-bare/kernel -C rev-parse --git-dir
   -->--> command failed with error code 128 after 0 seconds
--> (9) WARNING: stacktrace for failed command [ exit code 128:git --no-pager -C /home/flash/build-fork/cache/git-bare/kernel -C rev-parse --git-dir
                       regular_git() --> lib/functions/general/git.sh:44
         git_ensure_safe_directory() --> lib/functions/general/git.sh:58
      kernel_prepare_bare_repo_from_oras_gitball() --> lib/functions/compilation/kernel-git-oras.sh:232
                     do_with_hooks() --> lib/functions/general/extensions.sh:557
                   do_with_logging() --> lib/functions/logging/section-logging.sh:81
                    compile_kernel() --> lib/functions/compilation/kernel.sh:30
      artifact_kernel_build_from_sources() --> lib/functions/artifacts/artifact-kernel.sh:230
       artifact_build_from_sources() --> lib/functions/artifacts/artifacts-obtain.sh:34
          obtain_complete_artifact() --> lib/functions/artifacts/artifacts-obtain.sh:280
          build_artifact_for_image() --> lib/functions/artifacts/artifacts-obtain.sh:392
       main_default_build_packages() --> lib/functions/main/build-packages.sh:108
      full_build_packages_rootfs_and_image() --> lib/functions/main/default-build.sh:31
             do_with_default_build() --> lib/functions/main/default-build.sh:42
            cli_standard_build_run() --> lib/functions/cli/cli-build.sh:25
           armbian_cli_run_command() --> lib/functions/cli/utils-cli.sh:136
                    cli_entrypoint() --> lib/functions/cli/entrypoint.sh:176
                              main() --> compile.sh:50 ]
```

Also fixes #6223 

Jira reference number [AR-2041]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Ran compilation both inside and outside docker-shell. 

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-2041]: https://armbian.atlassian.net/browse/AR-2041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ