### PR TITLE
nanopi-m6: add LCD overlay as default

### DIFF
--- a/config/boards/nanopi-m6.wip
+++ b/config/boards/nanopi-m6.wip
@@ -11,6 +11,8 @@ IMAGE_PARTITION_TABLE="gpt"
 BOOT_FDT_FILE="rockchip/rk3588s-nanopi-m6.dtb"
 BOOT_SCENARIO="spl-blobs"
 
+DEFAULT_OVERLAYS="nanopi-m6-display-dsi1-yx35" # Enable YX35 LCD
+
 function post_family_tweaks__nanopim6_naming_udev_audios() {
 	display_alert "$BOARD" "Renaming NanoPi M6 HDMI audio" "info"
 

--- a/extensions/mesa-vpu.sh
+++ b/extensions/mesa-vpu.sh
@@ -29,7 +29,11 @@ function extension_prepare_config__3d() {
 
 	# This should be enabled on all for rk3588 distributions where mesa and vendor kernel is present
 	if [[ "${LINUXFAMILY}" =~ ^(rockchip-rk3588|rk35xx)$ && "$BRANCH" == vendor ]]; then
-		declare -g DEFAULT_OVERLAYS="panthor-gpu"
+		if [[ -n $DEFAULT_OVERLAYS ]]; then
+			DEFAULT_OVERLAYS+=" panthor-gpu"
+		else
+			declare -g DEFAULT_OVERLAYS="panthor-gpu"
+		fi
 	fi
 
 }


### PR DESCRIPTION
# Description

Enable DSI1 overlay by default in order to support 3.5" LCD OOTB.

[GitHub issue](https://github.com/armbian/build/labels/Task%2FTo-Do) reference: 
[Jira](https://armbian.atlassian.net/jira) reference number [AR-9999]

# Documentation summary for feature / change

_Please delete this section if entry to main documentation is not needed._

If documentation entry is predicted, please provide key elements for further implementation [into main documentation](https://docs.armbian.com) and set label to "Needs Documentation". You are welcome to open a PR to documentation or you can leave following information for technical writer:

- [ ] short description (copy / paste of PR title)
- [ ] summary (description relevant for end users)
- [ ] example of usage (how to see this in function)

# How Has This Been Tested?
- [x]  Built an image and it works.

# Checklist:

_Please delete options that are not relevant._

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
