### PR TITLE
Mesa extension: adjust KDE related troubles with packages downgrade

### DIFF
--- a/extensions/mesa-vpu.sh
+++ b/extensions/mesa-vpu.sh
@@ -140,20 +140,26 @@ function post_install_kernel_debs__3d() {
 		EOF
 	fi
 
-	# KDE neon downgrades base-files for some reason. This prevents tacking it
-	do_with_retries 3 chroot_sdcard apt-mark hold base-files
-
 	display_alert "Updating sources list, after kisak PPAs" "${EXTENSION}" "info"
 	do_with_retries 3 chroot_sdcard_apt_get_update
 
+	# KDE neon downgrades base-files for some reason. This prevents tacking it
+	do_with_retries 3 chroot_sdcard apt-mark hold base-files
+
+	# This library must be installed before rockchip-multimedia
+	do_with_retries 3 chroot_sdcard_apt_get_install libv4l-0
+
 	display_alert "Installing 3D extension packages" "${EXTENSION}" "info"
-	do_with_retries 3 chroot_sdcard_apt_get_install --allow-downgrades "${pkgs[@]}"
+	do_with_retries 3 chroot_sdcard_apt_get_install "${pkgs[@]}"
+
+	# This library gets downgraded
+	do_with_retries 3 chroot_sdcard apt-mark hold libdav1d7
 
 	display_alert "Upgrading Mesa packages" "${EXTENSION}" "info"
 	do_with_retries 3 chroot_sdcard_apt_get dist-upgrade
 
 	# KDE neon downgrade hack undo
-	do_with_retries 3 chroot_sdcard apt-mark unhold base-files
+	do_with_retries 3 chroot_sdcard apt-mark unhold base-files libdav1d7
 
 	# Disable wayland flag for XFCE
 	#if [[ "${DESKTOP_ENVIRONMENT}" == "xfce" ]]; then

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstrun
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstrun
@@ -105,6 +105,9 @@ case "$1" in
 	[[ "${LINUXFAMILY}" == meson64 ]] && set_fixed_mac
 	[[ "${BOARD}" == nanopi-r6* ]] && set_fixed_mac
 
+	# Remove KDE Neon base files upgrade pin
+	[[ -f /etc/apt/preferences.d/99-neon-base-files ]] && rm -f /etc/apt/preferences.d/99-neon-base-files
+
 	systemctl disable armbian-firstrun
 	exit 0
 	;;


### PR DESCRIPTION
# Description

- one is actually general fix - recommened installation of library before installing rockchip-multimedia
- second is holding package before running upgrade as it wants to pull older library from kde repositories
- remove KDE Neon base files upgrade pin

# How Has This Been Tested?

- [x] Build KDE and Gnome Jammy / Noble image with extension for Odroid M1 (tested on HW)
- [x] Build the same for Opi5

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
