### PR TITLE
Add recore dts patch to series.conf so it gets applied

### DIFF
--- a/patch/kernel/archive/sunxi-6.6/series.conf
+++ b/patch/kernel/archive/sunxi-6.6/series.conf
@@ -473,3 +473,4 @@
 	patches.armbian/arm64-dts-sun50i-h618-add-overlay.patch
 	patches.armbian/arm-dts-orangepi-one-pinctr-dummy-regulators.patch
 	patches.armbian/sound-soc-sunxi-h616-h618.patch
+	patches.armbian/arm64-dts-sun50i-a64-add-dts-for-recore-a5-to-a8.patch


### PR DESCRIPTION
# Description

The Recore dts patch submitted earlier was not applied since the patch was not not referenced in the series.conf file. The patch adds it to the list. 

# Documentation summary for feature / change

- [x] short description (copy / paste of PR title)
- [x] summary (description relevant for end users)
- [ ] example of usage (how to see this in function)

# How Has This Been Tested?

It has been tested on the following hardware:
- [x] Recore A8

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
