### PR TITLE
rk322x: fixes uboot v2024.01 interoperability with vendor kernel

### DIFF
--- a/patch/u-boot/v2024.01/board_rk322x-box/rk3228-hdmi-driver.patch
+++ b/patch/u-boot/v2024.01/board_rk322x-box/rk3228-hdmi-driver.patch
@@ -10,18 +10,19 @@ Subject: [PATCH 3/4] rockchip rk3228 HDMI driver
 
 diff --git a/drivers/video/rockchip/rk3228_hdmi.c b/drivers/video/rockchip/rk3228_hdmi.c
 new file mode 100644
-index 0000000000..b07ac35ce1
+index 0000000000..ec67790c71
 --- /dev/null
 +++ b/drivers/video/rockchip/rk3228_hdmi.c
-@@ -0,0 +1,161 @@
+@@ -0,0 +1,179 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * Copyright (c) 2023 Edgeble AI Technologies Pvt. Ltd.
 + */
-+
 +#include <common.h>
 +#include <clk.h>
 +#include <display.h>
++#include <reset.h>
++#include <linux/delay.h>
 +#include <dm.h>
 +#include <dw_hdmi.h>
 +#include <asm/io.h>
@@ -136,9 +137,14 @@ index 0000000000..b07ac35ce1
 +	return 0;
 +}
 +
++/*
++ * Asserting and deasserting the HDMI resets allows the vendor kernel
++ * to turn on HDMI when necessary. Mainline kernel does not need it though
++ */
 +static int rk3228_hdmi_remove(struct udevice *dev)
 +{
 +	struct rk_hdmi_priv *priv = dev_get_priv(dev);
++	struct reset_ctl_bulk resets;
 +	int ret;
 +
 +	debug("%s\n", __func__);
@@ -149,6 +155,18 @@ index 0000000000..b07ac35ce1
 +	if (ret) {
 +		printf("failed to on hdmi phy (ret=%d)\n", ret);
 +	}
++
++	ret = reset_get_bulk(dev, &resets);
++	if (ret) {
++		printf("failed to get resets (ret=%d)\n", ret);
++		return ret;
++	}
++
++	reset_assert_bulk(&resets);
++	udelay(20);
++
++	reset_deassert_bulk(&resets);
++	udelay(20);
 +
 +	return 0;
 +

--- a/patch/u-boot/v2024.01/board_rk322x-box/rk3228-vop-driver.patch
+++ b/patch/u-boot/v2024.01/board_rk322x-box/rk3228-vop-driver.patch
@@ -10,15 +10,14 @@ Subject: [PATCH 2/4] rockchip rk3228 VOP driver
 
 diff --git a/drivers/video/rockchip/rk3228_vop.c b/drivers/video/rockchip/rk3228_vop.c
 new file mode 100644
-index 0000000000..f09097709a
+index 0000000000..ec558078a0
 --- /dev/null
 +++ b/drivers/video/rockchip/rk3228_vop.c
-@@ -0,0 +1,109 @@
+@@ -0,0 +1,107 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * Copyright (c) 2023 Edgeble AI Technologies Pvt. Ltd.
 + */
-+
 +#include <common.h>
 +#include <dm.h>
 +#include <video.h>
@@ -57,15 +56,17 @@ index 0000000000..f09097709a
 +}
 +
 +/**
-+ * Remove the device deasserting the dclk, thus disabling the VOP.
-+ * This is essential to avoid iommu complaining later during kernel boot
++ * During remove phase we assert the resets and deassert them,
++ * so in practice we "turn off" the VOP resetting it and then
++ * "turn on" it. This is especially true for the dlck because
++ * this avoids iommu complaining later during kernel boot
 + * @see https://lore.kernel.org/linux-arm-kernel/20230330131746.1475514-1-jagan@amarulasolutions.com/
 + */
 +static int rk3228_vop_remove(struct udevice *dev)
 +{
 +	struct rk_vop_priv *priv = dev_get_priv(dev);
 +	struct rk3288_vop *regs = priv->regs;
-+	struct reset_ctl dclk_rst;
++	struct reset_ctl_bulk resets;
 +
 +	int ret;
 +
@@ -75,20 +76,17 @@ index 0000000000..f09097709a
 +	setbits_le32(&regs->sys_ctrl, V_STANDBY_EN(1));
 +	clrsetbits_le32(&regs->sys_ctrl, M_ALL_OUT_EN, 0x0);
 +
-+	ret = reset_get_by_name(dev, "dclk", &dclk_rst);
-+	if (ret)
-+		printf("failed to get dclk reset (ret=%d)\n", ret);
++	ret = reset_get_bulk(dev, &resets);
++	if (ret) {
++		printf("failed to get resets (ret=%d)\n", ret);
++		return ret;
++	}
 +
-+	/* assert and deassert reset */
-+	ret = reset_assert(&dclk_rst);
-+	if (ret)
-+		printf("failed to assert dclk reset (ret=%d)\n", ret);
-+
++	reset_assert_bulk(&resets);
 +	udelay(20);
 +
-+	ret = reset_deassert(&dclk_rst);
-+	if (ret)
-+		printf("failed to deassert dclk reset (ret=%d)\n", ret);
++	reset_deassert_bulk(&resets);
++	udelay(20);
 +
 +	return 0;
 +

--- a/patch/u-boot/v2024.01/board_rk322x-box/rk322x-add-usb-reset-props.patch
+++ b/patch/u-boot/v2024.01/board_rk322x-box/rk322x-add-usb-reset-props.patch
@@ -46,7 +46,42 @@ index 8eed9e3a92..ffe503e5db 100644
 +		reset-names = "ehci";
  		status = "disabled";
  	};
+
+diff --git a/drivers/usb/host/dwc2.c b/drivers/usb/host/dwc2.c
+index 936e30438d..09d3805e78 100644
+--- a/drivers/usb/host/dwc2.c
++++ b/drivers/usb/host/dwc2.c
+@@ -1436,7 +1438,10 @@ static int dwc2_usb_remove(struct udevice *dev)
  
+ 	dwc2_uninit_common(priv->regs);
+ 
+-	reset_release_bulk(&priv->resets);
++	// Assert first and then leave the resets deasserted
++	reset_assert_bulk(&priv->resets);
++	reset_deassert_bulk(&priv->resets);
++
+ 	clk_disable_bulk(&priv->clks);
+ 	clk_release_bulk(&priv->clks);
+ 
+diff --git a/drivers/usb/host/ehci-generic.c b/drivers/usb/host/ehci-generic.c
+index 936e30438d..09d3805e78 100644
+--- a/drivers/usb/host/ehci-generic.c
++++ b/drivers/usb/host/ehci-generic.c
+@@ -148,9 +148,9 @@ static int ehci_usb_remove(struct udevice *dev)
+ 	if (ret)
+ 		return ret;
+ 
+-	ret = reset_release_bulk(&priv->resets);
+-	if (ret)
+-		return ret;
++	// Assert first and then leave the resets deasserted
++	reset_assert_bulk(&priv->resets);
++	reset_deassert_bulk(&priv->resets);
+ 
+ 	return clk_release_bulk(&priv->clocks);
+ }
 -- 
 2.34.1
+
+
 


### PR DESCRIPTION
# Description

Uboot v2024.01 leaves HDMI/VOP and USB ports in a state that is not liked by vendor kernel and tools that use it (eg. the multitool), thus making their usage difficult or impossible.

These patches will assert the resets for HDMI, VOP and USB ports and deassert them on uboot exit, so the kernel (any kernel) will find them in active and "clean" state.

Nerd note: the USB nodes in uboot device tree do not have the `reset` properties. Adding the `reset` properties makes the USB ports undetectable to the kernel because uboot - on purpose - leaves the devices with the reset asserted. To let the kernel detect the ports, you have to add the `reset` properties in the kernel device tree too, so the kernel is able to deassert them. A more complete device tree is not always to be a good thing, for uboot at least.

[Jira](https://armbian.atlassian.net/jira) reference number [AR-2349]

# How Has This Been Tested?

- [x] Compiled uboot via armbian tools
- [x] Tested produced uboot on various live systems
- [x] Tested uboot in conjuction with tools using vendor kernel (multitool)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


[AR-2349]: https://armbian.atlassian.net/browse/AR-2349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ