### PR TITLE
lib & config: give shellcheck directions (to /dev/null for dynamic, to repo-relative path for static) for all sourced references

### DIFF
--- a/config/sources/families/imx8m.conf
+++ b/config/sources/families/imx8m.conf
@@ -7,6 +7,7 @@
 # https://github.com/armbian/build/
 #
 
+# shellcheck source=config/sources/families/include/imx8_common.inc
 source "${BASH_SOURCE%/*}/include/imx8_common.inc"
 OFFSET=32
 

--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -18,6 +18,7 @@ UBOOT_TARGET_MAP="${UBOOT_TARGET_MAP:-BINMAN_ALLOW_MISSING=1;;u-boot-sunxi-with-
 declare -g BOOTSCRIPT='boot-sun50i-next.cmd:boot.cmd'
 declare -g LINUXFAMILY=sunxi64
 
+# shellcheck source=config/sources/families/include/crust_firmware.inc
 source "${BASH_SOURCE%/*}/crust_firmware.inc"
 
 case $BRANCH in

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -19,6 +19,7 @@ declare -g UBOOT_FW_ENV='0x88000,0x20000' # /etc/fw_env.config offset and env si
 declare -g ASOUND_STATE='asound.state.sunxi-next'
 declare -g GOVERNOR=ondemand
 
+# shellcheck source=config/sources/families/include/crust_firmware.inc
 source "${BASH_SOURCE%/*}/crust_firmware.inc"
 
 case $BRANCH in

--- a/config/sources/families/jethub.conf
+++ b/config/sources/families/jethub.conf
@@ -8,6 +8,7 @@
 # https://github.com/armbian/build/
 #
 
+# shellcheck source=config/sources/families/include/meson64_common.inc
 source "${BASH_SOURCE%/*}/include/meson64_common.inc"
 
 UBOOT_TARGET_MAP="u-boot-dtb.img;;u-boot.bin.sd.bin:u-boot.bin u-boot.bin:u-boot.nosd.bin u-boot-dtb.img"

--- a/config/sources/families/media.conf
+++ b/config/sources/families/media.conf
@@ -6,6 +6,7 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 #
+# shellcheck source=config/sources/families/include/rockchip64_common.inc
 source "${BASH_SOURCE%/*}/include/rockchip64_common.inc"
 
 if [[ $BOARD == station-p2 || $BOARD == station-m2 ]]; then

--- a/config/sources/families/meson-g12a.conf
+++ b/config/sources/families/meson-g12a.conf
@@ -6,6 +6,7 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 #
+# shellcheck source=config/sources/families/include/meson64_common.inc
 source "${BASH_SOURCE%/*}/include/meson64_common.inc"
 ASOUND_STATE="${ASOUND_STATE:-"asound.state.meson64"}"
 

--- a/config/sources/families/meson-g12b.conf
+++ b/config/sources/families/meson-g12b.conf
@@ -6,6 +6,7 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 #
+# shellcheck source=config/sources/families/include/meson64_common.inc
 source "${BASH_SOURCE%/*}/include/meson64_common.inc"
 ASOUND_STATE="${ASOUND_STATE:-"asound.state.meson64"}"
 

--- a/config/sources/families/meson-gxbb.conf
+++ b/config/sources/families/meson-gxbb.conf
@@ -6,6 +6,7 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 #
+# shellcheck source=config/sources/families/include/meson64_common.inc
 source "${BASH_SOURCE%/*}/include/meson64_common.inc"
 
 # Fetch c2 blobs. Those are ancient, when first released by HK. Also used in meson-gxl.conf

--- a/config/sources/families/meson-gxl.conf
+++ b/config/sources/families/meson-gxl.conf
@@ -6,6 +6,7 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 #
+# shellcheck source=config/sources/families/include/meson64_common.inc
 source "${BASH_SOURCE%/*}/include/meson64_common.inc"
 
 # Fetch c2 blobs. Those are ancient, when first released by HK. Also used in meson-gxbb.conf

--- a/config/sources/families/meson-sm1.conf
+++ b/config/sources/families/meson-sm1.conf
@@ -6,6 +6,7 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 #
+# shellcheck source=config/sources/families/include/meson64_common.inc
 source "${BASH_SOURCE%/*}/include/meson64_common.inc"
 ASOUND_STATE="${ASOUND_STATE:-"asound.state.meson64"}"
 CPUMIN=667000

--- a/config/sources/families/meson8b.conf
+++ b/config/sources/families/meson8b.conf
@@ -6,4 +6,5 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 #
+# shellcheck source=config/sources/families/include/meson_common.inc
 source "${BASH_SOURCE%/*}/include/meson_common.inc"

--- a/config/sources/families/mvebu.conf
+++ b/config/sources/families/mvebu.conf
@@ -9,9 +9,11 @@
 enable_extension "marvell-tools"
 ARCH=armhf
 if [[ $BOARD == helios4 ]]; then
+	# shellcheck source=config/sources/families/include/mvebu-helios4.inc
 	source "${BASH_SOURCE%/*}/include/mvebu-helios4.inc"
 	BOOTENV_FILE='helios4.txt'
 else
+	# shellcheck source=config/sources/families/include/mvebu-clearfog.inc
 	source "${BASH_SOURCE%/*}/include/mvebu-clearfog.inc"
 	BOOTENV_FILE='clearfog.txt'
 fi

--- a/config/sources/families/rk35xx.conf
+++ b/config/sources/families/rk35xx.conf
@@ -6,6 +6,7 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 #
+# shellcheck source=config/sources/families/include/rockchip64_common.inc
 source "${BASH_SOURCE%/*}/include/rockchip64_common.inc"
 
 BOOTSOURCE='https://github.com/radxa/u-boot.git'

--- a/config/sources/families/rock-s0.conf
+++ b/config/sources/families/rock-s0.conf
@@ -6,6 +6,7 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 #
+# shellcheck source=config/sources/families/include/rockchip64_common.inc
 source "${BASH_SOURCE%/*}/include/rockchip64_common.inc"
 BOOTENV_FILE='rockpis.txt'
 OVERLAY_PREFIX='rk3308'

--- a/config/sources/families/rockchip-rk3588.conf
+++ b/config/sources/families/rockchip-rk3588.conf
@@ -6,6 +6,7 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 #
+# shellcheck source=config/sources/families/include/rockchip64_common.inc
 source "${BASH_SOURCE%/*}/include/rockchip64_common.inc"
 
 BOOTSOURCE='https://github.com/radxa/u-boot.git'

--- a/config/sources/families/rockchip64.conf
+++ b/config/sources/families/rockchip64.conf
@@ -6,5 +6,6 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 #
+# shellcheck source=config/sources/families/include/rockchip64_common.inc
 source "${BASH_SOURCE%/*}/include/rockchip64_common.inc"
 prepare_boot_configuration

--- a/config/sources/families/rockpis.conf
+++ b/config/sources/families/rockpis.conf
@@ -6,6 +6,7 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 #
+# shellcheck source=config/sources/families/include/rockchip64_common.inc
 source "${BASH_SOURCE%/*}/include/rockchip64_common.inc"
 #BOOTPATCHDIR="u-boot-rockchip64"
 BOOTENV_FILE='rockpis.txt'

--- a/config/sources/families/sun4i.conf
+++ b/config/sources/families/sun4i.conf
@@ -6,6 +6,7 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 #
+# shellcheck source=config/sources/families/include/sunxi_common.inc
 source "${BASH_SOURCE%/*}/include/sunxi_common.inc"
 OVERLAY_PREFIX='sun4i-a10'
 [[ -z $CPUMIN ]] && CPUMIN=480000

--- a/config/sources/families/sun50iw1.conf
+++ b/config/sources/families/sun50iw1.conf
@@ -7,6 +7,7 @@
 # https://github.com/armbian/build/
 #
 ATF_PLAT="sun50i_a64"
+# shellcheck source=config/sources/families/include/sunxi64_common.inc
 source "${BASH_SOURCE%/*}/include/sunxi64_common.inc"
 OVERLAY_PREFIX='sun50i-a64'
 [[ -z $CPUMIN ]] && CPUMIN=480000

--- a/config/sources/families/sun50iw2.conf
+++ b/config/sources/families/sun50iw2.conf
@@ -7,6 +7,7 @@
 # https://github.com/armbian/build/
 #
 ATF_PLAT="sun50i_a64"
+# shellcheck source=config/sources/families/include/sunxi64_common.inc
 source "${BASH_SOURCE%/*}/include/sunxi64_common.inc"
 OVERLAY_PREFIX='sun50i-h5'
 [[ -z $CPUMIN ]] && CPUMIN=480000

--- a/config/sources/families/sun50iw6.conf
+++ b/config/sources/families/sun50iw6.conf
@@ -7,6 +7,7 @@
 # https://github.com/armbian/build/
 #
 ATF_PLAT="sun50i_h6"
+# shellcheck source=config/sources/families/include/sunxi64_common.inc
 source "${BASH_SOURCE%/*}/include/sunxi64_common.inc"
 OVERLAY_PREFIX='sun50i-h6'
 [[ -z $CPUMIN ]] && CPUMIN=480000

--- a/config/sources/families/sun50iw9-bpi.conf
+++ b/config/sources/families/sun50iw9-bpi.conf
@@ -6,6 +6,7 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 #
+# shellcheck source=config/sources/families/include/sunxi64_common.inc
 source "${BASH_SOURCE%/*}/include/sunxi64_common.inc"
 
 [[ -z $CPUMIN ]] && CPUMIN=480000

--- a/config/sources/families/sun50iw9-btt.conf
+++ b/config/sources/families/sun50iw9-btt.conf
@@ -6,6 +6,7 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 #
+# shellcheck source=config/sources/families/include/sunxi64_common.inc
 source "${BASH_SOURCE%/*}/include/sunxi64_common.inc"
 
 [[ -z $CPUMIN ]] && CPUMIN=480000

--- a/config/sources/families/sun50iw9.conf
+++ b/config/sources/families/sun50iw9.conf
@@ -6,6 +6,7 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 #
+# shellcheck source=config/sources/families/include/sunxi64_common.inc
 source "${BASH_SOURCE%/*}/include/sunxi64_common.inc"
 
 [[ -z $CPUMIN ]] && CPUMIN=480000

--- a/config/sources/families/sun5i.conf
+++ b/config/sources/families/sun5i.conf
@@ -6,6 +6,7 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 #
+# shellcheck source=config/sources/families/include/sunxi_common.inc
 source "${BASH_SOURCE%/*}/include/sunxi_common.inc"
 OVERLAY_PREFIX='sun5i-a13'
 [[ -z $CPUMIN ]] && CPUMIN=480000

--- a/config/sources/families/sun6i.conf
+++ b/config/sources/families/sun6i.conf
@@ -6,6 +6,7 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 #
+# shellcheck source=config/sources/families/include/sunxi_common.inc
 source "${BASH_SOURCE%/*}/include/sunxi_common.inc"
 OVERLAY_PREFIX='sun6i-a31s'
 [[ -z $CPUMIN ]] && CPUMIN=480000

--- a/config/sources/families/sun7i.conf
+++ b/config/sources/families/sun7i.conf
@@ -6,6 +6,7 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 #
+# shellcheck source=config/sources/families/include/sunxi_common.inc
 source "${BASH_SOURCE%/*}/include/sunxi_common.inc"
 OVERLAY_PREFIX='sun7i-a20'
 [[ -z $CPUMIN ]] && CPUMIN=480000

--- a/config/sources/families/sun8i-v3s.conf
+++ b/config/sources/families/sun8i-v3s.conf
@@ -6,6 +6,7 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 #
+# shellcheck source=config/sources/families/include/sunxi_common.inc
 source "${BASH_SOURCE%/*}/include/sunxi_common.inc"
 
 OVERLAY_PREFIX='sun8i-v3s'

--- a/config/sources/families/sun8i.conf
+++ b/config/sources/families/sun8i.conf
@@ -6,6 +6,7 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 #
+# shellcheck source=config/sources/families/include/sunxi_common.inc
 source "${BASH_SOURCE%/*}/include/sunxi_common.inc"
 
 if [[ -z ${OVERLAY_PREFIX} ]]; then

--- a/config/sources/families/sun9i.conf
+++ b/config/sources/families/sun9i.conf
@@ -6,4 +6,5 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 #
+# shellcheck source=config/sources/families/include/sunxi_common.inc
 source "${BASH_SOURCE%/*}/include/sunxi_common.inc"

--- a/config/sources/families/uefi-arm64.conf
+++ b/config/sources/families/uefi-arm64.conf
@@ -10,5 +10,6 @@
 declare -g UEFI_GRUB_TERMINAL="gfxterm" # Use graphics in grub, for the Armbian wallpaper.
 declare -g LINUXFAMILY="arm64"
 declare -g ARCH="arm64"
+# shellcheck source=config/sources/families/include/uefi_common.inc
 source "${BASH_SOURCE%/*}/include/uefi_common.inc"
 enable_extension "grub"

--- a/config/sources/families/uefi-riscv64.conf
+++ b/config/sources/families/uefi-riscv64.conf
@@ -11,5 +11,6 @@ declare -g UBOOT_USE_GCC="none"
 declare -g UEFI_GRUB_TERMINAL="gfxterm"
 declare -g LINUXFAMILY="riscv64"
 declare -g ARCH="riscv64"
+# shellcheck source=config/sources/families/include/uefi_common.inc
 source "${BASH_SOURCE%/*}/include/uefi_common.inc"
 enable_extension "grub-riscv64"

--- a/config/sources/families/uefi-x86.conf
+++ b/config/sources/families/uefi-x86.conf
@@ -10,5 +10,6 @@
 declare -g UEFI_GRUB_TERMINAL="${UEFI_GRUB_TERMINAL:-gfxterm}"
 declare -g LINUXFAMILY="x86"
 declare -g ARCH="amd64"
+# shellcheck source=config/sources/families/include/uefi_common.inc
 source "${BASH_SOURCE%/*}/include/uefi_common.inc"
 enable_extension "grub"

--- a/lib/functions/bsp/armbian-bsp-cli-deb.sh
+++ b/lib/functions/bsp/armbian-bsp-cli-deb.sh
@@ -409,6 +409,7 @@ function board_side_bsp_cli_postrm() { # not run here
 
 function board_side_bsp_cli_postinst_base() {
 	# Source the armbian-release information file
+	# shellcheck source=/dev/null
 	[ -f /etc/armbian-release ] && . /etc/armbian-release
 
 	# ARMBIAN_PRETTY_NAME is now set in armbian-base-files.

--- a/lib/functions/compilation/uboot.sh
+++ b/lib/functions/compilation/uboot.sh
@@ -443,7 +443,9 @@ function compile_uboot() {
 
 function uboot_postinst_base() {
 	# Source the armbian-release information file
+	# shellcheck source=/dev/null
 	[ -f /etc/armbian-release ] && . /etc/armbian-release
+	# shellcheck source=/dev/null
 	source /usr/lib/u-boot/platform_install.sh
 
 	if [ "${FORCE_UBOOT_UPDATE:-no}" == "yes" ]; then

--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -358,6 +358,7 @@ function do_extra_configuration() {
 	#         in case the user tries to use them in lib.config, hopefully they'll be detected as "wishful hooking" and the user will be wrn'ed.
 	if [[ -f $USERPATCHES_PATH/lib.config ]]; then
 		display_alert "Using user configuration override" "$USERPATCHES_PATH/lib.config" "info"
+		# shellcheck source=/dev/null
 		source "$USERPATCHES_PATH"/lib.config
 		track_general_config_variables "after sourcing lib.config"
 	fi

--- a/lib/functions/image/loop.sh
+++ b/lib/functions/image/loop.sh
@@ -82,6 +82,7 @@ function write_uboot_to_loop_image() {
 	fi
 
 	display_alert "Sourcing u-boot install functions" "${uboot_deb}" "info"
+	# shellcheck source=/dev/null
 	source "${TEMP_DIR}"/usr/lib/u-boot/platform_install.sh
 	set -e # make sure, we just included something that might disable it
 

--- a/lib/functions/rootfs/customize.sh
+++ b/lib/functions/rootfs/customize.sh
@@ -10,6 +10,7 @@
 customize_image() {
 
 	# for users that need to prepare files at host
+	# shellcheck source=/dev/null
 	[[ -f $USERPATCHES_PATH/customize-image-host.sh ]] && source "$USERPATCHES_PATH"/customize-image-host.sh
 
 	call_extension_method "pre_customize_image" "image_tweaks_pre_customize" <<- 'PRE_CUSTOMIZE_IMAGE'


### PR DESCRIPTION
#### lib & config: give shellcheck directions (to /dev/null for dynamic, to repo-relative path for static) for all sourced references

- lib & config: give shellcheck directions (to /dev/null for dynamic, to repo-relative path for static) for all sourced references
  - in preparation for tightening the shellcheck severity level
    - it needs to be able to follow all sources; dynamic ones are ignored, static ones need root-relative prefix