### PR TITLE
mekotronics 3588: add SRC_CMDLINE, for use with `u-boot-menu` extension

### DIFF
--- a/config/sources/vendors/mekotronics/mekotronics-rk3588.conf.sh
+++ b/config/sources/vendors/mekotronics/mekotronics-rk3588.conf.sh
@@ -25,3 +25,6 @@ declare -g IMAGE_PARTITION_TABLE="gpt"
 # set as variables, early, so they're picked up by `prepare_boot_configuration()`
 declare -g DDR_BLOB='rk35/rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.11.bin'
 declare -g BL31_BLOB='rk35/rk3588_bl31_v1.38.elf'
+
+# For the u-boot-menu extension (build with 'EXT=u-boot-menu')
+declare -g SRC_CMDLINE="loglevel=7 console=ttyS2,1500000 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory swapaccount=1"


### PR DESCRIPTION
#### mekotronics 3588: add SRC_CMDLINE, for use with `u-boot-menu` extension

- mekotronics 3588: add SRC_CMDLINE, for use with `u-boot-menu` extension
  - does nothing otherwise