### PR TITLE
`Automatic` board configs status synchronise

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -68,7 +68,7 @@ config/boards/mekotronics-r58x-4g.csc		@monkaBlyat
 config/boards/mekotronics-r58x.csc		@monkaBlyat
 config/boards/mixtile-blade3.csc		@rpardini
 config/boards/nanopc-cm3588-nas.csc		@ColorfulRhino
-config/boards/nanopct6.conf		@Tonymac32
+config/boards/nanopct6.conf		@SuperKali @Tonymac32
 config/boards/nanopi-r4s.conf		@Manouchehri
 config/boards/nanopi-r5s.csc		@utlark
 config/boards/nanopi-r6c.csc		@ColorfulRhino

--- a/config/boards/nanopct6.conf
+++ b/config/boards/nanopct6.conf
@@ -1,7 +1,7 @@
 # Rockchip RK3588S octa core 8GB RAM SoC eMMC USB3 USB2 1x GbE 2x 2.5GbE
 BOARD_NAME="NanoPC T6"
 BOARDFAMILY="rockchip-rk3588"
-BOARD_MAINTAINER="Tonymac32"
+BOARD_MAINTAINER="SuperKali Tonymac32"
 BOOTCONFIG="nanopc_t6_defconfig" # vendor name, not standard, see hook below, set BOOT_SOC below to compensate
 BOOT_SOC="rk3588"
 KERNEL_TARGET="edge,current,vendor"


### PR DESCRIPTION
Update maintainers and board status

- synced status from the database
- rename to .`csc` where we don't have anyone

If you want to become a board maintainer, [adjust data here](https://www.armbian.com/update-data/).

Ref: [Board Maintainers Procedures and Guidelines](https://docs.armbian.com/Board_Maintainers_Procedures_and_Guidelines/)