### PR TITLE
prevent armbian-install from running on aml-s9xx-box

### DIFF
--- a/config/boards/aml-s9xx-box.tvb
+++ b/config/boards/aml-s9xx-box.tvb
@@ -13,11 +13,16 @@ BOOT_LOGO="desktop"
 SRC_CMDLINE='rootflags=data=writeback console=ttyAML0,115200n8 console=tty0'
 
 
-function post_family_tweaks__config_aml-s9xx-box_bsp() {
+function post_family_tweaks_bsp__config_aml-s9xx-box_bsp() {
 
     display_alert "$BOARD" "Installing bsp files" "info"
 
-    cp -r $SRC/packages/bsp/aml-s9xx-box/boot $SDCARD
-    install -m 755 $SRC/packages/bsp/aml-s9xx-box/root/install-aml.sh $SDCARD/root
-    install -m 644 $SRC/packages/bsp/aml-s9xx-box/root/fstab.template $SDCARD/root
+    cp -r "${SRC}"/packages/bsp/aml-s9xx-box/boot "${destination}"
+    install -D -m 744 "${SRC}"/packages/bsp/aml-s9xx-box/root/install-aml.sh "${destination}"/root/install-aml.sh
+    install -m 644 "${SRC}"/packages/bsp/aml-s9xx-box/root/fstab.template "${destination}"/root/fstab.template
+
+    display_alert "${BOARD}" "Removing armbian-install" "info"
+
+    rm "${destination}"/usr/sbin/armbian-install
+
 }

--- a/packages/bsp/common/usr/sbin/armbian-install
+++ b/packages/bsp/common/usr/sbin/armbian-install
@@ -44,11 +44,6 @@ BOOTLOADER="${CWD}/${DEVICE_TYPE}/bootloader"
 [ ! -d ${BOOTLOADER} ] && echo -e "### Board installation issue: Directory ${BOOTLOADER} does not exist or is not accessible!\n" && exit 1
 FIRSTSECTOR=32768
 
-if [[ $BOARD == 'aml-s9xx-box' ]]; then
-# aml-s9xx-box not supported by this script will make box unbootable if run
-exit 0
-fi
-
 #recognize_root
 root_uuid=$(sed -e 's/^.*root=//' -e 's/ .*$//' < /proc/cmdline)
 root_partition=$(blkid | tr -d '":' | grep "${root_uuid}" | awk '{print $1}')

--- a/packages/bsp/common/usr/sbin/armbian-install
+++ b/packages/bsp/common/usr/sbin/armbian-install
@@ -44,6 +44,11 @@ BOOTLOADER="${CWD}/${DEVICE_TYPE}/bootloader"
 [ ! -d ${BOOTLOADER} ] && echo -e "### Board installation issue: Directory ${BOOTLOADER} does not exist or is not accessible!\n" && exit 1
 FIRSTSECTOR=32768
 
+if [[ $BOARD == 'aml-s9xx-box' ]]; then
+# aml-s9xx-box not supported by this script will make box unbootable if run
+exit 0
+fi
+
 #recognize_root
 root_uuid=$(sed -e 's/^.*root=//' -e 's/ .*$//' < /proc/cmdline)
 root_partition=$(blkid | tr -d '":' | grep "${root_uuid}" | awk '{print $1}')


### PR DESCRIPTION
aml-s9xx-box uses the u-boot shipped with the TV Box instead of installing
a new u-boot.  Because of this, armbian-install will make the box unbootable 
if it is run to install to emmc.  This change prevents running armbian-install 
on aml-s9xx-box boards

Changes to be committed:
	modified:   packages/bsp/common/usr/sbin/armbian-install

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Built aml-s9xx-box and verified armbian-install is no longer present
- [X] Confirmed that armbian-config runs correctly in the absence of armbian-install

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
