### PR TITLE
Remove libu2f-udev, universal 2nd factor (U2F) — transitional package

### DIFF
--- a/config/desktop/common/environments/budgie/config_base/packages
+++ b/config/desktop/common/environments/budgie/config_base/packages
@@ -111,7 +111,6 @@ libplank1
 libplank-common
 libproxy1-plugin-gsettings
 libproxy1-plugin-networkmanager
-libu2f-udev
 libwmf0.2-7-gtk
 libxcursor1
 gdm3

--- a/config/desktop/common/environments/deepin/config_base/packages
+++ b/config/desktop/common/environments/deepin/config_base/packages
@@ -120,7 +120,6 @@ libgtk2.0-bin
 libnotify-bin
 libproxy1-plugin-gsettings
 libproxy1-plugin-networkmanager
-libu2f-udev
 libwmf0.2-7-gtk
 libxcursor1
 lightdm

--- a/config/desktop/common/environments/enlightenment/config_base/packages
+++ b/config/desktop/common/environments/enlightenment/config_base/packages
@@ -86,7 +86,6 @@ libplank1
 libplank-common
 libproxy1-plugin-gsettings
 libproxy1-plugin-networkmanager
-libu2f-udev
 libwmf0.2-7-gtk
 libxcursor1
 lightdm

--- a/config/desktop/common/environments/i3-wm/config_base/packages
+++ b/config/desktop/common/environments/i3-wm/config_base/packages
@@ -82,7 +82,6 @@ libjson-xs-perl
 libnotify-bin
 libproxy1-plugin-gsettings
 libproxy1-plugin-networkmanager
-libu2f-udev
 libwmf0.2-7-gtk
 libxcb-cursor0
 libxcursor1

--- a/config/desktop/common/environments/kde-plasma/config_base/packages
+++ b/config/desktop/common/environments/kde-plasma/config_base/packages
@@ -82,7 +82,6 @@ libgtk2.0-bin
 libnotify-bin
 libproxy1-plugin-gsettings
 libproxy1-plugin-networkmanager
-libu2f-udev
 libwmf0.2-7-gtk
 libxcursor1
 sddm

--- a/config/desktop/common/environments/mate/config_base/packages
+++ b/config/desktop/common/environments/mate/config_base/packages
@@ -82,7 +82,6 @@ libgtk2.0-bin
 libnotify-bin
 libproxy1-plugin-gsettings
 libproxy1-plugin-networkmanager
-libu2f-udev
 libwmf0.2-7-gtk
 libxcursor1
 lightdm

--- a/config/desktop/common/environments/xfce/config_base/packages
+++ b/config/desktop/common/environments/xfce/config_base/packages
@@ -53,7 +53,6 @@ libnotify-bin
 libpam-gnome-keyring
 libproxy1-plugin-gsettings
 libproxy1-plugin-networkmanager
-libu2f-udev
 libwmf0.2-7-gtk
 libxcursor1
 lightdm

--- a/config/desktop/common/environments/xmonad/config_base/packages
+++ b/config/desktop/common/environments/xmonad/config_base/packages
@@ -74,7 +74,6 @@ libgsettings-qt1
 libnotify-bin
 libproxy1-plugin-gsettings
 libproxy1-plugin-networkmanager
-libu2f-udev
 libwmf0.2-7-gtk
 libxcursor1
 lightdm


### PR DESCRIPTION
# Description

According to https://packages.debian.org/bookworm/libu2f-udev this package is not necessary anymore, and can be safely removed: since udev v244, U2F devices are autodetected without needing 3rd party udev rules.

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
