### PR TITLE
rockchip-rk3588 6.8/610: add `i2c8-m2` overlay

### DIFF
--- a/patch/kernel/archive/rockchip-rk3588-6.10/overlay/Makefile
+++ b/patch/kernel/archive/rockchip-rk3588-6.10/overlay/Makefile
@@ -2,6 +2,7 @@
 dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	rockchip-rk3588-sata1.dtbo \
 	rockchip-rk3588-sata2.dtbo \
+	rockchip-rk3588-i2c8-m2.dtbo \
 	rockchip-rk3588-pwm0-m0.dtbo \
 	rockchip-rk3588-pwm0-m1.dtbo \
 	rockchip-rk3588-pwm0-m2.dtbo \

--- a/patch/kernel/archive/rockchip-rk3588-6.10/overlay/rockchip-rk3588-i2c8-m2.dtso
+++ b/patch/kernel/archive/rockchip-rk3588-6.10/overlay/rockchip-rk3588-i2c8-m2.dtso
@@ -1,0 +1,14 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&i2c8>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-names = "default";
+			pinctrl-0 = <&i2c8m2_xfer>;
+		};
+	};
+};

--- a/patch/kernel/archive/rockchip-rk3588-6.8/overlay/Makefile
+++ b/patch/kernel/archive/rockchip-rk3588-6.8/overlay/Makefile
@@ -2,6 +2,7 @@
 dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	rockchip-rk3588-sata1.dtbo \
 	rockchip-rk3588-sata2.dtbo \
+	rockchip-rk3588-i2c8-m2.dtbo \
 	rockchip-rk3588-pwm0-m0.dtbo \
 	rockchip-rk3588-pwm0-m1.dtbo \
 	rockchip-rk3588-pwm0-m2.dtbo \

--- a/patch/kernel/archive/rockchip-rk3588-6.8/overlay/rockchip-rk3588-i2c8-m2.dts
+++ b/patch/kernel/archive/rockchip-rk3588-6.8/overlay/rockchip-rk3588-i2c8-m2.dts
@@ -1,0 +1,14 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&i2c8>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-names = "default";
+			pinctrl-0 = <&i2c8m2_xfer>;
+		};
+	};
+};


### PR DESCRIPTION
#### rockchip-rk3588 6.8/610: add `i2c8-m2` overlay

- rockchip-rk3588 6.8/610: add `i2c8-m2` overlay
  - from vendor kernel
  - `i2c8m2`: 40-pin pins 3 & 5 of cm3588-nas & nanopct6