### PR TITLE
NanoPi R6S: Update blobs to fix issue

### DIFF
--- a/config/boards/nanopi-r6s.csc
+++ b/config/boards/nanopi-r6s.csc
@@ -15,23 +15,22 @@ DDR_BLOB='rk35/rk3588_ddr_lp4_2112MHz_lp5_2400MHz_v1.16.bin'
 BL31_BLOB='rk35/rk3588_bl31_v1.45.elf'
 declare -g UEFI_EDK2_BOARD_ID="nanopi-r6s" # This _only_ used for uefi-edk2-rk3588 extension
 
-function post_family_tweaks__nanopir6s_naming_audios() {
-	display_alert "$BOARD" "Renaming nanopir6s audio" "info"
+function post_family_tweaks__nanopir6s_naming_udev_audios() {
+	display_alert "$BOARD" "Renaming NanoPi R6S HDMI audio" "info"
 
 	mkdir -p $SDCARD/etc/udev/rules.d/
-	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-hdmi0-sound", ENV{SOUND_DESCRIPTION}="HDMI0 Audio"' > $SDCARD/etc/udev/rules.d/90-naming-audios.rules
-
-	return 0
+	cat <<- EOF > $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+		SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-hdmi0-sound", ENV{SOUND_DESCRIPTION}="HDMI0 Audio"'
+	EOF
 }
 
-function post_family_tweaks__nanopir6s_udev_network_interfaces() {
-	display_alert "$BOARD" "Renaming interfaces WAN LAN1 LAN2" "info"
+function post_family_tweaks__nanopir6s_naming_udev_network_interfaces() {
+	display_alert "$BOARD" "Renaming NanoPi R6S network interfaces to WAN LAN1 LAN2" "info"
 
 	mkdir -p $SDCARD/etc/udev/rules.d/
-	cat << EOF > "${SDCARD}/etc/udev/rules.d/70-persistent-net.rules"
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", KERNELS=="fe1c0000.ethernet", NAME:="wan"
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="r8169", KERNELS=="0003:31:00.0", NAME:="lan1"
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="r8169", KERNELS=="0004:41:00.0", NAME:="lan2"
-EOF
-
+	cat <<- EOF > "${SDCARD}/etc/udev/rules.d/70-persistent-net.rules"
+		SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", KERNELS=="fe1c0000.ethernet", NAME:="wan"
+		SUBSYSTEM=="net", ACTION=="add", DRIVERS=="r8169", KERNELS=="0003:31:00.0", NAME:="lan1"
+		SUBSYSTEM=="net", ACTION=="add", DRIVERS=="r8169", KERNELS=="0004:41:00.0", NAME:="lan2"
+	EOF
 }


### PR DESCRIPTION
# Description

FriendlyElec ships their devices with the latest blobs. Trying to run an Armbian image on this board with the old blobs might cause issues.
@rpardini run into those issues with the NanoPC T6 and fixed it in https://github.com/armbian/build/pull/6711

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
