### PR TITLE
(partially) Revert "python: Move `python3-setuptools` and `python3-pyelftools` to requirements.txt"

### DIFF
--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -290,8 +290,7 @@ function adaptative_prepare_host_dependencies() {
 	host_deps_add_extra_python # See python-tools.sh::host_deps_add_extra_python()
 
 	### Python3 -- required for Armbian's Python tooling, and also for more recent u-boot builds. Needs 3.9+; ffi-dev is needed for some Python packages when the wheel is not prebuilt
-	### 'python3-setuptools' and 'python3-pyelftools' moved to requirements.txt to make sure build hosts use the same/latest versions of these tools.
-	host_dependencies+=("python3-dev" "python3-pip" "libffi-dev")
+	host_dependencies+=("python3-dev" "python3-setuptools" "python3-pip" "python3-pyelftools" "libffi-dev")
 
 	# Needed for some u-boot's, lest "tools/mkeficapsule.c:21:10: fatal error: gnutls/gnutls.h"
 	host_dependencies+=("libgnutls28-dev")


### PR DESCRIPTION
#### (partially) Revert "python: Move `python3-setuptools` and `python3-pyelftools` to requirements.txt"

- (partially) Revert "python: Move `python3-setuptools` and `python3-pyelftools` to requirements.txt"
  - "Fixes" https://github.com/armbian/build/pull/6799
  This (partially) reverts commit 04f619dc