### PR TITLE
nanopi-r5s: bump blobs & u-boot enhancements for UMS/otg/bootorder

### DIFF
--- a/patch/u-boot/v2024.04/board_nanopi-r5s/0001-rockchip-common-boot-USB-devices-first-then-nvme-mmc-s-scsi.patch
+++ b/patch/u-boot/v2024.04/board_nanopi-r5s/0001-rockchip-common-boot-USB-devices-first-then-nvme-mmc-s-scsi.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ricardo Pardini <ricardo@pardini.net>
+Date: Wed, 16 Aug 2023 13:54:31 +0200
+Subject: rockchip-common: boot USB devices first, then sd, then nvme, then
+ emmc
+
+---
+ include/configs/rockchip-common.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/configs/rockchip-common.h b/include/configs/rockchip-common.h
+index 111111111111..222222222222 100644
+--- a/include/configs/rockchip-common.h
++++ b/include/configs/rockchip-common.h
+@@ -13,7 +13,7 @@
+ 
+ #ifndef CONFIG_SPL_BUILD
+ 
+-#define BOOT_TARGETS	"mmc1 mmc0 nvme scsi usb pxe dhcp spi"
++#define BOOT_TARGETS	"usb mmc1 nvme scsi mmc0 pxe dhcp spi"
+ 
+ #ifdef CONFIG_ARM64
+ #define ROOT_UUID "B921B045-1DF0-41C3-AF44-4C6F280D3FAE;\0"
+-- 
+Armbian
+

--- a/patch/u-boot/v2024.04/board_nanopi-r5s/0002-usb-otg-mode.patch
+++ b/patch/u-boot/v2024.04/board_nanopi-r5s/0002-usb-otg-mode.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ricardo Pardini <ricardo@pardini.net>
+Date: Sat, 29 Jun 2024 15:00:54 +0200
+Subject: nanopi-r5s: u-boot: 2024.04: usb otg in u-boot for working
+ UMS/RockUSB
+
+---
+ arch/arm/dts/rk3568-nanopi-r5s-u-boot.dtsi | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/arch/arm/dts/rk3568-nanopi-r5s-u-boot.dtsi b/arch/arm/dts/rk3568-nanopi-r5s-u-boot.dtsi
+index 111111111111..222222222222 100644
+--- a/arch/arm/dts/rk3568-nanopi-r5s-u-boot.dtsi
++++ b/arch/arm/dts/rk3568-nanopi-r5s-u-boot.dtsi
+@@ -24,3 +24,7 @@
+ 	/delete-property/ regulator-always-on;
+ 	/delete-property/ regulator-boot-on;
+ };
++
++&usb_host0_xhci {
++	dr_mode = "otg";
++};
+\ No newline at end of file
+-- 
+Armbian
+


### PR DESCRIPTION
#### nanopi-r5s: bump blobs & u-boot enhancements for UMS/otg/bootorder

- nanopi-r5s: make u-boot fancy (ums, rockusb, leds, tcp networking stuff)
  - use preboot to flash all leds for 100ms, then leave power LED on
- nanopi-r5s: u-boot: 2024.04: boot order: usb -> sd -> nvme -> scsi -> emmc
- nanopi-r5s: u-boot: 2024.04: usb otg in u-boot for working UMS/RockUSB