### PR TITLE
Add board config for Retro Lite CM5

### DIFF
--- a/config/boards/retro-lite-cm5.csc
+++ b/config/boards/retro-lite-cm5.csc
@@ -1,0 +1,47 @@
+# Rockchip RK3588S octa core 4/8/16GB RAM SoC NVMe USB3 USB-C GbE
+BOARD_NAME="Retro Lite CM5"
+BOARDFAMILY="rockchip-rk3588"
+BOARD_MAINTAINER="ginkage"
+BOOT_SOC="rk3588"
+KERNEL_TARGET="vendor"
+FULL_DESKTOP="yes"
+BOOT_LOGO="desktop"
+BOOT_FDT_FILE="rockchip/rk3588s-retro-lite-cm5.dtb"
+BOOT_SCENARIO="spl-blobs"
+IMAGE_PARTITION_TABLE="gpt"
+DDR_BLOB="rk35/rk3588_ddr_lp4_2112MHz_lp5_2400MHz_v1.16.bin"
+BL31_BLOB="rk35/rk3588_bl31_v1.45.elf"
+
+function post_family_tweaks__retrolitecm5_naming_audios() {
+	display_alert "$BOARD" "Renaming Retro Lite CM5 audios" "info"
+
+	mkdir -p $SDCARD/etc/udev/rules.d/
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-hdmi0-sound", ENV{SOUND_DESCRIPTION}="HDMI0 Audio"' > $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-dp0-sound", ENV{SOUND_DESCRIPTION}="DP0 Audio"' >> $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-wm8960-sound", ENV{SOUND_DESCRIPTION}="WM8960 Audio"' >> $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+
+	return 0
+}
+
+# Mainline U-Boot
+function post_family_config__retro_lite_cm5_use_mainline_uboot() {
+	display_alert "$BOARD" "Using mainline U-Boot for $BOARD / $BRANCH" "info"
+
+	declare -g BOOTCONFIG="generic-rk3588_defconfig"               # Use generic defconfig which should boot all RK3588 boards
+	declare -g BOOTDELAY=1                                         # Wait for UART interrupt to enter UMS/RockUSB mode etc
+	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git"   # We ❤️ Mainline U-Boot
+	declare -g BOOTBRANCH="tag:v2024.07-rc4"
+	declare -g BOOTPATCHDIR="v2024.07/board_${BOARD}"
+	# Don't set BOOTDIR, allow shared U-Boot source directory for disk space efficiency
+
+	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin"
+
+	# Disable stuff from rockchip64_common; we're using binman here which does all the work already
+	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd
+
+	# Just use the binman-provided u-boot-rockchip.bin, which is ready-to-go
+	function write_uboot_platform() {
+		dd "if=$1/u-boot-rockchip.bin" "of=$2" bs=32k seek=1 conv=notrunc status=none
+	}
+}
+


### PR DESCRIPTION
# Description

Community-supported board (myself as the maintainer).

# Documentation summary for feature / change

Pretty straightforward: mainline U-Boot, only the vendor kernel supported (no legacy or edge), device tree already present in the kernel branch, common defconfig for RK3588.

# How Has This Been Tested?

Built, flashed, ran on the board.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
