### PR TITLE
orangepi5: fix SPI flash boot

### DIFF
--- a/patch/u-boot/legacy/u-boot-radxa-rk35xx/dt/rk3588s-orangepi-5.dts
+++ b/patch/u-boot/legacy/u-boot-radxa-rk35xx/dt/rk3588s-orangepi-5.dts
@@ -177,7 +177,40 @@
 	status = "okay";
 };
 
+&sfc {
+	u-boot,dm-pre-reloc;
+	pinctrl-names = "default";
+	pinctrl-0 = <&fspim0_pins>;
+	status = "okay";
+};
+
+&spi_nor {
+	u-boot,dm-pre-reloc;
+	status = "okay";
+};
+
 &pinctrl {
+	/delete-node/ fspi;
+	fspi {
+		u-boot,dm-spl;
+		fspim0_pins: fspim0-pins {
+			u-boot,dm-spl;
+			rockchip,pins =
+				/* fspi_clk_m0 */
+				<2 RK_PA0 2 &pcfg_pull_none>,
+				/* fspi_cs0n_m0 */
+				<2 RK_PD6 2 &pcfg_pull_none>,
+				/* fspi_d0_m0 */
+				<2 RK_PD0 2 &pcfg_pull_none>,
+				/* fspi_d1_m0 */
+				<2 RK_PD1 2 &pcfg_pull_none>,
+				/* fspi_d2_m0 */
+				<2 RK_PD2 2 &pcfg_pull_none>,
+				/* fspi_d3_m0 */
+				<2 RK_PD3 2 &pcfg_pull_none>;
+		};
+	};
+
 	usb {
 		u-boot,dm-pre-reloc;
 		typec5v_pwren: typec5v-pwren {


### PR DESCRIPTION
# Description

Orange Pi 5 requires to relocate FSPI0 pinctrl to identify SPI flash. Otherwise, it breaks NVME/USB boot like now. This PR fixes it

# How Has This Been Tested?
- [x] Build and boot with both USB and NVME

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
