### PR TITLE
Add SK-AM68 board support

### DIFF
--- a/config/boards/sk-am68.conf
+++ b/config/boards/sk-am68.conf
@@ -1,0 +1,15 @@
+# TI SK-AM68 dual core 16GB 8TOPS GBE USB3 OSPI DisplayPort HDMI
+
+BOARD_NAME="SK-AM68"
+BOARDFAMILY="k3"
+BOARD_MAINTAINER="3V3RYONE"
+BOOTCONFIG="j721s2_evm_a72_defconfig"
+BOOTFS_TYPE="fat"
+BOOT_FDT_FILE="ti/k3-am68-sk-base-board.dts"
+TIBOOT3_BOOTCONFIG="j721s2_evm_r5_defconfig"
+TIBOOT3_FILE="tiboot3-j721s2-hs-fs-evm.bin"
+DEFAULT_CONSOLE="serial"
+KERNEL_TARGET="current,edge"
+SERIALCON="ttyS2"
+ATF_BOARD="generic"
+ATF_K3_USART_OFFSET="K3_USART=0x8"

--- a/config/sources/families/k3.conf
+++ b/config/sources/families/k3.conf
@@ -34,7 +34,7 @@ case "${BRANCH}" in
 esac
 
 ATF_PLAT="k3"
-ATF_TARGET_MAP="PLAT=$ATF_PLAT TARGET_BOARD=$ATF_BOARD DEBUG=1 bl31;;build/$ATF_PLAT/$ATF_BOARD/debug/bl31.bin:bl31.bin"
+ATF_TARGET_MAP="PLAT=$ATF_PLAT TARGET_BOARD=$ATF_BOARD DEBUG=1 ${ATF_K3_USART_OFFSET} bl31;;build/$ATF_PLAT/$ATF_BOARD/debug/bl31.bin:bl31.bin"
 
 UBOOT_TARGET_MAP="BL31=bl31.bin TEE=bl31.bin BINMAN_INDIRS=${SRC}/cache/sources/ti-linux-firmware all;;tiboot3.bin ${SYSFW_FILE:+sysfw.itb} tispl.bin u-boot.img"
 


### PR DESCRIPTION
# Description

This PR adds support for the Texas Instruments SK-AM68 board.

Notable features of SK-AM68 board:
- 16GB LPDDR4‐4266 with support for inline error correction code (ECC)
- DisplayPort 4K resolution with MST support and HDMI
- Two CSI-2 ports compatible with Raspberry Pi
- 8 TOPS deep-learning performance and hardware-accelerated edge AI 
- Three USB 3.0 Type A ports, one USB 3.0 Type C port
- Gigabit Ethernet and 4x CAN-FD Headers
- One M.2 key M connector

Further details like features, schematics and purchase links can be found on the board page: [SK-AM68](https://www.ti.com/tool/SK-AM68)

# How Has This Been Tested?
First, we verified that the changes introduced do not deprecate any existing board support by:
- [x] Build and boot SK-AM62B Jammy CLI/Standard on Edge(v6.6) kernel
- [x] Build and boot SK-AM64B Jammy CLI/Standard on Current(v6.1) and Edge(v6.6) kernels
- [x] Build and boot SK-TDA4VM Jammy CLI/Standard on Current(v6.1) and Edge(v6.6) kernels

Further, the functionalities of new boards were tested by:
- [x] Build and boot SK-AM68 Jammy CLI/Standard on Current(v6.1) and Edge(v6.6) kernels
- [x]  Gbit Ethernet works
- [x]  USB 3.0 ports work
- [x] HDMI works

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
