### PR TITLE
mesa-vpu: fix dist-upgrade when upstream release new conf file

### DIFF
--- a/extensions/mesa-vpu.sh
+++ b/extensions/mesa-vpu.sh
@@ -158,7 +158,7 @@ function post_install_kernel_debs__3d() {
 	fi
 
 	display_alert "Upgrading Mesa packages" "${EXTENSION}" "info"
-	do_with_retries 3 chroot_sdcard_apt_get dist-upgrade
+	do_with_retries 3 chroot_sdcard_apt_get -o Dpkg::Options::="--force-confold" dist-upgrade
 
 	# KDE neon downgrade hack undo
 	do_with_retries 3 chroot_sdcard apt-mark unhold base-files


### PR DESCRIPTION
# Description

Ubuntu noble has updated its repo and `/etc/apt/apt.conf.d/20apt-esm-hook.conf` from `ubuntu-pro-client` will ask user whether to keep the old conf file or override it.
Add arg `-o Dpkg::Options::="--force-confold"` to apt to keep the old conf by default.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh BOARD=rock-5c BRANCH=vendor BUILD_MINIMAL=no DEB_COMPRESS=xz KERNEL_CONFIGURE=no RELEASE=noble KERNEL_GIT=shallow BUILD_DESKTOP=yes DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base ENABLE_EXTENSIONS="mesa-vpu"`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
