### PR TITLE
Add new user to render group

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -412,7 +412,7 @@ add_user() {
 			else
 				passwd -d "$RealUserName" > /dev/null 2>&1
 			fi
-			for additionalgroup in sudo netdev audio video disk tty users games dialout plugdev input bluetooth systemd-journal ssh; do
+			for additionalgroup in sudo netdev audio video disk tty users games dialout plugdev input bluetooth systemd-journal ssh render; do
 				usermod -aG "${additionalgroup}" "${RealUserName}" 2> /dev/null
 			done
 


### PR DESCRIPTION
# Description

_Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change._

[Jira](https://armbian.atlassian.net/jira) reference number [AR-9999]

# Documentation summary for feature / change

Add new user to render group, otherwise the non-root user do not have access `/dev/dri/renderD128` on RK3399. When login using non-root user to the desktop environment, the GPU acceleration does not work.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] Test A
Login to the desktop environment using non-root user, `glxinfo -B` shows the right render device.
```
name of display: :10.0
display: :10  screen: 0
direct rendering: Yes
Extended renderer info (GLX_MESA_query_renderer):
    Vendor: Panfrost (0xffffffff)
    Device: Mali-T860 (Panfrost) (0xffffffff)
    Version: 22.3.6
    Accelerated: yes
    Video memory: 3860MB
    Unified memory: yes
    Preferred profile: core (0x1)
    Max core profile version: 3.1
    Max compat profile version: 3.1
    Max GLES1 profile version: 1.1
    Max GLES[23] profile version: 3.1
OpenGL vendor string: Panfrost
OpenGL renderer string: Mali-T860 (Panfrost)
OpenGL core profile version string: 3.1 Mesa 22.3.6
OpenGL core profile shading language version string: 1.40
OpenGL core profile context flags: (none)

OpenGL version string: 3.1 Mesa 22.3.6
OpenGL shading language version string: 1.40
OpenGL context flags: (none)

OpenGL ES profile version string: OpenGL ES 3.1 Mesa 22.3.6
OpenGL ES profile shading language version string: OpenGL ES GLSL ES 3.10
```

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
