### PR TITLE
Add JetHome JetHub D2 support

### DIFF
--- a/config/boards/jethubj200.wip
+++ b/config/boards/jethubj200.wip
@@ -1,0 +1,20 @@
+# Amlogic S905X3 quad core 4GB RAM SoC eMMC GBE USB2 SPI
+BOARD_NAME="JetHub D2 family"
+BOARDFAMILY="jethub"
+BOARD_MAINTAINER="adeepn"
+BOOTCONFIG="jethub_j200_defconfig"
+KERNEL_TARGET="current,edge"
+MODULES_BLACKLIST="simpledrm" # SimpleDRM conflicts with Panfrost
+FULL_DESKTOP="yes"
+SERIALCON="ttyAML0"
+#BOOT_LOGO="desktop"
+
+BOOTBRANCH_BOARD="tag:v2024.01"
+BOOTPATCHDIR="v2024.01"
+
+BOOT_FDT_FILE="amlogic/meson-sm1-jethome-jethub-j200.dtb"
+
+# To enable the SPI NOR the -spi .dtb is required, because eMMC shares a pin with SPI on the D2. To use it:
+# fdtfile=amlogic/meson-sm1-jethome-jethub-j200-spinor.dtb # in armbianEnv.txt and reboot, then run armbian-install
+# After deploying to SPI-NOR/MTD, return back to the normal DTB, otherwise eMMC speed is impaired.
+#UBOOT_TARGET_MAP="u-boot-dtb.img;;u-boot.bin.sd.bin:u-boot.bin u-boot-dtb.img u-boot.bin:u-boot-spi.bin"

--- a/config/sources/families/include/meson64_common.inc
+++ b/config/sources/families/include/meson64_common.inc
@@ -287,7 +287,7 @@ family_tweaks_bsp() {
 				EndSection
 			EOF
 			;;
-		"odroidn2" | "odroidc4" | "khadas-vim2" | "odroidhc4" | "khadas-vim3" | "khadas-vim3l" | "radxa-zero" | "radxa-zero2" | "bananapi-m2s")
+		"jethubj200" | "odroidn2" | "odroidc4" | "khadas-vim2" | "odroidhc4" | "khadas-vim3" | "khadas-vim3l" | "radxa-zero" | "radxa-zero2" | "bananapi-m2s")
 			cat <<- EOF > "$destination"/etc/X11/xorg.conf
 				Section "Device"
 				    Identifier  "DRM Graphics Acclerated"

--- a/config/sources/families/jethub.conf
+++ b/config/sources/families/jethub.conf
@@ -27,7 +27,14 @@ if [[ "$BOARD" == "jethubj80" ]]; then
 elif [[ "$BOARD" == "jethubj100" ]]; then
 	CPUMAX=1416000
 	OFFSET=126
+elif [[ "$BOARD" == "jethubj200" ]]; then
+	ASOUND_STATE="${ASOUND_STATE:-"asound.state.meson64"}"
+	CPUMIN=667000
+	CPUMAX=2100000
+	BOOTBRANCH="tag:v2024.01"
+	BOOTPATCHDIR="v2024.01"
 fi
+
 
 ########
 # @TODO: Put this in the board configs of the respective boards
@@ -49,11 +56,22 @@ fi
 # but having a core extension allows it to be pre-included in the Dockerfile generation and thus in the Docker images.
 enable_extension "c-plus-plus-compiler"
 
+
+function fetch_sources_tools__jethub_amlogic_fip() {
+       fetch_from_repo "https://github.com/adeepn/amlogic-boot-fip" "amlogic-boot-fip-jethub" "branch:add_jethub_j200"
+}
+
+
 uboot_custom_postprocess() {
 	if [[ "$BOARD" == "jethubj80" ]]; then
 		uboot_gxl_postprocess_ng "$SRC/cache/sources/amlogic-boot-fip/jethub-j80"
 	elif [[ "$BOARD" == "jethubj100" ]]; then
 		uboot_axg_postprocess_ng "$SRC/cache/sources/amlogic-boot-fip/jethub-j100"
+	elif [[ "$BOARD" == "jethubj200" ]]; then
+		uboot_g12_postprocess "$SRC/cache/sources/amlogic-boot-fip-jethub/jethub-j200" g12a
+	else
+		display_alert "uboot_custom_postprocess jethub" "Unknown BOARD: $BOARD - not using FIP trees" "err"
+		exit 1
 	fi
 }
 
@@ -155,7 +173,7 @@ buildjethomecmds() {
 	run_host_command_logged env PATH="${toolchain}:${PATH}" "$gpp" $gpp_options "$SRC/packages/bsp/jethub/jethub_get_cmdline_key.cpp" -o "$destination/usr/bin/jethub_get_cmdline_key" || exit_with_error "Unable to compile jethub_get_cmdline_key.cpp"
 	run_host_command_logged env PATH="${toolchain}:${PATH}" "$gpp" $gpp_options "$SRC/packages/bsp/jethub/jethub_get_cmdline_key_cpuid.cpp" -o "$destination/usr/bin/jethub_get_cpuid" || exit_with_error "Unable to compile jethub_get_cmdline_key_cpuid.cpp"
 
-	if [[ $BOARD == jethubj80 ]]; then
+	if [[ "$BOARD" == "jethubj80" ]]; then
 		# Bluetooth
 		run_host_command_logged install -m 755 "$SRC/packages/blobs/bt/hciattach/rtk_hciattach_$ARCH" "$destination/usr/bin/rtk_hciattach" || exit_with_error "Unable to install rtk_hciattach"
 
@@ -170,7 +188,7 @@ buildjethomecmds() {
 		run_host_command_logged env PATH="${toolchain}:${PATH}" "$gpp" $gpp_options "$SRC/packages/bsp/jethub/$BOARD/jethub_get_efuse_key_mac.cpp" -o "$destination/usr/bin/jethub_get_mac" || exit_with_error "Unable to compile jethub_get_efuse_key_mac.cpp"
 		run_host_command_logged env PATH="${toolchain}:${PATH}" "$gpp" $gpp_options "$SRC/packages/bsp/jethub/$BOARD/jethub_get_efuse_key_serial.cpp" -o "$destination/usr/bin/jethub_get_serial" || exit_with_error "Unable to compile jethub_get_efuse_key_serial.cpp"
 		run_host_command_logged env PATH="${toolchain}:${PATH}" "$gpp" $gpp_options "$SRC/packages/bsp/jethub/$BOARD/jethub_get_efuse_key_usid.cpp" -o "$destination/usr/bin/jethub_get_usid" || exit_with_error "Unable to compile jethub_get_efuse_key_usid.cpp"
-	elif [[ $BOARD == jethubj100 ]]; then
+	elif [[ "$BOARD" == "jethubj100" ]]; then
 		# Board identifiers
 		run_host_command_logged env PATH="${toolchain}:${PATH}" "$gpp" $gpp_options "$SRC/packages/bsp/jethub/$BOARD/jethub_get_cmdline_key_mac.cpp" -o "$destination/usr/bin/jethub_get_mac" || exit_with_error "Unable to compile jethub_get_cmdline_key_mac.cpp"
 
@@ -182,6 +200,8 @@ buildjethomecmds() {
 		run_host_command_logged ln -s "brcmfmac43455-sdio.txt" "$destination/lib/firmware/brcm/brcmfmac43455-sdio.jethome,jethub-j100.txt"
 		run_host_command_logged ln -s "brcmfmac43456-sdio.bin" "$destination/lib/firmware/brcm/brcmfmac43456-sdio.jethome,jethub-j100.bin"
 		run_host_command_logged ln -s "brcmfmac43456-sdio.txt" "$destination/lib/firmware/brcm/brcmfmac43456-sdio.jethome,jethub-j100.txt"
+	elif [[ "$BOARD" == "jethubj200" ]]; then
+		:
 	else
 		exit_with_error "Unexpected board \"$BOARD\""
 	fi

--- a/packages/bsp/jethub/jethubj200/libjethubconfig.sh
+++ b/packages/bsp/jethub/jethubj200/libjethubconfig.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# shellcheck disable=SC2034
+
+#TODO: empty now
+
+GPIOCHIPNUMBER=0
+
+GPIO_DIRECTION_OUTPUT=0
+GPIO_DIRECTION_INPUT=1
+
+GPIO_ACTIVE_LOW=0
+GPIO_ACTIVE_HIGH=1
+
+GPIOS=(
+)
+
+
+# Set LED states
+LEDS=(
+)
+
+
+
+ADDITIONALFUNC=""

--- a/patch/kernel/archive/meson64-6.9/dt/meson-sm1-jethome-jethub-j200-spinor.dts
+++ b/patch/kernel/archive/meson64-6.9/dt/meson-sm1-jethome-jethub-j200-spinor.dts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+
+/dts-v1/;
+
+#include "meson-sm1-jethome-jethub-j200.dts"
+
+/ {
+	model = "JetHub D2 with SPI NOR flash";
+};
+
+#include "meson-g12-enable-spinor.dtsi"

--- a/patch/kernel/archive/meson64-6.9/jethome-0003-dt-bindings-arm-amlogic-add-binding-for-JetHome-JetH.patch
+++ b/patch/kernel/archive/meson64-6.9/jethome-0003-dt-bindings-arm-amlogic-add-binding-for-JetHome-JetH.patch
@@ -1,0 +1,28 @@
+From e38ecc4ec467c5eb1b7e510877532239a43f7db8 Mon Sep 17 00:00:00 2001
+From: Viacheslav Bocharov <adeep@lexina.in>
+Date: Thu, 6 Jun 2024 14:31:12 +0300
+Subject: [PATCH 1/2] dt-bindings: arm: amlogic: add binding for JetHome JetHub
+ D2
+
+JetHome JetHub D2 is a home automation controller, based on Amlogic S905X3 SoC
+
+Signed-off-by: Viacheslav Bocharov <adeep@lexina.in>
+---
+ Documentation/devicetree/bindings/arm/amlogic.yaml | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Documentation/devicetree/bindings/arm/amlogic.yaml b/Documentation/devicetree/bindings/arm/amlogic.yaml
+index a374b98080fe..1acfb184aa9e 100644
+--- a/Documentation/devicetree/bindings/arm/amlogic.yaml
++++ b/Documentation/devicetree/bindings/arm/amlogic.yaml
+@@ -190,6 +190,7 @@ properties:
+               - hardkernel,odroid-c4
+               - hardkernel,odroid-hc4
+               - haochuangyi,h96-max
++              - jethome,jethub-j200
+               - khadas,vim3l
+               - libretech,aml-s905d3-cc
+               - seirobotics,sei610
+-- 
+2.45.2
+

--- a/patch/kernel/archive/meson64-6.9/jethome-0004-arm64-dts-meson-axg-add-support-for-JetHome-JetHub-D.patch
+++ b/patch/kernel/archive/meson64-6.9/jethome-0004-arm64-dts-meson-axg-add-support-for-JetHome-JetHub-D.patch
@@ -1,0 +1,682 @@
+From 7ad1d0a9aa045348451287ab7538201233c64a5b Mon Sep 17 00:00:00 2001
+From: Viacheslav Bocharov <adeep@lexina.in>
+Date: Thu, 16 May 2024 15:14:08 +0300
+Subject: [PATCH 2/2] arm64: dts: meson-axg: add support for JetHome JetHub D2
+ (j200)
+
+JetHome Jethub D2 is a home automation controller with the following features:
+  - DIN Rail Mounting
+  - Amlogic S905X3 (ARM Cortex-A55) quad-core
+  - micro-HDMI video out
+  - 4GB LPDDR4
+  - 32GB eMMC flash
+  - 1 x USB 2.0
+  - 1 x 10/100/1000Mbps ethernet
+  - two module slots for radio/wire interface cards
+  - 2 x gpio LEDS
+  - 1 x 1-Wire
+  - 1 x RS-485
+  - 3 x dry contact digital GPIO inputs
+  - 2 x relay GPIO outputs
+  - DC 9-36V power source with battery UPS on board option
+
+Signed-off-by: Viacheslav Bocharov <adeep@lexina.in>
+---
+ arch/arm64/boot/dts/amlogic/Makefile          |   1 +
+ .../amlogic/meson-sm1-jethome-jethub-j200.dts | 632 ++++++++++++++++++
+ 2 files changed, 633 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/amlogic/meson-sm1-jethome-jethub-j200.dts
+
+diff --git a/arch/arm64/boot/dts/amlogic/Makefile b/arch/arm64/boot/dts/amlogic/Makefile
+index 0f29517da5ec..d007b59497d4 100644
+--- a/arch/arm64/boot/dts/amlogic/Makefile
++++ b/arch/arm64/boot/dts/amlogic/Makefile
+@@ -79,6 +79,7 @@ dtb-$(CONFIG_ARCH_MESON) += meson-sm1-a95xf3-air.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-sm1-bananapi-m2-pro.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-sm1-bananapi-m5.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-sm1-h96-max.dtb
++dtb-$(CONFIG_ARCH_MESON) += meson-sm1-jethome-jethub-j200.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-sm1-khadas-vim3l.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-sm1-khadas-vim3l-ts050.dtb
+ dtb-$(CONFIG_ARCH_MESON) += meson-sm1-s905d3-libretech-cc.dtb
+diff --git a/arch/arm64/boot/dts/amlogic/meson-sm1-jethome-jethub-j200.dts b/arch/arm64/boot/dts/amlogic/meson-sm1-jethome-jethub-j200.dts
+new file mode 100644
+index 000000000000..fcffbd0e24cc
+--- /dev/null
++++ b/arch/arm64/boot/dts/amlogic/meson-sm1-jethome-jethub-j200.dts
+@@ -0,0 +1,632 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2024 JetHome
++ * Author: Viacheslav Bocharov <adeep@lexina.in>
++ */
++
++/dts-v1/;
++
++#include "meson-sm1.dtsi"
++
++#include <dt-bindings/gpio/meson-g12a-gpio.h>
++#include <dt-bindings/leds/common.h>
++#include <dt-bindings/sound/meson-g12a-tohdmitx.h>
++
++
++/ {
++
++	compatible = "jethome,jethub-j200", "amlogic,sm1";
++	model = "JetHome JetHub D2";
++
++	aliases {
++		serial0 = &uart_AO;
++		ethernet0 = &ethmac;
++		rtc0 = &rtc;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	memory@0 {
++		device_type = "memory";
++		reg = <0x0 0x0 0x0 0x40000000>;
++	};
++
++	emmc_pwrseq: emmc-pwrseq {
++		compatible = "mmc-pwrseq-emmc";
++		reset-gpios = <&gpio BOOT_12 GPIO_ACTIVE_LOW>;
++	};
++
++	tflash_vdd: regulator-tflash_vdd {
++		compatible = "regulator-fixed";
++
++		regulator-name = "TFLASH_VDD";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++
++		gpio = <&gpio_ao GPIOAO_3 GPIO_OPEN_DRAIN>; // #TODO: check
++		enable-active-high;
++		regulator-always-on;
++	};
++
++	tf_io: gpio-regulator-tf_io {
++		compatible = "regulator-gpio";
++
++		regulator-name = "TF_IO";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc_5v>;
++
++		enable-gpios = <&gpio_ao GPIOE_2 GPIO_OPEN_DRAIN>;
++		enable-active-high;
++		regulator-always-on;
++
++		gpios = <&gpio_ao GPIOAO_6 GPIO_OPEN_SOURCE>; // #TODO: check
++		gpios-states = <0>;
++
++		states = <3300000 0>,
++			 <1800000 1>;
++	};
++
++	flash_1v8: regulator-flash_1v8 {
++		compatible = "regulator-fixed";
++		regulator-name = "FLASH_1V8";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vcc_3v3>;
++		regulator-always-on;
++	};
++
++	main_12v: regulator-main_12v {
++		compatible = "regulator-fixed";
++		regulator-name = "12V";
++		regulator-min-microvolt = <12000000>;
++		regulator-max-microvolt = <12000000>;
++		regulator-always-on;
++	};
++
++	vcc_5v: regulator-vcc_5v {
++		compatible = "regulator-fixed";
++		regulator-name = "5V";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		regulator-always-on;
++		vin-supply = <&main_12v>;
++		gpio = <&gpio GPIOH_8 GPIO_OPEN_DRAIN>; // #TODO: check
++		enable-active-high;
++	};
++
++	vcc_1v8: regulator-vcc_1v8 {
++		compatible = "regulator-fixed";
++		regulator-name = "VCC_1V8";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vcc_3v3>;
++		regulator-always-on;
++	};
++
++	vcc_3v3: regulator-vcc_3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "VCC_3V3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vddao_3v3>;
++		regulator-always-on;
++		/* FIXME: actually controlled by VDDCPU_B_EN */
++	};
++
++	vddcpu: regulator-vddcpu {
++		/*
++		 * MP8756GD Regulator.
++		 */
++		compatible = "pwm-regulator";
++
++		regulator-name = "VDDCPU";
++		regulator-min-microvolt = <721000>;
++		regulator-max-microvolt = <1022000>;
++
++		pwm-supply = <&main_12v>;
++
++		pwms = <&pwm_AO_cd 1 1250 0>;
++		pwm-dutycycle-range = <100 0>;
++
++		regulator-boot-on;
++		regulator-always-on;
++	};
++
++	usb_pwr_en: regulator-usb_pwr_en {
++		compatible = "regulator-fixed";
++		regulator-name = "USB_PWR_EN";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc_5v>;
++
++		/* Connected to the microUSB port power enable */
++		gpio = <&gpio_ao GPIOAO_2 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++	};
++
++	vddao_1v8: regulator-vddao_1v8 {
++		compatible = "regulator-fixed";
++		regulator-name = "VDDAO_1V8";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vddao_3v3>;
++		regulator-always-on;
++	};
++
++	vddao_3v3: regulator-vddao_3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "VDDAO_3V3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&main_12v>;
++		regulator-always-on;
++	};
++
++	hdmi-connector {
++		compatible = "hdmi-connector";
++		type = "a";
++
++		port {
++			hdmi_connector_in: endpoint {
++				remote-endpoint = <&hdmi_tx_tmds_out>;
++			};
++		};
++	};
++
++	sound {
++		compatible = "amlogic,axg-sound-card";
++		audio-aux-devs = <&tdmout_b>;
++		audio-routing = "TDM_B Playback", "TDMOUT_B OUT";
++
++		assigned-clocks = <&clkc CLKID_MPLL2>,
++				  <&clkc CLKID_MPLL0>,
++				  <&clkc CLKID_MPLL1>;
++		assigned-clock-parents = <0>, <0>, <0>;
++		assigned-clock-rates = <294912000>,
++				       <270950400>,
++				       <393216000>;
++
++		/* 8ch hdmi interface */
++		dai-link-0 {
++			sound-dai = <&tdmif_b>;
++			dai-format = "i2s";
++			dai-tdm-slot-tx-mask-0 = <1 1>;
++			dai-tdm-slot-tx-mask-1 = <1 1>;
++			dai-tdm-slot-tx-mask-2 = <1 1>;
++			dai-tdm-slot-tx-mask-3 = <1 1>;
++			mclk-fs = <256>;
++
++			codec {
++				sound-dai = <&tohdmitx TOHDMITX_I2S_IN_B>;
++			};
++		};
++
++		/* hdmi glue */
++		dai-link-1 {
++			sound-dai = <&tohdmitx TOHDMITX_I2S_OUT>;
++
++			codec {
++				sound-dai = <&hdmi_tx>;
++			};
++		};
++	};
++
++	meson64-reboot {
++		compatible = "meson64,reboot";
++		sys_reset = <0x84000009>;
++		sys_poweroff = <0x84000008>;
++
++		sd-vqen = <&gpio GPIOE_2 GPIO_ACTIVE_HIGH>;
++		sd-vqsw = <&gpio_ao GPIOAO_6 GPIO_ACTIVE_HIGH>;
++		sd-vmmc = <&gpio_ao GPIOAO_3 GPIO_ACTIVE_HIGH>;
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led-green {
++			color = <LED_COLOR_ID_GREEN>;
++			function = LED_FUNCTION_STATUS;
++			gpios = <&gpio_ao GPIOAO_11 GPIO_ACTIVE_LOW>;
++			linux,default-trigger = "activity";
++			panic-indicator;
++		};
++
++		led-red {
++			color = <LED_COLOR_ID_RED>;
++			function = LED_FUNCTION_POWER;
++			gpios = <&gpio GPIOH_5 GPIO_ACTIVE_HIGH>;
++			default-state = "on";
++		};
++
++	};
++
++	sound {
++		model = "JETHUB-D2";
++	};
++
++};
++
++
++&arb {
++	status = "okay";
++};
++
++&cec_AO {
++	pinctrl-0 = <&cec_ao_a_h_pins>;
++	pinctrl-names = "default";
++	status = "disabled";
++	hdmi-phandle = <&hdmi_tx>;
++};
++
++&cecb_AO {
++	pinctrl-0 = <&cec_ao_b_h_pins>;
++	pinctrl-names = "default";
++	status = "okay";
++	hdmi-phandle = <&hdmi_tx>;
++};
++
++&clkc_audio {
++	status = "okay";
++};
++
++&cpu0 {
++	cpu-supply = <&vddcpu>;
++	operating-points-v2 = <&cpu_opp_table>;
++	clocks = <&clkc CLKID_CPU_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu1 {
++	cpu-supply = <&vddcpu>;
++	operating-points-v2 = <&cpu_opp_table>;
++	clocks = <&clkc CLKID_CPU1_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu2 {
++	cpu-supply = <&vddcpu>;
++	operating-points-v2 = <&cpu_opp_table>;
++	clocks = <&clkc CLKID_CPU2_CLK>;
++	clock-latency = <50000>;
++};
++
++&cpu3 {
++	cpu-supply = <&vddcpu>;
++	operating-points-v2 = <&cpu_opp_table>;
++	clocks = <&clkc CLKID_CPU3_CLK>;
++	clock-latency = <50000>;
++};
++
++&ext_mdio {
++	external_phy: ethernet-phy@0 {
++		/* Realtek RTL8211F (0x001cc916) */
++		reg = <0>;
++		max-speed = <1000>;
++
++		reset-assert-us = <10000>;
++		reset-deassert-us = <80000>;
++		reset-gpios = <&gpio GPIOZ_15 (GPIO_ACTIVE_LOW | GPIO_OPEN_DRAIN)>;
++
++		interrupt-parent = <&gpio_intc>;
++		/* MAC_INTR on GPIOZ_14 */
++		interrupts = <IRQID_GPIOZ_14 IRQ_TYPE_LEVEL_LOW>;
++	};
++};
++
++&ethmac {
++	pinctrl-0 = <&eth_pins>, <&eth_rgmii_pins>;
++	pinctrl-names = "default";
++	status = "okay";
++	phy-mode = "rgmii";
++	phy-handle = <&external_phy>;
++	amlogic,tx-delay-ns = <2>;
++};
++
++&gpio {
++	gpio-line-names =
++		/* GPIOZ */
++		"", "", "", "", "", "", "", "",
++		"", "", "", "", "", "", "", "",
++		/* GPIOH */
++		"", "", "", "", "",
++		"LED_RED", /* GPIOH_5 */
++		"I2C_SDA_MODULES", /* GPIOH_6 */
++		"I2C_SCL_MODULES", /* GPIOH_7 */
++		"",
++		/* BOOT */
++		"", "", "", "", "", "", "", "",
++		"", "", "", "", "", "", "", "",
++		/* GPIOC */
++		"", "", "", "", "", "", "", "",
++		/* GPIOA */
++		"", "", "", "", "", "", "", "",
++		"", "", "", "", "", "",
++		"I2C_SDA_SYSBUS", /* GPIOA_14 */
++		"I2C_SCL_SYSBUS", /* GPIOA_15 */
++		/* GPIOX */
++		"", /* GPIOX_0 */
++		"", /* GPIOX_1 */
++		"", /* GPIOX_2 */
++		"", /* GPIOX_3 */
++		"", /* GPIOX_4 */
++		"",  /* GPIOX_5 */
++		"RS485_TX", /* GPIOX_6 */
++		"RS485_RX", /* GPIOX_7 */
++		"", /* GPIOX_8 */
++		"", /* GPIOX_9 */
++		"", /* GPIOX_10 */
++		"", /* GPIOX_11 */
++		"",  /* GPIOX_12 */
++		"", /* GPIOX_13 */
++		"", /* GPIOX_14 */
++		"", /* GPIOX_15 */
++		"", /* GPIOX_16 */
++		"I2C_SDA_LCDBUS",  /* GPIOX_17 */
++		"I2C_SCL_LCDBUS",  /* GPIOX_18 */
++		""; /* GPIOX_19 */
++};
++
++&gpio_ao {
++	gpio-line-names =
++		/* GPIOAO */
++		"", "", "", "",
++		"MCU_RESET", /* GPIOAO_4 */
++		"POWER_GOOD", /* GPIOAO_5 */
++		"",
++		"MCU_BOOT", /* GPIOAO_7 */
++		"MCU_UART_TX", /* GPIOAO_8 */
++		"MCU_UART_RX", /* GPIOAO_9 */
++		"BUTTON_USR", /* GPIOAO_10 */
++		"LED_GREEN", /* GPIOAO_11 */
++		/* GPIOE */
++		"", "", "";
++};
++
++&hdmi_tx {
++	status = "okay";
++	pinctrl-0 = <&hdmitx_hpd_pins>, <&hdmitx_ddc_pins>;
++	pinctrl-names = "default";
++	hdmi-supply = <&vcc_5v>;
++};
++
++&hdmi_tx_tmds_port {
++	hdmi_tx_tmds_out: endpoint {
++		remote-endpoint = <&hdmi_connector_in>;
++	};
++};
++
++&pwm_AO_cd {
++	pinctrl-0 = <&pwm_ao_d_e_pins>; // GPIOE_1
++	pinctrl-names = "default";
++	clocks = <&xtal>;
++	clock-names = "clkin1";
++	status = "okay";
++};
++
++&saradc {
++	status = "okay";
++};
++
++/* SD card */
++&sd_emmc_b {
++	status = "okay";
++	pinctrl-0 = <&sdcard_c_pins>;
++	pinctrl-1 = <&sdcard_clk_gate_c_pins>;
++	pinctrl-names = "default", "clk-gate";
++
++	bus-width = <4>;
++	cap-sd-highspeed;
++	max-frequency = <200000000>;
++	sd-uhs-sdr12;
++	sd-uhs-sdr25;
++	sd-uhs-sdr50;
++	sd-uhs-sdr104;
++	disable-wp;
++
++	cd-gpios = <&gpio GPIOC_6 GPIO_ACTIVE_LOW>;
++	vmmc-supply = <&tflash_vdd>;
++	vqmmc-supply = <&tf_io>;
++};
++
++/* eMMC */
++&sd_emmc_c {
++	status = "okay";
++	pinctrl-0 = <&emmc_ctrl_pins>, <&emmc_data_8b_pins>, <&emmc_ds_pins>;
++	pinctrl-1 = <&emmc_clk_gate_pins>;
++	pinctrl-names = "default", "clk-gate";
++
++	bus-width = <8>;
++	cap-mmc-highspeed;
++	mmc-ddr-1_8v;
++	mmc-hs200-1_8v;
++	max-frequency = <200000000>;
++	disable-wp;
++
++	mmc-pwrseq = <&emmc_pwrseq>;
++	vmmc-supply = <&vcc_3v3>;
++	vqmmc-supply = <&flash_1v8>;
++};
++
++/*
++&sd_emmc_c {
++	pinctrl-0 = <&emmc_ctrl_pins>, <&emmc_data_4b_pins>, <&emmc_ds_pins>;
++        bus-width = <4>;
++};
++
++&spifc {
++	status = "okay";
++	pinctrl-0 = <&nor_pins>;
++	pinctrl-names = "default";
++
++	flash@0 {
++		#address-cells = <1>;
++		#size-cells = <1>;
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <104000000>;
++	};
++};
++*/
++
++&tdmif_b {
++	status = "okay";
++};
++
++&tdmout_b {
++	status = "okay";
++};
++
++&tohdmitx {
++	status = "okay";
++};
++
++&uart_AO {
++	status = "okay";
++	pinctrl-0 = <&uart_ao_a_pins>;
++	pinctrl-names = "default";
++};
++
++&uart_AO_B {
++	status = "okay";
++	pinctrl-0 = <&uart_ao_b_8_9_pins>;
++	pinctrl-names = "default";
++};
++
++&uart_B {
++	status = "okay";
++	pinctrl-0 = <&uart_b_pins>;
++	pinctrl-names = "default";
++};
++
++
++&usb {
++	status = "okay";
++	vbus-supply = <&usb_pwr_en>;
++};
++
++&dwc2 {
++	#address-cells = <1>;
++	#size-cells = <0>;
++
++	/* USB 2.0 hub on otg port */
++	hub_2_0: hub@1 {
++		compatible = "usb4b4,6504"; /* use 10000us timeout for reset */
++		reg = <1>;
++		reset-gpios = <&gpio GPIOH_4 GPIO_ACTIVE_LOW>;
++		vdd-supply = <&vcc_5v>;
++	};
++};
++
++&usb2_phy0 {
++	phy-supply = <&vcc_5v>;
++};
++
++
++/* I2C for modules */
++&i2c1 {
++	status = "okay";
++	pinctrl-0 = <&i2c1_sda_h6_pins>, <&i2c1_sck_h7_pins>;
++	pinctrl-names = "default";
++
++	/* GPIO expander */
++	u9: gpio@22 {
++		compatible = "nxp,pca9535";
++		reg = <0x22>;
++		gpio-controller;
++		#gpio-cells = <2>;
++
++		gpio-line-names =
++			"RELAY_1", "RELAY_2",
++			"", "",
++			"UXM1_RESET", "UXM1_BOOT",
++			"UXM2_RESET", "UXM2_BOOT",
++			"DIN_1", "DIN_2", "DIN_3",
++			"","","","","";
++	};
++
++	/* 1-wire */
++	w1: onewire@18 {
++        	compatible = "maxim,ds2482";
++        	reg = <0x18>;
++      	};
++
++};
++
++
++/* I2C for lcd/etc */
++&i2c2 {
++	status = "okay";
++	pinctrl-0 = <&i2c2_sda_x_pins>, <&i2c2_sck_x_pins>;
++	pinctrl-names = "default";
++};
++
++/* I2C_EE_M3: I2C for CPU board */
++&i2c3 {
++	status = "okay";
++	pinctrl-0 = <&i2c3_sda_a_pins>, <&i2c3_sck_a_pins>;
++	pinctrl-names = "default";
++
++	/* I2C for rtc */
++	rtc: rtc@51 {
++		status = "okay";
++		compatible = "nxp,pcf8563";
++		reg = <0x51>;
++		wakeup-source;
++	};
++
++	/* FRAM on base board */
++	fram: eeprom@52 {
++		compatible = "atmel,24c64";
++		reg = <0x52>;
++		pagesize = <0x20>;
++		label = "fram";
++		address-width = <0x10>;
++		vcc-supply = <&vddao_3v3>;
++	};
++
++	/* EEPROM on CPU board */
++	eepromc: eeprom@54 {
++		compatible = "atmel,24c64";
++		reg = <0x54>;
++		pagesize = <0x20>;
++		label = "eepromc";
++		address-width = <0x10>;
++		vcc-supply = <&vddao_3v3>;
++	};
++
++	/* EEPROM on base board */
++	eeprompd: eeprom@56 {
++		compatible = "atmel,24c64";
++		reg = <0x56>;
++		pagesize = <0x20>;
++		label = "eeprompd";
++		address-width = <0x10>;
++		vcc-supply = <&vddao_3v3>;
++	};
++
++	/* EEPROM on power module */
++	eeprompm: eeprom@57 {
++		compatible = "atmel,24c64";
++		reg = <0x57>;
++		pagesize = <0x20>;
++		label = "eeprompm";
++		address-width = <0x10>;
++		vcc-supply = <&vddao_3v3>;
++	};
++
++	/* temperature sensors */
++	temp1: tmp102@48 {
++		compatible = "ti,tmp102";
++		reg = <0x48>;
++	};
++
++	temp2: tmp102@49 {
++		compatible = "ti,tmp102";
++		reg = <0x49>;
++	};
++
++};
+-- 
+2.45.2
+

--- a/patch/kernel/archive/meson64-6.9/overlay/Makefile
+++ b/patch/kernel/archive/meson64-6.9/overlay/Makefile
@@ -28,7 +28,8 @@ dtbo-$(CONFIG_ARCH_MESON) += \
 	meson-sm1-bananapi-m5-rtl8822cs.dtbo \
 	meson-sm1-bananapi-uartA.dtbo \
 	meson-sm1-bananapi-uartA_cts_rts.dtbo \
-	meson-sm1-bananapi-uartAO_B.dtbo
+	meson-sm1-bananapi-uartAO_B.dtbo \
+	meson-sm1-jethome-jethub-j200-spi.dtbo
 
 scr-$(CONFIG_ARCH_MESON) += \
        meson-fixup.scr

--- a/patch/kernel/archive/meson64-6.9/overlay/meson-sm1-jethome-jethub-j200-spi.dtso
+++ b/patch/kernel/archive/meson64-6.9/overlay/meson-sm1-jethome-jethub-j200-spi.dtso
@@ -1,0 +1,19 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&sd_emmc_c>;
+		__overlay__ {
+			pinctrl-0 = <&emmc_ctrl_pins>, <&emmc_data_4b_pins>, <&emmc_ds_pins>;
+			bus-width = <4>;
+		};
+	};
+
+	fragment@1 {
+		target = <&spifc>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};


### PR DESCRIPTION
# Description

JetHome Jethub D2 (j200) is a home automation controller with the following
features:
  - DIN Rail Mounting
  - Amlogic S905X3 (ARM Cortex-A55) quad-core
  - micro-HDMI video out
  - 4GB LPDDR4
  - 32GB eMMC flash
  - 1 x USB 2.0
  - 1 x 10/100/1000Mbps ethernet
  - two module slots for radio/wire interface cards
  - 2 x gpio LEDS
  - 1 x 1-Wire
  - 1 x RS-485
  - 3 x dry contact digital GPIO inputs
  - 2 x relay GPIO outputs
  - DC 9-36V power source with battery UPS on board option


[Jira](https://armbian.atlassian.net/jira) reference number [AR-2028]

# How Has This Been Tested?

Build and run ok.

- [X] JetHub D2

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings


[AR-2028]: https://armbian.atlassian.net/browse/AR-2028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ