### PR TITLE
BananaPi M2S: `remove fan control`

### DIFF
--- a/patch/kernel/archive/meson64-6.10/board-bananapi-m2s.patch
+++ b/patch/kernel/archive/meson64-6.10/board-bananapi-m2s.patch
@@ -1,9 +1,9 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Patrick Yavitz <pyavitz@xxxxx.com>
+From: Patrick Yavitz <pyavitz@armbian.com>
 Date: Tue, 25 Jul 2023 13:34:18 -0400
 Subject: arch: arm64: dts: amlogic: meson g12b bananapi m2s
 
-Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
+Signed-off-by: Patrick Yavitz <pyavitz@armbian.com>
 ---
  arch/arm64/boot/dts/amlogic/meson-g12b-a311d-bananapi-m2s.dts | 4 ++++
  arch/arm64/boot/dts/amlogic/meson-g12b-bananapi.dtsi          | 9 +++++++++
@@ -57,51 +57,6 @@ index 111111111111..222222222222 100644
 +&reboot {
 +	sd-vqen = <&gpio_ao GPIOAO_3 GPIO_ACTIVE_HIGH>;
 +};
--- 
-Armbian
-
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Patrick Yavitz <pyavitz@xxxxx.com>
-Date: Mon, 6 Nov 2023 08:53:24 -0500
-Subject: v2: arch: arm64: dts: amlogic: meson-g12b-bananapi-m2s: fan control
-
-The fan on the unit is constantly running. So lets set thermal
-trip points and add the ability to control when we want it to
-kick on. By default it is set to power on at 60*C.
-
-Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
----
- arch/arm64/boot/dts/amlogic/meson-g12b-bananapi.dtsi | 17 ++++++++++
- 1 file changed, 17 insertions(+)
-
-diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-bananapi.dtsi b/arch/arm64/boot/dts/amlogic/meson-g12b-bananapi.dtsi
-index 111111111111..222222222222 100644
---- a/arch/arm64/boot/dts/amlogic/meson-g12b-bananapi.dtsi
-+++ b/arch/arm64/boot/dts/amlogic/meson-g12b-bananapi.dtsi
-@@ -313,6 +313,23 @@ &cpu103 {
- 	clock-latency = <50000>;
- };
- 
-+&cpu_thermal {
-+	trips {
-+		cpu_active: cpu-active {
-+			temperature = <60000>; /* millicelsius */
-+			hysteresis = <2000>; /* millicelsius */
-+			type = "active";
-+		};
-+	};
-+
-+	cooling-maps {
-+		map {
-+			trip = <&cpu_active>;
-+			cooling-device = <&fan0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
-+		};
-+	};
-+};
-+
- &ethmac {
- 	pinctrl-0 = <&eth_pins>, <&eth_rgmii_pins>;
- 	pinctrl-names = "default";
 -- 
 Armbian
 


### PR DESCRIPTION
The fan0 and pwm_cd nodes were removed in linux-6.11.y.

https://github.com/torvalds/linux/commit/1095ad0e92175d19cb7f0b5256af300c921a2d63 https://lore.kernel.org/all/20240606-topic-amlogic-upstream-bindings-fixes-dts-v1-1-62e812729541@linaro.org/

Remove the patch now, so it doesn't become a problem later.
