### PR TITLE
Set fixed MAC address for Nanaopi R6S series

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-common
+++ b/packages/bsp/common/usr/lib/armbian/armbian-common
@@ -53,7 +53,7 @@ set_fixed_mac ()
 	EOF
 
 	# Iterate over each Ethernet interface
-	for iface in $(ip link | awk -F: '$0 !~ "lo|vir|wl|^[^0-9]"{print $2;getline}' | sed 's/^[ \t]*//' | grep "^e")
+	for iface in $(ip link | awk -F: '$0 !~ "lo|vir|wl|^[^0-9]"{print $2;getline}' | sed 's/^[ \t]*//' | grep "^e\|^wan\|^lan")
 	do
 		generate_random_mac
 

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstrun
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstrun
@@ -16,7 +16,9 @@ case "$1" in
 	start)
 
 	# Run a q&d benchmark to be able to identify cards way too slow easily
+	if command -v "iozone" > /dev/null 2>&1; then
 	echo -e "\n### quick iozone test:$(cd /root; iozone -e -I -a -s 1M -r 4k -i 0 -i 1 -i 2 | grep '^            1024' | sed 's/            1024      //')" >> $Log
+	fi
 
 	# Bluetooth tweaks
 	case ${BOARD} in
@@ -98,8 +100,10 @@ case "$1" in
 	esac
 
 	# varios temporary hardware workarounds
-	[[ $LINUXFAMILY == meson ]] && set_fixed_mac
-	[[ $LINUXFAMILY == meson64 ]] && set_fixed_mac
+	[[ "${LINUXFAMILY}" == meson ]] && set_fixed_mac
+	[[ "${LINUXFAMILY}" == meson64 ]] && set_fixed_mac
+	[[ "${BOARD}" == nanopi-r6* ]] && set_fixed_mac
+
 	systemctl disable armbian-firstrun
 	exit 0
 	;;


### PR DESCRIPTION
# Description

Apply small fixes to MAC setting routine, address some shell check stuff.

# How Has This Been Tested?

- [x] Executed script created YAML configs, reboot succeeded, vendor kernel 6.1.y

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
