### PR TITLE
rk35xx-vendor: bump to latest sdk release rkr3

### DIFF
--- a/config/sources/families/rk35xx.conf
+++ b/config/sources/families/rk35xx.conf
@@ -31,7 +31,7 @@ case $BRANCH in
 		declare -g KERNEL_MAJOR_MINOR="6.1"    # Major and minor versions of this kernel.
 		declare -g -i KERNEL_GIT_CACHE_TTL=120 # 2 minutes; this is a high-traffic repo
 		KERNELSOURCE='https://github.com/armbian/linux-rockchip.git'
-		KERNELBRANCH='branch:rk-6.1-rkr1'
+		KERNELBRANCH='branch:rk-6.1-rkr3'
 		KERNELPATCHDIR='rk35xx-vendor-6.1'
 		;;
 esac

--- a/config/sources/families/rockchip-rk3588.conf
+++ b/config/sources/families/rockchip-rk3588.conf
@@ -34,7 +34,7 @@ case $BRANCH in
 		declare -g KERNEL_MAJOR_MINOR="6.1"    # Major and minor versions of this kernel.
 		declare -g -i KERNEL_GIT_CACHE_TTL=120 # 2 minutes; this is a high-traffic repo
 		KERNELSOURCE='https://github.com/armbian/linux-rockchip.git'
-		KERNELBRANCH='branch:rk-6.1-rkr1'
+		KERNELBRANCH='branch:rk-6.1-rkr3'
 		KERNELPATCHDIR='rk35xx-vendor-6.1'
 		LINUXFAMILY=rk35xx
 		;;

--- a/patch/kernel/rk35xx-vendor-6.1/0000.patching_config.yaml
+++ b/patch/kernel/rk35xx-vendor-6.1/0000.patching_config.yaml
@@ -4,8 +4,8 @@ config:
   name: rk35xx-6.1
   kind: kernel
   type: vendor # or: vendor
-  branch: rk-6.1-rkr1
-  last-known-good-tag: v6.1.43
+  branch: rk-6.1-rkr3
+  last-known-good-tag: v6.1.75
 
   # .dts files in these directories will be copied as-is to the build tree; later ones overwrite earlier ones.
   # This is meant to provide a way to "add a board DTS" without having to null-patch them in.


### PR DESCRIPTION
# Description

Rockchip has released new sdk with rk3576 support and kernel's tag is `linux-6.1-stan-rkr3`.
I have rebased commits from rkr1 to rkr3 and this pr depends on https://github.com/armbian/linux-rockchip/pull/200.
Prebuilt kernel can get downloaded from github actions: https://github.com/armbian/linux-rockchip/actions/runs/9740746614?pr=200

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh BOARD=rock-5b BRANCH=vendor DEB_COMPRESS=xz KERNEL_CONFIGURE=no KERNEL_GIT=shallow`
- [x] Kernel boots fine on rock5b.
- [ ] rk356x boards need test
- [ ] rk3528 boads need test
- [ ] Other rk3588 boards need test

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
