### PR TITLE
u-boot: 2024.07: fix boot from btrfs

### DIFF
--- a/patch/u-boot/v2024.07/general-btrfs-fix-out-of-bounds-write.patch
+++ b/patch/u-boot/v2024.07/general-btrfs-fix-out-of-bounds-write.patch
@@ -1,0 +1,43 @@
+From ee1941e4fec601a8444f49c7dad04ad700d501a6 Mon Sep 17 00:00:00 2001
+From: Alex Shumsky <alexthreed@gmail.com>
+Date: Wed, 19 Jun 2024 00:41:38 +0300
+Subject: [PATCH] fs: btrfs: fix out of bounds write
+
+Fix btrfs_read/read_and_truncate_page write out of bounds of destination
+buffer. Old behavior break bootstd malloc'd buffers of exact file size.
+Previously this OOB write have not been noticed because distroboot usually
+read files into huge static memory areas.
+
+Signed-off-by: Alex Shumsky <alexthreed@gmail.com>
+Fixes: e342718 ("fs: btrfs: Implement btrfs_file_read()")
+Reviewed-by: Qu Wenruo <wqu@suse.com>
+---
+ fs/btrfs/inode.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/fs/btrfs/inode.c b/fs/btrfs/inode.c
+index 4691612eda33..3998ffc2c819 100644
+--- a/fs/btrfs/inode.c
++++ b/fs/btrfs/inode.c
+@@ -640,7 +640,11 @@ static int read_and_truncate_page(struct btrfs_path *path,
+ 	extent_type = btrfs_file_extent_type(leaf, fi);
+ 	if (extent_type == BTRFS_FILE_EXTENT_INLINE) {
+ 		ret = btrfs_read_extent_inline(path, fi, buf);
+-		memcpy(dest, buf + page_off, min(page_len, ret));
++		if (ret < 0) {
++			free(buf);
++			return ret;
++		}
++		memcpy(dest, buf + page_off, min3(page_len, ret, len));
+ 		free(buf);
+ 		return len;
+ 	}
+@@ -652,7 +656,7 @@ static int read_and_truncate_page(struct btrfs_path *path,
+ 		free(buf);
+ 		return ret;
+ 	}
+-	memcpy(dest, buf + page_off, page_len);
++	memcpy(dest, buf + page_off, min(page_len, len));
+ 	free(buf);
+ 	return len;
+ }


### PR DESCRIPTION
# Description

Fix boot from btrfs fs in uboot 2024.07 (backport patch from uboot.next https://github.com/u-boot/u-boot/commit/ee1941e4fec601a8444f49c7dad04ad700d501a6)

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x]  Compile image and boot from (zstd-compressed) btrfs sole rootfs/bootfs partition

# Checklist:

- [x] I have performed a self-review of my own code
