### PR TITLE
Op5+/HDMI-RX: fix spurious triggering of irq 5v while plugout code is running

### DIFF
--- a/patch/kernel/archive/rockchip-rk3588-6.10/0113-add-synopsys-designware-hdmi-rx-controller.patch
+++ b/patch/kernel/archive/rockchip-rk3588-6.10/0113-add-synopsys-designware-hdmi-rx-controller.patch
@@ -3768,3 +3768,81 @@ index 111111111111..222222222222 100644
 -- 
 Armbian
 
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ben Hoff <hoff.benjamin.k@gmail.com>
+Date: Sun, 15 Sep 2024 14:52:17 -0400
+Subject: [PATCH 1/2] fix spurious triggering of irq 5v while plugout code is
+ running
+
+---
+ drivers/media/platform/synopsys/hdmirx/snps_hdmirx.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/drivers/media/platform/synopsys/hdmirx/snps_hdmirx.c b/drivers/media/platform/synopsys/hdmirx/snps_hdmirx.c
+index 111111111111..222222222222 100644
+--- a/drivers/media/platform/synopsys/hdmirx/snps_hdmirx.c
++++ b/drivers/media/platform/synopsys/hdmirx/snps_hdmirx.c
+@@ -745,10 +745,17 @@ static void hdmirx_interrupts_setup(struct snps_hdmirx_dev *hdmirx_dev, bool en)
+ static void hdmirx_plugout(struct snps_hdmirx_dev *hdmirx_dev)
+ {
+ 	struct arm_smccc_res res;
++    int irq;
+ 
+ 	hdmirx_update_bits(hdmirx_dev, SCDC_CONFIG, POWERPROVIDED, 0);
+ 	hdmirx_interrupts_setup(hdmirx_dev, false);
+ 	hdmirx_hpd_ctrl(hdmirx_dev, false);
++    irq = gpiod_to_irq(hdmirx_dev->detect_5v_gpio);
++
++    if (irq >= 0) {
++        disable_irq(irq);
++    }
++
+ 	hdmirx_update_bits(hdmirx_dev, DMA_CONFIG6, HDMIRX_DMA_EN, 0);
+ 	hdmirx_update_bits(hdmirx_dev, DMA_CONFIG4,
+ 			   LINE_FLAG_INT_EN |
+@@ -766,6 +773,11 @@ static void hdmirx_plugout(struct snps_hdmirx_dev *hdmirx_dev)
+ 	cancel_delayed_work_sync(&hdmirx_dev->delayed_work_heartbeat);
+ 	flush_work(&hdmirx_dev->work_wdt_config);
+ 	arm_smccc_smc(SIP_WDT_CFG, WDT_STOP, 0, 0, 0, 0, 0, 0, &res);
++
++    hdmirx_hpd_ctrl(hdmirx_dev, true);
++    if (irq >= 0) {
++        enable_irq(irq);
++    }
+ }
+ 
+ static int hdmirx_set_edid(struct file *file, void *fh, struct v4l2_edid *edid)
+-- 
+Armbian
+
+
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ben Hoff <hoff.benjamin.k@gmail.com>
+Date: Sun, 15 Sep 2024 14:53:25 -0400
+Subject: [PATCH 2/2] remove timing handling from plug in function
+
+---
+ drivers/media/platform/synopsys/hdmirx/snps_hdmirx.c | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/drivers/media/platform/synopsys/hdmirx/snps_hdmirx.c b/drivers/media/platform/synopsys/hdmirx/snps_hdmirx.c
+index 111111111111..222222222222 100644
+--- a/drivers/media/platform/synopsys/hdmirx/snps_hdmirx.c
++++ b/drivers/media/platform/synopsys/hdmirx/snps_hdmirx.c
+@@ -2202,13 +2202,6 @@ static void hdmirx_plugin(struct snps_hdmirx_dev *hdmirx_dev)
+ 	hdmirx_hpd_ctrl(hdmirx_dev, true);
+ 	hdmirx_phy_config(hdmirx_dev);
+ 	ret = hdmirx_wait_lock_and_get_timing(hdmirx_dev);
+-	if (ret) {
+-		hdmirx_plugout(hdmirx_dev);
+-		queue_delayed_work(system_unbound_wq,
+-				   &hdmirx_dev->delayed_work_hotplug,
+-				   msecs_to_jiffies(200));
+-		return;
+-	}
+ 	hdmirx_dma_config(hdmirx_dev);
+ 	hdmirx_interrupts_setup(hdmirx_dev, true);
+ }
+-- 
+Armbian
+


### PR DESCRIPTION
# Description
HDMI-rx does not properly report if it is plugged out and says that it is plugged in all the time. The cause is the following. 

There is an irq that is watching a gpio for 5v high. 

During the plugout method for the driver, the driver resets the device state. If the irq that is watching for gpio 5 volts is not disabled during this time, it triggers on a transient voltage and sets the driver to run the "High"/plugged in logic. By the time the driver reaches the high logic, the gpio is low again, which resets the cycle by re-calling the plugout method.

This is probably why @efectn disabled the log in 0a0eb46 , because it's so noisy and spams the logs.

I don't know if this is the right solution, but I know it prevents this cycle by disabling the irq during the plugout code sequence.

# How Has This Been Tested?

Tested on orange pi 5 plus 

# Checklist:

_Please delete options that are not relevant._

- [ x ] My changes generate no new warnings

