### PR TITLE
SpacemiT: `write_uboot_platform`: eMMC Support

### DIFF
--- a/config/sources/families/spacemit.conf
+++ b/config/sources/families/spacemit.conf
@@ -86,12 +86,12 @@ write_uboot_platform() {
 
 	for f in "${!d[@]}"
 	do
-		#echo "skip\seek=${d[$f]%:*} count=${d[$f]#*:}" # uncomment for debugging
 		if $(dd if=${device} bs=1 skip="${d[$f]%:*}" count="${d[$f]#*:}" \
-			conv=notrunc status=noxfer 2>/dev/null | cmp ${f})
+			conv=notrunc status=noxfer 2>/dev/null | cmp --quiet "${f}")
 		then
 			echo "Skip $(basename $f), it is equal to the existing one"
 		else
+			echo "# Write =: $(basename $f) to ${device}"
 			dd if=$f of=${device} bs=1 seek="${d[$f]%:*}" conv=notrunc status=noxfer
 			sync
 		fi

--- a/config/sources/families/spacemit.conf
+++ b/config/sources/families/spacemit.conf
@@ -70,22 +70,35 @@ pre_prepare_partitions() {
 }
 
 write_uboot_platform() {
+	local device=${2}
 
-	if [[ $2 == /dev/mmcblk* && -b ${2}boot0 ]]; then
-		local is_emmc=1
-		local device=${2}boot0
+	declare -A d
+	d=(
+	[${1}/bootinfo_emmc.bin]="0:$(du -b ${1}/bootinfo_emmc.bin | awk '{print $1}')"
+	[${1}/FSBL.bin]="512:$(du -b ${1}/FSBL.bin | awk '{print $1}')"
+	)
+
+	if [ -b ${2}boot0 ]; then
+		device=${2}boot0
+		echo 0 > /sys/block/$(basename ${device})/force_ro
+		sync
 	fi
-	if [[ $is_emmc == 1 ]]; then
-		echo 0 > /sys/block/$(basename $device)/force_ro
-		sleep .50
-		dd if=$1/bootinfo_emmc.bin of=$device bs=512 conv=notrunc
-		dd if=$1/FSBL.bin of=$device bs=512 seek=1 conv=notrunc
-		dd if=$1/FSBL.bin of=$device bs=512 seek=512 conv=notrunc
-	else
-		dd if=$1/bootinfo_emmc.bin of=$2 bs=512 conv=notrunc
-		dd if=$1/FSBL.bin of=$2 bs=512 seek=1 conv=notrunc
-		dd if=$1/FSBL.bin of=$2 bs=512 seek=512 conv=notrunc
-	fi
-	dd if=$1/fw_dynamic.itb of=$2 bs=512 seek=1280 conv=notrunc
-	dd if=$1/u-boot.itb of=$2 bs=512 seek=2048 conv=notrunc
+
+	for f in ${!d[@]}
+	do
+		echo "skip\seek=${d[$f]%:*} count=${d[$f]#*:}"
+		if $(dd if=${device} bs=1 skip=${d[$f]%:*} count=${d[$f]#*:} \
+			conv=notrunc status=noxfer | cmp ${f})
+		then
+			dd if=$f of=${device} bs=1 seek=${d[$f]%:*} conv=notrunc status=noxfer
+			sync
+		else
+			echo "Skip $f, it is equal to the existing one"
+		fi
+	done
+
+	dd if=$1/fw_dynamic.itb of=${2} bs=512 seek=1280 conv=notrunc
+	sync
+	dd if=$1/u-boot.itb of=${2} bs=512 seek=2048 conv=notrunc
+	sync
 }

--- a/config/sources/families/spacemit.conf
+++ b/config/sources/families/spacemit.conf
@@ -86,14 +86,14 @@ write_uboot_platform() {
 
 	for f in ${!d[@]}
 	do
-		echo "skip\seek=${d[$f]%:*} count=${d[$f]#*:}"
+		#echo "skip\seek=${d[$f]%:*} count=${d[$f]#*:}" # uncomment for debugging
 		if $(dd if=${device} bs=1 skip=${d[$f]%:*} count=${d[$f]#*:} \
 			conv=notrunc status=noxfer | cmp ${f})
 		then
+			echo "Skip $(basename $f), it is equal to the existing one"
+		else
 			dd if=$f of=${device} bs=1 seek=${d[$f]%:*} conv=notrunc status=noxfer
 			sync
-		else
-			echo "Skip $f, it is equal to the existing one"
 		fi
 	done
 

--- a/config/sources/families/spacemit.conf
+++ b/config/sources/families/spacemit.conf
@@ -70,10 +70,22 @@ pre_prepare_partitions() {
 }
 
 write_uboot_platform() {
-	# SDCARD
-	dd if=$1/bootinfo_emmc.bin of=$2 bs=512 conv=notrunc
-	dd if=$1/FSBL.bin of=$2 bs=512 seek=1 conv=notrunc
-	dd if=$1/FSBL.bin of=$2 bs=512 seek=512 conv=notrunc
+
+	if [[ $2 == /dev/mmcblk* && -b ${2}boot0 ]]; then
+		local is_emmc=1
+		local device=${2}boot0
+	fi
+	if [[ $is_emmc == 1 ]]; then
+		echo 0 > /sys/block/$(basename $device)/force_ro
+		sleep .50
+		dd if=$1/bootinfo_emmc.bin of=$device bs=512 conv=notrunc
+		dd if=$1/FSBL.bin of=$device bs=512 seek=1 conv=notrunc
+		dd if=$1/FSBL.bin of=$device bs=512 seek=512 conv=notrunc
+	else
+		dd if=$1/bootinfo_emmc.bin of=$2 bs=512 conv=notrunc
+		dd if=$1/FSBL.bin of=$2 bs=512 seek=1 conv=notrunc
+		dd if=$1/FSBL.bin of=$2 bs=512 seek=512 conv=notrunc
+	fi
 	dd if=$1/fw_dynamic.itb of=$2 bs=512 seek=1280 conv=notrunc
 	dd if=$1/u-boot.itb of=$2 bs=512 seek=2048 conv=notrunc
 }

--- a/config/sources/families/spacemit.conf
+++ b/config/sources/families/spacemit.conf
@@ -84,15 +84,15 @@ write_uboot_platform() {
 		sync
 	fi
 
-	for f in ${!d[@]}
+	for f in "${!d[@]}"
 	do
 		#echo "skip\seek=${d[$f]%:*} count=${d[$f]#*:}" # uncomment for debugging
-		if $(dd if=${device} bs=1 skip=${d[$f]%:*} count=${d[$f]#*:} \
-			conv=notrunc status=noxfer | cmp ${f})
+		if $(dd if=${device} bs=1 skip="${d[$f]%:*}" count="${d[$f]#*:}" \
+			conv=notrunc status=noxfer 2>/dev/null | cmp ${f})
 		then
 			echo "Skip $(basename $f), it is equal to the existing one"
 		else
-			dd if=$f of=${device} bs=1 seek=${d[$f]%:*} conv=notrunc status=noxfer
+			dd if=$f of=${device} bs=1 seek="${d[$f]%:*}" conv=notrunc status=noxfer
 			sync
 		fi
 	done

--- a/packages/bsp/common/usr/sbin/armbian-install
+++ b/packages/bsp/common/usr/sbin/armbian-install
@@ -832,10 +832,15 @@ main()
 		[[ -n $emmccheck ]] 						&& options+=(2 "Boot from $ichip - system on $ichip")
 		[[ -n $emmccheck && -n $diskcheck ]] 				&& options+=(3 "Boot from $ichip - system on SATA, USB or NVMe")
 		[[ -n $mtdcheck ]] 						&& options+=(4 'Boot from MTD Flash - system on SATA, USB or NVMe')
-		[[ -n ${root_partition_device} && ${DEVICE_TYPE} != "uefi" ]]	&& options+=(5 'Install/Update the bootloader on SD/eMMC')
-		[[ ( $LINUXFAMILY == odroidxu4 || $LINUXFAMILY == mvebu* \
-		|| $LINUXFAMILY == mt7623 ) && \
-		( -b /dev/mmcblk0boot0 || -b /dev/mmcblk1boot0 ) ]]		&& options+=(6 'Install/Update the bootloader on special eMMC partition')
+		[[ -n ${root_partition_device} && ${DEVICE_TYPE} != "uefi" ]]	&& options+=(5 'Install/Update the bootloader on ${root_partition_device}')
+
+		case $LINUXFAMILY in
+			odroidxu4 | mvebu* | mt7623 | spacemit)
+				BOOTPART=$(find /dev -name 'mmcblk*boot0' -and -type b)
+				[[ "$(echo $BOOTPART | wc -w)" == "1" ]] && \
+				options+=(6 "Install/Update the bootloader on eMMC ${BOOTPART/boot0/} partition")
+				;;
+		esac
 		[[ -n $mtdcheck && \
 		$(type -t write_uboot_platform_mtd) == function ]] 		&& options+=(7 'Install/Update the bootloader on MTD Flash')
 	fi
@@ -907,20 +912,15 @@ main()
 				fi
 				;;
 			5)
-				show_warning 'This script will update the bootloader on SD/eMMC. Continue?'
+				show_warning 'This script will update the bootloader on ${root_partition_device}. Continue?'
 				write_uboot_platform "$DIR" "${root_partition_device}"
 				update_bootscript
 				dialog --backtitle "$backtitle" --title 'Writing bootloader' --msgbox '\n          Done.' 7 30
 				return
 				;;
 			6)
-				if [[ -b /dev/mmcblk0boot0 ]]; then
-					BOOTPART='/dev/mmcblk0'
-				elif [[ -b /dev/mmcblk1boot0 ]]; then
-					BOOTPART='/dev/mmcblk1'
-				fi
-				show_warning "This script will update the bootloader on $BOOTPART. Continue?"
-				write_uboot_platform "$DIR" $BOOTPART
+				show_warning "This script will update the bootloader on ${BOOTPART/boot0/}. Continue?"
+				write_uboot_platform "$DIR" ${BOOTPART/boot0/}
 				echo 'Done'
 				return
 				;;

--- a/packages/bsp/common/usr/sbin/armbian-install
+++ b/packages/bsp/common/usr/sbin/armbian-install
@@ -810,10 +810,14 @@ main()
 	IFS="'"
 	options=()
 	if [[ -n $emmccheck ]]; then
-		ichip='eMMC';
+		if [[ "${emmccheck#*mmcblk}" == "0" ]]; then
+			ichip='SD card'
+		else
+			ichip='eMMC'
+		fi
 		dest_boot=$emmccheck'p1'
 		dest_root=$emmccheck'p1'
-	else
+	elif [ -b /dev/nand1 ] && [ -b /dev/nand2 ]; then
 		ichip='legacy SUNXI NAND'
 		dest_boot='/dev/nand1'
 		dest_root='/dev/nand2'
@@ -828,19 +832,30 @@ main()
 
 	else
 
-		[[ -n $sduuid && -n $diskcheck ]]					&& options+=(1 'Boot from SD - system on SATA, USB or NVMe')
-		[[ -n $emmccheck ]] 						&& options+=(2 "Boot from $ichip - system on $ichip")
-		[[ -n $emmccheck && -n $diskcheck ]] 				&& options+=(3 "Boot from $ichip - system on SATA, USB or NVMe")
-		[[ -n $mtdcheck ]] 						&& options+=(4 'Boot from MTD Flash - system on SATA, USB or NVMe')
-		[[ -n ${root_partition_device} && ${DEVICE_TYPE} != "uefi" ]]	&& options+=(5 'Install/Update the bootloader on ${root_partition_device}')
+		[[ -n $sduuid && -n $diskcheck ]]		&& options+=(1 'Boot from SD - system on SATA, USB or NVMe')
+		[[ -n $emmccheck ]] 				&& options+=(2 "Boot from $ichip - system on $ichip")
+		[[ -n $emmccheck && -n $diskcheck ]] 		&& options+=(3 "Boot from $ichip - system on SATA, USB or NVMe")
+		[[ -n $mtdcheck ]] 				&& options+=(4 'Boot from MTD Flash - system on SATA, USB or NVMe')
 
-		case $LINUXFAMILY in
-			odroidxu4 | mvebu* | mt7623 | spacemit)
-				BOOTPART=$(find /dev -name 'mmcblk*boot0' -and -type b)
-				[[ "$(echo $BOOTPART | wc -w)" == "1" ]] && \
-				options+=(6 "Install/Update the bootloader on eMMC ${BOOTPART/boot0/} partition")
-				;;
-		esac
+		if [[ -n ${root_partition_device} && ${DEVICE_TYPE} != "uefi" ]]; then
+			if [ "${root_partition_device#*mmcblk}" == "0" ]; then
+				rootchip='SD card'
+			else
+				rootchip='eMMC'
+			fi
+			options+=(5 "Install/Update the bootloader on $rootchip (${root_partition_device})")
+                fi
+
+		BOOTPART=$(find /dev -name 'mmcblk*boot0' -and -type b)
+		if [ "${BOOTPART/boot0}" != "${root_partition_device}" ]; then
+
+			options+=(6 "Install/Update the bootloader on eMMC (${BOOTPART/boot0/})")
+
+		elif [ -b /dev/mmcblk0 ]; then
+			BOOTPART=/dev/mmcblk0
+			options+=(6 "Install/Update the bootloader on SD card (${BOOTPART/boot0/})")
+		fi
+
 		[[ -n $mtdcheck && \
 		$(type -t write_uboot_platform_mtd) == function ]] 		&& options+=(7 'Install/Update the bootloader on MTD Flash')
 	fi
@@ -865,11 +880,11 @@ main()
 			2)
 				title="$ichip install"
 				command='Power off'
-				show_warning "This script will erase your $ichip. Continue?"
+				show_warning "This script will erase your $ichip ($emmccheck).\n     Continue?"
 				if [[ -n $emmccheck ]]; then
 					umount_device "$emmccheck"
 					format_emmc "$emmccheck"
-				else
+				elif [ -b /dev/nand ]; then
 					umount_device '/dev/nand'
 					format_nand
 				fi
@@ -879,11 +894,11 @@ main()
 				title="$ichip boot | USB/SATA/NVMe root install"
 				command='Power off'
 				check_partitions
-				show_warning "This script will erase your $ichip and $DISK_ROOT_PART. Continue?"
+				show_warning "This script will erase your ${ichip} ($emmccheck)\n    and $DISK_ROOT_PART. Continue?"
 				if [[ -n $emmccheck ]]; then
 					umount_device "$emmccheck"
 					format_emmc "$emmccheck"
-				else
+				elif [ -b /dev/nand ]; then
 					umount_device '/dev/nand'
 					format_nand
 				fi
@@ -912,14 +927,14 @@ main()
 				fi
 				;;
 			5)
-				show_warning 'This script will update the bootloader on ${root_partition_device}. Continue?'
+				show_warning 'This script will update the bootloader on ${root_partition_device}.\n\n    Continue?'
 				write_uboot_platform "$DIR" "${root_partition_device}"
 				update_bootscript
 				dialog --backtitle "$backtitle" --title 'Writing bootloader' --msgbox '\n          Done.' 7 30
 				return
 				;;
 			6)
-				show_warning "This script will update the bootloader on ${BOOTPART/boot0/}. Continue?"
+				show_warning "This script will update the bootloader on ${BOOTPART/boot0/}.\n\n    Continue?"
 				write_uboot_platform "$DIR" ${BOOTPART/boot0/}
 				echo 'Done'
 				return


### PR DESCRIPTION
Before merging please test.

```
 ____  ____  _   _____ _____ 
| __ )|  _ \(_) |  ___|___ / 
|  _ \| |_) | | | |_    |_ \ 
| |_) |  __/| | |  _|  ___) |
|____/|_|   |_| |_|   |____/ 
                             
Welcome to Armbian-unofficial 24.8.0-trunk Trixie with Linux 6.1.15-legacy-spacemit

No end-user support: built from trunk & unsupported (trixie) userspace!

System load:   25%           	Up time:       2 min	Local users:   2            	
Memory usage:  6% of 3.59G  	IP:	       10.0.0.244
CPU temp:      42°C           	Usage of /:    10% of 15G    	

patrick@bananapif3:~$ lsblk
NAME         MAJ:MIN RM   SIZE RO TYPE MOUNTPOINTS
mmcblk2      179:0    0  14.6G  0 disk 
└─mmcblk2p1  179:1    0  14.4G  0 part /var/log.hdd
                                       /
mmcblk2boot0 179:8    0     4M  1 disk 
mmcblk2boot1 179:16   0     4M  1 disk 
zram0        250:0    0   1.8G  0 disk [SWAP]
zram1        250:1    0    50M  0 disk /var/log
zram2        250:2    0     0B  0 disk 
nvme0n1      259:0    0 238.5G  0 disk 
├─nvme0n1p1  259:1    0   508M  0 part 
└─nvme0n1p2  259:2    0   238G  0 part
```