### PR TITLE
NanoPi R5C/R5S: Bump U-Boot and don't install headers by default

### DIFF
--- a/config/boards/nanopi-r5c.csc
+++ b/config/boards/nanopi-r5c.csc
@@ -11,11 +11,9 @@ IMAGE_PARTITION_TABLE="gpt"
 FULL_DESKTOP="no"
 BOOT_LOGO="desktop"
 
-BOOTSOURCE="https://github.com/Kwiboo/u-boot-rockchip.git" # also following kwiboo's uboot due to his rk3568 work
-BOOTBRANCH_BOARD="commit:a6e84f9f5b90ff0fa3ac4e6b7e0d6e2c3ac9bb1b" # specific commit, from "branch:rk3568-2023.10" which is v2023.10-rc2 + kwiboo's patches (including GMAC)
-BOOTPATCHDIR="v2023.10"
+BOOTBRANCH_BOARD="tag:v2024.04-rc3"
+BOOTPATCHDIR="v2024.04"
 BOOTCONFIG="nanopi-r5c-rk3568_defconfig"
-BOOTDIR="u-boot-${BOARD}" # do not share u-boot directory
 
 OVERLAY_PREFIX="rockchip-rk3568"
 DEFAULT_OVERLAYS="nanopi-r5c-leds"

--- a/config/boards/nanopi-r5s.csc
+++ b/config/boards/nanopi-r5s.csc
@@ -11,11 +11,9 @@ IMAGE_PARTITION_TABLE="gpt"
 FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
 
-BOOTSOURCE="https://github.com/Kwiboo/u-boot-rockchip.git" # also following kwiboo's u-boot due to his rk3568 work
-BOOTBRANCH_BOARD="commit:a6e84f9f5b90ff0fa3ac4e6b7e0d6e2c3ac9bb1b" # specific commit, from "branch:rk3568-2023.10" which is v2023.10-rc2 + kwiboo's patches (including GMAC)
-BOOTPATCHDIR="v2023.10"
+BOOTBRANCH_BOARD="tag:v2024.04-rc3"
+BOOTPATCHDIR="v2024.04"
 BOOTCONFIG="nanopi-r5s-rk3568_defconfig"
-BOOTDIR="u-boot-${BOARD}" # do not share u-boot directory
 
 OVERLAY_PREFIX="rockchip-rk3568"
 DEFAULT_OVERLAYS="nanopi-r5s-leds"


### PR DESCRIPTION
# Description

This PR applies to both NanoPi R5C as well as R5S since they are only distinguishable in very few aspects.

1) Remove `INSTALL_HEADERS="yes"` since only these two boards have this option by default in their board config
2) Switch U-Boot from Kwiboo's repo to mainline, since many of his patches for RK3568 have been merged upstream. Use the latest version 2024.4 since it has some improvements for RK3568 (thanks @Kwiboo)

[AR-2279]

# How Has This Been Tested?

Compiled and tested with NanoPi R5C.

- [x] Boots into the system normally (Armbian Bookworm)
- [x] No new warnings or errors in bootlog (see below)
- [ ] Advanced U-Boot functionalities have not been tested

## Bootlogs
### Old (Kwiboo's U-Boot 2023.10 commit:a6e84f9f5b90ff0fa3ac4e6b7e0d6e2c3ac9bb1b)

```
DDR V1.18 f366f69a7d typ 23/07/17-15:48:58
In
LP4/4x derate en, other dram:1x trefi
ddrconfig:0
LPDDR4X, 324MHz
BW=32 Col=10 Bk=8 CS0 Row=17 CS=1 Die BW=16 Size=4096MB
tdqss: cs0 dqs0: 48ps, dqs1: -72ps, dqs2: 48ps, dqs3: -24ps, 

change to: 324MHz
clk skew:0x60

change to: 528MHz
clk skew:0x58

change to: 780MHz
clk skew:0x58

change to: 1560MHz(final freq)
PHY drv:clk:36,ca:36,DQ:29,odt:60
vrefinner:16%, vrefout:22%
dram drv:40,odt:80
vref_ca:00000071
clk skew:0x1d
cs 0:
the read training result:
DQS0:0x36, DQS1:0x32, DQS2:0x34, DQS3:0x38, 
min  : 0xd 0x12 0x11 0x11  0x1  0x8  0xb  0x9 , 0x2  0x1  0xb  0xd  0xb  0xf 0x10  0xf ,
       0xd  0xd  0xd  0x8  0x2  0x0  0x5  0x5 , 0xf  0xc  0xa  0x2 0x12 0x12 0x15 0x11 ,
mid  :0x28 0x2a 0x2a 0x2a 0x1d 0x22 0x27 0x24 ,0x1c 0x1c 0x25 0x28 0x26 0x2a 0x2b 0x29 ,
      0x2a 0x29 0x27 0x23 0x1d 0x1d 0x21 0x21 ,0x29 0x28 0x24 0x1e 0x2d 0x2d 0x30 0x2c ,
max  :0x44 0x43 0x44 0x44 0x39 0x3d 0x43 0x3f ,0x36 0x37 0x3f 0x44 0x42 0x46 0x47 0x44 ,
      0x47 0x45 0x42 0x3f 0x39 0x3a 0x3d 0x3e ,0x44 0x44 0x3f 0x3a 0x48 0x48 0x4c 0x48 ,
range:0x37 0x31 0x33 0x33 0x38 0x35 0x38 0x36 ,0x34 0x36 0x34 0x37 0x37 0x37 0x37 0x35 ,
      0x3a 0x38 0x35 0x37 0x37 0x3a 0x38 0x39 ,0x35 0x38 0x35 0x38 0x36 0x36 0x37 0x37 ,
the write training result:
DQS0:0x26, DQS1:0xf, DQS2:0x26, DQS3:0x19, 
min  :0x5e 0x63 0x64 0x63 0x55 0x5a 0x5c 0x5e 0x5c ,0x43 0x43 0x4b 0x4e 0x4d 0x50 0x51 0x50 0x4b ,
      0x62 0x60 0x5e 0x5c 0x55 0x55 0x56 0x5c 0x5a ,0x4e 0x4f 0x4b 0x46 0x52 0x54 0x55 0x55 0x4f ,
mid  :0x79 0x7e 0x7d 0x7d 0x6f 0x75 0x77 0x77 0x75 ,0x5e 0x5e 0x65 0x69 0x68 0x6b 0x6b 0x6a 0x65 ,
      0x7e 0x7d 0x79 0x77 0x71 0x70 0x72 0x77 0x76 ,0x6a 0x6a 0x65 0x61 0x6e 0x70 0x70 0x6f 0x69 ,
max  :0x95 0x99 0x97 0x97 0x8a 0x90 0x93 0x91 0x8e ,0x79 0x79 0x80 0x85 0x83 0x86 0x86 0x85 0x80 ,
      0x9a 0x9b 0x94 0x93 0x8d 0x8c 0x8e 0x92 0x93 ,0x86 0x86 0x7f 0x7c 0x8a 0x8c 0x8c 0x8a 0x84 ,
range:0x37 0x36 0x33 0x34 0x35 0x36 0x37 0x33 0x32 ,0x36 0x36 0x35 0x37 0x36 0x36 0x35 0x35 0x35 ,
      0x38 0x3b 0x36 0x37 0x38 0x37 0x38 0x36 0x39 ,0x38 0x37 0x34 0x36 0x38 0x38 0x37 0x35 0x35 ,
CA Training result:
cs:0 min  :0x47 0x40 0x45 0x3f 0x42 0x3b 0x48 ,0x48 0x43 0x48 0x44 0x46 0x42 0x4a ,
cs:0 mid  :0x82 0x81 0x81 0x7f 0x7f 0x7c 0x75 ,0x85 0x83 0x84 0x85 0x82 0x82 0x78 ,
cs:0 max  :0xbd 0xc2 0xbd 0xbf 0xbd 0xbe 0xa2 ,0xc2 0xc3 0xc0 0xc6 0xbf 0xc2 0xa6 ,
cs:0 range:0x76 0x82 0x78 0x80 0x7b 0x83 0x5a ,0x7a 0x80 0x78 0x82 0x79 0x80 0x5c ,
out

U-Boot SPL 2023.10-rc2-armbian (Mar 03 2024 - 18:08:12 +0000)
Trying to boot from MMC1
## Checking hash(es) for config config-1 ... OK
## Checking hash(es) for Image atf-1 ... sha256+ OK
## Checking hash(es) for Image u-boot ... sha256+ OK
## Checking hash(es) for Image fdt-1 ... sha256+ OK
## Checking hash(es) for Image atf-2 ... sha256+ OK
## Checking hash(es) for Image atf-3 ... sha256+ OK
## Checking hash(es) for Image atf-4 ... sha256+ OK
## Checking hash(es) for Image atf-5 ... sha256+ OK
## Checking hash(es) for Image atf-6 ... sha256+ OK
INFO:    Preloader serial: 2
NOTICE:  BL31: v2.3():v2.3-607-gbf602aff1:cl
NOTICE:  BL31: Built : 10:16:03, Jun  5 2023
INFO:    GICv3 without legacy support detected.
INFO:    ARM GICv3 driver initialized in EL3
INFO:    pmu v1 is valid 220114
INFO:    dfs DDR fsp_param[0].freq_mhz= 1560MHz
INFO:    dfs DDR fsp_param[1].freq_mhz= 324MHz
INFO:    dfs DDR fsp_param[2].freq_mhz= 528MHz
INFO:    dfs DDR fsp_param[3].freq_mhz= 780MHz
INFO:    Using opteed sec cpu_context!
INFO:    boot cpu mask: 0
INFO:    BL31: Initializing runtime services
WARNING: No OPTEE provided by BL2 boot loader, Booting device without OPTEE initialization. SMC`s destined for OPTEE will return SMC_UNK
ERROR:   Error initializing runtime service opteed_fast
INFO:    BL31: Preparing for EL3 exit to normal world
INFO:    Entry point address = 0xa00000
INFO:    SPSR = 0x3c9


U-Boot 2023.10-rc2-armbian (Mar 03 2024 - 18:08:12 +0000)

Model: FriendlyElec NanoPi R5C
DRAM:  4 GiB (effective 3.7 GiB)
PMIC:  RK8090 (on=0x40, off=0x00)
Core:  317 devices, 26 uclasses, devicetree: separate
MMC:   mmc@fe2b0000: 1, mmc@fe310000: 0
Loading Environment from nowhere... OK
In:    serial@fe660000
Out:   serial@fe660000
Err:   serial@fe660000
Model: FriendlyElec NanoPi R5C
Net:   No ethernet found.
Hit any key to stop autoboot:  2  1  0 
Card did not respond to voltage select! : -110
** Booting bootflow 'mmc@fe310000.bootdev.part_1' with script
Boot script loaded from mmc 0:1
237 bytes read in 12 ms (18.6 KiB/s)
14712165 bytes read in 102 ms (137.6 MiB/s)
31410688 bytes read in 196 ms (152.8 MiB/s)
117874 bytes read in 38 ms (3 MiB/s)
Working FDT set to a100000
314 bytes read in 36 ms (7.8 KiB/s)
Applying kernel provided DT overlay rockchip-rk3568-nanopi-r5c-leds.dtbo
Failed to load '/boot/dtb/rockchip/overlay/rockchip-rk3568-fixup.scr'
Unknown command 'kaslrseed' - try 'help'
Moving Image from 0x2080000 to 0x2200000, end=40a0000
## Loading init Ramdisk from Legacy Image at 0a200000 ...
   Image Name:   uInitrd
   Image Type:   AArch64 Linux RAMDisk Image (gzip compressed)
   Data Size:    14712101 Bytes = 14 MiB
   Load Address: 00000000
   Entry Point:  00000000
   Verifying Checksum ... OK
## Flattened Device Tree blob at 0a100000
   Booting using the fdt blob at 0xa100000
Working FDT set to a100000
   Loading Ramdisk to ebdd9000, end ecbe0d25 ... OK
   Loading Device Tree to 00000000ebd53000, end 00000000ebdd8fff ... OK
Working FDT set to ebd53000

Starting kernel ...


Friendlyelec 24.2.0-trunk Bookworm ttyS2
```

### New (mainline U-Boot 2024.4-rc3)

```
DDR V1.18 f366f69a7d typ 23/07/17-15:48:58
In
LP4/4x derate en, other dram:1x trefi
ddrconfig:0
LPDDR4X, 324MHz
BW=32 Col=10 Bk=8 CS0 Row=17 CS=1 Die BW=16 Size=4096MB
tdqss: cs0 dqs0: 48ps, dqs1: -72ps, dqs2: 48ps, dqs3: -24ps, 

change to: 324MHz
clk skew:0x60

change to: 528MHz
clk skew:0x58

change to: 780MHz
clk skew:0x58

change to: 1560MHz(final freq)
PHY drv:clk:36,ca:36,DQ:29,odt:60
vrefinner:16%, vrefout:22%
dram drv:40,odt:80
vref_ca:00000071
clk skew:0x1d
cs 0:
the read training result:
DQS0:0x37, DQS1:0x33, DQS2:0x36, DQS3:0x3a, 
min  : 0xd 0x13 0x11 0x11  0x2  0x7  0xc  0x9 , 0x3  0x2  0xa  0xe  0xc 0x10 0x10 0x10 ,
       0xe  0xe  0xd  0x7  0x2  0x2  0x5  0x6 ,0x10  0xc  0xa  0x2 0x13 0x13 0x15 0x11 ,
mid  :0x29 0x2b 0x2b 0x2b 0x1e 0x23 0x28 0x25 ,0x1d 0x1d 0x25 0x29 0x28 0x2b 0x2c 0x2b ,
      0x2b 0x2b 0x28 0x24 0x1e 0x1e 0x22 0x23 ,0x2b 0x29 0x25 0x1e 0x2e 0x2e 0x32 0x2d ,
max  :0x45 0x44 0x46 0x45 0x3a 0x3f 0x44 0x41 ,0x37 0x38 0x41 0x45 0x44 0x46 0x49 0x46 ,
      0x49 0x49 0x44 0x41 0x3b 0x3b 0x3f 0x40 ,0x46 0x46 0x41 0x3b 0x4a 0x4a 0x4f 0x4a ,
range:0x38 0x31 0x35 0x34 0x38 0x38 0x38 0x38 ,0x34 0x36 0x37 0x37 0x38 0x36 0x39 0x36 ,
      0x3b 0x3b 0x37 0x3a 0x39 0x39 0x3a 0x3a ,0x36 0x3a 0x37 0x39 0x37 0x37 0x3a 0x39 ,
the write training result:
DQS0:0x26, DQS1:0xf, DQS2:0x26, DQS3:0x19, 
min  :0x5f 0x63 0x63 0x63 0x55 0x5a 0x5d 0x5e 0x5c ,0x43 0x43 0x4a 0x4e 0x4c 0x4f 0x50 0x50 0x4a ,
      0x62 0x60 0x5e 0x5c 0x55 0x55 0x57 0x5c 0x5b ,0x4e 0x4f 0x4c 0x46 0x53 0x54 0x55 0x55 0x4e ,
mid  :0x7a 0x7e 0x7e 0x7d 0x6f 0x74 0x78 0x78 0x75 ,0x5e 0x5e 0x64 0x69 0x67 0x6a 0x6b 0x6a 0x64 ,
      0x7e 0x7d 0x79 0x77 0x71 0x70 0x73 0x77 0x77 ,0x6a 0x6a 0x65 0x61 0x6e 0x6f 0x70 0x6f 0x69 ,
max  :0x95 0x9a 0x99 0x97 0x8a 0x8f 0x94 0x92 0x8f ,0x79 0x79 0x7f 0x84 0x82 0x86 0x86 0x85 0x7f ,
      0x9b 0x9b 0x94 0x93 0x8d 0x8c 0x8f 0x92 0x93 ,0x86 0x86 0x7f 0x7d 0x89 0x8a 0x8b 0x8a 0x84 ,
range:0x36 0x37 0x36 0x34 0x35 0x35 0x37 0x34 0x33 ,0x36 0x36 0x35 0x36 0x36 0x37 0x36 0x35 0x35 ,
      0x39 0x3b 0x36 0x37 0x38 0x37 0x38 0x36 0x38 ,0x38 0x37 0x33 0x37 0x36 0x36 0x36 0x35 0x36 ,
CA Training result:
cs:0 min  :0x47 0x40 0x45 0x3f 0x43 0x3b 0x49 ,0x48 0x43 0x49 0x44 0x45 0x42 0x4a ,
cs:0 mid  :0x82 0x81 0x81 0x7e 0x80 0x7c 0x76 ,0x85 0x83 0x84 0x85 0x82 0x82 0x78 ,
cs:0 max  :0xbd 0xc2 0xbd 0xbe 0xbd 0xbd 0xa3 ,0xc2 0xc3 0xc0 0xc6 0xbf 0xc3 0xa6 ,
cs:0 range:0x76 0x82 0x78 0x7f 0x7a 0x82 0x5a ,0x7a 0x80 0x77 0x82 0x7a 0x81 0x5c ,
out

U-Boot SPL 2024.04-rc3-armbian (Mar 06 2024 - 14:05:42 +0000)
Trying to boot from MMC1
## Checking hash(es) for config config-1 ... OK
## Checking hash(es) for Image atf-1 ... sha256+ OK
## Checking hash(es) for Image u-boot ... sha256+ OK
## Checking hash(es) for Image fdt-1 ... sha256+ OK
## Checking hash(es) for Image atf-2 ... sha256+ OK
## Checking hash(es) for Image atf-3 ... sha256+ OK
## Checking hash(es) for Image atf-4 ... sha256+ OK
## Checking hash(es) for Image atf-5 ... sha256+ OK
## Checking hash(es) for Image atf-6 ... sha256+ OK
INFO:    Preloader serial: 2
NOTICE:  BL31: v2.3():v2.3-607-gbf602aff1:cl
NOTICE:  BL31: Built : 10:16:03, Jun  5 2023
INFO:    GICv3 without legacy support detected.
INFO:    ARM GICv3 driver initialized in EL3
INFO:    pmu v1 is valid 220114
INFO:    dfs DDR fsp_param[0].freq_mhz= 1560MHz
INFO:    dfs DDR fsp_param[1].freq_mhz= 324MHz
INFO:    dfs DDR fsp_param[2].freq_mhz= 528MHz
INFO:    dfs DDR fsp_param[3].freq_mhz= 780MHz
INFO:    Using opteed sec cpu_context!
INFO:    boot cpu mask: 0
INFO:    BL31: Initializing runtime services
WARNING: No OPTEE provided by BL2 boot loader, Booting device without OPTEE initialization. SMC`s destined for OPTEE will return SMC_UNK
ERROR:   Error initializing runtime service opteed_fast
INFO:    BL31: Preparing for EL3 exit to normal world
INFO:    Entry point address = 0xa00000
INFO:    SPSR = 0x3c9
ns16550_serial serial@fe660000: pinctrl_select_state_full: uclass_get_device_by_phandle_id: err=-19


U-Boot 2024.04-rc3-armbian (Mar 06 2024 - 14:05:42 +0000)

Model: FriendlyElec NanoPi R5C
DRAM:  4 GiB (effective 3.7 GiB)
PMIC:  RK8090 (on=0x40, off=0x00)
Core:  317 devices, 26 uclasses, devicetree: separate
MMC:   mmc@fe2b0000: 1, mmc@fe310000: 0
Loading Environment from nowhere... OK
In:    serial@fe660000
Out:   serial@fe660000
Err:   serial@fe660000
Model: FriendlyElec NanoPi R5C
Net:   No ethernet found.
Hit any key to stop autoboot:  2  1  0 
Card did not respond to voltage select! : -110
** Booting bootflow 'mmc@fe310000.bootdev.part_1' with script
Boot script loaded from mmc 0:1
237 bytes read in 12 ms (18.6 KiB/s)
14648372 bytes read in 102 ms (137 MiB/s)
31343104 bytes read in 189 ms (158.2 MiB/s)
117874 bytes read in 38 ms (3 MiB/s)
Working FDT set to 12000000
314 bytes read in 38 ms (7.8 KiB/s)
Applying kernel provided DT overlay rockchip-rk3568-nanopi-r5c-leds.dtbo
Failed to load '/boot/dtb/rockchip/overlay/rockchip-rk3568-fixup.scr'
Unknown command 'kaslrseed' - try 'help'
## Loading init Ramdisk from Legacy Image at 12180000 ...
   Image Name:   uInitrd
   Image Type:   AArch64 Linux RAMDisk Image (gzip compressed)
   Data Size:    14648308 Bytes = 14 MiB
   Load Address: 00000000
   Entry Point:  00000000
   Verifying Checksum ... OK
## Flattened Device Tree blob at 12000000
   Booting using the fdt blob at 0x12000000
Working FDT set to 12000000
   Loading Ramdisk to ebde8000, end ecbe03f4 ... OK
   Loading Device Tree to 00000000ebd62000, end 00000000ebde7fff ... OK
Working FDT set to ebd62000

Starting kernel ...


Friendlyelec 24.2.0-trunk Bookworm ttyS2 
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-2279]: https://armbian.atlassian.net/browse/AR-2279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ