### PR TITLE
distro-specific: systemd-resolved: don't impose 1.0.0.1 DNS server on users

### DIFF
--- a/lib/functions/rootfs/distro-specific.sh
+++ b/lib/functions/rootfs/distro-specific.sh
@@ -42,19 +42,8 @@ function install_distribution_specific() {
 
 	# Set DNS server if systemd-resolved is in use
 	if [[ -n "$NAMESERVER" && -f "${SDCARD}"/etc/systemd/resolved.conf ]]; then
-		display_alert "Setup DNS server for systemd-resolved" "${NAMESERVER}" "info"
-
-		# Use resolved.conf.d/ directory as recommended by resolved itself
-		mkdir -p "${SDCARD}"/etc/systemd/resolved.conf.d/
-
-		cat <<- EOF > "${SDCARD}"/etc/systemd/resolved.conf.d/00-armbian-default-dns.conf
-			# Added by Armbian
-			#
-			# See resolved.conf(5) for details
-
-			[Resolve]
-			DNS=${NAMESERVER}
-		EOF
+		display_alert "Using systemd-resolved" "for DNS management" "info"
+		# This used to set a default DNS entry from $NAMESERVER into "${SDCARD}"/etc/systemd/resolved.conf.d/00-armbian-default-dns.conf -- no longer; better left to DHCP.
 	fi
 
 	# cleanup motd services and related files


### PR DESCRIPTION
#### distro-specific: systemd-resolved: don't impose 1.0.0.1 DNS server on users

- distro-specific: systemd-resolved: don't impose 1.0.0.1 DNS server on users
  - See https://github.com/armbian/build/pull/6756/files#r1731373505
  Fixes: b6f018a2b1d345729571b75b580e287f06d24f8f