### PR TITLE
Fix board firefly-itx3588j bluetooth

### DIFF
--- a/config/boards/firefly-itx-3588j.csc
+++ b/config/boards/firefly-itx-3588j.csc
@@ -18,3 +18,23 @@ function post_family_config__firefly-itx-3588j_use_vendor_uboot() {
 	BOOTDIR="u-boot-${BOARD}"
 	BOOTPATCHDIR="u-boot-firefly-itx-3588j"
 }
+
+function post_family_tweaks_bsp__firefly-itx-3588j() {
+	display_alert "$BOARD" "Installing rk3588-bluetooth.service" "info"
+
+	# Bluetooth on this board is handled by a Broadcom (AP6275PR3) chip and requires
+	# a custom brcm_patchram_plus binary, plus a systemd service to run it at boot time
+	install -m 755 $SRC/packages/bsp/rk3399/brcm_patchram_plus_rk3399 $destination/usr/bin
+	cp $SRC/packages/bsp/rk3399/rk3399-bluetooth.service $destination/lib/systemd/system/rk3588-bluetooth.service
+
+	# Reuse the service file, ttyS0 -> ttyS6; BCM4345C5.hcd -> BCM4362A2.hcd
+	sed -i 's/ttyS0/ttyS6/g' $destination/lib/systemd/system/rk3588-bluetooth.service
+	sed -i 's/BCM4345C5.hcd/BCM4362A2.hcd/g' $destination/lib/systemd/system/rk3588-bluetooth.service
+	return 0
+}
+
+function post_family_tweaks__firefly-itx-3588j_enable_services() {
+	display_alert "$BOARD" "Enabling rk3588-bluetooth.service" "info"
+	chroot_sdcard systemctl enable rk3588-bluetooth.service
+	return 0
+}


### PR DESCRIPTION
# Description

This board comes with AP6275PR3 wifi6/BT5.0 chip, But it need a `brcm_patchram_plus` to enpower bluetooth.

This commit reused rk3399's bluetooth service file and patchram, replaced serial and firmware.

![image](https://github.com/armbian/build/assets/166212217/a7667093-7195-443d-b0e0-f57b1ea3739a)


# How Has This Been Tested?

- [x] build
- [x] run
- [x] played song using bluetooth speaker
- [x] blueman scan shows devices and uuids correctly

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
