### PR TITLE
OP5+/HDMIRX: Allow ability to restream without reopening device

### DIFF
--- a/patch/kernel/archive/rockchip-rk3588-6.10/0113-add-synopsys-designware-hdmi-rx-controller.patch
+++ b/patch/kernel/archive/rockchip-rk3588-6.10/0113-add-synopsys-designware-hdmi-rx-controller.patch
@@ -3768,3 +3768,49 @@ index 111111111111..222222222222 100644
 -- 
 Armbian
 
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ben Hoff <hoff.benjamin.k@gmail.com>
+Date: Mon, 16 Sep 2024 01:39:44 -0400
+Subject: [PATCH] mark each buffer complete to allow restreaming without
+ closing & reopening the device
+
+---
+ .../media/platform/synopsys/hdmirx/snps_hdmirx.c  | 15 ++++++---------
+ 1 file changed, 6 insertions(+), 9 deletions(-)
+
+diff --git a/drivers/media/platform/synopsys/hdmirx/snps_hdmirx.c b/drivers/media/platform/synopsys/hdmirx/snps_hdmirx.c
+index 111111111111..222222222222 100644
+--- a/drivers/media/platform/synopsys/hdmirx/snps_hdmirx.c
++++ b/drivers/media/platform/synopsys/hdmirx/snps_hdmirx.c
+@@ -1586,7 +1586,7 @@ static void hdmirx_buf_queue(struct vb2_buffer *vb)
+ static void return_all_buffers(struct hdmirx_stream *stream,
+ 			       enum vb2_buffer_state state)
+ {
+-	struct hdmirx_buffer *buf;
++	struct hdmirx_buffer *buf, *tmp;
+ 	unsigned long flags;
+ 
+ 	spin_lock_irqsave(&stream->vbq_lock, flags);
+@@ -1597,14 +1597,11 @@ static void return_all_buffers(struct hdmirx_stream *stream,
+ 	stream->curr_buf = NULL;
+ 	stream->next_buf = NULL;
+ 
+-	while (!list_empty(&stream->buf_head)) {
+-		buf = list_first_entry(&stream->buf_head,
+-				       struct hdmirx_buffer, queue);
+-		list_del(&buf->queue);
+-		spin_unlock_irqrestore(&stream->vbq_lock, flags);
+-		vb2_buffer_done(&buf->vb.vb2_buf, state);
+-		spin_lock_irqsave(&stream->vbq_lock, flags);
+-	}
++    list_for_each_entry_safe(buf, tmp, &stream->buf_head, queue) {
++        vb2_buffer_done(&buf->vb.vb2_buf, state);
++        list_del(&buf->queue);
++    }
++
+ 	spin_unlock_irqrestore(&stream->vbq_lock, flags);
+ }
+ 
+-- 
+Armbian
+


### PR DESCRIPTION

# Description

 I couldn't "restream" on the hdmirx driver for OPi5+. Meaning once I had opened the hdmirx device, called start stream, then stopped the stream, and then tried to start the stream again without closing the file/device, I would get a "device busy" code. The error/busy signal is thrown from [this line of code](https://gitlab.collabora.com/hardware-enablement/rockchip-3588/linux/-/blob/2685126d3dd189aa9b0a7bf87edd50bed8a090dd/drivers/media/platform/synopsys/hdmirx/snps_hdmirx.c#L1367). Looking at the function call for `vb2_is_busy` the `stream->buf_queue` just needs to be marked as done.

I'm not sure what this function `return_all_buffers` was doing before, but this patch marks items as done before delete them and use a helper method in the kernel to iterate the list instead of hand-rolling the logic.

This patch has been submitted to collabora for upstreaming.


# How Has This Been Tested?
Tested on OP5+


# Checklist:

_Please delete options that are not relevant._

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

