### PR TITLE
Update Odin2 kernel branch to skip initialization using the preset configuration

### DIFF
--- a/config/boards/ayn-odin2.conf
+++ b/config/boards/ayn-odin2.conf
@@ -19,14 +19,13 @@ declare -g DESKTOP_AUTOLOGIN="yes"
 function post_family_config_branch_sm8550__edk2_kernel() {	
 	declare -g KERNELSOURCE='https://github.com/edk2-porting/linux-next'
 	declare -g KERNEL_MAJOR_MINOR="6.7" # Major and minor versions of this kernel.
-	declare -g KERNELBRANCH="branch:integration/ayn-odin2"
+	declare -g KERNELBRANCH="branch:ci/odin2/stable"
 	declare -g LINUXCONFIG="linux-${ARCH}-${BRANCH}" # for this board: linux-arm64-sm8550
 	display_alert "Setting up kernel ${KERNEL_MAJOR_MINOR} for" "${BOARD}" "info"
 }
 
 function ayn-odin2_is_userspace_supported() {
-	[[ "${RELEASE}" == "trixie" ]] && return 0
-	[[ "${RELEASE}" == "noble" ]] && return 0
+	[[ "${RELEASE}" == "trixie" || "${RELEASE}" == "sid" || "${RELEASE}" == "mantic" || "${RELEASE}" == "noble" ]] && return 0
 	return 1
 }
 
@@ -78,6 +77,44 @@ function post_family_tweaks__enable_services() {
 	cp $SRC/packages/bsp/ayn-odin2/LinuxLoader.cfg "${SDCARD}"/boot/
 
 	return 0
+}
+
+function post_family_tweaks__preset_configs() {
+	display_alert "$BOARD" "preset configs for rootfs" "info"
+	# Set PRESET_NET_CHANGE_DEFAULTS to 1 to apply any network related settings below
+	echo "PRESET_NET_CHANGE_DEFAULTS=1" > "${SDCARD}"/root/.not_logged_in_yet
+
+	# Enable WiFi or Ethernet.
+	#      NB: If both are enabled, WiFi will take priority and Ethernet will be disabled.
+	echo "PRESET_NET_ETHERNET_ENABLED=0" >> "${SDCARD}"/root/.not_logged_in_yet
+	echo "PRESET_NET_WIFI_ENABLED=1" >> "${SDCARD}"/root/.not_logged_in_yet
+
+	# Preset user default shell, you can choose bash or zsh
+	echo "PRESET_USER_SHELL=zsh" >> "${SDCARD}"/root/.not_logged_in_yet
+
+	# Set PRESET_CONNECT_WIRELESS=y if you want to connect wifi manually at first login
+	echo "PRESET_CONNECT_WIRELESS=n" >> "${SDCARD}"/root/.not_logged_in_yet
+
+	# Set SET_LANG_BASED_ON_LOCATION=n if you want to choose "Set user language based on your location?" with "n" at first login
+	echo "SET_LANG_BASED_ON_LOCATION=y" >> "${SDCARD}"/root/.not_logged_in_yet
+
+	# Preset default locale
+	echo "PRESET_LOCALE=en_US.UTF-8" >> "${SDCARD}"/root/.not_logged_in_yet
+
+	# Preset timezone
+	echo "PRESET_TIMEZONE=Etc/UTC" >> "${SDCARD}"/root/.not_logged_in_yet
+
+	# Preset root password
+	echo "PRESET_ROOT_PASSWORD=admin" >> "${SDCARD}"/root/.not_logged_in_yet
+
+	# Preset username
+	echo "PRESET_USER_NAME=odin" >> "${SDCARD}"/root/.not_logged_in_yet
+
+	# Preset user password
+	echo "PRESET_USER_PASSWORD=admin" >> "${SDCARD}"/root/.not_logged_in_yet
+
+	# Preset user default realname
+	echo "PRESET_DEFAULT_REALNAME=Odin" >> "${SDCARD}"/root/.not_logged_in_yet
 }
 
 function post_family_tweaks_bsp__firmware_in_initrd() {


### PR DESCRIPTION
# Description

Update the kernel to use the preset configurations so that you don't need an external keyboard to access the desktop

[Jira](https://armbian.atlassian.net/jira) reference number [AR-9999]

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] Flash and directly boot to the desktop

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
