### PR TITLE
khadas-edge2: add vendor uboot to images

### DIFF
--- a/config/boards/khadas-edge2.conf
+++ b/config/boards/khadas-edge2.conf
@@ -25,10 +25,17 @@ function post_family_tweaks__kedge2_naming_audios() {
 	return 0
 }
 
+declare -g DDR_BLOB='rk35/rk3588_ddr_lp4_2112MHz_lp5_2400MHz_v1.16.bin'
+declare -g BL31_BLOB='rk35/rk3588_bl31_v1.45.elf'
+declare -g BL32_BLOB='rk35/rk3588_bl32_v1.15.bin'
+
 # for the kedge2, we're counting on the blobs+u-boot in SPI working, as it comes from factory. It does not support bootscripts.
 function post_family_config__uboot_kedge2() {
-	display_alert "$BOARD" "Configuring ($BOARD) non-u-boot" "info"
-	unset BOOTSOURCE
-	declare -g BOOTCONFIG='none'
+	display_alert "$BOARD" "Configuring ($BOARD) u-boot" "info"
+
+	declare -g BOOTSOURCE='https://github.com/khadas/u-boot.git'
+	declare -g BOOTBRANCH='branch:khadas-edges-v2017.09'
+	declare -g BOOTPATCHDIR="legacy/u-boot-khadas-edge2-rk3588"
+	declare -g BOOTCONFIG="khadas-edge2-rk3588s_defconfig"
 	declare -g SRC_EXTLINUX="yes" # For now, use extlinux. Thanks Monka
 }

--- a/config/sources/families/include/rockchip64_common.inc
+++ b/config/sources/families/include/rockchip64_common.inc
@@ -174,6 +174,10 @@ prepare_boot_configuration() {
 			;;
 	esac
 
+	if [[ ! -z $BL32_BLOB ]]; then
+		UBOOT_TARGET_MAP="BL32=$RKBIN_DIR/$BL32_BLOB ${UBOOT_TARGET_MAP}"
+	fi
+
 	if [[ $BOOT_SUPPORT_SPI == yes ]]; then
 
 		if [[ "${BOOT_SPI_RKSPI_LOADER:-"no"}" != "yes" ]]; then

--- a/lib/functions/artifacts/artifact-uboot.sh
+++ b/lib/functions/artifacts/artifact-uboot.sh
@@ -97,7 +97,7 @@ function artifact_uboot_prepare_version() {
 		"${BOOTCONFIG:-"no_bootconfig"}"
 		"${BOOTDELAY}" "${UBOOT_DEBUGGING}" "${UBOOT_TARGET_MAP}" # general for all families
 		"${BOOT_SCENARIO}" "${BOOT_SUPPORT_SPI}" "${BOOT_SOC}"    # rockchip stuff, sorry.
-		"${DDR_BLOB}" "${BL31_BLOB}" "${MINILOADER_BLOB}"         # More rockchip stuff, even more sorry.
+		"${DDR_BLOB}" "${BL31_BLOB}" "${BL32_BLOB}" "${MINILOADER_BLOB}"         # More rockchip stuff, even more sorry.
 		"${ATF_COMPILE}" "${ATFBRANCH}" "${ATFPATCHDIR}"          # arm-trusted-firmware stuff
 		"${CRUSTCONFIG}" "${CRUSTBRANCH}" "${CRUSTPATCHDIR}"      # crust stuff
 	)

--- a/patch/u-boot/legacy/u-boot-khadas-edge2-rk3588/0001-fix-tee.bin-not-found-error.patch
+++ b/patch/u-boot/legacy/u-boot-khadas-edge2-rk3588/0001-fix-tee.bin-not-found-error.patch
@@ -1,0 +1,104 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Muhammed Efe Cetin <efectn@protonmail.com>
+Date: Thu, 13 Jun 2024 16:46:31 +0300
+Subject: fix tee.bin not found error
+
+---
+ arch/arm/mach-rockchip/decode_bl31.py  | 14 +++++++--
+ arch/arm/mach-rockchip/fit_nodes.sh    | 10 ++-----
+ arch/arm/mach-rockchip/make_fit_atf.py | 15 ++++++++--
+ 3 files changed, 27 insertions(+), 12 deletions(-)
+
+diff --git a/arch/arm/mach-rockchip/decode_bl31.py b/arch/arm/mach-rockchip/decode_bl31.py
+index 111111111111..222222222222 100755
+--- a/arch/arm/mach-rockchip/decode_bl31.py
++++ b/arch/arm/mach-rockchip/decode_bl31.py
+@@ -41,8 +41,18 @@ def generate_atf_binary(bl31_file_name):
+             atf.write(data)
+ 
+ def main():
+-    bl31_elf="./bl31.elf"
++    if "BL31" in os.environ:
++        bl31_elf=os.getenv("BL31");
++    elif os.path.isfile("./bl31.elf"):
++        bl31_elf = "./bl31.elf"
++    else:
++        os.system("echo 'int main(){}' > bl31.c")
++        os.system("${CROSS_COMPILE}gcc -c bl31.c -o bl31.elf")
++        bl31_elf = "./bl31.elf"
++        logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.DEBUG)
++        logging.warning(' BL31 file bl31.elf NOT found, resulting binary is non-functional')
++        logging.warning(' Please read Building section in doc/README.rockchip')
+     generate_atf_binary(bl31_elf);
+ 
+ if __name__ == "__main__":
+-    main()
++    main()
+\ No newline at end of file
+diff --git a/arch/arm/mach-rockchip/fit_nodes.sh b/arch/arm/mach-rockchip/fit_nodes.sh
+index 111111111111..222222222222 100755
+--- a/arch/arm/mach-rockchip/fit_nodes.sh
++++ b/arch/arm/mach-rockchip/fit_nodes.sh
+@@ -171,16 +171,10 @@ function gen_bl32_node()
+ 		# If not AArch32 mode
+ 		if ! grep  -q '^CONFIG_ARM64_BOOT_AARCH32=y' .config ; then
+ 			ENTRY="entry = <"${TEE_LOAD_ADDR}">;"
+-
+-			# if disable packing tee.bin
+-			if ! grep -q '^CONFIG_SPL_OPTEE=y' .config ; then
+-				return
+-			fi
+-
+ 		fi
+ 	fi
+ 
+-	TEE="tee.bin"
++	TEE="${BL32:-"tee.bin"}"
+ 	echo "		optee {
+ 			description = \"OP-TEE\";
+ 			data = /incbin/(\"${TEE}${SUFFIX}\");
+@@ -204,7 +198,7 @@ function gen_bl32_node()
+ 		};"
+ 	LOADABLE_OPTEE=", \"optee\""
+ 	FIRMWARE_OPTEE="firmware = \"optee\";"
+-	FIRMWARE_SIGN="\"firmware\""
++	FIRMWARE_SIGN=", \"firmware\""
+ }
+ 
+ function gen_mcu_node()
+diff --git a/arch/arm/mach-rockchip/make_fit_atf.py b/arch/arm/mach-rockchip/make_fit_atf.py
+index 111111111111..222222222222 100755
+--- a/arch/arm/mach-rockchip/make_fit_atf.py
++++ b/arch/arm/mach-rockchip/make_fit_atf.py
+@@ -212,9 +212,20 @@ def get_bl31_segments_info(bl31_file_name):
+ 
+ def main():
+     uboot_elf="./u-boot"
+-    bl31_elf="./bl31.elf"
+     FIT_ITS=sys.stdout
+ 
++    if "BL31" in os.environ:
++        bl31_elf=os.getenv("BL31");
++    elif os.path.isfile("./bl31.elf"):
++        bl31_elf = "./bl31.elf"
++    else:
++        os.system("echo 'int main(){}' > bl31.c")
++        os.system("${CROSS_COMPILE}gcc -c bl31.c -o bl31.elf")
++        bl31_elf = "./bl31.elf"
++        logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.DEBUG)
++        logging.warning(' BL31 file bl31.elf NOT found, resulting binary is non-functional')
++        logging.warning(' Please read Building section in doc/README.rockchip')
++
+     opts, args = getopt.getopt(sys.argv[1:], "o:u:b:h")
+     for opt, val in opts:
+         if opt == "-o":
+@@ -235,4 +246,4 @@ def main():
+     generate_atf_binary(bl31_elf);
+ 
+ if __name__ == "__main__":
+-    main()
++    main()
+\ No newline at end of file
+-- 
+Armbian
+


### PR DESCRIPTION
# Description

Replication of https://github.com/armbian/build/pull/6741

Khadas Edge 2 images has been shipped without Uboot and it may cause some problems like not-booting when eMMC and SPI is empty. This PR adds vendor's uboot to Edge 2 images. 
I've also added BL32 blob because the board doesn't boot when SPI has BL32 blobs and SD card doesn't have.

cc @rpardini @viraniac 

# How Has This Been Tested?
- [x] SPI + SD card
- [x] Empty SPI + SD card
- [x] SPI + eMMC
- [x] Empty SPI + eMMC
# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
