### PR TITLE
bsp: armbian-install: fix the search for eMMC and SD card devices

### DIFF
--- a/packages/bsp/common/usr/sbin/armbian-install
+++ b/packages/bsp/common/usr/sbin/armbian-install
@@ -807,12 +807,23 @@ main()
 	[ -f $logfile ] && echo -e '\n\n\n' >> $logfile
 	LANG=C echo -e "$(date): Start ${0##*/}.\n" >> $logfile
 
+	# find real mmcblk device numbered 0, 1, 2 for eMMC, SD
+	for ret in $(find /dev -name 'mmcblk[0-2]' -and -type b)
+	do
+		if [ -b ${ret}boot0 ];then
+			emmc_dev=$ret
+		else
+			sd_dev=$ret
+		fi
+	done
+
 	IFS="'"
 	options=()
+
 	if [[ -n $emmccheck ]]; then
-		if [[ "${emmccheck#*mmcblk}" == "0" ]]; then
+		if [[ "${emmccheck}" == "$sd_dev" ]]; then
 			ichip='SD card'
-		else
+		elif [[ "${emmccheck}" == "$emmc_dev" ]]; then
 			ichip='eMMC'
 		fi
 		dest_boot=$emmccheck'p1'
@@ -838,22 +849,23 @@ main()
 		[[ -n $mtdcheck ]] 				&& options+=(4 'Boot from MTD Flash - system on SATA, USB or NVMe')
 
 		if [[ -n ${root_partition_device} && ${DEVICE_TYPE} != "uefi" ]]; then
-			if [ "${root_partition_device#*mmcblk}" == "0" ]; then
+			if [ "${root_partition_device}" == "$sd_dev" ]; then
 				rootchip='SD card'
-			else
+			elif [ "${root_partition_device}" == "$emmc_dev" ]; then
 				rootchip='eMMC'
 			fi
 			options+=(5 "Install/Update the bootloader on $rootchip (${root_partition_device})")
                 fi
 
-		BOOTPART=$(find /dev -name 'mmcblk*boot0' -and -type b)
-		if [ "${BOOTPART/boot0}" != "${root_partition_device}" ]; then
+		if [ -n ${emmc_dev} ] && [ "${emmc_dev}" != "${root_partition_device}" ]; then
 
-			options+=(6 "Install/Update the bootloader on eMMC (${BOOTPART/boot0/})")
+			options+=(6 "Install/Update the bootloader on eMMC (${emmc_dev})")
+			BOOTPART=${emmc_dev}
 
-		elif [ -b /dev/mmcblk0 ]; then
-			BOOTPART=/dev/mmcblk0
-			options+=(6 "Install/Update the bootloader on SD card (${BOOTPART/boot0/})")
+		elif [ -n ${sd_dev} ] && [ "${sd_dev}" != "${root_partition_device}" ]; then
+
+			options+=(6 "Install/Update the bootloader on SD card (${sd_dev})")
+			BOOTPART=${sd_dev}
 		fi
 
 		[[ -n $mtdcheck && \
@@ -862,7 +874,7 @@ main()
 
 	[[ ${#options[@]} -eq 0 || "$root_uuid" == "$emmcuuid" || "$root_uuid" == "/dev/nand2" ]] && \
 	dialog --ok-label 'Cancel' --title ' Warning ' --backtitle "$backtitle" --colors --no-collapse --msgbox '\n\Z1There are no targets. Please check your drives.\Zn' 7 52
-	cmd=(dialog --title 'Choose an option:' --backtitle "$backtitle" --menu "\nCurrent root: $root_uuid \n \n" 14 60 7)
+	cmd=(dialog --title 'Choose an option:' --backtitle "$backtitle" --menu "\nCurrent root: $root_uuid \n              $rootchip (${root_partition_device})\n" 14 75 7)
 	choices=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
 	[[ $? -ne 0 ]] && exit 16
 
@@ -927,15 +939,15 @@ main()
 				fi
 				;;
 			5)
-				show_warning 'This script will update the bootloader on ${root_partition_device}.\n\n    Continue?'
+				show_warning "This script will update the bootloader on ${root_partition_device}.\n\n    Continue?"
 				write_uboot_platform "$DIR" "${root_partition_device}"
 				update_bootscript
 				dialog --backtitle "$backtitle" --title 'Writing bootloader' --msgbox '\n          Done.' 7 30
 				return
 				;;
 			6)
-				show_warning "This script will update the bootloader on ${BOOTPART/boot0/}.\n\n    Continue?"
-				write_uboot_platform "$DIR" ${BOOTPART/boot0/}
+				show_warning "This script will update the bootloader on ${BOOTPART}.\n\n    Continue?"
+				write_uboot_platform "$DIR" ${BOOTPART}
 				echo 'Done'
 				return
 				;;

--- a/packages/bsp/common/usr/sbin/armbian-install
+++ b/packages/bsp/common/usr/sbin/armbian-install
@@ -857,12 +857,12 @@ main()
 			options+=(5 "Install/Update the bootloader on $rootchip (${root_partition_device})")
                 fi
 
-		if [ -n ${emmc_dev} ] && [ "${emmc_dev}" != "${root_partition_device}" ]; then
+		if [ -n "${emmc_dev}" ] && [ "${emmc_dev}" != "${root_partition_device}" ]; then
 
 			options+=(6 "Install/Update the bootloader on eMMC (${emmc_dev})")
 			BOOTPART=${emmc_dev}
 
-		elif [ -n ${sd_dev} ] && [ "${sd_dev}" != "${root_partition_device}" ]; then
+		elif [ -n "${sd_dev}" ] && [ "${sd_dev}" != "${root_partition_device}" ]; then
 
 			options+=(6 "Install/Update the bootloader on SD card (${sd_dev})")
 			BOOTPART=${sd_dev}


### PR DESCRIPTION
# Description

On different boards, eMMC and SDcard memory devices can have numbers 0, 1, 2 in any sequence.
SDcard -> 0; eMMC -> 2
SDcard -> 1; eMMC -> 0
SDcard -> 0; eMMC -> 1

eMMC has additional physical partitions such as *boot0, *boot1 and others.
Use this attribute for unambiguous identification.

Print the type and name of the memory device in the message to the user.


[GitHub issue on #6958](https://github.com/armbian/build/pull/6958#issuecomment-2262874087)

# How Has This Been Tested?

- [x] Test work on board
