### PR TITLE
oci-oras: fix for ORAS > 1.x, as it now requires `HOME` to be set (fixes `download-artifact`)

### DIFF
--- a/lib/functions/general/oci-oras.sh
+++ b/lib/functions/general/oci-oras.sh
@@ -81,9 +81,11 @@ function run_tool_oras() {
 	fi
 
 	# Run oras, possibly with retries...
+	declare ORAS_HOME="${HOME:-"${TMPDIR}"}" # oras _requires_ a HOME to work atleast in 1.2+
+	display_alert "Running ORAS ${ACTUAL_VERSION}" "HOME='${ORAS_HOME}'; retries='${retries:-1}'; cmdline: $*" "debug"
 	if [[ "${retries:-1}" -gt 1 ]]; then
 		display_alert "Calling ORAS with retries ${retries}" "$*" "debug"
-		sleep_seconds="30" do_with_retries "${retries}" "${ORAS_BIN}" "$@"
+		sleep_seconds="30" do_with_retries "${retries}" env -i "HOME=${ORAS_HOME}" "${ORAS_BIN}" "$@"
 	else
 		# If any parameters passed, call ORAS, otherwise exit. We call it this way (sans-parameters) early to prepare ORAS tooling.
 		if [[ $# -eq 0 ]]; then
@@ -92,7 +94,7 @@ function run_tool_oras() {
 		fi
 
 		display_alert "Calling ORAS" "$*" "debug"
-		"${ORAS_BIN}" "$@"
+		env -i "HOME=${ORAS_HOME}" "${ORAS_BIN}" "$@"
 	fi
 }
 


### PR DESCRIPTION
#### oci-oras: fix for ORAS > 1.x, as it now requires `HOME` to be set (fixes `download-artifact`)

- oci-oras: fix for ORAS > 1.x, as it now requires `HOME` to be set (fixes `download-artifact`)
  - it hasn't HOME when run under the matrix-prepare multiprocess launcher, so use TMPDIR
  - fixes https://github.com/armbian/build/pull/6964