### PR TITLE
xiaomi elish fix 6.7

### DIFF
--- a/config/boards/xiaomi-elish.conf
+++ b/config/boards/xiaomi-elish.conf
@@ -16,7 +16,7 @@ declare -g BOARD_FIRMWARE_INSTALL="-full"
 function post_family_config_branch_sm8250__pmos_kernel() {
 	display_alert "Setting up kernel for" "${BOARD}" "info"
 	declare -g KERNEL_MAJOR_MINOR="6.7" # Major and minor versions of this kernel.
-	declare -g KERNELBRANCH='branch:linux-6.7.y'
+	declare -g KERNELBRANCH='tag:v6.7.5'
 }
 
 function xiaomi-elish_is_userspace_supported() {

--- a/patch/kernel/archive/sm8250-6.7/0027-arm64-dts-qcom-sm8250-xiaomi-elish-add-tcpm-pd-suppo.patch
+++ b/patch/kernel/archive/sm8250-6.7/0027-arm64-dts-qcom-sm8250-xiaomi-elish-add-tcpm-pd-suppo.patch
@@ -1,34 +1,36 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: amazingfate <liujianfeng1994@gmail.com>
-Date: Mon, 27 Nov 2023 12:04:32 +0800
-Subject: arm64: dts: qcom: sm8250-xiaomi-elish: add tcpm pd support
+From: Jianhua Lu <lujianhua000@gmail.com>
+Date: Sat, 2 Dec 2023 19:04:51 +0800
+Subject: arm64: dts: qcom: sm8250-xiaomi-elish: add pd negotiation support
 
 ---
- arch/arm64/boot/dts/qcom/sm8250-xiaomi-elish-common.dtsi | 6 +++++-
- 1 file changed, 5 insertions(+), 1 deletion(-)
+ arch/arm64/boot/dts/qcom/sm8250-xiaomi-elish-common.dtsi | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/qcom/sm8250-xiaomi-elish-common.dtsi b/arch/arm64/boot/dts/qcom/sm8250-xiaomi-elish-common.dtsi
-index b55bcdbcbe2c..726d886ecce8 100644
+index b55bcdbcbe2c..9029fe5fda30 100644
 --- a/arch/arm64/boot/dts/qcom/sm8250-xiaomi-elish-common.dtsi
 +++ b/arch/arm64/boot/dts/qcom/sm8250-xiaomi-elish-common.dtsi
-@@ -809,8 +809,10 @@ &pm8150b_typec {
+@@ -809,7 +809,8 @@ &pm8150b_typec {
  	connector {
  		compatible = "usb-c-connector";
  
 -		power-role = "source";
++		op-sink-microwatt = <10000000>;
 +		power-role = "dual";
  		data-role = "dual";
-+		try-power-role = "sink";
-+		op-sink-microwatt = <10000000>;
  		self-powered;
  
- 		source-pdos = <PDO_FIXED(5000, 3000,
-@@ -818,6 +820,8 @@ PDO_FIXED_DUAL_ROLE |
+@@ -818,6 +819,12 @@ PDO_FIXED_DUAL_ROLE |
  					 PDO_FIXED_USB_COMM |
  					 PDO_FIXED_DATA_SWAP)>;
  
-+		sink-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)
-+			     PDO_VAR(5000, 12000, 5000)>;
++		sink-pdos = <PDO_FIXED(5000, 3000,
++					 PDO_FIXED_DUAL_ROLE |
++					 PDO_FIXED_USB_COMM |
++					 PDO_FIXED_DATA_SWAP)
++					 PDO_VAR(5000, 12000, 5000)>;
++
  		ports {
  			#address-cells = <1>;
  			#size-cells = <0>;


### PR DESCRIPTION
# Description

Mainline kernel linux-6.7.y has broken dsi panel since 6.7.6, so we use back v6.7.5 avoid it. Other sm8250 device xiaomi 10 doesn't support panel in kernel so it should be fine.
Use typec pd patch from lujianhua and now the typec port can auto switch to host mode when usb deivices are plugged in.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] `./compile.sh kernel BOARD=xiaomi-elish BRANCH=sm8250 DEB_COMPRESS=xz KERNEL_GIT=shallow DEB_COMPRESS=xz`
- [x] Xiaomi pad5 pro works fine.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
