### PR TITLE
rock-5b: move `edge` (only) to mainline/Kwiboo u-boot 2024.04; store env in SPI (12Mb offset, with userspace support)

### DIFF
--- a/config/boards/rock-5b.csc
+++ b/config/boards/rock-5b.csc
@@ -27,3 +27,57 @@ function post_family_tweaks__rock5b_naming_audios() {
 
 	return 0
 }
+
+# Mainline u-boot or Kwiboo's tree
+function post_family_config_branch_edge__rock-5b_use_mainline_uboot() {
+	display_alert "$BOARD" "mainline (next branch) u-boot overrides for $BOARD / $BRANCH" "info"
+
+	unset BOOTFS_TYPE                                                     # mainline can boot from ext4 no problem
+	declare -g BOOTCONFIG="rock5b-rk3588_defconfig"                       # override the default for the board/family
+	declare -g BOOTDELAY=1                                                # Wait for UART interrupt to enter UMS/RockUSB mode etc
+	declare -g BOOTSOURCE="https://github.com/Kwiboo/u-boot-rockchip.git" # We ❤️ Kwiboo's tree
+	declare -g BOOTBRANCH="branch:rk3xxx-2024.04"                         # commit:31522fe7b3c7733313e1c5eb4e340487f6000196 as of 2024-04-01
+	declare -g BOOTPATCHDIR="v2024.04-rock5b-radxa"                       # empty; defconfig changes are done in hook below
+	declare -g BOOTDIR="u-boot-${BOARD}"                                  # do not share u-boot directory
+	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
+	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # disable stuff from rockchip64_common; we're using binman here which does all the work already
+
+	# Just use the binman-provided u-boot-rockchip.bin, which is ready-to-go
+	function write_uboot_platform() {
+		dd "if=$1/u-boot-rockchip.bin" "of=$2" bs=32k seek=1 conv=notrunc status=none
+	}
+
+	function write_uboot_platform_mtd() {
+		flashcp -v -p "$1/u-boot-rockchip-spi.bin" /dev/mtd0
+	}
+}
+
+function post_config_uboot_target__extra_configs_for_rock5b_mainline_environment_in_spi() {
+	[[ "${BRANCH}" != "edge" ]] && return 0
+
+	display_alert "$BOARD" "u-boot configs for ${BOOTBRANCH} u-boot config BRANCH=${BRANCH}" "info"
+	run_host_command_logged scripts/config --set-val CONFIG_ENV_IS_NOWHERE "n"
+	run_host_command_logged scripts/config --set-val CONFIG_ENV_IS_IN_SPI_FLASH "y"
+	run_host_command_logged scripts/config --set-val CONFIG_ENV_SECT_SIZE_AUTO "y"
+	run_host_command_logged scripts/config --set-val CONFIG_ENV_OVERWRITE "y"
+	run_host_command_logged scripts/config --set-val CONFIG_ENV_SIZE "0x20000"
+	run_host_command_logged scripts/config --set-val CONFIG_ENV_OFFSET "0xc00000"
+}
+
+# Include fw_setenv, configured to point to the correct spot on the SPI Flash
+PACKAGE_LIST_BOARD="libubootenv-tool" # libubootenv-tool provides fw_printenv and fw_setenv, for talking to U-Boot environment
+function post_family_tweaks__config_rock5b_fwenv() {
+	[[ "${BRANCH}" != "edge" ]] && return 0
+	display_alert "Configuring fw_printenv and fw_setenv" "for ${BOARD} and u-boot ${BOOTBRANCH}" "info"
+	# Addresses below come from CONFIG_ENV_OFFSET and CONFIG_ENV_SIZE in defconfig
+	cat <<- 'FW_ENV_CONFIG' > "${SDCARD}"/etc/fw_env.config
+		# MTD/SPI u-boot env for the Rock-5b
+		# MTD device name Device offset Env. size Flash sector size Number of sectors
+		/dev/mtd0         0xc00000      0x20000
+	FW_ENV_CONFIG
+}
+
+# I'm FED UP with this, @TODO lets make it part of core deps soon and cleanup all those hooks all spread around - lol it's another week and this still in
+function add_host_dependencies__new_uboot_wants_pyelftools() {
+	declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} python3-pyelftools" # @TODO: convert to array later
+}


### PR DESCRIPTION
#### rock-5b: move `edge` (only) to mainline/Kwiboo u-boot 2024.04; store env in SPI (12Mb offset, with userspace support)

- rock-5b: move `edge` (only) to mainline/Kwiboo u-boot 2024.04; store env in SPI (12Mb offset, with userspace support)