### PR TITLE
Improve armbian-install to address mounted fs correctly

### DIFF
--- a/packages/bsp/common/usr/sbin/armbian-install
+++ b/packages/bsp/common/usr/sbin/armbian-install
@@ -164,7 +164,7 @@ create_armbian()
 
 	# count files is needed for progress bar
 	dialog --title " $title " --backtitle "$backtitle" --infobox "\n  Counting files ... few seconds." 5 60
-	TODO=$(rsync -ahvrltDn --delete --stats --exclude-from=$EX_LIST / "${TempDir}"/rootfs | grep "Number of files:"|awk '{print $4}' | tr -d '.,')
+	TODO=$(rsync -avx --delete --stats --exclude-from=$EX_LIST / "${TempDir}"/rootfs | grep "Number of files:"|awk '{print $4}' | tr -d '.,')
 	echo -e "\nCopying ${TODO} files to $2. \c" >> $logfile
 
 	# creating rootfs
@@ -179,7 +179,7 @@ create_armbian()
 
 	 # Launch rsync in background
 	{ \
-	rsync -avrltD --delete --exclude-from=$EX_LIST / "${TempDir}"/rootfs | \
+	rsync -avx --delete --exclude-from=$EX_LIST / "${TempDir}"/rootfs | \
 	nl | awk '{ printf "%.0f\n", 100*$1/"'"$TODO"'" }' \
 	> "${nsi_conn_progress}" ;
 	 # create empty persistent journal directory if it exists before install
@@ -225,7 +225,7 @@ create_armbian()
 
 	# run rsync again to silently catch outstanding changes between / and "${TempDir}"/rootfs/
 	dialog --title "$title" --backtitle "$backtitle" --infobox "\n               Cleaning up ... Almost done." 5 60
-	rsync -avrltD --delete --exclude-from=$EX_LIST / "${TempDir}"/rootfs >/dev/null 2>&1
+	rsync -avx --delete --exclude-from=$EX_LIST / "${TempDir}"/rootfs >/dev/null 2>&1
 
 	# creating fstab from scratch
 	rm -f "${TempDir}"/rootfs/etc/fstab


### PR DESCRIPTION
# Description

Any mounted directory should not be copied but also mounted on the new boot device when booting.

Jira reference number [AR-2043] Closing https://github.com/armbian/build/issues/6242

# How Has This Been Tested?

- [x] Fresh install to eMMC media
- [x] Install to eMMC with configured zfs device

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-2043]: https://armbian.atlassian.net/browse/AR-2043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ