### PR TITLE
JetHome: Update bsp: fix jethub-init to support /etc/defaults

### DIFF
--- a/packages/bsp/jethub/jethub-init
+++ b/packages/bsp/jethub/jethub-init
@@ -11,6 +11,11 @@ SCRIPTPATH=$(dirname "${RP}")
 # shellcheck source=/dev/null
 source "${SCRIPTPATH}/libjethubconfig.sh"
 
+# Include jethub-init defaults if available
+if [ -f /etc/default/jethub ] ; then
+    . /etc/default/jethub
+fi
+
 # Enable legacy sysfs gpio export. Will be disabled in future releases
 
 ENABLESYSFS=${JETHUB_SYSFS_ENABLE:-true}


### PR DESCRIPTION
# Description

JetHome: Update bsp: fix jethub-init to support /etc/defaults

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-2426]



[AR-2426]: https://armbian.atlassian.net/browse/AR-2426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ