### PR TITLE
Install wireguard tools also in minimal image

### DIFF
--- a/config/cli/common/main/packages
+++ b/config/cli/common/main/packages
@@ -48,4 +48,5 @@ usbutils
 vlan
 wget
 wireless-tools
+wireguard-tools
 wpasupplicant


### PR DESCRIPTION
# Description

Installing wireguard will also install stock Debian kernel which obviously will not work. 

[Jira](https://armbian.atlassian.net/jira) reference number [AR-2333] https://github.com/armbian/build/issues/6647

# How Has This Been Tested?

- [x] CI installs only package wireguard-tools. Which is installed by wireguard. 

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-2333]: https://armbian.atlassian.net/browse/AR-2333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ