### PR TITLE
add csc hinlink h6xk boards

### DIFF
--- a/config/boards/hinlink-h66k.csc
+++ b/config/boards/hinlink-h66k.csc
@@ -1,0 +1,12 @@
+# Rockchip RK3568 quad core 1-8GB SoC 2.5GBe eMMC USB3
+BOARD_NAME="Hinlink H66K"
+BOARDFAMILY="rk35xx"
+BOOTCONFIG="radxa-e25-rk3568_defconfig"
+KERNEL_TARGET="legacy,vendor"
+FULL_DESKTOP="yes"
+BOOT_LOGO="desktop"
+BOOT_FDT_FILE="rockchip/rk3568-hinlink-h66k.dtb"
+BOOT_SCENARIO="spl-blobs"
+WIREGUARD="no"
+IMAGE_PARTITION_TABLE="gpt"
+BOOTFS_TYPE="fat"

--- a/config/boards/hinlink-h68k.csc
+++ b/config/boards/hinlink-h68k.csc
@@ -1,0 +1,12 @@
+# Rockchip RK3568 quad core 1-8GB SoC 2xGBe 2x2.5GBe eMMC USB3
+BOARD_NAME="Hinlink H68K"
+BOARDFAMILY="rk35xx"
+BOOTCONFIG="radxa-e25-rk3568_defconfig"
+KERNEL_TARGET="legacy,vendor"
+FULL_DESKTOP="yes"
+BOOT_LOGO="desktop"
+BOOT_FDT_FILE="rockchip/rk3568-hinlink-h68k.dtb"
+BOOT_SCENARIO="spl-blobs"
+WIREGUARD="no"
+IMAGE_PARTITION_TABLE="gpt"
+BOOTFS_TYPE="fat"

--- a/config/boards/hinlink-hnas.csc
+++ b/config/boards/hinlink-hnas.csc
@@ -1,0 +1,12 @@
+# Rockchip RK3568 quad core 1-8GB SoC 2x2.5GBe eMMC USB3 SATA
+BOARD_NAME="Hinlink HNAS"
+BOARDFAMILY="rk35xx"
+BOOTCONFIG="radxa-e25-rk3568_defconfig"
+KERNEL_TARGET="legacy,vendor"
+FULL_DESKTOP="yes"
+BOOT_LOGO="desktop"
+BOOT_FDT_FILE="rockchip/rk3568-hinlink-hnas.dtb"
+BOOT_SCENARIO="spl-blobs"
+WIREGUARD="no"
+IMAGE_PARTITION_TABLE="gpt"
+BOOTFS_TYPE="fat"


### PR DESCRIPTION
# Description

These rk3568 boards are made by hinlink: https://doc.hinlink.cn/
H66K and H68K share the same core board, and H68K has two more GBe gmac ethernet.
HNAS is a board based on H68K with a 4-slot sata for nas use.
These board configs have been in [my repo](https://github.com/amazingfate/armbian-h68k-images) for a long time, and there dts have get merged in armbian/linux-rockchip. Now we have vendor 6.1 kernel and no need to worry about backporting drivers so add these boards upstream.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] `./compile.sh build BOARD=hinlink-hnas BRANCH=vendor BUILD_DESKTOP=no BUILD_MINIMAL=no COMPRESS_OUTPUTIMAGE=sha,gpg,xz DEB_COMPRESS=xz KERNEL_CONFIGURE=no MAINLINE_MIRROR=tuna RELEASE=bookworm`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
