### PR TITLE
extensions: Establish some consistency with extension logging

### DIFF
--- a/extensions/armbian-live-patch.sh
+++ b/extensions/armbian-live-patch.sh
@@ -1,6 +1,6 @@
 function post_family_tweaks_bsp__armbian-live-patch() {
 
-	display_alert "Installing Armbian Live Patch" "${EXTENSION}" "info"
+	display_alert "Extension: ${EXTENSION}: Installing Armbian Live Patch" "${EXTENSION}" "info"
 
 	run_host_command_logged cat <<- 'armbian-live-patch' > "${destination}"/etc/systemd/system/armbian-live-patch.service
 		# Armbian simple patch system service

--- a/extensions/bluetooth-hciattach.sh
+++ b/extensions/bluetooth-hciattach.sh
@@ -8,11 +8,11 @@
 # To use, enable_extension bluetooth-hciattach, and set BLUETOOTH_HCIATTACH_PARAMS and BLUETOOTH_HCIATTACH_RKFILL_NUM.
 
 function extension_prepare_config__bluetooth_hciattach() {
-	display_alert "${EXTENSION} ${BOARD}" "initializing config" "info"
+	display_alert "Extension: ${EXTENSION}: ${BOARD}" "initializing config" "info"
 
 	# Bomb if BLUETOOTH_HCIATTACH_PARAMS is not set.
 	if [[ -z "${BLUETOOTH_HCIATTACH_PARAMS}" ]]; then
-		exit_with_error "${EXTENSION} ${BOARD} - BLUETOOTH_HCIATTACH_PARAMS is not set - please set in the board file."
+		exit_with_error "Extension: ${EXTENSION}: ${BOARD} - BLUETOOTH_HCIATTACH_PARAMS is not set - please set in the board file."
 	fi
 
 	# Default BLUETOOTH_HCIATTACH_RKFILL_NUM to 0 if not set.
@@ -23,13 +23,13 @@ function extension_prepare_config__bluetooth_hciattach() {
 
 # Add bluetooth packages to the image (not rootfs cache)
 function post_family_config__bluetooth_hciattach_add_bluetooth_packages() {
-	display_alert "${EXTENSION} ${BOARD}" "adding bluetooth packages to image" "info"
+	display_alert "Extension: ${EXTENSION}: ${BOARD}" "adding bluetooth packages to image" "info"
 	add_packages_to_image rfkill bluetooth bluez bluez-tools
 }
 
 # Deploy the script and the systemd service in the BSP. It'll be enabled below in the image.
 function post_family_tweaks_bsp__bluetooth_hciattach_add_systemd_service() {
-	display_alert "${EXTENSION} ${BOARD}" "adding bluetooth hciattach service to BSP" "info"
+	display_alert "Extension: ${EXTENSION}: ${BOARD}" "adding bluetooth hciattach service to BSP" "info"
 	: "${destination:?destination is not set}"
 
 	declare script_dir="/usr/local/sbin"
@@ -61,7 +61,7 @@ function post_family_tweaks_bsp__bluetooth_hciattach_add_systemd_service() {
 
 # Enable the service created in the BSP above.
 function post_family_tweaks__bluetooth_hciattach_enable_bt_service_in_image() {
-	display_alert "${EXTENSION} ${BOARD}" "enabling bluetooth hciattach service in the image" "info"
+	display_alert "Extension: ${EXTENSION}: ${BOARD}" "enabling bluetooth hciattach service in the image" "info"
 
 	chroot_sdcard systemctl --no-reload enable "bluetooth-hciattach.service"
 

--- a/extensions/c-plus-plus-compiler.sh
+++ b/extensions/c-plus-plus-compiler.sh
@@ -2,6 +2,6 @@
 # Enable this extension if you need a C++ compiler during the build.
 
 function add_host_dependencies__add_arm64_c_plus_plus_compiler() {
-	display_alert "Adding arm64 c++ compiler to host dependencies" "g++" "debug"
+	display_alert "Extension: ${EXTENSION}: Adding arm64 c++ compiler to host dependencies" "g++" "debug"
 	declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} g++-aarch64-linux-gnu g++" # @TODO: convert to array later
 }

--- a/extensions/cleanup-space-final-image.sh
+++ b/extensions/cleanup-space-final-image.sh
@@ -22,15 +22,15 @@ function post_umount_final_image__200_zerofree() {
 		local partType
 		partType="$(file -s "${partDev}" | awk -F ': ' '{print $2}')"
 		if [[ "${partType}" == *"ext4"* ]]; then
-			display_alert "Zerofreeing ext4 partition ${partDev}" "${EXTENSION}" "info"
+			display_alert "Extension: ${EXTENSION}: Zerofreeing ext4 partition ${partDev}" "${EXTENSION}" "info"
 			run_host_command_logged zerofree "${partDev}"
 		else
-			display_alert "Skipping zerofreeing partition ${partDev} of type '${partType}'" "${EXTENSION}" "info"
+			display_alert "Extension: ${EXTENSION}: Skipping zerofreeing partition ${partDev} of type '${partType}'" "${EXTENSION}" "info"
 		fi
 	done
 }
 
 function pre_umount_final_image__999_show_space_usage() {
-	display_alert "Calculating used space in image" "${EXTENSION}" "info"
+	display_alert "Extension: ${EXTENSION}: Calculating used space in image" "${EXTENSION}" "info"
 	run_host_command_logged "cd ${MOUNT} && " du -h -d 4 -x "." "| sort -h | tail -20"
 }

--- a/extensions/cloud-init/cloud-init.sh
+++ b/extensions/cloud-init/cloud-init.sh
@@ -23,6 +23,7 @@ function extension_prepare_config__ci_image_suffix() {
 
 function extension_prepare_config__prepare_ci() {
 	# Cloud Init related packages selected from Ubuntu RPI distirbution
+	display_alert "Extension: ${EXTENSION}: Adding extra packages to image" "cloud-init cloud-initramfs-dyn-netconf" "info"
 	add_packages_to_image cloud-init cloud-initramfs-dyn-netconf
 }
 
@@ -30,23 +31,23 @@ function extension_prepare_config__ci_compatibility_check() {
 	# We require fat boot partition, will change and if the user provided another type, will fail.
 	if [[ -z "${BOOTFS_TYPE}" ]]; then
 		declare -g BOOTFS_TYPE="fat"
-		display_alert "Changing BOOTFS_TYPE" "cloud_init requires a fat partition" "warn"
+		display_alert "Extension: ${EXTENSION}: Changing BOOTFS_TYPE" "cloud_init requires a fat partition" "warn"
 	fi
 
 	if [[ "${BOOTFS_TYPE}" != "fat" ]]; then
-		exit_with_error "BOOTFS_TYPE ${BOOTFS_TYPE} not compatible with cloud-init"
+		exit_with_error "Extension: ${EXTENSION}: BOOTFS_TYPE ${BOOTFS_TYPE} not compatible with cloud-init"
 	fi
 }
 
 function pre_customize_image__inject_cloud_init_config() {
 	# Copy the NoCLoud Cloud-Init Configuration
-	display_alert "Configuring" "cloud-init" "info"
+	display_alert "Extension: ${EXTENSION}: Configuring" "cloud-init" "info"
 	local config_src="${EXTENSION_DIR}/config"
 	local config_dst="${SDCARD}/etc/cloud/cloud.cfg.d"
 	run_host_command_logged cp ${config_src}/* $config_dst
 
 	# Provide default cloud-init files
-	display_alert "Defaults" "cloud-init" "info"
+	display_alert "Extension: ${EXTENSION}: Defaults" "cloud-init" "info"
 	local defaults_src="${EXTENSION_DIR}/defaults"
 	local defaults_dst="${SDCARD}/boot"
 	run_host_command_logged cp ${defaults_src}/* $defaults_dst
@@ -55,7 +56,7 @@ function pre_customize_image__inject_cloud_init_config() {
 
 # @TODO: would be better to have "armbian first run" as an extension that can be disabled
 function pre_customize_image__disable_armbian_first_run() {
-	display_alert "Disabling" "armbian first run" "info"
+	display_alert "Extension: ${EXTENSION}: Disabling" "armbian firstrun" "info"
 
 	# Clean up default profile and network
 	rm -f ${SDCARD}/etc/profile.d/armbian-check-first-*

--- a/extensions/fake-vcgencmd.sh
+++ b/extensions/fake-vcgencmd.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function pre_umount_final_image__install_fake_vcgencmd() {
-	display_alert "Installing fake vcgencmd" "${EXTENSION}" "info"
+	display_alert "Extension: ${EXTENSION}: Installing fake vcgencmd" "${EXTENSION}" "info"
 
 	if [[ $BOARD != rpi4b ]]; then
 		run_host_command_logged curl -vo "${MOUNT}"/usr/bin/vcgencmd "https://raw.githubusercontent.com/clach04/fake_vcgencmd/0.0.2/vcgencmd"
@@ -11,6 +11,6 @@ function pre_umount_final_image__install_fake_vcgencmd() {
 		run_host_command_logged curl -vo "${MOUNT}"/usr/share/doc/fake_vcgencmd/LICENSE "https://raw.githubusercontent.com/clach04/fake_vcgencmd/0.0.2/LICENSE"
 		run_host_command_logged curl -vo "${MOUNT}"/usr/share/doc/fake_vcgencmd/README.md "https://raw.githubusercontent.com/clach04/fake_vcgencmd/0.0.2/README.md"
 	else
-		display_alert "Omitting installation on Raspberry Pi boards as these ship the original vcgencmd" "${EXTENSION}" "info"
+		display_alert "Extension: ${EXTENSION}: Omitting installation on Raspberry Pi boards as these ship the original vcgencmd" "${EXTENSION}" "info"
 	fi
 }

--- a/extensions/fs-btrfs-support.sh
+++ b/extensions/fs-btrfs-support.sh
@@ -3,11 +3,11 @@
 # This is automatically enabled if ROOTFS_TYPE is set to btrfs in main-config.sh.
 
 function extension_prepare_config__add_to_image_btrfs-progs() {
-	display_alert "Adding btrfs-progs extra package..." "${EXTENSION}" "info"
+	display_alert "Extension: ${EXTENSION}: Adding extra package to image" "btrfs-progs" "info"
 	add_packages_to_image btrfs-progs
 }
 
 function add_host_dependencies__add_btrfs_tooling() {
-	display_alert "Adding BTRFS to host dependencies" "BTRFS" "debug"
+	display_alert "Extension: ${EXTENSION}: Adding packages to host dependencies" "btrfs-progs" "debug"
 	EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} btrfs-progs" # @TODO: convert to array later
 }

--- a/extensions/fs-cryptroot-support.sh
+++ b/extensions/fs-cryptroot-support.sh
@@ -3,12 +3,12 @@
 # This is automatically enabled if CRYPTROOT_ENABLE is set to yes in main-config.sh.
 
 function add_host_dependencies__add_cryptroot_tooling() {
-	display_alert "Adding cryptroot to host dependencies" "cryptsetup LUKS" "debug"
+	display_alert "Extension: ${EXTENSION}: Adding packages to host dependencies" "cryptsetup openssh-client" "info"
 	EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} cryptsetup openssh-client" # @TODO: convert to array later
 }
 
 function extension_prepare_config__prepare_cryptroot() {
-	display_alert "Adding rootfs encryption related packages" "cryptsetup cryptsetup-initramfs" "info"
+	display_alert "Extension: ${EXTENSION}: Adding extra packages to image" "cryptsetup cryptsetup-initramfs" "info"
 	add_packages_to_image cryptsetup cryptsetup-initramfs
 
 	# Config for cryptroot, a boot partition is required.
@@ -16,7 +16,7 @@ function extension_prepare_config__prepare_cryptroot() {
 	EXTRA_IMAGE_SUFFIXES+=("-crypt")
 
 	if [[ $CRYPTROOT_SSH_UNLOCK == yes ]]; then
-		display_alert "Adding rootfs encryption related packages" "dropbear-initramfs" "info"
+		display_alert "Extension: ${EXTENSION}: Adding extra packages to image" "dropbear-initramfs" "info"
 		add_packages_to_image dropbear-initramfs
 	fi
 }
@@ -24,10 +24,10 @@ function extension_prepare_config__prepare_cryptroot() {
 function prepare_root_device__encrypt_root_device() {
 	# We encrypt the rootdevice (currently a loop device) and return the new mapped rootdevice
 	check_loop_device "$rootdevice"
-	display_alert "Encrypting root partition with LUKS..." "cryptsetup luksFormat $rootdevice" ""
+	display_alert "Extension: ${EXTENSION}: Encrypting root partition with LUKS..." "cryptsetup luksFormat $rootdevice" ""
 	echo -n $CRYPTROOT_PASSPHRASE | cryptsetup luksFormat $CRYPTROOT_PARAMETERS $rootdevice -
 	echo -n $CRYPTROOT_PASSPHRASE | cryptsetup luksOpen $rootdevice $ROOT_MAPPER -
-	display_alert "Root partition encryption complete." "" "ext"
+	display_alert "Extension: ${EXTENSION}: Root partition encryption complete." "" "ext"
 	# TODO: pass /dev/mapper to Docker
 	rootdevice=/dev/mapper/$ROOT_MAPPER # used by `mkfs` and `mount` commands
 }
@@ -56,7 +56,7 @@ function pre_install_kernel_debs__adjust_dropbear_configuration() {
 		else
 			# generate a default ssh key for login on dropbear in initramfs
 			# this key should be changed by the user on first login
-			display_alert "Generating a new SSH key pair for dropbear (initramfs)" "" ""
+			display_alert "Extension: ${EXTENSION}: Generating a new SSH key pair for dropbear (initramfs)" "" ""
 
 			# Generate the SSH keys
 			ssh-keygen -t ecdsa -f "${dropbear_dir}"/id_ecdsa \
@@ -68,7 +68,7 @@ function pre_install_kernel_debs__adjust_dropbear_configuration() {
 			CRYPTROOT_SSH_UNLOCK_KEY_NAME="${VENDOR}_${REVISION}_${BOARD^}_${RELEASE}_${BRANCH}_${DESKTOP_ENVIRONMENT}".key
 			# copy dropbear ssh key to image output dir for convenience
 			cp "${dropbear_dir}"/id_ecdsa "${DEST}/images/${CRYPTROOT_SSH_UNLOCK_KEY_NAME}"
-			display_alert "SSH private key for dropbear (initramfs) has been copied to:" \
+			display_alert "Extension: ${EXTENSION}: SSH private key for dropbear (initramfs) has been copied to:" \
 				"$DEST/images/$CRYPTROOT_SSH_UNLOCK_KEY_NAME" "info"
 		fi
 	fi

--- a/extensions/fs-f2fs-support.sh
+++ b/extensions/fs-f2fs-support.sh
@@ -3,6 +3,6 @@
 # This is automatically enabled if ROOTFS_TYPE is set to f2fs in main-config.sh.
 
 function add_host_dependencies__add_f2fs_tooling() {
-	display_alert "Adding F2FS to host dependencies" "F2FS" "debug"
+	display_alert "Extension: ${EXTENSION}: Adding packages to host dependencies" "f2fs-tools" "debug"
 	EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} f2fs-tools" # @TODO: convert to array later
 }

--- a/extensions/fs-nilfs2-support.sh
+++ b/extensions/fs-nilfs2-support.sh
@@ -2,12 +2,12 @@
 # This is automatically enabled if ROOTFS_TYPE is set to nilfs2 in main-config.sh.
 
 function extension_prepare_config__add_to_image_nilfs-tools() {
-	display_alert "Adding nilfs-tools extra package..." "${EXTENSION}" "info"
+	display_alert "Extension: ${EXTENSION}: Adding extra packages to image" "nilfs-tools" "info"
 	add_packages_to_image nilfs-tools
 }
 
 function add_host_dependencies__add_nilfs_tools() {
-	display_alert "Adding NILFS tools to host dependencies..." "${EXTENSION}" "debug"
+	display_alert "Extension: ${EXTENSION}: Adding packages to host dependencies" "nilfs-tools" "debug"
 	EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} nilfs-tools" # @TODO: convert to array later
 }
 

--- a/extensions/fs-xfs-support.sh
+++ b/extensions/fs-xfs-support.sh
@@ -3,11 +3,11 @@
 # This is automatically enabled if ROOTFS_TYPE is set to xfs in main-config.sh.
 
 function extension_prepare_config__add_to_image_xfsprogs() {
-	display_alert "Adding xfsprogs extra package..." "${EXTENSION}" "info"
+	display_alert "Extension: ${EXTENSION}: Adding extra packages to image" "xfsprogs" "info"
 	add_packages_to_image xfsprogs
 }
 
 function add_host_dependencies__add_xfs_tooling() {
-	display_alert "Adding XFS to host dependencies" "XFS xfsprogs" "debug"
+	display_alert "Extension: ${EXTENSION}: Adding packages to host dependencies" "xfsprogs" "debug"
 	EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS} xfsprogs" # @TODO: convert to array later
 }

--- a/extensions/gen-sample-extension-docs.sh
+++ b/extensions/gen-sample-extension-docs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 ## Hooks
 function extension_metadata_ready__499_display_docs_generation_start_info() {
-	display_alert "Generating hook documentation and sample extension"
+	display_alert "Extension: ${EXTENSION}: Generating hook documentation and sample extension"
 }
 
 function extension_metadata_ready__docs_markdown() {

--- a/extensions/grub-with-dtb.sh
+++ b/extensions/grub-with-dtb.sh
@@ -18,7 +18,7 @@ function extension_prepare_config__prepare_grub_with_dtb() {
 	# Make sure BOOT_FDT_FILE is set and not empty
 	[[ -n "${BOOT_FDT_FILE}" ]] || exit_with_error "BOOT_FDT_FILE is not set, required for grub-with-dtb"
 
-	display_alert "initializing config" "${EXTENSION} :: ${BOARD}" "info"
+	display_alert "Extension: ${EXTENSION}: Initializing config" "${BOARD}" "info"
 }
 
 # Hack the bsp-cli to:
@@ -27,7 +27,7 @@ function extension_prepare_config__prepare_grub_with_dtb() {
 #   works across Debian and Ubuntu. it reads /etc/armbian-grub-with-dtb and puts symlinks or copies in /boot/dtb-<kernel-version>
 function post_family_tweaks_bsp__add_grub_with_dtb_config_file() {
 	: "${destination:?}"
-	display_alert "adding grub-with-dtb config file" "${EXTENSION} :: ${BOARD}" "info"
+	display_alert "Extension: ${EXTENSION}: Adding grub-with-dtb config file" "${BOARD}" "info"
 	# maybe add this to conffiles?
 	cat <<- EOD > "${destination}"/etc/armbian-grub-with-dtb
 		BOOT_FDT_FILE="${BOOT_FDT_FILE}"
@@ -36,7 +36,7 @@ function post_family_tweaks_bsp__add_grub_with_dtb_config_file() {
 
 function post_family_tweaks_bsp__add_grub_with_dtb_kernel_hook() {
 	: "${destination:?}"
-	display_alert "adding grub-with-dtb kernel hook" "${EXTENSION} :: ${BOARD}" "info"
+	display_alert "Extension: ${EXTENSION}: Adding grub-with-dtb kernel hook" "${BOARD}" "info"
 	run_host_command_logged mkdir -p "${destination}"/etc/kernel/postinst.d
 	cat <<- 'EOD' > "${destination}"/etc/kernel/postinst.d/armbian-grub-with-dtb
 		#! /bin/bash
@@ -75,21 +75,21 @@ function grub_pre_install__force_run_kernel_hook_for_armbian_dtb() {
 	# Run the kernel hook to deploy the DTB file to the boot partition.
 	# This is done forcibly here during `grub_pre_install`, since the kernel hook is deployed in the bsp-cli package
 	# which is only deployed after the linux-image package is installed and thus is not run.
-	display_alert "deploy DTB for GRUB for image build" "${EXTENSION} :: ${BOARD}" "info"
+	display_alert "Extension: ${EXTENSION}: Deploying DTB for GRUB for image build" "${BOARD}" "info"
 	chroot_custom "${MOUNT}" 'for k in $(linux-version list); do /etc/kernel/postinst.d/armbian-grub-with-dtb "$k"; done'
 }
 
 function grub_late_config__check_dtb_in_grub_cfg() {
 	if [[ "${SHOW_DEBUG}" == "yes" ]]; then
-		display_alert "Debugging" "GRUB config and /boot contents" "info"
+		display_alert "Extension: ${EXTENSION}: Debugging" "GRUB config and /boot contents" "info"
 		run_tool_batcat "${MOUNT}/boot/grub/grub.cfg"
 		run_host_command_logged ls -la --color=always "${MOUNT}"/boot
 	fi
 
 	if ! grep -q 'devicetree' "${MOUNT}/boot/grub/grub.cfg"; then
-		display_alert "Sanity check failed" "GRUB DTB not found in grub.cfg; RELEASE=${RELEASE}" "warn"
+		display_alert "Extension: ${EXTENSION}: Sanity check failed" "GRUB DTB not found in grub.cfg; RELEASE=${RELEASE}" "warn"
 	else
-		display_alert "Sanity check passed" "GRUB DTB found in grub.cfg; RELEASE=${RELEASE}" "info"
+		display_alert "Extension: ${EXTENSION}: Sanity check passed" "GRUB DTB found in grub.cfg; RELEASE=${RELEASE}" "info"
 	fi
 	return 0
 }

--- a/extensions/network/net-chrony.sh
+++ b/extensions/network/net-chrony.sh
@@ -2,6 +2,6 @@
 # Extension to manage network time synchronization with Chrony
 #
 function extension_prepare_config__install_chrony() {
-	display_alert "Extension: ${EXTENSION}: Installing additional packages" "chrony" "info"
+	display_alert "Extension: ${EXTENSION}: Adding extra package to image" "chrony" "info"
 	add_packages_to_image chrony
 }

--- a/extensions/network/net-network-manager.sh
+++ b/extensions/network/net-network-manager.sh
@@ -7,16 +7,16 @@ function extension_prepare_config__install_network_manager() {
 		exit_with_error "Extension: ${EXTENSION}: requires NETWORKING_STACK='network-manager', currently set to '${NETWORKING_STACK}'"
 	fi
 
-	display_alert "Extension: ${EXTENSION}: Installing additional packages" "network-manager network-manager-openvpn netplan.io" "info"
+	display_alert "Extension: ${EXTENSION}: Adding extra packages to image" "network-manager network-manager-openvpn netplan.io" "info"
 	add_packages_to_image network-manager network-manager-openvpn netplan.io
 
 	if [[ "${BUILD_DESKTOP}" == "yes" ]]; then
-		display_alert "Extension: ${EXTENSION}: Installing additional packages for desktop" "network-manager-gnome network-manager-ssh network-manager-vpnc" "info"
+		display_alert "Extension: ${EXTENSION}: Adding extra packages for desktop to image" "network-manager-gnome network-manager-ssh network-manager-vpnc" "info"
 		add_packages_to_image network-manager-gnome network-manager-ssh network-manager-vpnc
 	fi
 
 	if [[ "${DISTRIBUTION}" == "Ubuntu" ]]; then
-		display_alert "Extension: ${EXTENSION}: Installing additional packages for Ubuntu" "network-manager-config-connectivity-ubuntu" "info"
+		display_alert "Extension: ${EXTENSION}: Adding extra packages for Ubuntu to image" "network-manager-config-connectivity-ubuntu" "info"
 		add_packages_to_image network-manager-config-connectivity-ubuntu
 	fi
 }

--- a/extensions/network/net-systemd-networkd.sh
+++ b/extensions/network/net-systemd-networkd.sh
@@ -7,7 +7,7 @@ function extension_prepare_config__install_systemd_networkd() {
 		exit_with_error "Extension: ${EXTENSION}: requires NETWORKING_STACK='systemd-networkd', currently set to '${NETWORKING_STACK}'"
 	fi
 
-	display_alert "Extension: ${EXTENSION}: Installing additional packages" "netplan.io" "info"
+	display_alert "Extension: ${EXTENSION}: Adding extra packages to image" "netplan.io" "info"
 	add_packages_to_image netplan.io
 }
 
@@ -20,7 +20,7 @@ function pre_install_kernel_debs__configure_systemd_networkd() {
 	chroot_sdcard systemctl enable systemd-resolved.service || display_alert "Failed to enable systemd-resolved.service" "" "wrn"
 
 	# Copy network config files into the appropriate folders
-	display_alert "Configuring" "systemd-networkd and Netplan" "info"
+	display_alert "Extension: ${EXTENSION}: Configuring" "systemd-networkd and Netplan" "info"
 	local netplan_config_src_folder="${EXTENSION_DIR}/config-networkd/netplan/"
 	local netplan_config_dst_folder="${SDCARD}/etc/netplan/"
 

--- a/extensions/network/net-systemd-timesyncd.sh
+++ b/extensions/network/net-systemd-timesyncd.sh
@@ -2,7 +2,7 @@
 # Extension to manage network time synchronization with systemd-timesyncd
 #
 function extension_prepare_config__install_systemd-timesyncd() {
-	display_alert "Extension: ${EXTENSION}: Installing additional packages" "systemd-timesyncd" "info"
+	display_alert "Extension: ${EXTENSION}: Adding extra packages to image" "systemd-timesyncd" "info"
 	add_packages_to_image systemd-timesyncd
 }
 


### PR DESCRIPTION
# Description

Establish some consistency with extension logging:
- Add "Extension: ${EXTENSION}: " prefix to some extension logs
- Make the log messages more consistent throughout extensions.

Some extensions use another format: `display_alert "message" "${EXTENSION}" "info"`

These were *not* adapted to this new schema.


---

Yes I do realize there is probably a better way to do this e.g. by introducing a new `display_alert` category, like "extension" instead of "info".

# How Has This Been Tested?

- [x] Build an image with this enabled, shows more consistent logging

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
