### PR TITLE
Fix OPi5plus hym8563 pinctrls and poweroff support

### DIFF
--- a/patch/kernel/rockchip-rk3588-edge/0034-arm64-dts-fix-rtc-add-poweroff-support-Orange-Pi-5-Plus.patch
+++ b/patch/kernel/rockchip-rk3588-edge/0034-arm64-dts-fix-rtc-add-poweroff-support-Orange-Pi-5-Plus.patch
@@ -1,0 +1,57 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: John Doe <john.doe@somewhere.on.planet>
+Date: Mon, 29 Jan 2024 12:51:13 +0100
+Subject: Patching kernel rockchip-rk3588 files
+ arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-plus.dts
+
+Signed-off-by: John Doe <john.doe@somewhere.on.planet>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-plus.dts | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-plus.dts b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-plus.dts
+index 88bfce6237db..70cc6bd5a0af 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-plus.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-plus.dts
+@@ -462,11 +462,11 @@ &pcie3x4 {
+ };
+ 
+ &pinctrl {
+ 	hym8563 {
+ 		hym8563_int: hym8563-int {
+-			rockchip,pins = <0 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
++			rockchip,pins = <0 RK_PB0 RK_FUNC_GPIO &pcfg_pull_up>;
+ 		};
+ 	};
+ 
+ 	leds {
+ 		blue_led_pin: blue-led {
+@@ -572,10 +572,12 @@ pmic@0 {
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&pmic_pins>, <&rk806_dvs1_null>,
+ 			    <&rk806_dvs2_null>, <&rk806_dvs3_null>;
+ 		spi-max-frequency = <1000000>;
+ 
++		system-power-controller;
++
+ 		vcc1-supply = <&vcc5v0_sys>;
+ 		vcc2-supply = <&vcc5v0_sys>;
+ 		vcc3-supply = <&vcc5v0_sys>;
+ 		vcc4-supply = <&vcc5v0_sys>;
+ 		vcc5-supply = <&vcc5v0_sys>;
+@@ -592,11 +594,11 @@ pmic@0 {
+ 
+ 		gpio-controller;
+ 		#gpio-cells = <2>;
+ 
+ 		rk806_dvs1_null: dvs1-null-pins {
+-			pins = "gpio_pwrctrl2";
++			pins = "gpio_pwrctrl1";
+ 			function = "pin_fun0";
+ 		};
+ 
+ 		rk806_dvs2_null: dvs2-null-pins {
+ 			pins = "gpio_pwrctrl2";
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+


### PR DESCRIPTION
# Description

This patch fixes the high interrupt issue on the Orange Pi5 Plus. Forum discussion available here. https://forum.armbian.com/topic/33360-orangepi-5-plus-rtc-hym8563-irq-issue/

The patch also adds `poweroff` support. Right now the Orange Pi 5 Plus just reboots when `poweroff` or `shutdown -h now` is executed.

Third fix of the patch is to correct `gpio_pwrctrl1` typo.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Build command `./compile.sh BOARD=orangepi5-plus BRANCH=edge RELEASE=trixie KERNEL_CONFIGURE=no BUILD_MINIMAL=yes BUILD_DESKTOP=no COMPRESS_OUTPUTIMAGE=img BOOTSIZE=512`
- [x] Booted the image and went through the first-run wizard
- [x] Checked the system via `top` and `procinfo` and monitored the cpu usage and interrupts

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
