### PR TITLE
rockchip: fix bootloader upgrade

### DIFF
--- a/config/sources/families/rockchip.conf
+++ b/config/sources/families/rockchip.conf
@@ -65,96 +65,108 @@ CPUMIN="600000"
 CPUMAX="1900000"
 GOVERNOR="ondemand"
 
-write_uboot_platform() {
+# write_uboot_platform() and uboot_custom_postprocess() functions are dependent upon SOC,
+# so we declare them differently for each supported SOC. Also note that write_uboot_platform()
+# is used to install the bootloader in the proper place during live systems upgrade.
+if [[ "$BOOT_SOC" == "rk3288" ]]; then
 
-	# Extract the Command Rate bit from existing loader.
-	# Some DDR memories have issues with different Command Rate, so we
-	# restore the same value after installing the new loader.
-	# Note: this has to be done only on live installations (DIR variable
-	# is present only during boot loader upgrade on running system)
-	# while loop is only for convenient break syntax
-	while [[ -n $DIR ]]; do
+	write_uboot_platform() {
 
-		# Only applicable to rk322x
-		[[ "$BOOT_SOC" != "rk322x" ]] && break
-
-		# Find the signature "a7866565" in the first 128k of the stored running image
-		SIGNATURE_OFFSET=$(dd if=$2 bs=128k count=1 2> /dev/null | od -A o -w4 -tx4 | grep 'a7866565' | cut -d " " -f 1)
-
-		# Some command failed, skip the rest
-		[[ $? -ne 0 ]] && break
-
-		# No signature found, skip the rest
-		[[ -z $SIGNATURE_OFFSET ]] && break
-
-		# Command rate bit is 16 bytes before signature
-		CMD_RATE_OFFSET=$(($SIGNATURE_OFFSET - 16))
-		CR_BYTE=$(od -A n -t dI -j $CMD_RATE_OFFSET -N 1 $2)
-
-		# No command rate byte for some reason, skip the rest
-		[[ -z $CR_BYTE ]] && break
-
-		# Invalid command rate byte (should be 0 or 1), skip the rest
-		[[ "$CR_BYTE" -ne 0 && "$CR_BYTE" -ne 1 ]] && break
-
-		# Proceed patching u-boot-rk322x-with-spl.bin, do find the
-		# cr bit there too to verify that the position of the CR bit is right
-		SIGNATURE_OFFSET=$(dd if=$1/u-boot-rk322x-with-spl.bin bs=128k count=1 2> /dev/null | od -A o -w4 -tx4 | grep 'a7866565' | cut -d " " -f 1)
-
-		# Some command failed, skip the rest
-		[[ $? -ne 0 ]] && break
-
-		# No signature found, skip the rest
-		[[ -z $SIGNATURE_OFFSET ]] && break
-
-		# Command rate bit is 16 bytes before signature
-		CMD_RATE_OFFSET=$(($SIGNATURE_OFFSET - 16))
-		DST_BYTE=$(od -A n -t dI -j $CMD_RATE_OFFSET -N 1 $1/u-boot-rk322x-with-spl.bin)
-
-		# Verify command rate byte is 0 or 1
-		[[ "$DST_BYTE" -ne 0 && "$DST_BYTE" -ne 1 ]] && break
-
-		# Patch the file
-		[[ "$CR_BYTE" -eq 0 ]] && HEX_CR="\x00"
-		[[ "$CR_BYTE" -eq 1 ]] && HEX_CR="\x01"
-
-		echo -e $HEX_CR | dd of=$1/u-boot-rk322x-with-spl.bin bs=1 seek=$CMD_RATE_OFFSET count=1 conv=notrunc > /dev/null 2>&1
-
-		# always break the while loop
-		break
-
-	done
-
-	if [[ "$BOOT_SOC" == "rk3288" ]]; then
 		UBOOT_SRC="u-boot-rockchip-with-spl.bin"
-	elif [[ "$BOOT_SOC" == "rk322x" ]]; then
-		UBOOT_SRC="u-boot-rk322x-with-spl.bin"
-	fi
 
-	dd if=/dev/zero of=$2 bs=32k count=63 seek=1 status=noxfer > /dev/null 2>&1
-	dd if=$1/$UBOOT_SRC of=$2 bs=32k seek=1 conv=notrunc
+		dd if=/dev/zero of=$2 bs=32k count=63 seek=1 status=noxfer > /dev/null 2>&1
+		dd if=$1/$UBOOT_SRC of=$2 bs=32k seek=1 conv=notrunc
 
-}
+	}
 
-uboot_custom_postprocess() {
-
-	if [[ "$BOOT_SOC" == "rk3288" ]]; then
+	uboot_custom_postprocess() {
 
 		# xt-q8l-v10 requires the original DDR init blob because u-boot does not support LPDDR2 initialization
 		# for rk3288 SoC (binary is in sources/rkbin-tools/rk32 path). U-boot is configured to produce a TPL
 		# which is thrown away. SPL does some more initial configurations, expecially pinmux for power hold,
 		# so reset works more reliably. U-boot image is set to be at sector 0x200 on the eMMC/SD,
 		# so we burn it 0x200-0x40 because of the rockchip 0x40 sectors offset.
-		if [[ $BOARD == xt-q8l-v10 ]]; then
+		if [[ "$BOARD" == "xt-q8l-v10" ]]; then
 			run_host_command_logged tools/mkimage -n rk3288 -T rksd -d $SRC/cache/sources/rkbin-tools/rk32/rk3288_ddr_400MHz_v1.08.bin u-boot-rockchip-with-spl.bin
 		else
 			run_host_command_logged tools/mkimage -n rk3288 -T rksd -d tpl/u-boot-tpl.bin u-boot-rockchip-with-spl.bin
 		fi
 
-		cat spl/u-boot-spl-dtb.bin >> u-boot-rockchip-with-spl.bin
-		dd if=u-boot-dtb.img of=u-boot-rockchip-with-spl.bin seek=$((0x200 - 0x40)) conv=notrunc
+		run_host_command_logged cat spl/u-boot-spl-dtb.bin >> u-boot-rockchip-with-spl.bin
+		run_host_command_logged dd if=u-boot-dtb.img of=u-boot-rockchip-with-spl.bin seek=$((0x200 - 0x40)) conv=notrunc
 
-	elif [[ "$BOOT_SOC" == "rk322x" ]]; then
+	}
+
+elif [[ "$BOOT_SOC" == "rk322x" ]]; then
+
+	write_uboot_platform() {
+
+		# Extract the Command Rate bit from existing loader.
+		# Some DDR memories have issues with different Command Rate, so we
+		# restore the same value after installing the new loader.
+		# Note: this has to be done only on live installations (DIR variable
+		# is present only during boot loader upgrade on running system)
+		# while loop is only for convenient break syntax
+		while [[ -n $DIR ]]; do
+
+			# Only applicable to rk322x
+			[[ "$BOOT_SOC" != "rk322x" ]] && break
+
+			# Find the signature "a7866565" in the first 128k of the stored running image
+			SIGNATURE_OFFSET=$(dd if=$2 bs=128k count=1 2> /dev/null | od -A o -w4 -tx4 | grep 'a7866565' | cut -d " " -f 1)
+
+			# Some command failed, skip the rest
+			[[ $? -ne 0 ]] && break
+
+			# No signature found, skip the rest
+			[[ -z $SIGNATURE_OFFSET ]] && break
+
+			# Command rate bit is 16 bytes before signature
+			CMD_RATE_OFFSET=$(($SIGNATURE_OFFSET - 16))
+			CR_BYTE=$(od -A n -t dI -j $CMD_RATE_OFFSET -N 1 $2)
+
+			# No command rate byte for some reason, skip the rest
+			[[ -z $CR_BYTE ]] && break
+
+			# Invalid command rate byte (should be 0 or 1), skip the rest
+			[[ "$CR_BYTE" -ne 0 && "$CR_BYTE" -ne 1 ]] && break
+
+			# Proceed patching u-boot-rk322x-with-spl.bin, do find the
+			# cr bit there too to verify that the position of the CR bit is right
+			SIGNATURE_OFFSET=$(dd if=$1/u-boot-rk322x-with-spl.bin bs=128k count=1 2> /dev/null | od -A o -w4 -tx4 | grep 'a7866565' | cut -d " " -f 1)
+
+			# Some command failed, skip the rest
+			[[ $? -ne 0 ]] && break
+
+			# No signature found, skip the rest
+			[[ -z $SIGNATURE_OFFSET ]] && break
+
+			# Command rate bit is 16 bytes before signature
+			CMD_RATE_OFFSET=$(($SIGNATURE_OFFSET - 16))
+			DST_BYTE=$(od -A n -t dI -j $CMD_RATE_OFFSET -N 1 $1/u-boot-rk322x-with-spl.bin)
+
+			# Verify command rate byte is 0 or 1
+			[[ "$DST_BYTE" -ne 0 && "$DST_BYTE" -ne 1 ]] && break
+
+			# Patch the file
+			[[ "$CR_BYTE" -eq 0 ]] && HEX_CR="\x00"
+			[[ "$CR_BYTE" -eq 1 ]] && HEX_CR="\x01"
+
+			echo -e $HEX_CR | dd of=$1/u-boot-rk322x-with-spl.bin bs=1 seek=$CMD_RATE_OFFSET count=1 conv=notrunc > /dev/null 2>&1
+
+			# always break the while loop
+			break
+
+		done
+
+		UBOOT_SRC="u-boot-rk322x-with-spl.bin"
+
+		dd if=/dev/zero of=$2 bs=32k count=63 seek=1 status=noxfer > /dev/null 2>&1
+		dd if=$1/$UBOOT_SRC of=$2 bs=32k seek=1 conv=notrunc
+
+	}
+
+	uboot_custom_postprocess() {
 
 		# We use the rockchip proprietary blob to initialize memory chips
 		# instead of letting u-boot doing the job. Such devices, like xt-mx4vr-v01, have DDR2
@@ -172,9 +184,9 @@ uboot_custom_postprocess() {
 		run_host_command_logged cat spl/u-boot-spl.bin ">>" u-boot-rk322x-with-spl.bin
 		run_host_command_logged dd if=u-boot.itb of=u-boot-rk322x-with-spl.bin seek=$((0x200 - 0x40)) conv=notrunc
 
-	fi
+	}
 
-}
+fi
 
 family_tweaks() {
 


### PR DESCRIPTION
# Description

As described in the forum topic https://forum.armbian.com/topic/35677-tinkerboard-not-booting-after-updates/#comment-185896, upgrading on Asus Tinkerboard breaks the bootloader and prevents the entire system to reboot.
As side effect - but not yet reported by anyone - should also break other rk3288 and rk322x board bootloaders.

This PR restores the previous post-install `platform_install.sh` script for each board/family as it was before the family merge. 

[Jira](https://armbian.atlassian.net/jira) reference number [AR-2109]

# How Has This Been Tested?

- [x] Compiled tinkerboard target, extracted the u-boot .deb package and manually inspected `platform_install.sh` script, not tested on a live system
- [x] Compiled rk322x-box target, extract u-boot .deb package and manually inspected `platform_install.sh` script

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


[AR-2109]: https://armbian.atlassian.net/browse/AR-2109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ