### PR TITLE
rockchip-rk3588: edge: fix hantro vpu

### DIFF
--- a/patch/kernel/rockchip-rk3588-edge/0147-arm64-dts-rockchip-rk3588-add-VDPU-and-RGA2-nodes.patch
+++ b/patch/kernel/rockchip-rk3588-edge/0147-arm64-dts-rockchip-rk3588-add-VDPU-and-RGA2-nodes.patch
@@ -15,9 +15,9 @@ index 387cfc7ee261..1ca59486b61c 100644
  		status = "disabled";
  	};
  
-+	vpu: video-codec@fdb50400 {
++	vpu: video-codec@fdb50000 {
 +		compatible = "rockchip,rk3568-vpu";
-+		reg = <0x0 0xfdb50400 0x0 0x400>;
++		reg = <0x0 0xfdb50000 0x0 0x800>;
 +		interrupts = <GIC_SPI 119 IRQ_TYPE_LEVEL_HIGH 0>;
 +		interrupt-names = "vdpu";
 +		clocks = <&cru ACLK_VPU>, <&cru HCLK_VPU>;


### PR DESCRIPTION
# Description

Upstreaming patch: https://patchwork.kernel.org/project/linux-rockchip/patch/20240430024002.708227-3-liujianfeng1994@gmail.com/
The current `fdb50400` won't work. there are errors in dmesg when doing decoding.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh kernel BOARD=rock-5b BRANCH=edge DEB_COMPRESS=xz KERNEL_CONFIGURE=no KERNEL_GIT=shallow`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
