### PR TITLE
MOTD: display hostapd parameters if AP is in operation

### DIFF
--- a/packages/bsp/common/etc/update-motd.d/10-armbian-header
+++ b/packages/bsp/common/etc/update-motd.d/10-armbian-header
@@ -85,6 +85,10 @@ KERNELID=$(uname -r)
 # Get other variables
 ip_address=$(get_ip_addresses &)
 wan_ip_address=$(get_wan_address &)
+# Get access point info
+if systemctl is-active --quiet service hostapd && [ -f /etc/hostapd/hostapd.conf ]; then
+. /etc/hostapd/hostapd.conf
+fi
 
 # Display software vendor logo
 echo -e "\e[1;91m$(figlet -f small " $VENDOR")\e[0m";
@@ -151,8 +155,15 @@ if [[ -n $HARDWARE_STATUS ]]; then
 fi
 
 IFS='|' read -r ipv4s ipv6s <<< "$ip_address"
-echo -en " IP addresses: \x1B[93m(LAN)\x1B[0m IPv4: \x1B[92m${ipv4s// /, }\x1B[0m IPv6: \x1B[96m${ipv6s// /, }\x1B[0m"
+echo -en " IP addresses: \x1B[93m(LAN)\x1B[0m IPv4: \x1B[92m${ipv4s// /, }\x1B[0m IPv6: \x1B[96m${ipv6s// /, }\x1B[0m "
 if [[ -n $wan_ip_address ]]; then
 echo -e "\x1B[93m(WAN)\x1B[0m $wan_ip_address"
 fi
+
+# Display hostapd
+if [[ -n $ssid ]]; then
+        echo -e " WiFi AP:      SSID: (\x1B[91m$ssid\x1B[0m), $(iw $interface info | grep channel | xargs)"
+fi
+
+
 echo ""


### PR DESCRIPTION
# Description

- adding optional line for displaying AP status.
- fixed missing space between IPV6 address and WAN

![image](https://github.com/user-attachments/assets/9f1b6213-3a6a-4470-8040-51f7cb5d0c63)

# How Has This Been Tested?

- [x] Configured via [armbion-config](https://github.com/armbian/configng) way

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
