### PR TITLE
VIM1S/VIM4: Allow building on arm64 platform

### DIFF
--- a/config/sources/families/meson-s4t7.conf
+++ b/config/sources/families/meson-s4t7.conf
@@ -50,14 +50,16 @@ function add_host_dependencies__khadas_fips_needs_xxd() {
 function fetch_sources_tools__meson_s4t7_download_uboot_toolchain() {
 	display_alert "$BOARD" "preparing linaro toolchain for bootloader fip" "info"
 
-	if [[ "${HOSTARCH}" != "amd64" ]]; then
-		exit_with_error "vim1s/vim4 uboot requires amd64 system to build"
+	if [[ "${HOSTARCH}" != "amd64" ]] && [[ "${HOSTARCH}" != "arm64" ]]; then
+		exit_with_error "vim1s/vim4 uboot requires amd64 or arm64 system to build"
 	fi
 
 	declare tversion="7.3.1-2018.05"
 	declare tbasedir="${SRC}/cache/toolchain"
-	declare tdir="${tbasedir}/gcc-linaro-${tversion}-x86_64_aarch64-elf"
-	declare tfile="gcc-linaro-${tversion}-x86_64_aarch64-elf.tar.xz"
+	declare tos="x86_64"
+	[[ "${HOSTARCH}" == "arm64" ]] && tos="aarch64"
+	declare tdir="${tbasedir}/gcc-linaro-${tversion}-${tos}_aarch64-elf"
+	declare tfile="gcc-linaro-${tversion}-${tos}_aarch64-elf.tar.xz"
 	declare turl="https://dl.armbian.com/_toolchain/${tfile}"
 
 	if [[ ! -d "${tdir}" ]]; then

--- a/patch/u-boot/u-boot-meson-s4t7/allow-aarch64-compilation.patch
+++ b/patch/u-boot/u-boot-meson-s4t7/allow-aarch64-compilation.patch
@@ -1,0 +1,113 @@
+From b3e36f79e4e71699366575716ac34da15dfdd9a2 Mon Sep 17 00:00:00 2001
+From: Gunjan Gupta <viraniac@gmail.com>
+Date: Thu, 2 May 2024 11:06:51 +0000
+Subject: [PATCH] Allow building on arm64 platform
+
+---
+ fip/s4/bin/add-dvinit-params.sh | 4 ++++
+ fip/s4/bin/gen-bl.sh            | 5 +++++
+ fip/s4/build.sh                 | 6 +++++-
+ fip/t7/bin/add-dvinit-params.sh | 4 ++++
+ fip/t7/bin/gen-bl.sh            | 5 +++++
+ fip/t7/build.sh                 | 6 +++++-
+ 6 files changed, 28 insertions(+), 2 deletions(-)
+
+diff --git a/fip/s4/bin/add-dvinit-params.sh b/fip/s4/bin/add-dvinit-params.sh
+index 79e7afc0c0c..f98c7a79bd8 100755
+--- a/fip/s4/bin/add-dvinit-params.sh
++++ b/fip/s4/bin/add-dvinit-params.sh
+@@ -10,6 +10,10 @@ set -e
+ EXEC_BASEDIR=$(dirname $(readlink -f $0))
+ ACPU_IMAGETOOL=${EXEC_BASEDIR}/../binary-tool/acpu-imagetool
+ 
++if [ $(arch) != "x86_64" ]; then
++	ACPU_IMAGETOOL="qemu-x86_64-static ${ACPU_IMAGETOOL}"
++fi
++
+ BASEDIR_TOP=$(readlink -f ${EXEC_BASEDIR}/..)
+ 
+ #
+diff --git a/fip/s4/bin/gen-bl.sh b/fip/s4/bin/gen-bl.sh
+index 5a8d267fd15..6d0bf541059 100755
+--- a/fip/s4/bin/gen-bl.sh
++++ b/fip/s4/bin/gen-bl.sh
+@@ -9,6 +9,11 @@ set -e
+ 
+ EXEC_BASEDIR=$(dirname $(readlink -f $0))
+ ACPU_IMAGETOOL=${EXEC_BASEDIR}/../binary-tool/acpu-imagetool
++
++if [ $(arch) != "x86_64" ]; then
++	ACPU_IMAGETOOL="qemu-x86_64-static ${ACPU_IMAGETOOL}"
++fi
++
+ CP=cp
+ 
+ BASEDIR_TOP=$(readlink -f ${EXEC_BASEDIR}/..)
+diff --git a/fip/s4/build.sh b/fip/s4/build.sh
+index ec0705c9081..3b54617c391 100755
+--- a/fip/s4/build.sh
++++ b/fip/s4/build.sh
+@@ -577,7 +577,11 @@ function cleanup() {
+ function encrypt_step() {
+ 	dbg "encrypt: $@"
+ 	local ret=0
+-	./${FIP_FOLDER}${CUR_SOC}/aml_encrypt_${CUR_SOC} $@
++	if [ $(arch) != "x86_64" ]; then
++		qemu-x86_64-static ./${FIP_FOLDER}${CUR_SOC}/aml_encrypt_${CUR_SOC} $@
++	else
++		./${FIP_FOLDER}${CUR_SOC}/aml_encrypt_${CUR_SOC} $@
++	fi
+ 	ret=$?
+ 	if [ 0 != $ret ]; then
+ 		echo "Err! aml_encrypt_${CUR_SOC} return $ret"
+diff --git a/fip/t7/bin/add-dvinit-params.sh b/fip/t7/bin/add-dvinit-params.sh
+index 261edb6aa45..116a64360a8 100755
+--- a/fip/t7/bin/add-dvinit-params.sh
++++ b/fip/t7/bin/add-dvinit-params.sh
+@@ -10,6 +10,10 @@ set -e
+ EXEC_BASEDIR=$(dirname $(readlink -f $0))
+ ACPU_IMAGETOOL=${EXEC_BASEDIR}/../binary-tool/acpu-imagetool
+ 
++if [ $(arch) != "x86_64" ]; then
++	ACPU_IMAGETOOL="qemu-x86_64-static ${ACPU_IMAGETOOL}"
++fi
++
+ BASEDIR_TOP=$(readlink -f ${EXEC_BASEDIR}/..)
+ 
+ #
+diff --git a/fip/t7/bin/gen-bl.sh b/fip/t7/bin/gen-bl.sh
+index 9122db65ed8..d87c696bd2b 100755
+--- a/fip/t7/bin/gen-bl.sh
++++ b/fip/t7/bin/gen-bl.sh
+@@ -9,6 +9,11 @@ set -e
+ 
+ EXEC_BASEDIR=$(dirname $(readlink -f $0))
+ ACPU_IMAGETOOL=${EXEC_BASEDIR}/../binary-tool/acpu-imagetool
++
++if [ $(arch) != "x86_64" ]; then
++	ACPU_IMAGETOOL="qemu-x86_64-static ${ACPU_IMAGETOOL}"
++fi
++
+ CP=cp
+ 
+ BASEDIR_TOP=$(readlink -f ${EXEC_BASEDIR}/..)
+diff --git a/fip/t7/build.sh b/fip/t7/build.sh
+index 2ad7bf85076..9209fff49c3 100755
+--- a/fip/t7/build.sh
++++ b/fip/t7/build.sh
+@@ -576,7 +576,11 @@ function cleanup() {
+ function encrypt_step() {
+ 	dbg "encrypt: $@"
+ 	local ret=0
+-	./${FIP_FOLDER}${CUR_SOC}/aml_encrypt_${CUR_SOC} $@
++	if [ $(arch) != "x86_64" ]; then
++		qemu-x86_64-static ./${FIP_FOLDER}${CUR_SOC}/aml_encrypt_${CUR_SOC} $@
++	else
++		./${FIP_FOLDER}${CUR_SOC}/aml_encrypt_${CUR_SOC} $@
++	fi
+ 	ret=$?
+ 	if [ 0 != $ret ]; then
+ 		echo "Err! aml_encrypt_${CUR_SOC} return $ret"
+-- 
+2.34.1
+


### PR DESCRIPTION
# Description

Add support to build VIM1S/VIM4 images on arm64 platform. Currently only x86_64 platform was supported as build host as the gcc-linaro-aarch64-elf compiler version 7.3.1-2018.05 was not available for aarch64 platform. I have built the compiler myself on vim4 using the commands given [here](https://paste.armbian.com/ukexeximad.shell) 

# How Has This Been Tested?

- [X] Compiled u-boot for VIM1S and VIM4
- [X] Created a minimal bookworm image for VIM1S and booted on the same

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
