### PR TITLE
Fix for no network inside Docker container

### DIFF
--- a/extensions/network/config-networkd/netplan/10-dhcp-all-interfaces.yaml
+++ b/extensions/network/config-networkd/netplan/10-dhcp-all-interfaces.yaml
@@ -10,7 +10,7 @@ network:
   ethernets:
     all-eth-interfaces:
       match:
-        name: "*"
+        name: "e*"
       dhcp4: yes
       dhcp6: yes
       ipv6-privacy: yes # Enabled by default on most current systems, but networkd currently doesn't enable IPv6 privacy by default, see https://man.archlinux.org/man/systemd.network.5


### PR DESCRIPTION
# Description

Force netplan to use DHCP only on interface e* and not also on the docker interface

[Jira](https://armbian.atlassian.net/jira) reference number [AR-2430]

# How Has This Been Tested?

- [x] Test by user on forum

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-2430]: https://armbian.atlassian.net/browse/AR-2430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ