### PR TITLE
Optimize the kernel device tree patch for rk3399-firefly.

### DIFF
--- a/patch/kernel/archive/rockchip64-6.6/board-firefly-rk3399-dts.patch
+++ b/patch/kernel/archive/rockchip64-6.6/board-firefly-rk3399-dts.patch
@@ -1,64 +1,16 @@
 index c654b6b02f3..f73f792eb44 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts
-@@ -177,6 +177,15 @@
- 		};
- 	};
- 
-+	vcc_vbus_typec0: vcc-vbus-typec0 {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc_vbus_typec0";
-+		regulator-always-on;
-+		regulator-boot-on;
-+		regulator-min-microvolt = <5000000>;
-+		regulator-max-microvolt = <5000000>;
-+	};
-+
- 	/* switched by pmic_sleep */
- 	vcc1v8_s3: vcca1v8_s3: vcc1v8-s3 {
- 		compatible = "regulator-fixed";
-@@ -188,15 +197,15 @@
- 		vin-supply = <&vcc_1v8>;
- 	};
- 
--	vcc3v3_pcie: vcc3v3-pcie-regulator {
-+	vcc3v3_pcie: vcc3v3-pcie {
- 		compatible = "regulator-fixed";
-+		regulator-name = "vcc3v3_pcie";
- 		enable-active-high;
- 		gpio = <&gpio1 RK_PC1 GPIO_ACTIVE_HIGH>;
- 		pinctrl-names = "default";
--		pinctrl-0 = <&pcie_pwr_en>;
--		regulator-name = "vcc3v3_pcie";
--		regulator-always-on;
--		regulator-boot-on;
-+		pinctrl-0 = <&vcc3v3_pcie_en>;
-+		regulator-min-microvolt = <3300000>;
-+		regulator-max-microvolt = <3300000>;
- 		vin-supply = <&dc_12v>;
- 	};
- 
-@@ -207,7 +216,7 @@
- 		regulator-boot-on;
- 		regulator-min-microvolt = <3300000>;
- 		regulator-max-microvolt = <3300000>;
--		vin-supply = <&vcc_sys>;
-+		vin-supply = <&dc_12v>;
- 	};
- 
- 	/* Actually 3 regulators (host0, 1, 2) controlled by the same gpio */
-@@ -216,9 +225,8 @@
+@@ -216,7 +216,7 @@
  		enable-active-high;
  		gpio = <&gpio1 RK_PA0 GPIO_ACTIVE_HIGH>;
  		pinctrl-names = "default";
 -		pinctrl-0 = <&vcc5v0_host_en>;
 +		pinctrl-0 = <&vcc5v0_host_en &hub_rst>;
  		regulator-name = "vcc5v0_host";
--		regulator-always-on;
+ 		regulator-always-on;
  		vin-supply = <&vcc_sys>;
- 	};
- 
-@@ -235,8 +243,11 @@
+@@ -235,8 +235,11 @@
  
  	vcc_sys: vcc-sys {
  		compatible = "regulator-fixed";
@@ -71,7 +23,7 @@ index c654b6b02f3..f73f792eb44 100644
  		regulator-boot-on;
  		regulator-min-microvolt = <5000000>;
  		regulator-max-microvolt = <5000000>;
-@@ -253,6 +264,41 @@
+@@ -253,6 +256,27 @@
  		regulator-min-microvolt = <430000>;
  		regulator-max-microvolt = <1400000>;
  	};
@@ -84,20 +36,6 @@ index c654b6b02f3..f73f792eb44 100644
 +		regulator-min-microvolt = <900000>;
 +		regulator-max-microvolt = <900000>;
 +		vin-supply = <&vcc3v3_sys>;
-+	};
-+
-+	vcc3v3_ngff: vcc3v3-ngff {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc3v3_ngff";
-+		enable-active-high;
-+		gpio = <&gpio4 RK_PD3 GPIO_ACTIVE_HIGH>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&vcc3v3_ngff_en>;
-+		regulator-always-on;
-+		regulator-boot-on;
-+		regulator-min-microvolt = <3300000>;
-+		regulator-max-microvolt = <3300000>;
-+		vin-supply = <&dc_12v>;
 +	};
 +	
 +	vcc3v3_3g: vcc3v3-3g-regulator {
@@ -113,7 +51,7 @@ index c654b6b02f3..f73f792eb44 100644
  };
  
  &cpu_l0 {
-@@ -305,6 +351,8 @@
+@@ -305,6 +329,8 @@
  };
  
  &hdmi {
@@ -122,7 +60,7 @@ index c654b6b02f3..f73f792eb44 100644
  	ddc-i2c-bus = <&i2c3>;
  	pinctrl-names = "default";
  	pinctrl-0 = <&hdmi_cec>;
-@@ -329,18 +377,18 @@
+@@ -329,18 +355,18 @@
  		rockchip,system-power-controller;
  		wakeup-source;
  
@@ -151,7 +89,7 @@ index c654b6b02f3..f73f792eb44 100644
  
  		regulators {
  			vdd_center: DCDC_REG1 {
-@@ -388,8 +436,8 @@
+@@ -388,8 +414,8 @@
  				};
  			};
  
@@ -162,7 +100,7 @@ index c654b6b02f3..f73f792eb44 100644
  				regulator-always-on;
  				regulator-boot-on;
  				regulator-min-microvolt = <1800000>;
-@@ -399,12 +447,12 @@
+@@ -399,12 +425,12 @@
  				};
  			};
  
@@ -179,7 +117,7 @@ index c654b6b02f3..f73f792eb44 100644
  				regulator-state-mem {
  					regulator-off-in-suspend;
  				};
-@@ -457,12 +505,12 @@
+@@ -457,12 +483,12 @@
  				};
  			};
  
@@ -196,7 +134,7 @@ index c654b6b02f3..f73f792eb44 100644
  				regulator-state-mem {
  					regulator-off-in-suspend;
  				};
-@@ -503,14 +551,16 @@
+@@ -503,14 +529,16 @@
  	vdd_cpu_b: regulator@40 {
  		compatible = "silergy,syr827";
  		reg = <0x40>;
@@ -215,7 +153,7 @@ index c654b6b02f3..f73f792eb44 100644
  
  		regulator-state-mem {
  			regulator-off-in-suspend;
-@@ -521,18 +571,31 @@
+@@ -521,13 +549,15 @@
  		compatible = "silergy,syr828";
  		reg = <0x41>;
  		fcs,suspend-voltage-selector = <1>;
@@ -232,23 +170,7 @@ index c654b6b02f3..f73f792eb44 100644
  
  		regulator-state-mem {
  			regulator-off-in-suspend;
- 		};
- 	};
-+
-+	hym8563: hym8563@51 {
-+		compatible = "haoyu,hym8563";
-+		reg = <0x51>;
-+		interrupt-parent = <&gpio0>;
-+		interrupts = <5 IRQ_TYPE_EDGE_FALLING>;
-+		pinctrl-names = "default";
-+		#clock-cells = <0>;
-+		clock-frequency = <32768>;
-+		clock-output-names = "xin32k";
-+	};
- };
- 
- &i2c1 {
-@@ -564,7 +627,7 @@
+@@ -564,7 +594,7 @@
  	status = "okay";
  
  	fusb0: typec-portc@22 {
@@ -257,23 +179,16 @@ index c654b6b02f3..f73f792eb44 100644
  		reg = <0x22>;
  		interrupt-parent = <&gpio1>;
  		interrupts = <RK_PA2 IRQ_TYPE_LEVEL_LOW>;
-@@ -635,12 +698,11 @@
- };
- 
+@@ -637,7 +667,7 @@
  &io_domains {
--	status = "okay";
--
--	bt656-supply = <&vcc1v8_dvp>;
- 	audio-supply = <&vcca1v8_codec>;
--	sdmmc-supply = <&vcc_sdio>;
-+	bt656-supply = <&vcc_3v0>;
- 	gpio1830-supply = <&vcc_3v0>;
-+	sdmmc-supply = <&vcc_sdio>;
-+	status = "okay";
- };
+ 	status = "okay";
  
- &pcie_phy {
-@@ -651,7 +713,10 @@
+-	bt656-supply = <&vcc1v8_dvp>;
++	bt656-supply = <&vcc_3v0>;
+ 	audio-supply = <&vcca1v8_codec>;
+ 	sdmmc-supply = <&vcc_sdio>;
+ 	gpio1830-supply = <&vcc_3v0>;
+@@ -651,7 +681,10 @@
  	ep-gpios = <&gpio4 RK_PD1 GPIO_ACTIVE_HIGH>;
  	num-lanes = <4>;
  	pinctrl-names = "default";
@@ -285,44 +200,18 @@ index c654b6b02f3..f73f792eb44 100644
  	status = "okay";
  };
  
-@@ -696,20 +761,20 @@
- 	};
- 
- 	pcie {
--		pcie_pwr_en: pcie-pwr-en {
-+		vcc3v3_pcie_en: vcc3v3-pcie-en {
- 			rockchip,pins = <1 RK_PC1 RK_FUNC_GPIO &pcfg_pull_none>;
- 		};
- 
-+		pcie_perst: pcie-perst {
-+			rockchip,pins = <4 RK_PD1 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+
+@@ -703,6 +736,10 @@
  		pcie_3g_drv: pcie-3g-drv {
  			rockchip,pins = <0 RK_PA2 RK_FUNC_GPIO &pcfg_pull_up>;
  		};
- 	};
- 
- 	pmic {
--		pmic_int_l: pmic-int-l {
--			rockchip,pins = <1 RK_PC5 RK_FUNC_GPIO &pcfg_pull_up>;
--		};
--
- 		vsel1_pin: vsel1-pin {
- 			rockchip,pins = <1 RK_PC2 RK_FUNC_GPIO &pcfg_pull_down>;
- 		};
-@@ -717,6 +782,10 @@
- 		vsel2_pin: vsel2-pin {
- 			rockchip,pins = <1 RK_PB6 RK_FUNC_GPIO &pcfg_pull_down>;
- 		};
 +
-+		pmic_int_l: pmic-int-l {
-+			rockchip,pins = <1 RK_PC5 RK_FUNC_GPIO &pcfg_pull_up>;
++		pcie_perst: pcie-perst {
++			rockchip,pins = <4 RK_PD1 RK_FUNC_GPIO &pcfg_pull_none>;
 +		};
  	};
  
- 	rt5640 {
-@@ -741,6 +810,14 @@
+ 	pmic {
+@@ -741,6 +778,14 @@
  		vcc5v0_host_en: vcc5v0-host-en {
  			rockchip,pins = <1 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
  		};
@@ -337,16 +226,10 @@ index c654b6b02f3..f73f792eb44 100644
  	};
  
  	wifi {
-@@ -748,6 +825,26 @@
+@@ -748,6 +793,20 @@
  			rockchip,pins = <0 RK_PA3 RK_FUNC_GPIO &pcfg_pull_none>;
  		};
  	};
-+
-+	ngff {
-+		vcc3v3_ngff_en: vcc3v3-ngff-en {
-+			rockchip,pins = <4 RK_PD3 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
 +
 +	bt {
 +		bt_host_wake_l: bt-host-wake-l {
@@ -364,24 +247,8 @@ index c654b6b02f3..f73f792eb44 100644
  };
  
  &pwm0 {
-@@ -771,6 +868,7 @@
- 	keep-power-in-suspend;
- 	mmc-pwrseq = <&sdio_pwrseq>;
- 	non-removable;
-+	num-slots = <1>;
- 	pinctrl-names = "default";
- 	pinctrl-0 = <&sdio0_bus4 &sdio0_cmd &sdio0_clk>;
- 	sd-uhs-sdr104;
-@@ -779,15 +877,12 @@
- 	vqmmc-supply = <&vcc1v8_s3>;	/* IO line */
- 	vmmc-supply = <&vcc_sdio>;	/* card's power */
- 
--	#address-cells = <1>;
--	#size-cells = <0>;
- 	status = "okay";
- 
- 	brcmf: wifi@1 {
--		reg = <1>;
+@@ -787,7 +846,7 @@
+ 		reg = <1>;
  		compatible = "brcm,bcm4329-fmac";
  		interrupt-parent = <&gpio0>;
 -		interrupts = <RK_PA3 IRQ_TYPE_LEVEL_HIGH>;
@@ -389,7 +256,7 @@ index c654b6b02f3..f73f792eb44 100644
  		interrupt-names = "host-wake";
  		brcm,drive-strength = <5>;
  		pinctrl-names = "default";
-@@ -884,8 +979,22 @@
+@@ -884,8 +943,22 @@
  
  &uart0 {
  	pinctrl-names = "default";
@@ -413,17 +280,3 @@ index c654b6b02f3..f73f792eb44 100644
  };
  
  &uart2 {
-@@ -914,7 +1023,6 @@
- 
- &usbdrd_dwc3_0 {
- 	status = "okay";
--	dr_mode = "otg";
- };
- 
- &usbdrd3_1 {
-@@ -940,4 +1048,4 @@
- 
- &vopl_mmu {
- 	status = "okay";
--};
-+};

--- a/patch/kernel/archive/rockchip64-6.8/board-firefly-rk3399-dts.patch
+++ b/patch/kernel/archive/rockchip64-6.8/board-firefly-rk3399-dts.patch
@@ -1,64 +1,16 @@
 index c654b6b02f3..f73f792eb44 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-firefly.dts
-@@ -178,6 +177,15 @@
- 		};
- 	};
- 
-+	vcc_vbus_typec0: vcc-vbus-typec0 {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc_vbus_typec0";
-+		regulator-always-on;
-+		regulator-boot-on;
-+		regulator-min-microvolt = <5000000>;
-+		regulator-max-microvolt = <5000000>;
-+	};
-+
- 	/* switched by pmic_sleep */
- 	vcc1v8_s3: vcca1v8_s3: vcc1v8-s3 {
- 		compatible = "regulator-fixed";
-@@ -189,15 +197,15 @@
- 		vin-supply = <&vcc_1v8>;
- 	};
- 
--	vcc3v3_pcie: vcc3v3-pcie-regulator {
-+	vcc3v3_pcie: vcc3v3-pcie {
- 		compatible = "regulator-fixed";
-+		regulator-name = "vcc3v3_pcie";
- 		enable-active-high;
- 		gpio = <&gpio1 RK_PC1 GPIO_ACTIVE_HIGH>;
- 		pinctrl-names = "default";
--		pinctrl-0 = <&pcie_pwr_en>;
--		regulator-name = "vcc3v3_pcie";
--		regulator-always-on;
--		regulator-boot-on;
-+		pinctrl-0 = <&vcc3v3_pcie_en>;
-+		regulator-min-microvolt = <3300000>;
-+		regulator-max-microvolt = <3300000>;
- 		vin-supply = <&dc_12v>;
- 	};
- 
-@@ -208,7 +216,7 @@
- 		regulator-boot-on;
- 		regulator-min-microvolt = <3300000>;
- 		regulator-max-microvolt = <3300000>;
--		vin-supply = <&vcc_sys>;
-+		vin-supply = <&dc_12v>;
- 	};
- 
- 	/* Actually 3 regulators (host0, 1, 2) controlled by the same gpio */
-@@ -217,9 +225,8 @@
+@@ -217,7 +216,7 @@
  		enable-active-high;
  		gpio = <&gpio1 RK_PA0 GPIO_ACTIVE_HIGH>;
  		pinctrl-names = "default";
 -		pinctrl-0 = <&vcc5v0_host_en>;
 +		pinctrl-0 = <&vcc5v0_host_en &hub_rst>;
  		regulator-name = "vcc5v0_host";
--		regulator-always-on;
+ 		regulator-always-on;
  		vin-supply = <&vcc_sys>;
- 	};
- 
-@@ -236,8 +243,11 @@
+@@ -236,8 +235,11 @@
  
  	vcc_sys: vcc-sys {
  		compatible = "regulator-fixed";
@@ -71,7 +23,7 @@ index c654b6b02f3..f73f792eb44 100644
  		regulator-boot-on;
  		regulator-min-microvolt = <5000000>;
  		regulator-max-microvolt = <5000000>;
-@@ -254,6 +264,41 @@
+@@ -254,6 +256,27 @@
  		regulator-min-microvolt = <430000>;
  		regulator-max-microvolt = <1400000>;
  	};
@@ -84,20 +36,6 @@ index c654b6b02f3..f73f792eb44 100644
 +		regulator-min-microvolt = <900000>;
 +		regulator-max-microvolt = <900000>;
 +		vin-supply = <&vcc3v3_sys>;
-+	};
-+
-+	vcc3v3_ngff: vcc3v3-ngff {
-+		compatible = "regulator-fixed";
-+		regulator-name = "vcc3v3_ngff";
-+		enable-active-high;
-+		gpio = <&gpio4 RK_PD3 GPIO_ACTIVE_HIGH>;
-+		pinctrl-names = "default";
-+		pinctrl-0 = <&vcc3v3_ngff_en>;
-+		regulator-always-on;
-+		regulator-boot-on;
-+		regulator-min-microvolt = <3300000>;
-+		regulator-max-microvolt = <3300000>;
-+		vin-supply = <&dc_12v>;
 +	};
 +	
 +	vcc3v3_3g: vcc3v3-3g-regulator {
@@ -113,7 +51,7 @@ index c654b6b02f3..f73f792eb44 100644
  };
  
  &cpu_l0 {
-@@ -306,6 +351,8 @@
+@@ -306,6 +329,8 @@
  };
  
  &hdmi {
@@ -122,7 +60,7 @@ index c654b6b02f3..f73f792eb44 100644
  	ddc-i2c-bus = <&i2c3>;
  	pinctrl-names = "default";
  	pinctrl-0 = <&hdmi_cec>;
-@@ -330,18 +377,18 @@
+@@ -330,18 +355,18 @@
  		rockchip,system-power-controller;
  		wakeup-source;
  
@@ -151,7 +89,7 @@ index c654b6b02f3..f73f792eb44 100644
  
  		regulators {
  			vdd_center: DCDC_REG1 {
-@@ -389,8 +436,8 @@
+@@ -389,8 +414,8 @@
  				};
  			};
  
@@ -162,7 +100,7 @@ index c654b6b02f3..f73f792eb44 100644
  				regulator-always-on;
  				regulator-boot-on;
  				regulator-min-microvolt = <1800000>;
-@@ -400,12 +447,12 @@
+@@ -400,12 +425,12 @@
  				};
  			};
  
@@ -179,7 +117,7 @@ index c654b6b02f3..f73f792eb44 100644
  				regulator-state-mem {
  					regulator-off-in-suspend;
  				};
-@@ -458,12 +505,12 @@
+@@ -458,12 +483,12 @@
  				};
  			};
  
@@ -196,7 +134,7 @@ index c654b6b02f3..f73f792eb44 100644
  				regulator-state-mem {
  					regulator-off-in-suspend;
  				};
-@@ -504,14 +551,16 @@
+@@ -504,14 +529,16 @@
  	vdd_cpu_b: regulator@40 {
  		compatible = "silergy,syr827";
  		reg = <0x40>;
@@ -215,7 +153,7 @@ index c654b6b02f3..f73f792eb44 100644
  
  		regulator-state-mem {
  			regulator-off-in-suspend;
-@@ -522,18 +571,31 @@
+@@ -522,13 +549,15 @@
  		compatible = "silergy,syr828";
  		reg = <0x41>;
  		fcs,suspend-voltage-selector = <1>;
@@ -232,23 +170,7 @@ index c654b6b02f3..f73f792eb44 100644
  
  		regulator-state-mem {
  			regulator-off-in-suspend;
- 		};
- 	};
-+
-+	hym8563: hym8563@51 {
-+		compatible = "haoyu,hym8563";
-+		reg = <0x51>;
-+		interrupt-parent = <&gpio0>;
-+		interrupts = <5 IRQ_TYPE_EDGE_FALLING>;
-+		pinctrl-names = "default";
-+		#clock-cells = <0>;
-+		clock-frequency = <32768>;
-+		clock-output-names = "xin32k";
-+	};
- };
- 
- &i2c1 {
-@@ -565,7 +627,7 @@
+@@ -565,7 +594,7 @@
  	status = "okay";
  
  	fusb0: typec-portc@22 {
@@ -257,23 +179,16 @@ index c654b6b02f3..f73f792eb44 100644
  		reg = <0x22>;
  		interrupt-parent = <&gpio1>;
  		interrupts = <RK_PA2 IRQ_TYPE_LEVEL_LOW>;
-@@ -636,12 +698,11 @@
- };
- 
+@@ -638,7 +667,7 @@
  &io_domains {
--	status = "okay";
--
--	bt656-supply = <&vcc1v8_dvp>;
- 	audio-supply = <&vcca1v8_codec>;
--	sdmmc-supply = <&vcc_sdio>;
-+	bt656-supply = <&vcc_3v0>;
- 	gpio1830-supply = <&vcc_3v0>;
-+	sdmmc-supply = <&vcc_sdio>;
-+	status = "okay";
- };
+ 	status = "okay";
  
- &pcie_phy {
-@@ -652,7 +713,10 @@
+-	bt656-supply = <&vcc1v8_dvp>;
++	bt656-supply = <&vcc_3v0>;
+ 	audio-supply = <&vcca1v8_codec>;
+ 	sdmmc-supply = <&vcc_sdio>;
+ 	gpio1830-supply = <&vcc_3v0>;
+@@ -652,7 +681,10 @@
  	ep-gpios = <&gpio4 RK_PD1 GPIO_ACTIVE_HIGH>;
  	num-lanes = <4>;
  	pinctrl-names = "default";
@@ -285,44 +200,18 @@ index c654b6b02f3..f73f792eb44 100644
  	status = "okay";
  };
  
-@@ -697,20 +761,20 @@
- 	};
- 
- 	pcie {
--		pcie_pwr_en: pcie-pwr-en {
-+		vcc3v3_pcie_en: vcc3v3-pcie-en {
- 			rockchip,pins = <1 RK_PC1 RK_FUNC_GPIO &pcfg_pull_none>;
- 		};
- 
-+		pcie_perst: pcie-perst {
-+			rockchip,pins = <4 RK_PD1 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+
+@@ -704,6 +736,10 @@
  		pcie_3g_drv: pcie-3g-drv {
  			rockchip,pins = <0 RK_PA2 RK_FUNC_GPIO &pcfg_pull_up>;
  		};
- 	};
- 
- 	pmic {
--		pmic_int_l: pmic-int-l {
--			rockchip,pins = <1 RK_PC5 RK_FUNC_GPIO &pcfg_pull_up>;
--		};
--
- 		vsel1_pin: vsel1-pin {
- 			rockchip,pins = <1 RK_PC2 RK_FUNC_GPIO &pcfg_pull_down>;
- 		};
-@@ -718,6 +782,10 @@
- 		vsel2_pin: vsel2-pin {
- 			rockchip,pins = <1 RK_PB6 RK_FUNC_GPIO &pcfg_pull_down>;
- 		};
 +
-+		pmic_int_l: pmic-int-l {
-+			rockchip,pins = <1 RK_PC5 RK_FUNC_GPIO &pcfg_pull_up>;
++		pcie_perst: pcie-perst {
++			rockchip,pins = <4 RK_PD1 RK_FUNC_GPIO &pcfg_pull_none>;
 +		};
  	};
  
- 	rt5640 {
-@@ -742,6 +810,14 @@
+ 	pmic {
+@@ -742,6 +778,14 @@
  		vcc5v0_host_en: vcc5v0-host-en {
  			rockchip,pins = <1 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
  		};
@@ -337,16 +226,10 @@ index c654b6b02f3..f73f792eb44 100644
  	};
  
  	wifi {
-@@ -749,6 +825,26 @@
+@@ -749,6 +793,20 @@
  			rockchip,pins = <0 RK_PA3 RK_FUNC_GPIO &pcfg_pull_none>;
  		};
  	};
-+
-+	ngff {
-+		vcc3v3_ngff_en: vcc3v3-ngff-en {
-+			rockchip,pins = <4 RK_PD3 RK_FUNC_GPIO &pcfg_pull_none>;
-+		};
-+	};
 +
 +	bt {
 +		bt_host_wake_l: bt-host-wake-l {
@@ -364,24 +247,8 @@ index c654b6b02f3..f73f792eb44 100644
  };
  
  &pwm0 {
-@@ -772,6 +868,7 @@
- 	keep-power-in-suspend;
- 	mmc-pwrseq = <&sdio_pwrseq>;
- 	non-removable;
-+	num-slots = <1>;
- 	pinctrl-names = "default";
- 	pinctrl-0 = <&sdio0_bus4 &sdio0_cmd &sdio0_clk>;
- 	sd-uhs-sdr104;
-@@ -780,15 +877,12 @@
- 	vqmmc-supply = <&vcc1v8_s3>;	/* IO line */
- 	vmmc-supply = <&vcc_sdio>;	/* card's power */
- 
--	#address-cells = <1>;
--	#size-cells = <0>;
- 	status = "okay";
- 
- 	brcmf: wifi@1 {
--		reg = <1>;
+@@ -788,7 +846,7 @@
+ 		reg = <1>;
  		compatible = "brcm,bcm4329-fmac";
  		interrupt-parent = <&gpio0>;
 -		interrupts = <RK_PA3 IRQ_TYPE_LEVEL_HIGH>;
@@ -389,7 +256,7 @@ index c654b6b02f3..f73f792eb44 100644
  		interrupt-names = "host-wake";
  		brcm,drive-strength = <5>;
  		pinctrl-names = "default";
-@@ -885,8 +979,22 @@
+@@ -885,8 +943,22 @@
  
  &uart0 {
  	pinctrl-names = "default";
@@ -413,17 +280,3 @@ index c654b6b02f3..f73f792eb44 100644
  };
  
  &uart2 {
-@@ -915,7 +1023,6 @@
- 
- &usbdrd_dwc3_0 {
- 	status = "okay";
--	dr_mode = "otg";
- };
- 
- &usbdrd3_1 {
-@@ -941,4 +1048,4 @@
- 
- &vopl_mmu {
- 	status = "okay";
--};
-+};


### PR DESCRIPTION
# Description

After testing, it was found that Firefly-RK3399 cannot boot using the mainline device tree due to issues with the PMU (Power Management Unit). 
Even after fixing the PMU problem, Bluetooth still cannot be used. 
Therefore, the original patch has been optimized by removing unnecessary parts.

# How Has This Been Tested?

- [x] Almost all hardware functions(HDMI, WiFi, BT, GbE, USB...).
- [x] System startup.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
