### PR TITLE
cli: introduce `kernel-dtb` cli command, to build only DTB, and output full preprocessed dts source

### DIFF
--- a/lib/functions/artifacts/artifact-kernel.sh
+++ b/lib/functions/artifacts/artifact-kernel.sh
@@ -182,12 +182,14 @@ function artifact_kernel_prepare_version() {
 
 	# map what "compile_kernel()" will produce - legacy deb names and versions
 
-	# linux-image is always produced...
-	artifact_map_packages=(["linux-image"]="linux-image-${BRANCH}-${LINUXFAMILY}")
+	# linux-image is always produced... unless we're in DTB-only mode
+	if [[ "${KERNEL_DTB_ONLY}" != "yes" ]]; then
+		artifact_map_packages=(["linux-image"]="linux-image-${BRANCH}-${LINUXFAMILY}")
 
-	# some/most kernels have also working headers...
-	if [[ "${KERNEL_HAS_WORKING_HEADERS:-"no"}" == "yes" ]]; then
-		artifact_map_packages+=(["linux-headers"]="linux-headers-${BRANCH}-${LINUXFAMILY}")
+		# some/most kernels have also working headers...
+		if [[ "${KERNEL_HAS_WORKING_HEADERS:-"no"}" == "yes" ]]; then
+			artifact_map_packages+=(["linux-headers"]="linux-headers-${BRANCH}-${LINUXFAMILY}")
+		fi
 	fi
 
 	# x86, specially, does not have working dtbs...
@@ -195,7 +197,13 @@ function artifact_kernel_prepare_version() {
 		artifact_map_packages+=(["linux-dtb"]="linux-dtb-${BRANCH}-${LINUXFAMILY}")
 	fi
 
-	artifact_name="kernel-${LINUXFAMILY}-${BRANCH}"
+	artifact_name="kernel-${LINUXFAMILY}-${BRANCH}" # default name of regular artifact
+
+	# Separate artifact name if we're in DTB-only mode, so stuff doesn't get mixed up later
+	if [[ "${KERNEL_DTB_ONLY}" == "yes" ]]; then
+		artifact_name="kernel-dtb-only-${LINUXFAMILY}-${BRANCH}"
+	fi
+
 	artifact_type="deb-tar" # this triggers processing of .deb files in the maps to produce a tarball
 	artifact_deb_repo="global"
 	artifact_deb_arch="${ARCH}"

--- a/lib/functions/cli/commands.sh
+++ b/lib/functions/cli/commands.sh
@@ -57,6 +57,7 @@ function armbian_register_commands() {
 		["rootfs"]="artifact"
 
 		["kernel"]="artifact"
+		["kernel-dtb"]="artifact"
 		["kernel-patch"]="artifact"
 		["kernel-config"]="artifact"
 		["rewrite-kernel-config"]="artifact"
@@ -113,6 +114,7 @@ function armbian_register_commands() {
 		["kernel-config"]="WHAT='kernel' KERNEL_CONFIGURE='yes' ${common_cli_artifact_interactive_vars} ${common_cli_artifact_vars}"
 		["rewrite-kernel-config"]="WHAT='kernel' KERNEL_CONFIGURE='yes' ARTIFACT_WILL_NOT_BUILD='yes' ARTIFACT_IGNORE_CACHE='yes' ${common_cli_artifact_vars}"
 		["kernel-patch"]="WHAT='kernel' CREATE_PATCHES='yes' ${common_cli_artifact_interactive_vars} ${common_cli_artifact_vars}"
+		["kernel-dtb"]="WHAT='kernel' KERNEL_DTB_ONLY='yes' ${common_cli_artifact_interactive_vars} ${common_cli_artifact_vars}"
 
 		["uboot"]="WHAT='uboot' ${common_cli_artifact_vars}"
 		["uboot-config"]="WHAT='uboot' UBOOT_CONFIGURE='yes' ${common_cli_artifact_interactive_vars} ${common_cli_artifact_vars}"

--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -66,9 +66,11 @@ function prepare_kernel_packaging_debs() {
 	# Due to we call `make install` twice, we will get some `.old` files
 	run_host_command_logged rm -rf "${tmp_kernel_install_dirs[INSTALL_PATH]}/*.old" || true
 
-	# package the linux-image (image, modules, dtbs (if present))
-	display_alert "Packaging linux-image" "${LINUXFAMILY} ${LINUXCONFIG}" "info"
-	create_kernel_deb "linux-image-${BRANCH}-${LINUXFAMILY}" "${debs_target_dir}" kernel_package_callback_linux_image "linux-image"
+	if [[ "${KERNEL_DTB_ONLY}" != "yes" ]]; then
+		# package the linux-image (image, modules, dtbs (if present))
+		display_alert "Packaging linux-image" "${LINUXFAMILY} ${LINUXCONFIG}" "info"
+		create_kernel_deb "linux-image-${BRANCH}-${LINUXFAMILY}" "${debs_target_dir}" kernel_package_callback_linux_image "linux-image"
+	fi
 
 	# if dtbs present, package those too separately, for u-boot usage.
 	if [[ -d "${tmp_kernel_install_dirs[INSTALL_DTBS_PATH]}" ]]; then
@@ -76,11 +78,13 @@ function prepare_kernel_packaging_debs() {
 		create_kernel_deb "linux-dtb-${BRANCH}-${LINUXFAMILY}" "${debs_target_dir}" kernel_package_callback_linux_dtb "linux-dtb"
 	fi
 
-	if [[ "${KERNEL_HAS_WORKING_HEADERS}" == "yes" ]]; then
-		display_alert "Packaging linux-headers" "${LINUXFAMILY} ${LINUXCONFIG}" "info"
-		create_kernel_deb "linux-headers-${BRANCH}-${LINUXFAMILY}" "${debs_target_dir}" kernel_package_callback_linux_headers "linux-headers"
-	else
-		display_alert "Skipping linux-headers package" "for ${KERNEL_MAJOR_MINOR} kernel version" "info"
+	if [[ "${KERNEL_DTB_ONLY}" != "yes" ]]; then
+		if [[ "${KERNEL_HAS_WORKING_HEADERS}" == "yes" ]]; then
+			display_alert "Packaging linux-headers" "${LINUXFAMILY} ${LINUXCONFIG}" "info"
+			create_kernel_deb "linux-headers-${BRANCH}-${LINUXFAMILY}" "${debs_target_dir}" kernel_package_callback_linux_headers "linux-headers"
+		else
+			display_alert "Skipping linux-headers package" "for ${KERNEL_MAJOR_MINOR} kernel version" "info"
+		fi
 	fi
 }
 

--- a/lib/functions/compilation/kernel.sh
+++ b/lib/functions/compilation/kernel.sh
@@ -46,7 +46,6 @@ function compile_kernel() {
 		*Hook to copy extra kernel sources to the kernel under compilation*
 	ARMBIAN_KERNEL_SOURCES_EXTRA
 
-
 	# Possibly 'make clean'.
 	LOG_SECTION="kernel_maybe_clean" do_with_logging do_with_hooks kernel_maybe_clean
 
@@ -150,12 +149,63 @@ function kernel_prepare_build_and_package() {
 		install_make_params_quoted+=("${value}")
 	done
 
-	# Fire off the build & package
-	LOG_SECTION="kernel_build" do_with_logging do_with_hooks kernel_build
+	if [[ "${KERNEL_DTB_ONLY}" == "yes" ]]; then
+		# Helper for local development of device tree
+		kernel_dtb_only_build
+	else
+		# Normal build, which includes "all" target etc
+		LOG_SECTION="kernel_build" do_with_logging do_with_hooks kernel_build
+	fi
 
+	# Package what has been built
 	LOG_SECTION="kernel_package" do_with_logging do_with_hooks kernel_package
 
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
+}
+
+function kernel_dtb_only_build() {
+	display_alert "Kernel DTB-only for development" "KERNEL_DTB_ONLY: ${KERNEL_DTB_ONLY}" "warn"
+	# Do it in two separate steps, first build the dtbs then install them.
+	build_targets=("dtbs")
+	LOG_SECTION="kernel_build" do_with_logging do_with_hooks kernel_build
+
+	display_alert "Kernel DTB-only for development" "Installing DTBs" "warn"
+	build_targets=("dtbs_install")
+	LOG_SECTION="kernel_build" do_with_logging do_with_hooks kernel_build
+
+	# If BOOT_FDT_FILE is set...
+	if [[ -n "${BOOT_FDT_FILE}" ]]; then
+		display_alert "Kernel DTB-only for development" "Copying preprocessed version of ${BOOT_FDT_FILE}" "warn"
+
+		# Take BOOT_FDT_FILE (eg: "rockchip/rk3588-smth.dtb") and parse fdt_dir and fdt_file out of it
+		declare fdt_dir fdt_file
+		[[ "${BOOT_FDT_FILE}" =~ ^(.*)/(.*)$ ]] && fdt_dir="${BASH_REMATCH[1]}" && fdt_file="${BASH_REMATCH[2]}"
+
+		# Check it worked, or bail
+		if [[ -z "${fdt_dir}" || -z "${fdt_file}" ]]; then
+			exit_with_error "Failed to parse BOOT_FDT_FILE: ${BOOT_FDT_FILE}"
+		fi
+
+		# Kernel build should produce a preprocessed version of all DTS files built into DTBs at arch/arm64/boot/dts/${fdt_dir}/.${fdt_file}.dts.tmp
+		declare preprocessed_fdt_source="${kernel_work_dir}/arch/${ARCH}/boot/dts/${fdt_dir}/.${fdt_file}.dts.tmp"
+
+		# Check it exists, or bail
+		if [[ ! -f "${preprocessed_fdt_source}" ]]; then
+			exit_with_error "Preprocessed FDT source not found: ${preprocessed_fdt_source}"
+		fi
+
+		declare preprocessed_fdt_dest="${SRC}/output/${fdt_dir}-${fdt_file}--${KERNEL_MAJOR_MINOR}-${BRANCH}.preprocessed.dts"
+		run_host_command_logged cp -v "${preprocessed_fdt_source}" "${preprocessed_fdt_dest}"
+
+		# Include a normalization pass through the dtc tool, with DTS as both input and output formats; this introduces phandles, unfortunately
+		declare preprocessed_fdt_normalized="${SRC}/output/${fdt_dir}-${fdt_file}--${KERNEL_MAJOR_MINOR}-${BRANCH}.preprocessed.normalized.dts"
+		run_host_command_logged dtc -I dts -O dts -o "${preprocessed_fdt_normalized}" "${preprocessed_fdt_dest}"
+
+		display_alert "Kernel DTB-only for development" "Preprocessed FDT dest: ${preprocessed_fdt_dest}" "warn"
+		display_alert "Kernel DTB-only for development" "Preprocessed FDT normalized: ${preprocessed_fdt_normalized}" "warn"
+	fi
+
+	return 0
 }
 
 function kernel_build() {


### PR DESCRIPTION
#### cli: introduce `kernel-dtb` cli command, to build only DTB, and output full preprocessed dts source

- cli: introduce `kernel-dtb` cli command, to build only DTB, and output full preprocessed dts source
  - example: `./compile.sh BOARD=xxxxx BRANCH=edge kernel-dtb`
  - outputs preprocessed DTS source for board in question to `output/`
  - also outputs same preprocessed DTS source, ran through `dtc` with input and output DTS formats for "normalized" comparisions