### PR TITLE
Op5+/HDMI-RX: expose ITC type to v4l2 in synopsys hdmir rx

### DIFF
--- a/patch/kernel/archive/rockchip-rk3588-6.10/0113-add-synopsys-designware-hdmi-rx-controller.patch
+++ b/patch/kernel/archive/rockchip-rk3588-6.10/0113-add-synopsys-designware-hdmi-rx-controller.patch
@@ -3846,3 +3846,76 @@ index 111111111111..222222222222 100644
 -- 
 Armbian
 
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ben Hoff <hoff.benjamin.k@gmail.com>
+Date: Mon, 23 Sep 2024 09:43:38 -0400
+Subject: [PATCH] expose itc type to v4l2 in synopsys hdmir rx
+
+---
+ .../media/platform/synopsys/hdmirx/snps_hdmirx.c | 16 +++++++++++++++-
+ 1 file changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/media/platform/synopsys/hdmirx/snps_hdmirx.c b/drivers/media/platform/synopsys/hdmirx/snps_hdmirx.c
+index 111111111111..222222222222 100644
+--- a/drivers/media/platform/synopsys/hdmirx/snps_hdmirx.c
++++ b/drivers/media/platform/synopsys/hdmirx/snps_hdmirx.c
+@@ -151,6 +151,7 @@ struct snps_hdmirx_dev {
+ 	struct v4l2_ctrl_handler hdl;
+ 	struct v4l2_ctrl *detect_tx_5v_ctrl;
+ 	struct v4l2_ctrl *rgb_range;
++    struct v4l2_ctrl *content_type;
+ 	struct v4l2_dv_timings timings;
+ 	struct gpio_desc *detect_5v_gpio;
+ 	struct work_struct work_wdt_config;
+@@ -512,6 +513,11 @@ static void hdmirx_get_avi_infoframe(struct snps_hdmirx_dev *hdmirx_dev)
+ 	}
+ 
+ 	v4l2_ctrl_s_ctrl(hdmirx_dev->rgb_range, frame.avi.quantization_range);
++    if (frame.avi.itc) {
++        v4l2_ctrl_s_ctrl(hdmirx_dev->content_type, frame.avi.content_type);
++    } else {
++        v4l2_ctrl_s_ctrl(hdmirx_dev->content_type, V4L2_DV_IT_CONTENT_TYPE_NO_ITC);
++    }
+ }
+ 
+ /*
+@@ -1192,6 +1198,7 @@ static int hdmirx_wait_lock_and_get_timing(struct snps_hdmirx_dev *hdmirx_dev)
+ 			break;
+ 
+ 		if (!tx_5v_power_present(hdmirx_dev)) {
++            v4l2_ctrl_s_ctrl(hdmirx_dev->content_type, V4L2_DV_IT_CONTENT_TYPE_NO_ITC);
+ 			//v4l2_err(v4l2_dev, "%s: HDMI pull out, return\n", __func__);
+ 			return -1;
+ 		}
+@@ -1204,6 +1211,7 @@ static int hdmirx_wait_lock_and_get_timing(struct snps_hdmirx_dev *hdmirx_dev)
+ 			 __func__, hdmirx_dev->tmds_clk_ratio);
+ 		v4l2_err(v4l2_dev, "%s: mu_st:%#x, scdc_st:%#x, dma_st10:%#x\n",
+ 			 __func__, mu_status, scdc_status, dma_st10);
++        v4l2_ctrl_s_ctrl(hdmirx_dev->content_type, V4L2_DV_IT_CONTENT_TYPE_NO_ITC);
+ 		return -1;
+ 	}
+ 
+@@ -2668,7 +2676,7 @@ static int hdmirx_probe(struct platform_device *pdev)
+ 	strscpy(v4l2_dev->name, dev_name(dev), sizeof(v4l2_dev->name));
+ 
+ 	hdl = &hdmirx_dev->hdl;
+-	v4l2_ctrl_handler_init(hdl, 1);
++	v4l2_ctrl_handler_init(hdl, 3);
+ 
+ 	hdmirx_dev->detect_tx_5v_ctrl = v4l2_ctrl_new_std(hdl, NULL,
+ 							  V4L2_CID_DV_RX_POWER_PRESENT,
+@@ -2681,6 +2689,12 @@ static int hdmirx_probe(struct platform_device *pdev)
+ 
+ 	hdmirx_dev->rgb_range->flags |= V4L2_CTRL_FLAG_READ_ONLY;
+ 
++    hdmirx_dev->content_type = v4l2_ctrl_new_std_menu(hdl, NULL,
++            V4L2_CID_DV_RX_IT_CONTENT_TYPE,
++            V4L2_DV_IT_CONTENT_TYPE_NO_ITC,
++            0,
++            V4L2_DV_IT_CONTENT_TYPE_NO_ITC);
++
+ 	if (hdl->error) {
+ 		dev_err(dev, "v4l2 ctrl handler init failed\n");
+ 		ret = hdl->error;
+-- 
+Armbian


### PR DESCRIPTION
# Description
This exposes the ITC content type provided by hdmi spec to v4l2. This allows user space applications to query the driver using V4L2_CID_DV_RX_IT_CONTENT_TYPE. This way user applications can see not only if a hdmi is plugged in or not, but also what type of video is being transmitted. 

For my use case specifically, I just want to know if the recieved type is no type (V4L2_DV_IT_CONTENT_TYPE_NO_ITC) or literally anything else.

 This would let me detect when my main computer's goes to sleep with the hdmi out from the main computer plugged into the OP5+ HDMI in.

Without this patch, there's no way to tell that happened, as for my gpu/hdmi plug, it keeps the hot plug detection pin high the whole time.


# How Has This Been Tested?

tested on orange pi 5 plus

# Checklist:



- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

