### PR TITLE
enable android binder on rk3588 edge config for android container sup…

### DIFF
--- a/config/kernel/linux-rockchip-rk3588-edge.config
+++ b/config/kernel/linux-rockchip-rk3588-edge.config
@@ -9325,7 +9325,9 @@ CONFIG_RAS=y
 
 #
 # Android
-#
+CONFIG_ANDROID_BINDER_IPC=y
+CONFIG_ANDROID_BINDERFS=y
+CONFIG_ANDROID_BINDER_DEVICES="binder,hwbinder,vndbinder,anbox-binder,anbox-hwbinder,anbox-vndbinder"
 # CONFIG_ANDROID_BINDER_IPC is not set
 # end of Android
 


### PR DESCRIPTION

# Description

enable android binder to support android containers like anbox or waydroid on rk3588 edge kernel builds



- [ ] short description (copy / paste of PR title)
- [ ] summary (description relevant for end users)
- [ ] example of usage (how to see this in function)

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [ ] Test A
- [ ] Test B

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
