### PR TITLE
mainline-kernel: v6.11 was released

### DIFF
--- a/config/sources/mainline-kernel.conf.sh
+++ b/config/sources/mainline-kernel.conf.sh
@@ -7,8 +7,8 @@
 # Shared versioning logic for Armbian mainline kernels.
 function mainline_kernel_decide_version__upstream_release_candidate_number() {
 	[[ -n "${KERNELBRANCH}" ]] && return 0           # if already set, don't touch it; that way other hooks can run in any order
-	if [[ "${KERNEL_MAJOR_MINOR}" == "6.11" ]]; then # @TODO: roll over to next MAJOR.MINOR and MAJOR.MINOR-rc1 when it is released
-		declare -g KERNELBRANCH="tag:v6.11-rc7"
+	if [[ "${KERNEL_MAJOR_MINOR}" == "6.12" ]]; then # @TODO: roll over to next MAJOR.MINOR and MAJOR.MINOR-rc1 when it is released
+		declare -g KERNELBRANCH="tag:v6.12-rc1" # predicted to be released on Sunday, the 6th of October 2024 - will most probably be an LTS release
 		display_alert "mainline-kernel: upstream release candidate" "Using KERNELBRANCH='${KERNELBRANCH}' for KERNEL_MAJOR_MINOR='${KERNEL_MAJOR_MINOR}'" "info"
 	fi
 }

--- a/patch/kernel/archive/meson64-6.11/general-socinfo-sm-4-soc-amlogic-meson-gx-socinfo-sm-Add-Amlogic-secure-m.patch
+++ b/patch/kernel/archive/meson64-6.11/general-socinfo-sm-4-soc-amlogic-meson-gx-socinfo-sm-Add-Amlogic-secure-m.patch
@@ -10,7 +10,7 @@ This patchs adds support for secure-monitor call decoding and exposing
 with the SoC bus infrastructure in addition to the previous SoC
 Information driver.
 
-- rpardini: hack to fix "initialization of 'void (*)(struct platform_device *)' from incompatible pointer type 'int (*)(struct platform_device *)'" 
+- rpardini: hack to fix "initialization of 'void (*)(struct platform_device *)' from incompatible pointer type 'int (*)(struct platform_device *)'"
 
 Signed-off-by: Viacheslav Bocharov <adeep@lexina.in>
 ---

--- a/patch/kernel/archive/rockchip-rk3588-6.11/0134-drm-bridge-synopsys-Add-initial-support-for-DW-HDMI-Controller.patch
+++ b/patch/kernel/archive/rockchip-rk3588-6.11/0134-drm-bridge-synopsys-Add-initial-support-for-DW-HDMI-Controller.patch
@@ -2547,7 +2547,7 @@ diff --git a/drivers/gpu/drm/rockchip/rockchip_drm_drv.c b/drivers/gpu/drm/rockc
 index 111111111111..222222222222 100644
 --- a/drivers/gpu/drm/rockchip/rockchip_drm_drv.c
 +++ b/drivers/gpu/drm/rockchip/rockchip_drm_drv.c
-@@ -503,6 +503,8 @@ static int __init rockchip_drm_init(void)
+@@ -507,6 +507,8 @@ static int __init rockchip_drm_init(void)
  	ADD_ROCKCHIP_SUB_DRIVER(cdn_dp_driver, CONFIG_ROCKCHIP_CDN_DP);
  	ADD_ROCKCHIP_SUB_DRIVER(dw_hdmi_rockchip_pltfm_driver,
  				CONFIG_ROCKCHIP_DW_HDMI);

--- a/patch/kernel/archive/rockchip-rk3588-6.11/1031-arm64-dts-rockchip-Add-HDMI-support-to-ArmSoM-Sige7.patch
+++ b/patch/kernel/archive/rockchip-rk3588-6.11/1031-arm64-dts-rockchip-Add-HDMI-support-to-ArmSoM-Sige7.patch
@@ -4,8 +4,8 @@ Date: Thu, 6 Jun 2024 23:28:01 +0800
 Subject: arm64: dts: rockchip: Add HDMI support to ArmSoM Sige7
 
 ---
- arch/arm64/boot/dts/rockchip/rk3588-armsom-sige7.dts | 30 ++++++++++
- 1 file changed, 30 insertions(+)
+ arch/arm64/boot/dts/rockchip/rk3588-armsom-sige7.dts | 35 ++++++++++
+ 1 file changed, 35 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/rockchip/rk3588-armsom-sige7.dts b/arch/arm64/boot/dts/rockchip/rk3588-armsom-sige7.dts
 index 111111111111..222222222222 100644

--- a/patch/kernel/archive/rockchip-rk3588-6.11/1032-arm64-dts-rockchip-Add-ap6275p-wireless-support-to-A.patch
+++ b/patch/kernel/archive/rockchip-rk3588-6.11/1032-arm64-dts-rockchip-Add-ap6275p-wireless-support-to-A.patch
@@ -11,7 +11,7 @@ diff --git a/arch/arm64/boot/dts/rockchip/rk3588-armsom-sige7.dts b/arch/arm64/b
 index 111111111111..222222222222 100644
 --- a/arch/arm64/boot/dts/rockchip/rk3588-armsom-sige7.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-armsom-sige7.dts
-@@ -283,6 +283,22 @@ &pcie2x1l0 {
+@@ -288,6 +288,22 @@ &pcie2x1l0 {
  &pcie2x1l1 {
  	reset-gpios = <&gpio3 RK_PD4 GPIO_ACTIVE_HIGH>;
  	status = "okay";


### PR DESCRIPTION
#### mainline-kernel: v6.11 was released

- mainline-kernel: v6.11 was released
- rockchip-rk3588-6.11: rewrite/rebase patches onto v6.11 final
  - no changes
- meson64-6.11: rewrite/rebase patches onto v6.11 final
  - no changes, I forgot a trailing space in my hackfix comment (facepalm)