### PR TITLE
userspace: removals so trixie/noble builds again

### DIFF
--- a/config/desktop/bookworm/environments/xfce/config_base/packages
+++ b/config/desktop/bookworm/environments/xfce/config_base/packages
@@ -37,7 +37,6 @@ gtk2-engines-murrine
 gtk2-engines-pixbuf
 gvfs-backends
 hplip
-ayatana-indicator-printers
 inputattach
 inxi
 keyutils

--- a/config/desktop/common/environments/gnome/config_base/packages
+++ b/config/desktop/common/environments/gnome/config_base/packages
@@ -27,7 +27,6 @@ gnome-shell
 gnome-shell-extension-appindicator
 inputattach
 libnotify-bin
-libpulsedsp
 gdm3
 lm-sensors
 nautilus


### PR DESCRIPTION
#### userspace: removals so trixie/noble builds again

- userspace: debian: xfce: remove 'ayatana-indicator-printers' which is gone from trixie
- userspace: desktop: common: gnome: remove 'libpulsedsp' which is gone from noble