### PR TITLE
cli: `rewrite-<uboot,kernel>-patches`: rewrite only patches needing a rebase

### DIFF
--- a/lib/functions/cli/commands.sh
+++ b/lib/functions/cli/commands.sh
@@ -42,10 +42,12 @@ function armbian_register_commands() {
 		# Patch to git & patch rewrite, for kernel
 		["kernel-patches-to-git"]="patch_kernel"  # implemented in cli_patch_kernel_pre_run and cli_patch_kernel_run
 		["rewrite-kernel-patches"]="patch_kernel" # implemented in cli_patch_kernel_pre_run and cli_patch_kernel_run
+		["rewrite-kernel-patches-needing-rebase"]="patch_kernel" # implemented in cli_patch_kernel_pre_run and cli_patch_kernel_run
 
 		# Patch to git & patch rewrite, for u-boot
 		["uboot-patches-to-git"]="patch_uboot"  # implemented in cli_patch_uboot_pre_run and cli_patch_uboot_run
 		["rewrite-uboot-patches"]="patch_uboot" # implemented in cli_patch_uboot_pre_run and cli_patch_uboot_run
+		["rewrite-uboot-patches-needing-rebase"]="patch_uboot" # implemented in cli_patch_uboot_pre_run and cli_patch_uboot_run
 
 		["build"]="standard_build" # implemented in cli_standard_build_pre_run and cli_standard_build_run
 		["distccd"]="distccd"      # implemented in cli_distccd_pre_run and cli_distccd_run
@@ -114,8 +116,10 @@ function armbian_register_commands() {
 		["inventory-boards"]="TARGETS_FILE='something_that_does_not_exist_so_defaults_are_used'"
 
 		# patching
-		["rewrite-kernel-patches"]="REWRITE_PATCHES=yes" # rewrite the patches after round-tripping to git: "rebase patches"
-		["rewrite-uboot-patches"]="REWRITE_PATCHES=yes"  # rewrite the patches after round-tripping to git: "rebase patches"
+		["rewrite-kernel-patches"]="REWRITE_PATCHES='yes'" # rewrite the patches after round-tripping to git: "rebase patches"
+		["rewrite-uboot-patches"]="REWRITE_PATCHES='yes'"  # rewrite the patches after round-tripping to git: "rebase patches"
+		["rewrite-kernel-patches-needing-rebase"]="REWRITE_PATCHES='yes' REWRITE_PATCHES_NEEDING_REBASE='yes'"
+		["rewrite-uboot-patches-needing-rebase"]="REWRITE_PATCHES='yes' REWRITE_PATCHES_NEEDING_REBASE='yes'"
 
 		# artifact shortcuts
 		["rootfs"]="WHAT='rootfs' ${common_cli_artifact_vars}"

--- a/lib/functions/compilation/kernel-patching.sh
+++ b/lib/functions/compilation/kernel-patching.sh
@@ -38,9 +38,10 @@ function kernel_main_patching_python() {
 		"PATH=${PATH}"
 		"HOME=${HOME}"
 		# What to do?
-		"APPLY_PATCHES=yes"                      # Apply the patches to the filesystem. Does not imply git commiting. If no, still exports the hash.
-		"PATCHES_TO_GIT=${PATCHES_TO_GIT:-no}"   # Commit to git after applying the patches.
-		"REWRITE_PATCHES=${REWRITE_PATCHES:-no}" # Rewrite the original patch files after git commiting.
+		"APPLY_PATCHES=yes"                                                    # Apply the patches to the filesystem. Does not imply git commiting. If no, still exports the hash.
+		"PATCHES_TO_GIT=${PATCHES_TO_GIT:-no}"                                 # Commit to git after applying the patches.
+		"REWRITE_PATCHES=${REWRITE_PATCHES:-no}"                               # Rewrite the original patch files after git commiting.
+		"REWRITE_PATCHES_NEEDING_REBASE=${REWRITE_PATCHES_NEEDING_REBASE:-no}" # Only rewrite those patch files in need of a rebase.
 		# Git dir, revision, and target branch
 		"GIT_WORK_DIR=${kernel_work_dir}"                                # "Where to apply patches?"
 		"BASE_GIT_REVISION=${kernel_git_revision}"                       # The revision we're building/patching. Python will reset and clean to this.

--- a/lib/functions/compilation/uboot-patching.sh
+++ b/lib/functions/compilation/uboot-patching.sh
@@ -33,9 +33,10 @@ function uboot_main_patching_python() {
 		"PATH=${PATH}"
 		"HOME=${HOME}"
 		# What to do?
-		"APPLY_PATCHES=yes"                      # Apply the patches to the filesystem. Does not imply git commiting. If no, still exports the hash.
-		"PATCHES_TO_GIT=${PATCHES_TO_GIT:-no}"   # Commit to git after applying the patches.
-		"REWRITE_PATCHES=${REWRITE_PATCHES:-no}" # Rewrite the original patch files after git commiting.
+		"APPLY_PATCHES=yes"                                                    # Apply the patches to the filesystem. Does not imply git commiting. If no, still exports the hash.
+		"PATCHES_TO_GIT=${PATCHES_TO_GIT:-no}"                                 # Commit to git after applying the patches.
+		"REWRITE_PATCHES=${REWRITE_PATCHES:-no}"                               # Rewrite the original patch files after git commiting.
+		"REWRITE_PATCHES_NEEDING_REBASE=${REWRITE_PATCHES_NEEDING_REBASE:-no}" # Only rewrite those patch files in need of a rebase.
 		# Git dir, revision, and target branch
 		"GIT_WORK_DIR=${uboot_work_dir}"               # "Where to apply patches?"
 		"BASE_GIT_REVISION=${uboot_git_revision}"      # The revision we're building/patching. Python will reset and clean to this.

--- a/lib/tools/patching.py
+++ b/lib/tools/patching.py
@@ -44,6 +44,7 @@ PATCH_DIRS_TO_APPLY = armbian_utils.parse_env_for_tokens("PATCH_DIRS_TO_APPLY")
 APPLY_PATCHES = armbian_utils.get_from_env("APPLY_PATCHES")
 PATCHES_TO_GIT = armbian_utils.get_from_env("PATCHES_TO_GIT")
 REWRITE_PATCHES = armbian_utils.get_from_env("REWRITE_PATCHES")
+REWRITE_PATCHES_NEEDING_REBASE = armbian_utils.get_from_env("REWRITE_PATCHES_NEEDING_REBASE")
 SPLIT_PATCHES = armbian_utils.get_from_env("SPLIT_PATCHES")
 ALLOW_RECREATE_EXISTING_FILES = armbian_utils.get_from_env("ALLOW_RECREATE_EXISTING_FILES")
 GIT_ARCHEOLOGY = armbian_utils.get_from_env("GIT_ARCHEOLOGY")
@@ -53,6 +54,7 @@ apply_patches_to_git = PATCHES_TO_GIT == "yes"
 git_archeology = GIT_ARCHEOLOGY == "yes"
 fast_archeology = FAST_ARCHEOLOGY == "yes"
 rewrite_patches_in_place = REWRITE_PATCHES == "yes"
+rewrite_only_patches_needing_rebase = REWRITE_PATCHES_NEEDING_REBASE == "yes"
 split_patches = SPLIT_PATCHES == "yes"
 apply_options = {
 	"allow_recreate_existing_files": (ALLOW_RECREATE_EXISTING_FILES == "yes"),
@@ -357,6 +359,12 @@ if apply_patches:
 			if one_patch.rewritten_patch is None:
 				log.warning(f"Skipping patch {one_patch} from rewrite because it was not rewritten.")
 				continue
+			
+			# Skip the patch if it doesn't need rebasing
+			if rewrite_only_patches_needing_rebase:
+				if "needs_rebase" not in one_patch.problems:
+					log.info(f"Skipping patch {one_patch} from rewrite because it doesn't need a rebase.")
+					continue
 
 			if one_patch.parent not in patch_files_by_parent:
 				patch_files_by_parent[one_patch.parent] = []
@@ -365,8 +373,8 @@ if apply_patches:
 		for parent in patch_files_by_parent:
 			patches = patch_files_by_parent[parent]
 			parent.rewrite_patch_file(patches)
-		UNAPPLIED_PATCHES = [one_patch for one_patch in VALID_PATCHES if (not one_patch.applied_ok) or (one_patch.rewritten_patch is None)]
-		for failed_patch in UNAPPLIED_PATCHES:
+		FAILED_PATCHES = [one_patch for one_patch in VALID_PATCHES if (not one_patch.applied_ok) or (one_patch.rewritten_patch is None)]
+		for failed_patch in FAILED_PATCHES:
 			log.info(
 				f"Consider removing {failed_patch.parent.full_file_path()}(:{failed_patch.counter}); "
 				f"it was not applied successfully.")


### PR DESCRIPTION
# Description

This is a follow-up on this PR https://github.com/armbian/build/pull/6376 and this comment https://github.com/armbian/build/pull/6376#issuecomment-1987147291
It's more of an idea, since I tried `rewrite-uboot-patches` and noticed the following:

Board NanoPi-R6S has 5 U-Boot patches in total (`legacy/u-boot-raxda-rk3588`). Using `./compile.sh BOARD=nanopi-r6s BRANCH=edge rewrite-uboot-patches` has the following patch summary:
`Summary: u-boot patching: 5 total patches; 5 applied; 2 with problems; 2 needs_rebase`
However, instead of only rewriting/rebasing the 2 patches, it modifies all 5 patches slightly (see example below). This means your git working tree quickly gets cluttered with these modified-without-any-real-changes patch files. And you'll have to either figure out which patches were changed/rebased if you only want to commit those, or commit all and make it harder to see the actual changes (I think?).

**Example of a patch file getting modified even if the patch stays the same:**
(Notice the lines/hunks did not get changed, only the metadata)

```diff
git diff patch/u-boot/legacy/u-boot-radxa-rk3588/0001-Add-defconfig-and-dtb-of-nanopi6.patch | cat

diff --git a/patch/u-boot/legacy/u-boot-radxa-rk3588/0001-Add-defconfig-and-dtb-of-nanopi6.patch b/patch/u-boot/legacy/u-boot-radxa-rk3588/0001-Add-defconfig-and-dtb-of-nanopi6.patch
index 38f1a5a..b8e16cd 100644
--- a/patch/u-boot/legacy/u-boot-radxa-rk3588/0001-Add-defconfig-and-dtb-of-nanopi6.patch
+++ b/patch/u-boot/legacy/u-boot-radxa-rk3588/0001-Add-defconfig-and-dtb-of-nanopi6.patch
@@ -1,18 +1,16 @@
-From 70d65e65db965295ddd23d5db752aad1c035c205 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Muhammed=20Efe=20=C3=87etin?= <efectn@protonmail.com>
 Date: Sat, 15 Apr 2023 23:12:17 +0300
-Subject: [PATCH] Add defconfig and dtb of nanopi6
+Subject: Add defconfig and dtb of nanopi6
 
 ---
- arch/arm/dts/rk3588s-nanopi-r6s.dts  | 126 ++++++++++++++++
- configs/nanopi-r6s-rk3588s_defconfig | 217 +++++++++++++++++++++++++++
+ arch/arm/dts/rk3588s-nanopi-r6s.dts  | 126 ++++++
+ configs/nanopi-r6s-rk3588s_defconfig | 217 ++++++++++
  2 files changed, 343 insertions(+)
- create mode 100644 arch/arm/dts/rk3588s-nanopi-r6s.dts
- create mode 100644 configs/nanopi-r6s-rk3588s_defconfig
 
 diff --git a/arch/arm/dts/rk3588s-nanopi-r6s.dts b/arch/arm/dts/rk3588s-nanopi-r6s.dts
 new file mode 100644
-index 0000000000..4899e23fa3
+index 000000000000..4899e23fa3aa
 --- /dev/null
 +++ b/arch/arm/dts/rk3588s-nanopi-r6s.dts
 @@ -0,0 +1,126 @@
@@ -144,7 +142,7 @@ index 0000000000..4899e23fa3
 +};
 diff --git a/configs/nanopi-r6s-rk3588s_defconfig b/configs/nanopi-r6s-rk3588s_defconfig
 new file mode 100644
-index 0000000000..19bae55629
+index 000000000000..19bae5562928
 --- /dev/null
 +++ b/configs/nanopi-r6s-rk3588s_defconfig
 @@ -0,0 +1,217 @@
@@ -366,5 +364,5 @@ index 0000000000..19bae55629
 +CONFIG_OPTEE_V2=y
 +CONFIG_OPTEE_ALWAYS_USE_SECURITY_PARTITION=y
 -- 
-2.39.2
+Armbian
```

### How I tried to solve this

The information if a patch needs rebasing is already there, so I tried to solve this by introducing a new option `REWRITE_PATCHES_NEEDING_REBASE` in addition to the existing `REWRITE_PATCHES`. Why an additional option?
1) I didn't want to break anything (took me some hours already to figure out where the actual patch rewriting happes and to understand their logic, so I'm not confident to change what `REWRITE_PATCHES` does on its own 😅)
2) Maybe there will be some reason when you want to actually rewrite all patches even if they don't need rebasing?

If it's not an issue, I could also just remove the additional option `REWRITE_PATCHES_NEEDING_REBASE` and instead make this the default behaviour for `REWRITE_PATCHES`.

# How Has This Been Tested?

- [x] Run the same command as earlier: `./compile.sh BOARD=nanopi-r6s BRANCH=edge rewrite-uboot-patches` and only the 2 patches that needed rebasing were modified
- [x] Compiled a board image to check if nothing got broken: `./compile.sh build BOARD=nanopi-r5c BRANCH=edge BUILD_DESKTOP=no BUILD_MINIMAL=no KERNEL_CONFIGURE=no RELEASE=bookworm`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
