### PR TITLE
FriendlyElec CM3588-NAS: device tree fixes & improvements

### DIFF
--- a/patch/kernel/rockchip-rk3588-edge/dt/rk3588-nanopc-cm3588-nas.dts
+++ b/patch/kernel/rockchip-rk3588-edge/dt/rk3588-nanopc-cm3588-nas.dts
@@ -58,7 +58,6 @@
 		simple-audio-card,mclk-fs = <256>;
 
 		simple-audio-card,hp-det-gpio = <&gpio1 RK_PC4 GPIO_ACTIVE_LOW>;
-		simple-audio-card,hp-pin-name = "Headphones";
 
 		simple-audio-card,routing =
 			"Headphones", "HPOL",
@@ -69,7 +68,6 @@
 			"Headphone", "Headphones",
 			"Microphone", "Microphone Jack";
 		
-
 		simple-audio-card,cpu {
 			sound-dai = <&i2s0_8ch>;
 		};
@@ -80,11 +78,11 @@
 	};
 
 	fan: pwm-fan {
-		status = "disabled";
 		compatible = "pwm-fan";
 		#cooling-cells = <2>;
 		cooling-levels = <0 50 100 150 200 255>;
 		pwms = <&pwm1 0 50000 0>;
+		status = "disabled";
 	};
 
 	gpio_keys: gpio-keys {
@@ -92,7 +90,7 @@
 		pinctrl-names = "default";
 		pinctrl-0 = <&key1_pin>;
 
-		button@1 {
+		button-user {
 			debounce-interval = <50>;
 			gpios = <&gpio0 RK_PD5 GPIO_ACTIVE_LOW>;
 			label = "User Button";
@@ -221,7 +219,6 @@
 
 	vcc_3v3_sd_s0: vcc-3v3-sd-s0-regulator {
 		compatible = "regulator-fixed";
-		enable-active-low;
 		gpio = <&gpio4 RK_PA5 GPIO_ACTIVE_HIGH>;
 		pinctrl-names = "default";
 		pinctrl-0 = <&sd_s0_pwr>;
@@ -287,21 +284,11 @@
 	cpu-supply = <&vdd_cpu_big1_s0>;
 };
 
-/* @TODO: gpio0 to gpio4 is from rk3588-nanopc-t6.dts and is not yet adapted to CM3588 NAS */
-// &gpio0 {
-// 	gpio-line-names = /* GPIO0 A0-A7 */
-// 			  "", "", "", "",
-// 			  "", "", "", "",
-// 			  /* GPIO0 B0-B7 */
-// 			  "", "", "", "",
-// 			  "", "", "", "",
-// 			  /* GPIO0 C0-C7 */
-// 			  "", "", "", "",
-// 			  "HEADER_10", "HEADER_08", "HEADER_32", "",
-// 			  /* GPIO0 D0-D7 */
-// 			  "", "", "", "",
-// 			  "", "", "", "";
-// };
+/* Properties "clock" and "clock-names" introduced by Collabora https://gitlab.collabora.com/hardware-enablement/rockchip-3588/linux/-/commit/8fff68cb7cfe1e698445896252e34f79fad41720 */
+&display_subsystem {
+	clocks = <&hdptxphy_hdmi0>;
+	clock-names = "hdmi0_phy_pll";
+};
 
 /* Signal labels [SIGNAL_LABEL] are from the official CM3588 NAS schematic revision 2309 */
 /* Some GPIOs like USB, sdmmc or SPI-NOR are not listed here */
@@ -389,11 +376,6 @@
 	mali-supply = <&vdd_gpu_s0>;
 	sram-supply = <&vdd_gpu_mem_s0>;
 	status = "okay";
-};
-
-&display_subsystem {
-	clocks = <&hdptxphy_hdmi0>;
-	clock-names = "hdmi0_phy_pll";
 };
 
 &hdmi0 {
@@ -495,6 +477,19 @@
 	};
 };
 
+&i2c4 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c4m3_xfer>;
+	status = "disabled";
+};
+
+/* Connected to MIPI-DSI0 */
+&i2c5 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c5m0_xfer>;
+	status = "disabled";
+};
+
 &i2c6 {
 	clock-frequency = <200000>;
 	pinctrl-names = "default";
@@ -577,7 +572,7 @@
 	};
 };
 
-/* Connected with MIPI-CSI1 */
+/* Connected to MIPI-CSI1 */
 &i2c7 {
 	clock-frequency = <200000>;
 	status = "okay";
@@ -599,7 +594,7 @@
 	};
 };
 
-/* Connected with Header_2.54MM */
+/* GPIO Connector, connected to 40-pin GPIO header */
 &i2c8 {
 	pinctrl-0 = <&i2c8m2_xfer>;
 };
@@ -866,22 +861,24 @@
 	};
 };
 
+/* Connected to 5V Fan */
 &pwm1 {
 	pinctrl-0 = <&pwm1m1_pins>;
 	status = "okay";
 };
 
-/* Connected with MIPI-DSI0 */
+/* Connected to MIPI-DSI0 */
 &pwm2 {
 	pinctrl-0 = <&pwm2m1_pins>;
 };
 
-/* GPIO Connector */
+/* GPIO Connector, connected to 40-pin GPIO header */
 &pwm5 {
 	pinctrl-0 = <&pwm5m1_pins>;
 	status = "okay";
 };
 
+/* GPIO Connector */
 &pwm8 {
 	pinctrl-0 = <&pwm8m0_pins>;
 	status = "okay";
@@ -902,7 +899,6 @@
 &sdhci {
 	bus-width = <8>;
 	full-pwr-cycle-in-suspend;
-	max-frequency = <200000000>;
 	mmc-hs400-1_8v;
 	mmc-hs400-enhanced-strobe;
 	no-sd;
@@ -928,8 +924,10 @@
 };
 
 /* GPIO Connector */
-&spi1 {
-	status = "okay";
+&spi0 {
+	num-cs = <1>;
+	pinctrl-0 = <&spi0m2_cs0 &spi0m2_pins>;
+	status = "disabled";
 };
 
 &spi2 {
@@ -1258,7 +1256,7 @@
 	};
 };
 
-/* GPIO Connector */
+/* GPIO Connector, connected to 40-pin GPIO header */
 &spi4 {
 	num-cs = <1>;
 	pinctrl-0 = <&spi4m1_cs0 &spi4m1_pins>;
@@ -1269,7 +1267,7 @@
 	status = "okay";
 };
 
-/* GPIO Connector */
+/* GPIO Connector, connected to 40-pin GPIO header */
 &uart0 {
 	pinctrl-0 = <&uart0m0_xfer>;
 	status = "disabled";
@@ -1281,31 +1279,31 @@
 	status = "okay";
 };
 
-/* GPIO Connector */
+/* GPIO Connector, connected to 40-pin GPIO header */
 &uart3 {
 	pinctrl-0 = <&uart3m1_xfer>;
 	status = "disabled";
 };
 
-/* GPIO Connector */
+/* GPIO Connector, connected to 40-pin GPIO header */
 &uart4 {
 	pinctrl-0 = <&uart4m2_xfer>;
 	status = "disabled";
 };
 
-/* GPIO Connector */
+/* GPIO Connector, connected to 40-pin GPIO header */
 &uart6 {
 	pinctrl-0 = <&uart6m1_xfer>;
 	status = "okay";
 };
 
-/* GPIO Connector */
+/* GPIO Connector, connected to 40-pin GPIO header */
 &uart7 {
 	pinctrl-0 = <&uart7m2_xfer>;
 	status = "disabled";
 };
 
-/* GPIO Connector */
+/* GPIO Connector, connected to 40-pin GPIO header */
 &uart8 {
 	pinctrl-0 = <&uart8m1_xfer>;
 	status = "disabled";


### PR DESCRIPTION
# Description
The device tree for the FriendlyElec CM3588-NAS is improved in the following ways:
- Add detailed GPIO descriptions
- Add &spi0, &i2c4, &i2c5 for the pin-conections (all disabled)
- Remove &spi1 since it's not available on the board
- vcc_3v3_sd_s0: remove unevaluated property flasgs"enable-active-low", it's unneeded since the default assumed is Active low (linux/Documentation/devicetree/bindings/regulator/fixed-regulator.yaml)
- analog-sound: remove unevaluated property "simple-audio-card,hp-pin-name"
- &sdhci: remove "max-frequency = <200000000>;" since this value already defined as default in rk3588s.dtsi
- Rename node "button@1" to "button-user"
- Move "status" property to bottom, even if disabled
- Improve comments

# How Has This Been Tested?

- [x] `./compile.sh BOARD=nanopc-cm3588-nas BRANCH=edge kernel`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
