### PR TITLE
After enabling Ubuntu Oracular on nightly builds, oibaf extension fails to work

### DIFF
--- a/extensions/mesa-oibaf.sh
+++ b/extensions/mesa-oibaf.sh
@@ -40,6 +40,15 @@ function post_install_kernel_debs__oibaf() {
 	Pin-Priority: 1001
 	EOF
 
+	# Ubuntu oracular workaround
+	local url_to_check='https://ppa.launchpadcontent.net/oibaf/graphics-drivers/ubuntu/dists/${RELEASE}/Release'
+	if curl -o/dev/null -sfIL "$url_to_check" 2>&1; then
+		:
+	else
+		display_alert "Converting to generic sources list due to missing release file" "${EXTENSION}" "info"
+		sed -i "s/${RELEASE}/noble/g" "${SDCARD}"/etc/apt/sources.list.d/oibaf-ubuntu-graphics-drivers-"${RELEASE}".sources
+	fi
+
 	display_alert "Updating sources list, after oibaf PPAs" "${EXTENSION}" "info"
 	do_with_retries 3 chroot_sdcard_apt_get_update
 


### PR DESCRIPTION
# Description

I think we just need to use "devel" key for unknown Ubuntu release.

# How Has This Been Tested?

./compile.sh build BOARD=uefi-x86 BRANCH=current BUILD_DESKTOP=yes BUILD_MINIMAL=no DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=xfce DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base ENABLE_EXTENSIONS=mesa-oibaf EXPERT=yes KERNEL_CONFIGURE=no RELEASE=oracular SHARE_LOG=yes

# Checklist:

- [x] My changes generate no new warnings