### PR TITLE
Attach Collabora branch to last known working

### DIFF
--- a/config/sources/families/rockchip-rk3588.conf
+++ b/config/sources/families/rockchip-rk3588.conf
@@ -53,7 +53,7 @@ case $BRANCH in
 		KERNEL_MAJOR_MINOR="6.9"				# Major and minor versions of this kernel.
 		KERNELPATCHDIR='rockchip-rk3588-collabora'
 		KERNELSOURCE='https://gitlab.collabora.com/hardware-enablement/rockchip-3588/linux.git'
-		KERNELBRANCH='branch:rk3588'			# Rolling kernel branch, will be rebased
+		KERNELBRANCH='branch:rk3588-v6.9'			# Rolling kernel branch, will be rebased
 		KERNEL_DRIVERS_SKIP+=(driver_rtw88)		# This is a custom kernel, while the rtw88 driver patching expects pure mainline
 		;;
 esac


### PR DESCRIPTION
# Description

Collabora is rebasing their Git, so we need to use branches. Current 6.10.RC is broken and I don't think we need this (anymore?) problem right now. Can be revered later, but it currently breaks CI.

# How Has This Been Tested?

- [x] Manual build

# Checklist:

- [x] My changes generate no new warnings