### PR TITLE
Lets not spam users with error message on fresh checkout

### DIFF
--- a/lib/functions/general/extensions.sh
+++ b/lib/functions/general/extensions.sh
@@ -465,6 +465,8 @@ function enable_extension() {
 
 	# there are many opportunities here. too many, actually. let userpatches override just some functions, etc.
 	for extension_base_path in "${USERPATCHES_PATH}/extensions" "${SRC}/extensions"; do
+		[[ -d "${extension_base_path}" ]] || continue
+
 		extension_dir="${extension_base_path}/${extension_name}"
 		extension_file_in_dir="${extension_dir}/${extension_name}.sh"
 		extension_floating_file="${extension_base_path}/${extension_name}.sh"


### PR DESCRIPTION
# Description

Don't throw 50+ `userpatches/extensions: No such file or directory` errors when running build from fresh checkout. The error was introduced by 497c6dc

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [X] By removing userpatches folder and rerunning ./compile.sh commandline

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
