### PR TITLE
rockchip-rk3588: current edge: add a pwm fan control overlay

### DIFF
--- a/patch/kernel/archive/rockchip-rk3588-6.10/overlay/Makefile
+++ b/patch/kernel/archive/rockchip-rk3588-6.10/overlay/Makefile
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0
 dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
+	rockchip-rk3588-fanctrl.dtbo \
 	rockchip-rk3588-sata1.dtbo \
 	rockchip-rk3588-sata2.dtbo \
 	rockchip-rk3588-hdmirx.dtbo \

--- a/patch/kernel/archive/rockchip-rk3588-6.10/overlay/rockchip-rk3588-fanctrl.dtso
+++ b/patch/kernel/archive/rockchip-rk3588-6.10/overlay/rockchip-rk3588-fanctrl.dtso
@@ -1,0 +1,11 @@
+/dts-v1/;
+/plugin/;
+/ {
+        fragment@0 {
+                target = <&pwm-fan>;
+                __overlay__ {
+                        cooling-levels = <146 146 146 146 146 146 149 149 151>;
+                };
+        };
+};
+

--- a/patch/kernel/archive/rockchip-rk3588-6.11/overlay/Makefile
+++ b/patch/kernel/archive/rockchip-rk3588-6.11/overlay/Makefile
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0
 dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
+	rockchip-rk3588-fanctrl.dtbo \
 	rockchip-rk3588-sata1.dtbo \
 	rockchip-rk3588-sata2.dtbo \
 	rockchip-rk3588-hdmirx.dtbo \

--- a/patch/kernel/archive/rockchip-rk3588-6.11/overlay/rockchip-rk3588-fanctrl.dtso
+++ b/patch/kernel/archive/rockchip-rk3588-6.11/overlay/rockchip-rk3588-fanctrl.dtso
@@ -1,0 +1,11 @@
+/dts-v1/;
+/plugin/;
+/ {
+        fragment@0 {
+                target = <&pwm-fan>;
+                __overlay__ {
+                        cooling-levels = <146 146 146 146 146 146 149 149 151>;
+                };
+        };
+};
+


### PR DESCRIPTION
# Description
Improve fan curve from rockchip default via device-tree overlay

- Better operating temperatures
- No discernible noise during standard workloads 
- Low always-on rotation (make sure it's not too low to buzz)

Credits: [incognito](https://forum.radxa.com/u/incognito)
Source: [Radxa Forum](https://forum.radxa.com/t/guide-how-to-make-the-rock-5b-fan-work-properly-joshua-rieks-ubuntu-24-04/20836/2)

# How Has This Been Tested?

- [x] Built and enabled on Radxa Rock 5B `${BRANCH}="current"`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
