### PR TITLE
Orange Pi 3B: Vendor: Enable audio via headphone jack

### DIFF
--- a/config/boards/orangepi3b.csc
+++ b/config/boards/orangepi3b.csc
@@ -61,3 +61,14 @@ function post_family_tweaks__orangepi3b_enable_services() {
 	chroot_sdcard systemctl enable orangepi3b-sprd-bluetooth.service
 	return 0
 }
+
+function post_family_tweaks__orangepi3b_naming_audios() {
+	display_alert "$BOARD" "Renaming orangepi3b audios" "info"
+
+	mkdir -p $SDCARD/etc/udev/rules.d/
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-hdmi-sound", ENV{SOUND_DESCRIPTION}="HDMI Audio"' > $SDCARD/etc/udev/rules.d/90-naming-audios.rules
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-rk809-sound", ENV{SOUND_DESCRIPTION}="RK809 Audio"' >> $SDCARD/etc/udev/rules.d/90-naming-audios.rules # vendor dts
+	echo 'SUBSYSTEM=="sound", ENV{ID_PATH}=="platform-sound", ENV{SOUND_DESCRIPTION}="RK809 Audio"' >> $SDCARD/etc/udev/rules.d/90-naming-audios.rules # mainline dts
+
+	return 0
+}

--- a/packages/bsp/common/usr/lib/armbian/armbian-audio-config
+++ b/packages/bsp/common/usr/lib/armbian/armbian-audio-config
@@ -156,5 +156,9 @@ else
 		mixer_cmds 'OUT MIXR DAC R1' on
 		mixer_cmds 'Stereo DAC MIXL DAC L1' on
 		mixer_cmds 'Stereo DAC MIXR DAC R1' on
+
+		# Orange Pi 3B
+		mixer_cmds 'Playback Path' 'HP'
+		mixer_cmds 'Capture MIC Path' 'Main Mic'
 	) | amixer -c "$card" --stdin > /dev/null 2>&1; done
 fi


### PR DESCRIPTION
# Description

In vendor kernel, audio via headphone jack does not work out of the box. Updating alsamixer configurations [as hinted in vendor's build](https://github.com/orangepi-xunlong/orangepi-build/blob/1b0ec5f44334e20dd7cecdf7fc4cd323feb29dbb/external/packages/bsp/common/usr/lib/orangepi/orangepi-hardware-optimization#L302-L303) fixes this.

Also taking this chance to rename audio devices. This is especially useful for mainline kernel, which displays both HDMI and headphone jack audio devices as "Analog Output - Built-in Audio".

# How Has This Been Tested?

Tested vendor and edge images on v2.1 board. On both images, audio works out of the box via HDMI and headphone jack. Audio device names updated accordingly.

- [x] Vendor build: `./compile.sh build BOARD=orangepi3b BRANCH=vendor BUILD_DESKTOP=yes BUILD_MINIMAL=no DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base KERNEL_CONFIGURE=no KERNEL_GIT=shallow RELEASE=noble`
- [x] Edge build: `./compile.sh build BOARD=orangepi3b BRANCH=edge BUILD_DESKTOP=yes BUILD_MINIMAL=no DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base KERNEL_CONFIGURE=no KERNEL_GIT=shallow RELEASE=noble`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
