### PR TITLE
cpufrequtils cleanup after PR6507

### DIFF
--- a/config/cli/bullseye/main/packages
+++ b/config/cli/bullseye/main/packages
@@ -4,7 +4,6 @@ bridge-utils
 chrony
 command-not-found
 console-setup
-cpufrequtils
 cron
 curl
 dbus-user-session

--- a/config/cli/common/main/packages
+++ b/config/cli/common/main/packages
@@ -4,7 +4,6 @@ bridge-utils
 chrony
 command-not-found
 console-setup
-cpufrequtils
 cron
 curl
 dbus-user-session

--- a/config/cli/jammy/main/packages
+++ b/config/cli/jammy/main/packages
@@ -4,7 +4,6 @@ bridge-utils
 chrony
 command-not-found
 console-setup
-cpufrequtils
 cron
 curl
 dbus-user-session


### PR DESCRIPTION
In [PR6507](https://github.com/armbian/build/pull/6507) the use of cpufrequtils was removed and the functionality put into armbian-hardware-optimization This commit removes the remaining now unused installs of the deprecated cpufrequtils package

 Changes to be committed:
	modified:   config/cli/bullseye/main/packages
	modified:   config/cli/common/main/packages
	modified:   config/cli/jammy/main/packages

# Description

# How Has This Been Tested?

- [x] jammy cli build

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
