### PR TITLE
mekotronics: rk3588: u-boot: borrow patch to fix build on newer gcc

### DIFF
--- a/patch/u-boot/legacy/u-boot-meko-rk3588/0001-use-serial-as-base-for-MAC-address-find-serial-first-then-ethaddr-add-a-lot-of-debugging.patch
+++ b/patch/u-boot/legacy/u-boot-meko-rk3588/0001-use-serial-as-base-for-MAC-address-find-serial-first-then-ethaddr-add-a-lot-of-debugging.patch
@@ -9,7 +9,7 @@ Subject: use serial# as base for MAC address; find serial# first, then
  1 file changed, 67 insertions(+), 5 deletions(-)
 
 diff --git a/arch/arm/mach-rockchip/board.c b/arch/arm/mach-rockchip/board.c
-index 1d0ae1bbe0ca..75bd0adc8f8f 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/mach-rockchip/board.c
 +++ b/arch/arm/mach-rockchip/board.c
 @@ -109,15 +109,55 @@ static int rockchip_set_ethaddr(void)

--- a/patch/u-boot/legacy/u-boot-meko-rk3588/0002-cmd-source-fix-the-error-that-the-command-source-failed-to-execute.patch
+++ b/patch/u-boot/legacy/u-boot-meko-rk3588/0002-cmd-source-fix-the-error-that-the-command-source-failed-to-execute.patch
@@ -9,7 +9,7 @@ Signed-off-by: Stephen <stephen@vamrs.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/cmd/source.c b/cmd/source.c
-index 6b1c8b744b49..cf820c072af1 100644
+index 111111111111..222222222222 100644
 --- a/cmd/source.c
 +++ b/cmd/source.c
 @@ -87,7 +87,7 @@ source (ulong addr, const char *fit_uname)

--- a/patch/u-boot/legacy/u-boot-meko-rk3588/0003-rk3588_meko_defconfig-evb-sans-optee-original-ish-by-Meko-from-EVB.patch
+++ b/patch/u-boot/legacy/u-boot-meko-rk3588/0003-rk3588_meko_defconfig-evb-sans-optee-original-ish-by-Meko-from-EVB.patch
@@ -10,7 +10,7 @@ Subject: rk3588_meko_defconfig - evb sans optee (original-ish by Meko from
 
 diff --git a/configs/rk3588_meko_defconfig b/configs/rk3588_meko_defconfig
 new file mode 100644
-index 000000000000..73104bb182de
+index 000000000000..111111111111
 --- /dev/null
 +++ b/configs/rk3588_meko_defconfig
 @@ -0,0 +1,238 @@

--- a/patch/u-boot/legacy/u-boot-meko-rk3588/0004-rk3588_meko_r58x_defconfig-and-dts-with-pci3x4-nvme-boot-and-working-RECOVERY-button.patch
+++ b/patch/u-boot/legacy/u-boot-meko-rk3588/0004-rk3588_meko_r58x_defconfig-and-dts-with-pci3x4-nvme-boot-and-working-RECOVERY-button.patch
@@ -13,7 +13,7 @@ Subject: rk3588_meko_r58x_defconfig and dts with pci3x4 nvme boot and working
 
 diff --git a/arch/arm/dts/rk3588-blueberry-edge-v12.dts b/arch/arm/dts/rk3588-blueberry-edge-v12.dts
 new file mode 100644
-index 000000000000..5dd31189e3d4
+index 000000000000..111111111111
 --- /dev/null
 +++ b/arch/arm/dts/rk3588-blueberry-edge-v12.dts
 @@ -0,0 +1,159 @@
@@ -178,7 +178,7 @@ index 000000000000..5dd31189e3d4
 +
 diff --git a/configs/rk3588_meko_r58x_defconfig b/configs/rk3588_meko_r58x_defconfig
 new file mode 100644
-index 000000000000..b03ffa9437c7
+index 000000000000..111111111111
 --- /dev/null
 +++ b/configs/rk3588_meko_r58x_defconfig
 @@ -0,0 +1,248 @@

--- a/patch/u-boot/legacy/u-boot-meko-rk3588/0005-boot_rkimg-don-t-try-rockchip_u2phy_vbus_detect-when-RECOVERY-button-pressed.patch
+++ b/patch/u-boot/legacy/u-boot-meko-rk3588/0005-boot_rkimg-don-t-try-rockchip_u2phy_vbus_detect-when-RECOVERY-button-pressed.patch
@@ -10,7 +10,7 @@ Subject: boot_rkimg: don't try rockchip_u2phy_vbus_detect when RECOVERY button
  1 file changed, 6 insertions(+), 3 deletions(-)
 
 diff --git a/arch/arm/mach-rockchip/boot_rkimg.c b/arch/arm/mach-rockchip/boot_rkimg.c
-index 9e6c3556a9e2..f79aed467bc1 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm/mach-rockchip/boot_rkimg.c
 +++ b/arch/arm/mach-rockchip/boot_rkimg.c
 @@ -322,14 +322,17 @@ void setup_download_mode(void)

--- a/patch/u-boot/legacy/u-boot-meko-rk3588/1000-Fix-build-errors.patch
+++ b/patch/u-boot/legacy/u-boot-meko-rk3588/1000-Fix-build-errors.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Muhammed Efe Cetin <efectn@protonmail.com>
+Date: Tue, 2 Jul 2024 18:14:23 +0300
+Subject: Fix build errors
+
+---
+ common/edid.c     | 2 +-
+ include/command.h | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/common/edid.c b/common/edid.c
+index 111111111111..222222222222 100644
+--- a/common/edid.c
++++ b/common/edid.c
+@@ -3579,7 +3579,7 @@ int add_cea_modes(struct hdmi_edid_data *data, struct edid *edid)
+ {
+ 	const u8 *cea = drm_find_cea_extension(edid);
+ 	const u8 *db, *hdmi = NULL, *video = NULL;
+-	u8 dbl, hdmi_len, video_len = 0;
++	u8 dbl, hdmi_len = 0, video_len = 0;
+ 	int modes = 0;
+ 
+ 	if (cea && cea_revision(cea) >= 3) {
+diff --git a/include/command.h b/include/command.h
+index 111111111111..222222222222 100644
+--- a/include/command.h
++++ b/include/command.h
+@@ -139,7 +139,7 @@ enum command_ret_t {
+  *			number of ticks the command took to complete.
+  * @return 0 if the command succeeded, 1 if it failed
+  */
+-int cmd_process(int flag, int argc, char * const argv[],
++enum command_ret_t cmd_process(int flag, int argc, char * const argv[],
+ 			       int *repeatable, unsigned long *ticks);
+ 
+ void fixup_cmdtable(cmd_tbl_t *cmdtp, int size);
+-- 
+Armbian
+


### PR DESCRIPTION
#### mekotronics: rk3588: u-boot: borrow patch to fix build on newer gcc

- mekotronics: rk3588: u-boot: rewrite u-boot patches, no changes
  - rewritten against 609a77ef6e99c56aacd4b8d8f9c3056378f9c761 - a specific commit in radxa's next-dev
- mekotronics: rk3588: u-boot: borrow patch to fix build on newer gcc