### PR TITLE
sm8250 devices improve: use losetup and fix qbootctl

### DIFF
--- a/config/boards/xiaomi-elish.conf
+++ b/config/boards/xiaomi-elish.conf
@@ -51,7 +51,7 @@ function post_family_tweaks__xiaomi-elish_enable_services() {
 		return 0
 	fi
 
-	if [[ "${RELEASE}" == "jammy" ]];then
+	if [[ "${RELEASE}" == "jammy" ]] || [[ "${RELEASE}" == "noble" ]];then
 		display_alert "Adding qcom-mainline PPA" "${BOARD}" "info"
 		do_with_retries 3 chroot_sdcard add-apt-repository ppa:liujianfeng1994/qcom-mainline --yes --no-update
 	fi

--- a/config/boards/xiaomi-umi.conf
+++ b/config/boards/xiaomi-umi.conf
@@ -52,7 +52,7 @@ function post_family_tweaks__xiaomi-umi_enable_services() {
 		return 0
 	fi
 
-	if [[ "${RELEASE}" == "jammy" ]]; then
+	if [[ "${RELEASE}" == "jammy" ]] || [[ "${RELEASE}" == "noble" ]]; then
 		display_alert "Adding qcom-mainline PPA" "${BOARD}" "info"
 		do_with_retries 3 chroot_sdcard add-apt-repository ppa:liujianfeng1994/qcom-mainline --yes --no-update
 	fi


### PR DESCRIPTION
# Description

- Ubuntu noble ships  qbootctl with a bug which makes qbootctl service can't start: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1057918. I fixed it in my ppa `liujianfeng1994/qcom-mainline`.
- I use a silly dd method to create rootfs. It's better to use `losetup` to load the built image and copy rootfs from the mounted loop device.

Note: ubuntu noble also ships mkbootimg with bug: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1050300, which will make this extension not working. So it's better not using noble as build environment. Debian's fix is still not packaged: https://salsa.debian.org/android-tools-team/android-platform-tools/-/commit/d26c3b5ac89efd92eb96ad029cd06400c1c9f015

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh BOARD=xiaomi-elish BRANCH=current BUILD_DESKTOP=yes BUILD_MINIMAL=no  DEB_COMPRESS=xz DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base  KERNEL_CONFIGURE=no KERNEL_GIT=shallow RELEASE=noble`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
