### PR TITLE
UX: cosmetic improvements on motd and armbian-install

### DIFF
--- a/packages/bsp/common/etc/update-motd.d/41-commands
+++ b/packages/bsp/common/etc/update-motd.d/41-commands
@@ -18,9 +18,12 @@ for f in $MOTD_DISABLE; do
 	[[ $f == $THIS_SCRIPT ]] && exit 0
 done
 
+# text, sudo / without, command, condition
+# condition can be fairly complex
 list=(
-    "System config","sudo ","armbian-config"
-    "System monitor","","htop"
+    "System config","sudo ","armbian-config","true"
+    "System monitor","","htop","true"
+    "Installer","","armbian-install","! grep -q \"INSTALLED=true\" /etc/armbian-image-release 2> /dev/null && ((($(date +%s) - $(stat -c +%X /etc/armbian-image-release 2> /dev/null)) < 86400))"
 )
 
 # verify if command exits on the system
@@ -32,7 +35,8 @@ do
 	name=$(echo $l | cut -d"," -f1)
 	sudo=$(echo $l | cut -d"," -f2)
 	command=$(echo $l | cut -d"," -f3)
-	if command -v $command &> /dev/null
+	condition=$(echo $l | cut -d"," -f4)
+	if eval $condition 2> /dev/null && command -v $command &> /dev/null
 	then
 		# seek for maximum description lenght
 		if [ ${#name} -ge $name_len ]; then

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -247,11 +247,12 @@ set_shell() {
 					;;
 			esac
 		done
-	fi
-	SHELL_PATH=$(grep "/$USER_SHELL$" /etc/shells | tail -1)
-
-	chsh -s "$(grep -iF "/$USER_SHELL" /etc/shells | tail -1)"
+	# Display shell selection only if needs to be selected
 	echo -e "\nShell: \x1B[92m${USER_SHELL^^}\x1B[0m"
+	fi
+
+	SHELL_PATH=$(grep "/$USER_SHELL$" /etc/shells | tail -1)
+	chsh -s "$(grep -iF "/$USER_SHELL" /etc/shells | tail -1)"
 
 	# change shell for future users
 	sed -i "s|^SHELL=.*|SHELL=${SHELL_PATH}|" /etc/default/useradd

--- a/packages/bsp/common/usr/sbin/armbian-install
+++ b/packages/bsp/common/usr/sbin/armbian-install
@@ -228,6 +228,11 @@ create_armbian()
 	dialog --title "$title" --backtitle "$backtitle" --infobox "\n               Cleaning up ... Almost done." 5 60
 	rsync -avx --delete --exclude-from=$EX_LIST / "${TempDir}"/rootfs >/dev/null 2>&1
 
+	# mark OS as transferred
+	if ! grep -q "INSTALLED=true" /etc/armbian-image-release; then
+	echo "INSTALLED=true" >> "${TempDir}"/rootfs/etc/armbian-image-release
+	fi
+
 	# creating fstab from scratch
 	rm -f "${TempDir}"/rootfs/etc/fstab
 	mkdir -p "${TempDir}"/rootfs/etc "${TempDir}"/rootfs/media/mmcboot "${TempDir}"/rootfs/media/mmcroot


### PR DESCRIPTION
# Description

![image](https://github.com/user-attachments/assets/6c2c0610-4468-4fca-b987-69ed041166ee)


- display armbian-install command only up to one day and if armbian-install was not run yet.
- hide displaying BASH shell at first login when this is the only option (minimal images). De-clutter 1st login screen.
- add variable `INSTALLED=true` to /etc/armbian-image-release indicating armbian-install was executed.

# How Has This Been Tested?

Manual run.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings