### PR TITLE
Fix btrfs and xfs resize

### DIFF
--- a/extensions/fs-btrfs-support.sh
+++ b/extensions/fs-btrfs-support.sh
@@ -2,6 +2,11 @@
 # Enable this extension to include the required dependencies for building.
 # This is automatically enabled if ROOTFS_TYPE is set to btrfs in main-config.sh.
 
+function extension_prepare_config__add_to_image_btrfs-progs() {
+	display_alert "Adding btrfs-progs extra package..." "${EXTENSION}" "info"
+	add_packages_to_image btrfs-progs
+}
+
 function add_host_dependencies__add_btrfs_tooling() {
 	display_alert "Adding BTRFS to host dependencies" "BTRFS" "debug"
 	EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} btrfs-progs" # @TODO: convert to array later

--- a/extensions/fs-xfs-support.sh
+++ b/extensions/fs-xfs-support.sh
@@ -2,6 +2,11 @@
 # Enable this extension to include the required dependencies for building.
 # This is automatically enabled if ROOTFS_TYPE is set to xfs in main-config.sh.
 
+function extension_prepare_config__add_to_image_xfsprogs() {
+	display_alert "Adding xfsprogs extra package..." "${EXTENSION}" "info"
+	add_packages_to_image xfsprogs
+}
+
 function add_host_dependencies__add_xfs_tooling() {
 	display_alert "Adding XFS to host dependencies" "XFS xfsprogs" "debug"
 	EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} xfsprogs" # @TODO: convert to array later

--- a/packages/bsp/common/usr/lib/armbian/armbian-resize-filesystem
+++ b/packages/bsp/common/usr/lib/armbian/armbian-resize-filesystem
@@ -217,12 +217,16 @@ do_expand_filesystem()
 			echo "Running 'resize2fs $partdev' now..."
 			resize2fs $partdev
 			;;
+		xfs)
+			echo "Running 'xfs_growfs $mountpoint' now..."
+			xfs_growfs $mountpoint
+			;;
 		btrfs)
 			echo "Running 'btrfs filesystem resize max $mountpoint' now..."
 			btrfs filesystem resize max $mountpoint
 			;;
 		nilfs2)
-			echo "Running 'nilfs2 filesystem resize max $mountpoint' now..."
+			echo "Running 'nilfs-resize -v -y $partdev' now..."
 			nilfs-resize -v -y $partdev
 			;;
 		*)


### PR DESCRIPTION
# Description

Auto resize rootfs don't work if build image with:
ROOTFS_TYPE=btrfs
ROOTFS_TYPE=xfs

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] Build image, flash, check rootfs resized

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
