### PR TITLE
rk35xx-legacy: 0000.patching_config.yaml with incremental: true for rk 5.10 vendor kernel

### DIFF
--- a/lib/tools/common/patching_config.py
+++ b/lib/tools/common/patching_config.py
@@ -16,9 +16,10 @@ class PatchingAutoPatchMakefileDTConfig:
 	def __init__(self, data: dict):
 		self.config_var: str = data.get("config-var", None)
 		self.directory: str = data.get("directory", None)
+		self.incremental: bool = not not data.get("incremental", False)
 
 	def __str__(self):
-		return f"PatchingAutoPatchMakefileDTConfig(config-var={self.config_var}, directory={self.directory})"
+		return f"PatchingAutoPatchMakefileDTConfig(config-var={self.config_var}, directory={self.directory}, incremental={self.incremental})"
 
 
 class PatchingDTSDirectoryConfig:

--- a/patch/kernel/rk35xx-legacy/0000.patching_config.yaml
+++ b/patch/kernel/rk35xx-legacy/0000.patching_config.yaml
@@ -1,0 +1,31 @@
+config:
+
+  # Just some info stuff; not used by the patching scripts
+  name: rk35xx-5.10
+  kind: kernel
+  type: vendor # or: vendor
+  branch: rk-5.10-rkr6
+  last-known-good-tag: v5.10.160
+
+  # .dts files in these directories will be copied as-is to the build tree; later ones overwrite earlier ones.
+  # This is meant to provide a way to "add a board DTS" without having to null-patch them in.
+  dts-directories:
+    - { source: "dt", target: "arch/arm64/boot/dts/rockchip" }
+
+  # the Makefile in each of these directories will be magically patched to include the dts files copied
+  #  or patched-in; overlay subdir will be included "-y" if it exists.
+  # No more Makefile patching needed, yay!
+  # "incremental: true" changes the logic of the Makefile re-writing to only add the
+  #                     dts-directories's *.dts files to existing Makefile instead of
+  #                     full rewrite from *.dts in the dt dir at the end of patching.
+  auto-patch-dt-makefile:
+    - { incremental: true, directory: "arch/arm64/boot/dts/rockchip", config-var: "CONFIG_ARCH_ROCKCHIP" }
+
+  # configuration for when applying patches to git / auto-rewriting patches (development cycle helpers)
+  patches-to-git:
+    do-not-commit-files:
+      - "MAINTAINERS" # constant churn, drop them. sorry.
+      - "Documentation/devicetree/bindings/arm/rockchip.yaml" # constant churn, conflicts on every bump, drop it. sorry.
+    do-not-commit-regexes: # Python-style regexes
+      - "^arch/([a-zA-Z0-9]+)/boot/dts/([a-zA-Z0-9]+)/Makefile$" # ignore DT Makefile patches, we've an auto-patcher now
+


### PR DESCRIPTION
#### rk35xx-legacy: 0000.patching_config.yaml with incremental: true for rk 5.10 vendor kernel

- patching: support 'incremental' Makefile auto-patching, for vendor kernels
  - without incremental: true:
    - we replace the DT Makefile based on *.dts at the DT directory after all patching/copying is done
    - overlay target is added if overlays present
  - with incremental: true:
    - we parse the Makefile, parse the DTs being built, and only add .dts's we have added from 'dt' directory
    - overlays target are not added; we assume smth else already added them
- rk35xx-legacy: 0000.patching_config.yaml with incremental: true for rk 5.10 vendor kernel
  - allows users to put .dts files bare in `userpatches/kernel/rk35xx-legacy/dt`
  - important: everyone is still invited to send the DTs to https://github.com/armbian/linux-rockchip directly
    - where yes, they'll have to patch the Makefile there as normal