### PR TITLE
Pinctr dummy regulators

### DIFF
--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm-dts-orangepi-one-pinctr-dummy-regulators.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm-dts-orangepi-one-pinctr-dummy-regulators.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: John Doe <john.doe@somewhere.on.planet>
+Date: Thu, 30 May 2024 18:19:07 -0700
+Subject: Patching kernel sunxi files
+ arch/arm/boot/dts/allwinner/sun8i-h3-orangepi-one.dts
+
+Signed-off-by: John Doe <john.doe@somewhere.on.planet>
+---
+ arch/arm/boot/dts/allwinner/sun8i-h3-orangepi-one.dts | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/arch/arm/boot/dts/allwinner/sun8i-h3-orangepi-one.dts b/arch/arm/boot/dts/allwinner/sun8i-h3-orangepi-one.dts
+index 927fd1bab..1aee01494 100644
+--- a/arch/arm/boot/dts/allwinner/sun8i-h3-orangepi-one.dts
++++ b/arch/arm/boot/dts/allwinner/sun8i-h3-orangepi-one.dts
+@@ -207,5 +207,12 @@ &usbphy {
+ 	/* USB Type-A port's VBUS is always on */
+ 	usb0_id_det-gpios = <&pio 6 12 GPIO_ACTIVE_HIGH>; /* PG12 */
+ 	usb0_vbus-supply = <&reg_usb0_vbus>;
+ 	status = "okay";
+ };
++
++&pio {
++        vcc-pa-supply = <&reg_vcc3v3>;
++        vcc-pc-supply = <&reg_vcc3v3>;
++        vcc-pd-supply = <&reg_vcc3v3>;
++        vcc-pg-supply = <&reg_vcc3v3>;
++};
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm-dts-orangepi-one-pinctr-dummy-regulators.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm-dts-orangepi-one-pinctr-dummy-regulators.patch
@@ -1,10 +1,10 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: John Doe <john.doe@somewhere.on.planet>
+From: Stephen Graf <stephen.graf@gmail.com>
 Date: Thu, 30 May 2024 18:19:07 -0700
-Subject: Patching kernel sunxi files
+Subject: adding dummy regulators in pinctr
  arch/arm/boot/dts/allwinner/sun8i-h3-orangepi-one.dts
 
-Signed-off-by: John Doe <john.doe@somewhere.on.planet>
+Signed-off-by: Stephen Graf <stephen.graf@gmail.com>
 ---
  arch/arm/boot/dts/allwinner/sun8i-h3-orangepi-one.dts | 7 +++++++
  1 file changed, 7 insertions(+)

--- a/patch/kernel/archive/sunxi-6.6/series.armbian
+++ b/patch/kernel/archive/sunxi-6.6/series.armbian
@@ -201,3 +201,4 @@
 	patches.armbian/arm64-dts-allwinner-sun50i-h616-PG-12c-pins.patch
 	patches.armbian/arm64-dts-allwinner-sun50i-h616-spi1-cs1-pin.patch
 	patches.armbian/arm64-dts-sun50i-h618-add-overlay.patch
+	patches.armbian/arm-dts-orangepi-one-pinctr-dummy-regulators.patch

--- a/patch/kernel/archive/sunxi-6.6/series.conf
+++ b/patch/kernel/archive/sunxi-6.6/series.conf
@@ -470,3 +470,4 @@
 	patches.armbian/arm64-dts-allwinner-sun50i-h616-PG-12c-pins.patch
 	patches.armbian/arm64-dts-allwinner-sun50i-h616-spi1-cs1-pin.patch
 	patches.armbian/arm64-dts-sun50i-h618-add-overlay.patch
+	patches.armbian/arm-dts-orangepi-one-pinctr-dummy-regulators.patch


### PR DESCRIPTION
# Description

Add dummy regulators to pinctr dts for orangepione SBC. This will prevent the kernel driver from issuing warnings "supply vcc-xx not found, using dummy regulator" for the dummy regulators added.

# Documentation summary for feature / change

# How Has This Been Tested?

Initially the dts entries were manually added to a running system using the dts editor in armbian-config to verify that the changes produced the desired result.

Then a kernel patch was created, put into a git repository and an image generated from that repository. After installing the image on an orangepione the dtb was examined via the dts editor of armbian-config to confirm the presence of the required entries and the relevant output of dmesg was compared to a dmesg prior to the changed image.

Patched pinctr:
                pinctrl@1c20800 {
                        reg = <0x1c20800 0x400>;
                        interrupt-parent = <0x1c>;
                        interrupts = <0x00 0x0b 0x04 0x00 0x11 0x04>;
                        clocks = <0x03 0x36 0x1a 0x1b 0x00>;
                        clock-names = "apb\0hosc\0losc";
                        gpio-controller;
                        #gpio-cells = <0x03>;
                        interrupt-controller;
                        #interrupt-cells = <0x03>;
                        compatible = "allwinner,sun8i-h3-pinctrl";
                        vcc-pa-supply = <0x15>;
                        vcc-pc-supply = <0x15>;
                        vcc-pd-supply = <0x15>;
                        vcc-pg-supply = <0x15>;
                        phandle = <0x16>;

Before dmesg:

[    1.624523] gpio gpiochip0: Static allocation of GPIO base is deprecated, use dynamic allocation.
[    1.627934] sun8i-h3-pinctrl 1c20800.pinctrl: initialized sunXi PIO driver
[    1.628539] gpio gpiochip1: Static allocation of GPIO base is deprecated, use dynamic allocation.
[    1.630347] sun8i-h3-r-pinctrl 1f02c00.pinctrl: initialized sunXi PIO driver
[    1.630717] sun8i-h3-pinctrl 1c20800.pinctrl: supply vcc-pa not found, using dummy regulator
[    1.631449] printk: console [ttyS0] disabled
[    1.631881] 1c28000.serial: ttyS0 at MMIO 0x1c28000 (irq = 138, base_baud = 1500000) is a 16550A
[    1.631943] printk: console [ttyS0] enabled
[    1.662003] sun4i-drm display-engine: bound 1100000.mixer (ops 0xc0bb3530)
[    1.664046] sun4i-drm display-engine: bound 1200000.mixer (ops 0xc0bb3530)
[    1.664515] sun4i-drm display-engine: bound 1c0c000.lcd-controller (ops 0xc0baed88)
[    1.664916] sun4i-drm display-engine: bound 1c0d000.lcd-controller (ops 0xc0baed88)
[    1.665001] sun8i-dw-hdmi 1ee0000.hdmi: supply hvcc not found, using dummy regulator
[    1.665983] sun8i-dw-hdmi 1ee0000.hdmi: Detected HDMI TX controller v1.32a with HDCP (sun8i_dw_hdmi_phy)
[    1.666767] sun8i-dw-hdmi 1ee0000.hdmi: registered DesignWare HDMI I2C bus driver
[    1.667325] sun4i-drm display-engine: bound 1ee0000.hdmi (ops 0xc0bb28fc)
[    1.668197] [drm] Initialized sun4i-drm 1.0.0 20150629 for display-engine on minor 0
[    1.668296] sun4i-drm display-engine: [drm] Cannot find any crtc or sizes
[    1.672029] sun8i-h3-r-pinctrl 1f02c00.pinctrl: supply vcc-pl not found, using dummy regulator
[    1.672085] sun8i-h3-pinctrl 1c20800.pinctrl: supply vcc-pf not found, using dummy regulator
[    1.672396] sun4i-drm display-engine: [drm] Cannot find any crtc or sizes
[    1.676045] sun8i-h3-pinctrl 1c20800.pinctrl: supply vcc-pg not found, using dummy regulator


After dmesg (note that supply vcc-pa and pg warnings are not present): 

[    1.993966] gpio gpiochip0: Static allocation of GPIO base is deprecated, use dynamic allocation.
[    1.997326] sun8i-h3-pinctrl 1c20800.pinctrl: initialized sunXi PIO driver
[    1.997891] gpio gpiochip1: Static allocation of GPIO base is deprecated, use dynamic allocation.
[    1.999757] sun8i-h3-r-pinctrl 1f02c00.pinctrl: initialized sunXi PIO driver
[    2.000715] printk: console [ttyS0] disabled
[    2.001152] 1c28000.serial: ttyS0 at MMIO 0x1c28000 (irq = 138, base_baud = 1500000) is a 16550A
[    2.001213] printk: console [ttyS0] enabled
[    2.031315] sun4i-drm display-engine: bound 1100000.mixer (ops 0xc0bb3530)
[    2.033318] sun4i-drm display-engine: bound 1200000.mixer (ops 0xc0bb3530)
[    2.033766] sun4i-drm display-engine: bound 1c0c000.lcd-controller (ops 0xc0baed88)
[    2.034153] sun4i-drm display-engine: bound 1c0d000.lcd-controller (ops 0xc0baed88)
[    2.034238] sun8i-dw-hdmi 1ee0000.hdmi: supply hvcc not found, using dummy regulator
[    2.035482] sun8i-dw-hdmi 1ee0000.hdmi: Detected HDMI TX controller v1.32a with HDCP (sun8i_dw_hdmi_phy)
[    2.036244] sun8i-dw-hdmi 1ee0000.hdmi: registered DesignWare HDMI I2C bus driver
[    2.036617] sun4i-drm display-engine: bound 1ee0000.hdmi (ops 0xc0bb28fc)
[    2.037494] [drm] Initialized sun4i-drm 1.0.0 20150629 for display-engine on minor 0
[    2.037592] sun4i-drm display-engine: [drm] Cannot find any crtc or sizes
[    2.041301] sun8i-h3-r-pinctrl 1f02c00.pinctrl: supply vcc-pl not found, using dummy regulator
[    2.041356] sun8i-h3-pinctrl 1c20800.pinctrl: supply vcc-pf not found, using dummy regulator


# Checklist:

- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my own code
- [ x ] My changes generate no new warnings

