### PR TITLE
Add rock5c support

### DIFF
--- a/config/boards/rock-5c.csc
+++ b/config/boards/rock-5c.csc
@@ -1,0 +1,30 @@
+# Rockchip RK3588s SoC octa core 4-16GB SoC eMMC USB3 NvME
+BOARD_NAME="Rock 5C"
+BOARDFAMILY="rockchip-rk3588"
+BOARD_MAINTAINER="amazingfate"
+BOOTCONFIG="rock-5c-rk3588s_defconfig"
+KERNEL_TARGET="vendor,edge"
+FULL_DESKTOP="yes"
+BOOT_LOGO="desktop"
+BOOT_FDT_FILE="rockchip/rk3588s-rock-5c.dtb"
+BOOT_SCENARIO="spl-blobs"
+BOOT_SOC="rk3588"
+IMAGE_PARTITION_TABLE="gpt"
+
+function post_family_config__uboot_rock5c() {
+        display_alert "$BOARD" "Configuring armsom u-boot" "info"
+        declare -g BOOTSOURCE='https://github.com/radxa/u-boot.git'
+        declare -g BOOTBRANCH="branch:next-dev-v2024.03"
+        declare -g OVERLAY_PREFIX='rockchip-rk3588'
+	declare -g BOOTDELAY=1   # build injects this into u-boot config. we can then get into UMS mode and avoid the whole rockusb/rkdeveloptool thing
+}
+
+function post_family_tweaks__rock5c_naming_audios() {
+	display_alert "$BOARD" "Renaming rock5c audios" "info"
+
+	mkdir -p $SDCARD/etc/udev/rules.d/
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-hdmi0-sound", ENV{SOUND_DESCRIPTION}="HDMI0 Audio"' > $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-es8316-sound", ENV{SOUND_DESCRIPTION}="ES8316 Audio"' >> $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+
+	return 0
+}

--- a/patch/kernel/rockchip-rk3588-edge/dt/rk3588s-rock-5c.dts
+++ b/patch/kernel/rockchip-rk3588-edge/dt/rk3588s-rock-5c.dts
@@ -1,0 +1,825 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/pinctrl/rockchip.h>
+#include <dt-bindings/soc/rockchip,vop2.h>
+#include "rk3588s.dtsi"
+
+/ {
+	model = "Radxa ROCK 5 Model C";
+	compatible = "radxa,rock-5c", "rockchip,rk3588s";
+
+	aliases {
+		ethernet0 = &gmac1;
+		mmc0 = &sdhci;
+		mmc1 = &sdmmc;
+	};
+
+	analog-sound {
+		compatible = "audio-graph-card";
+		label = "rk3588-es8316";
+
+		widgets = "Microphone", "Mic Jack",
+			  "Headphone", "Headphones";
+
+		routing = "MIC2", "Mic Jack",
+			  "Headphones", "HPOL",
+			  "Headphones", "HPOR";
+
+		dais = <&i2s0_8ch_p0>;
+	};
+
+	chosen {
+		stdout-path = "serial2:1500000n8";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+
+		user-led {
+			gpios = <&gpio3 RK_PC4 GPIO_ACTIVE_HIGH>;
+		};
+
+		io-led {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio3 RK_PD5 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "heartbeat";
+		};
+	};
+
+	fan: pwm-fan {
+		compatible = "pwm-fan";
+		cooling-levels = <0 95 145 195 255>;
+		fan-supply = <&vcc_5v0>;
+		pwms = <&pwm3 0 50000 0>;
+		#cooling-cells = <2>;
+	};
+
+	vcc5v0_sys: vcc5v0-sys {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc5v0_sys";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+	};
+
+	vcc_1v1_nldo_s3: vcc-1v1-nldo-s3-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc_1v1_nldo_s3";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <1100000>;
+		regulator-max-microvolt = <1100000>;
+		vin-supply = <&vcc5v0_sys>;
+	};
+
+	vcc3v3_pcie: vcc3v3-pcie {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc3v3_pcie";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		startup-delay-us = <5000>;
+		enable-active-high;
+		gpio = <&gpio0 RK_PC5 GPIO_ACTIVE_HIGH>;
+		vin-supply = <&vcc5v0_sys>;
+	};
+
+	vcc_5v0: vcc-5v0 {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc_5v0";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-boot-on;
+		regulator-always-on;
+		enable-active-high;
+		gpio = <&gpio4 RK_PA3 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&vcc_5v0_en>;
+		vin-supply = <&vcc5v0_sys>;
+	};
+
+	vcc5v0_host: vcc5v0-host-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc5v0_host";
+		regulator-boot-on;
+		regulator-always-on;
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		enable-active-high;
+		gpio = <&gpio4 RK_PB5 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&vcc5v0_host_en>;
+		vin-supply = <&vcc5v0_sys>;
+	};
+
+	vcc5v0_otg: vcc5v0-otg-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc5v0_otg";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		enable-active-high;
+		gpio = <&gpio0 RK_PD4 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&vcc5v0_otg_en>;
+		vin-supply = <&vcc5v0_sys>;
+	};
+};
+
+&combphy0_ps {
+	status = "okay";
+};
+
+&combphy2_psu {
+	status = "okay";
+};
+
+&cpu_b0 {
+	cpu-supply = <&vdd_cpu_big0_s0>;
+};
+
+&cpu_b1 {
+	cpu-supply = <&vdd_cpu_big0_s0>;
+};
+
+&cpu_b2 {
+	cpu-supply = <&vdd_cpu_big1_s0>;
+};
+
+&cpu_b3 {
+	cpu-supply = <&vdd_cpu_big1_s0>;
+};
+
+&cpu_l0 {
+	cpu-supply = <&vdd_cpu_lit_s0>;
+};
+
+&cpu_l1 {
+	cpu-supply = <&vdd_cpu_lit_s0>;
+};
+
+&cpu_l2 {
+	cpu-supply = <&vdd_cpu_lit_s0>;
+};
+
+&cpu_l3 {
+	cpu-supply = <&vdd_cpu_lit_s0>;
+};
+
+&i2c0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c0m2_xfer>;
+	status = "okay";
+
+	vdd_cpu_big0_s0: regulator@42 {
+		compatible = "rockchip,rk8602";
+		reg = <0x42>;
+		fcs,suspend-voltage-selector = <1>;
+		regulator-name = "vdd_cpu_big0_s0";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <550000>;
+		regulator-max-microvolt = <1050000>;
+		regulator-ramp-delay = <2300>;
+		vin-supply = <&vcc5v0_sys>;
+
+		regulator-state-mem {
+			regulator-off-in-suspend;
+		};
+	};
+
+	vdd_cpu_big1_s0: regulator@43 {
+		compatible = "rockchip,rk8603", "rockchip,rk8602";
+		reg = <0x43>;
+		fcs,suspend-voltage-selector = <1>;
+		regulator-name = "vdd_cpu_big1_s0";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <550000>;
+		regulator-max-microvolt = <1050000>;
+		regulator-ramp-delay = <2300>;
+		vin-supply = <&vcc5v0_sys>;
+
+		regulator-state-mem {
+			regulator-off-in-suspend;
+		};
+	};
+};
+
+&i2c2 {
+	status = "okay";
+
+	vdd_npu_s0: regulator@42 {
+		compatible = "rockchip,rk8602";
+		reg = <0x42>;
+		fcs,suspend-voltage-selector = <1>;
+		regulator-name = "vdd_npu_s0";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <550000>;
+		regulator-max-microvolt = <950000>;
+		regulator-ramp-delay = <2300>;
+		vin-supply = <&vcc5v0_sys>;
+
+		regulator-state-mem {
+			regulator-off-in-suspend;
+		};
+	};
+
+	eeprom: eeprom@50 {
+		compatible = "belling,bl24c16a", "atmel,24c16";
+		reg = <0x50>;
+		pagesize = <16>;
+	};
+};
+
+&i2c3 {
+	status = "okay";
+};
+
+&i2c5 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c5m2_xfer>;
+};
+
+&i2c7 {
+	status = "okay";
+
+	es8316: audio-codec@11 {
+		compatible = "everest,es8316";
+		reg = <0x11>;
+		clocks = <&cru I2S0_8CH_MCLKOUT>;
+		clock-names = "mclk";
+		assigned-clocks = <&cru I2S0_8CH_MCLKOUT>;
+		assigned-clock-rates = <12288000>;
+		#sound-dai-cells = <0>;
+
+		port {
+			es8316_p0_0: endpoint {
+				remote-endpoint = <&i2s0_8ch_p0_0>;
+			};
+		};
+	};
+};
+
+&i2s0_8ch {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2s0_lrck
+		     &i2s0_mclk
+		     &i2s0_sclk
+		     &i2s0_sdi0
+		     &i2s0_sdo0>;
+	status = "okay";
+
+	i2s0_8ch_p0: port {
+		i2s0_8ch_p0_0: endpoint {
+			dai-format = "i2s";
+			mclk-fs = <256>;
+			remote-endpoint = <&es8316_p0_0>;
+		};
+	};
+};
+
+&gmac1 {
+	clock_in_out = "output";
+	phy-handle = <&rgmii_phy1>;
+	phy-mode = "rgmii";
+	pinctrl-0 = <&gmac1_miim
+		     &gmac1_tx_bus2
+		     &gmac1_rx_bus2
+		     &gmac1_rgmii_clk
+		     &gmac1_rgmii_bus>;
+	pinctrl-names = "default";
+	tx_delay = <0x3a>;
+	rx_delay = <0x3e>;
+	status = "okay";
+};
+
+&gpu {
+	mali-supply = <&vdd_gpu_s0>;
+	status = "okay";
+};
+
+&mdio1 {
+	rgmii_phy1: ethernet-phy@1 {
+		/* RTL8211F */
+		compatible = "ethernet-phy-id001c.c916";
+		reg = <0x1>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&rtl8211f_rst>;
+		reset-assert-us = <20000>;
+		reset-deassert-us = <100000>;
+		reset-gpios = <&gpio3 RK_PB7 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&pcie2x1l2 {
+	status = "okay";
+	reset-gpios = <&gpio3 RK_PD1 GPIO_ACTIVE_HIGH>;
+	vpcie3v3-supply = <&vcc3v3_pcie>;
+};
+
+&pinctrl {
+	power {
+		vcc_5v0_en: vcc-5v0-en {
+			rockchip,pins = <4 RK_PA3 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
+
+	rtl8211f {
+		rtl8211f_rst: rtl8211f-rst {
+			rockchip,pins = <3 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
+
+	usb {
+		vcc5v0_host_en: vcc5v0-host-en {
+			rockchip,pins = <4 RK_PB5 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+
+		vcc5v0_otg_en: vcc5v0-otg-en {
+                        rockchip,pins = <0 RK_PD4 RK_FUNC_GPIO &pcfg_pull_none>;
+                };
+	};
+
+	wifibt {
+		wifibt_en: wifibit-en {
+			rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_up>;
+		};
+
+		host_wake_wl: host-wake-wl {
+			rockchip,pins = <0 RK_PC6 RK_FUNC_GPIO &pcfg_output_high>;
+		};
+
+		wl_wake_host: wl-wake-host {
+			rockchip,pins = <0 RK_PD3 RK_FUNC_GPIO &pcfg_pull_up>;
+		};
+
+		host_wake_bt: host-wake-bt {
+			rockchip,pins = <1 RK_PA6 RK_FUNC_GPIO &pcfg_output_high>;
+		};
+
+		bt_wake_host: bt-wake-host {
+			rockchip,pins = <3 RK_PC0 RK_FUNC_GPIO &pcfg_pull_up>;
+		};
+	};
+};
+
+&pwm3 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pwm3m1_pins>;
+	status = "okay";
+};
+
+&saradc {
+	vref-supply = <&avcc_1v8_s0>;
+	status = "okay";
+};
+
+&sdhci {
+	bus-width = <8>;
+	no-sdio;
+	no-sd;
+	non-removable;
+	mmc-hs400-1_8v;
+	mmc-hs400-enhanced-strobe;
+	status = "okay";
+};
+
+&sdmmc {
+	bus-width = <4>;
+	cap-mmc-highspeed;
+	cap-sd-highspeed;
+	cd-gpios = <&gpio0 RK_PA4 GPIO_ACTIVE_LOW>;
+	disable-wp;
+	max-frequency = <150000000>;
+	no-sdio;
+	no-mmc;
+	sd-uhs-sdr104;
+	vmmc-supply = <&vcc_3v3_s0>;
+	vqmmc-supply = <&vccio_sd_s0>;
+	status = "okay";
+};
+
+&spi2 {
+	status = "okay";
+	assigned-clocks = <&cru CLK_SPI2>;
+	assigned-clock-rates = <200000000>;
+	num-cs = <1>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi2m2_cs0 &spi2m2_pins>;
+
+	pmic@0 {
+		compatible = "rockchip,rk806";
+		reg = <0x0>;
+		interrupt-parent = <&gpio0>;
+		interrupts = <7 IRQ_TYPE_LEVEL_LOW>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&pmic_pins>, <&rk806_dvs1_null>,
+			    <&rk806_dvs2_null>, <&rk806_dvs3_null>;
+		spi-max-frequency = <1000000>;
+
+		system-power-controller;
+
+		vcc1-supply = <&vcc5v0_sys>;
+		vcc2-supply = <&vcc5v0_sys>;
+		vcc3-supply = <&vcc5v0_sys>;
+		vcc4-supply = <&vcc5v0_sys>;
+		vcc5-supply = <&vcc5v0_sys>;
+		vcc6-supply = <&vcc5v0_sys>;
+		vcc7-supply = <&vcc5v0_sys>;
+		vcc8-supply = <&vcc5v0_sys>;
+		vcc9-supply = <&vcc5v0_sys>;
+		vcc10-supply = <&vcc5v0_sys>;
+		vcc11-supply = <&vcc_2v0_pldo_s3>;
+		vcc12-supply = <&vcc5v0_sys>;
+		vcc13-supply = <&vcc_1v1_nldo_s3>;
+		vcc14-supply = <&vcc_1v1_nldo_s3>;
+		vcca-supply = <&vcc5v0_sys>;
+
+		gpio-controller;
+		#gpio-cells = <2>;
+
+		rk806_dvs1_null: dvs1-null-pins {
+			pins = "gpio_pwrctrl2";
+			function = "pin_fun0";
+		};
+
+		rk806_dvs2_null: dvs2-null-pins {
+			pins = "gpio_pwrctrl2";
+			function = "pin_fun0";
+		};
+
+		rk806_dvs3_null: dvs3-null-pins {
+			pins = "gpio_pwrctrl3";
+			function = "pin_fun0";
+		};
+
+		regulators {
+			vdd_gpu_s0: vdd_gpu_mem_s0: dcdc-reg1 {
+				regulator-name = "vdd_gpu_s0";
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-min-microvolt = <550000>;
+				regulator-max-microvolt = <950000>;
+				regulator-ramp-delay = <12500>;
+				regulator-enable-ramp-delay = <400>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+				};
+			};
+
+			vdd_cpu_lit_s0: vdd_cpu_lit_mem_s0: dcdc-reg2 {
+				regulator-name = "vdd_cpu_lit_s0";
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-min-microvolt = <550000>;
+				regulator-max-microvolt = <950000>;
+				regulator-ramp-delay = <12500>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+				};
+			};
+
+			vdd_log_s0: dcdc-reg3 {
+				regulator-name = "vdd_log_s0";
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-min-microvolt = <675000>;
+				regulator-max-microvolt = <750000>;
+				regulator-ramp-delay = <12500>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <750000>;
+				};
+			};
+
+			vdd_vdenc_s0: vdd_vdenc_mem_s0: dcdc-reg4 {
+				regulator-name = "vdd_vdenc_s0";
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-min-microvolt = <550000>;
+				regulator-max-microvolt = <950000>;
+				regulator-ramp-delay = <12500>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+				};
+			};
+
+			vdd_ddr_s0: dcdc-reg5 {
+				regulator-name = "vdd_ddr_s0";
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-min-microvolt = <675000>;
+				regulator-max-microvolt = <900000>;
+				regulator-ramp-delay = <12500>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <850000>;
+				};
+			};
+
+			vdd2_ddr_s3: dcdc-reg6 {
+				regulator-name = "vdd2_ddr_s3";
+				regulator-always-on;
+				regulator-boot-on;
+
+				regulator-state-mem {
+					regulator-on-in-suspend;
+				};
+			};
+
+			vcc_2v0_pldo_s3: dcdc-reg7 {
+				regulator-name = "vdd_2v0_pldo_s3";
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-min-microvolt = <2000000>;
+				regulator-max-microvolt = <2000000>;
+				regulator-ramp-delay = <12500>;
+
+				regulator-state-mem {
+					regulator-on-in-suspend;
+					regulator-suspend-microvolt = <2000000>;
+				};
+			};
+
+			vcc_3v3_s3: dcdc-reg8 {
+				regulator-name = "vcc_3v3_s3";
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-min-microvolt = <3300000>;
+				regulator-max-microvolt = <3300000>;
+
+				regulator-state-mem {
+					regulator-on-in-suspend;
+					regulator-suspend-microvolt = <3300000>;
+				};
+			};
+
+			vddq_ddr_s0: dcdc-reg9 {
+				regulator-name = "vddq_ddr_s0";
+				regulator-always-on;
+				regulator-boot-on;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+				};
+			};
+
+			vcc_1v8_s3: dcdc-reg10 {
+				regulator-name = "vcc_1v8_s3";
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-min-microvolt = <1800000>;
+				regulator-max-microvolt = <1800000>;
+
+				regulator-state-mem {
+					regulator-on-in-suspend;
+					regulator-suspend-microvolt = <1800000>;
+				};
+			};
+
+			avcc_1v8_s0: pldo-reg1 {
+				regulator-name = "avcc_1v8_s0";
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-min-microvolt = <1800000>;
+				regulator-max-microvolt = <1800000>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+				};
+			};
+
+			vcc_1v8_s0: pldo-reg2 {
+				regulator-name = "vcc_1v8_s0";
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-min-microvolt = <1800000>;
+				regulator-max-microvolt = <1800000>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <1800000>;
+				};
+			};
+
+			avdd_1v2_s0: pldo-reg3 {
+				regulator-name = "avdd_1v2_s0";
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-min-microvolt = <1200000>;
+				regulator-max-microvolt = <1200000>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+				};
+			};
+
+			vcc_3v3_s0: pldo-reg4 {
+				regulator-name = "vcc_3v3_s0";
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-min-microvolt = <3300000>;
+				regulator-max-microvolt = <3300000>;
+				regulator-ramp-delay = <12500>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+				};
+			};
+
+			vccio_sd_s0: pldo-reg5 {
+				regulator-name = "vccio_sd_s0";
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-min-microvolt = <1800000>;
+				regulator-max-microvolt = <3300000>;
+				regulator-ramp-delay = <12500>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+				};
+			};
+
+			pldo6_s3: pldo-reg6 {
+				regulator-name = "pldo6_s3";
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-min-microvolt = <1800000>;
+				regulator-max-microvolt = <1800000>;
+
+				regulator-state-mem {
+					regulator-on-in-suspend;
+					regulator-suspend-microvolt = <1800000>;
+				};
+			};
+
+			vdd_0v75_s3: nldo-reg1 {
+				regulator-name = "vdd_0v75_s3";
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-min-microvolt = <750000>;
+				regulator-max-microvolt = <750000>;
+
+				regulator-state-mem {
+					regulator-on-in-suspend;
+					regulator-suspend-microvolt = <750000>;
+				};
+			};
+
+			vdd_ddr_pll_s0: nldo-reg2 {
+				regulator-name = "vdd_ddr_pll_s0";
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-min-microvolt = <850000>;
+				regulator-max-microvolt = <850000>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <850000>;
+				};
+			};
+
+			avdd_0v75_s0: nldo-reg3 {
+				regulator-name = "avdd_0v75_s0";
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-min-microvolt = <750000>;
+				regulator-max-microvolt = <750000>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+				};
+			};
+
+			vdd_0v85_s0: nldo-reg4 {
+				regulator-name = "vdd_0v85_s0";
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-min-microvolt = <850000>;
+				regulator-max-microvolt = <850000>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+				};
+			};
+
+			vdd_0v75_s0: nldo-reg5 {
+				regulator-name = "vdd_0v75_s0";
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-min-microvolt = <750000>;
+				regulator-max-microvolt = <750000>;
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+				};
+			};
+		};
+	};
+};
+
+&u2phy0 {
+	status = "okay";
+};
+
+&u2phy0_otg {
+	status = "okay";
+	vbus-supply = <&vcc5v0_otg>;
+};
+
+&u2phy2 {
+	status = "okay";
+};
+
+&u2phy2_host {
+	status = "okay";
+	phy-supply = <&vcc5v0_host>;
+};
+
+&u2phy3 {
+	status = "okay";
+};
+
+&u2phy3_host {
+	phy-supply = <&vcc5v0_host>;
+	status = "okay";
+};
+
+&uart2 {
+	pinctrl-0 = <&uart2m0_xfer>;
+	status = "okay";
+};
+
+&usbdp_phy0 {
+	status = "okay";
+	rockchip,dp-lane-mux = <2 3>;
+};
+
+&usb_host0_ehci {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&wifibt_en &host_wake_wl &wl_wake_host &host_wake_bt &bt_wake_host>;
+};
+
+&usb_host0_ohci {
+	status = "okay";
+};
+
+&usb_host0_xhci {
+	dr_mode = "host";
+	status = "okay";
+};
+
+&usb_host1_ehci {
+	status = "okay";
+};
+
+&usb_host1_ohci {
+	status = "okay";
+};
+
+&usb_host2_xhci {
+	status = "okay";
+};
+
+&hdmi0 {
+	status = "okay";
+};
+
+&hdptxphy_hdmi0 {
+	status = "okay";
+};
+
+&vop_mmu {
+	status = "okay";
+};
+
+&hdmi0_in {
+	hdmi0_in_vp0: endpoint {
+		remote-endpoint = <&vp0_out_hdmi0>;
+	};
+};
+
+&vop {
+	status = "okay";
+};
+
+&vp0 {
+	vp0_out_hdmi0: endpoint@ROCKCHIP_VOP2_EP_HDMI0 {
+		reg = <ROCKCHIP_VOP2_EP_HDMI0>;
+		remote-endpoint = <&hdmi0_in_vp0>;
+	};
+};

--- a/patch/u-boot/legacy/u-boot-radxa-rk3588/board_rock-5c/reopen_disabled_nodes.patch
+++ b/patch/u-boot/legacy/u-boot-radxa-rk3588/board_rock-5c/reopen_disabled_nodes.patch
@@ -1,0 +1,172 @@
+diff --git a/arch/arm/mach-rockchip/rk3588/rk3588.c b/arch/arm/mach-rockchip/rk3588/rk3588.c
+index f7928a7f2..3c4d1e2f2 100644
+--- a/arch/arm/mach-rockchip/rk3588/rk3588.c
++++ b/arch/arm/mach-rockchip/rk3588/rk3588.c
+@@ -1067,6 +1067,7 @@ int arch_cpu_init(void)
+ #endif
+ 
+ #define BAD_CPU(mask, n)	((mask) & (1 << (n)))
++#define BAD_GPU(mask, n)	((mask) & (1 << (n)))
+ #define BAD_RKVENC(mask, n)	((mask) & (1 << (n)))
+ #define BAD_RKVDEC(mask, n)	((mask) & (1 << (n)))
+ 
+@@ -1220,51 +1221,44 @@ static void fdt_rm_cpu(const void *blob, u8 cpu_mask)
+ 
+ static void rk3582_fdt_rm_cpus(const void *blob, u8 cpu_mask)
+ {
+-	/*
+-	 * policy:
+-	 *
+-	 * 1. both of cores within the same cluster should be normal, otherwise
+-	 *    remove both of them.
+-	 * 2. if core4~7 are all normal, remove core6 and core7 anyway.
+-	 */
+-	if (BAD_CPU(cpu_mask, 4) || BAD_CPU(cpu_mask, 5))
+-		cpu_mask |= BIT(4) | BIT(5);
+-	if (BAD_CPU(cpu_mask, 6) || BAD_CPU(cpu_mask, 7))
+-		cpu_mask |= BIT(6) | BIT(7);
+-
+-	if (!BAD_CPU(cpu_mask, 4) & !BAD_CPU(cpu_mask, 5) &&
+-	    !BAD_CPU(cpu_mask, 6) & !BAD_CPU(cpu_mask, 7))
+-		cpu_mask |= BIT(6) | BIT(7);
++	if (BAD_CPU(cpu_mask, 4))
++		cpu_mask |= BIT(4);
++	if (BAD_CPU(cpu_mask, 5))
++		cpu_mask |= BIT(5);
++	if (BAD_CPU(cpu_mask, 6))
++		cpu_mask |= BIT(6);
++	if (BAD_CPU(cpu_mask, 7))
++		cpu_mask |= BIT(7);
+ 
+ 	fdt_rm_cooling_map(blob, cpu_mask);
+ 	fdt_rm_cpu_affinity(blob, cpu_mask);
+ 	fdt_rm_cpu(blob, cpu_mask);
+ }
+ 
+-static void rk3582_fdt_rm_gpu(void *blob)
++static void rk3582_fdt_rm_gpu(void *blob, u8 mask)
+ {
+-	/*
+-	 * policy:
+-	 *
+-	 * Remove GPU by default.
+-	 */
+-	fdt_rm_path(blob, "/gpu@fb000000");
+-	fdt_rm_path(blob, "/thermal-zones/soc-thermal/cooling-maps/map3");
+-	debug("rm: gpu\n");
++	/* If one core is bad, disable gpu */
++	if ((BAD_GPU(mask, 0)) || (BAD_GPU(mask, 1)) || (BAD_GPU(mask, 2)) || (BAD_GPU(mask, 3)))
++	{
++		fdt_rm_path(blob, "/gpu@fb000000");
++		fdt_rm_path(blob, "/thermal-zones/soc-thermal/cooling-maps/map3");
++		debug("rm: gpu\n");
++	}
+ }
+ 
+-static void rk3582_fdt_rm_rkvdec01(void *blob)
++static void rk3582_fdt_rm_rkvdec01(void *blob, u8 mask)
+ {
+-	/*
+-	 * policy:
+-	 *
+-	 * Remove rkvdec0 and rkvdec1 by default.
+-	 */
+-	fdt_rm_path(blob, "/rkvdec-core@fdc38000");
+-	fdt_rm_path(blob, "/iommu@fdc38700");
+-	fdt_rm_path(blob, "/rkvdec-core@fdc48000");
+-	fdt_rm_path(blob, "/iommu@fdc48700");
+-	debug("rm: rkvdec0, rkvdec1\n");
++	/* Only remove bad cores */
++	if (BAD_RKVDEC(mask, 0)) {
++		fdt_rm_path(blob, "/rkvdec-core@fdc38000");
++		fdt_rm_path(blob, "/iommu@fdc38700");
++		debug("rm: rkvdec0\n");
++	}
++	if (BAD_RKVDEC(mask, 1)) {
++		fdt_rm_path(blob, "/rkvdec-core@fdc48000");
++		fdt_rm_path(blob, "/iommu@fdc48700");
++		debug("rm: rkvdec1\n");
++	}
+ }
+ 
+ static void rk3582_fdt_rm_rkvenc01(void *blob, u8 mask)
+@@ -1277,31 +1271,27 @@ static void rk3582_fdt_rm_rkvenc01(void *blob, u8 mask)
+ 	 * 3. disable '*-ccu' node
+ 	 * 4. rename '*-core@' node
+ 	 */
+-	if (!BAD_RKVENC(mask, 0) && !BAD_RKVENC(mask, 1)) {
+-		/* rkvenc1 */
++	if (BAD_RKVENC(mask, 0)) {
++		fdt_rm_path(blob, "/rkvenc-core@fdbd0000");
++		fdt_rm_path(blob, "/iommu@fdbdf000");
++		debug("rm: rkvenv0\n");
++
++	}
++	if (BAD_RKVENC(mask, 1)) {
+ 		fdt_rm_path(blob, "/rkvenc-core@fdbe0000");
+ 		fdt_rm_path(blob, "/iommu@fdbef000");
+ 		debug("rm: rkvenv1\n");
+-	} else {
+-		if (BAD_RKVENC(mask, 0)) {
+-			fdt_rm_path(blob, "/rkvenc-core@fdbd0000");
+-			fdt_rm_path(blob, "/iommu@fdbdf000");
+-			debug("rm: rkvenv0\n");
+-
+-		}
+-		if (BAD_RKVENC(mask, 1)) {
+-			fdt_rm_path(blob, "/rkvenc-core@fdbe0000");
+-			fdt_rm_path(blob, "/iommu@fdbef000");
+-			debug("rm: rkvenv1\n");
+-		}
+ 	}
+ 
+-	do_fixup_by_path((void *)blob, "/rkvenc-ccu",
+-			 "status", "disabled", sizeof("disabled"), 0);
++	/* If there is bad core, fix multi core related nodes */
++	if (BAD_RKVENC(mask, 0) || BAD_RKVENC(mask, 1)) {
++		do_fixup_by_path((void *)blob, "/rkvenc-ccu",
++				 "status", "disabled", sizeof("disabled"), 0);
+ 
+-	/* rename node name if the node exist, actually only one exist  */
+-	fdt_rename_path(blob, "/rkvenc-core@fdbd0000", "rkvenc@fdbd0000");
+-	fdt_rename_path(blob, "/rkvenc-core@fdbe0000", "rkvenc@fdbe0000");
++		/* rename node name if the node exist, actually only one exist  */
++		fdt_rename_path(blob, "/rkvenc-core@fdbd0000", "rkvenc@fdbd0000");
++		fdt_rename_path(blob, "/rkvenc-core@fdbe0000", "rkvenc@fdbe0000");
++	}
+ }
+ 
+ static void rk3583_fdt_rm_rkvdec01(void *blob, u8 mask)
+@@ -1352,6 +1342,7 @@ static int fdt_fixup_modules(void *blob)
+ 	u8 rkvenc_mask;
+ 	u8 rkvdec_mask;
+ 	u8 cpu_mask;
++	u8 gpu_mask;
+ 	int ret;
+ 
+ 	ret = uclass_get_device_by_driver(UCLASS_MISC,
+@@ -1386,12 +1377,10 @@ static int fdt_fixup_modules(void *blob)
+ 	rkvenc_mask = (ip_state[2] & 0x1) | ((ip_state[2] & 0x4) >> 1);
+ 	/* ip_state[1]: bit6,7 */
+ 	rkvdec_mask = (ip_state[1] & 0xc0) >> 6;
+-#if 0
+ 	/* ip_state[1]: bit1~4 */
+ 	gpu_mask = (ip_state[1] & 0x1e) >> 1;
+-#endif
+ 	debug("hw-mask: 0x%02x, 0x%02x, 0x%02x\n", ip_state[0], ip_state[1], ip_state[2]);
+-	debug("sw-mask: 0x%02x, 0x%02x, 0x%02x\n", cpu_mask, rkvenc_mask, rkvdec_mask);
++	debug("sw-mask: 0x%02x, 0x%02x, 0x%02x, 0x%02x\n", cpu_mask, gpu_mask, rkvenc_mask, rkvdec_mask);
+ 
+ 	/*
+ 	 *		FIXUP WARNING!
+@@ -1408,8 +1397,8 @@ static int fdt_fixup_modules(void *blob)
+ 		 * So don't use pattern like "if (rkvenc_mask) then rk3582_fdt_rm_rkvenc01()",
+ 		 * just go through all of them as this chip is rk3582.
+ 		 */
+-		rk3582_fdt_rm_gpu(blob);
+-		rk3582_fdt_rm_rkvdec01(blob);
++		rk3582_fdt_rm_gpu(blob, gpu_mask);
++		rk3582_fdt_rm_rkvdec01(blob, rkvdec_mask);
+ 		rk3582_fdt_rm_rkvenc01(blob, rkvenc_mask);
+ 		rk3582_fdt_rm_cpus(blob, cpu_mask);
+ 	} else if (chip_id[0] == 0x35 && chip_id[1] == 0x83) {


### PR DESCRIPTION
# Description

rock 5c and rock 5c lite share the same kernel dts, and dts nodes in rk3582 is disabled at uboot, so I add one board config for both rock 5c and rock 5c lite.
I also add a uboot patch to unlock good ip cores in rk3582. So rock 5c lite may boot with 6/7/8 cpu cores, or full encoder/decoder support.
vendor kernel support depends on https://github.com/armbian/linux-rockchip/pull/176

# How Has This Been Tested?

- [x] `./compile.sh BOARD=rock-5c BRANCH=vendor BUILD_DESKTOP=no BUILD_MINIMAL=no COMPRESS_OUTPUTIMAGE=sha,gpg,xz DEB_COMPRESS=xz KERNEL_CONFIGURE=no RELEASE=bookworm KERNEL_GIT=shallow`
- [x] `./compile.sh BOARD=rock-5c BRANCH=edge BUILD_DESKTOP=no BUILD_MINIMAL=no COMPRESS_OUTPUTIMAGE=sha,gpg,xz DEB_COMPRESS=xz KERNEL_CONFIGURE=no RELEASE=bookworm KERNEL_GIT=shallow`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
