### PR TITLE
actions: Fix typo in actions/labeler labeler.yml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,7 +14,7 @@
 - all:
   - changed-files:
     - any-glob-to-any-file: ['patch/**/*','config/**/*']
-    - any-globs-to-all-files: ['!config/cli/*','!config/desktop/*','!config/distributions/*']
+    - any-glob-to-all-files: ['!config/cli/*','!config/desktop/*','!config/distributions/*']
 
 "Framework":
 - all:


### PR DESCRIPTION
Quick fix for PR https://github.com/armbian/build/pull/6743, see https://github.com/armbian/build/actions/runs/9520292766/job/26245280729

It's not `any-globs-to-all-files`, but `any-glob-to-all-files`.