### PR TITLE
Enable oras pull to use system proxy

### DIFF
--- a/lib/functions/general/oci-oras.sh
+++ b/lib/functions/general/oci-oras.sh
@@ -85,7 +85,7 @@ function run_tool_oras() {
 	display_alert "Running ORAS ${ACTUAL_VERSION}" "HOME='${ORAS_HOME}'; retries='${retries:-1}'; cmdline: $*" "debug"
 	if [[ "${retries:-1}" -gt 1 ]]; then
 		display_alert "Calling ORAS with retries ${retries}" "$*" "debug"
-		sleep_seconds="30" do_with_retries "${retries}" env -i "HOME=${ORAS_HOME}" "${ORAS_BIN}" "$@"
+		sleep_seconds="30" do_with_retries "${retries}" env -i "HOME=${ORAS_HOME}" "HTTPS_PROXY=${HTTPS_PROXY}"  "${ORAS_BIN}" "$@"
 	else
 		# If any parameters passed, call ORAS, otherwise exit. We call it this way (sans-parameters) early to prepare ORAS tooling.
 		if [[ $# -eq 0 ]]; then


### PR DESCRIPTION
# Description

If you encounter some network reasons that cause the download speed of resources on github and apt source stations to be very slow or fail, maybe we can use the system network proxy to solve it. The latest version supports the network proxy configured by the system environment variable HTTPS_PROXY. This commit solves the problem that the HTTPS_PROXY system network proxy configured by oras pull is not effective.

[GitHub issue 7006](https://github.com/armbian/build/issues/7006) 

The issue mentioned that in some complex network environments, it may be necessary to mount a proxy to allow normal "apt install" and "oras pull". However, because oras pull uses "env", the HTTPS_PROXY system proxy we configured is invalid. Therefore, loading the original HTTPS_PROXY in "env" can solve the problem of slow "apt install" and slow "oras pull"

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
