### PR TITLE
artifact-uboot: include BOOTCONFIG in u-boot artifact version hash

### DIFF
--- a/lib/functions/artifacts/artifact-uboot.sh
+++ b/lib/functions/artifacts/artifact-uboot.sh
@@ -90,9 +90,11 @@ function artifact_uboot_prepare_version() {
 	hash_hooks_and_functions="$(echo "${hash_hooks}" "${hash_uboot_functions}" | sha256sum | cut -d' ' -f1)"
 	declare hash_hooks_and_functions_short="${hash_hooks_and_functions:0:${short_hash_size}}"
 
+	display_alert "BOOTCONFIG: ${BOOTCONFIG}" "BOOTCONFIG: ${BOOTCONFIG}" "debug"
+
 	# Hash variables that affect the build and package of u-boot
 	declare -a vars_to_hash=(
-		"BASE_VAR_REBUILD_2"                                      # Change this to force a full rebuild of all uboot's
+		"${BOOTCONFIG:-"no_bootconfig"}"
 		"${BOOTDELAY}" "${UBOOT_DEBUGGING}" "${UBOOT_TARGET_MAP}" # general for all families
 		"${BOOT_SCENARIO}" "${BOOT_SUPPORT_SPI}" "${BOOT_SOC}"    # rockchip stuff, sorry.
 		"${DDR_BLOB}" "${BL31_BLOB}" "${MINILOADER_BLOB}"         # More rockchip stuff, even more sorry.


### PR DESCRIPTION
#### artifact-uboot: include BOOTCONFIG in u-boot artifact version hash

- artifact-uboot: include BOOTCONFIG in u-boot artifact version hash
  - HOW did we get this far without this?
  - should cause rebuild of all u-boots, hopefully