### PR TITLE
`Automatic` board configs status synchronise

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,6 +27,7 @@ config/boards/bananapi.conf		@DylanHP @janprunk
 config/boards/bananapicm4io.conf		@pyavitz
 config/boards/bananapim2pro.conf		@bretmlw
 config/boards/bananapim2s.conf		@jeanrhum @pyavitz
+config/boards/bananapim2zero.csc		@mhawkins-consultant
 config/boards/bananapim3.csc		@AaronNGray
 config/boards/bananapim4zero.conf		@pyavitz
 config/boards/bananapim5.conf		@bretmlw
@@ -72,6 +73,7 @@ config/boards/mixtile-blade3.csc		@rpardini
 config/boards/nanopc-cm3588-nas.csc		@ColorfulRhino
 config/boards/nanopct6-lts.conf		@SuperKali @Tonymac32
 config/boards/nanopct6.conf		@SuperKali @Tonymac32
+config/boards/nanopi-m6.conf		@efectn
 config/boards/nanopi-r4s.conf		@Manouchehri
 config/boards/nanopi-r5s.csc		@utlark
 config/boards/nanopi-r6c.csc		@ColorfulRhino
@@ -89,8 +91,6 @@ config/boards/odroidn2.conf		@NicoD-SBC
 config/boards/odroidxu4.conf		@joekhoobyar
 config/boards/olimex-teres-a64.conf		@Kreyren
 config/boards/onecloud.conf		@hzyitc
-config/boards/orangepi-r1.csc		@schwar3kat
-config/boards/orangepi-r1plus-lts.csc		@schwar3kat
 config/boards/orangepi4-lts.conf		@paolosabatino
 config/boards/orangepi4.csc		@paolosabatino
 config/boards/orangepi5-plus.conf		@alexl83 @efectn
@@ -164,17 +164,17 @@ config/kernel/linux-phytium-embedded-*.config		@chainsx
 config/kernel/linux-rk35xx-*.config		@ColorfulRhino @SeeleVolleri @SuperKali @Tonymac32 @ZazaBR @alexl83 @amazingfate @catalinii @chainsx @efectn @ginkage @hoochiwetech @krachlatte @lanefu @linhz0hz @mahdichi @mattx433 @monkaBlyat @prahal @rpardini @schwar3kat @sputnik2019 @vamzii
 config/kernel/linux-rockchip-*.config		@paolosabatino
 config/kernel/linux-rockchip-rk3588-*.config		@ColorfulRhino @SuperKali @Tonymac32 @alexl83 @amazingfate @andyshrk @efectn @lanefu @linhz0hz @rpardini @schwar3kat
-config/kernel/linux-rockchip64-*.config		@150balbes @Manouchehri @TRSx80 @TheSnowfield @Tonymac32 @ZazaBR @ahoneybun @amazingfate @andyshrk @brentr @catalinii @clee @hqnicolas @igorpecovnik @joekhoobyar @krachlatte @paolosabatino @prahal @rpardini @schwar3kat @sicXnull @tdleiyao @utlark @vamzii
+config/kernel/linux-rockchip64-*.config		@150balbes @Manouchehri @TRSx80 @TheSnowfield @Tonymac32 @ZazaBR @ahoneybun @amazingfate @andyshrk @brentr @catalinii @clee @hqnicolas @igorpecovnik @joekhoobyar @krachlatte @paolosabatino @prahal @rpardini @sicXnull @tdleiyao @utlark @vamzii
 config/kernel/linux-sm8250-*.config		@FantasyGmm @amazingfate
 config/kernel/linux-sun55iw3-syterkit-*.config		@chainsx
-config/kernel/linux-sunxi-*.config		@1ubuntuuser @AaronNGray @DylanHP @Janmcha @StephenGraf @Tonymac32 @janprunk @lbmendes @schwar3kat @sgjava
+config/kernel/linux-sunxi-*.config		@1ubuntuuser @AaronNGray @DylanHP @Janmcha @StephenGraf @Tonymac32 @janprunk @lbmendes @mhawkins-consultant @sgjava
 config/kernel/linux-sunxi64-*.config		@AGM1968 @IsMrX @JohnTheCoolingFan @Kreyren @NicoD-SBC @PanderMusubi @Ressetkk @Tonymac32 @alexl83 @chraac @devdotnetorg @eliasbakken @krachlatte @pyavitz @schwar3kat @sicXnull @teknoid
 config/kernel/linux-thead-*.config		@chainsx
 config/kernel/linux-uefi-arm64-*.config		@PeterChrz @rpardini
 config/kernel/linux-uefi-x86-*.config		@davidandreoletti @rpardini
 patch/kernel/archive/meson-s4t7-*/		@adeepn @rpardini @viraniac
 patch/kernel/archive/odroidxu4-*/		@joekhoobyar
-patch/kernel/archive/sunxi-*/		@1ubuntuuser @AGM1968 @AaronNGray @DylanHP @IsMrX @Janmcha @JohnTheCoolingFan @Kreyren @NicoD-SBC @PanderMusubi @Ressetkk @StephenGraf @Tonymac32 @alexl83 @chraac @devdotnetorg @eliasbakken @janprunk @krachlatte @lbmendes @pyavitz @schwar3kat @sgjava @sicXnull @teknoid
+patch/kernel/archive/sunxi-*/		@1ubuntuuser @AGM1968 @AaronNGray @DylanHP @IsMrX @Janmcha @JohnTheCoolingFan @Kreyren @NicoD-SBC @PanderMusubi @Ressetkk @StephenGraf @Tonymac32 @alexl83 @chraac @devdotnetorg @eliasbakken @janprunk @krachlatte @lbmendes @mhawkins-consultant @pyavitz @schwar3kat @sgjava @sicXnull @teknoid
 patch/kernel/archive/uefi-arm64-*/		@PeterChrz @rpardini
 patch/kernel/archive/uefi-x86-*/		@davidandreoletti @rpardini
 patch/kernel/bcm2711-*/		@PanderMusubi @teknoid
@@ -188,7 +188,7 @@ patch/kernel/phytium-embedded-*/		@chainsx
 patch/kernel/rk35xx-vendor-*/		@ColorfulRhino @SeeleVolleri @SuperKali @Tonymac32 @ZazaBR @alexl83 @amazingfate @catalinii @chainsx @efectn @ginkage @hoochiwetech @krachlatte @lanefu @linhz0hz @mahdichi @mattx433 @monkaBlyat @prahal @rpardini @schwar3kat @sputnik2019 @vamzii
 patch/kernel/rockchip-*/		@paolosabatino
 patch/kernel/rockchip-rk3588-*/		@ColorfulRhino @SuperKali @Tonymac32 @alexl83 @amazingfate @andyshrk @efectn @lanefu @linhz0hz @rpardini @schwar3kat
-patch/kernel/rockchip64-*/		@150balbes @Manouchehri @TRSx80 @TheSnowfield @Tonymac32 @ZazaBR @ahoneybun @amazingfate @andyshrk @brentr @catalinii @clee @hqnicolas @igorpecovnik @joekhoobyar @krachlatte @paolosabatino @prahal @rpardini @schwar3kat @sicXnull @tdleiyao @utlark @vamzii
+patch/kernel/rockchip64-*/		@150balbes @Manouchehri @TRSx80 @TheSnowfield @Tonymac32 @ZazaBR @ahoneybun @amazingfate @andyshrk @brentr @catalinii @clee @hqnicolas @igorpecovnik @joekhoobyar @krachlatte @paolosabatino @prahal @rpardini @sicXnull @tdleiyao @utlark @vamzii
 patch/kernel/sm8250-*/		@FantasyGmm @amazingfate
 patch/kernel/sm8550-*/		@FantasyGmm
 patch/kernel/sun55iw3-syterkit-*/		@chainsx
@@ -206,10 +206,10 @@ sources/families/phytium-embedded.conf		@chainsx
 sources/families/rk35xx.conf		@ColorfulRhino @SeeleVolleri @SuperKali @Tonymac32 @ZazaBR @alexl83 @amazingfate @catalinii @chainsx @efectn @ginkage @hoochiwetech @krachlatte @lanefu @linhz0hz @mahdichi @mattx433 @monkaBlyat @prahal @rpardini @schwar3kat @sputnik2019 @vamzii
 sources/families/rockchip-rk3588.conf		@ColorfulRhino @SuperKali @Tonymac32 @alexl83 @amazingfate @andyshrk @efectn @lanefu @linhz0hz @rpardini @schwar3kat
 sources/families/rockchip.conf		@paolosabatino
-sources/families/rockchip64.conf		@150balbes @Manouchehri @TRSx80 @TheSnowfield @Tonymac32 @ZazaBR @ahoneybun @amazingfate @andyshrk @brentr @catalinii @clee @hqnicolas @igorpecovnik @joekhoobyar @krachlatte @paolosabatino @prahal @rpardini @schwar3kat @sicXnull @tdleiyao @utlark @vamzii
+sources/families/rockchip64.conf		@150balbes @Manouchehri @TRSx80 @TheSnowfield @Tonymac32 @ZazaBR @ahoneybun @amazingfate @andyshrk @brentr @catalinii @clee @hqnicolas @igorpecovnik @joekhoobyar @krachlatte @paolosabatino @prahal @rpardini @sicXnull @tdleiyao @utlark @vamzii
 sources/families/sm8250.conf		@FantasyGmm @amazingfate
 sources/families/sun55iw3-syterkit.conf		@chainsx
-sources/families/sunxi.conf		@1ubuntuuser @AaronNGray @DylanHP @Janmcha @StephenGraf @Tonymac32 @janprunk @lbmendes @schwar3kat @sgjava
+sources/families/sunxi.conf		@1ubuntuuser @AaronNGray @DylanHP @Janmcha @StephenGraf @Tonymac32 @janprunk @lbmendes @mhawkins-consultant @sgjava
 sources/families/sunxi64.conf		@AGM1968 @IsMrX @JohnTheCoolingFan @Kreyren @NicoD-SBC @PanderMusubi @Ressetkk @Tonymac32 @alexl83 @chraac @devdotnetorg @eliasbakken @krachlatte @pyavitz @schwar3kat @sicXnull @teknoid
 sources/families/thead.conf		@chainsx
 sources/families/x86.conf		@davidandreoletti @rpardini

--- a/config/boards/bananapim2zero.csc
+++ b/config/boards/bananapim2zero.csc
@@ -1,7 +1,7 @@
 # Allwinner H2+ quad core 512MB SoC Wi-Fi/BT
 BOARD_NAME="Banana Pi M2 Zero"
 BOARDFAMILY="sun8i"
-BOARD_MAINTAINER=""
+BOARD_MAINTAINER="mhawkins-consultant"
 BOOTCONFIG="bananapi_m2_zero_defconfig"
 MODULES_LEGACY="g_serial"
 MODULES_CURRENT="g_serial"

--- a/config/boards/orangepi-r1.csc
+++ b/config/boards/orangepi-r1.csc
@@ -1,7 +1,7 @@
 # Allwinner H2+ quad core 256MB/512MB RAM SoC WiFi SPI 2xETH
 BOARD_NAME="Orange Pi R1"
 BOARDFAMILY="sun8i"
-BOARD_MAINTAINER="schwar3kat"
+BOARD_MAINTAINER=""
 BOOTCONFIG="orangepi_r1_defconfig"
 DEFAULT_OVERLAYS="usbhost2 usbhost3"
 MODULES="g_serial"

--- a/config/boards/orangepi-r1plus-lts.csc
+++ b/config/boards/orangepi-r1plus-lts.csc
@@ -1,7 +1,7 @@
 # Rockchip RK3328 quad core 1GB 2 x GBE USB2 SPI
 BOARD_NAME="Orange Pi R1 Plus LTS"
 BOARDFAMILY="rockchip64"
-BOARD_MAINTAINER="schwar3kat"
+BOARD_MAINTAINER=""
 BOOTCONFIG="orangepi_r1_plus_lts_rk3328_defconfig"
 KERNEL_TARGET="current,edge"
 KERNEL_TEST_TARGET="current"


### PR DESCRIPTION
Update maintainers and board status

- synced status from the database
- rename to .`csc` where we don't have anyone

If you want to become a board maintainer, [adjust data here](https://www.armbian.com/update-data/).

Ref: [Board Maintainers Procedures and Guidelines](https://docs.armbian.com/Board_Maintainers_Procedures_and_Guidelines/)