### PR TITLE
sunxi-6.6: switch to v6.6.50, re-extract patches

### DIFF
--- a/config/sources/families/include/sunxi64_common.inc
+++ b/config/sources/families/include/sunxi64_common.inc
@@ -30,7 +30,7 @@ case $BRANCH in
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.6.44"
+		declare -g KERNELBRANCH="tag:v6.6.50"
 		;;
 
 	edge)

--- a/config/sources/families/include/sunxi_common.inc
+++ b/config/sources/families/include/sunxi_common.inc
@@ -31,7 +31,7 @@ case $BRANCH in
 
 	current)
 		declare -g KERNEL_MAJOR_MINOR="6.6" # Major and minor versions of this kernel.
-		declare -g KERNELBRANCH="tag:v6.6.44"
+		declare -g KERNELBRANCH="tag:v6.6.50"
 		;;
 
 	edge)

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/ARM64-dts-sun50i-h616-BigTreeTech-CB1-Enable-EMAC1.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/ARM64-dts-sun50i-h616-BigTreeTech-CB1-Enable-EMAC1.patch
@@ -1,20 +1,18 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From db077486d19a00ad0bb59da1bf2c2f7633cf0ec4 Mon Sep 17 00:00:00 2001
 From: JohnTheCoolingFan <ivan8215145640@gmail.com>
 Date: Thu, 13 Jun 2024 11:50:55 +0000
 Subject: ARM64: dts: sun50i-h616: BigTreeTech CB1: Enable EMAC1
 
 Signed-off-by: JohnTheCoolingFan <ivan8215145640@gmail.com>
 ---
- arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi | 18 ++++++++++
+ .../allwinner/sun50i-h616-bigtreetech-cb1.dtsi | 18 ++++++++++++++++++
  1 file changed, 18 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
-index bbff30ccf..b98e85a51 100644
+index bbff30ccf5a9..b98e85a51261 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
-@@ -142,10 +142,28 @@ mcp2515_clock: mcp2515_clock {
- 		#clock-cells = <0>;
- 		clock-frequency  = <12000000>;
+@@ -144,6 +144,24 @@ mcp2515_clock: mcp2515_clock {
  	};
  };
  
@@ -39,8 +37,6 @@ index bbff30ccf..b98e85a51 100644
  &mmc0 {
  	vmmc-supply = <&reg_dldo1>;
  	broken-cd;
- 	bus-width = <4>;
- 	max-frequency = <50000000>;
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+2.35.3
 

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/ARM64-dts-sun50i-h616-BigTreeTech-CB1-Enable-HDMI.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/ARM64-dts-sun50i-h616-BigTreeTech-CB1-Enable-HDMI.patch
@@ -1,20 +1,18 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From d5b75d642454ebc118116da157cbd6cd47fff18d Mon Sep 17 00:00:00 2001
 From: JohnTheCoolingFan <ivan8215145640@gmail.com>
 Date: Thu, 13 Jun 2024 11:07:35 +0000
 Subject: ARM64: dts: sun50i-h616: BigTreeTech CB1: Enable HDMI
 
 Signed-off-by: JohnTheCoolingFan <ivan8215145640@gmail.com>
 ---
- arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi | 26 ++++++++++
+ .../sun50i-h616-bigtreetech-cb1.dtsi          | 26 +++++++++++++++++++
  1 file changed, 26 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
-index e82da4b6e..bbff30ccf 100644
+index e82da4b6e340..bbff30ccf5a9 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
-@@ -23,10 +23,21 @@ aliases {
- 
- 	chosen {
+@@ -25,6 +25,17 @@ chosen {
  		stdout-path = "serial0:115200n8";
  	};
  
@@ -32,11 +30,7 @@ index e82da4b6e..bbff30ccf 100644
  	leds {
  		compatible = "gpio-leds";
  
- 		act_led: led-0 {
- 			gpios = <&pio 7 5 GPIO_ACTIVE_LOW>; /* PH5 */
-@@ -255,10 +266,25 @@ reg_dldo1: dldo1 {
- 			};
- 		};
+@@ -257,6 +268,21 @@ reg_dldo1: dldo1 {
  	};
  };
  
@@ -58,8 +52,6 @@ index e82da4b6e..bbff30ccf 100644
  &cpu0 {
  	cpu-supply = <&reg_dcdc2>;
  	status = "okay";
- };
- 
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+2.35.3
 

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/ARM64-dts-sun50i-h616-BigTreeTech-CB1-Enable-IR-receiver.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/ARM64-dts-sun50i-h616-BigTreeTech-CB1-Enable-IR-receiver.patch
@@ -1,20 +1,18 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 829920ddfcb5ede0daf50c19c51da340dc3d3fae Mon Sep 17 00:00:00 2001
 From: JohnTheCoolingFan <ivan8215145640@gmail.com>
 Date: Mon, 12 Aug 2024 14:50:16 +0000
 Subject: ARM64: dts: sun50i-h616: BigTreeTech CB1: Enable IR receiver
 
 Signed-off-by: JohnTheCoolingFan <ivan8215145640@gmail.com>
 ---
- arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi | 4 ++++
+ .../arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi | 4 ++++
  1 file changed, 4 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
-index b98e85a51..c2e20408c 100644
+index b98e85a51261..c2e20408cb66 100644
 --- a/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
-@@ -352,10 +352,14 @@ &ehci3 {
- 
- &ohci3 {
+@@ -354,6 +354,10 @@ &ohci3 {
  	status = "okay";
  };
  
@@ -25,8 +23,6 @@ index b98e85a51..c2e20408c 100644
  &usbotg {
  	/*
  	 * PHY0 pins are connected to a USB-C socket, but a role switch
- 	 * is not implemented: both CC pins are pulled to GND.
- 	 * The VBUS pins power the device, so a fixed peripheral mode
 -- 
-Created with Armbian build tools https://github.com/armbian/build
+2.35.3
 

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/Add-wifi-nodes-for-Inovato-Quadra.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/Add-wifi-nodes-for-Inovato-Quadra.patch
@@ -1,4 +1,4 @@
-From 68e3c93f16478ac7a1fe2d64b79c76b96e5782f6 Mon Sep 17 00:00:00 2001
+From fadd70613a61331f6f95f3c3ba4d47de81a36f6d Mon Sep 17 00:00:00 2001
 From: Gunjan Gupta <viraniac@gmail.com>
 Date: Tue, 19 Sep 2023 11:06:01 +0000
 Subject: Add wifi nodes for Inovato Quadra
@@ -10,10 +10,10 @@ Subject: Add wifi nodes for Inovato Quadra
  create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h6-inovato-quadra.dts
 
 diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
-index ad82da8e2aad..8b504ee408e7 100644
+index 1a37d4ec9a60..468d3f235490 100644
 --- a/arch/arm64/boot/dts/allwinner/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/Makefile
-@@ -48,6 +48,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-orangepi-one-plus.dtb
+@@ -49,6 +49,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-orangepi-one-plus.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-pine-h64.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-pine-h64-model-b.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6.dtb

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/Sound-for-H616-H618-Allwinner-SOCs.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/Sound-for-H616-H618-Allwinner-SOCs.patch
@@ -1,4 +1,4 @@
-From 1a8ee4f49169293e1144c2297db537a1e7de63ed Mon Sep 17 00:00:00 2001
+From a79a7298a4f883ae0a09338b9eb4d4d475b88bed Mon Sep 17 00:00:00 2001
 From: Stephen Graf <stephen.graf@gmail.com>
 Date: Thu, 9 May 2024 20:59:34 -0700
 Subject: Sound for H616, H618 Allwinner SOCs

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/add-bigtreetech-cb1-dts.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/add-bigtreetech-cb1-dts.patch
@@ -1,4 +1,4 @@
-From bbd85618d5e4ba7921e3ac2b648a137d48004022 Mon Sep 17 00:00:00 2001
+From e5d1534191477274938e2746f6190688c037028b Mon Sep 17 00:00:00 2001
 From: Your Name <you@example.com>
 Date: Tue, 30 May 2023 10:18:55 +0800
 Subject: add bigtreetech-cb1 dts
@@ -14,10 +14,10 @@ Subject: add bigtreetech-cb1 dts
  create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h616-bigtreetech-cb1.dtsi
 
 diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
-index 4d4d2e5c01f2..74a6e5e0d7b3 100644
+index 4759f09a89cc..443344f664b8 100644
 --- a/arch/arm64/boot/dts/allwinner/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/Makefile
-@@ -50,6 +50,8 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6.dtb
+@@ -51,6 +51,8 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6-mini.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-orangepi-zero2.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-x96-mate.dtb

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/add-initial-support-for-orangepi3-lts.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/add-initial-support-for-orangepi3-lts.patch
@@ -1,4 +1,4 @@
-From d476463d4e4271266bfdc2fbec353810fbaa5165 Mon Sep 17 00:00:00 2001
+From e4c7a32b8cf8a75a6472d6cf41681fc68809bbda Mon Sep 17 00:00:00 2001
 From: The-going <48602507+The-going@users.noreply.github.com>
 Date: Sat, 16 Apr 2022 11:51:35 +0300
 Subject: add initial support for orangepi3-lts
@@ -10,10 +10,10 @@ Subject: add initial support for orangepi3-lts
  create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h6-orangepi-3-lts.dts
 
 diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
-index fd2f4f11e1fb..ad82da8e2aad 100644
+index cedf4d9bb14d..1a37d4ec9a60 100644
 --- a/arch/arm64/boot/dts/allwinner/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/Makefile
-@@ -42,6 +42,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-zero-plus.dtb
+@@ -43,6 +43,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-zero-plus.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-zero-plus2.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-beelink-gs1.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-orangepi-3.dtb

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arch-arm64-dts-allwinner-sun50i-h618-bananapi-m4-zero.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arch-arm64-dts-allwinner-sun50i-h618-bananapi-m4-zero.patch
@@ -1,4 +1,4 @@
-From e13a5648e7b0cadac49af05ac7452771253b0f73 Mon Sep 17 00:00:00 2001
+From ae6338d484fb29a3ecf30dee62af2811dfcfe54f Mon Sep 17 00:00:00 2001
 From: Patrick Yavitz <pyavitz@xxxxx.com>
 Date: Sun, 17 Mar 2024 18:54:24 -0400
 Subject: arch: arm64: dts: allwinner: sun50i-h618-bananapi-m4-zero
@@ -11,10 +11,10 @@ Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
  create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h618-bananapi-m4-zero.dts
 
 diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
-index 74a6e5e0d7b3..fd2f4f11e1fb 100644
+index 443344f664b8..cedf4d9bb14d 100644
 --- a/arch/arm64/boot/dts/allwinner/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/Makefile
-@@ -52,6 +52,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-orangepi-zero2.dtb
+@@ -53,6 +53,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-orangepi-zero2.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-x96-mate.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-sd.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-emmc.dtb

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm-dts-Add-sun8i-h2-plus-nanopi-duo-device.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm-dts-Add-sun8i-h2-plus-nanopi-duo-device.patch
@@ -1,4 +1,4 @@
-From d1c82c30050a9447f25890a4099701f039794f4b Mon Sep 17 00:00:00 2001
+From 92f42429ec083b513f51e0316b35b6a52db4f4c4 Mon Sep 17 00:00:00 2001
 From: The-going <48602507+The-going@users.noreply.github.com>
 Date: Mon, 24 Jan 2022 15:00:36 +0300
 Subject: arm:dts: Add sun8i-h2-plus-nanopi-duo device
@@ -10,10 +10,10 @@ Subject: arm:dts: Add sun8i-h2-plus-nanopi-duo device
  create mode 100644 arch/arm/boot/dts/allwinner/sun8i-h2-plus-nanopi-duo.dts
 
 diff --git a/arch/arm/boot/dts/allwinner/Makefile b/arch/arm/boot/dts/allwinner/Makefile
-index eebb5a0c873a..5833777340fd 100644
+index 296be33ec934..aa134fdf6905 100644
 --- a/arch/arm/boot/dts/allwinner/Makefile
 +++ b/arch/arm/boot/dts/allwinner/Makefile
-@@ -281,6 +281,7 @@ dtb-$(CONFIG_MACH_SUN8I) += \
+@@ -220,6 +220,7 @@ dtb-$(CONFIG_MACH_SUN8I) += \
  	sun8i-a83t-tbs-a711.dtb \
  	sun8i-h2-plus-bananapi-m2-zero.dtb \
  	sun8i-h2-plus-libretech-all-h3-cc.dtb \

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm-dts-Add-sun8i-h2-plus-sunvell-r69-device.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm-dts-Add-sun8i-h2-plus-sunvell-r69-device.patch
@@ -1,4 +1,4 @@
-From ec9bef87e3b1cbcd2d32f012ce1ed264beb36c09 Mon Sep 17 00:00:00 2001
+From f739483dd0fca0a83e01b2ab9e3bef15e31db864 Mon Sep 17 00:00:00 2001
 From: The-going <48602507+The-going@users.noreply.github.com>
 Date: Mon, 24 Jan 2022 15:23:33 +0300
 Subject: arm:dts: Add sun8i-h2-plus-sunvell-r69 device
@@ -10,10 +10,10 @@ Subject: arm:dts: Add sun8i-h2-plus-sunvell-r69 device
  create mode 100644 arch/arm/boot/dts/allwinner/sun8i-h2-plus-sunvell-r69.dts
 
 diff --git a/arch/arm/boot/dts/allwinner/Makefile b/arch/arm/boot/dts/allwinner/Makefile
-index 5833777340fd..cf12179accb7 100644
+index aa134fdf6905..055d241d7851 100644
 --- a/arch/arm/boot/dts/allwinner/Makefile
 +++ b/arch/arm/boot/dts/allwinner/Makefile
-@@ -284,6 +284,7 @@ dtb-$(CONFIG_MACH_SUN8I) += \
+@@ -223,6 +223,7 @@ dtb-$(CONFIG_MACH_SUN8I) += \
  	sun8i-h2-plus-nanopi-duo.dtb \
  	sun8i-h2-plus-orangepi-r1.dtb \
  	sun8i-h2-plus-orangepi-zero.dtb \

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm-dts-overlay-Add-Overlays-for-sunxi.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm-dts-overlay-Add-Overlays-for-sunxi.patch
@@ -1,4 +1,4 @@
-From 3cf9b6e35340b89f11cb0911e03bbfd963ca5f4b Mon Sep 17 00:00:00 2001
+From fdcda15280ded628172403d36b0a421b1f6477de Mon Sep 17 00:00:00 2001
 From: The-going <48602507+The-going@users.noreply.github.com>
 Date: Wed, 2 Feb 2022 12:54:05 +0300
 Subject: arm:dts:overlay Add Overlays for sunxi
@@ -200,10 +200,10 @@ Subject: arm:dts:overlay Add Overlays for sunxi
  create mode 100644 arch/arm/boot/dts/allwinner/overlay/sun8i-r40-uart7.dtso
 
 diff --git a/arch/arm/boot/dts/allwinner/Makefile b/arch/arm/boot/dts/allwinner/Makefile
-index cf12179accb7..bd7f5c844e21 100644
+index 055d241d7851..4104f83a2d33 100644
 --- a/arch/arm/boot/dts/allwinner/Makefile
 +++ b/arch/arm/boot/dts/allwinner/Makefile
-@@ -334,3 +334,5 @@ dtb-$(CONFIG_MACH_SUNIV) += \
+@@ -272,3 +272,5 @@ dtb-$(CONFIG_MACH_SUNIV) += \
  	suniv-f1c100s-licheepi-nano.dtb \
  	suniv-f1c200s-lctech-pi.dtb \
  	suniv-f1c200s-popstick-v1.1.dtb

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-Add-sun50i-h5-nanopi-k1-plus-device.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-Add-sun50i-h5-nanopi-k1-plus-device.patch
@@ -1,4 +1,4 @@
-From c58846e90da14ec10cf697032867990cb63d5a07 Mon Sep 17 00:00:00 2001
+From c5b9ec529a75394b533c5aa7d1dacbb859893c90 Mon Sep 17 00:00:00 2001
 From: wuweidong <625769020@qq.com>
 Date: Mon, 27 Nov 2017 10:23:51 +0800
 Subject: arm64:dts: Add sun50i-h5-nanopi-k1-plus device
@@ -10,10 +10,10 @@ Subject: arm64:dts: Add sun50i-h5-nanopi-k1-plus device
  create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-k1-plus.dts
 
 diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
-index 358efa5d6abc..29c44ac36599 100644
+index 94aaf6384267..a31fbac871a1 100644
 --- a/arch/arm64/boot/dts/allwinner/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/Makefile
-@@ -28,6 +28,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo2.dtb
+@@ -29,6 +29,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo2.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo-plus2.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-r1s-h5.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-pc2.dtb

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-Add-sun50i-h5-nanopi-m1-plus2-device.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-Add-sun50i-h5-nanopi-m1-plus2-device.patch
@@ -1,4 +1,4 @@
-From dda53c73e018e9599dc9d0e637ca01308e1340a8 Mon Sep 17 00:00:00 2001
+From 2852a163f264003f0c436fc7b37ad49f32a22783 Mon Sep 17 00:00:00 2001
 From: The-going <48602507+The-going@users.noreply.github.com>
 Date: Mon, 24 Jan 2022 18:54:36 +0300
 Subject: arm64:dts: Add sun50i-h5-nanopi-m1-plus2 device
@@ -10,10 +10,10 @@ Subject: arm64:dts: Add sun50i-h5-nanopi-m1-plus2 device
  create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-m1-plus2.dts
 
 diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
-index 0250c273de9c..9d813575ca26 100644
+index 8f360b752ad4..b27d424e7731 100644
 --- a/arch/arm64/boot/dts/allwinner/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/Makefile
-@@ -31,6 +31,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo-core2.dtb
+@@ -32,6 +32,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo-core2.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-r1s-h5.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-orangepi-pc2.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-k1-plus.dtb

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-Add-sun50i-h5-nanopi-neo-core2-device.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-Add-sun50i-h5-nanopi-neo-core2-device.patch
@@ -1,4 +1,4 @@
-From 5b2ce3f3ca2aa45dfd3a77a9a5e810f46056fa69 Mon Sep 17 00:00:00 2001
+From 0b19525b9c5d54d2559b26fb0ebf4e4730fef612 Mon Sep 17 00:00:00 2001
 From: The-going <48602507+The-going@users.noreply.github.com>
 Date: Mon, 24 Jan 2022 18:43:42 +0300
 Subject: arm64:dts: Add sun50i-h5-nanopi-neo-core2 device
@@ -10,10 +10,10 @@ Subject: arm64:dts: Add sun50i-h5-nanopi-neo-core2 device
  create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-neo-core2.dts
 
 diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
-index 29c44ac36599..1764856f6c2d 100644
+index a31fbac871a1..aa75246ef731 100644
 --- a/arch/arm64/boot/dts/allwinner/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/Makefile
-@@ -26,6 +26,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-libretech-all-h3-it.dtb
+@@ -27,6 +27,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-libretech-all-h3-it.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-libretech-all-h5-cc.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo2.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo-plus2.dtb

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-Add-sun50i-h5-nanopi-neo2-v1.1-device.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-Add-sun50i-h5-nanopi-neo2-v1.1-device.patch
@@ -1,4 +1,4 @@
-From 5cd23fb9d4492ddbed0bfebcc838c9115e5419cf Mon Sep 17 00:00:00 2001
+From 4d2f3d661acacf474f7af7e3603886d75b2a4edc Mon Sep 17 00:00:00 2001
 From: The-going <48602507+The-going@users.noreply.github.com>
 Date: Mon, 24 Jan 2022 18:49:55 +0300
 Subject: arm64:dts: Add sun50i-h5-nanopi-neo2-v1.1 device
@@ -10,10 +10,10 @@ Subject: arm64:dts: Add sun50i-h5-nanopi-neo2-v1.1 device
  create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h5-nanopi-neo2-v1.1.dts
 
 diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
-index 1764856f6c2d..0250c273de9c 100644
+index aa75246ef731..8f360b752ad4 100644
 --- a/arch/arm64/boot/dts/allwinner/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/Makefile
-@@ -25,6 +25,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-libretech-all-h3-cc.dtb
+@@ -26,6 +26,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-libretech-all-h3-cc.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-libretech-all-h3-it.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-libretech-all-h5-cc.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-nanopi-neo2.dtb

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-allwinner-overlay-Add-Overlays-for-sunxi64.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-allwinner-overlay-Add-Overlays-for-sunxi64.patch
@@ -1,4 +1,4 @@
-From 44a30e3d24d0930e8eade41e0ece23559a47a013 Mon Sep 17 00:00:00 2001
+From 4ff893fe0318e3dc386ddc9399155b2a88f9106e Mon Sep 17 00:00:00 2001
 From: The-going <48602507+The-going@users.noreply.github.com>
 Date: Wed, 2 Feb 2022 13:02:10 +0300
 Subject: arm64:dts:allwinner:overlay: Add Overlays for sunxi64
@@ -104,10 +104,10 @@ Subject: arm64:dts:allwinner:overlay: Add Overlays for sunxi64
  create mode 100644 arch/arm64/boot/dts/allwinner/overlay/sun50i-h6-w1-gpio.dtso
 
 diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
-index 9d813575ca26..54424ab784a5 100644
+index b27d424e7731..b6d5142c2b01 100644
 --- a/arch/arm64/boot/dts/allwinner/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/Makefile
-@@ -46,3 +46,5 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6-mini.dtb
+@@ -47,3 +47,5 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6-mini.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-orangepi-zero2.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-x96-mate.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-orangepi-zero3.dtb

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-sun50i-h313-x96q-lpddr3.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/arm64-dts-sun50i-h313-x96q-lpddr3.patch
@@ -1,8 +1,23 @@
+From 09ae685141a5a584f5dca0866efeb877ee4d2105 Mon Sep 17 00:00:00 2001
+From: The-going <48602507+The-going@users.noreply.github.com>
+Date: Sun, 8 Sep 2024 18:43:14 +0300
+Subject: [PATCH] arm64: dts: sun50i-h313-x96q-lpddr3
+
+Author: sic <31908995+sicXnull@users.noreply.github.com>  2024-08-20
+Add Board X96Q TV Box LPDDR3 H313 (#7101)
+
+Signed-off-by: The-going <48602507+The-going@users.noreply.github.com>
+---
+ arch/arm64/boot/dts/allwinner/Makefile        |   1 +
+ .../dts/allwinner/sun50i-h313-x96q-lpddr3.dts | 491 ++++++++++++++++++
+ 2 files changed, 492 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h313-x96q-lpddr3.dts
+
 diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
-index a957365..812685d 100644
+index 358efa5d6abc..94aaf6384267 100644
 --- a/arch/arm64/boot/dts/allwinner/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/Makefile
-@@ -23,6 +23,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-a64-pinetab-early-adopter.dtb
+@@ -18,6 +18,7 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-a64-pinetab-early-adopter.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-a64-sopine-baseboard.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-a64-teres-i.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-a100-allwinner-perf1.dtb
@@ -10,10 +25,9 @@ index a957365..812685d 100644
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-bananapi-m2-plus.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-bananapi-m2-plus-v1.2.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h5-emlid-neutis-n5-devboard.dtb
-
 diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h313-x96q-lpddr3.dts b/arch/arm64/boot/dts/allwinner/sun50i-h313-x96q-lpddr3.dts
 new file mode 100644
-index 0000000..ba48e0d
+index 000000000000..ba48e0dcbdee
 --- /dev/null
 +++ b/arch/arm64/boot/dts/allwinner/sun50i-h313-x96q-lpddr3.dts
 @@ -0,0 +1,491 @@
@@ -508,4 +522,6 @@ index 0000000..ba48e0d
 +		function = "pwm5";
 +	};
 +};
+-- 
+2.35.3
 

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/driver-allwinner-h618-emac.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/driver-allwinner-h618-emac.patch
@@ -1,4 +1,4 @@
-From 9eb9f2e36907405e3644fb1434652a7a13116ad8 Mon Sep 17 00:00:00 2001
+From b5ca1302f9a2cd6abe9dff77cc9e0b71ec81b3bb Mon Sep 17 00:00:00 2001
 From: chraac <chraac@gmail.com>
 Date: Wed, 1 May 2024 14:32:00 +0800
 Subject: driver: allwinner h618 emac
@@ -29,7 +29,7 @@ commit:
  create mode 100644 include/linux/mfd/ac200.h
 
 diff --git a/drivers/gpio/gpiolib-of.c b/drivers/gpio/gpiolib-of.c
-index d9525d95e818..6842f90f9efe 100644
+index cec9e8f29bbd..5ad3ebcb8c2e 100644
 --- a/drivers/gpio/gpiolib-of.c
 +++ b/drivers/gpio/gpiolib-of.c
 @@ -25,21 +25,6 @@
@@ -54,7 +54,7 @@ index d9525d95e818..6842f90f9efe 100644
  /**
   * of_gpio_named_count() - Count GPIOs for a device
   * @np:		device node to count GPIOs for
-@@ -398,6 +383,20 @@ static struct gpio_desc *of_get_named_gpiod_flags(const struct device_node *np,
+@@ -416,6 +401,20 @@ static struct gpio_desc *of_get_named_gpiod_flags(const struct device_node *np,
  	return desc;
  }
  
@@ -97,7 +97,7 @@ index caed5e75d11f..e532334e024f 100644
  	tristate
  	select MFD_CORE
 diff --git a/drivers/mfd/Makefile b/drivers/mfd/Makefile
-index 0c3b4aaf4eb7..bc180cf44009 100644
+index f03188b74d62..f0127d83609a 100644
 --- a/drivers/mfd/Makefile
 +++ b/drivers/mfd/Makefile
 @@ -141,6 +141,7 @@ obj-$(CONFIG_MFD_DA9052_I2C)	+= da9052-i2c.o

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/drv-gpu-drm-panel-simple-Add-compability-olinuxino-lcd.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/drv-gpu-drm-panel-simple-Add-compability-olinuxino-lcd.patch
@@ -1,4 +1,4 @@
-From 3f4dde3f169acdc6f2421a121541836c5ae62f63 Mon Sep 17 00:00:00 2001
+From d7f5ad32894db824abb0aaaf8bedfbd6205a69a7 Mon Sep 17 00:00:00 2001
 From: The-going <48602507+The-going@users.noreply.github.com>
 Date: Wed, 2 Feb 2022 19:34:55 +0300
 Subject: drv:gpu:drm: panel-simple Add compability olinuxino lcd
@@ -8,10 +8,10 @@ Subject: drv:gpu:drm: panel-simple Add compability olinuxino lcd
  1 file changed, 122 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/gpu/drm/panel/panel-simple.c b/drivers/gpu/drm/panel/panel-simple.c
-index e8d12ec8dbec..cad1bcd383b7 100644
+index 11ade6bac592..a3305a27c7b7 100644
 --- a/drivers/gpu/drm/panel/panel-simple.c
 +++ b/drivers/gpu/drm/panel/panel-simple.c
-@@ -3103,6 +3103,44 @@ static const struct panel_desc okaya_rs800480t_7x0gp = {
+@@ -3104,6 +3104,44 @@ static const struct panel_desc okaya_rs800480t_7x0gp = {
  	.bus_format = MEDIA_BUS_FMT_RGB666_1X18,
  };
  
@@ -56,7 +56,7 @@ index e8d12ec8dbec..cad1bcd383b7 100644
  static const struct drm_display_mode olimex_lcd_olinuxino_43ts_mode = {
  	.clock = 9000,
  	.hdisplay = 480,
-@@ -3115,8 +3153,8 @@ static const struct drm_display_mode olimex_lcd_olinuxino_43ts_mode = {
+@@ -3116,8 +3154,8 @@ static const struct drm_display_mode olimex_lcd_olinuxino_43ts_mode = {
  	.vtotal = 272 + 8 + 5 + 3,
  };
  
@@ -67,7 +67,7 @@ index e8d12ec8dbec..cad1bcd383b7 100644
  	.num_modes = 1,
  	.size = {
  		.width = 95,
-@@ -3125,6 +3163,71 @@ static const struct panel_desc olimex_lcd_olinuxino_43ts = {
+@@ -3126,6 +3164,71 @@ static const struct panel_desc olimex_lcd_olinuxino_43ts = {
  	.bus_format = MEDIA_BUS_FMT_RGB888_1X24,
  };
  
@@ -139,7 +139,7 @@ index e8d12ec8dbec..cad1bcd383b7 100644
  /*
   * 800x480 CVT. The panel appears to be quite accepting, at least as far as
   * pixel clocks, but this is the timing that was being used in the Adafruit
-@@ -4393,8 +4496,23 @@ static const struct of_device_id platform_of_match[] = {
+@@ -4394,8 +4497,23 @@ static const struct of_device_id platform_of_match[] = {
  		.compatible = "okaya,rs800480t-7x0gp",
  		.data = &okaya_rs800480t_7x0gp,
  	}, {

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/drv-spi-spidev-Add-armbian-spi-dev-compatible.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/drv-spi-spidev-Add-armbian-spi-dev-compatible.patch
@@ -11,15 +11,15 @@ diff --git a/drivers/spi/spidev.c b/drivers/spi/spidev.c
 index d13dc15cc191..456eca57ee4f 100644
 --- a/drivers/spi/spidev.c
 +++ b/drivers/spi/spidev.c
-@@ -704,6 +704,7 @@ static const struct file_operations spidev_fops = {
- static struct class *spidev_class;
- 
- static const struct spi_device_id spidev_spi_ids[] = {
-+	{ .name = "spi-dev" },
+@@ -707,6 +707,7 @@ static const struct spi_device_id spidev_spi_ids[] = {
+ 	{ .name = "bh2228fv" },
  	{ .name = "dh2228fv" },
  	{ .name = "ltc2488" },
++	{ .name = "spi-dev" },
  	{ .name = "sx1301" },
-@@ -728,10 +729,12 @@ static int spidev_of_check(struct device *dev)
+ 	{ .name = "bk4" },
+ 	{ .name = "dhcom-board" },
+@@ -729,10 +730,12 @@ static int spidev_of_check(struct device *dev)
  		return 0;
  
  	dev_err(dev, "spidev listed directly in DT is not supported\n");

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/orangepi-zero2w-add-dtb.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/orangepi-zero2w-add-dtb.patch
@@ -1,4 +1,4 @@
-From aeccb62b0f4c6891a09790f5f4546dff8cc60815 Mon Sep 17 00:00:00 2001
+From 1f4f2ce3a2866697b2abdb7b51b10ddaaf2fdc66 Mon Sep 17 00:00:00 2001
 From: chraac <chraac@gmail.com>
 Date: Fri, 15 Mar 2024 12:30:26 +0800
 Subject: orangepi-zero2w add dtb
@@ -11,10 +11,10 @@ Subject: orangepi-zero2w add dtb
  create mode 100644 arch/arm64/boot/dts/allwinner/sun50i-h618-orangepi-zero2w.dts
 
 diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
-index 8b504ee408e7..a957365edc1a 100644
+index 468d3f235490..812685d6740f 100644
 --- a/arch/arm64/boot/dts/allwinner/Makefile
 +++ b/arch/arm64/boot/dts/allwinner/Makefile
-@@ -56,5 +56,6 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-sd.dtb
+@@ -57,5 +57,6 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-sd.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-bigtreetech-cb1-emmc.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-bananapi-m4-zero.dtb
  dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-orangepi-zero3.dtb

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/scripts-add-overlay-compilation-support.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/scripts-add-overlay-compilation-support.patch
@@ -1,12 +1,12 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 3a60accf09317a9a81a208c3629fe933aad34608 Mon Sep 17 00:00:00 2001
 From: The-going <48602507+The-going@users.noreply.github.com>
 Date: Tue, 1 Feb 2022 21:04:08 +0300
 Subject: scripts: add overlay compilation support
 
 ---
  .gitignore               |  1 +
- scripts/Makefile.dtbinst | 16 ++++++++--
- scripts/Makefile.lib     |  9 ++++++
+ scripts/Makefile.dtbinst | 16 ++++++++++++++--
+ scripts/Makefile.lib     |  9 +++++++++
  3 files changed, 24 insertions(+), 2 deletions(-)
 
 diff --git a/.gitignore b/.gitignore
@@ -22,7 +22,7 @@ index 0bbae167bf93..d790eee1273d 100644
  *.so.dbg
  *.su
 diff --git a/scripts/Makefile.dtbinst b/scripts/Makefile.dtbinst
-index 4405d5b67578..6e3f7fa513d5 100644
+index fa3ad33a19df..8a53d0e1c2f7 100644
 --- a/scripts/Makefile.dtbinst
 +++ b/scripts/Makefile.dtbinst
 @@ -19,8 +19,10 @@ include $(kbuild-file)
@@ -58,7 +58,7 @@ index 4405d5b67578..6e3f7fa513d5 100644
  
  .PHONY: $(PHONY)
 diff --git a/scripts/Makefile.lib b/scripts/Makefile.lib
-index 68d0134bdbf9..8fe35137004f 100644
+index e702552fb131..f3ace21906ae 100644
 --- a/scripts/Makefile.lib
 +++ b/scripts/Makefile.lib
 @@ -88,6 +88,9 @@ base-dtb-y := $(foreach m, $(multi-dtb-y), $(firstword $(call suffix-search, $m,
@@ -71,7 +71,7 @@ index 68d0134bdbf9..8fe35137004f 100644
  # Add subdir path
  
  ifneq ($(obj),.)
-@@ -421,6 +424,12 @@ $(obj)/%.dtb: $(src)/%.dts $(DTC) $(DT_TMP_SCHEMA) FORCE
+@@ -425,6 +428,12 @@ $(obj)/%.dtb: $(src)/%.dts $(DTC) $(DT_TMP_SCHEMA) FORCE
  $(obj)/%.dtbo: $(src)/%.dtso $(DTC) FORCE
  	$(call if_changed_dep,dtc)
  
@@ -85,5 +85,5 @@ index 68d0134bdbf9..8fe35137004f 100644
  
  # Bzip2
 -- 
-Armbian
+2.35.3
 

--- a/patch/kernel/archive/sunxi-6.6/patches.megous/usb-quirks-Add-USB_QUIRK_RESET-for-Quectel-EG25G-Modem.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.megous/usb-quirks-Add-USB_QUIRK_RESET-for-Quectel-EG25G-Modem.patch
@@ -1,4 +1,4 @@
-From d73ef934b16a409b6e9ea83f270981f4c20526fb Mon Sep 17 00:00:00 2001
+From 8d40b77a7e84268c91fa491dba98ddb0122aedc7 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Ond=C5=99ej=20Jirman?= <megi@xff.cz>
 Date: Thu, 18 Feb 2021 07:48:07 +0100
 Subject: usb: quirks: Add USB_QUIRK_RESET for Quectel EG25G Modem
@@ -11,10 +11,10 @@ Signed-off-by: Ondrej Jirman <megi@xff.cz>
  1 file changed, 3 insertions(+)
 
 diff --git a/drivers/usb/core/quirks.c b/drivers/usb/core/quirks.c
-index b4783574b8e6..ecfd4b6ab602 100644
+index 13171454f959..0494c8bb42a7 100644
 --- a/drivers/usb/core/quirks.c
 +++ b/drivers/usb/core/quirks.c
-@@ -549,6 +549,9 @@ static const struct usb_device_id usb_quirk_list[] = {
+@@ -552,6 +552,9 @@ static const struct usb_device_id usb_quirk_list[] = {
  	/* INTEL VALUE SSD */
  	{ USB_DEVICE(0x8086, 0xf1a5), .driver_info = USB_QUIRK_RESET_RESUME },
  

--- a/patch/kernel/archive/sunxi-6.6/series.armbian
+++ b/patch/kernel/archive/sunxi-6.6/series.armbian
@@ -189,7 +189,7 @@
 	patches.armbian/arch-arm64-dts-allwinner-sun50i-h616-spi1-cs1-pin.patch
 	patches.armbian/add-dtb-overlay-for-zero2w.patch
 	patches.armbian/adding-dummy-regulators-in-pinctr-arch-arm-boot-dts-allwinner-s.patch
-	patches.armbian/Sound-for-H616-H618-Allwinner-SOCs-arch-arm64-boot-dts-allwinne.patch
-	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-enable-hdmi.patch
-	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-enable-emac1.patch
-	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-enable-ir-receiver.patch
+	patches.armbian/Sound-for-H616-H618-Allwinner-SOCs.patch
+	patches.armbian/ARM64-dts-sun50i-h616-BigTreeTech-CB1-Enable-HDMI.patch
+	patches.armbian/ARM64-dts-sun50i-h616-BigTreeTech-CB1-Enable-EMAC1.patch
+	patches.armbian/ARM64-dts-sun50i-h616-BigTreeTech-CB1-Enable-IR-receiver.patch

--- a/patch/kernel/archive/sunxi-6.6/series.conf
+++ b/patch/kernel/archive/sunxi-6.6/series.conf
@@ -441,7 +441,7 @@
 	patches.armbian/arch-arm64-dts-allwinner-sun50i-h616-spi1-cs1-pin.patch
 	patches.armbian/add-dtb-overlay-for-zero2w.patch
 	patches.armbian/adding-dummy-regulators-in-pinctr-arch-arm-boot-dts-allwinner-s.patch
-	patches.armbian/Sound-for-H616-H618-Allwinner-SOCs-arch-arm64-boot-dts-allwinne.patch
-	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-enable-hdmi.patch
-	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-enable-emac1.patch
-	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-enable-ir-receiver.patch
+	patches.armbian/Sound-for-H616-H618-Allwinner-SOCs.patch
+	patches.armbian/ARM64-dts-sun50i-h616-BigTreeTech-CB1-Enable-HDMI.patch
+	patches.armbian/ARM64-dts-sun50i-h616-BigTreeTech-CB1-Enable-EMAC1.patch
+	patches.armbian/ARM64-dts-sun50i-h616-BigTreeTech-CB1-Enable-IR-receiver.patch


### PR DESCRIPTION
# Description
- sunxi-6.6: switch to v6.6.50, re-extract patches
- The four patch files were renamed automatically and now correspond to the field in the `Subject:` line.

# How Has This Been Tested?

- [ ] Test build arm
- [ ] Test build arm64
