### PR TITLE
Fix loop device search in docker when there are no loop devices before container launch

### DIFF
--- a/lib/functions/cli/cli-docker.sh
+++ b/lib/functions/cli/cli-docker.sh
@@ -74,10 +74,7 @@ function cli_docker_run() {
 	case "${DOCKER_SUBCMD}" in
 		shell)
 			display_alert "Launching Docker shell" "docker-shell" "info"
-			# The MKNOD capability is required for loop device search function.
-			# In case there are no loop devices available, losetup -f would not be able to create a loop
-			# device, yet it will output a loop device path
-			docker run -it --cap-add MKNOD "${DOCKER_ARGS[@]}" "${DOCKER_ARMBIAN_INITIAL_IMAGE_TAG}" /bin/bash
+			docker run -it "${DOCKER_ARGS[@]}" "${DOCKER_ARMBIAN_INITIAL_IMAGE_TAG}" /bin/bash
 			;;
 
 		purge)

--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -572,6 +572,13 @@ function docker_cli_launch() {
 		run_host_command_logged find "${SRC}/userpatches" -name ".DS_Store" -type f -delete "||" true
 	fi
 
+	# This check is performed in order to set up the host so that it has a loop device, as calling losetup inside of
+	# docker creates a loop device but does not make it available to the already running container
+	if [[ ! -e /dev/loop0 ]]; then
+		display_alert "Running losetup in a temporary container" "because no loop devices exist" "info"
+		docker run "${DOCKER_ARGS[@]}" "${DOCKER_ARMBIAN_INITIAL_IMAGE_TAG}" /usr/sbin/losetup -f
+	fi
+
 	display_alert "-----------------Relaunching in Docker after ${SECONDS}s------------------" "here comes the 🐳" "info"
 
 	local -i docker_build_result

--- a/lib/functions/host/docker.sh
+++ b/lib/functions/host/docker.sh
@@ -574,9 +574,10 @@ function docker_cli_launch() {
 
 	# This check is performed in order to set up the host so that it has a loop device, as calling losetup inside of
 	# docker creates a loop device but does not make it available to the already running container
+	# The amount of privileges and capabilities given is a bare minimum needed for losetup to work
 	if [[ ! -e /dev/loop0 ]]; then
 		display_alert "Running losetup in a temporary container" "because no loop devices exist" "info"
-		docker run "${DOCKER_ARGS[@]}" "${DOCKER_ARMBIAN_INITIAL_IMAGE_TAG}" /usr/sbin/losetup -f
+		run_host_command_logged docker run --rm --privileged --cap-add=MKNOD "${DOCKER_ARMBIAN_INITIAL_IMAGE_TAG}" /usr/sbin/losetup -f
 	fi
 
 	display_alert "-----------------Relaunching in Docker after ${SECONDS}s------------------" "here comes the 🐳" "info"


### PR DESCRIPTION
# Description

Currently, if `losetup -f` has to create a new device node and is run in a docker container, the device will be created on host butt will not be available to the already running container. This PR mitigates that by running `losetup -f` in a container in case there are no loop devices (`/dev/loop0` is checked). The container exits after executing `losetup` and the main build container is run after.

The MKNOD capability does not affect the issue, so it was removed.

For additional context, previous attempts at fixing: #6576 #6642 #6927 #6936 

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: #6568 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-2132]

# How Has This Been Tested?

- Fresh boot on a system that doesn't have loop devices created by default
- Run a dockerized build `./compile.sh build PREFER_DOCKER=yes`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


[AR-2132]: https://armbian.atlassian.net/browse/AR-2132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ