### PR TITLE
RFC: DO NOT MERGE: patching: rewrite: try to stabilize patch `index` stanzas as well as From lines

### DIFF
--- a/patch/kernel/archive/rockchip64-6.8/board-rockpis-0019-Sync-rk3308_codec-to-BSP-tree.patch
+++ b/patch/kernel/archive/rockchip64-6.8/board-rockpis-0019-Sync-rk3308_codec-to-BSP-tree.patch
@@ -12,7 +12,7 @@ Subject: Sync `rk3308_codec` to BSP tree
 
 diff --git a/Documentation/devicetree/bindings/sound/rockchip,rk3308-codec.txt b/Documentation/devicetree/bindings/sound/rockchip,rk3308-codec.txt
 new file mode 100644
-index 000000000000..e20bbd73e37e
+index 000000000000..111111111111
 --- /dev/null
 +++ b/Documentation/devicetree/bindings/sound/rockchip,rk3308-codec.txt
 @@ -0,0 +1,78 @@
@@ -95,7 +95,7 @@ index 000000000000..e20bbd73e37e
 +	status = "okay";
 +};
 diff --git a/sound/soc/codecs/rk3308_codec.c b/sound/soc/codecs/rk3308_codec.c
-index 106f09738dd0..815e22fc346c 100644
+index 111111111111..222222222222 100644
 --- a/sound/soc/codecs/rk3308_codec.c
 +++ b/sound/soc/codecs/rk3308_codec.c
 @@ -29,1420 +29,4699 @@
@@ -6251,7 +6251,7 @@ index 106f09738dd0..815e22fc346c 100644
  	},
  	.probe = rk3308_platform_probe,
 diff --git a/sound/soc/codecs/rk3308_codec.h b/sound/soc/codecs/rk3308_codec.h
-index 6cfa69157785..93e089dae081 100644
+index 111111111111..222222222222 100644
 --- a/sound/soc/codecs/rk3308_codec.h
 +++ b/sound/soc/codecs/rk3308_codec.h
 @@ -26,7 +26,8 @@
@@ -6701,7 +6701,7 @@ index 6cfa69157785..93e089dae081 100644
  #endif /* __RK3308_CODEC_H__ */
 diff --git a/sound/soc/codecs/rk3308_codec_provider.h b/sound/soc/codecs/rk3308_codec_provider.h
 new file mode 100644
-index 000000000000..68042b1328dc
+index 000000000000..111111111111
 --- /dev/null
 +++ b/sound/soc/codecs/rk3308_codec_provider.h
 @@ -0,0 +1,28 @@


### PR DESCRIPTION
#### RFC: DO NOT MERGE: patching: rewrite: try to stabilize patch `index` stanzas as well as From lines

- RFC: DO NOT MERGE: patching: rewrite: try to stabilize patch `index` stanzas as well as From lines
  - `git format-patch --zero-commit` doesn't affect `index xxx...yyy` lines, only `From: `
    - so use the _classy_ "use a regex with a callback" solution as git format-patch doesn't offer one
  - this will make _all_ patches change when rewritten, but hopefully _for the last time_ !
  - not sure what other impacts this might have though - `git am` might not work any more?
  - we need to preserve `index 000000000000..xxx` as zeros, which indicate new file creation, thus:
    - new file creations are rewritten as `index 000000000000..111111111111`
    - non-creations are rewritten as `index 111111111111..222222222222`
- DO NOT MERGE: Example rewrite of a patch with both file change & file creation