### PR TITLE
arm64: dts: rockchip: fix gmac PHY attach error on ROCK Pi E

### DIFF
--- a/patch/kernel/archive/rockchip64-6.10/board-rockpie-0001-arm64-dts-rockchip-fix-gmac-PHY-attach-error.patch
+++ b/patch/kernel/archive/rockchip64-6.10/board-rockpie-0001-arm64-dts-rockchip-fix-gmac-PHY-attach-error.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: FUKAUMI Naoki <naoki@radxa.com>
+Date: Tue, 10 Sep 2024 19:33:28 +0000
+Subject: arm64: dts: rockchip: fix gmac PHY attach error on ROCK Pi E
+
+Signed-off-by: FUKAUMI Naoki <naoki@radxa.com>
+---
+ arch/arm64/boot/dts/rockchip/rk3328-rock-pi-e.dts | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3328-rock-pi-e.dts b/arch/arm64/boot/dts/rockchip/rk3328-rock-pi-e.dts
+index f2616bfe3843..4fa44218447e 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3328-rock-pi-e.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3328-rock-pi-e.dts
+@@ -165,10 +165,11 @@ mdio {
+ 		compatible = "snps,dwmac-mdio";
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+ 
+ 		rtl8211: ethernet-phy@1 {
++			compatible = "ethernet-phy-id001c.c916";
+ 			reg = <1>;
+ 			pinctrl-0 = <&eth_phy_int_pin>, <&eth_phy_reset_pin>;
+ 			pinctrl-names = "default";
+ 			interrupt-parent = <&gpio1>;
+ 			interrupts = <24 IRQ_TYPE_LEVEL_LOW>;
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/kernel/archive/rockchip64-6.6/board-rockpie-0001-arm64-dts-rockchip-fix-gmac-PHY-attach-error.patch
+++ b/patch/kernel/archive/rockchip64-6.6/board-rockpie-0001-arm64-dts-rockchip-fix-gmac-PHY-attach-error.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: FUKAUMI Naoki <naoki@radxa.com>
+Date: Tue, 10 Sep 2024 02:49:42 +0000
+Subject: arm64: dts: rockchip: fix gmac PHY attach error on ROCK Pi E
+
+this fixes following error:
+
+rk_gmac-dwmac ff540000.ethernet end0: __stmmac_open: Cannot attach to PHY (error: -19)
+
+Signed-off-by: FUKAUMI Naoki <naoki@radxa.com>
+---
+ arch/arm64/boot/dts/rockchip/rk3328-rock-pi-e.dts | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3328-rock-pi-e.dts b/arch/arm64/boot/dts/rockchip/rk3328-rock-pi-e.dts
+index 98f391f675df..ebb3617395ec 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3328-rock-pi-e.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3328-rock-pi-e.dts
+@@ -163,10 +163,11 @@ mdio {
+ 		compatible = "snps,dwmac-mdio";
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+ 
+ 		rtl8211e: ethernet-phy@1 {
++			compatible = "ethernet-phy-id001c.c916";
+ 			reg = <1>;
+ 			pinctrl-0 = <&eth_phy_int_pin>, <&eth_phy_reset_pin>;
+ 			pinctrl-names = "default";
+ 			interrupt-parent = <&gpio1>;
+ 			interrupts = <24 IRQ_TYPE_LEVEL_LOW>;
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+


### PR DESCRIPTION
# Description

ROCK Pi E 1000M port is not working due to following error:

rk_gmac-dwmac ff540000.ethernet end0: __stmmac_open: Cannot attach to PHY (error: -19)

# Documentation summary for feature / change

this patch fixes above error and make 1000M port usable.

# How Has This Been Tested?

- [x] connect 1000M port and see `dmesg`
- [x] connect 1000M port and see `ip a`

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
