### PR TITLE
MBa8MPxL: replace HAS_VIDEO_OUTPUT with FULL_DESKTOP

### DIFF
--- a/config/boards/mba8mpxl-ras314.conf
+++ b/config/boards/mba8mpxl-ras314.conf
@@ -2,7 +2,7 @@
 BOARD_NAME="TQ8MP-RAS314"
 BOARDFAMILY="imx8m"
 BOARD_MAINTAINER="schmiedelm"
-HAS_VIDEO_OUTPUT="yes"
+FULL_DESKTOP="yes"
 ATF_PLAT="imx8mp"
 ATF_UART_BASE="0x30a60000"
 BOOTCONFIG="tqma8mpxl_multi_mba8mp_ras314_defconfig"

--- a/config/boards/mba8mpxl.conf
+++ b/config/boards/mba8mpxl.conf
@@ -2,7 +2,7 @@
 BOARD_NAME="MBa8MPxL"
 BOARDFAMILY="imx8m"
 BOARD_MAINTAINER="schmiedelm"
-HAS_VIDEO_OUTPUT="yes"
+FULL_DESKTOP="yes"
 ATF_PLAT="imx8mp"
 ATF_UART_BASE="0x30a60000"
 BOOTCONFIG="tqma8mpxl_multi_mba8mpxl_defconfig"


### PR DESCRIPTION
# Description

Defining HAS_VIDEO_OUTPUT either no or yes groups the board in standard-support-headless (armbian/os)

[`elif grep -q HAS_VIDEO_OUTPUT $board; then TARGET_SECTION="${SUPPORT}-headless";`](https://github.com/armbian/os/blob/5f09dcace467142c619296c544ed042a63324046/.github/workflows/recreate-matrix.yml#L199)

The expectation is to move the entry from "standard-support-headless"  to "standard-support-fast-hdmi" in 
https://github.com/armbian/os/blob/main/userpatches/targets-release-standard-support.yaml

# How Has This Been Tested?

I don't know how to test this.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

