### PR TITLE
build script: configuration: Check if ROOTFS_TYPE is supported by build host

### DIFF
--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -140,46 +140,7 @@ function do_main_configuration() {
 
 	# Check if the filesystem type is supported by the build host
 	if [[ $CONFIG_DEFS_ONLY != yes ]]; then # don't waste time if only gathering config defs
-		if [[ -f "/proc/filesystems" ]]; then
-			# Check if the filesystem is listed in /proc/filesystems
-			if ! grep -q "\<$ROOTFS_TYPE\>" /proc/filesystems; then		# ensure exact match with \<...\>
-				# Try modprobing the fs module since it doesn't show up in /proc/filesystems if it's an unloaded module versus built-in
-				if ! modprobe "$ROOTFS_TYPE"; then
-					exit_with_error "Filesystem type unsupported by build host:" "$ROOTFS_TYPE"
-				else
-					display_alert "Sucessfully loaded kernel module for filesystem" "$ROOTFS_TYPE" ""
-				fi
-			fi
-
-			# For f2fs, check if support for extended attributes is enabled in kernel config (otherwise will fail later when using rsync)
-			if [ "$ROOTFS_TYPE" = "f2fs" ]; then
-				local build_host_kernel_config=""
-				# Try to find kernel config in different places
-				if [ -f "/boot/config-$(uname -r)" ]; then
-					build_host_kernel_config="/boot/config-$(uname -r)"
-				elif [ -f "/proc/config.gz" ]; then
-					# Try to extract kernel config from /proc/config.gz
-					if command -v gzip &> /dev/null; then
-						gzip -dc /proc/config.gz > /tmp/build_host_kernel_config
-						build_host_kernel_config="/tmp/build_host_kernel_config"
-					else
-						display_alert "Could extract kernel config from build host, please install 'gzip'." "Build might fail in case of missing kernel configs for '${ROOTFS_TYPE}'" "wrn"
-					fi
-				else
-					display_alert "Could not find kernel config of build host." "Build might fail in case of missing kernel configs for '${ROOTFS_TYPE}'." "wrn"
-				fi
-
-				# Check if required configurations are set
-				if [ -n "$build_host_kernel_config" ]; then
-					if ! grep -q '^CONFIG_F2FS_FS_XATTR=y$' "$build_host_kernel_config" || \
-					! grep -q '^CONFIG_F2FS_FS_SECURITY=y$' "$build_host_kernel_config"; then
-						exit_with_error "Required kernel configurations for f2fs filesystem not enabled." "Please enable CONFIG_F2FS_FS_XATTR and CONFIG_F2FS_FS_SECURITY in your kernel configuration." "err"
-					fi
-				fi
-			fi
-		else
-			display_alert "Could not check filesystem support via /proc/filesystems on build host." "Build might fail in case of unsupported rootfs type." "wrn"
-		fi
+		check_filesystem_compatibility_on_host
 	fi
 
 	# Support for LUKS / cryptroot
@@ -561,5 +522,50 @@ function set_git_build_repo_url_and_commit_vars() {
 	BUILD_REPOSITORY_COMMIT="$(git -C "${SRC}" describe --match=d_e_a_d_b_e_e_f --always --dirty || true)"             # ignore error
 	display_alert "BUILD_REPOSITORY_URL set during ${1}" "${BUILD_REPOSITORY_URL}" "debug"
 	display_alert "BUILD_REPOSITORY_COMMIT set during ${1}" "${BUILD_REPOSITORY_COMMIT}" "debug"
+	return 0
+}
+
+function check_filesystem_compatibility_on_host() {
+	if [[ -f "/proc/filesystems" ]]; then
+			# Check if the filesystem is listed in /proc/filesystems
+		if ! grep -q "\<$ROOTFS_TYPE\>" /proc/filesystems; then		# ensure exact match with \<...\>
+			# Try modprobing the fs module since it doesn't show up in /proc/filesystems if it's an unloaded module versus built-in
+			if ! modprobe "$ROOTFS_TYPE"; then
+				exit_with_error "Filesystem type unsupported by build host:" "$ROOTFS_TYPE"
+			else
+				display_alert "Sucessfully loaded kernel module for filesystem" "$ROOTFS_TYPE" ""
+			fi
+		fi
+
+		# For f2fs, check if support for extended attributes is enabled in kernel config (otherwise will fail later when using rsync)
+		if [ "$ROOTFS_TYPE" = "f2fs" ]; then
+			local build_host_kernel_config=""
+
+			# Try to find kernel config in different places
+			if [ -f "/boot/config-$(uname -r)" ]; then
+				build_host_kernel_config="/boot/config-$(uname -r)"
+			elif [ -f "/proc/config.gz" ]; then
+				# Try to extract kernel config from /proc/config.gz
+				if command -v gzip &> /dev/null; then
+					gzip -dc /proc/config.gz > /tmp/build_host_kernel_config
+					build_host_kernel_config="/tmp/build_host_kernel_config"
+				else
+					display_alert "Could extract kernel config from build host, please install 'gzip'." "Build might fail in case of missing kernel configs for '${ROOTFS_TYPE}'" "wrn"
+				fi
+			else
+				display_alert "Could not find kernel config of build host." "Build might fail in case of missing kernel configs for '${ROOTFS_TYPE}'." "wrn"
+			fi
+
+			# Check if required configurations are set
+			if [ -n "$build_host_kernel_config" ]; then
+				if ! grep -q '^CONFIG_F2FS_FS_XATTR=y$' "$build_host_kernel_config" || \
+				! grep -q '^CONFIG_F2FS_FS_SECURITY=y$' "$build_host_kernel_config"; then
+					exit_with_error "Required kernel configurations for f2fs filesystem not enabled." "Please enable CONFIG_F2FS_FS_XATTR and CONFIG_F2FS_FS_SECURITY in your kernel configuration." "err"
+				fi
+			fi
+		fi
+	else
+		display_alert "Could not check filesystem support via /proc/filesystems on build host." "Build might fail in case of unsupported rootfs type." "wrn"
+	fi
 	return 0
 }


### PR DESCRIPTION
# Description

When trying to build an image with `FIXED_IMAGE_SIZE=3000 ROOTFS_TYPE=f2fs` with WSL2 as build host, I stumbled on an error pretty late in the build process when trying to mount the rootfs:

```
[💲|🌿] Creating rootfs [ f2fs on /dev/loop2p2 ]
[💲|🔨]
[💲|🔨]         F2FS-tools: mkfs.f2fs Ver: 1.14.0 (2020-08-24)
[💲|🔨]
[💲|🔨]   Info: Disable heap-based policy
[💲|🔨]   Info: Debug level = 0
[💲|🔨]   Info: Label = armbi_root
[💲|🔨]   Info: Trim is enabled
[💲|🔨]   Info: Segments per section = 1
[💲|🔨]   Info: Sections per zone = 1
[💲|🔨]   Info: sector size = 512
[💲|🔨]   Info: total sectors = 5586911 (2727 MB)
[💲|🔨]   Info: zone aligned segment0 blkaddr: 512
[💲|🔨]   Info: format version with
[💲|🔨]     "Linux version 6.1.21.2-microsoft-standard-WSL2+) (gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, GNU ld (GNU Binutils for Ubuntu) 2.38) #1 SMP Wed Jan 31 20:29:07 CET 2024"
[💲|🔨]   Info: [/dev/loop2p2] Discarding device
[💲|🔨]   Info: This device doesn't support BLKSECDISCARD
[💲|🔨]   Info: Discarded 2727 MB
[💲|🔨]   Info: Overprovision ratio = 3.860%
[💲|🔨]   Info: Overprovision segments = 108 (GC reserved = 59)
[💲|🔨]   Info: format successful
[💲|🌿] Mounting rootfs [ /dev/loop2p2 (UUID=02dfb13e-172d-44b1-b71c-25164f29cc0b) ]
[💲|🔨]   mount: /home/user/build-fork/.tmp/mount-bfedd4e1-02f1-4bac-99c1-88d420d40809: unknown filesystem type 'f2fs'.
[💲|💥] Error 32 occurred in main shell [ at /home/user/build-fork/lib/functions/logging/runners.sh:211
    run_host_command_logged_raw() --> lib/functions/logging/runners.sh:211
        run_host_command_logged() --> lib/functions/logging/runners.sh:193
             prepare_partitions() --> lib/functions/image/partitioning.sh:275
                do_with_logging() --> lib/functions/logging/section-logging.sh:81
         build_rootfs_and_image() --> lib/functions/main/rootfs-image.sh:86
   full_build_packages_rootfs_and_image() --> lib/functions/main/default-build.sh:36
          do_with_default_build() --> lib/functions/main/default-build.sh:42
         cli_standard_build_run() --> lib/functions/cli/cli-build.sh:25
        armbian_cli_run_command() --> lib/functions/cli/utils-cli.sh:136
                 cli_entrypoint() --> lib/functions/cli/entrypoint.sh:176
                           main() --> compile.sh:50
 ]
[💲|💥] Cleaning up [ please wait for cleanups to finish ]
```

I found out that this is because the WSL2 kernel does not have support for the F2FS filesystem. `f2fs-tools` could be installed normally though.
To make the build script exit at the beginning instead of at a late stage and to tell the user a more exact reason why it failed, I added a check if the chosen ROOTFS_TYPE is supported by the host the build script is running on.

The check checks `/proc/filesystems` which should be present in all Linux distros. But just in case `/proc/filesystems` is not present, the build won't fail and instead print a warning that the build _might_ fail just like if it can't install `python2`.

EDIT: Extended the check to fix https://github.com/armbian/build/pull/6386#issuecomment-1989660144:
1) If the filesystem can't be found in `/proc/filesystems`, try to modprobe it.
2) For f2fs, check if support for extended attributes is enabled in kernel config (otherwise will fail later when using rsync)

# How Has This Been Tested?

**Build host:** `Linux version 6.1.21.2-microsoft-standard-WSL2+` (no F2FS support, but BTRFS and EXT4 support)
**Command:** `./compile.sh build BOARD=nanopi-r5c BRANCH=edge BUILD_DESKTOP=no BUILD_MINIMAL=no KERNEL_CONFIGURE=no RELEASE=bookworm FIXED_IMAGE_SIZE=3000 ROOTFS_TYPE=f2fs`


- [x] Ran build with `FIXED_IMAGE_SIZE=3000 ROOTFS_TYPE=f2fs` --> build exits at an early stage with` [💲|💥] error! [ Filesystem type unsupported by build host: f2fs ]`
- [x] Ran build with `FIXED_IMAGE_SIZE=3000 ROOTFS_TYPE=f2fs` but now with f2fs installed as **module** and extended attributes DISABLED in host kernel --> build exits with `[💲|💥] error! [ Required kernel configurations for f2fs filesystem not enabled. Please enable CONFIG_F2FS_FS_XATTR and CONFIG_F2FS_FS_SECURITY in your kernel configuration. ]`
- [x] Ran build with `FIXED_IMAGE_SIZE=3000 ROOTFS_TYPE=f2fs` with f2fs installed as **module** and extended attributes ENABLED in host kernel --> build sucess
- [x] Ran build with `FIXED_IMAGE_SIZE=3000 ROOTFS_TYPE=f2fs` with f2fs installed **built-in** and extended attributes ENABLED in host kernel --> build sucess
- [x] Ran build with `ROOTFS_TYPE=btrfs` --> build success
- [x] Ran build without `ROOTFS_TYPE` option --> build success

_Might need some testing with other more exotic build hosts like Docker._

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
