### PR TITLE
On uefi-x86, allow GRUB boot without GUI display and display early kernel boot messages on the serial console

### DIFF
--- a/config/sources/families/include/uefi_common.inc
+++ b/config/sources/families/include/uefi_common.inc
@@ -7,6 +7,7 @@
 # https://github.com/armbian/build/
 #
 declare -g SERIALCON="tty1,ttyS0"                    # Soft expectation for graphic terminal (tty1) and fallback to serial terminal (ttyS0) - Customize if needed
+declare -g DEFAULT_CONSOLE="both"                    #
 declare -g SKIP_BOOTSPLASH="yes"                     # No splash.
 declare -g UEFI_GRUB_TIMEOUT=${UEFI_GRUB_TIMEOUT:-3} # Default 3-seconds timeout for GRUB menu.
 declare -g BOARD_FIRMWARE_INSTALL="-full"            # Install full firmware for UEFI boards

--- a/config/sources/families/include/uefi_common.inc
+++ b/config/sources/families/include/uefi_common.inc
@@ -10,6 +10,7 @@ declare -g SERIALCON="tty1,ttyS0"                    # Soft expectation for grap
 declare -g DEFAULT_CONSOLE="both"                    #
 declare -g SKIP_BOOTSPLASH="yes"                     # No splash.
 declare -g UEFI_GRUB_TIMEOUT=${UEFI_GRUB_TIMEOUT:-3} # Default 3-seconds timeout for GRUB menu.
+declare -g GRUB_CMDLINE_LINUX_DEFAULT="earlyprintk=ttyS0,115200,keep"
 declare -g BOARD_FIRMWARE_INSTALL="-full"            # Install full firmware for UEFI boards
 case "${BRANCH}" in
 

--- a/config/sources/families/include/uefi_common.inc
+++ b/config/sources/families/include/uefi_common.inc
@@ -6,7 +6,7 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 #
-declare -g SERIALCON="tty1"                          # Cant reasonably expect UEFI stuff to have a serial console. Customize if otherwise.
+declare -g SERIALCON="tty1,ttyS0"                    # Soft expectation for graphic terminal (tty1) and fallback to serial terminal (ttyS0) - Customize if needed
 declare -g SKIP_BOOTSPLASH="yes"                     # No splash.
 declare -g UEFI_GRUB_TIMEOUT=${UEFI_GRUB_TIMEOUT:-3} # Default 3-seconds timeout for GRUB menu.
 declare -g BOARD_FIRMWARE_INSTALL="-full"            # Install full firmware for UEFI boards

--- a/config/sources/families/uefi-x86.conf
+++ b/config/sources/families/uefi-x86.conf
@@ -8,7 +8,7 @@
 #
 # Important: LINUXFAMILY and ARCH are defined _before_ including the common family include
 [[ "$BUILD_DESKTOP" == yes && "$RELEASE" == jammy ]] && enable_extension "nvidia"
-declare -g UEFI_GRUB_TERMINAL="gfxterm"
+declare -g UEFI_GRUB_TERMINAL="gfxterm vga_text console serial"
 declare -g LINUXFAMILY="x86"
 declare -g ARCH="amd64"
 source "${BASH_SOURCE%/*}/include/uefi_common.inc"

--- a/extensions/grub.sh
+++ b/extensions/grub.sh
@@ -220,7 +220,7 @@ pre_umount_final_image__install_grub() {
 	fi
 
 	# Check and warn if the wallpaper was not picked up by grub-mkconfig, if UEFI_GRUB_TERMINAL==gfxterm
-	if [[ "${UEFI_GRUB_TERMINAL}" == "gfxterm" ]]; then
+	if [[ "${UEFI_GRUB_TERMINAL}" =~ "gfxterm" ]]; then
 		if ! grep -q "background_image" "${chroot_target}/boot/grub/grub.cfg"; then
 			display_alert "GRUB mkconfig problem" "no wallpaper detected in generated grub.cfg" "warn"
 		else


### PR DESCRIPTION
**Remark: This PR is based off **v23.11** for now and will be rebased of main/master branch before review**

# Description

Running "uefi-x86" board image on ```qemu-system-x86_64  --display none --serial stdio ...``` did not:
- allow GRUB boot without GUI display
- display early kernel boot messages on the serial console
- display the console prompt on serial console 

Jira reference number: None

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A: Boot uefi-x86 board image on ```qemu-system-x86_64  --display none --serial stdio ...```
- [ ] Test B: Boot uefi-x86 board image on ```qemu-system-x86_64  --display vga ```

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
