### PR TITLE
firstlogin: quote values if space is legal

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -528,10 +528,10 @@ add_user() {
 	REPEATS=3
 	while [ -f "/root/.not_logged_in_yet" ]; do
 		echo -e "\nPlease provide a username (eg. your first name): \c"
-		if [ -z $PRESET_USER_NAME ];then
+		if [ -z "$PRESET_USER_NAME" ];then
 			read -r -e username
 		else
-			username=$PRESET_USER_NAME
+			username="$PRESET_USER_NAME"
 		fi
 		if ! grep '^[a-zA-Z][a-zA-Z0-9]*$' <<< "$username" > /dev/null; then
 			echo -e "\n\x1B[91mError\x1B[0m: illegal characters in username"
@@ -544,17 +544,17 @@ add_user() {
 	done
 
 	while [ -f "/root/.not_logged_in_yet" ]; do
-		if [ -z $PRESET_USER_PASSWORD ];then
+		if [ -z "$PRESET_USER_PASSWORD" ];then
 			read_password "Create user ($username)"
 		else
-			password=$PRESET_USER_PASSWORD
+			password="$PRESET_USER_PASSWORD"
 		fi
 		first_input="$password"
 		echo ""
-		if [ -z $PRESET_USER_PASSWORD ];then
+		if [ -z "$PRESET_USER_PASSWORD" ];then
 			read_password "Repeat user ($username)"
 		else
-			password=$PRESET_USER_PASSWORD
+			password="$PRESET_USER_PASSWORD"
 		fi
 		second_input="$password"
 		echo ""
@@ -568,10 +568,10 @@ add_user() {
 				fi
 			fi
 			echo -e ""
-			if [ -z $PRESET_DEFAULT_REALNAME ];then
+			if [ -z "$PRESET_DEFAULT_REALNAME" ];then
 				read -r -e -p "Please provide your real name: " -i "${RealUserName^}" RealName
 			else
-				RealName=$PRESET_DEFAULT_REALNAME
+				RealName="$PRESET_DEFAULT_REALNAME"
 			fi
 
 			adduser --quiet --disabled-password --home /home/"$RealUserName" --gecos "$RealName" "$RealUserName"
@@ -665,13 +665,13 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 	REPEATS=3
 	while [ -f "/root/.not_logged_in_yet" ]; do
 		. /root/.not_logged_in_yet
-		if [ -z $PRESET_ROOT_PASSWORD ];then
+		if [ -z "$PRESET_ROOT_PASSWORD" ];then
 			read_password "Create root"
 		else
 			if [ "$(who am i | awk '{print $2}')" != "tty1" ];then
 				exit
 			fi
-			password=$PRESET_ROOT_PASSWORD
+			password="$PRESET_ROOT_PASSWORD"
 		fi
 
 		# only allow one login. Once you enter root password, kill others.
@@ -680,10 +680,10 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 
 		first_input="$password"
 		echo ""
-		if [ -z $PRESET_ROOT_PASSWORD ];then
+		if [ -z "$PRESET_ROOT_PASSWORD" ];then
 			read_password "Repeat root"
 		else
-			password=$PRESET_ROOT_PASSWORD
+			password="$PRESET_ROOT_PASSWORD"
 		fi
 		second_input="$password"
 		echo ""


### PR DESCRIPTION
# Description

_Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change._

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: #6940 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-2419]

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] Test A
  * create `/root/.not_logged_in_yet` as noted in #6940 
  * notice the errors disappear

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


[AR-2419]: https://armbian.atlassian.net/browse/AR-2419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ