### PR TITLE
Rockchip64: adjust patch as it doesn't align anymore

### DIFF
--- a/patch/kernel/archive/rockchip64-6.6/board-pbp-add-dp-alt-mode.patch
+++ b/patch/kernel/archive/rockchip64-6.6/board-pbp-add-dp-alt-mode.patch
@@ -274,14 +274,16 @@ index d962f67c95ae..5ac809870867 100644
  				tcpm_register_partner_altmodes(port);
  			}
  			break;
-@@ -3650,6 +3692,7 @@ static int tcpm_src_attach(struct tcpm_port *port)
+@@ -3650,8 +3692,9 @@ static int tcpm_src_attach(struct tcpm_port *port)
  static void tcpm_typec_disconnect(struct tcpm_port *port)
  {
  	if (port->connected) {
-+		tcpm_update_extcon_data(port, false);
- 		typec_partner_set_usb_power_delivery(port->partner, NULL);
- 		typec_unregister_partner(port->partner);
- 		port->partner = NULL;
+ 		if (port->partner) {
++			tcpm_update_extcon_data(port, false);
+ 			typec_partner_set_usb_power_delivery(port->partner, NULL);
+ 			typec_unregister_partner(port->partner);
+ 			port->partner = NULL;
+ 		}
 @@ -3739,6 +3782,8 @@ static void tcpm_detach(struct tcpm_port *port)
  	}
  

--- a/patch/kernel/archive/rockchip64-6.8/board-pbp-add-dp-alt-mode.patch
+++ b/patch/kernel/archive/rockchip64-6.8/board-pbp-add-dp-alt-mode.patch
@@ -274,14 +274,16 @@ index d962f67c95ae..5ac809870867 100644
  				tcpm_register_partner_altmodes(port);
  			}
  			break;
-@@ -3650,6 +3692,7 @@ static int tcpm_src_attach(struct tcpm_port *port)
+@@ -3650,8 +3692,9 @@ static int tcpm_src_attach(struct tcpm_port *port)
  static void tcpm_typec_disconnect(struct tcpm_port *port)
  {
  	if (port->connected) {
-+		tcpm_update_extcon_data(port, false);
- 		typec_partner_set_usb_power_delivery(port->partner, NULL);
- 		typec_unregister_partner(port->partner);
- 		port->partner = NULL;
+ 		if (port->partner) {
++			tcpm_update_extcon_data(port, false);
+ 			typec_partner_set_usb_power_delivery(port->partner, NULL);
+ 			typec_unregister_partner(port->partner);
+ 			port->partner = NULL;
+ 		}
 @@ -3739,6 +3782,8 @@ static void tcpm_detach(struct tcpm_port *port)
  	}
  


### PR DESCRIPTION
# Description

Due to changes in https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/drivers/usb/typec/tcpm/tcpm.c?h=v6.6.31&id=789326cafbd1f67f424436b6bc8bdb887a364637 we need to adjust patch

# How Has This Been Tested?

- [x] Patch applies well
- [ ] Build test

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
