### PR TITLE
rock-5c: rename wifi interface name to a static one

### DIFF
--- a/config/boards/rock-5c.conf
+++ b/config/boards/rock-5c.conf
@@ -28,3 +28,12 @@ function post_family_tweaks__rock5c_naming_audios() {
 
 	return 0
 }
+
+function post_family_tweaks__rock5c_naming_wireless_interface() {
+	display_alert "$BOARD" "Renaming rock5c wifi" "info"
+
+	mkdir -p $SDCARD/etc/udev/rules.d/
+	echo 'SUBSYSTEM=="net", ACTION=="add", ATTR{address}=="88:00:*", NAME="$ENV{ID_NET_SLOT}"' > $SDCARD/etc/udev/rules.d/99-radxa-aic8800.rules
+
+	return 0
+}


### PR DESCRIPTION
# Description

Issue reported from radxa's forum: https://forum.radxa.com/t/the-changable-wifi-interface-name-of-rock-5c-lite/20921
Rock5c has an onboard aic8800 usb wifi/bt module, which has random wifi interface name by default, which will cause non-static connection name created by networkmanager.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `PREFER_DOCKER=no ./compile.sh kernel BOARD=rock-5c BRANCH=vendor BUILD_DESKTOP=yes BUILD_MINIMAL=no DEB_COMPRESS=xz KERNEL_CONFIGURE=no RELEASE=jammy KERNEL_GIT=shallow DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
