### PR TITLE
fix rtl8723cs compilation for kernel 6.8

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -521,6 +521,11 @@ driver_rtl8723cs() {
 	if linux-version compare "${version}" ge 6.7; then
 		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/8723cs-Port-to-6.7.patch" "applying"
 	fi
+
+	if linux-version compare "${version}" ge 6.8; then
+		process_patch_file "${SRC}/patch/misc/wireless-rtl8723cs/8723cs-Port-to-6.8.patch" "applying"
+	fi
+
 }
 
 

--- a/patch/misc/wireless-rtl8723cs/8723cs-Port-to-6.8.patch
+++ b/patch/misc/wireless-rtl8723cs/8723cs-Port-to-6.8.patch
@@ -1,0 +1,34 @@
+diff --git a/drivers/staging/rtl8723cs/os_dep/linux/os_intfs.c b/drivers/staging/rtl8723cs/os_dep/linux/os_intfs.c
+index 7fbce22c0842..4ac2cac55221 100644
+--- a/drivers/staging/rtl8723cs/os_dep/linux/os_intfs.c
++++ b/drivers/staging/rtl8723cs/os_dep/linux/os_intfs.c
+@@ -2025,13 +2025,13 @@ static void rtw_ethtool_get_drvinfo(struct net_device *dev, struct ethtool_drvin
+ 
+ 	wdev = dev->ieee80211_ptr;
+ 	if (wdev) {
+-		strlcpy(info->driver, wiphy_dev(wdev->wiphy)->driver->name,
++		strscpy(info->driver, wiphy_dev(wdev->wiphy)->driver->name,
+ 			sizeof(info->driver));
+ 	} else {
+-		strlcpy(info->driver, "N/A", sizeof(info->driver));
++		strscpy(info->driver, "N/A", sizeof(info->driver));
+ 	}
+ 
+-	strlcpy(info->version, DRIVERVERSION, sizeof(info->version));
++	strscpy(info->version, DRIVERVERSION, sizeof(info->version));
+ 
+ 	padapter = (_adapter *)rtw_netdev_priv(dev);
+ 	if (padapter) {
+@@ -2042,10 +2042,10 @@ static void rtw_ethtool_get_drvinfo(struct net_device *dev, struct ethtool_drvin
+ 		scnprintf(info->fw_version, sizeof(info->fw_version), "%d.%d",
+ 			  hal_data->firmware_version, hal_data->firmware_sub_version);
+ 	} else {
+-		strlcpy(info->fw_version, "N/A", sizeof(info->fw_version));
++		strscpy(info->fw_version, "N/A", sizeof(info->fw_version));
+ 	}
+ 
+-	strlcpy(info->bus_info, dev_name(wiphy_dev(wdev->wiphy)),
++	strscpy(info->bus_info, dev_name(wiphy_dev(wdev->wiphy)),
+ 		sizeof(info->bus_info));
+ }
+ 


### PR DESCRIPTION
# Description

Some changes in kernel made `strlcpy()` function unavailable for some reason. Substitute it with `strscpy()` in rtl8723cs.

[Jira](https://armbian.atlassian.net/jira) reference number [AR-2110]

# How Has This Been Tested?

- [x] Rockchip kernel compiles correctly with no errors

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


[AR-2110]: https://armbian.atlassian.net/browse/AR-2110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ