### PR TITLE
board: orangepi-5-plus: Add mainline U-Boot for edge kernel

### DIFF
--- a/config/boards/orangepi5-plus.conf
+++ b/config/boards/orangepi5-plus.conf
@@ -10,6 +10,8 @@ FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
 BOOT_FDT_FILE="rockchip/rk3588-orangepi-5-plus.dtb"
 BOOT_SCENARIO="spl-blobs"
+DDR_BLOB='rk35/rk3588_ddr_lp4_2112MHz_lp5_2400MHz_v1.16.bin'
+BL31_BLOB='rk35/rk3588_bl31_v1.45.elf'
 BOOT_SUPPORT_SPI="yes"
 BOOT_SPI_RKSPI_LOADER="yes"
 IMAGE_PARTITION_TABLE="gpt"
@@ -43,7 +45,7 @@ function post_family_config_branch_vendor__orangepi5plus_use_vendor_uboot() {
 }
 
 # Mainline U-Boot for edge kernel
-function post_family_config_branch_edge__nanopct6_use_mainline_uboot() {
+function post_family_config_branch_edge__orangepi5plus_use_mainline_uboot() {
 	display_alert "$BOARD" "Mainline U-Boot overrides for $BOARD - $BRANCH" "info"
 
 	declare -g BOOTCONFIG="orangepi-5-plus-rk3588_defconfig"      # override the default for the board/family


### PR DESCRIPTION
# Description

Helping @alexl83 with his OrangePi 5 Plus 😄

Support for this board with SPI image was added to U-Boot this january: https://github.com/u-boot/u-boot/commit/7c084fd51c0c52b24facdbcfeeaf2c70fba03406

Also add the latest DDR and BL31 blobs, this should fix issues like recently on the NanoPC T6.

Marked as WIP to give room for testing.

# How Has This Been Tested?

- [x] Build success: `./compile.sh BOARD=orangepi5-plus BRANCH=edge RELEASE=trixie EXPERT=yes KERNEL_CONFIGURE=no BUILD_MINIMAL=no BUILD_DESKTOP=no uboot`
- [x] @alexl83 please test freshly built edge kernel image
- [x] @alexl83 please test freshly built vendor kernel image (vendor u-boot should be applied)
- [x] @alexl83 please test edge image on SD card while vendor U-Boot is installed in SPI (or wherever it lives when it comes from the factory)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
