### PR TITLE
ramlog: harden the zram mounting

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-ramlog
+++ b/packages/bsp/common/usr/lib/armbian/armbian-ramlog
@@ -126,7 +126,7 @@ case "$1" in
 		case $LOG_TYPE in
 			zram)
 				echo -e "Mounting $rd as $RAM_LOG \c" | $LOG_OUTPUT
-				mount -o discard $rd $RAM_LOG 2>&1 | $LOG_OUTPUT
+				mount -o discard,nosuid,noexec,nodev $rd $RAM_LOG 2>&1 | $LOG_OUTPUT
 				;;
 			tmpfs)
 				echo -e "Setting up $RAM_LOG as tmpfs \c" | $LOG_OUTPUT


### PR DESCRIPTION
# Description

this is to improve the score of /var/log for [FILE-6374](https://github.com/CISOfy/lynis/blob/967b9f1ec7ff504c91805bbf6f8e6ff170d05173/include/tests_filesystems#L554-L574) in Lynis audit

<details>
<summary>before</summary>

```
[+] File systems
------------------------------------
  - Mount options of /boot                                    [ HARDENED ]
  - Mount options of /dev                                     [ PARTIALLY HARDENED ]
  - Mount options of /dev/shm                                 [ PARTIALLY HARDENED ]
  - Mount options of /run                                     [ HARDENED ]
  - Mount options of /tmp                                     [ HARDENED ]
  - Mount options of /var/log                                 [ PARTIALLY HARDENED ]
```
</details>
<details>
<summary>after</summary>

```
[+] File systems
------------------------------------
  - Mount options of /boot                                    [ HARDENED ]
  - Mount options of /dev                                     [ PARTIALLY HARDENED ]
  - Mount options of /dev/shm                                 [ PARTIALLY HARDENED ]
  - Mount options of /run                                     [ HARDENED ]
  - Mount options of /tmp                                     [ HARDENED ]
  - Mount options of /var/log                                 [ HARDENED ]
```
</details>

---

Also, I saw that when using tmpfs, the mount options are already hardened.
https://github.com/armbian/build/blob/aee4c495a1c989723f7874b636088ba46f9fedf2/packages/bsp/common/usr/lib/armbian/armbian-ramlog#L133
So for the consistency, why not we do the same when using zram? 😉 

# How Has This Been Tested?

Run Lynis with the parameters below
```
./lynis audit system --tests FILE-6374
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
