### PR TITLE
git: git_ensure_safe_directory(): use env vars instead of changing config

### DIFF
--- a/lib/functions/general/git.sh
+++ b/lib/functions/general/git.sh
@@ -53,15 +53,24 @@ function improved_git_fetch() {
 
 # workaround new limitations imposed by CVE-2022-24765 fix in git, otherwise  "fatal: unsafe repository"
 function git_ensure_safe_directory() {
-	if [[ -n "$(command -v git)" ]]; then
-		local git_dir="$1"
-		if [[ -e "$1/.git" ]]; then
-			display_alert "git: Marking all directories as safe, which should include" "$git_dir" "debug"
-			regular_git config --global --get safe.directory "$1" > /dev/null || regular_git config --global --add safe.directory "$1"
-		fi
-	else
-		display_alert "git not installed" "a true wonder how you got this far without git - it will be installed for you" "warn"
-	fi
+	# instead of previous attempts to
+	# 1) mark all directories as safe
+	# 2) mark the passed-in directory (${1}) as safe
+	# 3) conditionally mark the passed-in diretory (${1}) as safe
+	# this is now
+	# 4) don't change any config. instead:
+	#    export environment variables GIT_CONFIG_COUNT & GIT_CONFIG_KEY_0 & GIT_CONFIG_VALUE_0
+	#    I learned about this by studying systemd-mkosi.
+	#    see https://git-scm.com/docs/git-config/#Documentation/git-config.txt-GITCONFIGCOUNT
+	#    see https://github.com/systemd/mkosi/blob/76b0a04e48e3b606c729660477db9615a5d0437b/mkosi/__init__.py#L402
+	# rpardini, 20204-07-01
+	display_alert "git_ensure_safe_directory" "ignoring ${1} - all dirs are safe" "debug" # this fools shellcheck that we actually use the argument passed-in
+	export GIT_CONFIG_COUNT="1"
+	export GIT_CONFIG_KEY_0="safe.directory"
+	export GIT_CONFIG_VALUE_0="*"
+	# For the next person who comes saying this is insecure:
+	# feel free to store ${1} in dictkeys and assembling a list of actually safe directories.
+	# then run into environment size issues. you're welcome.
 }
 
 # fetch_from_repo <url> <directory> <ref> <ref_subdir>


### PR DESCRIPTION
#### git: git_ensure_safe_directory(): use env vars instead of changing config

- git: git_ensure_safe_directory(): use env vars instead of changing config

---

Example of the warning/error that always appeared up to now:

```bash
### fetch_and_build_host_tools.log 
--> (2) INFO: Getting sources from Git [ rkbin-tools master ]
--> (3) COMMAND: git --no-pager config --global --get safe.directory /armbian/cache/sources/rkbin-tools
   -->--> command failed with error code 1 after 0 seconds
--> (3) WARNING: stacktrace for failed command [ exit code 1:git --no-pager config --global --get safe.directory /armbian/cache/sources/rkbin-tools
                       regular_git() --> lib/functions/general/git.sh:44
         git_ensure_safe_directory() --> lib/functions/general/git.sh:60
                   fetch_from_repo() --> lib/functions/general/git.sh:159
      fetch_sources_tools__rkbin_tools() --> extensions/rkbin-tools.sh:3
               fetch_sources_tools() --> <extension_magic>:74
             call_extension_method() --> lib/functions/general/extensions.sh:57
        fetch_and_build_host_tools() --> lib/functions/host/host-utils.sh:11
                   do_with_logging() --> lib/functions/logging/section-logging.sh:81
      artifact_uboot_build_from_sources() --> lib/functions/artifacts/artifact-uboot.sh:139
       artifact_build_from_sources() --> lib/functions/artifacts/artifacts-obtain.sh:34
          obtain_complete_artifact() --> lib/functions/artifacts/artifacts-obtain.sh:280
             do_with_default_build() --> lib/functions/main/default-build.sh:42
                  cli_artifact_run() --> lib/functions/cli/cli-artifact.sh:67
           armbian_cli_run_command() --> lib/functions/cli/utils-cli.sh:136
                    cli_entrypoint() --> lib/functions/cli/entrypoint.sh:176
                              main() --> compile.sh:50 ]
--> (3) COMMAND: git --no-pager config --global --add safe.directory /armbian/cache/sources/rkbin-tools
--> (3) INFO: Fetching updates from remote repository [ rkbin-tools master ]
--> (3) COMMAND: /usr/bin/git --no-pager fetch --recurse-submodules=no --no-tags https://github.com/armbian/rkbin master
   From https://github.com/armbian/rkbin
    * branch            master     -> FETCH_HEAD
--> (3) INFO: git: Fetch from remote completed, rev-parsing... [ 'rkbin-tools' 'master' 'FETCH_HEAD' ]
```