### PR TITLE
KDE wallet: ship KDE distro with default disabled KDE Wallet

### DIFF
--- a/packages/blobs/desktop/skel/.config/kwalletrc
+++ b/packages/blobs/desktop/skel/.config/kwalletrc
@@ -1,0 +1,2 @@
+[Wallet]
+Enabled=false


### PR DESCRIPTION
# Description

It is better to store WiFi passwords (and similar) encrypted. Which is one of the advantages of Kwallet. But since this is not the case with other desktops, lets set it to disabled by default. People who use it,

`kwallet -> enable kwallet subsystem.`

# How Has This Been Tested?

- [x] Produced KDE image comes with disabled subsystem

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
