### PR TITLE
armsom-w3: fix m.2 usb bluetooth

### DIFF
--- a/config/boards/armsom-w3.csc
+++ b/config/boards/armsom-w3.csc
@@ -28,3 +28,12 @@ function post_family_tweaks__armsom-w3_naming_audios() {
 
 	return 0
 }
+
+function post_family_tweaks__armsom-w3_fix_m2_bluetooth() {
+	display_alert "$BOARD" "Fixing armsom-w3 m.2 usb bluetooth" "info"
+
+	mkdir -p $SDCARD/etc/udev/rules.d/
+	echo 'ACTION=="add", SUBSYSTEM=="usb",ATTR{bConfigurationValue}=="", ATTR{bConfigurationValue}="1"' > $SDCARD/etc/udev/rules.d/91-m2-usb-bluetooth.rules
+
+	return 0
+}


### PR DESCRIPTION
# Description

When m.2 wifi module has a usb bluetooth, it can get detected but has error when loading driver:
```
rejected 1 configuration due to insufficient available bus power
```
This commit will add a udev rule setting all usb device attr `bConfigurationValue` to 1 if it has a null value, which will fix the bluetooth usb device.

Hint from https://community.nxp.com/t5/i-MX-Processors/USB-1-0-disable-100mA-current-limit-permanently/td-p/1600252

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh BOARD=armsom-w3 BRANCH=vendor BUILD_MINIMAL=no DEB_COMPRESS=xz KERNEL_CONFIGURE=no RELEASE=noble KERNEL_GIT=shallow BUILD_DESKTOP=yes DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base ENABLE_EXTENSIONS="mesa-vpu"`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
