### PR TITLE
remove slick greater on environments on gdm3 and sddm

### DIFF
--- a/config/desktop/bullseye/environments/budgie/config_base/packages
+++ b/config/desktop/bullseye/environments/budgie/config_base/packages
@@ -128,7 +128,6 @@ profile-sync-daemon
 pulseaudio-module-bluetooth
 redshift
 samba
-slick-greeter
 smbclient
 software-properties-gtk
 spice-vdagent

--- a/config/desktop/bullseye/environments/gnome/config_base/packages
+++ b/config/desktop/bullseye/environments/gnome/config_base/packages
@@ -40,7 +40,6 @@ printer-driver-all
 profile-sync-daemon
 pulseaudio
 pulseaudio-module-bluetooth
-slick-greeter
 software-properties-gtk
 synaptic
 system-config-printer

--- a/config/desktop/bullseye/environments/kde-plasma/config_base/packages
+++ b/config/desktop/bullseye/environments/kde-plasma/config_base/packages
@@ -91,7 +91,6 @@ profile-sync-daemon
 pulseaudio-module-bluetooth
 redshift
 samba
-slick-greeter
 smbclient
 software-properties-gtk
 spice-vdagent

--- a/config/desktop/buster/environments/gnome/config_base/packages
+++ b/config/desktop/buster/environments/gnome/config_base/packages
@@ -41,7 +41,6 @@ printer-driver-all
 profile-sync-daemon
 pulseaudio
 pulseaudio-module-bluetooth
-slick-greeter
 software-properties-gtk
 synaptic
 system-config-printer

--- a/config/desktop/focal/environments/budgie/config_base/packages
+++ b/config/desktop/focal/environments/budgie/config_base/packages
@@ -147,7 +147,6 @@ profile-sync-daemon
 pulseaudio-module-bluetooth
 redshift
 samba
-slick-greeter
 smbclient
 software-properties-gtk
 spice-vdagent

--- a/config/desktop/focal/environments/gnome/config_base/packages
+++ b/config/desktop/focal/environments/gnome/config_base/packages
@@ -41,7 +41,6 @@ printer-driver-all
 profile-sync-daemon
 pulseaudio
 pulseaudio-module-bluetooth
-slick-greeter
 software-properties-gtk
 synaptic
 system-config-printer

--- a/config/desktop/focal/environments/kde-plasma/config_base/packages
+++ b/config/desktop/focal/environments/kde-plasma/config_base/packages
@@ -113,7 +113,6 @@ pulseaudio-module-bluetooth
 plasma-workspace-wayland
 redshift
 samba
-slick-greeter
 smbclient
 software-properties-gtk
 spice-vdagent

--- a/config/desktop/jammy/environments/budgie/config_base/packages
+++ b/config/desktop/jammy/environments/budgie/config_base/packages
@@ -145,7 +145,6 @@ profile-sync-daemon
 pulseaudio-module-bluetooth
 redshift
 samba
-slick-greeter
 smbclient
 software-properties-gtk
 spice-vdagent

--- a/config/desktop/jammy/environments/gnome/config_base/packages
+++ b/config/desktop/jammy/environments/gnome/config_base/packages
@@ -41,7 +41,6 @@ printer-driver-all
 profile-sync-daemon
 pulseaudio
 pulseaudio-module-bluetooth
-slick-greeter
 software-properties-gtk
 synaptic
 system-config-printer

--- a/config/desktop/jammy/environments/kde-plasma/config_base/packages
+++ b/config/desktop/jammy/environments/kde-plasma/config_base/packages
@@ -115,7 +115,6 @@ pulseaudio-module-bluetooth
 plasma-workspace-wayland
 redshift
 samba
-slick-greeter
 smbclient
 software-properties-gtk
 spice-vdagent

--- a/config/desktop/sid/environments/budgie/config_base/packages
+++ b/config/desktop/sid/environments/budgie/config_base/packages
@@ -123,7 +123,6 @@ pulseaudio-module-bluetooth
 qalculate-gtk
 redshift
 samba
-slick-greeter
 smbclient
 software-properties-gtk
 spice-vdagent

--- a/config/desktop/sid/environments/gnome/config_base/packages
+++ b/config/desktop/sid/environments/gnome/config_base/packages
@@ -40,7 +40,6 @@ printer-driver-all
 profile-sync-daemon
 pulseaudio
 pulseaudio-module-bluetooth
-slick-greeter
 software-properties-gtk
 synaptic
 system-config-printer

--- a/config/desktop/sid/environments/kde-plasma/config_base/packages
+++ b/config/desktop/sid/environments/kde-plasma/config_base/packages
@@ -90,7 +90,6 @@ pulseaudio-module-bluetooth
 plasma-workspace-wayland
 redshift
 samba
-slick-greeter
 smbclient
 software-properties-gtk
 spice-vdagent


### PR DESCRIPTION
# Description

Removed slick-greeter on desktop environments that have gdm3 or sddm installed. Installing slick greeter installs back lightdm as well. On vim4 during first boot with gnome images, lightdm was getting started immediately on boot hiding the firstlogin setup screen. This fixes the same

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested bookworm gnome image on vim4

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
