### PR TITLE
GH: ISSUE_TEMPLATE: Improve bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugreport.yml
+++ b/.github/ISSUE_TEMPLATE/bugreport.yml
@@ -1,5 +1,5 @@
 name: Armbian Linux Build Framework Bug Report
-description: Create a bug report if there is something wrong with build framework mechanism.
+description: Create a bug report if there is something wrong with the Armbian build framework.
 title: "Problem found ... "
 labels: ["bug"]
 assignees: "armbian/build-scripts"
@@ -12,34 +12,29 @@ body:
     id: what-happened
     attributes:
       label: What happened?
-      description: "
-      <br>
-      Tell us, what did you expect to happen?
-      "
-      placeholder: Tell us what you see!
-      value: "A bug happened!"
+      description: |
+
+        Also tell us, what did you expect to happen?
+      placeholder: An error x ocurred when I did y!
     validations:
       required: true
   - type: textarea
     id: reproduce
     attributes:
       label: How to reproduce?
-      description: "
-      <br>
-      Provide command line or explain steps which you did?
-      "
-      placeholder: Tell us how you did it!
-      value: "Command you gave to the framework!"
+      description: |
+
+        Provide the command you ran or explain the steps you did.
+      placeholder: Tell us how you did it! E.g. the command you gave to the framework.
     validations:
       required: true
   - type: dropdown
     id: version
     attributes:
       label: Branch
-      description: "
-      <br>
-      Which branch are you using?
-      "
+      description: |
+
+        Which branch are you using?
       options:
         - main (main development branch)
         - other
@@ -48,14 +43,23 @@ body:
   - type: dropdown
     id: host
     attributes:
-      label: On which host OS are you observing this problem?
+      label: On which host OS are you running the build script and observing this problem?
       multiple: false
       options:
-        - Jammy
-        - Bullseye
+        - Ubuntu 24.04 Noble
+        - Ubuntu 22.04 Jammy
+        - Debian 13 Trixie
+        - Debian 12 Bookworm
         - Other
     validations:
       required: true
+  - type: checkboxes
+    id: host-is-wsl
+    attributes:
+      label: Are you building on Windows WSL2?
+      options:
+        - label: Yes, my Ubuntu/Debian/OtherOS is running on WSL2
+          required: false
   - type: input
     id: logs
     attributes:
@@ -63,7 +67,8 @@ body:
       description: |
         Run with `SHARE_LOG=yes`, at the end of log you will get something like this
         ```[🌿] Log uploaded, share URL: [ https://paste.armbian.com/xxx ]```
-        Paste the URL on here.
+
+        Paste the URL here:
       placeholder: https://paste.armbian.com/xxx
   - type: checkboxes
     id: terms


### PR DESCRIPTION
# Description

This PR tries to improve the GitHub bug report template for the build framework:

- Don't have pre-placed text in text boxes which have to be deleted each time (placeholder/light grey background text is still there)
- Add latest host systems
- Add optional checkbox if building on WSL2
- Small wording improvements/changes

# How Has This Been Tested?

- [x] View the result (preview) in my forked repo

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings