### PR TITLE
khadas-vim3/khadas-vim3l: u-boot v2024.01: enable more compression, kaslr, and led config options via hook

### DIFF
--- a/config/boards/khadas-vim3.conf
+++ b/config/boards/khadas-vim3.conf
@@ -40,3 +40,16 @@ function post_uboot_custom_postprocess__khadas_vim3_uboot() {
 	display_alert "Signing u-boot FIP" "${BOARD}" "info"
 	uboot_g12_postprocess "${SRC}"/cache/sources/amlogic-boot-fip/khadas-vim3 g12b
 }
+
+# Enable extra u-boot .config options, this way we avoid patching defconfig
+function post_config_uboot_target__extra_configs_for_khadas_vim3() {
+	display_alert "u-boot for ${BOARD}" "u-boot: enable more compression support" "info"
+	run_host_command_logged scripts/config --enable CONFIG_LZO
+	run_host_command_logged scripts/config --enable CONFIG_BZIP2
+	run_host_command_logged scripts/config --enable CONFIG_ZSTD
+	display_alert "u-boot for ${BOARD}" "u-boot: enable kaslrseed support" "info"
+	run_host_command_logged scripts/config --enable CONFIG_CMD_KASLRSEED
+	display_alert "u-boot for ${BOARD}" "u-boot: enable gpio LED support" "info"
+	run_host_command_logged scripts/config --enable CONFIG_LED
+	run_host_command_logged scripts/config --enable CONFIG_LED_GPIO
+}

--- a/config/boards/khadas-vim3l.conf
+++ b/config/boards/khadas-vim3l.conf
@@ -11,8 +11,8 @@ BOOT_LOGO="desktop"
 BOOT_FDT_FILE="amlogic/meson-sm1-khadas-vim3l.dtb"
 ASOUND_STATE="asound.state.khadas-vim3l"
 
-BOOTBRANCH_BOARD="tag:v2023.10"
-BOOTPATCHDIR="v2023.10" # this has 'board_khadas-vim3l' which has a patch to boot USB/NVMe/SCSI first
+BOOTBRANCH_BOARD="tag:v2024.01"
+BOOTPATCHDIR="v2024.01" # this has 'board_khadas-vim3' which has a patch to boot USB/NVMe/SCSI first
 
 declare -g KHADAS_OOWOW_BOARD_ID="VIM3L" # for use with EXT=output-image-oowow
 

--- a/config/boards/khadas-vim3l.conf
+++ b/config/boards/khadas-vim3l.conf
@@ -40,3 +40,16 @@ function post_uboot_custom_postprocess__khadas_vim3l_uboot() {
 	display_alert "Signing u-boot FIP" "${BOARD}" "info"
 	uboot_g12_postprocess "${SRC}"/cache/sources/amlogic-boot-fip/khadas-vim3l g12a
 }
+
+# Enable extra u-boot .config options, this way we avoid patching defconfig
+function post_config_uboot_target__extra_configs_for_khadas_vim3l() {
+	display_alert "u-boot for ${BOARD}" "u-boot: enable more compression support" "info"
+	run_host_command_logged scripts/config --enable CONFIG_LZO
+	run_host_command_logged scripts/config --enable CONFIG_BZIP2
+	run_host_command_logged scripts/config --enable CONFIG_ZSTD
+	display_alert "u-boot for ${BOARD}" "u-boot: enable kaslrseed support" "info"
+	run_host_command_logged scripts/config --enable CONFIG_CMD_KASLRSEED
+	display_alert "u-boot for ${BOARD}" "u-boot: enable gpio LED support" "info"
+	run_host_command_logged scripts/config --enable CONFIG_LED
+	run_host_command_logged scripts/config --enable CONFIG_LED_GPIO
+}

--- a/patch/u-boot/v2024.01/board_khadas-vim3l/meson64-boot-usb-nvme-scsi-first.patch
+++ b/patch/u-boot/v2024.01/board_khadas-vim3l/meson64-boot-usb-nvme-scsi-first.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ricardo Pardini <ricardo@pardini.net>
+Date: Sun, 14 Jan 2024 13:44:58 +0100
+Subject: meson64: change `BOOT_TARGET_DEVICES` to try to boot USB, NVME and
+ SCSI before SD, MMC, PXE, DHCP
+
+---
+ include/configs/meson64.h | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/include/configs/meson64.h b/include/configs/meson64.h
+index efab9a624dc..32c25098e67 100644
+--- a/include/configs/meson64.h
++++ b/include/configs/meson64.h
+@@ -99,12 +99,12 @@
+ #define BOOT_TARGET_DEVICES(func) \
+ 	func(ROMUSB, romusb, na)  \
+ 	func(USB_DFU, usbdfu, na)  \
+-	func(MMC, mmc, 0) \
+-	func(MMC, mmc, 1) \
+-	func(MMC, mmc, 2) \
+ 	BOOT_TARGET_DEVICES_USB(func) \
+ 	BOOT_TARGET_NVME(func) \
+ 	BOOT_TARGET_SCSI(func) \
++	func(MMC, mmc, 0) \
++	func(MMC, mmc, 1) \
++	func(MMC, mmc, 2) \
+ 	func(PXE, pxe, na) \
+ 	func(DHCP, dhcp, na)
+ #endif
+-- 
+Armbian
+


### PR DESCRIPTION
#### khadas-vim3/khadas-vim3l: u-boot v2024.01: enable more compression, kaslr, and led config options via hook

- khadas-vim3l: bump to u-boot v2024.01; boot-usb-first patch in board folder
  - patch is slightly different for 2024.01
- khadas-vim3l: u-boot v2024.01: enable more compression, kaslr, and led config options via hook
- khadas-vim3: u-boot v2024.01: enable more compression, kaslr, and led config options via hook