### PR TITLE
Rk3588 edge: enable nodes for sige7, rock5a and h88k

### DIFF
--- a/patch/kernel/rockchip-rk3588-edge/0048-arch-arm64-dts-enable-gpu-node-for-rock-5a.patch
+++ b/patch/kernel/rockchip-rk3588-edge/0048-arch-arm64-dts-enable-gpu-node-for-rock-5a.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: amazingfate <liujianfeng1994@gmail.com>
+Date: Thu, 28 Mar 2024 00:41:34 +0800
+Subject: arch: arm64: dts: enable gpu node for rock-5a
+
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
+index 81377dc4b583..8d34c616e672 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
+@@ -281,6 +281,11 @@ &gmac1_rgmii_clk
+ 	status = "okay";
+ };
+ 
++&gpu {
++	mali-supply = <&vdd_gpu_s0>;
++	status = "okay";
++};
++
+ &mdio1 {
+ 	rgmii_phy1: ethernet-phy@1 {
+ 		/* RTL8211F */
+@@ -433,6 +438,7 @@ rk806_dvs3_null: dvs3-null-pins {
+ 		regulators {
+ 			vdd_gpu_s0: vdd_gpu_mem_s0: dcdc-reg1 {
+ 				regulator-name = "vdd_gpu_s0";
++				regulator-always-on;
+ 				regulator-boot-on;
+ 				regulator-min-microvolt = <550000>;
+ 				regulator-max-microvolt = <950000>;
+-- 
+Armbian
+

--- a/patch/kernel/rockchip-rk3588-edge/0049-arm64-dts-rockchip-support-poweroff-on-rock-5a.patch
+++ b/patch/kernel/rockchip-rk3588-edge/0049-arm64-dts-rockchip-support-poweroff-on-rock-5a.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: amazingfate <liujianfeng1994@gmail.com>
+Date: Thu, 28 Mar 2024 10:59:29 +0800
+Subject: arm64: dts: rockchip: support poweroff on rock-5a
+
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
+index 8d34c616e672..1bc5b6a4e9b8 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
+@@ -401,6 +401,8 @@ pmic@0 {
+ 			    <&rk806_dvs2_null>, <&rk806_dvs3_null>;
+ 		spi-max-frequency = <1000000>;
+ 
++		system-power-controller;
++
+ 		vcc1-supply = <&vcc5v0_sys>;
+ 		vcc2-supply = <&vcc5v0_sys>;
+ 		vcc3-supply = <&vcc5v0_sys>;
+-- 
+Armbian
+

--- a/patch/kernel/rockchip-rk3588-edge/0050-arm64-dts-rockchip-add-PCIe-for-M.2-E-Key-to-rock-5a.patch
+++ b/patch/kernel/rockchip-rk3588-edge/0050-arm64-dts-rockchip-add-PCIe-for-M.2-E-Key-to-rock-5a.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: amazingfate <liujianfeng1994@gmail.com>
+Date: Thu, 28 Mar 2024 16:07:18 +0800
+Subject: arm64: dts: rockchip: add PCIe for M.2 E-Key to rock-5a
+
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
+index 1bc5b6a4e9b8..77893c3af613 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
+@@ -115,6 +115,10 @@ vcc_1v1_nldo_s3: vcc-1v1-nldo-s3-regulator {
+ 	};
+ };
+ 
++&combphy0_ps {
++	status = "okay";
++};
++
+ &combphy2_psu {
+ 	status = "okay";
+ };
+@@ -299,6 +303,11 @@ rgmii_phy1: ethernet-phy@1 {
+ 	};
+ };
+ 
++&pcie2x1l2 {
++	status = "okay";
++	reset-gpios = <&gpio3 RK_PB0 GPIO_ACTIVE_HIGH>;
++};
++
+ &pinctrl {
+ 	leds {
+ 		io_led: io-led {
+-- 
+Armbian
+

--- a/patch/kernel/rockchip-rk3588-edge/dt/rk3588-armsom-sige7.dts
+++ b/patch/kernel/rockchip-rk3588-edge/dt/rk3588-armsom-sige7.dts
@@ -165,6 +165,11 @@
 	cpu-supply = <&vdd_cpu_lit_s0>;
 };
 
+&gpu {
+	mali-supply = <&vdd_gpu_s0>;
+	status = "okay";
+};
+
 &hdmi0 {
 	status = "okay";
 };
@@ -439,6 +444,7 @@
 
 		regulators {
 			vdd_gpu_s0: vdd_gpu_mem_s0: dcdc-reg1 {
+				regulator-always-on;
 				regulator-boot-on;
 				regulator-min-microvolt = <550000>;
 				regulator-max-microvolt = <950000>;

--- a/patch/kernel/rockchip-rk3588-edge/dt/rk3588-hinlink-h88k.dts
+++ b/patch/kernel/rockchip-rk3588-edge/dt/rk3588-hinlink-h88k.dts
@@ -216,6 +216,11 @@
 	status = "okay";
 };
 
+&gpu {
+	mali-supply = <&vdd_gpu_s0>;
+	status = "okay";
+};
+
 &hdmi0 {
 	status = "okay";
 };
@@ -503,6 +508,7 @@
 
 		regulators {
 			vdd_gpu_s0: vdd_gpu_mem_s0: dcdc-reg1 {
+				regulator-always-on;
 				regulator-boot-on;
 				regulator-min-microvolt = <550000>;
 				regulator-max-microvolt = <950000>;


### PR DESCRIPTION
# Description

armsom-sige7: enable gpu
rock-5a: enable gpu, fix poweroff, enable pcie2x1 for M.2 E slot
hinlink-h88k: enable gpu

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh kernel BOARD=armsom-sige7 BRANCH=edge DEB_COMPRESS=xz`
- [x] Tested with armsom-sige7, rock-5a and hinlink-h88k

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
