### PR TITLE
Fix aml-s9xx-box bsp-cli package upgrade

### DIFF
--- a/config/boards/aml-s9xx-box.tvb
+++ b/config/boards/aml-s9xx-box.tvb
@@ -24,11 +24,13 @@ function aml-s9xx-box-bsp-cli-preinst() {
     [ -f /boot/u-boot-s905x-s912 ] && rm /boot/u-boot-s905x-s912
     [ -f /boot/u-boot-s905x2-s922 ] && rm /boot/u-boot-s905x2-s922
     [ -f /boot/u-boot-s905x3 ] && rm /boot/u-boot-s905x3
+    [ -f /boot/u-boot-s905x3-ugoosx3 ] && rm /boot/u-boot-s905x3-ugoosx3
     [ -f /boot/extlinux/extlinux.conf.template ] && rm /boot/extlinux/extlinux.conf.template
     [ -f /boot/build-u-boot/readme.txt ] && rm /boot/build-u-boot/readme.txt
     [ -f /boot/build-u-boot/u-boot-s905x-s912.patch ] && rm /boot/build-u-boot/u-boot-s905x-s912.patch
     [ -f /boot/build-u-boot/u-boot-s905x2-s922.patch ] && rm /boot/build-u-boot/u-boot-s905x2-s922.patch
     [ -f /boot/build-u-boot/u-boot-s905x3.patch ] && rm /boot/build-u-boot/u-boot-s905x3.patch
+    [ -f /boot/build-u-boot/u-boot-s905x3-ugoos-x3.patch ] && rm /boot/build-u-boot/u-boot-s905x3-ugoos-x3.patch
 
 }
 


### PR DESCRIPTION
 Changes to be committed:
	modified:   aml-s9xx-box.tvb

PR #6659 broke upgrades for the aml-s9xx-box package.  That PR introduced two new files in /boot which is a fat filesystem on this box.  The standard package upgrade fails on a fat filesystem when files already exist. PR #6659 failed to add the files to the remove list.  This PR does that.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] build aml-s9xx-box image and debs
- [x] test upgrade of the bsp-cli deb 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
