### PR TITLE
cm3588-nas: switch edge uboot to kwiboo mainline

### DIFF
--- a/config/boards/nanopc-cm3588-nas.csc
+++ b/config/boards/nanopc-cm3588-nas.csc
@@ -39,7 +39,7 @@ function post_family_tweaks__nanopccm3588nas_udev_naming_network_interfaces() {
 }
 
 # Mainline u-boot or Kwiboo's tree
-function post_family_config_branch_edge__rock-5b_use_mainline_uboot() {
+function post_family_config_branch_edge__nanopccm3588nas_use_mainline_uboot() {
 	display_alert "$BOARD" "mainline (next branch) u-boot overrides for $BOARD / $BRANCH" "info"
 
 	unset BOOTFS_TYPE                                                     # mainline can boot from ext4 no problem


### PR DESCRIPTION
# Description

Boots cleanly from sdcard even when OEM uboot is installed on EMMC

(was having optee errors using radxa uboot when OEM was on EMMC)

```
-Boot 2024.04-armbian (May 13 2024 - 20:34:52 +0000)

Model: FriendlyElec NanoPC-T6
DRAM:  16 GiB
Core:  338 devices, 30 uclasses, devicetree: separate
MMC:   mmc@fe2c0000: 1, mmc@fe2e0000: 0
Loading Environment from nowhere... OK
In:    serial@feb50000
Out:   serial@feb50000
Err:   serial@feb50000
Model: FriendlyElec NanoPC-T6
rockchip_dnl_key_pressed: no saradc device found
Net:   No ethernet found.
Hit any key to stop autoboot:  0
Scanning for bootflows in all bootdevs
```