### PR TITLE
Trixie: remove non-existing packages from Budgie desktop

### DIFF
--- a/config/desktop/bookworm/environments/budgie/config_base/packages
+++ b/config/desktop/bookworm/environments/budgie/config_base/packages
@@ -10,7 +10,6 @@ brltty
 brltty-x11
 budgie-app-launcher-applet
 budgie-applications-menu-applet
-budgie-appmenu-applet
 budgie-brightness-controller-applet
 budgie-clockworks-applet
 budgie-countdown-applet
@@ -31,7 +30,6 @@ budgie-quicknote-applet
 budgie-recentlyused-applet
 budgie-rotation-lock-applet
 budgie-showtime-applet
-budgie-sntray-plugin
 budgie-takeabreak-applet
 budgie-trash-applet
 budgie-visualspace-applet


### PR DESCRIPTION
# Description

Budgie desktop packages deprecation fixes.

# How Has This Been Tested?

- [x] [CI](https://github.com/armbian/os/actions/runs/9977589113)

# Checklist:

-  [x] My changes generate no new warnings