### PR TITLE
cli: packages: use iputils-ping instead of inetutils-ping

### DIFF
--- a/config/cli/bullseye/main/packages
+++ b/config/cli/bullseye/main/packages
@@ -15,7 +15,7 @@ fake-hwclock
 fdisk
 figlet
 htop
-inetutils-ping
+iputils-ping
 init
 initramfs-tools
 iw

--- a/config/cli/common/main/packages
+++ b/config/cli/common/main/packages
@@ -13,7 +13,7 @@ fake-hwclock
 fdisk
 figlet
 htop
-inetutils-ping
+iputils-ping
 init
 initramfs-tools
 iproute2

--- a/config/cli/jammy/main/packages
+++ b/config/cli/jammy/main/packages
@@ -15,7 +15,7 @@ fake-hwclock
 fdisk
 figlet
 htop
-inetutils-ping
+iputils-ping
 init
 initramfs-tools
 iw


### PR DESCRIPTION
# Description

We used `iputils-ping` before https://github.com/armbian/build/pull/4893, and debian/ubuntu is using it by default, so change it back.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [ ] Not tested yet, but I think it should be okay

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
