### PR TITLE
mesa-vpu: use kisak mesa ppa instead of oibaf

### DIFF
--- a/extensions/mesa-vpu.sh
+++ b/extensions/mesa-vpu.sh
@@ -20,7 +20,7 @@ function extension_prepare_config__3d() {
 
 	elif [[ "${DISTRIBUTION}" == "Ubuntu" ]]; then
 
-		EXTRA_IMAGE_SUFFIXES+=("-oibaf")
+		EXTRA_IMAGE_SUFFIXES+=("-kisak")
 
 	fi
 
@@ -62,13 +62,13 @@ function post_install_kernel_debs__3d() {
 
 	elif [[ "${DISTRIBUTION}" == "Ubuntu" ]]; then
 
-		display_alert "Adding oibaf PPAs" "${EXTENSION}" "info"
-		do_with_retries 3 chroot_sdcard add-apt-repository ppa:oibaf/graphics-drivers --yes --no-update
+		display_alert "Adding kisak PPAs" "${EXTENSION}" "info"
+		do_with_retries 3 chroot_sdcard add-apt-repository ppa:kisak/kisak-mesa --yes --no-update
 
-		display_alert "Pinning oibaf PPAs" "${EXTENSION}" "info"
-		cat <<- EOF > "${SDCARD}"/etc/apt/preferences.d/mesa-oibaf-graphics-drivers-pin
+		display_alert "Pinning kisak PPAs" "${EXTENSION}" "info"
+		cat <<- EOF > "${SDCARD}"/etc/apt/preferences.d/mesa-kisak-kisak-mesa-pin
 			Package: *
-			Pin: release o=LP-PPA-oibaf-graphics-drivers
+			Pin: release o=LP-PPA-kisak-kisak-mesa
 			Pin-Priority: 1001
 		EOF
 
@@ -94,7 +94,7 @@ function post_install_kernel_debs__3d() {
 		EOF
 	fi
 
-	display_alert "Updating sources list, after oibaf PPAs" "${EXTENSION}" "info"
+	display_alert "Updating sources list, after kisak PPAs" "${EXTENSION}" "info"
 	do_with_retries 3 chroot_sdcard_apt_get_update
 
 	display_alert "Installing 3D extension packages" "${EXTENSION}" "info"


### PR DESCRIPTION
# Description

Latest update of oibaf mesa is causing gpu fallback to llvmpipe on rk3588 panthor gpu driver, reported here https://github.com/armbian/linux-rockchip/pull/210#issuecomment-2241501670.

Including bleeding edge git version of mesa is not a good idea. And now we have another ppa packaging release version of mesa: https://launchpad.net/~kisak/+archive/ubuntu/kisak-mesa

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [ ] Not yet tested, I will build image and test later

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
