### PR TITLE
rockchip-rk3588: rock-5b current, edge: u-boot: bump to mainline 2024.10-rc3

### DIFF
--- a/config/boards/rock-5b.conf
+++ b/config/boards/rock-5b.conf
@@ -27,13 +27,13 @@ function post_family_tweaks__rock5b_naming_audios() {
 	return 0
 }
 
- Mainline u-boot tree
+# Mainline u-boot tree
 function post_family_config_branch_edge__rock-5b_use_mainline_uboot() {
 	display_alert "$BOARD" "mainline (next branch) u-boot overrides for $BOARD / $BRANCH" "info"
 
 	declare -g BOOTCONFIG="rock5b-rk3588_defconfig"				# override the default for the board/family
 	declare -g BOOTDELAY=1							# Wait for UART interrupt to enter UMS/RockUSB mode etc
-	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git"		# We ❤️Mainline tree
+	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git"		# We ❤️  Mainline tree
 	declare -g BOOTBRANCH="tag:v2024.10-rc3"				# commit:d11a60610e17373331ad17b6c5c31735cf9fffa8 as of 2024-08-20
 	declare -g BOOTPATCHDIR="v2024.10-rock5b-radxa"				# empty; defconfig changes are done in hook below
 	declare -g BOOTDIR="u-boot-${BOARD}"					# do not share u-boot directory
@@ -56,7 +56,7 @@ function post_family_config_branch_current__rock-5b_use_mainline_uboot() {
 
 	declare -g BOOTCONFIG="rock5b-rk3588_defconfig"				# override the default for the board/family
 	declare -g BOOTDELAY=1							# Wait for UART interrupt to enter UMS/RockUSB mode etc
-	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git"		# We ❤️  Mainline tree
+	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git"		# We ❤️  ainline tree
 	declare -g BOOTBRANCH="tag:v2024.10-rc3"				# commit:d11a60610e17373331ad17b6c5c31735cf9fffa8 as of 2024-08-20
 	declare -g BOOTPATCHDIR="v2024.10-rock5b-radxa"				# empty; defconfig changes are done in hook below
 	declare -g BOOTDIR="u-boot-${BOARD}"					# do not share u-boot directory


### PR DESCRIPTION
# Description

**Radxa Rock 5B**

 - Bump `current` and `edge` to mainline 2024.10-rc3
 - ensure `ARMV8_CRYPTO` is disabled (currently broken)
 - enable creation of `/chosen/kaslr-seed` node (to enable Kernel address space layout randomization)

# How Has This Been Tested?

- [x] Built, installed, and succesfully booted trixie current and edge

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
