### PR TITLE
Fix random MAC on Orangepi 5 series

### DIFF
--- a/config/boards/orangepi5-plus.conf
+++ b/config/boards/orangepi5-plus.conf
@@ -33,5 +33,5 @@ function post_family_tweaks__orangepi5plus_naming_audios() {
 function post_family_config__orangepi5plus_use_vendor_uboot() {
 	BOOTSOURCE='https://github.com/orangepi-xunlong/u-boot-orangepi.git'
 	BOOTBRANCH='branch:v2017.09-rk3588'
-	BOOTPATCHDIR="legacy"
+	BOOTPATCHDIR="legacy/u-boot-orangepi5-rk3588"
 }

--- a/config/boards/orangepi5.conf
+++ b/config/boards/orangepi5.conf
@@ -132,6 +132,6 @@ function post_family_config__orangepi5_use_vendor_uboot() {
 	else
 		BOOTSOURCE='https://github.com/orangepi-xunlong/u-boot-orangepi.git'
 		BOOTBRANCH='branch:v2017.09-rk3588'
-		BOOTPATCHDIR="legacy"
+		BOOTPATCHDIR="legacy/u-boot-orangepi5-rk3588"
 	fi
 }

--- a/patch/u-boot/legacy/u-boot-orangepi5-rk3588/set-fixed-mac.patch
+++ b/patch/u-boot/legacy/u-boot-orangepi5-rk3588/set-fixed-mac.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Igor <igor@armbian.com>
+Date: Sat, 24 Feb 2024 21:50:04 +0000
+Subject: Do not change MAC address randomly
+
+Signed-off-by: Igor <igor@armbian.com>
+---
+ common/fdt_support.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/common/fdt_support.c b/common/fdt_support.c
+index e72aaf04e0..fa3d3e7af2 100644
+--- a/common/fdt_support.c
++++ b/common/fdt_support.c
+@@ -703,12 +703,12 @@ void fdt_fixup_ethernet(void *fdt)
+ 					tmp = (*end) ? end + 1 : end;
+ 			}
+ 
+ 			do_fixup_by_path(fdt, path, "mac-address",
+ 					 &mac_addr, 6, 0);
+-			//do_fixup_by_path(fdt, path, "local-mac-address",
+-			//		 &mac_addr, 6, 1);
++			do_fixup_by_path(fdt, path, "local-mac-address",
++					 &mac_addr, 6, 1);
+ 		}
+ 	}
+ }
+ 
+ /* Resize the fdt to its actual size + a bit of padding */
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+


### PR DESCRIPTION
# Description

We don't want that MAC address is changed on every reboot

Jira reference number [AR-2076]

# How Has This Been Tested?

- [x] Tested on hardware with several reboots

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-2076]: https://armbian.atlassian.net/browse/AR-2076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ