### PR TITLE
Debian buster: disable non-existing backports repository

### DIFF
--- a/lib/functions/rootfs/distro-specific.sh
+++ b/lib/functions/rootfs/distro-specific.sh
@@ -106,9 +106,6 @@ function create_sources_list_and_deploy_repo_key() {
 				deb http://${DEBIAN_MIRROR} ${release}-updates main contrib non-free
 				#deb-src http://${DEBIAN_MIRROR} ${release}-updates main contrib non-free
 
-				deb http://${DEBIAN_MIRROR} ${release}-backports main contrib non-free
-				#deb-src http://${DEBIAN_MIRROR} ${release}-backports main contrib non-free
-
 				deb http://${DEBIAN_SECURTY} ${release}/updates main contrib non-free
 				#deb-src http://${DEBIAN_SECURTY} ${release}/updates main contrib non-free
 			EOF


### PR DESCRIPTION
# Description

Maintainace.

# How Has This Been Tested?

- [x] Noticed that it breaks on building if this repo is enabled

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
