### PR TITLE
packages: Enable bash-completion on all images

### DIFF
--- a/config/cli/common/main/packages
+++ b/config/cli/common/main/packages
@@ -1,4 +1,5 @@
 alsa-utils
+bash-completion
 bc
 bridge-utils
 chrony

--- a/config/cli/common/main/packages.additional
+++ b/config/cli/common/main/packages.additional
@@ -3,7 +3,6 @@ apt-utils
 aptitude
 automake
 avahi-autoipd
-bash-completion
 bison
 btrfs-progs
 build-essential


### PR DESCRIPTION
# Description

`bash-completion` adds the functionality for autocompleting command when pressing TAB.

This is an essential shell functionality and should be enabled even on a minimal image.
The package has no dependencies and is slim: https://packages.ubuntu.com/noble/bash-completion

# How Has This Been Tested?

- [x] Install minimal image without `bash-completion`: _pain_ 😵‍💫
- [x] Install minimal image without `bash-completion`: nice and efficient 🌈

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] My changes generate no new warnings
