### PR TITLE
Use random-mac only with systemd-networkd (minimal images)

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-common
+++ b/packages/bsp/common/usr/lib/armbian/armbian-common
@@ -37,6 +37,12 @@ generate_random_mac ()
 # Set a fixed random MAC for each Ethernet interface
 set_fixed_mac ()
 {
+
+	# we use random mac routine only with sytemd-network.
+	if ! grep 'renderer: networkd' /etc/netplan/*.yaml >/dev/null; then
+		exit 0
+	fi
+
 	local netplan_config_file="/etc/netplan/20-eth-fixed-mac.yaml"
 
 	# Initialize a new Netplan config file

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstrun
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstrun
@@ -119,7 +119,6 @@ case "$1" in
 	esac
 
 	# varios temporary hardware workarounds
-	[[ $LINUXFAMILY == rk3399 || $LINUXFAMILY == rockchip64 ]] && [[ $BOARD != helios64 && $BOARD != khadas-edge ]] && set_fixed_mac
 	[[ $LINUXFAMILY == meson ]] && set_fixed_mac
 	[[ $LINUXFAMILY == meson64 ]] && set_fixed_mac
 	systemctl disable armbian-firstrun


### PR DESCRIPTION
# Description

Closing https://github.com/armbian/build/issues/6773 

[Jira](https://armbian.atlassian.net/jira) reference number [AR-2382]

# How Has This Been Tested?

- [x] When netplan random mac defs are present, device (Odroid M1) does not get IP

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-2382]: https://armbian.atlassian.net/browse/AR-2382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ