### PR TITLE
Expand predicted size for rootfs for abl type of images

### DIFF
--- a/extensions/image-output-abl.sh
+++ b/extensions/image-output-abl.sh
@@ -15,7 +15,7 @@ function post_build_image__900_convert_to_abl_img() {
 	old_rootfs_image_mount_dir=${DESTIMG}/rootfs-old
 	new_rootfs_image_mount_dir=${DESTIMG}/rootfs-new
 	mkdir -p ${old_rootfs_image_mount_dir} ${new_rootfs_image_mount_dir}
-	truncate --size=8192M ${ROOTFS_IMAGE_FILE}
+	truncate --size=9216M ${ROOTFS_IMAGE_FILE}
 	mkfs.ext4 -F ${ROOTFS_IMAGE_FILE}
 	new_rootfs_image_uuid=$(blkid -s UUID -o value ${ROOTFS_IMAGE_FILE})
 	mount ${DESTIMG}/rootfs.img ${old_rootfs_image_mount_dir}


### PR DESCRIPTION
# Description

Rootfs is on the edge and can ran out of space. Add 1Gb to the rootfs.

# How Has This Been Tested?

- [ ] Recreated image

# Checklist:

- [ ] My changes generate no new warnings
