### PR TITLE
update xapian-apt-index only in case of stable release

### DIFF
--- a/lib/functions/main/rootfs-image.sh
+++ b/lib/functions/main/rootfs-image.sh
@@ -56,7 +56,7 @@ function build_rootfs_and_image() {
 	LOG_SECTION="apt_lists_copy_from_host_to_image_and_update" do_with_logging apt_lists_copy_from_host_to_image_and_update
 
 	# creating xapian index that synaptic runs faster
-	if [[ "${BUILD_DESKTOP}" == yes && ${BETA} != "yes" && -f "${SDCARD}/usr/sbin/update-apt-xapian-index" ]]; then
+	if [[ "${BUILD_DESKTOP}" == yes && "${BETA}" != "yes" && -f "${SDCARD}/usr/sbin/update-apt-xapian-index" ]]; then
 		display_alert "Recreating Synaptic search index" "Please wait - updating Xapian index for image" "info"
 		chroot_sdcard "/usr/sbin/update-apt-xapian-index -u"
 	fi

--- a/lib/functions/main/rootfs-image.sh
+++ b/lib/functions/main/rootfs-image.sh
@@ -56,7 +56,7 @@ function build_rootfs_and_image() {
 	LOG_SECTION="apt_lists_copy_from_host_to_image_and_update" do_with_logging apt_lists_copy_from_host_to_image_and_update
 
 	# creating xapian index that synaptic runs faster
-	if [[ "${BUILD_DESKTOP}" == yes && -f "${SDCARD}/usr/sbin/update-apt-xapian-index" ]]; then
+	if [[ "${BUILD_DESKTOP}" == yes && ${BETA} != "yes" && -f "${SDCARD}/usr/sbin/update-apt-xapian-index" ]]; then
 		display_alert "Recreating Synaptic search index" "Please wait - updating Xapian index for image" "info"
 		chroot_sdcard "/usr/sbin/update-apt-xapian-index -u"
 	fi


### PR DESCRIPTION
# Description
`update-apt-xapian-index` takes an insane amout of time during buid - compounding over dozens of builds you get a nice overhead in compute-time in the hours range

This PR disables `update-apt-xapian-index` for unstable releases `( $BETA = yes )`

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] Built orangepi5-plus desktop with and without BETA=yes, results below

```
Baseline 1st run ( CLEAN_LEVEL="debs,cache" )
Repeat Build Options [ ./compile.sh opi5plus build BRANCH=edge BUILD_DESKTOP=yes CLEAN_LEVEL=debs,cache DESKTOP_APPGROUPS_SELECTED='browsers chat desktop_tools office remote_desktop' DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base RELEASE=bookworm ]
Runtime [ 14:54 min ]
```

```
Baseline 2nd run ( CLEAN_LEVEL="debs" )
Repeat Build Options [ ./compile.sh opi5plus build BRANCH=edge BUILD_DESKTOP=yes CLEAN_LEVEL=debs DESKTOP_APPGROUPS_SELECTED='browsers chat desktop_tools office remote_desktop' DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base RELEASE=bookworm ]
Runtime [ 5:45 min ]

```
```
Baseline 3rd run ( CLEAN_LEVEL="debs" BETA="yes")
Repeat Build Options [ ./compile.sh opi5plus build BETA=yes BRANCH=edge BUILD_DESKTOP=yes CLEAN_LEVEL=debs DESKTOP_APPGROUPS_SELECTED='browsers chat desktop_tools office remote_desktop' DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base RELEASE=bookworm ]
Runtime [ 5:04 min ]
```


```
Baseline 4th run ( CLEAN_LEVEL="debs,cache" BETA="yes")
Repeat Build Options [ ./compile.sh opi5plus build BETA=yes BRANCH=edge BUILD_DESKTOP=yes CLEAN_LEVEL=debs,cache DESKTOP_APPGROUPS_SELECTED='browsers chat desktop_tools office remote_desktop' DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base RELEASE=bookworm ]
Runtime [ 14:14 min ]
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
