### PR TITLE
GH Actions: Update forked-helper and add some doc on secrets in workflow's README.md

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -38,10 +38,14 @@ You need to get a valid token from our DevOps team to proceed.
 
 `forked-helper.yml` workflow helper can help to run custom workflows on the forked repositories.
 
-1. Set `ARMBIAN_SELF_DISPATCH_TOKEN` secret on your repository with `security_events` permissions.
-2. Helper will dispatch `repository_dispatch` event `armbian` on `push`, `release`, `deployment`, 
-   `pull_request` and `workflow_dispatch` events. All needed event details you can find in `client_payload` 
-   property of the event.
+1. Create a [fine-grained Personal Access Token (PAT)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token) with the `repo` scope and store it as a secret. It needs the following permissions on the target repositories:
+    - `contents`: read & write
+    - `metadata`: read only (automatically selected when selecting the contents permission)
+2. Create a secret named `ARMBIAN_SELF_DISPATCH_TOKEN` on your repository with `security_events` permissions. To do this, head to your forked repository, go to `Settings` on the top bar, select `Secrets and variables` and then `Actions`. From here you can create a new repository secret.
+    - `Name`: `ARMBIAN_SELF_DISPATCH_TOKEN`
+    - `Secret`: Paste your fine-grained Personal Access Token that you created in step 1 here
+3. Helper will dispatch `repository_dispatch` event `armbian` on `push`, `release`, `deployment`, 
+   `pull_request` and `workflow_dispatch` events. All needed event details you can find in `client_payload` property of the event.
 4. Create empty default branch in forked repository
 5. Create workflow with `repository_dispatch` in default branch.
 6. Run any need actions in this workflow.

--- a/.github/workflows/forked-helper.yml
+++ b/.github/workflows/forked-helper.yml
@@ -15,16 +15,16 @@ jobs:
     steps:
       - name: Assign secret
         id: get_dispatch_secret
-        run: echo '::set-output name=dispatch_secret::${{ secrets.ARMBIAN_SELF_DISPATCH_TOKEN }}'
+        run: echo 'name=dispatch_secret::${{ secrets.ARMBIAN_SELF_DISPATCH_TOKEN }}' >> $GITHUB_OUTPUT
       - name: Get event details
         id: get_event_details
-        # Process JSON according https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/td-p/37870
+        # Process JSON according https://github.com/orgs/community/discussions/26288
         run: |
           JSON=$(cat ${{ github.event_path }})
           JSON="${JSON//'%'/'%25'}"
           JSON="${JSON//$'\n'/'%0A'}"
           JSON="${JSON//$'\r'/'%0D'}"
-          echo "::set-output name=event_details::${JSON}"
+          echo "name=event_details::${JSON}" >> $GITHUB_OUTPUT
       - name: Dispatch event on forked repostitory
         if: steps.get_dispatch_secret.outputs.dispatch_secret
         uses: peter-evans/repository-dispatch@v3


### PR DESCRIPTION
# Description

`::set-output` has been deprecated in 2022: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
Thus replacing it with` >> $GITHUB_OUTPUT` as described in the guide above.

Also, took me a while to figure out how to create and use the `ARMBIAN_SELF_DISPATCH_TOKEN` mentioned in the readme. So I updated the readme accordingly so others don't have to spend time figuring it out on their own in the future.
(This helped me a lot: https://github.com/peter-evans/repository-dispatch?tab=readme-ov-file#token)

# How Has This Been Tested?

- [x] Ran the workflow on my forked repo without issues. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
