### PR TITLE
Cosmetic / UX: Display VENDORPRETTYNAME instead of VENDOR 

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -651,6 +651,8 @@ if [[ -f /root/.not_logged_in_yet && -n $(tty) ]]; then
 
 	clear
 
+	# In case VENDORPRETTYNAME is defined, display that
+	[[ -n "${VENDORPRETTYNAME}" ]] && VENDOR="$VENDORPRETTYNAME"
 	echo -e "Welcome to \e[1m\e[97m${VENDOR}\x1B[0m! \n"
 	echo -e "Documentation: \e[1m\e[92m${VENDORDOCS}\x1B[0m | Community support: \e[1m\e[92m${VENDORSUPPORT}\x1B[0m\n"
 


### PR DESCRIPTION
# Description

First run on welcome screen. If defined.

```
Welcome to Armbian_community! 

Documentation: https://docs.armbian.com | Community support: https://community.armbian.com/

IP address: 
```

VENDORPRETTYNAME="Cool Armbian community"

```
Welcome to Cool Armbian community! 

Documentation: https://docs.armbian.com | Community support: https://community.armbian.com/

IP address: 
```

# Checklist:

- [x] My changes generate no new warnings