### PR TITLE
Fix Khadas Edge 2 uboot build

### DIFF
--- a/patch/u-boot/legacy/u-boot-khadas-edge2-rk3588/0002-Fix-build-errors.patch
+++ b/patch/u-boot/legacy/u-boot-khadas-edge2-rk3588/0002-Fix-build-errors.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Muhammed Efe Cetin <efectn@protonmail.com>
+Date: Tue, 2 Jul 2024 18:14:23 +0300
+Subject: Fix build errors
+
+---
+ common/edid.c     | 2 +-
+ include/command.h | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/common/edid.c b/common/edid.c
+index 111111111111..222222222222 100644
+--- a/common/edid.c
++++ b/common/edid.c
+@@ -3579,7 +3579,7 @@ int add_cea_modes(struct hdmi_edid_data *data, struct edid *edid)
+ {
+ 	const u8 *cea = drm_find_cea_extension(edid);
+ 	const u8 *db, *hdmi = NULL, *video = NULL;
+-	u8 dbl, hdmi_len, video_len = 0;
++	u8 dbl, hdmi_len = 0, video_len = 0;
+ 	int modes = 0;
+ 
+ 	if (cea && cea_revision(cea) >= 3) {
+diff --git a/include/command.h b/include/command.h
+index 111111111111..222222222222 100644
+--- a/include/command.h
++++ b/include/command.h
+@@ -139,7 +139,7 @@ enum command_ret_t {
+  *			number of ticks the command took to complete.
+  * @return 0 if the command succeeded, 1 if it failed
+  */
+-int cmd_process(int flag, int argc, char * const argv[],
++enum command_ret_t cmd_process(int flag, int argc, char * const argv[],
+ 			       int *repeatable, unsigned long *ticks);
+ 
+ void fixup_cmdtable(cmd_tbl_t *cmdtp, int size);
+-- 
+Armbian
+


### PR DESCRIPTION
# Description

Fix build errors on Khadas Edge 2 vendor uboot.

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: https://github.com/armbian/build/issues/6862
[Jira](https://armbian.atlassian.net/jira) reference number [AR-2402]

# How Has This Been Tested?
- [x] Now it builds with `DOCKER_ARMBIAN_BASE_IMAGE="ubuntu:noble"` argument.

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-2402]: https://armbian.atlassian.net/browse/AR-2402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ