### PR TITLE
DTS-check: Python librarires have troubles to build, disabling for now

### DIFF
--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -225,6 +225,7 @@ function docker_cli_prepare_dockerfile() {
 		!/VERSION
 		!/LICENSE
 		!/compile.sh
+		!/requirements.txt
 		!/lib
 		!/extensions
 		!/config/sources

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,7 @@ PyYAML == 6.0.1        # for parsing/writing YAML
 oras == 0.1.30         # for OCI stuff in mapper-oci-update
 Jinja2 == 3.1.4        # for templating
 rich == 13.7.1         # for rich text formatting
-dtschema == 2024.5     # for checking dts files and dt bindings
-yamllint == 1.35.1     # for checking dts files and dt bindings
+#dtschema == 2024.5     # for checking dts files and dt bindings
+#yamllint == 1.35.1     # for checking dts files and dt bindings
+
+#### dts-schema and its functionality dts-check does not build


### PR DESCRIPTION
# Description

- disable
- add requirements.txt to Dockerfile generation

# How Has This Been Tested?

- [x] Manual build passes

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
