### PR TITLE
Improvement: Update MOTD to include IPv6 local addresses

### DIFF
--- a/packages/bsp/common/etc/default/armbian-motd.dpkg-dist
+++ b/packages/bsp/common/etc/default/armbian-motd.dpkg-dist
@@ -6,7 +6,7 @@
 
 MOTD_DISABLE=""
 ONE_WIRE=""
-HIDE_IP_PATTERN="^dummy0|^lo|^docker|^hassio"
+HIDE_IP_PATTERN="^dummy0|^lo|^docker|^hassio|^br-*|^veth"
 PRIMARY_INTERFACE="$(ip route | grep '^default' | sed "s/.*dev //" | cut -d" " -f1)"
 PRIMARY_DIRECTION="rx"
 STORAGE=/dev/sda1

--- a/packages/bsp/common/etc/default/armbian-motd.dpkg-dist
+++ b/packages/bsp/common/etc/default/armbian-motd.dpkg-dist
@@ -6,7 +6,7 @@
 
 MOTD_DISABLE=""
 ONE_WIRE=""
-HIDE_IP_PATTERN="^dummy0|^lo|^docker|^hassio|^br-*|^veth"
+HIDE_IP_PATTERN="^dummy0|^lo|^docker|^hassio"
 PRIMARY_INTERFACE="$(ip route | grep '^default' | sed "s/.*dev //" | cut -d" " -f1)"
 PRIMARY_DIRECTION="rx"
 STORAGE=/dev/sda1

--- a/packages/bsp/common/etc/update-motd.d/10-armbian-header
+++ b/packages/bsp/common/etc/update-motd.d/10-armbian-header
@@ -27,57 +27,57 @@ VENDORTEMP="${VENDOR}"
 [[ -n $VENDORPRETTYNAME ]] && VENDOR="$VENDORPRETTYNAME"
 
 if [[ -f /etc/armbian-distribution-status ]]; then
-    . /etc/armbian-distribution-status
-    # Find a way that works
-    [[ -f /etc/lsb-release ]] && DISTRIBUTION_CODENAME=$(grep CODENAME /etc/lsb-release | cut -d"=" -f2)
-    [[ -f /etc/lsb-release ]] && DISTRIBUTION_ID=$(grep DISTRIB_ID /etc/lsb-release | cut -d"=" -f2)
-    [[ -z "$DISTRIBUTION_CODENAME" && -f /etc/os-release ]] && DISTRIBUTION_CODENAME=$(grep VERSION_CODENAME /etc/os-release | cut -d"=" -f2)
-    [[ -z "$DISTRIBUTION_ID" && -f /etc/os-release ]] && DISTRIBUTION_ID=$(grep "^ID" /etc/os-release | cut -d"=" -f2)
-    [[ -z "$DISTRIBUTION_CODENAME" && -x /usr/bin/lsb_release ]] && DISTRIBUTION_CODENAME=$(/usr/bin/lsb_release -c | cut -d":" -f2 | tr -d "\t")
-    [[ -z "$DISTRIBUTION_ID" && -x /usr/bin/lsb_release ]] && DISTRIBUTION_ID=$(/usr/bin/lsb_release -i | cut -d":" -f2 | tr -d "\t")
-    # Read Armbian distribution status
-    DISTRIBUTION_STATUS=$(grep "^${DISTRIBUTION_CODENAME}" /etc/armbian-distribution-status | cut -d"=" -f2 | cut -d";" -f1)
+	. /etc/armbian-distribution-status
+	# Find a way that works
+	[[ -f /etc/lsb-release ]] && DISTRIBUTION_CODENAME=$(grep CODENAME /etc/lsb-release | cut -d"=" -f2)
+	[[ -f /etc/lsb-release ]] && DISTRIBUTION_ID=$(grep DISTRIB_ID /etc/lsb-release | cut -d"=" -f2)
+	[[ -z "$DISTRIBUTION_CODENAME" && -f /etc/os-release ]] && DISTRIBUTION_CODENAME=$(grep VERSION_CODENAME /etc/os-release | cut -d"=" -f2)
+	[[ -z "$DISTRIBUTION_ID" && -f /etc/os-release ]] && DISTRIBUTION_ID=$(grep "^ID" /etc/os-release | cut -d"=" -f2)
+	[[ -z "$DISTRIBUTION_CODENAME" && -x /usr/bin/lsb_release ]] && DISTRIBUTION_CODENAME=$(/usr/bin/lsb_release -c | cut -d":" -f2 | tr -d "\t")
+	[[ -z "$DISTRIBUTION_ID" && -x /usr/bin/lsb_release ]] && DISTRIBUTION_ID=$(/usr/bin/lsb_release -i | cut -d":" -f2 | tr -d "\t")
+	# Read Armbian distribution status
+	DISTRIBUTION_STATUS=$(grep "^${DISTRIBUTION_CODENAME}" /etc/armbian-distribution-status | cut -d"=" -f2 | cut -d";" -f1)
 
-    # Read upgrade possibilities on stable channel
-    filter=$(grep "supported" /etc/armbian-distribution-status | cut -d"=" -f1)
-    upgrade=$(for j in $filter; do
-        for i in $(grep "^${DISTRIBUTION_CODENAME}" /etc/armbian-distribution-status | cut -d";" -f2 | cut -d"=" -f2 | sed "s/,/ /g"); do
-            if [[ $i == $j ]]; then
-                echo $i
-            fi
-        done
-    done | tail -1)
+	# Read upgrade possibilities on stable channel
+	filter=$(grep "supported" /etc/armbian-distribution-status | cut -d"=" -f1)
+	upgrade=$(for j in $filter; do
+		for i in $(grep "^${DISTRIBUTION_CODENAME}" /etc/armbian-distribution-status | cut -d";" -f2 | cut -d"=" -f2 | sed "s/,/ /g"); do
+			if [[ $i == $j ]]; then
+				echo $i
+			fi
+		done
+	done | tail -1)
 
 fi
 [[ -f /etc/default/armbian-motd ]] && . /etc/default/armbian-motd
 
 for f in $MOTD_DISABLE; do
-    [[ $f == $THIS_SCRIPT ]] && exit 0
+	[[ $f == $THIS_SCRIPT ]] && exit 0
 done
 
 function get_wan_address() {
-    curl --connect-timeout 2 -s http://whatismyip.akamai.com/
+	curl --connect-timeout 2 -s http://whatismyip.akamai.com/
 } # get wan ip address
 
 function get_ip_addresses() {
-    local ipv4s=()
-    local ipv6s=()
+	local ipv4s=()
+	local ipv6s=()
 
-    for f in /sys/class/net/*; do
-        local intf=$(basename $f)
-        # match only interface names
-        if [[ $intf =~ $HIDE_IP_PATTERN ]]; then
-            continue
-        else
-            local ipv4=$(ip -4 addr show dev $intf | grep -v "$intf:avahi" | awk '/inet/ {print $2}' | cut -d'/' -f1 | uniq)
-            local ipv6=$(ip -6 addr show dev $intf | grep -v "$intf:avahi" | awk '/inet6/ {print $2}' | cut -d'/' -f1 | uniq)
+	for f in /sys/class/net/*; do
+		local intf=$(basename $f)
+		# match only interface names
+		if [[ $intf =~ $HIDE_IP_PATTERN ]]; then
+			continue
+		else
+			local ipv4=$(ip -4 addr show dev $intf | grep -v "$intf:avahi" | awk '/inet/ {print $2}' | cut -d'/' -f1 | uniq)
+			local ipv6=$(ip -6 addr show dev $intf | grep -v "$intf:avahi" | awk '/inet6/ {print $2}' | cut -d'/' -f1 | uniq)
 
-            [[ -n $ipv4 ]] && ipv4s+=("$ipv4")
-            [[ -n $ipv6 ]] && ipv6s+=("$ipv6")
-        fi
-    done
+			[[ -n $ipv4 ]] && ipv4s+=("$ipv4")
+			[[ -n $ipv6 ]] && ipv6s+=("$ipv6")
+		fi
+	done
 
-    echo "${ipv4s[@]}|${ipv6s[@]}"
+	echo "${ipv4s[@]}|${ipv6s[@]}"
 } # get_ip_addresses
 
 # Read Armbian kernel version
@@ -95,22 +95,23 @@ echo -e " \e[0;92mv${VERSION}\x1B[0m for $BOARD_NAME running Armbian Linux \e[0;
 
 # render image and board type
 if [[ "$IMAGE_TYPE" != "stable" ]]; then
-    [[ "$IMAGE_TYPE" == "user-built" ]] && HARDWARE_STATUS="\e[0;91mDIY\x1B[0m (custom image)\x1B[0m"
-    [[ "$IMAGE_TYPE" == "nightly" ]] && HARDWARE_STATUS="\e[0;91mfor advanced users\x1B[0m (rolling release)\x1B[0m"
+	[[ "$IMAGE_TYPE" == "user-built" ]] && HARDWARE_STATUS="\e[0;91mDIY\x1B[0m (custom image)\x1B[0m"
+	[[ "$IMAGE_TYPE" == "nightly" ]] && HARDWARE_STATUS="\e[0;91mfor advanced users\x1B[0m (rolling release)\x1B[0m"
 else
-    [[ "$BOARD_TYPE" == "csc" || "$BOARD_TYPE" == "tvb" ]] && HARDWARE_STATUS="\e[0;91mDIY (community maintained)\x1B[0m"
-    [[ "$BOARD_TYPE" == "wip" ]] && HARDWARE_STATUS="\e[0;91mfor advanced users\x1B[0m (work in progress)\x1B[0m"
-    [[ "$BOARD_TYPE" == "eos" ]] && HARDWARE_STATUS="\e[0;91mend of life\x1B[0m"
+	[[ "$BOARD_TYPE" == "csc" || "$BOARD_TYPE" == "tvb" ]] && HARDWARE_STATUS="\e[0;91mDIY (community maintained)\x1B[0m"
+	[[ "$BOARD_TYPE" == "wip" ]] && HARDWARE_STATUS="\e[0;91mfor advanced users\x1B[0m (work in progress)\x1B[0m"
+	[[ "$BOARD_TYPE" == "eos" ]] && HARDWARE_STATUS="\e[0;91mend of life\x1B[0m"
 fi
 
 # render distribution status
 if [[ $DISTRIBUTION_STATUS == supported ]]; then
-    DISTRO_STATUS="\e[0;92mstable\e[0m ($DISTRIBUTION_CODENAME)"
+	DISTRO_STATUS="\e[0;92mstable\e[0m ($DISTRIBUTION_CODENAME)"
 elif [[ $DISTRIBUTION_STATUS == eos ]]; then
-    DISTRO_STATUS="\e[0;91mend of life\e[0m ($DISTRIBUTION_CODENAME)"
+	DISTRO_STATUS="\e[0;91mend of life\e[0m ($DISTRIBUTION_CODENAME)"
 else
-    DISTRO_STATUS="\e[0;93mrolling\e[0m ($DISTRIBUTION_CODENAME)"
+	DISTRO_STATUS="\e[0;93mrolling\e[0m ($DISTRIBUTION_CODENAME)"
 fi
+
 
 # read packages update status
 NUM_UPDATES=0
@@ -118,41 +119,40 @@ NUM_UPDATES_ONHOLD=0
 NUM_SECURITY_UPDATES=0
 [[ -f /var/cache/apt/archives/updates.number ]] && . /var/cache/apt/archives/updates.number
 if [[ $NUM_UPDATES -gt 0 ]]; then
-    if apt-mark showhold | grep -q linux-image 2>/dev/null; then
-        UPDATE_STATUS="Kernel upgrade \e[0;91mdisabled\e[0m"
-    else
-        UPDATE_STATUS="Kernel upgrade \e[0;92menabled\e[0m"
-    fi
-    UPDATE_STATUS+=" and \e[1;92m$NUM_UPDATES\e[0m package"
-    # Cosmetic is important
-    [[ $NUM_UPDATES -gt 1 ]] && UPDATE_STATUS+="s"
-    UPDATE_STATUS+=" available for upgrade\e[0m "
+	if apt-mark showhold | grep -q linux-image 2>/dev/null; then
+		UPDATE_STATUS="Kernel upgrade \e[0;91mdisabled\e[0m"
+		else
+		UPDATE_STATUS="Kernel upgrade \e[0;92menabled\e[0m"
+	fi
+	UPDATE_STATUS+=" and \e[1;92m$NUM_UPDATES\e[0m package"
+	# Cosmetic is important
+	[[ $NUM_UPDATES -gt 1 ]] && UPDATE_STATUS+="s"
+	UPDATE_STATUS+=" available for upgrade\e[0m "
 fi
 
 echo ""
 
 # Display packages status
 if [[ -n $DISTRO_STATUS ]]; then
-    if [[ -n "${upgrade}" ]]; then
-        DISTRO_STATUS+=", possible distro upgrade ($upgrade)"
-    fi
-    echo -e " Packages:     ${DISTRIBUTION_ID^} ${DISTRO_STATUS}"
+	if [[ -n "${upgrade}" ]]; then
+		DISTRO_STATUS+=", possible distro upgrade ($upgrade)"
+	fi
+	echo -e " Packages:     ${DISTRIBUTION_ID^} ${DISTRO_STATUS}"
 fi
 
 # Display available updates
 if [[ -n $UPDATE_STATUS ]]; then
-    echo -e " Updates:      $UPDATE_STATUS"
+        echo -e " Updates:      $UPDATE_STATUS"
 fi
 
 # Display hardware support status
 if [[ -n $HARDWARE_STATUS ]]; then
-    echo -e " Support:      $HARDWARE_STATUS"
+        echo -e " Support:      $HARDWARE_STATUS"
 fi
-
 
 IFS='|' read -r ipv4s ipv6s <<< "$ip_address"
 echo -en " IP addresses: \x1B[93m(LAN)\x1B[0m IPv4: \x1B[92m${ipv4s// /, }\x1B[0m IPv6: \x1B[96m${ipv6s// /, }\x1B[0m"
 if [[ -n $wan_ip_address ]]; then
-    echo -e " \x1B[93m(WAN)\x1B[0m $wan_ip_address"
+echo -e "\x1B[93m(WAN)\x1B[0m $wan_ip_address"
 fi
 echo ""

--- a/packages/bsp/common/etc/update-motd.d/10-armbian-header
+++ b/packages/bsp/common/etc/update-motd.d/10-armbian-header
@@ -27,54 +27,57 @@ VENDORTEMP="${VENDOR}"
 [[ -n $VENDORPRETTYNAME ]] && VENDOR="$VENDORPRETTYNAME"
 
 if [[ -f /etc/armbian-distribution-status ]]; then
-	. /etc/armbian-distribution-status
-	# Fina a way that works
-	[[ -f /etc/lsb-release ]] && DISTRIBUTION_CODENAME=$(grep CODENAME /etc/lsb-release | cut -d"=" -f2)
-	[[ -f /etc/lsb-release ]] && DISTRIBUTION_ID=$(grep DISTRIB_ID /etc/lsb-release | cut -d"=" -f2)
-	[[ -z "$DISTRIBUTION_CODENAME" && -f /etc/os-release ]] && DISTRIBUTION_CODENAME=$(grep VERSION_CODENAME /etc/os-release | cut -d"=" -f2)
-	[[ -z "$DISTRIBUTION_ID" && -f /etc/os-release ]] && DISTRIBUTION_ID=$(grep "^ID" /etc/os-release | cut -d"=" -f2)
-	[[ -z "$DISTRIBUTION_CODENAME" && -x /usr/bin/lsb_release ]] && DISTRIBUTION_CODENAME=$(/usr/bin/lsb_release -c | cut -d":" -f2 | tr -d "\t")
-	[[ -z "$DISTRIBUTION_ID" && -x /usr/bin/lsb_release ]] && DISTRIBUTION_ID=$(/usr/bin/lsb_release -i | cut -d":" -f2 | tr -d "\t")
-	# Read Armbian distribution status
-	DISTRIBUTION_STATUS=$(grep "^${DISTRIBUTION_CODENAME}" /etc/armbian-distribution-status | cut -d"=" -f2 | cut -d";" -f1)
+    . /etc/armbian-distribution-status
+    # Find a way that works
+    [[ -f /etc/lsb-release ]] && DISTRIBUTION_CODENAME=$(grep CODENAME /etc/lsb-release | cut -d"=" -f2)
+    [[ -f /etc/lsb-release ]] && DISTRIBUTION_ID=$(grep DISTRIB_ID /etc/lsb-release | cut -d"=" -f2)
+    [[ -z "$DISTRIBUTION_CODENAME" && -f /etc/os-release ]] && DISTRIBUTION_CODENAME=$(grep VERSION_CODENAME /etc/os-release | cut -d"=" -f2)
+    [[ -z "$DISTRIBUTION_ID" && -f /etc/os-release ]] && DISTRIBUTION_ID=$(grep "^ID" /etc/os-release | cut -d"=" -f2)
+    [[ -z "$DISTRIBUTION_CODENAME" && -x /usr/bin/lsb_release ]] && DISTRIBUTION_CODENAME=$(/usr/bin/lsb_release -c | cut -d":" -f2 | tr -d "\t")
+    [[ -z "$DISTRIBUTION_ID" && -x /usr/bin/lsb_release ]] && DISTRIBUTION_ID=$(/usr/bin/lsb_release -i | cut -d":" -f2 | tr -d "\t")
+    # Read Armbian distribution status
+    DISTRIBUTION_STATUS=$(grep "^${DISTRIBUTION_CODENAME}" /etc/armbian-distribution-status | cut -d"=" -f2 | cut -d";" -f1)
 
-	# Read upgrade possibilities on stable channel
-	filter=$(grep "supported" /etc/armbian-distribution-status | cut -d"=" -f1)
-	upgrade=$(for j in $filter; do
-		for i in $(grep "^${DISTRIBUTION_CODENAME}" /etc/armbian-distribution-status | cut -d";" -f2 | cut -d"=" -f2 | sed "s/,/ /g"); do
-			if [[ $i == $j ]]; then
-				echo $i
-			fi
-		done
-	done | tail -1)
+    # Read upgrade possibilities on stable channel
+    filter=$(grep "supported" /etc/armbian-distribution-status | cut -d"=" -f1)
+    upgrade=$(for j in $filter; do
+        for i in $(grep "^${DISTRIBUTION_CODENAME}" /etc/armbian-distribution-status | cut -d";" -f2 | cut -d"=" -f2 | sed "s/,/ /g"); do
+            if [[ $i == $j ]]; then
+                echo $i
+            fi
+        done
+    done | tail -1)
 
 fi
 [[ -f /etc/default/armbian-motd ]] && . /etc/default/armbian-motd
 
 for f in $MOTD_DISABLE; do
-	[[ $f == $THIS_SCRIPT ]] && exit 0
+    [[ $f == $THIS_SCRIPT ]] && exit 0
 done
 
 function get_wan_address() {
-	curl --connect-timeout 2 -s http://whatismyip.akamai.com/
+    curl --connect-timeout 2 -s http://whatismyip.akamai.com/
 } # get wan ip address
 
 function get_ip_addresses() {
-	local ips=()
-	for f in /sys/class/net/*; do
-		local intf=$(basename $f)
-		# match only interface names "dummy0" and "lo"
-		if [[ $intf =~ $HIDE_IP_PATTERN ]]; then
-			continue
-		else
-			local tmp=$(ip -4 addr show dev $intf | grep -v "$intf:avahi" | awk '/inet/ {print $2}' | cut -d'/' -f1 | uniq)
-			# add both name and IP - can be informative but becomes ugly with long persistent/predictable device names
-			#[[ -n $tmp ]] && ips+=("$intf: $tmp")
-			# add IP only
-			[[ -n $tmp ]] && ips+=("$tmp")
-		fi
-	done
-	echo "${ips[@]}"
+    local ipv4s=()
+    local ipv6s=()
+
+    for f in /sys/class/net/*; do
+        local intf=$(basename $f)
+        # match only interface names
+        if [[ $intf =~ $HIDE_IP_PATTERN ]]; then
+            continue
+        else
+            local ipv4=$(ip -4 addr show dev $intf | grep -v "$intf:avahi" | awk '/inet/ {print $2}' | cut -d'/' -f1 | uniq)
+            local ipv6=$(ip -6 addr show dev $intf | grep -v "$intf:avahi" | awk '/inet6/ {print $2}' | cut -d'/' -f1 | uniq)
+
+            [[ -n $ipv4 ]] && ipv4s+=("$ipv4")
+            [[ -n $ipv6 ]] && ipv6s+=("$ipv6")
+        fi
+    done
+
+    echo "${ipv4s[@]}|${ipv6s[@]}"
 } # get_ip_addresses
 
 # Read Armbian kernel version
@@ -92,23 +95,22 @@ echo -e " \e[0;92mv${VERSION}\x1B[0m for $BOARD_NAME running Armbian Linux \e[0;
 
 # render image and board type
 if [[ "$IMAGE_TYPE" != "stable" ]]; then
-	[[ "$IMAGE_TYPE" == "user-built" ]] && HARDWARE_STATUS="\e[0;91mDIY\x1B[0m (custom image)\x1B[0m"
-	[[ "$IMAGE_TYPE" == "nightly" ]] && HARDWARE_STATUS="\e[0;91mfor advanced users\x1B[0m (rolling release)\x1B[0m"
+    [[ "$IMAGE_TYPE" == "user-built" ]] && HARDWARE_STATUS="\e[0;91mDIY\x1B[0m (custom image)\x1B[0m"
+    [[ "$IMAGE_TYPE" == "nightly" ]] && HARDWARE_STATUS="\e[0;91mfor advanced users\x1B[0m (rolling release)\x1B[0m"
 else
-	[[ "$BOARD_TYPE" == "csc" || "$BOARD_TYPE" == "tvb" ]] && HARDWARE_STATUS="\e[0;91mDIY (community maintained)\x1B[0m"
-	[[ "$BOARD_TYPE" == "wip" ]] && HARDWARE_STATUS="\e[0;91mfor advanced users\x1B[0m (work in progress)\x1B[0m"
-	[[ "$BOARD_TYPE" == "eos" ]] && HARDWARE_STATUS="\e[0;91mend of life\x1B[0m"
+    [[ "$BOARD_TYPE" == "csc" || "$BOARD_TYPE" == "tvb" ]] && HARDWARE_STATUS="\e[0;91mDIY (community maintained)\x1B[0m"
+    [[ "$BOARD_TYPE" == "wip" ]] && HARDWARE_STATUS="\e[0;91mfor advanced users\x1B[0m (work in progress)\x1B[0m"
+    [[ "$BOARD_TYPE" == "eos" ]] && HARDWARE_STATUS="\e[0;91mend of life\x1B[0m"
 fi
 
 # render distribution status
 if [[ $DISTRIBUTION_STATUS == supported ]]; then
-	DISTRO_STATUS="\e[0;92mstable\e[0m ($DISTRIBUTION_CODENAME)"
+    DISTRO_STATUS="\e[0;92mstable\e[0m ($DISTRIBUTION_CODENAME)"
 elif [[ $DISTRIBUTION_STATUS == eos ]]; then
-	DISTRO_STATUS="\e[0;91mend of life\e[0m ($DISTRIBUTION_CODENAME)"
+    DISTRO_STATUS="\e[0;91mend of life\e[0m ($DISTRIBUTION_CODENAME)"
 else
-	DISTRO_STATUS="\e[0;93mrolling\e[0m ($DISTRIBUTION_CODENAME)"
+    DISTRO_STATUS="\e[0;93mrolling\e[0m ($DISTRIBUTION_CODENAME)"
 fi
-
 
 # read packages update status
 NUM_UPDATES=0
@@ -116,39 +118,41 @@ NUM_UPDATES_ONHOLD=0
 NUM_SECURITY_UPDATES=0
 [[ -f /var/cache/apt/archives/updates.number ]] && . /var/cache/apt/archives/updates.number
 if [[ $NUM_UPDATES -gt 0 ]]; then
-	if apt-mark showhold | grep -q linux-image 2>/dev/null; then
-		UPDATE_STATUS="Kernel upgrade \e[0;91mdisabled\e[0m"
-		else
-		UPDATE_STATUS="Kernel upgrade \e[0;92menabled\e[0m"
-	fi
-	UPDATE_STATUS+=" and \e[1;92m$NUM_UPDATES\e[0m package"
-	# Cosmetic is important
-	[[ $NUM_UPDATES -gt 1 ]] && UPDATE_STATUS+="s"
-	UPDATE_STATUS+=" available for upgrade\e[0m "
+    if apt-mark showhold | grep -q linux-image 2>/dev/null; then
+        UPDATE_STATUS="Kernel upgrade \e[0;91mdisabled\e[0m"
+    else
+        UPDATE_STATUS="Kernel upgrade \e[0;92menabled\e[0m"
+    fi
+    UPDATE_STATUS+=" and \e[1;92m$NUM_UPDATES\e[0m package"
+    # Cosmetic is important
+    [[ $NUM_UPDATES -gt 1 ]] && UPDATE_STATUS+="s"
+    UPDATE_STATUS+=" available for upgrade\e[0m "
 fi
 
 echo ""
 
 # Display packages status
 if [[ -n $DISTRO_STATUS ]]; then
-	if [[ -n "${upgrade}" ]]; then
-		DISTRO_STATUS+=", possible distro upgrade ($upgrade)"
-	fi
-	echo -e " Packages:     ${DISTRIBUTION_ID^} ${DISTRO_STATUS}"
+    if [[ -n "${upgrade}" ]]; then
+        DISTRO_STATUS+=", possible distro upgrade ($upgrade)"
+    fi
+    echo -e " Packages:     ${DISTRIBUTION_ID^} ${DISTRO_STATUS}"
 fi
 
 # Display available updates
 if [[ -n $UPDATE_STATUS ]]; then
-        echo -e " Updates:      $UPDATE_STATUS"
+    echo -e " Updates:      $UPDATE_STATUS"
 fi
 
 # Display hardware support status
 if [[ -n $HARDWARE_STATUS ]]; then
-        echo -e " Support:      $HARDWARE_STATUS"
+    echo -e " Support:      $HARDWARE_STATUS"
 fi
 
-echo -en " IP addresses: \x1B[93m(LAN)\x1B[0m \x1B[92m$ip_address\x1B[0m "
+
+IFS='|' read -r ipv4s ipv6s <<< "$ip_address"
+echo -en " IP addresses: \x1B[93m(LAN)\x1B[0m IPv4: \x1B[92m${ipv4s// /, }\x1B[0m IPv6: \x1B[96m${ipv6s// /, }\x1B[0m"
 if [[ -n $wan_ip_address ]]; then
-echo -e "\x1B[93m(WAN)\x1B[0m $wan_ip_address"
+    echo -e " \x1B[93m(WAN)\x1B[0m $wan_ip_address"
 fi
 echo ""


### PR DESCRIPTION
This PR include these changes:

- Added functionality to display local IPv6 addresses in the MOTD.
- Reverted: Default behavior now excludes interfaces matching 'br-*' and 'veth'.
- This PR is referenced to another PR #7299, will be closed.

# How Has This Been Tested?

Tested on my board:

For privacy reason I didn't include the WAN IP on the screenshot 👀

<img width="727" alt="image" src="https://github.com/user-attachments/assets/095c5a0b-a2a9-48f8-ad80-c48705a61b6e">

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
