### PR TITLE
armbian-firstrun: Optionally skip OpenSSH host key regeneration

### DIFF
--- a/lib/functions/bsp/armbian-bsp-cli-deb.sh
+++ b/lib/functions/bsp/armbian-bsp-cli-deb.sh
@@ -451,6 +451,9 @@ function board_side_bsp_cli_postinst_finish() {
 	if [ ! -f "/etc/default/armbian-zram-config" ] && [ -f /etc/default/armbian-zram-config.dpkg-dist ]; then
 		mv /etc/default/armbian-zram-config.dpkg-dist /etc/default/armbian-zram-config
 	fi
+    if [ ! -f "/etc/default/armbian-firstrun" ]; then
+		mv /etc/default/armbian-firstrun.dpkg-dist /etc/default/armbian-firstrun
+	fi
 
 	if [ -L "/usr/lib/chromium-browser/master_preferences.dpkg-dist" ]; then
 		mv /usr/lib/chromium-browser/master_preferences.dpkg-dist /usr/lib/chromium-browser/master_preferences

--- a/lib/functions/rootfs/distro-agnostic.sh
+++ b/lib/functions/rootfs/distro-agnostic.sh
@@ -398,7 +398,14 @@ function install_distribution_agnostic() {
 
 	# enable additional services, if they exist.
 	display_alert "Enabling Armbian services" "systemd" "info"
-	[[ -f "${SDCARD}"/lib/systemd/system/armbian-firstrun.service ]] && chroot_sdcard systemctl --no-reload enable armbian-firstrun.service
+	if [[ -f "${SDCARD}"/lib/systemd/system/armbian-firstrun.service ]]; then
+	    # Note: armbian-firstrun starts before the user has a chance to edit the env file's values.
+	    # Exceptionaly, the env file can be edited during image build time
+        if test -n "$OPENSSHD_REGENERATE_HOST_KEYS"; then
+            sed -i "s/\(^OPENSSHD_REGENERATE_HOST_KEYS *= *\).*/\1$OPENSSHD_REGENERATE_HOST_KEYS/" "${SDCARD}"/etc/default/armbian-firstrun
+        fi
+		chroot_sdcard systemctl --no-reload enable armbian-firstrun.service
+	fi
 	[[ -f "${SDCARD}"/lib/systemd/system/armbian-zram-config.service ]] && chroot_sdcard systemctl --no-reload enable armbian-zram-config.service
 	[[ -f "${SDCARD}"/lib/systemd/system/armbian-hardware-optimize.service ]] && chroot_sdcard systemctl --no-reload enable armbian-hardware-optimize.service
 	[[ -f "${SDCARD}"/lib/systemd/system/armbian-ramlog.service ]] && chroot_sdcard systemctl --no-reload enable armbian-ramlog.service

--- a/packages/bsp/common/etc/default/armbian-firstrun.dpkg-dist
+++ b/packages/bsp/common/etc/default/armbian-firstrun.dpkg-dist
@@ -1,0 +1,6 @@
+# configuration values for the armbian-firstrun service
+
+# Delete + regenerate OpenSSH host keys
+# true  = delete + generate host keys
+# false = no deletion / no generation for host keys
+OPENSSHD_REGENERATE_HOST_KEYS=true

--- a/packages/bsp/common/lib/systemd/system/armbian-firstrun.service
+++ b/packages/bsp/common/lib/systemd/system/armbian-firstrun.service
@@ -10,6 +10,7 @@ After=ssh.service
 [Service]
 Type=simple
 RemainAfterExit=yes
+EnvironmentFile=/etc/default/armbian-firstrun
 ExecStart=/usr/lib/armbian/armbian-firstrun start
 TimeoutStartSec=2min
 

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstrun
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstrun
@@ -46,12 +46,16 @@ case "$1" in
 	[[ -f /etc/systemd/system/armbian-live-patch.service ]] && systemctl --no-reload enable armbian-live-patch.service
 
 	# SSH Keys creation
-	rm -f /etc/ssh/ssh_host*
-	read entropy_before </proc/sys/kernel/random/entropy_avail
-	dpkg-reconfigure openssh-server >/dev/null 2>&1
-	service ssh restart
-	read entropy_after </proc/sys/kernel/random/entropy_avail
-	echo -e "\n### [firstrun] Recreated SSH keys (entropy: ${entropy_before} ${entropy_after})" >>${Log}
+	if [[ "${OPENSSHD_REGENERATE_HOST_KEYS}" = true ]]; then
+		rm -f /etc/ssh/ssh_host*
+		read entropy_before </proc/sys/kernel/random/entropy_avail
+		dpkg-reconfigure openssh-server >/dev/null 2>&1
+		service ssh restart
+		read entropy_after </proc/sys/kernel/random/entropy_avail
+		echo -e "\n### [firstrun] Recreated SSH keys (entropy: ${entropy_before} ${entropy_after})" >>${Log}
+	else
+		echo -e "\n### [firstrun] SSH host keys unchanged" >>${Log}
+	fi
 
 	# get rid of purple background color in newt apps whiptail, partimage, debconf ... Reverting to Debian look.
 	[[ -f /etc/newt/palette ]] && sed -e 's/magenta/blue/g' -i /etc/newt/palette


### PR DESCRIPTION
# Description

**Context**
 
systemd's cloud-init.target and armbian-firstrun.service will be started concurrently (both are wanted by multi-user.target). Both will try to create SSH host keys by default:
 - armbian-firstrun will always delete SSH host keys and then generate new ones
 - cloud-init.target (by default) will always delete SSH host keys and then generate new ones.
 
**Problem**
 
When one must run armbian-firstrun and cloud-init, there is no deterministic ordering between the 2 files execution and therefore no one can guarantee which will be last to setup OpenSSH host keys. In my current scenario, host keys are explicitly setup in cloud-init and I would expect armbian-firstrun to not delete keys + no ssh host key generation.
 
**Implemented Solution**
 
armbian-firstrun support user defined boolean setting to optionally regenerate SSH host keys in `armbian-firstrun`:
- `false`: no ssh key deleted + no ssh host key generated. 
  - Allows cloud-init to take over this task and do it deterministically.
- `true (or undefined)`:  ssh host key deleted + generated (compatibility: current armbian behaviour) 

# Documentation summary for feature / change


If documentation entry is predicted, please provide key elements for further implementation [into main documentation](https://docs.armbian.com) and set label to "Needs Documentation". You are welcome to open a PR to documentation or you can leave following information for technical writer:

- [x] short description

armbian-firstrun: Optionally skip OpenSSH host key regeneration

- [x] summary

To skip armbian-firstrun's OpenSSH host keys deletion + regeneration (eg: to let cloud-init set the SSH host keys):
 - define `OPENSSHD_REGENERATE_HOST_KEYS=false` in the `/path/to/userpatches/config-*.conf` file used by `./compile.sh` to build the image.
 
 To execute armbian-firstrun's OpenSSH host keys deletion + regeneration:
 - define `OPENSSHD_REGENERATE_HOST_KEYS=true` in the `/path/to/userpatches/config-*.conf` file used by `./compile.sh` to build the image OR do not define `OPENSSHD_REGENERATE_HOST_KEYS` at all.

- [x] example of usage

See summary section.

# How Has This Been Tested?


- [x] qemu-uefi-x86 board: build with `OPENSSHD_REGENERATE_HOST_KEYS=false` and expect armbian-firstrun to not delete ssh host keys and not regenerate ssh host keys
- [x] qemu-uefi-x86 board: build with `OPENSSHD_REGENERATE_HOST_KEYS` undefined (most common setup for everyone) and expect armbian-firstrun to delete ssh host keys and regenerate ssh host keys


# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
