### PR TITLE
Add doas support to `is_root_or_sudo_prefix`

### DIFF
--- a/lib/functions/host/host-utils.sh
+++ b/lib/functions/host/host-utils.sh
@@ -96,6 +96,10 @@ function is_root_or_sudo_prefix() {
 		# sudo binary found in path, use it.
 		display_alert "EUID is not 0" "sudo binary found, using it" "debug"
 		__my_sudo_prefix="sudo"
+	elif [[ -n "$(command -v doas)" ]]; then
+		# doas binary found in path, use it.
+		display_alert "EUID is not 0" "doas binary found, using it" "debug"
+		__my_sudo_prefix="doas"
 	else
 		# No root and no sudo binary. Bail out
 		exit_with_error "EUID is not 0 and no sudo binary found - Please install sudo or run as root"


### PR DESCRIPTION
# Description

doas is not compatible with sudo flags. The codebase was checked for sudo-specific uses of this function, but none were found, all cases were in the form of `sudo <command>`. Replacing it with `doas <command>` yields the same result.

Was extracted from #6576 and can't be merged until it's reverted in #6642 

# How Has This Been Tested?

Used to build images on my machine with extensions that use `is_root_or_sudo_prefix`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
