### PR TITLE
Adds --partscan parameter to losetup command to force scan partitions

### DIFF
--- a/lib/functions/image/partitioning.sh
+++ b/lib/functions/image/partitioning.sh
@@ -221,7 +221,8 @@ function prepare_partitions() {
 
 	CHECK_LOOP_FOR_SIZE="no" check_loop_device "$LOOP" # initially loop is zero sized, ignore it.
 
-	run_host_command_logged losetup "${LOOP}" "${SDCARD}".raw # @TODO: had a '-P- here, what was it?
+        #--partscan is using to force the kernel for scaning partition table in preventing of partprobe errors
+	run_host_command_logged losetup --partscan "${LOOP}" "${SDCARD}".raw
 
 	# loop device was grabbed here, unlock
 	flock -u $FD


### PR DESCRIPTION
# Description

There was an error in execution of partprobe in Ubuntu 22.04.3 LTS. There is parameter in losetup program that forces the kernel to scan partitions. 

Jira reference number [AR-2094]

# How Has This Been Tested?

I added the infinity loop where the partprobe executes until success and then run the following commands inside the building container (docker exec -it <CONTAINER_ID> bash). Console commands history:
Run commands as they are executed in compile process before changes.
```
root@292a3a58b216:/armbian# losetup /dev/loop16 /armbian/.tmp/rootfs-852b9b33-c651-4808-95bc-390ae09c4029.raw 
root@292a3a58b216:/armbian# lsblk|grep loop16
loop16        7:16   0   1.7G  0 loop 
root@292a3a58b216:/armbian# partprobe /dev/loop16
Error: Partition(s) 1, 2 on /dev/loop16 have been written, but we have been unable to inform the kernel of the change, probably because it/they are in use.  As a result, the old partition(s) will remain in use.  You should reboot now before making further changes.

```
Remove device:
`root@292a3a58b216:/armbian# losetup -d /dev/loop16`

Run the same sequence of commands but with --partscan parameter added to losetup program.

```
root@292a3a58b216:/armbian# losetup --partscan /dev/loop16 /armbian/.tmp/rootfs-852b9b33-c651-4808-95bc-390ae09c4029.raw 
root@292a3a58b216:/armbian# lsblk|grep loop16
loop16        7:16   0   1.7G  0 loop 
|-loop16p1  259:3    0   256M  0 part 
`-loop16p2  259:4    0   1.5G  0 part 
root@292a3a58b216:/armbian# partprobe /dev/loop16 # there is no error here
```




[AR-2094]: https://armbian.atlassian.net/browse/AR-2094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ