### PR TITLE
bsp-cli/bsp-desktop: hashing fixes

### DIFF
--- a/lib/functions/artifacts/artifact-armbian-bsp-cli.sh
+++ b/lib/functions/artifacts/artifact-armbian-bsp-cli.sh
@@ -70,7 +70,6 @@ function artifact_armbian-bsp-cli_prepare_version() {
 
 	declare -a dirs_to_hash=(
 		"${SRC}/packages/bsp/common" # common stuff
-		"${SRC}/packages/bsp-cli"
 		"${SRC}/config/optional/_any_board/_packages/bsp-cli"
 		"${SRC}/config/optional/architectures/${ARCH}/_packages/bsp-cli"
 		"${SRC}/config/optional/families/${LINUXFAMILY}/_packages/bsp-cli"
@@ -83,7 +82,7 @@ function artifact_armbian-bsp-cli_prepare_version() {
 
 	# get the hashes of the lib/ bash sources involved...
 	declare hash_files="undetermined"
-	calculate_hash_for_bash_deb_artifact "bsp/armbian-bsp-cli-deb.sh"
+	calculate_hash_for_bash_deb_artifact "bsp/armbian-bsp-cli-deb.sh" "bsp/utils-bsp.sh"
 	declare bash_hash="${hash_files}"
 	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
 

--- a/lib/functions/artifacts/artifact-armbian-bsp-desktop.sh
+++ b/lib/functions/artifacts/artifact-armbian-bsp-desktop.sh
@@ -37,7 +37,7 @@ function artifact_armbian-bsp-desktop_prepare_version() {
 
 	# get the hashes of the lib/ bash sources involved...
 	declare hash_files="undetermined"
-	calculate_hash_for_bash_deb_artifact "bsp/armbian-bsp-desktop-deb.sh"
+	calculate_hash_for_bash_deb_artifact "bsp/armbian-bsp-desktop-deb.sh" "bsp/utils-bsp.sh"
 	declare bash_hash="${hash_files}"
 	declare bash_hash_short="${bash_hash:0:${short_hash_size}}"
 

--- a/lib/functions/bsp/armbian-bsp-cli-deb.sh
+++ b/lib/functions/bsp/armbian-bsp-cli-deb.sh
@@ -119,7 +119,9 @@ function compile_armbian-bsp-cli() {
 
 	# copy common files from a premade directory structure
 	# @TODO this includes systemd config, assumes things about serial console, etc, that need dynamism or just to not exist with modern systemd
-	run_host_command_logged rsync -a "${SRC}"/packages/bsp/common/* "${destination}"
+	display_alert "Copying common bsp files" "packages/bsp/common" "info"
+	run_host_command_logged rsync -av "${SRC}"/packages/bsp/common/* "${destination}"
+	wait_for_disk_sync "after rsync'ing package/bsp/common for bsp-cli"
 
 	mkdir -p "${destination}"/usr/share/armbian/
 
@@ -242,7 +244,7 @@ function reversion_armbian-bsp-cli_deb_contents() {
 		depends_base_files=""
 	fi
 	cat <<- EOF >> "${control_file_new}"
-		Depends: bash, linux-base, u-boot-tools, initramfs-tools, lsb-release, fping${depends_base_files}, device-tree-compiler
+		Depends: bash, linux-base, u-boot-tools, initramfs-tools, lsb-release, fping, device-tree-compiler${depends_base_files}
 		Replaces: zram-config, armbian-bsp-cli-${BOARD}${EXTRA_BSP_NAME} (<< ${REVISION})
 		Breaks: armbian-bsp-cli-${BOARD}${EXTRA_BSP_NAME} (<< ${REVISION})
 	EOF

--- a/lib/functions/bsp/utils-bsp.sh
+++ b/lib/functions/bsp/utils-bsp.sh
@@ -25,10 +25,11 @@ copy_all_packages_files_for() {
 	for package_src_dir in ${PACKAGES_SEARCH_ROOT_ABSOLUTE_DIRS}; do
 		local package_dirpath="${package_src_dir}/${package_name}"
 		if [ -d "${package_dirpath}" ]; then
-			display_alert "Adding found files" "${package_dirpath} for '${package_name}'" "debug"
-			run_host_command_logged cp -r "${package_dirpath}/"* "${destination}/"
+			display_alert "Adding found files" "${package_dirpath} for '${package_name}'" "info"
+			run_host_command_logged cp -rv "${package_dirpath}/"* "${destination}/"
 		else
 			display_alert "No files found in" "${package_dirpath} for '${package_name}'" "debug"
 		fi
+		wait_for_disk_sync "after copying ${package_src_dir} files for ${package_name} package"
 	done
 }


### PR DESCRIPTION
#### bsp-cli/bsp-desktop: hashing fixes

- bsp-cli/bsp-desktop: hashing fixes
  - both artifacts use functions in the bsp/utils-bsp.sh file, which wasn't being hashed
  - bsp-cli hashed non-existent 'packages/bsp-cli' directory, remove
  - bsp-cli: be verbose when rsync'ing `packages/bsp/common`
  - force sync in a few strategic spots
  - utils-bsp.sh: be verbose when copying files (incl `config/optional` stuff)