### PR TITLE
rk-multimedia-amazingfate: add noble support

### DIFF
--- a/extensions/rk-multimedia-amazingfate.sh
+++ b/extensions/rk-multimedia-amazingfate.sh
@@ -5,7 +5,7 @@
 #
 
 # This add's amazingfate's PPAs to the the image, and installs all needed packages.
-# It only works on LINUXFAMILY="rk3588-legacy" and RELEASE=jammy and BRANCH=legacy/vendor
+# It only works on LINUXFAMILY="rk3588-legacy" and RELEASE=jammy/noble and BRANCH=legacy/vendor
 # if on a desktop, installs more useful packages, and tries to coerce lightdm to use gtk-greeter and a Wayland session.
 function extension_prepare_config__amazingfate_rk35xx_multimedia() {
 	display_alert "Preparing amazingfate's PPAs for rk35xx multimedia" "${EXTENSION}" "info"
@@ -13,8 +13,8 @@ function extension_prepare_config__amazingfate_rk35xx_multimedia() {
 
 	[[ "${BUILDING_IMAGE}" != "yes" ]] && return 0
 
-	if [[ "${RELEASE}" != "jammy" ]]; then
-		display_alert "skipping..." "${EXTENSION} not for ${RELEASE}, only jammy, skipping" "warn"
+	if [[ "${RELEASE}" != "jammy" ]] && [[ "${RELEASE}" != "noble" ]]; then
+		display_alert "skipping..." "${EXTENSION} not for ${RELEASE}, only jammy/noble, skipping" "warn"
 		return 0
 	fi
 
@@ -28,8 +28,8 @@ function extension_prepare_config__amazingfate_rk35xx_multimedia() {
 }
 
 function post_install_kernel_debs__amazingfated_rk35xx_multimedia() {
-	if [[ "${RELEASE}" != "jammy" ]]; then
-		display_alert "skipping..." "${EXTENSION} not for ${RELEASE}, only jammy, skipping" "info"
+	if [[ "${RELEASE}" != "jammy" ]] && [[ "${RELEASE}" != "noble" ]]; then
+		display_alert "skipping..." "${EXTENSION} not for ${RELEASE}, only jammy/noble, skipping" "info"
 		return 0
 	fi
 
@@ -42,7 +42,12 @@ function post_install_kernel_debs__amazingfated_rk35xx_multimedia() {
 
 	declare -a pkgs=(rockchip-multimedia-config)
 	if [[ "${BUILD_DESKTOP}" == "yes" ]]; then
-		pkgs+=(chromium-browser libwidevinecdm)
+		pkgs+=(chromium-browser)
+		if [[ "${RELEASE}" == "jammy" ]]; then
+			pkgs+=(libwidevinecdm)
+		else
+			pkgs+=(libwidevinecdm0)
+		fi
 		pkgs+=("libv4l-rkmpp" "gstreamer1.0-rockchip") # @TODO: remove when added as dependencies to chromium...?
 	fi
 


### PR DESCRIPTION
# Description
Ubuntu noble is released and I just updated rk multimedia packages for it: https://launchpad.net/~liujianfeng1994/+archive/ubuntu/rockchip-multimedia/+packages?field.name_filter=&field.status_filter=published&field.series_filter=noble

widevine package  is renamed to `libwidevinecdm0` because I borrow it from raspberypi: https://archive.raspberrypi.org/debian/pool/main/w/widevine/. It does not work at the moment but I don't want to get back to jammy's one which has to patch glibc.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh BOARD=rock-5b BRANCH=vendor BUILD_DESKTOP=yes BUILD_MINIMAL=no  DEB_COMPRESS=xz DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base KERNEL_CONFIGURE=no KERNEL_GIT=shallow RELEASE=noble ENABLE_EXTENSIONS="rk-panthor mesa-oibaf rk-multimedia-amazingfate"`
- [x] chromium-browser v114 should have mpp support with arg `--ozone-platform=wayland --use-gl=egl`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
