### PR TITLE
board: nanopi-r6s: Add system-power-controller to pmic

### DIFF
--- a/patch/kernel/archive/rockchip-rk3588-6.10/dt/rk3588s-nanopi-r6s.dts
+++ b/patch/kernel/archive/rockchip-rk3588-6.10/dt/rk3588s-nanopi-r6s.dts
@@ -482,6 +482,8 @@
 		pinctrl-0 = <&pmic_pins>, <&rk806_dvs1_null>,
 			    <&rk806_dvs2_null>, <&rk806_dvs3_null>;
 
+		system-power-controller;
+
 		vcc1-supply = <&vcc5v0_sys>;
 		vcc2-supply = <&vcc5v0_sys>;
 		vcc3-supply = <&vcc5v0_sys>;

--- a/patch/kernel/archive/rockchip-rk3588-6.8/dt/rk3588s-nanopi-r6s.dts
+++ b/patch/kernel/archive/rockchip-rk3588-6.8/dt/rk3588s-nanopi-r6s.dts
@@ -482,6 +482,8 @@
 		pinctrl-0 = <&pmic_pins>, <&rk806_dvs1_null>,
 			    <&rk806_dvs2_null>, <&rk806_dvs3_null>;
 
+		system-power-controller;
+
 		vcc1-supply = <&vcc5v0_sys>;
 		vcc2-supply = <&vcc5v0_sys>;
 		vcc3-supply = <&vcc5v0_sys>;


### PR DESCRIPTION
# Description

Without this, the board can't be powered off with the `poweroff` command. Also affects NanoPi R6C.

# How Has This Been Tested?

- [x] NanoPi R6C can properly poweroff

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
