### PR TITLE
Add support for HUAWEI MateBook E Go(sc8280xp)

### DIFF
--- a/config/boards/matebook-e-go.conf
+++ b/config/boards/matebook-e-go.conf
@@ -1,0 +1,185 @@
+# Qualcomm Snapdragon 8cx Gen 3 Adreno 690 Qualcomm WCN685x Wi-Fi 6E Qualcomm Snapdragon X55 5G Bluetooth 5.1
+declare -g BOARD_NAME="HUAWEI MateBook E Go"
+declare -g BOARD_MAINTAINER="chenxuecong"
+declare -g BOARDFAMILY="uefi-arm64"
+declare -g KERNEL_TARGET="sc8280xp"
+
+declare -g BOOT_LOGO=desktop
+
+declare -g GRUB_CMDLINE_LINUX_DEFAULT="efi=noruntime clk_ignore_unused pd_ignore_unused arm64.nopauth iommu.passthrough=0 iommu.strict=0 pcie_aspm.policy=powersupersave modprobe.blacklist=msm"
+declare -g BOOT_FDT_FILE="qcom/sc8280xp-lenovo-thinkpad-x13s.dtb"
+declare -g UEFI_MOUNT_POINT_SKIP_FSTAB="yes" # If we leave the /boot/efi in fstab, systemd hangs waiting for it. @TODO why?
+enable_extension "grub-with-dtb"             # important, puts the whole DTB handling in place.
+
+# Use the full firmware, complete linux-firmware plus Armbian's
+declare -g BOARD_FIRMWARE_INSTALL="-full"
+
+# The 6.4 branch is incompatible with x13s Concept's alsa-ucm-conf package, so keep it at 6.3.y for now. @TODO what about 6.6
+function post_family_config_branch_sc8280xp__steevs_67y_kernel() {
+	declare -g KERNEL_MAJOR_MINOR="6.7" # Major and minor versions of this kernel.
+	declare -g KERNELBRANCH='branch:lenovo-x13s-linux-6.7.y'
+	declare -g KERNELSOURCE='https://github.com/steev/linux.git'
+	declare -g LINUXCONFIG="linux-${ARCH}-${BRANCH}" # for this board: linux-arm64-sc8280xp
+	display_alert "Set up steev's kernel ${KERNELBRANCH} for" "${BOARD}" "info"
+}
+
+function x13s_is_userspace_supported() {
+	[[ "${RELEASE}" == "trixie" || "${RELEASE}" == "sid" || "${RELEASE}" == "mantic" || "${RELEASE}" == "noble" ]] && return 0
+	return 1
+}
+
+# https://wiki.debian.org/InstallingDebianOn/Thinkpad/X13s
+function post_family_config__debian_now_has_userspace_for_the_x13s() {
+	if ! x13s_is_userspace_supported; then
+		if [[ "${RELEASE}" != "" ]]; then
+			display_alert "Missing userspace for ${BOARD}" "${RELEASE} does not have the userspace necessary to support the ${BOARD}" "warn"
+		fi
+		return 0
+	fi
+
+	display_alert "Setting up extra Debian packages for ${BOARD}" "${RELEASE}///${BOARD}" "info"
+	add_packages_to_image "bluez" "bluetooth"        # for bluetooth stuff
+	add_packages_to_image "protection-domain-mapper" # for charging; see https://packages.ubuntu.com/protection-domain-mapper and https://packages.debian.org/protection-domain-mapper
+	add_packages_to_image "qrtr-tools"               # for charging; see https://packages.ubuntu.com/qrtr-tools and https://packages.debian.org/qrtr-tools
+	add_packages_to_image "alsa-ucm-conf"            # for audio; see https://packages.ubuntu.com/alsa-ucm-conf and https://packages.debian.org/alsa-ucm-conf - we need 1.2.10 + patches, see below
+	add_packages_to_image "acpi"                     # general ACPI support
+	add_packages_to_image "zstd"                     # for zstd compression of initrd
+
+	# Trixie, as of 2023-10-13, is missing fprintd and libpam-fprintd; see https://tracker.debian.org/pkg/fprintd and https://tracker.debian.org/pkg/libpam-fprintd
+	# @TODO: check again later, and remove this if it's there
+	if [[ "${RELEASE}" != "trixie" ]]; then
+		add_packages_to_image "fprintd"        # for fingerprint reader; see https://packages.ubuntu.com/fprintd and https://packages.debian.org/fprintd
+		add_packages_to_image "libpam-fprintd" # for fingerprint reader PAM support; see https://packages.ubuntu.com/libpam-fprintd and https://packages.debian.org/libpam-fprintd
+	fi
+
+	# Also needed, not listed here:
+	# - mesa > 23.1.5; see https://packages.ubuntu.com/mesa-vulkan-drivers and https://packages.debian.org/mesa-vulkan-drivers
+}
+
+# Distros don't carry the necessary alsa-ucm-conf files.
+# We need https://github.com/alsa-project/alsa-ucm-conf/pull/335
+# Specifically https://github.com/Srinivas-Kandagatla/alsa-ucm-conf.git branch x13s-volume-fixes
+# And specifically SHA1 e8c3e7792336e9f68aa560db8ad19ba06ba786bb -- it has been force pushed a few times
+# As quick-n-dirty solution, we dump the whole contents of that branch on top of the distro's alsa-ucm-conf.
+# This means the fixes will be lost if package is updated, so we apt-mark it to hold.
+# Also means that this will break when ucm package is actually updated, so we can remove this when it is upstreamed.
+function pre_customize_image__x13s_debian_ucm_hack_via_patch() {
+	if ! x13s_is_userspace_supported; then
+		return 0
+	fi
+
+	display_alert "Fixing alsa-ucm-conf for ${BOARD}" "${RELEASE}///${BOARD}" "warn"
+	(
+		cd "${SDCARD}/usr/share/alsa"
+		curl -L "https://github.com/alsa-project/alsa-ucm-conf/archive/refs/heads/master.tar.gz" | tar xvzf - --strip-components=1
+	)
+
+	chroot_sdcard "apt-mark hold alsa-ucm-conf"
+}
+
+function post_family_tweaks_bsp__thinkpad_x13s_bsp_bluetooth_addr() {
+	### The bluetooth does not have a public MAC address set in DT, and BT won't start without one.
+	### Use a systemd override to hook up setting a public-addr before starting bluetoothd
+	declare random_mac_address="" # would be much better to rnd mac on board-side though
+	random_mac_address=$(printf '02:%02X:%02X:%02X:%02X:%02X' $((RANDOM % 256)) $((RANDOM % 256)) $((RANDOM % 256)) $((RANDOM % 256)) $((RANDOM % 256)))
+	display_alert "Adding systemd override for bluetooth public address init" "${BOARD} :: bt mac ${random_mac_address}" "info"
+
+	add_file_from_stdin_to_bsp_destination "/etc/systemd/system/bluetooth.service.d/override.conf" <<- EOD
+		[Service]
+		ExecStartPre=/bin/bash -c 'sleep 5 && yes | btmgmt public-addr ${random_mac_address}'
+	EOD
+}
+
+function post_family_tweaks_bsp__thinkpad_x13s_bsp_always_start_pdmapper() {
+	### (At least) Ubuntu's version of protection-domain-mapper's pd-mapper.service has a kernel condition.
+	### On Debian, this does not hurt.
+	### Remove it using a systemd override.
+	add_file_from_stdin_to_bsp_destination "/etc/systemd/system/pd-mapper.service.d/override.conf" <<- EOD
+		[Unit]
+		Description=Qualcomm PD mapper service (always starts)
+		ConditionKernelVersion=
+	EOD
+}
+
+function post_family_tweaks_bsp__thinkpad_x13s_bsp_touchscreen_udev_unbind_i2c_hid_hack() {
+	## Hack in udev so touchscreen can work - from https://github.com/ironrobin/x13s-alarm/tree/trunk/x13s-touchscreen-udev
+	display_alert "Adding to bsp-cli" "${BOARD}: udev for touchscreen bind" "info"
+	add_file_from_stdin_to_bsp_destination "/usr/lib/udev/rules.d/72-x13s-touchscreen.rules" <<- 'EOD'
+		ACTION=="add" \
+		, RUN+="/bin/bash -c 'echo 4-0010 > /sys/bus/i2c/drivers/i2c_hid_of/bind'"
+	EOD
+}
+
+##
+## Include certain firmware in the initrd
+##
+function post_family_tweaks_bsp__thinkpad_x13s_bsp_firmware_in_initrd() {
+	display_alert "Adding to bsp-cli" "${BOARD}: firmware in initrd" "info"
+	declare file_added_to_bsp_destination # will be filled in by add_file_from_stdin_to_bsp_destination
+	add_file_from_stdin_to_bsp_destination "/etc/initramfs-tools/hooks/x13s-firmware" <<- 'FIRMWARE_HOOK'
+		#!/bin/bash
+		[[ "$1" == "prereqs" ]] && exit 0
+		. /usr/share/initramfs-tools/hook-functions
+		for f in /lib/firmware/qcom/sc8280xp/LENOVO/21BX/* ; do
+			add_firmware "${f#/lib/firmware/}"
+		done
+		add_firmware "qcom/a660_sqe.fw" # extra one for dpu
+		add_firmware "qcom/a660_gmu.bin" # extra one for gpu
+		add_firmware "qcom/a690_gmu.bin" # extra one for gpu (is a symlink)
+	FIRMWARE_HOOK
+	run_host_command_logged chmod -v +x "${file_added_to_bsp_destination}"
+}
+
+## Modules, required to boot, add them to initrd; might need to be done in '.d/x13s-modules' instead
+function post_family_tweaks_bsp__thinkpad_x13s_bsp_modules_in_initrd() {
+	display_alert "Adding to bsp-cli" "${BOARD}: modules in initrd" "info"
+	add_file_from_stdin_to_bsp_destination "/etc/initramfs-tools/modules" <<- 'EXTRA_MODULES'
+		# @TODO this list is outdated, much has changed; check jhovold's defconfig commit msg
+		pwm_bl
+		phy_qcom_qmp_pcie
+		pcie_qcom
+		phy_qcom
+		qmp_pcie
+		phy_qcom_qmp_combo
+		qrtr
+		phy_qcom_edp
+		gpio_sbu_mux
+		i2c_hid_of
+		i2c_qcom_geni
+		pmic_glink_altmode
+		leds_qcom_lpg
+		qcom_q6v5_pas  # This module loads a lot of FW blobs
+		panel-edp
+		msm
+		nvme
+		usb_storage
+		uas
+	EXTRA_MODULES
+
+}
+
+# armbian-firstrun waits for systemd to be ready, but snapd.seeded might cause it to hang due to wrong clock.
+# if the battery runs out, the clock is reset to 1970. This causes snapd.seeded to hang, and armbian-firstrun to hang.
+function pre_customize_image__disable_snapd_seeded() {
+	[[ "${DISTRIBUTION}" != "Ubuntu" ]] && return 0 # only needed for Ubuntu
+	display_alert "Disabling snapd.seeded" "${BOARD}" "info"
+	chroot_sdcard systemctl disable snapd.seeded.service "||" true
+}
+
+# Utility to get firmware needed; this is used to populate armbian/firmware, and is here for reference only.
+function x13s_obtain_firmware() {
+	display_alert "Getting extra firmware for ${BOARD}" "${RELEASE}///${BOARD}" "info"
+	declare fw_target="${SDCARD}/lib/firmware"
+	mkdir -p "${fw_target}/qcom/sc8280xp/LENOVO/21BX"
+
+	# interconnect stuff; get it from ironrobin's repo;
+	wget --output-document "${fw_target}/qcom/sc8280xp/LENOVO/21BX/qcvss8280.mbn" "https://raw.githubusercontent.com/ironrobin/x13s-alarm/trunk/x13s-firmware/qcvss8280.mbn"
+
+	# add a link to audio fw
+	(cd "${fw_target}/qcom/sc8280xp" && ln -s "LENOVO/21BX/audioreach-tplg.bin" "SC8280XP-LENOVO-X13S-tplg.bin")
+
+	# gpu, link 690 to 660 gmu
+	(cd "${fw_target}/qcom/" && ln -s a660_gmu.bin a690_gmu.bin)
+
+	return 0
+}

--- a/config/boards/matebook-e-go.conf
+++ b/config/boards/matebook-e-go.conf
@@ -1,13 +1,14 @@
 # Qualcomm Snapdragon 8cx Gen 3 Adreno 690 Qualcomm WCN685x Wi-Fi 6E Qualcomm Snapdragon X55 5G Bluetooth 5.1
 declare -g BOARD_NAME="HUAWEI MateBook E Go"
-declare -g BOARD_MAINTAINER="chenxuecong"
 declare -g BOARDFAMILY="uefi-arm64"
-declare -g KERNEL_TARGET="sc8280xp"
+declare -g BOARD_MAINTAINER="chenxuecong"
+declare -g KERNEL_TARGET="gaokun"
+declare -g BRANCH="gaokun"
 
 declare -g BOOT_LOGO=desktop
 
-declare -g GRUB_CMDLINE_LINUX_DEFAULT="efi=noruntime clk_ignore_unused pd_ignore_unused arm64.nopauth iommu.passthrough=0 iommu.strict=0 pcie_aspm.policy=powersupersave modprobe.blacklist=msm"
-declare -g BOOT_FDT_FILE="qcom/sc8280xp-lenovo-thinkpad-x13s.dtb"
+declare -g GRUB_CMDLINE_LINUX_DEFAULT="modprobe.blacklist=msm efi=noruntime clk_ignore_unused pd_ignore_unused arm64.nopauth iommu.passthrough=0 iommu.strict=0 pcie_aspm.policy=powersupersave modprobe.blacklist=msm"
+declare -g BOOT_FDT_FILE="qcom/sc8280xp-huawei-matebook-e-go.dtb"
 declare -g UEFI_MOUNT_POINT_SKIP_FSTAB="yes" # If we leave the /boot/efi in fstab, systemd hangs waiting for it. @TODO why?
 enable_extension "grub-with-dtb"             # important, puts the whole DTB handling in place.
 
@@ -18,9 +19,8 @@ declare -g BOARD_FIRMWARE_INSTALL="-full"
 function post_family_config_branch_sc8280xp__steevs_67y_kernel() {
 	declare -g KERNEL_MAJOR_MINOR="6.7" # Major and minor versions of this kernel.
 	declare -g KERNELBRANCH='branch:lenovo-x13s-linux-6.7.y'
-	declare -g KERNELSOURCE='https://github.com/steev/linux.git'
-	declare -g LINUXCONFIG="linux-${ARCH}-${BRANCH}" # for this board: linux-arm64-sc8280xp
-	display_alert "Set up steev's kernel ${KERNELBRANCH} for" "${BOARD}" "info"
+	declare -g KERNELSOURCE='https://github.com/chenxuecong2/linux-huawei-matebook-e-go.git'
+	declare -g LINUXCONFIG="linux-arm64-sc8280xp"
 }
 
 function x13s_is_userspace_supported() {
@@ -63,7 +63,7 @@ function post_family_config__debian_now_has_userspace_for_the_x13s() {
 # As quick-n-dirty solution, we dump the whole contents of that branch on top of the distro's alsa-ucm-conf.
 # This means the fixes will be lost if package is updated, so we apt-mark it to hold.
 # Also means that this will break when ucm package is actually updated, so we can remove this when it is upstreamed.
-function pre_customize_image__x13s_debian_ucm_hack_via_patch() {
+function pre_customize_image__gaokun_debian_ucm_hack_via_patch() {
 	if ! x13s_is_userspace_supported; then
 		return 0
 	fi
@@ -77,7 +77,7 @@ function pre_customize_image__x13s_debian_ucm_hack_via_patch() {
 	chroot_sdcard "apt-mark hold alsa-ucm-conf"
 }
 
-function post_family_tweaks_bsp__thinkpad_x13s_bsp_bluetooth_addr() {
+function post_family_tweaks_bsp__thinkpad_gaokun_bsp_bluetooth_addr() {
 	### The bluetooth does not have a public MAC address set in DT, and BT won't start without one.
 	### Use a systemd override to hook up setting a public-addr before starting bluetoothd
 	declare random_mac_address="" # would be much better to rnd mac on board-side though
@@ -90,7 +90,7 @@ function post_family_tweaks_bsp__thinkpad_x13s_bsp_bluetooth_addr() {
 	EOD
 }
 
-function post_family_tweaks_bsp__thinkpad_x13s_bsp_always_start_pdmapper() {
+function post_family_tweaks_bsp__thinkpad_gaokun_bsp_always_start_pdmapper() {
 	### (At least) Ubuntu's version of protection-domain-mapper's pd-mapper.service has a kernel condition.
 	### On Debian, this does not hurt.
 	### Remove it using a systemd override.
@@ -101,7 +101,7 @@ function post_family_tweaks_bsp__thinkpad_x13s_bsp_always_start_pdmapper() {
 	EOD
 }
 
-function post_family_tweaks_bsp__thinkpad_x13s_bsp_touchscreen_udev_unbind_i2c_hid_hack() {
+function post_family_tweaks_bsp__thinkpad_gaokun_bsp_touchscreen_udev_unbind_i2c_hid_hack() {
 	## Hack in udev so touchscreen can work - from https://github.com/ironrobin/x13s-alarm/tree/trunk/x13s-touchscreen-udev
 	display_alert "Adding to bsp-cli" "${BOARD}: udev for touchscreen bind" "info"
 	add_file_from_stdin_to_bsp_destination "/usr/lib/udev/rules.d/72-x13s-touchscreen.rules" <<- 'EOD'
@@ -113,7 +113,7 @@ function post_family_tweaks_bsp__thinkpad_x13s_bsp_touchscreen_udev_unbind_i2c_h
 ##
 ## Include certain firmware in the initrd
 ##
-function post_family_tweaks_bsp__thinkpad_x13s_bsp_firmware_in_initrd() {
+function post_family_tweaks_bsp__thinkpad_gaokun_bsp_firmware_in_initrd() {
 	display_alert "Adding to bsp-cli" "${BOARD}: firmware in initrd" "info"
 	declare file_added_to_bsp_destination # will be filled in by add_file_from_stdin_to_bsp_destination
 	add_file_from_stdin_to_bsp_destination "/etc/initramfs-tools/hooks/x13s-firmware" <<- 'FIRMWARE_HOOK'
@@ -131,7 +131,7 @@ function post_family_tweaks_bsp__thinkpad_x13s_bsp_firmware_in_initrd() {
 }
 
 ## Modules, required to boot, add them to initrd; might need to be done in '.d/x13s-modules' instead
-function post_family_tweaks_bsp__thinkpad_x13s_bsp_modules_in_initrd() {
+function post_family_tweaks_bsp__thinkpad_gaokun_bsp_modules_in_initrd() {
 	display_alert "Adding to bsp-cli" "${BOARD}: modules in initrd" "info"
 	add_file_from_stdin_to_bsp_destination "/etc/initramfs-tools/modules" <<- 'EXTRA_MODULES'
 		# @TODO this list is outdated, much has changed; check jhovold's defconfig commit msg

--- a/config/boards/matebook-e-go.conf
+++ b/config/boards/matebook-e-go.conf
@@ -28,7 +28,7 @@ function x13s_is_userspace_supported() {
 	return 1
 }
 
-# https://wiki.debian.org/InstallingDebianOn/Thinkpad/X13s
+# https://wiki.debian.org/InstallingDebianOn/huawei/X13s
 function post_family_config__debian_now_has_userspace_for_the_x13s() {
 	if ! x13s_is_userspace_supported; then
 		if [[ "${RELEASE}" != "" ]]; then
@@ -77,7 +77,7 @@ function pre_customize_image__gaokun_debian_ucm_hack_via_patch() {
 	chroot_sdcard "apt-mark hold alsa-ucm-conf"
 }
 
-function post_family_tweaks_bsp__thinkpad_gaokun_bsp_bluetooth_addr() {
+function post_family_tweaks_bsp__huawei_gaokun_bsp_bluetooth_addr() {
 	### The bluetooth does not have a public MAC address set in DT, and BT won't start without one.
 	### Use a systemd override to hook up setting a public-addr before starting bluetoothd
 	declare random_mac_address="" # would be much better to rnd mac on board-side though
@@ -90,7 +90,7 @@ function post_family_tweaks_bsp__thinkpad_gaokun_bsp_bluetooth_addr() {
 	EOD
 }
 
-function post_family_tweaks_bsp__thinkpad_gaokun_bsp_always_start_pdmapper() {
+function post_family_tweaks_bsp__huawei_gaokun_bsp_always_start_pdmapper() {
 	### (At least) Ubuntu's version of protection-domain-mapper's pd-mapper.service has a kernel condition.
 	### On Debian, this does not hurt.
 	### Remove it using a systemd override.
@@ -101,7 +101,7 @@ function post_family_tweaks_bsp__thinkpad_gaokun_bsp_always_start_pdmapper() {
 	EOD
 }
 
-function post_family_tweaks_bsp__thinkpad_gaokun_bsp_touchscreen_udev_unbind_i2c_hid_hack() {
+function post_family_tweaks_bsp__huawei_gaokun_bsp_touchscreen_udev_unbind_i2c_hid_hack() {
 	## Hack in udev so touchscreen can work - from https://github.com/ironrobin/x13s-alarm/tree/trunk/x13s-touchscreen-udev
 	display_alert "Adding to bsp-cli" "${BOARD}: udev for touchscreen bind" "info"
 	add_file_from_stdin_to_bsp_destination "/usr/lib/udev/rules.d/72-x13s-touchscreen.rules" <<- 'EOD'
@@ -113,7 +113,7 @@ function post_family_tweaks_bsp__thinkpad_gaokun_bsp_touchscreen_udev_unbind_i2c
 ##
 ## Include certain firmware in the initrd
 ##
-function post_family_tweaks_bsp__thinkpad_gaokun_bsp_firmware_in_initrd() {
+function post_family_tweaks_bsp__huawei_gaokun_bsp_firmware_in_initrd() {
 	display_alert "Adding to bsp-cli" "${BOARD}: firmware in initrd" "info"
 	declare file_added_to_bsp_destination # will be filled in by add_file_from_stdin_to_bsp_destination
 	add_file_from_stdin_to_bsp_destination "/etc/initramfs-tools/hooks/x13s-firmware" <<- 'FIRMWARE_HOOK'
@@ -131,7 +131,7 @@ function post_family_tweaks_bsp__thinkpad_gaokun_bsp_firmware_in_initrd() {
 }
 
 ## Modules, required to boot, add them to initrd; might need to be done in '.d/x13s-modules' instead
-function post_family_tweaks_bsp__thinkpad_gaokun_bsp_modules_in_initrd() {
+function post_family_tweaks_bsp__huawei_gaokun_bsp_modules_in_initrd() {
 	display_alert "Adding to bsp-cli" "${BOARD}: modules in initrd" "info"
 	add_file_from_stdin_to_bsp_destination "/etc/initramfs-tools/modules" <<- 'EXTRA_MODULES'
 		# @TODO this list is outdated, much has changed; check jhovold's defconfig commit msg


### PR DESCRIPTION
Description
Add huawei matebook e go support

How Has This Been Tested?
Tested on HUAWEI MateBook E Go

 installed on sd card and device is booting fine
Checklist:
 My code follows the style guidelines of this project
 I have performed a self-review of my own code
 I have commented my code, particularly in hard-to-understand areas
 I have made corresponding changes to the documentation
 My changes generate no new warnings
 Any dependent changes have been merged and published in downstream modules