### PR TITLE
Add ipv6 addresses if present and sort ips

### DIFF
--- a/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
+++ b/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
@@ -72,8 +72,28 @@ function get_ip_addresses() {
 			[[ -n $tmp ]] && ips+=("$tmp")
 		fi
 	done
+	ips=($(printf "%s\n" "${ips[@]}" | sort -n))
 	echo "${ips[@]}"
 } # get_ip_addresses
+
+function get_ipv6_addresses() {
+	local ips=()
+	for f in /sys/class/net/*; do
+		local intf=$(basename $f)
+		# match only interface names "dummy0" and "lo"
+		if [[ $intf =~ $HIDE_IP_PATTERN ]]; then
+			continue
+		else
+			local tmp=$(ip -6 addr show dev $intf | grep -v "$intf:avahi" | awk '/inet6/ {print $2}' | cut -d'/' -f1 | grep -v "^fe80:" | uniq)
+			# add both name and IP - can be informative but becomes ugly with long persistent/predictable device names
+			#[[ -n $tmp ]] && ips+=("$intf: $tmp")
+			# add IP only
+			[[ -n $tmp ]] && ips+=("$tmp")
+		fi
+	done
+	ips=($(printf "%s\n" "${ips[@]}" | sort -n))
+	echo "${ips[@]}"
+} # get_ipv6_addresses
 
 function storage_info() {
 	# storage info
@@ -95,6 +115,7 @@ function storage_info() {
 # Works only with ambienttemp and batteryinfo since A20 is slow enough :)
 amb_temp=$(ambienttemp &)
 ip_address=$(get_ip_addresses &)
+ipv6_address=$(get_ipv6_addresses &)
 wan_ip_address=$(get_wan_address &)
 batteryinfo
 storage_info
@@ -133,8 +154,11 @@ swap_total=$(awk '{print $(2)}' <<<${swap_info})
 
 #echo ""
 echo -en " IP addresses: \x1B[93m(LAN)\x1B[0m \x1B[92m$ip_address\x1B[0m "
+if [[ -n $ipv6_address ]]; then
+  echo -e "\x1B[92m$ipv6_address\x1B[0m "
+fi
 if [[ -n $wan_ip_address ]]; then
-echo -e "\x1B[93m(WAN)\x1B[0m $wan_ip_address"
+  echo -e "\x1B[93m(WAN)\x1B[0m $wan_ip_address"
 fi
 echo ""
 printf "\e[0;90m Performance:  \x1B[0m"
@@ -219,3 +243,4 @@ if [[ $(command -v zpool) ]]; then
 	fi
 fi
 echo ""
+


### PR DESCRIPTION
# Description

Sorting IP addresses and adding IPv6 addresses to sysinfo motd.

# How Has This Been Tested?

Set IPv6 address on interface and run /etc/motd/30-armbian-sysinfo

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
