### PR TITLE
config: boards: add X96 Mate TV Box config

### DIFF
--- a/config/boards/x96-mate.tvb
+++ b/config/boards/x96-mate.tvb
@@ -1,0 +1,12 @@
+# Allwinner H616 TVBox with 4GB of RAM and EMMC
+BOARD_NAME="X96 Mate"
+BOARDFAMILY="sun50iw9"
+BOARD_MAINTAINER=""
+BOOTCONFIG="x96_mate_defconfig"
+BOOT_LOGO="desktop"
+KERNEL_TARGET="current,edge"
+KERNEL_TEST_TARGET="current,edge" # in case different then kernel target
+FORCE_BOOTSCRIPT_UPDATE="yes"
+OVERLAY_PREFIX="sun50i-h616"
+
+enable_extension "uwe5622-allwinner"


### PR DESCRIPTION
# Description

The board has mainline kernel and u-boot support for almost 3 years now but Armbian doesn't build images for it.
Add basic build config for this board with Wi-Fi extension enabled. Based on orangepizero2.conf

X96 mate is H616-powered TV Box with the same Wi-Fi/BT chip as OPiZ2 (AW859A).
Mainline DT is missing Wi-Fi node and some regulators are disabled, but PR is on its way. It doesn't hurt to add Wi-Fi extension to config now.

# How Has This Been Tested?
- [x] Compile and verify all defined flavours of image on working hardware
- [X] Tested Wi-Fi extension with patched DT and proved to be working

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
