### PR TITLE
rk3588: Bump kernel from 6.11-rc3 to 6.11-rc4

### DIFF
--- a/config/kernel/linux-rockchip-rk3588-6.11.config
+++ b/config/kernel/linux-rockchip-rk3588-6.11.config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.11.0-rc3 Kernel Configuration
+# Linux/arm64 6.11.0-rc4 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-linux-gnu-gcc (Ubuntu 13.2.0-23ubuntu4) 13.2.0"
 CONFIG_CC_IS_GCC=y
@@ -9803,6 +9803,7 @@ CONFIG_OVERLAY_FS_XINO_AUTO=y
 #
 CONFIG_NETFS_SUPPORT=m
 CONFIG_NETFS_STATS=y
+# CONFIG_NETFS_DEBUG is not set
 CONFIG_FSCACHE=y
 CONFIG_FSCACHE_STATS=y
 CONFIG_CACHEFILES=m

--- a/config/sources/mainline-kernel.conf.sh
+++ b/config/sources/mainline-kernel.conf.sh
@@ -8,7 +8,7 @@
 function mainline_kernel_decide_version__upstream_release_candidate_number() {
 	[[ -n "${KERNELBRANCH}" ]] && return 0           # if already set, don't touch it; that way other hooks can run in any order
 	if [[ "${KERNEL_MAJOR_MINOR}" == "6.11" ]]; then # @TODO: roll over to next MAJOR.MINOR and MAJOR.MINOR-rc1 when it is released
-		declare -g KERNELBRANCH="tag:v6.11-rc3"
+		declare -g KERNELBRANCH="tag:v6.11-rc4"
 		display_alert "mainline-kernel: upstream release candidate" "Using KERNELBRANCH='${KERNELBRANCH}' for KERNEL_MAJOR_MINOR='${KERNEL_MAJOR_MINOR}'" "info"
 	fi
 }


### PR DESCRIPTION
# Description

6.11-RC4 was released on 2024-08-18 (https://kernel.org/).

`rewrite-kernel-patches` results in no diff.

# How Has This Been Tested?

- [x] Successful build: `./compile.sh BOARD=nanopi-r6c BRANCH=edge BUILD_DESKTOP=no BUILD_MINIMAL=no EXPERT=yes KERNEL_CONFIGURE=no RELEASE=trixie EXTRAWIFI=no kernel`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
