### PR TITLE
rk3328: hotfix for broken pinctrl driver

### DIFF
--- a/patch/kernel/archive/rockchip64-6.6/general-revert-pinctrl-changes.patch
+++ b/patch/kernel/archive/rockchip64-6.6/general-revert-pinctrl-changes.patch
@@ -1,0 +1,27 @@
+From 11a50fb3ff01ff055ba576b2749793f90519ca59 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Sat, 13 Jul 2024 22:15:00 +0200
+Subject: [PATCH] revert change iomux width for bank2
+
+Apparently a mainlined kernel patch broke the pinctrl of rk3328
+See: https://patchwork.kernel.org/project/linux-rockchip/patch/20240606125755.53778-2-i@eh5.me/
+---
+ drivers/pinctrl/pinctrl-rockchip.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/pinctrl/pinctrl-rockchip.c b/drivers/pinctrl/pinctrl-rockchip.c
+index 21d9fbe1e8ff..0b756ab67ca0 100644
+--- a/drivers/pinctrl/pinctrl-rockchip.c
++++ b/drivers/pinctrl/pinctrl-rockchip.c
+@@ -3934,7 +3934,7 @@ static struct rockchip_pin_bank rk3328_pin_banks[] = {
+ 	PIN_BANK_IOMUX_FLAGS(0, 32, "gpio0", 0, 0, 0, 0),
+ 	PIN_BANK_IOMUX_FLAGS(1, 32, "gpio1", 0, 0, 0, 0),
+ 	PIN_BANK_IOMUX_FLAGS(2, 32, "gpio2", 0,
+-			     0,
++			     IOMUX_WIDTH_3BIT,
+ 			     IOMUX_WIDTH_3BIT,
+ 			     0),
+ 	PIN_BANK_IOMUX_FLAGS(3, 32, "gpio3",
+-- 
+2.34.1
+

--- a/patch/kernel/archive/rockchip64-6.9/general-revert-pinctrl-changes.patch
+++ b/patch/kernel/archive/rockchip64-6.9/general-revert-pinctrl-changes.patch
@@ -1,0 +1,27 @@
+From 11a50fb3ff01ff055ba576b2749793f90519ca59 Mon Sep 17 00:00:00 2001
+From: Paolo Sabatino <paolo.sabatino@gmail.com>
+Date: Sat, 13 Jul 2024 22:15:00 +0200
+Subject: [PATCH] revert change iomux width for bank2
+
+Apparently a mainlined kernel patch broke the pinctrl of rk3328
+See: https://patchwork.kernel.org/project/linux-rockchip/patch/20240606125755.53778-2-i@eh5.me/
+---
+ drivers/pinctrl/pinctrl-rockchip.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/pinctrl/pinctrl-rockchip.c b/drivers/pinctrl/pinctrl-rockchip.c
+index 21d9fbe1e8ff..0b756ab67ca0 100644
+--- a/drivers/pinctrl/pinctrl-rockchip.c
++++ b/drivers/pinctrl/pinctrl-rockchip.c
+@@ -3934,7 +3934,7 @@ static struct rockchip_pin_bank rk3328_pin_banks[] = {
+ 	PIN_BANK_IOMUX_FLAGS(0, 32, "gpio0", 0, 0, 0, 0),
+ 	PIN_BANK_IOMUX_FLAGS(1, 32, "gpio1", 0, 0, 0, 0),
+ 	PIN_BANK_IOMUX_FLAGS(2, 32, "gpio2", 0,
+-			     0,
++			     IOMUX_WIDTH_3BIT,
+ 			     IOMUX_WIDTH_3BIT,
+ 			     0),
+ 	PIN_BANK_IOMUX_FLAGS(3, 32, "gpio3",
+-- 
+2.34.1
+


### PR DESCRIPTION
# Description

[This](https://patchwork.kernel.org/project/linux-rockchip/patch/20240606125755.53778-2-i@eh5.me/) patch series has been mainlined in the kernel for both v6.6.37 and somewhere in v6.9.y branch too.

There are several reports on the forum that it broke rk3328 pinctrl and, as the worst side effect, eMMC controller does not work anymore on rk3318/rk3328 (see: [this](https://forum.armbian.com/topic/42107-rk3318-cant-boot-after-update/), [this](https://forum.armbian.com/topic/26978-csc-armbian-for-rk3318rk3328-tv-box-boards/?do=findComment&comment=196706) and [this](https://forum.armbian.com/topic/26978-csc-armbian-for-rk3318rk3328-tv-box-boards/?do=findComment&comment=196663))

A single line seems to cause the issues; reverting that line fixes the bad pinctrl behaviour in my case.

# How Has This Been Tested?

- [x] built and tested kernel 6.6.37 on live system
- [x] built and tested kernel 6.9.9 on live system

# Checklist:

- [x] My code follows the style guidelines of this project
- [x]  I have performed a self-review of my own code
- [x] My changes generate no new warnings
