### PR TITLE
Fix for c4 spi

### DIFF
--- a/patch/kernel/archive/meson64-6.6/overlay/Makefile
+++ b/patch/kernel/archive/meson64-6.6/overlay/Makefile
@@ -29,7 +29,8 @@ dtbo-$(CONFIG_ARCH_MESON) += \
 	meson-sm1-bananapi-m5-rtl8822cs.dtbo \
 	meson-sm1-bananapi-uartA.dtbo \
 	meson-sm1-bananapi-uartA_cts_rts.dtbo \
-	meson-sm1-bananapi-uartAO_B.dtbo
+	meson-sm1-bananapi-uartAO_B.dtbo \
+	meson-sm1-odroid-c4-spi-spidev.dtbo
 
 scr-$(CONFIG_ARCH_MESON) += \
        meson-fixup.scr

--- a/patch/kernel/archive/meson64-6.6/overlay/meson-sm1-odroid-c4-spi-spidev.dts
+++ b/patch/kernel/archive/meson64-6.6/overlay/meson-sm1-odroid-c4-spi-spidev.dts
@@ -1,0 +1,22 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+       compatible = "hardkernel,odroid-c4", "amlogic,sm1";
+
+       fragment@0 {
+               target = <&spicc0>;
+               __overlay__ {
+                       pinctrl-0 = <&spicc0_x_pins &spicc0_ss0_x_pins>;
+                       pinctrl-names = "default";
+                       status = "okay";
+
+                       spidev@0 {
+                               compatible = "armbian,spi-dev";
+                               status = "okay";
+                               reg = <0>;
+                               spi-max-frequency = <10000000>;
+                       };
+               };
+       };
+};

--- a/patch/kernel/archive/meson64-6.6/overlay/meson-sm1-odroid-c4-spi-spidev.dts
+++ b/patch/kernel/archive/meson64-6.6/overlay/meson-sm1-odroid-c4-spi-spidev.dts
@@ -15,7 +15,7 @@
                                compatible = "armbian,spi-dev";
                                status = "okay";
                                reg = <0>;
-                               spi-max-frequency = <10000000>;
+                               spi-max-frequency = <12000000>;
                        };
                };
        };


### PR DESCRIPTION
# Description

This pull requests adds a device tree overlay for the Odroid C4 enabling hardware SPI on pins 19, 21, 23 and 24 on the GPIO header. It doesn't require any other changes, except one additional line in the Makefile.
Besides, it can replace the old device tree *meson-sm1-odroid-c4-spidev.dtb* (which activates wrong pins and doesn't work due to this) while offering more flexibility.

# How Has This Been Tested?

The SPI communication has been successfully tested with a LogicPort analyzer and some custom made FPGA board (SPI readout of a Mamamatsu silicon spectrometer).

- [x] Logic Analyzer: timing of MOSI vs. SCK has been verified, maximum speed is about 12MHz for SCK
- [x] data transfer between C4 and spectrometer FPGA has been tested

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules