### PR TITLE
create linux-libc-dev when building kernel packages

### DIFF
--- a/lib/functions/artifacts/artifact-kernel.sh
+++ b/lib/functions/artifacts/artifact-kernel.sh
@@ -197,7 +197,7 @@ function artifact_kernel_prepare_version() {
 		artifact_map_packages+=(["linux-dtb"]="linux-dtb-${BRANCH}-${LINUXFAMILY}")
 	fi
 
-	artifact_map_packages+=(["linux-libc-dev"]="linux-libc-dev")
+	artifact_map_packages+=(["linux-libc-dev"]="linux-libc-dev-${BRANCH}-${LINUXFAMILY}")
 
 	artifact_name="kernel-${LINUXFAMILY}-${BRANCH}" # default name of regular artifact
 

--- a/lib/functions/artifacts/artifact-kernel.sh
+++ b/lib/functions/artifacts/artifact-kernel.sh
@@ -197,6 +197,8 @@ function artifact_kernel_prepare_version() {
 		artifact_map_packages+=(["linux-dtb"]="linux-dtb-${BRANCH}-${LINUXFAMILY}")
 	fi
 
+	artifact_map_packages+=(["linux-libc-dev"]="linux-libc-dev")
+
 	artifact_name="kernel-${LINUXFAMILY}-${BRANCH}" # default name of regular artifact
 
 	# Separate artifact name if we're in DTB-only mode, so stuff doesn't get mixed up later

--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -88,7 +88,7 @@ function prepare_kernel_packaging_debs() {
 	fi
 
 	display_alert "Packaging linux-libc-dev" "${LINUXFAMILY} ${LINUXCONFIG}" "info"
-	create_kernel_deb "linux-libc-dev" "${debs_target_dir}" kernel_package_callback_linux_libc_dev "linux-libc-dev"
+	create_kernel_deb "linux-libc-dev-${BRANCH}-${LINUXFAMILY}" "${debs_target_dir}" kernel_package_callback_linux_libc_dev "linux-libc-dev"
 }
 
 function create_kernel_deb() {
@@ -551,9 +551,8 @@ function kernel_package_callback_linux_libc_dev() {
 		Maintainer: ${MAINTAINER} <${MAINTAINERMAIL}>
 		Package: ${package_name}
 		Section: devel
-		Provides: linux-kernel-headers
-		Conflicts: linux-kernel-headers
-		Replaces: linux-kernel-headers
+		Priority: optional
+		Provides: linux-libc-dev
 		Architecture: ${ARCH}
 		Description: Armbian Linux support headers for userspace development
 		 This package provides userspaces headers from the Linux kernel.  These headers

--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -86,6 +86,9 @@ function prepare_kernel_packaging_debs() {
 			display_alert "Skipping linux-headers package" "for ${KERNEL_MAJOR_MINOR} kernel version" "info"
 		fi
 	fi
+
+	display_alert "Packaging linux-libc-dev" "${LINUXFAMILY} ${LINUXCONFIG}" "info"
+	create_kernel_deb "linux-libc-dev" "${debs_target_dir}" kernel_package_callback_linux_libc_dev "linux-libc-dev"
 }
 
 function create_kernel_deb() {
@@ -530,4 +533,31 @@ function kernel_package_callback_linux_headers() {
 			echo "Done compiling kernel-headers tools (${kernel_version_family})."
 		EOT_POSTINST_FINISH
 	)
+}
+
+
+function kernel_package_callback_linux_libc_dev() {
+	display_alert "linux-libc-dev packaging" "${package_directory}" "debug"
+
+	mkdir -p "${package_directory}/usr"
+	run_host_command_logged cp -rp "${tmp_kernel_install_dirs[INSTALL_HDR_PATH]}/include" "${package_directory}/usr"
+	HOST_ARCH=$(dpkg-architecture -a${ARCH} -q"DEB_HOST_MULTIARCH")
+	run_host_command_logged mkdir "${package_directory}/usr/include/${HOST_ARCH}"
+	run_host_command_logged mv "${package_directory}/usr/include/asm" "${package_directory}/usr/include/${HOST_ARCH}"
+
+    # Generate a control file
+	cat <<- CONTROL_FILE > "${package_DEBIAN_dir}/control"
+		Version: ${artifact_version}
+		Maintainer: ${MAINTAINER} <${MAINTAINERMAIL}>
+		Package: ${package_name}
+		Section: devel
+		Provides: linux-kernel-headers
+		Conflicts: linux-kernel-headers
+		Replaces: linux-kernel-headers
+		Architecture: ${ARCH}
+		Description: Armbian Linux support headers for userspace development
+		 This package provides userspaces headers from the Linux kernel.  These headers
+		 are used by the installed headers for GNU glibc and other system libraries.
+		Multi-Arch: same
+	CONTROL_FILE
 }

--- a/lib/functions/compilation/kernel.sh
+++ b/lib/functions/compilation/kernel.sh
@@ -122,7 +122,7 @@ function kernel_prepare_build_and_package() {
 	declare -A kernel_install_dirs=(
 		["INSTALL_PATH"]="${kernel_dest_install_dir}/image/boot"  # Used by `make install`
 		["INSTALL_MOD_PATH"]="${kernel_dest_install_dir}/modules" # Used by `make modules_install`
-		#["INSTALL_HDR_PATH"]="${kernel_dest_install_dir}/libc_headers" # Used by `make headers_install` - disabled, only used for libc headers
+		["INSTALL_HDR_PATH"]="${kernel_dest_install_dir}/libc_headers" # Used by `make headers_install` for libc headers
 	)
 
 	[ -z "${SRC_LOADADDR}" ] || install_make_params_quoted+=("${SRC_LOADADDR}") # For uImage
@@ -133,7 +133,8 @@ function kernel_prepare_build_and_package() {
 
 	install_make_params_quoted+=("INSTALL_MOD_STRIP=1") # strip modules during install
 
-	build_targets+=("modules_install") # headers_install disabled, only used for libc headers
+	build_targets+=("modules_install")
+	build_targets+=("headers_install") # headers_install for libc headers
 	if [[ "${KERNEL_BUILD_DTBS:-yes}" == "yes" ]]; then
 		display_alert "Kernel build will produce DTBs!" "DTBs YES" "debug"
 		build_targets+=("dtbs_install")


### PR DESCRIPTION
# Description

Added the necessary parts to create linux-libc-dev packages when creating armbian images. This functionality was not added to the new build system but worked just fine up until v23.02.

In my opinion linux-libc-dev should always be created when building an armbian kernel as the kernel versions often differ greatly from the ones natively in the distros (eg. debian bookworm: 6.1.76 vs. armbian current 6.6.21).

Also the armbian package source previously included the package but does not anymore, so the latest updates available were 23.02.2.

See also https://forum.armbian.com/topic/36140-linux-libc-dev-packages-not-available-after-2302/#comment-184962

# How Has This Been Tested?

Used the updated scripts to build deb packages and images for bananapi and rpi4b.
The created package linux-libc-dev installs the expected headers.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings