### PR TITLE
Disable automatic enablement of Nvidia proprietary drivers on x86

### DIFF
--- a/config/sources/families/uefi-x86.conf
+++ b/config/sources/families/uefi-x86.conf
@@ -7,7 +7,6 @@
 # https://github.com/armbian/build/
 #
 # Important: LINUXFAMILY and ARCH are defined _before_ including the common family include
-[[ "$BUILD_DESKTOP" == yes && "$RELEASE" == jammy ]] && enable_extension "nvidia"
 declare -g UEFI_GRUB_TERMINAL="${UEFI_GRUB_TERMINAL:-gfxterm}"
 declare -g LINUXFAMILY="x86"
 declare -g ARCH="amd64"


### PR DESCRIPTION
# Description

As per title.

Jira reference number [AR-2103]

# How Has This Been Tested?

- [x] Manual build

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-2103]: https://armbian.atlassian.net/browse/AR-2103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ