### PR TITLE
Fix base-files not being able to download because packages.debian.org is down

### DIFF
--- a/lib/functions/general/apt-utils.sh
+++ b/lib/functions/general/apt-utils.sh
@@ -69,8 +69,8 @@ function apt_find_upstream_package_version_and_download_url() {
 		display_alert "Could not find package filename for '${sought_package_name}' in '${package_info_download_urls[*]}'" "Trying alternative method to get ${sought_package_name}" "warn"
 		# Try alternative method since packages.debian.org is down often
 		# Use -N with wget so it always downloads the latest file, overwriting the local one if it exists
-		run_host_command_logged wget --no-verbose -N https://${mirror_with_slash}/dists/${RELEASE}/main/binary-${ARCH}/Packages.gz
-		run_host_command_logged gzip -d -f Packages.gz
+		run_host_command_logged wget --no-verbose -N https://${mirror_with_slash}/dists/${RELEASE}/main/binary-${ARCH}/Packages.xz
+		run_host_command_logged xz -d -f Packages.xz
 		declare package_filename_from_packages
 		package_filename_from_packages="$(grep -A 25 "Package: ${sought_package_name}" Packages | grep "Filename:" | awk '{print $2}')" # Format example: pool/main/b/base-files/base-files_13.3_arm64.deb
 

--- a/lib/functions/general/apt-utils.sh
+++ b/lib/functions/general/apt-utils.sh
@@ -66,8 +66,25 @@ function apt_find_upstream_package_version_and_download_url() {
 	if [[ "${found_package_filename}" == "${sought_package_name}_"* ]]; then
 		display_alert "Found upstream base-files package filename" "${found_package_filename}" "info"
 	else
-		display_alert "Could not find package filename for '${sought_package_name}' in '${package_info_download_urls[*]}'" "looking for ${sought_package_name}" "warn"
-		return 1
+		display_alert "Could not find package filename for '${sought_package_name}' in '${package_info_download_urls[*]}'" "Trying alternative method to get ${sought_package_name}" "warn"
+		# Try alternative method since packages.debian.org is down often
+		# Use -N with wget so it always downloads the latest file, overwriting the local one if it exists
+		run_host_command_logged wget --no-verbose -N https://${mirror_with_slash}/dists/${RELEASE}/main/binary-${ARCH}/Packages.gz
+		run_host_command_logged gzip -d -f Packages.gz
+		declare package_filename_from_packages
+		package_filename_from_packages="$(grep -A 25 "Package: ${sought_package_name}" Packages | grep "Filename:" | awk '{print $2}')" # Format example: pool/main/b/base-files/base-files_13.3_arm64.deb
+
+		found_package_down_url=="http://${mirror_with_slash}${package_filename_from_packages}"
+		found_package_filename="$(echo $found_package_down_url | awk -F'/' '{print $NF}')"
+
+		# Test again, same as if statement above
+		if [[ "${found_package_filename}" == "${sought_package_name}_"* ]]; then
+			display_alert "Found upstream base-files package filename" "${found_package_filename}" "info"
+			run_host_command_logged rm -f Packages
+		else
+			display_alert "Could not find package filename for '${sought_package_name}' in '${found_package_down_url}'" "looking for ${sought_package_name} with the alternative method" "warn"
+			return 1
+		fi
 	fi
 
 	# Now we have the package name, lets parse out the version.


### PR DESCRIPTION
# Description

[packages.debian.org](https://packages.debian.org) has been down a lot lately, so builds could not finish since the build system wants to find out the package name and version for `base-files`.
Use `Packages.xz` from the mirrors as an alternative method to search for this information.

# How Has This Been Tested?

- [x] Building works as normal even if packages.debian.org is down

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
