### PR TITLE
`Userspace` Switching armbian-config to new generation.

### DIFF
--- a/lib/functions/artifacts/artifact-armbian-config.sh
+++ b/lib/functions/artifacts/artifact-armbian-config.sh
@@ -15,8 +15,8 @@ function artifact_armbian-config_prepare_version() {
 	artifact_version="undetermined"        # outer scope
 	artifact_version_reason="undetermined" # outer scope
 
-	local ARMBIAN_CONFIG_SOURCE="${ARMBIAN_CONFIG_SOURCE:-"https://github.com/armbian/config"}"
-	local ARMBIAN_CONFIG_BRANCH="branch:${ARMBIAN_CONFIG_BRANCH:-"master"}"
+	local ARMBIAN_CONFIG_SOURCE="${ARMBIAN_CONFIG_SOURCE:-"https://github.com/armbian/configng"}"
+	local ARMBIAN_CONFIG_BRANCH="branch:${ARMBIAN_CONFIG_BRANCH:-"main"}"
 
 	debug_var ARMBIAN_CONFIG_SOURCE
 	debug_var ARMBIAN_CONFIG_BRANCH

--- a/lib/functions/compilation/packages/armbian-config-deb.sh
+++ b/lib/functions/compilation/packages/armbian-config-deb.sh
@@ -18,22 +18,26 @@ compile_armbian-config() {
 	declare armbian_config_dir="armbian-config"
 	mkdir -p "${tmp_dir}/${armbian_config_dir}"
 
-	local ARMBIAN_CONFIG_GIT_SOURCE="${ARMBIAN_FIRMWARE_GIT_SOURCE:-"https://github.com/armbian/config"}"
-	local ARMBIAN_CONFIG_GIT_BRANCH="${ARMBIAN_FIRMWARE_GIT_BRANCH:-"master"}"
+	local ARMBIAN_CONFIG_GIT_SOURCE="${ARMBIAN_FIRMWARE_GIT_SOURCE:-"https://github.com/armbian/configng"}"
+	local ARMBIAN_CONFIG_GIT_BRANCH="${ARMBIAN_FIRMWARE_GIT_BRANCH:-"main"}"
 
-	fetch_from_repo "https://github.com/armbian/config" "armbian-config" "branch:master"
 	# this is also not getting any updates
-	fetch_from_repo "https://github.com/dylanaraps/neofetch" "neofetch" "tag:7.1.0"
+	fetch_from_repo "$GITHUB_SOURCE/dylanaraps/neofetch" "neofetch" "tag:7.1.0"
+	fetch_from_repo "$GITHUB_SOURCE/armbian/configng" "armbian-config" "branch:main"
+	fetch_from_repo "$GITHUB_SOURCE/complexorganizations/wireguard-manager" "wireguard-manager" "branch:main"
 
 	# Fetch Armbian config from git.
 	declare fetched_revision
 	do_checkout="no" fetch_from_repo "${ARMBIAN_CONFIG_GIT_SOURCE}" "armbian-config-git" "branch:${ARMBIAN_CONFIG_GIT_BRANCH}"
 	declare -r armbian_firmware_git_sha1="${fetched_revision}"
 
+	# Compile Armbian config
+	${SRC}/cache/sources/armbian-config/tools/config-assemble.sh -p
+
 	# @TODO: move this to where it is actually used; not everyone needs to pull this in
 	fetch_from_repo "$GITHUB_SOURCE/complexorganizations/wireguard-manager" "wireguard-manager" "branch:main"
 
-	mkdir -p "${tmp_dir}/${armbian_config_dir}"/{DEBIAN,usr/bin/,usr/sbin/,usr/lib/armbian-config/}
+	mkdir -p "${tmp_dir}/${armbian_config_dir}"/{DEBIAN,bin/,lib/armbian-config/,usr/bin/,/etc/apt/sources.list.d/}
 
 	cd "${tmp_dir}/${armbian_config_dir}" || exit_with_error "can't change directory"
 
@@ -43,31 +47,29 @@ compile_armbian-config() {
 		Version: ${artifact_version}
 		Architecture: all
 		Maintainer: $MAINTAINER <$MAINTAINERMAIL>
-		Depends: bash, iperf3, psmisc, curl, bc, expect, dialog, pv, zip, debconf-utils, unzip, build-essential, html2text, html2text, dirmngr, software-properties-common, debconf, jq
-		Suggests: libpam-google-authenticator, qrencode, network-manager, sunxi-tools
+		Depends: whiptail, jq, sudo, procps, systemd, iproute2
 		Section: utils
 		Priority: optional
-		Description: Armbian configuration utility
+		Description: Armbian configuration utility - The new generation
 	END
 
 	install -m 755 "${SRC}"/cache/sources/neofetch/neofetch "${tmp_dir}/${armbian_config_dir}"/usr/bin/neofetch
 	cd "${tmp_dir}/${armbian_config_dir}"/usr/bin/ || exit_with_error "Failed to cd to ${tmp_dir}/${armbian_config_dir}/usr/bin/"
 	process_patch_file "${SRC}/patch/misc/add-armbian-neofetch.patch" "applying"
 
+	# 3rd party utilities
 	install -m 755 "${SRC}"/cache/sources/wireguard-manager/wireguard-manager.sh "${tmp_dir}/${armbian_config_dir}"/usr/bin/wireguard-manager
-	install -m 755 "${SRC}"/cache/sources/armbian-config/scripts/tv_grab_file "${tmp_dir}/${armbian_config_dir}"/usr/bin/tv_grab_file
-	install -m 755 "${SRC}"/cache/sources/armbian-config/debian-config "${tmp_dir}/${armbian_config_dir}"/usr/sbin/armbian-config
-	install -m 644 "${SRC}"/cache/sources/armbian-config/debian-config-jobs "${tmp_dir}/${armbian_config_dir}"/usr/lib/armbian-config/jobs.sh
-	install -m 644 "${SRC}"/cache/sources/armbian-config/debian-config-submenu "${tmp_dir}/${armbian_config_dir}"/usr/lib/armbian-config/submenu.sh
-	install -m 644 "${SRC}"/cache/sources/armbian-config/debian-config-functions "${tmp_dir}/${armbian_config_dir}"/usr/lib/armbian-config/functions.sh
-	install -m 644 "${SRC}"/cache/sources/armbian-config/debian-config-functions-network "${tmp_dir}/${armbian_config_dir}"/usr/lib/armbian-config/functions-network.sh
-	install -m 755 "${SRC}"/cache/sources/armbian-config/softy "${tmp_dir}/${armbian_config_dir}"/usr/sbin/softy
-	# fallback to replace armbian-config in BSP
-	ln -sf /usr/sbin/armbian-config "${tmp_dir}/${armbian_config_dir}"/usr/bin/armbian-config
-	ln -sf /usr/sbin/softy "${tmp_dir}/${armbian_config_dir}"/usr/bin/softy
+
+	# Armbian config parts
+	install -m 755 "${SRC}"/cache/sources/armbian-config/bin/armbian-config "${tmp_dir}/${armbian_config_dir}"/bin/armbian-config
+	cp -R "${SRC}"/cache/sources/armbian-config/lib/armbian-config/ "${tmp_dir}/${armbian_config_dir}"/lib/
+
+	# Add development repository to keep rooling release of this tool
+	cat <<- END > ${tmp_dir}/${armbian_config_dir}/etc/apt/sources.list.d/armbian-config.list
+	deb [signed-by=/usr/share/keyrings/armbian.gpg] https://armbian.github.io/configng stable main
+	END
 
 	dpkg_deb_build "${tmp_dir}/${armbian_config_dir}" "armbian-config"
-
 	done_with_temp_dir "${cleanup_id}" # changes cwd to "${SRC}" and fires the cleanup function early
 
 }

--- a/lib/functions/main/build-packages.sh
+++ b/lib/functions/main/build-packages.sh
@@ -32,9 +32,7 @@ function determine_artifacts_to_build_for_image() {
 	fi
 
 	if [[ "${PACKAGE_LIST_RM}" != *armbian-config* ]]; then
-		if [[ $BUILD_MINIMAL != yes ]]; then
-			artifacts_to_build+=("armbian-config")
-		fi
+		artifacts_to_build+=("armbian-config")
 	fi
 
 	if [[ "${PACKAGE_LIST_RM}" != *armbian-zsh* ]]; then

--- a/lib/functions/rootfs/distro-agnostic.sh
+++ b/lib/functions/rootfs/distro-agnostic.sh
@@ -335,9 +335,7 @@ function install_distribution_agnostic() {
 
 	# install armbian-config
 	if [[ "${PACKAGE_LIST_RM}" != *armbian-config* ]]; then
-		if [[ $BUILD_MINIMAL != yes ]]; then
-			install_artifact_deb_chroot "armbian-config"
-		fi
+		install_artifact_deb_chroot "armbian-config"
 	fi
 
 	# install armbian-zsh


### PR DESCRIPTION
# Description

We had a long sage with complete rework of [main hardware & system config tool](https://github.com/armbian/config). `armbian-config` still works, but it is largely unmaintained and bulky since early days. We tried several ways and failed ... [New tool](https://github.com/armbian/configng) contains all what we learned by failing.

Closing https://github.com/armbian/build/issues/7428

https://docs.armbian.com/User-Guide_Armbian-Software/

Most functions were ported from old config which is the reason we are merging this soon.

# How Has This Been Tested?

- we have unit testing in place, but test cases were not developed / enabled for all functions yet
- tested by developers and there might be bugs ... which should be reported at https://github.com/armbian/configng/issues
- making a minimal CLI image, tool is present and functional out of the box

# Checklist:

- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
