### PR TITLE
fix: cloudshell2 dtbo overlay path in boot.ini

### DIFF
--- a/config/bootscripts/boot-odroid-xu4.ini
+++ b/config/bootscripts/boot-odroid-xu4.ini
@@ -281,7 +281,7 @@ if test "${cs2enable}" = "true"; then
 
     setenv overlays "i2c0 i2c1 hktft-cs-ogst"
     for overlay in ${overlays}; do
-        ext4load mmc 0:1 0x60000000 /boot/dtb/overlays/${overlay}.dtbo
+        ext4load mmc 0:1 0x60000000 /boot/dtb/${overlay}.dtbo
         fdt apply 0x60000000
     done
 fi


### PR DESCRIPTION
# Description

Currently, dtbo path in boot.ini is wrong. So we cannot load device tree blob overlays for cloudshell2. This commit fix this path in boot.ini


# How Has This Been Tested?

Path was tested and dtbo's are succesfully loaded.

# Checklist:

_Please delete options that are not relevant._

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
