### PR TITLE
aml-s9xx-box: Remove u-boot and update generated extlinux.conf

### DIFF
--- a/config/boards/aml-s9xx-box.tvb
+++ b/config/boards/aml-s9xx-box.tvb
@@ -2,13 +2,13 @@
 BOARD_NAME="aml-s9xx-box"
 BOARDFAMILY="meson-gxl"
 BOARD_MAINTAINER="SteeManMI"
-BOOTCONFIG="libretech-cc_defconfig"
 BOOTSIZE="512"
 BOOTFS_TYPE="fat"
 KERNEL_TARGET="current,edge"
 SERIALCON="ttyAML0"
 FULL_DESKTOP="yes"
 ASOUND_STATE="asound.state.mesongx"
+BOOT_FDT_FILE="amlogic/meson-gxl-s905x-p212.dtb"
 BOOT_LOGO="desktop"
 SRC_EXTLINUX="yes"
 SRC_CMDLINE='rootflags=data=writeback console=ttyAML0,115200n8 console=tty0'
@@ -32,6 +32,15 @@ function aml-s9xx-box-bsp-cli-preinst() {
     [ -f /boot/build-u-boot/u-boot-s905x3.patch ] && rm /boot/build-u-boot/u-boot-s905x3.patch
     [ -f /boot/build-u-boot/u-boot-s905x3-ugoos-x3.patch ] && rm /boot/build-u-boot/u-boot-s905x3-ugoos-x3.patch
 
+}
+
+function post_family_config__uboot_aml-s9xx-box() {
+    # This board type relies on the vendor installed u-boot on emmc to boot 
+
+    display_alert "$BOARD" "Configuring ($BOARD) non-u-boot" "info"
+
+    unset BOOTSOURCE
+    declare -g BOOTCONFIG='none'
 }
 
 function post_family_tweaks_bsp__config_aml-s9xx-box_bsp() {

--- a/packages/bsp/aml-s9xx-box/boot/extlinux/extlinux.conf.template
+++ b/packages/bsp/aml-s9xx-box/boot/extlinux/extlinux.conf.template
@@ -1,12 +1,11 @@
 label Armbian-unofficial
   kernel /Image
   initrd /uInitrd
-  fdtdir /dtb/
 
 #Insert the correct FDT line for your box's dtb in the extlinux.conf file
 #The dtbs for Amlogic s9xx boxes are located in /boot/dtb/amlogic
 #For example for a TX3 mini box the FDT line to insert would look like this:
-  FDT /dtb/amlogic/meson-gxl-s905w-tx3-mini.dtb
+  fdt /dtb/amlogic/meson-gxl-s905w-tx3-mini.dtb
 
 
   append root=UUID=<root partition uuid> rootflags=data=writeback  console=ttyAML0,115200n8 console=tty0 rw no_console_suspend consoleblank=0 fsck.fix=yes fsck.repair=yes net.ifnames=0 splash plymouth.ignore-serial-consoles


### PR DESCRIPTION
 Changes to be committed:
	modified:   config/boards/aml-s9xx-box.tvb
	modified:   packages/bsp/aml-s9xx-box/boot/extlinux/extlinux.conf.template

The aml-s9xx-box builds use the native TV Box u-boot.  I've had as a todo item to figure out how to not build and include an unused u-boot. In a recent PR for a different board the opposite was being done (adding a u-boot where a board didn't previously ship one), thus I then had the info to remove it here.
This also changes the generated extlinux.conf to include a fdt line by adding the boot_fdt_file to the board config file.  This reduces the effort needed to manually modify the extlinux.conf.

# How Has This Been Tested?

- [x] Build aml-s9xx-box image and debs
- [x] Verify built contents

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

