### PR TITLE
VIM1S/VIM4: Add support for emmc + NVME/USB booting

### DIFF
--- a/config/bootscripts/boot-meson-s4t7.cmd
+++ b/config/bootscripts/boot-meson-s4t7.cmd
@@ -89,13 +89,8 @@ fi
 
 # The symlinks for kernel and initrd.img are at different locations in debian and ubuntu
 # Check and load from a location that exists
-if test -e ${devtype} ${devnum} /vmlinuz; then
-	load ${devtype} ${devnum} ${kernel_addr_r} /vmlinuz
-	load ${devtype} ${devnum} ${ramdisk_addr_r} /initrd.img
-else
-	load ${devtype} ${devnum} ${kernel_addr_r} ${prefix}vmlinuz
-	load ${devtype} ${devnum} ${ramdisk_addr_r} ${prefix}initrd.img
-fi
+load ${devtype} ${devnum} ${kernel_addr_r} ${prefix}Image
+load ${devtype} ${devnum} ${ramdisk_addr_r} ${prefix}Initrd
 booti ${kernel_addr_r} ${ramdisk_addr_r}:${filesize} ${fdt_addr_r}
 
 # Recompile with:

--- a/config/sources/families/meson-s4t7.conf
+++ b/config/sources/families/meson-s4t7.conf
@@ -215,3 +215,42 @@ function post_family_tweaks_bsp__add_postrm_hook() {
 	display_alert "$BOARD" "Adding postrm hook to restore /etc/initramfs-tools/modules file" "info"
 	postrm_functions+=(meson_s4t7_board_side_bsp_cli_postrm)
 }
+
+function post_family_tweaks_bsp__meson_s4t7_set_initrd_symlink_location() {
+	# We already create /boot/Image symlink ourselves. Lets also create a symlink for initrd so that
+	# we can have a consistent way for booting.
+	run_host_command_logged cat <<- 'zzz-update-initramfs' > "${destination}"/etc/initramfs/post-update.d/zzz-update-initramfs
+		#!/bin/bash -e
+
+		# Play nice when run under debconf.
+		exec </dev/null >&2
+
+		abi=$1
+		initrd_file=$2
+		target=/boot/
+
+		function is_boot_dev_vfat() {
+			if ! mountpoint -q /boot; then
+				return 1
+			fi
+			local boot_partition bootfstype
+			boot_partition=$(findmnt --nofsroot -n -o SOURCE /boot)
+			bootfstype=$(blkid -s TYPE -o value $boot_partition)
+			if [[ "$bootfstype" == "vfat" ]]; then
+				return 0
+			fi
+			return 1
+		}
+
+		if is_boot_dev_vfat; then
+			cp ${initrd_file} ${target}/Initrd
+			sync -f ${target}/Initrd || true
+		else
+			ln -sf ${initrd_file} ${target}/Initrd
+		fi
+
+		exit 0
+	zzz-update-initramfs
+
+	chmod a+x "${destination}"/etc/initramfs/post-update.d/zzz-update-initramfs
+}

--- a/packages/bsp/meson-s4t7/khadas-vim4/etc/initramfs-tools/modules
+++ b/packages/bsp/meson-s4t7/khadas-vim4/etc/initramfs-tools/modules
@@ -55,3 +55,4 @@ amlogic-irblaster
 amlogic-phy-debug
 amlogic-inphy
 aml_drm
+amlogic_pcie_v2_host

--- a/packages/bsp/meson-s4t7/khadas-vim4/etc/modprobe.d/initramfs-modules-load-order.conf
+++ b/packages/bsp/meson-s4t7/khadas-vim4/etc/modprobe.d/initramfs-modules-load-order.conf
@@ -43,3 +43,4 @@ softdep amlogic-irblaster pre: amlogic-usb
 softdep amlogic-phy-debug pre: amlogic-irblaster
 softdep amlogic-inphy pre: amlogic-phy-debug
 softdep aml_drm pre: amlogic-inphy
+softdep amlogic_pcie_v2_host pre: aml_drm


### PR DESCRIPTION
# Description

As per the title. Allows using emmc for boot partition and nvme or usb for root partition when installing via armbian-install.

# How Has This Been Tested?

- [X] Created and booted image on VIM1S with emmc+USB combo

# Checklist:

_Please delete options that are not relevant._

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
