### PR TITLE
hostdep fixes for Noble distutils and pyelftools removed hooks

### DIFF
--- a/config/boards/bananapir2pro.csc
+++ b/config/boards/bananapir2pro.csc
@@ -17,8 +17,3 @@ IMAGE_PARTITION_TABLE="gpt"
 function post_family_config___mainline_uboot() {
 	declare -g UBOOT_TARGET_MAP="ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB} BL31=$RKBIN_DIR/$BL31_BLOB spl/u-boot-spl u-boot.bin flash.bin;;idbloader.img u-boot.itb"
 }
-
-function add_host_dependencies__uboot_deps() {
-	display_alert "Adding python3-pyelftools for brute force mainline uboot" "${EXTENSION}" "info"
-	declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} python3-pyelftools"
-}

--- a/config/boards/nanopi-r5c.csc
+++ b/config/boards/nanopi-r5c.csc
@@ -24,11 +24,7 @@ BL31_BLOB="rk35/rk3568_bl31_v1.43.elf"
 function post_family_config__uboot_config() {
 	display_alert "$BOARD" "u-boot ${BOOTBRANCH_BOARD} overrides" "info"
 	BOOTDELAY=2 # Wait for UART interrupt to enter UMS/RockUSB mode etc
-    UBOOT_TARGET_MAP="ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB} BL31=$RKBIN_DIR/$BL31_BLOB spl/u-boot-spl u-boot.bin flash.bin;;idbloader.img u-boot.itb"
-}
-
-function add_host_dependencies__new_uboot_wants_python3() {
-	declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} python3-pyelftools" # @TODO: convert to array later
+	UBOOT_TARGET_MAP="ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB} BL31=$RKBIN_DIR/$BL31_BLOB spl/u-boot-spl u-boot.bin flash.bin;;idbloader.img u-boot.itb"
 }
 
 function post_family_tweaks__nanopir5c_udev_network_interfaces() {

--- a/config/boards/nanopi-r5s.csc
+++ b/config/boards/nanopi-r5s.csc
@@ -24,11 +24,7 @@ BL31_BLOB="rk35/rk3568_bl31_v1.43.elf"
 function post_family_config__uboot_config() {
 	display_alert "$BOARD" "u-boot ${BOOTBRANCH_BOARD} overrides" "info"
 	BOOTDELAY=2 # Wait for UART interrupt to enter UMS/RockUSB mode etc
-    UBOOT_TARGET_MAP="ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB} BL31=$RKBIN_DIR/$BL31_BLOB spl/u-boot-spl u-boot.bin flash.bin;;idbloader.img u-boot.itb"
-}
-
-function add_host_dependencies__new_uboot_wants_python3() {
-	declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} python3-pyelftools" # @TODO: convert to array later
+	UBOOT_TARGET_MAP="ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB} BL31=$RKBIN_DIR/$BL31_BLOB spl/u-boot-spl u-boot.bin flash.bin;;idbloader.img u-boot.itb"
 }
 
 function post_family_tweaks__nanopir5s_udev_network_interfaces() {

--- a/config/boards/odroidm1.conf
+++ b/config/boards/odroidm1.conf
@@ -60,10 +60,6 @@ function post_family_config__uboot_config() {
 	}
 }
 
-function add_host_dependencies__new_uboot_wants_python3_odroidm1() {
-	declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} python3-pyelftools" # @TODO: convert to array later
-}
-
 # Include fw_setenv, configured to point to Petitboot's u-env mtd partition
 PACKAGE_LIST_BOARD="libubootenv-tool" # libubootenv-tool provides fw_printenv and fw_setenv, for talking to U-Boot environment
 

--- a/config/boards/orangepi3b.csc
+++ b/config/boards/orangepi3b.csc
@@ -53,10 +53,6 @@ function post_family_config__orangepi3b_use_mainline_uboot() {
 
 }
 
-function add_host_dependencies__new_uboot_wants_python3_orangepi3b() {
-	declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} python3-pyelftools" # @TODO: convert to array later
-}
-
 function post_family_tweaks_bsp__orangepi3b() {
 	display_alert "$BOARD" "Installing sprd-bluetooth.service" "info"
 

--- a/config/boards/orangepi5.conf
+++ b/config/boards/orangepi5.conf
@@ -115,12 +115,6 @@ function post_uboot_custom_postprocess__create_sata_spi_image() {
 	dd if=u-boot.itb of=rkspi_loader_sata.img seek=16384 conv=notrunc
 }
 
-function add_host_dependencies__mainline_uboot_wants_python3_orangepi5() {
-	if [[ $BRANCH == "edge" ]]; then
-		declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} python3-pyelftools" # @TODO: convert to array later
-	fi
-}
-
 # Override family config for this board; let's avoid conditionals in family config.
 function post_family_config__orangepi5_use_vendor_uboot() {
 	if [[ $BRANCH == "edge" ]]; then

--- a/config/boards/radxa-zero3.wip
+++ b/config/boards/radxa-zero3.wip
@@ -25,7 +25,3 @@ function post_family_config__radxa-zero3_use_vendor_uboot() {
 		dd if=$1/u-boot-rockchip.bin of=$2 seek=64 conv=notrunc status=none
 	}
 }
-
-function add_host_dependencies__mainline_uboot_wants_pyelftools_radxa_zero3() {
-	declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} python3-pyelftools"
-}

--- a/config/boards/rock-4se.csc
+++ b/config/boards/rock-4se.csc
@@ -17,10 +17,5 @@ BL31_BLOB="rk33/rk3399_bl31_v1.36.elf"
 DDR_BLOB="rk33/rk3399_ddr_933MHz_v1.30.bin"
 
 function post_family_config___mainline_uboot() {
-        declare -g UBOOT_TARGET_MAP="ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB} BL31=$RKBIN_DIR/$BL31_BLOB spl/u-boot-spl u-boot.bin flash.bin;;idbloader.img u-boot.itb"
-}
-
-function add_host_dependencies__uboot_deps() {
-		display_alert "Adding python3-pyelftools for brute force mainline uboot" "${EXTENSION}" "info"
-		declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} python3-pyelftools libgnutls28-dev"
+	declare -g UBOOT_TARGET_MAP="ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB} BL31=$RKBIN_DIR/$BL31_BLOB spl/u-boot-spl u-boot.bin flash.bin;;idbloader.img u-boot.itb"
 }

--- a/config/boards/rock-5b.csc
+++ b/config/boards/rock-5b.csc
@@ -76,8 +76,3 @@ function post_family_tweaks__config_rock5b_fwenv() {
 		/dev/mtd0         0xc00000      0x20000
 	FW_ENV_CONFIG
 }
-
-# I'm FED UP with this, @TODO lets make it part of core deps soon and cleanup all those hooks all spread around - lol it's another week and this still in
-function add_host_dependencies__new_uboot_wants_pyelftools() {
-	declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} python3-pyelftools" # @TODO: convert to array later
-}

--- a/config/boards/rockpi-4cplus.csc
+++ b/config/boards/rockpi-4cplus.csc
@@ -16,10 +16,5 @@ DDR_BLOB="rk33/rk3399_ddr_933MHz_v1.30.bin"
 BL31_BLOB="rk33/rk3399_bl31_v1.36.elf"
 
 function post_family_config___mainline_uboot() {
-        declare -g UBOOT_TARGET_MAP="ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB} BL31=$RKBIN_DIR/$BL31_BLOB spl/u-boot-spl u-boot.bin flash.bin;;idbloader.img u-boot.itb"
-}
-
-function add_host_dependencies__uboot_deps() {
-		display_alert "Adding python3-pyelftools for brute force mainline uboot" "${EXTENSION}" "info"
-		declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} python3-pyelftools libgnutls28-dev"
+	declare -g UBOOT_TARGET_MAP="ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB} BL31=$RKBIN_DIR/$BL31_BLOB spl/u-boot-spl u-boot.bin flash.bin;;idbloader.img u-boot.itb"
 }

--- a/config/boards/rockpro64.conf
+++ b/config/boards/rockpro64.conf
@@ -17,10 +17,6 @@ BOOTPATCHDIR="v2024.04"
 # Include fw_setenv, configured to point to the correct spot on the SPI Flash
 PACKAGE_LIST_BOARD="libubootenv-tool" # libubootenv-tool provides fw_printenv and fw_setenv, for talking to U-Boot environment
 
-function add_host_dependencies__new_uboot_wants_python3_rockpro64() {
-	declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} python3-pyelftools" # @TODO: convert to array later
-}
-
 function post_family_config__use_mainline_uboot_rockpro64() {
 	# Use latest lts 2.8 ATF
 	ATFBRANCH='tag:lts-v2.8.16'

--- a/config/sources/families/k3.conf
+++ b/config/sources/families/k3.conf
@@ -44,7 +44,7 @@ ROOT_FS_LABEL="root"
 
 function add_host_dependencies__k3_python3_dep() {
 	display_alert "Preparing K3 U-Boot host-side dependencies" "${EXTENSION}" "info"
-	declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} python3-yaml python3-jsonschema python3-pyelftools"
+	declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} python3-yaml python3-jsonschema"
 }
 
 function compile_k3_bootgen() {

--- a/config/sources/vendors/mekotronics/mekotronics-rk3588.hooks.sh
+++ b/config/sources/vendors/mekotronics/mekotronics-rk3588.hooks.sh
@@ -44,9 +44,4 @@ if [[ "${MEKO_USE_MAINLINE_UBOOT:-"no"}" == "yes" ]]; then
 			dd "if=$1/u-boot-rockchip.bin" "of=$2" bs=32k seek=1 conv=notrunc status=none
 		}
 	}
-
-	# I'm FED UP with this, @TODO lets make it part of core deps soon and cleanup all those hooks all spread around
-	function add_host_dependencies__new_uboot_wants_pyelftools() {
-		declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} python3-pyelftools" # @TODO: convert to array later
-	}
 fi

--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -289,10 +289,17 @@ function adaptative_prepare_host_dependencies() {
 	### Python
 	host_deps_add_extra_python # See python-tools.sh::host_deps_add_extra_python()
 
-	# Python3 -- required for Armbian's Python tooling, and also for more recent u-boot builds. Needs 3.9+; ffi-dev is needed for some Python packages when the wheel is not prebuilt
-	host_dependencies+=("python3-dev" "python3-distutils" "python3-setuptools" "python3-pip" "python3-pyelftools" "libffi-dev")
+	### Python3 -- required for Armbian's Python tooling, and also for more recent u-boot builds. Needs 3.9+; ffi-dev is needed for some Python packages when the wheel is not prebuilt
+	host_dependencies+=("python3-dev" "python3-setuptools" "python3-pip" "python3-pyelftools" "libffi-dev")
 
-	# Python2 -- required for some older u-boot builds
+	# Noble and later releases do not carry "python3-distutils" https://docs.python.org/3.10/whatsnew/3.10.html#distutils-deprecated
+	if [[ "noble" == *"${host_release}"* ]]; then
+		display_alert "python3-distutils not available on host release '${host_release}'" "distutils was deprecated with Python 3.12" "debug"
+	else
+		host_dependencies+=("python3-distutils")
+	fi
+
+	### Python2 -- required for some older u-boot builds
 	# Debian 'sid'/'bookworm' and Ubuntu 'lunar' does not carry python2 anymore; in this case some u-boot's might fail to build.
 	if [[ "sid bookworm trixie lunar mantic noble" == *"${host_release}"* ]]; then
 		display_alert "Python2 not available on host release '${host_release}'" "old(er) u-boot builds might/will fail" "wrn"

--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -292,6 +292,9 @@ function adaptative_prepare_host_dependencies() {
 	### Python3 -- required for Armbian's Python tooling, and also for more recent u-boot builds. Needs 3.9+; ffi-dev is needed for some Python packages when the wheel is not prebuilt
 	host_dependencies+=("python3-dev" "python3-setuptools" "python3-pip" "python3-pyelftools" "libffi-dev")
 
+	# Needed for some u-boot's, lest "tools/mkeficapsule.c:21:10: fatal error: gnutls/gnutls.h"
+	host_dependencies+=("libgnutls28-dev")
+
 	# Noble and later releases do not carry "python3-distutils" https://docs.python.org/3.10/whatsnew/3.10.html#distutils-deprecated
 	if [[ "noble" == *"${host_release}"* ]]; then
 		display_alert "python3-distutils not available on host release '${host_release}'" "distutils was deprecated with Python 3.12" "debug"

--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -261,7 +261,7 @@ function adaptative_prepare_host_dependencies() {
 		imagemagick # required for plymouth: converting images / spinners
 		jq          # required for parsing JSON, specially rootfs-caching related.
 		kmod        # this causes initramfs rebuild, but is usually pre-installed, so no harm done unless it's an upgrade
-		libbison-dev libelf-dev libfdt-dev libfile-fcntllock-perl libmpc-dev libfl-dev liblz4-tool
+		libbison-dev libelf-dev libfdt-dev libfile-fcntllock-perl libmpc-dev libfl-dev lz4
 		libncurses-dev libssl-dev libusb-1.0-0-dev
 		linux-base locales lsof
 		ncurses-base ncurses-term # for `make menuconfig`


### PR DESCRIPTION
#### hostdep fixes for Noble distutils and pyelftools removed hooks

- prepare-host.sh: deps: replace `liblz4-tool` with `lz4`
  - should fix sid and trixie, which dropped the metapackage
- prepare-host.sh: deps: Noble dropped `python3-distutils`; fixes #6527
  - keep it for older releases
- prepare-host.sh: deps: add `libgnutls28-dev`, needed for some u-boot builds
- multiple boards: drop hooks adding 'python3-pyelftools' & `libgnutls28-dev` hostdeps, now included in standard core deps