### PR TITLE
Enable oras pull to use system proxy

### DIFF
--- a/config/boards/cherryba-m1.csc
+++ b/config/boards/cherryba-m1.csc
@@ -1,0 +1,11 @@
+ # Allwinner H618 quad core 1GB 2GB 4GB RAM SoC WiFi USB-C emmc
+BOARD_NAME="CherryBa M1"
+BOARDFAMILY="sun50iw9"
+BOOTCONFIG="cherryba-m1_defconfig"
+BOOT_LOGO="desktop"
+KERNEL_TARGET="current,legacy"
+KERNEL_TEST_TARGET="current,edge" # in case different then kernel target
+FORCE_BOOTSCRIPT_UPDATE="yes"
+BOOTBRANCH_BOARD="tag:v2024.01"
+BOOTPATCHDIR="v2024.01"
+VENDOR="CherryBaM1"

--- a/lib/functions/general/oci-oras.sh
+++ b/lib/functions/general/oci-oras.sh
@@ -85,7 +85,7 @@ function run_tool_oras() {
 	display_alert "Running ORAS ${ACTUAL_VERSION}" "HOME='${ORAS_HOME}'; retries='${retries:-1}'; cmdline: $*" "debug"
 	if [[ "${retries:-1}" -gt 1 ]]; then
 		display_alert "Calling ORAS with retries ${retries}" "$*" "debug"
-		sleep_seconds="30" do_with_retries "${retries}" env -i "HOME=${ORAS_HOME}" "${ORAS_BIN}" "$@"
+		sleep_seconds="30" do_with_retries "${retries}" env -i "HOME=${ORAS_HOME}" "https_proxy=${https_proxy}" "${ORAS_BIN}" "$@"
 	else
 		# If any parameters passed, call ORAS, otherwise exit. We call it this way (sans-parameters) early to prepare ORAS tooling.
 		if [[ $# -eq 0 ]]; then

--- a/patch/kernel/archive/sunxi-6.6/patches.armbian/cherryba-m1-add-dtb.patch
+++ b/patch/kernel/archive/sunxi-6.6/patches.armbian/cherryba-m1-add-dtb.patch
@@ -1,0 +1,485 @@
+diff --git a/arch/arm64/boot/dts/allwinner/Makefile b/arch/arm64/boot/dts/allwinner/Makefile
+index 3b0ad5406238..93401efad817 100644
+--- a/arch/arm64/boot/dts/allwinner/Makefile
++++ b/arch/arm64/boot/dts/allwinner/Makefile
+@@ -39,5 +39,6 @@ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-pine-h64-model-b.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h6-tanix-tx6-mini.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-orangepi-zero2.dtb
++dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-cherryba-m1.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h616-x96-mate.dtb
+ dtb-$(CONFIG_ARCH_SUNXI) += sun50i-h618-orangepi-zero3.dtb
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h618-cherryba-m1.dts b/arch/arm64/boot/dts/allwinner/sun50i-h618-cherryba-m1.dts
+new file mode 100644
+index 000000000000..20993f683c3b
+--- /dev/null
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h618-cherryba-m1.dts
+@@ -0,0 +1,468 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (C) 2023 Arm Ltd.
++ */
++
++/dts-v1/;
++
++#include "sun50i-h616.dtsi"
++#include "sun50i-h616-cpu-opp.dtsi"
++#include "sun50i-h618-cpu-dvfs.dtsi"
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/interrupt-controller/arm-gic.h>
++#include <dt-bindings/leds/common.h>
++
++/ {
++	model = "CherryBa M1";
++	compatible = "CherryBa,CherryBa-h618", "allwinner,sun50i-h618";
++
++	aliases {
++		serial0 = &uart0;
++		serial2 = &uart2;
++		serial3 = &uart3;
++		serial4 = &uart4;
++		serial5 = &uart5;
++		mmc0 = &mmc0;
++		mmc1 = &mmc1;
++		mmc2 = &mmc2;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	connector {
++		compatible = "hdmi-connector";
++		type = "d";
++
++		port {
++			hdmi_con_in: endpoint {
++				remote-endpoint = <&hdmi_out_con>;
++			};
++		};
++	};
++
++	reg_vcc5v: vcc5v {
++		/* board wide 5V supply directly from the USB-C socket */
++		compatible = "regulator-fixed";
++		regulator-name = "vcc-5v";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		regulator-always-on;
++	};
++
++	reg_vcc3v3: vcc3v3 {
++		/* SY8089 DC/DC converter */
++		compatible = "regulator-fixed";
++		regulator-name = "vcc-3v3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&reg_vcc5v>;
++		regulator-always-on;
++	};
++
++	reg_vcc_wifi_io: vcc-wifi-io {
++		/* Always on 1.8V/300mA regulator for WiFi and BT IO */
++		compatible = "regulator-fixed";
++		regulator-name = "vcc-wifi-io";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		regulator-always-on;
++		vin-supply = <&reg_vcc3v3>;
++	};
++
++	wifi_pwrseq: wifi-pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		clocks = <&rtc 1>;
++		clock-names = "osc32k-out";
++		reset-gpios = <&pio 6 18 GPIO_ACTIVE_LOW>; /* PG18 */
++		post-power-on-delay-ms = <200>;
++	};
++
++	ac200_pwm_clk: ac200_clk {
++		compatible = "pwm-clock";
++		#clock-cells = <0>;
++		// pwm5 period_ns = 500 > 334 for select 24M clock.
++		pwms = <&pwm 5 500 0>;
++		clock-frequency = <2000000>;
++		status = "okay";
++	};
++
++	soc {
++		pwm: pwm@300a000 {
++			compatible = "allwinner,sun50i-h616-pwm";
++			reg = <0x0300a000 0x400>;
++			clocks = <&osc24M>, <&ccu CLK_BUS_PWM>;
++			clock-names = "mod", "bus";
++			resets = <&ccu RST_BUS_PWM>;
++			pwm-number = <6>;
++			pwm-base = <0x0>;
++			sunxi-pwms = <&pwm0>, <&pwm1>, <&pwm2>, <&pwm3>, <&pwm4>, <&pwm5>;
++			#pwm-cells = <3>;
++			status = "okay";
++		};
++
++		pwm0: pwm0@0300a000 {
++			compatible = "allwinner,sunxi-pwm0";
++		};
++
++		pwm1: pwm1@0300a000 {
++			compatible = "allwinner,sunxi-pwm1";
++			pinctrl-names = "default";
++			pinctrl-0 = <&pwm1_ph_pin>;
++		};
++
++		pwm2: pwm2@0300a000 {
++			compatible = "allwinner,sunxi-pwm2";
++			pinctrl-names = "default";
++			pinctrl-0 = <&pwm2_ph_pin>;
++		};
++
++		pwm3: pwm3@0300a000 {
++			compatible = "allwinner,sunxi-pwm3";
++			pinctrl-names = "default";
++			pinctrl-0 = <&pwm3_ph_pin>;
++		};
++
++		pwm4: pwm4@0300a000 {
++			compatible = "allwinner,sunxi-pwm4";
++			pinctrl-names = "default";
++			pinctrl-0 = <&pwm4_ph_pin>;
++		};
++
++		pwm5: pwm5@0300a000 {
++			compatible = "allwinner,sunxi-pwm5";
++			pinctrl-names = "default";
++			pinctrl-0 = <&pwm5_pin>;
++			clk_bypass_output = <0x1>;
++			status = "okay";
++		};
++	};
++};
++
++&de {
++	status = "okay";
++};
++
++&hdmi {
++	status = "okay";
++};
++&codec {
++        allwinner,audio-routing =
++                "Line Out", "LINEOUT";
++        status = "okay";
++};
++
++&ahub_dam_plat {
++        status = "okay";
++};
++
++&ahub1_plat {
++        status = "okay";
++};
++
++&ahub1_mach {
++        status = "okay";
++};
++
++&hdmi_out {
++	hdmi_out_con: endpoint {
++		remote-endpoint = <&hdmi_con_in>;
++	};
++};
++
++&gpu {
++	mali-supply = <&reg_dcdc1>;
++	status = "okay";
++};
++
++&mmc0 {
++	cd-gpios = <&pio 5 6 GPIO_ACTIVE_LOW>;	/* PF6 */
++	bus-width = <4>;
++	vmmc-supply = <&reg_dldo1>;
++	max-frequency = <50000000>;
++	status = "okay";
++};
++
++&mmc1 {
++	vmmc-supply = <&reg_vcc3v3>;
++	vqmmc-supply = <&reg_vcc_wifi_io>;
++	mmc-pwrseq = <&wifi_pwrseq>;
++	bus-width = <4>;
++	non-removable;
++	mmc-ddr-1_8v;
++	status = "okay";
++};
++
++&mmc2 {
++	vmmc-supply = <&reg_vcc3v3>;
++	vqmmc-supply = <&reg_vcc_wifi_io>;
++	cap-mmc-hw-reset;
++	bus-width = <8>;
++	non-removable;
++	mmc-hs200-1_8v;
++	status = "okay";
++
++};
++&emac0 {
++	status = "disabled";
++};
++
++&emac1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&rmii_pins>;
++	phy-mode = "rmii";
++	phy-handle = <&rmii_phy>;
++	phy-supply = <&reg_dldo1>;
++	allwinner,rx-delay-ps = <3100>;
++	allwinner,tx-delay-ps = <700>;
++	status = "okay";
++};
++
++&mdio1 {
++	rmii_phy: ethernet-phy@1 {
++		compatible = "ethernet-phy-ieee802.3-c22";
++		reg = <1>;
++	};
++};
++
++&ehci0 {
++	status = "okay";
++};
++
++&ehci1 {
++	status = "okay";
++};
++
++&ehci2 {
++	status = "okay";
++};
++
++&ehci3 {
++	status = "okay";
++};
++
++&ohci0 {
++	status = "okay";
++};
++
++&ohci1 {
++	status = "okay";
++};
++
++&ohci2 {
++	status = "okay";
++};
++
++&ohci3 {
++	status = "okay";
++};
++
++&ir {
++	pinctrl-names = "default";
++	pinctrl-0 = <&ir_rx_pin>;
++	status = "okay";
++};
++
++&uart0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart0_ph_pins>;
++	status = "okay";
++};
++
++&uart2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart2_pi_pins>;
++	status = "disabled";
++};
++
++&uart3 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart3_pi_pins>;
++	status = "disabled";
++};
++
++&uart4 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart4_pi_pins>;
++	status = "disabled";
++};
++
++&uart5 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart5_ph_pins>;
++	status = "disabled";
++};
++
++&i2c3 {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c3_pa_pins>;
++
++	ac200_x: mfd@10 {
++		compatible = "x-powers,ac200-sunxi";
++		reg = <0x10>;
++		clocks = <&ac200_pwm_clk>;
++		// ephy id
++		nvmem-cells = <&ephy_calibration>;
++		nvmem-cell-names = "calibration";
++
++		ac200_ephy: phy {
++			compatible = "x-powers,ac200-ephy-sunxi";
++			status = "okay";
++		};
++	};
++};
++
++&i2c4 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c4_ph_pins>;
++	status = "disabled";
++};
++
++&usbotg {
++	/*
++	 * PHY0 pins are connected to a USB-C socket, but a role switch
++	 * is not implemented: both CC pins are pulled to GND.
++	 * The VBUS pins power the device, so a fixed peripheral mode
++	 * is the best choice.
++	 * The board can be powered via GPIOs, in this case port0 *can*
++	 * act as a host (with a cable/adapter ignoring CC), as VBUS is
++	 * then provided by the GPIOs. Any user of this setup would
++	 * need to adjust the DT accordingly: dr_mode set to "host",
++	 * enabling OHCI0 and EHCI0.
++	 */
++	dr_mode = "peripheral";
++	status = "okay";
++};
++
++&usbphy {
++	usb1_vbus-supply = <&reg_vcc5v>;
++	status = "okay";
++};
++
++&cpu0 {
++	cpu-supply = <&reg_dcdc2>;
++	status = "okay";
++};
++
++&sid {
++	ephy_calibration: ephy-calibration@2c {
++		reg = <0x2c 0x2>;
++	};
++};
++
++&cpu_temp_critical {
++	temperature = <100000>;
++};
++
++&gpu_temp_critical {
++	temperature = <100000>;
++};
++
++&ve_temp_critical {
++	temperature = <100000>;
++};
++
++&ddr_temp_critical {
++	temperature = <100000>;
++};
++
++&pio {
++	vcc-pc-supply = <&reg_dldo1>;
++	vcc-pf-supply = <&reg_dldo1>;
++	vcc-pg-supply = <&reg_aldo1>;
++	vcc-ph-supply = <&reg_dldo1>;
++	vcc-pi-supply = <&reg_dldo1>;
++
++	/omit-if-no-ref/
++	i2c0_pi_pins: i2c0-pi-pins {
++		pins = "PI5", "PI6";
++		function = "i2c0";
++	};
++
++	/omit-if-no-ref/
++	i2c1_pi_pins: i2c1-pi-pins {
++		pins = "PI7", "PI8";
++		function = "i2c1";
++	};
++
++	/omit-if-no-ref/
++	i2c2_pi_pins: i2c2-pi-pins {
++		pins = "PI9", "PI10";
++		function = "i2c2";
++	};
++
++    i2c3_pa_pins: i2c3-pa-pins {
++        pins = "PA10", "PA11";
++        function = "i2c3";
++        bias-pull-up;
++    };
++
++	/omit-if-no-ref/
++	i2c4_ph_pins: i2c4-ph-pins {
++		pins = "PH6", "PH7";
++		function = "i2c4";
++	};
++
++	/omit-if-no-ref/
++	uart2_pi_pins: uart2-pi-pins {
++		pins = "PI5", "PI6";
++		function = "uart2";
++	};
++
++	/omit-if-no-ref/
++	uart3_pi_pins: uart3-pi-pins {
++		pins = "PI9", "PI10";
++		function = "uart3";
++	};
++
++	/omit-if-no-ref/
++	uart4_pi_pins: uart4-pi-pins {
++		pins = "PI13", "PI14";
++		function = "uart4";
++	};
++
++	/omit-if-no-ref/
++	uart5_ph_pins: uart5-ph-pins {
++		pins = "PH2", "PH3";
++		function = "uart5";
++	};
++
++	/omit-if-no-ref/
++	spi1_cs1_pin: spi1-cs1-pin {
++		pins = "PH9";
++		function = "spi1";
++	};
++
++	/omit-if-no-ref/
++	pwm1_ph_pin: pwm1-ph-pin {
++		pins = "PH3";
++		function = "pwm1";
++	};
++
++	/omit-if-no-ref/
++	pwm2_ph_pin: pwm2-ph-pin {
++		pins = "PH2";
++		function = "pwm2";
++	};
++
++	/omit-if-no-ref/
++	pwm3_ph_pin: pwm3-ph-pin {
++		pins = "PH0";
++		function = "pwm3";
++	};
++
++	/omit-if-no-ref/
++	pwm4_ph_pin: pwm4-ph-pin {
++		pins = "PH1";
++		function = "pwm4";
++	};
++
++	/omit-if-no-ref/
++	pwm5_pin: pwm5-pin {
++		pins = "PA12";
++		function = "pwm5";
++	};
++};

--- a/patch/kernel/archive/sunxi-6.6/series.conf
+++ b/patch/kernel/archive/sunxi-6.6/series.conf
@@ -446,3 +446,4 @@
 	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-enable-hdmi.patch
 	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-enable-emac1.patch
 	patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-enable-ir-receiver.patch
+	patches.armbian/cherryba-m1-add-dtb.patch

--- a/patch/u-boot/v2024.01/board_cherryba-m1/add_and_fix_cherryba-m1_uboot.patch
+++ b/patch/u-boot/v2024.01/board_cherryba-m1/add_and_fix_cherryba-m1_uboot.patch
@@ -1,0 +1,379 @@
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index 9d28a485..2c2af950 100644
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -836,7 +836,8 @@ dtb-$(CONFIG_MACH_SUN50I_H6) += \
+ dtb-$(CONFIG_MACH_SUN50I_H616) += \
+ 	sun50i-h616-orangepi-zero2.dtb \
+ 	sun50i-h618-orangepi-zero3.dtb \
+-	sun50i-h616-x96-mate.dtb
++	sun50i-h616-x96-mate.dtb \
++	sun50i-h618-cherryba-m1.dtb
+ dtb-$(CONFIG_MACH_SUN50I) += \
+ 	sun50i-a64-amarula-relic.dtb \
+ 	sun50i-a64-bananapi-m64.dtb \
+diff --git a/arch/arm/dts/sun50i-h618-cherryba-m1.dts b/arch/arm/dts/sun50i-h618-cherryba-m1.dts
+new file mode 100644
+index 00000000..56e9dc1b
+--- /dev/null
++++ b/arch/arm/dts/sun50i-h618-cherryba-m1.dts
+@@ -0,0 +1,132 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2024 Patrick Yavitz <pyavitz@xxxxx.com>
++ */
++
++/dts-v1/;
++
++#include "sun50i-h616.dtsi"
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/interrupt-controller/arm-gic.h>
++#include <dt-bindings/leds/common.h>
++
++/ {
++	model = "CherryBa M1";
++	compatible = "CherryBa,CherryBa-h618", "allwinner,sun50i-h618";
++
++	aliases {
++		serial0 = &uart0;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	reg_vcc5v: regulator-5v {
++		/* board wide 5V supply directly from the USB-C socket */
++		compatible = "regulator-fixed";
++		regulator-name = "vcc-5v";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		regulator-always-on;
++	};
++
++	reg_usb_vbus: regulator-usb-vbus {
++		/* separate discrete regulator for the USB ports */
++		compatible = "regulator-fixed";
++		regulator-name = "usb-vbus";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&reg_vcc5v>;
++	};
++};
++
++&cpu0 {
++	cpu-supply = <&reg_dcdc2>;
++};
++
++&mmc0 {
++	vmmc-supply = <&reg_dldo1>;
++	cd-gpios = <&pio 5 6 GPIO_ACTIVE_LOW>;	/* PF6 */
++	bus-width = <4>;
++	max-frequency = <50000000>;
++	status = "okay";
++};
++
++&mmc2 {
++	vmmc-supply = <&reg_dldo1>;
++	vqmmc-supply = <&reg_aldo1>;
++	bus-width = <8>;
++	non-removable;
++	cap-mmc-hw-reset;
++	mmc-hs200-1_8v;
++	status = "okay";
++};
++
++&pio {
++	vcc-pc-supply = <&reg_aldo1>;
++	vcc-pf-supply = <&reg_dldo1>;
++	vcc-pg-supply = <&reg_dldo1>;
++	vcc-ph-supply = <&reg_dldo1>;
++	vcc-pi-supply = <&reg_dldo1>;
++};
++
++&r_i2c {
++	status = "okay";
++
++	axp313: pmic@36 {
++		compatible = "x-powers,axp313a";
++		reg = <0x36>;
++		#interrupt-cells = <1>;
++		interrupt-controller;
++		interrupt-parent = <&pio>;
++
++		vin1-supply = <&reg_vcc5v>;
++		vin2-supply = <&reg_vcc5v>;
++		vin3-supply = <&reg_vcc5v>;
++
++		regulators {
++			reg_aldo1: aldo1 {
++				regulator-always-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "vcc-1v8-pll";
++			};
++
++			reg_dldo1: dldo1 {
++				regulator-always-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-name = "vcc-3v3-io";
++			};
++
++			reg_dcdc1: dcdc1 {
++				regulator-always-on;
++				regulator-min-microvolt = <810000>;
++				regulator-max-microvolt = <990000>;
++				regulator-name = "vdd-gpu-sys";
++			};
++
++			reg_dcdc2: dcdc2 {
++				regulator-always-on;
++				regulator-min-microvolt = <810000>;
++				regulator-max-microvolt = <1100000>;
++				regulator-name = "vdd-cpu";
++			};
++
++			reg_dcdc3: dcdc3 {
++				regulator-always-on;
++				regulator-min-microvolt = <1100000>;
++				regulator-max-microvolt = <1100000>;
++				regulator-name = "vdd-dram";
++			};
++		};
++	};
++};
++
++&uart0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart0_ph_pins>;
++	status = "okay";
++};
+diff --git a/arch/arm/include/asm/arch-sunxi/dram.h b/arch/arm/include/asm/arch-sunxi/dram.h
+index 682daae6..9d21b492 100644
+--- a/arch/arm/include/asm/arch-sunxi/dram.h
++++ b/arch/arm/include/asm/arch-sunxi/dram.h
+@@ -40,5 +40,6 @@
+ unsigned long sunxi_dram_init(void);
+ void mctl_await_completion(u32 *reg, u32 mask, u32 val);
+ bool mctl_mem_matches(u32 offset);
++bool mctl_mem_matches_base(u32 offset, ulong base);
+ 
+ #endif /* _SUNXI_DRAM_H */
+diff --git a/arch/arm/mach-sunxi/clock_sun50i_h6.c b/arch/arm/mach-sunxi/clock_sun50i_h6.c
+index bea91c78..7f60b8c7 100644
+--- a/arch/arm/mach-sunxi/clock_sun50i_h6.c
++++ b/arch/arm/mach-sunxi/clock_sun50i_h6.c
+@@ -16,6 +16,8 @@ void clock_init_safe(void)
+ 		/* this seems to enable PLLs on H616 */
+ 		setbits_le32(&prcm->sys_pwroff_gating, 0x10);
+ 		setbits_le32(&prcm->res_cal_ctrl, 2);
++		/* enable GPU */
++		writel(0, 0x7010254);
+ 	}
+ 
+ 	if (IS_ENABLED(CONFIG_MACH_SUN50I_H616) ||
+diff --git a/arch/arm/mach-sunxi/dram_helpers.c b/arch/arm/mach-sunxi/dram_helpers.c
+index cdf2750f..df784550 100644
+--- a/arch/arm/mach-sunxi/dram_helpers.c
++++ b/arch/arm/mach-sunxi/dram_helpers.c
+@@ -5,11 +5,13 @@
+  * (C) Copyright 2015 Hans de Goede <hdegoede@redhat.com>
+  */
+ 
+-#include <common.h>
++#include <config.h>
+ #include <time.h>
++#include <vsprintf.h>
+ #include <asm/barriers.h>
+ #include <asm/io.h>
+ #include <asm/arch/dram.h>
++#include <linux/delay.h>
+ 
+ /*
+  * Wait up to 1s for value to be set in given part of reg.
+@@ -25,19 +27,40 @@ void mctl_await_completion(u32 *reg, u32 mask, u32 val)
+ }
+ 
+ /*
+- * Test if memory at offset offset matches memory at begin of DRAM
++ * Test if memory at offset matches memory at a certain base
+  *
+  * Note: dsb() is not available on ARMv5 in Thumb mode
+  */
+ #ifndef CONFIG_MACH_SUNIV
+-bool mctl_mem_matches(u32 offset)
++bool mctl_mem_matches_base(u32 offset, ulong base)
+ {
++	u32 val_base;
++	u32 val_offset;
++	bool ret;
++
++	/* Save original values */
++	val_base = readl(base);
++	val_offset = readl(base + offset);
++
+ 	/* Try to write different values to RAM at two addresses */
+-	writel(0, CFG_SYS_SDRAM_BASE);
+-	writel(0xaa55aa55, (ulong)CFG_SYS_SDRAM_BASE + offset);
++	writel(0, base);
++	writel(0xaa55aa55, base + offset);
+ 	dsb();
++	udelay(150);
+ 	/* Check if the same value is actually observed when reading back */
+-	return readl(CFG_SYS_SDRAM_BASE) ==
+-	       readl((ulong)CFG_SYS_SDRAM_BASE + offset);
++	ret = readl(base) == readl(base + offset);
++
++	/* Restore original values */
++	writel(val_base, base);
++	writel(val_offset, base + offset);
++	return ret;
++}
++
++/*
++ * Test if memory at offset matches memory at begin of DRAM
++ */
++bool mctl_mem_matches(u32 offset)
++{
++	return mctl_mem_matches_base(offset, CFG_SYS_SDRAM_BASE);
+ }
+ #endif
+diff --git a/arch/arm/mach-sunxi/dram_sunxi_dw.c b/arch/arm/mach-sunxi/dram_sunxi_dw.c
+index 9382d3d0..4dc1a196 100644
+--- a/arch/arm/mach-sunxi/dram_sunxi_dw.c
++++ b/arch/arm/mach-sunxi/dram_sunxi_dw.c
+@@ -652,20 +652,6 @@ static int mctl_channel_init(uint16_t socid, struct dram_para *para)
+ 	return 0;
+ }
+ 
+-/*
+- * Test if memory at offset offset matches memory at a certain base
+- */
+-static bool mctl_mem_matches_base(u32 offset, ulong base)
+-{
+-	/* Try to write different values to RAM at two addresses */
+-	writel(0, base);
+-	writel(0xaa55aa55, base + offset);
+-	dsb();
+-	/* Check if the same value is actually observed when reading back */
+-	return readl(base) ==
+-	       readl(base + offset);
+-}
+-
+ static void mctl_auto_detect_dram_size_rank(uint16_t socid, struct dram_para *para, ulong base, struct rank_para *rank)
+ {
+ 	/* detect row address bits */
+diff --git a/board/sunxi/board.c b/board/sunxi/board.c
+index 8c12c8de..bec14d61 100644
+--- a/board/sunxi/board.c
++++ b/board/sunxi/board.c
+@@ -226,6 +226,15 @@ int board_init(void)
+ 	if (ret)
+ 		return ret;
+ 
++#if CONFIG_MACH_SUN50I_H616
++	/*
++	 * The bit[16] of register reg[0x03000000] must be zero for the THS
++	 * driver to work properly in the kernel. The BSP u-boot is putting
++	 * the whole register to zero so we are doing the same.
++	 */
++	writel(0x0, SUNXI_SRAMC_BASE);
++#endif
++
+ #if CONFIG_IS_ENABLED(DM_I2C)
+ 	/*
+ 	 * Temporary workaround for enabling I2C clocks until proper sunxi DM
+diff --git a/configs/cherryba-m1_defconfig b/configs/cherryba-m1_defconfig
+new file mode 100644
+index 00000000..c264ba23
+--- /dev/null
++++ b/configs/cherryba-m1_defconfig
+@@ -0,0 +1,31 @@
++CONFIG_ARM=y
++CONFIG_ARCH_SUNXI=y
++CONFIG_DEFAULT_DEVICE_TREE="sun50i-h618-cherryba-m1"
++CONFIG_SPL=y
++CONFIG_DRAM_SUN50I_H616_DX_ODT=0x07070707
++CONFIG_DRAM_SUN50I_H616_DX_DRI=0x0e0e0e0e
++CONFIG_DRAM_SUN50I_H616_CA_DRI=0x0e0e
++CONFIG_DRAM_SUN50I_H616_ODT_EN=0xaaaaeeee
++CONFIG_DRAM_SUN50I_H616_TPR6=0x48808080
++CONFIG_DRAM_SUN50I_H616_TPR10=0x402f6663
++CONFIG_DRAM_SUN50I_H616_TPR11=0x26262524
++CONFIG_DRAM_SUN50I_H616_TPR12=0x100f100f
++CONFIG_MACH_SUN50I_H616=y
++CONFIG_SUNXI_DRAM_H616_LPDDR4=y
++CONFIG_DRAM_CLK=792
++CONFIG_MMC_SUNXI_SLOT_EXTRA=2
++CONFIG_R_I2C_ENABLE=y
++# CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
++CONFIG_SPL_I2C=y
++CONFIG_SPL_SYS_I2C_LEGACY=y
++CONFIG_SYS_I2C_MVTWSI=y
++CONFIG_SYS_I2C_SLAVE=0x7f
++CONFIG_SYS_I2C_SPEED=400000
++CONFIG_SUN8I_EMAC=y
++CONFIG_SUPPORT_EMMC_BOOT=y
++CONFIG_AXP313_POWER=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_OHCI_HCD=y
++CONFIG_USB_MUSB_GADGET=y
++CONFIG_AXP_DCDC2_VOLT=900
++CONFIG_AXP_DCDC3_VOLT=1100
+diff --git a/drivers/mmc/sunxi_mmc.c b/drivers/mmc/sunxi_mmc.c
+index 714706d2..0da18ad1 100644
+--- a/drivers/mmc/sunxi_mmc.c
++++ b/drivers/mmc/sunxi_mmc.c
+@@ -492,7 +492,7 @@ static int sunxi_mmc_core_init(struct mmc *mmc)
+ 
+ 	/* Reset controller */
+ 	writel(SUNXI_MMC_GCTRL_RESET, &priv->reg->gctrl);
+-	udelay(1000);
++	udelay(20000);
+ 
+ 	return 0;
+ }
+@@ -543,6 +543,10 @@ struct mmc *sunxi_mmc_init(int sdc_no)
+ 
+ 	cfg->f_min = 400000;
+ 	cfg->f_max = 52000000;
++	
++	if (sdc_no == 2) {
++		cfg->f_max = 8000000;
++	}
+ 
+ 	if (mmc_resource_init(sdc_no) != 0)
+ 		return NULL;
+@@ -640,20 +644,26 @@ static int sunxi_mmc_probe(struct udevice *dev)
+ 	struct mmc_config *cfg = &plat->cfg;
+ 	struct ofnode_phandle_args args;
+ 	u32 *ccu_reg;
+-	int ret;
++	int bus_width, ret;
+ 
+ 	cfg->name = dev->name;
++	bus_width = dev_read_u32_default(dev, "bus-width", 1);
+ 
+ 	cfg->voltages = MMC_VDD_32_33 | MMC_VDD_33_34;
++	cfg->host_caps = 0;
++	if (bus_width == 8)
++		cfg->host_caps |= MMC_MODE_8BIT;
++	if (bus_width >= 4)
++		cfg->host_caps |= MMC_MODE_4BIT;
+ 	cfg->host_caps = MMC_MODE_HS_52MHz | MMC_MODE_HS;
+ 	cfg->b_max = CONFIG_SYS_MMC_MAX_BLK_COUNT;
+ 
+ 	cfg->f_min = 400000;
+ 	cfg->f_max = 52000000;
+ 
+-	ret = mmc_of_parse(dev, cfg);
+-	if (ret)
+-		return ret;
++	if (bus_width == 8) {
++		cfg->f_max = 52000000;
++	}
+ 
+ 	priv->reg = dev_read_addr_ptr(dev);
+ 


### PR DESCRIPTION
# Description

### If you encounter some network reasons that cause the download speed of resources on github and apt source stations to be very slow or fail, maybe we can use the system network proxy to solve it. The latest version supports the network proxy configured by the system environment variable https_proxy. This commit solves the problem that the https_proxy system network proxy configured by oras pull is not effective. Fixed issues  [7006](https://github.com/armbian/build/issues/7006)

#### 1. Execute the system command before ./compile.sh
`export https_proxy="http://<your HTTP proxy service IP>:<your HTTP proxy service Port>"`

