### PR TITLE
meson-s4t7: fix kernel headers installation failure due to missing make file

### DIFF
--- a/config/sources/families/meson-s4t7.conf
+++ b/config/sources/families/meson-s4t7.conf
@@ -154,6 +154,14 @@ function kernel_copy_extra_sources__khadas_common_drivers() {
 		fetch_from_repo "${COMMON_DRIVERS_SOURCE}" "common_drivers:${KERNEL_MAJOR_MINOR}" "${KERNELBRANCH}" "yes"
 }
 
+function pre_package_kernel_headers__copy_common_drivers_header_include_mk_file() {
+	display_alert "Copy common_drivers/header_include.mk file in kernel headers"
+	declare makefile_destination="${headers_target_dir}"/common_drivers
+	run_host_command_logged mkdir -p ${makefile_destination}
+	run_host_command_logged cp ${kernel_work_dir}/common_drivers/header_include.mk ${makefile_destination}/
+	run_host_command_logged cp -r ${kernel_work_dir}/common_drivers/include ${makefile_destination}/
+}
+
 function pre_package_kernel_image__copy_meson_s4t7_overlays() {
 	display_alert "Copy meson s4t7 overlays"
 	declare dtbo_destination="${tmp_kernel_install_dirs[INSTALL_DTBS_PATH]}"/amlogic

--- a/lib/functions/artifacts/artifact-kernel.sh
+++ b/lib/functions/artifacts/artifact-kernel.sh
@@ -143,7 +143,7 @@ function artifact_kernel_prepare_version() {
 	declare var_config_hash_short="${vars_config_hash:0:${short_hash_size}}"
 
 	# Hash the extension hooks
-	declare -a extension_hooks_to_hash=("pre_package_kernel_image" "kernel_copy_extra_sources")
+	declare -a extension_hooks_to_hash=("pre_package_kernel_image" "kernel_copy_extra_sources" "pre_package_kernel_headers")
 	declare -a extension_hooks_hashed=("$(dump_extension_method_sources_functions "${extension_hooks_to_hash[@]}")")
 	declare hash_hooks="undetermined"
 	hash_hooks="$(echo "${extension_hooks_hashed[@]}" | sha256sum | cut -d' ' -f1)"

--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -457,6 +457,13 @@ function kernel_package_callback_linux_headers() {
 		)
 	fi
 
+	call_extension_method "pre_package_kernel_headers" <<- 'PRE_PACKAGE_KERNEL_HEADERS'
+		*fix kernel headers before packaging*
+		Some (legacy/vendor) kernels need preprocessing of the produced kernel headers before packaging.
+		Use this hook to do that, by modifying the file in place, in `${headers_target_dir}` directory.
+		The kernel sources can be found in `${kernel_work_dir}`.
+	PRE_PACKAGE_KERNEL_HEADERS
+
 	# Generate a control file
 	# TODO: libssl-dev is only required if we're signing modules, which is a kernel .config option.
 	cat <<- CONTROL_FILE > "${package_DEBIAN_dir}/control"


### PR DESCRIPTION
# Description

The kernel headers package is not getting installed due to missing common_drivers/header_include.mk file.

Jira reference number [AR-2072]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested installing kernel headers on vim1s 24.02 image.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-2072]: https://armbian.atlassian.net/browse/AR-2072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ