### PR TITLE
Gateway GZ80X: `use actual u-boot.bin`

### DIFF
--- a/config/sources/families/meson-axg.conf
+++ b/config/sources/families/meson-axg.conf
@@ -9,6 +9,9 @@
 
 # shellcheck source=config/sources/families/include/meson64_common.inc
 source "${BASH_SOURCE%/*}/include/meson64_common.inc"
+if [[ "$BOARD" == "gateway-gz80x" ]]; then
+	UBOOT_TARGET_MAP="u-boot-dtb.img;;u-boot.bin u-boot-dtb.img"
+fi
 
 uboot_custom_postprocess() {
 	if [[ "$BOARD" == "gateway-gz80x" ]]; then


### PR DESCRIPTION
The armbian way appears to be to use the u-boot.bin.sd.bin in place of the u-boot.bin. Usually this isn't a huge problem, but on this unit it isn't playing nicely.

There is also no SDCARD slot on this unit, so let's just use the intended binary.
