### PR TITLE
Add board: FriendlyElec CM3588 NAS

### DIFF
--- a/config/boards/nanopc-cm3588-nas.csc
+++ b/config/boards/nanopc-cm3588-nas.csc
@@ -1,0 +1,44 @@
+# Rockchip RK3588 octa core 16GB RAM SoC eMMC 4x NVMe 3x USB3 USB2 2.5GbE
+BOARD_NAME="NanoPC CM3588 NAS"
+BOARDFAMILY="rockchip-rk3588"
+#BOARD_MAINTAINER=""
+BOOTCONFIG="nanopc_cm3588_defconfig" # Enables booting from NVMe. Vendor name, not standard, see hook below, set BOOT_SOC below to compensate
+BOOT_SOC="rk3588"
+KERNEL_TARGET="legacy"
+FULL_DESKTOP="yes"
+BOOT_LOGO="desktop"
+BOOT_FDT_FILE="rockchip/rk3588-nanopc-cm3588-nas.dtb"
+BOOT_SCENARIO="spl-blobs"
+IMAGE_PARTITION_TABLE="gpt"
+BOOTFS_TYPE="fat"
+DDR_BLOB='rk35/rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.15.bin'
+BL31_BLOB='rk35/rk3588_bl31_v1.44.elf'
+declare -g UEFI_EDK2_BOARD_ID="nanopc-cm3588-nas" # This _only_ used for uefi-edk2-rk3588 extension
+
+
+function post_family_tweaks__nanopccm3588nas_udev_naming_audios() {
+	display_alert "$BOARD" "Renaming CM3588 audio interfaces to human-readable form" "info"
+
+	mkdir -p $SDCARD/etc/udev/rules.d/
+	
+	cat <<- EOF > "${SDCARD}/etc/udev/rules.d/90-naming-audios.rules"
+		SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-hdmi0-sound", ENV{SOUND_DESCRIPTION}="HDMI-0 Audio Out"
+		SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-hdmi1-sound", ENV{SOUND_DESCRIPTION}="HDMI-1 Audio Out"
+		SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-dp0-sound", ENV{SOUND_DESCRIPTION}="DisplayPort-Over-USB Audio Out"
+		SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-rt5616-sound", ENV{SOUND_DESCRIPTION}="Headphone Out/Mic In"
+		SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-hdmiin-sound", ENV{SOUND_DESCRIPTION}="HDMI-IN Audio In"
+	EOF
+
+}
+
+# Output from CM3588 syslog with edge kernel 6.8: r8169 0004:41:00.0 enP4p65s0: renamed from eth0
+# Note: legacy kernel 5.10 uses driver r8125, edge kernel uses r8169 as of 6.8
+function post_family_tweaks__nanopccm3588nas_udev_naming_network_interfaces() {
+	display_alert "$BOARD" "Renaming CM3588 LAN interface to eth0" "info"
+
+	mkdir -p $SDCARD/etc/udev/rules.d/
+	cat <<- EOF > "${SDCARD}/etc/udev/rules.d/70-persistent-net.rules"
+		SUBSYSTEM=="net", ACTION=="add", KERNELS=="0004:41:00.0", NAME:="eth0"
+	EOF
+
+}

--- a/config/boards/nanopc-cm3588-nas.csc
+++ b/config/boards/nanopc-cm3588-nas.csc
@@ -1,10 +1,10 @@
 # Rockchip RK3588 octa core 16GB RAM SoC eMMC 4x NVMe 3x USB3 USB2 2.5GbE
 BOARD_NAME="NanoPC CM3588 NAS"
 BOARDFAMILY="rockchip-rk3588"
-#BOARD_MAINTAINER=""
+BOARD_MAINTAINER=""
 BOOTCONFIG="nanopc_cm3588_defconfig" # Enables booting from NVMe. Vendor name, not standard, see hook below, set BOOT_SOC below to compensate
 BOOT_SOC="rk3588"
-KERNEL_TARGET="legacy"
+KERNEL_TARGET="legacy,vendor"
 FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
 BOOT_FDT_FILE="rockchip/rk3588-nanopc-cm3588-nas.dtb"
@@ -15,12 +15,11 @@ DDR_BLOB='rk35/rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.15.bin'
 BL31_BLOB='rk35/rk3588_bl31_v1.44.elf'
 declare -g UEFI_EDK2_BOARD_ID="nanopc-cm3588-nas" # This _only_ used for uefi-edk2-rk3588 extension
 
-
 function post_family_tweaks__nanopccm3588nas_udev_naming_audios() {
 	display_alert "$BOARD" "Renaming CM3588 audio interfaces to human-readable form" "info"
 
 	mkdir -p $SDCARD/etc/udev/rules.d/
-	
+
 	cat <<- EOF > "${SDCARD}/etc/udev/rules.d/90-naming-audios.rules"
 		SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-hdmi0-sound", ENV{SOUND_DESCRIPTION}="HDMI-0 Audio Out"
 		SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-hdmi1-sound", ENV{SOUND_DESCRIPTION}="HDMI-1 Audio Out"

--- a/patch/u-boot/legacy/u-boot-radxa-rk3588/0103-U-Boot-Add-defconfig-and-dts-for-FriendlyElec-CM3588.patch
+++ b/patch/u-boot/legacy/u-boot-radxa-rk3588/0103-U-Boot-Add-defconfig-and-dts-for-FriendlyElec-CM3588.patch
@@ -1,0 +1,480 @@
+From 72941e1891dfdc8a23ae01dc478ab6ac19fbbb4a Mon Sep 17 00:00:00 2001
+From: ColorfulRhino <131405023+ColorfulRhino@users.noreply.github.com>
+Date: Tue, 5 Mar 2024 20:38:59 +0000
+Subject: [PATCH] U-Boot: Add defconfig and dts for FriendlyElec CM3588
+
+---
+ arch/arm/dts/rk3588-nanopc-cm3588.dts | 235 ++++++++++++++++++++++++++
+ configs/nanopc_cm3588_defconfig       | 218 ++++++++++++++++++++++++
+ 2 files changed, 453 insertions(+)
+ create mode 100644 arch/arm/dts/rk3588-nanopc-cm3588.dts
+ create mode 100644 configs/nanopc_cm3588_defconfig
+
+diff --git a/arch/arm/dts/rk3588-nanopc-cm3588.dts b/arch/arm/dts/rk3588-nanopc-cm3588.dts
+new file mode 100644
+index 0000000..b8a8c64
+--- /dev/null
++++ b/arch/arm/dts/rk3588-nanopc-cm3588.dts
+@@ -0,0 +1,235 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2021 Rockchip Electronics Co., Ltd
++ *
++ */
++
++/dts-v1/;
++#include <dt-bindings/input/input.h>
++#include "rk3588.dtsi"
++#include "rk3588-u-boot.dtsi"
++
++/ {
++	model = "FriendlyElec CM3588";
++	compatible = "friendlyelec,cm3588", "rockchip,rk3588";
++
++	vcc12v_dcin: vcc12v-dcin {
++		u-boot,dm-pre-reloc;
++		compatible = "regulator-fixed";
++		regulator-name = "vcc12v_dcin";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <12000000>;
++		regulator-max-microvolt = <12000000>;
++	};
++
++	vcc5v0_sys: vcc5v0-sys {
++		u-boot,dm-pre-reloc;
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc12v_dcin>;
++	};
++
++	vcc_5v0: vcc-5v0 {
++		u-boot,dm-pre-reloc;
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_5v0";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		regulator-boot-on;
++		regulator-always-on;
++		enable-active-high;
++		gpio = <&gpio4 RK_PA3 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc_5v0_en>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	vcc5v0_host: vcc5v0-host-regulator {
++		u-boot,dm-pre-reloc;
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_host";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		enable-active-high;
++		gpio = <&gpio4 RK_PB5 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc5v0_host_en>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	vcc3v3_pcie30: vcc3v3-pcie30 {
++		u-boot,dm-pre-reloc;
++		startup-delay-us = <50000>;
++		compatible = "regulator-fixed";
++		regulator-name = "vcc3v3_pcie30";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	led_sys: led-sys {
++		u-boot,dm-pre-reloc;
++		compatible = "regulator-fixed";
++		regulator-name = "led_sys";
++		enable-active-high;
++		gpio = <&gpio1 RK_PC1 GPIO_ACTIVE_HIGH>; // Turn on user led
++		regulator-boot-on;
++		regulator-always-on;
++		vin-supply = <&vcc5v0_sys>;
++	};
++};
++
++&pcie2x1l0 {
++	u-boot,dm-pre-reloc;
++	/* 2. CON14: pcie30phy port0 lane1 */
++	max-link-speed = <3>;
++	num-lanes = <1>;
++	phys = <&pcie30phy>;
++	reset-gpios = <&gpio4 RK_PB4 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc3v3_pcie30>;
++	status = "okay";
++
++	pcie@0,0 {
++		reg = <0x00200000 0 0 0 0>;
++		#address-cells = <3>;
++		#size-cells = <2>;
++
++		nvme1: pcie@20,0 {
++			reg = <0x000000 0 0 0 0>;
++		};
++	};
++};
++
++&pcie2x1l1 {
++	u-boot,dm-pre-reloc;
++	/* 4. CON16: pcie30phy port1 lane1 */
++	max-link-speed = <3>;
++	num-lanes = <1>;
++	phys = <&pcie30phy>;
++	reset-gpios = <&gpio4 RK_PA2 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc3v3_pcie30>;
++	status = "okay";
++
++	pcie@0,0 {
++		reg = <0x00300000 0 0 0 0>;
++		#address-cells = <3>;
++		#size-cells = <2>;
++
++		nvme3: pcie@30,0 {
++			reg = <0x000000 0 0 0 0>;
++		};
++	};
++};
++
++&pcie3x4 {
++	u-boot,dm-pre-reloc;
++	/* 1. CON13: pcie30phy port0 lane0 */
++	max-link-speed = <3>;
++	num-lanes = <1>;
++	reset-gpios = <&gpio4 RK_PB6 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc3v3_pcie30>;
++	status = "okay";
++
++	pcie@0,0 {
++		reg = <0x00000000 0 0 0 0>;
++		#address-cells = <3>;
++		#size-cells = <2>;
++
++		nvme0: pcie@0,0 {
++			reg = <0x000000 0 0 0 0>;
++		};
++	};
++};
++
++&pcie3x2 {
++	u-boot,dm-pre-reloc;
++	/* 3. CON15: pcie30phy port1 lane0 */
++	max-link-speed = <3>;
++	num-lanes = <1>;
++	reset-gpios = <&gpio4 RK_PB3 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc3v3_pcie30>;
++	status = "okay";
++
++	pcie@0,0 {
++		reg = <0x00100000 0 0 0 0>;
++		#address-cells = <3>;
++		#size-cells = <2>;
++
++		nvme2: pcie@10,0 {
++			reg = <0x000000 0 0 0 0>;
++		};
++	};
++};
++
++&pcie30phy {
++	u-boot,dm-pre-reloc;
++	rockchip,pcie30-phymode = <PHY_MODE_PCIE_NABIBI>;
++	status = "okay";
++};
++
++&combphy0_ps {
++	u-boot,dm-pre-reloc;
++	status = "okay";
++};
++
++&combphy2_psu {
++	u-boot,dm-pre-reloc;
++	status = "okay";
++};
++
++&usb2phy0_grf {
++	status = "okay";
++	u-boot,dm-pre-reloc;
++};
++
++&u2phy0 {
++	status = "okay";
++	u-boot,dm-pre-reloc;
++};
++
++&u2phy0_otg {
++	status = "okay";
++	u-boot,dm-pre-reloc;
++};
++
++&usb2phy2_grf {
++	status = "okay";
++	u-boot,dm-pre-reloc;
++};
++
++&u2phy2 {
++	status = "okay";
++	u-boot,dm-pre-reloc;
++};
++
++&u2phy2_host {
++	status = "okay";
++	u-boot,dm-pre-reloc;
++};
++
++&pinctrl {
++	usb {
++		u-boot,dm-pre-reloc;
++		vcc5v0_host_en: vcc5v0-host-en {
++			u-boot,dm-pre-reloc;
++			rockchip,pins = <4 RK_PB5 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	power {
++		u-boot,dm-spl;
++		vcc_5v0_en: vcc-5v0-en {
++			u-boot,dm-spl;
++			rockchip,pins = <4 RK_PA3 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++};
+diff --git a/configs/nanopc_cm3588_defconfig b/configs/nanopc_cm3588_defconfig
+new file mode 100644
+index 0000000..885f958
+--- /dev/null
++++ b/configs/nanopc_cm3588_defconfig
+@@ -0,0 +1,218 @@
++CONFIG_ARM=y
++CONFIG_ARM_CPU_SUSPEND=y
++CONFIG_ARCH_ROCKCHIP=y
++CONFIG_SPL_GPIO_SUPPORT=y
++CONFIG_SPL_LIBCOMMON_SUPPORT=y
++CONFIG_SPL_LIBGENERIC_SUPPORT=y
++CONFIG_SYS_MALLOC_F_LEN=0x80000
++CONFIG_SPL_FIT_GENERATOR="arch/arm/mach-rockchip/make_fit_atf.sh"
++CONFIG_ROCKCHIP_RK3588=y
++CONFIG_ROCKCHIP_USB_BOOT=y
++CONFIG_ROCKCHIP_FIT_IMAGE=y
++CONFIG_ROCKCHIP_HWID_DTB=y
++CONFIG_ROCKCHIP_VENDOR_PARTITION=y
++CONFIG_USING_KERNEL_DTB_V2=y
++CONFIG_ROCKCHIP_FIT_IMAGE_PACK=y
++CONFIG_ROCKCHIP_NEW_IDB=y
++CONFIG_LOADER_INI="RK3588MINIALL.ini"
++CONFIG_TRUST_INI="RK3588TRUST.ini"
++CONFIG_SPL_SERIAL_SUPPORT=y
++CONFIG_SPL_DRIVERS_MISC_SUPPORT=y
++CONFIG_TARGET_EVB_RK3588=y
++CONFIG_SPL_LIBDISK_SUPPORT=y
++CONFIG_SPL_SPI_FLASH_SUPPORT=y
++CONFIG_SPL_SPI_SUPPORT=y
++CONFIG_DEFAULT_DEVICE_TREE="rk3588-nanopc-cm3588"
++CONFIG_DEBUG_UART=y
++CONFIG_FIT=y
++CONFIG_FIT_IMAGE_POST_PROCESS=y
++CONFIG_FIT_HW_CRYPTO=y
++CONFIG_SPL_LOAD_FIT=y
++CONFIG_SPL_FIT_IMAGE_POST_PROCESS=y
++CONFIG_SPL_FIT_HW_CRYPTO=y
++# CONFIG_SPL_SYS_DCACHE_OFF is not set
++CONFIG_BOOTDELAY=2
++CONFIG_SYS_CONSOLE_INFO_QUIET=y
++# CONFIG_DISPLAY_CPUINFO is not set
++CONFIG_ANDROID_BOOTLOADER=y
++CONFIG_ANDROID_AVB=y
++CONFIG_ANDROID_BOOT_IMAGE_HASH=y
++CONFIG_SPL_BOARD_INIT=y
++# CONFIG_SPL_RAW_IMAGE_SUPPORT is not set
++# CONFIG_SPL_LEGACY_IMAGE_SUPPORT is not set
++CONFIG_SPL_SEPARATE_BSS=y
++CONFIG_SYS_MMCSD_RAW_MODE_U_BOOT_USE_PARTITION=y
++CONFIG_SYS_MMCSD_RAW_MODE_U_BOOT_PARTITION=0x1
++CONFIG_SPL_MMC_WRITE=y
++CONFIG_SPL_MTD_SUPPORT=y
++CONFIG_SPL_ATF=y
++CONFIG_FASTBOOT_BUF_ADDR=0xc00800
++CONFIG_FASTBOOT_BUF_SIZE=0x04000000
++CONFIG_FASTBOOT_FLASH=y
++CONFIG_FASTBOOT_FLASH_MMC_DEV=0
++CONFIG_CMD_BOOTZ=y
++CONFIG_CMD_DTIMG=y
++# CONFIG_CMD_ELF is not set
++# CONFIG_CMD_IMI is not set
++# CONFIG_CMD_IMLS is not set
++# CONFIG_CMD_XIMG is not set
++# CONFIG_CMD_LZMADEC is not set
++# CONFIG_CMD_UNZIP is not set
++# CONFIG_CMD_FLASH is not set
++# CONFIG_CMD_FPGA is not set
++CONFIG_CMD_GPT=y
++# CONFIG_CMD_LOADB is not set
++# CONFIG_CMD_LOADS is not set
++CONFIG_CMD_BOOT_ANDROID=y
++CONFIG_CMD_MMC=y
++CONFIG_CMD_PCI=y
++CONFIG_CMD_SF=y
++CONFIG_CMD_SPI=y
++CONFIG_CMD_USB=y
++CONFIG_CMD_USB_MASS_STORAGE=y
++# CONFIG_CMD_ITEST is not set
++# CONFIG_CMD_SETEXPR is not set
++CONFIG_CMD_TFTPPUT=y
++CONFIG_CMD_TFTP_BOOTM=y
++CONFIG_CMD_TFTP_FLASH=y
++# CONFIG_CMD_MISC is not set
++CONFIG_CMD_MTD_BLK=y
++# CONFIG_SPL_DOS_PARTITION is not set
++# CONFIG_ISO_PARTITION is not set
++CONFIG_EFI_PARTITION_ENTRIES_NUMBERS=64
++CONFIG_SPL_OF_CONTROL=y
++CONFIG_SPL_DTB_MINIMUM=y
++CONFIG_OF_LIVE=y
++CONFIG_OF_SPL_REMOVE_PROPS="clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
++# CONFIG_NET_TFTP_VARS is not set
++CONFIG_REGMAP=y
++CONFIG_SPL_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_SPL_SYSCON=y
++# CONFIG_SARADC_ROCKCHIP is not set
++CONFIG_SARADC_ROCKCHIP_V2=y
++CONFIG_CLK=y
++CONFIG_SPL_CLK=y
++CONFIG_CLK_SCMI=y
++CONFIG_SPL_CLK_SCMI=y
++CONFIG_DM_CRYPTO=y
++CONFIG_SPL_DM_CRYPTO=y
++CONFIG_ROCKCHIP_CRYPTO_V2=y
++CONFIG_SPL_ROCKCHIP_CRYPTO_V2=y
++CONFIG_DM_RNG=y
++CONFIG_RNG_ROCKCHIP=y
++CONFIG_SCMI_FIRMWARE=y
++CONFIG_SPL_SCMI_FIRMWARE=y
++CONFIG_ROCKCHIP_GPIO=y
++CONFIG_ROCKCHIP_GPIO_V2=y
++CONFIG_SYS_I2C_ROCKCHIP=y
++CONFIG_DM_KEY=y
++CONFIG_ADC_KEY=y
++CONFIG_MISC=y
++CONFIG_SPL_MISC=y
++CONFIG_MISC_DECOMPRESS=y
++CONFIG_SPL_MISC_DECOMPRESS=y
++CONFIG_ROCKCHIP_OTP=y
++CONFIG_ROCKCHIP_HW_DECOMPRESS=y
++CONFIG_SPL_ROCKCHIP_HW_DECOMPRESS=y
++CONFIG_SPL_ROCKCHIP_SECURE_OTP=y
++CONFIG_MMC_DW=y
++CONFIG_MMC_DW_ROCKCHIP=y
++CONFIG_MMC_SDHCI=y
++CONFIG_MMC_SDHCI_SDMA=y
++CONFIG_MMC_SDHCI_ROCKCHIP=y
++CONFIG_MTD=y
++CONFIG_MTD_BLK=y
++CONFIG_MTD_DEVICE=y
++CONFIG_NAND=y
++CONFIG_MTD_SPI_NAND=y
++CONFIG_SPI_FLASH=y
++CONFIG_SF_DEFAULT_SPEED=80000000
++CONFIG_SPI_FLASH_EON=y
++CONFIG_SPI_FLASH_GIGADEVICE=y
++CONFIG_SPI_FLASH_MACRONIX=y
++CONFIG_SPI_FLASH_SST=y
++CONFIG_SPI_FLASH_WINBOND=y
++CONFIG_SPI_FLASH_XMC=y
++CONFIG_SPI_FLASH_XTX=y
++CONFIG_SPI_FLASH_MTD=y
++CONFIG_DM_ETH=y
++CONFIG_DM_ETH_PHY=y
++CONFIG_DWC_ETH_QOS=y
++CONFIG_GMAC_ROCKCHIP=y
++CONFIG_NVME=y
++CONFIG_PCI=y
++CONFIG_DM_PCI=y
++CONFIG_DM_PCI_COMPAT=y
++CONFIG_PCIE_DW_ROCKCHIP=y
++CONFIG_PHY_ROCKCHIP_INNO_USB2=y
++CONFIG_PHY_ROCKCHIP_SAMSUNG_HDPTX=y
++CONFIG_PHY_ROCKCHIP_SNPS_PCIE3=y
++CONFIG_PINCTRL=y
++CONFIG_SPL_PINCTRL=y
++CONFIG_DM_PMIC=y
++CONFIG_PMIC_SPI_RK8XX=y
++CONFIG_REGULATOR_PWM=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_DM_REGULATOR_GPIO=y
++CONFIG_REGULATOR_RK860X=y
++CONFIG_REGULATOR_RK806=y
++CONFIG_PWM_ROCKCHIP=y
++CONFIG_RAM=y
++CONFIG_SPL_RAM=y
++CONFIG_TPL_RAM=y
++CONFIG_ROCKCHIP_SDRAM_COMMON=y
++CONFIG_ROCKCHIP_TPL_INIT_DRAM_TYPE=0
++CONFIG_DM_RESET=y
++CONFIG_SPL_DM_RESET=y
++CONFIG_SPL_RESET_ROCKCHIP=y
++CONFIG_BAUDRATE=1500000
++CONFIG_DEBUG_UART_BASE=0xFEB50000
++CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_DEBUG_UART_SHIFT=2
++CONFIG_ROCKCHIP_SPI=y
++CONFIG_ROCKCHIP_SFC=y
++CONFIG_SYSRESET=y
++CONFIG_USB=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_XHCI_DWC3=y
++CONFIG_USB_XHCI_PCI=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_EHCI_GENERIC=y
++CONFIG_USB_OHCI_HCD=y
++CONFIG_USB_OHCI_GENERIC=y
++CONFIG_USB_DWC3=y
++CONFIG_USB_DWC3_GADGET=y
++CONFIG_USB_DWC3_GENERIC=y
++CONFIG_USB_STORAGE=y
++CONFIG_USB_GADGET=y
++CONFIG_USB_GADGET_MANUFACTURER="Rockchip"
++CONFIG_USB_GADGET_VENDOR_NUM=0x2207
++CONFIG_USB_GADGET_PRODUCT_NUM=0x350a
++CONFIG_USB_GADGET_DOWNLOAD=y
++CONFIG_DM_VIDEO=y
++CONFIG_DISPLAY=y
++CONFIG_DRM_ROCKCHIP=y
++CONFIG_DRM_ROCKCHIP_DW_MIPI_DSI2=y
++CONFIG_DRM_ROCKCHIP_ANALOGIX_DP=y
++CONFIG_DRM_ROCKCHIP_SAMSUNG_MIPI_DCPHY=y
++CONFIG_USE_TINY_PRINTF=y
++CONFIG_LIB_RAND=y
++CONFIG_SPL_TINY_MEMSET=y
++CONFIG_RSA=y
++CONFIG_SPL_RSA=y
++CONFIG_RSA_N_SIZE=0x200
++CONFIG_RSA_E_SIZE=0x10
++CONFIG_RSA_C_SIZE=0x20
++CONFIG_LZ4=y
++CONFIG_ERRNO_STR=y
++# CONFIG_EFI_LOADER is not set
++CONFIG_AVB_LIBAVB=y
++CONFIG_AVB_LIBAVB_AB=y
++CONFIG_AVB_LIBAVB_ATX=y
++CONFIG_AVB_LIBAVB_USER=y
++CONFIG_RK_AVB_LIBAVB_USER=y
++CONFIG_OPTEE_CLIENT=y
++CONFIG_OPTEE_V2=y
++CONFIG_OPTEE_ALWAYS_USE_SECURITY_PARTITION=y
++CONFIG_PHY_ROCKCHIP_NANENG_COMBOPHY=y
+-- 
+2.34.1
+


### PR DESCRIPTION
# Description

Hello! This adds board support for FriendlyElec's CM3588 board including its accompanying NAS Kit.
For now, only the legacy kernel 5.10 is supported. The required dts files have already been merged in https://github.com/armbian/linux-rockchip/pull/151

_About the board name: FriendlyElec did not name this board NanoPC or NanoPi. However, to make it easier to find, both for development and when using the build menu, I prefixed the board with "NanoPC", since simply "CM3588" is very generic otherwise. This way, it is grouped with the other FriendlyElec boards like the NanoPCs and NanoPis. This board also shares many similarities with the NanoPC-T6, I managed to boot the board with NanoPC-T6's Armbian image with some missing features._
Please let me know if you would prefer the name "NanoPi CM3588" or something else instead.

## Hardware specs:

**Notable features:**
- SoC: Rockchip RK3588
- 4 PCIe/NVMe slots (🌈)
- Basically equipped with most I/O stuff RK3588 has to offer

<details>
<summary>
<b>All hardware specs</b>
</summary>

<ul><li> SoC: Rockchip RK3588
<ul><li> CPU: Quad-core ARM Cortex-A76(up to 2.4GHz) and quad-core Cortex-A55 CPU (up to 1.8GHz)</li>
<li> GPU: Mali-G610 MP4, compatible with OpenGLES 1.1, 2.0, and 3.2, OpenCL up to 2.2 and Vulkan1.2</li>
<li> VPU: 8K@60fps H.265 and VP9 decoder, 8K@30fps H.264 decoder, 4K@60fps AV1 decoder, 8K@30fps H.264 and H.265 encoder</li>
<li> NPU: 6TOPs, supports INT4/INT8/INT16/FP16</li></ul></li>
<li> RAM: 64-bit 4GB/8GB/16GB LPDDR4X at 2133MHz</li>
<li> Flash: 0GB/64GB eMMC, at HS400 mode</li>
<li> 1 x microSD interface, support up to SDR104 mode</li>
<li> 1 x On-board PCIe 2.5G ethernet controller (RTL8125B)</li>
<li> USB:
<ul><li> 2 x USB 3.1 Gen1 OTG which combo with DP display（up to 4Kp60）</li>
<li> 1 x USB 3.1 Gen1 Host</li>
<li> 2 x USB 2.0 Host</li></ul></li>
<li> PCIe:
<ul><li> up to 4 x PCIe interfaces
<ul><li> 2 x  PCIe 2.1 x1 and 2 x PCIe 3.0 x2</li>
<li> or 2 x PCIe 2.1 x1 and 1 x PCIe 3.0 x4</li>
<li> or 1 x PCIe 2.1 x1, 1 x PCIe 3.0 x2, and 2 x PCIe 3.0 x1</li>
<li> or 4 x PCIe 3.0 x1</li></ul></li></ul></li>
<li> HDMI output: 
<ul><li> 2 x HDMI outputs which is compatible with HDMI2.1, HDMI2.0, and HDMI1.4 operation</li>
<li> one support displays up to 7680x4320@60Hz, another one support up to 4Kp60</li>
<li> Support RGB/YUV(up to 10bit) format</li></ul></li>
<li> HDMI input: 1 x HDMI input, up to 4Kp60</li>
<li> MIPI RX:
<ul><li> 2 x 4lane MIPI DPHY CSI RX which support x4 mode or x2+x2 mode ,compatible with MIPI V1.2</li>
<li> 2 x 4lane MIPI_D/CPHY_RX</li></ul></li>
<li> MIPI TX:
<ul><li> 2 x 4-lane MIPI D-PHY/C-PHY Combo PHY TX, compatible with MIPI DPHY 2.0 or CPHY 1.1</li></ul></li>
<li> Codec:
<ul><li> On-board ALC5616 Codec</li>
<li> 1 x stereo headphone output ( 20mW/CH, THD+N &lt;= -80dB, 16Ohm Load )</li>
<li> 1 x single-end microphone input</li></ul></li>
<li> GPIO: 
<ul><li> up to 3 x SPIs, 7 x UARTs, 6 x I2Cs, 15 x PWMs, 3 x I2Ss, 1 x SDIO, 81 x GPIOs</li></ul></li>
<li> others: 
<ul><li> low power RTC (HYM8563TS) with backup battery input</li>
<li> Support 38Khz IR input</li>
<li> MASK button for eMMC update, reset button, Power button, and recovery mode button</li>
<li> Debug UART,3.3V level, 1500000bps</li>
<li> 2 x GPIO Controlled LED (SYS, LED1)</li></ul></li>
<li> Power supply: 5~20VDC input, 15W max</li>
<li> PCB: 8 Layers, 55x65x1.6mm</li>
<li> Stacking height: 6.6mm</li>
<li> Connector: 4 x DF40C-100DP-0.4V(51), the mating connector is DF40HC(3.0)-100DS-0.4V(51)</li>
<li> Ambient Operating Temperature: 0℃ to 70℃</li></ul>
</details>

**Wiki link:** https://wiki.friendlyelec.com/wiki/index.php/CM3588_NAS_Kit

# How Has This Been Tested?

**Test build configuration:**
_Armbian-unofficial_24.5.0-trunk_Nanopc-cm3588-nas_bookworm_legacy_5.10.160_
- BRANCH=legacy
- RELEASE=bookworm
- BUILD_MINIMAL=no
- BUILD_DESKTOP=yes and no

**Tested and working:**
- [x] all 4 NVMe ports
- [x] eMMC (including booting from it)
- [x] Ethernet port
- [x] 2xUSB3, 1xUSB2 (USB-C and OTG/DP mode untested)
- [x] HDMI 4k@60 (tested with Gnome desktop)
- [x] Hardware buttons (power, reset)
- [x] LEDs (power, power2, disk activity for all 4 NVMe ports, ethernet)
- [x] Booting from NVMe while U-Boot is on eMMC
- [x] Hardware acceleration for video encoding/decoding (tested with jellyfin-ffmpeg6)
- [x] Hardware acceleration for crypto
- [x] CPU Watchdog


`lsblk` output with 1 NVMe SSD attached:
```
NAME         MAJ:MIN RM   SIZE RO TYPE MOUNTPOINTS
mmcblk0      179:0    0  57.6G  0 disk
├─mmcblk0p1  179:1    0   256M  0 part /boot
└─mmcblk0p2  179:2    0  56.8G  0 part /var/log.hdd
                                       /
mmcblk0boot0 179:32   0     4M  1 disk
mmcblk0boot1 179:64   0     4M  1 disk
zram0        254:0    0   7.8G  0 disk [SWAP]
zram1        254:1    0    50M  0 disk /var/log
nvme0n1      259:0    0 465.8G  0 disk
└─nvme0n1p1  259:1    0  93.1G  0 part
```

<details>

<summary>
<b>U-Boot log: click here</b>
</summary>

```
DDR d5483af87d cym 23/11/23-16:15:24,fwver: v1.15
LPDDR4X, 2112MHz
channel[0] BW=16 Col=10 Bk=8 CS0 Row=17 CS1 Row=17 CS=2 Die BW=8 Size=4096MB
channel[1] BW=16 Col=10 Bk=8 CS0 Row=17 CS1 Row=17 CS=2 Die BW=8 Size=4096MB
channel[2] BW=16 Col=10 Bk=8 CS0 Row=17 CS1 Row=17 CS=2 Die BW=8 Size=4096MB
channel[3] BW=16 Col=10 Bk=8 CS0 Row=17 CS1 Row=17 CS=2 Die BW=8 Size=4096MB
Manufacturer ID:0x1
CH0 RX Vref:29.3%, TX Vref:20.8%,19.8%
CH1 RX Vref:28.9%, TX Vref:21.8%,21.8%
CH2 RX Vref:30.1%, TX Vref:21.8%,21.8%
CH3 RX Vref:29.7%, TX Vref:21.8%,21.8%
change to F1: 528MHz
change to F2: 1068MHz
change to F3: 1560MHz
change to F0: 2112MHz
out
U-Boot SPL board init
U-Boot SPL 2017.09-armbian (Mar 05 2024 - 21:22:44)
unknown raw ID 0 0 0
unrecognized JEDEC id bytes: 00, 00, 00
Trying to boot from MMC2
MMC: no card present
mmc_init: -123, time 1
spl: mmc init failed with error: -123
Trying to boot from MMC1
spl: partition error
Trying fit image at 0x4000 sector
## Verified-boot: 0
## Checking atf-1 0x00040000 ... sha256(2e8446f969...) + OK
## Checking uboot 0x00200000 ... sha256(2749d6a722...) + OK
## Checking fdt 0x0031d258 ... sha256(99f4e4e4a9...) + OK
## Checking atf-2 0xff100000 ... sha256(9f75e6ec37...) + OK
## Checking atf-3 0x000f0000 ... sha256(c80587de50...) + OK
Jumping to U-Boot(0x00200000) via ARM Trusted Firmware(0x00040000)
Total: 116.373 ms

INFO:    Preloader serial: 2
NOTICE:  BL31: v2.3():v2.3-662-g4acbe711b-dirty:finley.xiao, fwver: v1.44
NOTICE:  BL31: Built : 16:44:24, Nov  7 2023
INFO:    spec: 0x1
INFO:    code: 0x88
INFO:    ext 32k is not valid
INFO:    ddr: stride-en 4CH
INFO:    GICv3 without legacy support detected.
INFO:    ARM GICv3 driver initialized in EL3
INFO:    valid_cpu_msk=0xff bcore0_rst = 0x0, bcore1_rst = 0x0
INFO:    l3 cache partition cfg-0
INFO:    system boots from cpu-hwid-0
INFO:    idle_st=0x21fff, pd_st=0x11fff9, repair_st=0xfff70001
INFO:    dfs DDR fsp_params[0].freq_mhz= 2112MHz
INFO:    dfs DDR fsp_params[1].freq_mhz= 528MHz
INFO:    dfs DDR fsp_params[2].freq_mhz= 1068MHz
INFO:    dfs DDR fsp_params[3].freq_mhz= 1560MHz
INFO:    BL31: Initialising Exception Handling Framework
INFO:    BL31: Initializing runtime services
WARNING: No OPTEE provided by BL2 boot loader, Booting device without OPTEE initialization. SMC`s destined for OPTEE will return SMC_UNK
ERROR:   Error initializing runtime service opteed_fast
INFO:    BL31: Preparing for EL3 exit to normal world
INFO:    Entry point address = 0x200000
INFO:    SPSR = 0x3c9


U-Boot 2017.09-armbian (Mar 05 2024 - 21:22:44)

Model: FriendlyElec CM3588
PreSerial: 2, raw, 0xfeb50000
DRAM:  16 GiB
Sysmem: init
Relocation Offset: eda40000
Relocation fdt: eb9f8f18 - eb9fecc0
CR: M/C/I
Using default environment

mmc@fe2c0000: 1, mmc@fe2e0000: 0
Bootdev(atags): mmc 0
MMC0: HS200, 200Mhz
PartType: EFI
DM: v2
No misc partition
boot mode: normal
FIT: No boot partition
No resource partition
No resource partition
Failed to load DTB, ret=-19
No find valid DTB, ret=-22
Failed to get kernel dtb, ret=-22
Model: FriendlyElec CM3588
starting USB...
No working controllers found
No usb mass storage found
CLK: (sync kernel. arm: enter 1008000 KHz, init 1008000 KHz, kernel 0N/A)
  b0pll 24000 KHz
  b1pll 24000 KHz
  lpll 24000 KHz
  v0pll 24000 KHz
  aupll 24000 KHz
  cpll 1500000 KHz
  gpll 1188000 KHz
  npll 24000 KHz
  ppll 1100000 KHz
  aclk_center_root 702000 KHz
  pclk_center_root 100000 KHz
  hclk_center_root 396000 KHz
  aclk_center_low_root 500000 KHz
  aclk_top_root 750000 KHz
  pclk_top_root 100000 KHz
  aclk_low_top_root 396000 KHz
Net:   No ethernet found.
Hit key to stop autoboot('CTRL+C'):  0 
MMC: no card present
mmc_init: -123, time 0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x1
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x1
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x1
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe Linking... LTSSM is 0x0
pcie@fe180000: PCIe-0 Link Fail

Device 0: unknown device
switch to partitions #0, OK
mmc0(part 0) is current device
Scanning mmc 0:1...
Found U-Boot script /boot.scr
reading /boot.scr
3892 bytes read in 0 ms
## Executing script at 00500000
Boot script loaded from mmc 0
Testing for existence mmc 0 /armbianEnv.txt ...
Found mmc 0 /armbianEnv.txt - loading mmc 0 0x9000000 /armbianEnv.txt ...
reading /armbianEnv.txt
170 bytes read in 0 ms
Loaded environment from mmc 0 /armbianEnv.txt into 0x9000000 filesize 0xaa...
Importing into environment ...
armbianEnv.txt imported into environment
reading /uInitrd
14883003 bytes read in 82 ms (173.1 MiB/s)
reading /Image
35062272 bytes read in 191 ms (175.1 MiB/s)
reading /dtb/rockchip/rk3588-nanopc-cm3588-nas.dtb
271333 bytes read in 5 ms (51.8 MiB/s)
** Unable to read file /dtb/rockchip/overlay/rockchip-rk3588-fixup.scr **
Unknown command 'kaslrseed' - try 'help'
Fdt Ramdisk skip relocation
No misc partition
## Loading init Ramdisk from Legacy Image at 0a200000 ...
   Image Name:   uInitrd
   Image Type:   AArch64 Linux RAMDisk Image (gzip compressed)
   Data Size:    14882939 Bytes = 14.2 MiB
   Load Address: 00000000
   Entry Point:  00000000
   Verifying Checksum ... OK
## Flattened Device Tree blob at 0x08300000
   Booting using the fdt blob at 0x08300000
   reserving fdt memory region: addr=8300000 size=a8000
  'reserved-memory' cma: addr=10000000 size=8000000
  'reserved-memory' ramoops@110000: addr=110000 size=f0000
   Using Device Tree in place at 0000000008300000, end 00000000083aafff
Adding bank: 0x00200000 - 0xf0000000 (size: 0xefe00000)
Adding bank: 0x100000000 - 0x3fc000000 (size: 0x2fc000000)
Adding bank: 0x3fc500000 - 0x3fff00000 (size: 0x03a00000)
Adding bank: 0x4f0000000 - 0x500000000 (size: 0x10000000)
Total: 1424.199 ms

Starting kernel ...

1;-1fdone.
Begin: Mounting root file system ... Begin: Running /scripts/local-top ... done.
Begin: Running /scripts/local-premount ... Scanning for Btrfs filesystems
done.
Begin: Will now check root file system ... fsck from util-linux 2.38.1
[/sbin/fsck.ext4 (1) -- /dev/mmcblk0p2] fsck.ext4 -a -C0 /dev/mmcblk0p2 
armbi_root: clean, 44982/145152 files, 459926/580603 blocks
done.
done.
Begin: Running /scripts/local-bottom ... done.
Begin: Running /scripts/init-bottom ... done.

Welcome to Armbian-unofficial 24.5.0-trunk bookworm!

[  OK  ] Created slice system-modpr lice - Slice /system/modprobe.
[  OK  ] Created slice system-seria  - Slice /system/serial-getty.
[  OK  ] Created slice system-syste  - Slice /system/systemd-fsck.
[  OK  ] Created slice user.slice - User and Session Slice.
[  OK  ] Started systemd-ask-passwo  Requests to Wall Directory Watch.
[  OK  ] Set up automount proc-sys- rmats File System Automount Point.
         Expecting device dev-disk- m - /dev/disk/by-uuid/FE8A-0707...
         Expecting device dev-ttyFIQ0.device - /dev/ttyFIQ0...
[  OK  ] Reached target integrityse Local Integrity Protected Volumes.
[  OK  ] Reached target slices.target - Slice Units.
[  OK  ] Reached target swap.target - Swaps.
[  OK  ] Reached target time-set.target - System Time Set.
[  OK  ] Reached target veritysetup  - Local Verity Protected Volumes.
[  OK  ] Listening on rpcbind.socke  RPCbind Server Activation Socket.
[  OK  ] Listening on syslog.socket - Syslog Socket.
[  OK  ] Listening on systemd-fsckd sck to fsckd communication Socket.
[  OK  ] Listening on systemd-initc  initctl Compatibility Named Pipe.
[  OK  ] Listening on systemd-journ socket - Journal Audit Socket.
[  OK  ] Listening on systemd-journ t - Journal Socket (/dev/log).
[  OK  ] Listening on systemd-journald.socket - Journal Socket.
[  OK  ] Listening on systemd-udevd .socket - udev Control Socket.
[  OK  ] Listening on systemd-udevd l.socket - udev Kernel Socket.
         Mounting dev-hugepages.mount - Huge Pages File System...
         Mounting dev-mqueue.mountPOSIX Message Queue File System...
         Mounting sys-kernel-debug.  - Kernel Debug File System...
         Mounting sys-kernel-tracin  - Kernel Trace File System...
         Starting fake-hwclock.serv estore / save the current clock...
         Starting keyboard-setup.se Set the console keyboard layout...
         Starting kmod-static-nodes ate List of Static Device Nodes...
         Starting modprobe@configfs m - Load Kernel Module configfs...
         Starting modprobe@dm_mod.s [0m - Load Kernel Module dm_mod...
         Starting modprobe@drm.service - Load Kernel Module drm...
         Starting modprobe@efi_psto - Load Kernel Module efi_pstore...
         Starting modprobe@fuse.ser e - Load Kernel Module fuse...
         Starting modprobe@loop.ser e - Load Kernel Module loop...
         Starting systemd-modules-l rvice - Load Kernel Modules...
         Starting systemd-remount-f nt Root and Kernel File Systems...
         Starting systemd-udev-trig [0m - Coldplug All udev Devices...
[  OK  ] Mounted dev-hugepages.mount - Huge Pages File System.
[  OK  ] Mounted dev-mqueue.mount- POSIX Message Queue File System.
[  OK  ] Mounted sys-kernel-debug.m nt - Kernel Debug File System.
[  OK  ] Mounted sys-kernel-tracing nt - Kernel Trace File System.
[  OK  ] Finished fake-hwclock.serv  Restore / save the current clock.
[  OK  ] Finished kmod-static-nodes reate List of Static Device Nodes.
[  OK  ] Finished modprobe@configfs [0m - Load Kernel Module configfs.
[  OK  ] Finished modprobe@dm_mod.s e - Load Kernel Module dm_mod.
[  OK  ] Finished modprobe@drm.service - Load Kernel Module drm.
[  OK  ] Finished modprobe@efi_psto m - Load Kernel Module efi_pstore.
[  OK  ] Finished modprobe@fuse.service - Load Kernel Module fuse.
[  OK  ] Finished modprobe@loop.service - Load Kernel Module loop.
[  OK  ] Finished systemd-modules-l service - Load Kernel Modules.
         Mounting sys-fs-fuse-conne  - FUSE Control File System...
         Mounting sys-kernel-config ernel Configuration File System...
         Starting systemd-sysctl.se ce - Apply Kernel Variables...
[  OK  ] Mounted sys-fs-fuse-connec nt - FUSE Control File System.
[  OK  ] Mounted sys-kernel-config.  Kernel Configuration File System.
[  OK  ] Finished systemd-remount-f ount Root and Kernel File Systems.
         Starting systemd-random-se ice - Load/Save Random Seed...
         Starting systemd-sysusers. rvice - Create System Users...
[  OK  ] Finished systemd-sysctl.service - Apply Kernel Variables.
[  OK  ] Finished systemd-random-se rvice - Load/Save Random Seed.
[  OK  ] Finished systemd-sysusers.service - Create System Users.
         Starting systemd-tmpfiles- ate Static Device Nodes in /dev...
[  OK  ] Finished keyboard-setup.se - Set the console keyboard layout.
[  OK  ] Finished systemd-tmpfiles- reate Static Device Nodes in /dev.
[  OK  ] Reached target local-fs-pr reparation for Local File Systems.
         Starting systemd-udevd.ser ger for Device Events and Files...
[  OK  ] Started systemd-udevd.serv nager for Device Events and Files.
[  OK  ] Found device dev-ttyFIQ0.device - /dev/ttyFIQ0.
[  OK  ] Finished systemd-udev-trig e - Coldplug All udev Devices.
         Starting ifupdown-pre.serv ynchronize boot up for ifupdown...
         Starting plymouth-start.se [0m - Show Plymouth Boot Screen...
[  OK  ] Found device dev-disk-by\x [0m - /dev/disk/by-uuid/FE8A-0707.
[  OK  ] Started plymouth-start.ser e - Show Plymouth Boot Screen.
[  OK  ] Started systemd-ask-passwo uests to Plymouth Directory Watch.
[  OK  ] Reached target cryptsetup. get - Local Encrypted Volumes.
[  OK  ] Reached target paths.target - Path Units.
         Starting modprobe@dm_mod.s [0m - Load Kernel Module dm_mod...
         Starting modprobe@efi_psto - Load Kernel Module efi_pstore...
         Starting modprobe@loop.ser e - Load Kernel Module loop...
         Starting systemd-fsck@dev-  on /dev/disk/by-uuid/FE8A-0707...
[  OK  ] Finished modprobe@dm_mod.s e - Load Kernel Module dm_mod.
[  OK  ] Finished modprobe@efi_psto m - Load Kernel Module efi_pstore.
[  OK  ] Finished modprobe@loop.service - Load Kernel Module loop.
[  OK  ] Started systemd-fsckd.serv tem Check Daemon to report status.
         Starting modprobe@dm_mod.s [0m - Load Kernel Module dm_mod...
         Starting modprobe@efi_psto - Load Kernel Module efi_pstore...
         Starting modprobe@loop.ser e - Load Kernel Module loop...
[  OK  ] Finished systemd-fsck@dev- ck on /dev/disk/by-uuid/FE8A-0707.
[  OK  ] Finished modprobe@dm_mod.s e - Load Kernel Module dm_mod.
[  OK  ] Finished modprobe@efi_psto m - Load Kernel Module efi_pstore.
[  OK  ] Finished modprobe@loop.service - Load Kernel Module loop.
[  OK  ] Listening on systemd-rfkil l Switch Status /dev/rfkill Watch.
[  OK  ] Reached target usb-gadget. m - Hardware activated USB gadget.
[  OK  ] Finished ifupdown-pre.serv  synchronize boot up for ifupdown.
         Mounting boot.mount - /boot...
         Mounting tmp.mount - /tmp...
[  OK  ] Mounted boot.mount - /boot.
[  OK  ] Mounted tmp.mount - /tmp.
[  OK  ] Reached target local-fs.target - Local File Systems.
         Starting armbian-zram-conf rvice - Armbian ZRAM config...
         Starting console-setup.ser m - Set console font and keymap...
         Starting networking.service - Raise network interfaces...
         Starting plymouth-read-wri…mouth To Write Out Runtime Data...
         Starting systemd-binfmt.se et Up Additional Binary Formats...
         Starting systemd-machine-i  a transient machine-id on disk...
[  OK  ] Finished plymouth-read-wri lymouth To Write Out Runtime Data.
         Mounting proc-sys-fs-binfm utable File Formats File System...
[  OK  ] Mounted proc-sys-fs-binfmt ecutable File Formats File System.
[  OK  ] Finished systemd-binfmt.se  Set Up Additional Binary Formats.
[  OK  ] Finished systemd-machine-i it a transient machine-id on disk.
[  OK  ] Finished armbian-zram-conf service - Armbian ZRAM config.
         Starting armbian-ramlog.se rmbian memory supported logging...
[  OK  ] Finished networking.service - Raise network interfaces.
[  OK  ] Finished console-setup.ser [0m - Set console font and keymap.
[  OK  ] Finished armbian-ramlog.se  Armbian memory supported logging.
         Starting systemd-journald.service - Journal Service...
[  OK  ] Started systemd-journald.service - Journal Service.
         Starting systemd-journal-f h Journal to Persistent Storage...
[  OK  ] Finished systemd-journal-f ush Journal to Persistent Storage.
         Starting systemd-tmpfiles-  Volatile Files and Directories...
[  OK  ] Finished systemd-tmpfiles- te Volatile Files and Directories.
         Mounting run-rpc_pipefs.mount - RPC Pipe File System...
[  OK  ] Started haveged.servicemon based on the HAVEGE algorithm.
         Starting rpcbind.service - RPC bind portmap service...
         Starting systemd-resolved. e - Network Name Resolution...
         Starting systemd-update-ut rd System Boot/Shutdown in UTMP...
[  OK  ] Mounted run-rpc_pipefs.mount - RPC Pipe File System.
[  OK  ] Reached target rpc_pipefs.target.
[  OK  ] Reached target nfs-client.target - NFS client services.
[  OK  ] Started rpcbind.service - RPC bind portmap service.
[  OK  ] Finished systemd-update-ut cord System Boot/Shutdown in UTMP.
[  OK  ] Reached target remote-fs-p eparation for Remote File Systems.
[  OK  ] Reached target remote-fs.target - Remote File Systems.
[  OK  ] Reached target rpcbind.target - RPC Port Mapper.
[  OK  ] Started systemd-resolved.s ice - Network Name Resolution.
[  OK  ] Reached target nss-lookup. m - Host and Network Name Lookups.
[  OK  ] Reached target sysinit.target - System Initialization.
[  OK  ] Started systemd-tmpfiles-c  Cleanup of Temporary Directories.
[  OK  ] Listening on dbus.socket- D-Bus System Message Bus Socket.
[  OK  ] Reached target sockets.target - Socket Units.
         Starting armbian-hardware- m - Armbian hardware monitoring...
         Starting armbian-hardware- - Armbian hardware optimization...
         Starting armbian-resize-fi [0m - Armbian filesystem resize...
[  OK  ] Finished armbian-hardware- [0m - Armbian hardware monitoring.
[  OK  ] Finished armbian-hardware- m - Armbian hardware optimization.
[  OK  ] Finished armbian-resize-fi e - Armbian filesystem resize.
[  OK  ] Reached target basic.target - Basic System.
         Starting alsa-restore.serv - Save/Restore Sound Card State...
[  OK  ] Started armbian-firstrun.s ice - Armbian first run tasks.
[  OK  ] Created slice system-getty.slice - Slice /system/getty.
[  OK  ] Started cron.service - kground program processing daemon.
         Starting dbus.service - D-Bus System Message Bus...
         Starting e2scrub_reap.serv e ext4 Metadata Check Snapshots...
         Starting loadcpufreq.servi eeded to enable cpufreq scaling...
         Starting rng-tools-debian. LSB: rng-tools (Debian variant)...
         Starting rsyslog.service - System Logging Service...
         Starting sysstat.service - Resets System Activity Logs...
         Starting systemd-logind.se ice - User Login Management...
[  OK  ] Finished alsa-restore.serv m - Save/Restore Sound Card State.
[  OK  ] Reached target sound.target - Sound Card.
[  OK  ] Finished sysstat.service - Resets System Activity Logs.
[  OK  ] Started rsyslog.service - System Logging Service.
[  OK  ] Started rng-tools-debian.s - LSB: rng-tools (Debian variant).
[  OK  ] Started dbus.service - D-Bus System Message Bus.
[  OK  ] Finished e2scrub_reap.serv ine ext4 Metadata Check Snapshots.
         Starting NetworkManager.service - Network Manager...
         Starting wpa_supplicant.service - WPA supplicant...
[  OK  ] Started loadcpufreq.servic  needed to enable cpufreq scaling.
         Starting cpufrequtils.serv : set CPUFreq kernel parameters...
[  OK  ] Started wpa_supplicant.service - WPA supplicant.
[  OK  ] Started cpufrequtils.servi SB: set CPUFreq kernel parameters.
         Starting sysfsutils.servic  variables from /etc/sysfs.conf...
[  OK  ] Started systemd-logind.service - User Login Management.
[  OK  ] Started sysfsutils.service fs variables from /etc/sysfs.conf.
[  OK  ] Started NetworkManager.service - Network Manager.
[  OK  ] Reached target network.target - Network.
[  OK  ] Reached target network-online.target - Network is Online.
         Starting chrony.service - chrony, an NTP client/server...
         Starting openvpn.service - OpenVPN service...
         Starting rc-local.servicem - /etc/rc.local Compatibility...
         Starting rpc-statd-notify. - Notify NFS peers of a restart...
         Starting ssh.service - OpenBSD Secure Shell server...
         Starting systemd-user-sess vice - Permit User Sessions...
[  OK  ] Started unattended-upgrade 0m - Unattended Upgrades Shutdown.
[  OK  ] Started vnstat.service - vnStat network traffic monitor.
[  OK  ] Finished openvpn.service - OpenVPN service.
[  OK  ] Started rc-local.service - /etc/rc.local Compatibility.
[  OK  ] Started rpc-statd-notify.s m - Notify NFS peers of a restart.
[  OK  ] Finished systemd-user-sess ervice - Permit User Sessions.
         Starting plymouth-quit-wai  until boot process finishes up...
         Starting plymouth-quit.ser  Terminate Plymouth Boot Screen...
         Starting systemd-hostnamed.service - Hostname Service...

nanopc-cm3588-nas login: root (automatic login)


Waiting for system to finish booting ...
/usr/lib/armbian/armbian-firstlogin: line 471: /sys/class/graphics/fb0/virtual_size: No such file or directory
Welcome to Armbian-unofficial! 
```

</details>

`dmesg` output: https://paste.armbian.com/xaneneqatu.yaml

<details>
<summary>
<b>Notable errors found in dmesg: click here</b>
</summary>

```
...
[    1.735730] OF: fdt: Reserved memory: failed to reserve memory for node 'drm-logo@00000000': base 0x0000000000000000, size 0 MiB
[    1.735748] OF: fdt: Reserved memory: failed to reserve memory for node 'drm-cubic-lut@00000000': base 0x0000000000000000, size 0 MiB
[    1.735833] Reserved memory: created CMA memory pool at 0x0000000010000000, size 128 MiB
...
[    3.491458] fiq_debugger fiq_debugger.0: IRQ fiq not found
[    3.491463] fiq_debugger fiq_debugger.0: IRQ wakeup not found
[    3.491467] fiq_debugger_probe: could not install nmi irq handler
...
[    3.493741] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up vdpu-supply from device tree
[    3.493759] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up vdpu-supply property in node /power-management@fd8d8000/power-controller failed
[    3.494014] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up rga30-supply from device tree
[    3.494030] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up rga30-supply property in node /power-management@fd8d8000/power-controller failed
[    3.494194] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up rga31-supply from device tree
[    3.494210] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up rga31-supply property in node /power-management@fd8d8000/power-controller failed
[    3.495418] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up venc0-supply from device tree
[    3.495434] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up venc0-supply property in node /power-management@fd8d8000/power-controller failed
[    3.495575] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up vcodec-supply from device tree
[    3.495591] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up vcodec-supply property in node /power-management@fd8d8000/power-controller failed
[    3.495688] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up venc1-supply from device tree
[    3.495704] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up venc1-supply property in node /power-management@fd8d8000/power-controller failed
[    3.495963] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up rkvdec0-supply from device tree
[    3.495978] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up rkvdec0-supply property in node /power-management@fd8d8000/power-controller failed
[    3.496249] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up rkvdec1-supply from device tree
[    3.496265] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up rkvdec1-supply property in node /power-management@fd8d8000/power-controller failed
...
[    4.296163] phy phy-fd5d0000.syscon:usb2-phy@0.0: Looking up phy-supply from device tree
[    4.296171] phy phy-fd5d0000.syscon:usb2-phy@0.0: Looking up phy-supply property in node /syscon@fd5d0000/usb2-phy@0/otg-port failed
[    4.296212] phy phy-fd5d0000.syscon:usb2-phy@0.0: Looking up vbus-supply from device tree
[    4.296218] phy phy-fd5d0000.syscon:usb2-phy@0.0: Looking up vbus-supply property in node /syscon@fd5d0000/usb2-phy@0/otg-port failed
[    4.297430] phy phy-fd5d8000.syscon:usb2-phy@8000.1: Looking up phy-supply from device tree
[    4.297552] vcc5v0_host_20: could not add device link phy-fd5d8000.syscon:usb2-phy@8000.1: -ENOENT
[    4.298783] phy phy-fd5dc000.syscon:usb2-phy@c000.2: Looking up phy-supply from device tree
[    4.298875] vcc3v3_host_32: could not add device link phy-fd5dc000.syscon:usb2-phy@c000.2: -ENOENT
[    4.300262] phy phy-fd5d4000.syscon:usb2-phy@4000.3: Looking up phy-supply from device tree
[    4.300271] vcc5v0_host_30: could not add device link phy-fd5d4000.syscon:usb2-phy@4000.3: -ENOENT
[    4.300340] phy phy-fd5d4000.syscon:usb2-phy@4000.3: Looking up vbus-supply from device tree
[    4.300346] phy phy-fd5d4000.syscon:usb2-phy@4000.3: Looking up vbus-supply property in node /syscon@fd5d4000/usb2-phy@4000/otg-port failed
[    4.302358] phy phy-fee00000.phy.4: Looking up phy-supply from device tree
[    4.302364] phy phy-fee00000.phy.4: Looking up phy-supply property in node /phy@fee00000 failed
[    4.302501] phy phy-fee20000.phy.5: Looking up phy-supply from device tree
[    4.302507] phy phy-fee20000.phy.5: Looking up phy-supply property in node /phy@fee20000 failed
[    4.302698] phy phy-fee10000.phy.6: Looking up phy-supply from device tree
[    4.302703] phy phy-fee10000.phy.6: Looking up phy-supply property in node /phy@fee10000 failed
[    4.303189] phy phy-feda0000.phy.7: Looking up phy-supply from device tree
[    4.303194] phy phy-feda0000.phy.7: Looking up phy-supply property in node /phy@feda0000 failed
[    4.303312] phy phy-fedb0000.phy.8: Looking up phy-supply from device tree
[    4.303316] phy phy-fedb0000.phy.8: Looking up phy-supply property in node /phy@fedb0000 failed
[    4.303686] phy phy-fed60000.hdmiphy.9: Looking up phy-supply from device tree
[    4.303692] phy phy-fed60000.hdmiphy.9: Looking up phy-supply property in node /hdmiphy@fed60000 failed
[    4.304380] rockchip-hdptx-phy-hdmi fed60000.hdmiphy: hdptx phy init success
[    4.304557] phy phy-fed70000.hdmiphy.10: Looking up phy-supply from device tree
[    4.304564] phy phy-fed70000.hdmiphy.10: Looking up phy-supply property in node /hdmiphy@fed70000 failed
[    4.305207] rockchip-hdptx-phy-hdmi fed70000.hdmiphy: hdptx phy init success
[    4.305517] phy phy-fee80000.phy.11: Looking up phy-supply from device tree
[    4.305522] phy phy-fee80000.phy.11: Looking up phy-supply property in node /phy@fee80000 failed
[    4.306283] phy phy-fed80000.phy.12: Looking up phy-supply from device tree
[    4.306289] phy phy-fed80000.phy.12: Looking up phy-supply property in node /phy@fed80000/dp-port failed
[    4.306319] phy phy-fed80000.phy.13: Looking up phy-supply from device tree
[    4.306324] phy phy-fed80000.phy.13: Looking up phy-supply property in node /phy@fed80000/u3-port failed
[    4.306571] phy phy-fed90000.phy.14: Looking up phy-supply from device tree
[    4.306577] phy phy-fed90000.phy.14: Looking up phy-supply property in node /phy@fed90000/u3-port failed
[    4.308197] rk-pcie fe180000.pcie: invalid prsnt-gpios property in node
[    4.308208] rk-pcie fe180000.pcie: Looking up vpcie3v3-supply from device tree
[    4.308382] rk-pcie fe150000.pcie: invalid prsnt-gpios property in node
[    4.308389] rk-pcie fe150000.pcie: Looking up vpcie3v3-supply from device tree
[    4.308562] rk-pcie fe160000.pcie: invalid prsnt-gpios property in node
[    4.308568] rk-pcie fe160000.pcie: Looking up vpcie3v3-supply from device tree
[    4.308685] rk-pcie fe170000.pcie: invalid prsnt-gpios property in node
[    4.308691] rk-pcie fe170000.pcie: Looking up vpcie3v3-supply from device tree
[    4.319652] rk-pcie fe180000.pcie: IRQ msi not found
[    4.319659] rk-pcie fe180000.pcie: use outband MSI support
[    4.319665] rk-pcie fe180000.pcie: Missing *config* reg space
[    4.319684] rk-pcie fe180000.pcie: host bridge /pcie@fe180000 ranges:
[    4.319686] rk-pcie fe150000.pcie: IRQ msi not found
[    4.319689] rk-pcie fe150000.pcie: use outband MSI support
[    4.319693] rk-pcie fe150000.pcie: Missing *config* reg space
[    4.319705] rk-pcie fe150000.pcie: host bridge /pcie@fe150000 ranges:
[    4.319737] rk-pcie fe150000.pcie:      err 0x00f0000000..0x00f00fffff -> 0x00f0000000
[    4.319746] rk-pcie fe180000.pcie:      err 0x00f3000000..0x00f30fffff -> 0x00f3000000
[    4.319749] rk-pcie fe150000.pcie:       IO 0x00f0100000..0x00f01fffff -> 0x00f0100000
[    4.319759] rk-pcie fe150000.pcie:      MEM 0x00f0200000..0x00f0ffffff -> 0x00f0200000
[    4.319769] rk-pcie fe150000.pcie:      MEM 0x0900000000..0x093fffffff -> 0x0900000000
[    4.319784] rk-pcie fe180000.pcie:       IO 0x00f3100000..0x00f31fffff -> 0x00f3100000
[    4.319797] rk-pcie fe150000.pcie: Missing *config* reg space
[    4.319808] rk-pcie fe180000.pcie:      MEM 0x00f3200000..0x00f3ffffff -> 0x00f3200000
[    4.319821] rk-pcie fe150000.pcie: invalid resource
[    4.319825] rk-pcie fe180000.pcie:      MEM 0x09c0000000..0x09ffffffff -> 0x09c0000000
[    4.319855] rk-pcie fe180000.pcie: Missing *config* reg space
[    4.319884] rk-pcie fe180000.pcie: invalid resource
[    4.319946] iep: Module initialized.
...
[    4.324741] mpp-iep2 fdbb0000.iep: Adding to iommu group 9
[    4.324869] mpp-iep2 fdbb0000.iep: probe device
[    4.324986] mpp-iep2 fdbb0000.iep: allocate roi buffer failed
[    4.325122] mpp-iep2 fdbb0000.iep: probing finish
...
[    4.326529] mpp_rkvdec2 fdc38100.rkvdec-core: rkvdec-core, probing start
[    4.326642] mpp_rkvdec2 fdc38100.rkvdec-core: shared_niu_a is not found!
[    4.326645] rkvdec2_init:1022: No niu aclk reset resource define
[    4.326648] mpp_rkvdec2 fdc38100.rkvdec-core: shared_niu_h is not found!
[    4.326650] rkvdec2_init:1025: No niu hclk reset resource define
[    4.326664] mpp_rkvdec2 fdc38100.rkvdec-core: Looking up vdec-supply from device tree
[    4.326669] mpp_rkvdec2 fdc38100.rkvdec-core: Looking up vdec-supply property in node /rkvdec-core@fdc38000 failed
[    4.326676] mpp_rkvdec2 fdc38100.rkvdec-core: no regulator, devfreq is disabled
...
[    4.327232] mpp_rkvdec2 fdc48100.rkvdec-core: rkvdec-core, probing start
[    4.327347] mpp_rkvdec2 fdc48100.rkvdec-core: shared_niu_a is not found!
[    4.327349] rkvdec2_init:1022: No niu aclk reset resource define
[    4.327352] mpp_rkvdec2 fdc48100.rkvdec-core: shared_niu_h is not found!
[    4.327354] rkvdec2_init:1025: No niu hclk reset resource define
[    4.327368] mpp_rkvdec2 fdc48100.rkvdec-core: Looking up vdec-supply from device tree
[    4.327372] mpp_rkvdec2 fdc48100.rkvdec-core: Looking up vdec-supply property in node /rkvdec-core@fdc48000 failed
[    4.327378] mpp_rkvdec2 fdc48100.rkvdec-core: no regulator, devfreq is disabled
...
[    4.328227] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up av1-supply from device tree
[    4.328244] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up av1-supply property in node /power-management@fd8d8000/power-controller failed
...
[    4.330467] rk-pcie fe160000.pcie: IRQ msi not found
[    4.330470] rk-pcie fe160000.pcie: use outband MSI support
[    4.330473] rk-pcie fe160000.pcie: Missing *config* reg space
[    4.330479] rk-pcie fe160000.pcie: host bridge /pcie@fe160000 ranges:
[    4.330489] rk-pcie fe160000.pcie:      err 0x00f1000000..0x00f10fffff -> 0x00f1000000
[    4.330496] rk-pcie fe160000.pcie:       IO 0x00f1100000..0x00f11fffff -> 0x00f1100000
[    4.330505] rk-pcie fe160000.pcie:      MEM 0x00f1200000..0x00f1ffffff -> 0x00f1200000
[    4.330510] rk-pcie fe160000.pcie:      MEM 0x0940000000..0x097fffffff -> 0x0940000000
[    4.330512] rk-pcie fe170000.pcie: IRQ msi not found
[    4.330514] rk-pcie fe170000.pcie: use outband MSI support
[    4.330517] rk-pcie fe170000.pcie: Missing *config* reg space
[    4.330523] rk-pcie fe170000.pcie: host bridge /pcie@fe170000 ranges:
[    4.330531] rk-pcie fe170000.pcie:      err 0x00f2000000..0x00f20fffff -> 0x00f2000000
[    4.330542] rk-pcie fe160000.pcie: Missing *config* reg space
[    4.330545] rk-pcie fe170000.pcie:       IO 0x00f2100000..0x00f21fffff -> 0x00f2100000
[    4.330552] rk-pcie fe170000.pcie:      MEM 0x00f2200000..0x00f2ffffff -> 0x00f2200000
[    4.330557] rk-pcie fe170000.pcie:      MEM 0x0980000000..0x09bfffffff -> 0x0980000000
[    4.330567] rk-pcie fe160000.pcie: invalid resource
[    4.330579] rk-pcie fe170000.pcie: Missing *config* reg space
[    4.330600] rk-pcie fe170000.pcie: invalid resource
...
[    4.356399] [drm] failed to init overlay plane Cluster0-win1
[    4.356401] [drm] failed to init overlay plane Cluster1-win1
[    4.356404] [drm] failed to init overlay plane Cluster2-win1
[    4.356406] [drm] failed to init overlay plane Cluster3-win1
...
[    4.368892] rockchip-drm display-subsystem: bound fdea0000.hdmi (ops 0xffff8000091d1c30)
[    4.368958] rockchip-drm display-subsystem: bound fde50000.dp (ops 0xffff8000091d4838)
[    4.369520] rockchip-drm display-subsystem: failed to parse loader memory
[    4.369591] rockchip-drm display-subsystem: [drm] Cannot find any crtc or sizes
[    4.369650] rockchip-drm display-subsystem: [drm] Cannot find any crtc or sizes
[    4.369676] rockchip-drm display-subsystem: [drm] Cannot find any crtc or sizes
...
[    4.383783] rockchip-spi feb20000.spi: no high_speed pinctrl state
[    4.385496] rk806 spi2.0: chip id: RK806,ver:0x2, 0x1
[    4.385639] rk806 spi2.0: ON: 0x80 OFF:0x80
[    4.387939] rk806-regulator rk806-regulator.10.auto: Looking up vcc1-supply from device tree
[    4.387946] vdd_gpu_s0: supplied by vcc5v0_sys
[    4.387952] vcc5v0_sys: could not add device link regulator.9: -ENOENT
[    4.388698] vdd_gpu_s0: 550 <--> 950 mV at 750 mV, enabled
[    4.389083] rk806-regulator rk806-regulator.10.auto: Looking up vcc2-supply from device tree
[    4.389089] vdd_cpu_lit_s0: supplied by vcc5v0_sys
[    4.389093] vcc5v0_sys: could not add device link regulator.10: -ENOENT
[    4.389352] vdd_cpu_lit_s0: 550 <--> 950 mV at 750 mV, enabled
[    4.389812] rk806-regulator rk806-regulator.10.auto: Looking up vcc3-supply from device tree
[    4.389818] vdd_log_s0: supplied by vcc5v0_sys
[    4.389822] vcc5v0_sys: could not add device link regulator.11: -ENOENT
[    4.390080] vdd_log_s0: 675 <--> 750 mV at 750 mV, enabled
[    4.390532] rk806-regulator rk806-regulator.10.auto: Looking up vcc4-supply from device tree
[    4.390547] vdd_vdenc_s0: supplied by vcc5v0_sys
[    4.390552] vcc5v0_sys: could not add device link regulator.12: -ENOENT
[    4.390814] vdd_vdenc_s0: 550 <--> 950 mV at 750 mV, enabled
[    4.391329] rk806-regulator rk806-regulator.10.auto: Looking up vcc5-supply from device tree
[    4.391334] vdd_ddr_s0: supplied by vcc5v0_sys
[    4.391340] vcc5v0_sys: could not add device link regulator.13: -ENOENT
[    4.391599] vdd_ddr_s0: 675 <--> 900 mV at 850 mV, enabled
[    4.391793] rk806-regulator rk806-regulator.10.auto: Looking up vcc6-supply from device tree
[    4.391798] vdd2_ddr_s3: supplied by vcc5v0_sys
[    4.391803] vcc5v0_sys: could not add device link regulator.14: -ENOENT
[    4.392118] vdd2_ddr_s3: at 500 mV, enabled
[    4.392459] rk806-regulator rk806-regulator.10.auto: Looking up vcc7-supply from device tree
[    4.392464] vdd_2v0_pldo_s3: supplied by vcc5v0_sys
[    4.392468] vcc5v0_sys: could not add device link regulator.15: -ENOENT
[    4.392726] vdd_2v0_pldo_s3: 2000 mV, enabled
[    4.393064] rk806-regulator rk806-regulator.10.auto: Looking up vcc8-supply from device tree
[    4.393069] vcc_3v3_s3: supplied by vcc5v0_sys
[    4.393073] vcc5v0_sys: could not add device link regulator.16: -ENOENT
[    4.393337] vcc_3v3_s3: 3300 mV, enabled
[    4.393645] rk806-regulator rk806-regulator.10.auto: Looking up vcc9-supply from device tree
[    4.393650] vddq_ddr_s0: supplied by vcc5v0_sys
[    4.393654] vcc5v0_sys: could not add device link regulator.17: -ENOENT
[    4.393992] vddq_ddr_s0: at 500 mV, enabled
[    4.394330] rk806-regulator rk806-regulator.10.auto: Looking up vcc10-supply from device tree
[    4.394335] vcc_1v8_s3: supplied by vcc5v0_sys
[    4.394339] vcc5v0_sys: could not add device link regulator.18: -ENOENT
[    4.394555] vcc_1v8_s3: 1800 mV, enabled
[    4.394899] rk806-regulator rk806-regulator.10.auto: Looking up vcc13-supply from device tree
[    4.394905] vdd_0v75_s3: supplied by vcc_1v1_nldo_s3
[    4.394910] vcc_1v1_nldo_s3: could not add device link regulator.19: -ENOENT
[    4.395126] vdd_0v75_s3: 750 mV, enabled
[    4.395517] rk806-regulator rk806-regulator.10.auto: Looking up vcc13-supply from device tree
[    4.395523] vdd_ddr_pll_s0: supplied by vcc_1v1_nldo_s3
[    4.395527] vcc_1v1_nldo_s3: could not add device link regulator.20: -ENOENT
[    4.395742] vdd_ddr_pll_s0: 850 mV, enabled
[    4.396008] avdd_0v75_s0: Bringing 750000uV into 837500-837500uV
[    4.396134] avdd_0v75_s0: ramp_delay not set
[    4.396198] rk806-regulator rk806-regulator.10.auto: Looking up vcc13-supply from device tree
[    4.396203] avdd_0v75_s0: supplied by vcc_1v1_nldo_s3
[    4.396208] vcc_1v1_nldo_s3: could not add device link regulator.21: -ENOENT
[    4.396425] avdd_0v75_s0: 837 mV, enabled
[    4.396743] rk806-regulator rk806-regulator.10.auto: Looking up vcc14-supply from device tree
[    4.396749] vdd_0v85_s0: supplied by vcc_1v1_nldo_s3
[    4.396753] vcc_1v1_nldo_s3: could not add device link regulator.22: -ENOENT
[    4.396973] vdd_0v85_s0: 850 mV, enabled
[    4.397302] rk806-regulator rk806-regulator.10.auto: Looking up vcc14-supply from device tree
[    4.397308] vdd_0v75_s0: supplied by vcc_1v1_nldo_s3
[    4.397312] vcc_1v1_nldo_s3: could not add device link regulator.23: -ENOENT
[    4.397530] vdd_0v75_s0: 750 mV, enabled
[    4.397932] rk806-regulator rk806-regulator.10.auto: Looking up vcc11-supply from device tree
[    4.397974] avcc_1v8_s0: supplied by vdd_2v0_pldo_s3
[    4.397978] vdd_2v0_pldo_s3: could not add device link regulator.24: -ENOENT
[    4.398261] avcc_1v8_s0: 1800 mV, enabled
[    4.398653] rk806-regulator rk806-regulator.10.auto: Looking up vcc11-supply from device tree
[    4.398660] vcc_1v8_s0: supplied by vdd_2v0_pldo_s3
[    4.398664] vdd_2v0_pldo_s3: could not add device link regulator.25: -ENOENT
[    4.398961] vcc_1v8_s0: 1800 mV, enabled
[    4.399285] rk806-regulator rk806-regulator.10.auto: Looking up vcc11-supply from device tree
[    4.399292] avdd_1v2_s0: supplied by vdd_2v0_pldo_s3
[    4.399296] vdd_2v0_pldo_s3: could not add device link regulator.26: -ENOENT
[    4.399591] avdd_1v2_s0: 1200 mV, enabled
[    4.399901] rk806-regulator rk806-regulator.10.auto: Looking up vcc12-supply from device tree
[    4.399906] vcc_3v3_s0: supplied by vcc5v0_sys
[    4.399910] vcc5v0_sys: could not add device link regulator.27: -ENOENT
[    4.400122] vcc_3v3_s0: 3300 mV, enabled
[    4.400430] rk806-regulator rk806-regulator.10.auto: Looking up vcc12-supply from device tree
[    4.400436] vccio_sd_s0: supplied by vcc5v0_sys
[    4.400440] vcc5v0_sys: could not add device link regulator.28: -ENOENT
[    4.400647] vccio_sd_s0: 1800 <--> 3300 mV at 3300 mV, enabled
[    4.400979] rk806-regulator rk806-regulator.10.auto: Looking up vcca-supply from device tree
[    4.400984] pldo6_s3: supplied by vcc5v0_sys
[    4.400988] vcc5v0_sys: could not add device link regulator.29: -ENOENT
[    4.401196] pldo6_s3: 1800 mV, enabled
[    4.401498] rk806 spi2.0: no sleep-setting state
[    4.401501] rk806 spi2.0: no reset-setting pinctrl state
[    4.401505] rk806 spi2.0: no dvs-setting pinctrl state
...
[    4.410206] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up usb-supply from device tree
[    4.410229] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up usb-supply property in node /power-management@fd8d8000/power-controller failed
...
[    4.569905] phy phy-fd5d4000.syscon:usb2-phy@4000.3: illegal mode
...
[    4.571200] usbcore: registered new interface driver uas
[    4.571264] usbcore: registered new interface driver usb-storage
[    4.571891] Error: Driver 'Goodix-TS' is already registered, aborting...
[    4.571924] usbcore: registered new interface driver usbtouchscreen
[    4.572092] .. rk pwm remotectl v2.0 init
...
[    4.618491] rk_hdmirx fdee0000.hdmirx-controller: No reserved memory for HDMIRX, use default CMA
[    4.618510] rk_hdmirx fdee0000.hdmirx-controller: hdmirx_probe: cpu_aff:0x400, Bound_cpu:4, wdt_cfg_bound_cpu:5
[    4.619744] rk_hdmirx fdee0000.hdmirx-controller: rk_hdmirx_hdcp_register success
[    4.619765] rk_hdmirx fdee0000.hdmirx-controller: fdee0000.hdmirx-controller driver probe ok!
...
[    4.639090] pci_bus 0000:01: busn_res: can not insert [bus 01-ff] under [bus 00-0f] (conflicts with (null) [bus 00-0f])
...
[    4.679794] sdhci-dwcmshc fe2e0000.mmc: Looking up vmmc-supply from device tree
[    4.679805] sdhci-dwcmshc fe2e0000.mmc: Looking up vmmc-supply property in node /mmc@fe2e0000 failed
[    4.680947] ledtrig-cpu: registered to indicate activity on CPUs
[    4.681003] arm-scmi firmware:scmi: Failed. SCMI protocol 17 not active.
[    4.681073] SMCCC: SOC_ID: ARCH_SOC_ID not implemented, skipping ....
[    4.682019] rk-crypto fe370000.crypto: invalid resource
[    4.682191] sdhci-dwcmshc fe2e0000.mmc: Looking up vqmmc-supply from device tree
[    4.682206] sdhci-dwcmshc fe2e0000.mmc: Looking up vqmmc-supply property in node /mmc@fe2e0000 failed
...
[    4.698688] optee: probing for conduit method.
[    4.698694] optee: api uid mismatch
[    4.698702] optee: probe of firmware:optee failed with error -22
...
[    4.718395] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up audio-supply from device tree
[    4.718415] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up audio-supply property in node /power-management@fd8d8000/power-controller failed
[    4.721541] rockchip-i2s-tdm fddf4000.i2s: CLK-ALWAYS-ON: mclk: 12288000, bclk: 3072000, fsync: 48000
[    4.724542] debugfs: File 'Capture' in directory 'dapm' already present!
[    4.726100] debugfs: File 'Capture' in directory 'dapm' already present!
...
[    4.771786] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up gpu-supply from device tree
[    4.771843] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up gpu-supply property in node /power-management@fd8d8000/power-controller failed
[    4.772052] mali fb000000.gpu: Kernel DDK version g18p0-01eac0
[    4.772061] reg-fixed-voltage vcc-3v3-sd-s0-regulator: Looking up vin-supply from device tree
[    4.772079] vcc_3v3_sd_s0: supplied by vcc_3v3_s3
[    4.772089] vcc_3v3_s3: could not add device link regulator.33: -ENOENT
[    4.772132] mali fb000000.gpu: Looking up mali-supply from device tree
[    4.772267] vcc_3v3_sd_s0: 3000 mV, enabled
[    4.772381] mali fb000000.gpu: Looking up mem-supply from device tree
[    4.772485] reg-fixed-voltage vcc-3v3-sd-s0-regulator: vcc_3v3_sd_s0 supplying 3000000uV
[    4.772636] mali fb000000.gpu: Looking up mali-supply from device tree
[    4.772669] vdd_gpu_s0: could not add device link fb000000.gpu: -EEXIST
[    4.772675] vdd_gpu_s0: Failed to create debugfs directory
[    4.772684] mali fb000000.gpu: Looking up mem-supply from device tree
[    4.772715] vdd_gpu_s0: could not add device link fb000000.gpu: -EEXIST
[    4.772720] vdd_gpu_s0: Failed to create debugfs directory
[    4.772848] reg-fixed-voltage vcc3v3-pcie20: Looking up vin-supply from device tree
[    4.772995] vcc_3v3_pcie20: supplied by vcc_3v3_s3
[    4.773007] vcc_3v3_s3: could not add device link regulator.34: -ENOENT
[    4.773112] mali fb000000.gpu: Looking up mali-supply from device tree
[    4.773137] vdd_gpu_s0: could not add device link fb000000.gpu: -EEXIST
[    4.773143] vdd_gpu_s0: Failed to create debugfs directory
[    4.773228] vcc_3v3_pcie20: 3300 mV, enabled
[    4.773495] reg-fixed-voltage vcc3v3-pcie20: vcc_3v3_pcie20 supplying 3300000uV
[    4.773609] mali fb000000.gpu: bin=0
[    4.773808] mali fb000000.gpu: leakage=15
[    4.773933] mali fb000000.gpu: Looking up mali-supply from device tree
[    4.773968] debugfs: Directory 'fb000000.gpu-mali' with parent 'vdd_gpu_s0' already present!
[    4.774184] dwmmc_rockchip fe2c0000.mmc: No normal pinctrl state
[    4.774192] dwmmc_rockchip fe2c0000.mmc: No idle pinctrl state
...
[    4.779142] W : [File] : drivers/gpu/arm/bifrost/platform/rk/mali_kbase_config_rk.c; [Line] : 143; [Func] : kbase_platform_rk_init(); power-off-delay-ms not available.
...
[    4.786682] rockchip-dmc dmc: failed to get vop bandwidth to dmc rate
[    4.786690] rockchip-dmc dmc: failed to get vop pn to msch rl
[    4.786871] rockchip-dmc dmc: l=10000 h=2147483647 hyst=5000 l_limit=0 h_limit=0 h_table=0
[    4.786934] rockchip-dmc dmc: could not find power_model node
[    4.787374] mmc_host mmc1: Bus speed (slot 0) = 400000Hz (slot req 400000Hz, actual 400000HZ div = 0)
[    4.788841] input: adc-keys as /devices/platform/adc-keys/input/input3
[    4.790220] asoc-simple-card rt5616-sound: ASoC: DAPM unknown pin Headphones
[    4.793105] input: realtek,rt5616-codec Headphones as /devices/platform/rt5616-sound/sound/card4/input4
[    4.793993] rk-pcie fe190000.pcie: invalid prsnt-gpios property in node
[    4.794001] rk-pcie fe190000.pcie: Looking up vpcie3v3-supply from device tree
[    4.795876] rk-pcie fe190000.pcie: IRQ msi not found
[    4.795879] rk-pcie fe190000.pcie: use outband MSI support
[    4.795883] rk-pcie fe190000.pcie: Missing *config* reg space
[    4.795891] rk-pcie fe190000.pcie: host bridge /pcie@fe190000 ranges:
[    4.795908] rk-pcie fe190000.pcie:      err 0x00f4000000..0x00f40fffff -> 0x00f4000000
[    4.795914] rk-pcie fe190000.pcie:       IO 0x00f4100000..0x00f41fffff -> 0x00f4100000
[    4.795923] rk-pcie fe190000.pcie:      MEM 0x00f4200000..0x00f4ffffff -> 0x00f4200000
[    4.795927] rk-pcie fe190000.pcie:      MEM 0x0a00000000..0x0a3fffffff -> 0x0a00000000
[    4.795973] rk-pcie fe190000.pcie: Missing *config* reg space
[    4.796000] rk-pcie fe190000.pcie: invalid resource
[    4.800900] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up sdio-supply from device tree
[    4.800919] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up sdio-supply property in node /power-management@fd8d8000/power-controller failed
[    4.800954] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up gmac-supply from device tree
[    4.800964] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up gmac-supply property in node /power-management@fd8d8000/power-controller failed
[    4.800989] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up npu-supply from device tree
[    4.800999] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up npu-supply property in node /power-management@fd8d8000/power-controller failed
[    4.801644] input: gpio-keys as /devices/platform/gpio-keys/input/input5
[    4.802597] RKNPU fdab0000.npu: Adding to iommu group 0
[    4.802718] RKNPU fdab0000.npu: RKNPU: rknpu iommu is enabled, using iommu mode
[    4.802778] RKNPU fdab0000.npu: Looking up rknpu-supply from device tree
[    4.803367] RKNPU fdab0000.npu: Looking up mem-supply from device tree
[    4.803841] RKNPU fdab0000.npu: can't request region for resource [mem 0xfdab0000-0xfdabffff]
[    4.803854] RKNPU fdab0000.npu: can't request region for resource [mem 0xfdac0000-0xfdacffff]
[    4.803860] RKNPU fdab0000.npu: can't request region for resource [mem 0xfdad0000-0xfdadffff]
...
[    4.807693] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up nputop-supply from device tree
[    4.807712] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up nputop-supply property in node /power-management@fd8d8000/power-controller failed
[    4.807781] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up npu1-supply from device tree
[    4.807792] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up npu1-supply property in node /power-management@fd8d8000/power-controller failed
[    4.807846] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up npu2-supply from device tree
[    4.807857] rockchip-pm-domain fd8d8000.power-management:power-controller: Looking up npu2-supply property in node /power-management@fd8d8000/power-controller failed
[    4.807961] RKNPU fdab0000.npu: Looking up rknpu-supply from device tree
[    4.807972] vdd_npu_s0: could not add device link fdab0000.npu: -EEXIST
[    4.807973] vdd_npu_s0: Failed to create debugfs directory
[    4.808490] RKNPU fdab0000.npu: Looking up mem-supply from device tree
[    4.808503] vdd_npu_s0: could not add device link fdab0000.npu: -EEXIST
[    4.808505] vdd_npu_s0: Failed to create debugfs directory
[    4.809031] RKNPU fdab0000.npu: Looking up rknpu-supply from device tree
[    4.809039] vdd_npu_s0: could not add device link fdab0000.npu: -EEXIST
[    4.809042] vdd_npu_s0: Failed to create debugfs directory
[    4.810565] RKNPU fdab0000.npu: RKNPU: bin=0
[    4.810733] RKNPU fdab0000.npu: leakage=9
[    4.810753] RKNPU fdab0000.npu: Looking up rknpu-supply from device tree
[    4.810762] debugfs: Directory 'fdab0000.npu-rknpu' with parent 'vdd_npu_s0' already present!
[    4.817512] RKNPU fdab0000.npu: pvtm=891
[    4.824922] RKNPU fdab0000.npu: pvtm-volt-sel=4
[    4.825642] RKNPU fdab0000.npu: avs=0
[    4.825726] RKNPU fdab0000.npu: l=10000 h=85000 hyst=5000 l_limit=0 h_limit=800000000 h_table=0
[    4.850080] vendor storage:20190527 ret = 0
[    4.854191] RKNPU fdab0000.npu: failed to find power_model node
[    4.854198] RKNPU fdab0000.npu: RKNPU: failed to initialize power model
[    4.854203] RKNPU fdab0000.npu: RKNPU: failed to get dynamic-coefficient
...
[    4.876901] rockchip-pm rockchip-suspend: not set pwm-regulator-config
[    4.877420] rockchip-suspend not set sleep-mode-config for mem-lite
[    4.877426] rockchip-suspend not set wakeup-config for mem-lite
[    4.877433] rockchip-suspend not set sleep-mode-config for mem-ultra
[    4.877438] rockchip-suspend not set wakeup-config for mem-ultra
...
[    4.940793] asoc-simple-card rt5616-sound: ASoC: DAPM unknown pin Headphones
...
[    5.106069] r8125 0004:41:00.0 (unnamed net_device) (uninitialized): Invalid ether addr 00:00:00:00:00:00
[    5.106077] r8125 0004:41:00.0 (unnamed net_device) (uninitialized): Random ether addr 42:69:55:fe:21:50
...
[    7.230595] rk-pcie fe180000.pcie: PCIe Link Fail
[    7.230605] rk-pcie fe180000.pcie: failed to initialize host
[    7.243912] rk-pcie fe160000.pcie: PCIe Link Fail
[    7.243925] rk-pcie fe160000.pcie: failed to initialize host
[    7.247361] rk-pcie fe170000.pcie: PCIe Link Fail
[    7.247373] rk-pcie fe170000.pcie: failed to initialize host
```

</details>

Even though there are many errors, warnings or failures, I did not have any immediate problems so far.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
