### PR TITLE
Corrected documentation error in Rockchip overlays

### DIFF
--- a/patch/kernel/archive/rockchip64-6.6/overlay/README.rockchip-overlays
+++ b/patch/kernel/archive/rockchip64-6.6/overlay/README.rockchip-overlays
@@ -197,7 +197,7 @@ Details for Rock Pi-S overlays  (2 Mar 2024):
 
 Older V1.1, V1.2, and those V1.3 boards produced during 2022 and 2023
 use a the B-S variant of the RK3308 that is optimized for lower core voltages.
-Per Radxa, these chips will be marked RK3308B-S instead of RK3308B 
+Per Radxa, these chips will be marked RK3308B-S instead of RK3308B
 All boards utilizing the RK3308B-S part should apply the:
 ###  rk3308-bs
 overlay to lower the core voltages to reduce power consumption.
@@ -244,12 +244,12 @@ Details for Rock S0 overlays  (2 Mar 2024):
 By default, the internal WiFi selects its internal chip antenna.
 This antenna is so noisy as to be nearly unusable.
 The external antenna, fortunately, works quite well.
-Install an external WiFi antenna and select it with:
+Connect an external WiFi antenna and select it with:
 ###  rk3308-s0-ext-antenna
 
 All Rock S0 boards use the RK3308B chip.
 The:
-###  rk3308-bs@1.3ghz
+###  rk3308-b@1.3ghz
 overlay enables (overclocked) operation at 1.3ghz
 1.3Ghz operation appears stable on the two boards I've tested.
 

--- a/patch/kernel/archive/rockchip64-6.6/overlay/README.rockchip-overlays
+++ b/patch/kernel/archive/rockchip64-6.6/overlay/README.rockchip-overlays
@@ -239,7 +239,7 @@ Note that older mainline kernels cannot drive the SDIO clock faster than 10Mhz.
 
 
 **********************************
-Details for Rock S0 overlays  (2 Mar 2024):
+Details for Rock S0 overlays  (10 Apr 2024):
 
 By default, the internal WiFi selects its internal chip antenna.
 This antenna is so noisy as to be nearly unusable.

--- a/patch/kernel/archive/rockchip64-6.8/overlay/README.rockchip-overlays
+++ b/patch/kernel/archive/rockchip64-6.8/overlay/README.rockchip-overlays
@@ -202,7 +202,7 @@ To overclock the RK3308B, apply:
 
 V1.3 boards produced during 2022 and most of 2023 use the lower voltage
 B-S variant of the RK3308.
-Per Radxa, these chips will be marked RK3308BS instead of RK3308B 
+Per Radxa, these chips will be marked RK3308BS instead of RK3308B
 All boards utilizing the RK3308B-S part should apply the:
 ###  rk3308-bs
 overlay to operate at the appropriate (lower) the core voltage.
@@ -213,7 +213,7 @@ Optionally, boards utilizing the RK3308B-S parts may add the
 to overclock the B-S CPU to 1.3Ghz.
 Apply the rk3308-bs@1.3Ghz overlay  *after applying*  rk3308-bs
 
-Applying the *-bs overlays to the B variant of the SOC may result in 
+Applying the *-bs overlays to the B variant of the SOC may result in
 unstable operation due to undervolting.
 Applying the rk3308-b@1.3ghz to a BS variant chip consumes more power and
 has the potential to damage the SOC due to overvolting.
@@ -242,17 +242,18 @@ Note that older mainline kernels cannot drive the SDIO clock faster than 10Mhz.
 
 
 **********************************
-Details for Rock S0 overlays  (2 Mar 2024):
+Details for Rock S0 overlays  (10 Apr 2024):
 
-By default, the internal WiFi uses its internal chip antenna.
-Almost any external antenna will improve WiFi performance over the internal one.
-Install an external WiFi antenna and select it by applying the overlay:
+By default, the internal WiFi selects its internal chip antenna.
+This antenna is so noisy as to be nearly unusable.
+The external antenna, fortunately, works quite well.
+Connect an external WiFi antenna and select it with:
 ###  rk3308-s0-ext-antenna
 
 All Rock S0 boards use the RK3308B chip.
-So, applying the overlay:
+The:
 ###  rk3308-b@1.3ghz
-enables (overclocked) operation at 1.3ghz
+overlay enables (overclocked) operation at 1.3ghz
+1.3Ghz operation appears stable on the two boards I've tested.
 
 The legacy kernel is not supported on the Rock S0
-


### PR DESCRIPTION
The overlay enabling operation @1.3ghz for the RK3308-b silicon is rk3308-b@1.3ghz -- not rk3308-bs@1.3ghz

# Description

The overlay README refers to the wrong overlay file.
