### PR TITLE
JetHome: fix u-boot patches for corrent rescue button handling

### DIFF
--- a/patch/u-boot/v2023.10/board_jethubj100/0001-HACK-mmc-meson-gx-limit-to-24MHz.patch
+++ b/patch/u-boot/v2023.10/board_jethubj100/0001-HACK-mmc-meson-gx-limit-to-24MHz.patch
@@ -1,7 +1,7 @@
-From 96437178d2cd464c29904514d40ac347cc888ee7 Mon Sep 17 00:00:00 2001
+From 24ba56015b1ce831639f482d26aeec11ac523906 Mon Sep 17 00:00:00 2001
 From: Neil Armstrong <narmstrong@baylibre.com>
 Date: Mon, 2 Sep 2019 15:42:04 +0200
-Subject: [PATCH 1/6] HACK: mmc: meson-gx: limit to 24MHz
+Subject: [PATCH 1/8] HACK: mmc: meson-gx: limit to 24MHz
 
 Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/mmc/meson_gx_mmc.c b/drivers/mmc/meson_gx_mmc.c
-index fcf4f03d1e..6ded4b619b 100644
+index fcf4f03d1e2..6ded4b619bf 100644
 --- a/drivers/mmc/meson_gx_mmc.c
 +++ b/drivers/mmc/meson_gx_mmc.c
 @@ -279,7 +279,7 @@ static int meson_mmc_probe(struct udevice *dev)
@@ -22,5 +22,5 @@ index fcf4f03d1e..6ded4b619b 100644
  	cfg->name = dev->name;
  
 -- 
-2.30.2
+2.43.2
 

--- a/patch/u-boot/v2023.10/board_jethubj100/0002-mmc-meson-gx-change-clock-phase-value-on-axg-SoCs.patch
+++ b/patch/u-boot/v2023.10/board_jethubj100/0002-mmc-meson-gx-change-clock-phase-value-on-axg-SoCs.patch
@@ -1,7 +1,7 @@
-From 4ac22afaa40da590605cd725850b81bfb562b0fb Mon Sep 17 00:00:00 2001
+From d2c54d518b8b3f362a8395d2a81a2e7cef7a1ae0 Mon Sep 17 00:00:00 2001
 From: Vyacheslav Bocharov <adeep@lexina.in>
 Date: Thu, 2 Dec 2021 13:10:24 +0300
-Subject: [PATCH 2/2] mmc: meson-gx: change clock phase value on axg SoCs
+Subject: [PATCH 2/8] mmc: meson-gx: change clock phase value on axg SoCs
 
 Amlogic AXG SoCs seems doesn't work over 50MHz. When phase sets to 270',
 it's working fine over 50MHz on Amlogic AXG SoCs.
@@ -15,7 +15,7 @@ To distinguish which value is used adds an u-boot only axg compatible.
  2 files changed, 4 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/mmc/meson_gx_mmc.c b/drivers/mmc/meson_gx_mmc.c
-index fcf4f03d1e..718eae42ec 100644
+index 6ded4b619bf..5e32c386caa 100644
 --- a/drivers/mmc/meson_gx_mmc.c
 +++ b/drivers/mmc/meson_gx_mmc.c
 @@ -68,7 +68,8 @@ static void meson_mmc_config_clock(struct mmc *mmc)
@@ -38,7 +38,7 @@ index fcf4f03d1e..718eae42ec 100644
  	{ /* sentinel */ }
  };
 diff --git a/drivers/mmc/meson_gx_mmc.h b/drivers/mmc/meson_gx_mmc.h
-index 8974b78f55..53201cedda 100644
+index 8974b78f559..53201ceddae 100644
 --- a/drivers/mmc/meson_gx_mmc.h
 +++ b/drivers/mmc/meson_gx_mmc.h
 @@ -12,6 +12,7 @@
@@ -50,5 +50,5 @@ index 8974b78f55..53201cedda 100644
  
  #define SDIO_PORT_A			0
 -- 
-2.30.2
+2.43.2
 

--- a/patch/u-boot/v2023.10/board_jethubj100/0003-Copy-and-update-amlogic-2019-aml-partition-keyman-co.patch
+++ b/patch/u-boot/v2023.10/board_jethubj100/0003-Copy-and-update-amlogic-2019-aml-partition-keyman-co.patch
@@ -1,7 +1,7 @@
-From 3363fab7438a17e336dbaf57fc3c8fa64114b94b Mon Sep 17 00:00:00 2001
+From cc245241593c097c03d73caad7e7900392603b5b Mon Sep 17 00:00:00 2001
 From: Vyacheslav Bocharov <adeep@lexina.in>
 Date: Wed, 29 Jun 2022 09:26:35 +0300
-Subject: [PATCH 3/7] Copy and update amlogic-2019 aml partition/keyman code to
+Subject: [PATCH 3/8] Copy and update amlogic-2019 aml partition/keyman code to
  mainline
 
 ---
@@ -207,7 +207,7 @@ Subject: [PATCH 3/7] Copy and update amlogic-2019 aml partition/keyman code to
 
 diff --git a/cmd/aml_mmc.c b/cmd/aml_mmc.c
 new file mode 100644
-index 0000000000..db9927e912
+index 00000000000..db9927e9120
 --- /dev/null
 +++ b/cmd/aml_mmc.c
 @@ -0,0 +1,3542 @@
@@ -3755,7 +3755,7 @@ index 0000000000..db9927e912
 +
 diff --git a/cmd/storage.c b/cmd/storage.c
 new file mode 100644
-index 0000000000..98147fbe22
+index 00000000000..98147fbe22c
 --- /dev/null
 +++ b/cmd/storage.c
 @@ -0,0 +1,1503 @@
@@ -5264,7 +5264,7 @@ index 0000000000..98147fbe22
 +);
 diff --git a/common/aml_dt.c b/common/aml_dt.c
 new file mode 100644
-index 0000000000..a6888999d4
+index 00000000000..a6888999d44
 --- /dev/null
 +++ b/common/aml_dt.c
 @@ -0,0 +1,600 @@
@@ -5870,7 +5870,7 @@ index 0000000000..a6888999d4
 +#endif //#ifdef 	AML_MULTI_DTB_CHECK_CMD
 diff --git a/common/partitions.c b/common/partitions.c
 new file mode 100644
-index 0000000000..25ad5e447d
+index 00000000000..25ad5e447d8
 --- /dev/null
 +++ b/common/partitions.c
 @@ -0,0 +1,206 @@
@@ -6082,7 +6082,7 @@ index 0000000000..25ad5e447d
 +}
 diff --git a/disk/part_aml.c b/disk/part_aml.c
 new file mode 100644
-index 0000000000..828a1b2d5c
+index 00000000000..828a1b2d5c3
 --- /dev/null
 +++ b/disk/part_aml.c
 @@ -0,0 +1,110 @@
@@ -6198,7 +6198,7 @@ index 0000000000..828a1b2d5c
 +#endif
 diff --git a/drivers/amlogic/Kconfig b/drivers/amlogic/Kconfig
 new file mode 100644
-index 0000000000..ff94c4b85e
+index 00000000000..ff94c4b85e2
 --- /dev/null
 +++ b/drivers/amlogic/Kconfig
 @@ -0,0 +1,14 @@
@@ -6218,7 +6218,7 @@ index 0000000000..ff94c4b85e
 +endmenu
 diff --git a/drivers/amlogic/Makefile b/drivers/amlogic/Makefile
 new file mode 100644
-index 0000000000..544cc608b5
+index 00000000000..544cc608b58
 --- /dev/null
 +++ b/drivers/amlogic/Makefile
 @@ -0,0 +1,5 @@
@@ -6229,7 +6229,7 @@ index 0000000000..544cc608b5
 +obj-$(CONFIG_SECURE_STORAGE) += storagekey/
 diff --git a/drivers/amlogic/keymanage/Kconfig b/drivers/amlogic/keymanage/Kconfig
 new file mode 100644
-index 0000000000..0c77689ae4
+index 00000000000..0c77689ae4b
 --- /dev/null
 +++ b/drivers/amlogic/keymanage/Kconfig
 @@ -0,0 +1,21 @@
@@ -6256,7 +6256,7 @@ index 0000000000..0c77689ae4
 +endif #if UNIFY_KEY_MANAGE
 diff --git a/drivers/amlogic/keymanage/Makefile b/drivers/amlogic/keymanage/Makefile
 new file mode 100644
-index 0000000000..08dd44eaec
+index 00000000000..08dd44eaec6
 --- /dev/null
 +++ b/drivers/amlogic/keymanage/Makefile
 @@ -0,0 +1,32 @@
@@ -6294,7 +6294,7 @@ index 0000000000..08dd44eaec
 +
 diff --git a/drivers/amlogic/keymanage/key_manage.c b/drivers/amlogic/keymanage/key_manage.c
 new file mode 100644
-index 0000000000..f8e0700b0a
+index 00000000000..f8e0700b0a1
 --- /dev/null
 +++ b/drivers/amlogic/keymanage/key_manage.c
 @@ -0,0 +1,689 @@
@@ -6989,7 +6989,7 @@ index 0000000000..f8e0700b0a
 +
 diff --git a/drivers/amlogic/keymanage/key_manage.h b/drivers/amlogic/keymanage/key_manage.h
 new file mode 100644
-index 0000000000..ab482f45a0
+index 00000000000..ab482f45a05
 --- /dev/null
 +++ b/drivers/amlogic/keymanage/key_manage.h
 @@ -0,0 +1,61 @@
@@ -7056,7 +7056,7 @@ index 0000000000..ab482f45a0
 +
 diff --git a/drivers/amlogic/keymanage/key_manage_i.h b/drivers/amlogic/keymanage/key_manage_i.h
 new file mode 100644
-index 0000000000..73404c1dbf
+index 00000000000..73404c1dbf1
 --- /dev/null
 +++ b/drivers/amlogic/keymanage/key_manage_i.h
 @@ -0,0 +1,65 @@
@@ -7127,7 +7127,7 @@ index 0000000000..73404c1dbf
 +
 diff --git a/drivers/amlogic/keymanage/key_unify.c b/drivers/amlogic/keymanage/key_unify.c
 new file mode 100644
-index 0000000000..069fff08dd
+index 00000000000..069fff08dd2
 --- /dev/null
 +++ b/drivers/amlogic/keymanage/key_unify.c
 @@ -0,0 +1,610 @@
@@ -7743,7 +7743,7 @@ index 0000000000..069fff08dd
 +
 diff --git a/drivers/amlogic/keymanage/km_dts.c b/drivers/amlogic/keymanage/km_dts.c
 new file mode 100644
-index 0000000000..d2a2186147
+index 00000000000..d2a2186147a
 --- /dev/null
 +++ b/drivers/amlogic/keymanage/km_dts.c
 @@ -0,0 +1,392 @@
@@ -8141,7 +8141,7 @@ index 0000000000..d2a2186147
 +
 diff --git a/drivers/amlogic/keymanage/km_efuse_key.c b/drivers/amlogic/keymanage/km_efuse_key.c
 new file mode 100644
-index 0000000000..c5c1e53baf
+index 00000000000..c5c1e53baf7
 --- /dev/null
 +++ b/drivers/amlogic/keymanage/km_efuse_key.c
 @@ -0,0 +1,156 @@
@@ -8303,7 +8303,7 @@ index 0000000000..c5c1e53baf
 +
 diff --git a/drivers/amlogic/keymanage/km_provision_key.c b/drivers/amlogic/keymanage/km_provision_key.c
 new file mode 100644
-index 0000000000..954a42b28a
+index 00000000000..954a42b28a2
 --- /dev/null
 +++ b/drivers/amlogic/keymanage/km_provision_key.c
 @@ -0,0 +1,102 @@
@@ -8411,7 +8411,7 @@ index 0000000000..954a42b28a
 +
 diff --git a/drivers/amlogic/keymanage/km_secure_key.c b/drivers/amlogic/keymanage/km_secure_key.c
 new file mode 100644
-index 0000000000..f33652b1b6
+index 00000000000..f33652b1b67
 --- /dev/null
 +++ b/drivers/amlogic/keymanage/km_secure_key.c
 @@ -0,0 +1,263 @@
@@ -8680,7 +8680,7 @@ index 0000000000..f33652b1b6
 +
 diff --git a/drivers/amlogic/keymanage/km_secure_key_2015.c b/drivers/amlogic/keymanage/km_secure_key_2015.c
 new file mode 100644
-index 0000000000..5baabb88f0
+index 00000000000..5baabb88f05
 --- /dev/null
 +++ b/drivers/amlogic/keymanage/km_secure_key_2015.c
 @@ -0,0 +1,118 @@
@@ -8804,7 +8804,7 @@ index 0000000000..5baabb88f0
 +
 diff --git a/drivers/amlogic/storagekey/Kconfig b/drivers/amlogic/storagekey/Kconfig
 new file mode 100644
-index 0000000000..311ab7e8ec
+index 00000000000..311ab7e8ec3
 --- /dev/null
 +++ b/drivers/amlogic/storagekey/Kconfig
 @@ -0,0 +1,2 @@
@@ -8812,7 +8812,7 @@ index 0000000000..311ab7e8ec
 +    bool "Amlogic bl31 storage key"
 diff --git a/drivers/amlogic/storagekey/Makefile b/drivers/amlogic/storagekey/Makefile
 new file mode 100644
-index 0000000000..6e7ccb4ba3
+index 00000000000..6e7ccb4ba3e
 --- /dev/null
 +++ b/drivers/amlogic/storagekey/Makefile
 @@ -0,0 +1,3 @@
@@ -8821,7 +8821,7 @@ index 0000000000..6e7ccb4ba3
 +obj-$(CONFIG_SECURE_STORAGE) += normal_key.o
 diff --git a/drivers/amlogic/storagekey/normal_key.c b/drivers/amlogic/storagekey/normal_key.c
 new file mode 100644
-index 0000000000..9e40c8fdfe
+index 00000000000..9e40c8fdfe9
 --- /dev/null
 +++ b/drivers/amlogic/storagekey/normal_key.c
 @@ -0,0 +1,672 @@
@@ -9499,7 +9499,7 @@ index 0000000000..9e40c8fdfe
 +}
 diff --git a/drivers/amlogic/storagekey/normal_key.h b/drivers/amlogic/storagekey/normal_key.h
 new file mode 100644
-index 0000000000..18772db67e
+index 00000000000..18772db67e0
 --- /dev/null
 +++ b/drivers/amlogic/storagekey/normal_key.h
 @@ -0,0 +1,49 @@
@@ -9554,7 +9554,7 @@ index 0000000000..18772db67e
 +#endif
 diff --git a/drivers/amlogic/storagekey/securestorage.c b/drivers/amlogic/storagekey/securestorage.c
 new file mode 100644
-index 0000000000..c65fee5586
+index 00000000000..c65fee5586f
 --- /dev/null
 +++ b/drivers/amlogic/storagekey/securestorage.c
 @@ -0,0 +1,389 @@
@@ -9949,7 +9949,7 @@ index 0000000000..c65fee5586
 +}
 diff --git a/drivers/amlogic/storagekey/storagekey.c b/drivers/amlogic/storagekey/storagekey.c
 new file mode 100644
-index 0000000000..646ad3f0de
+index 00000000000..646ad3f0ded
 --- /dev/null
 +++ b/drivers/amlogic/storagekey/storagekey.c
 @@ -0,0 +1,587 @@
@@ -10542,7 +10542,7 @@ index 0000000000..646ad3f0de
 +}
 diff --git a/drivers/efuse/Kconfig b/drivers/efuse/Kconfig
 new file mode 100644
-index 0000000000..3ee40478a1
+index 00000000000..3ee40478a11
 --- /dev/null
 +++ b/drivers/efuse/Kconfig
 @@ -0,0 +1,4 @@
@@ -10552,7 +10552,7 @@ index 0000000000..3ee40478a1
 +	  Enable support for the Amlogic EFUSE controller.
 diff --git a/drivers/efuse/Makefile b/drivers/efuse/Makefile
 new file mode 100644
-index 0000000000..62ab0325ba
+index 00000000000..62ab0325baf
 --- /dev/null
 +++ b/drivers/efuse/Makefile
 @@ -0,0 +1,9 @@
@@ -10567,7 +10567,7 @@ index 0000000000..62ab0325ba
 +obj-$(CONFIG_EFUSE) += bl31_apis.o
 diff --git a/drivers/efuse/aml_efuse.c b/drivers/efuse/aml_efuse.c
 new file mode 100644
-index 0000000000..a553a201f7
+index 00000000000..a553a201f71
 --- /dev/null
 +++ b/drivers/efuse/aml_efuse.c
 @@ -0,0 +1,123 @@
@@ -10696,7 +10696,7 @@ index 0000000000..a553a201f7
 +}
 diff --git a/drivers/efuse/bl31_apis.c b/drivers/efuse/bl31_apis.c
 new file mode 100644
-index 0000000000..18f6fc6968
+index 00000000000..18f6fc69683
 --- /dev/null
 +++ b/drivers/efuse/bl31_apis.c
 @@ -0,0 +1,474 @@
@@ -11176,7 +11176,7 @@ index 0000000000..18f6fc6968
 +}
 diff --git a/drivers/efuse/efuse.c b/drivers/efuse/efuse.c
 new file mode 100644
-index 0000000000..5560bcd384
+index 00000000000..5560bcd384c
 --- /dev/null
 +++ b/drivers/efuse/efuse.c
 @@ -0,0 +1,141 @@
@@ -11323,7 +11323,7 @@ index 0000000000..5560bcd384
 +}
 diff --git a/drivers/efuse/efuse_usr_space_api.c b/drivers/efuse/efuse_usr_space_api.c
 new file mode 100644
-index 0000000000..241b6d0be4
+index 00000000000..241b6d0be49
 --- /dev/null
 +++ b/drivers/efuse/efuse_usr_space_api.c
 @@ -0,0 +1,379 @@
@@ -11708,7 +11708,7 @@ index 0000000000..241b6d0be4
 +
 diff --git a/drivers/mmc/aml_emmc_partition.c b/drivers/mmc/aml_emmc_partition.c
 new file mode 100644
-index 0000000000..550042adb3
+index 00000000000..550042adb35
 --- /dev/null
 +++ b/drivers/mmc/aml_emmc_partition.c
 @@ -0,0 +1,1715 @@
@@ -13429,7 +13429,7 @@ index 0000000000..550042adb3
 +}
 diff --git a/drivers/mmc/mmc_aml copy.c b/drivers/mmc/mmc_aml copy.c
 new file mode 100644
-index 0000000000..66c0203dc6
+index 00000000000..66c0203dc6d
 --- /dev/null
 +++ b/drivers/mmc/mmc_aml copy.c	
 @@ -0,0 +1,3299 @@
@@ -16734,7 +16734,7 @@ index 0000000000..66c0203dc6
 +
 diff --git a/drivers/mmc/mmc_aml.c b/drivers/mmc/mmc_aml.c
 new file mode 100644
-index 0000000000..a9b0ff780f
+index 00000000000..a9b0ff780f8
 --- /dev/null
 +++ b/drivers/mmc/mmc_aml.c
 @@ -0,0 +1,416 @@
@@ -17156,7 +17156,7 @@ index 0000000000..a9b0ff780f
 +
 diff --git a/drivers/mmc/storage_emmc.c b/drivers/mmc/storage_emmc.c
 new file mode 100644
-index 0000000000..d938066e49
+index 00000000000..d938066e49b
 --- /dev/null
 +++ b/drivers/mmc/storage_emmc.c
 @@ -0,0 +1,946 @@
@@ -18108,7 +18108,7 @@ index 0000000000..d938066e49
 +
 diff --git a/include/amlogic/aml_cec.h b/include/amlogic/aml_cec.h
 new file mode 100644
-index 0000000000..4f0b2bd3a1
+index 00000000000..4f0b2bd3a1a
 --- /dev/null
 +++ b/include/amlogic/aml_cec.h
 @@ -0,0 +1,86 @@
@@ -18200,7 +18200,7 @@ index 0000000000..4f0b2bd3a1
 +
 diff --git a/include/amlogic/aml_efuse.h b/include/amlogic/aml_efuse.h
 new file mode 100644
-index 0000000000..4dece0725d
+index 00000000000..4dece0725de
 --- /dev/null
 +++ b/include/amlogic/aml_efuse.h
 @@ -0,0 +1,79 @@
@@ -18285,7 +18285,7 @@ index 0000000000..4dece0725d
 +#endif /* __BL2_EFUSE_H__ */
 diff --git a/include/amlogic/aml_gpio.h b/include/amlogic/aml_gpio.h
 new file mode 100644
-index 0000000000..c1e1ed1ef5
+index 00000000000..c1e1ed1ef5a
 --- /dev/null
 +++ b/include/amlogic/aml_gpio.h
 @@ -0,0 +1,54 @@
@@ -18345,7 +18345,7 @@ index 0000000000..c1e1ed1ef5
 +#endif
 diff --git a/include/amlogic/aml_hdmirx.h b/include/amlogic/aml_hdmirx.h
 new file mode 100644
-index 0000000000..b4b0f5a84a
+index 00000000000..b4b0f5a84ad
 --- /dev/null
 +++ b/include/amlogic/aml_hdmirx.h
 @@ -0,0 +1,19 @@
@@ -18370,7 +18370,7 @@ index 0000000000..b4b0f5a84a
 +#endif /* _AML_HDMIRX_H */
 diff --git a/include/amlogic/aml_irblaster.h b/include/amlogic/aml_irblaster.h
 new file mode 100644
-index 0000000000..b2c4ef703e
+index 00000000000..b2c4ef703e7
 --- /dev/null
 +++ b/include/amlogic/aml_irblaster.h
 @@ -0,0 +1,29 @@
@@ -18405,7 +18405,7 @@ index 0000000000..b2c4ef703e
 +
 diff --git a/include/amlogic/aml_is31fl32xx.h b/include/amlogic/aml_is31fl32xx.h
 new file mode 100644
-index 0000000000..6211ebc956
+index 00000000000..6211ebc956c
 --- /dev/null
 +++ b/include/amlogic/aml_is31fl32xx.h
 @@ -0,0 +1,9 @@
@@ -18420,7 +18420,7 @@ index 0000000000..6211ebc956
 +#endif
 diff --git a/include/amlogic/aml_led.h b/include/amlogic/aml_led.h
 new file mode 100644
-index 0000000000..b2f3bda3f7
+index 00000000000..b2f3bda3f7a
 --- /dev/null
 +++ b/include/amlogic/aml_led.h
 @@ -0,0 +1,68 @@
@@ -18495,7 +18495,7 @@ index 0000000000..b2f3bda3f7
 \ No newline at end of file
 diff --git a/include/amlogic/aml_mmc.h b/include/amlogic/aml_mmc.h
 new file mode 100644
-index 0000000000..4d7801c04e
+index 00000000000..4d7801c04e0
 --- /dev/null
 +++ b/include/amlogic/aml_mmc.h
 @@ -0,0 +1,105 @@
@@ -18606,7 +18606,7 @@ index 0000000000..4d7801c04e
 +#endif /* __AML_MMC_H__ */
 diff --git a/include/amlogic/aml_mtd.h b/include/amlogic/aml_mtd.h
 new file mode 100644
-index 0000000000..4eb17e4fa2
+index 00000000000..4eb17e4fa28
 --- /dev/null
 +++ b/include/amlogic/aml_mtd.h
 @@ -0,0 +1,31 @@
@@ -18643,7 +18643,7 @@ index 0000000000..4eb17e4fa2
 +#endif/* __AMLMTD_H_ */
 diff --git a/include/amlogic/aml_nand.h b/include/amlogic/aml_nand.h
 new file mode 100644
-index 0000000000..8be3974681
+index 00000000000..8be39746818
 --- /dev/null
 +++ b/include/amlogic/aml_nand.h
 @@ -0,0 +1,24 @@
@@ -18673,7 +18673,7 @@ index 0000000000..8be3974681
 +#endif/* __AML_NAND_H__ */
 diff --git a/include/amlogic/aml_rsv.h b/include/amlogic/aml_rsv.h
 new file mode 100644
-index 0000000000..7e17c83435
+index 00000000000..7e17c83435a
 --- /dev/null
 +++ b/include/amlogic/aml_rsv.h
 @@ -0,0 +1,106 @@
@@ -18785,7 +18785,7 @@ index 0000000000..7e17c83435
 +#endif/* __MESON_RSV_H_ */
 diff --git a/include/amlogic/aml_tlv.h b/include/amlogic/aml_tlv.h
 new file mode 100644
-index 0000000000..93fa0a305f
+index 00000000000..93fa0a305f4
 --- /dev/null
 +++ b/include/amlogic/aml_tlv.h
 @@ -0,0 +1,157 @@
@@ -18948,7 +18948,7 @@ index 0000000000..93fa0a305f
 +#endif /* __AMLOGIC_TLV_H_ */
 diff --git a/include/amlogic/aml_v2_burning.h b/include/amlogic/aml_v2_burning.h
 new file mode 100644
-index 0000000000..1ecdad65b0
+index 00000000000..1ecdad65b01
 --- /dev/null
 +++ b/include/amlogic/aml_v2_burning.h
 @@ -0,0 +1,31 @@
@@ -18985,7 +18985,7 @@ index 0000000000..1ecdad65b0
 +
 diff --git a/include/amlogic/aml_v3_burning.h b/include/amlogic/aml_v3_burning.h
 new file mode 100644
-index 0000000000..545ef33b1c
+index 00000000000..545ef33b1cc
 --- /dev/null
 +++ b/include/amlogic/aml_v3_burning.h
 @@ -0,0 +1,14 @@
@@ -19005,7 +19005,7 @@ index 0000000000..545ef33b1c
 +
 diff --git a/include/amlogic/amlkey_if.h b/include/amlogic/amlkey_if.h
 new file mode 100644
-index 0000000000..d15bbe7eee
+index 00000000000..d15bbe7eee3
 --- /dev/null
 +++ b/include/amlogic/amlkey_if.h
 @@ -0,0 +1,85 @@
@@ -19096,7 +19096,7 @@ index 0000000000..d15bbe7eee
 +
 diff --git a/include/amlogic/anti-rollback.h b/include/amlogic/anti-rollback.h
 new file mode 100644
-index 0000000000..95d42651ea
+index 00000000000..95d42651eab
 --- /dev/null
 +++ b/include/amlogic/anti-rollback.h
 @@ -0,0 +1,40 @@
@@ -19142,7 +19142,7 @@ index 0000000000..95d42651ea
 +#endif
 diff --git a/include/amlogic/asm/bl31_apis.h b/include/amlogic/asm/bl31_apis.h
 new file mode 100644
-index 0000000000..4227494b93
+index 00000000000..4227494b93e
 --- /dev/null
 +++ b/include/amlogic/asm/bl31_apis.h
 @@ -0,0 +1,166 @@
@@ -19314,7 +19314,7 @@ index 0000000000..4227494b93
 +#endif
 diff --git a/include/amlogic/asm/clock.h b/include/amlogic/asm/clock.h
 new file mode 100644
-index 0000000000..3a24778206
+index 00000000000..3a24778206e
 --- /dev/null
 +++ b/include/amlogic/asm/clock.h
 @@ -0,0 +1,41 @@
@@ -19361,7 +19361,7 @@ index 0000000000..3a24778206
 +#endif
 diff --git a/include/amlogic/asm/cpu_config.h b/include/amlogic/asm/cpu_config.h
 new file mode 100644
-index 0000000000..7e7c758f86
+index 00000000000..7e7c758f867
 --- /dev/null
 +++ b/include/amlogic/asm/cpu_config.h
 @@ -0,0 +1,101 @@
@@ -19468,7 +19468,7 @@ index 0000000000..7e7c758f86
 +#endif /* _BOOT_ROM_CONFIG_H_ */
 diff --git a/include/amlogic/asm/cpu_sdio.h b/include/amlogic/asm/cpu_sdio.h
 new file mode 100644
-index 0000000000..baf8706584
+index 00000000000..baf87065849
 --- /dev/null
 +++ b/include/amlogic/asm/cpu_sdio.h
 @@ -0,0 +1,264 @@
@@ -19738,7 +19738,7 @@ index 0000000000..baf8706584
 +#endif
 diff --git a/include/amlogic/asm/efuse.h b/include/amlogic/asm/efuse.h
 new file mode 100644
-index 0000000000..b5ea02723f
+index 00000000000..b5ea02723f9
 --- /dev/null
 +++ b/include/amlogic/asm/efuse.h
 @@ -0,0 +1,62 @@
@@ -19806,7 +19806,7 @@ index 0000000000..b5ea02723f
 +
 diff --git a/include/amlogic/asm/io.h b/include/amlogic/asm/io.h
 new file mode 100644
-index 0000000000..8640303b51
+index 00000000000..8640303b518
 --- /dev/null
 +++ b/include/amlogic/asm/io.h
 @@ -0,0 +1,118 @@
@@ -19930,7 +19930,7 @@ index 0000000000..8640303b51
 +#endif
 diff --git a/include/amlogic/asm/register.h b/include/amlogic/asm/register.h
 new file mode 100644
-index 0000000000..aa342a50fd
+index 00000000000..aa342a50fd9
 --- /dev/null
 +++ b/include/amlogic/asm/register.h
 @@ -0,0 +1,98 @@
@@ -20034,7 +20034,7 @@ index 0000000000..aa342a50fd
 +#endif //__REGISTER_H__
 diff --git a/include/amlogic/asm/regs.h b/include/amlogic/asm/regs.h
 new file mode 100644
-index 0000000000..26df3071cc
+index 00000000000..26df3071ccb
 --- /dev/null
 +++ b/include/amlogic/asm/regs.h
 @@ -0,0 +1,32964 @@
@@ -53004,7 +53004,7 @@ index 0000000000..26df3071cc
 +#define OSD1_HDR2_MATRIXO_EN_CTRL           0x38dc
 diff --git a/include/amlogic/asm/romboot.h b/include/amlogic/asm/romboot.h
 new file mode 100644
-index 0000000000..338365e87a
+index 00000000000..338365e87a6
 --- /dev/null
 +++ b/include/amlogic/asm/romboot.h
 @@ -0,0 +1,53 @@
@@ -53063,7 +53063,7 @@ index 0000000000..338365e87a
 +#endif /* __BOOT_ROM_H_ */
 diff --git a/include/amlogic/asm/sd_emmc.h b/include/amlogic/asm/sd_emmc.h
 new file mode 100644
-index 0000000000..81de3a9674
+index 00000000000..81de3a9674c
 --- /dev/null
 +++ b/include/amlogic/asm/sd_emmc.h
 @@ -0,0 +1,136 @@
@@ -53205,7 +53205,7 @@ index 0000000000..81de3a9674
 +#endif
 diff --git a/include/amlogic/asm/secure_apb.h b/include/amlogic/asm/secure_apb.h
 new file mode 100644
-index 0000000000..a146334e50
+index 00000000000..a146334e50f
 --- /dev/null
 +++ b/include/amlogic/asm/secure_apb.h
 @@ -0,0 +1,4235 @@
@@ -57446,7 +57446,7 @@ index 0000000000..a146334e50
 +
 diff --git a/include/amlogic/auge_sound.h b/include/amlogic/auge_sound.h
 new file mode 100644
-index 0000000000..2defa8018a
+index 00000000000..2defa8018ab
 --- /dev/null
 +++ b/include/amlogic/auge_sound.h
 @@ -0,0 +1,24 @@
@@ -57476,7 +57476,7 @@ index 0000000000..2defa8018a
 +#endif
 diff --git a/include/amlogic/blxx2bl33_param.h b/include/amlogic/blxx2bl33_param.h
 new file mode 100644
-index 0000000000..b2a5304e14
+index 00000000000..b2a5304e148
 --- /dev/null
 +++ b/include/amlogic/blxx2bl33_param.h
 @@ -0,0 +1,27 @@
@@ -57510,7 +57510,7 @@ index 0000000000..b2a5304e14
 \ No newline at end of file
 diff --git a/include/amlogic/canvas.h b/include/amlogic/canvas.h
 new file mode 100644
-index 0000000000..dc9ed10f02
+index 00000000000..dc9ed10f022
 --- /dev/null
 +++ b/include/amlogic/canvas.h
 @@ -0,0 +1,68 @@
@@ -57584,7 +57584,7 @@ index 0000000000..dc9ed10f02
 +#endif /* CANVAS_H */
 diff --git a/include/amlogic/color.h b/include/amlogic/color.h
 new file mode 100644
-index 0000000000..9839d11999
+index 00000000000..9839d119997
 --- /dev/null
 +++ b/include/amlogic/color.h
 @@ -0,0 +1,51 @@
@@ -57641,7 +57641,7 @@ index 0000000000..9839d11999
 +#endif
 diff --git a/include/amlogic/cpu_id.h b/include/amlogic/cpu_id.h
 new file mode 100644
-index 0000000000..588c131262
+index 00000000000..588c131262d
 --- /dev/null
 +++ b/include/amlogic/cpu_id.h
 @@ -0,0 +1,90 @@
@@ -57737,14 +57737,14 @@ index 0000000000..588c131262
 +int __get_chip_id(unsigned char *buff, unsigned int size);
 diff --git a/include/amlogic/enc_clk_config.h b/include/amlogic/enc_clk_config.h
 new file mode 100644
-index 0000000000..8b13789179
+index 00000000000..8b137891791
 --- /dev/null
 +++ b/include/amlogic/enc_clk_config.h
 @@ -0,0 +1 @@
 +
 diff --git a/include/amlogic/fb.h b/include/amlogic/fb.h
 new file mode 100644
-index 0000000000..d19e96928e
+index 00000000000..d19e96928e5
 --- /dev/null
 +++ b/include/amlogic/fb.h
 @@ -0,0 +1,399 @@
@@ -58149,7 +58149,7 @@ index 0000000000..d19e96928e
 +#endif /* _LINUX_FB_H */
 diff --git a/include/amlogic/instaboot.h b/include/amlogic/instaboot.h
 new file mode 100644
-index 0000000000..cfcae9ef4a
+index 00000000000..cfcae9ef4a9
 --- /dev/null
 +++ b/include/amlogic/instaboot.h
 @@ -0,0 +1,24 @@
@@ -58179,7 +58179,7 @@ index 0000000000..cfcae9ef4a
 +#endif /* __INSTABOOT_H_ */
 diff --git a/include/amlogic/jtag.h b/include/amlogic/jtag.h
 new file mode 100644
-index 0000000000..c85c513721
+index 00000000000..c85c513721c
 --- /dev/null
 +++ b/include/amlogic/jtag.h
 @@ -0,0 +1,61 @@
@@ -58246,7 +58246,7 @@ index 0000000000..c85c513721
 +#endif /*_MESON_JTAG_H_*/
 diff --git a/include/amlogic/keyunify.h b/include/amlogic/keyunify.h
 new file mode 100644
-index 0000000000..c89865f574
+index 00000000000..c89865f574d
 --- /dev/null
 +++ b/include/amlogic/keyunify.h
 @@ -0,0 +1,56 @@
@@ -58308,7 +58308,7 @@ index 0000000000..c89865f574
 +
 diff --git a/include/amlogic/media/vout/aml_cvbs.h b/include/amlogic/media/vout/aml_cvbs.h
 new file mode 100644
-index 0000000000..e4d0687d9b
+index 00000000000..e4d0687d9b2
 --- /dev/null
 +++ b/include/amlogic/media/vout/aml_cvbs.h
 @@ -0,0 +1,13 @@
@@ -58327,7 +58327,7 @@ index 0000000000..e4d0687d9b
 +
 diff --git a/include/amlogic/media/vout/aml_vinfo.h b/include/amlogic/media/vout/aml_vinfo.h
 new file mode 100644
-index 0000000000..7a453b26d6
+index 00000000000..7a453b26d6c
 --- /dev/null
 +++ b/include/amlogic/media/vout/aml_vinfo.h
 @@ -0,0 +1,148 @@
@@ -58481,7 +58481,7 @@ index 0000000000..7a453b26d6
 +#endif
 diff --git a/include/amlogic/media/vout/aml_vmode.h b/include/amlogic/media/vout/aml_vmode.h
 new file mode 100644
-index 0000000000..738bcd73b2
+index 00000000000..738bcd73b24
 --- /dev/null
 +++ b/include/amlogic/media/vout/aml_vmode.h
 @@ -0,0 +1,98 @@
@@ -58585,7 +58585,7 @@ index 0000000000..738bcd73b2
 +#endif
 diff --git a/include/amlogic/media/vout/aml_vout.h b/include/amlogic/media/vout/aml_vout.h
 new file mode 100644
-index 0000000000..53448bfc1e
+index 00000000000..53448bfc1e0
 --- /dev/null
 +++ b/include/amlogic/media/vout/aml_vout.h
 @@ -0,0 +1,25 @@
@@ -58616,7 +58616,7 @@ index 0000000000..53448bfc1e
 +
 diff --git a/include/amlogic/media/vout/hdmitx/hdmi_common.h b/include/amlogic/media/vout/hdmitx/hdmi_common.h
 new file mode 100644
-index 0000000000..66fdedd1d6
+index 00000000000..66fdedd1d62
 --- /dev/null
 +++ b/include/amlogic/media/vout/hdmitx/hdmi_common.h
 @@ -0,0 +1,655 @@
@@ -59277,7 +59277,7 @@ index 0000000000..66fdedd1d6
 +
 diff --git a/include/amlogic/media/vout/hdmitx/hdmitx.h b/include/amlogic/media/vout/hdmitx/hdmitx.h
 new file mode 100644
-index 0000000000..1458741089
+index 00000000000..1458741089b
 --- /dev/null
 +++ b/include/amlogic/media/vout/hdmitx/hdmitx.h
 @@ -0,0 +1,11 @@
@@ -59294,7 +59294,7 @@ index 0000000000..1458741089
 +#endif
 diff --git a/include/amlogic/media/vout/hdmitx/hdmitx_ext.h b/include/amlogic/media/vout/hdmitx/hdmitx_ext.h
 new file mode 100644
-index 0000000000..acf58a8091
+index 00000000000..acf58a80910
 --- /dev/null
 +++ b/include/amlogic/media/vout/hdmitx/hdmitx_ext.h
 @@ -0,0 +1,6 @@
@@ -59306,7 +59306,7 @@ index 0000000000..acf58a8091
 +#endif
 diff --git a/include/amlogic/media/vout/hdmitx/hdmitx_module.h b/include/amlogic/media/vout/hdmitx/hdmitx_module.h
 new file mode 100644
-index 0000000000..60d22f63e3
+index 00000000000..60d22f63e3f
 --- /dev/null
 +++ b/include/amlogic/media/vout/hdmitx/hdmitx_module.h
 @@ -0,0 +1,106 @@
@@ -59418,7 +59418,7 @@ index 0000000000..60d22f63e3
 +#endif
 diff --git a/include/amlogic/media/vout/hdmitx/hdmitx_reg.h b/include/amlogic/media/vout/hdmitx/hdmitx_reg.h
 new file mode 100644
-index 0000000000..b13e4ab986
+index 00000000000..b13e4ab986a
 --- /dev/null
 +++ b/include/amlogic/media/vout/hdmitx/hdmitx_reg.h
 @@ -0,0 +1,1041 @@
@@ -60465,7 +60465,7 @@ index 0000000000..b13e4ab986
 +#endif  /* __HDMI_TX_REG_H_ */
 diff --git a/include/amlogic/media/vout/hdmitx/mach_reg.h b/include/amlogic/media/vout/hdmitx/mach_reg.h
 new file mode 100644
-index 0000000000..865eddb198
+index 00000000000..865eddb198e
 --- /dev/null
 +++ b/include/amlogic/media/vout/hdmitx/mach_reg.h
 @@ -0,0 +1,625 @@
@@ -61096,7 +61096,7 @@ index 0000000000..865eddb198
 +#endif
 diff --git a/include/amlogic/media/vout/lcd/aml_lcd.h b/include/amlogic/media/vout/lcd/aml_lcd.h
 new file mode 100644
-index 0000000000..ef3334a5fb
+index 00000000000..ef3334a5fb0
 --- /dev/null
 +++ b/include/amlogic/media/vout/lcd/aml_lcd.h
 @@ -0,0 +1,168 @@
@@ -61270,7 +61270,7 @@ index 0000000000..ef3334a5fb
 +#endif /* INC_AML_LCD_H */
 diff --git a/include/amlogic/media/vout/lcd/bl_extern.h b/include/amlogic/media/vout/lcd/bl_extern.h
 new file mode 100644
-index 0000000000..6604672cea
+index 00000000000..6604672cea4
 --- /dev/null
 +++ b/include/amlogic/media/vout/lcd/bl_extern.h
 @@ -0,0 +1,88 @@
@@ -61364,7 +61364,7 @@ index 0000000000..6604672cea
 +
 diff --git a/include/amlogic/media/vout/lcd/bl_ldim.h b/include/amlogic/media/vout/lcd/bl_ldim.h
 new file mode 100644
-index 0000000000..fb42eb3f71
+index 00000000000..fb42eb3f71d
 --- /dev/null
 +++ b/include/amlogic/media/vout/lcd/bl_ldim.h
 @@ -0,0 +1,118 @@
@@ -61488,7 +61488,7 @@ index 0000000000..fb42eb3f71
 +#endif /* INC_AML_BL_LDIM_H */
 diff --git a/include/amlogic/media/vout/lcd/lcd_extern.h b/include/amlogic/media/vout/lcd/lcd_extern.h
 new file mode 100644
-index 0000000000..dc6ef565a8
+index 00000000000..dc6ef565a8a
 --- /dev/null
 +++ b/include/amlogic/media/vout/lcd/lcd_extern.h
 @@ -0,0 +1,116 @@
@@ -61610,7 +61610,7 @@ index 0000000000..dc6ef565a8
 +
 diff --git a/include/amlogic/media/vout/lcd/lcd_vout.h b/include/amlogic/media/vout/lcd/lcd_vout.h
 new file mode 100644
-index 0000000000..a5c0f3d817
+index 00000000000..a5c0f3d817a
 --- /dev/null
 +++ b/include/amlogic/media/vout/lcd/lcd_vout.h
 @@ -0,0 +1,520 @@
@@ -62136,7 +62136,7 @@ index 0000000000..a5c0f3d817
 +#endif /* INC_AML_LCD_VOUT_H */
 diff --git a/include/amlogic/media/vpp/vpp.h b/include/amlogic/media/vpp/vpp.h
 new file mode 100644
-index 0000000000..d77ddd3879
+index 00000000000..d77ddd3879d
 --- /dev/null
 +++ b/include/amlogic/media/vpp/vpp.h
 @@ -0,0 +1,24 @@
@@ -62166,7 +62166,7 @@ index 0000000000..d77ddd3879
 +#endif
 diff --git a/include/amlogic/media/vpu/vpu.h b/include/amlogic/media/vpu/vpu.h
 new file mode 100644
-index 0000000000..26bd575e07
+index 00000000000..26bd575e07f
 --- /dev/null
 +++ b/include/amlogic/media/vpu/vpu.h
 @@ -0,0 +1,11 @@
@@ -62183,7 +62183,7 @@ index 0000000000..26bd575e07
 +#endif
 diff --git a/include/amlogic/saradc.h b/include/amlogic/saradc.h
 new file mode 100644
-index 0000000000..7344a2bfa1
+index 00000000000..7344a2bfa1a
 --- /dev/null
 +++ b/include/amlogic/saradc.h
 @@ -0,0 +1,103 @@
@@ -62292,7 +62292,7 @@ index 0000000000..7344a2bfa1
 +#endif /*_MESON_SARADC_H_*/
 diff --git a/include/amlogic/secure_storage.h b/include/amlogic/secure_storage.h
 new file mode 100644
-index 0000000000..3a0148204b
+index 00000000000..3a0148204b2
 --- /dev/null
 +++ b/include/amlogic/secure_storage.h
 @@ -0,0 +1,46 @@
@@ -62344,7 +62344,7 @@ index 0000000000..3a0148204b
 +#endif
 diff --git a/include/amlogic/sound.h b/include/amlogic/sound.h
 new file mode 100644
-index 0000000000..4aceb7c9fd
+index 00000000000..4aceb7c9fd3
 --- /dev/null
 +++ b/include/amlogic/sound.h
 @@ -0,0 +1,180 @@
@@ -62530,7 +62530,7 @@ index 0000000000..4aceb7c9fd
 +#endif /* _SOUND_H_ */
 diff --git a/include/amlogic/spicc.h b/include/amlogic/spicc.h
 new file mode 100644
-index 0000000000..282af845c5
+index 00000000000..282af845c5f
 --- /dev/null
 +++ b/include/amlogic/spicc.h
 @@ -0,0 +1,44 @@
@@ -62581,7 +62581,7 @@ index 0000000000..282af845c5
 \ No newline at end of file
 diff --git a/include/amlogic/spifc.h b/include/amlogic/spifc.h
 new file mode 100644
-index 0000000000..0eb759896a
+index 00000000000..0eb759896a2
 --- /dev/null
 +++ b/include/amlogic/spifc.h
 @@ -0,0 +1,44 @@
@@ -62632,7 +62632,7 @@ index 0000000000..0eb759896a
 \ No newline at end of file
 diff --git a/include/amlogic/storage.h b/include/amlogic/storage.h
 new file mode 100644
-index 0000000000..5bdb4cb00e
+index 00000000000..5bdb4cb00e0
 --- /dev/null
 +++ b/include/amlogic/storage.h
 @@ -0,0 +1,501 @@
@@ -63139,7 +63139,7 @@ index 0000000000..5bdb4cb00e
 +#endif/* __STORAGE_H__ */
 diff --git a/include/amlogic/storagekey.h b/include/amlogic/storagekey.h
 new file mode 100644
-index 0000000000..f258b82c95
+index 00000000000..f258b82c95c
 --- /dev/null
 +++ b/include/amlogic/storagekey.h
 @@ -0,0 +1,57 @@
@@ -63202,7 +63202,7 @@ index 0000000000..f258b82c95
 +#endif /* __STORAGEKEY_H__ */
 diff --git a/include/amlogic/store_wrapper.h b/include/amlogic/store_wrapper.h
 new file mode 100644
-index 0000000000..0f3007de95
+index 00000000000..0f3007de959
 --- /dev/null
 +++ b/include/amlogic/store_wrapper.h
 @@ -0,0 +1,56 @@
@@ -63264,7 +63264,7 @@ index 0000000000..0f3007de95
 +
 diff --git a/include/amlstorage/emmc_partitions.h b/include/amlstorage/emmc_partitions.h
 new file mode 100644
-index 0000000000..5edc1f89c8
+index 00000000000..5edc1f89c8f
 --- /dev/null
 +++ b/include/amlstorage/emmc_partitions.h
 @@ -0,0 +1,271 @@
@@ -63541,7 +63541,7 @@ index 0000000000..5edc1f89c8
 +#endif
 diff --git a/include/amlstorage/emmc_storage.h b/include/amlstorage/emmc_storage.h
 new file mode 100644
-index 0000000000..f2dc55fde7
+index 00000000000..f2dc55fde77
 --- /dev/null
 +++ b/include/amlstorage/emmc_storage.h
 @@ -0,0 +1,76 @@
@@ -63623,7 +63623,7 @@ index 0000000000..f2dc55fde7
 +#endif
 diff --git a/include/amlstorage/partition_table.h b/include/amlstorage/partition_table.h
 new file mode 100644
-index 0000000000..4e170f3748
+index 00000000000..4e170f3748e
 --- /dev/null
 +++ b/include/amlstorage/partition_table.h
 @@ -0,0 +1,72 @@
@@ -63700,5 +63700,5 @@ index 0000000000..4e170f3748
 +#endif// #ifndef _PARTITION_TABLE_H
 +
 -- 
-2.34.1
+2.43.2
 

--- a/patch/u-boot/v2023.10/board_jethubj100/0004-Copy-and-update-amlogic-2019-aml-partition-keyman-co.patch
+++ b/patch/u-boot/v2023.10/board_jethubj100/0004-Copy-and-update-amlogic-2019-aml-partition-keyman-co.patch
@@ -1,7 +1,7 @@
-From ada871aefa0472d5524e8c501ff8c376de3a3398 Mon Sep 17 00:00:00 2001
+From aa7c8e63c6a81cf054af4392e7ae1fbf4e9bbf04 Mon Sep 17 00:00:00 2001
 From: Viacheslav Bocharov <adeep@lexina.in>
 Date: Tue, 3 Oct 2023 17:26:36 +0300
-Subject: [PATCH 4/7] Copy and update amlogic-2019 aml partition/keyman code to
+Subject: [PATCH 4/8] Copy and update amlogic-2019 aml partition/keyman code to
  mainline (fixes)
 
 ---
@@ -22,7 +22,7 @@ Subject: [PATCH 4/7] Copy and update amlogic-2019 aml partition/keyman code to
  14 files changed, 267 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm/dts/meson-axg-jethome-jethub-j100-u-boot.dtsi b/arch/arm/dts/meson-axg-jethome-jethub-j100-u-boot.dtsi
-index 3ecb233f8e..e0e6b2259c 100644
+index 3ecb233f8e2..e0e6b2259cc 100644
 --- a/arch/arm/dts/meson-axg-jethome-jethub-j100-u-boot.dtsi
 +++ b/arch/arm/dts/meson-axg-jethome-jethub-j100-u-boot.dtsi
 @@ -4,6 +4,98 @@
@@ -125,7 +125,7 @@ index 3ecb233f8e..e0e6b2259c 100644
  	status = "okay";
  	vref-supply = <&vddio_ao18>;
 diff --git a/cmd/Kconfig b/cmd/Kconfig
-index 43ca10f69c..71446cf092 100644
+index 43ca10f69cc..71446cf0923 100644
 --- a/cmd/Kconfig
 +++ b/cmd/Kconfig
 @@ -2698,6 +2698,11 @@ config CMD_REISER
@@ -141,7 +141,7 @@ index 43ca10f69c..71446cf092 100644
  	bool "yaffs2 - Access of YAFFS2 filesystem"
  	depends on YAFFS2
 diff --git a/cmd/Makefile b/cmd/Makefile
-index 9bebf321c3..1f68971aae 100644
+index 9bebf321c39..1f68971aaee 100644
 --- a/cmd/Makefile
 +++ b/cmd/Makefile
 @@ -214,6 +214,9 @@ obj-$(CONFIG_CMD_ETHSW) += ethsw.o
@@ -155,7 +155,7 @@ index 9bebf321c3..1f68971aae 100644
  obj-$(CONFIG_CMD_PMIC) += pmic.o
  obj-$(CONFIG_CMD_REGULATOR) += regulator.o
 diff --git a/common/Makefile b/common/Makefile
-index f5c3d90f06..26d9aefeaa 100644
+index f5c3d90f067..26d9aefeaaf 100644
 --- a/common/Makefile
 +++ b/common/Makefile
 @@ -11,6 +11,9 @@ obj-y += exports.o
@@ -169,7 +169,7 @@ index f5c3d90f06..26d9aefeaa 100644
  obj-y += board_f.o
  obj-y += board_r.o
 diff --git a/configs/jethub_j100_defconfig b/configs/jethub_j100_defconfig
-index 549d5514f7..26a22d96a6 100644
+index 549d5514f7a..26a22d96a6d 100644
 --- a/configs/jethub_j100_defconfig
 +++ b/configs/jethub_j100_defconfig
 @@ -68,3 +68,10 @@ CONFIG_USB_GADGET_VENDOR_NUM=0x1b8e
@@ -184,7 +184,7 @@ index 549d5514f7..26a22d96a6 100644
 +CONFIG_EFUSE=y
 +CONFIG_AML_PARTITION=y
 diff --git a/configs/jethub_j80_defconfig b/configs/jethub_j80_defconfig
-index df9b8f3aed..46bc96516e 100644
+index df9b8f3aedf..46bc96516e7 100644
 --- a/configs/jethub_j80_defconfig
 +++ b/configs/jethub_j80_defconfig
 @@ -72,3 +72,10 @@ CONFIG_USB_GADGET_VENDOR_NUM=0x1b8e
@@ -199,7 +199,7 @@ index df9b8f3aed..46bc96516e 100644
 +CONFIG_EFUSE=y
 +CONFIG_AML_PARTITION=y
 diff --git a/disk/Kconfig b/disk/Kconfig
-index 8549695807..5c65ad5065 100644
+index 85496958074..5c65ad5065c 100644
 --- a/disk/Kconfig
 +++ b/disk/Kconfig
 @@ -165,4 +165,17 @@ config SPL_PARTITION_TYPE_GUID
@@ -221,7 +221,7 @@ index 8549695807..5c65ad5065 100644
 +
  endmenu
 diff --git a/disk/Makefile b/disk/Makefile
-index 45588cf66e..23fc28bcbe 100644
+index 45588cf66e4..23fc28bcbe4 100644
 --- a/disk/Makefile
 +++ b/disk/Makefile
 @@ -17,4 +17,5 @@ obj-$(CONFIG_$(SPL_TPL_)DOS_PARTITION)   += part_dos.o
@@ -231,7 +231,7 @@ index 45588cf66e..23fc28bcbe 100644
 +#obj-$(CONFIG_AML_PARTITION) 		 += part_aml.o
  endif
 diff --git a/drivers/Kconfig b/drivers/Kconfig
-index a25f6ae02f..c074b7dce9 100644
+index a25f6ae02fd..c074b7dce93 100644
 --- a/drivers/Kconfig
 +++ b/drivers/Kconfig
 @@ -156,6 +156,10 @@ source "drivers/watchdog/Kconfig"
@@ -246,7 +246,7 @@ index a25f6ae02f..c074b7dce9 100644
  	bool "Custom physical to bus address mapping"
  	help
 diff --git a/drivers/Makefile b/drivers/Makefile
-index efc2a4afb2..91883a77af 100644
+index efc2a4afb24..91883a77af7 100644
 --- a/drivers/Makefile
 +++ b/drivers/Makefile
 @@ -43,6 +43,9 @@ obj-$(CONFIG_$(SPL_)VIDEO) += video/
@@ -260,7 +260,7 @@ index efc2a4afb2..91883a77af 100644
  ifndef CONFIG_VPL_BUILD
  ifdef CONFIG_SPL_BUILD
 diff --git a/drivers/mmc/Makefile b/drivers/mmc/Makefile
-index 2c65c4765a..2ee7af838e 100644
+index 2c65c4765ab..2ee7af838ed 100644
 --- a/drivers/mmc/Makefile
 +++ b/drivers/mmc/Makefile
 @@ -4,7 +4,10 @@
@@ -275,7 +275,7 @@ index 2c65c4765a..2ee7af838e 100644
  ifdef CONFIG_$(SPL_TPL_)DM_MMC
  obj-$(CONFIG_$(SPL_TPL_)BOOTSTD) += mmc_bootdev.o
 diff --git a/drivers/mmc/mmc.c b/drivers/mmc/mmc.c
-index 31cfda2885..9b275b82e1 100644
+index 31cfda28858..9b275b82e14 100644
 --- a/drivers/mmc/mmc.c
 +++ b/drivers/mmc/mmc.c
 @@ -26,6 +26,24 @@
@@ -410,7 +410,7 @@ index 31cfda2885..9b275b82e1 100644
 +	return;
 +}
 diff --git a/include/mmc.h b/include/mmc.h
-index 1022db3ffa..721758c3c7 100644
+index 1022db3ffa7..721758c3c7b 100644
 --- a/include/mmc.h
 +++ b/include/mmc.h
 @@ -109,6 +109,10 @@ struct bd_info;
@@ -481,7 +481,7 @@ index 1022db3ffa..721758c3c7 100644
  	u64 capacity_user;
  	u64 capacity_boot;
 diff --git a/include/part.h b/include/part.h
-index 8e451bbdff..b61e22c863 100644
+index 8e451bbdff9..b61e22c863b 100644
 --- a/include/part.h
 +++ b/include/part.h
 @@ -30,12 +30,15 @@ struct block_drvr {
@@ -501,5 +501,5 @@ index 8e451bbdff..b61e22c863 100644
   * Type string for U-Boot bootable partitions
   */
 -- 
-2.34.1
+2.43.2
 

--- a/patch/u-boot/v2023.10/board_jethubj100/0005-Add-usid-serial-mac-read-from-emmc.patch
+++ b/patch/u-boot/v2023.10/board_jethubj100/0005-Add-usid-serial-mac-read-from-emmc.patch
@@ -1,14 +1,14 @@
-From 5c51b2b597557e8981efe18f136e2304eeb2f364 Mon Sep 17 00:00:00 2001
+From 80d41294944231f135eb3b84dfc34658e0318b44 Mon Sep 17 00:00:00 2001
 From: Vyacheslav Bocharov <adeep@lexina.in>
 Date: Tue, 5 Jul 2022 19:06:25 +0300
-Subject: [PATCH 5/7] Add usid/serial/mac read from emmc
+Subject: [PATCH 5/8] Add usid/serial/mac read from emmc
 
 ---
  board/amlogic/jethub-j100/jethub-j100.c | 63 +++++++++++++++++++++++--
  1 file changed, 60 insertions(+), 3 deletions(-)
 
 diff --git a/board/amlogic/jethub-j100/jethub-j100.c b/board/amlogic/jethub-j100/jethub-j100.c
-index 6a2c4ad4c3..41ef5db493 100644
+index 6a2c4ad4c3c..41ef5db4932 100644
 --- a/board/amlogic/jethub-j100/jethub-j100.c
 +++ b/board/amlogic/jethub-j100/jethub-j100.c
 @@ -5,6 +5,7 @@
@@ -98,5 +98,5 @@ index 6a2c4ad4c3..41ef5db493 100644
  	return 0;
  }
 -- 
-2.34.1
+2.43.2
 

--- a/patch/u-boot/v2023.10/board_jethubj100/0006-HACK-force-disable-efi-options-for-JetHub-D1-H1.patch
+++ b/patch/u-boot/v2023.10/board_jethubj100/0006-HACK-force-disable-efi-options-for-JetHub-D1-H1.patch
@@ -1,7 +1,7 @@
-From 5b8e200dbcc24e457d45076b2e17795c5c28e851 Mon Sep 17 00:00:00 2001
+From 59305d9189e17b1f135112ea0333eac9746e9739 Mon Sep 17 00:00:00 2001
 From: Vyacheslav Bocharov <adeep@lexina.in>
 Date: Thu, 1 Sep 2022 09:53:19 +0300
-Subject: [PATCH 6/7] HACK: force disable efi options for JetHub D1+/H1
+Subject: [PATCH 6/8] HACK: force disable efi options for JetHub D1+/H1
 
 ---
  configs/jethub_j100_defconfig | 19 +++++++++++++++++++
@@ -9,7 +9,7 @@ Subject: [PATCH 6/7] HACK: force disable efi options for JetHub D1+/H1
  2 files changed, 38 insertions(+)
 
 diff --git a/configs/jethub_j100_defconfig b/configs/jethub_j100_defconfig
-index 26a22d96a6..112445ffef 100644
+index 26a22d96a6d..112445ffefb 100644
 --- a/configs/jethub_j100_defconfig
 +++ b/configs/jethub_j100_defconfig
 @@ -75,3 +75,22 @@ CONFIG_SECURE_STORAGE=y
@@ -36,7 +36,7 @@ index 26a22d96a6..112445ffef 100644
 +CONFIG_EFI_RNG_PROTOCOL=n
 +CONFIG_EFI_LOAD_FILE2_INITRD=n
 diff --git a/configs/jethub_j80_defconfig b/configs/jethub_j80_defconfig
-index 46bc96516e..5d1344b0b5 100644
+index 46bc96516e7..5d1344b0b5e 100644
 --- a/configs/jethub_j80_defconfig
 +++ b/configs/jethub_j80_defconfig
 @@ -79,3 +79,22 @@ CONFIG_SECURE_STORAGE=y
@@ -63,5 +63,5 @@ index 46bc96516e..5d1344b0b5 100644
 +CONFIG_EFI_RNG_PROTOCOL=n
 +CONFIG_EFI_LOAD_FILE2_INITRD=n
 -- 
-2.34.1
+2.43.2
 

--- a/patch/u-boot/v2023.10/board_jethubj100/0007-ARM-amlogic-revert-JetHub-D1-eth-mac-generation-with.patch
+++ b/patch/u-boot/v2023.10/board_jethubj100/0007-ARM-amlogic-revert-JetHub-D1-eth-mac-generation-with.patch
@@ -1,7 +1,7 @@
-From 371cd54d99e129dc7b0ded357fb3e6766f5ce1f1 Mon Sep 17 00:00:00 2001
+From 4c24d43140370f272a12b0695ffacb85863c51a7 Mon Sep 17 00:00:00 2001
 From: Viacheslav Bocharov <adeep@lexina.in>
 Date: Thu, 22 Dec 2022 15:10:29 +0300
-Subject: [PATCH 7/7] ARM: amlogic: revert JetHub D1 eth mac generation with
+Subject: [PATCH 7/8] ARM: amlogic: revert JetHub D1 eth mac generation with
  manufacturer OUI
 
 Partially revert add JetHub D1 eth mac generation with manufacturer OUI
@@ -13,7 +13,7 @@ Signed-off-by: Viacheslav Bocharov <adeep@lexina.in>
  1 file changed, 1 insertion(+), 18 deletions(-)
 
 diff --git a/board/amlogic/jethub-j100/jethub-j100.c b/board/amlogic/jethub-j100/jethub-j100.c
-index 41ef5db493..0d1cb6b21d 100644
+index 41ef5db4932..0d1cb6b21dc 100644
 --- a/board/amlogic/jethub-j100/jethub-j100.c
 +++ b/board/amlogic/jethub-j100/jethub-j100.c
 @@ -19,8 +19,6 @@
@@ -50,5 +50,5 @@ index 41ef5db493..0d1cb6b21d 100644
  	return 0;
  }
 -- 
-2.34.1
+2.43.2
 

--- a/patch/u-boot/v2023.10/board_jethubj100/0008-board-amlogic-jethub-j100-fix-common-config-header.patch
+++ b/patch/u-boot/v2023.10/board_jethubj100/0008-board-amlogic-jethub-j100-fix-common-config-header.patch
@@ -1,0 +1,28 @@
+From f55573d59d5bbe04046bb1a4f7b61a64ae5f3f78 Mon Sep 17 00:00:00 2001
+From: Viacheslav Bocharov <adeep@lexina.in>
+Date: Mon, 26 Feb 2024 18:06:30 +0300
+Subject: [PATCH 8/8] board: amlogic: jethub j100: fix common config header
+
+Fix JetHub board sequence to read correct gpio for rescue button
+
+Signed-off-by: Viacheslav Bocharov <adeep@lexina.in>
+---
+ include/configs/jethub.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/configs/jethub.h b/include/configs/jethub.h
+index e22db4991de..2c44bfc853e 100644
+--- a/include/configs/jethub.h
++++ b/include/configs/jethub.h
+@@ -11,7 +11,7 @@
+ #if defined(CONFIG_MESON_AXG)
+ #define BOOTENV_DEV_RESCUE(devtypeu, devtypel, instance) \
+ 	"bootcmd_rescue=" \
+-		"if gpio input 10; then " \
++		"if gpio input periphs-banks10; then " \
+ 		"run bootcmd_mmc0; " \
+ 		"run bootcmd_usb0;" \
+ 		"fi;\0"
+-- 
+2.43.2
+


### PR DESCRIPTION
# Description

JetHome: fix u-boot patches for rescue button. Applies only to JetHub devices

Jira reference number [AR-2081]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Fixed JetHub D1/D1+
- [ ] Test B

# Checklist:

- [X] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-2081]: https://armbian.atlassian.net/browse/AR-2081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ