### PR TITLE
MBa8MPxL: rework uboot patches

### DIFF
--- a/patch/u-boot/u-boot-tqma/0001-tqma8-enable-distro-boot.patch
+++ b/patch/u-boot/u-boot-tqma/0001-tqma8-enable-distro-boot.patch
@@ -1,4 +1,4 @@
-From ed1e8500596466e0115a5bbcd72a6818fc11ad1b Mon Sep 17 00:00:00 2001
+From e04dcf9f512273afd43b014db110e5823a5869e6 Mon Sep 17 00:00:00 2001
 From: Martin Schmiedel <Martin.Schmiedel@tq-group.com>
 Date: Mon, 9 Oct 2023 09:50:48 +0200
 Subject: [PATCH] tqma8: enable distro boot
@@ -118,10 +118,10 @@ index 0000000000..fc525e24c6
 +	env_set("boot_targets", boot_devtype);
 +}
 diff --git a/board/tqc/tqma8mpxl/tqma8mpxl.c b/board/tqc/tqma8mpxl/tqma8mpxl.c
-index f410c999ef..2c7b2b115c 100644
+index bc34c07e84..9077c6cea1 100644
 --- a/board/tqc/tqma8mpxl/tqma8mpxl.c
 +++ b/board/tqc/tqma8mpxl/tqma8mpxl.c
-@@ -297,9 +297,12 @@ int board_late_init(void)
+@@ -294,9 +294,12 @@ int board_late_init(void)
  
  #ifdef CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG
  	env_set("board_name", tqc_bb_get_boardname());

--- a/patch/u-boot/u-boot-tqma/0002-tqma8mpxl-enable-distro-boot.patch
+++ b/patch/u-boot/u-boot-tqma/0002-tqma8mpxl-enable-distro-boot.patch
@@ -1,4 +1,4 @@
-From b5f1593eac18b7aa5f9653bcebacaff377318046 Mon Sep 17 00:00:00 2001
+From 34ee47ccf7b67d01e9b44cd6e32a9b109424343c Mon Sep 17 00:00:00 2001
 From: Martin Schmiedel <Martin.Schmiedel@tq-group.com>
 Date: Mon, 9 Oct 2023 09:50:48 +0200
 Subject: [PATCH] tqma8mpxl: enable distro boot

--- a/patch/u-boot/u-boot-tqma/0003-imx-mkimage_fit_atf_imx8mp.sh-add-script-for-imx8mp.patch
+++ b/patch/u-boot/u-boot-tqma/0003-imx-mkimage_fit_atf_imx8mp.sh-add-script-for-imx8mp.patch
@@ -1,4 +1,4 @@
-From 37855f81b2eed3cf4b426d99823f43009755a416 Mon Sep 17 00:00:00 2001
+From 55a5f1cb804eba8065c8f959d71f334d7dc57eab Mon Sep 17 00:00:00 2001
 From: Martin Schmiedel <Martin.Schmiedel@tq-group.com>
 Date: Mon, 22 Jul 2024 07:48:26 +0200
 Subject: [PATCH] imx: mkimage_fit_atf_imx8mp.sh: add script for imx8mp
@@ -7,11 +7,25 @@ If Varibles can not be exported this script set default value for ATF_LOAD_ADDR
 
 Signed-off-by: Martin Schmiedel <Martin.Schmiedel@tq-group.com>
 ---
+ Makefile                                    |   2 +
  arch/arm/mach-imx/mkimage_fit_atf_imx8mp.sh | 139 ++++++++++++++++++++
  board/tqc/tqma8mpxl/Kconfig                 |   3 +
- 2 files changed, 142 insertions(+)
+ 3 files changed, 144 insertions(+)
  create mode 100755 arch/arm/mach-imx/mkimage_fit_atf_imx8mp.sh
 
+diff --git a/Makefile b/Makefile
+index 312bb794c3..2d65bebd95 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1281,6 +1281,8 @@ ifneq ($(CONFIG_SPL_FIT_GENERATOR),"")
+ U_BOOT_ITS := u-boot.its
+ ifeq ($(CONFIG_SPL_FIT_GENERATOR),"arch/arm/mach-imx/mkimage_fit_atf.sh")
+ U_BOOT_ITS_DEPS += u-boot-nodtb.bin
++else ifeq ($(CONFIG_SPL_FIT_GENERATOR),"arch/arm/mach-imx/mkimage_fit_atf_imx8mp.sh")
++U_BOOT_ITS_DEPS += u-boot-nodtb.bin
+ endif
+ ifeq ($(CONFIG_SPL_FIT_GENERATOR),"arch/arm/mach-rockchip/make_fit_atf.py")
+ U_BOOT_ITS_DEPS += u-boot
 diff --git a/arch/arm/mach-imx/mkimage_fit_atf_imx8mp.sh b/arch/arm/mach-imx/mkimage_fit_atf_imx8mp.sh
 new file mode 100755
 index 0000000000..25031ce710
@@ -164,13 +178,13 @@ index 19e5d5030f..a8bd61246f 100644
 @@ -15,6 +15,9 @@ config SPL_TEXT_BASE
  config CSF_SIZE
  	default 0x2000
-
+ 
 +config SPL_FIT_GENERATOR
 +	default "arch/arm/mach-imx/mkimage_fit_atf_imx8mp.sh"
 +
  config TQMA8MPXL_DEFAULTS
  	bool
  	default y
---
+-- 
 2.34.1
 


### PR DESCRIPTION
MBa8MPxL: rework uboot patches

# Description

The U-Boot Repo get some updates.
This reworks the patches depending on these updates. 

# How Has This Been Tested?

- [x] Build images for mba8mp-ras314 and mba8mpxl with new patches
- [x] Boot test "bookworm_current" mba8mp-ras314
- [x] Boot test "bookworm_current" mba8mpxl

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
