### PR TITLE
Armbian-install: add option to wipe target destination

### DIFF
--- a/packages/bsp/common/usr/sbin/armbian-install
+++ b/packages/bsp/common/usr/sbin/armbian-install
@@ -658,6 +658,20 @@ check_partitions()
 	[[ -n "$2" ]] && INCLUDE=" | grep $2" && diskcheck=$2
 	CMD="lsblk -io KNAME,FSTYPE,SIZE,TYPE,MOUNTPOINT | grep -v -w $root_partition_name $INCLUDE $EXCLUDE | grep -E '^sd|^nvme|^md|^mmc' | awk -F\" \" '/ part | raid..? / {print \$1}'"
 	AvailablePartitions=$(eval $CMD)
+
+	dialog --yes-label "Proceed" --no-label 'Skip' --title "$title" --backtitle "$backtitle" --yesno "\nIt is highly recommended to wipe all partitions on the destination disk /dev/$diskcheck and leave installer to make them!" 8 75
+
+	# wiping destination to make sure we don't run into issues
+	if [[ $? -eq 0 ]]; then
+		dd if=/dev/zero of=/dev/${diskcheck} bs=1M count=10 >> $logfile 2>&1
+		partprobe -s "/dev/${diskcheck}" >> $logfile 2>&1
+		echo -e 'mktable gpt\nmkpart primary ext4 0% 100%\nquit' | sudo parted "/dev/${diskcheck}" >> $logfile 2>&1
+		sudo partprobe -s "/dev/${diskcheck}" >> $logfile 2>&1
+		sudo mkfs.ext4 -E "/dev/${diskcheck}"p1 >> $logfile 2>&1
+		sudo partprobe -s "/dev/${diskcheck}" >> $logfile 2>&1
+		sleep 2
+	fi
+
 	if [[ -z $AvailablePartitions ]]; then
 		# Consider brand new devices or devices with a wiped partition table
 		if [[ -z $(blkid /dev/$diskcheck) ]]; then

--- a/packages/bsp/common/usr/sbin/armbian-install
+++ b/packages/bsp/common/usr/sbin/armbian-install
@@ -659,17 +659,21 @@ check_partitions()
 	CMD="lsblk -io KNAME,FSTYPE,SIZE,TYPE,MOUNTPOINT | grep -v -w $root_partition_name $INCLUDE $EXCLUDE | grep -E '^sd|^nvme|^md|^mmc' | awk -F\" \" '/ part | raid..? / {print \$1}'"
 	AvailablePartitions=$(eval $CMD)
 
-	dialog --yes-label "Proceed" --no-label 'Skip' --title "$title" --backtitle "$backtitle" --yesno "\nIt is highly recommended to wipe all partitions on the destination disk /dev/$diskcheck and leave installer to make them!" 8 75
+	dialog --yes-label "Proceed" --no-label 'Skip' --title "$title" --backtitle "$backtitle" --yesno "\nIt is highly recommended to wipe all partitions on the destination disk\n \n/dev/$diskcheck\n\nand leave installer to make them!" 10 75
 
 	# wiping destination to make sure we don't run into issues
 	if [[ $? -eq 0 ]]; then
-		dd if=/dev/zero of=/dev/${diskcheck} bs=1M count=10 >> $logfile 2>&1
-		partprobe -s "/dev/${diskcheck}" >> $logfile 2>&1
-		echo -e 'mktable gpt\nmkpart primary ext4 0% 100%\nquit' | sudo parted "/dev/${diskcheck}" >> $logfile 2>&1
-		sudo partprobe -s "/dev/${diskcheck}" >> $logfile 2>&1
-		sudo mkfs.ext4 -E "/dev/${diskcheck}"p1 >> $logfile 2>&1
-		sudo partprobe -s "/dev/${diskcheck}" >> $logfile 2>&1
-		sleep 2
+		exec 3>&1
+			ACKNOWLEDGEMENT=$(dialog --colors --nocancel --backtitle "$BACKTITLE" --no-collapse --title " Warning " \
+			--clear \--radiolist "\nTHIS OPERATION WILL WIPE ALL DATA ON DRIVE:\n\n/dev/$diskcheck\n " 0 56 4 "Yes, I understand" "" off       2>&1 1>&3)
+		exec 3>&-
+		if [[ "${ACKNOWLEDGEMENT}" == "Yes, I understand" ]]; then
+			dd if=/dev/zero of=/dev/${diskcheck} bs=1M count=10 >> $logfile 2>&1
+			partprobe -s "/dev/${diskcheck}" >> $logfile 2>&1
+			echo -e 'mktable gpt\nmkpart primary ext4 0% 100%\nquit' | sudo parted "/dev/${diskcheck}" >> $logfile 2>&1
+			sudo partprobe -s "/dev/${diskcheck}" >> $logfile 2>&1
+			sleep 2
+		fi
 	fi
 
 	if [[ -z $AvailablePartitions ]]; then


### PR DESCRIPTION
# Description

armbian-installer have troubles if we are installing OS to SSD with previously defined partitions. Adding a recommended option to start with a clean drive - wiping everything - is one way. In this case, our installer starts in predicted way. Also it gives user no option to choose wrong (too small) partition, if there are more of them pre-made.

[Jira](https://armbian.atlassian.net/jira) reference number [AR-2393]
https://forum.armbian.com/topic/41699-how-to-debugfix-armbian-config-for-kernel-update/#comment-195551

# How Has This Been Tested?

- [x] Made several installs to nvme with several or no partitions

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-2393]: https://armbian.atlassian.net/browse/AR-2393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ