### PR TITLE
armbianmonitor `-u`: rationalize paste server retrying, use ANSI dmesg

### DIFF
--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -96,7 +96,10 @@ Main() {
 		fi
 	fi
 
-	[ $# -eq 0 ] && (DisplayUsage ; exit 0)
+	[ $# -eq 0 ] && (
+		DisplayUsage
+		exit 0
+	)
 
 	ParseOptions "$@"
 
@@ -108,7 +111,7 @@ Main() {
 		# we should already provide monitoring, check whether DEBUG
 		# is also set
 		ArmbianMonitoring=TRUE
-		read -r DebugMode </etc/armbianmonitor/start-monitoring 2>/dev/null
+		read -r DebugMode < /etc/armbianmonitor/start-monitoring 2> /dev/null
 	fi
 
 	# check whether rpimonitord is running and compare with ${ArmbianMonitoring}
@@ -121,198 +124,212 @@ Main() {
 } # Main
 
 ParseOptions() {
-	while getopts 'hHbBuUrRmMsnNd:Dc:C:pPvz' c ; do
-	case ${c} in
-		H)
-			# display full help test
-			# export FullUsage=TRUE
-			DisplayUsage
-			exit 0
-			;;
-		h)
-			# display short help
-			DisplayUsage
-			exit 0
-			;;
-		m|M|s)
-			# monitoring mode, -s is for internal usage (debug log upload)
-			interval=$2
-			MonitorMode ${OPTARG}
-			exit 0
-			;;
-		n|N)
-			# network monitoring mode
-			rf1=$2
-			NetworkMonitorMode ${OPTARG}
-			exit 0
-			;;
-		u)
-                        # Upload /var/log/armbian-hardware-monitor.log with additional support info
-                        which curl >/dev/null 2>&1 || apt-get -f -qq -y install curl
-                        echo -e "System diagnosis information will now be uploaded to \c"
-                        fping paste.armbian.com 2>/dev/null | grep -q alive
-                        if [ $? != 0 ]; then
-                                echo -e "\nNetwork/firewall problem detected.\nTrying fallback..." >&2
-                                fping ix.io 2>/dev/null | grep -q alive
-                                if [ $? != 0 ]; then
-                                        echo -e "\nNetwork/firewall problem detected. Not able to upload debug info.\nPlease fix this or use \"-U\" instead and upload ${BOLD}whole output${NC} manually to an online pasteboard service\nand provide the URL in the forum where you have been asked for this.\n"
-					exit 1
-                                fi
-
-                                # we obfuscate IPv4 addresses somehow but not too much, MAC addresses have to remain
-                                # in clear since otherwise the log becomes worthless due to randomly generated
-                                # addresses here and there that might conflict
-	                        CollectSupportInfo \
-                                | sed -E 's/([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3})/XXX.XXX.\3\4/g' \
-                                | curl -F 'f:1=<-' ix.io
-                                echo -e "Please post the URL in the forum where you've been asked for.\n"
-	                        exit 0
-                        fi
-
-                        # we obfuscate IPv4 addresses somehow but not too much, MAC addresses have to remain
-                        # in clear since otherwise the log becomes worthless due to randomly generated
-                        # addresses here and there that might conflict
-                        CollectSupportInfo \
-                        | sed -E 's/([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3})/XXX.XXX.\3\4/g' \
-                        | curl -s --data-binary @- "https://paste.armbian.com/documents" \
-                        | awk -F'"' '{ print "https://paste.armbian.com/" $4 }'
-                        echo -e "Please post the URL in the forum where you've been asked for.\n"
-                        exit 0
-                        ;;
-
-                U)
-			# Send support info to stdout to be uploaded manually. Add line numbers to prevent
-			# users being creative and supressing everything that's important
-			CollectSupportInfo \
-				| sed -E 's/([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3})/XXX.XXX.\3\4/g' \
-				| awk '!NF{$0=" "}1' | nl -
-			echo -e "\nPlease upload the ${BOLD}whole output${NC} above to an online pasteboard service\nand provide the URL in the forum where you have been asked for this.\n"
-			exit 0
-			;;
-		r|R)
-			# Installs RPi-Monitor and patches templates (heavily on sun8i)
-			fping armbian.com 2>/dev/null | grep -q alive || \
-				(echo "Network/firewall problem detected. Please fix this prior to installing RPi-Monitor." >&2 ; exit 1)
-			InstallRPiMonitor
-			case $(awk '/Hardware/ {print $3$4}' </proc/cpuinfo) in
-				*sun8i*)
-					PatchRPiMonitor_for_sun8i
-					case $(uname -r) in
-						3.4.*)
-							sed -i 's|H3_Extended_Mainline.conf|H3_Extended.conf|' /etc/rpimonitor/template/OrangePi_H3.conf
-							systemctl restart rpimonitor >/dev/null 2>&1
-							;;
-					esac
-					;;
-				*)
-					# On other SoCs than H3 make minor adjustments to config to reflect Armbian reality:
-					. /etc/armbian-release
-					sed -e "s/^web.status.1.name=.*/web.status.1.name=$BOARD_NAME/" \
-						-e "s/^web.statistics.1.name=.*/web.statistics.1.name=$BOARD_NAME/" \
-						</etc/rpimonitor/template/raspbian.conf >/etc/rpimonitor/template/armbian.conf
-					cd /etc/rpimonitor/
-					ln -sf /etc/rpimonitor/template/armbian.conf data.conf
-					# fix temperature everywhere
-					sed -i -e 's|^dynamic.12.source=.*|dynamic.12.source=/etc/armbianmonitor/datasources/soctemp|' \
-						-e 's|^dynamic.12.postprocess=.*|dynamic.12.postprocess=sprintf("%.1f", $1/1000)|' \
-						/etc/rpimonitor/template/temperature.conf
-					# monitor big cores on big.LITTLE
-					if [ $(grep -c '^processor' /proc/cpuinfo) -ge 4 ]; then
-						sed -i 's|/sys/devices/system/cpu/cpu0/cpufreq/|/sys/devices/system/cpu/cpu4/cpufreq/|g' \
-						/etc/rpimonitor/template/cpu.conf
+	while getopts 'hHbBuUrRmMsnNd:Dc:C:pPvz' c; do
+		case ${c} in
+			H)
+				# display full help test
+				# export FullUsage=TRUE
+				DisplayUsage
+				exit 0
+				;;
+			h)
+				# display short help
+				DisplayUsage
+				exit 0
+				;;
+			m | M | s)
+				# monitoring mode, -s is for internal usage (debug log upload)
+				interval=$2
+				MonitorMode ${OPTARG}
+				exit 0
+				;;
+			n | N)
+				# network monitoring mode
+				rf1=$2
+				NetworkMonitorMode ${OPTARG}
+				exit 0
+				;;
+			u)
+				# Upload /var/log/armbian-hardware-monitor.log with additional support info
+				which curl > /dev/null 2>&1 || apt-get -f -qq -y install curl
+				echo -e "System diagnosis information will now be uploaded to \c"
+				fping paste.armbian.com 2> /dev/null | grep -q alive
+				if [ $? != 0 ]; then
+					echo -e "\nNetwork/firewall problem detected.\nTrying fallback..." >&2
+					fping ix.io 2> /dev/null | grep -q alive
+					if [ $? != 0 ]; then
+						echo -e "\nNetwork/firewall problem detected. Not able to upload debug info.\nPlease fix this or use \"-U\" instead and upload ${BOLD}whole output${NC} manually to an online pasteboard service\nand provide the URL in the forum where you have been asked for this.\n"
+						exit 1
 					fi
-					# display processor architecture instead of undefined
-					sed -i -e "s_^static.4.source=.*_static.4.source=lscpu | awk -F' ' '/^Architecture/ {print \$2}'_" \
-						-e "s/^static.4.regexp=.*/static.4.regexp=/" /etc/rpimonitor/template/version.conf
-					;;
-			esac
-			echo -e "\nNow you're able to enjoy RPi-Monitor at http://$(ip a | awk -F" " '/inet / {print $2}' | grep -v '127.0.0.1' | cut -f1 -d/ | head -n1):8888"
-			exit 0
-			;;
-		p|P)
-			# Installs cpuminer on 32-bit platforms
-			fping armbian.com 2>/dev/null | grep -q alive || \
-				(echo "Network/firewall problem detected. Please fix this prior to installing cpuminer." >&2 ; exit 1)
-			cd /usr/local/src/
-			wget http://downloads.sourceforge.net/project/cpuminer/pooler-cpuminer-2.5.1.tar.gz
-			tar xf pooler-cpuminer-2.5.1.tar.gz && rm pooler-cpuminer-2.5.1.tar.gz
-			cd cpuminer-2.5.1/
-			apt-get -f -qq -y install libcurl4-gnutls-dev
-			autoreconf --force --install --verbose
-			./configure CFLAGS="-O3"
-			make && make install
-			echo -e "\n\nNow you can use /usr/local/bin/minerd to do automated benchmarking.\nIn case you also installed RPi-Monitor you can do a"
-			echo -e "\n    touch /root/.cpuminer\n\nto ensure minerd is running after reboot and results are recorded\nwith RPi-Monitor"
-			exit 0
-			;;
-		d)
-			# monitors write activity to disk
-			MonitorIO "${OPTARG}"
-			exit 0
-			;;
-		D)
-			fping ix.io 2>/dev/null | grep -q alive || \
-				(echo "Network/firewall problem detected. Please fix this prior to installing RPi-Monitor." >&2 ; exit 1)
-			DebugOutput="$(mktemp /tmp/${0##*/}.XXXXXX)"
-			trap "rm \"${DebugOutput}\" ; exit 0" 0 1 2 3 15
-			set -x
-			exec 2>"${DebugOutput}"
-			PreRequisits >/dev/null 2>&1
-			CheckDisks
-			which curl >/dev/null 2>&1 || apt-get -f -qq -y install curl
-			echo -e "\nDebug output has been collected at the following URL: \c"
-			(cat "${DebugOutput}"; echo -e "\n\n\ngdisk.txt contents:\n" ; cat "${MyTempDir}/gdisk.txt" ;\
-				echo -e "\n\n\nsmartctl.txt contents:\n" ; cat "${MyTempDir}/smartctl.txt") \
-				| curl -F 'f:1=<-' ix.io
-			echo -e "Please post the URL in the Armbian forum where you've been asked for."
-			exit 0
-			;;
-		c|C)
-			# check card mode
-			CheckCard "${OPTARG}"
-			exit 0
-			;;
-		v)
-			# Verify installation integrity
-			VerifyRepairExcludes="/etc/|/boot/|cache|getty|/var/lib/smartmontools/"
-			VerifyInstallation
-			exit 0
-			;;
-		z)
-			# Do a quick 7-zip benchmark to estimate CPU performance
-			runs=$2
-			Run7ZipBenchmark 2>/dev/null
-			exit 0
-			;;
-	esac
+
+					# we obfuscate IPv4 addresses somehow but not too much, MAC addresses have to remain
+					# in clear since otherwise the log becomes worthless due to randomly generated
+					# addresses here and there that might conflict
+					CollectSupportInfo |
+						sed -E 's/([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3})/XXX.XXX.\3\4/g' |
+						curl -F 'f:1=<-' ix.io
+					echo -e "Please post the URL in the forum where you've been asked for.\n"
+					exit 0
+				fi
+
+				# we obfuscate IPv4 addresses somehow but not too much, MAC addresses have to remain
+				# in clear since otherwise the log becomes worthless due to randomly generated
+				# addresses here and there that might conflict
+				CollectSupportInfo |
+					sed -E 's/([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3})/XXX.XXX.\3\4/g' |
+					curl -s --data-binary @- "https://paste.armbian.com/documents" |
+					awk -F'"' '{ print "https://paste.armbian.com/" $4 }'
+				echo -e "Please post the URL in the forum where you've been asked for.\n"
+				exit 0
+				;;
+
+			U)
+				# Send support info to stdout to be uploaded manually. Add line numbers to prevent
+				# users being creative and supressing everything that's important
+				CollectSupportInfo |
+					sed -E 's/([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3})/XXX.XXX.\3\4/g' |
+					awk '!NF{$0=" "}1' | nl -
+				echo -e "\nPlease upload the ${BOLD}whole output${NC} above to an online pasteboard service\nand provide the URL in the forum where you have been asked for this.\n"
+				exit 0
+				;;
+			r | R)
+				# Installs RPi-Monitor and patches templates (heavily on sun8i)
+				fping armbian.com 2> /dev/null | grep -q alive ||
+					(
+						echo "Network/firewall problem detected. Please fix this prior to installing RPi-Monitor." >&2
+						exit 1
+					)
+				InstallRPiMonitor
+				case $(awk '/Hardware/ {print $3$4}' < /proc/cpuinfo) in
+					*sun8i*)
+						PatchRPiMonitor_for_sun8i
+						case $(uname -r) in
+							3.4.*)
+								sed -i 's|H3_Extended_Mainline.conf|H3_Extended.conf|' /etc/rpimonitor/template/OrangePi_H3.conf
+								systemctl restart rpimonitor > /dev/null 2>&1
+								;;
+						esac
+						;;
+					*)
+						# On other SoCs than H3 make minor adjustments to config to reflect Armbian reality:
+						. /etc/armbian-release
+						sed -e "s/^web.status.1.name=.*/web.status.1.name=$BOARD_NAME/" \
+							-e "s/^web.statistics.1.name=.*/web.statistics.1.name=$BOARD_NAME/" \
+							< /etc/rpimonitor/template/raspbian.conf > /etc/rpimonitor/template/armbian.conf
+						cd /etc/rpimonitor/
+						ln -sf /etc/rpimonitor/template/armbian.conf data.conf
+						# fix temperature everywhere
+						sed -i -e 's|^dynamic.12.source=.*|dynamic.12.source=/etc/armbianmonitor/datasources/soctemp|' \
+							-e 's|^dynamic.12.postprocess=.*|dynamic.12.postprocess=sprintf("%.1f", $1/1000)|' \
+							/etc/rpimonitor/template/temperature.conf
+						# monitor big cores on big.LITTLE
+						if [ $(grep -c '^processor' /proc/cpuinfo) -ge 4 ]; then
+							sed -i 's|/sys/devices/system/cpu/cpu0/cpufreq/|/sys/devices/system/cpu/cpu4/cpufreq/|g' \
+								/etc/rpimonitor/template/cpu.conf
+						fi
+						# display processor architecture instead of undefined
+						sed -i -e "s_^static.4.source=.*_static.4.source=lscpu | awk -F' ' '/^Architecture/ {print \$2}'_" \
+							-e "s/^static.4.regexp=.*/static.4.regexp=/" /etc/rpimonitor/template/version.conf
+						;;
+				esac
+				echo -e "\nNow you're able to enjoy RPi-Monitor at http://$(ip a | awk -F" " '/inet / {print $2}' | grep -v '127.0.0.1' | cut -f1 -d/ | head -n1):8888"
+				exit 0
+				;;
+			p | P)
+				# Installs cpuminer on 32-bit platforms
+				fping armbian.com 2> /dev/null | grep -q alive ||
+					(
+						echo "Network/firewall problem detected. Please fix this prior to installing cpuminer." >&2
+						exit 1
+					)
+				cd /usr/local/src/
+				wget http://downloads.sourceforge.net/project/cpuminer/pooler-cpuminer-2.5.1.tar.gz
+				tar xf pooler-cpuminer-2.5.1.tar.gz && rm pooler-cpuminer-2.5.1.tar.gz
+				cd cpuminer-2.5.1/
+				apt-get -f -qq -y install libcurl4-gnutls-dev
+				autoreconf --force --install --verbose
+				./configure CFLAGS="-O3"
+				make && make install
+				echo -e "\n\nNow you can use /usr/local/bin/minerd to do automated benchmarking.\nIn case you also installed RPi-Monitor you can do a"
+				echo -e "\n    touch /root/.cpuminer\n\nto ensure minerd is running after reboot and results are recorded\nwith RPi-Monitor"
+				exit 0
+				;;
+			d)
+				# monitors write activity to disk
+				MonitorIO "${OPTARG}"
+				exit 0
+				;;
+			D)
+				fping ix.io 2> /dev/null | grep -q alive ||
+					(
+						echo "Network/firewall problem detected. Please fix this prior to installing RPi-Monitor." >&2
+						exit 1
+					)
+				DebugOutput="$(mktemp /tmp/${0##*/}.XXXXXX)"
+				trap "rm \"${DebugOutput}\" ; exit 0" 0 1 2 3 15
+				set -x
+				exec 2> "${DebugOutput}"
+				PreRequisits > /dev/null 2>&1
+				CheckDisks
+				which curl > /dev/null 2>&1 || apt-get -f -qq -y install curl
+				echo -e "\nDebug output has been collected at the following URL: \c"
+				(
+					cat "${DebugOutput}"
+					echo -e "\n\n\ngdisk.txt contents:\n"
+					cat "${MyTempDir}/gdisk.txt"
+					echo -e "\n\n\nsmartctl.txt contents:\n"
+					cat "${MyTempDir}/smartctl.txt"
+				) |
+					curl -F 'f:1=<-' ix.io
+				echo -e "Please post the URL in the Armbian forum where you've been asked for."
+				exit 0
+				;;
+			c | C)
+				# check card mode
+				CheckCard "${OPTARG}"
+				exit 0
+				;;
+			v)
+				# Verify installation integrity
+				VerifyRepairExcludes="/etc/|/boot/|cache|getty|/var/lib/smartmontools/"
+				VerifyInstallation
+				exit 0
+				;;
+			z)
+				# Do a quick 7-zip benchmark to estimate CPU performance
+				runs=$2
+				Run7ZipBenchmark 2> /dev/null
+				exit 0
+				;;
+		esac
 	done
 } # ParseOptions
 
 DisplayUsage() {
 
-# Kept for referance.
-#	if [ ${FullUsage} ]; then
-#		echo -e "\nDetailed Description:"
-#		grep "^#" "$0" | grep -v "^#\!/bin/bash" | sed 's/^#//'
-#	fi
-    echo 
-    echo "Usage: $(basename $0) [-h] [-b] [-c \$path] [-d \$device] [-D] [-m] [-p] [-r] [-u]"
-    echo
-    echo "Options:"
-    echo "  -c /path/to/test   Performs disk health/performance tests"
-    echo "  -d                 Monitors writes to \$device"
-    echo "  -D                 Tries to upload debug disk info to improve armbianmonitor"
-    echo "  -m                 Provides simple CLI monitoring - scrolling output"
-    echo "  -M                 Provides simple CLI monitoring - fixed-line output"
-    echo "  -n                 Provides simple CLI network monitoring - scrolling output"
-    echo "  -N                 Provides simple CLI network monitoring - fixed-line output"
-    echo "  -p                 Tries to install cpuminer for performance measurements"
-    echo "  -r                 Tries to install RPi-Monitor"
-    echo "  -u                 Tries to upload armbian-hardware-monitor.log for support purposes"
-    echo "  -v                 Tries to verify installed package integrity"
-    echo "  -z                 Runs a quick 7-zip benchmark to estimate CPU performance"
-    echo 
-    
+	# Kept for referance.
+	#	if [ ${FullUsage} ]; then
+	#		echo -e "\nDetailed Description:"
+	#		grep "^#" "$0" | grep -v "^#\!/bin/bash" | sed 's/^#//'
+	#	fi
+	echo
+	echo "Usage: $(basename $0) [-h] [-b] [-c \$path] [-d \$device] [-D] [-m] [-p] [-r] [-u]"
+	echo
+	echo "Options:"
+	echo "  -c /path/to/test   Performs disk health/performance tests"
+	echo "  -d                 Monitors writes to \$device"
+	echo "  -D                 Tries to upload debug disk info to improve armbianmonitor"
+	echo "  -m                 Provides simple CLI monitoring - scrolling output"
+	echo "  -M                 Provides simple CLI monitoring - fixed-line output"
+	echo "  -n                 Provides simple CLI network monitoring - scrolling output"
+	echo "  -N                 Provides simple CLI network monitoring - fixed-line output"
+	echo "  -p                 Tries to install cpuminer for performance measurements"
+	echo "  -r                 Tries to install RPi-Monitor"
+	echo "  -u                 Tries to upload armbian-hardware-monitor.log for support purposes"
+	echo "  -v                 Tries to verify installed package integrity"
+	echo "  -z                 Runs a quick 7-zip benchmark to estimate CPU performance"
+	echo
+
 } # DisplayUsage
 
 MonitorMode() {
@@ -329,7 +346,7 @@ MonitorMode() {
 	trap "echo ; exit 0" 0 1 2 3 15
 
 	# Try to renice to 19 to not interfere with OS behaviour
-	renice 19 $BASHPID >/dev/null 2>&1
+	renice 19 $BASHPID > /dev/null 2>&1
 
 	LastUserStat=0
 	LastNiceStat=0
@@ -360,14 +377,14 @@ MonitorMode() {
 	[ -f "${Sensors}/pmictemp" ] && DisplayHeader="${DisplayHeader}   PMIC" || PMICTemp='n/a'
 	DCIN=$(CheckDCINVoltage)
 	[ -f "${DCIN}" ] && DisplayHeader="${DisplayHeader}   DC-IN" || DCIN='n/a'
-	[ -f /sys/devices/virtual/thermal/cooling_device0/cur_state ] \
-		&& DisplayHeader="${DisplayHeader}  C.St." || CoolingState='n/a'
+	[ -f /sys/devices/virtual/thermal/cooling_device0/cur_state ] &&
+		DisplayHeader="${DisplayHeader}  C.St." || CoolingState='n/a'
 	echo -e "Stop monitoring using [ctrl]-[c]"
-	[ $(echo "${SleepInterval} * 10" | bc | cut -d. -f1) -le 15 ] \
-		&& echo "Warning: High update frequency (${SleepInterval} sec) might change system behaviour!"
+	[ $(echo "${SleepInterval} * 10" | bc | cut -d. -f1) -le 15 ] &&
+		echo "Warning: High update frequency (${SleepInterval} sec) might change system behaviour!"
 	echo -e "${DisplayHeader}"
 	Counter=0
-	while true ; do
+	while true; do
 		if [ "$c" == "m" ]; then
 			let Counter++
 			if [ ${Counter} -eq 15 ]; then
@@ -383,16 +400,16 @@ MonitorMode() {
 		else
 			printf "\x1b[1A"
 		fi
-		LoadAvg=$(cut -f1 -d" " </proc/loadavg)
+		LoadAvg=$(cut -f1 -d" " < /proc/loadavg)
 		case ${CPUs} in
 			dual_cluster)
-				Cluster1=$(awk '{printf ("%0.0f",$1/1000); }' </sys/devices/system/cpu/cpu4/cpufreq/scaling_cur_freq) 2>/dev/null
-				Cluster0=$(awk '{printf ("%0.0f",$1/1000); }' </sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq) 2>/dev/null
+				Cluster1=$(awk '{printf ("%0.0f",$1/1000); }' < /sys/devices/system/cpu/cpu4/cpufreq/scaling_cur_freq) 2> /dev/null
+				Cluster0=$(awk '{printf ("%0.0f",$1/1000); }' < /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq) 2> /dev/null
 				ProcessStats
 				printf "\n%s  %4s/%4s MHz %5s %s" "$(date "+%H:%M:%S")" "$Cluster0" "$Cluster1" "$LoadAvg" "$procStats"
 				;;
 			normal)
-				CpuFreq=$(awk '{printf ("%0.0f",$1/1000); }' </sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq) 2>/dev/null
+				CpuFreq=$(awk '{printf ("%0.0f",$1/1000); }' < /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq) 2> /dev/null
 				ProcessStats
 				printf "\n%s  %4s MHz %5s %s" "$(date "+%H:%M:%S")" "$CpuFreq" "$LoadAvg" "$procStats"
 				;;
@@ -402,16 +419,16 @@ MonitorMode() {
 				;;
 		esac
 		if [ "X${SocTemp}" != "Xn/a" ]; then
-			read -r SocTemp <"${Sensors}/soctemp"
+			read -r SocTemp < "${Sensors}/soctemp"
 			if [ ${SocTemp} -ge 1000 ]; then
-				SocTemp=$(awk '{printf ("%0.1f",$1/1000); }' <<<${SocTemp})
+				SocTemp=$(awk '{printf ("%0.1f",$1/1000); }' <<< ${SocTemp})
 			fi
 			printf "  %4s °C" "$SocTemp"
 		fi
 		if [ "X${PMICTemp}" != "Xn/a" ]; then
-			read -r PMICTemp <"${Sensors}/pmictemp"
+			read -r PMICTemp < "${Sensors}/pmictemp"
 			if [ ${PMICTemp} -ge 1000 ]; then
-				PMICTemp=$(awk '{printf ("%0.1f",$1/1000); }' <<<${PMICTemp})
+				PMICTemp=$(awk '{printf ("%0.1f",$1/1000); }' <<< ${PMICTemp})
 			fi
 			printf "  %4s °C" "$PMICTemp"
 		fi
@@ -419,17 +436,17 @@ MonitorMode() {
 			case "${DCIN##*/}" in
 				in_voltage2_raw)
 					# Tinkerboard S
-					read -r RAWvoltage <"${DCIN}"
+					read -r RAWvoltage < "${DCIN}"
 					DCINvoltage=$(echo "(${RAWvoltage} / ((82.0/302.0) * 1023.0 / 1.8)) + 0.1" | bc -l)
 					;;
 				*)
-					DCINvoltage=$(awk '{printf ("%0.2f",$1/1000000); }' <"${DCIN}")
+					DCINvoltage=$(awk '{printf ("%0.2f",$1/1000000); }' < "${DCIN}")
 					;;
 			esac
 			printf "  %5sV" "$DCINvoltage"
 		fi
-		[ "X${CoolingState}" != "Xn/a" ] && \
-		printf "  %d/%d" "$(cat /sys/devices/virtual/thermal/cooling_device0/cur_state)" "$(cat /sys/devices/virtual/thermal/cooling_device0/max_state)"
+		[ "X${CoolingState}" != "Xn/a" ] &&
+			printf "  %d/%d" "$(cat /sys/devices/virtual/thermal/cooling_device0/cur_state)" "$(cat /sys/devices/virtual/thermal/cooling_device0/max_state)"
 		[ "$c" == "s" ] && sleep 0.3 || sleep ${SleepInterval}
 	done
 } # MonitorMode
@@ -438,9 +455,9 @@ CheckDCINVoltage() {
 	for i in /sys/devices/platform/sunxi-i2c.0/i2c-0/0-0034/axp20-supplyer.28/power_supply/usb/voltage_now \
 		/sys/power/axp_pmu/vbus/voltage \
 		/sys/devices/platform/sunxi-i2c.0/i2c-0/0-0034/axp20-supplyer.28/power_supply/ac/voltage_now \
-		/sys/power/axp_pmu/ac/voltage '/sys/bus/iio/devices/iio:device0/in_voltage2_raw' ; do
+		/sys/power/axp_pmu/ac/voltage '/sys/bus/iio/devices/iio:device0/in_voltage2_raw'; do
 		if [ -f $i ]; then
-			read -r DCINvoltage <$i 2>/dev/null
+			read -r DCINvoltage < $i 2> /dev/null
 			if [ ${DCINvoltage} -gt 4080000 ]; then
 				echo $i
 				break
@@ -452,15 +469,15 @@ CheckDCINVoltage() {
 ProcessStats() {
 	if [ -f /tmp/cpustat ]; then
 		# RPi-Monitor/Armbianmonitor already running and providing processed values
-		set $(awk -F" " '{print $1"\t"$2"\t"$3"\t"$4"\t"$5"\t"$6}' </tmp/cpustat)
+		set $(awk -F" " '{print $1"\t"$2"\t"$3"\t"$4"\t"$5"\t"$6}' < /tmp/cpustat)
 		CPULoad=$1
 		SystemLoad=$2
 		UserLoad=$3
 		NiceLoad=$4
 		IOWaitLoad=$5
-		IrqCombinedLoad=$6		
+		IrqCombinedLoad=$6
 	else
-		procStatLine=(`sed -n 's/^cpu\s//p' /proc/stat`)
+		procStatLine=($(sed -n 's/^cpu\s//p' /proc/stat))
 		UserStat=${procStatLine[0]}
 		NiceStat=${procStatLine[1]}
 		SystemStat=${procStatLine[2]}
@@ -471,26 +488,26 @@ ProcessStats() {
 
 		Total=0
 		for eachstat in "${procStatLine[@]}"; do
-			Total=$(( Total + eachstat ))
+			Total=$((Total + eachstat))
 		done
 
-		UserDiff=$(( UserStat - LastUserStat ))
-		NiceDiff=$(( NiceStat - LastNiceStat ))
-		SystemDiff=$(( SystemStat - LastSystemStat ))
-		IOWaitDiff=$(( IOWaitStat - LastIOWaitStat ))
-		IrqDiff=$(( IrqStat - LastIrqStat ))
-		SoftIrqDiff=$(( SoftIrqStat - LastSoftIrqStat ))
-		
-		diffIdle=$(( IdleStat - LastIdleStat ))
-		diffTotal=$(( Total - LastTotal ))
-		diffX=$(( diffTotal - diffIdle ))
-		CPULoad=$(( diffX * 100 / diffTotal ))
-		UserLoad=$(( UserDiff * 100 / diffTotal ))
-		SystemLoad=$(( SystemDiff * 100 / diffTotal ))
-		NiceLoad=$(( NiceDiff * 100 / diffTotal ))
-		IOWaitLoad=$(( IOWaitDiff * 100 / diffTotal ))
-		IrqCombined=$(( IrqDiff + SoftIrqDiff ))
-		IrqCombinedLoad=$(( IrqCombined * 100 / diffTotal ))
+		UserDiff=$((UserStat - LastUserStat))
+		NiceDiff=$((NiceStat - LastNiceStat))
+		SystemDiff=$((SystemStat - LastSystemStat))
+		IOWaitDiff=$((IOWaitStat - LastIOWaitStat))
+		IrqDiff=$((IrqStat - LastIrqStat))
+		SoftIrqDiff=$((SoftIrqStat - LastSoftIrqStat))
+
+		diffIdle=$((IdleStat - LastIdleStat))
+		diffTotal=$((Total - LastTotal))
+		diffX=$((diffTotal - diffIdle))
+		CPULoad=$((diffX * 100 / diffTotal))
+		UserLoad=$((UserDiff * 100 / diffTotal))
+		SystemLoad=$((SystemDiff * 100 / diffTotal))
+		NiceLoad=$((NiceDiff * 100 / diffTotal))
+		IOWaitLoad=$((IOWaitDiff * 100 / diffTotal))
+		IrqCombined=$((IrqDiff + SoftIrqDiff))
+		IrqCombinedLoad=$((IrqCombined * 100 / diffTotal))
 
 		LastUserStat=${UserStat}
 		LastNiceStat=${NiceStat}
@@ -505,21 +522,21 @@ ProcessStats() {
 } # ProcessStats
 
 MonitorIO() {
-	LastPagesOut=$(awk '/pgpgout/ {print $2}' </proc/vmstat)
+	LastPagesOut=$(awk '/pgpgout/ {print $2}' < /proc/vmstat)
 	if grep -q "$1" /proc/diskstats; then
-		LastWrite=$(awk -v d="$1" '{if($3 == d) print $8}' </proc/diskstats)
+		LastWrite=$(awk -v d="$1" '{if($3 == d) print $8}' < /proc/diskstats)
 	else
 		echo "Bud argument: [$1]"
 		echo "Disks valid for monitoring: $(
 			awk '{if($8 != 0) printf "%s ", $3}' /proc/diskstats
-			)"
+		)"
 		exit 1
 	fi
 	LastTimeChecked=$(date "+%s")
-	while true ; do
-		CurrentWrite=$(awk -v d="$1" '{if($3 == d) print $8}' </proc/diskstats)
+	while true; do
+		CurrentWrite=$(awk -v d="$1" '{if($3 == d) print $8}' < /proc/diskstats)
 		if [ ${CurrentWrite} -gt ${LastWrite} ]; then
-			PagesOut=$(awk '/pgpgout/ {print $2}' </proc/vmstat)
+			PagesOut=$(awk '/pgpgout/ {print $2}' < /proc/vmstat)
 			TimeNow=$(date "+%s")
 			PagesWritten=$((CurrentWrite - LastWrite))
 			PageOuts=$((PagesOut - LastPagesOut))
@@ -538,15 +555,15 @@ CheckDisks() {
 	# the drive only lists one temperature value and patches hddtemp.db if necessary
 	# and also tries to get CRC and LCC S.M.A.R.T. attributes to provide the user
 	# with the necessary config file contents for /etc/armbianmonitor/disks.conf:
-	
-	ls /sys/block/sd* >/dev/null 2>&1 || exit 0
-	
-	for i in /sys/block/sd* ; do
+
+	ls /sys/block/sd* > /dev/null 2>&1 || exit 0
+
+	for i in /sys/block/sd*; do
 		DeviceNode=/dev/${i##*/}
 		# get GUID/UUID for disk and check whether a partition table is existent. If
 		# not GUID will always be random
-		gdisk -l ${DeviceNode} >"${MyTempDir}/gdisk.txt"
-		GUID=$(awk -F" " '/^Disk identifier/ {print $4}' <"${MyTempDir}/gdisk.txt")
+		gdisk -l ${DeviceNode} > "${MyTempDir}/gdisk.txt"
+		GUID=$(awk -F" " '/^Disk identifier/ {print $4}' < "${MyTempDir}/gdisk.txt")
 		CountOfUnavailablePartitionTables=$(grep ': not present' "${MyTempDir}/gdisk.txt" | wc -l)
 		if [ ${CountOfUnavailablePartitionTables} -eq 4 ]; then
 			echo -e "\nSkipping ${DeviceNode} due to missing partition table. Use parted to create one."
@@ -554,25 +571,25 @@ CheckDisks() {
 		else
 			printf "\nExamining %s with GUID %s" "$DeviceNode" "$GUID"
 		fi
-		
+
 		# get name hddtemp needs
-		HddtempName="$(hddtemp --debug ${DeviceNode} | awk -F": " '/^Model: / {print $2}' | \
+		HddtempName="$(hddtemp --debug ${DeviceNode} | awk -F": " '/^Model: / {print $2}' |
 			cut -c-40 | sed 's/^[ \t]*//;s/[ \t]*$//')"
 		# store smartctl output in temporary file
-		smartctl -q noserial -s on -a ${DeviceNode} >"${MyTempDir}/smartctl.txt" 2>&1
-		DeviceModel="$(awk -F": " '/^Device Model/ {print $2}' <"${MyTempDir}/smartctl.txt" | \
+		smartctl -q noserial -s on -a ${DeviceNode} > "${MyTempDir}/smartctl.txt" 2>&1
+		DeviceModel="$(awk -F": " '/^Device Model/ {print $2}' < "${MyTempDir}/smartctl.txt" |
 			sed 's/^[ \t]*//;s/[ \t]*$//')"
 		if [ "X${DeviceModel}" = "X" ]; then
 			# Reading S.M.A.R.T. failed, we try autodetect mode iterating through all
 			# known smartctl modes (-d auto|sat|usbcypress|usbjmicron|usbprolific|usbsunplus)
-			SMARTPrefix="$(CheckSMARTModes ${DeviceNode} 2>/dev/null)"
+			SMARTPrefix="$(CheckSMARTModes ${DeviceNode} 2> /dev/null)"
 			if [ "X${SMARTPrefix}" = "X" ]; then
 				# we can't query the disk. Time to give up
 				echo -e "\nUnable to query the disk through S.M.A.R.T.\nPlease investigate manually using smartctl\n"
 				break
 			fi
 		fi
-		
+
 		# user feedback
 		if [ "X${SMARTPrefix}" = "X" ]; then
 			echo -e " \n(accessible through S.M.A.R.T.)"
@@ -581,17 +598,17 @@ CheckDisks() {
 		fi
 
 		# check for CRC and LCC attributes
-		CRCAttribute=$(awk -F" " '/CRC_Error_Count/ {print $1}' <"${MyTempDir}/smartctl.txt")
+		CRCAttribute=$(awk -F" " '/CRC_Error_Count/ {print $1}' < "${MyTempDir}/smartctl.txt")
 		LCCAttribute=$(grep -i "load.cycle" "${MyTempDir}/smartctl.txt" | awk -F" " '{print $1}')
-		
+
 		# check whether /etc/hddtemp.db should be patched
 		grep -q "${HddtempName}" /etc/hddtemp.db
 		if [ $? -ne 0 ]; then
 			# No entry into hddtemp database, we've a look whether there's a 'temperature'
 			# attribute available (we take the 1st we find) and if that's the case we use this
-			DiskTemp=$(awk -F" " '/Temperature/ {print $1}' <"${MyTempDir}/smartctl.txt" | head -n1)
+			DiskTemp=$(awk -F" " '/Temperature/ {print $1}' < "${MyTempDir}/smartctl.txt" | head -n1)
 			if [[ ${DiskTemp} -gt 0 ]]; then
-				echo -e "\"${HddtempName}\" ${DiskTemp} C \"${DeviceModel}\"" >>/etc/hddtemp.db
+				echo -e "\"${HddtempName}\" ${DiskTemp} C \"${DeviceModel}\"" >> /etc/hddtemp.db
 				echo -e "\nAdded disk \"${DeviceModel}\"/\"${HddtempName}\" to /etc/hddtemp.db using S.M.A.R.T. attribute ${DiskTemp}\nbased on the following available thermal values:"
 				grep "Temperature" "${MyTempDir}/smartctl.txt"
 				# check hddtemp result
@@ -612,14 +629,14 @@ CheckDisks() {
 		else
 			HddtempStatus="will work"
 		fi
-		
+
 		# check for firmware updates
 		FirmwareUpdate="$(grep "^http" "${MyTempDir}/smartctl.txt")"
-		
+
 		# Check whether the disk (based on GUID) is already configured in our config file
 		# /etc/armbianmonitor/disks.conf or not
-		
-		grep -q "^${GUID}:" /etc/armbianmonitor/disks.conf >/dev/null 2>/dev/null
+
+		grep -q "^${GUID}:" /etc/armbianmonitor/disks.conf > /dev/null 2> /dev/null
 		case $? in
 			0)
 				# already listed, we provide just infos:
@@ -641,7 +658,7 @@ CheckDisks() {
 						echo -e "You have to figure out how to query the disk for its thermal sensor."
 						echo -e "Please check the output of \"hddtemp --debug ${DeviceNode}\" and smartctl\n"
 						;;
-				esac		
+				esac
 				;;
 		esac
 		if [ "X${FirmwareUpdate}" != "X" ]; then
@@ -653,14 +670,14 @@ CheckDisks() {
 CheckSMARTModes() {
 	# This function tries to access USB disks through S.M.A.R.T. and returns the necessary
 	# '-d' call as well as fills in ${MyTempDir}/smartctl.txt
-	
-	for i in auto sat usbcypress usbjmicron usbprolific usbsunplus ; do
+
+	for i in auto sat usbcypress usbjmicron usbprolific usbsunplus; do
 		# user feedback
 		# echo -n "." >/dev/tty
 		# query disk using the specific protocol
-		echo -n "" >"${MyTempDir}/smartctl.txt"
-		smartctl -q noserial -s on -d ${i} -a ${1} >"${MyTempDir}/smartctl.txt" 2>/dev/null
-		DeviceModel="$(awk -F": " '/^Device Model/ {print $2}' <"${MyTempDir}/smartctl.txt" | \
+		echo -n "" > "${MyTempDir}/smartctl.txt"
+		smartctl -q noserial -s on -d ${i} -a ${1} > "${MyTempDir}/smartctl.txt" 2> /dev/null
+		DeviceModel="$(awk -F": " '/^Device Model/ {print $2}' < "${MyTempDir}/smartctl.txt" |
 			sed 's/^[ \t]*//;s/[ \t]*$//')"
 		if [ "X${DeviceModel}" != "X" ]; then
 			echo ${i}
@@ -679,13 +696,19 @@ PreRequisits() {
 	export PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
 	unset LANG
 	DISTROCODE=$(lsb_release -s -c)
-	
+
 	# check whether gdisk/smartctl are available and up to date
 	echo -e "Check whether necessary software is available\c"
-	which gdisk >/dev/null 2>&1 || (echo -e " Installing gdisk\c" ; apt-get -f -qq -y install gdisk)
-	which smartctl >/dev/null 2>&1 || (echo -e " Installing smartmontools\c" ; apt-get -f -qq -y install smartmontools)
+	which gdisk > /dev/null 2>&1 || (
+		echo -e " Installing gdisk\c"
+		apt-get -f -qq -y install gdisk
+	)
+	which smartctl > /dev/null 2>&1 || (
+		echo -e " Installing smartmontools\c"
+		apt-get -f -qq -y install smartmontools
+	)
 	echo -e " [done]\nUpdating smartmontools' drivedb\c"
-	/usr/sbin/update-smart-drivedb >/dev/null 2>&1
+	/usr/sbin/update-smart-drivedb > /dev/null 2>&1
 	if [ $? -ne 0 -a "X${DISTROCODE}" = "Xwheezy" ]; then
 		sed -i "/^SRCEXPR/{s#=.*#='http://sourceforge.net/p/smartmontools/code/HEAD/tree/\$location/smartmontools/drivedb.h?format=raw'#}" /usr/sbin/update-smart-drivedb
 		/usr/sbin/update-smart-drivedb
@@ -699,11 +722,14 @@ CreateTempDir() {
 	MyTempDir=$(mktemp -d /tmp/${0##*/}.XXXXXX)
 	if [ ! -d "${MyTempDir}" ]; then
 		MyTempDir=/tmp/${0##*/}.$RANDOM.$RANDOM.$RANDOM.$$
-		(umask 066 && mkdir ${MyTempDir}) || (echo "Failed to create temp dir. Aborting" >&2 ; exit 1)
+		(umask 066 && mkdir ${MyTempDir}) || (
+			echo "Failed to create temp dir. Aborting" >&2
+			exit 1
+		)
 	fi
 	chmod 711 "${MyTempDir}"
 	trap "rm -rf \"${MyTempDir}\" ; exit 0" 0 1 2 3 15
-	for file in smartctl.txt gdisk.txt ; do
+	for file in smartctl.txt gdisk.txt; do
 		touch "${MyTempDir}/${file}"
 		chmod 644 "${MyTempDir}/${file}"
 	done
@@ -864,35 +890,50 @@ K7qd4dHdmNB1zKYXCTyt5+Ab5Aoi6bRlcE1YWjZZ6rq+HvP7ivxGbegre891Rv5bvLZG5DXGGo6R
 8L5rj54+Pn3GcV6j6jKtZIyDTKKhbWDAZbNkmxBwmUuNpVlnAiQQrJiJV9xGQfO7ILIInXUTlvDO
 YUX8hyj7viIJ8WWAZ0RLFnmPSB+A/gde4wMj+tFkVTFgssGl/LWNqgYNGjRo0KBBgwYNGjRo0KBB
 gwYNGjRo0KBBw1eEfwH4UoBHAKAAAA==" | base64 --decode | tar xzf -
-	which systemctl >/dev/null 2>&1
+	which systemctl > /dev/null 2>&1
 	case $? in
 		0)
 			# Jessie|Stretch|Xenial|Bionic
-			systemctl enable rpimonitor-helper >/dev/null 2>&1
-			systemctl start rpimonitor-helper >/dev/null 2>&1
-			systemctl restart rpimonitor >/dev/null 2>&1
+			systemctl enable rpimonitor-helper > /dev/null 2>&1
+			systemctl start rpimonitor-helper > /dev/null 2>&1
+			systemctl restart rpimonitor > /dev/null 2>&1
 			;;
 		*)
 			# Wheezy|Trusty
-			insserv rpimonitor-helper >/dev/null 2>&1 || update-rc.d rpimonitor-helper defaults 90 10 >/dev/null 2>&1
-			cd /tmp && nohup /usr/local/sbin/rpimonitor-helper.sh & >/dev/null 2>&1
-			/etc/init.d/rpimonitor stop >/dev/null 2>&1
-			/etc/init.d/rpimonitor start >/dev/null 2>&1
+			insserv rpimonitor-helper > /dev/null 2>&1 || update-rc.d rpimonitor-helper defaults 90 10 > /dev/null 2>&1
+			cd /tmp && nohup /usr/local/sbin/rpimonitor-helper.sh &
+			> /dev/null 2>&1
+			/etc/init.d/rpimonitor stop > /dev/null 2>&1
+			/etc/init.d/rpimonitor start > /dev/null 2>&1
 			;;
 	esac
 } # PatchRPiMonitor_for_sun8i
 
 CollectSupportInfo() {
-	[[ -s /var/log/armbian-hardware-monitor.log ]] && cat /var/log/armbian-hardware-monitor.log || zcat /var/log/armbian-hardware-monitor.log.1.gz 2>/dev/null
+	[[ -s /var/log/armbian-hardware-monitor.log ]] && cat /var/log/armbian-hardware-monitor.log || zcat /var/log/armbian-hardware-monitor.log.1.gz 2> /dev/null
 	[[ -f /boot/armbianEnv.txt ]] && LOGLEVEL=$(awk -F'=' '/^verbosity/ {print $2}' /boot/armbianEnv.txt)
 	LOGLEVEL=${LOGLEVEL:-1}
 	if [ ${LOGLEVEL} -gt 4 ]; then
 		VERBOSE='-v'
-		which lshw >/dev/null 2>&1 && (echo -e "\n### lshw:" ; lshw -quiet -sanitize -numeric)
+		which lshw > /dev/null 2>&1 && (
+			echo -e "\n### lshw:"
+			lshw -quiet -sanitize -numeric
+		)
 	fi
-	lsusb >/dev/null 2>&1 && (echo -e "\n### lsusb:\n" ; lsusb ${VERBOSE} 2>/dev/null ; echo "" ; lsusb -t 2>/dev/null)
-	lspci >/dev/null 2>&1 && (echo -e "\n### lspci:\n" ; lspci ${VERBOSE} 2>/dev/null)
-	nvme >/dev/null 2>&1 && (echo -e "\n### nvme:\n" ; nvme list 2>/dev/null)
+	lsusb > /dev/null 2>&1 && (
+		echo -e "\n### lsusb:\n"
+		lsusb ${VERBOSE} 2> /dev/null
+		echo ""
+		lsusb -t 2> /dev/null
+	)
+	lspci > /dev/null 2>&1 && (
+		echo -e "\n### lspci:\n"
+		lspci ${VERBOSE} 2> /dev/null
+	)
+	nvme > /dev/null 2>&1 && (
+		echo -e "\n### nvme:\n"
+		nvme list 2> /dev/null
+	)
 	[ -z $SUDO_USER ] || echo -e "\n### Group membership of $(groups $SUDO_USER)"
 	echo -en "\n### Userland"
 	[[ -f /etc/armbian-release ]] && echo -en " generated with Armbian Build Framework"
@@ -902,24 +943,27 @@ CollectSupportInfo() {
 	KernelVersion=$(awk -F" " '{print $3}' < /proc/version)
 	case ${KernelVersion} in
 		3.*)
-			[[ -e /boot/script.bin ]] && echo -e "\n### fex settings: $(ls -la /boot/script.bin)\n\n$(bin2fex /boot/script.bin 2>/dev/null)"
+			[[ -e /boot/script.bin ]] && echo -e "\n### fex settings: $(ls -la /boot/script.bin)\n\n$(bin2fex /boot/script.bin 2> /dev/null)"
 			;;
 	esac
 	echo -e "\n### Loaded modules:\n\n$(lsmod)"
 	[[ -f /var/log/nand-sata-install.log ]] && echo -e "\n### nand-sata-install.log:\n\n$(cat /var/log/nand-sata-install.log)"
 	echo -e "\n### Current system health:\n\n$("$0" -s | grep -E "^Time|^[0-9]")"
-	stress -t 3 -c $(grep -c processor /proc/cpuinfo) --backoff 250 >/dev/null 2>&1 &
+	stress -t 3 -c $(grep -c processor /proc/cpuinfo) --backoff 250 > /dev/null 2>&1 &
 	"$0" -s | grep "^[0-9]"
 	# Include name resolving information only if upload is not possible
-	fping ix.io 2>/dev/null | grep -q alive || \
-		[ -f /etc/resolv.conf ] && echo -e "\n### resolv.conf\n\n$(ls -la /etc/resolv.conf ; cat /etc/resolv.conf)" || \
+	fping ix.io 2> /dev/null | grep -q alive ||
+		[ -f /etc/resolv.conf ] && echo -e "\n### resolv.conf\n\n$(
+		ls -la /etc/resolv.conf
+		cat /etc/resolv.conf
+	)" ||
 		echo -e "\n### resolv.conf does not exist or readable"
-	echo -e "\n### Current sysinfo:\n\n$(iostat -p ALL | grep -v "^loop")\n\n$(vmstat -w)\n\n$(free -h)\n\n$(zramctl 2>/dev/null)\n\n$(uptime)\n\n$(dmesg | tail -n 250)"
+	echo -e "\n### Current sysinfo:\n\n$(iostat -p ALL | grep -v "^loop")\n\n$(vmstat -w)\n\n$(free -h)\n\n$(zramctl 2> /dev/null)\n\n$(uptime)\n\n$(dmesg | tail -n 250)"
 	echo -e "\n"
-	[[ "$(id -u)" -eq "0" ]] && for sysfsnode in /proc/sys/vm/* ; do sysctl $(echo ${sysfsnode} | sed 's|/proc/sys/vm/|vm.|'); done
+	[[ "$(id -u)" -eq "0" ]] && for sysfsnode in /proc/sys/vm/*; do sysctl $(echo ${sysfsnode} | sed 's|/proc/sys/vm/|vm.|'); done
 	echo -e "\n### interrupts:\n$(cat /proc/interrupts)"
-	ls /tmp/armbianmonitor_checks_* >/dev/null 2>&1 || return
-	for file in /tmp/armbianmonitor_checks_* ; do
+	ls /tmp/armbianmonitor_checks_* > /dev/null 2>&1 || return
+	for file in /tmp/armbianmonitor_checks_*; do
 		echo -e "\n### \c"
 		ls "${file}" | cut -f1 -d.
 		echo
@@ -932,7 +976,7 @@ CheckCard() {
 		echo "Checking disks is not permitted as root or through sudo. Exiting" >&2
 		exit 1
 	fi
-	
+
 	if [ ! -d "$1" ]; then
 		echo "\"$1\" does not exist or is no directory. Exiting" >&2
 		exit 1
@@ -940,27 +984,27 @@ CheckCard() {
 	TargetDir="$1"
 
 	# check requirements
-	which f3write >/dev/null 2>&1 || MissingTools=" f3"
-	which iozone >/dev/null 2>&1 || MissingTools="${MissingTools} iozone3"
+	which f3write > /dev/null 2>&1 || MissingTools=" f3"
+	which iozone > /dev/null 2>&1 || MissingTools="${MissingTools} iozone3"
 	if [ "X${MissingTools}" != "X" ]; then
 		echo "Some tools are missing, please do an \"sudo apt-get -f -y install${MissingTools}\" before and try again" >&2
 		exit 1
 	fi
-	
+
 	# check provided path
 	Device="$(GetDevice "$1")"
 	set ${Device}
 	DeviceName=$1
 	FileSystem=$2
 	echo "${DeviceName}" | grep -q "mmcblk0" || echo -e "\n${BOLD}WARNING:${NC} It seems you're not testing the SD card but instead ${DeviceName} (${FileSystem})\n"
-	
+
 	TestDir="$(mktemp -d "${TargetDir}/cardtest.XXXXXX" || exit 1)"
-	date "+%s" >"${TestDir}/.starttime" || exit 1
+	date "+%s" > "${TestDir}/.starttime" || exit 1
 	trap "rm -rf \"${TestDir}\" ; exit 0" 0 1 2 3 15
 	LogFile="$(mktemp /tmp/armbianmonitor_checks_${DeviceName##*/}_${FileSystem}.XXXXXX)"
-	
+
 	# start actual test, create a small file for some space reserve
-	fallocate -l 32M "${TestDir}/empty.32m" 2>/dev/null || dd if=/dev/zero of="${TestDir}/empty.32m" bs=1M count=32 status=noxfer >/dev/null 2>&1
+	fallocate -l 32M "${TestDir}/empty.32m" 2> /dev/null || dd if=/dev/zero of="${TestDir}/empty.32m" bs=1M count=32 status=noxfer > /dev/null 2>&1
 	ShowWarning=false
 	# Start writing
 	echo -e "Starting to fill ${DeviceName} with test patterns, please be patient this might take a very long time"
@@ -969,12 +1013,12 @@ CheckCard() {
 	rm "${TestDir}/empty.32m"
 	# Start verify
 	echo -e "\nNow verifying the written data:"
-	echo "" >>"${LogFile}"
+	echo "" >> "${LogFile}"
 	f3read "${TestDir}" | tee -a "${LogFile}"
 	touch "${TestDir}/.starttime" || ShowDeviceWarning
 	rm "${TestDir}/"*.h2w
 	echo -e "\nStarting iozone tests. Be patient, this can take a very long time to complete:"
-	echo "" >>"${LogFile}"
+	echo "" >> "${LogFile}"
 	cd "${TestDir}"
 	iozone -e -I -a -s 100M -r 4k -r 512k -r 16M -i 0 -i 1 -i 2 | tee -a "${LogFile}"
 	touch "${TestDir}/.starttime" || ShowDeviceWarning
@@ -982,23 +1026,28 @@ CheckCard() {
 	grep -E "Average|Data" "${LogFile}" | sort -r
 	echo "                                            random    random"
 	echo -e "reclen    write  rewrite    read    reread    read     write\c"
-	awk -F"102400  " '/102400/ {print $2}' <"${LogFile}"
+	awk -F"102400  " '/102400/ {print $2}' < "${LogFile}"
 
 	# check health
 	echo -e "\n${BOLD}Health summary: \c"
-	grep -Eq "Read-only|Input/output error" "${LogFile}" && (echo -e "${LRED}${BOLD}${DeviceName} failed${NC}" ; exit 0)
-	grep -q "Data LOST: 0.00 Byte" "${LogFile}" && echo -e "${LGREEN}OK" || \
-		(echo -e "${LRED}${BOLD}${DeviceName} failed. Replace it as soon as possible!" ; \
-		grep -A3 "^Data LOST" "${LogFile}")
+	grep -Eq "Read-only|Input/output error" "${LogFile}" && (
+		echo -e "${LRED}${BOLD}${DeviceName} failed${NC}"
+		exit 0
+	)
+	grep -q "Data LOST: 0.00 Byte" "${LogFile}" && echo -e "${LGREEN}OK" ||
+		(
+			echo -e "${LRED}${BOLD}${DeviceName} failed. Replace it as soon as possible!"
+			grep -A3 "^Data LOST" "${LogFile}"
+		)
 
 	# check performance
-	RandomSpeed=$(awk -F" " '/102400       4/ {print $7"\t"$8}' <"${LogFile}")
+	RandomSpeed=$(awk -F" " '/102400       4/ {print $7"\t"$8}' < "${LogFile}")
 	if [ "X${RandomSpeed}" != "X" ]; then
 		# Only continue when we're able to read out iozone results
 		set ${RandomSpeed}
 		RandomReadSpead=$1
 		RandomWriteSpead=$2
-		ReadSpeed=$(awk -F" " '/Average reading speed/ {print $4"\t"$5}' <"${LogFile}")
+		ReadSpeed=$(awk -F" " '/Average reading speed/ {print $4"\t"$5}' < "${LogFile}")
 		set ${ReadSpeed}
 		if [ "X$2" = "XMB/s" ]; then
 			RawReadSpead=$(echo "$1 * 1000" | bc -s | cut -f1 -d.)
@@ -1015,7 +1064,7 @@ CheckCard() {
 		[ ${RandomReadSpead} -le 1400 ] && Exclamation="${Exclamation}${BOLD}too "
 		[ ${RandomReadSpead} -le 2500 ] && echo -e "(${Exclamation}low${NC})\c"
 		echo "${Exclamation}" | grep -q "too" && ShowWarning=true
-		WriteSpeed=$(awk -F" " '/Average writing speed/ {print $4"\t"$5}' <"${LogFile}")
+		WriteSpeed=$(awk -F" " '/Average writing speed/ {print $4"\t"$5}' < "${LogFile}")
 		set ${WriteSpeed}
 		if [ "X$2" = "XMB/s" ]; then
 			RawWriteSpeed=$(echo "$1 * 1000" | bc -s | cut -f1 -d.)
@@ -1055,7 +1104,8 @@ GetDevice() {
 	if TestPath=$(findmnt --noheadings --output SOURCE,FSTYPE --target "$1" --uniq); then
 		echo "${TestPath}"
 	else
-		echo "Bud Path: $1" >&2; exit 1
+		echo "Bud Path: $1" >&2
+		exit 1
 	fi
 } # GetDevice
 
@@ -1065,7 +1115,7 @@ VerifyInstallation() {
 		echo "This check must be run as root. Aborting." >&2
 		exit 1
 	fi
-	
+
 	echo -e "Starting package integrity check. This might take some time. Be patient please..."
 	OUTPUT=$(dpkg --verify | grep -Evi "${VerifyRepairExcludes}" | awk -F" /" '{print "/"$2}')
 	if [[ -z $OUTPUT ]]; then
@@ -1083,7 +1133,7 @@ NetworkMonitorMode() {
 
 	# Allow armbianmonitor to return back to armbian-config
 	trap "echo ; exit 0" 0 1 2 3 15
-	
+
 	# Count interfaces - multiple routes causing interfaces to show up more than once, filtering...
 	ifacecount=$(route -n | grep -E UG | grep -Eo '[^ ]*$' | sort | uniq)
 	# If there are two ore more interfaces detected open a dynamic dialog box to select which to monitor
@@ -1091,19 +1141,19 @@ NetworkMonitorMode() {
 		ifacemenu=$(route -n | grep -E UG | grep -Eo '[^ ]*$' | sort | uniq | awk '{a[$1]=$1}END{for(i in a)printf i" "a[i]" "}')
 		ifacefunc() {
 			dialog --backtitle "Interface selector" \
-			--title "Multiple network interfaces detected" \
-			--menu "Choose which interface to monitor:" \
-			15 50 $(route -n | grep -E UG | grep -Eo '[^ ]*$' | sort | uniq | wc -l) \
-			$(echo $ifacemenu) 2>&1 >$(tty)
+				--title "Multiple network interfaces detected" \
+				--menu "Choose which interface to monitor:" \
+				15 50 $(route -n | grep -E UG | grep -Eo '[^ ]*$' | sort | uniq | wc -l) \
+				$(echo $ifacemenu) 2>&1 > $(tty)
 		}
 		iface=$(ifacefunc)
 	else
-	# Use default behavior if one interface is found only
+		# Use default behavior if one interface is found only
 		iface=$(route -n | grep -E UG | grep -Eo '[^ ]*$')
 	fi
 	timerStart
 	kickAllStatsDown
-	
+
 	printf "\nruntime network statistics: %s\m" "$(uname -n)"
 	printf "network interface: %s\n" "$iface"
 	printf "[tap 'd' to display column headings]\n"
@@ -1112,39 +1162,39 @@ NetworkMonitorMode() {
 	printf "[bps: bits/s, Mbps: megabits/s, pps: packets/s, MB: megabytes]\n\n"
 	printf "%-11s %-66s          %-66s\n" "$iface" "rx.stats____________________________________________________________" "tx.stats____________________________________________________________"
 	printf "%-11s %-11s %-11s \u01B0.%-11s %-11s \u01B0.%-11s \u01A9.%-11s %-11s %-11s \u01B0.%-11s %-11s \u01B0.%-11s \u01A9.%-11s\n\n" "count" "bps" "Mbps" "Mbps" "pps" "pps" "MB" "bps" "Mbps" "Mbps" "pps" "pps" "MB"
-	
+
 	while true; do
-		nss=(`sed -n 's/'$iface':\s//p' /proc/net/dev`)
+		nss=($(sed -n 's/'$iface':\s//p' /proc/net/dev))
 		rxB=${nss[0]}
 		rxP=${nss[1]}
 		txB=${nss[8]}
 		txP=${nss[9]}
-		drxB=$(( rxB - prxB ))
-		drxb=$(( drxB* 8 ))
-		drxmb=$(echo "scale=2;$drxb/1000000"|bc)
-		drxP=$(( rxP - prxP  ))
-		dtxB=$(( txB - ptxB ))
-		dtxb=$(( dtxB * 8 ))
-		dtxmb=$(echo "scale=2;$dtxb/1000000"|bc)
-		dtxP=$(( txP - ptxP ))
+		drxB=$((rxB - prxB))
+		drxb=$((drxB * 8))
+		drxmb=$(echo "scale=2;$drxb/1000000" | bc)
+		drxP=$((rxP - prxP))
+		dtxB=$((txB - ptxB))
+		dtxb=$((dtxB * 8))
+		dtxmb=$(echo "scale=2;$dtxb/1000000" | bc)
+		dtxP=$((txP - ptxP))
 		if [ "$cnt" != "0" ]; then
 			if [ "$c" == "N" ]; then
 				printf "\x1b[1A"
 			fi
-			srxb=$(( srxb + drxb ))
-			stxb=$(( stxb + dtxb ))
-			srxB=$(( srxB + drxB ))
-			stxB=$(( stxB + dtxB ))
-			srxP=$(( srxP + drxP ))
-			stxP=$(( stxP + dtxP ))
-			srxMB=$(echo "scale=2;$srxB/1024^2"|bc)
-			stxMB=$(echo "scale=2;$stxB/1024^2"|bc)
-			arxb=$(echo "scale=2;$srxb/$cnt"|bc)
-			atxb=$(echo "scale=2;$stxb/$cnt"|bc)
-			arxmb=$(echo "scale=2;$arxb/1000000"|bc)
-			atxmb=$(echo "scale=2;$atxb/1000000"|bc)
-			arxP=$(echo "scale=0;$srxP/$cnt"|bc)
-			atxP=$(echo "scale=0;$stxP/$cnt"|bc)
+			srxb=$((srxb + drxb))
+			stxb=$((stxb + dtxb))
+			srxB=$((srxB + drxB))
+			stxB=$((stxB + dtxB))
+			srxP=$((srxP + drxP))
+			stxP=$((stxP + dtxP))
+			srxMB=$(echo "scale=2;$srxB/1024^2" | bc)
+			stxMB=$(echo "scale=2;$stxB/1024^2" | bc)
+			arxb=$(echo "scale=2;$srxb/$cnt" | bc)
+			atxb=$(echo "scale=2;$stxb/$cnt" | bc)
+			arxmb=$(echo "scale=2;$arxb/1000000" | bc)
+			atxmb=$(echo "scale=2;$atxb/1000000" | bc)
+			arxP=$(echo "scale=0;$srxP/$cnt" | bc)
+			atxP=$(echo "scale=0;$stxP/$cnt" | bc)
 			printf "%-11s %-11s %-11s   %-11s %-11s   %-11s   %-11s %-11s %-11s   %-11s %-11s   %-11s   %-11s\n" "$cnt" "$drxb" "$drxmb" "$arxmb" "$drxP" "$arxP" "$srxMB" "$dtxb" "$dtxmb" "$atxmb" "$dtxP" "$atxP" "$stxMB"
 		fi
 		prxB="$rxB"
@@ -1174,8 +1224,8 @@ timerStart() {
 }
 timerShut() {
 	read -r sh0 sh1 < <(date +'%s %N')
-	jusquaQuand=$(echo "scale=2;($sh0-$st0)*1000000000+($sh1-$st1)"|bc)
-	procSecs=$(echo "scale=2;(1000000000-$jusquaQuand)/1000000000"|bc)
+	jusquaQuand=$(echo "scale=2;($sh0-$st0)*1000000000+($sh1-$st1)" | bc)
+	procSecs=$(echo "scale=2;(1000000000-$jusquaQuand)/1000000000" | bc)
 	if [ "$rf1" == "debug" ]; then
 		printf "time controller adjustment: %d\n" "$procSecs"
 		if [ "$c" == "N" ]; then
@@ -1204,23 +1254,26 @@ Run7ZipBenchmark() {
 	# Do a quick 7-zip benchmark, check whether binary is there. If not install it
 	MyTool=$(which 7za || which 7zr)
 	[ -z "${MyTool}" ] && apt-get -f -qq -y install p7zip && MyTool=/usr/bin/7zr
-	[ -z "${MyTool}" ] && (echo "No 7-zip binary found and could not be installed. Aborting" >&2 ; exit 1)
+	[ -z "${MyTool}" ] && (
+		echo "No 7-zip binary found and could not be installed. Aborting" >&2
+		exit 1
+	)
 	# Send CLI monitoring to the background to be able to spot throttling and other problems
 	MonitoringOutput="$(mktemp /tmp/${0##*/}.XXXXXX)"
 	trap "rm \"${MonitoringOutput}\" ; exit 0" 0 1 2 3 15
-	armbianmonitor -m >${MonitoringOutput} &
+	armbianmonitor -m > ${MonitoringOutput} &
 	MonitoringPID=$!
 	# run 7-zip benchmarks after waiting 10 seconds to spot whether the system was idle before.
 	# We run the benchmark a single time by default unless otherwise specified on the command line
 	RunHowManyTimes=${runs:-1}
 	sleep 10
-	for ((i=1;i<=RunHowManyTimes;i++)); do
+	for ((i = 1; i <= RunHowManyTimes; i++)); do
 		"${MyTool}" b
 	done
 	# report CLI monitoring results as well
 	kill ${MonitoringPID}
 	echo -e "\nMonitoring output recorded while running the benchmark:\n"
-	sed -e '/^\s*$/d' -e '/^Stop/d' <${MonitoringOutput}
+	sed -e '/^\s*$/d' -e '/^Stop/d' < ${MonitoringOutput}
 	echo -e "\n"
 } # Run7ZipBenchmark
 

--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -81,6 +81,13 @@
 #
 ############################################################################
 
+# Config:
+declare -a paste_servers=("paste.armbian.com" "paste.next.armbian.com")
+if [[ "${PASTE_SERVER_HOST}" != "" ]]; then
+	echo "Using custom paste server: '${PASTE_SERVER_HOST}'"
+	paste_servers=("${PASTE_SERVER_HOST}" "${paste_servers[@]}")
+fi
+
 Main() {
 	export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
@@ -151,36 +158,40 @@ ParseOptions() {
 				;;
 			u)
 				# Upload /var/log/armbian-hardware-monitor.log with additional support info
-				which curl > /dev/null 2>&1 || apt-get -f -qq -y install curl
-				echo -e "System diagnosis information will now be uploaded to \c"
-				fping paste.armbian.com 2> /dev/null | grep -q alive
-				if [ $? != 0 ]; then
-					echo -e "\nNetwork/firewall problem detected.\nTrying fallback..." >&2
-					fping ix.io 2> /dev/null | grep -q alive
-					if [ $? != 0 ]; then
-						echo -e "\nNetwork/firewall problem detected. Not able to upload debug info.\nPlease fix this or use \"-U\" instead and upload ${BOLD}whole output${NC} manually to an online pasteboard service\nand provide the URL in the forum where you have been asked for this.\n"
-						exit 1
-					fi
-
-					# we obfuscate IPv4 addresses somehow but not too much, MAC addresses have to remain
-					# in clear since otherwise the log becomes worthless due to randomly generated
-					# addresses here and there that might conflict
-					CollectSupportInfo |
+				# NOTE(rpardini): was here. briefly. just because this uses the paste server and I want ANSI dmesgs
+				# check if curl binary is available in path, if not try to install it. use command, not which
+				if ! command -v curl > /dev/null 2>&1; then
+					echo "curl not found in PATH. Trying to install it." >&2
+					apt-get -f -y install curl
+				fi
+				# loop over the paste_servers; first to work wins.
+				for paste_server in "${paste_servers[@]}"; do # defined at top of file
+					echo "Collecting info and sending to ${paste_server}, wait..."
+					declare -i counter=0
+					{
+						LC_ALL=C date # include timestamp
+						echo "-----------------------------------------------------------------------------------------------------------------------------"
+						dmesg --color=always # output in ANSI color. The paste service handles this.
+						echo "-----------------------------------------------------------------------------------------------------------------------------"
+						CollectSupportInfo || echo "Error collecting support info via CollectSupportInfo"
+					} |
+						# we obfuscate IPv4 addresses somehow but not too much, MAC addresses have to remain
+						# in clear since otherwise the log becomes worthless due to randomly generated
+						# addresses here and there that might conflict
 						sed -E 's/([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3})/XXX.XXX.\3\4/g' |
-						curl -F 'f:1=<-' ix.io
+						curl -s --data-binary @- "https://${paste_server}/log"
+					# Check PIPESTATUS to know if everything worked. Any non-zero exit status means something didn't work.
+					for i in "${PIPESTATUS[@]}"; do
+						counter=$((counter + 1))
+						if [[ $i -ne 0 ]]; then
+							echo "Failed grabbing info (pipe ${counter} result ${i}) and sending to server ${paste_server}."
+							continue 2 # continue the outer loop (paste_servers)
+						fi
+					done
 					echo -e "Please post the URL in the forum where you've been asked for.\n"
 					exit 0
-				fi
+				done
 
-				# we obfuscate IPv4 addresses somehow but not too much, MAC addresses have to remain
-				# in clear since otherwise the log becomes worthless due to randomly generated
-				# addresses here and there that might conflict
-				CollectSupportInfo |
-					sed -E 's/([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3}\.)([0-9]{1,3})/XXX.XXX.\3\4/g' |
-					curl -s --data-binary @- "https://paste.armbian.com/documents" |
-					awk -F'"' '{ print "https://paste.armbian.com/" $4 }'
-				echo -e "Please post the URL in the forum where you've been asked for.\n"
-				exit 0
 				;;
 
 			U)

--- a/packages/bsp/common/usr/bin/armbianmonitor
+++ b/packages/bsp/common/usr/bin/armbianmonitor
@@ -124,7 +124,7 @@ Main() {
 } # Main
 
 ParseOptions() {
-	while getopts 'hHbBuUrRmMsnNd:Dc:C:pPvz' c; do
+	while getopts 'hHuUrRmMsnNd:Dc:C:pPvz' c; do
 		case ${c} in
 			H)
 				# display full help test
@@ -300,6 +300,10 @@ ParseOptions() {
 				runs=$2
 				Run7ZipBenchmark 2> /dev/null
 				exit 0
+				;;
+			*)
+				echo "Invalid flag: ${c}" >&2
+				exit 7
 				;;
 		esac
 	done


### PR DESCRIPTION
#### armbianmonitor `-u`: rationalize paste server retrying, use ANSI dmesg

- armbianmonitor: shellfmt, no changes
- armbianmonitor: squash shellcheck warnings around the main getopts case statement
  - `b` and `B` were never parsed
  - an `*` case is added to handle invalid options
- armbianmonitor `-u`: rationalize paste server retrying, use ANSI dmesg
  - use PIPESTATUS to check all steps for failure
  - avoid blaming paste server if data collection failed