### PR TITLE
rootfs: don't use the Armbian repo when building rootfs from both GHA pipelines and CLI; fixes #7123

### DIFF
--- a/lib/functions/artifacts/artifact-rootfs.sh
+++ b/lib/functions/artifacts/artifact-rootfs.sh
@@ -138,6 +138,13 @@ function artifact_rootfs_cli_adapter_config_prep() {
 	declare -g -r RELEASE="${RELEASE}" # make readonly for finding who tries to change it
 	declare -g -r NEEDS_BINFMT="yes"   # make sure binfmts are installed during prepare_host_interactive
 
+	if [[ "${SKIP_ARMBIAN_REPO}" != "yes" ]]; then # if not set to yes, force it to yes.
+		declare -g SKIP_ARMBIAN_REPO="yes"            # Using the repo during rootfs build causes insanity, so don't. Make readonly to ensure.
+	fi
+	declare -g -r SKIP_ARMBIAN_REPO # make it readonly to ensure sanity if hooks try to change it
+
+	track_general_config_variables "in artifact_rootfs_cli_adapter_config_prep"
+
 	# prep_conf_main_only_rootfs_ni is prep_conf_main_only_rootfs_ni() + mark_aggregation_required_in_default_build_start()
 	prep_conf_main_only_rootfs_ni < /dev/null # no stdin for this, so it bombs if tries to be interactive.
 

--- a/lib/functions/cli/cli-artifact.sh
+++ b/lib/functions/cli/cli-artifact.sh
@@ -32,8 +32,13 @@ function cli_artifact_run() {
 
 	display_alert "artifact" "${chosen_artifact}" "debug"
 	display_alert "artifact" "${chosen_artifact} :: ${chosen_artifact_impl}()" "debug"
+
+	track_general_config_variables "in cli_artifact_run before artifact_cli_adapter_config_prep"
+
 	declare -g artifact_version_requires_aggregation="no" # marker
 	artifact_cli_adapter_config_prep                      # only if in cli.
+
+	track_general_config_variables "in cli_artifact_run after artifact_cli_adapter_config_prep"
 
 	# if asked by _config_prep to aggregate, and HOSTRELEASE is not set, obtain it.
 	if [[ "${artifact_version_requires_aggregation}" == "yes" ]] && [[ -z "${HOSTRELEASE}" ]]; then

--- a/lib/functions/cli/commands.sh
+++ b/lib/functions/cli/commands.sh
@@ -127,7 +127,7 @@ function armbian_register_commands() {
 		["rewrite-uboot-patches-needing-rebase"]="REWRITE_PATCHES='yes' REWRITE_PATCHES_NEEDING_REBASE='yes'"
 
 		# artifact shortcuts
-		["rootfs"]="WHAT='rootfs' SKIP_ARMBIAN_REPO='yes' ${common_cli_artifact_vars}"
+		["rootfs"]="WHAT='rootfs' ${common_cli_artifact_vars}"
 
 		["kernel"]="WHAT='kernel' ${common_cli_artifact_vars}"
 		["kernel-config"]="WHAT='kernel' KERNEL_CONFIGURE='yes' ${common_cli_artifact_interactive_vars} ${common_cli_artifact_vars}"

--- a/lib/functions/configuration/change-tracking.sh
+++ b/lib/functions/configuration/change-tracking.sh
@@ -45,5 +45,5 @@ function track_general_config_variables() {
 	array_values="yes" track_config_variables "${1}" KERNEL_DRIVERS_SKIP
 	track_config_variables "${1}" BOOTSOURCE BOOTSOURCEDIR BOOTBRANCH BOOTPATCHDIR BOOTDIR BOOTCONFIG BOOTBRANCH_BOARD BOOTPATCHDIR_BOARD
 	track_config_variables "${1}" ATFSOURCEDIR ATFDIR ATFBRANCH CRUSTSOURCEDIR CRUSTDIR CRUSTBRANCH LINUXSOURCEDIR
-	track_config_variables "${1}" NETWORKING_STACK
+	track_config_variables "${1}" NETWORKING_STACK SKIP_ARMBIAN_REPO
 }

--- a/lib/functions/rootfs/create-cache.sh
+++ b/lib/functions/rootfs/create-cache.sh
@@ -132,5 +132,4 @@ function extract_rootfs_artifact() {
 }
 
 # This comment strategically introduced to force a rebuild of all rootfs, as this file's contents are hashed into all rootfs versions.
-# There was a problem when generating cache. Packages were upgraded from our (beta) repository which lead into package downgrade error problem.
-# Just a number to force rebuild 01
+# Just a number to force rebuild 002


### PR DESCRIPTION
#### rootfs: don't use the Armbian repo when building rootfs from both GHA pipelines and CLI; fixes #7123

- rootfs: don't use the Armbian repo when building rootfs from both GHA pipelines and CLI; fixes #7123
  - Fixes: 71296430fa9e849098baa5da2cb0734580b12be9 -- which only set `SKIP_ARMBIAN_REPO=yes` when `rootfs` cli shortcut used
    - GHA artifact pipelines are generic across all artifacts, and don't use the cli shortcuts
      - instead, they use the `artifact` shortcut, with the `WHAT=rootfs` parameter
      - so in GHA pipelines `SKIP_ARMBIAN_REPO=yes` was not taking effect
  - rootfs artifact itself now enforces `SKIP_ARMBIAN_REPO` to be `yes` and makes it readonly
  - also add `SKIP_ARMBIAN_REPO` to the general change-tracking for more clarity about configs and hooks etc
  - add change tracking calls before/after generic artifact config adapter for even more clarity