### PR TITLE
khadas-vim3: fix stray closing brace in board file

### DIFF
--- a/config/boards/khadas-vim3.conf
+++ b/config/boards/khadas-vim3.conf
@@ -57,5 +57,5 @@ function post_config_uboot_target__extra_configs_for_khadas_vim3() {
 	run_host_command_logged scripts/config --enable CONFIG_CMD_WGET
 	run_host_command_logged scripts/config --enable CONFIG_CMD_DNS
 	run_host_command_logged scripts/config --enable CONFIG_PROT_TCP
-	run_host_command_logged scripts/config --enable CONFIG_PROT_TCP_SACK}
+	run_host_command_logged scripts/config --enable CONFIG_PROT_TCP_SACK
 }


### PR DESCRIPTION
#### khadas-vim3: fix stray closing brace in board file

- khadas-vim3: fix stray closing brace in board file
  - a stray closing brace, meant for the function, that ends up doing the wrong config change