### PR TITLE
attempt to fix pr announce for all contributors

### DIFF
--- a/.github/workflows/pr-announce.yml
+++ b/.github/workflows/pr-announce.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     name: "Announce PR on Discord"
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'Armbian' }}
+    if: github.repository == 'armbian/build'
     steps:
       - name: Get repo
         uses: actions/checkout@v4


### PR DESCRIPTION
The earlier attempt seem to limit announces to repository members for some reason.  
This attempt limits to the repo only, therefore forks should not be affected.  
Not sure if it works, but there is only one way to find out.
