### PR TITLE
mesa-vpu: don't install mesa-vpu on minimal images

### DIFF
--- a/extensions/mesa-vpu.sh
+++ b/extensions/mesa-vpu.sh
@@ -9,6 +9,12 @@ function extension_prepare_config__3d() {
 	# Silently deny old releases which are not supported but are still in the system
 	[[ "${RELEASE}" =~ ^(bullseye|buster|focal)$ ]] && return 0
 
+	# Silently deny on minimal CLI images
+	if [[ "${BUILD_MINIMAL}" == "yes" ]]; then
+		display_alert "Extension: ${EXTENSION}" "skip installation in minimal images" "warn"
+		return 0
+	fi
+
 	# some desktops doesn't support wayland
 	[[ "${DESKTOP_ENVIRONMENT}" == "xfce" || "${DESKTOP_ENVIRONMENT}" == "i3-wm" ]] && return 0
 


### PR DESCRIPTION
# Description

Keeping minimal images as minimal as possible. Addition to:
https://github.com/armbian/build/pull/7318

# How Has This Been Tested?

CI throws error when trying to add PPA:`add-apt-repository: command not found` We don't (want) to have software-properties-common package and dependencies on minimal images.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
