### PR TITLE
enable panfrost driver for rk3576 boards

### DIFF
--- a/config/boards/armsom-cm5-io.csc
+++ b/config/boards/armsom-cm5-io.csc
@@ -9,7 +9,6 @@ BOOT_FDT_FILE="rockchip/rk3576-armsom-cm5-io.dtb"
 BOOT_SCENARIO="spl-blobs"
 IMAGE_PARTITION_TABLE="gpt"
 SRC_EXTLINUX="yes"
-MODULES_BLACKLIST="panfrost"
 BOARD_MAINTAINER=""
 
 function post_family_config_branch_vendor__armsom-cm5-io_use_vendor_uboot() {

--- a/config/boards/armsom-sige5.csc
+++ b/config/boards/armsom-sige5.csc
@@ -9,7 +9,6 @@ BOOT_FDT_FILE="rockchip/rk3576-armsom-sige5.dtb"
 BOOT_SCENARIO="spl-blobs"
 IMAGE_PARTITION_TABLE="gpt"
 SRC_EXTLINUX="yes"
-MODULES_BLACKLIST="panfrost"
 BOARD_MAINTAINER=""
 
 function post_family_config_branch_vendor__armsom-sige7_use_vendor_uboot() {


### PR DESCRIPTION
# Description

This depends on https://github.com/armbian/linux-rockchip/pull/249, which is using gpu dts from mainline patch.

When panfrost is blacklisted, if the driver is enabled by command `modprobe panfrost`, there will be kernel panic. This issue is described in this patch series: https://patchwork.kernel.org/project/linux-rockchip/cover/20240919091834.83572-1-sebastian.reichel@collabora.com/. When panfrost is automaticly loaded at boot, there will be no such issue.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh BOARD=armsom-cm5-io BRANCH=vendor BUILD_MINIMAL=no DEB_COMPRESS=xz KERNEL_CONFIGURE=no RELEASE=noble KERNEL_GIT=shallow BUILD_DESKTOP=yes DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base`
- [x] Gnome desktop starts with panfrost driver.

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
