### PR TITLE
sunxi-6.1: switch to tag:v6.1.97, re-extracting the corrected ones

### DIFF
--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -25,7 +25,7 @@ case $BRANCH in
 
 	legacy)
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.1.96"
+		declare -g KERNELBRANCH="tag:v6.1.97"
 		;;
 
 	current)

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -26,7 +26,7 @@ case $BRANCH in
 
 	legacy)
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.1.96"
+		declare -g KERNELBRANCH="tag:v6.1.97"
 		;;
 
 	current)

--- a/patch/kernel/archive/sunxi-6.1/patches.armbian/arm64-dts-sun50i-h6-Add-r_uart-uart2-3-pins.patch
+++ b/patch/kernel/archive/sunxi-6.1/patches.armbian/arm64-dts-sun50i-h6-Add-r_uart-uart2-3-pins.patch
@@ -11,7 +11,7 @@ diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h6.dtsi b/arch/arm64/boot/dts/
 index 80d7f4854..160fe50bd 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h6.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h6.dtsi
-@@ -319,6 +319,17 @@ msgbox: mailbox@3003000 {
+@@ -309,6 +309,17 @@ msgbox: mailbox@3003000 {
  			#mbox-cells = <1>;
  		};
  
@@ -29,7 +29,7 @@ index 80d7f4854..160fe50bd 100644
  		sid: efuse@3006000 {
  			compatible = "allwinner,sun50i-h6-sid";
  			reg = <0x03006000 0x400>;
-@@ -382,6 +393,7 @@ pio: pinctrl@300b000 {
+@@ -368,6 +379,7 @@ pio: pinctrl@300b000 {
  			interrupt-controller;
  			#interrupt-cells = <3>;
  
@@ -37,15 +37,15 @@ index 80d7f4854..160fe50bd 100644
  			ext_rgmii_pins: rgmii-pins {
  				pins = "PD0", "PD1", "PD2", "PD3", "PD4",
  				       "PD5", "PD7", "PD8", "PD9", "PD10",
-@@ -445,6 +457,7 @@ pwm1_pin: pwm1-pin {
- 				function = "pwm1";
+@@ -413,6 +425,7 @@ mmc1_pins: mmc1-pins {
+ 				bias-pull-up;
  			};
  
 +			/omit-if-no-ref/
  			mmc2_pins: mmc2-pins {
  				pins = "PC1", "PC4", "PC5", "PC6",
  				       "PC7", "PC8", "PC9", "PC10",
-@@ -498,17 +511,26 @@ uart1_rts_cts_pins: uart1-rts-cts-pins {
+@@ -467,17 +480,26 @@ uart1_rts_cts_pins: uart1-rts-cts-pins {
  				pins = "PG8", "PG9";
  				function = "uart1";
  			};
@@ -82,7 +82,7 @@ index 80d7f4854..160fe50bd 100644
  		};
  
  		iommu: iommu@30f0000 {
-@@ -1026,6 +1048,19 @@ tcon_tv_out_tcon_top: endpoint@1 {
+@@ -962,6 +984,19 @@ tcon_tv_out_tcon_top: endpoint@1 {
  			};
  		};
  
@@ -102,7 +102,7 @@ index 80d7f4854..160fe50bd 100644
  		rtc: rtc@7000000 {
  			compatible = "allwinner,sun50i-h6-rtc";
  			reg = <0x07000000 0x400>;
-@@ -1091,6 +1126,11 @@ r_rsb_pins: r-rsb-pins {
+@@ -1027,6 +1062,11 @@ r_rsb_pins: r-rsb-pins {
  				pins = "PL0", "PL1";
  				function = "s_rsb";
  			};

--- a/patch/kernel/archive/sunxi-6.1/patches.armbian/drivers-hack-for-h616-hdmi-video-output.patch
+++ b/patch/kernel/archive/sunxi-6.1/patches.armbian/drivers-hack-for-h616-hdmi-video-output.patch
@@ -1,4 +1,4 @@
-From 897ce7f9ba84e76d169511b34acace2d8c5707d7 Mon Sep 17 00:00:00 2001
+From 6a040d7333daad91cbcf44e4e777ff4050ccf30e Mon Sep 17 00:00:00 2001
 From: orangepi-xunlong <258384131@qq.com>
 Date: Mon, 5 Jun 2023 14:16:04 +0800
 Subject: [PATCH] drivers: hack for h616 hdmi video output
@@ -22,12 +22,12 @@ Subject: [PATCH] drivers: hack for h616 hdmi video output
  create mode 100644 drivers/clk/sunxi-ng/ccu-sun8i-de33.h
 
 diff --git a/drivers/clk/sunxi-ng/Kconfig b/drivers/clk/sunxi-ng/Kconfig
-index b547198a2c65..01d2f8c4d73e 100644
+index 461537679..2ca069af4 100644
 --- a/drivers/clk/sunxi-ng/Kconfig
 +++ b/drivers/clk/sunxi-ng/Kconfig
 @@ -103,6 +103,10 @@ config SUN8I_DE2_CCU
- 	default y
- 	depends on MACH_SUN8I || ARM64 || RISCV || COMPILE_TEST
+ 	tristate "Support for the Allwinner SoCs DE2 CCU"
+ 	default MACH_SUN8I || (ARM64 && ARCH_SUNXI)
  
 +config SUN8I_DE33_CCU
 +	tristate "Support for the Allwinner SoCs DE3.3 CCU"
@@ -35,9 +35,9 @@ index b547198a2c65..01d2f8c4d73e 100644
 +
  config SUN8I_R40_CCU
  	tristate "Support for the Allwinner R40 CCU"
- 	default y
+ 	default MACH_SUN8I
 diff --git a/drivers/clk/sunxi-ng/Makefile b/drivers/clk/sunxi-ng/Makefile
-index 6b3ae2b620db..cd20050cd9f1 100644
+index 6b3ae2b62..cd20050cd 100644
 --- a/drivers/clk/sunxi-ng/Makefile
 +++ b/drivers/clk/sunxi-ng/Makefile
 @@ -44,6 +44,7 @@ obj-$(CONFIG_SUN8I_H3_CCU)	+= sun8i-h3-ccu.o
@@ -58,7 +58,7 @@ index 6b3ae2b620db..cd20050cd9f1 100644
  sun9i-a80-de-ccu-y		+= ccu-sun9i-a80-de.o
 diff --git a/drivers/clk/sunxi-ng/ccu-sun8i-de33.c b/drivers/clk/sunxi-ng/ccu-sun8i-de33.c
 new file mode 100644
-index 000000000000..fa5b1cf62444
+index 000000000..fa5b1cf62
 --- /dev/null
 +++ b/drivers/clk/sunxi-ng/ccu-sun8i-de33.c
 @@ -0,0 +1,181 @@
@@ -245,7 +245,7 @@ index 000000000000..fa5b1cf62444
 +builtin_platform_driver(sunxi_de33_clk_driver);
 diff --git a/drivers/clk/sunxi-ng/ccu-sun8i-de33.h b/drivers/clk/sunxi-ng/ccu-sun8i-de33.h
 new file mode 100644
-index 000000000000..83cbef5a3f76
+index 000000000..83cbef5a3
 --- /dev/null
 +++ b/drivers/clk/sunxi-ng/ccu-sun8i-de33.h
 @@ -0,0 +1,19 @@
@@ -269,11 +269,11 @@ index 000000000000..83cbef5a3f76
 +
 +#endif /* _CCU_SUN8I_DE2_H_ */
 diff --git a/drivers/gpu/drm/sun4i/sun4i_tcon.c b/drivers/gpu/drm/sun4i/sun4i_tcon.c
-index 19875219fe3d..a005dcaaf788 100644
+index 972f44e13..3bf7bbbf1 100644
 --- a/drivers/gpu/drm/sun4i/sun4i_tcon.c
 +++ b/drivers/gpu/drm/sun4i/sun4i_tcon.c
 @@ -1313,6 +1313,10 @@ static int sun4i_tcon_bind(struct device *dev, struct device *master,
- 			goto err_free_dclk;
+ 			goto err_free_dotclock;
  	}
  
 +	regmap_update_bits(tcon->regs, SUN4I_TCON_GCTL_REG,
@@ -284,7 +284,7 @@ index 19875219fe3d..a005dcaaf788 100644
  		/*
  		 * We assume there is no dynamic muxing of backends
 diff --git a/drivers/gpu/drm/sun4i/sun4i_tcon.h b/drivers/gpu/drm/sun4i/sun4i_tcon.h
-index 7ba3df9e27df..e8687a696d2a 100644
+index 7ba3df9e2..e8687a696 100644
 --- a/drivers/gpu/drm/sun4i/sun4i_tcon.h
 +++ b/drivers/gpu/drm/sun4i/sun4i_tcon.h
 @@ -20,6 +20,7 @@
@@ -296,7 +296,7 @@ index 7ba3df9e27df..e8687a696d2a 100644
  #define SUN4I_TCON_GCTL_IOMAP_TCON1			(1 << 0)
  #define SUN4I_TCON_GCTL_IOMAP_TCON0			(0 << 0)
 diff --git a/drivers/gpu/drm/sun4i/sun8i_csc.c b/drivers/gpu/drm/sun4i/sun8i_csc.c
-index 58480d8e4f70..703c55ba788b 100644
+index 58480d8e4..703c55ba7 100644
 --- a/drivers/gpu/drm/sun4i/sun8i_csc.c
 +++ b/drivers/gpu/drm/sun4i/sun8i_csc.c
 @@ -107,6 +107,14 @@ static const u32 yuv2rgb_de3[2][3][12] = {
@@ -379,10 +379,10 @@ index 58480d8e4f70..703c55ba788b 100644
  	sun8i_csc_enable(mixer->engine.regs, base, enable);
  }
 diff --git a/drivers/gpu/drm/sun4i/sun8i_hdmi_phy.c b/drivers/gpu/drm/sun4i/sun8i_hdmi_phy.c
-index 4fa69c463dc4..5915326b2699 100644
+index ca53b5e9f..856b5ab5b 100644
 --- a/drivers/gpu/drm/sun4i/sun8i_hdmi_phy.c
 +++ b/drivers/gpu/drm/sun4i/sun8i_hdmi_phy.c
-@@ -124,6 +124,76 @@ static const struct dw_hdmi_phy_config sun50i_h6_phy_config[] = {
+@@ -123,6 +123,76 @@ static const struct dw_hdmi_phy_config sun50i_h6_phy_config[] = {
  	{ ~0UL,	     0x0000, 0x0000, 0x0000}
  };
  
@@ -459,7 +459,7 @@ index 4fa69c463dc4..5915326b2699 100644
  static void sun8i_hdmi_phy_set_polarity(struct sun8i_hdmi_phy *phy,
  					const struct drm_display_mode *mode)
  {
-@@ -626,6 +696,13 @@ static const struct sun8i_hdmi_phy_variant sun50i_h6_hdmi_phy = {
+@@ -625,6 +695,13 @@ static const struct sun8i_hdmi_phy_variant sun50i_h6_hdmi_phy = {
  	.phy_init = &sun50i_hdmi_phy_init_h6,
  };
  
@@ -473,7 +473,7 @@ index 4fa69c463dc4..5915326b2699 100644
  static const struct of_device_id sun8i_hdmi_phy_of_table[] = {
  	{
  		.compatible = "allwinner,sun8i-a83t-hdmi-phy",
-@@ -647,6 +724,10 @@ static const struct of_device_id sun8i_hdmi_phy_of_table[] = {
+@@ -646,6 +723,10 @@ static const struct of_device_id sun8i_hdmi_phy_of_table[] = {
  		.compatible = "allwinner,sun50i-h6-hdmi-phy",
  		.data = &sun50i_h6_hdmi_phy,
  	},
@@ -485,10 +485,10 @@ index 4fa69c463dc4..5915326b2699 100644
  };
  
 diff --git a/drivers/gpu/drm/sun4i/sun8i_mixer.c b/drivers/gpu/drm/sun4i/sun8i_mixer.c
-index 8316ef1547b6..85147617124c 100644
+index 9aae44e33..cf620cca2 100644
 --- a/drivers/gpu/drm/sun4i/sun8i_mixer.c
 +++ b/drivers/gpu/drm/sun4i/sun8i_mixer.c
-@@ -286,6 +286,9 @@ static void sun8i_mixer_commit(struct sunxi_engine *engine,
+@@ -278,6 +278,9 @@ static void sun8i_mixer_commit(struct sunxi_engine *engine,
  	struct drm_plane_state *plane_state;
  	struct drm_plane *plane;
  	u32 route = 0, pipe_en = 0;
@@ -498,7 +498,7 @@ index 8316ef1547b6..85147617124c 100644
  
  	if (mixer->hw_preconfigured && engine->id == 0) {
  		struct sun4i_tcon* tcon;
-@@ -347,7 +350,7 @@ static void sun8i_mixer_commit(struct sunxi_engine *engine,
+@@ -339,7 +342,7 @@ static void sun8i_mixer_commit(struct sunxi_engine *engine,
  		pipe_en |= SUN8I_MIXER_BLEND_PIPE_CTL_EN(zpos);
  	}
  
@@ -507,7 +507,7 @@ index 8316ef1547b6..85147617124c 100644
  			   SUN8I_MIXER_BLEND_ROUTE(bld_base),
  			   SUN8I_MIXER_BLEND_ROUTE_PIPE_MSK(0) |
  			   SUN8I_MIXER_BLEND_ROUTE_PIPE_MSK(1) |
-@@ -355,7 +358,7 @@ static void sun8i_mixer_commit(struct sunxi_engine *engine,
+@@ -347,7 +350,7 @@ static void sun8i_mixer_commit(struct sunxi_engine *engine,
  			   SUN8I_MIXER_BLEND_ROUTE_PIPE_MSK(3),
  			   route);
  
@@ -516,7 +516,7 @@ index 8316ef1547b6..85147617124c 100644
  			   SUN8I_MIXER_BLEND_PIPE_CTL(bld_base),
  			   SUN8I_MIXER_BLEND_PIPE_CTL_EN(0) |
  			   SUN8I_MIXER_BLEND_PIPE_CTL_EN(1) |
-@@ -363,8 +366,12 @@ static void sun8i_mixer_commit(struct sunxi_engine *engine,
+@@ -355,8 +358,12 @@ static void sun8i_mixer_commit(struct sunxi_engine *engine,
  			   SUN8I_MIXER_BLEND_PIPE_CTL_EN(3),
  			   pipe_en);
  
@@ -531,7 +531,7 @@ index 8316ef1547b6..85147617124c 100644
  }
  
  static struct drm_plane **sun8i_layers_init(struct drm_device *drm,
-@@ -418,25 +425,31 @@ static void sun8i_mixer_mode_set(struct sunxi_engine *engine,
+@@ -405,25 +412,31 @@ static void sun8i_mixer_mode_set(struct sunxi_engine *engine,
  				 const struct drm_display_mode *mode)
  {
  	struct sun8i_mixer *mixer = engine_to_sun8i_mixer(engine);
@@ -566,7 +566,7 @@ index 8316ef1547b6..85147617124c 100644
  			   SUN8I_MIXER_BLEND_OUTCTL_INTERLACED, val);
  
  	DRM_DEBUG_DRIVER("Switching display mixer interlaced mode %s\n",
-@@ -475,6 +488,20 @@ static const struct regmap_config sun8i_mixer_regmap_config = {
+@@ -443,6 +456,20 @@ static const struct regmap_config sun8i_mixer_regmap_config = {
  	.max_register	= 0xffffc, /* guessed */
  };
  
@@ -587,7 +587,7 @@ index 8316ef1547b6..85147617124c 100644
  static int sun8i_mixer_of_get_id(struct device_node *node)
  {
  	struct device_node *ep, *remote;
-@@ -495,6 +522,84 @@ static int sun8i_mixer_of_get_id(struct device_node *node)
+@@ -463,6 +490,84 @@ static int sun8i_mixer_of_get_id(struct device_node *node)
  	return of_ep.id;
  }
  
@@ -672,7 +672,7 @@ index 8316ef1547b6..85147617124c 100644
  static int sun8i_mixer_bind(struct device *dev, struct device *master,
  			      void *data)
  {
-@@ -571,6 +676,30 @@ static int sun8i_mixer_bind(struct device *dev, struct device *master,
+@@ -539,6 +644,30 @@ static int sun8i_mixer_bind(struct device *dev, struct device *master,
  		return PTR_ERR(mixer->engine.regs);
  	}
  
@@ -703,7 +703,7 @@ index 8316ef1547b6..85147617124c 100644
  	mixer->reset = devm_reset_control_get(dev, NULL);
  	if (IS_ERR(mixer->reset)) {
  		dev_err(dev, "Couldn't get our reset line\n");
-@@ -613,11 +742,11 @@ static int sun8i_mixer_bind(struct device *dev, struct device *master,
+@@ -581,11 +710,11 @@ static int sun8i_mixer_bind(struct device *dev, struct device *master,
  
  	list_add_tail(&mixer->engine.list, &drv->engine_list);
  
@@ -719,7 +719,7 @@ index 8316ef1547b6..85147617124c 100644
  		for (i = 0; i < DE3_MIXER_UNIT_SIZE; i += 4)
  			regmap_write(mixer->engine.regs, i, 0);
  
-@@ -631,7 +760,10 @@ static int sun8i_mixer_bind(struct device *dev, struct device *master,
+@@ -599,7 +728,10 @@ static int sun8i_mixer_bind(struct device *dev, struct device *master,
  		regmap_write(mixer->engine.regs, SUN50I_MIXER_FMT_EN, 0);
  		regmap_write(mixer->engine.regs, SUN50I_MIXER_CDC0_EN, 0);
  		regmap_write(mixer->engine.regs, SUN50I_MIXER_CDC1_EN, 0);
@@ -730,7 +730,7 @@ index 8316ef1547b6..85147617124c 100644
  		for (i = 0; i < DE2_MIXER_UNIT_SIZE; i += 4)
  			regmap_write(mixer->engine.regs, i, 0);
  
-@@ -642,35 +774,8 @@ static int sun8i_mixer_bind(struct device *dev, struct device *master,
+@@ -610,35 +742,8 @@ static int sun8i_mixer_bind(struct device *dev, struct device *master,
  		regmap_write(mixer->engine.regs, SUN8I_MIXER_ASE_EN, 0);
  		regmap_write(mixer->engine.regs, SUN8I_MIXER_FCC_EN, 0);
  		regmap_write(mixer->engine.regs, SUN8I_MIXER_DCSC_EN, 0);
@@ -768,7 +768,7 @@ index 8316ef1547b6..85147617124c 100644
  	}
  
  	return 0;
-@@ -825,6 +930,17 @@ static const struct sun8i_mixer_cfg sun50i_h6_mixer0_cfg = {
+@@ -794,6 +899,17 @@ static const struct sun8i_mixer_cfg sun50i_h6_mixer0_cfg = {
  	.vi_num		= 1,
  };
  
@@ -786,7 +786,7 @@ index 8316ef1547b6..85147617124c 100644
  static const struct of_device_id sun8i_mixer_of_table[] = {
  	{
  		.compatible = "allwinner,sun8i-a83t-de2-mixer-0",
-@@ -874,6 +990,10 @@ static const struct of_device_id sun8i_mixer_of_table[] = {
+@@ -843,6 +959,10 @@ static const struct of_device_id sun8i_mixer_of_table[] = {
  		.compatible = "allwinner,sun50i-h6-de3-mixer-0",
  		.data = &sun50i_h6_mixer0_cfg,
  	},
@@ -798,7 +798,7 @@ index 8316ef1547b6..85147617124c 100644
  };
  MODULE_DEVICE_TABLE(of, sun8i_mixer_of_table);
 diff --git a/drivers/gpu/drm/sun4i/sun8i_mixer.h b/drivers/gpu/drm/sun4i/sun8i_mixer.h
-index 7bc8efca6980..e28e65572a9f 100644
+index 68e2741b0..e41066b08 100644
 --- a/drivers/gpu/drm/sun4i/sun8i_mixer.h
 +++ b/drivers/gpu/drm/sun4i/sun8i_mixer.h
 @@ -21,6 +21,12 @@
@@ -814,7 +814,7 @@ index 7bc8efca6980..e28e65572a9f 100644
  #define SUN8I_MIXER_GLOBAL_CTL_RT_EN		BIT(0)
  
  #define SUN8I_MIXER_GLOBAL_DBUFF_ENABLE		BIT(0)
-@@ -166,6 +172,7 @@ enum {
+@@ -163,6 +169,7 @@ enum {
   * @mod_rate: module clock rate that needs to be set in order to have
   *	a functional block.
   * @is_de3: true, if this is next gen display engine 3.0, false otherwise.
@@ -822,7 +822,7 @@ index 7bc8efca6980..e28e65572a9f 100644
   * @scaline_yuv: size of a scanline for VI scaler for YUV formats.
   */
  struct sun8i_mixer_cfg {
-@@ -175,7 +182,9 @@ struct sun8i_mixer_cfg {
+@@ -172,7 +179,9 @@ struct sun8i_mixer_cfg {
  	int		ccsc;
  	unsigned long	mod_rate;
  	unsigned int	is_de3 : 1;
@@ -832,7 +832,7 @@ index 7bc8efca6980..e28e65572a9f 100644
  };
  
  struct sun8i_mixer {
-@@ -190,6 +199,8 @@ struct sun8i_mixer {
+@@ -187,6 +196,8 @@ struct sun8i_mixer {
  
  	struct sun4i_drv		*drv;
  	bool				hw_preconfigured;
@@ -841,7 +841,7 @@ index 7bc8efca6980..e28e65572a9f 100644
  };
  
  enum {
-@@ -223,10 +234,19 @@ sun8i_blender_base(struct sun8i_mixer *mixer)
+@@ -220,10 +231,19 @@ sun8i_blender_base(struct sun8i_mixer *mixer)
  	return mixer->cfg->is_de3 ? DE3_BLD_BASE : DE2_BLD_BASE;
  }
  
@@ -863,7 +863,7 @@ index 7bc8efca6980..e28e65572a9f 100644
  	else
  		return DE2_CH_BASE + channel * DE2_CH_SIZE;
 diff --git a/drivers/gpu/drm/sun4i/sun8i_ui_layer.c b/drivers/gpu/drm/sun4i/sun8i_ui_layer.c
-index 0349e8bdffd6..bab560f2edf9 100644
+index b90e5edef..92ab1ac97 100644
 --- a/drivers/gpu/drm/sun4i/sun8i_ui_layer.c
 +++ b/drivers/gpu/drm/sun4i/sun8i_ui_layer.c
 @@ -23,6 +23,7 @@
@@ -926,7 +926,7 @@ index 0349e8bdffd6..bab560f2edf9 100644
  		     outsize);
  
 diff --git a/drivers/gpu/drm/sun4i/sun8i_vi_layer.c b/drivers/gpu/drm/sun4i/sun8i_vi_layer.c
-index 9c09d9c08496..dca22df8c748 100644
+index 9c09d9c08..dca22df8c 100644
 --- a/drivers/gpu/drm/sun4i/sun8i_vi_layer.c
 +++ b/drivers/gpu/drm/sun4i/sun8i_vi_layer.c
 @@ -54,6 +54,7 @@ static int sun8i_vi_layer_update_coord(struct sun8i_mixer *mixer, int channel,
@@ -959,7 +959,7 @@ index 9c09d9c08496..dca22df8c748 100644
  		     outsize);
  
 diff --git a/drivers/gpu/drm/sun4i/sun8i_vi_scaler.c b/drivers/gpu/drm/sun4i/sun8i_vi_scaler.c
-index 7ba75011adf9..3f7afa8d37c5 100644
+index 7ba75011a..3f7afa8d3 100644
 --- a/drivers/gpu/drm/sun4i/sun8i_vi_scaler.c
 +++ b/drivers/gpu/drm/sun4i/sun8i_vi_scaler.c
 @@ -835,7 +835,9 @@ static const u32 bicubic4coefftab32[480] = {
@@ -974,5 +974,5 @@ index 7ba75011adf9..3f7afa8d37c5 100644
  		       DE3_VI_SCALER_UNIT_SIZE * channel;
  	else
 -- 
-2.34.1
+2.35.3
 

--- a/patch/kernel/archive/sunxi-6.1/patches.armbian/drivers-input-axp20x-pek-allow-wakeup-after-shutdown.patch
+++ b/patch/kernel/archive/sunxi-6.1/patches.armbian/drivers-input-axp20x-pek-allow-wakeup-after-shutdown.patch
@@ -21,8 +21,8 @@ Signed-off-by: Samuel Holland <samuel@sholland.org>
 
 --- a/drivers/input/misc/axp20x-pek.c
 +++ b/drivers/input/misc/axp20x-pek.c
-@@ -413,6 +413,11 @@ static const struct dev_pm_ops axp20x_pe
- 	.resume_noirq = pm_sleep_ptr(axp20x_pek_resume_noirq),
+@@ -395,6 +395,11 @@ static const struct dev_pm_ops axp20x_pek_pm_ops = {
+ #endif
  };
  
 +static void axp20x_pek_shutdown(struct platform_device *pdev)
@@ -33,7 +33,7 @@ Signed-off-by: Samuel Holland <samuel@sholland.org>
  static const struct platform_device_id axp_pek_id_match[] = {
  	{
  		.name = "axp20x-pek",
-@@ -428,6 +433,7 @@ MODULE_DEVICE_TABLE(platform, axp_pek_id
+@@ -410,6 +415,7 @@ MODULE_DEVICE_TABLE(platform, axp_pek_id_match);
  
  static struct platform_driver axp20x_pek_driver = {
  	.probe		= axp20x_pek_probe,

--- a/patch/kernel/archive/sunxi-6.1/patches.armbian/random-Revert-handle-entropy-from-atomic-process-con.patch
+++ b/patch/kernel/archive/sunxi-6.1/patches.armbian/random-Revert-handle-entropy-from-atomic-process-con.patch
@@ -1,0 +1,52 @@
+From 25ba88c95e844f900f5603890eaab8d19792a6a8 Mon Sep 17 00:00:00 2001
+From: The-going <48602507+The-going@users.noreply.github.com>
+Date: Sun, 7 Jul 2024 10:39:48 +0300
+Subject: [PATCH] random: Revert: handle entropy from atomic process context
+
+Revert 07b37f227c8daa27e68f57b1c691fab34a06731e commit
+For the sunxi architecture, this commit results in
+an inability to load the kernel. It's actually a crutch
+that can break everything tomorrow.
+Therefore, freeze the kernel version for better times.
+---
+ drivers/char/random.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/char/random.c b/drivers/char/random.c
+index fd57eb372..5d1c8e1c9 100644
+--- a/drivers/char/random.c
++++ b/drivers/char/random.c
+@@ -683,7 +683,7 @@ static void extract_entropy(void *buf, size_t len)
+ 
+ static void __cold _credit_init_bits(size_t bits)
+ {
+-	static DECLARE_WORK(set_ready, crng_set_ready);
++	static struct execute_work set_ready;
+ 	unsigned int new, orig, add;
+ 	unsigned long flags;
+ 
+@@ -699,8 +699,8 @@ static void __cold _credit_init_bits(size_t bits)
+ 
+ 	if (orig < POOL_READY_BITS && new >= POOL_READY_BITS) {
+ 		crng_reseed(); /* Sets crng_init to CRNG_READY under base_crng.lock. */
+-		if (static_key_initialized && system_unbound_wq)
+-			queue_work(system_unbound_wq, &set_ready);
++		if (static_key_initialized)
++			execute_in_process_context(crng_set_ready, &set_ready);
+ 		wake_up_interruptible(&crng_init_wait);
+ 		kill_fasync(&fasync, SIGIO, POLL_IN);
+ 		pr_notice("crng init done\n");
+@@ -870,8 +870,8 @@ void __init random_init(void)
+ 
+ 	/*
+ 	 * If we were initialized by the cpu or bootloader before jump labels
+-	 * or workqueues are initialized, then we should enable the static
+-	 * branch here, where it's guaranteed that these have been initialized.
++	 * are initialized, then we should enable the static branch here, where
++	 * it's guaranteed that jump labels have been initialized.
+ 	 */
+ 	if (!static_branch_likely(&crng_is_ready) && crng_init >= CRNG_READY)
+ 		crng_set_ready(NULL);
+-- 
+2.35.3
+

--- a/patch/kernel/archive/sunxi-6.1/patches.armbian/scripts-add-overlay-compilation-support.patch
+++ b/patch/kernel/archive/sunxi-6.1/patches.armbian/scripts-add-overlay-compilation-support.patch
@@ -56,7 +56,7 @@ index 190d781e8..d7d937903 100644
 +	$(call cmd,dtb_install,$(install-dir))
  
 -quiet_cmd_dtb_install = INSTALL $@
--      cmd_dtb_install = install -D $< $@
+-      cmd_dtb_install = install -D -m 0644 $< $@
 +$(script-files): %.scr: $(obj)/%.scr
 +	$(call cmd,dtb_install,$(install-dir))
  

--- a/patch/kernel/archive/sunxi-6.1/patches.megous/ARM-dts-sun8i-a83t-Add-missing-GPU-trip-point.patch
+++ b/patch/kernel/archive/sunxi-6.1/patches.megous/ARM-dts-sun8i-a83t-Add-missing-GPU-trip-point.patch
@@ -1,0 +1,35 @@
+From ff6f100b72e096027dbcfd78c4aa8dce00400a71 Mon Sep 17 00:00:00 2001
+From: Ondrej Jirman <megi@xff.cz>
+Date: Mon, 13 Mar 2023 06:02:27 +0100
+Subject: [PATCH] ARM: dts: sun8i-a83t: Add missing GPU trip point
+
+Without this, thermal sensor driver fails to probe.
+
+Signed-off-by: Ondrej Jirman <megi@xff.cz>
+---
+ arch/arm/boot/dts/sun8i-a83t.dtsi | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/arch/arm/boot/dts/sun8i-a83t.dtsi b/arch/arm/boot/dts/sun8i-a83t.dtsi
+index 4e36bf198..399561321 100644
+--- a/arch/arm/boot/dts/sun8i-a83t.dtsi
++++ b/arch/arm/boot/dts/sun8i-a83t.dtsi
+@@ -1290,6 +1290,15 @@ gpu_thermal: gpu-thermal {
+ 			polling-delay-passive = <0>;
+ 			polling-delay = <0>;
+ 			thermal-sensors = <&ths 2>;
++
++			trips {
++				gpu_crit: gpu-crit {
++					/* milliCelsius */
++					temperature = <100000>;
++					hysteresis = <2000>;
++					type = "critical";
++				};
++			};
+ 		};
+ 	};
+ };
+-- 
+2.35.3
+

--- a/patch/kernel/archive/sunxi-6.1/patches.megous/arm64-dts-allwinner-h6-Enable-hdmi-sound-card-on-boards-with-hd.patch
+++ b/patch/kernel/archive/sunxi-6.1/patches.megous/arm64-dts-allwinner-h6-Enable-hdmi-sound-card-on-boards-with-hd.patch
@@ -39,8 +39,8 @@ index 9ec49ac2f..c8cdab585 100644
 +};
 +
  &spdif {
- 	status = "okay";
- };
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&spdif_tx_pin>;
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-3.dts b/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-3.dts
 index c2ea73d43..ead12d861 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-3.dts

--- a/patch/kernel/archive/sunxi-6.1/patches.megous/media-gc2145-Galaxycore-camera-module-driver.patch
+++ b/patch/kernel/archive/sunxi-6.1/patches.megous/media-gc2145-Galaxycore-camera-module-driver.patch
@@ -17,7 +17,7 @@ diff --git a/drivers/media/i2c/Kconfig b/drivers/media/i2c/Kconfig
 index 1ebea5f24157..ca8f115efd28 100644
 --- a/drivers/media/i2c/Kconfig
 +++ b/drivers/media/i2c/Kconfig
-@@ -793,6 +793,16 @@ config VIDEO_HM5065
+@@ -800,6 +800,16 @@ config VIDEO_HM5065
  	  This is a V4L2 sensor-level driver for Himax HM5065
  	  5 Mpixel camera.
  
@@ -31,7 +31,7 @@ index 1ebea5f24157..ca8f115efd28 100644
 +	  This is a V4L2 sensor-level driver for GalaxyCore GC2145
 +	  2 Mpixel camera.
 +
- endmenu
+ endif
  
  menu "Lens drivers"
 diff --git a/drivers/media/i2c/Makefile b/drivers/media/i2c/Makefile

--- a/patch/kernel/archive/sunxi-6.1/patches.megous/media-hm5065-Add-subdev-driver-for-Himax-HM5065-camera-sensor.patch
+++ b/patch/kernel/archive/sunxi-6.1/patches.megous/media-hm5065-Add-subdev-driver-for-Himax-HM5065-camera-sensor.patch
@@ -25,7 +25,7 @@ diff --git a/drivers/media/i2c/Kconfig b/drivers/media/i2c/Kconfig
 index 7806d4b81716..1ebea5f24157 100644
 --- a/drivers/media/i2c/Kconfig
 +++ b/drivers/media/i2c/Kconfig
-@@ -783,6 +783,16 @@ source "drivers/media/i2c/ccs/Kconfig"
+@@ -790,6 +790,16 @@ source "drivers/media/i2c/ccs/Kconfig"
  source "drivers/media/i2c/et8ek8/Kconfig"
  source "drivers/media/i2c/m5mols/Kconfig"
  
@@ -39,7 +39,7 @@ index 7806d4b81716..1ebea5f24157 100644
 +	  This is a V4L2 sensor-level driver for Himax HM5065
 +	  5 Mpixel camera.
 +
- endmenu
+ endif
  
  menu "Lens drivers"
 diff --git a/drivers/media/i2c/Makefile b/drivers/media/i2c/Makefile

--- a/patch/kernel/archive/sunxi-6.1/patches.megous/media-ov5640-Don-t-powerup-the-sensor-during-driver-probe.patch
+++ b/patch/kernel/archive/sunxi-6.1/patches.megous/media-ov5640-Don-t-powerup-the-sensor-during-driver-probe.patch
@@ -17,7 +17,7 @@ diff --git a/drivers/media/i2c/ov5640.c b/drivers/media/i2c/ov5640.c
 index 75d7ed443..a9fee7ed9 100644
 --- a/drivers/media/i2c/ov5640.c
 +++ b/drivers/media/i2c/ov5640.c
-@@ -2472,6 +2472,7 @@ static void ov5640_reset(struct ov5640_dev *sensor)
+@@ -2493,6 +2493,7 @@ static void ov5640_powerup_sequence(struct ov5640_dev *sensor)
  static int ov5640_set_power_on(struct ov5640_dev *sensor)
  {
  	struct i2c_client *client = sensor->i2c_client;
@@ -25,7 +25,7 @@ index 75d7ed443..a9fee7ed9 100644
  	int ret;
  
  	ret = clk_prepare_enable(sensor->xclk);
-@@ -2496,6 +2497,13 @@ static int ov5640_set_power_on(struct ov5640_dev *sensor)
+@@ -2516,6 +2517,13 @@ static int ov5640_set_power_on(struct ov5640_dev *sensor)
  	if (ret)
  		goto power_off;
  
@@ -39,7 +39,7 @@ index 75d7ed443..a9fee7ed9 100644
  	return 0;
  
  power_off:
-@@ -3797,28 +3805,6 @@ static int ov5640_get_regulators(struct ov5640_dev *sensor)
+@@ -3813,28 +3821,6 @@ static int ov5640_get_regulators(struct ov5640_dev *sensor)
  				       sensor->supplies);
  }
  
@@ -68,8 +68,8 @@ index 75d7ed443..a9fee7ed9 100644
  static int ov5640_probe(struct i2c_client *client)
  {
  	struct device *dev = &client->dev;
-@@ -3922,14 +3908,9 @@ static int ov5640_probe(struct i2c_client *client)
- 		goto entity_cleanup;
+@@ -3938,14 +3924,9 @@ static int ov5640_probe(struct i2c_client *client)
+ 		goto free_ctrls;
  	}
  
 -	pm_runtime_set_active(dev);

--- a/patch/kernel/archive/sunxi-6.1/patches.megous/of-property-fw_devlink-Support-allwinner-sram-links.patch
+++ b/patch/kernel/archive/sunxi-6.1/patches.megous/of-property-fw_devlink-Support-allwinner-sram-links.patch
@@ -18,8 +18,8 @@ diff --git a/drivers/of/property.c b/drivers/of/property.c
 index 134cfc980b70..1111895070a4 100644
 --- a/drivers/of/property.c
 +++ b/drivers/of/property.c
-@@ -1383,6 +1383,27 @@ static struct device_node *parse_interrupts(struct device_node *np,
- 	return of_irq_parse_one(np, index, &sup_args) ? NULL : sup_args.np;
+@@ -1338,6 +1338,27 @@ static struct device_node *parse_remote_endpoint(struct device_node *np,
+ 	return of_graph_get_remote_port_parent(np);
  }
  
 +static struct device_node *parse_allwinner_sram(struct device_node *np,
@@ -46,7 +46,7 @@ index 134cfc980b70..1111895070a4 100644
  static const struct supplier_bindings of_supplier_bindings[] = {
  	{ .parse_prop = parse_clocks, },
  	{ .parse_prop = parse_interconnects, },
-@@ -1417,6 +1438,7 @@ static const struct supplier_bindings of_supplier_bindings[] = {
+@@ -1373,6 +1394,7 @@ static const struct supplier_bindings of_supplier_bindings[] = {
  	{ .parse_prop = parse_regulators, },
  	{ .parse_prop = parse_gpio, },
  	{ .parse_prop = parse_gpios, },

--- a/patch/kernel/archive/sunxi-6.1/patches.megous/usb-typec-tcpm-Unregister-altmodes-before-registering-new-ones.patch
+++ b/patch/kernel/archive/sunxi-6.1/patches.megous/usb-typec-tcpm-Unregister-altmodes-before-registering-new-ones.patch
@@ -38,8 +38,8 @@ diff --git a/drivers/usb/typec/tcpm/tcpm.c b/drivers/usb/typec/tcpm/tcpm.c
 index 293f8cc951c9..b9f023e601a5 100644
 --- a/drivers/usb/typec/tcpm/tcpm.c
 +++ b/drivers/usb/typec/tcpm/tcpm.c
-@@ -1549,6 +1549,9 @@ static void tcpm_register_partner_altmodes(struct tcpm_port *port)
- 	int i;
+@@ -1575,6 +1575,9 @@ static void tcpm_register_partner_altmodes(struct tcpm_port *port)
+ 		return;
  
  	for (i = 0; i < modep->altmodes; i++) {
 +		typec_unregister_altmode(port->partner_altmode[i]);

--- a/patch/kernel/archive/sunxi-6.1/series.armbian
+++ b/patch/kernel/archive/sunxi-6.1/series.armbian
@@ -190,3 +190,4 @@
 	patches.armbian/drivers-hack-for-h616-hdmi-video-output.patch
 	patches.armbian/arm64-dts-h616-add-hdmi-support-for-zero2.patch
 	patches.armbian/arm64-dts-sun50i-h616-Add-dma-node.patch
+	patches.armbian/random-Revert-handle-entropy-from-atomic-process-con.patch

--- a/patch/kernel/archive/sunxi-6.1/series.conf
+++ b/patch/kernel/archive/sunxi-6.1/series.conf
@@ -393,6 +393,7 @@
 	patches.megous/ASoC-codec-rt5640-Resolve-failure-to-set-DMIC-clock-after-playb.patch
 	patches.megous/media-ov5640-Fix-sensor-probe-with-the-anti-click-patch.patch
 -	patches.megous/arm64-dts-rockchip-rk3399-pinebook-pro-Fix-VDO-display-output.patch
+	patches.megous/ARM-dts-sun8i-a83t-Add-missing-GPU-trip-point.patch
 
 ###########        Fixes applied after megous patches        ###################
 #

--- a/patch/kernel/archive/sunxi-6.1/series.conf
+++ b/patch/kernel/archive/sunxi-6.1/series.conf
@@ -548,7 +548,7 @@
 	patches.armbian/arm64-dts-sun50i-a64-olinuxino-1Ge16GW-enable-bluetooth.patch
 	patches.armbian/arm64-dts-sun50i-a64.dtsi-adjust-thermal-trip-points.patch
 	patches.armbian/arm64-dts-sun50i-a64-olinuxino-1Ge16GW-Disable-clock-phase-and-.patch
--	patches.armbian/arm64-dts-sun50i-a64-pinephone-wowlan.patch
+	patches.armbian/arm64-dts-sun50i-a64-pinephone-wowlan.patch
 	patches.armbian/arm64-dts-sun50i-h6-orangepi-3-add-r_uart-aliase.patch
 	patches.armbian/arm64-dts-sun50i-h5-add-cpu-opp-refs.patch
 	patches.armbian/arm64-dts-sun50i-h5-add-termal-zones.patch
@@ -569,8 +569,8 @@
 	patches.armbian/arm64-dts-sun50i-h5-nanopi-r1s-h5-add-rtl8153-support.patch
 	patches.armbian/net-usb-r8152-add-LED-configuration-from-OF.patch
 	patches.armbian/arm64-dts-sun50i-h6-orangepi.dtsi-Rollback-r_rsb-to-r_i2c.patch
--	patches.armbian/arm-dts-sunxi-h3-h5-add_tve.patch
--	patches.armbian/arm-dts-sun8i-h3-fix-thermal-read.patch
+	patches.armbian/arm-dts-sunxi-h3-h5-add_tve.patch
+	patches.armbian/arm-dts-sun8i-h3-fix-thermal-read.patch
 	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1.patch
 	patches.armbian/arm-dts-sun8i-h3-nanopi-duo2-enable-powerbutton-and-ethernet.patch
 	patches.armbian/arm-dts-sun8i-h3-reduce-opp-microvolt-to-prevent-not.patch

--- a/patch/kernel/archive/sunxi-6.1/series.conf
+++ b/patch/kernel/archive/sunxi-6.1/series.conf
@@ -594,3 +594,4 @@
 	patches.armbian/drivers-hack-for-h616-hdmi-video-output.patch
 	patches.armbian/arm64-dts-h616-add-hdmi-support-for-zero2.patch
 	patches.armbian/arm64-dts-sun50i-h616-Add-dma-node.patch
+	patches.armbian/random-Revert-handle-entropy-from-atomic-process-con.patch

--- a/patch/kernel/archive/sunxi-6.1/series.conf
+++ b/patch/kernel/archive/sunxi-6.1/series.conf
@@ -548,7 +548,7 @@
 	patches.armbian/arm64-dts-sun50i-a64-olinuxino-1Ge16GW-enable-bluetooth.patch
 	patches.armbian/arm64-dts-sun50i-a64.dtsi-adjust-thermal-trip-points.patch
 	patches.armbian/arm64-dts-sun50i-a64-olinuxino-1Ge16GW-Disable-clock-phase-and-.patch
-	patches.armbian/arm64-dts-sun50i-a64-pinephone-wowlan.patch
+-	patches.armbian/arm64-dts-sun50i-a64-pinephone-wowlan.patch
 	patches.armbian/arm64-dts-sun50i-h6-orangepi-3-add-r_uart-aliase.patch
 	patches.armbian/arm64-dts-sun50i-h5-add-cpu-opp-refs.patch
 	patches.armbian/arm64-dts-sun50i-h5-add-termal-zones.patch
@@ -569,8 +569,8 @@
 	patches.armbian/arm64-dts-sun50i-h5-nanopi-r1s-h5-add-rtl8153-support.patch
 	patches.armbian/net-usb-r8152-add-LED-configuration-from-OF.patch
 	patches.armbian/arm64-dts-sun50i-h6-orangepi.dtsi-Rollback-r_rsb-to-r_i2c.patch
-	patches.armbian/arm-dts-sunxi-h3-h5-add_tve.patch
-	patches.armbian/arm-dts-sun8i-h3-fix-thermal-read.patch
+-	patches.armbian/arm-dts-sunxi-h3-h5-add_tve.patch
+-	patches.armbian/arm-dts-sun8i-h3-fix-thermal-read.patch
 	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1.patch
 	patches.armbian/arm-dts-sun8i-h3-nanopi-duo2-enable-powerbutton-and-ethernet.patch
 	patches.armbian/arm-dts-sun8i-h3-reduce-opp-microvolt-to-prevent-not.patch

--- a/patch/kernel/archive/sunxi-6.1/series.megous
+++ b/patch/kernel/archive/sunxi-6.1/series.megous
@@ -393,3 +393,4 @@
 	patches.megous/ASoC-codec-rt5640-Resolve-failure-to-set-DMIC-clock-after-playb.patch
 	patches.megous/media-ov5640-Fix-sensor-probe-with-the-anti-click-patch.patch
 -	patches.megous/arm64-dts-rockchip-rk3399-pinebook-pro-Fix-VDO-display-output.patch
+	patches.megous/ARM-dts-sun8i-a83t-Add-missing-GPU-trip-point.patch


### PR DESCRIPTION
Fix: dtb dtbo install, wrong select media sensors

Disable incorrectly designed patches.
They need to be aligned with the kernel code.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] Test build sunxi
- [ ] Test build sunxi64
