### PR TITLE
Board: h96 rk3566 HDMI sound & audio fix 

### DIFF
--- a/patch/kernel/archive/rockchip64-6.1/add-board-h96-tvbox-3566.patch
+++ b/patch/kernel/archive/rockchip64-6.1/add-board-h96-tvbox-3566.patch
@@ -194,17 +194,18 @@ index 000000000..6a53d23a5
 +       post-power-on-delay-ms = <100>;
 +	};
 +
-+	rk809-sound {
++	rk809_sound: rk809-sound {
++		status = "okay";
 +		compatible = "simple-audio-card";
 +		simple-audio-card,format = "i2s";
-+		simple-audio-card,name = "Analog RK809";
++		simple-audio-card,name = "rockchip,rk809-codec";
 +		simple-audio-card,mclk-fs = <256>;
 +
 +		simple-audio-card,cpu {
 +			sound-dai = <&i2s1_8ch>;
 +		};
 +		simple-audio-card,codec {
-+			sound-dai = <&rk809>;
++			sound-dai = <&rk809_codec>;
 +		};
 +	};
 +
@@ -265,6 +266,8 @@ index 000000000..6a53d23a5
 +};
 +
 +&hdmi {
++	assigned-clocks = <&cru CLK_HDMI_CEC>;
++	assigned-clock-rates = <32768>;
 +	avdd-0v9-supply = <&vdda0v9_image>;
 +	avdd-1v8-supply = <&vcca1v8_image>;
 +	status = "okay";
@@ -297,14 +300,14 @@ index 000000000..6a53d23a5
 +	vdd_cpu: regulator@1c {
 +		compatible = "tcs,tcs4525";
 +		reg = <0x1c>;
-+		vin-supply = <&vcc5v0_sys>;
++		fcs,suspend-voltage-selector = <1>;
 +		regulator-name = "vdd_cpu";
 +		regulator-min-microvolt = <800000>;
 +		regulator-max-microvolt = <1150000>;
 +		regulator-ramp-delay = <2300>;
-+		fcs,suspend-voltage-selector = <1>;
-+		regulator-boot-on;
 +		regulator-always-on;
++		regulator-boot-on;
++		vin-supply = <&vcc5v0_sys>;
 +
 +		regulator-state-mem {
 +			regulator-off-in-suspend;
@@ -316,7 +319,8 @@ index 000000000..6a53d23a5
 +		reg = <0x20>;
 +		interrupt-parent = <&gpio0>;
 +		interrupts = <RK_PA3 IRQ_TYPE_LEVEL_LOW>;
-+		#clock-cells = <1>;
++       #clock-cells = <1>;
++       #sound-dai-cells
 +		clock-output-names = "rk808-clkout1", "rk808-clkout2";
 +		pinctrl-names = "default";
 +		pinctrl-0 = <&pmic_int_l>;
@@ -338,11 +342,11 @@ index 000000000..6a53d23a5
 +				regulator-name = "vdd_logic";
 +				regulator-always-on;
 +				regulator-boot-on;
-+				regulator-init-microvolt = <900000>;
-+				regulator-initial-mode = <0x2>;
 +				regulator-min-microvolt = <500000>;
 +				regulator-max-microvolt = <1350000>;
++				regulator-init-microvolt = <900000>;
 +				regulator-ramp-delay = <6001>;
++				regulator-initial-mode = <0x2>;
 +				regulator-state-mem {
 +					regulator-off-in-suspend;
 +				};
@@ -495,7 +499,7 @@ index 000000000..6a53d23a5
 +				regulator-boot-on;
 +				regulator-min-microvolt = <1800000>;
 +				regulator-max-microvolt = <1800000>;
-+				regulator-name = "vcca1v8_image";
++				regulator-name = "vcc_1v8";
 +				regulator-state-mem {
 +					regulator-off-in-suspend;
 +				};
@@ -522,7 +526,7 @@ index 000000000..6a53d23a5
 +			};
 +		};
 +
-+			codec {
++			rk809_codec: codec {
 +				mic-in-differential;
 +			};
 +		};
@@ -535,11 +539,10 @@ index 000000000..6a53d23a5
 +&i2s1_8ch {
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&i2s1m0_sclktx
-+		     &i2s1m0_lrcktx
-+		     &i2s1m0_sdi0
-+		     &i2s1m0_sdo0>;
++		        &i2s1m0_lrcktx
++		        &i2s1m0_sdi0
++		        &i2s1m0_sdo0>;
 +	rockchip,trcm-sync-tx-only;
-+	status = "okay";
 +};
 +
 +&mdio1 {
@@ -716,6 +719,7 @@ index 000000000..6a53d23a5
 +	dma-names = "tx", "rx";
 +	pinctrl-0 = <&uart1m0_xfer &uart1m0_ctsn &uart1m0_rtsn>;
 +	status = "okay";
++ 	uart-has-rtscts;
 +
 +	bluetooth {
 +		compatible = "brcm,bcm43438-bt";
@@ -772,6 +776,10 @@ index 000000000..6a53d23a5
 +&vop {
 +	assigned-clocks = <&cru DCLK_VOP0>, <&cru DCLK_VOP1>;
 +	assigned-clock-parents = <&pmucru PLL_HPLL>, <&cru PLL_VPLL>;
++	status = "okay";
++};
++
++&vpu {
 +	status = "okay";
 +};
 +

--- a/patch/kernel/archive/rockchip64-6.6/dt/rk3566-h96-tvbox.dts
+++ b/patch/kernel/archive/rockchip64-6.6/dt/rk3566-h96-tvbox.dts
@@ -176,17 +176,18 @@
 		post-power-on-delay-ms = <100>;
 	};
 
-	rk809-sound {
+	rk809_sound: rk809-sound {
+		status = "okay";
 		compatible = "simple-audio-card";
 		simple-audio-card,format = "i2s";
-		simple-audio-card,name = "Analog RK809";
+		simple-audio-card,name = "rockchip,rk809-codec";
 		simple-audio-card,mclk-fs = <256>;
 
 		simple-audio-card,cpu {
 			sound-dai = <&i2s1_8ch>;
 		};
 		simple-audio-card,codec {
-			sound-dai = <&rk809>;
+			sound-dai = <&rk809_codec>;
 		};
 	};
 
@@ -247,6 +248,8 @@
 };
 
 &hdmi {
+	assigned-clocks = <&cru CLK_HDMI_CEC>;
+	assigned-clock-rates = <32768>;
 	avdd-0v9-supply = <&vdda0v9_image>;
 	avdd-1v8-supply = <&vcca1v8_image>;
 	status = "okay";
@@ -299,6 +302,7 @@
 		interrupt-parent = <&gpio0>;
 		interrupts = <RK_PA3 IRQ_TYPE_LEVEL_LOW>;
 		#clock-cells = <1>;
+		#sound-dai-cells
 		clock-output-names = "rk808-clkout1", "rk808-clkout2";
 		pinctrl-names = "default";
 		pinctrl-0 = <&pmic_int_l>;
@@ -504,11 +508,11 @@
 			};
 		};
 
-			codec {
-				mic-in-differential;
-			};
+		rk809_codec: codec {
+			mic-in-differential;
 		};
 	};
+};
 
 &i2s0_8ch {
 	status = "okay";
@@ -517,11 +521,10 @@
 &i2s1_8ch {
 	pinctrl-names = "default";
 	pinctrl-0 = <&i2s1m0_sclktx
-		     &i2s1m0_lrcktx
-		     &i2s1m0_sdi0
-		     &i2s1m0_sdo0>;
+				 &i2s1m0_lrcktx
+				 &i2s1m0_sdi0
+				 &i2s1m0_sdo0>;
 	rockchip,trcm-sync-tx-only;
-	status = "okay";
 };
 
 &mdio1 {
@@ -698,6 +701,7 @@
 	dma-names = "tx", "rx";
 	pinctrl-0 = <&uart1m0_xfer &uart1m0_ctsn &uart1m0_rtsn>;
 	status = "okay";
+	uart-has-rtscts;
 
 	bluetooth {
 		compatible = "brcm,bcm43438-bt";
@@ -754,6 +758,10 @@
 &vop {
 	assigned-clocks = <&cru DCLK_VOP0>, <&cru DCLK_VOP1>;
 	assigned-clock-parents = <&pmucru PLL_HPLL>, <&cru PLL_VPLL>;
+	status = "okay";
+};
+
+&vpu {
 	status = "okay";
 };
 


### PR DESCRIPTION
Board: H96 max rk3566 HDMI sound & audio fix

Fixed dmesg sound error - shifting to jammy gnome



# How Has This Been Tested?

Compiled Kernel 6.6 and flash to device EMMC

# Checklist:

_Please delete options that are not relevant._

- [ X ] My code follows the style guidelines of this project
- [ X ] I have performed a self-review of my own code
- [ X ] I have commented my code, particularly in hard-to-understand areas
- [ X ] My changes generate no new warnings
- [ X ] Any dependent changes have been merged and published in downstream modules
