### PR TITLE
Changing file to force full rootfs cache rebuild

### DIFF
--- a/lib/functions/rootfs/rootfs-create.sh
+++ b/lib/functions/rootfs/rootfs-create.sh
@@ -113,7 +113,7 @@ function create_new_rootfs_cache_via_debootstrap() {
 
 	deboostrap_arguments+=("${RELEASE}" "${SDCARD}/" "${debootstrap_apt_mirror}") # release, path and mirror; always last, positional arguments.
 
-	# Set DEBOOTSTRAP_DIR only for this invocation; if we instead export it, the 2nd stage will fail
+	# Set DEBOOTSTRAP_DIR only for this invocation; if we instead export it, the second stage will fail
 	run_host_command_logged "DEBOOTSTRAP_DIR='${debootstrap_wanted_dir}'" "${debootstrap_bin}" "${deboostrap_arguments[@]}" || {
 		exit_with_error "Debootstrap first stage failed" "${debootstrap_bin} ${RELEASE} ${DESKTOP_APPGROUPS_SELECTED} ${DESKTOP_ENVIRONMENT} ${BUILD_MINIMAL}"
 	}


### PR DESCRIPTION
# Description

Changing file to force full rootfs cache rebuild due to upstream [backdoor in xz-tools](https://www.openwall.com/lists/oss-security/2024/03/29/4). Even though we are almost certain that there were no affected packages we forced a fully rebuild of all cached objects to rule any chance out.