### PR TITLE
Allow to pass docker login when in CI, but not in GitHub actions

### DIFF
--- a/lib/functions/general/github-actions.sh
+++ b/lib/functions/general/github-actions.sh
@@ -9,7 +9,7 @@
 
 function github_actions_add_output() {
 	# if CI is not GitHub Actions, do nothing
-	if [[ "${CI}" != "true" ]] && [[ "${GITHUB_ACTIONS}" != "true" ]]; then
+	if [[ "${GITHUB_ACTIONS}" != "true" ]]; then
 		display_alert "Not running in GitHub Actions, not adding output" "'${*}'" "debug"
 		return 0
 	fi

--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -459,6 +459,8 @@ function docker_cli_prepare_launch() {
 		DOCKER_ARGS+=("--mount" "type=bind,source=${GITHUB_STEP_SUMMARY},target=${GITHUB_STEP_SUMMARY}")
 		DOCKER_ARGS+=("--env" "GITHUB_STEP_SUMMARY=${GITHUB_STEP_SUMMARY}")
 
+	fi
+	if [[ "${CI}" == "true" ]]; then
 		# For pushing/pulling from OCI/ghcr.io; if OCI_TARGET_BASE is set:
 		# - bind-mount the Docker config file (if it exists)
 		if [[ -n "${OCI_TARGET_BASE}" ]]; then
@@ -466,7 +468,7 @@ function docker_cli_prepare_launch() {
 			DOCKER_ARGS+=("--env" "OCI_TARGET_BASE=${OCI_TARGET_BASE}")
 		fi
 
-		# Mount the Docker config file (if it exists) -- always, even if OCI_TARGET_BASE is not set; @TODO: why only in GitHub actions?
+		# Mount the Docker config file (if it exists) -- always, even if OCI_TARGET_BASE is not set;
 		local docker_config_file_host="${HOME}/.docker/config.json"
 		local docker_config_file_docker="/root/.docker/config.json" # inside Docker
 		if [[ -f "${docker_config_file_host}" ]]; then

--- a/lib/functions/logging/trap-logging.sh
+++ b/lib/functions/logging/trap-logging.sh
@@ -97,7 +97,7 @@ function trap_handler_cleanup_logging() {
 	fi
 
 	# Export Markdown assets, but not if in GHA and GHA_EXPORT_MD_SUMMARY != yes
-	if [[ "${CI}" == "true" ]] && [[ "${GITHUB_ACTIONS}" == "true" ]] && [[ "${GHA_EXPORT_MD_SUMMARY:-no}" != "yes" ]]; then
+	if [[ "${CI}" == "true" ]] && ( [[ "${GITHUB_ACTIONS}" != "true" ]] || [[ "${GHA_EXPORT_MD_SUMMARY:-no}" != "yes" ]] ); then
 		display_alert "Not exporting Markdown logs to GitHub Actions" "GITHUB_ACTIONS: '${GITHUB_ACTIONS}', GHA_EXPORT_MD_SUMMARY: '${GHA_EXPORT_MD_SUMMARY}'" "debug"
 	else
 		# Export Markdown logs.


### PR DESCRIPTION
# Description

Allow to use Docker credentials for oras-cli push artifacts when `CI=true` is set, but not in GitHub action.

TODO: fix GITHUB_OUTPUT use if `CI=true` is set.

[Jira](https://armbian.atlassian.net/jira) reference number [AR-2357]


# How Has This Been Tested?


- [X] correct push to external container registry with CI=true

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings


[AR-2357]: https://armbian.atlassian.net/browse/AR-2357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ