### PR TITLE
meson64: u-boot: v2024.01: bananapicm4io: `sata support fixup`

### DIFF
--- a/patch/u-boot/v2024.01/board_bananapicm4io/002-configs-bananapi-cm4-cm4io_defconfig-sata-support.patch
+++ b/patch/u-boot/v2024.01/board_bananapicm4io/002-configs-bananapi-cm4-cm4io_defconfig-sata-support.patch
@@ -1,6 +1,6 @@
-From bdf6fe2c9236ff49284eaf54defa78c547fa43b9 Mon Sep 17 00:00:00 2001
+From 5f3f93f1a32c5969b35e320d6761af257d6c0c39 Mon Sep 17 00:00:00 2001
 From: Patrick Yavitz <pyavitz@xxxxx.com>
-Date: Tue, 30 Jan 2024 06:10:07 -0500
+Date: Thu, 1 Feb 2024 14:23:22 -0500
 Subject: [PATCH] configs: bananapi-cm4-cm4io_defconfig: sata support
 
 Enable SATA BOOT SUPPORT.
@@ -11,7 +11,7 @@ Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
  1 file changed, 8 insertions(+)
 
 diff --git a/configs/bananapi-cm4-cm4io_defconfig b/configs/bananapi-cm4-cm4io_defconfig
-index d552f5b640..6ceb460ec1 100644
+index 2016b94bce..92eb446812 100644
 --- a/configs/bananapi-cm4-cm4io_defconfig
 +++ b/configs/bananapi-cm4-cm4io_defconfig
 @@ -17,11 +17,13 @@ CONFIG_SYS_LOAD_ADDR=0x1000000
@@ -25,10 +25,10 @@ index d552f5b640..6ceb460ec1 100644
  CONFIG_LEGACY_IMAGE_FORMAT=y
  CONFIG_OF_BOARD_SETUP=y
 +CONFIG_SATA_BOOT=y
- CONFIG_USE_PREBOOT=y
  # CONFIG_DISPLAY_CPUINFO is not set
  CONFIG_MISC_INIT_R=y
-@@ -34,6 +36,7 @@ CONFIG_CMD_GPIO=y
+ CONFIG_PCI_INIT_R=y
+@@ -33,6 +35,7 @@ CONFIG_CMD_GPIO=y
  # CONFIG_CMD_LOADS is not set
  CONFIG_CMD_MMC=y
  CONFIG_CMD_PCI=y
@@ -36,7 +36,7 @@ index d552f5b640..6ceb460ec1 100644
  CONFIG_CMD_USB=y
  CONFIG_CMD_USB_MASS_STORAGE=y
  # CONFIG_CMD_SETEXPR is not set
-@@ -42,6 +45,9 @@ CONFIG_OF_CONTROL=y
+@@ -41,6 +44,9 @@ CONFIG_OF_CONTROL=y
  CONFIG_SYS_RELOC_GD_ENV_ADDR=y
  CONFIG_ADC=y
  CONFIG_SARADC_MESON=y
@@ -46,7 +46,7 @@ index d552f5b640..6ceb460ec1 100644
  CONFIG_BUTTON=y
  CONFIG_BUTTON_ADC=y
  CONFIG_DFU_RAM=y
-@@ -60,6 +66,8 @@ CONFIG_POWER_DOMAIN=y
+@@ -59,6 +65,8 @@ CONFIG_POWER_DOMAIN=y
  CONFIG_MESON_EE_POWER_DOMAIN=y
  CONFIG_DM_REGULATOR=y
  CONFIG_DM_REGULATOR_FIXED=y


### PR DESCRIPTION
Fix patch fail

Problem with ->002-configs-bananapi-cm4-cm4io_defconfig-sata-support(:1) (+8/-0)[1M] {bananapi-cm4-cm4io_defconfig}<-: Failed to apply patch /armbian/patch/u-boot/v2024.01/board_bananapicm4io/002-configs-bananapi-cm4-cm4io_defconfig-sata-support.patch

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
