### PR TITLE
Framework: expand package installing function with custom parameter

### DIFF
--- a/lib/functions/rootfs/apt-install.sh
+++ b/lib/functions/rootfs/apt-install.sh
@@ -77,6 +77,7 @@ function install_deb_chroot() {
 	local package="$1"
 	local variant="$2"
 	local transfer="$3"
+	local apt_options="$4"
 	local install_target="${package}"
 	local log_extra=" from repository"
 	local package_filename
@@ -103,7 +104,7 @@ function install_deb_chroot() {
 	declare -g if_error_detail_message="Installation of $install_target failed ${BOARD} ${RELEASE} ${BUILD_DESKTOP} ${LINUXFAMILY}"
 	declare -a extra_apt_envs=()
 	extra_apt_envs+=("ARMBIAN_IMAGE_BUILD_BOOTFS_TYPE=${BOOTFS_TYPE:-"unset"}")                             # used by package postinst scripts to bevahe
-	DONT_MAINTAIN_APT_CACHE="yes" chroot_sdcard_apt_get --no-install-recommends install "${install_target}" # don't auto-maintain apt cache when installing from packages.
+	DONT_MAINTAIN_APT_CACHE="yes" chroot_sdcard_apt_get --no-install-recommends "${apt_options}" install "${install_target}" # don't auto-maintain apt cache when installing from packages.
 	unset extra_apt_envs
 
 	# IMPORTANT! Do not use short-circuit above as last statement in a function, since it determines the result of the function.
@@ -112,13 +113,14 @@ function install_deb_chroot() {
 
 function install_artifact_deb_chroot() {
 	declare deb_name="$1"
+	declare apt_options="$2"
 	declare -A -g image_artifacts_debs_reversioned # global associative array
 	declare revisioned_deb_rel_path="${image_artifacts_debs_reversioned["${deb_name}"]}"
 	if [[ -z "${revisioned_deb_rel_path}" ]]; then
 		exit_with_error "No revisioned deb path found for '${deb_name}'"
 	fi
 	display_alert "Installing artifact deb" "${deb_name} :: ${revisioned_deb_rel_path}" "debug"
-	install_deb_chroot "${DEB_STORAGE}/${revisioned_deb_rel_path}"
+	install_deb_chroot "${DEB_STORAGE}/${revisioned_deb_rel_path}" "" "" "${apt_options}"
 
 	# Mark the deb as installed in the global associative array.
 	declare -A -g image_artifacts_debs_installed

--- a/lib/functions/rootfs/create-cache.sh
+++ b/lib/functions/rootfs/create-cache.sh
@@ -132,4 +132,4 @@ function extract_rootfs_artifact() {
 }
 
 # This comment strategically introduced to force a rebuild of all rootfs, as this file's contents are hashed into all rootfs versions.
-# There was a problem when generating cache. Packages were upgraded from our (beta) repository which lead into package downgrade error problem
+# There was a problem when generating cache. Packages were upgraded from our (beta) repository which lead into package downgrade error problem.

--- a/lib/functions/rootfs/distro-specific.sh
+++ b/lib/functions/rootfs/distro-specific.sh
@@ -37,7 +37,7 @@ function install_distribution_specific() {
 
 	# install our base-files package (this replaces the original from Debian/Ubuntu)
 	if [[ "${KEEP_ORIGINAL_OS_RELEASE:-"no"}" != "yes" ]]; then
-		install_artifact_deb_chroot "armbian-base-files"
+		install_artifact_deb_chroot "armbian-base-files" "--allow-downgrades"
 	fi
 
 	# Set DNS server if systemd-resolved is in use


### PR DESCRIPTION
# Description

- Expand functions `install_deb_chroot` and `install_artifact_deb_chroot` with additional parameter. This adds support to pass additional parameters to package installer.
- Enable allow-downgrades to base-files to allow building images with older version than current
- Force cache rebuild just to make sure this https://github.com/armbian/build/pull/7123 is executed (I hope that would do, but it doesn't cover everything)

Framework stores our base-files in rootfs cache with version that comes from trunk and when we make stable images for current or previous release, build fails with error E: Packages were downgraded and -y was used without --allow-downgrades.

@rpardini I didn't find better ways.

https://github.com/armbian/build/issues/7048 [AR-2350](https://armbian.atlassian.net/browse/AR-2350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ) [AR-2454](https://armbian.atlassian.net/browse/AR-2454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

# How Has This Been Tested?

- [x] Manual tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[AR-2350]: https://armbian.atlassian.net/browse/AR-2350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AR-2454]: https://armbian.atlassian.net/browse/AR-2454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ