### PR TITLE
dt_makefile_patcher: fix dtbs with dot in filename

### DIFF
--- a/lib/tools/common/dt_makefile_patcher.py
+++ b/lib/tools/common/dt_makefile_patcher.py
@@ -80,7 +80,7 @@ def auto_patch_dt_makefile(git_work_dir: str, dt_rel_dir: str, config_var: str, 
 	# Parse it into a list of lines
 	makefile_lines = makefile_contents.splitlines()
 	log.info(f"Read {len(makefile_lines)} lines from {makefile_path}")
-	regex_dtb = r"(.*)\s(([a-zA-Z0-9-_]+)\.dtb)(.*)"
+	regex_dtb = r"(.*)\s(([^ \f\n\r\t\v]+)\.dtb)(.*)"
 	regex_configopt = r"^dtb-\$\(([a-zA-Z0-9_]+)\)\s+"
 
 	# For each line, check if it matches the regex_dtb, extract the groups


### PR DESCRIPTION
# Description

We do not build dtbs with dot in filename because the current re match rule will ignore them.
This fixes https://github.com/armbian/build/issues/7187

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh kernel-dtb BOARD=orangepi3b BRANCH=vendor DEB_COMPRESS=xz KERNEL_CONFIGURE=no KERNEL_GIT=shallow` with kernel https://github.com/dust-7/linux-rockchip/tree/opi3b-v2, `rk3566-orangepi-3b-v1.1.dtb` and `rk3566-orangepi-3b-v1.1.dtb` are built.

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
