### PR TITLE
systemd-networkd: default to DUIDType=link-layer for ipv6; via networkd.conf.d

### DIFF
--- a/extensions/network/config-networkd/systemd/networkd.conf.d/mac-duid.conf
+++ b/extensions/network/config-networkd/systemd/networkd.conf.d/mac-duid.conf
@@ -1,0 +1,9 @@
+# Use LL (link-layer, sans timestamp) DUIDs for DHCP.
+# It is the default for v4, but not for v6.
+# Having it set to LL allows network admins to do MAC-based reservations for v6 the same way there's done for v4.
+# If the MAC address of an interface is 01:02:03:04:05:06, then the DUID will be 00030001010203040506
+[DHCPv4]
+DUIDType=link-layer
+
+[DHCPv6]
+DUIDType=link-layer

--- a/extensions/network/net-systemd-networkd.sh
+++ b/extensions/network/net-systemd-networkd.sh
@@ -24,11 +24,18 @@ function pre_install_kernel_debs__configure_systemd_networkd() {
 	local netplan_config_src_folder="${EXTENSION_DIR}/config-networkd/netplan/"
 	local netplan_config_dst_folder="${SDCARD}/etc/netplan/"
 
+	run_host_command_logged cp -v "${netplan_config_src_folder}"* "${netplan_config_dst_folder}"
+
 	local networkd_config_src_folder="${EXTENSION_DIR}/config-networkd/systemd/network/"
 	local networkd_config_dst_folder="${SDCARD}/etc/systemd/network/"
 
-	run_host_command_logged cp -v "${netplan_config_src_folder}"* "${netplan_config_dst_folder}"
 	run_host_command_logged cp -v "${networkd_config_src_folder}"* "${networkd_config_dst_folder}"
+
+	local networkd_conf_d_config_src_folder="${EXTENSION_DIR}/config-networkd/systemd/networkd.conf.d/"
+	local networkd_conf_d_config_dst_folder="${SDCARD}/etc/systemd/networkd.conf.d/"
+
+	mkdir -p "${networkd_conf_d_config_dst_folder}" # This doesn't exist by default, create it
+	run_host_command_logged cp -v "${networkd_conf_d_config_src_folder}"* "${networkd_conf_d_config_dst_folder}"
 
 	# Change the file permissions according to https://netplan.readthedocs.io/en/stable/security/
 	chmod -v 600 "${SDCARD}"/etc/netplan/*


### PR DESCRIPTION
#### systemd-networkd: default to DUIDType=link-layer for ipv6; via networkd.conf.d

- systemd-networkd: default to DUIDType=link-layer for ipv6; via networkd.conf.d
  - only affects systemd-networkd-using builds (MINIMAL images?)
  - does NOT affect NetworkManager
  - this allows network administrators to give out IPv6 addresses over DHCPv6 based on the MAC address (which should be stable) instead of systemd's own notion of it's "DUID", which is based on the machine-id and changes on every redeployment