### PR TITLE
Gateway AM-GZ80x: `Re-brand as Amper & update u-boot to v2024.04`

### DIFF
--- a/config/boards/gateway-gz80x.conf
+++ b/config/boards/gateway-gz80x.conf
@@ -1,25 +1,16 @@
 # Amlogic A113X quad core 1Gb RAM SoC, eMMC 8Gb
-BOARD_NAME="Gateway GZ80X"
+BOARD_NAME="Gateway GZ80x"
 BOARDFAMILY="meson-axg"
 BOARD_MAINTAINER="pyavitz"
-BOOTCONFIG="alfredsmart_gateway_gz80x_defconfig"
+BOOTCONFIG="amper_gateway_am-gz80x_defconfig"
 KERNEL_TARGET="current,edge"
 KERNEL_TEST_TARGET="current,edge"
-BOOTBRANCH_BOARD="tag:v2023.10"
-BOOTPATCHDIR="v2023.10"
-BOOT_FDT_FILE="amlogic/meson-axg-alfredsmart-gateway-gz80x.dtb"
+BOOTBRANCH_BOARD="tag:v2024.04"
+BOOTPATCHDIR="v2024.04"
+BOOT_FDT_FILE="amlogic/meson-axg-amper-gateway-am-gz80x.dtb"
 SRC_EXTLINUX="yes"
 SRC_CMDLINE="console=ttyAML0,115200n8 clk_ignore_unused loglevel=7"
 HAS_VIDEO_OUTPUT="no"
-
-function post_config_uboot_target__extra_configs_for_gateway_gz80x() {
-	display_alert "u-boot for ${BOARD}" "u-boot: enabling extra configs" "info"
-	
-	run_host_command_logged scripts/config --enable CONFIG_SD_BOOT
-	run_host_command_logged scripts/config --enable CONFIG_EXT4_WRITE
-	run_host_command_logged scripts/config --enable CONFIG_FS_BTRFS
-	run_host_command_logged scripts/config --enable CONFIG_CMD_BTRFS
-}
 
 function post_family_tweaks_bsp__gateway_gz80x_udev() {
 	mkdir -p "${destination}"/etc/udev/rules.d

--- a/patch/kernel/archive/meson64-6.10/dt/meson-axg-amper-gateway-am-gz80x.dts
+++ b/patch/kernel/archive/meson64-6.10/dt/meson-axg-amper-gateway-am-gz80x.dts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 /*
  * Copyright (c) 2024 Patrick Yavitz <pyavitz@armbian.com>
- * Copyright (c) 2024 Alfred Smart
+ *
  */
 
 /dts-v1/;
@@ -10,8 +10,8 @@
 #include <dt-bindings/leds/common.h>
 
 / {
-	compatible = "alfredsmart,gateway-gz80x", "amlogic,a113d", "amlogic,meson-axg";
-	model = "Alfred Smart Gateway (AM-GZ80X)";
+	compatible = "amper,gateway-am-gz80x", "amlogic,a113x", "amlogic,meson-axg";
+	model = "Amper Gateway AM-GZ80x";
 
 	aliases {
 		serial0 = &uart_AO;

--- a/patch/kernel/archive/meson64-6.6/dt/meson-axg-amper-gateway-am-gz80x.dts
+++ b/patch/kernel/archive/meson64-6.6/dt/meson-axg-amper-gateway-am-gz80x.dts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 /*
  * Copyright (c) 2024 Patrick Yavitz <pyavitz@armbian.com>
- * Copyright (c) 2024 Alfred Smart
+ *
  */
 
 /dts-v1/;
@@ -10,8 +10,8 @@
 #include <dt-bindings/leds/common.h>
 
 / {
-	compatible = "alfredsmart,gateway-gz80x", "amlogic,a113d", "amlogic,meson-axg";
-	model = "Alfred Smart Gateway (AM-GZ80X)";
+	compatible = "amper,gateway-am-gz80x", "amlogic,a113x", "amlogic,meson-axg";
+	model = "Amper Gateway AM-GZ80x";
 
 	aliases {
 		serial0 = &uart_AO;

--- a/patch/u-boot/v2024.04/board_gateway-gz80x/001-Add-board-Amper-Gateway-AM-GZ80x.patch
+++ b/patch/u-boot/v2024.04/board_gateway-gz80x/001-Add-board-Amper-Gateway-AM-GZ80x.patch
@@ -1,0 +1,215 @@
+From 7e431409a7c34b844b27c0bfa89fe582f4093dc7 Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@armbian.com>
+Date: Tue, 13 Aug 2024 07:13:24 -0400
+Subject: [PATCH] Add board Amper Gateway AM-GZ80X
+
+Signed-off-by: Patrick Yavitz <pyavitz@armbian.com>
+---
+ arch/arm/dts/Makefile                         |  1 +
+ ...-axg-amper-gateway-am-gz80x-u-boot.dtsi | 10 +++
+ .../meson-axg-amper-gateway-am-gz80x.dts   | 87 +++++++++++++++++++
+ configs/amper_gateway_gz80x_defconfig   | 69 +++++++++++++++
+ 4 files changed, 167 insertions(+)
+ create mode 100644 arch/arm/dts/meson-axg-amper-gateway-am-gz80x-u-boot.dtsi
+ create mode 100644 arch/arm/dts/meson-axg-amper-gateway-am-gz80x.dts
+ create mode 100644 configs/amper_gateway_am-gz80x_defconfig
+
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index b102ffb5f6..da81b57aec 100644
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -215,6 +215,7 @@ dtb-$(CONFIG_ARCH_S5P4418) += \
+ dtb-$(CONFIG_ARCH_MESON) += \
+ 	meson-a1-ad401.dtb \
+ 	meson-axg-s400.dtb \
++	meson-axg-amper-gateway-am-gz80x.dtb \
+ 	meson-axg-jethome-jethub-j100.dtb \
+ 	meson-gxbb-kii-pro.dtb \
+ 	meson-gxbb-nanopi-k2.dtb \
+diff --git a/arch/arm/dts/meson-axg-amper-gateway-am-gz80x-u-boot.dtsi b/arch/arm/dts/meson-axg-amper-gateway-am-gz80x-u-boot.dtsi
+new file mode 100644
+index 0000000000..ca380fdb4c
+--- /dev/null
++++ b/arch/arm/dts/meson-axg-amper-gateway-am-gz80x-u-boot.dtsi
+@@ -0,0 +1,10 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2024 Patrick Yavitz <pyavitz@armbian.com>
++ *
++ */
++
++&saradc {
++	status = "okay";
++	vref-supply = <&vddio_ao18>;
++};
+diff --git a/arch/arm/dts/meson-axg-amper-gateway-am-gz80x.dts b/arch/arm/dts/meson-axg-amper-gateway-am-gz80x.dts
+new file mode 100644
+index 0000000000..3606121039
+--- /dev/null
++++ b/arch/arm/dts/meson-axg-amper-gateway-am-gz80x.dts
+@@ -0,0 +1,87 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2024 Patrick Yavitz <pyavitz@armbian.com>
++ *
++ */
++
++/dts-v1/;
++
++#include "meson-axg-jethome-jethub-j100.dts"
++#include <dt-bindings/leds/common.h>
++
++/ {
++	compatible = "amper,gateway-am-gz80x", "amlogic,a113x", "amlogic,meson-axg";
++	model = "Amper Gateway AM-GZ80x";
++
++	aliases {
++		serial0 = &uart_AO;
++		serial1 = &uart_B;
++		serial2 = &uart_AO_B;
++		ethernet0 = &ethmac;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led-blue {
++			color = <LED_COLOR_ID_BLUE>;
++			function = LED_FUNCTION_STATUS;
++			gpios = <&gpio_ao GPIOAO_3 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "default-on";
++		};
++
++		led-green {
++			color = <LED_COLOR_ID_GREEN>;
++			function = LED_FUNCTION_STATUS;
++			gpios = <&gpio_ao GPIOAO_4 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "mmc1";
++		};
++
++		led-red {
++			color = <LED_COLOR_ID_RED>;
++			function = LED_FUNCTION_STATUS;
++			gpios = <&gpio_ao GPIOAO_7 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "usb-host";
++		};
++ 	};
++
++	/* 1024MB RAM */
++	memory@0 {
++		device_type = "memory";
++		reg = <0x0 0x0 0x0 0x40000000>;
++	};
++};
++
++/delete-node/ &i2c1;
++
++/* wifi module */
++&sd_emmc_b {
++	non-removable;
++
++	rtl8189ftv: wifi@1 {
++		reg = <1>;
++	};
++};
++
++&uart_B {
++	status = "okay";
++	pinctrl-0 = <&uart_b_z_pins>;
++	pinctrl-names = "default";
++};
++
++/* UART Wireless module */
++&uart_AO_B {
++	status = "okay";
++	pinctrl-0 = <&uart_ao_b_z_pins>;
++	pinctrl-names = "default";
++	reset-gpios = <&gpio GPIOZ_6 GPIO_ACTIVE_HIGH>;
++};
++
++&usb_pwr {
++	gpio = <&gpio_ao GPIOAO_5 GPIO_ACTIVE_HIGH>;
++	enable-active-high;
++};
+diff --git a/configs/amper_gateway_am-gz80x_defconfig b/configs/amper_gateway_am-gz80x_defconfig
+new file mode 100644
+index 0000000000..1bdefc0add
+--- /dev/null
++++ b/configs/amper_gateway_am-gz80x_defconfig
+@@ -0,0 +1,69 @@
++CONFIG_ARM=y
++CONFIG_ARCH_MESON=y
++CONFIG_TEXT_BASE=0x01000000
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_HAS_CUSTOM_SYS_INIT_SP_ADDR=y
++CONFIG_CUSTOM_SYS_INIT_SP_ADDR=0x20000000
++CONFIG_ENV_SIZE=0x2000
++CONFIG_DM_GPIO=y
++CONFIG_DEFAULT_DEVICE_TREE="meson-axg-amper-gateway-am-gz80x"
++CONFIG_OF_LIBFDT_OVERLAY=y
++CONFIG_DM_RESET=y
++CONFIG_MESON_AXG=y
++CONFIG_DEBUG_UART_BASE=0xff803000
++CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_IDENT_STRING=" gateway-am-gz80x"
++CONFIG_SYS_LOAD_ADDR=0x01000000
++CONFIG_DEBUG_UART=y
++CONFIG_REMAKE_ELF=y
++CONFIG_SD_BOOT=y
++CONFIG_OF_BOARD_SETUP=y
++CONFIG_USE_PREBOOT=y
++CONFIG_PREBOOT="usb start"
++# CONFIG_DISPLAY_CPUINFO is not set
++CONFIG_MISC_INIT_R=y
++CONFIG_SYS_MAXARGS=32
++# CONFIG_CMD_BDI is not set
++# CONFIG_CMD_IMI is not set
++CONFIG_CMD_EEPROM=y
++CONFIG_CMD_ADC=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_I2C=y
++# CONFIG_CMD_LOADS is not set
++CONFIG_CMD_MMC=y
++CONFIG_CMD_USB=y
++CONFIG_CMD_USB_MASS_STORAGE=y
++CONFIG_CMD_REGULATOR=y
++CONFIG_CMD_BTRFS=y
++CONFIG_PARTITION_TYPE_GUID=y
++CONFIG_OF_CONTROL=y
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_SARADC_MESON=y
++CONFIG_DM_I2C=y
++CONFIG_SYS_I2C_MESON=y
++CONFIG_MMC_MESON_GX=y
++CONFIG_PHY_REALTEK=y
++CONFIG_ETH_DESIGNWARE_MESON8B=y
++CONFIG_MESON_GXL_USB_PHY=y
++CONFIG_PINCTRL=y
++CONFIG_PINCTRL_MESON_AXG=y
++CONFIG_DM_REGULATOR=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_DEBUG_UART_ANNOUNCE=y
++CONFIG_DEBUG_UART_SKIP_INIT=y
++CONFIG_MESON_SERIAL=y
++CONFIG_USB=y
++CONFIG_DM_USB_GADGET=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_XHCI_DWC3=y
++CONFIG_USB_DWC2=y
++CONFIG_USB_DWC3=y
++# CONFIG_USB_DWC3_GADGET is not set
++CONFIG_USB_DWC3_MESON_GXL=y
++CONFIG_USB_GADGET=y
++CONFIG_USB_GADGET_VENDOR_NUM=0x1b8e
++CONFIG_USB_GADGET_PRODUCT_NUM=0xfada
++CONFIG_USB_GADGET_DWC2_OTG=y
++CONFIG_USB_GADGET_DOWNLOAD=y
++CONFIG_EXT4_WRITE=y
++CONFIG_RANDOM_UUID=y
+-- 
+2.39.2
+

--- a/patch/u-boot/v2024.04/board_gateway-gz80x/002-HACK-mmc-meson-gx-limit-to-24MHz.patch
+++ b/patch/u-boot/v2024.04/board_gateway-gz80x/002-HACK-mmc-meson-gx-limit-to-24MHz.patch
@@ -1,0 +1,26 @@
+From 24ba56015b1ce831639f482d26aeec11ac523906 Mon Sep 17 00:00:00 2001
+From: Neil Armstrong <narmstrong@baylibre.com>
+Date: Mon, 2 Sep 2019 15:42:04 +0200
+Subject: [PATCH 1/8] HACK: mmc: meson-gx: limit to 24MHz
+
+Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>
+---
+ drivers/mmc/meson_gx_mmc.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/mmc/meson_gx_mmc.c b/drivers/mmc/meson_gx_mmc.c
+index fcf4f03d1e2..6ded4b619bf 100644
+--- a/drivers/mmc/meson_gx_mmc.c
++++ b/drivers/mmc/meson_gx_mmc.c
+@@ -279,7 +279,7 @@ static int meson_mmc_probe(struct udevice *dev)
+ 	cfg->host_caps = MMC_MODE_8BIT | MMC_MODE_4BIT |
+ 			MMC_MODE_HS_52MHz | MMC_MODE_HS;
+ 	cfg->f_min = DIV_ROUND_UP(SD_EMMC_CLKSRC_24M, CLK_MAX_DIV);
+-	cfg->f_max = 100000000; /* 100 MHz */
++	cfg->f_max = SD_EMMC_CLKSRC_24M;
+ 	cfg->b_max = 511; /* max 512 - 1 blocks */
+ 	cfg->name = dev->name;
+ 
+-- 
+2.43.2
+

--- a/patch/u-boot/v2024.04/board_gateway-gz80x/003-mmc-meson-gx-change-clock-phase-value-on-axg-SoCs.patch
+++ b/patch/u-boot/v2024.04/board_gateway-gz80x/003-mmc-meson-gx-change-clock-phase-value-on-axg-SoCs.patch
@@ -1,0 +1,54 @@
+From d2c54d518b8b3f362a8395d2a81a2e7cef7a1ae0 Mon Sep 17 00:00:00 2001
+From: Vyacheslav Bocharov <adeep@lexina.in>
+Date: Thu, 2 Dec 2021 13:10:24 +0300
+Subject: [PATCH 2/8] mmc: meson-gx: change clock phase value on axg SoCs
+
+Amlogic AXG SoCs seems doesn't work over 50MHz. When phase sets to 270',
+it's working fine over 50MHz on Amlogic AXG SoCs.
+Based on 0dbb54eb3257c243c7968f967a6b183b1edb56c8 by Neil Armstrong
+<narmstrong@baylibre.com>
+
+To distinguish which value is used adds an u-boot only axg compatible.
+---
+ drivers/mmc/meson_gx_mmc.c | 5 +++--
+ drivers/mmc/meson_gx_mmc.h | 1 +
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/mmc/meson_gx_mmc.c b/drivers/mmc/meson_gx_mmc.c
+index 6ded4b619bf..5e32c386caa 100644
+--- a/drivers/mmc/meson_gx_mmc.c
++++ b/drivers/mmc/meson_gx_mmc.c
+@@ -68,7 +68,8 @@ static void meson_mmc_config_clock(struct mmc *mmc)
+ 	 * Other SoCs use CLK_CO_PHASE_180 by default.
+ 	 * It needs to find what is a proper value about each SoCs.
+ 	 */
+-	if (meson_gx_mmc_is_compatible(mmc->dev, MMC_COMPATIBLE_SM1))
++	if (meson_gx_mmc_is_compatible(mmc->dev, MMC_COMPATIBLE_SM1) ||
++            meson_gx_mmc_is_compatible(mmc->dev, MMC_COMPATIBLE_AXG))
+ 		meson_mmc_clk |= CLK_CO_PHASE_270;
+ 	else
+ 		meson_mmc_clk |= CLK_CO_PHASE_180;
+@@ -322,7 +323,7 @@ int meson_mmc_bind(struct udevice *dev)
+ 
+ static const struct udevice_id meson_mmc_match[] = {
+ 	{ .compatible = "amlogic,meson-gx-mmc", .data = MMC_COMPATIBLE_GX },
+-	{ .compatible = "amlogic,meson-axg-mmc", .data = MMC_COMPATIBLE_GX },
++	{ .compatible = "amlogic,meson-axg-mmc", .data = MMC_COMPATIBLE_AXG },
+ 	{ .compatible = "amlogic,meson-sm1-mmc", .data = MMC_COMPATIBLE_SM1 },
+ 	{ /* sentinel */ }
+ };
+diff --git a/drivers/mmc/meson_gx_mmc.h b/drivers/mmc/meson_gx_mmc.h
+index 8974b78f559..53201ceddae 100644
+--- a/drivers/mmc/meson_gx_mmc.h
++++ b/drivers/mmc/meson_gx_mmc.h
+@@ -12,6 +12,7 @@
+ enum meson_gx_mmc_compatible {
+ 	MMC_COMPATIBLE_GX,
+ 	MMC_COMPATIBLE_SM1,
++	MMC_COMPATIBLE_AXG,
+ };
+ 
+ #define SDIO_PORT_A			0
+-- 
+2.43.2
+

--- a/patch/u-boot/v2024.04/board_gateway-gz80x/004-HACK-meson64-boot-target-usb.patch
+++ b/patch/u-boot/v2024.04/board_gateway-gz80x/004-HACK-meson64-boot-target-usb.patch
@@ -1,0 +1,29 @@
+From 4af333376c257d432f641926d74c762921186b78 Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@armbian.com>
+Date: Sat, 27 Jan 2024 22:57:03 -0500
+Subject: [PATCH] HACK: meson64 boot target usb
+
+Signed-off-by: Patrick Yavitz <pyavitz@armbian.com>
+---
+ include/configs/meson64.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/configs/meson64.h b/include/configs/meson64.h
+index efab9a624d..ae1b79da0f 100644
+--- a/include/configs/meson64.h
++++ b/include/configs/meson64.h
+@@ -99,10 +99,10 @@
+ #define BOOT_TARGET_DEVICES(func) \
+ 	func(ROMUSB, romusb, na)  \
+ 	func(USB_DFU, usbdfu, na)  \
++	BOOT_TARGET_DEVICES_USB(func) \
+ 	func(MMC, mmc, 0) \
+ 	func(MMC, mmc, 1) \
+ 	func(MMC, mmc, 2) \
+-	BOOT_TARGET_DEVICES_USB(func) \
+ 	BOOT_TARGET_NVME(func) \
+ 	BOOT_TARGET_SCSI(func) \
+ 	func(PXE, pxe, na) \
+-- 
+2.39.2
+


### PR DESCRIPTION
During a search I noticed other companies are using the same unit. Lets re-brand to Amper as technically that is the product brand name.

https://products.z-wavealliance.org/products/4022
