### PR TITLE
uboot: rk3576: add patches to enable tf card boot

### DIFF
--- a/patch/u-boot/legacy/u-boot-armsom-rk3576/0001-dw_mmc-add-default-power-enable-config-val.patch
+++ b/patch/u-boot/legacy/u-boot-armsom-rk3576/0001-dw_mmc-add-default-power-enable-config-val.patch
@@ -1,0 +1,46 @@
+From d21080aff74c06f2b2303bc298bf7485818768db Mon Sep 17 00:00:00 2001
+From: Yifeng Zhao <yifeng.zhao@rock-chips.com>
+Date: Wed, 8 May 2024 10:00:14 +0800
+Subject: [PATCH 1/2] dw_mmc: add default power enable config value for rk3576
+
+Signed-off-by: Yifeng Zhao <yifeng.zhao@rock-chips.com>
+Change-Id: I2ce85f3c107c51b84413ca2f9ae66b33e4a00c18
+---
+ drivers/mmc/Kconfig  | 7 +++++++
+ drivers/mmc/dw_mmc.c | 2 +-
+ 2 files changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/mmc/Kconfig b/drivers/mmc/Kconfig
+index 8e365e45f58..3ccfaa5fa17 100644
+--- a/drivers/mmc/Kconfig
++++ b/drivers/mmc/Kconfig
+@@ -84,6 +84,13 @@ config MMC_DW
+ 	  block, this provides host support for SD and MMC interfaces, in both
+ 	  PIO, internal DMA mode and external DMA mode.
+ 
++config MMC_DW_PWREN_VALUE
++	hex "mmc dw powen value"
++	default 1 if ROCKCHIP_RK3576
++	default 0
++	help
++	  Config the value for MMC-DW drivers to power on sd card.
++
+ config MMC_DW_EXYNOS
+ 	bool "Exynos specific extensions for Synopsys DW Memory Card Interface"
+ 	depends on ARCH_EXYNOS
+diff --git a/drivers/mmc/dw_mmc.c b/drivers/mmc/dw_mmc.c
+index d961bce248b..37e4d50512d 100644
+--- a/drivers/mmc/dw_mmc.c
++++ b/drivers/mmc/dw_mmc.c
+@@ -818,7 +818,7 @@ static int dwmci_init(struct mmc *mmc)
+ 	if (host->dev_index == 0)
+ 		dwmci_writel(host, DWMCI_PWREN, 1);
+ 	else if (host->dev_index == 1)
+-		dwmci_writel(host, DWMCI_PWREN, 0);
++		dwmci_writel(host, DWMCI_PWREN, CONFIG_MMC_DW_PWREN_VALUE);
+ 	else
+ 		dwmci_writel(host, DWMCI_PWREN, 1);
+ #else
+-- 
+2.34.1
+

--- a/patch/u-boot/legacy/u-boot-armsom-rk3576/0002-dts-rockchip-rk3576-the-power_en-for-SD-co.patch
+++ b/patch/u-boot/legacy/u-boot-armsom-rk3576/0002-dts-rockchip-rk3576-the-power_en-for-SD-co.patch
@@ -1,0 +1,38 @@
+From 2138ea1a16205051685bf85771b4412019df5a56 Mon Sep 17 00:00:00 2001
+From: Yifeng Zhao <yifeng.zhao@rock-chips.com>
+Date: Wed, 8 May 2024 10:01:34 +0800
+Subject: [PATCH 2/2] dts: rockchip: rk3576: the power_en for SD control by the
+ controller
+
+Signed-off-by: Yifeng Zhao <yifeng.zhao@rock-chips.com>
+Change-Id: Ibf4d8a3f0502385c075cd114b13a30b1bff866a8
+---
+ arch/arm/dts/rk3576-u-boot.dtsi | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm/dts/rk3576-u-boot.dtsi b/arch/arm/dts/rk3576-u-boot.dtsi
+index 2abdef5c08f..fc7527064a5 100644
+--- a/arch/arm/dts/rk3576-u-boot.dtsi
++++ b/arch/arm/dts/rk3576-u-boot.dtsi
+@@ -139,7 +139,6 @@
+ &sdmmc {
+ 	bus-width = <4>;
+ 	u-boot,dm-spl;
+-	pwr-en-gpios = <&gpio0 RK_PB6 GPIO_ACTIVE_HIGH>;
+ 	status = "okay";
+ };
+ 
+@@ -172,6 +171,10 @@
+ 	u-boot,dm-spl;
+ };
+ 
++&sdmmc0_pwren {
++	u-boot,dm-spl;
++};
++
+ &pinctrl {
+ 	u-boot,dm-spl;
+ };
+-- 
+2.34.1
+


### PR DESCRIPTION
# Description

Current armbian images can't boot from sd card, and rockchip has provided uboot patches to fix it.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh BOARD=armsom-sige5 BRANCH=vendor BUILD_MINIMAL=no DEB_COMPRESS=xz KERNEL_CONFIGURE=no RELEASE=noble KERNEL_GIT=shallow BUILD_DESKTOP=yes DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base`
- [x] Tested sd card boot with armsom sige5

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
