### PR TITLE
nanopi-r6s: Use mainline U-Boot

### DIFF
--- a/config/boards/nanopi-r6s.csc
+++ b/config/boards/nanopi-r6s.csc
@@ -32,3 +32,25 @@ function post_family_tweaks__nanopir6s_naming_udev_network_interfaces() {
 		SUBSYSTEM=="net", ACTION=="add", DRIVERS=="r8169", KERNELS=="0004:41:00.0", NAME:="lan2"
 	EOF
 }
+
+# Mainline U-Boot
+function post_family_config__nanopi_r6s_use_mainline_uboot() {
+	display_alert "$BOARD" "Using mainline U-Boot for $BOARD / $BRANCH" "info"
+
+	declare -g BOOTCONFIG="generic-rk3588_defconfig"             # Use generic defconfig which should boot all RK3588 boards
+	declare -g BOOTDELAY=1                                       # Wait for UART interrupt to enter UMS/RockUSB mode etc
+	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git" # We ❤️ Mainline U-Boot
+	declare -g BOOTBRANCH="tag:v2024.07"
+	declare -g BOOTPATCHDIR="v2024.07"
+	# Don't set BOOTDIR, allow shared U-Boot source directory for disk space efficiency
+
+	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin"
+
+	# Disable stuff from rockchip64_common; we're using binman here which does all the work already
+	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd
+
+	# Just use the binman-provided u-boot-rockchip.bin, which is ready-to-go
+	function write_uboot_platform() {
+		dd "if=$1/u-boot-rockchip.bin" "of=$2" bs=32k seek=1 conv=notrunc status=none
+	}
+}


### PR DESCRIPTION
# Description

The same configuration has been working fine for the similar NanoPi R6C for a while. Users have reported issues with the vendor U-Boot not able to boot.

Ref: https://forum.armbian.com/topic/42105-report-bug-in-nanopi-r6s/

# How Has This Been Tested?

- [x] `./compile.sh BOARD=nanopi-r6s BRANCH=edge BUILD_DESKTOP=no BUILD_MINIMAL=no EXPERT=yes KERNEL_CONFIGURE=no RELEASE=trixie uboot`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
