### PR TITLE
extensions: add rk-panthor for vendor 6.1 rk3588 kernel

### DIFF
--- a/extensions/rk-panthor.sh
+++ b/extensions/rk-panthor.sh
@@ -1,0 +1,1 @@
+declare -g DEFAULT_OVERLAYS=panthor-gpu


### PR DESCRIPTION
# Description

Since we have deleted `vendor-boogie-panthor` branch from `rockchip-rk3588`,  but we still need a method to build 6.1 vendor kernel images with panthor driver working out of box.
This extension only enables overlay `panthor-gpu`. And extension `mesa-oibaf` has to get enabled for userspace driver. Mesa v24.1 may get packaged in future releases of distros so I don't add `mesa-oibaf` together.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh BOARD=rock-5b BRANCH=vendor BUILD_DESKTOP=yes BUILD_MINIMAL=no  DEB_COMPRESS=xz DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base KERNEL_CONFIGURE=no KERNEL_GIT=shallow RELEASE=noble ENABLE_EXTENSIONS="rk-panthor mesa-oibaf"`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
