### PR TITLE
mesa-vpu: install chromium package instead of chromium-browser

### DIFF
--- a/extensions/mesa-vpu.sh
+++ b/extensions/mesa-vpu.sh
@@ -86,7 +86,7 @@ function post_install_kernel_debs__3d() {
 
 	if [[ "${LINUXFAMILY}" =~ ^(rockchip-rk3588|rk35xx)$ && "${RELEASE}" =~ ^(jammy|noble)$ && "${BRANCH}" =~ ^(legacy|vendor)$ ]]; then
 
-		pkgs+=("rockchip-multimedia-config" "chromium-browser" "libv4l-rkmpp" "gstreamer1.0-rockchip")
+		pkgs+=("rockchip-multimedia-config" "chromium" "libv4l-rkmpp" "gstreamer1.0-rockchip")
 		if [[ "${RELEASE}" == "jammy" ]]; then
 			pkgs+=(libwidevinecdm)
 		else


### PR DESCRIPTION
# Description

Ship images with Chromium v126 instead of v124

# How Has This Been Tested?
- [x] VP9 and H264 works well with chromium and haven't caught any crash in various websites.

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
