### PR TITLE
Fix connecting to wifi networks where SSID contains a space or comma

### DIFF
--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -307,8 +307,8 @@ set_timezone_and_locales() {
 				while [[ ${scanning} -lt 3 ]]; do
 					sleep 0.5
 					scanning=$(( scanning + 1 ))
-					ARRAY=($(iwlist ${WIFI_DEVICE} scanning 2> /dev/null | egrep 'ESSID' | sed 's/^[ \t]*//' | sed 's/"//g' | sed 's/ESSID://' | sed '/^$/d' | sort | uniq | awk 'BEGIN{FS=OFS=","} {$NF=++count OFS $NF} 1'))
-					if [[ $? == 0 ]]; then broken=0; break; fi
+					readarray -t ARRAY < <(iwlist ${WIFI_DEVICE} scanning 2> /dev/null | egrep 'ESSID' | sed 's/^[ \t]*//' | sed 's/"//g' | sed 's/ESSID://' | sed '/^$/d' | sort | uniq | awk 'BEGIN{FS=OFS=","} {$NF=++count OFS $NF} 1')
+					if [[ ${#ARRAY[@]} -gt 0 ]]; then broken=0; break; fi
 				done
 				# wifi can also fail
 				if [[ ${broken} == 1 ]]; then
@@ -320,14 +320,14 @@ set_timezone_and_locales() {
 					while [[ ${scanning} -lt 3 ]]; do
 						scanning=$(( scanning + 1 ))
 						while [[ 1 ]] ; do
-							for str in ${ARRAY[@]}; do echo $str | sed "s/,/ \t /g"; done
+							for str in "${ARRAY[@]}"; do echo $str | sed "s/,/ \t /"; done
 							echo ""
 							read -r -p "Enter a number of SSID: " input
 							if [[ "$input" =~ ^[0-9]{,2}$ ]] ; then break; fi
 						done
 						# get password
 						while [[ -n "${input}" ]] ; do
-							SSID=$(echo ${ARRAY[$input-1]} | cut -d"," -f2)
+							SSID=$(echo ${ARRAY[$input-1]} | cut -d"," -f2-)
 							echo ""
 							read -r -p "Enter a password for ${SSID}: " password
 							break


### PR DESCRIPTION
# Description

_Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change._

As per the title

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [X] By connecting to my wifi network where SSID has a space in it.

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
