### PR TITLE
Move the `NETWORKING_STACK` in main config and add armhf support to Trixie

### DIFF
--- a/config/distributions/noble/architectures
+++ b/config/distributions/noble/architectures
@@ -1,1 +1,1 @@
-armhf,arm64,riscv64,amd64
+arm64,armhf,riscv64,amd64

--- a/config/distributions/oracular/architectures
+++ b/config/distributions/oracular/architectures
@@ -1,1 +1,1 @@
-armhf,arm64,riscv64,amd64
+arm64,armhf,riscv64,amd64

--- a/config/distributions/trixie/architectures
+++ b/config/distributions/trixie/architectures
@@ -1,1 +1,1 @@
-arm64,amd64
+arm64,armhf,amd64

--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -62,7 +62,9 @@ function do_main_configuration() {
 	declare -g SKIP_EXTERNAL_TOOLCHAINS="${SKIP_EXTERNAL_TOOLCHAINS:-yes}" # don't use any external toolchains, by default.
 
 	# Network stack to use, default to network-manager; configuration can override this.
+	# Will be made read-only further down.
 	declare -g NETWORKING_STACK="${NETWORKING_STACK}"
+
 	# If empty, default depending on BUILD_MINIMAL; if yes, use systemd-networkd; if no, use network-manager.
 	if [[ -z "${NETWORKING_STACK}" ]]; then
 		display_alert "NETWORKING_STACK not set" "Calculating defaults" "debug"
@@ -78,27 +80,6 @@ function do_main_configuration() {
 	else
 		display_alert "NETWORKING_STACK is preset during configuration" "NETWORKING_STACK: ${NETWORKING_STACK}" "debug"
 	fi
-	# Now make it read-only, as further changes would make the whole thing inconsistent.
-	# Individual networking extensions should _check_ this to make there's no spurious enablement.
-	display_alert "Using NETWORKING_STACK" "NETWORKING_STACK: ${NETWORKING_STACK}" "info"
-	declare -g -r NETWORKING_STACK="${NETWORKING_STACK}"
-
-	# Now enable extensions according to the configuration.
-	case "${NETWORKING_STACK}" in
-		"network-manager")
-			display_alert "Adding networking extensions" "net-network-manager, net-chrony" "info"
-			enable_extension "net-network-manager"
-			enable_extension "net-chrony"
-			;;
-		"systemd-networkd")
-			display_alert "Adding networking extensions" "net-systemd-networkd, net-systemd-timesyncd" "info"
-			enable_extension "net-systemd-networkd"
-			enable_extension "net-systemd-timesyncd"
-			;;
-		"none" | *)
-			display_alert "NETWORKING_STACK=${NETWORKING_STACK}" "Not adding networking extensions" "info"
-			;;
-	esac
 
 	# Timezone
 	if [[ -f /etc/timezone ]]; then # Timezone for target is taken from host, if it exists.
@@ -293,13 +274,41 @@ function do_main_configuration() {
 	# single ext4 partition is the default and preferred configuration
 	#BOOTFS_TYPE=''
 
-	## ------ Sourcing family config ---------------------------
+	###
+	### ------------------- Sourcing family config -------------------
+	###
 	source_family_config_and_arch
 
 	if [[ "$HAS_VIDEO_OUTPUT" == "no" ]]; then
 		PLYMOUTH="no"
 		[[ $BUILD_DESKTOP != "no" ]] && exit_with_error "HAS_VIDEO_OUTPUT is set to no. So we shouldn't build desktop environment"
 	fi
+
+	# Make NETWORKING_STACK read-only, as further changes would make the whole thing inconsistent.
+	# But only after family config to allow family to change it (post-family hooks CANNOT change NETWORKING_STACK since the hook is running after this).
+	# Individual networking extensions should _check_ this to make there's no spurious enablement.
+	display_alert "Using NETWORKING_STACK" "NETWORKING_STACK: ${NETWORKING_STACK}" "info"
+	declare -g -r NETWORKING_STACK="${NETWORKING_STACK}"
+
+	# Now enable extensions according to the configuration.
+	case "${NETWORKING_STACK}" in
+		"network-manager")
+			display_alert "Adding networking extensions" "net-network-manager, net-chrony" "info"
+			enable_extension "net-network-manager"
+			enable_extension "net-chrony"
+			;;
+		"systemd-networkd")
+			display_alert "Adding networking extensions" "net-systemd-networkd, net-systemd-timesyncd" "info"
+			enable_extension "net-systemd-networkd"
+			enable_extension "net-systemd-timesyncd"
+			;;
+		"none")
+			display_alert "NETWORKING_STACK=${NETWORKING_STACK}" "Not adding networking extensions" "info"
+			;;
+		*)
+			display_alert "NETWORKING_STACK=${NETWORKING_STACK}" "Invalid value? Not adding networking extensions" "wrn"
+			;;
+	esac
 
 	## Extensions: at this point we've sourced all the config files that will be used,
 	##             and (hopefully) not yet invoked any extension methods. So this is the perfect


### PR DESCRIPTION
# Description

Split off from https://github.com/armbian/build/pull/6902 as requested by @rpardini 

- Add armhf support to Trixie
- Move the `NETWORKING_STACK` in main config to after family config to allow the family config to change it.

# How Has This Been Tested?

- [x] `./compile.sh BOARD=bananapir2 BRANCH=current BUILD_DESKTOP=no BUILD_MINIMAL=no EXPERT=yes KERNEL_CONFIGURE=no RELEASE=trixie`
- [x] `./compile.sh BOARD=bananapir2 BRANCH=current BUILD_DESKTOP=no BUILD_MINIMAL=no EXPERT=yes KERNEL_CONFIGURE=no RELEASE=noble`
