### PR TITLE
RK3588: add generic pwm overlays from vendor kernel

### DIFF
--- a/patch/kernel/rockchip-rk3588-edge/overlay/Makefile
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/Makefile
@@ -1,7 +1,37 @@
 # SPDX-License-Identifier: GPL-2.0
 dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	rockchip-rk3588-sata1.dtbo \
-	rockchip-rk3588-sata2.dtbo
+	rockchip-rk3588-sata2.dtbo \
+	rockchip-rk3588-pwm0-m0.dtbo \
+	rockchip-rk3588-pwm0-m1.dtbo \
+	rockchip-rk3588-pwm0-m2.dtbo \
+	rockchip-rk3588-pwm1-m0.dtbo \
+	rockchip-rk3588-pwm1-m1.dtbo \
+	rockchip-rk3588-pwm1-m2.dtbo \
+	rockchip-rk3588-pwm2-m1.dtbo \
+	rockchip-rk3588-pwm3-m0.dtbo \
+	rockchip-rk3588-pwm3-m1.dtbo \
+	rockchip-rk3588-pwm3-m2.dtbo \
+	rockchip-rk3588-pwm3-m3.dtbo \
+	rockchip-rk3588-pwm5-m2.dtbo \
+	rockchip-rk3588-pwm6-m0.dtbo \
+	rockchip-rk3588-pwm6-m2.dtbo \
+	rockchip-rk3588-pwm7-m0.dtbo \
+	rockchip-rk3588-pwm7-m3.dtbo \
+	rockchip-rk3588-pwm8-m0.dtbo \
+	rockchip-rk3588-pwm10-m0.dtbo \
+	rockchip-rk3588-pwm11-m0.dtbo \
+	rockchip-rk3588-pwm11-m1.dtbo \
+	rockchip-rk3588-pwm12-m0.dtbo \
+	rockchip-rk3588-pwm13-m0.dtbo \
+	rockchip-rk3588-pwm13-m2.dtbo \
+	rockchip-rk3588-pwm14-m0.dtbo \
+	rockchip-rk3588-pwm14-m1.dtbo \
+	rockchip-rk3588-pwm14-m2.dtbo \
+	rockchip-rk3588-pwm15-m0.dtbo \
+	rockchip-rk3588-pwm15-m1.dtbo \
+	rockchip-rk3588-pwm15-m2.dtbo \
+	rockchip-rk3588-pwm15-m3.dtbo
 
 targets += $(dtbo-y)
 

--- a/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm0-m0.dts
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm0-m0.dts
@@ -1,0 +1,14 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&pwm0>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-names = "active";
+			pinctrl-0 = <&pwm0m0_pins>;
+		};
+	};
+};

--- a/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm0-m1.dts
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm0-m1.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&pwm0>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&pwm0m1_pins>;
+		};
+	};
+};

--- a/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm0-m2.dts
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm0-m2.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&pwm0>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&pwm0m2_pins>;
+		};
+	};
+};

--- a/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm1-m0.dts
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm1-m0.dts
@@ -1,0 +1,14 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&pwm1>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-names = "active";
+			pinctrl-0 = <&pwm1m0_pins>;
+		};
+	};
+};

--- a/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm1-m1.dts
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm1-m1.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&pwm1>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&pwm1m1_pins>;
+		};
+	};
+};

--- a/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm1-m2.dts
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm1-m2.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&pwm1>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&pwm1m2_pins>;
+		};
+	};
+};

--- a/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm10-m0.dts
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm10-m0.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&pwm10>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&pwm10m0_pins>;
+		};
+	};
+};

--- a/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm11-m0.dts
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm11-m0.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&pwm11>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&pwm11m0_pins>;
+		};
+	};
+};

--- a/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm11-m1.dts
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm11-m1.dts
@@ -1,0 +1,21 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable PWM11-M1";
+		compatible = "radxa,rock-5a";
+		category = "misc";
+		exclusive = "GPIO4_B4";
+		description = "Enable PWM11-M1.\nOn Radxa ROCK 5A this is pin 15.";
+	};
+
+	fragment@0 {
+		target = <&pwm11>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&pwm11m1_pins>;
+		};
+	};
+};

--- a/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm12-m0.dts
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm12-m0.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&pwm12>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&pwm12m0_pins>;
+		};
+	};
+};

--- a/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm13-m0.dts
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm13-m0.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&pwm13>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&pwm13m0_pins>;
+		};
+	};
+};

--- a/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm13-m2.dts
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm13-m2.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&pwm13>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&pwm13m2_pins>;
+		};
+	};
+};

--- a/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm14-m0.dts
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm14-m0.dts
@@ -1,0 +1,14 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&pwm14>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-names = "active";
+			pinctrl-0 = <&pwm14m0_pins>;
+		};
+	};
+};

--- a/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm14-m1.dts
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm14-m1.dts
@@ -1,0 +1,14 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&pwm14>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-names = "active";
+			pinctrl-0 = <&pwm14m1_pins>;
+		};
+	};
+};

--- a/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm14-m2.dts
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm14-m2.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&pwm14>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&pwm14m2_pins>;
+		};
+	};
+};

--- a/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm15-m0.dts
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm15-m0.dts
@@ -1,0 +1,21 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable PWM15-M0";
+		compatible = "radxa,rock-5b";
+		category = "misc";
+		exclusive = "GPIO3_C3";
+		description = "Enable PWM15-M0.\nOn Radxa ROCK 5B this is pin 7.";
+	};
+
+	fragment@0 {
+		target = <&pwm15>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&pwm15m0_pins>;
+		};
+	};
+};

--- a/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm15-m1.dts
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm15-m1.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&pwm15>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&pwm15m1_pins>;
+		};
+	};
+};

--- a/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm15-m2.dts
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm15-m2.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&pwm15>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&pwm15m2_pins>;
+		};
+	};
+};

--- a/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm15-m3.dts
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm15-m3.dts
@@ -1,0 +1,21 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable PWM15-M3";
+		compatible = "radxa,rock-5a", "radxa,rock-5b";
+		category = "misc";
+		exclusive = "GPIO1_D7";
+		description = "Enable PWM15-M3.\nOn Radxa ROCK 5A this is pin 3.\nOn Radxa ROCK 5B this is pin 29.";
+	};
+
+	fragment@0 {
+		target = <&pwm15>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&pwm15m3_pins>;
+		};
+	};
+};

--- a/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm2-m1.dts
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm2-m1.dts
@@ -1,0 +1,21 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable PWM2-M1";
+		compatible = "radxa,rock-5b";
+		category = "misc";
+		exclusive = "GPIO3_B1";
+		description = "Enable PWM2-M1.\nOn Radxa ROCK 5B this is pin 36.";
+	};
+
+	fragment@0 {
+		target = <&pwm2>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&pwm2m1_pins>;
+		};
+	};
+};

--- a/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm3-m0.dts
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm3-m0.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&pwm3>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&pwm3m0_pins>;
+		};
+	};
+};

--- a/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm3-m1.dts
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm3-m1.dts
@@ -1,0 +1,21 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable PWM3-M1";
+		compatible = "radxa,rock-5b";
+		category = "misc";
+		exclusive = "GPIO3_B2";
+		description = "Enable PWM3-M1.\nOn Radxa ROCK 5B this is pin 38.";
+	};
+
+	fragment@0 {
+		target = <&pwm3>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&pwm3m1_pins>;
+		};
+	};
+};

--- a/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm3-m2.dts
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm3-m2.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&pwm3>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&pwm3m2_pins>;
+		};
+	};
+};

--- a/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm3-m3.dts
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm3-m3.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&pwm3>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&pwm3m3_pins>;
+		};
+	};
+};

--- a/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm5-m2.dts
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm5-m2.dts
@@ -1,0 +1,21 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable PWM5-M2";
+		compatible = "radxa,rock-5b";
+		category = "misc";
+		exclusive = "GPIO4_C4";
+		description = "Enable PWM5-M2.\nOn Radxa ROCK 5B this is pin 18.";
+	};
+
+	fragment@0 {
+		target = <&pwm5>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&pwm5m2_pins>;
+		};
+	};
+};

--- a/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm6-m0.dts
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm6-m0.dts
@@ -1,0 +1,21 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable PWM6-M0";
+		compatible = "radxa,rock-5a";
+		category = "misc";
+		exclusive = "GPIO0_C7";
+		description = "Enable PWM6-M0.\nOn Radxa ROCK 5A this is pin 27.";
+	};
+
+	fragment@0 {
+		target = <&pwm6>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&pwm6m0_pins>;
+		};
+	};
+};

--- a/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm6-m2.dts
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm6-m2.dts
@@ -1,0 +1,21 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable PWM6-M2";
+		compatible = "radxa,rock-5b";
+		category = "misc";
+		exclusive = "GPIO4_C5";
+		description = "Enable PWM6-M2.\nOn Radxa ROCK 5B this is pin 28.";
+	};
+
+	fragment@0 {
+		target = <&pwm6>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&pwm6m2_pins>;
+		};
+	};
+};

--- a/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm7-m0.dts
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm7-m0.dts
@@ -1,0 +1,21 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable PWM7-M0";
+		compatible = "radxa,rock-5a";
+		category = "misc";
+		exclusive = "GPIO0_D0";
+		description = "Enable PWM7-M0.\nOn Radxa ROCK 5A this is pin 28.";
+	};
+
+	fragment@0 {
+		target = <&pwm7>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&pwm7m0_pins>;
+		};
+	};
+};

--- a/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm7-m3.dts
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm7-m3.dts
@@ -1,0 +1,21 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable PWM7-M3";
+		compatible = "radxa,rock-5b";
+		category = "misc";
+		exclusive = "GPIO4_C6";
+		description = "Enable PWM7-M3.\nOn Radxa ROCK 5B this is pin 27.";
+	};
+
+	fragment@0 {
+		target = <&pwm7>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&pwm7m3_pins>;
+		};
+	};
+};

--- a/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm8-m0.dts
+++ b/patch/kernel/rockchip-rk3588-edge/overlay/rockchip-rk3588-pwm8-m0.dts
@@ -1,0 +1,21 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable PWM8-M0";
+		compatible = "radxa,rock-5b";
+		category = "misc";
+		exclusive = "GPIO3_A7";
+		description = "Enable PWM8-M0.\nOn Radxa ROCK 5B this is pin 33.";
+	};
+
+	fragment@0 {
+		target = <&pwm8>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&pwm8m0_pins>;
+		};
+	};
+};


### PR DESCRIPTION
# Description

Imported @efectn's RK3588 PWM overlays from BSP 6.1 to mainline 
# How Has This Been Tested?

Tested pwm8 overlay with [25W POE hat fan control](https://github.com/lanefu/fan-control-rock5b-poe)

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
