### PR TITLE
rockchip-rk3588: fanctrl overlay: fix `<&fan>` alias for device tree

### DIFF
--- a/patch/kernel/archive/rockchip-rk3588-6.10/overlay/rockchip-rk3588-fanctrl.dtso
+++ b/patch/kernel/archive/rockchip-rk3588-6.10/overlay/rockchip-rk3588-fanctrl.dtso
@@ -2,7 +2,7 @@
 /plugin/;
 / {
         fragment@0 {
-                target = <&pwm-fan>;
+                target = <&fan>;
                 __overlay__ {
                         cooling-levels = <146 146 146 146 146 146 149 149 151>;
                 };

--- a/patch/kernel/archive/rockchip-rk3588-6.11/overlay/rockchip-rk3588-fanctrl.dtso
+++ b/patch/kernel/archive/rockchip-rk3588-6.11/overlay/rockchip-rk3588-fanctrl.dtso
@@ -2,7 +2,7 @@
 /plugin/;
 / {
         fragment@0 {
-                target = <&pwm-fan>;
+                target = <&fan>;
                 __overlay__ {
                         cooling-levels = <146 146 146 146 146 146 149 149 151>;
                 };


### PR DESCRIPTION
# Description

rockchip-rk3588: fanctrl overlay: fix "fan" alias for device tree
fixes PR #7137

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] Built and run current|edge rock-5b 

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
