### PR TITLE
Meson s4t7 aka Khadas vim4/vim1s fixes

### DIFF
--- a/config/bootscripts/boot-meson-s4t7.cmd
+++ b/config/bootscripts/boot-meson-s4t7.cmd
@@ -44,6 +44,20 @@ load ${devtype} ${devnum} ${fdt_addr_r} ${prefix}dtb/${fdtfile}
 fdt addr ${fdt_addr_r}
 fdt resize 65536
 
+if test "${mipi_lcd_exist}" = "0"; then
+	fdt set /lcd status disabled
+	fdt set /lcd1 status disabled
+	fdt set /lcd2 status disabled
+	fdt set /soc/apb4@fe000000/i2c@6c000/gt9xx@14 status disabled
+	fdt set /soc/apb4@fe000000/i2c@6c000/ft5336@38 status disabled
+else
+	if test "${panel_type}" = "mipi_1"; then
+		fdt set /drm-subsystem fbdev_sizes <1920 1200 1920 2400 32>
+	else
+		fdt set /drm-subsystem fbdev_sizes <1080 1920 1080 3840 32>
+	fi
+fi
+
 for overlay_file in ${overlays}; do
 	if load ${devtype} ${devnum} ${scriptaddr} ${prefix}dtb/amlogic/overlay/${overlay_prefix}-${overlay_file}.dtbo; then
 		echo "Applying kernel provided DT overlay ${overlay_prefix}-${overlay_file}.dtbo"

--- a/config/sources/families/meson-s4t7.conf
+++ b/config/sources/families/meson-s4t7.conf
@@ -186,3 +186,14 @@ function post_family_tweaks_bsp__add_fan_service() {
 		run_host_command_logged cp -R "${SRC}"/packages/bsp/meson-s4t7/${BOARD}/* "${destination}"/
 	fi
 }
+
+function meson_s4t7_board_side_bsp_cli_postrm() { # not run here
+	if [[ remove == "$1" ]] || [[ abort-install == "$1" ]]; then
+		cp /usr/share/initramfs-tools/modules /etc/initramfs-tools/modules
+	fi
+}
+
+function post_family_tweaks_bsp__add_postrm_hook() {
+	display_alert "$BOARD" "Adding postrm hook to restore /etc/initramfs-tools/modules file" "info"
+	postrm_functions+=(meson_s4t7_board_side_bsp_cli_postrm)
+}

--- a/config/sources/families/meson-s4t7.conf
+++ b/config/sources/families/meson-s4t7.conf
@@ -197,3 +197,11 @@ function post_family_tweaks_bsp__add_postrm_hook() {
 	display_alert "$BOARD" "Adding postrm hook to restore /etc/initramfs-tools/modules file" "info"
 	postrm_functions+=(meson_s4t7_board_side_bsp_cli_postrm)
 }
+
+function post_family_tweaks__disable_chrony_wait_service() {
+	# if chrony-wait service is there, disable the same
+	if [[ -f "${SDCARD}"/lib/systemd/system/chrony-wait.service ]]; then
+		chroot_sdcard systemctl disable chrony-wait.service || true
+		chroot_sdcard systemctl mask chrony-wait.service
+	fi
+}

--- a/lib/functions/bsp/armbian-bsp-cli-deb.sh
+++ b/lib/functions/bsp/armbian-bsp-cli-deb.sh
@@ -69,8 +69,10 @@ function compile_armbian-bsp-cli() {
 	mkdir -p "${destination}"/DEBIAN
 	cd "${destination}" || exit_with_error "Failed to cd to ${destination}"
 
-	# array of code to be included in postinst (more than base and finish)
+	# array of code to be included in preinst, postinst, prerm and postrm scripts (more than default code)
+	declare -a preinst_functions=()
 	declare -a postinst_functions=()
+	declare -a postrm_functions=()
 
 	declare -a extra_description=()
 	[[ "${EXTRA_BSP_NAME}" != "" ]] && extra_description+=("(variant '${EXTRA_BSP_NAME}')")
@@ -187,7 +189,8 @@ function compile_armbian-bsp-cli() {
 		*family_tweaks_bsp overrrides what is in the config, so give it a chance to override the family tweaks*
 		This should be implemented by the config to tweak the BSP, after the board or family has had the chance to.
 		You can write to `$destination` here and it will be packaged.
-		You can also append to the `postinst_functions` array, and the _content_ of those functions will be added to the postinst script.
+		You can also append to the `preinst_functions`, `postinst_functions` and `postrm` array, and the _content_
+		of those functions will be added to the preinst, postinst and postrm scripts respectively.
 	POST_FAMILY_TWEAKS_BSP
 
 	# Render the postinst/postrm/etc
@@ -195,11 +198,11 @@ function compile_armbian-bsp-cli() {
 	# This is never run in build context; instead, it's source code is dumped inside a file that is packaged.
 	# It is done this way so we get shellcheck and formatting instead of a huge heredoc.
 	### preinst
-	artifact_package_hook_helper_board_side_functions "preinst" board_side_bsp_cli_preinst
+	artifact_package_hook_helper_board_side_functions "preinst" board_side_bsp_cli_preinst  "${preinst_functions[@]}"
 	unset board_side_bsp_cli_preinst
 
 	### postrm
-	artifact_package_hook_helper_board_side_functions "postrm" board_side_bsp_cli_postrm
+	artifact_package_hook_helper_board_side_functions "postrm" board_side_bsp_cli_postrm  "${postrm_functions[@]}"
 	unset board_side_bsp_cli_postrm
 
 	### postinst -- a bit more complex, extendable via postinst_functions which can be customized in hook above


### PR DESCRIPTION
# Description

1. Removed lcd node when screen is not attached. Turns out the Khadas u-boot has some code hidden deep within [pxe.c](https://github.com/khadas/u-boot/blob/khadas-vims-v2019.01/cmd/pxe.c#L1035-L1049) file to enable and disable lcd screen. As we don't use extlinux for vim1s and vim4, that doesn't get executed for us leaving the device to detect ghost screens. Hence copied the code to bootscript in order to disable the lcd screens when they are not really present. This makes the vim4 and vim1s a lot more responsive. Also fixes issue where we can't login to gnome because login screen was being rendered on non-existent lcd screen.
2. Fixed issue that prevented armbian-bsp-cli package for meson-s4t7 family to uninstall because of the added /etc/initramfs-tools/modules file. As this required custom code to be added in the postrm script of the package, I have added support for the same in armbian-bsp-cli package similar to how things worked for postinst script.
3. Disabled chrony-wait service as it on meson-s4t7 devices as it was causing firstlogin to get stuck for 4 minutes. I had to mask it as its not really enabled when hook executes and gets enabled sometime later (not really sure when, was not able to track that down). 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested with Debian gnome bookworm image on VIM4

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
