### PR TITLE
firefly-rk3399: fix patch

### DIFF
--- a/patch/kernel/archive/rockchip64-6.6/board-firefly-rk3399-dts.patch
+++ b/patch/kernel/archive/rockchip64-6.6/board-firefly-rk3399-dts.patch
@@ -1,159 +1,10 @@
 index c654b6b02f3..f73f792eb44 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts
-@@ -1,13 +1,11 @@
- // SPDX-License-Identifier: (GPL-2.0+ OR MIT)
- /*
-- * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd.
-+ * Copyright (c) 2017 T-Chip Intelligent Technology Co., Ltd
-  */
- 
- /dts-v1/;
- #include <dt-bindings/input/linux-event-codes.h>
--#include <dt-bindings/interrupt-controller/irq.h>
- #include <dt-bindings/pwm/pwm.h>
--#include <dt-bindings/usb/pd.h>
- #include "rk3399.dtsi"
- #include "rk3399-opp.dtsi"
- 
-@@ -16,9 +14,9 @@
- 	compatible = "firefly,firefly-rk3399", "rockchip,rk3399";
- 
- 	aliases {
--		mmc0 = &sdio0;
--		mmc1 = &sdmmc;
--		mmc2 = &sdhci;
-+		mmc0 = &sdmmc;
-+		mmc1 = &sdhci;
-+		mmc2 = &sdio0;
+@@ -177,6 +177,15 @@
+ 		};
  	};
  
- 	chosen {
-@@ -27,42 +25,7 @@
- 
- 	backlight: backlight {
- 		compatible = "pwm-backlight";
--		enable-gpios = <&gpio1 RK_PB5 GPIO_ACTIVE_HIGH>;
- 		pwms = <&pwm0 0 25000 0>;
--		brightness-levels = <
--			  0   1   2   3   4   5   6   7
--			  8   9  10  11  12  13  14  15
--			 16  17  18  19  20  21  22  23
--			 24  25  26  27  28  29  30  31
--			 32  33  34  35  36  37  38  39
--			 40  41  42  43  44  45  46  47
--			 48  49  50  51  52  53  54  55
--			 56  57  58  59  60  61  62  63
--			 64  65  66  67  68  69  70  71
--			 72  73  74  75  76  77  78  79
--			 80  81  82  83  84  85  86  87
--			 88  89  90  91  92  93  94  95
--			 96  97  98  99 100 101 102 103
--			104 105 106 107 108 109 110 111
--			112 113 114 115 116 117 118 119
--			120 121 122 123 124 125 126 127
--			128 129 130 131 132 133 134 135
--			136 137 138 139 140 141 142 143
--			144 145 146 147 148 149 150 151
--			152 153 154 155 156 157 158 159
--			160 161 162 163 164 165 166 167
--			168 169 170 171 172 173 174 175
--			176 177 178 179 180 181 182 183
--			184 185 186 187 188 189 190 191
--			192 193 194 195 196 197 198 199
--			200 201 202 203 204 205 206 207
--			208 209 210 211 212 213 214 215
--			216 217 218 219 220 221 222 223
--			224 225 226 227 228 229 230 231
--			232 233 234 235 236 237 238 239
--			240 241 242 243 244 245 246 247
--			248 249 250 251 252 253 254 255>;
--		default-brightness-level = <200>;
- 	};
- 
- 	clkin_gmac: external-gmac-clock {
-@@ -72,13 +35,18 @@
- 		#clock-cells = <0>;
- 	};
- 
--	dc_12v: dc-12v {
--		compatible = "regulator-fixed";
--		regulator-name = "dc_12v";
--		regulator-always-on;
--		regulator-boot-on;
--		regulator-min-microvolt = <12000000>;
--		regulator-max-microvolt = <12000000>;
-+	adc-keys {
-+		compatible = "adc-keys";
-+		io-channels = <&saradc 1>;
-+		io-channel-names = "buttons";
-+		keyup-threshold-microvolt = <1500000>;
-+		poll-interval = <100>;
-+
-+		button-recovery {
-+			label = "Recovery";
-+			linux,code = <KEY_VENDOR>;
-+			press-threshold-microvolt = <18000>;
-+		};
- 	};
- 
- 	gpio-keys {
-@@ -103,47 +71,6 @@
- 		pinctrl-names = "default";
- 	};
- 
--	leds {
--		compatible = "gpio-leds";
--		pinctrl-names = "default";
--		pinctrl-0 = <&work_led_pin>, <&diy_led_pin>;
--
--		work_led: led-0 {
--			label = "work";
--			default-state = "on";
--			gpios = <&gpio2 RK_PD3 GPIO_ACTIVE_HIGH>;
--		};
--
--		diy_led: led-1 {
--			label = "diy";
--			default-state = "off";
--			gpios = <&gpio0 RK_PB5 GPIO_ACTIVE_HIGH>;
--		};
--	};
--
--	rt5640-sound {
--		compatible = "simple-audio-card";
--		simple-audio-card,name = "rockchip,rt5640-codec";
--		simple-audio-card,format = "i2s";
--		simple-audio-card,mclk-fs = <256>;
--		simple-audio-card,widgets =
--			"Microphone", "Mic Jack",
--			"Headphone", "Headphone Jack";
--		simple-audio-card,routing =
--			"Mic Jack", "MICBIAS1",
--			"IN1P", "Mic Jack",
--			"Headphone Jack", "HPOL",
--			"Headphone Jack", "HPOR";
--
--		simple-audio-card,cpu {
--			sound-dai = <&i2s1>;
--		};
--
--		simple-audio-card,codec {
--			sound-dai = <&rt5640>;
--		};
--	};
--
- 	sdio_pwrseq: sdio-pwrseq {
- 		compatible = "mmc-pwrseq-simple";
- 		clocks = <&rk808 1>;
-@@ -160,21 +87,21 @@
- 		reset-gpios = <&gpio0 RK_PB2 GPIO_ACTIVE_LOW>;
- 	};
- 
--	sound-dit {
--		compatible = "audio-graph-card";
--		label = "SPDIF";
--		dais = <&spdif_p0>;
 +	vcc_vbus_typec0: vcc-vbus-typec0 {
 +		compatible = "regulator-fixed";
 +		regulator-name = "vcc_vbus_typec0";
@@ -161,70 +12,42 @@ index c654b6b02f3..f73f792eb44 100644
 +		regulator-boot-on;
 +		regulator-min-microvolt = <5000000>;
 +		regulator-max-microvolt = <5000000>;
- 	};
- 
--	spdif-dit {
--		compatible = "linux,spdif-dit";
--		#sound-dai-cells = <0>;
--
--		port {
--			dit_p0_0: endpoint {
--				remote-endpoint = <&spdif_p0_0>;
--			};
--		};
-+	sys_12v: sys-12v {
-+		compatible = "regulator-fixed";
-+		regulator-name = "sys_12v";
-+		regulator-always-on;
-+		regulator-boot-on;
-+		vin-supply = <&dc_12v>;
- 	};
- 
++	};
++
  	/* switched by pmic_sleep */
-@@ -188,16 +115,17 @@
+ 	vcc1v8_s3: vcca1v8_s3: vcc1v8-s3 {
+ 		compatible = "regulator-fixed";
+@@ -188,15 +197,15 @@
  		vin-supply = <&vcc_1v8>;
  	};
  
 -	vcc3v3_pcie: vcc3v3-pcie-regulator {
-+	vcc3v0_sd: vcc3v0-sd {
++	vcc3v3_pcie: vcc3v3-pcie {
  		compatible = "regulator-fixed";
++		regulator-name = "vcc3v3_pcie";
  		enable-active-high;
--		gpio = <&gpio1 RK_PC1 GPIO_ACTIVE_HIGH>;
-+		gpio = <&gpio4 RK_PD6 GPIO_ACTIVE_HIGH>;
+ 		gpio = <&gpio1 RK_PC1 GPIO_ACTIVE_HIGH>;
  		pinctrl-names = "default";
 -		pinctrl-0 = <&pcie_pwr_en>;
 -		regulator-name = "vcc3v3_pcie";
 -		regulator-always-on;
-+		pinctrl-0 = <&vcc3v0_sd_en>;
-+		regulator-name = "vcc3v0_sd";
- 		regulator-boot-on;
--		vin-supply = <&dc_12v>;
-+		regulator-min-microvolt = <3000000>;
-+		regulator-max-microvolt = <3000000>;
-+		vin-supply = <&vcc3v3_sys>;
+-		regulator-boot-on;
++		pinctrl-0 = <&vcc3v3_pcie_en>;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
+ 		vin-supply = <&dc_12v>;
  	};
  
- 	vcc3v3_sys: vcc3v3-sys {
-@@ -207,7 +135,17 @@
+@@ -207,7 +216,7 @@
  		regulator-boot-on;
  		regulator-min-microvolt = <3300000>;
  		regulator-max-microvolt = <3300000>;
 -		vin-supply = <&vcc_sys>;
-+		vin-supply = <&sys_12v>;
-+	};
-+
-+	vcca_0v9: vcca-0v9 {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcca_0v9";
-+		regulator-always-on;
-+		regulator-boot-on;
-+		regulator-min-microvolt = <900000>;
-+		regulator-max-microvolt = <900000>;
-+		vin-supply = <&vcc3v3_sys>;
++		vin-supply = <&dc_12v>;
  	};
  
  	/* Actually 3 regulators (host0, 1, 2) controlled by the same gpio */
-@@ -216,42 +154,132 @@
+@@ -216,9 +225,8 @@
  		enable-active-high;
  		gpio = <&gpio1 RK_PA0 GPIO_ACTIVE_HIGH>;
  		pinctrl-names = "default";
@@ -235,20 +58,7 @@ index c654b6b02f3..f73f792eb44 100644
  		vin-supply = <&vcc_sys>;
  	};
  
--	vcc5v0_typec: vcc5v0-typec-regulator {
-+	vcc_vbus_typec1: vcc-vbus-typec1 {
- 		compatible = "regulator-fixed";
- 		enable-active-high;
--		gpio = <&gpio1 RK_PA3 GPIO_ACTIVE_HIGH>;
-+		gpio = <&gpio1 RK_PB5 GPIO_ACTIVE_HIGH>;
- 		pinctrl-names = "default";
--		pinctrl-0 = <&vcc5v0_typec_en>;
--		regulator-name = "vcc5v0_typec";
-+		pinctrl-0 = <&vcc_vbus_typec1_en>;
-+		regulator-name = "vcc_vbus_typec1";
- 		regulator-always-on;
- 		vin-supply = <&vcc_sys>;
- 	};
+@@ -235,8 +243,11 @@
  
  	vcc_sys: vcc-sys {
  		compatible = "regulator-fixed";
@@ -261,30 +71,19 @@ index c654b6b02f3..f73f792eb44 100644
  		regulator-boot-on;
  		regulator-min-microvolt = <5000000>;
  		regulator-max-microvolt = <5000000>;
--		vin-supply = <&dc_12v>;
-+		vin-supply = <&sys_12v>;
- 	};
- 
- 	vdd_log: vdd-log {
- 		compatible = "pwm-regulator";
- 		pwms = <&pwm2 0 25000 1>;
--		pwm-supply = <&vcc_sys>;
- 		regulator-name = "vdd_log";
- 		regulator-always-on;
- 		regulator-boot-on;
+@@ -253,6 +264,41 @@
  		regulator-min-microvolt = <430000>;
  		regulator-max-microvolt = <1400000>;
-+		pwm-supply = <&vcc3v3_sys>;
-+	};
+ 	};
 +
-+	/* MP8009 PoE PD */
-+	poe_12v: poe-12v {
++	vcca_0v9: vcca-0v9 {
 +		compatible = "regulator-fixed";
-+		regulator-name = "poe_12v";
++		regulator-name = "vcca_0v9";
 +		regulator-always-on;
 +		regulator-boot-on;
-+		regulator-min-microvolt = <12000000>;
-+		regulator-max-microvolt = <12000000>;
++		regulator-min-microvolt = <900000>;
++		regulator-max-microvolt = <900000>;
++		vin-supply = <&vcc3v3_sys>;
 +	};
 +
 +	vcc3v3_ngff: vcc3v3-ngff {
@@ -298,60 +97,7 @@ index c654b6b02f3..f73f792eb44 100644
 +		regulator-boot-on;
 +		regulator-min-microvolt = <3300000>;
 +		regulator-max-microvolt = <3300000>;
-+		vin-supply = <&sys_12v>;
-+	};
-+
-+	vcc3v3_pcie: vcc3v3-pcie {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc3v3_pcie";
-+		enable-active-high;
-+		gpio = <&gpio1 RK_PC1 GPIO_ACTIVE_HIGH>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&vcc3v3_pcie_en>;
-+		regulator-min-microvolt = <3300000>;
-+		regulator-max-microvolt = <3300000>;
-+		vin-supply = <&sys_12v>;
-+	};
-+
-+	leds {
-+		compatible = "gpio-leds";
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&work_led_pin>, <&diy_led_pin>;
-+
-+		work_led: led-0 {
-+			label = "work";
-+			default-state = "on";
-+			gpios = <&gpio2 RK_PD3 GPIO_ACTIVE_HIGH>;
-+		};
-+
-+		diy_led: led-1 {
-+			label = "diy";
-+			default-state = "off";
-+			gpios = <&gpio0 RK_PB5 GPIO_ACTIVE_HIGH>;
-+		};
-+	};
-+
-+	rt5640-sound {
-+		compatible = "simple-audio-card";
-+		simple-audio-card,name = "rockchip,rt5640-codec";
-+		simple-audio-card,format = "i2s";
-+		simple-audio-card,mclk-fs = <256>;
-+		simple-audio-card,widgets =
-+			"Microphone", "Mic Jack",
-+			"Headphone", "Headphone Jack";
-+		simple-audio-card,routing =
-+			"Mic Jack", "MICBIAS1",
-+			"IN1P", "Mic Jack",
-+			"Headphone Jack", "HPOL",
-+			"Headphone Jack", "HPOR";
-+
-+		simple-audio-card,cpu {
-+			sound-dai = <&i2s1>;
-+		};
-+
-+		simple-audio-card,codec {
-+			sound-dai = <&rt5640>;
-+		};
++		vin-supply = <&dc_12v>;
 +	};
 +	
 +	vcc3v3_3g: vcc3v3-3g-regulator {
@@ -363,10 +109,11 @@ index c654b6b02f3..f73f792eb44 100644
 +		regulator-name = "vcc3v3_3g";
 +		regulator-always-on;
 +		regulator-boot-on;
- 	};
++	};
  };
  
-@@ -305,12 +333,18 @@
+ &cpu_l0 {
+@@ -305,6 +351,8 @@
  };
  
  &hdmi {
@@ -375,17 +122,7 @@ index c654b6b02f3..f73f792eb44 100644
  	ddc-i2c-bus = <&i2c3>;
  	pinctrl-names = "default";
  	pinctrl-0 = <&hdmi_cec>;
- 	status = "okay";
- };
- 
-+&hdmi_sound {
-+	status = "okay";
-+};
-+
- &i2c0 {
- 	clock-frequency = <400000>;
- 	i2c-scl-rising-time-ns = <168>;
-@@ -329,18 +363,18 @@
+@@ -329,18 +377,18 @@
  		rockchip,system-power-controller;
  		wakeup-source;
  
@@ -414,7 +151,7 @@ index c654b6b02f3..f73f792eb44 100644
  
  		regulators {
  			vdd_center: DCDC_REG1 {
-@@ -388,8 +422,8 @@
+@@ -388,8 +436,8 @@
  				};
  			};
  
@@ -425,7 +162,7 @@ index c654b6b02f3..f73f792eb44 100644
  				regulator-always-on;
  				regulator-boot-on;
  				regulator-min-microvolt = <1800000>;
-@@ -399,12 +433,12 @@
+@@ -399,12 +447,12 @@
  				};
  			};
  
@@ -442,7 +179,7 @@ index c654b6b02f3..f73f792eb44 100644
  				regulator-state-mem {
  					regulator-off-in-suspend;
  				};
-@@ -457,12 +491,12 @@
+@@ -457,12 +505,12 @@
  				};
  			};
  
@@ -459,7 +196,7 @@ index c654b6b02f3..f73f792eb44 100644
  				regulator-state-mem {
  					regulator-off-in-suspend;
  				};
-@@ -503,14 +537,16 @@
+@@ -503,14 +551,16 @@
  	vdd_cpu_b: regulator@40 {
  		compatible = "silergy,syr827";
  		reg = <0x40>;
@@ -478,7 +215,7 @@ index c654b6b02f3..f73f792eb44 100644
  
  		regulator-state-mem {
  			regulator-off-in-suspend;
-@@ -521,13 +557,15 @@
+@@ -521,18 +571,31 @@
  		compatible = "silergy,syr828";
  		reg = <0x41>;
  		fcs,suspend-voltage-selector = <1>;
@@ -495,490 +232,9 @@ index c654b6b02f3..f73f792eb44 100644
  
  		regulator-state-mem {
  			regulator-off-in-suspend;
-@@ -539,17 +577,6 @@
- 	i2c-scl-rising-time-ns = <300>;
- 	i2c-scl-falling-time-ns = <15>;
- 	status = "okay";
--
--	rt5640: rt5640@1c {
--		compatible = "realtek,rt5640";
--		reg = <0x1c>;
--		clocks = <&cru SCLK_I2S_8CH_OUT>;
--		clock-names = "mclk";
--		realtek,in1-differential;
--		#sound-dai-cells = <0>;
--		pinctrl-names = "default";
--		pinctrl-0 = <&rt5640_hpcon>;
--	};
- };
- 
- &i2c3 {
-@@ -563,59 +590,51 @@
- 	i2c-scl-falling-time-ns = <20>;
- 	status = "okay";
- 
--	fusb0: typec-portc@22 {
--		compatible = "fcs,fusb302";
-+	fusb1: usb-typec@22 {
-+		compatible = "fairchild,fusb302";
-+		reg = <0x22>;
-+		interrupt-parent = <&gpio1>;
-+		interrupts = <1 IRQ_TYPE_LEVEL_LOW>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&fusb1_int>;
-+		vbus-supply = <&vcc_vbus_typec1>;
-+		status = "disabled";
-+	};
-+};
-+
-+&i2c7 {
-+	i2c-scl-rising-time-ns = <600>;
-+	i2c-scl-falling-time-ns = <20>;
-+	status = "okay";
-+
-+	fusb0: usb-typec@22 {
-+		compatible = "fairchild,fusb302";
- 		reg = <0x22>;
- 		interrupt-parent = <&gpio1>;
--		interrupts = <RK_PA2 IRQ_TYPE_LEVEL_LOW>;
-+		interrupts = <2 IRQ_TYPE_LEVEL_LOW>;
- 		pinctrl-names = "default";
- 		pinctrl-0 = <&fusb0_int>;
--		vbus-supply = <&vcc5v0_typec>;
--		status = "okay";
-+		vbus-supply = <&vcc_vbus_typec0>;
-+		status = "disabled";
-+	};
- 
--		connector {
--			compatible = "usb-c-connector";
--			data-role = "host";
--			label = "USB-C";
--			op-sink-microwatt = <1000000>;
--			power-role = "dual";
--			sink-pdos =
--				<PDO_FIXED(5000, 2500, PDO_FIXED_USB_COMM)>;
--			source-pdos =
--				<PDO_FIXED(5000, 1400, PDO_FIXED_USB_COMM)>;
--			try-power-role = "sink";
--
--			ports {
--				#address-cells = <1>;
--				#size-cells = <0>;
--
--				port@0 {
--					reg = <0>;
--
--					usbc_hs: endpoint {
--						remote-endpoint =
--							<&u2phy0_typec_hs>;
--					};
--				};
--
--				port@1 {
--					reg = <1>;
--
--					usbc_ss: endpoint {
--						remote-endpoint =
--							<&tcphy0_typec_ss>;
--					};
--				};
-+	mp8859: regulator@66 {
-+		compatible = "mps,mp8859";
-+		reg = <0x66>;
-+		dc_12v: mp8859_dcdc {
-+			regulator-name = "dc_12v";
-+			regulator-min-microvolt = <12000000>;
-+			regulator-max-microvolt = <12000000>;
-+			regulator-always-on;
-+			regulator-boot-on;
-+			vin-supply = <&vcc_vbus_typec0>;
-+
-+			regulator-state-mem {
-+				regulator-on-in-suspend;
-+				regulator-suspend-microvolt = <12000000>;
- 			};
  		};
  	};
--
--	accelerometer@68 {
--		compatible = "invensense,mpu6500";
--		reg = <0x68>;
--		interrupt-parent = <&gpio1>;
--		interrupts = <RK_PC6 IRQ_TYPE_EDGE_RISING>;
--	};
- };
- 
- &i2s0 {
-@@ -635,23 +654,10 @@
- };
- 
- &io_domains {
--	status = "okay";
--
--	bt656-supply = <&vcc1v8_dvp>;
- 	audio-supply = <&vcca1v8_codec>;
--	sdmmc-supply = <&vcc_sdio>;
-+	bt656-supply = <&vcc_3v0>;
- 	gpio1830-supply = <&vcc_3v0>;
--};
--
--&pcie_phy {
--	status = "okay";
--};
--
--&pcie0 {
--	ep-gpios = <&gpio4 RK_PD1 GPIO_ACTIVE_HIGH>;
--	num-lanes = <4>;
--	pinctrl-names = "default";
--	pinctrl-0 = <&pcie_clkreqn_cpm>;
-+	sdmmc-supply = <&vcc_sdio>;
- 	status = "okay";
- };
- 
-@@ -662,14 +668,12 @@
- 
- &pinctrl {
- 	buttons {
--		pwrbtn: pwrbtn {
-+		pwr_key_l: pwr-key-l {
- 			rockchip,pins = <0 RK_PA5 RK_FUNC_GPIO &pcfg_pull_up>;
- 		};
--	};
- 
--	fusb302x {
--		fusb0_int: fusb0-int {
--			rockchip,pins = <1 RK_PA2 RK_FUNC_GPIO &pcfg_pull_up>;
-+		pwrbtn: pwrbtn {
-+			rockchip,pins = <0 RK_PA5 RK_FUNC_GPIO &pcfg_pull_up>;
- 		};
- 	};
- 
-@@ -685,17 +689,77 @@
- 		};
- 	};
- 
--	leds {
--		work_led_pin: work-led-pin {
--			rockchip,pins = <2 RK_PD3 RK_FUNC_GPIO &pcfg_pull_none>;
-+	pmic {
-+		vsel1_pin: vsel1-pin {
-+			rockchip,pins = <1 RK_PC2 RK_FUNC_GPIO &pcfg_pull_down>;
- 		};
- 
--		diy_led_pin: diy-led-pin {
--			rockchip,pins = <0 RK_PB5 RK_FUNC_GPIO &pcfg_pull_none>;
-+		vsel2_pin: vsel2-pin {
-+			rockchip,pins = <1 RK_PB6 RK_FUNC_GPIO &pcfg_pull_down>;
-+		};
 +
-+		pmic_int_l: pmic-int-l {
-+			rockchip,pins = <1 RK_PC5 RK_FUNC_GPIO &pcfg_pull_up>;
-+		};
-+	};
-+
-+	sdio-pwrseq {
-+		wifi_enable_h: wifi-enable-h {
-+			rockchip,pins = <0 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+
-+	sdmmc {
-+		vcc3v0_sd_en: vcc3v0-sd-en {
-+			rockchip,pins = <4 RK_PD6 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+
-+	usb2 {
-+		vcc5v0_host_en: vcc5v0-host-en {
-+			rockchip,pins = <1 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+
-+		vcc_sys_en: vcc-sys-en {
-+			rockchip,pins = <2 RK_PA6 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+
-+		hub_rst: hub-rst {
-+			rockchip,pins = <2 RK_PA4 RK_FUNC_GPIO &pcfg_output_high>;
-+		};
-+	};
-+
-+	usb-typec {
-+		vcc_vbus_typec1_en: vcc-vbus-typec1-en {
-+			rockchip,pins = <1 RK_PB5 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+
-+	fusb30x {
-+		fusb0_int: fusb0-int {
-+			rockchip,pins = <1 RK_PA2 RK_FUNC_GPIO &pcfg_pull_up>;
-+		};
-+
-+		fusb1_int: fusb1-int {
-+			rockchip,pins = <1 RK_PA1 RK_FUNC_GPIO &pcfg_pull_up>;
-+		};
-+	};
-+
-+	ngff {
-+		vcc3v3_ngff_en: vcc3v3-ngff-en {
-+			rockchip,pins = <4 RK_PD3 RK_FUNC_GPIO &pcfg_pull_none>;
- 		};
- 	};
- 
- 	pcie {
-+		vcc3v3_pcie_en: vcc3v3-pcie-en {
-+			rockchip,pins = <1 RK_PC1 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+
-+		pcie_perst: pcie-perst {
-+			rockchip,pins = <4 RK_PD1 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+
- 		pcie_pwr_en: pcie-pwr-en {
- 			rockchip,pins = <1 RK_PC1 RK_FUNC_GPIO &pcfg_pull_none>;
- 		};
-@@ -705,17 +769,17 @@
- 		};
- 	};
- 
--	pmic {
--		pmic_int_l: pmic-int-l {
--			rockchip,pins = <1 RK_PC5 RK_FUNC_GPIO &pcfg_pull_up>;
-+	bt {
-+		bt_host_wake_l: bt-host-wake-l {
-+			rockchip,pins = <0 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
- 		};
- 
--		vsel1_pin: vsel1-pin {
--			rockchip,pins = <1 RK_PC2 RK_FUNC_GPIO &pcfg_pull_down>;
-+		bt_reg_on_h: bt-reg-on-h {
-+			rockchip,pins = <0 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;
- 		};
- 
--		vsel2_pin: vsel2-pin {
--			rockchip,pins = <1 RK_PB6 RK_FUNC_GPIO &pcfg_pull_down>;
-+		bt_wake_l: bt-wake-l {
-+			rockchip,pins = <2 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
- 		};
- 	};
- 
-@@ -725,27 +789,19 @@
- 		};
- 	};
- 
--	sdio-pwrseq {
--		wifi_enable_h: wifi-enable-h {
--			rockchip,pins = <0 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
--		};
--	};
--
--	usb-typec {
--		vcc5v0_typec_en: vcc5v0_typec_en {
--			rockchip,pins = <1 RK_PA3 RK_FUNC_GPIO &pcfg_pull_up>;
-+	wifi {
-+		wifi_host_wake_l: wifi-host-wake-l {
-+			rockchip,pins = <0 RK_PA3 RK_FUNC_GPIO &pcfg_pull_none>;
- 		};
- 	};
- 
--	usb2 {
--		vcc5v0_host_en: vcc5v0-host-en {
--			rockchip,pins = <1 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
-+	leds {
-+		work_led_pin: work-led-pin {
-+			rockchip,pins = <2 RK_PD3 RK_FUNC_GPIO &pcfg_pull_none>;
- 		};
--	};
- 
--	wifi {
--		wifi_host_wake_l: wifi-host-wake-l {
--			rockchip,pins = <0 RK_PA3 RK_FUNC_GPIO &pcfg_pull_none>;
-+		diy_led_pin: diy-led-pin {
-+			rockchip,pins = <0 RK_PB5 RK_FUNC_GPIO &pcfg_pull_none>;
- 		};
- 	};
- };
-@@ -763,66 +819,33 @@
- 	status = "okay";
- };
- 
--&sdio0 {
--	/* WiFi & BT combo module Ampak AP6356S */
--	bus-width = <4>;
--	cap-sdio-irq;
--	cap-sd-highspeed;
--	keep-power-in-suspend;
--	mmc-pwrseq = <&sdio_pwrseq>;
--	non-removable;
--	pinctrl-names = "default";
--	pinctrl-0 = <&sdio0_bus4 &sdio0_cmd &sdio0_clk>;
--	sd-uhs-sdr104;
--
--	/* Power supply */
--	vqmmc-supply = <&vcc1v8_s3>;	/* IO line */
--	vmmc-supply = <&vcc_sdio>;	/* card's power */
--
--	#address-cells = <1>;
--	#size-cells = <0>;
--	status = "okay";
--
--	brcmf: wifi@1 {
--		reg = <1>;
--		compatible = "brcm,bcm4329-fmac";
--		interrupt-parent = <&gpio0>;
--		interrupts = <RK_PA3 IRQ_TYPE_LEVEL_HIGH>;
--		interrupt-names = "host-wake";
--		brcm,drive-strength = <5>;
--		pinctrl-names = "default";
--		pinctrl-0 = <&wifi_host_wake_l>;
--	};
--};
--
- &sdmmc {
- 	bus-width = <4>;
--	cap-mmc-highspeed;
- 	cap-sd-highspeed;
--	cd-gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
-+	cd-gpios = <&gpio0 RK_PA7 GPIO_ACTIVE_LOW>;
- 	disable-wp;
- 	max-frequency = <150000000>;
- 	pinctrl-names = "default";
- 	pinctrl-0 = <&sdmmc_clk &sdmmc_cmd &sdmmc_bus4>;
-+	sd-uhs-sdr104;
-+	vmmc-supply = <&vcc3v0_sd>;
-+	vqmmc-supply = <&vcc_sdio>;
- 	status = "okay";
- };
- 
- &sdhci {
- 	bus-width = <8>;
--	mmc-hs400-1_8v;
--	mmc-hs400-enhanced-strobe;
- 	non-removable;
- 	status = "okay";
- };
- 
--&spdif {
--	pinctrl-0 = <&spdif_bus_1>;
-+&spi1 {
- 	status = "okay";
- 
--	spdif_p0: port {
--		spdif_p0_0: endpoint {
--			remote-endpoint = <&dit_p0_0>;
--		};
-+	flash@0 {
-+		compatible = "jedec,spi-nor";
-+		reg = <0>;
-+		spi-max-frequency = <10000000>;
- 	};
- };
- 
-@@ -830,14 +853,6 @@
- 	status = "okay";
- };
- 
--&tcphy0_usb3 {
--	port {
--		tcphy0_typec_ss: endpoint {
--			remote-endpoint = <&usbc_ss>;
--		};
--	};
--};
--
- &tcphy1 {
- 	status = "okay";
- };
-@@ -854,6 +869,7 @@
- 	status = "okay";
- 
- 	u2phy0_otg: otg-port {
-+		phy-supply = <&vcc_vbus_typec0>;
- 		status = "okay";
- 	};
- 
-@@ -861,18 +877,13 @@
- 		phy-supply = <&vcc5v0_host>;
- 		status = "okay";
- 	};
--
--	port {
--		u2phy0_typec_hs: endpoint {
--			remote-endpoint = <&usbc_hs>;
--		};
--	};
- };
- 
- &u2phy1 {
- 	status = "okay";
- 
- 	u2phy1_otg: otg-port {
-+		phy-supply = <&vcc_vbus_typec1>;
- 		status = "okay";
- 	};
- 
-@@ -914,7 +925,6 @@
- 
- &usbdrd_dwc3_0 {
- 	status = "okay";
--	dr_mode = "otg";
- };
- 
- &usbdrd3_1 {
-@@ -941,3 +951,144 @@
- &vopl_mmu {
- 	status = "okay";
- };
-+
-+&sys_12v {
-+	vin-supply = <&poe_12v>;
-+};
-+
-+&pcie_phy {
-+	status = "okay";
-+};
-+
-+&pcie0 {
-+	ep-gpios = <&gpio4 RK_PD1 GPIO_ACTIVE_HIGH>;
-+	num-lanes = <4>;
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&pcie_perst>;
-+	vpcie3v3-supply = <&vcc3v3_pcie>;
-+	vpcie1v8-supply = <&vcc1v8_pmu>;
-+	vpcie0v9-supply = <&vcca_0v9>;
-+	status = "okay";
-+};
-+
-+&sdio0 {
-+	bus-width = <4>;
-+	cap-sd-highspeed;
-+	cap-sdio-irq;
-+	keep-power-in-suspend;
-+	mmc-pwrseq = <&sdio_pwrseq>;
-+	non-removable;
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&sdio0_bus4 &sdio0_cmd &sdio0_clk>;
-+	sd-uhs-sdr104;
-+	vmmc-supply = <&vcc3v3_ngff>;
-+	vqmmc-supply = <&vcc_1v8>;
-+	status = "okay";
-+};
-+
-+&uart0 {
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&uart0_xfer &uart0_cts &uart0_rts>;
-+	status = "okay";
-+};
-+
-+&rk808{
-+	rtc {
-+		compatible = "rk808-rtc";	
-+		status = "disabled";
-+	};
-+};
-+
-+&i2c0 {
-+	status = "okay";
 +	hym8563: hym8563@51 {
 +		compatible = "haoyu,hym8563";
 +		reg = <0x51>;
@@ -989,72 +245,157 @@ index c654b6b02f3..f73f792eb44 100644
 +		clock-frequency = <32768>;
 +		clock-output-names = "xin32k";
 +	};
-+};
-+
-+&i2c1 {
-+	i2c-scl-rising-time-ns = <300>;
-+	i2c-scl-falling-time-ns = <15>;
+ };
+ 
+ &i2c1 {
+@@ -564,7 +627,7 @@
+ 	status = "okay";
+ 
+ 	fusb0: typec-portc@22 {
+-		compatible = "fcs,fusb302";
++		compatible = "fairchild,fusb302";
+ 		reg = <0x22>;
+ 		interrupt-parent = <&gpio1>;
+ 		interrupts = <RK_PA2 IRQ_TYPE_LEVEL_LOW>;
+@@ -635,12 +698,11 @@
+ };
+ 
+ &io_domains {
+-	status = "okay";
+-
+-	bt656-supply = <&vcc1v8_dvp>;
+ 	audio-supply = <&vcca1v8_codec>;
+-	sdmmc-supply = <&vcc_sdio>;
++	bt656-supply = <&vcc_3v0>;
+ 	gpio1830-supply = <&vcc_3v0>;
++	sdmmc-supply = <&vcc_sdio>;
 +	status = "okay";
+ };
+ 
+ &pcie_phy {
+@@ -651,7 +713,10 @@
+ 	ep-gpios = <&gpio4 RK_PD1 GPIO_ACTIVE_HIGH>;
+ 	num-lanes = <4>;
+ 	pinctrl-names = "default";
+-	pinctrl-0 = <&pcie_clkreqn_cpm>;
++	pinctrl-0 = <&pcie_perst>;
++	vpcie3v3-supply = <&vcc3v3_pcie>;
++	vpcie1v8-supply = <&vcc1v8_pmu>;
++	vpcie0v9-supply = <&vcca_0v9>;
+ 	status = "okay";
+ };
+ 
+@@ -696,20 +761,20 @@
+ 	};
+ 
+ 	pcie {
+-		pcie_pwr_en: pcie-pwr-en {
++		vcc3v3_pcie_en: vcc3v3-pcie-en {
+ 			rockchip,pins = <1 RK_PC1 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 
++		pcie_perst: pcie-perst {
++			rockchip,pins = <4 RK_PD1 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
 +
-+	rt5640: rt5640@1c {
-+		compatible = "realtek,rt5640";
-+		reg = <0x1c>;
-+		clocks = <&cru SCLK_I2S_8CH_OUT>;
-+		clock-names = "mclk";
-+		realtek,in1-differential;
-+		#sound-dai-cells = <0>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&rt5640_hpcon>;
+ 		pcie_3g_drv: pcie-3g-drv {
+ 			rockchip,pins = <0 RK_PA2 RK_FUNC_GPIO &pcfg_pull_up>;
+ 		};
+ 	};
+ 
+ 	pmic {
+-		pmic_int_l: pmic-int-l {
+-			rockchip,pins = <1 RK_PC5 RK_FUNC_GPIO &pcfg_pull_up>;
+-		};
+-
+ 		vsel1_pin: vsel1-pin {
+ 			rockchip,pins = <1 RK_PC2 RK_FUNC_GPIO &pcfg_pull_down>;
+ 		};
+@@ -717,6 +782,10 @@
+ 		vsel2_pin: vsel2-pin {
+ 			rockchip,pins = <1 RK_PB6 RK_FUNC_GPIO &pcfg_pull_down>;
+ 		};
++
++		pmic_int_l: pmic-int-l {
++			rockchip,pins = <1 RK_PC5 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
+ 	};
+ 
+ 	rt5640 {
+@@ -741,6 +810,14 @@
+ 		vcc5v0_host_en: vcc5v0-host-en {
+ 			rockchip,pins = <1 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
++
++		vcc_sys_en: vcc-sys-en {
++			rockchip,pins = <2 RK_PA6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		hub_rst: hub-rst {
++			rockchip,pins = <2 RK_PA4 RK_FUNC_GPIO &pcfg_output_high>;
++		};
+ 	};
+ 
+ 	wifi {
+@@ -748,6 +825,26 @@
+ 			rockchip,pins = <0 RK_PA3 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 	};
++
++	ngff {
++		vcc3v3_ngff_en: vcc3v3-ngff-en {
++			rockchip,pins = <4 RK_PD3 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
 +	};
-+};
 +
-+&i2c4 {
-+	i2c-scl-rising-time-ns = <600>;
-+	i2c-scl-falling-time-ns = <20>;
-+	status = "okay";
++	bt {
++		bt_host_wake_l: bt-host-wake-l {
++			rockchip,pins = <0 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
 +
-+	accelerometer@68 {
-+		compatible = "invensense,mpu6500";
-+		reg = <0x68>;
-+		interrupt-parent = <&gpio1>;
-+		interrupts = <RK_PC6 IRQ_TYPE_EDGE_RISING>;
++		bt_reg_on_h: bt-reg-on-h {
++			rockchip,pins = <0 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		bt_wake_l: bt-wake-l {
++			rockchip,pins = <2 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
 +	};
-+};
-+
-+&sdio0 {
-+	/* WiFi & BT combo module Ampak AP6356S */
-+	bus-width = <4>;
-+	cap-sdio-irq;
-+	cap-sd-highspeed;
-+	keep-power-in-suspend;
-+	mmc-pwrseq = <&sdio_pwrseq>;
-+	non-removable;
+ };
+ 
+ &pwm0 {
+@@ -771,6 +868,7 @@
+ 	keep-power-in-suspend;
+ 	mmc-pwrseq = <&sdio_pwrseq>;
+ 	non-removable;
 +	num-slots = <1>;
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&sdio0_bus4 &sdio0_cmd &sdio0_clk>;
-+	sd-uhs-sdr104;
-+
-+	/* Power supply */
-+	vqmmc-supply = <&vcc1v8_s3>;	/* IO line */
-+	vmmc-supply = <&vcc_sdio>;	/* card's power */
-+
-+	status = "okay";
-+
-+	brcmf: wifi@1 {
-+		compatible = "brcm,bcm4329-fmac";
-+		interrupt-parent = <&gpio0>;
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&sdio0_bus4 &sdio0_cmd &sdio0_clk>;
+ 	sd-uhs-sdr104;
+@@ -779,15 +877,12 @@
+ 	vqmmc-supply = <&vcc1v8_s3>;	/* IO line */
+ 	vmmc-supply = <&vcc_sdio>;	/* card's power */
+ 
+-	#address-cells = <1>;
+-	#size-cells = <0>;
+ 	status = "okay";
+ 
+ 	brcmf: wifi@1 {
+-		reg = <1>;
+ 		compatible = "brcm,bcm4329-fmac";
+ 		interrupt-parent = <&gpio0>;
+-		interrupts = <RK_PA3 IRQ_TYPE_LEVEL_HIGH>;
 +		interrupts = <RK_PA3 GPIO_ACTIVE_HIGH>;
-+		interrupt-names = "host-wake";
-+		brcm,drive-strength = <5>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&wifi_host_wake_l>;
-+	};
-+};
-+
-+&uart0 {
-+	pinctrl-names = "default";
+ 		interrupt-names = "host-wake";
+ 		brcm,drive-strength = <5>;
+ 		pinctrl-names = "default";
+@@ -884,8 +979,22 @@
+ 
+ &uart0 {
+ 	pinctrl-names = "default";
+-	pinctrl-0 = <&uart0_xfer &uart0_cts>;
 +	pinctrl-0 = <&uart0_xfer &uart0_rts &uart0_cts>;
-+	status = "okay";
+ 	status = "okay";
 +
 +	bluetooth {
 +		compatible = "brcm,bcm43438-bt";
@@ -1069,5 +410,20 @@ index c654b6b02f3..f73f792eb44 100644
 +		vbat-supply = <&vcc3v3_sys>;
 +		vddio-supply = <&vcc_1v8>;
 +	};
+ };
+ 
+ &uart2 {
+@@ -914,7 +1023,6 @@
+ 
+ &usbdrd_dwc3_0 {
+ 	status = "okay";
+-	dr_mode = "otg";
+ };
+ 
+ &usbdrd3_1 {
+@@ -940,4 +1048,4 @@
+ 
+ &vopl_mmu {
+ 	status = "okay";
+-};
 +};
-

--- a/patch/kernel/archive/rockchip64-6.8/board-firefly-rk3399-dts.patch
+++ b/patch/kernel/archive/rockchip64-6.8/board-firefly-rk3399-dts.patch
@@ -1,160 +1,10 @@
 index c654b6b02f3..f73f792eb44 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts
-@@ -1,13 +1,11 @@
- // SPDX-License-Identifier: (GPL-2.0+ OR MIT)
- /*
-- * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd.
-+ * Copyright (c) 2017 T-Chip Intelligent Technology Co., Ltd
-  */
- 
- /dts-v1/;
- #include <dt-bindings/input/linux-event-codes.h>
--#include <dt-bindings/interrupt-controller/irq.h>
- #include <dt-bindings/pwm/pwm.h>
--#include <dt-bindings/usb/pd.h>
- #include "rk3399.dtsi"
- #include "rk3399-opp.dtsi"
- 
-@@ -18,9 +16,9 @@
- 	compatible = "firefly,firefly-rk3399", "rockchip,rk3399";
- 
- 	aliases {
- 		ethernet0 = &gmac;
--		mmc0 = &sdio0;
--		mmc1 = &sdmmc;
--		mmc2 = &sdhci;
-+		mmc0 = &sdmmc;
-+		mmc1 = &sdhci;
-+		mmc2 = &sdio0;
+@@ -178,6 +177,15 @@
+ 		};
  	};
  
- 	chosen {
-@@ -27,42 +25,7 @@
- 
- 	backlight: backlight {
- 		compatible = "pwm-backlight";
--		enable-gpios = <&gpio1 RK_PB5 GPIO_ACTIVE_HIGH>;
- 		pwms = <&pwm0 0 25000 0>;
--		brightness-levels = <
--			  0   1   2   3   4   5   6   7
--			  8   9  10  11  12  13  14  15
--			 16  17  18  19  20  21  22  23
--			 24  25  26  27  28  29  30  31
--			 32  33  34  35  36  37  38  39
--			 40  41  42  43  44  45  46  47
--			 48  49  50  51  52  53  54  55
--			 56  57  58  59  60  61  62  63
--			 64  65  66  67  68  69  70  71
--			 72  73  74  75  76  77  78  79
--			 80  81  82  83  84  85  86  87
--			 88  89  90  91  92  93  94  95
--			 96  97  98  99 100 101 102 103
--			104 105 106 107 108 109 110 111
--			112 113 114 115 116 117 118 119
--			120 121 122 123 124 125 126 127
--			128 129 130 131 132 133 134 135
--			136 137 138 139 140 141 142 143
--			144 145 146 147 148 149 150 151
--			152 153 154 155 156 157 158 159
--			160 161 162 163 164 165 166 167
--			168 169 170 171 172 173 174 175
--			176 177 178 179 180 181 182 183
--			184 185 186 187 188 189 190 191
--			192 193 194 195 196 197 198 199
--			200 201 202 203 204 205 206 207
--			208 209 210 211 212 213 214 215
--			216 217 218 219 220 221 222 223
--			224 225 226 227 228 229 230 231
--			232 233 234 235 236 237 238 239
--			240 241 242 243 244 245 246 247
--			248 249 250 251 252 253 254 255>;
--		default-brightness-level = <200>;
- 	};
- 
- 	clkin_gmac: external-gmac-clock {
-@@ -72,13 +35,18 @@
- 		#clock-cells = <0>;
- 	};
- 
--	dc_12v: dc-12v {
--		compatible = "regulator-fixed";
--		regulator-name = "dc_12v";
--		regulator-always-on;
--		regulator-boot-on;
--		regulator-min-microvolt = <12000000>;
--		regulator-max-microvolt = <12000000>;
-+	adc-keys {
-+		compatible = "adc-keys";
-+		io-channels = <&saradc 1>;
-+		io-channel-names = "buttons";
-+		keyup-threshold-microvolt = <1500000>;
-+		poll-interval = <100>;
-+
-+		button-recovery {
-+			label = "Recovery";
-+			linux,code = <KEY_VENDOR>;
-+			press-threshold-microvolt = <18000>;
-+		};
- 	};
- 
- 	gpio-keys {
-@@ -103,47 +71,6 @@
- 		pinctrl-names = "default";
- 	};
- 
--	leds {
--		compatible = "gpio-leds";
--		pinctrl-names = "default";
--		pinctrl-0 = <&work_led_pin>, <&diy_led_pin>;
--
--		work_led: led-0 {
--			label = "work";
--			default-state = "on";
--			gpios = <&gpio2 RK_PD3 GPIO_ACTIVE_HIGH>;
--		};
--
--		diy_led: led-1 {
--			label = "diy";
--			default-state = "off";
--			gpios = <&gpio0 RK_PB5 GPIO_ACTIVE_HIGH>;
--		};
--	};
--
--	rt5640-sound {
--		compatible = "simple-audio-card";
--		simple-audio-card,name = "rockchip,rt5640-codec";
--		simple-audio-card,format = "i2s";
--		simple-audio-card,mclk-fs = <256>;
--		simple-audio-card,widgets =
--			"Microphone", "Mic Jack",
--			"Headphone", "Headphone Jack";
--		simple-audio-card,routing =
--			"Mic Jack", "MICBIAS1",
--			"IN1P", "Mic Jack",
--			"Headphone Jack", "HPOL",
--			"Headphone Jack", "HPOR";
--
--		simple-audio-card,cpu {
--			sound-dai = <&i2s1>;
--		};
--
--		simple-audio-card,codec {
--			sound-dai = <&rt5640>;
--		};
--	};
--
- 	sdio_pwrseq: sdio-pwrseq {
- 		compatible = "mmc-pwrseq-simple";
- 		clocks = <&rk808 1>;
-@@ -160,21 +87,21 @@
- 		reset-gpios = <&gpio0 RK_PB2 GPIO_ACTIVE_LOW>;
- 	};
- 
--	sound-dit {
--		compatible = "audio-graph-card";
--		label = "SPDIF";
--		dais = <&spdif_p0>;
 +	vcc_vbus_typec0: vcc-vbus-typec0 {
 +		compatible = "regulator-fixed";
 +		regulator-name = "vcc_vbus_typec0";
@@ -162,70 +12,42 @@ index c654b6b02f3..f73f792eb44 100644
 +		regulator-boot-on;
 +		regulator-min-microvolt = <5000000>;
 +		regulator-max-microvolt = <5000000>;
- 	};
- 
--	spdif-dit {
--		compatible = "linux,spdif-dit";
--		#sound-dai-cells = <0>;
--
--		port {
--			dit_p0_0: endpoint {
--				remote-endpoint = <&spdif_p0_0>;
--			};
--		};
-+	sys_12v: sys-12v {
-+		compatible = "regulator-fixed";
-+		regulator-name = "sys_12v";
-+		regulator-always-on;
-+		regulator-boot-on;
-+		vin-supply = <&dc_12v>;
- 	};
- 
++	};
++
  	/* switched by pmic_sleep */
-@@ -188,16 +115,17 @@
+ 	vcc1v8_s3: vcca1v8_s3: vcc1v8-s3 {
+ 		compatible = "regulator-fixed";
+@@ -189,15 +197,15 @@
  		vin-supply = <&vcc_1v8>;
  	};
  
 -	vcc3v3_pcie: vcc3v3-pcie-regulator {
-+	vcc3v0_sd: vcc3v0-sd {
++	vcc3v3_pcie: vcc3v3-pcie {
  		compatible = "regulator-fixed";
++		regulator-name = "vcc3v3_pcie";
  		enable-active-high;
--		gpio = <&gpio1 RK_PC1 GPIO_ACTIVE_HIGH>;
-+		gpio = <&gpio4 RK_PD6 GPIO_ACTIVE_HIGH>;
+ 		gpio = <&gpio1 RK_PC1 GPIO_ACTIVE_HIGH>;
  		pinctrl-names = "default";
 -		pinctrl-0 = <&pcie_pwr_en>;
 -		regulator-name = "vcc3v3_pcie";
 -		regulator-always-on;
-+		pinctrl-0 = <&vcc3v0_sd_en>;
-+		regulator-name = "vcc3v0_sd";
- 		regulator-boot-on;
--		vin-supply = <&dc_12v>;
-+		regulator-min-microvolt = <3000000>;
-+		regulator-max-microvolt = <3000000>;
-+		vin-supply = <&vcc3v3_sys>;
+-		regulator-boot-on;
++		pinctrl-0 = <&vcc3v3_pcie_en>;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
+ 		vin-supply = <&dc_12v>;
  	};
  
- 	vcc3v3_sys: vcc3v3-sys {
-@@ -207,7 +135,17 @@
+@@ -208,7 +216,7 @@
  		regulator-boot-on;
  		regulator-min-microvolt = <3300000>;
  		regulator-max-microvolt = <3300000>;
 -		vin-supply = <&vcc_sys>;
-+		vin-supply = <&sys_12v>;
-+	};
-+
-+	vcca_0v9: vcca-0v9 {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcca_0v9";
-+		regulator-always-on;
-+		regulator-boot-on;
-+		regulator-min-microvolt = <900000>;
-+		regulator-max-microvolt = <900000>;
-+		vin-supply = <&vcc3v3_sys>;
++		vin-supply = <&dc_12v>;
  	};
  
  	/* Actually 3 regulators (host0, 1, 2) controlled by the same gpio */
-@@ -216,42 +154,132 @@
+@@ -217,9 +225,8 @@
  		enable-active-high;
  		gpio = <&gpio1 RK_PA0 GPIO_ACTIVE_HIGH>;
  		pinctrl-names = "default";
@@ -236,20 +58,7 @@ index c654b6b02f3..f73f792eb44 100644
  		vin-supply = <&vcc_sys>;
  	};
  
--	vcc5v0_typec: vcc5v0-typec-regulator {
-+	vcc_vbus_typec1: vcc-vbus-typec1 {
- 		compatible = "regulator-fixed";
- 		enable-active-high;
--		gpio = <&gpio1 RK_PA3 GPIO_ACTIVE_HIGH>;
-+		gpio = <&gpio1 RK_PB5 GPIO_ACTIVE_HIGH>;
- 		pinctrl-names = "default";
--		pinctrl-0 = <&vcc5v0_typec_en>;
--		regulator-name = "vcc5v0_typec";
-+		pinctrl-0 = <&vcc_vbus_typec1_en>;
-+		regulator-name = "vcc_vbus_typec1";
- 		regulator-always-on;
- 		vin-supply = <&vcc_sys>;
- 	};
+@@ -236,8 +243,11 @@
  
  	vcc_sys: vcc-sys {
  		compatible = "regulator-fixed";
@@ -262,30 +71,19 @@ index c654b6b02f3..f73f792eb44 100644
  		regulator-boot-on;
  		regulator-min-microvolt = <5000000>;
  		regulator-max-microvolt = <5000000>;
--		vin-supply = <&dc_12v>;
-+		vin-supply = <&sys_12v>;
- 	};
- 
- 	vdd_log: vdd-log {
- 		compatible = "pwm-regulator";
- 		pwms = <&pwm2 0 25000 1>;
--		pwm-supply = <&vcc_sys>;
- 		regulator-name = "vdd_log";
- 		regulator-always-on;
- 		regulator-boot-on;
+@@ -254,6 +264,41 @@
  		regulator-min-microvolt = <430000>;
  		regulator-max-microvolt = <1400000>;
-+		pwm-supply = <&vcc3v3_sys>;
-+	};
+ 	};
 +
-+	/* MP8009 PoE PD */
-+	poe_12v: poe-12v {
++	vcca_0v9: vcca-0v9 {
 +		compatible = "regulator-fixed";
-+		regulator-name = "poe_12v";
++		regulator-name = "vcca_0v9";
 +		regulator-always-on;
 +		regulator-boot-on;
-+		regulator-min-microvolt = <12000000>;
-+		regulator-max-microvolt = <12000000>;
++		regulator-min-microvolt = <900000>;
++		regulator-max-microvolt = <900000>;
++		vin-supply = <&vcc3v3_sys>;
 +	};
 +
 +	vcc3v3_ngff: vcc3v3-ngff {
@@ -299,60 +97,7 @@ index c654b6b02f3..f73f792eb44 100644
 +		regulator-boot-on;
 +		regulator-min-microvolt = <3300000>;
 +		regulator-max-microvolt = <3300000>;
-+		vin-supply = <&sys_12v>;
-+	};
-+
-+	vcc3v3_pcie: vcc3v3-pcie {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc3v3_pcie";
-+		enable-active-high;
-+		gpio = <&gpio1 RK_PC1 GPIO_ACTIVE_HIGH>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&vcc3v3_pcie_en>;
-+		regulator-min-microvolt = <3300000>;
-+		regulator-max-microvolt = <3300000>;
-+		vin-supply = <&sys_12v>;
-+	};
-+
-+	leds {
-+		compatible = "gpio-leds";
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&work_led_pin>, <&diy_led_pin>;
-+
-+		work_led: led-0 {
-+			label = "work";
-+			default-state = "on";
-+			gpios = <&gpio2 RK_PD3 GPIO_ACTIVE_HIGH>;
-+		};
-+
-+		diy_led: led-1 {
-+			label = "diy";
-+			default-state = "off";
-+			gpios = <&gpio0 RK_PB5 GPIO_ACTIVE_HIGH>;
-+		};
-+	};
-+
-+	rt5640-sound {
-+		compatible = "simple-audio-card";
-+		simple-audio-card,name = "rockchip,rt5640-codec";
-+		simple-audio-card,format = "i2s";
-+		simple-audio-card,mclk-fs = <256>;
-+		simple-audio-card,widgets =
-+			"Microphone", "Mic Jack",
-+			"Headphone", "Headphone Jack";
-+		simple-audio-card,routing =
-+			"Mic Jack", "MICBIAS1",
-+			"IN1P", "Mic Jack",
-+			"Headphone Jack", "HPOL",
-+			"Headphone Jack", "HPOR";
-+
-+		simple-audio-card,cpu {
-+			sound-dai = <&i2s1>;
-+		};
-+
-+		simple-audio-card,codec {
-+			sound-dai = <&rt5640>;
-+		};
++		vin-supply = <&dc_12v>;
 +	};
 +	
 +	vcc3v3_3g: vcc3v3-3g-regulator {
@@ -364,10 +109,11 @@ index c654b6b02f3..f73f792eb44 100644
 +		regulator-name = "vcc3v3_3g";
 +		regulator-always-on;
 +		regulator-boot-on;
- 	};
++	};
  };
  
-@@ -305,12 +333,18 @@
+ &cpu_l0 {
+@@ -306,6 +351,8 @@
  };
  
  &hdmi {
@@ -376,17 +122,7 @@ index c654b6b02f3..f73f792eb44 100644
  	ddc-i2c-bus = <&i2c3>;
  	pinctrl-names = "default";
  	pinctrl-0 = <&hdmi_cec>;
- 	status = "okay";
- };
- 
-+&hdmi_sound {
-+	status = "okay";
-+};
-+
- &i2c0 {
- 	clock-frequency = <400000>;
- 	i2c-scl-rising-time-ns = <168>;
-@@ -329,18 +363,18 @@
+@@ -330,18 +377,18 @@
  		rockchip,system-power-controller;
  		wakeup-source;
  
@@ -415,7 +151,7 @@ index c654b6b02f3..f73f792eb44 100644
  
  		regulators {
  			vdd_center: DCDC_REG1 {
-@@ -388,8 +422,8 @@
+@@ -389,8 +436,8 @@
  				};
  			};
  
@@ -426,7 +162,7 @@ index c654b6b02f3..f73f792eb44 100644
  				regulator-always-on;
  				regulator-boot-on;
  				regulator-min-microvolt = <1800000>;
-@@ -399,12 +433,12 @@
+@@ -400,12 +447,12 @@
  				};
  			};
  
@@ -443,7 +179,7 @@ index c654b6b02f3..f73f792eb44 100644
  				regulator-state-mem {
  					regulator-off-in-suspend;
  				};
-@@ -457,12 +491,12 @@
+@@ -458,12 +505,12 @@
  				};
  			};
  
@@ -460,7 +196,7 @@ index c654b6b02f3..f73f792eb44 100644
  				regulator-state-mem {
  					regulator-off-in-suspend;
  				};
-@@ -503,14 +537,16 @@
+@@ -504,14 +551,16 @@
  	vdd_cpu_b: regulator@40 {
  		compatible = "silergy,syr827";
  		reg = <0x40>;
@@ -479,7 +215,7 @@ index c654b6b02f3..f73f792eb44 100644
  
  		regulator-state-mem {
  			regulator-off-in-suspend;
-@@ -521,13 +557,15 @@
+@@ -522,18 +571,31 @@
  		compatible = "silergy,syr828";
  		reg = <0x41>;
  		fcs,suspend-voltage-selector = <1>;
@@ -496,490 +232,9 @@ index c654b6b02f3..f73f792eb44 100644
  
  		regulator-state-mem {
  			regulator-off-in-suspend;
-@@ -539,17 +577,6 @@
- 	i2c-scl-rising-time-ns = <300>;
- 	i2c-scl-falling-time-ns = <15>;
- 	status = "okay";
--
--	rt5640: rt5640@1c {
--		compatible = "realtek,rt5640";
--		reg = <0x1c>;
--		clocks = <&cru SCLK_I2S_8CH_OUT>;
--		clock-names = "mclk";
--		realtek,in1-differential;
--		#sound-dai-cells = <0>;
--		pinctrl-names = "default";
--		pinctrl-0 = <&rt5640_hpcon>;
--	};
- };
- 
- &i2c3 {
-@@ -563,59 +590,51 @@
- 	i2c-scl-falling-time-ns = <20>;
- 	status = "okay";
- 
--	fusb0: typec-portc@22 {
--		compatible = "fcs,fusb302";
-+	fusb1: usb-typec@22 {
-+		compatible = "fairchild,fusb302";
-+		reg = <0x22>;
-+		interrupt-parent = <&gpio1>;
-+		interrupts = <1 IRQ_TYPE_LEVEL_LOW>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&fusb1_int>;
-+		vbus-supply = <&vcc_vbus_typec1>;
-+		status = "disabled";
-+	};
-+};
-+
-+&i2c7 {
-+	i2c-scl-rising-time-ns = <600>;
-+	i2c-scl-falling-time-ns = <20>;
-+	status = "okay";
-+
-+	fusb0: usb-typec@22 {
-+		compatible = "fairchild,fusb302";
- 		reg = <0x22>;
- 		interrupt-parent = <&gpio1>;
--		interrupts = <RK_PA2 IRQ_TYPE_LEVEL_LOW>;
-+		interrupts = <2 IRQ_TYPE_LEVEL_LOW>;
- 		pinctrl-names = "default";
- 		pinctrl-0 = <&fusb0_int>;
--		vbus-supply = <&vcc5v0_typec>;
--		status = "okay";
-+		vbus-supply = <&vcc_vbus_typec0>;
-+		status = "disabled";
-+	};
- 
--		connector {
--			compatible = "usb-c-connector";
--			data-role = "host";
--			label = "USB-C";
--			op-sink-microwatt = <1000000>;
--			power-role = "dual";
--			sink-pdos =
--				<PDO_FIXED(5000, 2500, PDO_FIXED_USB_COMM)>;
--			source-pdos =
--				<PDO_FIXED(5000, 1400, PDO_FIXED_USB_COMM)>;
--			try-power-role = "sink";
--
--			ports {
--				#address-cells = <1>;
--				#size-cells = <0>;
--
--				port@0 {
--					reg = <0>;
--
--					usbc_hs: endpoint {
--						remote-endpoint =
--							<&u2phy0_typec_hs>;
--					};
--				};
--
--				port@1 {
--					reg = <1>;
--
--					usbc_ss: endpoint {
--						remote-endpoint =
--							<&tcphy0_typec_ss>;
--					};
--				};
-+	mp8859: regulator@66 {
-+		compatible = "mps,mp8859";
-+		reg = <0x66>;
-+		dc_12v: mp8859_dcdc {
-+			regulator-name = "dc_12v";
-+			regulator-min-microvolt = <12000000>;
-+			regulator-max-microvolt = <12000000>;
-+			regulator-always-on;
-+			regulator-boot-on;
-+			vin-supply = <&vcc_vbus_typec0>;
-+
-+			regulator-state-mem {
-+				regulator-on-in-suspend;
-+				regulator-suspend-microvolt = <12000000>;
- 			};
  		};
  	};
--
--	accelerometer@68 {
--		compatible = "invensense,mpu6500";
--		reg = <0x68>;
--		interrupt-parent = <&gpio1>;
--		interrupts = <RK_PC6 IRQ_TYPE_EDGE_RISING>;
--	};
- };
- 
- &i2s0 {
-@@ -635,23 +654,10 @@
- };
- 
- &io_domains {
--	status = "okay";
--
--	bt656-supply = <&vcc1v8_dvp>;
- 	audio-supply = <&vcca1v8_codec>;
--	sdmmc-supply = <&vcc_sdio>;
-+	bt656-supply = <&vcc_3v0>;
- 	gpio1830-supply = <&vcc_3v0>;
--};
--
--&pcie_phy {
--	status = "okay";
--};
--
--&pcie0 {
--	ep-gpios = <&gpio4 RK_PD1 GPIO_ACTIVE_HIGH>;
--	num-lanes = <4>;
--	pinctrl-names = "default";
--	pinctrl-0 = <&pcie_clkreqn_cpm>;
-+	sdmmc-supply = <&vcc_sdio>;
- 	status = "okay";
- };
- 
-@@ -662,14 +668,12 @@
- 
- &pinctrl {
- 	buttons {
--		pwrbtn: pwrbtn {
-+		pwr_key_l: pwr-key-l {
- 			rockchip,pins = <0 RK_PA5 RK_FUNC_GPIO &pcfg_pull_up>;
- 		};
--	};
- 
--	fusb302x {
--		fusb0_int: fusb0-int {
--			rockchip,pins = <1 RK_PA2 RK_FUNC_GPIO &pcfg_pull_up>;
-+		pwrbtn: pwrbtn {
-+			rockchip,pins = <0 RK_PA5 RK_FUNC_GPIO &pcfg_pull_up>;
- 		};
- 	};
- 
-@@ -685,17 +689,77 @@
- 		};
- 	};
- 
--	leds {
--		work_led_pin: work-led-pin {
--			rockchip,pins = <2 RK_PD3 RK_FUNC_GPIO &pcfg_pull_none>;
-+	pmic {
-+		vsel1_pin: vsel1-pin {
-+			rockchip,pins = <1 RK_PC2 RK_FUNC_GPIO &pcfg_pull_down>;
- 		};
- 
--		diy_led_pin: diy-led-pin {
--			rockchip,pins = <0 RK_PB5 RK_FUNC_GPIO &pcfg_pull_none>;
-+		vsel2_pin: vsel2-pin {
-+			rockchip,pins = <1 RK_PB6 RK_FUNC_GPIO &pcfg_pull_down>;
-+		};
 +
-+		pmic_int_l: pmic-int-l {
-+			rockchip,pins = <1 RK_PC5 RK_FUNC_GPIO &pcfg_pull_up>;
-+		};
-+	};
-+
-+	sdio-pwrseq {
-+		wifi_enable_h: wifi-enable-h {
-+			rockchip,pins = <0 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+
-+	sdmmc {
-+		vcc3v0_sd_en: vcc3v0-sd-en {
-+			rockchip,pins = <4 RK_PD6 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+
-+	usb2 {
-+		vcc5v0_host_en: vcc5v0-host-en {
-+			rockchip,pins = <1 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+
-+		vcc_sys_en: vcc-sys-en {
-+			rockchip,pins = <2 RK_PA6 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+
-+		hub_rst: hub-rst {
-+			rockchip,pins = <2 RK_PA4 RK_FUNC_GPIO &pcfg_output_high>;
-+		};
-+	};
-+
-+	usb-typec {
-+		vcc_vbus_typec1_en: vcc-vbus-typec1-en {
-+			rockchip,pins = <1 RK_PB5 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
-+
-+	fusb30x {
-+		fusb0_int: fusb0-int {
-+			rockchip,pins = <1 RK_PA2 RK_FUNC_GPIO &pcfg_pull_up>;
-+		};
-+
-+		fusb1_int: fusb1-int {
-+			rockchip,pins = <1 RK_PA1 RK_FUNC_GPIO &pcfg_pull_up>;
-+		};
-+	};
-+
-+	ngff {
-+		vcc3v3_ngff_en: vcc3v3-ngff-en {
-+			rockchip,pins = <4 RK_PD3 RK_FUNC_GPIO &pcfg_pull_none>;
- 		};
- 	};
- 
- 	pcie {
-+		vcc3v3_pcie_en: vcc3v3-pcie-en {
-+			rockchip,pins = <1 RK_PC1 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+
-+		pcie_perst: pcie-perst {
-+			rockchip,pins = <4 RK_PD1 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+
- 		pcie_pwr_en: pcie-pwr-en {
- 			rockchip,pins = <1 RK_PC1 RK_FUNC_GPIO &pcfg_pull_none>;
- 		};
-@@ -705,17 +769,17 @@
- 		};
- 	};
- 
--	pmic {
--		pmic_int_l: pmic-int-l {
--			rockchip,pins = <1 RK_PC5 RK_FUNC_GPIO &pcfg_pull_up>;
-+	bt {
-+		bt_host_wake_l: bt-host-wake-l {
-+			rockchip,pins = <0 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
- 		};
- 
--		vsel1_pin: vsel1-pin {
--			rockchip,pins = <1 RK_PC2 RK_FUNC_GPIO &pcfg_pull_down>;
-+		bt_reg_on_h: bt-reg-on-h {
-+			rockchip,pins = <0 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;
- 		};
- 
--		vsel2_pin: vsel2-pin {
--			rockchip,pins = <1 RK_PB6 RK_FUNC_GPIO &pcfg_pull_down>;
-+		bt_wake_l: bt-wake-l {
-+			rockchip,pins = <2 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
- 		};
- 	};
- 
-@@ -725,27 +789,19 @@
- 		};
- 	};
- 
--	sdio-pwrseq {
--		wifi_enable_h: wifi-enable-h {
--			rockchip,pins = <0 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
--		};
--	};
--
--	usb-typec {
--		vcc5v0_typec_en: vcc5v0_typec_en {
--			rockchip,pins = <1 RK_PA3 RK_FUNC_GPIO &pcfg_pull_up>;
-+	wifi {
-+		wifi_host_wake_l: wifi-host-wake-l {
-+			rockchip,pins = <0 RK_PA3 RK_FUNC_GPIO &pcfg_pull_none>;
- 		};
- 	};
- 
--	usb2 {
--		vcc5v0_host_en: vcc5v0-host-en {
--			rockchip,pins = <1 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
-+	leds {
-+		work_led_pin: work-led-pin {
-+			rockchip,pins = <2 RK_PD3 RK_FUNC_GPIO &pcfg_pull_none>;
- 		};
--	};
- 
--	wifi {
--		wifi_host_wake_l: wifi-host-wake-l {
--			rockchip,pins = <0 RK_PA3 RK_FUNC_GPIO &pcfg_pull_none>;
-+		diy_led_pin: diy-led-pin {
-+			rockchip,pins = <0 RK_PB5 RK_FUNC_GPIO &pcfg_pull_none>;
- 		};
- 	};
- };
-@@ -763,66 +819,33 @@
- 	status = "okay";
- };
- 
--&sdio0 {
--	/* WiFi & BT combo module Ampak AP6356S */
--	bus-width = <4>;
--	cap-sdio-irq;
--	cap-sd-highspeed;
--	keep-power-in-suspend;
--	mmc-pwrseq = <&sdio_pwrseq>;
--	non-removable;
--	pinctrl-names = "default";
--	pinctrl-0 = <&sdio0_bus4 &sdio0_cmd &sdio0_clk>;
--	sd-uhs-sdr104;
--
--	/* Power supply */
--	vqmmc-supply = <&vcc1v8_s3>;	/* IO line */
--	vmmc-supply = <&vcc_sdio>;	/* card's power */
--
--	#address-cells = <1>;
--	#size-cells = <0>;
--	status = "okay";
--
--	brcmf: wifi@1 {
--		reg = <1>;
--		compatible = "brcm,bcm4329-fmac";
--		interrupt-parent = <&gpio0>;
--		interrupts = <RK_PA3 IRQ_TYPE_LEVEL_HIGH>;
--		interrupt-names = "host-wake";
--		brcm,drive-strength = <5>;
--		pinctrl-names = "default";
--		pinctrl-0 = <&wifi_host_wake_l>;
--	};
--};
--
- &sdmmc {
- 	bus-width = <4>;
--	cap-mmc-highspeed;
- 	cap-sd-highspeed;
--	cd-gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
-+	cd-gpios = <&gpio0 RK_PA7 GPIO_ACTIVE_LOW>;
- 	disable-wp;
- 	max-frequency = <150000000>;
- 	pinctrl-names = "default";
- 	pinctrl-0 = <&sdmmc_clk &sdmmc_cmd &sdmmc_bus4>;
-+	sd-uhs-sdr104;
-+	vmmc-supply = <&vcc3v0_sd>;
-+	vqmmc-supply = <&vcc_sdio>;
- 	status = "okay";
- };
- 
- &sdhci {
- 	bus-width = <8>;
--	mmc-hs400-1_8v;
--	mmc-hs400-enhanced-strobe;
- 	non-removable;
- 	status = "okay";
- };
- 
--&spdif {
--	pinctrl-0 = <&spdif_bus_1>;
-+&spi1 {
- 	status = "okay";
- 
--	spdif_p0: port {
--		spdif_p0_0: endpoint {
--			remote-endpoint = <&dit_p0_0>;
--		};
-+	flash@0 {
-+		compatible = "jedec,spi-nor";
-+		reg = <0>;
-+		spi-max-frequency = <10000000>;
- 	};
- };
- 
-@@ -830,14 +853,6 @@
- 	status = "okay";
- };
- 
--&tcphy0_usb3 {
--	port {
--		tcphy0_typec_ss: endpoint {
--			remote-endpoint = <&usbc_ss>;
--		};
--	};
--};
--
- &tcphy1 {
- 	status = "okay";
- };
-@@ -854,6 +869,7 @@
- 	status = "okay";
- 
- 	u2phy0_otg: otg-port {
-+		phy-supply = <&vcc_vbus_typec0>;
- 		status = "okay";
- 	};
- 
-@@ -861,18 +877,13 @@
- 		phy-supply = <&vcc5v0_host>;
- 		status = "okay";
- 	};
--
--	port {
--		u2phy0_typec_hs: endpoint {
--			remote-endpoint = <&usbc_hs>;
--		};
--	};
- };
- 
- &u2phy1 {
- 	status = "okay";
- 
- 	u2phy1_otg: otg-port {
-+		phy-supply = <&vcc_vbus_typec1>;
- 		status = "okay";
- 	};
- 
-@@ -914,7 +925,6 @@
- 
- &usbdrd_dwc3_0 {
- 	status = "okay";
--	dr_mode = "otg";
- };
- 
- &usbdrd3_1 {
-@@ -941,3 +951,144 @@
- &vopl_mmu {
- 	status = "okay";
- };
-+
-+&sys_12v {
-+	vin-supply = <&poe_12v>;
-+};
-+
-+&pcie_phy {
-+	status = "okay";
-+};
-+
-+&pcie0 {
-+	ep-gpios = <&gpio4 RK_PD1 GPIO_ACTIVE_HIGH>;
-+	num-lanes = <4>;
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&pcie_perst>;
-+	vpcie3v3-supply = <&vcc3v3_pcie>;
-+	vpcie1v8-supply = <&vcc1v8_pmu>;
-+	vpcie0v9-supply = <&vcca_0v9>;
-+	status = "okay";
-+};
-+
-+&sdio0 {
-+	bus-width = <4>;
-+	cap-sd-highspeed;
-+	cap-sdio-irq;
-+	keep-power-in-suspend;
-+	mmc-pwrseq = <&sdio_pwrseq>;
-+	non-removable;
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&sdio0_bus4 &sdio0_cmd &sdio0_clk>;
-+	sd-uhs-sdr104;
-+	vmmc-supply = <&vcc3v3_ngff>;
-+	vqmmc-supply = <&vcc_1v8>;
-+	status = "okay";
-+};
-+
-+&uart0 {
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&uart0_xfer &uart0_cts &uart0_rts>;
-+	status = "okay";
-+};
-+
-+&rk808{
-+	rtc {
-+		compatible = "rk808-rtc";	
-+		status = "disabled";
-+	};
-+};
-+
-+&i2c0 {
-+	status = "okay";
 +	hym8563: hym8563@51 {
 +		compatible = "haoyu,hym8563";
 +		reg = <0x51>;
@@ -990,72 +245,157 @@ index c654b6b02f3..f73f792eb44 100644
 +		clock-frequency = <32768>;
 +		clock-output-names = "xin32k";
 +	};
-+};
-+
-+&i2c1 {
-+	i2c-scl-rising-time-ns = <300>;
-+	i2c-scl-falling-time-ns = <15>;
+ };
+ 
+ &i2c1 {
+@@ -565,7 +627,7 @@
+ 	status = "okay";
+ 
+ 	fusb0: typec-portc@22 {
+-		compatible = "fcs,fusb302";
++		compatible = "fairchild,fusb302";
+ 		reg = <0x22>;
+ 		interrupt-parent = <&gpio1>;
+ 		interrupts = <RK_PA2 IRQ_TYPE_LEVEL_LOW>;
+@@ -636,12 +698,11 @@
+ };
+ 
+ &io_domains {
+-	status = "okay";
+-
+-	bt656-supply = <&vcc1v8_dvp>;
+ 	audio-supply = <&vcca1v8_codec>;
+-	sdmmc-supply = <&vcc_sdio>;
++	bt656-supply = <&vcc_3v0>;
+ 	gpio1830-supply = <&vcc_3v0>;
++	sdmmc-supply = <&vcc_sdio>;
 +	status = "okay";
+ };
+ 
+ &pcie_phy {
+@@ -652,7 +713,10 @@
+ 	ep-gpios = <&gpio4 RK_PD1 GPIO_ACTIVE_HIGH>;
+ 	num-lanes = <4>;
+ 	pinctrl-names = "default";
+-	pinctrl-0 = <&pcie_clkreqn_cpm>;
++	pinctrl-0 = <&pcie_perst>;
++	vpcie3v3-supply = <&vcc3v3_pcie>;
++	vpcie1v8-supply = <&vcc1v8_pmu>;
++	vpcie0v9-supply = <&vcca_0v9>;
+ 	status = "okay";
+ };
+ 
+@@ -697,20 +761,20 @@
+ 	};
+ 
+ 	pcie {
+-		pcie_pwr_en: pcie-pwr-en {
++		vcc3v3_pcie_en: vcc3v3-pcie-en {
+ 			rockchip,pins = <1 RK_PC1 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 
++		pcie_perst: pcie-perst {
++			rockchip,pins = <4 RK_PD1 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
 +
-+	rt5640: rt5640@1c {
-+		compatible = "realtek,rt5640";
-+		reg = <0x1c>;
-+		clocks = <&cru SCLK_I2S_8CH_OUT>;
-+		clock-names = "mclk";
-+		realtek,in1-differential;
-+		#sound-dai-cells = <0>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&rt5640_hpcon>;
+ 		pcie_3g_drv: pcie-3g-drv {
+ 			rockchip,pins = <0 RK_PA2 RK_FUNC_GPIO &pcfg_pull_up>;
+ 		};
+ 	};
+ 
+ 	pmic {
+-		pmic_int_l: pmic-int-l {
+-			rockchip,pins = <1 RK_PC5 RK_FUNC_GPIO &pcfg_pull_up>;
+-		};
+-
+ 		vsel1_pin: vsel1-pin {
+ 			rockchip,pins = <1 RK_PC2 RK_FUNC_GPIO &pcfg_pull_down>;
+ 		};
+@@ -718,6 +782,10 @@
+ 		vsel2_pin: vsel2-pin {
+ 			rockchip,pins = <1 RK_PB6 RK_FUNC_GPIO &pcfg_pull_down>;
+ 		};
++
++		pmic_int_l: pmic-int-l {
++			rockchip,pins = <1 RK_PC5 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
+ 	};
+ 
+ 	rt5640 {
+@@ -742,6 +810,14 @@
+ 		vcc5v0_host_en: vcc5v0-host-en {
+ 			rockchip,pins = <1 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
++
++		vcc_sys_en: vcc-sys-en {
++			rockchip,pins = <2 RK_PA6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		hub_rst: hub-rst {
++			rockchip,pins = <2 RK_PA4 RK_FUNC_GPIO &pcfg_output_high>;
++		};
+ 	};
+ 
+ 	wifi {
+@@ -749,6 +825,26 @@
+ 			rockchip,pins = <0 RK_PA3 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 	};
++
++	ngff {
++		vcc3v3_ngff_en: vcc3v3-ngff-en {
++			rockchip,pins = <4 RK_PD3 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
 +	};
-+};
 +
-+&i2c4 {
-+	i2c-scl-rising-time-ns = <600>;
-+	i2c-scl-falling-time-ns = <20>;
-+	status = "okay";
++	bt {
++		bt_host_wake_l: bt-host-wake-l {
++			rockchip,pins = <0 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
 +
-+	accelerometer@68 {
-+		compatible = "invensense,mpu6500";
-+		reg = <0x68>;
-+		interrupt-parent = <&gpio1>;
-+		interrupts = <RK_PC6 IRQ_TYPE_EDGE_RISING>;
++		bt_reg_on_h: bt-reg-on-h {
++			rockchip,pins = <0 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		bt_wake_l: bt-wake-l {
++			rockchip,pins = <2 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
 +	};
-+};
-+
-+&sdio0 {
-+	/* WiFi & BT combo module Ampak AP6356S */
-+	bus-width = <4>;
-+	cap-sdio-irq;
-+	cap-sd-highspeed;
-+	keep-power-in-suspend;
-+	mmc-pwrseq = <&sdio_pwrseq>;
-+	non-removable;
+ };
+ 
+ &pwm0 {
+@@ -772,6 +868,7 @@
+ 	keep-power-in-suspend;
+ 	mmc-pwrseq = <&sdio_pwrseq>;
+ 	non-removable;
 +	num-slots = <1>;
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&sdio0_bus4 &sdio0_cmd &sdio0_clk>;
-+	sd-uhs-sdr104;
-+
-+	/* Power supply */
-+	vqmmc-supply = <&vcc1v8_s3>;	/* IO line */
-+	vmmc-supply = <&vcc_sdio>;	/* card's power */
-+
-+	status = "okay";
-+
-+	brcmf: wifi@1 {
-+		compatible = "brcm,bcm4329-fmac";
-+		interrupt-parent = <&gpio0>;
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&sdio0_bus4 &sdio0_cmd &sdio0_clk>;
+ 	sd-uhs-sdr104;
+@@ -780,15 +877,12 @@
+ 	vqmmc-supply = <&vcc1v8_s3>;	/* IO line */
+ 	vmmc-supply = <&vcc_sdio>;	/* card's power */
+ 
+-	#address-cells = <1>;
+-	#size-cells = <0>;
+ 	status = "okay";
+ 
+ 	brcmf: wifi@1 {
+-		reg = <1>;
+ 		compatible = "brcm,bcm4329-fmac";
+ 		interrupt-parent = <&gpio0>;
+-		interrupts = <RK_PA3 IRQ_TYPE_LEVEL_HIGH>;
 +		interrupts = <RK_PA3 GPIO_ACTIVE_HIGH>;
-+		interrupt-names = "host-wake";
-+		brcm,drive-strength = <5>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&wifi_host_wake_l>;
-+	};
-+};
-+
-+&uart0 {
-+	pinctrl-names = "default";
+ 		interrupt-names = "host-wake";
+ 		brcm,drive-strength = <5>;
+ 		pinctrl-names = "default";
+@@ -885,8 +979,22 @@
+ 
+ &uart0 {
+ 	pinctrl-names = "default";
+-	pinctrl-0 = <&uart0_xfer &uart0_cts>;
 +	pinctrl-0 = <&uart0_xfer &uart0_rts &uart0_cts>;
-+	status = "okay";
+ 	status = "okay";
 +
 +	bluetooth {
 +		compatible = "brcm,bcm43438-bt";
@@ -1070,5 +410,20 @@ index c654b6b02f3..f73f792eb44 100644
 +		vbat-supply = <&vcc3v3_sys>;
 +		vddio-supply = <&vcc_1v8>;
 +	};
+ };
+ 
+ &uart2 {
+@@ -915,7 +1023,6 @@
+ 
+ &usbdrd_dwc3_0 {
+ 	status = "okay";
+-	dr_mode = "otg";
+ };
+ 
+ &usbdrd3_1 {
+@@ -941,4 +1048,4 @@
+ 
+ &vopl_mmu {
+ 	status = "okay";
+-};
 +};
-


### PR DESCRIPTION
# Description

I'm sorry, the error on the 6.8 kernel occurred because I didn't synchronize my code in time, resulting in patch errors that affected the compilation.

Based on the hints here, I am optimizing the device tree for the firefly-rk3399 kernel:
https://github.com/armbian/build/pull/6611

# How Has This Been Tested?

- [x] Almost all hardware functions(HDMI, WiFi, BT, GbE, USB...).
- [x] System startup.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
