### PR TITLE
rockchip: fix rk322x-box uboot boot order

### DIFF
--- a/patch/u-boot/v2024.01/board_rk322x-box/rk322x-box-add-device-tree-makefile.patch
+++ b/patch/u-boot/v2024.01/board_rk322x-box/rk322x-box-add-device-tree-makefile.patch
@@ -233,7 +233,7 @@ index 0000000000..994685dba3
 +#undef BOOT_TARGETS
 +#undef CFG_EXTRA_ENV_SETTINGS
 +
-+#define BOOT_TARGETS	"mmc1 usb mmc0 pxe dhcp"
++#define BOOT_TARGETS	"mmc0 usb mmc1 pxe dhcp"
 +
 +#define CFG_EXTRA_ENV_SETTINGS \
 +	"fdtfile=" CONFIG_DEFAULT_FDT_FILE "\0" \


### PR DESCRIPTION
# Description

Minimal fix for rk322x-box devices to restore the correct sdcard -> usb -> emmc boot order

# How Has This Been Tested?

- [x] Tested boot from sdcard and usb stick when armbian is installed in emmc

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
