### PR TITLE
Update DDR/BL31 blobs for Orangepi 5/Plus

### DIFF
--- a/config/boards/orangepi5.conf
+++ b/config/boards/orangepi5.conf
@@ -15,8 +15,8 @@ BOOT_SUPPORT_SPI="yes"
 BOOT_SPI_RKSPI_LOADER="yes"
 IMAGE_PARTITION_TABLE="gpt"
 BOOTFS_TYPE="fat"
-DDR_BLOB='rk35/rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.11.bin'
-BL31_BLOB='rk35/rk3588_bl31_v1.38.elf'
+DDR_BLOB='rk35/rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.15.bin'
+BL31_BLOB='rk35/rk3588_bl31_v1.44.elf'
 declare -g UEFI_EDK2_BOARD_ID="orangepi-5" # This _only_ used for uefi-edk2-rk3588 extension
 
 declare -g BLUETOOTH_HCIATTACH_PARAMS="-s 115200 /dev/ttyS9 bcm43xx 1500000" # For the bluetooth-hciattach extension


### PR DESCRIPTION
# Description

New blobs has been pushed to rk bin repository. https://github.com/armbian/rkbin/pull/25 Probably support for new memory chips.

Jira reference number [AR-2077]

# How Has This Been Tested?

- [x] Boot on Orange Pi 5 v1.2

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-2077]: https://armbian.atlassian.net/browse/AR-2077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ