### PR TITLE
rockchip-rk3588: fix hdmi display of armsom-sige7 for edge and current

### DIFF
--- a/patch/kernel/archive/rockchip-rk3588-6.10/1031-arm64-dts-rockchip-Add-HDMI-support-to-ArmSoM-Sige7.patch
+++ b/patch/kernel/archive/rockchip-rk3588-6.10/1031-arm64-dts-rockchip-Add-HDMI-support-to-ArmSoM-Sige7.patch
@@ -19,7 +19,17 @@ index 111111111111..222222222222 100644
  #include "rk3588.dtsi"
  
  / {
-@@ -164,6 +165,20 @@ &gpu {
+@@ -159,11 +160,30 @@ &cpu_l3 {
+ 	cpu-supply = <&vdd_cpu_lit_s0>;
+ };
+ 
++&display_subsystem {
++	clocks = <&hdptxphy_hdmi0>;
++	clock-names = "hdmi0_phy_pll";
++};
++
+ &gpu {
+ 	mali-supply = <&vdd_gpu_s0>;
  	status = "okay";
  };
  
@@ -40,7 +50,7 @@ index 111111111111..222222222222 100644
  &i2c0 {
  	pinctrl-names = "default";
  	pinctrl-0 = <&i2c0m2_xfer>;
-@@ -723,3 +738,18 @@ &usb_host1_xhci {
+@@ -723,3 +743,18 @@ &usb_host1_xhci {
  	dr_mode = "host";
  	status = "okay";
  };

--- a/patch/kernel/archive/rockchip-rk3588-6.11/1031-arm64-dts-rockchip-Add-HDMI-support-to-ArmSoM-Sige7.patch
+++ b/patch/kernel/archive/rockchip-rk3588-6.11/1031-arm64-dts-rockchip-Add-HDMI-support-to-ArmSoM-Sige7.patch
@@ -19,7 +19,17 @@ index 111111111111..222222222222 100644
  #include "rk3588.dtsi"
  
  / {
-@@ -164,6 +165,20 @@ &gpu {
+@@ -159,11 +160,30 @@ &cpu_l3 {
+ 	cpu-supply = <&vdd_cpu_lit_s0>;
+ };
+ 
++&display_subsystem {
++	clocks = <&hdptxphy_hdmi0>;
++	clock-names = "hdmi0_phy_pll";
++};
++
+ &gpu {
+ 	mali-supply = <&vdd_gpu_s0>;
  	status = "okay";
  };
  
@@ -40,7 +50,7 @@ index 111111111111..222222222222 100644
  &i2c0 {
  	pinctrl-names = "default";
  	pinctrl-0 = <&i2c0m2_xfer>;
-@@ -723,3 +738,18 @@ &usb_host1_xhci {
+@@ -723,3 +743,18 @@ &usb_host1_xhci {
  	dr_mode = "host";
  	status = "okay";
  };


### PR DESCRIPTION
# Description

HDMI patch for armsom sige7 lacks hdmi clk support, like patch `1014-arm64-dts-rockchip-Make-use-of-HDMI0-PHY-PLL-on-rock5b.patch` for rock5b. This patch will let gnome desktop start fine.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh BOARD=armsom-sige7 BRANCH=edge BUILD_MINIMAL=no DEB_COMPRESS=xz KERNEL_CONFIGURE=no RELEASE=noble KERNEL_GIT=shallow BUILD_DESKTOP=yes DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base ENABLE_EXTENSIONS=mesa-vpu`
- [x] Gnome desktop with edge kernel starts fine
- [x] `./compile.sh BOARD=armsom-sige7 kernel-dtb BRANCH=curent BUILD_MINIMAL=no DEB_COMPRESS=xz KERNEL_CONFIGURE=no RELEASE=noble KERNEL_GIT=shallow BUILD_DESKTOP=yes DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base ENABLE_EXTENSIONS=mesa-vpu` build fine

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
