### PR TITLE
Minor fixes

### DIFF
--- a/config/sources/arm64.conf
+++ b/config/sources/arm64.conf
@@ -33,6 +33,8 @@ else
 	[[ -z $UBOOT_COMPILER ]] && UBOOT_COMPILER="aarch64-none-linux-gnu-"
 	[[ -z $KERNEL_COMPILER ]] && KERNEL_COMPILER="aarch64-linux-gnu-"
 	[[ -z $KERNEL_USE_GCC ]] && KERNEL_USE_GCC='< 9.2'
+
+	export QEMU_CPU="cortex-a53"
 fi
 
 [[ $ATF_COMPILE != "no" && -z $ATFSOURCE ]] && ATFSOURCE='https://github.com/ARM-software/arm-trusted-firmware'

--- a/lib/functions/general/git-ref2info.sh
+++ b/lib/functions/general/git-ref2info.sh
@@ -75,7 +75,7 @@ function memoized_git_ref_to_info() {
 		exit_with_error "Failed to fetch SHA1 of '${MEMO_DICT[GIT_SOURCE]}' '${ref_type}' '${ref_name}' - make sure it's correct"
 	fi
 
-	if [[ ${ref_type} == "branch" ]]; then
+	if [[ "${ARMBIAN_COMMAND}" == "artifact-config-dump-json" ]] && [[ ${ref_type} == "branch" ]]; then
 		{
 			flock -x 5
 			flock -x 6


### PR DESCRIPTION
# Description

Minor fixes:
- limit creation of git-sources.json file to following commands - targets, debs-to-repo-json, gha-matrix and gha-workflow
- Solve slowness when building Ubuntu Noble images. Fixes #6531 

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [X] Tested Ubuntu noble rootfs creation speed improvement using `./compile.sh BOARD=khadas-vim4 BRANCH=legacy KERNEL_CONFIGURE=no BUILD_MINIMAL=yes RELEASE=noble ARTIFACT_IGNORE_CACHE=yes rootfs`. It reduced build time from 26 minutes down to only 8 minutes.

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
