### PR TITLE
rockchip-rk3588 6.8.y: nanopct6: Add NanoPC T6 SPI Flash (v6.8.y version)

### DIFF
--- a/patch/kernel/archive/rockchip-rk3588-6.8/1016-arm64-dts-rockchip-Add-NanoPC-T6-SPI-Flash.patch
+++ b/patch/kernel/archive/rockchip-rk3588-6.8/1016-arm64-dts-rockchip-Add-NanoPC-T6-SPI-Flash.patch
@@ -1,0 +1,52 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ricardo Pardini <ricardo@pardini.net>
+Date: Thu, 6 Jun 2024 23:00:05 +0200
+Subject: arm64: dts: rockchip: Add NanoPC T6 SPI Flash
+
+Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts | 14 ++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
+index 997b516c2533c..5ef2cc5fe0679 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
+@@ -541,20 +541,34 @@ &sdmmc {
+ 	cap-sd-highspeed;
+ 	disable-wp;
+ 	no-mmc;
+ 	no-sdio;
+ 	sd-uhs-sdr104;
+ 	vmmc-supply = <&vcc_3v3_s3>;
+ 	vqmmc-supply = <&vccio_sd_s0>;
+ 	status = "okay";
+ };
+ 
++&sfc {
++	pinctrl-names = "default";
++	pinctrl-0 = <&fspim1_pins>;
++	status = "okay";
++
++	flash@0 {
++		compatible = "jedec,spi-nor";
++		reg = <0x0>;
++		spi-max-frequency = <50000000>;
++		spi-rx-bus-width = <4>;
++		spi-tx-bus-width = <1>;
++	};
++};
++
+ &spi2 {
+ 	status = "okay";
+ 	assigned-clocks = <&cru CLK_SPI2>;
+ 	assigned-clock-rates = <200000000>;
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&spi2m2_cs0 &spi2m2_pins>;
+ 	num-cs = <1>;
+ 
+ 	pmic@0 {
+ 		compatible = "rockchip,rk806";
+-- 
+Armbian
+


### PR DESCRIPTION
#### rockchip-rk3588 6.8.y: nanopct6: Add NanoPC T6 SPI Flash (v6.8.y version)

- rockchip-rk3588 6.8.y: nanopct6: Add NanoPC T6 SPI Flash (v6.8.y version)