### PR TITLE
Rootfs cache is repeating generation over and over again

### DIFF
--- a/extensions/network/net-chrony.sh
+++ b/extensions/network/net-chrony.sh
@@ -2,6 +2,6 @@
 # Extension to manage network time synchronization with Chrony
 #
 function add_host_dependencies__install_chrony() {
-        display_alert "Extension: ${EXTENSION}: Installing additional packages" "chrony" "info"
-        add_packages_to_rootfs chrony
+	display_alert "Extension: ${EXTENSION}: Installing additional packages" "chrony" "info"
+	add_packages_to_image chrony
 }

--- a/extensions/network/net-network-manager.sh
+++ b/extensions/network/net-network-manager.sh
@@ -3,16 +3,16 @@
 #
 function add_host_dependencies__install_network_manager() {
 	display_alert "Extension: ${EXTENSION}: Installing additional packages" "network-manager network-manager-openvpn netplan.io" "info"
-	add_packages_to_rootfs network-manager network-manager-openvpn netplan.io
+	add_packages_to_image network-manager network-manager-openvpn netplan.io
 
 	if [[ "${BUILD_DESKTOP}" == "yes" ]]; then
 		display_alert "Extension: ${EXTENSION}: Installing additional packages for desktop" "network-manager-gnome network-manager-ssh network-manager-vpnc" "info"
-		add_packages_to_rootfs network-manager-gnome network-manager-ssh network-manager-vpnc
+		add_packages_to_image network-manager-gnome network-manager-ssh network-manager-vpnc
 	fi
 
 	if [[ "${DISTRIBUTION}" == "Ubuntu" ]]; then
 		display_alert "Extension: ${EXTENSION}: Installing additional packages for Ubuntu" "network-manager-config-connectivity-ubuntu" "info"
-		add_packages_to_rootfs network-manager-config-connectivity-ubuntu
+		add_packages_to_image network-manager-config-connectivity-ubuntu
 	fi
 }
 

--- a/extensions/network/net-systemd-neworkd.sh
+++ b/extensions/network/net-systemd-neworkd.sh
@@ -2,8 +2,8 @@
 # Extension to manage network interfaces with systemd-networkd + Netplan
 #
 function add_host_dependencies__install_systemd_networkd() {
-        display_alert "Extension: ${EXTENSION}: Installing additional packages" "netplan.io" "info"
-        add_packages_to_rootfs netplan.io
+	display_alert "Extension: ${EXTENSION}: Installing additional packages" "netplan.io" "info"
+	add_packages_to_image netplan.io
 }
 
 function pre_install_kernel_debs__configure_systemd_networkd()

--- a/extensions/network/net-systemd-timesyncd.sh
+++ b/extensions/network/net-systemd-timesyncd.sh
@@ -2,8 +2,8 @@
 # Extension to manage network time synchronization with systemd-timesyncd
 #
 function add_host_dependencies__install_systemd-timesyncd() {
-        display_alert "Extension: ${EXTENSION}: Installing additional packages" "systemd-timesyncd" "info"
-        add_packages_to_rootfs systemd-timesyncd
+	display_alert "Extension: ${EXTENSION}: Installing additional packages" "systemd-timesyncd" "info"
+	add_packages_to_image systemd-timesyncd
 }
 
 function pre_install_kernel_debs__configure_systemd-timesyncd()


### PR DESCRIPTION
# Description

In case we are changing rootfs cache content, we need to adjust cache name or rather have base cache package and add networking at image generation. This can be achieve with replacin `add_packages_to_rootfs` with `add_packages_to_image`.

[Jira](https://armbian.atlassian.net/jira) reference number [AR-2384]

# How Has This Been Tested?

- [x] One manual test, the rest will be tested with CI

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

[AR-2384]: https://armbian.atlassian.net/browse/AR-2384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ