### PR TITLE
add new board radxa-e52c

### DIFF
--- a/config/boards/radxa-e52c.conf
+++ b/config/boards/radxa-e52c.conf
@@ -1,0 +1,10 @@
+# Rockchip RK3582 SoC octa core 4-16GB SoC eMMC USB3
+BOARD_NAME="Radxa E52C"
+BOARDFAMILY="rockchip-rk3588"
+BOARD_MAINTAINER="amazingfate"
+BOOTCONFIG="radxa-e52c-rk3588s_defconfig"
+KERNEL_TARGET="vendor"
+BOOT_FDT_FILE="rockchip/rk3588s-radxa-e52c.dtb"
+BOOT_SCENARIO="spl-blobs"
+BOOT_SOC="rk3588"
+IMAGE_PARTITION_TABLE="gpt"

--- a/patch/u-boot/legacy/u-boot-radxa-rk35xx/board_radxa-e52c
+++ b/patch/u-boot/legacy/u-boot-radxa-rk35xx/board_radxa-e52c
@@ -1,0 +1,1 @@
+board_rock-5c/


### PR DESCRIPTION
# Description

Radxa E52C is a rk3582 based board with dual 2.5G ethernet. This pr depends on https://github.com/armbian/linux-rockchip/pull/203. Since its soc is rk3582 so it should the same uboot patch from rock-5c to enable good ip cores disabled by u-boot.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh BOARD=radxa-e52c BRANCH=vendor BUILD_MINIMAL=no DEB_COMPRESS=xz KERNEL_CONFIGURE=no RELEASE=noble KERNEL_GIT=shallow BUILD_DESKTOP=no`
- [x] Board boots fine.

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
