### PR TITLE
KDE Neon: hack must be implemented only on Ubuntu Noble / Oracular

### DIFF
--- a/extensions/mesa-vpu.sh
+++ b/extensions/mesa-vpu.sh
@@ -153,13 +153,18 @@ function post_install_kernel_debs__3d() {
 	do_with_retries 3 chroot_sdcard_apt_get_install "${pkgs[@]}"
 
 	# This library gets downgraded
-	do_with_retries 3 chroot_sdcard apt-mark hold libdav1d7
+	if [[ "${RELEASE}" =~ ^(oracular|noble)$ ]]; then
+		do_with_retries 3 chroot_sdcard apt-mark hold libdav1d7
+	fi
 
 	display_alert "Upgrading Mesa packages" "${EXTENSION}" "info"
 	do_with_retries 3 chroot_sdcard_apt_get dist-upgrade
 
 	# KDE neon downgrade hack undo
-	do_with_retries 3 chroot_sdcard apt-mark unhold base-files libdav1d7
+	do_with_retries 3 chroot_sdcard apt-mark unhold base-files
+	if [[ "${RELEASE}" =~ ^(oracular|noble)$ ]]; then
+		do_with_retries 3 chroot_sdcard apt-mark unhold libdav1d7
+	fi
 
 	# Disable wayland flag for XFCE
 	#if [[ "${DESKTOP_ENVIRONMENT}" == "xfce" ]]; then


### PR DESCRIPTION
# Description

Fixing broken desktop compilation with MESA extension on Debian.

# How Has This Been Tested?

CI breaks without this.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
