### PR TITLE
rk35xx-vendor: Add kernel patching config

### DIFF
--- a/patch/kernel/rk35xx-vendor-6.1/0000.patching_config.yaml
+++ b/patch/kernel/rk35xx-vendor-6.1/0000.patching_config.yaml
@@ -1,0 +1,30 @@
+config:
+
+  # Just some info stuff; not used by the patching scripts
+  name: rk35xx-6.1
+  kind: kernel
+  type: vendor # or: vendor
+  branch: rk-6.1-rkr1
+  last-known-good-tag: v6.1.43
+
+  # .dts files in these directories will be copied as-is to the build tree; later ones overwrite earlier ones.
+  # This is meant to provide a way to "add a board DTS" without having to null-patch them in.
+  dts-directories:
+    - { source: "dt", target: "arch/arm64/boot/dts/rockchip" }
+
+  # the Makefile in each of these directories will be magically patched to include the dts files copied
+  #  or patched-in; overlay subdir will be included "-y" if it exists.
+  # No more Makefile patching needed, yay!
+  # "incremental: true" changes the logic of the Makefile re-writing to only add the
+  #                     dts-directories's *.dts files to existing Makefile instead of
+  #                     full rewrite from *.dts in the dt dir at the end of patching.
+  auto-patch-dt-makefile:
+    - { incremental: true, directory: "arch/arm64/boot/dts/rockchip", config-var: "CONFIG_ARCH_ROCKCHIP" }
+
+  # configuration for when applying patches to git / auto-rewriting patches (development cycle helpers)
+  patches-to-git:
+    do-not-commit-files:
+      - "MAINTAINERS" # constant churn, drop them. sorry.
+      - "Documentation/devicetree/bindings/arm/rockchip.yaml" # constant churn, conflicts on every bump, drop it. sorry.
+    do-not-commit-regexes: # Python-style regexes
+      - "^arch/([a-zA-Z0-9]+)/boot/dts/([a-zA-Z0-9]+)/Makefile$" # ignore DT Makefile patches, we've an auto-patcher now


### PR DESCRIPTION
# Description

Add the patching config file for ~~`rk35xx-vendor`~~ `rk35xx-vendor-6.1` to easily patch in `dts` files by putting them in the `dt` folder.

# How Has This Been Tested?

- [x] ~~Put new dts files in `patch/kernel/rk3588-vendor/dt` and successfully ran `./compile.sh build BOARD=nanopc-cm3588-nas BRANCH=vendor BUILD_DESKTOP=no BUILD_MINIMAL=no KERNEL_CONFIGURE=no RELEASE=bookworm`. New patches were applied.~~ EDIT: First test was wrong.
- [x] Put new dts files in `patch/kernel/rk3588-vendor-6.1/dt` and successfully ran `./compile.sh build BOARD=nanopc-cm3588-nas BRANCH=vendor BUILD_DESKTOP=no BUILD_MINIMAL=no KERNEL_CONFIGURE=no RELEASE=bookworm`. New patches were applied.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
