### PR TITLE
Show correct reason about omit tmpfs usage if FORCE_USE_RAMDISK is set

### DIFF
--- a/lib/functions/rootfs/trap-rootfs.sh
+++ b/lib/functions/rootfs/trap-rootfs.sh
@@ -31,7 +31,10 @@ function prepare_rootfs_build_params_and_trap() {
 	declare use_tmpfs=no                      # by default
 	if [[ ${FORCE_USE_RAMDISK} == no ]]; then # do not use, even if it fits
 		display_alert "Not using tmpfs for rootfs" "due to FORCE_USE_RAMDISK=no" "info"
-	elif [[ ${FORCE_USE_RAMDISK} == yes || ${available_physical_memory_mib} -gt ${tmpfs_estimated_size} ]]; then # use, either force or fits
+	elif [[ ${FORCE_USE_RAMDISK} == yes ]]; then # use, either force or fits
+		use_tmpfs=yes
+		display_alert "Using tmpfs for rootfs build" "FORCE_USE_RAMDISK forced to \"yes\"" "info"
+	elif [[ ${available_physical_memory_mib} -gt ${tmpfs_estimated_size} ]]; then
 		use_tmpfs=yes
 		display_alert "Using tmpfs for rootfs build" "RAM available: ${available_physical_memory_mib}MiB > ${tmpfs_estimated_size}MiB estimated" "info"
 	else


### PR DESCRIPTION
# Description
Currently if used `FORCE_USE_RAMDISK=yes` and there not enough free space in ram, I see in log
```
[🐳|🌱] Using tmpfs for rootfs build [ RAM available: 1762MiB > 5000MiB estimated ]
[🐳|🌱] Extracting 202403-e4b438b83a21-H01ba47-Bd5847b [ 1 days old ]
```
That's looks strange, and not points to a reason, if you just forgot about `FORCE_USE_RAMDISK` in your config or another way.

sample: https://paste.armbian.com/hubuqodihu

# How Has This Been Tested?

- [x] run with not enough ram, `FORCE_USE_RAMDISK=yes`
  https://paste.armbian.com/ujonufiqoy
- [x] run with not enough ram, without `FORCE_USE_RAMDISK=yes`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
