### PR TITLE
Display "repeat build options" at the end if process was cancelled

### DIFF
--- a/lib/functions/logging/trap-logging.sh
+++ b/lib/functions/logging/trap-logging.sh
@@ -83,6 +83,8 @@ function trap_handler_cleanup_logging() {
 	# Check if fd 13 is still open; close it and wait for tee to die. This is done again in discard_logs_tmp_dir()
 	check_and_close_fd_13
 
+	display_alert "Repeat Build Options" "${repeat_args[*]}" "ext" # * = expand array, space delimited, single-word.
+
 	# Export ANSI logs.
 	local target_file="${target_path}/log-${ARMBIAN_LOG_CLI_ID}-${ARMBIAN_BUILD_UUID}.log.ans"
 	export_ansi_logs


### PR DESCRIPTION
# Description

Currently "Repeat Build Options" shows at the end of screen log only if process was successfully finished.

This change adds "Repeat Build Options" text on the screen at the end of visible log.