### PR TITLE
Workaround for "Signature Key Uses Weak Algorithm"

### DIFF
--- a/extensions/mesa-vpu.sh
+++ b/extensions/mesa-vpu.sh
@@ -72,6 +72,18 @@ function post_install_kernel_debs__3d() {
 		Pin-Priority: 1001
 		EOF
 
+		if [[ "${RELEASE}" == oracular ]]; then
+
+			# workaround for "Signature Key Uses Weak Algorithm"
+			# https://ubuntuhandbook.org/index.php/2024/04/workaround-apt-warning-signature-key-uses-weak-algorithm/
+			# can be dropped once PPA upgrades signing methods
+
+			display_alert "Workaround for weak algorythm" "${EXTENSION}" "info"
+			cat <<- EOF > "${SDCARD}"/etc/apt/apt.conf.d/99weakkey-warning
+			APT::Key::Assert-Pubkey-Algo ">=rsa1024,ed25529,ed448";
+			EOF
+		fi
+
 	fi
 
 	if [[ "${LINUXFAMILY}" =~ ^(rockchip-rk3588|rk35xx)$ && "${RELEASE}" =~ ^(jammy|noble)$ && "${BRANCH}" =~ ^(legacy|vendor)$ ]]; then


### PR DESCRIPTION
# Description

Due to crypto policy update, apt now (since v2.7.13, see the [commit](https://salsa.debian.org/apt-team/apt/-/commit/50e3fee26ae843a812b1c9ec8531946931773fd3)) requires repositories to be signed using one of the following public key algorithms:

- RSA with at least 2048-bit keys
- Ed25519
- Ed448
 
Affected: Ubuntu Oracular when adding Mesa PPA.

More info
https://ubuntuhandbook.org/index.php/2024/04/workaround-apt-warning-signature-key-uses-weak-algorithm/

[Jira](https://armbian.atlassian.net/jira) reference number [AR-2359]

# How Has This Been Tested?

- [x] https://github.com/armbian/os/actions/runs/9434613892

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-2359]: https://armbian.atlassian.net/browse/AR-2359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ