### PR TITLE
rockchip-rk3588-edge: opi5-plus: fix USB3 Host

### DIFF
--- a/patch/kernel/rockchip-rk3588-edge/0027-arm64-dts-Add-missing-nodes-to-Orange-Pi-5-Plus.patch
+++ b/patch/kernel/rockchip-rk3588-edge/0027-arm64-dts-Add-missing-nodes-to-Orange-Pi-5-Plus.patch
@@ -1,14 +1,14 @@
-From 54a207592a425697c5b81fa486062d10a551d223 Mon Sep 17 00:00:00 2001
+From 98ad20c1d298e3458541c7d0a133ac55427f812b Mon Sep 17 00:00:00 2001
 From: Muhammed Efe Cetin <efectn@protonmail.com>
 Date: Thu, 16 Nov 2023 18:15:09 +0300
 Subject: [PATCH] arm64: dts: Add missing nodes to Orange Pi 5 Plus
 
 ---
- .../dts/rockchip/rk3588-orangepi-5-plus.dts   | 189 +++++++++++++++++-
- 1 file changed, 188 insertions(+), 1 deletion(-)
+ .../dts/rockchip/rk3588-orangepi-5-plus.dts   | 190 +++++++++++++++++-
+ 1 file changed, 189 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-plus.dts b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-plus.dts
-index 3e660ff6cd5f..69cdc966d602 100644
+index 3e660ff6cd5f..ef7f9386fc02 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-plus.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-plus.dts
 @@ -10,6 +10,7 @@
@@ -257,12 +257,13 @@ index 3e660ff6cd5f..69cdc966d602 100644
  &usb_host1_ehci {
  	status = "okay";
  };
-@@ -845,3 +991,44 @@ &usb_host1_ehci {
+@@ -845,3 +991,45 @@ &usb_host1_ehci {
  &usb_host1_ohci {
  	status = "okay";
  };
 +
 +&usb_host1_xhci {
++	dr_mode = "host";
 +	status = "okay";
 +};
 +


### PR DESCRIPTION
# Description

This PR fixed usb_host1_xhci port on Orange Pi 5 Plus with edge kernel. We have to use `host` mode by default since OPi makes the port USB3 host and connect it to USB hub.

Jira reference number [AR-9999]

# How Has This Been Tested?
- [x] Build

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
