### PR TITLE
radxa-zero2: bump to u-boot 2024.07 (from 2023.10)

### DIFF
--- a/config/boards/radxa-zero2.csc
+++ b/config/boards/radxa-zero2.csc
@@ -14,5 +14,5 @@ BOOT_FDT_FILE="amlogic/meson-g12b-radxa-zero2.dtb"
 # Newer u-boot for the Zero2
 # 2022.10: Radxa's patches with new DT, Makefile and defconfig in v2022.10/board_radxa-zero2 dir; common to 22.10's meson64 boot-usb-first
 # v2023.10: board-specific boot-usb-first patch; zero2 landed in upstream u-boot v2023.07-rc1
-BOOTBRANCH_BOARD="tag:v2023.10"
-BOOTPATCHDIR="v2023.10"
+BOOTBRANCH_BOARD="tag:v2024.07"
+BOOTPATCHDIR="v2024.07"

--- a/patch/u-boot/v2024.07/board_radxa-zero2/meson64-boot-usb-nvme-scsi-first.patch
+++ b/patch/u-boot/v2024.07/board_radxa-zero2/meson64-boot-usb-nvme-scsi-first.patch
@@ -1,22 +1,21 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Ricardo Pardini <ricardo@pardini.net>
-Date: Mon, 14 Nov 2022 14:59:45 +0100
+Date: Sun, 14 Jan 2024 13:44:58 +0100
 Subject: meson64: change `BOOT_TARGET_DEVICES` to try to boot USB, NVME and
  SCSI before SD, MMC, PXE, DHCP
 
-meson64: change `BOOT_TARGET_DEVICES` to try to boot USB, NVME and SCSI before SD, MMC, PXE, DHCP
 ---
  include/configs/meson64.h | 6 +++---
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/include/configs/meson64.h b/include/configs/meson64.h
-index 801cdae47081..927919ef17a2 100644
+index 111111111111..222222222222 100644
 --- a/include/configs/meson64.h
 +++ b/include/configs/meson64.h
-@@ -74,12 +74,12 @@
- #ifndef BOOT_TARGET_DEVICES
+@@ -99,12 +99,12 @@
  #define BOOT_TARGET_DEVICES(func) \
  	func(ROMUSB, romusb, na)  \
+ 	func(USB_DFU, usbdfu, na)  \
 -	func(MMC, mmc, 0) \
 -	func(MMC, mmc, 1) \
 -	func(MMC, mmc, 2) \


### PR DESCRIPTION
#### radxa-zero2: bump to u-boot 2024.07 (from 2023.10)

- radxa-zero2: bump to u-boot 2024.07 (from 2023.10)
  - (confirmed by testing on-device) fixes UMS/Gadget stuff by including https://github.com/u-boot/u-boot/commit/4005729c0de234ffcf36465f6471755617b42375 that landed in v2024.01