### PR TITLE
Revert "distro: trixie: Add riscv64 to supported architectures"

### DIFF
--- a/config/distributions/trixie/architectures
+++ b/config/distributions/trixie/architectures
@@ -1,1 +1,1 @@
-arm64,riscv64,amd64
+arm64,amd64


### PR DESCRIPTION
Some packages in the Debian Trixie repo aren't available for the riscv64 architecture yet, e.g. libgcc-s1 (see https://packages.debian.org/trixie/libgcc-s1)

See also https://github.com/armbian/build/pull/6793