### PR TITLE
kernel-debs: linux-libc-dev: add `Conflicts: linux-libc-dev`

### DIFF
--- a/lib/functions/compilation/kernel-debs.sh
+++ b/lib/functions/compilation/kernel-debs.sh
@@ -554,6 +554,7 @@ function kernel_package_callback_linux_libc_dev() {
 		Section: devel
 		Priority: optional
 		Provides: linux-libc-dev
+		Conflicts: linux-libc-dev
 		Architecture: ${ARCH}
 		Description: Armbian Linux support headers for userspace development
 		 This package provides userspaces headers from the Linux kernel.  These headers


### PR DESCRIPTION
#### kernel-debs: linux-libc-dev: add `Conflicts: linux-libc-dev`

- kernel-debs: linux-libc-dev: add `Conflicts: linux-libc-dev`
  - can't remember if should add `Replaces: linux-libc-dev` as well
  Maybe-fixes: 22511b31cf7018de65fce7bf6ae41f88b47b4cfa