### PR TITLE
rk35xx/rockchip-rk3588: vendor: switch to `armbian/linux-rockchip#rk-6.1-rkr1`

### DIFF
--- a/config/boards/khadas-edge2.conf
+++ b/config/boards/khadas-edge2.conf
@@ -3,7 +3,7 @@ declare -g BOARD_NAME="Khadas Edge2"
 declare -g BOARDFAMILY="rockchip-rk3588"
 declare -g BOARD_MAINTAINER="igorpecovnik"
 declare -g BOOT_SOC="rk3588" # Just to avoid errors in rockchip64_commmon
-declare -g KERNEL_TARGET="legacy,vendor,edge"
+declare -g KERNEL_TARGET="legacy,edge" # @TODO: khadas-edge2 doesn't have ',vendor' yet
 declare -g IMAGE_PARTITION_TABLE="gpt"
 declare -g BOOT_FDT_FILE="rockchip/rk3588s-khadas-edge2.dtb" # Specific to this board
 

--- a/config/sources/families/rk35xx.conf
+++ b/config/sources/families/rk35xx.conf
@@ -29,7 +29,7 @@ case $BRANCH in
 		BOOTDIR='u-boot-rockchip64'
 		declare -g KERNEL_MAJOR_MINOR="6.1"    # Major and minor versions of this kernel.
 		declare -g -i KERNEL_GIT_CACHE_TTL=120 # 2 minutes; this is a high-traffic repo
-		KERNELSOURCE='https://github.com/amazingfate/linux-rockchip.git'
+		KERNELSOURCE='https://github.com/armbian/linux-rockchip.git'
 		KERNELBRANCH='branch:rk-6.1-rkr1'
 		KERNELPATCHDIR='rk35xx-vendor-6.1'
 		;;

--- a/config/sources/families/rockchip-rk3588.conf
+++ b/config/sources/families/rockchip-rk3588.conf
@@ -32,7 +32,7 @@ case $BRANCH in
 		BOOTDIR='u-boot-rockchip64'
 		declare -g KERNEL_MAJOR_MINOR="6.1"    # Major and minor versions of this kernel.
 		declare -g -i KERNEL_GIT_CACHE_TTL=120 # 2 minutes; this is a high-traffic repo
-		KERNELSOURCE='https://github.com/amazingfate/linux-rockchip.git'
+		KERNELSOURCE='https://github.com/armbian/linux-rockchip.git'
 		KERNELBRANCH='branch:rk-6.1-rkr1'
 		KERNELPATCHDIR='rk35xx-vendor-6.1'
 		LINUXFAMILY=rk35xx


### PR DESCRIPTION
#### rk35xx/rockchip-rk3588: vendor: switch to `armbian/linux-rockchip#rk-6.1-rkr1`

- rk35xx/rockchip-rk3588: vendor: switch to `armbian/linux-rockchip#rk-6.1-rkr1`
  - since https://github.com/armbian/linux-rockchip/pull/155
- khadas-edge2: remove `vendor` branch, we've no kedge2 DT/patches for it yet