### PR TITLE
opi3b: fix mainline uboot with vendor kernel and fix uwe5622 bt for rk35xx

### DIFF
--- a/config/boards/orangepi3b.csc
+++ b/config/boards/orangepi3b.csc
@@ -19,9 +19,9 @@ MODULES_BLACKLIST_LEGACY="bcmdhd"
 function post_family_config__orangepi3b_use_mainline_uboot() {
 	display_alert "$BOARD" "mainline (Kwiboo's tree) u-boot overrides" "info"
 
-	BOOTSOURCE="https://github.com/Kwiboo/u-boot-rockchip.git"
-	BOOTBRANCH="branch:rk3xxx-2024.04" # specific commit tested is commit:ccef7dfc453bc03c5b5c61fa67d2745b96fa7da6
-	BOOTPATCHDIR="v2024.04-orangepi3b" # empty, patches are already in Kwiboo's branch:rk3xxx-2024.04
+	BOOTSOURCE='https://github.com/u-boot/u-boot'
+	BOOTBRANCH="tag:v2024.10-rc3"
+	BOOTPATCHDIR="v2024.10-orangepi3b"
 
 	BOOTDIR="u-boot-${BOARD}" # do not share u-boot directory
 

--- a/lib/functions/compilation/patch/drivers_network.sh
+++ b/lib/functions/compilation/patch/drivers_network.sh
@@ -501,7 +501,7 @@ driver_uwe5622() {
 		fi
 
 		# Apply patches that adjust the driver only for rockchip platforms
-		if [[ "$LINUXFAMILY" == rockchip* ]]; then
+		if [[ "$LINUXFAMILY" == rockchip* || "$LINUXFAMILY" == "rk35xx" ]]; then
 			if linux-version compare "${version}" le 6.1; then
 				process_patch_file "${SRC}/patch/misc/wireless-uwe5622/uwe5622-adjust-for-rockchip-pre-6.1.patch"
 			else

--- a/patch/u-boot/v2024.10-orangepi3b/0001-rockchip-rk3566-orangepi-3b-enable-npu-regulator.patch
+++ b/patch/u-boot/v2024.10-orangepi3b/0001-rockchip-rk3566-orangepi-3b-enable-npu-regulator.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Wed, 14 Aug 2024 21:35:16 +0000
+Subject: rockchip: rk3566-orangepi-3b: enable npu regulator
+
+The power-domain driver in Linux does not know what regulator is
+supplying power to a specific power-domain. This prevent use of NPU with
+vendor kernel because vdd_npu is disabled.
+
+Change vdd_npu to use always-on/boot-on to enable the regulator at boot
+and set initial 0v9 voltage, the recommended voltage in soc datasheet.
+
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+---
+ arch/arm/dts/rk3566-orangepi-3b-u-boot.dtsi | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/arch/arm/dts/rk3566-orangepi-3b-u-boot.dtsi b/arch/arm/dts/rk3566-orangepi-3b-u-boot.dtsi
+index 111111111111..222222222222 100644
+--- a/arch/arm/dts/rk3566-orangepi-3b-u-boot.dtsi
++++ b/arch/arm/dts/rk3566-orangepi-3b-u-boot.dtsi
+@@ -12,3 +12,9 @@
+ 		bootph-some-ram;
+ 	};
+ };
++
++&vdd_npu {
++	regulator-always-on;
++	regulator-boot-on;
++	regulator-init-microvolt = <900000>;
++};
+-- 
+Armbian
+


### PR DESCRIPTION
# Description

6.1 vendor kernel is not bootable on opi3b. There is a post in forum: https://forum.armbian.com/topic/36332-orangepi3b-kernel-panic-when-trying-to-boot-with-the-new-vendor-kernel6143/#comment-186436

Opi3b is using mainline uboot for all branches which is not compatibale with vendor kernel's npu, ~so I use radxa's rockchip uboot instead and limit mainline uboot to branch edge~. I find that setting vdd_npu with property `regulator-always-on` will fix the issue.
There is also a missing uwe5622 patch on rk35xx family, which will cause kernel panic of sprdbt_tty kernel module.


_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh BOARD=orangepi3b BRANCH=vendor BUILD_MINIMAL=no DEB_COMPRESS=xz KERNEL_CONFIGURE=no RELEASE=noble KERNEL_GIT=shallow BUILD_DESKTOP=yes DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base`
- [x] Opi3b vendor kernel can boot now

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
