### PR TITLE
meson-s4t7: disable lcd nodes if lcd is not attached

### DIFF
--- a/config/bootscripts/boot-meson-s4t7.cmd
+++ b/config/bootscripts/boot-meson-s4t7.cmd
@@ -44,6 +44,20 @@ load ${devtype} ${devnum} ${fdt_addr_r} ${prefix}dtb/${fdtfile}
 fdt addr ${fdt_addr_r}
 fdt resize 65536
 
+if test "${mipi_lcd_exist}" = "0"; then
+	fdt set /lcd status disabled
+	fdt set /lcd1 status disabled
+	fdt set /lcd2 status disabled
+	fdt set /soc/apb4@fe000000/i2c@6c000/gt9xx@14 status disabled
+	fdt set /soc/apb4@fe000000/i2c@6c000/ft5336@38 status disabled
+else
+	if test "${panel_type}" = "mipi_1"; then
+		fdt set /drm-subsystem fbdev_sizes <1920 1200 1920 2400 32>
+	else
+		fdt set /drm-subsystem fbdev_sizes <1080 1920 1080 3840 32>
+	fi
+fi
+
 for overlay_file in ${overlays}; do
 	if load ${devtype} ${devnum} ${scriptaddr} ${prefix}dtb/amlogic/overlay/${overlay_prefix}-${overlay_file}.dtbo; then
 		echo "Applying kernel provided DT overlay ${overlay_prefix}-${overlay_file}.dtbo"


### PR DESCRIPTION
# Description

Turns out the Khadas u-boot has some code hidden deep within [pxe.c](https://github.com/khadas/u-boot/blob/khadas-vims-v2019.01/cmd/pxe.c#L1035-L1049) file to enable and disable lcd screen. As we don't use extlinux for vim1s and vim4, that doesn't get executed for us leaving the device to detect ghost screens. Hence copied the code to bootscript in order to disable the lcd screens when they are not really present. This makes the vim4 and vim1s a lot more responsive. Also fixes issue where we can't login to gnome because login screen was being rendered on non-existent lcd screen.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested new build on vim4. Only hdmi was getting detected as expected as I don't have any lcd screens attached

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
