### PR TITLE
Userspace: remove System Activity Reporter (SAR) from server package base

### DIFF
--- a/config/cli/bullseye/main/packages
+++ b/config/cli/bullseye/main/packages
@@ -35,7 +35,6 @@ rsync
 rsyslog
 sudo
 sysfsutils
-sysstat
 toilet
 tzdata
 u-boot-tools

--- a/config/cli/common/main/packages.additional
+++ b/config/cli/common/main/packages.additional
@@ -51,7 +51,6 @@ software-properties-common
 smartmontools
 stress
 sysfsutils
-sysstat
 unattended-upgrades
 unicode-data
 unzip

--- a/config/cli/jammy/main/packages
+++ b/config/cli/jammy/main/packages
@@ -35,7 +35,6 @@ rsync
 rsyslog
 sudo
 sysfsutils
-sysstat
 toilet
 tzdata
 u-boot-tools


### PR DESCRIPTION
# Description

We really don't need this pkg by default.

# Checklist:

- [x] My code follows the style guidelines of this project