### PR TITLE
rockchip-rk3588: current: add `rfkill-bt` device node to Radxa Rock-5B

### DIFF
--- a/patch/kernel/archive/rockchip-rk3588-6.10/rk3588-rock-5b_dts_add_rfkill-bt.patch
+++ b/patch/kernel/archive/rockchip-rk3588-6.10/rk3588-rock-5b_dts_add_rfkill-bt.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: John Doe <john.doe@somewhere.on.planet>
+Date: Tue, 20 Aug 2024 22:47:51 +0000
+Subject: rk3588-rock-5b.dts: add rfkill-bt node to Radxa Rock5B board DT
+
+Signed-off-by: John Doe <john.doe@somewhere.on.planet>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+index 111111111111..222222222222 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+@@ -66,6 +66,13 @@ rfkill {
+ 		shutdown-gpios = <&gpio4 RK_PA2 GPIO_ACTIVE_HIGH>;
+ 	};
+ 
++	rfkill-bt {
++		compatible = "rfkill-gpio";
++		label = "rfkill-m2-bt";
++		radio-type = "bluetooth";
++		shutdown-gpios = <&gpio3 RK_PD5 GPIO_ACTIVE_HIGH>;
++	};
++
+ 	vcc3v3_pcie2x1l0: vcc3v3-pcie2x1l0-regulator {
+ 		compatible = "regulator-fixed";
+ 		enable-active-high;
+-- 
+Armbian
+


### PR DESCRIPTION
# Description
Enable proper enumeration of usb-bluetooth modules via M2/NGFF slot - without this patch, no pcie-integrated usb-module would wourk as device-tree lacks `rfkill-bt` device node

# How Has This Been Tested?


- [x] Applied patch to BOARD=rock-5b BRANCH=current, got `lsusb` output 
      `Bus 004 Device 004: ID 0bda:b85b Realtek Semiconductor Corp. Bluetooth Radio`
- [x] `Bluetoothctl` recognized bluetooth controller
- [x] Succesfully paired to a bluettoth device (iPhone)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
