### PR TITLE
Disable release upgrade checking on release manager

### DIFF
--- a/packages/bsp/common/etc/update-manager/release-upgrades
+++ b/packages/bsp/common/etc/update-manager/release-upgrades
@@ -1,0 +1,17 @@
+# Default behavior for the release upgrader.
+
+
+[DEFAULT]
+# Default prompting and upgrade behavior, valid options:
+#
+#  never  - Never check for, or allow upgrading to, a new release.
+#  normal - Check to see if a new release is available.  If more than one new
+#           release is found, the release upgrader will attempt to upgrade to
+#           the supported release that immediately succeeds the
+#           currently-running release.
+#  lts    - Check to see if a new LTS release is available.  The upgrader
+#           will attempt to upgrade to the first LTS release available after
+#           the currently-running one.  Note that if this option is used and
+#           the currently-running release is not itself an LTS release the
+#           upgrader will assume prompt was meant to be normal.
+Prompt=never


### PR DESCRIPTION
# Description

We probably don't want to bother people with upstream release upgrades as they are outside our power.

# How Has This Been Tested?

Tested:
```
sudo apt-get install ubuntu-release-upgrader-core
```
```
sudo do-release-upgrade -d
Checking for a new Ubuntu release
In /etc/update-manager/release-upgrades Prompt 
is set to never so upgrading is not possible.
```


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Disabled prompts and automatic upgrades to newer releases by default.
  * Added documentation describing supported release-upgrade prompt modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->