### PR TITLE
rootfs-create: if debootstrap second stage fails, find debootstrap.log and show it so we know what the error is

### DIFF
--- a/lib/functions/logging/runners.sh
+++ b/lib/functions/logging/runners.sh
@@ -246,7 +246,7 @@ function logging_enrich_run_command_error_info() {
 		display_alert "Searching for if_error_find_files_sdcard files" "${SDCARD}/${path}" "debug"
 		declare -a sdcard_files
 		# shellcheck disable=SC2086 # I wanna expand, thank you...
-		mapfile -t sdcard_files < <(find ${SDCARD}/${path} -type f)
+		mapfile -t sdcard_files < <(find ${SDCARD}/ -type f -name "${path}")
 		display_alert "Found if_error_find_files_sdcard files" "${sdcard_files[@]}" "debug"
 		found_files+=("${sdcard_files[@]}") # add to result
 	done

--- a/lib/functions/rootfs/rootfs-create.sh
+++ b/lib/functions/rootfs/rootfs-create.sh
@@ -124,6 +124,7 @@ function create_new_rootfs_cache_via_debootstrap() {
 	deploy_qemu_binary_to_chroot "${SDCARD}" # this is cleaned-up later by post_debootstrap_tweaks() @TODO: which is too late for a cache
 
 	display_alert "Installing base system" "Stage 2/2" "info"
+	declare -g -a if_error_find_files_sdcard=("debootstrap.log") # if command fails, go look for this file and show it's contents during error processing
 	declare -g if_error_detail_message="Debootstrap second stage failed ${RELEASE} ${DESKTOP_APPGROUPS_SELECTED} ${DESKTOP_ENVIRONMENT} ${BUILD_MINIMAL}"
 	chroot_sdcard LC_ALL=C LANG=C /debootstrap/debootstrap --second-stage
 	[[ ! -f "${SDCARD}/bin/bash" ]] && exit_with_error "Debootstrap first stage did not produce /bin/bash"


### PR DESCRIPTION
#### rootfs-create: if debootstrap second stage fails, find debootstrap.log and show it so we know what the error is

- rootfs-create: if debootstrap second stage fails, find debootstrap.log and show it so we know what the error is
  - runner: let `if_error_find_files_sdcard` be a simple filename (different debootstraps put debootstrap.log in different places)