### PR TITLE
Use oibaf and v4l2 in desktops only

### DIFF
--- a/extensions/mesa-oibaf.sh
+++ b/extensions/mesa-oibaf.sh
@@ -15,25 +15,30 @@ function extension_prepare_config__oibaf() {
 		return 0
 	fi
 
+	[[ "${BUILD_DESKTOP}" != "yes" ]] && return 0
+
 	# Add to the image suffix.
 	EXTRA_IMAGE_SUFFIXES+=("-oibaf") # global array
 }
 
 function post_install_kernel_debs__oibaf() {
+
 	if [[ "${DISTRIBUTION}" != "Ubuntu" ]]; then
 		display_alert "oibaf" "${EXTENSION} extension only works with Ubuntu, skipping" "debug"
 		return 0
 	fi
 
+	[[ "${BUILD_DESKTOP}" != "yes" ]] && return 0
+
 	display_alert "Adding oibaf PPAs" "${EXTENSION}" "info"
 	do_with_retries 3 chroot_sdcard add-apt-repository ppa:oibaf/graphics-drivers --yes --no-update
 
 	display_alert "Pinning oibaf PPAs" "${EXTENSION}" "info"
-	cat > "${SDCARD}"/etc/apt/preferences.d/mesa-oibaf-graphics-drivers-pin <<EOF
-Package: *
-Pin: release o=LP-PPA-oibaf-graphics-drivers
-Pin-Priority: 1001
-EOF
+	cat <<- EOF > "${SDCARD}"/etc/apt/preferences.d/mesa-oibaf-graphics-drivers-pin
+	Package: *
+	Pin: release o=LP-PPA-oibaf-graphics-drivers
+	Pin-Priority: 1001
+	EOF
 
 	display_alert "Updating sources list, after oibaf PPAs" "${EXTENSION}" "info"
 	do_with_retries 3 chroot_sdcard_apt_get_update

--- a/extensions/v4l2loopback-dkms.sh
+++ b/extensions/v4l2loopback-dkms.sh
@@ -3,12 +3,14 @@ function extension_finish_config__build_v4l2loopback_dkms_kernel_module() {
 		display_alert "Kernel version has no working headers package" "skipping v4l2loopback-dkms for kernel v${KERNEL_MAJOR_MINOR}" "warn"
 		return 0
 	fi
+	[[ "${BUILD_DESKTOP}" != "yes" ]] && return 0
 	declare -g INSTALL_HEADERS="yes"
 	display_alert "Forcing INSTALL_HEADERS=yes; for use with v4l2loopback-dkms" "${EXTENSION}" "debug"
 }
 
 function post_install_kernel_debs__build_v4l2loopback_dkms_kernel_module() {
 	[[ "${INSTALL_HEADERS}" != "yes" ]] || [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]] && return 0
+	[[ "${BUILD_DESKTOP}" != "yes" ]] && return 0
 	display_alert "Install v4l2loopback-dkms packages, will build kernel module in chroot" "${EXTENSION}" "info"
 	declare -g if_error_detail_message="v4l2loopback-dkms build failed, extension 'v4l2loopback-dkms'"
 	declare -ag if_error_find_files_sdcard=("/var/lib/dkms/v4l2loopback*/*/build/*.log")


### PR DESCRIPTION
# Description

We don't want to install desktop ready extensions on CLI images.

# How Has This Been Tested?

Manual run.

# Checklist:

- [x] My changes generate no new warnings