### PR TITLE
armsom-sige7: add ap6275p wifi support

### DIFF
--- a/patch/kernel/rockchip-rk3588-edge/dt/rk3588-armsom-sige7.dts
+++ b/patch/kernel/rockchip-rk3588-edge/dt/rk3588-armsom-sige7.dts
@@ -284,6 +284,22 @@
 &pcie2x1l1 {
 	reset-gpios = <&gpio3 RK_PD4 GPIO_ACTIVE_HIGH>;
 	status = "okay";
+
+	pcie@0,0 {
+		reg = <0x300000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+		device_type = "pci";
+		bus-range = <0x30 0x3f>;
+
+		wifi: wifi@0,0 {
+			compatible = "pci14e4,449d";
+			reg = <0x310000 0 0 0 0>;
+			clocks = <&hym8563>;
+			clock-names = "32k";
+		};
+	};
 };
 
 /* phy0 - left ethernet port */


### PR DESCRIPTION
# Description

similar to #6335
@efectn can you get ipv6  address from wifi? I get errors  like:
`IPv6: wlP3p49s0: IPv6 duplicate address fe80::32c4:b6c0:22b0:fae3 used by b8:2d:28:5a:54:6e detected!`  and then no ipv6 address.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh kernel BOARD=armsom-sige7 BRANCH=edge DEB_COMPRESS=xz`
- [x] wifi works

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
