### PR TITLE
rockchip64-edge: add pcie support to orangepi rk3399

### DIFF
--- a/patch/kernel/archive/rockchip64-6.8/board-orangepi-rk3399-pcie.patch
+++ b/patch/kernel/archive/rockchip64-6.8/board-orangepi-rk3399-pcie.patch
@@ -1,0 +1,68 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: amazingfate <liujianfeng1994@gmail.com>
+Date: Thu, 18 Apr 2024 00:42:13 +0800
+Subject: arm64: dts: rockchip: add pcie support to orangepi rk3399 board
+
+---
+ arch/arm64/boot/dts/rockchip/rk3399-orangepi.dts | 31 ++++++++++
+ 1 file changed, 31 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-orangepi.dts b/arch/arm64/boot/dts/rockchip/rk3399-orangepi.dts
+index e7551449e718..fc23d4733509 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-orangepi.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3399-orangepi.dts
+@@ -124,6 +124,17 @@ vcc3v0_sd: vcc3v0-sd {
+ 		vin-supply = <&vcc3v3_sys>;
+ 	};
+ 
++	vcc3v3_pcie: vcc3v3-pcie-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio0 2 0>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pcie_drv>;
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-name = "vcc3v3_pcie";
++	};
++
+ 	vcc3v3_sys: vcc3v3-sys {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vcc3v3_sys";
+@@ -588,6 +599,20 @@ &io_domains {
+ 	gpio1830-supply = <&vcc_3v0>;
+ };
+ 
++&pcie_phy {
++	status = "okay";
++	assigned-clocks = <&cru 138>;
++	assigned-clock-parents = <&cru 167>;
++	assigned-clock-rates = <100000000>;
++};
++
++&pcie0 {
++	status = "okay";
++	ep-gpios = <&gpio2 4 0>;
++	num-lanes = <4>;
++	max-link-speed = <1>;
++};
++
+ &pmu_io_domains {
+ 	status = "okay";
+ 	pmu1830-supply = <&vcc_3v0>;
+@@ -610,6 +635,12 @@ phy_rstb: phy-rstb {
+ 		};
+ 	};
+ 
++	pcie {
++		pcie_drv: pcie-drv {
++			rockchip,pins = <0 2 0 &pcfg_pull_none>;
++		};
++	};
++
+ 	pmic {
+ 		cpu_b_sleep: cpu-b-sleep {
+ 			rockchip,pins = <1 RK_PC1 RK_FUNC_GPIO &pcfg_pull_down>;
+-- 
+Armbian
+


### PR DESCRIPTION
# Description

This dts patch is based on an overlay I wrote before: https://paste.armbian.com/raw/uqopizudow which tested by an user of opi rk3399.
I don't have this board so it's better someone has it can test.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [ ] `./compile.sh kernel BOARD=orangepi-rk3399 BRANCH=edge DEB_COMPRESS=xz KERNEL_CONFIGURE=no KERNEL_GIT=shallow`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
