### PR TITLE
Adding DMA support and Overlays for H616/H618 devices

### DIFF
--- a/config/boards/orangepizero3.csc
+++ b/config/boards/orangepizero3.csc
@@ -1,7 +1,7 @@
 # Allwinner H618 quad core 1/2/4GB RAM SoC WiFi SPI USB-C
 BOARD_NAME="Orange Pi Zero3"
 BOARDFAMILY="sun50iw9"
-BOARD_MAINTAINER="viraniac"
+BOARD_MAINTAINER=""
 BOOTCONFIG="orangepi_zero3_defconfig"
 OVERLAY_PREFIX="sun50i-h616"
 BOOT_LOGO="desktop"

--- a/patch/kernel/archive/sunxi-6.1/patches.armbian/arm64-dts-sun50i-h616-Add-dma-node.patch
+++ b/patch/kernel/archive/sunxi-6.1/patches.armbian/arm64-dts-sun50i-h616-Add-dma-node.patch
@@ -1,0 +1,53 @@
+From 8cdd9309fce75995cf3068be5c7ffb65cec51cff Mon Sep 17 00:00:00 2001
+From: Gunjan Gupta <viraniac@gmail.com>
+Date: Wed, 3 Jan 2024 09:53:55 +0000
+Subject: [PATCH] arm64: dts: sun50i-h616: Add dma node
+
+---
+ arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
+index 2424a2827455..e71b79ebced8 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
+@@ -170,6 +170,18 @@ mixer0_out_tcon_top_mixer0: endpoint {
+ 			};
+ 		};
+ 
++		dma: dma-controller@3002000 {
++			compatible = "allwinner,sun50i-h6-dma";
++			reg = <0x03002000 0x1000>;
++			interrupts = <GIC_SPI 42 IRQ_TYPE_LEVEL_HIGH>;
++			clocks = <&ccu CLK_BUS_DMA>, <&ccu CLK_MBUS_DMA>;
++			clock-names = "bus", "mbus";
++			dma-channels = <16>;
++			dma-requests = <49>;
++			resets = <&ccu RST_BUS_DMA>;
++			#dma-cells = <1>;
++		};
++
+ 		gpu: gpu@1800000 {
+ 			compatible = "allwinner,sun50i-h616-mali",
+ 				     "arm,mali-bifrost";
+@@ -606,6 +618,8 @@ spi0: spi@5010000 {
+ 			interrupts = <GIC_SPI 12 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&ccu CLK_BUS_SPI0>, <&ccu CLK_SPI0>;
+ 			clock-names = "ahb", "mod";
++			dmas = <&dma 22>, <&dma 22>;
++			dma-names = "rx", "tx";
+ 			resets = <&ccu RST_BUS_SPI0>;
+ 			pinctrl-names = "default";
+ 			pinctrl-0 = <&spi0_pins>;
+@@ -621,6 +635,8 @@ spi1: spi@5011000 {
+ 			interrupts = <GIC_SPI 13 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&ccu CLK_BUS_SPI1>, <&ccu CLK_SPI1>;
+ 			clock-names = "ahb", "mod";
++			dmas = <&dma 23>, <&dma 23>;
++			dma-names = "rx", "tx";
+ 			resets = <&ccu RST_BUS_SPI1>;
+ 			pinctrl-names = "default";
+ 			pinctrl-0 = <&spi1_pins>;
+-- 
+2.34.1
+

--- a/patch/kernel/archive/sunxi-6.1/series.armbian
+++ b/patch/kernel/archive/sunxi-6.1/series.armbian
@@ -189,3 +189,4 @@
 	patches.armbian/arm64-dts-h616-add-wifi-support-for-orange-pi-zero-2.patch
 	patches.armbian/drivers-hack-for-h616-hdmi-video-output.patch
 	patches.armbian/arm64-dts-h616-add-hdmi-support-for-zero2.patch
+	patches.armbian/arm64-dts-sun50i-h616-Add-dma-node.patch

--- a/patch/kernel/archive/sunxi-6.1/series.conf
+++ b/patch/kernel/archive/sunxi-6.1/series.conf
@@ -593,3 +593,4 @@
 	patches.armbian/arm64-dts-h616-add-wifi-support-for-orange-pi-zero-2.patch
 	patches.armbian/drivers-hack-for-h616-hdmi-video-output.patch
 	patches.armbian/arm64-dts-h616-add-hdmi-support-for-zero2.patch
+	patches.armbian/arm64-dts-sun50i-h616-Add-dma-node.patch

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-H616-Add-overlays-that-are-also-compatible-with.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-H616-Add-overlays-that-are-also-compatible-with.patch
@@ -1,0 +1,166 @@
+From bcbe9ca5716942afb2a11ba1b9cbbb435d1ffa51 Mon Sep 17 00:00:00 2001
+From: Gunjan Gupta <viraniac@mgmail.com>
+Date: Thu, 1 Feb 2024 22:38:21 +0000
+Subject: [PATCH] arm64: dts: H616: Add overlays that are also compatible with
+ orange pi zero2 and zero3
+
+---
+ .../arm64/boot/dts/allwinner/overlay/Makefile |  5 ++++
+ .../allwinner/overlay/sun50i-h616-i2c2.dtso   |  8 ++++++
+ .../allwinner/overlay/sun50i-h616-i2c3.dtso   |  8 ++++++
+ .../allwinner/overlay/sun50i-h616-i2c4.dtso   |  8 ++++++
+ .../allwinner/overlay/sun50i-h616-uart2.dtso  |  8 ++++++
+ .../allwinner/overlay/sun50i-h616-uart5.dtso  |  8 ++++++
+ .../arm64/boot/dts/allwinner/sun50i-h616.dtsi | 27 +++++++++++++++++--
+ 7 files changed, 70 insertions(+), 2 deletions(-)
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c2.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c3.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c4.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-uart2.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-uart5.dtso
+
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/Makefile b/arch/arm64/boot/dts/allwinner/overlay/Makefile
+index 84711585fc86..369b2976b1bb 100644
+--- a/arch/arm64/boot/dts/allwinner/overlay/Makefile
++++ b/arch/arm64/boot/dts/allwinner/overlay/Makefile
+@@ -49,6 +49,11 @@ dtb-$(CONFIG_ARCH_SUNXI) += \
+ 	sun50i-h6-uart2.dtbo \
+ 	sun50i-h6-uart3.dtbo \
+ 	sun50i-h6-w1-gpio.dtbo \
++	sun50i-h616-i2c2.dtbo \
++	sun50i-h616-i2c3.dtbo \
++	sun50i-h616-i2c4.dtbo \
++	sun50i-h616-uart2.dtbo \
++	sun50i-h616-uart5.dtbo \
+ 	sun50i-h616-spi-spidev.dtbo \
+ 	sun50i-h616-spidev0_0.dtbo \
+ 	sun50i-h616-spidev1_0.dtbo \
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c2.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c2.dtso
+new file mode 100644
+index 000000000000..feebc9ad85fb
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c2.dtso
+@@ -0,0 +1,8 @@
++/dts-v1/;
++/plugin/;
++
++&i2c2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c2_ph_pins>;
++	status = "okay";
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c3.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c3.dtso
+new file mode 100644
+index 000000000000..bb212d3c66da
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c3.dtso
+@@ -0,0 +1,8 @@
++/dts-v1/;
++/plugin/;
++
++&i2c3 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c3_ph_pins>;
++	status = "okay";
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c4.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c4.dtso
+new file mode 100644
+index 000000000000..8fbcc658b22c
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c4.dtso
+@@ -0,0 +1,8 @@
++/dts-v1/;
++/plugin/;
++
++&i2c4 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c4_ph_pins>;
++	status = "okay";
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-uart2.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-uart2.dtso
+new file mode 100644
+index 000000000000..6a6806906972
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-uart2.dtso
+@@ -0,0 +1,8 @@
++/dts-v1/;
++/plugin/;
++
++&uart2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart2_pins>;
++	status = "okay";
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-uart5.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-uart5.dtso
+new file mode 100644
+index 000000000000..6a6806906972
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-uart5.dtso
+@@ -0,0 +1,8 @@
++/dts-v1/;
++/plugin/;
++
++&uart5 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart5_pins>;
++	status = "okay";
++};
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
+index 52bd986abcdb..157b6736770e 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
+@@ -319,11 +319,21 @@ i2c0_pins: i2c0-pins {
+ 				function = "i2c0";
+ 			};
+ 
++			i2c2_ph_pins: i2c2-ph-pins {
++				pins = "PH2", "PH3";
++				function = "i2c2";
++			};
++
+ 			i2c3_ph_pins: i2c3-ph-pins {
+ 				pins = "PH4", "PH5";
+ 				function = "i2c3";
+ 			};
+ 
++			i2c4_ph_pins: i2c4-ph-pins {
++				pins = "PH6", "PH7";
++				function = "i2c4";
++			};
++
+ 			ir_rx_pin: ir-rx-pin {
+ 				pins = "PH10";
+ 				function = "ir_rx";
+@@ -374,7 +384,6 @@ spi0_cs0_pin: spi0-cs0-pin {
+ 				function = "spi0";
+ 			};
+ 
+-			/omit-if-no-ref/
+ 			spi1_pins: spi1-pins {
+ 				pins = "PH6", "PH7", "PH8";
+ 				function = "spi1";
+@@ -402,6 +410,21 @@ uart1_rts_cts_pins: uart1-rts-cts-pins {
+ 				pins = "PG8", "PG9";
+ 				function = "uart1";
+ 			};
++
++			uart2_pins: uart2-pins {
++				pins = "PH5", "PH6";
++				function = "uart2";
++			};
++
++			uart2_rts_cts_pins: uart2-rts-cts-pins {
++				pins = "PH7", "PH8";
++				function = "uart2";
++			};
++
++			uart5_pins: uart5-pins {
++				pins = "PH2", "PH3";
++				function = "uart5";
++			};
+ 		};
+ 
+ 		gic: interrupt-controller@3021000 {
+-- 
+2.34.1
+

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-sun50i-h616-Add-dma-node.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-sun50i-h616-Add-dma-node.patch
@@ -1,0 +1,53 @@
+From 8cdd9309fce75995cf3068be5c7ffb65cec51cff Mon Sep 17 00:00:00 2001
+From: Gunjan Gupta <viraniac@gmail.com>
+Date: Wed, 3 Jan 2024 09:53:55 +0000
+Subject: [PATCH] arm64: dts: sun50i-h616: Add dma node
+
+---
+ arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
+index 2424a2827455..e71b79ebced8 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
+@@ -170,6 +170,18 @@ mixer0_out_tcon_top_mixer0: endpoint {
+ 			};
+ 		};
+ 
++		dma: dma-controller@3002000 {
++			compatible = "allwinner,sun50i-h6-dma";
++			reg = <0x03002000 0x1000>;
++			interrupts = <GIC_SPI 42 IRQ_TYPE_LEVEL_HIGH>;
++			clocks = <&ccu CLK_BUS_DMA>, <&ccu CLK_MBUS_DMA>;
++			clock-names = "bus", "mbus";
++			dma-channels = <16>;
++			dma-requests = <49>;
++			resets = <&ccu RST_BUS_DMA>;
++			#dma-cells = <1>;
++		};
++
+ 		gpu: gpu@1800000 {
+ 			compatible = "allwinner,sun50i-h616-mali",
+ 				     "arm,mali-bifrost";
+@@ -606,6 +618,8 @@ spi0: spi@5010000 {
+ 			interrupts = <GIC_SPI 12 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&ccu CLK_BUS_SPI0>, <&ccu CLK_SPI0>;
+ 			clock-names = "ahb", "mod";
++			dmas = <&dma 22>, <&dma 22>;
++			dma-names = "rx", "tx";
+ 			resets = <&ccu RST_BUS_SPI0>;
+ 			pinctrl-names = "default";
+ 			pinctrl-0 = <&spi0_pins>;
+@@ -621,6 +635,8 @@ spi1: spi@5011000 {
+ 			interrupts = <GIC_SPI 13 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&ccu CLK_BUS_SPI1>, <&ccu CLK_SPI1>;
+ 			clock-names = "ahb", "mod";
++			dmas = <&dma 23>, <&dma 23>;
++			dma-names = "rx", "tx";
+ 			resets = <&ccu RST_BUS_SPI1>;
+ 			pinctrl-names = "default";
+ 			pinctrl-0 = <&spi1_pins>;
+-- 
+2.34.1
+

--- a/patch/kernel/archive/sunxi-6.6/series.armbian
+++ b/patch/kernel/archive/sunxi-6.6/series.armbian
@@ -195,3 +195,4 @@
 	patches.armbian/drivers-hack-for-h616-hdmi-video-output.patch
 	patches.armbian/arm64-dts-h616-add-hdmi-support-for-zero2-and-zero3.patch
 	patches.armbian/arm64-dts-sun50i-h616-Add-dma-node.patch
+	patches.armbian/arm64-dts-H616-Add-overlays-that-are-also-compatible-with.patch

--- a/patch/kernel/archive/sunxi-6.6/series.armbian
+++ b/patch/kernel/archive/sunxi-6.6/series.armbian
@@ -194,3 +194,4 @@
 	patches.armbian/arm64-dts-sun50i-h618-orangepi-zero3-Enable-GPU-mali.patch
 	patches.armbian/drivers-hack-for-h616-hdmi-video-output.patch
 	patches.armbian/arm64-dts-h616-add-hdmi-support-for-zero2-and-zero3.patch
+	patches.armbian/arm64-dts-sun50i-h616-Add-dma-node.patch

--- a/patch/kernel/archive/sunxi-6.6/series.conf
+++ b/patch/kernel/archive/sunxi-6.6/series.conf
@@ -464,3 +464,4 @@
 	patches.armbian/drivers-hack-for-h616-hdmi-video-output.patch
 	patches.armbian/arm64-dts-h616-add-hdmi-support-for-zero2-and-zero3.patch
 	patches.armbian/arm64-dts-sun50i-h616-Add-dma-node.patch
+	patches.armbian/arm64-dts-H616-Add-overlays-that-are-also-compatible-with.patch

--- a/patch/kernel/archive/sunxi-6.6/series.conf
+++ b/patch/kernel/archive/sunxi-6.6/series.conf
@@ -463,3 +463,4 @@
 	patches.armbian/arm64-dts-sun50i-h618-orangepi-zero3-Enable-GPU-mali.patch
 	patches.armbian/drivers-hack-for-h616-hdmi-video-output.patch
 	patches.armbian/arm64-dts-h616-add-hdmi-support-for-zero2-and-zero3.patch
+	patches.armbian/arm64-dts-sun50i-h616-Add-dma-node.patch

--- a/patch/kernel/archive/sunxi-6.7/patches.armbian/arm64-dts-H616-Add-overlays-that-are-also-compatible-with.patch
+++ b/patch/kernel/archive/sunxi-6.7/patches.armbian/arm64-dts-H616-Add-overlays-that-are-also-compatible-with.patch
@@ -1,0 +1,166 @@
+From bcbe9ca5716942afb2a11ba1b9cbbb435d1ffa51 Mon Sep 17 00:00:00 2001
+From: Gunjan Gupta <viraniac@mgmail.com>
+Date: Thu, 1 Feb 2024 22:38:21 +0000
+Subject: [PATCH] arm64: dts: H616: Add overlays that are also compatible with
+ orange pi zero2 and zero3
+
+---
+ .../arm64/boot/dts/allwinner/overlay/Makefile |  5 ++++
+ .../allwinner/overlay/sun50i-h616-i2c2.dtso   |  8 ++++++
+ .../allwinner/overlay/sun50i-h616-i2c3.dtso   |  8 ++++++
+ .../allwinner/overlay/sun50i-h616-i2c4.dtso   |  8 ++++++
+ .../allwinner/overlay/sun50i-h616-uart2.dtso  |  8 ++++++
+ .../allwinner/overlay/sun50i-h616-uart5.dtso  |  8 ++++++
+ .../arm64/boot/dts/allwinner/sun50i-h616.dtsi | 27 +++++++++++++++++--
+ 7 files changed, 70 insertions(+), 2 deletions(-)
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c2.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c3.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c4.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-uart2.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-uart5.dtso
+
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/Makefile b/arch/arm64/boot/dts/allwinner/overlay/Makefile
+index 84711585fc86..369b2976b1bb 100644
+--- a/arch/arm64/boot/dts/allwinner/overlay/Makefile
++++ b/arch/arm64/boot/dts/allwinner/overlay/Makefile
+@@ -49,6 +49,11 @@ dtb-$(CONFIG_ARCH_SUNXI) += \
+ 	sun50i-h6-uart2.dtbo \
+ 	sun50i-h6-uart3.dtbo \
+ 	sun50i-h6-w1-gpio.dtbo \
++	sun50i-h616-i2c2.dtbo \
++	sun50i-h616-i2c3.dtbo \
++	sun50i-h616-i2c4.dtbo \
++	sun50i-h616-uart2.dtbo \
++	sun50i-h616-uart5.dtbo \
+ 	sun50i-h616-spi-spidev.dtbo \
+ 	sun50i-h616-spidev0_0.dtbo \
+ 	sun50i-h616-spidev1_0.dtbo \
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c2.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c2.dtso
+new file mode 100644
+index 000000000000..feebc9ad85fb
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c2.dtso
+@@ -0,0 +1,8 @@
++/dts-v1/;
++/plugin/;
++
++&i2c2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c2_ph_pins>;
++	status = "okay";
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c3.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c3.dtso
+new file mode 100644
+index 000000000000..bb212d3c66da
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c3.dtso
+@@ -0,0 +1,8 @@
++/dts-v1/;
++/plugin/;
++
++&i2c3 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c3_ph_pins>;
++	status = "okay";
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c4.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c4.dtso
+new file mode 100644
+index 000000000000..8fbcc658b22c
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c4.dtso
+@@ -0,0 +1,8 @@
++/dts-v1/;
++/plugin/;
++
++&i2c4 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c4_ph_pins>;
++	status = "okay";
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-uart2.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-uart2.dtso
+new file mode 100644
+index 000000000000..6a6806906972
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-uart2.dtso
+@@ -0,0 +1,8 @@
++/dts-v1/;
++/plugin/;
++
++&uart2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart2_pins>;
++	status = "okay";
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-uart5.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-uart5.dtso
+new file mode 100644
+index 000000000000..6a6806906972
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-uart5.dtso
+@@ -0,0 +1,8 @@
++/dts-v1/;
++/plugin/;
++
++&uart5 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart5_pins>;
++	status = "okay";
++};
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
+index 52bd986abcdb..157b6736770e 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
+@@ -319,11 +319,21 @@ i2c0_pins: i2c0-pins {
+ 				function = "i2c0";
+ 			};
+ 
++			i2c2_ph_pins: i2c2-ph-pins {
++				pins = "PH2", "PH3";
++				function = "i2c2";
++			};
++
+ 			i2c3_ph_pins: i2c3-ph-pins {
+ 				pins = "PH4", "PH5";
+ 				function = "i2c3";
+ 			};
+ 
++			i2c4_ph_pins: i2c4-ph-pins {
++				pins = "PH6", "PH7";
++				function = "i2c4";
++			};
++
+ 			ir_rx_pin: ir-rx-pin {
+ 				pins = "PH10";
+ 				function = "ir_rx";
+@@ -374,7 +384,6 @@ spi0_cs0_pin: spi0-cs0-pin {
+ 				function = "spi0";
+ 			};
+ 
+-			/omit-if-no-ref/
+ 			spi1_pins: spi1-pins {
+ 				pins = "PH6", "PH7", "PH8";
+ 				function = "spi1";
+@@ -402,6 +410,21 @@ uart1_rts_cts_pins: uart1-rts-cts-pins {
+ 				pins = "PG8", "PG9";
+ 				function = "uart1";
+ 			};
++
++			uart2_pins: uart2-pins {
++				pins = "PH5", "PH6";
++				function = "uart2";
++			};
++
++			uart2_rts_cts_pins: uart2-rts-cts-pins {
++				pins = "PH7", "PH8";
++				function = "uart2";
++			};
++
++			uart5_pins: uart5-pins {
++				pins = "PH2", "PH3";
++				function = "uart5";
++			};
+ 		};
+ 
+ 		gic: interrupt-controller@3021000 {
+-- 
+2.34.1
+

--- a/patch/kernel/archive/sunxi-6.7/patches.armbian/arm64-dts-sun50i-h616-Add-dma-node.patch
+++ b/patch/kernel/archive/sunxi-6.7/patches.armbian/arm64-dts-sun50i-h616-Add-dma-node.patch
@@ -1,0 +1,53 @@
+From 8cdd9309fce75995cf3068be5c7ffb65cec51cff Mon Sep 17 00:00:00 2001
+From: Gunjan Gupta <viraniac@gmail.com>
+Date: Wed, 3 Jan 2024 09:53:55 +0000
+Subject: [PATCH] arm64: dts: sun50i-h616: Add dma node
+
+---
+ arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
+index 2424a2827455..e71b79ebced8 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
+@@ -170,6 +170,18 @@ mixer0_out_tcon_top_mixer0: endpoint {
+ 			};
+ 		};
+ 
++		dma: dma-controller@3002000 {
++			compatible = "allwinner,sun50i-h6-dma";
++			reg = <0x03002000 0x1000>;
++			interrupts = <GIC_SPI 42 IRQ_TYPE_LEVEL_HIGH>;
++			clocks = <&ccu CLK_BUS_DMA>, <&ccu CLK_MBUS_DMA>;
++			clock-names = "bus", "mbus";
++			dma-channels = <16>;
++			dma-requests = <49>;
++			resets = <&ccu RST_BUS_DMA>;
++			#dma-cells = <1>;
++		};
++
+ 		gpu: gpu@1800000 {
+ 			compatible = "allwinner,sun50i-h616-mali",
+ 				     "arm,mali-bifrost";
+@@ -606,6 +618,8 @@ spi0: spi@5010000 {
+ 			interrupts = <GIC_SPI 12 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&ccu CLK_BUS_SPI0>, <&ccu CLK_SPI0>;
+ 			clock-names = "ahb", "mod";
++			dmas = <&dma 22>, <&dma 22>;
++			dma-names = "rx", "tx";
+ 			resets = <&ccu RST_BUS_SPI0>;
+ 			pinctrl-names = "default";
+ 			pinctrl-0 = <&spi0_pins>;
+@@ -621,6 +635,8 @@ spi1: spi@5011000 {
+ 			interrupts = <GIC_SPI 13 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&ccu CLK_BUS_SPI1>, <&ccu CLK_SPI1>;
+ 			clock-names = "ahb", "mod";
++			dmas = <&dma 23>, <&dma 23>;
++			dma-names = "rx", "tx";
+ 			resets = <&ccu RST_BUS_SPI1>;
+ 			pinctrl-names = "default";
+ 			pinctrl-0 = <&spi1_pins>;
+-- 
+2.34.1
+

--- a/patch/kernel/archive/sunxi-6.7/series.armbian
+++ b/patch/kernel/archive/sunxi-6.7/series.armbian
@@ -195,3 +195,4 @@
 	patches.armbian/drivers-hack-for-h616-hdmi-video-output.patch
 	patches.armbian/arm64-dts-h616-add-hdmi-support-for-zero2-and-zero3.patch
 	patches.armbian/arm64-dts-sun50i-h616-Add-dma-node.patch
+	patches.armbian/arm64-dts-H616-Add-overlays-that-are-also-compatible-with.patch

--- a/patch/kernel/archive/sunxi-6.7/series.armbian
+++ b/patch/kernel/archive/sunxi-6.7/series.armbian
@@ -194,3 +194,4 @@
 	patches.armbian/arm64-dts-sun50i-h618-orangepi-zero3-Enable-GPU-mali.patch
 	patches.armbian/drivers-hack-for-h616-hdmi-video-output.patch
 	patches.armbian/arm64-dts-h616-add-hdmi-support-for-zero2-and-zero3.patch
+	patches.armbian/arm64-dts-sun50i-h616-Add-dma-node.patch

--- a/patch/kernel/archive/sunxi-6.7/series.conf
+++ b/patch/kernel/archive/sunxi-6.7/series.conf
@@ -516,3 +516,4 @@
 	patches.armbian/arm64-dts-sun50i-h618-orangepi-zero3-Enable-GPU-mali.patch
 	patches.armbian/drivers-hack-for-h616-hdmi-video-output.patch
 	patches.armbian/arm64-dts-h616-add-hdmi-support-for-zero2-and-zero3.patch
+	patches.armbian/arm64-dts-sun50i-h616-Add-dma-node.patch

--- a/patch/kernel/archive/sunxi-6.7/series.conf
+++ b/patch/kernel/archive/sunxi-6.7/series.conf
@@ -517,3 +517,4 @@
 	patches.armbian/drivers-hack-for-h616-hdmi-video-output.patch
 	patches.armbian/arm64-dts-h616-add-hdmi-support-for-zero2-and-zero3.patch
 	patches.armbian/arm64-dts-sun50i-h616-Add-dma-node.patch
+	patches.armbian/arm64-dts-H616-Add-overlays-that-are-also-compatible-with.patch


### PR DESCRIPTION
# Description

Added DMA support for H616/H618 devices. The dma node is taken from orange pi's kernel. I noticed they also made modifications to the dma driver, but that was exactly the same as H6. Hence I have simply changed the compatible string to use the same compatible string as H6 reducing the need to change dma driver. Also added overlays for interfaces available on 26-pin header of orangepi zero2 and zero3. The 26 pin headers can provide upto 3 i2c interfaces, 2 pwm, 2 uarts and 1 spi with 2 chip selects. I have added overlays for the 3 i2c and 2 uart interfaces. I didn't saw the pwm suppport yet in the kernel and hence have skipped the same. For spi, the existing spidev1_0 and spidev1_1 seems to apply fine.

As part of this PR, I am also stepping down as the maintainer. As a wip device needs a maintainer, I have moved the device to be csc instead. Any further development for this device should be handled by the community.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested patch applies and both kernel builds fine.
- [X] Tested all the overlays applies correctly on 6.7 kernel and their corresponding device nodes appear in /dev. I don't have any peripherals to attach and hence detail testing is not performed.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
