### PR TITLE
Fix broken uboot compilation for boards with multiple targets

### DIFF
--- a/config/sources/families/meson-s4t7.conf
+++ b/config/sources/families/meson-s4t7.conf
@@ -97,6 +97,13 @@ function fetch_sources_tools__meson_s4t7_download_uboot_toolchain() {
 function build_custom_uboot__meson_s4t7_build_custom_uboot() {
 	: "${KHADAS_BOARD_ID:?KHADAS_BOARD_ID not set}"
 	display_alert "$BOARD" "building fip" "info"
+
+	patch_uboot_target
+
+	if [[ $CREATE_PATCHES == yes ]]; then
+		return 0
+	fi
+
 	export CROSS_COMPILE="aarch64-elf-"
 	rm -rf "${PWD}"/fip/_tmp
 	run_host_command_logged bash fip/mk_script.sh "${KHADAS_BOARD_ID}" "${PWD}"


### PR DESCRIPTION
# Description

Fix regression caused by my previous PR #6248 that broke compilation for clearfog uboot. This PR refactors the patching logic to a separate function thereby making it easy to use outside uboot.sh.

During the process I also noticed that uboot_prepatch_version variable being initialized as part of that logic was not really being used anywhere. Hence removed the same.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Test build for meson-s4t7
- [X] Test build for clearfog

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
