### PR TITLE
add device-tree-overlay to bsp-cli debian dependencies

### DIFF
--- a/lib/functions/bsp/armbian-bsp-cli-deb.sh
+++ b/lib/functions/bsp/armbian-bsp-cli-deb.sh
@@ -242,7 +242,7 @@ function reversion_armbian-bsp-cli_deb_contents() {
 		depends_base_files=""
 	fi
 	cat <<- EOF >> "${control_file_new}"
-		Depends: bash, linux-base, u-boot-tools, initramfs-tools, lsb-release, fping${depends_base_files}
+		Depends: bash, linux-base, u-boot-tools, initramfs-tools, lsb-release, fping${depends_base_files}, device-tree-compiler
 		Replaces: zram-config, armbian-bsp-cli-${BOARD}${EXTRA_BSP_NAME} (<< ${REVISION})
 		Breaks: armbian-bsp-cli-${BOARD}${EXTRA_BSP_NAME} (<< ${REVISION})
 	EOF


### PR DESCRIPTION
# Description
Fixes issue: [AR-2381](https://armbian.atlassian.net/browse/AR-2381) - GH https://github.com/armbian/build/issues/6772

[Jira](https://armbian.atlassian.net/jira) reference number [AR-2381]

# How Has This Been Tested?

- [x] Built orangepi5-plus trixie image with an extension that uses `armbian-add-overlay` in `sdcard_chroot`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings



[AR-2381]: https://armbian.atlassian.net/browse/AR-2381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AR-2381]: https://armbian.atlassian.net/browse/AR-2381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ