### PR TITLE
GH Actions: Kernel hardening analysis: Exclude RISC-V configs

### DIFF
--- a/.github/workflows/kernel-security-analysis-pr.yml
+++ b/.github/workflows/kernel-security-analysis-pr.yml
@@ -44,9 +44,11 @@ jobs:
            path: kconfig-hardened-check
 
        - name: Check kernel config for security issues
+         # Run kernel-hardening-checker for each kernel config file excluding RISC-V configs, since they are not supported yet.
+         # See https://github.com/a13xp0p0v/kernel-hardening-checker/issues/56
          run: |
            for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-               if [[  "${file}" = config/kernel/*.config ]]; then
+               if [[ "${file}" = config/kernel/*.config && ! $(head -n 10 "${file}" | grep -q "riscv") ]]; then
                    kconfig-hardened-check/bin/kernel-hardening-checker -m show_fail -c $file | sed -e 's/^/    /' >> $GITHUB_STEP_SUMMARY
                fi
            done


### PR DESCRIPTION
# Description

I was checking this Actions workflow https://github.com/armbian/build/actions/runs/8309150018/job/22740183634 and noticed `[!] ERROR: failed to detect microarchitecture`

Reason: RISC-V is not yet supported by kernel-hardening-checker. See https://github.com/a13xp0p0v/kernel-hardening-checker/issues/56

In their README:

> Supported microarchitectures
> 
>     X86_64
>     X86_32
>     ARM64
>     ARM
> 
> TODO: RISC-V (issue https://github.com/a13xp0p0v/kernel-hardening-checker/issues/56)

# How Has This Been Tested?

Ran manual in CLI: `file=config/kernel/linux-uefi-risc64-edge.config` and then `if [[ "${file}" = config/kernel/*.config && ! "${file}" =~ riscv ]]; then echo yes; fi`
Don't know how to run the whole workflow manually quickly, and on a specific file.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
