### PR TITLE
rockchip-rk3588-6.11: bump to v6.11-rc7; manually rebase `0001-general-add-overlay-support.patch`

### DIFF
--- a/patch/kernel/archive/rockchip-rk3588-6.11/0001-general-add-overlay-support.patch
+++ b/patch/kernel/archive/rockchip-rk3588-6.11/0001-general-add-overlay-support.patch
@@ -36,24 +36,24 @@ diff --git a/scripts/Makefile.lib b/scripts/Makefile.lib
 index 111111111111..222222222222 100644
 --- a/scripts/Makefile.lib
 +++ b/scripts/Makefile.lib
-@@ -402,7 +402,7 @@ $(obj)/%.dtbo.S: $(obj)/%.dtbo FORCE
+@@ -405,7 +405,7 @@ cmd_dtb_check = $(if $(dtb-check-enabled),; $(DT_CHECKER) $(DT_CHECKER_FLAGS) -u
  
- quiet_cmd_dtc = DTC     $@
+ quiet_cmd_dtc = DTC $(quiet_dtb_check_tag) $@
  cmd_dtc = $(HOSTCC) -E $(dtc_cpp_flags) -x assembler-with-cpp -o $(dtc-tmp) $< ; \
 -	$(DTC) -o $@ -b 0 \
 +	$(DTC) -@ -o $@ -b 0 \
  		$(addprefix -i,$(dir $<) $(DTC_INCLUDE)) $(DTC_FLAGS) \
  		-d $(depfile).dtc.tmp $(dtc-tmp) ; \
- 	cat $(depfile).pre.tmp $(depfile).dtc.tmp > $(depfile)
-@@ -438,12 +438,18 @@ quiet_cmd_dtb = $(quiet_cmd_dtc)
-       cmd_dtb = $(cmd_dtc)
+ 	cat $(depfile).pre.tmp $(depfile).dtc.tmp > $(depfile) \
+@@ -430,12 +430,18 @@ DT_TMP_SCHEMA := $(objtree)/$(DT_BINDING_DIR)/processed-schema.json
+ dtb-check-enabled = $(if $(filter %.dtb, $@),y)
  endif
  
 +quiet_cmd_scr = MKIMAGE $@
 +cmd_scr = mkimage -C none -A $(ARCH) -T script -d $< $@
 +
  $(obj)/%.dtb: $(obj)/%.dts $(DTC) $(DT_TMP_SCHEMA) FORCE
- 	$(call if_changed_dep,dtb)
+ 	$(call if_changed_dep,dtc)
  
  $(obj)/%.dtbo: $(src)/%.dtso $(DTC) FORCE
  	$(call if_changed_dep,dtc)

--- a/patch/kernel/archive/rockchip-rk3588-6.11/0011-irqchip-fix-its-timeout-issue.patch
+++ b/patch/kernel/archive/rockchip-rk3588-6.11/0011-irqchip-fix-its-timeout-issue.patch
@@ -19,7 +19,7 @@ index 111111111111..222222222222 100644
  	u32			nr_ites;
  	u32			device_id;
  	bool			shared;
-@@ -2186,6 +2187,9 @@ static void gic_reset_prop_table(void *va)
+@@ -2180,6 +2181,9 @@ static void gic_reset_prop_table(void *va)
  static struct page *its_allocate_prop_table(gfp_t gfp_flags)
  {
  	struct page *prop_page;
@@ -29,7 +29,7 @@ index 111111111111..222222222222 100644
  
  	prop_page = alloc_pages(gfp_flags, get_order(LPI_PROPBASE_SZ));
  	if (!prop_page)
-@@ -2310,6 +2314,7 @@ static int its_setup_baser(struct its_node *its, struct its_baser *baser,
+@@ -2304,6 +2308,7 @@ static int its_setup_baser(struct its_node *its, struct its_baser *baser,
  	u32 alloc_pages, psz;
  	struct page *page;
  	void *base;
@@ -37,7 +37,7 @@ index 111111111111..222222222222 100644
  
  	psz = baser->psz;
  	alloc_pages = (PAGE_ORDER_TO_SIZE(order) / psz);
-@@ -2321,7 +2326,11 @@ static int its_setup_baser(struct its_node *its, struct its_baser *baser,
+@@ -2315,7 +2320,11 @@ static int its_setup_baser(struct its_node *its, struct its_baser *baser,
  		order = get_order(GITS_BASER_PAGES_MAX * psz);
  	}
  
@@ -50,7 +50,7 @@ index 111111111111..222222222222 100644
  	if (!page)
  		return -ENOMEM;
  
-@@ -2371,6 +2380,15 @@ static int its_setup_baser(struct its_node *its, struct its_baser *baser,
+@@ -2365,6 +2374,15 @@ static int its_setup_baser(struct its_node *its, struct its_baser *baser,
  	its_write_baser(its, baser, val);
  	tmp = baser->val;
  
@@ -66,7 +66,7 @@ index 111111111111..222222222222 100644
  	if ((val ^ tmp) & GITS_BASER_SHAREABILITY_MASK) {
  		/*
  		 * Shareability didn't stick. Just use
-@@ -2960,7 +2978,9 @@ static int its_alloc_collections(struct its_node *its)
+@@ -2954,7 +2972,9 @@ static int its_alloc_collections(struct its_node *its)
  static struct page *its_allocate_pending_table(gfp_t gfp_flags)
  {
  	struct page *pend_page;
@@ -77,7 +77,7 @@ index 111111111111..222222222222 100644
  	pend_page = alloc_pages(gfp_flags | __GFP_ZERO,
  				get_order(LPI_PENDBASE_SZ));
  	if (!pend_page)
-@@ -3119,6 +3139,11 @@ static void its_cpu_init_lpis(void)
+@@ -3113,6 +3133,11 @@ static void its_cpu_init_lpis(void)
  	if (!rdists_support_shareable())
  		tmp &= ~GICR_PROPBASER_SHAREABILITY_MASK;
  
@@ -89,7 +89,7 @@ index 111111111111..222222222222 100644
  	if ((tmp ^ val) & GICR_PROPBASER_SHAREABILITY_MASK) {
  		if (!(tmp & GICR_PROPBASER_SHAREABILITY_MASK)) {
  			/*
-@@ -3146,6 +3171,11 @@ static void its_cpu_init_lpis(void)
+@@ -3140,6 +3165,11 @@ static void its_cpu_init_lpis(void)
  	if (!rdists_support_shareable())
  		tmp &= ~GICR_PENDBASER_SHAREABILITY_MASK;
  
@@ -101,7 +101,7 @@ index 111111111111..222222222222 100644
  	if (!(tmp & GICR_PENDBASER_SHAREABILITY_MASK)) {
  		/*
  		 * The HW reports non-shareable, we must remove the
-@@ -3309,7 +3339,11 @@ static bool its_alloc_table_entry(struct its_node *its,
+@@ -3303,7 +3333,11 @@ static bool its_alloc_table_entry(struct its_node *its,
  
  	/* Allocate memory for 2nd level table */
  	if (!table[idx]) {
@@ -114,7 +114,7 @@ index 111111111111..222222222222 100644
  					get_order(baser->psz));
  		if (!page)
  			return false;
-@@ -3398,6 +3432,7 @@ static struct its_device *its_create_device(struct its_node *its, u32 dev_id,
+@@ -3392,6 +3426,7 @@ static struct its_device *its_create_device(struct its_node *its, u32 dev_id,
  	int nr_lpis;
  	int nr_ites;
  	int sz;
@@ -122,7 +122,7 @@ index 111111111111..222222222222 100644
  
  	if (!its_alloc_device_table(its, dev_id))
  		return NULL;
-@@ -3413,7 +3448,15 @@ static struct its_device *its_create_device(struct its_node *its, u32 dev_id,
+@@ -3407,7 +3442,15 @@ static struct its_device *its_create_device(struct its_node *its, u32 dev_id,
  	nr_ites = max(2, nvecs);
  	sz = nr_ites * (FIELD_GET(GITS_TYPER_ITT_ENTRY_SIZE, its->typer) + 1);
  	sz = max(sz, ITS_ITT_ALIGN) + ITS_ITT_ALIGN - 1;
@@ -139,7 +139,7 @@ index 111111111111..222222222222 100644
  	if (alloc_lpis) {
  		lpi_map = its_lpi_alloc(nvecs, &lpi_base, &nr_lpis);
  		if (lpi_map)
-@@ -3427,7 +3470,13 @@ static struct its_device *its_create_device(struct its_node *its, u32 dev_id,
+@@ -3421,7 +3464,13 @@ static struct its_device *its_create_device(struct its_node *its, u32 dev_id,
  
  	if (!dev || !itt ||  !col_map || (!lpi_map && alloc_lpis)) {
  		kfree(dev);
@@ -154,7 +154,7 @@ index 111111111111..222222222222 100644
  		bitmap_free(lpi_map);
  		kfree(col_map);
  		return NULL;
-@@ -3437,6 +3486,7 @@ static struct its_device *its_create_device(struct its_node *its, u32 dev_id,
+@@ -3431,6 +3480,7 @@ static struct its_device *its_create_device(struct its_node *its, u32 dev_id,
  
  	dev->its = its;
  	dev->itt = itt;
@@ -162,7 +162,7 @@ index 111111111111..222222222222 100644
  	dev->nr_ites = nr_ites;
  	dev->event_map.lpi_map = lpi_map;
  	dev->event_map.col_map = col_map;
-@@ -3464,7 +3514,13 @@ static void its_free_device(struct its_device *its_dev)
+@@ -3458,7 +3508,13 @@ static void its_free_device(struct its_device *its_dev)
  	list_del(&its_dev->entry);
  	raw_spin_unlock_irqrestore(&its_dev->its->lock, flags);
  	kfree(its_dev->event_map.col_map);
@@ -177,7 +177,7 @@ index 111111111111..222222222222 100644
  	kfree(its_dev);
  }
  
-@@ -5079,6 +5135,7 @@ static int __init its_probe_one(struct its_node *its)
+@@ -5083,6 +5139,7 @@ static int __init its_probe_one(struct its_node *its)
  	struct page *page;
  	u32 ctlr;
  	int err;
@@ -185,7 +185,7 @@ index 111111111111..222222222222 100644
  
  	its_enable_quirks(its);
  
-@@ -5112,7 +5169,10 @@ static int __init its_probe_one(struct its_node *its)
+@@ -5116,7 +5173,10 @@ static int __init its_probe_one(struct its_node *its)
  		}
  	}
  
@@ -197,7 +197,7 @@ index 111111111111..222222222222 100644
  				get_order(ITS_CMD_QUEUE_SZ));
  	if (!page) {
  		err = -ENOMEM;
-@@ -5141,6 +5201,11 @@ static int __init its_probe_one(struct its_node *its)
+@@ -5145,6 +5205,11 @@ static int __init its_probe_one(struct its_node *its)
  	if (its->flags & ITS_FLAGS_FORCE_NON_SHAREABLE)
  		tmp &= ~GITS_CBASER_SHAREABILITY_MASK;
  

--- a/patch/kernel/archive/rockchip-rk3588-6.11/1060-arm64-dts-rockchip-Split-pcie30x1m1-pinctrl.patch
+++ b/patch/kernel/archive/rockchip-rk3588-6.11/1060-arm64-dts-rockchip-Split-pcie30x1m1-pinctrl.patch
@@ -1,7 +1,7 @@
-From 3d447d15299c7eab3058e259c2514d4b407d8de1 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Joshua Riek <jjriek@verizon.net>
 Date: Wed, 7 Aug 2024 10:19:47 -0400
-Subject: [PATCH 05/15] arm64: dts: rockchip: Split pcie30x1m1 pinctrl
+Subject: arm64: dts: rockchip: Split pcie30x1m1 pinctrl
 
 The PCIe 3.0 PHYs need an external clock and will assert CLKREQ# to
 get it. Some RK3588 boards such as the Turning RK1, Mixtile 3588E,
@@ -9,11 +9,11 @@ and the ArmSoM AIM7 only provide this clock when CLKREQ# is asserted.
 
 Signed-off-by: Joshua Riek <jjriek@verizon.net>
 ---
- .../boot/dts/rockchip/rk3588-base-pinctrl.dtsi   | 16 +++++++++++++---
+ arch/arm64/boot/dts/rockchip/rk3588-base-pinctrl.dtsi | 16 ++++++++--
  1 file changed, 13 insertions(+), 3 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-base-pinctrl.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-base-pinctrl.dtsi
-index ca006f5a4c90..6de5729d2e65 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-base-pinctrl.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-base-pinctrl.dtsi
 @@ -1799,12 +1799,22 @@ pcie30x4m0_pins: pcie30x4m0-pins {
@@ -43,5 +43,5 @@ index ca006f5a4c90..6de5729d2e65 100644
  				<4 RK_PB5 4 &pcfg_pull_none>;
  		};
 -- 
-2.25.1
+Armbian
 

--- a/patch/kernel/archive/rockchip-rk3588-6.11/1061-arm64-dts-rockchip-Add-PCIe-3.0-pinctrl-to-Turing-RK.patch
+++ b/patch/kernel/archive/rockchip-rk3588-6.11/1061-arm64-dts-rockchip-Add-PCIe-3.0-pinctrl-to-Turing-RK.patch
@@ -1,8 +1,7 @@
-From b8322ec8dc89b0020bb4d552e79f99fac04fa3aa Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Joshua Riek <jjriek@verizon.net>
 Date: Wed, 7 Aug 2024 10:30:50 -0400
-Subject: [PATCH 06/15] arm64: dts: rockchip: Add PCIe 3.0 pinctrl to Turing
- RK1
+Subject: arm64: dts: rockchip: Add PCIe 3.0 pinctrl to Turing RK1
 
 The Turning RK1 needs to assert CLKREQ# to provide an external
 clock to the PCIe 3.0 PHYs.
@@ -13,7 +12,7 @@ Signed-off-by: Joshua Riek <jjriek@verizon.net>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
-index dbaa94ca69f4..5d0053ee3d45 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
 @@ -223,7 +223,7 @@ &pcie30phy {
@@ -26,5 +25,5 @@ index dbaa94ca69f4..5d0053ee3d45 100644
  	vpcie3v3-supply = <&vcc3v3_pcie30>;
  	status = "okay";
 -- 
-2.25.1
+Armbian
 

--- a/patch/kernel/archive/rockchip-rk3588-6.11/1062-arm64-dts-rockchip-Enable-GPU-node-on-Turing-RK1.patch
+++ b/patch/kernel/archive/rockchip-rk3588-6.11/1062-arm64-dts-rockchip-Enable-GPU-node-on-Turing-RK1.patch
@@ -1,7 +1,7 @@
-From 82e3d9c7dc918bb4278bdce7e9a0c4579781818d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Joshua Riek <jjriek@verizon.net>
 Date: Wed, 7 Aug 2024 10:34:35 -0400
-Subject: [PATCH 07/15] arm64: dts: rockchip: Enable GPU node on Turing RK1
+Subject: arm64: dts: rockchip: Enable GPU node on Turing RK1
 
 Enables the Mali G610 GPU.
 
@@ -11,7 +11,7 @@ Signed-off-by: Joshua Riek <jjriek@verizon.net>
  1 file changed, 5 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
-index 5d0053ee3d45..e157c5acfcb5 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
 @@ -101,6 +101,11 @@ &cpu_l3 {
@@ -27,5 +27,5 @@ index 5d0053ee3d45..e157c5acfcb5 100644
  	clock_in_out = "output";
  	phy-handle = <&rgmii_phy>;
 -- 
-2.25.1
+Armbian
 

--- a/patch/kernel/archive/rockchip-rk3588-6.11/1063-arm64-dts-rockchip-Enable-automatic-fan-control-on-t.patch
+++ b/patch/kernel/archive/rockchip-rk3588-6.11/1063-arm64-dts-rockchip-Enable-automatic-fan-control-on-t.patch
@@ -1,18 +1,17 @@
-From ec302349e26ce4bc00b2d438348d302bd468cb11 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Joshua Riek <jjriek@verizon.net>
 Date: Thu, 22 Aug 2024 22:32:47 -0400
-Subject: [PATCH 12/15] arm64: dts: rockchip: Enable automatic fan control on
- the Turing RK1
+Subject: arm64: dts: rockchip: Enable automatic fan control on the Turing RK1
 
 ---
- .../boot/dts/rockchip/rk3588-turing-rk1.dtsi  | 32 ++++++++++++++++++-
+ arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi | 32 +++++++++-
  1 file changed, 31 insertions(+), 1 deletion(-)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
-index f56a6a10c2ad..18b687a30e94 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
-@@ -24,7 +24,7 @@ aliases {
+@@ -23,7 +23,7 @@ aliases {
  
  	fan: pwm-fan {
  		compatible = "pwm-fan";
@@ -21,7 +20,7 @@ index f56a6a10c2ad..18b687a30e94 100644
  		fan-supply = <&vcc5v0_sys>;
  		pinctrl-names = "default";
  		pinctrl-0 = <&pwm0m2_pins &fan_int>;
-@@ -234,6 +234,36 @@ rgmii_phy: ethernet-phy@1 {
+@@ -213,6 +213,36 @@ rgmii_phy: ethernet-phy@1 {
  	};
  };
  
@@ -59,5 +58,5 @@ index f56a6a10c2ad..18b687a30e94 100644
  	linux,pci-domain = <1>;
  	pinctrl-names = "default";
 -- 
-2.25.1
+Armbian
 

--- a/patch/kernel/archive/rockchip-rk3588-6.11/1064-arm64-dts-rockchip-Add-missing-hym8563-clock-frequen.patch
+++ b/patch/kernel/archive/rockchip-rk3588-6.11/1064-arm64-dts-rockchip-Add-missing-hym8563-clock-frequen.patch
@@ -1,8 +1,8 @@
-From 8fa9e89184e736af4b81fdb67d5efa35f5d1996e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Joshua Riek <jjriek@verizon.net>
 Date: Wed, 7 Aug 2024 14:12:21 -0400
-Subject: [PATCH 08/15] arm64: dts: rockchip: Add missing hym8563
- clock-frequency for Turing RK1
+Subject: arm64: dts: rockchip: Add missing hym8563 clock-frequency for Turing
+ RK1
 
 Signed-off-by: Joshua Riek <jjriek@verizon.net>
 ---
@@ -10,7 +10,7 @@ Signed-off-by: Joshua Riek <jjriek@verizon.net>
  1 file changed, 1 insertion(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi b/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
-index e157c5acfcb5..dc36a7e048da 100644
+index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
 @@ -191,6 +191,7 @@ hym8563: rtc@51 {
@@ -22,5 +22,5 @@ index e157c5acfcb5..dc36a7e048da 100644
  		pinctrl-names = "default";
  		pinctrl-0 = <&hym8563_int>;
 -- 
-2.25.1
+Armbian
 


### PR DESCRIPTION
#### rockchip-rk3588-6.11: bump to v6.11-rc7; manually rebase `0001-general-add-overlay-support.patch`

- rockchip-rk3588-6.11: bump to v6.11-rc7; manually rebase `0001-general-add-overlay-support.patch`
  - this rebases manually around https://github.com/torvalds/linux/commit/8fcd8d1e63c05c48b3ac16d0c3e2cd6a7a5c8ec4 introduced in v6.11-rc5 (so much for "fixes only in rc's")
- rockchip-rk3588-6.11: rebase/rewrite patches onto v6.11-rc7
  - automatic / no conflicts