### PR TITLE
meson-s4t7: make it possible to uninstall armbian-bsp-cli package

### DIFF
--- a/config/sources/families/meson-s4t7.conf
+++ b/config/sources/families/meson-s4t7.conf
@@ -186,3 +186,14 @@ function post_family_tweaks_bsp__add_fan_service() {
 		run_host_command_logged cp -R "${SRC}"/packages/bsp/meson-s4t7/${BOARD}/* "${destination}"/
 	fi
 }
+
+function meson_s4t7_board_side_bsp_cli_postrm() { # not run here
+	if [[ remove == "$1" ]] || [[ abort-install == "$1" ]]; then
+		cp /usr/share/initramfs-tools/modules /etc/initramfs-tools/modules
+	fi
+}
+
+function post_family_tweaks_bsp__add_postrm_hook() {
+	display_alert "$BOARD" "Adding postrm hook to restore /etc/initramfs-tools/modules file" "info"
+	postrm_functions+=(meson_s4t7_board_side_bsp_cli_postrm)
+}

--- a/lib/functions/bsp/armbian-bsp-cli-deb.sh
+++ b/lib/functions/bsp/armbian-bsp-cli-deb.sh
@@ -69,8 +69,10 @@ function compile_armbian-bsp-cli() {
 	mkdir -p "${destination}"/DEBIAN
 	cd "${destination}" || exit_with_error "Failed to cd to ${destination}"
 
-	# array of code to be included in postinst (more than base and finish)
+	# array of code to be included in preinst, postinst, prerm and postrm scripts (more than default code)
+	declare -a preinst_functions=()
 	declare -a postinst_functions=()
+	declare -a postrm_functions=()
 
 	declare -a extra_description=()
 	[[ "${EXTRA_BSP_NAME}" != "" ]] && extra_description+=("(variant '${EXTRA_BSP_NAME}')")
@@ -187,7 +189,8 @@ function compile_armbian-bsp-cli() {
 		*family_tweaks_bsp overrrides what is in the config, so give it a chance to override the family tweaks*
 		This should be implemented by the config to tweak the BSP, after the board or family has had the chance to.
 		You can write to `$destination` here and it will be packaged.
-		You can also append to the `postinst_functions` array, and the _content_ of those functions will be added to the postinst script.
+		You can also append to the `preinst_functions`, `postinst_functions` and `postrm` array, and the _content_
+		of those functions will be added to the preinst, postinst and postrm scripts respectively.
 	POST_FAMILY_TWEAKS_BSP
 
 	# Render the postinst/postrm/etc
@@ -195,11 +198,11 @@ function compile_armbian-bsp-cli() {
 	# This is never run in build context; instead, it's source code is dumped inside a file that is packaged.
 	# It is done this way so we get shellcheck and formatting instead of a huge heredoc.
 	### preinst
-	artifact_package_hook_helper_board_side_functions "preinst" board_side_bsp_cli_preinst
+	artifact_package_hook_helper_board_side_functions "preinst" board_side_bsp_cli_preinst  "${preinst_functions[@]}"
 	unset board_side_bsp_cli_preinst
 
 	### postrm
-	artifact_package_hook_helper_board_side_functions "postrm" board_side_bsp_cli_postrm
+	artifact_package_hook_helper_board_side_functions "postrm" board_side_bsp_cli_postrm  "${postrm_functions[@]}"
 	unset board_side_bsp_cli_postrm
 
 	### postinst -- a bit more complex, extendable via postinst_functions which can be customized in hook above


### PR DESCRIPTION
# Description

Fixed issue that prevented armbian-bsp-cli package for meson-s4t7 family to uninstall because of the added /etc/initramfs-tools/modules file. As this required custom code to be added in the postrm script of the package, I have added support for the same in armbian-bsp-cli package similar to how things worked for postinst script. 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested that armbian-bsp-cli-vim4-legacy package uninstalls fine.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
