### PR TITLE
Mesa fixes applies only to armhf and arm64. Adjusting

### DIFF
--- a/extensions/mesa-vpu.sh
+++ b/extensions/mesa-vpu.sh
@@ -153,7 +153,7 @@ function post_install_kernel_debs__3d() {
 	do_with_retries 3 chroot_sdcard_apt_get_install "${pkgs[@]}"
 
 	# This library gets downgraded
-	if [[ "${RELEASE}" =~ ^(oracular|noble|jammy)$ ]]; then
+	if [[ "${RELEASE}" =~ ^(oracular|noble|jammy)$ && "${ARCH}" == arm* ]]; then
 		do_with_retries 3 chroot_sdcard apt-mark hold libdav1d7
 	fi
 
@@ -162,7 +162,7 @@ function post_install_kernel_debs__3d() {
 
 	# KDE neon downgrade hack undo
 	do_with_retries 3 chroot_sdcard apt-mark unhold base-files
-	if [[ "${RELEASE}" =~ ^(oracular|noble|jammy)$ ]]; then
+	if [[ "${RELEASE}" =~ ^(oracular|noble|jammy)$ && "${ARCH}" == arm* ]]; then
 		do_with_retries 3 chroot_sdcard apt-mark unhold libdav1d7
 	fi
 


### PR DESCRIPTION
# Description

MESA workaround is applicable only to arm/aarch64 architecture.


# How Has This Been Tested?

- [x] Manual build of x86 and arm64 image with enabled extension

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
