### PR TITLE
Bugfix: xradio wireless stopped working if those files were removed.

### DIFF
--- a/packages/bsp/common/etc/NetworkManager/conf.d/zz-10-override-wifi-random-mac-disable.conf
+++ b/packages/bsp/common/etc/NetworkManager/conf.d/zz-10-override-wifi-random-mac-disable.conf
@@ -1,0 +1,5 @@
+[connection]
+wifi.mac-address-randomization=1
+
+[device]
+wifi.scan-rand-mac-address=no

--- a/packages/bsp/common/etc/NetworkManager/conf.d/zz-20-override-wifi-powersave-disable.conf
+++ b/packages/bsp/common/etc/NetworkManager/conf.d/zz-20-override-wifi-powersave-disable.conf
@@ -1,0 +1,2 @@
+[connection]
+wifi.powersave = 2


### PR DESCRIPTION
# Description

Few months ago we did some extensive cleaning of deprecated sections in scripts. We also removed those two files, while they are needed for xradio to work properly. Lets put the back.

# How Has This Been Tested?

Wifi start working if those files are present.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
