### PR TITLE
debsums: changing default checking as it will fail on base-files

### DIFF
--- a/lib/functions/rootfs/rootfs-create.sh
+++ b/lib/functions/rootfs/rootfs-create.sh
@@ -224,7 +224,7 @@ function create_new_rootfs_cache_via_debootstrap() {
 
 	# stage: check md5 sum of installed packages. Just in case. @TODO: rpardini: this should also be done when a cache is used, not only when it is created
 	# lets check only for supported targets only unless forced
-	if [[ "${DISTRIBUTION_STATUS}" == "supported" || "${FORCE_CHECK_MD5_PACKAGES:-"no"}" == "yes" ]]; then
+	if [[ "${DISTRIBUTION_STATUS}" == "supported" && "${FORCE_CHECK_MD5_PACKAGES:-"no"}" == "yes" ]]; then
 		display_alert "Checking MD5 sum of installed packages" "debsums" "info"
 		declare -g if_error_detail_message="Check MD5 sum of installed packages failed"
 		chroot_sdcard debsums --silent


### PR DESCRIPTION
# Description

Base files are changed during the process. We already planned to set this off by default but conditions `||` and `&&` got mixed. Debsums authors recommends to use other tools anyway:

_If  you are looking for an integrity checker that can run from safe media, do integrity checks on checksum databases and can be easily configured to run periodically to warn the admin of changes see other tools such as: `aide`, `integrit`, `samhain`, or `tripwire`._

FORCE_CHECK_MD5_PACKAGES=yes turns checking back on.

Closing https://github.com/armbian/build/issues/7048

# How Has This Been Tested?

- [x] Error with enable, no error with this fix

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
