### PR TITLE
extlinux: add DEFAULT_OVERLAYS support

### DIFF
--- a/lib/functions/rootfs/distro-agnostic.sh
+++ b/lib/functions/rootfs/distro-agnostic.sh
@@ -146,6 +146,15 @@ function install_distribution_agnostic() {
 		else
 			echo "  fdtdir ${bootpart_prefix}dtb/" >> "$SDCARD/boot/extlinux/extlinux.conf"
 		fi
+
+		if [[ -n $DEFAULT_OVERLAYS ]]; then
+			DEFAULT_OVERLAYS=(${DEFAULT_OVERLAYS//,/ })
+			DEFAULT_OVERLAYS=("${DEFAULT_OVERLAYS[@]/%/".dtbo"}")
+			DEFAULT_OVERLAYS=("${DEFAULT_OVERLAYS[@]/#/"${bootpart_prefix}dtb/${BOOT_FDT_FILE%%/*}/overlay/${OVERLAY_PREFIX}-"}")
+
+			display_alert "Adding to extlinux.conf" "fdtoverlays=${DEFAULT_OVERLAYS[@]}" "debug"
+			echo "  fdtoverlays ${DEFAULT_OVERLAYS[@]}" >> "$SDCARD/boot/extlinux/extlinux.conf"
+		fi
 	else # ... not extlinux ...
 
 		if [[ -n "${BOOTSCRIPT}" ]]; then # @TODO: && "${BOOTCONFIG}" != "none"


### PR DESCRIPTION
# Description

DEFAULT_OVERLAYS is only supported for bootscripts and is not used by Extlinux. Let's add it to Extlinux to fix some extensions like `mesa-vpu`.

[Jira](https://armbian.atlassian.net/jira) reference number [AR-2370]

# How Has This Been Tested?
- [x] Khadas Edge2 now works well with `mesa-vpu` extension using panthor

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-2370]: https://armbian.atlassian.net/browse/AR-2370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ