### PR TITLE
add new board bananapim7

### DIFF
--- a/config/boards/bananapim7.conf
+++ b/config/boards/bananapim7.conf
@@ -1,0 +1,4 @@
+source "${SRC}/config/boards/armsom-sige7.csc"
+BOARD_NAME="Banana Pi M7"
+BOARD_MAINTAINER="amazingfate"
+BOOT_FDT_FILE="rockchip/rk3588-bananapi-m7.dtb"

--- a/patch/kernel/rockchip-rk3588-edge/dt/rk3588-bananapi-m7.dts
+++ b/patch/kernel/rockchip-rk3588-edge/dt/rk3588-bananapi-m7.dts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+
+/dts-v1/;
+
+#include "rk3588-armsom-sige7.dts"
+
+/ {
+	model = "Banana Pi M7";
+	compatible = "bananapi,m7", "rockchip,rk3588";
+};


### PR DESCRIPTION
# Description
bananapim7 and armsom-sige7 are the same board. This pr will simplely add a new board with a different name.
legacy and vendor kernel dts are added in https://github.com/armbian/linux-rockchip/pull/160 and https://github.com/armbian/linux-rockchip/pull/161

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh BOARD=bananapim7 BRANCH=edge BUILD_DESKTOP=no BUILD_MINIMAL=no COMPRESS_OUTPUTIMAGE=sha,gpg,xz DEB_COMPRESS=xz KERNEL_CONFIGURE=no RELEASE=bookworm`
- [x] `./compile.sh kernel BOARD=bananapim7 BRANCH=legacy DEB_COMPRESS=xz KERNEL_CONFIGURE=no`
- [x] `./compile.sh kernel BOARD=bananapim7 BRANCH=vendor DEB_COMPRESS=xz KERNEL_CONFIGURE=no`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
