### PR TITLE
Actually fix loop device not being available in a container

### DIFF
--- a/lib/functions/cli/cli-docker.sh
+++ b/lib/functions/cli/cli-docker.sh
@@ -74,10 +74,7 @@ function cli_docker_run() {
 	case "${DOCKER_SUBCMD}" in
 		shell)
 			display_alert "Launching Docker shell" "docker-shell" "info"
-			# The MKNOD capability is required for loop device search function.
-			# In case there are no loop devices available, losetup -f would not be able to create a loop
-			# device, yet it will output a loop device path
-			docker run -it --cap-add MKNOD "${DOCKER_ARGS[@]}" "${DOCKER_ARMBIAN_INITIAL_IMAGE_TAG}" /bin/bash
+			docker run -it "${DOCKER_ARGS[@]}" "${DOCKER_ARMBIAN_INITIAL_IMAGE_TAG}" /bin/bash
 			;;
 
 		purge)

--- a/lib/functions/cli/cli-docker.sh
+++ b/lib/functions/cli/cli-docker.sh
@@ -74,7 +74,10 @@ function cli_docker_run() {
 	case "${DOCKER_SUBCMD}" in
 		shell)
 			display_alert "Launching Docker shell" "docker-shell" "info"
-			docker run -it "${DOCKER_ARGS[@]}" "${DOCKER_ARMBIAN_INITIAL_IMAGE_TAG}" /bin/bash
+			# Bind mount /dev into the container to fix an edge case where device reported by
+			# `losetup -f` wouldn't be available in the container if the device didn't exist
+			# on host when container is launched.
+			docker run -v /dev:/dev -it "${DOCKER_ARGS[@]}" "${DOCKER_ARMBIAN_INITIAL_IMAGE_TAG}" /bin/bash
 			;;
 
 		purge)

--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -575,7 +575,10 @@ function docker_cli_launch() {
 	display_alert "-----------------Relaunching in Docker after ${SECONDS}s------------------" "here comes the 🐳" "info"
 
 	local -i docker_build_result
-	if docker run "${DOCKER_ARGS[@]}" "${DOCKER_ARMBIAN_INITIAL_IMAGE_TAG}" /bin/bash "${DOCKER_ARMBIAN_TARGET_PATH}/compile.sh" "${ARMBIAN_CLI_FINAL_RELAUNCH_ARGS[@]}"; then
+	# Bind mount /dev into the container to fix an edge case where device reported by `losetup -f`
+	# wouldn't be available in the container if the device didn't exist on host
+	# when container is launched.
+	if docker run -v /dev:/dev "${DOCKER_ARGS[@]}" "${DOCKER_ARMBIAN_INITIAL_IMAGE_TAG}" /bin/bash "${DOCKER_ARMBIAN_TARGET_PATH}/compile.sh" "${ARMBIAN_CLI_FINAL_RELAUNCH_ARGS[@]}"; then
 		docker_build_result=$? # capture exit code of test done in the line above.
 		display_alert "-------------Docker run finished after ${SECONDS}s------------------------" "🐳 successfull" "info"
 	else


### PR DESCRIPTION
# Description

Follow-up to #6927 

1. Bind mount `/dev` into the container
2. Remove previous attempt via `MKNOD` capability which actually didn't affect the issue

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: #6568 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-2132]

# Documentation summary for feature / change

The issue has been found in other projects as well, and they end up bind mounting `/dev` into the container:
- https://github.com/moby/moby/issues/27886
- https://github.com/moby/moby/issues/16160

The issues have a lot of discussion on the various aspects of the problem and solutions. The most accepted one is binding `/dev` into the container.

The `MKNOD` capability doesn't solve the issue, as it turns out. Testing in #6927 was faulty, as the device is available by the next launch, and the most reliable way to remove it that I've found is to reboot the machine.

# How Has This Been Tested?

1. Fresh system boot
2. Check that `/dev/loopX` devices do not exist
3. run `./compile.sh build BOARD=odroidm1 BRANCH=current BUILD_DESKTOP=no BUILD_MINIMAL=no KERNEL_CONFIGURE=no KERNEL_GIT=shallow RELEASE=bookworm PREFER_DOCKER=yes`
4. Observe the error at image creation stage
5. Mark that `/dev/loopX` device appeared but was not accessible to the container.

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-2132]: https://armbian.atlassian.net/browse/AR-2132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ