### PR TITLE
Support kernel compilation with Clang/LLVM

### DIFF
--- a/lib/functions/compilation/kernel-make.sh
+++ b/lib/functions/compilation/kernel-make.sh
@@ -37,6 +37,14 @@ function run_kernel_make_internal() {
 	# Add the distcc envs, if any.
 	common_make_envs+=("${DISTCC_EXTRA_ENVS[@]}")
 
+	if [[ "${KERNEL_COMPILER}" == "clang" ]]; then
+		llvm_flag="LLVM=1"
+		cc_name="CC"
+		extra_warnings="-Wno-error=unused-command-line-argument -Wno-error=unknown-warning-option" # downgrade errors to warnings
+	else
+		cc_name="CROSS_COMPILE"
+		extra_warnings=""
+	fi
 	common_make_params_quoted=(
 		# @TODO: introduce O=path/to/binaries, so sources and bins are not in the same dir; this has high impact in headers packaging though.
 
@@ -45,8 +53,8 @@ function run_kernel_make_internal() {
 		"ARCH=${ARCHITECTURE}"                   # Key param. Everything depends on this.
 		"LOCALVERSION=-${BRANCH}-${LINUXFAMILY}" # Change the internal kernel version to include the family. Changing this causes recompiles # @TODO change hack at .config; that might handles mtime better
 
-		"CROSS_COMPILE=${CCACHE} ${DISTCC_CROSS_COMPILE_PREFIX[@]} ${KERNEL_COMPILER}"                    # added as prefix to every compiler invocation by make
-		"KCFLAGS=-fdiagnostics-color=always -Wno-error=misleading-indentation ${KERNEL_EXTRA_CFLAGS:-""}" # Force GCC colored messages, downgrade misleading indentation to warning
+		"${cc_name}=${CCACHE} ${DISTCC_CROSS_COMPILE_PREFIX[@]} ${KERNEL_COMPILER}"                    # added as prefix to every compiler invocation by make
+		"KCFLAGS=-fdiagnostics-color=always -Wno-error=misleading-indentation ${extra_warnings} ${KERNEL_EXTRA_CFLAGS:-""}" # Force GCC colored messages, downgrade misleading indentation to warning
 
 		"SOURCE_DATE_EPOCH=${kernel_base_revision_ts}"        # https://reproducible-builds.org/docs/source-date-epoch/ and https://www.kernel.org/doc/html/latest/kbuild/reproducible-builds.html
 		"KBUILD_BUILD_TIMESTAMP=${kernel_base_revision_date}" # https://www.kernel.org/doc/html/latest/kbuild/kbuild.html#kbuild-build-timestamp
@@ -55,6 +63,9 @@ function run_kernel_make_internal() {
 
 		"KGZIP=pigz" "KBZIP2=pbzip2" # Parallel compression, use explicit parallel compressors https://lore.kernel.org/lkml/20200901151002.988547791@linuxfoundation.org/ # @TODO: what about XZ?
 	)
+	if [[ -n "${llvm_flag}" ]]; then
+		common_make_params_quoted+=("${llvm_flag}")
+	fi
 
 	# last statement, so it passes the result to calling function. "env -i" is used for empty env
 	full_command=("${KERNEL_MAKE_RUNNER:-run_host_command_logged}" "env" "-i" "${common_make_envs[@]}"
@@ -87,6 +98,11 @@ function kernel_determine_toolchain() {
 		[[ -z $toolchain ]] && exit_with_error "Could not find required toolchain" "${KERNEL_COMPILER}gcc $KERNEL_USE_GCC"
 	fi
 
-	kernel_compiler_version="$(eval env PATH="${toolchain}:${PATH}" "${KERNEL_COMPILER}gcc" -dumpfullversion -dumpversion)"
-	display_alert "Compiler version" "${KERNEL_COMPILER}gcc ${kernel_compiler_version}" "info"
+	if [[ "${KERNEL_COMPILER}" == "clang" ]]; then
+		KERNEL_COMPILER_FULL="${KERNEL_COMPILER}"
+	else
+		KERNEL_COMPILER_FULL="${KERNEL_COMPILER}gcc"
+	fi
+	kernel_compiler_version="$(eval env PATH="${toolchain}:${PATH}" "${KERNEL_COMPILER_FULL}" -dumpfullversion -dumpversion)"
+	display_alert "Compiler version" "${KERNEL_COMPILER_FULL} ${kernel_compiler_version}" "info"
 }

--- a/lib/functions/host/prepare-host.sh
+++ b/lib/functions/host/prepare-host.sh
@@ -342,6 +342,12 @@ function adaptative_prepare_host_dependencies() {
 		host_dependencies+=(libc6-amd64-cross) # Support for running x86 binaries (under qemu on other arches)
 	fi
 
+	if [[ "${KERNEL_COMPILER}" == "clang" ]]; then
+		host_dependencies+=("clang")
+		host_dependencies+=("llvm")
+		host_dependencies+=("lld")
+	fi
+
 	declare -g EXTRA_BUILD_DEPS=""
 	call_extension_method "add_host_dependencies" <<- 'ADD_HOST_DEPENDENCIES'
 		*run before installing host dependencies*


### PR DESCRIPTION
# Description

The kernel supports compilation with LLVM in addition to GCC, including cross-compilation to arm and riscv. This PR adds an option to use `KERNEL_COMPILER=clang` to compile kernel with clang.

# Documentation summary for feature / change

I haven't added documentation but probably should?

# How Has This Been Tested?


- [x] Built armbian with clang for one target of each architecture (x86, arm, riscv)
- [x] Verified that gcc build still works

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
