### PR TITLE
rockpro64: u-boot: patch u-boot's dtsi to enable otg port for UMS/Gadget capabilities

### DIFF
--- a/patch/u-boot/v2024.07/board_rockpro64/1000-rockchip-dts-rk3399-rockpro64-otg-usbdrd_dwc3_0-for-working-gadget-mode.patch
+++ b/patch/u-boot/v2024.07/board_rockpro64/1000-rockchip-dts-rk3399-rockpro64-otg-usbdrd_dwc3_0-for-working-gadget-mode.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ricardo Pardini <ricardo@pardini.net>
+Date: Sun, 8 Sep 2024 15:08:48 +0200
+Subject: rockchip: dts: rk3399: rockpro64: otg usbdrd_dwc3_0 for working
+ gadget mode
+
+---
+ arch/arm/dts/rk3399-rockpro64-u-boot.dtsi | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/arch/arm/dts/rk3399-rockpro64-u-boot.dtsi b/arch/arm/dts/rk3399-rockpro64-u-boot.dtsi
+index 43b67991fe5..2af0611c3b7 100644
+--- a/arch/arm/dts/rk3399-rockpro64-u-boot.dtsi
++++ b/arch/arm/dts/rk3399-rockpro64-u-boot.dtsi
+@@ -53,10 +53,16 @@
+ };
+ 
+ &vdd_center {
+ 	regulator-min-microvolt = <950000>;
+ 	regulator-max-microvolt = <950000>;
+ };
+ 
+ &vdd_log {
+ 	regulator-init-microvolt = <950000>;
+ };
++
++// both usbdrd_dwc3_0 usbdrd_dwc3_1 seem to be OTG-capable; use usbdrd_dwc3_0 for the type-c port
++&usbdrd_dwc3_0 {
++	status = "okay";
++	dr_mode = "otg";
++};
+-- 
+Armbian
+


### PR DESCRIPTION
#### rockpro64: u-boot: patch u-boot's dtsi to enable otg port for UMS/Gadget capabilities

- rockpro64: u-boot: patch u-boot's dtsi to enable otg port for UMS/Gadget capabilities
  - Fixes c158f74d228ab4a5e85c673b51df69143e956935
  - I'm slightly unsure why this wasn't needed before; possibly because in 2024.07 this board moved to OF_UPSTREAM?