### PR TITLE
Cosmetic fix: do not show repository keys that doesn't exits

### DIFF
--- a/tools/repository/repo
+++ b/tools/repository/repo
@@ -35,8 +35,6 @@ showall(){
 		echo "Displaying common repository contents"
 		aptly repo show -with-packages -config="${CONFIG}" common | tail -n +7
 		for release in "${DISTROS[@]}"; do
-			echo "Displaying repository contents for $release"
-			aptly repo show -with-packages -config="${CONFIG}" "${release}" | tail -n +7
 			echo "Displaying repository contents for $release-utils"
 			aptly repo show -with-packages -config="${CONFIG}" "${release}-utils" | tail -n +7
 			echo "Displaying repository contents for $release-desktop"


### PR DESCRIPTION
# Description

Cosmetic: suppress warning on repository creation.

[Jira](https://armbian.atlassian.net/jira) reference number [AR-2445]

# How Has This Been Tested?

- [x] Manual run

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-2445]: https://armbian.atlassian.net/browse/AR-2445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ