### PR TITLE
Fixing syntax at Recore and add missing board level variables

### DIFF
--- a/config/boards/aml-t95z-plus.tvb
+++ b/config/boards/aml-t95z-plus.tvb
@@ -3,6 +3,7 @@ BOARD_NAME="T95Z Plus"                          #  (a q201 Chinese clone with in
 BOOT_FDT_FILE="amlogic/meson-gxm-t95z-plus.dtb" # From chewitt's patches
 BOARDFAMILY="meson-gxl"                         # s912's are actually meson-gxm, no harm done.
 BOOTCONFIG="meson-gxm-t95z-plus_defconfig"      # patched-in
+BOARD_MAINTAINER=""
 KERNEL_TARGET="edge"
 FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"

--- a/config/boards/recore.csc
+++ b/config/boards/recore.csc
@@ -5,24 +5,23 @@ BOOTCONFIG="recore_defconfig"
 KERNEL_TARGET="legacy,current,edge"
 MODULES="g_serial"
 BOOT_LOGO="yes"
+BOARD_MAINTAINER=""
 
 function post_family_config__shrink_atf() {
-    echo "🍰Choose ATF branch"
-    declare -g ATFBRANCH="tag:v2.8.0"
+	display_alert "Choose ATF branch 🍰" "recore"
+	declare -g ATFBRANCH="tag:v2.8.0"
 
-    echo "🍰Shrink ATF"
-    declare -g ATF_TARGET_MAP="PLAT=$ATF_PLAT DEBUG=0 SUNXI_PSCI_USE_SCPI=0 bl31;;build/$ATF_PLAT/release/bl31.bin"
-
-    echo "🍰Compile without SCP binary"
-    UBOOT_TARGET_MAP="SCP=/dev/null;;u-boot-sunxi-with-spl.bin"
+	declare -g ATF_TARGET_MAP="PLAT=$ATF_PLAT DEBUG=0 SUNXI_PSCI_USE_SCPI=0 bl31;;build/$ATF_PLAT/release/bl31.bin"
+	display_alert "Compile without SCP binary 🍰" "recore"
+	UBOOT_TARGET_MAP="SCP=/dev/null;;u-boot-sunxi-with-spl.bin"
 }
 
 function format_partitions__make_boot_ro() {
-    echo "🍰Making boot partition ro"
-    sed -i 's:/boot ext4 defaults,commit=600,errors=remount-ro:/boot ext4 ro,defaults:' $SDCARD/etc/fstab
+	display_alert "Making boot partition ro 🍰" "recore"
+	sed -i 's:/boot ext4 defaults,commit=600,errors=remount-ro:/boot ext4 ro,defaults:' $SDCARD/etc/fstab
 }
 
 function extension_finish_config__enable_plymouth() {
-    echo "🍰Enable Plymouth on minimal build"
-    PLYMOUTH=yes
+	display_alert "Enable Plymouth on minimal build 🍰" "recore"
+	PLYMOUTH=yes
 }


### PR DESCRIPTION
# Description

Addressing syntax error when making build targets.

```Error parsing Armbian JSON: params: {'configs': [], 'inventory': {'BOARD': 'recore', 'BOARD_CORE_OR_USERPATCHED': 'core', 'BOARD_FILE_HARDWARE_DESC': 'Allwinner A64 quad core 1GB RAM SoC GBE for 3D printers', 'BOARD_HAS_VIDEO': True, 'BOARD_MAINTAINERS': [], 'BOARD_POSSIBLE_BRANCHES': ['legacy', 'current', 'edge'], 'BOARD_SUPPORT_LEVEL': 'csc', 'BOARD_TOP_LEVEL_VARS': {'BOARD': 'recore', 'BOARDFAMILY': 'sun50iw1', 'BOARD_CORE_OR_USERPATCHED': 'core', 'BOARD_FILE_HARDWARE_DESC': 'Allwinner A64 quad core 1GB RAM SoC GBE for 3D printers', 'BOARD_HAS_VIDEO': True, 'BOARD_MAINTAINERS': [], 'BOARD_NAME': 'Iagent Recore', 'BOARD_POSSIBLE_BRANCHES': ['legacy', 'current', 'edge'], 'BOARD_SLASH_BRANCH': 'recore/legacy', 'BOARD_SUPPORT_LEVEL': 'csc', 'BOOTCONFIG': 'recore_defconfig', 'BOOT_LOGO': 'yes', 'KERNEL_TARGET': 'legacy,current,edge', 'MODULES': 'g_serial'}}, 'pipeline': {}, 'target_id': '00000008860000001021', 'vars': {'BETA': '', 'BOARD': 'recore', 'BRANCH': 'legacy', 'BUILD_DESKTOP': 'no', 'BUILD_MINIMAL': 'yes', 'RELEASE': 'jammy', 'REVISION': '24.8.0-trunk'}}, stderr: 
  [🐳|🔨]   Failed get info for build 'config-dump-json' '{'configs': [], 'inventory': {'BOARD': 'recore', 'BOARD_CORE_OR_USERPATCHED': 'core', 'BOARD_FILE_HARDWARE_DESC': 'Allwinner A64 quad core 1GB RAM SoC GBE for 3D printers', 'BOARD_HAS_VIDEO': True, 'BOARD_MAINTAINERS': [], 'BOARD_POSSIBLE_BRANCHES': ['legacy', 'current', 'edge'], 'BOARD_SUPPORT_LEVEL': 'csc', 'BOARD_TOP_LEVEL_VARS': {'BOARD': 'recore', 'BOARDFAMILY': 'sun50iw1', 'BOARD_CORE_OR_USERPATCHED': 'core', 'BOARD_FILE_HARDWARE_DESC': 'Allwinner A64 quad core 1GB RAM SoC GBE for 3D printers', 'BOARD_HAS_VIDEO': True, 'BOARD_MAINTAINERS': [], 'BOARD_NAME': 'Iagent Recore', 'BOARD_POSSIBLE_BRANCHES': ['legacy', 'current', 'edge'], 'BOARD_SLASH_BRANCH': 'recore/legacy', 'BOARD_SUPPORT_LEVEL': 'csc', 'BOOTCONFIG': 'recore_defconfig', 'BOOT_LOGO': 'yes', 'KERNEL_TARGET': 'legacy,current,edge', 'MODULES': 'g_serial'}}, 'pipeline': {}, 'target_id': '00000008860000001021', 'vars': {'BETA': '', 'BOARD': 'recore', 'BRANCH': 'legacy', 'BUILD_DESKTOP': 'no', 'BUILD_MINIMAL': 'yes', 'RELEASE': 'jammy', 'REVISION': '24.8.0-trunk'}}': 'Expecting value: line 1 column 1 (char 0)'
```

@eliasbakken nothing to worry about.

# How Has This Been Tested?

- [x] ./compile.sh targets
- [x] ./compile.sh BOARD=recore BRANCH=current BUILD_DESKTOP=no BUILD_MINIMAL=no KERNEL_CONFIGURE=no RELEASE=bookworm

# Checklist:

- [x] My changes generate no new warnings