### PR TITLE
BigTreeTech CB1: current: Enable IR Receiver

### DIFF
--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-enable-ir-receiver.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-enable-ir-receiver.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: JohnTheCoolingFan <ivan8215145640@gmail.com>
+Date: Mon, 12 Aug 2024 14:50:16 +0000
+Subject: ARM64: dts: sun50i-h616: BigTreeTech CB1: Enable IR receiver
+
+Signed-off-by: JohnTheCoolingFan <ivan8215145640@gmail.com>
+---
+ arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
+index b98e85a51..c2e20408c 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
+@@ -352,10 +352,14 @@ &ehci3 {
+ 
+ &ohci3 {
+ 	status = "okay";
+ };
+ 
++&ir {
++	status = "okay";
++};
++
+ &usbotg {
+ 	/*
+ 	 * PHY0 pins are connected to a USB-C socket, but a role switch
+ 	 * is not implemented: both CC pins are pulled to GND.
+ 	 * The VBUS pins power the device, so a fixed peripheral mode
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/kernel/archive/sunxi-6.6/series.armbian
+++ b/patch/kernel/archive/sunxi-6.6/series.armbian
@@ -191,3 +191,4 @@
 	patches.armbian/Sound-for-H616-H618-Allwinner-SOCs-arch-arm64-boot-dts-allwinne.patch
 	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-enable-hdmi.patch
 	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-enable-emac1.patch
+	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-enable-ir-receiver.patch

--- a/patch/kernel/archive/sunxi-6.6/series.conf
+++ b/patch/kernel/archive/sunxi-6.6/series.conf
@@ -443,3 +443,4 @@
 	patches.armbian/Sound-for-H616-H618-Allwinner-SOCs-arch-arm64-boot-dts-allwinne.patch
 	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-enable-hdmi.patch
 	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-enable-emac1.patch
+	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-enable-ir-receiver.patch


### PR DESCRIPTION
# Description

Enables onboard IR receiver on BigTreeTech CB1

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-2075]

# How Has This Been Tested?

- [x] Build and boot on BigTreeTech Pi v1.2

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
