### PR TITLE
tools: Update shellfmt from version 3.6.0 to 3.8.0

### DIFF
--- a/extensions/mesa-vpu.sh
+++ b/extensions/mesa-vpu.sh
@@ -53,9 +53,9 @@ function post_install_kernel_debs__3d() {
 
 		display_alert "Pinning amazingfated's rk3588 PPAs" "${EXTENSION}" "info"
 		cat <<- EOF > "${SDCARD}"/etc/apt/preferences.d/amazingfated-rk3588-panfork-pin
-		Package: *
-		Pin: release o=LP-PPA-liujianfeng1994-panfork-mesa
-		Pin-Priority: 1001
+			Package: *
+			Pin: release o=LP-PPA-liujianfeng1994-panfork-mesa
+			Pin-Priority: 1001
 		EOF
 
 		sed -i "s/noble/jammy/g" "${SDCARD}"/etc/apt/sources.list.d/liujianfeng1994-ubuntu-panfork-mesa-"${RELEASE}".*
@@ -67,9 +67,9 @@ function post_install_kernel_debs__3d() {
 
 		display_alert "Pinning oibaf PPAs" "${EXTENSION}" "info"
 		cat <<- EOF > "${SDCARD}"/etc/apt/preferences.d/mesa-oibaf-graphics-drivers-pin
-		Package: *
-		Pin: release o=LP-PPA-oibaf-graphics-drivers
-		Pin-Priority: 1001
+			Package: *
+			Pin: release o=LP-PPA-oibaf-graphics-drivers
+			Pin-Priority: 1001
 		EOF
 
 	fi
@@ -88,9 +88,9 @@ function post_install_kernel_debs__3d() {
 
 		display_alert "Pinning amazingfated's multimedia PPAs" "${EXTENSION}" "info"
 		cat <<- EOF > "${SDCARD}"/etc/apt/preferences.d/amazingfated-rk3588-rockchip-multimedia-pin
-		Package: *
-		Pin: release o=LP-PPA-liujianfeng1994-rockchip-multimedia
-		Pin-Priority: 1001
+			Package: *
+			Pin: release o=LP-PPA-liujianfeng1994-rockchip-multimedia
+			Pin-Priority: 1001
 		EOF
 	fi
 
@@ -98,7 +98,7 @@ function post_install_kernel_debs__3d() {
 	do_with_retries 3 chroot_sdcard_apt_get_update
 
 	display_alert "Installing 3D extension packages" "${EXTENSION}" "info"
-	do_with_retries 3 chroot_sdcard_apt_get_install --allow-downgrades  "${pkgs[@]}"
+	do_with_retries 3 chroot_sdcard_apt_get_install --allow-downgrades "${pkgs[@]}"
 
 	display_alert "Upgrading Mesa packages" "${EXTENSION}" "info"
 	do_with_retries 3 chroot_sdcard_apt_get dist-upgrade

--- a/lib/functions/artifacts/artifact-armbian-base-files.sh
+++ b/lib/functions/artifacts/artifact-armbian-base-files.sh
@@ -147,18 +147,18 @@ function compile_armbian-base-files() {
 	# Create preinst file if not exists (Debian)
 	if [[ ! -e "${destination}"/DEBIAN/preinst ]]; then
 		cat <<- EOD >> "${destination}"/DEBIAN/preinst
-		#!/bin/sh
-		set -e
-		# Start of automatically added by ${VENDOR}
-		rm -f /etc/dpkg/origins/default # reset default link
-		# End of automatically added by ${VENDOR}
+			#!/bin/sh
+			set -e
+			# Start of automatically added by ${VENDOR}
+			rm -f /etc/dpkg/origins/default # reset default link
+			# End of automatically added by ${VENDOR}
 		EOD
 		chmod 0755 "${destination}"/DEBIAN/preinst
 	else
 		cat <<- EOD >> "${destination}"/DEBIAN/preinst
-		# Start of automatically added by ${VENDOR}
-		rm -f /etc/dpkg/origins/default # reset default link
-		# End of automatically added by ${VENDOR}
+			# Start of automatically added by ${VENDOR}
+			rm -f /etc/dpkg/origins/default # reset default link
+			# End of automatically added by ${VENDOR}
 		EOD
 	fi
 

--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -568,8 +568,8 @@ function set_git_build_repo_url_and_commit_vars() {
 
 function check_filesystem_compatibility_on_host() {
 	if [[ -f "/proc/filesystems" ]]; then
-			# Check if the filesystem is listed in /proc/filesystems
-		if ! grep -q "\<$ROOTFS_TYPE\>" /proc/filesystems; then		# ensure exact match with \<...\>
+		# Check if the filesystem is listed in /proc/filesystems
+		if ! grep -q "\<$ROOTFS_TYPE\>" /proc/filesystems; then # ensure exact match with \<...\>
 			# Try modprobing the fs module since it doesn't show up in /proc/filesystems if it's an unloaded module versus built-in
 			if ! modprobe "$ROOTFS_TYPE"; then
 				exit_with_error "Filesystem type unsupported by build host:" "$ROOTFS_TYPE"
@@ -599,8 +599,8 @@ function check_filesystem_compatibility_on_host() {
 
 			# Check if required configurations are set
 			if [ -n "$build_host_kernel_config" ]; then
-				if ! grep -q '^CONFIG_F2FS_FS_XATTR=y$' "$build_host_kernel_config" || \
-				! grep -q '^CONFIG_F2FS_FS_SECURITY=y$' "$build_host_kernel_config"; then
+				if ! grep -q '^CONFIG_F2FS_FS_XATTR=y$' "$build_host_kernel_config" ||
+					! grep -q '^CONFIG_F2FS_FS_SECURITY=y$' "$build_host_kernel_config"; then
 					exit_with_error "Required kernel configurations for f2fs filesystem not enabled." "Please enable CONFIG_F2FS_FS_XATTR and CONFIG_F2FS_FS_SECURITY in your kernel configuration." "err"
 				fi
 			fi
@@ -611,18 +611,17 @@ function check_filesystem_compatibility_on_host() {
 	return 0
 }
 
-function pre_install_distribution_specific__disable_cnf_apt_hook(){
+function pre_install_distribution_specific__disable_cnf_apt_hook() {
 	if [[ $(dpkg --print-architecture) != "${ARCH}" && -f "${SDCARD}"/etc/apt/apt.conf.d/50command-not-found ]]; then #disable command-not-found (60% build-time saved under qemu)
-	display_alert "Disabling command-not-found during build-time to speed up image creation" "${BOARD}:${RELEASE}-${BRANCH}" "info"
-	run_host_command_logged mv "${SDCARD}"/etc/apt/apt.conf.d/50command-not-found "${SDCARD}"/etc/apt/apt.conf.d/50command-not-found.disabled
-        fi
+		display_alert "Disabling command-not-found during build-time to speed up image creation" "${BOARD}:${RELEASE}-${BRANCH}" "info"
+		run_host_command_logged mv "${SDCARD}"/etc/apt/apt.conf.d/50command-not-found "${SDCARD}"/etc/apt/apt.conf.d/50command-not-found.disabled
+	fi
 }
 
-
-function post_post_debootstrap_tweaks__restore_cnf_apt_hook(){
+function post_post_debootstrap_tweaks__restore_cnf_apt_hook() {
 	if [ -f "${SDCARD}"/etc/apt/apt.conf.d/50command-not-found.disabled ]; then # (re-enable command-not-found after building rootfs if it's been disabled)
-	display_alert "Enabling command-not-found after build-time " "${BOARD}:${RELEASE}-${BRANCH}" "info"
-	run_host_command_logged mv "${SDCARD}"/etc/apt/apt.conf.d/50command-not-found.disabled "${SDCARD}"/etc/apt/apt.conf.d/50command-not-found
+		display_alert "Enabling command-not-found after build-time " "${BOARD}:${RELEASE}-${BRANCH}" "info"
+		run_host_command_logged mv "${SDCARD}"/etc/apt/apt.conf.d/50command-not-found.disabled "${SDCARD}"/etc/apt/apt.conf.d/50command-not-found
 	fi
 
 }

--- a/lib/functions/rootfs/distro-specific.sh
+++ b/lib/functions/rootfs/distro-specific.sh
@@ -137,7 +137,7 @@ function create_sources_list_and_deploy_repo_key() {
 			EOF
 			;;
 
-		sid|unstable) # sid is permanent unstable development and has no such thing as updates or security
+		sid | unstable) # sid is permanent unstable development and has no such thing as updates or security
 			cat <<- EOF > "${basedir}"/etc/apt/sources.list
 				deb http://${DEBIAN_MIRROR} $release main contrib non-free non-free-firmware
 				#deb-src http://${DEBIAN_MIRROR} $release main contrib non-free non-free-firmware
@@ -204,8 +204,8 @@ function create_sources_list_and_deploy_repo_key() {
 	[[ -n $LOCAL_MIRROR ]] && echo "deb ${SIGNED_BY}http://$LOCAL_MIRROR $RELEASE ${components[*]}" > "${basedir}"/etc/apt/sources.list.d/armbian.list
 
 	# disable repo if DISTRIBUTION_STATUS==eos, or if SKIP_ARMBIAN_REPO==yes, or if when==image-early.
-	if [[ "${when}" == "image-early" || \
-		"$(cat "${SRC}/config/distributions/${RELEASE}/support")" == "eos" || \
+	if [[ "${when}" == "image-early" ||
+		"$(cat "${SRC}/config/distributions/${RELEASE}/support")" == "eos" ||
 		"${SKIP_ARMBIAN_REPO}" == "yes" ]]; then
 		display_alert "Disabling Armbian repo" "${ARCH}-${RELEASE} :: skip:${SKIP_ARMBIAN_REPO:-"no"} when:${when}" "info"
 		mv "${SDCARD}"/etc/apt/sources.list.d/armbian.list "${SDCARD}"/etc/apt/sources.list.d/armbian.list.disabled

--- a/lib/tools/shellfmt.sh
+++ b/lib/tools/shellfmt.sh
@@ -7,7 +7,7 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 
-SHELLFMT_VERSION=${SHELLFMT_VERSION:-3.6.0} # https://github.com/mvdan/sh/releases/
+SHELLFMT_VERSION=${SHELLFMT_VERSION:-3.8.0} # https://github.com/mvdan/sh/releases/
 
 SRC="$(
 	cd "$(dirname "$0")/../.."

--- a/lib/tools/shellfmt.sh
+++ b/lib/tools/shellfmt.sh
@@ -42,7 +42,7 @@ DOWN_URL="${GITHUB_SOURCE:-"https://github.com"}/mvdan/sh/releases/download/v${S
 SHELLFMT_BIN="${DIR_SHELLFMT}/${SHELLFMT_FN}"
 
 echo "MACHINE: ${MACHINE}"
-echo "Down URL: ${DOWN_URL}"
+echo "Download URL: ${DOWN_URL}"
 echo "SHELLFMT_BIN: ${SHELLFMT_BIN}"
 
 if [[ ! -f "${SHELLFMT_BIN}" ]]; then
@@ -73,3 +73,5 @@ echo "Shellfmt files differing:"
 
 echo "Doing for real:"
 "${SHELLFMT_BIN}" -w "${ALL_BASH_FILES[@]}"
+
+echo "Shellfmt finished!"


### PR DESCRIPTION
# Description

Update and run our shellfmt script version 3.8.0

# How Has This Been Tested?

- [x] Run `sudo ./lib/tools/shellfmt.sh`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
