### PR TITLE
fix uboot compilation issues on Orange Pi 5/5 Plus

### DIFF
--- a/patch/u-boot/legacy/u-boot-orangepi5-rk3588/fix-build-errors.patch
+++ b/patch/u-boot/legacy/u-boot-orangepi5-rk3588/fix-build-errors.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Muhammed Efe Cetin <efectn@protonmail.com>
+Date: Tue, 2 Jul 2024 18:14:23 +0300
+Subject: Fix build errors
+
+---
+ common/edid.c                 | 2 +-
+ drivers/mmc/rockchip_dw_mmc.c | 2 +-
+ include/command.h             | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/common/edid.c b/common/edid.c
+index 111111111111..222222222222 100644
+--- a/common/edid.c
++++ b/common/edid.c
+@@ -3579,7 +3579,7 @@ int add_cea_modes(struct hdmi_edid_data *data, struct edid *edid)
+ {
+ 	const u8 *cea = drm_find_cea_extension(edid);
+ 	const u8 *db, *hdmi = NULL, *video = NULL;
+-	u8 dbl, hdmi_len, video_len = 0;
++	u8 dbl, hdmi_len = 0, video_len = 0;
+ 	int modes = 0;
+ 
+ 	if (cea && cea_revision(cea) >= 3) {
+diff --git a/drivers/mmc/rockchip_dw_mmc.c b/drivers/mmc/rockchip_dw_mmc.c
+index 111111111111..222222222222 100644
+--- a/drivers/mmc/rockchip_dw_mmc.c
++++ b/drivers/mmc/rockchip_dw_mmc.c
+@@ -42,7 +42,7 @@ int board_mmc_dm_reinit(struct udevice *dev)
+ {
+ 	struct rockchip_dwmmc_priv *priv = dev_get_priv(dev);
+ 
+-	if (!priv || !&priv->clk)
++	if (!priv)
+ 		return 0;
+ 
+ 	if (!memcmp(dev->name, "dwmmc", strlen("dwmmc")))
+diff --git a/include/command.h b/include/command.h
+index 111111111111..222222222222 100644
+--- a/include/command.h
++++ b/include/command.h
+@@ -139,7 +139,7 @@ enum command_ret_t {
+  *			number of ticks the command took to complete.
+  * @return 0 if the command succeeded, 1 if it failed
+  */
+-int cmd_process(int flag, int argc, char * const argv[],
++enum command_ret_t cmd_process(int flag, int argc, char * const argv[],
+ 			       int *repeatable, unsigned long *ticks);
+ 
+ void fixup_cmdtable(cmd_tbl_t *cmdtp, int size);
+-- 
+Armbian
+

--- a/patch/u-boot/legacy/u-boot-orangepi5-rk3588/set-fixed-mac.patch
+++ b/patch/u-boot/legacy/u-boot-orangepi5-rk3588/set-fixed-mac.patch
@@ -9,12 +9,10 @@ Signed-off-by: Igor <igor@armbian.com>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/common/fdt_support.c b/common/fdt_support.c
-index e72aaf04e0..fa3d3e7af2 100644
+index 111111111111..222222222222 100644
 --- a/common/fdt_support.c
 +++ b/common/fdt_support.c
-@@ -703,12 +703,12 @@ void fdt_fixup_ethernet(void *fdt)
- 					tmp = (*end) ? end + 1 : end;
- 			}
+@@ -705,8 +705,8 @@ void fdt_fixup_ethernet(void *fdt)
  
  			do_fixup_by_path(fdt, path, "mac-address",
  					 &mac_addr, 6, 0);
@@ -25,8 +23,6 @@ index e72aaf04e0..fa3d3e7af2 100644
  		}
  	}
  }
- 
- /* Resize the fdt to its actual size + a bit of padding */
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+Armbian
 


### PR DESCRIPTION
# Description
I'll create a separate PR to migrate Radxa uboot later. Let's fix current builds first of all.

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: https://github.com/armbian/build/issues/6862
[Jira](https://armbian.atlassian.net/jira) reference number [AR-2402]

# How Has This Been Tested?
- [x] Both boards can be built with Noble host now

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[AR-2402]: https://armbian.atlassian.net/browse/AR-2402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ