### PR TITLE
rk3588: Add board NanoPi R6C

### DIFF
--- a/config/boards/nanopi-r6c.csc
+++ b/config/boards/nanopi-r6c.csc
@@ -1,0 +1,55 @@
+# Rockchip RK3588S octa core 8GB RAM SoC eMMC 1x NVMe 1x USB3 1x USB2 1x 2.5GbE 1x GbE
+BOARD_NAME="NanoPi R6C"
+BOARDFAMILY="rockchip-rk3588"
+BOARD_MAINTAINER="ColorfulRhino"
+BOOTCONFIG="nanopi-r6c-rk3588s_defconfig" # vendor name, not standard, see hook below, set BOOT_SOC below to compensate
+BOOT_SOC="rk3588"
+KERNEL_TARGET="vendor,current,edge"
+FULL_DESKTOP="yes"
+BOOT_LOGO="desktop"
+IMAGE_PARTITION_TABLE="gpt"
+BOOT_FDT_FILE="rockchip/rk3588s-nanopi-r6c.dtb"
+BOOT_SCENARIO="spl-blobs"
+DDR_BLOB='rk35/rk3588_ddr_lp4_2112MHz_lp5_2400MHz_v1.16.bin'
+BL31_BLOB='rk35/rk3588_bl31_v1.45.elf'
+
+function post_family_tweaks__nanopi_r6c_naming_audios() {
+	display_alert "$BOARD" "Renaming NanoPi R6C HDMI audio interface to human-readable form" "info"
+
+	mkdir -p $SDCARD/etc/udev/rules.d/
+	cat <<- EOF > $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+		SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-hdmi0-sound", ENV{SOUND_DESCRIPTION}="HDMI0 Audio"'
+	EOF
+}
+
+function post_family_tweaks__nanopi_r6c_naming_udev_network_interfaces() {
+	display_alert "$BOARD" "Renaming NanoPi R6C network interfaces to 'wan' and 'lan'" "info"
+
+	mkdir -p $SDCARD/etc/udev/rules.d/
+	cat <<- EOF > "${SDCARD}/etc/udev/rules.d/70-persistent-net.rules"
+		SUBSYSTEM=="net", ACTION=="add", KERNELS=="fe1c0000.ethernet", NAME:="wan"
+		SUBSYSTEM=="net", ACTION=="add", KERNELS=="0003:31:00.0", NAME:="lan"
+	EOF
+}
+
+# Mainline U-Boot
+function post_family_config__nanopi_r6c_use_mainline_uboot() {
+	display_alert "$BOARD" "Using mainline U-Boot for $BOARD / $BRANCH" "info"
+
+	declare -g BOOTCONFIG="generic-rk3588_defconfig"               # Use generic defconfig which should boot all RK3588 boards
+	declare -g BOOTDELAY=1                                         # Wait for UART interrupt to enter UMS/RockUSB mode etc
+	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git"   # We ❤️ Mainline U-Boot
+	declare -g BOOTBRANCH="tag:v2024.07-rc4"
+	declare -g BOOTPATCHDIR="v2024.07/board_${BOARD}"
+	# Don't set BOOTDIR, allow shared U-Boot source directory for disk space efficiency
+
+	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin"
+
+	# Disable stuff from rockchip64_common; we're using binman here which does all the work already
+	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd
+
+	# Just use the binman-provided u-boot-rockchip.bin, which is ready-to-go
+	function write_uboot_platform() {
+		dd "if=$1/u-boot-rockchip.bin" "of=$2" bs=32k seek=1 conv=notrunc status=none
+	}
+}


### PR DESCRIPTION
# Description

While the NanoPi R6C can in theory also use an Armbian image built for the NanoPi R6S [like described on the Armbian website](https://www.armbian.com/nanopi-r6s/), it was not a user-friendly solution at all.

Add the R6C as separate board with support for the latest mainline U-Boot.

The R6S is a solid little machine with one M.2 slot for a NVMe SSD as well as two Ethernet ports (1x 1G, 1x 2.5G), two USB-A (USB2 and USB3) ports and even an integrated chip for UART debugging, so you only need to connect a USB-C cable for debugging instead of the three cables with a separate UART-USB adapter.

**Wiki link**: https://wiki.friendlyelec.com/wiki/index.php/NanoPi_R6C

### Hardware specs:

```
    SoC: Rockchip RK3588S
        CPU: Quad-core ARM Cortex-A76(up to 2.4GHz) and quad-core Cortex-A55 CPU (up to 1.8GHz)
        GPU: Mali-G610 MP4, compatible with OpenGLES 1.1, 2.0, and 3.2, OpenCL up to 2.2 and Vulkan1.2
        VPU: 8K@60fps H.265 and VP9 decoder, 8K@30fps H.264 decoder, 4K@60fps AV1 decoder, 8K@30fps H.264 and H.265 encoder
        NPU: 6TOPs, supports INT4/INT8/INT16/FP16
    RAM: 64-bit 4GB/8GB LPDDR4X at 2133MHz
    Flash: 32GB/None eMMC, at HS400 mode
    Ethernet: one Native Gigabit Ethernet, and one PCIe 2.5G Ethernet
    USB: one USB 3.0 Type-A and one USB 2.0 Type-A
    PCIe: one M.2 Key M connector with PCIe 2.1 x1
    HDMI:
        compatible with HDMI2.1, HDMI2.0, and HDMI1.4 operation
        support up to 7680x4320@60Hz
        Support RGB/YUV(up to 10bit) format
    microSD: support up to SDR104 mode
    GPIO:
        30-pin 2.54mm header connector
        up to 1x SPI, 3x UARTs, 3x I2Cs, 2x SPDIFs, 1x I2Ss, 3x PWMs, 20x GPIOs
    Debug: UART via 3-Pin 2.54mm header, or on-board USB-C to UART
    LEDs: 4 x GPIO Controlled LED (SYS, WAN, LAN, LED1)
    others:
        2 Pin 1.27/1.25mm RTC battery input connector for low power RTC IC HYM8563TS
        MASK button for eMMC update
        one user button
    Power supply: USB-C, support PD, 5V/9V/12V/20V input
    PCB: 8 Layer, 62x90x1.6mm
```

# How Has This Been Tested?

- [x] Build success: `./compile.sh BOARD=nanopi-r6c BRANCH=edge RELEASE=trixie EXPERT=yes KERNEL_CONFIGURE=no BUILD_MINIMAL=no BUILD_DESKTOP=no EXTRAWIFI=no`
- [x] Booting successfully into Armbian, no board-specific problems observed, works as expected

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
