### PR TITLE
BananaPi CM4: `improve SDIO WiFi speeds`

### DIFF
--- a/patch/kernel/archive/meson64-6.10/board-bananapi-cm4-cm4io.patch
+++ b/patch/kernel/archive/meson64-6.10/board-bananapi-cm4-cm4io.patch
@@ -1,9 +1,9 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Patrick Yavitz <pyavitz@xxxxx.com>
+From: Patrick Yavitz <pyavitz@armbian.com>
 Date: Tue, 25 Jul 2023 13:31:54 -0400
 Subject: arch: arm64: dts: amlogic: meson g12b bananapi cm4
 
-Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
+Signed-off-by: Patrick Yavitz <pyavitz@armbian.com>
 ---
  arch/arm64/boot/dts/amlogic/meson-g12b-bananapi-cm4-cm4io.dts |  9 +++++--
  arch/arm64/boot/dts/amlogic/meson-g12b-bananapi-cm4.dtsi      | 12 ++++++++--
@@ -74,4 +74,48 @@ index 111111111111..222222222222 100644
  };
 -- 
 Armbian
+
+From cd42f604cd3298eb563c2d8788cbde1eb8e23970 Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@armbian.com>
+Date: Sun, 8 Sep 2024 05:55:13 -0400
+Subject: [PATCH] BananaPi CM4: improve SDIO WiFi speeds
+
+Signed-off-by: Patrick Yavitz <pyavitz@armbian.com>
+---
+ arch/arm64/boot/dts/amlogic/meson-g12b-bananapi-cm4.dtsi | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-bananapi-cm4.dtsi b/arch/arm64/boot/dts/amlogic/meson-g12b-bananapi-cm4.dtsi
+index 995ce10d5c81..32cf5ae2ee36 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-g12b-bananapi-cm4.dtsi
++++ b/arch/arm64/boot/dts/amlogic/meson-g12b-bananapi-cm4.dtsi
+@@ -294,8 +294,10 @@ &sd_emmc_a {
+ 	#size-cells = <0>;
+ 
+ 	bus-width = <4>;
++	cap-sd-highspeed;
++	sd-uhs-sdr50;
+ 	sd-uhs-sdr104;
+-	max-frequency = <50000000>;
++	max-frequency = <100000000>;
+ 
+ 	non-removable;
+ 	disable-wp;
+@@ -303,10 +305,13 @@ &sd_emmc_a {
+ 	/* WiFi firmware requires power in suspend */
+ 	keep-power-in-suspend;
+ 
++	/* Removing quirk improves WiFi performance */
++	/delete-property/ amlogic,dram-access-quirk;
++
+ 	mmc-pwrseq = <&sdio_pwrseq>;
+ 
+ 	vmmc-supply = <&vddao_3v3>;
+-	vqmmc-supply = <&vddao_3v3>;
++	vqmmc-supply = <&vddao_1v8>;
+ 
+ 	status = "okay";
+ 
+-- 
+2.39.2
 

--- a/patch/kernel/archive/meson64-6.10/overlay/Makefile
+++ b/patch/kernel/archive/meson64-6.10/overlay/Makefile
@@ -22,6 +22,7 @@ dtbo-$(CONFIG_ARCH_MESON) += \
 	meson-g12a-radxa-zero-uart-ao-b-on-gpioao-8-gpioao-9.dtbo \
 	meson-g12a-radxa-zero-uart-ee-c.dtbo \
 	meson-g12b-bananapi-cm4-pwm-gpioh-5-fan.dtbo \
+	meson-g12b-bananapi-cm4-wifi-freq-200mhz.dtbo \
 	meson-g12b-bananapi-m2s-rtl8822cs.dtbo \
 	meson-g12b-odroid-n2-spi.dtbo \
 	meson-g12b-waveshare-cm4-io-base-usb.dtbo \

--- a/patch/kernel/archive/meson64-6.10/overlay/meson-g12b-bananapi-cm4-wifi-freq-200mhz.dtso
+++ b/patch/kernel/archive/meson64-6.10/overlay/meson-g12b-bananapi-cm4-wifi-freq-200mhz.dtso
@@ -1,0 +1,22 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "bananapi,bpi-cm4io", "bananapi,bpi-cm4", "amlogic,a311d", "amlogic,g12b";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			sdio-pwrseq {
+				post-power-on-delay-ms = <200>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&sd_emmc_a>;
+		__overlay__ {
+			max-frequency = <200000000>;
+		};
+	};
+};

--- a/patch/kernel/archive/meson64-6.6/board-bananapi-cm4-cm4io.patch
+++ b/patch/kernel/archive/meson64-6.6/board-bananapi-cm4-cm4io.patch
@@ -1,9 +1,9 @@
 From 5fb77258c07ec1cbad6f21d66bafde7c64a4f89a Mon Sep 17 00:00:00 2001
-From: Patrick Yavitz <pyavitz@xxxxx.com>
+From: Patrick Yavitz <pyavitz@armbian.com>
 Date: Tue, 25 Jul 2023 13:31:54 -0400
 Subject: [PATCH] arch: arm64: dts: amlogic: meson g12b bananapi cm4
 
-Signed-off-by: Patrick Yavitz <pyavitz@xxxxx.com>
+Signed-off-by: Patrick Yavitz <pyavitz@armbian.com>
 ---
  .../dts/amlogic/meson-g12b-bananapi-cm4-cm4io.dts    |  9 +++++++--
  .../boot/dts/amlogic/meson-g12b-bananapi-cm4.dtsi    | 12 ++++++++++--
@@ -72,6 +72,50 @@ index 97e522921b06..b90097f07be9 100644
  		device-wake-gpios = <&gpio GPIOX_18 GPIO_ACTIVE_HIGH>;
  	};
  };
+-- 
+2.39.2
+
+From cd42f604cd3298eb563c2d8788cbde1eb8e23970 Mon Sep 17 00:00:00 2001
+From: Patrick Yavitz <pyavitz@armbian.com>
+Date: Sun, 8 Sep 2024 05:55:13 -0400
+Subject: [PATCH] BananaPi CM4: improve SDIO WiFi speeds
+
+Signed-off-by: Patrick Yavitz <pyavitz@armbian.com>
+---
+ arch/arm64/boot/dts/amlogic/meson-g12b-bananapi-cm4.dtsi | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-g12b-bananapi-cm4.dtsi b/arch/arm64/boot/dts/amlogic/meson-g12b-bananapi-cm4.dtsi
+index 995ce10d5c81..32cf5ae2ee36 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-g12b-bananapi-cm4.dtsi
++++ b/arch/arm64/boot/dts/amlogic/meson-g12b-bananapi-cm4.dtsi
+@@ -294,8 +294,10 @@ &sd_emmc_a {
+ 	#size-cells = <0>;
+ 
+ 	bus-width = <4>;
++	cap-sd-highspeed;
++	sd-uhs-sdr50;
+ 	sd-uhs-sdr104;
+-	max-frequency = <50000000>;
++	max-frequency = <100000000>;
+ 
+ 	non-removable;
+ 	disable-wp;
+@@ -303,10 +305,13 @@ &sd_emmc_a {
+ 	/* WiFi firmware requires power in suspend */
+ 	keep-power-in-suspend;
+ 
++	/* Removing quirk improves WiFi performance */
++	/delete-property/ amlogic,dram-access-quirk;
++
+ 	mmc-pwrseq = <&sdio_pwrseq>;
+ 
+ 	vmmc-supply = <&vddao_3v3>;
+-	vqmmc-supply = <&vddao_3v3>;
++	vqmmc-supply = <&vddao_1v8>;
+ 
+ 	status = "okay";
+ 
 -- 
 2.39.2
 

--- a/patch/kernel/archive/meson64-6.6/dt/meson-g12b-waveshare-cm4-io-base-b.dts
+++ b/patch/kernel/archive/meson64-6.6/dt/meson-g12b-waveshare-cm4-io-base-b.dts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 /*
- * Copyright (c) 2024 Patrick Yavitz <pyavitz@xxxxx.com>
+ * Copyright (c) 2024 Patrick Yavitz <pyavitz@armbian.com>
  */
 
 /dts-v1/;
@@ -13,21 +13,6 @@
 
 	aliases {
 		rtc0 = &rtc;
-	};
-};
-
-&i2c1 {
-	rtc: rtc@51 {
-		compatible = "nxp,pcf85063a";
-		reg = <0x51>;
-		wakeup-source;
-	};
-
-	fanctrl: emc2305@2f {
-		compatible = "smsc,emc2305";
-		reg = <0x2f>;
-		#cooling-cells = <0x02>;
-		wakeup-source;
 	};
 };
 
@@ -56,6 +41,21 @@
 			trip = <&fanmax0>;
 			cooling-device = <&fanctrl 7 THERMAL_NO_LIMIT>;
 		};
+	};
+};
+
+&i2c1 {
+	rtc: rtc@51 {
+		compatible = "nxp,pcf85063a";
+		reg = <0x51>;
+		wakeup-source;
+	};
+
+	fanctrl: emc2305@2f {
+		compatible = "smsc,emc2305";
+		reg = <0x2f>;
+		#cooling-cells = <0x02>;
+		wakeup-source;
 	};
 };
 

--- a/patch/kernel/archive/meson64-6.6/overlay/Makefile
+++ b/patch/kernel/archive/meson64-6.6/overlay/Makefile
@@ -22,6 +22,7 @@ dtbo-$(CONFIG_ARCH_MESON) += \
 	meson-g12a-radxa-zero-uart-ao-b-on-gpioao-8-gpioao-9.dtbo \
 	meson-g12a-radxa-zero-uart-ee-c.dtbo \
 	meson-g12b-bananapi-cm4-pwm-gpioh-5-fan.dtbo \
+	meson-g12b-bananapi-cm4-wifi-freq-200mhz.dtbo \
 	meson-g12b-bananapi-m2s-rtl8822cs.dtbo \
 	meson-g12b-odroid-n2-spi.dtbo \
 	meson-g12b-waveshare-cm4-io-base-usb.dtbo \

--- a/patch/kernel/archive/meson64-6.6/overlay/meson-g12b-bananapi-cm4-wifi-freq-200mhz.dts
+++ b/patch/kernel/archive/meson64-6.6/overlay/meson-g12b-bananapi-cm4-wifi-freq-200mhz.dts
@@ -1,0 +1,22 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "bananapi,bpi-cm4io", "bananapi,bpi-cm4", "amlogic,a311d", "amlogic,g12b";
+
+	fragment@0 {
+		target-path = "/";
+		__overlay__ {
+			sdio-pwrseq {
+				post-power-on-delay-ms = <200>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&sd_emmc_a>;
+		__overlay__ {
+			max-frequency = <200000000>;
+		};
+	};
+};


### PR DESCRIPTION
Improve overall WiFi experience
Default freq now set to 100MHz (optional overlay to 200MHz)
Resolved incompatibility with the github driver: https://github.com/jethome-ru/rtl88x2cs

If the github driver is preferred blacklist RTW88

/etc/modprobe.d/blacklist-rtw88.conf
blacklist rtw88_8822c
blacklist rtw88_8822cs

EXTRA: Waveshare DTS fixup

Discussion: https://forum.armbian.com/topic/44899-slow-wifi-speeds-on-banana-pi-cm4/
