### PR TITLE
Orange Pi 3B: Update board config to support v2.1 boards

### DIFF
--- a/config/boards/orangepi3b.csc
+++ b/config/boards/orangepi3b.csc
@@ -1,5 +1,5 @@
 # Rockchip RK3566 quad core 4/8GB RAM SoC WIFI/BT eMMC USB2 USB3 NVMe PCIe GbE HDMI SPI
-BOARD_NAME="orangepi3b"
+BOARD_NAME="Orange Pi 3B"
 BOARDFAMILY="rk35xx"
 BOARD_MAINTAINER=""
 BOOTCONFIG="orangepi-3b-rk3566_defconfig"
@@ -7,17 +7,20 @@ BOOT_SOC="rk3566"
 KERNEL_TARGET="vendor,edge"
 FULL_DESKTOP="yes"
 BOOT_LOGO="desktop"
-BOOT_FDT_FILE="rockchip/rk3566-orangepi-3b.dtb"
 IMAGE_PARTITION_TABLE="gpt"
 BOOT_SCENARIO="spl-blobs"
 BOOT_SUPPORT_SPI="yes"
 BOOT_SPI_RKSPI_LOADER="yes"
-MODULES="sprdbt_tty sprdwl_ng"
-MODULES_BLACKLIST_LEGACY="bcmdhd"
+
+function post_family_config_branch_edge__orangepi3b_use_patched_dtb() {
+	# orangepi 3b dtbs are coming to mainline in v6.11
+	# until then, v1.1 boards can continue to use patched dtb
+	BOOT_FDT_FILE="rockchip/rk3566-orangepi-3b.dtb"
+}
 
 # Override family config for this board; let's avoid conditionals in family config.
 function post_family_config__orangepi3b_use_mainline_uboot() {
-	display_alert "$BOARD" "mainline (Kwiboo's tree) u-boot overrides" "info"
+	display_alert "$BOARD" "mainline u-boot overrides" "info"
 
 	BOOTSOURCE='https://github.com/u-boot/u-boot'
 	BOOTBRANCH="tag:v2024.10-rc3"
@@ -45,22 +48,22 @@ function post_family_config__orangepi3b_use_mainline_uboot() {
 		fi
 		flashcp "${extra_opts_flashcp[@]}" "${1}/u-boot-rockchip-spi.bin" /dev/mtd0
 	}
-
 }
 
 function post_family_tweaks_bsp__orangepi3b() {
-	display_alert "$BOARD" "Installing sprd-bluetooth.service" "info"
+	display_alert "$BOARD" "Installing orangepi3b-sprd-bluetooth.service" "info"
 
 	# Bluetooth on orangepi3b board is handled by a Spreadtrum (sprd) chip and requires
 	# a custom hciattach_opi binary, plus a systemd service to run it at boot time
 	install -m 755 $SRC/packages/bsp/rk3399/hciattach_opi $destination/usr/bin
-	cp $SRC/packages/bsp/rk3399/sprd-bluetooth.service $destination/lib/systemd/system/
+	install -m 755 $SRC/packages/bsp/orangepi3b/orangepi3b-sprd-bluetooth $destination/usr/bin/
+	cp $SRC/packages/bsp/orangepi3b/orangepi3b-sprd-bluetooth.service $destination/lib/systemd/system/
 
 	return 0
 }
 
 function post_family_tweaks__orangepi3b_enable_services() {
-	display_alert "$BOARD" "Enabling sprd-bluetooth.service" "info"
-	chroot_sdcard systemctl enable sprd-bluetooth.service
+	display_alert "$BOARD" "Enabling orangepi3b-sprd-bluetooth.service" "info"
+	chroot_sdcard systemctl enable orangepi3b-sprd-bluetooth.service
 	return 0
 }

--- a/packages/bsp/orangepi3b/orangepi3b-sprd-bluetooth
+++ b/packages/bsp/orangepi3b/orangepi3b-sprd-bluetooth
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# only run this for boards with sprd bluetooth chip (i.e. v1.1 boards)
+if [[ ! -d /proc/device-tree/sprd-mtty ]]; then
+	systemctl disable orangepi3b-sprd-bluetooth.service
+
+	exit 0
+fi
+
+modprobe -a sprdbt_tty sprdwl_ng
+rfkill unblock all
+/usr/bin/hciattach_opi -n -s 1500000 /dev/ttyBT0 sprd
+
+exit 0

--- a/packages/bsp/orangepi3b/orangepi3b-sprd-bluetooth.service
+++ b/packages/bsp/orangepi3b/orangepi3b-sprd-bluetooth.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Spreadtrum (sprd) bluetooth support for Orange Pi 3B v1.1
+Before=bluetooth.service
+
+[Service]
+Type=simple
+RemainAfterExit=Yes
+ExecStart=/usr/bin/orangepi3b-sprd-bluetooth
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
# Description

Orange Pi 3B v2.1 was released a few months back. This PR adds support for building vendor branch images for v2.1 boards.

We will rely on mainline U-Boot to [detect board version and serve the appropriate DTB](https://github.com/u-boot/u-boot/commit/a52099b4a2ae9e8cafc79268325249bcad308012#diff-1ca8d9ce95828f53150c73714c349fd38c171c4c3d51c2e606fea59a4358af84R13-R14).

Bluetooth and wifi functionality is provided by a Spreadtrum chip for v1.1 boards and a Broadcomm chip for v2.1 boards. Additional modules have to be added for v1.1, and these conflict with v2.1. A service is created to add these modules for v1.1 on boot.

Only vendor branch will support v2.1 boards. For edge, v2.1 boards will be supported in kernel v6.11.

v1.1 boards should ideally not notice any difference.

# How Has This Been Tested?

Tested on v2.1 board with build command:
`./compile.sh build BOARD=orangepi3b BRANCH=vendor BUILD_DESKTOP=no BUILD_MINIMAL=no KERNEL_CONFIGURE=no KERNEL_GIT=shallow RELEASE=noble`
- Successfully booted
- bluetooth and wifi works

I do not have a v1.1 board, and require testers to verify bluetooth and wifi works on vendor and edge images for v1.1.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
