### PR TITLE
Fixing missing host dependency: adding python3-pyelftools

### DIFF
--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -290,7 +290,7 @@ function adaptative_prepare_host_dependencies() {
 	host_deps_add_extra_python # See python-tools.sh::host_deps_add_extra_python()
 
 	# Python3 -- required for Armbian's Python tooling, and also for more recent u-boot builds. Needs 3.9+; ffi-dev is needed for some Python packages when the wheel is not prebuilt
-	host_dependencies+=("python3-dev" "python3-distutils" "python3-setuptools" "python3-pip" "libffi-dev")
+	host_dependencies+=("python3-dev" "python3-distutils" "python3-setuptools" "python3-pip" "python3-pyelftools" "libffi-dev")
 
 	# Python2 -- required for some older u-boot builds
 	# Debian 'sid'/'bookworm' and Ubuntu 'lunar' does not carry python2 anymore; in this case some u-boot's might fail to build.


### PR DESCRIPTION
# Description

After bumping rk3319-box u-boot to most recent versions, we need pure-python3 library for parsing ELF and DWARF

https://github.com/armbian/build/pull/6509

# How Has This Been Tested?

- [x] Manual build on machine where previously failed

# Checklist:

- [x] My changes generate no new warnings