### PR TITLE
Framework: disable armbian repository while generating rootfs cache

### DIFF
--- a/lib/functions/cli/commands.sh
+++ b/lib/functions/cli/commands.sh
@@ -127,7 +127,7 @@ function armbian_register_commands() {
 		["rewrite-uboot-patches-needing-rebase"]="REWRITE_PATCHES='yes' REWRITE_PATCHES_NEEDING_REBASE='yes'"
 
 		# artifact shortcuts
-		["rootfs"]="WHAT='rootfs' ${common_cli_artifact_vars}"
+		["rootfs"]="WHAT='rootfs' SKIP_ARMBIAN_REPO='yes' ${common_cli_artifact_vars}"
 
 		["kernel"]="WHAT='kernel' ${common_cli_artifact_vars}"
 		["kernel-config"]="WHAT='kernel' KERNEL_CONFIGURE='yes' ${common_cli_artifact_interactive_vars} ${common_cli_artifact_vars}"

--- a/lib/functions/rootfs/create-cache.sh
+++ b/lib/functions/rootfs/create-cache.sh
@@ -132,4 +132,4 @@ function extract_rootfs_artifact() {
 }
 
 # This comment strategically introduced to force a rebuild of all rootfs, as this file's contents are hashed into all rootfs versions.
-# Lets do this before releasing new images
+# There was a problem when generating cache. Packages were upgraded from our (beta) repository which lead into package downgrade error problem


### PR DESCRIPTION
# Description

Rootfs cache was designed to contain clean package base without any Armbian packages. Since we are providing our own base-files (also via repository) cache file is upgraded from, if repository is present. We don't want that.

This caused several problems: https://github.com/armbian/build/issues/7048 [AR-2350] [AR-2454]

# How Has This Been Tested?

- [x] https://paste.armbian.de/wugawiletu

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-2350]: https://armbian.atlassian.net/browse/AR-2350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AR-2454]: https://armbian.atlassian.net/browse/AR-2454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ