### PR TITLE
thinkpad-x13s: bump to jhovold's `wip/sc8280xp-6.10-rc6`; add fprintd back to Trixie; fixes

### DIFF
--- a/config/boards/thinkpad-x13s.wip
+++ b/config/boards/thinkpad-x13s.wip
@@ -29,7 +29,7 @@ declare -g BOARD_FIRMWARE_INSTALL="-full"
 
 function post_family_config_branch_sc8280xp__jhovolds_69y_kernel() {
 	declare -g KERNEL_MAJOR_MINOR="6.9" # Major and minor versions of this kernel.
-	declare -g KERNELBRANCH='branch:wip/sc8280xp-6.9-rc7'
+	declare -g KERNELBRANCH='branch:wip/sc8280xp-6.10-rc6'
 	declare -g KERNELSOURCE='https://github.com/jhovold/linux.git'
 	declare -g LINUXCONFIG="linux-${ARCH}-${BRANCH}" # for this board: linux-arm64-sc8280xp
 	display_alert "Set up jhovold's kernel ${KERNELBRANCH} for" "${BOARD}" "info"
@@ -57,12 +57,12 @@ function post_family_config__debian_now_has_userspace_for_the_x13s() {
 	add_packages_to_image "acpi"                     # general ACPI support
 	add_packages_to_image "zstd"                     # for zstd compression of initrd
 
-	# Trixie, as of 2023-10-13, is missing fprintd and libpam-fprintd; see https://tracker.debian.org/pkg/fprintd and https://tracker.debian.org/pkg/libpam-fprintd
-	# @TODO: check again later, and remove this if it's there
-	if [[ "${RELEASE}" != "trixie" ]]; then
-		add_packages_to_image "fprintd"        # for fingerprint reader; see https://packages.ubuntu.com/fprintd and https://packages.debian.org/fprintd
-		add_packages_to_image "libpam-fprintd" # for fingerprint reader PAM support; see https://packages.ubuntu.com/libpam-fprintd and https://packages.debian.org/libpam-fprintd
-	fi
+	## Trixie, as of 2023-10-13, is missing fprintd and libpam-fprintd; see https://tracker.debian.org/pkg/fprintd and https://tracker.debian.org/pkg/libpam-fprintd
+	## rpardini: checked on 2024-07-07 and they're back!
+	#if [[ "${RELEASE}" != "trixie" ]]; then
+	#	add_packages_to_image "fprintd"        # for fingerprint reader; see https://packages.ubuntu.com/fprintd and https://packages.debian.org/fprintd
+	#	add_packages_to_image "libpam-fprintd" # for fingerprint reader PAM support; see https://packages.ubuntu.com/libpam-fprintd and https://packages.debian.org/libpam-fprintd
+	#fi
 
 	# Also needed, not listed here:
 	# - mesa > 23.1.5; see https://packages.ubuntu.com/mesa-vulkan-drivers and https://packages.debian.org/mesa-vulkan-drivers
@@ -162,7 +162,7 @@ function post_family_tweaks_bsp__thinkpad_x13s_bsp_modules_in_initrd() {
 		pmic_glink_altmode
 		leds_qcom_lpg
 		qcom_q6v5_pas  # This module loads a lot of FW blobs
-		panel-edp
+		panel_edp
 		msm
 		nvme
 		usb_storage


### PR DESCRIPTION
#### thinkpad-x13s: bump to jhovold's `wip/sc8280xp-6.10-rc6`; add fprintd back to Trixie; fixes

- thinkpad-x13s: bump to jhovold's `wip/sc8280xp-6.10-rc6`; add fprintd back to Trixie; fixes
  - adapt according to most recent instructions from jhovold:
    - https://github.com/jhovold/linux/wiki/X13s
    - https://github.com/jhovold/linux/commit/993ae484d12ae6323647638000ed683c5222feb3