### PR TITLE
bcm2711: Use FS UUID and write config.txt and cmdline.txt earlier

### DIFF
--- a/config/sources/families/bcm2711.conf
+++ b/config/sources/families/bcm2711.conf
@@ -292,7 +292,7 @@ function pre_umount_final_image__write_raspi_config() {
 
 function pre_umount_final_image__write_raspi_cmdline() {
 	cat <<- EOD > "${MOUNT}"/boot/firmware/cmdline.txt
-		console=serial0,115200 console=tty1 loglevel=1 root=LABEL=${ROOT_FS_LABEL} rootfstype=${ROOTFS_TYPE} fsck.repair=yes rootwait logo.nologo cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory
+		console=serial0,115200 console=tty1 loglevel=1 root=UUID=${ROOT_PART_UUID} rootfstype=${ROOTFS_TYPE} fsck.repair=yes rootwait logo.nologo cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory
 	EOD
 
 	if [[ "${SHOW_DEBUG}" == "yes" ]]; then

--- a/config/sources/families/bcm2711.conf
+++ b/config/sources/families/bcm2711.conf
@@ -237,8 +237,9 @@ function pre_umount_final_image__remove_esp() {
 }
 
 # write the default config.txt config
-function pre_umount_final_image__write_raspi_config() {
-	cat <<- EOD > "${MOUNT}"/boot/firmware/config.txt
+function pre_install_distribution_specific__write_raspi_config() {
+	mkdir -p "${SDCARD}"/boot/firmware
+	cat <<- EOD > "${SDCARD}"/boot/firmware/config.txt
 		# For more options and information see
 		# http://rptl.io/configtxt
 		# Some settings may impact device functionality. See link above for details
@@ -290,10 +291,18 @@ function pre_umount_final_image__write_raspi_config() {
 	EOD
 }
 
-function pre_umount_final_image__write_raspi_cmdline() {
-	cat <<- EOD > "${MOUNT}"/boot/firmware/cmdline.txt
-		console=serial0,115200 console=tty1 loglevel=1 root=UUID=${ROOT_PART_UUID} rootfstype=${ROOTFS_TYPE} fsck.repair=yes rootwait logo.nologo cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory
+function pre_install_distribution_specific__write_raspi_cmdline() {
+	# Write most of the commandline early, to allow customizing it
+	mkdir -p "${SDCARD}"/boot/firmware
+	cat <<- EOD > "${SDCARD}"/boot/firmware/cmdline.txt
+		console=serial0,115200 console=tty1 loglevel=1 rootfstype=${ROOTFS_TYPE} fsck.repair=yes rootwait logo.nologo cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory
 	EOD
+}
+
+function pre_umount_final_image__write_raspi_cmdline_root() {
+	# Write the root option late, since we only know the FS UUID
+	# when the image is being created
+	sed -i "s/$/ root=UUID=${ROOT_PART_UUID}/" "${MOUNT}"/boot/firmware/cmdline.txt
 
 	if [[ "${SHOW_DEBUG}" == "yes" ]]; then
 		display_alert "Showing /boot/firmware as mounted" "bcm2711" "debug"


### PR DESCRIPTION
# Description

This PR makes two changes for the bcm2711 family:
 1. Use FS UUID for mounting the root filesystem instead of the FS label, bringing this family in line with most other boards.
 2. Write `config.txt` and `cmdline.txt` earlier, allowing it to be modified from `customize-image-host.sh` or `customize-image.sh`.

These two changes are conceptually independent, but touch the same area of code, so I put them in a single PR instead of splitting them.

# Documentation summary for feature / change

No documentation needed.

# How Has This Been Tested?

 - Built for rpi4b, with customizations to cmdline.txt and config.txt in `customize-image-host.sh`. Tested on rpi3b+ board.
 - I do not have a rpi5 to test with, but I expect no issues there.

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Raspberry Pi firmware configuration during image installation.
  * Updated kernel command-line generation to reference the root filesystem by partition UUID, improving reliability across storage layouts.
  * Ensured firmware configuration files are written to the correct boot directory earlier in the installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->