### PR TITLE
Hook leftovers when introducing vendor kernel for Rockchip 3588

### DIFF
--- a/config/boards/armsom-sige7.csc
+++ b/config/boards/armsom-sige7.csc
@@ -18,6 +18,10 @@ BL31_BLOB='rk35/rk3588_bl31_v1.38.elf'
 
 # post_family_config hook which only runs when branch is legacy.
 function post_family_config_branch_legacy__uboot_armsom() {
+post_family_config_branch_vendor__uboot_armsom
+}
+# post_family_config hook which only runs when branch is vendor.
+function post_family_config_branch_vendor__uboot_armsom() {
 	display_alert "$BOARD" "Configuring armsom u-boot" "info"
 	declare -g BOOTSOURCE='https://github.com/radxa/u-boot.git'
 	declare -g BOOTBRANCH="commit:b54d452d46459bc6e4cfc1a2795c9aad143aa174" # specific commit in next-dev branch

--- a/config/boards/armsom-w3.csc
+++ b/config/boards/armsom-w3.csc
@@ -18,6 +18,10 @@ BL31_BLOB='rk35/rk3588_bl31_v1.38.elf'
 
 # post_family_config hook which only runs when branch is legacy.
 function post_family_config_branch_legacy__uboot_armsom() {
+post_family_config_branch_vendor__uboot_armsom
+}
+# post_family_config hook which only runs when branch is legacy.
+function post_family_config_branch_vendor__uboot_armsom() {
 	display_alert "$BOARD" "Configuring armsom u-boot" "info"
 	declare -g BOOTSOURCE='https://github.com/radxa/u-boot.git'
 	declare -g BOOTBRANCH="commit:b54d452d46459bc6e4cfc1a2795c9aad143aa174" # specific commit in next-dev branch

--- a/config/boards/indiedroid-nova.csc
+++ b/config/boards/indiedroid-nova.csc
@@ -32,6 +32,11 @@ function post_family_config_branch_legacy__use_9tripod_dtb() {
 	declare -g BOOT_FDT_FILE="rockchip/rk3588s-9tripod-linux.dtb"
 }
 
+# post_family_config hook which also run for vendor kernel
+function post_family_config_branch_vendor__use_9tripod_dtb() {
+post_family_config_branch_legacy__use_9tripod_dtb
+}
+
 # Add bluetooth packages to the image (not rootfs cache)
 function post_family_config__bluetooth_hciattach_add_bluetooth_packages() {
 	display_alert "${BOARD}" "adding bluetooth packages to image" "info"


### PR DESCRIPTION
# Description

Expand legacy hooks to vendor.

# How Has This Been Tested?

- [x] Build previously broken u-boot

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
