### PR TITLE
Add OpenSBI compilation to D1

### DIFF
--- a/config/sources/families/d1.conf
+++ b/config/sources/families/d1.conf
@@ -13,6 +13,14 @@ BOOTBRANCH='branch:d1-wip'
 BOOTPATCHDIR="u-boot-nezha"
 UBOOT_TARGET_MAP=";;u-boot.img"
 
+# Arm Trusted Firmware
+declare -g ATF_USE_GCC="> 8.0"
+declare -g ATF_COMPILER="riscv64-linux-gnu-"
+declare -g ATFSOURCE="https://github.com/riscv-software-src/opensbi.git"
+declare -g ATFDIR="opensbi"
+declare -g ATFBRANCH="tag:v1.5.1"
+declare -g ATF_TARGET_MAP="PLATFORM=generic  FW_TEXT_START=0x40000000 ;;build/platform/generic/firmware/fw_dynamic.bin"
+
 LINUXFAMILY="d1"
 LINUXCONFIG="linux-d1-${BRANCH}"
 


### PR DESCRIPTION
# Description

Building for mangopi mq crashes with the following error:

```
   Image 'itb' is missing external blobs and is non-functional: opensbi
   
   /binman/itb/fit/images/opensbi/opensbi (fw_dynamic.bin):
      See the documentation for your board. The OpenSBI git repo is at
      https://github.com/riscv/opensbi.git
      You may need to build fw_dynamic.bin first and re-build u-boot with
      OPENSBI=/path/to/fw_dynamic.bin
   
   Some images are invalid
   make: *** [Makefile:1124: .binman_stamp] Error 103
--> (179) ERROR: Error 2 occurred in main shell [ at /armbian/lib/functions/logging/runners.sh:211
       run_host_command_logged_raw() --> lib/functions/logging/runners.sh:211
      run_host_command_logged_long_running() --> lib/functions/logging/runners.sh:188
         do_with_ccache_statistics() --> lib/functions/compilation/ccache.sh:39
              compile_uboot_target() --> lib/functions/compilation/uboot.sh:230
      loop_over_uboot_targets_and_do() --> lib/functions/compilation/uboot.sh:287
                     compile_uboot() --> lib/functions/compilation/uboot.sh:391
                   do_with_logging() --> lib/functions/logging/section-logging.sh:81
      artifact_uboot_build_from_sources() --> lib/functions/artifacts/artifact-uboot.sh:175
       artifact_build_from_sources() --> lib/functions/artifacts/artifacts-obtain.sh:34
          obtain_complete_artifact() --> lib/functions/artifacts/artifacts-obtain.sh:280
          build_artifact_for_image() --> lib/functions/artifacts/artifacts-obtain.sh:392
       main_default_build_packages() --> lib/functions/main/build-packages.sh:108
      full_build_packages_rootfs_and_image() --> lib/functions/main/default-build.sh:31
             do_with_default_build() --> lib/functions/main/default-build.sh:42
            cli_standard_build_run() --> lib/functions/cli/cli-build.sh:25
           armbian_cli_run_command() --> lib/functions/cli/utils-cli.sh:136
                    cli_entrypoint() --> lib/functions/cli/entrypoint.sh:176
                              main() --> compile.sh:50
```
See, e.g., https://forum.armbian.com/topic/21465-armbian-image-and-build-support-for-risc-v/?do=findComment&comment=190008

The fix is to build OpenSBI and use it to build uboot as suggested in error message, as discussed in https://forum.rvspace.org/t/building-u-boot-from-mainline-repo/3398 for example. This PR adds OpenSBI building stage.
# How Has This Been Tested?

- [x] Built for `BOARD=mangopi-m28k`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
