### PR TITLE
`Automatic` board configs status synchronise

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -82,6 +82,7 @@ config/boards/orangepiprime.conf		@viraniac
 config/boards/orangepizero.conf		@viraniac
 config/boards/orangepizero2.conf		@AGM1968 @krachlatte
 config/boards/orangepizeroplus.conf		@schwar3kat
+config/boards/phytiumpi.csc		@chainsx
 config/boards/pine64.conf		@PanderMusubi
 config/boards/pine64so.csc		@joshaspinall
 config/boards/pinebook-pro.conf		@TRSx80 @ahoneybun
@@ -132,11 +133,11 @@ config/kernel/linux-meson64-*.config		@NicoD-SBC @SteeManMI @Tonymac32 @adeepn @
 config/kernel/linux-mvebu-*.config		@Heisath
 config/kernel/linux-mvebu64-*.config		@ManoftheSea
 config/kernel/linux-odroidxu4-*.config		@joekhoobyar
+config/kernel/linux-phytium-embedded-*.config		@chainsx
 config/kernel/linux-rk35xx-*.config		@Tonymac32 @Z-Keven @ZazaBR @amazingfate @catalinii @chainsx @efectn @hoochiwetech @igorpecovnik @krachlatte @lanefu @linhz0hz @mahdichi @monkaBlyat @rpardini @sputnik2019 @vamzii
 config/kernel/linux-rockchip-*.config		@paolosabatino
 config/kernel/linux-rockchip-rk3588-*.config		@Tonymac32 @amazingfate @efectn @igorpecovnik @lanefu @linhz0hz @rpardini
 config/kernel/linux-rockchip64-*.config		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @rpardini @schwar3kat @tdleiyao @utlark @vamzii
-config/kernel/linux-rockpis-*.config		@brentr
 config/kernel/linux-sun50iw9-*.config		@AGM1968 @krachlatte
 config/kernel/linux-sun50iw9-btt-*.config		@bigtreetech
 config/kernel/linux-sunxi-*.config		@1ubuntuuser @AaronNGray @DylanHP @StephenGraf @Tonymac32 @lbmendes @schwar3kat @sgjava @viraniac
@@ -145,7 +146,6 @@ config/kernel/linux-thead-*.config		@chainsx
 config/kernel/linux-uefi-arm64-*.config		@150balbes @PeterChrz @rpardini
 config/kernel/linux-uefi-x86-*.config		@davidandreoletti @rpardini
 patch/kernel/archive/meson-s4t7-*/		@echatzip @rpardini @viraniac
-patch/kernel/archive/rockpis-*/		@brentr
 patch/kernel/archive/sm8250-*/		@FantasyGmm @amazingfate
 patch/kernel/archive/sun50iw9-*/		@AGM1968 @krachlatte
 patch/kernel/archive/sun50iw9-btt-*/		@bigtreetech
@@ -161,12 +161,12 @@ patch/kernel/meson64-*/		@NicoD-SBC @SteeManMI @Tonymac32 @adeepn @bretmlw @clee
 patch/kernel/mvebu-*/		@Heisath
 patch/kernel/mvebu64-*/		@ManoftheSea
 patch/kernel/odroidxu4-*/		@joekhoobyar
+patch/kernel/phytium-embedded-*/		@chainsx
 patch/kernel/rk35xx-*/		@Tonymac32 @Z-Keven @ZazaBR @amazingfate @catalinii @chainsx @efectn @hoochiwetech @igorpecovnik @krachlatte @lanefu @linhz0hz @mahdichi @monkaBlyat @rpardini @sputnik2019 @vamzii
 patch/kernel/rk35xx-vendor-*/		@Tonymac32 @Z-Keven @ZazaBR @amazingfate @catalinii @chainsx @efectn @hoochiwetech @krachlatte @lanefu @linhz0hz @mahdichi @monkaBlyat @rpardini @sputnik2019 @vamzii
 patch/kernel/rockchip-*/		@paolosabatino
 patch/kernel/rockchip-rk3588-*/		@Tonymac32 @amazingfate @efectn @igorpecovnik @lanefu @linhz0hz @rpardini
 patch/kernel/rockchip64-*/		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @rpardini @schwar3kat @tdleiyao @utlark @vamzii
-patch/kernel/rockpis-*/		@brentr
 patch/kernel/sun50iw9-*/		@AGM1968 @krachlatte
 patch/kernel/thead-*/		@chainsx
 sources/families/arm64.conf		@150balbes @FantasyGmm @PeterChrz @amazingfate @rpardini
@@ -179,11 +179,11 @@ sources/families/meson64.conf		@NicoD-SBC @SteeManMI @Tonymac32 @adeepn @bretmlw
 sources/families/mvebu.conf		@Heisath
 sources/families/mvebu64.conf		@ManoftheSea
 sources/families/odroidxu4.conf		@joekhoobyar
+sources/families/phytium-embedded.conf		@chainsx
 sources/families/rk35xx.conf		@Tonymac32 @Z-Keven @ZazaBR @amazingfate @catalinii @chainsx @efectn @hoochiwetech @igorpecovnik @krachlatte @lanefu @linhz0hz @mahdichi @monkaBlyat @rpardini @sputnik2019 @vamzii
 sources/families/rockchip-rk3588.conf		@Tonymac32 @amazingfate @efectn @igorpecovnik @lanefu @linhz0hz @rpardini
 sources/families/rockchip.conf		@paolosabatino
 sources/families/rockchip64.conf		@Manouchehri @TRSx80 @Tonymac32 @ZazaBR @ahoneybun @amazingfate @brentr @catalinii @clee @joekhoobyar @krachlatte @paolosabatino @rpardini @schwar3kat @tdleiyao @utlark @vamzii
-sources/families/rockpis.conf		@brentr
 sources/families/sun50iw9-btt.conf		@bigtreetech
 sources/families/sun50iw9.conf		@AGM1968 @krachlatte
 sources/families/sunxi.conf		@1ubuntuuser @AaronNGray @DylanHP @StephenGraf @Tonymac32 @lbmendes @schwar3kat @sgjava @viraniac

--- a/config/boards/phytiumpi.csc
+++ b/config/boards/phytiumpi.csc
@@ -1,7 +1,7 @@
 # Phytium PhytiumPi quad core 4GB SoC GBe USB3
 BOARD_NAME="Phytium Pi"
 BOARDFAMILY="phytium-embedded"
-BOARD_MAINTAINER=""
+BOARD_MAINTAINER="chainsx"
 KERNEL_TARGET="legacy"
 BOOT_FDT_FILE="phytium/phytiumpi_firefly.dtb"
 SRC_EXTLINUX="yes"


### PR DESCRIPTION
Update maintainers and board status

- synced status from the database
- rename to .`csc` where we don't have anyone

If you want to become a board maintainer, [adjust data here](https://www.armbian.com/update-data/).

Ref: [Board Maintainers Procedures and Guidelines](https://docs.armbian.com/Board_Maintainers_Procedures_and_Guidelines/)