### PR TITLE
kernel: mainline: Bump 6.10-rc4 to 6.10-rc5

### DIFF
--- a/config/kernel/linux-rockchip-rk3588-6.10.config
+++ b/config/kernel/linux-rockchip-rk3588-6.10.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.10.0-rc4 Kernel Configuration
+# Linux/arm64 6.10.0-rc5 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (Ubuntu 13.2.0-23ubuntu4) 13.2.0"
 CONFIG_CC_IS_GCC=y
@@ -10136,7 +10136,6 @@ CONFIG_INIT_STACK_NONE=y
 # CONFIG_INIT_STACK_ALL_ZERO is not set
 CONFIG_INIT_ON_ALLOC_DEFAULT_ON=y
 # CONFIG_INIT_ON_FREE_DEFAULT_ON is not set
-# CONFIG_INIT_MLOCKED_ON_FREE_DEFAULT_ON is not set
 CONFIG_CC_HAS_ZERO_CALL_USED_REGS=y
 # CONFIG_ZERO_CALL_USED_REGS is not set
 # end of Memory initialization
@@ -10574,7 +10573,6 @@ CONFIG_CMA_ALIGNMENT=8
 # CONFIG_DMA_MAP_BENCHMARK is not set
 CONFIG_SGL_ALLOC=y
 CONFIG_CHECK_SIGNATURE=y
-# CONFIG_FORCE_NR_CPUS is not set
 CONFIG_CPU_RMAP=y
 CONFIG_DQL=y
 CONFIG_GLOB=y

--- a/config/sources/mainline-kernel.conf.sh
+++ b/config/sources/mainline-kernel.conf.sh
@@ -8,7 +8,7 @@
 function mainline_kernel_decide_version__upstream_release_candidate_number() {
 	[[ -n "${KERNELBRANCH}" ]] && return 0          # if already set, don't touch it; that way other hooks can run in any order
 	if [[ "${KERNEL_MAJOR_MINOR}" == "6.10" ]]; then # @TODO: roll over to next MAJOR.MINOR and MAJOR.MINOR-rc1 when it is released
-		declare -g KERNELBRANCH="tag:v6.10-rc4"
+		declare -g KERNELBRANCH="tag:v6.10-rc5"
 		display_alert "mainline-kernel: upstream release candidate" "Using KERNELBRANCH='${KERNELBRANCH}' for KERNEL_MAJOR_MINOR='${KERNEL_MAJOR_MINOR}'" "info"
 	fi
 }


### PR DESCRIPTION
# Description

Bump the 6.10 kernel from 6.10-rc4 to 6.10-rc5.
Includes kernel config rewrite for RK3588.

# How Has This Been Tested?

- [x] Build success: `./compile.sh BOARD=nanopi-r6c BRANCH=edge RELEASE=trixie EXPERT=yes KERNEL_CONFIGURE=no BUILD_MINIMAL=no BUILD_DESKTOP=no EXTRAWIFI=no kernel`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
