### PR TITLE
Wifi: Switch to mainline driver for RTL8723CS, RTL8811CU, RTL8821C, RTL8192EU from 6.10 onwards

### DIFF
--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -373,13 +373,24 @@ driver_uwe5622() {
 	fi
 }
 
-###  The vendor's RTL8723DS driver is still required for RockPI-S support because
-###  the RTW88 driver for the chip configures its RF gains incorrectly
+###
+###
+### NOTICE: <=6.9 BELOW ONLY
+### With exceptions for a few boards that still rely on these 3rd party drivers
+###
+### All drivers and patches listed below are only used in kernels <=6.9 and **not** in >=6.10
+### Sorted by: "linux-version le ..." from high (newer kernel) to low (older kernel).
+### It is sorted like this for better visibility.
+###
+### v v v v v v v v v v v v v v v v v v v v v v v
+
 driver_rtl8723DS() {
 
 	# Wireless drivers for Realtek 8723DS chipsets
 
-	if linux-version compare "${version}" ge 5.0; then
+	# The vendor's RTL8723DS driver is still required for RockPI-S support because the RTW88 driver for the chip configures its RF gains incorrectly
+	# Keep this driver enabled for RockPi-S and Asus Tinkerboard Rev.2 even for kernels >= 6.10 since they still rely on these 3rd party drivers to work properly
+	if linux-version compare "${version}" ge 5.0 && (linux-version compare "${version}" le 6.9 || [[ "$BOARD" == rockpi-s || "$BOARD" == tinkerboard-2 ]]); then
 
 		# Attach to specific commit (was "branch:master")
 		local rtl8723dsver='commit:52e593e8c889b68ba58bd51cbdbcad7fe71362e4' # Commit date: Nov 14, 2023 (please update when updating commit ref)
@@ -418,22 +429,12 @@ driver_rtl8723DS() {
 	fi
 }
 
-###
-###
-### NOTICE: <=6.10 BELOW ONLY
-###
-### All drivers and patches listed below are only used in kernels <=6.10 and **not** in >=6.11
-### Sorted by: "linux-version le ..." from high (newer kernel) to low (older kernel).
-### It is sorted like this for better visibility.
-###
-### v v v v v v v v v v v v v v v v v v v v v v v
-
 driver_rtl8192EU() {
 
 	# Wireless drivers for Realtek 8192EU chipsets
 
 	# RTL8192EU is supported by mainline driver RTL8XXXU as seen in the Linux kernel folder at "drivers/net/wireless/realtek/rtl8xxxu/Kconfig"
-	if linux-version compare "${version}" ge 3.14 && linux-version compare "${version}" le 6.10; then
+	if linux-version compare "${version}" ge 3.14 && linux-version compare "${version}" le 6.9; then
 
 		# Attach to specific commit (was "branch:realtek-4.4.x")
 		local rtl8192euver='commit:a5ac6789a78a4f5ca0bf157a0f62385ea034cb9c' # Commit date: May 18, 2024 (please update when updating commit ref)
@@ -476,7 +477,8 @@ driver_rtl8811CU_rtl8821C() {
 
 	# Support for these chips is included in the mainline RTW88 driver as seen in this commit for example:
 	# https://github.com/torvalds/linux/commit/605d7c0b05eecb985273b1647070497142c470d3
-	if linux-version compare "${version}" ge 3.14 && linux-version compare "${version}" le 6.10; then
+	# Keep this driver enabled for BananaPi M4 Zero even for kernels >= 6.10 since they still rely on these 3rd party drivers to work properly
+	if linux-version compare "${version}" ge 3.14 && (linux-version compare "${version}" le 6.9 || [[ "$BOARD" == bananapim4zero ]]); then
 
 		# Attach to specific commit (is branch:main)
 		local rtl8811cuver="commit:3eacc28b721950b51b0249508cc31e6e54988a0c" # Commit date: May 3, 2024 (please update when updating commit ref)
@@ -527,7 +529,7 @@ driver_rtl8723cs() {
 
 	# Support for RTL8723cs has been added to mainline 6.10 via RTW88 driver in kernel commit 64be03575f:
 	# https://github.com/torvalds/linux/commit/64be03575f9e9772ebdebc7f067d533348602083
-	if linux-version compare "${version}" ge 6.1 && linux-version compare "${version}" le 6.10; then
+	if linux-version compare "${version}" ge 6.1 && linux-version compare "${version}" le 6.9; then
 
 		# Add to section Makefile
 		echo "obj-\$(CONFIG_RTL8723CS)                += rtl8723cs/" >> "$kerneldir/drivers/staging/Makefile"


### PR DESCRIPTION
# Description

In an effort to reduce wifi driver burdens [AR-1745], I went through the 6.10 kernel to check if any third party wifi drivers can be removed.

The following drivers are part of the mainline kernel as of 6.10:

- RTL8723CS (driver: RTW88)
- RTL8723DS (driver: RTW88)
- RTL8811CU and RTL8821C (driver: RTW88)
- RTL8192EU (driver: RTL8XXXU)

I went through the Armbian forums, Jira and GiHub issues to see if anyone had used those drivers for these chips in the past and had reported issues. But I haven't found anything yet.

- **RTL8723CS**: Add to every board < 6.10
- **RTL8723DS**: Add to every board < 6.10, ALSO add to RockPi-S and Asus Tinkerboard Rev.2 regardless of kernel version (issue with RockPi-S reported by @brentr)
- **RTL8192EU**: Add to every board < 6.10, use RTL8XXXU mainline driver from 6.10 onwards
- **RTL8811CU and RTL8821C**: Add to every board < 6.10, ALSO add to BananaPi M4 Zero regardless of kernel version (@pyavitz reported issue)

This way, maintainers of these specific boards can decide when it's time to switch to a mainline driver.

[Jira](https://armbian.atlassian.net/jira) reference number [AR-1745]

# How Has This Been Tested?

- [x] Build success: ./compile.sh BOARD=nanopc-cm3588-nas BRANCH=edge RELEASE=trixie EXPERT=yes KERNEL_CONFIGURE=no BUILD_MINIMAL=no BUILD_DESKTOP=no
- [ ] Mainline drivers should be tested

**RTL8821CU:**
- [x] @pyavitz USB dongle with this Wifi chip, used on the NanoPi M1 (Allwinner H3), kernel 6.9.3, has no issues with RTW88.
- [ ] @pyavitz onboard module module with this Wifi chip, used on BananaPi M4-ZERO (Allwinner H618), kernel 6.9.3, has a USB-related issue (https://paste.armbian.com/ocomoxuvom.yaml) with RTW88. Suspected cause is the immaturity of the H618.  BSP and Mainline both suffer.

**LOOKING FOR TESTERS:**

Drivers for **RTL8811CU, RTL8821C and RTL8192EU are available also in 6.9**, so if you have a device with those chips, it would be very nice if you could **test them** with their respective kernel driver (RTW88 or RTL8XXXU). You may have to enable them in your board's kernel config.

**If you have a board with a RTL8723DS chip, especially Asus Tinkerboard Rev.2, please test the RTW88 driver. If RockPi-S is the only board which broken RTL8723DS driver, we could switch most other boards to RTW88 for this chip.**

_Installation instructions for the latest RTW88 driver_ (also for older kernels, **you don't need 6.9 or 6.10 to test this**): https://github.com/lwfinger/rtw88/?tab=readme-ov-file#installation-guide

```shell
sudo apt-get update
sudo apt-get install make gcc linux-headers-$(uname -r) build-essential git

git clone https://github.com/lwfinger/rtw88.git
cd rtw88
make
sudo make install
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-1745]: https://armbian.atlassian.net/browse/AR-1745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ