### PR TITLE
rk3318: enable uboot gpio command

### DIFF
--- a/patch/u-boot/u-boot-rockchip64/board_rk3318-box/rk3318-box-add-defconfig.patch
+++ b/patch/u-boot/u-boot-rockchip64/board_rk3318-box/rk3318-box-add-defconfig.patch
@@ -3,7 +3,7 @@ new file mode 100644
 index 00000000..b6a038f7
 --- /dev/null
 +++ b/configs/rk3318-box_defconfig
-@@ -0,0 +1,121 @@
+@@ -0,0 +1,123 @@
 +CONFIG_ARM=y
 +CONFIG_ARCH_ROCKCHIP=y
 +CONFIG_SYS_TEXT_BASE=0x00200000
@@ -125,3 +125,5 @@ index 00000000..b6a038f7
 +CONFIG_BUTTON=y
 +CONFIG_BUTTON_ADC=y
 +CONFIG_CMD_BUTTON=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_GPIO_READ=y


### PR DESCRIPTION
# Description

Enable uboot gpio command. This would allow to set up rk3318-box'es LED display in custom uboot script. For example, to show "boot", this snippet can be added (gpio pins and letter codes should be adjusted for different STB/LCD models):
```
  FD650_MODE_WRCMD='0 1 0 0 1 0 0 0'
  DISPON='0 0 0 0 0 0 0 1'
  FD655_BASE_ADDR='0 1 1 0 0 1 1 0'
  Z='0 0 0 0 0 0 0 0'
  B='0 1 1 0 0 1 1 1'
  O='0 1 1 0 0 0 1 1'
  T='0 1 0 0 0 1 1 1'
  setenv d0 gpio clear C22
  setenv d1 gpio set C22
  setenv LC gpio clear C19
  setenv HC gpio set C19
  setenv send 'run d0 LC; for b in $cmd; do run d$b HC LC; done; run HC d1'
  cmd="$FD650_MODE_WRCMD 1 $DISPON 1" run send
  cmd="$FD655_BASE_ADDR 1 $Z 1 $B 1 $O 1 $O 1 $T 1" run send
```


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Compile and boot rk3318-box

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
