### PR TITLE
utils-dpkgdeb: force rebuild of all artifacts, due to https://github.com/armbian/build/pull/6964 (ORAS change)

### DIFF
--- a/lib/functions/compilation/packages/utils-dpkgdeb.sh
+++ b/lib/functions/compilation/packages/utils-dpkgdeb.sh
@@ -183,3 +183,5 @@ function generic_artifact_package_hook_helper() {
 	# produce log asset for script (@TODO: batcat?)
 	LOG_ASSET="deb-${artifact_name:?}-${script}.sh" do_with_log_asset run_host_command_logged cat "${package_DEBIAN_dir}/${script}"
 }
+
+# 2024-07-20: change here to force a rebuild of hopefully all artifacts.


### PR DESCRIPTION
#### utils-dpkgdeb: force rebuild of all artifacts, due to https://github.com/armbian/build/pull/6964 (ORAS change)

- utils-dpkgdeb: force rebuild of all artifacts, due to https://github.com/armbian/build/pull/6964 (ORAS change)