### PR TITLE
actions: forked-helper: Run only if secret is set and simplify workflow

### DIFF
--- a/.github/workflows/forked-helper.yml
+++ b/.github/workflows/forked-helper.yml
@@ -9,20 +9,18 @@ on:
   workflow_dispatch:
 
 jobs:
-  fork-repository-dispatch:
-    name: 📢 Run repository dispatch to default fork branch
-    if: ${{ github.repository_owner != 'armbian' }}
+  dispatch-on-forked-repo:
+    name: 📢 Run repository dispatch on fork
+    env:
+      DISPATCH_SECRET: ${{ secrets.ARMBIAN_SELF_DISPATCH_TOKEN }}
+    if: ${{ github.repository_owner != 'armbian' }} # Run only on forks
     runs-on: ubuntu-latest
     steps:
-      - name: Assign secret
-        id: get_dispatch_secret
-        run: echo "dispatch_secret=${{ secrets.ARMBIAN_SELF_DISPATCH_TOKEN }}" >> $GITHUB_OUTPUT
-
-      - name: Dispatch event on forked repostitory
-        if: steps.get_dispatch_secret.outputs.dispatch_secret
+      - name: Dispatch event on forked repository
+        if: ${{ env.DISPATCH_SECRET != '' }}  # Check that the secret has been set, if not, exit
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ steps.get_dispatch_secret.outputs.dispatch_secret }}
+          token: ${{ env.DISPATCH_SECRET }}
           repository: ${{ github.repository }}
           event-type: armbian
           client-payload: >


### PR DESCRIPTION
# Description

The forked helper workflow ran regardless whether `ARMBIAN_SELF_DISPATCH_TOKEN` was set or not, generating errors if the secret could not be found.

In addition, simplify and beautify the workflow.

# How Has This Been Tested?

- [ ] To be tested in future automatic workflow runs, if no errors are generated

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
