### PR TITLE
station-m3: use radxa's new u-boot

### DIFF
--- a/config/boards/station-m3.csc
+++ b/config/boards/station-m3.csc
@@ -3,11 +3,11 @@ BOARD_NAME="Station M3"
 BOARDFAMILY="rockchip-rk3588"
 BOARD_MAINTAINER="chainsx"
 KERNEL_TARGET="legacy,vendor"
+BOOTCONFIG="rock-5a-rk3588s_defconfig"
 FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
 BOOT_FDT_FILE="rockchip/rk3588s-roc-pc.dtb"
-SRC_EXTLINUX="yes"
-SRC_CMDLINE="console=ttyS02,1500000 console=tty0"
+BOOT_SCENARIO="spl-blobs"
 BOOT_SOC="rk3588"
 IMAGE_PARTITION_TABLE="gpt"
 declare -g UEFI_EDK2_BOARD_ID="station-m3" # This _only_ used for uefi-edk2-rk3588 extension
@@ -20,11 +20,13 @@ function post_family_tweaks__station_m3() {
 	return 0
 }
 
-# Override family config for this board; let's avoid conditionals in family config.
-function post_family_config__stationm3_use_vendor_uboot() {
-	BOOTCONFIG="rk3588_defconfig"
-	BOOTSOURCE='https://github.com/150balbes/u-boot-rk'
-	BOOTBRANCH='branch:rk3588'
-	BOOTDIR="u-boot-${BOARD}"
-	BOOTPATCHDIR="u-boot-station-p2"
+function post_family_tweaks__station-m3_naming_audios() {
+	display_alert "$BOARD" "Renaming station-m3 audios" "info"
+
+	mkdir -p $SDCARD/etc/udev/rules.d/
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-hdmi0-sound", ENV{SOUND_DESCRIPTION}="HDMI0 Audio"' > $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-dp0-sound", ENV{SOUND_DESCRIPTION}="DP0 Audio"' >> $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-es8388-sound", ENV{SOUND_DESCRIPTION}="ES8388 Audio"' >> $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+
+	return 0
 }

--- a/patch/u-boot/legacy/u-boot-radxa-rk3588/board_station-m3/uboot-station-m3-config.patch
+++ b/patch/u-boot/legacy/u-boot-radxa-rk3588/board_station-m3/uboot-station-m3-config.patch
@@ -1,0 +1,13 @@
+t a/configs/rock-5a-rk3588s_defconfig b/configs/rock-5a-rk3588s_defconfig
+index adcdb4d9..92951132 100644
+--- a/configs/rock-5a-rk3588s_defconfig
++++ b/configs/rock-5a-rk3588s_defconfig
+@@ -23,7 +23,7 @@
+ CONFIG_SPL_LIBDISK_SUPPORT=y
+ CONFIG_SPL_SPI_FLASH_SUPPORT=y
+ CONFIG_SPL_SPI_SUPPORT=y
+-CONFIG_DEFAULT_DEVICE_TREE="rk3588s-rock-5a"
++CONFIG_DEFAULT_DEVICE_TREE="rk3588-evb"
+ CONFIG_DEBUG_UART=y
+ CONFIG_FIT=y
+ CONFIG_FIT_IMAGE_POST_PROCESS=y


### PR DESCRIPTION
# Description

station-m3: use radxa's new u-boot.
Fix station-m3 audio issue.

# How Has This Been Tested?

- [x] Successfully built.
- [x] System startup.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
