### PR TITLE
fix: firefly-itx-3588j fails to boot, and audio output

### DIFF
--- a/config/boards/firefly-itx-3588j.csc
+++ b/config/boards/firefly-itx-3588j.csc
@@ -24,8 +24,17 @@ function post_family_tweaks_bsp__firefly_itx_3588j() {
 	return 0
 }
 
+function post_family_tweaks__firefly_itx_3588j_naming_audios() {
+	display_alert "$BOARD" "Renaming firefly-itx-3588j audios" "info"
+	mkdir -p $SDCARD/etc/udev/rules.d/
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-hdmi0-sound", ENV{SOUND_DESCRIPTION}="HDMI0 Audio"' > $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+	return 0
+}
+
 function post_family_tweaks__firefly_itx_3588j_enable_services() {
 	display_alert "$BOARD" "Enabling rk3588-bluetooth.service" "info"
 	chroot_sdcard systemctl enable rk3588-bluetooth.service
 	return 0
 }
+
+

--- a/patch/u-boot/legacy/u-boot-radxa-rk3588/board_firefly-itx-3588j/board-firefly-itx-3588j-disable-optee-security.patch
+++ b/patch/u-boot/legacy/u-boot-radxa-rk3588/board_firefly-itx-3588j/board-firefly-itx-3588j-disable-optee-security.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: None <None>
+Date: Tue, 2 Jul 2024 21:37:46 +0000
+Subject: disable always use security partition avoid not booting
+
+---
+ configs/rk3588_defconfig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configs/rk3588_defconfig b/configs/rk3588_defconfig
+index 111111111111..222222222222 100644
+--- a/configs/rk3588_defconfig
++++ b/configs/rk3588_defconfig
+@@ -233,4 +233,4 @@ CONFIG_AVB_LIBAVB_USER=y
+ CONFIG_RK_AVB_LIBAVB_USER=y
+ CONFIG_OPTEE_CLIENT=y
+ CONFIG_OPTEE_V2=y
+-CONFIG_OPTEE_ALWAYS_USE_SECURITY_PARTITION=y
++CONFIG_OPTEE_ALWAYS_USE_SECURITY_PARTITION=n
+-- 
+Armbian
+


### PR DESCRIPTION
# Description

Change to mainline uboot, fixed not booting issue, added hdmi0 audio interface alias.

# How Has This Been Tested?

- [x] `./compile.sh build BOARD=firefly-itx-3588j BRANCH=vendor BUILD_DESKTOP=yes BUILD_MINIMAL=no DESKTOP_APPGROUPS_SELECTED='browsers internet' DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base KERNEL_CONFIGURE=no RELEASE=bookworm`
- [x] 
![image](https://github.com/armbian/build/assets/166212217/781c5e96-b2d3-4600-a669-f17441e3aebe)


# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
