### PR TITLE
riscv64: fixes/skips for building (sans Docker) ON riscv64

### DIFF
--- a/lib/functions/general/bat-cat.sh
+++ b/lib/functions/general/bat-cat.sh
@@ -41,6 +41,11 @@ function run_tool_batcat() {
 		*x86_64-*-linux-gnu*) BATCAT_ARCH_OS="x86_64-unknown-linux-gnu" ;;
 		*aarch64-*-linux-gnu*) BATCAT_ARCH_OS="aarch64-unknown-linux-gnu" ;;
 		*x86_64-apple-darwin*) BATCAT_ARCH_OS="x86_64-apple-darwin" ;;
+		*riscv64*)
+			# check https://github.com/sharkdp/bat in the future, build might be possible
+			display_alert "No RISC-V riscv64 support for batcat" "batcat will not run" "wrn"
+			return 0
+			;;
 		*)
 			exit_with_error "unknown os/arch for batcat download: '$MACHINE'"
 			;;
@@ -97,8 +102,8 @@ function run_tool_batcat() {
 		bat_cat_columns=60
 	fi
 	case "${background_dark_or_light}" in
-		dark)	declare bat_cat_theme="Dracula" ;;
-		*)	declare bat_cat_theme="ansi" ;;
+		dark) declare bat_cat_theme="Dracula" ;;
+		*) declare bat_cat_theme="ansi" ;;
 	esac
 	display_alert "Calling batcat" "COLUMNS: ${bat_cat_columns} | $*" "debug"
 	BAT_CONFIG_DIR="${DIR_BATCAT}/config" BAT_CACHE_PATH="${DIR_BATCAT}/cache" "${BATCAT_BIN}" --theme "${bat_cat_theme}" --paging=never --force-colorization --wrap auto --terminal-width "${bat_cat_columns}" "$@"

--- a/lib/functions/general/oci-oras.sh
+++ b/lib/functions/general/oci-oras.sh
@@ -48,6 +48,10 @@ function run_tool_oras() {
 	case "$MACHINE" in
 		*aarch64*) ORAS_ARCH="arm64" ;;
 		*x86_64*) ORAS_ARCH="amd64" ;;
+		*riscv64*)
+			ORAS_ARCH="riscv64"
+			ORAS_VERSION="1.2.0-beta.1" # Only v1.2.0-beta.1+ has risv64 support
+			;;
 		*)
 			exit_with_error "unknown arch: $MACHINE"
 			;;

--- a/lib/functions/general/shellcheck.sh
+++ b/lib/functions/general/shellcheck.sh
@@ -87,6 +87,11 @@ function run_tool_shellcheck() {
 	case "$MACHINE" in
 		*aarch64*) SHELLCHECK_ARCH="aarch64" ;;
 		*x86_64*) SHELLCHECK_ARCH="x86_64" ;;
+		*riscv64*)
+			# check https://github.com/koalaman/shellcheck in the future, build might be possible
+			display_alert "No RISC-V riscv64 support for SHELLCHECK" "SHELLCHECK will not run" "wrn"
+			return 0
+			;;
 		*)
 			exit_with_error "unknown arch: $MACHINE"
 			;;

--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -289,8 +289,8 @@ function adaptative_prepare_host_dependencies() {
 	### Python
 	host_deps_add_extra_python # See python-tools.sh::host_deps_add_extra_python()
 
-	# Python3 -- required for Armbian's Python tooling, and also for more recent u-boot builds. Needs 3.9+
-	host_dependencies+=("python3-dev" "python3-distutils" "python3-setuptools" "python3-pip")
+	# Python3 -- required for Armbian's Python tooling, and also for more recent u-boot builds. Needs 3.9+; ffi-dev is needed for some Python packages when the wheel is not prebuilt
+	host_dependencies+=("python3-dev" "python3-distutils" "python3-setuptools" "python3-pip" "libffi-dev")
 
 	# Python2 -- required for some older u-boot builds
 	# Debian 'sid'/'bookworm' and Ubuntu 'lunar' does not carry python2 anymore; in this case some u-boot's might fail to build.


### PR DESCRIPTION
#### riscv64: fixes/skips for building (sans Docker) ON riscv64

- oci-oras: use ORAS `1.2.0-beta.1` for riscv64
- prepare-host: add libffi-dev host dependency, needed for Python3 setuptools (when prebuilt wheel not found)
  - fixes errors that show up only when building on non-arm64/amd64, when there's no prebuilt wheel (eg on riscv64)
- shellcheck: skip running shellcheck, with a warning, if running on riscv64
  - someone go add riscv64 to https://github.com/koalaman/shellcheck
- batcat: skip running batcat, with a warning, if running on riscv64
  - someone go add riscv64 to https://github.com/sharkdp/bat