### PR TITLE
More descriptive ethernet interface name matching

### DIFF
--- a/extensions/network/config-networkd/netplan/10-dhcp-all-interfaces.yaml
+++ b/extensions/network/config-networkd/netplan/10-dhcp-all-interfaces.yaml
@@ -10,7 +10,7 @@ network:
   ethernets:
     all-eth-interfaces:
       match:
-        name: "e*"
+        name: "en*"
       dhcp4: yes
       dhcp6: yes
       ipv6-privacy: yes # Enabled by default on most current systems, but networkd currently doesn't enable IPv6 privacy by default, see https://man.archlinux.org/man/systemd.network.5


### PR DESCRIPTION
# Description

All ethernet network names start with en, not just e. This is how predictible network interface names work in udev/systemd. :D

Commit a57f4e2cf00da902610a6640507797e6eff071e5 already prevents managing other interfaces, for example docker and vpn interfaces (which should not be managed by netplan), but this makes it even less likely to match a wrong interface name.

# Documentation summary for feature / change

I'm guessing the documentation will be automatically generated into here: https://docs.armbian.com/User-Guide_Networking/#default-armbian-configuration ? Please correct me if something needs to be done.

# How Has This Been Tested?

* Edited and applied the config file locally on my radxa zero 3w, tested that network continues to work as expected.

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
