### PR TITLE
Bananapi M5: Bump u-boot to v2024.07 final

### DIFF
--- a/config/boards/bananapim5.conf
+++ b/config/boards/bananapim5.conf
@@ -9,8 +9,8 @@ MODULES_BLACKLIST="simpledrm" # SimpleDRM conflicts with Panfrost
 FULL_DESKTOP="yes"
 SERIALCON="ttyAML0"
 BOOT_LOGO="desktop"
-BOOTBRANCH_BOARD="tag:v2023.07.02"
-BOOTPATCHDIR="v2023.07.02"
+BOOTBRANCH_BOARD="tag:v2024.07"
+BOOTPATCHDIR="v2024.07"
 
 function fetch_sources_tools__libreelec_amlogic_fip_pre_m5_blob_update() {
 	fetch_from_repo "https://github.com/Dangku/amlogic-boot-fip" "amlogic-boot-fip" "branch:master"


### PR DESCRIPTION
# Description

Bump u-boot to latest.

# How Has This Been Tested?

- [x] Boot from SD card
- [x] Installed and boot from eMMC

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
