### PR TITLE
mesa-vpu: install backported mesa from obs for bookworm panthor driver

### DIFF
--- a/extensions/mesa-vpu.sh
+++ b/extensions/mesa-vpu.sh
@@ -22,6 +22,10 @@ function extension_prepare_config__3d() {
 
 		EXTRA_IMAGE_SUFFIXES+=("-kisak")
 
+	elif [[ "${DISTRIBUTION}" == "Debian" && "${RELEASE}" == "bookworm" ]]; then
+
+		EXTRA_IMAGE_SUFFIXES+=("-backported-mesa")
+
 	fi
 
 	# This should be enabled on all for rk3588 distributions where mesa and vendor kernel is present
@@ -71,6 +75,12 @@ function post_install_kernel_debs__3d() {
 			Pin: release o=LP-PPA-kisak-kisak-mesa
 			Pin-Priority: 1001
 		EOF
+
+	elif [[ "${DISTRIBUTION}" == "Debian" && "${RELEASE}" == "bookworm" ]]; then
+
+		display_alert "Adding mesa backport repo for ${RELEASE} from OBS" "${EXTENSION}" "info"
+		echo 'deb http://download.opensuse.org/repositories/home:/amazingfate:/mesa-bookworm-backport/Debian_12/ /' | tee "${SDCARD}"/etc/apt/sources.list.d/home:amazingfate:mesa-bookworm-backport.list
+		curl -fsSL https://download.opensuse.org/repositories/home:amazingfate:mesa-bookworm-backport/Debian_12/Release.key | gpg --dearmor | tee "${SDCARD}"/etc/apt/trusted.gpg.d/home_amazingfate_mesa-bookworm-backport.gpg > /dev/null
 
 	fi
 


### PR DESCRIPTION
# Description

Bookworm is the latest stable release of debian from 2023, with mesa 22 in its repo, which will not support rk3588 panthor mainline gpu driver. I backported mesa 24.1.3 in obs: https://build.opensuse.org/project/show/home:amazingfate:mesa-bookworm-backport. And here is the instruction of updating mesa from obs's repo: https://software.opensuse.org//download.html?project=home%3Aamazingfate%3Amesa-bookworm-backport&package=libgl1-mesa-dri

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh BOARD=rock-5b BRANCH=edge BUILD_MINIMAL=no DEB_COMPRESS=xz KERNEL_CONFIGURE=no RELEASE=bookworm KERNEL_GIT=shallow BUILD_DESKTOP=yes DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base ENABLE_EXTENSIONS="mesa-vpu"`
- [x] tested with rock5b, bookworm gnome has gpu hardware acceleration

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
