### PR TITLE
qemu-uefi-x86: new board for virtualized environment with serial console support, kernel boot messages

### DIFF
--- a/config/boards/qemu-uefi-x86.conf
+++ b/config/boards/qemu-uefi-x86.conf
@@ -1,0 +1,24 @@
+# x86_64 via UEFI/BIOS for generic virtual board
+#
+# Usage: Use this board to run armbian on a
+#        virtualized environment (eg: QEMU/KVM)
+#
+# Notes:
+# - Differences with the 'uefi-x86' board:
+#   - support kernel boot messages on graphical
+#     and console/serial devices
+#   - support prompt on graphical/console devices
+#   - Patches targeting virtualized env on x86
+#     should be added here - when it make sense :)
+#
+declare -g BOARD_NAME="UEFI x86 (QEMU)"
+declare -g BOARDFAMILY="uefi-x86"
+declare -g BOARD_MAINTAINER="@davidandreoletti"
+declare -g KERNEL_TARGET="legacy,current,edge"
+declare -g SERIALCON="tty1,ttyS0"
+
+declare -g BOOT_LOGO=desktop
+
+declare -g GRUB_CMDLINE_LINUX_DEFAULT="earlyprintk=ttyS0,115200,keep"
+declare -g DEFAULT_CONSOLE="both"
+declare -g UEFI_GRUB_TERMINAL="gfxterm vga_text console serial"

--- a/config/boards/uefi-x86.conf
+++ b/config/boards/uefi-x86.conf
@@ -1,7 +1,8 @@
-# x86_64 via UEFI/BIOS for all boards
+# x86_64 via UEFI/BIOS for a generic hardware board
 declare -g BOARD_NAME="UEFI x86"
 declare -g BOARDFAMILY="uefi-x86"
 declare -g BOARD_MAINTAINER="rpardini"
 declare -g KERNEL_TARGET="legacy,current,edge"
+declare -g SERIALCON="tty1"
 
 declare -g BOOT_LOGO=desktop

--- a/config/sources/families/include/uefi_common.inc
+++ b/config/sources/families/include/uefi_common.inc
@@ -6,7 +6,7 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 #
-declare -g SERIALCON="tty1"                          # Cant reasonably expect UEFI stuff to have a serial console. Customize if otherwise.
+declare -g SERIALCON="${SERIALCON:-tty1}"            # Consistent serial console device unlikely on UEFI arch pair. Customize if otherwise.
 declare -g UEFI_GRUB_TIMEOUT=${UEFI_GRUB_TIMEOUT:-3} # Default 3-seconds timeout for GRUB menu.
 declare -g BOARD_FIRMWARE_INSTALL="-full"            # Install full firmware for UEFI boards
 declare -g DISTRO_GENERIC_KERNEL=no

--- a/config/sources/families/uefi-x86.conf
+++ b/config/sources/families/uefi-x86.conf
@@ -8,7 +8,7 @@
 #
 # Important: LINUXFAMILY and ARCH are defined _before_ including the common family include
 [[ "$BUILD_DESKTOP" == yes && "$RELEASE" == jammy ]] && enable_extension "nvidia"
-declare -g UEFI_GRUB_TERMINAL="gfxterm"
+declare -g UEFI_GRUB_TERMINAL="${UEFI_GRUB_TERMINAL:-gfxterm}"
 declare -g LINUXFAMILY="x86"
 declare -g ARCH="amd64"
 source "${BASH_SOURCE%/*}/include/uefi_common.inc"

--- a/extensions/grub.sh
+++ b/extensions/grub.sh
@@ -218,7 +218,7 @@ pre_umount_final_image__install_grub() {
 	fi
 
 	# Check and warn if the wallpaper was not picked up by grub-mkconfig, if UEFI_GRUB_TERMINAL==gfxterm
-	if [[ "${UEFI_GRUB_TERMINAL}" == "gfxterm" ]]; then
+	if [[ "${UEFI_GRUB_TERMINAL}" =~ "gfxterm" ]]; then
 		if ! grep -q "background_image" "${chroot_target}/boot/grub/grub.cfg"; then
 			display_alert "GRUB mkconfig problem" "no wallpaper detected in generated grub.cfg" "warn"
 		else


### PR DESCRIPTION
_As of 2024 Feb, Github still not allow source branch renaming. Previous PR https://github.com/armbian/build/pull/6291 was auto closed by Github upon source branch renaming. This new PR supersedes it._

# Description

Running "uefi-x86" board image on qemu-system-x86_64  --display none --serial stdio ... did not:
- allow GRUB boot without GUI display
- display early kernel boot messages on the serial console
- display the console prompt on serial console

@rpardini  [suggested adding a new board:](https://github.com/armbian/build/pull/6307#issuecomment-1975110930). 
This PR adds support for this new board along with the missing features above.

Jira reference number: None

# How Has This Been Tested?

- [x] Test A: Boot uefi-x86 board image on `qemu-system-x86_64  --display none --serial stdio ...`
     - Armbian Build.git: 24.5.0-trunk
   - Build configuration: 
     ```
     BUILD_MINIMAL=no 
     BUILD_DESKTOP=no
     BOARD=uefi-x86
     ```
   - ✅ Result: early kernel messages + boot messages/prompt displayed on vm's serial console

<img width="1239" alt="image" src="https://github.com/armbian/build/assets/1195702/5f5474c1-2ad2-4ab7-86a5-06767ff45b5f">


- [x] Test B: Boot uefi-x86 board image on `qemu-system-x86_64  --display auto -vga virtio ...`
     - Armbian Build.git: 24.5.0-trunk 
     - Build configuration:
     ```
     BUILD_MINIMAL=no 
     BUILD_DESKTOP=yes
     # Xfce desktop
     BOARD=uefi-x86
     ```
   - ✅ Result: early kernel messages on serial + boot message/prompt displayed on serial + prompt displayed on GUI

![image](https://github.com/armbian/build/assets/1195702/87e30fec-d619-487d-988a-909ce7e5598b)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
