### PR TITLE
rootfs: add comment to force rootfs rebuild

### DIFF
--- a/lib/functions/rootfs/create-cache.sh
+++ b/lib/functions/rootfs/create-cache.sh
@@ -132,3 +132,4 @@ function extract_rootfs_artifact() {
 }
 
 # This comment strategically introduced to force a rebuild of all rootfs, as this file's contents are hashed into all rootfs versions.
+# Lets do this before releasing new images


### PR DESCRIPTION
# Description

Force rootfs rebuild to speed up image generation right before releasing new images.

# How Has This Been Tested?

It's just a command. Which must work ;)

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
