### PR TITLE
GH Actions: Beautify kernel hardening analysis

### DIFF
--- a/.github/workflows/kernel-security-analysis-pr.yml
+++ b/.github/workflows/kernel-security-analysis-pr.yml
@@ -23,7 +23,7 @@ jobs:
 
   Analysis:
 
-    name: Analyse
+    name: Check kernel security options
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'Armbian' }}
     steps:
@@ -46,9 +46,10 @@ jobs:
        - name: Check kernel config for security issues
          # Run kernel-hardening-checker for each kernel config file excluding RISC-V configs, since they are not supported yet.
          # See https://github.com/a13xp0p0v/kernel-hardening-checker/issues/56
+         # sed explanation: 1) Put spaces in front of every line 2) replace colored output with emojis since GitHub Actions job summaries don't support colored output
          run: |
            for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
                if [[ "${file}" = config/kernel/*.config && ! $(head -n 10 "${file}" | grep -q "riscv") ]]; then
-                   kconfig-hardened-check/bin/kernel-hardening-checker -m show_fail -c $file | sed -e 's/^/    /' >> $GITHUB_STEP_SUMMARY
+                   kconfig-hardened-check/bin/kernel-hardening-checker -m show_fail -c $file | sed 's/^/     /; s/\x1b\[32m/✅ /; s/\x1b\[31m/❌ /; s/\x1b\[0m//' >> $GITHUB_STEP_SUMMARY
                fi
            done


### PR DESCRIPTION
# Description

GitHub job summaries do not support colored output, but the kernel hardening script is using colored output. Thus, the job summary in the Actions panel is littered with ugly characters. This commit replaces them with emojis to enhance visibility.

**Before:**

![](https://github.com/armbian/build/assets/131405023/bb9a33c1-4373-49b4-92d4-3ca776c42e73)

**After:**

![](https://github.com/armbian/build/assets/131405023/16e42ed6-2b3d-4974-b37a-f4c9342a793f)


# How Has This Been Tested?

- [x] run locally: `kernel-hardening-checker -m show_fail -c linux-rockchip64-edge.config | sed 's/^/     /; s/\x1b\[32m/✅ /; s/\x1b\[31m/❌ /; s/\x1b\[0m//'`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
