### PR TITLE
rockchip-rk3588: orangepi5-plus current, edge: u-boot: bump to mainline 2024.10-rc3

### DIFF
--- a/config/boards/orangepi5-plus.conf
+++ b/config/boards/orangepi5-plus.conf
@@ -27,7 +27,6 @@ function post_family_tweaks__orangepi5plus_naming_audios() {
 
 	return 0
 }
-
 # Mainline U-Boot for edge kernel
 function post_family_config_branch_edge__orangepi5plus_use_mainline_uboot() {
 	display_alert "$BOARD" "Mainline U-Boot overrides for $BOARD - $BRANCH" "info"
@@ -35,8 +34,8 @@ function post_family_config_branch_edge__orangepi5plus_use_mainline_uboot() {
 	declare -g BOOTCONFIG="orangepi-5-plus-rk3588_defconfig"     # override the default for the board/family
 	declare -g BOOTDELAY=1                                       # Wait for UART interrupt to enter UMS/RockUSB mode etc
 	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git" # We ❤️ mainline U-Boot
-	declare -g BOOTBRANCH="tag:v2024.07"
-	declare -g BOOTPATCHDIR="v2024.07"
+	declare -g BOOTBRANCH="tag:v2024.10-rc3"
+	declare -g BOOTPATCHDIR="v2024.10"
 	declare -g BOOTDIR="u-boot-${BOARD}" # do not share u-boot directory
 	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
 	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # disable stuff from rockchip64_common; we're using binman here which does all the work already
@@ -49,4 +48,37 @@ function post_family_config_branch_edge__orangepi5plus_use_mainline_uboot() {
 	function write_uboot_platform_mtd() {
 		flashcp -v -p "$1/u-boot-rockchip-spi.bin" /dev/mtd0
 	}
+}
+
+# Mainline U-Boot for current kernel
+function post_family_config_branch_current__orangepi5plus_use_mainline_uboot() {
+	display_alert "$BOARD" "Mainline U-Boot overrides for $BOARD - $BRANCH" "info"
+
+	declare -g BOOTCONFIG="orangepi-5-plus-rk3588_defconfig"     # override the default for the board/family
+	declare -g BOOTDELAY=1                                       # Wait for UART interrupt to enter UMS/RockUSB mode etc
+	declare -g BOOTSOURCE="https://github.com/u-boot/u-boot.git" # We ❤️ mainline U-Boot
+	declare -g BOOTBRANCH="tag:v2024.10-rc3"
+	declare -g BOOTPATCHDIR="v2024.10"
+	declare -g BOOTDIR="u-boot-${BOARD}" # do not share u-boot directory
+	declare -g UBOOT_TARGET_MAP="BL31=${RKBIN_DIR}/${BL31_BLOB} ROCKCHIP_TPL=${RKBIN_DIR}/${DDR_BLOB};;u-boot-rockchip.bin u-boot-rockchip-spi.bin"
+	unset uboot_custom_postprocess write_uboot_platform write_uboot_platform_mtd # disable stuff from rockchip64_common; we're using binman here which does all the work already
+
+	# Just use the binman-provided u-boot-rockchip.bin, which is ready-to-go
+	function write_uboot_platform() {
+		dd "if=$1/u-boot-rockchip.bin" "of=$2" bs=32k seek=1 conv=notrunc status=none
+	}
+
+	function write_uboot_platform_mtd() {
+		flashcp -v -p "$1/u-boot-rockchip-spi.bin" /dev/mtd0
+	}
+}
+
+function post_config_uboot_target__extra_configs_for_rock5b_mainline_environment_in_spi() {
+	[[ "${BRANCH}" != "edge" && "${BRANCH}" != "current" ]] && return 0
+
+	 display_alert "$BOARD" "u-boot configs for ${BOOTBRANCH} u-boot config BRANCH=${BRANCH}" "info"
+	run_host_command_logged scripts/config --set-val CONFIG_BOARD_RNG_SEED "y"
+	run_host_command_logged scripts/config --set-val ARMV8_CRYPTO "n" #broken as per 2024.10-rc3
+	run_host_command_logged scripts/config --set-val ARMV8_CE_SHA1 "n" #broken as per 2024.10-rc3
+	run_host_command_logged scripts/config --set-val ARMV8_CE_SHA256 "n" #broken as per 2024.10-rc3
 }


### PR DESCRIPTION
# Description

**OrangePi 5 Plus**

 - Bump `current` and `edge` to mainline 2024.10-rc3
 - ensure `ARMV8_CRYPTO` is disabled (currently broken)
 - enable creation of `/chosen/kaslr-seed` node (to enable Kernel address space layout randomization)

# How Has This Been Tested?

- [x] Built, installed, and succesfully booted trixie current and edge

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
