### PR TITLE
odroidn2: u-boot: fix eMMC stability

### DIFF
--- a/patch/u-boot/v2022.10/board_odroidn2/0001-mmc-meson_gx_mmc-limit-f_max-to-24-MHz.patch
+++ b/patch/u-boot/v2022.10/board_odroidn2/0001-mmc-meson_gx_mmc-limit-f_max-to-24-MHz.patch
@@ -1,0 +1,42 @@
+From dc847a8091517dea6b4c07f7ed3b11cb8123b726 Mon Sep 17 00:00:00 2001
+From: Martin Pietryka <martin@pietryka.at>
+Date: Fri, 26 Apr 2024 15:43:21 +0200
+Subject: [PATCH] mmc: meson_gx_mmc: limit f_max to 24 MHz
+
+This fixes issues on the Odroid N2+ where reading from the eMMC is
+unreliable in U-Boot and probably being temperature dependent.
+
+Changing the clock phase to CLK_CO_PHASE_270 also improved stability, but
+a mailing-list post indicates that this could lead to other instabilities
+with other eMMC cards, see:
+ - https://lists.denx.de/pipermail/u-boot/2020-December/434954.html
+
+Signed-off-by: Martin Pietryka <martin@pietryka.at>
+---
+ drivers/mmc/meson_gx_mmc.c | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/mmc/meson_gx_mmc.c b/drivers/mmc/meson_gx_mmc.c
+index fcf4f03d1e..9ecffccee4 100644
+--- a/drivers/mmc/meson_gx_mmc.c
++++ b/drivers/mmc/meson_gx_mmc.c
+@@ -279,7 +279,15 @@ static int meson_mmc_probe(struct udevice *dev)
+ 	cfg->host_caps = MMC_MODE_8BIT | MMC_MODE_4BIT |
+ 			MMC_MODE_HS_52MHz | MMC_MODE_HS;
+ 	cfg->f_min = DIV_ROUND_UP(SD_EMMC_CLKSRC_24M, CLK_MAX_DIV);
+-	cfg->f_max = 100000000; /* 100 MHz */
++
++	/*
++	 * Some SoCs have issues with higher frequencies and combinations
++	 * of CLK_CO_PHASE_* values. So limit it to 24 MHz, which according
++	 * to a mailing list post seems to be more stable:
++	 * - https://lists.denx.de/pipermail/u-boot/2020-December/434954.html
++	 */
++	cfg->f_max = 24000000; /* 24 MHz */
++
+ 	cfg->b_max = 511; /* max 512 - 1 blocks */
+ 	cfg->name = dev->name;
+ 
+-- 
+2.44.0
+


### PR DESCRIPTION
This includes a patch that sets the maximum frequency to 24 MHz in U-Boot which improves reliability as previously U-Boot would randomly fail reading from the eMMC.


# Description


On my Odroid N2+ the current 2022.10 U-Boot in Armbian has sometimes issues reading from eMMC (Odroid Orange eMMC module Rev 0.5), it will fail with an `** fs_devread read error - block` error when reading the Images from the eMMC.

There was an upstream discussion about this issue in 2020, see here: https://lists.denx.de/pipermail/u-boot/2020-December/434954.html

And I can confirm that either changing the clock phase value as well as limiting the max speed to 24 MHz solves this issue. I've decided to limit the maximum frequency as according to the commenter on the mailing list it should have better compatibility with eMMC flashes.

As a side effect, this increases the image read speeds form 5.9 MiB/s to 21.1 MiB/s, I assume with the previous setup the MMC controller was somehow struggling because of signal integrity.

This might be related to the following Jira ticket:
https://armbian.atlassian.net/browse/AR-650

# How Has This Been Tested?

Boot form eMMC flash and try reading an kernel Image into memory.

## Default Armbian 2022.10 U-Boot:
```
U-Boot 2022.10-armbian (Feb 23 2024 - 10:32:33 +0000) odroid-n2/n2-plus

Model: Hardkernel ODROID-N2
SoC:   Amlogic Meson G12B (S922X) Revision 29:c (40:2)
DRAM:  3.8 GiB
Core:  388 devices, 27 uclasses, devicetree: separate
MMC:   sd@ffe05000: 0, mmc@ffe07000: 1
Loading Environment from nowhere... OK
In:    serial
Out:   serial
Err:   serial
Board variant: n2-plus
Net:   dwmac_meson8b ethernet@ff3f0000: Can't get reset: -2
eth0: ethernet@ff3f0000
Hit any key to stop autoboot:  0
=>
=> load mmc 1 0x34000000 /boot/Image
28346880 bytes read in 4593 ms (5.9 MiB/s)
=> load mmc 1 0x34000000 /boot/Image
28346880 bytes read in 4593 ms (5.9 MiB/s)
=> load mmc 1 0x34000000 /boot/Image
28346880 bytes read in 4594 ms (5.9 MiB/s)
=> load mmc 1 0x34000000 /boot/Image
 ** fs_devread read error - block
Failed to load '/boot/Image'
=> load mmc 1 0x34000000 /boot/Image
 ** fs_devread read error - block
Failed to mount ext2 filesystem...
Can't set block device
=>
```
NOTE: Sometimes it already fails on the first try, sometimes not, it's really unpredictable and probably temperature depended as the mailing list post above suggested. 

## Patched Armbian 2022.10 U-Boot:
```
U-Boot 2022.10-armbian (Apr 26 2024 - 14:21:01 +0000) odroid-n2/n2-plus

Model: Hardkernel ODROID-N2
SoC:   Amlogic Meson G12B (S922X) Revision 29:c (40:2)
DRAM:  3.8 GiB
Core:  388 devices, 27 uclasses, devicetree: separate
MMC:   sd@ffe05000: 0, mmc@ffe07000: 1
Loading Environment from nowhere... OK
In:    serial
Out:   serial
Err:   serial
Board variant: n2-plus
Net:   dwmac_meson8b ethernet@ff3f0000: Can't get reset: -2
eth0: ethernet@ff3f0000
Hit any key to stop autoboot:  0
=> load mmc 1 0x34000000 /boot/Image
28346880 bytes read in 1283 ms (21.1 MiB/s)
=> load mmc 1 0x34000000 /boot/Image
28346880 bytes read in 1284 ms (21.1 MiB/s)
=> load mmc 1 0x34000000 /boot/Image
28346880 bytes read in 1284 ms (21.1 MiB/s)
=> load mmc 1 0x34000000 /boot/Image
28346880 bytes read in 1284 ms (21.1 MiB/s)
=>
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
