### PR TITLE
add customized GHCR_MIRROR_ADDRESS support

### DIFF
--- a/lib/functions/configuration/main-config.sh
+++ b/lib/functions/configuration/main-config.sh
@@ -251,7 +251,8 @@ function do_main_configuration() {
 
 	case $GHCR_MIRROR in
 		dockerproxy)
-			declare -g -r GHCR_SOURCE='ghcr.dockerproxy.com'
+			GHCR_MIRROR_ADDRESS="${GHCR_MIRROR_ADDRESS:-"ghcr.dockerproxy.com"}"
+			declare -g -r GHCR_SOURCE=$GHCR_MIRROR_ADDRESS
 			;;
 		*)
 			declare -g -r GHCR_SOURCE='ghcr.io'


### PR DESCRIPTION
# Description

dockerproxy.com is not avaiable from China mainland, but there are many alternative mirrors, for example we can deploy one to cloudflare: https://github.com/ciiiii/cloudflare-docker-proxy
I have deployed mine: ghcr.haguro.top

# Documentation summary for feature / change

_Please delete this section if entry to main documentation is not needed._

If documentation entry is predicted, please provide key elements for further implementation [into main documentation](https://docs.armbian.com) and set label to "Needs Documentation". You are welcome to open a PR to documentation or you can leave following information for technical writer:

- [x] short description: customized GHCR_MIRROR_ADDRESS
- [x] summary: Default mirror address for ghcr.io set by `GHCR_MIRROR=dockerproxy` is `ghcr.dockerproxy.com`. When this address is not availabe, we can set an alternative address with `GHCR_MIRROR_ADDRESS`.
- [x] example of usage: `./compile.sh GHCR_MIRROR=dockerproxy GHCR_MIRROR_ADDRESS=ghcr.libcuda.so`

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh BOARD=rock-5b BRANCH=edge BUILD_MINIMAL=no DEB_COMPRESS=xz DOWNLOAD_MIRROR=china KERNEL_CONFIGURE=no RELEASE=bookworm BUILD_DESKTOP=yes DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base GHCR_MIRROR_ADDRESS=ghcr.haguro.top GHCR_MIRROR=dockerproxy`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
