### PR TITLE
u-boot: add HOME env for make invocations to avoid binman/Python problems with older u-boot versions

### DIFF
--- a/lib/functions/compilation/uboot.sh
+++ b/lib/functions/compilation/uboot.sh
@@ -214,6 +214,7 @@ function compile_uboot_target() {
 		"CCACHE_BASEDIR=$(pwd)"
 		"PATH=${toolchain}:${toolchain2}:${PATH}"
 		"PYTHONPATH=\"${PYTHON3_INFO[MODULES_PATH]}:${PYTHONPATH}\"" # Insert the pip modules downloaded by Armbian into PYTHONPATH (needed e.g. for pyelftools)
+		"HOME=${WORKDIR}"                                            # give it a temporary-dir HOME; some Python stuff in old u-boots wants HOME env to be set
 	)
 
 	# workaround when two compilers are needed

--- a/patch/u-boot/v2022.04/board_tinkerboard/0001-tinkerboard-defconfig-fix.patch
+++ b/patch/u-boot/v2022.04/board_tinkerboard/0001-tinkerboard-defconfig-fix.patch
@@ -1,8 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Thu, 24 Mar 2022 09:21:56 +0000
+Subject: [ARCHEOLOGY] rockchip: fix kernel device tree in u-boot
+
+> X-Git-Archeology: - Revision 2cbd35f3b2fbc90e4c93f3c1669fcd0f459d08a4: https://github.com/armbian/build/commit/2cbd35f3b2fbc90e4c93f3c1669fcd0f459d08a4
+> X-Git-Archeology:   Date: Thu, 24 Mar 2022 09:21:56 +0000
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip: fix kernel device tree in u-boot
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 445062b8dc243c55381db7f5a579a08ca6a0d73a: https://github.com/armbian/build/commit/445062b8dc243c55381db7f5a579a08ca6a0d73a
+> X-Git-Archeology:   Date: Thu, 24 Mar 2022 09:21:56 +0000
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip: advance tinkerboard u-boot to v2022.01
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision c674bac80c15025081086ef481e31365dddc74c2: https://github.com/armbian/build/commit/c674bac80c15025081086ef481e31365dddc74c2
+> X-Git-Archeology:   Date: Thu, 24 Mar 2022 09:21:56 +0000
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip: advance tinkerboard u-boot to v2021.01
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision de26797423e22d58ec2882d7032c67f77196ecc5: https://github.com/armbian/build/commit/de26797423e22d58ec2882d7032c67f77196ecc5
+> X-Git-Archeology:   Date: Sun, 06 Nov 2022 20:32:46 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Move all legacy u-boot patches under one general legacy folder (#4386)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 97c34489831f2146940f52915428263b7edfcbe1: https://github.com/armbian/build/commit/97c34489831f2146940f52915428263b7edfcbe1
+> X-Git-Archeology:   Date: Fri, 24 Mar 2023 23:13:42 +0100
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip: put all rockchip 32 bit into uboot/v2022.04 directory
+> X-Git-Archeology:
+---
+ configs/tinker-rk3288_defconfig | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
 diff --git a/configs/tinker-rk3288_defconfig b/configs/tinker-rk3288_defconfig
-index a9c9a122..842a43fb 100644
+index 111111111111..222222222222 100644
 --- a/configs/tinker-rk3288_defconfig
 +++ b/configs/tinker-rk3288_defconfig
-@@ -17,11 +17,12 @@ CONFIG_DEBUG_UART=y
+@@ -18,11 +18,12 @@ CONFIG_DEBUG_UART=y
  CONFIG_SYS_LOAD_ADDR=0x800800
  # CONFIG_ANDROID_BOOT_IMAGE is not set
  CONFIG_USE_PREBOOT=y
@@ -16,7 +50,7 @@ index a9c9a122..842a43fb 100644
  CONFIG_SPL_I2C=y
  CONFIG_SPL_POWER=y
  CONFIG_CMD_GPIO=y
-@@ -75,6 +76,7 @@ CONFIG_REGULATOR_RK8XX=y
+@@ -76,6 +77,7 @@ CONFIG_REGULATOR_RK8XX=y
  CONFIG_PWM_ROCKCHIP=y
  CONFIG_RAM=y
  CONFIG_SPL_RAM=y
@@ -24,7 +58,7 @@ index a9c9a122..842a43fb 100644
  CONFIG_DEBUG_UART_SHIFT=2
  CONFIG_SYSRESET=y
  CONFIG_USB=y
-@@ -85,6 +87,9 @@ CONFIG_USB_HOST_ETHER=y
+@@ -86,6 +88,9 @@ CONFIG_USB_HOST_ETHER=y
  CONFIG_USB_ETHER_ASIX=y
  CONFIG_USB_ETHER_SMSC95XX=y
  CONFIG_USB_GADGET=y
@@ -34,3 +68,6 @@ index a9c9a122..842a43fb 100644
  CONFIG_USB_GADGET_DWC2_OTG=y
  CONFIG_DM_VIDEO=y
  CONFIG_DISPLAY=y
+-- 
+Armbian
+

--- a/patch/u-boot/v2022.04/board_tinkerboard/0002-tinkerboard-add-emmc.patch
+++ b/patch/u-boot/v2022.04/board_tinkerboard/0002-tinkerboard-add-emmc.patch
@@ -1,15 +1,15 @@
-From b89be51a2e80e7a56ddd444cc57b042594016218 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
 Date: Sat, 19 Mar 2022 21:37:32 +0000
-Subject: [PATCH] rk3288: add emmc to tinkerboard dts
+Subject: rk3288: add emmc to tinkerboard dts
 
 ---
  arch/arm/dts/rk3288-tinker-u-boot.dtsi |  4 ++++
- arch/arm/dts/rk3288-tinker.dts         | 12 ++++++++++++
+ arch/arm/dts/rk3288-tinker.dts         | 12 ++++++++++
  2 files changed, 16 insertions(+)
 
 diff --git a/arch/arm/dts/rk3288-tinker-u-boot.dtsi b/arch/arm/dts/rk3288-tinker-u-boot.dtsi
-index 56d10c82e..164c72eb7 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/dts/rk3288-tinker-u-boot.dtsi
 +++ b/arch/arm/dts/rk3288-tinker-u-boot.dtsi
 @@ -36,6 +36,10 @@
@@ -24,7 +24,7 @@ index 56d10c82e..164c72eb7 100644
  	u-boot,dm-spl;
  };
 diff --git a/arch/arm/dts/rk3288-tinker.dts b/arch/arm/dts/rk3288-tinker.dts
-index 8b1848c31..8db248412 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/dts/rk3288-tinker.dts
 +++ b/arch/arm/dts/rk3288-tinker.dts
 @@ -31,3 +31,15 @@
@@ -44,5 +44,5 @@ index 8b1848c31..8db248412 100644
 +	status = "okay";
 +};
 -- 
-2.30.2
+Armbian
 

--- a/patch/u-boot/v2022.04/board_tinkerboard/0003-UMS-mode-on-otg-port.patch
+++ b/patch/u-boot/v2022.04/board_tinkerboard/0003-UMS-mode-on-otg-port.patch
@@ -1,15 +1,15 @@
-From 2636bc3f11c953c24b3af7334082811737bf475b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
 Date: Sat, 19 Mar 2022 21:41:38 +0000
-Subject: [PATCH] rk3288: tinkerboard: add UMS mode when USB host is connected
- to OTG port during boot
+Subject: rk3288: tinkerboard: add UMS mode when USB host is connected to OTG
+ port during boot
 
 ---
- arch/arm/include/asm/arch-rockchip/gpio.h  |  22 ++++
- arch/arm/mach-rockchip/board.c             | 115 +++++++++++++++++++++
- arch/arm/mach-rockchip/spl.c               |  23 ++++-
+ arch/arm/include/asm/arch-rockchip/gpio.h  |  22 ++
+ arch/arm/mach-rockchip/board.c             | 115 ++++++++++
+ arch/arm/mach-rockchip/spl.c               |  23 +-
  cmd/usb_mass_storage.c                     |   9 +-
- common/autoboot.c                          |  22 ++++
+ common/autoboot.c                          |  22 ++
  common/board_r.c                           |   1 +
  drivers/usb/gadget/dwc2_udc_otg_xfer_dma.c |   1 +
  drivers/usb/gadget/f_mass_storage.c        |  10 +-
@@ -18,7 +18,7 @@ Subject: [PATCH] rk3288: tinkerboard: add UMS mode when USB host is connected
  10 files changed, 203 insertions(+), 4 deletions(-)
 
 diff --git a/arch/arm/include/asm/arch-rockchip/gpio.h b/arch/arm/include/asm/arch-rockchip/gpio.h
-index 1aaec5fae..135688d3b 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/include/asm/arch-rockchip/gpio.h
 +++ b/arch/arm/include/asm/arch-rockchip/gpio.h
 @@ -24,6 +24,28 @@ struct rockchip_gpio_regs {
@@ -51,10 +51,10 @@ index 1aaec5fae..135688d3b 100644
  	GPIO_PULL_NORMAL = 0,
  	GPIO_PULL_UP,
 diff --git a/arch/arm/mach-rockchip/board.c b/arch/arm/mach-rockchip/board.c
-index ba4da72b3..5ae2c7f8f 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/mach-rockchip/board.c
 +++ b/arch/arm/mach-rockchip/board.c
-@@ -17,10 +17,26 @@
+@@ -18,10 +18,26 @@
  #include <asm/arch-rockchip/clock.h>
  #include <asm/arch-rockchip/periph.h>
  #include <asm/arch-rockchip/misc.h>
@@ -81,7 +81,7 @@ index ba4da72b3..5ae2c7f8f 100644
  __weak int rk_board_late_init(void)
  {
  	return 0;
-@@ -33,6 +49,105 @@ int board_late_init(void)
+@@ -34,6 +50,105 @@ int board_late_init(void)
  	return rk_board_late_init();
  }
  
@@ -188,10 +188,10 @@ index ba4da72b3..5ae2c7f8f 100644
  {
  	int ret;
 diff --git a/arch/arm/mach-rockchip/spl.c b/arch/arm/mach-rockchip/spl.c
-index f148d48b6..59daff438 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/mach-rockchip/spl.c
 +++ b/arch/arm/mach-rockchip/spl.c
-@@ -106,6 +106,27 @@ __weak int arch_cpu_init(void)
+@@ -108,6 +108,27 @@ __weak int arch_cpu_init(void)
  	return 0;
  }
  
@@ -219,7 +219,7 @@ index f148d48b6..59daff438 100644
  void board_init_f(ulong dummy)
  {
  	int ret;
-@@ -122,7 +143,7 @@ void board_init_f(ulong dummy)
+@@ -124,7 +145,7 @@ void board_init_f(ulong dummy)
  	debug_uart_init();
  	debug("\nspl:debug uart enabled in %s\n", __func__);
  #endif
@@ -229,7 +229,7 @@ index f148d48b6..59daff438 100644
  
  	ret = spl_early_init();
 diff --git a/cmd/usb_mass_storage.c b/cmd/usb_mass_storage.c
-index cf2f55994..d406ea453 100644
+index 111111111111..222222222222 100644
 --- a/cmd/usb_mass_storage.c
 +++ b/cmd/usb_mass_storage.c
 @@ -111,7 +111,7 @@ static int ums_init(const char *devtype, const char *devnums_part_str)
@@ -263,7 +263,7 @@ index cf2f55994..d406ea453 100644
  			/* Check I/O error */
  			if (rc == -EIO)
 diff --git a/common/autoboot.c b/common/autoboot.c
-index e628baffb..eefaa28d4 100644
+index 111111111111..222222222222 100644
 --- a/common/autoboot.c
 +++ b/common/autoboot.c
 @@ -40,6 +40,9 @@ DECLARE_GLOBAL_DATA_PTR;
@@ -276,9 +276,9 @@ index e628baffb..eefaa28d4 100644
  #if !defined(CONFIG_AUTOBOOT_STOP_STR_CRYPT)
  #define CONFIG_AUTOBOOT_STOP_STR_CRYPT ""
  #endif
-@@ -49,6 +52,10 @@ static int menukey;
- #define AUTOBOOT_MENUKEY 0
- #endif
+@@ -120,6 +123,10 @@ static int passwd_abort_crypt(uint64_t etime)
+ 	return abort;
+ }
  
 +extern int do_usb_mass_storage(struct cmd_tbl *cmdtp, int flag, int argc, char * const argv[]);
 +void usb_current_limit_ctrl(bool unlock_current);
@@ -287,7 +287,7 @@ index e628baffb..eefaa28d4 100644
  /*
   * Use a "constant-length" time compare function for this
   * hash compare:
-@@ -363,6 +370,21 @@ void autoboot_command(const char *s)
+@@ -476,6 +483,21 @@ void autoboot_command(const char *s)
  {
  	debug("### main_loop: bootcmd=\"%s\"\n", s ? s : "<UNDEFINED>");
  
@@ -310,19 +310,19 @@ index e628baffb..eefaa28d4 100644
  		 (stored_bootdelay != -1 && !abortboot(stored_bootdelay)))) {
  		bool lock;
 diff --git a/common/board_r.c b/common/board_r.c
-index 29dd7d26d..5b952d00c 100644
+index 111111111111..222222222222 100644
 --- a/common/board_r.c
 +++ b/common/board_r.c
-@@ -797,6 +797,7 @@ static init_fnc_t init_sequence_r[] = {
+@@ -697,6 +697,7 @@ static init_fnc_t init_sequence_r[] = {
  #ifdef CONFIG_MMC
  	initr_mmc,
  #endif
 +	check_force_enter_ums_mode,
  #ifdef CONFIG_XEN
- 	initr_xen,
+ 	xen_init,
  #endif
 diff --git a/drivers/usb/gadget/dwc2_udc_otg_xfer_dma.c b/drivers/usb/gadget/dwc2_udc_otg_xfer_dma.c
-index f17009a29..b85b3f825 100644
+index 111111111111..222222222222 100644
 --- a/drivers/usb/gadget/dwc2_udc_otg_xfer_dma.c
 +++ b/drivers/usb/gadget/dwc2_udc_otg_xfer_dma.c
 @@ -1393,6 +1393,7 @@ static void dwc2_ep0_setup(struct dwc2_udc *dev)
@@ -334,7 +334,7 @@ index f17009a29..b85b3f825 100644
  
  		case USB_REQ_SET_INTERFACE:
 diff --git a/drivers/usb/gadget/f_mass_storage.c b/drivers/usb/gadget/f_mass_storage.c
-index 45f0504b6..80706d41b 100644
+index 111111111111..222222222222 100644
 --- a/drivers/usb/gadget/f_mass_storage.c
 +++ b/drivers/usb/gadget/f_mass_storage.c
 @@ -655,7 +655,7 @@ static void busy_indicator(void)
@@ -369,10 +369,10 @@ index 45f0504b6..80706d41b 100644
  	}
  	common->thread_wakeup_needed = 0;
 diff --git a/include/init.h b/include/init.h
-index 0f48ccb57..bae1cb88e 100644
+index 111111111111..222222222222 100644
 --- a/include/init.h
 +++ b/include/init.h
-@@ -261,6 +261,7 @@ int board_early_init_f(void);
+@@ -297,6 +297,7 @@ int board_early_init_f(void);
  /* manipulate the U-Boot fdt before its relocation */
  int board_fix_fdt(void *rw_fdt_blob);
  int board_late_init(void);
@@ -381,7 +381,7 @@ index 0f48ccb57..bae1cb88e 100644
  int board_early_init_r(void);
  
 diff --git a/include/linux/usb/gadget.h b/include/linux/usb/gadget.h
-index 06292ddeb..48709f3b0 100644
+index 111111111111..222222222222 100644
 --- a/include/linux/usb/gadget.h
 +++ b/include/linux/usb/gadget.h
 @@ -25,6 +25,9 @@
@@ -395,5 +395,5 @@ index 06292ddeb..48709f3b0 100644
   * struct usb_request - describes one i/o request
   * @buf: Buffer used for data.  Always provide this; some controllers
 -- 
-2.30.2
+Armbian
 

--- a/patch/u-boot/v2022.04/board_tinkerboard/0004-make-emmc-bootable.patch
+++ b/patch/u-boot/v2022.04/board_tinkerboard/0004-make-emmc-bootable.patch
@@ -1,14 +1,14 @@
-From e8926f5e4dd307c01b59883db7ae76e67bb47894 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
 Date: Sat, 19 Mar 2022 12:58:06 +0000
-Subject: [PATCH] rk3288: tinkerboard-s emmc boot
+Subject: rk3288: tinkerboard-s emmc boot
 
 ---
  include/configs/tinker_rk3288.h | 9 +--------
  1 file changed, 1 insertion(+), 8 deletions(-)
 
 diff --git a/include/configs/tinker_rk3288.h b/include/configs/tinker_rk3288.h
-index 269ec529..e19fa902 100644
+index 111111111111..222222222222 100644
 --- a/include/configs/tinker_rk3288.h
 +++ b/include/configs/tinker_rk3288.h
 @@ -13,13 +13,6 @@
@@ -26,18 +26,20 @@ index 269ec529..e19fa902 100644
 +#define CONFIG_SYS_MMC_ENV_DEV 0
  
  #endif
+-- 
+Armbian
 
-From b8a75200b11fc0005a8e12192473159e51abd29c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
 Date: Sat, 19 Mar 2022 13:05:33 +0000
-Subject: [PATCH] rk3288: fix redefined symbol
+Subject: rk3288: fix redefined symbol
 
 ---
  include/configs/tinker_rk3288.h | 1 +
  1 file changed, 1 insertion(+)
 
 diff --git a/include/configs/tinker_rk3288.h b/include/configs/tinker_rk3288.h
-index e19fa9021..bde7d72e6 100644
+index 111111111111..222222222222 100644
 --- a/include/configs/tinker_rk3288.h
 +++ b/include/configs/tinker_rk3288.h
 @@ -13,6 +13,7 @@
@@ -49,5 +51,5 @@ index e19fa9021..bde7d72e6 100644
  
  #endif
 -- 
-2.30.2
+Armbian
 

--- a/patch/u-boot/v2022.04/board_tinkerboard/add-overlay-support.patch
+++ b/patch/u-boot/v2022.04/board_tinkerboard/add-overlay-support.patch
@@ -1,13 +1,52 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zador-blood-stained <zador-blood-stained@users.noreply.github.com>
+Date: Tue, 31 Oct 2017 21:23:43 +0300
+Subject: [ARCHEOLOGY] Add mvebu dev branch
+
+> X-Git-Archeology: > recovered message: > It uses the same kernel as next, but it uses mainline u-boot with DT
+> X-Git-Archeology: > recovered message: > overlay support, but without SPI, USB and possibly SATA support
+> X-Git-Archeology: - Revision aba730f4880b20f7ba37504a8d1d6bc484f28c54: https://github.com/armbian/build/commit/aba730f4880b20f7ba37504a8d1d6bc484f28c54
+> X-Git-Archeology:   Date: Tue, 31 Oct 2017 21:23:43 +0300
+> X-Git-Archeology:   From: zador-blood-stained <zador-blood-stained@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Add mvebu dev branch
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision e71d1560f0429d9ecbc077ac457c6247735e3e9a: https://github.com/armbian/build/commit/e71d1560f0429d9ecbc077ac457c6247735e3e9a
+> X-Git-Archeology:   Date: Fri, 23 Nov 2018 15:39:23 +0100
+> X-Git-Archeology:   From: aprayoga <aprayoga@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Helios4: various updates (#1161)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 3a185c8b8262a3189fd99fedc4350d738e825d0d: https://github.com/armbian/build/commit/3a185c8b8262a3189fd99fedc4350d738e825d0d
+> X-Git-Archeology:   Date: Thu, 13 Dec 2018 19:04:47 -0500
+> X-Git-Archeology:   From: Thomas McKahan <tonymckahan@gmail.com>
+> X-Git-Archeology:   Subject: [ rockchip-dev ] Add DT overlay framework
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision de26797423e22d58ec2882d7032c67f77196ecc5: https://github.com/armbian/build/commit/de26797423e22d58ec2882d7032c67f77196ecc5
+> X-Git-Archeology:   Date: Sun, 06 Nov 2022 20:32:46 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Move all legacy u-boot patches under one general legacy folder (#4386)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 97c34489831f2146940f52915428263b7edfcbe1: https://github.com/armbian/build/commit/97c34489831f2146940f52915428263b7edfcbe1
+> X-Git-Archeology:   Date: Fri, 24 Mar 2023 23:13:42 +0100
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip: put all rockchip 32 bit into uboot/v2022.04 directory
+> X-Git-Archeology:
+---
+ arch/arm/Kconfig | 2 ++
+ 1 file changed, 2 insertions(+)
+
 diff --git a/arch/arm/Kconfig b/arch/arm/Kconfig
-index 8a23c76d..bb1e3cb7 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/Kconfig
 +++ b/arch/arm/Kconfig
-@@ -1321,6 +1321,8 @@ config ARCH_ROCKCHIP
+@@ -1908,6 +1908,8 @@ config ARCH_ROCKCHIP
+ 	select DM_SPI
  	select DM_SPI_FLASH
- 	select DM_USB if USB
  	select ENABLE_ARM_SOC_BOOT0_HOOK
 +	select OF_LIBFDT
 +	select OF_LIBFDT_OVERLAY
  	select OF_CONTROL
  	select SPI
  	select SPL_DM if SPL
+-- 
+Armbian
+

--- a/patch/u-boot/v2022.04/board_xt-q8l-v10/u-boot-1000-enable-rockchip-efuse-for-rk322x-rk3288-and-rk3328.patch
+++ b/patch/u-boot/v2022.04/board_xt-q8l-v10/u-boot-1000-enable-rockchip-efuse-for-rk322x-rk3288-and-rk3328.patch
@@ -1,10 +1,10 @@
-From 768ff9ab40cc54e03895a46a4818d36dec150cac Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paolo Sabatino <paolo.sabatino@gmail.com>
 Date: Sun, 4 Apr 2021 10:29:29 +0000
-Subject: [PATCH] Enable rockchip efuse for rk322x, rk3288 and rk3328
+Subject: Enable rockchip efuse for rk322x, rk3288 and rk3328
 
 ---
- arch/arm/dts/rk322x.dtsi               |  14 +++
+ arch/arm/dts/rk322x.dtsi               |  14 +
  arch/arm/dts/rk3288.dtsi               |   3 +-
  configs/evb-rk3229_defconfig           |   3 +
  configs/evb-rk3328_defconfig           |   3 +
@@ -12,12 +12,12 @@ Subject: [PATCH] Enable rockchip efuse for rk322x, rk3288 and rk3328
  configs/rock64-rk3328_defconfig        |   2 +
  configs/tinker-rk3288_defconfig        |   1 +
  configs/tinker-s-rk3288_defconfig      |   1 +
- drivers/misc/rockchip-efuse.c          | 142 ++++++++++++++++++++++++-
+ drivers/misc/rockchip-efuse.c          | 142 +++++++++-
  include/dt-bindings/clock/rk3228-cru.h |   4 +
  10 files changed, 169 insertions(+), 6 deletions(-)
 
 diff --git a/arch/arm/dts/rk322x.dtsi b/arch/arm/dts/rk322x.dtsi
-index 4a8be5dabb..255e3a7a28 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/dts/rk322x.dtsi
 +++ b/arch/arm/dts/rk322x.dtsi
 @@ -212,6 +212,20 @@
@@ -42,7 +42,7 @@ index 4a8be5dabb..255e3a7a28 100644
  		compatible = "rockchip,rk3228-i2c";
  		reg = <0x11050000 0x1000>;
 diff --git a/arch/arm/dts/rk3288.dtsi b/arch/arm/dts/rk3288.dtsi
-index 22bb06cec5..381391360c 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/dts/rk3288.dtsi
 +++ b/arch/arm/dts/rk3288.dtsi
 @@ -919,8 +919,7 @@
@@ -56,10 +56,10 @@ index 22bb06cec5..381391360c 100644
  
  	gic: interrupt-controller@ffc01000 {
 diff --git a/configs/evb-rk3229_defconfig b/configs/evb-rk3229_defconfig
-index e708ed4909..e3ba0651fd 100644
+index 111111111111..222222222222 100644
 --- a/configs/evb-rk3229_defconfig
 +++ b/configs/evb-rk3229_defconfig
-@@ -49,6 +49,8 @@ CONFIG_FASTBOOT_BUF_SIZE=0x04000000
+@@ -54,6 +54,8 @@ CONFIG_FASTBOOT_BUF_SIZE=0x04000000
  CONFIG_FASTBOOT_CMD_OEM_FORMAT=y
  CONFIG_ROCKCHIP_GPIO=y
  CONFIG_SYS_I2C_ROCKCHIP=y
@@ -68,16 +68,16 @@ index e708ed4909..e3ba0651fd 100644
  CONFIG_MMC_DW=y
  CONFIG_MMC_DW_ROCKCHIP=y
  CONFIG_MTD=y
-@@ -68,3 +70,4 @@ CONFIG_USB_GADGET=y
+@@ -73,3 +75,4 @@ CONFIG_USB_GADGET=y
  CONFIG_USB_GADGET_DWC2_OTG=y
  CONFIG_TPL_TINY_MEMSET=y
  CONFIG_ERRNO_STR=y
 +CONFIG_MISC_INIT_R=y
 diff --git a/configs/evb-rk3328_defconfig b/configs/evb-rk3328_defconfig
-index 9cbfeb0279..f0acfd8abd 100644
+index 111111111111..222222222222 100644
 --- a/configs/evb-rk3328_defconfig
 +++ b/configs/evb-rk3328_defconfig
-@@ -20,6 +20,7 @@ CONFIG_FIT=y
+@@ -22,6 +22,7 @@ CONFIG_FIT=y
  CONFIG_FIT_VERBOSE=y
  CONFIG_SPL_LOAD_FIT=y
  CONFIG_DEFAULT_FDT_FILE="rockchip/rk3328-evb.dtb"
@@ -85,7 +85,7 @@ index 9cbfeb0279..f0acfd8abd 100644
  # CONFIG_DISPLAY_CPUINFO is not set
  CONFIG_DISPLAY_BOARDINFO_LATE=y
  # CONFIG_SPL_RAW_IMAGE_SUPPORT is not set
-@@ -56,6 +57,8 @@ CONFIG_FASTBOOT_BUF_ADDR=0x800800
+@@ -58,6 +59,8 @@ CONFIG_FASTBOOT_BUF_ADDR=0x800800
  CONFIG_FASTBOOT_CMD_OEM_FORMAT=y
  CONFIG_ROCKCHIP_GPIO=y
  CONFIG_SYS_I2C_ROCKCHIP=y
@@ -95,10 +95,10 @@ index 9cbfeb0279..f0acfd8abd 100644
  CONFIG_MMC_DW_ROCKCHIP=y
  CONFIG_SF_DEFAULT_SPEED=20000000
 diff --git a/configs/miqi-rk3288_defconfig b/configs/miqi-rk3288_defconfig
-index 234ced5ab0..3d42e93866 100644
+index 111111111111..222222222222 100644
 --- a/configs/miqi-rk3288_defconfig
 +++ b/configs/miqi-rk3288_defconfig
-@@ -49,6 +49,8 @@ CONFIG_SPL_CLK=y
+@@ -52,6 +52,8 @@ CONFIG_SPL_CLK=y
  CONFIG_FASTBOOT_CMD_OEM_FORMAT=y
  CONFIG_ROCKCHIP_GPIO=y
  CONFIG_SYS_I2C_ROCKCHIP=y
@@ -108,10 +108,10 @@ index 234ced5ab0..3d42e93866 100644
  CONFIG_MMC_DW_ROCKCHIP=y
  CONFIG_MTD=y
 diff --git a/configs/rock64-rk3328_defconfig b/configs/rock64-rk3328_defconfig
-index cb79cea821..dacb57165e 100644
+index 111111111111..222222222222 100644
 --- a/configs/rock64-rk3328_defconfig
 +++ b/configs/rock64-rk3328_defconfig
-@@ -57,6 +57,8 @@ CONFIG_FASTBOOT_BUF_ADDR=0x800800
+@@ -59,6 +59,8 @@ CONFIG_FASTBOOT_BUF_ADDR=0x800800
  CONFIG_FASTBOOT_CMD_OEM_FORMAT=y
  CONFIG_ROCKCHIP_GPIO=y
  CONFIG_SYS_I2C_ROCKCHIP=y
@@ -121,10 +121,10 @@ index cb79cea821..dacb57165e 100644
  CONFIG_MMC_DW_ROCKCHIP=y
  CONFIG_SF_DEFAULT_SPEED=20000000
 diff --git a/configs/tinker-rk3288_defconfig b/configs/tinker-rk3288_defconfig
-index 8686a66d13..b7dc845451 100644
+index 111111111111..222222222222 100644
 --- a/configs/tinker-rk3288_defconfig
 +++ b/configs/tinker-rk3288_defconfig
-@@ -52,6 +52,7 @@ CONFIG_FASTBOOT_CMD_OEM_FORMAT=y
+@@ -56,6 +56,7 @@ CONFIG_FASTBOOT_CMD_OEM_FORMAT=y
  CONFIG_ROCKCHIP_GPIO=y
  CONFIG_SYS_I2C_ROCKCHIP=y
  CONFIG_MISC=y
@@ -133,10 +133,10 @@ index 8686a66d13..b7dc845451 100644
  CONFIG_MMC_DW=y
  CONFIG_MMC_DW_ROCKCHIP=y
 diff --git a/configs/tinker-s-rk3288_defconfig b/configs/tinker-s-rk3288_defconfig
-index 22714833cc..19aa314164 100644
+index 111111111111..222222222222 100644
 --- a/configs/tinker-s-rk3288_defconfig
 +++ b/configs/tinker-s-rk3288_defconfig
-@@ -53,6 +53,7 @@ CONFIG_FASTBOOT_CMD_OEM_FORMAT=y
+@@ -57,6 +57,7 @@ CONFIG_FASTBOOT_CMD_OEM_FORMAT=y
  CONFIG_ROCKCHIP_GPIO=y
  CONFIG_SYS_I2C_ROCKCHIP=y
  CONFIG_MISC=y
@@ -145,7 +145,7 @@ index 22714833cc..19aa314164 100644
  CONFIG_MMC_DW=y
  CONFIG_MMC_DW_ROCKCHIP=y
 diff --git a/drivers/misc/rockchip-efuse.c b/drivers/misc/rockchip-efuse.c
-index 083ee65e0a..0fcbcfc69a 100644
+index 111111111111..222222222222 100644
 --- a/drivers/misc/rockchip-efuse.c
 +++ b/drivers/misc/rockchip-efuse.c
 @@ -14,6 +14,7 @@
@@ -343,7 +343,7 @@ index 083ee65e0a..0fcbcfc69a 100644
  };
  
 diff --git a/include/dt-bindings/clock/rk3228-cru.h b/include/dt-bindings/clock/rk3228-cru.h
-index 1217d5239f..13b2f4e4a4 100644
+index 111111111111..222222222222 100644
 --- a/include/dt-bindings/clock/rk3228-cru.h
 +++ b/include/dt-bindings/clock/rk3228-cru.h
 @@ -67,6 +67,10 @@
@@ -358,5 +358,5 @@ index 1217d5239f..13b2f4e4a4 100644
  #define PCLK_I2C0		332
  #define PCLK_I2C1		333
 -- 
-2.25.1
+Armbian
 

--- a/patch/u-boot/v2022.04/board_xt-q8l-v10/xt-q8l-v10-defconfig.patch
+++ b/patch/u-boot/v2022.04/board_xt-q8l-v10/xt-q8l-v10-defconfig.patch
@@ -1,6 +1,149 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paolo <paolo.sabatino@gmail.com>
+Date: Thu, 22 Nov 2018 07:04:19 +0100
+Subject: [ARCHEOLOGY] Add rk3288 xt-q8l-v10 CSC board (#1158)
+
+> X-Git-Archeology: > recovered message: > This merge request contains various files which add support for xt-q8l-v10 boards (TVBox) equipped with Rockchip RK3288 SoC, AP6330 WiSoC (BCM4330 WiFi + Bluetooth), 2 GB DRAM (LPDDR2 or DDR3), 8 Gb eMMC, Gigabit Ethernet, 3 USB (1 OTG), 1 microSD slot, SPDIF optical output, 1 HDMI.
+> X-Git-Archeology: > recovered message: > Kernel patches:
+> X-Git-Archeology: > recovered message: > This thouches all three linux-rockchip-* kernelconfigs, just adds brcmfmac and brcmutil modules and remote controller support. default flavor activates rockchip own remote controller driver, next and dev use the mainline GPIO CIR driver (dev has lirc userland support activated too).
+> X-Git-Archeology: > recovered message: > About the remote controller, an additional kernel module is added to the existing keymaps which is activated via device tree.
+> X-Git-Archeology: > recovered message: > About possibly clashing patches assert-phy-reset-when-waking-up-in-rk3288-platform.patch should be checked against other rk3288 boards because it addresses an errata in rk3288 which causes the USB Host ports to stop responding when exiting from autosleep. On my device if I connect the first USB device when the system is already running, the USB Host gets stuck without this patch. Probably to work correctly on other platforms the device tree should include the proper reset lines of the USB PHYs (for reference, check patch/kernel/rockchip-dev/xt-q8l-v10-add-device-tree.patch starting from line 869).
+> X-Git-Archeology: > recovered message: > Patch 1-2-regulator-act8865-add-restart-handler-for-act8846.patch adds a restart handler which allows reboot using SIPC bit on act8846 power regulator. Possibly MiQi board is affected (is reboot working there?), others (tinkerboard) should not care.
+> X-Git-Archeology: > recovered message: > Patch brcmfmac-add-ap6330-firmware.patch adds firmware file names for ap6330 , should be harmless in other cases.
+> X-Git-Archeology: > recovered message: > Patch 0010-GPU-Mali-Midgard-remove-rcu_read_lock-references.patch is from Miouyouyou. It should be harmless, it was suggested by him to do some tests with devfreq
+> X-Git-Archeology: > recovered message: > Other patches just add the proper device trees, Kconfig and bits for supporting the board as a regular kernel supported board and should not interfere with anything else
+> X-Git-Archeology: > recovered message: > U-Boot patches:
+> X-Git-Archeology: > recovered message: > All the patches for u-boot are per-board, so nothing is added which may interfere with other existing boards here. They include the device tree and u-boot config and also a couple of patches to support the silergy power regulators driving current to CPU and GPU
+> X-Git-Archeology: > recovered message: > * Initial commit to provide kernel and u-boot configuration and device trees for xt-q8-v10 as patches
+> X-Git-Archeology: > recovered message: > Modification to rockchip config to add initialization bits for xt-q8-v10
+> X-Git-Archeology: > recovered message: > * Committing correct path for rk3288_ddr_400Mhz... rockchip blob, moved assembling into another section to produce
+> X-Git-Archeology: > recovered message: > immediately an u-boot working binary
+> X-Git-Archeology: > recovered message: > * Enabled broadcom fmac driver in rockchip-next config
+> X-Git-Archeology: > recovered message: > * Changed name definition of rk3288-xt-q8-v10 board to "TVBox"
+> X-Git-Archeology: > recovered message: > Added bits to include support AP6330 and binary firmwares into the final image
+> X-Git-Archeology: > recovered message: > * Fixed device tree file name in related patch, added patching of Makefile to produce the device tree binary accordingly
+> X-Git-Archeology: > recovered message: > * Fixed xt-q8-v10 device tree patch
+> X-Git-Archeology: > recovered message: > Added brcmfmac driver to rockchip dev and default kernel configs
+> X-Git-Archeology: > recovered message: > * Syncing with upstream
+> X-Git-Archeology: > recovered message: > * Splitted add-xt-q8... kernel patches into two separate patches
+> X-Git-Archeology: > recovered message: > * Fixed bad extension while adding dtb in makefile for rockchip-default configuration
+> X-Git-Archeology: > recovered message: > Updated device tree patches for all rockchip confs
+> X-Git-Archeology: > recovered message: > * Enable mmc0 and usb in u-boot config
+> X-Git-Archeology: > recovered message: > Fixed again makefile patch for kernel next
+> X-Git-Archeology: > recovered message: > * Adding patches to reset the USB phy when kernel requires a reset, fixes autosuspend issue
+> X-Git-Archeology: > recovered message: > * Changed xt-q8-v10 to proper xt-q8l-v10 in every string and every filename
+> X-Git-Archeology: > recovered message: > Added power hold to u-boot, so now the device will boot and stay turned on without the need for the OTG cable anymore
+> X-Git-Archeology: > recovered message: > * Changed names from 'Q8' to proper 'XT-Q8L-V10' in device tree patch files
+> X-Git-Archeology: > recovered message: > * Legacy kernel device tree:
+> X-Git-Archeology: > recovered message: > Fixed bluetooth gpio pin clashing
+> X-Git-Archeology: > recovered message: > Fixed HDMI gpio pin clashing
+> X-Git-Archeology: > recovered message: > Added support for PWM-based IR-Receiver, added driver in kernel default config too
+> X-Git-Archeology: > recovered message: > Various other fixes to avoid some complaints from the kernel
+> X-Git-Archeology: > recovered message: > * Added booting bluetooth systemd service for AP6330 (xt-q8l-v10) that loads patchram and invokes hciattach
+> X-Git-Archeology: > recovered message: > Minor fixes to -next and -dev device trees for xt-q8l-v10
+> X-Git-Archeology: > recovered message: > * Disabled OTG USB port in u-boot due to long timeout during initialization
+> X-Git-Archeology: > recovered message: > Fixed warning during u-boot dts compilation
+> X-Git-Archeology: > recovered message: > Added emmc as second boot device in dts
+> X-Git-Archeology: > recovered message: > * Adding myself to licensing
+> X-Git-Archeology: > recovered message: > * Committing modifications to device trees
+> X-Git-Archeology: > recovered message: > * Fixed dmac_bus_s explicitly set to unused dmac, restored right dmac in xt-q8l-v10 dts only
+> X-Git-Archeology: > recovered message: > Change PLL_CPLL frequency in device tree to 408 Mhz to avoid fractional divisor warnings
+> X-Git-Archeology: > recovered message: > * Added proper xt-q8l-v10_rk3288 configuration to u-boot, now appearing in config menu and
+> X-Git-Archeology: > recovered message: > correctly selectable as a real target
+> X-Git-Archeology: > recovered message: > Fixed typo in device tree from rockchip
+> X-Git-Archeology: > recovered message: > * Fixed missing semicolon in device tree for default configuration
+> X-Git-Archeology: > recovered message: > Fixed patch files for u-boot appending themselves to files on each compilation
+> X-Git-Archeology: > recovered message: > * Added bits to enable power to USB ports in u-boot, thus enabling booting from USB devices (only USB host port for now)
+> X-Git-Archeology: > recovered message: > * Changed u-boot binary creation using the rockchip SPL properly
+> X-Git-Archeology: > recovered message: > * Added boot order for xt-q8l-v10: sdcard, usb0, eMMC, network
+> X-Git-Archeology: > recovered message: > * Added bionic:next in beta config for xt-q8l-v10 board
+> X-Git-Archeology: > recovered message: > * Changed some minor bits in xt-q8l-v10 device tree files, added missing bits to dev flavour
+> X-Git-Archeology: > recovered message: > Added patches to introduce fairchild fan53555/silergy82x regulators to u-boot and enabled in xt-q8l-v10 device tree
+> X-Git-Archeology: > recovered message: > * Updated u-boot to version v2018.03 for xt-q8l-v10. Other rk3288 boards will gain v2018.05 from main armbian fork
+> X-Git-Archeology: > recovered message: > Removed pre-reloc labels in u-boot device tree because they are not necessary since we don't use u-boot SPL for xt-q8l-v10
+> X-Git-Archeology: > recovered message: > Removed vmmc-supply and vqmmc-supply in u-boot device tree to avoid hang on boot
+> X-Git-Archeology: > recovered message: > * Tidied up a bit device trees, in particular some modifications are made to power regulator properties comparing them against the original q8l device tree
+> X-Git-Archeology: > recovered message: > Removed unnecessary dummy regulator, removed unnecessary capacities to embedded eMMC
+> X-Git-Archeology: > recovered message: > Disabled unused USB host
+> X-Git-Archeology: > recovered message: > Removed vmmc-supply and vqmmc-supply from emmc section because it causes hang in u-boot v2018.03 and newer
+> X-Git-Archeology: > recovered message: > * Restored previous regulator in u-boot dts
+> X-Git-Archeology: > recovered message: > removed assert phy reset USB patch from rockchip-dev because of some upstream incompatible changes
+> X-Git-Archeology: > recovered message: > * Added patch to enable IRQ for Midgard drivers which caused massive slowdown on dev kernel
+> X-Git-Archeology: > recovered message: > Changed u-boot if-code for xt-q8l-v10 in rockchip.conf
+> X-Git-Archeology: > recovered message: > Removed references to rk3288-linux.dtsi in xt-q8l-v10 device tree for default kernel
+> X-Git-Archeology: > recovered message: > * Committing effective removal of USB reset assert for dev kernel
+> X-Git-Archeology: > recovered message: > Committing changes to u-boot device tree
+> X-Git-Archeology: > recovered message: > * Added patch to disable USB power down for rockchip devices broken on latest kernel
+> X-Git-Archeology: > recovered message: > * Removed usb dwc2 patch to reinject it from specific branch
+> X-Git-Archeology: > recovered message: > * Reverting some voltage changes for xt-q8l-v10 device in rockchip-dev
+> X-Git-Archeology: > recovered message: > * Reverting some voltage changes for xt-q8l-v10 in u-boot section
+> X-Git-Archeology: > recovered message: > * Added patch to make USB ports working again on rockchip devices with mainline
+> X-Git-Archeology: > recovered message: > kernel >= 4.18
+> X-Git-Archeology: > recovered message: > * Changed the 0 into false
+> X-Git-Archeology: > recovered message: > * Moved xt-q8l-v10 u-boot patches into board_xt-q8l-v10 directory
+> X-Git-Archeology: > recovered message: > * Changed some minor things in rockchip-dev dts for xt-q8l-v10, added mali midgard driver to dev kernel config
+> X-Git-Archeology: > recovered message: > * Added devfreq support for Mali in rockchip-next flavour
+> X-Git-Archeology: > recovered message: > * Remove manually applied patch (0007-drivers-drm...) because it has been
+> X-Git-Archeology: > recovered message: > added to armbian main repo
+> X-Git-Archeology: > recovered message: > * Removed duplicate patch which has added to main armbian repository
+> X-Git-Archeology: > recovered message: > * Tidied up regulators for default/next/dev rockchip flavours for xt-q8l-v10, disabling those regulators which are not tied to anything
+> X-Git-Archeology: > recovered message: > Enabled voltage regulator to make SPDIF connector work (thus not tested because I have no DAC)
+> X-Git-Archeology: > recovered message: > Changed rockchip-dev and rockchip-next config files to enable gpio-ir-receiver module to enable bundled remote IR controller, including kernel patch for keymap
+> X-Git-Archeology: > recovered message: > * Enabled back regulator REG7 to allow propert bluetooth functionaly
+> X-Git-Archeology: > recovered message: > * Minor changes to u-boot device tree for xt-q8l-v10
+> X-Git-Archeology: > recovered message: > Added patch to set act8846 SIPC to correctly reboot the device (thus require some power-hold at reboot to make reboot fully working)
+> X-Git-Archeology: > recovered message: > * Fixed u-boot device tree
+> X-Git-Archeology: > recovered message: > * Added configuration bits to support TPL in u-boot for xt-q8l-v10 (TPL is thrown away though) to allow faster reboot times and achieve a working reset feature activating power hold gpio pin as soon as possible. gpio pin is hardwired into spl_board_init() u-boot code because it is not possible to let it work via device tree
+> X-Git-Archeology: > recovered message: > Fixed OTG USB port in u-boot, allowing devices detection and booting
+> X-Git-Archeology: > recovered message: > Added proper vbus-supply properties for USB controllers in u-boot dts, so u-boot activates USB vbus itself
+> X-Git-Archeology: > recovered message: > * Fixed dts makefile patching for next and dev rockchip kernel
+> X-Git-Archeology: > recovered message: > * Fixed fdt_file renamed to fdtfile in armbianEnv.txt
+> X-Git-Archeology: > recovered message: > * Changed xt-q8l-v10 board config as per recomendations
+> X-Git-Archeology: > recovered message: > * Moved xt-q8l-v10 configuration to CSC
+> X-Git-Archeology: > recovered message: > Restored linux-rockchip-* configurations, enabled brcmfmac driver, GPIO remote controller driver and lirc kernel compatibility interface
+> X-Git-Archeology: > recovered message: > Polished a bit rockchip.conf
+> X-Git-Archeology: > recovered message: > * Add patch to brcmfmac driver to search for ap6330 firmware
+> X-Git-Archeology: > recovered message: > Removed copy-work from rockchip.conf about ap6330 firmware for xt-q8l-v10 and tidied up
+> X-Git-Archeology: > recovered message: > Avoid using brcm_patchram_plus in ap6330-bluetooth-service putting proper firmware file in /etc/firmware for hciattach do firmware uploading itself
+> X-Git-Archeology: > recovered message: > * Fixed bcm4330 bluetooth firmware linking for hciattach used by ap6330-bluetooth.service
+> X-Git-Archeology: > recovered message: > * Removed foreign test patches from xt-q8l-v10 u-boot directory
+> X-Git-Archeology: - Revision 60b4166a8a9efe74c76bf75246cd297ccf4cf7ca: https://github.com/armbian/build/commit/60b4166a8a9efe74c76bf75246cd297ccf4cf7ca
+> X-Git-Archeology:   Date: Thu, 22 Nov 2018 07:04:19 +0100
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: Add rk3288 xt-q8l-v10 CSC board (#1158)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision f4cce9754879f1d8e956b5ee7dc05b6d049f0e94: https://github.com/armbian/build/commit/f4cce9754879f1d8e956b5ee7dc05b6d049f0e94
+> X-Git-Archeology:   Date: Wed, 10 Jun 2020 20:35:52 +0200
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: [rk3288] Various fixes and enhancements for xt-q8l-v10 CSC board (#2013)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 2dbdae284585eae321cb307afb75a9b70ed660b8: https://github.com/armbian/build/commit/2dbdae284585eae321cb307afb75a9b70ed660b8
+> X-Git-Archeology:   Date: Mon, 05 Apr 2021 13:53:08 +0000
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: xt-q8l-v10: bump to u-boot v2021.01
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision b87e8085fbbdccce462a9926bc29fe5e9db6f0db: https://github.com/armbian/build/commit/b87e8085fbbdccce462a9926bc29fe5e9db6f0db
+> X-Git-Archeology:   Date: Sun, 10 Apr 2022 16:45:44 +0200
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip: move u-boot to v2022.04 for tinkerboard and xt-q8l-v10
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision de26797423e22d58ec2882d7032c67f77196ecc5: https://github.com/armbian/build/commit/de26797423e22d58ec2882d7032c67f77196ecc5
+> X-Git-Archeology:   Date: Sun, 06 Nov 2022 20:32:46 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Move all legacy u-boot patches under one general legacy folder (#4386)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 97c34489831f2146940f52915428263b7edfcbe1: https://github.com/armbian/build/commit/97c34489831f2146940f52915428263b7edfcbe1
+> X-Git-Archeology:   Date: Fri, 24 Mar 2023 23:13:42 +0100
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip: put all rockchip 32 bit into uboot/v2022.04 directory
+> X-Git-Archeology:
+---
+ configs/xt-q8l-v10-rk3288_defconfig | 97 ++++++++++
+ 1 file changed, 97 insertions(+)
+
 diff --git a/configs/xt-q8l-v10-rk3288_defconfig b/configs/xt-q8l-v10-rk3288_defconfig
 new file mode 100644
-index 00000000..182451c6
+index 000000000000..111111111111
 --- /dev/null
 +++ b/configs/xt-q8l-v10-rk3288_defconfig
 @@ -0,0 +1,97 @@
@@ -101,3 +244,6 @@ index 00000000..182451c6
 +CONFIG_SHA256=y
 +CONFIG_ERRNO_STR=y
 +CONFIG_OF_LIBFDT_OVERLAY=y
+-- 
+Armbian
+

--- a/patch/u-boot/v2022.04/board_xt-q8l-v10/xt-q8l-v10-device-tree-makefile.patch
+++ b/patch/u-boot/v2022.04/board_xt-q8l-v10/xt-q8l-v10-device-tree-makefile.patch
@@ -1,17 +1,185 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paolo <paolo.sabatino@gmail.com>
+Date: Thu, 22 Nov 2018 07:04:19 +0100
+Subject: [ARCHEOLOGY] Add rk3288 xt-q8l-v10 CSC board (#1158)
+
+> X-Git-Archeology: > recovered message: > This merge request contains various files which add support for xt-q8l-v10 boards (TVBox) equipped with Rockchip RK3288 SoC, AP6330 WiSoC (BCM4330 WiFi + Bluetooth), 2 GB DRAM (LPDDR2 or DDR3), 8 Gb eMMC, Gigabit Ethernet, 3 USB (1 OTG), 1 microSD slot, SPDIF optical output, 1 HDMI.
+> X-Git-Archeology: > recovered message: > Kernel patches:
+> X-Git-Archeology: > recovered message: > This thouches all three linux-rockchip-* kernelconfigs, just adds brcmfmac and brcmutil modules and remote controller support. default flavor activates rockchip own remote controller driver, next and dev use the mainline GPIO CIR driver (dev has lirc userland support activated too).
+> X-Git-Archeology: > recovered message: > About the remote controller, an additional kernel module is added to the existing keymaps which is activated via device tree.
+> X-Git-Archeology: > recovered message: > About possibly clashing patches assert-phy-reset-when-waking-up-in-rk3288-platform.patch should be checked against other rk3288 boards because it addresses an errata in rk3288 which causes the USB Host ports to stop responding when exiting from autosleep. On my device if I connect the first USB device when the system is already running, the USB Host gets stuck without this patch. Probably to work correctly on other platforms the device tree should include the proper reset lines of the USB PHYs (for reference, check patch/kernel/rockchip-dev/xt-q8l-v10-add-device-tree.patch starting from line 869).
+> X-Git-Archeology: > recovered message: > Patch 1-2-regulator-act8865-add-restart-handler-for-act8846.patch adds a restart handler which allows reboot using SIPC bit on act8846 power regulator. Possibly MiQi board is affected (is reboot working there?), others (tinkerboard) should not care.
+> X-Git-Archeology: > recovered message: > Patch brcmfmac-add-ap6330-firmware.patch adds firmware file names for ap6330 , should be harmless in other cases.
+> X-Git-Archeology: > recovered message: > Patch 0010-GPU-Mali-Midgard-remove-rcu_read_lock-references.patch is from Miouyouyou. It should be harmless, it was suggested by him to do some tests with devfreq
+> X-Git-Archeology: > recovered message: > Other patches just add the proper device trees, Kconfig and bits for supporting the board as a regular kernel supported board and should not interfere with anything else
+> X-Git-Archeology: > recovered message: > U-Boot patches:
+> X-Git-Archeology: > recovered message: > All the patches for u-boot are per-board, so nothing is added which may interfere with other existing boards here. They include the device tree and u-boot config and also a couple of patches to support the silergy power regulators driving current to CPU and GPU
+> X-Git-Archeology: > recovered message: > * Initial commit to provide kernel and u-boot configuration and device trees for xt-q8-v10 as patches
+> X-Git-Archeology: > recovered message: > Modification to rockchip config to add initialization bits for xt-q8-v10
+> X-Git-Archeology: > recovered message: > * Committing correct path for rk3288_ddr_400Mhz... rockchip blob, moved assembling into another section to produce
+> X-Git-Archeology: > recovered message: > immediately an u-boot working binary
+> X-Git-Archeology: > recovered message: > * Enabled broadcom fmac driver in rockchip-next config
+> X-Git-Archeology: > recovered message: > * Changed name definition of rk3288-xt-q8-v10 board to "TVBox"
+> X-Git-Archeology: > recovered message: > Added bits to include support AP6330 and binary firmwares into the final image
+> X-Git-Archeology: > recovered message: > * Fixed device tree file name in related patch, added patching of Makefile to produce the device tree binary accordingly
+> X-Git-Archeology: > recovered message: > * Fixed xt-q8-v10 device tree patch
+> X-Git-Archeology: > recovered message: > Added brcmfmac driver to rockchip dev and default kernel configs
+> X-Git-Archeology: > recovered message: > * Syncing with upstream
+> X-Git-Archeology: > recovered message: > * Splitted add-xt-q8... kernel patches into two separate patches
+> X-Git-Archeology: > recovered message: > * Fixed bad extension while adding dtb in makefile for rockchip-default configuration
+> X-Git-Archeology: > recovered message: > Updated device tree patches for all rockchip confs
+> X-Git-Archeology: > recovered message: > * Enable mmc0 and usb in u-boot config
+> X-Git-Archeology: > recovered message: > Fixed again makefile patch for kernel next
+> X-Git-Archeology: > recovered message: > * Adding patches to reset the USB phy when kernel requires a reset, fixes autosuspend issue
+> X-Git-Archeology: > recovered message: > * Changed xt-q8-v10 to proper xt-q8l-v10 in every string and every filename
+> X-Git-Archeology: > recovered message: > Added power hold to u-boot, so now the device will boot and stay turned on without the need for the OTG cable anymore
+> X-Git-Archeology: > recovered message: > * Changed names from 'Q8' to proper 'XT-Q8L-V10' in device tree patch files
+> X-Git-Archeology: > recovered message: > * Legacy kernel device tree:
+> X-Git-Archeology: > recovered message: > Fixed bluetooth gpio pin clashing
+> X-Git-Archeology: > recovered message: > Fixed HDMI gpio pin clashing
+> X-Git-Archeology: > recovered message: > Added support for PWM-based IR-Receiver, added driver in kernel default config too
+> X-Git-Archeology: > recovered message: > Various other fixes to avoid some complaints from the kernel
+> X-Git-Archeology: > recovered message: > * Added booting bluetooth systemd service for AP6330 (xt-q8l-v10) that loads patchram and invokes hciattach
+> X-Git-Archeology: > recovered message: > Minor fixes to -next and -dev device trees for xt-q8l-v10
+> X-Git-Archeology: > recovered message: > * Disabled OTG USB port in u-boot due to long timeout during initialization
+> X-Git-Archeology: > recovered message: > Fixed warning during u-boot dts compilation
+> X-Git-Archeology: > recovered message: > Added emmc as second boot device in dts
+> X-Git-Archeology: > recovered message: > * Adding myself to licensing
+> X-Git-Archeology: > recovered message: > * Committing modifications to device trees
+> X-Git-Archeology: > recovered message: > * Fixed dmac_bus_s explicitly set to unused dmac, restored right dmac in xt-q8l-v10 dts only
+> X-Git-Archeology: > recovered message: > Change PLL_CPLL frequency in device tree to 408 Mhz to avoid fractional divisor warnings
+> X-Git-Archeology: > recovered message: > * Added proper xt-q8l-v10_rk3288 configuration to u-boot, now appearing in config menu and
+> X-Git-Archeology: > recovered message: > correctly selectable as a real target
+> X-Git-Archeology: > recovered message: > Fixed typo in device tree from rockchip
+> X-Git-Archeology: > recovered message: > * Fixed missing semicolon in device tree for default configuration
+> X-Git-Archeology: > recovered message: > Fixed patch files for u-boot appending themselves to files on each compilation
+> X-Git-Archeology: > recovered message: > * Added bits to enable power to USB ports in u-boot, thus enabling booting from USB devices (only USB host port for now)
+> X-Git-Archeology: > recovered message: > * Changed u-boot binary creation using the rockchip SPL properly
+> X-Git-Archeology: > recovered message: > * Added boot order for xt-q8l-v10: sdcard, usb0, eMMC, network
+> X-Git-Archeology: > recovered message: > * Added bionic:next in beta config for xt-q8l-v10 board
+> X-Git-Archeology: > recovered message: > * Changed some minor bits in xt-q8l-v10 device tree files, added missing bits to dev flavour
+> X-Git-Archeology: > recovered message: > Added patches to introduce fairchild fan53555/silergy82x regulators to u-boot and enabled in xt-q8l-v10 device tree
+> X-Git-Archeology: > recovered message: > * Updated u-boot to version v2018.03 for xt-q8l-v10. Other rk3288 boards will gain v2018.05 from main armbian fork
+> X-Git-Archeology: > recovered message: > Removed pre-reloc labels in u-boot device tree because they are not necessary since we don't use u-boot SPL for xt-q8l-v10
+> X-Git-Archeology: > recovered message: > Removed vmmc-supply and vqmmc-supply in u-boot device tree to avoid hang on boot
+> X-Git-Archeology: > recovered message: > * Tidied up a bit device trees, in particular some modifications are made to power regulator properties comparing them against the original q8l device tree
+> X-Git-Archeology: > recovered message: > Removed unnecessary dummy regulator, removed unnecessary capacities to embedded eMMC
+> X-Git-Archeology: > recovered message: > Disabled unused USB host
+> X-Git-Archeology: > recovered message: > Removed vmmc-supply and vqmmc-supply from emmc section because it causes hang in u-boot v2018.03 and newer
+> X-Git-Archeology: > recovered message: > * Restored previous regulator in u-boot dts
+> X-Git-Archeology: > recovered message: > removed assert phy reset USB patch from rockchip-dev because of some upstream incompatible changes
+> X-Git-Archeology: > recovered message: > * Added patch to enable IRQ for Midgard drivers which caused massive slowdown on dev kernel
+> X-Git-Archeology: > recovered message: > Changed u-boot if-code for xt-q8l-v10 in rockchip.conf
+> X-Git-Archeology: > recovered message: > Removed references to rk3288-linux.dtsi in xt-q8l-v10 device tree for default kernel
+> X-Git-Archeology: > recovered message: > * Committing effective removal of USB reset assert for dev kernel
+> X-Git-Archeology: > recovered message: > Committing changes to u-boot device tree
+> X-Git-Archeology: > recovered message: > * Added patch to disable USB power down for rockchip devices broken on latest kernel
+> X-Git-Archeology: > recovered message: > * Removed usb dwc2 patch to reinject it from specific branch
+> X-Git-Archeology: > recovered message: > * Reverting some voltage changes for xt-q8l-v10 device in rockchip-dev
+> X-Git-Archeology: > recovered message: > * Reverting some voltage changes for xt-q8l-v10 in u-boot section
+> X-Git-Archeology: > recovered message: > * Added patch to make USB ports working again on rockchip devices with mainline
+> X-Git-Archeology: > recovered message: > kernel >= 4.18
+> X-Git-Archeology: > recovered message: > * Changed the 0 into false
+> X-Git-Archeology: > recovered message: > * Moved xt-q8l-v10 u-boot patches into board_xt-q8l-v10 directory
+> X-Git-Archeology: > recovered message: > * Changed some minor things in rockchip-dev dts for xt-q8l-v10, added mali midgard driver to dev kernel config
+> X-Git-Archeology: > recovered message: > * Added devfreq support for Mali in rockchip-next flavour
+> X-Git-Archeology: > recovered message: > * Remove manually applied patch (0007-drivers-drm...) because it has been
+> X-Git-Archeology: > recovered message: > added to armbian main repo
+> X-Git-Archeology: > recovered message: > * Removed duplicate patch which has added to main armbian repository
+> X-Git-Archeology: > recovered message: > * Tidied up regulators for default/next/dev rockchip flavours for xt-q8l-v10, disabling those regulators which are not tied to anything
+> X-Git-Archeology: > recovered message: > Enabled voltage regulator to make SPDIF connector work (thus not tested because I have no DAC)
+> X-Git-Archeology: > recovered message: > Changed rockchip-dev and rockchip-next config files to enable gpio-ir-receiver module to enable bundled remote IR controller, including kernel patch for keymap
+> X-Git-Archeology: > recovered message: > * Enabled back regulator REG7 to allow propert bluetooth functionaly
+> X-Git-Archeology: > recovered message: > * Minor changes to u-boot device tree for xt-q8l-v10
+> X-Git-Archeology: > recovered message: > Added patch to set act8846 SIPC to correctly reboot the device (thus require some power-hold at reboot to make reboot fully working)
+> X-Git-Archeology: > recovered message: > * Fixed u-boot device tree
+> X-Git-Archeology: > recovered message: > * Added configuration bits to support TPL in u-boot for xt-q8l-v10 (TPL is thrown away though) to allow faster reboot times and achieve a working reset feature activating power hold gpio pin as soon as possible. gpio pin is hardwired into spl_board_init() u-boot code because it is not possible to let it work via device tree
+> X-Git-Archeology: > recovered message: > Fixed OTG USB port in u-boot, allowing devices detection and booting
+> X-Git-Archeology: > recovered message: > Added proper vbus-supply properties for USB controllers in u-boot dts, so u-boot activates USB vbus itself
+> X-Git-Archeology: > recovered message: > * Fixed dts makefile patching for next and dev rockchip kernel
+> X-Git-Archeology: > recovered message: > * Fixed fdt_file renamed to fdtfile in armbianEnv.txt
+> X-Git-Archeology: > recovered message: > * Changed xt-q8l-v10 board config as per recomendations
+> X-Git-Archeology: > recovered message: > * Moved xt-q8l-v10 configuration to CSC
+> X-Git-Archeology: > recovered message: > Restored linux-rockchip-* configurations, enabled brcmfmac driver, GPIO remote controller driver and lirc kernel compatibility interface
+> X-Git-Archeology: > recovered message: > Polished a bit rockchip.conf
+> X-Git-Archeology: > recovered message: > * Add patch to brcmfmac driver to search for ap6330 firmware
+> X-Git-Archeology: > recovered message: > Removed copy-work from rockchip.conf about ap6330 firmware for xt-q8l-v10 and tidied up
+> X-Git-Archeology: > recovered message: > Avoid using brcm_patchram_plus in ap6330-bluetooth-service putting proper firmware file in /etc/firmware for hciattach do firmware uploading itself
+> X-Git-Archeology: > recovered message: > * Fixed bcm4330 bluetooth firmware linking for hciattach used by ap6330-bluetooth.service
+> X-Git-Archeology: > recovered message: > * Removed foreign test patches from xt-q8l-v10 u-boot directory
+> X-Git-Archeology: - Revision 60b4166a8a9efe74c76bf75246cd297ccf4cf7ca: https://github.com/armbian/build/commit/60b4166a8a9efe74c76bf75246cd297ccf4cf7ca
+> X-Git-Archeology:   Date: Thu, 22 Nov 2018 07:04:19 +0100
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: Add rk3288 xt-q8l-v10 CSC board (#1158)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision f4cce9754879f1d8e956b5ee7dc05b6d049f0e94: https://github.com/armbian/build/commit/f4cce9754879f1d8e956b5ee7dc05b6d049f0e94
+> X-Git-Archeology:   Date: Wed, 10 Jun 2020 20:35:52 +0200
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: [rk3288] Various fixes and enhancements for xt-q8l-v10 CSC board (#2013)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision de26797423e22d58ec2882d7032c67f77196ecc5: https://github.com/armbian/build/commit/de26797423e22d58ec2882d7032c67f77196ecc5
+> X-Git-Archeology:   Date: Sun, 06 Nov 2022 20:32:46 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Move all legacy u-boot patches under one general legacy folder (#4386)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 97c34489831f2146940f52915428263b7edfcbe1: https://github.com/armbian/build/commit/97c34489831f2146940f52915428263b7edfcbe1
+> X-Git-Archeology:   Date: Fri, 24 Mar 2023 23:13:42 +0100
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip: put all rockchip 32 bit into uboot/v2022.04 directory
+> X-Git-Archeology:
+---
+ arch/arm/dts/Makefile                                |  1 +
+ arch/arm/mach-rockchip/rk3288/Kconfig                | 12 ++++
+ board/rockchip/xt-q8l-v10_rk3288/Kconfig             | 15 +++++
+ board/rockchip/xt-q8l-v10_rk3288/MAINTAINERS         |  6 ++
+ board/rockchip/xt-q8l-v10_rk3288/Makefile            |  7 +++
+ board/rockchip/xt-q8l-v10_rk3288/xt-q8l-v10-rk3288.c | 21 +++++++
+ include/configs/xt-q8l-v10_rk3288.h                  | 28 ++++++++++
+ 7 files changed, 90 insertions(+)
+
 diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
-index 0127a91a..ae99b02a 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/dts/Makefile
 +++ b/arch/arm/dts/Makefile
-@@ -92,6 +92,7 @@ dtb-$(CONFIG_ROCKCHIP_RK3288) += \
- 	rk3288-rock2-square.dtb \
+@@ -109,6 +109,7 @@ dtb-$(CONFIG_ROCKCHIP_RK3288) += \
+ 	rk3288-rock-pi-n8.dtb \
  	rk3288-tinker.dtb \
  	rk3288-tinker-s.dtb \
 +	rk3288-xt-q8l-v10.dtb \
  	rk3288-veyron-jerry.dtb \
  	rk3288-veyron-mickey.dtb \
  	rk3288-veyron-minnie.dtb \
+diff --git a/arch/arm/mach-rockchip/rk3288/Kconfig b/arch/arm/mach-rockchip/rk3288/Kconfig
+index 111111111111..222222222222 100644
+--- a/arch/arm/mach-rockchip/rk3288/Kconfig
++++ b/arch/arm/mach-rockchip/rk3288/Kconfig
+@@ -134,6 +134,16 @@ config TARGET_TINKER_RK3288
+ 	  8GB eMMC and 2GB of SDRAM. Expansion connectors provide access to
+ 	  I2C, SPI, UART, GPIOs.
+ 
++config TARGET_XT_Q8L_V10_RK3288
++       bool "xt-q8l-v10 tvbox board"
++       select BOARD_LATE_INIT
++       select TPL
++       help
++         xt-q8l-v10 is a RK3288 common tv box with 3 USB ports (1 OTG), HDMI,
++         micro-SD card, Gigabit Ethernet and SPDIF output. It also includes on-board
++         8GB eMMC and 2GB of SDRAM, 802.11n Wifi and Bluetooth based upon AP6330
++         WiSoC.
++
+ endchoice
+ 
+ config ROCKCHIP_FAST_SPL
+@@ -196,4 +206,6 @@ source "board/rockchip/evb_rk3288/Kconfig"
+ 
+ source "board/rockchip/tinker_rk3288/Kconfig"
+ 
++source "board/rockchip/xt-q8l-v10_rk3288/Kconfig"
++
+ endif
 diff --git a/board/rockchip/xt-q8l-v10_rk3288/Kconfig b/board/rockchip/xt-q8l-v10_rk3288/Kconfig
-index e69de29..176abf0 100644
+new file mode 100644
+index 000000000000..111111111111
 --- /dev/null
 +++ b/board/rockchip/xt-q8l-v10_rk3288/Kconfig
 @@ -0,0 +1,15 @@
@@ -31,7 +199,8 @@ index e69de29..176abf0 100644
 +
 +endif
 diff --git a/board/rockchip/xt-q8l-v10_rk3288/MAINTAINERS b/board/rockchip/xt-q8l-v10_rk3288/MAINTAINERS
-index e69de29..9a3ad97 100644
+new file mode 100644
+index 000000000000..111111111111
 --- /dev/null
 +++ b/board/rockchip/xt-q8l-v10_rk3288/MAINTAINERS
 @@ -0,0 +1,6 @@
@@ -42,7 +211,8 @@ index e69de29..9a3ad97 100644
 +F:	include/configs/xt-q8l-v10_rk3288.h
 +F:	configs/xt-q8l-v10-rk3288_defconfig
 diff --git a/board/rockchip/xt-q8l-v10_rk3288/Makefile b/board/rockchip/xt-q8l-v10_rk3288/Makefile
-index e69de29..852c910 100644
+new file mode 100644
+index 000000000000..111111111111
 --- /dev/null
 +++ b/board/rockchip/xt-q8l-v10_rk3288/Makefile
 @@ -0,0 +1,7 @@
@@ -53,37 +223,9 @@ index e69de29..852c910 100644
 +#
 +
 +obj-y	+= xt-q8l-v10-rk3288.o
-diff --git a/arch/arm/mach-rockchip/rk3288/Kconfig b/arch/arm/mach-rockchip/rk3288/Kconfig
-index afb62fca..187a75ba 100644
---- a/arch/arm/mach-rockchip/rk3288/Kconfig
-+++ b/arch/arm/mach-rockchip/rk3288/Kconfig
-@@ -131,6 +131,16 @@ config TARGET_TINKER_RK3288
- 	  8GB eMMC and 2GB of SDRAM. Expansion connectors provide access to
- 	  I2C, SPI, UART, GPIOs.
- 
-+config TARGET_XT_Q8L_V10_RK3288
-+       bool "xt-q8l-v10 tvbox board"
-+       select BOARD_LATE_INIT
-+       select TPL
-+       help
-+         xt-q8l-v10 is a RK3288 common tv box with 3 USB ports (1 OTG), HDMI,
-+         micro-SD card, Gigabit Ethernet and SPDIF output. It also includes on-board
-+         8GB eMMC and 2GB of SDRAM, 802.11n Wifi and Bluetooth based upon AP6330
-+         WiSoC.
-+
- endchoice
- 
- config ROCKCHIP_FAST_SPL
-@@ -193,4 +203,6 @@ source "board/rockchip/evb_rk3288/Kconfig"
- 
- source "board/rockchip/tinker_rk3288/Kconfig"
- 
-+source "board/rockchip/xt-q8l-v10_rk3288/Kconfig"
-+
- endif
 diff --git a/board/rockchip/xt-q8l-v10_rk3288/xt-q8l-v10-rk3288.c b/board/rockchip/xt-q8l-v10_rk3288/xt-q8l-v10-rk3288.c
 new file mode 100644
-index 00000000..f0f618a5
+index 000000000000..111111111111
 --- /dev/null
 +++ b/board/rockchip/xt-q8l-v10_rk3288/xt-q8l-v10-rk3288.c
 @@ -0,0 +1,21 @@
@@ -110,7 +252,7 @@ index 00000000..f0f618a5
 +
 diff --git a/include/configs/xt-q8l-v10_rk3288.h b/include/configs/xt-q8l-v10_rk3288.h
 new file mode 100644
-index 00000000..1211875a
+index 000000000000..111111111111
 --- /dev/null
 +++ b/include/configs/xt-q8l-v10_rk3288.h
 @@ -0,0 +1,28 @@
@@ -142,3 +284,6 @@ index 00000000..1211875a
 +#define CONFIG_SYS_MMC_ENV_DEV 0
 +
 +#endif
+-- 
+Armbian
+

--- a/patch/u-boot/v2022.04/board_xt-q8l-v10/xt-q8l-v10-device-tree.patch
+++ b/patch/u-boot/v2022.04/board_xt-q8l-v10/xt-q8l-v10-device-tree.patch
@@ -1,6 +1,174 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paolo <paolo.sabatino@gmail.com>
+Date: Thu, 22 Nov 2018 07:04:19 +0100
+Subject: [ARCHEOLOGY] Add rk3288 xt-q8l-v10 CSC board (#1158)
+
+> X-Git-Archeology: > recovered message: > This merge request contains various files which add support for xt-q8l-v10 boards (TVBox) equipped with Rockchip RK3288 SoC, AP6330 WiSoC (BCM4330 WiFi + Bluetooth), 2 GB DRAM (LPDDR2 or DDR3), 8 Gb eMMC, Gigabit Ethernet, 3 USB (1 OTG), 1 microSD slot, SPDIF optical output, 1 HDMI.
+> X-Git-Archeology: > recovered message: > Kernel patches:
+> X-Git-Archeology: > recovered message: > This thouches all three linux-rockchip-* kernelconfigs, just adds brcmfmac and brcmutil modules and remote controller support. default flavor activates rockchip own remote controller driver, next and dev use the mainline GPIO CIR driver (dev has lirc userland support activated too).
+> X-Git-Archeology: > recovered message: > About the remote controller, an additional kernel module is added to the existing keymaps which is activated via device tree.
+> X-Git-Archeology: > recovered message: > About possibly clashing patches assert-phy-reset-when-waking-up-in-rk3288-platform.patch should be checked against other rk3288 boards because it addresses an errata in rk3288 which causes the USB Host ports to stop responding when exiting from autosleep. On my device if I connect the first USB device when the system is already running, the USB Host gets stuck without this patch. Probably to work correctly on other platforms the device tree should include the proper reset lines of the USB PHYs (for reference, check patch/kernel/rockchip-dev/xt-q8l-v10-add-device-tree.patch starting from line 869).
+> X-Git-Archeology: > recovered message: > Patch 1-2-regulator-act8865-add-restart-handler-for-act8846.patch adds a restart handler which allows reboot using SIPC bit on act8846 power regulator. Possibly MiQi board is affected (is reboot working there?), others (tinkerboard) should not care.
+> X-Git-Archeology: > recovered message: > Patch brcmfmac-add-ap6330-firmware.patch adds firmware file names for ap6330 , should be harmless in other cases.
+> X-Git-Archeology: > recovered message: > Patch 0010-GPU-Mali-Midgard-remove-rcu_read_lock-references.patch is from Miouyouyou. It should be harmless, it was suggested by him to do some tests with devfreq
+> X-Git-Archeology: > recovered message: > Other patches just add the proper device trees, Kconfig and bits for supporting the board as a regular kernel supported board and should not interfere with anything else
+> X-Git-Archeology: > recovered message: > U-Boot patches:
+> X-Git-Archeology: > recovered message: > All the patches for u-boot are per-board, so nothing is added which may interfere with other existing boards here. They include the device tree and u-boot config and also a couple of patches to support the silergy power regulators driving current to CPU and GPU
+> X-Git-Archeology: > recovered message: > * Initial commit to provide kernel and u-boot configuration and device trees for xt-q8-v10 as patches
+> X-Git-Archeology: > recovered message: > Modification to rockchip config to add initialization bits for xt-q8-v10
+> X-Git-Archeology: > recovered message: > * Committing correct path for rk3288_ddr_400Mhz... rockchip blob, moved assembling into another section to produce
+> X-Git-Archeology: > recovered message: > immediately an u-boot working binary
+> X-Git-Archeology: > recovered message: > * Enabled broadcom fmac driver in rockchip-next config
+> X-Git-Archeology: > recovered message: > * Changed name definition of rk3288-xt-q8-v10 board to "TVBox"
+> X-Git-Archeology: > recovered message: > Added bits to include support AP6330 and binary firmwares into the final image
+> X-Git-Archeology: > recovered message: > * Fixed device tree file name in related patch, added patching of Makefile to produce the device tree binary accordingly
+> X-Git-Archeology: > recovered message: > * Fixed xt-q8-v10 device tree patch
+> X-Git-Archeology: > recovered message: > Added brcmfmac driver to rockchip dev and default kernel configs
+> X-Git-Archeology: > recovered message: > * Syncing with upstream
+> X-Git-Archeology: > recovered message: > * Splitted add-xt-q8... kernel patches into two separate patches
+> X-Git-Archeology: > recovered message: > * Fixed bad extension while adding dtb in makefile for rockchip-default configuration
+> X-Git-Archeology: > recovered message: > Updated device tree patches for all rockchip confs
+> X-Git-Archeology: > recovered message: > * Enable mmc0 and usb in u-boot config
+> X-Git-Archeology: > recovered message: > Fixed again makefile patch for kernel next
+> X-Git-Archeology: > recovered message: > * Adding patches to reset the USB phy when kernel requires a reset, fixes autosuspend issue
+> X-Git-Archeology: > recovered message: > * Changed xt-q8-v10 to proper xt-q8l-v10 in every string and every filename
+> X-Git-Archeology: > recovered message: > Added power hold to u-boot, so now the device will boot and stay turned on without the need for the OTG cable anymore
+> X-Git-Archeology: > recovered message: > * Changed names from 'Q8' to proper 'XT-Q8L-V10' in device tree patch files
+> X-Git-Archeology: > recovered message: > * Legacy kernel device tree:
+> X-Git-Archeology: > recovered message: > Fixed bluetooth gpio pin clashing
+> X-Git-Archeology: > recovered message: > Fixed HDMI gpio pin clashing
+> X-Git-Archeology: > recovered message: > Added support for PWM-based IR-Receiver, added driver in kernel default config too
+> X-Git-Archeology: > recovered message: > Various other fixes to avoid some complaints from the kernel
+> X-Git-Archeology: > recovered message: > * Added booting bluetooth systemd service for AP6330 (xt-q8l-v10) that loads patchram and invokes hciattach
+> X-Git-Archeology: > recovered message: > Minor fixes to -next and -dev device trees for xt-q8l-v10
+> X-Git-Archeology: > recovered message: > * Disabled OTG USB port in u-boot due to long timeout during initialization
+> X-Git-Archeology: > recovered message: > Fixed warning during u-boot dts compilation
+> X-Git-Archeology: > recovered message: > Added emmc as second boot device in dts
+> X-Git-Archeology: > recovered message: > * Adding myself to licensing
+> X-Git-Archeology: > recovered message: > * Committing modifications to device trees
+> X-Git-Archeology: > recovered message: > * Fixed dmac_bus_s explicitly set to unused dmac, restored right dmac in xt-q8l-v10 dts only
+> X-Git-Archeology: > recovered message: > Change PLL_CPLL frequency in device tree to 408 Mhz to avoid fractional divisor warnings
+> X-Git-Archeology: > recovered message: > * Added proper xt-q8l-v10_rk3288 configuration to u-boot, now appearing in config menu and
+> X-Git-Archeology: > recovered message: > correctly selectable as a real target
+> X-Git-Archeology: > recovered message: > Fixed typo in device tree from rockchip
+> X-Git-Archeology: > recovered message: > * Fixed missing semicolon in device tree for default configuration
+> X-Git-Archeology: > recovered message: > Fixed patch files for u-boot appending themselves to files on each compilation
+> X-Git-Archeology: > recovered message: > * Added bits to enable power to USB ports in u-boot, thus enabling booting from USB devices (only USB host port for now)
+> X-Git-Archeology: > recovered message: > * Changed u-boot binary creation using the rockchip SPL properly
+> X-Git-Archeology: > recovered message: > * Added boot order for xt-q8l-v10: sdcard, usb0, eMMC, network
+> X-Git-Archeology: > recovered message: > * Added bionic:next in beta config for xt-q8l-v10 board
+> X-Git-Archeology: > recovered message: > * Changed some minor bits in xt-q8l-v10 device tree files, added missing bits to dev flavour
+> X-Git-Archeology: > recovered message: > Added patches to introduce fairchild fan53555/silergy82x regulators to u-boot and enabled in xt-q8l-v10 device tree
+> X-Git-Archeology: > recovered message: > * Updated u-boot to version v2018.03 for xt-q8l-v10. Other rk3288 boards will gain v2018.05 from main armbian fork
+> X-Git-Archeology: > recovered message: > Removed pre-reloc labels in u-boot device tree because they are not necessary since we don't use u-boot SPL for xt-q8l-v10
+> X-Git-Archeology: > recovered message: > Removed vmmc-supply and vqmmc-supply in u-boot device tree to avoid hang on boot
+> X-Git-Archeology: > recovered message: > * Tidied up a bit device trees, in particular some modifications are made to power regulator properties comparing them against the original q8l device tree
+> X-Git-Archeology: > recovered message: > Removed unnecessary dummy regulator, removed unnecessary capacities to embedded eMMC
+> X-Git-Archeology: > recovered message: > Disabled unused USB host
+> X-Git-Archeology: > recovered message: > Removed vmmc-supply and vqmmc-supply from emmc section because it causes hang in u-boot v2018.03 and newer
+> X-Git-Archeology: > recovered message: > * Restored previous regulator in u-boot dts
+> X-Git-Archeology: > recovered message: > removed assert phy reset USB patch from rockchip-dev because of some upstream incompatible changes
+> X-Git-Archeology: > recovered message: > * Added patch to enable IRQ for Midgard drivers which caused massive slowdown on dev kernel
+> X-Git-Archeology: > recovered message: > Changed u-boot if-code for xt-q8l-v10 in rockchip.conf
+> X-Git-Archeology: > recovered message: > Removed references to rk3288-linux.dtsi in xt-q8l-v10 device tree for default kernel
+> X-Git-Archeology: > recovered message: > * Committing effective removal of USB reset assert for dev kernel
+> X-Git-Archeology: > recovered message: > Committing changes to u-boot device tree
+> X-Git-Archeology: > recovered message: > * Added patch to disable USB power down for rockchip devices broken on latest kernel
+> X-Git-Archeology: > recovered message: > * Removed usb dwc2 patch to reinject it from specific branch
+> X-Git-Archeology: > recovered message: > * Reverting some voltage changes for xt-q8l-v10 device in rockchip-dev
+> X-Git-Archeology: > recovered message: > * Reverting some voltage changes for xt-q8l-v10 in u-boot section
+> X-Git-Archeology: > recovered message: > * Added patch to make USB ports working again on rockchip devices with mainline
+> X-Git-Archeology: > recovered message: > kernel >= 4.18
+> X-Git-Archeology: > recovered message: > * Changed the 0 into false
+> X-Git-Archeology: > recovered message: > * Moved xt-q8l-v10 u-boot patches into board_xt-q8l-v10 directory
+> X-Git-Archeology: > recovered message: > * Changed some minor things in rockchip-dev dts for xt-q8l-v10, added mali midgard driver to dev kernel config
+> X-Git-Archeology: > recovered message: > * Added devfreq support for Mali in rockchip-next flavour
+> X-Git-Archeology: > recovered message: > * Remove manually applied patch (0007-drivers-drm...) because it has been
+> X-Git-Archeology: > recovered message: > added to armbian main repo
+> X-Git-Archeology: > recovered message: > * Removed duplicate patch which has added to main armbian repository
+> X-Git-Archeology: > recovered message: > * Tidied up regulators for default/next/dev rockchip flavours for xt-q8l-v10, disabling those regulators which are not tied to anything
+> X-Git-Archeology: > recovered message: > Enabled voltage regulator to make SPDIF connector work (thus not tested because I have no DAC)
+> X-Git-Archeology: > recovered message: > Changed rockchip-dev and rockchip-next config files to enable gpio-ir-receiver module to enable bundled remote IR controller, including kernel patch for keymap
+> X-Git-Archeology: > recovered message: > * Enabled back regulator REG7 to allow propert bluetooth functionaly
+> X-Git-Archeology: > recovered message: > * Minor changes to u-boot device tree for xt-q8l-v10
+> X-Git-Archeology: > recovered message: > Added patch to set act8846 SIPC to correctly reboot the device (thus require some power-hold at reboot to make reboot fully working)
+> X-Git-Archeology: > recovered message: > * Fixed u-boot device tree
+> X-Git-Archeology: > recovered message: > * Added configuration bits to support TPL in u-boot for xt-q8l-v10 (TPL is thrown away though) to allow faster reboot times and achieve a working reset feature activating power hold gpio pin as soon as possible. gpio pin is hardwired into spl_board_init() u-boot code because it is not possible to let it work via device tree
+> X-Git-Archeology: > recovered message: > Fixed OTG USB port in u-boot, allowing devices detection and booting
+> X-Git-Archeology: > recovered message: > Added proper vbus-supply properties for USB controllers in u-boot dts, so u-boot activates USB vbus itself
+> X-Git-Archeology: > recovered message: > * Fixed dts makefile patching for next and dev rockchip kernel
+> X-Git-Archeology: > recovered message: > * Fixed fdt_file renamed to fdtfile in armbianEnv.txt
+> X-Git-Archeology: > recovered message: > * Changed xt-q8l-v10 board config as per recomendations
+> X-Git-Archeology: > recovered message: > * Moved xt-q8l-v10 configuration to CSC
+> X-Git-Archeology: > recovered message: > Restored linux-rockchip-* configurations, enabled brcmfmac driver, GPIO remote controller driver and lirc kernel compatibility interface
+> X-Git-Archeology: > recovered message: > Polished a bit rockchip.conf
+> X-Git-Archeology: > recovered message: > * Add patch to brcmfmac driver to search for ap6330 firmware
+> X-Git-Archeology: > recovered message: > Removed copy-work from rockchip.conf about ap6330 firmware for xt-q8l-v10 and tidied up
+> X-Git-Archeology: > recovered message: > Avoid using brcm_patchram_plus in ap6330-bluetooth-service putting proper firmware file in /etc/firmware for hciattach do firmware uploading itself
+> X-Git-Archeology: > recovered message: > * Fixed bcm4330 bluetooth firmware linking for hciattach used by ap6330-bluetooth.service
+> X-Git-Archeology: > recovered message: > * Removed foreign test patches from xt-q8l-v10 u-boot directory
+> X-Git-Archeology: - Revision 60b4166a8a9efe74c76bf75246cd297ccf4cf7ca: https://github.com/armbian/build/commit/60b4166a8a9efe74c76bf75246cd297ccf4cf7ca
+> X-Git-Archeology:   Date: Thu, 22 Nov 2018 07:04:19 +0100
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: Add rk3288 xt-q8l-v10 CSC board (#1158)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 88467bad9d53a0cca1e0a6c0d19f8113df5841aa: https://github.com/armbian/build/commit/88467bad9d53a0cca1e0a6c0d19f8113df5841aa
+> X-Git-Archeology:   Date: Fri, 30 Nov 2018 11:16:50 +0000
+> X-Git-Archeology:   From: paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: Modified xt-q8l-v10 device tree patches to properly source from /dev/null
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 43383c4e2455e51985a89b61230f722c7ba351ec: https://github.com/armbian/build/commit/43383c4e2455e51985a89b61230f722c7ba351ec
+> X-Git-Archeology:   Date: Thu, 06 Dec 2018 21:58:33 +0000
+> X-Git-Archeology:   From: paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: Changed minor bits in xt-q8l-v10 device tree patch for dev flavour
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 76de54fb38cecb25a7c44f1d544573ed62e01cf8: https://github.com/armbian/build/commit/76de54fb38cecb25a7c44f1d544573ed62e01cf8
+> X-Git-Archeology:   Date: Fri, 14 Dec 2018 12:16:26 +0000
+> X-Git-Archeology:   From: paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: Changed minor bits in xt-q8l-v10 device tree patch for dev flavour
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision a818f64885b33e68b732465d774547e94cc4a904: https://github.com/armbian/build/commit/a818f64885b33e68b732465d774547e94cc4a904
+> X-Git-Archeology:   Date: Sat, 15 Dec 2018 10:43:59 +0000
+> X-Git-Archeology:   From: paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: Changed minor bits in xt-q8l-v10 device tree patch for dev flavour
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 868d7390fcf66a7883e0ff4fdea6310ca3b282af: https://github.com/armbian/build/commit/868d7390fcf66a7883e0ff4fdea6310ca3b282af
+> X-Git-Archeology:   Date: Sat, 15 Dec 2018 10:44:00 +0000
+> X-Git-Archeology:   From: paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: Disabled dma for serial ports in xt-q8l-v10 dev kernel device tree due to changes in kernel 4.19
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision f82001666bef3a4fa3da78b7527d726c9b9b13d7: https://github.com/armbian/build/commit/f82001666bef3a4fa3da78b7527d726c9b9b13d7
+> X-Git-Archeology:   Date: Sat, 31 Aug 2019 22:02:25 +0200
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: [xt-q8l-v10] Updates for CSC board (#1539)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision f4cce9754879f1d8e956b5ee7dc05b6d049f0e94: https://github.com/armbian/build/commit/f4cce9754879f1d8e956b5ee7dc05b6d049f0e94
+> X-Git-Archeology:   Date: Wed, 10 Jun 2020 20:35:52 +0200
+> X-Git-Archeology:   From: Paolo <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: [rk3288] Various fixes and enhancements for xt-q8l-v10 CSC board (#2013)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 2dbdae284585eae321cb307afb75a9b70ed660b8: https://github.com/armbian/build/commit/2dbdae284585eae321cb307afb75a9b70ed660b8
+> X-Git-Archeology:   Date: Mon, 05 Apr 2021 13:53:08 +0000
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: xt-q8l-v10: bump to u-boot v2021.01
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision de26797423e22d58ec2882d7032c67f77196ecc5: https://github.com/armbian/build/commit/de26797423e22d58ec2882d7032c67f77196ecc5
+> X-Git-Archeology:   Date: Sun, 06 Nov 2022 20:32:46 +0100
+> X-Git-Archeology:   From: Igor Pecovnik <igorpecovnik@users.noreply.github.com>
+> X-Git-Archeology:   Subject: Move all legacy u-boot patches under one general legacy folder (#4386)
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 97c34489831f2146940f52915428263b7edfcbe1: https://github.com/armbian/build/commit/97c34489831f2146940f52915428263b7edfcbe1
+> X-Git-Archeology:   Date: Fri, 24 Mar 2023 23:13:42 +0100
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip: put all rockchip 32 bit into uboot/v2022.04 directory
+> X-Git-Archeology:
+---
+ arch/arm/dts/rk3288-xt-q8l-v10.dts | 749 ++++++++++
+ 1 file changed, 749 insertions(+)
+
 diff --git a/arch/arm/dts/rk3288-xt-q8l-v10.dts b/arch/arm/dts/rk3288-xt-q8l-v10.dts
 new file mode 100755
-index 00000000..be7a0806
+index 000000000000..111111111111
 --- /dev/null
 +++ b/arch/arm/dts/rk3288-xt-q8l-v10.dts
 @@ -0,0 +1,749 @@
@@ -753,3 +921,6 @@ index 00000000..be7a0806
 +	u-boot,dm-spl;
 +};
 +
+-- 
+Armbian
+

--- a/patch/u-boot/v2022.04/dwc2-usb-otg-fix.patch
+++ b/patch/u-boot/v2022.04/dwc2-usb-otg-fix.patch
@@ -1,8 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Fri, 12 Mar 2021 20:20:12 +0000
+Subject: [ARCHEOLOGY] Changes and fixes to rk322x uboot and kernel config
+
+> X-Git-Archeology: > recovered message: > - Enabled nfc on rk322x-dev and disable on rk322x-current (need further development)
+> X-Git-Archeology: > recovered message: > - Tidied up rk322x-current device tree
+> X-Git-Archeology: > recovered message: > - enabled nfc rockchip driver enabled in rk322x-dev kernel config
+> X-Git-Archeology: > recovered message: > - Enabled EHCI controller in u-boot (added patch for inno-phy, device tree and config bits), better device detection for dwc2 usb otg port
+> X-Git-Archeology: > recovered message: > - Removed SPL_FIT_GENERATOR from u-boot configuration, fixed .its file to use binman
+> X-Git-Archeology: > recovered message: > - fixed rk322x its file (now includes dtb), reverted u-boot to v2020.10 and changed dev_* into log_debug() calls
+> X-Git-Archeology: - Revision 95425c27b9d3bbb96e7936cc531638c9150538f9: https://github.com/armbian/build/commit/95425c27b9d3bbb96e7936cc531638c9150538f9
+> X-Git-Archeology:   Date: Fri, 12 Mar 2021 20:20:12 +0000
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: Changes and fixes to rk322x uboot and kernel config
+> X-Git-Archeology:
+> X-Git-Archeology: - Revision 97c34489831f2146940f52915428263b7edfcbe1: https://github.com/armbian/build/commit/97c34489831f2146940f52915428263b7edfcbe1
+> X-Git-Archeology:   Date: Fri, 24 Mar 2023 23:13:42 +0100
+> X-Git-Archeology:   From: Paolo Sabatino <paolo.sabatino@gmail.com>
+> X-Git-Archeology:   Subject: rockchip: put all rockchip 32 bit into uboot/v2022.04 directory
+> X-Git-Archeology:
+---
+ drivers/usb/host/dwc2.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
 diff --git a/drivers/usb/host/dwc2.c b/drivers/usb/host/dwc2.c
-index cefe9d83..f7288203 100644
+index 111111111111..222222222222 100644
 --- a/drivers/usb/host/dwc2.c
 +++ b/drivers/usb/host/dwc2.c
-@@ -440,6 +440,8 @@ static void dwc_otg_core_init(struct dwc2_priv *priv)
+@@ -445,6 +445,8 @@ static void dwc_otg_core_init(struct udevice *dev)
  
  	writel(usbcfg, &regs->gusbcfg);
  
@@ -11,3 +36,6 @@ index cefe9d83..f7288203 100644
  	/* Program the GAHBCFG Register. */
  	switch (readl(&regs->ghwcfg2) & DWC2_HWCFG2_ARCHITECTURE_MASK) {
  	case DWC2_HWCFG2_ARCHITECTURE_SLAVE_ONLY:
+-- 
+Armbian
+


### PR DESCRIPTION
#### u-boot: add HOME env for make invocations to avoid binman/Python problems with older u-boot versions

- tinkerboard: rewrite u-boot patches, no changes
- xt-q8l-v10: rewrite u-boot patches, no changes
- u-boot: add HOME env for make invocations to avoid binman/Python problems with older u-boot versions
  - this avoids trouble building certain older versions with binman
    - as it tries to `os.path.join(os.getenv('HOME'), 'bin')` and gets a `None` and dies
  - naming names: `tinkerboard` & `xt-q8l-v10` (BOARDFAMILY=rockchip), which _actually use_ binman & 22.04 combo