### PR TITLE
Odroid M1: add a network rule to rename default name

### DIFF
--- a/config/boards/odroidm1.conf
+++ b/config/boards/odroidm1.conf
@@ -77,4 +77,12 @@ function post_family_tweaks__config_odroidm1_fwenv() {
 		# MTD device name Device offset Env. size Flash sector size Number of sectors
 		/dev/mtd1                       0x0000                      0x20000
 	FW_ENV_CONFIG
+
+	# add a network rule to rename default name
+	display_alert "Creating network rename rule for Odroid M1"
+	mkdir -p "${SDCARD}"/etc/udev/rules.d/
+	cat <<- EOF > "${SDCARD}"/etc/udev/rules.d/70-rename-lan.rules
+	SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", KERNEL=="end*", NAME="eth0"
+	EOF
+
 }


### PR DESCRIPTION
# Description

Renaming network device to eth0

# How Has This Been Tested?

- [x] Generated image

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
