### PR TITLE
Add `sun50i-h616-light` dt overlay fix to 6.10

### DIFF
--- a/patch/kernel/archive/sunxi-6.10/patches.armbian/cb1-overlay-light-fix.patch
+++ b/patch/kernel/archive/sunxi-6.10/patches.armbian/cb1-overlay-light-fix.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: JohnTheCoolingFan <ivan8215145640@gmail.com>
+Date: Tue, 10 Sep 2024 20:43:08 +0000
+Subject: ARM64 DTS: sun50i-h616 overlays: fix sun50i-h616-light overlay
+
+Signed-off-by: JohnTheCoolingFan <ivan8215145640@gmail.com>
+---
+ arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-light.dtso | 9 +--------
+ 1 file changed, 1 insertion(+), 8 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-light.dtso b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-light.dtso
+index 5010ea6a5..4ab9dc952 100755
+--- a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-light.dtso
++++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-light.dtso
+@@ -9,19 +9,12 @@ fragment@0 {
+ 		 __overlay__ {
+ 			status = "okay";
+ 		};
+ 	};
+ 
+-    fragment@1 {
++	fragment@1 {
+ 		target = <&uart0>;
+ 		__overlay__ {
+ 			status = "disabled";
+ 		};
+ 	};
+-
+-    fragment@2 {
+-		target = <&pwm>;
+-		__overlay__ {
+-            status = "okay";
+-		};
+-	};
+ };
+-- 
+Created with Armbian build tools https://github.com/armbian/build
+

--- a/patch/kernel/archive/sunxi-6.10/series.armbian
+++ b/patch/kernel/archive/sunxi-6.10/series.armbian
@@ -104,6 +104,7 @@
 	patches.armbian/Move-sun50i-h6-pwm-settings-to-its-own-overlay.patch
 	patches.armbian/Compile-the-pwm-overlay.patch
 	patches.armbian/cb1-overlay.patch
+	patches.armbian/cb1-overlay-light-fix.patch
 	patches.armbian/arm-dts-sunxi-h3-h5.dtsi-add-i2s0-i2s1-pins.patch
 	patches.armbian/arm-dts-sun5i-a13-olinuxino-micro-add-panel-lcd-olinuxino-4.3.patch
 	patches.armbian/arm-dts-sun5i-a13-olinuxino-Add-panel-lcd-olinuxino-4.3-needed-.patch

--- a/patch/kernel/archive/sunxi-6.10/series.conf
+++ b/patch/kernel/archive/sunxi-6.10/series.conf
@@ -368,6 +368,7 @@
 	patches.armbian/Move-sun50i-h6-pwm-settings-to-its-own-overlay.patch
 	patches.armbian/Compile-the-pwm-overlay.patch
 	patches.armbian/cb1-overlay.patch
+	patches.armbian/cb1-overlay-light-fix.patch
 	patches.armbian/arm-dts-sunxi-h3-h5.dtsi-add-i2s0-i2s1-pins.patch
 	patches.armbian/arm-dts-sun5i-a13-olinuxino-micro-add-panel-lcd-olinuxino-4.3.patch
 	patches.armbian/arm-dts-sun5i-a13-olinuxino-Add-panel-lcd-olinuxino-4.3-needed-.patch


### PR DESCRIPTION
# Description

In follow-up to #7183 after the merge of #7127 

# How Has This Been Tested?

- [x] build and boot with overlay on bigtreetech pi v1.2

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
