### PR TITLE
rk3318-box: enable usb3 port in uboot

### DIFF
--- a/patch/u-boot/v2024.07/board_rk3318-box/rk3318-box-add-dts.patch
+++ b/patch/u-boot/v2024.07/board_rk3318-box/rk3318-box-add-dts.patch
@@ -96,7 +96,7 @@ new file mode 100644
 index 000000000000..111111111111
 --- /dev/null
 +++ b/dts/upstream/src/arm64/rockchip/rk3318-box.dts
-@@ -0,0 +1,648 @@
+@@ -0,0 +1,649 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd
@@ -673,11 +673,12 @@ index 000000000000..111111111111
 +	status = "okay";
 +};
 +
-+/*
 +&usbdrd3 {
++	dr_mode = "host";
 +	status = "okay";
 +};
 +
++/*
 +&usbdrd_dwc3 {
 +	dr_mode = "host";
 +	status = "okay";


### PR DESCRIPTION
# Description

enable usb3 port in uboot

# How Has This Been Tested?

- [x] compile and boot rk3318-box from flash drive in usb3 port

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
