### PR TITLE
Orange Pi Zero2W (CSC) current and edge 

### DIFF
--- a/config/boards/orangepizero2w.csc
+++ b/config/boards/orangepizero2w.csc
@@ -1,0 +1,14 @@
+# Allwinner H618 quad core 1GB/1.5GB/2GB/4GB RAM
+BOARD_NAME="Orange Pi Zero2W"
+BOARDFAMILY="sun50iw9"
+BOARD_MAINTAINER="chraac"
+BOOTCONFIG="orangepi_zero2w_defconfig"
+BOOTBRANCH="tag:v2024.04"
+BOOTPATCHDIR="v2024.04"
+BOOTDIR="u-boot-${BOARD}" # do not share u-boot directory
+BOOT_LOGO="desktop"
+OVERLAY_PREFIX="sun50i-h616"
+KERNEL_TARGET="current,edge"
+FORCE_BOOTSCRIPT_UPDATE="yes"
+
+enable_extension "uwe5622-allwinner"

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-allwinner-h616-Add-efuse_xlate-cpu-frequency-scaling-v1_6_2.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-allwinner-h616-Add-efuse_xlate-cpu-frequency-scaling-v1_6_2.patch
@@ -3,19 +3,22 @@ From: AGM1968 <AGM1968@users.noreply.github.com>
 Date: Tue, 23 May 2023 16:43:00 +0000
 Subject: arm64-dts-allwinner-h616-Add-efuse_xlate-cpu-frequency-scaling-v1_6_2
  arch/arm64/boot/dts/allwinner/sun50i-h616-cpu-opp.dtsi
+ arch/arm64/boot/dts/allwinner/sun50i-h618-cpu-dvfs.dtsi
  arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts
  drivers/cpufreq/cpufreq-dt-platdev.c drivers/cpufreq/sun50i-cpufreq-nvmem.c
 
 Signed-off-by: AGM1968 <AGM1968@users.noreply.github.com>
 ---
  arch/arm64/boot/dts/allwinner/sun50i-h616-cpu-opp.dtsi       | 75 ++++++++
+ arch/arm64/boot/dts/allwinner/sun50i-h618-cpu-dvfs.dtsi      | 64 +++++++++++++
  arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero.dtsi |  1 +
  arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts |  5 +
- arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero3.dts |  5 +
+ arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero3.dts | 62 ++-----------
  drivers/cpufreq/cpufreq-dt-platdev.c                         |  2 +
  drivers/cpufreq/sun50i-cpufreq-nvmem.c                       | 92 +++++++---
- 6 files changed, 156 insertions(+), 24 deletions(-)
-
+ 7 files changed, 221 insertions(+), 80 deletions(-)
+ create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h618-cpu-dvfs.dtsi
+ 
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616-cpu-opp.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616-cpu-opp.dtsi
 new file mode 100644
 index 000000000000..36f2950367c6
@@ -125,11 +128,88 @@ index 8d8009c7f9a3..41a5a4013091 100644
  &emac0 {
  	phy-supply = <&reg_dcdce>;
  };
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h618-cpu-dvfs.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h618-cpu-dvfs.dtsi
+new file mode 100644
+index 0000000000000..0509e3fb22e26
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h618-cpu-dvfs.dtsi
+@@ -0,0 +1,64 @@
++
++
++&r_i2c {
++	status = "okay";
++
++	axp313: pmic@36 {
++		compatible = "x-powers,axp313a";
++		reg = <0x36>;
++		#interrupt-cells = <1>;
++		interrupt-controller;
++		interrupt-parent = <&pio>;
++		interrupts = <2 9 IRQ_TYPE_LEVEL_LOW>;	/* PC9 */
++
++		vin1-supply = <&reg_vcc5v>;
++		vin2-supply = <&reg_vcc5v>;
++		vin3-supply = <&reg_vcc5v>;
++
++		regulators {
++			/* Supplies VCC-PLL and DRAM */
++			reg_aldo1: aldo1 {
++				regulator-always-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "vcc1v8";
++			};
++
++			/* Supplies VCC-IO, so needs to be always on. */
++			reg_dldo1: dldo1 {
++				regulator-always-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-name = "vcc3v3";
++			};
++
++			reg_dcdc1: dcdc1 {
++				regulator-always-on;
++				regulator-min-microvolt = <810000>;
++				regulator-max-microvolt = <990000>;
++				regulator-step-delay-us = <25>;
++				regulator-final-delay-us = <50>;
++				regulator-name = "vdd-gpu-sys";
++			};
++
++			reg_dcdc2: dcdc2 {
++				regulator-always-on;
++				regulator-min-microvolt = <500000>;
++				regulator-max-microvolt = <1100000>;
++				regulator-step-delay-us = <25>;
++				regulator-final-delay-us = <50>;
++				regulator-ramp-delay = <200>;
++				regulator-name = "vdd-cpu";
++			};
++
++			reg_dcdc3: dcdc3 {
++				regulator-always-on;
++				regulator-min-microvolt = <1100000>;
++				regulator-max-microvolt = <1100000>;
++				regulator-step-delay-us = <25>;
++				regulator-final-delay-us = <50>;
++				regulator-name = "vdd-dram";
++			};
++		};
++	};
++};
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero3.dts b/arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero3.dts
 index 00fe28caac93..edbfc83f390a 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero3.dts
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero3.dts
-@@ -12,6 +12,11 @@ / {
+@@ -6,12 +6,18 @@
+ /dts-v1/;
+ 
+ #include "sun50i-h616-orangepi-zero.dtsi"
++#include "sun50i-h618-cpu-dvfs.dtsi"
+ 
+ / {
+ 	model = "OrangePi Zero3";
  	compatible = "xunlong,orangepi-zero3", "allwinner,sun50i-h618";
  };
  
@@ -141,6 +221,69 @@ index 00fe28caac93..edbfc83f390a 100644
  &emac0 {
  	phy-supply = <&reg_dldo1>;
  };
+@@ -31,62 +37,6 @@ &mmc0 {
+ 	vmmc-supply = <&reg_dldo1>;
+ };
+ 
+-&r_i2c {
+-	status = "okay";
+-
+-	axp313: pmic@36 {
+-		compatible = "x-powers,axp313a";
+-		reg = <0x36>;
+-		#interrupt-cells = <1>;
+-		interrupt-controller;
+-		interrupt-parent = <&pio>;
+-		interrupts = <2 9 IRQ_TYPE_LEVEL_LOW>;	/* PC9 */
+-
+-		vin1-supply = <&reg_vcc5v>;
+-		vin2-supply = <&reg_vcc5v>;
+-		vin3-supply = <&reg_vcc5v>;
+-
+-		regulators {
+-			/* Supplies VCC-PLL, so needs to be always on. */
+-			reg_aldo1: aldo1 {
+-				regulator-always-on;
+-				regulator-min-microvolt = <1800000>;
+-				regulator-max-microvolt = <1800000>;
+-				regulator-name = "vcc1v8";
+-			};
+-
+-			/* Supplies VCC-IO, so needs to be always on. */
+-			reg_dldo1: dldo1 {
+-				regulator-always-on;
+-				regulator-min-microvolt = <3300000>;
+-				regulator-max-microvolt = <3300000>;
+-				regulator-name = "vcc3v3";
+-			};
+-
+-			reg_dcdc1: dcdc1 {
+-				regulator-always-on;
+-				regulator-min-microvolt = <810000>;
+-				regulator-max-microvolt = <990000>;
+-				regulator-name = "vdd-gpu-sys";
+-			};
+-
+-			reg_dcdc2: dcdc2 {
+-				regulator-always-on;
+-				regulator-min-microvolt = <810000>;
+-				regulator-max-microvolt = <1100000>;
+-				regulator-name = "vdd-cpu";
+-			};
+-
+-			reg_dcdc3: dcdc3 {
+-				regulator-always-on;
+-				regulator-min-microvolt = <1100000>;
+-				regulator-max-microvolt = <1100000>;
+-				regulator-name = "vdd-dram";
+-			};
+-		};
+-	};
+-};
+-
+ &pio {
+ 	vcc-pc-supply = <&reg_dldo1>;
+ 	vcc-pf-supply = <&reg_dldo1>;
 diff --git a/drivers/cpufreq/cpufreq-dt-platdev.c b/drivers/cpufreq/cpufreq-dt-platdev.c
 index fb2875ce1fdd..e63d36839769 100644
 --- a/drivers/cpufreq/cpufreq-dt-platdev.c

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-sun50i-h618-add-overlay.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-sun50i-h618-add-overlay.patch
@@ -1,0 +1,214 @@
+From cb5d17d4fcca040e7af10457008e5199dc35cc03 Mon Sep 17 00:00:00 2001
+From: chraac <chraac@gmail.com>
+Date: Fri, 5 Apr 2024 10:57:18 +0800
+Subject: add dtb overlay for zero2w
+
+---
+ .../arm64/boot/dts/allwinner/overlay/Makefile | 16 ++++++++-----
+ .../allwinner/overlay/sun50i-h616-gpu.dtso    | 14 +++++++++++
+ .../overlay/sun50i-h616-i2c0-pi.dtso          | 23 +++++++++++++++++++
+ .../overlay/sun50i-h616-i2c1-pi.dtso          | 16 +++++++++++++
+ ...616-i2c2.dtso => sun50i-h616-i2c2-ph.dtso} |  0
+ .../overlay/sun50i-h616-i2c2-pi.dtso          | 23 +++++++++++++++++++
+ ...616-i2c3.dtso => sun50i-h616-i2c3-ph.dtso} |  0
+ ...616-i2c4.dtso => sun50i-h616-i2c4-ph.dtso} |  0
+ ...6-uart2.dtso => sun50i-h616-uart2-ph.dtso} |  0
+ ...6-uart5.dtso => sun50i-h616-uart5-ph.dtso} |  0
+ .../allwinner/sun50i-h618-orangepi-zero2w.dts | 12 ----------
+ 11 files changed, 86 insertions(+), 18 deletions(-)
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-gpu.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c0-pi.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c1-pi.dtso
+ rename arch/arm64/boot/dts/allwinner/overlay/{sun50i-h616-i2c2.dtso => sun50i-h616-i2c2-ph.dtso} (100%)
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c2-pi.dtso
+ rename arch/arm64/boot/dts/allwinner/overlay/{sun50i-h616-i2c3.dtso => sun50i-h616-i2c3-ph.dtso} (100%)
+ rename arch/arm64/boot/dts/allwinner/overlay/{sun50i-h616-i2c4.dtso => sun50i-h616-i2c4-ph.dtso} (100%)
+ rename arch/arm64/boot/dts/allwinner/overlay/{sun50i-h616-uart2.dtso => sun50i-h616-uart2-ph.dtso} (100%)
+ rename arch/arm64/boot/dts/allwinner/overlay/{sun50i-h616-uart5.dtso => sun50i-h616-uart5-ph.dtso} (100%)
+
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/Makefile b/arch/arm64/boot/dts/allwinner/overlay/Makefile
+index 369b2976b1bba..24383cb63770e 100644
+--- a/arch/arm64/boot/dts/allwinner/overlay/Makefile
++++ b/arch/arm64/boot/dts/allwinner/overlay/Makefile
+@@ -49,11 +49,11 @@ dtb-$(CONFIG_ARCH_SUNXI) += \
+ 	sun50i-h6-uart2.dtbo \
+ 	sun50i-h6-uart3.dtbo \
+ 	sun50i-h6-w1-gpio.dtbo \
+-	sun50i-h616-i2c2.dtbo \
+-	sun50i-h616-i2c3.dtbo \
+-	sun50i-h616-i2c4.dtbo \
+-	sun50i-h616-uart2.dtbo \
+-	sun50i-h616-uart5.dtbo \
++	sun50i-h616-i2c2-ph.dtbo \
++	sun50i-h616-i2c3-ph.dtbo \
++	sun50i-h616-i2c4-ph.dtbo \
++	sun50i-h616-uart2-ph.dtbo \
++	sun50i-h616-uart5-ph.dtbo \
+ 	sun50i-h616-spi-spidev.dtbo \
+ 	sun50i-h616-spidev0_0.dtbo \
+ 	sun50i-h616-spidev1_0.dtbo \
+@@ -63,7 +63,11 @@ dtb-$(CONFIG_ARCH_SUNXI) += \
+ 	sun50i-h616-tft35_spi.dtbo \
+ 	sun50i-h616-mcp2515.dtbo \
+ 	sun50i-h616-ws2812.dtbo \
+-	sun50i-h616-light.dtbo
++	sun50i-h616-light.dtbo \
++	sun50i-h616-i2c0-pi.dtbo \
++	sun50i-h616-i2c1-pi.dtbo \
++	sun50i-h616-i2c2-pi.dtbo \
++	sun50i-h616-gpu.dtbo
+ 
+ scr-$(CONFIG_ARCH_SUNXI) += \
+ 	sun50i-a64-fixup.scr \
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-gpu.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-gpu.dtso
+new file mode 100644
+index 0000000000000..ac8846ac7d274
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-gpu.dtso
+@@ -0,0 +1,14 @@
++/dts-v1/;
++/plugin/;
++
++
++/ {
++	compatible = "allwinner,sun50i-h616";
++
++	fragment@0 {
++		target = <&gpu>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c0-pi.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c0-pi.dtso
+new file mode 100644
+index 0000000000000..b5003934c895c
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c0-pi.dtso
+@@ -0,0 +1,23 @@
++/dts-v1/;
++/plugin/;
++
++
++/ {
++	compatible = "allwinner,sun50i-h616";
++
++	fragment@0 {
++		target = <&i2c0>;
++		__overlay__ {
++			pinctrl-names = "default";
++			pinctrl-0 = <&i2c0_pi_pins>;
++			status = "okay";
++		};
++	};
++
++	fragment@1 {
++		target = <&uart2>;
++		__overlay__ {
++			status = "disabled";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c1-pi.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c1-pi.dtso
+new file mode 100644
+index 0000000000000..05f3100967ff1
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c1-pi.dtso
+@@ -0,0 +1,16 @@
++/dts-v1/;
++/plugin/;
++
++
++/ {
++	compatible = "allwinner,sun50i-h616";
++
++	fragment@0 {
++		target = <&i2c1>;
++		__overlay__ {
++			pinctrl-names = "default";
++			pinctrl-0 = <&i2c1_pi_pins>;
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c2.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c2-ph.dtso
+similarity index 100%
+rename from arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c2.dtso
+rename to arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c2-ph.dtso
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c2-pi.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c2-pi.dtso
+new file mode 100644
+index 0000000000000..0f7d7e9968d6c
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c2-pi.dtso
+@@ -0,0 +1,23 @@
++/dts-v1/;
++/plugin/;
++
++
++/ {
++	compatible = "allwinner,sun50i-h616";
++
++	fragment@0 {
++		target = <&i2c2>;
++		__overlay__ {
++			pinctrl-names = "default";
++			pinctrl-0 = <&i2c2_pi_pins>;
++			status = "okay";
++		};
++	};
++
++	fragment@1 {
++		target = <&uart3>;
++		__overlay__ {
++			status = "disabled";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c3.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c3-ph.dtso
+similarity index 100%
+rename from arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c3.dtso
+rename to arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c3-ph.dtso
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c4.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c4-ph.dtso
+similarity index 100%
+rename from arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c4.dtso
+rename to arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c4-ph.dtso
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-uart2.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-uart2-ph.dtso
+similarity index 100%
+rename from arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-uart2.dtso
+rename to arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-uart2-ph.dtso
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-uart5.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-uart5-ph.dtso
+similarity index 100%
+rename from arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-uart5.dtso
+rename to arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-uart5-ph.dtso
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dts b/arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dts
+index c09cc24a8b279..436896936fb3b 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dts
+@@ -280,12 +280,6 @@ &uart4 {
+ 	status = "disabled";
+ };
+ 
+-&uart5 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&uart5_ph_pins>;
+-	status = "disabled";
+-};
+-
+ &i2c3 {
+ 	status = "okay";
+ 	pinctrl-names = "default";
+@@ -415,12 +409,6 @@ uart4_pi_pins: uart4-pi-pins {
+ 		function = "uart4";
+ 	};
+ 
+-	/omit-if-no-ref/
+-	uart5_ph_pins: uart5-ph-pins {
+-		pins = "PH2", "PH3";
+-		function = "uart5";
+-	};
+-
+ 	/omit-if-no-ref/
+ 	spi1_cs1_pin: spi1-cs1-pin {
+ 		pins = "PH9";
+-- 
+GitLab

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-sun50i-h618-orangepi-zero2w-add-dtb.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-sun50i-h618-orangepi-zero2w-add-dtb.patch
@@ -1,0 +1,474 @@
+From 09a088f5c8e28c394a74730481adf9cec434fc93 Mon Sep 17 00:00:00 2001
+From: chraac <chraac@gmail.com>
+Date: Fri, 15 Mar 2024 12:30:26 +0800
+Subject: [PATCH] orangepi-zero2w add dtb
+
+update zero2w dts
+
+udpate zero2w dts from linux kernel 6.8+
+
+add log for thermal zone
+
+reference the sun50i-h618-cpu-dvfs.dtsi in zero2w
+
+remove i2c bind
+---
+ arch/arm64/boot/dts/allwinner/Makefile        |   1 +
+ .../allwinner/sun50i-h618-orangepi-zero2w.dts | 435 ++++++++++++++++++
+ 2 files changed, 436 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dts
+
+diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
+index 8b504ee408e78..a957365edc1aa 100644
+--- a/arch/arm64/boot/dts/allwinner/Makefile
++++ b/arch/arm64/boot/dts/allwinner/Makefile
+@@ -56,5 +56,6 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-sd.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-emmc.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-bananapi-m4-zero.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-orangepi-zero3.dtb
++dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-orangepi-zero2w.dtb
+ 
+ subdir-y	:= $(dts-dirs) overlay
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dts b/arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dts
+new file mode 100644
+index 0000000000000..c09cc24a8b279
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dts
+@@ -0,0 +1,435 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (C) 2023 Arm Ltd.
++ */
++
++/dts-v1/;
++
++#include "sun50i-h616.dtsi"
++#include "sun50i-h616-cpu-opp.dtsi"
++#include "sun50i-h618-cpu-dvfs.dtsi"
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/interrupt-controller/arm-gic.h>
++#include <dt-bindings/leds/common.h>
++
++/ {
++	model = "OrangePi Zero 2W";
++	compatible = "xunlong,orangepi-zero2w", "allwinner,sun50i-h618";
++
++	aliases {
++		serial0 = &uart0;
++		serial2 = &uart2;
++		serial3 = &uart3;
++		serial4 = &uart4;
++		serial5 = &uart5;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	connector {
++		compatible = "hdmi-connector";
++		type = "d";
++
++		port {
++			hdmi_con_in: endpoint {
++				remote-endpoint = <&hdmi_out_con>;
++			};
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led-0 {
++			function = LED_FUNCTION_STATUS;
++			color = <LED_COLOR_ID_GREEN>;
++			label = "green_led";
++			gpios = <&pio 2 13 GPIO_ACTIVE_HIGH>; /* PC13 */
++			linux,default-trigger = "heartbeat";
++		};
++
++		100m_link {
++			label = "100m_link";
++			gpios = <&pio 2 15 GPIO_ACTIVE_HIGH>; /* PC15 */
++			default-state = "off";
++		};
++
++		100m_act {
++			label = "100m_act";
++			gpios = <&pio 2 16 GPIO_ACTIVE_HIGH>; /* PC16 */
++			default-state = "off";
++		};
++	};
++
++	reg_vcc5v: vcc5v {
++		/* board wide 5V supply directly from the USB-C socket */
++		compatible = "regulator-fixed";
++		regulator-name = "vcc-5v";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		regulator-always-on;
++	};
++
++	reg_vcc3v3: vcc3v3 {
++		/* SY8089 DC/DC converter */
++		compatible = "regulator-fixed";
++		regulator-name = "vcc-3v3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&reg_vcc5v>;
++		regulator-always-on;
++	};
++
++	reg_vcc_wifi_io: vcc-wifi-io {
++		/* Always on 1.8V/300mA regulator for WiFi and BT IO */
++		compatible = "regulator-fixed";
++		regulator-name = "vcc-wifi-io";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		regulator-always-on;
++		vin-supply = <&reg_vcc3v3>;
++	};
++
++	wifi_pwrseq: wifi-pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		clocks = <&rtc 1>;
++		clock-names = "osc32k-out";
++		reset-gpios = <&pio 6 18 GPIO_ACTIVE_LOW>; /* PG18 */
++		post-power-on-delay-ms = <200>;
++	};
++
++	ac200_pwm_clk: ac200_clk {
++		compatible = "pwm-clock";
++		#clock-cells = <0>;
++		// pwm5 period_ns = 500 > 334 for select 24M clock.
++		pwms = <&pwm 5 500 0>;
++		clock-frequency = <2000000>;
++		status = "okay";
++	};
++
++	soc {
++		pwm: pwm@300a000 {
++			compatible = "allwinner,sun50i-h616-pwm";
++			reg = <0x0300a000 0x400>;
++			clocks = <&osc24M>, <&ccu CLK_BUS_PWM>;
++			clock-names = "mod", "bus";
++			resets = <&ccu RST_BUS_PWM>;
++			pwm-number = <6>;
++			pwm-base = <0x0>;
++			sunxi-pwms = <&pwm5>;
++			#pwm-cells = <3>;
++			status = "okay";
++		};
++
++		pwm5: pwm5@0300a000 {
++			compatible = "allwinner,sunxi-pwm5";
++			pinctrl-names = "default";
++			pinctrl-0 = <&pwm5_pin>;
++			clk_bypass_output = <0x1>;
++			status = "okay";
++		};
++	};
++};
++
++&de {
++	status = "okay";
++};
++
++&hdmi {
++	status = "okay";
++};
++
++&hdmi_out {
++	hdmi_out_con: endpoint {
++		remote-endpoint = <&hdmi_con_in>;
++	};
++};
++
++&gpu {
++	mali-supply = <&reg_dcdc1>;
++	status = "disabled";
++};
++
++&mmc0 {
++	cd-gpios = <&pio 5 6 GPIO_ACTIVE_LOW>;	/* PF6 */
++	bus-width = <4>;
++	vmmc-supply = <&reg_dldo1>;
++	max-frequency = <50000000>;
++	status = "okay";
++};
++
++&mmc1 {
++	vmmc-supply = <&reg_vcc3v3>;
++	vqmmc-supply = <&reg_vcc_wifi_io>;
++	mmc-pwrseq = <&wifi_pwrseq>;
++	bus-width = <4>;
++	non-removable;
++	mmc-ddr-1_8v;
++	status = "okay";
++};
++
++&emac0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&ext_rgmii_pins>;
++	phy-handle = <&ext_rgmii_phy>;
++	allwinner,tx-delay-ps = <700>;
++	phy-mode = "rgmii-rxid";
++	phy-supply = <&reg_dldo1>;
++	status = "okay";
++};
++
++&mdio0 {
++	ext_rgmii_phy: ethernet-phy@1 {
++		compatible = "ethernet-phy-ieee802.3-c22";
++		motorcomm,clk-out-frequency-hz = <125000000>;
++		reg = <1>;
++	};
++};
++
++&ehci0 {
++	status = "disabled";
++};
++
++&ehci1 {
++	status = "okay";
++};
++
++&ehci2 {
++	status = "okay";
++};
++
++&ehci3 {
++	status = "okay";
++};
++
++&ohci0 {
++	status = "disabled";
++};
++
++&ohci1 {
++	status = "okay";
++};
++
++&ohci2 {
++	status = "okay";
++};
++
++&ohci3 {
++	status = "okay";
++};
++
++&ir {
++	pinctrl-names = "default";
++	pinctrl-0 = <&ir_rx_pin>;
++	status = "okay";
++};
++
++&spi0  {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi0_pins>, <&spi0_cs0_pin>;
++
++	flash@0 {
++		#address-cells = <1>;
++		#size-cells = <1>;
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <40000000>;
++	};
++};
++
++&spi1 {
++	status = "disabled";
++	#address-cells = <1>;
++	#size-cells = <0>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi1_pins>, <&spi1_cs1_pin>;
++
++	spidev@1 {
++		compatible = "rohm,dh2228fv";
++		status = "disabled";
++		reg = <1>;
++		spi-max-frequency = <1000000>;
++	};
++};
++
++&uart0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart0_ph_pins>;
++	status = "okay";
++};
++
++&uart2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart2_pi_pins>;
++	status = "disabled";
++};
++
++&uart3 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart3_pi_pins>;
++	status = "disabled";
++};
++
++&uart4 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart4_pi_pins>;
++	status = "disabled";
++};
++
++&uart5 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart5_ph_pins>;
++	status = "disabled";
++};
++
++&i2c3 {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c3_pa_pins>;
++
++	ac200_x: mfd@10 {
++		compatible = "x-powers,ac200";
++		reg = <0x10>;
++		clocks = <&ac200_pwm_clk>;
++		// ephy id
++		nvmem-cells = <&ephy_calibration>;
++		nvmem-cell-names = "calibration";
++
++		ac200_ephy: phy {
++			compatible = "x-powers,ac200-ephy";
++			status = "okay";
++		};
++	};
++};
++
++&i2c4 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c4_ph_pins>;
++	status = "disabled";
++};
++
++&usbotg {
++	/*
++	 * PHY0 pins are connected to a USB-C socket, but a role switch
++	 * is not implemented: both CC pins are pulled to GND.
++	 * The VBUS pins power the device, so a fixed peripheral mode
++	 * is the best choice.
++	 * The board can be powered via GPIOs, in this case port0 *can*
++	 * act as a host (with a cable/adapter ignoring CC), as VBUS is
++	 * then provided by the GPIOs. Any user of this setup would
++	 * need to adjust the DT accordingly: dr_mode set to "host",
++	 * enabling OHCI0 and EHCI0.
++	 */
++	dr_mode = "peripheral";
++	status = "okay";
++};
++
++&usbphy {
++	usb1_vbus-supply = <&reg_vcc5v>;
++	status = "okay";
++};
++
++&cpu0 {
++	cpu-supply = <&reg_dcdc2>;
++	status = "okay";
++};
++
++&sid {
++	ephy_calibration: ephy-calibration@2c {
++		reg = <0x2c 0x2>;
++	};
++};
++
++&cpu_temp_critical {
++	temperature = <100000>;
++};
++
++&gpu_temp_critical {
++	temperature = <100000>;
++};
++
++&ve_temp_critical {
++	temperature = <100000>;
++};
++
++&ddr_temp_critical {
++	temperature = <100000>;
++};
++
++&pio {
++	vcc-pc-supply = <&reg_dldo1>;
++	vcc-pf-supply = <&reg_dldo1>;
++	vcc-pg-supply = <&reg_aldo1>;
++	vcc-ph-supply = <&reg_dldo1>;
++	vcc-pi-supply = <&reg_dldo1>;
++
++	/omit-if-no-ref/
++	i2c0_pi_pins: i2c0-pi-pins {
++		pins = "PI5", "PI6";
++		function = "i2c0";
++	};
++
++	/omit-if-no-ref/
++	i2c1_pi_pins: i2c1-pi-pins {
++		pins = "PI7", "PI8";
++		function = "i2c1";
++	};
++
++	/omit-if-no-ref/
++	i2c2_pi_pins: i2c2-pi-pins {
++		pins = "PI9", "PI10";
++		function = "i2c2";
++	};
++
++    i2c3_pa_pins: i2c3-pa-pins {
++        pins = "PA10", "PA11";
++        function = "i2c3";
++        bias-pull-up;
++    };
++
++	/omit-if-no-ref/
++	i2c4_ph_pins: i2c4-ph-pins {
++		pins = "PH6", "PH7";
++		function = "i2c4";
++	};
++
++	/omit-if-no-ref/
++	uart2_pi_pins: uart2-pi-pins {
++		pins = "PI5", "PI6";
++		function = "uart2";
++	};
++
++	/omit-if-no-ref/
++	uart3_pi_pins: uart3-pi-pins {
++		pins = "PI9", "PI10";
++		function = "uart3";
++	};
++
++	/omit-if-no-ref/
++	uart4_pi_pins: uart4-pi-pins {
++		pins = "PI13", "PI14";
++		function = "uart4";
++	};
++
++	/omit-if-no-ref/
++	uart5_ph_pins: uart5-ph-pins {
++		pins = "PH2", "PH3";
++		function = "uart5";
++	};
++
++	/omit-if-no-ref/
++	spi1_cs1_pin: spi1-cs1-pin {
++		pins = "PH9";
++		function = "spi1";
++	};
++
++	/omit-if-no-ref/
++	pwm5_pin: pwm5-pin {
++		pins = "PA12";
++		function = "pwm5";
++	};
++};
+-- 
+GitLab

--- a/patch/kernel/archive/sunxi-6.6/series.armbian
+++ b/patch/kernel/archive/sunxi-6.6/series.armbian
@@ -197,5 +197,7 @@
 	patches.armbian/arm64-dts-h616-add-hdmi-support-for-zero2-and-zero3.patch
 	patches.armbian/arm64-dts-sun50i-h616-Add-dma-node.patch
 	patches.armbian/arm64-dts-H616-Add-overlays-that-are-also-compatible-with.patch
+	patches.armbian/arm64-dts-sun50i-h618-orangepi-zero2w-add-dtb.patch
 	patches.armbian/arm64-dts-allwinner-sun50i-h616-PG-12c-pins.patch
 	patches.armbian/arm64-dts-allwinner-sun50i-h616-spi1-cs1-pin.patch
+	patches.armbian/arm64-dts-sun50i-h618-add-overlay.patch

--- a/patch/kernel/archive/sunxi-6.6/series.conf
+++ b/patch/kernel/archive/sunxi-6.6/series.conf
@@ -466,5 +466,7 @@
 	patches.armbian/arm64-dts-h616-add-hdmi-support-for-zero2-and-zero3.patch
 	patches.armbian/arm64-dts-sun50i-h616-Add-dma-node.patch
 	patches.armbian/arm64-dts-H616-Add-overlays-that-are-also-compatible-with.patch
+	patches.armbian/arm64-dts-sun50i-h618-orangepi-zero2w-add-dtb.patch
 	patches.armbian/arm64-dts-allwinner-sun50i-h616-PG-12c-pins.patch
 	patches.armbian/arm64-dts-allwinner-sun50i-h616-spi1-cs1-pin.patch
+	patches.armbian/arm64-dts-sun50i-h618-add-overlay.patch

--- a/patch/kernel/archive/sunxi-6.7/patches.armbian/arm64-dts-allwinner-h616-Add-efuse_xlate-cpu-frequency-scaling-v1_6_2.patch
+++ b/patch/kernel/archive/sunxi-6.7/patches.armbian/arm64-dts-allwinner-h616-Add-efuse_xlate-cpu-frequency-scaling-v1_6_2.patch
@@ -3,19 +3,22 @@ From: AGM1968 <AGM1968@users.noreply.github.com>
 Date: Tue, 23 May 2023 16:43:00 +0000
 Subject: arm64-dts-allwinner-h616-Add-efuse_xlate-cpu-frequency-scaling-v1_6_2
  arch/arm64/boot/dts/allwinner/sun50i-h616-cpu-opp.dtsi
+ arch/arm64/boot/dts/allwinner/sun50i-h618-cpu-dvfs.dtsi
  arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts
  drivers/cpufreq/cpufreq-dt-platdev.c drivers/cpufreq/sun50i-cpufreq-nvmem.c
 
 Signed-off-by: AGM1968 <AGM1968@users.noreply.github.com>
 ---
  arch/arm64/boot/dts/allwinner/sun50i-h616-cpu-opp.dtsi       | 75 ++++++++
+ arch/arm64/boot/dts/allwinner/sun50i-h618-cpu-dvfs.dtsi      | 64 +++++++++++++
  arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero.dtsi |  1 +
  arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts |  5 +
- arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero3.dts |  5 +
+ arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero3.dts | 62 ++-----------
  drivers/cpufreq/cpufreq-dt-platdev.c                         |  2 +
  drivers/cpufreq/sun50i-cpufreq-nvmem.c                       | 92 +++++++---
- 6 files changed, 156 insertions(+), 24 deletions(-)
-
+ 7 files changed, 221 insertions(+), 80 deletions(-)
+ create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h618-cpu-dvfs.dtsi
+ 
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616-cpu-opp.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616-cpu-opp.dtsi
 new file mode 100644
 index 000000000000..36f2950367c6
@@ -125,11 +128,88 @@ index 8d8009c7f9a3..41a5a4013091 100644
  &emac0 {
  	phy-supply = <&reg_dcdce>;
  };
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h618-cpu-dvfs.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h618-cpu-dvfs.dtsi
+new file mode 100644
+index 0000000000000..0509e3fb22e26
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h618-cpu-dvfs.dtsi
+@@ -0,0 +1,64 @@
++
++
++&r_i2c {
++	status = "okay";
++
++	axp313: pmic@36 {
++		compatible = "x-powers,axp313a";
++		reg = <0x36>;
++		#interrupt-cells = <1>;
++		interrupt-controller;
++		interrupt-parent = <&pio>;
++		interrupts = <2 9 IRQ_TYPE_LEVEL_LOW>;	/* PC9 */
++
++		vin1-supply = <&reg_vcc5v>;
++		vin2-supply = <&reg_vcc5v>;
++		vin3-supply = <&reg_vcc5v>;
++
++		regulators {
++			/* Supplies VCC-PLL and DRAM */
++			reg_aldo1: aldo1 {
++				regulator-always-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "vcc1v8";
++			};
++
++			/* Supplies VCC-IO, so needs to be always on. */
++			reg_dldo1: dldo1 {
++				regulator-always-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-name = "vcc3v3";
++			};
++
++			reg_dcdc1: dcdc1 {
++				regulator-always-on;
++				regulator-min-microvolt = <810000>;
++				regulator-max-microvolt = <990000>;
++				regulator-step-delay-us = <25>;
++				regulator-final-delay-us = <50>;
++				regulator-name = "vdd-gpu-sys";
++			};
++
++			reg_dcdc2: dcdc2 {
++				regulator-always-on;
++				regulator-min-microvolt = <500000>;
++				regulator-max-microvolt = <1100000>;
++				regulator-step-delay-us = <25>;
++				regulator-final-delay-us = <50>;
++				regulator-ramp-delay = <200>;
++				regulator-name = "vdd-cpu";
++			};
++
++			reg_dcdc3: dcdc3 {
++				regulator-always-on;
++				regulator-min-microvolt = <1100000>;
++				regulator-max-microvolt = <1100000>;
++				regulator-step-delay-us = <25>;
++				regulator-final-delay-us = <50>;
++				regulator-name = "vdd-dram";
++			};
++		};
++	};
++};
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero3.dts b/arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero3.dts
 index 00fe28caac93..edbfc83f390a 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero3.dts
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero3.dts
-@@ -12,6 +12,11 @@ / {
+@@ -6,12 +6,18 @@
+ /dts-v1/;
+ 
+ #include "sun50i-h616-orangepi-zero.dtsi"
++#include "sun50i-h618-cpu-dvfs.dtsi"
+ 
+ / {
+ 	model = "OrangePi Zero3";
  	compatible = "xunlong,orangepi-zero3", "allwinner,sun50i-h618";
  };
  
@@ -141,6 +221,69 @@ index 00fe28caac93..edbfc83f390a 100644
  &emac0 {
  	phy-supply = <&reg_dldo1>;
  };
+@@ -31,62 +37,6 @@ &mmc0 {
+ 	vmmc-supply = <&reg_dldo1>;
+ };
+ 
+-&r_i2c {
+-	status = "okay";
+-
+-	axp313: pmic@36 {
+-		compatible = "x-powers,axp313a";
+-		reg = <0x36>;
+-		#interrupt-cells = <1>;
+-		interrupt-controller;
+-		interrupt-parent = <&pio>;
+-		interrupts = <2 9 IRQ_TYPE_LEVEL_LOW>;	/* PC9 */
+-
+-		vin1-supply = <&reg_vcc5v>;
+-		vin2-supply = <&reg_vcc5v>;
+-		vin3-supply = <&reg_vcc5v>;
+-
+-		regulators {
+-			/* Supplies VCC-PLL, so needs to be always on. */
+-			reg_aldo1: aldo1 {
+-				regulator-always-on;
+-				regulator-min-microvolt = <1800000>;
+-				regulator-max-microvolt = <1800000>;
+-				regulator-name = "vcc1v8";
+-			};
+-
+-			/* Supplies VCC-IO, so needs to be always on. */
+-			reg_dldo1: dldo1 {
+-				regulator-always-on;
+-				regulator-min-microvolt = <3300000>;
+-				regulator-max-microvolt = <3300000>;
+-				regulator-name = "vcc3v3";
+-			};
+-
+-			reg_dcdc1: dcdc1 {
+-				regulator-always-on;
+-				regulator-min-microvolt = <810000>;
+-				regulator-max-microvolt = <990000>;
+-				regulator-name = "vdd-gpu-sys";
+-			};
+-
+-			reg_dcdc2: dcdc2 {
+-				regulator-always-on;
+-				regulator-min-microvolt = <810000>;
+-				regulator-max-microvolt = <1100000>;
+-				regulator-name = "vdd-cpu";
+-			};
+-
+-			reg_dcdc3: dcdc3 {
+-				regulator-always-on;
+-				regulator-min-microvolt = <1100000>;
+-				regulator-max-microvolt = <1100000>;
+-				regulator-name = "vdd-dram";
+-			};
+-		};
+-	};
+-};
+-
+ &pio {
+ 	vcc-pc-supply = <&reg_dldo1>;
+ 	vcc-pf-supply = <&reg_dldo1>;
 diff --git a/drivers/cpufreq/cpufreq-dt-platdev.c b/drivers/cpufreq/cpufreq-dt-platdev.c
 index fb2875ce1fdd..e63d36839769 100644
 --- a/drivers/cpufreq/cpufreq-dt-platdev.c

--- a/patch/kernel/archive/sunxi-6.7/patches.armbian/arm64-dts-sun50i-h618-add-overlay.patch
+++ b/patch/kernel/archive/sunxi-6.7/patches.armbian/arm64-dts-sun50i-h618-add-overlay.patch
@@ -1,0 +1,214 @@
+From cb5d17d4fcca040e7af10457008e5199dc35cc03 Mon Sep 17 00:00:00 2001
+From: chraac <chraac@gmail.com>
+Date: Fri, 5 Apr 2024 10:57:18 +0800
+Subject: add dtb overlay for zero2w
+
+---
+ .../arm64/boot/dts/allwinner/overlay/Makefile | 16 ++++++++-----
+ .../allwinner/overlay/sun50i-h616-gpu.dtso    | 14 +++++++++++
+ .../overlay/sun50i-h616-i2c0-pi.dtso          | 23 +++++++++++++++++++
+ .../overlay/sun50i-h616-i2c1-pi.dtso          | 16 +++++++++++++
+ ...616-i2c2.dtso => sun50i-h616-i2c2-ph.dtso} |  0
+ .../overlay/sun50i-h616-i2c2-pi.dtso          | 23 +++++++++++++++++++
+ ...616-i2c3.dtso => sun50i-h616-i2c3-ph.dtso} |  0
+ ...616-i2c4.dtso => sun50i-h616-i2c4-ph.dtso} |  0
+ ...6-uart2.dtso => sun50i-h616-uart2-ph.dtso} |  0
+ ...6-uart5.dtso => sun50i-h616-uart5-ph.dtso} |  0
+ .../allwinner/sun50i-h618-orangepi-zero2w.dts | 12 ----------
+ 11 files changed, 86 insertions(+), 18 deletions(-)
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-gpu.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c0-pi.dtso
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c1-pi.dtso
+ rename arch/arm64/boot/dts/allwinner/overlay/{sun50i-h616-i2c2.dtso => sun50i-h616-i2c2-ph.dtso} (100%)
+ create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c2-pi.dtso
+ rename arch/arm64/boot/dts/allwinner/overlay/{sun50i-h616-i2c3.dtso => sun50i-h616-i2c3-ph.dtso} (100%)
+ rename arch/arm64/boot/dts/allwinner/overlay/{sun50i-h616-i2c4.dtso => sun50i-h616-i2c4-ph.dtso} (100%)
+ rename arch/arm64/boot/dts/allwinner/overlay/{sun50i-h616-uart2.dtso => sun50i-h616-uart2-ph.dtso} (100%)
+ rename arch/arm64/boot/dts/allwinner/overlay/{sun50i-h616-uart5.dtso => sun50i-h616-uart5-ph.dtso} (100%)
+
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/Makefile b/arch/arm64/boot/dts/allwinner/overlay/Makefile
+index 369b2976b1bba..24383cb63770e 100644
+--- a/arch/arm64/boot/dts/allwinner/overlay/Makefile
++++ b/arch/arm64/boot/dts/allwinner/overlay/Makefile
+@@ -49,11 +49,11 @@ dtb-$(CONFIG_ARCH_SUNXI) += \
+ 	sun50i-h6-uart2.dtbo \
+ 	sun50i-h6-uart3.dtbo \
+ 	sun50i-h6-w1-gpio.dtbo \
+-	sun50i-h616-i2c2.dtbo \
+-	sun50i-h616-i2c3.dtbo \
+-	sun50i-h616-i2c4.dtbo \
+-	sun50i-h616-uart2.dtbo \
+-	sun50i-h616-uart5.dtbo \
++	sun50i-h616-i2c2-ph.dtbo \
++	sun50i-h616-i2c3-ph.dtbo \
++	sun50i-h616-i2c4-ph.dtbo \
++	sun50i-h616-uart2-ph.dtbo \
++	sun50i-h616-uart5-ph.dtbo \
+ 	sun50i-h616-spi-spidev.dtbo \
+ 	sun50i-h616-spidev0_0.dtbo \
+ 	sun50i-h616-spidev1_0.dtbo \
+@@ -63,7 +63,11 @@ dtb-$(CONFIG_ARCH_SUNXI) += \
+ 	sun50i-h616-tft35_spi.dtbo \
+ 	sun50i-h616-mcp2515.dtbo \
+ 	sun50i-h616-ws2812.dtbo \
+-	sun50i-h616-light.dtbo
++	sun50i-h616-light.dtbo \
++	sun50i-h616-i2c0-pi.dtbo \
++	sun50i-h616-i2c1-pi.dtbo \
++	sun50i-h616-i2c2-pi.dtbo \
++	sun50i-h616-gpu.dtbo
+ 
+ scr-$(CONFIG_ARCH_SUNXI) += \
+ 	sun50i-a64-fixup.scr \
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-gpu.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-gpu.dtso
+new file mode 100644
+index 0000000000000..ac8846ac7d274
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-gpu.dtso
+@@ -0,0 +1,14 @@
++/dts-v1/;
++/plugin/;
++
++
++/ {
++	compatible = "allwinner,sun50i-h616";
++
++	fragment@0 {
++		target = <&gpu>;
++		__overlay__ {
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c0-pi.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c0-pi.dtso
+new file mode 100644
+index 0000000000000..b5003934c895c
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c0-pi.dtso
+@@ -0,0 +1,23 @@
++/dts-v1/;
++/plugin/;
++
++
++/ {
++	compatible = "allwinner,sun50i-h616";
++
++	fragment@0 {
++		target = <&i2c0>;
++		__overlay__ {
++			pinctrl-names = "default";
++			pinctrl-0 = <&i2c0_pi_pins>;
++			status = "okay";
++		};
++	};
++
++	fragment@1 {
++		target = <&uart2>;
++		__overlay__ {
++			status = "disabled";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c1-pi.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c1-pi.dtso
+new file mode 100644
+index 0000000000000..05f3100967ff1
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c1-pi.dtso
+@@ -0,0 +1,16 @@
++/dts-v1/;
++/plugin/;
++
++
++/ {
++	compatible = "allwinner,sun50i-h616";
++
++	fragment@0 {
++		target = <&i2c1>;
++		__overlay__ {
++			pinctrl-names = "default";
++			pinctrl-0 = <&i2c1_pi_pins>;
++			status = "okay";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c2.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c2-ph.dtso
+similarity index 100%
+rename from arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c2.dtso
+rename to arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c2-ph.dtso
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c2-pi.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c2-pi.dtso
+new file mode 100644
+index 0000000000000..0f7d7e9968d6c
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c2-pi.dtso
+@@ -0,0 +1,23 @@
++/dts-v1/;
++/plugin/;
++
++
++/ {
++	compatible = "allwinner,sun50i-h616";
++
++	fragment@0 {
++		target = <&i2c2>;
++		__overlay__ {
++			pinctrl-names = "default";
++			pinctrl-0 = <&i2c2_pi_pins>;
++			status = "okay";
++		};
++	};
++
++	fragment@1 {
++		target = <&uart3>;
++		__overlay__ {
++			status = "disabled";
++		};
++	};
++};
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c3.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c3-ph.dtso
+similarity index 100%
+rename from arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c3.dtso
+rename to arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c3-ph.dtso
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c4.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c4-ph.dtso
+similarity index 100%
+rename from arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c4.dtso
+rename to arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-i2c4-ph.dtso
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-uart2.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-uart2-ph.dtso
+similarity index 100%
+rename from arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-uart2.dtso
+rename to arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-uart2-ph.dtso
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-uart5.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-uart5-ph.dtso
+similarity index 100%
+rename from arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-uart5.dtso
+rename to arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-uart5-ph.dtso
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dts b/arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dts
+index c09cc24a8b279..436896936fb3b 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dts
+@@ -280,12 +280,6 @@ &uart4 {
+ 	status = "disabled";
+ };
+ 
+-&uart5 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&uart5_ph_pins>;
+-	status = "disabled";
+-};
+-
+ &i2c3 {
+ 	status = "okay";
+ 	pinctrl-names = "default";
+@@ -415,12 +409,6 @@ uart4_pi_pins: uart4-pi-pins {
+ 		function = "uart4";
+ 	};
+ 
+-	/omit-if-no-ref/
+-	uart5_ph_pins: uart5-ph-pins {
+-		pins = "PH2", "PH3";
+-		function = "uart5";
+-	};
+-
+ 	/omit-if-no-ref/
+ 	spi1_cs1_pin: spi1-cs1-pin {
+ 		pins = "PH9";
+-- 
+GitLab

--- a/patch/kernel/archive/sunxi-6.7/patches.armbian/arm64-dts-sun50i-h618-orangepi-zero2w-add-dtb.patch
+++ b/patch/kernel/archive/sunxi-6.7/patches.armbian/arm64-dts-sun50i-h618-orangepi-zero2w-add-dtb.patch
@@ -1,0 +1,474 @@
+From 09a088f5c8e28c394a74730481adf9cec434fc93 Mon Sep 17 00:00:00 2001
+From: chraac <chraac@gmail.com>
+Date: Fri, 15 Mar 2024 12:30:26 +0800
+Subject: [PATCH] orangepi-zero2w add dtb
+
+update zero2w dts
+
+udpate zero2w dts from linux kernel 6.8+
+
+add log for thermal zone
+
+reference the sun50i-h618-cpu-dvfs.dtsi in zero2w
+
+remove i2c bind
+---
+ arch/arm64/boot/dts/allwinner/Makefile        |   1 +
+ .../allwinner/sun50i-h618-orangepi-zero2w.dts | 435 ++++++++++++++++++
+ 2 files changed, 436 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dts
+
+diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
+index 8b504ee408e78..a957365edc1aa 100644
+--- a/arch/arm64/boot/dts/allwinner/Makefile
++++ b/arch/arm64/boot/dts/allwinner/Makefile
+@@ -56,5 +56,6 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-sd.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-emmc.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-bananapi-m4-zero.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-orangepi-zero3.dtb
++dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-orangepi-zero2w.dtb
+ 
+ subdir-y	:= $(dts-dirs) overlay
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dts b/arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dts
+new file mode 100644
+index 0000000000000..c09cc24a8b279
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dts
+@@ -0,0 +1,435 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (C) 2023 Arm Ltd.
++ */
++
++/dts-v1/;
++
++#include "sun50i-h616.dtsi"
++#include "sun50i-h616-cpu-opp.dtsi"
++#include "sun50i-h618-cpu-dvfs.dtsi"
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/interrupt-controller/arm-gic.h>
++#include <dt-bindings/leds/common.h>
++
++/ {
++	model = "OrangePi Zero 2W";
++	compatible = "xunlong,orangepi-zero2w", "allwinner,sun50i-h618";
++
++	aliases {
++		serial0 = &uart0;
++		serial2 = &uart2;
++		serial3 = &uart3;
++		serial4 = &uart4;
++		serial5 = &uart5;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	connector {
++		compatible = "hdmi-connector";
++		type = "d";
++
++		port {
++			hdmi_con_in: endpoint {
++				remote-endpoint = <&hdmi_out_con>;
++			};
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led-0 {
++			function = LED_FUNCTION_STATUS;
++			color = <LED_COLOR_ID_GREEN>;
++			label = "green_led";
++			gpios = <&pio 2 13 GPIO_ACTIVE_HIGH>; /* PC13 */
++			linux,default-trigger = "heartbeat";
++		};
++
++		100m_link {
++			label = "100m_link";
++			gpios = <&pio 2 15 GPIO_ACTIVE_HIGH>; /* PC15 */
++			default-state = "off";
++		};
++
++		100m_act {
++			label = "100m_act";
++			gpios = <&pio 2 16 GPIO_ACTIVE_HIGH>; /* PC16 */
++			default-state = "off";
++		};
++	};
++
++	reg_vcc5v: vcc5v {
++		/* board wide 5V supply directly from the USB-C socket */
++		compatible = "regulator-fixed";
++		regulator-name = "vcc-5v";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		regulator-always-on;
++	};
++
++	reg_vcc3v3: vcc3v3 {
++		/* SY8089 DC/DC converter */
++		compatible = "regulator-fixed";
++		regulator-name = "vcc-3v3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&reg_vcc5v>;
++		regulator-always-on;
++	};
++
++	reg_vcc_wifi_io: vcc-wifi-io {
++		/* Always on 1.8V/300mA regulator for WiFi and BT IO */
++		compatible = "regulator-fixed";
++		regulator-name = "vcc-wifi-io";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		regulator-always-on;
++		vin-supply = <&reg_vcc3v3>;
++	};
++
++	wifi_pwrseq: wifi-pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		clocks = <&rtc 1>;
++		clock-names = "osc32k-out";
++		reset-gpios = <&pio 6 18 GPIO_ACTIVE_LOW>; /* PG18 */
++		post-power-on-delay-ms = <200>;
++	};
++
++	ac200_pwm_clk: ac200_clk {
++		compatible = "pwm-clock";
++		#clock-cells = <0>;
++		// pwm5 period_ns = 500 > 334 for select 24M clock.
++		pwms = <&pwm 5 500 0>;
++		clock-frequency = <2000000>;
++		status = "okay";
++	};
++
++	soc {
++		pwm: pwm@300a000 {
++			compatible = "allwinner,sun50i-h616-pwm";
++			reg = <0x0300a000 0x400>;
++			clocks = <&osc24M>, <&ccu CLK_BUS_PWM>;
++			clock-names = "mod", "bus";
++			resets = <&ccu RST_BUS_PWM>;
++			pwm-number = <6>;
++			pwm-base = <0x0>;
++			sunxi-pwms = <&pwm5>;
++			#pwm-cells = <3>;
++			status = "okay";
++		};
++
++		pwm5: pwm5@0300a000 {
++			compatible = "allwinner,sunxi-pwm5";
++			pinctrl-names = "default";
++			pinctrl-0 = <&pwm5_pin>;
++			clk_bypass_output = <0x1>;
++			status = "okay";
++		};
++	};
++};
++
++&de {
++	status = "okay";
++};
++
++&hdmi {
++	status = "okay";
++};
++
++&hdmi_out {
++	hdmi_out_con: endpoint {
++		remote-endpoint = <&hdmi_con_in>;
++	};
++};
++
++&gpu {
++	mali-supply = <&reg_dcdc1>;
++	status = "disabled";
++};
++
++&mmc0 {
++	cd-gpios = <&pio 5 6 GPIO_ACTIVE_LOW>;	/* PF6 */
++	bus-width = <4>;
++	vmmc-supply = <&reg_dldo1>;
++	max-frequency = <50000000>;
++	status = "okay";
++};
++
++&mmc1 {
++	vmmc-supply = <&reg_vcc3v3>;
++	vqmmc-supply = <&reg_vcc_wifi_io>;
++	mmc-pwrseq = <&wifi_pwrseq>;
++	bus-width = <4>;
++	non-removable;
++	mmc-ddr-1_8v;
++	status = "okay";
++};
++
++&emac0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&ext_rgmii_pins>;
++	phy-handle = <&ext_rgmii_phy>;
++	allwinner,tx-delay-ps = <700>;
++	phy-mode = "rgmii-rxid";
++	phy-supply = <&reg_dldo1>;
++	status = "okay";
++};
++
++&mdio0 {
++	ext_rgmii_phy: ethernet-phy@1 {
++		compatible = "ethernet-phy-ieee802.3-c22";
++		motorcomm,clk-out-frequency-hz = <125000000>;
++		reg = <1>;
++	};
++};
++
++&ehci0 {
++	status = "disabled";
++};
++
++&ehci1 {
++	status = "okay";
++};
++
++&ehci2 {
++	status = "okay";
++};
++
++&ehci3 {
++	status = "okay";
++};
++
++&ohci0 {
++	status = "disabled";
++};
++
++&ohci1 {
++	status = "okay";
++};
++
++&ohci2 {
++	status = "okay";
++};
++
++&ohci3 {
++	status = "okay";
++};
++
++&ir {
++	pinctrl-names = "default";
++	pinctrl-0 = <&ir_rx_pin>;
++	status = "okay";
++};
++
++&spi0  {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi0_pins>, <&spi0_cs0_pin>;
++
++	flash@0 {
++		#address-cells = <1>;
++		#size-cells = <1>;
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <40000000>;
++	};
++};
++
++&spi1 {
++	status = "disabled";
++	#address-cells = <1>;
++	#size-cells = <0>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi1_pins>, <&spi1_cs1_pin>;
++
++	spidev@1 {
++		compatible = "rohm,dh2228fv";
++		status = "disabled";
++		reg = <1>;
++		spi-max-frequency = <1000000>;
++	};
++};
++
++&uart0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart0_ph_pins>;
++	status = "okay";
++};
++
++&uart2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart2_pi_pins>;
++	status = "disabled";
++};
++
++&uart3 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart3_pi_pins>;
++	status = "disabled";
++};
++
++&uart4 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart4_pi_pins>;
++	status = "disabled";
++};
++
++&uart5 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart5_ph_pins>;
++	status = "disabled";
++};
++
++&i2c3 {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c3_pa_pins>;
++
++	ac200_x: mfd@10 {
++		compatible = "x-powers,ac200";
++		reg = <0x10>;
++		clocks = <&ac200_pwm_clk>;
++		// ephy id
++		nvmem-cells = <&ephy_calibration>;
++		nvmem-cell-names = "calibration";
++
++		ac200_ephy: phy {
++			compatible = "x-powers,ac200-ephy";
++			status = "okay";
++		};
++	};
++};
++
++&i2c4 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c4_ph_pins>;
++	status = "disabled";
++};
++
++&usbotg {
++	/*
++	 * PHY0 pins are connected to a USB-C socket, but a role switch
++	 * is not implemented: both CC pins are pulled to GND.
++	 * The VBUS pins power the device, so a fixed peripheral mode
++	 * is the best choice.
++	 * The board can be powered via GPIOs, in this case port0 *can*
++	 * act as a host (with a cable/adapter ignoring CC), as VBUS is
++	 * then provided by the GPIOs. Any user of this setup would
++	 * need to adjust the DT accordingly: dr_mode set to "host",
++	 * enabling OHCI0 and EHCI0.
++	 */
++	dr_mode = "peripheral";
++	status = "okay";
++};
++
++&usbphy {
++	usb1_vbus-supply = <&reg_vcc5v>;
++	status = "okay";
++};
++
++&cpu0 {
++	cpu-supply = <&reg_dcdc2>;
++	status = "okay";
++};
++
++&sid {
++	ephy_calibration: ephy-calibration@2c {
++		reg = <0x2c 0x2>;
++	};
++};
++
++&cpu_temp_critical {
++	temperature = <100000>;
++};
++
++&gpu_temp_critical {
++	temperature = <100000>;
++};
++
++&ve_temp_critical {
++	temperature = <100000>;
++};
++
++&ddr_temp_critical {
++	temperature = <100000>;
++};
++
++&pio {
++	vcc-pc-supply = <&reg_dldo1>;
++	vcc-pf-supply = <&reg_dldo1>;
++	vcc-pg-supply = <&reg_aldo1>;
++	vcc-ph-supply = <&reg_dldo1>;
++	vcc-pi-supply = <&reg_dldo1>;
++
++	/omit-if-no-ref/
++	i2c0_pi_pins: i2c0-pi-pins {
++		pins = "PI5", "PI6";
++		function = "i2c0";
++	};
++
++	/omit-if-no-ref/
++	i2c1_pi_pins: i2c1-pi-pins {
++		pins = "PI7", "PI8";
++		function = "i2c1";
++	};
++
++	/omit-if-no-ref/
++	i2c2_pi_pins: i2c2-pi-pins {
++		pins = "PI9", "PI10";
++		function = "i2c2";
++	};
++
++    i2c3_pa_pins: i2c3-pa-pins {
++        pins = "PA10", "PA11";
++        function = "i2c3";
++        bias-pull-up;
++    };
++
++	/omit-if-no-ref/
++	i2c4_ph_pins: i2c4-ph-pins {
++		pins = "PH6", "PH7";
++		function = "i2c4";
++	};
++
++	/omit-if-no-ref/
++	uart2_pi_pins: uart2-pi-pins {
++		pins = "PI5", "PI6";
++		function = "uart2";
++	};
++
++	/omit-if-no-ref/
++	uart3_pi_pins: uart3-pi-pins {
++		pins = "PI9", "PI10";
++		function = "uart3";
++	};
++
++	/omit-if-no-ref/
++	uart4_pi_pins: uart4-pi-pins {
++		pins = "PI13", "PI14";
++		function = "uart4";
++	};
++
++	/omit-if-no-ref/
++	uart5_ph_pins: uart5-ph-pins {
++		pins = "PH2", "PH3";
++		function = "uart5";
++	};
++
++	/omit-if-no-ref/
++	spi1_cs1_pin: spi1-cs1-pin {
++		pins = "PH9";
++		function = "spi1";
++	};
++
++	/omit-if-no-ref/
++	pwm5_pin: pwm5-pin {
++		pins = "PA12";
++		function = "pwm5";
++	};
++};
+-- 
+GitLab

--- a/patch/kernel/archive/sunxi-6.7/series.armbian
+++ b/patch/kernel/archive/sunxi-6.7/series.armbian
@@ -197,5 +197,7 @@
 	patches.armbian/arm64-dts-h616-add-hdmi-support-for-zero2-and-zero3.patch
 	patches.armbian/arm64-dts-sun50i-h616-Add-dma-node.patch
 	patches.armbian/arm64-dts-H616-Add-overlays-that-are-also-compatible-with.patch
+	patches.armbian/arm64-dts-sun50i-h618-orangepi-zero2w-add-dtb.patch
 	patches.armbian/arm64-dts-allwinner-sun50i-h616-PG-12c-pins.patch
 	patches.armbian/arm64-dts-allwinner-sun50i-h616-spi1-cs1-pin.patch
+	patches.armbian/arm64-dts-sun50i-h618-add-overlay.patch

--- a/patch/kernel/archive/sunxi-6.7/series.conf
+++ b/patch/kernel/archive/sunxi-6.7/series.conf
@@ -519,5 +519,7 @@
 	patches.armbian/arm64-dts-h616-add-hdmi-support-for-zero2-and-zero3.patch
 	patches.armbian/arm64-dts-sun50i-h616-Add-dma-node.patch
 	patches.armbian/arm64-dts-H616-Add-overlays-that-are-also-compatible-with.patch
+	patches.armbian/arm64-dts-sun50i-h618-orangepi-zero2w-add-dtb.patch
 	patches.armbian/arm64-dts-allwinner-sun50i-h616-PG-12c-pins.patch
 	patches.armbian/arm64-dts-allwinner-sun50i-h616-spi1-cs1-pin.patch
+	patches.armbian/arm64-dts-sun50i-h618-add-overlay.patch

--- a/patch/u-boot/v2024.04/board_orangepizero2w/001-allwinner-common-enable-autoboot-keyed.patch
+++ b/patch/u-boot/v2024.04/board_orangepizero2w/001-allwinner-common-enable-autoboot-keyed.patch
@@ -1,0 +1,46 @@
+From ed59733d86e8b509c7afcab3e670dc8bb1020589 Mon Sep 17 00:00:00 2001
+From: hongruichen <chraac@gmail.com>
+Date: Wed, 27 Mar 2024 22:03:00 +0800
+Subject: allwinner-common-enable-autoboot-keyed.patch
+
+---
+ arch/arm/Kconfig | 2 ++
+ boot/Kconfig     | 3 ++-
+ 2 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm/Kconfig b/arch/arm/Kconfig
+index 01d6556c42b..12d19c98ddd 100644
+--- a/arch/arm/Kconfig
++++ b/arch/arm/Kconfig
+@@ -1175,6 +1175,8 @@ config ARCH_SUNXI
+ 	select USB_KEYBOARD if DISTRO_DEFAULTS && USB_HOST
+ 	select USB_STORAGE if DISTRO_DEFAULTS && USB_HOST
+ 	select SPL_USE_TINY_PRINTF if SPL
++	imply AUTOBOOT_KEYED
++	imply AUTOBOOT_KEYED_CTRLC 
+ 	select USE_PREBOOT
+ 	select SYS_RELOC_GD_ENV_ADDR
+ 	imply BOARD_LATE_INIT
+diff --git a/boot/Kconfig b/boot/Kconfig
+index 3d7aabd27d6..5b9e7b15849 100644
+--- a/boot/Kconfig
++++ b/boot/Kconfig
+@@ -1286,7 +1286,7 @@ config AUTOBOOT_FLUSH_STDIN
+ 
+ config AUTOBOOT_PROMPT
+ 	string "Autoboot stop prompt"
+-	default "Autoboot in %d seconds\\n"
++	default "Autoboot in %d seconds, press <Space> to stop\\n"
+ 	help
+ 	  This string is displayed before the boot delay selected by
+ 	  CONFIG_BOOTDELAY starts. If it is not defined	there is no
+@@ -1340,6 +1340,7 @@ config AUTOBOOT_DELAY_STR
+ config AUTOBOOT_STOP_STR
+ 	string "Stop autobooting via specific input key / string"
+ 	depends on !AUTOBOOT_ENCRYPTION
++	default " "
+ 	help
+ 	  This option enables stopping (aborting) of the automatic
+ 	  boot feature only by issuing a specific input key or
+-- 
+GitLab

--- a/patch/u-boot/v2024.04/board_orangepizero2w/002-allwinner-common-boot-splash.patch
+++ b/patch/u-boot/v2024.04/board_orangepizero2w/002-allwinner-common-boot-splash.patch
@@ -1,0 +1,96 @@
+From 4c2ee8db69d4e0c7cd2b2f6c6bca476e92715193 Mon Sep 17 00:00:00 2001
+From: hongruichen <chraac@gmail.com>
+Date: Wed, 27 Mar 2024 22:11:48 +0800
+Subject: allwinner-common-boot-splash.patch
+
+---
+ cmd/Kconfig                     |  1 +
+ include/config_distro_bootcmd.h |  9 +++++++++
+ include/configs/sunxi-common.h  | 30 ++++++++++++++++++++++++++++++
+ 3 files changed, 40 insertions(+)
+
+diff --git a/cmd/Kconfig b/cmd/Kconfig
+index a86b5705174..7ec22b7d37d 100644
+--- a/cmd/Kconfig
++++ b/cmd/Kconfig
+@@ -2066,6 +2066,7 @@ config CMD_BMP
+ 	bool "Enable 'bmp' command"
+ 	depends on VIDEO
+ 	select BMP
++	default y
+ 	help
+ 	  This provides a way to obtain information about a BMP-format image
+ 	  and to display it. BMP (which presumably stands for BitMaP) is a
+diff --git a/include/config_distro_bootcmd.h b/include/config_distro_bootcmd.h
+index 2a136b96a6d..fac28ceb155 100644
+--- a/include/config_distro_bootcmd.h
++++ b/include/config_distro_bootcmd.h
+@@ -492,6 +492,15 @@
+ 	BOOTENV_SHARED_VIRTIO \
+ 	BOOTENV_SHARED_EXTENSION \
+ 	"boot_prefixes=/ /boot/\0" \
++	"splashpos=m,m\0" \
++	"splashimage=66000000\0" \
++	"loadsplash= " \
++		"for prefix in ${boot_prefixes}; do " \
++			"if test -e mmc 0 ${prefix}boot.bmp; then " \
++				"load mmc 0 ${splashimage} ${prefix}boot.bmp; " \
++				"bmp d ${splashimage}; " \
++			"fi; " \
++		"done\0" \
+ 	"boot_scripts=boot.scr.uimg boot.scr\0" \
+ 	"boot_script_dhcp=boot.scr.uimg\0" \
+ 	BOOTENV_BOOT_TARGETS \
+diff --git a/include/configs/sunxi-common.h b/include/configs/sunxi-common.h
+index b29a25d5617..1559d5ec2cc 100644
+--- a/include/configs/sunxi-common.h
++++ b/include/configs/sunxi-common.h
+@@ -245,9 +245,15 @@
+ #include <config_distro_bootcmd.h>
+ 
+ #ifdef CONFIG_USB_KEYBOARD
++#if defined CONFIG_VIDEO
+ #define CONSOLE_STDIN_SETTINGS \
++	"preboot=run loadsplash; usb start\0" \
+ 	"stdin=serial,usbkbd\0"
+ #else
++#define CONSOLE_STDIN_SETTINGS \
++	"stdin=serial,usbkbd\0"
++#endif
++#else
+ #define CONSOLE_STDIN_SETTINGS \
+ 	"stdin=serial\0"
+ #endif
+@@ -280,6 +286,30 @@
+ 	CONSOLE_STDIN_SETTINGS \
+ 	CONSOLE_STDOUT_SETTINGS
+ 
++#if defined CONFIG_VIDEO
++#if !defined CONFIG_VIDEO_LOGO
++#define CONFIG_VIDEO_LOGO
++#endif
++#if !defined CONFIG_SPLASH_SCREEN
++#define CONFIG_SPLASH_SCREEN
++#endif
++#if !defined CONFIG_SPLASH_SCREEN_ALIGN
++#define CONFIG_SPLASH_SCREEN_ALIGN
++#endif
++#if !defined CONFIG_BMP_16BPP
++#define CONFIG_BMP_16BPP
++#endif
++#if !defined CONFIG_BMP_24BPP
++#define CONFIG_BMP_24BPP
++#endif
++#if !defined CONFIG_BMP_32BPP
++#define CONFIG_BMP_32BPP
++#endif
++#if !defined CONFIG_VIDEO_BMP_RLE8
++#define CONFIG_VIDEO_BMP_RLE8
++#endif
++#endif
++
+ #ifdef CONFIG_ARM64
+ #define FDTFILE "allwinner/" CONFIG_DEFAULT_DEVICE_TREE ".dtb"
+ #else
+-- 
+GitLab

--- a/patch/u-boot/v2024.04/board_orangepizero2w/003-allwinner-common-h616-THS-workaround.patch
+++ b/patch/u-boot/v2024.04/board_orangepizero2w/003-allwinner-common-h616-THS-workaround.patch
@@ -1,0 +1,31 @@
+From 692b81cd26bd1626bf629f675e3441d1ea98006f Mon Sep 17 00:00:00 2001
+From: hongruichen <chraac@gmail.com>
+Date: Wed, 10 Apr 2024 22:48:14 +0800
+Subject: allwinner-common-h616-THS-workaround.patch
+
+---
+ board/sunxi/board.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/board/sunxi/board.c b/board/sunxi/board.c
+index 8c12c8deade..bec14d61058 100644
+--- a/board/sunxi/board.c
++++ b/board/sunxi/board.c
+@@ -226,6 +226,15 @@ int board_init(void)
+ 	if (ret)
+ 		return ret;
+ 
++#if CONFIG_MACH_SUN50I_H616
++	/*
++	 * The bit[16] of register reg[0x03000000] must be zero for the THS
++	 * driver to work properly in the kernel. The BSP u-boot is putting
++	 * the whole register to zero so we are doing the same.
++	 */
++	writel(0x0, SUNXI_SRAMC_BASE);
++#endif
++
+ #if CONFIG_IS_ENABLED(DM_I2C)
+ 	/*
+ 	 * Temporary workaround for enabling I2C clocks until proper sunxi DM
+-- 
+GitLab

--- a/patch/u-boot/v2024.04/board_orangepizero2w/004-allwinner-common-h616-GPU-enable-hack.patch
+++ b/patch/u-boot/v2024.04/board_orangepizero2w/004-allwinner-common-h616-GPU-enable-hack.patch
@@ -1,0 +1,24 @@
+From 47486e201dc8b8a92ecc99b7d6822539d3ecb3f7 Mon Sep 17 00:00:00 2001
+From: hongruichen <chraac@gmail.com>
+Date: Wed, 10 Apr 2024 22:48:34 +0800
+Subject: allwinner-common-h616-GPU-enable-hack.patch
+
+---
+ arch/arm/mach-sunxi/clock_sun50i_h6.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/arch/arm/mach-sunxi/clock_sun50i_h6.c b/arch/arm/mach-sunxi/clock_sun50i_h6.c
+index dac3663e1be..1f3b4ad4db1 100644
+--- a/arch/arm/mach-sunxi/clock_sun50i_h6.c
++++ b/arch/arm/mach-sunxi/clock_sun50i_h6.c
+@@ -15,6 +15,8 @@ void clock_init_safe(void)
+ 		/* this seems to enable PLLs on H616 */
+ 		setbits_le32(&prcm->sys_pwroff_gating, 0x10);
+ 		setbits_le32(&prcm->res_cal_ctrl, 2);
++		/* enable GPU */
++		writel(0, 0x7010254);
+ 	}
+ 
+ 	if (IS_ENABLED(CONFIG_MACH_SUN50I_H616) ||
+-- 
+GitLab

--- a/patch/u-boot/v2024.04/board_orangepizero2w/005-allwinner-common-pwrled-config-option.patch
+++ b/patch/u-boot/v2024.04/board_orangepizero2w/005-allwinner-common-pwrled-config-option.patch
@@ -1,0 +1,60 @@
+From 8b3f2f451b7d0ff2ce931940fa913e6ef2ff7093 Mon Sep 17 00:00:00 2001
+From: hongruichen <chraac@gmail.com>
+Date: Wed, 10 Apr 2024 22:49:20 +0800
+Subject: allwinner-common-pwrled-config-option.patch
+
+---
+ arch/arm/mach-sunxi/Kconfig |  9 +++++++++
+ board/sunxi/board.c         | 10 +++++++++-
+ 2 files changed, 18 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm/mach-sunxi/Kconfig b/arch/arm/mach-sunxi/Kconfig
+index fe89aec6b9a..9e9e8fc1654 100644
+--- a/arch/arm/mach-sunxi/Kconfig
++++ b/arch/arm/mach-sunxi/Kconfig
+@@ -752,6 +752,15 @@ config OLD_SUNXI_KERNEL_COMPAT
+ 	Set this to enable various workarounds for old kernels, this results in
+ 	sub-optimal settings for newer kernels, only enable if needed.
+ 
++config PWRLED
++        string "Power led pin"
++        default "PL10" if MACH_SUNXI_H3_H5
++        default "PL4" if MACH_SUN50I_H6
++        default ""
++        help
++          Set the pin used to power the led. This takes a string in the format
++          understood by sunxi_name_to_gpio, e.g. PC12 for pin 1 of port H.
++
+ config MMC1_PINS_PH
+ 	bool "Pins for mmc1 are on Port H"
+ 	depends on MACH_SUN4I || MACH_SUN7I || MACH_SUN8I_R40
+diff --git a/board/sunxi/board.c b/board/sunxi/board.c
+index bec14d61058..ec45ed3e05f 100644
+--- a/board/sunxi/board.c
++++ b/board/sunxi/board.c
+@@ -189,7 +189,7 @@ enum env_location env_get_location(enum env_operation op, int prio)
+ /* add board specific code here */
+ int board_init(void)
+ {
+-	__maybe_unused int id_pfr1, ret;
++	__maybe_unused int id_pfr1, ret, pwrled_pin;
+ 
+ 	gd->bd->bi_boot_params = (PHYS_SDRAM_0 + 0x100);
+ 
+@@ -226,6 +226,14 @@ int board_init(void)
+ 	if (ret)
+ 		return ret;
+ 
++	if (CONFIG_PWRLED[0]) {
++		pwrled_pin = sunxi_name_to_gpio(CONFIG_PWRLED);
++		if (pwrled_pin >= 0) {
++			gpio_request(pwrled_pin, "pwrled");
++			gpio_direction_output(pwrled_pin, 1);
++		}
++	}
++
+ #if CONFIG_MACH_SUN50I_H616
+ 	/*
+ 	 * The bit[16] of register reg[0x03000000] must be zero for the THS
+-- 
+GitLab

--- a/patch/u-boot/v2024.04/board_orangepizero2w/006-allwinner-common-fdt-setprop-fix-unaligned-access.patch
+++ b/patch/u-boot/v2024.04/board_orangepizero2w/006-allwinner-common-fdt-setprop-fix-unaligned-access.patch
@@ -1,0 +1,35 @@
+From f38e856264066fdf09becdfebf0e9957a40bf702 Mon Sep 17 00:00:00 2001
+From: hongruichen <chraac@gmail.com>
+Date: Wed, 10 Apr 2024 22:58:15 +0800
+Subject: allwinner-common-fdt-setprop-fix-unaligned-access.patch
+
+---
+ cmd/fdt.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/cmd/fdt.c b/cmd/fdt.c
+index 331564c13be..67d8d27e724 100644
+--- a/cmd/fdt.c
++++ b/cmd/fdt.c
+@@ -18,6 +18,7 @@
+ #include <fdt_support.h>
+ #include <mapmem.h>
+ #include <asm/io.h>
++#include <asm/unaligned.h>
+ 
+ #define MAX_LEVEL	32		/* how deeply nested we will go */
+ #define SCRATCHPAD	1024		/* bytes of scratchpad memory */
+@@ -830,7 +831,10 @@ static int fdt_parse_prop(char * const *newval, int count, char *data, int *len)
+ 			cp = newp;
+ 			tmp = simple_strtoul(cp, &newp, 0);
+ 			if (*cp != '?')
+-				*(fdt32_t *)data = cpu_to_fdt32(tmp);
++			{
++				tmp = cpu_to_fdt32(tmp);
++				put_unaligned(tmp, (fdt32_t *)data);
++			}
+ 			else
+ 				newp++;
+ 
+-- 
+GitLab


### PR DESCRIPTION
# Description
Add support to [OrangePi Zero 2W](http://www.orangepi.org/html/hardWare/computerAndMicrocontrollers/details/Orange-Pi-Zero-2W.html) (allwinner H618), changes:
- Patch for u-boot `v2024.04`, includes: 
  - allwinner-h616-THS-workaround.patch
  - allwinner-h616-GPU-enable-hack.patch
  - allwinner-pwrled-config-option.patch
  - allwinner-enable-autoboot-keyed.patch
  - allwinner-boot-splash.patch
- Kernel patch for adding zero2w dts, some part are taken from [the orange pi official repo](https://github.com/orangepi-xunlong/linux-orangepi/blob/orange-pi-6.1-sun50iw9/arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2w.dts) and another part was from [kernel `6.8.y`](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dts?h=linux-6.8.y).

_Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change._

[Jira](https://armbian.atlassian.net/jira) reference number [AR-9999]

# Documentation summary for feature / change

_Please delete this section if entry to main documentation is not needed._

If documentation entry is predicted, please provide key elements for further implementation [into main documentation](https://docs.armbian.com) and set label to "Needs Documentation". You are welcome to open a PR to documentation or you can leave following information for technical writer:

- [ ] short description (copy / paste of PR title)
- [ ] summary (description relevant for end users)
- [ ] example of usage (how to see this in function)

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] Build and install the `current` image to SD, and then test on zero2w
- [x] Build and install the `edge` image to SD, and then test on zero2w
- [x] HDMI: test if HDMI output correctly
- [x] Network: test if wifi connect to access point correctly
- [x] USB: test onboard type-c (host)
- [x] USB: test onboard type-c (otg)
- [x] USB: test usb port on the 24pin connector
- [x] GPIO: test GPIO voltage level - pull down and pull up by `gpioset`, both ok
- [x] Uart: test uart0 to get the kernel output
- [x] I2C: test i2c connectivity - tested with i2c lcd, text was displayed correctly
- [x] GPU: test if gpu can work correctly

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
