### PR TITLE
rockchip-rk3588-edge: opi5: fix typec and add support for GPU

### DIFF
--- a/patch/kernel/rockchip-rk3588-edge/1031-Add-missing-nodes-to-Orange-Pi-5.patch
+++ b/patch/kernel/rockchip-rk3588-edge/1031-Add-missing-nodes-to-Orange-Pi-5.patch
@@ -4,11 +4,11 @@ Date: Thu, 16 Nov 2023 18:09:07 +0300
 Subject: arm64: dts: Add missing nodes to Orange Pi 5
 
 ---
- arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dts | 197 +++++++++-
- 1 file changed, 196 insertions(+), 1 deletion(-)
+ arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dts | 203 +++++++++-
+ 1 file changed, 201 insertions(+), 2 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dts b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dts
-index 25de4362af38..42ce897faf0f 100644
+index 25de4362af38..621049e1492b 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dts
 @@ -6,6 +6,8 @@
@@ -104,7 +104,7 @@ index 25de4362af38..42ce897faf0f 100644
  };
  
  &gmac1 {
-@@ -223,6 +267,75 @@ hym8563: rtc@51 {
+@@ -223,6 +267,80 @@ hym8563: rtc@51 {
  		interrupts = <RK_PB0 IRQ_TYPE_LEVEL_LOW>;
  		wakeup-source;
  	};
@@ -177,10 +177,15 @@ index 25de4362af38..42ce897faf0f 100644
 +	             &i2s1m0_sdi1
 +	             &i2s1m0_sdo3>;
 +	status = "okay";
++};
++
++&gpu {
++	mali-supply = <&vdd_gpu_s0>;
++	status = "okay";
  };
  
  &mdio1 {
-@@ -263,6 +376,12 @@ typec5v_pwren: typec5v-pwren {
+@@ -263,6 +381,12 @@ typec5v_pwren: typec5v-pwren {
  			rockchip,pins = <3 RK_PC0 RK_FUNC_GPIO &pcfg_pull_none>;
  		};
  	};
@@ -193,7 +198,16 @@ index 25de4362af38..42ce897faf0f 100644
  };
  
  &saradc {
-@@ -364,7 +483,7 @@ regulator-state-mem {
+@@ -336,7 +460,7 @@ pmic@0 {
+ 		#gpio-cells = <2>;
+ 
+ 		rk806_dvs1_null: dvs1-null-pins {
+-			pins = "gpio_pwrctrl2";
++			pins = "gpio_pwrctrl1";
+ 			function = "pin_fun0";
+ 		};
+ 
+@@ -364,7 +488,7 @@ regulator-state-mem {
  				};
  			};
  
@@ -202,7 +216,7 @@ index 25de4362af38..42ce897faf0f 100644
  				regulator-name = "vdd_cpu_lit_s0";
  				regulator-always-on;
  				regulator-boot-on;
-@@ -625,6 +744,14 @@ &tsadc {
+@@ -625,6 +749,14 @@ &tsadc {
  	status = "okay";
  };
  
@@ -217,16 +231,16 @@ index 25de4362af38..42ce897faf0f 100644
  &u2phy2 {
  	status = "okay";
  };
-@@ -650,10 +777,48 @@ &usb_host0_ehci {
+@@ -650,10 +782,48 @@ &usb_host0_ehci {
  	status = "okay";
  };
  
 +&usbdp_phy0 {
 +	orientation-switch;
 +	mode-switch;
-+	svid = <0xff01>;
 +	sbu1-dc-gpios = <&gpio4 RK_PA5 GPIO_ACTIVE_HIGH>;
 +	sbu2-dc-gpios = <&gpio4 RK_PA7 GPIO_ACTIVE_HIGH>;
++	status = "okay";
 +
 +	port {
 +		#address-cells = <1>;
@@ -250,7 +264,7 @@ index 25de4362af38..42ce897faf0f 100644
  
 +&usb_host0_xhci {
 +	usb-role-switch;
-+	dr_mode = "otg";
++	role-switch-default-mode = "host";
 +	status = "okay";
 +
 +	port {
@@ -266,21 +280,16 @@ index 25de4362af38..42ce897faf0f 100644
  &usb_host1_ehci {
  	status = "okay";
  };
-@@ -665,3 +830,33 @@ &usb_host1_ohci {
+@@ -665,3 +835,32 @@ &usb_host1_ohci {
  &usb_host2_xhci {
  	status = "okay";
  };
-+
-+&hdmi0 {
-+	status = "okay";
-+};
-+
 +
 +&hdptxphy_hdmi0 {
 +	status = "okay";
 +};
 +
-+&vop_mmu {
++&hdmi0 {
 +	status = "okay";
 +};
 +
@@ -288,6 +297,10 @@ index 25de4362af38..42ce897faf0f 100644
 +	hdmi0_in_vp0: endpoint {
 +		remote-endpoint = <&vp0_out_hdmi0>;
 +	};
++};
++
++&vop_mmu {
++	status = "okay";
 +};
 +
 +&vop {


### PR DESCRIPTION
# Description
This PR:
- Adds GPU node to Orange Pi 5
- Fixes USB-C host mode

[Jira](https://armbian.atlassian.net/jira) reference number [AR-9999]

# How Has This Been Tested?
- [x] Confirmed vertical USB and TYPEC works
- [x] Panthor also works
