### PR TITLE
BananaPi M4 Zero: `add gpu and uart nodes`

### DIFF
--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-allwinner-sun50i-h618-bananapi-m4-zero.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-allwinner-sun50i-h618-bananapi-m4-zero.patch
@@ -1,16 +1,13 @@
 From 4da52c3e9298df267644b7244703f7c3132c26d8 Mon Sep 17 00:00:00 2001
 From: Patrick Yavitz <pyavitz@xxxxx.com>
-Date: Thu, 22 Feb 2024 19:24:54 -0500
+Date: Sun, 17 Mar 2024 18:54:24 -0400
 Subject: [PATCH] arch: arm64: dts: allwinner: sun50i-h618-bananapi-m4-zero
-
-Based on DTS by: Andre Przywara
-https://lore.kernel.org/linux-sunxi/20240204101054.152012-1-andre.przywara@arm.com/T/#t
 
 Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
 ---
  arch/arm64/boot/dts/allwinner/Makefile        |   1 +
- .../sun50i-h618-bananapi-m4-zero.dts          | 255 ++++++++++++++++++
- 2 files changed, 256 insertions(+)
+ .../sun50i-h618-bananapi-m4-zero.dts          | 276 ++++++++++++++++++
+ 2 files changed, 277 insertions(+)
  create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts
 
 diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
@@ -27,10 +24,10 @@ index d2266f5e5795..4374ed5d9c86 100644
  subdir-y	:= $(dts-dirs) overlay
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts b/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts
 new file mode 100644
-index 000000000000..248e1f5a344e
+index 000000000000..94b940f993d9
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts
-@@ -0,0 +1,258 @@
+@@ -0,0 +1,276 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2024 Patrick Yavitz <pyavitz@xxxxx.com>
@@ -53,6 +50,7 @@ index 000000000000..248e1f5a344e
 +	aliases {
 +		ethernet0 = &emac1;
 +		serial0 = &uart0;
++		serial5 = &uart5;
 +		i2c3 = &i2c3;
 +		i2c4 = &i2c4;
 +		spi1 = &spi1;
@@ -73,6 +71,16 @@ index 000000000000..248e1f5a344e
 +		};
 +	};
 +
++	gpio-keys {
++		compatible = "gpio-keys";
++
++		key-sw3 {
++			label = "sw3";
++			linux,code = <BTN_0>;
++			gpios = <&pio 2 7 GPIO_ACTIVE_LOW>;	/* PC7 */
++		};
++	};
++
 +	leds {
 +		compatible = "gpio-leds";
 +
@@ -81,16 +89,6 @@ index 000000000000..248e1f5a344e
 +			function = LED_FUNCTION_STATUS;
 +			gpios = <&pio 2 12 GPIO_ACTIVE_HIGH>;	/* PC12 */
 +			linux,default-trigger = "heartbeat";
-+		};
-+	};
-+
-+	gpio-keys {
-+		compatible = "gpio-keys";
-+
-+		key-sw3 {
-+			label = "sw3";
-+			linux,code = <BTN_0>;
-+			gpios = <&pio 2 7 GPIO_ACTIVE_LOW>;	/* PC7 */
 +		};
 +	};
 +
@@ -145,6 +143,21 @@ index 000000000000..248e1f5a344e
 +	status = "disabled";
 +};
 +
++&gpu {
++	mali-supply = <&reg_dcdc1>;
++	status = "disabled";
++};
++
++&hdmi {
++	status = "okay";
++};
++
++&hdmi_out {
++	hdmi_out_con: endpoint {
++		remote-endpoint = <&hdmi_con_in>;
++	};
++};
++
 +&ir {
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&ir_rx_pin>;
@@ -155,16 +168,6 @@ index 000000000000..248e1f5a344e
 +	ext_rgmii_phy: ethernet-phy@1 {
 +		compatible = "ethernet-phy-ieee802.3-c22";
 +		reg = <1>;
-+	};
-+};
-+
-+&hdmi {
-+	status = "okay";
-+};
-+
-+&hdmi_out {
-+	hdmi_out_con: endpoint {
-+		remote-endpoint = <&hdmi_con_in>;
 +	};
 +};
 +
@@ -277,6 +280,18 @@ index 000000000000..248e1f5a344e
 +&uart0 {
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&uart0_ph_pins>;
++	status = "okay";
++};
++
++&uart1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart1_pins>, <&uart1_rts_cts_pins>;
++	status = "okay";
++};
++
++&uart5 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart5_pins>;
 +	status = "okay";
 +};
 +

--- a/patch/kernel/archive/sunxi-6.7/patches.armbian/arm64-dts-allwinner-sun50i-h618-bananapi-m4-zero.patch
+++ b/patch/kernel/archive/sunxi-6.7/patches.armbian/arm64-dts-allwinner-sun50i-h618-bananapi-m4-zero.patch
@@ -1,16 +1,13 @@
 From 4da52c3e9298df267644b7244703f7c3132c26d8 Mon Sep 17 00:00:00 2001
 From: Patrick Yavitz <pyavitz@xxxxx.com>
-Date: Thu, 22 Feb 2024 19:24:54 -0500
+Date: Sun, 17 Mar 2024 18:54:24 -0400
 Subject: [PATCH] arch: arm64: dts: allwinner: sun50i-h618-bananapi-m4-zero
-
-Based on DTS by: Andre Przywara
-https://lore.kernel.org/linux-sunxi/20240204101054.152012-1-andre.przywara@arm.com/T/#t
 
 Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
 ---
  arch/arm64/boot/dts/allwinner/Makefile        |   1 +
- .../sun50i-h618-bananapi-m4-zero.dts          | 255 ++++++++++++++++++
- 2 files changed, 256 insertions(+)
+ .../sun50i-h618-bananapi-m4-zero.dts          | 276 ++++++++++++++++++
+ 2 files changed, 277 insertions(+)
  create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts
 
 diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
@@ -27,10 +24,10 @@ index d2266f5e5795..4374ed5d9c86 100644
  subdir-y	:= $(dts-dirs) overlay
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts b/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts
 new file mode 100644
-index 000000000000..248e1f5a344e
+index 000000000000..94b940f993d9
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts
-@@ -0,0 +1,258 @@
+@@ -0,0 +1,276 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2024 Patrick Yavitz <pyavitz@xxxxx.com>
@@ -53,6 +50,7 @@ index 000000000000..248e1f5a344e
 +	aliases {
 +		ethernet0 = &emac1;
 +		serial0 = &uart0;
++		serial5 = &uart5;
 +		i2c3 = &i2c3;
 +		i2c4 = &i2c4;
 +		spi1 = &spi1;
@@ -73,6 +71,16 @@ index 000000000000..248e1f5a344e
 +		};
 +	};
 +
++	gpio-keys {
++		compatible = "gpio-keys";
++
++		key-sw3 {
++			label = "sw3";
++			linux,code = <BTN_0>;
++			gpios = <&pio 2 7 GPIO_ACTIVE_LOW>;	/* PC7 */
++		};
++	};
++
 +	leds {
 +		compatible = "gpio-leds";
 +
@@ -81,16 +89,6 @@ index 000000000000..248e1f5a344e
 +			function = LED_FUNCTION_STATUS;
 +			gpios = <&pio 2 12 GPIO_ACTIVE_HIGH>;	/* PC12 */
 +			linux,default-trigger = "heartbeat";
-+		};
-+	};
-+
-+	gpio-keys {
-+		compatible = "gpio-keys";
-+
-+		key-sw3 {
-+			label = "sw3";
-+			linux,code = <BTN_0>;
-+			gpios = <&pio 2 7 GPIO_ACTIVE_LOW>;	/* PC7 */
 +		};
 +	};
 +
@@ -145,6 +143,21 @@ index 000000000000..248e1f5a344e
 +	status = "disabled";
 +};
 +
++&gpu {
++	mali-supply = <&reg_dcdc1>;
++	status = "disabled";
++};
++
++&hdmi {
++	status = "okay";
++};
++
++&hdmi_out {
++	hdmi_out_con: endpoint {
++		remote-endpoint = <&hdmi_con_in>;
++	};
++};
++
 +&ir {
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&ir_rx_pin>;
@@ -155,16 +168,6 @@ index 000000000000..248e1f5a344e
 +	ext_rgmii_phy: ethernet-phy@1 {
 +		compatible = "ethernet-phy-ieee802.3-c22";
 +		reg = <1>;
-+	};
-+};
-+
-+&hdmi {
-+	status = "okay";
-+};
-+
-+&hdmi_out {
-+	hdmi_out_con: endpoint {
-+		remote-endpoint = <&hdmi_con_in>;
 +	};
 +};
 +
@@ -277,6 +280,18 @@ index 000000000000..248e1f5a344e
 +&uart0 {
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&uart0_ph_pins>;
++	status = "okay";
++};
++
++&uart1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart1_pins>, <&uart1_rts_cts_pins>;
++	status = "okay";
++};
++
++&uart5 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart5_pins>;
 +	status = "okay";
 +};
 +


### PR DESCRIPTION
Additions:
GPU node
UART 1 & 5 nodes

GPU is disabled by default as I am not 100% how functional it currently is.

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
