### PR TITLE
Detach CB1 / Zero2 and Zero 3 (Allwinner H61x) from ATF master branch

### DIFF
--- a/config/sources/families/sun50iw9-btt.conf
+++ b/config/sources/families/sun50iw9-btt.conf
@@ -27,7 +27,7 @@ case $BRANCH in
 		ASOUND_STATE='asound.state.sun50iw9-legacy'
 
 		ATFSOURCE='https://github.com/ARM-software/arm-trusted-firmware'
-		ATFBRANCH='branch:master'
+		ATFBRANCH='tag:lts-v2.10.2'
 		ATF_PLAT="sun50i_h616"
 		ATF_TARGET_MAP='PLAT=sun50i_h616 DEBUG=1 bl31;;build/sun50i_h616/debug/bl31.bin'
 		BOOTSCRIPT='boot-sun50i-next.cmd:boot.cmd'
@@ -36,7 +36,7 @@ case $BRANCH in
 
 	current | edge)
 		ATFSOURCE='https://github.com/ARM-software/arm-trusted-firmware'
-		ATFBRANCH='branch:master'
+		ATFBRANCH='tag:lts-v2.10.2'
 		ATF_PLAT="sun50i_h616"
 		ATF_TARGET_MAP='PLAT=sun50i_h616 DEBUG=1 bl31;;build/sun50i_h616/debug/bl31.bin'
 		BOOTSCRIPT='boot-sun50i-next.cmd:boot.cmd'

--- a/config/sources/families/sun50iw9.conf
+++ b/config/sources/families/sun50iw9.conf
@@ -60,7 +60,7 @@ case $BRANCH in
 
 	current | edge)
 		ATFSOURCE='https://github.com/ARM-software/arm-trusted-firmware'
-		ATFBRANCH='branch:master'
+		ATFBRANCH='tag:lts-v2.10.2'
 		ATF_PLAT="sun50i_h616"
 		ATF_TARGET_MAP='PLAT=sun50i_h616 DEBUG=1 bl31;;build/sun50i_h616/debug/bl31.bin'
 		BOOTSCRIPT='boot-sun50i-next.cmd:boot.cmd'


### PR DESCRIPTION
# Description

Due to upstream ATF changes, we are unable to compile u-boot for Allwinner H61x. Until we don't find time for detailed inspection, lets attach ATF sources to last known working tag. 

# How Has This Been Tested?

Not tested yet, but it builds now.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
