### PR TITLE
rockchip-rk3588-edge: add ap6275p support

### DIFF
--- a/patch/kernel/rockchip-rk3588-edge/board-khadas-edge2-add-nodes.patch
+++ b/patch/kernel/rockchip-rk3588-edge/board-khadas-edge2-add-nodes.patch
@@ -1,7 +1,7 @@
-From 5a7bd2cd8703e51382abfc11242de59d45286477 Mon Sep 17 00:00:00 2001
+From 3c0d205a6f796e0497d1e06d5f3648baeea6f8fe Mon Sep 17 00:00:00 2001
 From: Muhammed Efe Cetin <efectn@protonmail.com>
 Date: Sat, 10 Feb 2024 16:42:04 +0300
-Subject: [PATCH 01/12] arm64: dts: rockchip: Add cpu regulators and vcc5v0_sys
+Subject: [PATCH 01/14] arm64: dts: rockchip: Add cpu regulators and vcc5v0_sys
  to Khadas Edge 2
 
 This commit adds 5V fixed power regulator and CPU regulators to Khadas
@@ -108,10 +108,10 @@ index f53e993c785e..1d1ce70a0f3a 100644
 2.43.1
 
 
-From 617faf64a68f5af560267d77fd23fc9fb23e6c88 Mon Sep 17 00:00:00 2001
+From fbd05671eda5f21854192255f3a37e94a45fa24a Mon Sep 17 00:00:00 2001
 From: Muhammed Efe Cetin <efectn@protonmail.com>
 Date: Sat, 10 Feb 2024 17:04:20 +0300
-Subject: [PATCH 02/12] arm64: dts: rockchip: Add PMIC to Khadas Edge 2
+Subject: [PATCH 02/14] arm64: dts: rockchip: Add PMIC to Khadas Edge 2
 
 This commit adds PMIC to Khadas Edge 2 board.
 
@@ -477,10 +477,10 @@ index 1d1ce70a0f3a..b99d2b82c787 100644
 2.43.1
 
 
-From 6e9062feb40bbad304f2e5bb300601034e805081 Mon Sep 17 00:00:00 2001
+From 4dfc4a6fd6f61c16d0b3656b20e971cc974701ce Mon Sep 17 00:00:00 2001
 From: Muhammed Efe Cetin <efectn@protonmail.com>
 Date: Sat, 10 Feb 2024 17:17:29 +0300
-Subject: [PATCH 03/12] arm64: dts: rockchip: Add TF card to Khadas Edge 2
+Subject: [PATCH 03/14] arm64: dts: rockchip: Add TF card to Khadas Edge 2
 
 Add TF card support to Khadas Edge 2.
 The board exposes sdmmc pins via EXTIO. TF card can be used with IO
@@ -561,10 +561,10 @@ index b99d2b82c787..856ce4f869a2 100644
 2.43.1
 
 
-From 4d22afd70e5583458f405f5170f67690584e7efa Mon Sep 17 00:00:00 2001
+From 3867e0dc57922a5f318078011b10fc29b8ddb2c4 Mon Sep 17 00:00:00 2001
 From: Muhammed Efe Cetin <efectn@protonmail.com>
 Date: Sat, 10 Feb 2024 17:34:15 +0300
-Subject: [PATCH 04/12] arm64: dts: rockchip: USB2, USB3 Host, PCIe2 to Khadas
+Subject: [PATCH 04/14] arm64: dts: rockchip: USB2, USB3 Host, PCIe2 to Khadas
  Edge 2
 
 Khadas Edge 2 has 1x USB2 with hub, 1x USB3 Host and 1x USB-C.
@@ -705,10 +705,10 @@ index 856ce4f869a2..ea7f1bb7c908 100644
 2.43.1
 
 
-From 335629f57e593e20418a4a55a1e662505640cbde Mon Sep 17 00:00:00 2001
+From 5171ff9690848a0580cfafe91fe44644f80fd497 Mon Sep 17 00:00:00 2001
 From: Muhammed Efe Cetin <efectn@protonmail.com>
 Date: Sat, 10 Feb 2024 18:13:56 +0300
-Subject: [PATCH 05/12] arm64: dts: rockchip: Add ir receiver and leds to
+Subject: [PATCH 05/14] arm64: dts: rockchip: Add ir receiver and leds to
  Khadas Edge 2
 
 Khadas Edge 2 exposes IR receiver pins as same as TF card via EXTIO. The
@@ -825,10 +825,10 @@ index ea7f1bb7c908..5a3b52e62dce 100644
 2.43.1
 
 
-From 03feaafefd0c13268ba1630251558749654a567d Mon Sep 17 00:00:00 2001
+From 776c86fb604c70919b2237143a6c8a7f208b8c32 Mon Sep 17 00:00:00 2001
 From: Muhammed Efe Cetin <efectn@protonmail.com>
 Date: Sat, 10 Feb 2024 18:15:44 +0300
-Subject: [PATCH 06/12] arm64: dts: rockchip: Add saradc and adc buttons to
+Subject: [PATCH 06/14] arm64: dts: rockchip: Add saradc and adc buttons to
  Khadas Edge 2 and enable tsadc
 
 This commit enables tsadc, saradc and the
@@ -899,10 +899,10 @@ index 5a3b52e62dce..dfcdbec3534d 100644
 2.43.1
 
 
-From 00942603f7e61ecb2a0067bebf6795dab3571613 Mon Sep 17 00:00:00 2001
+From 47f5ca47ec2252c6a7c52373e5fb65922af196b8 Mon Sep 17 00:00:00 2001
 From: Muhammed Efe Cetin <efectn@protonmail.com>
 Date: Sat, 10 Feb 2024 18:17:54 +0300
-Subject: [PATCH 07/12] arm64: dts: rockchip: Add SFC to Khadas Edge 2
+Subject: [PATCH 07/14] arm64: dts: rockchip: Add SFC to Khadas Edge 2
 
 This commit adds SPI flash support for Khadas Edge 2.
 
@@ -940,10 +940,10 @@ index dfcdbec3534d..c2a329f151a1 100644
 2.43.1
 
 
-From 0a10afeff3aec3a8bccca2dbe4e65f7b4a2c4666 Mon Sep 17 00:00:00 2001
+From 5b4a43334f92b28b6ec7f14497d59bb9ee0690a0 Mon Sep 17 00:00:00 2001
 From: Muhammed Efe Cetin <efectn@protonmail.com>
 Date: Sat, 10 Feb 2024 18:23:14 +0300
-Subject: [PATCH 08/12] arm64: dts: rockchip: Add UART9 (bluetooth) to Khadas
+Subject: [PATCH 08/14] arm64: dts: rockchip: Add UART9 (bluetooth) to Khadas
  Edge 2
 
 Khadas Edge 2 has onboard AP6275P Wi-Fi6 (PCIe2) and BT5 (UART9) module.
@@ -996,10 +996,10 @@ index c2a329f151a1..767e21b2dc34 100644
 2.43.1
 
 
-From 4c4c9140ff36f290ba64ecc8b3e218df6a5ab273 Mon Sep 17 00:00:00 2001
+From e42ab57fdd3ce1f1a307c2c6a938b385685704be Mon Sep 17 00:00:00 2001
 From: Muhammed Efe Cetin <efectn@protonmail.com>
 Date: Sun, 11 Feb 2024 16:16:11 +0300
-Subject: [PATCH 09/12] arm64: dts: rockchip: Add RTC to Khadas Edge 2
+Subject: [PATCH 09/14] arm64: dts: rockchip: Add RTC to Khadas Edge 2
 
 Khadas Edge 2 has PT7C4363 RTC that compatible with HYM8563.
 The RTC pinctrl is also connected to MCU.
@@ -1036,10 +1036,10 @@ index 767e21b2dc34..2022a174594c 100644
 2.43.1
 
 
-From 275f03469cabfcbb6d70cd0a3a7dce99ed59e678 Mon Sep 17 00:00:00 2001
+From 8798c9890a82cb0c1f06c1b2c00a7adb34ed24e8 Mon Sep 17 00:00:00 2001
 From: Muhammed Efe Cetin <efectn@protonmail.com>
 Date: Mon, 12 Feb 2024 17:35:13 +0300
-Subject: [PATCH 10/12] arm64: dts: rockchip: Add USB-C to Khadas Edge 2
+Subject: [PATCH 10/14] arm64: dts: rockchip: Add USB-C to Khadas Edge 2
 
 Khadas Edge 2 has 2x Type-C port. One just supports PD and
 controlled by MCU. The other one supports PD, DP Alt mode and DRD. This
@@ -1047,11 +1047,11 @@ commit adds support for DRD.
 
 Signed-off-by: Muhammed Efe Cetin <efectn@protonmail.com>
 ---
- .../dts/rockchip/rk3588s-khadas-edge2.dts     | 127 ++++++++++++++++++
- 1 file changed, 127 insertions(+)
+ .../dts/rockchip/rk3588s-khadas-edge2.dts     | 120 ++++++++++++++++++
+ 1 file changed, 120 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
-index 2022a174594c..9e963340265d 100644
+index 2022a174594c..62167dca75b7 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
 @@ -6,6 +6,7 @@
@@ -1081,7 +1081,7 @@ index 2022a174594c..9e963340265d 100644
  	vcc3v3_pcie_wl: vcc3v3-pcie-wl-regulator {
  		compatible = "regulator-fixed";
  		enable-active-high;
-@@ -219,6 +232,58 @@ regulator-state-mem {
+@@ -219,6 +232,56 @@ regulator-state-mem {
  &i2c2 {
  	status = "okay";
  
@@ -1102,12 +1102,10 @@ index 2022a174594c..9e963340265d 100644
 +			power-role = "dual";
 +			try-power-role = "source";
 +			op-sink-microwatt = <1000000>;
-+			sink-pdos =
-+                		<PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)
-+                		 PDO_FIXED(9000, 3000, PDO_FIXED_USB_COMM)
-+                		 PDO_FIXED(12000, 3000, PDO_FIXED_USB_COMM)>;
-+            		source-pdos =
-+                		<PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>;
++			sink-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)
++                		     PDO_FIXED(9000, 3000, PDO_FIXED_USB_COMM)
++                		     PDO_FIXED(12000, 3000, PDO_FIXED_USB_COMM)>;
++            		source-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>;
 +
 +			ports {
 +				#address-cells = <1>;
@@ -1140,7 +1138,7 @@ index 2022a174594c..9e963340265d 100644
  	hym8563: rtc@51 {
  		compatible = "haoyu,hym8563";
  		reg = <0x51>;
-@@ -251,6 +316,16 @@ vcc5v0_host_en: vcc5v0-host-en {
+@@ -251,6 +314,16 @@ vcc5v0_host_en: vcc5v0-host-en {
  		};
  	};
  
@@ -1157,7 +1155,7 @@ index 2022a174594c..9e963340265d 100644
  	ir-receiver {
  		ir_receiver_pin: ir-receiver-pin {
  			rockchip,pins = <1  RK_PA7  RK_FUNC_GPIO  &pcfg_pull_none>;
-@@ -679,6 +754,15 @@ &uart9 {
+@@ -679,6 +752,15 @@ &uart9 {
  	status = "okay";
  };
  
@@ -1173,7 +1171,7 @@ index 2022a174594c..9e963340265d 100644
  &u2phy2 {
  	status = "okay";
  };
-@@ -705,6 +789,49 @@ &usb_host0_ohci {
+@@ -705,6 +787,44 @@ &usb_host0_ohci {
  	status = "okay";
  };
  
@@ -1201,12 +1199,7 @@ index 2022a174594c..9e963340265d 100644
 +	};
 +};
 +
-+&usbdp_phy0_u3 {
-+	status = "okay";
-+};
-+
 +&usb_host0_xhci {
-+	dr_mode = "otg";
 +	usb-role-switch;
 +	status = "okay";
 +
@@ -1227,10 +1220,10 @@ index 2022a174594c..9e963340265d 100644
 2.43.1
 
 
-From cc15294481e8120e90d11b57e5b737f743fffd45 Mon Sep 17 00:00:00 2001
+From 270ed8c8c620022c5d140830abc1770bf63bf760 Mon Sep 17 00:00:00 2001
 From: Muhammed Efe Cetin <efectn@protonmail.com>
 Date: Mon, 12 Feb 2024 17:35:13 +0300
-Subject: [PATCH 11/12] arm64: dts: rockchip: Add bluetooth rfkill to Khadas
+Subject: [PATCH 11/14] arm64: dts: rockchip: Add bluetooth rfkill to Khadas
  Edge 2
 
 ---
@@ -1238,7 +1231,7 @@ Subject: [PATCH 11/12] arm64: dts: rockchip: Add bluetooth rfkill to Khadas
  1 file changed, 9 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
-index 9e963340265d..278789763013 100644
+index 62167dca75b7..b95a36b717f1 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
 @@ -77,6 +77,15 @@ blue_led: led-2 {
@@ -1261,17 +1254,17 @@ index 9e963340265d..278789763013 100644
 2.43.1
 
 
-From d7ca9251cf5c6f279f257924ccbe443125a01fe7 Mon Sep 17 00:00:00 2001
+From 99633816871ad539b1ce0aacf90d06dfd69d6d06 Mon Sep 17 00:00:00 2001
 From: Muhammed Efe Cetin <efectn@protonmail.com>
 Date: Mon, 19 Feb 2024 23:32:11 +0300
-Subject: [PATCH 12/12] arm64: dts: rockchip: Add HDMI & VOP2 to Khadas Edge 2
+Subject: [PATCH 12/14] arm64: dts: rockchip: Add HDMI & VOP2 to Khadas Edge 2
 
 ---
- .../dts/rockchip/rk3588s-khadas-edge2.dts     | 55 +++++++++++++++++--
- 1 file changed, 50 insertions(+), 5 deletions(-)
+ .../dts/rockchip/rk3588s-khadas-edge2.dts     | 50 +++++++++++++++++++
+ 1 file changed, 50 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
-index 278789763013..76388bec1f09 100644
+index b95a36b717f1..0e0afa68f65c 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
 @@ -7,6 +7,7 @@
@@ -1300,22 +1293,15 @@ index 278789763013..76388bec1f09 100644
  	bluetooth-rfkill {
  		compatible = "rfkill-gpio";
  		label = "rfkill-bluetooth";
-@@ -822,13 +834,9 @@ usbdp_phy0_dp_altmode_mux: endpoint@1 {
- 	};
+@@ -821,6 +833,7 @@ usbdp_phy0_dp_altmode_mux: endpoint@1 {
  };
  
--&usbdp_phy0_u3 {
--	status = "okay";
--};
--
  &usb_host0_xhci {
--	dr_mode = "otg";
- 	usb-role-switch;
 +	dr-mode = "otg";
+ 	usb-role-switch;
  	status = "okay";
  
- 	port {
-@@ -852,3 +860,40 @@ &usb_host1_ohci {
+@@ -845,3 +858,40 @@ &usb_host1_ohci {
  &usb_host2_xhci {
  	status = "okay";
  };
@@ -1356,6 +1342,127 @@ index 278789763013..76388bec1f09 100644
 +		remote-endpoint = <&hdmi0_in_vp0>;
 +	};
 +};
+-- 
+2.43.1
+
+
+From f3a71dd599d098a610447e99cd682f569ee3282a Mon Sep 17 00:00:00 2001
+From: Muhammed Efe Cetin <efectn@protonmail.com>
+Date: Sat, 2 Mar 2024 19:13:59 +0300
+Subject: [PATCH 13/14] arm64: dts: rockchip: Add AP6275P wireless support to
+ Khadas Edge 2
+
+---
+ .../boot/dts/rockchip/rk3588s-khadas-edge2.dts  | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 0e0afa68f65c..931ef1c49cb7 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -372,6 +372,23 @@ &pcie2x1l2 {
+ 	reset-gpios = <&gpio3 RK_PD1 GPIO_ACTIVE_HIGH>;
+ 	vpcie3v3-supply = <&vcc3v3_pcie_wl>;
+ 	status = "okay";
++
++	pcie@0,0 {
++		reg = <0x400000 0 0 0 0>;
++		#address-cells = <3>;
++		#size-cells = <2>;
++		ranges;
++		device_type = "pci";
++		bus-range = <0x40 0x4f>;
++
++		wifi: wifi@0,0 {
++			compatible = "pci14e4,449d";
++			reg = <0x410000 0 0 0 0>;
++			clocks = <&hym8563>;
++			clock-names = "32k";
++		};
++	};
++
+ };
+ 
+ &pwm11 {
+-- 
+2.43.1
+
+
+From 7b1bf3d826fd750ddf67bb08423da1639e2c46ab Mon Sep 17 00:00:00 2001
+From: Muhammed Efe Cetin <efectn@protonmail.com>
+Date: Sat, 2 Mar 2024 19:26:09 +0300
+Subject: [PATCH 14/14] arm64: dts: rockchip: Add cpufreq support to Khadas
+ Edge 2
+
+---
+ .../arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 931ef1c49cb7..8b40b5af6722 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -172,34 +172,42 @@ vdd_3v3_sd: vdd-3v3-sd-regulator {
+ 
+ &cpu_b0 {
+ 	cpu-supply = <&vdd_cpu_big0_s0>;
++	mem-supply = <&vdd_cpu_big0_mem_s0>;
+ };
+ 
+ &cpu_b1 {
+ 	cpu-supply = <&vdd_cpu_big0_s0>;
++	mem-supply = <&vdd_cpu_big0_mem_s0>;
+ };
+ 
+ &cpu_b2 {
+ 	cpu-supply = <&vdd_cpu_big1_s0>;
++	mem-supply = <&vdd_cpu_big1_mem_s0>;
+ };
+ 
+ &cpu_b3 {
+ 	cpu-supply = <&vdd_cpu_big1_s0>;
++	mem-supply = <&vdd_cpu_big1_mem_s0>;
+ };
+ 
+ &cpu_l0 {
+ 	cpu-supply = <&vdd_cpu_lit_s0>;
++	mem-supply = <&vdd_cpu_lit_mem_s0>;
+ };
+ 
+ &cpu_l1 {
+ 	cpu-supply = <&vdd_cpu_lit_s0>;
++	mem-supply = <&vdd_cpu_lit_mem_s0>;
+ };
+ 
+ &cpu_l2 {
+ 	cpu-supply = <&vdd_cpu_lit_s0>;
++	mem-supply = <&vdd_cpu_lit_mem_s0>;
+ };
+ 
+ &cpu_l3 {
+ 	cpu-supply = <&vdd_cpu_lit_s0>;
++	mem-supply = <&vdd_cpu_lit_mem_s0>;
+ };
+ 
+ &combphy0_ps {
+@@ -215,7 +223,7 @@ &i2c0 {
+ 	pinctrl-0 = <&i2c0m2_xfer>;
+ 	status = "okay";
+ 
+-	vdd_cpu_big0_s0: regulator@42 {
++	vdd_cpu_big0_s0: vdd_cpu_big0_mem_s0: regulator@42 {
+ 		compatible = "rockchip,rk8602";
+ 		reg = <0x42>;
+ 		fcs,suspend-voltage-selector = <1>;
+@@ -232,7 +240,7 @@ regulator-state-mem {
+ 		};
+ 	};
+ 
+-	vdd_cpu_big1_s0: regulator@43 {
++	vdd_cpu_big1_s0: vdd_cpu_big1_mem_s0: regulator@43 {
+ 		compatible = "rockchip,rk8603", "rockchip,rk8602";
+ 		reg = <0x43>;
+ 		fcs,suspend-voltage-selector = <1>;
 -- 
 2.43.1
 

--- a/patch/kernel/rockchip-rk3588-edge/wireless-add-bcm43752.patch
+++ b/patch/kernel/rockchip-rk3588-edge/wireless-add-bcm43752.patch
@@ -1,0 +1,74 @@
+From d1949944db6cc04614712799660d67c0b68d45cc Mon Sep 17 00:00:00 2001
+From: Ondrej Jirman
+Date: Wed, 28 Feb 2024 20:59:15 +0100
+Subject: net: wireless: brcmfmac: Add support for AP6275P
+
+This module features BCM43752A2 chipset. The firmware requires
+randomness seeding, so enabled it.
+
+Signed-off-by: Ondrej Jirman <megi@xff.cz>
+---
+ drivers/net/wireless/broadcom/brcm80211/brcmfmac/pcie.c       | 5 ++++-
+ drivers/net/wireless/broadcom/brcm80211/include/brcm_hw_ids.h | 2 ++
+ 2 files changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/pcie.c b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/pcie.c
+index d7fb88bb6ae1..89b9f25f56d4 100644
+--- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/pcie.c
++++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/pcie.c
+@@ -70,6 +70,7 @@ BRCMF_FW_CLM_DEF(4377B3, "brcmfmac4377b3-pcie");
+ BRCMF_FW_CLM_DEF(4378B1, "brcmfmac4378b1-pcie");
+ BRCMF_FW_CLM_DEF(4378B3, "brcmfmac4378b3-pcie");
+ BRCMF_FW_CLM_DEF(4387C2, "brcmfmac4387c2-pcie");
++BRCMF_FW_CLM_DEF(43752, "brcmfmac43752-pcie");
+ 
+ /* firmware config files */
+ MODULE_FIRMWARE(BRCMF_FW_DEFAULT_PATH "brcmfmac*-pcie.txt");
+@@ -104,6 +105,7 @@ static const struct brcmf_firmware_mapping brcmf_pcie_fwnames[] = {
+ 	BRCMF_FW_ENTRY(BRCM_CC_43664_CHIP_ID, 0xFFFFFFF0, 4366C),
+ 	BRCMF_FW_ENTRY(BRCM_CC_43666_CHIP_ID, 0xFFFFFFF0, 4366C),
+ 	BRCMF_FW_ENTRY(BRCM_CC_4371_CHIP_ID, 0xFFFFFFFF, 4371),
++	BRCMF_FW_ENTRY(BRCM_CC_43752_CHIP_ID, 0xFFFFFFFF, 43752),
+ 	BRCMF_FW_ENTRY(BRCM_CC_4377_CHIP_ID, 0xFFFFFFFF, 4377B3), /* revision ID 4 */
+ 	BRCMF_FW_ENTRY(BRCM_CC_4378_CHIP_ID, 0x0000000F, 4378B1), /* revision ID 3 */
+ 	BRCMF_FW_ENTRY(BRCM_CC_4378_CHIP_ID, 0xFFFFFFE0, 4378B3), /* revision ID 5 */
+@@ -1711,7 +1713,7 @@ static int brcmf_pcie_download_fw_nvram(struct brcmf_pciedev_info *devinfo,
+ 		memcpy_toio(devinfo->tcm + address, nvram, nvram_len);
+ 		brcmf_fw_nvram_free(nvram);
+ 
+-		if (devinfo->otp.valid) {
++		if (devinfo->otp.valid || devinfo->ci->chip == BRCM_CC_43752_CHIP_ID) {
+ 			size_t rand_len = BRCMF_RANDOM_SEED_LENGTH;
+ 			struct brcmf_random_seed_footer footer = {
+ 				.length = cpu_to_le32(rand_len),
+@@ -2695,6 +2697,7 @@ static const struct pci_device_id brcmf_pcie_devid_table[] = {
+ 	BRCMF_PCIE_DEVICE(BRCM_PCIE_4366_5G_DEVICE_ID, BCA),
+ 	BRCMF_PCIE_DEVICE(BRCM_PCIE_4371_DEVICE_ID, WCC),
+ 	BRCMF_PCIE_DEVICE(BRCM_PCIE_43596_DEVICE_ID, CYW),
++	BRCMF_PCIE_DEVICE(BRCM_PCIE_43752_DEVICE_ID, WCC),
+ 	BRCMF_PCIE_DEVICE(BRCM_PCIE_4377_DEVICE_ID, WCC),
+ 	BRCMF_PCIE_DEVICE(BRCM_PCIE_4378_DEVICE_ID, WCC),
+ 	BRCMF_PCIE_DEVICE(BRCM_PCIE_4387_DEVICE_ID, WCC),
+diff --git a/drivers/net/wireless/broadcom/brcm80211/include/brcm_hw_ids.h b/drivers/net/wireless/broadcom/brcm80211/include/brcm_hw_ids.h
+index 44684bf1b9ac..c1e22c589d85 100644
+--- a/drivers/net/wireless/broadcom/brcm80211/include/brcm_hw_ids.h
++++ b/drivers/net/wireless/broadcom/brcm80211/include/brcm_hw_ids.h
+@@ -52,6 +52,7 @@
+ #define BRCM_CC_43664_CHIP_ID		43664
+ #define BRCM_CC_43666_CHIP_ID		43666
+ #define BRCM_CC_4371_CHIP_ID		0x4371
++#define BRCM_CC_43752_CHIP_ID		43752
+ #define BRCM_CC_4377_CHIP_ID		0x4377
+ #define BRCM_CC_4378_CHIP_ID		0x4378
+ #define BRCM_CC_4387_CHIP_ID		0x4387
+@@ -94,6 +95,7 @@
+ #define BRCM_PCIE_4366_5G_DEVICE_ID	0x43c5
+ #define BRCM_PCIE_4371_DEVICE_ID	0x440d
+ #define BRCM_PCIE_43596_DEVICE_ID	0x4415
++#define BRCM_PCIE_43752_DEVICE_ID	0x449d
+ #define BRCM_PCIE_4377_DEVICE_ID	0x4488
+ #define BRCM_PCIE_4378_DEVICE_ID	0x4425
+ #define BRCM_PCIE_4387_DEVICE_ID	0x4433
+-- 
+cgit v1.2.3
+

--- a/patch/kernel/rockchip-rk3588-edge/wireless-add-clk-property.patch
+++ b/patch/kernel/rockchip-rk3588-edge/wireless-add-clk-property.patch
@@ -1,0 +1,51 @@
+From ef6097e0c226b66d3ff8626f49255b1e2648641f Mon Sep 17 00:00:00 2001
+From: Ondrej Jirman
+Date: Wed, 28 Feb 2024 21:09:51 +0100
+Subject: net: wireless: brcmfmac: Add optional 32k clock enable support
+
+WiFi modules often require 32kHz clock to function. Add support to
+enable the clock to pcie driver.
+
+Signed-off-by: Ondrej Jirman <megi@xff.cz>
+---
+ drivers/net/wireless/broadcom/brcm80211/brcmfmac/pcie.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/pcie.c b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/pcie.c
+index 89b9f25f56d4..b2e0b5f0512e 100644
+--- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/pcie.c
++++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/pcie.c
+@@ -3,6 +3,7 @@
+  * Copyright (c) 2014 Broadcom Corporation
+  */
+ 
++#include <linux/clk.h>
+ #include <linux/kernel.h>
+ #include <linux/module.h>
+ #include <linux/firmware.h>
+@@ -2408,6 +2409,7 @@ brcmf_pcie_probe(struct pci_dev *pdev, const struct pci_device_id *id)
+ 	struct brcmf_pciedev *pcie_bus_dev;
+ 	struct brcmf_core *core;
+ 	struct brcmf_bus *bus;
++	struct clk *clk;
+ 
+ 	if (!id) {
+ 		id = pci_match_id(brcmf_pcie_devid_table, pdev);
+@@ -2419,6 +2421,14 @@ brcmf_pcie_probe(struct pci_dev *pdev, const struct pci_device_id *id)
+ 
+ 	brcmf_dbg(PCIE, "Enter %x:%x\n", pdev->vendor, pdev->device);
+ 
++	clk = devm_clk_get_optional_enabled(&pdev->dev, "32k");
++	if (IS_ERR(clk))
++		return PTR_ERR(clk);
++	if (clk) {
++		dev_info(&pdev->dev, "enabling 32kHz clock\n");
++		clk_set_rate(clk, 32768);
++	}
++
+ 	ret = -ENOMEM;
+ 	devinfo = kzalloc(sizeof(*devinfo), GFP_KERNEL);
+ 	if (devinfo == NULL)
+-- 
+cgit v1.2.3
+


### PR DESCRIPTION
# Description

This PR mainly adds support for AP6275P (BCM43752) chipset wireless and necessary nodes to khadas edge2. 
I've also added some missing properties to khadas-edge2 devicetree.

Patches have been taken from https://xnux.eu/log/100.html

Jira reference number [AR-2084]

# How Has This Been Tested?
- [x] Tested on Khadas Edge2

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-2084]: https://armbian.atlassian.net/browse/AR-2084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ