### PR TITLE
Removing myself as maintainer for allwinner and rpi boards

### DIFF
--- a/config/boards/nanopiduo2.csc
+++ b/config/boards/nanopiduo2.csc
@@ -1,7 +1,7 @@
 # Allwinner H3 quad core 512MB RAM SoC headless WiFi/BT
 BOARD_NAME="NanoPi Duo2"
 BOARDFAMILY="sun8i"
-BOARD_MAINTAINER="viraniac"
+BOARD_MAINTAINER=""
 BOOTCONFIG="nanopi_neo_defconfig"
 MODULES="g_serial"
 MODULES_BLACKLIST="lima"

--- a/config/boards/orangepi3-lts.csc
+++ b/config/boards/orangepi3-lts.csc
@@ -1,7 +1,7 @@
 # Allwinner H6 quad core 2GB RAM SoC GBE USB3
 BOARD_NAME="Orange Pi 3 LTS"
 BOARDFAMILY="sun50iw6"
-BOARD_MAINTAINER="viraniac"
+BOARD_MAINTAINER=""
 BOOTCONFIG="orangepi_3_lts_defconfig"
 BOOT_LOGO="desktop"
 KERNEL_TARGET="legacy,current,edge"

--- a/config/boards/orangepi3.csc
+++ b/config/boards/orangepi3.csc
@@ -1,7 +1,7 @@
 # Allwinner H6 quad core 2GB RAM SoC GBE USB3
 BOARD_NAME="Orange Pi 3"
 BOARDFAMILY="sun50iw6"
-BOARD_MAINTAINER="viraniac"
+BOARD_MAINTAINER=""
 BOOTCONFIG="orangepi_3_defconfig"
 KERNEL_TARGET="legacy,current,edge"
 KERNEL_TEST_TARGET="current,edge"

--- a/config/boards/orangepiprime.csc
+++ b/config/boards/orangepiprime.csc
@@ -1,7 +1,7 @@
 # Allwinner H5 quad core 2GB RAM Wi-Fi/BT
 BOARD_NAME="Orange Pi Prime"
 BOARDFAMILY="sun50iw2"
-BOARD_MAINTAINER="viraniac"
+BOARD_MAINTAINER=""
 BOOTCONFIG="orangepi_prime_defconfig"
 DEFAULT_OVERLAYS="analog-codec"
 KERNEL_TARGET="legacy,current,edge"

--- a/config/boards/orangepizero.csc
+++ b/config/boards/orangepizero.csc
@@ -1,7 +1,7 @@
 # Allwinner H2+ quad core 256/512MB RAM SoC WiFi SPI
 BOARD_NAME="Orange Pi Zero"
 BOARDFAMILY="sun8i"
-BOARD_MAINTAINER="viraniac"
+BOARD_MAINTAINER=""
 BOOTCONFIG="orangepi_zero_defconfig"
 MODULES_CURRENT="g_serial"
 MODULES_BLACKLIST="sunxi_cedrus"

--- a/config/boards/rpi4b.conf
+++ b/config/boards/rpi4b.conf
@@ -1,7 +1,7 @@
 # Broadcom BCM2711 quad core 1-8Gb RAM SoC USB3 GBE USB-C WiFi/BT
 declare -g BOARD_NAME="Raspberry Pi 4"
 declare -g BOARDFAMILY="bcm2711"
-declare -g BOARD_MAINTAINER="viraniac teknoid PanderMusubi"
+declare -g BOARD_MAINTAINER="teknoid PanderMusubi"
 declare -g KERNEL_TARGET="legacy,current,edge"
 declare -g ASOUND_STATE="asound.state.rpi"
 declare -g KERNEL_TEST_TARGET="current,edge"

--- a/config/boards/rpi5b.csc
+++ b/config/boards/rpi5b.csc
@@ -1,7 +1,7 @@
 # Broadcom BCM2712 quad core 1-8Gb RAM SoC USB3 GBE USB-C WiFi/BT
 declare -g BOARD_NAME="Raspberry Pi 5"
 declare -g BOARDFAMILY="bcm2711"
-declare -g BOARD_MAINTAINER="viraniac"
+declare -g BOARD_MAINTAINER=""
 declare -g KERNEL_TARGET="current,edge"
 declare -g ASOUND_STATE="asound.state.rpi"
 declare -g KERNEL_TEST_TARGET="current,edge"


### PR DESCRIPTION
# Description

Removing myself as maintainer for Raspberry Pi and Allwinner boards as I no longer have time to maintain them. As some of the boards no longer have maintainer, changed them to csc.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
