### PR TITLE
cli: Update shellcheck 0.9.0 --> 0.10.0

### DIFF
--- a/lib/tools/shellcheck.sh
+++ b/lib/tools/shellcheck.sh
@@ -7,7 +7,7 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 
-SHELLCHECK_VERSION=${SHELLCHECK_VERSION:-0.9.0} # https://github.com/koalaman/shellcheck/releases
+SHELLCHECK_VERSION=${SHELLCHECK_VERSION:-0.10.0} # https://github.com/koalaman/shellcheck/releases
 
 SRC="$(
 	cd "$(dirname "$0")/../.."


### PR DESCRIPTION
# Description

Update shellcheck to version 0.10.0 which was released a few weeks ago.

# How Has This Been Tested?

- [x] `sudo lib/tools/shellcheck.sh`

Output:
```
Running shellcheck version: 0.10.0 against 308 config files, severity 'SEVERITY=error', please wait...
Congrats, no error's detected in config/sources.
Running shellcheck version: 0.10.0 against 'compile.sh' -- lib/ checks, severity 'SEVERITY=critical', please wait...
All params:  --check-sourced --color=always --external-sources --format=tty --shell=bash --severity=warning --exclude=SC2034 --exclude=SC2207 --exclude=SC2046 --exclude=SC2086 --exclude=SC2206
Congrats, no critical's detected in lib/ code.
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
