### PR TITLE
Fix distro-specific.sh to treat sid and unstable as the same distribution

### DIFF
--- a/config/bootenv/rockchip64.txt
+++ b/config/bootenv/rockchip64.txt
@@ -1,2 +1,3 @@
 verbosity=1
 bootlogo=false
+console=both

--- a/lib/functions/rootfs/distro-specific.sh
+++ b/lib/functions/rootfs/distro-specific.sh
@@ -147,13 +147,11 @@ function create_sources_list_and_deploy_repo_key() {
 			EOF
 			;;
 
-		sid) # sid is permanent unstable development and has no such thing as updates or security
+		sid|unstable) # sid is permanent unstable development and has no such thing as updates or security
 			cat <<- EOF > "${basedir}"/etc/apt/sources.list
 				deb http://${DEBIAN_MIRROR} $release main contrib non-free non-free-firmware
 				#deb-src http://${DEBIAN_MIRROR} $release main contrib non-free non-free-firmware
 
-				deb http://${DEBIAN_MIRROR} unstable main contrib non-free non-free-firmware
-				#deb-src http://${DEBIAN_MIRROR} unstable main contrib non-free non-free-firmware
 			EOF
 
 			# Exception: with riscv64 not everything was moved from ports


### PR DESCRIPTION
# Description

sid and unstable are synonyms of the same repository
Credits: going --> https://forum.armbian.com/topic/37503-kali-linux-as-supported-distro/

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
