### PR TITLE
RPi5 has troubles booting when faster memory access is enabled

### DIFF
--- a/config/boards/rpi5b.conf
+++ b/config/boards/rpi5b.conf
@@ -11,21 +11,21 @@ function post_family_config__rename_linux_family() {
 	declare -g LINUXFAMILY=bcm2712
 }
 
-function custom_kernel_config__rpi5b_16k_variant() {
-	display_alert "rpi5b" "Enabling 16K page size" "info"
-	kernel_config_modifying_hashes+=(
-		"CONFIG_ARM64_16K_PAGES=y"
-		"CONFIG_ARCH_MMAP_RND_BITS=18"
-		"CONFIG_ARCH_MMAP_RND_COMPAT_BITS=11"
-	)
+#function custom_kernel_config__rpi5b_16k_variant() {
+#	display_alert "rpi5b" "Enabling 16K page size" "info"
+#	kernel_config_modifying_hashes+=(
+#		"CONFIG_ARM64_16K_PAGES=y"
+#		"CONFIG_ARCH_MMAP_RND_BITS=18"
+#		"CONFIG_ARCH_MMAP_RND_COMPAT_BITS=11"
+#	)
 
-	# As kernel config is shared between two variants, override the settings
-	# but make sure not to write them back to config/kernel directory
-	if [[ -f .config ]] && [[ "${KERNEL_CONFIGURE:-yes}" != "yes" ]]; then
-		display_alert "Enabling 16K page size" "armbian-kernel" "debug"
-		kernel_config_set_y CONFIG_ARM64_16K_PAGES
-		run_host_command_logged ./scripts/config --set-val CONFIG_ARCH_MMAP_RND_BITS 18
-		run_host_command_logged ./scripts/config --set-val CONFIG_ARCH_MMAP_RND_COMPAT_BITS 11
-		run_kernel_make olddefconfig
-	fi
-}
+#	# As kernel config is shared between two variants, override the settings
+#	# but make sure not to write them back to config/kernel directory
+#	if [[ -f .config ]] && [[ "${KERNEL_CONFIGURE:-yes}" != "yes" ]]; then
+#		display_alert "Enabling 16K page size" "armbian-kernel" "debug"
+#		kernel_config_set_y CONFIG_ARM64_16K_PAGES
+#		run_host_command_logged ./scripts/config --set-val CONFIG_ARCH_MMAP_RND_BITS 18
+#		run_host_command_logged ./scripts/config --set-val CONFIG_ARCH_MMAP_RND_COMPAT_BITS 11
+#		run_kernel_make olddefconfig
+#	fi
+#}


### PR DESCRIPTION
# Description

Lets (temporally) disable this feature as it doesn't work well and wait until things are fixed upstream / research problem deeper some other day.

# How Has This Been Tested?

- [x] Rpi5 boots with rpi4 image

# Checklist:

- [x] My changes generate no new warnings