### PR TITLE
Fix: firefly-itx-3588j: Use mainline u-boot and rename audio output

### DIFF
--- a/config/boards/firefly-itx-3588j.csc
+++ b/config/boards/firefly-itx-3588j.csc
@@ -36,3 +36,25 @@ function post_family_tweaks__firefly_itx_3588j_enable_services() {
 	chroot_sdcard systemctl enable rk3588-bluetooth.service
 	return 0
 }
+
+# Mainline U-Boot
+function post_family_config__firefly_itx_3588j_use_mainline_uboot() {
+	display_alert "$BOARD" "Using mainline U-Boot for $BOARD / $BRANCH" "info"
+
+	declare -g BOOTCONFIG="generic-rk3588_defconfig"             # Use generic defconfig which should boot all RK3588 boards
+	declare -g BOOTDELAY=1                                       # Wait for UART interrupt to enter UMS/RockUSB mode etc
+	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git" # We ❤️ Mainline U-Boot
+	declare -g BOOTBRANCH="tag:v2024.07-rc5"
+	declare -g BOOTPATCHDIR="v2024.07/board_${BOARD}"
+	# Don't set BOOTDIR, allow shared U-Boot source directory for disk space efficiency
+
+	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin"
+
+	# Disable stuff from rockchip64_common; we're using binman here which does all the work already
+	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd
+
+	# Just use the binman-provided u-boot-rockchip.bin, which is ready-to-go
+	function write_uboot_platform() {
+		dd "if=$1/u-boot-rockchip.bin" "of=$2" bs=32k seek=1 conv=notrunc status=none
+	}
+}


### PR DESCRIPTION
# Description

Helping @SeeleVolleri from: https://github.com/armbian/build/pull/6849

The default 2017.09 u-boot for rk3588 doesn't seem to work on this board with the generic config. Try mainline u-boot.

Reference: https://github.com/armbian/build/pull/6834#issuecomment-2198765229

@SeeleVolleri Please test if this works :) You can edit this message to add your tests as well.

# How Has This Been Tested?

- [ ] Test A

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
