### PR TITLE
Disable autosuspend on Gnome based desktops

### DIFF
--- a/config/desktop/bookworm/environments/budgie/debian/postinst
+++ b/config/desktop/bookworm/environments/budgie/debian/postinst
@@ -66,6 +66,9 @@ exec='/usr/bin/terminator'
 [org/cinnamon/desktop/default-applications/terminal]
 exec='/usr/bin/terminator'
 
+[org/gnome/settings-daemon/plugins/power]
+sleep-inactive-ac-timeout='0'
+
 [org/gnome/desktop/wm/preferences]
 button-layout='appmenu:minimize,maximize,close'
 num-workspaces=2

--- a/config/desktop/bookworm/environments/gnome/debian/postinst
+++ b/config/desktop/bookworm/environments/gnome/debian/postinst
@@ -18,6 +18,9 @@ picture-options='zoom'
 primary-color='#456789'
 secondary-color='#FFFFFF'
 
+[org/gnome/settings-daemon/plugins/power]
+sleep-inactive-ac-timeout='0'
+
 [org/gnome/desktop/screensaver]
 picture-uri='file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'
 picture-options='zoom'

--- a/config/desktop/common/environments/budgie/debian/postinst
+++ b/config/desktop/common/environments/budgie/debian/postinst
@@ -47,6 +47,9 @@ picture-options='stretched'
 picture-uri='file:////usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'
 primary-color='#008094'
 
+[org/gnome/settings-daemon/plugins/power]
+sleep-inactive-ac-timeout='0'
+
 [org/gnome/desktop/interface]
 cursor-theme='DMZ-White'
 document-font-name='Noto Sans UI 11'

--- a/config/desktop/common/environments/gnome/debian/postinst
+++ b/config/desktop/common/environments/gnome/debian/postinst
@@ -17,6 +17,9 @@ echo "
 [org/gnome/shell]
 favorite-apps = ['terminator.desktop', 'org.gnome.Nautilus.desktop', 'google-chrome.desktop', 'thunderbird.desktop', 'code.desktop', 'Zoom.desktop']
 
+[org/gnome/settings-daemon/plugins/power]
+sleep-inactive-ac-timeout='0'
+
 [org/gnome/desktop/background]
 picture-uri='file:///usr/share/backgrounds/armbian/armbian03-Dre0x-Minum-dark-3840x2160.jpg'
 picture-options='zoom'


### PR DESCRIPTION
# Description

[Jira](https://armbian.atlassian.net/jira) reference number [AR-2368]

# How Has This Been Tested?

- [x] Generated Gnome desktop image didn't go into suspend by default

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-2368]: https://armbian.atlassian.net/browse/AR-2368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ