### PR TITLE
aic8800: update firmware package URL

### DIFF
--- a/extensions/radxa-aic8800.sh
+++ b/extensions/radxa-aic8800.sh
@@ -12,7 +12,7 @@ function post_install_kernel_debs__install_aic8800_dkms_package() {
 	[[ -z $AIC8800_TYPE ]] && return 0
 	api_url="https://api.github.com/repos/radxa-pkg/aic8800/releases/latest"
 	latest_version=$(curl -s "${api_url}" | jq -r '.tag_name')
-	aic8800_firmware_url="https://github.com/radxa-pkg/aic8800/releases/download/${latest_version}/aic8800-firmware_${latest_version}_arm64.deb"
+	aic8800_firmware_url="https://github.com/radxa-pkg/aic8800/releases/download/${latest_version}/aic8800-firmware_${latest_version}_all.deb"
 	aic8800_pcie_url="https://github.com/radxa-pkg/aic8800/releases/download/${latest_version}/aic8800-pcie-dkms_${latest_version}_all.deb"
 	aic8800_sdio_url="https://github.com/radxa-pkg/aic8800/releases/download/${latest_version}/aic8800-sdio-dkms_${latest_version}_all.deb"
 	aic8800_usb_url="https://github.com/radxa-pkg/aic8800/releases/download/${latest_version}/aic8800-usb-dkms_${latest_version}_all.deb"
@@ -43,6 +43,6 @@ function post_install_kernel_debs__install_aic8800_dkms_package() {
 	use_clean_environment="yes" chroot_sdcard "wget ${aic8800_firmware_url} -P /tmp"
 	display_alert "Install aic8800 packages, will build kernel module in chroot" "${EXTENSION}" "info"
 	declare -ag if_error_find_files_sdcard=("/var/lib/dkms/aic8800*/*/build/*.log")
-	use_clean_environment="yes" chroot_sdcard_apt_get_install "/tmp/${aic8800_dkms_file_name} /tmp/aic8800-firmware_${latest_version}_arm64.deb"
+	use_clean_environment="yes" chroot_sdcard_apt_get_install "/tmp/${aic8800_dkms_file_name} /tmp/aic8800-firmware_${latest_version}_all.deb"
 	use_clean_environment="yes" chroot_sdcard "rm -f /tmp/aic8800*.deb"
 }


### PR DESCRIPTION
# Description

Firmware package was incorrectly marked as machine dependent.
This was fixed in radxa-pkg/aic8800#12, causing the file name to change.

First reported in #6761

Signed-off-by: ZHANG Yuntian <yt@radxa.com>

# How Has This Been Tested?

Same change was tested by @CT1IQI: https://github.com/armbian/build/issues/6761#issuecomment-2180013954

There is a seperate runtime error though.

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
