### PR TITLE
RK3588: add mpp and rkvenc2 nodes

### DIFF
--- a/patch/kernel/archive/rockchip-rk3588-6.10/0029-Add-rkvenc2-mpp-Support.patch
+++ b/patch/kernel/archive/rockchip-rk3588-6.10/0029-Add-rkvenc2-mpp-Support.patch
@@ -1,0 +1,7161 @@
+From 3603dce5a03eb47cfb32ca90a047b8887d6f09ab Mon Sep 17 00:00:00 2001
+From: Sebastian Reichel <sebastian.reichel@collabora.com>
+Date: Mon, 8 Jul 2024 19:19:30 +0200
+Subject: [PATCH 1/3] video: rockchip: add MPP rkvenc2 driver
+
+This code has been copied from the Rockchip kernel tree.
+
+This is not intended to be upstreamed and just needed for
+hardware testing purposes.
+
+With that considered the Kconfig options are marked to be
+enabled by default and the DT binding is not documented.
+
+Signed-off-by: Sebastian Reichel <sebastian.reichel@collabora.com>
+---
+ drivers/video/Kconfig                    |    4 +
+ drivers/video/Makefile                   |    1 +
+ drivers/video/rockchip/Kconfig           |    2 +
+ drivers/video/rockchip/Makefile          |    2 +
+ drivers/video/rockchip/mpp/Kconfig       |   25 +
+ drivers/video/rockchip/mpp/Makefile      |    7 +
+ drivers/video/rockchip/mpp/mpp_common.c  | 2471 ++++++++++++++++++++++
+ drivers/video/rockchip/mpp/mpp_common.h  |  854 ++++++++
+ drivers/video/rockchip/mpp/mpp_debug.h   |  138 ++
+ drivers/video/rockchip/mpp/mpp_iommu.c   |  509 +++++
+ drivers/video/rockchip/mpp/mpp_iommu.h   |  145 ++
+ drivers/video/rockchip/mpp/mpp_rkvenc2.c | 2241 ++++++++++++++++++++
+ drivers/video/rockchip/mpp/mpp_service.c |  497 +++++
+ 13 files changed, 6896 insertions(+)
+ create mode 100644 drivers/video/rockchip/Kconfig
+ create mode 100644 drivers/video/rockchip/Makefile
+ create mode 100644 drivers/video/rockchip/mpp/Kconfig
+ create mode 100644 drivers/video/rockchip/mpp/Makefile
+ create mode 100644 drivers/video/rockchip/mpp/mpp_common.c
+ create mode 100644 drivers/video/rockchip/mpp/mpp_common.h
+ create mode 100644 drivers/video/rockchip/mpp/mpp_debug.h
+ create mode 100644 drivers/video/rockchip/mpp/mpp_iommu.c
+ create mode 100644 drivers/video/rockchip/mpp/mpp_iommu.h
+ create mode 100644 drivers/video/rockchip/mpp/mpp_rkvenc2.c
+ create mode 100644 drivers/video/rockchip/mpp/mpp_service.c
+
+diff --git a/drivers/video/Kconfig b/drivers/video/Kconfig
+index 44c9ef1435a2..5f41a16acea7 100644
+--- a/drivers/video/Kconfig
++++ b/drivers/video/Kconfig
+@@ -48,6 +48,10 @@ endmenu
+ 
+ source "drivers/video/backlight/Kconfig"
+ 
++menu "Rockchip Misc Video driver"
++source "drivers/video/rockchip/Kconfig"
++endmenu
++
+ config VGASTATE
+        tristate
+        default n
+diff --git a/drivers/video/Makefile b/drivers/video/Makefile
+index ffbac4387c67..02052f7afafd 100644
+--- a/drivers/video/Makefile
++++ b/drivers/video/Makefile
+@@ -14,6 +14,7 @@ obj-$(CONFIG_VT)		  += console/
+ obj-$(CONFIG_FB_STI)		  += console/
+ obj-$(CONFIG_LOGO)		  += logo/
+ obj-y				  += backlight/
++obj-y				  += rockchip/
+ 
+ obj-y				  += fbdev/
+ 
+diff --git a/drivers/video/rockchip/Kconfig b/drivers/video/rockchip/Kconfig
+new file mode 100644
+index 000000000000..7eaac4717513
+--- /dev/null
++++ b/drivers/video/rockchip/Kconfig
+@@ -0,0 +1,2 @@
++# SPDX-License-Identifier: GPL-2.0
++source "drivers/video/rockchip/mpp/Kconfig"
+diff --git a/drivers/video/rockchip/Makefile b/drivers/video/rockchip/Makefile
+new file mode 100644
+index 000000000000..8b48b689c765
+--- /dev/null
++++ b/drivers/video/rockchip/Makefile
+@@ -0,0 +1,2 @@
++# SPDX-License-Identifier: GPL-2.0
++obj-$(CONFIG_ROCKCHIP_MPP_SERVICE) += mpp/
+diff --git a/drivers/video/rockchip/mpp/Kconfig b/drivers/video/rockchip/mpp/Kconfig
+new file mode 100644
+index 000000000000..7e04eebd4886
+--- /dev/null
++++ b/drivers/video/rockchip/mpp/Kconfig
+@@ -0,0 +1,25 @@
++# SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++
++menuconfig ROCKCHIP_MPP_SERVICE
++	tristate "mpp service framework"
++	default m
++	depends on ARCH_ROCKCHIP
++	help
++	  rockchip mpp service framework.
++
++if ROCKCHIP_MPP_SERVICE
++
++config ROCKCHIP_MPP_PROC_FS
++	bool "mpp service procfs"
++	depends on PROC_FS
++	default y
++	help
++	  rockchip mpp service procfs.
++
++config ROCKCHIP_MPP_RKVENC2
++	bool "RKV encoder v2 device driver"
++	default y
++	help
++	  rockchip mpp rkv combo encoder v2.
++
++endif
+diff --git a/drivers/video/rockchip/mpp/Makefile b/drivers/video/rockchip/mpp/Makefile
+new file mode 100644
+index 000000000000..a7af57ea8cc5
+--- /dev/null
++++ b/drivers/video/rockchip/mpp/Makefile
+@@ -0,0 +1,7 @@
++# SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++
++rk_vcodec-objs := mpp_service.o mpp_common.o mpp_iommu.o
++
++rk_vcodec-$(CONFIG_ROCKCHIP_MPP_RKVENC2) += mpp_rkvenc2.o
++
++obj-$(CONFIG_ROCKCHIP_MPP_SERVICE) += rk_vcodec.o
+diff --git a/drivers/video/rockchip/mpp/mpp_common.c b/drivers/video/rockchip/mpp/mpp_common.c
+new file mode 100644
+index 000000000000..06d989959f55
+--- /dev/null
++++ b/drivers/video/rockchip/mpp/mpp_common.c
+@@ -0,0 +1,2471 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2019 Fuzhou Rockchip Electronics Co., Ltd
++ *
++ * author:
++ *	Alpha Lin, alpha.lin@rock-chips.com
++ *	Randy Li, randy.li@rock-chips.com
++ *	Ding Wei, leo.ding@rock-chips.com
++ *
++ */
++
++#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
++
++#include <linux/clk.h>
++#include <linux/delay.h>
++#include <linux/interrupt.h>
++#include <linux/iopoll.h>
++#include <linux/module.h>
++#include <linux/of.h>
++#include <linux/of_platform.h>
++#include <linux/of_irq.h>
++#include <linux/proc_fs.h>
++#include <linux/pm_runtime.h>
++#include <linux/poll.h>
++#include <linux/regmap.h>
++#include <linux/rwsem.h>
++#include <linux/mfd/syscon.h>
++#include <linux/seq_file.h>
++#include <linux/slab.h>
++#include <linux/uaccess.h>
++#include <linux/nospec.h>
++
++#include <soc/rockchip/pm_domains.h>
++
++#include "mpp_debug.h"
++#include "mpp_common.h"
++#include "mpp_iommu.h"
++
++#define MPP_WORK_TIMEOUT_DELAY		(500)
++#define MPP_WAIT_TIMEOUT_DELAY		(2000)
++
++/* Use 'v' as magic number */
++#define MPP_IOC_MAGIC		'v'
++
++#define MPP_IOC_CFG_V1	_IOW(MPP_IOC_MAGIC, 1, unsigned int)
++#define MPP_IOC_CFG_V2	_IOW(MPP_IOC_MAGIC, 2, unsigned int)
++
++/* input parmater structure for version 1 */
++struct mpp_msg_v1 {
++	__u32 cmd;
++	__u32 flags;
++	__u32 size;
++	__u32 offset;
++	__u64 data_ptr;
++};
++
++#define MPP_BAT_MSG_DONE		(0x00000001)
++
++struct mpp_bat_msg {
++	__u64 flag;
++	__u32 fd;
++	__s32 ret;
++};
++
++#ifdef CONFIG_ROCKCHIP_MPP_PROC_FS
++const char *mpp_device_name[MPP_DEVICE_BUTT] = {
++	[MPP_DEVICE_VDPU1]		= "VDPU1",
++	[MPP_DEVICE_VDPU2]		= "VDPU2",
++	[MPP_DEVICE_VDPU1_PP]		= "VDPU1_PP",
++	[MPP_DEVICE_VDPU2_PP]		= "VDPU2_PP",
++	[MPP_DEVICE_AV1DEC]		= "AV1DEC",
++	[MPP_DEVICE_HEVC_DEC]		= "HEVC_DEC",
++	[MPP_DEVICE_RKVDEC]		= "RKVDEC",
++	[MPP_DEVICE_AVSPLUS_DEC]	= "AVSPLUS_DEC",
++	[MPP_DEVICE_RKVENC]		= "RKVENC",
++	[MPP_DEVICE_VEPU1]		= "VEPU1",
++	[MPP_DEVICE_VEPU2]		= "VEPU2",
++	[MPP_DEVICE_VEPU22]		= "VEPU22",
++	[MPP_DEVICE_IEP2]		= "IEP2",
++};
++
++const char *enc_info_item_name[ENC_INFO_BUTT] = {
++	[ENC_INFO_BASE]		= "null",
++	[ENC_INFO_WIDTH]	= "width",
++	[ENC_INFO_HEIGHT]	= "height",
++	[ENC_INFO_FORMAT]	= "format",
++	[ENC_INFO_FPS_IN]	= "fps_in",
++	[ENC_INFO_FPS_OUT]	= "fps_out",
++	[ENC_INFO_RC_MODE]	= "rc_mode",
++	[ENC_INFO_BITRATE]	= "bitrate",
++	[ENC_INFO_GOP_SIZE]	= "gop_size",
++	[ENC_INFO_FPS_CALC]	= "fps_calc",
++	[ENC_INFO_PROFILE]	= "profile",
++};
++
++#endif
++
++static void mpp_attach_workqueue(struct mpp_dev *mpp,
++				 struct mpp_taskqueue *queue);
++
++static int
++mpp_taskqueue_pop_pending(struct mpp_taskqueue *queue,
++			  struct mpp_task *task)
++{
++	if (!task->session || !task->session->mpp)
++		return -EINVAL;
++
++	mutex_lock(&queue->pending_lock);
++	list_del_init(&task->queue_link);
++	mutex_unlock(&queue->pending_lock);
++	kref_put(&task->ref, mpp_free_task);
++
++	return 0;
++}
++
++static struct mpp_task *
++mpp_taskqueue_get_pending_task(struct mpp_taskqueue *queue)
++{
++	struct mpp_task *task = NULL;
++
++	mutex_lock(&queue->pending_lock);
++	task = list_first_entry_or_null(&queue->pending_list,
++					struct mpp_task,
++					queue_link);
++	mutex_unlock(&queue->pending_lock);
++
++	return task;
++}
++
++static bool
++mpp_taskqueue_is_running(struct mpp_taskqueue *queue)
++{
++	unsigned long flags;
++	bool flag;
++
++	spin_lock_irqsave(&queue->running_lock, flags);
++	flag = !list_empty(&queue->running_list);
++	spin_unlock_irqrestore(&queue->running_lock, flags);
++
++	return flag;
++}
++
++static int
++mpp_taskqueue_pending_to_run(struct mpp_taskqueue *queue,
++			     struct mpp_task *task)
++{
++	unsigned long flags;
++
++	mutex_lock(&queue->pending_lock);
++	spin_lock_irqsave(&queue->running_lock, flags);
++	list_move_tail(&task->queue_link, &queue->running_list);
++	spin_unlock_irqrestore(&queue->running_lock, flags);
++
++	mutex_unlock(&queue->pending_lock);
++
++	return 0;
++}
++
++static struct mpp_task *
++mpp_taskqueue_get_running_task(struct mpp_taskqueue *queue)
++{
++	unsigned long flags;
++	struct mpp_task *task = NULL;
++
++	spin_lock_irqsave(&queue->running_lock, flags);
++	task = list_first_entry_or_null(&queue->running_list,
++					struct mpp_task,
++					queue_link);
++	spin_unlock_irqrestore(&queue->running_lock, flags);
++
++	return task;
++}
++
++static int
++mpp_taskqueue_pop_running(struct mpp_taskqueue *queue,
++			  struct mpp_task *task)
++{
++	unsigned long flags;
++
++	if (!task->session || !task->session->mpp)
++		return -EINVAL;
++
++	spin_lock_irqsave(&queue->running_lock, flags);
++	list_del_init(&task->queue_link);
++	spin_unlock_irqrestore(&queue->running_lock, flags);
++	kref_put(&task->ref, mpp_free_task);
++
++	return 0;
++}
++
++static void
++mpp_taskqueue_trigger_work(struct mpp_dev *mpp)
++{
++	kthread_queue_work(&mpp->queue->worker, &mpp->work);
++}
++
++int mpp_power_on(struct mpp_dev *mpp)
++{
++	pm_runtime_get_sync(mpp->dev);
++	pm_stay_awake(mpp->dev);
++
++	if (mpp->hw_ops->clk_on)
++		mpp->hw_ops->clk_on(mpp);
++
++	return 0;
++}
++
++int mpp_power_off(struct mpp_dev *mpp)
++{
++	if (mpp->hw_ops->clk_off)
++		mpp->hw_ops->clk_off(mpp);
++
++	pm_relax(mpp->dev);
++	if (mpp_taskqueue_get_pending_task(mpp->queue) ||
++	    mpp_taskqueue_get_running_task(mpp->queue)) {
++		pm_runtime_mark_last_busy(mpp->dev);
++		pm_runtime_put_autosuspend(mpp->dev);
++	} else {
++		pm_runtime_put_sync_suspend(mpp->dev);
++	}
++
++	return 0;
++}
++
++static void task_msgs_reset(struct mpp_task_msgs *msgs)
++{
++	list_del_init(&msgs->list);
++
++	msgs->flags = 0;
++	msgs->req_cnt = 0;
++	msgs->set_cnt = 0;
++	msgs->poll_cnt = 0;
++}
++
++static void task_msgs_init(struct mpp_task_msgs *msgs, struct mpp_session *session)
++{
++	INIT_LIST_HEAD(&msgs->list);
++
++	msgs->session = session;
++	msgs->queue = NULL;
++	msgs->task = NULL;
++	msgs->mpp = NULL;
++
++	msgs->ext_fd = -1;
++
++	task_msgs_reset(msgs);
++}
++
++static struct mpp_task_msgs *get_task_msgs(struct mpp_session *session)
++{
++	unsigned long flags;
++	struct mpp_task_msgs *msgs;
++
++	spin_lock_irqsave(&session->lock_msgs, flags);
++	msgs = list_first_entry_or_null(&session->list_msgs_idle,
++					struct mpp_task_msgs, list_session);
++	if (msgs) {
++		list_move_tail(&msgs->list_session, &session->list_msgs);
++		spin_unlock_irqrestore(&session->lock_msgs, flags);
++
++		return msgs;
++	}
++	spin_unlock_irqrestore(&session->lock_msgs, flags);
++
++	msgs = kzalloc(sizeof(*msgs), GFP_KERNEL);
++	task_msgs_init(msgs, session);
++	INIT_LIST_HEAD(&msgs->list_session);
++
++	spin_lock_irqsave(&session->lock_msgs, flags);
++	list_move_tail(&msgs->list_session, &session->list_msgs);
++	session->msgs_cnt++;
++	spin_unlock_irqrestore(&session->lock_msgs, flags);
++
++	mpp_debug_func(DEBUG_TASK_INFO, "session %d:%d msgs cnt %d\n",
++		       session->pid, session->index, session->msgs_cnt);
++
++	return msgs;
++}
++
++static void put_task_msgs(struct mpp_task_msgs *msgs)
++{
++	struct mpp_session *session = msgs->session;
++	unsigned long flags;
++
++	if (!session) {
++		pr_err("invalid msgs without session\n");
++		return;
++	}
++
++	if (msgs->ext_fd >= 0) {
++		fdput(msgs->f);
++		msgs->ext_fd = -1;
++	}
++
++	task_msgs_reset(msgs);
++
++	spin_lock_irqsave(&session->lock_msgs, flags);
++	list_move_tail(&msgs->list_session, &session->list_msgs_idle);
++	spin_unlock_irqrestore(&session->lock_msgs, flags);
++}
++
++static void clear_task_msgs(struct mpp_session *session)
++{
++	struct mpp_task_msgs *msgs, *n;
++	LIST_HEAD(list_to_free);
++	unsigned long flags;
++
++	spin_lock_irqsave(&session->lock_msgs, flags);
++
++	list_for_each_entry_safe(msgs, n, &session->list_msgs, list_session)
++		list_move_tail(&msgs->list_session, &list_to_free);
++
++	list_for_each_entry_safe(msgs, n, &session->list_msgs_idle, list_session)
++		list_move_tail(&msgs->list_session, &list_to_free);
++
++	spin_unlock_irqrestore(&session->lock_msgs, flags);
++
++	list_for_each_entry_safe(msgs, n, &list_to_free, list_session)
++		kfree(msgs);
++}
++
++static void mpp_session_clear_pending(struct mpp_session *session)
++{
++	struct mpp_task *task = NULL, *n;
++
++	/* clear session pending list */
++	mutex_lock(&session->pending_lock);
++	list_for_each_entry_safe(task, n,
++				 &session->pending_list,
++				 pending_link) {
++		/* abort task in taskqueue */
++		atomic_inc(&task->abort_request);
++		list_del_init(&task->pending_link);
++		kref_put(&task->ref, mpp_free_task);
++	}
++	mutex_unlock(&session->pending_lock);
++}
++
++void mpp_session_cleanup_detach(struct mpp_taskqueue *queue, struct kthread_work *work)
++{
++	struct mpp_session *session, *n;
++
++	if (!atomic_read(&queue->detach_count))
++		return;
++
++	mutex_lock(&queue->session_lock);
++	list_for_each_entry_safe(session, n, &queue->session_detach, session_link) {
++		s32 task_count = atomic_read(&session->task_count);
++
++		if (!task_count) {
++			list_del_init(&session->session_link);
++			atomic_dec(&queue->detach_count);
++		}
++
++		mutex_unlock(&queue->session_lock);
++
++		if (task_count) {
++			mpp_dbg_session("session %d:%d task not finished %d\n",
++					session->pid, session->index,
++					atomic_read(&queue->detach_count));
++
++			mpp_session_clear_pending(session);
++		} else {
++			mpp_dbg_session("queue detach %d\n",
++					atomic_read(&queue->detach_count));
++
++			mpp_session_deinit(session);
++		}
++
++		mutex_lock(&queue->session_lock);
++	}
++	mutex_unlock(&queue->session_lock);
++
++	if (atomic_read(&queue->detach_count)) {
++		mpp_dbg_session("queue detach %d again\n",
++				atomic_read(&queue->detach_count));
++
++		kthread_queue_work(&queue->worker, work);
++	}
++}
++
++static struct mpp_session *mpp_session_init(void)
++{
++	struct mpp_session *session = kzalloc(sizeof(*session), GFP_KERNEL);
++
++	if (!session)
++		return NULL;
++
++	session->pid = current->pid;
++
++	mutex_init(&session->pending_lock);
++	INIT_LIST_HEAD(&session->pending_list);
++	INIT_LIST_HEAD(&session->service_link);
++	INIT_LIST_HEAD(&session->session_link);
++
++	atomic_set(&session->task_count, 0);
++	atomic_set(&session->release_request, 0);
++
++	INIT_LIST_HEAD(&session->list_msgs);
++	INIT_LIST_HEAD(&session->list_msgs_idle);
++	spin_lock_init(&session->lock_msgs);
++
++	mpp_dbg_session("session %p init\n", session);
++	return session;
++}
++
++static void mpp_session_deinit_default(struct mpp_session *session)
++{
++	if (session->mpp) {
++		struct mpp_dev *mpp = session->mpp;
++
++		if (mpp->dev_ops->free_session)
++			mpp->dev_ops->free_session(session);
++
++		mpp_session_clear_pending(session);
++
++		if (session->dma) {
++			mpp_iommu_down_read(mpp->iommu_info);
++			mpp_dma_session_destroy(session->dma);
++			mpp_iommu_up_read(mpp->iommu_info);
++			session->dma = NULL;
++		}
++	}
++
++	if (session->srv) {
++		struct mpp_service *srv = session->srv;
++
++		mutex_lock(&srv->session_lock);
++		list_del_init(&session->service_link);
++		mutex_unlock(&srv->session_lock);
++	}
++
++	list_del_init(&session->session_link);
++}
++
++void mpp_session_deinit(struct mpp_session *session)
++{
++	mpp_dbg_session("session %d:%d task %d deinit\n", session->pid,
++			session->index, atomic_read(&session->task_count));
++
++	if (likely(session->deinit))
++		session->deinit(session);
++	else
++		pr_err("invalid NULL session deinit function\n");
++
++	clear_task_msgs(session);
++
++	kfree(session);
++}
++
++static void mpp_session_attach_workqueue(struct mpp_session *session,
++					 struct mpp_taskqueue *queue)
++{
++	mpp_dbg_session("session %d:%d attach\n", session->pid, session->index);
++	mutex_lock(&queue->session_lock);
++	list_add_tail(&session->session_link, &queue->session_attach);
++	mutex_unlock(&queue->session_lock);
++}
++
++static void mpp_session_detach_workqueue(struct mpp_session *session)
++{
++	struct mpp_taskqueue *queue;
++	struct mpp_dev *mpp;
++
++	if (!session->mpp || !session->mpp->queue)
++		return;
++
++	mpp_dbg_session("session %d:%d detach\n", session->pid, session->index);
++	mpp = session->mpp;
++	queue = mpp->queue;
++
++	mutex_lock(&queue->session_lock);
++	list_del_init(&session->session_link);
++	list_add_tail(&session->session_link, &queue->session_detach);
++	atomic_inc(&queue->detach_count);
++	mutex_unlock(&queue->session_lock);
++
++	mpp_taskqueue_trigger_work(mpp);
++}
++
++static int
++mpp_session_push_pending(struct mpp_session *session,
++			 struct mpp_task *task)
++{
++	kref_get(&task->ref);
++	mutex_lock(&session->pending_lock);
++	list_add_tail(&task->pending_link, &session->pending_list);
++	mutex_unlock(&session->pending_lock);
++
++	return 0;
++}
++
++static int
++mpp_session_pop_pending(struct mpp_session *session,
++			struct mpp_task *task)
++{
++	mutex_lock(&session->pending_lock);
++	list_del_init(&task->pending_link);
++	mutex_unlock(&session->pending_lock);
++	kref_put(&task->ref, mpp_free_task);
++
++	return 0;
++}
++
++static struct mpp_task *
++mpp_session_get_pending_task(struct mpp_session *session)
++{
++	struct mpp_task *task = NULL;
++
++	mutex_lock(&session->pending_lock);
++	task = list_first_entry_or_null(&session->pending_list,
++					struct mpp_task,
++					pending_link);
++	mutex_unlock(&session->pending_lock);
++
++	return task;
++}
++
++void mpp_free_task(struct kref *ref)
++{
++	struct mpp_dev *mpp;
++	struct mpp_session *session;
++	struct mpp_task *task = container_of(ref, struct mpp_task, ref);
++
++	if (!task->session) {
++		mpp_err("task %p, task->session is null.\n", task);
++		return;
++	}
++	session = task->session;
++
++	mpp_debug_func(DEBUG_TASK_INFO, "task %d:%d free state 0x%lx abort %d\n",
++		       session->index, task->task_id, task->state,
++		       atomic_read(&task->abort_request));
++
++	mpp = mpp_get_task_used_device(task, session);
++	if (mpp->dev_ops->free_task)
++		mpp->dev_ops->free_task(session, task);
++
++	/* Decrease reference count */
++	atomic_dec(&session->task_count);
++	atomic_dec(&mpp->task_count);
++}
++
++static void mpp_task_timeout_work(struct work_struct *work_s)
++{
++	struct mpp_dev *mpp;
++	struct mpp_session *session;
++	struct mpp_task *task = container_of(to_delayed_work(work_s),
++					     struct mpp_task,
++					     timeout_work);
++
++	if (test_and_set_bit(TASK_STATE_HANDLE, &task->state)) {
++		mpp_err("task has been handled\n");
++		return;
++	}
++
++	if (!task->session) {
++		mpp_err("task %p, task->session is null.\n", task);
++		return;
++	}
++
++	session = task->session;
++	mpp_err("task %d:%d:%d processing time out!\n", session->pid,
++		session->index, task->task_id);
++
++	if (!session->mpp) {
++		mpp_err("session %d:%d, session mpp is null.\n", session->pid,
++			session->index);
++		return;
++	}
++
++	mpp = mpp_get_task_used_device(task, session);
++	/* hardware maybe dead, reset it */
++	mpp_reset_up_read(mpp->reset_group);
++	mpp_dev_reset(mpp);
++	mpp_power_off(mpp);
++
++	set_bit(TASK_STATE_TIMEOUT, &task->state);
++	set_bit(TASK_STATE_DONE, &task->state);
++	/* Wake up the GET thread */
++	wake_up(&task->wait);
++
++	/* remove task from taskqueue running list */
++	mpp_taskqueue_pop_running(mpp->queue, task);
++}
++
++static int mpp_process_task_default(struct mpp_session *session,
++				    struct mpp_task_msgs *msgs)
++{
++	struct mpp_task *task = NULL;
++	struct mpp_dev *mpp = session->mpp;
++
++	if (unlikely(!mpp)) {
++		mpp_err("pid %d client %d found invalid process function\n",
++			session->pid, session->device_type);
++		return -EINVAL;
++	}
++
++	if (mpp->dev_ops->alloc_task)
++		task = mpp->dev_ops->alloc_task(session, msgs);
++	if (!task) {
++		mpp_err("alloc_task failed.\n");
++		return -ENOMEM;
++	}
++	/* ensure current device */
++	mpp = mpp_get_task_used_device(task, session);
++
++	kref_init(&task->ref);
++	init_waitqueue_head(&task->wait);
++	atomic_set(&task->abort_request, 0);
++	task->task_index = atomic_fetch_inc(&mpp->task_index);
++	task->task_id = atomic_fetch_inc(&mpp->queue->task_id);
++	INIT_DELAYED_WORK(&task->timeout_work, mpp_task_timeout_work);
++
++	if (mpp->auto_freq_en && mpp->hw_ops->get_freq)
++		mpp->hw_ops->get_freq(mpp, task);
++
++	msgs->queue = mpp->queue;
++	msgs->task = task;
++	msgs->mpp = mpp;
++
++	/*
++	 * Push task to session should be in front of push task to queue.
++	 * Otherwise, when mpp_task_finish finish and worker_thread call
++	 * task worker, it may be get a task who has push in queue but
++	 * not in session, cause some errors.
++	 */
++	atomic_inc(&session->task_count);
++	mpp_session_push_pending(session, task);
++
++	return 0;
++}
++
++static int mpp_process_task(struct mpp_session *session,
++			    struct mpp_task_msgs *msgs)
++{
++	if (likely(session->process_task))
++		return session->process_task(session, msgs);
++
++	pr_err("invalid NULL process task function\n");
++	return -EINVAL;
++}
++
++struct reset_control *
++mpp_reset_control_get(struct mpp_dev *mpp, enum MPP_RESET_TYPE type, const char *name)
++{
++	int index;
++	struct reset_control *rst = NULL;
++	char shared_name[32] = "shared_";
++	struct mpp_reset_group *group;
++
++	/* check reset whether belone to device alone */
++	index = of_property_match_string(mpp->dev->of_node, "reset-names", name);
++	if (index >= 0) {
++		rst = devm_reset_control_get(mpp->dev, name);
++		mpp_safe_unreset(rst);
++
++		return rst;
++	}
++
++	/* check reset whether is shared */
++	strncat(shared_name, name,
++		sizeof(shared_name) - strlen(shared_name) - 1);
++	index = of_property_match_string(mpp->dev->of_node,
++					 "reset-names", shared_name);
++	if (index < 0) {
++		dev_err(mpp->dev, "%s is not found!\n", shared_name);
++		return NULL;
++	}
++
++	if (!mpp->reset_group) {
++		dev_err(mpp->dev, "reset group is empty!\n");
++		return NULL;
++	}
++	group = mpp->reset_group;
++
++	down_write(&group->rw_sem);
++	rst = group->resets[type];
++	if (!rst) {
++		rst = devm_reset_control_get(mpp->dev, shared_name);
++		mpp_safe_unreset(rst);
++		group->resets[type] = rst;
++		group->queue = mpp->queue;
++	}
++	/* if reset not in the same queue, it means different device
++	 * may reset in the same time, then rw_sem_on should set true.
++	 */
++	group->rw_sem_on |= (group->queue != mpp->queue) ? true : false;
++	dev_info(mpp->dev, "reset_group->rw_sem_on=%d\n", group->rw_sem_on);
++	up_write(&group->rw_sem);
++
++	return rst;
++}
++
++int mpp_dev_reset(struct mpp_dev *mpp)
++{
++	dev_info(mpp->dev, "resetting...\n");
++
++	/*
++	 * before running, we have to switch grf ctrl bit to ensure
++	 * working in current hardware
++	 */
++	if (mpp->hw_ops->set_grf)
++		mpp->hw_ops->set_grf(mpp);
++	else
++		mpp_set_grf(mpp->grf_info);
++
++	if (mpp->auto_freq_en && mpp->hw_ops->reduce_freq)
++		mpp->hw_ops->reduce_freq(mpp);
++	/* FIXME lock resource lock of the other devices in combo */
++	mpp_iommu_down_write(mpp->iommu_info);
++	mpp_reset_down_write(mpp->reset_group);
++	atomic_set(&mpp->reset_request, 0);
++
++	if (mpp->hw_ops->reset)
++		mpp->hw_ops->reset(mpp);
++
++	/* Note: if the domain does not change, iommu attach will be return
++	 * as an empty operation. Therefore, force to close and then open,
++	 * will be update the domain. In this way, domain can really attach.
++	 */
++	mpp_iommu_refresh(mpp->iommu_info, mpp->dev);
++
++	mpp_reset_up_write(mpp->reset_group);
++	mpp_iommu_up_write(mpp->iommu_info);
++
++	dev_info(mpp->dev, "reset done\n");
++
++	return 0;
++}
++
++static int mpp_task_run(struct mpp_dev *mpp,
++			struct mpp_task *task)
++{
++	int ret;
++
++	mpp_debug_enter();
++
++	/*
++	 * before running, we have to switch grf ctrl bit to ensure
++	 * working in current hardware
++	 */
++	if (mpp->hw_ops->set_grf) {
++		ret = mpp->hw_ops->set_grf(mpp);
++		if (ret) {
++			dev_err(mpp->dev, "set grf failed\n");
++			return ret;
++		}
++	} else {
++		mpp_set_grf(mpp->grf_info);
++	}
++
++	mpp_power_on(mpp);
++	mpp_debug_func(DEBUG_TASK_INFO, "pid %d run %s\n",
++		       task->session->pid, dev_name(mpp->dev));
++
++	if (mpp->auto_freq_en && mpp->hw_ops->set_freq)
++		mpp->hw_ops->set_freq(mpp, task);
++	/*
++	 * TODO: Lock the reader locker of the device resource lock here,
++	 * release at the finish operation
++	 */
++	mpp_reset_down_read(mpp->reset_group);
++
++	set_bit(TASK_STATE_START, &task->state);
++	mpp_time_record(task);
++	schedule_delayed_work(&task->timeout_work,
++			      msecs_to_jiffies(MPP_WORK_TIMEOUT_DELAY));
++	if (mpp->dev_ops->run)
++		mpp->dev_ops->run(mpp, task);
++
++	mpp_debug_leave();
++
++	return 0;
++}
++
++static void mpp_task_worker_default(struct kthread_work *work_s)
++{
++	struct mpp_task *task;
++	struct mpp_dev *mpp = container_of(work_s, struct mpp_dev, work);
++	struct mpp_taskqueue *queue = mpp->queue;
++
++	mpp_debug_enter();
++
++again:
++	task = mpp_taskqueue_get_pending_task(queue);
++	if (!task)
++		goto done;
++
++	/* if task timeout and aborted, remove it */
++	if (atomic_read(&task->abort_request) > 0) {
++		mpp_taskqueue_pop_pending(queue, task);
++		goto again;
++	}
++
++	/* get device for current task */
++	mpp = task->session->mpp;
++
++	/*
++	 * In the link table mode, the prepare function of the device
++	 * will check whether I can insert a new task into device.
++	 * If the device supports the task status query(like the HEVC
++	 * encoder), it can report whether the device is busy.
++	 * If the device does not support multiple task or task status
++	 * query, leave this job to mpp service.
++	 */
++	if (mpp->dev_ops->prepare)
++		task = mpp->dev_ops->prepare(mpp, task);
++	else if (mpp_taskqueue_is_running(queue))
++		task = NULL;
++
++	/*
++	 * FIXME if the hardware supports task query, but we still need to lock
++	 * the running list and lock the mpp service in the current state.
++	 */
++	/* Push a pending task to running queue */
++	if (task) {
++		struct mpp_dev *task_mpp = mpp_get_task_used_device(task, task->session);
++
++		mpp_taskqueue_pending_to_run(queue, task);
++		set_bit(TASK_STATE_RUNNING, &task->state);
++		if (mpp_task_run(task_mpp, task))
++			mpp_taskqueue_pop_running(queue, task);
++		else
++			goto again;
++	}
++
++done:
++	mpp_session_cleanup_detach(queue, work_s);
++}
++
++static int mpp_wait_result_default(struct mpp_session *session,
++				   struct mpp_task_msgs *msgs)
++{
++	int ret;
++	struct mpp_task *task;
++	struct mpp_dev *mpp;
++
++	task = mpp_session_get_pending_task(session);
++	if (!task) {
++		mpp_err("session %d:%d pending list is empty!\n",
++			session->pid, session->index);
++		return -EIO;
++	}
++	mpp = mpp_get_task_used_device(task, session);
++
++	ret = wait_event_timeout(task->wait,
++				 test_bit(TASK_STATE_DONE, &task->state),
++				 msecs_to_jiffies(MPP_WAIT_TIMEOUT_DELAY));
++	if (ret > 0) {
++		if (mpp->dev_ops->result)
++			ret = mpp->dev_ops->result(mpp, task, msgs);
++	} else {
++		atomic_inc(&task->abort_request);
++		set_bit(TASK_STATE_ABORT, &task->state);
++		mpp_err("timeout, pid %d session %d:%d count %d cur_task %p id %d\n",
++			session->pid, session->pid, session->index,
++			atomic_read(&session->task_count), task,
++			task->task_id);
++	}
++
++	mpp_debug_func(DEBUG_TASK_INFO, "task %d kref_%d\n",
++		       task->task_id, kref_read(&task->ref));
++
++	mpp_session_pop_pending(session, task);
++
++	return ret;
++}
++
++static int mpp_wait_result(struct mpp_session *session,
++			   struct mpp_task_msgs *msgs)
++{
++	if (likely(session->wait_result))
++		return session->wait_result(session, msgs);
++
++	pr_err("invalid NULL wait result function\n");
++	return -EINVAL;
++}
++
++static int mpp_attach_service(struct mpp_dev *mpp, struct device *dev)
++{
++	u32 taskqueue_node = 0;
++	u32 reset_group_node = 0;
++	struct device_node *np = NULL;
++	struct platform_device *pdev = NULL;
++	struct mpp_taskqueue *queue = NULL;
++	int ret = 0;
++
++	np = of_parse_phandle(dev->of_node, "rockchip,srv", 0);
++	if (!np || !of_device_is_available(np)) {
++		dev_err(dev, "failed to get the mpp service node\n");
++		return -ENODEV;
++	}
++
++	pdev = of_find_device_by_node(np);
++	of_node_put(np);
++	if (!pdev) {
++		dev_err(dev, "failed to get mpp service from node\n");
++		return -ENODEV;
++	}
++
++	mpp->srv = platform_get_drvdata(pdev);
++	platform_device_put(pdev);
++	if (!mpp->srv) {
++		dev_err(dev, "failed attach service\n");
++		return -EINVAL;
++	}
++
++	ret = of_property_read_u32(dev->of_node,
++				   "rockchip,taskqueue-node", &taskqueue_node);
++	if (ret) {
++		dev_err(dev, "failed to get taskqueue-node\n");
++		return ret;
++	} else if (taskqueue_node >= mpp->srv->taskqueue_cnt) {
++		dev_err(dev, "taskqueue-node %d must less than %d\n",
++			taskqueue_node, mpp->srv->taskqueue_cnt);
++		return -ENODEV;
++	}
++	/* set taskqueue according dtsi */
++	queue = mpp->srv->task_queues[taskqueue_node];
++	if (!queue) {
++		dev_err(dev, "taskqueue attach to invalid node %d\n",
++			taskqueue_node);
++		return -ENODEV;
++	}
++	mpp_attach_workqueue(mpp, queue);
++
++	ret = of_property_read_u32(dev->of_node,
++				   "rockchip,resetgroup-node", &reset_group_node);
++	if (!ret) {
++		/* set resetgroup according dtsi */
++		if (reset_group_node >= mpp->srv->reset_group_cnt) {
++			dev_err(dev, "resetgroup-node %d must less than %d\n",
++				reset_group_node, mpp->srv->reset_group_cnt);
++			return -ENODEV;
++		} else {
++			mpp->reset_group = mpp->srv->reset_groups[reset_group_node];
++		}
++	}
++
++	return 0;
++}
++
++struct mpp_taskqueue *mpp_taskqueue_init(struct device *dev)
++{
++	struct mpp_taskqueue *queue = devm_kzalloc(dev, sizeof(*queue),
++						   GFP_KERNEL);
++	if (!queue)
++		return NULL;
++
++	mutex_init(&queue->session_lock);
++	mutex_init(&queue->pending_lock);
++	spin_lock_init(&queue->running_lock);
++	mutex_init(&queue->mmu_lock);
++	mutex_init(&queue->dev_lock);
++	INIT_LIST_HEAD(&queue->session_attach);
++	INIT_LIST_HEAD(&queue->session_detach);
++	INIT_LIST_HEAD(&queue->pending_list);
++	INIT_LIST_HEAD(&queue->running_list);
++	INIT_LIST_HEAD(&queue->mmu_list);
++	INIT_LIST_HEAD(&queue->dev_list);
++
++	/* default taskqueue has max 16 task capacity */
++	queue->task_capacity = MPP_MAX_TASK_CAPACITY;
++	atomic_set(&queue->reset_request, 0);
++	atomic_set(&queue->detach_count, 0);
++	atomic_set(&queue->task_id, 0);
++
++	return queue;
++}
++
++static void mpp_attach_workqueue(struct mpp_dev *mpp,
++				 struct mpp_taskqueue *queue)
++{
++	s32 core_id;
++
++	INIT_LIST_HEAD(&mpp->queue_link);
++
++	mutex_lock(&queue->dev_lock);
++
++	if (mpp->core_id >= 0)
++		core_id = mpp->core_id;
++	else
++		core_id = queue->core_count;
++
++	if (core_id < 0 || core_id >= MPP_MAX_CORE_NUM) {
++		dev_err(mpp->dev, "invalid core id %d\n", core_id);
++		goto done;
++	}
++
++	if (queue->cores[core_id]) {
++		dev_err(mpp->dev, "can not attach device with same id %d", core_id);
++		goto done;
++	}
++
++	queue->cores[core_id] = mpp;
++	queue->core_count++;
++
++	set_bit(core_id, &queue->core_idle);
++	list_add_tail(&mpp->queue_link, &queue->dev_list);
++
++	mpp->core_id = core_id;
++	mpp->queue = queue;
++
++	mpp_dbg_core("%s attach queue as core %d\n",
++			dev_name(mpp->dev), mpp->core_id);
++
++	if (queue->task_capacity > mpp->task_capacity)
++		queue->task_capacity = mpp->task_capacity;
++
++done:
++	mutex_unlock(&queue->dev_lock);
++}
++
++static void mpp_detach_workqueue(struct mpp_dev *mpp)
++{
++	struct mpp_taskqueue *queue = mpp->queue;
++
++	if (queue) {
++		mutex_lock(&queue->dev_lock);
++
++		queue->cores[mpp->core_id] = NULL;
++		queue->core_count--;
++
++		clear_bit(queue->core_count, &queue->core_idle);
++		list_del_init(&mpp->queue_link);
++
++		mpp->queue = NULL;
++
++		mutex_unlock(&queue->dev_lock);
++	}
++}
++
++static int mpp_check_cmd_v1(__u32 cmd)
++{
++	bool found;
++
++	found = (cmd < MPP_CMD_QUERY_BUTT) ? true : false;
++	found = (cmd >= MPP_CMD_INIT_BASE && cmd < MPP_CMD_INIT_BUTT) ? true : found;
++	found = (cmd >= MPP_CMD_SEND_BASE && cmd < MPP_CMD_SEND_BUTT) ? true : found;
++	found = (cmd >= MPP_CMD_POLL_BASE && cmd < MPP_CMD_POLL_BUTT) ? true : found;
++	found = (cmd >= MPP_CMD_CONTROL_BASE && cmd < MPP_CMD_CONTROL_BUTT) ? true : found;
++
++	return found ? 0 : -EINVAL;
++}
++
++static inline int mpp_msg_is_last(struct mpp_request *req)
++{
++	int flag;
++
++	if (req->flags & MPP_FLAGS_MULTI_MSG)
++		flag = (req->flags & MPP_FLAGS_LAST_MSG) ? 1 : 0;
++	else
++		flag = 1;
++
++	return flag;
++}
++
++static __u32 mpp_get_cmd_butt(__u32 cmd)
++{
++	__u32 mask = 0;
++
++	switch (cmd) {
++	case MPP_CMD_QUERY_BASE:
++		mask = MPP_CMD_QUERY_BUTT;
++		break;
++	case MPP_CMD_INIT_BASE:
++		mask = MPP_CMD_INIT_BUTT;
++		break;
++
++	case MPP_CMD_SEND_BASE:
++		mask = MPP_CMD_SEND_BUTT;
++		break;
++	case MPP_CMD_POLL_BASE:
++		mask = MPP_CMD_POLL_BUTT;
++		break;
++	case MPP_CMD_CONTROL_BASE:
++		mask = MPP_CMD_CONTROL_BUTT;
++		break;
++	default:
++		mpp_err("unknown dev cmd 0x%x\n", cmd);
++		break;
++	}
++
++	return mask;
++}
++
++static int mpp_process_request(struct mpp_session *session,
++			       struct mpp_service *srv,
++			       struct mpp_request *req,
++			       struct mpp_task_msgs *msgs)
++{
++	int ret;
++	struct mpp_dev *mpp;
++
++	mpp_debug(DEBUG_IOCTL, "cmd %x process\n", req->cmd);
++
++	switch (req->cmd) {
++	case MPP_CMD_QUERY_HW_SUPPORT: {
++		u32 hw_support = srv->hw_support;
++
++		mpp_debug(DEBUG_IOCTL, "hw_support %08x\n", hw_support);
++		if (put_user(hw_support, (u32 __user *)req->data))
++			return -EFAULT;
++	} break;
++	case MPP_CMD_QUERY_HW_ID: {
++		struct mpp_hw_info *hw_info;
++
++		mpp = NULL;
++		if (session && session->mpp) {
++			mpp = session->mpp;
++		} else {
++			u32 client_type;
++
++			if (get_user(client_type, (u32 __user *)req->data))
++				return -EFAULT;
++
++			mpp_debug(DEBUG_IOCTL, "client %d\n", client_type);
++			client_type = array_index_nospec(client_type, MPP_DEVICE_BUTT);
++			if (test_bit(client_type, &srv->hw_support))
++				mpp = srv->sub_devices[client_type];
++		}
++
++		if (!mpp)
++			return -EINVAL;
++
++		hw_info = mpp->var->hw_info;
++		mpp_debug(DEBUG_IOCTL, "hw_id %08x\n", hw_info->hw_id);
++		if (put_user(hw_info->hw_id, (u32 __user *)req->data))
++			return -EFAULT;
++	} break;
++	case MPP_CMD_QUERY_CMD_SUPPORT: {
++		__u32 cmd = 0;
++
++		if (get_user(cmd, (u32 __user *)req->data))
++			return -EINVAL;
++
++		if (put_user(mpp_get_cmd_butt(cmd), (u32 __user *)req->data))
++			return -EFAULT;
++	} break;
++	case MPP_CMD_INIT_CLIENT_TYPE: {
++		u32 client_type;
++
++		if (get_user(client_type, (u32 __user *)req->data))
++			return -EFAULT;
++
++		mpp_debug(DEBUG_IOCTL, "client %d\n", client_type);
++		if (client_type >= MPP_DEVICE_BUTT) {
++			mpp_err("client_type must less than %d\n",
++				MPP_DEVICE_BUTT);
++			return -EINVAL;
++		}
++		client_type = array_index_nospec(client_type, MPP_DEVICE_BUTT);
++		mpp = srv->sub_devices[client_type];
++		if (!mpp)
++			return -EINVAL;
++
++		session->device_type = (enum MPP_DEVICE_TYPE)client_type;
++		session->dma = mpp_dma_session_create(mpp->dev, mpp->session_max_buffers);
++		session->mpp = mpp;
++		if (mpp->dev_ops) {
++			if (mpp->dev_ops->process_task)
++				session->process_task =
++					mpp->dev_ops->process_task;
++
++			if (mpp->dev_ops->wait_result)
++				session->wait_result =
++					mpp->dev_ops->wait_result;
++
++			if (mpp->dev_ops->deinit)
++				session->deinit = mpp->dev_ops->deinit;
++		}
++		session->index = atomic_fetch_inc(&mpp->session_index);
++		if (mpp->dev_ops && mpp->dev_ops->init_session) {
++			ret = mpp->dev_ops->init_session(session);
++			if (ret)
++				return ret;
++		}
++
++		mpp_session_attach_workqueue(session, mpp->queue);
++	} break;
++	case MPP_CMD_INIT_DRIVER_DATA: {
++		u32 val;
++
++		mpp = session->mpp;
++		if (!mpp)
++			return -EINVAL;
++		if (get_user(val, (u32 __user *)req->data))
++			return -EFAULT;
++		if (mpp->grf_info->grf)
++			regmap_write(mpp->grf_info->grf, 0x5d8, val);
++	} break;
++	case MPP_CMD_INIT_TRANS_TABLE: {
++		if (session && req->size) {
++			int trans_tbl_size = sizeof(session->trans_table);
++
++			if (req->size > trans_tbl_size) {
++				mpp_err("init table size %d more than %d\n",
++					req->size, trans_tbl_size);
++				return -ENOMEM;
++			}
++
++			if (copy_from_user(session->trans_table,
++					   req->data, req->size)) {
++				mpp_err("copy_from_user failed\n");
++				return -EINVAL;
++			}
++			session->trans_count =
++				req->size / sizeof(session->trans_table[0]);
++		}
++	} break;
++	case MPP_CMD_SET_REG_WRITE:
++	case MPP_CMD_SET_REG_READ:
++	case MPP_CMD_SET_REG_ADDR_OFFSET:
++	case MPP_CMD_SET_RCB_INFO: {
++		msgs->flags |= req->flags;
++		msgs->set_cnt++;
++	} break;
++	case MPP_CMD_POLL_HW_FINISH: {
++		msgs->flags |= req->flags;
++		msgs->poll_cnt++;
++		msgs->poll_req = NULL;
++	} break;
++	case MPP_CMD_POLL_HW_IRQ: {
++		if (msgs->poll_cnt || msgs->poll_req)
++			mpp_err("Do NOT poll hw irq when previous call not return\n");
++
++		msgs->flags |= req->flags;
++		msgs->poll_cnt++;
++
++		if (req->size && req->data) {
++			if (!msgs->poll_req)
++				msgs->poll_req = req;
++		} else {
++			msgs->poll_req = NULL;
++		}
++	} break;
++	case MPP_CMD_RESET_SESSION: {
++		int ret;
++		int val;
++
++		ret = readx_poll_timeout(atomic_read,
++					 &session->task_count,
++					 val, val == 0, 1000, 500000);
++		if (ret == -ETIMEDOUT) {
++			mpp_err("wait task running time out\n");
++		} else {
++			mpp = session->mpp;
++			if (!mpp)
++				return -EINVAL;
++
++			mpp_session_clear_pending(session);
++			mpp_iommu_down_write(mpp->iommu_info);
++			ret = mpp_dma_session_destroy(session->dma);
++			mpp_iommu_up_write(mpp->iommu_info);
++		}
++		return ret;
++	} break;
++	case MPP_CMD_TRANS_FD_TO_IOVA: {
++		u32 i;
++		u32 count;
++		u32 data[MPP_MAX_REG_TRANS_NUM];
++
++		mpp = session->mpp;
++		if (!mpp)
++			return -EINVAL;
++
++		if (req->size <= 0 ||
++		    req->size > sizeof(data))
++			return -EINVAL;
++
++		memset(data, 0, sizeof(data));
++		if (copy_from_user(data, req->data, req->size)) {
++			mpp_err("copy_from_user failed.\n");
++			return -EINVAL;
++		}
++		count = req->size / sizeof(u32);
++		for (i = 0; i < count; i++) {
++			struct mpp_dma_buffer *buffer;
++			int fd = data[i];
++
++			mpp_iommu_down_read(mpp->iommu_info);
++			buffer = mpp_dma_import_fd(mpp->iommu_info,
++						   session->dma, fd);
++			mpp_iommu_up_read(mpp->iommu_info);
++			if (IS_ERR_OR_NULL(buffer)) {
++				mpp_err("can not import fd %d\n", fd);
++				return -EINVAL;
++			}
++			data[i] = (u32)buffer->iova;
++			mpp_debug(DEBUG_IOMMU, "fd %d => iova %08x\n",
++				  fd, data[i]);
++		}
++		if (copy_to_user(req->data, data, req->size)) {
++			mpp_err("copy_to_user failed.\n");
++			return -EINVAL;
++		}
++	} break;
++	case MPP_CMD_RELEASE_FD: {
++		u32 i;
++		int ret;
++		u32 count;
++		u32 data[MPP_MAX_REG_TRANS_NUM];
++
++		if (req->size <= 0 ||
++		    req->size > sizeof(data))
++			return -EINVAL;
++
++		memset(data, 0, sizeof(data));
++		if (copy_from_user(data, req->data, req->size)) {
++			mpp_err("copy_from_user failed.\n");
++			return -EINVAL;
++		}
++		count = req->size / sizeof(u32);
++		for (i = 0; i < count; i++) {
++			ret = mpp_dma_release_fd(session->dma, data[i]);
++			if (ret) {
++				mpp_err("release fd %d failed.\n", data[i]);
++				return ret;
++			}
++		}
++	} break;
++	default: {
++		mpp = session->mpp;
++		if (!mpp) {
++			mpp_err("pid %d not find client %d\n",
++				session->pid, session->device_type);
++			return -EINVAL;
++		}
++		if (mpp->dev_ops->ioctl)
++			return mpp->dev_ops->ioctl(session, req);
++
++		mpp_debug(DEBUG_IOCTL, "unknown mpp ioctl cmd %x\n", req->cmd);
++	} break;
++	}
++
++	return 0;
++}
++
++static void task_msgs_add(struct mpp_task_msgs *msgs, struct list_head *head)
++{
++	struct mpp_session *session = msgs->session;
++	int ret = 0;
++
++	/* process each task */
++	if (msgs->set_cnt) {
++		/* NOTE: update msg_flags for fd over 1024 */
++		session->msg_flags = msgs->flags;
++		ret = mpp_process_task(session, msgs);
++	}
++
++	if (!ret) {
++		INIT_LIST_HEAD(&msgs->list);
++		list_add_tail(&msgs->list, head);
++	} else {
++		put_task_msgs(msgs);
++	}
++}
++
++static int mpp_collect_msgs(struct list_head *head, struct mpp_session *session,
++			    unsigned int cmd, void __user *msg)
++{
++	struct mpp_msg_v1 msg_v1;
++	struct mpp_request *req;
++	struct mpp_task_msgs *msgs = NULL;
++	int last = 1;
++	int ret;
++
++	if (cmd != MPP_IOC_CFG_V1) {
++		mpp_err("unknown ioctl cmd %x\n", cmd);
++		return -EINVAL;
++	}
++
++next:
++	/* first, parse to fixed struct */
++	if (copy_from_user(&msg_v1, msg, sizeof(msg_v1)))
++		return -EFAULT;
++
++	msg += sizeof(msg_v1);
++
++	mpp_debug(DEBUG_IOCTL, "cmd %x collect flags %08x, size %d, offset %x\n",
++		  msg_v1.cmd, msg_v1.flags, msg_v1.size, msg_v1.offset);
++
++	if (mpp_check_cmd_v1(msg_v1.cmd)) {
++		mpp_err("mpp cmd %x is not supported.\n", msg_v1.cmd);
++		return -EFAULT;
++	}
++
++	if (msg_v1.flags & MPP_FLAGS_MULTI_MSG)
++		last = (msg_v1.flags & MPP_FLAGS_LAST_MSG) ? 1 : 0;
++	else
++		last = 1;
++
++	/* check cmd for change msgs session */
++	if (msg_v1.cmd == MPP_CMD_SET_SESSION_FD) {
++		struct mpp_bat_msg bat_msg;
++		struct mpp_bat_msg __user *usr_cmd;
++		struct fd f;
++
++		/* try session switch here */
++		usr_cmd = (struct mpp_bat_msg __user *)(unsigned long)msg_v1.data_ptr;
++
++		if (copy_from_user(&bat_msg, usr_cmd, sizeof(bat_msg)))
++			return -EFAULT;
++
++		/* skip finished message */
++		if (bat_msg.flag & MPP_BAT_MSG_DONE)
++			goto session_switch_done;
++
++		f = fdget(bat_msg.fd);
++		if (!f.file) {
++			int ret = -EBADF;
++
++			mpp_err("fd %d get session failed\n", bat_msg.fd);
++
++			if (copy_to_user(&usr_cmd->ret, &ret, sizeof(usr_cmd->ret)))
++				mpp_err("copy_to_user failed.\n");
++			goto session_switch_done;
++		}
++
++		/* NOTE: add previous ready task to queue and drop empty task */
++		if (msgs) {
++			if (msgs->req_cnt)
++				task_msgs_add(msgs, head);
++			else
++				put_task_msgs(msgs);
++
++			msgs = NULL;
++		}
++
++		/* switch session */
++		session = f.file->private_data;
++		msgs = get_task_msgs(session);
++
++		if (f.file->private_data == session)
++			msgs->ext_fd = bat_msg.fd;
++
++		msgs->f = f;
++
++		mpp_debug(DEBUG_IOCTL, "fd %d, session %d msg_cnt %d\n",
++				bat_msg.fd, session->index, session->msgs_cnt);
++
++session_switch_done:
++		/* session id should NOT be the last message */
++		if (last)
++			return 0;
++
++		goto next;
++	}
++
++	if (!msgs)
++		msgs = get_task_msgs(session);
++
++	if (!msgs) {
++		pr_err("session %d:%d failed to get task msgs",
++		       session->pid, session->index);
++		return -EINVAL;
++	}
++
++	if (msgs->req_cnt >= MPP_MAX_MSG_NUM) {
++		mpp_err("session %d message count %d more than %d.\n",
++			session->index, msgs->req_cnt, MPP_MAX_MSG_NUM);
++		return -EINVAL;
++	}
++
++	req = &msgs->reqs[msgs->req_cnt++];
++	req->cmd = msg_v1.cmd;
++	req->flags = msg_v1.flags;
++	req->size = msg_v1.size;
++	req->offset = msg_v1.offset;
++	req->data = (void __user *)(unsigned long)msg_v1.data_ptr;
++
++	ret = mpp_process_request(session, session->srv, req, msgs);
++	if (ret) {
++		mpp_err("session %d process cmd %x ret %d\n",
++			session->index, req->cmd, ret);
++		return ret;
++	}
++
++	if (!last)
++		goto next;
++
++	task_msgs_add(msgs, head);
++	msgs = NULL;
++
++	return 0;
++}
++
++static void mpp_msgs_trigger(struct list_head *msgs_list)
++{
++	struct mpp_task_msgs *msgs, *n;
++	struct mpp_dev *mpp_prev = NULL;
++	struct mpp_taskqueue *queue_prev = NULL;
++
++	/* push task to queue */
++	list_for_each_entry_safe(msgs, n, msgs_list, list) {
++		struct mpp_dev *mpp;
++		struct mpp_task *task;
++		struct mpp_taskqueue *queue;
++
++		if (!msgs->set_cnt || !msgs->queue)
++			continue;
++
++		mpp = msgs->mpp;
++		task = msgs->task;
++		queue = msgs->queue;
++
++		if (queue_prev != queue) {
++			if (queue_prev && mpp_prev) {
++				mutex_unlock(&queue_prev->pending_lock);
++				mpp_taskqueue_trigger_work(mpp_prev);
++			}
++
++			if (queue)
++				mutex_lock(&queue->pending_lock);
++
++			mpp_prev = mpp;
++			queue_prev = queue;
++		}
++
++		if (test_bit(TASK_STATE_ABORT, &task->state))
++			pr_info("try to trigger abort task %d\n", task->task_id);
++
++		atomic_inc(&mpp->task_count);
++
++		set_bit(TASK_STATE_PENDING, &task->state);
++		list_add_tail(&task->queue_link, &queue->pending_list);
++	}
++
++	if (mpp_prev && queue_prev) {
++		mutex_unlock(&queue_prev->pending_lock);
++		mpp_taskqueue_trigger_work(mpp_prev);
++	}
++}
++
++static void mpp_msgs_wait(struct list_head *msgs_list)
++{
++	struct mpp_task_msgs *msgs, *n;
++
++	/* poll and release each task */
++	list_for_each_entry_safe(msgs, n, msgs_list, list) {
++		struct mpp_session *session = msgs->session;
++
++		if (msgs->poll_cnt) {
++			int ret = mpp_wait_result(session, msgs);
++
++			if (ret) {
++				mpp_err("session %d wait result ret %d\n",
++					session->index, ret);
++			}
++		}
++
++		put_task_msgs(msgs);
++
++	}
++}
++
++static long mpp_dev_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
++{
++	struct mpp_service *srv;
++	struct mpp_session *session = (struct mpp_session *)filp->private_data;
++	struct list_head msgs_list;
++	int ret = 0;
++
++	mpp_debug_enter();
++
++	if (!session || !session->srv) {
++		mpp_err("session %p\n", session);
++		return -EINVAL;
++	}
++
++	srv = session->srv;
++
++	if (atomic_read(&session->release_request) > 0) {
++		mpp_debug(DEBUG_IOCTL, "release session had request\n");
++		return -EBUSY;
++	}
++	if (atomic_read(&srv->shutdown_request) > 0) {
++		mpp_debug(DEBUG_IOCTL, "shutdown had request\n");
++		return -EBUSY;
++	}
++
++	INIT_LIST_HEAD(&msgs_list);
++
++	ret = mpp_collect_msgs(&msgs_list, session, cmd, (void __user *)arg);
++	if (ret)
++		mpp_err("collect msgs failed %d\n", ret);
++
++	mpp_msgs_trigger(&msgs_list);
++
++	mpp_msgs_wait(&msgs_list);
++
++	mpp_debug_leave();
++
++	return ret;
++}
++
++static int mpp_dev_open(struct inode *inode, struct file *filp)
++{
++	struct mpp_session *session = NULL;
++	struct mpp_service *srv = container_of(inode->i_cdev,
++					       struct mpp_service,
++					       mpp_cdev);
++	mpp_debug_enter();
++
++	session = mpp_session_init();
++	if (!session)
++		return -ENOMEM;
++
++	session->srv = srv;
++
++	if (session->srv) {
++		mutex_lock(&srv->session_lock);
++		list_add_tail(&session->service_link, &srv->session_list);
++		mutex_unlock(&srv->session_lock);
++	}
++	session->process_task = mpp_process_task_default;
++	session->wait_result = mpp_wait_result_default;
++	session->deinit = mpp_session_deinit_default;
++	filp->private_data = (void *)session;
++
++	mpp_debug_leave();
++
++	return nonseekable_open(inode, filp);
++}
++
++static int mpp_dev_release(struct inode *inode, struct file *filp)
++{
++	struct mpp_session *session = filp->private_data;
++
++	mpp_debug_enter();
++
++	if (!session) {
++		mpp_err("session is null\n");
++		return -EINVAL;
++	}
++
++	/* wait for task all done */
++	atomic_inc(&session->release_request);
++
++	if (session->mpp || atomic_read(&session->task_count))
++		mpp_session_detach_workqueue(session);
++	else
++		mpp_session_deinit(session);
++
++	filp->private_data = NULL;
++
++	mpp_debug_leave();
++	return 0;
++}
++
++const struct file_operations rockchip_mpp_fops = {
++	.open		= mpp_dev_open,
++	.release	= mpp_dev_release,
++	.unlocked_ioctl = mpp_dev_ioctl,
++#ifdef CONFIG_COMPAT
++	.compat_ioctl   = mpp_dev_ioctl,
++#endif
++};
++
++struct mpp_mem_region *
++mpp_task_attach_fd(struct mpp_task *task, int fd)
++{
++	struct mpp_mem_region *mem_region = NULL, *loop = NULL, *n;
++	struct mpp_dma_buffer *buffer = NULL;
++	struct mpp_dev *mpp = task->session->mpp;
++	struct mpp_dma_session *dma = task->session->dma;
++	u32 mem_num = ARRAY_SIZE(task->mem_regions);
++	bool found = false;
++
++	if (fd <= 0 || !dma || !mpp)
++		return ERR_PTR(-EINVAL);
++
++	if (task->mem_count > mem_num) {
++		mpp_err("mem_count %d must less than %d\n", task->mem_count, mem_num);
++		return ERR_PTR(-ENOMEM);
++	}
++
++	/* find fd whether had import */
++	list_for_each_entry_safe_reverse(loop, n, &task->mem_region_list, reg_link) {
++		if (loop->fd == fd) {
++			found = true;
++			break;
++		}
++	}
++
++	mem_region = &task->mem_regions[task->mem_count];
++	if (found) {
++		memcpy(mem_region, loop, sizeof(*loop));
++		mem_region->is_dup = true;
++	} else {
++		mpp_iommu_down_read(mpp->iommu_info);
++		buffer = mpp_dma_import_fd(mpp->iommu_info, dma, fd);
++		mpp_iommu_up_read(mpp->iommu_info);
++		if (IS_ERR(buffer)) {
++			mpp_err("can't import dma-buf %d\n", fd);
++			return ERR_CAST(buffer);
++		}
++
++		mem_region->hdl = buffer;
++		mem_region->iova = buffer->iova;
++		mem_region->len = buffer->size;
++		mem_region->fd = fd;
++		mem_region->is_dup = false;
++	}
++	task->mem_count++;
++	INIT_LIST_HEAD(&mem_region->reg_link);
++	list_add_tail(&mem_region->reg_link, &task->mem_region_list);
++
++	return mem_region;
++}
++
++int mpp_translate_reg_address(struct mpp_session *session,
++			      struct mpp_task *task, int fmt,
++			      u32 *reg, struct reg_offset_info *off_inf)
++{
++	int i;
++	int cnt;
++	const u16 *tbl;
++
++	mpp_debug_enter();
++
++	if (session->trans_count > 0) {
++		cnt = session->trans_count;
++		tbl = session->trans_table;
++	} else {
++		struct mpp_dev *mpp = mpp_get_task_used_device(task, session);
++		struct mpp_trans_info *trans_info = mpp->var->trans_info;
++
++		cnt = trans_info[fmt].count;
++		tbl = trans_info[fmt].table;
++	}
++
++	for (i = 0; i < cnt; i++) {
++		int usr_fd;
++		u32 offset;
++		struct mpp_mem_region *mem_region = NULL;
++
++		if (session->msg_flags & MPP_FLAGS_REG_NO_OFFSET) {
++			usr_fd = reg[tbl[i]];
++			offset = 0;
++		} else {
++			usr_fd = reg[tbl[i]] & 0x3ff;
++			offset = reg[tbl[i]] >> 10;
++		}
++
++		if (usr_fd == 0)
++			continue;
++
++		mem_region = mpp_task_attach_fd(task, usr_fd);
++		if (IS_ERR(mem_region)) {
++			mpp_err("reg[%3d]: 0x%08x fd %d failed\n",
++				tbl[i], reg[tbl[i]], usr_fd);
++			return PTR_ERR(mem_region);
++		}
++		mpp_debug(DEBUG_IOMMU,
++			  "reg[%3d]: %d => %pad, offset %10d, size %lx\n",
++			  tbl[i], usr_fd, &mem_region->iova,
++			  offset, mem_region->len);
++		mem_region->reg_idx = tbl[i];
++		reg[tbl[i]] = mem_region->iova + offset;
++	}
++
++	mpp_debug_leave();
++
++	return 0;
++}
++
++int mpp_check_req(struct mpp_request *req, int base,
++		  int max_size, u32 off_s, u32 off_e)
++{
++	int req_off;
++
++	if (req->offset < base) {
++		mpp_err("error: base %x, offset %x\n",
++			base, req->offset);
++		return -EINVAL;
++	}
++	req_off = req->offset - base;
++	if ((req_off + req->size) < off_s) {
++		mpp_err("error: req_off %x, req_size %x, off_s %x\n",
++			req_off, req->size, off_s);
++		return -EINVAL;
++	}
++	if (max_size < off_e) {
++		mpp_err("error: off_e %x, max_size %x\n",
++			off_e, max_size);
++		return -EINVAL;
++	}
++	if (req_off > max_size) {
++		mpp_err("error: req_off %x, max_size %x\n",
++			req_off, max_size);
++		return -EINVAL;
++	}
++	if ((req_off + req->size) > max_size) {
++		mpp_err("error: req_off %x, req_size %x, max_size %x\n",
++			req_off, req->size, max_size);
++		req->size = req_off + req->size - max_size;
++	}
++
++	return 0;
++}
++
++int mpp_extract_reg_offset_info(struct reg_offset_info *off_inf,
++				struct mpp_request *req)
++{
++	int max_size = ARRAY_SIZE(off_inf->elem);
++	int cnt = req->size / sizeof(off_inf->elem[0]);
++
++	if ((cnt + off_inf->cnt) > max_size) {
++		mpp_err("count %d, total %d, max_size %d\n",
++			cnt, off_inf->cnt, max_size);
++		return -EINVAL;
++	}
++	if (copy_from_user(&off_inf->elem[off_inf->cnt],
++			   req->data, req->size)) {
++		mpp_err("copy_from_user failed\n");
++		return -EINVAL;
++	}
++	off_inf->cnt += cnt;
++
++	return 0;
++}
++
++int mpp_query_reg_offset_info(struct reg_offset_info *off_inf,
++			      u32 index)
++{
++	mpp_debug_enter();
++	if (off_inf) {
++		int i;
++
++		for (i = 0; i < off_inf->cnt; i++) {
++			if (off_inf->elem[i].index == index)
++				return off_inf->elem[i].offset;
++		}
++	}
++	mpp_debug_leave();
++
++	return 0;
++}
++
++int mpp_translate_reg_offset_info(struct mpp_task *task,
++				  struct reg_offset_info *off_inf,
++				  u32 *reg)
++{
++	mpp_debug_enter();
++
++	if (off_inf) {
++		int i;
++
++		for (i = 0; i < off_inf->cnt; i++) {
++			mpp_debug(DEBUG_IOMMU, "reg[%d] + offset %d\n",
++				  off_inf->elem[i].index,
++				  off_inf->elem[i].offset);
++			reg[off_inf->elem[i].index] += off_inf->elem[i].offset;
++		}
++	}
++	mpp_debug_leave();
++
++	return 0;
++}
++
++int mpp_task_init(struct mpp_session *session, struct mpp_task *task)
++{
++	INIT_LIST_HEAD(&task->pending_link);
++	INIT_LIST_HEAD(&task->queue_link);
++	INIT_LIST_HEAD(&task->mem_region_list);
++	task->state = 0;
++	task->mem_count = 0;
++	task->session = session;
++
++	return 0;
++}
++
++int mpp_task_finish(struct mpp_session *session,
++		    struct mpp_task *task)
++{
++	struct mpp_dev *mpp = mpp_get_task_used_device(task, session);
++
++	if (mpp->dev_ops->finish)
++		mpp->dev_ops->finish(mpp, task);
++
++	mpp_reset_up_read(mpp->reset_group);
++	if (atomic_read(&mpp->reset_request) > 0)
++		mpp_dev_reset(mpp);
++	mpp_power_off(mpp);
++
++	set_bit(TASK_STATE_FINISH, &task->state);
++	set_bit(TASK_STATE_DONE, &task->state);
++	/* Wake up the GET thread */
++	wake_up(&task->wait);
++	mpp_taskqueue_pop_running(mpp->queue, task);
++
++	return 0;
++}
++
++int mpp_task_finalize(struct mpp_session *session,
++		      struct mpp_task *task)
++{
++	struct mpp_mem_region *mem_region = NULL, *n;
++	struct mpp_dev *mpp = mpp_get_task_used_device(task, session);
++
++	/* release memory region attach to this registers table. */
++	list_for_each_entry_safe(mem_region, n,
++				 &task->mem_region_list,
++				 reg_link) {
++		if (!mem_region->is_dup) {
++			mpp_iommu_down_read(mpp->iommu_info);
++			mpp_dma_release(session->dma, mem_region->hdl);
++			mpp_iommu_up_read(mpp->iommu_info);
++		}
++		list_del_init(&mem_region->reg_link);
++	}
++
++	return 0;
++}
++
++int mpp_task_dump_mem_region(struct mpp_dev *mpp,
++			     struct mpp_task *task)
++{
++	struct mpp_mem_region *mem = NULL, *n;
++
++	if (!task)
++		return -EIO;
++
++	mpp_err("--- dump mem region ---\n");
++	if (!list_empty(&task->mem_region_list)) {
++		list_for_each_entry_safe(mem, n,
++					 &task->mem_region_list,
++					 reg_link) {
++			mpp_err("reg[%3d]: %pad, size %lx\n",
++				mem->reg_idx, &mem->iova, mem->len);
++		}
++	} else {
++		dev_err(mpp->dev, "no memory region mapped\n");
++	}
++
++	return 0;
++}
++
++int mpp_task_dump_reg(struct mpp_dev *mpp,
++		      struct mpp_task *task)
++{
++	if (!task)
++		return -EIO;
++
++	if (mpp_debug_unlikely(DEBUG_DUMP_ERR_REG)) {
++		mpp_err("--- dump task register ---\n");
++		if (task->reg) {
++			u32 i;
++			u32 s = task->hw_info->reg_start;
++			u32 e = task->hw_info->reg_end;
++
++			for (i = s; i <= e; i++) {
++				u32 reg = i * sizeof(u32);
++
++				mpp_err("reg[%03d]: %04x: 0x%08x\n",
++					i, reg, task->reg[i]);
++			}
++		}
++	}
++
++	return 0;
++}
++
++int mpp_task_dump_hw_reg(struct mpp_dev *mpp)
++{
++	if (mpp_debug_unlikely(DEBUG_DUMP_ERR_REG)) {
++		u32 i;
++		u32 s = mpp->var->hw_info->reg_start;
++		u32 e = mpp->var->hw_info->reg_end;
++
++		mpp_err("--- dump hardware register ---\n");
++		for (i = s; i <= e; i++) {
++			u32 reg = i * sizeof(u32);
++
++			mpp_err("reg[%03d]: %04x: 0x%08x\n",
++				i, reg, readl_relaxed(mpp->reg_base + reg));
++		}
++	}
++
++	return 0;
++}
++
++static int mpp_iommu_handle(struct iommu_domain *iommu,
++			    struct device *iommu_dev,
++			    unsigned long iova,
++			    int status, void *arg)
++{
++	struct mpp_dev *mpp = (struct mpp_dev *)arg;
++
++	dev_err(mpp->dev, "fault addr 0x%08lx status %x\n", iova, status);
++	mpp_task_dump_hw_reg(mpp);
++
++	if (mpp->iommu_info->hdl)
++		mpp->iommu_info->hdl(iommu, iommu_dev, iova, status, arg);
++
++	return 0;
++}
++
++void mpp_reg_show(struct mpp_dev *mpp, u32 offset)
++{
++	if (!mpp)
++		return;
++
++	dev_err(mpp->dev, "reg[%03d]: %04x: 0x%08x\n",
++		offset >> 2, offset, mpp_read_relaxed(mpp, offset));
++}
++
++/* The device will do more probing work after this */
++int mpp_dev_probe(struct mpp_dev *mpp,
++		  struct platform_device *pdev)
++{
++	int ret;
++	struct resource *res = NULL;
++	struct device *dev = &pdev->dev;
++	struct device_node *np = dev->of_node;
++	struct mpp_hw_info *hw_info = mpp->var->hw_info;
++
++	/* Get disable auto frequent flag from dtsi */
++	mpp->auto_freq_en = !device_property_read_bool(dev, "rockchip,disable-auto-freq");
++	/* read flag for pum idle request */
++	mpp->skip_idle = device_property_read_bool(dev, "rockchip,skip-pmu-idle-request");
++
++	/* read link table capacity */
++	ret = of_property_read_u32(np, "rockchip,task-capacity",
++				   &mpp->task_capacity);
++	if (ret)
++		mpp->task_capacity = 1;
++
++	mpp->dev = dev;
++	mpp->hw_ops = mpp->var->hw_ops;
++	mpp->dev_ops = mpp->var->dev_ops;
++
++	/* Get and attach to service */
++	ret = mpp_attach_service(mpp, dev);
++	if (ret) {
++		dev_err(dev, "failed to attach service\n");
++		return -ENODEV;
++	}
++
++	if (mpp->task_capacity == 1) {
++		/* power domain autosuspend delay 2s */
++		pm_runtime_set_autosuspend_delay(dev, 2000);
++		pm_runtime_use_autosuspend(dev);
++	} else {
++		dev_info(dev, "link mode task capacity %d\n",
++			 mpp->task_capacity);
++		/* do not setup autosuspend on multi task device */
++	}
++
++	kthread_init_work(&mpp->work, mpp_task_worker_default);
++
++	atomic_set(&mpp->reset_request, 0);
++	atomic_set(&mpp->session_index, 0);
++	atomic_set(&mpp->task_count, 0);
++	atomic_set(&mpp->task_index, 0);
++
++	device_init_wakeup(dev, true);
++	pm_runtime_enable(dev);
++
++	mpp->irq = platform_get_irq(pdev, 0);
++	if (mpp->irq < 0) {
++		dev_err(dev, "No interrupt resource found\n");
++		ret = -ENODEV;
++		goto failed;
++	}
++
++	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
++	if (!res) {
++		dev_err(&pdev->dev, "no memory resource defined\n");
++		ret = -ENODEV;
++		goto failed;
++	}
++	/*
++	 * Tips: here can not use function devm_ioremap_resource. The resion is
++	 * that hevc and vdpu map the same register address region in rk3368.
++	 * However, devm_ioremap_resource will call function
++	 * devm_request_mem_region to check region. Thus, use function
++	 * devm_ioremap can avoid it.
++	 */
++	mpp->reg_base = devm_ioremap(dev, res->start, resource_size(res));
++	if (!mpp->reg_base) {
++		dev_err(dev, "ioremap failed for resource %pR\n", res);
++		ret = -ENOMEM;
++		goto failed;
++	}
++
++	/*
++	 * TODO: here or at the device itself, some device does not
++	 * have the iommu, maybe in the device is better.
++	 */
++	mpp->iommu_info = mpp_iommu_probe(dev);
++	if (IS_ERR(mpp->iommu_info)) {
++		dev_err(dev, "failed to attach iommu\n");
++		mpp->iommu_info = NULL;
++	}
++	if (mpp->hw_ops->init) {
++		ret = mpp->hw_ops->init(mpp);
++		if (ret)
++			goto failed;
++	}
++	/* set iommu fault handler */
++	if (mpp->iommu_info)
++		iommu_set_fault_handler(mpp->iommu_info->domain,
++					mpp_iommu_handle, mpp);
++
++	/* read hardware id */
++	if (hw_info->reg_id >= 0) {
++		pm_runtime_get_sync(dev);
++		if (mpp->hw_ops->clk_on)
++			mpp->hw_ops->clk_on(mpp);
++
++		hw_info->hw_id = mpp_read(mpp, hw_info->reg_id);
++		if (mpp->hw_ops->clk_off)
++			mpp->hw_ops->clk_off(mpp);
++		pm_runtime_put_sync(dev);
++	}
++
++	return ret;
++failed:
++	mpp_detach_workqueue(mpp);
++	device_init_wakeup(dev, false);
++	pm_runtime_disable(dev);
++
++	return ret;
++}
++
++int mpp_dev_remove(struct mpp_dev *mpp)
++{
++	if (mpp->hw_ops->exit)
++		mpp->hw_ops->exit(mpp);
++
++	mpp_iommu_remove(mpp->iommu_info);
++	mpp_detach_workqueue(mpp);
++	device_init_wakeup(mpp->dev, false);
++	pm_runtime_disable(mpp->dev);
++
++	return 0;
++}
++
++void mpp_dev_shutdown(struct platform_device *pdev)
++{
++	int ret;
++	int val;
++	struct device *dev = &pdev->dev;
++	struct mpp_dev *mpp = dev_get_drvdata(dev);
++
++	dev_info(dev, "shutdown device\n");
++
++	atomic_inc(&mpp->srv->shutdown_request);
++	ret = readx_poll_timeout(atomic_read,
++				 &mpp->task_count,
++				 val, val == 0, 20000, 200000);
++	if (ret == -ETIMEDOUT)
++		dev_err(dev, "wait total %d running time out\n",
++			atomic_read(&mpp->task_count));
++	else
++		dev_info(dev, "shutdown success\n");
++}
++
++int mpp_dev_register_srv(struct mpp_dev *mpp, struct mpp_service *srv)
++{
++	enum MPP_DEVICE_TYPE device_type = mpp->var->device_type;
++
++	srv->sub_devices[device_type] = mpp;
++	set_bit(device_type, &srv->hw_support);
++
++	return 0;
++}
++
++irqreturn_t mpp_dev_irq(int irq, void *param)
++{
++	struct mpp_dev *mpp = param;
++	struct mpp_task *task = mpp->cur_task;
++	irqreturn_t irq_ret = IRQ_NONE;
++
++	if (mpp->dev_ops->irq)
++		irq_ret = mpp->dev_ops->irq(mpp);
++
++	if (task) {
++		if (irq_ret != IRQ_NONE) {
++			/* if wait or delayed work timeout, abort request will turn on,
++			 * isr should not to response, and handle it in delayed work
++			 */
++			if (test_and_set_bit(TASK_STATE_HANDLE, &task->state)) {
++				mpp_err("error, task has been handled, irq_status %08x\n",
++					mpp->irq_status);
++				irq_ret = IRQ_HANDLED;
++				goto done;
++			}
++			cancel_delayed_work(&task->timeout_work);
++			/* normal condition, set state and wake up isr thread */
++			set_bit(TASK_STATE_IRQ, &task->state);
++		}
++	} else {
++		mpp_debug(DEBUG_IRQ_CHECK, "error, task is null\n");
++	}
++done:
++	return irq_ret;
++}
++
++irqreturn_t mpp_dev_isr_sched(int irq, void *param)
++{
++	irqreturn_t ret = IRQ_NONE;
++	struct mpp_dev *mpp = param;
++
++	if (mpp->auto_freq_en &&
++	    mpp->hw_ops->reduce_freq &&
++	    list_empty(&mpp->queue->pending_list))
++		mpp->hw_ops->reduce_freq(mpp);
++
++	if (mpp->dev_ops->isr)
++		ret = mpp->dev_ops->isr(mpp);
++
++	/* trigger current queue to run next task */
++	mpp_taskqueue_trigger_work(mpp);
++
++	return ret;
++}
++
++u32 mpp_get_grf(struct mpp_grf_info *grf_info)
++{
++	u32 val = 0;
++
++	if (grf_info && grf_info->grf && grf_info->val)
++		regmap_read(grf_info->grf, grf_info->offset, &val);
++
++	return (val & MPP_GRF_VAL_MASK);
++}
++
++bool mpp_grf_is_changed(struct mpp_grf_info *grf_info)
++{
++	bool changed = false;
++
++	if (grf_info && grf_info->grf && grf_info->val) {
++		u32 grf_status = mpp_get_grf(grf_info);
++		u32 grf_val = grf_info->val & MPP_GRF_VAL_MASK;
++
++		changed = (grf_status == grf_val) ? false : true;
++	}
++
++	return changed;
++}
++
++int mpp_set_grf(struct mpp_grf_info *grf_info)
++{
++	if (grf_info && grf_info->grf && grf_info->val)
++		regmap_write(grf_info->grf, grf_info->offset, grf_info->val);
++
++	return 0;
++}
++
++int mpp_time_record(struct mpp_task *task)
++{
++	if (mpp_debug_unlikely(DEBUG_TIMING) && task) {
++		task->start = ktime_get();
++		task->part = task->start;
++	}
++
++	return 0;
++}
++
++int mpp_time_part_diff(struct mpp_task *task)
++{
++	ktime_t end;
++	struct mpp_dev *mpp = mpp_get_task_used_device(task, task->session);
++
++	end = ktime_get();
++	mpp_debug(DEBUG_PART_TIMING, "%s:%d session %d:%d part time: %lld us\n",
++		  dev_name(mpp->dev), task->core_id, task->session->pid,
++		  task->session->index, ktime_us_delta(end, task->part));
++	task->part = end;
++
++	return 0;
++}
++
++int mpp_time_diff(struct mpp_task *task)
++{
++	ktime_t end;
++	struct mpp_dev *mpp = mpp_get_task_used_device(task, task->session);
++
++	end = ktime_get();
++	mpp_debug(DEBUG_TIMING, "%s:%d session %d:%d time: %lld us\n",
++		  dev_name(mpp->dev), task->core_id, task->session->pid,
++		  task->session->index, ktime_us_delta(end, task->start));
++
++	return 0;
++}
++
++int mpp_write_req(struct mpp_dev *mpp, u32 *regs,
++		  u32 start_idx, u32 end_idx, u32 en_idx)
++{
++	int i;
++
++	for (i = start_idx; i < end_idx; i++) {
++		if (i == en_idx)
++			continue;
++		mpp_write_relaxed(mpp, i * sizeof(u32), regs[i]);
++	}
++
++	return 0;
++}
++
++int mpp_read_req(struct mpp_dev *mpp, u32 *regs,
++		 u32 start_idx, u32 end_idx)
++{
++	int i;
++
++	for (i = start_idx; i < end_idx; i++)
++		regs[i] = mpp_read_relaxed(mpp, i * sizeof(u32));
++
++	return 0;
++}
++
++int mpp_get_clk_info(struct mpp_dev *mpp,
++		     struct mpp_clk_info *clk_info,
++		     const char *name)
++{
++	int index = of_property_match_string(mpp->dev->of_node,
++					     "clock-names", name);
++
++	if (index < 0)
++		return -EINVAL;
++
++	clk_info->clk = devm_clk_get(mpp->dev, name);
++	of_property_read_u32_index(mpp->dev->of_node,
++				   "rockchip,normal-rates",
++				   index,
++				   &clk_info->normal_rate_hz);
++	of_property_read_u32_index(mpp->dev->of_node,
++				   "rockchip,advanced-rates",
++				   index,
++				   &clk_info->advanced_rate_hz);
++
++	return 0;
++}
++
++int mpp_set_clk_info_rate_hz(struct mpp_clk_info *clk_info,
++			     enum MPP_CLOCK_MODE mode,
++			     unsigned long val)
++{
++	if (!clk_info->clk || !val)
++		return 0;
++
++	switch (mode) {
++	case CLK_MODE_DEBUG:
++		clk_info->debug_rate_hz = val;
++	break;
++	case CLK_MODE_REDUCE:
++		clk_info->reduce_rate_hz = val;
++	break;
++	case CLK_MODE_NORMAL:
++		clk_info->normal_rate_hz = val;
++	break;
++	case CLK_MODE_ADVANCED:
++		clk_info->advanced_rate_hz = val;
++	break;
++	case CLK_MODE_DEFAULT:
++		clk_info->default_rate_hz = val;
++	break;
++	default:
++		mpp_err("error mode %d\n", mode);
++	break;
++	}
++
++	return 0;
++}
++
++#define MPP_REDUCE_RATE_HZ (50 * MHZ)
++
++unsigned long mpp_get_clk_info_rate_hz(struct mpp_clk_info *clk_info,
++				       enum MPP_CLOCK_MODE mode)
++{
++	unsigned long clk_rate_hz = 0;
++
++	if (!clk_info->clk)
++		return 0;
++
++	if (clk_info->debug_rate_hz)
++		return clk_info->debug_rate_hz;
++
++	switch (mode) {
++	case CLK_MODE_REDUCE: {
++		if (clk_info->reduce_rate_hz)
++			clk_rate_hz = clk_info->reduce_rate_hz;
++		else
++			clk_rate_hz = MPP_REDUCE_RATE_HZ;
++	} break;
++	case CLK_MODE_NORMAL: {
++		if (clk_info->normal_rate_hz)
++			clk_rate_hz = clk_info->normal_rate_hz;
++		else
++			clk_rate_hz = clk_info->default_rate_hz;
++	} break;
++	case CLK_MODE_ADVANCED: {
++		if (clk_info->advanced_rate_hz)
++			clk_rate_hz = clk_info->advanced_rate_hz;
++		else if (clk_info->normal_rate_hz)
++			clk_rate_hz = clk_info->normal_rate_hz;
++		else
++			clk_rate_hz = clk_info->default_rate_hz;
++	} break;
++	case CLK_MODE_DEFAULT:
++	default: {
++		clk_rate_hz = clk_info->default_rate_hz;
++	} break;
++	}
++
++	return clk_rate_hz;
++}
++
++int mpp_clk_set_rate(struct mpp_clk_info *clk_info,
++		     enum MPP_CLOCK_MODE mode)
++{
++	unsigned long clk_rate_hz;
++
++	if (!clk_info->clk)
++		return -EINVAL;
++
++	clk_rate_hz = mpp_get_clk_info_rate_hz(clk_info, mode);
++	if (clk_rate_hz) {
++		clk_info->used_rate_hz = clk_rate_hz;
++		clk_set_rate(clk_info->clk, clk_rate_hz);
++	}
++
++	return 0;
++}
++
++#ifdef CONFIG_ROCKCHIP_MPP_PROC_FS
++static int fops_show_u32(struct seq_file *file, void *v)
++{
++	u32 *val = file->private;
++
++	seq_printf(file, "%d\n", *val);
++
++	return 0;
++}
++
++static int fops_open_u32(struct inode *inode, struct file *file)
++{
++	return single_open(file, fops_show_u32, pde_data(inode));
++}
++
++static ssize_t fops_write_u32(struct file *file, const char __user *buf,
++			      size_t count, loff_t *ppos)
++{
++	int rc;
++	struct seq_file *priv = file->private_data;
++
++	rc = kstrtou32_from_user(buf, count, 0, priv->private);
++	if (rc)
++		return rc;
++
++	return count;
++}
++
++static const struct proc_ops procfs_fops_u32 = {
++	.proc_open = fops_open_u32,
++	.proc_read = seq_read,
++	.proc_release = single_release,
++	.proc_write = fops_write_u32,
++};
++
++struct proc_dir_entry *
++mpp_procfs_create_u32(const char *name, umode_t mode,
++		      struct proc_dir_entry *parent, void *data)
++{
++	return proc_create_data(name, mode, parent, &procfs_fops_u32, data);
++}
++#endif
+diff --git a/drivers/video/rockchip/mpp/mpp_common.h b/drivers/video/rockchip/mpp/mpp_common.h
+new file mode 100644
+index 000000000000..6215328db805
+--- /dev/null
++++ b/drivers/video/rockchip/mpp/mpp_common.h
+@@ -0,0 +1,854 @@
++/* SPDX-License-Identifier: (GPL-2.0+ OR MIT) */
++/*
++ * Copyright (c) 2019 Fuzhou Rockchip Electronics Co., Ltd
++ *
++ * author:
++ *	Alpha Lin, alpha.lin@rock-chips.com
++ *	Randy Li, randy.li@rock-chips.com
++ *	Ding Wei, leo.ding@rock-chips.com
++ *
++ */
++#ifndef __ROCKCHIP_MPP_COMMON_H__
++#define __ROCKCHIP_MPP_COMMON_H__
++
++#include <linux/cdev.h>
++#include <linux/clk.h>
++#include <linux/dma-buf.h>
++#include <linux/kfifo.h>
++#include <linux/types.h>
++#include <linux/time.h>
++#include <linux/workqueue.h>
++#include <linux/kthread.h>
++#include <linux/reset.h>
++#include <linux/irqreturn.h>
++#include <linux/poll.h>
++#include <linux/platform_device.h>
++#include <soc/rockchip/pm_domains.h>
++
++#define MHZ			(1000 * 1000)
++
++#define MPP_MAX_MSG_NUM			(16)
++#define MPP_MAX_REG_TRANS_NUM		(60)
++#define MPP_MAX_TASK_CAPACITY		(16)
++/* define flags for mpp_request */
++#define MPP_FLAGS_MULTI_MSG		(0x00000001)
++#define MPP_FLAGS_LAST_MSG		(0x00000002)
++#define MPP_FLAGS_REG_FD_NO_TRANS	(0x00000004)
++#define MPP_FLAGS_SCL_FD_NO_TRANS	(0x00000008)
++#define MPP_FLAGS_REG_NO_OFFSET		(0x00000010)
++#define MPP_FLAGS_SECURE_MODE		(0x00010000)
++
++/* grf mask for get value */
++#define MPP_GRF_VAL_MASK		(0xFFFF)
++
++/* max 4 cores supported */
++#define MPP_MAX_CORE_NUM		(4)
++
++/**
++ * Device type: classified by hardware feature
++ */
++enum MPP_DEVICE_TYPE {
++	MPP_DEVICE_VDPU1	= 0, /* 0x00000001 */
++	MPP_DEVICE_VDPU2	= 1, /* 0x00000002 */
++	MPP_DEVICE_VDPU1_PP	= 2, /* 0x00000004 */
++	MPP_DEVICE_VDPU2_PP	= 3, /* 0x00000008 */
++	MPP_DEVICE_AV1DEC	= 4, /* 0x00000010 */
++
++	MPP_DEVICE_HEVC_DEC	= 8, /* 0x00000100 */
++	MPP_DEVICE_RKVDEC	= 9, /* 0x00000200 */
++	MPP_DEVICE_AVSPLUS_DEC	= 12, /* 0x00001000 */
++	MPP_DEVICE_JPGDEC	= 13, /* 0x00002000 */
++
++	MPP_DEVICE_RKVENC	= 16, /* 0x00010000 */
++	MPP_DEVICE_VEPU1	= 17, /* 0x00020000 */
++	MPP_DEVICE_VEPU2	= 18, /* 0x00040000 */
++	MPP_DEVICE_VEPU22	= 24, /* 0x01000000 */
++
++	MPP_DEVICE_IEP2		= 28, /* 0x10000000 */
++	MPP_DEVICE_BUTT,
++};
++
++/**
++ * Driver type: classified by driver
++ */
++enum MPP_DRIVER_TYPE {
++	MPP_DRIVER_NULL = 0,
++	MPP_DRIVER_VDPU1,
++	MPP_DRIVER_VEPU1,
++	MPP_DRIVER_VDPU2,
++	MPP_DRIVER_VEPU2,
++	MPP_DRIVER_VEPU22,
++	MPP_DRIVER_RKVDEC,
++	MPP_DRIVER_RKVENC,
++	MPP_DRIVER_IEP,
++	MPP_DRIVER_IEP2,
++	MPP_DRIVER_JPGDEC,
++	MPP_DRIVER_RKVDEC2,
++	MPP_DRIVER_RKVENC2,
++	MPP_DRIVER_AV1DEC,
++	MPP_DRIVER_BUTT,
++};
++
++/**
++ * Command type: keep the same as user space
++ */
++enum MPP_DEV_COMMAND_TYPE {
++	MPP_CMD_QUERY_BASE		= 0,
++	MPP_CMD_QUERY_HW_SUPPORT	= MPP_CMD_QUERY_BASE + 0,
++	MPP_CMD_QUERY_HW_ID		= MPP_CMD_QUERY_BASE + 1,
++	MPP_CMD_QUERY_CMD_SUPPORT	= MPP_CMD_QUERY_BASE + 2,
++	MPP_CMD_QUERY_BUTT,
++
++	MPP_CMD_INIT_BASE		= 0x100,
++	MPP_CMD_INIT_CLIENT_TYPE	= MPP_CMD_INIT_BASE + 0,
++	MPP_CMD_INIT_DRIVER_DATA	= MPP_CMD_INIT_BASE + 1,
++	MPP_CMD_INIT_TRANS_TABLE	= MPP_CMD_INIT_BASE + 2,
++	MPP_CMD_INIT_BUTT,
++
++	MPP_CMD_SEND_BASE		= 0x200,
++	MPP_CMD_SET_REG_WRITE		= MPP_CMD_SEND_BASE + 0,
++	MPP_CMD_SET_REG_READ		= MPP_CMD_SEND_BASE + 1,
++	MPP_CMD_SET_REG_ADDR_OFFSET	= MPP_CMD_SEND_BASE + 2,
++	MPP_CMD_SET_RCB_INFO		= MPP_CMD_SEND_BASE + 3,
++	MPP_CMD_SET_SESSION_FD		= MPP_CMD_SEND_BASE + 4,
++	MPP_CMD_SEND_BUTT,
++
++	MPP_CMD_POLL_BASE		= 0x300,
++	MPP_CMD_POLL_HW_FINISH		= MPP_CMD_POLL_BASE + 0,
++	MPP_CMD_POLL_HW_IRQ		= MPP_CMD_POLL_BASE + 1,
++	MPP_CMD_POLL_BUTT,
++
++	MPP_CMD_CONTROL_BASE		= 0x400,
++	MPP_CMD_RESET_SESSION		= MPP_CMD_CONTROL_BASE + 0,
++	MPP_CMD_TRANS_FD_TO_IOVA	= MPP_CMD_CONTROL_BASE + 1,
++	MPP_CMD_RELEASE_FD		= MPP_CMD_CONTROL_BASE + 2,
++	MPP_CMD_SEND_CODEC_INFO		= MPP_CMD_CONTROL_BASE + 3,
++	MPP_CMD_CONTROL_BUTT,
++
++	MPP_CMD_BUTT,
++};
++
++enum MPP_CLOCK_MODE {
++	CLK_MODE_BASE		= 0,
++	CLK_MODE_DEFAULT	= CLK_MODE_BASE,
++	CLK_MODE_DEBUG,
++	CLK_MODE_REDUCE,
++	CLK_MODE_NORMAL,
++	CLK_MODE_ADVANCED,
++	CLK_MODE_BUTT,
++};
++
++enum MPP_RESET_TYPE {
++	RST_TYPE_BASE		= 0,
++	RST_TYPE_A		= RST_TYPE_BASE,
++	RST_TYPE_H,
++	RST_TYPE_NIU_A,
++	RST_TYPE_NIU_H,
++	RST_TYPE_CORE,
++	RST_TYPE_CABAC,
++	RST_TYPE_HEVC_CABAC,
++	RST_TYPE_BUTT,
++};
++
++enum ENC_INFO_TYPE {
++	ENC_INFO_BASE		= 0,
++	ENC_INFO_WIDTH,
++	ENC_INFO_HEIGHT,
++	ENC_INFO_FORMAT,
++	ENC_INFO_FPS_IN,
++	ENC_INFO_FPS_OUT,
++	ENC_INFO_RC_MODE,
++	ENC_INFO_BITRATE,
++	ENC_INFO_GOP_SIZE,
++	ENC_INFO_FPS_CALC,
++	ENC_INFO_PROFILE,
++
++	ENC_INFO_BUTT,
++};
++
++enum DEC_INFO_TYPE {
++	DEC_INFO_BASE		= 0,
++	DEC_INFO_WIDTH,
++	DEC_INFO_HEIGHT,
++	DEC_INFO_FORMAT,
++	DEC_INFO_BITDEPTH,
++	DEC_INFO_FPS,
++
++	DEC_INFO_BUTT,
++};
++
++enum CODEC_INFO_FLAGS {
++	CODEC_INFO_FLAG_NULL	= 0,
++	CODEC_INFO_FLAG_NUMBER,
++	CODEC_INFO_FLAG_STRING,
++
++	CODEC_INFO_FLAG_BUTT,
++};
++
++struct mpp_task;
++struct mpp_session;
++struct mpp_dma_session;
++struct mpp_taskqueue;
++
++/* data common struct for parse out */
++struct mpp_request {
++	__u32 cmd;
++	__u32 flags;
++	__u32 size;
++	__u32 offset;
++	void __user *data;
++};
++
++/* struct use to collect task set and poll message */
++struct mpp_task_msgs {
++	/* for ioctl msgs bat process */
++	struct list_head list;
++	struct list_head list_session;
++
++	struct mpp_session *session;
++	struct mpp_taskqueue *queue;
++	struct mpp_task *task;
++	struct mpp_dev *mpp;
++
++	/* for fd reference */
++	int ext_fd;
++	struct fd f;
++
++	u32 flags;
++	u32 req_cnt;
++	u32 set_cnt;
++	u32 poll_cnt;
++
++	struct mpp_request reqs[MPP_MAX_MSG_NUM];
++	struct mpp_request *poll_req;
++};
++
++struct mpp_grf_info {
++	u32 offset;
++	u32 val;
++	struct regmap *grf;
++};
++
++/**
++ * struct for hardware info
++ */
++struct mpp_hw_info {
++	/* register number */
++	u32 reg_num;
++	/* hardware id */
++	int reg_id;
++	u32 hw_id;
++	/* start index of register */
++	u32 reg_start;
++	/* end index of register */
++	u32 reg_end;
++	/* register of enable hardware */
++	int reg_en;
++};
++
++struct mpp_trans_info {
++	const int count;
++	const u16 * const table;
++};
++
++struct reg_offset_elem {
++	u32 index;
++	u32 offset;
++};
++
++struct reg_offset_info {
++	u32 cnt;
++	struct reg_offset_elem elem[MPP_MAX_REG_TRANS_NUM];
++};
++
++struct codec_info_elem {
++	__u32 type;
++	__u32 flag;
++	__u64 data;
++};
++
++struct mpp_clk_info {
++	struct clk *clk;
++
++	/* debug rate, from debug */
++	u32 debug_rate_hz;
++	/* normal rate, from dtsi */
++	u32 normal_rate_hz;
++	/* high performance rate, from dtsi */
++	u32 advanced_rate_hz;
++
++	u32 default_rate_hz;
++	u32 reduce_rate_hz;
++	/* record last used rate */
++	u32 used_rate_hz;
++};
++
++struct mpp_dev_var {
++	enum MPP_DEVICE_TYPE device_type;
++
++	/* info for each hardware */
++	struct mpp_hw_info *hw_info;
++	struct mpp_trans_info *trans_info;
++	struct mpp_hw_ops *hw_ops;
++	struct mpp_dev_ops *dev_ops;
++};
++
++struct mpp_mem_region {
++	struct list_head reg_link;
++	/* address for iommu */
++	dma_addr_t iova;
++	unsigned long len;
++	u32 reg_idx;
++	void *hdl;
++	int fd;
++	/* whether is dup import entity */
++	bool is_dup;
++};
++
++
++struct mpp_dev {
++	struct device *dev;
++	const struct mpp_dev_var *var;
++	struct mpp_hw_ops *hw_ops;
++	struct mpp_dev_ops *dev_ops;
++
++	/* per-device work for attached taskqueue */
++	struct kthread_work work;
++	/* the flag for get/get/reduce freq */
++	bool auto_freq_en;
++	/* the flag for pmu idle request before device reset */
++	bool skip_idle;
++
++	/*
++	 * The task capacity is the task queue length that hardware can accept.
++	 * Default 1 means normal hardware can only accept one task at once.
++	 */
++	u32 task_capacity;
++	/*
++	 * The message capacity is the max message parallel process capacity.
++	 * Default 1 means normal hardware can only accept one message at one
++	 * shot ioctl.
++	 * Multi-core hardware can accept more message at one shot ioctl.
++	 */
++	u32 msgs_cap;
++
++	int irq;
++	bool is_irq_startup;
++	u32 irq_status;
++
++	void __iomem *reg_base;
++	struct mpp_grf_info *grf_info;
++	struct mpp_iommu_info *iommu_info;
++
++	atomic_t reset_request;
++	atomic_t session_index;
++	atomic_t task_count;
++	atomic_t task_index;
++	/* current task in running */
++	struct mpp_task *cur_task;
++	/* set session max buffers */
++	u32 session_max_buffers;
++	struct mpp_taskqueue *queue;
++	struct mpp_reset_group *reset_group;
++	/* point to MPP Service */
++	struct mpp_service *srv;
++
++	/* multi-core data */
++	struct list_head queue_link;
++	s32 core_id;
++};
++
++struct mpp_session {
++	enum MPP_DEVICE_TYPE device_type;
++	u32 index;
++	/* the session related device private data */
++	struct mpp_service *srv;
++	struct mpp_dev *mpp;
++	struct mpp_dma_session *dma;
++
++	/* lock for session task pending list */
++	struct mutex pending_lock;
++	/* task pending list in session */
++	struct list_head pending_list;
++
++	pid_t pid;
++	atomic_t task_count;
++	atomic_t release_request;
++	/* trans info set by user */
++	int trans_count;
++	u16 trans_table[MPP_MAX_REG_TRANS_NUM];
++	u32 msg_flags;
++	/* link to mpp_service session_list */
++	struct list_head service_link;
++	/* link to mpp_workqueue session_attach / session_detach */
++	struct list_head session_link;
++	/* private data */
++	void *priv;
++
++	/*
++	 * session handler from mpp_dev_ops
++	 * process_task - handle messages of sending task
++	 * wait_result  - handle messages of polling task
++	 * deinit	- handle session deinit
++	 */
++	int (*process_task)(struct mpp_session *session,
++			    struct mpp_task_msgs *msgs);
++	int (*wait_result)(struct mpp_session *session,
++			   struct mpp_task_msgs *msgs);
++	void (*deinit)(struct mpp_session *session);
++
++	/* max message count */
++	int msgs_cnt;
++	struct list_head list_msgs;
++	struct list_head list_msgs_idle;
++	spinlock_t lock_msgs;
++};
++
++/* task state in work thread */
++enum mpp_task_state {
++	TASK_STATE_PENDING	= 0,
++	TASK_STATE_RUNNING	= 1,
++	TASK_STATE_START	= 2,
++	TASK_STATE_HANDLE	= 3,
++	TASK_STATE_IRQ		= 4,
++	TASK_STATE_FINISH	= 5,
++	TASK_STATE_TIMEOUT	= 6,
++	TASK_STATE_DONE		= 7,
++
++	TASK_STATE_PREPARE	= 8,
++	TASK_STATE_ABORT	= 9,
++	TASK_STATE_ABORT_READY	= 10,
++	TASK_STATE_PROC_DONE	= 11,
++};
++
++/* The context for the a task */
++struct mpp_task {
++	/* context belong to */
++	struct mpp_session *session;
++
++	/* link to pending list in session */
++	struct list_head pending_link;
++	/* link to done list in session */
++	struct list_head done_link;
++	/* link to list in taskqueue */
++	struct list_head queue_link;
++	/* The DMA buffer used in this task */
++	struct list_head mem_region_list;
++	u32 mem_count;
++	struct mpp_mem_region mem_regions[MPP_MAX_REG_TRANS_NUM];
++
++	/* state in the taskqueue */
++	unsigned long state;
++	atomic_t abort_request;
++	/* delayed work for hardware timeout */
++	struct delayed_work timeout_work;
++	struct kref ref;
++
++	/* record context running start time */
++	ktime_t start;
++	ktime_t part;
++	/* hardware info for current task */
++	struct mpp_hw_info *hw_info;
++	u32 task_index;
++	u32 task_id;
++	u32 *reg;
++	/* event for session wait thread */
++	wait_queue_head_t wait;
++
++	/* for multi-core */
++	struct mpp_dev *mpp;
++	s32 core_id;
++};
++
++struct mpp_taskqueue {
++	/* kworker for attached taskqueue */
++	struct kthread_worker worker;
++	/* task for work queue */
++	struct task_struct *kworker_task;
++
++	/* lock for session attach and session_detach */
++	struct mutex session_lock;
++	/* link to session session_link for attached sessions */
++	struct list_head session_attach;
++	/* link to session session_link for detached sessions */
++	struct list_head session_detach;
++	atomic_t detach_count;
++
++	atomic_t task_id;
++	/* lock for pending list */
++	struct mutex pending_lock;
++	struct list_head pending_list;
++	/* lock for running list */
++	spinlock_t running_lock;
++	struct list_head running_list;
++
++	/* point to MPP Service */
++	struct mpp_service *srv;
++	/* lock for mmu list */
++	struct mutex mmu_lock;
++	struct list_head mmu_list;
++	/* lock for dev list */
++	struct mutex dev_lock;
++	struct list_head dev_list;
++	/*
++	 * task_capacity in taskqueue is the minimum task capacity of the
++	 * device task capacity which is attached to the taskqueue
++	 */
++	u32 task_capacity;
++
++	/* multi-core task distribution */
++	atomic_t reset_request;
++	struct mpp_dev *cores[MPP_MAX_CORE_NUM];
++	unsigned long core_idle;
++	u32 core_count;
++};
++
++struct mpp_reset_group {
++	/* the flag for whether use rw_sem */
++	u32 rw_sem_on;
++	struct rw_semaphore rw_sem;
++	struct reset_control *resets[RST_TYPE_BUTT];
++	/* for set rw_sem */
++	struct mpp_taskqueue *queue;
++};
++
++struct mpp_service {
++	struct class *cls;
++	struct device *dev;
++	dev_t dev_id;
++	struct cdev mpp_cdev;
++	struct device *child_dev;
++#ifdef CONFIG_ROCKCHIP_MPP_PROC_FS
++	struct proc_dir_entry *procfs;
++#endif
++	unsigned long hw_support;
++	atomic_t shutdown_request;
++	/* follows for device probe */
++	struct mpp_grf_info grf_infos[MPP_DRIVER_BUTT];
++	struct platform_driver *sub_drivers[MPP_DRIVER_BUTT];
++	/* follows for attach service */
++	struct mpp_dev *sub_devices[MPP_DEVICE_BUTT];
++	u32 taskqueue_cnt;
++	struct mpp_taskqueue *task_queues[MPP_DEVICE_BUTT];
++	u32 reset_group_cnt;
++	struct mpp_reset_group *reset_groups[MPP_DEVICE_BUTT];
++
++	/* lock for session list */
++	struct mutex session_lock;
++	struct list_head session_list;
++	u32 session_count;
++};
++
++/*
++ * struct mpp_hw_ops - context specific operations for device
++ * @init	Do something when hardware probe.
++ * @exit	Do something when hardware remove.
++ * @clk_on	Enable clocks.
++ * @clk_off	Disable clocks.
++ * @get_freq	Get special freq for setting.
++ * @set_freq	Set freq to hardware.
++ * @reduce_freq	Reduce freq when hardware is not running.
++ * @reset	When error, reset hardware.
++ */
++struct mpp_hw_ops {
++	int (*init)(struct mpp_dev *mpp);
++	int (*exit)(struct mpp_dev *mpp);
++	int (*clk_on)(struct mpp_dev *mpp);
++	int (*clk_off)(struct mpp_dev *mpp);
++	int (*get_freq)(struct mpp_dev *mpp,
++			struct mpp_task *mpp_task);
++	int (*set_freq)(struct mpp_dev *mpp,
++			struct mpp_task *mpp_task);
++	int (*reduce_freq)(struct mpp_dev *mpp);
++	int (*reset)(struct mpp_dev *mpp);
++	int (*set_grf)(struct mpp_dev *mpp);
++};
++
++/*
++ * struct mpp_dev_ops - context specific operations for task
++ * @alloc_task	Alloc and set task.
++ * @prepare	Check HW status for determining run next task or not.
++ * @run		Start a single {en,de}coding run. Set registers to hardware.
++ * @irq		Deal with hardware interrupt top-half.
++ * @isr		Deal with hardware interrupt bottom-half.
++ * @finish	Read back processing results and additional data from hardware.
++ * @result	Read status to userspace.
++ * @free_task	Release the resource allocate which alloc.
++ * @ioctl	Special cammand from userspace.
++ * @init_session extra initialization on session init.
++ * @free_session extra cleanup on session deinit.
++ * @dump_session information dump for session.
++ * @dump_dev    information dump for hardware device.
++ */
++struct mpp_dev_ops {
++	int (*process_task)(struct mpp_session *session,
++			    struct mpp_task_msgs *msgs);
++	int (*wait_result)(struct mpp_session *session,
++			   struct mpp_task_msgs *msgs);
++	void (*deinit)(struct mpp_session *session);
++	void (*task_worker)(struct kthread_work *work_s);
++
++	void *(*alloc_task)(struct mpp_session *session,
++			    struct mpp_task_msgs *msgs);
++	void *(*prepare)(struct mpp_dev *mpp, struct mpp_task *task);
++	int (*run)(struct mpp_dev *mpp, struct mpp_task *task);
++	int (*irq)(struct mpp_dev *mpp);
++	int (*isr)(struct mpp_dev *mpp);
++	int (*finish)(struct mpp_dev *mpp, struct mpp_task *task);
++	int (*result)(struct mpp_dev *mpp, struct mpp_task *task,
++		      struct mpp_task_msgs *msgs);
++	int (*free_task)(struct mpp_session *session,
++			 struct mpp_task *task);
++	int (*ioctl)(struct mpp_session *session, struct mpp_request *req);
++	int (*init_session)(struct mpp_session *session);
++	int (*free_session)(struct mpp_session *session);
++	int (*dump_session)(struct mpp_session *session, struct seq_file *seq);
++	int (*dump_dev)(struct mpp_dev *mpp);
++};
++
++struct mpp_taskqueue *mpp_taskqueue_init(struct device *dev);
++
++struct mpp_mem_region *
++mpp_task_attach_fd(struct mpp_task *task, int fd);
++int mpp_translate_reg_address(struct mpp_session *session,
++			      struct mpp_task *task, int fmt,
++			      u32 *reg, struct reg_offset_info *off_inf);
++
++int mpp_check_req(struct mpp_request *req, int base,
++		  int max_size, u32 off_s, u32 off_e);
++int mpp_extract_reg_offset_info(struct reg_offset_info *off_inf,
++				struct mpp_request *req);
++int mpp_query_reg_offset_info(struct reg_offset_info *off_inf,
++			      u32 index);
++int mpp_translate_reg_offset_info(struct mpp_task *task,
++				  struct reg_offset_info *off_inf,
++				  u32 *reg);
++int mpp_task_init(struct mpp_session *session,
++		  struct mpp_task *task);
++int mpp_task_finish(struct mpp_session *session,
++		    struct mpp_task *task);
++int mpp_task_finalize(struct mpp_session *session,
++		      struct mpp_task *task);
++int mpp_task_dump_mem_region(struct mpp_dev *mpp,
++			     struct mpp_task *task);
++int mpp_task_dump_reg(struct mpp_dev *mpp,
++		      struct mpp_task *task);
++int mpp_task_dump_hw_reg(struct mpp_dev *mpp);
++void mpp_reg_show(struct mpp_dev *mpp, u32 offset);
++void mpp_free_task(struct kref *ref);
++
++void mpp_session_deinit(struct mpp_session *session);
++void mpp_session_cleanup_detach(struct mpp_taskqueue *queue,
++				struct kthread_work *work);
++
++int mpp_dev_probe(struct mpp_dev *mpp,
++		  struct platform_device *pdev);
++int mpp_dev_remove(struct mpp_dev *mpp);
++void mpp_dev_shutdown(struct platform_device *pdev);
++int mpp_dev_register_srv(struct mpp_dev *mpp, struct mpp_service *srv);
++
++int mpp_power_on(struct mpp_dev *mpp);
++int mpp_power_off(struct mpp_dev *mpp);
++int mpp_dev_reset(struct mpp_dev *mpp);
++
++irqreturn_t mpp_dev_irq(int irq, void *param);
++irqreturn_t mpp_dev_isr_sched(int irq, void *param);
++
++struct reset_control *mpp_reset_control_get(struct mpp_dev *mpp,
++					    enum MPP_RESET_TYPE type,
++					    const char *name);
++
++u32 mpp_get_grf(struct mpp_grf_info *grf_info);
++bool mpp_grf_is_changed(struct mpp_grf_info *grf_info);
++int mpp_set_grf(struct mpp_grf_info *grf_info);
++
++int mpp_time_record(struct mpp_task *task);
++int mpp_time_diff(struct mpp_task *task);
++int mpp_time_part_diff(struct mpp_task *task);
++
++int mpp_write_req(struct mpp_dev *mpp, u32 *regs,
++		  u32 start_idx, u32 end_idx, u32 en_idx);
++int mpp_read_req(struct mpp_dev *mpp, u32 *regs,
++		 u32 start_idx, u32 end_idx);
++
++int mpp_get_clk_info(struct mpp_dev *mpp,
++		     struct mpp_clk_info *clk_info,
++		     const char *name);
++int mpp_set_clk_info_rate_hz(struct mpp_clk_info *clk_info,
++			     enum MPP_CLOCK_MODE mode,
++			     unsigned long val);
++unsigned long mpp_get_clk_info_rate_hz(struct mpp_clk_info *clk_info,
++				       enum MPP_CLOCK_MODE mode);
++int mpp_clk_set_rate(struct mpp_clk_info *clk_info,
++		     enum MPP_CLOCK_MODE mode);
++
++static inline int mpp_write(struct mpp_dev *mpp, u32 reg, u32 val)
++{
++	int idx = reg / sizeof(u32);
++
++	mpp_debug(DEBUG_SET_REG,
++		  "write reg[%03d]: %04x: 0x%08x\n", idx, reg, val);
++	writel(val, mpp->reg_base + reg);
++
++	return 0;
++}
++
++static inline int mpp_write_relaxed(struct mpp_dev *mpp, u32 reg, u32 val)
++{
++	int idx = reg / sizeof(u32);
++
++	mpp_debug(DEBUG_SET_REG,
++		  "write reg[%03d]: %04x: 0x%08x\n", idx, reg, val);
++	writel_relaxed(val, mpp->reg_base + reg);
++
++	return 0;
++}
++
++static inline u32 mpp_read(struct mpp_dev *mpp, u32 reg)
++{
++	u32 val = 0;
++	int idx = reg / sizeof(u32);
++
++	val = readl(mpp->reg_base + reg);
++	mpp_debug(DEBUG_GET_REG,
++		  "read reg[%03d]: %04x: 0x%08x\n", idx, reg, val);
++
++	return val;
++}
++
++static inline u32 mpp_read_relaxed(struct mpp_dev *mpp, u32 reg)
++{
++	u32 val = 0;
++	int idx = reg / sizeof(u32);
++
++	val = readl_relaxed(mpp->reg_base + reg);
++	mpp_debug(DEBUG_GET_REG,
++		  "read reg[%03d] %04x: 0x%08x\n", idx, reg, val);
++
++	return val;
++}
++
++static inline int mpp_safe_reset(struct reset_control *rst)
++{
++	if (rst)
++		reset_control_assert(rst);
++
++	return 0;
++}
++
++static inline int mpp_safe_unreset(struct reset_control *rst)
++{
++	if (rst)
++		reset_control_deassert(rst);
++
++	return 0;
++}
++
++static inline int mpp_clk_safe_enable(struct clk *clk)
++{
++	if (clk)
++		clk_prepare_enable(clk);
++
++	return 0;
++}
++
++static inline int mpp_clk_safe_disable(struct clk *clk)
++{
++	if (clk)
++		clk_disable_unprepare(clk);
++
++	return 0;
++}
++
++static inline int mpp_reset_down_read(struct mpp_reset_group *group)
++{
++	if (group && group->rw_sem_on)
++		down_read(&group->rw_sem);
++
++	return 0;
++}
++
++static inline int mpp_reset_up_read(struct mpp_reset_group *group)
++{
++	if (group && group->rw_sem_on)
++		up_read(&group->rw_sem);
++
++	return 0;
++}
++
++static inline int mpp_reset_down_write(struct mpp_reset_group *group)
++{
++	if (group && group->rw_sem_on)
++		down_write(&group->rw_sem);
++
++	return 0;
++}
++
++static inline int mpp_reset_up_write(struct mpp_reset_group *group)
++{
++	if (group && group->rw_sem_on)
++		up_write(&group->rw_sem);
++
++	return 0;
++}
++
++static inline int mpp_pmu_idle_request(struct mpp_dev *mpp, bool idle)
++{
++	if (mpp->skip_idle)
++		return 0;
++
++#if 0
++	// Upstream Rockchip platform code does not support sending idle
++	// requests to the PMU. Let's just ignore this.
++	return rockchip_pmu_idle_request(mpp->dev, idle);
++#else
++	return 0;
++#endif
++}
++
++static inline struct mpp_dev *
++mpp_get_task_used_device(const struct mpp_task *task,
++			 const struct mpp_session *session)
++{
++	return task->mpp ? task->mpp : session->mpp;
++}
++
++#ifdef CONFIG_ROCKCHIP_MPP_PROC_FS
++struct proc_dir_entry *
++mpp_procfs_create_u32(const char *name, umode_t mode,
++		      struct proc_dir_entry *parent, void *data);
++#else
++static inline struct proc_dir_entry *
++mpp_procfs_create_u32(const char *name, umode_t mode,
++		      struct proc_dir_entry *parent, void *data)
++{
++	return 0;
++}
++#endif
++
++#ifdef CONFIG_ROCKCHIP_MPP_PROC_FS
++extern const char *mpp_device_name[MPP_DEVICE_BUTT];
++extern const char *enc_info_item_name[ENC_INFO_BUTT];
++#endif
++
++extern const struct file_operations rockchip_mpp_fops;
++
++extern struct platform_driver rockchip_rkvdec_driver;
++extern struct platform_driver rockchip_rkvenc_driver;
++extern struct platform_driver rockchip_vdpu1_driver;
++extern struct platform_driver rockchip_vepu1_driver;
++extern struct platform_driver rockchip_vdpu2_driver;
++extern struct platform_driver rockchip_vepu2_driver;
++extern struct platform_driver rockchip_vepu22_driver;
++extern struct platform_driver rockchip_iep2_driver;
++extern struct platform_driver rockchip_jpgdec_driver;
++extern struct platform_driver rockchip_rkvdec2_driver;
++extern struct platform_driver rockchip_rkvenc2_driver;
++extern struct platform_driver rockchip_av1dec_driver;
++extern struct platform_driver rockchip_av1_iommu_driver;
++
++extern int av1dec_driver_register(struct platform_driver *drv);
++extern void av1dec_driver_unregister(struct platform_driver *drv);
++extern struct bus_type av1dec_bus;
++
++#endif
+diff --git a/drivers/video/rockchip/mpp/mpp_debug.h b/drivers/video/rockchip/mpp/mpp_debug.h
+new file mode 100644
+index 000000000000..411c8a7b2074
+--- /dev/null
++++ b/drivers/video/rockchip/mpp/mpp_debug.h
+@@ -0,0 +1,138 @@
++/* SPDX-License-Identifier: (GPL-2.0+ OR MIT) */
++/*
++ * Copyright (c) 2019 Fuzhou Rockchip Electronics Co., Ltd
++ *
++ * author:
++ *	Alpha Lin, alpha.lin@rock-chips.com
++ *	Randy Li, randy.li@rock-chips.com
++ *	Ding Wei, leo.ding@rock-chips.com
++ *
++ */
++#ifndef __ROCKCHIP_MPP_DEBUG_H__
++#define __ROCKCHIP_MPP_DEBUG_H__
++
++#include <linux/types.h>
++
++/*
++ * debug flag usage:
++ * +------+-------------------+
++ * | 8bit |      24bit        |
++ * +------+-------------------+
++ *  0~23 bit is for different information type
++ * 24~31 bit is for information print format
++ */
++
++#define DEBUG_POWER				0x00000001
++#define DEBUG_CLOCK				0x00000002
++#define DEBUG_IRQ_STATUS			0x00000004
++#define DEBUG_IOMMU				0x00000008
++#define DEBUG_IOCTL				0x00000010
++#define DEBUG_FUNCTION				0x00000020
++#define DEBUG_REGISTER				0x00000040
++#define DEBUG_EXTRA_INFO			0x00000080
++#define DEBUG_TIMING				0x00000100
++#define DEBUG_TASK_INFO				0x00000200
++#define DEBUG_DUMP_ERR_REG			0x00000400
++#define DEBUG_LINK_TABLE			0x00000800
++
++#define DEBUG_SET_REG				0x00001000
++#define DEBUG_GET_REG				0x00002000
++#define DEBUG_PPS_FILL				0x00004000
++#define DEBUG_IRQ_CHECK				0x00008000
++#define DEBUG_CACHE_32B				0x00010000
++
++#define DEBUG_RESET				0x00020000
++#define DEBUG_SET_REG_L2			0x00040000
++#define DEBUG_GET_REG_L2			0x00080000
++#define DEBUG_GET_PERF_VAL			0x00100000
++#define DEBUG_SRAM_INFO				0x00200000
++
++#define DEBUG_SESSION				0x00400000
++#define DEBUG_DEVICE				0x00800000
++
++#define DEBUG_CCU				0x01000000
++#define DEBUG_CORE				0x02000000
++
++#define PRINT_FUNCTION				0x80000000
++#define PRINT_LINE				0x40000000
++
++/* reuse old debug bit flag */
++#define DEBUG_PART_TIMING			0x00000080
++#define DEBUG_SLICE				0x00000002
++
++extern unsigned int mpp_dev_debug;
++
++#define mpp_debug_unlikely(type)				\
++		(unlikely(mpp_dev_debug & (type)))
++
++#define mpp_debug_func(type, fmt, args...)			\
++	do {							\
++		if (unlikely(mpp_dev_debug & (type))) {		\
++			pr_info("%s:%d: " fmt,			\
++				 __func__, __LINE__, ##args);	\
++		}						\
++	} while (0)
++#define mpp_debug(type, fmt, args...)				\
++	do {							\
++		if (unlikely(mpp_dev_debug & (type))) {		\
++			pr_info(fmt, ##args);			\
++		}						\
++	} while (0)
++
++#define mpp_debug_enter()					\
++	do {							\
++		if (unlikely(mpp_dev_debug & DEBUG_FUNCTION)) {	\
++			pr_info("%s:%d: enter\n",		\
++				 __func__, __LINE__);		\
++		}						\
++	} while (0)
++
++#define mpp_debug_leave()					\
++	do {							\
++		if (unlikely(mpp_dev_debug & DEBUG_FUNCTION)) {	\
++			pr_info("%s:%d: leave\n",		\
++				 __func__, __LINE__);		\
++		}						\
++	} while (0)
++
++#define mpp_err(fmt, args...)					\
++		pr_err("%s:%d: " fmt, __func__, __LINE__, ##args)
++
++#define mpp_dbg_link_flow(fmt, args...)				\
++	do {							\
++		if (unlikely(mpp_dev_debug & DEBUG_LINK_TABLE)) {		\
++			pr_info("%s:%d: " fmt,			\
++				 __func__, __LINE__, ##args);	\
++		}						\
++	} while (0)
++
++#define mpp_dbg_session(fmt, args...)				\
++	do {							\
++		if (unlikely(mpp_dev_debug & DEBUG_SESSION)) {	\
++			pr_info(fmt, ##args);			\
++		}						\
++	} while (0)
++
++#define mpp_dbg_ccu(fmt, args...)				\
++	do {							\
++		if (unlikely(mpp_dev_debug & DEBUG_CCU)) {	\
++			pr_info("%s:%d: " fmt,			\
++				 __func__, __LINE__, ##args);	\
++		}						\
++	} while (0)
++
++#define mpp_dbg_core(fmt, args...)				\
++	do {							\
++		if (unlikely(mpp_dev_debug & DEBUG_CORE)) {	\
++			pr_info(fmt, ##args);			\
++		}						\
++	} while (0)
++
++#define mpp_dbg_slice(fmt, args...)				\
++	do {							\
++		if (unlikely(mpp_dev_debug & DEBUG_SLICE)) {	\
++			pr_info(fmt, ##args);			\
++		}						\
++	} while (0)
++
++#endif
+diff --git a/drivers/video/rockchip/mpp/mpp_iommu.c b/drivers/video/rockchip/mpp/mpp_iommu.c
+new file mode 100644
+index 000000000000..1713ca5012c2
+--- /dev/null
++++ b/drivers/video/rockchip/mpp/mpp_iommu.c
+@@ -0,0 +1,509 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2019 Fuzhou Rockchip Electronics Co., Ltd
++ *
++ * author:
++ *	Alpha Lin, alpha.lin@rock-chips.com
++ *	Randy Li, randy.li@rock-chips.com
++ *	Ding Wei, leo.ding@rock-chips.com
++ *
++ */
++#include <linux/delay.h>
++#include <linux/dma-buf.h>
++#include <linux/iommu.h>
++#include <linux/of.h>
++#include <linux/of_platform.h>
++#include <linux/platform_device.h>
++#include <linux/kref.h>
++#include <linux/slab.h>
++#include <linux/pm_runtime.h>
++
++#ifdef CONFIG_ARM_DMA_USE_IOMMU
++#include <asm/dma-iommu.h>
++#endif
++
++#include "mpp_debug.h"
++#include "mpp_iommu.h"
++
++MODULE_IMPORT_NS(DMA_BUF);
++
++static struct mpp_dma_buffer *
++mpp_dma_find_buffer_fd(struct mpp_dma_session *dma, int fd)
++{
++	struct dma_buf *dmabuf;
++	struct mpp_dma_buffer *out = NULL;
++	struct mpp_dma_buffer *buffer = NULL, *n;
++
++	dmabuf = dma_buf_get(fd);
++	if (IS_ERR(dmabuf))
++		return NULL;
++
++	mutex_lock(&dma->list_mutex);
++	list_for_each_entry_safe(buffer, n,
++				 &dma->used_list, link) {
++		/*
++		 * fd may dup several and point the same dambuf.
++		 * thus, here should be distinguish with the dmabuf.
++		 */
++		if (buffer->dmabuf == dmabuf) {
++			out = buffer;
++			break;
++		}
++	}
++	mutex_unlock(&dma->list_mutex);
++	dma_buf_put(dmabuf);
++
++	return out;
++}
++
++/* Release the buffer from the current list */
++static void mpp_dma_release_buffer(struct kref *ref)
++{
++	struct mpp_dma_buffer *buffer =
++		container_of(ref, struct mpp_dma_buffer, ref);
++
++	buffer->dma->buffer_count--;
++	list_move_tail(&buffer->link, &buffer->dma->unused_list);
++
++	dma_buf_unmap_attachment(buffer->attach, buffer->sgt, buffer->dir);
++	dma_buf_detach(buffer->dmabuf, buffer->attach);
++	dma_buf_put(buffer->dmabuf);
++	buffer->dma = NULL;
++	buffer->dmabuf = NULL;
++	buffer->attach = NULL;
++	buffer->sgt = NULL;
++	buffer->copy_sgt = NULL;
++	buffer->iova = 0;
++	buffer->size = 0;
++	buffer->vaddr = NULL;
++	buffer->last_used = 0;
++}
++
++/* Remove the oldest buffer when count more than the setting */
++static int
++mpp_dma_remove_extra_buffer(struct mpp_dma_session *dma)
++{
++	struct mpp_dma_buffer *n;
++	struct mpp_dma_buffer *oldest = NULL, *buffer = NULL;
++	ktime_t oldest_time = ktime_set(0, 0);
++
++	if (dma->buffer_count > dma->max_buffers) {
++		mutex_lock(&dma->list_mutex);
++		list_for_each_entry_safe(buffer, n,
++					 &dma->used_list,
++					 link) {
++			if (ktime_to_ns(oldest_time) == 0 ||
++			    ktime_after(oldest_time, buffer->last_used)) {
++				oldest_time = buffer->last_used;
++				oldest = buffer;
++			}
++		}
++		if (oldest)
++			kref_put(&oldest->ref, mpp_dma_release_buffer);
++		mutex_unlock(&dma->list_mutex);
++	}
++
++	return 0;
++}
++
++int mpp_dma_release(struct mpp_dma_session *dma,
++		    struct mpp_dma_buffer *buffer)
++{
++	mutex_lock(&dma->list_mutex);
++	kref_put(&buffer->ref, mpp_dma_release_buffer);
++	mutex_unlock(&dma->list_mutex);
++
++	return 0;
++}
++
++int mpp_dma_release_fd(struct mpp_dma_session *dma, int fd)
++{
++	struct device *dev = dma->dev;
++	struct mpp_dma_buffer *buffer = NULL;
++
++	buffer = mpp_dma_find_buffer_fd(dma, fd);
++	if (IS_ERR_OR_NULL(buffer)) {
++		dev_err(dev, "can not find %d buffer in list\n", fd);
++
++		return -EINVAL;
++	}
++
++	mutex_lock(&dma->list_mutex);
++	kref_put(&buffer->ref, mpp_dma_release_buffer);
++	mutex_unlock(&dma->list_mutex);
++
++	return 0;
++}
++
++struct mpp_dma_buffer *
++mpp_dma_alloc(struct device *dev, size_t size)
++{
++	size_t align_size;
++	dma_addr_t iova;
++	struct  mpp_dma_buffer *buffer;
++
++	buffer = kzalloc(sizeof(*buffer), GFP_KERNEL);
++	if (!buffer)
++		return NULL;
++
++	align_size = PAGE_ALIGN(size);
++	buffer->vaddr = dma_alloc_coherent(dev, align_size, &iova, GFP_KERNEL);
++	if (!buffer->vaddr)
++		goto fail_dma_alloc;
++
++	buffer->size = align_size;
++	buffer->iova = iova;
++	buffer->dev = dev;
++
++	return buffer;
++fail_dma_alloc:
++	kfree(buffer);
++	return NULL;
++}
++
++int mpp_dma_free(struct mpp_dma_buffer *buffer)
++{
++	dma_free_coherent(buffer->dev, buffer->size,
++			buffer->vaddr, buffer->iova);
++	buffer->vaddr = NULL;
++	buffer->iova = 0;
++	buffer->size = 0;
++	buffer->dev = NULL;
++	kfree(buffer);
++
++	return 0;
++}
++
++struct mpp_dma_buffer *mpp_dma_import_fd(struct mpp_iommu_info *iommu_info,
++					 struct mpp_dma_session *dma,
++					 int fd)
++{
++	int ret = 0;
++	struct sg_table *sgt;
++	struct dma_buf *dmabuf;
++	struct mpp_dma_buffer *buffer;
++	struct dma_buf_attachment *attach;
++
++	if (!dma) {
++		mpp_err("dma session is null\n");
++		return ERR_PTR(-EINVAL);
++	}
++
++	/* remove the oldest before add buffer */
++	mpp_dma_remove_extra_buffer(dma);
++
++	/* Check whether in dma session */
++	buffer = mpp_dma_find_buffer_fd(dma, fd);
++	if (!IS_ERR_OR_NULL(buffer)) {
++		if (kref_get_unless_zero(&buffer->ref)) {
++			buffer->last_used = ktime_get();
++			return buffer;
++		}
++		dev_dbg(dma->dev, "missing the fd %d\n", fd);
++	}
++
++	dmabuf = dma_buf_get(fd);
++	if (IS_ERR(dmabuf)) {
++		ret = PTR_ERR(dmabuf);
++		mpp_err("dma_buf_get fd %d failed(%d)\n", fd, ret);
++		return ERR_PTR(ret);
++	}
++	/* A new DMA buffer */
++	mutex_lock(&dma->list_mutex);
++	buffer = list_first_entry_or_null(&dma->unused_list,
++					   struct mpp_dma_buffer,
++					   link);
++	if (!buffer) {
++		ret = -ENOMEM;
++		mutex_unlock(&dma->list_mutex);
++		goto fail;
++	}
++	list_del_init(&buffer->link);
++	mutex_unlock(&dma->list_mutex);
++
++	buffer->dmabuf = dmabuf;
++	buffer->dir = DMA_BIDIRECTIONAL;
++	buffer->last_used = ktime_get();
++
++	attach = dma_buf_attach(buffer->dmabuf, dma->dev);
++	if (IS_ERR(attach)) {
++		ret = PTR_ERR(attach);
++		mpp_err("dma_buf_attach fd %d failed(%d)\n", fd, ret);
++		goto fail_attach;
++	}
++
++	sgt = dma_buf_map_attachment(attach, buffer->dir);
++	if (IS_ERR(sgt)) {
++		ret = PTR_ERR(sgt);
++		mpp_err("dma_buf_map_attachment fd %d failed(%d)\n", fd, ret);
++		goto fail_map;
++	}
++	buffer->iova = sg_dma_address(sgt->sgl);
++	buffer->size = sg_dma_len(sgt->sgl);
++	buffer->attach = attach;
++	buffer->sgt = sgt;
++	buffer->dma = dma;
++
++	kref_init(&buffer->ref);
++	/* Increase the reference for used outside the buffer pool */
++	kref_get(&buffer->ref);
++
++	mutex_lock(&dma->list_mutex);
++	dma->buffer_count++;
++	list_add_tail(&buffer->link, &dma->used_list);
++	mutex_unlock(&dma->list_mutex);
++
++	return buffer;
++
++fail_map:
++	dma_buf_detach(buffer->dmabuf, attach);
++fail_attach:
++	mutex_lock(&dma->list_mutex);
++	list_add_tail(&buffer->link, &dma->unused_list);
++	mutex_unlock(&dma->list_mutex);
++fail:
++	dma_buf_put(dmabuf);
++	return ERR_PTR(ret);
++}
++
++int mpp_dma_unmap_kernel(struct mpp_dma_session *dma,
++			 struct mpp_dma_buffer *buffer)
++{
++	void *vaddr = buffer->vaddr;
++	struct dma_buf *dmabuf = buffer->dmabuf;
++
++	if (IS_ERR_OR_NULL(vaddr) ||
++	    IS_ERR_OR_NULL(dmabuf))
++		return -EINVAL;
++
++	dma_buf_vunmap(dmabuf, vaddr);
++	buffer->vaddr = NULL;
++
++	dma_buf_end_cpu_access(dmabuf, DMA_FROM_DEVICE);
++
++	return 0;
++}
++
++int mpp_dma_map_kernel(struct mpp_dma_session *dma,
++		       struct mpp_dma_buffer *buffer)
++{
++	int ret;
++	struct iosys_map map;
++	struct dma_buf *dmabuf = buffer->dmabuf;
++
++	if (IS_ERR_OR_NULL(dmabuf))
++		return -EINVAL;
++
++	ret = dma_buf_begin_cpu_access(dmabuf, DMA_FROM_DEVICE);
++	if (ret) {
++		dev_dbg(dma->dev, "can't access the dma buffer\n");
++		goto failed_access;
++	}
++
++	ret = dma_buf_vmap(dmabuf, &map);
++	if (ret) {
++		dev_dbg(dma->dev, "can't vmap the dma buffer\n");
++		goto failed_vmap;
++	}
++
++	buffer->vaddr = map.vaddr;
++
++	return 0;
++
++failed_vmap:
++	dma_buf_end_cpu_access(dmabuf, DMA_FROM_DEVICE);
++failed_access:
++
++	return ret;
++}
++
++int mpp_dma_session_destroy(struct mpp_dma_session *dma)
++{
++	struct mpp_dma_buffer *n, *buffer = NULL;
++
++	if (!dma)
++		return -EINVAL;
++
++	mutex_lock(&dma->list_mutex);
++	list_for_each_entry_safe(buffer, n,
++				 &dma->used_list,
++				 link) {
++		kref_put(&buffer->ref, mpp_dma_release_buffer);
++	}
++	mutex_unlock(&dma->list_mutex);
++
++	kfree(dma);
++
++	return 0;
++}
++
++struct mpp_dma_session *
++mpp_dma_session_create(struct device *dev, u32 max_buffers)
++{
++	int i;
++	struct mpp_dma_session *dma = NULL;
++	struct mpp_dma_buffer *buffer = NULL;
++
++	dma = kzalloc(sizeof(*dma), GFP_KERNEL);
++	if (!dma)
++		return NULL;
++
++	mutex_init(&dma->list_mutex);
++	INIT_LIST_HEAD(&dma->unused_list);
++	INIT_LIST_HEAD(&dma->used_list);
++
++	if (max_buffers > MPP_SESSION_MAX_BUFFERS) {
++		mpp_debug(DEBUG_IOCTL, "session_max_buffer %d must less than %d\n",
++			  max_buffers, MPP_SESSION_MAX_BUFFERS);
++		dma->max_buffers = MPP_SESSION_MAX_BUFFERS;
++	} else {
++		dma->max_buffers = max_buffers;
++	}
++
++	for (i = 0; i < ARRAY_SIZE(dma->dma_bufs); i++) {
++		buffer = &dma->dma_bufs[i];
++		buffer->dma = dma;
++		INIT_LIST_HEAD(&buffer->link);
++		list_add_tail(&buffer->link, &dma->unused_list);
++	}
++	dma->dev = dev;
++
++	return dma;
++}
++
++int mpp_iommu_detach(struct mpp_iommu_info *info)
++{
++	if (!info)
++		return 0;
++
++	iommu_detach_group(info->domain, info->group);
++	return 0;
++}
++
++int mpp_iommu_attach(struct mpp_iommu_info *info)
++{
++	if (!info)
++		return 0;
++
++	return iommu_attach_group(info->domain, info->group);
++}
++
++struct mpp_iommu_info *
++mpp_iommu_probe(struct device *dev)
++{
++	int ret = 0;
++	struct device_node *np = NULL;
++	struct platform_device *pdev = NULL;
++	struct mpp_iommu_info *info = NULL;
++	struct iommu_domain *domain = NULL;
++	struct iommu_group *group = NULL;
++#ifdef CONFIG_ARM_DMA_USE_IOMMU
++	struct dma_iommu_mapping *mapping;
++#endif
++	np = of_parse_phandle(dev->of_node, "iommus", 0);
++	if (!np || !of_device_is_available(np)) {
++		mpp_err("failed to get device node\n");
++		return ERR_PTR(-ENODEV);
++	}
++
++	pdev = of_find_device_by_node(np);
++	of_node_put(np);
++	if (!pdev) {
++		mpp_err("failed to get platform device\n");
++		return ERR_PTR(-ENODEV);
++	}
++
++	group = iommu_group_get(dev);
++	if (!group) {
++		ret = -EINVAL;
++		goto err_put_pdev;
++	}
++
++	/*
++	 * On arm32-arch, group->default_domain should be NULL,
++	 * domain store in mapping created by arm32-arch.
++	 * we re-attach domain here
++	 */
++#ifdef CONFIG_ARM_DMA_USE_IOMMU
++	if (!iommu_group_default_domain(group)) {
++		mapping = to_dma_iommu_mapping(dev);
++		WARN_ON(!mapping);
++		domain = mapping->domain;
++	}
++#endif
++	if (!domain) {
++		domain = iommu_get_domain_for_dev(dev);
++		if (!domain) {
++			ret = -EINVAL;
++			goto err_put_group;
++		}
++	}
++
++	info = devm_kzalloc(dev, sizeof(*info), GFP_KERNEL);
++	if (!info) {
++		ret = -ENOMEM;
++		goto err_put_group;
++	}
++
++	init_rwsem(&info->rw_sem);
++	info->dev = dev;
++	info->pdev = pdev;
++	info->group = group;
++	info->domain = domain;
++	info->irq = platform_get_irq(pdev, 0);
++	info->got_irq = (info->irq < 0) ? false : true;
++
++	return info;
++
++err_put_group:
++	if (group)
++		iommu_group_put(group);
++err_put_pdev:
++	if (pdev)
++		platform_device_put(pdev);
++
++	return ERR_PTR(ret);
++}
++
++int mpp_iommu_remove(struct mpp_iommu_info *info)
++{
++	if (!info)
++		return 0;
++
++	iommu_group_put(info->group);
++	platform_device_put(info->pdev);
++
++	return 0;
++}
++
++int mpp_iommu_refresh(struct mpp_iommu_info *info, struct device *dev)
++{
++#if 0
++	int ret;
++#endif
++
++	if (!info)
++		return 0;
++#if 0
++	/* disable iommu */
++	ret = rockchip_iommu_disable(dev);
++	if (ret)
++		return ret;
++	/* re-enable iommu */
++	return rockchip_iommu_enable(dev);
++#else
++	dev_warn(info->dev, "missing iommu reset support\n");
++	return 0;
++#endif
++}
++
++int mpp_iommu_flush_tlb(struct mpp_iommu_info *info)
++{
++	if (!info)
++		return 0;
++
++	if (info->domain && info->domain->ops)
++		iommu_flush_iotlb_all(info->domain);
++
++	return 0;
++}
+diff --git a/drivers/video/rockchip/mpp/mpp_iommu.h b/drivers/video/rockchip/mpp/mpp_iommu.h
+new file mode 100644
+index 000000000000..e9b57da39eb9
+--- /dev/null
++++ b/drivers/video/rockchip/mpp/mpp_iommu.h
+@@ -0,0 +1,145 @@
++/* SPDX-License-Identifier: (GPL-2.0+ OR MIT) */
++/*
++ * Copyright (c) 2019 Fuzhou Rockchip Electronics Co., Ltd
++ *
++ * author:
++ *	Alpha Lin, alpha.lin@rock-chips.com
++ *	Randy Li, randy.li@rock-chips.com
++ *	Ding Wei, leo.ding@rock-chips.com
++ *
++ */
++#ifndef __ROCKCHIP_MPP_IOMMU_H__
++#define __ROCKCHIP_MPP_IOMMU_H__
++
++#include <linux/iommu.h>
++#include <linux/dma-mapping.h>
++
++struct mpp_dma_buffer {
++	/* link to dma session buffer list */
++	struct list_head link;
++
++	/* dma session belong */
++	struct mpp_dma_session *dma;
++	/* DMABUF information */
++	struct dma_buf *dmabuf;
++	struct dma_buf_attachment *attach;
++	struct sg_table *sgt;
++	struct sg_table *copy_sgt;
++	enum dma_data_direction dir;
++
++	dma_addr_t iova;
++	unsigned long size;
++	void *vaddr;
++
++	struct kref ref;
++	ktime_t last_used;
++	/* alloc by device */
++	struct device *dev;
++};
++
++#define MPP_SESSION_MAX_BUFFERS		60
++
++struct mpp_dma_session {
++	/* the buffer used in session */
++	struct list_head unused_list;
++	struct list_head used_list;
++	struct mpp_dma_buffer dma_bufs[MPP_SESSION_MAX_BUFFERS];
++	/* the mutex for the above buffer list */
++	struct mutex list_mutex;
++	/* the max buffer num for the buffer list */
++	u32 max_buffers;
++	/* the count for the buffer list */
++	int buffer_count;
++
++	struct device *dev;
++};
++
++struct mpp_rk_iommu {
++	struct list_head link;
++	u32 grf_val;
++	int mmu_num;
++	u32 base_addr[2];
++	void __iomem *bases[2];
++	u32 dte_addr;
++	u32 is_paged;
++};
++
++struct mpp_iommu_info {
++	struct rw_semaphore rw_sem;
++
++	struct device *dev;
++	struct platform_device *pdev;
++	struct iommu_domain *domain;
++	struct iommu_group *group;
++	struct mpp_rk_iommu *iommu;
++	iommu_fault_handler_t hdl;
++	u32 av1d_iommu;
++	int irq;
++	int got_irq;
++};
++
++struct mpp_dma_session *
++mpp_dma_session_create(struct device *dev, u32 max_buffers);
++int mpp_dma_session_destroy(struct mpp_dma_session *dma);
++
++struct mpp_dma_buffer *
++mpp_dma_alloc(struct device *dev, size_t size);
++int mpp_dma_free(struct mpp_dma_buffer *buffer);
++
++struct mpp_dma_buffer *
++mpp_dma_import_fd(struct mpp_iommu_info *iommu_info,
++		  struct mpp_dma_session *dma, int fd);
++int mpp_dma_release(struct mpp_dma_session *dma,
++		    struct mpp_dma_buffer *buffer);
++int mpp_dma_release_fd(struct mpp_dma_session *dma, int fd);
++
++int mpp_dma_unmap_kernel(struct mpp_dma_session *dma,
++			 struct mpp_dma_buffer *buffer);
++int mpp_dma_map_kernel(struct mpp_dma_session *dma,
++		       struct mpp_dma_buffer *buffer);
++
++struct mpp_iommu_info *
++mpp_iommu_probe(struct device *dev);
++int mpp_iommu_remove(struct mpp_iommu_info *info);
++
++int mpp_iommu_attach(struct mpp_iommu_info *info);
++int mpp_iommu_detach(struct mpp_iommu_info *info);
++
++int mpp_iommu_refresh(struct mpp_iommu_info *info, struct device *dev);
++int mpp_iommu_flush_tlb(struct mpp_iommu_info *info);
++int mpp_av1_iommu_disable(struct device *dev);
++int mpp_av1_iommu_enable(struct device *dev);
++
++static inline int mpp_iommu_down_read(struct mpp_iommu_info *info)
++{
++	if (info)
++		down_read(&info->rw_sem);
++
++	return 0;
++}
++
++static inline int mpp_iommu_up_read(struct mpp_iommu_info *info)
++{
++	if (info)
++		up_read(&info->rw_sem);
++
++	return 0;
++}
++
++static inline int mpp_iommu_down_write(struct mpp_iommu_info *info)
++{
++	if (info)
++		down_write(&info->rw_sem);
++
++	return 0;
++}
++
++static inline int mpp_iommu_up_write(struct mpp_iommu_info *info)
++{
++	if (info)
++		up_write(&info->rw_sem);
++
++	return 0;
++}
++
++#endif
+diff --git a/drivers/video/rockchip/mpp/mpp_rkvenc2.c b/drivers/video/rockchip/mpp/mpp_rkvenc2.c
+new file mode 100644
+index 000000000000..887750853c77
+--- /dev/null
++++ b/drivers/video/rockchip/mpp/mpp_rkvenc2.c
+@@ -0,0 +1,2241 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2021 Rockchip Electronics Co., Ltd
++ *
++ * author:
++ *	Ding Wei, leo.ding@rock-chips.com
++ *
++ */
++
++#include <asm/cacheflush.h>
++#include <linux/delay.h>
++#include <linux/devfreq.h>
++#include <linux/devfreq_cooling.h>
++#include <linux/iopoll.h>
++#include <linux/interrupt.h>
++#include <linux/kernel.h>
++#include <linux/module.h>
++#include <linux/types.h>
++#include <linux/of_platform.h>
++#include <linux/of_address.h>
++#include <linux/slab.h>
++#include <linux/seq_file.h>
++#include <linux/uaccess.h>
++#include <linux/regmap.h>
++#include <linux/regulator/consumer.h>
++#include <linux/proc_fs.h>
++#include <linux/pm_runtime.h>
++#include <linux/nospec.h>
++#include <linux/workqueue.h>
++#include <soc/rockchip/pm_domains.h>
++
++#include "mpp_debug.h"
++#include "mpp_iommu.h"
++#include "mpp_common.h"
++
++#define RKVENC_DRIVER_NAME			"mpp_rkvenc2"
++
++#define	RKVENC_SESSION_MAX_BUFFERS		40
++#define RKVENC_MAX_CORE_NUM			4
++#define RKVENC_MAX_DCHS_ID			4
++
++#define to_rkvenc_info(info)		\
++		container_of(info, struct rkvenc_hw_info, hw)
++#define to_rkvenc_task(ctx)		\
++		container_of(ctx, struct rkvenc_task, mpp_task)
++#define to_rkvenc_dev(dev)		\
++		container_of(dev, struct rkvenc_dev, mpp)
++
++
++enum RKVENC_FORMAT_TYPE {
++	RKVENC_FMT_BASE		= 0x0000,
++	RKVENC_FMT_H264E	= RKVENC_FMT_BASE + 0,
++	RKVENC_FMT_H265E	= RKVENC_FMT_BASE + 1,
++
++	RKVENC_FMT_OSD_BASE	= 0x1000,
++	RKVENC_FMT_H264E_OSD	= RKVENC_FMT_OSD_BASE + 0,
++	RKVENC_FMT_H265E_OSD	= RKVENC_FMT_OSD_BASE + 1,
++	RKVENC_FMT_BUTT,
++};
++
++enum RKVENC_CLASS_TYPE {
++	RKVENC_CLASS_BASE	= 0,	/* base */
++	RKVENC_CLASS_PIC	= 1,	/* picture configure */
++	RKVENC_CLASS_RC		= 2,	/* rate control */
++	RKVENC_CLASS_PAR	= 3,	/* parameter */
++	RKVENC_CLASS_SQI	= 4,	/* subjective Adjust */
++	RKVENC_CLASS_SCL	= 5,	/* scaling list */
++	RKVENC_CLASS_OSD	= 6,	/* osd */
++	RKVENC_CLASS_ST		= 7,	/* status */
++	RKVENC_CLASS_DEBUG	= 8,	/* debug */
++	RKVENC_CLASS_BUTT,
++};
++
++enum RKVENC_CLASS_FD_TYPE {
++	RKVENC_CLASS_FD_BASE	= 0,	/* base */
++	RKVENC_CLASS_FD_OSD	= 1,	/* osd */
++	RKVENC_CLASS_FD_BUTT,
++};
++
++struct rkvenc_reg_msg {
++	u32 base_s;
++	u32 base_e;
++};
++
++struct rkvenc_hw_info {
++	struct mpp_hw_info hw;
++	/* for register range check */
++	u32 reg_class;
++	struct rkvenc_reg_msg reg_msg[RKVENC_CLASS_BUTT];
++	/* for fd translate */
++	u32 fd_class;
++	struct {
++		u32 class;
++		u32 base_fmt;
++	} fd_reg[RKVENC_CLASS_FD_BUTT];
++	/* for get format */
++	struct {
++		u32 class;
++		u32 base;
++		u32 bitpos;
++		u32 bitlen;
++	} fmt_reg;
++	/* register info */
++	u32 enc_start_base;
++	u32 enc_clr_base;
++	u32 int_en_base;
++	u32 int_mask_base;
++	u32 int_clr_base;
++	u32 int_sta_base;
++	u32 enc_wdg_base;
++	u32 err_mask;
++};
++
++#define INT_STA_ENC_DONE_STA	BIT(0)
++#define INT_STA_SCLR_DONE_STA	BIT(2)
++#define INT_STA_SLC_DONE_STA	BIT(3)
++#define INT_STA_BSF_OFLW_STA	BIT(4)
++#define INT_STA_BRSP_OTSD_STA	BIT(5)
++#define INT_STA_WBUS_ERR_STA	BIT(6)
++#define INT_STA_RBUS_ERR_STA	BIT(7)
++#define INT_STA_WDG_STA		BIT(8)
++
++#define DCHS_REG_OFFSET		(0x304)
++#define DCHS_CLASS_OFFSET	(33)
++#define DCHS_TXE		(0x10)
++#define DCHS_RXE		(0x20)
++
++/* dual core hand-shake info */
++union rkvenc2_dual_core_handshake_id {
++	u64 val;
++	struct {
++		u32 txid	: 2;
++		u32 rxid	: 2;
++		u32 txe		: 1;
++		u32 rxe		: 1;
++		u32 working	: 1;
++		u32 reserve0	: 1;
++		u32 txid_orig	: 2;
++		u32 rxid_orig	: 2;
++		u32 txid_map	: 2;
++		u32 rxid_map	: 2;
++		u32 offset	: 11;
++		u32 reserve1	: 1;
++		u32 txe_orig	: 1;
++		u32 rxe_orig	: 1;
++		u32 txe_map	: 1;
++		u32 rxe_map	: 1;
++		u32 session_id;
++	};
++};
++
++#define RKVENC2_REG_INT_EN		(8)
++#define RKVENC2_BIT_SLICE_DONE_EN	BIT(3)
++
++#define RKVENC2_REG_INT_MASK		(9)
++#define RKVENC2_BIT_SLICE_DONE_MASK	BIT(3)
++
++#define RKVENC2_REG_ENC_PIC		(32)
++#define RKVENC2_BIT_SLEN_FIFO		BIT(30)
++
++#define RKVENC2_REG_SLI_SPLIT		(56)
++#define RKVENC2_BIT_SLI_SPLIT		BIT(0)
++#define RKVENC2_BIT_SLI_FLUSH		BIT(15)
++
++#define RKVENC2_REG_SLICE_NUM_BASE	(0x4034)
++#define RKVENC2_REG_SLICE_LEN_BASE	(0x4038)
++
++union rkvenc2_slice_len_info {
++	u32 val;
++
++	struct {
++		u32 slice_len	: 31;
++		u32 last	: 1;
++	};
++};
++
++struct rkvenc_poll_slice_cfg {
++	s32 poll_type;
++	s32 poll_ret;
++	s32 count_max;
++	s32 count_ret;
++	union rkvenc2_slice_len_info slice_info[];
++};
++
++struct rkvenc_task {
++	struct mpp_task mpp_task;
++	int fmt;
++	struct rkvenc_hw_info *hw_info;
++
++	/* class register */
++	struct {
++		u32 valid;
++		u32 *data;
++		u32 size;
++	} reg[RKVENC_CLASS_BUTT];
++	/* register offset info */
++	struct reg_offset_info off_inf;
++
++	enum MPP_CLOCK_MODE clk_mode;
++	u32 irq_status;
++	/* req for current task */
++	u32 w_req_cnt;
++	struct mpp_request w_reqs[MPP_MAX_MSG_NUM];
++	u32 r_req_cnt;
++	struct mpp_request r_reqs[MPP_MAX_MSG_NUM];
++	struct mpp_dma_buffer *table;
++
++	union rkvenc2_dual_core_handshake_id dchs_id;
++
++	/* split output / slice mode info */
++	u32 task_split;
++	u32 task_split_done;
++	u32 last_slice_found;
++	u32 slice_wr_cnt;
++	u32 slice_rd_cnt;
++	DECLARE_KFIFO(slice_info, union rkvenc2_slice_len_info, 64);
++};
++
++#define RKVENC_MAX_RCB_NUM		(4)
++
++struct rcb_info_elem {
++	u32 index;
++	u32 size;
++};
++
++struct rkvenc2_rcb_info {
++	u32 cnt;
++	struct rcb_info_elem elem[RKVENC_MAX_RCB_NUM];
++};
++
++struct rkvenc2_session_priv {
++	struct rw_semaphore rw_sem;
++	/* codec info from user */
++	struct {
++		/* show mode */
++		u32 flag;
++		/* item data */
++		u64 val;
++	} codec_info[ENC_INFO_BUTT];
++	/* rcb_info for sram */
++	struct rkvenc2_rcb_info rcb_inf;
++};
++
++struct rkvenc_dev {
++	struct mpp_dev mpp;
++	struct rkvenc_hw_info *hw_info;
++
++	struct mpp_clk_info aclk_info;
++	struct mpp_clk_info hclk_info;
++	struct mpp_clk_info core_clk_info;
++	u32 default_max_load;
++#ifdef CONFIG_ROCKCHIP_MPP_PROC_FS
++	struct proc_dir_entry *procfs;
++#endif
++	struct reset_control *rst_a;
++	struct reset_control *rst_h;
++	struct reset_control *rst_core;
++	/* for ccu */
++	struct rkvenc_ccu *ccu;
++	struct list_head core_link;
++	u32 disable_work;
++
++	/* internal rcb-memory */
++	u32 sram_size;
++	u32 sram_used;
++	dma_addr_t sram_iova;
++	u32 sram_enabled;
++	struct page *rcb_page;
++};
++
++struct rkvenc_ccu {
++	u32 core_num;
++	/* lock for core attach */
++	struct mutex lock;
++	struct list_head core_list;
++	struct mpp_dev *main_core;
++
++	spinlock_t lock_dchs;
++	union rkvenc2_dual_core_handshake_id dchs[RKVENC_MAX_CORE_NUM];
++};
++
++static struct rkvenc_hw_info rkvenc_v2_hw_info = {
++	.hw = {
++		.reg_num = 254,
++		.reg_id = 0,
++		.reg_en = 4,
++		.reg_start = 160,
++		.reg_end = 253,
++	},
++	.reg_class = RKVENC_CLASS_BUTT,
++	.reg_msg[RKVENC_CLASS_BASE] = {
++		.base_s = 0x0000,
++		.base_e = 0x0058,
++	},
++	.reg_msg[RKVENC_CLASS_PIC] = {
++		.base_s = 0x0280,
++		.base_e = 0x03f4,
++	},
++	.reg_msg[RKVENC_CLASS_RC] = {
++		.base_s = 0x1000,
++		.base_e = 0x10e0,
++	},
++	.reg_msg[RKVENC_CLASS_PAR] = {
++		.base_s = 0x1700,
++		.base_e = 0x1cd4,
++	},
++	.reg_msg[RKVENC_CLASS_SQI] = {
++		.base_s = 0x2000,
++		.base_e = 0x21e4,
++	},
++	.reg_msg[RKVENC_CLASS_SCL] = {
++		.base_s = 0x2200,
++		.base_e = 0x2c98,
++	},
++	.reg_msg[RKVENC_CLASS_OSD] = {
++		.base_s = 0x3000,
++		.base_e = 0x347c,
++	},
++	.reg_msg[RKVENC_CLASS_ST] = {
++		.base_s = 0x4000,
++		.base_e = 0x42cc,
++	},
++	.reg_msg[RKVENC_CLASS_DEBUG] = {
++		.base_s = 0x5000,
++		.base_e = 0x5354,
++	},
++	.fd_class = RKVENC_CLASS_FD_BUTT,
++	.fd_reg[RKVENC_CLASS_FD_BASE] = {
++		.class = RKVENC_CLASS_PIC,
++		.base_fmt = RKVENC_FMT_BASE,
++	},
++	.fd_reg[RKVENC_CLASS_FD_OSD] = {
++		.class = RKVENC_CLASS_OSD,
++		.base_fmt = RKVENC_FMT_OSD_BASE,
++	},
++	.fmt_reg = {
++		.class = RKVENC_CLASS_PIC,
++		.base = 0x0300,
++		.bitpos = 0,
++		.bitlen = 1,
++	},
++	.enc_start_base = 0x0010,
++	.enc_clr_base = 0x0014,
++	.int_en_base = 0x0020,
++	.int_mask_base = 0x0024,
++	.int_clr_base = 0x0028,
++	.int_sta_base = 0x002c,
++	.enc_wdg_base = 0x0038,
++	.err_mask = 0x03f0,
++};
++
++/*
++ * file handle translate information for v2
++ */
++static const u16 trans_tbl_h264e_v2[] = {
++	0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
++	10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
++	20, 21, 22, 23,
++};
++
++static const u16 trans_tbl_h264e_v2_osd[] = {
++	20, 21, 22, 23, 24, 25, 26, 27,
++};
++
++static const u16 trans_tbl_h265e_v2[] = {
++	0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
++	10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
++	20, 21, 22, 23,
++};
++
++static const u16 trans_tbl_h265e_v2_osd[] = {
++	20, 21, 22, 23, 24, 25, 26, 27,
++};
++
++static struct mpp_trans_info trans_rkvenc_v2[] = {
++	[RKVENC_FMT_H264E] = {
++		.count = ARRAY_SIZE(trans_tbl_h264e_v2),
++		.table = trans_tbl_h264e_v2,
++	},
++	[RKVENC_FMT_H264E_OSD] = {
++		.count = ARRAY_SIZE(trans_tbl_h264e_v2_osd),
++		.table = trans_tbl_h264e_v2_osd,
++	},
++	[RKVENC_FMT_H265E] = {
++		.count = ARRAY_SIZE(trans_tbl_h265e_v2),
++		.table = trans_tbl_h265e_v2,
++	},
++	[RKVENC_FMT_H265E_OSD] = {
++		.count = ARRAY_SIZE(trans_tbl_h265e_v2_osd),
++		.table = trans_tbl_h265e_v2_osd,
++	},
++};
++
++static bool req_over_class(struct mpp_request *req,
++			   struct rkvenc_task *task, int class)
++{
++	bool ret;
++	u32 base_s, base_e, req_e;
++	struct rkvenc_hw_info *hw = task->hw_info;
++
++	base_s = hw->reg_msg[class].base_s;
++	base_e = hw->reg_msg[class].base_e;
++	req_e = req->offset + req->size - sizeof(u32);
++
++	ret = (req->offset <= base_e && req_e >= base_s) ? true : false;
++
++	return ret;
++}
++
++static int rkvenc_free_class_msg(struct rkvenc_task *task)
++{
++	u32 i;
++	u32 reg_class = task->hw_info->reg_class;
++
++	for (i = 0; i < reg_class; i++) {
++		kfree(task->reg[i].data);
++		task->reg[i].size = 0;
++	}
++
++	return 0;
++}
++
++static int rkvenc_alloc_class_msg(struct rkvenc_task *task, int class)
++{
++	u32 *data;
++	struct rkvenc_hw_info *hw = task->hw_info;
++
++	if (!task->reg[class].data) {
++		u32 base_s = hw->reg_msg[class].base_s;
++		u32 base_e = hw->reg_msg[class].base_e;
++		u32 class_size = base_e - base_s + sizeof(u32);
++
++		data = kzalloc(class_size, GFP_KERNEL);
++		if (!data)
++			return -ENOMEM;
++		task->reg[class].data = data;
++		task->reg[class].size = class_size;
++	}
++
++	return 0;
++}
++
++static int rkvenc_update_req(struct rkvenc_task *task, int class,
++			     struct mpp_request *req_in,
++			     struct mpp_request *req_out)
++{
++	u32 base_s, base_e, req_e, s, e;
++	struct rkvenc_hw_info *hw = task->hw_info;
++
++	base_s = hw->reg_msg[class].base_s;
++	base_e = hw->reg_msg[class].base_e;
++	req_e = req_in->offset + req_in->size - sizeof(u32);
++	s = max(req_in->offset, base_s);
++	e = min(req_e, base_e);
++
++	req_out->offset = s;
++	req_out->size = e - s + sizeof(u32);
++	req_out->data = (u8 *)req_in->data + (s - req_in->offset);
++
++	return 0;
++}
++
++static int rkvenc_get_class_msg(struct rkvenc_task *task,
++				u32 addr, struct mpp_request *msg)
++{
++	int i;
++	bool found = false;
++	u32 base_s, base_e;
++	struct rkvenc_hw_info *hw = task->hw_info;
++
++	if (!msg)
++		return -EINVAL;
++
++	memset(msg, 0, sizeof(*msg));
++	for (i = 0; i < hw->reg_class; i++) {
++		base_s = hw->reg_msg[i].base_s;
++		base_e = hw->reg_msg[i].base_e;
++		if (addr >= base_s && addr < base_e) {
++			found = true;
++			msg->offset = base_s;
++			msg->size = task->reg[i].size;
++			msg->data = task->reg[i].data;
++			break;
++		}
++	}
++
++	return (found ? 0 : (-EINVAL));
++}
++
++static u32 *rkvenc_get_class_reg(struct rkvenc_task *task, u32 addr)
++{
++	int i;
++	u8 *reg = NULL;
++	u32 base_s, base_e;
++	struct rkvenc_hw_info *hw = task->hw_info;
++
++	for (i = 0; i < hw->reg_class; i++) {
++		base_s = hw->reg_msg[i].base_s;
++		base_e = hw->reg_msg[i].base_e;
++		if (addr >= base_s && addr < base_e) {
++			reg = (u8 *)task->reg[i].data + (addr - base_s);
++			break;
++		}
++	}
++
++	return (u32 *)reg;
++}
++
++static int rkvenc2_extract_rcb_info(struct rkvenc2_rcb_info *rcb_inf,
++				    struct mpp_request *req)
++{
++	int max_size = ARRAY_SIZE(rcb_inf->elem);
++	int cnt = req->size / sizeof(rcb_inf->elem[0]);
++
++	if (req->size > sizeof(rcb_inf->elem)) {
++		mpp_err("count %d,max_size %d\n", cnt, max_size);
++		return -EINVAL;
++	}
++	if (copy_from_user(rcb_inf->elem, req->data, req->size)) {
++		mpp_err("copy_from_user failed\n");
++		return -EINVAL;
++	}
++	rcb_inf->cnt = cnt;
++
++	return 0;
++}
++
++static int rkvenc_extract_task_msg(struct mpp_session *session,
++				   struct rkvenc_task *task,
++				   struct mpp_task_msgs *msgs)
++{
++	int ret;
++	u32 i, j;
++	struct mpp_request *req;
++	struct rkvenc_hw_info *hw = task->hw_info;
++
++	mpp_debug_enter();
++
++	for (i = 0; i < msgs->req_cnt; i++) {
++		req = &msgs->reqs[i];
++		if (!req->size)
++			continue;
++
++		switch (req->cmd) {
++		case MPP_CMD_SET_REG_WRITE: {
++			void *data;
++			struct mpp_request *wreq;
++
++			for (j = 0; j < hw->reg_class; j++) {
++				if (!req_over_class(req, task, j))
++					continue;
++
++				ret = rkvenc_alloc_class_msg(task, j);
++				if (ret) {
++					mpp_err("alloc class msg %d fail.\n", j);
++					goto fail;
++				}
++				wreq = &task->w_reqs[task->w_req_cnt];
++				rkvenc_update_req(task, j, req, wreq);
++				data = rkvenc_get_class_reg(task, wreq->offset);
++				if (!data)
++					goto fail;
++				if (copy_from_user(data, wreq->data, wreq->size)) {
++					mpp_err("copy_from_user fail, offset %08x\n", wreq->offset);
++					ret = -EIO;
++					goto fail;
++				}
++				task->reg[j].valid = 1;
++				task->w_req_cnt++;
++			}
++		} break;
++		case MPP_CMD_SET_REG_READ: {
++			struct mpp_request *rreq;
++
++			for (j = 0; j < hw->reg_class; j++) {
++				if (!req_over_class(req, task, j))
++					continue;
++
++				ret = rkvenc_alloc_class_msg(task, j);
++				if (ret) {
++					mpp_err("alloc class msg reg %d fail.\n", j);
++					goto fail;
++				}
++				rreq = &task->r_reqs[task->r_req_cnt];
++				rkvenc_update_req(task, j, req, rreq);
++				task->reg[j].valid = 1;
++				task->r_req_cnt++;
++			}
++		} break;
++		case MPP_CMD_SET_REG_ADDR_OFFSET: {
++			mpp_extract_reg_offset_info(&task->off_inf, req);
++		} break;
++		case MPP_CMD_SET_RCB_INFO: {
++			struct rkvenc2_session_priv *priv = session->priv;
++
++			if (priv)
++				rkvenc2_extract_rcb_info(&priv->rcb_inf, req);
++		} break;
++		default:
++			break;
++		}
++	}
++	mpp_debug(DEBUG_TASK_INFO, "w_req_cnt=%d, r_req_cnt=%d\n",
++		  task->w_req_cnt, task->r_req_cnt);
++
++	mpp_debug_enter();
++	return 0;
++
++fail:
++	rkvenc_free_class_msg(task);
++
++	mpp_debug_enter();
++	return ret;
++}
++
++static int rkvenc_task_get_format(struct mpp_dev *mpp,
++				  struct rkvenc_task *task)
++{
++	u32 offset, val;
++
++	struct rkvenc_hw_info *hw = task->hw_info;
++	u32 class = hw->fmt_reg.class;
++	u32 *class_reg = task->reg[class].data;
++	u32 class_size = task->reg[class].size;
++	u32 class_base = hw->reg_msg[class].base_s;
++	u32 bitpos = hw->fmt_reg.bitpos;
++	u32 bitlen = hw->fmt_reg.bitlen;
++
++	if (!class_reg || !class_size)
++		return -EINVAL;
++
++	offset = hw->fmt_reg.base - class_base;
++	val = class_reg[offset/sizeof(u32)];
++	task->fmt = (val >> bitpos) & ((1 << bitlen) - 1);
++
++	return 0;
++}
++
++static int rkvenc2_set_rcbbuf(struct mpp_dev *mpp, struct mpp_session *session,
++			      struct rkvenc_task *task)
++{
++	struct rkvenc_dev *enc = to_rkvenc_dev(mpp);
++	struct rkvenc2_session_priv *priv = session->priv;
++	u32 sram_enabled = 0;
++
++	mpp_debug_enter();
++
++	if (priv && enc->sram_iova) {
++		int i;
++		u32 *reg;
++		u32 reg_idx, rcb_size, rcb_offset;
++		struct rkvenc2_rcb_info *rcb_inf = &priv->rcb_inf;
++
++		rcb_offset = 0;
++		for (i = 0; i < rcb_inf->cnt; i++) {
++			reg_idx = rcb_inf->elem[i].index;
++			rcb_size = rcb_inf->elem[i].size;
++
++			if (rcb_offset > enc->sram_size ||
++			    (rcb_offset + rcb_size) > enc->sram_used)
++				continue;
++
++			mpp_debug(DEBUG_SRAM_INFO, "rcb: reg %d offset %d, size %d\n",
++				  reg_idx, rcb_offset, rcb_size);
++
++			reg = rkvenc_get_class_reg(task, reg_idx * sizeof(u32));
++			if (reg)
++				*reg = enc->sram_iova + rcb_offset;
++
++			rcb_offset += rcb_size;
++			sram_enabled = 1;
++		}
++	}
++	if (enc->sram_enabled != sram_enabled) {
++		mpp_debug(DEBUG_SRAM_INFO, "sram %s\n", sram_enabled ? "enabled" : "disabled");
++		enc->sram_enabled = sram_enabled;
++	}
++
++	mpp_debug_leave();
++
++	return 0;
++}
++
++static void rkvenc2_setup_task_id(u32 session_id, struct rkvenc_task *task)
++{
++	u32 val = task->reg[RKVENC_CLASS_PIC].data[DCHS_CLASS_OFFSET];
++
++	/* always enable tx */
++	val |= DCHS_TXE;
++
++	task->reg[RKVENC_CLASS_PIC].data[DCHS_CLASS_OFFSET] = val;
++	task->dchs_id.val = (((u64)session_id << 32) | val);
++
++	task->dchs_id.txid_orig = task->dchs_id.txid;
++	task->dchs_id.rxid_orig = task->dchs_id.rxid;
++	task->dchs_id.txid_map = task->dchs_id.txid;
++	task->dchs_id.rxid_map = task->dchs_id.rxid;
++
++	task->dchs_id.txe_orig = task->dchs_id.txe;
++	task->dchs_id.rxe_orig = task->dchs_id.rxe;
++	task->dchs_id.txe_map = task->dchs_id.txe;
++	task->dchs_id.rxe_map = task->dchs_id.rxe;
++}
++
++static int rkvenc2_is_split_task(struct rkvenc_task *task)
++{
++	u32 slc_done_en;
++	u32 slc_done_msk;
++	u32 slen_fifo_en;
++	u32 sli_split_en;
++	u32 sli_flsh_en;
++
++	if (task->reg[RKVENC_CLASS_BASE].valid) {
++		u32 *reg = task->reg[RKVENC_CLASS_BASE].data;
++
++		slc_done_en  = (reg[RKVENC2_REG_INT_EN] & RKVENC2_BIT_SLICE_DONE_EN) ? 1 : 0;
++		slc_done_msk = (reg[RKVENC2_REG_INT_MASK] & RKVENC2_BIT_SLICE_DONE_MASK) ? 1 : 0;
++	} else {
++		slc_done_en  = 0;
++		slc_done_msk = 0;
++	}
++
++	if (task->reg[RKVENC_CLASS_PIC].valid) {
++		u32 *reg = task->reg[RKVENC_CLASS_PIC].data;
++
++		slen_fifo_en = (reg[RKVENC2_REG_ENC_PIC] & RKVENC2_BIT_SLEN_FIFO) ? 1 : 0;
++		sli_split_en = (reg[RKVENC2_REG_SLI_SPLIT] & RKVENC2_BIT_SLI_SPLIT) ? 1 : 0;
++		sli_flsh_en  = (reg[RKVENC2_REG_SLI_SPLIT] & RKVENC2_BIT_SLI_FLUSH) ? 1 : 0;
++	} else {
++		slen_fifo_en = 0;
++		sli_split_en = 0;
++		sli_flsh_en  = 0;
++	}
++
++	if (sli_split_en && slen_fifo_en && sli_flsh_en) {
++		if (!slc_done_en || slc_done_msk)
++			mpp_dbg_slice("task %d slice output enabled but irq disabled!\n",
++				      task->mpp_task.task_id);
++
++		return 1;
++	}
++
++	return 0;
++}
++
++static void *rkvenc_alloc_task(struct mpp_session *session,
++			       struct mpp_task_msgs *msgs)
++{
++	int ret;
++	struct rkvenc_task *task;
++	struct mpp_task *mpp_task;
++	struct mpp_dev *mpp = session->mpp;
++
++	mpp_debug_enter();
++
++	task = kzalloc(sizeof(*task), GFP_KERNEL);
++	if (!task)
++		return NULL;
++
++	mpp_task = &task->mpp_task;
++	mpp_task_init(session, mpp_task);
++	mpp_task->hw_info = mpp->var->hw_info;
++	task->hw_info = to_rkvenc_info(mpp_task->hw_info);
++	/* extract reqs for current task */
++	ret = rkvenc_extract_task_msg(session, task, msgs);
++	if (ret)
++		goto free_task;
++	mpp_task->reg = task->reg[0].data;
++	/* get format */
++	ret = rkvenc_task_get_format(mpp, task);
++	if (ret)
++		goto free_task;
++	/* process fd in register */
++	if (!(msgs->flags & MPP_FLAGS_REG_FD_NO_TRANS)) {
++		u32 i, j;
++		int cnt;
++		u32 off;
++		const u16 *tbl;
++		struct rkvenc_hw_info *hw = task->hw_info;
++
++		for (i = 0; i < hw->fd_class; i++) {
++			u32 class = hw->fd_reg[i].class;
++			u32 fmt = hw->fd_reg[i].base_fmt + task->fmt;
++			u32 *reg = task->reg[class].data;
++			u32 ss = hw->reg_msg[class].base_s / sizeof(u32);
++
++			if (!reg)
++				continue;
++
++			ret = mpp_translate_reg_address(session, mpp_task, fmt, reg, NULL);
++			if (ret)
++				goto fail;
++
++			cnt = mpp->var->trans_info[fmt].count;
++			tbl = mpp->var->trans_info[fmt].table;
++			for (j = 0; j < cnt; j++) {
++				off = mpp_query_reg_offset_info(&task->off_inf, tbl[j] + ss);
++				mpp_debug(DEBUG_IOMMU, "reg[%d] + offset %d\n", tbl[j] + ss, off);
++				reg[tbl[j]] += off;
++			}
++		}
++	}
++	rkvenc2_set_rcbbuf(mpp, session, task);
++	rkvenc2_setup_task_id(session->index, task);
++	task->clk_mode = CLK_MODE_NORMAL;
++	task->task_split = rkvenc2_is_split_task(task);
++	if (task->task_split)
++		INIT_KFIFO(task->slice_info);
++
++	mpp_debug_leave();
++
++	return mpp_task;
++
++fail:
++	mpp_task_dump_mem_region(mpp, mpp_task);
++	mpp_task_dump_reg(mpp, mpp_task);
++	mpp_task_finalize(session, mpp_task);
++	/* free class register buffer */
++	rkvenc_free_class_msg(task);
++free_task:
++	kfree(task);
++
++	return NULL;
++}
++
++static void *rkvenc2_prepare(struct mpp_dev *mpp, struct mpp_task *mpp_task)
++{
++	struct mpp_taskqueue *queue = mpp->queue;
++	unsigned long flags;
++	s32 core_id;
++
++	spin_lock_irqsave(&queue->running_lock, flags);
++
++	core_id = find_first_bit(&queue->core_idle, queue->core_count);
++
++	if (core_id >= queue->core_count) {
++		mpp_task = NULL;
++		mpp_dbg_core("core %d all busy %lx\n", core_id, queue->core_idle);
++	} else {
++		unsigned long core_idle = queue->core_idle;
++
++		clear_bit(core_id, &queue->core_idle);
++		mpp_task->mpp = queue->cores[core_id];
++		mpp_task->core_id = core_id;
++
++		mpp_dbg_core("core %d set idle %lx -> %lx\n", core_id,
++			     core_idle, queue->core_idle);
++	}
++
++	spin_unlock_irqrestore(&queue->running_lock, flags);
++
++	return mpp_task;
++}
++
++static void rkvenc2_patch_dchs(struct rkvenc_dev *enc, struct rkvenc_task *task)
++{
++	struct rkvenc_ccu *ccu;
++	union rkvenc2_dual_core_handshake_id *dchs;
++	union rkvenc2_dual_core_handshake_id *task_dchs = &task->dchs_id;
++	int core_num;
++	int core_id = enc->mpp.core_id;
++	unsigned long flags;
++	int i;
++
++	if (!enc->ccu)
++		return;
++
++	if (core_id >= RKVENC_MAX_CORE_NUM) {
++		dev_err(enc->mpp.dev, "invalid core id %d max %d\n",
++			core_id, RKVENC_MAX_CORE_NUM);
++		return;
++	}
++
++	ccu = enc->ccu;
++	dchs = ccu->dchs;
++	core_num = ccu->core_num;
++
++	spin_lock_irqsave(&ccu->lock_dchs, flags);
++
++	if (dchs[core_id].working) {
++		spin_unlock_irqrestore(&ccu->lock_dchs, flags);
++
++		mpp_err("can not config when core %d is still working\n", core_id);
++		return;
++	}
++
++	if (mpp_debug_unlikely(DEBUG_CORE))
++		pr_info("core tx:rx 0 %s %d:%d %d:%d -- 1 %s %d:%d %d:%d -- task %d %d:%d %d:%d\n",
++			dchs[0].working ? "work" : "idle",
++			dchs[0].txid, dchs[0].txe, dchs[0].rxid, dchs[0].rxe,
++			dchs[1].working ? "work" : "idle",
++			dchs[1].txid, dchs[1].txe, dchs[1].rxid, dchs[1].rxe,
++			core_id, task_dchs->txid, task_dchs->txe,
++			task_dchs->rxid, task_dchs->rxe);
++
++	/* always use new id as  */
++	{
++		struct mpp_task *mpp_task = &task->mpp_task;
++		unsigned long id_valid = (unsigned long)-1;
++		int txid_map = -1;
++		int rxid_map = -1;
++
++		/* scan all used id */
++		for (i = 0; i < core_num; i++) {
++			if (!dchs[i].working)
++				continue;
++
++			clear_bit(dchs[i].txid_map, &id_valid);
++			clear_bit(dchs[i].rxid_map, &id_valid);
++		}
++
++		if (task_dchs->rxe) {
++			for (i = 0; i < core_num; i++) {
++				if (i == core_id)
++					continue;
++
++				if (!dchs[i].working)
++					continue;
++
++				if (task_dchs->session_id != dchs[i].session_id)
++					continue;
++
++				if (task_dchs->rxid_orig != dchs[i].txid_orig)
++					continue;
++
++				rxid_map = dchs[i].txid_map;
++				break;
++			}
++		}
++
++		txid_map = find_first_bit(&id_valid, RKVENC_MAX_DCHS_ID);
++		if (txid_map == RKVENC_MAX_DCHS_ID) {
++			spin_unlock_irqrestore(&ccu->lock_dchs, flags);
++
++			mpp_err("task %d:%d on core %d failed to find a txid\n",
++				mpp_task->session->pid, mpp_task->task_id,
++				mpp_task->core_id);
++			return;
++		}
++
++		clear_bit(txid_map, &id_valid);
++		task_dchs->txid_map = txid_map;
++
++		if (rxid_map < 0) {
++			rxid_map = find_first_bit(&id_valid, RKVENC_MAX_DCHS_ID);
++			if (rxid_map == RKVENC_MAX_DCHS_ID) {
++				spin_unlock_irqrestore(&ccu->lock_dchs, flags);
++
++				mpp_err("task %d:%d on core %d failed to find a rxid\n",
++					mpp_task->session->pid, mpp_task->task_id,
++					mpp_task->core_id);
++				return;
++			}
++
++			task_dchs->rxe_map = 0;
++		}
++
++		task_dchs->rxid_map = rxid_map;
++	}
++
++	task_dchs->txid = task_dchs->txid_map;
++	task_dchs->rxid = task_dchs->rxid_map;
++	task_dchs->rxe = task_dchs->rxe_map;
++
++	dchs[core_id].val = task_dchs->val;
++	task->reg[RKVENC_CLASS_PIC].data[DCHS_CLASS_OFFSET] = task_dchs->val;
++
++	dchs[core_id].working = 1;
++
++	spin_unlock_irqrestore(&ccu->lock_dchs, flags);
++}
++
++static void rkvenc2_update_dchs(struct rkvenc_dev *enc, struct rkvenc_task *task)
++{
++	struct rkvenc_ccu *ccu = enc->ccu;
++	int core_id = enc->mpp.core_id;
++	unsigned long flags;
++
++	if (!ccu)
++		return;
++
++	if (core_id >= RKVENC_MAX_CORE_NUM) {
++		dev_err(enc->mpp.dev, "invalid core id %d max %d\n",
++			core_id, RKVENC_MAX_CORE_NUM);
++		return;
++	}
++
++	spin_lock_irqsave(&ccu->lock_dchs, flags);
++	ccu->dchs[core_id].val = 0;
++
++	if (mpp_debug_unlikely(DEBUG_CORE)) {
++		union rkvenc2_dual_core_handshake_id *dchs = ccu->dchs;
++		union rkvenc2_dual_core_handshake_id *task_dchs = &task->dchs_id;
++
++		pr_info("core %d task done\n", core_id);
++		pr_info("core tx:rx 0 %s %d:%d %d:%d -- 1 %s %d:%d %d:%d -- task %d %d:%d %d:%d\n",
++			dchs[0].working ? "work" : "idle",
++			dchs[0].txid, dchs[0].txe, dchs[0].rxid, dchs[0].rxe,
++			dchs[1].working ? "work" : "idle",
++			dchs[1].txid, dchs[1].txe, dchs[1].rxid, dchs[1].rxe,
++			core_id, task_dchs->txid, task_dchs->txe,
++			task_dchs->rxid, task_dchs->rxe);
++	}
++
++	spin_unlock_irqrestore(&ccu->lock_dchs, flags);
++}
++
++static int rkvenc_run(struct mpp_dev *mpp, struct mpp_task *mpp_task)
++{
++	u32 i, j;
++	u32 start_val = 0;
++	struct rkvenc_dev *enc = to_rkvenc_dev(mpp);
++	struct rkvenc_task *task = to_rkvenc_task(mpp_task);
++	struct rkvenc_hw_info *hw = enc->hw_info;
++
++	mpp_debug_enter();
++
++	/* Add force clear to avoid pagefault */
++	mpp_write(mpp, hw->enc_clr_base, 0x2);
++	udelay(5);
++	mpp_write(mpp, hw->enc_clr_base, 0x0);
++
++	/* clear hardware counter */
++	mpp_write_relaxed(mpp, 0x5300, 0x2);
++
++	rkvenc2_patch_dchs(enc, task);
++
++	for (i = 0; i < task->w_req_cnt; i++) {
++		int ret;
++		u32 s, e, off;
++		u32 *regs;
++
++		struct mpp_request msg;
++		struct mpp_request *req = &task->w_reqs[i];
++
++		ret = rkvenc_get_class_msg(task, req->offset, &msg);
++		if (ret)
++			return -EINVAL;
++
++		s = (req->offset - msg.offset) / sizeof(u32);
++		e = s + req->size / sizeof(u32);
++		regs = (u32 *)msg.data;
++		for (j = s; j < e; j++) {
++			off = msg.offset + j * sizeof(u32);
++			if (off == enc->hw_info->enc_start_base) {
++				start_val = regs[j];
++				continue;
++			}
++			mpp_write_relaxed(mpp, off, regs[j]);
++		}
++	}
++
++	if (mpp_debug_unlikely(DEBUG_CORE))
++		dev_info(mpp->dev, "core %d dchs %08x\n", mpp->core_id,
++			 mpp_read_relaxed(&enc->mpp, DCHS_REG_OFFSET));
++
++	/* flush tlb before starting hardware */
++	mpp_iommu_flush_tlb(mpp->iommu_info);
++
++	/* init current task */
++	mpp->cur_task = mpp_task;
++
++	/* Flush the register before the start the device */
++	wmb();
++	mpp_write(mpp, enc->hw_info->enc_start_base, start_val);
++
++	mpp_debug_leave();
++
++	return 0;
++}
++
++static void rkvenc2_read_slice_len(struct mpp_dev *mpp, struct rkvenc_task *task)
++{
++	u32 last = mpp_read_relaxed(mpp, 0x002c) & INT_STA_ENC_DONE_STA;
++	u32 sli_num = mpp_read_relaxed(mpp, RKVENC2_REG_SLICE_NUM_BASE);
++	union rkvenc2_slice_len_info slice_info;
++	u32 task_id = task->mpp_task.task_id;
++	u32 i;
++
++	mpp_dbg_slice("task %d wr %3d len start %s\n", task_id,
++		      sli_num, last ? "last" : "");
++
++	for (i = 0; i < sli_num; i++) {
++		slice_info.val = mpp_read_relaxed(mpp, RKVENC2_REG_SLICE_LEN_BASE);
++
++		if (last && i == sli_num - 1) {
++			task->last_slice_found = 1;
++			slice_info.last = 1;
++		}
++
++		mpp_dbg_slice("task %d wr %3d len %d %s\n", task_id,
++			      task->slice_wr_cnt, slice_info.slice_len,
++			      slice_info.last ? "last" : "");
++
++		kfifo_in(&task->slice_info, &slice_info, 1);
++		task->slice_wr_cnt++;
++	}
++
++	/* Fixup for async between last flag and slice number register */
++	if (last && !task->last_slice_found) {
++		mpp_dbg_slice("task %d mark last slice\n", task_id);
++		slice_info.last = 1;
++		slice_info.slice_len = 0;
++		kfifo_in(&task->slice_info, &slice_info, 1);
++	}
++}
++
++static int rkvenc_irq(struct mpp_dev *mpp)
++{
++	struct rkvenc_dev *enc = to_rkvenc_dev(mpp);
++	struct rkvenc_hw_info *hw = enc->hw_info;
++	struct mpp_task *mpp_task = NULL;
++	struct rkvenc_task *task = NULL;
++	int ret = IRQ_NONE;
++
++	mpp_debug_enter();
++
++	mpp->irq_status = mpp_read(mpp, hw->int_sta_base);
++	if (!mpp->irq_status)
++		return ret;
++
++	if (mpp->cur_task) {
++		mpp_task = mpp->cur_task;
++		task = to_rkvenc_task(mpp_task);
++	}
++
++	if (mpp->irq_status & INT_STA_ENC_DONE_STA) {
++		if (task) {
++			if (task->task_split)
++				rkvenc2_read_slice_len(mpp, task);
++
++			wake_up(&mpp_task->wait);
++		}
++
++		mpp_write(mpp, hw->int_mask_base, 0x100);
++		mpp_write(mpp, hw->int_clr_base, 0xffffffff);
++		udelay(5);
++		mpp_write(mpp, hw->int_sta_base, 0);
++
++		ret = IRQ_WAKE_THREAD;
++	} else if (mpp->irq_status & INT_STA_SLC_DONE_STA) {
++		if (task && task->task_split) {
++			mpp_time_part_diff(mpp_task);
++
++			rkvenc2_read_slice_len(mpp, task);
++			wake_up(&mpp_task->wait);
++		}
++
++		mpp_write(mpp, hw->int_clr_base, INT_STA_SLC_DONE_STA);
++	}
++
++	mpp_debug_leave();
++
++	return ret;
++}
++
++static int rkvenc_isr(struct mpp_dev *mpp)
++{
++	struct rkvenc_task *task;
++	struct mpp_task *mpp_task;
++	struct rkvenc_dev *enc = to_rkvenc_dev(mpp);
++	struct mpp_taskqueue *queue = mpp->queue;
++	unsigned long core_idle;
++
++	mpp_debug_enter();
++
++	/* FIXME use a spin lock here */
++	if (!mpp->cur_task) {
++		dev_err(mpp->dev, "no current task\n");
++		return IRQ_HANDLED;
++	}
++
++	mpp_task = mpp->cur_task;
++	mpp_time_diff(mpp_task);
++	mpp->cur_task = NULL;
++
++	if (mpp_task->mpp && mpp_task->mpp != mpp)
++		dev_err(mpp->dev, "mismatch core dev %p:%p\n", mpp_task->mpp, mpp);
++
++	task = to_rkvenc_task(mpp_task);
++	task->irq_status = mpp->irq_status;
++
++	rkvenc2_update_dchs(enc, task);
++
++	mpp_debug(DEBUG_IRQ_STATUS, "%s irq_status: %08x\n",
++		  dev_name(mpp->dev), task->irq_status);
++
++	if (task->irq_status & enc->hw_info->err_mask) {
++		atomic_inc(&mpp->reset_request);
++		/* dump register */
++
++		mpp_task_dump_hw_reg(mpp);
++	}
++	mpp_task_finish(mpp_task->session, mpp_task);
++
++	core_idle = queue->core_idle;
++	set_bit(mpp->core_id, &queue->core_idle);
++
++	mpp_dbg_core("core %d isr idle %lx -> %lx\n", mpp->core_id, core_idle,
++		     queue->core_idle);
++
++	mpp_debug_leave();
++
++	return IRQ_HANDLED;
++}
++
++static int rkvenc_finish(struct mpp_dev *mpp, struct mpp_task *mpp_task)
++{
++	u32 i, j;
++	u32 *reg;
++	struct rkvenc_task *task = to_rkvenc_task(mpp_task);
++
++	mpp_debug_enter();
++
++	for (i = 0; i < task->r_req_cnt; i++) {
++		int ret;
++		int s, e;
++		struct mpp_request msg;
++		struct mpp_request *req = &task->r_reqs[i];
++
++		ret = rkvenc_get_class_msg(task, req->offset, &msg);
++		if (ret)
++			return -EINVAL;
++		s = (req->offset - msg.offset) / sizeof(u32);
++		e = s + req->size / sizeof(u32);
++		reg = (u32 *)msg.data;
++		for (j = s; j < e; j++)
++			reg[j] = mpp_read_relaxed(mpp, msg.offset + j * sizeof(u32));
++
++	}
++
++	/* revert hack for irq status */
++	reg = rkvenc_get_class_reg(task, task->hw_info->int_sta_base);
++	if (reg)
++		*reg = task->irq_status;
++
++	mpp_debug_leave();
++
++	return 0;
++}
++
++static int rkvenc_result(struct mpp_dev *mpp,
++			 struct mpp_task *mpp_task,
++			 struct mpp_task_msgs *msgs)
++{
++	u32 i;
++	struct rkvenc_task *task = to_rkvenc_task(mpp_task);
++
++	mpp_debug_enter();
++
++	for (i = 0; i < task->r_req_cnt; i++) {
++		struct mpp_request *req = &task->r_reqs[i];
++		u32 *reg = rkvenc_get_class_reg(task, req->offset);
++
++		if (!reg)
++			return -EINVAL;
++		if (copy_to_user(req->data, reg, req->size)) {
++			mpp_err("copy_to_user reg fail\n");
++			return -EIO;
++		}
++	}
++
++	mpp_debug_leave();
++
++	return 0;
++}
++
++static int rkvenc_free_task(struct mpp_session *session,
++			    struct mpp_task *mpp_task)
++{
++	struct rkvenc_task *task = to_rkvenc_task(mpp_task);
++
++	mpp_task_finalize(session, mpp_task);
++	rkvenc_free_class_msg(task);
++	kfree(task);
++
++	return 0;
++}
++
++static int rkvenc_control(struct mpp_session *session, struct mpp_request *req)
++{
++	switch (req->cmd) {
++	case MPP_CMD_SEND_CODEC_INFO: {
++		int i;
++		int cnt;
++		struct codec_info_elem elem;
++		struct rkvenc2_session_priv *priv;
++
++		if (!session || !session->priv) {
++			mpp_err("session info null\n");
++			return -EINVAL;
++		}
++		priv = session->priv;
++
++		cnt = req->size / sizeof(elem);
++		cnt = (cnt > ENC_INFO_BUTT) ? ENC_INFO_BUTT : cnt;
++		mpp_debug(DEBUG_IOCTL, "codec info count %d\n", cnt);
++		for (i = 0; i < cnt; i++) {
++			if (copy_from_user(&elem, req->data + i * sizeof(elem), sizeof(elem))) {
++				mpp_err("copy_from_user failed\n");
++				continue;
++			}
++			if (elem.type > ENC_INFO_BASE && elem.type < ENC_INFO_BUTT &&
++			    elem.flag > CODEC_INFO_FLAG_NULL && elem.flag < CODEC_INFO_FLAG_BUTT) {
++				elem.type = array_index_nospec(elem.type, ENC_INFO_BUTT);
++				priv->codec_info[elem.type].flag = elem.flag;
++				priv->codec_info[elem.type].val = elem.data;
++			} else {
++				mpp_err("codec info invalid, type %d, flag %d\n",
++					elem.type, elem.flag);
++			}
++		}
++	} break;
++	default: {
++		mpp_err("unknown mpp ioctl cmd %x\n", req->cmd);
++	} break;
++	}
++
++	return 0;
++}
++
++static int rkvenc_free_session(struct mpp_session *session)
++{
++	if (session && session->priv) {
++		kfree(session->priv);
++		session->priv = NULL;
++	}
++
++	return 0;
++}
++
++static int rkvenc_init_session(struct mpp_session *session)
++{
++	struct rkvenc2_session_priv *priv;
++
++	if (!session) {
++		mpp_err("session is null\n");
++		return -EINVAL;
++	}
++
++	priv = kzalloc(sizeof(*priv), GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++
++	init_rwsem(&priv->rw_sem);
++	session->priv = priv;
++
++	return 0;
++}
++
++#ifdef CONFIG_ROCKCHIP_MPP_PROC_FS
++static int rkvenc_procfs_remove(struct mpp_dev *mpp)
++{
++	struct rkvenc_dev *enc = to_rkvenc_dev(mpp);
++
++	if (enc->procfs) {
++		proc_remove(enc->procfs);
++		enc->procfs = NULL;
++	}
++
++	return 0;
++}
++
++static int rkvenc_dump_session(struct mpp_session *session, struct seq_file *seq)
++{
++	int i;
++	struct rkvenc2_session_priv *priv = session->priv;
++
++	down_read(&priv->rw_sem);
++	/* item name */
++	seq_puts(seq, "------------------------------------------------------");
++	seq_puts(seq, "------------------------------------------------------\n");
++	seq_printf(seq, "|%8s|", (const char *)"session");
++	seq_printf(seq, "%8s|", (const char *)"device");
++	for (i = ENC_INFO_BASE; i < ENC_INFO_BUTT; i++) {
++		bool show = priv->codec_info[i].flag;
++
++		if (show)
++			seq_printf(seq, "%8s|", enc_info_item_name[i]);
++	}
++	seq_puts(seq, "\n");
++	/* item data*/
++	seq_printf(seq, "|%8p|", session);
++	seq_printf(seq, "%8s|", mpp_device_name[session->device_type]);
++	for (i = ENC_INFO_BASE; i < ENC_INFO_BUTT; i++) {
++		u32 flag = priv->codec_info[i].flag;
++
++		if (!flag)
++			continue;
++		if (flag == CODEC_INFO_FLAG_NUMBER) {
++			u32 data = priv->codec_info[i].val;
++
++			seq_printf(seq, "%8d|", data);
++		} else if (flag == CODEC_INFO_FLAG_STRING) {
++			const char *name = (const char *)&priv->codec_info[i].val;
++
++			seq_printf(seq, "%8s|", name);
++		} else {
++			seq_printf(seq, "%8s|", (const char *)"null");
++		}
++	}
++	seq_puts(seq, "\n");
++	up_read(&priv->rw_sem);
++
++	return 0;
++}
++
++static int rkvenc_show_session_info(struct seq_file *seq, void *offset)
++{
++	struct mpp_session *session = NULL, *n;
++	struct mpp_dev *mpp = seq->private;
++
++	mutex_lock(&mpp->srv->session_lock);
++	list_for_each_entry_safe(session, n,
++				 &mpp->srv->session_list,
++				 session_link) {
++		if (session->device_type != MPP_DEVICE_RKVENC)
++			continue;
++		if (!session->priv)
++			continue;
++		if (mpp->dev_ops->dump_session)
++			mpp->dev_ops->dump_session(session, seq);
++	}
++	mutex_unlock(&mpp->srv->session_lock);
++
++	return 0;
++}
++
++static int rkvenc_procfs_init(struct mpp_dev *mpp)
++{
++	struct rkvenc_dev *enc = to_rkvenc_dev(mpp);
++	char name[32];
++
++	if (!mpp->dev || !mpp->dev->of_node || !mpp->dev->of_node->name ||
++	    !mpp->srv || !mpp->srv->procfs)
++		return -EINVAL;
++
++	snprintf(name, sizeof(name) - 1, "%s%d",
++		 mpp->dev->of_node->name, mpp->core_id);
++
++	enc->procfs = proc_mkdir(name, mpp->srv->procfs);
++	if (IS_ERR_OR_NULL(enc->procfs)) {
++		mpp_err("failed on open procfs\n");
++		enc->procfs = NULL;
++		return -EIO;
++	}
++	/* for debug */
++	mpp_procfs_create_u32("aclk", 0644,
++			      enc->procfs, &enc->aclk_info.debug_rate_hz);
++	mpp_procfs_create_u32("clk_core", 0644,
++			      enc->procfs, &enc->core_clk_info.debug_rate_hz);
++	mpp_procfs_create_u32("session_buffers", 0644,
++			      enc->procfs, &mpp->session_max_buffers);
++	/* for show session info */
++	proc_create_single_data("sessions-info", 0444,
++				enc->procfs, rkvenc_show_session_info, mpp);
++
++	return 0;
++}
++
++static int rkvenc_procfs_ccu_init(struct mpp_dev *mpp)
++{
++	struct rkvenc_dev *enc = to_rkvenc_dev(mpp);
++
++	if (!enc->procfs)
++		goto done;
++
++	mpp_procfs_create_u32("disable_work", 0644,
++			      enc->procfs, &enc->disable_work);
++done:
++	return 0;
++}
++#else
++static inline int rkvenc_procfs_remove(struct mpp_dev *mpp)
++{
++	return 0;
++}
++
++static inline int rkvenc_procfs_init(struct mpp_dev *mpp)
++{
++	return 0;
++}
++
++static inline int rkvenc_procfs_ccu_init(struct mpp_dev *mpp)
++{
++	return 0;
++}
++#endif
++
++static int rkvenc_init(struct mpp_dev *mpp)
++{
++	struct rkvenc_dev *enc = to_rkvenc_dev(mpp);
++	int ret = 0;
++
++	mpp->grf_info = &mpp->srv->grf_infos[MPP_DRIVER_RKVENC];
++
++	/* Get clock info from dtsi */
++	ret = mpp_get_clk_info(mpp, &enc->aclk_info, "aclk_vcodec");
++	if (ret)
++		mpp_err("failed on clk_get aclk_vcodec\n");
++	ret = mpp_get_clk_info(mpp, &enc->hclk_info, "hclk_vcodec");
++	if (ret)
++		mpp_err("failed on clk_get hclk_vcodec\n");
++	ret = mpp_get_clk_info(mpp, &enc->core_clk_info, "clk_core");
++	if (ret)
++		mpp_err("failed on clk_get clk_core\n");
++	/* Get normal max workload from dtsi */
++	of_property_read_u32(mpp->dev->of_node,
++			     "rockchip,default-max-load",
++			     &enc->default_max_load);
++	/* Set default rates */
++	mpp_set_clk_info_rate_hz(&enc->aclk_info, CLK_MODE_DEFAULT, 300 * MHZ);
++	mpp_set_clk_info_rate_hz(&enc->core_clk_info, CLK_MODE_DEFAULT, 600 * MHZ);
++
++	/* Get reset control from dtsi */
++	enc->rst_a = mpp_reset_control_get(mpp, RST_TYPE_A, "video_a");
++	if (!enc->rst_a)
++		mpp_err("No aclk reset resource define\n");
++	enc->rst_h = mpp_reset_control_get(mpp, RST_TYPE_H, "video_h");
++	if (!enc->rst_h)
++		mpp_err("No hclk reset resource define\n");
++	enc->rst_core = mpp_reset_control_get(mpp, RST_TYPE_CORE, "video_core");
++	if (!enc->rst_core)
++		mpp_err("No core reset resource define\n");
++
++	return 0;
++}
++
++static int rkvenc_reset(struct mpp_dev *mpp)
++{
++	struct rkvenc_dev *enc = to_rkvenc_dev(mpp);
++	struct rkvenc_hw_info *hw = enc->hw_info;
++	struct mpp_taskqueue *queue = mpp->queue;
++
++	mpp_debug_enter();
++
++	/* safe reset */
++	mpp_write(mpp, hw->int_mask_base, 0x3FF);
++	mpp_write(mpp, hw->enc_clr_base, 0x1);
++	udelay(5);
++	mpp_write(mpp, hw->int_clr_base, 0xffffffff);
++	mpp_write(mpp, hw->int_sta_base, 0);
++
++	/* cru reset */
++	if (enc->rst_a && enc->rst_h && enc->rst_core) {
++		mpp_pmu_idle_request(mpp, true);
++		mpp_safe_reset(enc->rst_a);
++		mpp_safe_reset(enc->rst_h);
++		mpp_safe_reset(enc->rst_core);
++		udelay(5);
++		mpp_safe_unreset(enc->rst_a);
++		mpp_safe_unreset(enc->rst_h);
++		mpp_safe_unreset(enc->rst_core);
++		mpp_pmu_idle_request(mpp, false);
++	}
++
++	set_bit(mpp->core_id, &queue->core_idle);
++	if (enc->ccu)
++		enc->ccu->dchs[mpp->core_id].val = 0;
++
++	mpp_dbg_core("core %d reset idle %lx\n", mpp->core_id, queue->core_idle);
++
++	mpp_debug_leave();
++
++	return 0;
++}
++
++static int rkvenc_clk_on(struct mpp_dev *mpp)
++{
++	struct rkvenc_dev *enc = to_rkvenc_dev(mpp);
++
++	mpp_clk_safe_enable(enc->aclk_info.clk);
++	mpp_clk_safe_enable(enc->hclk_info.clk);
++	mpp_clk_safe_enable(enc->core_clk_info.clk);
++
++	return 0;
++}
++
++static int rkvenc_clk_off(struct mpp_dev *mpp)
++{
++	struct rkvenc_dev *enc = to_rkvenc_dev(mpp);
++
++	clk_disable_unprepare(enc->aclk_info.clk);
++	clk_disable_unprepare(enc->hclk_info.clk);
++	clk_disable_unprepare(enc->core_clk_info.clk);
++
++	return 0;
++}
++
++static int rkvenc_set_freq(struct mpp_dev *mpp, struct mpp_task *mpp_task)
++{
++	struct rkvenc_dev *enc = to_rkvenc_dev(mpp);
++	struct rkvenc_task *task = to_rkvenc_task(mpp_task);
++
++	mpp_clk_set_rate(&enc->aclk_info, task->clk_mode);
++	mpp_clk_set_rate(&enc->core_clk_info, task->clk_mode);
++
++	return 0;
++}
++
++#define RKVENC2_WORK_TIMEOUT_DELAY		(200)
++#define RKVENC2_WAIT_TIMEOUT_DELAY		(2000)
++
++static void rkvenc2_task_pop_pending(struct mpp_task *task)
++{
++	struct mpp_session *session = task->session;
++
++	mutex_lock(&session->pending_lock);
++	list_del_init(&task->pending_link);
++	mutex_unlock(&session->pending_lock);
++
++	kref_put(&task->ref, mpp_free_task);
++}
++
++static int rkvenc2_task_default_process(struct mpp_dev *mpp,
++					struct mpp_task *task)
++{
++	int ret = 0;
++
++	if (mpp->dev_ops && mpp->dev_ops->result)
++		ret = mpp->dev_ops->result(mpp, task, NULL);
++
++	mpp_debug_func(DEBUG_TASK_INFO, "kref_read %d, ret %d\n",
++			kref_read(&task->ref), ret);
++
++	rkvenc2_task_pop_pending(task);
++
++	return ret;
++}
++
++#define RKVENC2_TIMEOUT_DUMP_REG_START	(0x5100)
++#define RKVENC2_TIMEOUT_DUMP_REG_END	(0x5160)
++
++static void rkvenc2_task_timeout_process(struct mpp_session *session,
++					 struct mpp_task *task)
++{
++	atomic_inc(&task->abort_request);
++	set_bit(TASK_STATE_ABORT, &task->state);
++
++	mpp_err("session %d:%d count %d task %d ref %d timeout\n",
++		session->pid, session->index, atomic_read(&session->task_count),
++		task->task_id, kref_read(&task->ref));
++
++	if (task->mpp) {
++		struct mpp_dev *mpp = task->mpp;
++		u32 start = RKVENC2_TIMEOUT_DUMP_REG_START;
++		u32 end = RKVENC2_TIMEOUT_DUMP_REG_END;
++		u32 offset;
++
++		dev_err(mpp->dev, "core %d dump timeout status:\n", mpp->core_id);
++
++		for (offset = start; offset < end; offset += sizeof(u32))
++			mpp_reg_show(mpp, offset);
++	}
++
++	rkvenc2_task_pop_pending(task);
++}
++
++static int rkvenc2_wait_result(struct mpp_session *session,
++			       struct mpp_task_msgs *msgs)
++{
++	struct rkvenc_poll_slice_cfg cfg;
++	struct rkvenc_task *enc_task;
++	struct mpp_request *req;
++	struct mpp_task *task;
++	struct mpp_dev *mpp;
++	union rkvenc2_slice_len_info slice_info;
++	u32 task_id;
++	int ret = 0;
++
++	mutex_lock(&session->pending_lock);
++	task = list_first_entry_or_null(&session->pending_list,
++					struct mpp_task,
++					pending_link);
++	mutex_unlock(&session->pending_lock);
++	if (!task) {
++		mpp_err("session %p pending list is empty!\n", session);
++		return -EIO;
++	}
++
++	mpp = mpp_get_task_used_device(task, session);
++	enc_task = to_rkvenc_task(task);
++	task_id = task->task_id;
++
++	req = cmpxchg(&msgs->poll_req, msgs->poll_req, NULL);
++
++	if (!enc_task->task_split || enc_task->task_split_done) {
++task_done_ret:
++		ret = wait_event_timeout(task->wait,
++					 test_bit(TASK_STATE_DONE, &task->state),
++					 msecs_to_jiffies(RKVENC2_WAIT_TIMEOUT_DELAY));
++
++		if (ret > 0)
++			return rkvenc2_task_default_process(mpp, task);
++
++		rkvenc2_task_timeout_process(session, task);
++		return ret;
++	}
++
++	/* not slice return just wait all slice length */
++	if (!req) {
++		do {
++			ret = wait_event_timeout(task->wait,
++						 kfifo_out(&enc_task->slice_info, &slice_info, 1),
++						 msecs_to_jiffies(RKVENC2_WORK_TIMEOUT_DELAY));
++			if (ret > 0) {
++				mpp_dbg_slice("task %d rd %3d len %d %s\n",
++					      task_id, enc_task->slice_rd_cnt, slice_info.slice_len,
++					      slice_info.last ? "last" : "");
++
++				enc_task->slice_rd_cnt++;
++
++				if (slice_info.last)
++					goto task_done_ret;
++
++				continue;
++			}
++
++			rkvenc2_task_timeout_process(session, task);
++			return ret;
++		} while (1);
++	}
++
++	if (copy_from_user(&cfg, req->data, sizeof(cfg))) {
++		mpp_err("copy_from_user failed\n");
++		return -EINVAL;
++	}
++
++	mpp_dbg_slice("task %d poll irq %d:%d\n", task->task_id,
++		      cfg.count_max, cfg.count_ret);
++	cfg.count_ret = 0;
++
++	/* handle slice mode poll return */
++	ret = wait_event_timeout(task->wait,
++				 kfifo_out(&enc_task->slice_info, &slice_info, 1),
++				 msecs_to_jiffies(RKVENC2_WORK_TIMEOUT_DELAY));
++	if (ret > 0) {
++		mpp_dbg_slice("task %d rd %3d len %d %s\n", task_id,
++			      enc_task->slice_rd_cnt, slice_info.slice_len,
++			      slice_info.last ? "last" : "");
++
++		enc_task->slice_rd_cnt++;
++
++		if (cfg.count_ret < cfg.count_max) {
++			struct rkvenc_poll_slice_cfg __user *ucfg =
++				(struct rkvenc_poll_slice_cfg __user *)(req->data);
++			u32 __user *dst = (u32 __user *)(ucfg + 1);
++
++			/* Do NOT return here when put_user error. Just continue */
++			if (put_user(slice_info.val, dst + cfg.count_ret))
++				ret = -EFAULT;
++
++			cfg.count_ret++;
++			if (put_user(cfg.count_ret, &ucfg->count_ret))
++				ret = -EFAULT;
++		}
++
++		if (slice_info.last) {
++			enc_task->task_split_done = 1;
++			goto task_done_ret;
++		}
++
++		return ret < 0 ? ret : 0;
++	}
++
++	rkvenc2_task_timeout_process(session, task);
++
++	return ret;
++}
++
++static struct mpp_hw_ops rkvenc_hw_ops = {
++	.init = rkvenc_init,
++	.clk_on = rkvenc_clk_on,
++	.clk_off = rkvenc_clk_off,
++	.set_freq = rkvenc_set_freq,
++	.reset = rkvenc_reset,
++};
++
++static struct mpp_dev_ops rkvenc_dev_ops_v2 = {
++	.wait_result = rkvenc2_wait_result,
++	.alloc_task = rkvenc_alloc_task,
++	.run = rkvenc_run,
++	.irq = rkvenc_irq,
++	.isr = rkvenc_isr,
++	.finish = rkvenc_finish,
++	.result = rkvenc_result,
++	.free_task = rkvenc_free_task,
++	.ioctl = rkvenc_control,
++	.init_session = rkvenc_init_session,
++	.free_session = rkvenc_free_session,
++	.dump_session = rkvenc_dump_session,
++};
++
++static struct mpp_dev_ops rkvenc_ccu_dev_ops = {
++	.wait_result = rkvenc2_wait_result,
++	.alloc_task = rkvenc_alloc_task,
++	.prepare = rkvenc2_prepare,
++	.run = rkvenc_run,
++	.irq = rkvenc_irq,
++	.isr = rkvenc_isr,
++	.finish = rkvenc_finish,
++	.result = rkvenc_result,
++	.free_task = rkvenc_free_task,
++	.ioctl = rkvenc_control,
++	.init_session = rkvenc_init_session,
++	.free_session = rkvenc_free_session,
++	.dump_session = rkvenc_dump_session,
++};
++
++
++static const struct mpp_dev_var rkvenc_v2_data = {
++	.device_type = MPP_DEVICE_RKVENC,
++	.hw_info = &rkvenc_v2_hw_info.hw,
++	.trans_info = trans_rkvenc_v2,
++	.hw_ops = &rkvenc_hw_ops,
++	.dev_ops = &rkvenc_dev_ops_v2,
++};
++
++static const struct mpp_dev_var rkvenc_ccu_data = {
++	.device_type = MPP_DEVICE_RKVENC,
++	.hw_info = &rkvenc_v2_hw_info.hw,
++	.trans_info = trans_rkvenc_v2,
++	.hw_ops = &rkvenc_hw_ops,
++	.dev_ops = &rkvenc_ccu_dev_ops,
++};
++
++static const struct of_device_id mpp_rkvenc_dt_match[] = {
++	{
++		.compatible = "rockchip,rkv-encoder-v2",
++		.data = &rkvenc_v2_data,
++	},
++	{
++		.compatible = "rockchip,rkv-encoder-v2-core",
++		.data = &rkvenc_ccu_data,
++	},
++	{
++		.compatible = "rockchip,rkv-encoder-v2-ccu",
++	},
++	{},
++};
++
++static int rkvenc_ccu_probe(struct platform_device *pdev)
++{
++	struct rkvenc_ccu *ccu;
++	struct device *dev = &pdev->dev;
++
++	ccu = devm_kzalloc(dev, sizeof(*ccu), GFP_KERNEL);
++	if (!ccu)
++		return -ENOMEM;
++
++	platform_set_drvdata(pdev, ccu);
++
++	mutex_init(&ccu->lock);
++	INIT_LIST_HEAD(&ccu->core_list);
++	spin_lock_init(&ccu->lock_dchs);
++
++	return 0;
++}
++
++static int rkvenc_attach_ccu(struct device *dev, struct rkvenc_dev *enc)
++{
++	struct device_node *np;
++	struct platform_device *pdev;
++	struct rkvenc_ccu *ccu;
++
++	mpp_debug_enter();
++
++	np = of_parse_phandle(dev->of_node, "rockchip,ccu", 0);
++	if (!np || !of_device_is_available(np))
++		return -ENODEV;
++
++	pdev = of_find_device_by_node(np);
++	of_node_put(np);
++	if (!pdev)
++		return -ENODEV;
++
++	ccu = platform_get_drvdata(pdev);
++	if (!ccu)
++		return -ENOMEM;
++
++	INIT_LIST_HEAD(&enc->core_link);
++	mutex_lock(&ccu->lock);
++	ccu->core_num++;
++	list_add_tail(&enc->core_link, &ccu->core_list);
++	mutex_unlock(&ccu->lock);
++
++	/* attach the ccu-domain to current core */
++	if (!ccu->main_core) {
++		/**
++		 * set the first device for the main-core,
++		 * then the domain of the main-core named ccu-domain
++		 */
++		ccu->main_core = &enc->mpp;
++	} else {
++		struct mpp_iommu_info *ccu_info, *cur_info;
++
++		/* set the ccu-domain for current device */
++		ccu_info = ccu->main_core->iommu_info;
++		cur_info = enc->mpp.iommu_info;
++
++		cur_info->domain = ccu_info->domain;
++		cur_info->rw_sem = ccu_info->rw_sem;
++		mpp_iommu_attach(cur_info);
++
++		/* increase main core message capacity */
++		ccu->main_core->msgs_cap++;
++		enc->mpp.msgs_cap = 0;
++	}
++	enc->ccu = ccu;
++
++	dev_info(dev, "attach ccu as core %d\n", enc->mpp.core_id);
++	mpp_debug_enter();
++
++	return 0;
++}
++
++static int rkvenc2_alloc_rcbbuf(struct platform_device *pdev, struct rkvenc_dev *enc)
++{
++#if 0
++	// iommu_dma_reserve_iova() is missing upstream, also the DT nodes sre imported
++	// from Rockchip's tree does not define rockchip,rcb-iova property, so this can
++	// just error out early.
++
++	int ret;
++	u32 vals[2];
++	dma_addr_t iova;
++	u32 sram_used, sram_size;
++	struct device_node *sram_np;
++	struct resource sram_res;
++	resource_size_t sram_start, sram_end;
++	struct iommu_domain *domain;
++	struct device *dev = &pdev->dev;
++
++	/* get rcb iova start and size */
++	ret = device_property_read_u32_array(dev, "rockchip,rcb-iova", vals, 2);
++	if (ret)
++		return ret;
++
++	iova = PAGE_ALIGN(vals[0]);
++	sram_used = PAGE_ALIGN(vals[1]);
++	if (!sram_used) {
++		dev_err(dev, "sram rcb invalid.\n");
++		return -EINVAL;
++	}
++	/* alloc reserve iova for rcb */
++	ret = iommu_dma_reserve_iova(dev, iova, sram_used);
++	if (ret) {
++		dev_err(dev, "alloc rcb iova error.\n");
++		return ret;
++	}
++	/* get sram device node */
++	sram_np = of_parse_phandle(dev->of_node, "rockchip,sram", 0);
++	if (!sram_np) {
++		dev_err(dev, "could not find phandle sram\n");
++		return -ENODEV;
++	}
++	/* get sram start and size */
++	ret = of_address_to_resource(sram_np, 0, &sram_res);
++	of_node_put(sram_np);
++	if (ret) {
++		dev_err(dev, "find sram res error\n");
++		return ret;
++	}
++	/* check sram start and size is PAGE_SIZE align */
++	sram_start = round_up(sram_res.start, PAGE_SIZE);
++	sram_end = round_down(sram_res.start + resource_size(&sram_res), PAGE_SIZE);
++	if (sram_end <= sram_start) {
++		dev_err(dev, "no available sram, phy_start %pa, phy_end %pa\n",
++			&sram_start, &sram_end);
++		return -ENOMEM;
++	}
++	sram_size = sram_end - sram_start;
++	sram_size = sram_used < sram_size ? sram_used : sram_size;
++	/* iova map to sram */
++	domain = enc->mpp.iommu_info->domain;
++	ret = iommu_map(domain, iova, sram_start, sram_size, IOMMU_READ | IOMMU_WRITE, GFP_DMA);
++	if (ret) {
++		dev_err(dev, "sram iommu_map error.\n");
++		return ret;
++	}
++	/* alloc dma for the remaining buffer, sram + dma */
++	if (sram_size < sram_used) {
++		struct page *page;
++		size_t page_size = PAGE_ALIGN(sram_used - sram_size);
++
++		page = alloc_pages(GFP_KERNEL | __GFP_ZERO, get_order(page_size));
++		if (!page) {
++			dev_err(dev, "unable to allocate pages\n");
++			ret = -ENOMEM;
++			goto err_sram_map;
++		}
++		/* iova map to dma */
++		ret = iommu_map(domain, iova + sram_size, page_to_phys(page),
++				page_size, IOMMU_READ | IOMMU_WRITE, GFP_DMA);
++		if (ret) {
++			dev_err(dev, "page iommu_map error.\n");
++			__free_pages(page, get_order(page_size));
++			goto err_sram_map;
++		}
++		enc->rcb_page = page;
++	}
++
++	enc->sram_size = sram_size;
++	enc->sram_used = sram_used;
++	enc->sram_iova = iova;
++	enc->sram_enabled = -1;
++	dev_info(dev, "sram_start %pa\n", &sram_start);
++	dev_info(dev, "sram_iova %pad\n", &enc->sram_iova);
++	dev_info(dev, "sram_size %u\n", enc->sram_size);
++	dev_info(dev, "sram_used %u\n", enc->sram_used);
++
++	return 0;
++
++err_sram_map:
++	iommu_unmap(domain, iova, sram_size);
++#else
++	int ret = -EINVAL;
++
++	dev_warn(&pdev->dev, "missing SRAM support\n");
++#endif
++
++	return ret;
++}
++
++static int rkvenc2_iommu_fault_handle(struct iommu_domain *iommu,
++				      struct device *iommu_dev,
++				      unsigned long iova, int status, void *arg)
++{
++	struct mpp_dev *mpp = (struct mpp_dev *)arg;
++	struct rkvenc_dev *enc = to_rkvenc_dev(mpp);
++	struct mpp_task *mpp_task = mpp->cur_task;
++
++	dev_info(mpp->dev, "core %d page fault found dchs %08x\n",
++		 mpp->core_id, mpp_read_relaxed(&enc->mpp, DCHS_REG_OFFSET));
++
++	if (mpp_task)
++		mpp_task_dump_mem_region(mpp, mpp_task);
++
++	return 0;
++}
++
++static int rkvenc_core_probe(struct platform_device *pdev)
++{
++	int ret = 0;
++	struct device *dev = &pdev->dev;
++	struct rkvenc_dev *enc = NULL;
++	struct mpp_dev *mpp = NULL;
++
++	enc = devm_kzalloc(dev, sizeof(*enc), GFP_KERNEL);
++	if (!enc)
++		return -ENOMEM;
++
++	mpp = &enc->mpp;
++	platform_set_drvdata(pdev, mpp);
++
++	if (pdev->dev.of_node) {
++		struct device_node *np = pdev->dev.of_node;
++		const struct of_device_id *match = NULL;
++
++		match = of_match_node(mpp_rkvenc_dt_match, np);
++		if (match)
++			mpp->var = (struct mpp_dev_var *)match->data;
++
++		mpp->core_id = of_alias_get_id(np, "rkvenc");
++	}
++
++	ret = mpp_dev_probe(mpp, pdev);
++	if (ret)
++		return ret;
++
++	if (!mpp->iommu_info)
++		return -ENODEV;
++
++	rkvenc2_alloc_rcbbuf(pdev, enc);
++
++	/* attach core to ccu */
++	ret = rkvenc_attach_ccu(dev, enc);
++	if (ret) {
++		dev_err(dev, "attach ccu failed\n");
++		return ret;
++	}
++
++	ret = devm_request_threaded_irq(dev, mpp->irq,
++					mpp_dev_irq,
++					mpp_dev_isr_sched,
++					IRQF_SHARED,
++					dev_name(dev), mpp);
++	if (ret) {
++		dev_err(dev, "register interrupter runtime failed\n");
++		return -EINVAL;
++	}
++	mpp->session_max_buffers = RKVENC_SESSION_MAX_BUFFERS;
++	enc->hw_info = to_rkvenc_info(mpp->var->hw_info);
++	mpp->iommu_info->hdl = rkvenc2_iommu_fault_handle;
++	rkvenc_procfs_init(mpp);
++	rkvenc_procfs_ccu_init(mpp);
++
++	/* if current is main-core, register current device to mpp service */
++	if (mpp == enc->ccu->main_core)
++		mpp_dev_register_srv(mpp, mpp->srv);
++
++	return 0;
++}
++
++static int rkvenc_probe_default(struct platform_device *pdev)
++{
++	int ret = 0;
++	struct device *dev = &pdev->dev;
++	struct rkvenc_dev *enc = NULL;
++	struct mpp_dev *mpp = NULL;
++	const struct of_device_id *match = NULL;
++
++	enc = devm_kzalloc(dev, sizeof(*enc), GFP_KERNEL);
++	if (!enc)
++		return -ENOMEM;
++
++	mpp = &enc->mpp;
++	platform_set_drvdata(pdev, mpp);
++
++	if (pdev->dev.of_node) {
++		match = of_match_node(mpp_rkvenc_dt_match, pdev->dev.of_node);
++		if (match)
++			mpp->var = (struct mpp_dev_var *)match->data;
++	}
++
++	ret = mpp_dev_probe(mpp, pdev);
++	if (ret)
++		return ret;
++
++	rkvenc2_alloc_rcbbuf(pdev, enc);
++
++	ret = devm_request_threaded_irq(dev, mpp->irq,
++					mpp_dev_irq,
++					mpp_dev_isr_sched,
++					IRQF_SHARED,
++					dev_name(dev), mpp);
++	if (ret) {
++		dev_err(dev, "register interrupter runtime failed\n");
++		goto failed_get_irq;
++	}
++	mpp->session_max_buffers = RKVENC_SESSION_MAX_BUFFERS;
++	enc->hw_info = to_rkvenc_info(mpp->var->hw_info);
++	rkvenc_procfs_init(mpp);
++	mpp_dev_register_srv(mpp, mpp->srv);
++
++	return 0;
++
++failed_get_irq:
++	mpp_dev_remove(mpp);
++
++	return ret;
++}
++
++static int rkvenc_probe(struct platform_device *pdev)
++{
++	int ret = 0;
++	struct device *dev = &pdev->dev;
++	struct device_node *np = dev->of_node;
++
++	dev_info(dev, "probing start\n");
++
++	if (strstr(np->name, "ccu"))
++		ret = rkvenc_ccu_probe(pdev);
++	else if (strstr(np->name, "core"))
++		ret = rkvenc_core_probe(pdev);
++	else
++		ret = rkvenc_probe_default(pdev);
++
++	dev_info(dev, "probing finish\n");
++
++	return ret;
++}
++
++static int rkvenc2_free_rcbbuf(struct platform_device *pdev, struct rkvenc_dev *enc)
++{
++	struct iommu_domain *domain;
++
++	if (enc->rcb_page) {
++		size_t page_size = PAGE_ALIGN(enc->sram_used - enc->sram_size);
++
++		__free_pages(enc->rcb_page, get_order(page_size));
++	}
++	if (enc->sram_iova) {
++		domain = enc->mpp.iommu_info->domain;
++		iommu_unmap(domain, enc->sram_iova, enc->sram_used);
++	}
++
++	return 0;
++}
++
++static int rkvenc_remove(struct platform_device *pdev)
++{
++	struct device *dev = &pdev->dev;
++	struct device_node *np = dev->of_node;
++
++	if (strstr(np->name, "ccu")) {
++		dev_info(dev, "remove ccu\n");
++	} else if (strstr(np->name, "core")) {
++		struct mpp_dev *mpp = dev_get_drvdata(dev);
++		struct rkvenc_dev *enc = to_rkvenc_dev(mpp);
++
++		dev_info(dev, "remove core\n");
++		if (enc->ccu) {
++			mutex_lock(&enc->ccu->lock);
++			list_del_init(&enc->core_link);
++			enc->ccu->core_num--;
++			mutex_unlock(&enc->ccu->lock);
++		}
++		rkvenc2_free_rcbbuf(pdev, enc);
++		mpp_dev_remove(&enc->mpp);
++		rkvenc_procfs_remove(&enc->mpp);
++	} else {
++		struct mpp_dev *mpp = dev_get_drvdata(dev);
++		struct rkvenc_dev *enc = to_rkvenc_dev(mpp);
++
++		dev_info(dev, "remove device\n");
++		rkvenc2_free_rcbbuf(pdev, enc);
++		mpp_dev_remove(mpp);
++		rkvenc_procfs_remove(mpp);
++	}
++
++	return 0;
++}
++
++static void rkvenc_shutdown(struct platform_device *pdev)
++{
++	struct device *dev = &pdev->dev;
++
++	if (!strstr(dev_name(dev), "ccu"))
++		mpp_dev_shutdown(pdev);
++}
++
++struct platform_driver rockchip_rkvenc2_driver = {
++	.probe = rkvenc_probe,
++	.remove = rkvenc_remove,
++	.shutdown = rkvenc_shutdown,
++	.driver = {
++		.name = RKVENC_DRIVER_NAME,
++		.of_match_table = of_match_ptr(mpp_rkvenc_dt_match),
++	},
++};
+diff --git a/drivers/video/rockchip/mpp/mpp_service.c b/drivers/video/rockchip/mpp/mpp_service.c
+new file mode 100644
+index 000000000000..9ccd1499dbc7
+--- /dev/null
++++ b/drivers/video/rockchip/mpp/mpp_service.c
+@@ -0,0 +1,497 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2019 Fuzhou Rockchip Electronics Co., Ltd
++ *
++ * author:
++ *	Alpha Lin, alpha.lin@rock-chips.com
++ *	Randy Li, randy.li@rock-chips.com
++ *	Ding Wei, leo.ding@rock-chips.com
++ *
++ */
++#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
++
++#include <linux/completion.h>
++#include <linux/delay.h>
++#include <linux/module.h>
++#include <linux/of_platform.h>
++#include <linux/proc_fs.h>
++#include <linux/seq_file.h>
++#include <linux/slab.h>
++#include <linux/nospec.h>
++#include <linux/mfd/syscon.h>
++
++#include "mpp_debug.h"
++#include "mpp_common.h"
++#include "mpp_iommu.h"
++
++#define MPP_CLASS_NAME		"mpp_class"
++#define MPP_SERVICE_NAME	"mpp_service"
++
++#define HAS_RKVDEC	IS_ENABLED(CONFIG_ROCKCHIP_MPP_RKVDEC)
++#define HAS_RKVENC	IS_ENABLED(CONFIG_ROCKCHIP_MPP_RKVENC)
++#define HAS_VDPU1	IS_ENABLED(CONFIG_ROCKCHIP_MPP_VDPU1)
++#define HAS_VEPU1	IS_ENABLED(CONFIG_ROCKCHIP_MPP_VEPU1)
++#define HAS_VDPU2	IS_ENABLED(CONFIG_ROCKCHIP_MPP_VDPU2)
++#define HAS_VEPU2	IS_ENABLED(CONFIG_ROCKCHIP_MPP_VEPU2)
++#define HAS_VEPU22	IS_ENABLED(CONFIG_ROCKCHIP_MPP_VEPU22)
++#define HAS_IEP2	IS_ENABLED(CONFIG_ROCKCHIP_MPP_IEP2)
++#define HAS_JPGDEC	IS_ENABLED(CONFIG_ROCKCHIP_MPP_JPGDEC)
++#define HAS_RKVDEC2	IS_ENABLED(CONFIG_ROCKCHIP_MPP_RKVDEC2)
++#define HAS_RKVENC2	IS_ENABLED(CONFIG_ROCKCHIP_MPP_RKVENC2)
++#define HAS_AV1DEC	IS_ENABLED(CONFIG_ROCKCHIP_MPP_AV1DEC)
++
++#define MPP_REGISTER_DRIVER(srv, flag, X, x) {\
++	if (flag)\
++		mpp_add_driver(srv, MPP_DRIVER_##X, &rockchip_##x##_driver, "grf_"#x);\
++	}
++
++unsigned int mpp_dev_debug;
++module_param(mpp_dev_debug, uint, 0644);
++MODULE_PARM_DESC(mpp_dev_debug, "bit switch for mpp debug information");
++
++static const char mpp_version[] = "unknown mpp version for missing VCS info";
++
++static int mpp_init_grf(struct device_node *np,
++			struct mpp_grf_info *grf_info,
++			const char *grf_name)
++{
++	int ret;
++	int index;
++	u32 grf_offset = 0;
++	u32 grf_value = 0;
++	struct regmap *grf;
++
++	grf = syscon_regmap_lookup_by_phandle(np, "rockchip,grf");
++	if (IS_ERR_OR_NULL(grf))
++		return -EINVAL;
++
++	ret = of_property_read_u32(np, "rockchip,grf-offset", &grf_offset);
++	if (ret)
++		return -ENODATA;
++
++	index = of_property_match_string(np, "rockchip,grf-names", grf_name);
++	if (index < 0)
++		return -ENODATA;
++
++	ret = of_property_read_u32_index(np, "rockchip,grf-values",
++					 index, &grf_value);
++	if (ret)
++		return -ENODATA;
++
++	grf_info->grf = grf;
++	grf_info->offset = grf_offset;
++	grf_info->val = grf_value;
++
++	mpp_set_grf(grf_info);
++
++	return 0;
++}
++
++static int mpp_add_driver(struct mpp_service *srv,
++			  enum MPP_DRIVER_TYPE type,
++			  struct platform_driver *driver,
++			  const char *grf_name)
++{
++	int ret;
++
++	mpp_init_grf(srv->dev->of_node,
++		     &srv->grf_infos[type],
++		     grf_name);
++
++	if (type == MPP_DRIVER_AV1DEC)
++		ret = av1dec_driver_register(driver);
++	else
++		ret = platform_driver_register(driver);
++	if (ret)
++		return ret;
++
++	srv->sub_drivers[type] = driver;
++
++	return 0;
++}
++
++static int mpp_remove_driver(struct mpp_service *srv, int i)
++{
++	if (srv && srv->sub_drivers[i]) {
++		if (i != MPP_DRIVER_AV1DEC) {
++			mpp_set_grf(&srv->grf_infos[i]);
++			platform_driver_unregister(srv->sub_drivers[i]);
++		}
++#if IS_ENABLED(CONFIG_ROCKCHIP_MPP_AV1DEC)
++		else
++			av1dec_driver_unregister(srv->sub_drivers[i]);
++#endif
++		srv->sub_drivers[i] = NULL;
++	}
++
++	return 0;
++}
++
++static int mpp_register_service(struct mpp_service *srv,
++				const char *service_name)
++{
++	int ret;
++	struct device *dev = srv->dev;
++
++	/* create a device */
++	ret = alloc_chrdev_region(&srv->dev_id, 0, 1, service_name);
++	if (ret) {
++		dev_err(dev, "alloc dev_t failed\n");
++		return ret;
++	}
++
++	cdev_init(&srv->mpp_cdev, &rockchip_mpp_fops);
++	srv->mpp_cdev.owner = THIS_MODULE;
++	srv->mpp_cdev.ops = &rockchip_mpp_fops;
++
++	ret = cdev_add(&srv->mpp_cdev, srv->dev_id, 1);
++	if (ret) {
++		unregister_chrdev_region(srv->dev_id, 1);
++		dev_err(dev, "add device failed\n");
++		return ret;
++	}
++
++	srv->child_dev = device_create(srv->cls, dev, srv->dev_id,
++				       NULL, "%s", service_name);
++
++	return 0;
++}
++
++static int mpp_remove_service(struct mpp_service *srv)
++{
++	device_destroy(srv->cls, srv->dev_id);
++	cdev_del(&srv->mpp_cdev);
++	unregister_chrdev_region(srv->dev_id, 1);
++
++	return 0;
++}
++
++#ifdef CONFIG_ROCKCHIP_MPP_PROC_FS
++static int mpp_procfs_remove(struct mpp_service *srv)
++{
++	if (srv->procfs) {
++		proc_remove(srv->procfs);
++		srv->procfs = NULL;
++	}
++
++	return 0;
++}
++
++static int mpp_show_version(struct seq_file *seq, void *offset)
++{
++	seq_printf(seq, "%s\n", mpp_version);
++
++	return 0;
++}
++
++static int mpp_dump_session(struct mpp_session *session, struct seq_file *s)
++{
++	struct mpp_dma_session *dma = session->dma;
++	struct mpp_dma_buffer *n;
++	struct mpp_dma_buffer *buffer;
++	phys_addr_t end;
++	unsigned long z = 0, t = 0;
++	int i = 0;
++#define K(size) ((unsigned long)((size) >> 10))
++
++	if (!dma)
++		return 0;
++
++	seq_puts(s, "session iova range dump:\n");
++
++	mutex_lock(&dma->list_mutex);
++	list_for_each_entry_safe(buffer, n, &dma->used_list, link) {
++		end = buffer->iova + buffer->size - 1;
++		z = (unsigned long)buffer->size;
++		t += z;
++
++		seq_printf(s, "%4d: ", i++);
++		seq_printf(s, "%pa..%pa (%10lu %s)\n", &buffer->iova, &end,
++			   (z >= 1024) ? (K(z)) : z,
++			   (z >= 1024) ? "KiB" : "Bytes");
++	}
++	i = 0;
++	list_for_each_entry_safe(buffer, n, &dma->unused_list, link) {
++		if (!buffer->dmabuf)
++			continue;
++
++		end = buffer->iova + buffer->size - 1;
++		z = (unsigned long)buffer->size;
++		t += z;
++
++		seq_printf(s, "%4d: ", i++);
++		seq_printf(s, "%pa..%pa (%10lu %s)\n", &buffer->iova, &end,
++			   (z >= 1024) ? (K(z)) : z,
++			   (z >= 1024) ? "KiB" : "Bytes");
++	}
++
++	mutex_unlock(&dma->list_mutex);
++	seq_printf(s, "session: pid=%d index=%d\n", session->pid, session->index);
++	seq_printf(s, " device: %s\n", dev_name(session->mpp->dev));
++	seq_printf(s, " memory: %lu MiB\n", K(K(t)));
++
++	return 0;
++}
++
++static int mpp_show_session_summary(struct seq_file *seq, void *offset)
++{
++	struct mpp_session *session = NULL, *n;
++	struct mpp_service *srv = seq->private;
++
++	mutex_lock(&srv->session_lock);
++	list_for_each_entry_safe(session, n,
++				 &srv->session_list,
++				 service_link) {
++		struct  mpp_dev *mpp;
++
++		if (!session->priv)
++			continue;
++
++		if (!session->mpp)
++			continue;
++		mpp = session->mpp;
++
++		mpp_dump_session(session, seq);
++
++		if (mpp->dev_ops->dump_session)
++			mpp->dev_ops->dump_session(session, seq);
++	}
++	mutex_unlock(&srv->session_lock);
++
++	return 0;
++}
++
++static int mpp_show_support_cmd(struct seq_file *file, void *v)
++{
++	seq_puts(file, "------------- SUPPORT CMD -------------\n");
++	seq_printf(file, "QUERY_HW_SUPPORT:     0x%08x\n", MPP_CMD_QUERY_HW_SUPPORT);
++	seq_printf(file, "QUERY_HW_ID:          0x%08x\n", MPP_CMD_QUERY_HW_ID);
++	seq_printf(file, "QUERY_CMD_SUPPORT:    0x%08x\n", MPP_CMD_QUERY_CMD_SUPPORT);
++	seq_printf(file, "QUERY_BUTT:           0x%08x\n", MPP_CMD_QUERY_BUTT);
++	seq_puts(file, "----\n");
++	seq_printf(file, "INIT_CLIENT_TYPE:     0x%08x\n", MPP_CMD_INIT_CLIENT_TYPE);
++	seq_printf(file, "INIT_TRANS_TABLE:     0x%08x\n", MPP_CMD_INIT_TRANS_TABLE);
++	seq_printf(file, "INIT_BUTT:            0x%08x\n", MPP_CMD_INIT_BUTT);
++	seq_puts(file, "----\n");
++	seq_printf(file, "SET_REG_WRITE:        0x%08x\n", MPP_CMD_SET_REG_WRITE);
++	seq_printf(file, "SET_REG_READ:         0x%08x\n", MPP_CMD_SET_REG_READ);
++	seq_printf(file, "SET_REG_ADDR_OFFSET:  0x%08x\n", MPP_CMD_SET_REG_ADDR_OFFSET);
++	seq_printf(file, "SEND_BUTT:            0x%08x\n", MPP_CMD_SEND_BUTT);
++	seq_puts(file, "----\n");
++	seq_printf(file, "POLL_HW_FINISH:       0x%08x\n", MPP_CMD_POLL_HW_FINISH);
++	seq_printf(file, "POLL_BUTT:            0x%08x\n", MPP_CMD_POLL_BUTT);
++	seq_puts(file, "----\n");
++	seq_printf(file, "RESET_SESSION:        0x%08x\n", MPP_CMD_RESET_SESSION);
++	seq_printf(file, "TRANS_FD_TO_IOVA:     0x%08x\n", MPP_CMD_TRANS_FD_TO_IOVA);
++	seq_printf(file, "RELEASE_FD:           0x%08x\n", MPP_CMD_RELEASE_FD);
++	seq_printf(file, "SEND_CODEC_INFO:      0x%08x\n", MPP_CMD_SEND_CODEC_INFO);
++	seq_printf(file, "CONTROL_BUTT:         0x%08x\n", MPP_CMD_CONTROL_BUTT);
++
++	return 0;
++}
++
++static int mpp_show_support_device(struct seq_file *file, void *v)
++{
++	u32 i;
++	struct mpp_service *srv = file->private;
++
++	seq_puts(file, "---- SUPPORT DEVICES ----\n");
++	for (i = 0; i < MPP_DEVICE_BUTT; i++) {
++		struct mpp_dev *mpp;
++		struct mpp_hw_info *hw_info;
++
++		if (test_bit(i, &srv->hw_support)) {
++			mpp = srv->sub_devices[array_index_nospec(i, MPP_DEVICE_BUTT)];
++			if (!mpp)
++				continue;
++
++			seq_printf(file, "DEVICE[%2d]:%-10s", i, mpp_device_name[i]);
++			hw_info = mpp->var->hw_info;
++			if (hw_info->hw_id)
++				seq_printf(file, "HW_ID:0x%08x", hw_info->hw_id);
++			seq_puts(file, "\n");
++		}
++	}
++
++	return 0;
++}
++
++static int mpp_procfs_init(struct mpp_service *srv)
++{
++	srv->procfs = proc_mkdir(MPP_SERVICE_NAME, NULL);
++	if (IS_ERR_OR_NULL(srv->procfs)) {
++		mpp_err("failed on mkdir /proc/%s\n", MPP_SERVICE_NAME);
++		srv->procfs = NULL;
++		return -EIO;
++	}
++	/* show version */
++	proc_create_single("version", 0444, srv->procfs, mpp_show_version);
++	/* for show session info */
++	proc_create_single_data("sessions-summary", 0444,
++				srv->procfs, mpp_show_session_summary, srv);
++	/* show support dev cmd */
++	proc_create_single("supports-cmd", 0444, srv->procfs, mpp_show_support_cmd);
++	/* show support devices */
++	proc_create_single_data("supports-device", 0444,
++				srv->procfs, mpp_show_support_device, srv);
++
++	return 0;
++}
++#else
++static inline int mpp_procfs_remove(struct mpp_service *srv)
++{
++	return 0;
++}
++
++static inline int mpp_procfs_init(struct mpp_service *srv)
++{
++	return 0;
++}
++#endif
++
++static int mpp_service_probe(struct platform_device *pdev)
++{
++	int ret, i;
++	struct mpp_service *srv = NULL;
++	struct mpp_taskqueue *queue;
++	struct device *dev = &pdev->dev;
++	struct device_node *np = dev->of_node;
++
++	dev_info(dev, "%s\n", mpp_version);
++	dev_info(dev, "probe start\n");
++	srv = devm_kzalloc(dev, sizeof(*srv), GFP_KERNEL);
++	if (!srv)
++		return -ENOMEM;
++
++	srv->dev = dev;
++	atomic_set(&srv->shutdown_request, 0);
++	platform_set_drvdata(pdev, srv);
++
++	srv->cls = class_create(MPP_CLASS_NAME);
++	if (PTR_ERR_OR_ZERO(srv->cls))
++		return PTR_ERR(srv->cls);
++
++	of_property_read_u32(np, "rockchip,taskqueue-count",
++			     &srv->taskqueue_cnt);
++	if (srv->taskqueue_cnt > MPP_DEVICE_BUTT) {
++		dev_err(dev, "rockchip,taskqueue-count %d must less than %d\n",
++			srv->taskqueue_cnt, MPP_DEVICE_BUTT);
++		return -EINVAL;
++	}
++
++	for (i = 0; i < srv->taskqueue_cnt; i++) {
++		queue = mpp_taskqueue_init(dev);
++		if (!queue)
++			continue;
++
++		kthread_init_worker(&queue->worker);
++		queue->kworker_task = kthread_run(kthread_worker_fn, &queue->worker,
++						  "queue_work%d", i);
++		srv->task_queues[i] = queue;
++	}
++
++	of_property_read_u32(np, "rockchip,resetgroup-count",
++			     &srv->reset_group_cnt);
++	if (srv->reset_group_cnt > MPP_DEVICE_BUTT) {
++		dev_err(dev, "rockchip,resetgroup-count %d must less than %d\n",
++			srv->reset_group_cnt, MPP_DEVICE_BUTT);
++		return -EINVAL;
++	}
++
++	if (srv->reset_group_cnt) {
++		u32 i = 0;
++		struct mpp_reset_group *group;
++
++		for (i = 0; i < srv->reset_group_cnt; i++) {
++			group = devm_kzalloc(dev, sizeof(*group), GFP_KERNEL);
++			if (!group)
++				continue;
++
++			init_rwsem(&group->rw_sem);
++			srv->reset_groups[i] = group;
++		}
++	}
++
++	ret = mpp_register_service(srv, MPP_SERVICE_NAME);
++	if (ret) {
++		dev_err(dev, "register %s device\n", MPP_SERVICE_NAME);
++		goto fail_register;
++	}
++	mutex_init(&srv->session_lock);
++	INIT_LIST_HEAD(&srv->session_list);
++	mpp_procfs_init(srv);
++
++	/* register sub drivers */
++	MPP_REGISTER_DRIVER(srv, HAS_RKVDEC, RKVDEC, rkvdec);
++	MPP_REGISTER_DRIVER(srv, HAS_RKVENC, RKVENC, rkvenc);
++	MPP_REGISTER_DRIVER(srv, HAS_VDPU1, VDPU1, vdpu1);
++	MPP_REGISTER_DRIVER(srv, HAS_VEPU1, VEPU1, vepu1);
++	MPP_REGISTER_DRIVER(srv, HAS_VDPU2, VDPU2, vdpu2);
++	MPP_REGISTER_DRIVER(srv, HAS_VEPU2, VEPU2, vepu2);
++	MPP_REGISTER_DRIVER(srv, HAS_VEPU22, VEPU22, vepu22);
++	MPP_REGISTER_DRIVER(srv, HAS_IEP2, IEP2, iep2);
++	MPP_REGISTER_DRIVER(srv, HAS_JPGDEC, JPGDEC, jpgdec);
++	MPP_REGISTER_DRIVER(srv, HAS_RKVDEC2, RKVDEC2, rkvdec2);
++	MPP_REGISTER_DRIVER(srv, HAS_RKVENC2, RKVENC2, rkvenc2);
++	MPP_REGISTER_DRIVER(srv, HAS_AV1DEC, AV1DEC, av1dec);
++
++	dev_info(dev, "probe success\n");
++
++	return 0;
++
++fail_register:
++	class_destroy(srv->cls);
++
++	return ret;
++}
++
++static int mpp_service_remove(struct platform_device *pdev)
++{
++	struct mpp_taskqueue *queue;
++	struct device *dev = &pdev->dev;
++	struct mpp_service *srv = platform_get_drvdata(pdev);
++	int i;
++
++	dev_info(dev, "remove device\n");
++
++	for (i = 0; i < srv->taskqueue_cnt; i++) {
++		queue = srv->task_queues[i];
++		if (queue && queue->kworker_task) {
++			kthread_flush_worker(&queue->worker);
++			kthread_stop(queue->kworker_task);
++			queue->kworker_task = NULL;
++		}
++	}
++
++	/* remove sub drivers */
++	for (i = 0; i < MPP_DRIVER_BUTT; i++)
++		mpp_remove_driver(srv, i);
++
++	mpp_remove_service(srv);
++	class_destroy(srv->cls);
++	mpp_procfs_remove(srv);
++
++	return 0;
++}
++
++static const struct of_device_id mpp_dt_ids[] = {
++	{
++		.compatible = "rockchip,mpp-service",
++	},
++	{ },
++};
++
++static struct platform_driver mpp_service_driver = {
++	.probe = mpp_service_probe,
++	.remove = mpp_service_remove,
++	.driver = {
++		.name = "mpp_service",
++		.of_match_table = of_match_ptr(mpp_dt_ids),
++	},
++};
++
++module_platform_driver(mpp_service_driver);
++
++MODULE_LICENSE("Dual MIT/GPL");
++MODULE_AUTHOR("Ding Wei leo.ding@rock-chips.com");
++MODULE_DESCRIPTION("Rockchip mpp service driver");
+-- 
+2.46.0
+
+
+From abbccf375c01195e72315dfc07ddeb7dc42aa995 Mon Sep 17 00:00:00 2001
+From: Sebastian Reichel <sebastian.reichel@collabora.com>
+Date: Mon, 8 Jul 2024 18:51:41 +0200
+Subject: [PATCH 2/3] add VEPU580 MPP nodes
+
+---
+ arch/arm64/boot/dts/rockchip/rk3588s.dtsi | 83 +++++++++++++++++++++++
+ 1 file changed, 83 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588s.dtsi b/arch/arm64/boot/dts/rockchip/rk3588s.dtsi
+index 6ac5ac8b48ab..7f47acfa5eff 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3588s.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588s.dtsi
+@@ -1159,6 +1159,89 @@ power-domain@RK3588_PD_SDMMC {
+ 		};
+ 	};
+ 
++
++	mpp_srv: mpp-srv {
++		compatible = "rockchip,mpp-service";
++		rockchip,taskqueue-count = <12>;
++	};
++
++	rkvenc_ccu: rkvenc-ccu {
++		compatible = "rockchip,rkv-encoder-v2-ccu";
++	};
++
++	rkvenc0: rkvenc-core@fdbd0000 {
++		compatible = "rockchip,rkv-encoder-v2-core";
++		reg = <0x0 0xfdbd0000 0x0 0x6000>;
++		interrupts = <GIC_SPI 101 IRQ_TYPE_LEVEL_HIGH 0>;
++		interrupt-names = "irq_rkvenc0";
++		clocks = <&cru ACLK_RKVENC0>, <&cru HCLK_RKVENC0>, <&cru CLK_RKVENC0_CORE>;
++		clock-names = "aclk_vcodec", "hclk_vcodec", "clk_core";
++		rockchip,normal-rates = <600000000>, <0>, <800000000>;
++		assigned-clocks = <&cru ACLK_RKVENC0>, <&cru CLK_RKVENC0_CORE>;
++		assigned-clock-rates = <600000000>, <800000000>;
++		resets = <&cru SRST_A_RKVENC0>, <&cru SRST_H_RKVENC0>, <&cru SRST_RKVENC0_CORE>;
++		reset-names = "video_a", "video_h", "video_core";
++		rockchip,skip-pmu-idle-request;
++		iommus = <&rkvenc0_mmu>;
++		rockchip,srv = <&mpp_srv>;
++		rockchip,ccu = <&rkvenc_ccu>;
++		rockchip,taskqueue-node = <7>;
++		rockchip,task-capacity = <8>;
++		power-domains = <&power RK3588_PD_VENC0>;
++	};
++
++	rkvenc0_mmu: iommu@fdbdf000 {
++		compatible = "rockchip,rk3568-iommu";
++		reg = <0x0 0xfdbdf000 0x0 0x40>, <0x0 0xfdbdf040 0x0 0x40>;
++		interrupts = <GIC_SPI 99 IRQ_TYPE_LEVEL_HIGH 0>,
++			     <GIC_SPI 100 IRQ_TYPE_LEVEL_HIGH 0>;
++		interrupt-names = "irq_rkvenc0_mmu0", "irq_rkvenc0_mmu1";
++		clocks = <&cru ACLK_RKVENC0>, <&cru HCLK_RKVENC0>;
++		clock-names = "aclk", "iface";
++		rockchip,disable-mmu-reset;
++		rockchip,enable-cmd-retry;
++		rockchip,shootdown-entire;
++		#iommu-cells = <0>;
++		power-domains = <&power RK3588_PD_VENC0>;
++	};
++
++	rkvenc1: rkvenc-core@fdbe0000 {
++		compatible = "rockchip,rkv-encoder-v2-core";
++		reg = <0x0 0xfdbe0000 0x0 0x6000>;
++		interrupts = <GIC_SPI 104 IRQ_TYPE_LEVEL_HIGH 0>;
++		interrupt-names = "irq_rkvenc1";
++		clocks = <&cru ACLK_RKVENC1>, <&cru HCLK_RKVENC1>, <&cru CLK_RKVENC1_CORE>;
++		clock-names = "aclk_vcodec", "hclk_vcodec", "clk_core";
++		rockchip,normal-rates = <600000000>, <0>, <800000000>;
++		assigned-clocks = <&cru ACLK_RKVENC1>, <&cru CLK_RKVENC1_CORE>;
++		assigned-clock-rates = <600000000>, <800000000>;
++		resets = <&cru SRST_A_RKVENC1>, <&cru SRST_H_RKVENC1>, <&cru SRST_RKVENC1_CORE>;
++		reset-names = "video_a", "video_h", "video_core";
++		rockchip,skip-pmu-idle-request;
++		iommus = <&rkvenc1_mmu>;
++		rockchip,srv = <&mpp_srv>;
++		rockchip,ccu = <&rkvenc_ccu>;
++		rockchip,taskqueue-node = <7>;
++		rockchip,task-capacity = <8>;
++		power-domains = <&power RK3588_PD_VENC1>;
++	};
++
++	rkvenc1_mmu: iommu@fdbef000 {
++		compatible = "rockchip,rk3568-iommu";
++		reg = <0x0 0xfdbef000 0x0 0x40>, <0x0 0xfdbef040 0x0 0x40>;
++		interrupts = <GIC_SPI 102 IRQ_TYPE_LEVEL_HIGH 0>,
++			     <GIC_SPI 103 IRQ_TYPE_LEVEL_HIGH 0>;
++		interrupt-names = "irq_rkvenc1_mmu0", "irq_rkvenc1_mmu1";
++		clocks = <&cru ACLK_RKVENC1>, <&cru HCLK_RKVENC1>;
++		clock-names = "aclk", "iface";
++		rockchip,disable-mmu-reset;
++		rockchip,enable-cmd-retry;
++		rockchip,shootdown-entire;
++		#iommu-cells = <0>;
++		power-domains = <&power RK3588_PD_VENC1>;
++	};
++
++
+ 	av1d: video-codec@fdc70000 {
+ 		compatible = "rockchip,rk3588-av1-vpu";
+ 		reg = <0x0 0xfdc70000 0x0 0x800>;
+-- 
+2.46.0
+
+
+From 031432317621e7abe7a3556a749fadbfac0cac31 Mon Sep 17 00:00:00 2001
+From: Ben Hoff <hoff.benjamin.k@gmail.com>
+Date: Tue, 24 Sep 2024 10:10:08 -0400
+Subject: [PATCH 3/3] defer until ccu device is available
+
+---
+ drivers/video/rockchip/mpp/mpp_rkvenc2.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/video/rockchip/mpp/mpp_rkvenc2.c b/drivers/video/rockchip/mpp/mpp_rkvenc2.c
+index 887750853c77..adf2730f72b1 100644
+--- a/drivers/video/rockchip/mpp/mpp_rkvenc2.c
++++ b/drivers/video/rockchip/mpp/mpp_rkvenc2.c
+@@ -1876,7 +1876,7 @@ static int rkvenc_attach_ccu(struct device *dev, struct rkvenc_dev *enc)
+ 
+ 	ccu = platform_get_drvdata(pdev);
+ 	if (!ccu)
+-		return -ENOMEM;
++		return -EPROBE_DEFER; // wait until ccu platform has been created
+ 
+ 	INIT_LIST_HEAD(&enc->core_link);
+ 	mutex_lock(&ccu->lock);
+-- 
+2.46.0
+


### PR DESCRIPTION
# Description
This ports Collabora's patches from 6.8 to 6.10 for the 580 encoding nodes. This should allow `ffmpeg-rockchip` to be used with an up to date kernel

# How Has This Been Tested?

To be tested using OP5+

# Checklist:

_Please delete options that are not relevant._

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
