### PR TITLE
Fix ddbr to handle current lsblk output

### DIFF
--- a/packages/bsp/common/usr/sbin/ddbr
+++ b/packages/bsp/common/usr/sbin/ddbr
@@ -207,7 +207,7 @@ then
 	echo "$_r UNABLE TO FIND ANY DRIVES ON THIS SYSTEM!!! $_x"
 	exit 1
 fi
-runfrom=$(lsblk | grep / | grep -oE '(mmcblk[0-9]|sda[0-9])')
+runfrom=$(lsblk | grep / | grep -oE '(mmcblk[0-9]|sda[0-9])' | sort | uniq)
 if [ "$runfrom" = "" ]
 then
 	echo "$_r UNABLE TO FIND ROOT OF THE RUNNING SYSTEM!!! $_x"


### PR DESCRIPTION

Description

ddbr was failing on a recent jammy build.  The issue is that lsblk output has changed sometime since this script was written.  
The logic to parse out the $runfrom drive was returning duplicate info, so instead of 'mmcblk0' the value was 'mmcblk0 mmcblk0'
Having this duplicate value was causing an error further down the script.
Fix is to add ' | sort | uniq' this was already being done on the other lsblk outputs, just not this one.
I've run into this before, and I guess at that time, I forgot to submit a PR for the fix, or it was for a different script that had the same issue.

 Changes to be committed:
	modified:   packages/bsp/common/usr/sbin/ddbr


Jira reference number [AR-9999]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Tested backup on board that was failing without this fix 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
