### PR TITLE
armsom-sige7: add missing vop node

### DIFF
--- a/patch/kernel/rockchip-rk3588-edge/dt/rk3588-armsom-sige7.dts
+++ b/patch/kernel/rockchip-rk3588-edge/dt/rk3588-armsom-sige7.dts
@@ -754,6 +754,10 @@
 	status = "okay";
 };
 
+&vop {
+	status = "okay";
+};
+
 &vop_mmu {
 	status = "okay";
 };


### PR DESCRIPTION
# Description

Missing `&vop` node makes hdmi not work, add it.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh kernel BOARD=armsom-sige7 BRANCH=edge DEB_COMPRESS=xz`
- [x] hdmi works

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
