### PR TITLE
rock5c: fix rk3582 with disabled rkvdec node

### DIFF
--- a/patch/u-boot/legacy/u-boot-radxa-rk3588/board_rock-5c/reopen_disabled_nodes.patch
+++ b/patch/u-boot/legacy/u-boot-radxa-rk3588/board_rock-5c/reopen_disabled_nodes.patch
@@ -87,6 +87,16 @@ index f7928a7f2..3c4d1e2f2 100644
 +		fdt_rm_path(blob, "/iommu@fdc48700");
 +		debug("rm: rkvdec1\n");
 +	}
++
++	/* If there is bad core, fix multi core related nodes */
++	if (BAD_RKVDEC(mask, 0) || BAD_RKVDEC(mask, 1)) {
++		do_fixup_by_path((void *)blob, "/rkvdec-ccu",
++				 "status", "disabled", sizeof("disabled"), 0);
++
++		/* rename node name if the node exist, actually only one exist  */
++		fdt_rename_path(blob, "/rkvdec-core@fdc38000", "rkvdec@fdc38000");
++		fdt_rename_path(blob, "/rkvdec-core@fdc48000", "rkvdec@fdc48000");
++	}
  }
  
  static void rk3582_fdt_rm_rkvenc01(void *blob, u8 mask)


### PR DESCRIPTION
# Description

Today many users get their rock5c/lite. And they find some rk3582 socs has disabled rkvdec nodes. The board I have has good rkvdec nodes, but when there is at least one rkvdec node disabled, node `rkvdec-ccu` should get disabled. Otherwise this will cause board not booting.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh BOARD=rock-5c BRANCH=vendor BUILD_DESKTOP=no BUILD_MINIMAL=yes DEB_COMPRESS=xz KERNEL_CONFIGURE=no RELEASE=bookworm KERNEL_GIT=shallow`
- [x] `Tested on board with broken rkvdec nodes.`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
