### PR TITLE
desktop: jammy: kde-neon: more basic packages needed

### DIFF
--- a/config/desktop/common/environments/kde-plasma/armbian/create_desktop_package.sh
+++ b/config/desktop/common/environments/kde-plasma/armbian/create_desktop_package.sh
@@ -1,18 +1,18 @@
 # install sddm greeter theme
-mkdir -p "${destination}"/usr/share/sddm/themes
-cp -R "${SRC}"/packages/blobs/desktop/sddm/themes/plasma-chili/ "${destination}"/usr/share/sddm/themes
+mkdir -pv "${destination}"/usr/share/sddm/themes
+cp -Rv "${SRC}"/packages/blobs/desktop/sddm/themes/plasma-chili/ "${destination}"/usr/share/sddm/themes
 
 # install default desktop settings
-mkdir -p "${destination}"/etc/skel
-cp -R "${SRC}"/packages/blobs/desktop/skel/. "${destination}"/etc/skel
+mkdir -pv "${destination}"/etc/skel
+cp -Rv "${SRC}"/packages/blobs/desktop/skel/. "${destination}"/etc/skel
 
 # install wallpapers
-mkdir -p "${destination}"/usr/share/backgrounds/armbian/
-cp "${SRC}"/packages/blobs/desktop/desktop-wallpapers/*.jpg "${destination}"/usr/share/backgrounds/armbian
+mkdir -pv "${destination}"/usr/share/backgrounds/armbian/
+cp -v "${SRC}"/packages/blobs/desktop/desktop-wallpapers/*.jpg "${destination}"/usr/share/backgrounds/armbian
 
 # install logo for login screen
-mkdir -p "${destination}"/usr/share/pixmaps/armbian
-cp "${SRC}"/packages/blobs/desktop/icons/armbian.png "${destination}"/usr/share/pixmaps/armbian
+mkdir -pv "${destination}"/usr/share/pixmaps/armbian
+cp -v "${SRC}"/packages/blobs/desktop/icons/armbian.png "${destination}"/usr/share/pixmaps/armbian
 
 # set default wallpaper
 #echo "

--- a/config/desktop/common/environments/kde-plasma/debian/postinst
+++ b/config/desktop/common/environments/kde-plasma/debian/postinst
@@ -1,2 +1,2 @@
 # Disable Pulseaudio timer scheduling which does not work with sndhdmi driver
-if [ -f /etc/pulse/default.pa ]; then sed "s/load-module module-udev-detect$/& tsched=0/g" -i  /etc/pulse/default.pa; fi
+# if [ -f /etc/pulse/default.pa ]; then sed "s/load-module module-udev-detect$/& tsched=0/g" -i /etc/pulse/default.pa; fi

--- a/config/desktop/jammy/environments/kde-neon/config_base/packages
+++ b/config/desktop/jammy/environments/kde-neon/config_base/packages
@@ -1,3 +1,8 @@
 neon-desktop
 kde-standard
 sddm
+plasma-nm
+plasma-pa
+plasma-discover
+plasma-vault
+scdaemon


### PR DESCRIPTION
#### desktop: jammy: kde-neon: more basic packages needed

- desktop: jammy: kde-neon: more basic packages needed
  - add network-manager & pulseaudio settings
  - add discover, otherwise there is a broken icon on the dock
  - add vault/scdaemon for gpg wallet
  - enable debugs in create_desktop_package.sh; disable old postinst pa hack