### PR TITLE
rockchip-rk3588-edge: opi5b: add support for pcie wifi

### DIFF
--- a/patch/kernel/rockchip-rk3588-edge/dt/rk3588s-orangepi-5b.dts
+++ b/patch/kernel/rockchip-rk3588-edge/dt/rk3588s-orangepi-5b.dts
@@ -28,3 +28,21 @@
 &sfc {
 	status = "disabled";
 };
+
+&pcie2x1l2 {
+	pcie@0,0 {
+		reg = <0x400000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+		device_type = "pci";
+		bus-range = <0x40 0x4f>;
+
+		wifi: wifi@0,0 {
+			compatible = "pci14e4,449d";
+			reg = <0x410000 0 0 0 0>;
+			clocks = <&hym8563>;
+			clock-names = "32k";
+		};
+	};
+};


### PR DESCRIPTION
# Description

Add support for AP6275P wifi on Orange Pi 5B.
[Jira](https://armbian.atlassian.net/jira) reference number [AR-9999]

# How Has This Been Tested?
- [x] It builds

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
