### PR TITLE
Fix `dts-check` command and use Pip for some Python packages instead of APT

### DIFF
--- a/lib/functions/cli/commands.sh
+++ b/lib/functions/cli/commands.sh
@@ -134,7 +134,7 @@ function armbian_register_commands() {
 		["rewrite-kernel-config"]="WHAT='kernel' KERNEL_CONFIGURE='yes' ARTIFACT_WILL_NOT_BUILD='yes' ARTIFACT_IGNORE_CACHE='yes' ${common_cli_artifact_vars}"
 		["kernel-patch"]="WHAT='kernel' CREATE_PATCHES='yes' ${common_cli_artifact_interactive_vars} ${common_cli_artifact_vars}"
 		["kernel-dtb"]="WHAT='kernel' KERNEL_DTB_ONLY='yes' ${common_cli_artifact_interactive_vars} ${common_cli_artifact_vars}"
-		["dts-check"]="WHAT='kernel' DTS_VALIDATE='yes' ARTIFACT_WILL_NOT_BUILD='yes'" # Not really an artifact, but cli output only. Builds nothing.
+		["dts-check"]="WHAT='kernel' DTS_VALIDATE='yes' ARTIFACT_WILL_NOT_BUILD='yes' ARTIFACT_IGNORE_CACHE='yes'" # Not really an artifact, but cli output only. Builds nothing.
 
 		["uboot"]="WHAT='uboot' ${common_cli_artifact_vars}"
 		["uboot-config"]="WHAT='uboot' UBOOT_CONFIGURE='yes' ${common_cli_artifact_interactive_vars} ${common_cli_artifact_vars}"

--- a/lib/functions/cli/commands.sh
+++ b/lib/functions/cli/commands.sh
@@ -73,7 +73,7 @@ function armbian_register_commands() {
 		["rewrite-kernel-config"]="artifact"
 
 		# Patch kernel and then check & validate the dtb file
-		["dts-check"]="artifact"				# Not really an artifact, but cli output only. Builds nothing.
+		["dts-check"]="artifact" # Not really an artifact, but cli output only. Builds nothing.
 
 		["uboot"]="artifact"
 		["uboot-patch"]="artifact"

--- a/lib/functions/compilation/kernel-dts-check.sh
+++ b/lib/functions/compilation/kernel-dts-check.sh
@@ -7,16 +7,15 @@
 # This file is a part of the Armbian Build Framework
 # https://github.com/armbian/build/
 
-
 # Validate the dts/dtb file against dt bindings found in "linux/Documentation/devicetree/bindings/"
 # See slide 15 in https://elinux.org/images/1/17/How_to_Get_Your_DT_Schema_Bindings_Accepted_in_Less_than_10_Iterations_-_Krzysztof_Kozlowski%2C_Linaro_-_ELCE_2023.pdf
 function validate_dts() {
-    [[ -z "${BOOT_FDT_FILE}" ]] && exit_with_error "BOOT_FDT_FILE not set! No dts file to validate."
-    display_alert "Validating dts/dtb file for selected board" "${BOOT_FDT_FILE} ; see output below" "info"
+	[[ -z "${BOOT_FDT_FILE}" ]] && exit_with_error "BOOT_FDT_FILE not set! No dts file to validate."
+	display_alert "Validating dts/dtb file for selected board" "${BOOT_FDT_FILE} ; see output below" "info"
 
-    # "make CHECK_DTBS=y" uses the pip modules "dtschema" and "yamllint"
-    prepare_python_and_pip
+	# "make CHECK_DTBS=y" uses the pip modules "dtschema" and "yamllint"
+	prepare_python_and_pip
 
-    # Run "make CHECK_DTBS=y" for the selected board's dtb file
+	# Run "make CHECK_DTBS=y" for the selected board's dtb file
 	run_kernel_make "CHECK_DTBS=y ${BOOT_FDT_FILE}"
 }

--- a/lib/functions/compilation/kernel-make.sh
+++ b/lib/functions/compilation/kernel-make.sh
@@ -18,13 +18,13 @@ function run_kernel_make_internal() {
 	prepare_distcc_compilation_config
 
 	common_make_envs=(
-		"CCACHE_BASEDIR=\"$(pwd)\""                                     # Base directory for ccache, for cache reuse # @TODO: experiment with this and the source path to maximize hit rate
-		"CCACHE_TEMPDIR=\"${CCACHE_TEMPDIR:?}\""                        # Temporary directory for ccache, under WORKDIR
-		"PATH=\"${toolchain}:${PYTHON3_INFO[USERBASE]}/bin:${PATH}\""   # Insert the toolchain and the pip binaries into the PATH
-		"PYTHONPATH=\"${PYTHON3_INFO[MODULES_PATH]}:${PYTHONPATH}\""	# Insert the pip modules downloaded by Armbian into PYTHONPATH (needed for dtb checks)
-		"DPKG_COLORS=always"                                            # Use colors for dpkg @TODO no dpkg is done anymore, remove?
-		"XZ_OPT='--threads=0'"                                          # Use parallel XZ compression
-		"TERM='${TERM}'"                                                # Pass the terminal type, so that 'make menuconfig' can work.
+		"CCACHE_BASEDIR=\"$(pwd)\""                                   # Base directory for ccache, for cache reuse # @TODO: experiment with this and the source path to maximize hit rate
+		"CCACHE_TEMPDIR=\"${CCACHE_TEMPDIR:?}\""                      # Temporary directory for ccache, under WORKDIR
+		"PATH=\"${toolchain}:${PYTHON3_INFO[USERBASE]}/bin:${PATH}\"" # Insert the toolchain and the pip binaries into the PATH
+		"PYTHONPATH=\"${PYTHON3_INFO[MODULES_PATH]}:${PYTHONPATH}\""  # Insert the pip modules downloaded by Armbian into PYTHONPATH (needed for dtb checks)
+		"DPKG_COLORS=always"                                          # Use colors for dpkg @TODO no dpkg is done anymore, remove?
+		"XZ_OPT='--threads=0'"                                        # Use parallel XZ compression
+		"TERM='${TERM}'"                                              # Pass the terminal type, so that 'make menuconfig' can work.
 		"COLUMNS='${COLUMNS:-160}'"
 		"COLORFGBG='${COLORFGBG}'"
 	)

--- a/lib/functions/general/python-tools.sh
+++ b/lib/functions/general/python-tools.sh
@@ -118,6 +118,7 @@ function prepare_python_and_pip() {
 		"PYTHONUSERBASE=${PYTHON3_INFO[USERBASE]}"
 		"PYTHONUNBUFFERED=yes"
 		"PYTHONPYCACHEPREFIX=${PYTHON3_INFO[PYCACHEPREFIX]}"
+		"PATH=\"${toolchain}:${PYTHON3_INFO[USERBASE]}/bin:${PATH}\"" # add toolchain to PATH to make building wheels work
 	)
 
 	# If the hash file exists, we're done.

--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -290,7 +290,7 @@ function adaptative_prepare_host_dependencies() {
 	host_deps_add_extra_python # See python-tools.sh::host_deps_add_extra_python()
 
 	### Python3 -- required for Armbian's Python tooling, and also for more recent u-boot builds. Needs 3.9+; ffi-dev is needed for some Python packages when the wheel is not prebuilt
-	### 'python3-setuptools' and 'python3-pyelftools' moved to requirements.txt to make sure build hosts use the same/latest versions of these tools. 
+	### 'python3-setuptools' and 'python3-pyelftools' moved to requirements.txt to make sure build hosts use the same/latest versions of these tools.
 	host_dependencies+=("python3-dev" "python3-pip" "libffi-dev")
 
 	# Needed for some u-boot's, lest "tools/mkeficapsule.c:21:10: fatal error: gnutls/gnutls.h"

--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -304,11 +304,12 @@ function adaptative_prepare_host_dependencies() {
 	fi
 
 	### Python2 -- required for some older u-boot builds
-	# Debian 'sid'/'bookworm' and Ubuntu 'lunar' does not carry python2 anymore; in this case some u-boot's might fail to build.
-	if [[ "sid bookworm trixie lunar mantic noble" == *"${host_release}"* ]]; then
-		display_alert "Python2 not available on host release '${host_release}'" "old(er) u-boot builds might/will fail" "wrn"
-	else
+	# Debian newer than 'bookworm' and Ubuntu newer than 'lunar'/'mantic' does not carry python2 anymore; in this case some u-boot's might fail to build.
+	# Last versions to support python2 were Debian 'bullseye' and Ubuntu 'jammy'
+	if [[ "bullseye jammy" == *"${host_release}"* ]]; then
 		host_dependencies+=("python2" "python2-dev")
+	else
+		display_alert "Python2 not available on host release '${host_release}'" "ancient u-boot versions might/will fail to build" "info"
 	fi
 
 	# Only install acng if asked to.

--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -290,7 +290,8 @@ function adaptative_prepare_host_dependencies() {
 	host_deps_add_extra_python # See python-tools.sh::host_deps_add_extra_python()
 
 	### Python3 -- required for Armbian's Python tooling, and also for more recent u-boot builds. Needs 3.9+; ffi-dev is needed for some Python packages when the wheel is not prebuilt
-	host_dependencies+=("python3-dev" "python3-setuptools" "python3-pip" "python3-pyelftools" "libffi-dev")
+	### 'python3-setuptools' and 'python3-pyelftools' moved to requirements.txt to make sure build hosts use the same/latest versions of these tools. 
+	host_dependencies+=("python3-dev" "python3-pip" "libffi-dev")
 
 	# Needed for some u-boot's, lest "tools/mkeficapsule.c:21:10: fatal error: gnutls/gnutls.h"
 	host_dependencies+=("libgnutls28-dev")

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,5 @@ PyYAML == 6.0.1        # for parsing/writing YAML
 oras == 0.1.30         # for OCI stuff in mapper-oci-update
 Jinja2 == 3.1.4        # for templating
 rich == 13.7.1         # for rich text formatting
-#dtschema == 2024.5     # for checking dts files and dt bindings
-#yamllint == 1.35.1     # for checking dts files and dt bindings
-
-#### dts-schema and its functionality dts-check does not build
+dtschema == 2024.5     # for checking dts files and dt bindings
+yamllint == 1.35.1     # for checking dts files and dt bindings

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,8 @@
 # Always use a fixed version, this is important for correct hashing.
 # Dependabot will keep these versions up to date.
 
+setuptools == 70.1.1   # for building Python packages
+pyelftools == 0.31     # for building U-Boot
 unidiff == 0.7.5       # for parsing unified diff
 GitPython == 3.1.43    # for manipulating git repos
 unidecode == 1.3.8     # for converting strings to ascii


### PR DESCRIPTION
# Description

Please see the commit messages for details on each change.

Fixes: https://paste.armbian.com/ezuliwofij.bash

This will also make sure that build hosts don't use inconsistent versions for python3-setuptools and python3-pyelftools. These are vastly different if you compare these packages on e.g. Ubuntu Jammy and Ubuntu Noble.
Pip packages will automatically be updated via Dependabot.

In addition, this change will improve compatibility with other build host OSs since Pip is independant.

# How Has This Been Tested?

- [x] `./compile.sh dts-check BOARD=nanopi-r6c BRANCH=edge BUILD_DESKTOP=no BUILD_MINIMAL=yes EXPERT=yes KERNEL_CONFIGURE=no RELEASE=trixie` while using `no-cache-dir` with pip, build host Ubuntu Noble

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
