### PR TITLE
Odroid M1: resolve lowered network speed

### DIFF
--- a/patch/kernel/archive/rockchip64-6.10/general-net-stmmac-dwmac4-fix_PCS_duplex_mode_decode.patch
+++ b/patch/kernel/archive/rockchip64-6.10/general-net-stmmac-dwmac4-fix_PCS_duplex_mode_decode.patch
@@ -1,0 +1,52 @@
+From 85ba108a529d99c82e814eaf782a9443acf5eaed Mon Sep 17 00:00:00 2001
+From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
+Date: Tue, 6 Aug 2024 14:08:41 +0100
+Subject: net: stmmac: dwmac4: fix PCS duplex mode decode
+
+dwmac4 was decoding the duplex mode from the GMAC_PHYIF_CONTROL_STATUS
+register incorrectly, using GMAC_PHYIF_CTRLSTATUS_LNKMOD_MASK (value 1)
+rather than GMAC_PHYIF_CTRLSTATUS_LNKMOD (bit 16). Fix this.
+
+Fixes: 70523e639bf8c ("drivers: net: stmmac: reworking the PCS code.")
+Reviewed-by: Andrew Halaney <ahalaney@redhat.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Reviewed-by: Serge Semin <fancer.lancer@gmail.com>
+Signed-off-by: Russell King (Oracle) <rmk+kernel@armlinux.org.uk>
+Link: https://patch.msgid.link/E1sbJvd-001rGD-E3@rmk-PC.armlinux.org.uk
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/stmicro/stmmac/dwmac4.h      | 2 --
+ drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c | 2 +-
+ 2 files changed, 1 insertion(+), 3 deletions(-)
+
+(limited to 'drivers/net/ethernet/stmicro/stmmac')
+
+diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac4.h b/drivers/net/ethernet/stmicro/stmmac/dwmac4.h
+index d3c5306f1c41f7..93a78fd0737b6c 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/dwmac4.h
++++ b/drivers/net/ethernet/stmicro/stmmac/dwmac4.h
+@@ -573,8 +573,6 @@ static inline u32 mtl_low_credx_base_addr(const struct dwmac4_addrs *addrs,
+ #define GMAC_PHYIF_CTRLSTATUS_LNKSTS		BIT(19)
+ #define GMAC_PHYIF_CTRLSTATUS_JABTO		BIT(20)
+ #define GMAC_PHYIF_CTRLSTATUS_FALSECARDET	BIT(21)
+-/* LNKMOD */
+-#define GMAC_PHYIF_CTRLSTATUS_LNKMOD_MASK	0x1
+ /* LNKSPEED */
+ #define GMAC_PHYIF_CTRLSTATUS_SPEED_125		0x2
+ #define GMAC_PHYIF_CTRLSTATUS_SPEED_25		0x1
+diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c b/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c
+index f98741d2607ec4..31c387cc5f269d 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c
++++ b/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c
+@@ -786,7 +786,7 @@ static void dwmac4_phystatus(void __iomem *ioaddr, struct stmmac_extra_stats *x)
+ 		else
+ 			x->pcs_speed = SPEED_10;
+ 
+-		x->pcs_duplex = (status & GMAC_PHYIF_CTRLSTATUS_LNKMOD_MASK);
++		x->pcs_duplex = (status & GMAC_PHYIF_CTRLSTATUS_LNKMOD);
+ 
+ 		pr_info("Link is Up - %d/%s\n", (int)x->pcs_speed,
+ 			x->pcs_duplex ? "Full" : "Half");
+-- 
+cgit 1.2.3-korg
+

--- a/patch/kernel/archive/rockchip64-6.6/general-net-stmmac-dwmac4-fix_PCS_duplex_mode_decode.patch
+++ b/patch/kernel/archive/rockchip64-6.6/general-net-stmmac-dwmac4-fix_PCS_duplex_mode_decode.patch
@@ -1,0 +1,52 @@
+From 85ba108a529d99c82e814eaf782a9443acf5eaed Mon Sep 17 00:00:00 2001
+From: "Russell King (Oracle)" <rmk+kernel@armlinux.org.uk>
+Date: Tue, 6 Aug 2024 14:08:41 +0100
+Subject: net: stmmac: dwmac4: fix PCS duplex mode decode
+
+dwmac4 was decoding the duplex mode from the GMAC_PHYIF_CONTROL_STATUS
+register incorrectly, using GMAC_PHYIF_CTRLSTATUS_LNKMOD_MASK (value 1)
+rather than GMAC_PHYIF_CTRLSTATUS_LNKMOD (bit 16). Fix this.
+
+Fixes: 70523e639bf8c ("drivers: net: stmmac: reworking the PCS code.")
+Reviewed-by: Andrew Halaney <ahalaney@redhat.com>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Reviewed-by: Serge Semin <fancer.lancer@gmail.com>
+Signed-off-by: Russell King (Oracle) <rmk+kernel@armlinux.org.uk>
+Link: https://patch.msgid.link/E1sbJvd-001rGD-E3@rmk-PC.armlinux.org.uk
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/stmicro/stmmac/dwmac4.h      | 2 --
+ drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c | 2 +-
+ 2 files changed, 1 insertion(+), 3 deletions(-)
+
+(limited to 'drivers/net/ethernet/stmicro/stmmac')
+
+diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac4.h b/drivers/net/ethernet/stmicro/stmmac/dwmac4.h
+index d3c5306f1c41f7..93a78fd0737b6c 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/dwmac4.h
++++ b/drivers/net/ethernet/stmicro/stmmac/dwmac4.h
+@@ -573,8 +573,6 @@ static inline u32 mtl_low_credx_base_addr(const struct dwmac4_addrs *addrs,
+ #define GMAC_PHYIF_CTRLSTATUS_LNKSTS		BIT(19)
+ #define GMAC_PHYIF_CTRLSTATUS_JABTO		BIT(20)
+ #define GMAC_PHYIF_CTRLSTATUS_FALSECARDET	BIT(21)
+-/* LNKMOD */
+-#define GMAC_PHYIF_CTRLSTATUS_LNKMOD_MASK	0x1
+ /* LNKSPEED */
+ #define GMAC_PHYIF_CTRLSTATUS_SPEED_125		0x2
+ #define GMAC_PHYIF_CTRLSTATUS_SPEED_25		0x1
+diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c b/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c
+index f98741d2607ec4..31c387cc5f269d 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c
++++ b/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c
+@@ -786,7 +786,7 @@ static void dwmac4_phystatus(void __iomem *ioaddr, struct stmmac_extra_stats *x)
+ 		else
+ 			x->pcs_speed = SPEED_10;
+ 
+-		x->pcs_duplex = (status & GMAC_PHYIF_CTRLSTATUS_LNKMOD_MASK);
++		x->pcs_duplex = (status & GMAC_PHYIF_CTRLSTATUS_LNKMOD);
+ 
+ 		pr_info("Link is Up - %d/%s\n", (int)x->pcs_speed,
+ 			x->pcs_duplex ? "Full" : "Half");
+-- 
+cgit 1.2.3-korg
+


### PR DESCRIPTION
# Description

https://forum.armbian.com/topic/45066-odroid-m1-network-adapter-performance-in-jammy

# How Has This Been Tested?

Before:
```
[  5]   0.00-1.00   sec  63.5 MBytes   532 Mbits/sec  250   22.6 KBytes       
[  5]   1.00-2.00   sec  71.2 MBytes   598 Mbits/sec  234   21.2 KBytes       
[  5]   2.00-3.00   sec  68.6 MBytes   576 Mbits/sec  246   25.5 KBytes       
[  5]   3.00-4.00   sec  68.5 MBytes   575 Mbits/sec  250   26.9 KBytes       
[  5]   4.00-5.00   sec  68.6 MBytes   576 Mbits/sec  243   18.4 KBytes       
[  5]   5.00-6.00   sec  67.9 MBytes   570 Mbits/sec  252   29.7 KBytes       
[  5]   6.00-7.00   sec  68.9 MBytes   577 Mbits/sec  248   28.3 KBytes       
[  5]   7.00-8.00   sec  67.2 MBytes   564 Mbits/sec  250   28.3 KBytes       
[  5]   8.00-9.00   sec  70.1 MBytes   589 Mbits/sec  242   15.6 KBytes       
[  5]   9.00-10.01  sec  69.8 MBytes   580 Mbits/sec  243   19.8 KBytes  
```
After:
```
[  5]   0.00-1.00   sec  87.4 MBytes   732 Mbits/sec  143   24.0 KBytes       
[  5]   1.00-2.00   sec  92.1 MBytes   773 Mbits/sec  153   65.0 KBytes       
[  5]   2.00-3.00   sec  89.1 MBytes   748 Mbits/sec  165   39.6 KBytes       
[  5]   3.00-4.00   sec  89.2 MBytes   749 Mbits/sec  167   31.1 KBytes       
[  5]   4.00-5.00   sec  85.8 MBytes   719 Mbits/sec  180   38.2 KBytes       
[  5]   5.00-6.00   sec  88.6 MBytes   743 Mbits/sec  173   12.7 KBytes       
[  5]   6.00-7.00   sec  88.4 MBytes   741 Mbits/sec  171   59.4 KBytes       
[  5]   7.00-8.00   sec  89.9 MBytes   754 Mbits/sec  158   28.3 KBytes       
[  5]   8.00-9.00   sec  89.0 MBytes   747 Mbits/sec  164   21.2 KBytes       
[  5]   9.00-10.01  sec  87.6 MBytes   729 Mbits/sec  182   39.6 KByte

```
# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
