### PR TITLE
MBa8MPxL: update atf to v2.10

### DIFF
--- a/config/sources/families/imx8m.conf
+++ b/config/sources/families/imx8m.conf
@@ -21,7 +21,7 @@ OFFSET=32
 case $BOARD in
 	mba8mpxl*)
 		ATFSOURCE='https://github.com/tq-systems/atf' # required for ram
-		ATFBRANCH="branch:TQMa8-imx_5.4.70_2.3.0"
+		ATFBRANCH="branch:TQM-lf_v2.10"
 		BOOTSOURCE='https://github.com/tq-systems/u-boot-tqmaxx.git' # u-boot mainlining is hard and has low-priority
 		BOOTBRANCH='branch:TQMa8-v2020.04_imx_5.4.70_2.3.0'
 		BOOTPATCHDIR="u-boot-tqma" # could be removed when distro boot patches are integrated


### PR DESCRIPTION
# Description

- a new atf version is now available on GitHub (v2.10) 
- the new version is compatible with GCC13

[Jira](https://armbian.atlassian.net/jira) reference number [AR-2441]

# How Has This Been Tested?

- [x] Build images for mba8mp-ras314 and mba8mpxl with new patches
- [x] Boot test "bookworm_current" mba8mp-ras314
- [x] Boot test "bookworm_current" mba8mpxl

```
NOTICE:  BL31: v2.10.0  (release):armbian                                                                                                                   
NOTICE:  BL31: Built : 08:58:44, Aug 26 2024      
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code


[AR-2441]: https://armbian.atlassian.net/browse/AR-2441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ