### PR TITLE
networking: main-config: introduce `NETWORKING_STACK` to control network exts; allow "none"; fix typo

### DIFF
--- a/extensions/network/net-network-manager.sh
+++ b/extensions/network/net-network-manager.sh
@@ -2,6 +2,11 @@
 # Extension to manage network interfaces with NetworkManager + Netplan
 #
 function extension_prepare_config__install_network_manager() {
+	# Sanity check
+	if [[ "${NETWORKING_STACK}" != "network-manager" ]]; then
+		exit_with_error "Extension: ${EXTENSION}: requires NETWORKING_STACK='network-manager', currently set to '${NETWORKING_STACK}'"
+	fi
+
 	display_alert "Extension: ${EXTENSION}: Installing additional packages" "network-manager network-manager-openvpn netplan.io" "info"
 	add_packages_to_image network-manager network-manager-openvpn netplan.io
 
@@ -39,9 +44,9 @@ function pre_install_kernel_debs__configure_network_manager() {
 	local network_manager_config_src_folder="${EXTENSION_DIR}/config-nm/NetworkManager/"
 	local network_manager_config_dst_folder="${SDCARD}/etc/NetworkManager/conf.d/"
 
-	run_host_command_logged cp "${netplan_config_src_folder}"* "${netplan_config_dst_folder}"
-	run_host_command_logged cp "${network_manager_config_src_folder}"* "${network_manager_config_dst_folder}"
+	run_host_command_logged cp -v "${netplan_config_src_folder}"* "${netplan_config_dst_folder}"
+	run_host_command_logged cp -v "${network_manager_config_src_folder}"* "${network_manager_config_dst_folder}"
 
 	# Change the file permissions according to https://netplan.readthedocs.io/en/stable/security/
-	chmod 600 "${SDCARD}"/etc/netplan/*
+	chmod -v 600 "${SDCARD}"/etc/netplan/*
 }

--- a/extensions/network/net-systemd-networkd.sh
+++ b/extensions/network/net-systemd-networkd.sh
@@ -2,6 +2,11 @@
 # Extension to manage network interfaces with systemd-networkd + Netplan
 #
 function extension_prepare_config__install_systemd_networkd() {
+	# Sanity check
+	if [[ "${NETWORKING_STACK}" != "systemd-networkd" ]]; then
+		exit_with_error "Extension: ${EXTENSION}: requires NETWORKING_STACK='systemd-networkd', currently set to '${NETWORKING_STACK}'"
+	fi
+
 	display_alert "Extension: ${EXTENSION}: Installing additional packages" "netplan.io" "info"
 	add_packages_to_image netplan.io
 }
@@ -22,9 +27,9 @@ function pre_install_kernel_debs__configure_systemd_networkd() {
 	local networkd_config_src_folder="${EXTENSION_DIR}/config-networkd/systemd/network/"
 	local networkd_config_dst_folder="${SDCARD}/etc/systemd/network/"
 
-	run_host_command_logged cp "${netplan_config_src_folder}"* "${netplan_config_dst_folder}"
-	run_host_command_logged cp "${networkd_config_src_folder}"* "${networkd_config_dst_folder}"
+	run_host_command_logged cp -v "${netplan_config_src_folder}"* "${netplan_config_dst_folder}"
+	run_host_command_logged cp -v "${networkd_config_src_folder}"* "${networkd_config_dst_folder}"
 
 	# Change the file permissions according to https://netplan.readthedocs.io/en/stable/security/
-	chmod 600 "${SDCARD}"/etc/netplan/*
+	chmod -v 600 "${SDCARD}"/etc/netplan/*
 }

--- a/lib/functions/configuration/change-tracking.sh
+++ b/lib/functions/configuration/change-tracking.sh
@@ -45,4 +45,5 @@ function track_general_config_variables() {
 	array_values="yes" track_config_variables "${1}" KERNEL_DRIVERS_SKIP
 	track_config_variables "${1}" BOOTSOURCE BOOTSOURCEDIR BOOTBRANCH BOOTPATCHDIR BOOTDIR BOOTCONFIG BOOTBRANCH_BOARD BOOTPATCHDIR_BOARD
 	track_config_variables "${1}" ATFSOURCEDIR ATFDIR ATFBRANCH CRUSTSOURCEDIR CRUSTDIR CRUSTBRANCH LINUXSOURCEDIR
+	track_config_variables "${1}" NETWORKING_STACK
 }


### PR DESCRIPTION
#### networking: main-config: introduce `NETWORKING_STACK` to control network exts; allow "none"; fix typo

- networking: exts: introduce sanity checks, debug info
  - protect against enabling networking exts directly
  - debug logging
  - fix typo in ext name
- networking: main-config: introduce `NETWORKING_STACK` to control network exts; allow "none"; fix typo
  - `NETWORKING_STACK` can be set to `none` (in config phase, pre-extensions) to not-add any networking extensions
  - keep defaulting to systemd-networkd if BUILD_MINIMAL and NetworkManager otherwise
  - fix typo in extension name
  - add `NETWORKING_STACK` to change-tracking