### PR TITLE
radxa-aic8800: remove kernel version check

### DIFF
--- a/extensions/radxa-aic8800.sh
+++ b/extensions/radxa-aic8800.sh
@@ -1,10 +1,5 @@
 function extension_finish_config__install_kernel_headers_for_aic8800_dkms() {
 
-	if [[ ( "${KERNEL_MAJOR_MINOR}" < 6.6 ) ]]; then
-		display_alert "Driver compilation is not supported on kernel ${KERNEL_MAJOR_MINOR} or higher" "skipping aic8800 dkms for kernel v${KERNEL_MAJOR_MINOR}" "warn"
-		return 0
-	fi
-
 	if [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]]; then
 		display_alert "Kernel version has no working headers package" "skipping aic8800 dkms for kernel v${KERNEL_MAJOR_MINOR}" "warn"
 		return 0
@@ -15,7 +10,6 @@ function extension_finish_config__install_kernel_headers_for_aic8800_dkms() {
 
 function post_install_kernel_debs__install_aic8800_dkms_package() {
 
-	[[ ( "${KERNEL_MAJOR_MINOR}" < 6.6 ) ]] && return 0
 	[[ "${INSTALL_HEADERS}" != "yes" ]] || [[ "${KERNEL_HAS_WORKING_HEADERS}" != "yes" ]] && return 0
 	[[ -z $AIC8800_TYPE ]] && return 0
 	api_url="https://api.github.com/repos/radxa-pkg/aic8800/releases/latest"


### PR DESCRIPTION
# Description

At first we added the version check to skip kernel version larger than 6.6 because upstream did not support kernel after 6.6 at that time. Then this condition is changed to skip kernel before 6.6.
Now kernel 6.11 is supported, we can remove the version check.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh BOARD=rock-5c BRANCH=edge BUILD_MINIMAL=no DEB_COMPRESS=xz KERNEL_CONFIGURE=no RELEASE=noble KERNEL_GIT=shallow BUILD_DESKTOP=yes DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base`
- [x] `./compile.sh BOARD=rock-5c BRANCH=vendor BUILD_MINIMAL=no DEB_COMPRESS=xz KERNEL_CONFIGURE=no RELEASE=noble KERNEL_GIT=shallow BUILD_DESKTOP=yes DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
