### PR TITLE
add armsom-sige1 support

### DIFF
--- a/config/boards/armsom-sige1.csc
+++ b/config/boards/armsom-sige1.csc
@@ -1,0 +1,19 @@
+# Rockchip RK3528 quad core 1-8GB SoC GBe eMMC USB3 Wifi Bt
+BOARD_NAME="ArmSoM Sige1"
+BOARDFAMILY="rk35xx"
+BOOTCONFIG="hinlink_rk3528_defconfig"
+BOARD_MAINTAINER="amazingfate"
+KERNEL_TARGET="vendor"
+FULL_DESKTOP="yes"
+BOOT_LOGO="desktop"
+BOOT_FDT_FILE="rockchip/rk3528-armsom-sige1.dtb"
+BOOT_SCENARIO="spl-blobs"
+WIREGUARD="no"
+IMAGE_PARTITION_TABLE="gpt"
+
+# Override family config for this board; let's avoid conditionals in family config.
+function post_family_config__armsom-sige1_use_vendor_uboot() {
+	BOOTSOURCE='https://github.com/rockchip-linux/u-boot.git'
+	BOOTBRANCH='commit:32640b0ada9344f91e7a407576568782907161cd'
+	BOOTPATCHDIR="legacy/board_hinlink-h28k"
+}


### PR DESCRIPTION
# Description

ArmSoM Sige1 is a rk3528 board with emmc, dual ethernet, rtl8852bs wifi/bt, HDMI, usb.
https://docs.armsom.org/armsom-sige1
I just use the uboot defconfig from hinlink-h28k and it works fine.
At the moment only vendor 6.1 kernel is supported. This pr depends on https://github.com/armbian/linux-rockchip/pull/178

# How Has This Been Tested?

- [x] `./compile.sh BOARD=armsom-sige1 BRANCH=vendor BUILD_DESKTOP=no BUILD_MINIMAL=no DEB_COMPRESS=xz KERNEL_CONFIGURE=no RELEASE=bookworm KERNEL_GIT=shallow`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
