### PR TITLE
prepare-host/host-release: enable noble for building; noble also doesn't have python2 anymore

### DIFF
--- a/lib/functions/general/python-tools.sh
+++ b/lib/functions/general/python-tools.sh
@@ -18,7 +18,7 @@ function early_prepare_pip3_dependencies_for_python_tools() {
 		"GitPython==3.1.30"   # for manipulating git repos
 		"unidecode==1.3.6"    # for converting strings to ascii
 		"coloredlogs==15.0.1" # for colored logging
-		"PyYAML==6.0"         # for parsing/writing YAML
+		"PyYAML==6.0.1"       # for parsing/writing YAML
 		"oras==0.1.17"        # for OCI stuff in mapper-oci-update
 		"Jinja2==3.1.2"       # for templating
 		"rich==13.4.1"        # for rich text formatting

--- a/lib/functions/host/host-release.sh
+++ b/lib/functions/host/host-release.sh
@@ -33,7 +33,7 @@ function obtain_and_check_host_release_and_arch() {
 	#
 	# NO_HOST_RELEASE_CHECK overrides the check for a supported host system
 	# Disable host OS check at your own risk. Any issues reported with unsupported releases will be closed without discussion
-	if [[ -z $HOSTRELEASE || "bookworm trixie sid jammy kinetic lunar vanessa vera victoria mantic" != *"$HOSTRELEASE"* ]]; then
+	if [[ -z $HOSTRELEASE || "bookworm trixie sid jammy kinetic lunar vanessa vera victoria mantic noble" != *"$HOSTRELEASE"* ]]; then
 		if [[ $NO_HOST_RELEASE_CHECK == yes ]]; then
 			display_alert "You are running on an unsupported system" "${HOSTRELEASE:-(unknown)}" "wrn"
 			display_alert "Do not report any errors, warnings or other issues encountered beyond this point" "" "wrn"

--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -294,7 +294,7 @@ function adaptative_prepare_host_dependencies() {
 
 	# Python2 -- required for some older u-boot builds
 	# Debian 'sid'/'bookworm' and Ubuntu 'lunar' does not carry python2 anymore; in this case some u-boot's might fail to build.
-	if [[ "sid bookworm trixie lunar mantic" == *"${host_release}"* ]]; then
+	if [[ "sid bookworm trixie lunar mantic noble" == *"${host_release}"* ]]; then
 		display_alert "Python2 not available on host release '${host_release}'" "old(er) u-boot builds might/will fail" "wrn"
 	else
 		host_dependencies+=("python2" "python2-dev")


### PR DESCRIPTION
#### prepare-host/host-release: enable noble for building; noble also doesn't have python2 anymore

- prepare-host/host-release: enable noble for building; noble also doesn't have python2 anymore
- python-tools: bump PyYAML to 6.0.1 to fix build failures on sid/trixie/noble etc