### PR TITLE
cli: Fix DEFAULT_OVERLAYS array

### DIFF
--- a/lib/functions/rootfs/distro-agnostic.sh
+++ b/lib/functions/rootfs/distro-agnostic.sh
@@ -148,13 +148,14 @@ function install_distribution_agnostic() {
 		fi
 
 		if [[ -n $DEFAULT_OVERLAYS ]]; then
-			DEFAULT_OVERLAYS=(${DEFAULT_OVERLAYS//,/ })
-			DEFAULT_OVERLAYS=("${DEFAULT_OVERLAYS[@]/%/".dtbo"}")
-			DEFAULT_OVERLAYS=("${DEFAULT_OVERLAYS[@]/#/"${bootpart_prefix}dtb/${BOOT_FDT_FILE%%/*}/overlay/${OVERLAY_PREFIX}-"}")
+			DEFAULT_OVERLAYS_ARR=(${DEFAULT_OVERLAYS//,/ })
+			DEFAULT_OVERLAYS_ARR=("${DEFAULT_OVERLAYS_ARR[@]/%/".dtbo"}")
+			DEFAULT_OVERLAYS_ARR=("${DEFAULT_OVERLAYS_ARR[@]/#/"${bootpart_prefix}dtb/${BOOT_FDT_FILE%%/*}/overlay/${OVERLAY_PREFIX}-"}")
 
-			display_alert "Adding to extlinux.conf" "fdtoverlays=${DEFAULT_OVERLAYS[@]}" "debug"
-			echo "  fdtoverlays ${DEFAULT_OVERLAYS[@]}" >> "$SDCARD/boot/extlinux/extlinux.conf"
+			display_alert "Adding to extlinux.conf" "fdtoverlays=${DEFAULT_OVERLAYS_ARR[*]}" "debug"
+			echo "  fdtoverlays ${DEFAULT_OVERLAYS_ARR[*]}" >> "$SDCARD/boot/extlinux/extlinux.conf"
 		fi
+
 	else # ... not extlinux ...
 
 		if [[ -n "${BOOTSCRIPT}" ]]; then # @TODO: && "${BOOTCONFIG}" != "none"


### PR DESCRIPTION
# Description

Shellcheck errors/warnings were:
```
In lib/functions/rootfs/distro-agnostic.sh line 155:
                        display_alert "Adding to extlinux.conf" "fdtoverlays=${DEFAULT_OVERLAYS[@]}" "debug"
                                                                             ^--------------------^ SC2145 (error): Argument mixes string and array. Use * or separate argument.

In lib/functions/rootfs/distro-agnostic.sh line 156:
                        echo "  fdtoverlays ${DEFAULT_OVERLAYS[@]}" >> "$SDCARD/boot/extlinux/extlinux.conf"
                                            ^--------------------^ SC2145 (error): Argument mixes string and array. Use * or separate argument.

In lib/functions/rootfs/distro-agnostic.sh line 193:
                if [[ -n $DEFAULT_OVERLAYS && -f "${SDCARD}"/boot/armbianEnv.txt ]]; then
                         ^---------------^ SC2128 (warning): Expanding an array without an index only gives the first element.
```

Fixes https://github.com/armbian/build/pull/6744

# How it was tested

- [x] Shellcheck does not output any warnings or errors anymore: https://github.com/armbian/build/actions/runs/9522581973/job/26252408859?pr=6746