### PR TITLE
Add chromium v4l2 encoder/decoder udev rules for all boards

### DIFF
--- a/config/boards/ayn-odin2.conf
+++ b/config/boards/ayn-odin2.conf
@@ -51,9 +51,6 @@ function post_family_tweaks__enable_services() {
 	echo 'GALLIUM_DRIVER=zink' | tee -a "${SDCARD}"/etc/environment
 	# Add Gamepad udev rule
 	echo 'SUBSYSTEM=="input", ATTRS{name}=="Ayn Odin2 Gamepad", MODE="0666", ENV{ID_INPUT_MOUSE}="0", ENV{ID_INPUT_JOYSTICK}="1"'> "${SDCARD}"/etc/udev/rules.d/99-ignore-gamepad.rules
-	# Add video decoder/encoder udev rule
-	echo 'SUBSYSTEM=="video4linux", ATTR{name}=="qcom-venus-decoder", SYMLINK+="video-dec%n"' >> "${SDCARD}"/etc/udev/rules.d/90-browser-video.rules
-	echo 'SUBSYSTEM=="video4linux", ATTR{name}=="qcom-venus-encoder", SYMLINK+="video-enc%n"' >> "${SDCARD}"/etc/udev/rules.d/90-browser-video.rules
 	# No driver support for suspend
 	chroot_sdcard systemctl mask suspend.target
 	# Add Bt Mac Fixed service

--- a/packages/bsp/common/etc/udev/rules.d/90-chromium-video.rules
+++ b/packages/bsp/common/etc/udev/rules.d/90-chromium-video.rules
@@ -1,0 +1,16 @@
+# This is qcom venus v4l2 stateful decoder, tested on sm8250
+SUBSYSTEM=="video4linux", ATTR{name}=="qcom-venus-decoder", SYMLINK+="video-dec%n"
+
+# This is qcom venus v4l2 stateful encoder, not tested yet, but chromium did query /dev/video-enc* devives for v4l2 encoding.
+SUBSYSTEM=="video4linux", ATTR{name}=="qcom-venus-encoder", SYMLINK+="video-enc%n"
+
+# These rules are for hantro v4l2 stateless decoders found on rk3399, rk3568 and rk3588
+SUBSYSTEM=="video4linux", ATTR{name}=="rockchip,rk3568-vpu-dec", SYMLINK+="video-dec%n"
+SUBSYSTEM=="video4linux", ATTR{name}=="rockchip,rk3399-vpu-dec", SYMLINK+="video-dec%n"
+# AV1 decoder on rk3588 is still not well supported, so disable it now
+#SUBSYSTEM=="video4linux", ATTR{name}=="rockchip,rk3588-av1-vpu-dec", SYMLINK+="video-dec%n"
+SUBSYSTEM=="media", ATTR{model}=="hantro-vpu", SYMLINK+="media-dec%n"
+
+# These rules are for rkvdec v4l2 stateless decoder found on rk3399
+SUBSYSTEM=="video4linux", ATTR{name}=="rkvdec", SYMLINK+="video-dec%n"
+SUBSYSTEM=="media", ATTR{model}=="rkvdec", SYMLINK+="media-dec%n"


### PR DESCRIPTION
# Description

Chromium is querying  path  like `/dev/video-dec*` for its v4l2 video acceleration: https://github.com/chromium/chromium/blob/125.0.6422.132/media/gpu/v4l2/v4l2_device.cc#L916-L920. So udev rules is needed to let chromium know there are supported encoders/decoders.

I create an universal udev rule for all boards, so we don't have to add the rules to board configs here and there. When there are devices matching the rules, devices like `/dev/video-dec0` will be created as a symlink.

Maybe armhf platforms like rk3288 also support chromium v4l2, but do users of the old armhf boards have the need of chromium v4l2 decoding? This is only for arm64 now.

Chromium with mainline v4l2 support is packaged in ppa: https://launchpad.net/~liujianfeng1994/+archive/ubuntu/chromium

[AR-2335]

# How Has This Been Tested?

- [x] `./compile.sh BOARD=rock-5b BRANCH=edge BUILD_DESKTOP=yes BUILD_MINIMAL=no  DEB_COMPRESS=xz DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base KERNEL_CONFIGURE=no KERNEL_GIT=shallow RELEASE=jammy ENABLE_EXTENSIONS="mesa-oibaf"`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-2335]: https://armbian.atlassian.net/browse/AR-2335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ