### PR TITLE
Add RTL8211f support for Rockpi E

### DIFF
--- a/patch/kernel/archive/rockchip-6.1/overlay/README.rk322x-overlays
+++ b/patch/kernel/archive/rockchip-6.1/overlay/README.rk322x-overlays
@@ -19,6 +19,7 @@ rk322x (Rockchip)
 - rk322x-bt-*
 - rk322x-usb-otg-peripheral
 - rk322x-ir-wakeup
+- rk3328-r8211f
 
 ### Overlay details:
 
@@ -96,4 +97,8 @@ of USB host
 Enable the rockchip-ir-driver in place of the standard gpio-ir-receiver.
 The rockchip-specific driver exploits the Trust OS and Virtual Poweroff mode
 to allow power up via remote controller power button.
+
+### rk3328-r8211f
+
+Enable the 1 Gbit/s on Rockpi S found on hardware revison 1.2
 

--- a/patch/kernel/archive/rockchip-6.1/overlay/rk3328-r8211f.dts
+++ b/patch/kernel/archive/rockchip-6.1/overlay/rk3328-r8211f.dts
@@ -1,0 +1,24 @@
+/dts-v1/;
+/ {
+	compatible = "rockchip,rk3328";
+	fragment@0 {
+		target-path = "/ethernet@ff540000";
+		__overlay__ {
+			snps,reset-delays-us = <0 20000 100000>;
+			tx_delay = <0x1a>;
+			rx_delay = <0x14>;
+		};
+	};
+	fragment@1 {
+		target-path = "/ethernet@ff540000/mdio";
+		__overlay__ {
+			ethernet-phy@1 {
+				compatible = "ethernet-phy-id001c.c916", "ethernet-phy-ieee802.3-c22";
+				reset-assert-us = <20000>;
+				reset-deassert-us = <100000>;
+				max-speed = <1000>;
+			};
+		};
+	};
+};
+


### PR DESCRIPTION
# Description

As discussed [here](https://forum.armbian.com/topic/16100-rockpi-e-enabling-uart1-and-otg-using-custom-dt-overlays/?do=findComment&comment=184656) on the forums this overlay adds support for the RTL8211f chip found on Rockpi E Hardware revision 1.21

# Documentation summary for feature / change

Documentation updated, hope that's enough and appropriate.

# How Has This Been Tested?

Running that overlay currently on four Rockpi S instances connected to the 1 Gbit/s port

# Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
