### PR TITLE
distro: trixie: Add riscv64 to supported architectures

### DIFF
--- a/config/distributions/trixie/architectures
+++ b/config/distributions/trixie/architectures
@@ -1,1 +1,1 @@
-arm64,amd64
+arm64,riscv64,amd64


### PR DESCRIPTION
Add riscv64 to supported architectures for Debian Trixie.

# How Has This Been Tested?

- [x] Try compiling minimal Trixie image: https://github.com/armbian/build/pull/6771#issuecomment-2186837485
- [ ] There is currently another issue with the base-files: https://github.com/armbian/build/issues/6790

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
