### PR TITLE
rockchip64: rework drm hunk due to mainlined patch

### DIFF
--- a/patch/kernel/archive/rockchip64-6.8/general-hdmi-clock-fixes.patch
+++ b/patch/kernel/archive/rockchip64-6.8/general-hdmi-clock-fixes.patch
@@ -257,31 +257,8 @@ index 4b338cb89d32..468347e16f92 100644
  	act_info = (actual_h - 1) << 16 | ((actual_w - 1) & 0xffff);
  
  	dsp_info = (drm_rect_height(dest) - 1) << 16;
-@@ -952,7 +959,12 @@ static void vop_plane_atomic_update(struct drm_plane *plane,
- 	dsp_sty = dest->y1 + crtc->mode.vtotal - crtc->mode.vsync_start;
- 	dsp_st = dsp_sty << 16 | (dsp_stx & 0xffff);
- 
--	offset = (src->x1 >> 16) * fb->format->cpp[0];
-+	if (fb->format->block_w[0])
-+		offset = (src->x1 >> 16) * fb->format->char_per_block[0] /
-+			 fb->format->block_w[0];
-+	else
-+		offset = (src->x1 >> 16) * fb->format->cpp[0];
-+
- 	offset += (src->y1 >> 16) * fb->pitches[0];
- 	dma_addr = rk_obj->dma_addr + offset + fb->offsets[0];
- 
-@@ -994,11 +1006,15 @@ static void vop_plane_atomic_update(struct drm_plane *plane,
- 		uv_obj = fb->obj[1];
- 		rk_uv_obj = to_rockchip_obj(uv_obj);
- 
--		offset = (src->x1 >> 16) * bpp / hsub;
-+		if (fb->format->block_w[1])
-+			offset = (src->x1 >> 16) * bpp /
-+				 fb->format->block_w[1] / hsub;
-+		else
-+			offset = (src->x1 >> 16) * bpp / hsub;
- 		offset += (src->y1 >> 16) * fb->pitches[1] / vsub;
+@@ -1022,7 +1022,7 @@ static void vop_plane_atomic_update(struct drm_plane *plane,
+ 		offset += (src->y1 >> 16) * fb->pitches[1] / fb->format->vsub;
  
  		dma_addr = rk_uv_obj->dma_addr + offset + fb->offsets[1];
 -		VOP_WIN_SET(vop, win, uv_vir, DIV_ROUND_UP(fb->pitches[1], 4));
@@ -289,6 +266,7 @@ index 4b338cb89d32..468347e16f92 100644
  		VOP_WIN_SET(vop, win, uv_mst, dma_addr);
  
  		for (i = 0; i < NUM_YUV2YUV_COEFFICIENTS; i++) {
+
 diff --git a/drivers/gpu/drm/rockchip/rockchip_vop_reg.c b/drivers/gpu/drm/rockchip/rockchip_vop_reg.c
 index 7b2805006776..ffa0c717290e 100644
 --- a/drivers/gpu/drm/rockchip/rockchip_vop_reg.c
@@ -559,4 +537,3 @@ index 341550199111..05c5a4fb16b2 100644
 
 -- 
 2.34.1
-


### PR DESCRIPTION
# Description

Quick fix to hdmi patch due to mainlined hunks.

# How Has This Been Tested?

- [x] New fixed patch apply on 6.8.9 edge kernel
- [x] Compiled rockchip drm code on the fly to check it works

Did not check the real functionality, but *I hope* I did not break anything, the patch is minimal...

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

