### PR TITLE
Remove reverse dependency for armbian-config

### DIFF
--- a/lib/functions/bsp/armbian-bsp-cli-deb.sh
+++ b/lib/functions/bsp/armbian-bsp-cli-deb.sh
@@ -84,7 +84,6 @@ function compile_armbian-bsp-cli() {
 		Maintainer: $MAINTAINER <$MAINTAINERMAIL>
 		Section: kernel
 		Priority: optional
-		Suggests: armbian-config
 		Recommends: bsdutils, parted, util-linux, toilet
 		Description: Armbian CLI BSP for board '${BOARD}' branch '${BRANCH}' ${extra_description[@]}
 	EOF

--- a/lib/functions/compilation/packages/armbian-config-deb.sh
+++ b/lib/functions/compilation/packages/armbian-config-deb.sh
@@ -43,9 +43,7 @@ compile_armbian-config() {
 		Version: ${artifact_version}
 		Architecture: all
 		Maintainer: $MAINTAINER <$MAINTAINERMAIL>
-		Replaces: armbian-bsp, neofetch
 		Depends: bash, iperf3, psmisc, curl, bc, expect, dialog, pv, zip, debconf-utils, unzip, build-essential, html2text, html2text, dirmngr, software-properties-common, debconf, jq
-		Recommends: armbian-bsp
 		Suggests: libpam-google-authenticator, qrencode, network-manager, sunxi-tools
 		Section: utils
 		Priority: optional


### PR DESCRIPTION
# Description

This utility doesn't need any (Armbian) build dependency and should be able to work standalone. Also on clean Debian / Ubuntu distro.

# How Has This Been Tested?

After installed:

```
apt-cache showpkg armbian-config
Package: armbian-config
Versions: 
24.5.0-trunk (/var/lib/dpkg/status)
 Description Language: 
                 File: /var/lib/dpkg/status
                  MD5: f38cf0e4e7bf638768677b23e3fc75b9


Reverse Depends: 
Dependencies: 
24.5.0-trunk - bash (0 (null)) iperf3 (0 (null)) psmisc (0 (null)) curl (0 (null)) bc (0 (null)) expect (0 (null)) dialog (0 (null)) pv (0 (null)) zip (0 (null)) debconf-utils (0 (null)) unzip (0 (null)) build-essential (0 (null)) html2text (0 (null)) html2text (0 (null)) dirmngr (0 (null)) software-properties-common (0 (null)) debconf (0 (null)) jq (0 (null)) libpam-google-authenticator (0 (null)) qrencode (0 (null)) network-manager (0 (null)) sunxi-tools (0 (null)) 
Provides: 
24.5.0-trunk - 
Reverse Provides:
```

User test: https://forum.armbian.com/topic/39555-package-armbian-config-is-not-available/#comment-191583

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
