### PR TITLE
re-add some Khadas Edge 2 patches to edge kernel

### DIFF
--- a/patch/kernel/archive/rockchip-rk3588-6.10/0170-drm-rockchip-vop2-add-clocks-reset-support.patch
+++ b/patch/kernel/archive/rockchip-rk3588-6.10/0170-drm-rockchip-vop2-add-clocks-reset-support.patch
@@ -1,0 +1,190 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Detlev Casanova <detlev.casanova@collabora.com>
+Date: Fri, 3 May 2024 14:27:39 -0400
+Subject: vop2: Add clock resets support
+
+At the end of initialization, each VP clock needs to be reset before
+they can be used.
+
+Failing to do so can put the VOP in an undefined state where the
+generated HDMI signal is either lost or not matching the selected mode.
+
+Signed-off-by: Detlev Casanova <detlev.casanova@collabora.com>
+---
+ drivers/gpu/drm/rockchip/rockchip_drm_vop2.c | 30 ++++++++++
+ 1 file changed, 30 insertions(+)
+
+diff --git a/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c b/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c
+index 111111111111..222222222222 100644
+--- a/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c
++++ b/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c
+@@ -19,6 +19,7 @@
+ #include <linux/platform_device.h>
+ #include <linux/pm_runtime.h>
+ #include <linux/regmap.h>
++#include <linux/reset.h>
+ #include <linux/swab.h>
+ 
+ #include <drm/drm.h>
+@@ -159,6 +160,7 @@ struct vop2_win {
+ struct vop2_video_port {
+ 	struct drm_crtc crtc;
+ 	struct vop2 *vop2;
++	struct reset_control *dclk_rst;
+ 	struct clk *dclk;
+ 	unsigned int id;
+ 	const struct vop2_video_port_data *data;
+@@ -2064,6 +2066,26 @@ static struct vop2_clk *vop2_clk_get(struct vop2 *vop2, const char *name)
+ 	return NULL;
+ }
+ 
++static int vop2_clk_reset(struct vop2_video_port *vp)
++{
++	struct reset_control *rstc = vp->dclk_rst;
++	struct vop2 *vop2 = vp->vop2;
++	int ret;
++
++	if (!rstc)
++		return 0;
++
++	ret = reset_control_assert(rstc);
++	if (ret < 0)
++		drm_warn(vop2->drm, "failed to assert reset\n");
++	udelay(10);
++	ret = reset_control_deassert(rstc);
++	if (ret < 0)
++		drm_warn(vop2->drm, "failed to deassert reset\n");
++
++	return ret;
++}
++
+ static void vop2_crtc_atomic_enable(struct drm_crtc *crtc,
+ 				    struct drm_atomic_state *state)
+ {
+@@ -2233,6 +2255,8 @@ static void vop2_crtc_atomic_enable(struct drm_crtc *crtc,
+ 
+ 	vop2_vp_write(vp, RK3568_VP_DSP_CTRL, dsp_ctrl);
+ 
++	vop2_clk_reset(vp);
++
+ 	drm_crtc_vblank_on(crtc);
+ 
+ 	vop2_unlock(vop2);
+@@ -2920,6 +2944,12 @@ static int vop2_create_crtcs(struct vop2 *vop2)
+ 		vp->data = vp_data;
+ 
+ 		snprintf(dclk_name, sizeof(dclk_name), "dclk_vp%d", vp->id);
++		vp->dclk_rst = devm_reset_control_get_optional(vop2->dev, dclk_name);
++		if (IS_ERR(vp->dclk_rst)) {
++		        drm_err(vop2->drm, "failed to get %s reset\n", dclk_name);
++		        return PTR_ERR(vp->dclk_rst);
++		}
++
+ 		vp->dclk = devm_clk_get(vop2->dev, dclk_name);
+ 		if (IS_ERR(vp->dclk)) {
+ 			drm_err(vop2->drm, "failed to get %s\n", dclk_name);
+-- 
+Armbian
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Detlev Casanova <detlev.casanova@collabora.com>
+Date: Fri, 3 May 2024 14:28:12 -0400
+Subject: arm64: dts: rockchip: Add VOP clock resets for rk3588s
+
+This adds the needed clock resets for all rk3588(s) based SOCs.
+
+Signed-off-by: Detlev Casanova <detlev.casanova@collabora.com>
+---
+ arch/arm64/boot/dts/rockchip/rk3588s.dtsi | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s.dtsi b/arch/arm64/boot/dts/rockchip/rk3588s.dtsi
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588s.dtsi
+@@ -1348,6 +1348,14 @@ vop: vop@fdd90000 {
+ 			      "pclk_vop";
+ 		iommus = <&vop_mmu>;
+ 		power-domains = <&power RK3588_PD_VOP>;
++		resets = <&cru SRST_D_VOP0>,
++			 <&cru SRST_D_VOP1>,
++			 <&cru SRST_D_VOP2>,
++			 <&cru SRST_D_VOP3>;
++		reset-names = "dclk_vp0",
++			      "dclk_vp1",
++			      "dclk_vp2",
++			      "dclk_vp3";
+ 		rockchip,grf = <&sys_grf>;
+ 		rockchip,vop-grf = <&vop_grf>;
+ 		rockchip,vo1-grf = <&vo1_grf>;
+-- 
+Armbian
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Detlev Casanova <detlev.casanova@collabora.com>
+Date: Mon, 6 May 2024 13:54:01 -0400
+Subject: dt-bindings: display: vop2: Add VP clock resets
+
+Add the documentation for VOP2 video ports reset clocks.
+One reset can be set per video port.
+
+Signed-off-by: Detlev Casanova <detlev.casanova@collabora.com>
+---
+ Documentation/devicetree/bindings/display/rockchip/rockchip-vop2.yaml | 27 ++++++++++
+ 1 file changed, 27 insertions(+)
+
+diff --git a/Documentation/devicetree/bindings/display/rockchip/rockchip-vop2.yaml b/Documentation/devicetree/bindings/display/rockchip/rockchip-vop2.yaml
+index 111111111111..222222222222 100644
+--- a/Documentation/devicetree/bindings/display/rockchip/rockchip-vop2.yaml
++++ b/Documentation/devicetree/bindings/display/rockchip/rockchip-vop2.yaml
+@@ -65,6 +65,22 @@ properties:
+       - const: dclk_vp3
+       - const: pclk_vop
+ 
++  resets:
++    minItems: 3
++    items:
++      - description: Pixel clock reset for video port 0.
++      - description: Pixel clock reset for video port 1.
++      - description: Pixel clock reset for video port 2.
++      - description: Pixel clock reset for video port 3.
++
++  reset-names:
++    minItems: 3
++    items:
++      - const: dclk_vp0
++      - const: dclk_vp1
++      - const: dclk_vp2
++      - const: dclk_vp3
++
+   rockchip,grf:
+     $ref: /schemas/types.yaml#/definitions/phandle
+     description:
+@@ -128,6 +144,11 @@ allOf:
+         clock-names:
+           minItems: 7
+ 
++        resets:
++          minItems: 4
++        reset-names:
++          minItems: 4
++
+         ports:
+           required:
+             - port@0
+@@ -183,6 +204,12 @@ examples:
+                               "dclk_vp0",
+                               "dclk_vp1",
+                               "dclk_vp2";
++                resets = <&cru SRST_VOP0>,
++                         <&cru SRST_VOP1>,
++                         <&cru SRST_VOP2>;
++                reset-names = "dclk_vp0",
++                              "dclk_vp1",
++                              "dclk_vp2";
+                 power-domains = <&power RK3568_PD_VO>;
+                 iommus = <&vop_mmu>;
+                 vop_out: ports {
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip-rk3588-6.10/1040-board-khadas-edge2-add-nodes.patch
+++ b/patch/kernel/archive/rockchip-rk3588-6.10/1040-board-khadas-edge2-add-nodes.patch
@@ -1,0 +1,325 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Muhammed Efe Cetin <efectn@protonmail.com>
+Date: Mon, 12 Feb 2024 17:35:13 +0300
+Subject: arm64: dts: rockchip: Add USB-C to Khadas Edge 2
+
+Khadas Edge 2 has 2x Type-C port. One just supports PD and
+controlled by MCU. The other one supports PD, DP Alt mode and DRD. This
+commit adds support for DRD.
+
+Signed-off-by: Muhammed Efe Cetin <efectn@protonmail.com>
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 120 ++++++++++
+ 1 file changed, 120 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -6,6 +6,7 @@
+ #include <dt-bindings/input/input.h>
+ #include <dt-bindings/pinctrl/rockchip.h>
+ #include <dt-bindings/leds/common.h>
++#include <dt-bindings/usb/pd.h>
+ #include "rk3588s.dtsi"
+ 
+ / {
+@@ -76,6 +77,18 @@ blue_led: led-2 {
+ 		};
+ 	};
+ 
++	vbus5v0_typec: vbus5v0-typec-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vbus5v0_typec";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		enable-active-high;
++		gpio = <&gpio3 RK_PA4 GPIO_ACTIVE_HIGH>;
++		vin-supply = <&vcc5v0_sys>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&typec5v_pwren>;
++	};
++
+ 	vcc3v3_pcie_wl: vcc3v3-pcie-wl-regulator {
+ 		compatible = "regulator-fixed";
+ 		enable-active-high;
+@@ -224,6 +237,56 @@ regulator-state-mem {
+ &i2c2 {
+ 	status = "okay";
+ 
++	usbc0: usb-typec@22 {
++		compatible = "fcs,fusb302";
++		reg = <0x22>;
++		interrupt-parent = <&gpio1>;
++		interrupts = <RK_PB5 IRQ_TYPE_LEVEL_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&usbc0_int>;
++		vbus-supply = <&vbus5v0_typec>;
++		status = "okay";
++
++		usb_con: connector {
++			compatible = "usb-c-connector";
++			label = "USB-C";
++			data-role = "dual";
++			power-role = "dual";
++			try-power-role = "source";
++			op-sink-microwatt = <1000000>;
++			sink-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)
++                		     PDO_FIXED(9000, 3000, PDO_FIXED_USB_COMM)
++                		     PDO_FIXED(12000, 3000, PDO_FIXED_USB_COMM)>;
++            		source-pdos = <PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>;
++
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				port@0 {
++					reg = <0>;
++					usbc0_orien_sw: endpoint {
++						remote-endpoint = <&usbdp_phy0_orientation_switch>;
++					};
++				};
++
++				port@1 {
++					reg = <1>;
++					usbc0_role_sw: endpoint {
++						remote-endpoint = <&dwc3_0_role_switch>;
++					};
++				};
++
++				port@2 {
++					reg = <2>;
++					dp_altmode_mux: endpoint {
++						remote-endpoint = <&usbdp_phy0_dp_altmode_mux>;
++					};
++				};
++			};
++		};
++	};
++
+ 	hym8563: rtc@51 {
+ 		compatible = "haoyu,hym8563";
+ 		reg = <0x51>;
+@@ -256,6 +319,16 @@ vcc5v0_host_en: vcc5v0-host-en {
+ 		};
+ 	};
+ 
++	usb-typec {
++		usbc0_int: usbc0-int {
++			rockchip,pins = <1 RK_PB5 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++
++		typec5v_pwren: typec5v-pwren {
++			rockchip,pins = <3 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
+ 	ir-receiver {
+ 		ir_receiver_pin: ir-receiver-pin {
+ 			rockchip,pins = <1  RK_PA7  RK_FUNC_GPIO  &pcfg_pull_none>;
+@@ -681,6 +754,15 @@ &uart9 {
+ 	status = "okay";
+ };
+ 
++&u2phy0 {
++	status = "okay";
++};
++
++&u2phy0_otg {
++	status = "okay";
++};
++
++
+ &u2phy2 {
+ 	status = "okay";
+ };
+@@ -707,6 +789,44 @@ &usb_host0_ohci {
+ 	status = "okay";
+ };
+ 
++&usbdp_phy0 {
++	orientation-switch;
++	mode-switch;
++	svid = <0xff01>;
++	sbu1-dc-gpios = <&gpio4 RK_PA0 GPIO_ACTIVE_HIGH>;
++	sbu2-dc-gpios = <&gpio4 RK_PA1 GPIO_ACTIVE_HIGH>;
++	status = "okay";
++
++	port {
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		usbdp_phy0_orientation_switch: endpoint@0 {
++			reg = <0>;
++			remote-endpoint = <&usbc0_orien_sw>;
++		};
++
++		usbdp_phy0_dp_altmode_mux: endpoint@1 {
++			reg = <1>;
++			remote-endpoint = <&dp_altmode_mux>;
++		};
++	};
++};
++
++&usb_host0_xhci {
++	usb-role-switch;
++	status = "okay";
++
++	port {
++		#address-cells = <1>;
++		#size-cells = <0>;
++		dwc3_0_role_switch: endpoint@0 {
++			reg = <0>;
++			remote-endpoint = <&usbc0_role_sw>;
++		};
++	};
++};
++
+ &usb_host1_ehci {
+ 	status = "okay";
+ };
+-- 
+Armbian
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Muhammed Efe Cetin <efectn@protonmail.com>
+Date: Mon, 12 Feb 2024 17:35:13 +0300
+Subject: arm64: dts: rockchip: Add bluetooth rfkill to Khadas Edge 2
+
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -116,6 +116,15 @@ vcc5v0_host: vcc5v0-host-regulator {
+ 		vin-supply = <&vcc5v0_sys>;
+ 	};
+ 
++	bluetooth-rfkill {
++		compatible = "rfkill-gpio";
++		label = "rfkill-bluetooth";
++		radio-type = "bluetooth";
++		shutdown-gpios = <&gpio0 RK_PD4 GPIO_ACTIVE_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&bt_reset_pin>;
++	};
++
+ 	vcc5v0_sys: vcc5v0-sys-regulator {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vcc5v0_sys";
+-- 
+Armbian
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Muhammed Efe Cetin <efectn@protonmail.com>
+Date: Mon, 19 Feb 2024 23:32:11 +0300
+Subject: arm64: dts: rockchip: Add HDMI & VOP2 to Khadas Edge 2
+
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 36 ++++++++++
+ 1 file changed, 36 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -7,6 +7,7 @@
+ #include <dt-bindings/pinctrl/rockchip.h>
+ #include <dt-bindings/leds/common.h>
+ #include <dt-bindings/usb/pd.h>
++#include <dt-bindings/soc/rockchip,vop2.h>
+ #include "rk3588s.dtsi"
+ 
+ / {
+@@ -823,6 +824,7 @@ usbdp_phy0_dp_altmode_mux: endpoint@1 {
+ };
+ 
+ &usb_host0_xhci {
++	dr-mode = "otg";
+ 	usb-role-switch;
+ 	status = "okay";
+ 
+@@ -847,3 +849,37 @@ &usb_host1_ohci {
+ &usb_host2_xhci {
+ 	status = "okay";
+ };
++
++&hdmi0 {
++	status = "okay";
++};
++
++&hdptxphy_hdmi0 {
++	status = "okay";
++};
++
++&display_subsystem {
++	clocks = <&hdptxphy_hdmi0>;
++	clock-names = "hdmi0_phy_pll";
++};
++
++&vop_mmu {
++	status = "okay";
++};
++
++&hdmi0_in {
++	hdmi0_in_vp0: endpoint {
++		remote-endpoint = <&vp0_out_hdmi0>;
++	};
++};
++
++&vop {
++	status = "okay";
++};
++
++&vp0 {
++	vp0_out_hdmi0: endpoint@ROCKCHIP_VOP2_EP_HDMI0 {
++		reg = <ROCKCHIP_VOP2_EP_HDMI0>;
++		remote-endpoint = <&hdmi0_in_vp0>;
++	};
++};
+-- 
+Armbian
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Muhammed Efe Cetin <efectn@protonmail.com>
+Date: Sat, 2 Mar 2024 19:13:59 +0300
+Subject: arm64: dts: rockchip: Add AP6275P wireless support to Khadas Edge 2
+
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts | 17 ++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+@@ -366,6 +366,23 @@ &pcie2x1l2 {
+ 	reset-gpios = <&gpio3 RK_PD1 GPIO_ACTIVE_HIGH>;
+ 	vpcie3v3-supply = <&vcc3v3_pcie_wl>;
+ 	status = "okay";
++
++	pcie@0,0 {
++		reg = <0x400000 0 0 0 0>;
++		#address-cells = <3>;
++		#size-cells = <2>;
++		ranges;
++		device_type = "pci";
++		bus-range = <0x40 0x4f>;
++
++		wifi: wifi@0,0 {
++			compatible = "pci14e4,449d";
++			reg = <0x410000 0 0 0 0>;
++			clocks = <&hym8563>;
++			clock-names = "32k";
++		};
++	};
++
+ };
+ 
+ &pwm11 {
+-- 
+Armbian
+

--- a/patch/kernel/archive/rockchip-rk3588-6.10/1041-board-khadas-edge2-mcu.patch
+++ b/patch/kernel/archive/rockchip-rk3588-6.10/1041-board-khadas-edge2-mcu.patch
@@ -4,9 +4,9 @@ Date: Wed, 6 Mar 2024 00:09:25 +0300
 Subject: mfd: khadas-mcu: add Edge2 registers
 
 ---
- drivers/mfd/khadas-mcu.c       |  6 ++-
+ drivers/mfd/khadas-mcu.c       |  8 +++-
  include/linux/mfd/khadas-mcu.h | 24 ++++++++++
- 2 files changed, 29 insertions(+), 1 deletion(-)
+ 2 files changed, 30 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/mfd/khadas-mcu.c b/drivers/mfd/khadas-mcu.c
 index 111111111111..222222222222 100644
@@ -23,7 +23,15 @@ index 111111111111..222222222222 100644
  		return true;
  	default:
  		return false;
-@@ -76,7 +80,7 @@ static const struct regmap_config khadas_mcu_regmap_config = {
+@@ -69,14 +73,14 @@ static const struct regmap_config khadas_mcu_regmap_config = {
+ 	.reg_bits	= 8,
+ 	.reg_stride	= 1,
+ 	.val_bits	= 8,
+-	.max_register	= KHADAS_MCU_CMD_FAN_STATUS_CTRL_REG,
++	.max_register	= KHADAS_MCU_SYS_RST_REG,
+ 	.volatile_reg	= khadas_mcu_reg_volatile,
+ 	.writeable_reg	= khadas_mcu_reg_writeable,
+ 	.cache_type	= REGCACHE_MAPLE,
  };
  
  static struct mfd_cell khadas_mcu_fan_cells[] = {
@@ -335,7 +343,7 @@ diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
-@@ -231,6 +231,13 @@ hym8563: rtc@51 {
+@@ -304,6 +304,13 @@ hym8563: rtc@51 {
  		clock-output-names = "hym8563";
  		wakeup-source;
  	};
@@ -365,7 +373,7 @@ diff --git a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts b/arch/arm64/
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
-@@ -240,6 +240,62 @@ khadas_mcu: system-controller@18 {
+@@ -313,6 +313,62 @@ khadas_mcu: system-controller@18 {
  	};
  };
  

--- a/patch/kernel/archive/rockchip-rk3588-6.10/1051-arm64-dts-rockchip-Add-NanoPC-T6-SPI-Flash.patch
+++ b/patch/kernel/archive/rockchip-rk3588-6.10/1051-arm64-dts-rockchip-Add-NanoPC-T6-SPI-Flash.patch
@@ -9,17 +9,10 @@ Signed-off-by: Ricardo Pardini <ricardo@pardini.net>
  1 file changed, 14 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
-index ad8e36a339dc4..2085e73a44642 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
-@@ -569,20 +569,34 @@ &sdmmc {
- 	cd-gpios = <&gpio0 RK_PA4 GPIO_ACTIVE_LOW>;
- 	disable-wp;
- 	no-mmc;
- 	no-sdio;
- 	sd-uhs-sdr104;
- 	vmmc-supply = <&vcc3v3_sd_s0>;
- 	vqmmc-supply = <&vccio_sd_s0>;
+@@ -576,6 +576,20 @@ &sdmmc {
  	status = "okay";
  };
  
@@ -40,13 +33,6 @@ index ad8e36a339dc4..2085e73a44642 100644
  &spi2 {
  	status = "okay";
  	assigned-clocks = <&cru CLK_SPI2>;
- 	assigned-clock-rates = <200000000>;
- 	pinctrl-names = "default";
- 	pinctrl-0 = <&spi2m2_cs0 &spi2m2_pins>;
- 	num-cs = <1>;
- 
- 	pmic@0 {
- 		compatible = "rockchip,rk806";
 -- 
 Armbian
 


### PR DESCRIPTION
# Description

The latest migration to 6.10 broke some functions of Khadas Edge2 board. This PR fixes them.

[Jira](https://armbian.atlassian.net/jira) reference number [AR-9999]

# How Has This Been Tested?
- [x] Auto fan control works.
- [x] Typec works again.

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
