### PR TITLE
Revert Odin2 branch change as new one is changing daily and breaks

### DIFF
--- a/config/boards/ayn-odin2.conf
+++ b/config/boards/ayn-odin2.conf
@@ -19,7 +19,7 @@ declare -g DESKTOP_AUTOLOGIN="yes"
 function post_family_config_branch_sm8550__edk2_kernel() {	
 	declare -g KERNELSOURCE='https://github.com/edk2-porting/linux-next'
 	declare -g KERNEL_MAJOR_MINOR="6.7" # Major and minor versions of this kernel.
-	declare -g KERNELBRANCH="branch:ci/odin2/stable"
+	declare -g KERNELBRANCH="branch:integration/ayn-odin2"
 	declare -g LINUXCONFIG="linux-${ARCH}-${BRANCH}" # for this board: linux-arm64-sm8550
 	display_alert "Setting up kernel ${KERNEL_MAJOR_MINOR} for" "${BOARD}" "info"
 }

--- a/patch/kernel/archive/sm8250-6.8/0001-tools-Makefile-delete-missing-cgroup_clean.patch
+++ b/patch/kernel/archive/sm8250-6.8/0001-tools-Makefile-delete-missing-cgroup_clean.patch
@@ -1,0 +1,34 @@
+From 2fd526ca3197f01c5075e3c81948c4decd016f06 Mon Sep 17 00:00:00 2001
+From: amazingfate <liujianfeng1994@gmail.com>
+Date: Wed, 24 Jan 2024 18:03:52 +0800
+Subject: [PATCH] tools/Makefile: delete missing cgroup_clean
+
+---
+ tools/Makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tools/Makefile b/tools/Makefile
+index 37e9f68048..9903abe51d 100644
+--- a/tools/Makefile
++++ b/tools/Makefile
+@@ -169,7 +169,7 @@ acpi_clean:
+ cpupower_clean:
+ 	$(call descend,power/cpupower,clean)
+ 
+-cgroup_clean counter_clean hv_clean firewire_clean bootconfig_clean spi_clean usb_clean virtio_clean mm_clean wmi_clean bpf_clean iio_clean gpio_clean objtool_clean leds_clean pci_clean firmware_clean debugging_clean tracing_clean:
++counter_clean hv_clean firewire_clean bootconfig_clean spi_clean usb_clean virtio_clean mm_clean wmi_clean bpf_clean iio_clean gpio_clean objtool_clean leds_clean pci_clean firmware_clean debugging_clean tracing_clean:
+ 	$(call descend,$(@:_clean=),clean)
+ 
+ libapi_clean:
+@@ -209,7 +209,7 @@ freefall_clean:
+ build_clean:
+ 	$(call descend,build,clean)
+ 
+-clean: acpi_clean cgroup_clean counter_clean cpupower_clean hv_clean firewire_clean \
++clean: acpi_clean counter_clean cpupower_clean hv_clean firewire_clean \
+ 		perf_clean selftests_clean turbostat_clean bootconfig_clean spi_clean usb_clean virtio_clean \
+ 		mm_clean bpf_clean iio_clean x86_energy_perf_policy_clean tmon_clean \
+ 		freefall_clean build_clean libbpf_clean libsubcmd_clean \
+-- 
+2.34.1
+


### PR DESCRIPTION
# Description

@FantasyGmm Look into this when you find time and change back once works well.

# How Has This Been Tested?

- [x] Compilation ./compile.sh kernel BOARD='ayn-odin2' 'BRANCH=sm8550' 

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
