### PR TITLE
Fix failure on purging armbian-bsp-cli package

### DIFF
--- a/packages/bsp/common/etc/apt/apt.conf.d/02-armbian-postupdate
+++ b/packages/bsp/common/etc/apt/apt.conf.d/02-armbian-postupdate
@@ -1,1 +1,1 @@
-DPkg::Post-Invoke {"/usr/lib/armbian/armbian-apt-updates";};
+DPkg::Post-Invoke {"test -x /usr/lib/armbian/armbian-apt-updates && /usr/lib/armbian/armbian-apt-updates || true";};


### PR DESCRIPTION
# Description

As per the title

Jira reference number [AR-1987]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested purging armbian-bsp-cli package on UEFI-x86 image

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-1987]: https://armbian.atlassian.net/browse/AR-1987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ