### PR TITLE
Remove wireless tools dependency from all user space variants

### DIFF
--- a/config/cli/bullseye/main/packages
+++ b/config/cli/bullseye/main/packages
@@ -41,5 +41,4 @@ u-boot-tools
 usbutils
 vlan
 wget
-wireless-tools
 wpasupplicant

--- a/config/cli/common/main/packages
+++ b/config/cli/common/main/packages
@@ -39,6 +39,5 @@ tzdata
 u-boot-tools
 usbutils
 wget
-wireless-tools
 wireguard-tools
 wpasupplicant

--- a/config/cli/jammy/main/packages
+++ b/config/cli/jammy/main/packages
@@ -41,5 +41,4 @@ u-boot-tools
 usbutils
 vlan
 wget
-wireless-tools
 wpasupplicant

--- a/packages/bsp/99disable-power-management
+++ b/packages/bsp/99disable-power-management
@@ -1,5 +1,5 @@
 #!/bin/sh
 case "$2" in
-	up) /sbin/iwconfig $1 power off || true ;;
-	down) /sbin/iwconfig $1 power on || true ;;
+	up) iw dev $1 set power_save off || true ;;
+	down) iw dev $1 set power_save on || true ;;
 esac

--- a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
+++ b/packages/bsp/common/usr/lib/armbian/armbian-firstlogin
@@ -307,7 +307,7 @@ set_timezone_and_locales() {
 				while [[ ${scanning} -lt 3 ]]; do
 					sleep 0.5
 					scanning=$(( scanning + 1 ))
-					readarray -t ARRAY < <(iwlist ${WIFI_DEVICE} scanning 2> /dev/null | egrep 'ESSID' | sed 's/^[ \t]*//' | sed 's/"//g' | sed 's/ESSID://' | sed '/^$/d' | sort | uniq | awk 'BEGIN{FS=OFS=","} {$NF=++count OFS $NF} 1')
+					readarray -t ARRAY < <(iw dev ${WIFI_DEVICE} scan 2> /dev/null | egrep 'SSID' | sed 's/^[ \t]*//' | sed 's/"//g' | sed 's/SSID: //' | sed '/^$/d' | sort | uniq | awk 'BEGIN{FS=OFS=","} {$NF=++count OFS $NF} 1')
 					if [[ ${#ARRAY[@]} -gt 0 ]]; then broken=0; break; fi
 				done
 				# wifi can also fail


### PR DESCRIPTION
# Description

Due to removal https://bugs.launchpad.net/ubuntu/+source/wireless-tools/+bug/2068612

# How Has This Been Tested?

Manual running of replaced commands.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
