### PR TITLE
Discord announcement: push only when label "Needs review" is set

### DIFF
--- a/.github/workflows/pr-announce.yml
+++ b/.github/workflows/pr-announce.yml
@@ -1,8 +1,7 @@
-name: "Announce on Discord"
+name: "Announce ready-to-review PR on Discord"
 on:
   pull_request:
-    types: [ opened, reopened, labeled, review_requested ]
-    branches: [ main ]
+    types: [ labeled ]
 
 jobs:
   Announce:
@@ -10,7 +9,7 @@ jobs:
       pull-requests: read
 
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'armbian/build' && contains(github.event.pull_request.labels.*.name, 'Needs review') }}
+    if: ${{ github.repository == 'armbian/build' && github.event.label.id == '6210849975' }}
     steps:
       - name: Get repo
         uses: actions/checkout@v4

--- a/.github/workflows/pr-announce.yml
+++ b/.github/workflows/pr-announce.yml
@@ -1,4 +1,6 @@
-name: "Announce ready-to-review PR on Discord"
+name: "Announce PR on Discord for review"
+run-name: 'Announce PR #${{ github.event.pull_request.number }} on Discord for review'
+
 on:
   pull_request:
     types: [ labeled ]

--- a/.github/workflows/pr-announce.yml
+++ b/.github/workflows/pr-announce.yml
@@ -1,13 +1,16 @@
+name: "Announce on Discord"
 on:
   pull_request:
-    types: [ opened ]
+    types: [ opened, reopened, labeled, review_requested ]
     branches: [ main ]
 
 jobs:
-  build:
-    name: "Announce PR on Discord"
+  Announce:
+    permissions:
+      pull-requests: read
+
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'Armbian' }}
+    if: ${{ github.repository_owner == 'Armbian' && contains(github.event.pull_request.labels.*.name, 'Needs review') }}
     steps:
       - name: Get repo
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description

As tittle said.

# How Has This Been Tested?

Need to be tested.

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
