### PR TITLE
Add latest Linux Mint versions, Virginia and Wilma, to supported hosts.

### DIFF
--- a/lib/functions/host/host-release.sh
+++ b/lib/functions/host/host-release.sh
@@ -33,7 +33,7 @@ function obtain_and_check_host_release_and_arch() {
 	#
 	# NO_HOST_RELEASE_CHECK overrides the check for a supported host system
 	# Disable host OS check at your own risk. Any issues reported with unsupported releases will be closed without discussion
-	if [[ -z $HOSTRELEASE || "bookworm trixie sid jammy kinetic lunar vanessa vera victoria mantic noble" != *"$HOSTRELEASE"* ]]; then
+	if [[ -z $HOSTRELEASE || "bookworm trixie sid jammy kinetic lunar vanessa vera victoria virginia wilma mantic noble" != *"$HOSTRELEASE"* ]]; then
 		if [[ $NO_HOST_RELEASE_CHECK == yes ]]; then
 			display_alert "You are running on an unsupported system" "${HOSTRELEASE:-(unknown)}" "wrn"
 			display_alert "Do not report any errors, warnings or other issues encountered beyond this point" "" "wrn"

--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -297,7 +297,7 @@ function adaptative_prepare_host_dependencies() {
 	host_dependencies+=("libgnutls28-dev")
 
 	# Noble and later releases do not carry "python3-distutils" https://docs.python.org/3.10/whatsnew/3.10.html#distutils-deprecated
-	if [[ "noble" == *"${host_release}"* ]]; then
+	if [[ "$host_release" =~ ^(noble|wilma)$ ]]; then
 		display_alert "python3-distutils not available on host release '${host_release}'" "distutils was deprecated with Python 3.12" "debug"
 	else
 		host_dependencies+=("python3-distutils")


### PR DESCRIPTION
# Description
**Add latest Linux Mint versions, Virginia and Wilma, to supported hosts.**

Add virginia and wilma in host-release.sh
Add wilma (noble) in prepare-host.sh.

# How Has This Been Tested?

- [x] Linux Mint Virginia (xfce) - ./compile.sh build BOARD=orangepizeroplus BRANCH=edge RELEASE=bookworm
- [x] Linux Mint Wilma (xfce)  - ./compile.sh build BOARD=orangepizeroplus BRANCH=edge RELEASE=bookworm
- [x] Armbian 23.08 Jammy  - ./compile.sh build BOARD=orangepizeroplus BRANCH=edge RELEASE=bookworm
# Checklist:

- [x] My changes generate no new warnings

