### PR TITLE
Add orangepi5-plus UART overlays

### DIFF
--- a/patch/kernel/archive/rockchip-rk3588-6.10/overlay/Makefile
+++ b/patch/kernel/archive/rockchip-rk3588-6.10/overlay/Makefile
@@ -32,7 +32,13 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	rockchip-rk3588-pwm15-m0.dtbo \
 	rockchip-rk3588-pwm15-m1.dtbo \
 	rockchip-rk3588-pwm15-m2.dtbo \
-	rockchip-rk3588-pwm15-m3.dtbo
+	rockchip-rk3588-pwm15-m3.dtbo \
+	rockchip-rk3588-uart1-m1.dtbo \
+	rockchip-rk3588-uart3-m1.dtbo \
+	rockchip-rk3588-uart4-m2.dtbo \
+	rockchip-rk3588-uart6-m1.dtbo \
+	rockchip-rk3588-uart7-m2.dtbo \
+	rockchip-rk3588-uart8-m1.dtbo
 
 dtb-y += $(dtbo-y)
 

--- a/patch/kernel/archive/rockchip-rk3588-6.10/overlay/rockchip-rk3588-uart1-m1.dts
+++ b/patch/kernel/archive/rockchip-rk3588-6.10/overlay/rockchip-rk3588-uart1-m1.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&uart1>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&uart1m1_xfer>;
+		};
+	};
+};

--- a/patch/kernel/archive/rockchip-rk3588-6.10/overlay/rockchip-rk3588-uart3-m1.dts
+++ b/patch/kernel/archive/rockchip-rk3588-6.10/overlay/rockchip-rk3588-uart3-m1.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&uart3>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&uart3m1_xfer>;
+		};
+	};
+};

--- a/patch/kernel/archive/rockchip-rk3588-6.10/overlay/rockchip-rk3588-uart4-m2.dts
+++ b/patch/kernel/archive/rockchip-rk3588-6.10/overlay/rockchip-rk3588-uart4-m2.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&uart4>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&uart4m2_xfer>;
+		};
+	};
+};

--- a/patch/kernel/archive/rockchip-rk3588-6.10/overlay/rockchip-rk3588-uart6-m1.dts
+++ b/patch/kernel/archive/rockchip-rk3588-6.10/overlay/rockchip-rk3588-uart6-m1.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&uart6>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&uart6m1_xfer>;
+		};
+	};
+};

--- a/patch/kernel/archive/rockchip-rk3588-6.10/overlay/rockchip-rk3588-uart7-m2.dts
+++ b/patch/kernel/archive/rockchip-rk3588-6.10/overlay/rockchip-rk3588-uart7-m2.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&uart7>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&uart7m2_xfer>;
+		};
+	};
+};

--- a/patch/kernel/archive/rockchip-rk3588-6.10/overlay/rockchip-rk3588-uart8-m1.dts
+++ b/patch/kernel/archive/rockchip-rk3588-6.10/overlay/rockchip-rk3588-uart8-m1.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&uart8>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&uart8m1_xfer>;
+		};
+	};
+};

--- a/patch/kernel/archive/rockchip-rk3588-6.8/overlay/Makefile
+++ b/patch/kernel/archive/rockchip-rk3588-6.8/overlay/Makefile
@@ -32,7 +32,13 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	rockchip-rk3588-pwm15-m0.dtbo \
 	rockchip-rk3588-pwm15-m1.dtbo \
 	rockchip-rk3588-pwm15-m2.dtbo \
-	rockchip-rk3588-pwm15-m3.dtbo
+	rockchip-rk3588-pwm15-m3.dtbo \
+	rockchip-rk3588-uart1-m1.dtbo \
+	rockchip-rk3588-uart3-m1.dtbo \
+	rockchip-rk3588-uart4-m2.dtbo \
+	rockchip-rk3588-uart6-m1.dtbo \
+	rockchip-rk3588-uart7-m2.dtbo \
+	rockchip-rk3588-uart8-m1.dtbo
 
 targets += $(dtbo-y)
 

--- a/patch/kernel/archive/rockchip-rk3588-6.8/overlay/rockchip-rk3588-uart1-m1.dts
+++ b/patch/kernel/archive/rockchip-rk3588-6.8/overlay/rockchip-rk3588-uart1-m1.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&uart1>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&uart1m1_xfer>;
+		};
+	};
+};

--- a/patch/kernel/archive/rockchip-rk3588-6.8/overlay/rockchip-rk3588-uart3-m1.dts
+++ b/patch/kernel/archive/rockchip-rk3588-6.8/overlay/rockchip-rk3588-uart3-m1.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&uart3>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&uart3m1_xfer>;
+		};
+	};
+};

--- a/patch/kernel/archive/rockchip-rk3588-6.8/overlay/rockchip-rk3588-uart4-m2.dts
+++ b/patch/kernel/archive/rockchip-rk3588-6.8/overlay/rockchip-rk3588-uart4-m2.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&uart4>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&uart4m2_xfer>;
+		};
+	};
+};

--- a/patch/kernel/archive/rockchip-rk3588-6.8/overlay/rockchip-rk3588-uart6-m1.dts
+++ b/patch/kernel/archive/rockchip-rk3588-6.8/overlay/rockchip-rk3588-uart6-m1.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&uart6>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&uart6m1_xfer>;
+		};
+	};
+};

--- a/patch/kernel/archive/rockchip-rk3588-6.8/overlay/rockchip-rk3588-uart7-m2.dts
+++ b/patch/kernel/archive/rockchip-rk3588-6.8/overlay/rockchip-rk3588-uart7-m2.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&uart7>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&uart7m2_xfer>;
+		};
+	};
+};

--- a/patch/kernel/archive/rockchip-rk3588-6.8/overlay/rockchip-rk3588-uart8-m1.dts
+++ b/patch/kernel/archive/rockchip-rk3588-6.8/overlay/rockchip-rk3588-uart8-m1.dts
@@ -1,0 +1,13 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&uart8>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-0 = <&uart8m1_xfer>;
+		};
+	};
+};


### PR DESCRIPTION
# Description

Add uarts dts as per vendor spec
<img width="779" alt="SCR-20240623-tlfc" src="https://github.com/armbian/build/assets/18349597/7ae61b29-3bc0-4700-b55a-0c23f0ac0184">


# How Has This Been Tested?

- [x] Built orangepi5-plus with kernel 6.8 and connected serial gps to uart3-m1 ttyS3 - got a fix


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
