### PR TITLE
actions: forked-helper: Don't escape multiline strings

### DIFF
--- a/.github/workflows/forked-helper.yml
+++ b/.github/workflows/forked-helper.yml
@@ -18,16 +18,6 @@ jobs:
         id: get_dispatch_secret
         run: echo "dispatch_secret=${{ secrets.ARMBIAN_SELF_DISPATCH_TOKEN }}" >> $GITHUB_OUTPUT
 
-      - name: Get event details
-        id: get_event_details
-        # Process JSON according https://github.com/orgs/community/discussions/26288
-        run: |
-          JSON=$(cat ${{ github.event_path }})
-          JSON="${JSON//'%'/'%25'}"
-          JSON="${JSON//$'\n'/'%0A'}"
-          JSON="${JSON//$'\r'/'%0D'}"
-          echo "event_details=${JSON}" >> $GITHUB_OUTPUT
-
       - name: Dispatch event on forked repostitory
         if: steps.get_dispatch_secret.outputs.dispatch_secret
         uses: peter-evans/repository-dispatch@v3
@@ -41,5 +31,5 @@ jobs:
               "ref": "${{ github.ref }}",
               "base_ref": "${{ github.base_ref }}",
               "sha": "${{ github.sha }}",
-              "event_details": ${{ steps.get_event_details.outputs.event_details }}
+              "event_details": ${{ toJSON(github.event) }}
             }


### PR DESCRIPTION
# Description

Before, the string would look like this and fails since it's not a valid JSON:
`{%0A  "after": "f6ddb25e6d6affbfdd92b4cd33a9b874254b4a09",%0A  "base_ref": null,%0A  "before": "0000000000000000000000000000000000000000",%0A  "commits": [%0A    {%0A      "author": ...`

After, the JSON gets correctly parsed:

```
{
    "after": "090850f02e35af562dd5adc39c23d423be6bfe15",
    "base_ref": null,
    "before": "0000000000000000000000000000000000000000",
    "commits": [
      {
        "author": {
...
```

Escaping multiline strings is not needed anymore with GITHUB_OUTPUT.
See https://github.com/orgs/community/discussions/26288#discussioncomment-3876281

Instead, use the `toJSON` function that Actions offers to convert the `event` object to JSON.

# How Has This Been Tested?

- [x] Run the fixed workflow once

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings