### PR TITLE
add extension radxa-aic8800 for rock-5c onboard wifi

### DIFF
--- a/config/boards/rock-5c.conf
+++ b/config/boards/rock-5c.conf
@@ -10,6 +10,8 @@ BOOT_FDT_FILE="rockchip/rk3588s-rock-5c.dtb"
 BOOT_SCENARIO="spl-blobs"
 BOOT_SOC="rk3588"
 IMAGE_PARTITION_TABLE="gpt"
+enable_extension "radxa-aic8800"
+AIC8800_TYPE="usb"
 
 function post_family_config__uboot_rock5c() {
         display_alert "$BOARD" "Configuring armsom u-boot" "info"

--- a/extensions/radxa-aic8800.sh
+++ b/extensions/radxa-aic8800.sh
@@ -1,0 +1,48 @@
+function extension_finish_config__install_kernel_headers_for_aic8800_dkms() {
+	if [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]]; then
+		display_alert "Kernel version has no working headers package" "skipping aic8800 dkms for kernel v${KERNEL_MAJOR_MINOR}" "warn"
+		return 0
+	fi
+	declare -g INSTALL_HEADERS="yes"
+	display_alert "Forcing INSTALL_HEADERS=yes; for use with aic8800 dkms" "${EXTENSION}" "debug"
+}
+
+function post_install_kernel_debs__install_aic8800_dkms_package() {
+	[[ "${INSTALL_HEADERS}" != "yes" ]] || [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]] && return 0
+	[[ -z $AIC8800_TYPE ]] && return 0
+	api_url="https://api.github.com/repos/radxa-pkg/aic8800/releases/latest"
+	latest_version=$(curl -s "${api_url}" | jq -r '.tag_name')
+	aic8800_firmware_url="https://github.com/radxa-pkg/aic8800/releases/download/${latest_version}/aic8800-firmware_${latest_version}_arm64.deb"
+	aic8800_pcie_url="https://github.com/radxa-pkg/aic8800/releases/download/${latest_version}/aic8800-pcie-dkms_${latest_version}_all.deb"
+	aic8800_sdio_url="https://github.com/radxa-pkg/aic8800/releases/download/${latest_version}/aic8800-sdio-dkms_${latest_version}_all.deb"
+	aic8800_usb_url="https://github.com/radxa-pkg/aic8800/releases/download/${latest_version}/aic8800-usb-dkms_${latest_version}_all.deb"
+	if [[ "${GITHUB_MIRROR}" == "ghproxy" ]];then
+		ghproxy_header="https://mirror.ghproxy.com/"
+		aic8800_firmware_url=${ghproxy_header}${aic8800_firmware_url}
+		aic8800_pcie_url=${ghproxy_header}${aic8800_pcie_url}
+		aic8800_sdio_url=${ghproxy_header}${aic8800_sdio_url}
+		aic8800_usb_url=${ghproxy_header}${aic8800_usb_url}
+	fi
+	case "${AIC8800_TYPE}" in
+		"pcie")
+			aic8800_dkms_file_name=aic8800-pcie-dkms_${latest_version}_all.deb
+			use_clean_environment="yes" chroot_sdcard "wget ${aic8800_pcie_url} -P /tmp"
+			;;
+		"sdio")
+			aic8800_dkms_file_name=aic8800-usb-dkms_${latest_version}_all.deb
+			use_clean_environment="yes" chroot_sdcard "wget ${aic8800_sdio_url} -P /tmp"
+			;;
+		"usb")
+			aic8800_dkms_file_name=aic8800-usb-dkms_${latest_version}_all.deb
+			use_clean_environment="yes" chroot_sdcard "wget ${aic8800_usb_url} -P /tmp"
+			;;
+		*)
+			return 0
+			;;
+	esac
+	use_clean_environment="yes" chroot_sdcard "wget ${aic8800_firmware_url} -P /tmp"
+	display_alert "Install aic8800 packages, will build kernel module in chroot" "${EXTENSION}" "info"
+	declare -ag if_error_find_files_sdcard=("/var/lib/dkms/aic8800*/*/build/*.log")
+	use_clean_environment="yes" chroot_sdcard_apt_get_install "/tmp/${aic8800_dkms_file_name} /tmp/aic8800-firmware_${latest_version}_arm64.deb"
+	use_clean_environment="yes" chroot_sdcard "rm -f /tmp/aic8800*.deb"
+}


### PR DESCRIPTION
# Description

Rock 5c has an on board aic8800 usb wifi module, which need dkms packages from https://github.com/radxa-pkg/aic8800. Add an extension to preinstall these packages to image.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh build BOARD=rock-5c BRANCH=vendor BUILD_DESKTOP=no BUILD_MINIMAL=yes DEB_COMPRESS=xz KERNEL_CONFIGURE=no KERNEL_GIT=shallow RELEASE=bookworm`. Build log: https://paste.armbian.com/jabulawezu
- [ ] I don't have rock 5c at my hand to test, I will share my built images to my friends to test.

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
