### PR TITLE
Allwinner: set legacy 6.1.y to last known build tag

### DIFF
--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -25,6 +25,7 @@ case $BRANCH in
 
 	legacy)
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
+		declare -g KERNELBRANCH="tag:v6.1.96"
 		;;
 
 	current)

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -26,6 +26,7 @@ case $BRANCH in
 
 	legacy)
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
+		declare -g KERNELBRANCH="tag:v6.1.96"
 		;;
 
 	current)


### PR DESCRIPTION
# Description

Allwinner 6.1.y was set to branch, but lets set it to tag as currently its broken and maintaining legacy is low priority.

Ref: https://github.com/armbian/build/pull/6887

# How Has This Been Tested?

- [x] Build test

# Checklist:

- [x] My changes generate no new warnings