### PR TITLE
RFC: Add functionality to freeze git resources

### DIFF
--- a/config/sources/git_sources.json
+++ b/config/sources/git_sources.json
@@ -1,0 +1,202 @@
+[
+  {
+    "source": "https://github.com/armbian/firmware",
+    "branch": "master",
+    "sha1": "6b6f053f6089e08dd2a675cda1ec813de2e842e2"
+  },
+  {
+    "source": "https://github.com/armbian/config",
+    "branch": "master",
+    "sha1": "fb171f9634d3c855ac135ead10c65f7aac59c12c"
+  },
+  {
+    "source": "https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git",
+    "branch": "main",
+    "sha1": "fbef4d381e3d0143427e1a8c924be8e738c0fc2d"
+  },
+  {
+    "source": "https://github.com/starfive-tech/linux",
+    "branch": "JH7110_VisionFive2_devel",
+    "sha1": "06ad134b6efeb393868e300058752ecfbf7258d1"
+  },
+  {
+    "source": "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git",
+    "branch": "linux-6.6.y",
+    "sha1": "eb3e299184cc4f40d4bd84fda269b3a20ddcff80"
+  },
+  {
+    "source": "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git",
+    "branch": "linux-6.1.y",
+    "sha1": "f1bb70486c9c11d7e2d55240d4557f9fc575fbac"
+  },
+  {
+    "source": "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git",
+    "branch": "linux-6.2.y",
+    "sha1": "46df6964c1a9eb72027710f626cb1c6bfb5d58c9"
+  },
+  {
+    "source": "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git",
+    "branch": "linux-6.7.y",
+    "sha1": "18d179e11910a53ef98791eabc410d5abcfa377e"
+  },
+  {
+    "source": "https://github.com/armbian/linux-rockchip.git",
+    "branch": "rk-5.10-rkr6",
+    "sha1": "f6c51fb62ed48897d359dcdb04578004a68169b3"
+  },
+  {
+    "source": "https://gitlab.collabora.com/hardware-enablement/rockchip-3588/linux.git",
+    "branch": "rk3588-v6.7",
+    "sha1": "b07290444a7fb5cf56a5200d2bad7f927e77e8b8"
+  },
+  {
+    "source": "https://github.com/khadas/linux.git",
+    "branch": "khadas-vims-5.15.y",
+    "sha1": "325ac1bbba2d857e3c103d23412ade471fdd8373"
+  },
+  {
+    "source": "https://github.com/khadas/common_drivers",
+    "branch": "khadas-vims-5.15.y",
+    "sha1": "68f0856b5fb80cb9c17b53ec367ff8d3c1ff142a"
+  },
+  {
+    "source": "https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel",
+    "branch": "ti-linux-6.1.y",
+    "sha1": "2233af66faf7b81b6c286285e50cda5595dc410d"
+  },
+  {
+    "source": "https://github.com/bigtreetech/u-boot.git",
+    "branch": "v2023.07-cb1",
+    "sha1": "272cd1ca1e11962087d94cd4dc5db3733b2b3ad7"
+  },
+  {
+    "source": "https://github.com/bigtreetech/linux.git",
+    "branch": "linux-6.1.y-cb1",
+    "sha1": "f33ca29a323571460e56167c986a52c19a3f1e01"
+  },
+  {
+    "source": "https://github.com/SolidRun/u-boot.git",
+    "branch": "v2018.01-solidrun-imx6",
+    "sha1": "5b6bc28ead0674ed9c9b7afa35f35828aad07cda"
+  },
+  {
+    "source": "https://github.com/functionland/u-boot.git",
+    "branch": "next-dev",
+    "sha1": "46da2bfe5068535caf919a36c6fcc5a7e744a04b"
+  },
+  {
+    "source": "https://github.com/radxa/u-boot.git",
+    "branch": "next-dev",
+    "sha1": "52701b71a875a315b16d7383536be19d044c6a63"
+  },
+  {
+    "source": "https://github.com/stvhay/u-boot.git",
+    "branch": "rockchip-rk3588-unified",
+    "sha1": "2f6e967dc901ae570f522d1b47309e7c34acf542"
+  },
+  {
+    "source": "https://github.com/radxa/u-boot.git",
+    "branch": "stable-4.19-rock3",
+    "sha1": "c55987146f4f9b20f7cb2f917ca88300419afe8d"
+  },
+  {
+    "source": "https://github.com/chainsx/thead-u-boot",
+    "branch": "extlinux",
+    "sha1": "990e122d26d1ef94f4e0e1bbf5d7df58e8393eee"
+  },
+  {
+    "source": "https://github.com/chainsx/thead-kernel",
+    "branch": "th1520",
+    "sha1": "a76d97e234b6613fc20a3dcbfc99128fe9b05e7a"
+  },
+  {
+    "source": "https://github.com/hardkernel/u-boot.git",
+    "branch": "odroidxu4-v2017.05",
+    "sha1": "42ac93dcfbbb8a08c2bdc02e19f96eb35a81891a"
+  },
+  {
+    "source": "https://github.com/hardkernel/linux",
+    "branch": "odroidxu4-6.1.y",
+    "sha1": "39395b11c5c42292575a53d3566d965378a81368"
+  },
+  {
+    "source": "https://github.com/orangepi-xunlong/u-boot-orangepi.git",
+    "branch": "v2017.09-rk3588",
+    "sha1": "752ac3f2fdcfe9427ca8868d95025aacd48fc00b"
+  },
+  {
+    "source": "https://github.com/orangepi-xunlong/u-boot-orangepi.git",
+    "branch": "v2018.05-sun50iw9",
+    "sha1": "2807819ec387107020dc0cd97bb0b2487a3d0714"
+  },
+  {
+    "source": "https://github.com/orangepi-xunlong/linux-orangepi.git",
+    "branch": "orange-pi-4.9-sun50iw9",
+    "sha1": "0cd0547ea405b84b5b60fbc92978ac1bc2b68055"
+  },
+  {
+    "source": "https://github.com/150balbes/u-boot-rk",
+    "branch": "rk35xx",
+    "sha1": "1776a2ace31f490c34a4dc4f13db7d3611c3555f"
+  },
+  {
+    "source": "https://github.com/raspberrypi/linux",
+    "branch": "rpi-6.1.y",
+    "sha1": "77fc1fbcb5c013329af9583307dd1ff3cd4752aa"
+  },
+  {
+    "source": "https://github.com/raspberrypi/linux",
+    "branch": "rpi-6.6.y",
+    "sha1": "5c67103f944ce7ab7e90ec04994ff0bad4dd6bfb"
+  },
+  {
+    "source": "https://github.com/raspberrypi/linux",
+    "branch": "rpi-6.7.y",
+    "sha1": "7e63f5a10fdf4adb28bcdb20e8e68a89678e89eb"
+  },
+  {
+    "source": "https://github.com/150balbes/u-boot-rk",
+    "branch": "rk356x",
+    "sha1": "d4d2e85f6836cf24f08e422520ebb273e2379952"
+  },
+  {
+    "source": "https://github.com/150balbes/u-boot-rk",
+    "branch": "rk3588",
+    "sha1": "1133c25725b07bfa27f2eeef26a3af262296fcbf"
+  },
+  {
+    "source": "https://github.com/steev/linux.git",
+    "branch": "lenovo-x13s-linux-6.6.y",
+    "sha1": "0d6a5d6312e4ad69b18d699c48ee93a9ba564dfb"
+  },
+  {
+    "source": "https://github.com/jglathe/linux_ms_dev_kit.git",
+    "branch": "jg/wdk2023-gunyah-6.7-rc6",
+    "sha1": "401bea57d6b96f440142b9039d483c671c4a9587"
+  },
+  {
+    "source": "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git",
+    "branch": "linux-5.15.y",
+    "sha1": "6139f2a02fe0ac7a08389b4eb786e0c659039ddd"
+  },
+  {
+    "source": "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git",
+    "branch": "linux-4.19.y",
+    "sha1": "b060cfd3f707ad3c8ae8322e1b149ba7e2cf33e0"
+  },
+  {
+    "source": "https://github.com/SolidRun/u-boot",
+    "branch": "v2018.01-solidrun-a38x",
+    "sha1": "a8004c1f1112ca2f867badccce5a76f052034853"
+  },
+  {
+    "source": "https://github.com/piter75/rockchip-u-boot.git",
+    "branch": "rockpis-next-dev",
+    "sha1": "02e49ecd27c15f06d01b4ab8202175be7be9e4eb"
+  },
+  {
+    "source": "https://github.com/piter75/rockchip-kernel",
+    "branch": "rockpis-develop-4.4",
+    "sha1": "6c923e306e11a9fa60bae4c319bdb0da9ba38f08"
+  }
+]

--- a/lib/functions/general/git-ref2info.sh
+++ b/lib/functions/general/git-ref2info.sh
@@ -75,6 +75,30 @@ function memoized_git_ref_to_info() {
 		exit_with_error "Failed to fetch SHA1 of '${MEMO_DICT[GIT_SOURCE]}' '${ref_type}' '${ref_name}' - make sure it's correct"
 	fi
 
+	if [[ ${ref_type} == "branch" ]]; then
+		{
+			flock -x 5
+			flock -x 6
+
+			[[ -s "${SRC}"/output/git_sources.json ]] || echo '[]' >&5
+			jq --arg source "${MEMO_DICT[GIT_SOURCE]}" \
+				--arg branch "${ref_name}" \
+				--arg sha1 "${sha1}" \
+				"if (map(select(.source == \$source and .branch == \$branch))| length) !=0 then \
+					(.[]|select(.source == \$source and .branch == \$branch)).sha1 |= \$sha1 \
+				else \
+					. + [{\"source\": \$source, \"branch\": \$branch, \"sha1\": \$sha1}] \
+				end" /dev/fd/5 >&6
+			cat /dev/fd/6 >"${SRC}"/output/git_sources.json
+		} 5<>"${SRC}"/output/git_sources.json 6<>"${SRC}"/output/git_sources.json.new
+	fi
+
+	if [[ -f "${SRC}"/config/sources/git_sources.json && ${ref_type} == "branch" ]]; then
+		cached_revision=$(jq --raw-output '.[] | select(.source == "'${MEMO_DICT[GIT_SOURCE]}'" and .branch == "'$ref_name'") |.sha1' "${SRC}"/config/sources/git_sources.json)
+		display_alert "Found cached git version" "${cached_revision}" "info"
+		[[ -z "${cached_revision}" ]] || sha1=${cached_revision}
+	fi
+
 	MEMO_DICT+=(["SHA1"]="${sha1}")
 
 	if [[ "${2}" == "include_makefile_body" ]]; then

--- a/lib/functions/general/git.sh
+++ b/lib/functions/general/git.sh
@@ -252,6 +252,11 @@ function fetch_from_repo() {
 		esac
 	fi
 
+	if [[ -f "${SRC}"/config/sources/git_sources.json && $ref_type == "branch" ]]; then
+		cached_revision=$(jq --raw-output '.[] | select(.source == "'$url'" and .branch == "'$ref_name'") |.sha1' "${SRC}"/config/sources/git_sources.json)
+		[[ -z "${cached_revision}" ]] || fetched_revision=${cached_revision}
+	fi
+
 	if [[ "${do_checkout:-"yes"}" == "yes" ]]; then
 		display_alert "git checking out revision SHA" "${fetched_revision}" "git"
 		regular_git checkout -f -q "${fetched_revision}" # Return the files that are tracked by git to the initial state.


### PR DESCRIPTION
# Description

The idea is to generate `output/git_sources.json` file that will contain url, branch and commit hash combo. The easiest way to generate file for all devices is to run `./compile.sh targets`. Then at the time of release we will copy the `output/git_sources.json` file to `config/sources/git_sources.json`. Once the file is copied, the hash information from the file will be used to fetch resources for git repositories where branches are specified instead of tags or commits.

There can be other ways to do this as well. I am just too tired to experiment more on the same. Raising it to be a communication starter. 

I have also added the json file that I have generated today. I think it can be used to freeze sources for 24.02 release. Hence I have raised this PR again v24.02 branch

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Tested `output/git_sources.json` file generation using `./compile.sh targets` command
- [ ]  Copied generated file to config/sources and modified it to use a different commit hash for 6.6 kernel. Then tested that kernel is being built from that hash instead of the latest available 6.6 kernel.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
