### PR TITLE
Fix systemd on bookworm and later starting all services on firstboot

### DIFF
--- a/config/sources/families/meson-s4t7.conf
+++ b/config/sources/families/meson-s4t7.conf
@@ -197,11 +197,3 @@ function post_family_tweaks_bsp__add_postrm_hook() {
 	display_alert "$BOARD" "Adding postrm hook to restore /etc/initramfs-tools/modules file" "info"
 	postrm_functions+=(meson_s4t7_board_side_bsp_cli_postrm)
 }
-
-function post_family_tweaks__disable_chrony_wait_service() {
-	# if chrony-wait service is there, disable the same
-	if [[ -f "${SDCARD}"/lib/systemd/system/chrony-wait.service ]]; then
-		chroot_sdcard systemctl disable chrony-wait.service || true
-		chroot_sdcard systemctl mask chrony-wait.service
-	fi
-}

--- a/lib/functions/rootfs/rootfs-create.sh
+++ b/lib/functions/rootfs/rootfs-create.sh
@@ -234,8 +234,11 @@ function create_new_rootfs_cache_via_debootstrap() {
 	run_host_command_logged echo "nameserver $NAMESERVER" ">" "${SDCARD}"/etc/resolv.conf
 
 	# Remove `machine-id` (https://www.freedesktop.org/software/systemd/man/machine-id.html)
-	# Note: This will mark machine `firstboot`
-	run_host_command_logged echo "uninitialized" ">" "${SDCARD}/etc/machine-id"
+	# Note: As we don't use systemd-firstboot.service functionality, we make it empty to prevent services
+	# from starting up automatically on first boot on system version 2.50+. If someone is using the same,
+	# please reinitialize this to uninitialized. Do note that systemd will start all services then by
+	# default and that has to be handled in by setting system presets.
+	run_host_command_logged echo -n ">" "${SDCARD}/etc/machine-id"
 	run_host_command_logged rm -v "${SDCARD}/var/lib/dbus/machine-id"
 
 	# Mask `systemd-firstboot.service` which will prompt locale, timezone and root-password too early.


### PR DESCRIPTION
# Description

On bookworm, and also possibly on newer version of ubuntu, systemd starts all of the services present on first boot. Making the /etc/machine-id file empty ensures that machine id is still initialized on first-boot, while other services are not started automatically. This also seems to be observed by alex3d as well as reported in #6264 . 

This also makes the previous hack of masking chrony-wait.service in meson-s4t7 family unnecessary and hence I have reverted that change.

Jira reference number [AR-2051], [AR-2054]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested on vim1s bookworm and jammy image. machine-id is reinitialized, but no extra service is started.

# Checklist:

- [X] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-2051]: https://armbian.atlassian.net/browse/AR-2051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AR-2054]: https://armbian.atlassian.net/browse/AR-2054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ