### PR TITLE
Recycling armbian sunxi patches

### DIFF
--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -29,6 +29,7 @@ case $BRANCH in
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel.
+		declare -g KERNELBRANCH="tag:v6.6.31"
 		;;
 
 	edge)

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -30,6 +30,7 @@ case $BRANCH in
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel.
+		declare -g KERNELBRANCH="tag:v6.6.31"
 		;;
 
 	edge)

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-allwinner-h616-Add-efuse_xlate-cpu-frequency-scaling-v1_6_2.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-allwinner-h616-Add-efuse_xlate-cpu-frequency-scaling-v1_6_2.patch
@@ -126,8 +126,8 @@ index 8d8009c7f9a3..41a5a4013091 100644
 +};
 +
  &emac0 {
- 	phy-supply = <&reg_dcdce>;
- };
+ 	allwinner,rx-delay-ps = <3100>;
+ 	allwinner,tx-delay-ps = <700>;
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h618-cpu-dvfs.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h618-cpu-dvfs.dtsi
 new file mode 100644
 index 0000000000000..0509e3fb22e26
@@ -219,8 +219,8 @@ index 00fe28caac93..edbfc83f390a 100644
 +};
 +
  &emac0 {
- 	phy-supply = <&reg_dldo1>;
- };
+ 	allwinner,tx-delay-ps = <700>;
+ 	phy-mode = "rgmii-rxid";
 @@ -31,62 +37,6 @@ &mmc0 {
  	vmmc-supply = <&reg_dldo1>;
  };

--- a/patch/kernel/archive/sunxi-6.6/patches.megous/arm64-dts-allwinner-h6-Enable-hdmi-sound-card-on-boards-with-hd.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.megous/arm64-dts-allwinner-h6-Enable-hdmi-sound-card-on-boards-with-hd.patch
@@ -38,8 +38,8 @@ index 9ec49ac2f6fd..c8cdab585491 100644
 +};
 +
  &spdif {
- 	status = "okay";
- };
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&spdif_tx_pin>;
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-3.dts b/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-3.dts
 index 6fc65e8db220..3d264de784de 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-3.dts

--- a/patch/kernel/archive/sunxi-6.6/patches.megous/media-ov5640-Don-t-powerup-the-sensor-during-driver-probe.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.megous/media-ov5640-Don-t-powerup-the-sensor-during-driver-probe.patch
@@ -38,7 +38,7 @@ index 44643687f467..2b0878468394 100644
  	return 0;
  
  power_off:
-@@ -3813,28 +3821,6 @@ static int ov5640_get_regulators(struct ov5640_dev *sensor)
+@@ -3822,28 +3830,6 @@ static int ov5640_get_regulators(struct ov5640_dev *sensor)
  				       sensor->supplies);
  }
  
@@ -67,7 +67,7 @@ index 44643687f467..2b0878468394 100644
  static int ov5640_probe(struct i2c_client *client)
  {
  	struct device *dev = &client->dev;
-@@ -3934,36 +3920,17 @@ static int ov5640_probe(struct i2c_client *client)
+@@ -3943,35 +3929,16 @@ static int ov5640_probe(struct i2c_client *client)
  	if (ret)
  		goto entity_cleanup;
  
@@ -105,9 +105,7 @@ index 44643687f467..2b0878468394 100644
  free_ctrls:
  	v4l2_ctrl_handler_free(&sensor->ctrls.handler);
  entity_cleanup:
- 	media_entity_cleanup(&sensor->sd.entity);
- 	mutex_destroy(&sensor->lock);
-@@ -3976,6 +3944,8 @@ static void ov5640_remove(struct i2c_client *client)
+@@ -3986,6 +3953,8 @@ static void ov5640_remove(struct i2c_client *client)
  	struct ov5640_dev *sensor = to_ov5640_dev(sd);
  	struct device *dev = &client->dev;
  

--- a/patch/kernel/archive/sunxi-6.6/patches.megous/of-property-fw_devlink-Support-allwinner-sram-links.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.megous/of-property-fw_devlink-Support-allwinner-sram-links.patch
@@ -17,8 +17,8 @@ diff --git a/drivers/of/property.c b/drivers/of/property.c
 index cf8dacf3e3b8..5b46ce975734 100644
 --- a/drivers/of/property.c
 +++ b/drivers/of/property.c
-@@ -1326,6 +1326,27 @@ static struct device_node *parse_interrupts(struct device_node *np,
- 	return of_irq_parse_one(np, index, &sup_args) ? NULL : sup_args.np;
+@@ -1308,6 +1308,27 @@ static struct device_node *parse_remote_endpoint(struct device_node *np,
+ 	return of_graph_get_remote_port_parent(np);
  }
  
 +static struct device_node *parse_allwinner_sram(struct device_node *np,
@@ -45,7 +45,7 @@ index cf8dacf3e3b8..5b46ce975734 100644
  static const struct supplier_bindings of_supplier_bindings[] = {
  	{ .parse_prop = parse_clocks, },
  	{ .parse_prop = parse_interconnects, },
-@@ -1361,6 +1382,7 @@ static const struct supplier_bindings of_supplier_bindings[] = {
+@@ -1346,6 +1367,7 @@ static const struct supplier_bindings of_supplier_bindings[] = {
  	{ .parse_prop = parse_regulators, },
  	{ .parse_prop = parse_gpio, },
  	{ .parse_prop = parse_gpios, },


### PR DESCRIPTION
# Description
It is known that it is built without errors and works on a test platform.

- freeze the kernel version v6.6.31
- sunxi-6.6: rework patches for current v6.6.31

- [ ] short description (copy / paste of PR title)
- [ ] summary (description relevant for end users)
- [ ] example of usage (how to see this in function)

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] Build & Test on board Bananapi-m64

