### PR TITLE
Run pre-config script before 'make menuconfig'

### DIFF
--- a/lib/functions/compilation/kernel-config.sh
+++ b/lib/functions/compilation/kernel-config.sh
@@ -36,6 +36,13 @@ function kernel_config() {
 	if [[ "${KERNEL_CONFIGURE}" == "yes" ]]; then
 		# Start interactive config menu unless running rewrite-kernel-config
 		if [[ "${ARMBIAN_COMMAND}" != "rewrite-kernel-config" ]]; then
+			# Run pre-config script. It may contain instructions like:
+			# scripts/config --enable CONFIG_DEBUG_KERNEL
+			declare pre_config_script_path="$USERPATCHES_PATH/kernel/pre-config.sh"
+			display_alert "Running user's pre-config script" "$pre_config_script_path" "info"
+			if [[ -f $pre_config_script_path ]]; then
+				source $pre_config_script_path
+			fi
 			# This piece is interactive, no logging
 			display_alert "Starting (interactive) kernel ${KERNEL_MENUCONFIG:-menuconfig}" "${LINUXCONFIG}" "debug"
 			run_kernel_make_dialog "${KERNEL_MENUCONFIG:-menuconfig}"


### PR DESCRIPTION
This update ensures that `./userpatches/kernel/pre-config.sh` runs before the kernel's `make menuconfig` command. Users can now place configuration instructions in this file instead of manually configuring the kernel.

The `pre-config.sh` file may include instructions like:

scripts/config --enable CONFIG_DEBUG_FS
scripts/config --enable CONFIG_KGDB
scripts/config --enable CONFIG_UBSAN

The `scripts/config` utility is provided by the kernel to facilitate configuration changes through scripts.