### PR TITLE
fix rk3568-roc-pc

### DIFF
--- a/config/boards/station-p2.csc
+++ b/config/boards/station-p2.csc
@@ -2,11 +2,11 @@
 BOARD_NAME="Station P2"
 BOARDFAMILY="rockchip64"
 BOOT_SOC="rk3568"
-BOARD_MAINTAINER="150balbes"
+BOARD_MAINTAINER=""
 KERNEL_TARGET="current,edge"
 FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
-BOOT_FDT_FILE="rockchip/rk3568-firefly-roc-pc.dtb"
+BOOT_FDT_FILE="rockchip/rk3568-roc-pc.dtb"
 ASOUND_STATE="asound.state.station-p2"
 IMAGE_PARTITION_TABLE="gpt"
 

--- a/patch/kernel/archive/rockchip64-6.10/board-station-p2.patch
+++ b/patch/kernel/archive/rockchip64-6.10/board-station-p2.patch
@@ -1,0 +1,580 @@
+--- a/arch/arm64/boot/dts/rockchip/rk3568-roc-pc.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3568-roc-pc.dts
+@@ -48,17 +48,15 @@
+ 		#clock-cells = <0>;
+ 	};
+ 
+-	leds {
++	firefly_leds: leds {
+ 		compatible = "gpio-leds";
+-
+-		led-user {
+-			label = "user-led";
++		power_led: power {
++			label = "firefly:blue:power";
++			linux,default-trigger = "ir-power-click";
+ 			default-state = "on";
+ 			gpios = <&gpio1 RK_PB2 GPIO_ACTIVE_HIGH>;
+-			linux,default-trigger = "heartbeat";
+ 			pinctrl-names = "default";
+-			pinctrl-0 = <&user_led_enable_h>;
+-			retain-state-suspended;
++			pinctrl-0 = <&led_power>;
+ 		};
+ 	};
+ 
+@@ -126,41 +124,134 @@
+ 		vin-supply = <&dc_12v>;
+ 	};
+ 
+-	vcc5v0_usb: vcc5v0-usb-regulator {
+-		compatible = "regulator-fixed";
+-		regulator-name = "vcc5v0_usb";
+-		regulator-always-on;
+-		regulator-boot-on;
+-		regulator-min-microvolt = <5000000>;
+-		regulator-max-microvolt = <5000000>;
+-		vin-supply = <&vcc5v0_sys>;
+-	};
+-
+ 	vcc5v0_host: vcc5v0-host-regulator {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vcc5v0_host";
+ 		enable-active-high;
+-		gpio = <&gpio0 RK_PA6 GPIO_ACTIVE_HIGH>;
++		gpio = <&gpio0 RK_PD6 GPIO_ACTIVE_HIGH>;
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&vcc5v0_host_en>;
+ 		regulator-always-on;
+-		vin-supply = <&vcc5v0_usb>;
+ 	};
+ 
+ 	vcc5v0_otg: vcc5v0-otg-regulator {
+ 		compatible = "regulator-fixed";
+-		regulator-name = "vcc5v0_otg";
+ 		enable-active-high;
+ 		gpio = <&gpio0 RK_PA5 GPIO_ACTIVE_HIGH>;
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&vcc5v0_otg_en>;
+-		vin-supply = <&vcc5v0_usb>;
++		regulator-name = "vcc5v0_otg";
+ 	};
+-};
+ 
+-&combphy0 {
+-	/* used for USB3 */
+-	status = "okay";
++	vcc2v5_sys: vcc2v5-ddr-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc2v5-sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <2500000>;
++		regulator-max-microvolt = <2500000>;
++		vin-supply = <&vcc3v3_sys>;
++	};
++
++	vcc_hub_power: vcc-hub-power-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio0 RK_PA6 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc_hub_power_en>;
++		regulator-name = "vcc_hub_power_en";
++		regulator-always-on;
++	};
++
++	vcc_hub_reset: vcc-hub-reset-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio1 RK_PA4 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc_hub_reset_en>;
++		regulator-name = "vcc_hub_reset_en";
++		regulator-always-on;
++	};
++
++	pcie_pi6c_oe: pcie-pi6c-oe-regulator {
++		compatible = "regulator-fixed";
++		//enable-active-high;
++		gpio = <&gpio3 RK_PA7 GPIO_ACTIVE_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pcie_pi6c_oe_en>;
++		regulator-name = "pcie_pi6c_oe_en";
++		regulator-always-on;
++	};
++
++	sdio_pwrseq: sdio-pwrseq {
++		status = "okay";
++		compatible = "mmc-pwrseq-simple";
++		clocks = <&rk809 1>;
++		clock-names = "ext_clock";
++		pinctrl-names = "default";
++		pinctrl-0 = <&wifi_enable_h>;
++		reset-gpios = <&gpio3 RK_PD5 GPIO_ACTIVE_LOW>;
++		post-power-on-delay-ms = <100>;
++	};
++
++	wireless_wlan: wireless-wlan {
++		compatible = "wlan-platdata";
++		rockchip,grf = <&grf>;
++		wifi_chip_type = "ap6275s";
++		pinctrl-names = "default";
++		pinctrl-0 = <&wifi_host_wake_irq>;
++		WIFI,host_wake_irq = <&gpio3 RK_PD4 GPIO_ACTIVE_HIGH>;
++		status = "okay";
++	};
++
++	wireless_bluetooth: wireless-bluetooth {
++		compatible = "bluetooth-platdata";
++		clocks = <&rk809 1>;
++		clock-names = "ext_clock";
++		//wifi-bt-power-toggle;
++		uart_rts_gpios = <&gpio2 RK_PB1 GPIO_ACTIVE_LOW>;
++		pinctrl-names = "default", "rts_gpio";
++		pinctrl-0 = <&uart8m0_rtsn>;
++		pinctrl-1 = <&uart8_gpios>;
++		BT,reset_gpio    = <&gpio3 RK_PA0 GPIO_ACTIVE_HIGH>;
++		BT,wake_gpio     = <&gpio3 RK_PA1 GPIO_ACTIVE_HIGH>;
++		BT,wake_host_irq = <&gpio3 RK_PA2 GPIO_ACTIVE_HIGH>;
++		status = "okay";
++	};
++
++	flash_led: flash-led {
++		compatible = "led,rgb13h";
++		label = "pwm-flash-led";
++		led-max-microamp = <20000>;
++		flash-max-microamp = <20000>;
++		flash-max-timeout-us = <1000000>;
++		pwms = <&pwm11 0 25000 0>;
++		rockchip,camera-module-index = <1>;
++		rockchip,camera-module-facing = "front";
++		status = "disabled";
++	};
++
++	rk809-sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,name = "Analog RK809";
++		simple-audio-card,mclk-fs = <256>;
++
++		simple-audio-card,cpu {
++			sound-dai = <&i2s1_8ch>;
++		};
++		simple-audio-card,codec {
++			sound-dai = <&rk809>;
++		};
++	};
++
++	rk_headset: rk-headset {
++		compatible = "rockchip_headset";
++		headset_gpio = <&gpio2 RK_PD2 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&hp_det>;
++		io-channels = <&saradc 2>;    //HP_HOOK pin
++	};
+ };
+ 
+ &combphy1 {
+@@ -247,15 +338,59 @@
+ &i2c0 {
+ 	status = "okay";
+ 
++	fusb0: fusb30x@22 {
++		compatible = "fairchild,fusb302";
++		reg = <0x22>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&fusb0_int>;
++		int-n-gpios = <&gpio0 RK_PC1 GPIO_ACTIVE_HIGH>;
++		fusb340-switch-gpios = <&gpio3 RK_PC2 GPIO_ACTIVE_HIGH>;
++		vbus-5v-gpios = <&gpio0 RK_PA5 GPIO_ACTIVE_HIGH>;
++		status = "okay";
++	};
++
++	vdd_cpu: regulator@1c {
++		compatible = "tcs,tcs4525";
++		reg = <0x1c>;
++		vin-supply = <&vcc5v0_sys>;
++		regulator-compatible = "fan53555-reg";
++		regulator-name = "vdd_cpu";
++		regulator-min-microvolt = <712500>;
++		regulator-max-microvolt = <1390000>;
++		regulator-ramp-delay = <2300>;
++		fcs,suspend-voltage-selector = <1>;
++		regulator-boot-on;
++		regulator-always-on;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++
+ 	rk809: pmic@20 {
+ 		compatible = "rockchip,rk809";
+ 		reg = <0x20>;
+ 		interrupt-parent = <&gpio0>;
+ 		interrupts = <RK_PA3 IRQ_TYPE_LEVEL_LOW>;
++		assigned-clocks = <&cru I2S1_MCLKOUT_TX>;
++		assigned-clock-rates = <12288000>;
++		assigned-clock-parents = <&cru CLK_I2S1_8CH_TX>;
+ 		#clock-cells = <1>;
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&pmic_int>;
++		clock-names = "mclk";
++		clocks = <&cru I2S1_MCLKOUT_TX>;
++		pinctrl-names = "default", "pmic-sleep",
++				"pmic-power-off", "pmic-reset";
++		pinctrl-0 = <&pmic_int>, <&i2s1m0_mclk>;
++
+ 		rockchip,system-power-controller;
++		#sound-dai-cells = <0>;
++		clock-output-names = "rk808-clkout1", "rk808-clkout2";
++		//fb-inner-reg-idxs = <2>;
++		/* 1: rst regs (default in codes), 0: rst the pmic */
++		pmic-reset-func = <0>;
++		/* not save the PMIC_POWER_EN register in uboot */
++		not-save-power-en = <1>;
++
+ 		vcc1-supply = <&vcc3v3_sys>;
+ 		vcc2-supply = <&vcc3v3_sys>;
+ 		vcc3-supply = <&vcc3v3_sys>;
+@@ -284,6 +419,8 @@
+ 			};
+ 
+ 			vdd_gpu: DCDC_REG2 {
++				regulator-always-on;
++				regulator-boot-on;
+ 				regulator-name = "vdd_gpu";
+ 				regulator-init-microvolt = <900000>;
+ 				regulator-initial-mode = <0x2>;
+@@ -320,19 +457,9 @@
+ 				};
+ 			};
+ 
+-			vcc_1v8: DCDC_REG5 {
+-				regulator-name = "vcc_1v8";
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <1800000>;
+-				regulator-max-microvolt = <1800000>;
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+ 			vdda0v9_image: LDO_REG1 {
++				regulator-boot-on;
++				regulator-always-on;
+ 				regulator-name = "vdda0v9_image";
+ 				regulator-min-microvolt = <900000>;
+ 				regulator-max-microvolt = <900000>;
+@@ -368,6 +495,8 @@
+ 			};
+ 
+ 			vccio_acodec: LDO_REG4 {
++				regulator-always-on;
++				regulator-boot-on;
+ 				regulator-name = "vccio_acodec";
+ 				regulator-min-microvolt = <3300000>;
+ 				regulator-max-microvolt = <3300000>;
+@@ -379,6 +508,8 @@
+ 
+ 			vccio_sd: LDO_REG5 {
+ 				regulator-name = "vccio_sd";
++				regulator-always-on;
++				regulator-boot-on;
+ 				regulator-min-microvolt = <1800000>;
+ 				regulator-max-microvolt = <3300000>;
+ 
+@@ -426,6 +557,8 @@
+ 			};
+ 
+ 			vcca1v8_image: LDO_REG9 {
++				regulator-always-on;
++				regulator-boot-on;
+ 				regulator-name = "vcca1v8_image";
+ 				regulator-min-microvolt = <1800000>;
+ 				regulator-max-microvolt = <1800000>;
+@@ -435,6 +568,17 @@
+ 				};
+ 			};
+ 
++			vcc_1v8: DCDC_REG5 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "vcc_1v8";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
+ 			vcc_3v3: SWITCH_REG1 {
+ 				regulator-name = "vcc_3v3";
+ 				regulator-always-on;
+@@ -455,6 +599,10 @@
+ 				};
+ 			};
+ 		};
++
++		codec {
++			mic-in-differential;
++		};
+ 	};
+ };
+ 
+@@ -477,7 +625,7 @@
+ };
+ 
+ &pcie30phy {
+-	status = "okay";
++	tatus = "okay";
+ };
+ 
+ &pcie3x2 {
+@@ -490,19 +638,27 @@
+ 
+ &pinctrl {
+ 	leds {
+-		user_led_enable_h: user-led-enable-h {
+-			rockchip,pins = <1 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
++		led_power: led-power {
++			rockchip,pins = <0 RK_PD3 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 	};
+ 
+ 	usb {
+ 		vcc5v0_host_en: vcc5v0-host-en {
+-			rockchip,pins = <0 RK_PA6 RK_FUNC_GPIO &pcfg_pull_none>;
++			rockchip,pins = <0 RK_PD6 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 
+ 		vcc5v0_otg_en: vcc5v0-otg-en {
+ 			rockchip,pins = <0 RK_PA5 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
++
++		vcc_hub_power_en: vcc-hub-power-en {
++			rockchip,pins = <0 RK_PA6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		vcc_hub_reset_en: vcc-hub-reset-en {
++			rockchip,pins = <1 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
+ 	};
+ 
+ 	pcie {
+@@ -512,21 +668,53 @@
+ 		vcc3v3_pcie_en_pin: vcc3v3-pcie-en-pin {
+ 			rockchip,pins = <0 RK_PD4 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
++		pcie_pi6c_oe_en: pcie-pi6c-oe-en {
++			rockchip,pins = <3 RK_PA7 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
+ 	};
+ 
+ 	pmic {
+-		pmic_int: pmic-int {
++		pmic_int: pmic_int {
+ 			rockchip,pins =
+ 				<0 RK_PA3 RK_FUNC_GPIO &pcfg_pull_up>;
+ 		};
+ 	};
++
++	sdio-pwrseq {
++		wifi_enable_h: wifi-enable-h {
++			rockchip,pins = <3 RK_PD5 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	wireless-wlan {
++		wifi_host_wake_irq: wifi-host-wake-irq {
++			rockchip,pins = <3 RK_PD4 RK_FUNC_GPIO &pcfg_pull_down>;
++		};
++	};
++
++	wireless-bluetooth {
++		uart8_gpios: uart8-gpios {
++			rockchip,pins = <2 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	fusb30x {
++		fusb0_int: fusb0-int {
++			rockchip,pins = <0 RK_PC1 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	headphone {
++		hp_det: hp-det {
++			rockchip,pins = <2 RK_PD2 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
+ };
+ 
+ &pmu_io_domains {
+ 	pmuio1-supply = <&vcc3v3_pmu>;
+ 	pmuio2-supply = <&vcc3v3_pmu>;
+ 	vccio1-supply = <&vccio_acodec>;
+-	vccio2-supply = <&vcc_1v8>;
+ 	vccio3-supply = <&vccio_sd>;
+ 	vccio4-supply = <&vcc_1v8>;
+ 	vccio5-supply = <&vcc_3v3>;
+@@ -548,25 +736,44 @@
+ 	bus-width = <8>;
+ 	max-frequency = <200000000>;
+ 	non-removable;
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&emmc_bus8 &emmc_clk &emmc_cmd &emmc_datastrobe>;
++	supports-emmc;
+ 	status = "okay";
+ };
+ 
+ &sdmmc0 {
+ 	bus-width = <4>;
+ 	cap-sd-highspeed;
+-	cd-gpios = <&gpio0 RK_PA4 GPIO_ACTIVE_LOW>;
+ 	disable-wp;
+-	pinctrl-names = "default";
+ 	pinctrl-0 = <&sdmmc0_bus4 &sdmmc0_clk &sdmmc0_cmd &sdmmc0_det>;
+ 	sd-uhs-sdr104;
+ 	vmmc-supply = <&vcc3v3_sd>;
+ 	vqmmc-supply = <&vccio_sd>;
++	max-frequency = <150000000>;
++	supports-sd;
++	cap-mmc-highspeed;
++	pinctrl-names = "default";
++	status = "okay";
++};
++
++&sdmmc2 {
++	max-frequency = <150000000>;
++	supports-sdio;
++	bus-width = <4>;
++	disable-wp;
++	cap-sd-highspeed;
++	cap-sdio-irq;
++	keep-power-in-suspend;
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdmmc2m0_bus4 &sdmmc2m0_cmd &sdmmc2m0_clk>;
++	sd-uhs-sdr104;
++	mmc-pwrseq = <&sdio_pwrseq>;
++	non-removable;
+ 	status = "okay";
+ };
+ 
+ &tsadc {
++	rockchip,hw-tshut-mode = <1>;
++	rockchip,hw-tshut-polarity = <0>;
+ 	status = "okay";
+ };
+ 
+@@ -588,6 +795,7 @@
+ };
+ 
+ &usb2phy0_otg {
++	vbus-supply = <&vcc5v0_otg>;
+ 	status = "okay";
+ };
+ 
+@@ -609,6 +817,10 @@
+ 	status = "okay";
+ };
+ 
++&usb_host0_xhci {
++	status = "okay";
++};
++
+ &usb_host1_ehci {
+ 	status = "okay";
+ };
+@@ -617,11 +829,13 @@
+ 	status = "okay";
+ };
+ 
+-&usb_host0_xhci {
++&usb_host1_xhci {
+ 	status = "okay";
+ };
+ 
+-&usb_host1_xhci {
++&vop {
++	assigned-clocks = <&cru DCLK_VOP0>, <&cru DCLK_VOP1>;
++	assigned-clock-parents = <&pmucru PLL_HPLL>, <&cru PLL_VPLL>;
+ 	status = "okay";
+ };
+ 
+@@ -632,12 +846,68 @@
+ 	};
+ };
+ 
+-&vop {
+-	assigned-clocks = <&cru DCLK_VOP0>, <&cru DCLK_VOP1>;
+-	assigned-clock-parents = <&pmucru PLL_HPLL>, <&cru PLL_VPLL>;
++&vop_mmu {
+ 	status = "okay";
+ };
+ 
+-&vop_mmu {
++&i2s1_8ch {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2s1m0_sclktx
++		     &i2s1m0_lrcktx
++		     &i2s1m0_sdi0
++		     &i2s1m0_sdo0>;
++	rockchip,trcm-sync-tx-only;
++	status = "okay";
++};
++
++&i2c1 {
++    status = "okay";
++};
++
++&i2c4 {
++	status = "okay";
++};
++
++&i2c5 {
++    status = "okay";
++};
++
++&gic {
++    status = "okay";
++};
++
++&uart3 {
++//	status = "disabled";
++	pinctrl-names = "default";
++	status = "okay";
++};
++
++&uart4 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart4m1_xfer>;
++        status = "okay";
++};
++
++&uart8 {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart8m0_xfer &uart8m0_ctsn>;
++};
++
++&rk809 {
++    rtc {
++        status = "disabled";
++    };
++};
++
++&pwm4 {
++	status = "okay";
++};
++
++&pwm5 {
++	status = "okay";
++};
++
++&pwm7 {
+ 	status = "okay";
+ };

--- a/patch/kernel/archive/rockchip64-6.6/board-station-p2.patch
+++ b/patch/kernel/archive/rockchip64-6.6/board-station-p2.patch
@@ -1,0 +1,580 @@
+--- a/arch/arm64/boot/dts/rockchip/rk3568-roc-pc.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3568-roc-pc.dts
+@@ -48,17 +48,15 @@
+ 		#clock-cells = <0>;
+ 	};
+ 
+-	leds {
++	firefly_leds: leds {
+ 		compatible = "gpio-leds";
+-
+-		led-user {
+-			label = "user-led";
++		power_led: power {
++			label = "firefly:blue:power";
++			linux,default-trigger = "ir-power-click";
+ 			default-state = "on";
+ 			gpios = <&gpio1 RK_PB2 GPIO_ACTIVE_HIGH>;
+-			linux,default-trigger = "heartbeat";
+ 			pinctrl-names = "default";
+-			pinctrl-0 = <&user_led_enable_h>;
+-			retain-state-suspended;
++			pinctrl-0 = <&led_power>;
+ 		};
+ 	};
+ 
+@@ -126,41 +124,134 @@
+ 		vin-supply = <&dc_12v>;
+ 	};
+ 
+-	vcc5v0_usb: vcc5v0-usb-regulator {
+-		compatible = "regulator-fixed";
+-		regulator-name = "vcc5v0_usb";
+-		regulator-always-on;
+-		regulator-boot-on;
+-		regulator-min-microvolt = <5000000>;
+-		regulator-max-microvolt = <5000000>;
+-		vin-supply = <&vcc5v0_sys>;
+-	};
+-
+ 	vcc5v0_host: vcc5v0-host-regulator {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vcc5v0_host";
+ 		enable-active-high;
+-		gpio = <&gpio0 RK_PA6 GPIO_ACTIVE_HIGH>;
++		gpio = <&gpio0 RK_PD6 GPIO_ACTIVE_HIGH>;
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&vcc5v0_host_en>;
+ 		regulator-always-on;
+-		vin-supply = <&vcc5v0_usb>;
+ 	};
+ 
+ 	vcc5v0_otg: vcc5v0-otg-regulator {
+ 		compatible = "regulator-fixed";
+-		regulator-name = "vcc5v0_otg";
+ 		enable-active-high;
+ 		gpio = <&gpio0 RK_PA5 GPIO_ACTIVE_HIGH>;
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&vcc5v0_otg_en>;
+-		vin-supply = <&vcc5v0_usb>;
++		regulator-name = "vcc5v0_otg";
+ 	};
+-};
+ 
+-&combphy0 {
+-	/* used for USB3 */
+-	status = "okay";
++	vcc2v5_sys: vcc2v5-ddr-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc2v5-sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <2500000>;
++		regulator-max-microvolt = <2500000>;
++		vin-supply = <&vcc3v3_sys>;
++	};
++
++	vcc_hub_power: vcc-hub-power-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio0 RK_PA6 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc_hub_power_en>;
++		regulator-name = "vcc_hub_power_en";
++		regulator-always-on;
++	};
++
++	vcc_hub_reset: vcc-hub-reset-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio1 RK_PA4 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc_hub_reset_en>;
++		regulator-name = "vcc_hub_reset_en";
++		regulator-always-on;
++	};
++
++	pcie_pi6c_oe: pcie-pi6c-oe-regulator {
++		compatible = "regulator-fixed";
++		//enable-active-high;
++		gpio = <&gpio3 RK_PA7 GPIO_ACTIVE_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pcie_pi6c_oe_en>;
++		regulator-name = "pcie_pi6c_oe_en";
++		regulator-always-on;
++	};
++
++	sdio_pwrseq: sdio-pwrseq {
++		status = "okay";
++		compatible = "mmc-pwrseq-simple";
++		clocks = <&rk809 1>;
++		clock-names = "ext_clock";
++		pinctrl-names = "default";
++		pinctrl-0 = <&wifi_enable_h>;
++		reset-gpios = <&gpio3 RK_PD5 GPIO_ACTIVE_LOW>;
++		post-power-on-delay-ms = <100>;
++	};
++
++	wireless_wlan: wireless-wlan {
++		compatible = "wlan-platdata";
++		rockchip,grf = <&grf>;
++		wifi_chip_type = "ap6275s";
++		pinctrl-names = "default";
++		pinctrl-0 = <&wifi_host_wake_irq>;
++		WIFI,host_wake_irq = <&gpio3 RK_PD4 GPIO_ACTIVE_HIGH>;
++		status = "okay";
++	};
++
++	wireless_bluetooth: wireless-bluetooth {
++		compatible = "bluetooth-platdata";
++		clocks = <&rk809 1>;
++		clock-names = "ext_clock";
++		//wifi-bt-power-toggle;
++		uart_rts_gpios = <&gpio2 RK_PB1 GPIO_ACTIVE_LOW>;
++		pinctrl-names = "default", "rts_gpio";
++		pinctrl-0 = <&uart8m0_rtsn>;
++		pinctrl-1 = <&uart8_gpios>;
++		BT,reset_gpio    = <&gpio3 RK_PA0 GPIO_ACTIVE_HIGH>;
++		BT,wake_gpio     = <&gpio3 RK_PA1 GPIO_ACTIVE_HIGH>;
++		BT,wake_host_irq = <&gpio3 RK_PA2 GPIO_ACTIVE_HIGH>;
++		status = "okay";
++	};
++
++	flash_led: flash-led {
++		compatible = "led,rgb13h";
++		label = "pwm-flash-led";
++		led-max-microamp = <20000>;
++		flash-max-microamp = <20000>;
++		flash-max-timeout-us = <1000000>;
++		pwms = <&pwm11 0 25000 0>;
++		rockchip,camera-module-index = <1>;
++		rockchip,camera-module-facing = "front";
++		status = "disabled";
++	};
++
++	rk809-sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,name = "Analog RK809";
++		simple-audio-card,mclk-fs = <256>;
++
++		simple-audio-card,cpu {
++			sound-dai = <&i2s1_8ch>;
++		};
++		simple-audio-card,codec {
++			sound-dai = <&rk809>;
++		};
++	};
++
++	rk_headset: rk-headset {
++		compatible = "rockchip_headset";
++		headset_gpio = <&gpio2 RK_PD2 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&hp_det>;
++		io-channels = <&saradc 2>;    //HP_HOOK pin
++	};
+ };
+ 
+ &combphy1 {
+@@ -247,15 +338,59 @@
+ &i2c0 {
+ 	status = "okay";
+ 
++	fusb0: fusb30x@22 {
++		compatible = "fairchild,fusb302";
++		reg = <0x22>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&fusb0_int>;
++		int-n-gpios = <&gpio0 RK_PC1 GPIO_ACTIVE_HIGH>;
++		fusb340-switch-gpios = <&gpio3 RK_PC2 GPIO_ACTIVE_HIGH>;
++		vbus-5v-gpios = <&gpio0 RK_PA5 GPIO_ACTIVE_HIGH>;
++		status = "okay";
++	};
++
++	vdd_cpu: regulator@1c {
++		compatible = "tcs,tcs4525";
++		reg = <0x1c>;
++		vin-supply = <&vcc5v0_sys>;
++		regulator-compatible = "fan53555-reg";
++		regulator-name = "vdd_cpu";
++		regulator-min-microvolt = <712500>;
++		regulator-max-microvolt = <1390000>;
++		regulator-ramp-delay = <2300>;
++		fcs,suspend-voltage-selector = <1>;
++		regulator-boot-on;
++		regulator-always-on;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++
+ 	rk809: pmic@20 {
+ 		compatible = "rockchip,rk809";
+ 		reg = <0x20>;
+ 		interrupt-parent = <&gpio0>;
+ 		interrupts = <RK_PA3 IRQ_TYPE_LEVEL_LOW>;
++		assigned-clocks = <&cru I2S1_MCLKOUT_TX>;
++		assigned-clock-rates = <12288000>;
++		assigned-clock-parents = <&cru CLK_I2S1_8CH_TX>;
+ 		#clock-cells = <1>;
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&pmic_int>;
++		clock-names = "mclk";
++		clocks = <&cru I2S1_MCLKOUT_TX>;
++		pinctrl-names = "default", "pmic-sleep",
++				"pmic-power-off", "pmic-reset";
++		pinctrl-0 = <&pmic_int>, <&i2s1m0_mclk>;
++
+ 		rockchip,system-power-controller;
++		#sound-dai-cells = <0>;
++		clock-output-names = "rk808-clkout1", "rk808-clkout2";
++		//fb-inner-reg-idxs = <2>;
++		/* 1: rst regs (default in codes), 0: rst the pmic */
++		pmic-reset-func = <0>;
++		/* not save the PMIC_POWER_EN register in uboot */
++		not-save-power-en = <1>;
++
+ 		vcc1-supply = <&vcc3v3_sys>;
+ 		vcc2-supply = <&vcc3v3_sys>;
+ 		vcc3-supply = <&vcc3v3_sys>;
+@@ -284,6 +419,8 @@
+ 			};
+ 
+ 			vdd_gpu: DCDC_REG2 {
++				regulator-always-on;
++				regulator-boot-on;
+ 				regulator-name = "vdd_gpu";
+ 				regulator-init-microvolt = <900000>;
+ 				regulator-initial-mode = <0x2>;
+@@ -320,19 +457,9 @@
+ 				};
+ 			};
+ 
+-			vcc_1v8: DCDC_REG5 {
+-				regulator-name = "vcc_1v8";
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <1800000>;
+-				regulator-max-microvolt = <1800000>;
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+ 			vdda0v9_image: LDO_REG1 {
++				regulator-boot-on;
++				regulator-always-on;
+ 				regulator-name = "vdda0v9_image";
+ 				regulator-min-microvolt = <900000>;
+ 				regulator-max-microvolt = <900000>;
+@@ -368,6 +495,8 @@
+ 			};
+ 
+ 			vccio_acodec: LDO_REG4 {
++				regulator-always-on;
++				regulator-boot-on;
+ 				regulator-name = "vccio_acodec";
+ 				regulator-min-microvolt = <3300000>;
+ 				regulator-max-microvolt = <3300000>;
+@@ -379,6 +508,8 @@
+ 
+ 			vccio_sd: LDO_REG5 {
+ 				regulator-name = "vccio_sd";
++				regulator-always-on;
++				regulator-boot-on;
+ 				regulator-min-microvolt = <1800000>;
+ 				regulator-max-microvolt = <3300000>;
+ 
+@@ -426,6 +557,8 @@
+ 			};
+ 
+ 			vcca1v8_image: LDO_REG9 {
++				regulator-always-on;
++				regulator-boot-on;
+ 				regulator-name = "vcca1v8_image";
+ 				regulator-min-microvolt = <1800000>;
+ 				regulator-max-microvolt = <1800000>;
+@@ -435,6 +568,17 @@
+ 				};
+ 			};
+ 
++			vcc_1v8: DCDC_REG5 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "vcc_1v8";
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
+ 			vcc_3v3: SWITCH_REG1 {
+ 				regulator-name = "vcc_3v3";
+ 				regulator-always-on;
+@@ -455,6 +599,10 @@
+ 				};
+ 			};
+ 		};
++
++		codec {
++			mic-in-differential;
++		};
+ 	};
+ };
+ 
+@@ -477,7 +625,7 @@
+ };
+ 
+ &pcie30phy {
+-	status = "okay";
++	tatus = "okay";
+ };
+ 
+ &pcie3x2 {
+@@ -490,19 +638,27 @@
+ 
+ &pinctrl {
+ 	leds {
+-		user_led_enable_h: user-led-enable-h {
+-			rockchip,pins = <1 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
++		led_power: led-power {
++			rockchip,pins = <0 RK_PD3 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 	};
+ 
+ 	usb {
+ 		vcc5v0_host_en: vcc5v0-host-en {
+-			rockchip,pins = <0 RK_PA6 RK_FUNC_GPIO &pcfg_pull_none>;
++			rockchip,pins = <0 RK_PD6 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 
+ 		vcc5v0_otg_en: vcc5v0-otg-en {
+ 			rockchip,pins = <0 RK_PA5 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
++
++		vcc_hub_power_en: vcc-hub-power-en {
++			rockchip,pins = <0 RK_PA6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		vcc_hub_reset_en: vcc-hub-reset-en {
++			rockchip,pins = <1 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
+ 	};
+ 
+ 	pcie {
+@@ -512,21 +668,53 @@
+ 		vcc3v3_pcie_en_pin: vcc3v3-pcie-en-pin {
+ 			rockchip,pins = <0 RK_PD4 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
++		pcie_pi6c_oe_en: pcie-pi6c-oe-en {
++			rockchip,pins = <3 RK_PA7 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
+ 	};
+ 
+ 	pmic {
+-		pmic_int: pmic-int {
++		pmic_int: pmic_int {
+ 			rockchip,pins =
+ 				<0 RK_PA3 RK_FUNC_GPIO &pcfg_pull_up>;
+ 		};
+ 	};
++
++	sdio-pwrseq {
++		wifi_enable_h: wifi-enable-h {
++			rockchip,pins = <3 RK_PD5 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	wireless-wlan {
++		wifi_host_wake_irq: wifi-host-wake-irq {
++			rockchip,pins = <3 RK_PD4 RK_FUNC_GPIO &pcfg_pull_down>;
++		};
++	};
++
++	wireless-bluetooth {
++		uart8_gpios: uart8-gpios {
++			rockchip,pins = <2 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	fusb30x {
++		fusb0_int: fusb0-int {
++			rockchip,pins = <0 RK_PC1 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	headphone {
++		hp_det: hp-det {
++			rockchip,pins = <2 RK_PD2 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
+ };
+ 
+ &pmu_io_domains {
+ 	pmuio1-supply = <&vcc3v3_pmu>;
+ 	pmuio2-supply = <&vcc3v3_pmu>;
+ 	vccio1-supply = <&vccio_acodec>;
+-	vccio2-supply = <&vcc_1v8>;
+ 	vccio3-supply = <&vccio_sd>;
+ 	vccio4-supply = <&vcc_1v8>;
+ 	vccio5-supply = <&vcc_3v3>;
+@@ -548,25 +736,44 @@
+ 	bus-width = <8>;
+ 	max-frequency = <200000000>;
+ 	non-removable;
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&emmc_bus8 &emmc_clk &emmc_cmd &emmc_datastrobe>;
++	supports-emmc;
+ 	status = "okay";
+ };
+ 
+ &sdmmc0 {
+ 	bus-width = <4>;
+ 	cap-sd-highspeed;
+-	cd-gpios = <&gpio0 RK_PA4 GPIO_ACTIVE_LOW>;
+ 	disable-wp;
+-	pinctrl-names = "default";
+ 	pinctrl-0 = <&sdmmc0_bus4 &sdmmc0_clk &sdmmc0_cmd &sdmmc0_det>;
+ 	sd-uhs-sdr104;
+ 	vmmc-supply = <&vcc3v3_sd>;
+ 	vqmmc-supply = <&vccio_sd>;
++	max-frequency = <150000000>;
++	supports-sd;
++	cap-mmc-highspeed;
++	pinctrl-names = "default";
++	status = "okay";
++};
++
++&sdmmc2 {
++	max-frequency = <150000000>;
++	supports-sdio;
++	bus-width = <4>;
++	disable-wp;
++	cap-sd-highspeed;
++	cap-sdio-irq;
++	keep-power-in-suspend;
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdmmc2m0_bus4 &sdmmc2m0_cmd &sdmmc2m0_clk>;
++	sd-uhs-sdr104;
++	mmc-pwrseq = <&sdio_pwrseq>;
++	non-removable;
+ 	status = "okay";
+ };
+ 
+ &tsadc {
++	rockchip,hw-tshut-mode = <1>;
++	rockchip,hw-tshut-polarity = <0>;
+ 	status = "okay";
+ };
+ 
+@@ -588,6 +795,7 @@
+ };
+ 
+ &usb2phy0_otg {
++	vbus-supply = <&vcc5v0_otg>;
+ 	status = "okay";
+ };
+ 
+@@ -609,6 +817,10 @@
+ 	status = "okay";
+ };
+ 
++&usb_host0_xhci {
++	status = "okay";
++};
++
+ &usb_host1_ehci {
+ 	status = "okay";
+ };
+@@ -617,11 +829,13 @@
+ 	status = "okay";
+ };
+ 
+-&usb_host0_xhci {
++&usb_host1_xhci {
+ 	status = "okay";
+ };
+ 
+-&usb_host1_xhci {
++&vop {
++	assigned-clocks = <&cru DCLK_VOP0>, <&cru DCLK_VOP1>;
++	assigned-clock-parents = <&pmucru PLL_HPLL>, <&cru PLL_VPLL>;
+ 	status = "okay";
+ };
+ 
+@@ -632,12 +846,68 @@
+ 	};
+ };
+ 
+-&vop {
+-	assigned-clocks = <&cru DCLK_VOP0>, <&cru DCLK_VOP1>;
+-	assigned-clock-parents = <&pmucru PLL_HPLL>, <&cru PLL_VPLL>;
++&vop_mmu {
+ 	status = "okay";
+ };
+ 
+-&vop_mmu {
++&i2s1_8ch {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2s1m0_sclktx
++		     &i2s1m0_lrcktx
++		     &i2s1m0_sdi0
++		     &i2s1m0_sdo0>;
++	rockchip,trcm-sync-tx-only;
++	status = "okay";
++};
++
++&i2c1 {
++    status = "okay";
++};
++
++&i2c4 {
++	status = "okay";
++};
++
++&i2c5 {
++    status = "okay";
++};
++
++&gic {
++    status = "okay";
++};
++
++&uart3 {
++//	status = "disabled";
++	pinctrl-names = "default";
++	status = "okay";
++};
++
++&uart4 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart4m1_xfer>;
++        status = "okay";
++};
++
++&uart8 {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart8m0_xfer &uart8m0_ctsn>;
++};
++
++&rk809 {
++    rtc {
++        status = "disabled";
++    };
++};
++
++&pwm4 {
++	status = "okay";
++};
++
++&pwm5 {
++	status = "okay";
++};
++
++&pwm7 {
+ 	status = "okay";
+ };


### PR DESCRIPTION
# Description

station-p2 cannot start up properly.
This is an interesting thing.

Device tree name for station-p2: `rk3568-firefly-roc-pc`, derived from the previous `media` kernel family: https://github.com/armbian/build/blob/v24.05/patch/kernel/media-current/00170-v95-rk3568-firefly-roc-pc.patch

But its name in the mainline kernel is: `rk3568-roc-pc`.

But there has been an interesting change in this modification, and I am doubting whether this change is wise:
https://github.com/armbian/build/commit/eb60d33abac91b25eb720bae27981a2a8950f9f7

I borrowed a station-p2 from my friend to fix this issue.

# How Has This Been Tested?

- [x] Successfully built.
- [x] System startup.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
