### PR TITLE
GH actions: Kernel hardening analysis path and name of a tool has been changed

### DIFF
--- a/.github/workflows/kernel-security-analysis-pr.yml
+++ b/.github/workflows/kernel-security-analysis-pr.yml
@@ -47,6 +47,6 @@ jobs:
          run: |
            for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
                if [[  "${file}" = config/kernel/*.config ]]; then
-                   kconfig-hardened-check/bin/kconfig-hardened-check -m show_fail -c $file | sed -e 's/^/    /' >> $GITHUB_STEP_SUMMARY
+                   kconfig-hardened-check/bin/kernel-hardening-checker -m show_fail -c $file | sed -e 's/^/    /' >> $GITHUB_STEP_SUMMARY
                fi
            done


### PR DESCRIPTION
# Description

In title.

Jira reference number [AR-2097] Closing https://github.com/armbian/build/issues/6369

# How Has This Been Tested?

- [x] Manual run
- [x] CI run

![image](https://github.com/armbian/build/assets/6281704/8c6144a3-ca79-4f20-ba16-11e85c4663c8)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

[AR-2097]: https://armbian.atlassian.net/browse/AR-2097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ