### PR TITLE
Bugfix: BigTreeTech CB1 patches and edge dts

### DIFF
--- a/config/boards/bigtreetech-cb1.conf
+++ b/config/boards/bigtreetech-cb1.conf
@@ -11,9 +11,3 @@ BOOTFS_TYPE="fat"
 BOOT_FS_LABEL="BOOT"
 OVERLAY_PREFIX="sun50i-h616"
 BOOT_FDT_FILE="allwinner/sun50i-h616-bigtreetech-cb1-sd.dtb"
-
-post_family_config__fdt_bigtreetech_cb1() {
-	if [[ "${BRANCH}" = "edge" ]]; then
-		BOOT_FDT_FILE="allwinner/sun50i-h616-bigtreetech-pi.dtb"
-	fi
-}

--- a/patch/kernel/archive/sunxi-6.7/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-enable-emac1.patch
+++ b/patch/kernel/archive/sunxi-6.7/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-enable-emac1.patch
@@ -1,1 +1,46 @@
-../../sunxi-6.6/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-enable-emac1.patch
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: JohnTheCoolingFan <ivan8215145640@gmail.com>
+Date: Thu, 13 Jun 2024 11:50:55 +0000
+Subject: ARM64: dts: sun50i-h616: BigTreeTech CB1: Enable EMAC1
+
+Signed-off-by: JohnTheCoolingFan <ivan8215145640@gmail.com>
+---
+ arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi | 18 ++++++++++
+ 1 file changed, 18 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
+index bbff30ccf..b98e85a51 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
+@@ -142,10 +142,28 @@ mcp2515_clock: mcp2515_clock {
+ 		#clock-cells = <0>;
+ 		clock-frequency  = <12000000>;
+ 	};
+ };
+ 
++&emac1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&rmii_pins>;
++	phy-mode = "rmii";
++	phy-handle = <&rmii_phy>;
++	phy-supply = <&reg_dldo1>;
++	allwinner,rx-delay-ps = <3100>;
++	allwinner,tx-delay-ps = <700>;
++	status = "okay";
++};
++
++&mdio1 {
++	rmii_phy: ethernet-phy@1 {
++		compatible = "ethernet-phy-ieee802.3-c22";
++		reg = <1>;
++	};
++};
++
+ &mmc0 {
+ 	vmmc-supply = <&reg_dldo1>;
+ 	broken-cd;
+ 	bus-width = <4>;
+ 	max-frequency = <50000000>;
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/kernel/archive/sunxi-6.7/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-enable-hdmi.patch
+++ b/patch/kernel/archive/sunxi-6.7/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-enable-hdmi.patch
@@ -1,1 +1,65 @@
-../../sunxi-6.6/patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-enable-hdmi.patch
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: JohnTheCoolingFan <ivan8215145640@gmail.com>
+Date: Thu, 13 Jun 2024 11:07:35 +0000
+Subject: ARM64: dts: sun50i-h616: BigTreeTech CB1: Enable HDMI
+
+Signed-off-by: JohnTheCoolingFan <ivan8215145640@gmail.com>
+---
+ arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi | 26 ++++++++++
+ 1 file changed, 26 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
+index e82da4b6e..bbff30ccf 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
+@@ -23,10 +23,21 @@ aliases {
+ 
+ 	chosen {
+ 		stdout-path = "serial0:115200n8";
+ 	};
+ 
++	connector {
++		compatible = "hdmi-connector";
++		type = "d";
++
++		port {
++			hdmi_con_in: endpoint {
++				remote-endpoint = <&hdmi_out_con>;
++			};
++		};
++	};
++
+ 	leds {
+ 		compatible = "gpio-leds";
+ 
+ 		act_led: led-0 {
+ 			gpios = <&pio 7 5 GPIO_ACTIVE_LOW>; /* PH5 */
+@@ -255,10 +266,25 @@ reg_dldo1: dldo1 {
+ 			};
+ 		};
+ 	};
+ };
+ 
++&de {
++	status = "okay";
++};
++
++&hdmi {
++	hvcc-supply = <&reg_aldo1>;
++	status = "okay";
++};
++
++&hdmi_out {
++	hdmi_out_con: endpoint {
++		remote-endpoint = <&hdmi_con_in>;
++	};
++};
++
+ &cpu0 {
+ 	cpu-supply = <&reg_dcdc2>;
+ 	status = "okay";
+ };
+ 
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+


### PR DESCRIPTION
# Description

As asked in #7127, removed the hook in board config that changed which dts file is used on edge kernel branch and changed symlink patches to actual files.

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-9999]

# How Has This Been Tested?

- [x] build for bigtreetech cb1 and boot

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
