### PR TITLE
main-config.sh: workaround: set the default ARCH to arm64 (replacing armhf)

### DIFF
--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -240,7 +240,7 @@ function do_main_configuration() {
 
 	# Let's set default data if not defined in board configuration above
 	[[ -z $OFFSET ]] && OFFSET=4 # offset to 1st partition (we use 4MiB boundaries by default)
-	[[ -z $ARCH ]] && ARCH=armhf # makes little sense to default to anything... # @TODO: remove
+	[[ -z $ARCH ]] && ARCH=arm64 # makes little sense to default to anything... # @TODO: remove, but check_config_userspace_release_and_desktop requires it
 	ATF_COMPILE=yes              # @TODO: move to armhf/arm64
 	[[ -z $WIREGUARD ]] && WIREGUARD="yes"
 	[[ -z $EXTRAWIFI ]] && EXTRAWIFI="yes"


### PR DESCRIPTION
#### main-config.sh: workaround: set the default ARCH to arm64 (replacing armhf)

- main-config.sh: workaround: set the default ARCH to arm64 (replacing armhf)
  - armhf was disabled for some releases and now we get spurious failures building certain artifacts (firmware)
  Signed-off-by: Ricardo Pardini <ricardo@pardini.net>