### PR TITLE
vim1s/vim4 - fix intermittent boot issues when booting from uhs sd card

### DIFF
--- a/patch/u-boot/u-boot-meson-s4t7/Revert-emmc-enable-hs-SD-adjust-function-in-uboot-20.patch
+++ b/patch/u-boot/u-boot-meson-s4t7/Revert-emmc-enable-hs-SD-adjust-function-in-uboot-20.patch
@@ -1,0 +1,31 @@
+From 762693b0c2f54a9c1922cceef9b8d45c6bd1e4a5 Mon Sep 17 00:00:00 2001
+From: Gunjan Gupta <viraniac@gmail.com>
+Date: Fri, 16 Feb 2024 11:48:57 +0000
+Subject: [PATCH] Revert "emmc: enable hs SD adjust function in uboot 2019
+ [1/1]"
+
+This reverts commit bfa451f799eac8a69d4e58a32af7b00bec012e1d.
+---
+ drivers/mmc/mmc.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/mmc/mmc.c b/drivers/mmc/mmc.c
+index f5cf48099b..18eacc6e0a 100644
+--- a/drivers/mmc/mmc.c
++++ b/drivers/mmc/mmc.c
+@@ -1722,9 +1722,9 @@ static const struct mode_width_tuning sd_modes_by_pref[] = {
+ 	{
+ 		.mode = SD_HS,
+ 		.widths = MMC_MODE_4BIT | MMC_MODE_1BIT,
+-#ifdef MMC_SUPPORTS_TUNING
+-		.tuning = MMC_SD_HS_TUNING
+-#endif
++//#ifdef MMC_SUPPORTS_TUNING
++//		.tuning = MMC_SD_HS_TUNING
++//#endif
+ 	},
+ #if CONFIG_IS_ENABLED(MMC_UHS_SUPPORT)
+ 	{
+-- 
+2.34.1
+


### PR DESCRIPTION
# Description

When booting from UHS-I cards on VIM4 and VIM1S, mine was Samsung EVO Plus card (MB-MC64KA), booting only worked 1 out of 5 reboots. Other times the device either tried booting from EMMC or from SPI flash. The following logs appear when booting doesn't work from sdcard

```
mmc0 is current device
sd: resp crc error, cmd17, status=0x1ff2400
** Can't read partition table on 0:0 **
sd: resp crc error, cmd17, status=0x1ff2400
** Can't read partition table on 0:0 **
** Invalid partition 1 **
```

Using git bisect brought me to [bfa451f](https://github.com/khadas/u-boot/commit/bfa451f799eac8a69d4e58a32af7b00bec012e1d) commit and reverting the same solves the issue. Booting now works reliably from SD card every time I restart the same.

Jira reference number [AR-2070]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested rebooting multiple times when booting from sdcard on VIM4

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
