### PR TITLE
VIM1S/VIM4: initialize video firmware symlink

### DIFF
--- a/config/boards/khadas-vim1s.conf
+++ b/config/boards/khadas-vim1s.conf
@@ -20,3 +20,11 @@ function post_family_tweaks_bsp__populate_etc_firmware() {
 	run_host_command_logged mkdir -p "${destination}"/etc/firmware/brcm
 	run_host_command_logged ln -sf /lib/firmware/brcm/BCM4345C5.hcd "${destination}"/etc/firmware/brcm/BCM4345C5.hcd
 }
+
+function vim1s_bsp_legacy_postinst_link_video_firmware() {
+        ln -sf video_ucode.bin.s4 /lib/firmware/video/video_ucode.bin
+}
+
+function post_family_tweaks_bsp__vim1s_link_video_firmware_on_install() {
+        postinst_functions+=(vim1s_bsp_legacy_postinst_link_video_firmware)
+}

--- a/config/boards/khadas-vim4.conf
+++ b/config/boards/khadas-vim4.conf
@@ -28,3 +28,11 @@ function post_family_tweaks_bsp__use_correct_bluetooth_firmware() {
 	run_host_command_logged mkdir -p "${destination}"/etc/firmware/brcm
 	run_host_command_logged ln -sf /lib/firmware/brcm/BCM4362A2-khadas-vim4.hcd "${destination}"/etc/firmware/brcm/BCM4362A2.hcd
 }
+
+function vim4_bsp_legacy_postinst_link_video_firmware() {
+	ln -sf video_ucode.bin.t7 /lib/firmware/video/video_ucode.bin
+}
+
+function post_family_tweaks_bsp__vim4_link_video_firmware_on_install() {
+	postinst_functions+=(vim4_bsp_legacy_postinst_link_video_firmware)
+}


### PR DESCRIPTION
# Description

Set correct video firmware based on the device being used. Fixes - https://forum.khadas.com/t/ffmpeg-and-hardware-h264-decode/19033/24

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [X] Checked that the preload service starts correctly on vim4 and video_code.bin file points to correct firmware file.

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
