### PR TITLE
actions: Use "all-globs" instead of "any-glob" for negated checks

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,7 +14,7 @@
 - all:
   - changed-files:
     - any-glob-to-any-file: ['patch/**/*','config/**/*']
-    - any-glob-to-all-files: ['!config/cli/**/*','!config/desktop/**/*','!config/distributions/**/*']
+    - all-globs-to-all-files: ['!config/cli/**/*','!config/desktop/**/*','!config/distributions/**/*']
 
 "Framework":
 - all:


### PR DESCRIPTION
# Description

If we want to check if a file is not from one of the listed folders, it needs to be check that
"NOT x AND NOT y AND NOT z" is true, instead of
"NOT x OR NOT y OR NOT z"

Example: This PR should not have the "Hardware" label: https://github.com/armbian/build/pull/6781

# How Has This Been Tested?

- [ ] To be tested in future PRs

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code