### PR TITLE
rockchip-rk3588: edge: improve display modes support

### DIFF
--- a/patch/kernel/rockchip-rk3588-edge/0037-drm-bridge-synopsys-Add-initial-support-for-DW-HDMI-.patch
+++ b/patch/kernel/rockchip-rk3588-edge/0037-drm-bridge-synopsys-Add-initial-support-for-DW-HDMI-.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
 Date: Wed, 1 Nov 2023 18:50:38 +0200
-Subject: drm/bridge: synopsys: Add initial support for DW HDMI QP TX
+Subject: [WIP] drm/bridge: synopsys: Add initial support for DW HDMI QP TX
  Controller
 
 Co-developed-by: Algea Cao <algea.cao@rock-chips.com>
@@ -13,9 +13,9 @@ Signed-off-by: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
  drivers/gpu/drm/bridge/synopsys/dw-hdmi-qp.h |  831 +++
  drivers/gpu/drm/bridge/synopsys/dw-hdmi.c    |   89 +
  drivers/gpu/drm/bridge/synopsys/dw-hdmi.h    |    4 +
- drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c  | 2741 +++++++++-
+ drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c  | 2740 +++++++++-
  include/drm/bridge/dw_hdmi.h                 |  101 +
- 7 files changed, 6103 insertions(+), 66 deletions(-)
+ 7 files changed, 6102 insertions(+), 66 deletions(-)
 
 diff --git a/drivers/gpu/drm/bridge/synopsys/Makefile b/drivers/gpu/drm/bridge/synopsys/Makefile
 index ce715562e9e5..8354e4879f70 100644
@@ -3409,7 +3409,7 @@ index af43a0414b78..8ebdec7254f2 100644
  	HDMI_FC_DBGFORCE_FORCEAUDIO = 0x10,
  	HDMI_FC_DBGFORCE_FORCEVIDEO = 0x1,
 diff --git a/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c b/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c
-index fe33092abbe7..5c056d9c8e1a 100644
+index fe33092abbe7..a5d1a70d9b98 100644
 --- a/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c
 +++ b/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c
 @@ -4,21 +4,32 @@
@@ -3638,7 +3638,7 @@ index fe33092abbe7..5c056d9c8e1a 100644
  };
  
  static struct rockchip_hdmi *to_rockchip_hdmi(struct drm_encoder *encoder)
-@@ -202,13 +361,831 @@ static const struct dw_hdmi_phy_config rockchip_phy_config[] = {
+@@ -202,13 +361,830 @@ static const struct dw_hdmi_phy_config rockchip_phy_config[] = {
  	/*pixelclk   symbol   term   vlev*/
  	{ 74250000,  0x8009, 0x0004, 0x0272},
  	{ 148500000, 0x802b, 0x0004, 0x028d},
@@ -4018,13 +4018,12 @@ index fe33092abbe7..5c056d9c8e1a 100644
 +	hdmi->link_cfg.rate_per_lane = max_rate_per_lane;
 +
 +	if (!max_frl_rate || (tmdsclk < HDMI20_MAX_RATE && mode.clock < HDMI20_MAX_RATE)) {
-+		dev_info(hdmi->dev, "use tmds hdmi mode\n");
 +		hdmi->link_cfg.frl_mode = false;
 +		return;
 +	}
 +
 +	hdmi->link_cfg.frl_mode = true;
-+	dev_info(hdmi->dev, "use frl hdmi mode\n");
++	dev_warn(hdmi->dev, "use unsupported frl hdmi mode\n");
 +
 +	// if (!hdmi->dsc_cap.v_1p2)
 +	// 	return;
@@ -4470,7 +4469,7 @@ index fe33092abbe7..5c056d9c8e1a 100644
  
  	hdmi->regmap = syscon_regmap_lookup_by_phandle(np, "rockchip,grf");
  	if (IS_ERR(hdmi->regmap)) {
-@@ -216,6 +1193,14 @@ static int rockchip_hdmi_parse_dt(struct rockchip_hdmi *hdmi)
+@@ -216,6 +1192,14 @@ static int rockchip_hdmi_parse_dt(struct rockchip_hdmi *hdmi)
  		return PTR_ERR(hdmi->regmap);
  	}
  
@@ -4485,7 +4484,7 @@ index fe33092abbe7..5c056d9c8e1a 100644
  	hdmi->ref_clk = devm_clk_get_optional(hdmi->dev, "ref");
  	if (!hdmi->ref_clk)
  		hdmi->ref_clk = devm_clk_get_optional(hdmi->dev, "vpll");
-@@ -245,6 +1230,79 @@ static int rockchip_hdmi_parse_dt(struct rockchip_hdmi *hdmi)
+@@ -245,6 +1229,79 @@ static int rockchip_hdmi_parse_dt(struct rockchip_hdmi *hdmi)
  	if (IS_ERR(hdmi->avdd_1v8))
  		return PTR_ERR(hdmi->avdd_1v8);
  
@@ -4565,7 +4564,7 @@ index fe33092abbe7..5c056d9c8e1a 100644
  	return 0;
  }
  
-@@ -283,9 +1341,114 @@ dw_hdmi_rockchip_mode_valid(struct dw_hdmi *dw_hdmi, void *data,
+@@ -283,9 +1340,114 @@ dw_hdmi_rockchip_mode_valid(struct dw_hdmi *dw_hdmi, void *data,
  
  	return MODE_BAD;
  }
@@ -4680,7 +4679,7 @@ index fe33092abbe7..5c056d9c8e1a 100644
  }
  
  static bool
-@@ -301,6 +1464,27 @@ static void dw_hdmi_rockchip_encoder_mode_set(struct drm_encoder *encoder,
+@@ -301,6 +1463,27 @@ static void dw_hdmi_rockchip_encoder_mode_set(struct drm_encoder *encoder,
  					      struct drm_display_mode *adj_mode)
  {
  	struct rockchip_hdmi *hdmi = to_rockchip_hdmi(encoder);
@@ -4708,7 +4707,7 @@ index fe33092abbe7..5c056d9c8e1a 100644
  
  	clk_set_rate(hdmi->ref_clk, adj_mode->clock * 1000);
  }
-@@ -308,14 +1492,25 @@ static void dw_hdmi_rockchip_encoder_mode_set(struct drm_encoder *encoder,
+@@ -308,14 +1491,25 @@ static void dw_hdmi_rockchip_encoder_mode_set(struct drm_encoder *encoder,
  static void dw_hdmi_rockchip_encoder_enable(struct drm_encoder *encoder)
  {
  	struct rockchip_hdmi *hdmi = to_rockchip_hdmi(encoder);
@@ -4736,7 +4735,7 @@ index fe33092abbe7..5c056d9c8e1a 100644
  		val = hdmi->chip_data->lcdsel_lit;
  	else
  		val = hdmi->chip_data->lcdsel_big;
-@@ -330,24 +1525,992 @@ static void dw_hdmi_rockchip_encoder_enable(struct drm_encoder *encoder)
+@@ -330,24 +1524,992 @@ static void dw_hdmi_rockchip_encoder_enable(struct drm_encoder *encoder)
  	if (ret != 0)
  		DRM_DEV_ERROR(hdmi->dev, "Could not write to GRF: %d\n", ret);
  
@@ -5736,7 +5735,7 @@ index fe33092abbe7..5c056d9c8e1a 100644
  static const struct drm_encoder_helper_funcs dw_hdmi_rockchip_encoder_helper_funcs = {
  	.mode_fixup = dw_hdmi_rockchip_encoder_mode_fixup,
  	.mode_set   = dw_hdmi_rockchip_encoder_mode_set,
-@@ -356,20 +2519,24 @@ static const struct drm_encoder_helper_funcs dw_hdmi_rockchip_encoder_helper_fun
+@@ -356,20 +2518,24 @@ static const struct drm_encoder_helper_funcs dw_hdmi_rockchip_encoder_helper_fun
  	.atomic_check = dw_hdmi_rockchip_encoder_atomic_check,
  };
  
@@ -5767,7 +5766,7 @@ index fe33092abbe7..5c056d9c8e1a 100644
  }
  
  static void dw_hdmi_rk3228_setup_hpd(struct dw_hdmi *dw_hdmi, void *data)
-@@ -436,6 +2603,90 @@ static void dw_hdmi_rk3328_setup_hpd(struct dw_hdmi *dw_hdmi, void *data)
+@@ -436,6 +2602,90 @@ static void dw_hdmi_rk3328_setup_hpd(struct dw_hdmi *dw_hdmi, void *data)
  			      RK3328_HDMI_HPD_IOE));
  }
  
@@ -5858,7 +5857,7 @@ index fe33092abbe7..5c056d9c8e1a 100644
  static const struct dw_hdmi_phy_ops rk3228_hdmi_phy_ops = {
  	.init		= dw_hdmi_rockchip_genphy_init,
  	.disable	= dw_hdmi_rockchip_genphy_disable,
-@@ -525,6 +2776,30 @@ static const struct dw_hdmi_plat_data rk3568_hdmi_drv_data = {
+@@ -525,6 +2775,30 @@ static const struct dw_hdmi_plat_data rk3568_hdmi_drv_data = {
  	.use_drm_infoframe = true,
  };
  
@@ -5889,7 +5888,7 @@ index fe33092abbe7..5c056d9c8e1a 100644
  static const struct of_device_id dw_hdmi_rockchip_dt_ids[] = {
  	{ .compatible = "rockchip,rk3228-dw-hdmi",
  	  .data = &rk3228_hdmi_drv_data
-@@ -541,6 +2816,9 @@ static const struct of_device_id dw_hdmi_rockchip_dt_ids[] = {
+@@ -541,6 +2815,9 @@ static const struct of_device_id dw_hdmi_rockchip_dt_ids[] = {
  	{ .compatible = "rockchip,rk3568-dw-hdmi",
  	  .data = &rk3568_hdmi_drv_data
  	},
@@ -5899,7 +5898,7 @@ index fe33092abbe7..5c056d9c8e1a 100644
  	{},
  };
  MODULE_DEVICE_TABLE(of, dw_hdmi_rockchip_dt_ids);
-@@ -550,44 +2828,103 @@ static int dw_hdmi_rockchip_bind(struct device *dev, struct device *master,
+@@ -550,44 +2827,103 @@ static int dw_hdmi_rockchip_bind(struct device *dev, struct device *master,
  {
  	struct platform_device *pdev = to_platform_device(dev);
  	struct dw_hdmi_plat_data *plat_data;
@@ -6026,7 +6025,7 @@ index fe33092abbe7..5c056d9c8e1a 100644
  
  	ret = rockchip_hdmi_parse_dt(hdmi);
  	if (ret) {
-@@ -596,34 +2933,44 @@ static int dw_hdmi_rockchip_bind(struct device *dev, struct device *master,
+@@ -596,34 +2932,44 @@ static int dw_hdmi_rockchip_bind(struct device *dev, struct device *master,
  		return ret;
  	}
  
@@ -6087,7 +6086,7 @@ index fe33092abbe7..5c056d9c8e1a 100644
  		regmap_write(hdmi->regmap, RK3568_GRF_VO_CON1,
  			     HIWORD_UPDATE(RK3568_HDMI_SDAIN_MSK |
  					   RK3568_HDMI_SCLIN_MSK,
-@@ -631,12 +2978,131 @@ static int dw_hdmi_rockchip_bind(struct device *dev, struct device *master,
+@@ -631,12 +2977,131 @@ static int dw_hdmi_rockchip_bind(struct device *dev, struct device *master,
  					   RK3568_HDMI_SCLIN_MSK));
  	}
  
@@ -6223,7 +6222,7 @@ index fe33092abbe7..5c056d9c8e1a 100644
  
  	/*
  	 * If dw_hdmi_bind() fails we'll never call dw_hdmi_unbind(),
-@@ -647,11 +3113,24 @@ static int dw_hdmi_rockchip_bind(struct device *dev, struct device *master,
+@@ -647,11 +3112,24 @@ static int dw_hdmi_rockchip_bind(struct device *dev, struct device *master,
  		goto err_bind;
  	}
  
@@ -6249,7 +6248,7 @@ index fe33092abbe7..5c056d9c8e1a 100644
  err_clk:
  	regulator_disable(hdmi->avdd_1v8);
  err_avdd_1v8:
-@@ -665,9 +3144,29 @@ static void dw_hdmi_rockchip_unbind(struct device *dev, struct device *master,
+@@ -665,9 +3143,29 @@ static void dw_hdmi_rockchip_unbind(struct device *dev, struct device *master,
  {
  	struct rockchip_hdmi *hdmi = dev_get_drvdata(dev);
  
@@ -6280,7 +6279,7 @@ index fe33092abbe7..5c056d9c8e1a 100644
  
  	regulator_disable(hdmi->avdd_1v8);
  	regulator_disable(hdmi->avdd_0v9);
-@@ -680,30 +3179,142 @@ static const struct component_ops dw_hdmi_rockchip_ops = {
+@@ -680,30 +3178,142 @@ static const struct component_ops dw_hdmi_rockchip_ops = {
  
  static int dw_hdmi_rockchip_probe(struct platform_device *pdev)
  {

--- a/patch/kernel/rockchip-rk3588-edge/0044-phy-phy-rockchip-samsung-hdptx-Add-FRL-EARC-support.patch
+++ b/patch/kernel/rockchip-rk3588-edge/0044-phy-phy-rockchip-samsung-hdptx-Add-FRL-EARC-support.patch
@@ -1,0 +1,549 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
+Date: Mon, 5 Feb 2024 01:38:48 +0200
+Subject: phy: phy-rockchip-samsung-hdptx: Add FRL & EARC support
+
+For upstreaming, this requires extending the standard PHY API to support
+HDMI configuration options [1].
+
+Currently, the bus_width PHY attribute is used to pass clock rate and
+flags for 10-bit color depth, FRL and EARC. This is done by the HDMI
+bridge driver via phy_set_bus_width().
+
+[1]: https://lore.kernel.org/all/59d5595a24bbcca897e814440179fa2caf3dff38.1707040881.git.Sandor.yu@nxp.com/
+
+Signed-off-by: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
+---
+ drivers/phy/rockchip/phy-rockchip-samsung-hdptx.c | 434 +++++++++-
+ 1 file changed, 431 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/phy/rockchip/phy-rockchip-samsung-hdptx.c b/drivers/phy/rockchip/phy-rockchip-samsung-hdptx.c
+index 946c01210ac8..44acea3f86af 100644
+--- a/drivers/phy/rockchip/phy-rockchip-samsung-hdptx.c
++++ b/drivers/phy/rockchip/phy-rockchip-samsung-hdptx.c
+@@ -190,6 +190,12 @@
+ #define LN3_TX_SER_RATE_SEL_HBR2	BIT(3)
+ #define LN3_TX_SER_RATE_SEL_HBR3	BIT(2)
+ 
++#define HDMI20_MAX_RATE			600000000
++#define DATA_RATE_MASK			0xFFFFFFF
++#define COLOR_DEPTH_MASK		BIT(31)
++#define HDMI_MODE_MASK			BIT(30)
++#define HDMI_EARC_MASK			BIT(29)
++
+ struct lcpll_config {
+ 	u32 bit_rate;
+ 	u8 lcvco_mode_en;
+@@ -272,6 +278,25 @@ struct rk_hdptx_phy {
+ 	struct clk_bulk_data *clks;
+ 	int nr_clks;
+ 	struct reset_control_bulk_data rsts[RST_MAX];
++	bool earc_en;
++};
++
++static const struct lcpll_config lcpll_cfg[] = {
++	{ 48000000, 1, 0, 0, 0x7d, 0x7d, 1, 1, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 2,
++	  0, 0x13, 0x18, 1, 0, 0x20, 0x0c, 1, 0, },
++	{ 40000000, 1, 1, 0, 0x68, 0x68, 1, 1, 0, 0, 0, 1, 1, 1, 1, 9, 0, 1, 1,
++	  0, 2, 3, 1, 0, 0x20, 0x0c, 1, 0, },
++	{ 32000000, 1, 1, 1, 0x6b, 0x6b, 1, 1, 0, 1, 2, 1, 1, 1, 1, 9, 1, 2, 1,
++	  0, 0x0d, 0x18, 1, 0, 0x20, 0x0c, 1, 1, },
++};
++
++static const struct ropll_config ropll_frl_cfg[] = {
++	{ 24000000, 0x19, 0x19, 1, 1, 0, 1, 2, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1,
++	  0, 0, 0x20, 0x0c, 1, 0x0e, 0, 0, },
++	{ 18000000, 0x7d, 0x7d, 1, 1, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1,
++	  0, 0, 0x20, 0x0c, 1, 0x0e, 0, 0, },
++	{ 9000000, 0x7d, 0x7d, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1,
++	  0, 0, 0x20, 0x0c, 1, 0x0e, 0, 0, },
+ };
+ 
+ static const struct ropll_config ropll_tmds_cfg[] = {
+@@ -449,6 +474,73 @@ static const struct reg_sequence rk_hdtpx_tmds_cmn_init_seq[] = {
+ 	REG_SEQ0(CMN_REG(009b), 0x00),
+ };
+ 
++static const struct reg_sequence rk_hdtpx_frl_cmn_init_seq[] = {
++	REG_SEQ0(CMN_REG(0011), 0x00),
++	REG_SEQ0(CMN_REG(0017), 0x00),
++	REG_SEQ0(CMN_REG(0026), 0x53),
++	REG_SEQ0(CMN_REG(0030), 0x00),
++	REG_SEQ0(CMN_REG(0031), 0x20),
++	REG_SEQ0(CMN_REG(0032), 0x30),
++	REG_SEQ0(CMN_REG(0033), 0x0b),
++	REG_SEQ0(CMN_REG(0034), 0x23),
++	REG_SEQ0(CMN_REG(0042), 0xb8),
++	REG_SEQ0(CMN_REG(004e), 0x14),
++	REG_SEQ0(CMN_REG(0074), 0x00),
++	REG_SEQ0(CMN_REG(0081), 0x09),
++	REG_SEQ0(CMN_REG(0086), 0x01),
++	REG_SEQ0(CMN_REG(0087), 0x0c),
++	REG_SEQ0(CMN_REG(009b), 0x10),
++};
++
++static const struct reg_sequence rk_hdtpx_frl_ropll_cmn_init_seq[] = {
++	REG_SEQ0(CMN_REG(0008), 0x00),
++	REG_SEQ0(CMN_REG(001e), 0x14),
++	REG_SEQ0(CMN_REG(0020), 0x00),
++	REG_SEQ0(CMN_REG(0021), 0x00),
++	REG_SEQ0(CMN_REG(0022), 0x11),
++	REG_SEQ0(CMN_REG(0023), 0x00),
++	REG_SEQ0(CMN_REG(0025), 0x00),
++	REG_SEQ0(CMN_REG(0027), 0x00),
++	REG_SEQ0(CMN_REG(0028), 0x00),
++	REG_SEQ0(CMN_REG(002a), 0x01),
++	REG_SEQ0(CMN_REG(002b), 0x00),
++	REG_SEQ0(CMN_REG(002c), 0x00),
++	REG_SEQ0(CMN_REG(002d), 0x00),
++	REG_SEQ0(CMN_REG(002e), 0x00),
++	REG_SEQ0(CMN_REG(002f), 0x04),
++	REG_SEQ0(CMN_REG(003d), 0x40),
++	REG_SEQ0(CMN_REG(005c), 0x25),
++	REG_SEQ0(CMN_REG(0089), 0x00),
++	REG_SEQ0(CMN_REG(0094), 0x00),
++	REG_SEQ0(CMN_REG(0097), 0x02),
++	REG_SEQ0(CMN_REG(0099), 0x04),
++};
++
++static const struct reg_sequence rk_hdtpx_frl_lcpll_cmn_init_seq[] = {
++	REG_SEQ0(CMN_REG(0025), 0x10),
++	REG_SEQ0(CMN_REG(0027), 0x01),
++	REG_SEQ0(CMN_REG(0028), 0x0d),
++	REG_SEQ0(CMN_REG(002e), 0x02),
++	REG_SEQ0(CMN_REG(002f), 0x0d),
++	REG_SEQ0(CMN_REG(003d), 0x00),
++	REG_SEQ0(CMN_REG(0051), 0x00),
++	REG_SEQ0(CMN_REG(0055), 0x00),
++	REG_SEQ0(CMN_REG(0059), 0x11),
++	REG_SEQ0(CMN_REG(005a), 0x03),
++	REG_SEQ0(CMN_REG(005c), 0x05),
++	REG_SEQ0(CMN_REG(005e), 0x07),
++	REG_SEQ0(CMN_REG(0060), 0x01),
++	REG_SEQ0(CMN_REG(0064), 0x07),
++	REG_SEQ0(CMN_REG(0065), 0x00),
++	REG_SEQ0(CMN_REG(0069), 0x00),
++	REG_SEQ0(CMN_REG(006c), 0x00),
++	REG_SEQ0(CMN_REG(0070), 0x01),
++	REG_SEQ0(CMN_REG(0089), 0x02),
++	REG_SEQ0(CMN_REG(0095), 0x00),
++	REG_SEQ0(CMN_REG(0097), 0x00),
++	REG_SEQ0(CMN_REG(0099), 0x00),
++};
++
+ static const struct reg_sequence rk_hdtpx_common_sb_init_seq[] = {
+ 	REG_SEQ0(SB_REG(0114), 0x00),
+ 	REG_SEQ0(SB_REG(0115), 0x00),
+@@ -472,6 +564,17 @@ static const struct reg_sequence rk_hdtpx_tmds_lntop_lowbr_seq[] = {
+ 	REG_SEQ0(LNTOP_REG(0205), 0x1f),
+ };
+ 
++static const struct reg_sequence rk_hdtpx_frl_lntop_init_seq[] = {
++	REG_SEQ0(LNTOP_REG(0200), 0x04),
++	REG_SEQ0(LNTOP_REG(0201), 0x00),
++	REG_SEQ0(LNTOP_REG(0202), 0x00),
++	REG_SEQ0(LNTOP_REG(0203), 0xf0),
++	REG_SEQ0(LNTOP_REG(0204), 0xff),
++	REG_SEQ0(LNTOP_REG(0205), 0xff),
++	REG_SEQ0(LNTOP_REG(0206), 0x05),
++	REG_SEQ0(LNTOP_REG(0207), 0x0f),
++};
++
+ static const struct reg_sequence rk_hdtpx_common_lane_init_seq[] = {
+ 	REG_SEQ0(LANE_REG(0303), 0x0c),
+ 	REG_SEQ0(LANE_REG(0307), 0x20),
+@@ -550,6 +653,40 @@ static const struct reg_sequence rk_hdtpx_tmds_lane_init_seq[] = {
+ 	REG_SEQ0(LANE_REG(0606), 0x1c),
+ };
+ 
++static const struct reg_sequence rk_hdtpx_frl_ropll_lane_init_seq[] = {
++	REG_SEQ0(LANE_REG(0312), 0x3c),
++	REG_SEQ0(LANE_REG(0412), 0x3c),
++	REG_SEQ0(LANE_REG(0512), 0x3c),
++	REG_SEQ0(LANE_REG(0612), 0x3c),
++};
++
++static const struct reg_sequence rk_hdtpx_frl_lcpll_lane_init_seq[] = {
++	REG_SEQ0(LANE_REG(0312), 0x3c),
++	REG_SEQ0(LANE_REG(0412), 0x3c),
++	REG_SEQ0(LANE_REG(0512), 0x3c),
++	REG_SEQ0(LANE_REG(0612), 0x3c),
++	REG_SEQ0(LANE_REG(0303), 0x2f),
++	REG_SEQ0(LANE_REG(0403), 0x2f),
++	REG_SEQ0(LANE_REG(0503), 0x2f),
++	REG_SEQ0(LANE_REG(0603), 0x2f),
++	REG_SEQ0(LANE_REG(0305), 0x03),
++	REG_SEQ0(LANE_REG(0405), 0x03),
++	REG_SEQ0(LANE_REG(0505), 0x03),
++	REG_SEQ0(LANE_REG(0605), 0x03),
++	REG_SEQ0(LANE_REG(0306), 0xfc),
++	REG_SEQ0(LANE_REG(0406), 0xfc),
++	REG_SEQ0(LANE_REG(0506), 0xfc),
++	REG_SEQ0(LANE_REG(0606), 0xfc),
++	REG_SEQ0(LANE_REG(0305), 0x4f),
++	REG_SEQ0(LANE_REG(0405), 0x4f),
++	REG_SEQ0(LANE_REG(0505), 0x4f),
++	REG_SEQ0(LANE_REG(0605), 0x4f),
++	REG_SEQ0(LANE_REG(0304), 0x14),
++	REG_SEQ0(LANE_REG(0404), 0x14),
++	REG_SEQ0(LANE_REG(0504), 0x14),
++	REG_SEQ0(LANE_REG(0604), 0x14),
++};
++
+ static bool rk_hdptx_phy_is_rw_reg(struct device *dev, unsigned int reg)
+ {
+ 	switch (reg) {
+@@ -651,6 +788,47 @@ static int rk_hdptx_post_enable_pll(struct rk_hdptx_phy *hdptx)
+ 	return 0;
+ }
+ 
++static int rk_hdptx_post_power_up(struct rk_hdptx_phy *hdptx)
++{
++	u32 val;
++	int ret;
++
++	val = (HDPTX_I_BIAS_EN | HDPTX_I_BGR_EN) << 16 |
++	       HDPTX_I_BIAS_EN | HDPTX_I_BGR_EN;
++	regmap_write(hdptx->grf, GRF_HDPTX_CON0, val);
++
++	usleep_range(10, 15);
++	reset_control_deassert(hdptx->rsts[RST_INIT].rstc);
++
++	usleep_range(10, 15);
++	val = HDPTX_I_PLL_EN << 16 | HDPTX_I_PLL_EN;
++	regmap_write(hdptx->grf, GRF_HDPTX_CON0, val);
++
++	usleep_range(10, 15);
++	reset_control_deassert(hdptx->rsts[RST_CMN].rstc);
++
++	ret = regmap_read_poll_timeout(hdptx->grf, GRF_HDPTX_STATUS, val,
++				       val & HDPTX_O_PLL_LOCK_DONE, 20, 400);
++	if (ret) {
++		dev_err(hdptx->dev, "Failed to get PHY PLL lock: %d\n", ret);
++		return ret;
++	}
++
++	usleep_range(20, 30);
++	reset_control_deassert(hdptx->rsts[RST_LANE].rstc);
++
++	ret = regmap_read_poll_timeout(hdptx->grf, GRF_HDPTX_STATUS, val,
++				       val & HDPTX_O_PHY_RDY, 100, 5000);
++	if (ret) {
++		dev_err(hdptx->dev, "Failed to get PHY ready: %d\n", ret);
++		return ret;
++	}
++
++	dev_dbg(hdptx->dev, "PHY ready\n");
++
++	return 0;
++}
++
+ static void rk_hdptx_phy_disable(struct rk_hdptx_phy *hdptx)
+ {
+ 	u32 val;
+@@ -680,6 +858,99 @@ static void rk_hdptx_phy_disable(struct rk_hdptx_phy *hdptx)
+ 	regmap_write(hdptx->grf, GRF_HDPTX_CON0, val);
+ }
+ 
++static void rk_hdptx_earc_config(struct rk_hdptx_phy *hdptx)
++{
++	regmap_update_bits(hdptx->regmap, SB_REG(0113), SB_RX_RCAL_OPT_CODE_MASK,
++			   FIELD_PREP(SB_RX_RCAL_OPT_CODE_MASK, 1));
++	regmap_write(hdptx->regmap, SB_REG(011c), 0x04);
++	regmap_update_bits(hdptx->regmap, SB_REG(011b), SB_AFC_TOL_MASK,
++			   FIELD_PREP(SB_AFC_TOL_MASK, 3));
++	regmap_write(hdptx->regmap, SB_REG(0109), 0x05);
++
++	regmap_update_bits(hdptx->regmap, SB_REG(0120),
++			   SB_EARC_EN_MASK | SB_EARC_AFC_EN_MASK,
++			   FIELD_PREP(SB_EARC_EN_MASK, 1) |
++			   FIELD_PREP(SB_EARC_AFC_EN_MASK, 1));
++	regmap_update_bits(hdptx->regmap, SB_REG(011b), SB_EARC_SIG_DET_BYPASS_MASK,
++			   FIELD_PREP(SB_EARC_SIG_DET_BYPASS_MASK, 1));
++	regmap_update_bits(hdptx->regmap, SB_REG(011f),
++			   SB_PWM_AFC_CTRL_MASK | SB_RCAL_RSTN_MASK,
++			   FIELD_PREP(SB_PWM_AFC_CTRL_MASK, 0xc) |
++			   FIELD_PREP(SB_RCAL_RSTN_MASK, 1));
++	regmap_update_bits(hdptx->regmap, SB_REG(0115), SB_READY_DELAY_TIME_MASK,
++			   FIELD_PREP(SB_READY_DELAY_TIME_MASK, 2));
++	regmap_update_bits(hdptx->regmap, SB_REG(0113), SB_RX_RTERM_CTRL_MASK,
++			   FIELD_PREP(SB_RX_RTERM_CTRL_MASK, 3));
++	regmap_update_bits(hdptx->regmap, SB_REG(0102), ANA_SB_RXTERM_OFFSP_MASK,
++			   FIELD_PREP(ANA_SB_RXTERM_OFFSP_MASK, 3));
++	regmap_update_bits(hdptx->regmap, SB_REG(0103), ANA_SB_RXTERM_OFFSN_MASK,
++			   FIELD_PREP(ANA_SB_RXTERM_OFFSN_MASK, 3));
++
++	regmap_write(hdptx->regmap, SB_REG(011a), 0x03);
++	regmap_write(hdptx->regmap, SB_REG(0118), 0x0a);
++	regmap_write(hdptx->regmap, SB_REG(011e), 0x6a);
++	regmap_write(hdptx->regmap, SB_REG(011d), 0x67);
++
++	regmap_update_bits(hdptx->regmap, SB_REG(0117), FAST_PULSE_TIME_MASK,
++			   FIELD_PREP(FAST_PULSE_TIME_MASK, 4));
++	regmap_update_bits(hdptx->regmap, SB_REG(0114),
++			   SB_TG_SB_EN_DELAY_TIME_MASK | SB_TG_RXTERM_EN_DELAY_TIME_MASK,
++			   FIELD_PREP(SB_TG_SB_EN_DELAY_TIME_MASK, 2) |
++			   FIELD_PREP(SB_TG_RXTERM_EN_DELAY_TIME_MASK, 2));
++	regmap_update_bits(hdptx->regmap, SB_REG(0105), ANA_SB_TX_HLVL_PROG_MASK,
++			   FIELD_PREP(ANA_SB_TX_HLVL_PROG_MASK, 7));
++	regmap_update_bits(hdptx->regmap, SB_REG(0106), ANA_SB_TX_LLVL_PROG_MASK,
++			   FIELD_PREP(ANA_SB_TX_LLVL_PROG_MASK, 7));
++	regmap_update_bits(hdptx->regmap, SB_REG(010f), ANA_SB_VREG_GAIN_CTRL_MASK,
++			   FIELD_PREP(ANA_SB_VREG_GAIN_CTRL_MASK, 0));
++	regmap_update_bits(hdptx->regmap, SB_REG(0110), ANA_SB_VREG_REF_SEL_MASK,
++			   FIELD_PREP(ANA_SB_VREG_REF_SEL_MASK, 1));
++	regmap_update_bits(hdptx->regmap, SB_REG(0115), SB_TG_OSC_EN_DELAY_TIME_MASK,
++			   FIELD_PREP(SB_TG_OSC_EN_DELAY_TIME_MASK, 2));
++	regmap_update_bits(hdptx->regmap, SB_REG(0116), AFC_RSTN_DELAY_TIME_MASK,
++			   FIELD_PREP(AFC_RSTN_DELAY_TIME_MASK, 2));
++	regmap_update_bits(hdptx->regmap, SB_REG(0109), ANA_SB_DMRX_AFC_DIV_RATIO_MASK,
++			   FIELD_PREP(ANA_SB_DMRX_AFC_DIV_RATIO_MASK, 5));
++	regmap_update_bits(hdptx->regmap, SB_REG(0103), OVRD_SB_RX_RESCAL_DONE_MASK,
++			   FIELD_PREP(OVRD_SB_RX_RESCAL_DONE_MASK, 1));
++	regmap_update_bits(hdptx->regmap, SB_REG(0104), OVRD_SB_EN_MASK,
++			   FIELD_PREP(OVRD_SB_EN_MASK, 1));
++	regmap_update_bits(hdptx->regmap, SB_REG(0102), OVRD_SB_RXTERM_EN_MASK,
++			   FIELD_PREP(OVRD_SB_RXTERM_EN_MASK, 1));
++	regmap_update_bits(hdptx->regmap, SB_REG(0105), OVRD_SB_EARC_CMDC_EN_MASK,
++			   FIELD_PREP(OVRD_SB_EARC_CMDC_EN_MASK, 1));
++	regmap_update_bits(hdptx->regmap, SB_REG(010f),
++			   OVRD_SB_VREG_EN_MASK | OVRD_SB_VREG_LPF_BYPASS_MASK,
++			   FIELD_PREP(OVRD_SB_VREG_EN_MASK, 1) |
++			   FIELD_PREP(OVRD_SB_VREG_LPF_BYPASS_MASK, 1));
++	regmap_update_bits(hdptx->regmap, SB_REG(0123), OVRD_SB_READY_MASK,
++			   FIELD_PREP(OVRD_SB_READY_MASK, 1));
++
++	usleep_range(1000, 1100);
++	regmap_update_bits(hdptx->regmap, SB_REG(0103), SB_RX_RESCAL_DONE_MASK,
++			   FIELD_PREP(SB_RX_RESCAL_DONE_MASK, 1));
++	usleep_range(50, 60);
++	regmap_update_bits(hdptx->regmap, SB_REG(0104), SB_EN_MASK,
++			   FIELD_PREP(SB_EN_MASK, 1));
++	usleep_range(50, 60);
++	regmap_update_bits(hdptx->regmap, SB_REG(0102), SB_RXTERM_EN_MASK,
++			   FIELD_PREP(SB_RXTERM_EN_MASK, 1));
++	usleep_range(50, 60);
++	regmap_update_bits(hdptx->regmap, SB_REG(0105), SB_EARC_CMDC_EN_MASK,
++			   FIELD_PREP(SB_EARC_CMDC_EN_MASK, 1));
++	regmap_update_bits(hdptx->regmap, SB_REG(010f), SB_VREG_EN_MASK,
++			   FIELD_PREP(SB_VREG_EN_MASK, 1));
++	usleep_range(50, 60);
++	regmap_update_bits(hdptx->regmap, SB_REG(010f), OVRD_SB_VREG_LPF_BYPASS_MASK,
++			   FIELD_PREP(OVRD_SB_VREG_LPF_BYPASS_MASK, 1));
++	usleep_range(250, 300);
++	regmap_update_bits(hdptx->regmap, SB_REG(010f), OVRD_SB_VREG_LPF_BYPASS_MASK,
++			   FIELD_PREP(OVRD_SB_VREG_LPF_BYPASS_MASK, 0));
++	usleep_range(100, 120);
++	regmap_update_bits(hdptx->regmap, SB_REG(0123), SB_READY_MASK,
++			   FIELD_PREP(SB_READY_MASK, 1));
++}
++
+ static bool rk_hdptx_phy_clk_pll_calc(unsigned int data_rate,
+ 				      struct ropll_config *cfg)
+ {
+@@ -755,9 +1026,13 @@ static bool rk_hdptx_phy_clk_pll_calc(unsigned int data_rate,
+ static int rk_hdptx_ropll_tmds_cmn_config(struct rk_hdptx_phy *hdptx,
+ 					  unsigned int rate)
+ {
++	int i, bus_width = phy_get_bus_width(hdptx->phy);
++	u8 color_depth = (bus_width & COLOR_DEPTH_MASK) ? 1 : 0;
+ 	const struct ropll_config *cfg = NULL;
+ 	struct ropll_config rc = {0};
+-	int i;
++
++	if (color_depth)
++		rate = rate * 10 / 8;
+ 
+ 	for (i = 0; i < ARRAY_SIZE(ropll_tmds_cfg); i++)
+ 		if (rate == ropll_tmds_cfg[i].bit_rate) {
+@@ -813,6 +1088,9 @@ static int rk_hdptx_ropll_tmds_cmn_config(struct rk_hdptx_phy *hdptx,
+ 	regmap_update_bits(hdptx->regmap, CMN_REG(0086), PLL_PCG_POSTDIV_SEL_MASK,
+ 			   FIELD_PREP(PLL_PCG_POSTDIV_SEL_MASK, cfg->pms_sdiv));
+ 
++	regmap_update_bits(hdptx->regmap, CMN_REG(0086), PLL_PCG_CLK_SEL_MASK,
++			   FIELD_PREP(PLL_PCG_CLK_SEL_MASK, color_depth));
++
+ 	regmap_update_bits(hdptx->regmap, CMN_REG(0086), PLL_PCG_CLK_EN,
+ 			   PLL_PCG_CLK_EN);
+ 
+@@ -853,9 +1131,146 @@ static int rk_hdptx_ropll_tmds_mode_config(struct rk_hdptx_phy *hdptx,
+ 	rk_hdptx_multi_reg_write(hdptx, rk_hdtpx_common_lane_init_seq);
+ 	rk_hdptx_multi_reg_write(hdptx, rk_hdtpx_tmds_lane_init_seq);
+ 
++	if (hdptx->earc_en)
++		rk_hdptx_earc_config(hdptx);
++
+ 	return rk_hdptx_post_enable_lane(hdptx);
+ }
+ 
++static int rk_hdptx_ropll_frl_mode_config(struct rk_hdptx_phy *hdptx,
++					  u32 bus_width)
++{
++	u32 bit_rate = bus_width & DATA_RATE_MASK;
++	u8 color_depth = (bus_width & COLOR_DEPTH_MASK) ? 1 : 0;
++	const struct ropll_config *cfg = NULL;
++	int i;
++
++	for (i = 0; i < ARRAY_SIZE(ropll_frl_cfg); i++)
++		if (bit_rate == ropll_frl_cfg[i].bit_rate) {
++			cfg = &ropll_frl_cfg[i];
++			break;
++		}
++
++	if (!cfg) {
++		dev_err(hdptx->dev, "%s cannot find pll cfg\n", __func__);
++		return -EINVAL;
++	}
++
++	rk_hdptx_pre_power_up(hdptx);
++
++	reset_control_assert(hdptx->rsts[RST_ROPLL].rstc);
++	usleep_range(10, 20);
++	reset_control_deassert(hdptx->rsts[RST_ROPLL].rstc);
++
++	rk_hdptx_multi_reg_write(hdptx, rk_hdtpx_common_cmn_init_seq);
++	rk_hdptx_multi_reg_write(hdptx, rk_hdtpx_frl_cmn_init_seq);
++	rk_hdptx_multi_reg_write(hdptx, rk_hdtpx_frl_ropll_cmn_init_seq);
++
++	regmap_write(hdptx->regmap, CMN_REG(0051), cfg->pms_mdiv);
++	regmap_write(hdptx->regmap, CMN_REG(0055), cfg->pms_mdiv_afc);
++	regmap_write(hdptx->regmap, CMN_REG(0059),
++		     (cfg->pms_pdiv << 4) | cfg->pms_refdiv);
++	regmap_write(hdptx->regmap, CMN_REG(005a), cfg->pms_sdiv << 4);
++
++	regmap_update_bits(hdptx->regmap, CMN_REG(005e), ROPLL_SDM_EN_MASK,
++			   FIELD_PREP(ROPLL_SDM_EN_MASK, cfg->sdm_en));
++	if (!cfg->sdm_en)
++		regmap_update_bits(hdptx->regmap, CMN_REG(005e), 0xf, 0);
++
++	regmap_update_bits(hdptx->regmap, CMN_REG(0064), ROPLL_SDM_NUM_SIGN_RBR_MASK,
++			   FIELD_PREP(ROPLL_SDM_NUM_SIGN_RBR_MASK, cfg->sdm_num_sign));
++
++	regmap_write(hdptx->regmap, CMN_REG(0060), cfg->sdm_deno);
++	regmap_write(hdptx->regmap, CMN_REG(0065), cfg->sdm_num);
++
++	regmap_update_bits(hdptx->regmap, CMN_REG(0069), ROPLL_SDC_N_RBR_MASK,
++			   FIELD_PREP(ROPLL_SDC_N_RBR_MASK, cfg->sdc_n));
++
++	regmap_write(hdptx->regmap, CMN_REG(006c), cfg->sdc_num);
++	regmap_write(hdptx->regmap, CMN_REG(0070), cfg->sdc_deno);
++
++	regmap_update_bits(hdptx->regmap, CMN_REG(0086), PLL_PCG_POSTDIV_SEL_MASK,
++			   FIELD_PREP(PLL_PCG_POSTDIV_SEL_MASK, cfg->pms_sdiv));
++	regmap_update_bits(hdptx->regmap, CMN_REG(0086), PLL_PCG_CLK_SEL_MASK,
++			   FIELD_PREP(PLL_PCG_CLK_SEL_MASK, color_depth));
++
++	rk_hdptx_multi_reg_write(hdptx, rk_hdtpx_common_sb_init_seq);
++	rk_hdptx_multi_reg_write(hdptx, rk_hdtpx_frl_lntop_init_seq);
++
++	rk_hdptx_multi_reg_write(hdptx, rk_hdtpx_common_lane_init_seq);
++	rk_hdptx_multi_reg_write(hdptx, rk_hdtpx_frl_ropll_lane_init_seq);
++
++	if (hdptx->earc_en)
++		rk_hdptx_earc_config(hdptx);
++
++	return rk_hdptx_post_power_up(hdptx);
++}
++
++static int rk_hdptx_lcpll_frl_mode_config(struct rk_hdptx_phy *hdptx,
++					  u32 bus_width)
++{
++	u32 bit_rate = bus_width & DATA_RATE_MASK;
++	u8 color_depth = (bus_width & COLOR_DEPTH_MASK) ? 1 : 0;
++	const struct lcpll_config *cfg = NULL;
++	int i;
++
++	for (i = 0; i < ARRAY_SIZE(lcpll_cfg); i++)
++		if (bit_rate == lcpll_cfg[i].bit_rate) {
++			cfg = &lcpll_cfg[i];
++			break;
++		}
++
++	if (!cfg) {
++		dev_err(hdptx->dev, "%s cannot find pll cfg\n", __func__);
++		return -EINVAL;
++	}
++
++	rk_hdptx_pre_power_up(hdptx);
++
++	rk_hdptx_multi_reg_write(hdptx, rk_hdtpx_common_cmn_init_seq);
++	rk_hdptx_multi_reg_write(hdptx, rk_hdtpx_frl_cmn_init_seq);
++	rk_hdptx_multi_reg_write(hdptx, rk_hdtpx_frl_lcpll_cmn_init_seq);
++
++	regmap_update_bits(hdptx->regmap, CMN_REG(0008),
++			   LCPLL_EN_MASK | LCPLL_LCVCO_MODE_EN_MASK,
++			   FIELD_PREP(LCPLL_EN_MASK, 1) |
++			   FIELD_PREP(LCPLL_LCVCO_MODE_EN_MASK, cfg->lcvco_mode_en));
++
++	regmap_update_bits(hdptx->regmap, CMN_REG(001e),
++			   LCPLL_PI_EN_MASK | LCPLL_100M_CLK_EN_MASK,
++			   FIELD_PREP(LCPLL_PI_EN_MASK, cfg->pi_en) |
++			   FIELD_PREP(LCPLL_100M_CLK_EN_MASK, cfg->clk_en_100m));
++
++	regmap_write(hdptx->regmap, CMN_REG(0020), cfg->pms_mdiv);
++	regmap_write(hdptx->regmap, CMN_REG(0021), cfg->pms_mdiv_afc);
++	regmap_write(hdptx->regmap, CMN_REG(0022),
++		     (cfg->pms_pdiv << 4) | cfg->pms_refdiv);
++	regmap_write(hdptx->regmap, CMN_REG(0023),
++		     (cfg->pms_sdiv << 4) | cfg->pms_sdiv);
++	regmap_write(hdptx->regmap, CMN_REG(002a), cfg->sdm_deno);
++	regmap_write(hdptx->regmap, CMN_REG(002b), cfg->sdm_num_sign);
++	regmap_write(hdptx->regmap, CMN_REG(002c), cfg->sdm_num);
++
++	regmap_update_bits(hdptx->regmap, CMN_REG(002d), LCPLL_SDC_N_MASK,
++			   FIELD_PREP(LCPLL_SDC_N_MASK, cfg->sdc_n));
++
++	regmap_update_bits(hdptx->regmap, CMN_REG(0086), PLL_PCG_POSTDIV_SEL_MASK,
++			   FIELD_PREP(PLL_PCG_POSTDIV_SEL_MASK, cfg->pms_sdiv));
++	regmap_update_bits(hdptx->regmap, CMN_REG(0086), PLL_PCG_CLK_SEL_MASK,
++			   FIELD_PREP(PLL_PCG_CLK_SEL_MASK, color_depth));
++
++	rk_hdptx_multi_reg_write(hdptx, rk_hdtpx_common_sb_init_seq);
++	rk_hdptx_multi_reg_write(hdptx, rk_hdtpx_frl_lntop_init_seq);
++
++	rk_hdptx_multi_reg_write(hdptx, rk_hdtpx_common_lane_init_seq);
++	rk_hdptx_multi_reg_write(hdptx, rk_hdtpx_frl_lcpll_lane_init_seq);
++
++	if (hdptx->earc_en)
++		rk_hdptx_earc_config(hdptx);
++
++	return rk_hdptx_post_power_up(hdptx);
++}
++
+ static int rk_hdptx_phy_power_on(struct phy *phy)
+ {
+ 	struct rk_hdptx_phy *hdptx = phy_get_drvdata(phy);
+@@ -865,7 +1280,7 @@ static int rk_hdptx_phy_power_on(struct phy *phy)
+ 	 * from the HDMI bridge driver until phy_configure_opts_hdmi
+ 	 * becomes available in the PHY API.
+ 	 */
+-	unsigned int rate = bus_width & 0xfffffff;
++	unsigned int rate = bus_width & DATA_RATE_MASK;
+ 
+ 	dev_dbg(hdptx->dev, "%s bus_width=%x rate=%u\n",
+ 		__func__, bus_width, rate);
+@@ -876,7 +1291,20 @@ static int rk_hdptx_phy_power_on(struct phy *phy)
+ 		return ret;
+ 	}
+ 
+-	ret = rk_hdptx_ropll_tmds_mode_config(hdptx, rate);
++	if (bus_width & HDMI_EARC_MASK)
++		hdptx->earc_en = true;
++	else
++		hdptx->earc_en = false;
++
++	if (bus_width & HDMI_MODE_MASK) {
++		if (rate > 24000000)
++			ret = rk_hdptx_lcpll_frl_mode_config(hdptx, bus_width);
++		else
++			ret = rk_hdptx_ropll_frl_mode_config(hdptx, bus_width);
++	} else {
++		ret = rk_hdptx_ropll_tmds_mode_config(hdptx, rate);
++	}
++
+ 	if (ret)
+ 		pm_runtime_put(hdptx->dev);
+ 
+-- 
+Armbian
+

--- a/patch/kernel/rockchip-rk3588-edge/0045-phy-phy-rockchip-samsung-hdptx-Add-clock-provider.patch
+++ b/patch/kernel/rockchip-rk3588-edge/0045-phy-phy-rockchip-samsung-hdptx-Add-clock-provider.patch
@@ -1,0 +1,222 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
+Date: Tue, 16 Jan 2024 19:27:40 +0200
+Subject: phy: phy-rockchip-samsung-hdptx: Add clock provider
+
+The HDMI PHY PLL can be used as an alternative dclk source to SoC CRU.
+It provides more accurate clock rates required to properly support
+various display modes, e.g. those relying on non-integer refresh rates.
+
+Also note this only works for HDMI 2.0 or bellow, e.g. cannot be used to
+support HDMI 2.1 4K@120Hz mode.
+
+Signed-off-by: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
+---
+ drivers/phy/rockchip/phy-rockchip-samsung-hdptx.c | 148 +++++++++-
+ 1 file changed, 143 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/phy/rockchip/phy-rockchip-samsung-hdptx.c b/drivers/phy/rockchip/phy-rockchip-samsung-hdptx.c
+index 44acea3f86af..a3ac4f3835bc 100644
+--- a/drivers/phy/rockchip/phy-rockchip-samsung-hdptx.c
++++ b/drivers/phy/rockchip/phy-rockchip-samsung-hdptx.c
+@@ -8,6 +8,7 @@
+  */
+ #include <linux/bitfield.h>
+ #include <linux/clk.h>
++#include <linux/clk-provider.h>
+ #include <linux/delay.h>
+ #include <linux/mfd/syscon.h>
+ #include <linux/module.h>
+@@ -279,6 +280,12 @@ struct rk_hdptx_phy {
+ 	int nr_clks;
+ 	struct reset_control_bulk_data rsts[RST_MAX];
+ 	bool earc_en;
++
++	/* clk provider */
++	struct clk_hw hw;
++	unsigned long rate;
++	int id;
++	int count;
+ };
+ 
+ static const struct lcpll_config lcpll_cfg[] = {
+@@ -1031,6 +1038,8 @@ static int rk_hdptx_ropll_tmds_cmn_config(struct rk_hdptx_phy *hdptx,
+ 	const struct ropll_config *cfg = NULL;
+ 	struct ropll_config rc = {0};
+ 
++	hdptx->rate = rate * 100;
++
+ 	if (color_depth)
+ 		rate = rate * 10 / 8;
+ 
+@@ -1315,11 +1324,13 @@ static int rk_hdptx_phy_power_off(struct phy *phy)
+ {
+ 	struct rk_hdptx_phy *hdptx = phy_get_drvdata(phy);
+ 	u32 val;
+-	int ret;
++	int ret = 0;
+ 
+-	ret = regmap_read(hdptx->grf, GRF_HDPTX_STATUS, &val);
+-	if (ret == 0 && (val & HDPTX_O_PLL_LOCK_DONE))
+-		rk_hdptx_phy_disable(hdptx);
++	if (hdptx->count == 0) {
++		ret = regmap_read(hdptx->grf, GRF_HDPTX_STATUS, &val);
++		if (ret == 0 && (val & HDPTX_O_PLL_LOCK_DONE))
++			rk_hdptx_phy_disable(hdptx);
++	}
+ 
+ 	pm_runtime_put(hdptx->dev);
+ 
+@@ -1332,6 +1343,129 @@ static const struct phy_ops rk_hdptx_phy_ops = {
+ 	.owner	   = THIS_MODULE,
+ };
+ 
++static struct rk_hdptx_phy *to_rk_hdptx_phy(struct clk_hw *hw)
++{
++	return container_of(hw, struct rk_hdptx_phy, hw);
++}
++
++static int rk_hdptx_phy_clk_prepare(struct clk_hw *hw)
++{
++	struct rk_hdptx_phy *hdptx = to_rk_hdptx_phy(hw);
++	int ret;
++
++	ret = pm_runtime_resume_and_get(hdptx->dev);
++	if (ret) {
++		dev_err(hdptx->dev, "Failed to resume phy clk: %d\n", ret);
++		return ret;
++	}
++
++	if (!hdptx->count && hdptx->rate) {
++		ret = rk_hdptx_ropll_tmds_cmn_config(hdptx, hdptx->rate / 100);
++		if (ret < 0) {
++			dev_err(hdptx->dev, "Failed to init PHY PLL: %d\n", ret);
++			pm_runtime_put(hdptx->dev);
++			return ret;
++		}
++	}
++
++	hdptx->count++;
++
++	return 0;
++}
++
++static void rk_hdptx_phy_clk_unprepare(struct clk_hw *hw)
++{
++	struct rk_hdptx_phy *hdptx = to_rk_hdptx_phy(hw);
++
++	if (hdptx->count == 1) {
++		u32 val;
++		int ret = regmap_read(hdptx->grf, GRF_HDPTX_STATUS, &val);
++		if (ret == 0 && (val & HDPTX_O_PLL_LOCK_DONE))
++			rk_hdptx_phy_disable(hdptx);
++	}
++
++	hdptx->count--;
++	pm_runtime_put(hdptx->dev);
++}
++
++static unsigned long rk_hdptx_phy_clk_recalc_rate(struct clk_hw *hw,
++						  unsigned long parent_rate)
++{
++	struct rk_hdptx_phy *hdptx = to_rk_hdptx_phy(hw);
++
++	return hdptx->rate;
++}
++
++static long rk_hdptx_phy_clk_round_rate(struct clk_hw *hw, unsigned long rate,
++					unsigned long *parent_rate)
++{
++	const struct ropll_config *cfg = NULL;
++	u32 bit_rate = rate / 100;
++	int i;
++
++	if (rate > HDMI20_MAX_RATE)
++		return rate;
++
++	for (i = 0; i < ARRAY_SIZE(ropll_tmds_cfg); i++)
++		if (bit_rate == ropll_tmds_cfg[i].bit_rate) {
++			cfg = &ropll_tmds_cfg[i];
++			break;
++		}
++
++	if (!cfg && !rk_hdptx_phy_clk_pll_calc(bit_rate, NULL))
++		return -EINVAL;
++
++	return rate;
++}
++
++static int rk_hdptx_phy_clk_set_rate(struct clk_hw *hw, unsigned long rate,
++				     unsigned long parent_rate)
++{
++	struct rk_hdptx_phy *hdptx = to_rk_hdptx_phy(hw);
++	u32 val;
++	int ret = regmap_read(hdptx->grf, GRF_HDPTX_STATUS, &val);
++	if (ret == 0 && (val & HDPTX_O_PLL_LOCK_DONE))
++		rk_hdptx_phy_disable(hdptx);
++
++	return rk_hdptx_ropll_tmds_cmn_config(hdptx, rate / 100);
++}
++
++static const struct clk_ops hdptx_phy_clk_ops = {
++	.prepare = rk_hdptx_phy_clk_prepare,
++	.unprepare = rk_hdptx_phy_clk_unprepare,
++	.recalc_rate = rk_hdptx_phy_clk_recalc_rate,
++	.round_rate = rk_hdptx_phy_clk_round_rate,
++	.set_rate = rk_hdptx_phy_clk_set_rate,
++};
++
++static int rk_hdptx_phy_clk_register(struct rk_hdptx_phy *hdptx)
++{
++	struct device *dev = hdptx->dev;
++	const char *name, *pname;
++	struct clk *refclk;
++	int ret;
++
++	refclk = devm_clk_get(dev, "ref");
++	if (IS_ERR(refclk))
++		return dev_err_probe(dev, PTR_ERR(refclk),
++				     "Failed to get ref clock\n");
++
++	pname = __clk_get_name(refclk);
++	name = hdptx->id ? "clk_hdmiphy_pixel1" : "clk_hdmiphy_pixel0";
++	hdptx->hw.init = CLK_HW_INIT(name, pname, &hdptx_phy_clk_ops,
++				     CLK_GET_RATE_NOCACHE);
++
++	ret = devm_clk_hw_register(dev, &hdptx->hw);
++	if (ret)
++		return dev_err_probe(dev, ret, "Failed to register clock\n");
++
++	ret = devm_of_clk_add_hw_provider(dev, of_clk_hw_simple_get, &hdptx->hw);
++	if (ret)
++		return dev_err_probe(dev, ret,
++				     "Failed to register clk provider\n");
++	return 0;
++}
++
+ static int rk_hdptx_phy_runtime_suspend(struct device *dev)
+ {
+ 	struct rk_hdptx_phy *hdptx = dev_get_drvdata(dev);
+@@ -1367,6 +1501,10 @@ static int rk_hdptx_phy_probe(struct platform_device *pdev)
+ 
+ 	hdptx->dev = dev;
+ 
++	hdptx->id = of_alias_get_id(dev->of_node, "hdptxphy");
++	if (hdptx->id < 0)
++		hdptx->id = 0;
++
+ 	regs = devm_platform_ioremap_resource(pdev, 0);
+ 	if (IS_ERR(regs))
+ 		return dev_err_probe(dev, PTR_ERR(regs),
+@@ -1426,7 +1564,7 @@ static int rk_hdptx_phy_probe(struct platform_device *pdev)
+ 	reset_control_deassert(hdptx->rsts[RST_CMN].rstc);
+ 	reset_control_deassert(hdptx->rsts[RST_INIT].rstc);
+ 
+-	return 0;
++	return rk_hdptx_phy_clk_register(hdptx);
+ }
+ 
+ static const struct dev_pm_ops rk_hdptx_phy_pm_ops = {
+-- 
+Armbian
+

--- a/patch/kernel/rockchip-rk3588-edge/0046-drm-rockchip-vop2-Improve-display-modes-handling-on-.patch
+++ b/patch/kernel/rockchip-rk3588-edge/0046-drm-rockchip-vop2-Improve-display-modes-handling-on-.patch
@@ -1,0 +1,679 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
+Date: Fri, 3 Nov 2023 19:58:02 +0200
+Subject: drm/rockchip: vop2: Improve display modes handling on rk3588
+
+The initial vop2 support for rk3588 in mainline is not able to handle
+all display modes supported by connected displays, e.g.
+2560x1440-75.00Hz, 2048x1152-60.00Hz, 1024x768-60.00Hz.
+
+Additionally, it doesn't cope with non-integer refresh rates like 59.94,
+29.97, 23.98, etc.
+
+Improve HDMI0 clocking in order to support the additional display modes.
+
+Fixes: 5a028e8f062f ("drm/rockchip: vop2: Add support for rk3588")
+Signed-off-by: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
+---
+ drivers/gpu/drm/rockchip/rockchip_drm_vop2.c | 553 +++++++++-
+ 1 file changed, 552 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c b/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c
+index fdd768bbd487..c1361ceaec41 100644
+--- a/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c
++++ b/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c
+@@ -5,6 +5,8 @@
+  */
+ #include <linux/bitfield.h>
+ #include <linux/clk.h>
++#include <linux/clk-provider.h>
++#include <linux/clkdev.h>
+ #include <linux/component.h>
+ #include <linux/delay.h>
+ #include <linux/iopoll.h>
+@@ -212,6 +214,10 @@ struct vop2 {
+ 	struct clk *hclk;
+ 	struct clk *aclk;
+ 	struct clk *pclk;
++	// [CC:] hack to support additional display modes
++	struct clk *hdmi0_phy_pll;
++	/* list_head of internal clk */
++	struct list_head clk_list_head;
+ 
+ 	/* optional internal rgb encoder */
+ 	struct rockchip_rgb *rgb;
+@@ -220,6 +226,19 @@ struct vop2 {
+ 	struct vop2_win win[];
+ };
+ 
++struct vop2_clk {
++	struct vop2 *vop2;
++	struct list_head list;
++	unsigned long rate;
++	struct clk_hw hw;
++	struct clk_divider div;
++	int div_val;
++	u8 parent_index;
++};
++
++#define to_vop2_clk(_hw) container_of(_hw, struct vop2_clk, hw)
++#define VOP2_MAX_DCLK_RATE	600000 /* kHz */
++
+ #define vop2_output_if_is_hdmi(x)	((x) == ROCKCHIP_VOP2_EP_HDMI0 || \
+ 					 (x) == ROCKCHIP_VOP2_EP_HDMI1)
+ 
+@@ -1474,9 +1493,30 @@ static bool vop2_crtc_mode_fixup(struct drm_crtc *crtc,
+ 				 const struct drm_display_mode *mode,
+ 				 struct drm_display_mode *adj_mode)
+ {
++	struct vop2_video_port *vp = to_vop2_video_port(crtc);
++	struct drm_connector *connector;
++	struct drm_connector_list_iter conn_iter;
++	struct drm_crtc_state *new_crtc_state = container_of(mode, struct drm_crtc_state, mode);
+ 	drm_mode_set_crtcinfo(adj_mode, CRTC_INTERLACE_HALVE_V |
+ 					CRTC_STEREO_DOUBLE);
+ 
++	if (mode->flags & DRM_MODE_FLAG_DBLCLK)
++		adj_mode->crtc_clock *= 2;
++
++	drm_connector_list_iter_begin(crtc->dev, &conn_iter);
++	drm_for_each_connector_iter(connector, &conn_iter) {
++		if ((new_crtc_state->connector_mask & drm_connector_mask(connector)) &&
++		    ((connector->connector_type == DRM_MODE_CONNECTOR_DisplayPort) ||
++		     (connector->connector_type == DRM_MODE_CONNECTOR_HDMIA))) {
++			drm_connector_list_iter_end(&conn_iter);
++			return true;
++		}
++	}
++	drm_connector_list_iter_end(&conn_iter);
++
++	if (adj_mode->crtc_clock <= VOP2_MAX_DCLK_RATE)
++		adj_mode->crtc_clock = DIV_ROUND_UP(clk_round_rate(vp->dclk,
++						    adj_mode->crtc_clock * 1000), 1000);
+ 	return true;
+ }
+ 
+@@ -1661,6 +1701,31 @@ static unsigned long rk3588_calc_dclk(unsigned long child_clk, unsigned long max
+ 		return 0;
+ }
+ 
++static struct vop2_clk *vop2_clk_get(struct vop2 *vop2, const char *name);
++
++static int vop2_cru_set_rate(struct vop2_clk *if_pixclk, struct vop2_clk *if_dclk)
++{
++	int ret = 0;
++
++	if (if_pixclk) {
++		ret =  clk_set_rate(if_pixclk->hw.clk, if_pixclk->rate);
++		if (ret < 0) {
++			DRM_DEV_ERROR(if_pixclk->vop2->dev, "set %s to %ld failed: %d\n",
++				      clk_hw_get_name(&if_pixclk->hw), if_pixclk->rate, ret);
++			return ret;
++		}
++	}
++
++	if (if_dclk) {
++		ret = clk_set_rate(if_dclk->hw.clk, if_dclk->rate);
++		if (ret < 0)
++			DRM_DEV_ERROR(if_dclk->vop2->dev, "set %s to %ld failed %d\n",
++				      clk_hw_get_name(&if_dclk->hw), if_dclk->rate, ret);
++	}
++
++	return ret;
++}
++
+ /*
+  * 4 pixclk/cycle on rk3588
+  * RGB/eDP/HDMI: if_pixclk >= dclk_core
+@@ -1684,6 +1749,72 @@ static unsigned long rk3588_calc_cru_cfg(struct vop2_video_port *vp, int id,
+ 	int K = 1;
+ 
+ 	if (vop2_output_if_is_hdmi(id)) {
++		if (vop2->data->soc_id == 3588 && id == ROCKCHIP_VOP2_EP_HDMI0 &&
++		    vop2->hdmi0_phy_pll) {
++			const char *clk_src_name = "hdmi_edp0_clk_src";
++			const char *clk_parent_name = "dclk";
++			const char *pixclk_name = "hdmi_edp0_pixclk";
++			const char *dclk_name = "hdmi_edp0_dclk";
++			struct vop2_clk *if_clk_src, *if_clk_parent, *if_pixclk, *if_dclk, *dclk, *dclk_core, *dclk_out;
++			char clk_name[32];
++			int ret;
++
++			if_clk_src = vop2_clk_get(vop2, clk_src_name);
++			snprintf(clk_name, sizeof(clk_name), "%s%d", clk_parent_name, vp->id);
++			if_clk_parent = vop2_clk_get(vop2, clk_name);
++			if_pixclk = vop2_clk_get(vop2, pixclk_name);
++			if_dclk = vop2_clk_get(vop2, dclk_name);
++			if (!if_pixclk || !if_clk_parent) {
++				DRM_DEV_ERROR(vop2->dev, "failed to get connector interface clk\n");
++				return -ENODEV;
++			}
++
++			ret = clk_set_parent(if_clk_src->hw.clk, if_clk_parent->hw.clk);
++			if (ret < 0) {
++				DRM_DEV_ERROR(vop2->dev, "failed to set parent(%s) for %s: %d\n",
++					      __clk_get_name(if_clk_parent->hw.clk),
++					      __clk_get_name(if_clk_src->hw.clk), ret);
++				return ret;
++			}
++
++			if (output_mode == ROCKCHIP_OUT_MODE_YUV420)
++				K = 2;
++
++			if_pixclk->rate = (dclk_core_rate << 1) / K;
++			if_dclk->rate = dclk_core_rate / K;
++
++			snprintf(clk_name, sizeof(clk_name), "dclk_core%d", vp->id);
++			dclk_core = vop2_clk_get(vop2, clk_name);
++
++			snprintf(clk_name, sizeof(clk_name), "dclk_out%d", vp->id);
++			dclk_out = vop2_clk_get(vop2, clk_name);
++
++			snprintf(clk_name, sizeof(clk_name), "dclk%d", vp->id);
++			dclk = vop2_clk_get(vop2, clk_name);
++			if (v_pixclk <= (VOP2_MAX_DCLK_RATE * 1000)) {
++				if (output_mode == ROCKCHIP_OUT_MODE_YUV420)
++					v_pixclk = v_pixclk >> 1;
++			} else {
++				v_pixclk = v_pixclk >> 2;
++			}
++			clk_set_rate(dclk->hw.clk, v_pixclk);
++
++			if (dclk_core_rate > if_pixclk->rate) {
++				clk_set_rate(dclk_core->hw.clk, dclk_core_rate);
++				ret = vop2_cru_set_rate(if_pixclk, if_dclk);
++			} else {
++				ret = vop2_cru_set_rate(if_pixclk, if_dclk);
++				clk_set_rate(dclk_core->hw.clk, dclk_core_rate);
++			}
++
++			*dclk_core_div = dclk_core->div_val;
++			*dclk_out_div = dclk_out->div_val;
++			*if_pixclk_div = if_pixclk->div_val;
++			*if_dclk_div = if_dclk->div_val;
++
++			return dclk->rate;
++		}
++
+ 		/*
+ 		 * K = 2: dclk_core = if_pixclk_rate > if_dclk_rate
+ 		 * K = 1: dclk_core = hdmie_edp_dclk > if_pixclk_rate
+@@ -1915,6 +2046,22 @@ static int us_to_vertical_line(struct drm_display_mode *mode, int us)
+ 	return us * mode->clock / mode->htotal / 1000;
+ }
+ 
++// [CC:] rework virtual clock
++static struct vop2_clk *vop2_clk_get(struct vop2 *vop2, const char *name)
++{
++	struct vop2_clk *clk, *n;
++
++	if (!name)
++		return NULL;
++
++	list_for_each_entry_safe(clk, n, &vop2->clk_list_head, list) {
++		if (!strcmp(clk_hw_get_name(&clk->hw), name))
++			return clk;
++	}
++
++	return NULL;
++}
++
+ static void vop2_crtc_atomic_enable(struct drm_crtc *crtc,
+ 				    struct drm_atomic_state *state)
+ {
+@@ -1942,6 +2089,8 @@ static void vop2_crtc_atomic_enable(struct drm_crtc *crtc,
+ 	u32 val, polflags;
+ 	int ret;
+ 	struct drm_encoder *encoder;
++	char clk_name[32];
++	struct vop2_clk *dclk;
+ 
+ 	drm_dbg(vop2->drm, "Update mode to %dx%d%s%d, type: %d for vp%d\n",
+ 		hdisplay, vdisplay, mode->flags & DRM_MODE_FLAG_INTERLACE ? "i" : "p",
+@@ -2042,11 +2191,38 @@ static void vop2_crtc_atomic_enable(struct drm_crtc *crtc,
+ 
+ 	if (mode->flags & DRM_MODE_FLAG_DBLCLK) {
+ 		dsp_ctrl |= RK3568_VP_DSP_CTRL__CORE_DCLK_DIV;
+-		clock *= 2;
++		// [CC:] done via mode_fixup
++		// clock *= 2;
+ 	}
+ 
+ 	vop2_vp_write(vp, RK3568_VP_MIPI_CTRL, 0);
+ 
++	snprintf(clk_name, sizeof(clk_name), "dclk%d", vp->id);
++	dclk = vop2_clk_get(vop2, clk_name);
++	if (dclk) {
++		/*
++		 * use HDMI_PHY_PLL as dclk source under 4K@60 if it is available,
++		 * otherwise use system cru as dclk source.
++		 */
++		drm_for_each_encoder_mask(encoder, crtc->dev, crtc_state->encoder_mask) {
++			struct rockchip_encoder *rkencoder = to_rockchip_encoder(encoder);
++
++			// [CC:] Using PHY PLL to handle all display modes
++			if (rkencoder->crtc_endpoint_id == ROCKCHIP_VOP2_EP_HDMI0) {
++				clk_get_rate(vop2->hdmi0_phy_pll);
++
++				if (mode->crtc_clock <= VOP2_MAX_DCLK_RATE) {
++					ret = clk_set_parent(vp->dclk, vop2->hdmi0_phy_pll);
++					if (ret < 0)
++						DRM_WARN("failed to set clock parent for %s\n",
++							 __clk_get_name(vp->dclk));
++				}
++
++				clock = dclk->rate;
++			}
++		}
++	}
++
+ 	clk_set_rate(vp->dclk, clock);
+ 
+ 	vop2_post_config(crtc);
+@@ -2502,7 +2678,43 @@ static void vop2_crtc_atomic_flush(struct drm_crtc *crtc,
+ 	spin_unlock_irq(&crtc->dev->event_lock);
+ }
+ 
++static enum drm_mode_status
++vop2_crtc_mode_valid(struct drm_crtc *crtc, const struct drm_display_mode *mode)
++{
++	struct rockchip_crtc_state *vcstate = to_rockchip_crtc_state(crtc->state);
++	struct vop2_video_port *vp = to_vop2_video_port(crtc);
++	struct vop2 *vop2 = vp->vop2;
++	const struct vop2_data *vop2_data = vop2->data;
++	const struct vop2_video_port_data *vp_data = &vop2_data->vp[vp->id];
++	int request_clock = mode->clock;
++	int clock;
++
++	if (mode->hdisplay > vp_data->max_output.width)
++		return MODE_BAD_HVALUE;
++
++	if (mode->flags & DRM_MODE_FLAG_DBLCLK)
++		request_clock *= 2;
++
++	if (request_clock <= VOP2_MAX_DCLK_RATE) {
++		clock = request_clock;
++	} else {
++		request_clock = request_clock >> 2;
++		clock = clk_round_rate(vp->dclk, request_clock * 1000) / 1000;
++	}
++
++	/*
++	 * Hdmi or DisplayPort request a Accurate clock.
++	 */
++	if (vcstate->output_type == DRM_MODE_CONNECTOR_HDMIA ||
++	    vcstate->output_type == DRM_MODE_CONNECTOR_DisplayPort)
++		if (clock != request_clock)
++			return MODE_CLOCK_RANGE;
++
++	return MODE_OK;
++}
++
+ static const struct drm_crtc_helper_funcs vop2_crtc_helper_funcs = {
++	.mode_valid = vop2_crtc_mode_valid,
+ 	.mode_fixup = vop2_crtc_mode_fixup,
+ 	.atomic_check = vop2_crtc_atomic_check,
+ 	.atomic_begin = vop2_crtc_atomic_begin,
+@@ -3072,6 +3284,336 @@ static const struct regmap_config vop2_regmap_config = {
+ 	.cache_type	= REGCACHE_MAPLE,
+ };
+ 
++/*
++ * BEGIN virtual clock
++ */
++#define PLL_RATE_MIN	30000000
++
++#define cru_dbg(format, ...) do {				\
++		if (cru_debug)					\
++			pr_info("%s: " format, __func__, ## __VA_ARGS__); \
++	} while (0)
++
++#define PNAME(x) static const char *const x[]
++
++enum vop_clk_branch_type {
++	branch_mux,
++	branch_divider,
++	branch_factor,
++	branch_virtual,
++};
++
++#define VIR(cname)						\
++	{							\
++		.branch_type	= branch_virtual,		\
++		.name		= cname,			\
++	}
++
++
++#define MUX(cname, pnames, f)			\
++	{							\
++		.branch_type	= branch_mux,			\
++		.name		= cname,			\
++		.parent_names	= pnames,			\
++		.num_parents	= ARRAY_SIZE(pnames),		\
++		.flags		= f,				\
++	}
++
++#define FACTOR(cname, pname,  f)			\
++	{							\
++		.branch_type	= branch_factor,		\
++		.name		= cname,			\
++		.parent_names	= (const char *[]){ pname },	\
++		.num_parents	= 1,				\
++		.flags		= f,				\
++	}
++
++#define DIV(cname, pname, f, w)			\
++	{							\
++		.branch_type	= branch_divider,		\
++		.name		= cname,			\
++		.parent_names	= (const char *[]){ pname },	\
++		.num_parents	= 1,				\
++		.flags		= f,				\
++		.div_width	= w,				\
++	}
++
++struct vop2_clk_branch {
++	enum vop_clk_branch_type	branch_type;
++	const char			*name;
++	const char			*const *parent_names;
++	u8				num_parents;
++	unsigned long			flags;
++	u8				div_shift;
++	u8				div_width;
++	u8				div_flags;
++};
++
++PNAME(mux_port0_dclk_src_p)		= { "dclk0", "dclk1" };
++PNAME(mux_port2_dclk_src_p)		= { "dclk2", "dclk1" };
++PNAME(mux_dp_pixclk_p)			= { "dclk_out0", "dclk_out1", "dclk_out2" };
++PNAME(mux_hdmi_edp_clk_src_p)		= { "dclk0", "dclk1", "dclk2" };
++PNAME(mux_mipi_clk_src_p)		= { "dclk_out1", "dclk_out2", "dclk_out3" };
++PNAME(mux_dsc_8k_clk_src_p)		= { "dclk0", "dclk1", "dclk2", "dclk3" };
++PNAME(mux_dsc_4k_clk_src_p)		= { "dclk0", "dclk1", "dclk2", "dclk3" };
++
++/*
++ * We only use this clk driver calculate the div
++ * of dclk_core/dclk_out/if_pixclk/if_dclk and
++ * the rate of the dclk from the soc.
++ *
++ * We don't touch the cru in the vop here, as
++ * these registers has special read andy write
++ * limits.
++ */
++static struct vop2_clk_branch rk3588_vop_clk_branches[] = {
++	VIR("dclk0"),
++	VIR("dclk1"),
++	VIR("dclk2"),
++	VIR("dclk3"),
++
++	MUX("port0_dclk_src", mux_port0_dclk_src_p, CLK_SET_RATE_PARENT | CLK_SET_RATE_NO_REPARENT),
++	DIV("dclk_core0", "port0_dclk_src", CLK_SET_RATE_PARENT, 2),
++	DIV("dclk_out0", "port0_dclk_src", CLK_SET_RATE_PARENT, 2),
++
++	FACTOR("port1_dclk_src", "dclk1", CLK_SET_RATE_PARENT),
++	DIV("dclk_core1", "port1_dclk_src", CLK_SET_RATE_PARENT, 2),
++	DIV("dclk_out1", "port1_dclk_src", CLK_SET_RATE_PARENT, 2),
++
++	MUX("port2_dclk_src", mux_port2_dclk_src_p, CLK_SET_RATE_PARENT | CLK_SET_RATE_NO_REPARENT),
++	DIV("dclk_core2", "port2_dclk_src", CLK_SET_RATE_PARENT, 2),
++	DIV("dclk_out2", "port2_dclk_src", CLK_SET_RATE_PARENT, 2),
++
++	FACTOR("port3_dclk_src", "dclk3", CLK_SET_RATE_PARENT),
++	DIV("dclk_core3", "port3_dclk_src", CLK_SET_RATE_PARENT, 2),
++	DIV("dclk_out3", "port3_dclk_src", CLK_SET_RATE_PARENT, 2),
++
++	MUX("dp0_pixclk", mux_dp_pixclk_p, CLK_SET_RATE_PARENT | CLK_SET_RATE_NO_REPARENT),
++	MUX("dp1_pixclk", mux_dp_pixclk_p, CLK_SET_RATE_PARENT | CLK_SET_RATE_NO_REPARENT),
++
++	MUX("hdmi_edp0_clk_src", mux_hdmi_edp_clk_src_p,
++	    CLK_SET_RATE_PARENT | CLK_SET_RATE_NO_REPARENT),
++	DIV("hdmi_edp0_dclk", "hdmi_edp0_clk_src", 0, 2),
++	DIV("hdmi_edp0_pixclk", "hdmi_edp0_clk_src", CLK_SET_RATE_PARENT, 1),
++
++	MUX("hdmi_edp1_clk_src", mux_hdmi_edp_clk_src_p,
++	    CLK_SET_RATE_PARENT | CLK_SET_RATE_NO_REPARENT),
++	DIV("hdmi_edp1_dclk", "hdmi_edp1_clk_src", 0, 2),
++	DIV("hdmi_edp1_pixclk", "hdmi_edp1_clk_src", CLK_SET_RATE_PARENT, 1),
++
++	MUX("mipi0_clk_src", mux_mipi_clk_src_p, CLK_SET_RATE_PARENT | CLK_SET_RATE_NO_REPARENT),
++	DIV("mipi0_pixclk", "mipi0_clk_src", CLK_SET_RATE_PARENT, 2),
++
++	MUX("mipi1_clk_src", mux_mipi_clk_src_p, CLK_SET_RATE_PARENT | CLK_SET_RATE_NO_REPARENT),
++	DIV("mipi1_pixclk", "mipi1_clk_src", CLK_SET_RATE_PARENT, 2),
++
++	FACTOR("rgb_pixclk", "port3_dclk_src", CLK_SET_RATE_PARENT),
++
++	MUX("dsc_8k_txp_clk_src", mux_dsc_8k_clk_src_p, CLK_SET_RATE_PARENT | CLK_SET_RATE_NO_REPARENT),
++	DIV("dsc_8k_txp_clk", "dsc_8k_txp_clk_src", 0, 2),
++	DIV("dsc_8k_pxl_clk", "dsc_8k_txp_clk_src", 0, 2),
++	DIV("dsc_8k_cds_clk", "dsc_8k_txp_clk_src", 0, 2),
++
++	MUX("dsc_4k_txp_clk_src", mux_dsc_4k_clk_src_p, CLK_SET_RATE_PARENT | CLK_SET_RATE_NO_REPARENT),
++	DIV("dsc_4k_txp_clk", "dsc_4k_txp_clk_src", 0, 2),
++	DIV("dsc_4k_pxl_clk", "dsc_4k_txp_clk_src", 0, 2),
++	DIV("dsc_4k_cds_clk", "dsc_4k_txp_clk_src", 0, 2),
++};
++
++static unsigned long clk_virtual_recalc_rate(struct clk_hw *hw,
++		unsigned long parent_rate)
++{
++	struct vop2_clk *vop2_clk = to_vop2_clk(hw);
++
++	return (unsigned long)vop2_clk->rate;
++}
++
++static long clk_virtual_round_rate(struct clk_hw *hw, unsigned long rate,
++				unsigned long *prate)
++{
++	struct vop2_clk *vop2_clk = to_vop2_clk(hw);
++
++	vop2_clk->rate = rate;
++
++	return rate;
++}
++
++static int clk_virtual_set_rate(struct clk_hw *hw, unsigned long rate,
++				unsigned long parent_rate)
++{
++	return 0;
++}
++
++const struct clk_ops clk_virtual_ops = {
++	.round_rate = clk_virtual_round_rate,
++	.set_rate = clk_virtual_set_rate,
++	.recalc_rate = clk_virtual_recalc_rate,
++};
++
++static u8 vop2_mux_get_parent(struct clk_hw *hw)
++{
++	struct vop2_clk *vop2_clk = to_vop2_clk(hw);
++
++	// cru_dbg("%s index: %d\n", clk_hw_get_name(hw), vop2_clk->parent_index);
++	return vop2_clk->parent_index;
++}
++
++static int vop2_mux_set_parent(struct clk_hw *hw, u8 index)
++{
++	struct vop2_clk *vop2_clk = to_vop2_clk(hw);
++
++	vop2_clk->parent_index = index;
++
++	// cru_dbg("%s index: %d\n", clk_hw_get_name(hw), index);
++	return 0;
++}
++
++static int vop2_clk_mux_determine_rate(struct clk_hw *hw,
++			     struct clk_rate_request *req)
++{
++	// cru_dbg("%s  %ld(min: %ld max: %ld)\n",
++	//        clk_hw_get_name(hw), req->rate, req->min_rate, req->max_rate);
++	return __clk_mux_determine_rate(hw, req);
++}
++
++static const struct clk_ops vop2_mux_clk_ops = {
++	.get_parent = vop2_mux_get_parent,
++	.set_parent = vop2_mux_set_parent,
++	.determine_rate = vop2_clk_mux_determine_rate,
++};
++
++#define div_mask(width)	((1 << (width)) - 1)
++
++static int vop2_div_get_val(unsigned long rate, unsigned long parent_rate)
++{
++	unsigned int div, value;
++
++	div = DIV_ROUND_UP_ULL((u64)parent_rate, rate);
++
++	value = ilog2(div);
++
++	return value;
++}
++
++static unsigned long vop2_clk_div_recalc_rate(struct clk_hw *hw,
++					  unsigned long parent_rate)
++{
++	struct vop2_clk *vop2_clk = to_vop2_clk(hw);
++	unsigned long rate;
++	unsigned int div;
++
++	div =  1 << vop2_clk->div_val;
++	rate = parent_rate / div;
++
++	// cru_dbg("%s rate: %ld(prate: %ld)\n", clk_hw_get_name(hw), rate, parent_rate);
++	return rate;
++}
++
++static long vop2_clk_div_round_rate(struct clk_hw *hw, unsigned long rate,
++				unsigned long *prate)
++{
++	struct vop2_clk *vop2_clk = to_vop2_clk(hw);
++
++	if (clk_hw_get_flags(hw) & CLK_SET_RATE_PARENT) {
++		if (*prate < rate)
++			*prate = rate;
++		if ((*prate >> vop2_clk->div.width) > rate)
++			*prate = rate;
++
++		if ((*prate % rate))
++			*prate = rate;
++
++		/* SOC PLL can't output a too low pll freq */
++		if (*prate < PLL_RATE_MIN)
++			*prate = rate << vop2_clk->div.width;
++	}
++
++	// cru_dbg("%s rate: %ld(prate: %ld)\n", clk_hw_get_name(hw), rate, *prate);
++	return rate;
++}
++
++static int vop2_clk_div_set_rate(struct clk_hw *hw, unsigned long rate, unsigned long parent_rate)
++{
++	struct vop2_clk *vop2_clk = to_vop2_clk(hw);
++	int div_val;
++
++	div_val = vop2_div_get_val(rate, parent_rate);
++	vop2_clk->div_val = div_val;
++
++	// cru_dbg("%s prate: %ld rate: %ld div_val: %d\n",
++	//        clk_hw_get_name(hw), parent_rate, rate, div_val);
++	return 0;
++}
++
++static const struct clk_ops vop2_div_clk_ops = {
++	.recalc_rate = vop2_clk_div_recalc_rate,
++	.round_rate = vop2_clk_div_round_rate,
++	.set_rate = vop2_clk_div_set_rate,
++};
++
++static struct clk *vop2_clk_register(struct vop2 *vop2, struct vop2_clk_branch *branch)
++{
++	struct clk_init_data init = {};
++	struct vop2_clk *vop2_clk;
++	struct clk *clk;
++
++	vop2_clk = devm_kzalloc(vop2->dev, sizeof(*vop2_clk), GFP_KERNEL);
++	if (!vop2_clk)
++		return ERR_PTR(-ENOMEM);
++
++	vop2_clk->vop2 = vop2;
++	vop2_clk->hw.init = &init;
++	vop2_clk->div.shift = branch->div_shift;
++	vop2_clk->div.width = branch->div_width;
++
++	init.name = branch->name;
++	init.flags = branch->flags;
++	init.num_parents = branch->num_parents;
++	init.parent_names = branch->parent_names;
++	if (branch->branch_type == branch_divider) {
++		init.ops = &vop2_div_clk_ops;
++	} else if (branch->branch_type == branch_virtual) {
++		init.ops = &clk_virtual_ops;
++		init.num_parents = 0;
++		init.parent_names = NULL;
++	} else {
++		init.ops = &vop2_mux_clk_ops;
++	}
++
++	clk = devm_clk_register(vop2->dev, &vop2_clk->hw);
++	if (!IS_ERR(clk))
++		list_add_tail(&vop2_clk->list, &vop2->clk_list_head);
++	else
++		DRM_DEV_ERROR(vop2->dev, "Register %s failed\n", branch->name);
++
++	return clk;
++}
++
++static int vop2_clk_init(struct vop2 *vop2)
++{
++	struct vop2_clk_branch *branch = rk3588_vop_clk_branches;
++	unsigned int nr_clk = ARRAY_SIZE(rk3588_vop_clk_branches);
++	unsigned int idx;
++	struct vop2_clk *clk, *n;
++
++	INIT_LIST_HEAD(&vop2->clk_list_head);
++
++	if (vop2->data->soc_id < 3588 || vop2->hdmi0_phy_pll == NULL)
++		return 0;
++
++	list_for_each_entry_safe(clk, n, &vop2->clk_list_head, list) {
++		list_del(&clk->list);
++	}
++
++	for (idx = 0; idx < nr_clk; idx++, branch++)
++		vop2_clk_register(vop2, branch);
++
++	return 0;
++}
++/*
++ * END virtual clock
++ */
++
+ static int vop2_bind(struct device *dev, struct device *master, void *data)
+ {
+ 	struct platform_device *pdev = to_platform_device(dev);
+@@ -3165,6 +3707,12 @@ static int vop2_bind(struct device *dev, struct device *master, void *data)
+ 		return PTR_ERR(vop2->pclk);
+ 	}
+ 
++	vop2->hdmi0_phy_pll = devm_clk_get_optional(vop2->drm->dev, "hdmi0_phy_pll");
++	if (IS_ERR(vop2->hdmi0_phy_pll)) {
++		DRM_DEV_ERROR(vop2->dev, "failed to get hdmi0_phy_pll source\n");
++		return PTR_ERR(vop2->hdmi0_phy_pll);
++	}
++
+ 	vop2->irq = platform_get_irq(pdev, 0);
+ 	if (vop2->irq < 0) {
+ 		drm_err(vop2->drm, "cannot find irq for vop2\n");
+@@ -3181,6 +3729,9 @@ static int vop2_bind(struct device *dev, struct device *master, void *data)
+ 	if (ret)
+ 		return ret;
+ 
++	// [CC:] rework virtual clock
++	vop2_clk_init(vop2);
++
+ 	ret = vop2_find_rgb_encoder(vop2);
+ 	if (ret >= 0) {
+ 		vop2->rgb = rockchip_rgb_init(dev, &vop2->vps[ret].crtc,
+-- 
+Armbian
+

--- a/patch/kernel/rockchip-rk3588-edge/0047-arm64-dts-rockchip-Make-use-of-HDMI0-PHY-PLL-on-rock.patch
+++ b/patch/kernel/rockchip-rk3588-edge/0047-arm64-dts-rockchip-Make-use-of-HDMI0-PHY-PLL-on-rock.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
+Date: Fri, 3 Nov 2023 20:05:05 +0200
+Subject: arm64: dts: rockchip: Make use of HDMI0 PHY PLL on rock-5b
+
+The initial vop2 support for rk3588 in mainline is not able to handle
+all display modes supported by connected displays, e.g.
+2560x1440-75.00Hz, 2048x1152-60.00Hz, 1024x768-60.00Hz.
+
+Additionally, it doesn't cope with non-integer refresh rates like 59.94,
+29.97, 23.98, etc.
+
+Make use of the HDMI0 PHY PLL to support the additional display modes.
+
+Note this requires commit "drm/rockchip: vop2: Improve display modes
+handling on rk3588", which needs a rework to be upstreamable.
+
+Signed-off-by: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+index 7cb5874f3ec2..78e4a6f346e0 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+@@ -187,6 +187,11 @@ &gpu {
+ 	status = "okay";
+ };
+ 
++&display_subsystem {
++	clocks = <&hdptxphy_hdmi0>;
++	clock-names = "hdmi0_phy_pll";
++};
++
+ &hdmi0 {
+ 	status = "okay";
+ };
+-- 
+Armbian
+


### PR DESCRIPTION
# Description

Last time when I update hdmi driver patches, I drooped [this commit from collabora](https://gitlab.collabora.com/hardware-enablement/rockchip-3588/linux/-/commit/befbfde7f750c35f5653d8c8d4ba6cd9a940697b) because it will break the system. Now I add it back with other necessary patches. Now hdmi should support more display modes.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh kernel BOARD=rock-5b BRANCH=edge DEB_COMPRESS=xz KERNEL_GIT=shallow`
- [x] HDMI works on rock5b. I don't have monitors with resolution like 1440p to test, but this will not break current status.

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
