### PR TITLE
armsom boards: all branches use the same uboot

### DIFF
--- a/config/boards/armsom-sige7.csc
+++ b/config/boards/armsom-sige7.csc
@@ -16,12 +16,8 @@ BOOTFS_TYPE="ext4"
 DDR_BLOB='rk35/rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.11.bin'
 BL31_BLOB='rk35/rk3588_bl31_v1.38.elf'
 
-# post_family_config hook which only runs when branch is legacy.
-function post_family_config_branch_legacy__uboot_armsom() {
-post_family_config_branch_vendor__uboot_armsom
-}
-# post_family_config hook which only runs when branch is vendor.
-function post_family_config_branch_vendor__uboot_armsom() {
+# post_family_config hook runs in all branch.
+function post_family_config__uboot_armsom() {
 	display_alert "$BOARD" "Configuring armsom u-boot" "info"
 	declare -g BOOTSOURCE='https://github.com/radxa/u-boot.git'
 	declare -g BOOTBRANCH="commit:b54d452d46459bc6e4cfc1a2795c9aad143aa174" # specific commit in next-dev branch

--- a/config/boards/armsom-w3.csc
+++ b/config/boards/armsom-w3.csc
@@ -16,12 +16,8 @@ BOOTFS_TYPE="ext4"
 DDR_BLOB='rk35/rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.11.bin'
 BL31_BLOB='rk35/rk3588_bl31_v1.38.elf'
 
-# post_family_config hook which only runs when branch is legacy.
-function post_family_config_branch_legacy__uboot_armsom() {
-post_family_config_branch_vendor__uboot_armsom
-}
-# post_family_config hook which only runs when branch is legacy.
-function post_family_config_branch_vendor__uboot_armsom() {
+# post_family_config hook runs in all branch.
+function post_family_config__uboot_armsom() {
 	display_alert "$BOARD" "Configuring armsom u-boot" "info"
 	declare -g BOOTSOURCE='https://github.com/radxa/u-boot.git'
 	declare -g BOOTBRANCH="commit:b54d452d46459bc6e4cfc1a2795c9aad143aa174" # specific commit in next-dev branch


### PR DESCRIPTION
# Description

Armsom is going to add mainline edge support to these two boards, and now all branches are using the same uboot config. So we do the uboot config to all branches.
Just like what we do to `mixtile-blade3`: https://github.com/armbian/build/commit/bd0a09b24c7c9e4f9eae6bb24f526ae6cea48777

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh uboot BOARD=armsom-w3 BRANCH=edge DEB_COMPRESS=xz`
- [x] `./compile.sh uboot BOARD=armsom-sige7 BRANCH=edge DEB_COMPRESS=xz`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
