### PR TITLE
rockchip-rk3588-edge: add Hantro G1 VDPU and RGA2

### DIFF
--- a/patch/kernel/rockchip-rk3588-edge/0147-arm64-dts-rockchip-rk3588-add-VDPU-and-RGA2-nodes.patch
+++ b/patch/kernel/rockchip-rk3588-edge/0147-arm64-dts-rockchip-rk3588-add-VDPU-and-RGA2-nodes.patch
@@ -1,0 +1,55 @@
+From 54b308f31f637004f3e0f3e13a3d08e1c62c8ae3 Mon Sep 17 00:00:00 2001
+From: Muhammed Efe Cetin <efectn@protonmail.com>
+Date: Mon, 13 May 2024 20:29:49 +0300
+Subject: [PATCH] arm64: dts: rockchip: rk3588: add VDPU and RGA2 nodes
+
+---
+ arch/arm64/boot/dts/rockchip/rk3588s.dtsi | 32 +++++++++++++++++++++++
+ 1 file changed, 32 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s.dtsi b/arch/arm64/boot/dts/rockchip/rk3588s.dtsi
+index 387cfc7ee261..1ca59486b61c 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588s.dtsi
+@@ -848,6 +848,38 @@ gpu: gpu@fb000000 {
+ 		status = "disabled";
+ 	};
+ 
++	vpu: video-codec@fdb50400 {
++		compatible = "rockchip,rk3568-vpu";
++		reg = <0x0 0xfdb50400 0x0 0x400>;
++		interrupts = <GIC_SPI 119 IRQ_TYPE_LEVEL_HIGH 0>;
++		interrupt-names = "vdpu";
++		clocks = <&cru ACLK_VPU>, <&cru HCLK_VPU>;
++		clock-names = "aclk", "hclk";
++		iommus = <&vdpu_mmu>;
++		power-domains = <&power RK3588_PD_VDPU>;
++	};
++
++	vdpu_mmu: iommu@fdb50800 {
++		compatible = "rockchip,rk3568-iommu";
++		reg = <0x0 0xfdb50800 0x0 0x40>;
++		interrupts = <GIC_SPI 118 IRQ_TYPE_LEVEL_HIGH 0>;
++		clock-names = "aclk", "iface";
++		clocks = <&cru ACLK_VPU>, <&cru HCLK_VPU>;
++		power-domains = <&power RK3588_PD_VDPU>;
++		#iommu-cells = <0>;
++	};
++
++	rga: rga@fdb80000 {
++		compatible = "rockchip,rk3568-rga", "rockchip,rk3288-rga";
++		reg = <0x0 0xfdb80000 0x0 0x1000>;
++		interrupts = <GIC_SPI 116 IRQ_TYPE_LEVEL_HIGH 0>;
++		clocks = <&cru ACLK_RGA2>, <&cru HCLK_RGA2>, <&cru CLK_RGA2_CORE>;
++		clock-names = "aclk", "hclk", "sclk";
++		resets = <&cru SRST_RGA2_CORE>, <&cru SRST_A_RGA2>, <&cru SRST_H_RGA2>;
++		reset-names = "core", "axi", "ahb";
++		power-domains = <&power RK3588_PD_VDPU>;
++	};
++
+ 	pmu1grf: syscon@fd58a000 {
+ 		compatible = "rockchip,rk3588-pmugrf", "syscon", "simple-mfd";
+ 		reg = <0x0 0xfd58a000 0x0 0x10000>;
+-- 
+2.44.0
+


### PR DESCRIPTION
# Description

Add H264/VP8/MPEG2 decoder and RGA2 nodes to RK3588 edge kernel.

cc @amazingfate 

# How Has This Been Tested?
- [x] Built and probed v4l2 device

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
