### PR TITLE
kernel-dtbs: output a somewhat-diffable preprocessed dtc-massaged version of the DTS

### DIFF
--- a/lib/functions/compilation/kernel.sh
+++ b/lib/functions/compilation/kernel.sh
@@ -120,8 +120,8 @@ function kernel_prepare_build_and_package() {
 
 	# define dict with vars passed and target directories
 	declare -A kernel_install_dirs=(
-		["INSTALL_PATH"]="${kernel_dest_install_dir}/image/boot"  # Used by `make install`
-		["INSTALL_MOD_PATH"]="${kernel_dest_install_dir}/modules" # Used by `make modules_install`
+		["INSTALL_PATH"]="${kernel_dest_install_dir}/image/boot"       # Used by `make install`
+		["INSTALL_MOD_PATH"]="${kernel_dest_install_dir}/modules"      # Used by `make modules_install`
 		["INSTALL_HDR_PATH"]="${kernel_dest_install_dir}/libc_headers" # Used by `make headers_install` for libc headers
 	)
 
@@ -202,8 +202,13 @@ function kernel_dtb_only_build() {
 		declare preprocessed_fdt_normalized="${SRC}/output/${fdt_dir}-${fdt_file}--${KERNEL_MAJOR_MINOR}-${BRANCH}.preprocessed.normalized.dts"
 		run_host_command_logged dtc -I dts -O dts -o "${preprocessed_fdt_normalized}" "${preprocessed_fdt_dest}"
 
+		# Remove phandles and hex references, probably the worst way possible (grep) -- somehow the diff is reasonable then.
+		declare preprocessed_fdt_normalized_nophandles="${SRC}/output/${fdt_dir}-${fdt_file}--${KERNEL_MAJOR_MINOR}-${BRANCH}.preprocessed.normalized.nophandles.dts"
+		grep -v -e "phandle =" -e "connect =" -e '= <0x' "${preprocessed_fdt_normalized}" > "${preprocessed_fdt_normalized_nophandles}"
+
 		display_alert "Kernel DTB-only for development" "Preprocessed FDT dest: ${preprocessed_fdt_dest}" "warn"
 		display_alert "Kernel DTB-only for development" "Preprocessed FDT normalized: ${preprocessed_fdt_normalized}" "warn"
+		display_alert "Kernel DTB-only for development" "Preprocessed FDT normalized, no phandles: ${preprocessed_fdt_normalized_nophandles}" "warn"
 	fi
 
 	return 0


### PR DESCRIPTION
#### kernel-dtbs: output a somewhat-diffable preprocessed dtc-massaged version of the DTS

- kernel-dtbs: output a somewhat-diffable preprocessed dtc-massaged version of the DTS
  - useful for diffs across the same kernel, much less so across