### PR TITLE
Allwinner legacy and current - bump to latest version

### DIFF
--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -25,12 +25,12 @@ case $BRANCH in
 
 	legacy)
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.1.97"
+		declare -g KERNELBRANCH="tag:v6.1.104"
 		;;
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.6.43"
+		declare -g KERNELBRANCH="tag:v6.6.44"
 		;;
 
 	edge)

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -26,12 +26,12 @@ case $BRANCH in
 
 	legacy)
 		declare -g KERNEL_MAJOR_MINOR="6.1" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.1.97"
+		declare -g KERNELBRANCH="tag:v6.1.104"
 		;;
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.6.43"
+		declare -g KERNELBRANCH="tag:v6.6.44"
 		;;
 
 	edge)

--- a/patch/kernel/archive/sunxi-6.1/patches.armbian/drv-spi-spidev-Add-armbian-spi-dev-compatible.patch
+++ b/patch/kernel/archive/sunxi-6.1/patches.armbian/drv-spi-spidev-Add-armbian-spi-dev-compatible.patch
@@ -29,9 +29,9 @@ index 71c3db60e..4593051f4 100644
  
  static const struct of_device_id spidev_dt_ids[] = {
 +	{ .compatible = "armbian,spi-dev", .data = &spidev_of_check },
- 	{ .compatible = "rohm,dh2228fv", .data = &spidev_of_check },
+ 	{ .compatible = "cisco,spi-petra", .data = &spidev_of_check },
+ 	{ .compatible = "dh,dhcom-board", .data = &spidev_of_check },
  	{ .compatible = "lineartechnology,ltc2488", .data = &spidev_of_check },
- 	{ .compatible = "semtech,sx1301", .data = &spidev_of_check },
 -- 
 2.35.3
 


### PR DESCRIPTION
# Description

Maint.

# How Has This Been Tested?

- [x] Running legacy kernel on Nanopi Neo https://paste.armbian.com/juzupiburi

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
