### PR TITLE
ext: fs-cryptroot-support: don't abuse `add_host_dependencies`

### DIFF
--- a/extensions/fs-cryptroot-support.sh
+++ b/extensions/fs-cryptroot-support.sh
@@ -5,20 +5,20 @@
 function add_host_dependencies__add_cryptroot_tooling() {
 	display_alert "Adding cryptroot to host dependencies" "cryptsetup LUKS" "debug"
 	EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} cryptsetup openssh-client" # @TODO: convert to array later
-
-	display_alert "Adding rootfs encryption related packages" "cryptsetup cryptsetup-initramfs" "info"
-	add_packages_to_rootfs cryptsetup cryptsetup-initramfs
-
-	if [[ $CRYPTROOT_SSH_UNLOCK == yes ]]; then
-		display_alert "Adding rootfs encryption related packages" "dropbear-initramfs" "info"
-		add_packages_to_rootfs dropbear-initramfs
-	fi
 }
 
 function extension_prepare_config__prepare_cryptroot() {
+	display_alert "Adding rootfs encryption related packages" "cryptsetup cryptsetup-initramfs" "info"
+	add_packages_to_image cryptsetup cryptsetup-initramfs
+
 	# Config for cryptroot, a boot partition is required.
 	declare -g BOOTPART_REQUIRED=yes
 	EXTRA_IMAGE_SUFFIXES+=("-crypt")
+
+	if [[ $CRYPTROOT_SSH_UNLOCK == yes ]]; then
+		display_alert "Adding rootfs encryption related packages" "dropbear-initramfs" "info"
+		add_packages_to_image dropbear-initramfs
+	fi
 }
 
 function prepare_root_device__encrypt_root_device() {


### PR DESCRIPTION
#### ext: fs-cryptroot-support: don't abuse `add_host_dependencies`

- ext: fs-cryptroot-support: don't abuse `add_host_dependencies`
  - use correct hook to make config changes