### PR TITLE
Fix issue 7210, rootdevice altering extensions

### DIFF
--- a/extensions/lvm.sh
+++ b/extensions/lvm.sh
@@ -71,6 +71,13 @@ function post_create_partitions__setup_lvm() {
 }
 
 function prepare_root_device__create_volume_group() {
+
+	LOOP=$(losetup -f)
+	[[ -z $LOOP ]] && exit_with_error "Unable to find free loop device"
+	check_loop_device "$LOOP"
+	losetup $LOOP ${SDCARD}.raw
+	partprobe $LOOP
+
 	display_alert "Using LVM root" "${EXTENSION}" "info"
 	vgscan
 	vgchange -a y ${LVM_VG_NAME}

--- a/lib/functions/image/partitioning.sh
+++ b/lib/functions/image/partitioning.sh
@@ -300,7 +300,7 @@ function prepare_partitions() {
 		wait_for_disk_sync "after mkfs" # force writes to be really flushed
 
 		# store in readonly global for usage in later hooks
-		root_part_uuid="$(blkid -s UUID -o value ${LOOP}p${rootpart})"
+		root_part_uuid="$(blkid -s UUID -o value ${rootdevice})"
 		declare -g -r ROOT_PART_UUID="${root_part_uuid}"
 
 		display_alert "Mounting rootfs" "$rootdevice (UUID=${ROOT_PART_UUID})"


### PR DESCRIPTION
# Description

Minor regression fix for extensions that need to modify the root device, such as LVM and Crypto Root.
Fix for newer ubuntu build host requiring re-instantiation of LVM devices mid build process.

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: #7210 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-2489]

# How Has This Been Tested?

The build process failed before, now builds again. Tested with Jammy and Noble, installed distributions, etc.


[AR-2489]: https://armbian.atlassian.net/browse/AR-2489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ