### PR TITLE
rockchip-rk3588-edge: fix vepu of rk3588

### DIFF
--- a/patch/kernel/archive/rockchip-rk3588-6.10/0025-RK3588-Add-VPU121-H.264-Decoder-Support.patch
+++ b/patch/kernel/archive/rockchip-rk3588-6.10/0025-RK3588-Add-VPU121-H.264-Decoder-Support.patch
@@ -169,7 +169,7 @@ index 111111111111..222222222222 100644
  	{ .compatible = "rockchip,rk3399-vpu", .data = &rk3399_vpu_variant, },
  	{ .compatible = "rockchip,rk3568-vepu", .data = &rk3568_vepu_variant, },
  	{ .compatible = "rockchip,rk3568-vpu", .data = &rk3568_vpu_variant, },
-+	{ .compatible = "rockchip,rk3588-vepu121", .data = &rk3568_vpu_variant, },
++	{ .compatible = "rockchip,rk3588-vepu121", .data = &rk3568_vepu_variant, },
  	{ .compatible = "rockchip,rk3588-av1-vpu", .data = &rk3588_vpu981_variant, },
  #endif
  #ifdef CONFIG_VIDEO_HANTRO_IMX8M


### PR DESCRIPTION
# Description

This is a typo in the patch. `rk3568_vpu_variant` is for decoder.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh kernel BOARD=rock-5b BRANCH=edge DEB_COMPRESS=xz KERNEL_CONFIGURE=no KERNEL_GIT=shallow`
- [x] `gst-launch-1.0 videotestsrc pattern=ball flip=true ! v4l2jpegenc  ! matroskamux ! filesink location=jpegtest.mkv`, see vepu load by command `cat /proc/interrupts |grep fdba`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
