### PR TITLE
rock-3a:add u-boot image for sata boot on m.2 e.key

### DIFF
--- a/config/boards/rock-3a.conf
+++ b/config/boards/rock-3a.conf
@@ -3,6 +3,7 @@ BOARD_NAME="Rock 3A"
 BOARDFAMILY="rk35xx"
 BOARD_MAINTAINER="ZazaBR amazingfate catalinii vamzii"
 BOOTCONFIG="rock-3a-rk3568_defconfig"
+BOOTCONFIG_SATA="rock-3a-sata-rk3568_defconfig"
 KERNEL_TARGET="edge,current,vendor"
 KERNEL_TEST_TARGET="current"
 FULL_DESKTOP="yes"
@@ -34,4 +35,29 @@ function post_family_config_branch_edge__rock-3a_use_mainline_uboot() {
 	function write_uboot_platform_mtd() {
 		flashcp -v -p "$1/u-boot-rockchip-spi.bin" /dev/mtd0
 	}
+}
+
+function post_family_config__rock3a_uboot_add_sata_target() {
+    display_alert "$BOARD" "Configuring ($BOARD) standard and sata uboot target map" "info"
+
+	UBOOT_TARGET_MAP="
+	BL31=$RKBIN_DIR/$BL31_BLOB $BOOTCONFIG spl/u-boot-spl.bin u-boot.dtb u-boot.itb;;idbloader.img u-boot.itb rkspi_loader.img
+	BL31=$RKBIN_DIR/$BL31_BLOB $BOOTCONFIG_SATA spl/u-boot-spl.bin u-boot.dtb u-boot.itb;; rkspi_loader_sata.img"
+}
+
+function post_uboot_custom_postprocess__create_sata_spi_image() {
+
+	display_alert "$BOARD" "Create rkspi_loader_sata.img" "info"
+
+	dd if=/dev/zero of=rkspi_loader_sata.img bs=1M count=0 seek=16
+	/sbin/parted -s rkspi_loader_sata.img mklabel gpt
+	/sbin/parted -s rkspi_loader_sata.img unit s mkpart idbloader 64 7167
+	/sbin/parted -s rkspi_loader_sata.img unit s mkpart vnvm 7168 7679
+	/sbin/parted -s rkspi_loader_sata.img unit s mkpart reserved_space 7680 8063
+	/sbin/parted -s rkspi_loader_sata.img unit s mkpart reserved1 8064 8127
+	/sbin/parted -s rkspi_loader_sata.img unit s mkpart uboot_env 8128 8191
+	/sbin/parted -s rkspi_loader_sata.img unit s mkpart reserved2 8192 16383
+	/sbin/parted -s rkspi_loader_sata.img unit s mkpart uboot 16384 32734
+	dd if=idbloader.img of=rkspi_loader_sata.img seek=64 conv=notrunc
+	dd if=u-boot.itb of=rkspi_loader_sata.img seek=16384 conv=notrunc
 }


### PR DESCRIPTION
# Description

add patch which add to vendor u-boot support for sata boot from m.2 e-key(switch m.2 to sata and extra sata defconfig)
added additional u-boot target too build the additional u-boot  image with these changes
the patch can be removed if this  pull request for  vendor u-boot for rock-3a  is accepted  https://github.com/radxa/u-boot/pull/95


# Documentation summary for feature / change
rock-3a:add u-boot image for sata boot on m.2 e.key

- for sata boot the rkspi_loader_sata.img has to be flashed on spi flash (use dd or flashcp)
- flash armbian image to sata device with dd (or ifd3f/caligula , etcher cli )
- mount armbian  boot partition on sata device and add rock-3a-sata too useroverlay
- poweroff and remove sdcard( or emmc ) to  boot from sata


  armbian install doesnt work because u-boot needs extra vfat boot partition which armbian install doesnt create only single 
  partition


# How Has This Been Tested?

compiled with github ci https://github.com/pykpkg47/armbian-image-build/actions/runs/10874313933/job/30171463631
compile log https://paste.armbian.com/fasuhomeri
artifacts : https://github.com/pykpkg47/armbian-image-build/releases/tag/24.8.3

tested on rock-3a u-boots detects sata ssd connected via adapter to m.2 e-key and boots kernel from it

# Checklist:

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ x] My changes generate no new warnings

