### PR TITLE
Call `losetup -f` to make sure loop device exists

### DIFF
--- a/lib/functions/cli/cli-build.sh
+++ b/lib/functions/cli/cli-build.sh
@@ -10,6 +10,8 @@
 function cli_standard_build_pre_run() {
 	declare -g ARMBIAN_COMMAND_REQUIRE_BASIC_DEPS="yes" # Require prepare_host_basic to run before the command.
 
+	ensure_loop_exists
+
 	# "gimme root on a Linux machine"
 	cli_standard_relaunch_docker_or_sudo
 }

--- a/lib/functions/cli/cli-docker.sh
+++ b/lib/functions/cli/cli-docker.sh
@@ -40,6 +40,8 @@ function cli_docker_run() {
 		set_git_build_repo_url_and_commit_vars "docker launcher"
 	fi
 
+	ensure_loop_exists
+
 	LOG_SECTION="docker_cli_prepare" do_with_logging docker_cli_prepare
 
 	# @TODO: and can be very well said that in CI, we always want FAST_DOCKER=yes, unless we're building the Docker image itself.

--- a/lib/functions/host/host-utils.sh
+++ b/lib/functions/host/host-utils.sh
@@ -96,6 +96,10 @@ function is_root_or_sudo_prefix() {
 		# sudo binary found in path, use it.
 		display_alert "EUID is not 0" "sudo binary found, using it" "debug"
 		__my_sudo_prefix="sudo"
+	elif [[ -n "$(command -v doas)" ]]; then
+		# doas binary found in path, use it.
+		display_alert "EUID is not 0" "doas binary found, using it" "debug"
+		__my_sudo_prefix="sudo"
 	else
 		# No root and no sudo binary. Bail out
 		exit_with_error "EUID is not 0 and no sudo binary found - Please install sudo or run as root"

--- a/lib/functions/host/host-utils.sh
+++ b/lib/functions/host/host-utils.sh
@@ -99,7 +99,7 @@ function is_root_or_sudo_prefix() {
 	elif [[ -n "$(command -v doas)" ]]; then
 		# doas binary found in path, use it.
 		display_alert "EUID is not 0" "doas binary found, using it" "debug"
-		__my_sudo_prefix="sudo"
+		__my_sudo_prefix="doas"
 	else
 		# No root and no sudo binary. Bail out
 		exit_with_error "EUID is not 0 and no sudo binary found - Please install sudo or run as root"

--- a/lib/functions/image/loop.sh
+++ b/lib/functions/image/loop.sh
@@ -115,3 +115,9 @@ function free_loop_device_retried() {
 	fi
 	losetup -d "${1}"
 }
+
+# Runs losetup -f as root to ensure that there is a /dev/loopX or /dev/loopXY device existing and available
+function ensure_loop_exists() {
+	local sudo_prefix="" && is_root_or_sudo_prefix sudo_prefix
+	${sudo_prefix} losetup -f
+}


### PR DESCRIPTION
# Description

1. Added a call to `losetup -f` which would make sure that there is a loop device that exists and available for use. See #6568 
2. Added doas support to `is_root_or_sudo_prefix` function. I will understand if this change would be asked to be removed, added just because I use doas.

[Jira](https://armbian.atlassian.net/jira) reference number [AR-2132]

# How Has This Been Tested?

Building using the command `./compile.sh BOARD=orangepi5 BRANCH=legacy BUILD_DESKTOP=no BUILD_MINIMAL=no KERNEL_CONFIGURE=no KERNEL_GIT=shallow RELEASE=bookworm` on my machine.

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


[AR-2132]: https://armbian.atlassian.net/browse/AR-2132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ