### PR TITLE
Repo management: base-files are placed under wrong repo key

### DIFF
--- a/lib/functions/artifacts/artifact-armbian-base-files.sh
+++ b/lib/functions/artifacts/artifact-armbian-base-files.sh
@@ -55,7 +55,7 @@ function artifact_armbian-base-files_prepare_version() {
 
 	artifact_name="armbian-base-files-${RELEASE}-${ARCH}"
 	artifact_type="deb"
-	artifact_deb_repo="${RELEASE}" # release-specific repo (jammy etc)
+	artifact_deb_repo="extra/${RELEASE}-utils" # release-specific repo (jammy etc)
 	artifact_deb_arch="${ARCH}"    # arch-specific packages (arm64 etc)
 	artifact_map_packages=(["armbian-base-files"]="base-files")
 

--- a/lib/functions/artifacts/artifact-armbian-bsp-desktop.sh
+++ b/lib/functions/artifacts/artifact-armbian-bsp-desktop.sh
@@ -53,7 +53,7 @@ function artifact_armbian-bsp-desktop_prepare_version() {
 
 	artifact_name="armbian-bsp-desktop-${BOARD}-${BRANCH}"
 	artifact_type="deb"
-	artifact_deb_repo="${RELEASE}"
+	artifact_deb_repo="extra/${RELEASE}-desktop"
 	artifact_deb_arch="${ARCH}"
 
 	artifact_map_packages=(["armbian-bsp-desktop"]="${artifact_name}")

--- a/lib/functions/artifacts/artifact-armbian-desktop.sh
+++ b/lib/functions/artifacts/artifact-armbian-desktop.sh
@@ -59,7 +59,7 @@ function artifact_armbian-desktop_prepare_version() {
 
 	artifact_name="armbian-${RELEASE}-desktop-${DESKTOP_ENVIRONMENT}"
 	artifact_type="deb"
-	artifact_deb_repo="${RELEASE}"
+	artifact_deb_repo="extra/${RELEASE}-desktop"
 	artifact_deb_arch="all"
 
 	artifact_map_packages=(["armbian-desktop"]="${artifact_name}")

--- a/tools/repository/repo
+++ b/tools/repository/repo
@@ -93,9 +93,6 @@ publishing(){
 	for release in "${distributions[@]}"; do
 
 		# create for each one
-		if [[ -z $(aptly repo list -config="${CONFIG}" -raw | awk '{print $(NF)}' | grep "${release}") ]]; then
-		aptly repo create -config="${CONFIG}" -component="${release}" -distribution="${release}" -comment="Armbian ${release} repository" "${release}" | sudo tee -a "${DEBUGFILE}" >/dev/null
-		fi
 		if [[ -z $(aptly repo list -config="${CONFIG}" -raw | awk '{print $(NF)}' | grep "${release}-utils") ]]; then
 		aptly repo create -config="${CONFIG}" -component="${release}-utils" -distribution="${release}" -comment="Armbian ${release}-utils repository" "${release}-utils" | sudo tee -a "${DEBUGFILE}" >/dev/null
 		fi
@@ -103,14 +100,9 @@ publishing(){
 		aptly repo create -config="${CONFIG}" -component="${release}-desktop" -distribution="${release}" -comment="Armbian ma${release}-desktop repository" "${release}-desktop" | sudo tee -a "${DEBUGFILE}" >/dev/null
 		fi
 
-		adding_packages "${release}" "/${release}" "release packages" "$1"
 		adding_packages "${release}-utils" "/extra/${release}-utils" "release utils" "$1"
 		adding_packages "${release}-desktop" "/extra/${release}-desktop" "release desktop" "$1"
 
-		# drop release snapshot
-		if [[ -n $(aptly snapshot list -config="${CONFIG}" -raw | awk '{print $(NF)}' | grep "${release}") ]]; then
-			aptly -config="${CONFIG}" snapshot drop ${release} | sudo tee -a "${DEBUGFILE}" 2>/dev/null
-		fi
 		# drop release utils snapshot
 		if [[ -n $(aptly snapshot list -config="${CONFIG}" -raw | awk '{print $(NF)}' | grep "${release}-utils") ]]; then
 			aptly -config="${CONFIG}" snapshot drop ${release}-utils | sudo tee -a "${DEBUGFILE}" 2>/dev/null
@@ -120,7 +112,6 @@ publishing(){
 			aptly -config="${CONFIG}" snapshot drop ${release}-desktop | sudo tee -a "${DEBUGFILE}" 2>/dev/null
 		fi
 
-		aptly -config="${CONFIG}" snapshot create ${release} from repo ${release} | sudo tee -a "${DEBUGFILE}" >/dev/null
 		aptly -config="${CONFIG}" snapshot create ${release}-utils from repo ${release}-utils | sudo tee -a "${DEBUGFILE}" >/dev/null
 		aptly -config="${CONFIG}" snapshot create ${release}-desktop from repo ${release}-desktop | sudo tee -a "${DEBUGFILE}" >/dev/null
 
@@ -133,8 +124,8 @@ publishing(){
 			-origin="Armbian" \
 			-label="Armbian" \
 			-config="${CONFIG}" \
-			-component=main,${release},${release}-utils,${release}-desktop \
-			-distribution="${release}" snapshot common ${release} ${release}-utils ${release}-desktop > /dev/null
+			-component=main,${release}-utils,${release}-desktop \
+			-distribution="${release}" snapshot common ${release}-utils ${release}-desktop > /dev/null
 done
 # cleanup
 aptly db cleanup -config="${CONFIG}"
@@ -173,8 +164,6 @@ case $3 in
 		for release in "${DISTROS[@]}"; do
 		echo "<thead><tr><td colspan=3><h2>$release</h2></tr><tr><th>Main</th><th>Utils</th><th>Desktop</th></tr></thead>"
 		echo "<tbody><tr><td width=33% valing=top>"
-		aptly repo show -with-packages -config="${CONFIG}" "${release}" | tail -n +7 | sed 's/.*/&<br>/'
-		echo "</td><td width=33% valign=top>" | sudo tee -a ${filename}
 		aptly repo show -with-packages -config="${CONFIG}" "${release}-utils" | tail -n +7 | sed 's/.*/&<br>/'
 		echo "</td><td width=33% valign=top>" | sudo tee -a ${filename}
 		aptly repo show -with-packages -config="${CONFIG}" "${release}-desktop" | tail -n +7 | sed 's/.*/&<br>/'
@@ -188,8 +177,6 @@ case $3 in
 			echo "Deleting $6 from common"
 			aptly -config="${CONFIG}" repo remove common "$6"
 			for release in "${DISTROS[@]}"; do
-				echo "Deleting $6 from $release"
-				aptly -config="${CONFIG}" repo remove "${release}" "$6"
 				echo "Deleting $6 from $release-utils"
 				aptly -config="${CONFIG}" repo remove "${release}-utils" "$6"
 				echo "Deleting $6 from $release-desktop"
@@ -212,7 +199,6 @@ case $3 in
 			LIST=()
 			LIST+=($(aptly repo show -with-packages -config="${CONFIG}" common | tail -n +7))
 			for release in "${DISTROS[@]}"; do
-				LIST+=($(aptly repo show -with-packages -config="${CONFIG}" "${release}" | tail -n +7))
 				LIST+=($(aptly repo show -with-packages -config="${CONFIG}" "${release}-utils" | tail -n +7))
 				LIST+=($(aptly repo show -with-packages -config="${CONFIG}" "${release}-desktop" | tail -n +7))
 			done
@@ -233,7 +219,6 @@ case $3 in
 			if [[ $exitstatus -eq 0 ]]; then
 				aptly repo remove -config="${CONFIG}" "common" "$TARGET_VERSION"
 				for release in "${DISTROS[@]}"; do
-					aptly repo remove -config="${CONFIG}" "${release}" "$TARGET_VERSION"
 					aptly repo remove -config="${CONFIG}" "${release}-utils" "$TARGET_VERSION"
 					aptly repo remove -config="${CONFIG}" "${release}-desktop" "$TARGET_VERSION"
 				done


### PR DESCRIPTION
# Description

After [last rework](https://github.com/armbian/build/pull/6924) of Armbian repository management, a new $RELEASE key was created, but that would require changes to 

`/etc/apt/sources.list.d/armbian.list`

In order to not touch this file and revert this, we rather make change on repository side and move:
base-files, bsp → RELEASE-utils
desktop-bsp → RELEASE-desktop

Their incoming folder is under:
```
output/debs/extra/RELEASE-utils
output/debs/extra/RELEASE-desktop
```

[Jira](https://armbian.atlassian.net/jira) reference number [AR-2445]

# How Has This Been Tested?

- [x] Generate image, generate repo, update from repo / check lists

# Mandatory

- [x] Stable repository re-created from scratch

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-2445]: https://armbian.atlassian.net/browse/AR-2445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ