### PR TITLE
Move board-specific config (Odroid C1) away from family config

### DIFF
--- a/config/boards/odroidc1.csc
+++ b/config/boards/odroidc1.csc
@@ -4,8 +4,23 @@ BOARDFAMILY="meson8b"
 BOARD_MAINTAINER=""
 KERNEL_TARGET="current,edge"
 
+BOOTDIR='u-boot-odroidc1'
+BOOTSOURCE='https://github.com/hardkernel/u-boot.git'
+BOOTBRANCH='branch:odroidc-v2011.03'
+BOOTPATCHDIR="legacy"
+UBOOT_COMPILER="arm-linux-gnueabi-"
+UBOOT_USE_GCC='< 4.9'
 BOOTCONFIG="odroidc_config"
 BOOTSCRIPT="boot-odroid-c1.ini:boot.ini"
 
+UBOOT_TARGET_MAP=';;sd_fuse/bl1.bin.hardkernel sd_fuse/u-boot.bin'
+
 BOOTSIZE="200"
 BOOTFS_TYPE="fat"
+
+write_uboot_platform() {
+    dd if=$1/bl1.bin.hardkernel of=$2 bs=1 count=442 conv=fsync > /dev/null 2>&1
+    dd if=$1/bl1.bin.hardkernel of=$2 bs=512 skip=1 seek=1 conv=fsync > /dev/null 2>&1
+    dd if=$1/u-boot.bin of=$2 bs=512 seek=64 conv=fsync > /dev/null 2>&1
+    dd if=/dev/zero of=$2 seek=1024 count=32 bs=512 conv=fsync > /dev/null 2>&1
+}

--- a/config/boards/onecloud.conf
+++ b/config/boards/onecloud.conf
@@ -16,3 +16,7 @@ BOOTFS_TYPE="fat"
 # FIXED_IMAGE_SIZE=7456
 
 BOOT_LOGO=desktop
+
+family_tweaks() {
+    cp $SRC/packages/blobs/splash/armbian-u-boot-24.bmp $SDCARD/boot/boot.bmp
+}

--- a/config/sources/families/include/meson_common.inc
+++ b/config/sources/families/include/meson_common.inc
@@ -19,26 +19,7 @@ CPUMIN=504000
 CPUMAX=1632000
 GOVERNOR=ondemand
 
-case $BOARD in
-	odroidc1)
-
-		BOOTDIR='u-boot-odroidc1'
-		BOOTSOURCE='https://github.com/hardkernel/u-boot.git'
-		BOOTBRANCH='branch:odroidc-v2011.03'
-		BOOTPATCHDIR="legacy"
-		UBOOT_COMPILER="arm-linux-gnueabi-"
-
-		UBOOT_TARGET_MAP=';;sd_fuse/bl1.bin.hardkernel sd_fuse/u-boot.bin'
-
-		write_uboot_platform() {
-			dd if=$1/bl1.bin.hardkernel of=$2 bs=1 count=442 conv=fsync > /dev/null 2>&1
-			dd if=$1/bl1.bin.hardkernel of=$2 bs=512 skip=1 seek=1 conv=fsync > /dev/null 2>&1
-			dd if=$1/u-boot.bin of=$2 bs=512 seek=64 conv=fsync > /dev/null 2>&1
-			dd if=/dev/zero of=$2 seek=1024 count=32 bs=512 conv=fsync > /dev/null 2>&1
-		}
-
-		;;
-esac
+SKIP_BOOTSPLASH="yes"
 
 case $BRANCH in
 
@@ -54,14 +35,6 @@ case $BRANCH in
 		declare -g KERNEL_MAJOR_MINOR="6.9"
 		;;
 esac
-
-family_tweaks() {
-	case $BOARD in
-		onecloud)
-			cp $SRC/packages/blobs/splash/armbian-u-boot-24.bmp $SDCARD/boot/boot.bmp
-			;;
-	esac
-}
 
 family_tweaks_bsp() {
 	mkdir -p "$destination/etc/X11/xorg.conf.d"


### PR DESCRIPTION
# Description

This PR is a cherry-picked commit from an old PR https://github.com/armbian/build/pull/4643

Unfortunately I seem to have borked the linked PR. Using `git rebase main` usually works, but with a PR going this far back, something seems to not have rebased as expected. Please let me know if you know why this is 😄

---
The commit includes a fix from https://github.com/armbian/build/commit/7488222b2aac8bc6a395b6714dbac3f88177585e


