### PR TITLE
Add support for rk3568 based board Lubancat2

### DIFF
--- a/config/boards/lubancat2.csc
+++ b/config/boards/lubancat2.csc
@@ -1,0 +1,30 @@
+# Rockchip RK3568 quad core SOC with 1-8GB eMMC USB3
+BOARD_NAME="Lubancat2"
+BOARDFAMILY="rk35xx"
+BOARD_FIRMWARE_INSTALL="-full"
+BOARD_MAINTAINER="Andyshrk"
+BOOTCONFIG="lubancat-2-rk3568_defconfig"
+KERNEL_TARGET="edge"
+FULL_DESKTOP="yes"
+BOOT_LOGO="desktop"
+BOOT_FDT_FILE="rockchip/rk3568-lubancat-2.dtb"
+BOOT_SCENARIO="spl-blobs"
+IMAGE_PARTITION_TABLE="gpt"
+
+# Mainline U-Boot
+function post_family_config_branch_edge__lubancat2_use_mainline_uboot() {
+	display_alert "$BOARD" "mainline (next branch) u-boot overrides for $BOARD / $BRANCH" "info"
+
+	declare -g BOOTSOURCE="https://github.com/Kwiboo/u-boot-rockchip.git" # Kwiboo U-Boot
+	unset BOOTBRANCH
+	declare BOOTPATCHDIR="v2024.07-lubancat2" 			      # empty, no patchs needed
+	declare -g BOOTBRANCH_BOARD="tag:v2024.07-rc3"                        # commit: a7f0154c4128 as of v2024.07-rc3
+	declare -g BOOTDIR="u-boot-${BOARD}"                                  # do not share u-boot directory
+	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin"
+	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # disable stuff from rockchip64_common; we're using binman here which does all the work already
+
+	# Just use the binman-provided u-boot-rockchip.bin, which is ready-to-go
+	function write_uboot_platform() {
+		dd "if=$1/u-boot-rockchip.bin" "of=$2" bs=32k seek=1 conv=notrunc status=none
+	}
+}


### PR DESCRIPTION
# Description
Add support for a rk3568 based SBC Lubancat2 in my hand.
The u-boot and linux kernel support is landing mainline for a few months.


# How Has This Been Tested?
Test:
`./compile.sh build BOARD=lubancat2 BRANCH=edge BUILD_DESKTOP=yes BUILD_MINIMAL=no DESKTOP_APPGROUPS_SELECTED='browsers chat desktop_tools editors email internet multimedia office programming remote_desktop' DESKTOP_ENVIRONMENT=xfce DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base DOWNLOAD_MIRROR=bfsu ENABLE_EXTENSIONS=mesa-vpu EXPERT=yes EXTRAWIFI=no KERNEL_CONFIGURE=no PREFER_DOCKER=no RELEASE=noble VENDOR=Armbian`

Write the image to tf card, insert the card to the board, the board can boot into desktop.


# Checklist:

_Please delete options that are not relevant._

- [ &check;] My code follows the style guidelines of this project
- [ &check;] I have performed a self-review of my own code
- [ &check;] I have commented my code, particularly in hard-to-understand areas
- [ &check;] My changes generate no new warnings
- [ &check;] Any dependent changes have been merged and published in downstream modules
