### PR TITLE
Framework: bump tmpfs size as we are going over

### DIFF
--- a/lib/functions/rootfs/trap-rootfs.sh
+++ b/lib/functions/rootfs/trap-rootfs.sh
@@ -26,7 +26,7 @@ function prepare_rootfs_build_params_and_trap() {
 	# @TODO: well those are very... arbitrary numbers. At least when using cached rootfs, we can be more precise.
 	# predicting the size of tmpfs is hard/impossible, so would be nice to show the used size at the end so we can tune.
 	declare -i tmpfs_estimated_size=2300                     # MiB - bumped from 2000, empirically
-	[[ $BUILD_DESKTOP == yes ]] && tmpfs_estimated_size=5000 # MiB
+	[[ $BUILD_DESKTOP == yes ]] && tmpfs_estimated_size=6000 # MiB
 
 	declare use_tmpfs=no                      # by default
 	if [[ ${FORCE_USE_RAMDISK} == no ]]; then # do not use, even if it fits


### PR DESCRIPTION
# Description

Suppress this warning: "Rootfs post-tweaks size is larger than estimated tmpfs size"

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
