### PR TITLE
partitioning: Reduce `commit` mount option for btrfs and ext4 to 120

### DIFF
--- a/config/boards/recore.csc
+++ b/config/boards/recore.csc
@@ -18,7 +18,7 @@ function post_family_config__shrink_atf() {
 
 function format_partitions__make_boot_ro() {
 	display_alert "Making boot partition ro 🍰" "recore"
-	sed -i 's:/boot ext4 defaults,commit=600,errors=remount-ro:/boot ext4 ro,defaults:' $SDCARD/etc/fstab
+	sed -i 's:/boot ext4 defaults,commit=120,errors=remount-ro:/boot ext4 ro,defaults:' $SDCARD/etc/fstab
 }
 
 function extension_finish_config__enable_plymouth() {

--- a/lib/functions/image/partitioning.sh
+++ b/lib/functions/image/partitioning.sh
@@ -53,9 +53,9 @@ function prepare_partitions() {
 	fi
 
 	# mkopts[fat] is empty
-	mkopts[ext2]=''
+	# mkopts[ext2] is empty
 	# mkopts[f2fs] is empty
-	mkopts[btrfs]='-m dup'
+	mkopts[btrfs]='-m dup' # '-m dup' is already the default https://man.archlinux.org/man/mkfs.btrfs.8#m_
 	# mkopts[nilfs2] is empty
 	# mkopts[xfs] is empty
 	# mkopts[nfs] is empty
@@ -78,11 +78,11 @@ function prepare_partitions() {
 	mkfs[xfs]=xfs
 	# mkfs[nfs] is empty
 
-	mountopts[ext4]=',commit=600,errors=remount-ro'
+	mountopts[ext4]=',commit=120,errors=remount-ro' # EXT4 default: 5 (https://www.man7.org/linux/man-pages/man5/ext4.5.html)
 	# mountopts[ext2] is empty
 	# mountopts[fat] is empty
 	# mountopts[f2fs] is empty
-	mountopts[btrfs]=',commit=600'
+	mountopts[btrfs]=',commit=120' # BTRFS default: 30 (https://btrfs.readthedocs.io/en/latest/ch-mount-options.html)
 	# mountopts[nilfs2] is empty
 	# mountopts[xfs] is empty
 	# mountopts[nfs] is empty

--- a/packages/bsp/common/usr/sbin/armbian-install
+++ b/packages/bsp/common/usr/sbin/armbian-install
@@ -91,8 +91,9 @@ fi
 mkopts[btrfs]='-f'
 mkopts[f2fs]='-f'
 
-mountopts[ext4]='defaults,noatime,commit=600,errors=remount-ro,x-gvfs-hide	0	1'
-mountopts[btrfs]='defaults,noatime,commit=600,compress=lzo,x-gvfs-hide			0	2'
+# @TODO source these options from one source, this is mostly defined in partioning.sh
+mountopts[ext4]='defaults,noatime,commit=120,errors=remount-ro,x-gvfs-hide	0	1'
+mountopts[btrfs]='defaults,noatime,commit=120,compress=lzo,x-gvfs-hide			0	2'
 mountopts[f2fs]='defaults,noatime,x-gvfs-hide	0	2'
 
 # Create boot and root file system #
@@ -241,8 +242,9 @@ create_armbian()
 	if [[ $1 == *nand* ]]; then
 		echo "Finishing installation to NAND." >> $logfile
 		REMOVESDTXT="and remove SD to boot from NAND"
+		# @TODO source these fstab options from one source, this is mostly defined in partioning.sh
 		echo "$1 /boot vfat	defaults 0 0" >> "${TempDir}"/rootfs/etc/fstab
-		echo "$2 / ext4 defaults,noatime,commit=600,errors=remount-ro 0 1" >> "${TempDir}"/rootfs/etc/fstab
+		echo "$2 / ext4 defaults,noatime,commit=120,errors=remount-ro 0 1" >> "${TempDir}"/rootfs/etc/fstab
 		dialog --title "$title" --backtitle "$backtitle" --infobox "\nConverting kernel ... few seconds." 5 60
 		mkimage -A arm -O linux -T kernel -C none -a "0x40008000" -e "0x40008000" -n "Linux kernel" -d \
 			/boot/zImage "${TempDir}"/bootfs/uImage >/dev/null 2>&1


### PR DESCRIPTION
# Description

Mount option `commit=600` (=10 minutes) seems pretty high.
Reduce it to 120 for ext4 (default for ext4 is `commit=5`) and 120 for btrfs (default for btrfs is `commit=30`) to reduce risk of losing data on power loss.

Only verly low settings (maybe 1-10) will have impact on performance according to documentation.

**From ext4:**

> **commit=nrsec (*)**
> 
> This setting limits the maximum age of the running transaction to ‘nrsec’ seconds. The default value is 5 seconds. This means that if you lose your power, you will lose as much as the latest 5 seconds of metadata changes (your filesystem will not be damaged though, thanks to the journaling). This default value (or any low value) will hurt performance, but it’s good for data-safety. Setting it to 0 will have the same effect as leaving it at the default (5 seconds). Setting it to very large values will improve performance. Note that due to delayed allocation even older data can be lost on power failure since writeback of those data begins only after time set in /proc/sys/vm/dirty_expire_centisecs.

**From btrfs:**

> **commit=<seconds>**
> 
> (since: 3.12, default: 30)
> 
> Set the interval of periodic transaction commit when data are synchronized to permanent storage. Higher interval values lead to larger amount of unwritten data, which has obvious consequences when the system crashes. The upper bound is not forced, but a warning is printed if it’s more than 300 seconds (5 minutes). Use with care.


Sources:
- https://www.kernel.org/doc/html/latest/admin-guide/ext4.html
- https://wiki.archlinux.org/title/Btrfs#Commit_interval
- https://btrfs.readthedocs.io/en/latest/Administration.html

# How Has This Been Tested?

- [x] Change is reflected in fstab

# Checklist:


- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings