### PR TITLE
odroidm1/orangepi3b: use default (newer) blobs; rewrite patches; bump -rc u-boot to final

### DIFF
--- a/config/boards/odroidm1.conf
+++ b/config/boards/odroidm1.conf
@@ -11,15 +11,11 @@ IMAGE_PARTITION_TABLE="gpt"
 FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
 
-BOOTBRANCH_BOARD="tag:v2024.04-rc3"
+BOOTBRANCH_BOARD="tag:v2024.04"
 BOOTPATCHDIR="v2024.04"
 
 BOOTCONFIG="odroid-m1-rk3568_defconfig"
 BOOTDIR="u-boot-${BOARD}" # do not share u-boot directory
-
-# Newer blobs...
-DDR_BLOB="rk35/rk3568_ddr_1560MHz_v1.18.bin"
-BL31_BLOB="rk35/rk3568_bl31_v1.43.elf"
 
 # The overlays for this board are prefixed by 'rockchip-rk3568-hk' (see for example patch/kernel/archive/rockchip64-6.x/overlay/rockchip-rk3328-i2c0.dts)
 OVERLAY_PREFIX="rockchip-rk3568-hk"
@@ -82,7 +78,7 @@ function post_family_tweaks__config_odroidm1_fwenv() {
 	display_alert "Creating network rename rule for Odroid M1"
 	mkdir -p "${SDCARD}"/etc/udev/rules.d/
 	cat <<- EOF > "${SDCARD}"/etc/udev/rules.d/70-rename-lan.rules
-	SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", KERNEL=="end*", NAME="eth0"
+		SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", KERNEL=="end*", NAME="eth0"
 	EOF
 
 }

--- a/config/boards/orangepi3b.csc
+++ b/config/boards/orangepi3b.csc
@@ -15,10 +15,6 @@ BOOT_SPI_RKSPI_LOADER="yes"
 MODULES="sprdbt_tty sprdwl_ng"
 MODULES_BLACKLIST_LEGACY="bcmdhd"
 
-# Newer blobs. Tested to work with opi3b
-DDR_BLOB="rk35/rk3566_ddr_1056MHz_v1.18.bin"
-BL31_BLOB="rk35/rk3568_bl31_v1.43.elf"         # NOT a typo, bl31 is shared across 68 and 66
-
 # Override family config for this board; let's avoid conditionals in family config.
 function post_family_config__orangepi3b_use_mainline_uboot() {
 	display_alert "$BOARD" "mainline (Kwiboo's tree) u-boot overrides" "info"

--- a/patch/u-boot/v2024.04/board_odroidm1/0001-rockchip-common-boot-USB-devices-first-then-mmc-s-nvme-scsi.patch
+++ b/patch/u-boot/v2024.04/board_odroidm1/0001-rockchip-common-boot-USB-devices-first-then-mmc-s-nvme-scsi.patch
@@ -8,7 +8,7 @@ Subject: rockchip-common: boot USB devices first, then mmc's, nvme, scsi
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/include/configs/rockchip-common.h b/include/configs/rockchip-common.h
-index 9121bba37384..1204113f63e0 100644
+index 111111111111..222222222222 100644
 --- a/include/configs/rockchip-common.h
 +++ b/include/configs/rockchip-common.h
 @@ -13,7 +13,7 @@

--- a/patch/u-boot/v2024.04/board_odroidm1/0002-board-rockchip-ODROID-M1-override-kernel-DT-for-xhci-otg-dr_mode.patch
+++ b/patch/u-boot/v2024.04/board_odroidm1/0002-board-rockchip-ODROID-M1-override-kernel-DT-for-xhci-otg-dr_mode.patch
@@ -8,7 +8,7 @@ Subject: board: rockchip: ODROID-M1: override kernel DT for xhci otg dr_mode
  1 file changed, 4 insertions(+)
 
 diff --git a/arch/arm/dts/rk3568-odroid-m1-u-boot.dtsi b/arch/arm/dts/rk3568-odroid-m1-u-boot.dtsi
-index 1fc71faa9e07..8c24e81d500f 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/dts/rk3568-odroid-m1-u-boot.dtsi
 +++ b/arch/arm/dts/rk3568-odroid-m1-u-boot.dtsi
 @@ -22,3 +22,7 @@

--- a/patch/u-boot/v2024.04/board_odroidm1/0003-board-rockchip-ODROID-M1-enable-DM_USB_GADGET-UMS-RockUSB.patch
+++ b/patch/u-boot/v2024.04/board_odroidm1/0003-board-rockchip-ODROID-M1-enable-DM_USB_GADGET-UMS-RockUSB.patch
@@ -8,7 +8,7 @@ Subject: board: rockchip: ODROID-M1: enable DM_USB_GADGET & UMS & RockUSB
  1 file changed, 7 insertions(+)
 
 diff --git a/configs/odroid-m1-rk3568_defconfig b/configs/odroid-m1-rk3568_defconfig
-index 3130e341e776..5ae65de2b31e 100644
+index 111111111111..222222222222 100644
 --- a/configs/odroid-m1-rk3568_defconfig
 +++ b/configs/odroid-m1-rk3568_defconfig
 @@ -52,6 +52,8 @@ CONFIG_CMD_MMC=y

--- a/patch/u-boot/v2024.04/board_odroidm1/0004-board-rockchip-ODROID-M1-use-env-in-SPI-use-HK-s-offset-size-for-SPI-env-enable-LED_GPIO-use-preboot-to-blink-all-leds-leave-red-one-on-clear-env-once.patch
+++ b/patch/u-boot/v2024.04/board_odroidm1/0004-board-rockchip-ODROID-M1-use-env-in-SPI-use-HK-s-offset-size-for-SPI-env-enable-LED_GPIO-use-preboot-to-blink-all-leds-leave-red-one-on-clear-env-once.patch
@@ -10,7 +10,7 @@ Subject: board: rockchip: ODROID-M1: use env in SPI; use HK's offset/size for
  1 file changed, 8 insertions(+)
 
 diff --git a/configs/odroid-m1-rk3568_defconfig b/configs/odroid-m1-rk3568_defconfig
-index 5ae65de2b31e..ec95588b2664 100644
+index 111111111111..222222222222 100644
 --- a/configs/odroid-m1-rk3568_defconfig
 +++ b/configs/odroid-m1-rk3568_defconfig
 @@ -10,6 +10,8 @@ CONFIG_HAS_CUSTOM_SYS_INIT_SP_ADDR=y

--- a/patch/u-boot/v2024.04/general-btrfs-fix-out-of-bounds-write.patch
+++ b/patch/u-boot/v2024.04/general-btrfs-fix-out-of-bounds-write.patch
@@ -1,6 +1,6 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Alex Shumsky <alexthreed@gmail.com>
-Date: Mon, 14 Jun 2024 19:01:48 +0000
+Date: Fri, 14 Jun 2024 19:01:48 +0000
 Subject: fs/btrfs: fix out of bounds write
 
 Signed-off-by: Alex Shumsky <alexthreed@gmail.com>
@@ -9,12 +9,10 @@ Signed-off-by: Alex Shumsky <alexthreed@gmail.com>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/fs/btrfs/inode.c b/fs/btrfs/inode.c
-index 4691612eda..b51f578b49 100644
+index 111111111111..222222222222 100644
 --- a/fs/btrfs/inode.c
 +++ b/fs/btrfs/inode.c
-@@ -638,11 +638,11 @@ static int read_and_truncate_page(struct btrfs_path *path,
- 		return -ENOMEM;
- 
+@@ -640,7 +640,7 @@ static int read_and_truncate_page(struct btrfs_path *path,
  	extent_type = btrfs_file_extent_type(leaf, fi);
  	if (extent_type == BTRFS_FILE_EXTENT_INLINE) {
  		ret = btrfs_read_extent_inline(path, fi, buf);
@@ -23,11 +21,7 @@ index 4691612eda..b51f578b49 100644
  		free(buf);
  		return len;
  	}
- 
- 	ret = btrfs_read_extent_reg(path, fi,
-@@ -650,11 +650,11 @@ static int read_and_truncate_page(struct btrfs_path *path,
- 			fs_info->sectorsize, buf);
- 	if (ret < 0) {
+@@ -652,7 +652,7 @@ static int read_and_truncate_page(struct btrfs_path *path,
  		free(buf);
  		return ret;
  	}
@@ -36,8 +30,6 @@ index 4691612eda..b51f578b49 100644
  	free(buf);
  	return len;
  }
- 
- int btrfs_file_read(struct btrfs_root *root, u64 ino, u64 file_offset, u64 len,
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+Armbian
 


### PR DESCRIPTION
#### odroidm1/orangepi3b: use default (newer) blobs; rewrite patches; bump -rc u-boot to final

- patch/u-boot/v2024.04: rewrite patches, no changes
- odroidm1: remove custom blobs, use defaults; bump u-boot 2024.04-rc3 to 2024.04 final
- orangepi3b: remove custom blobs, use defaults
- odroidm1: u-boot: rewrite patches, no changes