### PR TITLE
rockchip: rk3588: edge: fix wrong gpu node patch

### DIFF
--- a/patch/kernel/rockchip-rk3588-edge/0042-arm64-dts-rockchip-rk3588-Add-GPU-nodes.patch
+++ b/patch/kernel/rockchip-rk3588-edge/0042-arm64-dts-rockchip-rk3588-Add-GPU-nodes.patch
@@ -12,12 +12,10 @@ diff --git a/arch/arm64/boot/dts/rockchip/rk3588s.dtsi b/arch/arm64/boot/dts/roc
 index 762a095648b1..f43f10340d5d 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s.dtsi
-@@ -962,6 +962,120 @@ usb_host2_xhci: usb@fcd00000 {
- 		snps,dis-del-phy-power-chg-quirk;
- 		snps,dis-tx-ipgap-linecheck-quirk;
- 		snps,dis_rxdet_inp3_quirk;
-+	};
-+
+@@ -962,6 +962,121 @@ usb_host2_xhci: usb@fcd00000 {
+ 		status = "disabled";
+ 	};
+ 
 +	gpu_opp_table: gpu-opp-table {
 +		compatible = "operating-points-v2";
 +
@@ -130,9 +128,12 @@ index 762a095648b1..f43f10340d5d 100644
 +		#cooling-cells = <2>;
 +		dynamic-power-coefficient = <2982>;
 +
- 		status = "disabled";
- 	};
- 
++		status = "disabled";
++	};
++
+ 	pmu1grf: syscon@fd58a000 {
+ 		compatible = "rockchip,rk3588-pmugrf", "syscon", "simple-mfd";
+ 		reg = <0x0 0xfd58a000 0x0 0x10000>;
 @@ -3124,6 +3238,11 @@ gpio4: gpio@fec50000 {
  		};
  	};


### PR DESCRIPTION
# Description

As  mentioned by @andyshrk , this gpu node patch has deleted line `status = "disabled";` of node `usb_host2_xhci`, this will fix that so `usb_host2_xhci` will not get enabled on all boards.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh kernel BOARD=rock-5b BRANCH=edge DEB_COMPRESS=xz KERNEL_GIT=shallow`
- [x] Check node `usb_host2_xhci` in file `cache/sources/linux-kernel-worktree/6.8__rockchip-rk3588__arm64/arch/arm64/boot/dts/rockchip/rk3588s.dtsi`
- [x] rock5b boots fine

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
