### PR TITLE
Gateway GZ80x: add dtsi and power off support via pwr button

### DIFF
--- a/patch/kernel/archive/meson64-6.11/dt/meson-axg-amper-gateway-am-gz80x.dts
+++ b/patch/kernel/archive/meson64-6.11/dt/meson-axg-amper-gateway-am-gz80x.dts
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 /*
  * Copyright (c) 2024 Patrick Yavitz <pyavitz@armbian.com>
- *
  */
 
 /dts-v1/;
 
-#include "meson-axg-jethome-jethub-j1xx.dtsi"
-#include <dt-bindings/leds/common.h>
+#include "meson-axg-amper-gateway-gz80x.dtsi"
 
 / {
 	compatible = "amper,gateway-am-gz80x", "amlogic,a113x", "amlogic,meson-axg";
@@ -20,35 +18,6 @@
 		ethernet0 = &ethmac;
 	};
 
-	chosen {
-		stdout-path = "serial0:115200n8";
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		led-blue {
-			color = <LED_COLOR_ID_BLUE>;
-			function = LED_FUNCTION_STATUS;
-			gpios = <&gpio_ao GPIOAO_3 GPIO_ACTIVE_HIGH>;
-			linux,default-trigger = "default-on";
-		};
-
-		led-green {
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_STATUS;
-			gpios = <&gpio_ao GPIOAO_4 GPIO_ACTIVE_HIGH>;
-			linux,default-trigger = "mmc1";
-		};
-
-		led-red {
-			color = <LED_COLOR_ID_RED>;
-			function = LED_FUNCTION_STATUS;
-			gpios = <&gpio_ao GPIOAO_7 GPIO_ACTIVE_HIGH>;
-			linux,default-trigger = "usb-host";
-		};
- 	};
-
 	/* 1024MB RAM */
 	memory@0 {
 		device_type = "memory";
@@ -56,13 +25,8 @@
 	};
 };
 
-/delete-node/ &i2c1;
-
-/* wifi module */
 &sd_emmc_b {
-	non-removable;
-
-	rtl8189ftv: wifi@1 {
+	sdio: wifi@1 {
 		reg = <1>;
 	};
 };
@@ -71,17 +35,4 @@
 	status = "okay";
 	pinctrl-0 = <&uart_b_z_pins>;
 	pinctrl-names = "default";
-};
-
-/* UART Wireless module */
-&uart_AO_B {
-	status = "okay";
-	pinctrl-0 = <&uart_ao_b_z_pins>;
-	pinctrl-names = "default";
-	reset-gpios = <&gpio GPIOZ_6 GPIO_ACTIVE_HIGH>;
-};
-
-&usb_pwr {
-	gpio = <&gpio_ao GPIOAO_5 GPIO_ACTIVE_HIGH>;
-	enable-active-high;
 };

--- a/patch/kernel/archive/meson64-6.11/dt/meson-axg-amper-gateway-am-gz80x.dts
+++ b/patch/kernel/archive/meson64-6.11/dt/meson-axg-amper-gateway-am-gz80x.dts
@@ -12,7 +12,6 @@
 	model = "Amper Gateway AM-GZ80x";
 
 	aliases {
-		serial0 = &uart_AO;
 		serial1 = &uart_B;
 		serial2 = &uart_AO_B;
 		ethernet0 = &ethmac;

--- a/patch/kernel/archive/meson64-6.11/dt/meson-axg-amper-gateway-gz80x.dtsi
+++ b/patch/kernel/archive/meson64-6.11/dt/meson-axg-amper-gateway-gz80x.dtsi
@@ -11,6 +11,10 @@
 #include <dt-bindings/thermal/thermal.h>
 
 / {
+	aliases {
+		serial0 = &uart_AO;
+	};
+
 	chosen {
 		stdout-path = "serial0:115200n8";
 	};

--- a/patch/kernel/archive/meson64-6.11/dt/meson-axg-amper-gateway-gz80x.dtsi
+++ b/patch/kernel/archive/meson64-6.11/dt/meson-axg-amper-gateway-gz80x.dtsi
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright (c) 2024 Patrick Yavitz <pyavitz@armbian.com>
+ */
+
+/dts-v1/;
+
+#include "meson-axg.dtsi"
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/thermal/thermal.h>
+
+/ {
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	emmc_pwrseq: emmc-pwrseq {
+		compatible = "mmc-pwrseq-emmc";
+		reset-gpios = <&gpio BOOT_9 GPIO_ACTIVE_LOW>;
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		button-power {
+			label = "power";
+			linux,code = <KEY_POWER>;
+			gpios = <&gpio_ao GPIOAO_6 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-blue {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio_ao GPIOAO_3 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "default-on";
+		};
+
+		led-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio_ao GPIOAO_4 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "mmc1";
+		};
+
+		led-red {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio_ao GPIOAO_7 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "usb-host";
+		};
+ 	};
+
+	reserved-memory {
+		linux,cma {
+			size = <0x0 0x400000>;
+		};
+	};
+
+	sdio_pwrseq: sdio-pwrseq {
+		compatible = "mmc-pwrseq-simple";
+		reset-gpios = <&gpio GPIOX_7 GPIO_ACTIVE_LOW>;
+		clocks = <&wifi32k>;
+		clock-names = "ext_clock";
+	};
+
+	thermal-zones {
+		cpu_thermal: cpu-thermal {
+			polling-delay-passive = <250>;
+			polling-delay = <1000>;
+			thermal-sensors = <&scpi_sensors 0>;
+			trips {
+				cpu_passive: cpu-passive {
+					temperature = <70000>; /* millicelsius */
+					hysteresis = <2000>; /* millicelsius */
+					type = "passive";
+				};
+
+				cpu_hot: cpu-hot {
+					temperature = <80000>; /* millicelsius */
+					hysteresis = <2000>; /* millicelsius */
+					type = "hot";
+				};
+
+				cpu_critical: cpu-critical {
+					temperature = <100000>; /* millicelsius */
+					hysteresis = <2000>; /* millicelsius */
+					type = "critical";
+				};
+			};
+
+			cpu_cooling_maps: cooling-maps {
+				map0 {
+					trip = <&cpu_passive>;
+					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+							<&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+							<&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+							<&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+				};
+
+				map1 {
+					trip = <&cpu_hot>;
+					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+							<&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+							<&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+							<&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+				};
+			};
+		};
+	};
+
+	usb_pwr: regulator-usb_pwr {
+		compatible = "regulator-fixed";
+		regulator-name = "USB_PWR";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		vin-supply = <&vcc_5v>;
+		regulator-always-on;
+
+		gpio = <&gpio_ao GPIOAO_5 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+
+	vcc_3v3: regulator-vcc_3v3 {
+		compatible = "regulator-fixed";
+		regulator-name = "VCC_3V3";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		vin-supply = <&vddao_3v3>;
+		regulator-always-on;
+	};
+
+	vcc_5v: regulator-vcc_5v {
+		compatible = "regulator-fixed";
+		regulator-name = "VCC5V";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-always-on;
+	};
+
+	vddao_3v3: regulator-vddao_3v3 {
+		compatible = "regulator-fixed";
+		regulator-name = "VDDAO_3V3";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		vin-supply = <&vcc_5v>;
+		regulator-always-on;
+	};
+
+	vddio_ao18: regulator-vddio_ao18 {
+		compatible = "regulator-fixed";
+		regulator-name = "VDDIO_AO18";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		vin-supply = <&vddao_3v3>;
+		regulator-always-on;
+	};
+
+	vddio_boot: regulator-vddio_boot {
+		compatible = "regulator-fixed";
+		regulator-name = "VDDIO_BOOT";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		vin-supply = <&vddao_3v3>;
+		regulator-always-on;
+	};
+
+	vccq_1v8: regulator-vccq_1v8 {
+		compatible = "regulator-fixed";
+		regulator-name = "VCCQ_1V8";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		vin-supply = <&vddao_3v3>;
+		regulator-always-on;
+	};
+
+	wifi32k: wifi32k {
+		compatible = "pwm-clock";
+		#clock-cells = <0>;
+		clock-frequency = <32768>;
+		pwms = <&pwm_ab 0 30518 0>; /* PWM_A at 32.768KHz */
+	};
+};
+
+&cpu0 {
+	#cooling-cells = <2>;
+};
+
+&cpu1 {
+	#cooling-cells = <2>;
+};
+
+&cpu2 {
+	#cooling-cells = <2>;
+};
+
+&cpu3 {
+	#cooling-cells = <2>;
+};
+
+&ethmac {
+	status = "okay";
+	pinctrl-0 = <&eth_rmii_x_pins>;
+	pinctrl-names = "default";
+	phy-mode = "rmii";
+};
+
+/* Peripheral I2C bus (on motherboard) */
+&i2c_AO {
+	status = "okay";
+	pinctrl-0 = <&i2c_ao_sck_10_pins>, <&i2c_ao_sda_11_pins>;
+	pinctrl-names = "default";
+};
+
+&pwm_ab {
+	status = "okay";
+	pinctrl-0 = <&pwm_a_x20_pins>;
+	pinctrl-names = "default";
+};
+
+/* WiFi module */
+&sd_emmc_b {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	pinctrl-0 = <&sdio_pins>;
+	pinctrl-1 = <&sdio_clk_gate_pins>;
+	pinctrl-names = "default", "clk-gate";
+
+	bus-width = <4>;
+	cap-sd-highspeed;
+	max-frequency = <50000000>;
+	disable-wp;
+	non-removable;
+
+	mmc-pwrseq = <&sdio_pwrseq>;
+
+	vmmc-supply = <&vddao_3v3>;
+	vqmmc-supply = <&vddio_boot>;
+};
+
+/* eMMC Storage */
+&sd_emmc_c {
+	status = "okay";
+	pinctrl-0 = <&emmc_pins>, <&emmc_ds_pins>;
+	pinctrl-1 = <&emmc_clk_gate_pins>;
+	pinctrl-names = "default", "clk-gate";
+
+	bus-width = <8>;
+	cap-mmc-highspeed;
+	max-frequency = <200000000>;
+	non-removable;
+	disable-wp;
+	mmc-ddr-1_8v;
+	mmc-hs200-1_8v;
+
+	mmc-pwrseq = <&emmc_pwrseq>;
+
+	vmmc-supply = <&vcc_3v3>;
+	vqmmc-supply = <&vccq_1v8>;
+};
+
+&spicc1 {
+	status = "okay";
+	pinctrl-0 = <&spi1_x_pins>, <&spi1_ss0_x_pins>;
+	pinctrl-names = "default";
+};
+
+/* UART Console */
+&uart_AO {
+	status = "okay";
+	pinctrl-0 = <&uart_ao_a_pins>;
+	pinctrl-names = "default";
+};
+
+/* UART Wireless module */
+&uart_AO_B {
+	status = "okay";
+	pinctrl-0 = <&uart_ao_b_z_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&gpio GPIOZ_6 GPIO_ACTIVE_HIGH>;
+};
+
+&usb {
+	status = "okay";
+	vbus-supply = <&usb_pwr>;
+};

--- a/patch/kernel/archive/meson64-6.6/dt/meson-axg-amper-gateway-am-gz80x.dts
+++ b/patch/kernel/archive/meson64-6.6/dt/meson-axg-amper-gateway-am-gz80x.dts
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 /*
  * Copyright (c) 2024 Patrick Yavitz <pyavitz@armbian.com>
- *
  */
 
 /dts-v1/;
 
-#include "meson-axg-jethome-jethub-j1xx.dtsi"
-#include <dt-bindings/leds/common.h>
+#include "meson-axg-amper-gateway-gz80x.dtsi"
 
 / {
 	compatible = "amper,gateway-am-gz80x", "amlogic,a113x", "amlogic,meson-axg";
@@ -20,35 +18,6 @@
 		ethernet0 = &ethmac;
 	};
 
-	chosen {
-		stdout-path = "serial0:115200n8";
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		led-blue {
-			color = <LED_COLOR_ID_BLUE>;
-			function = LED_FUNCTION_STATUS;
-			gpios = <&gpio_ao GPIOAO_3 GPIO_ACTIVE_HIGH>;
-			linux,default-trigger = "default-on";
-		};
-
-		led-green {
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_STATUS;
-			gpios = <&gpio_ao GPIOAO_4 GPIO_ACTIVE_HIGH>;
-			linux,default-trigger = "mmc1";
-		};
-
-		led-red {
-			color = <LED_COLOR_ID_RED>;
-			function = LED_FUNCTION_STATUS;
-			gpios = <&gpio_ao GPIOAO_7 GPIO_ACTIVE_HIGH>;
-			linux,default-trigger = "usb-host";
-		};
- 	};
-
 	/* 1024MB RAM */
 	memory@0 {
 		device_type = "memory";
@@ -56,13 +25,8 @@
 	};
 };
 
-/delete-node/ &i2c1;
-
-/* wifi module */
 &sd_emmc_b {
-	non-removable;
-
-	rtl8189ftv: wifi@1 {
+	sdio: wifi@1 {
 		reg = <1>;
 	};
 };
@@ -71,17 +35,4 @@
 	status = "okay";
 	pinctrl-0 = <&uart_b_z_pins>;
 	pinctrl-names = "default";
-};
-
-/* UART Wireless module */
-&uart_AO_B {
-	status = "okay";
-	pinctrl-0 = <&uart_ao_b_z_pins>;
-	pinctrl-names = "default";
-	reset-gpios = <&gpio GPIOZ_6 GPIO_ACTIVE_HIGH>;
-};
-
-&usb_pwr {
-	gpio = <&gpio_ao GPIOAO_5 GPIO_ACTIVE_HIGH>;
-	enable-active-high;
 };

--- a/patch/kernel/archive/meson64-6.6/dt/meson-axg-amper-gateway-am-gz80x.dts
+++ b/patch/kernel/archive/meson64-6.6/dt/meson-axg-amper-gateway-am-gz80x.dts
@@ -12,7 +12,6 @@
 	model = "Amper Gateway AM-GZ80x";
 
 	aliases {
-		serial0 = &uart_AO;
 		serial1 = &uart_B;
 		serial2 = &uart_AO_B;
 		ethernet0 = &ethmac;

--- a/patch/kernel/archive/meson64-6.6/dt/meson-axg-amper-gateway-gz80x.dtsi
+++ b/patch/kernel/archive/meson64-6.6/dt/meson-axg-amper-gateway-gz80x.dtsi
@@ -11,6 +11,10 @@
 #include <dt-bindings/thermal/thermal.h>
 
 / {
+	aliases {
+		serial0 = &uart_AO;
+	};
+
 	chosen {
 		stdout-path = "serial0:115200n8";
 	};

--- a/patch/kernel/archive/meson64-6.6/dt/meson-axg-amper-gateway-gz80x.dtsi
+++ b/patch/kernel/archive/meson64-6.6/dt/meson-axg-amper-gateway-gz80x.dtsi
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright (c) 2024 Patrick Yavitz <pyavitz@armbian.com>
+ */
+
+/dts-v1/;
+
+#include "meson-axg.dtsi"
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/thermal/thermal.h>
+
+/ {
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	emmc_pwrseq: emmc-pwrseq {
+		compatible = "mmc-pwrseq-emmc";
+		reset-gpios = <&gpio BOOT_9 GPIO_ACTIVE_LOW>;
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		button-power {
+			label = "power";
+			linux,code = <KEY_POWER>;
+			gpios = <&gpio_ao GPIOAO_6 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-blue {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio_ao GPIOAO_3 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "default-on";
+		};
+
+		led-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio_ao GPIOAO_4 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "mmc1";
+		};
+
+		led-red {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio_ao GPIOAO_7 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "usb-host";
+		};
+ 	};
+
+	reserved-memory {
+		linux,cma {
+			size = <0x0 0x400000>;
+		};
+	};
+
+	sdio_pwrseq: sdio-pwrseq {
+		compatible = "mmc-pwrseq-simple";
+		reset-gpios = <&gpio GPIOX_7 GPIO_ACTIVE_LOW>;
+		clocks = <&wifi32k>;
+		clock-names = "ext_clock";
+	};
+
+	thermal-zones {
+		cpu_thermal: cpu-thermal {
+			polling-delay-passive = <250>;
+			polling-delay = <1000>;
+			thermal-sensors = <&scpi_sensors 0>;
+			trips {
+				cpu_passive: cpu-passive {
+					temperature = <70000>; /* millicelsius */
+					hysteresis = <2000>; /* millicelsius */
+					type = "passive";
+				};
+
+				cpu_hot: cpu-hot {
+					temperature = <80000>; /* millicelsius */
+					hysteresis = <2000>; /* millicelsius */
+					type = "hot";
+				};
+
+				cpu_critical: cpu-critical {
+					temperature = <100000>; /* millicelsius */
+					hysteresis = <2000>; /* millicelsius */
+					type = "critical";
+				};
+			};
+
+			cpu_cooling_maps: cooling-maps {
+				map0 {
+					trip = <&cpu_passive>;
+					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+							<&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+							<&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+							<&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+				};
+
+				map1 {
+					trip = <&cpu_hot>;
+					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+							<&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+							<&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
+							<&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+				};
+			};
+		};
+	};
+
+	usb_pwr: regulator-usb_pwr {
+		compatible = "regulator-fixed";
+		regulator-name = "USB_PWR";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		vin-supply = <&vcc_5v>;
+		regulator-always-on;
+
+		gpio = <&gpio_ao GPIOAO_5 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+
+	vcc_3v3: regulator-vcc_3v3 {
+		compatible = "regulator-fixed";
+		regulator-name = "VCC_3V3";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		vin-supply = <&vddao_3v3>;
+		regulator-always-on;
+	};
+
+	vcc_5v: regulator-vcc_5v {
+		compatible = "regulator-fixed";
+		regulator-name = "VCC5V";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-always-on;
+	};
+
+	vddao_3v3: regulator-vddao_3v3 {
+		compatible = "regulator-fixed";
+		regulator-name = "VDDAO_3V3";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		vin-supply = <&vcc_5v>;
+		regulator-always-on;
+	};
+
+	vddio_ao18: regulator-vddio_ao18 {
+		compatible = "regulator-fixed";
+		regulator-name = "VDDIO_AO18";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		vin-supply = <&vddao_3v3>;
+		regulator-always-on;
+	};
+
+	vddio_boot: regulator-vddio_boot {
+		compatible = "regulator-fixed";
+		regulator-name = "VDDIO_BOOT";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		vin-supply = <&vddao_3v3>;
+		regulator-always-on;
+	};
+
+	vccq_1v8: regulator-vccq_1v8 {
+		compatible = "regulator-fixed";
+		regulator-name = "VCCQ_1V8";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		vin-supply = <&vddao_3v3>;
+		regulator-always-on;
+	};
+
+	wifi32k: wifi32k {
+		compatible = "pwm-clock";
+		#clock-cells = <0>;
+		clock-frequency = <32768>;
+		pwms = <&pwm_ab 0 30518 0>; /* PWM_A at 32.768KHz */
+	};
+};
+
+&cpu0 {
+	#cooling-cells = <2>;
+};
+
+&cpu1 {
+	#cooling-cells = <2>;
+};
+
+&cpu2 {
+	#cooling-cells = <2>;
+};
+
+&cpu3 {
+	#cooling-cells = <2>;
+};
+
+&ethmac {
+	status = "okay";
+	pinctrl-0 = <&eth_rmii_x_pins>;
+	pinctrl-names = "default";
+	phy-mode = "rmii";
+};
+
+/* Peripheral I2C bus (on motherboard) */
+&i2c_AO {
+	status = "okay";
+	pinctrl-0 = <&i2c_ao_sck_10_pins>, <&i2c_ao_sda_11_pins>;
+	pinctrl-names = "default";
+};
+
+&pwm_ab {
+	status = "okay";
+	pinctrl-0 = <&pwm_a_x20_pins>;
+	pinctrl-names = "default";
+};
+
+/* WiFi module */
+&sd_emmc_b {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	pinctrl-0 = <&sdio_pins>;
+	pinctrl-1 = <&sdio_clk_gate_pins>;
+	pinctrl-names = "default", "clk-gate";
+
+	bus-width = <4>;
+	cap-sd-highspeed;
+	max-frequency = <50000000>;
+	disable-wp;
+	non-removable;
+
+	mmc-pwrseq = <&sdio_pwrseq>;
+
+	vmmc-supply = <&vddao_3v3>;
+	vqmmc-supply = <&vddio_boot>;
+};
+
+/* eMMC Storage */
+&sd_emmc_c {
+	status = "okay";
+	pinctrl-0 = <&emmc_pins>, <&emmc_ds_pins>;
+	pinctrl-1 = <&emmc_clk_gate_pins>;
+	pinctrl-names = "default", "clk-gate";
+
+	bus-width = <8>;
+	cap-mmc-highspeed;
+	max-frequency = <200000000>;
+	non-removable;
+	disable-wp;
+	mmc-ddr-1_8v;
+	mmc-hs200-1_8v;
+
+	mmc-pwrseq = <&emmc_pwrseq>;
+
+	vmmc-supply = <&vcc_3v3>;
+	vqmmc-supply = <&vccq_1v8>;
+};
+
+&spicc1 {
+	status = "okay";
+	pinctrl-0 = <&spi1_x_pins>, <&spi1_ss0_x_pins>;
+	pinctrl-names = "default";
+};
+
+/* UART Console */
+&uart_AO {
+	status = "okay";
+	pinctrl-0 = <&uart_ao_a_pins>;
+	pinctrl-names = "default";
+};
+
+/* UART Wireless module */
+&uart_AO_B {
+	status = "okay";
+	pinctrl-0 = <&uart_ao_b_z_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&gpio GPIOZ_6 GPIO_ACTIVE_HIGH>;
+};
+
+&usb {
+	status = "okay";
+	vbus-supply = <&usb_pwr>;
+};

--- a/patch/u-boot/v2024.04/board_gateway-gz80x/001-Add-board-Amper-Gateway-AM-GZ80x.patch
+++ b/patch/u-boot/v2024.04/board_gateway-gz80x/001-Add-board-Amper-Gateway-AM-GZ80x.patch
@@ -1,21 +1,23 @@
-From 7e431409a7c34b844b27c0bfa89fe582f4093dc7 Mon Sep 17 00:00:00 2001
+From 945e2a0eabe3760f545e751c41e9ed7551787d29 Mon Sep 17 00:00:00 2001
 From: Patrick Yavitz <pyavitz@armbian.com>
-Date: Tue, 13 Aug 2024 07:13:24 -0400
-Subject: [PATCH] Add board Amper Gateway AM-GZ80X
+Date: Sat, 14 Sep 2024 19:54:57 -0400
+Subject: [PATCH] Add board Amper Gateway AM-GZ80x
 
 Signed-off-by: Patrick Yavitz <pyavitz@armbian.com>
 ---
- arch/arm/dts/Makefile                         |  1 +
- ...-axg-amper-gateway-am-gz80x-u-boot.dtsi | 10 +++
- .../meson-axg-amper-gateway-am-gz80x.dts   | 87 +++++++++++++++++++
- configs/amper_gateway_gz80x_defconfig   | 69 +++++++++++++++
- 4 files changed, 167 insertions(+)
+ arch/arm/dts/Makefile                         |   1 +
+ ...son-axg-amper-gateway-am-gz80x-u-boot.dtsi |   9 +
+ .../dts/meson-axg-amper-gateway-am-gz80x.dts  |  38 +++
+ .../dts/meson-axg-amper-gateway-gz80x.dtsi    | 293 ++++++++++++++++++
+ configs/amper_gateway_am-gz80x_defconfig      |  69 +++++
+ 5 files changed, 410 insertions(+)
  create mode 100644 arch/arm/dts/meson-axg-amper-gateway-am-gz80x-u-boot.dtsi
  create mode 100644 arch/arm/dts/meson-axg-amper-gateway-am-gz80x.dts
+ create mode 100644 arch/arm/dts/meson-axg-amper-gateway-gz80x.dtsi
  create mode 100644 configs/amper_gateway_am-gz80x_defconfig
 
 diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
-index b102ffb5f6..da81b57aec 100644
+index b102ffb5f6..dc25441b9d 100644
 --- a/arch/arm/dts/Makefile
 +++ b/arch/arm/dts/Makefile
 @@ -215,6 +215,7 @@ dtb-$(CONFIG_ARCH_S5P4418) += \
@@ -28,14 +30,13 @@ index b102ffb5f6..da81b57aec 100644
  	meson-gxbb-nanopi-k2.dtb \
 diff --git a/arch/arm/dts/meson-axg-amper-gateway-am-gz80x-u-boot.dtsi b/arch/arm/dts/meson-axg-amper-gateway-am-gz80x-u-boot.dtsi
 new file mode 100644
-index 0000000000..ca380fdb4c
+index 0000000000..814f891bdc
 --- /dev/null
 +++ b/arch/arm/dts/meson-axg-amper-gateway-am-gz80x-u-boot.dtsi
-@@ -0,0 +1,10 @@
+@@ -0,0 +1,9 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2024 Patrick Yavitz <pyavitz@armbian.com>
-+ *
 + */
 +
 +&saradc {
@@ -44,20 +45,18 @@ index 0000000000..ca380fdb4c
 +};
 diff --git a/arch/arm/dts/meson-axg-amper-gateway-am-gz80x.dts b/arch/arm/dts/meson-axg-amper-gateway-am-gz80x.dts
 new file mode 100644
-index 0000000000..3606121039
+index 0000000000..a6cf5ad81b
 --- /dev/null
 +++ b/arch/arm/dts/meson-axg-amper-gateway-am-gz80x.dts
-@@ -0,0 +1,87 @@
+@@ -0,0 +1,38 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2024 Patrick Yavitz <pyavitz@armbian.com>
-+ *
 + */
 +
 +/dts-v1/;
 +
-+#include "meson-axg-jethome-jethub-j100.dts"
-+#include <dt-bindings/leds/common.h>
++#include "meson-axg-amper-gateway-gz80x.dtsi"
 +
 +/ {
 +	compatible = "amper,gateway-am-gz80x", "amlogic,a113x", "amlogic,meson-axg";
@@ -70,8 +69,61 @@ index 0000000000..3606121039
 +		ethernet0 = &ethmac;
 +	};
 +
++	/* 1024MB RAM */
++	memory@0 {
++		device_type = "memory";
++		reg = <0x0 0x0 0x0 0x40000000>;
++	};
++};
++
++&sd_emmc_b {
++	sdio: wifi@1 {
++		reg = <1>;
++	};
++};
++
++&uart_B {
++	status = "okay";
++	pinctrl-0 = <&uart_b_z_pins>;
++	pinctrl-names = "default";
++};
+diff --git a/arch/arm/dts/meson-axg-amper-gateway-gz80x.dtsi b/arch/arm/dts/meson-axg-amper-gateway-gz80x.dtsi
+new file mode 100644
+index 0000000000..a11e33dd06
+--- /dev/null
++++ b/arch/arm/dts/meson-axg-amper-gateway-gz80x.dtsi
+@@ -0,0 +1,293 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2024 Patrick Yavitz <pyavitz@armbian.com>
++ */
++
++/dts-v1/;
++
++#include "meson-axg.dtsi"
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/leds/common.h>
++#include <dt-bindings/thermal/thermal.h>
++
++/ {
 +	chosen {
 +		stdout-path = "serial0:115200n8";
++	};
++
++	emmc_pwrseq: emmc-pwrseq {
++		compatible = "mmc-pwrseq-emmc";
++		reset-gpios = <&gpio BOOT_9 GPIO_ACTIVE_LOW>;
++	};
++
++	gpio-keys-polled {
++		compatible = "gpio-keys-polled";
++		poll-interval = <100>;
++
++		button-power {
++			label = "power";
++			linux,code = <KEY_POWER>;
++			gpios = <&gpio_ao GPIOAO_6 GPIO_ACTIVE_HIGH>;
++		};
 +	};
 +
 +	leds {
@@ -99,27 +151,226 @@ index 0000000000..3606121039
 +		};
 + 	};
 +
-+	/* 1024MB RAM */
-+	memory@0 {
-+		device_type = "memory";
-+		reg = <0x0 0x0 0x0 0x40000000>;
++	reserved-memory {
++		linux,cma {
++			size = <0x0 0x400000>;
++		};
++	};
++
++	sdio_pwrseq: sdio-pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		reset-gpios = <&gpio GPIOX_7 GPIO_ACTIVE_LOW>;
++		clocks = <&wifi32k>;
++		clock-names = "ext_clock";
++	};
++
++	thermal-zones {
++		cpu_thermal: cpu-thermal {
++			polling-delay-passive = <250>;
++			polling-delay = <1000>;
++			thermal-sensors = <&scpi_sensors 0>;
++			trips {
++				cpu_passive: cpu-passive {
++					temperature = <70000>; /* millicelsius */
++					hysteresis = <2000>; /* millicelsius */
++					type = "passive";
++				};
++
++				cpu_hot: cpu-hot {
++					temperature = <80000>; /* millicelsius */
++					hysteresis = <2000>; /* millicelsius */
++					type = "hot";
++				};
++
++				cpu_critical: cpu-critical {
++					temperature = <100000>; /* millicelsius */
++					hysteresis = <2000>; /* millicelsius */
++					type = "critical";
++				};
++			};
++
++			cpu_cooling_maps: cooling-maps {
++				map0 {
++					trip = <&cpu_passive>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							<&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							<&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							<&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++
++				map1 {
++					trip = <&cpu_hot>;
++					cooling-device = <&cpu0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							<&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							<&cpu2 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>,
++							<&cpu3 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
++				};
++			};
++		};
++	};
++
++	usb_pwr: regulator-usb_pwr {
++		compatible = "regulator-fixed";
++		regulator-name = "USB_PWR";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc_5v>;
++		regulator-always-on;
++
++		gpio = <&gpio_ao GPIOAO_5 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++	};
++
++	vcc_3v3: regulator-vcc_3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "VCC_3V3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vddao_3v3>;
++		regulator-always-on;
++	};
++
++	vcc_5v: regulator-vcc_5v {
++		compatible = "regulator-fixed";
++		regulator-name = "VCC5V";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		regulator-always-on;
++	};
++
++	vddao_3v3: regulator-vddao_3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "VDDAO_3V3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc_5v>;
++		regulator-always-on;
++	};
++
++	vddio_ao18: regulator-vddio_ao18 {
++		compatible = "regulator-fixed";
++		regulator-name = "VDDIO_AO18";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vddao_3v3>;
++		regulator-always-on;
++	};
++
++	vddio_boot: regulator-vddio_boot {
++		compatible = "regulator-fixed";
++		regulator-name = "VDDIO_BOOT";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vddao_3v3>;
++		regulator-always-on;
++	};
++
++	vccq_1v8: regulator-vccq_1v8 {
++		compatible = "regulator-fixed";
++		regulator-name = "VCCQ_1V8";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vddao_3v3>;
++		regulator-always-on;
++	};
++
++	wifi32k: wifi32k {
++		compatible = "pwm-clock";
++		#clock-cells = <0>;
++		clock-frequency = <32768>;
++		pwms = <&pwm_ab 0 30518 0>; /* PWM_A at 32.768KHz */
 +	};
 +};
 +
-+/delete-node/ &i2c1;
++&cpu0 {
++	#cooling-cells = <2>;
++};
 +
-+/* wifi module */
++&cpu1 {
++	#cooling-cells = <2>;
++};
++
++&cpu2 {
++	#cooling-cells = <2>;
++};
++
++&cpu3 {
++	#cooling-cells = <2>;
++};
++
++&ethmac {
++	status = "okay";
++	pinctrl-0 = <&eth_rmii_x_pins>;
++	pinctrl-names = "default";
++	phy-mode = "rmii";
++};
++
++/* Peripheral I2C bus (on motherboard) */
++&i2c_AO {
++	status = "okay";
++	pinctrl-0 = <&i2c_ao_sck_10_pins>, <&i2c_ao_sda_11_pins>;
++	pinctrl-names = "default";
++};
++
++&pwm_ab {
++	status = "okay";
++	pinctrl-0 = <&pwm_a_x20_pins>;
++	pinctrl-names = "default";
++};
++
++/* WiFi module */
 +&sd_emmc_b {
++	status = "okay";
++	#address-cells = <1>;
++	#size-cells = <0>;
++
++	pinctrl-0 = <&sdio_pins>;
++	pinctrl-1 = <&sdio_clk_gate_pins>;
++	pinctrl-names = "default", "clk-gate";
++
++	bus-width = <4>;
++	cap-sd-highspeed;
++	max-frequency = <50000000>;
++	disable-wp;
 +	non-removable;
 +
-+	rtl8189ftv: wifi@1 {
-+		reg = <1>;
-+	};
++	mmc-pwrseq = <&sdio_pwrseq>;
++
++	vmmc-supply = <&vddao_3v3>;
++	vqmmc-supply = <&vddio_boot>;
 +};
 +
-+&uart_B {
++/* eMMC Storage */
++&sd_emmc_c {
 +	status = "okay";
-+	pinctrl-0 = <&uart_b_z_pins>;
++	pinctrl-0 = <&emmc_pins>, <&emmc_ds_pins>;
++	pinctrl-1 = <&emmc_clk_gate_pins>;
++	pinctrl-names = "default", "clk-gate";
++
++	bus-width = <8>;
++	cap-mmc-highspeed;
++	max-frequency = <200000000>;
++	non-removable;
++	disable-wp;
++	mmc-ddr-1_8v;
++	mmc-hs200-1_8v;
++
++	mmc-pwrseq = <&emmc_pwrseq>;
++
++	vmmc-supply = <&vcc_3v3>;
++	vqmmc-supply = <&vccq_1v8>;
++};
++
++&spicc1 {
++	status = "okay";
++	pinctrl-0 = <&spi1_x_pins>, <&spi1_ss0_x_pins>;
++	pinctrl-names = "default";
++};
++
++/* UART Console */
++&uart_AO {
++	status = "okay";
++	pinctrl-0 = <&uart_ao_a_pins>;
 +	pinctrl-names = "default";
 +};
 +
@@ -131,13 +382,13 @@ index 0000000000..3606121039
 +	reset-gpios = <&gpio GPIOZ_6 GPIO_ACTIVE_HIGH>;
 +};
 +
-+&usb_pwr {
-+	gpio = <&gpio_ao GPIOAO_5 GPIO_ACTIVE_HIGH>;
-+	enable-active-high;
++&usb {
++	status = "okay";
++	vbus-supply = <&usb_pwr>;
 +};
 diff --git a/configs/amper_gateway_am-gz80x_defconfig b/configs/amper_gateway_am-gz80x_defconfig
 new file mode 100644
-index 0000000000..1bdefc0add
+index 0000000000..5991f66c29
 --- /dev/null
 +++ b/configs/amper_gateway_am-gz80x_defconfig
 @@ -0,0 +1,69 @@


### PR DESCRIPTION
There are three revs: AM-GZ80x, AM-GZ80x-US and SC-GZ80x

Add a DSTI in case one should drop out of the sky and we need a DTS for it.
This also removes its dependency on meson-axg-jethome-jethub-j1xx.dtsi.

Can now power down via power button on the back of the unit and power back on via reset button on the side.
