### PR TITLE
MBa8MPxL: use nxp WLAN/BT firmware, cleanup board files, leave WIP

### DIFF
--- a/config/boards/mba8mpxl-ras314.conf
+++ b/config/boards/mba8mpxl-ras314.conf
@@ -2,6 +2,7 @@
 BOARD_NAME="TQ8MP-RAS314"
 BOARDFAMILY="imx8m"
 BOARD_MAINTAINER="schmiedelm"
+HAS_VIDEO_OUTPUT="yes"
 ATF_PLAT="imx8mp"
 ATF_UART_BASE="0x30a60000"
 BOOTCONFIG="tqma8mpxl_multi_mba8mp_ras314_defconfig"
@@ -10,7 +11,6 @@ DEFAULT_CONSOLE="serial"
 SERIALCON="ttymxc3"
 BOOT_FDT_FILE="freescale/imx8mp-tqma8mpql-mba8mp-ras314.dtb"
 ASOUND_STATE="asound.state.tqma"
-PACKAGE_LIST_BOARD="gpiod python3-pip python3-periphery"
 
 function post_family_tweaks_bsp__mba8mpxl-ras314() {
 
@@ -24,15 +24,6 @@ function post_family_tweaks_bsp__mba8mpxl-ras314() {
 	cat <<- EOF > "${destination}"/etc/udev/rules.d/10-nxp-bluetooth-delay.rules
 		# wait until combo FW is loaded by wifi driver
 		KERNEL=="mlan*", ACTION=="add", RUN+="/sbin/modprobe btnxpuart"
-	EOF
-
-	mkdir -p $destination/etc/udev/rules.d
-	cat <<- EOF > "$destination"/etc/udev/70-periphery.rules
-		# Allow group periphery to access devices
-		SUBSYSTEM=="gpio*", GROUP="periphery", MODE="0660"
-		SUBSYSTEM=="spidev*", GROUP="periphery", MODE="0660"
-		SUBSYSTEM=="pwm*", GROUP="periphery", MODE="0660"
-		SUBSYSTEM=="leds*", GROUP="periphery", MODE="0660"
 	EOF
 
 	# Define a function to be run board-side during postinst of the BSP

--- a/config/boards/mba8mpxl-ras314.wip
+++ b/config/boards/mba8mpxl-ras314.wip
@@ -10,10 +10,21 @@ DEFAULT_CONSOLE="serial"
 SERIALCON="ttymxc3"
 BOOT_FDT_FILE="freescale/imx8mp-tqma8mpql-mba8mp-ras314.dtb"
 ASOUND_STATE="asound.state.tqma"
-BOARD_FIRMWARE_INSTALL="-full"
 PACKAGE_LIST_BOARD="gpiod python3-pip python3-periphery"
 
 function post_family_tweaks_bsp__mba8mpxl-ras314() {
+
+	# Wifi & Bluetooth (use firmware from NXP)
+	wget https://github.com/nxp-imx/imx-firmware/raw/lf-6.6.3_1.0.0/nxp/FwImage_8997/pcieuart8997_combo_v4.bin
+	run_host_command_logged mkdir -pv --mode=755 "$destination/lib/firmware/" || exit_with_error "Unable to mkdir firmware"
+	run_host_command_logged mkdir -v --mode=775 "$destination/lib/firmware/mrvl/" || exit_with_error "Unable to mkdir mrvl"
+	run_host_command_logged cp -Pv "pcieuart8997_combo_v4.bin" "$destination/lib/firmware/mrvl/" || exit_with_error "Unable to copy mrvl firmware"
+
+	# Add udev rule to delay btnxpuart loading
+	cat <<- EOF > "${destination}"/etc/udev/rules.d/10-nxp-bluetooth-delay.rules
+		# wait until combo FW is loaded by wifi driver
+		KERNEL=="mlan*", ACTION=="add", RUN+="/sbin/modprobe btnxpuart"
+	EOF
 
 	mkdir -p $destination/etc/udev/rules.d
 	cat <<- EOF > "$destination"/etc/udev/70-periphery.rules

--- a/config/boards/mba8mpxl.conf
+++ b/config/boards/mba8mpxl.conf
@@ -2,6 +2,7 @@
 BOARD_NAME="MBa8MPxL"
 BOARDFAMILY="imx8m"
 BOARD_MAINTAINER="schmiedelm"
+HAS_VIDEO_OUTPUT="yes"
 ATF_PLAT="imx8mp"
 ATF_UART_BASE="0x30a60000"
 BOOTCONFIG="tqma8mpxl_multi_mba8mpxl_defconfig"
@@ -10,7 +11,6 @@ DEFAULT_CONSOLE="serial"
 SERIALCON="ttymxc3"
 BOOT_FDT_FILE="freescale/imx8mp-tqma8mpql-mba8mpxl.dtb"
 ASOUND_STATE="asound.state.tqma"
-PACKAGE_LIST_BOARD="gpiod python3-pip python3-periphery"
 
 function post_family_tweaks_bsp__mba8mpxl() {
 	mkdir -p "$destination"/etc/X11/xorg.conf.d


### PR DESCRIPTION
# Description

After a discussion with NXP it is allowed to download the proprietary firmware (for the WLAN/BT module on mba8mp-ras314) from NXP and integrate it into the rootfs. Deployment via the armbian-firmware repo was rejected. Unfortunately, there seems to be no interest on the part of NXP to integrate the WLAN/BT firmware into linux-firware in a timely manner.

So installing firmware for this chip become a step in post_family_tweaks_bsp_.

It is time to leave the WIP state and so the board-configs are cleaned up and renamed 

# How Has This Been Tested?

- [x] Build images for mba8mp-ras314 and mba8mpxl with current kernel
- [x] Boot test "bookworm_current" mba8mp-ras314
- [x] Boot test "bookworm_current" mba8mpxl
- [x] HDMI, WLAN, USB test's mba8mp-ras314" bookworm_current" with xfce image
- [x] HDMI, USB test's mba8mpxl" bookworm_current" with xfce image

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

