### PR TITLE
mesa-vpu: use mesa from debian bookworm-backports

### DIFF
--- a/extensions/mesa-vpu.sh
+++ b/extensions/mesa-vpu.sh
@@ -116,12 +116,6 @@ function post_install_kernel_debs__3d() {
 
 			pkgs+=("chromium")
 		fi
-	elif [[ "${DISTRIBUTION}" == "Debian" && "${RELEASE}" == "bookworm" ]]; then
-
-		display_alert "Adding mesa backport repo for ${RELEASE} from OBS" "${EXTENSION}" "info"
-		echo 'deb http://download.opensuse.org/repositories/home:/amazingfate:/mesa-bookworm-backport/Debian_12/ /' | tee "${SDCARD}"/etc/apt/sources.list.d/home:amazingfate:mesa-bookworm-backport.list
-		curl -fsSL https://download.opensuse.org/repositories/home:amazingfate:mesa-bookworm-backport/Debian_12/Release.key | gpg --dearmor | tee "${SDCARD}"/etc/apt/trusted.gpg.d/home_amazingfate_mesa-bookworm-backport.gpg > /dev/null
-
 	fi
 
 	if [[ "${BUILD_DESKTOP}" == "yes" ]]; then # if desktop, add amazingfated's multimedia PPAs and rockchip-multimedia-config utility, chromium, gstreamer, etc
@@ -156,7 +150,11 @@ function post_install_kernel_debs__3d() {
 	fi
 
 	display_alert "Installing 3D extension packages" "${EXTENSION}" "info"
-	do_with_retries 3 chroot_sdcard_apt_get_install "${pkgs[@]}"
+	if [[ "${DISTRIBUTION}" == "Debian" && "${RELEASE}" == "bookworm" ]]; then
+		do_with_retries 3 chroot_sdcard_apt_get_install -t bookworm-backports "${pkgs[@]}"
+	else
+		do_with_retries 3 chroot_sdcard_apt_get_install "${pkgs[@]}"
+	fi
 
 	# This library gets downgraded
 	if [[ "${BUILD_DESKTOP}" == "yes" ]]; then


### PR DESCRIPTION
# Description

Now debian has backported mesa 24.2.2 for bookworm: https://packages.debian.org/source/bookworm-backports/mesa, and there is no need to use a thirdparty obs repo.

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration._

- [x] `./compile.sh BOARD=armsom-w3 BRANCH=vendor BUILD_MINIMAL=no DEB_COMPRESS=xz KERNEL_CONFIGURE=no RELEASE=bookworm KERNEL_GIT=shallow BUILD_DESKTOP=yes DESKTOP_APPGROUPS_SELECTED= DESKTOP_ENVIRONMENT=gnome DESKTOP_ENVIRONMENT_CONFIG_NAME=config_base ENABLE_EXTENSIONS="mesa-vpu"`

# Checklist:

_Please delete options that are not relevant._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
