### PR TITLE
improve fs-cryptroot-support.sh

### DIFF
--- a/extensions/fs-cryptroot-support.sh
+++ b/extensions/fs-cryptroot-support.sh
@@ -47,7 +47,7 @@ function pre_install_kernel_debs__adjust_dropbear_configuration() {
 		# Set the port of the dropbear ssh daemon in the initramfs to a different one if configured
 		# this avoids the typical 'host key changed warning' - `WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!`
 		[[ -f "${dropbear_dir}/${dropbear_config}" ]] &&
-			sed -i "s/^#DROPBEAR_OPTIONS=.*/DROPBEAR_OPTIONS=\"-I 10 -j -k -p "${CRYPTROOT_SSH_UNLOCK_PORT}" -s -c cryptroot-unlock\"/" \
+			sed -i "s/^#DROPBEAR_OPTIONS=.*/DROPBEAR_OPTIONS=\"-I 100 -j -k -p "${CRYPTROOT_SSH_UNLOCK_PORT}" -s -c cryptroot-unlock\"/" \
 				"${dropbear_dir}/${dropbear_config}"
 
 		# setup dropbear authorized_keys, either provided by userpatches or generated

--- a/extensions/fs-cryptroot-support.sh
+++ b/extensions/fs-cryptroot-support.sh
@@ -47,7 +47,7 @@ function pre_install_kernel_debs__adjust_dropbear_configuration() {
 		# Set the port of the dropbear ssh daemon in the initramfs to a different one if configured
 		# this avoids the typical 'host key changed warning' - `WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!`
 		[[ -f "${dropbear_dir}/${dropbear_config}" ]] &&
-			sed -i 's/^#DROPBEAR_OPTIONS=/DROPBEAR_OPTIONS="-j -k -p '"${CRYPTROOT_SSH_UNLOCK_PORT}"' -s -c cryptroot-unlock"/' \
+			sed -i "s/^#DROPBEAR_OPTIONS=.*/DROPBEAR_OPTIONS=\"-j -k -p "${CRYPTROOT_SSH_UNLOCK_PORT}" -s -c cryptroot-unlock\"/" \
 				"${dropbear_dir}/${dropbear_config}"
 
 		# setup dropbear authorized_keys, either provided by userpatches or generated

--- a/extensions/fs-cryptroot-support.sh
+++ b/extensions/fs-cryptroot-support.sh
@@ -47,7 +47,7 @@ function pre_install_kernel_debs__adjust_dropbear_configuration() {
 		# Set the port of the dropbear ssh daemon in the initramfs to a different one if configured
 		# this avoids the typical 'host key changed warning' - `WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!`
 		[[ -f "${dropbear_dir}/${dropbear_config}" ]] &&
-			sed -i "s/^#DROPBEAR_OPTIONS=.*/DROPBEAR_OPTIONS=\"-j -k -p "${CRYPTROOT_SSH_UNLOCK_PORT}" -s -c cryptroot-unlock\"/" \
+			sed -i "s/^#DROPBEAR_OPTIONS=.*/DROPBEAR_OPTIONS=\"-I 10 -j -k -p "${CRYPTROOT_SSH_UNLOCK_PORT}" -s -c cryptroot-unlock\"/" \
 				"${dropbear_dir}/${dropbear_config}"
 
 		# setup dropbear authorized_keys, either provided by userpatches or generated


### PR DESCRIPTION
# Description

Fix #6857 and add 10 seconds network timeout to initramfs ssh daemon waiting for cryptroot-unlock password

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: #6857 
[Jira](https://armbian.atlassian.net/jira) reference number [[AR-2401](https://armbian.atlassian.net/browse/AR-2401)]


# How Has This Been Tested?

- [x] Succesfully running CRYPTROOT_ENABLE="y" nanopi-r5c 
- [x] Succesfully running CRYPTROOT_ENABLE="y" orangepi5-plus

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings



[AR-2401]: https://armbian.atlassian.net/browse/AR-2401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ