### PR TITLE
Fix armbian-firstrun service not disabled on start.

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-common
+++ b/packages/bsp/common/usr/lib/armbian/armbian-common
@@ -40,7 +40,7 @@ set_fixed_mac ()
 
 	# we use random mac routine only with sytemd-network.
 	if ! grep 'renderer: networkd' /etc/netplan/*.yaml >/dev/null; then
-		exit 0
+		return
 	fi
 
 	local netplan_config_file="/etc/netplan/20-eth-fixed-mac.yaml"


### PR DESCRIPTION
# Description

Fix armbian-firstrun service not disabled on start.

Fixes: 7b33243c27c48bea6345aeff9e836c0f2b4f06e9


[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: #6929 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-2415]

# How Has This Been Tested?

```
./armbian-firstrun start
setupcon: We are not on the console, the console is left unconfigured.
Removed /etc/systemd/system/multi-user.target.wants/armbian-firstrun.service.
```
- [X] disabled on run

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings


[AR-2415]: https://armbian.atlassian.net/browse/AR-2415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ