### PR TITLE
armbian-resize-filesystem: fix off-by-one error

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-resize-filesystem
+++ b/packages/bsp/common/usr/lib/armbian/armbian-resize-filesystem
@@ -114,7 +114,7 @@ do_expand_partition()
 	fi
 
 	# use 16MiB to align partitions since this is the erase block size of more recent SD cards
-	local lastsector=$(( $lastsector - ($lastsector % (16 * 1024 * 1024 / $sectorsize)) ))
+	local lastsector=$(( $lastsector - ($lastsector % (16 * 1024 * 1024 / $sectorsize)) - 1 ))
 	[[ -n "$newpartition" ]] && local newpartition=$(( $newpartition - ($newpartition % (16 * 1024 * 1024 / $sectorsize)) ))
 
 	if [[ $lastsector -lt $partend ]]; then


### PR DESCRIPTION
armbian-resize-filesystem wants to align partitions on 16 MB boundaries, however due to an off-by-one error it would make the last sector of the partition start at a 16 MB boundary instead of ending at a 16 MB boundary.
