### PR TITLE
reinstate tinker edge r dts

### DIFF
--- a/patch/kernel/archive/rockchip64-6.11/dt/rk3399pro-tinker-edge-r.dts
+++ b/patch/kernel/archive/rockchip64-6.11/dt/rk3399pro-tinker-edge-r.dts
@@ -9,7 +9,6 @@
 /dts-v1/;
 #include <dt-bindings/input/linux-event-codes.h>
 #include <dt-bindings/pwm/pwm.h>
-#include "rk3399pro.dtsi"
 #include "rk3399-opp.dtsi"
 
 / {
@@ -199,7 +198,7 @@
 		compatible = "linux,spdif-dit";
 		#sound-dai-cells = <0>;
 	};
-	
+
 	hdmi_dp_sound: hdmi-dp-sound {
 		status = "okay";
 		compatible = "rockchip,rk3399-hdmi-dp";
@@ -284,7 +283,7 @@
 	status = "disabled";
 };
 
-&vopb {	
+&vopb {
 	status = "okay";
 	// assigned-clocks = <&cru DCLK_VOP0_DIV>;
 	// assigned-clock-parents = <&cru PLL_VPLL>;


### PR DESCRIPTION
# Description

bump to 6.11 simply disabled it without any corresponding changes to board config/etc, so re-enable it once offending (inert) dtsi include removed.

# How Has This Been Tested?

build OK.  boot NOK, however one can assume it's pre-existing condition since this and the previous change were only to the dts file.  I may come back to check on it, or @ARC-MX can return to take a look as original contributor.

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
