### PR TITLE
Add config for Libre Computer Sweet Potato

### DIFF
--- a/config/boards/sweet-potato.conf
+++ b/config/boards/sweet-potato.conf
@@ -1,0 +1,15 @@
+# Amlogic S905x quad core 2Gb RAM SoC eMMC SPI
+BOARD_NAME="Sweet Potato"
+BOARDFAMILY="meson-gxl"
+BOARD_MAINTAINER="Tonymac32"
+BOOTCONFIG="libretech-cc_v2_defconfig"
+BOOT_FDT_FILE="amlogic/meson-gxl-s905x-libretech-cc-v2.dts"
+KERNEL_TARGET="current,edge"
+FULL_DESKTOP="yes"
+ASOUND_STATE="asound.state.mesongx"
+BOOT_LOGO="desktop"
+
+function post_family_config__declare_u-boot-version() {
+	BOOTBRANCH='tag:v2024.04'
+	BOOTPATCHDIR='v2024.04'
+ }

--- a/config/sources/families/meson-gxl.conf
+++ b/config/sources/families/meson-gxl.conf
@@ -14,7 +14,7 @@ function fetch_sources_tools__amlogic_odroidc2_blobs_fip() {
 	fetch_from_repo "https://github.com/armbian/odroidc2-blobs" "odroidc2-blobs" "branch:master"
 }
 
-if [[ $BOARD == lafrite ]]; then
+if [[ $BOARD == lafrite ]] || [[ $BOARD == sweet-potato ]]; then
 	UBOOT_TARGET_MAP="u-boot-dtb.img;;u-boot.bin:u-boot.bin u-boot-dtb.img"
 	BOOTSCRIPT="boot-meson-gx.cmd:boot.cmd"
 fi


### PR DESCRIPTION
# Description

Add support for the AML-S905X-CC-V2, "Sweet Potato".  SPI flash bootloader on Le Potato with some other updates

# How Has This Been Tested?

Sweet Potato builds/boots.

NOTE:  While the board *can* boot from USB, linux resets the usb hub and boot fails, images must be loaded from SD like normal for now.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
