### PR TITLE
Remove deprecated fonts from desktop and retire armhf for Trixie

### DIFF
--- a/config/desktop/bookworm/environments/i3-wm/config_base/packages
+++ b/config/desktop/bookworm/environments/i3-wm/config_base/packages
@@ -30,8 +30,6 @@ fonts-dejavu-core
 fonts-freefont-ttf
 fonts-guru
 fonts-guru-extra
-fonts-kacst
-fonts-kacst-one
 fonts-khmeros
 fonts-liberation
 fonts-nanum
@@ -48,7 +46,6 @@ gnome-disk-utility
 gnome-font-viewer
 gnome-power-manager
 gnome-system-monitor
-gnome-system-tools
 gromit
 gstreamer1.0-packagekit
 gstreamer1.0-plugins-base-apps

--- a/config/desktop/bookworm/environments/kde-plasma/config_base/packages
+++ b/config/desktop/bookworm/environments/kde-plasma/config_base/packages
@@ -24,8 +24,6 @@ fonts-dejavu-core
 fonts-freefont-ttf
 fonts-guru
 fonts-guru-extra
-fonts-kacst
-fonts-kacst-one
 fonts-liberation
 fonts-nanum
 fonts-opensymbol

--- a/config/desktop/bookworm/environments/xmonad/config_base/packages
+++ b/config/desktop/bookworm/environments/xmonad/config_base/packages
@@ -29,8 +29,6 @@ fonts-dejavu-core
 fonts-freefont-ttf
 fonts-guru
 fonts-guru-extra
-fonts-kacst
-fonts-kacst-one
 fonts-liberation
 fonts-nanum
 fonts-opensymbol

--- a/config/desktop/common/environments/deepin/config_base/packages
+++ b/config/desktop/common/environments/deepin/config_base/packages
@@ -64,8 +64,6 @@ fonts-dejavu-core
 fonts-freefont-ttf
 fonts-guru
 fonts-guru-extra
-fonts-kacst
-fonts-kacst-one
 fonts-khmeros-core
 fonts-liberation
 fonts-nanum

--- a/config/desktop/common/environments/enlightenment/config_base/packages
+++ b/config/desktop/common/environments/enlightenment/config_base/packages
@@ -27,8 +27,6 @@ fonts-dejavu-core
 fonts-freefont-ttf
 fonts-guru
 fonts-guru-extra
-fonts-kacst
-fonts-kacst-one
 fonts-khmeros-core
 fonts-liberation
 fonts-nanum

--- a/config/desktop/common/environments/i3-wm/config_base/packages
+++ b/config/desktop/common/environments/i3-wm/config_base/packages
@@ -31,8 +31,6 @@ fonts-dejavu-core
 fonts-freefont-ttf
 fonts-guru
 fonts-guru-extra
-fonts-kacst
-fonts-kacst-one
 fonts-khmeros-core
 fonts-liberation
 fonts-nanum
@@ -51,7 +49,6 @@ gnome-font-viewer
 gnome-orca
 gnome-power-manager
 gnome-system-monitor
-gnome-system-tools
 gromit
 gstreamer1.0-packagekit
 gstreamer1.0-plugins-base-apps

--- a/config/desktop/common/environments/kde-plasma/config_base/packages
+++ b/config/desktop/common/environments/kde-plasma/config_base/packages
@@ -25,8 +25,6 @@ fonts-dejavu-core
 fonts-freefont-ttf
 fonts-guru
 fonts-guru-extra
-fonts-kacst
-fonts-kacst-one
 fonts-khmeros-core
 fonts-liberation
 fonts-nanum

--- a/config/desktop/common/environments/mate/config_base/packages
+++ b/config/desktop/common/environments/mate/config_base/packages
@@ -25,8 +25,6 @@ fonts-dejavu-core
 fonts-freefont-ttf
 fonts-guru
 fonts-guru-extra
-fonts-kacst
-fonts-kacst-one
 fonts-khmeros-core
 fonts-liberation
 fonts-nanum

--- a/config/desktop/common/environments/xmonad/config_base/packages
+++ b/config/desktop/common/environments/xmonad/config_base/packages
@@ -27,8 +27,6 @@ fonts-dejavu-core
 fonts-freefont-ttf
 fonts-guru
 fonts-guru-extra
-fonts-kacst
-fonts-kacst-one
 fonts-khmeros-core
 fonts-liberation
 fonts-nanum

--- a/config/desktop/jammy/environments/i3-wm/config_base/packages
+++ b/config/desktop/jammy/environments/i3-wm/config_base/packages
@@ -31,8 +31,6 @@ fonts-dejavu-core
 fonts-freefont-ttf
 fonts-guru
 fonts-guru-extra
-fonts-kacst
-fonts-kacst-one
 fonts-khmeros-core
 fonts-liberation
 fonts-nanum
@@ -50,7 +48,6 @@ gnome-font-viewer
 gnome-orca
 gnome-power-manager
 gnome-system-monitor
-gnome-system-tools
 gromit
 gstreamer1.0-packagekit
 gstreamer1.0-plugins-base-apps

--- a/config/desktop/jammy/environments/kde-plasma/config_base/packages
+++ b/config/desktop/jammy/environments/kde-plasma/config_base/packages
@@ -25,8 +25,6 @@ fonts-dejavu-core
 fonts-freefont-ttf
 fonts-guru
 fonts-guru-extra
-fonts-kacst
-fonts-kacst-one
 fonts-khmeros-core
 fonts-liberation
 fonts-nanum

--- a/config/desktop/jammy/environments/xmonad/config_base/packages
+++ b/config/desktop/jammy/environments/xmonad/config_base/packages
@@ -28,8 +28,6 @@ fonts-dejavu-core
 fonts-freefont-ttf
 fonts-guru
 fonts-guru-extra
-fonts-kacst
-fonts-kacst-one
 fonts-khmeros-core
 fonts-liberation
 fonts-nanum

--- a/config/distributions/noble/architectures
+++ b/config/distributions/noble/architectures
@@ -1,1 +1,1 @@
-arm64,armhf,riscv64,amd64
+arm64,riscv64,amd64

--- a/config/distributions/trixie/architectures
+++ b/config/distributions/trixie/architectures
@@ -1,1 +1,1 @@
-arm64,armhf,amd64
+arm64,amd64


### PR DESCRIPTION
# Description

Upstream packages are getting troublesome for armhf. It might be fixed in the future, but until then, armhf can be put on a side for Noble / Trixie

# How Has This Been Tested?

- [x] CI build test

# Checklist:

- [x] My changes generate no new warnings