### PR TITLE
Infrastructure: add GH Action to check coding style from .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,9 +14,9 @@ insert_final_newline = true
 [*.patch]
 trim_trailing_whitespace = false
 
+
 [*.md]
 indent_style = space
-indent_size = 4
 insert_final_newline = false
 
 [*.json]

--- a/.github/workflows/pr-coding-style.yml
+++ b/.github/workflows/pr-coding-style.yml
@@ -1,0 +1,24 @@
+name: Coding style check
+
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize, review_requested]
+    paths:
+      - lib/**
+      - packages/**
+      - extensions/**
+      - tools/**
+      - .github/workflows/*
+
+concurrency:
+  group: coding-style-${{github.event.pull_request.number}}
+  cancel-in-progress: true
+
+jobs:
+  editorconfig:
+    name: "Coding style check"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: editorconfig-checker/action-editorconfig-checker@main
+      - run: editorconfig-checker


### PR DESCRIPTION
# Description

As the title says. If this is added, it will fail always as it checks all code ...

# How Has This Been Tested?

Tested at CI.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
