### PR TITLE
Repository management: add config driven BSP package modification

### DIFF
--- a/tools/repository/repo
+++ b/tools/repository/repo
@@ -56,6 +56,24 @@ adding_packages() {
 	return 0
 	fi
 	for f in "${4}${2}"/*.deb; do
+			# If we have a list of last known working kernels, repack BSP files to prevent upgrade to kernel that breaks
+			if [[ -f userpatches/last-known-good.map ]]; then
+				PACKAGE_NAME=$(dpkg-deb -W $f | awk '{ print $1 }')
+				for g in $(cat userpatches/last-known-good-kernel-pkg.map); do
+					# Read values from file
+					BOARD=$(echo $g | cut -d"|" -f1);
+					BRANCH=$(echo $g | cut -d"|" -f2);
+					LINUXFAMILY=$(echo $g | cut -d"|" -f3)
+					LASTKERNEL=$(echo $g | cut -d"|" -f4);
+					if [[ ${PACKAGE_NAME} == "armbian-bsp-cli-${BOARD}-${BRANCH}" ]]; then
+					echo "Setting last kernel upgrade for $BOARD to linux-image-$BRANCH-$BOARD=${LASTKERNEL}"
+					tempdir=$(mktemp -d)
+					dpkg-deb -R $f $tempdir
+					sed -i '/^Replaces:/ s/$/, linux-image-'$BRANCH'-'$LINUXFAMILY' (>> '$LASTKERNEL'), linux-dtb-'$BRANCH'-'$LINUXFAMILY' (>> '$LASTKERNEL')/' $tempdir/DEBIAN/control
+					dpkg-deb -b $tempdir ${f} >/dev/null
+					fi
+				done
+			fi
 			aptly repo add -remove-files -force-replace -config="${CONFIG}" "${1}" "${f}"
 	done
 }


### PR DESCRIPTION
# Description

This provide an option to set last good kernel for dedicated device. It will prevent upgrading to higher kernels which are known to be broken. For example. At this moment we have Rockchip BSP kernel which was fixed that Radxa ITX has working ports, while this fix will break NVME support on Orangepi. Also this we can use for Pinebook PRO.

Configuration:

|BOARD|BRANCH|LINUXFAMILY|Last good kernel package from repository|
|----|--------:|------:|-----:|
|orangepi5|vendor|rk35xx|24.5.3|
|orangepi5plus|vendor|rk35xx|24.5.3|


```
orangepi5|vendor|rk35xx|24.5.3
orangepi5plus|vendor|rk35xx|24.5.3
```

Before and after: https://paste.armbian.com/mixiquliro.yaml

# How Has This Been Tested?

- [x] Test with locally generated repo that contained higer version of kernel. It was hold back.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
