### PR TITLE
Re-enabling KDE Neon Jammy builds

### DIFF
--- a/config/desktop/jammy/environments/kde-neon/support
+++ b/config/desktop/jammy/environments/kde-neon/support
@@ -1,1 +1,1 @@
-csc
+supported

--- a/extensions/mesa-vpu.sh
+++ b/extensions/mesa-vpu.sh
@@ -140,6 +140,9 @@ function post_install_kernel_debs__3d() {
 		EOF
 	fi
 
+	# KDE neon downgrades base-files for some reason. This prevents tacking it
+	do_with_retries 3 chroot_sdcard apt-mark hold base-files
+
 	display_alert "Updating sources list, after kisak PPAs" "${EXTENSION}" "info"
 	do_with_retries 3 chroot_sdcard_apt_get_update
 
@@ -148,6 +151,9 @@ function post_install_kernel_debs__3d() {
 
 	display_alert "Upgrading Mesa packages" "${EXTENSION}" "info"
 	do_with_retries 3 chroot_sdcard_apt_get dist-upgrade
+
+	# KDE neon downgrade hack undo
+	do_with_retries 3 chroot_sdcard apt-mark unhold base-files
 
 	# Disable wayland flag for XFCE
 	#if [[ "${DESKTOP_ENVIRONMENT}" == "xfce" ]]; then


### PR DESCRIPTION
# Description

We have disabled this since base-files were downgrading when MESA extension was used. I still down know why this happens, but holding base-files before and unholding after solves the problem. KDE Neon builds and works fine.

# How Has This Been Tested?

- [x] Generate image and playing around with

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
